### PR TITLE
fix: convert ArrayOfVector element placeholders

### DIFF
--- a/internal/proxy/vector_type_convert.go
+++ b/internal/proxy/vector_type_convert.go
@@ -79,6 +79,9 @@ func ConvertPlaceholderGroup(phgBytes []byte, fieldSchema *schemapb.FieldSchema)
 	placeholder := phg.Placeholders[0]
 	phType := placeholder.Type
 	fieldType := fieldSchema.GetDataType()
+	if fieldType == schemapb.DataType_ArrayOfVector {
+		fieldType = fieldSchema.GetElementType()
+	}
 
 	// Check if types already match
 	if isVectorTypeMatch(placeholder.Type, fieldType) {

--- a/internal/proxy/vector_type_convert_test.go
+++ b/internal/proxy/vector_type_convert_test.go
@@ -226,6 +226,42 @@ func TestConvertPlaceholderGroupToBFloat16(t *testing.T) {
 	assert.Equal(t, 4*2, len(resultPhg.Placeholders[0].Values[0]))
 }
 
+func TestConvertPlaceholderGroupArrayOfVectorElementType(t *testing.T) {
+	for _, tt := range []struct {
+		name            string
+		elementType     schemapb.DataType
+		placeholderType commonpb.PlaceholderType
+	}{
+		{
+			name:            "float16 element",
+			elementType:     schemapb.DataType_Float16Vector,
+			placeholderType: commonpb.PlaceholderType_Float16Vector,
+		},
+		{
+			name:            "bfloat16 element",
+			elementType:     schemapb.DataType_BFloat16Vector,
+			placeholderType: commonpb.PlaceholderType_BFloat16Vector,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			vectors := [][]float32{{0.1, 0.2, 0.3, 0.4}}
+			phgBytes := createFloat32PlaceholderGroup(vectors)
+			fieldSchema := &schemapb.FieldSchema{
+				DataType:    schemapb.DataType_ArrayOfVector,
+				ElementType: tt.elementType,
+			}
+
+			convertedBytes, _, err := ConvertPlaceholderGroup(phgBytes, fieldSchema)
+			assert.NoError(t, err)
+
+			var resultPhg commonpb.PlaceholderGroup
+			err = proto.Unmarshal(convertedBytes, &resultPhg)
+			assert.NoError(t, err)
+			assertPlaceholderVectorsMatchFloat32(t, tt.placeholderType, tt.elementType, resultPhg.Placeholders, vectors)
+		})
+	}
+}
+
 func TestConvertPlaceholderGroupTypeMismatch(t *testing.T) {
 	// Test: Float16Vector searching BFloat16Vector field -> should error
 	// (Only fp32 -> fp16/bf16 conversion is supported)


### PR DESCRIPTION
issue: #52014

## What changed

- Use `ArrayOfVector.ElementType` when proxy decides whether a search placeholder needs fp32 -> fp16/bf16 conversion.
- Add coverage for `ArrayOfVector` fields whose element type is `Float16Vector` or `BFloat16Vector`.

## Verification

- Red proof before fix:
  `GOWORK=off go test -tags proof,dynamic,test -gcflags="all=-N -l" -count=1 ./internal/proxy/vector_type_convert.go ./internal/proxy/vector_type_convert_proof_test.go -run TestProofConvertPlaceholderGroupArrayOfVectorElementType`
  - Failed as expected: placeholder type stayed `FloatVector` instead of `Float16Vector`/`BFloat16Vector`.
- Green proof after fix:
  `GOWORK=off go test -tags proof,dynamic,test -gcflags="all=-N -l" -count=1 ./internal/proxy/vector_type_convert.go ./internal/proxy/vector_type_convert_proof_test.go -run TestProofConvertPlaceholderGroupArrayOfVectorElementType`
- Focused package tests:
  `LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:/home/sheep/workspace/milvus/cmake_build/lib LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:/home/sheep/workspace/milvus/cmake_build/lib PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig:/home/sheep/workspace/milvus/cmake_build/src:/home/sheep/workspace/milvus/cmake_build/thirdparty/milvus-storage GOWORK=off go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/proxy -run 'TestConvertPlaceholderGroup|TestNormalizeFp32ToFp16Bf16VectorFieldData'`
- Static check:
  `LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:/home/sheep/workspace/milvus/cmake_build/lib LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:/home/sheep/workspace/milvus/cmake_build/lib PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig:/home/sheep/workspace/milvus/cmake_build/src:/home/sheep/workspace/milvus/cmake_build/thirdparty/milvus-storage GOWORK=off make static-check`
