### PR TITLE
fix: reject out-of-range narrow integers in REST

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -432,6 +432,12 @@ proxy:
     debug_mode: false # Whether to enable http server debug mode
     port:  # high-level restful api
     acceptTypeAllowInt64: true # high-level restful api, whether http client can deal with int64
+    # high-level restful api, restore the value handling of releases that predate the REST insert validation work.
+    # When true the server keeps the previous lenient behaviour: a missing or null non-nullable field is stored as an
+    # empty value, out-of-range integers wrap instead of being rejected, numbers reach VarChar and JSON fields through
+    # their float64 rendering, and integers too large for the JSON engine become 0. This is a temporary escape hatch
+    # for clients that have not been corrected yet: every one of those behaviours silently changes what is stored.
+    compatibilityMode: false
     enablePprof: true # Whether to enable pprof middleware on the metrics port
     readHeaderTimeout: 5s # HTTP server timeout for reading request headers
     readTimeout: 0s # HTTP server timeout for reading the entire request, including the body. 0 disables this timeout

--- a/internal/distributed/proxy/httpserver/handler_v1_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v1_test.go
@@ -869,6 +869,35 @@ func TestInsertForDataType(t *testing.T) {
 	}
 }
 
+func TestNarrowIntegerOverflowV1(t *testing.T) {
+	paramtable.Init()
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         generateNarrowIntegerCollectionSchema(schemapb.DataType_Int8),
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Twice()
+	testEngine := initHTTPServer(mp, true)
+	body := []byte(`{"collectionName":"book","data":[{"book_id":1,"book_intro":[0.1,0.2],"word_count":2,"narrow_int":128}]}`)
+
+	for _, path := range []string{VectorInsertPath, VectorUpsertPath} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, versional(path), bytes.NewReader(body))
+			req.SetBasicAuth(util.UserRoot, getDefaultRootPassword())
+			w := httptest.NewRecorder()
+			testEngine.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			returnBody := &ReturnErrMsg{}
+			assert.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody))
+			assert.Equal(t, merr.Code(merr.ErrInvalidInsertData), returnBody.Code)
+			assert.Contains(t, returnBody.Message, "actual=128")
+			assert.Contains(t, returnBody.Message, "field narrow_int value must be an integer in range [-128, 127]")
+		})
+	}
+}
+
 func TestReturnInt64(t *testing.T) {
 	paramtable.Init()
 	paramtable.Get().Save(proxy.Params.HTTPCfg.AcceptTypeAllowInt64.Key, "false")

--- a/internal/distributed/proxy/httpserver/handler_v1_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v1_test.go
@@ -898,6 +898,70 @@ func TestNarrowIntegerOverflowV1(t *testing.T) {
 	}
 }
 
+func TestStructArrayIntegerExponentV1(t *testing.T) {
+	paramtable.Init()
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         buildStructArrayTestSchema(),
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Twice()
+	testEngine := initHTTPServer(mp, true)
+	body := []byte(`{"collectionName":"book","data":[{"id":1,"vec":[0.1,0.2,0.3,0.4],"my_struct":[{"sub_int":1e-999999,"sub_vec":[1.1,1.2,1.3,1.4]}]}]}`)
+
+	for _, path := range []string{VectorInsertPath, VectorUpsertPath} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, versional(path), bytes.NewReader(body))
+			req.SetBasicAuth(util.UserRoot, getDefaultRootPassword())
+			w := httptest.NewRecorder()
+			testEngine.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			returnBody := &ReturnErrMsg{}
+			assert.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody))
+			assert.Equal(t, merr.Code(merr.ErrInvalidInsertData), returnBody.Code)
+			assert.Contains(t, returnBody.Message, "sub-field sub_int")
+			assert.Contains(t, returnBody.Message, "value=1e-999999")
+		})
+	}
+}
+
+func TestStructArrayExactInt64V1(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+	schema := buildStructArrayTestSchema()
+	schema.GetStructArrayFields()[0].GetFields()[0].ElementType = schemapb.DataType_Int64
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         schema,
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Once()
+	mp.EXPECT().Insert(mock.Anything, mock.MatchedBy(func(req *milvuspb.InsertRequest) bool {
+		return hasStructArrayInt64Value(req.GetFieldsData(), "my_struct", "sub_int", 9007199254740993)
+	})).Return(&milvuspb.MutationResult{
+		Status:    &StatusSuccess,
+		InsertCnt: 1,
+		IDs: &schemapb.IDs{IdField: &schemapb.IDs_IntId{
+			IntId: &schemapb.LongArray{Data: []int64{1}},
+		}},
+	}, nil).Once()
+	testEngine := initHTTPServer(mp, true)
+	body := []byte(`{"collectionName":"book","data":[{"id":1,"vec":[0.1,0.2,0.3,0.4],"my_struct":[{"sub_int":9007199254740993.0,"sub_vec":[1.1,1.2,1.3,1.4]}]}]}`)
+	req := httptest.NewRequest(http.MethodPost, versional(VectorInsertPath), bytes.NewReader(body))
+	req.SetBasicAuth(util.UserRoot, getDefaultRootPassword())
+	w := httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	returnBody := &ReturnErrMsg{}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody))
+	assert.Equal(t, http.StatusOK, returnBody.Code)
+}
+
 func TestReturnInt64(t *testing.T) {
 	paramtable.Init()
 	paramtable.Get().Save(proxy.Params.HTTPCfg.AcceptTypeAllowInt64.Key, "false")

--- a/internal/distributed/proxy/httpserver/handler_v1_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v1_test.go
@@ -959,7 +959,7 @@ func TestStructArrayExactInt64V1(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	returnBody := &ReturnErrMsg{}
 	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody))
-	assert.Equal(t, http.StatusOK, returnBody.Code)
+	assert.Equal(t, int32(http.StatusOK), returnBody.Code)
 }
 
 func TestReturnInt64(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -3918,6 +3918,68 @@ func TestNarrowIntegerOverflowV2(t *testing.T) {
 	}
 }
 
+func TestStructArrayIntegerExponentV2(t *testing.T) {
+	paramtable.Init()
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         buildStructArrayTestSchema(),
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Twice()
+	testEngine := initHTTPServerV2(mp, false)
+	body := []byte(`{"collectionName":"book","data":[{"id":1,"vec":[0.1,0.2,0.3,0.4],"my_struct":[{"sub_int":1e-999999,"sub_vec":[1.1,1.2,1.3,1.4]}]}]}`)
+
+	for _, action := range []string{InsertAction, UpsertAction} {
+		t.Run(action, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, versionalV2(EntityCategory, action), bytes.NewReader(body))
+			w := httptest.NewRecorder()
+			testEngine.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			returnBody := &ReturnErrMsg{}
+			assert.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody))
+			assert.Equal(t, merr.Code(merr.ErrInvalidInsertData), returnBody.Code)
+			assert.Contains(t, returnBody.Message, "sub-field sub_int")
+			assert.Contains(t, returnBody.Message, "value=1e-999999")
+		})
+	}
+}
+
+func TestStructArrayExactInt64V2(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+	schema := buildStructArrayTestSchema()
+	schema.GetStructArrayFields()[0].GetFields()[0].ElementType = schemapb.DataType_Int64
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         schema,
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Once()
+	mp.EXPECT().Insert(mock.Anything, mock.MatchedBy(func(req *milvuspb.InsertRequest) bool {
+		return hasStructArrayInt64Value(req.GetFieldsData(), "my_struct", "sub_int", 9007199254740993)
+	})).Return(&milvuspb.MutationResult{
+		Status:    &StatusSuccess,
+		InsertCnt: 1,
+		IDs: &schemapb.IDs{IdField: &schemapb.IDs_IntId{
+			IntId: &schemapb.LongArray{Data: []int64{1}},
+		}},
+	}, nil).Once()
+	testEngine := initHTTPServerV2(mp, false)
+	body := []byte(`{"collectionName":"book","data":[{"id":1,"vec":[0.1,0.2,0.3,0.4],"my_struct":[{"sub_int":9007199254740993.0,"sub_vec":[1.1,1.2,1.3,1.4]}]}]}`)
+	req := httptest.NewRequest(http.MethodPost, versionalV2(EntityCategory, InsertAction), bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	returnBody := &ReturnErrMsg{}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody))
+	assert.Equal(t, merr.Code(nil), returnBody.Code)
+}
+
 func generateCollectionSchemaWithVectorFields() *schemapb.CollectionSchema {
 	collSchema := generateCollectionSchema(schemapb.DataType_Int64, false, true)
 	binaryVectorField := generateVectorFieldSchema(schemapb.DataType_BinaryVector)

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -3890,6 +3890,34 @@ func TestAllowInt64(t *testing.T) {
 	validateTestCases(t, testEngine, queryTestCases, true)
 }
 
+func TestNarrowIntegerOverflowV2(t *testing.T) {
+	paramtable.Init()
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         generateNarrowIntegerCollectionSchema(schemapb.DataType_Int8),
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Twice()
+	testEngine := initHTTPServerV2(mp, false)
+	body := []byte(`{"collectionName":"book","data":[{"book_id":1,"book_intro":[0.1,0.2],"word_count":2,"narrow_int":128}]}`)
+
+	for _, action := range []string{InsertAction, UpsertAction} {
+		t.Run(action, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, versionalV2(EntityCategory, action), bytes.NewReader(body))
+			w := httptest.NewRecorder()
+			testEngine.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			returnBody := &ReturnErrMsg{}
+			assert.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody))
+			assert.Equal(t, merr.Code(merr.ErrInvalidInsertData), returnBody.Code)
+			assert.Contains(t, returnBody.Message, "actual=128")
+			assert.Contains(t, returnBody.Message, "field narrow_int value must be an integer in range [-128, 127]")
+		})
+	}
+}
+
 func generateCollectionSchemaWithVectorFields() *schemapb.CollectionSchema {
 	collSchema := generateCollectionSchema(schemapb.DataType_Int64, false, true)
 	binaryVectorField := generateVectorFieldSchema(schemapb.DataType_BinaryVector)

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -643,9 +643,29 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 					}
 					reallyData[fieldName] = int32(result)
 				case schemapb.DataType_Int64:
