### PR TITLE
enhance: centralize index load parameter preparation

### DIFF
--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -47,9 +47,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querynodev2/segments/state"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
-	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/internal/util/segcore"
-	"github.com/milvus-io/milvus/internal/util/vecindexmgr"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -58,8 +56,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/segcorepb"
 	"github.com/milvus-io/milvus/pkg/v3/util/contextutil"
-	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
-	"github.com/milvus-io/milvus/pkg/v3/util/indexparams"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
@@ -1160,25 +1156,12 @@ func GetCLoadInfoWithFunc(ctx context.Context,
 	}
 	defer deleteLoadIndexInfo(loadIndexInfo)
 
-	indexParams := funcutil.KeyValuePair2Map(indexInfo.IndexParams)
-	// as Knowhere reports error if encounter an unknown param, we need to delete it
-	delete(indexParams, common.MmapEnabledKey)
-
-	// some build params also exist in indexParams, which are useless during loading process
-	if vecindexmgr.GetVecIndexMgrInstance().IsDiskANN(indexParams["index_type"]) {
-		if err := indexparams.SetDiskIndexLoadParams(paramtable.Get(), indexParams, indexInfo.GetNumRows()); err != nil {
-			return err
-		}
-	}
-
-	// set whether enable offset cache for bitmap index
-	if indexParams["index_type"] == indexparamcheck.IndexBitmap {
-		indexparams.SetBitmapIndexLoadParams(paramtable.Get(), indexParams)
-	}
-
-	if err := indexparams.AppendPrepareLoadParams(paramtable.Get(), indexParams); err != nil {
+	indexParams, err := buildIndexLoadParams(indexInfo)
+	if err != nil {
 		return err
 	}
+	// as Knowhere reports error if encounter an unknown param, we need to delete it
+	delete(indexParams, common.MmapEnabledKey)
 
 	enableMmap := isIndexMmapEnable(fieldSchema, indexInfo)
 	// Add warmup policy to index_params if not already present

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -2411,6 +2411,32 @@ func SupportInterimIndexDataType(dataType schemapb.DataType) bool {
 		dataType == schemapb.DataType_BFloat16Vector
 }
 
+// buildIndexLoadParams returns the QueryNode-local runtime configuration for a
+// single index without mutating the FieldIndexInfo owned by the caller. Full
+// Load, Reopen, and resource estimation must all use this builder so they cannot
+// drift when a new runtime parameter is introduced.
+func buildIndexLoadParams(indexInfo *querypb.FieldIndexInfo) (map[string]string, error) {
+	indexParams := funcutil.KeyValuePair2Map(indexInfo.GetIndexParams())
+
+	// Some build params also exist in indexParams, which are useless during loading process.
+	if vecindexmgr.GetVecIndexMgrInstance().IsDiskANN(indexParams[common.IndexTypeKey]) {
+		if err := indexparams.SetDiskIndexLoadParams(paramtable.Get(), indexParams, indexInfo.GetNumRows()); err != nil {
+			return nil, err
+		}
+	}
+
+	// Set whether to enable the offset cache for bitmap indexes.
+	if indexParams[common.IndexTypeKey] == indexparamcheck.IndexBitmap {
+		indexparams.SetBitmapIndexLoadParams(paramtable.Get(), indexParams)
+	}
+
+	if err := indexparams.AppendPrepareLoadParams(paramtable.Get(), indexParams); err != nil {
+		return nil, err
+	}
+
+	return indexParams, nil
+}
+
 // prepareIndexLoadParams injects QueryNode-local index load parameters into each
 // index's IndexParams in place. These params (e.g. DISKANN num_load_thread) are
 // derived from local QueryNode resources/config and are never persisted in the
@@ -2423,21 +2449,8 @@ func prepareIndexLoadParams(indexInfos []*querypb.FieldIndexInfo) error {
 		if indexInfo == nil {
 			continue
 		}
-		indexParams := funcutil.KeyValuePair2Map(indexInfo.GetIndexParams())
-
-		// some build params also exist in indexParams, which are useless during loading process
-		if vecindexmgr.GetVecIndexMgrInstance().IsDiskANN(indexParams["index_type"]) {
-			if err := indexparams.SetDiskIndexLoadParams(paramtable.Get(), indexParams, indexInfo.GetNumRows()); err != nil {
-				return err
-			}
-		}
-
-		// set whether enable offset cache for bitmap index
-		if indexParams["index_type"] == indexparamcheck.IndexBitmap {
-			indexparams.SetBitmapIndexLoadParams(paramtable.Get(), indexParams)
-		}
-
-		if err := indexparams.AppendPrepareLoadParams(paramtable.Get(), indexParams); err != nil {
+		indexParams, err := buildIndexLoadParams(indexInfo)
+		if err != nil {
 			return err
 		}
 

--- a/internal/querynodev2/segments/segment_test.go
+++ b/internal/querynodev2/segments/segment_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/indexparams"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
@@ -968,6 +969,89 @@ func TestLocalSegmentReopenInjectsDiskIndexLoadParams(t *testing.T) {
 	numLoadThread, ok := getParam(captured.GetIndexInfos()[0].GetIndexParams(), indexparams.NumLoadThreadKey)
 	assert.True(t, ok, "num_load_thread must be injected into DISKANN index params on Reopen")
 	assert.NotEmpty(t, numLoadThread)
+}
+
+func TestBuildIndexLoadParamsMatchesActualLoadPreparation(t *testing.T) {
+	paramtable.Init()
+	params := paramtable.Get()
+
+	oldEnable := params.KnowhereConfig.Enable.GetValue()
+	loadParamKey := params.KnowhereConfig.IndexParam.KeyPrefix + "HNSW.load.issue_51720"
+	oldLoadParam := params.GetWithDefault(loadParamKey, "")
+	t.Cleanup(func() {
+		require.NoError(t, params.Save(params.KnowhereConfig.Enable.Key, oldEnable))
+		if oldLoadParam == "" {
+			params.Remove(loadParamKey)
+			return
+		}
+		require.NoError(t, params.Save(loadParamKey, oldLoadParam))
+	})
+	require.NoError(t, params.Save(params.KnowhereConfig.Enable.Key, "true"))
+	require.NoError(t, params.Save(loadParamKey, "prepared"))
+
+	tests := []struct {
+		name       string
+		indexInfo  *querypb.FieldIndexInfo
+		assertions func(t *testing.T, prepared map[string]string)
+	}{
+		{
+			name: "DISKANN runtime params",
+			indexInfo: &querypb.FieldIndexInfo{
+				NumRows: 5000,
+				IndexParams: []*commonpb.KeyValuePair{
+					{Key: common.IndexTypeKey, Value: "DISKANN"},
+					{Key: common.DimKey, Value: "128"},
+				},
+			},
+			assertions: func(t *testing.T, prepared map[string]string) {
+				assert.NotEmpty(t, prepared[indexparams.NumLoadThreadKey])
+				assert.NotEmpty(t, prepared[indexparams.SearchCacheBudgetKey])
+				assert.NotEmpty(t, prepared[indexparams.BeamWidthKey])
+			},
+		},
+		{
+			name: "BITMAP offset cache param",
+			indexInfo: &querypb.FieldIndexInfo{
+				IndexParams: []*commonpb.KeyValuePair{
+					{Key: common.IndexTypeKey, Value: "BITMAP"},
+				},
+			},
+			assertions: func(t *testing.T, prepared map[string]string) {
+				assert.Equal(t, params.QueryNodeCfg.IndexOffsetCacheEnabled.GetValue(), prepared[common.IndexOffsetCacheEnabledKey])
+			},
+		},
+		{
+			name: "Knowhere load-stage param",
+			indexInfo: &querypb.FieldIndexInfo{
+				IndexParams: []*commonpb.KeyValuePair{
+					{Key: common.IndexTypeKey, Value: "HNSW"},
+				},
+			},
+			assertions: func(t *testing.T, prepared map[string]string) {
+				assert.Equal(t, "prepared", prepared["issue_51720"])
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			original := funcutil.KeyValuePair2Map(test.indexInfo.GetIndexParams())
+			prepared, err := buildIndexLoadParams(test.indexInfo)
+			require.NoError(t, err)
+
+			// The builder must not mutate metadata owned by QueryCoord. Resource
+			// estimation applies mmap/warmup changes only to the returned map.
+			assert.Equal(t, original, funcutil.KeyValuePair2Map(test.indexInfo.GetIndexParams()))
+
+			actualLoadInfo := &querypb.FieldIndexInfo{
+				NumRows:     test.indexInfo.GetNumRows(),
+				IndexParams: funcutil.Map2KeyValuePair(original),
+			}
+			require.NoError(t, prepareIndexLoadParams([]*querypb.FieldIndexInfo{actualLoadInfo}))
+			assert.Equal(t, prepared, funcutil.KeyValuePair2Map(actualLoadInfo.GetIndexParams()))
+			test.assertions(t, prepared)
+		})
+	}
 }
 
 // TestBaseSegment_SkipGrowingBF tests that skipGrowingBF bypasses PK candidate checks.


### PR DESCRIPTION
## Summary

- centralize QueryNode-local index runtime parameter preparation
- reuse the same preparation path for full load, reopen, and resource estimation
- add regression coverage for DISKANN, BITMAP, and load-stage parameters without mutating caller-owned metadata

issue: #51720
