### PR TITLE
fix: [2.6] redact sensitive configuration values

### DIFF
--- a/internal/coordinator/restful_mgr_routes.go
+++ b/internal/coordinator/restful_mgr_routes.go
@@ -1443,10 +1443,7 @@ func (s *mixCoordImpl) HandleGetConfig(writer http.ResponseWriter, request *http
 		if key == "" {
 			continue
 		}
-		// Redact sensitive config keys (passwords, secrets, tokens).
-		normalizedKey := strings.ToLower(key)
-		if strings.Contains(normalizedKey, "password") || strings.Contains(normalizedKey, "secret") ||
-			strings.Contains(normalizedKey, "token") || strings.Contains(normalizedKey, "credential") {
+		if paramMgr.IsSensitiveConfigKey(key) {
 			results = append(results, configResult{Key: key, Error: "access to sensitive config key is denied"})
 			continue
 		}

--- a/internal/coordinator/restful_mgr_routes_test.go
+++ b/internal/coordinator/restful_mgr_routes_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -309,6 +310,61 @@ func TestHandleGetConfig(t *testing.T) {
 	mgr.SetConfig("test.getconfig.key1", "val1")
 	mgr.SetConfig("test.getconfig.key2", "val2")
 	mgr.SetConfig("test.getconfig.key3", "val3")
+	realSensitiveKeys := []string{
+		"minio.accessKeyID",
+		"minio.secretAccessKey",
+		"minio.gcpCredentialJSON",
+		"credential.aksk1.access_key_id",
+		"credential.aksk1.secret_access_key",
+		"credential.apikey1.apikey",
+		"credential.gcp1.credential_json",
+		"cipherPlugin.kms.credentials.aws.roleARN",
+		"cipherPlugin.kms.credentials.aws.externalID",
+		"function.textEmbedding.providers.azure_openai.credential",
+		"function.textEmbedding.providers.bedrock.credential",
+		"function.textEmbedding.providers.cohere.credential",
+		"function.textEmbedding.providers.dashscope.credential",
+		"function.textEmbedding.providers.gemini.credential",
+		"function.textEmbedding.providers.huggingface.credential",
+		"function.textEmbedding.providers.openai.credential",
+		"function.textEmbedding.providers.siliconflow.credential",
+		"function.textEmbedding.providers.tei.credential",
+		"function.textEmbedding.providers.vertexai.credential",
+		"function.textEmbedding.providers.voyageai.credential",
+		"function.rerank.model.providers.cohere.credential",
+		"function.rerank.model.providers.huggingface.credential",
+		"function.rerank.model.providers.siliconflow.credential",
+		"function.rerank.model.providers.tei.credential",
+		"function.rerank.model.providers.vllm.credential",
+		"function.rerank.model.providers.voyageai.credential",
+		"etcd.auth.userName",
+		"etcd.auth.password",
+		"kafka.saslUsername",
+		"kafka.saslPassword",
+		"kafka.ssl.tlsKeyPassword",
+		"common.security.defaultRootPassword",
+		"pulsar.authParams",
+		"trace.otlp.headers",
+	}
+	dynamicSensitiveKeys := []string{
+		"dynamic/auth-token",
+		"dynamic.client-secret",
+		"dynamic.private-key-passphrase",
+		"dynamic.credential",
+	}
+	sensitiveKeys := append(realSensitiveKeys, dynamicSensitiveKeys...)
+	t.Cleanup(func() {
+		for _, key := range append([]string{
+			"test.getconfig.key1",
+			"test.getconfig.key2",
+			"test.getconfig.key3",
+		}, sensitiveKeys...) {
+			mgr.ResetConfig(key)
+		}
+	})
+	for _, key := range sensitiveKeys {
+		mgr.SetConfig(key, "plain-text-sensitive-value")
+	}
 
 	type configResult struct {
 		Key    string `json:"key"`
@@ -408,17 +464,24 @@ func TestHandleGetConfig(t *testing.T) {
 		assert.Contains(t, w.Body.String(), "keys")
 	})
 
-	t.Run("sensitive keys are redacted", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/management/config/get?keys=minio.secretAccessKey,test.getconfig.key1,etcd.auth.password", nil)
+	t.Run("sensitive keys are denied", func(t *testing.T) {
+		keys := append(append([]string{}, sensitiveKeys...), "test.getconfig.key1")
+		req := httptest.NewRequest(http.MethodGet, "/management/config/get?keys="+strings.Join(keys, ","), nil)
 		w := httptest.NewRecorder()
 		coord.HandleGetConfig(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		configs := parseResponse(t, w)
-		require.Len(t, configs, 3)
-		assert.Contains(t, configs[0].Error, "sensitive")
-		assert.Equal(t, "val1", configs[1].Value)
-		assert.Contains(t, configs[2].Error, "sensitive")
+		require.Len(t, configs, len(keys))
+		for i, key := range sensitiveKeys {
+			assert.Equal(t, key, configs[i].Key)
+			assert.Equal(t, "access to sensitive config key is denied", configs[i].Error)
+			assert.Empty(t, configs[i].Value)
+			assert.Empty(t, configs[i].Source)
+		}
+		assert.Equal(t, "test.getconfig.key1", configs[len(sensitiveKeys)].Key)
+		assert.Equal(t, "val1", configs[len(sensitiveKeys)].Value)
+		assert.Empty(t, configs[len(sensitiveKeys)].Error)
 	})
 
 	t.Run("all empty keys should fail", func(t *testing.T) {

--- a/internal/proxy/http_req_impl.go
+++ b/internal/proxy/http_req_impl.go
@@ -47,35 +47,9 @@ var (
 	httpDBName         = "db_name"
 	HTTPCollectionName = "collection_name"
 	UnknownData        = "unknown"
-	sensitiveMark      = "*****"
-	sensitiveKeys      = []string{
-		"secretaccesskey",
-		"secret_access_key",
-		"password",
-		"apikey",
-		"credentialjson",
-		"credential_json",
-	}
 )
 
-func hideSensitive(configs map[string]string) {
-	checkFunc := func(key string) bool {
-		for _, sensitive := range sensitiveKeys {
-			if strings.Contains(strings.ToLower(key), sensitive) {
-				return true
-			}
-		}
-		return false
-	}
-	for key := range configs {
-		if checkFunc(key) {
-			configs[key] = sensitiveMark
-		}
-	}
-}
-
 func getConfigs(configs map[string]string) gin.HandlerFunc {
-	hideSensitive(configs)
 	return func(c *gin.Context) {
 		bs, err := json.Marshal(configs)
 		if err != nil {

--- a/internal/proxy/http_req_impl_test.go
+++ b/internal/proxy/http_req_impl_test.go
@@ -21,48 +21,19 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
-func TestHideSensitive(t *testing.T) {
-	visibleConfigs := map[string]string{
-		"dummy":      "secretAccessKey",
-		"Foo":        "password",
-		"api":        "apikey",
-		"access":     "XXX",
-		"key":        "XXX",
-		"credential": "XXX",
+func TestGetConfigsOnlySerializesInput(t *testing.T) {
+	configs := map[string]string{
+		"minio.secretAccessKey": "caller-owned-value",
 	}
-	invisibleConfigs := map[string]string{
-		"MyPassword":                          "123456",
-		"your_secret_access_Key":              "ABCD",
-		"SECRETACCESSKEY2":                    "XXX",
-		"minio.secretAccessKey":               "secretAccessKey",
-		"common.security.defaultRootPassword": "milvus",
-		"credentialaksk1secretaccesskey":      "XXX",
-		"credential.aksk1.secret_access_key":  "XXX",
-		"credentialapikey1apikey":             "apikey",
-		"credential.apikey1.apikey":           "apikey",
-		"credentialgcp1credentialjson":        "credential",
-		"credential.gcp1.credentialjson":      "credential",
-	}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
 
-	copiedConfigs := make(map[string]string)
-	for k, v := range visibleConfigs {
-		copiedConfigs[k] = v
-	}
-	hideSensitive(copiedConfigs)
-	for k, v := range visibleConfigs {
-		assert.Contains(t, copiedConfigs, k)
-		assert.Equal(t, copiedConfigs[k], v)
-	}
+	handler := getConfigs(configs)
+	handler(c)
 
-	copiedConfigs = make(map[string]string)
-	for k, v := range invisibleConfigs {
-		copiedConfigs[k] = v
-	}
-	hideSensitive(copiedConfigs)
-	for k := range invisibleConfigs {
-		assert.Contains(t, copiedConfigs, k)
-		assert.Equal(t, copiedConfigs[k], sensitiveMark)
-	}
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "caller-owned-value", configs["minio.secretAccessKey"])
+	assert.JSONEq(t, `{"minio.secretAccessKey":"caller-owned-value"}`, w.Body.String())
 }
 
 func TestGetConfigs(t *testing.T) {

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -6717,7 +6717,7 @@ func (node *Proxy) RegisterRestRouter(router gin.IRouter) {
 	router.GET(http.ClusterDependenciesPath, getDependencies)
 
 	// Hook request that executed by proxy
-	router.GET(http.HookConfigsPath, getConfigs(paramtable.GetHookParams().GetAll()))
+	router.GET(http.HookConfigsPath, getConfigs(paramtable.GetHookParams().GetConfigsView()))
 
 	// Slow query request that executed by proxy
 	router.GET(http.SlowQueryPath, getSlowQuery(node))

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -33,7 +33,19 @@ import (
 const (
 	TombValue     = "TOMB_VAULE"
 	RuntimeSource = "RuntimeSource"
+	redactedValue = "*****"
 )
+
+var sensitiveConfigSubstrings = []string{
+	"password",
+	"passphrase",
+	"secret",
+	"token",
+	"credential",
+	"apikey",
+	"accesskey",
+	"username",
+}
 
 type Filter func(key string) (string, bool)
 
@@ -173,6 +185,32 @@ func (m *Manager) GetConfig(key string) (string, string, error) {
 	return sourceName, v, err
 }
 
+// IsSensitiveConfigKey returns whether a configuration value should be hidden from public views.
+func (m *Manager) IsSensitiveConfigKey(key string) bool {
+	normalizedKey := strings.NewReplacer("/", "", "_", "", ".", "", "-", "").Replace(strings.ToLower(key))
+	for _, substring := range sensitiveConfigSubstrings {
+		if strings.Contains(normalizedKey, substring) {
+			return true
+		}
+	}
+
+	switch normalizedKey {
+	case "pulsarauthparams", "traceotlpheaders":
+		return true
+	default:
+		return false
+	}
+}
+
+// RedactSensitiveConfigValues replaces sensitive values in configs with the public-view mask.
+func (m *Manager) RedactSensitiveConfigValues(configs map[string]string) {
+	for key := range configs {
+		if m.IsSensitiveConfigKey(key) {
+			configs[key] = redactedValue
+		}
+	}
+}
+
 // GetConfigs returns all the key values
 func (m *Manager) GetConfigs() map[string]string {
 	config := make(map[string]string)
@@ -217,6 +255,7 @@ func (m *Manager) GetConfigsView() map[string]string {
 		return true
 	})
 
+	m.RedactSensitiveConfigValues(config)
 	return config
 }
 

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -209,6 +209,108 @@ func TestGetConfigAndSource(t *testing.T) {
 	assert.Contains(t, v, RuntimeSource)
 }
 
+func TestIsSensitiveConfigKey(t *testing.T) {
+	mgr := NewManager()
+	sensitiveKeys := []string{
+		"password",
+		"passphrase",
+		"secret",
+		"token",
+		"credential",
+		"apiKey",
+		"accessKey",
+		"userName",
+		"pulsar.authParams",
+		"trace.otlp.headers",
+	}
+
+	for _, key := range sensitiveKeys {
+		t.Run(key, func(t *testing.T) {
+			assert.True(t, mgr.IsSensitiveConfigKey(key))
+		})
+	}
+}
+
+func TestGetConfigsViewRedactsSensitiveValues(t *testing.T) {
+	realSensitiveKeys := []string{
+		"minio.accessKeyID",
+		"minio.secretAccessKey",
+		"minio.gcpCredentialJSON",
+		"credential.aksk1.access_key_id",
+		"credential.aksk1.secret_access_key",
+		"credential.apikey1.apikey",
+		"credential.gcp1.credential_json",
+		"cipherPlugin.kms.credentials.aws.roleARN",
+		"cipherPlugin.kms.credentials.aws.externalID",
+		"function.textEmbedding.providers.azure_openai.credential",
+		"function.textEmbedding.providers.bedrock.credential",
+		"function.textEmbedding.providers.cohere.credential",
+		"function.textEmbedding.providers.dashscope.credential",
+		"function.textEmbedding.providers.gemini.credential",
+		"function.textEmbedding.providers.huggingface.credential",
+		"function.textEmbedding.providers.openai.credential",
+		"function.textEmbedding.providers.siliconflow.credential",
+		"function.textEmbedding.providers.tei.credential",
+		"function.textEmbedding.providers.vertexai.credential",
+		"function.textEmbedding.providers.voyageai.credential",
+		"function.rerank.model.providers.cohere.credential",
+		"function.rerank.model.providers.huggingface.credential",
+		"function.rerank.model.providers.siliconflow.credential",
+		"function.rerank.model.providers.tei.credential",
+		"function.rerank.model.providers.vllm.credential",
+		"function.rerank.model.providers.voyageai.credential",
+		"etcd.auth.userName",
+		"etcd.auth.password",
+		"kafka.saslUsername",
+		"kafka.saslPassword",
+		"kafka.ssl.tlsKeyPassword",
+		"common.security.defaultRootPassword",
+		"pulsar.authParams",
+		"trace.otlp.headers",
+	}
+	dynamicSensitiveKeys := []string{
+		"dynamic/auth-token",
+		"dynamic.client-secret",
+		"dynamic.private-key-passphrase",
+		"dynamic.credential",
+	}
+	sensitiveKeys := append(realSensitiveKeys, dynamicSensitiveKeys...)
+
+	assertRedacted := func(t *testing.T, mgr *Manager) {
+		configs := mgr.GetConfigsView()
+		rawConfigs := mgr.GetConfigs()
+		for _, key := range sensitiveKeys {
+			t.Run(key, func(t *testing.T) {
+				_, rawValue, err := mgr.GetConfig(key)
+				require.NoError(t, err)
+				assert.Equal(t, "plain-text-sensitive-value", rawValue)
+				assert.Equal(t, "plain-text-sensitive-value", rawConfigs[formatKey(key)])
+				assert.Equal(t, "*****", configs[formatKey(key)])
+			})
+		}
+	}
+
+	t.Run("configuration source", func(t *testing.T) {
+		mgr := NewManager()
+		envSource := NewEnvSource(formatKey)
+		for _, key := range sensitiveKeys {
+			envSource.configs.Insert(formatKey(key), "plain-text-sensitive-value")
+		}
+		require.NoError(t, mgr.AddSource(envSource))
+
+		assertRedacted(t, mgr)
+	})
+
+	t.Run("runtime overlay", func(t *testing.T) {
+		mgr := NewManager()
+		for _, key := range sensitiveKeys {
+			mgr.SetConfig(key, "plain-text-sensitive-value")
+		}
+
+		assertRedacted(t, mgr)
+	})
+}
+
 func TestDeadlock(t *testing.T) {
 	mgr, _ := Init()
 

--- a/pkg/util/paramtable/hook_config.go
+++ b/pkg/util/paramtable/hook_config.go
@@ -42,6 +42,13 @@ func (h *hookConfig) GetAll() map[string]string {
 	return h.hookBase.mgr.GetConfigs()
 }
 
+// GetConfigsView returns hook configurations with sensitive values redacted.
+func (h *hookConfig) GetConfigsView() map[string]string {
+	configs := h.GetAll()
+	h.hookBase.mgr.RedactSensitiveConfigValues(configs)
+	return configs
+}
+
 func (h *hookConfig) Save(key string, value string) error {
 	return h.hookBase.Save(key, value)
 }

--- a/pkg/util/paramtable/hook_config_test.go
+++ b/pkg/util/paramtable/hook_config_test.go
@@ -1,0 +1,40 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package paramtable
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/pkg/v2/config"
+)
+
+func TestHookConfigViewRedactsSensitiveValuesWithoutFormattingPublicValues(t *testing.T) {
+	hooks := &hookConfig{}
+	hooks.init(&BaseTable{mgr: config.NewManager()})
+	require.NoError(t, hooks.Save("plugin.password", "plain-text-sensitive-value"))
+	require.NoError(t, hooks.Save("plugin.enabled", "true"))
+
+	rawConfigs := hooks.GetAll()
+	view := hooks.GetConfigsView()
+	assert.Equal(t, "plain-text-sensitive-value", rawConfigs["pluginpassword"])
+	assert.Equal(t, "true", rawConfigs["pluginenabled"])
+	assert.Equal(t, "*****", view["pluginpassword"])
+	assert.Equal(t, "true", view["pluginenabled"])
+}


### PR DESCRIPTION
Configuration views in 2.6 rely on separate key-name denylists, allowing
credential-related and dynamic secret keys to be returned in plaintext.

Centralize sensitive-key classification in the config manager and apply the
same ***** mask to cluster and hook configuration views. Reuse the classifier
to deny sensitive management config reads, while keeping raw configuration
APIs unchanged and leaving the Proxy response helper serialization-only.

Add regression coverage for 34 built-in sensitive keys, four dynamic secret
patterns, raw API behavior, configuration sources and runtime overlays,
management reads, Proxy serialization, and hook-view compatibility.

See also: #52052

Signed-off-by: yangxuan <xuan.yang@zilliz.com>