### PR TITLE
fix: keep latest delete snapshot timestamp monotonic

### DIFF
--- a/internal/core/src/segcore/DeletedRecord.h
+++ b/internal/core/src/segcore/DeletedRecord.h
@@ -17,6 +17,7 @@
 #include <mutex>
 #include <shared_mutex>
 #include <tuple>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 #include <folly/ConcurrentSkipList.h>
@@ -79,7 +80,8 @@ class DeletedRecord {
         : insert_record_(insert_record),
           search_pk_func_(std::move(search_pk_func)),
           segment_id_(segment_id),
-          deleted_lists_(SortedDeleteList::createInstance()) {
+          deleted_lists_(SortedDeleteList::createInstance()),
+          rollback_delete_list_(SortedDeleteList::createInstance()) {
     }
 
     ~DeletedRecord() {
@@ -141,6 +143,7 @@ class DeletedRecord {
         Timestamp max_timestamp = 0;
 
         SortedDeleteList::Accessor accessor(deleted_lists_);
+        SortedDeleteList::Accessor rollback_accessor(rollback_delete_list_);
         for (size_t i = 0; i < pks.size(); ++i) {
             auto deleted_ts = timestamps[i];
             if (deleted_ts > max_timestamp) {
@@ -152,10 +155,6 @@ class DeletedRecord {
             timestamps,
             [&](const SegOffset offset, const Timestamp delete_ts) {
                 auto row_id = offset.get();
-                // if already deleted, no need to add new record
-                if (deleted_mask_.size() > row_id && deleted_mask_[row_id]) {
-                    return;
-                }
                 // Skip delete when delete_ts <= insert_ts.
                 // Normal segment callers search PKs with include_same_ts=false,
                 // so only rows with insert_ts < delete_ts reach this callback.
@@ -171,6 +170,31 @@ class DeletedRecord {
                 if (insert_ts != 0 && delete_ts <= insert_ts) {
                     return;
                 }
+
+                // The main delete list keeps the first-arriving delete for a
+                // physical row. If an out-of-order delete for the same row
+                // arrives later, preserve the minimum duplicate timestamp in
+                // a sparse overlay so historical queries can move the row's
+                // visibility boundary backward without expanding per-row
+                // storage for the whole segment.
+                if (deleted_mask_.size() > row_id && deleted_mask_[row_id]) {
+                    auto [it, inserted] =
+                        rollback_min_timestamps_.try_emplace(row_id, delete_ts);
+                    if (inserted) {
+                        rollback_accessor.insert(
+                            std::make_pair(delete_ts, row_id));
+                        mem_add += DELETE_PAIR_SIZE;
+                    } else if (delete_ts < it->second) {
+                        auto previous_ts = it->second;
+                        rollback_accessor.insert(
+                            std::make_pair(delete_ts, row_id));
+                        rollback_accessor.erase(
+                            std::make_pair(previous_ts, row_id));
+                        it->second = delete_ts;
+                    }
+                    return;
+                }
+
                 accessor.insert(std::make_pair(delete_ts, row_id));
                 if constexpr (is_sealed) {
                     Assert(deleted_mask_.size() > 0);
@@ -277,6 +301,20 @@ class DeletedRecord {
                 bitset.set(it->second);
             }
             it++;
+        }
+
+        // Historical snapshots are built from the first-arriving delete list.
+        // Always overlay late duplicate deletes on the slow path so a smaller
+        // timestamp for an already-deleted row is still visible without
+        // invalidating or rebuilding all dumped snapshots.
+        SortedDeleteList::Accessor rollback_accessor(rollback_delete_list_);
+        auto rollback_it = rollback_accessor.begin();
+        while (rollback_it != rollback_accessor.end() &&
+               rollback_it->first <= query_timestamp) {
+            if (rollback_it->second < insert_barrier) {
+                bitset.set(rollback_it->second);
+            }
+            rollback_it++;
         }
     }
 
@@ -430,6 +468,11 @@ class DeletedRecord {
         search_pk_func_;
     int64_t segment_id_{0};
     std::shared_ptr<SortedDeleteList> deleted_lists_;
+    // Sparse timestamp correction for physical rows whose duplicate deletes
+    // arrive out of order. The main list keeps the first-arriving timestamp;
+    // this overlay keeps the minimum timestamp among later arrivals.
+    std::shared_ptr<SortedDeleteList> rollback_delete_list_;
+    std::unordered_map<Offset, Timestamp> rollback_min_timestamps_;
     // max timestamp of deleted records which replayed in load process
     Timestamp max_load_timestamp_{0};
     // max timestamp of all delete batches processed by this record;

--- a/internal/core/src/segcore/DeletedRecord.h
+++ b/internal/core/src/segcore/DeletedRecord.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <limits>
 #include <memory>
 #include <mutex>
@@ -103,6 +104,7 @@ class DeletedRecord {
         }
 
         auto max_deleted_ts = InternalPush(pks, timestamps);
+        max_delete_timestamp_ = std::max(max_delete_timestamp_, max_deleted_ts);
 
         if (max_deleted_ts > max_load_timestamp_) {
             max_load_timestamp_ = max_deleted_ts;
@@ -120,9 +122,10 @@ class DeletedRecord {
         }
 
         auto max_ts = InternalPush(pks, timestamps);
+        max_delete_timestamp_ = std::max(max_delete_timestamp_, max_ts);
 
         if (ENABLE_LATEST_DELETE_SNAPSHOT_OPTIMIZATION.load()) {
-            UpdateLatestSnapshot(max_ts);
+            UpdateLatestSnapshot(max_delete_timestamp_);
         }
 
         bool can_dump = timestamps[0] >= max_load_timestamp_;
@@ -429,6 +432,9 @@ class DeletedRecord {
     std::shared_ptr<SortedDeleteList> deleted_lists_;
     // max timestamp of deleted records which replayed in load process
     Timestamp max_load_timestamp_{0};
+    // max timestamp of all delete batches processed by this record;
+    // a conservative upper bound for every delete in deleted_mask_
+    Timestamp max_delete_timestamp_{0};
     int32_t sealed_row_count_;
     // used to remove duplicated deleted records for fast access
     BitsetType deleted_mask_;

--- a/internal/core/src/segcore/DeletedRecord.h
+++ b/internal/core/src/segcore/DeletedRecord.h
@@ -173,10 +173,10 @@ class DeletedRecord {
 
                 // The main delete list keeps the first-arriving delete for a
                 // physical row. If an out-of-order delete for the same row
-                // arrives later, preserve the minimum duplicate timestamp in
-                // a sparse overlay so historical queries can move the row's
-                // visibility boundary backward without expanding per-row
-                // storage for the whole segment.
+                // arrives later, append each decreasing timestamp to a sparse
+                // overlay so historical queries can move the row's visibility
+                // boundary backward without expanding per-row storage for the
+                // whole segment.
                 if (deleted_mask_.size() > row_id && deleted_mask_[row_id]) {
                     auto [it, inserted] =
                         rollback_min_timestamps_.try_emplace(row_id, delete_ts);
@@ -185,12 +185,10 @@ class DeletedRecord {
                             std::make_pair(delete_ts, row_id));
                         mem_add += DELETE_PAIR_SIZE;
                     } else if (delete_ts < it->second) {
-                        auto previous_ts = it->second;
                         rollback_accessor.insert(
                             std::make_pair(delete_ts, row_id));
-                        rollback_accessor.erase(
-                            std::make_pair(previous_ts, row_id));
                         it->second = delete_ts;
+                        mem_add += DELETE_PAIR_SIZE;
                     }
                     return;
                 }
@@ -468,9 +466,12 @@ class DeletedRecord {
         search_pk_func_;
     int64_t segment_id_{0};
     std::shared_ptr<SortedDeleteList> deleted_lists_;
-    // Sparse timestamp correction for physical rows whose duplicate deletes
-    // arrive out of order. The main list keeps the first-arriving timestamp;
-    // this overlay keeps the minimum timestamp among later arrivals.
+    // Append-only timestamp corrections for physical rows whose duplicate
+    // deletes arrive out of order. The main list keeps the first-arriving
+    // timestamp, while rollback_min_timestamps_ tracks the current minimum so
+    // only corrections that move the visibility boundary backward are added.
+    // Older corrections stay in the list so a concurrent reader can observe
+    // either boundary without racing with node removal.
     std::shared_ptr<SortedDeleteList> rollback_delete_list_;
     std::unordered_map<Offset, Timestamp> rollback_min_timestamps_;
     // max timestamp of deleted records which replayed in load process

--- a/internal/core/src/segcore/DeletedRecordTest.cpp
+++ b/internal/core/src/segcore/DeletedRecordTest.cpp
@@ -46,6 +46,35 @@ using namespace milvus;
 using namespace milvus::segcore;
 using namespace milvus::exec;
 
+namespace {
+
+class LatestDeleteSnapshotOptimizationGuard {
+ public:
+    explicit LatestDeleteSnapshotOptimizationGuard(bool enabled)
+        : original_(
+              ENABLE_LATEST_DELETE_SNAPSHOT_OPTIMIZATION.exchange(enabled)) {
+    }
+
+    ~LatestDeleteSnapshotOptimizationGuard() {
+        ENABLE_LATEST_DELETE_SNAPSHOT_OPTIMIZATION.store(original_);
+    }
+
+ private:
+    bool original_;
+};
+
+void
+SearchDirectDeleteOffsets(
+    const std::vector<PkType>& pks,
+    const Timestamp* timestamps,
+    std::function<void(SegOffset offset, Timestamp ts)> cb) {
+    for (size_t i = 0; i < pks.size(); ++i) {
+        cb(SegOffset(std::get<int64_t>(pks[i])), timestamps[i]);
+    }
+}
+
+}  // namespace
+
 TEST(DeleteMVCC, common_case) {
     milvus::exec::expression::FunctionFactory& factory =
         milvus::exec::expression::FunctionFactory::Instance();
@@ -174,6 +203,91 @@ TEST(DeleteMVCC, common_case) {
             ASSERT_EQ(bitsets_view[i], expected[i]);
         }
     }
+}
+
+TEST(DeleteMVCC, LatestSnapshotCoversDeletesLoadedBeforeOlderStreamPush) {
+    LatestDeleteSnapshotOptimizationGuard guard(true);
+
+    constexpr int64_t row_count = 2;
+    DeletedRecord<true> delete_record(nullptr, SearchDirectDeleteOffsets, 0);
+    delete_record.set_sealed_row_count(row_count);
+
+    std::vector<PkType> newer_pk = {1};
+    std::vector<Timestamp> newer_ts = {200};
+    delete_record.LoadPush(newer_pk, newer_ts.data());
+
+    std::vector<PkType> older_pk = {0};
+    std::vector<Timestamp> older_ts = {100};
+    delete_record.StreamPush(older_pk, older_ts.data());
+
+    BitsetType between(row_count);
+    BitsetTypeView between_view(between);
+    delete_record.Query(between_view, row_count, 150);
+    EXPECT_TRUE(between_view[0]);
+    EXPECT_FALSE(between_view[1]);
+
+    BitsetType after(row_count);
+    BitsetTypeView after_view(after);
+    delete_record.Query(after_view, row_count, 200);
+    EXPECT_TRUE(after_view[0]);
+    EXPECT_TRUE(after_view[1]);
+}
+
+TEST(DeleteMVCC, LatestSnapshotTimestampDoesNotRegressAcrossStreamPushes) {
+    LatestDeleteSnapshotOptimizationGuard guard(true);
+
+    constexpr int64_t row_count = 2;
+    DeletedRecord<true> delete_record(nullptr, SearchDirectDeleteOffsets, 0);
+    delete_record.set_sealed_row_count(row_count);
+
+    std::vector<PkType> newer_pk = {1};
+    std::vector<Timestamp> newer_ts = {200};
+    delete_record.StreamPush(newer_pk, newer_ts.data());
+
+    std::vector<PkType> older_pk = {0};
+    std::vector<Timestamp> older_ts = {100};
+    delete_record.StreamPush(older_pk, older_ts.data());
+
+    BitsetType between(row_count);
+    BitsetTypeView between_view(between);
+    delete_record.Query(between_view, row_count, 150);
+    EXPECT_TRUE(between_view[0]);
+    EXPECT_FALSE(between_view[1]);
+
+    BitsetType after(row_count);
+    BitsetTypeView after_view(after);
+    delete_record.Query(after_view, row_count, 200);
+    EXPECT_TRUE(after_view[0]);
+    EXPECT_TRUE(after_view[1]);
+}
+
+TEST(DeleteMVCC, LatestSnapshotCoversDeletesPushedWhileOptimizationDisabled) {
+    LatestDeleteSnapshotOptimizationGuard guard(false);
+
+    constexpr int64_t row_count = 2;
+    DeletedRecord<true> delete_record(nullptr, SearchDirectDeleteOffsets, 0);
+    delete_record.set_sealed_row_count(row_count);
+
+    std::vector<PkType> newer_pk = {1};
+    std::vector<Timestamp> newer_ts = {200};
+    delete_record.StreamPush(newer_pk, newer_ts.data());
+
+    ENABLE_LATEST_DELETE_SNAPSHOT_OPTIMIZATION.store(true);
+    std::vector<PkType> older_pk = {0};
+    std::vector<Timestamp> older_ts = {100};
+    delete_record.StreamPush(older_pk, older_ts.data());
+
+    BitsetType between(row_count);
+    BitsetTypeView between_view(between);
+    delete_record.Query(between_view, row_count, 150);
+    EXPECT_TRUE(between_view[0]);
+    EXPECT_FALSE(between_view[1]);
+
+    BitsetType after(row_count);
+    BitsetTypeView after_view(after);
+    delete_record.Query(after_view, row_count, 200);
+    EXPECT_TRUE(after_view[0]);
+    EXPECT_TRUE(after_view[1]);
 }
 
 TEST(DeleteMVCC, normal_caller_filters_delete_before_or_at_insert_timestamp) {

--- a/internal/core/src/segcore/DeletedRecordTest.cpp
+++ b/internal/core/src/segcore/DeletedRecordTest.cpp
@@ -233,6 +233,37 @@ TEST(DeleteMVCC, LatestSnapshotCoversDeletesLoadedBeforeOlderStreamPush) {
     EXPECT_TRUE(after_view[1]);
 }
 
+TEST(DeleteMVCC, LatestSnapshotPreservesEarlierDeleteForSameRow) {
+    LatestDeleteSnapshotOptimizationGuard guard(true);
+
+    constexpr int64_t row_count = 1;
+    DeletedRecord<true> delete_record(nullptr, SearchDirectDeleteOffsets, 0);
+    delete_record.set_sealed_row_count(row_count);
+
+    std::vector<PkType> pk = {0};
+    std::vector<Timestamp> newer_ts = {200};
+    delete_record.LoadPush(pk, newer_ts.data());
+
+    std::vector<Timestamp> older_ts = {100};
+    delete_record.StreamPush(pk, older_ts.data());
+    EXPECT_EQ(1, delete_record.size());
+
+    BitsetType before(row_count);
+    BitsetTypeView before_view(before);
+    delete_record.Query(before_view, row_count, 50);
+    EXPECT_FALSE(before_view[0]);
+
+    BitsetType between(row_count);
+    BitsetTypeView between_view(between);
+    delete_record.Query(between_view, row_count, 150);
+    EXPECT_TRUE(between_view[0]);
+
+    BitsetType after(row_count);
+    BitsetTypeView after_view(after);
+    delete_record.Query(after_view, row_count, 200);
+    EXPECT_TRUE(after_view[0]);
+}
+
 TEST(DeleteMVCC, LatestSnapshotTimestampDoesNotRegressAcrossStreamPushes) {
     LatestDeleteSnapshotOptimizationGuard guard(true);
 

--- a/internal/core/src/segcore/DeletedRecordTest.cpp
+++ b/internal/core/src/segcore/DeletedRecordTest.cpp
@@ -264,6 +264,42 @@ TEST(DeleteMVCC, LatestSnapshotPreservesEarlierDeleteForSameRow) {
     EXPECT_TRUE(after_view[0]);
 }
 
+TEST(DeleteMVCC, RollbackOverlayKeepsDecreasingDeleteHistory) {
+    LatestDeleteSnapshotOptimizationGuard guard(true);
+
+    constexpr int64_t row_count = 1;
+    DeletedRecord<true> delete_record(nullptr, SearchDirectDeleteOffsets, 0);
+    delete_record.set_sealed_row_count(row_count);
+
+    std::vector<PkType> pk = {0};
+    std::vector<Timestamp> newest_ts = {500};
+    delete_record.LoadPush(pk, newest_ts.data());
+
+    std::vector<Timestamp> middle_ts = {300};
+    delete_record.StreamPush(pk, middle_ts.data());
+
+    std::vector<Timestamp> oldest_ts = {100};
+    delete_record.StreamPush(pk, oldest_ts.data());
+
+    EXPECT_EQ(1, delete_record.size());
+    EXPECT_EQ(3 * DELETE_PAIR_SIZE, delete_record.mem_size());
+
+    BitsetType before(row_count);
+    BitsetTypeView before_view(before);
+    delete_record.Query(before_view, row_count, 50);
+    EXPECT_FALSE(before_view[0]);
+
+    BitsetType between(row_count);
+    BitsetTypeView between_view(between);
+    delete_record.Query(between_view, row_count, 150);
+    EXPECT_TRUE(between_view[0]);
+
+    BitsetType after(row_count);
+    BitsetTypeView after_view(after);
+    delete_record.Query(after_view, row_count, 500);
+    EXPECT_TRUE(after_view[0]);
+}
+
 TEST(DeleteMVCC, LatestSnapshotTimestampDoesNotRegressAcrossStreamPushes) {
     LatestDeleteSnapshotOptimizationGuard guard(true);
 


### PR DESCRIPTION
issue: #52005

- segcore delete MVCC: retain a monotonic maximum timestamp across load and stream delete batches before publishing the cumulative delete bitmap
- out-of-order delete history: append decreasing timestamp corrections per affected physical row in a rollback overlay for historical queries
- concurrent historical queries: keep rollback corrections append-only so readers cannot miss both the old and new visibility boundary during node replacement