### PR TITLE
fix: return native JSON arrays from REST APIs

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -448,11 +448,21 @@ proxy:
     # itself is the risk the setting exists to remove; values below 1 are read as 1.
     maxExprParamsDepth: 100
     # high-level restful api, return a JSON field as the document it holds rather than as a string.
-    # A JSON field reads back as "{\"a\":1}" by default, while the same value in the dynamic field reads back as {"a":1}.
-    # Turning this on removes that difference. Rows written before the insert path stopped storing non-JSON bytes may not
-    # hold a document; if any row in a response is such a row, every JSON field in that response falls back to the string
-    # form and a warning is logged, so a caller always sees one shape or the other and never a mixture.
-    nativeJSONResponse: false
+    # Turn this off only to keep clients written against the older shape working while they migrate: there a JSON field read
+    # back as "{\"a\":1}" while the same value in the dynamic field read back as {"a":1}. The insert path follows the same
+    # switch, so either shape can be sent back unchanged: while the field reads back as text, a JSON string is read as the
+    # document it spells; once it reads back as the document itself, a string is stored as the string it is. Rows written
+    # before the insert path stopped storing non-JSON bytes may not hold a document; if any row in a response is such a row,
+    # every JSON field in that response falls back to the string form and a warning is logged, so a caller always sees one
+    # shape or the other and never a mixture.
+    nativeJSONResponse: true
+    # high-level restful api, whether to return Array fields wrapped in the raw protobuf ScalarField shape
+    # ({"tags":{"Data":{"StringData":{"data":["a","b"]}}}}) instead of a native JSON array ({"tags":["a","b"]}).
+    # Only enable this to keep clients written against the old, incorrect shape working while they migrate;
+    # it will be removed in a future release. It covers the shape of a top-level Array field and nothing else:
+    # a struct array's sub-fields are unaffected, and so is Accept-Type-Allow-Int64, which renders an Int64 as a
+    # string wherever one appears, including inside either kind of array.
+    legacyArrayResponse: false
     enablePprof: true # Whether to enable pprof middleware on the metrics port
     readHeaderTimeout: 5s # HTTP server timeout for reading request headers
     readTimeout: 0s # HTTP server timeout for reading the entire request, including the body. 0 disables this timeout

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -432,6 +432,11 @@ proxy:
     debug_mode: false # Whether to enable http server debug mode
     port:  # high-level restful api
     acceptTypeAllowInt64: true # high-level restful api, whether http client can deal with int64
+    # high-level restful api, whether to return Array fields wrapped in the raw protobuf ScalarField shape
+    # ({"tags":{"Data":{"StringData":{"data":["a","b"]}}}}) instead of a native JSON array ({"tags":["a","b"]}).
+    # Only enable this to keep clients written against the old, incorrect shape working while they migrate;
+    # it will be removed in a future release.
+    legacyArrayResponse: false
     enablePprof: true # Whether to enable pprof middleware on the metrics port
     readHeaderTimeout: 5s # HTTP server timeout for reading request headers
     readTimeout: 0s # HTTP server timeout for reading the entire request, including the body. 0 disables this timeout

--- a/internal/distributed/proxy/httpserver/handler_v1.go
+++ b/internal/distributed/proxy/httpserver/handler_v1.go
@@ -557,7 +557,7 @@ func (h *HandlersV1) query(c *gin.Context) {
 			mlog.Warn(ctx, "high level restful api, fail to deal with query result", mlog.Any("response", response), mlog.Err(err))
 			HTTPReturn(c, http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-				HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
+				HTTPReturnMessage: resultErrMessage(err),
 			})
 		} else {
 			HTTPReturnStream(c, http.StatusOK, gin.H{HTTPReturnCode: http.StatusOK, HTTPReturnData: outputData})
@@ -637,7 +637,7 @@ func (h *HandlersV1) get(c *gin.Context) {
 			mlog.Warn(ctx, "high level restful api, fail to deal with get result", mlog.Any("response", response), mlog.Err(err))
 			HTTPReturn(c, http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-				HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
+				HTTPReturnMessage: resultErrMessage(err),
 			})
 		} else {
 			HTTPReturnStream(c, http.StatusOK, gin.H{HTTPReturnCode: http.StatusOK, HTTPReturnData: outputData})
@@ -1036,7 +1036,7 @@ func (h *HandlersV1) search(c *gin.Context) {
 				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(err))
 				HTTPReturn(c, http.StatusOK, gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
+					HTTPReturnMessage: resultErrMessage(err),
 				})
 			} else {
 				HTTPReturnStream(c, http.StatusOK, gin.H{HTTPReturnCode: http.StatusOK, HTTPReturnData: outputData})

--- a/internal/distributed/proxy/httpserver/handler_v1.go
+++ b/internal/distributed/proxy/httpserver/handler_v1.go
@@ -557,7 +557,7 @@ func (h *HandlersV1) query(c *gin.Context) {
 			mlog.Warn(ctx, "high level restful api, fail to deal with query result", mlog.Any("response", response), mlog.Err(err))
 			HTTPReturn(c, http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-				HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
+				HTTPReturnMessage: resultErrMessage(err),
 			})
 		} else {
 			HTTPReturnStream(c, http.StatusOK, gin.H{HTTPReturnCode: http.StatusOK, HTTPReturnData: outputData})
@@ -636,7 +636,7 @@ func (h *HandlersV1) get(c *gin.Context) {
 			mlog.Warn(ctx, "high level restful api, fail to deal with get result", mlog.Any("response", response), mlog.Err(err))
 			HTTPReturn(c, http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-				HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
+				HTTPReturnMessage: resultErrMessage(err),
 			})
 		} else {
 			HTTPReturnStream(c, http.StatusOK, gin.H{HTTPReturnCode: http.StatusOK, HTTPReturnData: outputData})
@@ -1034,7 +1034,7 @@ func (h *HandlersV1) search(c *gin.Context) {
 				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(err))
 				HTTPReturn(c, http.StatusOK, gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
+					HTTPReturnMessage: resultErrMessage(err),
 				})
 			} else {
 				HTTPReturnStream(c, http.StatusOK, gin.H{HTTPReturnCode: http.StatusOK, HTTPReturnData: outputData})

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -1428,7 +1428,7 @@ func (h *HandlersV2) query(ctx context.Context, c *gin.Context, anyReq any, dbNa
 			mlog.Warn(ctx, "high level restful api, fail to deal with query result", mlog.Any("response", resp), mlog.Err(err))
 			HTTPReturn(c, http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-				HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
+				HTTPReturnMessage: resultErrMessage(err),
 			})
 		} else {
 			scannedRemoteBytes, scannedTotalBytes, cacheHitRatio, isValid := proxy.GetStorageCost(queryResp.GetStatus())
@@ -1496,7 +1496,7 @@ func (h *HandlersV2) get(ctx context.Context, c *gin.Context, anyReq any, dbName
 			mlog.Warn(ctx, "high level restful api, fail to deal with get result", mlog.Any("response", resp), mlog.Err(err))
 			HTTPReturn(c, http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-				HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
+				HTTPReturnMessage: resultErrMessage(err),
 			})
 		} else {
 			scannedRemoteBytes, scannedTotalBytes, cacheHitRatio, isValid := proxy.GetStorageCost(queryResp.GetStatus())
@@ -2007,7 +2007,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 				mlog.Warn(ctx, "high level restful api, fail to deal with search aggregation result", mlog.Any("result", searchResp.Results), mlog.Err(err))
 				HTTPReturn(c, http.StatusOK, gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
+					HTTPReturnMessage: resultErrMessage(err),
 				})
 			} else {
 				respBody := gin.H{
@@ -2035,7 +2035,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(err))
 				HTTPReturn(c, http.StatusOK, gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
+					HTTPReturnMessage: resultErrMessage(err),
 				})
 			} else {
 				if len(searchResp.Results.Recalls) > 0 {
@@ -2207,7 +2207,7 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(err))
 				HTTPReturn(c, http.StatusOK, gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
+					HTTPReturnMessage: resultErrMessage(err),
 				})
 			} else {
 				if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() && isValid {

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -1480,7 +1480,7 @@ func (h *HandlersV2) query(ctx context.Context, c *gin.Context, anyReq any, dbNa
 			mlog.Warn(ctx, "high level restful api, fail to deal with query result", mlog.Any("response", resp), mlog.Err(err))
 			HTTPReturn(c, http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-				HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
+				HTTPReturnMessage: resultErrMessage(err),
 			})
 		} else {
 			scannedRemoteBytes, scannedTotalBytes, cacheHitRatio, isValid := proxy.GetStorageCost(queryResp.GetStatus())
@@ -1549,7 +1549,7 @@ func (h *HandlersV2) get(ctx context.Context, c *gin.Context, anyReq any, dbName
 			mlog.Warn(ctx, "high level restful api, fail to deal with get result", mlog.Any("response", resp), mlog.Err(err))
 			HTTPReturn(c, http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-				HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
+				HTTPReturnMessage: resultErrMessage(err),
 			})
 		} else {
 			scannedRemoteBytes, scannedTotalBytes, cacheHitRatio, isValid := proxy.GetStorageCost(queryResp.GetStatus())
@@ -2180,7 +2180,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 				mlog.Warn(ctx, "high level restful api, fail to deal with search aggregation result", mlog.Any("result", searchResp.Results), mlog.Err(err))
 				HTTPReturn(c, http.StatusOK, gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
+					HTTPReturnMessage: resultErrMessage(err),
 				})
 			} else {
 				respBody := gin.H{
@@ -2208,7 +2208,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(err))
 				HTTPReturn(c, http.StatusOK, gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
+					HTTPReturnMessage: resultErrMessage(err),
 				})
 			} else {
 				if len(searchResp.Results.Recalls) > 0 {
@@ -2387,7 +2387,7 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(err))
 				HTTPReturn(c, http.StatusOK, gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
+					HTTPReturnMessage: resultErrMessage(err),
 				})
 			} else {
 				if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() && isValid {

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -4731,8 +4731,13 @@ func TestSearchV2(t *testing.T) {
 	queryTestCases = append(queryTestCases, requestBodyTestCase{
 		path:        SearchAction,
 		requestBody: []byte(`{"collectionName": "book", "data": [[0.1, 0.2]], "annsField": "binaryVector", "filter": "book_id in [2, 4, 6, 8]", "limit": 4, "outputFields": ["word_count"]}`),
-		errMsg:      "can only accept json format request, error: Mismatch type uint8",
-		errCode:     1801,
+		// Do not pin the reported Go type here. sonic selects its decoder by
+		// architecture (internal/decoder/api: jitdec on amd64, optdec on arm64) and
+		// the two disagree on which type they blame for a []byte mismatch — jitdec
+		// says "uint8", optdec says "[]uint8". Asserting either one turns this case
+		// red on the other architecture.
+		errMsg:  "can only accept json format request, error: Mismatch type",
+		errCode: 1801,
 	})
 	queryTestCases = append(queryTestCases, requestBodyTestCase{
 		path:        SearchAction,

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -4193,8 +4193,13 @@ func TestSearchV2(t *testing.T) {
 	queryTestCases = append(queryTestCases, requestBodyTestCase{
 		path:        SearchAction,
 		requestBody: []byte(`{"collectionName": "book", "data": [[0.1, 0.2]], "annsField": "binaryVector", "filter": "book_id in [2, 4, 6, 8]", "limit": 4, "outputFields": ["word_count"]}`),
-		errMsg:      "can only accept json format request, error: Mismatch type uint8",
-		errCode:     1801,
+		// Do not pin the reported Go type here. sonic selects its decoder by
+		// architecture (internal/decoder/api: jitdec on amd64, optdec on arm64) and
+		// the two disagree on which type they blame for a []byte mismatch — jitdec
+		// says "uint8", optdec says "[]uint8". Asserting either one turns this case
+		// red on the other architecture.
+		errMsg:  "can only accept json format request, error: Mismatch type",
+		errCode: 1801,
 	})
 	queryTestCases = append(queryTestCases, requestBodyTestCase{
 		path:        SearchAction,

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/gin-gonic/gin"
 	"github.com/spf13/cast"
 	"github.com/tidwall/gjson"
@@ -1448,7 +1449,7 @@ func newStructArrayRowAccessor(fd *schemapb.FieldData, schema *schemapb.Collecti
 	return accessor, nil
 }
 
-func (accessor *structArrayRowAccessor) row(rowIdx int) ([]map[string]interface{}, error) {
+func (accessor *structArrayRowAccessor) row(rowIdx int, enableInt64 bool) ([]map[string]interface{}, error) {
 	fd := accessor.fieldData
 	subs := accessor.subFields
 	if len(subs) == 0 {
@@ -1492,7 +1493,7 @@ func (accessor *structArrayRowAccessor) row(rowIdx int) ([]map[string]interface{
 			if dataIdx >= len(rowData) {
 				return nil, merr.WrapErrParameterInvalidMsg("struct sub-field %s missing row %d", short, dataIdx)
 			}
-			values := scalarArrayToInterfaces(rowData[dataIdx])
+			values := scalarArrayToInterfaces(rowData[dataIdx], enableInt64)
 			if len(values) != elemCount {
 				return nil, merr.WrapErrParameterInvalidMsg("struct sub-field %s element count mismatch: expect %d got %d",
 					short, elemCount, len(values))
@@ -1558,7 +1559,9 @@ func structSubElemCount(sub *schemapb.FieldData, rowIdx int, subDims map[string]
 		if rowIdx >= len(rowData) {
 			return 0, merr.WrapErrParameterInvalidMsg("struct sub-field %s row %d out of range", sub.GetFieldName(), rowIdx)
 		}
-		return len(scalarArrayToInterfaces(rowData[rowIdx])), nil
+		// Element count is independent of the Int64 response mode; pass true to
+		// skip the per-element string conversion.
+		return len(scalarArrayToInterfaces(rowData[rowIdx], true)), nil
 	case schemapb.DataType_ArrayOfVector:
 		va := sub.GetVectors().GetVectorArray()
 		if va == nil || rowIdx >= len(va.GetData()) {
@@ -1575,7 +1578,11 @@ func structSubElemCount(sub *schemapb.FieldData, rowIdx int, subDims map[string]
 	}
 }
 
-func scalarArrayToInterfaces(sf *schemapb.ScalarField) []interface{} {
+// scalarArrayToInterfaces flattens one array row into per-element values so the
+// caller can zip them into the struct's per-element maps. enableInt64 carries the
+// Accept-Type-Allow-Int64 semantics down to Int64 elements, matching what
+// scalarFieldToRESTAny does for top-level Array fields.
+func scalarArrayToInterfaces(sf *schemapb.ScalarField, enableInt64 bool) []interface{} {
 	switch sf.GetData().(type) {
 	case *schemapb.ScalarField_BoolData:
 		src := sf.GetBoolData().GetData()
@@ -1595,7 +1602,11 @@ func scalarArrayToInterfaces(sf *schemapb.ScalarField) []interface{} {
 		src := sf.GetLongData().GetData()
 		out := make([]interface{}, len(src))
 		for i, v := range src {
-			out[i] = v
+			if enableInt64 {
+				out[i] = v
+			} else {
+				out[i] = strconv.FormatInt(v, 10)
+			}
 		}
 		return out
 	case *schemapb.ScalarField_FloatData:
@@ -2592,7 +2603,7 @@ func fieldDataValueCount(fieldData *schemapb.FieldData) (int64, error) {
 			return 0, merr.WrapErrParameterInvalidMsg("unsupported struct sub-field type %s for field %s", subs[0].GetType(), fieldData.GetFieldName())
 		}
 	default:
-		return 0, merr.WrapErrParameterInvalidMsg("the type(%v) of field(%v) is not supported, use other sdk please", fieldData.GetType(), fieldData.GetFieldName())
+		return 0, asSafeMessage(merr.WrapErrParameterInvalidMsg("the type(%v) of field(%v) is not supported, use other sdk please", fieldData.GetType(), fieldData.GetFieldName()))
 	}
 }
 
@@ -2664,6 +2675,119 @@ func (accessor *fieldDataRowAccessor) rowIndex(rowIdx int64) (int64, bool, error
 	return rowIdx, true, nil
 }
 
+// safeMessageError marks an error whose message was written for the caller and is
+// therefore safe to echo in an HTTP response. Errors are not safe by default: most
+// of the ParameterInvalid errors on the response path report a server-side shape
+// mismatch (row counts, valid-data bitmap lengths, element counts) whose wording
+// leaks internal layout, so classification alone cannot decide what to echo.
+type safeMessageError struct{ error }
+
+func (e *safeMessageError) Unwrap() error { return e.error }
+
+// asSafeMessage marks err as caller-facing. Apply it only where the message tells
+// the caller what to do about their own request.
+func asSafeMessage(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &safeMessageError{err}
+}
+
+// outputFieldError attributes a response-serialization failure to the output field
+// that caused it. The name comes from the caller's own outputFields, so echoing it
+// back tells them which column to drop or report without exposing anything internal.
+// The wrapped cause is not safe to echo and is only unwrapped for classification.
+type outputFieldError struct {
+	field string
+	inner error
+}
+
+func (e *outputFieldError) Error() string {
+	return fmt.Sprintf("failed to serialize output field %s: %s", e.field, e.inner.Error())
+}
+
+func (e *outputFieldError) Unwrap() error { return e.inner }
+
+func wrapOutputFieldErr(fieldName string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &outputFieldError{field: fieldName, inner: err}
+}
+
+// resultErrMessage builds the client-facing message for a response-serialization
+// failure. Input errors carry guidance the caller can act on (e.g. an output field
+// type the REST layer cannot render — "use other sdk please") and are passed through
+// whole. A server-side fault only yields the offending output field: the rest of its
+// detail names internal structures and row offsets that mean nothing to the caller,
+// and stays in the log line the caller of this function already emits.
+func resultErrMessage(err error) string {
+	base := merr.ErrInvalidSearchResult.Error()
+	// Explicitly marked messages are echoed whole; the mark, not the error type,
+	// is what makes a message safe.
+	var safeErr *safeMessageError
+	if errors.As(err, &safeErr) {
+		return base + ", error: " + safeErr.Error()
+	}
+	var fieldErr *outputFieldError
+	if errors.As(err, &fieldErr) {
+		return base + ", error: failed to serialize output field " + fieldErr.field
+	}
+	return base
+}
+
+func nonNilSlice[T any](values []T) []T {
+	if values == nil {
+		return []T{}
+	}
+	return values
+}
+
+func scalarFieldToRESTAny(field *schemapb.ScalarField, enableInt64 bool) (any, error) {
+	// A missing row renders as null and an unset oneof as [], matching what the
+	// previous implementation produced. Turning either into a request-level
+	// failure would widen this change beyond the serialization format it fixes.
+	if field == nil {
+		return nil, nil
+	}
+
+	switch data := field.GetData().(type) {
+	case nil:
+		// segcore emits a default-constructed ScalarField for an empty array whose
+		// element type it could not determine (Array.h: `default: { // empty array }`).
+		return []any{}, nil
+	case *schemapb.ScalarField_BoolData:
+		return nonNilSlice(data.BoolData.GetData()), nil
+	case *schemapb.ScalarField_IntData:
+		return nonNilSlice(data.IntData.GetData()), nil
+	case *schemapb.ScalarField_LongData:
+		values := nonNilSlice(data.LongData.GetData())
+		if enableInt64 {
+			return values, nil
+		}
+		return formatInt64(values), nil
+	case *schemapb.ScalarField_FloatData:
+		return nonNilSlice(data.FloatData.GetData()), nil
+	case *schemapb.ScalarField_DoubleData:
+		return nonNilSlice(data.DoubleData.GetData()), nil
+	case *schemapb.ScalarField_StringData:
+		return nonNilSlice(data.StringData.GetData()), nil
+	case *schemapb.ScalarField_ArrayData:
+		elements := data.ArrayData.GetData()
+		values := make([]any, 0, len(elements))
+		for _, element := range elements {
+			value, err := scalarFieldToRESTAny(element, enableInt64)
+			if err != nil {
+				return nil, err
+			}
+			values = append(values, value)
+		}
+		return values, nil
+	default:
+		return nil, merr.WrapErrServiceInternalMsg("unsupported array row scalar field type %T", data)
+	}
+}
+
 //nolint:gosec // G602: slice indices are bounded by rowsNum which is derived from the data length
 func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemapb.FieldData, ids *schemapb.IDs,
 	scores []float32, enableInt64 bool, collectionSchema *schemapb.CollectionSchema,
@@ -2674,7 +2798,7 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 			var err error
 			rowsNum, err = fieldDataRowCount(fieldDataList[0])
 			if err != nil {
-				return nil, err
+				return nil, wrapOutputFieldErr(fieldDataList[0].GetFieldName(), err)
 			}
 		} else if ids != nil {
 			switch ids.GetIdField().(type) {
@@ -2685,7 +2809,7 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 				stringPks := ids.GetStrId().GetData()
 				rowsNum = int64(len(stringPks))
 			default:
-				return nil, merr.WrapErrParameterInvalidMsg("the type of primary key(id) is not supported, use other sdk please")
+				return nil, asSafeMessage(merr.WrapErrParameterInvalidMsg("the type of primary key(id) is not supported, use other sdk please"))
 			}
 		}
 	}
@@ -2697,19 +2821,20 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 	for idx, fieldData := range fieldDataList {
 		accessor, err := newFieldDataRowAccessor(fieldData)
 		if err != nil {
-			return nil, err
+			return nil, wrapOutputFieldErr(fieldData.GetFieldName(), err)
 		}
 		fieldDataAccessors = append(fieldDataAccessors, accessor)
 		if fieldData.GetType() == schemapb.DataType_ArrayOfStruct {
 			structAccessor, err := newStructArrayRowAccessor(fieldData, collectionSchema)
 			if err != nil {
-				return nil, err
+				return nil, wrapOutputFieldErr(fieldData.GetFieldName(), err)
 			}
 			structArrayAccessors[idx] = structAccessor
 		}
 	}
 	queryResp := make([]map[string]interface{}, 0, rowsNum)
 	dynamicOutputFields := genDynamicFields(needFields, fieldDataList)
+	legacyArrayResponse := paramtable.Get().HTTPCfg.LegacyArrayResponse.GetAsBool()
 
 	pkFieldName := DefaultPrimaryFieldName
 	if collectionSchema != nil {
@@ -2728,7 +2853,7 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 				fieldData := fieldDataList[j]
 				dataIdx, valid, err := fieldDataAccessors[j].rowIndex(i)
 				if err != nil {
-					return nil, err
+					return nil, wrapOutputFieldErr(fieldData.GetFieldName(), err)
 				}
 				if !valid {
 					if !fieldData.GetIsDynamic() {
@@ -2778,7 +2903,18 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 				case schemapb.DataType_Int8Vector:
 					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetInt8Vector()[dataIdx*fieldDataList[j].GetVectors().GetDim() : (dataIdx+1)*fieldDataList[j].GetVectors().GetDim()]
 				case schemapb.DataType_Array:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetArrayData().GetData()[dataIdx]
+					arrayRow := fieldDataList[j].GetScalars().GetArrayData().GetData()[dataIdx]
+					if legacyArrayResponse {
+						// Escape hatch: emit the raw ScalarField so it serializes back into
+						// the protobuf wrapper shape clients may have parsed before the fix.
+						row[fieldDataList[j].GetFieldName()] = arrayRow
+						continue
+					}
+					value, err := scalarFieldToRESTAny(arrayRow, enableInt64)
+					if err != nil {
+						return nil, wrapOutputFieldErr(fieldData.GetFieldName(), merr.Wrapf(err, "row %d", i))
+					}
+					row[fieldDataList[j].GetFieldName()] = value
 				case schemapb.DataType_JSON:
 					data, ok := fieldDataList[j].GetScalars().GetData().(*schemapb.ScalarField_JsonData)
 					if ok && !fieldDataList[j].GetIsDynamic() {
@@ -2790,7 +2926,7 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 						if err != nil {
 							mlog.Error(context.TODO(),
 								fmt.Sprintf("[BuildQueryResp] Unmarshal error %s", err.Error()))
-							return nil, err
+							return nil, wrapOutputFieldErr(fieldData.GetFieldName(), err)
 						}
 
 						if containsString(dynamicOutputFields, fieldDataList[j].GetFieldName()) {
@@ -2812,9 +2948,9 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 						row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetGeometryWktData().Data[dataIdx]
 					}
 				case schemapb.DataType_ArrayOfStruct:
-					structRow, err := structArrayAccessors[j].row(int(dataIdx))
+					structRow, err := structArrayAccessors[j].row(int(dataIdx), enableInt64)
 					if err != nil {
-						return nil, err
+						return nil, wrapOutputFieldErr(fieldData.GetFieldName(), err)
 					}
 					row[fieldDataList[j].GetFieldName()] = structRow
 				default:
@@ -2835,7 +2971,7 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 				stringPks := ids.GetStrId().GetData()
 				row[pkFieldName] = stringPks[i]
 			default:
-				return nil, merr.WrapErrParameterInvalidMsg("the type of primary key(id) is not supported, use other sdk please")
+				return nil, asSafeMessage(merr.WrapErrParameterInvalidMsg("the type of primary key(id) is not supported, use other sdk please"))
 			}
 		}
 		if scores != nil && int64(len(scores)) > i {

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -32,6 +32,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/cockroachdb/errors"
 	"github.com/gin-gonic/gin"
 	"github.com/spf13/cast"
 	"github.com/tidwall/gjson"
@@ -891,6 +892,7 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 	// Escape hatch for clients that relied on the previous value handling.
 	// Read once per request rather than per field.
 	compatibilityMode := paramtable.Get().HTTPCfg.CompatibilityMode.GetAsBool()
+	nativeJSONResponse := paramtable.Get().HTTPCfg.NativeJSONResponse.GetAsBool()
 	dataResult := gjson.GetBytes(body, HTTPRequestData)
 	dataResultArray := dataResult.Array()
 	if len(dataResultArray) == 0 {
@@ -1207,119 +1209,40 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 								fieldName, idx)
 						}
 					}
-					switch field.ElementType {
-					case schemapb.DataType_Bool:
-						arr := make([]bool, 0)
-						err := json.Unmarshal([]byte(dataString), &arr)
-						if err != nil {
+					scalar, err := unmarshalScalarArray(field.ElementType, dataString)
+					if err != nil {
+						// An element can arrive in a form the plain decode does not
+						// take: an Int64 rendered as a string because the caller did
+						// not allow native Int64, or the quoted numbers and booleans
+						// a plain column of the same type has always accepted. Read
+						// those the way that column reads them, so a row this API
+						// emits can be sent back to it unchanged. Only a payload the
+						// decode already rejected reaches here, so nothing that was
+						// accepted before is read differently now.
+						//
+						// compatibilityMode is about values -- it restores the
+						// wrapping, truncating conversions of the releases before
+						// this validation work -- not about how a value is spelled.
+						// The element reader below keeps that split: it reads the
+						// quoted spelling in either mode, and leaves the number
+						// conversions of each mode alone. Reading a number through
+						// gjson here would be the escape hatch growing a new
+						// meaning, so this path never does.
+						if !gjson.Parse(dataString).IsArray() {
 							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)]+
 								" of "+schemapb.DataType_name[int32(field.ElementType)], dataString, err.Error())
 						}
-						reallyData[fieldName] = &schemapb.ScalarField{
-							Data: &schemapb.ScalarField_BoolData{
-								BoolData: &schemapb.BoolArray{
-									Data: arr,
-								},
-							},
-						}
-					case schemapb.DataType_Int8:
-						arr := make([]int32, 0)
-						err := json.Unmarshal([]byte(dataString), &arr)
-						if err != nil {
+						lenient, lenientErr := parseScalarArrayElements(field.ElementType, gjson.Parse(dataString).Array(), false)
+						if lenientErr != nil {
+							// The element reader says which element failed and why;
+							// the decode above only knows the whole value did.
 							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)]+
-								" of "+schemapb.DataType_name[int32(field.ElementType)], dataString, err.Error())
+								" of "+schemapb.DataType_name[int32(field.ElementType)], dataString, lenientErr.Error())
 						}
-						reallyData[fieldName] = &schemapb.ScalarField{
-							Data: &schemapb.ScalarField_IntData{
-								IntData: &schemapb.IntArray{
-									Data: arr,
-								},
-							},
-						}
-					case schemapb.DataType_Int16:
-						arr := make([]int32, 0)
-						err := json.Unmarshal([]byte(dataString), &arr)
-						if err != nil {
-							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)]+
-								" of "+schemapb.DataType_name[int32(field.ElementType)], dataString, err.Error())
-						}
-						reallyData[fieldName] = &schemapb.ScalarField{
-							Data: &schemapb.ScalarField_IntData{
-								IntData: &schemapb.IntArray{
-									Data: arr,
-								},
-							},
-						}
-					case schemapb.DataType_Int32:
-						arr := make([]int32, 0)
-						err := json.Unmarshal([]byte(dataString), &arr)
-						if err != nil {
-							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)]+
-								" of "+schemapb.DataType_name[int32(field.ElementType)], dataString, err.Error())
-						}
-						reallyData[fieldName] = &schemapb.ScalarField{
-							Data: &schemapb.ScalarField_IntData{
-								IntData: &schemapb.IntArray{
-									Data: arr,
-								},
-							},
-						}
-					case schemapb.DataType_Int64:
-						arr := make([]int64, 0)
-						err := json.Unmarshal([]byte(dataString), &arr)
-						if err != nil {
-							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)]+
-								" of "+schemapb.DataType_name[int32(field.ElementType)], dataString, err.Error())
-						}
-						reallyData[fieldName] = &schemapb.ScalarField{
-							Data: &schemapb.ScalarField_LongData{
-								LongData: &schemapb.LongArray{
-									Data: arr,
-								},
-							},
-						}
-					case schemapb.DataType_Float:
-						arr := make([]float32, 0)
-						err := json.Unmarshal([]byte(dataString), &arr)
-						if err != nil {
-							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)]+
-								" of "+schemapb.DataType_name[int32(field.ElementType)], dataString, err.Error())
-						}
-						reallyData[fieldName] = &schemapb.ScalarField{
-							Data: &schemapb.ScalarField_FloatData{
-								FloatData: &schemapb.FloatArray{
-									Data: arr,
-								},
-							},
-						}
-					case schemapb.DataType_Double:
-						arr := make([]float64, 0)
-						err := json.Unmarshal([]byte(dataString), &arr)
-						if err != nil {
-							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)]+
-								" of "+schemapb.DataType_name[int32(field.ElementType)], dataString, err.Error())
-						}
-						reallyData[fieldName] = &schemapb.ScalarField{
-							Data: &schemapb.ScalarField_DoubleData{
-								DoubleData: &schemapb.DoubleArray{
-									Data: arr,
-								},
-							},
-						}
-					case schemapb.DataType_VarChar:
-						arr := make([]string, 0)
-						err := json.Unmarshal([]byte(dataString), &arr)
-						if err != nil {
-							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)]+
-								" of "+schemapb.DataType_name[int32(field.ElementType)], dataString, err.Error())
-						}
-						reallyData[fieldName] = &schemapb.ScalarField{
-							Data: &schemapb.ScalarField_StringData{
-								StringData: &schemapb.StringArray{
-									Data: arr,
-								},
-							},
-						}
+						scalar = lenient
+					}
+					if scalar != nil {
+						reallyData[fieldName] = scalar
 					}
 				case schemapb.DataType_JSON:
 					// Store the original JSON token verbatim. gjson's String()
