### PR TITLE
auto: bump Milvus version to v3.0.0

### DIFF
--- a/deployments/binary/README.md
+++ b/deployments/binary/README.md
@@ -30,7 +30,7 @@ $ ./minio server /minio
 To start Milvus standalone, you need a Milvus binary file. Currently you can get the latest version of Milvus binary file through the Milvus docker image. (We will upload Milvus binary files in the future)
 
 ```shell
-$ docker run -d --name milvus milvusdb/milvus:v3.0-beta /bin/bash
+$ docker run -d --name milvus milvusdb/milvus:v3.0.0 /bin/bash
 $ docker cp milvus:/milvus .
 ```
 

--- a/deployments/docker/cluster-distributed-deployment/inventory.ini
+++ b/deployments/docker/cluster-distributed-deployment/inventory.ini
@@ -33,7 +33,7 @@ dependencies_network= host
 nodes_network= host
 
 ; Setup varibale to controll what image version of Milvus to use.
-image= milvusdb/milvus:v3.0-beta
+image= milvusdb/milvus:v3.0.0
 
 ; Setup static IP addresses of the docker hosts as variable for container environment variable config.
 ; Before running the playbook, below 4 IP addresses need to be replaced with the IP of your host VM

--- a/deployments/docker/gpu/standalone/docker-compose.yml
+++ b/deployments/docker/gpu/standalone/docker-compose.yml
@@ -38,7 +38,7 @@ services:
 
   standalone:
     container_name: milvus-standalone
-    image: milvusdb/milvus:v3.0-beta-gpu
+    image: milvusdb/milvus:v3.0.0-gpu
     command: ["milvus", "run", "standalone"]
     security_opt:
       - seccomp:unconfined

--- a/deployments/docker/standalone/docker-compose.yml
+++ b/deployments/docker/standalone/docker-compose.yml
@@ -38,7 +38,7 @@ services:
 
   standalone:
     container_name: milvus-standalone
-    image: milvusdb/milvus:v3.0-beta
+    image: milvusdb/milvus:v3.0.0
     command: ["milvus", "run", "standalone"]
     security_opt:
     - seccomp:unconfined

--- a/scripts/standalone_embed.bat
+++ b/scripts/standalone_embed.bat
@@ -80,7 +80,7 @@ docker run -d ^
     --health-start-period=90s ^
     --health-timeout=20s ^
     --health-retries=3 ^
-    milvusdb/milvus:v3.0-beta ^
+    milvusdb/milvus:v3.0.0 ^
     milvus run standalone >nul
 if %errorlevel% neq 0 (
     echo Failed to start Milvus container.

--- a/scripts/standalone_embed.sh
+++ b/scripts/standalone_embed.sh
@@ -59,7 +59,7 @@ EOF
         --health-start-period=90s \
         --health-timeout=20s \
         --health-retries=3 \
-        milvusdb/milvus:v3.0-beta \
+        milvusdb/milvus:v3.0.0 \
         milvus run standalone  1> /dev/null
 }
 


### PR DESCRIPTION
Update the default Milvus release image references on master from v3.0-beta to v3.0.0.

This is the master counterpart of #52016.

Changes:
- bump CPU deployment and binary examples to v3.0.0
- bump GPU standalone deployment to v3.0.0-gpu
- bump standalone embed shell and batch scripts to v3.0.0

Validation:
- exactly six release files changed
- no targeted v3.0-beta image references remain
- bash -n scripts/standalone_embed.sh
- docker compose config --quiet for CPU and GPU standalone files
- git diff --check