### PR TITLE
enhance: support AutoIndex for add_function_field bound index (#52083)

### DIFF
--- a/internal/datacoord/index_meta_test.go
+++ b/internal/datacoord/index_meta_test.go
@@ -284,6 +284,74 @@ func TestMeta_ScalarAutoIndex(t *testing.T) {
 	})
 }
 
+// TestMeta_CanCreateIndex_BoundAutoIndexEquivalence: the add-function-field DDL
+// persists an AutoIndex-resolved bound index in the create_index convention
+// (UserIndexParams = AUTOINDEX + final metric); a later create_index(AUTOINDEX)
+// on the same field must dedupe as idempotent instead of hitting the
+// one-distinct-index-per-field conflict.
+func TestMeta_CanCreateIndex_BoundAutoIndexEquivalence(t *testing.T) {
+	catalog := catalogmocks.NewDataCoordCatalog(t)
+	catalog.On("CreateIndex", mock.Anything, mock.Anything).Return(nil)
+	m := newSegmentIndexMeta(catalog)
+
+	resolvedIndexParams := []*commonpb.KeyValuePair{
+		{Key: common.IndexTypeKey, Value: "SPARSE_INVERTED_INDEX"},
+		{Key: common.MetricTypeKey, Value: "BM25"},
+		{Key: "bm25_k1", Value: "1.2"},
+		{Key: "bm25_b", Value: "0.75"},
+		{Key: "bm25_avgdl", Value: "100"},
+	}
+	autoIndexUserParams := []*commonpb.KeyValuePair{
+		{Key: common.IndexTypeKey, Value: common.AutoIndexName},
+		{Key: common.MetricTypeKey, Value: "BM25"},
+	}
+	// Shape persisted by rootcoord prepareBoundFieldIndex on the AutoIndex path.
+	boundIndex := &model.Index{
+		CollectionID:    UniqueID(1),
+		FieldID:         UniqueID(101),
+		IndexID:         UniqueID(10),
+		IndexName:       "sparse",
+		IndexParams:     resolvedIndexParams,
+		UserIndexParams: autoIndexUserParams,
+		IsAutoIndex:     false,
+	}
+	err := m.CreateIndex(context.TODO(), boundIndex)
+	assert.NoError(t, err)
+
+	// What proxy sends for a later create_index(AUTOINDEX, metric_type=BM25).
+	req := &indexpb.CreateIndexRequest{
+		CollectionID:                     UniqueID(1),
+		FieldID:                          UniqueID(101),
+		IndexName:                        "sparse",
+		IndexParams:                      resolvedIndexParams,
+		UserIndexParams:                  autoIndexUserParams,
+		IsAutoIndex:                      false,
+		UserAutoindexMetricTypeSpecified: true,
+	}
+	tmpIndexID, err := m.CanCreateIndex(req, false)
+	assert.ErrorIs(t, err, errIndexOperationIgnored)
+	assert.Zero(t, tmpIndexID)
+
+	// A different explicit index on the same field remains a conflict.
+	conflictReq := &indexpb.CreateIndexRequest{
+		CollectionID: UniqueID(1),
+		FieldID:      UniqueID(101),
+		IndexName:    "sparse",
+		IndexParams: []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: "SPARSE_WAND"},
+			{Key: common.MetricTypeKey, Value: "IP"},
+		},
+		UserIndexParams: []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: "SPARSE_WAND"},
+			{Key: common.MetricTypeKey, Value: "IP"},
+		},
+	}
+	tmpIndexID, err = m.CanCreateIndex(conflictReq, false)
+	assert.Error(t, err)
+	assert.NotErrorIs(t, err, errIndexOperationIgnored)
+	assert.Zero(t, tmpIndexID)
+}
+
 func TestMeta_CanCreateIndex(t *testing.T) {
 	var (
 		collID = UniqueID(1)

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -1032,17 +1032,31 @@ func (h *HandlersV2) dropCollectionFunction(ctx context.Context, c *gin.Context,
 // A function is coupled to its output field, so both are added in one request.
 func (h *HandlersV2) addCollectionFunctionField(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
 	httpReq := anyReq.(*CollectionAddFunctionField)
-	// The index always targets the newly-added output field; reject a mismatched
-	// indexParams.fieldName rather than silently building the index on outputField.
-	if httpReq.IndexParam.FieldName != httpReq.OutputField.FieldName {
-		err := merr.WrapErrParameterInvalidMsg(
-			"indexParams.fieldName %q must match outputField.fieldName %q",
-			httpReq.IndexParam.FieldName, httpReq.OutputField.FieldName)
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
-			HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
-			HTTPReturnMessage: err.Error(),
-		})
-		return nil, err
+	var indexName string
+	var extraParams []*commonpb.KeyValuePair
+	if httpReq.IndexParam != nil {
+		// The index always targets the newly-added output field; reject a mismatched
+		// indexParams.fieldName rather than silently building the index on outputField.
+		if httpReq.IndexParam.FieldName != httpReq.OutputField.FieldName {
+			err := merr.WrapErrParameterInvalidMsg(
+				"indexParams.fieldName %q must match outputField.fieldName %q",
+				httpReq.IndexParam.FieldName, httpReq.OutputField.FieldName)
+			HTTPAbortReturn(c, http.StatusOK, gin.H{
+				HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
+				HTTPReturnMessage: err.Error(),
+			})
+			return nil, err
+		}
+		var err error
+		extraParams, err = convertToExtraParams(*httpReq.IndexParam)
+		if err != nil {
+			HTTPAbortReturn(c, http.StatusOK, gin.H{
+				HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
+				HTTPReturnMessage: err.Error(),
+			})
+			return nil, err
+		}
+		indexName = httpReq.IndexParam.IndexName
 	}
 	fSchema, err := genFunctionSchema(ctx, &httpReq.Function)
 	if err != nil {
@@ -1060,14 +1074,6 @@ func (h *HandlersV2) addCollectionFunctionField(ctx context.Context, c *gin.Cont
 		})
 		return nil, err
 	}
-	extraParams, err := convertToExtraParams(httpReq.IndexParam)
-	if err != nil {
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
-			HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
-			HTTPReturnMessage: err.Error(),
-		})
-		return nil, err
-	}
 	req := &milvuspb.AlterCollectionSchemaRequest{
 		DbName:         dbName,
 		CollectionName: httpReq.CollectionName,
@@ -1077,7 +1083,7 @@ func (h *HandlersV2) addCollectionFunctionField(ctx context.Context, c *gin.Cont
 					FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
 						{
 							FieldSchema: fieldSchema,
-							IndexName:   httpReq.IndexParam.IndexName,
+							IndexName:   indexName,
 							ExtraParams: extraParams,
 						},
 					},

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -5030,6 +5030,13 @@ func (s *CollectionFunctionSuite) TestAddCollectionFunctionFieldNormal() {
 				errCode:     0,
 				errMsg:      "",
 			},
+			{
+				// indexParams omitted: the bound index resolves via AutoIndex on the server side.
+				path:        versionalV2(CollectionCategory, AddFunctionFieldAction),
+				requestBody: []byte(`{"dbName": "db", "collectionName": "coll", "function": {"name": "bm25_fn", "type": "BM25", "inputFieldNames": ["text"], "outputFieldNames": ["sparse"]}, "outputField": {"fieldName": "sparse", "dataType": "SparseFloatVector"}}`),
+				errCode:     0,
+				errMsg:      "",
+			},
 		}
 		s.mp.EXPECT().AlterCollectionSchema(mock.Anything, mock.Anything).Return(&milvuspb.AlterCollectionSchemaResponse{AlterStatus: &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success}}, nil).Maybe()
 

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -138,7 +138,9 @@ type CollectionAddFunctionField struct {
 	CollectionName string         `json:"collectionName" binding:"required"`
 	Function       FunctionSchema `json:"function" binding:"required"`
 	OutputField    FieldSchema    `json:"outputField" binding:"required"`
-	IndexParam     IndexParam     `json:"indexParams" binding:"required"`
+	// Optional: when omitted, the bound index of the output field is resolved
+	// via the AutoIndex config on the server side.
+	IndexParam *IndexParam `json:"indexParams"`
 }
 
 func (req *CollectionAddFunctionField) GetDbName() string { return req.DbName }

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -1048,6 +1048,7 @@ func (node *Proxy) AlterCollectionSchema(ctx context.Context, request *milvuspb.
 		AlterCollectionSchemaRequest: request,
 		mixCoord:                     node.mixCoord,
 		oldSchema:                    dresp.GetSchema(),
+		collectionProperties:         dresp.GetProperties(),
 	}
 	method := "AlterCollectionSchema"
 	tr := timerecord.NewTimeRecorder(method)

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -1085,9 +1085,10 @@ type alterCollectionSchemaTask struct {
 	Condition
 	*milvuspb.AlterCollectionSchemaRequest
 	*milvuspb.AlterCollectionSchemaResponse
-	ctx       context.Context
-	mixCoord  types.MixCoordClient
-	oldSchema *schemapb.CollectionSchema
+	ctx                  context.Context
+	mixCoord             types.MixCoordClient
+	oldSchema            *schemapb.CollectionSchema
+	collectionProperties []*commonpb.KeyValuePair
 }
 
 func (t *alterCollectionSchemaTask) TraceCtx() context.Context {
@@ -1187,10 +1188,11 @@ func (t *alterCollectionSchemaTask) preExecuteAdd(ctx context.Context) error {
 
 	// Validate the bound index params against the new field, mirroring the
 	// create_index path (index name rules, checker existence, data-type
-	// compatibility, train params, dimension filling). Validation-only: the
-	// request keeps the user's original params so the persisted UserIndexParams
-	// match the create_index convention; rootcoord independently derives the
-	// normalized IndexParams at prepare.
+	// compatibility, train params, dimension filling, AUTOINDEX resolution when
+	// index_type is omitted). Validation-only: the request keeps the user's
+	// original params so the persisted UserIndexParams match the create_index
+	// convention; rootcoord independently derives the normalized IndexParams at
+	// prepare.
 	if plan.Kind == schemautil.AlterSchemaAddFunctionField {
 		if err := validateIndexName(plan.IndexName); err != nil {
 			return err
@@ -1198,8 +1200,8 @@ func (t *alterCollectionSchemaTask) preExecuteAdd(ctx context.Context) error {
 		if err := indexparamcheck.ValidateIndexParamsSize(plan.IndexExtraParams...); err != nil {
 			return err
 		}
-		indexParamsMap, err := indexparamcheck.PrepareFunctionOutputIndexParams(
-			plan.Function.GetType(), plan.Field.GetName(), plan.IndexExtraParams)
+		indexParamsMap, _, err := indexparamcheck.PrepareFunctionOutputIndexParams(
+			plan.Function.GetType(), plan.Field, t.collectionProperties, plan.IndexExtraParams)
 		if err != nil {
 			return err
 		}

--- a/internal/proxy/task_index.go
+++ b/internal/proxy/task_index.go
@@ -52,8 +52,6 @@ const (
 	AutoIndexName = common.AutoIndexName
 	DimKey        = common.DimKey
 	IsSparseKey   = common.IsSparseKey
-
-	RefineTypeKey = "refine_type"
 )
 
 // mapVectorMetricToEmbListMetric maps element-level vector metrics to EmbList-level metrics for ArrayOfVector.
@@ -74,58 +72,6 @@ func mapVectorMetricToEmbListMetric(metricType string) string {
 	default:
 		return metricType
 	}
-}
-
-// adjustAutoIndexParamsByDataType adjusts autoindex params based on vector data type
-// If data_type is bf16 and refine_type is fp16/fp32, adjust to BF16
-// If data_type is fp16 and refine_type is bf16/fp32, adjust to FP16
-// Other refine_type values (e.g., sq8) are not modified
-func adjustAutoIndexParamsByDataType(config map[string]string, dataType schemapb.DataType) map[string]string {
-	if config == nil {
-		return config
-	}
-	refineType, hasRefine := config[RefineTypeKey]
-	if !hasRefine {
-		return config
-	}
-
-	refineTypeLower := strings.ToLower(refineType)
-	var requiredRefineType string
-
-	switch dataType {
-	case schemapb.DataType_Float16Vector:
-		// fp16 data requires fp16 refine, adjust if refine_type is bf16/fp32
-		if refineTypeLower == "bf16" || refineTypeLower == "fp32" {
-			requiredRefineType = "FP16"
-		}
-	case schemapb.DataType_BFloat16Vector:
-		// bf16 data requires bf16 refine, adjust if refine_type is fp16/fp32
-		if refineTypeLower == "fp16" || refineTypeLower == "fp32" {
-			requiredRefineType = "BF16"
-		}
-	}
-
-	if requiredRefineType == "" {
-		return config
-	}
-
-	adjusted := make(map[string]string, len(config))
-	for k, v := range config {
-		adjusted[k] = v
-	}
-	adjusted[RefineTypeKey] = requiredRefineType
-	return adjusted
-}
-
-func getDenseFloatAutoIndexParams(collectionProperties []*commonpb.KeyValuePair) map[string]string {
-	// autoindex is enabled only for cloud instance.
-	// and large_topk query mode is set in collection properties.
-	// we will use large_topk index params for dense float vector index when these two conditions are met.
-	if Params.AutoIndexConfig.Enable.GetAsBool() && common.IsQueryModeLargeTopK(collectionProperties...) {
-		return Params.AutoIndexConfig.LargeTopKIndexParams.GetAsJSONMap()
-	}
-
-	return Params.AutoIndexConfig.IndexParams.GetAsJSONMap()
 }
 
 type createIndexTask struct {
@@ -189,19 +135,6 @@ func (cit *createIndexTask) OnEnqueue() error {
 	return nil
 }
 
-func wrapUserIndexParams(metricType string) []*commonpb.KeyValuePair {
-	return []*commonpb.KeyValuePair{
-		{
-			Key:   common.IndexTypeKey,
-			Value: AutoIndexName,
-		},
-		{
-			Key:   common.MetricTypeKey,
-			Value: metricType,
-		},
-	}
-}
-
 func (cit *createIndexTask) parseFunctionParamsToIndex(indexParamsMap map[string]string) error {
 	if !cit.fieldSchema.GetIsFunctionOutput() {
 		return nil
@@ -220,6 +153,9 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// Whether the metric came from the USER (before any autoindex config merge)
+	// — a config-injected metric is not a user choice.
+	_, userMetricSpecified := indexParamsMap[common.MetricTypeKey]
 
 	if jsonCastType, exist := indexParamsMap[common.JSONCastTypeKey]; exist {
 		indexParamsMap[common.JSONCastTypeKey] = strings.ToUpper(strings.TrimSpace(jsonCastType))
@@ -318,14 +254,14 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 
 			if typeutil.IsDenseFloatVectorType(cit.fieldSchema.DataType) ||
 				(typeutil.IsArrayOfVectorType(cit.fieldSchema.DataType) && typeutil.IsDenseFloatVectorType(cit.fieldSchema.ElementType)) {
-				autoIndexParams := getDenseFloatAutoIndexParams(cit.collectionProperties)
+				autoIndexParams := indexparamcheck.GetDenseFloatAutoIndexParams(cit.collectionProperties)
 				// override float vector index params by autoindex
 				// filter incompatible refine_type for fp16/bf16 vectors
 				dataType := cit.fieldSchema.DataType
 				if typeutil.IsArrayOfVectorType(cit.fieldSchema.DataType) {
 					dataType = cit.fieldSchema.ElementType
 				}
-				autoIndexParams = adjustAutoIndexParamsByDataType(autoIndexParams, dataType)
+				autoIndexParams = indexparamcheck.AdjustAutoIndexParamsByDataType(autoIndexParams, dataType)
 				for k, v := range autoIndexParams {
 					indexParamsMap[k] = v
 				}
@@ -387,7 +323,7 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 				if len(indexParamsMap) == numberParams {
 					// though we already know there must be metric type, how to make this safer to avoid crash?
 					metricType := autoIndexConfig[common.MetricTypeKey]
-					cit.newExtraParams = wrapUserIndexParams(metricType)
+					cit.newExtraParams = indexparamcheck.WrapUserIndexParams(metricType)
 					useAutoIndex(autoIndexConfig)
 					return nil
 				}
@@ -402,7 +338,7 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 					}
 
 					// only metric type is passed.
-					cit.newExtraParams = wrapUserIndexParams(metricType)
+					cit.newExtraParams = indexparamcheck.WrapUserIndexParams(metricType)
 					useAutoIndex(autoIndexConfig)
 					// make the users' metric type first class citizen.
 					indexParamsMap[common.MetricTypeKey] = metricType
@@ -415,13 +351,13 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 			var config map[string]string
 			if typeutil.IsDenseFloatVectorType(cit.fieldSchema.DataType) ||
 				(typeutil.IsArrayOfVectorType(cit.fieldSchema.DataType) && typeutil.IsDenseFloatVectorType(cit.fieldSchema.ElementType)) {
-				config = getDenseFloatAutoIndexParams(cit.collectionProperties)
+				config = indexparamcheck.GetDenseFloatAutoIndexParams(cit.collectionProperties)
 				// filter incompatible refine_type for fp16/bf16 vectors
 				dataType := cit.fieldSchema.DataType
 				if typeutil.IsArrayOfVectorType(cit.fieldSchema.DataType) {
 					dataType = cit.fieldSchema.ElementType
 				}
-				config = adjustAutoIndexParamsByDataType(config, dataType)
+				config = indexparamcheck.AdjustAutoIndexParamsByDataType(config, dataType)
 			} else if typeutil.IsSparseFloatVectorType(cit.fieldSchema.DataType) ||
 				(typeutil.IsArrayOfVectorType(cit.fieldSchema.DataType) && typeutil.IsSparseFloatVectorType(cit.fieldSchema.ElementType)) {
 				// override sparse float vector index params by autoindex
@@ -452,6 +388,24 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 			if !metricTypeExist && typeutil.IsArrayOfVectorType(cit.fieldSchema.DataType) {
 				if m, ok := indexParamsMap[common.MetricTypeKey]; ok {
 					indexParamsMap[common.MetricTypeKey] = mapVectorMetricToEmbListMetric(m)
+				}
+			}
+		}
+
+		// For a BM25 function output field the required metric is known
+		// authoritatively; when the metric in the map was injected by the
+		// autoindex config (not user-specified), force it to BM25 instead of
+		// failing the BM25 metric check below — same rule as the
+		// add_function_field bound-index resolution. The user-facing wrapped
+		// extra params must carry the same final metric.
+		if !userMetricSpecified && cit.fieldSchema.GetIsFunctionOutput() &&
+			cit.functionSchema.GetType() == schemapb.FunctionType_BM25 {
+			if m, ok := indexParamsMap[common.MetricTypeKey]; ok && m != metric.BM25 {
+				indexParamsMap[common.MetricTypeKey] = metric.BM25
+				for _, kv := range cit.newExtraParams {
+					if kv.GetKey() == common.MetricTypeKey {
+						kv.Value = metric.BM25
+					}
 				}
 			}
 		}
@@ -918,7 +872,7 @@ func (dit *describeIndexTask) Execute(ctx context.Context) error {
 		if params == nil {
 			metricType, err := funcutil.GetAttrByKeyFromRepeatedKV(MetricTypeKey, indexInfo.GetIndexParams())
 			if err == nil {
-				params = wrapUserIndexParams(metricType)
+				params = indexparamcheck.WrapUserIndexParams(metricType)
 			}
 		}
 		fieldName := field.Name

--- a/internal/proxy/task_index_test.go
+++ b/internal/proxy/task_index_test.go
@@ -1661,7 +1661,7 @@ func Test_ngram_parseIndexParams(t *testing.T) {
 }
 
 func Test_wrapUserIndexParams(t *testing.T) {
-	params := wrapUserIndexParams("L2")
+	params := indexparamcheck.WrapUserIndexParams("L2")
 	assert.Equal(t, 2, len(params))
 	assert.Equal(t, "index_type", params[0].Key)
 	assert.Equal(t, AutoIndexName, params[0].Value)
@@ -2085,9 +2085,100 @@ func newTestSchema() *schemapb.CollectionSchema {
 	}
 }
 
+// A config-injected metric is not a user choice: for a BM25 function output
+// field, AutoIndex requests without a user metric must resolve to metric BM25
+// (same rule as the add_function_field bound-index resolution) so they reach
+// datacoord's dedup instead of failing the BM25 metric check at the proxy.
+func Test_parseIndexParams_AutoIndexBM25FunctionOutput(t *testing.T) {
+	paramtable.Init()
+
+	sparseOutputField := &schemapb.FieldSchema{
+		DataType:         schemapb.DataType_SparseFloatVector,
+		IsFunctionOutput: true,
+	}
+	bm25Function := &schemapb.FunctionSchema{Type: schemapb.FunctionType_BM25}
+
+	t.Run("empty params resolve with BM25 metric forced", func(t *testing.T) {
+		task := &createIndexTask{
+			fieldSchema:    sparseOutputField,
+			functionSchema: bm25Function,
+			req: &milvuspb.CreateIndexRequest{
+				ExtraParams: make([]*commonpb.KeyValuePair, 0),
+			},
+		}
+		err := task.parseIndexParams(context.TODO())
+		assert.NoError(t, err)
+		assert.False(t, task.userAutoIndexMetricTypeSpecified)
+		assert.ElementsMatch(t, []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: AutoIndexName},
+			{Key: common.MetricTypeKey, Value: "BM25"},
+		}, task.newExtraParams)
+		newIndexParams := funcutil.KeyValuePair2Map(task.newIndexParams)
+		assert.Equal(t, "BM25", newIndexParams[common.MetricTypeKey])
+		assert.Equal(t, "1.2", newIndexParams["bm25_k1"])
+	})
+
+	t.Run("AUTOINDEX without metric resolves with BM25 metric forced", func(t *testing.T) {
+		task := &createIndexTask{
+			fieldSchema:    sparseOutputField,
+			functionSchema: bm25Function,
+			req: &milvuspb.CreateIndexRequest{
+				ExtraParams: []*commonpb.KeyValuePair{
+					{Key: common.IndexTypeKey, Value: AutoIndexName},
+				},
+			},
+		}
+		err := task.parseIndexParams(context.TODO())
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: AutoIndexName},
+			{Key: common.MetricTypeKey, Value: "BM25"},
+		}, task.newExtraParams)
+	})
+
+	t.Run("user-specified BM25 metric unchanged", func(t *testing.T) {
+		task := &createIndexTask{
+			fieldSchema:    sparseOutputField,
+			functionSchema: bm25Function,
+			req: &milvuspb.CreateIndexRequest{
+				ExtraParams: []*commonpb.KeyValuePair{
+					{Key: common.IndexTypeKey, Value: AutoIndexName},
+					{Key: common.MetricTypeKey, Value: "BM25"},
+				},
+			},
+		}
+		err := task.parseIndexParams(context.TODO())
+		assert.NoError(t, err)
+		assert.True(t, task.userAutoIndexMetricTypeSpecified)
+		assert.ElementsMatch(t, []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: AutoIndexName},
+			{Key: common.MetricTypeKey, Value: "BM25"},
+		}, task.newExtraParams)
+	})
+
+	t.Run("cloud mode forces metric in build params but keeps raw user params", func(t *testing.T) {
+		Params.Save(Params.AutoIndexConfig.Enable.Key, "true")
+		defer Params.Reset(Params.AutoIndexConfig.Enable.Key)
+
+		task := &createIndexTask{
+			fieldSchema:    sparseOutputField,
+			functionSchema: bm25Function,
+			req: &milvuspb.CreateIndexRequest{
+				ExtraParams: make([]*commonpb.KeyValuePair, 0),
+			},
+		}
+		err := task.parseIndexParams(context.TODO())
+		assert.NoError(t, err)
+		newIndexParams := funcutil.KeyValuePair2Map(task.newIndexParams)
+		assert.Equal(t, "BM25", newIndexParams[common.MetricTypeKey])
+		// the cloud branch keeps the caller's raw extra params.
+		assert.Empty(t, task.newExtraParams)
+	})
+}
+
 func TestAdjustAutoIndexParamsByDataType(t *testing.T) {
 	t.Run("nil config", func(t *testing.T) {
-		result := adjustAutoIndexParamsByDataType(nil, schemapb.DataType_FloatVector)
+		result := indexparamcheck.AdjustAutoIndexParamsByDataType(nil, schemapb.DataType_FloatVector)
 		assert.Nil(t, result)
 	})
 
@@ -2096,7 +2187,7 @@ func TestAdjustAutoIndexParamsByDataType(t *testing.T) {
 			"index_type": "HNSW_SQ",
 			"M":          "18",
 		}
-		result := adjustAutoIndexParamsByDataType(config, schemapb.DataType_BFloat16Vector)
+		result := indexparamcheck.AdjustAutoIndexParamsByDataType(config, schemapb.DataType_BFloat16Vector)
 		assert.Equal(t, config, result)
 	})
 
@@ -2105,7 +2196,7 @@ func TestAdjustAutoIndexParamsByDataType(t *testing.T) {
 			"index_type":  "HNSW_SQ",
 			"refine_type": "FP16",
 		}
-		result := adjustAutoIndexParamsByDataType(config, schemapb.DataType_FloatVector)
+		result := indexparamcheck.AdjustAutoIndexParamsByDataType(config, schemapb.DataType_FloatVector)
 		assert.Contains(t, result, "refine_type")
 		assert.Equal(t, "FP16", result["refine_type"])
 	})
