### PR TITLE
test: fix flaky concurrent cancellation test

### DIFF
--- a/internal/core/src/segcore/LoadCancellationTest.cpp
+++ b/internal/core/src/segcore/LoadCancellationTest.cpp
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <future>
 #include <memory>
 #include <string>
 #include <thread>
@@ -184,24 +185,32 @@ TEST(LoadCancellationUtility, ConcurrentCancellation) {
     OpContext op_ctx(source.getToken());
     std::atomic<int> iterations{0};
     std::atomic<bool> caught{false};
+    std::promise<void> worker_ready_promise;
+    auto worker_ready = worker_ready_promise.get_future();
+    std::promise<void> cancellation_requested_promise;
+    auto cancellation_requested = cancellation_requested_promise.get_future();
     std::thread worker([&]() {
         try {
             for (int i = 0; i < 1000; ++i) {
                 CheckCancellation(&op_ctx, 456, fmt::format("Iter{}", i));
-                std::this_thread::sleep_for(std::chrono::milliseconds(1));
                 iterations++;
+                if (i == 0) {
+                    worker_ready_promise.set_value();
+                    cancellation_requested.wait();
+                }
             }
         } catch (const SegcoreError& e) {
             caught = true;
             EXPECT_EQ(e.get_error_code(), ErrorCode::FollyCancel);
         }
     });
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    auto ready_status = worker_ready.wait_for(std::chrono::seconds(5));
     source.requestCancellation();
+    cancellation_requested_promise.set_value();
     worker.join();
+    ASSERT_EQ(ready_status, std::future_status::ready);
     EXPECT_TRUE(caught.load());
-    EXPECT_GT(iterations.load(), 0);
-    EXPECT_LT(iterations.load(), 1000);
+    EXPECT_EQ(iterations.load(), 1);
 }
 
 // Test that token is shared across contexts


### PR DESCRIPTION
### What changed

Replace fixed sleeps in `LoadCancellationUtility.ConcurrentCancellation` with an explicit two-phase promise/future handshake:

- wait until the worker completes its first successful cancellation checkpoint
- request cancellation from the main thread
- release the worker and verify the next checkpoint throws `FollyCancel`
- assert exactly one successful iteration

This is a test-only change and does not modify production cancellation behavior.

### Why

The previous test slept for 50 ms before requesting cancellation. Under busy CI scheduling, the worker could remain unscheduled until after cancellation was requested, so its first checkpoint threw and `iterations` stayed at zero.

Jenkins example: [build-ut-ciloop #20740](https://jenkins-milvus-ci.milvus.io/job/MILVUS-CI-V2-PR-PIPELINES/job/milvus-build-ut-ciloop-pipeline/20740/)

### Reproduction

On the unmodified baseline, with the test pinned to CPU 7 at nice 10 alongside 16 bounded CPU hogs:

- 3/3 real test runs reproduced `LoadCancellationTest.cpp:203`
- all failures were `Expected iterations.load() > 0, actual 0`
- no timeout, OOM, or skipped GTest shard was counted

### Validation

- same pressure and same `total_runs=3`: 3/3 passed
- `LoadCancellation*.*`: 18/18 passed
- target test repeated without pressure: 100/100 passed
- incremental `all_tests` build and install passed
- `clang-format-15` and `git diff --check` passed