### PR TITLE
enhance: [3.0] support mmap for sealed offset mapping

### DIFF
--- a/internal/core/src/common/OffsetMapping.cpp
+++ b/internal/core/src/common/OffsetMapping.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include "common/EasyAssert.h"
+#include "storage/MmapManager.h"
 
 namespace milvus {
 namespace {
@@ -33,6 +34,48 @@ ShouldSkipBitsetTransform(const BitsetView& bitset,
 
 }  // namespace
 
+void
+OffsetMappingArray::Resize(
+    size_t size,
+    int32_t value,
+    bool enable_mmap,
+    const storage::MmapChunkManagerPtr& mmap_chunk_manager,
+    const storage::MmapChunkDescriptorPtr& mmap_descriptor) {
+    Clear();
+    if (size == 0) {
+        return;
+    }
+
+    if (enable_mmap) {
+        AssertInfo(mmap_chunk_manager != nullptr,
+                   "offset mapping mmap chunk manager is null");
+        AssertInfo(mmap_descriptor != nullptr,
+                   "offset mapping mmap descriptor is null");
+        mmap_chunk_manager_ = mmap_chunk_manager;
+        mmap_descriptor_ = mmap_descriptor;
+        mmap_data_ = static_cast<int32_t*>(mmap_chunk_manager_->Allocate(
+            mmap_descriptor_, sizeof(int32_t) * size));
+        AssertInfo(mmap_data_ != nullptr,
+                   "failed to allocate offset mapping mmap buffer, size: {}",
+                   sizeof(int32_t) * size);
+        size_ = size;
+        std::fill_n(mmap_data_, size_, value);
+        return;
+    }
+
+    vec_.assign(size, value);
+    size_ = size;
+}
+
+void
+OffsetMappingArray::Clear() {
+    size_ = 0;
+    vec_.clear();
+    mmap_data_ = nullptr;
+    mmap_descriptor_ = nullptr;
+    mmap_chunk_manager_ = nullptr;
+}
+
 int64_t
 OffsetMapping::GetPhysicalOffset(int64_t logical_offset) const {
     return logical_offset;
@@ -55,6 +98,11 @@ OffsetMapping::GetValidCount() const {
 
 bool
 OffsetMapping::IsEnabled() const {
+    return false;
+}
+
+bool
+OffsetMapping::IsMmap() const {
     return false;
 }
 
@@ -99,20 +147,28 @@ OffsetMapping::FilterValidLogicalOffsets(
 }
 
 void
-SealedOffsetMapping::Build(const bool* valid_data, int64_t total_count) {
+SealedOffsetMapping::Build(const bool* valid_data,
+                           int64_t total_count,
+                           const OffsetMappingBuildOptions& options) {
     constexpr int64_t start_logical = 0;
     constexpr int64_t start_physical = 0;
+
+    valid_count_ = 0;
+    total_count_ = 0;
+    enabled_ = false;
+    use_i2o_map_ = false;
+    use_o2i_map_ = false;
+    l2p_vec_.Clear();
+    p2l_vec_.Clear();
+    l2p_map_.clear();
+    p2l_map_.clear();
+
     if (total_count == 0 || valid_data == nullptr) {
         return;
     }
 
     enabled_ = true;
     total_count_ = start_logical + total_count;
-    valid_count_ = 0;
-    l2p_vec_.clear();
-    p2l_vec_.clear();
-    l2p_map_.clear();
-    p2l_map_.clear();
 
     int64_t valid_count = 0;
     for (int64_t i = 0; i < total_count; ++i) {
@@ -121,33 +177,70 @@ SealedOffsetMapping::Build(const bool* valid_data, int64_t total_count) {
         }
     }
 
-    use_map_ = valid_count * 10 < total_count;
+    const bool use_sparse_mapping = valid_count * 10 < total_count;
+    use_i2o_map_ = !options.enable_mmap_i2o_map && use_sparse_mapping;
+    use_o2i_map_ = !options.enable_mmap_o2i_map && use_sparse_mapping;
 
-    if (use_map_) {
-        int64_t physical_idx = start_physical;
-        for (int64_t i = 0; i < total_count; ++i) {
-            if (valid_data[i]) {
-                l2p_map_[start_logical + i] = physical_idx;
-                p2l_map_[physical_idx] = start_logical + i;
-                ++physical_idx;
-            }
+    const int64_t required_size = start_logical + total_count;
+    const int64_t required_p2l_size = start_physical + valid_count;
+
+    auto build_options = options;
+    const bool need_o2i_mmap =
+        !use_o2i_map_ && build_options.enable_mmap_o2i_map && required_size > 0;
+    const bool need_i2o_mmap = !use_i2o_map_ &&
+                               build_options.enable_mmap_i2o_map &&
+                               required_p2l_size > 0;
+    if (need_i2o_mmap || need_o2i_mmap) {
+        if (build_options.mmap_chunk_manager == nullptr) {
+            build_options.mmap_chunk_manager =
+                storage::MmapManager::GetInstance().GetMmapChunkManager();
         }
-    } else {
-        const int64_t required_size = start_logical + total_count;
-        l2p_vec_.resize(required_size, -1);
+    }
+    if (need_o2i_mmap && build_options.o2i_mmap_descriptor == nullptr) {
+        build_options.o2i_mmap_descriptor =
+            build_options.mmap_chunk_manager->Register();
+    }
+    if (need_i2o_mmap && build_options.i2o_mmap_descriptor == nullptr) {
+        build_options.i2o_mmap_descriptor =
+            build_options.mmap_chunk_manager->Register();
+    }
+    if (need_i2o_mmap && need_o2i_mmap) {
+        AssertInfo(build_options.i2o_mmap_descriptor !=
+                       build_options.o2i_mmap_descriptor,
+                   "offset mapping i2o and o2i mmap descriptors must be "
+                   "different");
+    }
 
-        const int64_t required_p2l_size = start_physical + valid_count;
-        p2l_vec_.resize(required_p2l_size, -1);
+    if (!use_o2i_map_) {
+        l2p_vec_.Resize(required_size,
+                        -1,
+                        build_options.enable_mmap_o2i_map,
+                        build_options.mmap_chunk_manager,
+                        build_options.o2i_mmap_descriptor);
+    }
 
-        int64_t physical_idx = start_physical;
-        for (int64_t i = 0; i < total_count; ++i) {
-            if (valid_data[i]) {
-                l2p_vec_[start_logical + i] = physical_idx;
-                p2l_vec_[physical_idx] = start_logical + i;
-                ++physical_idx;
+    if (!use_i2o_map_) {
+        p2l_vec_.Resize(required_p2l_size,
+                        -1,
+                        build_options.enable_mmap_i2o_map,
+                        build_options.mmap_chunk_manager,
+                        build_options.i2o_mmap_descriptor);
+    }
+
+    int64_t physical_idx = start_physical;
+    for (int64_t i = 0; i < total_count; ++i) {
+        if (valid_data[i]) {
+            if (use_o2i_map_) {
+                l2p_map_[start_logical + i] = physical_idx;
             } else {
-                l2p_vec_[start_logical + i] = -1;
+                l2p_vec_[start_logical + i] = physical_idx;
             }
+            if (use_i2o_map_) {
+                p2l_map_[physical_idx] = start_logical + i;
+            } else {
+                p2l_vec_[physical_idx] = start_logical + i;
+            }
+            ++physical_idx;
         }
     }
 
@@ -167,7 +260,7 @@ SealedOffsetMapping::GetPhysicalOffsetInternal(int64_t logical_offset) const {
     if (logical_offset < 0 || logical_offset >= total_count_) {
         return -1;
     }
-    if (use_map_) {
+    if (use_o2i_map_) {
         auto it = l2p_map_.find(static_cast<int32_t>(logical_offset));
         return it == l2p_map_.end() ? -1 : it->second;
     }
@@ -189,7 +282,7 @@ SealedOffsetMapping::GetLogicalOffsetInternal(int64_t physical_offset) const {
     if (physical_offset < 0 || physical_offset >= valid_count_) {
         return -1;
     }
-    if (use_map_) {
+    if (use_i2o_map_) {
         auto it = p2l_map_.find(static_cast<int32_t>(physical_offset));
         return it == p2l_map_.end() ? -1 : it->second;
     }
@@ -206,6 +299,11 @@ SealedOffsetMapping::GetValidCount() const {
 bool
 SealedOffsetMapping::IsEnabled() const {
     return enabled_;
+}
+
+bool
+SealedOffsetMapping::IsMmap() const {
+    return l2p_vec_.IsMmap() || p2l_vec_.IsMmap();
 }
 
 int64_t
@@ -226,7 +324,7 @@ SealedOffsetMapping::TransformBitset(const BitsetView& bitset,
     }
 
     result.resize(valid_count_, true);
-    if (use_map_) {
+    if (use_i2o_map_) {
         for (int64_t physical_idx = 0; physical_idx < valid_count_;
              ++physical_idx) {
             auto it = p2l_map_.find(static_cast<int32_t>(physical_idx));

--- a/internal/core/src/common/OffsetMapping.cpp
+++ b/internal/core/src/common/OffsetMapping.cpp
@@ -1,15 +1,50 @@
 #include "common/OffsetMapping.h"
 
 #include <algorithm>
+#include <cerrno>
+#include <cstring>
+#include <filesystem>
+#include <limits>
 #include <mutex>
 #include <shared_mutex>
 #include <utility>
 
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
 #include "common/EasyAssert.h"
-#include "storage/MmapManager.h"
 
 namespace milvus {
 namespace {
+
+constexpr const char* O2I_MMAP_FILE = "o2i";
+constexpr const char* I2O_MMAP_FILE = "i2o";
+
+class FileDescriptorGuard {
+ public:
+    explicit FileDescriptorGuard(int fd) : fd_(fd) {
+    }
+
+    ~FileDescriptorGuard() {
+        if (fd_ >= 0) {
+            close(fd_);
+        }
+    }
+
+    int
+    Get() const {
+        return fd_;
+    }
+
+ private:
+    int fd_;
+};
+
+std::string
+GetMmapFilePath(const std::string& mmap_dir_path, const char* filename) {
+    return (std::filesystem::path(mmap_dir_path) / filename).string();
+}
 
 bool
 ShouldSkipBitsetTransform(const BitsetView& bitset,
@@ -34,30 +69,70 @@ ShouldSkipBitsetTransform(const BitsetView& bitset,
 
 }  // namespace
 
+OffsetMappingArray::~OffsetMappingArray() {
+    Clear();
+}
+
 void
-OffsetMappingArray::Resize(
-    size_t size,
-    int32_t value,
-    bool enable_mmap,
-    const storage::MmapChunkManagerPtr& mmap_chunk_manager,
-    const storage::MmapChunkDescriptorPtr& mmap_descriptor) {
+OffsetMappingArray::Resize(size_t size,
+                           int32_t value,
+                           bool enable_mmap,
+                           std::string filepath) {
     Clear();
     if (size == 0) {
         return;
     }
 
     if (enable_mmap) {
-        AssertInfo(mmap_chunk_manager != nullptr,
-                   "offset mapping mmap chunk manager is null");
-        AssertInfo(mmap_descriptor != nullptr,
-                   "offset mapping mmap descriptor is null");
-        mmap_chunk_manager_ = mmap_chunk_manager;
-        mmap_descriptor_ = mmap_descriptor;
-        mmap_data_ = static_cast<int32_t*>(mmap_chunk_manager_->Allocate(
-            mmap_descriptor_, sizeof(int32_t) * size));
+        AssertInfo(!filepath.empty(), "offset mapping mmap filepath is empty");
+        AssertInfo(size <= std::numeric_limits<size_t>::max() / sizeof(int32_t),
+                   "offset mapping mmap buffer is too large");
+
+        const auto mmap_size = sizeof(int32_t) * size;
+        std::filesystem::create_directories(
+            std::filesystem::path(filepath).parent_path());
+
+        const int fd = open(filepath.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0600);
+        if (fd < 0) {
+            ThrowInfo(MmapError,
+                      "failed to create offset mapping mmap file {}: {}",
+                      filepath,
+                      std::strerror(errno));
+        }
+        FileDescriptorGuard fd_guard(fd);
+
+        if (ftruncate(fd_guard.Get(), mmap_size) != 0) {
+            const auto err = errno;
+            unlink(filepath.c_str());
+            ThrowInfo(MmapError,
+                      "failed to resize offset mapping mmap file {} to {} "
+                      "bytes: {}",
+                      filepath,
+                      mmap_size,
+                      std::strerror(err));
+        }
+
+        auto* data = mmap(nullptr,
+                          mmap_size,
+                          PROT_READ | PROT_WRITE,
+                          MAP_SHARED,
+                          fd_guard.Get(),
+                          0);
+        if (data == MAP_FAILED) {
+            const auto err = errno;
+            unlink(filepath.c_str());
+            ThrowInfo(MmapError,
+                      "failed to mmap offset mapping file {}: {}",
+                      filepath,
+                      std::strerror(err));
+        }
+
+        mmap_data_ = static_cast<int32_t*>(data);
+        mmap_size_ = mmap_size;
+        mmap_filepath_ = std::move(filepath);
         AssertInfo(mmap_data_ != nullptr,
                    "failed to allocate offset mapping mmap buffer, size: {}",
-                   sizeof(int32_t) * size);
+                   mmap_size_);
         size_ = size;
         std::fill_n(mmap_data_, size_, value);
         return;
@@ -69,11 +144,17 @@ OffsetMappingArray::Resize(
 
 void
 OffsetMappingArray::Clear() {
+    if (mmap_data_ != nullptr) {
+        munmap(mmap_data_, mmap_size_);
+    }
+    if (!mmap_filepath_.empty()) {
+        unlink(mmap_filepath_.c_str());
+    }
     size_ = 0;
     vec_.clear();
     mmap_data_ = nullptr;
-    mmap_descriptor_ = nullptr;
-    mmap_chunk_manager_ = nullptr;
+    mmap_size_ = 0;
+    mmap_filepath_.clear();
 }
 
 int64_t
@@ -184,47 +265,31 @@ SealedOffsetMapping::Build(const bool* valid_data,
     const int64_t required_size = start_logical + total_count;
     const int64_t required_p2l_size = start_physical + valid_count;
 
-    auto build_options = options;
     const bool need_o2i_mmap =
-        !use_o2i_map_ && build_options.enable_mmap_o2i_map && required_size > 0;
-    const bool need_i2o_mmap = !use_i2o_map_ &&
-                               build_options.enable_mmap_i2o_map &&
-                               required_p2l_size > 0;
+        !use_o2i_map_ && options.enable_mmap_o2i_map && required_size > 0;
+    const bool need_i2o_mmap =
+        !use_i2o_map_ && options.enable_mmap_i2o_map && required_p2l_size > 0;
     if (need_i2o_mmap || need_o2i_mmap) {
-        if (build_options.mmap_chunk_manager == nullptr) {
-            build_options.mmap_chunk_manager =
-                storage::MmapManager::GetInstance().GetMmapChunkManager();
-        }
-    }
-    if (need_o2i_mmap && build_options.o2i_mmap_descriptor == nullptr) {
-        build_options.o2i_mmap_descriptor =
-            build_options.mmap_chunk_manager->Register();
-    }
-    if (need_i2o_mmap && build_options.i2o_mmap_descriptor == nullptr) {
-        build_options.i2o_mmap_descriptor =
-            build_options.mmap_chunk_manager->Register();
-    }
-    if (need_i2o_mmap && need_o2i_mmap) {
-        AssertInfo(build_options.i2o_mmap_descriptor !=
-                       build_options.o2i_mmap_descriptor,
-                   "offset mapping i2o and o2i mmap descriptors must be "
-                   "different");
+        AssertInfo(!options.mmap_dir_path.empty(),
+                   "offset mapping mmap dir path is empty");
     }
 
     if (!use_o2i_map_) {
         l2p_vec_.Resize(required_size,
                         -1,
-                        build_options.enable_mmap_o2i_map,
-                        build_options.mmap_chunk_manager,
-                        build_options.o2i_mmap_descriptor);
+                        options.enable_mmap_o2i_map,
+                        need_o2i_mmap ? GetMmapFilePath(options.mmap_dir_path,
+                                                        O2I_MMAP_FILE)
+                                      : "");
     }
 
     if (!use_i2o_map_) {
         p2l_vec_.Resize(required_p2l_size,
                         -1,
-                        build_options.enable_mmap_i2o_map,
-                        build_options.mmap_chunk_manager,
-                        build_options.i2o_mmap_descriptor);
+                        options.enable_mmap_i2o_map,
+                        need_i2o_mmap ? GetMmapFilePath(options.mmap_dir_path,
+                                                        I2O_MMAP_FILE)
+                                      : "");
     }
 
     int64_t physical_idx = start_physical;

--- a/internal/core/src/common/OffsetMapping.h
+++ b/internal/core/src/common/OffsetMapping.h
@@ -16,15 +16,28 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <shared_mutex>
 #include <unordered_map>
 #include <vector>
 
 #include "common/BitsetView.h"
 #include "common/Types.h"
+#include "storage/MmapChunkManager.h"
 
 namespace milvus {
+
+struct OffsetMappingBuildOptions {
+    // i2o: index/internal id -> original/logical offset.
+    bool enable_mmap_i2o_map{false};
+    // o2i: original/logical offset -> index/internal id.
+    bool enable_mmap_o2i_map{false};
+    storage::MmapChunkManagerPtr mmap_chunk_manager{nullptr};
+    storage::MmapChunkDescriptorPtr i2o_mmap_descriptor{nullptr};
+    storage::MmapChunkDescriptorPtr o2i_mmap_descriptor{nullptr};
+};
 
 // Bidirectional offset mapping for nullable vector storage
 // Maps between logical offsets (with nulls) and physical offsets (only valid
@@ -61,6 +74,9 @@ class OffsetMapping {
     virtual bool
     IsEnabled() const;
 
+    virtual bool
+    IsMmap() const;
+
     // Get total logical count (including nulls)
     virtual int64_t
     GetTotalCount() const;
@@ -81,10 +97,52 @@ class OffsetMapping {
                               std::vector<int64_t>& physical_offsets) const;
 };
 
+class OffsetMappingArray {
+ public:
+    void
+    Resize(size_t size,
+           int32_t value,
+           bool enable_mmap,
+           const storage::MmapChunkManagerPtr& mmap_chunk_manager,
+           const storage::MmapChunkDescriptorPtr& mmap_descriptor);
+
+    void
+    Clear();
+
+    size_t
+    size() const {
+        return size_;
+    }
+
+    bool
+    IsMmap() const {
+        return mmap_data_ != nullptr;
+    }
+
+    int32_t&
+    operator[](size_t index) {
+        return IsMmap() ? mmap_data_[index] : vec_[index];
+    }
+
+    const int32_t&
+    operator[](size_t index) const {
+        return IsMmap() ? mmap_data_[index] : vec_[index];
+    }
+
+ private:
+    size_t size_{0};
+    std::vector<int32_t> vec_;
+    int32_t* mmap_data_{nullptr};
+    storage::MmapChunkManagerPtr mmap_chunk_manager_{nullptr};
+    storage::MmapChunkDescriptorPtr mmap_descriptor_{nullptr};
+};
+
 class SealedOffsetMapping final : public OffsetMapping {
  public:
     void
-    Build(const bool* valid_data, int64_t total_count);
+    Build(const bool* valid_data,
+          int64_t total_count,
+          const OffsetMappingBuildOptions& options = {});
 
     int64_t
     GetPhysicalOffset(int64_t logical_offset) const override;
@@ -97,6 +155,9 @@ class SealedOffsetMapping final : public OffsetMapping {
 
     bool
     IsEnabled() const override;
+
+    bool
+    IsMmap() const override;
 
     int64_t
     GetTotalCount() const override;
@@ -118,6 +179,31 @@ class SealedOffsetMapping final : public OffsetMapping {
         bool* valid_data,
         std::vector<int64_t>& physical_offsets) const override;
 
+    bool
+    IsUsingMap() const {
+        return IsI2OUsingMap() || IsO2IUsingMap();
+    }
+
+    bool
+    IsI2OUsingMap() const {
+        return use_i2o_map_;
+    }
+
+    bool
+    IsO2IUsingMap() const {
+        return use_o2i_map_;
+    }
+
+    bool
+    IsI2OMmap() const {
+        return p2l_vec_.IsMmap();
+    }
+
+    bool
+    IsO2IMmap() const {
+        return l2p_vec_.IsMmap();
+    }
+
  private:
     int64_t
     GetPhysicalOffsetInternal(int64_t logical_offset) const;
@@ -126,10 +212,11 @@ class SealedOffsetMapping final : public OffsetMapping {
     GetLogicalOffsetInternal(int64_t physical_offset) const;
 
     bool enabled_{false};
-    bool use_map_{false};
+    bool use_i2o_map_{false};
+    bool use_o2i_map_{false};
     // Sealed vec mode storage (uses int32_t to save memory)
-    std::vector<int32_t> l2p_vec_;  // logical -> physical, -1 means null
-    std::vector<int32_t> p2l_vec_;  // physical -> logical
+    OffsetMappingArray l2p_vec_;  // o2i: logical/original -> physical/index
+    OffsetMappingArray p2l_vec_;  // i2o: physical/index -> logical/original
 
     // Sealed map mode storage (for sparse valid data)
     std::unordered_map<int32_t, int32_t> l2p_map_;  // logical -> physical

--- a/internal/core/src/common/OffsetMapping.h
+++ b/internal/core/src/common/OffsetMapping.h
@@ -20,12 +20,12 @@
 #include <cstdint>
 #include <memory>
 #include <shared_mutex>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
 #include "common/BitsetView.h"
 #include "common/Types.h"
-#include "storage/MmapChunkManager.h"
 
 namespace milvus {
 
@@ -34,9 +34,7 @@ struct OffsetMappingBuildOptions {
     bool enable_mmap_i2o_map{false};
     // o2i: original/logical offset -> index/internal id.
     bool enable_mmap_o2i_map{false};
-    storage::MmapChunkManagerPtr mmap_chunk_manager{nullptr};
-    storage::MmapChunkDescriptorPtr i2o_mmap_descriptor{nullptr};
-    storage::MmapChunkDescriptorPtr o2i_mmap_descriptor{nullptr};
+    std::string mmap_dir_path;
 };
 
 // Bidirectional offset mapping for nullable vector storage
@@ -99,12 +97,14 @@ class OffsetMapping {
 
 class OffsetMappingArray {
  public:
+    OffsetMappingArray() = default;
+    ~OffsetMappingArray();
+    OffsetMappingArray(const OffsetMappingArray&) = delete;
+    OffsetMappingArray&
+    operator=(const OffsetMappingArray&) = delete;
+
     void
-    Resize(size_t size,
-           int32_t value,
-           bool enable_mmap,
-           const storage::MmapChunkManagerPtr& mmap_chunk_manager,
-           const storage::MmapChunkDescriptorPtr& mmap_descriptor);
+    Resize(size_t size, int32_t value, bool enable_mmap, std::string filepath);
 
     void
     Clear();
@@ -133,8 +133,8 @@ class OffsetMappingArray {
     size_t size_{0};
     std::vector<int32_t> vec_;
     int32_t* mmap_data_{nullptr};
-    storage::MmapChunkManagerPtr mmap_chunk_manager_{nullptr};
-    storage::MmapChunkDescriptorPtr mmap_descriptor_{nullptr};
+    size_t mmap_size_{0};
+    std::string mmap_filepath_;
 };
 
 class SealedOffsetMapping final : public OffsetMapping {

--- a/internal/core/src/common/OffsetMappingTest.cpp
+++ b/internal/core/src/common/OffsetMappingTest.cpp
@@ -11,9 +11,18 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <initializer_list>
+#include <memory>
+#include <string>
 #include <vector>
 
 #include "common/OffsetMapping.h"
+#include "index/VectorIndexValidDataUtils.h"
+#include "storage/MmapChunkManager.h"
 
 namespace milvus {
 
@@ -36,6 +45,212 @@ ToBoolBytes(const std::vector<bool>& valid) {
     }
     return bytes;
 }
+
+std::filesystem::path
+MakeMmapRoot(const std::string& test_name) {
+    return std::filesystem::temp_directory_path() /
+           ("milvus_offset_mapping_" + test_name + "_" +
+            std::to_string(
+                std::chrono::steady_clock::now().time_since_epoch().count()));
+}
+
+storage::MmapChunkManagerPtr
+MakeMmapChunkManager(const std::filesystem::path& mmap_root) {
+    return std::make_shared<storage::MmapChunkManager>(
+        mmap_root.string(), 64 * 1024 * 1024, 4 * 1024);
+}
+
+OffsetMappingBuildOptions
+MmapOptions(const storage::MmapChunkManagerPtr& mmap_chunk_manager,
+            bool enable_i2o = true,
+            bool enable_o2i = true) {
+    OffsetMappingBuildOptions options;
+    options.enable_mmap_i2o_map = enable_i2o;
+    options.enable_mmap_o2i_map = enable_o2i;
+    options.mmap_chunk_manager = mmap_chunk_manager;
+    return options;
+}
+
+std::vector<std::filesystem::path>
+MmapBlockFiles(const std::filesystem::path& mmap_root) {
+    std::vector<std::filesystem::path> files;
+    if (!std::filesystem::exists(mmap_root)) {
+        return files;
+    }
+    for (const auto& entry : std::filesystem::directory_iterator(mmap_root)) {
+        if (entry.is_regular_file()) {
+            files.emplace_back(entry.path());
+        }
+    }
+    std::sort(files.begin(), files.end());
+    return files;
+}
+
+void
+ExpectMmapBlockFiles(const std::filesystem::path& mmap_root,
+                     std::vector<uint64_t> minimum_bytes) {
+    auto mmap_files = MmapBlockFiles(mmap_root);
+    ASSERT_EQ(mmap_files.size(), minimum_bytes.size());
+
+    std::sort(minimum_bytes.begin(), minimum_bytes.end());
+    std::vector<uint64_t> file_sizes;
+    file_sizes.reserve(mmap_files.size());
+    for (const auto& mmap_file : mmap_files) {
+        file_sizes.emplace_back(std::filesystem::file_size(mmap_file));
+    }
+    std::sort(file_sizes.begin(), file_sizes.end());
+
+    for (size_t i = 0; i < file_sizes.size(); ++i) {
+        EXPECT_GE(file_sizes[i], minimum_bytes[i]);
+    }
+}
+
+void
+ExpectMappingValues(const SealedOffsetMapping& mapping,
+                    const std::vector<int64_t>& expected_l2p,
+                    const std::vector<int64_t>& expected_p2l) {
+    EXPECT_TRUE(mapping.IsEnabled());
+    EXPECT_EQ(mapping.GetTotalCount(),
+              static_cast<int64_t>(expected_l2p.size()));
+    EXPECT_EQ(mapping.GetValidCount(),
+              static_cast<int64_t>(expected_p2l.size()));
+
+    for (size_t i = 0; i < expected_l2p.size(); ++i) {
+        EXPECT_EQ(mapping.GetPhysicalOffset(i), expected_l2p[i])
+            << "logical offset: " << i;
+    }
+    for (size_t i = 0; i < expected_p2l.size(); ++i) {
+        EXPECT_EQ(mapping.GetLogicalOffset(i), expected_p2l[i])
+            << "physical offset: " << i;
+    }
+}
+
+void
+ExpectStorageMode(const SealedOffsetMapping& mapping,
+                  bool i2o_mmap,
+                  bool o2i_mmap,
+                  bool i2o_map,
+                  bool o2i_map) {
+    EXPECT_EQ(mapping.IsI2OMmap(), i2o_mmap);
+    EXPECT_EQ(mapping.IsO2IMmap(), o2i_mmap);
+    EXPECT_EQ(mapping.IsMmap(), i2o_mmap || o2i_mmap);
+    EXPECT_EQ(mapping.IsI2OUsingMap(), i2o_map);
+    EXPECT_EQ(mapping.IsO2IUsingMap(), o2i_map);
+    EXPECT_EQ(mapping.IsUsingMap(), i2o_map || o2i_map);
+}
+
+void
+ExpectTransformOperations(const SealedOffsetMapping& mapping) {
+    TargetBitmap bitset(5, false);
+    bitset.set(2);
+    TargetBitmap transformed;
+    EXPECT_EQ(mapping.TransformBitset(bitset, transformed),
+              OffsetMapping::BitsetTransformStatus::Transformed);
+    ASSERT_EQ(transformed.size(), 3);
+    EXPECT_FALSE(transformed[0]);
+    EXPECT_TRUE(transformed[1]);
+    EXPECT_FALSE(transformed[2]);
+
+    std::vector<int64_t> physical_offsets{0, 1, 2, -1};
+    mapping.TransformOffsets(physical_offsets);
+    EXPECT_EQ(physical_offsets, (std::vector<int64_t>{0, 2, 3, -1}));
+
+    std::vector<int64_t> logical_offsets{0, 1, 3, 4};
+    mapping.TransformLogicalOffsets(logical_offsets);
+    EXPECT_EQ(logical_offsets, (std::vector<int64_t>{0, -1, 2, -1}));
+
+    const int64_t input_offsets[] = {0, 1, 2, 4};
+    bool input_valid_data[4] = {};
+    std::vector<int64_t> filtered_offsets;
+    mapping.FilterValidLogicalOffsets(
+        input_offsets, 4, input_valid_data, filtered_offsets);
+    EXPECT_TRUE(input_valid_data[0]);
+    EXPECT_FALSE(input_valid_data[1]);
+    EXPECT_TRUE(input_valid_data[2]);
+    EXPECT_FALSE(input_valid_data[3]);
+    EXPECT_EQ(filtered_offsets, (std::vector<int64_t>{0, 1}));
+}
+
+class TestVectorIndex : public index::VectorIndex {
+ public:
+    TestVectorIndex() : index::VectorIndex("TEST", knowhere::metric::L2) {
+    }
+
+    BinarySet
+    Serialize(const Config& config) override {
+        (void)config;
+        return {};
+    }
+
+    void
+    Load(const BinarySet& binary_set, const Config& config) override {
+        (void)binary_set;
+        (void)config;
+    }
+
+    void
+    Load(milvus::tracer::TraceContext ctx, const Config& config) override {
+        (void)ctx;
+        (void)config;
+    }
+
+    void
+    BuildWithDataset(const DatasetPtr& dataset, const Config& config) override {
+        (void)dataset;
+        (void)config;
+    }
+
+    void
+    Build(const Config& config) override {
+        (void)config;
+    }
+
+    int64_t
+    Count() override {
+        return 0;
+    }
+
+    index::IndexStatsPtr
+    Upload(const Config& config) override {
+        (void)config;
+        return nullptr;
+    }
+
+    void
+    Query(const DatasetPtr dataset,
+          const SearchInfo& search_info,
+          const BitsetView& bitset,
+          milvus::OpContext* op_context,
+          SearchResult& search_result) const override {
+        (void)dataset;
+        (void)search_info;
+        (void)bitset;
+        (void)op_context;
+        (void)search_result;
+    }
+
+    const bool
+    HasRawData() const override {
+        return false;
+    }
+
+    bool
+    IsIndexRefineEnabled() const override {
+        return false;
+    }
+
+    std::vector<uint8_t>
+    GetVector(const DatasetPtr dataset) const override {
+        (void)dataset;
+        return {};
+    }
+
+    std::unique_ptr<const knowhere::sparse::SparseRow<SparseValueType>[]>
+    GetSparseVector(const DatasetPtr dataset) const override {
+        (void)dataset;
+        return nullptr;
+    }
+};
 }  // namespace
 
 // ---------- Default (disabled) state ----------
@@ -53,85 +268,376 @@ TEST(OffsetMapping, DefaultIsDisabledAndPassThrough) {
 // ---------- Build (eager) ----------
 
 TEST(OffsetMapping, BuildBasicVecMode) {
-    SealedOffsetMapping mapping;
     auto valid = ToBoolBytes(MakeValid({1, 0, 1, 1, 0}));
-    mapping.Build(reinterpret_cast<const bool*>(valid.data()), 5);
+    const std::vector<int64_t> expected_l2p{0, -1, 1, 2, -1};
+    const std::vector<int64_t> expected_p2l{0, 2, 3};
 
-    EXPECT_TRUE(mapping.IsEnabled());
-    EXPECT_EQ(mapping.GetTotalCount(), 5);
-    EXPECT_EQ(mapping.GetValidCount(), 3);
-    EXPECT_EQ(mapping.GetPhysicalOffset(0), 0);
-    EXPECT_EQ(mapping.GetPhysicalOffset(1), -1);
-    EXPECT_EQ(mapping.GetPhysicalOffset(2), 1);
-    EXPECT_EQ(mapping.GetPhysicalOffset(3), 2);
-    EXPECT_EQ(mapping.GetPhysicalOffset(4), -1);
-    EXPECT_EQ(mapping.GetLogicalOffset(0), 0);
-    EXPECT_EQ(mapping.GetLogicalOffset(1), 2);
-    EXPECT_EQ(mapping.GetLogicalOffset(2), 3);
+    {
+        SealedOffsetMapping mapping;
+        mapping.Build(reinterpret_cast<const bool*>(valid.data()), 5);
+        ExpectMappingValues(mapping, expected_l2p, expected_p2l);
+        ExpectStorageMode(mapping, false, false, false, false);
+    }
+
+    {
+        const auto mmap_root = MakeMmapRoot("basic_both");
+        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        SealedOffsetMapping mapping;
+        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
+                      5,
+                      MmapOptions(mmap_chunk_manager));
+        ExpectMappingValues(mapping, expected_l2p, expected_p2l);
+        ExpectStorageMode(mapping, true, true, false, false);
+        ExpectMmapBlockFiles(mmap_root,
+                             {3 * sizeof(int32_t), 5 * sizeof(int32_t)});
+    }
+}
+
+TEST(OffsetMapping, BuildBasicVecModeMapsDirectionsIndependently) {
+    auto valid = ToBoolBytes(MakeValid({1, 0, 1, 1, 0}));
+    const std::vector<int64_t> expected_l2p{0, -1, 1, 2, -1};
+    const std::vector<int64_t> expected_p2l{0, 2, 3};
+
+    {
+        const auto mmap_root = MakeMmapRoot("basic_i2o");
+        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        SealedOffsetMapping mapping;
+        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
+                      5,
+                      MmapOptions(mmap_chunk_manager, true, false));
+        ExpectMappingValues(mapping, expected_l2p, expected_p2l);
+        ExpectStorageMode(mapping, true, false, false, false);
+        ExpectMmapBlockFiles(mmap_root, {3 * sizeof(int32_t)});
+    }
+
+    {
+        const auto mmap_root = MakeMmapRoot("basic_o2i");
+        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        SealedOffsetMapping mapping;
+        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
+                      5,
+                      MmapOptions(mmap_chunk_manager, false, true));
+        ExpectMappingValues(mapping, expected_l2p, expected_p2l);
+        ExpectStorageMode(mapping, false, true, false, false);
+        ExpectMmapBlockFiles(mmap_root, {5 * sizeof(int32_t)});
+    }
 }
 
 TEST(OffsetMapping, BuildMapModeOnSparse) {
-    SealedOffsetMapping mapping;
     std::vector<uint8_t> valid(100, 0);
     valid[5] = 1;
     valid[50] = 1;
-    mapping.Build(reinterpret_cast<const bool*>(valid.data()), 100);
+    std::vector<int64_t> expected_l2p(100, -1);
+    expected_l2p[5] = 0;
+    expected_l2p[50] = 1;
+    const std::vector<int64_t> expected_p2l{5, 50};
 
-    EXPECT_EQ(mapping.GetTotalCount(), 100);
-    EXPECT_EQ(mapping.GetValidCount(), 2);
-    EXPECT_EQ(mapping.GetPhysicalOffset(5), 0);
-    EXPECT_EQ(mapping.GetPhysicalOffset(50), 1);
-    EXPECT_EQ(mapping.GetPhysicalOffset(0), -1);
-    EXPECT_EQ(mapping.GetLogicalOffset(0), 5);
-    EXPECT_EQ(mapping.GetLogicalOffset(1), 50);
+    {
+        SealedOffsetMapping mapping;
+        mapping.Build(reinterpret_cast<const bool*>(valid.data()), 100);
+        ExpectMappingValues(mapping, expected_l2p, expected_p2l);
+        ExpectStorageMode(mapping, false, false, true, true);
+    }
+
+    {
+        const auto mmap_root = MakeMmapRoot("sparse_both");
+        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        SealedOffsetMapping mapping;
+        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
+                      100,
+                      MmapOptions(mmap_chunk_manager));
+        ExpectMappingValues(mapping, expected_l2p, expected_p2l);
+        ExpectStorageMode(mapping, true, true, false, false);
+        ExpectMmapBlockFiles(mmap_root,
+                             {2 * sizeof(int32_t), 100 * sizeof(int32_t)});
+    }
+
+    {
+        const auto mmap_root = MakeMmapRoot("sparse_i2o");
+        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        SealedOffsetMapping mapping;
+        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
+                      100,
+                      MmapOptions(mmap_chunk_manager, true, false));
+        ExpectMappingValues(mapping, expected_l2p, expected_p2l);
+        ExpectStorageMode(mapping, true, false, false, true);
+        ExpectMmapBlockFiles(mmap_root, {2 * sizeof(int32_t)});
+    }
+
+    {
+        const auto mmap_root = MakeMmapRoot("sparse_o2i");
+        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        SealedOffsetMapping mapping;
+        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
+                      100,
+                      MmapOptions(mmap_chunk_manager, false, true));
+        ExpectMappingValues(mapping, expected_l2p, expected_p2l);
+        ExpectStorageMode(mapping, false, true, true, false);
+        ExpectMmapBlockFiles(mmap_root, {100 * sizeof(int32_t)});
+    }
 }
 
 TEST(OffsetMapping, BuildAllValid) {
-    SealedOffsetMapping mapping;
     std::vector<uint8_t> valid(4, 1);
-    mapping.Build(reinterpret_cast<const bool*>(valid.data()), 4);
-    EXPECT_EQ(mapping.GetValidCount(), 4);
-    for (int64_t i = 0; i < 4; ++i) {
-        EXPECT_EQ(mapping.GetPhysicalOffset(i), i);
-        EXPECT_EQ(mapping.GetLogicalOffset(i), i);
+    const std::vector<int64_t> expected{0, 1, 2, 3};
+
+    {
+        SealedOffsetMapping mapping;
+        mapping.Build(reinterpret_cast<const bool*>(valid.data()), 4);
+        ExpectMappingValues(mapping, expected, expected);
+        ExpectStorageMode(mapping, false, false, false, false);
+    }
+
+    {
+        const auto mmap_root = MakeMmapRoot("all_valid");
+        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        SealedOffsetMapping mapping;
+        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
+                      4,
+                      MmapOptions(mmap_chunk_manager));
+        ExpectMappingValues(mapping, expected, expected);
+        ExpectStorageMode(mapping, true, true, false, false);
+        ExpectMmapBlockFiles(mmap_root,
+                             {4 * sizeof(int32_t), 4 * sizeof(int32_t)});
     }
 }
 
 TEST(OffsetMapping, BuildAllNull) {
-    SealedOffsetMapping mapping;
     std::vector<uint8_t> valid(4, 0);
-    mapping.Build(reinterpret_cast<const bool*>(valid.data()), 4);
-    EXPECT_TRUE(mapping.IsEnabled());
-    EXPECT_EQ(mapping.GetValidCount(), 0);
-    EXPECT_EQ(mapping.GetTotalCount(), 4);
-    for (int64_t i = 0; i < 4; ++i) {
-        EXPECT_EQ(mapping.GetPhysicalOffset(i), -1);
+    const std::vector<int64_t> expected_l2p(4, -1);
+    const std::vector<int64_t> expected_p2l;
+
+    {
+        SealedOffsetMapping mapping;
+        mapping.Build(reinterpret_cast<const bool*>(valid.data()), 4);
+        ExpectMappingValues(mapping, expected_l2p, expected_p2l);
+        ExpectStorageMode(mapping, false, false, true, true);
+        EXPECT_EQ(mapping.GetLogicalOffset(0), -1);
+    }
+
+    {
+        const auto mmap_root = MakeMmapRoot("all_null");
+        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        SealedOffsetMapping mapping;
+        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
+                      4,
+                      MmapOptions(mmap_chunk_manager));
+        ExpectMappingValues(mapping, expected_l2p, expected_p2l);
+        ExpectStorageMode(mapping, false, true, false, false);
+        EXPECT_EQ(mapping.GetLogicalOffset(0), -1);
+        ExpectMmapBlockFiles(mmap_root, {4 * sizeof(int32_t)});
+    }
+}
+
+TEST(OffsetMapping, TransformOperationsMatchBuildMode) {
+    auto valid = ToBoolBytes(MakeValid({1, 0, 1, 1, 0}));
+
+    {
+        SealedOffsetMapping mapping;
+        mapping.Build(reinterpret_cast<const bool*>(valid.data()), 5);
+        ExpectTransformOperations(mapping);
+    }
+
+    {
+        const auto mmap_root = MakeMmapRoot("transform");
+        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        SealedOffsetMapping mapping;
+        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
+                      5,
+                      MmapOptions(mmap_chunk_manager));
+        ExpectTransformOperations(mapping);
     }
 }
 
 TEST(OffsetMapping, BuildNoopOnNullOrZero) {
-    SealedOffsetMapping mapping;
-    mapping.Build(nullptr, 100);
-    EXPECT_FALSE(mapping.IsEnabled());
-    std::vector<uint8_t> valid(1, 1);
-    mapping.Build(reinterpret_cast<const bool*>(valid.data()), 0);
-    EXPECT_FALSE(mapping.IsEnabled());
+    {
+        SealedOffsetMapping mapping;
+        mapping.Build(nullptr, 100);
+        EXPECT_FALSE(mapping.IsEnabled());
+
+        std::vector<uint8_t> valid(1, 1);
+        mapping.Build(reinterpret_cast<const bool*>(valid.data()), 0);
+        EXPECT_FALSE(mapping.IsEnabled());
+    }
+
+    {
+        const auto mmap_root = MakeMmapRoot("noop");
+        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        SealedOffsetMapping mapping;
+        auto valid = ToBoolBytes(MakeValid({1, 0, 1, 1, 0}));
+
+        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
+                      5,
+                      MmapOptions(mmap_chunk_manager));
+        EXPECT_TRUE(mapping.IsEnabled());
+        EXPECT_TRUE(mapping.IsMmap());
+
+        mapping.Build(nullptr, 100, MmapOptions(mmap_chunk_manager));
+        EXPECT_FALSE(mapping.IsEnabled());
+        EXPECT_FALSE(mapping.IsMmap());
+        EXPECT_FALSE(mapping.IsUsingMap());
+        EXPECT_EQ(mapping.GetPhysicalOffset(3), 3);
+
+        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
+                      0,
+                      MmapOptions(mmap_chunk_manager));
+        EXPECT_FALSE(mapping.IsEnabled());
+        EXPECT_FALSE(mapping.IsMmap());
+        EXPECT_FALSE(mapping.IsUsingMap());
+    }
 }
 
 TEST(OffsetMapping, BuildTwiceResetsState) {
-    SealedOffsetMapping mapping;
     auto v1 = ToBoolBytes(MakeValid({1, 1, 0, 0, 1}));
-    mapping.Build(reinterpret_cast<const bool*>(v1.data()), 5);
-    EXPECT_EQ(mapping.GetValidCount(), 3);
-    EXPECT_EQ(mapping.GetTotalCount(), 5);
-
     auto v2 = ToBoolBytes(MakeValid({1, 0, 0}));
-    mapping.Build(reinterpret_cast<const bool*>(v2.data()), 3);
-    EXPECT_EQ(mapping.GetValidCount(), 1);
-    EXPECT_EQ(mapping.GetTotalCount(), 3);
-    EXPECT_EQ(mapping.GetPhysicalOffset(0), 0);
-    EXPECT_EQ(mapping.GetPhysicalOffset(1), -1);
-    EXPECT_EQ(mapping.GetPhysicalOffset(2), -1);
+
+    {
+        SealedOffsetMapping mapping;
+        mapping.Build(reinterpret_cast<const bool*>(v1.data()), 5);
+        EXPECT_EQ(mapping.GetValidCount(), 3);
+        EXPECT_EQ(mapping.GetTotalCount(), 5);
+
+        mapping.Build(reinterpret_cast<const bool*>(v2.data()), 3);
+        EXPECT_EQ(mapping.GetValidCount(), 1);
+        EXPECT_EQ(mapping.GetTotalCount(), 3);
+        EXPECT_EQ(mapping.GetPhysicalOffset(0), 0);
+        EXPECT_EQ(mapping.GetPhysicalOffset(1), -1);
+        EXPECT_EQ(mapping.GetPhysicalOffset(2), -1);
+        EXPECT_FALSE(mapping.IsMmap());
+    }
+
+    {
+        const auto mmap_root = MakeMmapRoot("build_twice");
+        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        SealedOffsetMapping mapping;
+        mapping.Build(reinterpret_cast<const bool*>(v1.data()),
+                      5,
+                      MmapOptions(mmap_chunk_manager));
+        EXPECT_TRUE(mapping.IsMmap());
+
+        mapping.Build(reinterpret_cast<const bool*>(v2.data()), 3);
+        EXPECT_EQ(mapping.GetValidCount(), 1);
+        EXPECT_EQ(mapping.GetTotalCount(), 3);
+        EXPECT_EQ(mapping.GetPhysicalOffset(0), 0);
+        EXPECT_EQ(mapping.GetPhysicalOffset(1), -1);
+        EXPECT_EQ(mapping.GetPhysicalOffset(2), -1);
+        EXPECT_FALSE(mapping.IsMmap());
+    }
+}
+
+TEST(OffsetMapping, MmapOptionsUseOnlyIdMappingConfigKeys) {
+    Config config;
+    config[index::ENABLE_MMAP] = true;
+
+    auto options = index::GetOffsetMappingMmapOptions(config);
+    EXPECT_FALSE(options.enable_mmap_i2o_map);
+    EXPECT_FALSE(options.enable_mmap_o2i_map);
+
+    config[index::ENABLE_MMAP_I2O_MAP] = true;
+    config[index::ENABLE_MMAP_O2I_MAP] = false;
+
+    options = index::GetOffsetMappingMmapOptions(config);
+    EXPECT_TRUE(options.enable_mmap_i2o_map);
+    EXPECT_FALSE(options.enable_mmap_o2i_map);
+
+    config[index::ENABLE_MMAP_I2O_MAP] = "false";
+    config[index::ENABLE_MMAP_O2I_MAP] = "true";
+
+    options = index::GetOffsetMappingMmapOptions(config);
+    EXPECT_FALSE(options.enable_mmap_i2o_map);
+    EXPECT_TRUE(options.enable_mmap_o2i_map);
+}
+
+TEST(OffsetMapping, OffsetMappingMmapDirUsesDedicatedIndexSubdirectory) {
+    const auto local_index_prefix = (std::filesystem::temp_directory_path() /
+                                     "milvus_local_chunk/index_files/1_2_3_4")
+                                        .string();
+    const auto mmap_dir = index::GetOffsetMappingMmapDir(local_index_prefix);
+
+    EXPECT_EQ(mmap_dir,
+              (std::filesystem::path(local_index_prefix) /
+               index::OFFSET_MAPPING_MMAP_DIR)
+                  .string());
+    EXPECT_EQ(std::filesystem::path(mmap_dir).parent_path(),
+              std::filesystem::path(local_index_prefix));
+}
+
+TEST(OffsetMapping, NeedOffsetMappingMmapMatchesDirectionSizes) {
+    OffsetMappingBuildOptions options;
+    EXPECT_FALSE(index::NeedOffsetMappingMmap(options, 10, 5));
+
+    options.enable_mmap_i2o_map = true;
+    EXPECT_TRUE(index::NeedOffsetMappingMmap(options, 10, 5));
+    EXPECT_FALSE(index::NeedOffsetMappingMmap(options, 10, 0));
+
+    options.enable_mmap_i2o_map = false;
+    options.enable_mmap_o2i_map = true;
+    EXPECT_TRUE(index::NeedOffsetMappingMmap(options, 10, 0));
+    EXPECT_FALSE(index::NeedOffsetMappingMmap(options, 0, 0));
+}
+
+TEST(OffsetMapping, ValidDataHelpersPreserveMappingValuesWithMmapOptions) {
+    const std::vector<uint8_t> bitmap{0b00001101};
+    const std::vector<int64_t> expected_l2p{0, -1, 1, 2, -1};
+    const std::vector<int64_t> expected_p2l{0, 2, 3};
+
+    {
+        TestVectorIndex vector_index;
+        index::BuildValidDataFromBitmap(&vector_index, 5, bitmap.data());
+        const auto* mapping = dynamic_cast<const SealedOffsetMapping*>(
+            &vector_index.GetOffsetMapping());
+        ASSERT_NE(mapping, nullptr);
+        ExpectMappingValues(*mapping, expected_l2p, expected_p2l);
+        ExpectStorageMode(*mapping, false, false, false, false);
+    }
+
+    {
+        const auto mmap_root = MakeMmapRoot("bitmap_helper");
+        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        TestVectorIndex vector_index;
+        index::BuildValidDataFromBitmap(
+            &vector_index, 5, bitmap.data(), MmapOptions(mmap_chunk_manager));
+        const auto* mapping = dynamic_cast<const SealedOffsetMapping*>(
+            &vector_index.GetOffsetMapping());
+        ASSERT_NE(mapping, nullptr);
+        ExpectMappingValues(*mapping, expected_l2p, expected_p2l);
+        ExpectStorageMode(*mapping, true, true, false, false);
+    }
+}
+
+TEST(OffsetMapping, LoadValidDataFromBinarySetUsesProvidedMmapOptions) {
+    SealedOffsetMapping source_mapping;
+    auto valid = ToBoolBytes(MakeValid({1, 0, 1, 1, 0}));
+    source_mapping.Build(reinterpret_cast<const bool*>(valid.data()), 5);
+
+    BinarySet binary_set;
+    index::AppendValidDataToBinarySet(source_mapping, binary_set);
+
+    {
+        TestVectorIndex vector_index;
+        ASSERT_TRUE(
+            index::LoadValidDataFromBinarySet(binary_set, &vector_index));
+        const auto* mapping = dynamic_cast<const SealedOffsetMapping*>(
+            &vector_index.GetOffsetMapping());
+        ASSERT_NE(mapping, nullptr);
+        EXPECT_FALSE(mapping->IsMmap());
+        EXPECT_EQ(mapping->GetPhysicalOffset(3), 2);
+        EXPECT_EQ(mapping->GetLogicalOffset(2), 3);
+    }
+
+    {
+        const auto mmap_root = MakeMmapRoot("binary_set_helper");
+        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        TestVectorIndex vector_index;
+        ASSERT_TRUE(index::LoadValidDataFromBinarySet(
+            binary_set, &vector_index, MmapOptions(mmap_chunk_manager)));
+        const auto* mapping = dynamic_cast<const SealedOffsetMapping*>(
+            &vector_index.GetOffsetMapping());
+        ASSERT_NE(mapping, nullptr);
+        EXPECT_TRUE(mapping->IsMmap());
+        EXPECT_EQ(mapping->GetPhysicalOffset(3), 2);
+        EXPECT_EQ(mapping->GetLogicalOffset(2), 3);
+    }
 }
 
 // ---------- Append ----------
@@ -183,23 +689,53 @@ TEST(OffsetMapping, AppendNoopOnNullOrZero) {
 // ---------- IsValid ----------
 
 TEST(OffsetMapping, IsValidMatchesPhysicalOffsetSign) {
-    SealedOffsetMapping mapping;
     auto v = ToBoolBytes(MakeValid({1, 0, 1, 0}));
-    mapping.Build(reinterpret_cast<const bool*>(v.data()), 4);
-    EXPECT_TRUE(mapping.IsValid(0));
-    EXPECT_FALSE(mapping.IsValid(1));
-    EXPECT_TRUE(mapping.IsValid(2));
-    EXPECT_FALSE(mapping.IsValid(3));
+
+    {
+        SealedOffsetMapping mapping;
+        mapping.Build(reinterpret_cast<const bool*>(v.data()), 4);
+        EXPECT_TRUE(mapping.IsValid(0));
+        EXPECT_FALSE(mapping.IsValid(1));
+        EXPECT_TRUE(mapping.IsValid(2));
+        EXPECT_FALSE(mapping.IsValid(3));
+    }
+
+    {
+        const auto mmap_root = MakeMmapRoot("is_valid");
+        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        SealedOffsetMapping mapping;
+        mapping.Build(reinterpret_cast<const bool*>(v.data()),
+                      4,
+                      MmapOptions(mmap_chunk_manager));
+        EXPECT_TRUE(mapping.IsValid(0));
+        EXPECT_FALSE(mapping.IsValid(1));
+        EXPECT_TRUE(mapping.IsValid(2));
+        EXPECT_FALSE(mapping.IsValid(3));
+    }
 }
 
 // ---------- Out-of-bounds queries ----------
 
 TEST(OffsetMapping, OutOfBoundsReturnsMinusOne) {
-    SealedOffsetMapping mapping;
     auto v = ToBoolBytes(MakeValid({1, 0, 1}));
-    mapping.Build(reinterpret_cast<const bool*>(v.data()), 3);
-    EXPECT_EQ(mapping.GetPhysicalOffset(99), -1);
-    EXPECT_EQ(mapping.GetLogicalOffset(99), -1);
+
+    {
+        SealedOffsetMapping mapping;
+        mapping.Build(reinterpret_cast<const bool*>(v.data()), 3);
+        EXPECT_EQ(mapping.GetPhysicalOffset(99), -1);
+        EXPECT_EQ(mapping.GetLogicalOffset(99), -1);
+    }
+
+    {
+        const auto mmap_root = MakeMmapRoot("out_of_bounds");
+        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        SealedOffsetMapping mapping;
+        mapping.Build(reinterpret_cast<const bool*>(v.data()),
+                      3,
+                      MmapOptions(mmap_chunk_manager));
+        EXPECT_EQ(mapping.GetPhysicalOffset(99), -1);
+        EXPECT_EQ(mapping.GetLogicalOffset(99), -1);
+    }
 }
 
 }  // namespace milvus

--- a/internal/core/src/common/OffsetMappingTest.cpp
+++ b/internal/core/src/common/OffsetMappingTest.cpp
@@ -61,13 +61,13 @@ MakeMmapChunkManager(const std::filesystem::path& mmap_root) {
 }
 
 OffsetMappingBuildOptions
-MmapOptions(const storage::MmapChunkManagerPtr& mmap_chunk_manager,
+MmapOptions(const std::filesystem::path& mmap_dir,
             bool enable_i2o = true,
             bool enable_o2i = true) {
     OffsetMappingBuildOptions options;
     options.enable_mmap_i2o_map = enable_i2o;
     options.enable_mmap_o2i_map = enable_o2i;
-    options.mmap_chunk_manager = mmap_chunk_manager;
+    options.mmap_dir_path = mmap_dir.string();
     return options;
 }
 
@@ -281,11 +281,11 @@ TEST(OffsetMapping, BuildBasicVecMode) {
 
     {
         const auto mmap_root = MakeMmapRoot("basic_both");
-        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        auto mmap_dir = mmap_root;
         SealedOffsetMapping mapping;
         mapping.Build(reinterpret_cast<const bool*>(valid.data()),
                       5,
-                      MmapOptions(mmap_chunk_manager));
+                      MmapOptions(mmap_dir));
         ExpectMappingValues(mapping, expected_l2p, expected_p2l);
         ExpectStorageMode(mapping, true, true, false, false);
         ExpectMmapBlockFiles(mmap_root,
@@ -300,11 +300,11 @@ TEST(OffsetMapping, BuildBasicVecModeMapsDirectionsIndependently) {
 
     {
         const auto mmap_root = MakeMmapRoot("basic_i2o");
-        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        auto mmap_dir = mmap_root;
         SealedOffsetMapping mapping;
         mapping.Build(reinterpret_cast<const bool*>(valid.data()),
                       5,
-                      MmapOptions(mmap_chunk_manager, true, false));
+                      MmapOptions(mmap_dir, true, false));
         ExpectMappingValues(mapping, expected_l2p, expected_p2l);
         ExpectStorageMode(mapping, true, false, false, false);
         ExpectMmapBlockFiles(mmap_root, {3 * sizeof(int32_t)});
@@ -312,11 +312,11 @@ TEST(OffsetMapping, BuildBasicVecModeMapsDirectionsIndependently) {
 
     {
         const auto mmap_root = MakeMmapRoot("basic_o2i");
-        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        auto mmap_dir = mmap_root;
         SealedOffsetMapping mapping;
         mapping.Build(reinterpret_cast<const bool*>(valid.data()),
                       5,
-                      MmapOptions(mmap_chunk_manager, false, true));
+                      MmapOptions(mmap_dir, false, true));
         ExpectMappingValues(mapping, expected_l2p, expected_p2l);
         ExpectStorageMode(mapping, false, true, false, false);
         ExpectMmapBlockFiles(mmap_root, {5 * sizeof(int32_t)});
@@ -341,11 +341,11 @@ TEST(OffsetMapping, BuildMapModeOnSparse) {
 
     {
         const auto mmap_root = MakeMmapRoot("sparse_both");
-        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        auto mmap_dir = mmap_root;
         SealedOffsetMapping mapping;
         mapping.Build(reinterpret_cast<const bool*>(valid.data()),
                       100,
-                      MmapOptions(mmap_chunk_manager));
+                      MmapOptions(mmap_dir));
         ExpectMappingValues(mapping, expected_l2p, expected_p2l);
         ExpectStorageMode(mapping, true, true, false, false);
         ExpectMmapBlockFiles(mmap_root,
@@ -354,11 +354,11 @@ TEST(OffsetMapping, BuildMapModeOnSparse) {
 
     {
         const auto mmap_root = MakeMmapRoot("sparse_i2o");
-        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        auto mmap_dir = mmap_root;
         SealedOffsetMapping mapping;
         mapping.Build(reinterpret_cast<const bool*>(valid.data()),
                       100,
-                      MmapOptions(mmap_chunk_manager, true, false));
+                      MmapOptions(mmap_dir, true, false));
         ExpectMappingValues(mapping, expected_l2p, expected_p2l);
         ExpectStorageMode(mapping, true, false, false, true);
         ExpectMmapBlockFiles(mmap_root, {2 * sizeof(int32_t)});
@@ -366,11 +366,11 @@ TEST(OffsetMapping, BuildMapModeOnSparse) {
 
     {
         const auto mmap_root = MakeMmapRoot("sparse_o2i");
-        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        auto mmap_dir = mmap_root;
         SealedOffsetMapping mapping;
         mapping.Build(reinterpret_cast<const bool*>(valid.data()),
                       100,
-                      MmapOptions(mmap_chunk_manager, false, true));
+                      MmapOptions(mmap_dir, false, true));
         ExpectMappingValues(mapping, expected_l2p, expected_p2l);
         ExpectStorageMode(mapping, false, true, true, false);
         ExpectMmapBlockFiles(mmap_root, {100 * sizeof(int32_t)});
@@ -390,11 +390,11 @@ TEST(OffsetMapping, BuildAllValid) {
 
     {
         const auto mmap_root = MakeMmapRoot("all_valid");
-        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        auto mmap_dir = mmap_root;
         SealedOffsetMapping mapping;
         mapping.Build(reinterpret_cast<const bool*>(valid.data()),
                       4,
-                      MmapOptions(mmap_chunk_manager));
+                      MmapOptions(mmap_dir));
         ExpectMappingValues(mapping, expected, expected);
         ExpectStorageMode(mapping, true, true, false, false);
         ExpectMmapBlockFiles(mmap_root,
@@ -417,11 +417,11 @@ TEST(OffsetMapping, BuildAllNull) {
 
     {
         const auto mmap_root = MakeMmapRoot("all_null");
-        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        auto mmap_dir = mmap_root;
         SealedOffsetMapping mapping;
         mapping.Build(reinterpret_cast<const bool*>(valid.data()),
                       4,
-                      MmapOptions(mmap_chunk_manager));
+                      MmapOptions(mmap_dir));
         ExpectMappingValues(mapping, expected_l2p, expected_p2l);
         ExpectStorageMode(mapping, false, true, false, false);
         EXPECT_EQ(mapping.GetLogicalOffset(0), -1);
@@ -440,11 +440,11 @@ TEST(OffsetMapping, TransformOperationsMatchBuildMode) {
 
     {
         const auto mmap_root = MakeMmapRoot("transform");
-        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        auto mmap_dir = mmap_root;
         SealedOffsetMapping mapping;
         mapping.Build(reinterpret_cast<const bool*>(valid.data()),
                       5,
-                      MmapOptions(mmap_chunk_manager));
+                      MmapOptions(mmap_dir));
         ExpectTransformOperations(mapping);
     }
 }
@@ -462,17 +462,17 @@ TEST(OffsetMapping, BuildNoopOnNullOrZero) {
 
     {
         const auto mmap_root = MakeMmapRoot("noop");
-        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        auto mmap_dir = mmap_root;
         SealedOffsetMapping mapping;
         auto valid = ToBoolBytes(MakeValid({1, 0, 1, 1, 0}));
 
         mapping.Build(reinterpret_cast<const bool*>(valid.data()),
                       5,
-                      MmapOptions(mmap_chunk_manager));
+                      MmapOptions(mmap_dir));
         EXPECT_TRUE(mapping.IsEnabled());
         EXPECT_TRUE(mapping.IsMmap());
 
-        mapping.Build(nullptr, 100, MmapOptions(mmap_chunk_manager));
+        mapping.Build(nullptr, 100, MmapOptions(mmap_dir));
         EXPECT_FALSE(mapping.IsEnabled());
         EXPECT_FALSE(mapping.IsMmap());
         EXPECT_FALSE(mapping.IsUsingMap());
@@ -480,7 +480,7 @@ TEST(OffsetMapping, BuildNoopOnNullOrZero) {
 
         mapping.Build(reinterpret_cast<const bool*>(valid.data()),
                       0,
-                      MmapOptions(mmap_chunk_manager));
+                      MmapOptions(mmap_dir));
         EXPECT_FALSE(mapping.IsEnabled());
         EXPECT_FALSE(mapping.IsMmap());
         EXPECT_FALSE(mapping.IsUsingMap());
@@ -508,11 +508,10 @@ TEST(OffsetMapping, BuildTwiceResetsState) {
 
     {
         const auto mmap_root = MakeMmapRoot("build_twice");
-        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        auto mmap_dir = mmap_root;
         SealedOffsetMapping mapping;
-        mapping.Build(reinterpret_cast<const bool*>(v1.data()),
-                      5,
-                      MmapOptions(mmap_chunk_manager));
+        mapping.Build(
+            reinterpret_cast<const bool*>(v1.data()), 5, MmapOptions(mmap_dir));
         EXPECT_TRUE(mapping.IsMmap());
 
         mapping.Build(reinterpret_cast<const bool*>(v2.data()), 3);
@@ -562,6 +561,31 @@ TEST(OffsetMapping, OffsetMappingMmapDirUsesDedicatedIndexSubdirectory) {
               std::filesystem::path(local_index_prefix));
 }
 
+TEST(OffsetMapping, FileBackedMmapDoesNotResetMmapChunkManagerAccounting) {
+    const auto manager_root = MakeMmapRoot("accounting_manager");
+    auto mmap_chunk_manager = MakeMmapChunkManager(manager_root);
+    auto descriptor = mmap_chunk_manager->Register();
+    mmap_chunk_manager->Allocate(descriptor, sizeof(int32_t));
+    const auto allocated_size = mmap_chunk_manager->GetDiskAllocSize();
+    ASSERT_GT(allocated_size, 0);
+
+    auto valid = ToBoolBytes(MakeValid({1, 0, 1, 1, 0}));
+    const auto mmap_root = MakeMmapRoot("accounting_mapping");
+    auto mmap_dir = mmap_root;
+    {
+        SealedOffsetMapping mapping;
+        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
+                      5,
+                      MmapOptions(mmap_dir));
+        EXPECT_TRUE(mapping.IsMmap());
+        ExpectMmapBlockFiles(mmap_root,
+                             {3 * sizeof(int32_t), 5 * sizeof(int32_t)});
+        EXPECT_EQ(mmap_chunk_manager->GetDiskAllocSize(), allocated_size);
+    }
+
+    EXPECT_EQ(mmap_chunk_manager->GetDiskAllocSize(), allocated_size);
+}
+
 TEST(OffsetMapping, NeedOffsetMappingMmapMatchesDirectionSizes) {
     OffsetMappingBuildOptions options;
     EXPECT_FALSE(index::NeedOffsetMappingMmap(options, 10, 5));
@@ -593,10 +617,10 @@ TEST(OffsetMapping, ValidDataHelpersPreserveMappingValuesWithMmapOptions) {
 
     {
         const auto mmap_root = MakeMmapRoot("bitmap_helper");
-        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        auto mmap_dir = mmap_root;
         TestVectorIndex vector_index;
         index::BuildValidDataFromBitmap(
-            &vector_index, 5, bitmap.data(), MmapOptions(mmap_chunk_manager));
+            &vector_index, 5, bitmap.data(), MmapOptions(mmap_dir));
         const auto* mapping = dynamic_cast<const SealedOffsetMapping*>(
             &vector_index.GetOffsetMapping());
         ASSERT_NE(mapping, nullptr);
@@ -627,10 +651,10 @@ TEST(OffsetMapping, LoadValidDataFromBinarySetUsesProvidedMmapOptions) {
 
     {
         const auto mmap_root = MakeMmapRoot("binary_set_helper");
-        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        auto mmap_dir = mmap_root;
         TestVectorIndex vector_index;
         ASSERT_TRUE(index::LoadValidDataFromBinarySet(
-            binary_set, &vector_index, MmapOptions(mmap_chunk_manager)));
+            binary_set, &vector_index, MmapOptions(mmap_dir)));
         const auto* mapping = dynamic_cast<const SealedOffsetMapping*>(
             &vector_index.GetOffsetMapping());
         ASSERT_NE(mapping, nullptr);
@@ -702,11 +726,10 @@ TEST(OffsetMapping, IsValidMatchesPhysicalOffsetSign) {
 
     {
         const auto mmap_root = MakeMmapRoot("is_valid");
-        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        auto mmap_dir = mmap_root;
         SealedOffsetMapping mapping;
-        mapping.Build(reinterpret_cast<const bool*>(v.data()),
-                      4,
-                      MmapOptions(mmap_chunk_manager));
+        mapping.Build(
+            reinterpret_cast<const bool*>(v.data()), 4, MmapOptions(mmap_dir));
         EXPECT_TRUE(mapping.IsValid(0));
         EXPECT_FALSE(mapping.IsValid(1));
         EXPECT_TRUE(mapping.IsValid(2));
@@ -728,11 +751,10 @@ TEST(OffsetMapping, OutOfBoundsReturnsMinusOne) {
 
     {
         const auto mmap_root = MakeMmapRoot("out_of_bounds");
-        auto mmap_chunk_manager = MakeMmapChunkManager(mmap_root);
+        auto mmap_dir = mmap_root;
         SealedOffsetMapping mapping;
-        mapping.Build(reinterpret_cast<const bool*>(v.data()),
-                      3,
-                      MmapOptions(mmap_chunk_manager));
+        mapping.Build(
+            reinterpret_cast<const bool*>(v.data()), 3, MmapOptions(mmap_dir));
         EXPECT_EQ(mapping.GetPhysicalOffset(99), -1);
         EXPECT_EQ(mapping.GetLogicalOffset(99), -1);
     }

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -124,6 +124,39 @@ SortLegacyAuxBytes(int64_t num_rows) {
 }
 
 uint64_t
+SaturatingAdd(uint64_t lhs, uint64_t rhs) {
+    if (lhs > std::numeric_limits<uint64_t>::max() - rhs) {
+        return std::numeric_limits<uint64_t>::max();
+    }
+    return lhs + rhs;
+}
+
+uint64_t
+SaturatingMul(uint64_t lhs, uint64_t rhs) {
+    if (lhs != 0 && rhs > std::numeric_limits<uint64_t>::max() / lhs) {
+        return std::numeric_limits<uint64_t>::max();
+    }
+    return lhs * rhs;
+}
+
+uint64_t
+OffsetMappingMmapDiskCost(const Config& config, int64_t num_rows) {
+    if (num_rows <= 0) {
+        return 0;
+    }
+
+    const auto enable_mmap_o2i =
+        GetValueFromConfig<bool>(config, ENABLE_MMAP_O2I_MAP).value_or(false);
+    const auto enable_mmap_i2o =
+        GetValueFromConfig<bool>(config, ENABLE_MMAP_I2O_MAP).value_or(false);
+    if (!enable_mmap_o2i && !enable_mmap_i2o) {
+        return 0;
+    }
+
+    return SaturatingMul(static_cast<uint64_t>(num_rows), sizeof(int32_t));
+}
+
+uint64_t
 MarisaLegacyCsrBytes(int64_t num_rows, uint64_t arrays_per_row) {
     if (num_rows <= 0) {
         return 0;
@@ -554,6 +587,14 @@ IndexFactory::VecIndexLoadResource(
     } else {
         request.max_disk_cost = 0;
         request.max_memory_cost = 2 * res.memoryCost;
+    }
+    if (knowhere::UseDiskLoad(index_type, index_version)) {
+        const auto offset_mapping_disk_cost =
+            OffsetMappingMmapDiskCost(config, num_rows);
+        request.final_disk_cost =
+            SaturatingAdd(request.final_disk_cost, offset_mapping_disk_cost);
+        request.max_disk_cost =
+            SaturatingAdd(request.max_disk_cost, offset_mapping_disk_cost);
     }
     return request;
 }

--- a/internal/core/src/index/Meta.h
+++ b/internal/core/src/index/Meta.h
@@ -81,6 +81,8 @@ constexpr const char* HYBRID_HIGH_CARDINALITY_INDEX_TYPE =
 // index config key
 constexpr const char* MMAP_FILE_PATH = "mmap_filepath";
 constexpr const char* ENABLE_MMAP = "enable_mmap";
+constexpr const char* ENABLE_MMAP_I2O_MAP = "enable_mmap_i2o_map";
+constexpr const char* ENABLE_MMAP_O2I_MAP = "enable_mmap_o2i_map";
 constexpr const char* WARMUP = "warmup";
 constexpr const char* INDEX_FILES = "index_files";
 constexpr const char* INDEX_SIZE = "index_size";

--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -23,6 +23,7 @@
 #include <cstdlib>
 #include <exception>
 #include <iosfwd>
+#include <memory>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -54,6 +55,7 @@
 #include "pb/common.pb.h"
 #include "storage/LocalChunkManager.h"
 #include "storage/LocalChunkManagerSingleton.h"
+#include "storage/MmapManager.h"
 #include "storage/ThreadPools.h"
 #include "storage/Types.h"
 #include "storage/Util.h"
@@ -374,8 +376,22 @@ VectorDiskAnnIndex<T>::Load(milvus::tracer::TraceContext ctx,
     }
 
     if (disk_valid_data.found) {
-        BuildValidDataFromBitmap(
-            this, disk_valid_data.total_count, disk_valid_data.bitmap.data());
+        auto offset_mapping_options = GetOffsetMappingMmapOptions(load_config);
+        if (NeedOffsetMappingMmap(offset_mapping_options,
+                                  disk_valid_data.total_count,
+                                  disk_valid_data.valid_count)) {
+            const auto& mmap_config =
+                storage::MmapManager::GetInstance().GetMmapConfig();
+            offset_mapping_options.mmap_chunk_manager =
+                std::make_shared<storage::MmapChunkManager>(
+                    GetOffsetMappingMmapDir(local_index_path_prefix),
+                    mmap_config.disk_limit,
+                    mmap_config.fix_file_size);
+        }
+        BuildValidDataFromBitmap(this,
+                                 disk_valid_data.total_count,
+                                 disk_valid_data.bitmap.data(),
+                                 offset_mapping_options);
     }
 }
 

--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -55,7 +55,6 @@
 #include "pb/common.pb.h"
 #include "storage/LocalChunkManager.h"
 #include "storage/LocalChunkManagerSingleton.h"
-#include "storage/MmapManager.h"
 #include "storage/ThreadPools.h"
 #include "storage/Types.h"
 #include "storage/Util.h"
@@ -377,17 +376,8 @@ VectorDiskAnnIndex<T>::Load(milvus::tracer::TraceContext ctx,
 
     if (disk_valid_data.found) {
         auto offset_mapping_options = GetOffsetMappingMmapOptions(load_config);
-        if (NeedOffsetMappingMmap(offset_mapping_options,
-                                  disk_valid_data.total_count,
-                                  disk_valid_data.valid_count)) {
-            const auto& mmap_config =
-                storage::MmapManager::GetInstance().GetMmapConfig();
-            offset_mapping_options.mmap_chunk_manager =
-                std::make_shared<storage::MmapChunkManager>(
-                    GetOffsetMappingMmapDir(local_index_path_prefix),
-                    mmap_config.disk_limit,
-                    mmap_config.fix_file_size);
-        }
+        offset_mapping_options.mmap_dir_path =
+            GetOffsetMappingMmapDir(local_index_path_prefix);
         BuildValidDataFromBitmap(this,
                                  disk_valid_data.total_count,
                                  disk_valid_data.bitmap.data(),

--- a/internal/core/src/index/VectorIndex.h
+++ b/internal/core/src/index/VectorIndex.h
@@ -197,9 +197,11 @@ class VectorIndex : public IndexBase {
     }
 
     void
-    BuildValidData(const bool* valid_data, int64_t total_count) {
+    BuildValidData(const bool* valid_data,
+                   int64_t total_count,
+                   const milvus::OffsetMappingBuildOptions& options = {}) {
         auto sealed_mapping = std::make_unique<milvus::SealedOffsetMapping>();
-        sealed_mapping->Build(valid_data, total_count);
+        sealed_mapping->Build(valid_data, total_count, options);
         offset_mapping_ = std::move(sealed_mapping);
     }
 

--- a/internal/core/src/index/VectorIndexValidDataUtils.h
+++ b/internal/core/src/index/VectorIndexValidDataUtils.h
@@ -18,16 +18,19 @@
 
 #include <algorithm>
 #include <cstddef>
-#include "common/FastMem.h"
 #include <cstdint>
 #include <cstring>
+#include <filesystem>
 #include <limits>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include "common/EasyAssert.h"
+#include "common/FastMem.h"
 #include "common/OffsetMapping.h"
+#include "index/Meta.h"
+#include "index/Utils.h"
 #include "index/VectorIndex.h"
 
 namespace milvus::index {
@@ -124,6 +127,33 @@ CountValidDataBitmap(size_t count, const uint8_t* bitmap) {
     return valid_count;
 }
 
+inline constexpr const char* OFFSET_MAPPING_MMAP_DIR = "id_mapping_mmap";
+
+inline std::string
+GetOffsetMappingMmapDir(const std::string& local_index_path_prefix) {
+    return (std::filesystem::path(local_index_path_prefix) /
+            OFFSET_MAPPING_MMAP_DIR)
+        .string();
+}
+
+inline bool
+NeedOffsetMappingMmap(const OffsetMappingBuildOptions& options,
+                      size_t total_count,
+                      size_t valid_count) {
+    return (options.enable_mmap_o2i_map && total_count > 0) ||
+           (options.enable_mmap_i2o_map && valid_count > 0);
+}
+
+inline OffsetMappingBuildOptions
+GetOffsetMappingMmapOptions(const Config& config) {
+    OffsetMappingBuildOptions options;
+    options.enable_mmap_i2o_map =
+        GetValueFromConfig<bool>(config, ENABLE_MMAP_I2O_MAP).value_or(false);
+    options.enable_mmap_o2i_map =
+        GetValueFromConfig<bool>(config, ENABLE_MMAP_O2I_MAP).value_or(false);
+    return options;
+}
+
 inline std::vector<uint8_t>
 PackValidDataBitmap(const OffsetMapping& offset_mapping) {
     auto count = static_cast<size_t>(offset_mapping.GetTotalCount());
@@ -139,12 +169,13 @@ PackValidDataBitmap(const OffsetMapping& offset_mapping) {
 inline void
 BuildValidDataFromBitmap(VectorIndex* vector_index,
                          size_t count,
-                         const uint8_t* bitmap) {
+                         const uint8_t* bitmap,
+                         const OffsetMappingBuildOptions& options = {}) {
     std::unique_ptr<bool[]> valid_data(new bool[count]);
     for (size_t i = 0; i < count; ++i) {
         valid_data[i] = (bitmap[i / 8] >> (i % 8)) & 1;
     }
-    vector_index->BuildValidData(valid_data.get(), count);
+    vector_index->BuildValidData(valid_data.get(), count, options);
 }
 
 inline void
@@ -171,7 +202,8 @@ AppendValidDataToBinarySet(const OffsetMapping& offset_mapping,
 
 inline bool
 LoadValidDataFromBinarySet(const BinarySet& binary_set,
-                           VectorIndex* vector_index) {
+                           VectorIndex* vector_index,
+                           const OffsetMappingBuildOptions& options = {}) {
     bool has_count = binary_set.Contains(VALID_DATA_COUNT_KEY);
     bool has_data = binary_set.Contains(VALID_DATA_KEY);
     if (!has_count && !has_data) {
@@ -192,7 +224,8 @@ LoadValidDataFromBinarySet(const BinarySet& binary_set,
     AssertInfo(
         data_ptr != nullptr && data_ptr->size >= GetValidDataBitmapSize(count),
         "nullable vector index valid_data bitmap file is invalid");
-    BuildValidDataFromBitmap(vector_index, count, data_ptr->data.get());
+    BuildValidDataFromBitmap(
+        vector_index, count, data_ptr->data.get(), options);
     return true;
 }
 

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -214,7 +214,8 @@ class ChunkedColumnInterface {
     }
 
     virtual void
-    BuildValidRowIds(milvus::OpContext* op_ctx) {
+    BuildValidRowIds(milvus::OpContext* op_ctx,
+                     const OffsetMappingBuildOptions& options = {}) {
         if (!IsNullable()) {
             return;
         }
@@ -253,15 +254,16 @@ class ChunkedColumnInterface {
             num_valid_rows_until_chunk_.push_back(
                 num_valid_rows_until_chunk_.back() + valid_count_per_chunk_[i]);
         }
-        BuildOffsetMapping();
+        BuildOffsetMapping(options);
         valid_row_ids_built_.store(true, std::memory_order_release);
     }
 
     // Build offset mapping from valid_data
     void
-    BuildOffsetMapping() {
+    BuildOffsetMapping(const OffsetMappingBuildOptions& options = {}) {
         if (!valid_data_.empty()) {
-            offset_mapping_.Build(valid_data_.data(), valid_data_.size());
+            offset_mapping_.Build(
+                valid_data_.data(), valid_data_.size(), options);
         }
     }
 

--- a/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
@@ -17,10 +17,13 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <chrono>
 #include <cstring>
+#include <filesystem>
 #include <iterator>
 #include <memory>
 #include <set>
+#include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -29,6 +32,7 @@
 #include "common/GroupChunk.h"
 #include "mmap/ChunkedColumn.h"
 #include "mmap/ChunkedColumnGroup.h"
+#include "storage/MmapChunkManager.h"
 #include "test_utils/cachinglayer_test_utils.h"
 
 namespace milvus {
@@ -39,6 +43,20 @@ constexpr int64_t kTestFieldId = 1;
 constexpr int64_t kVectorArrayFieldId = 2;
 constexpr int64_t kVectorArrayRows = 4;
 constexpr int64_t kVectorArrayDim = 2;
+
+std::filesystem::path
+MakeMmapRoot(const std::string& test_name) {
+    return std::filesystem::temp_directory_path() /
+           ("milvus_chunked_column_" + test_name + "_" +
+            std::to_string(
+                std::chrono::steady_clock::now().time_since_epoch().count()));
+}
+
+storage::MmapChunkManagerPtr
+MakeMmapChunkManager(const std::filesystem::path& mmap_root) {
+    return std::make_shared<storage::MmapChunkManager>(
+        mmap_root.string(), 64 * 1024 * 1024, 4 * 1024);
+}
 
 struct ColumnFixture {
     std::shared_ptr<ChunkedColumnInterface> column;
@@ -357,33 +375,48 @@ TYPED_TEST(ChunkedColumnInterfaceTest, BuildValidRowIdsBuildsFullMapping) {
                      {false, false, false},
                      {true, true, true, true}},
                     true};
-    auto fx = TypeParam::Create(spec);
 
-    EXPECT_TRUE(fx.fetched->empty());
+    auto run_case = [&](bool enable_mmap) {
+        auto fx = TypeParam::Create(spec);
+        EXPECT_TRUE(fx.fetched->empty());
 
-    fx.column->BuildValidRowIds(nullptr);
-    EXPECT_EQ(fx.fetched->size(), 3u);
-    EXPECT_EQ(fx.fetched->count(0), 1u);
-    EXPECT_EQ(fx.fetched->count(1), 1u);
-    EXPECT_EQ(fx.fetched->count(2), 1u);
+        OffsetMappingBuildOptions options;
+        options.enable_mmap_i2o_map = enable_mmap;
+        options.enable_mmap_o2i_map = enable_mmap;
+        storage::MmapChunkManagerPtr mmap_chunk_manager;
+        if (enable_mmap) {
+            mmap_chunk_manager =
+                MakeMmapChunkManager(MakeMmapRoot("valid_row_ids"));
+            options.mmap_chunk_manager = mmap_chunk_manager;
+        }
+        fx.column->BuildValidRowIds(nullptr, options);
+        EXPECT_EQ(fx.fetched->size(), 3u);
+        EXPECT_EQ(fx.fetched->count(0), 1u);
+        EXPECT_EQ(fx.fetched->count(1), 1u);
+        EXPECT_EQ(fx.fetched->count(2), 1u);
 
-    EXPECT_EQ(fx.column->GetValidCountInChunk(0), 3);
-    EXPECT_EQ(fx.column->GetValidCountInChunk(1), 0);
-    EXPECT_EQ(fx.column->GetValidCountInChunk(2), 4);
+        EXPECT_EQ(fx.column->GetValidCountInChunk(0), 3);
+        EXPECT_EQ(fx.column->GetValidCountInChunk(1), 0);
+        EXPECT_EQ(fx.column->GetValidCountInChunk(2), 4);
 
-    const auto& m = fx.column->GetOffsetMapping();
-    EXPECT_TRUE(m.IsEnabled());
-    EXPECT_EQ(m.GetTotalCount(), 12);
-    EXPECT_EQ(m.GetValidCount(), 7);
-    EXPECT_EQ(m.GetPhysicalOffset(0), 0);
-    EXPECT_EQ(m.GetPhysicalOffset(2), 1);
-    EXPECT_EQ(m.GetPhysicalOffset(3), 2);
-    EXPECT_EQ(m.GetPhysicalOffset(1), -1);
-    EXPECT_EQ(m.GetPhysicalOffset(4), -1);
-    EXPECT_EQ(m.GetPhysicalOffset(8), 3);
-    EXPECT_EQ(m.GetPhysicalOffset(9), 4);
-    EXPECT_EQ(m.GetPhysicalOffset(10), 5);
-    EXPECT_EQ(m.GetPhysicalOffset(11), 6);
+        const auto& m = fx.column->GetOffsetMapping();
+        EXPECT_TRUE(m.IsEnabled());
+        EXPECT_EQ(m.IsMmap(), enable_mmap);
+        EXPECT_EQ(m.GetTotalCount(), 12);
+        EXPECT_EQ(m.GetValidCount(), 7);
+        EXPECT_EQ(m.GetPhysicalOffset(0), 0);
+        EXPECT_EQ(m.GetPhysicalOffset(2), 1);
+        EXPECT_EQ(m.GetPhysicalOffset(3), 2);
+        EXPECT_EQ(m.GetPhysicalOffset(1), -1);
+        EXPECT_EQ(m.GetPhysicalOffset(4), -1);
+        EXPECT_EQ(m.GetPhysicalOffset(8), 3);
+        EXPECT_EQ(m.GetPhysicalOffset(9), 4);
+        EXPECT_EQ(m.GetPhysicalOffset(10), 5);
+        EXPECT_EQ(m.GetPhysicalOffset(11), 6);
+    };
+
+    run_case(false);
+    run_case(true);
 }
 
 TYPED_TEST(ChunkedColumnInterfaceTest, CellsLoadedDoesNotFetchCells) {

--- a/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
@@ -32,7 +32,6 @@
 #include "common/GroupChunk.h"
 #include "mmap/ChunkedColumn.h"
 #include "mmap/ChunkedColumnGroup.h"
-#include "storage/MmapChunkManager.h"
 #include "test_utils/cachinglayer_test_utils.h"
 
 namespace milvus {
@@ -50,12 +49,6 @@ MakeMmapRoot(const std::string& test_name) {
            ("milvus_chunked_column_" + test_name + "_" +
             std::to_string(
                 std::chrono::steady_clock::now().time_since_epoch().count()));
-}
-
-storage::MmapChunkManagerPtr
-MakeMmapChunkManager(const std::filesystem::path& mmap_root) {
-    return std::make_shared<storage::MmapChunkManager>(
-        mmap_root.string(), 64 * 1024 * 1024, 4 * 1024);
 }
 
 struct ColumnFixture {
@@ -383,11 +376,8 @@ TYPED_TEST(ChunkedColumnInterfaceTest, BuildValidRowIdsBuildsFullMapping) {
         OffsetMappingBuildOptions options;
         options.enable_mmap_i2o_map = enable_mmap;
         options.enable_mmap_o2i_map = enable_mmap;
-        storage::MmapChunkManagerPtr mmap_chunk_manager;
         if (enable_mmap) {
-            mmap_chunk_manager =
-                MakeMmapChunkManager(MakeMmapRoot("valid_row_ids"));
-            options.mmap_chunk_manager = mmap_chunk_manager;
+            options.mmap_dir_path = MakeMmapRoot("valid_row_ids").string();
         }
         fx.column->BuildValidRowIds(nullptr, options);
         EXPECT_EQ(fx.fetched->size(), 3u);

--- a/internal/core/src/storage/DiskFileManagerTest.cpp
+++ b/internal/core/src/storage/DiskFileManagerTest.cpp
@@ -24,6 +24,7 @@
 #include <chrono>
 #include <cstdint>
 #include <exception>
+#include <fstream>
 #include <future>
 #include <initializer_list>
 #include <iostream>
@@ -112,6 +113,48 @@ class DiskAnnFileManagerTest : public testing::Test {
     ChunkManagerPtr cm_;
     milvus_storage::ArrowFileSystemPtr fs_;
 };
+
+namespace {
+
+std::string
+GeneratedIndexIdentifierPrefixForTest(const IndexMeta& index_meta) {
+    return std::to_string(index_meta.build_id) + "_" +
+           std::to_string(index_meta.index_version) + "_" +
+           std::to_string(index_meta.segment_id) + "_" +
+           std::to_string(index_meta.field_id) + "_";
+}
+
+std::vector<std::string>
+CollectOffsetMappingMmapFiles(const std::string& root_path,
+                              const IndexMeta& index_meta) {
+    std::vector<std::string> files;
+    boost::filesystem::path root(root_path);
+    if (!boost::filesystem::exists(root)) {
+        return files;
+    }
+
+    const auto index_identifier =
+        GeneratedIndexIdentifierPrefixForTest(index_meta);
+    for (boost::filesystem::recursive_directory_iterator it(root), end;
+         it != end;
+         ++it) {
+        const auto& path = it->path();
+        if (!boost::filesystem::is_regular_file(path)) {
+            continue;
+        }
+        if (path.string().find(index_identifier) == std::string::npos) {
+            continue;
+        }
+        if (path.parent_path().filename().string() ==
+            milvus::index::OFFSET_MAPPING_MMAP_DIR) {
+            files.emplace_back(path.string());
+        }
+    }
+    std::sort(files.begin(), files.end());
+    return files;
+}
+
+}  // namespace
 
 TEST_F(DiskAnnFileManagerTest, AddFilePositiveParallel) {
     auto lcm = LocalChunkManagerSingleton::GetInstance().GetChunkManager();
@@ -1714,6 +1757,47 @@ TEST_F(DiskAnnFileManagerTest, LoadAllNullNullableDiskVectorIndexFromDataset) {
     ASSERT_EQ(files.size(), 1);
     EXPECT_NE(files[0].find(milvus::index::VALID_DATA_KEY), std::string::npos);
 
+    milvus::Config load_config;
+    load_config[DIM_KEY] = dim;
+    load_config[milvus::index::DISK_ANN_LOAD_THREAD_NUM] = "1";
+    load_config["index_files"] = files;
+
+    auto local_chunk_manager =
+        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+    const auto mmap_file_count_before_load =
+        CollectOffsetMappingMmapFiles(local_chunk_manager->GetRootPath(),
+                                      index_meta)
+            .size();
+
+    {
+        auto generic_mmap_load_config = load_config;
+        generic_mmap_load_config[milvus::index::ENABLE_MMAP] = true;
+
+        milvus::index::VectorDiskAnnIndex<float> loaded_index(
+            DataType::NONE,
+            knowhere::IndexEnum::INDEX_DISKANN,
+            knowhere::metric::L2,
+            knowhere::Version::GetCurrentVersion().VersionNumber(),
+            file_manager_context);
+
+        loaded_index.Load(milvus::tracer::TraceContext{},
+                          generic_mmap_load_config);
+        ASSERT_TRUE(loaded_index.GetOffsetMapping().IsEnabled());
+        EXPECT_FALSE(loaded_index.GetOffsetMapping().IsMmap());
+        EXPECT_EQ(loaded_index.GetOffsetMapping().GetTotalCount(), num_rows);
+        EXPECT_EQ(loaded_index.GetOffsetMapping().GetValidCount(), 0);
+        EXPECT_EQ(loaded_index.GetDim(), dim);
+    }
+
+    EXPECT_EQ(CollectOffsetMappingMmapFiles(local_chunk_manager->GetRootPath(),
+                                            index_meta)
+                  .size(),
+              mmap_file_count_before_load);
+
+    auto offset_mapping_mmap_load_config = load_config;
+    offset_mapping_mmap_load_config[milvus::index::ENABLE_MMAP_I2O_MAP] = true;
+    offset_mapping_mmap_load_config[milvus::index::ENABLE_MMAP_O2I_MAP] = true;
+
     milvus::index::VectorDiskAnnIndex<float> loaded_index(
         DataType::NONE,
         knowhere::IndexEnum::INDEX_DISKANN,
@@ -1721,16 +1805,24 @@ TEST_F(DiskAnnFileManagerTest, LoadAllNullNullableDiskVectorIndexFromDataset) {
         knowhere::Version::GetCurrentVersion().VersionNumber(),
         file_manager_context);
 
-    milvus::Config load_config;
-    load_config[DIM_KEY] = dim;
-    load_config[milvus::index::DISK_ANN_LOAD_THREAD_NUM] = "1";
-    load_config["index_files"] = files;
-
-    loaded_index.Load(milvus::tracer::TraceContext{}, load_config);
-    ASSERT_TRUE(loaded_index.GetOffsetMapping().IsEnabled());
-    EXPECT_EQ(loaded_index.GetOffsetMapping().GetTotalCount(), num_rows);
-    EXPECT_EQ(loaded_index.GetOffsetMapping().GetValidCount(), 0);
+    loaded_index.Load(milvus::tracer::TraceContext{},
+                      offset_mapping_mmap_load_config);
+    const auto& offset_mapping = loaded_index.GetOffsetMapping();
+    ASSERT_TRUE(offset_mapping.IsEnabled());
+    EXPECT_TRUE(offset_mapping.IsMmap());
+    EXPECT_EQ(offset_mapping.GetTotalCount(), num_rows);
+    EXPECT_EQ(offset_mapping.GetValidCount(), 0);
     EXPECT_EQ(loaded_index.GetDim(), dim);
+
+    const auto* sealed_mapping =
+        dynamic_cast<const SealedOffsetMapping*>(&offset_mapping);
+    ASSERT_NE(sealed_mapping, nullptr);
+    EXPECT_FALSE(sealed_mapping->IsI2OMmap());
+    EXPECT_TRUE(sealed_mapping->IsO2IMmap());
+    EXPECT_EQ(CollectOffsetMappingMmapFiles(local_chunk_manager->GetRootPath(),
+                                            index_meta)
+                  .size(),
+              mmap_file_count_before_load + 1);
 
     for (const auto& file : files) {
         cm_->Remove(file);

--- a/internal/core/unittest/test_loading.cpp
+++ b/internal/core/unittest/test_loading.cpp
@@ -357,6 +357,77 @@ TEST(IndexLoadTest, LoadResourceRequestCacheIsOptional) {
     ASSERT_TRUE(loadIndexInfo.load_resource_request.has_value());
 }
 
+#ifdef BUILD_DISK_ANN
+TEST(IndexLoadTest, DiskAnnOffsetMappingMmapEstimateChargesDiskCost) {
+    constexpr uint64_t kIndexSize = 1024UL * 1024 * 1024;
+    constexpr int64_t kNumRows = 1025;
+    constexpr uint64_t kOffsetMappingMmapBytes =
+        static_cast<uint64_t>(kNumRows) * sizeof(int32_t);
+
+    auto make_load_info = [] {
+        milvus::segcore::LoadIndexInfo loadIndexInfo;
+        loadIndexInfo.collection_id = 1;
+        loadIndexInfo.partition_id = 2;
+        loadIndexInfo.segment_id = 3;
+        loadIndexInfo.field_id = 4;
+        loadIndexInfo.field_type = milvus::DataType::VECTOR_FLOAT;
+        loadIndexInfo.element_type = milvus::DataType::NONE;
+        loadIndexInfo.enable_mmap = false;
+        loadIndexInfo.index_id = 5;
+        loadIndexInfo.index_build_id = 6;
+        loadIndexInfo.index_version = 1;
+        loadIndexInfo.index_params = {
+            {"index_type", "DISKANN"},
+            {"metric_type", "L2"},
+            {"nlist", "1024"},
+        };
+        loadIndexInfo.index_files = {"/tmp/index/1"};
+        loadIndexInfo.index = nullptr;
+        loadIndexInfo.cache_index = nullptr;
+        loadIndexInfo.uri = "";
+        loadIndexInfo.index_engine_version =
+            knowhere::Version::GetCurrentVersion().VersionNumber();
+        loadIndexInfo.index_size = kIndexSize;
+        loadIndexInfo.num_rows = kNumRows;
+        return loadIndexInfo;
+    };
+
+    auto baseline_info = make_load_info();
+    auto baseline = EstimateLoadIndexResource(&baseline_info);
+
+    auto i2o_info = make_load_info();
+    i2o_info.index_params[milvus::index::ENABLE_MMAP_I2O_MAP] = "true";
+    auto i2o = EstimateLoadIndexResource(&i2o_info);
+    ASSERT_EQ(i2o.final_disk_cost,
+              baseline.final_disk_cost + kOffsetMappingMmapBytes);
+    ASSERT_EQ(i2o.max_disk_cost,
+              baseline.max_disk_cost + kOffsetMappingMmapBytes);
+    ASSERT_EQ(i2o.final_memory_cost, baseline.final_memory_cost);
+    ASSERT_EQ(i2o.max_memory_cost, baseline.max_memory_cost);
+
+    auto o2i_info = make_load_info();
+    o2i_info.index_params[milvus::index::ENABLE_MMAP_O2I_MAP] = "true";
+    auto o2i = EstimateLoadIndexResource(&o2i_info);
+    ASSERT_EQ(o2i.final_disk_cost,
+              baseline.final_disk_cost + kOffsetMappingMmapBytes);
+    ASSERT_EQ(o2i.max_disk_cost,
+              baseline.max_disk_cost + kOffsetMappingMmapBytes);
+    ASSERT_EQ(o2i.final_memory_cost, baseline.final_memory_cost);
+    ASSERT_EQ(o2i.max_memory_cost, baseline.max_memory_cost);
+
+    auto both_info = make_load_info();
+    both_info.index_params[milvus::index::ENABLE_MMAP_I2O_MAP] = "true";
+    both_info.index_params[milvus::index::ENABLE_MMAP_O2I_MAP] = "true";
+    auto both = EstimateLoadIndexResource(&both_info);
+    ASSERT_EQ(both.final_disk_cost,
+              baseline.final_disk_cost + kOffsetMappingMmapBytes);
+    ASSERT_EQ(both.max_disk_cost,
+              baseline.max_disk_cost + kOffsetMappingMmapBytes);
+    ASSERT_EQ(both.final_memory_cost, baseline.final_memory_cost);
+    ASSERT_EQ(both.max_memory_cost, baseline.max_memory_cost);
+}
+#endif
+
 TEST(IndexLoadTest, ScalarSortMmapEstimateReservesLegacyAux) {
     constexpr uint64_t kIndexSize = 1024UL * 1024 * 1024;
     constexpr int64_t kNumRows = 1025;


### PR DESCRIPTION
pr: #51817

Backport sealed offset mapping mmap support to 3.0.

This includes:
- dedicated i2o/o2i id mapping mmap load options
- index-local file-backed mmap files under id_mapping_mmap
- conservative disk load-resource accounting for idmap mmap

Validation:
- Not run per request.