@@ -2115,7 +2206,7 @@ func TestAdjustAutoIndexParamsByDataType(t *testing.T) {
 			"index_type":  "HNSW_SQ",
 			"refine_type": "FP16",
 		}
-		result := adjustAutoIndexParamsByDataType(config, schemapb.DataType_Float16Vector)
+		result := indexparamcheck.AdjustAutoIndexParamsByDataType(config, schemapb.DataType_Float16Vector)
 		assert.Equal(t, config, result) // same object, no copy needed
 	})
 
@@ -2125,7 +2216,7 @@ func TestAdjustAutoIndexParamsByDataType(t *testing.T) {
 			"refine_type": "BF16",
 			"M":           "18",
 		}
-		result := adjustAutoIndexParamsByDataType(config, schemapb.DataType_Float16Vector)
+		result := indexparamcheck.AdjustAutoIndexParamsByDataType(config, schemapb.DataType_Float16Vector)
 		assert.Contains(t, result, "refine_type")
 		assert.Equal(t, "FP16", result["refine_type"])
 		assert.Contains(t, result, "index_type")
@@ -2137,7 +2228,7 @@ func TestAdjustAutoIndexParamsByDataType(t *testing.T) {
 			"index_type":  "HNSW_SQ",
 			"refine_type": "BF16",
 		}
