### PR TITLE
enhance: reduce parser rewriter column key allocations

### DIFF
--- a/internal/parser/planparserv2/rewriter/util.go
+++ b/internal/parser/planparserv2/rewriter/util.go
@@ -1,10 +1,9 @@
 package rewriter
 
 import (
-	"fmt"
 	"math"
 	"sort"
-	"strings"
+	"strconv"
 
 	"github.com/samber/lo"
 
@@ -14,15 +13,21 @@ import (
 )
 
 func columnKey(c *planpb.ColumnInfo) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "%d|%t|%d|",
-		c.GetFieldId(),
-		c.GetIsElementLevel(),
-		len(c.GetNestedPath()))
-	for _, p := range c.GetNestedPath() {
-		fmt.Fprintf(&b, "%d:%s|", len(p), p)
+	nestedPath := c.GetNestedPath()
+	buf := make([]byte, 0, 32)
+	buf = strconv.AppendInt(buf, c.GetFieldId(), 10)
+	buf = append(buf, '|')
+	buf = strconv.AppendBool(buf, c.GetIsElementLevel())
+	buf = append(buf, '|')
+	buf = strconv.AppendInt(buf, int64(len(nestedPath)), 10)
+	buf = append(buf, '|')
+	for _, p := range nestedPath {
+		buf = strconv.AppendInt(buf, int64(len(p)), 10)
+		buf = append(buf, ':')
+		buf = append(buf, p...)
+		buf = append(buf, '|')
 	}
-	return b.String()
+	return string(buf)
 }
 
 // effectiveDataType returns the real scalar type to be used for comparisons.


### PR DESCRIPTION
issue: #52106

### What changed

Replaced the repeated `fmt.Fprintf` calls in the plan parser rewriter's `columnKey` helper with append-based formatting. The helper keeps the exact same key layout while avoiding formatter overhead in predicate grouping paths.

### Why

`columnKey` is used while grouping range, JSON term, and text-match predicates during expression rewrite. Complex parser expressions can call this helper several times in one parse.

### Verification

Behavior tests:

```bash
GOWORK=off go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/parser/planparserv2 ./internal/parser/planparserv2/rewriter
```

Benchmark command:

```bash
GOWORK=off go test -tags dynamic,test -gcflags="all=-N -l" -run '^$' -bench 'BenchmarkOptimizationComparison/(complex_(and_chain|mixed|nested|with_json|full))$' -benchmem -count=5 ./internal/parser/planparserv2
```

Median samples (before -> after):

| Benchmark | ns/op | B/op | allocs/op |
|---|---|---|---|
| `complex_nested` | 175797 -> 162741 (-7.4%) | 39957 -> 39593 (-0.9%) | 685 -> 674 (-11) |
| `complex_full` | 154299 -> 150081 (-2.7%) | 37447 -> 37096 (-0.9%) | 640 -> 628 (-12) |
| `complex_with_json` | 105629 -> 103996 (-1.5%) | 24221 -> 23886 (-1.4%) | 424 -> 412 (-12) |

Static check:

```bash
GOWORK=off PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib make static-check
```

Passed with 0 issues. The environment variables point at existing local C++ build artifacts because this nested worktree does not have its own `internal/core/output`.
