### PR TITLE
fix: [3.0] support TLS-only MixCoord client connections (#52089)

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -328,6 +328,9 @@ rocksmq:
 # Related configuration of mixCoord
 mixCoord:
   enableActiveStandby: false
+  grpc:
+    # Enable TLS only for outbound connections to MixCoord. This does not enable TLS on this component's gRPC server.
+    clientTlsEnabled: false
 
 # Related configuration of rootCoord, used to handle data definition language (DDL) and data control language (DCL) requests
 rootCoord:

--- a/internal/distributed/mixcoord/client/client.go
+++ b/internal/distributed/mixcoord/client/client.go
@@ -83,15 +83,16 @@ func NewClient(ctx context.Context) (types.MixCoordClient, error) {
 	client.grpcClient.SetNewGrpcClientFunc(client.newGrpcClient)
 	client.grpcClient.SetSession(sess)
 
-	if Params.InternalTLSCfg.InternalTLSEnabled.GetAsBool() {
+	clientTLSEnabled, caPemPath, serverName := Params.ResolveMixCoordClientTLS()
+	if clientTLSEnabled {
 		client.grpcClient.EnableEncryption()
-		cp, err := utils.CreateCertPoolforClient(Params.InternalTLSCfg.InternalTLSCaPemPath.GetValue(), "RootCoord")
+		cp, err := utils.CreateCertPoolforClient(caPemPath, "MixCoord")
 		if err != nil {
-			mlog.Error(ctx, "Failed to create cert pool for RootCoord client")
+			mlog.Error(ctx, "Failed to create cert pool for MixCoord client")
 			return nil, err
 		}
 		client.grpcClient.SetInternalTLSCertPool(cp)
-		client.grpcClient.SetInternalTLSServerName(Params.InternalTLSCfg.InternalTLSSNI.GetValue())
+		client.grpcClient.SetInternalTLSServerName(serverName)
 	}
 	return client, nil
 }

--- a/internal/distributed/mixcoord/client/client_test.go
+++ b/internal/distributed/mixcoord/client/client_test.go
@@ -623,6 +623,50 @@ func Test_NewClient(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func Test_NewClient_MixCoordClientTLS(t *testing.T) {
+	paramtable.Init()
+
+	setParam := func(t *testing.T, item *paramtable.ParamItem, value string) {
+		t.Helper()
+		old := item.SwapTempValue(value)
+		t.Cleanup(func() { item.SwapTempValue(old) })
+	}
+
+	t.Run("external TLS mode keeps the client plaintext", func(t *testing.T) {
+		setParam(t, &Params.RootCoordGrpcClientCfg.TLSMode, "1")
+		setParam(t, &Params.InternalTLSCfg.InternalTLSEnabled, "false")
+		setParam(t, &Params.MixCoordCfg.ClientTLSEnabled, "false")
+		setParam(t, &Params.RootCoordGrpcClientCfg.CaPemPath, "/does/not/exist.pem")
+
+		client, err := NewClient(context.Background())
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		assert.NoError(t, client.Close())
+	})
+
+	t.Run("directional TLS uses the external CA", func(t *testing.T) {
+		setParam(t, &Params.InternalTLSCfg.InternalTLSEnabled, "false")
+		setParam(t, &Params.MixCoordCfg.ClientTLSEnabled, "true")
+		setParam(t, &Params.RootCoordGrpcClientCfg.CaPemPath, "../../../../configs/cert/ca.pem")
+		setParam(t, &Params.InternalTLSCfg.InternalTLSCaPemPath, "/does/not/exist.pem")
+
+		client, err := NewClient(context.Background())
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		assert.NoError(t, client.Close())
+	})
+
+	t.Run("directional TLS fails closed for an invalid CA", func(t *testing.T) {
+		setParam(t, &Params.InternalTLSCfg.InternalTLSEnabled, "false")
+		setParam(t, &Params.MixCoordCfg.ClientTLSEnabled, "true")
+		setParam(t, &Params.RootCoordGrpcClientCfg.CaPemPath, "/does/not/exist.pem")
+
+		client, err := NewClient(context.Background())
+		assert.Error(t, err)
+		assert.Nil(t, client)
+	})
+}
+
 func Test_Flush(t *testing.T) {
 	paramtable.Init()
 

--- a/internal/streamingcoord/client/client.go
+++ b/internal/streamingcoord/client/client.go
@@ -7,6 +7,8 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/internal/json"
@@ -24,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v3/tracer"
 	"github.com/milvus-io/milvus/pkg/v3/util/interceptor"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/replicateutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -110,7 +113,6 @@ func NewClient(etcdCli *clientv3.Client) Client {
 // getDialOptions returns grpc dial options.
 func getDialOptions(rb resolver.Builder) []grpc.DialOption {
 	cfg := &paramtable.Get().StreamingCoordGrpcClientCfg
-	tlsCfg := &paramtable.Get().InternalTLSCfg
 	retryPolicy := cfg.GetDefaultRetryPolicy()
 	retryPolicy["retryableStatusCodes"] = []string{"UNAVAILABLE"}
 	defaultServiceConfig := map[string]interface{}{
@@ -131,7 +133,7 @@ func getDialOptions(rb resolver.Builder) []grpc.DialOption {
 	if err != nil {
 		panic(err)
 	}
-	creds, err := tlsCfg.GetClientCreds(context.Background())
+	creds, err := getMixCoordClientCredentials(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -156,4 +158,17 @@ func getDialOptions(rb resolver.Builder) []grpc.DialOption {
 		grpc.WithDefaultServiceConfig(string(defaultServiceConfigJSON)),
 	)
 	return dialOptions
+}
+
+func getMixCoordClientCredentials(ctx context.Context) (credentials.TransportCredentials, error) {
+	enabled, caPemPath, serverName := paramtable.Get().ResolveMixCoordClientTLS()
+	if !enabled {
+		return insecure.NewCredentials(), nil
+	}
+	creds, err := credentials.NewClientTLSFromFile(caPemPath, serverName)
+	if err != nil {
+		mlog.Error(ctx, "Failed to create MixCoord client TLS credentials", mlog.Err(err))
+		return nil, merr.Wrap(err, "failed to create MixCoord client TLS credentials")
+	}
+	return creds, nil
 }

--- a/internal/streamingcoord/client/client_test.go
+++ b/internal/streamingcoord/client/client_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,4 +19,47 @@ func TestDial(t *testing.T) {
 	client := NewClient(c)
 	assert.NotNil(t, client)
 	client.Close()
+}
+
+func TestMixCoordClientCredentials(t *testing.T) {
+	paramtable.Init()
+	params := paramtable.Get()
+
+	setParam := func(t *testing.T, item *paramtable.ParamItem, value string) {
+		t.Helper()
+		old := item.SwapTempValue(value)
+		t.Cleanup(func() { item.SwapTempValue(old) })
+	}
+
+	t.Run("external TLS mode keeps the client plaintext", func(t *testing.T) {
+		setParam(t, &params.RootCoordGrpcClientCfg.TLSMode, "1")
+		setParam(t, &params.InternalTLSCfg.InternalTLSEnabled, "false")
+		setParam(t, &params.MixCoordCfg.ClientTLSEnabled, "false")
+		setParam(t, &params.RootCoordGrpcClientCfg.CaPemPath, "/does/not/exist.pem")
+
+		creds, err := getMixCoordClientCredentials(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, "insecure", creds.Info().SecurityProtocol)
+	})
+
+	t.Run("directional TLS uses the external CA", func(t *testing.T) {
+		setParam(t, &params.InternalTLSCfg.InternalTLSEnabled, "false")
+		setParam(t, &params.MixCoordCfg.ClientTLSEnabled, "true")
+		setParam(t, &params.RootCoordGrpcClientCfg.CaPemPath, "../../../configs/cert/ca.pem")
+		setParam(t, &params.InternalTLSCfg.InternalTLSCaPemPath, "/does/not/exist.pem")
+
+		creds, err := getMixCoordClientCredentials(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, "tls", creds.Info().SecurityProtocol)
+	})
+
+	t.Run("directional TLS fails closed for an invalid CA", func(t *testing.T) {
+		setParam(t, &params.InternalTLSCfg.InternalTLSEnabled, "false")
+		setParam(t, &params.MixCoordCfg.ClientTLSEnabled, "true")
+		setParam(t, &params.RootCoordGrpcClientCfg.CaPemPath, "/does/not/exist.pem")
+
+		creds, err := getMixCoordClientCredentials(context.Background())
+		assert.Error(t, err)
+		assert.Nil(t, creds)
+	})
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1929,6 +1929,7 @@ Once the log message exceeds the max bytes per log, it will be truncated.`,
 // --- mixcoord ---
 type mixCoordConfig struct {
 	EnableActiveStandby ParamItem `refreshable:"false"`
+	ClientTLSEnabled    ParamItem `refreshable:"false"`
 }
 
 func (p *mixCoordConfig) init(base *BaseTable) {
@@ -1940,6 +1941,30 @@ func (p *mixCoordConfig) init(base *BaseTable) {
 		FallbackKeys: []string{"rootCoord.enableActiveStandby"},
 	}
 	p.EnableActiveStandby.Init(base.mgr)
+
+	p.ClientTLSEnabled = ParamItem{
+		Key:          "mixCoord.grpc.clientTlsEnabled",
+		Version:      "3.0.0",
+		DefaultValue: "false",
+		Doc:          "Whether to enable TLS only for outbound gRPC connections to MixCoord",
+		Export:       true,
+	}
+	p.ClientTLSEnabled.Init(base.mgr)
+}
+
+// ResolveMixCoordClientTLS returns the TLS settings for outbound MixCoord
+// connections. Cluster-wide internal TLS keeps its existing certificate
+// settings and takes precedence. The directional setting intentionally uses
+// the external TLS CA while reusing the internal SNI setting.
+func (p *ComponentParam) ResolveMixCoordClientTLS() (enabled bool, caPemPath, serverName string) {
+	serverName = p.InternalTLSCfg.InternalTLSSNI.GetValue()
+	if p.InternalTLSCfg.InternalTLSEnabled.GetAsBool() {
+		return true, p.InternalTLSCfg.InternalTLSCaPemPath.GetValue(), serverName
+	}
+	if p.MixCoordCfg.ClientTLSEnabled.GetAsBool() {
+		return true, p.RootCoordGrpcClientCfg.CaPemPath.GetValue(), serverName
+	}
+	return false, "", serverName
 }
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/pkg/util/paramtable/grpc_param_test.go
+++ b/pkg/util/paramtable/grpc_param_test.go
@@ -220,3 +220,33 @@ func TestInternalTLSParams(t *testing.T) {
 	assert.Equal(t, internalTLSCfg.InternalTLSCaPemPath.GetValue(), "/ca")
 	assert.Equal(t, internalTLSCfg.InternalTLSSNI.GetValue(), "localhost")
 }
+
+func TestResolveMixCoordClientTLS(t *testing.T) {
+	params := ComponentParam{}
+	params.Init(NewBaseTable(SkipRemote(true)))
+
+	assert.Equal(t, "mixCoord.grpc.clientTlsEnabled", params.MixCoordCfg.ClientTLSEnabled.Key)
+	assert.False(t, params.MixCoordCfg.ClientTLSEnabled.GetAsBool())
+
+	params.Save("common.security.tlsMode", "1")
+	params.Save("tls.caPemPath", "/external/ca.pem")
+	params.Save("internaltls.caPemPath", "/internal/ca.pem")
+	params.Save("internaltls.sni", "mixcoord.test")
+
+	enabled, caPemPath, serverName := params.ResolveMixCoordClientTLS()
+	assert.False(t, enabled, "external tlsMode must not enable MixCoord client TLS")
+	assert.Empty(t, caPemPath)
+	assert.Equal(t, "mixcoord.test", serverName)
+
+	params.Save("mixCoord.grpc.clientTlsEnabled", "true")
+	enabled, caPemPath, serverName = params.ResolveMixCoordClientTLS()
+	assert.True(t, enabled)
+	assert.Equal(t, "/external/ca.pem", caPemPath)
+	assert.Equal(t, "mixcoord.test", serverName)
+
+	params.Save("common.security.internaltlsEnabled", "true")
+	enabled, caPemPath, serverName = params.ResolveMixCoordClientTLS()
+	assert.True(t, enabled)
+	assert.Equal(t, "/internal/ca.pem", caPemPath, "cluster-wide internal TLS must retain precedence")
+	assert.Equal(t, "mixcoord.test", serverName)
+}


### PR DESCRIPTION
Cherry-pick of #52089 to the 3.0 branch.

## What this PR does

- adds the default-off `mixCoord.grpc.clientTlsEnabled` setting for outbound MixCoord connections
- applies it to both the classic MixCoord gRPC client and the StreamingCoord client
- preserves cluster-wide internal TLS precedence and leaves component gRPC servers unchanged

The setting uses `tls.caPemPath` and `internaltls.sni` when enabled. It does not depend on `common.security.tlsMode`, so deployments with external TLS and plaintext internal coordinator endpoints retain their current behavior.

## Verification

- `cd pkg && go test ./util/paramtable -run 'TestResolveMixCoordClientTLS|TestInternalTLSParams' -count=1`
- added regression coverage for `tlsMode=1` with the new setting disabled, directional certificate loading, internal TLS precedence, and fail-closed certificate errors
- `git diff --check`

The two client-package tests require the repository's native RocksDB/Milvus Core/Kafka build dependencies, which are not installed in the local environment; CI will execute them.

issue: #52091
pr: #52089