-		result := adjustAutoIndexParamsByDataType(config, schemapb.DataType_BFloat16Vector)
+		result := indexparamcheck.AdjustAutoIndexParamsByDataType(config, schemapb.DataType_BFloat16Vector)
 		assert.Equal(t, config, result) // same object, no copy needed
 	})
 
@@ -2147,7 +2238,7 @@ func TestAdjustAutoIndexParamsByDataType(t *testing.T) {
 			"refine_type": "FP16",
 			"M":           "18",
 		}
-		result := adjustAutoIndexParamsByDataType(config, schemapb.DataType_BFloat16Vector)
+		result := indexparamcheck.AdjustAutoIndexParamsByDataType(config, schemapb.DataType_BFloat16Vector)
 		assert.Contains(t, result, "refine_type")
 		assert.Equal(t, "BF16", result["refine_type"])
 		assert.Contains(t, result, "index_type")
@@ -2159,7 +2250,7 @@ func TestAdjustAutoIndexParamsByDataType(t *testing.T) {
 			"index_type":  "HNSW_SQ",
 			"refine_type": "SQ8",
 		}
-		result := adjustAutoIndexParamsByDataType(config, schemapb.DataType_Float16Vector)
+		result := indexparamcheck.AdjustAutoIndexParamsByDataType(config, schemapb.DataType_Float16Vector)
 		assert.Equal(t, config, result) // not modified
 	})
 
@@ -2168,7 +2259,7 @@ func TestAdjustAutoIndexParamsByDataType(t *testing.T) {
 			"index_type":  "HNSW_SQ",
 			"refine_type": "SQ8",
 		}
-		result := adjustAutoIndexParamsByDataType(config, schemapb.DataType_BFloat16Vector)
+		result := indexparamcheck.AdjustAutoIndexParamsByDataType(config, schemapb.DataType_BFloat16Vector)
 		assert.Equal(t, config, result) // not modified
 	})
 
@@ -2177,7 +2268,7 @@ func TestAdjustAutoIndexParamsByDataType(t *testing.T) {
 			"index_type":  "HNSW_SQ",
 			"refine_type": "FP16",
 		}
-		result := adjustAutoIndexParamsByDataType(config, schemapb.DataType_BFloat16Vector)
+		result := indexparamcheck.AdjustAutoIndexParamsByDataType(config, schemapb.DataType_BFloat16Vector)
 		// Original config should still have original refine_type
 		assert.Equal(t, "FP16", config["refine_type"])
 		// Result should have replaced refine_type

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -7865,6 +7865,33 @@ func TestAlterCollectionSchemaTask(t *testing.T) {
 			},
 		}
 	}
