### PR TITLE
fix: [3.0] allow altering integration_id and model_deployment_id for TextEmbedding function (#51924)

### DIFF
--- a/internal/util/function/validator/alter_whitelist.go
+++ b/internal/util/function/validator/alter_whitelist.go
@@ -46,11 +46,15 @@ import (
 //     differs — altering them mixes old and new vector semantics in one field.
 //
 // url stays alterable because model_name providers keep their identity in model_name
-// and use url only as a relocatable API host.
+// and use url only as a relocatable API host. model_deployment_id is likewise
+// alterable: it re-points the function to a model deployment on the cluster, and
+// keeping the new deployment model-compatible is the user's responsibility.
 var alterableFunctionParams = map[schemapb.FunctionType]typeutil.Set[string]{
 	schemapb.FunctionType_TextEmbedding: typeutil.NewSet(
 		models.URLParamKey,
 		models.CredentialParamKey,
+		models.IntegrationIDKey,
+		models.ModelDeploymentIDKey,
 		models.TimeoutMsParamKey,
 		models.MaxClientBatchSizeParamKey,
 		models.RegionParamKey,

--- a/internal/util/function/validator/alter_whitelist_test.go
+++ b/internal/util/function/validator/alter_whitelist_test.go
@@ -50,6 +50,18 @@ func TestCheckFunctionAlterAllowed(t *testing.T) {
 		assert.NoError(t, CheckFunctionAlterAllowed(old, newFn))
 	})
 
+	t.Run("change integration_id -> ok", func(t *testing.T) {
+		oldFn := embFn(kv("model_name", "m1"), kv("dim", "8"), kv("integration_id", "itg-a"))
+		newFn := embFn(kv("model_name", "m1"), kv("dim", "8"), kv("integration_id", "itg-b"))
+		assert.NoError(t, CheckFunctionAlterAllowed(oldFn, newFn))
+	})
+
+	t.Run("change model_deployment_id -> ok", func(t *testing.T) {
+		oldFn := embFn(kv("model_deployment_id", "dep-a"))
+		newFn := embFn(kv("model_deployment_id", "dep-b"))
+		assert.NoError(t, CheckFunctionAlterAllowed(oldFn, newFn))
+	})
+
 	t.Run("remove whitelisted param -> ok", func(t *testing.T) {
 		newFn := embFn(kv("model_name", "m1"), kv("dim", "8"))
 		assert.NoError(t, CheckFunctionAlterAllowed(old, newFn))


### PR DESCRIPTION
Cherry-pick of #52080 to 3.0.

Altering a TextEmbedding function rejects changing `integration_id` / `model_deployment_id`. Both are connection/runtime params (`integration_id` only feeds the runtime api key; `model_deployment_id` re-points the function to a model deployment, with model compatibility being the user's responsibility), so add both to the TextEmbedding alter whitelist.

issue: #51924
pr: #52080

🤖 Generated with [Claude Code](https://claude.com/claude-code)