### PR TITLE
enhance: [cp2.6] batch QueryCoord metadata updates

### DIFF
--- a/internal/querycoordv2/meta/replica_manager.go
+++ b/internal/querycoordv2/meta/replica_manager.go
@@ -63,7 +63,7 @@ type ReplicaManagerInterface interface {
 	// Node management
 	RecoverNodesInCollection(ctx context.Context, collectionID typeutil.UniqueID, rgs map[string]*ResourceGroup) error
 	RemoveNode(ctx context.Context, collectionID typeutil.UniqueID, replicaID typeutil.UniqueID, nodes ...typeutil.UniqueID) error
-	RemoveSQNode(ctx context.Context, collectionID typeutil.UniqueID, replicaID typeutil.UniqueID, nodes ...typeutil.UniqueID) error
+	RemoveSQNodesInCollections(ctx context.Context, removals []SQNodeRemoval) error
 
 	// Metadata access
 	GetResourceGroupByCollection(ctx context.Context, collection typeutil.UniqueID) typeutil.Set[string]
@@ -90,6 +90,12 @@ type ReplicaManager struct {
 
 	idAllocator func() (int64, error)
 	catalog     metastore.QueryCoordCatalog
+}
+
+type SQNodeRemoval struct {
+	CollectionID int64
+	ReplicaID    int64
+	Nodes        []int64
 }
 
 func NewReplicaManager(idAllocator func() (int64, error), catalog metastore.QueryCoordCatalog) *ReplicaManager {
@@ -523,7 +529,8 @@ func (m *ReplicaManager) getSrcReplicasAndCheckIfTransferable(collectionID typeu
 				len(srcReplicas),
 				collectionID,
 				srcRGName,
-				replicaNum))
+				replicaNum),
+		)
 		return nil, err
 	}
 	return srcReplicas, nil
@@ -802,19 +809,66 @@ func (m *ReplicaManager) RemoveNode(ctx context.Context, collectionID typeutil.U
 	return m.put(ctx, collectionID, mutableReplica.IntoReplica())
 }
 