+	buildValidMinHashRequest := func() *milvuspb.AlterCollectionSchemaRequest {
+		req := buildValidRequest()
+		addRequest := req.GetAction().GetAddRequest()
+		addRequest.FieldInfos[0].FieldSchema = &schemapb.FieldSchema{
+			Name:     "binary_minhash",
+			DataType: schemapb.DataType_BinaryVector,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.DimKey, Value: "4096"},
+			},
+		}
+		addRequest.FieldInfos[0].ExtraParams = []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: "MINHASH_LSH"},
+			{Key: common.MetricTypeKey, Value: "MHJACCARD"},
+		}
+		functionSchema := proto.Clone(addRequest.GetFuncSchema()[0]).(*schemapb.FunctionSchema)
+		functionSchema.Name = "minhash_func"
+		functionSchema.Type = schemapb.FunctionType_MinHash
+		functionSchema.OutputFieldNames = []string{"binary_minhash"}
+		functionSchema.Params = []*commonpb.KeyValuePair{
+			{Key: "num_hashes", Value: "128"},
+			{Key: "shingle_size", Value: "3"},
+			{Key: "hash_function", Value: "xxhash64"},
+			{Key: "seed", Value: "42"},
+		}
+		addRequest.FuncSchema = []*schemapb.FunctionSchema{functionSchema}
+		return req
+	}
 
 	buildAddFieldRequest := func(fieldName string, nullable bool, doBackfill bool) *milvuspb.AlterCollectionSchemaRequest {
 		return &milvuspb.AlterCollectionSchemaRequest{
@@ -8158,34 +8185,21 @@ func TestAlterCollectionSchemaTask(t *testing.T) {
 	})
 
 	t.Run("PreExecute supports MinHash function with new output field", func(t *testing.T) {
-		req := buildValidRequest()
-		addRequest := req.GetAction().GetAddRequest()
-		addRequest.FieldInfos[0].FieldSchema = &schemapb.FieldSchema{
-			Name:     "binary_minhash",
-			DataType: schemapb.DataType_BinaryVector,
-			TypeParams: []*commonpb.KeyValuePair{
-				{Key: common.DimKey, Value: "4096"},
-			},
-		}
-		addRequest.FieldInfos[0].ExtraParams = []*commonpb.KeyValuePair{
-			{Key: common.IndexTypeKey, Value: "MINHASH_LSH"},
-			{Key: common.MetricTypeKey, Value: "MHJACCARD"},
-		}
-		functionSchema := proto.Clone(addRequest.GetFuncSchema()[0]).(*schemapb.FunctionSchema)
-		functionSchema.Name = "minhash_func"
-		functionSchema.Type = schemapb.FunctionType_MinHash
-		functionSchema.OutputFieldNames = []string{"binary_minhash"}
-		functionSchema.Params = []*commonpb.KeyValuePair{
-			{Key: "num_hashes", Value: "128"},
-			{Key: "shingle_size", Value: "3"},
-			{Key: "hash_function", Value: "xxhash64"},
-			{Key: "seed", Value: "42"},
-		}
-		addRequest.FuncSchema = []*schemapb.FunctionSchema{functionSchema}
-
-		task := buildTask(req, oldSchema)
+		task := buildTask(buildValidMinHashRequest(), oldSchema)
 		err := task.PreExecute(ctx)
 		assert.NoError(t, err)
+	})
+
+	t.Run("PreExecute rejects MinHash AutoIndex with non-MHJACCARD metric", func(t *testing.T) {
+		req := buildValidMinHashRequest()
+		req.GetAction().GetAddRequest().GetFieldInfos()[0].ExtraParams = []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: common.AutoIndexName},
+			{Key: common.MetricTypeKey, Value: "HAMMING"},
+		}
+		task := buildTask(req, oldSchema)
+		err := task.PreExecute(ctx)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.ErrorContains(t, err, "must be MHJACCARD")
 	})
 
 	t.Run("PreExecute rejects unsupported function", func(t *testing.T) {
@@ -8265,6 +8279,52 @@ func TestAlterCollectionSchemaTask(t *testing.T) {
 		// UserIndexParams stay aligned with the create_index convention and a
 		// later create_index with identical params remains idempotent.
 		assert.True(t, proto.Equal(original, req.GetAction().GetAddRequest().GetFieldInfos()[0]))
+	})
+
+	t.Run("PreExecute empty index params resolve via AutoIndex", func(t *testing.T) {
+		req := buildValidRequest()
+		req.GetAction().GetAddRequest().GetFieldInfos()[0].ExtraParams = nil
+		task := buildTask(req, oldSchema)
+		err := task.PreExecute(ctx)
+		assert.NoError(t, err)
+		// Validation-only: the request still carries no params; rootcoord
+		// resolves and persists the concrete index at prepare.
+		assert.Empty(t, req.GetAction().GetAddRequest().GetFieldInfos()[0].GetExtraParams())
+	})
+
+	t.Run("PreExecute AUTOINDEX with metric passes", func(t *testing.T) {
+		req := buildValidRequest()
+		req.GetAction().GetAddRequest().GetFieldInfos()[0].ExtraParams = []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: common.AutoIndexName},
+			{Key: common.MetricTypeKey, Value: "BM25"},
+		}
+		task := buildTask(req, oldSchema)
+		assert.NoError(t, task.PreExecute(ctx))
+	})
+
+	t.Run("PreExecute AUTOINDEX with non-metric param rejected", func(t *testing.T) {
+		req := buildValidRequest()
+		req.GetAction().GetAddRequest().GetFieldInfos()[0].ExtraParams = []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: common.AutoIndexName},
+			{Key: "drop_ratio_build", Value: "0.2"},
+		}
+		task := buildTask(req, oldSchema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.ErrorContains(t, err, "only metric type can be passed")
+	})
+
+	t.Run("PreExecute AUTOINDEX with wrong metric for BM25 rejected", func(t *testing.T) {
+		req := buildValidRequest()
+		req.GetAction().GetAddRequest().GetFieldInfos()[0].ExtraParams = []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: common.AutoIndexName},
+			{Key: common.MetricTypeKey, Value: "IP"},
+		}
+		task := buildTask(req, oldSchema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "must be BM25")
 	})
 
 	t.Run("Execute leaves function output marker to RootCoord", func(t *testing.T) {

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
@@ -37,6 +37,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/timestamptz"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -193,8 +194,8 @@ func (c *Core) broadcastAlterCollectionSchemaAdd(ctx context.Context, broadcaste
 // apply is a pure idempotent write (a replayed callback rebuilds the identical
 // index), and every input-dependent rejection happens before anything commits.
 func (c *Core) prepareBoundFieldIndex(ctx context.Context, coll *model.Collection, plan *schemautil.AlterSchemaAddPlan) (*indexpb.FieldIndex, error) {
-	indexParamsMap, err := indexparamcheck.PrepareFunctionOutputIndexParams(
-		plan.Function.GetType(), plan.Field.GetName(), plan.IndexExtraParams)
+	indexParamsMap, autoResolved, err := indexparamcheck.PrepareFunctionOutputIndexParams(
+		plan.Function.GetType(), plan.Field, coll.Properties, plan.IndexExtraParams)
 	if err != nil {
 		return nil, err
 	}
@@ -207,6 +208,21 @@ func (c *Core) prepareBoundFieldIndex(ctx context.Context, coll *model.Collectio
 		return nil, merr.WrapErrParameterInvalidMsg(
 			"invalid index type %s for the bound index of function output field %q",
 			indexType, plan.Field.GetName())
+	}
+	// Merge the YAML build-stage knowhere defaults into the params BEFORE
+	// validation, as create_index does. Without this, an operator-configured
+	// build param (e.g. MINHASH_LSH mh_lsh_band/mh_element_bit_width) reaches the
+	// index build via datacoord's own merge but not the collection metadata that
+	// QueryNode uses for brute-force fallback, so indexed and fallback segments
+	// could evaluate one query with incompatible settings. Merging first also
+	// lets the field validation below reject an invalid/oversized operator
+	// default instead of persisting an index that cannot build. Pre-existing gap
+	// for the explicit bound path too; fixing both here. No-op with the default
+	// (empty) knowhere config.
+	if Params.KnowhereConfig.Enable.GetAsBool() {
+		if indexParamsMap, err = Params.KnowhereConfig.MergeIndexParams(indexType, paramtable.BuildStage, indexParamsMap); err != nil {
+			return nil, err
+		}
 	}
 	// Full field-aware validation (params size, dimension fill+match, data-type
 	// compatibility, train params), identical to the create_index path — an index
@@ -255,6 +271,16 @@ func (c *Core) prepareBoundFieldIndex(ctx context.Context, coll *model.Collectio
 	typeParams := lo.Filter(plan.Field.GetTypeParams(), func(kv *commonpb.KeyValuePair, _ int) bool {
 		return kv.GetKey() != common.MmapEnabledKey && kv.GetKey() != common.WarmupKey
 	})
+	// Persist exactly what create_index would persist for the equivalent request,
+	// per deployment mode, so datacoord's checkParams (which compares these pairs)
+	// dedupes a later create_index instead of reporting a distinct-index conflict:
+	// OSS wraps autoindex requests into the canonical AUTOINDEX+metric pair
+	// (wrapUserIndexParams), while the cloud branch (autoIndex.enable=true) keeps
+	// the caller's raw extra params.
+	userIndexParams := plan.IndexExtraParams
+	if autoResolved && !Params.AutoIndexConfig.Enable.GetAsBool() {
+		userIndexParams = indexparamcheck.WrapUserIndexParams(indexParamsMap[common.MetricTypeKey])
+	}
 	index := &model.Index{
 		CollectionID:    coll.CollectionID,
 		FieldID:         plan.Field.GetFieldID(),
@@ -264,7 +290,7 @@ func (c *Core) prepareBoundFieldIndex(ctx context.Context, coll *model.Collectio
 		IndexParams:     indexParams,
 		CreateTime:      createTime,
 		IsAutoIndex:     false,
-		UserIndexParams: plan.IndexExtraParams,
+		UserIndexParams: userIndexParams,
 	}
 	if err := indexparamcheck.ValidateIndexParams(index); err != nil {
 		return nil, err

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
@@ -450,14 +450,6 @@ func TestDDLCallbacksBroadcastAlterCollectionSchema(t *testing.T) {
 	})
 	require.ErrorIs(t, merr.CheckRPCCall(resp.GetAlterStatus(), err), merr.ErrParameterInvalid)
 
-	// case 7.1: vector function output field without bound index params is rejected.
-	noIndexReq := buildAlterSchemaReq(dbName, collectionName, "field1", "sparse_no_index", "fn_no_index")
-	noIndexReq.GetAction().GetAddRequest().GetFieldInfos()[0].ExtraParams = nil
-	resp, err = core.AlterCollectionSchema(ctx, noIndexReq)
-	noIndexErr := merr.CheckRPCCall(resp.GetAlterStatus(), err)
-	require.ErrorIs(t, noIndexErr, merr.ErrParameterInvalid)
-	require.ErrorContains(t, noIndexErr, "index params are required")
-
 	// case 8: output field points to an existing field while FieldInfos adds a different field
 	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
 		DbName:         dbName,
@@ -496,16 +488,18 @@ func TestDDLCallbacksBroadcastAlterCollectionSchema(t *testing.T) {
 	})
 	require.NoError(t, merr.CheckRPCCall(addFieldResp, err))
 
-	// case 7.2: AUTOINDEX is not accepted as the bound index type in V1
-	// (rejected at rootcoord prepare, after function validation passes).
+	// case 7.2: AUTOINDEX only tolerates an additional metric_type; any other
+	// build param is rejected (rejected at rootcoord prepare, after function
+	// validation passes), mirroring the create_index AUTOINDEX restriction.
 	autoIndexReq := buildAlterSchemaReq(dbName, collectionName, "text_input", "sparse_auto_index", "fn_auto_index")
 	autoIndexReq.GetAction().GetAddRequest().GetFieldInfos()[0].ExtraParams = []*commonpb.KeyValuePair{
 		{Key: common.IndexTypeKey, Value: common.AutoIndexName},
+		{Key: "nlist", Value: "128"},
 	}
 	resp, err = core.AlterCollectionSchema(ctx, autoIndexReq)
 	autoIndexErr := merr.CheckRPCCall(resp.GetAlterStatus(), err)
 	require.ErrorIs(t, autoIndexErr, merr.ErrParameterInvalid)
-	require.ErrorContains(t, autoIndexErr, "explicit index_type is required")
+	require.ErrorContains(t, autoIndexErr, "only metric type can be passed")
 
 	// case 7.3: an index type without a registered checker is rejected at prepare —
 	// it would otherwise be persisted via the ack callback and never build.
@@ -706,6 +700,29 @@ func TestDDLCallbacksBroadcastAlterCollectionSchema(t *testing.T) {
 		},
 	})
 	require.Error(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
+
+	// case 12: no index params at all — the bound index resolves via AutoIndex:
+	// the sparse config supplies the index type, the BM25 function forces the
+	// metric (config default IP is not a user choice), and the persisted user
+	// params take the canonical AUTOINDEX shape so a later
+	// create_index(AUTOINDEX) dedupes as idempotent.
+	autoBoundReq := buildAlterSchemaReq(dbName, collectionName, "text_input", "sparse_auto_bound", "fn_auto_bound")
+	autoBoundReq.GetAction().GetAddRequest().GetFieldInfos()[0].ExtraParams = nil
+	resp, err = core.AlterCollectionSchema(ctx, autoBoundReq)
+	require.NoError(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 9)
+	boundIndexes = recordedBoundIndexes()
+	autoBoundIndexInfo := boundIndexes[len(boundIndexes)-1].GetIndexInfo()
+	require.Equal(t, "sparse_auto_bound", autoBoundIndexInfo.GetIndexName())
+	autoBoundParams := funcutil.KeyValuePair2Map(autoBoundIndexInfo.GetIndexParams())
+	require.Equal(t, "SPARSE_INVERTED_INDEX", autoBoundParams[common.IndexTypeKey])
+	require.Equal(t, "BM25", autoBoundParams[common.MetricTypeKey])
+	require.Equal(t, "1.2", autoBoundParams["bm25_k1"])
+	require.Equal(t, []*commonpb.KeyValuePair{
+		{Key: common.IndexTypeKey, Value: common.AutoIndexName},
+		{Key: common.MetricTypeKey, Value: "BM25"},
+	}, autoBoundIndexInfo.GetUserIndexParams())
+	require.False(t, autoBoundIndexInfo.GetIsAutoIndex())
 }
 
 func TestDDLCallbacksAlterCollectionSchemaAnalyzerFileResourceRefs(t *testing.T) {
@@ -1509,6 +1526,220 @@ func TestPrepareBoundFieldIndex(t *testing.T) {
 		// convention), so a later create_index with identical params is
 		// treated as idempotent instead of a distinct index.
 		require.Equal(t, plan.IndexExtraParams, info.GetUserIndexParams())
+	})
+
+	t.Run("empty params resolve via AutoIndex with BM25 metric forced", func(t *testing.T) {
+		coll, plan := newBoundIndexTestPlan()
+		plan.IndexExtraParams = nil
+		c := newTestCore(withMixCoord(withNoIndexMixCoord(t)), withValidIDAllocator(), withTsoAllocator(withOkTso(t)))
+		fieldIndex, err := c.prepareBoundFieldIndex(context.Background(), coll, plan)
+		require.NoError(t, err)
+		info := fieldIndex.GetIndexInfo()
+		params := funcutil.KeyValuePair2Map(info.GetIndexParams())
+		require.Equal(t, "SPARSE_INVERTED_INDEX", params[common.IndexTypeKey])
+		// The sparse autoindex config defaults to IP; the BM25 function type
+		// authoritatively overrides a non-user-specified metric.
+		require.Equal(t, "BM25", params[common.MetricTypeKey])
+		require.Equal(t, "1.2", params["bm25_k1"])
+		require.Equal(t, "0.75", params["bm25_b"])
+		require.Equal(t, "100", params["bm25_avgdl"])
+		require.Equal(t, []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: common.AutoIndexName},
+			{Key: common.MetricTypeKey, Value: "BM25"},
+		}, info.GetUserIndexParams())
+		require.False(t, info.GetIsAutoIndex())
+	})
+
+	t.Run("explicit AUTOINDEX with metric resolves identically", func(t *testing.T) {
+		coll, plan := newBoundIndexTestPlan()
+		plan.IndexExtraParams = []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: common.AutoIndexName},
+			{Key: common.MetricTypeKey, Value: "BM25"},
+		}
+		c := newTestCore(withMixCoord(withNoIndexMixCoord(t)), withValidIDAllocator(), withTsoAllocator(withOkTso(t)))
+		fieldIndex, err := c.prepareBoundFieldIndex(context.Background(), coll, plan)
+		require.NoError(t, err)
+		info := fieldIndex.GetIndexInfo()
+		params := funcutil.KeyValuePair2Map(info.GetIndexParams())
+		require.Equal(t, "SPARSE_INVERTED_INDEX", params[common.IndexTypeKey])
+		require.Equal(t, "BM25", params[common.MetricTypeKey])
+		require.Equal(t, []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: common.AutoIndexName},
+			{Key: common.MetricTypeKey, Value: "BM25"},
+		}, info.GetUserIndexParams())
+	})
+
+	t.Run("AUTOINDEX with non-metric build param rejected", func(t *testing.T) {
+		coll, plan := newBoundIndexTestPlan()
+		plan.IndexExtraParams = []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: common.AutoIndexName},
+			{Key: "nlist", Value: "128"},
+		}
+		c := newTestCore(withMixCoord(withNoIndexMixCoord(t)), withValidIDAllocator(), withTsoAllocator(withOkTso(t)))
+		_, err := c.prepareBoundFieldIndex(context.Background(), coll, plan)
+		require.ErrorIs(t, err, merr.ErrParameterInvalid)
+		require.ErrorContains(t, err, "only metric type can be passed")
+	})
+
+	t.Run("explicit empty index type rejected, not auto-resolved", func(t *testing.T) {
+		coll, plan := newBoundIndexTestPlan()
+		plan.IndexExtraParams = []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: ""},
+		}
+		c := newTestCore(withMixCoord(withNoIndexMixCoord(t)), withValidIDAllocator(), withTsoAllocator(withOkTso(t)))
+		_, err := c.prepareBoundFieldIndex(context.Background(), coll, plan)
+		require.ErrorIs(t, err, merr.ErrParameterInvalid)
+		require.ErrorContains(t, err, "invalid index type")
+	})
+
+	t.Run("MinHash AutoIndex with dedup metric picks deduplicate config", func(t *testing.T) {
+		coll, plan := newBoundIndexTestPlan()
+		plan.Field = &schemapb.FieldSchema{
+			FieldID:  102,
+			Name:     "binary_mh",
+			DataType: schemapb.DataType_BinaryVector,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.DimKey, Value: "512"},
+			},
+		}
+		plan.Function = &schemapb.FunctionSchema{Name: "mh_fn", Type: schemapb.FunctionType_MinHash}
+		plan.IndexExtraParams = []*commonpb.KeyValuePair{
+			{Key: common.MetricTypeKey, Value: "MHJACCARD"},
+		}
+		c := newTestCore(withMixCoord(withNoIndexMixCoord(t)), withValidIDAllocator(), withTsoAllocator(withOkTso(t)))
+		fieldIndex, err := c.prepareBoundFieldIndex(context.Background(), coll, plan)
+		require.NoError(t, err)
+		info := fieldIndex.GetIndexInfo()
+		params := funcutil.KeyValuePair2Map(info.GetIndexParams())
+		require.Equal(t, "MINHASH_LSH", params[common.IndexTypeKey])
+		require.Equal(t, "MHJACCARD", params[common.MetricTypeKey])
+		require.Equal(t, []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: common.AutoIndexName},
+			{Key: common.MetricTypeKey, Value: "MHJACCARD"},
+		}, info.GetUserIndexParams())
+	})
+
+	t.Run("MinHash AutoIndex with non-dedup metric rejected", func(t *testing.T) {
+		coll, plan := newBoundIndexTestPlan()
+		plan.Field = &schemapb.FieldSchema{
+			FieldID:  102,
+			Name:     "binary_mh",
+			DataType: schemapb.DataType_BinaryVector,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.DimKey, Value: "512"},
+			},
+		}
+		plan.Function = &schemapb.FunctionSchema{Name: "mh_fn", Type: schemapb.FunctionType_MinHash}
+		plan.IndexExtraParams = []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: common.AutoIndexName},
+			{Key: common.MetricTypeKey, Value: "HAMMING"},
+		}
+		c := newTestCore(withMixCoord(withNoIndexMixCoord(t)), withValidIDAllocator(), withTsoAllocator(withOkTso(t)))
+		_, err := c.prepareBoundFieldIndex(context.Background(), coll, plan)
+		require.ErrorIs(t, err, merr.ErrParameterInvalid)
+		require.ErrorContains(t, err, "must be MHJACCARD")
+	})
+
+	t.Run("MinHash empty params resolve to deduplicate config", func(t *testing.T) {
+		coll, plan := newBoundIndexTestPlan()
+		plan.Field = &schemapb.FieldSchema{
+			FieldID:  102,
+			Name:     "binary_mh",
+			DataType: schemapb.DataType_BinaryVector,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.DimKey, Value: "512"},
+			},
+		}
+		plan.Function = &schemapb.FunctionSchema{Name: "mh_fn", Type: schemapb.FunctionType_MinHash}
+		plan.IndexExtraParams = nil
+		c := newTestCore(withMixCoord(withNoIndexMixCoord(t)), withValidIDAllocator(), withTsoAllocator(withOkTso(t)))
+		fieldIndex, err := c.prepareBoundFieldIndex(context.Background(), coll, plan)
+		require.NoError(t, err)
+		info := fieldIndex.GetIndexInfo()
+		params := funcutil.KeyValuePair2Map(info.GetIndexParams())
+		// The function type authoritatively selects the dedup config; the
+		// generic binary config cannot serve MinHash searches.
+		require.Equal(t, "MINHASH_LSH", params[common.IndexTypeKey])
+		require.Equal(t, "MHJACCARD", params[common.MetricTypeKey])
+		require.Equal(t, []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: common.AutoIndexName},
+			{Key: common.MetricTypeKey, Value: "MHJACCARD"},
+		}, info.GetUserIndexParams())
+	})
+
+	t.Run("cloud mode persists raw user params for auto-resolved index", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().AutoIndexConfig.Enable.Key, "true")
+		defer paramtable.Get().Reset(paramtable.Get().AutoIndexConfig.Enable.Key)
+
+		coll, plan := newBoundIndexTestPlan()
+		plan.IndexExtraParams = nil
+		c := newTestCore(withMixCoord(withNoIndexMixCoord(t)), withValidIDAllocator(), withTsoAllocator(withOkTso(t)))
+		fieldIndex, err := c.prepareBoundFieldIndex(context.Background(), coll, plan)
+		require.NoError(t, err)
+		info := fieldIndex.GetIndexInfo()
+		params := funcutil.KeyValuePair2Map(info.GetIndexParams())
+		require.Equal(t, "SPARSE_INVERTED_INDEX", params[common.IndexTypeKey])
+		require.Equal(t, "BM25", params[common.MetricTypeKey])
+		// The cloud create_index branch does not canonicalize user params, so the
+		// bound index must not either — otherwise a later create_index would hit a
+		// UserIndexParams length mismatch in checkParams instead of deduping.
+		require.Empty(t, info.GetUserIndexParams())
+	})
+
+	t.Run("knowhere build defaults merged into persisted index params", func(t *testing.T) {
+		// Operator-configured build params must be persisted the same way
+		// create_index does, so QueryNode's brute-force fallback and the built
+		// index agree on MinHash settings.
+		paramtable.Get().Save("knowhere.MINHASH_LSH.build.mh_lsh_band", "6")
+		defer paramtable.Get().Reset("knowhere.MINHASH_LSH.build.mh_lsh_band")
+
+		coll, plan := newBoundIndexTestPlan()
+		plan.Field = &schemapb.FieldSchema{
+			FieldID:  102,
+			Name:     "binary_mh",
+			DataType: schemapb.DataType_BinaryVector,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.DimKey, Value: "512"},
+			},
+		}
+		plan.Function = &schemapb.FunctionSchema{Name: "mh_fn", Type: schemapb.FunctionType_MinHash}
+		plan.IndexExtraParams = []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: "MINHASH_LSH"},
+			{Key: common.MetricTypeKey, Value: "MHJACCARD"},
+		}
+		c := newTestCore(withMixCoord(withNoIndexMixCoord(t)), withValidIDAllocator(), withTsoAllocator(withOkTso(t)))
+		fieldIndex, err := c.prepareBoundFieldIndex(context.Background(), coll, plan)
+		require.NoError(t, err)
+		params := funcutil.KeyValuePair2Map(fieldIndex.GetIndexInfo().GetIndexParams())
+		require.Equal(t, "6", params["mh_lsh_band"])
+	})
+
+	t.Run("oversized knowhere build default rejected after merge", func(t *testing.T) {
+		// The merged defaults must be validated (size, train), matching
+		// create_index, so an invalid operator default rejects the DDL instead
+		// of persisting an index that cannot build.
+		paramtable.Get().Save("knowhere.MINHASH_LSH.build.mh_lsh_band",
+			strings.Repeat("x", paramtable.Get().ProxyCfg.MaxIndexParamsSize.GetAsInt()+1))
+		defer paramtable.Get().Reset("knowhere.MINHASH_LSH.build.mh_lsh_band")
+
+		coll, plan := newBoundIndexTestPlan()
+		plan.Field = &schemapb.FieldSchema{
+			FieldID:  102,
+			Name:     "binary_mh",
+			DataType: schemapb.DataType_BinaryVector,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.DimKey, Value: "512"},
+			},
+		}
+		plan.Function = &schemapb.FunctionSchema{Name: "mh_fn", Type: schemapb.FunctionType_MinHash}
+		plan.IndexExtraParams = []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: "MINHASH_LSH"},
+			{Key: common.MetricTypeKey, Value: "MHJACCARD"},
+		}
+		c := newTestCore(withMixCoord(withNoIndexMixCoord(t)), withValidIDAllocator(), withTsoAllocator(withOkTso(t)))
+		_, err := c.prepareBoundFieldIndex(context.Background(), coll, plan)
+		require.ErrorIs(t, err, merr.ErrParameterInvalid)
+		require.ErrorContains(t, err, "exceeds limit")
 	})
 
 	t.Run("index name conflict rejected", func(t *testing.T) {

--- a/internal/util/indexparamcheck/index_params_validation.go
+++ b/internal/util/indexparamcheck/index_params_validation.go
@@ -112,25 +112,174 @@ func FillFunctionOutputIndexParams(functionType schemapb.FunctionType, indexPara
 	return nil
 }
 
+// RefineTypeKey is the autoindex build-param key carrying the refine type for
+// dense float vector indexes.
+const RefineTypeKey = "refine_type"
+
+// WrapUserIndexParams builds the canonical user-index-params of an
+// AUTOINDEX-resolved index. Shared by the create_index path (proxy) and the
+// add-function-field bound-index prepare (rootcoord): datacoord's checkParams
+// dedupes a later create_index by comparing exactly these pairs, so both paths
+// must persist the same shape.
+func WrapUserIndexParams(metricType string) []*commonpb.KeyValuePair {
+	return []*commonpb.KeyValuePair{
+		{
+			Key:   common.IndexTypeKey,
+			Value: common.AutoIndexName,
+		},
+		{
+			Key:   common.MetricTypeKey,
+			Value: metricType,
+		},
+	}
+}
+
+// AdjustAutoIndexParamsByDataType adjusts autoindex params based on vector data type.
+// If data_type is bf16 and refine_type is fp16/fp32, adjust to BF16.
+// If data_type is fp16 and refine_type is bf16/fp32, adjust to FP16.
+// Other refine_type values (e.g., sq8) are not modified.
+func AdjustAutoIndexParamsByDataType(config map[string]string, dataType schemapb.DataType) map[string]string {
+	if config == nil {
+		return config
+	}
+	refineType, hasRefine := config[RefineTypeKey]
+	if !hasRefine {
+		return config
+	}
+
+	refineTypeLower := strings.ToLower(refineType)
+	var requiredRefineType string
+
+	switch dataType {
+	case schemapb.DataType_Float16Vector:
+		// fp16 data requires fp16 refine, adjust if refine_type is bf16/fp32
+		if refineTypeLower == "bf16" || refineTypeLower == "fp32" {
+			requiredRefineType = "FP16"
+		}
+	case schemapb.DataType_BFloat16Vector:
+		// bf16 data requires bf16 refine, adjust if refine_type is fp16/fp32
+		if refineTypeLower == "fp16" || refineTypeLower == "fp32" {
+			requiredRefineType = "BF16"
+		}
+	}
+
+	if requiredRefineType == "" {
+		return config
+	}
+
+	adjusted := make(map[string]string, len(config))
+	for k, v := range config {
+		adjusted[k] = v
+	}
+	adjusted[RefineTypeKey] = requiredRefineType
+	return adjusted
+}
+
+// GetDenseFloatAutoIndexParams returns the autoindex build params for dense
+// float vector fields. Large-topk params apply only when autoindex is enabled
+// (cloud instance) and the collection is in large-topk query mode.
+func GetDenseFloatAutoIndexParams(collectionProperties []*commonpb.KeyValuePair) map[string]string {
+	autoIndexCfg := &paramtable.Get().AutoIndexConfig
+	if autoIndexCfg.Enable.GetAsBool() && common.IsQueryModeLargeTopK(collectionProperties...) {
+		return autoIndexCfg.LargeTopKIndexParams.GetAsJSONMap()
+	}
+	return autoIndexCfg.IndexParams.GetAsJSONMap()
+}
+
 // PrepareFunctionOutputIndexParams expands the user-provided extra params of a
-// function output field's bound index, requires an explicit index type (no
-// AUTOINDEX resolution for bound indexes), and applies function-type-specific
-// defaults. Shared by proxy validation and rootcoord materialization so both
-// operate on identical params.
-func PrepareFunctionOutputIndexParams(functionType schemapb.FunctionType, fieldName string, extraParams []*commonpb.KeyValuePair) (map[string]string, error) {
+// function output field's bound index and produces its concrete build params.
+// An explicit index_type passes through unchanged (function-type defaults
+// applied). A missing or AUTOINDEX index_type is resolved from the AutoIndex
+// config of the field's vector type under the create_index AUTOINDEX rules:
+// besides index_type only metric_type may be supplied, and a user-specified
+// metric wins over the config one. One deliberate divergence: for a BM25
+// function the required metric is known authoritatively, so a config-injected
+// (non-user) metric is forced to BM25 instead of failing the BM25 metric check.
+// Likewise, a MinHash function requires MHJACCARD: an omitted metric selects
+// the deduplicate config, while an explicitly conflicting metric is rejected.
+// Returns resolvedByAutoIndex=true when the AutoIndex path was taken so callers
+// persist the canonical AUTOINDEX user params (WrapUserIndexParams). Shared by
+// proxy validation and rootcoord materialization so both operate on identical
+// params.
+func PrepareFunctionOutputIndexParams(functionType schemapb.FunctionType, field *schemapb.FieldSchema, collectionProperties, extraParams []*commonpb.KeyValuePair) (map[string]string, bool, error) {
 	indexParamsMap, err := ExpandIndexParams(extraParams)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	indexType := indexParamsMap[common.IndexTypeKey]
-	if indexType == "" || indexType == common.AutoIndexName {
-		return nil, merr.WrapErrParameterInvalidMsg(
-			"an explicit index_type is required for the bound index of function output field %q", fieldName)
+	// AutoIndex resolution triggers only when the index_type KEY is absent or its
+	// value is exactly AUTOINDEX — same presence-based rule as create_index. A
+	// present-but-empty value is a malformed request that stays on the explicit
+	// path and is rejected downstream by the checker-existence validation.
+	indexType, hasIndexType := indexParamsMap[common.IndexTypeKey]
+	if hasIndexType && indexType != common.AutoIndexName {
+		if err := FillFunctionOutputIndexParams(functionType, indexParamsMap); err != nil {
+			return nil, false, err
+		}
+		return indexParamsMap, false, nil
+	}
+
+	allowed := 0
+	if hasIndexType {
+		allowed++
+	}
+	userMetric, userMetricSpecified := indexParamsMap[common.MetricTypeKey]
+	if userMetricSpecified {
+		allowed++
+	}
+	if len(indexParamsMap) > allowed {
+		return nil, false, merr.WrapErrParameterInvalidMsg(
+			"only metric type can be passed when use AutoIndex for the bound index of function output field %q", field.GetName())
+	}
+	if functionType == schemapb.FunctionType_MinHash && userMetricSpecified && userMetric != metric.MHJACCARD {
+		return nil, false, merr.WrapErrParameterInvalidMsg(
+			"index metric type of MinHash function output field must be MHJACCARD, got %s", userMetric)
+	}
+
+	autoIndexCfg := &paramtable.Get().AutoIndexConfig
+	var config map[string]string
+	switch {
+	case typeutil.IsDenseFloatVectorType(field.GetDataType()):
+		config = AdjustAutoIndexParamsByDataType(GetDenseFloatAutoIndexParams(collectionProperties), field.GetDataType())
+	case typeutil.IsSparseFloatVectorType(field.GetDataType()):
+		config = autoIndexCfg.SparseIndexParams.GetAsJSONMap()
+	case typeutil.IsBinaryVectorType(field.GetDataType()):
+		// A MinHash output field with no user metric must resolve to the
+		// deduplicate config (MINHASH_LSH/MHJACCARD): the generic binary config
+		// would build an index that cannot serve MinHash searches. Same
+		// function-knows-best rule as the BM25 metric forcing below.
+		if (userMetricSpecified && funcutil.SliceContain(DeduplicateMetrics, userMetric)) ||
+			(!userMetricSpecified && functionType == schemapb.FunctionType_MinHash) {
+			// The cloud create_index path gates deduplicate autoindex behind
+			// autoIndex.params.deduplicate.enable; mirror it. The OSS
+			// create_index path ignores the gate, so OSS stays ungated here too.
+			if autoIndexCfg.Enable.GetAsBool() && !autoIndexCfg.EnableDeduplicateIndex.GetAsBool() {
+				return nil, false, merr.WrapErrParameterInvalidMsg(
+					"Deduplicate index is not enabled, cannot resolve the bound index of function output field %q via AutoIndex", field.GetName())
+			}
+			config = autoIndexCfg.DeduplicateIndexParams.GetAsJSONMap()
+		} else {
+			config = autoIndexCfg.BinaryIndexParams.GetAsJSONMap()
+		}
+	case typeutil.IsIntVectorType(field.GetDataType()):
+		config = autoIndexCfg.IntVectorIndexParams.GetAsJSONMap()
+	default:
+		return nil, false, merr.WrapErrParameterInvalidMsg(
+			"AutoIndex for the bound index of function output field %q is not supported on data type %s",
+			field.GetName(), field.GetDataType().String())
+	}
+	for k, v := range config {
+		indexParamsMap[k] = v
+	}
+	if userMetricSpecified {
+		// the user's metric type is first class citizen, same as create_index.
+		indexParamsMap[common.MetricTypeKey] = userMetric
+	} else if functionType == schemapb.FunctionType_BM25 {
+		indexParamsMap[common.MetricTypeKey] = metric.BM25
 	}
 	if err := FillFunctionOutputIndexParams(functionType, indexParamsMap); err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return indexParamsMap, nil
+	return indexParamsMap, true, nil
 }
 
 // ExpandIndexParams flattens user-provided index extra params into a plain map,

--- a/internal/util/indexparamcheck/index_params_validation_test.go
+++ b/internal/util/indexparamcheck/index_params_validation_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -259,4 +260,215 @@ func TestValidateIndexName(t *testing.T) {
 	assert.Error(t, ValidateIndexName("1bad"))
 	assert.Error(t, ValidateIndexName("bad-name"))
 	assert.Error(t, ValidateIndexName(strings.Repeat("x", paramtable.Get().ProxyCfg.MaxNameLength.GetAsInt()+1)))
+}
+
+func TestPrepareFunctionOutputIndexParams(t *testing.T) {
+	paramtable.Init()
+
+	sparseField := &schemapb.FieldSchema{
+		FieldID:  101,
+		Name:     "sparse",
+		DataType: schemapb.DataType_SparseFloatVector,
+	}
+	binaryField := &schemapb.FieldSchema{
+		FieldID:  102,
+		Name:     "binary_mh",
+		DataType: schemapb.DataType_BinaryVector,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: common.DimKey, Value: "512"},
+		},
+	}
+	denseField := &schemapb.FieldSchema{
+		FieldID:  103,
+		Name:     "dense",
+		DataType: schemapb.DataType_FloatVector,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: common.DimKey, Value: "128"},
+		},
+	}
+
+	t.Run("explicit index type passes through with function defaults", func(t *testing.T) {
+		params, resolved, err := PrepareFunctionOutputIndexParams(schemapb.FunctionType_BM25, sparseField, nil, []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: "SPARSE_INVERTED_INDEX"},
+			{Key: common.MetricTypeKey, Value: "BM25"},
+		})
+		assert.NoError(t, err)
+		assert.False(t, resolved)
+		assert.Equal(t, "SPARSE_INVERTED_INDEX", params[common.IndexTypeKey])
+		assert.Equal(t, "1.2", params["bm25_k1"])
+	})
+
+	t.Run("explicit wrong metric for BM25 function rejected", func(t *testing.T) {
+		_, _, err := PrepareFunctionOutputIndexParams(schemapb.FunctionType_BM25, sparseField, nil, []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: "SPARSE_INVERTED_INDEX"},
+			{Key: common.MetricTypeKey, Value: "IP"},
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "must be BM25")
+	})
+
+	t.Run("empty params resolve sparse with BM25 metric forced", func(t *testing.T) {
+		params, resolved, err := PrepareFunctionOutputIndexParams(schemapb.FunctionType_BM25, sparseField, nil, nil)
+		assert.NoError(t, err)
+		assert.True(t, resolved)
+		sparseCfg := paramtable.Get().AutoIndexConfig.SparseIndexParams.GetAsJSONMap()
+		assert.Equal(t, sparseCfg[common.IndexTypeKey], params[common.IndexTypeKey])
+		// the sparse config default metric (IP) is not a user choice; the BM25
+		// function type forces BM25.
+		assert.Equal(t, "BM25", params[common.MetricTypeKey])
+		assert.Equal(t, "1.2", params["bm25_k1"])
+		assert.Equal(t, "0.75", params["bm25_b"])
+		assert.Equal(t, "100", params["bm25_avgdl"])
+	})
+
+	t.Run("AUTOINDEX with metric resolves", func(t *testing.T) {
+		params, resolved, err := PrepareFunctionOutputIndexParams(schemapb.FunctionType_BM25, sparseField, nil, []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: common.AutoIndexName},
+			{Key: common.MetricTypeKey, Value: "BM25"},
+		})
+		assert.NoError(t, err)
+		assert.True(t, resolved)
+		assert.Equal(t, "BM25", params[common.MetricTypeKey])
+		assert.NotEqual(t, common.AutoIndexName, params[common.IndexTypeKey])
+	})
+
+	t.Run("metric only resolves", func(t *testing.T) {
+		params, resolved, err := PrepareFunctionOutputIndexParams(schemapb.FunctionType_BM25, sparseField, nil, []*commonpb.KeyValuePair{
+			{Key: common.MetricTypeKey, Value: "BM25"},
+		})
+		assert.NoError(t, err)
+		assert.True(t, resolved)
+		assert.Equal(t, "BM25", params[common.MetricTypeKey])
+	})
+
+	t.Run("metric via legacy params json resolves", func(t *testing.T) {
+		params, resolved, err := PrepareFunctionOutputIndexParams(schemapb.FunctionType_BM25, sparseField, nil, []*commonpb.KeyValuePair{
+			{Key: common.ParamsKey, Value: `{"metric_type": "BM25"}`},
+		})
+		assert.NoError(t, err)
+		assert.True(t, resolved)
+		assert.Equal(t, "BM25", params[common.MetricTypeKey])
+	})
+
+	t.Run("AUTOINDEX with non-metric build param rejected", func(t *testing.T) {
+		_, _, err := PrepareFunctionOutputIndexParams(schemapb.FunctionType_BM25, sparseField, nil, []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: common.AutoIndexName},
+			{Key: "drop_ratio_build", Value: "0.2"},
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "only metric type can be passed")
+	})
+
+	t.Run("user wrong metric on BM25 function still rejected in AutoIndex path", func(t *testing.T) {
+		_, _, err := PrepareFunctionOutputIndexParams(schemapb.FunctionType_BM25, sparseField, nil, []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: common.AutoIndexName},
+			{Key: common.MetricTypeKey, Value: "IP"},
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "must be BM25")
+	})
+
+	t.Run("dense field resolves from dense config", func(t *testing.T) {
+		params, resolved, err := PrepareFunctionOutputIndexParams(schemapb.FunctionType_TextEmbedding, denseField, nil, nil)
+		assert.NoError(t, err)
+		assert.True(t, resolved)
+		denseCfg := GetDenseFloatAutoIndexParams(nil)
+		assert.Equal(t, denseCfg[common.IndexTypeKey], params[common.IndexTypeKey])
+		assert.Equal(t, denseCfg[common.MetricTypeKey], params[common.MetricTypeKey])
+	})
+
+	t.Run("binary dedup metric picks deduplicate config", func(t *testing.T) {
+		params, resolved, err := PrepareFunctionOutputIndexParams(schemapb.FunctionType_MinHash, binaryField, nil, []*commonpb.KeyValuePair{
+			{Key: common.MetricTypeKey, Value: "MHJACCARD"},
+		})
+		assert.NoError(t, err)
+		assert.True(t, resolved)
+		dedupCfg := paramtable.Get().AutoIndexConfig.DeduplicateIndexParams.GetAsJSONMap()
+		assert.Equal(t, dedupCfg[common.IndexTypeKey], params[common.IndexTypeKey])
+		assert.Equal(t, "MHJACCARD", params[common.MetricTypeKey])
+	})
+
+	t.Run("MinHash without metric picks deduplicate config", func(t *testing.T) {
+		params, resolved, err := PrepareFunctionOutputIndexParams(schemapb.FunctionType_MinHash, binaryField, nil, nil)
+		assert.NoError(t, err)
+		assert.True(t, resolved)
+		// The generic binary config (BIN_IVF_FLAT/HAMMING) cannot serve MinHash
+		// searches; the function type authoritatively picks the dedup config.
+		dedupCfg := paramtable.Get().AutoIndexConfig.DeduplicateIndexParams.GetAsJSONMap()
+		assert.Equal(t, dedupCfg[common.IndexTypeKey], params[common.IndexTypeKey])
+		assert.Equal(t, dedupCfg[common.MetricTypeKey], params[common.MetricTypeKey])
+	})
+
+	t.Run("MinHash with explicit non-dedup metric rejected", func(t *testing.T) {
+		_, _, err := PrepareFunctionOutputIndexParams(schemapb.FunctionType_MinHash, binaryField, nil, []*commonpb.KeyValuePair{
+			{Key: common.MetricTypeKey, Value: "HAMMING"},
+		})
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "must be MHJACCARD")
+	})
+
+	t.Run("explicit empty index type stays on explicit path", func(t *testing.T) {
+		// Presence-based rule, same as create_index: a present-but-empty
+		// index_type is a malformed request, NOT an AutoIndex trigger, and dies
+		// at the checker-existence validation the callers run.
+		params, resolved, err := PrepareFunctionOutputIndexParams(schemapb.FunctionType_BM25, sparseField, nil, []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: ""},
+		})
+		assert.NoError(t, err)
+		assert.False(t, resolved)
+		assert.Equal(t, "", params[common.IndexTypeKey])
+		err = ValidateFieldIndexParams(sparseField, params)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid index type")
+	})
+
+	t.Run("cloud dedup gate rejects MinHash AutoIndex when disabled", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().AutoIndexConfig.Enable.Key, "true")
+		defer paramtable.Get().Reset(paramtable.Get().AutoIndexConfig.Enable.Key)
+
+		// autoIndex.params.deduplicate.enable defaults to false.
+		_, _, err := PrepareFunctionOutputIndexParams(schemapb.FunctionType_MinHash, binaryField, nil, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Deduplicate index is not enabled")
+
+		_, _, err = PrepareFunctionOutputIndexParams(schemapb.FunctionType_MinHash, binaryField, nil, []*commonpb.KeyValuePair{
+			{Key: common.MetricTypeKey, Value: "MHJACCARD"},
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Deduplicate index is not enabled")
+	})
+
+	t.Run("cloud dedup gate enabled resolves MinHash AutoIndex", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().AutoIndexConfig.Enable.Key, "true")
+		paramtable.Get().Save(paramtable.Get().AutoIndexConfig.EnableDeduplicateIndex.Key, "true")
+		defer paramtable.Get().Reset(paramtable.Get().AutoIndexConfig.Enable.Key)
+		defer paramtable.Get().Reset(paramtable.Get().AutoIndexConfig.EnableDeduplicateIndex.Key)
+
+		params, resolved, err := PrepareFunctionOutputIndexParams(schemapb.FunctionType_MinHash, binaryField, nil, nil)
+		assert.NoError(t, err)
+		assert.True(t, resolved)
+		dedupCfg := paramtable.Get().AutoIndexConfig.DeduplicateIndexParams.GetAsJSONMap()
+		assert.Equal(t, dedupCfg[common.IndexTypeKey], params[common.IndexTypeKey])
+	})
+
+	t.Run("unsupported data type rejected", func(t *testing.T) {
+		varcharField := &schemapb.FieldSchema{FieldID: 104, Name: "vc", DataType: schemapb.DataType_VarChar}
+		_, _, err := PrepareFunctionOutputIndexParams(schemapb.FunctionType_BM25, varcharField, nil, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not supported on data type")
+	})
+
+	t.Run("unknown function type rejected", func(t *testing.T) {
+		_, _, err := PrepareFunctionOutputIndexParams(schemapb.FunctionType_Unknown, sparseField, nil, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown function type")
+	})
+
+	t.Run("duplicated extra param key rejected", func(t *testing.T) {
+		_, _, err := PrepareFunctionOutputIndexParams(schemapb.FunctionType_BM25, sparseField, nil, []*commonpb.KeyValuePair{
+			{Key: common.MetricTypeKey, Value: "BM25"},
+			{Key: common.MetricTypeKey, Value: "IP"},
+		})
+		assert.Error(t, err)
+	})
 }

--- a/internal/util/schemautil/alter_schema_add.go
+++ b/internal/util/schemautil/alter_schema_add.go
@@ -37,9 +37,10 @@ type AlterSchemaAddPlan struct {
 	Field    *schemapb.FieldSchema
 	Function *schemapb.FunctionSchema
 	// Index meta bound to the newly added field, parsed from
-	// FieldInfo.index_name/extra_params. Mandatory for vector-type function
-	// output fields so that bump-schema-version compaction results are never
-	// blocked on a missing vector index.
+	// FieldInfo.index_name/extra_params. A vector-type function output field
+	// always materializes a bound index so that bump-schema-version compaction
+	// results are never blocked on a missing vector index; empty or AUTOINDEX
+	// params resolve to concrete ones via the AutoIndex config at prepare.
 	IndexName        string
 	IndexExtraParams []*commonpb.KeyValuePair
 }
@@ -129,17 +130,10 @@ func ValidateAlterSchemaAddFunctionPlan(plan *AlterSchemaAddPlan) error {
 				plan.Field.GetName(),
 			)
 		}