-					result, err := json.Number(dataString).Int64()
-					if err != nil {
-						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error())
+					// Only the JSON-number form goes through the raw literal.
+					// gjson's String() renders a number through float64 as soon
+					// as the raw text is not all digits, so 9007199254740993.0
+					// reached json.Number as 9007199254740992 and was accepted.
+					// Quoted integers keep their base-10 parsing: this path also
+					// carries Int64 primary keys, and strconv's base detection
+					// would silently reinterpret a zero-padded id such as "010".
+					var result int64
+					if fieldValue.Type == gjson.Number {
+						parsed, ok := parseJSONInteger(fieldValue.Raw, 64)
+						if !ok {
+							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(
+								schemapb.DataType_name[int32(fieldType)], fieldValue.Raw,
+								fmt.Sprintf("field %s value must be an integer in range [%d, %d]",
+									fieldName, int64(math.MinInt64), int64(math.MaxInt64)))
+						}
+						result = parsed
+					} else {
+						parsed, err := json.Number(dataString).Int64()
+						if err != nil {
+							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error())
+						}
+						result = parsed
 					}
 					reallyData[fieldName] = result
 				case schemapb.DataType_Array:

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math"
+	"math/big"
 	"net/http"
 	"reflect"
 	"slices"
@@ -935,6 +936,20 @@ func parseStructArrayRow(rawJSON string, structSchema *schemapb.StructArrayField
 	return row, nil
 }
 
+func parseStructSubInteger(raw string, bitSize int) (int64, bool) {
+	value, err := strconv.ParseInt(raw, 10, bitSize)
+	if err == nil {
+		return value, true
+	}
+
+	number, ok := new(big.Rat).SetString(raw)
+	if !ok || !number.IsInt() {
+		return 0, false
+	}
+	value, err = strconv.ParseInt(number.Num().String(), 10, bitSize)
+	return value, err == nil
+}
+
 func buildStructSubArrayScalar(sub *schemapb.FieldSchema, vals []gjson.Result) (*schemapb.ScalarField, error) {
 	switch sub.GetElementType() {
 	case schemapb.DataType_Bool:
@@ -949,12 +964,27 @@ func buildStructSubArrayScalar(sub *schemapb.FieldSchema, vals []gjson.Result) (
 			Data: &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{Data: arr}},
 		}, nil
 	case schemapb.DataType_Int8, schemapb.DataType_Int16, schemapb.DataType_Int32:
+		bitSize := 32
+		minValue, maxValue := int64(math.MinInt32), int64(math.MaxInt32)
+		switch sub.GetElementType() {
+		case schemapb.DataType_Int8:
+			bitSize = 8
+			minValue, maxValue = math.MinInt8, math.MaxInt8
+		case schemapb.DataType_Int16:
+			bitSize = 16
+			minValue, maxValue = math.MinInt16, math.MaxInt16
+		}
 		arr := make([]int32, 0, len(vals))
 		for _, v := range vals {
 			if v.Type != gjson.Number {
 				return nil, wrapStructSubParseError(sub, v, "expect integer")
 			}
-			arr = append(arr, int32(v.Int()))
+			value, ok := parseStructSubInteger(v.Raw, bitSize)
+			if !ok {
+				return nil, wrapStructSubParseError(sub, v,
+					fmt.Sprintf("expect integer in range [%d, %d]", minValue, maxValue))
+			}
+			arr = append(arr, int32(value))
 		}
 		return &schemapb.ScalarField{
 			Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: arr}},
@@ -965,7 +995,12 @@ func buildStructSubArrayScalar(sub *schemapb.FieldSchema, vals []gjson.Result) (
 			if v.Type != gjson.Number {
 				return nil, wrapStructSubParseError(sub, v, "expect integer")
 			}
-			arr = append(arr, v.Int())
+			value, ok := parseStructSubInteger(v.Raw, 64)
+			if !ok {
+				return nil, wrapStructSubParseError(sub, v,
+					fmt.Sprintf("expect integer in range [%d, %d]", int64(math.MinInt64), int64(math.MaxInt64)))
+			}
+			arr = append(arr, value)
 		}
 		return &schemapb.ScalarField{
 			Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: arr}},

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -21,7 +21,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math"
-	"math/big"
 	"net/http"
 	"reflect"
 	"slices"
@@ -936,18 +935,160 @@ func parseStructArrayRow(rawJSON string, structSchema *schemapb.StructArrayField
 	return row, nil
 }
 
