### PR TITLE
fix: exclude uncommitted V3 manifests from snapshots

### DIFF
--- a/internal/datacoord/handler.go
+++ b/internal/datacoord/handler.go
@@ -33,6 +33,7 @@ import (
 	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
@@ -650,6 +651,22 @@ func (h *ServerHandler) GetSnapshotSeekPositions(ctx context.Context, collection
 	return positions, minTs, nil
 }
 
+// hasCommittedManifest reports whether a Storage V3 manifest references
+// committed files. ManifestEarliest is only the placeholder assigned to a new
+// Growing segment before its first manifest commit.
+func hasCommittedManifest(info *SegmentInfo) (bool, error) {
+	if info.GetStorageVersion() != storage.StorageV3 || info.GetManifestPath() == "" {
+		return false, nil
+	}
+
+	_, version, err := packed.UnmarshalManifestPath(info.GetManifestPath())
+	if err != nil {
+		return false, merr.WrapErrDataIntegrity(err,
+			"invalid manifest path for segment %d", info.GetID())
+	}
+	return version > packed.ManifestEarliest, nil
+}
+
 // GenSnapshot generates a point-in-time snapshot of a collection's data and metadata.
 //
 // This function captures a consistent view of a collection at a specific timestamp, including:
@@ -684,7 +701,7 @@ func (h *ServerHandler) GetSnapshotSeekPositions(ctx context.Context, collection
 //   - Collections with partition key: Include all partitions (filtering handled elsewhere)
 //
 // Segment selection criteria:
-// - Must have data (binlogs or deltalogs present)
+// - Must have data (binlogs, deltalogs, or a committed V3 manifest present)
 // - StartPosition timestamp < channel seek timestamp (data started before snapshot)
 // - State != Dropped (still valid)
 // - Not importing (stable segments only)
@@ -751,16 +768,21 @@ func (h *ServerHandler) GenSnapshot(ctx context.Context, collectionID UniqueID) 
 
 	// get segment info
 	candidateSegments := h.s.meta.SelectSegments(ctx, WithCollection(collectionID), SegmentFilterFunc(func(info *SegmentInfo) bool {
-		// A V3 segment persists its file paths in the LOON manifest, and after a
-		// DataCoord restart it reloads from etcd with empty Binlogs/Deltalogs
-		// arrays (AlterSegments skips the per-FieldBinlog KVs for V3). A non-empty
-		// ManifestPath therefore also means the segment has data; without this the
-		// snapshot silently drops restarted V3 segments and loses them on restore.
-		segmentHasData := len(info.GetBinlogs()) > 0 || len(info.GetDeltalogs()) > 0 || info.GetManifestPath() != ""
-		return segmentHasData && info.GetState() != commonpb.SegmentState_Dropped && !info.GetIsImporting()
+		return info.GetState() != commonpb.SegmentState_Dropped && !info.GetIsImporting()
 	}))
 	segments := make([]*SegmentInfo, 0, len(candidateSegments))
 	for _, info := range candidateSegments {
+		segmentHasData := len(info.GetBinlogs()) > 0 || len(info.GetDeltalogs()) > 0
+		if !segmentHasData {
+			segmentHasData, err = hasCommittedManifest(info)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if !segmentHasData {
+			continue
+		}
+
 		seekTs, ok := channelSeekTs[info.GetInsertChannel()]
 		if !ok {
 			return nil, merr.WrapErrServiceInternalMsg(

--- a/internal/datacoord/handler_test.go
+++ b/internal/datacoord/handler_test.go
@@ -2030,14 +2030,80 @@ func TestGenSnapshot_UsesPerChannelSeekPositions(t *testing.T) {
 	assert.Equal(t, "ch-2", snapshotData.Segments[0].GetChannelName())
 }
 
+func TestHasCommittedManifest(t *testing.T) {
+	tests := []struct {
+		name        string
+		segment     *SegmentInfo
+		expected    bool
+		expectedErr error
+	}{
+		{
+			name: "empty manifest path",
+			segment: NewSegmentInfo(&datapb.SegmentInfo{
+				StorageVersion: storage.StorageV3,
+			}),
+		},
+		{
+			name: "non-v3 manifest path",
+			segment: NewSegmentInfo(&datapb.SegmentInfo{
+				ManifestPath: packed.MarshalManifestPath("/data/segments/2000", 1),
+			}),
+		},
+		{
+			name: "earliest manifest",
+			segment: NewSegmentInfo(&datapb.SegmentInfo{
+				StorageVersion: storage.StorageV3,
+				ManifestPath:   packed.MarshalManifestPath("/data/segments/2001", packed.ManifestEarliest),
+			}),
+		},
+		{
+			name: "committed manifest version one",
+			segment: NewSegmentInfo(&datapb.SegmentInfo{
+				StorageVersion: storage.StorageV3,
+				ManifestPath:   packed.MarshalManifestPath("/data/segments/2002", 1),
+			}),
+			expected: true,
+		},
+		{
+			name: "committed manifest version three",
+			segment: NewSegmentInfo(&datapb.SegmentInfo{
+				StorageVersion: storage.StorageV3,
+				ManifestPath:   packed.MarshalManifestPath("/data/segments/2003", 3),
+			}),
+			expected: true,
+		},
+		{
+			name: "invalid manifest path",
+			segment: NewSegmentInfo(&datapb.SegmentInfo{
+				ID:             2004,
+				StorageVersion: storage.StorageV3,
+				ManifestPath:   "invalid",
+			}),
+			expectedErr: merr.ErrDataIntegrity,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := hasCommittedManifest(test.segment)
+			if test.expectedErr != nil {
+				require.ErrorIs(t, err, test.expectedErr)
+				assert.Contains(t, err.Error(), "invalid manifest path for segment 2004")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
 // TestGenSnapshot_IncludesV3ManifestOnlySegment guards the snapshot filter: a
 // V3 segment that reloaded from etcd with empty Binlogs/Deltalogs (per-field
-// KVs are not persisted for V3) but a non-empty ManifestPath still carries
-// data and must not be dropped from the snapshot. An empty segment with no
-// manifest is the negative control.
+// KVs are not persisted for V3) must be retained only after its manifest is
+// committed. A growing segment's earliest manifest is only a placeholder.
 func TestGenSnapshot_IncludesV3ManifestOnlySegment(t *testing.T) {
 	schema := newTestSchema()
-	// V3 segment: empty binlog arrays but a live manifest path — must be kept.
+	// Committed V3 manifest with empty legacy arrays must be kept.
 	manifestSeg := NewSegmentInfo(&datapb.SegmentInfo{
 		ID:             2001,
 		CollectionID:   200,
@@ -2049,9 +2115,21 @@ func TestGenSnapshot_IncludesV3ManifestOnlySegment(t *testing.T) {
 		StorageVersion: storage.StorageV3,
 		ManifestPath:   packed.MarshalManifestPath("/data/segments/2001", 3),
 	})
+	// A growing V3 segment only has an allocation placeholder and must be dropped.
+	growingSeg := NewSegmentInfo(&datapb.SegmentInfo{
+		ID:             2002,
+		CollectionID:   200,
+		PartitionID:    0,
+		InsertChannel:  "ch-1",
+		State:          commonpb.SegmentState_Growing,
+		StartPosition:  &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 500},
+		DmlPosition:    &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 600},
+		StorageVersion: storage.StorageV3,
+		ManifestPath:   packed.MarshalManifestPath("/data/segments/2002", packed.ManifestEarliest),
+	})
 	// Empty segment with no manifest — must be dropped.
 	emptySeg := NewSegmentInfo(&datapb.SegmentInfo{
-		ID:            2002,
+		ID:            2003,
 		CollectionID:  200,
 		PartitionID:   0,
 		InsertChannel: "ch-1",
@@ -2059,6 +2137,7 @@ func TestGenSnapshot_IncludesV3ManifestOnlySegment(t *testing.T) {
 		StartPosition: &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 500},
 		DmlPosition:   &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 600},
 	})
+	candidates := []*SegmentInfo{manifestSeg, growingSeg, emptySeg}
 
 	mockMeta := &meta{indexMeta: &indexMeta{}}
 	handler := &ServerHandler{
@@ -2108,7 +2187,6 @@ func TestGenSnapshot_IncludesV3ManifestOnlySegment(t *testing.T) {
 
 	mockSelectSegments := mockey.Mock((*meta).SelectSegments).To(
 		func(m *meta, ctx context.Context, filters ...SegmentFilter) []*SegmentInfo {
-			candidates := []*SegmentInfo{manifestSeg, emptySeg}
 			var result []*SegmentInfo
 			for _, seg := range candidates {
 				pass := true
@@ -2143,6 +2221,22 @@ func TestGenSnapshot_IncludesV3ManifestOnlySegment(t *testing.T) {
 	require.Len(t, snapshotData.Segments, 1)
 	assert.Equal(t, int64(2001), snapshotData.Segments[0].GetSegmentId())
 	assert.NotEmpty(t, snapshotData.Segments[0].GetManifestPath())
+
+	candidates = []*SegmentInfo{NewSegmentInfo(&datapb.SegmentInfo{
+		ID:             2004,
+		CollectionID:   200,
+		PartitionID:    0,
+		InsertChannel:  "ch-1",
+		State:          commonpb.SegmentState_Flushed,
+		StartPosition:  &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 500},
+		DmlPosition:    &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 600},
+		StorageVersion: storage.StorageV3,
+		ManifestPath:   "invalid",
+	})}
+	snapshotData, err = handler.GenSnapshot(context.Background(), 200)
+	assert.Nil(t, snapshotData)
+	require.ErrorIs(t, err, merr.ErrDataIntegrity)
+	assert.Contains(t, err.Error(), "invalid manifest path for segment 2004")
 }
 
 func TestGenSnapshot_RejectsSegmentWithoutChannelSeekPosition(t *testing.T) {


### PR DESCRIPTION
issue: #52043
pr: #50410

## What this PR does

Snapshot V2 used any non-empty `ManifestPath` as evidence that a segment
contains data. Storage V3 assigns a `ManifestEarliest` version 0 path as
soon as a Growing segment is allocated, before it has committed files.

That placeholder therefore passed snapshot selection and created a
`CopySegment` restore task for a segment with no insert or delete
binlogs.

This PR separates segment-state filtering from data-presence filtering:

- existing insert and delete binlog arrays continue to qualify a
  segment;
- manifest-only Storage V3 segments qualify only when their manifest
  version is greater than `ManifestEarliest`;
- version 0 placeholders are excluded before channel timestamp
  filtering;
- malformed persisted manifest paths return a data-integrity error.

## Behavior boundary

The change keeps committed manifest-only Storage V3 segments eligible,
including segments reloaded without legacy `FieldBinlog` arrays. It
only removes uncommitted placeholders from Snapshot V2.

It intentionally does not loosen `CopySegment` validation. The legal
Flushed manifest-only restore problem tracked by
[#51836](https://github.com/milvus-io/milvus/issues/51836) remains a
separate downstream case.

## Test coverage

The DataCoord regression coverage includes:

- Growing V3 + version 0 + no legacy binlogs: excluded;
- Flushed V3 + committed manifest + no legacy arrays: included;
- mixed committed, Growing placeholder, and empty segments: only the
  committed segment is snapshotted;
- malformed manifest metadata: reported as `ErrDataIntegrity`;
- legacy and non-V3 behavior: unchanged.

## Validation

Not run for this exact candidate because matching `check-commit`
evidence is unavailable.