### PR TITLE
feat: add the index types the Go client was missing, and fix the broken ones (#52095)

### DIFF
--- a/client/index/common.go
+++ b/client/index/common.go
@@ -47,9 +47,13 @@ const (
 	IvfSQ8     IndexType = "IVF_SQ8"
 	IvfRabitQ  IndexType = "IVF_RABITQ"
 	HNSW       IndexType = "HNSW"
+	HNSWSQ     IndexType = "HNSW_SQ"
+	HNSWPQ     IndexType = "HNSW_PQ"
+	HNSWPRQ    IndexType = "HNSW_PRQ"
 	IvfHNSW    IndexType = "IVF_HNSW"
 	AUTOINDEX  IndexType = "AUTOINDEX"
 	DISKANN    IndexType = "DISKANN"
+	AISAQ      IndexType = "AISAQ"
 	SCANN      IndexType = "SCANN"
 	MinHashLSH IndexType = "MINHASH_LSH"
 
@@ -67,5 +71,7 @@ const (
 	Sorted   IndexType = "STL_SORT"
 	Inverted IndexType = "INVERTED"
 	BITMAP   IndexType = "BITMAP"
+	NGRAM    IndexType = "NGRAM"
+	FMINDEX  IndexType = "FMINDEX"
 	RTREE    IndexType = "RTREE"
 )

--- a/client/index/disk_ann.go
+++ b/client/index/disk_ann.go
@@ -16,6 +16,8 @@
 
 package index
 
+import "strconv"
+
 const (
 	diskANNSearchListKey = `search_list`
 )
@@ -60,4 +62,143 @@ func (ap diskANNParam) Params() map[string]any {
 	result := ap.baseAnnParam.params
 	result[diskANNSearchListKey] = ap.searchList
 	return result
+}
+
+// WithBeamwidth sets the maximum number of IO requests issued per search
+// iteration.
+func (ap diskANNParam) WithBeamwidth(beamwidth int) diskANNParam {
+	ap.params[aisaqBeamwidthKey] = beamwidth
+	return ap
+}
+
+// AISAQ-specific params (knowhere AisaqConfig). Everything AISAQ inherits from
+// DiskANNConfig keeps its server-side default, exactly as NewDiskANNIndex does.
+const (
+	aisaqInlinePQKey            = `inline_pq`
+	aisaqPQCacheSizeKey         = `pq_cache_size`
+	aisaqRearrangeKey           = `rearrange`
+	aisaqPQReadIOEngineKey      = `pq_read_io_engine`
+	aisaqNumEntryPointsKey      = `num_entry_points`
+	aisaqPQReadPageCacheSizeKey = `pq_read_page_cache_size`
+	aisaqBeamwidthKey           = `beamwidth`
+	aisaqVectorsBeamwidthKey    = `vectors_beamwidth`
+)
+
+var _ Index = &aisaqIndex{}
+
+// aisaqIndex is a DiskANN variant that keeps PQ codes inline with the graph to
+// cut the number of random reads per hop. Every build param has a server-side
+// default, so the constructor takes only the metric type and the rest are
+// opt-in.
+type aisaqIndex struct {
+	baseIndex
+
+	params map[string]string
+}
+
+func (idx *aisaqIndex) Params() map[string]string {
+	result := map[string]string{
+		MetricTypeKey: string(idx.metricType),
+		IndexTypeKey:  string(AISAQ),
+	}
+	// An unset param must stay absent: every one of these is range-checked
+	// server-side, so sending a zero would be rejected rather than treated as
+	// "use the default".
+	for k, v := range idx.params {
+		result[k] = v
+	}
+	return result
+}
+
+// WithInlinePQ sets how many compressed vectors are stored inline in a node.
+// Capped by the graph's max degree; range [0, 2048].
+func (idx *aisaqIndex) WithInlinePQ(inlinePQ int) *aisaqIndex {
+	idx.params[aisaqInlinePQKey] = strconv.Itoa(inlinePQ)
+	return idx
+}
+
+// WithPQCacheSize sets the compressed-vector cache size in bytes.
+func (idx *aisaqIndex) WithPQCacheSize(bytes int) *aisaqIndex {
+	idx.params[aisaqPQCacheSizeKey] = strconv.Itoa(bytes)
+	return idx
+}
+
+// WithRearrange enables the compressed-vector reordering search optimization.
+func (idx *aisaqIndex) WithRearrange(rearrange bool) *aisaqIndex {
+	idx.params[aisaqRearrangeKey] = strconv.FormatBool(rearrange)
+	return idx
+}
+
+// WithPQReadIOEngine selects the IO engine used to read PQ vectors, either
+// "aio" (server default) or "uring".
+func (idx *aisaqIndex) WithPQReadIOEngine(engine string) *aisaqIndex {
+	idx.params[aisaqPQReadIOEngineKey] = engine
+	return idx
+}
+
+// WithNumEntryPoints sets how many entry points are generated and stored when
+// the graph is built. This is a build param (knowhere marks it for_train), not
+// a per-search knob.
+func (idx *aisaqIndex) WithNumEntryPoints(numEntryPoints int) *aisaqIndex {
+	idx.params[aisaqNumEntryPointsKey] = strconv.Itoa(numEntryPoints)
+	return idx
+}
+
+// WithPQReadPageCacheSize sets the per-thread read-page cache size in bytes.
+// This one is honored at both build and search time.
+func (idx *aisaqIndex) WithPQReadPageCacheSize(bytes int) *aisaqIndex {
+	idx.params[aisaqPQReadPageCacheSizeKey] = strconv.Itoa(bytes)
+	return idx
+}
+
+func NewAISAQIndex(metricType MetricType) *aisaqIndex {
+	return &aisaqIndex{
+		baseIndex: baseIndex{
+			metricType: metricType,
+			indexType:  AISAQ,
+		},
+		params: make(map[string]string),
+	}
+}
+
+// aisaqAnnParam carries DiskANN's search_list plus the two beam widths AISAQ
+// adds on top of it.
+type aisaqAnnParam struct {
+	baseAnnParam
+	searchList int
+}
+
+func (ap *aisaqAnnParam) Params() map[string]any {
+	result := ap.baseAnnParam.params
+	result[diskANNSearchListKey] = ap.searchList
+	return result
+}
+
+// WithBeamwidth sets the maximum number of IO requests issued per search
+// iteration.
+func (ap *aisaqAnnParam) WithBeamwidth(beamwidth int) *aisaqAnnParam {
+	ap.params[aisaqBeamwidthKey] = beamwidth
+	return ap
+}
+
+// WithVectorsBeamwidth sets the beam width used for the compressed vectors.
+func (ap *aisaqAnnParam) WithVectorsBeamwidth(beamwidth int) *aisaqAnnParam {
+	ap.params[aisaqVectorsBeamwidthKey] = beamwidth
+	return ap
+}
+
+// WithPQReadPageCacheSize sets the per-thread read-page cache size in bytes for
+// this search.
+func (ap *aisaqAnnParam) WithPQReadPageCacheSize(bytes int) *aisaqAnnParam {
+	ap.params[aisaqPQReadPageCacheSizeKey] = bytes
+	return ap
+}
+
+func NewAISAQAnnParam(searchList int) *aisaqAnnParam {
+	return &aisaqAnnParam{
+		baseAnnParam: baseAnnParam{
+			params: make(map[string]any),
+		},
+		searchList: searchList,
+	}
 }

--- a/client/index/disk_ann_test.go
+++ b/client/index/disk_ann_test.go
@@ -1,0 +1,66 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/client/v3/entity"
+)
+
+func TestAISAQ(t *testing.T) {
+	result := NewAISAQIndex(entity.L2).Params()
+	assert.EqualValues(t, entity.L2, result[MetricTypeKey])
+	assert.EqualValues(t, AISAQ, result[IndexTypeKey])
+
+	// Every build param is range-checked server-side, so an unset one must stay
+	// absent rather than being sent as a zero.
+	assert.Len(t, result, 2)
+}
+
+func TestAISAQBuildParams(t *testing.T) {
+	result := NewAISAQIndex(entity.L2).
+		WithInlinePQ(8).
+		WithPQCacheSize(1 << 20).
+		WithRearrange(true).
+		WithPQReadIOEngine("uring").
+		WithNumEntryPoints(4).
+		WithPQReadPageCacheSize(4096).
+		Params()
+
+	assert.Equal(t, "8", result[aisaqInlinePQKey])
+	assert.Equal(t, "1048576", result[aisaqPQCacheSizeKey])
+	assert.Equal(t, "true", result[aisaqRearrangeKey])
+	assert.Equal(t, "uring", result[aisaqPQReadIOEngineKey])
+	assert.Equal(t, "4", result[aisaqNumEntryPointsKey])
+	assert.Equal(t, "4096", result[aisaqPQReadPageCacheSizeKey])
+}
+
+func TestAISAQAnnParam(t *testing.T) {
+	ap := NewAISAQAnnParam(100)
+	result := ap.Params()
+	assert.Equal(t, 100, result[diskANNSearchListKey])
+	assert.NotContains(t, result, aisaqBeamwidthKey)
+	assert.NotContains(t, result, aisaqVectorsBeamwidthKey)
+
+	result = ap.WithBeamwidth(8).WithVectorsBeamwidth(2).WithPQReadPageCacheSize(4096).Params()
+	assert.Equal(t, 8, result[aisaqBeamwidthKey])
+	assert.Equal(t, 2, result[aisaqVectorsBeamwidthKey])
+	assert.Equal(t, 4096, result[aisaqPQReadPageCacheSizeKey])
+}

--- a/client/index/gpu.go
+++ b/client/index/gpu.go
@@ -36,6 +36,7 @@ func NewGPUBruteForceIndex(metricType MetricType) Index {
 	return gpuBruteForceIndex{
 		baseIndex: baseIndex{
 			metricType: metricType,
+			indexType:  GPUBruteForce,
 		},
 	}
 }
@@ -48,12 +49,13 @@ type gpuIVFFlatIndex struct {
 }
 
 func (idx gpuIVFFlatIndex) Params() map[string]string {
+	// nlist is not reachable through the constructor, so it is zero here; an
+	// absent key lets the server apply its default, while "0" is below the
+	// accepted range and fails the build. Use WithExtraIndexParams to set it.
 	return map[string]string{
 		// build meta
 		MetricTypeKey: string(idx.metricType),
 		IndexTypeKey:  string(GPUIvfFlat),
-		// build param
-		ivfNlistKey: strconv.Itoa(idx.nlist),
 	}
 }
 
@@ -61,6 +63,7 @@ func NewGPUIVPFlatIndex(metricType MetricType) Index {
 	return gpuIVFFlatIndex{
 		baseIndex: baseIndex{
 			metricType: metricType,
+			indexType:  GPUIvfFlat,
 		},
 	}
 }
@@ -75,28 +78,30 @@ type gpuIVFPQIndex struct {
 }
 
 func (idx gpuIVFPQIndex) Params() map[string]string {
-	return map[string]string{
+	result := map[string]string{
 		// build meta
 		MetricTypeKey: string(idx.metricType),
-		IndexTypeKey:  string(GPUIvfFlat),
-		// build params
-		ivfNlistKey: strconv.Itoa(idx.nlist),
-		ivfPQMKey:   strconv.Itoa(idx.m),
-		ivfPQNbits:  strconv.Itoa(idx.nbits),
+		IndexTypeKey:  string(GPUIvfPQ),
 	}
+	// nlist / m / nbits have never been reachable through the constructor, so
+	// they are zero here; emitting them is worse than omitting them, because
+	// zero is below every accepted range while an absent key lets the server
+	// apply its default. Set them with WithExtraIndexParams if needed.
+	return result
 }
 
 func NewGPUIVPPQIndex(metricType MetricType) Index {
 	return gpuIVFPQIndex{
 		baseIndex: baseIndex{
 			metricType: metricType,
+			indexType:  GPUIvfPQ,
 		},
 	}
 }
 
 const (
 	cagraInterGraphDegreeKey = `intermediate_graph_degree`
-	cagraGraphDegreeKey      = `"graph_degree"`
+	cagraGraphDegreeKey      = `graph_degree`
 )
 
 type gpuCagra struct {
@@ -105,11 +110,13 @@ type gpuCagra struct {
 	graphDegree             int
 }
 
+var _ Index = gpuCagra{}
+
 func (idx gpuCagra) Params() map[string]string {
 	return map[string]string{
 		// build meta
 		MetricTypeKey: string(idx.metricType),
-		IndexTypeKey:  string(GPUIvfFlat),
+		IndexTypeKey:  string(GPUCagra),
 		// build params
 		cagraInterGraphDegreeKey: strconv.Itoa(idx.intermediateGraphDegree),
 		cagraGraphDegreeKey:      strconv.Itoa(idx.graphDegree),
@@ -123,6 +130,7 @@ func NewGPUCagraIndex(metricType MetricType,
 	return gpuCagra{
 		baseIndex: baseIndex{
 			metricType: metricType,
+			indexType:  GPUCagra,
 		},
 		intermediateGraphDegree: intermediateGraphDegree,
 		graphDegree:             graphDegree,

--- a/client/index/gpu_test.go
+++ b/client/index/gpu_test.go
@@ -1,0 +1,77 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/client/v3/entity"
+)
+
+// Each GPU builder must report its own type, both on the wire and through
+// IndexType(). GPU_IVF_PQ and GPU_CAGRA used to send GPU_IVF_FLAT, and none of
+// them set baseIndex.indexType at all.
+func TestGPUIndexTypes(t *testing.T) {
+	type testCase struct {
+		tag    string
+		idx    Index
+		expect IndexType
+	}
+
+	for _, tc := range []testCase{
+		{tag: "brute_force", idx: NewGPUBruteForceIndex(entity.L2), expect: GPUBruteForce},
+		{tag: "ivf_flat", idx: NewGPUIVPFlatIndex(entity.L2), expect: GPUIvfFlat},
+		{tag: "ivf_pq", idx: NewGPUIVPPQIndex(entity.L2), expect: GPUIvfPQ},
+		{tag: "cagra", idx: NewGPUCagraIndex(entity.L2, 128, 64), expect: GPUCagra},
+	} {
+		t.Run(tc.tag, func(t *testing.T) {
+			assert.EqualValues(t, tc.expect, tc.idx.Params()[IndexTypeKey])
+			assert.EqualValues(t, tc.expect, tc.idx.IndexType())
+			assert.EqualValues(t, entity.L2, tc.idx.Params()[MetricTypeKey])
+		})
+	}
+}
+
+func TestGPUUnsetBuildParamsAreOmitted(t *testing.T) {
+	// nlist / m / nbits are unreachable through these constructors, so they sat
+	// at zero and were emitted as "0" — below every accepted range, which fails
+	// the build. An absent key lets the server apply its default instead.
+	flat := NewGPUIVPFlatIndex(entity.L2).Params()
+	assert.NotContains(t, flat, ivfNlistKey)
+
+	pq := NewGPUIVPPQIndex(entity.L2).Params()
+	assert.NotContains(t, pq, ivfNlistKey)
+	assert.NotContains(t, pq, ivfPQMKey)
+	assert.NotContains(t, pq, ivfPQNbits)
+
+	// They remain reachable without changing the constructor signature.
+	withNlist := WithExtraIndexParams(NewGPUIVPFlatIndex(entity.L2), map[string]string{
+		ivfNlistKey: "1024",
+	}).Params()
+	assert.Equal(t, "1024", withNlist[ivfNlistKey])
+}
+
+func TestGPUCagraGraphDegreeKey(t *testing.T) {
+	result := NewGPUCagraIndex(entity.L2, 128, 64).Params()
+	// The key used to be declared as `"graph_degree"` — backquotes around a
+	// string that itself contains the quote characters.
+	assert.Equal(t, "64", result["graph_degree"])
+	assert.NotContains(t, result, `"graph_degree"`)
+	assert.Equal(t, "128", result[cagraInterGraphDegreeKey])
+}

--- a/client/index/hnsw.go
+++ b/client/index/hnsw.go
@@ -74,3 +74,233 @@ func (ap hsnwAnnParam) Params() map[string]any {
 	result[hnswEfKey] = ap.ef
 	return result
 }
+
+// WithSeedEf sets the ef used to seed an iterator search (knowhere
+// FaissHnswConfig::seed_ef). Server default 40.
+func (ap hsnwAnnParam) WithSeedEf(seedEf int) hsnwAnnParam {
+	ap.params[hnswSeedEfKey] = seedEf
+	return ap
+}
+
+// The quantized HNSW variants share M / efConstruction with plain HNSW and add
+// their own quantizer params. Note that `M` (graph degree) and `m` (number of
+// PQ sub-quantizers) are two different params — the case is significant.
+//
+// refine is only valid on these three. Plain HNSW maps to knowhere's
+// FaissHnswFlatConfig, whose CheckAndAdjust rejects the build outright with
+// "refine is not supported for this index" if refine or refine_type is set.
+const (
+	hnswSQTypeKey  = `sq_type`
+	hnswPQMKey     = `m`
+	hnswPQNbitsKey = `nbits`
+	hnswPRQNrqKey  = `nrq`
+
+	hnswRefineKey     = `refine`
+	hnswRefineTypeKey = `refine_type`
+	hnswRefineKKey    = `refine_k`
+	hnswSeedEfKey     = `seed_ef`
+)
+
+// hnswQuantIndex carries what the three quantized HNSW variants have in common:
+// the graph params and the optional refine index. Refine keeps full-precision
+// vectors alongside the quantized ones and re-ranks with them, trading storage
+// for recall.
+type hnswQuantIndex struct {
+	baseIndex
+
+	m              int
+	efConstruction int
+	refine         bool
+	refineType     string
+}
+
+func (idx hnswQuantIndex) commonParams(indexType IndexType) map[string]string {
+	result := map[string]string{
+		MetricTypeKey:      string(idx.metricType),
+		IndexTypeKey:       string(indexType),
+		hnswMKey:           strconv.Itoa(idx.m),
+		hsnwEfConstruction: strconv.Itoa(idx.efConstruction),
+	}
+	// Only emitted once the caller opts in, so an index built without refine
+	// does not carry an empty refine_type the server would reject.
+	if idx.refine {
+		result[hnswRefineKey] = strconv.FormatBool(idx.refine)
+		result[hnswRefineTypeKey] = idx.refineType
+	}
+	return result
+}
+
+var _ Index = &hnswSQIndex{}
+
+type hnswSQIndex struct {
+	hnswQuantIndex
+
+	sqType string
+}
+
+func (idx *hnswSQIndex) Params() map[string]string {
+	result := idx.commonParams(HNSWSQ)
+	result[hnswSQTypeKey] = idx.sqType
+	return result
+}
+
+// WithRefineType enables the refine index and sets its precision. knowhere
+// accepts sq4u / sq6 / sq8 / fp16 / bf16 / fp32 / flat.
+func (idx *hnswSQIndex) WithRefineType(refineType string) *hnswSQIndex {
+	idx.refine = true
+	idx.refineType = refineType
+	return idx
+}
+
+// NewHNSWSQIndex creates an HNSW index whose vectors are scalar-quantized.
+// sqType is the quantizer: knowhere accepts sq4u / sq6 / sq8 / fp16 / bf16,
+// and its default is SQ8.
+func NewHNSWSQIndex(metricType MetricType, m int, efConstruction int, sqType string) *hnswSQIndex {
+	return &hnswSQIndex{
+		hnswQuantIndex: hnswQuantIndex{
+			baseIndex: baseIndex{
+				metricType: metricType,
+				indexType:  HNSWSQ,
+			},
+			m:              m,
+			efConstruction: efConstruction,
+		},
+		sqType: sqType,
+	}
+}
+
+var _ Index = &hnswPQIndex{}
+
+type hnswPQIndex struct {
+	hnswQuantIndex
+
+	pqM   int
+	nbits int
+}
+
+func (idx *hnswPQIndex) Params() map[string]string {
+	result := idx.commonParams(HNSWPQ)
+	result[hnswPQMKey] = strconv.Itoa(idx.pqM)
+	result[hnswPQNbitsKey] = strconv.Itoa(idx.nbits)
+	return result
+}
+
+// WithRefineType enables the refine index and sets its precision. knowhere
+// accepts sq4u / sq6 / sq8 / fp16 / bf16 / fp32 / flat.
+func (idx *hnswPQIndex) WithRefineType(refineType string) *hnswPQIndex {
+	idx.refine = true
+	idx.refineType = refineType
+	return idx
+}
+
+// NewHNSWPQIndex creates an HNSW index whose vectors are product-quantized.
+// pqM is the number of sub-quantizers (server default 32) and nbits the bits
+// per sub-quantizer, in [1, 24] (server default 8).
+func NewHNSWPQIndex(metricType MetricType, m int, efConstruction int, pqM int, nbits int) *hnswPQIndex {
+	return &hnswPQIndex{
+		hnswQuantIndex: hnswQuantIndex{
+			baseIndex: baseIndex{
+				metricType: metricType,
+				indexType:  HNSWPQ,
+			},
+			m:              m,
+			efConstruction: efConstruction,
+		},
+		pqM:   pqM,
+		nbits: nbits,
+	}
+}
+
+var _ Index = &hnswPRQIndex{}
+
+type hnswPRQIndex struct {
+	hnswQuantIndex
+
+	pqM   int
+	nrq   int
+	nbits int
+}
+
+func (idx *hnswPRQIndex) Params() map[string]string {
+	result := idx.commonParams(HNSWPRQ)
+	result[hnswPQMKey] = strconv.Itoa(idx.pqM)
+	result[hnswPRQNrqKey] = strconv.Itoa(idx.nrq)
+	result[hnswPQNbitsKey] = strconv.Itoa(idx.nbits)
+	return result
+}
+
+// WithRefineType enables the refine index and sets its precision. knowhere
+// accepts sq4u / sq6 / sq8 / fp16 / bf16 / fp32 / flat.
+func (idx *hnswPRQIndex) WithRefineType(refineType string) *hnswPRQIndex {
+	idx.refine = true
+	idx.refineType = refineType
+	return idx
+}
+
+// NewHNSWPRQIndex creates an HNSW index whose vectors are quantized with a
+// product-residual quantizer. pqM is the number of splits (server default 2),
+// nrq the number of residual quantizers, in [1, 16] (server default 2), and
+// nbits the bits per sub-quantizer, in [1, 24] (server default 8).
+func NewHNSWPRQIndex(metricType MetricType, m int, efConstruction int, pqM int, nrq int, nbits int) *hnswPRQIndex {
+	return &hnswPRQIndex{
+		hnswQuantIndex: hnswQuantIndex{
+			baseIndex: baseIndex{
+				metricType: metricType,
+				indexType:  HNSWPRQ,
+			},
+			m:              m,
+			efConstruction: efConstruction,
+		},
+		pqM:   pqM,
+		nrq:   nrq,
+		nbits: nbits,
+	}
+}
+
+// hnswQuantAnnParam is the search-time param set the three quantized variants
+// share: `ef` as for plain HNSW, plus refine_k (how many candidates the refine
+// index re-ranks) and seed_ef (used by the iterator).
+type hnswQuantAnnParam struct {
+	baseAnnParam
+	ef int
+}
+
+func (ap *hnswQuantAnnParam) Params() map[string]any {
+	result := ap.baseAnnParam.params
+	result[hnswEfKey] = ap.ef
+	return result
+}
+
+// WithRefineK sets how many candidates the refine index re-ranks, as a
+// multiple of the requested top-k: knowhere types it CFG_FLOAT and passes it
+// straight through as faiss::IndexRefineSearchParameters::k_factor, so
+// fractional values such as 1.5 are meaningful. Only useful on an index built
+// with WithRefineType.
+func (ap *hnswQuantAnnParam) WithRefineK(refineK float64) *hnswQuantAnnParam {
+	ap.params[hnswRefineKKey] = refineK
+	return ap
+}
+
+// WithSeedEf sets the ef used to seed an iterator search.
+func (ap *hnswQuantAnnParam) WithSeedEf(seedEf int) *hnswQuantAnnParam {
+	ap.params[hnswSeedEfKey] = seedEf
+	return ap
+}
+
+func newHNSWQuantAnnParam(ef int) *hnswQuantAnnParam {
+	return &hnswQuantAnnParam{
+		baseAnnParam: baseAnnParam{
+			params: make(map[string]any),
+		},
+		ef: ef,
+	}
+}
+
+// NewHNSWSQAnnParam creates the search params for an HNSW_SQ index.
+func NewHNSWSQAnnParam(ef int) *hnswQuantAnnParam { return newHNSWQuantAnnParam(ef) }
+
+// NewHNSWPQAnnParam creates the search params for an HNSW_PQ index.
+func NewHNSWPQAnnParam(ef int) *hnswQuantAnnParam { return newHNSWQuantAnnParam(ef) }
+
+// NewHNSWPRQAnnParam creates the search params for an HNSW_PRQ index.
+func NewHNSWPRQAnnParam(ef int) *hnswQuantAnnParam { return newHNSWQuantAnnParam(ef) }

--- a/client/index/hnsw_test.go
+++ b/client/index/hnsw_test.go
@@ -1,0 +1,107 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/client/v3/entity"
+)
+
+func TestHNSWSQ(t *testing.T) {
+	idx := NewHNSWSQIndex(entity.COSINE, 16, 200, "SQ8")
+
+	result := idx.Params()
+	assert.EqualValues(t, entity.COSINE, result[MetricTypeKey])
+	assert.EqualValues(t, HNSWSQ, result[IndexTypeKey])
+	assert.Equal(t, "16", result[hnswMKey])
+	assert.Equal(t, "200", result[hsnwEfConstruction])
+	assert.Equal(t, "SQ8", result[hnswSQTypeKey])
+}
+
+func TestHNSWPQ(t *testing.T) {
+	idx := NewHNSWPQIndex(entity.L2, 16, 200, 32, 8)
+
+	result := idx.Params()
+	assert.EqualValues(t, entity.L2, result[MetricTypeKey])
+	assert.EqualValues(t, HNSWPQ, result[IndexTypeKey])
+	assert.Equal(t, "16", result[hnswMKey])
+	assert.Equal(t, "200", result[hsnwEfConstruction])
+	// `M` is the graph degree, `m` the number of PQ sub-quantizers: distinct
+	// params that differ only in case, so assert both survive the map.
+	assert.Equal(t, "32", result[hnswPQMKey])
+	assert.NotEqual(t, result[hnswMKey], result[hnswPQMKey])
+	assert.Equal(t, "8", result[hnswPQNbitsKey])
+}
+
+func TestHNSWPRQ(t *testing.T) {
+	idx := NewHNSWPRQIndex(entity.IP, 16, 200, 2, 2, 8)
+
+	result := idx.Params()
+	assert.EqualValues(t, entity.IP, result[MetricTypeKey])
+	assert.EqualValues(t, HNSWPRQ, result[IndexTypeKey])
+	assert.Equal(t, "16", result[hnswMKey])
+	assert.Equal(t, "200", result[hsnwEfConstruction])
+	assert.Equal(t, "2", result[hnswPQMKey])
+	assert.Equal(t, "2", result[hnswPRQNrqKey])
+	assert.Equal(t, "8", result[hnswPQNbitsKey])
+}
+
+func TestHNSWQuantizedRefine(t *testing.T) {
+	// Refine must stay absent unless the caller opts in: an index built without
+	// it would otherwise carry an empty refine_type the server rejects.
+	for _, result := range []map[string]string{
+		NewHNSWSQIndex(entity.L2, 16, 200, "SQ8").Params(),
+		NewHNSWPQIndex(entity.L2, 16, 200, 32, 8).Params(),
+		NewHNSWPRQIndex(entity.L2, 16, 200, 2, 2, 8).Params(),
+	} {
+		assert.NotContains(t, result, hnswRefineKey)
+		assert.NotContains(t, result, hnswRefineTypeKey)
+	}
+
+	result := NewHNSWSQIndex(entity.L2, 16, 200, "SQ8").WithRefineType("FP32").Params()
+	assert.Equal(t, "true", result[hnswRefineKey])
+	assert.Equal(t, "FP32", result[hnswRefineTypeKey])
+
+	result = NewHNSWPQIndex(entity.L2, 16, 200, 32, 8).WithRefineType("SQ8").Params()
+	assert.Equal(t, "true", result[hnswRefineKey])
+	assert.Equal(t, "SQ8", result[hnswRefineTypeKey])
+
+	result = NewHNSWPRQIndex(entity.L2, 16, 200, 2, 2, 8).WithRefineType("BF16").Params()
+	assert.Equal(t, "true", result[hnswRefineKey])
+	assert.Equal(t, "BF16", result[hnswRefineTypeKey])
+}
+
+func TestHNSWQuantizedAnnParam(t *testing.T) {
+	for _, ap := range []*hnswQuantAnnParam{
+		NewHNSWSQAnnParam(64),
+		NewHNSWPQAnnParam(64),
+		NewHNSWPRQAnnParam(64),
+	} {
+		result := ap.Params()
+		assert.Equal(t, 64, result[hnswEfKey])
+		assert.NotContains(t, result, hnswRefineKKey)
+		assert.NotContains(t, result, hnswSeedEfKey)
+
+		result = ap.WithRefineK(1.5).WithSeedEf(32).Params()
+		// refine_k is knowhere's k_factor (CFG_FLOAT), so fractions must survive.
+		assert.Equal(t, 1.5, result[hnswRefineKKey])
+		assert.Equal(t, 32, result[hnswSeedEfKey])
+	}
+}

--- a/client/index/index.go
+++ b/client/index/index.go
@@ -81,3 +81,49 @@ func NewGenericIndex(name string, params map[string]string) GenericIndex {
 		params: params,
 	}
 }
+
+var _ Index = extraParamIndex{}
+
+// Keys the extra-param wrapper refuses to touch: they define which index is
+// being built, and letting them be overridden would put Params() and
+// IndexType() into disagreement.
+var reservedIndexParamKeys = map[string]struct{}{
+	IndexTypeKey:  {},
+	MetricTypeKey: {},
+}
+
+type extraParamIndex struct {
+	Index
+	extra map[string]string
+}
+
+func (idx extraParamIndex) Params() map[string]string {
+	result := idx.Index.Params()
+	for k, v := range idx.extra {
+		if _, reserved := reservedIndexParamKeys[k]; reserved {
+			continue
+		}
+		result[k] = v
+	}
+	return result
+}
+
+// WithExtraIndexParams merges additional raw build params into whatever `idx`
+// produces. index_type and metric_type are reserved and silently ignored:
+// overriding them would make Params() disagree with IndexType(), so use the
+// constructor for the index you actually want. Any other key overrides.
+//
+// The typed constructors model the params each index most needs, not every one
+// the engine accepts, and they necessarily trail the engine as it gains new
+// ones. This is the escape hatch for the rest — the build-side counterpart of
+// baseAnnParam.WithExtraParam — so reaching for a param the constructor does
+// not expose does not mean giving up the constructor for NewGenericIndex and a
+// hand-built map.
+//
+// Params are forwarded verbatim; the server validates names and ranges.
+func WithExtraIndexParams(idx Index, extra map[string]string) Index {
+	return extraParamIndex{
+		Index: idx,
+		extra: extra,
+	}
+}

--- a/client/index/index_test.go
+++ b/client/index/index_test.go
@@ -16,8 +16,52 @@
 
 package index
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/client/v3/entity"
+)
 
 func TestGenericIndex(t *testing.T) {
 	// idx := NewGenericIndex("auto_scalar_index")
+}
+
+func TestWithExtraIndexParams(t *testing.T) {
+	// A param the typed constructor does not model must reach the wire without
+	// giving up the constructor.
+	idx := WithExtraIndexParams(NewHNSWIndex(entity.L2, 16, 200), map[string]string{
+		"refine":      "true",
+		"refine_type": "fp32",
+	})
+
+	result := idx.Params()
+	assert.EqualValues(t, HNSW, result[IndexTypeKey])
+	assert.Equal(t, "16", result[hnswMKey])
+	assert.Equal(t, "true", result["refine"])
+	assert.Equal(t, "fp32", result["refine_type"])
+	assert.EqualValues(t, HNSW, idx.IndexType())
+
+	// Extras win on collision, and the wrapped index is left untouched.
+	base := NewHNSWIndex(entity.L2, 16, 200)
+	wrapped := WithExtraIndexParams(base, map[string]string{hnswMKey: "32"})
+	assert.Equal(t, "32", wrapped.Params()[hnswMKey])
+	assert.Equal(t, "16", base.Params()[hnswMKey])
+}
+
+func TestWithExtraIndexParamsReservedKeys(t *testing.T) {
+	// Overriding index_type would make Params() disagree with IndexType(), so
+	// the reserved keys are ignored rather than honored.
+	idx := WithExtraIndexParams(NewHNSWIndex(entity.L2, 16, 200), map[string]string{
+		IndexTypeKey:  string(IvfFlat),
+		MetricTypeKey: string(entity.IP),
+		"refine_k":    "64",
+	})
+
+	result := idx.Params()
+	assert.EqualValues(t, HNSW, result[IndexTypeKey])
+	assert.EqualValues(t, HNSW, idx.IndexType())
+	assert.EqualValues(t, entity.L2, result[MetricTypeKey])
+	assert.Equal(t, "64", result["refine_k"])
 }

--- a/client/index/ivf.go
+++ b/client/index/ivf.go
@@ -26,8 +26,12 @@ const (
 	ivfRefineKey     = `refine`
 	ivfRefineTypeKey = `refine_type`
 
-	ivfRbqQueryBitsKey = `rbq_query_bits`
+	// knowhere's IvfRaBitQConfig declares the field as rbq_bits_query and
+	// KNOWHERE_CONFIG_DECLARE_FIELD stringifies the field name into the JSON
+	// key, so the transposed spelling reached no consumer.
+	ivfRbqQueryBitsKey = `rbq_bits_query`
 	ivfRbqRefineKKey   = `refine_k`
+	ivfRbqBitsKey      = `rbq_bits`
 )
 
 var _ Index = ivfFlatIndex{}
@@ -121,6 +125,8 @@ type ivfRabitQIndex struct {
 	baseIndex
 
 	nlist      int
+	rbqBits    int
+	rbqBitsSet bool
 	refine     bool
 	refineType string
 }
@@ -132,11 +138,24 @@ func (idx *ivfRabitQIndex) Params() map[string]string {
 		ivfNlistKey:   strconv.Itoa(idx.nlist),
 	}
 
+	// Forwarded as given once set, so an out-of-range value is rejected by the
+	// server rather than silently falling back to the default.
+	if idx.rbqBitsSet {
+		result[ivfRbqBitsKey] = strconv.Itoa(idx.rbqBits)
+	}
 	if idx.refine {
 		result[ivfRefineKey] = strconv.FormatBool(idx.refine)
 		result[ivfRefineTypeKey] = idx.refineType
 	}
 	return result
+}
+
+// WithRbqBits sets how many bits each dimension is quantized to at build time,
+// in [1, 9]. The server default is 1, applied when this is never called.
+func (idx *ivfRabitQIndex) WithRbqBits(rbqBits int) *ivfRabitQIndex {
+	idx.rbqBits = rbqBits
+	idx.rbqBitsSet = true
+	return idx
 }
 
 func (idx *ivfRabitQIndex) WithRefineType(refineType string) *ivfRabitQIndex {
@@ -149,7 +168,9 @@ func NewIvfRabitQIndex(metricType MetricType, nlist int) *ivfRabitQIndex {
 	return &ivfRabitQIndex{
 		baseIndex: baseIndex{
 			metricType: metricType,
-			indexType:  BinIvfFlat,
+			// Params() has always emitted IVF_RABITQ; indexType was left on
+			// BinIvfFlat, so IndexType() reported BIN_IVF_FLAT for a RaBitQ index.
+			indexType: IvfRabitQ,
 		},
 
 		nlist: nlist,

--- a/client/index/ivf_test.go
+++ b/client/index/ivf_test.go
@@ -53,8 +53,26 @@ func TestIvfRabitQAnnParam(t *testing.T) {
 	ap = ap.WithRabitQueryBits(8)
 	result = ap.Params()
 	assert.Equal(t, 8, result[ivfRbqQueryBitsKey])
+	// Pin the wire name: knowhere reads rbq_bits_query, and a transposed key
+	// silently leaves the search on the default instead of erroring.
+	assert.Equal(t, 8, result["rbq_bits_query"])
 
 	ap = ap.WithRefineK(256)
 	result = ap.Params()
 	assert.Equal(t, 256, result[ivfRbqRefineKKey])
+}
+
+func TestIvfRabitQBits(t *testing.T) {
+	idx := NewIvfRabitQIndex(entity.COSINE, 128)
+	// Params() has always reported IVF_RABITQ; IndexType() used to disagree.
+	assert.EqualValues(t, IvfRabitQ, idx.IndexType())
+	assert.EqualValues(t, IvfRabitQ, idx.Params()[IndexTypeKey])
+
+	// Never set: absent, so the server's default applies.
+	assert.NotContains(t, idx.Params(), ivfRbqBitsKey)
+	assert.Equal(t, "5", idx.WithRbqBits(5).Params()[ivfRbqBitsKey])
+
+	// Explicitly set to an out-of-range value: forwarded so the server rejects
+	// it, instead of being mistaken for "unset".
+	assert.Equal(t, "0", NewIvfRabitQIndex(entity.COSINE, 128).WithRbqBits(0).Params()[ivfRbqBitsKey])
 }

--- a/client/index/scalar.go
+++ b/client/index/scalar.go
@@ -16,9 +16,23 @@
 
 package index
 
+import "strconv"
+
+// Scalar index build param keys. The server rejects unknown or out-of-range
+// values, so these mirror the checkers in internal/util/indexparamcheck.
+const (
+	ngramMinGramKey = `min_gram`
+	ngramMaxGramKey = `max_gram`
+
+	fmIndexSaSampleRateKey = `fm_sa_sample_rate`
+	fmIndexBlockBytesKey   = `fm_block_bytes`
+)
+
 type scalarIndex struct {
 	name      string
 	indexType IndexType
+	// extra build params; nil for the index types that take none
+	params map[string]string
 }
 
 func (idx scalarIndex) Name() string {
@@ -30,9 +44,13 @@ func (idx scalarIndex) IndexType() IndexType {
 }
 
 func (idx scalarIndex) Params() map[string]string {
-	return map[string]string{
+	result := map[string]string{
 		IndexTypeKey: string(idx.indexType),
 	}
+	for k, v := range idx.params {
+		result[k] = v
+	}
+	return result
 }
 
 var _ Index = scalarIndex{}
@@ -58,5 +76,85 @@ func NewSortedIndex() Index {
 func NewBitmapIndex() Index {
 	return scalarIndex{
 		indexType: BITMAP,
+	}
+}
+
+// NewNgramIndex creates an NGRAM index for VARCHAR fields and JSON paths. By
+// indexing every n-gram in [minGram, maxGram] it accelerates the substring
+// operators — LIKE prefix / infix / suffix and regex match. TEXT_MATCH is a
+// different index (TextMatchIndex) and is not served by this one.
+// Both bounds are mandatory: the server rejects an NGRAM index that omits
+// either, so there is no default to fall back to.
+func NewNgramIndex(minGram, maxGram int) Index {
+	return scalarIndex{
+		indexType: NGRAM,
+		params: map[string]string{
+			ngramMinGramKey: strconv.Itoa(minGram),
+			ngramMaxGramKey: strconv.Itoa(maxGram),
+		},
+	}
+}
+
+var _ Index = &FMIndex{}
+
+// FMIndex is the pre-defined index model for the FM-index scalar index: an
+// exact byte-level substring index for VARCHAR that answers anchored LIKE
+// (prefix / infix / suffix) with no candidate recheck.
+//
+// Both build params are optional; leave them unset to take the server defaults.
+type FMIndex struct {
+	scalarIndex
+
+	// Recorded verbatim once a setter is called. Gating on a positive value
+	// instead would make an explicitly invalid argument indistinguishable from
+	// an omitted one, and quietly build with the default rather than letting
+	// the server reject it.
+	buildParams map[string]string
+}
+
+// WithIndexName setup the index name of FMIndex.
+func (idx *FMIndex) WithIndexName(name string) *FMIndex {
+	idx.name = name
+	return idx
+}
+
+// WithSaSampleRate sets the suffix-array sampling rate, trading index size
+// against locate latency (it does not affect count-only queries). Must be in
+// [4, 256]; the server default is 8.
+func (idx *FMIndex) WithSaSampleRate(rate int) *FMIndex {
+	idx.buildParams[fmIndexSaSampleRateKey] = strconv.Itoa(rate)
+	return idx
+}
+
+// WithBlockBytes sets the rank-directory block granularity in bytes. Must be a
+// power of two in [8, 128]; the server default is 64. Larger blocks shrink the
+// resident directory at no throughput cost up to ~64.
+func (idx *FMIndex) WithBlockBytes(blockBytes int) *FMIndex {
+	idx.buildParams[fmIndexBlockBytesKey] = strconv.Itoa(blockBytes)
+	return idx
+}
+
+// Params implements Index interface
+// returns the create index related parameters.
+func (idx *FMIndex) Params() map[string]string {
+	result := map[string]string{
+		IndexTypeKey: string(idx.indexType),
+	}
+	// A param the caller never set stays absent so the server applies its own
+	// default; one the caller did set is forwarded as given, valid or not, so
+	// the server's range check is what reports the mistake.
+	for k, v := range idx.buildParams {
+		result[k] = v
+	}
+	return result
+}
+
+// NewFMIndex creates an `FMIndex` with the server's default build params.
+func NewFMIndex() *FMIndex {
+	return &FMIndex{
+		scalarIndex: scalarIndex{
+			indexType: FMINDEX,
+		},
+		buildParams: make(map[string]string),
 	}
 }

--- a/client/index/scalar_test.go
+++ b/client/index/scalar_test.go
@@ -39,6 +39,8 @@ func (s *ScalarIndexSuite) TestConstructors() {
 		{tag: "Sorted", input: NewSortedIndex(), expectIndexType: Sorted},
 		{tag: "Inverted", input: NewInvertedIndex(), expectIndexType: Inverted},
 		{tag: "Bitmap", input: NewBitmapIndex(), expectIndexType: BITMAP},
+		{tag: "Ngram", input: NewNgramIndex(2, 3), expectIndexType: NGRAM},
+		{tag: "FMIndex", input: NewFMIndex(), expectIndexType: FMINDEX},
 	}
 
 	for _, tc := range testcases {
@@ -56,6 +58,36 @@ func (s *ScalarIndexSuite) TestConstructors() {
 			}
 		})
 	}
+}
+
+func (s *ScalarIndexSuite) TestNgramParams() {
+	// Both bounds are mandatory server-side, so they must always be emitted.
+	params := NewNgramIndex(2, 4).Params()
+	s.Equal("2", params[ngramMinGramKey])
+	s.Equal("4", params[ngramMaxGramKey])
+}
+
+func (s *ScalarIndexSuite) TestFMIndexInvalidValuesAreSentVerbatim() {
+	// An explicitly invalid argument must reach the server, which rejects it,
+	// rather than being swallowed and silently building with the default.
+	params := NewFMIndex().WithSaSampleRate(-1).WithBlockBytes(0).Params()
+	s.Equal("-1", params[fmIndexSaSampleRateKey])
+	s.Equal("0", params[fmIndexBlockBytesKey])
+}
+
+func (s *ScalarIndexSuite) TestFMIndexParams() {
+	// Unset build params must stay absent so the server applies its defaults
+	// instead of receiving a zero.
+	params := NewFMIndex().Params()
+	s.NotContains(params, fmIndexSaSampleRateKey)
+	s.NotContains(params, fmIndexBlockBytesKey)
+
+	idx := NewFMIndex().WithSaSampleRate(16).WithBlockBytes(32).WithIndexName("fm_idx")
+	params = idx.Params()
+	s.Equal("16", params[fmIndexSaSampleRateKey])
+	s.Equal("32", params[fmIndexBlockBytesKey])
+	s.EqualValues(FMINDEX, params[IndexTypeKey])
+	s.Equal("fm_idx", idx.Name())
 }
 
 func TestScalarIndexes(t *testing.T) {

--- a/client/index/sparse.go
+++ b/client/index/sparse.go
@@ -6,6 +6,11 @@ import (
 
 const (
 	dropRatio = `drop_ratio_build`
+
+	sparseDropRatioSearchKey  = `drop_ratio_search`
+	sparseSearchAlgoKey       = `search_algo`
+	sparseRefineFactorKey     = `refine_factor`
+	sparseDimMaxScoreRatioKey = `dim_max_score_ratio`
 )
 
 var _ Index = sparseInvertedIndex{}
@@ -75,5 +80,26 @@ func NewSparseAnnParam() sparseAnnParam {
 }
 
 func (b sparseAnnParam) WithDropRatio(dropRatio float64) {
-	b.WithExtraParam("drop_ratio_search", dropRatio)
+	b.WithExtraParam(sparseDropRatioSearchKey, dropRatio)
+}
+
+// WithSearchAlgo overrides the traversal algorithm for this search. Defaults to
+// "INHERIT", i.e. whatever the index was built with.
+func (b sparseAnnParam) WithSearchAlgo(algo string) sparseAnnParam {
+	b.WithExtraParam(sparseSearchAlgoKey, algo)
+	return b
+}
+
+// WithRefineFactor sets how many extra candidates are gathered before refining
+// against the full values. Server default 1.
+func (b sparseAnnParam) WithRefineFactor(refineFactor int) sparseAnnParam {
+	b.WithExtraParam(sparseRefineFactorKey, refineFactor)
+	return b
+}
+
+// WithDimMaxScoreRatio tunes the block-max pruning threshold. Server default
+// 1.05.
+func (b sparseAnnParam) WithDimMaxScoreRatio(ratio float64) sparseAnnParam {
+	b.WithExtraParam(sparseDimMaxScoreRatioKey, ratio)
+	return b
 }


### PR DESCRIPTION
issue: #52095
design doc: docs/design-docs/design_docs/20260708-fm_index_scalar_index.md

The design doc covers `FMINDEX`, the one genuinely new index type here; it landed
on master with the server implementation in #51375. The other five types this PR
adds — `NGRAM`, `HNSW_SQ`, `HNSW_PQ`, `HNSW_PRQ`, `AISAQ` — are existing engine
capabilities that the Go client had simply never declared, and the rest of the
change is bug fixes, so neither needs a design of its own.

`client/index` had drifted behind the server. Audited it against the index checker
registry (`internal/util/indexparamcheck/conf_adapter_mgr.go`), the knowhere v3.0.6
config classes — the version Milvus pins — and the Java / C++ / Rust / Node SDKs.

### Missing index types

| | |
|---|---|
| scalar | `NGRAM`, `FMINDEX` |
| vector | `HNSW_SQ`, `HNSW_PQ`, `HNSW_PRQ`, `AISAQ` |

All but `FMINDEX` already exist in the Java, C++ and Rust SDKs; `NGRAM` has been on
master for a while and simply never reached this client, so a Go user had to fall
back to `NewGenericIndex` with a hand-built param map, and `DescribeIndex` returned
a type the package had no constant for.

New constructors follow the shape each family already uses — `NewNgramIndex`,
`NewFMIndex`, `NewHNSWSQ/PQ/PRQIndex` with matching AnnParams, and `NewAISAQIndex`.

`refine` is deliberately confined to the three quantized HNSW variants. Plain HNSW
maps to `FaissHnswFlatConfig`, whose `CheckAndAdjust` rejects the build with
`refine is not supported for this index` if `refine` or `refine_type` is set, so
exposing it there would only produce failures.

### Bugs fixed, all surfaced by the same audit

- `WithRabitQueryBits` emitted `rbq_query_bits`. knowhere's `IvfRaBitQConfig`
  declares the field as `rbq_bits_query`, and `KNOWHERE_CONFIG_DECLARE_FIELD`
  stringifies the field name into the JSON key, so the transposed spelling reached
  no consumer. It appears nowhere else in the repo — the server's own e2e tests pass
  `rbq_bits_query` and the out-of-range error they assert on quotes it. Unknown
  search params are not rejected, so callers setting query bits silently got 0.
- `NewIvfRabitQIndex` set `baseIndex.indexType` to `BinIvfFlat`, so `IndexType()`
  reported `BIN_IVF_FLAT` while `Params()` emitted `IVF_RABITQ`.
- `gpuIVFPQIndex` and `gpuCagra` both emitted `IndexTypeKey: GPUIvfFlat`, so
  `NewGPUIVPPQIndex` and `NewGPUCagraIndex` built `GPU_IVF_FLAT` indexes — the
  latter with CAGRA-only graph params attached to it.
- `cagraGraphDegreeKey` was `` `"graph_degree"` ``; the backquoted literal contains
  the quote characters, so the emitted key matched nothing.
- None of the four GPU builders set `baseIndex.indexType`, so `IndexType()` returned
  `""` for all of them.
- `gpuIVFFlatIndex` / `gpuIVFPQIndex` emitted `nlist` / `m` / `nbits` as `"0"`,
  because the constructors never accepted them. Zero is below every accepted range,
  so the build was rejected outright; they are now omitted so the server applies its
  default, and remain reachable through `WithExtraIndexParams`.

### Compatibility

Existing constructors are untouched — same parameters, same `Index` return type — so
callers that take them as function values still compile. Verified by diffing every
`New*` signature against the base commit, and `go vet` passes on `tests/go_client`,
which exercises these constructors throughout.

Params the typed constructors do not model are reachable through
`WithExtraIndexParams`, which merges raw params into any `Index`. `index_type` and
`metric_type` are reserved there: overriding them would put `Params()` and
`IndexType()` into disagreement. This matches how pymilvus behaves — it forwards
whatever param dict it is given (its `valid_index_params_keys` frozenset is dead
code, referenced nowhere and still listing `n_trees` and `PQM` from the Annoy era).

Also adds the search params that only needed a method on an existing type:
`hsnwAnnParam.WithSeedEf`, `diskANNParam.WithBeamwidth`, and `sparseAnnParam`'s
`WithSearchAlgo` / `WithRefineFactor` / `WithDimMaxScoreRatio`.

Opt-in params distinguish "never set" from "set to something invalid": a value the
caller supplied is forwarded verbatim so the server's range check reports the
mistake, rather than being mistaken for an omission and silently replaced by the
default.

### Known follow-up, not addressed here

`ivfRabitQAnnParam.WithRefineK` takes an `int`, but knowhere types `refine_k` as
`CFG_FLOAT` and passes it through as `faiss::IndexRefineSearchParameters::k_factor`
— a multiple of top-k, so `1.5` is meaningful and currently inexpressible. The new
`hnswQuantAnnParam.WithRefineK` takes a `float64`; changing the existing one would
break source compatibility, so it is left for a maintainer decision.

### Not added

`SCANN_DVR`, `IVF_FLAT_CC`, `IVF_SQ_CC`, `IVF_RABITQ_FASTSCAN`, `SVS_*`,
`SPARSE_*_CC` and the `GPU_FAISS_*` / `GPU_CUVS_*` families. They exist in knowhere
but no SDK exposes them; they are internal or experimental.

Also left alone: the stale `IVF_HNSW` constant. The server no longer supports it,
but removing it would break anyone still referencing it.

### Testing

`go build`, `go vet` and `go test ./index/...` pass on the client module; `go vet`
passes on `tests/go_client`.