-		// A vector output field MUST come with bound index params: without an index
-		// meta, bump-schema-version compaction results can never pass the
+		// A vector output field always gets a bound index (empty/AUTOINDEX params
+		// resolve via the AutoIndex config at prepare): without an index meta,
+		// bump-schema-version compaction results can never pass the
 		// indexed-visibility check and the whole backfill pipeline silently stalls.
-		if typeutil.IsVectorType(plan.Field.GetDataType()) && len(plan.IndexExtraParams) == 0 {
-			return merr.WrapErrParameterInvalidMsg(
-				"index params are required when adding function output field %q of vector type %s: "+
-					"provide index_type/metric_type (and params) in field_info.extra_params",
-				plan.Field.GetName(),
-				plan.Field.GetDataType().String(),
-			)
-		}
 		return nil
 	default:
 		return merr.WrapErrParameterInvalidMsg("unknown alter schema add request kind")

--- a/internal/util/schemautil/alter_schema_add_test.go
+++ b/internal/util/schemautil/alter_schema_add_test.go
@@ -34,6 +34,25 @@ func TestValidateAlterSchemaAddFunctionPlan_StandaloneAddRejected(t *testing.T) 
 	assert.Contains(t, err.Error(), "adding a function over existing fields is not supported")
 }
 
+// Empty index params on a vector output field are accepted at the plan level:
+// the bound index is still always materialized, resolved via AutoIndex at prepare.
+func TestValidateAlterSchemaAddFunctionPlan_EmptyIndexParamsAllowed(t *testing.T) {
+	plan := &AlterSchemaAddPlan{
+		Kind: AlterSchemaAddFunctionField,
+		Field: &schemapb.FieldSchema{
+			Name:     "sparse",
+			DataType: schemapb.DataType_SparseFloatVector,
+		},
+		Function: &schemapb.FunctionSchema{
+			Name:             "bm25_fn",
+			Type:             schemapb.FunctionType_BM25,
+			InputFieldNames:  []string{"text"},
+			OutputFieldNames: []string{"sparse"},
+		},
+	}
+	assert.NoError(t, ValidateAlterSchemaAddFunctionPlan(plan))
+}
+
 func TestCheckNoFunctionCascade(t *testing.T) {
 	existing := []*schemapb.FunctionSchema{
 		{Name: "bm25", OutputFieldNames: []string{"sparse"}},

--- a/tests/python_client/milvus_client/test_add_function_field_feature.py
+++ b/tests/python_client/milvus_client/test_add_function_field_feature.py
@@ -12,7 +12,6 @@ from pymilvus import (
     FieldSchema,
     Function,
     FunctionType,
-    MilvusException,
     RRFRanker,
     WeightedRanker,
 )
@@ -491,7 +490,8 @@ class TestMilvusClientAddFunctionFieldFeature(TestMilvusClientV2Base):
 
         target: verify invalid BM25 add_function_field requests are rejected without partial schema mutation
         method: send invalid field/function combinations and compare schema before/after each failure
-        expected: each invalid request fails clearly; schema_version, fields, functions, and max_field_id stay unchanged
+        expected: each invalid request fails clearly; schema_version, fields, functions, and max_field_id stay
+                  unchanged; a request without index params succeeds via server-side AutoIndex resolution
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
@@ -754,9 +754,15 @@ class TestMilvusClientAddFunctionFieldFeature(TestMilvusClientV2Base):
             },
         )
 