@@ -1334,13 +1257,19 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 						reallyData[fieldName] = []byte(dataString)
 						break
 					}
-					// A JSON document supplied as a JSON string is unwrapped, as
-					// it always has been. The unwrapped token is then validated
-					// like any other: it used to be trusted, which let an
-					// oversized integer, a duplicate key or a lone surrogate in
-					// through the string form.
+					// What a JSON string means here depends on the shape this
+					// deployment serves. While a JSON field reads back as the text
+					// of its document, that text is the field's wire form, and
+					// decoding it is how a caller sends a document at all -- not a
+					// guess about what they meant. Once the field reads back as
+					// the document itself, a string is a string: unwrapping it
+					// would store a value the caller did not send, and would leave
+					// no way to store "123" or "true" as the text it is.
+					// The unwrapped token is validated like any other: it used to
+					// be trusted, which let an oversized integer, a duplicate key
+					// or a lone surrogate in through the string form.
 					document := fieldValue.Raw
-					if fieldValue.Type == gjson.String && json.Valid([]byte(dataString)) {
+					if !nativeJSONResponse && fieldValue.Type == gjson.String && json.Valid([]byte(dataString)) {
 						document = dataString
 					}
 					stored, err := jsonDocumentForStorage(fieldName, document)
@@ -1797,15 +1726,115 @@ func parseRESTInteger(value gjson.Result, bitSize int) (int64, string, bool) {
 	return parsed, actual, err == nil
 }
 
-func buildStructSubArrayScalar(sub *schemapb.FieldSchema, vals []gjson.Result, compatibilityMode bool) (*schemapb.ScalarField, error) {
-	switch sub.GetElementType() {
+// unmarshalScalarArray decodes an array column the way it has always been
+// decoded: straight into the Go slice the element type maps to. It answers a nil
+// field, and no error, for an element type this path never supported.
+func unmarshalScalarArray(elementType schemapb.DataType, dataString string) (*schemapb.ScalarField, error) {
+	switch elementType {
+	case schemapb.DataType_Bool:
+		arr := make([]bool, 0)
+		if err := json.Unmarshal([]byte(dataString), &arr); err != nil {
+			return nil, err
+		}
+		return &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{Data: arr}},
+		}, nil
+	case schemapb.DataType_Int8, schemapb.DataType_Int16, schemapb.DataType_Int32:
+		arr := make([]int32, 0)
+		if err := json.Unmarshal([]byte(dataString), &arr); err != nil {
+			return nil, err
+		}
+		return &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: arr}},
+		}, nil
+	case schemapb.DataType_Int64:
+		arr := make([]int64, 0)
+		if err := json.Unmarshal([]byte(dataString), &arr); err != nil {
+			return nil, err
+		}
+		return &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: arr}},
+		}, nil
+	case schemapb.DataType_Float:
+		arr := make([]float32, 0)
+		if err := json.Unmarshal([]byte(dataString), &arr); err != nil {
+			return nil, err
+		}
+		return &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_FloatData{FloatData: &schemapb.FloatArray{Data: arr}},
+		}, nil
+	case schemapb.DataType_Double:
+		arr := make([]float64, 0)
+		if err := json.Unmarshal([]byte(dataString), &arr); err != nil {
+			return nil, err
+		}
+		return &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_DoubleData{DoubleData: &schemapb.DoubleArray{Data: arr}},
+		}, nil
+	case schemapb.DataType_VarChar:
+		arr := make([]string, 0)
+		if err := json.Unmarshal([]byte(dataString), &arr); err != nil {
+			return nil, err
+		}
+		return &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: arr}},
+		}, nil
+	default:
+		return nil, nil
+	}
+}
+
+// arrayElementError says which element of an array could not be read and why,
+// without naming the field: the same element rules serve a top-level Array
+// column and a struct array's sub-field, and each caller words the failure the
+// way the rest of its own errors are worded.
+type arrayElementError struct {
+	index  int
+	value  gjson.Result
+	reason string
+}
+
+func (e *arrayElementError) Error() string {
+	return fmt.Sprintf("element %d: %s (value=%s)", e.index, e.reason, e.value.Raw)
+}
+
+func elementErr(index int, value gjson.Result, format string, args ...any) error {
+	return &arrayElementError{index: index, value: value, reason: fmt.Sprintf(format, args...)}
+}
+
+// parseScalarArrayElements turns the elements of one JSON array into a scalar
+// array. It is the only place that decides what an array element may look like,
+// so a top-level Array column and a struct array's sub-field cannot drift apart.
+//
+// The accepted spellings match what the same type accepts as a plain column: an
+// integer, float or boolean may arrive quoted, because that is how this API
+// renders an Int64 without Accept-Type-Allow-Int64 and how callers whose
+// language has no distinct numeric types send everything. A quoted integer is
+// read in base 10, so a zero-padded id keeps its value. A spelling carries the
+// same value either way, so it is read the same in every mode.
+//
+// legacyNumbers is a different question: whether a JSON number that does not
+// denote a value of this type -- a fraction for an integer, a magnitude past the
+// type's range -- is converted anyway, truncating or wrapping. Only the struct
+// sub-field path under compatibilityMode ever did that, and only it asks for it
+// here; nothing else grows that behavior by sharing this reader.
+func parseScalarArrayElements(elementType schemapb.DataType, vals []gjson.Result, legacyNumbers bool) (*schemapb.ScalarField, error) {
+	switch elementType {
 	case schemapb.DataType_Bool:
 		arr := make([]bool, 0, len(vals))
-		for _, v := range vals {
-			if v.Type != gjson.True && v.Type != gjson.False {
-				return nil, wrapStructSubParseError(sub, v, "expect bool")
+		for idx, v := range vals {
+			switch v.Type {
+			case gjson.True, gjson.False:
+				arr = append(arr, v.Bool())
+			case gjson.String:
+				parsed, err := cast.ToBoolE(v.String())
+				if err != nil {
+					return nil, elementErr(idx, v, "expect bool")
+				}
+				arr = append(arr, parsed)
+			default:
+				return nil, elementErr(idx, v, "expect bool")
 			}
-			arr = append(arr, v.Bool())
 		}
 		return &schemapb.ScalarField{
 			Data: &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{Data: arr}},
@@ -1813,7 +1842,7 @@ func buildStructSubArrayScalar(sub *schemapb.FieldSchema, vals []gjson.Result, c
 	case schemapb.DataType_Int8, schemapb.DataType_Int16, schemapb.DataType_Int32:
 		bitSize := 32
 		minValue, maxValue := int64(math.MinInt32), int64(math.MaxInt32)
-		switch sub.GetElementType() {
+		switch elementType {
 		case schemapb.DataType_Int8:
 			bitSize = 8
 			minValue, maxValue = math.MinInt8, math.MaxInt8
@@ -1822,18 +1851,19 @@ func buildStructSubArrayScalar(sub *schemapb.FieldSchema, vals []gjson.Result, c
 			minValue, maxValue = math.MinInt16, math.MaxInt16
 		}
 		arr := make([]int32, 0, len(vals))
-		for _, v := range vals {
-			if v.Type != gjson.Number {
-				return nil, wrapStructSubParseError(sub, v, "expect integer")
-			}
-			if compatibilityMode {
+		for idx, v := range vals {
+			if legacyNumbers && v.Type == gjson.Number {
 				arr = append(arr, int32(v.Int()))
 				continue
 			}
-			value, ok := parseJSONInteger(v.Raw, bitSize)
+			if v.Type != gjson.Number && v.Type != gjson.String {
+				return nil, elementErr(idx, v, "expect integer")
+			}
+			// parseRESTInteger is what a plain Int8/Int16/Int32 column uses: the
+			// raw literal for a number, base 10 for a quoted one.
+			value, _, ok := parseRESTInteger(v, bitSize)
 			if !ok {
-				return nil, wrapStructSubParseError(sub, v,
-					fmt.Sprintf("expect integer in range [%d, %d]", minValue, maxValue))
+				return nil, elementErr(idx, v, "expect integer in range [%d, %d]", minValue, maxValue)
 			}
 			arr = append(arr, int32(value))
 		}
@@ -1842,18 +1872,18 @@ func buildStructSubArrayScalar(sub *schemapb.FieldSchema, vals []gjson.Result, c
 		}, nil
 	case schemapb.DataType_Int64:
 		arr := make([]int64, 0, len(vals))
-		for _, v := range vals {
-			if v.Type != gjson.Number {
-				return nil, wrapStructSubParseError(sub, v, "expect integer")
-			}
-			if compatibilityMode {
+		for idx, v := range vals {
+			if legacyNumbers && v.Type == gjson.Number {
 				arr = append(arr, v.Int())
 				continue
 			}
-			value, ok := parseJSONInteger(v.Raw, 64)
+			if v.Type != gjson.Number && v.Type != gjson.String {
+				return nil, elementErr(idx, v, "expect integer")
+			}
+			value, _, ok := parseRESTInteger(v, 64)
 			if !ok {
-				return nil, wrapStructSubParseError(sub, v,
-					fmt.Sprintf("expect integer in range [%d, %d]", int64(math.MinInt64), int64(math.MaxInt64)))
+				return nil, elementErr(idx, v, "expect integer in range [%d, %d]",
+					int64(math.MinInt64), int64(math.MaxInt64))
 			}
 			arr = append(arr, value)
 		}
@@ -1862,42 +1892,78 @@ func buildStructSubArrayScalar(sub *schemapb.FieldSchema, vals []gjson.Result, c
 		}, nil
 	case schemapb.DataType_Float:
 		arr := make([]float32, 0, len(vals))
-		for _, v := range vals {
-			if v.Type != gjson.Number {
-				return nil, wrapStructSubParseError(sub, v, "expect float")
-			}
-			if compatibilityMode {
+		for idx, v := range vals {
+			switch {
+			case v.Type == gjson.Number && legacyNumbers:
 				arr = append(arr, float32(v.Float()))
-				continue
+			case v.Type == gjson.Number:
+				// through float64 like every path this value will be compared
+				// against; see the Float case in checkAndSetData
+				parsed, err := strconv.ParseFloat(v.Raw, 64)
+				if err != nil {
+					return nil, elementErr(idx, v, "expect float in the float32 range")
+				}
+				// Verified after the cast, which is where a magnitude past the
+				// float32 range turns into an infinity.
+				value := float32(parsed)
+				if typeutil.VerifyFloat(float64(value)) != nil {
+					return nil, elementErr(idx, v, "expect float in the float32 range")
+				}
+				arr = append(arr, value)
+			case v.Type == gjson.String:
+				// cast.ToFloat32E is what a plain Float column falls back to, but
+				// it reads "NaN", "Inf" and "Infinity" -- case-insensitively --
+				// without an error, and an array element has no later check that
+				// would catch them: checkArrayElement compares the element's type
+				// and never calls VerifyFloats32 the way a plain column does. One
+				// of those stored is a row that cannot be served, since the
+				// encoder fails on it after the status and part of the body are
+				// already written.
+				parsed, err := cast.ToFloat32E(v.String())
+				if err != nil || typeutil.VerifyFloat(float64(parsed)) != nil {
+					return nil, elementErr(idx, v, "expect float in the float32 range")
+				}
+				arr = append(arr, parsed)
+			default:
+				return nil, elementErr(idx, v, "expect float")
 			}
-			// through float64 like every path this value will be compared
-			// against, with the range checked before the cast; see the Float
-			// case in checkAndSetData
-			parsed, err := strconv.ParseFloat(v.Raw, 64)
-			if err != nil || math.IsInf(parsed, 0) || math.Abs(parsed) > math.MaxFloat32 {
-				return nil, wrapStructSubParseError(sub, v, "expect float in the float32 range")
-			}
-			arr = append(arr, float32(parsed))
 		}
 		return &schemapb.ScalarField{
 			Data: &schemapb.ScalarField_FloatData{FloatData: &schemapb.FloatArray{Data: arr}},
 		}, nil
 	case schemapb.DataType_Double:
 		arr := make([]float64, 0, len(vals))
-		for _, v := range vals {
-			if v.Type != gjson.Number {
-				return nil, wrapStructSubParseError(sub, v, "expect double")
+		for idx, v := range vals {
+			switch {
+			case v.Type == gjson.Number && legacyNumbers:
+				arr = append(arr, v.Float())
+			case v.Type == gjson.Number:
+				// gjson reads a magnitude past float64 as +Inf, a value no
+				// caller sent and one the decode this falls back from refuses.
+				parsed, err := strconv.ParseFloat(v.Raw, 64)
+				if err != nil || typeutil.VerifyFloat(parsed) != nil {
+					return nil, elementErr(idx, v, "expect double in the float64 range")
+				}
+				arr = append(arr, parsed)
+			case v.Type == gjson.String:
+				// strconv reads NaN, Inf and Infinity without an error.
+				parsed, err := cast.ToFloat64E(v.String())
+				if err != nil || typeutil.VerifyFloat(parsed) != nil {
+					return nil, elementErr(idx, v, "expect double in the float64 range")
+				}
+				arr = append(arr, parsed)
+			default:
+				return nil, elementErr(idx, v, "expect double")
 			}
-			arr = append(arr, v.Float())
 		}
 		return &schemapb.ScalarField{
 			Data: &schemapb.ScalarField_DoubleData{DoubleData: &schemapb.DoubleArray{Data: arr}},
 		}, nil
 	case schemapb.DataType_VarChar, schemapb.DataType_String:
 		arr := make([]string, 0, len(vals))
-		for _, v := range vals {
+		for idx, v := range vals {
 			if v.Type != gjson.String {
-				return nil, wrapStructSubParseError(sub, v, "expect string")
+				return nil, elementErr(idx, v, "expect string")
 			}
 			arr = append(arr, v.String())
 		}
@@ -1905,10 +1971,22 @@ func buildStructSubArrayScalar(sub *schemapb.FieldSchema, vals []gjson.Result, c
 			Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: arr}},
 		}, nil
 	default:
+		return nil, merr.WrapErrParameterInvalidMsg("unsupported array element type %s", elementType)
+	}
+}
+
+func buildStructSubArrayScalar(sub *schemapb.FieldSchema, vals []gjson.Result, compatibilityMode bool) (*schemapb.ScalarField, error) {
+	scalar, err := parseScalarArrayElements(sub.GetElementType(), vals, compatibilityMode)
+	if err != nil {
+		var elemErr *arrayElementError
+		if errors.As(err, &elemErr) {
+			return nil, wrapStructSubParseError(sub, elemErr.value, elemErr.reason)
+		}
 		return nil, merr.WrapErrParameterInvalidMsg(
 			"sub-field %s has unsupported array element type %s",
 			sub.GetName(), sub.GetElementType())
 	}
+	return scalar, nil
 }
 
 func buildStructSubVectorField(sub *schemapb.FieldSchema, vals []gjson.Result) (*schemapb.VectorField, error) {
@@ -2385,7 +2463,7 @@ func newStructArrayRowAccessor(fd *schemapb.FieldData, schema *schemapb.Collecti
 	return accessor, nil
 }
 
-func (accessor *structArrayRowAccessor) row(rowIdx int) ([]map[string]interface{}, error) {
+func (accessor *structArrayRowAccessor) row(rowIdx int, enableInt64 bool) ([]map[string]interface{}, error) {
 	fd := accessor.fieldData
 	subs := accessor.subFields
 	if len(subs) == 0 {
@@ -2429,7 +2507,7 @@ func (accessor *structArrayRowAccessor) row(rowIdx int) ([]map[string]interface{
 			if dataIdx >= len(rowData) {
 				return nil, merr.WrapErrParameterInvalidMsg("struct sub-field %s missing row %d", short, dataIdx)
 			}
-			values := scalarArrayToInterfaces(rowData[dataIdx])
+			values := scalarArrayToInterfaces(rowData[dataIdx], enableInt64)
 			if len(values) != elemCount {
 				return nil, merr.WrapErrParameterInvalidMsg("struct sub-field %s element count mismatch: expect %d got %d",
 					short, elemCount, len(values))
@@ -2495,7 +2573,9 @@ func structSubElemCount(sub *schemapb.FieldData, rowIdx int, subDims map[string]
 		if rowIdx >= len(rowData) {
 			return 0, merr.WrapErrParameterInvalidMsg("struct sub-field %s row %d out of range", sub.GetFieldName(), rowIdx)
 		}
-		return len(scalarArrayToInterfaces(rowData[rowIdx])), nil
+		// Element count is independent of the Int64 response mode; pass true to
+		// skip the per-element string conversion.
+		return len(scalarArrayToInterfaces(rowData[rowIdx], true)), nil
 	case schemapb.DataType_ArrayOfVector:
 		va := sub.GetVectors().GetVectorArray()
 		if va == nil || rowIdx >= len(va.GetData()) {
@@ -2512,7 +2592,11 @@ func structSubElemCount(sub *schemapb.FieldData, rowIdx int, subDims map[string]
 	}
 }
 
-func scalarArrayToInterfaces(sf *schemapb.ScalarField) []interface{} {
+// scalarArrayToInterfaces flattens one array row into per-element values so the
+// caller can zip them into the struct's per-element maps. enableInt64 carries the
+// Accept-Type-Allow-Int64 semantics down to Int64 elements, matching what
+// scalarFieldToRESTAny does for top-level Array fields.
+func scalarArrayToInterfaces(sf *schemapb.ScalarField, enableInt64 bool) []interface{} {
 	switch sf.GetData().(type) {
 	case *schemapb.ScalarField_BoolData:
 		src := sf.GetBoolData().GetData()
@@ -2532,7 +2616,11 @@ func scalarArrayToInterfaces(sf *schemapb.ScalarField) []interface{} {
 		src := sf.GetLongData().GetData()
 		out := make([]interface{}, len(src))
 		for i, v := range src {
-			out[i] = v
+			if enableInt64 {
+				out[i] = v
+			} else {
+				out[i] = strconv.FormatInt(v, 10)
+			}
 		}
 		return out
 	case *schemapb.ScalarField_FloatData:
@@ -3590,7 +3678,7 @@ func fieldDataValueCount(fieldData *schemapb.FieldData) (int64, error) {
 			return 0, merr.WrapErrParameterInvalidMsg("unsupported struct sub-field type %s for field %s", subs[0].GetType(), fieldData.GetFieldName())
 		}
 	default:
-		return 0, merr.WrapErrParameterInvalidMsg("the type(%v) of field(%v) is not supported, use other sdk please", fieldData.GetType(), fieldData.GetFieldName())
+		return 0, asSafeMessage(merr.WrapErrParameterInvalidMsg("the type(%v) of field(%v) is not supported, use other sdk please", fieldData.GetType(), fieldData.GetFieldName()))
 	}
 }
 
@@ -3662,6 +3750,200 @@ func (accessor *fieldDataRowAccessor) rowIndex(rowIdx int64) (int64, bool, error
 	return rowIdx, true, nil
 }
 
+// safeMessageError marks an error whose message was written for the caller and is
+// therefore safe to echo in an HTTP response. Errors are not safe by default: most
+// of the ParameterInvalid errors on the response path report a server-side shape
+// mismatch (row counts, valid-data bitmap lengths, element counts) whose wording
+// leaks internal layout, so classification alone cannot decide what to echo.
+type safeMessageError struct{ error }
+
+func (e *safeMessageError) Unwrap() error { return e.error }
+
+// asSafeMessage marks err as caller-facing. Apply it only where the message tells
+// the caller what to do about their own request.
+func asSafeMessage(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &safeMessageError{err}
+}
+
+// outputFieldError attributes a response-serialization failure to the output field
+// that caused it. The name comes from the caller's own outputFields, so echoing it
+// back tells them which column to drop or report without exposing anything internal.
+// The wrapped cause is not safe to echo and is only unwrapped for classification.
+type outputFieldError struct {
+	field string
+	inner error
+}
+
+func (e *outputFieldError) Error() string {
+	return fmt.Sprintf("failed to serialize output field %s: %s", e.field, e.inner.Error())
+}
+
+func (e *outputFieldError) Unwrap() error { return e.inner }
+
+func wrapOutputFieldErr(fieldName string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &outputFieldError{field: fieldName, inner: err}
+}
+
+// resultStageError names the part of the response build that failed, for faults
+// that cannot be attributed to an output field at all. Its detail describes a
+// server-side contract (reduce shapes, bucket counts) and stays in the log; the
+// stage name is all the caller gets, but it is enough to say which part of the
+// response broke when reporting the failure.
+type resultStageError struct {
+	stage string
+	inner error
+}
+
+func (e *resultStageError) Error() string {
+	return fmt.Sprintf("failed to build %s: %s", e.stage, e.inner.Error())
+}
+
+func (e *resultStageError) Unwrap() error { return e.inner }
+
+func wrapResultStageErr(stage string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &resultStageError{stage: stage, inner: err}
+}
+
+// resultErrMessage builds the client-facing message for a response-serialization
+// failure. Input errors carry guidance the caller can act on (e.g. an output field
+// type the REST layer cannot render — "use other sdk please") and are passed through
+// whole. A server-side fault only yields the offending output field: the rest of its
+// detail names internal structures and row offsets that mean nothing to the caller,
+// and stays in the log line the caller of this function already emits.
+func resultErrMessage(err error) string {
+	base := merr.ErrInvalidSearchResult.Error()
+	// Explicitly marked messages are echoed whole; the mark, not the error type,
+	// is what makes a message safe.
+	var safeErr *safeMessageError
+	if errors.As(err, &safeErr) {
+		return base + ", error: " + safeErr.Error()
+	}
+	var fieldErr *outputFieldError
+	if errors.As(err, &fieldErr) {
+		return base + ", error: failed to serialize output field " + fieldErr.field
+	}
+	var stageErr *resultStageError
+	if errors.As(err, &stageErr) {
+		return base + ", error: failed to build " + stageErr.stage
+	}
+	return base
+}
+
+// legacyArrayValue renders one array row in the protobuf wrapper shape that
+// proxy.http.legacyArrayResponse restores. The shape is reproduced by handing
+// the ScalarField itself to the encoder, which is what the clients this switch
+// exists for parse. An Int64 the caller cannot hold natively is the exception:
+// its slice has no room for the string form, so the wrapper around it is spelled
+// out instead. Everything else, and every row once the caller allows Int64, is
+// the message as it stands, byte for byte.
+func legacyArrayValue(row *schemapb.ScalarField, enableInt64 bool) any {
+	if enableInt64 || !holdsInt64(row) {
+		return row
+	}
+
+	switch data := row.GetData().(type) {
+	case *schemapb.ScalarField_LongData:
+		inner := map[string]any{}
+		if values := data.LongData.GetData(); len(values) > 0 {
+			inner["data"] = formatInt64(values)
+		}
+		return map[string]any{"Data": map[string]any{"LongData": inner}}
+	case *schemapb.ScalarField_ArrayData:
+		inner := map[string]any{}
+		if elements := data.ArrayData.GetData(); len(elements) > 0 {
+			rendered := make([]any, 0, len(elements))
+			for _, element := range elements {
+				rendered = append(rendered, legacyArrayValue(element, enableInt64))
+			}
+			inner["data"] = rendered
+		}
+		if elementType := data.ArrayData.GetElementType(); elementType != schemapb.DataType_None {
+			inner["element_type"] = elementType
+		}
+		return map[string]any{"Data": map[string]any{"ArrayData": inner}}
+	default:
+		return row
+	}
+}
+
+// holdsInt64 reports whether a row renders any Int64, directly or nested.
+func holdsInt64(row *schemapb.ScalarField) bool {
+	switch data := row.GetData().(type) {
+	case *schemapb.ScalarField_LongData:
+		return true
+	case *schemapb.ScalarField_ArrayData:
+		for _, element := range data.ArrayData.GetData() {
+			if holdsInt64(element) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+func nonNilSlice[T any](values []T) []T {
+	if values == nil {
+		return []T{}
+	}
+	return values
+}
+
+func scalarFieldToRESTAny(field *schemapb.ScalarField, enableInt64 bool) (any, error) {
+	// A missing row renders as null and an unset oneof as [], matching what the
+	// previous implementation produced. Turning either into a request-level
+	// failure would widen this change beyond the serialization format it fixes.
+	if field == nil {
+		return nil, nil
+	}
+
+	switch data := field.GetData().(type) {
+	case nil:
+		// segcore emits a default-constructed ScalarField for an empty array whose
+		// element type it could not determine (Array.h: `default: { // empty array }`).
+		return []any{}, nil
+	case *schemapb.ScalarField_BoolData:
+		return nonNilSlice(data.BoolData.GetData()), nil
+	case *schemapb.ScalarField_IntData:
+		return nonNilSlice(data.IntData.GetData()), nil
+	case *schemapb.ScalarField_LongData:
+		values := nonNilSlice(data.LongData.GetData())
+		if enableInt64 {
+			return values, nil
+		}
+		return formatInt64(values), nil
+	case *schemapb.ScalarField_FloatData:
+		return nonNilSlice(data.FloatData.GetData()), nil
+	case *schemapb.ScalarField_DoubleData:
+		return nonNilSlice(data.DoubleData.GetData()), nil
+	case *schemapb.ScalarField_StringData:
+		return nonNilSlice(data.StringData.GetData()), nil
+	case *schemapb.ScalarField_ArrayData:
+		elements := data.ArrayData.GetData()
+		values := make([]any, 0, len(elements))
+		for _, element := range elements {
+			value, err := scalarFieldToRESTAny(element, enableInt64)
+			if err != nil {
+				return nil, err
+			}
+			values = append(values, value)
+		}
+		return values, nil
+	default:
+		return nil, merr.WrapErrServiceInternalMsg("unsupported array row scalar field type %T", data)
+	}
+}
+
 //nolint:gosec // G602: slice indices are bounded by rowsNum which is derived from the data length
 func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemapb.FieldData, ids *schemapb.IDs,
 	scores []float32, enableInt64 bool, collectionSchema *schemapb.CollectionSchema,
@@ -3676,7 +3958,7 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 			var err error
 			rowsNum, err = fieldDataRowCount(fieldDataList[0])
 			if err != nil {
-				return nil, err
+				return nil, wrapOutputFieldErr(fieldDataList[0].GetFieldName(), err)
 			}
 		} else if ids != nil {
 			switch ids.GetIdField().(type) {
@@ -3687,7 +3969,7 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 				stringPks := ids.GetStrId().GetData()
 				rowsNum = int64(len(stringPks))
 			default:
-				return nil, merr.WrapErrParameterInvalidMsg("the type of primary key(id) is not supported, use other sdk please")
+				return nil, asSafeMessage(merr.WrapErrParameterInvalidMsg("the type of primary key(id) is not supported, use other sdk please"))
 			}
 		}
 	}
@@ -3699,19 +3981,20 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 	for idx, fieldData := range fieldDataList {
 		accessor, err := newFieldDataRowAccessor(fieldData)
 		if err != nil {
-			return nil, err
+			return nil, wrapOutputFieldErr(fieldData.GetFieldName(), err)
 		}
 		fieldDataAccessors = append(fieldDataAccessors, accessor)
 		if fieldData.GetType() == schemapb.DataType_ArrayOfStruct {
 			structAccessor, err := newStructArrayRowAccessor(fieldData, collectionSchema)
 			if err != nil {
-				return nil, err
+				return nil, wrapOutputFieldErr(fieldData.GetFieldName(), err)
 			}
 			structArrayAccessors[idx] = structAccessor
 		}
 	}
 	queryResp := make([]map[string]interface{}, 0, rowsNum)
 	dynamicOutputFields := genDynamicFields(needFields, fieldDataList)
+	legacyArrayResponse := paramtable.Get().HTTPCfg.LegacyArrayResponse.GetAsBool()
 
 	pkFieldName := DefaultPrimaryFieldName
 	if collectionSchema != nil {
@@ -3730,7 +4013,7 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 				fieldData := fieldDataList[j]
 				dataIdx, valid, err := fieldDataAccessors[j].rowIndex(i)
 				if err != nil {
-					return nil, err
+					return nil, wrapOutputFieldErr(fieldData.GetFieldName(), err)
 				}
 				if !valid {
 					if !fieldData.GetIsDynamic() {
@@ -3778,7 +4061,21 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 				case schemapb.DataType_Int8Vector:
 					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetInt8Vector()[dataIdx*fieldDataList[j].GetVectors().GetDim() : (dataIdx+1)*fieldDataList[j].GetVectors().GetDim()]
 				case schemapb.DataType_Array:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetArrayData().GetData()[dataIdx]
+					arrayRow := fieldDataList[j].GetScalars().GetArrayData().GetData()[dataIdx]
+					if legacyArrayResponse {
+						// Escape hatch: emit the raw ScalarField so it serializes back into
+						// the protobuf wrapper shape clients may have parsed before the fix.
+						// The shape is what those clients read; Accept-Type-Allow-Int64 is
+						// about what their JSON parser can hold, which the shape does not
+						// change, so an Int64 is still rendered the way the header asks.
+						row[fieldDataList[j].GetFieldName()] = legacyArrayValue(arrayRow, enableInt64)
+						continue
+					}
+					value, err := scalarFieldToRESTAny(arrayRow, enableInt64)
+					if err != nil {
+						return nil, wrapOutputFieldErr(fieldData.GetFieldName(), merr.Wrapf(err, "row %d", i))
+					}
+					row[fieldDataList[j].GetFieldName()] = value
 				case schemapb.DataType_JSON:
 					data, ok := fieldDataList[j].GetScalars().GetData().(*schemapb.ScalarField_JsonData)
 					if ok && !fieldDataList[j].GetIsDynamic() {
@@ -3836,7 +4133,17 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 						if err != nil {
 							mlog.Error(context.TODO(),
 								fmt.Sprintf("[BuildQueryResp] Unmarshal error %s", err.Error()))
-							return nil, err
+							// This branch is only entered for the dynamic field, so the
+							// name here is always the internal $meta -- never one of the
+							// caller's outputFields -- which makes wrapOutputFieldErr's
+							// contract not hold and would report a column the caller
+							// cannot drop. What it can act on is the cause: the stored
+							// bytes are not one JSON document. That describes its own
+							// data, not our layout, so echo it and keep the decoder's
+							// text (which can quote the bytes and an offset into them)
+							// in the log line above.
+							return nil, asSafeMessage(merr.WrapErrParameterInvalidMsg(
+								"dynamic field does not hold a single JSON document"))
 						}
 
 						if containsString(dynamicOutputFields, fieldDataList[j].GetFieldName()) {
@@ -3858,9 +4165,9 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 						row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetGeometryWktData().Data[dataIdx]
 					}
 				case schemapb.DataType_ArrayOfStruct:
-					structRow, err := structArrayAccessors[j].row(int(dataIdx))
+					structRow, err := structArrayAccessors[j].row(int(dataIdx), enableInt64)
 					if err != nil {
-						return nil, err
+						return nil, wrapOutputFieldErr(fieldData.GetFieldName(), err)
 					}
 					row[fieldDataList[j].GetFieldName()] = structRow
 				default:
@@ -3881,7 +4188,7 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 				stringPks := ids.GetStrId().GetData()
 				row[pkFieldName] = stringPks[i]
 			default:
-				return nil, merr.WrapErrParameterInvalidMsg("the type of primary key(id) is not supported, use other sdk please")
+				return nil, asSafeMessage(merr.WrapErrParameterInvalidMsg("the type of primary key(id) is not supported, use other sdk please"))
 			}
 		}
 		if scores != nil && int64(len(scores)) > i {
@@ -3921,7 +4228,20 @@ func hasSearchAggregationResult(results *schemapb.SearchResultData) bool {
 	return results != nil && (len(results.GetAggTopks()) > 0 || len(results.GetAggBuckets()) > 0)
 }
 
+// buildSearchAggregationResp renders the aggregation payload. Every failure below
+// it is a server-side reduce contract violation with no output field to blame, so
+// it would otherwise reach the caller as a bare "fail to parse search result".
+// Naming the stage keeps the response actionable enough to report while the
+// contract detail stays in the log.
 func buildSearchAggregationResp(results *schemapb.SearchResultData, enableInt64 bool, collectionSchema *schemapb.CollectionSchema) ([]gin.H, error) {
+	output, err := buildSearchAggregationRespData(results, enableInt64, collectionSchema)
+	if err != nil {
+		return nil, wrapResultStageErr("search aggregation result", err)
+	}
+	return output, nil
+}
+
+func buildSearchAggregationRespData(results *schemapb.SearchResultData, enableInt64 bool, collectionSchema *schemapb.CollectionSchema) ([]gin.H, error) {
 	if results == nil {
 		// The aggregation payload is produced by the server-side reduce, never
 		// by the request: a malformed shape is an internal contract violation.

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -18,6 +18,7 @@ package httpserver
 
 import (
 	"context"
+	gojson "encoding/json"
 	"fmt"
 	"math"
 	"net/http/httptest"
@@ -38,6 +39,7 @@ import (
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -1853,6 +1855,575 @@ func TestBuildQueryResp(t *testing.T) {
 	assert.Equal(t, nil, err)
 	exceptRows := generateSearchResult(schemapb.DataType_Int64)
 	assert.Equal(t, true, compareRows(rows, exceptRows, compareRow))
+}
+
+func TestResultErrMessage(t *testing.T) {
+	t.Run("marked message is echoed", func(t *testing.T) {
+		err := asSafeMessage(merr.WrapErrParameterInvalidMsg(
+			"the type(%v) of field(%v) is not supported, use other sdk please",
+			schemapb.DataType_Geometry, "geo"))
+		assert.Contains(t, resultErrMessage(err), "use other sdk please")
+	})
+
+	t.Run("marked message survives field wrapping", func(t *testing.T) {
+		err := asSafeMessage(merr.WrapErrParameterInvalidMsg(
+			"the type(%v) of field(%v) is not supported, use other sdk please",
+			schemapb.DataType_Geometry, "geo"))
+		msg := resultErrMessage(wrapOutputFieldErr("geo", err))
+		assert.Contains(t, msg, "use other sdk please")
+		assert.Contains(t, msg, "geo")
+	})
+
+	// Being an InputError is not enough on its own: most ParameterInvalid errors
+	// on this path describe a server-side shape mismatch.
+	t.Run("unmarked input error is not echoed", func(t *testing.T) {
+		err := merr.WrapErrParameterInvalidMsg("field %s has %d valid rows, but data length is %d", "tags", 2, 1)
+		msg := resultErrMessage(wrapOutputFieldErr("tags", err))
+		assert.Contains(t, msg, "tags")
+		assert.NotContains(t, msg, "valid rows")
+		assert.NotContains(t, msg, "data length")
+	})
+
+	t.Run("server fault names the field and nothing else", func(t *testing.T) {
+		inner := merr.WrapErrServiceInternalMsg("array row scalar field is nil")
+		err := wrapOutputFieldErr("user_email_tags", merr.Wrapf(inner, "row %d", 3))
+		msg := resultErrMessage(err)
+		// The caller learns which output field to drop or report...
+		assert.Contains(t, msg, "user_email_tags")
+		// ...but nothing about internal structures or row offsets.
+		assert.NotContains(t, msg, "service internal error")
+		assert.NotContains(t, msg, "scalar field")
+		assert.NotContains(t, msg, "row 3")
+	})
+
+	t.Run("non-milvus error is not echoed", func(t *testing.T) {
+		err := json.Unmarshal([]byte("{bad"), &struct{}{})
+		require.Error(t, err)
+		msg := resultErrMessage(err)
+		assert.Equal(t, merr.ErrInvalidSearchResult.Error(), msg)
+	})
+}
+
+// proxy.http.legacyArrayResponse lets a deployment keep serving the pre-fix shape
+// while clients that parsed it migrate. Default stays off.
+func TestBuildQueryRespLegacyArrayResponse(t *testing.T) {
+	fieldData := &schemapb.FieldData{
+		Type:      schemapb.DataType_Array,
+		FieldName: "tags",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_ArrayData{
+					ArrayData: &schemapb.ArrayArray{
+						ElementType: schemapb.DataType_VarChar,
+						Data: []*schemapb.ScalarField{
+							{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"a", "b"}}}},
+						},
+					},
+				},
+			},
+		},
+	}
+	render := func() string {
+		rows, err := buildQueryResp(0, []string{"tags"}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+		require.NoError(t, err)
+		payload, err := gojson.Marshal(gin.H{"data": rows})
+		require.NoError(t, err)
+		return string(payload)
+	}
+
+	params := paramtable.Get()
+	key := params.HTTPCfg.LegacyArrayResponse.Key
+
+	// Default: native JSON array.
+	require.False(t, params.HTTPCfg.LegacyArrayResponse.GetAsBool())
+	assert.JSONEq(t, `{"data":[{"tags":["a","b"]}]}`, render())
+
+	// Switched on: the pre-fix protobuf wrapper shape, byte for byte.
+	params.Save(key, "true")
+	defer params.Reset(key)
+	assert.JSONEq(t, `{"data":[{"tags":{"Data":{"StringData":{"data":["a","b"]}}}}]}`, render())
+
+	// And back off again, so the switch is not one-way.
+	params.Reset(key)
+	assert.JSONEq(t, `{"data":[{"tags":["a","b"]}]}`, render())
+}
+
+// The redaction rules must hold for the errors buildQueryResp actually produces,
+// not only for hand-built ones. Each case drives a real producer and asserts on
+// what the client would receive.
+func TestResultErrMessageFromRealProducers(t *testing.T) {
+	t.Run("valid-data shape mismatch is not echoed", func(t *testing.T) {
+		// ValidData describes 3 rows of which 2 are valid, but only 1 row exists.
+		fieldData := &schemapb.FieldData{
+			Type:      schemapb.DataType_Array,
+			FieldName: "tags",
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_ArrayData{
+						ArrayData: &schemapb.ArrayArray{
+							ElementType: schemapb.DataType_VarChar,
+							Data: []*schemapb.ScalarField{
+								{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"a"}}}},
+							},
+						},
+					},
+				},
+			},
+			ValidData: []bool{true, true, false},
+		}
+
+		_, err := buildQueryResp(0, []string{"tags"}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+		require.Error(t, err)
+		// The producer really does spell out the internal shape...
+		require.Contains(t, err.Error(), "valid rows")
+
+		// ...and the client must not see it.
+		msg := resultErrMessage(err)
+		assert.Contains(t, msg, "tags")
+		assert.NotContains(t, msg, "valid rows")
+		assert.NotContains(t, msg, "data length")
+	})
+
+	t.Run("unsupported field type is echoed", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{Type: schemapb.DataType_None, FieldName: "weird"}
+		_, err := buildQueryResp(0, []string{"weird"}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+		require.Error(t, err)
+		assert.Contains(t, resultErrMessage(err), "use other sdk please")
+	})
+
+	t.Run("unsupported primary key type is echoed", func(t *testing.T) {
+		_, err := buildQueryResp(0, nil, nil, &schemapb.IDs{}, nil, true, nil)
+		require.Error(t, err)
+		assert.Contains(t, resultErrMessage(err), "use other sdk please")
+	})
+}
+
+func TestScalarFieldToRESTAny(t *testing.T) {
+	testCases := []struct {
+		name        string
+		field       *schemapb.ScalarField
+		enableInt64 bool
+		expected    any
+	}{
+		{
+			name:     "bool",
+			field:    &schemapb.ScalarField{Data: &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{Data: []bool{true, false}}}},
+			expected: []bool{true, false},
+		},
+		{
+			name:     "int",
+			field:    &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{1, 2}}}},
+			expected: []int32{1, 2},
+		},
+		{
+			name:        "int64 enabled",
+			field:       &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{9007199254740993}}}},
+			enableInt64: true,
+			expected:    []int64{9007199254740993},
+		},
+		{
+			name:     "int64 disabled",
+			field:    &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{9007199254740993}}}},
+			expected: []string{"9007199254740993"},
+		},
+		{
+			name:     "float",
+			field:    &schemapb.ScalarField{Data: &schemapb.ScalarField_FloatData{FloatData: &schemapb.FloatArray{Data: []float32{1.5}}}},
+			expected: []float32{1.5},
+		},
+		{
+			name:     "double",
+			field:    &schemapb.ScalarField{Data: &schemapb.ScalarField_DoubleData{DoubleData: &schemapb.DoubleArray{Data: []float64{2.5}}}},
+			expected: []float64{2.5},
+		},
+		{
+			name:     "varchar",
+			field:    &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"a", "b"}}}},
+			expected: []string{"a", "b"},
+		},
+		{
+			name:     "empty",
+			field:    &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{}}},
+			expected: []string{},
+		},
+		{
+			name: "nested",
+			field: &schemapb.ScalarField{Data: &schemapb.ScalarField_ArrayData{ArrayData: &schemapb.ArrayArray{Data: []*schemapb.ScalarField{
+				{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2}}}},
+				{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"a"}}}},
+			}}}},
+			enableInt64: true,
+			expected:    []any{[]int64{1, 2}, []string{"a"}},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual, err := scalarFieldToRESTAny(testCase.field, testCase.enableInt64)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expected, actual)
+		})
+	}
+
+	// A missing row degrades to null rather than failing the whole request: the
+	// previous implementation rendered it as null, and this change only fixes the
+	// serialization format.
+	t.Run("nil field renders as null", func(t *testing.T) {
+		value, err := scalarFieldToRESTAny(nil, true)
+		require.NoError(t, err)
+		assert.Nil(t, value)
+	})
+
+	// Likewise for a ScalarField whose oneof was never set, which is what segcore
+	// emits for an empty array with an undetermined element type.
+	t.Run("unset oneof renders as empty array", func(t *testing.T) {
+		value, err := scalarFieldToRESTAny(&schemapb.ScalarField{}, true)
+		require.NoError(t, err)
+		assert.Equal(t, []any{}, value)
+	})
+
+	// A oneof that is set but genuinely unsupported still fails loudly.
+	t.Run("unsupported field", func(t *testing.T) {
+		_, err := scalarFieldToRESTAny(&schemapb.ScalarField{Data: &schemapb.ScalarField_BytesData{}}, true)
+		require.Error(t, err)
+		assert.Equal(t, merr.Code(merr.ErrServiceInternal), merr.Code(err))
+	})
+}
+
+// buildQueryResp must survive both degraded row shapes end to end rather than
+// failing the query, and must still tell them apart in the emitted JSON.
+func TestBuildQueryRespDegradedArrayRows(t *testing.T) {
+	fieldData := &schemapb.FieldData{
+		Type:      schemapb.DataType_Array,
+		FieldName: "tags",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_ArrayData{
+					ArrayData: &schemapb.ArrayArray{
+						ElementType: schemapb.DataType_VarChar,
+						Data: []*schemapb.ScalarField{
+							{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"a"}}}},
+							nil, // missing row -> null
+							{},  // unset oneof -> []
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rows, err := buildQueryResp(0, []string{"tags"}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+	require.NoError(t, err)
+	payload, err := json.Marshal(gin.H{"data": rows})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"data":[{"tags":["a"]},{"tags":null},{"tags":[]}]}`, string(payload))
+}
+
+func TestBuildQueryRespNativeArrayValues(t *testing.T) {
+	fieldData := &schemapb.FieldData{
+		Type:      schemapb.DataType_Array,
+		FieldName: "tags",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_ArrayData{
+					ArrayData: &schemapb.ArrayArray{
+						Data: []*schemapb.ScalarField{
+							{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"hello", "world"}}}},
+							{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{}}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rows, err := buildQueryResp(0, []string{"tags"}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+	require.NoError(t, err)
+	payload, err := json.Marshal(gin.H{"data": rows})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"data":[{"tags":["hello","world"]},{"tags":[]}]}`, string(payload))
+
+	fieldData.ValidData = []bool{true, false, true}
+	rows, err = buildQueryResp(0, []string{"tags"}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+	require.NoError(t, err)
+	payload, err = json.Marshal(gin.H{"data": rows})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"data":[{"tags":["hello","world"]},{"tags":null},{"tags":[]}]}`, string(payload))
+
+	int64FieldData := &schemapb.FieldData{
+		Type:      schemapb.DataType_Array,
+		FieldName: "ids",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_ArrayData{
+					ArrayData: &schemapb.ArrayArray{
+						Data: []*schemapb.ScalarField{
+							{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{9007199254740993}}}},
+						},
+					},
+				},
+			},
+		},
+	}
+	rows, err = buildQueryResp(0, []string{"ids"}, []*schemapb.FieldData{int64FieldData}, nil, nil, false, nil)
+	require.NoError(t, err)
+	payload, err = json.Marshal(gin.H{"data": rows})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"data":[{"ids":["9007199254740993"]}]}`, string(payload))
+}
+
+func TestBuildQueryRespComplexNativeArrayJSON(t *testing.T) {
+	arrayField := func(name string, validData []bool, rows ...*schemapb.ScalarField) *schemapb.FieldData {
+		return &schemapb.FieldData{
+			Type:      schemapb.DataType_Array,
+			FieldName: name,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_ArrayData{
+						ArrayData: &schemapb.ArrayArray{Data: rows},
+					},
+				},
+			},
+			ValidData: validData,
+		}
+	}
+
+	fieldData := []*schemapb.FieldData{
+		arrayField("bool_arr", []bool{true, false, true},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{Data: []bool{true, false}}}},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{}}},
+		),
+		arrayField("int_arr", []bool{true, true, true},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{-128, 0, 127}}}},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{}}},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{42}}}},
+		),
+		arrayField("long_arr", []bool{true, true, false},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{9007199254740993, -9007199254740993}}}},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{}}},
+		),
+		arrayField("float_arr", []bool{false, true, true},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_FloatData{FloatData: &schemapb.FloatArray{Data: []float32{1.25, -2.5}}}},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_FloatData{FloatData: &schemapb.FloatArray{}}},
+		),
+		arrayField("double_arr", []bool{true, false, true},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_DoubleData{DoubleData: &schemapb.DoubleArray{Data: []float64{3.125, -0.0625}}}},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_DoubleData{DoubleData: &schemapb.DoubleArray{}}},
+		),
+		arrayField("string_arr", []bool{false, true, true},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"hello", "世界", "quote\" and slash\\"}}}},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{}}},
+		),
+	}
+	ids := &schemapb.IDs{
+		IdField: &schemapb.IDs_IntId{
+			IntId: &schemapb.LongArray{Data: []int64{9007199254740993, 2, 3}},
+		},
+	}
+	scores := []float32{0.875, 0.5, -0.25}
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{{Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true}},
+	}
+
+	testCases := []struct {
+		name              string
+		enableInt64       bool
+		expected          string
+		expectedInt64JSON []string
+	}{
+		{
+			name: "stringify int64",
+			expectedInt64JSON: []string{
+				`"pk":"9007199254740993"`,
+				`"long_arr":["9007199254740993","-9007199254740993"]`,
+			},
+			expected: `{
+				"data": [
+					{
+						"pk": "9007199254740993",
+						"distance": 0.875,
+						"bool_arr": [true, false],
+						"int_arr": [-128, 0, 127],
+						"long_arr": ["9007199254740993", "-9007199254740993"],
+						"float_arr": null,
+						"double_arr": [3.125, -0.0625],
+						"string_arr": null
+					},
+					{
+						"pk": "2",
+						"distance": 0.5,
+						"bool_arr": null,
+						"int_arr": [],
+						"long_arr": [],
+						"float_arr": [1.25, -2.5],
+						"double_arr": null,
+						"string_arr": ["hello", "世界", "quote\" and slash\\"]
+					},
+					{
+						"pk": "3",
+						"distance": -0.25,
+						"bool_arr": [],
+						"int_arr": [42],
+						"long_arr": null,
+						"float_arr": [],
+						"double_arr": [],
+						"string_arr": []
+					}
+				]
+			}`,
+		},
+		{
+			name:        "preserve int64",
+			enableInt64: true,
+			expectedInt64JSON: []string{
+				`"pk":9007199254740993`,
+				`"long_arr":[9007199254740993,-9007199254740993]`,
+			},
+			expected: `{
+				"data": [
+					{
+						"pk": 9007199254740993,
+						"distance": 0.875,
+						"bool_arr": [true, false],
+						"int_arr": [-128, 0, 127],
+						"long_arr": [9007199254740993, -9007199254740993],
+						"float_arr": null,
+						"double_arr": [3.125, -0.0625],
+						"string_arr": null
+					},
+					{
+						"pk": 2,
+						"distance": 0.5,
+						"bool_arr": null,
+						"int_arr": [],
+						"long_arr": [],
+						"float_arr": [1.25, -2.5],
+						"double_arr": null,
+						"string_arr": ["hello", "世界", "quote\" and slash\\"]
+					},
+					{
+						"pk": 3,
+						"distance": -0.25,
+						"bool_arr": [],
+						"int_arr": [42],
+						"long_arr": null,
+						"float_arr": [],
+						"double_arr": [],
+						"string_arr": []
+					}
+				]
+			}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			rows, err := buildQueryResp(0, nil, fieldData, ids, scores, testCase.enableInt64, schema)
+			require.NoError(t, err)
+			payload, err := json.Marshal(gin.H{"data": rows})
+			require.NoError(t, err)
+			assert.JSONEq(t, testCase.expected, string(payload))
+			for _, expected := range testCase.expectedInt64JSON {
+				assert.Contains(t, string(payload), expected)
+			}
+		})
+	}
+}
+
+// Int64 elements inside an ArrayOfStruct sub-field must honor
+// Accept-Type-Allow-Int64 exactly like a top-level Array field does. Values beyond
+// the JavaScript safe-integer range are asserted against the raw JSON, because
+// assert.JSONEq decodes both sides into float64 and would pass even if the digits
+// were silently rounded.
+func TestBuildQueryRespStructArrayInt64(t *testing.T) {
+	const (
+		bigPositive = int64(9007199254740993)
+		bigNegative = int64(-9007199254740993)
+	)
+
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+		},
+		StructArrayFields: []*schemapb.StructArrayFieldSchema{
+			{
+				FieldID: 101,
+				Name:    "my_struct",
+				Fields: []*schemapb.FieldSchema{
+					{
+						FieldID:     102,
+						Name:        "score",
+						DataType:    schemapb.DataType_Array,
+						ElementType: schemapb.DataType_Int64,
+					},
+				},
+			},
+		},
+	}
+
+	newFieldData := func() *schemapb.FieldData {
+		return &schemapb.FieldData{
+			Type:      schemapb.DataType_ArrayOfStruct,
+			FieldName: "my_struct",
+			Field: &schemapb.FieldData_StructArrays{
+				StructArrays: &schemapb.StructArrayField{
+					Fields: []*schemapb.FieldData{
+						{
+							Type:      schemapb.DataType_Array,
+							FieldName: "score",
+							Field: &schemapb.FieldData_Scalars{
+								Scalars: &schemapb.ScalarField{
+									Data: &schemapb.ScalarField_ArrayData{
+										ArrayData: &schemapb.ArrayArray{
+											ElementType: schemapb.DataType_Int64,
+											Data: []*schemapb.ScalarField{
+												{Data: &schemapb.ScalarField_LongData{
+													LongData: &schemapb.LongArray{Data: []int64{bigPositive, bigNegative}},
+												}},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name        string
+		enableInt64 bool
+		expected    string
+		expectedRaw []string
+	}{
+		{
+			name:        "stringify int64",
+			enableInt64: false,
+			expected:    `{"data":[{"my_struct":[{"score":"9007199254740993"},{"score":"-9007199254740993"}]}]}`,
+			expectedRaw: []string{`"score":"9007199254740993"`, `"score":"-9007199254740993"`},
+		},
+		{
+			name:        "preserve int64",
+			enableInt64: true,
+			expected:    `{"data":[{"my_struct":[{"score":9007199254740993},{"score":-9007199254740993}]}]}`,
+			expectedRaw: []string{`"score":9007199254740993`, `"score":-9007199254740993`},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			rows, err := buildQueryResp(0, nil, []*schemapb.FieldData{newFieldData()}, nil, nil, testCase.enableInt64, schema)
+			require.NoError(t, err)
+			payload, err := json.Marshal(gin.H{"data": rows})
+			require.NoError(t, err)
+			assert.JSONEq(t, testCase.expected, string(payload))
+			for _, raw := range testCase.expectedRaw {
+				assert.Contains(t, string(payload), raw)
+			}
+		})
+	}
 }
 
 func TestBuildQueryRespWithNullableCompactFields(t *testing.T) {
@@ -3980,13 +4551,13 @@ func TestBuildStructArrayFieldDataRoundTrip(t *testing.T) {
 
 	accessor, err := newStructArrayRowAccessor(fd, buildStructArrayTestSchema())
 	require.NoError(t, err)
-	extracted0, err := accessor.row(0)
+	extracted0, err := accessor.row(0, true)
 	require.NoError(t, err)
 	require.Len(t, extracted0, 2)
 	assert.EqualValues(t, int32(1), extracted0[0]["sub_int"])
 	assert.EqualValues(t, []float32{0.1, 0.2, 0.3, 0.4}, extracted0[0]["sub_vec"])
 
-	extracted1, err := accessor.row(1)
+	extracted1, err := accessor.row(1, true)
 	require.NoError(t, err)
 	require.Len(t, extracted1, 1)
 	assert.EqualValues(t, int32(3), extracted1[0]["sub_int"])
@@ -4586,7 +5157,7 @@ func TestExtractStructArrayRowErrorPaths(t *testing.T) {
 		},
 	}, buildStructArrayTestSchema())
 	require.NoError(t, err)
-	empty, err := accessor.row(0)
+	empty, err := accessor.row(0, true)
 	require.NoError(t, err)
 	assert.Empty(t, empty)
 
@@ -4598,7 +5169,7 @@ func TestExtractStructArrayRowErrorPaths(t *testing.T) {
 
 	accessor, err = newStructArrayRowAccessor(fd, schema)
 	require.NoError(t, err)
-	_, err = accessor.row(2)
+	_, err = accessor.row(2, true)
 	assert.Error(t, err)
 
 	mismatch := &schemapb.FieldData{
@@ -4634,7 +5205,7 @@ func TestExtractStructArrayRowErrorPaths(t *testing.T) {
 	}
 	accessor, err = newStructArrayRowAccessor(mismatch, schema)
 	require.NoError(t, err)
-	_, err = accessor.row(0)
+	_, err = accessor.row(0, true)
 	assert.Error(t, err)
 
 	missingDimSchema := &schemapb.CollectionSchema{
@@ -4642,7 +5213,7 @@ func TestExtractStructArrayRowErrorPaths(t *testing.T) {
 	}
 	accessor, err = newStructArrayRowAccessor(mismatch, missingDimSchema)
 	require.NoError(t, err)
-	_, err = accessor.row(0)
+	_, err = accessor.row(0, true)
 	assert.Error(t, err)
 
 	unsupported := &schemapb.FieldData{
@@ -4667,7 +5238,7 @@ func TestExtractStructArrayRowErrorPaths(t *testing.T) {
 	}
 	accessor, err = newStructArrayRowAccessor(unsupported, schema)
 	require.NoError(t, err)
-	_, err = accessor.row(0)
+	_, err = accessor.row(0, true)
 	assert.Error(t, err)
 }
 
@@ -4684,9 +5255,9 @@ func TestStructArrayHelperValueConversions(t *testing.T) {
 		{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"five"}}}},
 	}
 	for _, scalar := range scalars {
-		assert.Len(t, scalarArrayToInterfaces(scalar), 1)
+		assert.Len(t, scalarArrayToInterfaces(scalar, true), 1)
 	}
-	assert.Nil(t, scalarArrayToInterfaces(&schemapb.ScalarField{}))
+	assert.Nil(t, scalarArrayToInterfaces(&schemapb.ScalarField{}, true))
 
 	vectorTests := []struct {
 		name        string

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -1720,6 +1720,239 @@ func TestInsertWithDefaultValueField(t *testing.T) {
 	assert.Equal(t, len(coll.Fields), len(fieldData))
 }
 
+// Without Accept-Type-Allow-Int64 the response renders Int64 array elements as
+// strings, so the insert path has to read that form back: a row this API emits
+// must be acceptable to it unchanged.
+func TestInsertQuotedInt64ArrayElements(t *testing.T) {
+	arrayFieldName := "array-int64"
+	coll := generateCollectionSchema(schemapb.DataType_Int64, false, true)
+	coll.Fields = append(coll.Fields, &schemapb.FieldSchema{
+		Name:        arrayFieldName,
+		DataType:    schemapb.DataType_Array,
+		ElementType: schemapb.DataType_Int64,
+	})
+
+	row := func(value string) []byte {
+		return []byte(`{"data": [{"book_id": 1, "book_intro": [0.1, 0.2], "word_count": 2, "` +
+			arrayFieldName + `": ` + value + `}]}`)
+	}
+
+	t.Run("quoted elements round-trip", func(t *testing.T) {
+		// 9007199254740993 is the first integer a float64 cannot hold, which is
+		// why the response quotes it in the first place.
+		data, _, err := checkAndSetData(row(`["9007199254740993", "-1", "010"]`), coll, false)
+		require.NoError(t, err)
+		arr, ok := data[0][arrayFieldName].(*schemapb.ScalarField)
+		require.True(t, ok)
+		// "010" reads as decimal 10, matching how a quoted top-level Int64 is read.
+		assert.Equal(t, []int64{9007199254740993, -1, 10}, arr.GetLongData().GetData())
+	})
+
+	t.Run("native elements still work", func(t *testing.T) {
+		data, _, err := checkAndSetData(row(`[9007199254740993]`), coll, false)
+		require.NoError(t, err)
+		arr, _ := data[0][arrayFieldName].(*schemapb.ScalarField)
+		assert.Equal(t, []int64{9007199254740993}, arr.GetLongData().GetData())
+	})
+
+	t.Run("the two forms may be mixed", func(t *testing.T) {
+		// Each element is read on its own, the way each row of a plain Int64
+		// column is: nothing about one element decides how the next is read.
+		data, _, err := checkAndSetData(row(`[9007199254740993, "1"]`), coll, false)
+		require.NoError(t, err)
+		arr, _ := data[0][arrayFieldName].(*schemapb.ScalarField)
+		assert.Equal(t, []int64{9007199254740993, 1}, arr.GetLongData().GetData())
+	})
+
+	// Accepting the quoted form does not accept nonsense in it.
+	for _, value := range []string{
+		`["9223372036854775808"]`, // out of range
+		`["1.5"]`,
+		`["abc"]`,
+		`[""]`,
+		`[{}]`,
+	} {
+		t.Run("rejects "+value, func(t *testing.T) {
+			_, _, err := checkAndSetData(row(value), coll, false)
+			assert.Error(t, err)
+		})
+	}
+}
+
+// An array element accepts the same quoted forms the same type accepts as a
+// plain column, and a struct array's sub-field accepts exactly what a top-level
+// Array column accepts -- the two read through one function, and this pins that
+// they cannot drift apart.
+func TestQuotedArrayElementsMatchPlainColumns(t *testing.T) {
+	for _, tc := range []struct {
+		elementType schemapb.DataType
+		quoted      string
+		want        interface{}
+		rejects     []string
+	}{
+		{schemapb.DataType_Bool, `["true", "false"]`, []bool{true, false}, []string{`["yes please"]`, `[{}]`}},
+		{schemapb.DataType_Int8, `["-8", "127"]`, []int32{-8, 127}, []string{`["128"]`, `["1.5"]`, `["abc"]`}},
+		{schemapb.DataType_Int16, `["-16", "32767"]`, []int32{-16, 32767}, []string{`["32768"]`, `["abc"]`}},
+		{schemapb.DataType_Int32, `["-32", "2147483647"]`, []int32{-32, 2147483647}, []string{`["2147483648"]`, `["abc"]`}},
+		{schemapb.DataType_Int64, `["9007199254740993", "010"]`, []int64{9007199254740993, 10}, []string{`["9223372036854775808"]`, `["abc"]`, `[""]`}},
+		// strconv reads NaN/Inf/Infinity without an error, case-insensitively,
+		// and an array element has no later check that would catch them.
+		{schemapb.DataType_Float, `["1.5", "-2"]`, []float32{1.5, -2}, []string{
+			`["3.5e38"]`, `["abc"]`, `["NaN"]`, `["nan"]`, `["Inf"]`, `["+Inf"]`, `["-inf"]`, `["Infinity"]`,
+		}},
+		{schemapb.DataType_Double, `["1.5", "-2"]`, []float64{1.5, -2}, []string{
+			`["abc"]`, `["1e400"]`, `[1e400]`, `["NaN"]`, `["Inf"]`, `["-Infinity"]`,
+		}},
+	} {
+		t.Run(tc.elementType.String(), func(t *testing.T) {
+			read := func(scalar *schemapb.ScalarField) interface{} {
+				switch tc.elementType {
+				case schemapb.DataType_Bool:
+					return scalar.GetBoolData().GetData()
+				case schemapb.DataType_Int8, schemapb.DataType_Int16, schemapb.DataType_Int32:
+					return scalar.GetIntData().GetData()
+				case schemapb.DataType_Int64:
+					return scalar.GetLongData().GetData()
+				case schemapb.DataType_Float:
+					return scalar.GetFloatData().GetData()
+				default:
+					return scalar.GetDoubleData().GetData()
+				}
+			}
+
+			// The top-level Array column.
+			coll := generateCollectionSchema(schemapb.DataType_Int64, false, true)
+			coll.Fields = append(coll.Fields, &schemapb.FieldSchema{
+				Name:        "arr",
+				DataType:    schemapb.DataType_Array,
+				ElementType: tc.elementType,
+			})
+			column := func(value string) ([]map[string]interface{}, error) {
+				body := []byte(`{"data": [{"book_id": 1, "book_intro": [0.1, 0.2], "word_count": 2, "arr": ` + value + `}]}`)
+				data, _, err := checkAndSetData(body, coll, false)
+				return data, err
+			}
+
+			// The same array as a struct sub-field.
+			sub := &schemapb.FieldSchema{Name: "arr", DataType: schemapb.DataType_Array, ElementType: tc.elementType}
+
+			data, err := column(tc.quoted)
+			require.NoError(t, err)
+			scalar, ok := data[0]["arr"].(*schemapb.ScalarField)
+			require.True(t, ok)
+			assert.Equal(t, tc.want, read(scalar))
+
+			subScalar, err := buildStructSubArrayScalar(sub, gjson.Parse(tc.quoted).Array(), false)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, read(subScalar))
+
+			for _, bad := range tc.rejects {
+				_, err := column(bad)
+				assert.Error(t, err, "column %s", bad)
+				_, err = buildStructSubArrayScalar(sub, gjson.Parse(bad).Array(), false)
+				assert.Error(t, err, "sub-field %s", bad)
+			}
+		})
+	}
+}
+
+// compatibilityMode restores the value handling of the releases before the REST
+// insert validation work: it decides whether a number that does not denote a
+// value of the element type is converted anyway. It says nothing about how a
+// value is spelled, so the quoted spelling -- which this API itself emits for an
+// Int64 without Accept-Type-Allow-Int64, in this mode too -- stays readable, and
+// the wrapping conversions do not spread to a column that never had them.
+func TestCompatibilityModeChangesValuesNotSpellings(t *testing.T) {
+	params := paramtable.Get()
+	key := params.HTTPCfg.CompatibilityMode.Key
+	params.Save(key, "true")
+	defer params.Reset(key)
+
+	column := func(elementType schemapb.DataType, value string) error {
+		coll := generateCollectionSchema(schemapb.DataType_Int64, false, true)
+		coll.Fields = append(coll.Fields, &schemapb.FieldSchema{
+			Name:        "arr",
+			DataType:    schemapb.DataType_Array,
+			ElementType: elementType,
+		})
+		body := []byte(`{"data": [{"book_id": 1, "book_intro": [0.1, 0.2], "word_count": 2, "arr": ` + value + `}]}`)
+		_, _, err := checkAndSetData(body, coll, false)
+		return err
+	}
+
+	// A column never converted a number it could not represent, and still does
+	// not: gjson would have stored 2 for 2.7, a wrapped numeral for one past
+	// int64, and +Inf for a magnitude past float32.
+	for _, tc := range []struct {
+		name        string
+		elementType schemapb.DataType
+		value       string
+	}{
+		{"fraction into an integer", schemapb.DataType_Int32, `[1, 2.7, 3]`},
+		{"numeral past int64", schemapb.DataType_Int64, `[1, 99999999999999999999]`},
+		{"magnitude past float32", schemapb.DataType_Float, `[1.0, 1e50, 2.0]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Error(t, column(tc.elementType, tc.value))
+		})
+	}
+
+	// The spelling this mode's own responses use is still readable.
+	t.Run("the quoted spelling round-trips", func(t *testing.T) {
+		assert.NoError(t, column(schemapb.DataType_Int64, `["9007199254740993"]`))
+	})
+
+	sub := &schemapb.FieldSchema{Name: "arr", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Int32}
+
+	// The struct sub-field keeps the lenient conversions it has always had --
+	// this is the one place they ever lived.
+	scalar, err := buildStructSubArrayScalar(sub, gjson.Parse(`[1, 2.7, 3]`).Array(), true)
+	require.NoError(t, err)
+	assert.Equal(t, []int32{1, 2, 3}, scalar.GetIntData().GetData())
+
+	// ...and reads the quoted spelling here too, on the same grounds.
+	scalar, err = buildStructSubArrayScalar(sub, gjson.Parse(`["1", "2"]`).Array(), true)
+	require.NoError(t, err)
+	assert.Equal(t, []int32{1, 2}, scalar.GetIntData().GetData())
+}
+
+// A rejected array says which element was wrong, not just that the value was.
+func TestArrayElementErrorNamesTheElement(t *testing.T) {
+	coll := generateCollectionSchema(schemapb.DataType_Int64, false, true)
+	coll.Fields = append(coll.Fields, &schemapb.FieldSchema{
+		Name:        "arr",
+		DataType:    schemapb.DataType_Array,
+		ElementType: schemapb.DataType_Int8,
+	})
+	body := []byte(`{"data": [{"book_id": 1, "book_intro": [0.1, 0.2], "word_count": 2, "arr": [1, "abc", 3]}]}`)
+	_, _, err := checkAndSetData(body, coll, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "element 1")
+	assert.Contains(t, err.Error(), "[-128, 127]")
+}
+
+// Same convention for the Int64 sub-field of a struct array.
+func TestStructSubArrayQuotedInt64(t *testing.T) {
+	sub := &schemapb.FieldSchema{
+		Name:        "scores",
+		DataType:    schemapb.DataType_Array,
+		ElementType: schemapb.DataType_Int64,
+	}
+
+	scalar, err := buildStructSubArrayScalar(sub, gjson.Parse(`["9007199254740993", "010"]`).Array(), false)
+	require.NoError(t, err)
+	assert.Equal(t, []int64{9007199254740993, 10}, scalar.GetLongData().GetData())
+
+	scalar, err = buildStructSubArrayScalar(sub, gjson.Parse(`[9007199254740993]`).Array(), false)
+	require.NoError(t, err)
+	assert.Equal(t, []int64{9007199254740993}, scalar.GetLongData().GetData())
+
+	for _, raw := range []string{`["9223372036854775808"]`, `["1.5"]`, `["abc"]`, `[""]`} {
+		_, err = buildStructSubArrayScalar(sub, gjson.Parse(raw).Array(), false)
+		assert.Error(t, err, raw)
+	}
+}
+
 func TestSerialize(t *testing.T) {
 	parameters := []float32{0.11111, 0.22222}
 	assert.Equal(t, "\n\x10\n\x02$0\x10e\x1a\b\xa4\x8d\xe3=\xa4\x8dc>", string(vectors2PlaceholderGroupBytes([][]float32{parameters}))) // todo
@@ -2079,9 +2312,18 @@ func compareRow(m1 map[string]interface{}, m2 map[string]interface{}) bool {
 				}
 			}
 		} else if key == "field-json" {
-			arr1 := value.(string)
-			arr2 := m2[key].([]byte)
-			if arr1 != string(arr2) {
+			// The field reads back as the document it holds, or as the text of
+			// that document when proxy.http.nativeJSONResponse is off.
+			var got []byte
+			switch v := value.(type) {
+			case string:
+				got = []byte(v)
+			case json.RawMessage:
+				got = []byte(v)
+			default:
+				return false
+			}
+			if string(got) != string(m2[key].([]byte)) {
 				return false
 			}
 		} else if key == "field-geometry" {
@@ -2129,6 +2371,692 @@ func TestBuildQueryResp(t *testing.T) {
 	assert.Equal(t, nil, err)
 	exceptRows := generateSearchResult(schemapb.DataType_Int64)
 	assert.Equal(t, true, compareRows(rows, exceptRows, compareRow))
+}
+
+func TestResultErrMessage(t *testing.T) {
+	t.Run("marked message is echoed", func(t *testing.T) {
+		err := asSafeMessage(merr.WrapErrParameterInvalidMsg(
+			"the type(%v) of field(%v) is not supported, use other sdk please",
+			schemapb.DataType_Geometry, "geo"))
+		assert.Contains(t, resultErrMessage(err), "use other sdk please")
+	})
+
+	t.Run("marked message survives field wrapping", func(t *testing.T) {
+		err := asSafeMessage(merr.WrapErrParameterInvalidMsg(
+			"the type(%v) of field(%v) is not supported, use other sdk please",
+			schemapb.DataType_Geometry, "geo"))
+		msg := resultErrMessage(wrapOutputFieldErr("geo", err))
+		assert.Contains(t, msg, "use other sdk please")
+		assert.Contains(t, msg, "geo")
+	})
+
+	// Being an InputError is not enough on its own: most ParameterInvalid errors
+	// on this path describe a server-side shape mismatch.
+	t.Run("unmarked input error is not echoed", func(t *testing.T) {
+		err := merr.WrapErrParameterInvalidMsg("field %s has %d valid rows, but data length is %d", "tags", 2, 1)
+		msg := resultErrMessage(wrapOutputFieldErr("tags", err))
+		assert.Contains(t, msg, "tags")
+		assert.NotContains(t, msg, "valid rows")
+		assert.NotContains(t, msg, "data length")
+	})
+
+	t.Run("server fault names the field and nothing else", func(t *testing.T) {
+		inner := merr.WrapErrServiceInternalMsg("array row scalar field is nil")
+		err := wrapOutputFieldErr("user_email_tags", merr.Wrapf(inner, "row %d", 3))
+		msg := resultErrMessage(err)
+		// The caller learns which output field to drop or report...
+		assert.Contains(t, msg, "user_email_tags")
+		// ...but nothing about internal structures or row offsets.
+		assert.NotContains(t, msg, "service internal error")
+		assert.NotContains(t, msg, "scalar field")
+		assert.NotContains(t, msg, "row 3")
+	})
+
+	t.Run("non-milvus error is not echoed", func(t *testing.T) {
+		err := json.Unmarshal([]byte("{bad"), &struct{}{})
+		require.Error(t, err)
+		msg := resultErrMessage(err)
+		assert.Equal(t, merr.ErrInvalidSearchResult.Error(), msg)
+	})
+
+	t.Run("stage fault names the stage and nothing else", func(t *testing.T) {
+		inner := merr.WrapErrServiceInternalMsg("search_aggregation agg_topks sum %d does not match bucket count %d", 3, 2)
+		msg := resultErrMessage(wrapResultStageErr("search aggregation result", inner))
+		assert.Contains(t, msg, "search aggregation result")
+		assert.NotContains(t, msg, "agg_topks")
+		assert.NotContains(t, msg, "bucket count")
+	})
+}
+
+// A dynamic field whose stored bytes are not one JSON document is the caller's own
+// data, so the reason reaches them. The internal $meta name does not: it is not one
+// of their output fields, so naming it would point at a column they cannot drop.
+func TestBuildQueryRespDynamicFieldNotSingleDocument(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  string
+	}{
+		{"trailing document", `{"a": 1}{"b": 2}`},
+		{"not json at all", `not-json`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fieldData := &schemapb.FieldData{
+				Type:      schemapb.DataType_JSON,
+				FieldName: common.MetaFieldName,
+				IsDynamic: true,
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_JsonData{
+							JsonData: &schemapb.JSONArray{Data: [][]byte{[]byte(tc.raw)}},
+						},
+					},
+				},
+			}
+			_, err := buildQueryResp(int64(0), []string{"a"}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+			require.Error(t, err)
+
+			msg := resultErrMessage(err)
+			assert.Contains(t, msg, "dynamic field does not hold a single JSON document")
+			assert.NotContains(t, msg, common.MetaFieldName)
+		})
+	}
+}
+
+// proxy.http.legacyArrayResponse lets a deployment keep serving the pre-fix shape
+// while clients that parsed it migrate. Default stays off.
+func TestBuildQueryRespLegacyArrayResponse(t *testing.T) {
+	fieldData := &schemapb.FieldData{
+		Type:      schemapb.DataType_Array,
+		FieldName: "tags",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_ArrayData{
+					ArrayData: &schemapb.ArrayArray{
+						ElementType: schemapb.DataType_VarChar,
+						Data: []*schemapb.ScalarField{
+							{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"a", "b"}}}},
+						},
+					},
+				},
+			},
+		},
+	}
+	render := func() string {
+		rows, err := buildQueryResp(0, []string{"tags"}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+		require.NoError(t, err)
+		payload, err := json.Marshal(gin.H{"data": rows})
+		require.NoError(t, err)
+		return string(payload)
+	}
+
+	params := paramtable.Get()
+	key := params.HTTPCfg.LegacyArrayResponse.Key
+
+	// Default: native JSON array.
+	require.False(t, params.HTTPCfg.LegacyArrayResponse.GetAsBool())
+	assert.JSONEq(t, `{"data":[{"tags":["a","b"]}]}`, render())
+
+	// Switched on: the pre-fix protobuf wrapper shape. Rendered by the
+	// encoder that serves responses, since reproducing that output is the
+	// whole point of the switch.
+	params.Save(key, "true")
+	defer params.Reset(key)
+	assert.JSONEq(t, `{"data":[{"tags":{"Data":{"StringData":{"data":["a","b"]}}}}]}`, render())
+
+	// And back off again, so the switch is not one-way.
+	params.Reset(key)
+	assert.JSONEq(t, `{"data":[{"tags":["a","b"]}]}`, render())
+}
+
+// The switch restores a shape, not a rendering: Accept-Type-Allow-Int64 says
+// what the caller's JSON parser can hold, which the shape does not change, so an
+// Int64 past the JavaScript safe range still arrives as a string inside the
+// wrapper rather than as a number that would round on arrival.
+func TestLegacyArrayResponseKeepsInt64Safe(t *testing.T) {
+	longRow := func(values ...int64) *schemapb.FieldData {
+		return &schemapb.FieldData{
+			Type:      schemapb.DataType_Array,
+			FieldName: "ids",
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_ArrayData{
+						ArrayData: &schemapb.ArrayArray{
+							ElementType: schemapb.DataType_Int64,
+							Data: []*schemapb.ScalarField{
+								{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: values}}},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	params := paramtable.Get()
+	key := params.HTTPCfg.LegacyArrayResponse.Key
+	params.Save(key, "true")
+	defer params.Reset(key)
+
+	render := func(enableInt64 bool) string {
+		rows, err := buildQueryResp(0, []string{"ids"},
+			[]*schemapb.FieldData{longRow(9007199254740993, 1)}, nil, nil, enableInt64, nil)
+		require.NoError(t, err)
+		payload, err := json.Marshal(gin.H{"data": rows})
+		require.NoError(t, err)
+		return string(payload)
+	}
+
+	// Without the header the value cannot be a JSON number, in any shape.
+	assert.JSONEq(t,
+		`{"data":[{"ids":{"Data":{"LongData":{"data":["9007199254740993","1"]}}}}]}`,
+		render(false))
+	assert.NotContains(t, render(false), "9007199254740993,")
+
+	// With it, the message is rendered as it stands.
+	assert.JSONEq(t,
+		`{"data":[{"ids":{"Data":{"LongData":{"data":[9007199254740993,1]}}}}]}`,
+		render(true))
+
+	// A row with no Int64 in it is untouched either way.
+	stringRow := &schemapb.FieldData{
+		Type:      schemapb.DataType_Array,
+		FieldName: "tags",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_ArrayData{
+					ArrayData: &schemapb.ArrayArray{
+						ElementType: schemapb.DataType_VarChar,
+						Data: []*schemapb.ScalarField{
+							{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"a"}}}},
+						},
+					},
+				},
+			},
+		},
+	}
+	rows, err := buildQueryResp(0, []string{"tags"}, []*schemapb.FieldData{stringRow}, nil, nil, false, nil)
+	require.NoError(t, err)
+	payload, err := json.Marshal(gin.H{"data": rows})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"data":[{"tags":{"Data":{"StringData":{"data":["a"]}}}}]}`, string(payload))
+}
+
+// The redaction rules must hold for the errors buildQueryResp actually produces,
+// not only for hand-built ones. Each case drives a real producer and asserts on
+// what the client would receive.
+func TestResultErrMessageFromRealProducers(t *testing.T) {
+	t.Run("valid-data shape mismatch is not echoed", func(t *testing.T) {
+		// ValidData describes 3 rows of which 2 are valid, but only 1 row exists.
+		fieldData := &schemapb.FieldData{
+			Type:      schemapb.DataType_Array,
+			FieldName: "tags",
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_ArrayData{
+						ArrayData: &schemapb.ArrayArray{
+							ElementType: schemapb.DataType_VarChar,
+							Data: []*schemapb.ScalarField{
+								{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"a"}}}},
+							},
+						},
+					},
+				},
+			},
+			ValidData: []bool{true, true, false},
+		}
+
+		_, err := buildQueryResp(0, []string{"tags"}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+		require.Error(t, err)
+		// The producer really does spell out the internal shape...
+		require.Contains(t, err.Error(), "valid rows")
+
+		// ...and the client must not see it.
+		msg := resultErrMessage(err)
+		assert.Contains(t, msg, "tags")
+		assert.NotContains(t, msg, "valid rows")
+		assert.NotContains(t, msg, "data length")
+	})
+
+	t.Run("unsupported field type is echoed", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{Type: schemapb.DataType_None, FieldName: "weird"}
+		_, err := buildQueryResp(0, []string{"weird"}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+		require.Error(t, err)
+		assert.Contains(t, resultErrMessage(err), "use other sdk please")
+	})
+
+	t.Run("unsupported primary key type is echoed", func(t *testing.T) {
+		_, err := buildQueryResp(0, nil, nil, &schemapb.IDs{}, nil, true, nil)
+		require.Error(t, err)
+		assert.Contains(t, resultErrMessage(err), "use other sdk please")
+	})
+}
+
+func TestScalarFieldToRESTAny(t *testing.T) {
+	testCases := []struct {
+		name        string
+		field       *schemapb.ScalarField
+		enableInt64 bool
+		expected    any
+	}{
+		{
+			name:     "bool",
+			field:    &schemapb.ScalarField{Data: &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{Data: []bool{true, false}}}},
+			expected: []bool{true, false},
+		},
+		{
+			name:     "int",
+			field:    &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{1, 2}}}},
+			expected: []int32{1, 2},
+		},
+		{
+			name:        "int64 enabled",
+			field:       &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{9007199254740993}}}},
+			enableInt64: true,
+			expected:    []int64{9007199254740993},
+		},
+		{
+			name:     "int64 disabled",
+			field:    &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{9007199254740993}}}},
+			expected: []string{"9007199254740993"},
+		},
+		{
+			name:     "float",
+			field:    &schemapb.ScalarField{Data: &schemapb.ScalarField_FloatData{FloatData: &schemapb.FloatArray{Data: []float32{1.5}}}},
+			expected: []float32{1.5},
+		},
+		{
+			name:     "double",
+			field:    &schemapb.ScalarField{Data: &schemapb.ScalarField_DoubleData{DoubleData: &schemapb.DoubleArray{Data: []float64{2.5}}}},
+			expected: []float64{2.5},
+		},
+		{
+			name:     "varchar",
+			field:    &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"a", "b"}}}},
+			expected: []string{"a", "b"},
+		},
+		{
+			name:     "empty",
+			field:    &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{}}},
+			expected: []string{},
+		},
+		{
+			name: "nested",
+			field: &schemapb.ScalarField{Data: &schemapb.ScalarField_ArrayData{ArrayData: &schemapb.ArrayArray{Data: []*schemapb.ScalarField{
+				{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2}}}},
+				{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"a"}}}},
+			}}}},
+			enableInt64: true,
+			expected:    []any{[]int64{1, 2}, []string{"a"}},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual, err := scalarFieldToRESTAny(testCase.field, testCase.enableInt64)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expected, actual)
+		})
+	}
+
+	// A missing row degrades to null rather than failing the whole request: the
+	// previous implementation rendered it as null, and this change only fixes the
+	// serialization format.
+	t.Run("nil field renders as null", func(t *testing.T) {
+		value, err := scalarFieldToRESTAny(nil, true)
+		require.NoError(t, err)
+		assert.Nil(t, value)
+	})
+
+	// Likewise for a ScalarField whose oneof was never set, which is what segcore
+	// emits for an empty array with an undetermined element type.
+	t.Run("unset oneof renders as empty array", func(t *testing.T) {
+		value, err := scalarFieldToRESTAny(&schemapb.ScalarField{}, true)
+		require.NoError(t, err)
+		assert.Equal(t, []any{}, value)
+	})
+
+	// A oneof that is set but genuinely unsupported still fails loudly.
+	t.Run("unsupported field", func(t *testing.T) {
+		_, err := scalarFieldToRESTAny(&schemapb.ScalarField{Data: &schemapb.ScalarField_BytesData{}}, true)
+		require.Error(t, err)
+		assert.Equal(t, merr.Code(merr.ErrServiceInternal), merr.Code(err))
+	})
+}
+
+// buildQueryResp must survive both degraded row shapes end to end rather than
+// failing the query, and must still tell them apart in the emitted JSON.
+func TestBuildQueryRespDegradedArrayRows(t *testing.T) {
+	fieldData := &schemapb.FieldData{
+		Type:      schemapb.DataType_Array,
+		FieldName: "tags",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_ArrayData{
+					ArrayData: &schemapb.ArrayArray{
+						ElementType: schemapb.DataType_VarChar,
+						Data: []*schemapb.ScalarField{
+							{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"a"}}}},
+							nil, // missing row -> null
+							{},  // unset oneof -> []
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rows, err := buildQueryResp(0, []string{"tags"}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+	require.NoError(t, err)
+	payload, err := json.Marshal(gin.H{"data": rows})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"data":[{"tags":["a"]},{"tags":null},{"tags":[]}]}`, string(payload))
+}
+
+func TestBuildQueryRespNativeArrayValues(t *testing.T) {
+	fieldData := &schemapb.FieldData{
+		Type:      schemapb.DataType_Array,
+		FieldName: "tags",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_ArrayData{
+					ArrayData: &schemapb.ArrayArray{
+						Data: []*schemapb.ScalarField{
+							{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"hello", "world"}}}},
+							{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{}}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rows, err := buildQueryResp(0, []string{"tags"}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+	require.NoError(t, err)
+	payload, err := json.Marshal(gin.H{"data": rows})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"data":[{"tags":["hello","world"]},{"tags":[]}]}`, string(payload))
+
+	fieldData.ValidData = []bool{true, false, true}
+	rows, err = buildQueryResp(0, []string{"tags"}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+	require.NoError(t, err)
+	payload, err = json.Marshal(gin.H{"data": rows})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"data":[{"tags":["hello","world"]},{"tags":null},{"tags":[]}]}`, string(payload))
+
+	int64FieldData := &schemapb.FieldData{
+		Type:      schemapb.DataType_Array,
+		FieldName: "ids",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_ArrayData{
+					ArrayData: &schemapb.ArrayArray{
+						Data: []*schemapb.ScalarField{
+							{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{9007199254740993}}}},
+						},
+					},
+				},
+			},
+		},
+	}
+	rows, err = buildQueryResp(0, []string{"ids"}, []*schemapb.FieldData{int64FieldData}, nil, nil, false, nil)
+	require.NoError(t, err)
+	payload, err = json.Marshal(gin.H{"data": rows})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"data":[{"ids":["9007199254740993"]}]}`, string(payload))
+}
+
+func TestBuildQueryRespComplexNativeArrayJSON(t *testing.T) {
+	arrayField := func(name string, validData []bool, rows ...*schemapb.ScalarField) *schemapb.FieldData {
+		return &schemapb.FieldData{
+			Type:      schemapb.DataType_Array,
+			FieldName: name,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_ArrayData{
+						ArrayData: &schemapb.ArrayArray{Data: rows},
+					},
+				},
+			},
+			ValidData: validData,
+		}
+	}
+
+	fieldData := []*schemapb.FieldData{
+		arrayField("bool_arr", []bool{true, false, true},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{Data: []bool{true, false}}}},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{}}},
+		),
+		arrayField("int_arr", []bool{true, true, true},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{-128, 0, 127}}}},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{}}},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{42}}}},
+		),
+		arrayField("long_arr", []bool{true, true, false},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{9007199254740993, -9007199254740993}}}},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{}}},
+		),
+		arrayField("float_arr", []bool{false, true, true},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_FloatData{FloatData: &schemapb.FloatArray{Data: []float32{1.25, -2.5}}}},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_FloatData{FloatData: &schemapb.FloatArray{}}},
+		),
+		arrayField("double_arr", []bool{true, false, true},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_DoubleData{DoubleData: &schemapb.DoubleArray{Data: []float64{3.125, -0.0625}}}},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_DoubleData{DoubleData: &schemapb.DoubleArray{}}},
+		),
+		arrayField("string_arr", []bool{false, true, true},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"hello", "世界", "quote\" and slash\\"}}}},
+			&schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{}}},
+		),
+	}
+	ids := &schemapb.IDs{
+		IdField: &schemapb.IDs_IntId{
+			IntId: &schemapb.LongArray{Data: []int64{9007199254740993, 2, 3}},
+		},
+	}
+	scores := []float32{0.875, 0.5, -0.25}
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{{Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true}},
+	}
+
+	testCases := []struct {
+		name              string
+		enableInt64       bool
+		expected          string
+		expectedInt64JSON []string
+	}{
+		{
+			name: "stringify int64",
+			expectedInt64JSON: []string{
+				`"pk":"9007199254740993"`,
+				`"long_arr":["9007199254740993","-9007199254740993"]`,
+			},
+			expected: `{
+				"data": [
+					{
+						"pk": "9007199254740993",
+						"distance": 0.875,
+						"bool_arr": [true, false],
+						"int_arr": [-128, 0, 127],
+						"long_arr": ["9007199254740993", "-9007199254740993"],
+						"float_arr": null,
+						"double_arr": [3.125, -0.0625],
+						"string_arr": null
+					},
+					{
+						"pk": "2",
+						"distance": 0.5,
+						"bool_arr": null,
+						"int_arr": [],
+						"long_arr": [],
+						"float_arr": [1.25, -2.5],
+						"double_arr": null,
+						"string_arr": ["hello", "世界", "quote\" and slash\\"]
+					},
+					{
+						"pk": "3",
+						"distance": -0.25,
+						"bool_arr": [],
+						"int_arr": [42],
+						"long_arr": null,
+						"float_arr": [],
+						"double_arr": [],
+						"string_arr": []
+					}
+				]
+			}`,
+		},
+		{
+			name:        "preserve int64",
+			enableInt64: true,
+			expectedInt64JSON: []string{
+				`"pk":9007199254740993`,
+				`"long_arr":[9007199254740993,-9007199254740993]`,
+			},
+			expected: `{
+				"data": [
+					{
+						"pk": 9007199254740993,
+						"distance": 0.875,
+						"bool_arr": [true, false],
+						"int_arr": [-128, 0, 127],
+						"long_arr": [9007199254740993, -9007199254740993],
+						"float_arr": null,
+						"double_arr": [3.125, -0.0625],
+						"string_arr": null
+					},
+					{
+						"pk": 2,
+						"distance": 0.5,
+						"bool_arr": null,
+						"int_arr": [],
+						"long_arr": [],
+						"float_arr": [1.25, -2.5],
+						"double_arr": null,
+						"string_arr": ["hello", "世界", "quote\" and slash\\"]
+					},
+					{
+						"pk": 3,
+						"distance": -0.25,
+						"bool_arr": [],
+						"int_arr": [42],
+						"long_arr": null,
+						"float_arr": [],
+						"double_arr": [],
+						"string_arr": []
+					}
+				]
+			}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			rows, err := buildQueryResp(0, nil, fieldData, ids, scores, testCase.enableInt64, schema)
+			require.NoError(t, err)
+			payload, err := json.Marshal(gin.H{"data": rows})
+			require.NoError(t, err)
+			assert.JSONEq(t, testCase.expected, string(payload))
+			for _, expected := range testCase.expectedInt64JSON {
+				assert.Contains(t, string(payload), expected)
+			}
+		})
+	}
+}
+
+// Int64 elements inside an ArrayOfStruct sub-field must honor
+// Accept-Type-Allow-Int64 exactly like a top-level Array field does. Values beyond
+// the JavaScript safe-integer range are asserted against the raw JSON, because
+// assert.JSONEq decodes both sides into float64 and would pass even if the digits
+// were silently rounded.
+func TestBuildQueryRespStructArrayInt64(t *testing.T) {
+	const (
+		bigPositive = int64(9007199254740993)
+		bigNegative = int64(-9007199254740993)
+	)
+
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+		},
+		StructArrayFields: []*schemapb.StructArrayFieldSchema{
+			{
+				FieldID: 101,
+				Name:    "my_struct",
+				Fields: []*schemapb.FieldSchema{
+					{
+						FieldID:     102,
+						Name:        "score",
+						DataType:    schemapb.DataType_Array,
+						ElementType: schemapb.DataType_Int64,
+					},
+				},
+			},
+		},
+	}
+
+	newFieldData := func() *schemapb.FieldData {
+		return &schemapb.FieldData{
+			Type:      schemapb.DataType_ArrayOfStruct,
+			FieldName: "my_struct",
+			Field: &schemapb.FieldData_StructArrays{
+				StructArrays: &schemapb.StructArrayField{
+					Fields: []*schemapb.FieldData{
+						{
+							Type:      schemapb.DataType_Array,
+							FieldName: "score",
+							Field: &schemapb.FieldData_Scalars{
+								Scalars: &schemapb.ScalarField{
+									Data: &schemapb.ScalarField_ArrayData{
+										ArrayData: &schemapb.ArrayArray{
+											ElementType: schemapb.DataType_Int64,
+											Data: []*schemapb.ScalarField{
+												{Data: &schemapb.ScalarField_LongData{
+													LongData: &schemapb.LongArray{Data: []int64{bigPositive, bigNegative}},
+												}},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name        string
+		enableInt64 bool
+		expected    string
+		expectedRaw []string
+	}{
+		{
+			name:        "stringify int64",
+			enableInt64: false,
+			expected:    `{"data":[{"my_struct":[{"score":"9007199254740993"},{"score":"-9007199254740993"}]}]}`,
+			expectedRaw: []string{`"score":"9007199254740993"`, `"score":"-9007199254740993"`},
+		},
+		{
+			name:        "preserve int64",
+			enableInt64: true,
+			expected:    `{"data":[{"my_struct":[{"score":9007199254740993},{"score":-9007199254740993}]}]}`,
+			expectedRaw: []string{`"score":9007199254740993`, `"score":-9007199254740993`},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			rows, err := buildQueryResp(0, nil, []*schemapb.FieldData{newFieldData()}, nil, nil, testCase.enableInt64, schema)
+			require.NoError(t, err)
+			payload, err := json.Marshal(gin.H{"data": rows})
+			require.NoError(t, err)
+			assert.JSONEq(t, testCase.expected, string(payload))
+			for _, raw := range testCase.expectedRaw {
+				assert.Contains(t, string(payload), raw)
+			}
+		})
+	}
 }
 
 func TestBuildQueryRespDynamicFieldLargeIntPrecision(t *testing.T) {
@@ -3524,6 +4452,13 @@ func TestBuildSearchAggregationResp(t *testing.T) {
 	_, err = buildSearchAggregationResp(&schemapb.SearchResultData{NumQueries: 1, AggTopks: []int64{2}, AggBuckets: results.GetAggBuckets()}, true, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "does not match bucket count")
+
+	// The reduce contract detail above stays in the log; the caller gets the stage
+	// so a bad aggregation response is still distinguishable when reported.
+	msg := resultErrMessage(err)
+	require.Contains(t, msg, "search aggregation result")
+	require.NotContains(t, msg, "agg_topks")
+	require.NotContains(t, msg, "bucket count")
 }
 
 func TestGenFunctionSchem(t *testing.T) {
@@ -4081,13 +5016,13 @@ func TestBuildStructArrayFieldDataRoundTrip(t *testing.T) {
 
 	accessor, err := newStructArrayRowAccessor(fd, buildStructArrayTestSchema())
 	require.NoError(t, err)
-	extracted0, err := accessor.row(0)
+	extracted0, err := accessor.row(0, true)
 	require.NoError(t, err)
 	require.Len(t, extracted0, 2)
 	assert.EqualValues(t, int32(1), extracted0[0]["sub_int"])
 	assert.EqualValues(t, []float32{0.1, 0.2, 0.3, 0.4}, extracted0[0]["sub_vec"])
 
-	extracted1, err := accessor.row(1)
+	extracted1, err := accessor.row(1, true)
 	require.NoError(t, err)
 	require.Len(t, extracted1, 1)
 	assert.EqualValues(t, int32(3), extracted1[0]["sub_int"])
@@ -4806,7 +5741,7 @@ func TestExtractStructArrayRowErrorPaths(t *testing.T) {
 		},
 	}, buildStructArrayTestSchema())
 	require.NoError(t, err)
-	empty, err := accessor.row(0)
+	empty, err := accessor.row(0, true)
 	require.NoError(t, err)
 	assert.Empty(t, empty)
 
@@ -4818,7 +5753,7 @@ func TestExtractStructArrayRowErrorPaths(t *testing.T) {
 
 	accessor, err = newStructArrayRowAccessor(fd, schema)
 	require.NoError(t, err)
-	_, err = accessor.row(2)
+	_, err = accessor.row(2, true)
 	assert.Error(t, err)
 
 	mismatch := &schemapb.FieldData{
@@ -4854,7 +5789,7 @@ func TestExtractStructArrayRowErrorPaths(t *testing.T) {
 	}
 	accessor, err = newStructArrayRowAccessor(mismatch, schema)
 	require.NoError(t, err)
-	_, err = accessor.row(0)
+	_, err = accessor.row(0, true)
 	assert.Error(t, err)
 
 	missingDimSchema := &schemapb.CollectionSchema{
@@ -4862,7 +5797,7 @@ func TestExtractStructArrayRowErrorPaths(t *testing.T) {
 	}
 	accessor, err = newStructArrayRowAccessor(mismatch, missingDimSchema)
 	require.NoError(t, err)
-	_, err = accessor.row(0)
+	_, err = accessor.row(0, true)
 	assert.Error(t, err)
 
 	unsupported := &schemapb.FieldData{
@@ -4887,7 +5822,7 @@ func TestExtractStructArrayRowErrorPaths(t *testing.T) {
 	}
 	accessor, err = newStructArrayRowAccessor(unsupported, schema)
 	require.NoError(t, err)
-	_, err = accessor.row(0)
+	_, err = accessor.row(0, true)
 	assert.Error(t, err)
 }
 
@@ -4904,9 +5839,9 @@ func TestStructArrayHelperValueConversions(t *testing.T) {
 		{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"five"}}}},
 	}
 	for _, scalar := range scalars {
-		assert.Len(t, scalarArrayToInterfaces(scalar), 1)
+		assert.Len(t, scalarArrayToInterfaces(scalar, true), 1)
 	}
-	assert.Nil(t, scalarArrayToInterfaces(&schemapb.ScalarField{}))
+	assert.Nil(t, scalarArrayToInterfaces(&schemapb.ScalarField{}, true))
 
 	vectorTests := []struct {
 		name        string
@@ -5581,11 +6516,65 @@ func TestCheckAndSetDataJSONFieldUnwrapsEncodedDocument(t *testing.T) {
 		{"plain text stays quoted", `"hello"`, `"hello"`},
 	}
 
+	// While the field reads back as the text of its document, that text is the
+	// field's wire form and decoding it is how a caller sends a document.
+	params := paramtable.Get()
+	key := params.HTTPCfg.NativeJSONResponse.Key
+	params.Save(key, "false")
+	defer params.Reset(key)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			stored := insertOneJSONValue(t, tt.value)
 			assert.Equal(t, tt.expected, string(stored))
 			assert.True(t, json.Valid(stored))
+		})
+	}
+}
+
+// The response returns a JSON field as the document it holds, so every document
+// it can return has to be sendable back. A document that is itself a string used
+// to fail: it came back as the string it is, and the insert path read that
+// string as the document's text and stored what it spelled -- a number for
+// "123", a boolean for "true", an object for "{\"a\":1}".
+func TestJSONFieldDocumentRoundTrips(t *testing.T) {
+	require.True(t, paramtable.Get().HTTPCfg.NativeJSONResponse.GetAsBool(),
+		"the round trip below is what returning documents natively requires")
+
+	for _, document := range []string{
+		`{"a":1}`,
+		`[1,2]`,
+		`"123"`,
+		`"true"`,
+		`"null"`,
+		`"hello"`,
+		`"{\"a\": 1}"`,
+		`123`,
+		`true`,
+	} {
+		t.Run(document, func(t *testing.T) {
+			fieldData := &schemapb.FieldData{
+				Type:      schemapb.DataType_JSON,
+				FieldName: "meta",
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_JsonData{
+							JsonData: &schemapb.JSONArray{Data: [][]byte{[]byte(document)}},
+						},
+					},
+				},
+			}
+			rows, err := buildQueryResp(int64(0), []string{"meta"}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+			require.NoError(t, err)
+
+			// What the caller receives, rendered by the encoder that serves it.
+			payload, err := json.Marshal(rows[0]["meta"])
+			require.NoError(t, err)
+			assert.JSONEq(t, document, string(payload))
+
+			// ...and sent straight back.
+			stored := insertOneJSONValue(t, string(payload))
+			assert.Equal(t, document, string(stored))
 		})
 	}
 }
@@ -6273,11 +7262,16 @@ func TestCheckAndSetDataJSONFieldNullVersusNullDocument(t *testing.T) {
 		assert.Contains(t, err.Error(), "not nullable")
 	})
 
-	// A JSON string whose content is itself a JSON document is unwrapped, which
-	// predates this change, so "null" reaches storage as the null document and
-	// the string "null" cannot be expressed. Recorded rather than changed: the
-	// unwrapping is the documented way to hand over a JSON document as a string.
-	t.Run("a string holding a document is unwrapped", func(t *testing.T) {
+	// While the field reads back as the text of its document, that text is the
+	// field's wire form, so a string holding a document is unwrapped -- and the
+	// string "null" cannot be expressed. Returning the document itself is what
+	// removes that limit, which is why the unwrapping follows the same setting.
+	t.Run("a string holding a document is unwrapped in the legacy shape", func(t *testing.T) {
+		params := paramtable.Get()
+		key := params.HTTPCfg.NativeJSONResponse.Key
+		params.Save(key, "false")
+		defer params.Reset(key)
+
 		assert.Equal(t, `null`, string(insertOneJSONValue(t, `"null"`)))
 		assert.Equal(t, `true`, string(insertOneJSONValue(t, `"true"`)))
 		assert.Equal(t, `123`, string(insertOneJSONValue(t, `"123"`)))
@@ -6650,7 +7644,10 @@ func TestBuildQueryRespNativeJSON(t *testing.T) {
 	paramtable.Init()
 	key := paramtable.Get().HTTPCfg.NativeJSONResponse.Key
 
-	t.Run("off by default: strings", func(t *testing.T) {
+	t.Run("switched off: strings", func(t *testing.T) {
+		paramtable.Get().Save(key, "false")
+		defer paramtable.Get().Reset(key)
+
 		rows, err := buildQueryResp(0, []string{"meta"},
 			[]*schemapb.FieldData{jsonRespFieldData(`{"a":1}`, `{"b":2}`)}, nil, nil, true, nil)
 		require.NoError(t, err)
@@ -6659,10 +7656,7 @@ func TestBuildQueryRespNativeJSON(t *testing.T) {
 		assert.Equal(t, `{"b":2}`, rows[1]["meta"])
 	})
 
-	t.Run("on: documents", func(t *testing.T) {
-		paramtable.Get().Save(key, "true")
-		defer paramtable.Get().Reset(key)
-
+	t.Run("on by default: documents", func(t *testing.T) {
 		rows, err := buildQueryResp(0, []string{"meta"},
 			[]*schemapb.FieldData{jsonRespFieldData(`{"a":1}`, `{"b":2}`)}, nil, nil, true, nil)
 		require.NoError(t, err)

--- a/pkg/util/paramtable/http_param.go
+++ b/pkg/util/paramtable/http_param.go
@@ -21,6 +21,7 @@ type httpConfig struct {
 	DebugMode             ParamItem `refreshable:"false"`
 	Port                  ParamItem `refreshable:"false"`
 	AcceptTypeAllowInt64  ParamItem `refreshable:"true"`
+	LegacyArrayResponse   ParamItem `refreshable:"true"`
 	EnablePprof           ParamItem `refreshable:"false"`
 	RequestTimeoutMs      ParamItem `refreshable:"true"`
 	ReadHeaderTimeout     ParamItem `refreshable:"false"`
@@ -71,6 +72,19 @@ func (p *httpConfig) init(base *BaseTable) {
 		Export:       true,
 	}
 	p.AcceptTypeAllowInt64.Init(base.mgr)
+
+	p.LegacyArrayResponse = ParamItem{
+		Key:          "proxy.http.legacyArrayResponse",
+		DefaultValue: "false",
+		Version:      "3.0.0",
+		Doc: `high-level restful api, whether to return Array fields wrapped in the raw protobuf ScalarField shape
+({"tags":{"Data":{"StringData":{"data":["a","b"]}}}}) instead of a native JSON array ({"tags":["a","b"]}).
+Only enable this to keep clients written against the old, incorrect shape working while they migrate;
+it will be removed in a future release.`,
+		PanicIfEmpty: false,
+		Export:       true,
+	}
+	p.LegacyArrayResponse.Init(base.mgr)
 
 	p.EnablePprof = ParamItem{
 		Key:          "proxy.http.enablePprof",

--- a/pkg/util/paramtable/http_param.go
+++ b/pkg/util/paramtable/http_param.go
@@ -24,6 +24,7 @@ type httpConfig struct {
 	CompatibilityMode     ParamItem `refreshable:"true"`
 	MaxExprParamsDepth    ParamItem `refreshable:"true"`
 	NativeJSONResponse    ParamItem `refreshable:"true"`
+	LegacyArrayResponse   ParamItem `refreshable:"true"`
 	EnablePprof           ParamItem `refreshable:"false"`
 	RequestTimeoutMs      ParamItem `refreshable:"true"`
 	ReadHeaderTimeout     ParamItem `refreshable:"false"`
@@ -78,7 +79,7 @@ func (p *httpConfig) init(base *BaseTable) {
 	p.CompatibilityMode = ParamItem{
 		Key:          "proxy.http.compatibilityMode",
 		DefaultValue: "false",
-		Version:      "2.7.0",
+		Version:      "3.0.1",
 		Doc: `high-level restful api, restore the value handling of releases that predate the REST insert
 validation work. When true the server keeps the previous lenient behavior: a missing or null non-nullable field is
 stored as an empty value, out-of-range integers wrap instead of being rejected, numbers reach VarChar and JSON fields
@@ -91,7 +92,7 @@ for clients that have not been corrected yet: every one of those behaviors silen
 	p.MaxExprParamsDepth = ParamItem{
 		Key:          "proxy.http.maxExprParamsDepth",
 		DefaultValue: "100",
-		Version:      "2.7.0",
+		Version:      "3.0.1",
 		Doc: `high-level restful api, the deepest nesting an expression template parameter may use. Converting a
 parameter walks its arrays and objects recursively, so the depth a caller may send has to be bounded; requests past the
 bound are rejected as invalid rather than served. Values above 1024 are read as 1024, since past that the recursion
@@ -102,17 +103,34 @@ itself is the risk the setting exists to remove; values below 1 are read as 1.`,
 	p.MaxExprParamsDepth.Init(base.mgr)
 	p.NativeJSONResponse = ParamItem{
 		Key:          "proxy.http.nativeJSONResponse",
-		DefaultValue: "false",
-		Version:      "2.7.0",
+		DefaultValue: "true",
+		Version:      "3.0.1",
 		Doc: `high-level restful api, return a JSON field as the document it holds rather than as a string.
-A JSON field reads back as "{\"a\":1}" by default, while the same value in the dynamic field reads back as {"a":1}.
-Turning this on removes that difference. Rows written before the insert path stopped storing non-JSON bytes may not
-hold a document; if any row in a response is such a row, every JSON field in that response falls back to the string
-form and a warning is logged, so a caller always sees one shape or the other and never a mixture.`,
+Turn this off only to keep clients written against the older shape working while they migrate: there a JSON field read
+back as "{\"a\":1}" while the same value in the dynamic field read back as {"a":1}. The insert path follows the same
+switch, so either shape can be sent back unchanged: while the field reads back as text, a JSON string is read as the
+document it spells; once it reads back as the document itself, a string is stored as the string it is. Rows written
+before the insert path stopped storing non-JSON bytes may not hold a document; if any row in a response is such a row,
+every JSON field in that response falls back to the string form and a warning is logged, so a caller always sees one
+shape or the other and never a mixture.`,
 		PanicIfEmpty: false,
 		Export:       true,
 	}
 	p.NativeJSONResponse.Init(base.mgr)
+	p.LegacyArrayResponse = ParamItem{
+		Key:          "proxy.http.legacyArrayResponse",
+		DefaultValue: "false",
+		Version:      "3.0.1",
+		Doc: `high-level restful api, whether to return Array fields wrapped in the raw protobuf ScalarField shape
+({"tags":{"Data":{"StringData":{"data":["a","b"]}}}}) instead of a native JSON array ({"tags":["a","b"]}).
+Only enable this to keep clients written against the old, incorrect shape working while they migrate;
+it will be removed in a future release. It covers the shape of a top-level Array field and nothing else:
+a struct array's sub-fields are unaffected, and so is Accept-Type-Allow-Int64, which renders an Int64 as a
+string wherever one appears, including inside either kind of array.`,
+		PanicIfEmpty: false,
+		Export:       true,
+	}
+	p.LegacyArrayResponse.Init(base.mgr)
 
 	p.EnablePprof = ParamItem{
 		Key:          "proxy.http.enablePprof",


### PR DESCRIPTION
issue: #52048

## What changed

- Unwrap protobuf `ScalarField` rows before serializing REST Array fields.
- Return native JSON arrays for all supported scalar element types.
- Normalize empty arrays to `[]` and preserve nullable rows as `null`.
- Apply `Accept-Type-Allow-Int64` semantics to Int64 array elements.
- Add exact JSON regression coverage for mixed Bool, Int, Int64, Float, Double, and String arrays, field-specific nullable bitmaps, empty arrays, escaped/non-ASCII strings, search scores, custom primary keys, and both Int64 response modes. Raw JSON assertions verify values beyond the JavaScript safe-integer range are emitted with the exact expected digits and quoting.

## Root cause

`buildQueryResp` placed the per-row `*schemapb.ScalarField` directly into the response map. The JSON encoder therefore exposed the protobuf oneof wrapper (`Data.StringData`, `Data.LongData`, and so on) instead of the contained values.

## Validation

```text
go test -tags dynamic,test -gcflags='all=-N -l' -count=1 ./internal/distributed/proxy/httpserver -run 'TestBuildQueryResp|TestScalarFieldToRESTAny|TestArray$'
```

The complex JSON regression test was also run in a temporary worktree with only the old direct-`ScalarField` response assignment restored. Both Int64 response-mode cases failed and showed the leaked protobuf wrappers, confirming the test catches the original defect.

The broader HTTP server package reaches an unrelated pre-existing `TestSearchV2/search#09` assertion failure that also reproduces on untouched `origin/master` under the same local test environment.