-func parseStructSubInteger(raw string, bitSize int) (int64, bool) {
-	value, err := strconv.ParseInt(raw, 10, bitSize)
-	if err == nil {
-		return value, true
-	}
+func isJSONDigit(ch byte) bool {
+	return ch >= '0' && ch <= '9'
+}
 
-	number, ok := new(big.Rat).SetString(raw)
-	if !ok || !number.IsInt() {
+// parseStructSubInteger parses an exact integer from a JSON number literal.
+// Integer-valued decimal and exponent forms are accepted without converting
+// through float64 or computing attacker-controlled arbitrary-precision powers.
+func parseStructSubInteger(raw string, bitSize int) (int64, bool) {
+	switch bitSize {
+	case 8, 16, 32, 64:
+	default:
 		return 0, false
 	}
-	value, err = strconv.ParseInt(number.Num().String(), 10, bitSize)
-	return value, err == nil
+	if raw == "" {
+		return 0, false
+	}
+
+	i := 0
+	negative := false
+	if raw[i] == '-' {
+		negative = true
+		i++
+		if i == len(raw) {
+			return 0, false
+		}
+	}
+
+	// An int64 has at most 19 decimal digits. Keep only the prefix that can
+	// possibly survive decimal scaling; the remaining input is still scanned
+	// to validate syntax and count significant/trailing digits.
+	var significantPrefix [19]byte
+	prefixLen := 0
+	significantDigits := 0
+	trailingZeros := 0
+	coefficientIsZero := true
+	recordDigit := func(ch byte) {
+		if coefficientIsZero {
+			if ch == '0' {
+				return
+			}
+			coefficientIsZero = false
+		}
+		significantDigits++
+		if prefixLen < len(significantPrefix) {
+			significantPrefix[prefixLen] = ch
+			prefixLen++
+		}
+		if ch == '0' {
+			trailingZeros++
+		} else {
+			trailingZeros = 0
+		}
+	}
+
+	// JSON integer part: 0 or a non-zero digit followed by digits.
+	if raw[i] == '0' {
+		recordDigit(raw[i])
+		i++
+		if i < len(raw) && isJSONDigit(raw[i]) {
+			return 0, false
+		}
+	} else if raw[i] >= '1' && raw[i] <= '9' {
+		for i < len(raw) && isJSONDigit(raw[i]) {
+			recordDigit(raw[i])
+			i++
+		}
+	} else {
+		return 0, false
+	}
+
+	fractionDigits := 0
+	if i < len(raw) && raw[i] == '.' {
+		i++
+		fractionStart := i
+		for i < len(raw) && isJSONDigit(raw[i]) {
+			recordDigit(raw[i])
+			fractionDigits++
+			i++
+		}
+		if i == fractionStart {
+			return 0, false
+		}
+	}
+
+	exponentAbs := 0
+	exponentNegative := false
+	if i < len(raw) && (raw[i] == 'e' || raw[i] == 'E') {
+		i++
+		if i < len(raw) && (raw[i] == '+' || raw[i] == '-') {
+			exponentNegative = raw[i] == '-'
+			i++
+		}
+		exponentStart := i
+		// Values beyond this limit cannot bring a non-zero coefficient into
+		// the int64 range. Saturating avoids integer overflow while preserving
+		// work proportional to the input length.
+		exponentLimit := len(raw) + 20
+		for i < len(raw) && isJSONDigit(raw[i]) {
+			digit := int(raw[i] - '0')
+			if exponentAbs < exponentLimit {
+				if exponentAbs > (exponentLimit-digit)/10 {
+					exponentAbs = exponentLimit
+				} else {
+					exponentAbs = exponentAbs*10 + digit
+				}
+			}
+			i++
+		}
+		if i == exponentStart {
+			return 0, false
+		}
+	}
+	if i != len(raw) {
+		return 0, false
+	}
+	if coefficientIsZero {
+		return 0, true
+	}
+
+	trimDigits, appendZeros := 0, 0
+	if exponentNegative {
+		trimDigits = exponentAbs + fractionDigits
+	} else if exponentAbs >= fractionDigits {
+		appendZeros = exponentAbs - fractionDigits
+	} else {
+		trimDigits = fractionDigits - exponentAbs
+	}
+	if trimDigits > trailingZeros {
+		return 0, false
+	}
+
+	keptDigits := significantDigits - trimDigits
+	if keptDigits <= 0 || keptDigits > prefixLen || appendZeros > len(significantPrefix)-keptDigits {
+		return 0, false
+	}
+
+	var integerLiteral [20]byte
+	integerLen := 0
+	if negative {
+		integerLiteral[integerLen] = '-'
+		integerLen++
+	}
+	copy(integerLiteral[integerLen:], significantPrefix[:keptDigits])
+	integerLen += keptDigits
+	for idx := 0; idx < appendZeros; idx++ {
+		integerLiteral[integerLen] = '0'
+		integerLen++
+	}
+
+	value, err := strconv.ParseInt(string(integerLiteral[:integerLen]), 10, bitSize)
+	if err != nil {
+		return 0, false
+	}
+	return value, true
 }
 
 func buildStructSubArrayScalar(sub *schemapb.FieldSchema, vals []gjson.Result) (*schemapb.ScalarField, error) {

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -619,23 +619,29 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 					}
 					reallyData[fieldName] = result
 				case schemapb.DataType_Int8:
-					result, err := cast.ToInt8E(dataString)
+					result, err := strconv.ParseInt(dataString, 0, 8)
 					if err != nil {
-						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error())
+						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(
+							schemapb.DataType_name[int32(fieldType)], dataString,
+							fmt.Sprintf("field %s value must be an integer in range [%d, %d]", fieldName, math.MinInt8, math.MaxInt8))
 					}
-					reallyData[fieldName] = result
+					reallyData[fieldName] = int8(result)
 				case schemapb.DataType_Int16:
-					result, err := cast.ToInt16E(dataString)
+					result, err := strconv.ParseInt(dataString, 0, 16)
 					if err != nil {
-						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error())
+						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(
+							schemapb.DataType_name[int32(fieldType)], dataString,
+							fmt.Sprintf("field %s value must be an integer in range [%d, %d]", fieldName, math.MinInt16, math.MaxInt16))
 					}
-					reallyData[fieldName] = result
+					reallyData[fieldName] = int16(result)
 				case schemapb.DataType_Int32:
-					result, err := cast.ToInt32E(dataString)
+					result, err := strconv.ParseInt(dataString, 0, 32)
 					if err != nil {
-						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error())
+						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(
+							schemapb.DataType_name[int32(fieldType)], dataString,
+							fmt.Sprintf("field %s value must be an integer in range [%d, %d]", fieldName, math.MinInt32, math.MaxInt32))
 					}
-					reallyData[fieldName] = result
+					reallyData[fieldName] = int32(result)
 				case schemapb.DataType_Int64:
 					result, err := json.Number(dataString).Int64()
 					if err != nil {

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -619,26 +619,26 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 					}
 					reallyData[fieldName] = result
 				case schemapb.DataType_Int8:
