### PR TITLE
enhance: [3.0] limit stats task submission by scheduler pending queue (#51816)

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -865,8 +865,6 @@ dataCoord:
     scalarIndexTaskSlotUsage: 16 # slot usage of scalar index task per 512mb
     statsTaskSlotUsage: 8 # slot usage of stats task per 512mb
     analyzeTaskSlotUsage: 65535 # slot usage of analyze task
-  jsonShreddingTriggerCount: 10 # jsonkey stats task count per trigger
-  jsonShreddingTriggerInterval: 10 # jsonkey task interval per trigger
   jsonShreddingMaxColumns: 1024 # the max number of columns to shred
   jsonShreddingRatioThreshold: 0.3 # the ratio threshold to shred
   jsonShreddingWriteBatchSize: 81920 # the batch size to write

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -847,8 +847,6 @@ dataCoord:
     scalarIndexTaskSlotUsage: 16 # slot usage of scalar index task per 512mb
     statsTaskSlotUsage: 8 # slot usage of stats task per 512mb
     analyzeTaskSlotUsage: 65535 # slot usage of analyze task
-  jsonShreddingTriggerCount: 10 # jsonkey stats task count per trigger
-  jsonShreddingTriggerInterval: 10 # jsonkey task interval per trigger
   jsonShreddingMaxColumns: 1024 # the max number of columns to shred
   jsonShreddingRatioThreshold: 0.3 # the ratio threshold to shred
   jsonShreddingWriteBatchSize: 81920 # the batch size to write

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -87,10 +87,42 @@ func newStatsInspector(ctx context.Context,
 }
 
 func (si *statsInspector) Start() {
+	si.warnDeprecatedThrottleConfigs()
 	si.reloadFromMeta()
 	si.loopWg.Add(2)
 	go si.triggerStatsTaskLoop()
 	go si.cleanupStatsTasksLoop()
+}
+
+// warnDeprecatedThrottleConfigs tells operators whose config still carries the
+// old JSON throttle that it no longer has any effect, instead of letting the
+// setting disappear silently on upgrade.
+func (si *statsInspector) warnDeprecatedThrottleConfigs() {
+	for _, item := range []*paramtable.ParamItem{
+		&Params.DataCoordCfg.JSONStatsTriggerCount,
+		&Params.DataCoordCfg.JSONStatsTriggerInterval,
+	} {
+		if item.GetValue() == item.DefaultValue {
+			continue
+		}
+		mlog.Warn(si.ctx, "deprecated config is set and no longer throttles stats tasks, use dataCoord.statsTaskPendingLimit instead",
+			mlog.String("key", item.Key),
+			mlog.String("value", item.GetValue()))
+	}
+	if jsonShreddingDisabledByDeprecatedConfig() {
+		mlog.Warn(si.ctx, "dataCoord.jsonShreddingTriggerCount is 0, keeping JSON key index submission disabled for compatibility",
+			mlog.String("suggestion", "set common.enabledJSONShredding to false instead"))
+	}
+}
+
+// jsonShreddingDisabledByDeprecatedConfig reports whether the deprecated
+// jsonShreddingTriggerCount is still being used as a kill switch. The removed
+// limiter broke out of the loop once the submitted count reached the configured
+// value, so 0 disabled JSON key-index submission on the very first segment.
+// Silently re-enabling shredding for an operator who had set 0 would undo a
+// deliberate decision, so that one value keeps its meaning.
+func jsonShreddingDisabledByDeprecatedConfig() bool {
+	return Params.DataCoordCfg.JSONStatsTriggerCount.GetAsInt() == 0
 }
 
 func (si *statsInspector) Stop() {
@@ -129,19 +161,33 @@ func (si *statsInspector) triggerStatsTaskLoop() {
 	ticker := time.NewTicker(Params.DataCoordCfg.TaskCheckInterval.GetAsDuration(time.Second))
 	defer ticker.Stop()
 
-	lastJSONStatsLastTrigger := time.Now().Unix()
-	maxJSONStatsTaskCount := 0
+	round := 0
 	for {
 		select {
 		case <-si.ctx.Done():
 			mlog.Warn(si.ctx, "DataCoord context done, exit checkStatsTaskLoop...")
 			return
 		case <-ticker.C:
-			si.triggerTextStatsTask()
-			si.triggerBM25StatsTask()
-			lastJSONStatsLastTrigger, maxJSONStatsTaskCount = si.triggerJSONKeyIndexStatsTask(lastJSONStatsLastTrigger, maxJSONStatsTaskCount)
+			si.triggerStatsTasks(round)
+			round++
 		}
 	}
+}
+
+// triggerStatsTasks runs one discovery round. The sub-jobs share a single
+// admission budget and each trigger returns as soon as it is refused, so
+// whichever runs first claims the capacity. Alternate text and JSON per round,
+// otherwise a long text-index backlog starves JSON shredding for as long as it
+// takes to drain - days on a large collection.
+func (si *statsInspector) triggerStatsTasks(round int) {
+	if round%2 == 0 {
+		si.triggerTextStatsTask()
+		si.triggerJSONKeyIndexStatsTask()
+	} else {
+		si.triggerJSONKeyIndexStatsTask()
+		si.triggerTextStatsTask()
+	}
+	si.triggerBM25StatsTask()
 }
 
 func (si *statsInspector) enableBM25() bool {
@@ -200,11 +246,32 @@ func needDoBM25(segment *SegmentInfo, fieldIDs []UniqueID) bool {
 	return false
 }
 
+// canSubmitStatsTask reports whether the global scheduler still has room for a
+// new stats task. The pending queue is shared by every task type, but tasks in
+// retry backoff are excluded because they are not currently waiting for a
+// worker slot. Discovery re-runs on every TaskCheckInterval tick, so a segment
+// skipped here is picked up again once the runnable queue drains.
+func (si *statsInspector) canSubmitStatsTask(subJobType indexpb.StatsSubJob) bool {
+	pendingTaskCount := si.scheduler.GetPendingTaskCount()
+	pendingTaskLimit := Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt()
+	if pendingTaskCount > pendingTaskLimit {
+		mlog.RatedInfo(si.ctx, rate.Limit(10), "skip submitting stats task because global scheduler has too many pending tasks",
+			mlog.Int("pendingTaskCount", pendingTaskCount),
+			mlog.Int("pendingTaskLimit", pendingTaskLimit),
+			mlog.String("subJobType", subJobType.String()))
+		return false
+	}
+	return true
+}
+
 func (si *statsInspector) triggerTextStatsTask() {
 	collections := si.mt.GetCollections()
 	for _, collection := range collections {
 		if collection == nil {
 			continue
+		}
+		if !si.canSubmitStatsTask(indexpb.StatsSubJob_TextIndexJob) {
+			return
 		}
 		needTriggerFieldIDs := make([]UniqueID, 0)
 		for _, field := range collection.Schema.GetFields() {
@@ -215,9 +282,21 @@ func (si *statsInspector) triggerTextStatsTask() {
 			}
 			needTriggerFieldIDs = append(needTriggerFieldIDs, field.GetFieldID())
 		}
+		// needDoTextIndex is false for every segment once there is no field to
+		// index, so skip the collection before scanning all of its segments.
+		if len(needTriggerFieldIDs) == 0 {
+			continue
+		}
 		allowUnsorted := collection.IsExternal()
 		segments := si.mt.SelectSegments(si.ctx, WithCollection(collection.ID), SegmentFilterFunc(func(seg *SegmentInfo) bool {
-			return needDoTextIndex(seg, needTriggerFieldIDs, allowUnsorted)
+			if !needDoTextIndex(seg, needTriggerFieldIDs, allowUnsorted) {
+				return false
+			}
+			// A segment whose task is already in meta must not be re-submitted;
+			// filtering it out here keeps the per-tick work proportional to the
+			// segments that still need a task instead of to all of them.
+			// Note this runs under meta.segMu.RLock, so keep it to a map read.
+			return !si.mt.statsTaskMeta.HasStatsTask(seg.GetID(), indexpb.StatsSubJob_TextIndexJob)
 		}))
 
 		resources := []*internalpb.FileResourceInfo{}
@@ -232,6 +311,9 @@ func (si *statsInspector) triggerTextStatsTask() {
 		}
 
 		for _, segment := range segments {
+			if !si.canSubmitStatsTask(indexpb.StatsSubJob_TextIndexJob) {
+				return
+			}
 			if err := si.SubmitStatsTask(segment.GetID(), segment.GetID(), indexpb.StatsSubJob_TextIndexJob, true, resources); err != nil {
 				mlog.Warn(si.ctx, "create stats task with text index for segment failed, wait for retry",
 					mlog.FieldSegmentID(segment.GetID()), mlog.Err(err))
@@ -241,11 +323,19 @@ func (si *statsInspector) triggerTextStatsTask() {
 	}
 }
 
-func (si *statsInspector) triggerJSONKeyIndexStatsTask(lastJSONStatsLastTrigger int64, maxJSONStatsTaskCount int) (int64, int) {
+func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
+	if jsonShreddingDisabledByDeprecatedConfig() {
+		mlog.RatedWarn(si.ctx, rate.Limit(0.1), "skip JSON key index stats task, dataCoord.jsonShreddingTriggerCount is set to 0",
+			mlog.String("suggestion", "set common.enabledJSONShredding to false instead"))
+		return
+	}
 	collections := si.mt.GetCollections()
 	for _, collection := range collections {
 		if collection == nil {
 			continue
+		}
+		if !si.canSubmitStatsTask(indexpb.StatsSubJob_JsonKeyIndexJob) {
+			return
 		}
 		needTriggerFieldIDs := make([]UniqueID, 0)
 		for _, field := range collection.Schema.GetFields() {
@@ -254,37 +344,47 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask(lastJSONStatsLastTrigger 
 				needTriggerFieldIDs = append(needTriggerFieldIDs, field.GetFieldID())
 			}
 		}
+		// Same as the text loop: no field to shred means no candidate segment,
+		// which also short-circuits every collection once JSON shredding is off.
+		if len(needTriggerFieldIDs) == 0 {
+			continue
+		}
 		allowUnsorted := collection.IsExternal()
 		segments := si.mt.SelectSegments(si.ctx, WithCollection(collection.ID), SegmentFilterFunc(func(seg *SegmentInfo) bool {
 			if collection.IsExternal() && !canBuildExternalJSONKeyIndex(seg) {
 				return false
 			}
-			return needDoJSONKeyIndex(seg, needTriggerFieldIDs, allowUnsorted)
+			if !needDoJSONKeyIndex(seg, needTriggerFieldIDs, allowUnsorted) {
+				return false
+			}
+			return !si.mt.statsTaskMeta.HasStatsTask(seg.GetID(), indexpb.StatsSubJob_JsonKeyIndexJob)
 		}))
-		if time.Now().Unix()-lastJSONStatsLastTrigger > int64(Params.DataCoordCfg.JSONStatsTriggerInterval.GetAsDuration(time.Minute).Seconds()) {
-			lastJSONStatsLastTrigger = time.Now().Unix()
-			maxJSONStatsTaskCount = 0
-		}
 		for _, segment := range segments {
-			if maxJSONStatsTaskCount >= Params.DataCoordCfg.JSONStatsTriggerCount.GetAsInt() {
-				break
+			if !si.canSubmitStatsTask(indexpb.StatsSubJob_JsonKeyIndexJob) {
+				return
 			}
 			if err := si.SubmitStatsTask(segment.GetID(), segment.GetID(), indexpb.StatsSubJob_JsonKeyIndexJob, true, nil); err != nil {
 				mlog.Warn(si.ctx, "create stats task with json key index for segment failed, wait for retry:",
 					mlog.FieldSegmentID(segment.GetID()), mlog.Err(err))
 				continue
 			}
-			maxJSONStatsTaskCount++
 		}
 	}
-	return lastJSONStatsLastTrigger, maxJSONStatsTaskCount
 }
 
 func (si *statsInspector) triggerBM25StatsTask() {
+	// BM25 stats tasks are not docked yet, so every collection would be scanned
+	// for nothing. Drop out before touching the segment meta at all.
+	if !si.enableBM25() {
+		return
+	}
 	collections := si.mt.GetCollections()
 	for _, collection := range collections {
 		if collection == nil || collection.IsExternal() {
 			continue
+		}
+		if !si.canSubmitStatsTask(indexpb.StatsSubJob_BM25Job) {
+			return
 		}
 		needTriggerFieldIDs := make([]UniqueID, 0)
 		for _, field := range collection.Schema.GetFields() {
@@ -294,10 +394,19 @@ func (si *statsInspector) triggerBM25StatsTask() {
 			}
 		}
 		segments := si.mt.SelectSegments(si.ctx, WithCollection(collection.ID), SegmentFilterFunc(func(seg *SegmentInfo) bool {
-			return (seg.GetIsSorted() || seg.GetIsSortedByNamespace()) && needDoBM25(seg, needTriggerFieldIDs)
+			if !seg.GetIsSorted() && !seg.GetIsSortedByNamespace() {
+				return false
+			}
+			if !needDoBM25(seg, needTriggerFieldIDs) {
+				return false
+			}
+			return !si.mt.statsTaskMeta.HasStatsTask(seg.GetID(), indexpb.StatsSubJob_BM25Job)
 		}))
 
 		for _, segment := range segments {
+			if !si.canSubmitStatsTask(indexpb.StatsSubJob_BM25Job) {
+				return
+			}
 			if err := si.SubmitStatsTask(segment.GetID(), segment.GetID(), indexpb.StatsSubJob_BM25Job, true, nil); err != nil {
 				mlog.Warn(si.ctx, "create stats task with bm25 for segment failed, wait for retry",
 					mlog.FieldSegmentID(segment.GetID()), mlog.Err(err))
@@ -361,6 +470,18 @@ func (si *statsInspector) SubmitStatsTask(originSegmentID, targetSegmentID int64
 				mlog.String("subJobType", subJobType.String()))
 			return nil
 		}
+	}
+	if si.mt.statsTaskMeta.HasStatsTask(originSegmentID, subJobType) {
+		mlog.RatedInfo(si.ctx, rate.Limit(10), "stats task already exists",
+			mlog.FieldCollectionID(originSegment.GetCollectionID()),
+			mlog.FieldSegmentID(originSegmentID),
+			mlog.String("subJobType", subJobType.String()))
+		return nil
+	}
+	// The trigger loops check admission before getting here; this guard covers
+	// callers that reach the StatsInspector interface directly.
+	if !si.canSubmitStatsTask(subJobType) {
+		return nil
 	}
 	taskID, err := si.allocator.AllocID(context.Background())
 	if err != nil {

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -34,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	taskcommon "github.com/milvus-io/milvus/pkg/v3/taskcommon"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -247,12 +248,14 @@ func needDoBM25(segment *SegmentInfo, fieldIDs []UniqueID) bool {
 }
 
 // canSubmitStatsTask reports whether the global scheduler still has room for a
-// new stats task. The pending queue is shared by every task type, but tasks in
-// retry backoff are excluded because they are not currently waiting for a
-// worker slot. Discovery re-runs on every TaskCheckInterval tick, so a segment
-// skipped here is picked up again once the runnable queue drains.
+// new stats task. The pending queue is shared by every task type, so the count is
+// scoped to stats work: an index or compaction backlog must not starve text-index
+// and JSON-shredding submission. Stats tasks waiting on a retry backoff are
+// counted, because they still occupy queue depth. Discovery re-runs on every
+// TaskCheckInterval tick, so a segment skipped here is picked up again once the
+// stats queue drains.
 func (si *statsInspector) canSubmitStatsTask(subJobType indexpb.StatsSubJob) bool {
-	pendingTaskCount := si.scheduler.GetPendingTaskCount()
+	pendingTaskCount := si.scheduler.GetPendingTaskCount(taskcommon.Stats)
 	pendingTaskLimit := Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt()
 	if pendingTaskCount > pendingTaskLimit {
 		mlog.RatedInfo(si.ctx, rate.Limit(10), "skip submitting stats task because global scheduler has too many pending tasks",

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -87,10 +87,42 @@ func newStatsInspector(ctx context.Context,
 }
 
 func (si *statsInspector) Start() {
+	si.warnDeprecatedThrottleConfigs()
 	si.reloadFromMeta()
 	si.loopWg.Add(2)
 	go si.triggerStatsTaskLoop()
 	go si.cleanupStatsTasksLoop()
+}
+
+// warnDeprecatedThrottleConfigs tells operators whose config still carries the
+// old JSON throttle that it no longer has any effect, instead of letting the
+// setting disappear silently on upgrade.
+func (si *statsInspector) warnDeprecatedThrottleConfigs() {
+	for _, item := range []*paramtable.ParamItem{
+		&Params.DataCoordCfg.JSONStatsTriggerCount,
+		&Params.DataCoordCfg.JSONStatsTriggerInterval,
+	} {
+		if item.GetValue() == item.DefaultValue {
+			continue
+		}
+		mlog.Warn(si.ctx, "deprecated config is set and no longer throttles stats tasks, use dataCoord.statsTaskPendingLimit instead",
+			mlog.String("key", item.Key),
+			mlog.String("value", item.GetValue()))
+	}
+	if jsonShreddingDisabledByDeprecatedConfig() {
+		mlog.Warn(si.ctx, "dataCoord.jsonShreddingTriggerCount is 0, keeping JSON key index submission disabled for compatibility",
+			mlog.String("suggestion", "set common.enabledJSONShredding to false instead"))
+	}
+}
+
+// jsonShreddingDisabledByDeprecatedConfig reports whether the deprecated
+// jsonShreddingTriggerCount is still being used as a kill switch. The removed
+// limiter broke out of the loop once the submitted count reached the configured
+// value, so 0 disabled JSON key-index submission on the very first segment.
+// Silently re-enabling shredding for an operator who had set 0 would undo a
+// deliberate decision, so that one value keeps its meaning.
+func jsonShreddingDisabledByDeprecatedConfig() bool {
+	return Params.DataCoordCfg.JSONStatsTriggerCount.GetAsInt() == 0
 }
 
 func (si *statsInspector) Stop() {
@@ -129,19 +161,33 @@ func (si *statsInspector) triggerStatsTaskLoop() {
 	ticker := time.NewTicker(Params.DataCoordCfg.TaskCheckInterval.GetAsDuration(time.Second))
 	defer ticker.Stop()
 
-	lastJSONStatsLastTrigger := time.Now().Unix()
-	maxJSONStatsTaskCount := 0
+	round := 0
 	for {
 		select {
 		case <-si.ctx.Done():
 			mlog.Warn(si.ctx, "DataCoord context done, exit checkStatsTaskLoop...")
 			return
 		case <-ticker.C:
-			si.triggerTextStatsTask()
-			si.triggerBM25StatsTask()
-			lastJSONStatsLastTrigger, maxJSONStatsTaskCount = si.triggerJSONKeyIndexStatsTask(lastJSONStatsLastTrigger, maxJSONStatsTaskCount)
+			si.triggerStatsTasks(round)
+			round++
 		}
 	}
+}
+
+// triggerStatsTasks runs one discovery round. The sub-jobs share a single
+// admission budget and each trigger returns as soon as it is refused, so
+// whichever runs first claims the capacity. Alternate text and JSON per round,
+// otherwise a long text-index backlog starves JSON shredding for as long as it
+// takes to drain - days on a large collection.
+func (si *statsInspector) triggerStatsTasks(round int) {
+	if round%2 == 0 {
+		si.triggerTextStatsTask()
+		si.triggerJSONKeyIndexStatsTask()
+	} else {
+		si.triggerJSONKeyIndexStatsTask()
+		si.triggerTextStatsTask()
+	}
+	si.triggerBM25StatsTask()
 }
 
 func (si *statsInspector) enableBM25() bool {
@@ -200,11 +246,32 @@ func needDoBM25(segment *SegmentInfo, fieldIDs []UniqueID) bool {
 	return false
 }
 
+// canSubmitStatsTask reports whether the global scheduler still has room for a
+// new stats task. The pending queue is shared by every task type, but tasks in
+// retry backoff are excluded because they are not currently waiting for a
+// worker slot. Discovery re-runs on every TaskCheckInterval tick, so a segment
+// skipped here is picked up again once the runnable queue drains.
+func (si *statsInspector) canSubmitStatsTask(subJobType indexpb.StatsSubJob) bool {
+	pendingTaskCount := si.scheduler.GetPendingTaskCount()
+	pendingTaskLimit := Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt()
+	if pendingTaskCount > pendingTaskLimit {
+		mlog.RatedInfo(si.ctx, rate.Limit(10), "skip submitting stats task because global scheduler has too many pending tasks",
+			mlog.Int("pendingTaskCount", pendingTaskCount),
+			mlog.Int("pendingTaskLimit", pendingTaskLimit),
+			mlog.String("subJobType", subJobType.String()))
+		return false
+	}
+	return true
+}
+
 func (si *statsInspector) triggerTextStatsTask() {
 	collections := si.mt.GetCollections()
 	for _, collection := range collections {
 		if collection == nil {
 			continue
+		}
+		if !si.canSubmitStatsTask(indexpb.StatsSubJob_TextIndexJob) {
+			return
 		}
 		needTriggerFieldIDs := make([]UniqueID, 0)
 		for _, field := range collection.Schema.GetFields() {
@@ -215,9 +282,21 @@ func (si *statsInspector) triggerTextStatsTask() {
 			}
 			needTriggerFieldIDs = append(needTriggerFieldIDs, field.GetFieldID())
 		}
+		// needDoTextIndex is false for every segment once there is no field to
+		// index, so skip the collection before scanning all of its segments.
+		if len(needTriggerFieldIDs) == 0 {
+			continue
+		}
 		allowUnsorted := collection.IsExternal()
 		segments := si.mt.SelectSegments(si.ctx, WithCollection(collection.ID), SegmentFilterFunc(func(seg *SegmentInfo) bool {
-			return needDoTextIndex(seg, needTriggerFieldIDs, allowUnsorted)
+			if !needDoTextIndex(seg, needTriggerFieldIDs, allowUnsorted) {
+				return false
+			}
+			// A segment whose task is already in meta must not be re-submitted;
+			// filtering it out here keeps the per-tick work proportional to the
+			// segments that still need a task instead of to all of them.
+			// Note this runs under meta.segMu.RLock, so keep it to a map read.
+			return !si.mt.statsTaskMeta.HasStatsTask(seg.GetID(), indexpb.StatsSubJob_TextIndexJob)
 		}))
 
 		resources := []*internalpb.FileResourceInfo{}
@@ -231,6 +310,9 @@ func (si *statsInspector) triggerTextStatsTask() {
 		}
 
 		for _, segment := range segments {
+			if !si.canSubmitStatsTask(indexpb.StatsSubJob_TextIndexJob) {
+				return
+			}
 			if err := si.SubmitStatsTask(segment.GetID(), segment.GetID(), indexpb.StatsSubJob_TextIndexJob, true, resources); err != nil {
 				mlog.Warn(si.ctx, "create stats task with text index for segment failed, wait for retry",
 					mlog.FieldSegmentID(segment.GetID()), mlog.Err(err))
@@ -240,11 +322,19 @@ func (si *statsInspector) triggerTextStatsTask() {
 	}
 }
 
-func (si *statsInspector) triggerJSONKeyIndexStatsTask(lastJSONStatsLastTrigger int64, maxJSONStatsTaskCount int) (int64, int) {
+func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
+	if jsonShreddingDisabledByDeprecatedConfig() {
+		mlog.RatedWarn(si.ctx, rate.Limit(0.1), "skip JSON key index stats task, dataCoord.jsonShreddingTriggerCount is set to 0",
+			mlog.String("suggestion", "set common.enabledJSONShredding to false instead"))
+		return
+	}
 	collections := si.mt.GetCollections()
 	for _, collection := range collections {
 		if collection == nil {
 			continue
+		}
+		if !si.canSubmitStatsTask(indexpb.StatsSubJob_JsonKeyIndexJob) {
+			return
 		}
 		needTriggerFieldIDs := make([]UniqueID, 0)
 		for _, field := range collection.Schema.GetFields() {
@@ -253,37 +343,47 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask(lastJSONStatsLastTrigger 
 				needTriggerFieldIDs = append(needTriggerFieldIDs, field.GetFieldID())
 			}
 		}
+		// Same as the text loop: no field to shred means no candidate segment,
+		// which also short-circuits every collection once JSON shredding is off.
+		if len(needTriggerFieldIDs) == 0 {
+			continue
+		}
 		allowUnsorted := collection.IsExternal()
 		segments := si.mt.SelectSegments(si.ctx, WithCollection(collection.ID), SegmentFilterFunc(func(seg *SegmentInfo) bool {
 			if collection.IsExternal() && !canBuildExternalJSONKeyIndex(seg) {
 				return false
 			}
-			return needDoJSONKeyIndex(seg, needTriggerFieldIDs, allowUnsorted)
+			if !needDoJSONKeyIndex(seg, needTriggerFieldIDs, allowUnsorted) {
+				return false
+			}
+			return !si.mt.statsTaskMeta.HasStatsTask(seg.GetID(), indexpb.StatsSubJob_JsonKeyIndexJob)
 		}))
-		if time.Now().Unix()-lastJSONStatsLastTrigger > int64(Params.DataCoordCfg.JSONStatsTriggerInterval.GetAsDuration(time.Minute).Seconds()) {
-			lastJSONStatsLastTrigger = time.Now().Unix()
-			maxJSONStatsTaskCount = 0
-		}
 		for _, segment := range segments {
-			if maxJSONStatsTaskCount >= Params.DataCoordCfg.JSONStatsTriggerCount.GetAsInt() {
-				break
+			if !si.canSubmitStatsTask(indexpb.StatsSubJob_JsonKeyIndexJob) {
+				return
 			}
 			if err := si.SubmitStatsTask(segment.GetID(), segment.GetID(), indexpb.StatsSubJob_JsonKeyIndexJob, true, nil); err != nil {
 				mlog.Warn(si.ctx, "create stats task with json key index for segment failed, wait for retry:",
 					mlog.FieldSegmentID(segment.GetID()), mlog.Err(err))
 				continue
 			}
-			maxJSONStatsTaskCount++
 		}
 	}
-	return lastJSONStatsLastTrigger, maxJSONStatsTaskCount
 }
 
 func (si *statsInspector) triggerBM25StatsTask() {
+	// BM25 stats tasks are not docked yet, so every collection would be scanned
+	// for nothing. Drop out before touching the segment meta at all.
+	if !si.enableBM25() {
+		return
+	}
 	collections := si.mt.GetCollections()
 	for _, collection := range collections {
 		if collection == nil || collection.IsExternal() {
 			continue
+		}
+		if !si.canSubmitStatsTask(indexpb.StatsSubJob_BM25Job) {
+			return
 		}
 		needTriggerFieldIDs := make([]UniqueID, 0)
 		for _, field := range collection.Schema.GetFields() {
@@ -293,10 +393,19 @@ func (si *statsInspector) triggerBM25StatsTask() {
 			}
 		}
 		segments := si.mt.SelectSegments(si.ctx, WithCollection(collection.ID), SegmentFilterFunc(func(seg *SegmentInfo) bool {
-			return (seg.GetIsSorted() || seg.GetIsSortedByNamespace()) && needDoBM25(seg, needTriggerFieldIDs)
+			if !seg.GetIsSorted() && !seg.GetIsSortedByNamespace() {
+				return false
+			}
+			if !needDoBM25(seg, needTriggerFieldIDs) {
+				return false
+			}
+			return !si.mt.statsTaskMeta.HasStatsTask(seg.GetID(), indexpb.StatsSubJob_BM25Job)
 		}))
 
 		for _, segment := range segments {
+			if !si.canSubmitStatsTask(indexpb.StatsSubJob_BM25Job) {
+				return
+			}
 			if err := si.SubmitStatsTask(segment.GetID(), segment.GetID(), indexpb.StatsSubJob_BM25Job, true, nil); err != nil {
 				mlog.Warn(si.ctx, "create stats task with bm25 for segment failed, wait for retry",
 					mlog.FieldSegmentID(segment.GetID()), mlog.Err(err))
@@ -360,6 +469,18 @@ func (si *statsInspector) SubmitStatsTask(originSegmentID, targetSegmentID int64
 				mlog.String("subJobType", subJobType.String()))
 			return nil
 		}
+	}
+	if si.mt.statsTaskMeta.HasStatsTask(originSegmentID, subJobType) {
+		mlog.RatedInfo(si.ctx, rate.Limit(10), "stats task already exists",
+			mlog.FieldCollectionID(originSegment.GetCollectionID()),
+			mlog.FieldSegmentID(originSegmentID),
+			mlog.String("subJobType", subJobType.String()))
+		return nil
+	}
+	// The trigger loops check admission before getting here; this guard covers
+	// callers that reach the StatsInspector interface directly.
+	if !si.canSubmitStatsTask(subJobType) {
+		return nil
 	}
 	taskID, err := si.allocator.AllocID(context.Background())
 	if err != nil {

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -18,6 +18,7 @@ package datacoord
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -239,6 +240,7 @@ func (s *statsInspectorSuite) SetupTest() {
 	gs := task.NewMockGlobalScheduler(s.T())
 	gs.EXPECT().Enqueue(mock.Anything).Return().Maybe()
 	gs.EXPECT().AbortAndRemoveTask(mock.Anything).Return().Maybe()
+	gs.EXPECT().GetPendingTaskCount().Return(0).Maybe()
 	s.scheduler = gs
 
 	s.inspector = newStatsInspector(
@@ -339,20 +341,169 @@ func (s *statsInspectorSuite) TestSubmitStatsTask() {
 	s.Error(err)
 	s.True(errors.Is(err, merr.ErrSegmentNotFound), "Error should be ErrSegmentNotFound")
 
-	s.mt.statsTaskMeta.tasks.Insert(1001, &indexpb.StatsTask{
-		TaskID:     1001,
-		SegmentID:  10,
-		SubJobType: indexpb.StatsSubJob_Sort,
-	})
-	s.mt.statsTaskMeta.segmentID2Tasks.Insert("10-Sort", &indexpb.StatsTask{
-		TaskID:     1001,
-		SegmentID:  10,
-		SubJobType: indexpb.StatsSubJob_Sort,
+	// Duplicate tasks are skipped before checking the scheduler or allocating a task ID.
+	s.inspector.scheduler = task.NewMockGlobalScheduler(s.T())
+	s.inspector.allocator = allocator.NewMockAllocator(s.T())
+	err = s.inspector.SubmitStatsTask(10, 10, indexpb.StatsSubJob_Sort, true, nil)
+	s.NoError(err)
+}
+
+func (s *statsInspectorSuite) TestSubmitStatsTaskPendingLimit() {
+	pendingTaskLimit := Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt()
+
+	s.Run("allow at limit", func() {
+		scheduler := task.NewMockGlobalScheduler(s.T())
+		scheduler.EXPECT().GetPendingTaskCount().Return(pendingTaskLimit).Once()
+		scheduler.EXPECT().Enqueue(mock.Anything).Return().Once()
+		s.inspector.scheduler = scheduler
+
+		err := s.inspector.SubmitStatsTask(20, 20, indexpb.StatsSubJob_TextIndexJob, true, nil)
+		s.NoError(err)
+		s.NotNil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(20, indexpb.StatsSubJob_TextIndexJob))
 	})
 
-	// Simulate duplicate task error
-	err = s.inspector.SubmitStatsTask(10, 10, indexpb.StatsSubJob_Sort, true, nil)
-	s.NoError(err) // Duplicate tasks are handled as success
+	s.Run("skip over limit", func() {
+		scheduler := task.NewMockGlobalScheduler(s.T())
+		scheduler.EXPECT().GetPendingTaskCount().Return(pendingTaskLimit + 1).Once()
+		s.inspector.scheduler = scheduler
+		// A strict allocator asserts the admission check runs before task ID allocation.
+		s.inspector.allocator = allocator.NewMockAllocator(s.T())
+
+		err := s.inspector.SubmitStatsTask(10, 10, indexpb.StatsSubJob_TextIndexJob, true, nil)
+		s.NoError(err)
+		s.Nil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(10, indexpb.StatsSubJob_TextIndexJob))
+	})
+}
+
+// A segment whose task is already in meta must be dropped by the segment
+// selector, so a repeated tick never reaches SubmitStatsTask at all. Asserting
+// on side effects (no ID allocated, nothing enqueued) would not prove this:
+// SubmitStatsTask's own duplicate guard produces exactly the same side effects,
+// so the assertion has to be on whether SubmitStatsTask is called.
+func (s *statsInspectorSuite) TestTriggerTextStatsTaskSkipsSubmittedSegments() {
+	submitted := make([]UniqueID, 0)
+	mockSubmit := mockey.Mock((*statsInspector).SubmitStatsTask).To(
+		func(_ *statsInspector, originSegmentID, _ int64, _ indexpb.StatsSubJob, _ bool, _ []*internalpb.FileResourceInfo) error {
+			submitted = append(submitted, originSegmentID)
+			return nil
+		}).Build()
+	defer mockSubmit.UnPatch()
+
+	// Without a task in meta the segment is a candidate.
+	s.inspector.triggerTextStatsTask()
+	s.Equal([]UniqueID{20}, submitted)
+
+	// Once the task is recorded the selector must drop the segment.
+	s.NoError(s.mt.statsTaskMeta.AddStatsTask(&indexpb.StatsTask{
+		CollectionID: 1,
+		TaskID:       1001,
+		SegmentID:    20,
+		SubJobType:   indexpb.StatsSubJob_TextIndexJob,
+	}))
+	submitted = submitted[:0]
+	s.inspector.triggerTextStatsTask()
+	s.Empty(submitted)
+}
+
+// The sub-jobs share one admission budget, so the trigger that runs first wins
+// it. Consecutive rounds must not give the same sub-job first claim.
+func (s *statsInspectorSuite) TestTriggerStatsTasksAlternatesSubJobOrder() {
+	s.putExternalSegment(220, false, storage.StorageV3, packed.MarshalManifestPath("files/insert_log/2/3/220", 1))
+
+	order := make([]indexpb.StatsSubJob, 0)
+	mockSubmit := mockey.Mock((*statsInspector).SubmitStatsTask).To(
+		func(_ *statsInspector, _, _ int64, subJobType indexpb.StatsSubJob, _ bool, _ []*internalpb.FileResourceInfo) error {
+			order = append(order, subJobType)
+			return nil
+		}).Build()
+	defer mockSubmit.UnPatch()
+
+	// Both sub-jobs have candidates, so the first entry is the one that would
+	// have claimed the budget had it been exhausted.
+	s.inspector.triggerStatsTasks(0)
+	s.Require().NotEmpty(order)
+	s.Equal(indexpb.StatsSubJob_TextIndexJob, order[0])
+	s.Contains(order, indexpb.StatsSubJob_JsonKeyIndexJob)
+
+	order = order[:0]
+	s.inspector.triggerStatsTasks(1)
+	s.Require().NotEmpty(order)
+	s.Equal(indexpb.StatsSubJob_JsonKeyIndexJob, order[0])
+	s.Contains(order, indexpb.StatsSubJob_TextIndexJob)
+}
+
+// jsonShreddingTriggerCount is deprecated, but 0 used to disable JSON key index
+// submission outright and must keep doing so instead of silently turning
+// shredding back on after an upgrade.
+func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskHonorsDeprecatedZero() {
+	segmentID := UniqueID(230)
+	s.putExternalSegment(segmentID, false, storage.StorageV3, packed.MarshalManifestPath("files/insert_log/2/3/230", 1))
+
+	// Sanity check: the segment is a candidate while the deprecated key is unset.
+	s.inspector.triggerJSONKeyIndexStatsTask()
+	s.NotNil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob))
+	s.NoError(s.mt.statsTaskMeta.DropStatsTask(s.ctx,
+		s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob).GetTaskID()))
+
+	Params.Save(Params.DataCoordCfg.JSONStatsTriggerCount.Key, "0")
+	defer Params.Reset(Params.DataCoordCfg.JSONStatsTriggerCount.Key)
+	s.inspector.allocator = allocator.NewMockAllocator(s.T())
+
+	s.inspector.triggerJSONKeyIndexStatsTask()
+	s.Nil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob))
+}
+
+// Every trigger loop must give up as soon as the scheduler is backlogged instead
+// of walking the remaining collections. The call count is what proves it: the
+// text and JSON loops each ask once for the first collection they look at and
+// then return, while the BM25 loop returns before asking because BM25 is not
+// docked yet. Walking on (continue) would ask once per collection instead.
+func (s *statsInspectorSuite) TestTriggerStatsTaskStopsWhenSchedulerBacklogged() {
+	scheduler := task.NewMockGlobalScheduler(s.T())
+	scheduler.EXPECT().GetPendingTaskCount().
+		Return(Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt() + 1).Times(2)
+	s.inspector.scheduler = scheduler
+	s.inspector.allocator = allocator.NewMockAllocator(s.T())
+
+	s.putExternalSegment(210, false, storage.StorageV3, packed.MarshalManifestPath("files/insert_log/2/3/210", 1))
+
+	s.inspector.triggerTextStatsTask()
+	s.inspector.triggerJSONKeyIndexStatsTask()
+	s.inspector.triggerBM25StatsTask()
+
+	s.Nil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(20, indexpb.StatsSubJob_TextIndexJob))
+	s.Nil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(210, indexpb.StatsSubJob_JsonKeyIndexJob))
+}
+
+// The loop keeps submitting while the pending count is at the limit and stops on
+// the first segment that would exceed it, mid-collection.
+func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskStopsAtPendingLimit() {
+	Params.Save(Params.DataCoordCfg.StatsTaskPendingLimit.Key, "1")
+	defer Params.Reset(Params.DataCoordCfg.StatsTaskPendingLimit.Key)
+
+	segmentIDs := []UniqueID{301, 302, 303, 304}
+	for _, segmentID := range segmentIDs {
+		s.putExternalSegment(segmentID, false, storage.StorageV3,
+			packed.MarshalManifestPath(fmt.Sprintf("files/insert_log/2/3/%d", segmentID), 1))
+	}
+
+	pending := 0
+	scheduler := task.NewMockGlobalScheduler(s.T())
+	scheduler.EXPECT().GetPendingTaskCount().RunAndReturn(func() int { return pending })
+	scheduler.EXPECT().Enqueue(mock.Anything).Run(func(_ task.Task) { pending++ }).Return()
+	s.inspector.scheduler = scheduler
+
+	s.inspector.triggerJSONKeyIndexStatsTask()
+
+	// pending 0 -> allowed, 1 -> allowed (== limit), 2 -> skipped (> limit).
+	submitted := 0
+	for _, segmentID := range segmentIDs {
+		if s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob) != nil {
+			submitted++
+		}
+	}
+	s.Equal(2, submitted)
+	s.Equal(2, pending)
 }
 
 func (s *statsInspectorSuite) TestSubmitStatsTaskSkipExternalCollection() {
@@ -389,9 +540,7 @@ func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskExternalCollection
 	segmentID := UniqueID(201)
 	s.putExternalSegment(segmentID, false, storage.StorageV3, packed.MarshalManifestPath("files/insert_log/2/3/201", 1))
 
-	lastTrigger := time.Now().Add(-time.Hour).Unix()
-	_, triggered := s.inspector.triggerJSONKeyIndexStatsTask(lastTrigger, 0)
-	s.Equal(1, triggered)
+	s.inspector.triggerJSONKeyIndexStatsTask()
 
 	jsonTask := s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob)
 	s.NotNil(jsonTask)
@@ -422,9 +571,7 @@ func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskExternalCollection
 		s.Run(testCase.name, func() {
 			s.putExternalSegment(testCase.segmentID, false, testCase.storageVersion, testCase.manifestPath)
 
-			lastTrigger := time.Now().Add(-time.Hour).Unix()
-			_, triggered := s.inspector.triggerJSONKeyIndexStatsTask(lastTrigger, 0)
-			s.Equal(0, triggered)
+			s.inspector.triggerJSONKeyIndexStatsTask()
 
 			jsonTask := s.mt.statsTaskMeta.GetStatsTaskBySegmentID(testCase.segmentID, indexpb.StatsSubJob_JsonKeyIndexJob)
 			s.Nil(jsonTask)

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -18,6 +18,7 @@ package datacoord
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -36,6 +37,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/lock"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -237,6 +239,7 @@ func (s *statsInspectorSuite) SetupTest() {
 	gs := task.NewMockGlobalScheduler(s.T())
 	gs.EXPECT().Enqueue(mock.Anything).Return().Maybe()
 	gs.EXPECT().AbortAndRemoveTask(mock.Anything).Return().Maybe()
+	gs.EXPECT().GetPendingTaskCount().Return(0).Maybe()
 	s.scheduler = gs
 
 	s.inspector = newStatsInspector(
@@ -300,20 +303,169 @@ func (s *statsInspectorSuite) TestSubmitStatsTask() {
 	s.Error(err)
 	s.True(errors.Is(err, merr.ErrSegmentNotFound), "Error should be ErrSegmentNotFound")
 
-	s.mt.statsTaskMeta.tasks.Insert(1001, &indexpb.StatsTask{
-		TaskID:     1001,
-		SegmentID:  10,
-		SubJobType: indexpb.StatsSubJob_Sort,
-	})
-	s.mt.statsTaskMeta.segmentID2Tasks.Insert("10-Sort", &indexpb.StatsTask{
-		TaskID:     1001,
-		SegmentID:  10,
-		SubJobType: indexpb.StatsSubJob_Sort,
+	// Duplicate tasks are skipped before checking the scheduler or allocating a task ID.
+	s.inspector.scheduler = task.NewMockGlobalScheduler(s.T())
+	s.inspector.allocator = allocator.NewMockAllocator(s.T())
+	err = s.inspector.SubmitStatsTask(10, 10, indexpb.StatsSubJob_Sort, true, nil)
+	s.NoError(err)
+}
+
+func (s *statsInspectorSuite) TestSubmitStatsTaskPendingLimit() {
+	pendingTaskLimit := Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt()
+
+	s.Run("allow at limit", func() {
+		scheduler := task.NewMockGlobalScheduler(s.T())
+		scheduler.EXPECT().GetPendingTaskCount().Return(pendingTaskLimit).Once()
+		scheduler.EXPECT().Enqueue(mock.Anything).Return().Once()
+		s.inspector.scheduler = scheduler
+
+		err := s.inspector.SubmitStatsTask(20, 20, indexpb.StatsSubJob_TextIndexJob, true, nil)
+		s.NoError(err)
+		s.NotNil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(20, indexpb.StatsSubJob_TextIndexJob))
 	})
 
-	// Simulate duplicate task error
-	err = s.inspector.SubmitStatsTask(10, 10, indexpb.StatsSubJob_Sort, true, nil)
-	s.NoError(err) // Duplicate tasks are handled as success
+	s.Run("skip over limit", func() {
+		scheduler := task.NewMockGlobalScheduler(s.T())
+		scheduler.EXPECT().GetPendingTaskCount().Return(pendingTaskLimit + 1).Once()
+		s.inspector.scheduler = scheduler
+		// A strict allocator asserts the admission check runs before task ID allocation.
+		s.inspector.allocator = allocator.NewMockAllocator(s.T())
+
+		err := s.inspector.SubmitStatsTask(10, 10, indexpb.StatsSubJob_TextIndexJob, true, nil)
+		s.NoError(err)
+		s.Nil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(10, indexpb.StatsSubJob_TextIndexJob))
+	})
+}
+
+// A segment whose task is already in meta must be dropped by the segment
+// selector, so a repeated tick never reaches SubmitStatsTask at all. Asserting
+// on side effects (no ID allocated, nothing enqueued) would not prove this:
+// SubmitStatsTask's own duplicate guard produces exactly the same side effects,
+// so the assertion has to be on whether SubmitStatsTask is called.
+func (s *statsInspectorSuite) TestTriggerTextStatsTaskSkipsSubmittedSegments() {
+	submitted := make([]UniqueID, 0)
+	mockSubmit := mockey.Mock((*statsInspector).SubmitStatsTask).To(
+		func(_ *statsInspector, originSegmentID, _ int64, _ indexpb.StatsSubJob, _ bool, _ []*internalpb.FileResourceInfo) error {
+			submitted = append(submitted, originSegmentID)
+			return nil
+		}).Build()
+	defer mockSubmit.UnPatch()
+
+	// Without a task in meta the segment is a candidate.
+	s.inspector.triggerTextStatsTask()
+	s.Equal([]UniqueID{20}, submitted)
+
+	// Once the task is recorded the selector must drop the segment.
+	s.NoError(s.mt.statsTaskMeta.AddStatsTask(&indexpb.StatsTask{
+		CollectionID: 1,
+		TaskID:       1001,
+		SegmentID:    20,
+		SubJobType:   indexpb.StatsSubJob_TextIndexJob,
+	}))
+	submitted = submitted[:0]
+	s.inspector.triggerTextStatsTask()
+	s.Empty(submitted)
+}
+
+// The sub-jobs share one admission budget, so the trigger that runs first wins
+// it. Consecutive rounds must not give the same sub-job first claim.
+func (s *statsInspectorSuite) TestTriggerStatsTasksAlternatesSubJobOrder() {
+	s.putExternalSegment(220, false, storage.StorageV3, packed.MarshalManifestPath("files/insert_log/2/3/220", 1))
+
+	order := make([]indexpb.StatsSubJob, 0)
+	mockSubmit := mockey.Mock((*statsInspector).SubmitStatsTask).To(
+		func(_ *statsInspector, _, _ int64, subJobType indexpb.StatsSubJob, _ bool, _ []*internalpb.FileResourceInfo) error {
+			order = append(order, subJobType)
+			return nil
+		}).Build()
+	defer mockSubmit.UnPatch()
+
+	// Both sub-jobs have candidates, so the first entry is the one that would
+	// have claimed the budget had it been exhausted.
+	s.inspector.triggerStatsTasks(0)
+	s.Require().NotEmpty(order)
+	s.Equal(indexpb.StatsSubJob_TextIndexJob, order[0])
+	s.Contains(order, indexpb.StatsSubJob_JsonKeyIndexJob)
+
+	order = order[:0]
+	s.inspector.triggerStatsTasks(1)
+	s.Require().NotEmpty(order)
+	s.Equal(indexpb.StatsSubJob_JsonKeyIndexJob, order[0])
+	s.Contains(order, indexpb.StatsSubJob_TextIndexJob)
+}
+
+// jsonShreddingTriggerCount is deprecated, but 0 used to disable JSON key index
+// submission outright and must keep doing so instead of silently turning
+// shredding back on after an upgrade.
+func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskHonorsDeprecatedZero() {
+	segmentID := UniqueID(230)
+	s.putExternalSegment(segmentID, false, storage.StorageV3, packed.MarshalManifestPath("files/insert_log/2/3/230", 1))
+
+	// Sanity check: the segment is a candidate while the deprecated key is unset.
+	s.inspector.triggerJSONKeyIndexStatsTask()
+	s.NotNil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob))
+	s.NoError(s.mt.statsTaskMeta.DropStatsTask(s.ctx,
+		s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob).GetTaskID()))
+
+	Params.Save(Params.DataCoordCfg.JSONStatsTriggerCount.Key, "0")
+	defer Params.Reset(Params.DataCoordCfg.JSONStatsTriggerCount.Key)
+	s.inspector.allocator = allocator.NewMockAllocator(s.T())
+
+	s.inspector.triggerJSONKeyIndexStatsTask()
+	s.Nil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob))
+}
+
+// Every trigger loop must give up as soon as the scheduler is backlogged instead
+// of walking the remaining collections. The call count is what proves it: the
+// text and JSON loops each ask once for the first collection they look at and
+// then return, while the BM25 loop returns before asking because BM25 is not
+// docked yet. Walking on (continue) would ask once per collection instead.
+func (s *statsInspectorSuite) TestTriggerStatsTaskStopsWhenSchedulerBacklogged() {
+	scheduler := task.NewMockGlobalScheduler(s.T())
+	scheduler.EXPECT().GetPendingTaskCount().
+		Return(Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt() + 1).Times(2)
+	s.inspector.scheduler = scheduler
+	s.inspector.allocator = allocator.NewMockAllocator(s.T())
+
+	s.putExternalSegment(210, false, storage.StorageV3, packed.MarshalManifestPath("files/insert_log/2/3/210", 1))
+
+	s.inspector.triggerTextStatsTask()
+	s.inspector.triggerJSONKeyIndexStatsTask()
+	s.inspector.triggerBM25StatsTask()
+
+	s.Nil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(20, indexpb.StatsSubJob_TextIndexJob))
+	s.Nil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(210, indexpb.StatsSubJob_JsonKeyIndexJob))
+}
+
+// The loop keeps submitting while the pending count is at the limit and stops on
+// the first segment that would exceed it, mid-collection.
+func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskStopsAtPendingLimit() {
+	Params.Save(Params.DataCoordCfg.StatsTaskPendingLimit.Key, "1")
+	defer Params.Reset(Params.DataCoordCfg.StatsTaskPendingLimit.Key)
+
+	segmentIDs := []UniqueID{301, 302, 303, 304}
+	for _, segmentID := range segmentIDs {
+		s.putExternalSegment(segmentID, false, storage.StorageV3,
+			packed.MarshalManifestPath(fmt.Sprintf("files/insert_log/2/3/%d", segmentID), 1))
+	}
+
+	pending := 0
+	scheduler := task.NewMockGlobalScheduler(s.T())
+	scheduler.EXPECT().GetPendingTaskCount().RunAndReturn(func() int { return pending })
+	scheduler.EXPECT().Enqueue(mock.Anything).Run(func(_ task.Task) { pending++ }).Return()
+	s.inspector.scheduler = scheduler
+
+	s.inspector.triggerJSONKeyIndexStatsTask()
+
+	// pending 0 -> allowed, 1 -> allowed (== limit), 2 -> skipped (> limit).
+	submitted := 0
+	for _, segmentID := range segmentIDs {
+		if s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob) != nil {
+			submitted++
+		}
+	}
+	s.Equal(2, submitted)
+	s.Equal(2, pending)
 }
 
 func (s *statsInspectorSuite) TestSubmitStatsTaskSkipExternalCollection() {
@@ -350,9 +502,7 @@ func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskExternalCollection
 	segmentID := UniqueID(201)
 	s.putExternalSegment(segmentID, false, storage.StorageV3, packed.MarshalManifestPath("files/insert_log/2/3/201", 1))
 
-	lastTrigger := time.Now().Add(-time.Hour).Unix()
-	_, triggered := s.inspector.triggerJSONKeyIndexStatsTask(lastTrigger, 0)
-	s.Equal(1, triggered)
+	s.inspector.triggerJSONKeyIndexStatsTask()
 
 	jsonTask := s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob)
 	s.NotNil(jsonTask)
@@ -383,9 +533,7 @@ func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskExternalCollection
 		s.Run(testCase.name, func() {
 			s.putExternalSegment(testCase.segmentID, false, testCase.storageVersion, testCase.manifestPath)
 
-			lastTrigger := time.Now().Add(-time.Hour).Unix()
-			_, triggered := s.inspector.triggerJSONKeyIndexStatsTask(lastTrigger, 0)
-			s.Equal(0, triggered)
+			s.inspector.triggerJSONKeyIndexStatsTask()
 
 			jsonTask := s.mt.statsTaskMeta.GetStatsTaskBySegmentID(testCase.segmentID, indexpb.StatsSubJob_JsonKeyIndexJob)
 			s.Nil(jsonTask)

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	taskcommon "github.com/milvus-io/milvus/pkg/v3/taskcommon"
 	"github.com/milvus-io/milvus/pkg/v3/util/lock"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
@@ -240,7 +241,7 @@ func (s *statsInspectorSuite) SetupTest() {
 	gs := task.NewMockGlobalScheduler(s.T())
 	gs.EXPECT().Enqueue(mock.Anything).Return().Maybe()
 	gs.EXPECT().AbortAndRemoveTask(mock.Anything).Return().Maybe()
-	gs.EXPECT().GetPendingTaskCount().Return(0).Maybe()
+	gs.EXPECT().GetPendingTaskCount(taskcommon.Stats).Return(0).Maybe()
 	s.scheduler = gs
 
 	s.inspector = newStatsInspector(
@@ -353,7 +354,7 @@ func (s *statsInspectorSuite) TestSubmitStatsTaskPendingLimit() {
 
 	s.Run("allow at limit", func() {
 		scheduler := task.NewMockGlobalScheduler(s.T())
-		scheduler.EXPECT().GetPendingTaskCount().Return(pendingTaskLimit).Once()
+		scheduler.EXPECT().GetPendingTaskCount(taskcommon.Stats).Return(pendingTaskLimit).Once()
 		scheduler.EXPECT().Enqueue(mock.Anything).Return().Once()
 		s.inspector.scheduler = scheduler
 
@@ -364,7 +365,7 @@ func (s *statsInspectorSuite) TestSubmitStatsTaskPendingLimit() {
 
 	s.Run("skip over limit", func() {
 		scheduler := task.NewMockGlobalScheduler(s.T())
-		scheduler.EXPECT().GetPendingTaskCount().Return(pendingTaskLimit + 1).Once()
+		scheduler.EXPECT().GetPendingTaskCount(taskcommon.Stats).Return(pendingTaskLimit + 1).Once()
 		s.inspector.scheduler = scheduler
 		// A strict allocator asserts the admission check runs before task ID allocation.
 		s.inspector.allocator = allocator.NewMockAllocator(s.T())
@@ -460,7 +461,7 @@ func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskHonorsDeprecatedZe
 // docked yet. Walking on (continue) would ask once per collection instead.
 func (s *statsInspectorSuite) TestTriggerStatsTaskStopsWhenSchedulerBacklogged() {
 	scheduler := task.NewMockGlobalScheduler(s.T())
-	scheduler.EXPECT().GetPendingTaskCount().
+	scheduler.EXPECT().GetPendingTaskCount(taskcommon.Stats).
 		Return(Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt() + 1).Times(2)
 	s.inspector.scheduler = scheduler
 	s.inspector.allocator = allocator.NewMockAllocator(s.T())
@@ -489,7 +490,7 @@ func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskStopsAtPendingLimi
 
 	pending := 0
 	scheduler := task.NewMockGlobalScheduler(s.T())
-	scheduler.EXPECT().GetPendingTaskCount().RunAndReturn(func() int { return pending })
+	scheduler.EXPECT().GetPendingTaskCount(taskcommon.Stats).RunAndReturn(func(taskcommon.Type) int { return pending })
 	scheduler.EXPECT().Enqueue(mock.Anything).Run(func(_ task.Task) { pending++ }).Return()
 	s.inspector.scheduler = scheduler
 

--- a/internal/datacoord/stats_task_meta.go
+++ b/internal/datacoord/stats_task_meta.go
@@ -315,6 +315,16 @@ func (stm *statsTaskMeta) GetStatsTaskStateBySegmentID(segmentID int64, subJobTy
 	return state
 }
 
+// HasStatsTask reports whether a task for (segmentID, subJobType) is recorded in
+// meta, regardless of its state: a Finished or Failed task still counts until GC
+// recycles it, which is exactly the condition under which AddStatsTask would
+// reject a resubmission.
+func (stm *statsTaskMeta) HasStatsTask(segmentID int64, subJobType indexpb.StatsSubJob) bool {
+	secondaryKey := createSecondaryIndexKey(segmentID, subJobType.String())
+	_, exists := stm.segmentID2Tasks.Get(secondaryKey)
+	return exists
+}
+
 func (stm *statsTaskMeta) CanCleanedTasks() []int64 {
 	needCleanedTaskIDs := make([]int64, 0)
 	stm.tasks.Range(func(key UniqueID, value *indexpb.StatsTask) bool {

--- a/internal/datacoord/stats_task_meta_test.go
+++ b/internal/datacoord/stats_task_meta_test.go
@@ -265,6 +265,15 @@ func (s *statsTaskMetaSuite) Test_Method() {
 		})
 	})
 
+	s.Run("HasStatsTask", func() {
+		s.False(m.HasStatsTask(100, indexpb.StatsSubJob_Sort))
+		s.False(m.HasStatsTask(s.segmentID, indexpb.StatsSubJob_BM25Job))
+		// The task is already Finished here: it keeps blocking resubmission
+		// until GC recycles it, matching AddStatsTask's duplicate guard.
+		s.Equal(indexpb.JobState_JobStateFinished, m.GetStatsTaskStateBySegmentID(s.segmentID, indexpb.StatsSubJob_Sort))
+		s.True(m.HasStatsTask(s.segmentID, indexpb.StatsSubJob_Sort))
+	})
+
 	s.Run("DropStatsTask", func() {
 		s.Run("failed case", func() {
 			catalog.EXPECT().DropStatsTask(mock.Anything, mock.Anything).Return(errors.New("mock error")).Once()
@@ -280,6 +289,8 @@ func (s *statsTaskMetaSuite) Test_Method() {
 			s.NoError(m.DropStatsTask(context.TODO(), 1))
 			_, ok := m.tasks.Get(1)
 			s.False(ok)
+			// Once recycled the segment becomes submittable again.
+			s.False(m.HasStatsTask(s.segmentID, indexpb.StatsSubJob_Sort))
 
 			s.NoError(m.DropStatsTask(context.TODO(), 1000))
 		})

--- a/internal/datacoord/task/global_scheduler.go
+++ b/internal/datacoord/task/global_scheduler.go
@@ -36,6 +36,9 @@ const NullNodeID = -1
 type GlobalScheduler interface {
 	Enqueue(task Task)
 	AbortAndRemoveTask(taskID int64)
+	// GetPendingTaskCount returns tasks that are eligible for dispatch now;
+	// tasks waiting for their retry backoff deadline are excluded.
+	GetPendingTaskCount() int
 
 	Start()
 	Stop()
@@ -121,6 +124,14 @@ func (s *globalTaskScheduler) Enqueue(task Task) {
 		s.runningTasks.Insert(task.GetTaskID(), task)
 	}
 	mlog.Info(s.ctx, "task enqueued", WrapTaskLog(task)...)
+}
+
+func (s *globalTaskScheduler) GetPendingTaskCount() int {
+	now := time.Now()
+	return s.pendingTasks.TaskCountBy(func(task Task) bool {
+		backoff, ok := s.backoffs.Get(task.GetTaskID())
+		return !ok || !now.Before(backoff.notBefore)
+	})
 }
 
 func (s *globalTaskScheduler) AbortAndRemoveTask(taskID int64) {
@@ -248,7 +259,7 @@ func (s *globalTaskScheduler) pickNode(slotHeap typeutil.Heap[*nodeSlotEntry], t
 }
 
 func (s *globalTaskScheduler) schedule() {
-	pendingNum := len(s.pendingTasks.TaskIDs())
+	pendingNum := s.pendingTasks.TaskCount()
 	if pendingNum == 0 {
 		return
 	}

--- a/internal/datacoord/task/global_scheduler.go
+++ b/internal/datacoord/task/global_scheduler.go
@@ -36,9 +36,13 @@ const NullNodeID = -1
 type GlobalScheduler interface {
 	Enqueue(task Task)
 	AbortAndRemoveTask(taskID int64)
-	// GetPendingTaskCount returns tasks that are eligible for dispatch now;
-	// tasks waiting for their retry backoff deadline are excluded.
-	GetPendingTaskCount() int
+	// GetPendingTaskCount returns the number of queued tasks of the given type.
+	// The queue is shared by every task type, so callers that gate admission for
+	// one kind of work must scope the count to that kind, otherwise an unrelated
+	// backlog starves them. Tasks waiting on a retry backoff deadline ARE counted:
+	// they still occupy queue depth, and excluding them would let a worker-side
+	// failure storm silently disable the caller's admission gate.
+	GetPendingTaskCount(taskType taskcommon.Type) int
 
 	Start()
 	Stop()
@@ -126,11 +130,9 @@ func (s *globalTaskScheduler) Enqueue(task Task) {
 	mlog.Info(s.ctx, "task enqueued", WrapTaskLog(task)...)
 }
 
-func (s *globalTaskScheduler) GetPendingTaskCount() int {
-	now := time.Now()
+func (s *globalTaskScheduler) GetPendingTaskCount(taskType taskcommon.Type) int {
 	return s.pendingTasks.TaskCountBy(func(task Task) bool {
-		backoff, ok := s.backoffs.Get(task.GetTaskID())
-		return !ok || !now.Before(backoff.notBefore)
+		return task.GetTaskType() == taskType
 	})
 }
 

--- a/internal/datacoord/task/global_scheduler_test.go
+++ b/internal/datacoord/task/global_scheduler_test.go
@@ -45,8 +45,10 @@ func TestGlobalScheduler_Enqueue(t *testing.T) {
 	task.EXPECT().SetTaskTime(mock.Anything, mock.Anything).Return()
 	scheduler.Enqueue(task)
 	assert.Equal(t, 1, len(scheduler.(*globalTaskScheduler).pendingTasks.TaskIDs()))
+	assert.Equal(t, 1, scheduler.GetPendingTaskCount())
 	scheduler.Enqueue(task)
 	assert.Equal(t, 1, len(scheduler.(*globalTaskScheduler).pendingTasks.TaskIDs()))
+	assert.Equal(t, 1, scheduler.GetPendingTaskCount())
 
 	task = NewMockTask(t)
 	task.EXPECT().GetTaskID().Return(2)
@@ -55,8 +57,36 @@ func TestGlobalScheduler_Enqueue(t *testing.T) {
 	task.EXPECT().SetTaskTime(mock.Anything, mock.Anything).Return()
 	scheduler.Enqueue(task)
 	assert.Equal(t, 1, scheduler.(*globalTaskScheduler).runningTasks.Len())
+	assert.Equal(t, 1, scheduler.GetPendingTaskCount())
 	scheduler.Enqueue(task)
 	assert.Equal(t, 1, scheduler.(*globalTaskScheduler).runningTasks.Len())
+}
+
+func TestGlobalScheduler_GetPendingTaskCountExcludesBackoff(t *testing.T) {
+	pt := paramtable.Get()
+	pt.Save(pt.DataCoordCfg.TaskRetryBackoffInterval.Key, "60")
+	defer pt.Reset(pt.DataCoordCfg.TaskRetryBackoffInterval.Key)
+
+	cluster := session.NewMockCluster(t)
+	scheduler := NewGlobalTaskScheduler(context.TODO(), cluster)
+	globalScheduler := scheduler.(*globalTaskScheduler)
+
+	tasks := make(map[int64]Task)
+	for taskID := int64(1); taskID <= 2; taskID++ {
+		task := NewMockTask(t)
+		task.EXPECT().GetTaskID().Return(taskID)
+		task.EXPECT().GetTaskState().Return(taskcommon.Init)
+		task.EXPECT().GetTaskType().Return(taskcommon.Compaction)
+		task.EXPECT().SetTaskTime(mock.Anything, mock.Anything).Return()
+		scheduler.Enqueue(task)
+		tasks[taskID] = task
+	}
+
+	globalScheduler.recordTaskFailure(tasks[2])
+	assert.Equal(t, 1, scheduler.GetPendingTaskCount())
+
+	globalScheduler.backoffs.Insert(2, &taskBackoff{notBefore: time.Now().Add(-time.Minute)})
+	assert.Equal(t, 2, scheduler.GetPendingTaskCount())
 }
 
 func TestGlobalScheduler_AbortAndRemoveTask(t *testing.T) {

--- a/internal/datacoord/task/global_scheduler_test.go
+++ b/internal/datacoord/task/global_scheduler_test.go
@@ -45,10 +45,10 @@ func TestGlobalScheduler_Enqueue(t *testing.T) {
 	task.EXPECT().SetTaskTime(mock.Anything, mock.Anything).Return()
 	scheduler.Enqueue(task)
 	assert.Equal(t, 1, len(scheduler.(*globalTaskScheduler).pendingTasks.TaskIDs()))
-	assert.Equal(t, 1, scheduler.GetPendingTaskCount())
+	assert.Equal(t, 1, scheduler.GetPendingTaskCount(taskcommon.Compaction))
 	scheduler.Enqueue(task)
 	assert.Equal(t, 1, len(scheduler.(*globalTaskScheduler).pendingTasks.TaskIDs()))
-	assert.Equal(t, 1, scheduler.GetPendingTaskCount())
+	assert.Equal(t, 1, scheduler.GetPendingTaskCount(taskcommon.Compaction))
 
 	task = NewMockTask(t)
 	task.EXPECT().GetTaskID().Return(2)
@@ -57,12 +57,36 @@ func TestGlobalScheduler_Enqueue(t *testing.T) {
 	task.EXPECT().SetTaskTime(mock.Anything, mock.Anything).Return()
 	scheduler.Enqueue(task)
 	assert.Equal(t, 1, scheduler.(*globalTaskScheduler).runningTasks.Len())
-	assert.Equal(t, 1, scheduler.GetPendingTaskCount())
+	assert.Equal(t, 1, scheduler.GetPendingTaskCount(taskcommon.Compaction))
 	scheduler.Enqueue(task)
 	assert.Equal(t, 1, scheduler.(*globalTaskScheduler).runningTasks.Len())
 }
 
-func TestGlobalScheduler_GetPendingTaskCountExcludesBackoff(t *testing.T) {
+func TestGlobalScheduler_GetPendingTaskCountIsScopedByTaskType(t *testing.T) {
+	cluster := session.NewMockCluster(t)
+	scheduler := NewGlobalTaskScheduler(context.TODO(), cluster)
+
+	enqueue := func(taskID int64, taskType taskcommon.Type) {
+		task := NewMockTask(t)
+		task.EXPECT().GetTaskID().Return(taskID)
+		task.EXPECT().GetTaskState().Return(taskcommon.Init)
+		task.EXPECT().GetTaskType().Return(taskType)
+		task.EXPECT().SetTaskTime(mock.Anything, mock.Anything).Return()
+		scheduler.Enqueue(task)
+	}
+
+	enqueue(1, taskcommon.Stats)
+	enqueue(2, taskcommon.Compaction)
+	enqueue(3, taskcommon.Index)
+	enqueue(4, taskcommon.Compaction)
+
+	// An index/compaction backlog must not consume the stats admission budget.
+	assert.Equal(t, 1, scheduler.GetPendingTaskCount(taskcommon.Stats))
+	assert.Equal(t, 2, scheduler.GetPendingTaskCount(taskcommon.Compaction))
+	assert.Equal(t, 1, scheduler.GetPendingTaskCount(taskcommon.Index))
+}
+
+func TestGlobalScheduler_GetPendingTaskCountIncludesBackoff(t *testing.T) {
 	pt := paramtable.Get()
 	pt.Save(pt.DataCoordCfg.TaskRetryBackoffInterval.Key, "60")
 	defer pt.Reset(pt.DataCoordCfg.TaskRetryBackoffInterval.Key)
@@ -76,17 +100,16 @@ func TestGlobalScheduler_GetPendingTaskCountExcludesBackoff(t *testing.T) {
 		task := NewMockTask(t)
 		task.EXPECT().GetTaskID().Return(taskID)
 		task.EXPECT().GetTaskState().Return(taskcommon.Init)
-		task.EXPECT().GetTaskType().Return(taskcommon.Compaction)
+		task.EXPECT().GetTaskType().Return(taskcommon.Stats)
 		task.EXPECT().SetTaskTime(mock.Anything, mock.Anything).Return()
 		scheduler.Enqueue(task)
 		tasks[taskID] = task
 	}
 
+	// A task waiting on its retry backoff still occupies queue depth: excluding it
+	// would let a worker-side failure storm silently disable the admission gate.
 	globalScheduler.recordTaskFailure(tasks[2])
-	assert.Equal(t, 1, scheduler.GetPendingTaskCount())
-
-	globalScheduler.backoffs.Insert(2, &taskBackoff{notBefore: time.Now().Add(-time.Minute)})
-	assert.Equal(t, 2, scheduler.GetPendingTaskCount())
+	assert.Equal(t, 2, scheduler.GetPendingTaskCount(taskcommon.Stats))
 }
 
 func TestGlobalScheduler_AbortAndRemoveTask(t *testing.T) {

--- a/internal/datacoord/task/mock_global_scheduler.go
+++ b/internal/datacoord/task/mock_global_scheduler.go
@@ -83,6 +83,51 @@ func (_c *MockGlobalScheduler_Enqueue_Call) RunAndReturn(run func(Task)) *MockGl
 	return _c
 }
 
+// GetPendingTaskCount provides a mock function with no fields
+func (_m *MockGlobalScheduler) GetPendingTaskCount() int {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPendingTaskCount")
+	}
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func() int); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	return r0
+}
+
+// MockGlobalScheduler_GetPendingTaskCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetPendingTaskCount'
+type MockGlobalScheduler_GetPendingTaskCount_Call struct {
+	*mock.Call
+}
+
+// GetPendingTaskCount is a helper method to define mock.On call
+func (_e *MockGlobalScheduler_Expecter) GetPendingTaskCount() *MockGlobalScheduler_GetPendingTaskCount_Call {
+	return &MockGlobalScheduler_GetPendingTaskCount_Call{Call: _e.mock.On("GetPendingTaskCount")}
+}
+
+func (_c *MockGlobalScheduler_GetPendingTaskCount_Call) Run(run func()) *MockGlobalScheduler_GetPendingTaskCount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockGlobalScheduler_GetPendingTaskCount_Call) Return(_a0 int) *MockGlobalScheduler_GetPendingTaskCount_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockGlobalScheduler_GetPendingTaskCount_Call) RunAndReturn(run func() int) *MockGlobalScheduler_GetPendingTaskCount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Start provides a mock function with no fields
 func (_m *MockGlobalScheduler) Start() {
 	_m.Called()

--- a/internal/datacoord/task/mock_global_scheduler.go
+++ b/internal/datacoord/task/mock_global_scheduler.go
@@ -83,17 +83,17 @@ func (_c *MockGlobalScheduler_Enqueue_Call) RunAndReturn(run func(Task)) *MockGl
 	return _c
 }
 
-// GetPendingTaskCount provides a mock function with no fields
-func (_m *MockGlobalScheduler) GetPendingTaskCount() int {
-	ret := _m.Called()
+// GetPendingTaskCount provides a mock function with given fields: taskType
+func (_m *MockGlobalScheduler) GetPendingTaskCount(taskType string) int {
+	ret := _m.Called(taskType)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetPendingTaskCount")
 	}
 
 	var r0 int
-	if rf, ok := ret.Get(0).(func() int); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(string) int); ok {
+		r0 = rf(taskType)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
@@ -107,13 +107,14 @@ type MockGlobalScheduler_GetPendingTaskCount_Call struct {
 }
 
 // GetPendingTaskCount is a helper method to define mock.On call
-func (_e *MockGlobalScheduler_Expecter) GetPendingTaskCount() *MockGlobalScheduler_GetPendingTaskCount_Call {
-	return &MockGlobalScheduler_GetPendingTaskCount_Call{Call: _e.mock.On("GetPendingTaskCount")}
+//   - taskType string
+func (_e *MockGlobalScheduler_Expecter) GetPendingTaskCount(taskType interface{}) *MockGlobalScheduler_GetPendingTaskCount_Call {
+	return &MockGlobalScheduler_GetPendingTaskCount_Call{Call: _e.mock.On("GetPendingTaskCount", taskType)}
 }
 
-func (_c *MockGlobalScheduler_GetPendingTaskCount_Call) Run(run func()) *MockGlobalScheduler_GetPendingTaskCount_Call {
+func (_c *MockGlobalScheduler_GetPendingTaskCount_Call) Run(run func(taskType string)) *MockGlobalScheduler_GetPendingTaskCount_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(string))
 	})
 	return _c
 }
@@ -123,7 +124,7 @@ func (_c *MockGlobalScheduler_GetPendingTaskCount_Call) Return(_a0 int) *MockGlo
 	return _c
 }
 
-func (_c *MockGlobalScheduler_GetPendingTaskCount_Call) RunAndReturn(run func() int) *MockGlobalScheduler_GetPendingTaskCount_Call {
+func (_c *MockGlobalScheduler_GetPendingTaskCount_Call) RunAndReturn(run func(string) int) *MockGlobalScheduler_GetPendingTaskCount_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/datacoord/task/priority_queue.go
+++ b/internal/datacoord/task/priority_queue.go
@@ -28,6 +28,8 @@ type PriorityQueue interface {
 	Pop() Task
 	Get(taskID int64) Task
 	Remove(taskID int64)
+	TaskCount() int
+	TaskCountBy(filter func(Task) bool) int
 	TaskIDs() []int64
 }
 
@@ -99,6 +101,26 @@ func (pqp *priorityQueuePolicy) Get(taskID int64) Task {
 	defer pqp.lock.RUnlock()
 
 	return pqp.tasks[taskID]
+}
+
+func (pqp *priorityQueuePolicy) TaskCount() int {
+	pqp.lock.RLock()
+	defer pqp.lock.RUnlock()
+
+	return len(pqp.tasks)
+}
+
+func (pqp *priorityQueuePolicy) TaskCountBy(filter func(Task) bool) int {
+	pqp.lock.RLock()
+	defer pqp.lock.RUnlock()
+
+	count := 0
+	for _, task := range pqp.tasks {
+		if filter(task) {
+			count++
+		}
+	}
+	return count
 }
 
 func (pqp *priorityQueuePolicy) TaskIDs() []int64 {

--- a/internal/datacoord/task/priority_queue_test.go
+++ b/internal/datacoord/task/priority_queue_test.go
@@ -17,6 +17,7 @@ func TestFIFOQueue_Push(t *testing.T) {
 
 	queue.Push(task1)
 	queue.Push(task2)
+	assert.Equal(t, 2, queue.TaskCount())
 
 	// Verify task ID list
 	taskIDs := queue.TaskIDs()
@@ -28,6 +29,10 @@ func TestFIFOQueue_Push(t *testing.T) {
 	queue.Push(task1)
 	taskIDs = queue.TaskIDs()
 	assert.Equal(t, 2, len(taskIDs))
+	assert.Equal(t, 2, queue.TaskCount())
+	assert.Equal(t, 1, queue.TaskCountBy(func(task Task) bool {
+		return task.GetTaskID() == 2
+	}))
 }
 
 func TestFIFOQueue_Pop(t *testing.T) {
@@ -47,10 +52,12 @@ func TestFIFOQueue_Pop(t *testing.T) {
 	poppedTask := queue.Pop()
 	assert.Equal(t, int64(1), poppedTask.GetTaskID())
 	assert.Equal(t, 1, len(queue.TaskIDs()))
+	assert.Equal(t, 1, queue.TaskCount())
 
 	poppedTask = queue.Pop()
 	assert.Equal(t, int64(2), poppedTask.GetTaskID())
 	assert.Equal(t, 0, len(queue.TaskIDs()))
+	assert.Equal(t, 0, queue.TaskCount())
 }
 
 func TestFIFOQueue_Get(t *testing.T) {
@@ -90,6 +97,7 @@ func TestFIFOQueue_Remove(t *testing.T) {
 	queue.Remove(2)
 	taskIDs := queue.TaskIDs()
 	assert.Equal(t, 2, len(taskIDs))
+	assert.Equal(t, 2, queue.TaskCount())
 	assert.Equal(t, int64(1), taskIDs[0])
 	assert.Equal(t, int64(3), taskIDs[1])
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5591,10 +5591,13 @@ type dataCoordConfig struct {
 	StatsTaskSlotUsage                   ParamItem `refreshable:"true"`
 	AnalyzeTaskSlotUsage                 ParamItem `refreshable:"true"`
 
-	EnableSortCompaction             ParamItem `refreshable:"true"`
-	TaskCheckInterval                ParamItem `refreshable:"true"`
-	SortCompactionTriggerCount       ParamItem `refreshable:"true"`
-	JSONStatsTriggerCount            ParamItem `refreshable:"true"`
+	EnableSortCompaction       ParamItem `refreshable:"true"`
+	TaskCheckInterval          ParamItem `refreshable:"true"`
+	SortCompactionTriggerCount ParamItem `refreshable:"true"`
+	StatsTaskPendingLimit      ParamItem `refreshable:"true"`
+	// Deprecated: JSON stats tasks are throttled by StatsTaskPendingLimit.
+	JSONStatsTriggerCount ParamItem `refreshable:"true"`
+	// Deprecated: JSON stats tasks now run on TaskCheckInterval.
 	JSONStatsTriggerInterval         ParamItem `refreshable:"true"`
 	JSONStatsMaxShreddingColumns     ParamItem `refreshable:"true"`
 	JSONStatsShreddingRatioThreshold ParamItem `refreshable:"true"`
@@ -7173,25 +7176,35 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 	}
 	p.SortCompactionTriggerCount.Init(base.mgr)
 
+	p.StatsTaskPendingLimit = ParamItem{
+		Key:          "dataCoord.statsTaskPendingLimit",
+		Version:      "3.0.0",
+		Doc:          "skip submitting new stats tasks when the global scheduler holds more pending tasks than this limit",
+		DefaultValue: "100",
+		PanicIfEmpty: false,
+		Export:       false,
+	}
+	p.StatsTaskPendingLimit.Init(base.mgr)
+
 	p.JSONStatsTriggerCount = ParamItem{
 		Key:          "dataCoord.jsonShreddingTriggerCount",
 		Version:      "2.6.5",
-		Doc:          "jsonkey stats task count per trigger",
+		Doc:          "Deprecated: JSON stats tasks are throttled by dataCoord.statsTaskPendingLimit.",
 		DefaultValue: "10",
 		FallbackKeys: []string{"dataCoord.jsonStatsTriggerCount"},
 		PanicIfEmpty: false,
-		Export:       true,
+		Export:       false,
 	}
 	p.JSONStatsTriggerCount.Init(base.mgr)
 
 	p.JSONStatsTriggerInterval = ParamItem{
 		Key:          "dataCoord.jsonShreddingTriggerInterval",
 		Version:      "2.6.5",
-		Doc:          "jsonkey task interval per trigger",
+		Doc:          "Deprecated: JSON stats tasks now run on dataCoord.taskCheckInterval.",
 		DefaultValue: "10",
 		FallbackKeys: []string{"dataCoord.jsonStatsTriggerInterval"},
 		PanicIfEmpty: false,
-		Export:       true,
+		Export:       false,
 	}
 	p.JSONStatsTriggerInterval.Init(base.mgr)
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5362,10 +5362,13 @@ type dataCoordConfig struct {
 	StatsTaskSlotUsage                   ParamItem `refreshable:"true"`
 	AnalyzeTaskSlotUsage                 ParamItem `refreshable:"true"`
 
-	EnableSortCompaction             ParamItem `refreshable:"true"`
-	TaskCheckInterval                ParamItem `refreshable:"true"`
-	SortCompactionTriggerCount       ParamItem `refreshable:"true"`
-	JSONStatsTriggerCount            ParamItem `refreshable:"true"`
+	EnableSortCompaction       ParamItem `refreshable:"true"`
+	TaskCheckInterval          ParamItem `refreshable:"true"`
+	SortCompactionTriggerCount ParamItem `refreshable:"true"`
+	StatsTaskPendingLimit      ParamItem `refreshable:"true"`
+	// Deprecated: JSON stats tasks are throttled by StatsTaskPendingLimit.
+	JSONStatsTriggerCount ParamItem `refreshable:"true"`
+	// Deprecated: JSON stats tasks now run on TaskCheckInterval.
 	JSONStatsTriggerInterval         ParamItem `refreshable:"true"`
 	JSONStatsMaxShreddingColumns     ParamItem `refreshable:"true"`
 	JSONStatsShreddingRatioThreshold ParamItem `refreshable:"true"`
@@ -6866,25 +6869,35 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 	}
 	p.SortCompactionTriggerCount.Init(base.mgr)
 
+	p.StatsTaskPendingLimit = ParamItem{
+		Key:          "dataCoord.statsTaskPendingLimit",
+		Version:      "2.7.0",
+		Doc:          "skip submitting new stats tasks when the global scheduler holds more pending tasks than this limit",
+		DefaultValue: "100",
+		PanicIfEmpty: false,
+		Export:       false,
+	}
+	p.StatsTaskPendingLimit.Init(base.mgr)
+
 	p.JSONStatsTriggerCount = ParamItem{
 		Key:          "dataCoord.jsonShreddingTriggerCount",
 		Version:      "2.6.5",
-		Doc:          "jsonkey stats task count per trigger",
+		Doc:          "Deprecated: JSON stats tasks are throttled by dataCoord.statsTaskPendingLimit.",
 		DefaultValue: "10",
 		FallbackKeys: []string{"dataCoord.jsonStatsTriggerCount"},
 		PanicIfEmpty: false,
-		Export:       true,
+		Export:       false,
 	}
 	p.JSONStatsTriggerCount.Init(base.mgr)
 
 	p.JSONStatsTriggerInterval = ParamItem{
 		Key:          "dataCoord.jsonShreddingTriggerInterval",
 		Version:      "2.6.5",
-		Doc:          "jsonkey task interval per trigger",
+		Doc:          "Deprecated: JSON stats tasks now run on dataCoord.taskCheckInterval.",
 		DefaultValue: "10",
 		FallbackKeys: []string{"dataCoord.jsonStatsTriggerInterval"},
 		PanicIfEmpty: false,
-		Export:       true,
+		Export:       false,
 	}
 	p.JSONStatsTriggerInterval.Init(base.mgr)
 

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -774,6 +774,10 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 500*time.Second, Params.TaskCheckInterval.GetAsDuration(time.Second))
 		params.Save("datacoord.statsTaskTriggerCount", "3")
 		assert.Equal(t, 3, Params.SortCompactionTriggerCount.GetAsInt())
+		// The stats admission limit is independent from the sort compaction trigger count.
+		assert.Equal(t, 100, Params.StatsTaskPendingLimit.GetAsInt())
+		params.Save("datacoord.statsTaskPendingLimit", "7")
+		assert.Equal(t, 7, Params.StatsTaskPendingLimit.GetAsInt())
 
 		assert.Equal(t, 100, Params.MaxSegmentsPerCopyTask.GetAsInt())
 		params.Save("dataCoord.import.maxSegmentsPerCopyTask", "200")

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -691,6 +691,10 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 500*time.Second, Params.TaskCheckInterval.GetAsDuration(time.Second))
 		params.Save("datacoord.statsTaskTriggerCount", "3")
 		assert.Equal(t, 3, Params.SortCompactionTriggerCount.GetAsInt())
+		// The stats admission limit is independent from the sort compaction trigger count.
+		assert.Equal(t, 100, Params.StatsTaskPendingLimit.GetAsInt())
+		params.Save("datacoord.statsTaskPendingLimit", "7")
+		assert.Equal(t, 7, Params.StatsTaskPendingLimit.GetAsInt())
 
 		assert.Equal(t, 100, Params.MaxSegmentsPerCopyTask.GetAsInt())
 		params.Save("dataCoord.import.maxSegmentsPerCopyTask", "200")

--- a/tests/go_client/testcases/external_table_json_shredding_e2e_test.go
+++ b/tests/go_client/testcases/external_table_json_shredding_e2e_test.go
@@ -44,10 +44,9 @@ func TestExternalTableJSONShreddingE2E(t *testing.T) {
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
 	restoreConfig := alterMilvusConfigForExternalJSONShredding(t, map[string]string{
-		"common.enabledJSONShredding":         "true",
-		"common.usingJSONShreddingForQuery":   "true",
-		"dataCoord.jsonShreddingMaxColumns":   "2",
-		"dataCoord.jsonShreddingTriggerCount": "10",
+		"common.enabledJSONShredding":       "true",
+		"common.usingJSONShreddingForQuery": "true",
+		"dataCoord.jsonShreddingMaxColumns": "2",
 	})
 	t.Cleanup(restoreConfig)
 


### PR DESCRIPTION
issue: #51815
pr: #51816

Backport of #51816 to the 3.0 branch.

> **Note:** the master PR #51816 was merged on 2026-08-20 (merge commit `07916765a1`).
> This branch is re-synced against that final state.

## What this PR does

- Skips new stats-task submission when the global scheduler holds more pending
  stats tasks than `dataCoord.statsTaskPendingLimit` (100 by default).
- The pending count is **scoped to `taskcommon.Stats`**: index, compaction and
  import share the same global scheduler queue, and an unrelated backlog must not
  starve text-index and JSON-shredding submission. Stats tasks waiting on a
  retry-backoff deadline **are counted** — they still occupy queue depth, and
  excluding them would let a worker-side failure storm silently disable the gate.
  Tasks already dispatched to workers remain excluded, as before.
- Uses queue depth as admission control, not as a submission-rate limit. The
  scheduler can drain and refill the queue as worker capacity becomes available,
  which is intentional for improving stats-task throughput.
- Removes the separate JSON key-index limit of 10 tasks per 10 minutes. JSON
  discovery continues on `dataCoord.taskCheckInterval` and shares the stats
  scheduler-backlog limit with text stats tasks.
- Alternates whether text indexing or JSON shredding gets first claim on the
  shared backlog budget each discovery round, preventing either sub-job from
  being permanently starved by fixed ordering.
- Filters segments whose stats task is already recorded in meta inside each
  trigger's selector, and skips collections with no eligible field before
  scanning segments.
- Checks admission before task-ID allocation, metadata persistence, and enqueue.
  `SubmitStatsTask` retains the check for direct callers and `AddStatsTask`
  retains the final duplicate guard.
- Exposes a type-scoped pending-task count through the global scheduler and
  priority queue, while the scheduler's own queue-depth log continues to use the
  allocation-free total count.
- Marks `dataCoord.jsonShreddingTriggerCount` and
  `dataCoord.jsonShreddingTriggerInterval` deprecated. The keys remain accepted,
  `jsonShreddingTriggerCount: 0` remains a compatibility kill switch, and
  DataCoord warns when deprecated non-default values are configured.

## Cherry-pick notes

All twelve commits of the master PR apply to 3.0 without conflict.
`internal/datacoord/*` and `internal/datacoord/task/*` are identical between the
master merge base and 3.0; only `configs/milvus.yaml` and
`pkg/util/paramtable/component_param.go` needed a three-way merge, and both
resolved to the same shape as master.

`dataCoord.statsTaskPendingLimit` carries `Version: "3.0.0"`, matching master's
final value.

After master merged, the final upstream commit `74abd95768` ("scope the stats
admission count to stats tasks and count backoff tasks") was cherry-picked onto
this branch with no conflict. `internal/datacoord/stats_inspector.go`,
`internal/datacoord/stats_inspector_test.go` and
`internal/datacoord/task/mock_global_scheduler.go` are now byte-identical to the
merged master state; the only remaining delta in
`internal/datacoord/task/global_scheduler{,_test}.go` is the
`pickNodeWithMinimumVersion` / `CopySegment` version-pinning path, which does not
exist on 3.0.

## Verification on this branch

- Passed: `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/datacoord/task/...`
- Passed: `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/datacoord/` (whole package)
- The admission-semantics change is covered by
  `TestGlobalScheduler_GetPendingTaskCountIsScopedByTaskType` (a mixed
  Stats/Compaction/Index queue reports 1 for Stats, not 4) and
  `TestGlobalScheduler_GetPendingTaskCountIncludesBackoff` (a task in retry
  backoff still counts), plus `Test_statsInspectorSuite`.
- Passed: `go test -count=1 ./cmd/tools/config -run TestYamlFile`
- Passed from `pkg/`: `go test -count=1 ./util/paramtable -run 'TestComponentParam$'`
- `go vet ./testcases/` passes in the `tests/go_client` module.
