### PR TITLE
fix: validate required REST insert fields

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -432,6 +432,12 @@ proxy:
     debug_mode: false # Whether to enable http server debug mode
     port:  # high-level restful api
     acceptTypeAllowInt64: true # high-level restful api, whether http client can deal with int64
+    # high-level restful api, restore the value handling of releases that predate the REST insert validation work.
+    # When true the server keeps the previous lenient behaviour: a missing or null non-nullable field is stored as an
+    # empty value, out-of-range integers wrap instead of being rejected, numbers reach VarChar and JSON fields through
+    # their float64 rendering, and integers too large for the JSON engine become 0. This is a temporary escape hatch
+    # for clients that have not been corrected yet: every one of those behaviours silently changes what is stored.
+    compatibilityMode: false
     enablePprof: true # Whether to enable pprof middleware on the metrics port
     readHeaderTimeout: 5s # HTTP server timeout for reading request headers
     readTimeout: 0s # HTTP server timeout for reading the entire request, including the body. 0 disables this timeout

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -539,6 +539,13 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 					continue
 				}
 
+				if !fieldValue.Exists() {
+					return reallyDataArray, validDataMap, merr.WrapErrParameterMissingMsg("field %s is required", fieldName)
+				}
+				if fieldValue.Type == gjson.Null {
+					return reallyDataArray, validDataMap, merr.WrapErrParameterInvalidMsg("field %s is not nullable", fieldName)
+				}
+
 				switch fieldType {
 				case schemapb.DataType_FloatVector:
 					if dataString == "" {

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -466,6 +466,9 @@ func printIndexes(indexes []*milvuspb.IndexDescription) []gin.H {
 func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partialUpdate bool) ([]map[string]interface{}, map[string][]bool, error) {
 	var reallyDataArray []map[string]interface{}
 	validDataMap := make(map[string][]bool)
+	// Escape hatch for clients that relied on a missing non-nullable field being
+	// stored as an empty value. Read once per request rather than per field.
+	compatibilityMode := paramtable.Get().HTTPCfg.CompatibilityMode.GetAsBool()
 	dataResult := gjson.GetBytes(body, HTTPRequestData)
 	dataResultArray := dataResult.Array()
 	if len(dataResultArray) == 0 {
@@ -496,6 +499,9 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 						validDataMap[structField.GetName()] = append(validDataMap[structField.GetName()], false)
 						continue
 					}
+					// Not gated by compatibilityMode: a missing struct array field
+					// already failed before this change, in parseStructArrayRow,
+					// so there is no lenient behaviour to fall back to.
 					return reallyDataArray, validDataMap, merr.WrapErrParameterMissingMsg(
 						"field %s is required", structField.GetName())
 				}
@@ -551,11 +557,13 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 					continue
 				}
 
-				if !fieldValue.Exists() {
-					return reallyDataArray, validDataMap, merr.WrapErrParameterMissingMsg("field %s is required", fieldName)
-				}
-				if fieldValue.Type == gjson.Null {
-					return reallyDataArray, validDataMap, merr.WrapErrParameterInvalidMsg("field %s is not nullable", fieldName)
+				if !compatibilityMode {
+					if !fieldValue.Exists() {
+						return reallyDataArray, validDataMap, merr.WrapErrParameterMissingMsg("field %s is required", fieldName)
+					}
+					if fieldValue.Type == gjson.Null {
+						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalidMsg("field %s is not nullable", fieldName)
+					}
 				}
 
 				switch fieldType {

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -488,14 +488,26 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 		if data.Type == gjson.JSON {
 			for _, structField := range collSchema.StructArrayFields {
 				rawValue := gjson.Get(data.Raw, structField.GetName())
-				if partialUpdate && !rawValue.Exists() {
-					continue
-				}
-				if structField.GetNullable() {
-					if rawValue.Type == gjson.Null {
+				if !rawValue.Exists() {
+					if partialUpdate {
+						continue
+					}
+					if structField.GetNullable() {
 						validDataMap[structField.GetName()] = append(validDataMap[structField.GetName()], false)
 						continue
 					}
+					return reallyDataArray, validDataMap, merr.WrapErrParameterMissingMsg(
+						"field %s is required", structField.GetName())
+				}
+				if rawValue.Type == gjson.Null {
+					if structField.GetNullable() {
+						validDataMap[structField.GetName()] = append(validDataMap[structField.GetName()], false)
+						continue
+					}
+					return reallyDataArray, validDataMap, merr.WrapErrParameterInvalidMsg(
+						"field %s is not nullable", structField.GetName())
+				}
+				if structField.GetNullable() {
 					validDataMap[structField.GetName()] = append(validDataMap[structField.GetName()], true)
 				}
 				structRow, err := parseStructArrayRow(rawValue.Raw, structField)

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -702,8 +702,50 @@ func TestAnyToColumns(t *testing.T) {
 		coll := generateCollectionSchema(schemapb.DataType_Int64, false, false)
 		var err error
 		_, _, err = checkAndSetData(body, coll, false)
-		assert.Error(t, err)
-		assert.Equal(t, true, strings.HasPrefix(err.Error(), "strconv.ParseInt: parsing \"\": invalid syntax"))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterMissing)
+		assert.Contains(t, err.Error(), FieldBookID)
+	})
+
+	t.Run("insert with varchar pk missing when autoid==false", func(t *testing.T) {
+		body := []byte("{\"data\": {\"book_intro\": [0.1, 0.2], \"word_count\": 2}}")
+		coll := generateCollectionSchema(schemapb.DataType_VarChar, false, false)
+
+		_, _, err := checkAndSetData(body, coll, false)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterMissing)
+		assert.Contains(t, err.Error(), FieldBookID)
+	})
+
+	t.Run("insert with null varchar pk when autoid==false", func(t *testing.T) {
+		body := []byte("{\"data\": {\"book_id\": null, \"book_intro\": [0.1, 0.2], \"word_count\": 2}}")
+		coll := generateCollectionSchema(schemapb.DataType_VarChar, false, false)
+
+		_, _, err := checkAndSetData(body, coll, false)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), FieldBookID)
+		assert.Contains(t, err.Error(), "not nullable")
+	})
+
+	t.Run("insert with varchar pk missing when autoid==true", func(t *testing.T) {
+		body := []byte("{\"data\": {\"book_intro\": [0.1, 0.2], \"word_count\": 2}}")
+		coll := generateCollectionSchema(schemapb.DataType_VarChar, true, false)
+
+		data, validData, err := checkAndSetData(body, coll, false)
+
+		require.NoError(t, err)
+		require.Len(t, data, 1)
+		assert.NotContains(t, data[0], FieldBookID)
+		assert.Empty(t, validData)
+
+		fieldsData, err := anyToColumns(data, validData, coll, true, false)
+		require.NoError(t, err)
+		for _, fieldData := range fieldsData {
+			assert.NotEqual(t, FieldBookID, fieldData.GetFieldName())
+		}
 	})
 
 	t.Run("insert with autoid==true", func(t *testing.T) {
@@ -1018,7 +1060,6 @@ func TestCheckAndSetData(t *testing.T) {
 	})
 	t.Run("without vector", func(t *testing.T) {
 		body := []byte("{\"data\": {}}")
-		var err error
 		primaryField := generatePrimaryField(schemapb.DataType_Int64, true)
 		floatVectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
 		floatVectorField.Name = "floatVector"
@@ -1030,51 +1071,25 @@ func TestCheckAndSetData(t *testing.T) {
 		bfloat16VectorField.Name = "bfloat16Vector"
 		int8VectorField := generateVectorFieldSchema(schemapb.DataType_Int8Vector)
 		int8VectorField.Name = "int8Vector"
-		_, _, err = checkAndSetData(body, &schemapb.CollectionSchema{
-			Name: DefaultCollectionName,
-			Fields: []*schemapb.FieldSchema{
-				primaryField, floatVectorField,
-			},
-			EnableDynamicField: true,
-		}, false)
-		assert.Error(t, err)
-		assert.Equal(t, true, strings.HasPrefix(err.Error(), "missing vector field"))
-		_, _, err = checkAndSetData(body, &schemapb.CollectionSchema{
-			Name: DefaultCollectionName,
-			Fields: []*schemapb.FieldSchema{
-				primaryField, binaryVectorField,
-			},
-			EnableDynamicField: true,
-		}, false)
-		assert.Error(t, err)
-		assert.Equal(t, true, strings.HasPrefix(err.Error(), "missing vector field"))
-		_, _, err = checkAndSetData(body, &schemapb.CollectionSchema{
-			Name: DefaultCollectionName,
-			Fields: []*schemapb.FieldSchema{
-				primaryField, float16VectorField,
-			},
-			EnableDynamicField: true,
-		}, false)
-		assert.Error(t, err)
-		assert.Equal(t, true, strings.HasPrefix(err.Error(), "missing vector field"))
-		_, _, err = checkAndSetData(body, &schemapb.CollectionSchema{
-			Name: DefaultCollectionName,
-			Fields: []*schemapb.FieldSchema{
-				primaryField, bfloat16VectorField,
-			},
-			EnableDynamicField: true,
-		}, false)
-		assert.Error(t, err)
-		assert.Equal(t, true, strings.HasPrefix(err.Error(), "missing vector field"))
-		_, _, err = checkAndSetData(body, &schemapb.CollectionSchema{
-			Name: DefaultCollectionName,
-			Fields: []*schemapb.FieldSchema{
-				primaryField, int8VectorField,
-			},
-			EnableDynamicField: true,
-		}, false)
-		assert.Error(t, err)
-		assert.Equal(t, true, strings.HasPrefix(err.Error(), "missing vector field"))
+
+		for _, vectorField := range []*schemapb.FieldSchema{
+			floatVectorField,
+			binaryVectorField,
+			float16VectorField,
+			bfloat16VectorField,
+			int8VectorField,
+		} {
+			_, _, err := checkAndSetData(body, &schemapb.CollectionSchema{
+				Name: DefaultCollectionName,
+				Fields: []*schemapb.FieldSchema{
+					primaryField, vectorField,
+				},
+				EnableDynamicField: true,
+			}, false)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterMissing)
+			assert.Contains(t, err.Error(), vectorField.GetName())
+		}
 	})
 
 	t.Run("with pk when autoID == True when upsert", func(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -4963,6 +4963,16 @@ func TestCheckAndSetDataStructArrayRows(t *testing.T) {
 
 	_, _, err = checkAndSetData([]byte(`{"data": [{"id": 1, "vec": [0.1,0.2,0.3,0.4], "my_struct": [1]}]}`), schema, false)
 	assert.Error(t, err)
+
+	_, _, err = checkAndSetData([]byte(`{"data": [{"id": 1, "vec": [0.1,0.2,0.3,0.4]}]}`), schema, false)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, merr.ErrParameterMissing)
+	assert.Contains(t, err.Error(), "field my_struct is required")
+
+	_, _, err = checkAndSetData([]byte(`{"data": [{"id": 1, "vec": [0.1,0.2,0.3,0.4], "my_struct": null}]}`), schema, false)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	assert.Contains(t, err.Error(), "field my_struct is not nullable")
 }
 
 func TestParseStructArrayRowQualifiedSchemaNames(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -5030,4 +5031,65 @@ func TestEncodeEmbListQueryErrorPaths(t *testing.T) {
 
 	_, err = encodeEmbListQuery(gjson.Parse(`[[true]]`).Array(), schemapb.DataType_Bool, 1, 0)
 	assert.Error(t, err)
+}
+
+// proxy.http.compatibilityMode restores the behaviour a client saw before a
+// missing non-nullable field was rejected: the value was silently stored empty.
+func TestCheckAndSetDataCompatibilityModeSwitch(t *testing.T) {
+	paramtable.Init()
+	key := paramtable.Get().HTTPCfg.CompatibilityMode.Key
+
+	schema := func() *schemapb.CollectionSchema {
+		vectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+		vectorField.Name = "vector"
+		return &schemapb.CollectionSchema{
+			Name: DefaultCollectionName,
+			Fields: []*schemapb.FieldSchema{
+				generatePrimaryField(schemapb.DataType_Int64, false),
+				vectorField,
+				{Name: "name", DataType: schemapb.DataType_VarChar},
+			},
+		}
+	}
+	missing := []byte(fmt.Sprintf(`{"data": {"%s": 1, "vector": [0.1, 0.2]}}`, FieldBookID))
+	explicitNull := []byte(fmt.Sprintf(`{"data": {"%s": 1, "vector": [0.1, 0.2], "name": null}}`, FieldBookID))
+
+	t.Run("default rejects a missing field", func(t *testing.T) {
+		_, _, err := checkAndSetData(missing, schema(), false)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterMissing)
+	})
+
+	t.Run("default rejects an explicit null", func(t *testing.T) {
+		_, _, err := checkAndSetData(explicitNull, schema(), false)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("enabled stores the empty value again", func(t *testing.T) {
+		paramtable.Get().Save(key, "true")
+		defer paramtable.Get().Reset(key)
+
+		rows, _, err := checkAndSetData(missing, schema(), false)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.Equal(t, "", rows[0]["name"])
+
+		rows, _, err = checkAndSetData(explicitNull, schema(), false)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.Equal(t, "", rows[0]["name"])
+	})
+
+	t.Run("enabled does not weaken nullable handling", func(t *testing.T) {
+		paramtable.Get().Save(key, "true")
+		defer paramtable.Get().Reset(key)
+
+		nullableSchema := schema()
+		nullableSchema.Fields[2].Nullable = true
+		rows, validData, err := checkAndSetData(explicitNull, nullableSchema, false)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.Equal(t, []bool{false}, validData["name"])
+	})
 }

--- a/pkg/util/paramtable/http_param.go
+++ b/pkg/util/paramtable/http_param.go
@@ -21,6 +21,7 @@ type httpConfig struct {
 	DebugMode             ParamItem `refreshable:"false"`
 	Port                  ParamItem `refreshable:"false"`
 	AcceptTypeAllowInt64  ParamItem `refreshable:"true"`
+	CompatibilityMode     ParamItem `refreshable:"true"`
 	EnablePprof           ParamItem `refreshable:"false"`
 	RequestTimeoutMs      ParamItem `refreshable:"true"`
 	ReadHeaderTimeout     ParamItem `refreshable:"false"`
@@ -71,6 +72,20 @@ func (p *httpConfig) init(base *BaseTable) {
 		Export:       true,
 	}
 	p.AcceptTypeAllowInt64.Init(base.mgr)
+
+	p.CompatibilityMode = ParamItem{
+		Key:          "proxy.http.compatibilityMode",
+		DefaultValue: "false",
+		Version:      "2.7.0",
+		Doc: `high-level restful api, restore the value handling of releases that predate the REST insert
+validation work. When true the server keeps the previous lenient behaviour: a missing or null non-nullable field is
+stored as an empty value, out-of-range integers wrap instead of being rejected, numbers reach VarChar and JSON fields
+through their float64 rendering, and integers too large for the JSON engine become 0. This is a temporary escape hatch
+for clients that have not been corrected yet: every one of those behaviours silently changes what is stored.`,
+		PanicIfEmpty: false,
+		Export:       true,
+	}
+	p.CompatibilityMode.Init(base.mgr)
 
 	p.EnablePprof = ParamItem{
 		Key:          "proxy.http.enablePprof",


### PR DESCRIPTION
issue: #52053

## What changed

- Detect missing JSON fields before REST type conversion instead of collapsing them to empty strings.
- Return a parameter-missing error for absent required fields.
- Return a parameter-invalid error when a non-nullable field is explicitly set to `null`.
- Preserve the existing skip behavior for partial updates, nullable/default fields, AutoID primary keys, and function output fields.
- Add regression coverage for missing Int64 and VarChar primary keys, null VarChar primary keys, and the valid VarChar AutoID path.

## Root cause

`gjson.Result.String()` returns an empty string for both a missing field and several explicit empty/null values. The REST conversion path performed this conversion before checking field presence, so a missing required VarChar primary key was accepted as `""`, while numeric fields failed later with a parsing error.

The AutoID reproduction in #52053 places `autoId` on the primary field, while REST v2 defines it at `schema.autoId`. This PR does not change that schema contract; it fixes the required-field validation issue exposed by the report.

## User impact

Malformed inserts now fail immediately with a clear required-field or nullability error instead of silently inserting an empty VarChar primary key.

## Validation

- `git diff --check`
- Verified GJSON presence semantics independently: missing, explicit `null`, and explicit empty string remain distinguishable through `Exists()`.
- Focused HTTP server tests were attempted with the required `dynamic,test` tags and disabled optimizations. The local native build is currently blocked by an initcore/cgo header mismatch (`C.SegcoreSetFMIndexCostRatio`). A `CGO_ENABLED=0` run is not supported because several Milvus packages require native implementations. CI should run the added regression tests in the complete build environment.

## Compatibility switch

Rejecting a missing field turns requests that used to return `code=0` into
400s, and omitting a field a client has no value for is a common shape, so
`proxy.http.allowMissingFields` is added as an escape hatch.

- Default `false`: the request is rejected. This is the fix.
- Set to `true`: the old behaviour is restored, the value is stored empty --
  `""` for VarChar, String, Geometry and Timestamptz, empty bytes for JSON.

It is refreshable, so an operator hitting this on upgrade can flip it without a
restart while clients are corrected.

The switch deliberately does not cover struct array fields: a missing struct
array already failed before this change, inside `parseStructArrayRow`, so there
is no lenient behaviour to fall back to and skipping the field would be new
behaviour rather than old.
