### PR TITLE
fix: preserve int64 precision for REST dynamic-field values > 2^53

### DIFF
--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -17,6 +17,7 @@
 package httpserver
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -2786,7 +2787,14 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 					} else {
 						var dataMap map[string]interface{}
 
-						err := json.Unmarshal(fieldDataList[j].GetScalars().GetJsonData().Data[dataIdx], &dataMap)
+						// Decode with UseNumber so numeric dynamic-field values are kept as
+						// json.Number instead of float64. float64 only has a 53-bit mantissa,
+						// so integers larger than 2^53 (e.g. 9223372036854775807) silently lose
+						// precision when round-tripped through the REST response. json.Number
+						// preserves the exact digits and serializes back as the same integer.
+						decoder := json.NewDecoder(bytes.NewReader(fieldDataList[j].GetScalars().GetJsonData().Data[dataIdx]))
+						decoder.UseNumber()
+						err := decoder.Decode(&dataMap)
 						if err != nil {
 							mlog.Error(context.TODO(),
 								fmt.Sprintf("[BuildQueryResp] Unmarshal error %s", err.Error()))

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -1855,6 +1855,50 @@ func TestBuildQueryResp(t *testing.T) {
 	assert.Equal(t, true, compareRows(rows, exceptRows, compareRow))
 }
 
+func TestBuildQueryRespDynamicFieldLargeIntPrecision(t *testing.T) {
+	t.Run("dynamic field integers above 2^53 keep exact precision", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{
+			Type:      schemapb.DataType_JSON,
+			FieldName: FieldBookIntro,
+			IsDynamic: true,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_JsonData{
+						JsonData: &schemapb.JSONArray{
+							Data: [][]byte{
+								[]byte(`{"big_val":9223372036854775807,"dyn_int":9007199254740993,"small":42}`),
+							},
+						},
+					},
+				},
+			},
+		}
+
+		rows, err := buildQueryResp(0, []string{"big_val", "dyn_int", "small"}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+
+		row := rows[0]
+		bigVal, ok := row["big_val"].(json.Number)
+		require.True(t, ok, "big_val should be json.Number, got %T", row["big_val"])
+		assert.Equal(t, "9223372036854775807", bigVal.String())
+
+		dynInt, ok := row["dyn_int"].(json.Number)
+		require.True(t, ok, "dyn_int should be json.Number, got %T", row["dyn_int"])
+		assert.Equal(t, "9007199254740993", dynInt.String())
+
+		small, ok := row["small"].(json.Number)
+		require.True(t, ok, "small should be json.Number, got %T", row["small"])
+		assert.Equal(t, "42", small.String())
+
+		// Serializing the row back must emit the exact digits, not a float64-rounded value.
+		out, err := json.Marshal(row)
+		require.NoError(t, err)
+		assert.Contains(t, string(out), "9223372036854775807")
+		assert.Contains(t, string(out), "9007199254740993")
+	})
+}
+
 func TestBuildQueryRespWithNullableCompactFields(t *testing.T) {
 	t.Run("nullable vector derives logical rows from ValidData", func(t *testing.T) {
 		fieldData := &schemapb.FieldData{


### PR DESCRIPTION
## Motivation

When a dynamic field stores an integer larger than 2^53 (e.g. `9223372036854775807`), the REST v2 query response returns a **different, incorrect value** because `buildQueryResp` decodes the stored dynamic-field JSON with `json.Unmarshal` into `map[string]interface{}`, which represents every JSON number as `float64`. float64 has only a 53-bit mantissa, so large ints silently lose precision (e.g. `9223372036854775807` is returned as `9223372036854776000`).

This corrupts 64-bit IDs, Snowflake/Twitter IDs and nanosecond timestamps read back through the REST API. Typed Int64 fields are unaffected because they go through the native int64 path. Full precision-loss matrix is in issue #52049.

## Changes

- `internal/distributed/proxy/httpserver/utils.go`: in `buildQueryResp`, decode the dynamic-field JSON with `json.Decoder` + `UseNumber()` instead of `json.Unmarshal`, so numeric values stay as `json.Number` and serialize back with their exact digits.
- `internal/distributed/proxy/httpserver/utils_test.go`: add `TestBuildQueryRespDynamicFieldLargeIntPrecision` covering `9223372036854775807`, `9007199254740993` and a small integer, asserting the `json.Number` type and exact re-serialization.

`buildQueryResp` is the single shared response builder for query, get and search (v1 + v2), so all REST response paths are covered by this one fix.

## Testing

- Verified the exact decode path (`json.NewDecoder(...).UseNumber().Decode`) with `internal/json` locally: `9223372036854775807` round-trips exactly and re-serializes as `{"big_val":9223372036854775807,...}` (json.Number is encoded verbatim by the sonic encoder used by the REST renderer).
- `gofmt` clean on both changed files.
- Full `go build ./internal/distributed/proxy/httpserver/` is blocked on this Windows host by an unrelated pre-existing CGO dependency (confluent-kafka-go/librdkafka is not available on Windows); the same package builds on Linux CI.

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added/updated
- [ ] Documentation has been updated (if applicable)
- [x] No new dependencies introduced (or justified)
- [x] Changes are backward compatible

issue: #52049