-// RemoveSQNode removes the sq node from the given replica.
-func (m *ReplicaManager) RemoveSQNode(ctx context.Context, collectionID typeutil.UniqueID, replicaID typeutil.UniqueID, nodes ...typeutil.UniqueID) error {
-	m.collLock.Lock(collectionID)
-	defer m.collLock.Unlock(collectionID)
-
-	replica, ok := m.flatReplicas.Get(replicaID)
-	if !ok || replica.GetCollectionID() != collectionID {
-		return merr.WrapErrReplicaNotFound(replicaID)
+// RemoveSQNodesInCollections applies one removal batch and expects at most one removal per replica.
+func (m *ReplicaManager) RemoveSQNodesInCollections(ctx context.Context, removals []SQNodeRemoval) error {
+	if len(removals) == 0 {
+		return nil
 	}
 
-	mutableReplica := replica.CopyForWrite()
-	mutableReplica.RemoveSQNode(nodes...) // ro -> unused
-	return m.put(ctx, collectionID, mutableReplica.IntoReplica())
+	collectionSet := typeutil.NewUniqueSet()
+	for _, removal := range removals {
+		collectionSet.Insert(removal.CollectionID)
+	}
+	lockedCollections := collectionSet.Collect()
+	sort.Slice(lockedCollections, func(i, j int) bool {
+		return lockedCollections[i] < lockedCollections[j]
+	})
+	for _, collectionID := range lockedCollections {
+		m.collLock.Lock(collectionID)
+	}
+	defer func() {
+		for i := len(lockedCollections) - 1; i >= 0; i-- {
+			m.collLock.Unlock(lockedCollections[i])
+		}
+	}()
+
+	modifiedByCollection := make(map[int64][]*Replica)
+	replicaPBs := make([]*querypb.Replica, 0, len(removals))
+	for _, removal := range removals {
+		replica, ok := m.flatReplicas.Get(removal.ReplicaID)
+		if !ok || replica.GetCollectionID() != removal.CollectionID {
+			// The removal may be stale after the observer collected it.
+			continue
+		}
+
+		removeNodes := make([]int64, 0, len(removal.Nodes))
+		for _, node := range removal.Nodes {
+			if replica.ContainROSQNode(node) {
+				removeNodes = append(removeNodes, node)
+			}
+		}
+		if len(removeNodes) == 0 {
+			continue
+		}
+
+		mutableReplica := replica.CopyForWrite()
+		mutableReplica.RemoveSQNode(removeNodes...)
+		modifiedReplica := mutableReplica.IntoReplica()
+		modifiedByCollection[removal.CollectionID] = append(modifiedByCollection[removal.CollectionID], modifiedReplica)
+		replicaPBs = append(replicaPBs, modifiedReplica.replicaPB)
+	}
+
+	if len(replicaPBs) == 0 {
+		return nil
+	}
+	if err := m.catalog.SaveReplica(ctx, replicaPBs...); err != nil {
+		return err
+	}
+
+	for collectionID, modifiedReplicas := range modifiedByCollection {
+		m.putReplicasInMemory(collectionID, modifiedReplicas...)
+	}
+	return nil
 }
 
 func (m *ReplicaManager) GetResourceGroupByCollection(ctx context.Context, collection typeutil.UniqueID) typeutil.Set[string] {
@@ -861,7 +915,7 @@ func (m *ReplicaManager) GetReplicasJSON(ctx context.Context, meta *Meta) string
 	return string(ret)
 }
 
-// RecoverSQNodesInCollection recovers all sq nodes in collection with latest node list.
+// RecoverSQNodesInCollections recovers all sq nodes in each collection with latest node list.
 // Promise a node will be only assigned to one replica in same collection at same time.
 // 1. Move the rw nodes to ro nodes if current replica use too much sqn.
 // 2. Add new incoming nodes into the replica if they are not ro node of other replicas in same collection.
@@ -869,16 +923,67 @@ func (m *ReplicaManager) GetReplicasJSON(ctx context.Context, meta *Meta) string
 // When sqnNodesByRG covers all resource groups of replicas in the collection, streaming nodes will be assigned
 // by resource group isolation (each replica only gets streaming nodes from its own resource group).
 // Otherwise, all streaming nodes will be pooled together and assigned fairly across all replicas (fallback mode).
-func (m *ReplicaManager) RecoverSQNodesInCollection(ctx context.Context, collectionID int64, sqnNodesByRG map[string]typeutil.UniqueSet) error {
-	m.collLock.Lock(collectionID)
-	defer m.collLock.Unlock(collectionID)
-
-	replicas, ok := m.coll2Replicas.Get(collectionID)
-	if !ok {
-		return merr.WrapErrCollectionNotLoaded(collectionID)
+func (m *ReplicaManager) RecoverSQNodesInCollections(
+	ctx context.Context,
+	collectionIDs []int64,
+	sqnNodesByRG map[string]typeutil.UniqueSet,
+) error {
+	if len(collectionIDs) == 0 {
+		return nil
 	}
 
-	// Build helpers based on whether we can use resource group isolation.
+	lockedCollections := lo.Uniq(collectionIDs)
+	sort.Slice(lockedCollections, func(i, j int) bool {
+		return lockedCollections[i] < lockedCollections[j]
+	})
+	for _, collectionID := range lockedCollections {
+		m.collLock.Lock(collectionID)
+	}
+	defer func() {
+		for i := len(lockedCollections) - 1; i >= 0; i-- {
+			m.collLock.Unlock(lockedCollections[i])
+		}
+	}()
+
+	modifiedByCollection := make(map[int64][]*Replica)
+	replicaPBs := make([]*querypb.Replica, 0, len(lockedCollections))
+	for _, collectionID := range lockedCollections {
+		replicas, ok := m.coll2Replicas.Get(collectionID)
+		if !ok {
+			continue
+		}
+
+		modifiedReplicas := m.recoverSQNodesInCollectionLocked(ctx, collectionID, replicas, sqnNodesByRG)
+		if len(modifiedReplicas) == 0 {
+			continue
+		}
+		modifiedByCollection[collectionID] = modifiedReplicas
+		for _, replica := range modifiedReplicas {
+			replicaPBs = append(replicaPBs, replica.replicaPB)
+		}
+	}
+
+	if len(replicaPBs) == 0 {
+		return nil
+	}
+	if err := m.catalog.SaveReplica(ctx, replicaPBs...); err != nil {
+		return err
+	}
+
+	for collectionID, modifiedReplicas := range modifiedByCollection {
+		m.putReplicasInMemory(collectionID, modifiedReplicas...)
+	}
+	return nil
+}
+
+// recoverSQNodesInCollectionLocked computes streaming query node assignment changes.
+// Caller must hold collLock for the collection.
+func (m *ReplicaManager) recoverSQNodesInCollectionLocked(
+	ctx context.Context,
+	collectionID int64,
+	replicas []*Replica,
+	sqnNodesByRG map[string]typeutil.UniqueSet,
+) []*Replica {
 	helpers := m.buildSQNodeAssignmentHelpers(replicas, sqnNodesByRG)
 
 	modifiedReplicas := make([]*Replica, 0)
@@ -908,7 +1013,7 @@ func (m *ReplicaManager) RecoverSQNodesInCollection(ctx context.Context, collect
 			modifiedReplicas = append(modifiedReplicas, mutableReplica.IntoReplica())
 		})
 	}
-	return m.put(ctx, collectionID, modifiedReplicas...)
+	return modifiedReplicas
 }
 
 // buildSQNodeAssignmentHelpers builds assignment helpers for streaming query node recovery.

--- a/internal/querycoordv2/meta/replica_manager_test.go
+++ b/internal/querycoordv2/meta/replica_manager_test.go
@@ -113,7 +113,8 @@ func (suite *ReplicaManagerSuite) SetupTest() {
 		config.EtcdTLSCert.GetValue(),
 		config.EtcdTLSKey.GetValue(),
 		config.EtcdTLSCACert.GetValue(),
-		config.EtcdTLSMinVersion.GetValue())
+		config.EtcdTLSMinVersion.GetValue(),
+	)
 	suite.Require().NoError(err)
 	suite.kv = etcdkv.NewEtcdKV(cli, config.MetaRootPath.GetValue())
 	suite.catalog = querycoord.NewCatalog(suite.kv)
@@ -447,7 +448,8 @@ func (suite *ReplicaManagerV2Suite) SetupSuite() {
 		config.EtcdTLSCert.GetValue(),
 		config.EtcdTLSKey.GetValue(),
 		config.EtcdTLSCACert.GetValue(),
-		config.EtcdTLSMinVersion.GetValue())
+		config.EtcdTLSMinVersion.GetValue(),
+	)
 	suite.Require().NoError(err)
 	suite.kv = etcdkv.NewEtcdKV(cli, config.MetaRootPath.GetValue())
 	suite.catalog = querycoord.NewCatalog(suite.kv)
@@ -473,7 +475,7 @@ func (suite *ReplicaManagerV2Suite) TestSpawn() {
 			rgsOfCollection[rg] = newTestResourceGroup(rg, suite.rgNodes[rg])
 		}
 		mgr.RecoverNodesInCollection(ctx, id, rgsOfCollection)
-		mgr.RecoverSQNodesInCollection(ctx, id, suite.sqNodesByRG)
+		mgr.RecoverSQNodesInCollections(ctx, []int64{id}, suite.sqNodesByRG)
 		for rg := range cfg.spawnConfig {
 			for _, node := range suite.rgNodes[rg].Collect() {
 				replica := mgr.GetByCollectionAndNode(ctx, id, node)
@@ -602,7 +604,7 @@ func (suite *ReplicaManagerV2Suite) recoverReplica(k int, clearOutbound bool) {
 				sqNodesByRG[rg].Remove(suite.outboundSQNodes...)
 			}
 			suite.mgr.RecoverNodesInCollection(ctx, id, rgsOfCollection)
-			suite.mgr.RecoverSQNodesInCollection(ctx, id, sqNodesByRG)
+			suite.mgr.RecoverSQNodesInCollections(ctx, []int64{id}, sqNodesByRG)
 		}
 
 		// clear all outbound nodes
@@ -612,7 +614,11 @@ func (suite *ReplicaManagerV2Suite) recoverReplica(k int, clearOutbound bool) {
 				for _, r := range replicas {
 					outboundNodes := r.GetRONodes()
 					suite.mgr.RemoveNode(ctx, id, r.GetID(), outboundNodes...)
-					suite.mgr.RemoveSQNode(ctx, id, r.GetID(), r.GetROSQNodes()...)
+					suite.mgr.RemoveSQNodesInCollections(ctx, []SQNodeRemoval{{
+						CollectionID: id,
+						ReplicaID:    r.GetID(),
+						Nodes:        r.GetROSQNodes(),
+					}})
 				}
 			}
 		}