-        # Case b: AUTOINDEX index_type is rejected; the bound index requires an explicit index_type.
+        # Case b: AUTOINDEX only tolerates an additional metric_type; any other
+        # build param is rejected, mirroring the create_index AUTOINDEX rule.
         autoindex_params = client.prepare_index_params()
-        autoindex_params.add_index(field_name="sparse_bound_neg", index_type="AUTOINDEX", metric_type="BM25")
+        autoindex_params.add_index(
+            field_name="sparse_bound_neg",
+            index_type="AUTOINDEX",
+            metric_type="BM25",
+            drop_ratio_build="0.2",
+        )
         self.add_function_field(
             client,
             collection_name,
@@ -766,18 +772,9 @@ class TestMilvusClientAddFunctionFieldFeature(TestMilvusClientV2Base):
             check_task=CheckTasks.err_res,
             check_items={
                 ct.err_code: 1100,
-                ct.err_msg: "an explicit index_type is required for the bound index of function output field",
+                ct.err_msg: "only metric type can be passed when use AutoIndex",
             },
         )
-
-        # Case c: the server mandates bound index params for vector function output fields;
-        # a raw alter_collection_schema without index params must be rejected.
-        with pytest.raises(MilvusException, match="index params are required"):
-            client._get_connection().alter_collection_schema(
-                collection_name=collection_name,
-                field_schema=bound_params_field,
-                func=bound_params_function,
-            )
 
         # Bound index params failures must not partially mutate schema either.
         after_desc = client.describe_collection(collection_name)
