### PR TITLE
test: make struct-array manual compaction wait for a compactable moment (#51686)

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
@@ -1096,7 +1096,6 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
             schema=schema,
             index_params=index_params,
             consistency_level="Strong",
-            properties={"collection.autocompaction.enabled": "false"},
         )
 
         def profile(row_id, length, tag_prefix="keep"):
@@ -1249,8 +1248,31 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
         baseline = collect_observations()
         assert baseline["match_ids"] == sorted(row_id for row_id, row in source_by_id.items() if row[STRUCT_FIELD])
         assert baseline["contains_ids"] == [4]
-        compact_id, _ = self.compact(client, collection_name)
-        assert compact_id > 0
+        # compact() returns -1 when datacoord finds no candidate segment for the
+        # request. isNormalManualCompactionCandidate requires each segment to be
+        # flushed, sorted, and not already compacting, and both of the remaining
+        # conditions are reached asynchronously:
+        #
+        #   - a freshly flushed segment is unsorted; IsSorted is written by the
+        #     sort compaction datacoord triggers on the datanode
+        #   - once sorted, an automatic mix compaction may claim the segments,
+        #     setting isCompacting until it finishes
+        #
+        # So wait for the segments to be sorted, then ask until the request is
+        # actually accepted. Datacoord only creates index tasks for sorted
+        # segments, so an index with no pending rows means every segment is
+        # sorted; the retry then rides out any automatic compaction holding them.
+        assert self.wait_for_index_ready(client, collection_name, index_name=VECTOR_FIELD, timeout=300), (
+            "vector index still has pending rows; segments are not all sorted yet"
+        )
+        compact_id = -1
+        deadline = time.time() + 120
+        while time.time() < deadline:
+            compact_id, _ = self.compact(client, collection_name)
+            if compact_id > 0:
+                break
+            time.sleep(2)
+        assert compact_id > 0, "no segment was compactable within the timeout"
         assert self.wait_for_compaction_ready(client, compact_id, timeout=300)
         assert collect_observations() == baseline
 


### PR DESCRIPTION
issue: #51686

`test_struct_array_compaction_preserves_null_empty_offsets_and_indexes` asserts
`compact()` returns a positive id, and is failing again on `ci-v2/e2e-default`
with `assert -1 > 0` (seen on #52098 and #52103; #52099 / #52097 / #52093 passed
in the same window).

### Why -1

`-1` means datacoord created zero compaction tasks. Under a forced manual trigger
that can only come from zero *candidate* segments — `generatePlans` puts every
candidate into `prioritizedCandidates` when `signal.isForce` is set, and
force-packs any leftover into a bucket of its own, so one candidate is enough to
produce one plan.

`isNormalManualCompactionCandidate` requires each segment to be flushed, sorted,
and not already compacting. Two of those are reached asynchronously, and the test
raced both:

1. **A freshly flushed segment is unsorted.** `IsSorted` is written by the sort
   compaction datacoord runs on the datanode, and datacoord triggers it from
   `singleCompactionPolicy` **before**, and independently of, the
   `isCollectionAutoCompactionEnabled` gate:

   ```go
   sortViews, err := policy.triggerSortCompaction(ctx, newTriggerID, collectionID, collectionTTL)
   ...
   if !isCollectionAutoCompactionEnabled(collection) {
       return nil, sortViews, 0, nil
   }
   ```

   That is why #51689 did not remove the failure: disabling this collection's
   autocompaction stopped *mix* compaction from claiming the segments first, but
   sort compaction runs either way.

2. **Once sorted, an automatic mix compaction may claim them**, holding
   `isCompacting` until it completes.

The intermittency follows: it depends entirely on where those two asynchronous
steps happen to be when the test reaches `compact()`.

### Fix

Wait for the first condition and tolerate the second, instead of turning a server
behaviour off to dodge it.

- Datacoord only creates index tasks for sorted segments — `index_inspector`
  gates on `IsSorted || IsSortedByNamespace` — so an index with no pending rows
  means every segment is sorted. `wait_for_index_ready` already exists in the
  framework, so this is a real barrier rather than a sleep.
- Then ask for up to two minutes, which rides out any automatic compaction
  holding the segments. `-1` is a legitimate transient answer meaning "nothing
  compactable right now", so retrying until the request is accepted expresses
  what the test wants without suppressing compaction it is not testing.

This also **drops the `collection.autocompaction.enabled` property added in
#51689**. The barrier plus retry covers both halves of the race, and the
collection now exercises the same compaction behaviour as any other — which is
closer to what a struct-array compaction test should be covering.

All existing data, offset, predicate, search and index assertions are unchanged.

### Evidence and its limits

The chain above is established from the code path. The Jenkins e2e job does not
archive datacoord logs, so I could not confirm from a server log which condition
applied in this particular run — only that the candidate set must have been empty
for a forced trigger to produce zero tasks. I also cannot run the
distributed-pulsar e2e locally, so CI on this PR is the first real check.