@@ -666,7 +672,7 @@ func TestSQNodeResourceGroupIsolation(t *testing.T) {
 		"RG3": typeutil.NewUniqueSet(301),
 	}
 
-	err = mgr.RecoverSQNodesInCollection(ctx, 100, sqNodesByRG)
+	err = mgr.RecoverSQNodesInCollections(ctx, []int64{100}, sqNodesByRG)
 	assert.NoError(t, err)
 
 	// Verify that each replica only gets streaming nodes from its own resource group.
@@ -699,7 +705,7 @@ func TestSQNodeResourceGroupIsolation(t *testing.T) {
 	err = mgr.Put(ctx, replica4, replica5)
 	assert.NoError(t, err)
 
-	err = mgr.RecoverSQNodesInCollection(ctx, 200, sqNodesByRG)
+	err = mgr.RecoverSQNodesInCollections(ctx, []int64{200}, sqNodesByRG)
 	assert.NoError(t, err)
 
 	// In fallback mode, all streaming nodes are pooled together.
@@ -747,7 +753,7 @@ func TestSQNodeResourceGroupIsolation(t *testing.T) {
 		"RG1":                    typeutil.NewUniqueSet(101, 102),
 	}
 
-	err = mgr.RecoverSQNodesInCollection(ctx, 250, rollingUpgradeSQNodesByRG)
+	err = mgr.RecoverSQNodesInCollections(ctx, []int64{250}, rollingUpgradeSQNodesByRG)
 	assert.NoError(t, err)
 
 	updatedReplica8 := mgr.Get(ctx, 8)
@@ -781,7 +787,7 @@ func TestSQNodeResourceGroupIsolation(t *testing.T) {
 	err = mgr.Put(ctx, replica6, replica7)
 	assert.NoError(t, err)
 
-	err = mgr.RecoverSQNodesInCollection(ctx, 300, sqNodesByRG)
+	err = mgr.RecoverSQNodesInCollections(ctx, []int64{300}, sqNodesByRG)
 	assert.NoError(t, err)
 
 	// In strict isolation mode:
@@ -828,7 +834,7 @@ func TestSQNodeRecoveryWithRONodes(t *testing.T) {
 		"RG1": typeutil.NewUniqueSet(101, 102, 104, 105),
 	}
 
-	err = mgr.RecoverSQNodesInCollection(ctx, 100, sqNodesByRG)
+	err = mgr.RecoverSQNodesInCollections(ctx, []int64{100}, sqNodesByRG)
 	assert.NoError(t, err)
 
 	updatedReplica := mgr.Get(ctx, 1)
@@ -873,7 +879,7 @@ func TestSQNodeRecoveryWithUnrecoverableNodes(t *testing.T) {
 		"RG1": typeutil.NewUniqueSet(101, 102),
 	}
 
-	err = mgr.RecoverSQNodesInCollection(ctx, 100, sqNodesByRG)
+	err = mgr.RecoverSQNodesInCollections(ctx, []int64{100}, sqNodesByRG)
 	assert.NoError(t, err)
 
 	updatedReplica := mgr.Get(ctx, 1)
@@ -883,6 +889,187 @@ func TestSQNodeRecoveryWithUnrecoverableNodes(t *testing.T) {
 	assert.Contains(t, updatedReplica.GetRWSQNodes(), int64(101))
 	// Node 102 should be added as new RW
 	assert.Contains(t, updatedReplica.GetRWSQNodes(), int64(102))
+}
+
+func TestRecoverSQNodesInCollectionsPersistsSingleBatch(t *testing.T) {
+	catalog := mocks.NewQueryCoordCatalog(t)
+	catalog.EXPECT().SaveReplica(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+
+	mgr := NewReplicaManager(RandomIncrementIDAllocator(), catalog)
+	ctx := context.Background()
+	replicas := []*Replica{
+		newReplica(&querypb.Replica{ID: 1, CollectionID: 100, ResourceGroup: "RG1", RwSqNodes: []int64{101}}),
+		newReplica(&querypb.Replica{ID: 2, CollectionID: 200, ResourceGroup: "RG1", RwSqNodes: []int64{101}}),
+		newReplica(&querypb.Replica{ID: 3, CollectionID: 300, ResourceGroup: "RG1", RwSqNodes: []int64{101}}),
+	}
+	for _, replica := range replicas {
+		mgr.putReplicasInMemory(replica.GetCollectionID(), replica)
+	}
+
+	err := mgr.RecoverSQNodesInCollections(ctx, []int64{100, 200, 300}, map[string]typeutil.UniqueSet{
+		"RG1": typeutil.NewUniqueSet(int64(102)),
+	})
+	assert.NoError(t, err)
+	for _, replica := range replicas {
+		updated := mgr.Get(ctx, replica.GetID())
+		assert.ElementsMatch(t, []int64{102}, updated.GetRWSQNodes())
+		assert.ElementsMatch(t, []int64{101}, updated.GetROSQNodes())
+	}
+}
+
+func TestRecoverSQNodesInCollectionsSkipsStaleCollection(t *testing.T) {
+	catalog := mocks.NewQueryCoordCatalog(t)
+	catalog.EXPECT().SaveReplica(mock.Anything, mock.Anything).Return(nil).Once()
+
+	mgr := NewReplicaManager(RandomIncrementIDAllocator(), catalog)
+	ctx := context.Background()
+	replica := newReplica(&querypb.Replica{ID: 1, CollectionID: 100, ResourceGroup: "RG1", RwSqNodes: []int64{101}})
+	mgr.putReplicasInMemory(replica.GetCollectionID(), replica)
+
+	err := mgr.RecoverSQNodesInCollections(ctx, []int64{999, 100}, map[string]typeutil.UniqueSet{
+		"RG1": typeutil.NewUniqueSet(int64(102)),
+	})
+	assert.NoError(t, err)
+
+	updated := mgr.Get(ctx, replica.GetID())
+	assert.ElementsMatch(t, []int64{102}, updated.GetRWSQNodes())
+	assert.ElementsMatch(t, []int64{101}, updated.GetROSQNodes())
+}
+
+func TestRecoverSQNodesInCollectionsReturnsSaveErrorAndKeepsMemory(t *testing.T) {
+	saveErr := errors.New("save failed")
+	catalog := mocks.NewQueryCoordCatalog(t)
+	catalog.EXPECT().SaveReplica(mock.Anything, mock.Anything).Return(saveErr).Once()
+
+	mgr := NewReplicaManager(RandomIncrementIDAllocator(), catalog)
+	ctx := context.Background()
+	replica := newReplica(&querypb.Replica{ID: 1, CollectionID: 100, ResourceGroup: "RG1", RwSqNodes: []int64{101}})
+	mgr.putReplicasInMemory(replica.GetCollectionID(), replica)
+
+	err := mgr.RecoverSQNodesInCollections(ctx, []int64{999, 100}, map[string]typeutil.UniqueSet{
+		"RG1": typeutil.NewUniqueSet(int64(102)),
+	})
+	assert.ErrorIs(t, err, saveErr)
+
+	updated := mgr.Get(ctx, replica.GetID())
+	assert.ElementsMatch(t, []int64{101}, updated.GetRWSQNodes())
+	assert.Empty(t, updated.GetROSQNodes())
+}
+
+func TestSQNodeCleanupBatchSave(t *testing.T) {
+	paramtable.Init()
+	catalog := mocks.NewQueryCoordCatalog(t)
+	catalog.EXPECT().SaveReplica(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
+
+	mgr := NewReplicaManager(RandomIncrementIDAllocator(), catalog)
+	ctx := context.Background()
+	replicas := []*Replica{
+		newReplica(&querypb.Replica{ID: 1, CollectionID: 100, ResourceGroup: "RG1", RwSqNodes: []int64{101}, RoSqNodes: []int64{201}}),
+		newReplica(&querypb.Replica{ID: 2, CollectionID: 200, ResourceGroup: "RG1", RwSqNodes: []int64{102}, RoSqNodes: []int64{202}}),
+		newReplica(&querypb.Replica{ID: 3, CollectionID: 300, ResourceGroup: "RG1", RwSqNodes: []int64{103}, RoSqNodes: []int64{203}}),
+	}
+	assert.NoError(t, mgr.Put(ctx, replicas...))
+
+	err := mgr.RemoveSQNodesInCollections(ctx, []SQNodeRemoval{
+		{CollectionID: 100, ReplicaID: 1, Nodes: []int64{201}},
+		{CollectionID: 200, ReplicaID: 2, Nodes: []int64{202}},
+		{CollectionID: 300, ReplicaID: 3, Nodes: []int64{203}},
+	})
+	assert.NoError(t, err)
+	for _, replica := range replicas {
+		updated := mgr.Get(ctx, replica.GetID())
+		assert.Empty(t, updated.GetROSQNodes())
+		assert.ElementsMatch(t, replica.GetRWSQNodes(), updated.GetRWSQNodes())
+	}
+}
+
+func TestSQNodeCleanupBatchIgnoresStaleRemovalForRecoveredRWNode(t *testing.T) {
+	paramtable.Init()
+	catalog := mocks.NewQueryCoordCatalog(t)
+	catalog.EXPECT().SaveReplica(mock.Anything, mock.Anything).Return(nil).Once()
+
+	mgr := NewReplicaManager(RandomIncrementIDAllocator(), catalog)
+	ctx := context.Background()
+	replica := newReplica(&querypb.Replica{
+		ID:            1,
+		CollectionID:  100,
+		ResourceGroup: "RG1",
+		RwSqNodes:     []int64{201},
+	})
+	assert.NoError(t, mgr.Put(ctx, replica))
+
+	err := mgr.RemoveSQNodesInCollections(ctx, []SQNodeRemoval{
+		{CollectionID: 100, ReplicaID: 1, Nodes: []int64{201}},
+	})
+	assert.NoError(t, err)
+
+	updated := mgr.Get(ctx, replica.GetID())
+	assert.ElementsMatch(t, []int64{201}, updated.GetRWSQNodes())
+	assert.Empty(t, updated.GetROSQNodes())
+}
+
+func TestSQNodeCleanupBatchSkipsStaleReplicas(t *testing.T) {
+	paramtable.Init()
+	catalog := mocks.NewQueryCoordCatalog(t)
+	catalog.EXPECT().SaveReplica(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+
+	mgr := NewReplicaManager(RandomIncrementIDAllocator(), catalog)
+	ctx := context.Background()
+	replica1 := newReplica(&querypb.Replica{
+		ID:            1,
+		CollectionID:  100,
+		ResourceGroup: "RG1",
+		RwSqNodes:     []int64{101},
+		RoSqNodes:     []int64{201},
+	})
+	replica2 := newReplica(&querypb.Replica{
+		ID:            2,
+		CollectionID:  200,
+		ResourceGroup: "RG1",
+		RwSqNodes:     []int64{102},
+		RoSqNodes:     []int64{202},
+	})
+	mgr.putReplicasInMemory(replica1.GetCollectionID(), replica1)
+	mgr.putReplicasInMemory(replica2.GetCollectionID(), replica2)
+
+	err := mgr.RemoveSQNodesInCollections(ctx, []SQNodeRemoval{
+		{CollectionID: 100, ReplicaID: 1, Nodes: []int64{201}},
+		{CollectionID: 100, ReplicaID: 999, Nodes: []int64{299}},
+		{CollectionID: 200, ReplicaID: 1, Nodes: []int64{201}},
+		{CollectionID: 200, ReplicaID: 2, Nodes: []int64{202}},
+	})
+	assert.NoError(t, err)
+
+	updated1 := mgr.Get(ctx, replica1.GetID())
+	assert.Empty(t, updated1.GetROSQNodes())
+	updated2 := mgr.Get(ctx, replica2.GetID())
+	assert.Empty(t, updated2.GetROSQNodes())
+}
+
+func TestRemoveSQNodesInCollectionsSaveErrorKeepsMemory(t *testing.T) {
+	saveErr := errors.New("save failed")
+	catalog := mocks.NewQueryCoordCatalog(t)
+	catalog.EXPECT().SaveReplica(mock.Anything, mock.Anything).Return(saveErr).Once()
+
+	mgr := NewReplicaManager(RandomIncrementIDAllocator(), catalog)
+	ctx := context.Background()
+	replica := newReplica(&querypb.Replica{
+		ID:            1,
+		CollectionID:  100,
+		ResourceGroup: "RG1",
+		RwSqNodes:     []int64{101},
+		RoSqNodes:     []int64{201},
+	})
+	mgr.putReplicasInMemory(replica.GetCollectionID(), replica)
+
+	err := mgr.RemoveSQNodesInCollections(ctx, []SQNodeRemoval{
+		{CollectionID: 100, ReplicaID: 1, Nodes: []int64{201}},
+	})
+	assert.ErrorIs(t, err, saveErr)
+
+	updated := mgr.Get(ctx, replica.GetID())
+	assert.ElementsMatch(t, []int64{101}, updated.GetRWSQNodes())
+	assert.ElementsMatch(t, []int64{201}, updated.GetROSQNodes())
 }
 
 func TestReplicaManager(t *testing.T) {
@@ -1134,7 +1321,11 @@ func TestReplicaManagerPersistErrorPaths(t *testing.T) {
 		})
 		mgr.putReplicasInMemory(replica.GetCollectionID(), replica)
 
-		err := mgr.RemoveSQNode(ctx, replica.GetCollectionID(), replica.GetID(), int64(202))
+		err := mgr.RemoveSQNodesInCollections(ctx, []SQNodeRemoval{{
+			CollectionID: replica.GetCollectionID(),
+			ReplicaID:    replica.GetID(),
+			Nodes:        []int64{202},
+		}})
 		assert.ErrorIs(t, err, saveErr)
 		assert.ElementsMatch(t, []int64{202}, mgr.Get(ctx, replica.GetID()).GetROSQNodes())
 	})

--- a/internal/querycoordv2/observers/replica_observer.go
+++ b/internal/querycoordv2/observers/replica_observer.go
@@ -124,19 +124,46 @@ func (ob *ReplicaObserver) checkStreamingQueryNodesInReplica(sqNodeIDsByRG map[s
 	ctx := context.Background()
 	log := log.Ctx(ctx).WithRateGroup("qcv2.checkStreamingQueryNodesInReplica", 1, 60)
 	collections := ob.meta.GetAll(context.Background())
-
-	for _, collectionID := range collections {
-		ob.meta.RecoverSQNodesInCollection(context.Background(), collectionID, sqNodeIDsByRG)
+	batchSize := paramtable.Get().MetaStoreCfg.MaxEtcdTxnNum.GetAsInt()
+	recoveryCollections := make([]int64, 0)
+	recoveryReplicaCount := 0
+	flushRecoveries := func() {
+		if len(recoveryCollections) == 0 {
+			return
+		}
+		if err := ob.meta.RecoverSQNodesInCollections(ctx, recoveryCollections, sqNodeIDsByRG); err != nil {
+			log.Warn("failed to recover streaming query nodes in batch", zap.Error(err))
+		}
+		recoveryCollections = recoveryCollections[:0]
+		recoveryReplicaCount = 0
 	}
-
 	for _, collectionID := range collections {
-		replicas := ob.meta.GetByCollection(ctx, collectionID)
-		for _, replica := range replicas {
+		replicaCount := len(ob.meta.GetByCollection(ctx, collectionID))
+		if replicaCount == 0 {
+			continue
+		}
+		if recoveryReplicaCount > 0 && recoveryReplicaCount+replicaCount > batchSize {
+			flushRecoveries()
+		}
+		recoveryCollections = append(recoveryCollections, collectionID)
+		recoveryReplicaCount += replicaCount
+	}
+	flushRecoveries()
+
+	removals := make([]meta.SQNodeRemoval, 0)
+	flushRemovals := func() {
+		if len(removals) == 0 {
+			return
+		}
+		if err := ob.meta.RemoveSQNodesInCollections(ctx, removals); err != nil {
+			log.Warn("failed to remove streaming query nodes in batch", zap.Error(err))
+		}
+		removals = removals[:0]
+	}
+	for _, collectionID := range collections {
+		for _, replica := range ob.meta.GetByCollection(ctx, collectionID) {
 			roSQNodes := replica.GetROSQNodes()
 			rwSQNodes := replica.GetRWSQNodes()
-			if len(roSQNodes) == 0 {
-				continue
-			}
 			removeNodes := make([]int64, 0, len(roSQNodes))
 			for _, node := range roSQNodes {
 				channels := ob.distMgr.ChannelDistManager.GetByFilter(meta.WithCollectionID2Channel(collectionID), meta.WithNodeID2Channel(node))
@@ -155,13 +182,18 @@ func (ob *ReplicaObserver) checkStreamingQueryNodesInReplica(sqNodeIDsByRG map[s
 				zap.Int64s("roNodes", roSQNodes),
 				zap.Int64s("rwNodes", rwSQNodes),
 			)
-			if err := ob.meta.RemoveSQNode(ctx, collectionID, replica.GetID(), removeNodes...); err != nil {
-				logger.Warn("fail to remove streaming query node from replica", zap.Error(err))
-				continue
+			removals = append(removals, meta.SQNodeRemoval{
+				CollectionID: collectionID,
+				ReplicaID:    replica.GetID(),
+				Nodes:        removeNodes,
+			})
+			logger.Info("all segment/channel has been removed from ro streaming query node, will remove it from replica")
+			if len(removals) >= batchSize {
+				flushRemovals()
 			}
-			logger.Info("all segment/channel has been removed from ro streaming query node, remove it from replica")
 		}
 	}
+	flushRemovals()
 }
 
 func (ob *ReplicaObserver) checkNodesInReplica() {

--- a/internal/querycoordv2/observers/replica_observer_test.go
+++ b/internal/querycoordv2/observers/replica_observer_test.go
@@ -20,13 +20,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/rgpb"
 	"github.com/milvus-io/milvus/internal/coordinator/snmanager"
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
+	"github.com/milvus-io/milvus/internal/metastore"
 	"github.com/milvus-io/milvus/internal/metastore/kv/querycoord"
 	"github.com/milvus-io/milvus/internal/mocks/streamingcoord/server/mock_balancer"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
@@ -65,6 +68,51 @@ type ReplicaObserverSuite struct {
 type replicaObserverTargetManager struct {
 	meta.TargetManagerInterface
 	collectionID int64
+}
+
+type countingChannelDistManager struct {
+	meta.ChannelDistManagerInterface
+	getByFilterCalls int
+	onGetByFilter    func(call int)
+}
+
+func (m *countingChannelDistManager) GetByFilter(filters ...meta.ChannelDistFilter) []*meta.DmChannel {
+	m.getByFilterCalls++
+	if m.onGetByFilter != nil {
+		m.onGetByFilter(m.getByFilterCalls)
+	}
+	return m.ChannelDistManagerInterface.GetByFilter(filters...)
+}
+
+type countingSegmentDistManager struct {
+	meta.SegmentDistManagerInterface
+	getByFilterCalls int
+}
+
+type saveReplicaRecordingCatalog struct {
+	metastore.QueryCoordCatalog
+	saveReplicaCalls    int
+	failSaveReplicaCall int
+	saveErr             error
+	saveReplicaBatchIDs [][]int64
+}
+
+func (c *saveReplicaRecordingCatalog) SaveReplica(ctx context.Context, replicas ...*querypb.Replica) error {
+	c.saveReplicaCalls++
+	replicaIDs := make([]int64, 0, len(replicas))
+	for _, replica := range replicas {
+		replicaIDs = append(replicaIDs, replica.GetID())
+	}
+	c.saveReplicaBatchIDs = append(c.saveReplicaBatchIDs, replicaIDs)
+	if c.saveReplicaCalls == c.failSaveReplicaCall {
+		return c.saveErr
+	}
+	return nil
+}
+
+func (m *countingSegmentDistManager) GetByFilter(filters ...meta.SegmentDistFilter) []*meta.Segment {
+	m.getByFilterCalls++
+	return m.SegmentDistManagerInterface.GetByFilter(filters...)
 }
 
 func (m *replicaObserverTargetManager) GetDmChannelsByCollection(ctx context.Context, collectionID int64, scope meta.TargetScope) map[string]*meta.DmChannel {
@@ -313,6 +361,195 @@ func (suite *ReplicaObserverSuite) TestCheckSQnodesInReplica() {
 		nodes.Insert(r.GetRWSQNodes()...)
 	}
 	suite.Equal(nodes.Len(), 2)
+}
+
+func (suite *ReplicaObserverSuite) TestCheckStreamingQueryNodesChecksDistributionForRONodes() {
+	suite.observer.Stop()
+
+	ctx := context.Background()
+	err := suite.meta.PutCollection(ctx, utils.CreateTestCollection(suite.collectionID, 1))
+	suite.NoError(err)
+	_, err = suite.meta.Spawn(ctx, suite.collectionID, map[string]int{"rg1": 1}, nil, commonpb.LoadPriority_LOW)
+	suite.NoError(err)
+
+	suite.observer.checkStreamingQueryNodesInReplica(map[string]typeutil.UniqueSet{
+		"rg1": typeutil.NewUniqueSet(int64(1)),
+	})
+	suite.distMgr.ChannelDistManager.Update(1, &meta.DmChannel{
+		VchannelInfo: &datapb.VchannelInfo{
+			CollectionID: suite.collectionID,
+			ChannelName:  "test-insert-channel1",
+		},
+	})
+
+	channelDist := &countingChannelDistManager{
+		ChannelDistManagerInterface: suite.distMgr.ChannelDistManager,
+	}
+	segmentDist := &countingSegmentDistManager{
+		SegmentDistManagerInterface: suite.distMgr.SegmentDistManager,
+	}
+	suite.distMgr.ChannelDistManager = channelDist
+	suite.distMgr.SegmentDistManager = segmentDist
+
+	suite.observer.checkStreamingQueryNodesInReplica(map[string]typeutil.UniqueSet{
+		"rg1": typeutil.NewUniqueSet(int64(2)),
+	})
+
+	replicas := suite.meta.GetByCollection(ctx, suite.collectionID)
+	suite.Require().Len(replicas, 1)
+	suite.Equal([]int64{1}, replicas[0].GetROSQNodes())
+	suite.Equal(1, channelDist.getByFilterCalls)
+	suite.Equal(1, segmentDist.getByFilterCalls)
+
+	suite.distMgr.ChannelDistManager.Update(1)
+	suite.observer.checkStreamingQueryNodesInReplica(map[string]typeutil.UniqueSet{
+		"rg1": typeutil.NewUniqueSet(int64(2)),
+	})
+
+	replicas = suite.meta.GetByCollection(ctx, suite.collectionID)
+	suite.Empty(replicas[0].GetROSQNodes())
+	suite.Equal(2, channelDist.getByFilterCalls)
+	suite.Equal(2, segmentDist.getByFilterCalls)
+}
+
+func (suite *ReplicaObserverSuite) TestCheckStreamingQueryNodesFlushesRemovalBeforeScanningNextBatch() {
+	suite.observer.Stop()
+
+	ctx := context.Background()
+	suite.NoError(suite.meta.PutCollection(ctx, utils.CreateTestCollection(suite.collectionID, 2)))
+	replica1 := meta.NewReplica(&querypb.Replica{
+		ID:            1,
+		CollectionID:  suite.collectionID,
+		ResourceGroup: "rg1",
+		RoSqNodes:     []int64{1},
+	})
+	replica2 := meta.NewReplica(&querypb.Replica{
+		ID:            2,
+		CollectionID:  suite.collectionID,
+		ResourceGroup: "rg1",
+		RoSqNodes:     []int64{2},
+	})
+	suite.NoError(suite.meta.Put(ctx, replica1, replica2))
+
+	maxTxnNumKey := paramtable.Get().MetaStoreCfg.MaxEtcdTxnNum.Key
+	originalMaxTxnNum := paramtable.Get().MetaStoreCfg.MaxEtcdTxnNum.GetValue()
+	suite.NoError(paramtable.Get().Save(maxTxnNumKey, "1"))
+	suite.T().Cleanup(func() {
+		suite.NoError(paramtable.Get().Save(maxTxnNumKey, originalMaxTxnNum))
+	})
+
+	firstBatchCommitted := false
+	channelDist := &countingChannelDistManager{
+		ChannelDistManagerInterface: suite.distMgr.ChannelDistManager,
+		onGetByFilter: func(call int) {
+			if call == 2 {
+				firstBatchCommitted = len(suite.meta.Get(ctx, replica1.GetID()).GetROSQNodes()) == 0
+			}
+		},
+	}
+	suite.distMgr.ChannelDistManager = channelDist
+
+	suite.observer.checkStreamingQueryNodesInReplica(map[string]typeutil.UniqueSet{
+		"rg1": typeutil.NewUniqueSet(),
+	})
+
+	suite.True(firstBatchCommitted)
+	suite.Empty(suite.meta.Get(ctx, replica1.GetID()).GetROSQNodes())
+	suite.Empty(suite.meta.Get(ctx, replica2.GetID()).GetROSQNodes())
+}
+
+func TestCheckStreamingQueryNodesBatchesRecoveryByReplicaCountAndContinuesAfterError(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	catalog := &saveReplicaRecordingCatalog{}
+	nodeMgr := session.NewNodeManager()
+	metadata := meta.NewMeta(RandomIncrementIDAllocator(), catalog, nodeMgr)
+
+	for collectionID, replicaNumber := range map[int64]int32{100: 2, 200: 1, 300: 2} {
+		require.NoError(t, metadata.PutCollectionWithoutSave(ctx, utils.CreateTestCollection(collectionID, replicaNumber)))
+	}
+	replicas := []*meta.Replica{
+		meta.NewReplica(&querypb.Replica{ID: 1, CollectionID: 100, ResourceGroup: "RG1"}),
+		meta.NewReplica(&querypb.Replica{ID: 2, CollectionID: 100, ResourceGroup: "RG1"}),
+		meta.NewReplica(&querypb.Replica{ID: 3, CollectionID: 200, ResourceGroup: "RG1"}),
+		meta.NewReplica(&querypb.Replica{ID: 4, CollectionID: 300, ResourceGroup: "RG1"}),
+		meta.NewReplica(&querypb.Replica{ID: 5, CollectionID: 300, ResourceGroup: "RG1"}),
+	}
+	require.NoError(t, metadata.Put(ctx, replicas...))
+
+	maxTxnNumKey := paramtable.Get().MetaStoreCfg.MaxEtcdTxnNum.Key
+	originalMaxTxnNum := paramtable.Get().MetaStoreCfg.MaxEtcdTxnNum.GetValue()
+	require.NoError(t, paramtable.Get().Save(maxTxnNumKey, "3"))
+	t.Cleanup(func() {
+		require.NoError(t, paramtable.Get().Save(maxTxnNumKey, originalMaxTxnNum))
+	})
+
+	catalog.saveReplicaCalls = 0
+	catalog.saveReplicaBatchIDs = nil
+	catalog.failSaveReplicaCall = 1
+	catalog.saveErr = errors.New("save failed")
+
+	observer := NewReplicaObserver(metadata, meta.NewDistributionManager(nodeMgr), nil)
+	observer.checkStreamingQueryNodesInReplica(map[string]typeutil.UniqueSet{
+		"RG1": typeutil.NewUniqueSet(int64(101), int64(102)),
+	})
+
+	require.Len(t, catalog.saveReplicaBatchIDs, 2)
+	require.ElementsMatch(t, []int{2, 3}, []int{
+		len(catalog.saveReplicaBatchIDs[0]),
+		len(catalog.saveReplicaBatchIDs[1]),
+	})
+	failedReplicaIDs := typeutil.NewUniqueSet(catalog.saveReplicaBatchIDs[0]...)
+	succeededReplicaIDs := typeutil.NewUniqueSet(catalog.saveReplicaBatchIDs[1]...)
+	for _, replica := range replicas {
+		updated := metadata.Get(ctx, replica.GetID())
+		if failedReplicaIDs.Contain(replica.GetID()) {
+			require.Empty(t, updated.GetRWSQNodes())
+		} else {
+			require.True(t, succeededReplicaIDs.Contain(replica.GetID()))
+			require.NotEmpty(t, updated.GetRWSQNodes())
+		}
+	}
+}
+
+func TestCheckStreamingQueryNodesContinuesCleanupAfterBatchError(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	catalog := &saveReplicaRecordingCatalog{}
+	nodeMgr := session.NewNodeManager()
+	metadata := meta.NewMeta(RandomIncrementIDAllocator(), catalog, nodeMgr)
+	require.NoError(t, metadata.PutCollectionWithoutSave(ctx, utils.CreateTestCollection(100, 2)))
+
+	replicas := []*meta.Replica{
+		meta.NewReplica(&querypb.Replica{ID: 1, CollectionID: 100, ResourceGroup: "RG1", RoSqNodes: []int64{101}}),
+		meta.NewReplica(&querypb.Replica{ID: 2, CollectionID: 100, ResourceGroup: "RG1", RoSqNodes: []int64{102}}),
+	}
+	require.NoError(t, metadata.Put(ctx, replicas...))
+
+	maxTxnNumKey := paramtable.Get().MetaStoreCfg.MaxEtcdTxnNum.Key
+	originalMaxTxnNum := paramtable.Get().MetaStoreCfg.MaxEtcdTxnNum.GetValue()
+	require.NoError(t, paramtable.Get().Save(maxTxnNumKey, "1"))
+	t.Cleanup(func() {
+		require.NoError(t, paramtable.Get().Save(maxTxnNumKey, originalMaxTxnNum))
+	})
+
+	catalog.saveReplicaCalls = 0
+	catalog.saveReplicaBatchIDs = nil
+	catalog.failSaveReplicaCall = 1
+	catalog.saveErr = errors.New("save failed")
+
+	observer := NewReplicaObserver(metadata, meta.NewDistributionManager(nodeMgr), nil)
+	observer.checkStreamingQueryNodesInReplica(map[string]typeutil.UniqueSet{
+		"RG1": typeutil.NewUniqueSet(),
+	})
+
+	require.Len(t, catalog.saveReplicaBatchIDs, 2)
+	require.Len(t, catalog.saveReplicaBatchIDs[0], 1)
+	require.Len(t, catalog.saveReplicaBatchIDs[1], 1)
+	failedReplicaID := catalog.saveReplicaBatchIDs[0][0]
+	succeededReplicaID := catalog.saveReplicaBatchIDs[1][0]
+	require.NotEmpty(t, metadata.Get(ctx, failedReplicaID).GetROSQNodes())
+	require.Empty(t, metadata.Get(ctx, succeededReplicaID).GetROSQNodes())
 }
 
 func (suite *ReplicaObserverSuite) TearDownTest() {

--- a/internal/querycoordv2/utils/meta.go
+++ b/internal/querycoordv2/utils/meta.go
@@ -165,7 +165,11 @@ func SpawnReplicasWithReplicaConfig(ctx context.Context, m *meta.Meta, params me
 	}
 	RecoverReplicaOfCollection(ctx, m, params.CollectionID)
 	if streamingutil.IsStreamingServiceEnabled() {
-		m.RecoverSQNodesInCollection(ctx, params.CollectionID, snmanager.StaticStreamingNodeManager.GetStreamingQueryNodeIDsByResourceGroup())
+		m.RecoverSQNodesInCollections(
+			ctx,
+			[]int64{params.CollectionID},
+			snmanager.StaticStreamingNodeManager.GetStreamingQueryNodeIDsByResourceGroup(),
+		)
 	}
 	return replicas, nil
 }
@@ -186,7 +190,11 @@ func SpawnReplicasWithRG(ctx context.Context, m *meta.Meta, collection int64, re
 	// Active recover it.
 	RecoverReplicaOfCollection(ctx, m, collection)
 	if streamingutil.IsStreamingServiceEnabled() {
-		m.RecoverSQNodesInCollection(ctx, collection, snmanager.StaticStreamingNodeManager.GetStreamingQueryNodeIDsByResourceGroup())
+		m.RecoverSQNodesInCollections(
+			ctx,
+			[]int64{collection},
+			snmanager.StaticStreamingNodeManager.GetStreamingQueryNodeIDsByResourceGroup(),
+		)
 	}
 	return replicas, nil
 }

--- a/pkg/util/paramtable/service_param.go
+++ b/pkg/util/paramtable/service_param.go
@@ -548,6 +548,13 @@ func (p *MetaStoreConfig) Init(base *BaseTable) {
 		DefaultValue: "64",
 		Doc:          `maximum number of operations in a single etcd transaction`,
 		Export:       true,
+		Formatter: func(value string) string {
+			maxTxnNum := getAsInt(value)
+			if maxTxnNum < 1 {
+				return "64"
+			}
+			return strconv.Itoa(maxTxnNum)
+		},
 	}
 	p.MaxEtcdTxnNum.Init(base.mgr)
 

--- a/pkg/util/paramtable/service_param_test.go
+++ b/pkg/util/paramtable/service_param_test.go
@@ -292,6 +292,15 @@ func TestServiceParam(t *testing.T) {
 		assert.Equal(t, util.MetaStoreTypeEtcd, Params.MetaStoreType.GetValue())
 		assert.Equal(t, 100000, Params.PaginationSize.GetAsInt())
 		assert.Equal(t, 32, Params.ReadConcurrency.GetAsInt())
+		assert.Equal(t, 64, Params.MaxEtcdTxnNum.GetAsInt())
+
+		for _, value := range []string{"0", "-1", "invalid"} {
+			assert.NoError(t, bt.Save(Params.MaxEtcdTxnNum.Key, value))
+			assert.Equal(t, 64, Params.MaxEtcdTxnNum.GetAsInt())
+		}
+		assert.NoError(t, bt.Save(Params.MaxEtcdTxnNum.Key, "2"))
+		assert.Equal(t, 2, Params.MaxEtcdTxnNum.GetAsInt())
+		assert.NoError(t, bt.Reset(Params.MaxEtcdTxnNum.Key))
 	})
 
 	t.Run("test profile config", func(t *testing.T) {


### PR DESCRIPTION
Cherry-pick from master
pr: #51321

issue: #51320

## What this PR does

- Batch streaming QueryNode replica recovery across collections using `metastore.maxEtcdTxnNum` as the accumulation threshold.
- Batch streaming QueryNode cleanup by removal count and skip stale cleanup entries without blocking valid entries in the same batch.
- Persist each replica batch before updating in-memory state; a failed batch leaves that batch unchanged while later observer batches continue.
- Fall back to the default transaction size when the configured value is invalid.

## Backport notes

- Adapt the logging calls to the 2.6 `pkg/v2/log` and `zap` APIs.
- Use the v2 milvus-proto imports required by the 2.6 branch.

## Test Plan

- [x] `CONAN_CMD=conan-1 make SKIP_3RDPARTY=1`
- [x] Package tests for `internal/querycoordv2/meta`, `internal/querycoordv2/observers`, and `internal/querycoordv2/utils`
- [x] `TestServiceParam` in the `pkg` module
- [x] Targeted golangci-lint for all changed packages
- [x] `gofumpt v0.5.0` and `gci v0.11.2` checks on all changed Go files
- [x] `git diff --check`