@@ -875,6 +872,32 @@ class TestMilvusClientAddFunctionFieldFeature(TestMilvusClientV2Base):
         desc = client.describe_collection(collection_name)
         assert "sparse" in [field["name"] for field in desc["fields"]]
         assert "bm25_fn" in [func["name"] for func in desc.get("functions", [])]
+
+        # Step 7: A raw alter_collection_schema WITHOUT index params succeeds —
+        # the bound index resolves via AutoIndex on the server (concrete build
+        # type from the sparse autoindex config, metric forced to BM25 by the
+        # function type). describe_index reports the normalized user params, so
+        # index_type surfaces as AUTOINDEX (same as a create_index AUTOINDEX);
+        # the concrete SPARSE_INVERTED_INDEX lives only in the internal build params.
+        auto_field = FieldSchema(name="sparse_auto", dtype=DataType.SPARSE_FLOAT_VECTOR)
+        auto_function = Function(
+            name="bm25_auto_fn",
+            function_type=FunctionType.BM25,
+            input_field_names=["text"],
+            output_field_names=["sparse_auto"],
+        )
+        client._get_connection().alter_collection_schema(
+            collection_name=collection_name,
+            field_schema=auto_field,
+            func=auto_function,
+        )
+        desc = client.describe_collection(collection_name)
+        assert "sparse_auto" in [field["name"] for field in desc["fields"]]
+        assert "bm25_auto_fn" in [func["name"] for func in desc.get("functions", [])]
+        auto_index_info = client.describe_index(collection_name, index_name="sparse_auto")
+        assert auto_index_info is not None
+        assert auto_index_info["index_type"] == "AUTOINDEX"
+        assert auto_index_info["metric_type"] == "BM25"
 
         self.drop_collection(client, duplicate_name_collection)
         self.drop_collection(client, collection_name)