-					result, err := strconv.ParseInt(dataString, 0, 8)
-					if err != nil {
+					result, actual, ok := parseRESTInteger(fieldValue, 8)
+					if !ok {
 						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(
-							schemapb.DataType_name[int32(fieldType)], dataString,
+							schemapb.DataType_name[int32(fieldType)], actual,
 							fmt.Sprintf("field %s value must be an integer in range [%d, %d]", fieldName, math.MinInt8, math.MaxInt8))
 					}
 					reallyData[fieldName] = int8(result)
 				case schemapb.DataType_Int16:
-					result, err := strconv.ParseInt(dataString, 0, 16)
-					if err != nil {
+					result, actual, ok := parseRESTInteger(fieldValue, 16)
+					if !ok {
 						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(
-							schemapb.DataType_name[int32(fieldType)], dataString,
+							schemapb.DataType_name[int32(fieldType)], actual,
 							fmt.Sprintf("field %s value must be an integer in range [%d, %d]", fieldName, math.MinInt16, math.MaxInt16))
 					}
 					reallyData[fieldName] = int16(result)
 				case schemapb.DataType_Int32:
-					result, err := strconv.ParseInt(dataString, 0, 32)
-					if err != nil {
+					result, actual, ok := parseRESTInteger(fieldValue, 32)
+					if !ok {
 						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(
-							schemapb.DataType_name[int32(fieldType)], dataString,
+							schemapb.DataType_name[int32(fieldType)], actual,
 							fmt.Sprintf("field %s value must be an integer in range [%d, %d]", fieldName, math.MinInt32, math.MaxInt32))
 					}
 					reallyData[fieldName] = int32(result)
@@ -939,10 +939,10 @@ func isJSONDigit(ch byte) bool {
 	return ch >= '0' && ch <= '9'
 }
 
-// parseStructSubInteger parses an exact integer from a JSON number literal.
+// parseJSONInteger parses an exact integer from a JSON number literal.
 // Integer-valued decimal and exponent forms are accepted without converting
 // through float64 or computing attacker-controlled arbitrary-precision powers.
-func parseStructSubInteger(raw string, bitSize int) (int64, bool) {
+func parseJSONInteger(raw string, bitSize int) (int64, bool) {
 	switch bitSize {
 	case 8, 16, 32, 64:
 	default:
@@ -1091,6 +1091,21 @@ func parseStructSubInteger(raw string, bitSize int) (int64, bool) {
 	return value, true
 }
 
+// parseRESTInteger preserves the raw token for JSON numbers so validation runs
+// before gjson can normalize decimal or exponent forms through float64. Quoted
+// integer strings retain the existing base-prefix behavior.
+func parseRESTInteger(value gjson.Result, bitSize int) (int64, string, bool) {
+	actual := value.String()
+	if value.Type == gjson.Number {
+		actual = value.Raw
+		parsed, ok := parseJSONInteger(actual, bitSize)
+		return parsed, actual, ok
+	}
+
+	parsed, err := strconv.ParseInt(actual, 0, bitSize)
+	return parsed, actual, err == nil
+}
+
 func buildStructSubArrayScalar(sub *schemapb.FieldSchema, vals []gjson.Result) (*schemapb.ScalarField, error) {
 	switch sub.GetElementType() {
 	case schemapb.DataType_Bool:
@@ -1120,7 +1135,7 @@ func buildStructSubArrayScalar(sub *schemapb.FieldSchema, vals []gjson.Result) (
 			if v.Type != gjson.Number {
 				return nil, wrapStructSubParseError(sub, v, "expect integer")
 			}
-			value, ok := parseStructSubInteger(v.Raw, bitSize)
+			value, ok := parseJSONInteger(v.Raw, bitSize)
 			if !ok {
 				return nil, wrapStructSubParseError(sub, v,
 					fmt.Sprintf("expect integer in range [%d, %d]", minValue, maxValue))
@@ -1136,7 +1151,7 @@ func buildStructSubArrayScalar(sub *schemapb.FieldSchema, vals []gjson.Result) (
 			if v.Type != gjson.Number {
 				return nil, wrapStructSubParseError(sub, v, "expect integer")
 			}
-			value, ok := parseStructSubInteger(v.Raw, 64)
+			value, ok := parseJSONInteger(v.Raw, 64)
 			if !ok {
 				return nil, wrapStructSubParseError(sub, v,
 					fmt.Sprintf("expect integer in range [%d, %d]", int64(math.MinInt64), int64(math.MaxInt64)))

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -1112,8 +1112,13 @@ func parseJSONInteger(raw string, bitSize int) (int64, bool) {
 }
 
 // parseRESTInteger preserves the raw token for JSON numbers so validation runs
-// before gjson can normalize decimal or exponent forms through float64. Quoted
-// integer strings retain the existing base-prefix behavior.
+// before gjson can normalize decimal or exponent forms through float64.
+//
+// Quoted integers are read as base 10. cast used strconv's base detection, so
+// a zero-padded id such as "010" became 8 in an Int8/Int16/Int32 field while
+// the Int64 field read the same string as 10 through json.Number. Decimal is
+// the only reading a REST caller can have meant, and it makes the integer
+// types agree.
 func parseRESTInteger(value gjson.Result, bitSize int) (int64, string, bool) {
 	actual := value.String()
 	if value.Type == gjson.Number {
@@ -1122,7 +1127,7 @@ func parseRESTInteger(value gjson.Result, bitSize int) (int64, string, bool) {
 		return parsed, actual, ok
 	}
 
-	parsed, err := strconv.ParseInt(actual, 0, bitSize)
+	parsed, err := strconv.ParseInt(actual, 10, bitSize)
 	return parsed, actual, err == nil
 }
 

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -466,6 +466,9 @@ func printIndexes(indexes []*milvuspb.IndexDescription) []gin.H {
 func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partialUpdate bool) ([]map[string]interface{}, map[string][]bool, error) {
 	var reallyDataArray []map[string]interface{}
 	validDataMap := make(map[string][]bool)
+	// Escape hatch for clients that relied on the previous value handling.
+	// Read once per request rather than per field.
+	compatibilityMode := paramtable.Get().HTTPCfg.CompatibilityMode.GetAsBool()
 	dataResult := gjson.GetBytes(body, HTTPRequestData)
 	dataResultArray := dataResult.Array()
 	if len(dataResultArray) == 0 {
@@ -619,6 +622,14 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 					}
 					reallyData[fieldName] = result
 				case schemapb.DataType_Int8:
+					if compatibilityMode {
+						legacy, err := cast.ToInt8E(dataString)
+						if err != nil {
+							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error())
+						}
+						reallyData[fieldName] = legacy
+						break
+					}
 					result, actual, ok := parseRESTInteger(fieldValue, 8)
 					if !ok {
 						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(
@@ -627,6 +638,14 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 					}
 					reallyData[fieldName] = int8(result)
 				case schemapb.DataType_Int16:
+					if compatibilityMode {
+						legacy, err := cast.ToInt16E(dataString)
+						if err != nil {
+							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error())
+						}
+						reallyData[fieldName] = legacy
+						break
+					}
 					result, actual, ok := parseRESTInteger(fieldValue, 16)
 					if !ok {
 						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(
@@ -635,6 +654,14 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 					}
 					reallyData[fieldName] = int16(result)
 				case schemapb.DataType_Int32:
+					if compatibilityMode {
+						legacy, err := cast.ToInt32E(dataString)
+						if err != nil {
+							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error())
+						}
+						reallyData[fieldName] = legacy
+						break
+					}
 					result, actual, ok := parseRESTInteger(fieldValue, 32)
 					if !ok {
 						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(
@@ -651,7 +678,7 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 					// carries Int64 primary keys, and strconv's base detection
 					// would silently reinterpret a zero-padded id such as "010".
 					var result int64
-					if fieldValue.Type == gjson.Number {
+					if fieldValue.Type == gjson.Number && !compatibilityMode {
 						parsed, ok := parseJSONInteger(fieldValue.Raw, 64)
 						if !ok {
 							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -1008,6 +1008,70 @@ func TestAnyToColumns(t *testing.T) {
 }
 
 func TestCheckAndSetData(t *testing.T) {
+	t.Run("integer range validation", func(t *testing.T) {
+		tests := []struct {
+			name          string
+			dataType      schemapb.DataType
+			min           int64
+			max           int64
+			invalidValues []int64
+		}{
+			{
+				name: "int8", dataType: schemapb.DataType_Int8, min: math.MinInt8, max: math.MaxInt8,
+				invalidValues: []int64{-129, 128, 256, 1000, 65535},
+			},
+			{
+				name: "int16", dataType: schemapb.DataType_Int16, min: math.MinInt16, max: math.MaxInt16,
+				invalidValues: []int64{-32769, 32768, 65535, 100000},
+			},
+			{
+				name: "int32", dataType: schemapb.DataType_Int32, min: math.MinInt32, max: math.MaxInt32,
+				invalidValues: []int64{-2147483649, 2147483648, 4294967295},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				const fieldName = "narrow_int"
+				schema := generateCollectionSchema(schemapb.DataType_Int64, false, false)
+				schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
+					FieldID:  common.StartOfUserFieldID + 100,
+					Name:     fieldName,
+					DataType: test.dataType,
+				})
+
+				for _, value := range []int64{test.min, test.max} {
+					body := []byte(fmt.Sprintf(`{"data":[{"book_id":1,"book_intro":[0.1,0.2],"word_count":2,"%s":%d}]}`, fieldName, value))
+					rows, validData, err := checkAndSetData(body, schema, false)
+					require.NoError(t, err)
+					require.Len(t, rows, 1)
+					assert.EqualValues(t, value, rows[0][fieldName])
+
+					fieldsData, err := anyToColumns(rows, validData, schema, true, false)
+					require.NoError(t, err)
+					var narrowFieldData *schemapb.FieldData
+					for _, fieldData := range fieldsData {
+						if fieldData.GetFieldName() == fieldName {
+							narrowFieldData = fieldData
+							break
+						}
+					}
+					require.NotNil(t, narrowFieldData)
+					assert.Equal(t, []int32{int32(value)}, narrowFieldData.GetScalars().GetIntData().GetData())
+				}
+
+				for _, value := range test.invalidValues {
+					body := []byte(fmt.Sprintf(`{"data":[{"book_id":1,"book_intro":[0.1,0.2],"word_count":2,"%s":%d}]}`, fieldName, value))
+					_, _, err := checkAndSetData(body, schema, false)
+					require.Error(t, err)
+					assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+					assert.Contains(t, err.Error(), fieldName)
+					assert.Contains(t, err.Error(), fmt.Sprintf("[%d, %d]", test.min, test.max))
+				}
+			})
+		}
+	})
+
 	t.Run("invalid field name with dynamic field", func(t *testing.T) {
 		body := []byte("{\"data\": {\"id\": 0,\"$meta\": 2,\"book_id\": 1, \"book_intro\": [0.1, 0.2], \"word_count\": 2, \"classified\": false, \"databaseID\": null}}")
 		coll := generateCollectionSchema(schemapb.DataType_Int64, false, true)

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -4395,11 +4395,35 @@ func TestStructArrayScalarSubFieldTypes(t *testing.T) {
 			},
 		},
 		{
+			name:        "int8",
+			elementType: schemapb.DataType_Int8,
+			raw:         `[-128,127,127.0,1e2]`,
+			assertFn: func(t *testing.T, sf *schemapb.ScalarField) {
+				assert.Equal(t, []int32{-128, 127, 127, 100}, sf.GetIntData().GetData())
+			},
+		},
+		{
+			name:        "int16",
+			elementType: schemapb.DataType_Int16,
+			raw:         `[-32768,32767]`,
+			assertFn: func(t *testing.T, sf *schemapb.ScalarField) {
+				assert.Equal(t, []int32{-32768, 32767}, sf.GetIntData().GetData())
+			},
+		},
+		{
+			name:        "int32",
+			elementType: schemapb.DataType_Int32,
+			raw:         `[-2147483648,2147483647]`,
+			assertFn: func(t *testing.T, sf *schemapb.ScalarField) {
+				assert.Equal(t, []int32{math.MinInt32, math.MaxInt32}, sf.GetIntData().GetData())
+			},
+		},
+		{
 			name:        "int64",
 			elementType: schemapb.DataType_Int64,
-			raw:         `[10,20]`,
+			raw:         `[-9223372036854775808,9223372036854775807,9007199254740993.0]`,
 			assertFn: func(t *testing.T, sf *schemapb.ScalarField) {
-				assert.Equal(t, []int64{10, 20}, sf.GetLongData().GetData())
+				assert.Equal(t, []int64{math.MinInt64, math.MaxInt64, 9007199254740993}, sf.GetLongData().GetData())
 			},
 		},
 		{
@@ -4442,6 +4466,40 @@ func TestStructArrayScalarSubFieldTypes(t *testing.T) {
 
 	_, err = buildStructSubArrayScalar(&schemapb.FieldSchema{Name: "bad_bool", ElementType: schemapb.DataType_Bool}, gjson.Parse(`[1]`).Array())
 	assert.Error(t, err)
+}
+
+func TestStructArrayNarrowIntegerSubFieldValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		elementType schemapb.DataType
+		raw         string
+		rangeText   string
+	}{
+		{name: "int8 above max", elementType: schemapb.DataType_Int8, raw: `[128]`, rangeText: "[-128, 127]"},
+		{name: "int8 below min", elementType: schemapb.DataType_Int8, raw: `[-129]`, rangeText: "[-128, 127]"},
+		{name: "int8 int32 wraparound", elementType: schemapb.DataType_Int8, raw: `[4294967296]`, rangeText: "[-128, 127]"},
+		{name: "int8 fraction", elementType: schemapb.DataType_Int8, raw: `[127.5]`, rangeText: "[-128, 127]"},
+		{name: "int16 above max", elementType: schemapb.DataType_Int16, raw: `[32768]`, rangeText: "[-32768, 32767]"},
+		{name: "int16 below min", elementType: schemapb.DataType_Int16, raw: `[-32769]`, rangeText: "[-32768, 32767]"},
+		{name: "int16 int32 wraparound", elementType: schemapb.DataType_Int16, raw: `[4294967296]`, rangeText: "[-32768, 32767]"},
+		{name: "int32 above max", elementType: schemapb.DataType_Int32, raw: `[2147483648]`, rangeText: "[-2147483648, 2147483647]"},
+		{name: "int32 below min", elementType: schemapb.DataType_Int32, raw: `[-2147483649]`, rangeText: "[-2147483648, 2147483647]"},
+		{name: "int64 above max", elementType: schemapb.DataType_Int64, raw: `[9223372036854775808]`, rangeText: "[-9223372036854775808, 9223372036854775807]"},
+		{name: "int64 below min", elementType: schemapb.DataType_Int64, raw: `[-9223372036854775809]`, rangeText: "[-9223372036854775808, 9223372036854775807]"},
+		{name: "int64 fraction", elementType: schemapb.DataType_Int64, raw: `[127.5]`, rangeText: "[-9223372036854775808, 9223372036854775807]"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sub := &schemapb.FieldSchema{Name: "narrow", ElementType: test.elementType}
+			_, err := buildStructSubArrayScalar(sub, gjson.Parse(test.raw).Array())
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+			assert.Contains(t, err.Error(), "sub-field narrow")
+			assert.Contains(t, err.Error(), "value="+strings.TrimSuffix(strings.TrimPrefix(test.raw, "["), "]"))
+			assert.Contains(t, err.Error(), test.rangeText)
+		})
+	}
 }
 
 func TestStructArrayVectorSubFieldTypes(t *testing.T) {
@@ -5022,8 +5080,45 @@ func TestCheckAndSetDataStructArrayRows(t *testing.T) {
 	assert.Contains(t, structRow, "sub_int")
 	assert.Contains(t, structRow, "sub_vec")
 
+	int64Schema := buildStructArrayTestSchema()
+	int64Schema.GetStructArrayFields()[0].GetFields()[0].ElementType = schemapb.DataType_Int64
+	int64Body := []byte(`{"data":[{"id":1,"vec":[0.1,0.2,0.3,0.4],"my_struct":[{"sub_int":9007199254740993.0,"sub_vec":[1.1,1.2,1.3,1.4]}]}]}`)
+	int64Rows, _, err := checkAndSetData(int64Body, int64Schema, false)
+	require.NoError(t, err)
+	int64StructRow, ok := int64Rows[0]["my_struct"].(structArrayRow)
+	require.True(t, ok)
+	int64Scalar, ok := int64StructRow["sub_int"].(*schemapb.ScalarField)
+	require.True(t, ok)
+	assert.Equal(t, []int64{9007199254740993}, int64Scalar.GetLongData().GetData())
+
 	_, _, err = checkAndSetData([]byte(`{"data": [{"id": 1, "vec": [0.1,0.2,0.3,0.4], "my_struct": [1]}]}`), schema, false)
 	assert.Error(t, err)
+
+	for _, test := range []struct {
+		name        string
+		elementType schemapb.DataType
+		value       string
+		rangeText   string
+	}{
+		{name: "int8 int32 wraparound", elementType: schemapb.DataType_Int8, value: "4294967296", rangeText: "[-128, 127]"},
+		{name: "int16 int32 wraparound", elementType: schemapb.DataType_Int16, value: "4294967296", rangeText: "[-32768, 32767]"},
+		{name: "int32 overflow", elementType: schemapb.DataType_Int32, value: "2147483648", rangeText: "[-2147483648, 2147483647]"},
+		{name: "fraction", elementType: schemapb.DataType_Int8, value: "127.5", rangeText: "[-128, 127]"},
+		{name: "int64 overflow", elementType: schemapb.DataType_Int64, value: "9223372036854775808", rangeText: "[-9223372036854775808, 9223372036854775807]"},
+		{name: "int64 fraction", elementType: schemapb.DataType_Int64, value: "127.5", rangeText: "[-9223372036854775808, 9223372036854775807]"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			testSchema := buildStructArrayTestSchema()
+			testSchema.GetStructArrayFields()[0].GetFields()[0].ElementType = test.elementType
+			invalidBody := []byte(fmt.Sprintf(`{"data":[{"id":1,"vec":[0.1,0.2,0.3,0.4],"my_struct":[{"sub_int":%s,"sub_vec":[1.1,1.2,1.3,1.4]}]}]}`, test.value))
+			_, _, err := checkAndSetData(invalidBody, testSchema, false)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+			assert.Contains(t, err.Error(), "sub-field sub_int")
+			assert.Contains(t, err.Error(), "value="+test.value)
+			assert.Contains(t, err.Error(), test.rangeText)
+		})
+	}
 }
 
 func TestParseStructArrayRowQualifiedSchemaNames(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -160,6 +160,22 @@ func generateNarrowIntegerCollectionSchema(dataType schemapb.DataType) *schemapb
 	return schema
 }
 
+func hasStructArrayInt64Value(fieldsData []*schemapb.FieldData, structName, subName string, expected int64) bool {
+	for _, fieldData := range fieldsData {
+		if fieldData.GetFieldName() != structName {
+			continue
+		}
+		for _, subFieldData := range fieldData.GetStructArrays().GetFields() {
+			if subFieldData.GetFieldName() != subName {
+				continue
+			}
+			rows := subFieldData.GetScalars().GetArrayData().GetData()
+			return len(rows) == 1 && len(rows[0].GetLongData().GetData()) == 1 && rows[0].GetLongData().GetData()[0] == expected
+		}
+	}
+	return false
+}
+
 func generateDocInDocOutCollectionSchema(primaryDataType schemapb.DataType) *schemapb.CollectionSchema {
 	primaryField := generatePrimaryField(primaryDataType, false)
 	vectorField := generateVectorFieldSchema(schemapb.DataType_SparseFloatVector)
@@ -4379,6 +4395,65 @@ func TestPrintStructArrayFieldsV2(t *testing.T) {
 	assert.Equal(t, schemapb.DataType_FloatVector.String(), subs[1][HTTPReturnFieldElementType])
 }
 
+func TestParseStructSubInteger(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		bitSize int
+		value   int64
+		ok      bool
+	}{
+		{name: "int8 max decimal", raw: "127.0", bitSize: 8, value: 127, ok: true},
+		{name: "int8 exponent", raw: "1e2", bitSize: 8, value: 100, ok: true},
+		{name: "negative scale integer", raw: "100e-2", bitSize: 8, value: 1, ok: true},
+		{name: "decimal exponent integer", raw: "1.2300e2", bitSize: 8, value: 123, ok: true},
+		{name: "exact beyond float64", raw: "9007199254740993.0", bitSize: 64, value: 9007199254740993, ok: true},
+		{name: "int64 max decimal", raw: "9223372036854775807.0", bitSize: 64, value: math.MaxInt64, ok: true},
+		{name: "int64 min decimal", raw: "-9223372036854775808.0", bitSize: 64, value: math.MinInt64, ok: true},
+		{name: "int64 max scaled", raw: "92233720368547758070e-1", bitSize: 64, value: math.MaxInt64, ok: true},
+		{name: "int64 min scaled", raw: "-92233720368547758080e-1", bitSize: 64, value: math.MinInt64, ok: true},
+		{name: "zero huge positive exponent", raw: "0.0e999999", bitSize: 64, value: 0, ok: true},
+		{name: "negative zero huge negative exponent", raw: "-0e-999999", bitSize: 64, value: 0, ok: true},
+		{name: "int8 overflow after scaling", raw: "1280e-1", bitSize: 8, ok: false},
+		{name: "fraction", raw: "127.5", bitSize: 8, ok: false},
+		{name: "negative scale fraction", raw: "100e-3", bitSize: 8, ok: false},
+		{name: "precision-sensitive fraction", raw: "1.00000000000000000000000000001", bitSize: 64, ok: false},
+		{name: "int64 max adjacent fraction", raw: "9223372036854775806.9", bitSize: 64, ok: false},
+		{name: "int64 max scaled overflow", raw: "92233720368547758080e-1", bitSize: 64, ok: false},
+		{name: "int64 min scaled overflow", raw: "-92233720368547758090e-1", bitSize: 64, ok: false},
+		{name: "huge positive exponent", raw: "1e999999", bitSize: 64, ok: false},
+		{name: "huge negative exponent", raw: "1e-999999", bitSize: 64, ok: false},
+		{name: "leading plus", raw: "+1", bitSize: 64, ok: false},
+		{name: "leading zero", raw: "01", bitSize: 64, ok: false},
+		{name: "missing integer part", raw: ".1", bitSize: 64, ok: false},
+		{name: "missing fraction", raw: "1.", bitSize: 64, ok: false},
+		{name: "missing exponent", raw: "1e", bitSize: 64, ok: false},
+		{name: "invalid bit size", raw: "1", bitSize: 7, ok: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			value, ok := parseStructSubInteger(test.raw, test.bitSize)
+			assert.Equal(t, test.ok, ok)
+			if test.ok {
+				assert.Equal(t, test.value, value)
+			}
+		})
+	}
+
+	largeScaledInteger := "1" + strings.Repeat("0", 4096) + "e-4096"
+	value, ok := parseStructSubInteger(largeScaledInteger, 64)
+	require.True(t, ok)
+	assert.Equal(t, int64(1), value)
+
+	_, ok = parseStructSubInteger("1e-999999", 64)
+	assert.False(t, ok)
+	allocations := testing.AllocsPerRun(1000, func() {
+		parseStructSubInteger("1e-999999", 64)
+	})
+	assert.LessOrEqual(t, allocations, float64(2))
+}
+
 func TestStructArrayScalarSubFieldTypes(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -4487,6 +4562,8 @@ func TestStructArrayNarrowIntegerSubFieldValidation(t *testing.T) {
 		{name: "int64 above max", elementType: schemapb.DataType_Int64, raw: `[9223372036854775808]`, rangeText: "[-9223372036854775808, 9223372036854775807]"},
 		{name: "int64 below min", elementType: schemapb.DataType_Int64, raw: `[-9223372036854775809]`, rangeText: "[-9223372036854775808, 9223372036854775807]"},
 		{name: "int64 fraction", elementType: schemapb.DataType_Int64, raw: `[127.5]`, rangeText: "[-9223372036854775808, 9223372036854775807]"},
+		{name: "int64 huge positive exponent", elementType: schemapb.DataType_Int64, raw: `[1e999999]`, rangeText: "[-9223372036854775808, 9223372036854775807]"},
+		{name: "int64 huge negative exponent", elementType: schemapb.DataType_Int64, raw: `[1e-999999]`, rangeText: "[-9223372036854775808, 9223372036854775807]"},
 	}
 
 	for _, test := range tests {

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -1037,23 +1037,39 @@ func TestAnyToColumns(t *testing.T) {
 func TestCheckAndSetData(t *testing.T) {
 	t.Run("integer range validation", func(t *testing.T) {
 		tests := []struct {
-			name          string
-			dataType      schemapb.DataType
-			min           int64
-			max           int64
-			invalidValues []int64
+			name              string
+			dataType          schemapb.DataType
+			min               int64
+			max               int64
+			invalidValues     []int64
+			invalidJSONValues []string
 		}{
 			{
 				name: "int8", dataType: schemapb.DataType_Int8, min: math.MinInt8, max: math.MaxInt8,
 				invalidValues: []int64{-129, 128, 200, 256, 1000, 65535},
+				invalidJSONValues: []string{
+					"127.00000000000000000000000000001",
+					"-128.00000000000000000000000000001",
+					"1e-999999",
+				},
 			},
 			{
 				name: "int16", dataType: schemapb.DataType_Int16, min: math.MinInt16, max: math.MaxInt16,
 				invalidValues: []int64{-32769, 32768, 65535, 100000},
+				invalidJSONValues: []string{
+					"32767.00000000000000000000000000001",
+					"-32768.00000000000000000000000000001",
+					"1e-999999",
+				},
 			},
 			{
 				name: "int32", dataType: schemapb.DataType_Int32, min: math.MinInt32, max: math.MaxInt32,
 				invalidValues: []int64{-2147483649, 2147483648, 4294967295},
+				invalidJSONValues: []string{
+					"2147483647.00000000000000000001",
+					"-2147483648.00000000000000000001",
+					"1e-999999",
+				},
 			},
 		}
 
@@ -1084,6 +1100,21 @@ func TestCheckAndSetData(t *testing.T) {
 					}
 				}
 
+				for _, input := range []struct {
+					raw      string
+					expected int64
+				}{
+					{raw: "100.0", expected: 100},
+					{raw: "1e2", expected: 100},
+					{raw: strconv.Quote("0x64"), expected: 100},
+				} {
+					body := []byte(fmt.Sprintf(`{"data":[{"book_id":1,"book_intro":[0.1,0.2],"word_count":2,"%s":%s}]}`, FieldNarrowInt, input.raw))
+					rows, _, err := checkAndSetData(body, schema, false)
+					require.NoError(t, err)
+					require.Len(t, rows, 1)
+					assert.EqualValues(t, input.expected, rows[0][FieldNarrowInt])
+				}
+
 				for _, value := range test.invalidValues {
 					literal := strconv.FormatInt(value, 10)
 					for _, valueJSON := range []string{literal, strconv.Quote(literal)} {
@@ -1095,6 +1126,16 @@ func TestCheckAndSetData(t *testing.T) {
 						assert.Contains(t, err.Error(), FieldNarrowInt)
 						assert.Contains(t, err.Error(), fmt.Sprintf("[%d, %d]", test.min, test.max))
 					}
+				}
+
+				for _, valueJSON := range test.invalidJSONValues {
+					body := []byte(fmt.Sprintf(`{"data":[{"book_id":1,"book_intro":[0.1,0.2],"word_count":2,"%s":%s}]}`, FieldNarrowInt, valueJSON))
+					_, _, err := checkAndSetData(body, schema, false)
+					require.Error(t, err)
+					assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+					assert.Contains(t, err.Error(), "actual="+valueJSON)
+					assert.Contains(t, err.Error(), FieldNarrowInt)
+					assert.Contains(t, err.Error(), fmt.Sprintf("[%d, %d]", test.min, test.max))
 				}
 			})
 		}
@@ -4395,7 +4436,7 @@ func TestPrintStructArrayFieldsV2(t *testing.T) {
 	assert.Equal(t, schemapb.DataType_FloatVector.String(), subs[1][HTTPReturnFieldElementType])
 }
 
-func TestParseStructSubInteger(t *testing.T) {
+func TestParseJSONInteger(t *testing.T) {
 	tests := []struct {
 		name    string
 		raw     string
@@ -4433,7 +4474,7 @@ func TestParseStructSubInteger(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			value, ok := parseStructSubInteger(test.raw, test.bitSize)
+			value, ok := parseJSONInteger(test.raw, test.bitSize)
 			assert.Equal(t, test.ok, ok)
 			if test.ok {
 				assert.Equal(t, test.value, value)
@@ -4442,14 +4483,14 @@ func TestParseStructSubInteger(t *testing.T) {
 	}
 
 	largeScaledInteger := "1" + strings.Repeat("0", 4096) + "e-4096"
-	value, ok := parseStructSubInteger(largeScaledInteger, 64)
+	value, ok := parseJSONInteger(largeScaledInteger, 64)
 	require.True(t, ok)
 	assert.Equal(t, int64(1), value)
 
-	_, ok = parseStructSubInteger("1e-999999", 64)
+	_, ok = parseJSONInteger("1e-999999", 64)
 	assert.False(t, ok)
 	allocations := testing.AllocsPerRun(1000, func() {
-		parseStructSubInteger("1e-999999", 64)
+		parseJSONInteger("1e-999999", 64)
 	})
 	assert.LessOrEqual(t, allocations, float64(2))
 }

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -5421,4 +5422,54 @@ func TestCheckAndSetDataQuotedIntegerIsDecimal(t *testing.T) {
 			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 		})
 	}
+}
+
+// proxy.http.compatibilityMode restores the previous integer handling,
+// including the two's complement wraparound this PR removes.
+func TestCheckAndSetDataIntegerCompatibilityMode(t *testing.T) {
+	paramtable.Init()
+	key := paramtable.Get().HTTPCfg.CompatibilityMode.Key
+	paramtable.Get().Save(key, "true")
+	defer paramtable.Get().Reset(key)
+
+	narrowSchema := func(dataType schemapb.DataType) *schemapb.CollectionSchema {
+		vectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+		vectorField.Name = "vector"
+		return &schemapb.CollectionSchema{
+			Name: DefaultCollectionName,
+			Fields: []*schemapb.FieldSchema{
+				generatePrimaryField(schemapb.DataType_Int64, false),
+				vectorField,
+				{Name: "narrow", DataType: dataType},
+			},
+		}
+	}
+	insert := func(t *testing.T, schema *schemapb.CollectionSchema, value string) map[string]interface{} {
+		t.Helper()
+		body := []byte(fmt.Sprintf(
+			`{"data": {"%s": 1, "vector": [0.1, 0.2], "narrow": %s}}`, FieldBookID, value))
+		rows, _, err := checkAndSetData(body, schema, false)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		return rows[0]
+	}
+
+	t.Run("int8 wraps again", func(t *testing.T) {
+		assert.Equal(t, int8(-128), insert(t, narrowSchema(schemapb.DataType_Int8), `128`)["narrow"])
+	})
+
+	t.Run("int32 wraps again", func(t *testing.T) {
+		assert.Equal(t, int32(0), insert(t, narrowSchema(schemapb.DataType_Int32), `4294967296`)["narrow"])
+	})
+
+	t.Run("quoted integer uses base detection again", func(t *testing.T) {
+		assert.Equal(t, int8(8), insert(t, narrowSchema(schemapb.DataType_Int8), `"010"`)["narrow"])
+	})
+
+	t.Run("int64 loses precision again", func(t *testing.T) {
+		rows, err := insertOneInt64Value(t, `9007199254740993.0`)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.Equal(t, int64(9007199254740992), rows[0]["count"])
+	})
 }

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -46,6 +46,7 @@ const (
 	FieldBookID    = "book_id"
 	FieldBookIntro = "book_intro"
 	FieldVarchar   = "varchar_field"
+	FieldNarrowInt = "narrow_int"
 )
 
 var DefaultScores = []float32{0.01, 0.04, 0.09}
@@ -147,6 +148,16 @@ func generateCollectionSchema(primaryDataType schemapb.DataType, autoID bool, is
 		Fields:             fields,
 		EnableDynamicField: isDynamic,
 	}
+}
+
+func generateNarrowIntegerCollectionSchema(dataType schemapb.DataType) *schemapb.CollectionSchema {
+	schema := generateCollectionSchema(schemapb.DataType_Int64, false, false)
+	schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
+		FieldID:  common.StartOfUserFieldID + 100,
+		Name:     FieldNarrowInt,
+		DataType: dataType,
+	})
+	return schema
 }
 
 func generateDocInDocOutCollectionSchema(primaryDataType schemapb.DataType) *schemapb.CollectionSchema {
@@ -1018,7 +1029,7 @@ func TestCheckAndSetData(t *testing.T) {
 		}{
 			{
 				name: "int8", dataType: schemapb.DataType_Int8, min: math.MinInt8, max: math.MaxInt8,
-				invalidValues: []int64{-129, 128, 256, 1000, 65535},
+				invalidValues: []int64{-129, 128, 200, 256, 1000, 65535},
 			},
 			{
 				name: "int16", dataType: schemapb.DataType_Int16, min: math.MinInt16, max: math.MaxInt16,
@@ -1032,41 +1043,42 @@ func TestCheckAndSetData(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				const fieldName = "narrow_int"
-				schema := generateCollectionSchema(schemapb.DataType_Int64, false, false)
-				schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
-					FieldID:  common.StartOfUserFieldID + 100,
-					Name:     fieldName,
-					DataType: test.dataType,
-				})
+				schema := generateNarrowIntegerCollectionSchema(test.dataType)
 
 				for _, value := range []int64{test.min, test.max} {
-					body := []byte(fmt.Sprintf(`{"data":[{"book_id":1,"book_intro":[0.1,0.2],"word_count":2,"%s":%d}]}`, fieldName, value))
-					rows, validData, err := checkAndSetData(body, schema, false)
-					require.NoError(t, err)
-					require.Len(t, rows, 1)
-					assert.EqualValues(t, value, rows[0][fieldName])
+					literal := strconv.FormatInt(value, 10)
+					for _, valueJSON := range []string{literal, strconv.Quote(literal)} {
+						body := []byte(fmt.Sprintf(`{"data":[{"book_id":1,"book_intro":[0.1,0.2],"word_count":2,"%s":%s}]}`, FieldNarrowInt, valueJSON))
+						rows, validData, err := checkAndSetData(body, schema, false)
+						require.NoError(t, err)
+						require.Len(t, rows, 1)
+						assert.EqualValues(t, value, rows[0][FieldNarrowInt])
 
-					fieldsData, err := anyToColumns(rows, validData, schema, true, false)
-					require.NoError(t, err)
-					var narrowFieldData *schemapb.FieldData
-					for _, fieldData := range fieldsData {
-						if fieldData.GetFieldName() == fieldName {
-							narrowFieldData = fieldData
-							break
+						fieldsData, err := anyToColumns(rows, validData, schema, true, false)
+						require.NoError(t, err)
+						var narrowFieldData *schemapb.FieldData
+						for _, fieldData := range fieldsData {
+							if fieldData.GetFieldName() == FieldNarrowInt {
+								narrowFieldData = fieldData
+								break
+							}
 						}
+						require.NotNil(t, narrowFieldData)
+						assert.Equal(t, []int32{int32(value)}, narrowFieldData.GetScalars().GetIntData().GetData())
 					}
-					require.NotNil(t, narrowFieldData)
-					assert.Equal(t, []int32{int32(value)}, narrowFieldData.GetScalars().GetIntData().GetData())
 				}
 
 				for _, value := range test.invalidValues {
-					body := []byte(fmt.Sprintf(`{"data":[{"book_id":1,"book_intro":[0.1,0.2],"word_count":2,"%s":%d}]}`, fieldName, value))
-					_, _, err := checkAndSetData(body, schema, false)
-					require.Error(t, err)
-					assert.ErrorIs(t, err, merr.ErrParameterInvalid)
-					assert.Contains(t, err.Error(), fieldName)
-					assert.Contains(t, err.Error(), fmt.Sprintf("[%d, %d]", test.min, test.max))
+					literal := strconv.FormatInt(value, 10)
+					for _, valueJSON := range []string{literal, strconv.Quote(literal)} {
+						body := []byte(fmt.Sprintf(`{"data":[{"book_id":1,"book_intro":[0.1,0.2],"word_count":2,"%s":%s}]}`, FieldNarrowInt, valueJSON))
+						_, _, err := checkAndSetData(body, schema, false)
+						require.Error(t, err)
+						assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+						assert.Contains(t, err.Error(), fmt.Sprintf("actual=%d", value))
+						assert.Contains(t, err.Error(), FieldNarrowInt)
+						assert.Contains(t, err.Error(), fmt.Sprintf("[%d, %d]", test.min, test.max))
+					}
 				}
 			})
 		}

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -1106,7 +1106,7 @@ func TestCheckAndSetData(t *testing.T) {
 				}{
 					{raw: "100.0", expected: 100},
 					{raw: "1e2", expected: 100},
-					{raw: strconv.Quote("0x64"), expected: 100},
+					{raw: strconv.Quote("100"), expected: 100},
 				} {
 					body := []byte(fmt.Sprintf(`{"data":[{"book_id":1,"book_intro":[0.1,0.2],"word_count":2,"%s":%s}]}`, FieldNarrowInt, input.raw))
 					rows, _, err := checkAndSetData(body, schema, false)
@@ -5373,6 +5373,52 @@ func TestCheckAndSetDataInt64FieldRejectsNonIntegers(t *testing.T) {
 			require.Error(t, err)
 			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 			assert.Contains(t, err.Error(), "count")
+		})
+	}
+}
+
+// Quoted integers are read as base 10 for every integer width. cast relied on
+// strconv's base detection, so "010" meant 8 in a narrow integer field and 10
+// in an Int64 field.
+func TestCheckAndSetDataQuotedIntegerIsDecimal(t *testing.T) {
+	narrowSchema := func(dataType schemapb.DataType) *schemapb.CollectionSchema {
+		vectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+		vectorField.Name = "vector"
+		return &schemapb.CollectionSchema{
+			Name: DefaultCollectionName,
+			Fields: []*schemapb.FieldSchema{
+				generatePrimaryField(schemapb.DataType_Int64, false),
+				vectorField,
+				{Name: "narrow", DataType: dataType},
+			},
+		}
+	}
+
+	for _, dataType := range []schemapb.DataType{
+		schemapb.DataType_Int8, schemapb.DataType_Int16, schemapb.DataType_Int32,
+	} {
+		t.Run(dataType.String()+" zero padded", func(t *testing.T) {
+			body := []byte(fmt.Sprintf(
+				`{"data": {"%s": 1, "vector": [0.1, 0.2], "narrow": "010"}}`, FieldBookID))
+			rows, _, err := checkAndSetData(body, narrowSchema(dataType), false)
+			require.NoError(t, err)
+			require.Len(t, rows, 1)
+			switch dataType {
+			case schemapb.DataType_Int8:
+				assert.Equal(t, int8(10), rows[0]["narrow"])
+			case schemapb.DataType_Int16:
+				assert.Equal(t, int16(10), rows[0]["narrow"])
+			case schemapb.DataType_Int32:
+				assert.Equal(t, int32(10), rows[0]["narrow"])
+			}
+		})
+
+		t.Run(dataType.String()+" hex prefix is rejected", func(t *testing.T) {
+			body := []byte(fmt.Sprintf(
+				`{"data": {"%s": 1, "vector": [0.1, 0.2], "narrow": "0x10"}}`, FieldBookID))
+			_, _, err := checkAndSetData(body, narrowSchema(dataType), false)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 		})
 	}
 }

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -5295,3 +5295,84 @@ func TestEncodeEmbListQueryErrorPaths(t *testing.T) {
 	_, err = encodeEmbListQuery(gjson.Parse(`[[true]]`).Array(), schemapb.DataType_Bool, 1, 0)
 	assert.Error(t, err)
 }
+
+func int64FieldTestSchema() *schemapb.CollectionSchema {
+	vectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+	vectorField.Name = "vector"
+	return &schemapb.CollectionSchema{
+		Name: DefaultCollectionName,
+		Fields: []*schemapb.FieldSchema{
+			generatePrimaryField(schemapb.DataType_Int64, false),
+			vectorField,
+			{
+				Name:     "count",
+				DataType: schemapb.DataType_Int64,
+			},
+		},
+	}
+}
+
+func insertOneInt64Value(t *testing.T, value string) ([]map[string]interface{}, error) {
+	t.Helper()
+	body := []byte(fmt.Sprintf(
+		`{"data": {"%s": 1, "vector": [0.1, 0.2], "count": %s}}`, FieldBookID, value))
+	rows, _, err := checkAndSetData(body, int64FieldTestSchema(), false)
+	return rows, err
+}
+
+// gjson's String() renders a number through float64 as soon as the raw text is
+// not all digits, so a decimal or exponent form lost precision before reaching
+// json.Number and was then accepted as a valid int64.
+func TestCheckAndSetDataInt64FieldParsesRawLiteral(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected int64
+	}{
+		{"plain integer", `42`, 42},
+		{"negative", `-7`, -7},
+		{"int64 upper bound", `9223372036854775807`, 9223372036854775807},
+		{"int64 lower bound", `-9223372036854775808`, -9223372036854775808},
+		{"integer valued decimal", `1.0`, 1},
+		{"integer valued exponent", `1e3`, 1000},
+		{"negative exponent that is exact", `100e-2`, 1},
+		{"beyond 2^53 as a plain integer", `9007199254740993`, 9007199254740993},
+		// this used to be stored as 9007199254740992
+		{"beyond 2^53 as a decimal", `9007199254740993.0`, 9007199254740993},
+		{"quoted integer", `"42"`, 42},
+		// base-10, not strconv base detection: this path carries Int64 primary keys
+		{"quoted zero padded integer", `"010"`, 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows, err := insertOneInt64Value(t, tt.value)
+			require.NoError(t, err)
+			require.Len(t, rows, 1)
+			assert.Equal(t, tt.expected, rows[0]["count"])
+		})
+	}
+}
+
+func TestCheckAndSetDataInt64FieldRejectsNonIntegers(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"fraction", `1.5`},
+		{"exponent past int64", `1e19`},
+		{"integer past int64", `9223372036854775808`},
+		{"integer below int64", `-9223372036854775809`},
+		// used to be stored as 0 because String() rendered it to "0"
+		{"underflow to zero", `1e-400`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := insertOneInt64Value(t, tt.value)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+			assert.Contains(t, err.Error(), "count")
+		})
+	}
+}

--- a/pkg/util/paramtable/http_param.go
+++ b/pkg/util/paramtable/http_param.go
@@ -21,6 +21,7 @@ type httpConfig struct {
 	DebugMode             ParamItem `refreshable:"false"`
 	Port                  ParamItem `refreshable:"false"`
 	AcceptTypeAllowInt64  ParamItem `refreshable:"true"`
+	CompatibilityMode     ParamItem `refreshable:"true"`
 	EnablePprof           ParamItem `refreshable:"false"`
 	RequestTimeoutMs      ParamItem `refreshable:"true"`
 	ReadHeaderTimeout     ParamItem `refreshable:"false"`
@@ -71,6 +72,20 @@ func (p *httpConfig) init(base *BaseTable) {
 		Export:       true,
 	}
 	p.AcceptTypeAllowInt64.Init(base.mgr)
+
+	p.CompatibilityMode = ParamItem{
+		Key:          "proxy.http.compatibilityMode",
+		DefaultValue: "false",
+		Version:      "2.7.0",
+		Doc: `high-level restful api, restore the value handling of releases that predate the REST insert
+validation work. When true the server keeps the previous lenient behaviour: a missing or null non-nullable field is
+stored as an empty value, out-of-range integers wrap instead of being rejected, numbers reach VarChar and JSON fields
+through their float64 rendering, and integers too large for the JSON engine become 0. This is a temporary escape hatch
+for clients that have not been corrected yet: every one of those behaviours silently changes what is stored.`,
+		PanicIfEmpty: false,
+		Export:       true,
+	}
+	p.CompatibilityMode.Init(base.mgr)
 
 	p.EnablePprof = ParamItem{
 		Key:          "proxy.http.enablePprof",


### PR DESCRIPTION
## What changed

- Parse REST scalar `Int8`, `Int16`, and `Int32` values with the target bit width before narrowing.
- Parse scalar `Int64` values from the raw JSON literal instead of gjson's
  `String()` rendering, so decimal and exponent forms keep full precision.
- Validate StructArray `Array<Int8/Int16/Int32/Int64>` sub-fields before converting them to protobuf integer arrays.
- Preserve exact integer-valued decimal and exponent forms in StructArray input while rejecting fractions and out-of-range values.
- Return errors that include the field/sub-field, offending value, and valid range.
- Add unit and endpoint coverage for REST v1/v2 insert and upsert.

## Root cause

The scalar REST adapter used `cast.ToInt8E`, `cast.ToInt16E`, and `cast.ToInt32E`. Those helpers parsed into a machine-sized integer and then narrowed without checking the destination range, so values such as `128` became `int8(-128)` before Proxy validation could see the original value.

The StructArray adapter had the same ordering problem: it called `int32(v.Int())` or `v.Int()` before validation. That allowed wraparound inputs such as `4294967296`, Int32 overflow, Int64 overflow, and fractional values to be silently changed.

The scalar `Int64` adapter had the same origin. It read `fieldValue.String()`,
which gjson renders through the parsed `float64` as soon as the raw text is not
all digits, so the value was already wrong before `json.Number` saw it:

| request | stored before | stored after |
|---|---|---|
| `{"count": 9007199254740993.0}` | `9007199254740992` (no error) | `9007199254740993` |
| `{"count": 1e-400}` | `0` (no error) | rejected |

Only the JSON-number form is rerouted through `parseJSONInteger`. Quoted
integers keep `json.Number`'s base-10 parsing: this path also carries Int64
primary keys, and strconv's base detection would silently reinterpret a
zero-padded id such as `"010"` as octal.

## Compatibility

- Valid min/max boundaries remain accepted.
- Scalar integer values remain accepted as either JSON numbers or quoted integer strings.
- StructArray and scalar integer-valued decimal/exponent forms remain accepted (`1.0`, `1e3`, `100e-2`), and Int64 values are parsed exactly rather than through float64.
- Two scalar Int64 inputs change: `9007199254740993.0` now keeps its exact value instead of being silently rounded, and `1e-400` is rejected instead of being silently stored as `0`. Quoted integers are unchanged.
- REST v1/v2 insert and upsert intentionally preserve the existing public error code `1804` (`ErrInvalidInsertData`). The underlying validation error remains `ErrParameterInvalid` (`1100`); this PR does not change the wire error-code contract.
- Rejected input does not reach Proxy insert/upsert calls.

## Validation

- `git diff --check` passed.
- The following tests passed with `-tags dynamic,test -gcflags="all=-N -l" -count=1` in a local source snapshot compatible with the available native artifacts:
  - `TestCheckAndSetData`
  - `TestCheckAndSetDataStructArrayRows`
  - `TestNarrowIntegerOverflowV1`
  - `TestNarrowIntegerOverflowV2`
  - `TestStructArrayScalarSubFieldTypes`
  - `TestStructArrayNarrowIntegerSubFieldValidation`
- The exact-head local package run is blocked before tests start because the existing native artifacts do not expose `SegcoreSetFMIndexCostRatio`; CI will build against matching native sources.

issue: #52050
