### PR TITLE
enhance: Make Go client connection creation extensible

### DIFF
--- a/client/milvusclient/client.go
+++ b/client/milvusclient/client.go
@@ -61,6 +61,21 @@ type Client struct {
 	telemetry *ClientTelemetryManager
 }
 
+// ConnectionOptions contains the settings required to create the Milvus gRPC
+// connection. ConnectionFactory implementations should apply DialOptions as
+// gRPC channel options and install the unary and stream interceptors in the
+// order provided.
+type ConnectionOptions struct {
+	TransportCredentials credentials.TransportCredentials
+	DialOptions          []grpc.DialOption
+	UnaryInterceptors    []grpc.UnaryClientInterceptor
+	StreamInterceptors   []grpc.StreamClientInterceptor
+}
+
+// ConnectionFactory creates the gRPC connection used by a Client. The Client
+// owns the returned connection and closes it when Client.Close is called.
+type ConnectionFactory func(context.Context, string, ConnectionOptions) (*grpc.ClientConn, error)
+
 func New(ctx context.Context, config *ClientConfig) (*Client, error) {
 	if err := config.parse(); err != nil {
 		return nil, err
@@ -77,10 +92,10 @@ func New(ctx context.Context, config *ClientConfig) (*Client, error) {
 	// parse authentication parameters
 	c.parseAuthentication()
 	// Parse grpc options
-	options := c.dialOptions()
+	options := c.connectionOptions()
 
 	// Connect the grpc server.
-	if err := c.connect(ctx, addr, options...); err != nil {
+	if err := c.connect(ctx, addr, options); err != nil {
 		return nil, err
 	}
 
@@ -95,25 +110,26 @@ func New(ctx context.Context, config *ClientConfig) (*Client, error) {
 	return c, nil
 }
 
-func (c *Client) dialOptions() []grpc.DialOption {
-	var options []grpc.DialOption
+func (c *Client) connectionOptions() ConnectionOptions {
+	var transportCredentials credentials.TransportCredentials
 	// Construct dial option.
 	if c.config.EnableTLSAuth {
 		if c.config.tlsConfig != nil {
-			options = append(options, grpc.WithTransportCredentials(credentials.NewTLS(c.config.tlsConfig)))
+			transportCredentials = credentials.NewTLS(c.config.tlsConfig)
 		} else {
-			options = append(options, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))
+			transportCredentials = credentials.NewTLS(&tls.Config{})
 		}
 	} else {
-		options = append(options, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		transportCredentials = insecure.NewCredentials()
 	}
 
 	// Always apply default connection options first, then let caller override/extend.
+	var options []grpc.DialOption
 	options = append(options, DefaultGrpcOpts...)
 	options = append(options, c.config.DialOptions...)
 
-	options = append(options,
-		grpc.WithChainUnaryInterceptor(grpc_retry.UnaryClientInterceptor(
+	unaryInterceptors := []grpc.UnaryClientInterceptor{
+		grpc_retry.UnaryClientInterceptor(
 			grpc_retry.WithMax(6),
 			grpc_retry.WithBackoff(func(attempt uint) time.Duration {
 				return 60 * time.Millisecond * time.Duration(math.Pow(3, float64(attempt)))
@@ -121,13 +137,26 @@ func (c *Client) dialOptions() []grpc.DialOption {
 			grpc_retry.WithCodes(codes.Unavailable, codes.ResourceExhausted)),
 
 		// c.getRetryOnRateLimitInterceptor(),
-		))
-
-	options = append(options, grpc.WithChainUnaryInterceptor(
 		c.MetadataUnaryInterceptor(),
-	))
+	}
 
-	return options
+	return ConnectionOptions{
+		TransportCredentials: transportCredentials,
+		DialOptions:          options,
+		UnaryInterceptors:    unaryInterceptors,
+	}
+}
+
+func defaultConnectionFactory(ctx context.Context, target string, options ConnectionOptions) (*grpc.ClientConn, error) {
+	dialOptions := []grpc.DialOption{grpc.WithTransportCredentials(options.TransportCredentials)}
+	dialOptions = append(dialOptions, options.DialOptions...)
+	if len(options.UnaryInterceptors) > 0 {
+		dialOptions = append(dialOptions, grpc.WithChainUnaryInterceptor(options.UnaryInterceptors...))
+	}
+	if len(options.StreamInterceptors) > 0 {
+		dialOptions = append(dialOptions, grpc.WithChainStreamInterceptor(options.StreamInterceptors...))
+	}
+	return grpc.DialContext(ctx, target, dialOptions...)
 }
 
 // parseAuthentication prepares authentication headers for grpc inteceptors based on the provided username, password or API key.
@@ -181,11 +210,15 @@ func (c *Client) setIdentifier(identifier string) {
 	c.identifier = identifier
 }
 
-func (c *Client) connect(ctx context.Context, addr string, options ...grpc.DialOption) error {
+func (c *Client) connect(ctx context.Context, addr string, options ConnectionOptions) error {
 	if addr == "" {
 		return errors.New("address is empty")
 	}
-	conn, err := grpc.DialContext(ctx, addr, options...)
+	connectionFactory := c.config.ConnectionFactory
+	if connectionFactory == nil {
+		connectionFactory = defaultConnectionFactory
+	}
+	conn, err := connectionFactory(ctx, addr, options)
 	if err != nil {
 		return err
 	}

--- a/client/milvusclient/client_config.go
+++ b/client/milvusclient/client_config.go
@@ -61,6 +61,12 @@ type ClientConfig struct {
 
 	DialOptions []grpc.DialOption // Dial options for GRPC.
 
+	// ConnectionFactory creates the underlying gRPC client connection. When nil,
+	// the client uses grpc.DialContext. A custom factory can integrate the Milvus
+	// client with a platform-specific gRPC connection framework while preserving
+	// the Milvus transport settings and interceptors.
+	ConnectionFactory ConnectionFactory
+
 	RetryRateLimit *RetryRateLimitOption // option for retry on rate limit inteceptor
 
 	DisableConn bool

--- a/client/milvusclient/client_config_test.go
+++ b/client/milvusclient/client_config_test.go
@@ -11,15 +11,18 @@ func TestDialOptionsAlwaysIncludesDefaults(t *testing.T) {
 	c := &Client{config: &ClientConfig{
 		DialOptions: []grpc.DialOption{grpc.WithAuthority("test")},
 	}}
-	opts := c.dialOptions()
-	// TLS/insecure (1) + DefaultGrpcOpts (len) + user option (1) + interceptors (2)
-	assert.True(t, len(opts) >= len(DefaultGrpcOpts)+1, "dialOptions should include DefaultGrpcOpts plus user options")
+	opts := c.connectionOptions()
+	assert.Len(t, opts.DialOptions, len(DefaultGrpcOpts)+1)
+	assert.Len(t, opts.UnaryInterceptors, 2)
+	assert.NotNil(t, opts.TransportCredentials)
 }
 
 func TestDialOptionsWithNilDialOptions(t *testing.T) {
 	c := &Client{config: &ClientConfig{}}
-	opts := c.dialOptions()
-	assert.True(t, len(opts) >= len(DefaultGrpcOpts), "dialOptions should include DefaultGrpcOpts even when DialOptions is nil")
+	opts := c.connectionOptions()
+	assert.Len(t, opts.DialOptions, len(DefaultGrpcOpts))
+	assert.Len(t, opts.UnaryInterceptors, 2)
+	assert.NotNil(t, opts.TransportCredentials)
 }
 
 func TestWithGrpcAuthority(t *testing.T) {

--- a/client/milvusclient/client_test.go
+++ b/client/milvusclient/client_test.go
@@ -31,6 +31,27 @@ func (s *ClientSuite) TestNewClient() {
 		s.NotNil(c)
 	})
 
+	s.Run("custom connection factory", func() {
+		var called bool
+		c, err := New(ctx, &ClientConfig{
+			Address: "bufnet",
+			DialOptions: []grpc.DialOption{
+				grpc.WithBlock(),
+				grpc.WithContextDialer(s.mockDialer),
+			},
+			ConnectionFactory: func(factoryCtx context.Context, target string, options ConnectionOptions) (*grpc.ClientConn, error) {
+				called = true
+				s.Equal("bufnet", target)
+				s.NotNil(options.TransportCredentials)
+				s.Len(options.UnaryInterceptors, 2)
+				return defaultConnectionFactory(factoryCtx, target, options)
+			},
+		})
+		s.NoError(err)
+		s.NotNil(c)
+		s.True(called)
+	})
+
 	s.Run("empty_addr", func() {
 		_, err := New(ctx, &ClientConfig{})
 		s.Error(err)


### PR DESCRIPTION
Add an optional ConnectionFactory to ClientConfig and expose structured ConnectionOptions for transport credentials, dial options, and unary and stream interceptors.

Keep grpc.DialContext as the default connection path while allowing callers to integrate platform-specific connection frameworks without reimplementing Milvus TLS, retry, metadata, or connection ownership behavior.

This separation provides greater flexibility for custom connection strategies and makes the client easier to extend with new transports, interceptors, and dialing behavior in the future.

Add tests covering connection option construction and custom factory invocation.