### PR DESCRIPTION
issue: #52083

### What

Allow omitting index params (or passing `AUTOINDEX`) when adding a function output field via `add_function_field` (`AlterCollectionSchema` ADD). The bound index of the new vector output field now resolves to concrete build params from the AutoIndex config, mirroring the `create_index` AUTOINDEX rules. Previously an explicit `index_type` was mandatory (#51105).

### How

- `indexparamcheck.PrepareFunctionOutputIndexParams` gains an AutoIndex resolution branch: when `index_type` is absent or `AUTOINDEX`, per-data-type AutoIndex config supplies the build params (dense incl. large-topk/refine handling, sparse, binary incl. deduplicate-metric selection, int8). With `AUTOINDEX`, only `metric_type` may additionally be passed ("only metric type can be passed when use AutoIndex", same as create_index); a user-specified metric wins over the config one. Explicit `index_type` behavior is byte-for-byte unchanged.
- Resolution happens pre-broadcast in rootcoord `prepareBoundFieldIndex` (single source of truth; the fully resolved FieldIndex is carried in the AlterCollectionMessage, so ack-callback replay stays a pure idempotent apply). Proxy `preExecuteAdd` validates with the same shared helper.
- The auto-resolved bound index persists in the create_index autoindex convention: `UserIndexParams = [index_type: AUTOINDEX, metric_type: <final>]` (`WrapUserIndexParams`). Datacoord `checkParams` dedupes by TypeParams+UserIndexParams, so a later `create_index(AUTOINDEX)` on the field returns idempotent success instead of "at most one distinct index per field", and the autoindex config-upgrade metric compatibility logic applies. No datacoord changes needed.
- One deliberate divergence from create_index: for BM25 functions a **non-user-specified** metric is forced to BM25 (the DDL knows the function type authoritatively; the sparse config default IP is not a user choice). A user-specified wrong metric is still rejected.
- `wrapUserIndexParams` / `getDenseFloatAutoIndexParams` / `adjustAutoIndexParamsByDataType` are moved (not copied) from proxy into `indexparamcheck` so proxy and rootcoord share one implementation.
- The empty-params gate in `schemautil.ValidateAlterSchemaAddFunctionPlan` is lifted (a vector output field still ALWAYS gets a bound index — now materialized via AutoIndex when params are omitted, so the bump-schema-version indexed-visibility invariant is preserved). The RESTful `add_function_field` `indexParams` field becomes optional accordingly.

### Verification

- UT: resolution table in `indexparamcheck` (explicit passthrough, empty/AUTOINDEX/metric-only/legacy-params-JSON resolution, only-metric restriction, BM25 metric forcing and wrong-metric rejection, dense/binary/dedup config selection, unsupported type, unknown function type); rootcoord `TestPrepareBoundFieldIndex` autoindex subcases incl. persisted-shape asserts; rootcoord DDL broadcast integration case (no-params add succeeds, bound index materialized with resolved params + canonical UserIndexParams); datacoord equivalence test (persisted bound autoindex + later `create_index(AUTOINDEX)` → `errIndexOperationIgnored`; different explicit index still conflicts); proxy `preExecuteAdd` accept/reject cases; RESTful omitted-`indexParams` case.
- e2e: the former negative case (raw `alter_collection_schema` without index params rejected) is flipped to a positive: the DDL succeeds and `describe_index` shows the resolved `SPARSE_INVERTED_INDEX` with metric `BM25`.

### Out of scope / follow-ups

- pymilvus still requires `index_params` in `add_function_field`; making it optional is a follow-up SDK change (raw gRPC/RESTful callers can omit it already).
- Unifying create_index's own two AUTOINDEX resolution branches with the shared helper.
- No change to the cloud (`autoIndex.enable=true`) behavior of overriding explicit index types — the bound-index explicit path keeps honoring user params as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
