### PR TITLE
enhance: expose false backfill segment status in JSON

### DIFF
--- a/internal/proxy/management.go
+++ b/internal/proxy/management.go
@@ -167,6 +167,30 @@ func (node *Proxy) PauseDatacoordGC(w http.ResponseWriter, req *http.Request) {
 	fmt.Fprintf(w, `{"msg": "OK", "ticket": "%s"}`, ticket)
 }
 
+type commitBackfillSegmentStatusJSON struct {
+	SegmentID int64  `json:"segment_id,omitempty"`
+	OK        bool   `json:"ok"`
+	Reason    string `json:"reason,omitempty"`
+	Kind      string `json:"kind,omitempty"`
+}
+
+func toCommitBackfillSegmentStatusesJSON(statuses []*datapb.CommitBackfillResultSegmentStatus) []*commitBackfillSegmentStatusJSON {
+	result := make([]*commitBackfillSegmentStatusJSON, 0, len(statuses))
+	for _, status := range statuses {
+		if status == nil {
+			result = append(result, nil)
+			continue
+		}
+		result = append(result, &commitBackfillSegmentStatusJSON{
+			SegmentID: status.GetSegmentId(),
+			OK:        status.GetOk(),
+			Reason:    status.GetReason(),
+			Kind:      status.GetKind(),
+		})
+	}
+	return result
+}
+
 // CommitBackfillResult is the proxy-side handler for the
 // /management/datacoord/backfill/commit endpoint. It forwards the S3 result
 // path to DataCoord.CommitBackfillResult and returns the aggregated
@@ -206,7 +230,7 @@ func (node *Proxy) CommitBackfillResult(w http.ResponseWriter, req *http.Request
 			"total_segments":     resp.GetTotalSegments(),
 			"committed_segments": resp.GetCommittedSegments(),
 			"failed_segments":    resp.GetFailedSegments(),
-			"segment_statuses":   resp.GetSegmentStatuses(),
+			"segment_statuses":   toCommitBackfillSegmentStatusesJSON(resp.GetSegmentStatuses()),
 		})
 		return
 	}
@@ -215,7 +239,7 @@ func (node *Proxy) CommitBackfillResult(w http.ResponseWriter, req *http.Request
 		"total_segments":     resp.GetTotalSegments(),
 		"committed_segments": resp.GetCommittedSegments(),
 		"failed_segments":    resp.GetFailedSegments(),
-		"segment_statuses":   resp.GetSegmentStatuses(),
+		"segment_statuses":   toCommitBackfillSegmentStatusesJSON(resp.GetSegmentStatuses()),
 	})
 }
 

--- a/internal/proxy/management_test.go
+++ b/internal/proxy/management_test.go
@@ -862,6 +862,16 @@ func (s *ProxyManagementSuite) TestCommitBackfillResult() {
 		s.Contains(body, "bad json")
 		s.Contains(body, `"failed_segments":1`)
 		s.Contains(body, `"segment_statuses"`)
+
+		var payload struct {
+			SegmentStatuses []struct {
+				OK *bool `json:"ok"`
+			} `json:"segment_statuses"`
+		}
+		s.Require().NoError(gojson.Unmarshal(recorder.Body.Bytes(), &payload))
+		s.Require().Len(payload.SegmentStatuses, 1)
+		s.Require().NotNil(payload.SegmentStatuses[0].OK)
+		s.False(*payload.SegmentStatuses[0].OK)
 	})
 }
 


### PR DESCRIPTION
Related to zilliztech/spark-milvus#74

Use an HTTP response DTO to ensure failed backfill segments explicitly include ok=false. Add regression coverage that distinguishes an omitted field from an explicit false value