### PR TITLE
fix: resolve search timezone before plan generation

### DIFF
--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -263,6 +263,18 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 	// searches with small result size could no longer need requery.
 	traceVal, _ := funcutil.GetAttrByKeyFromRepeatedKV(PipelineTraceKey, t.request.GetSearchParams())
 	t.traceEnabled = strings.EqualFold(traceVal, "true")
+	timezone, exist := funcutil.TryGetAttrByKeyFromRepeatedKV(common.TimezoneKey, t.request.SearchParams)
+	if exist {
+		if !timestamptz.IsTimezoneValid(timezone) {
+			log.Info(ctx, "get invalid timezone from request", mlog.String("timezone", timezone))
+			return merr.WrapErrParameterInvalidMsg("unknown or invalid IANA Time Zone ID: %s", timezone)
+		}
+		log.Debug(ctx, "determine timezone from request", mlog.String("user defined timezone", timezone))
+	} else {
+		timezone = getColTimezone(collectionInfo)
+		log.Debug(ctx, "determine timezone from collection", mlog.Any("collection timezone", timezone))
+	}
+	t.resolvedTimezoneStr = timezone
 	// initSearchAggregation must run before init{,Advanced}SearchRequest so
 	// that t.SearchRequest.GroupByFieldIds and t.aggCtx are populated before
 	// queryInfo is built and captured — otherwise queryInfo.GroupByFieldIds
@@ -339,19 +351,6 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 			return merr.WrapErrServiceInternalMsg("ttl timestamp overflow, base timestamp: %d, ttl duration %v", t.GetBase().GetTimestamp(), collectionInfo.collectionTTL)
 		}
 	}
-
-	timezone, exist := funcutil.TryGetAttrByKeyFromRepeatedKV(common.TimezoneKey, t.request.SearchParams)
-	if exist {
-		if !timestamptz.IsTimezoneValid(timezone) {
-			log.Info(ctx, "get invalid timezone from request", mlog.String("timezone", timezone))
-			return merr.WrapErrParameterInvalidMsg("unknown or invalid IANA Time Zone ID: %s", timezone)
-		}
-		log.Debug(ctx, "determine timezone from request", mlog.String("user defined timezone", timezone))
-	} else {
-		timezone = getColTimezone(collectionInfo)
-		log.Debug(ctx, "determine timezone from collection", mlog.Any("collection timezone", timezone))
-	}
-	t.resolvedTimezoneStr = timezone
 
 	t.resultBuf = typeutil.NewConcurrentSet[*internalpb.SearchResults]()
 

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -119,6 +119,72 @@ func TestSearchTaskPreExecuteTextRequiresStorageV3(t *testing.T) {
 	assert.Contains(t, err.Error(), "TEXT field requires StorageV3")
 }
 
+func TestSearchTaskPreExecuteUsesTimezoneForTimestamptzFilter(t *testing.T) {
+	mockey.PatchConvey("TestSearchTaskPreExecuteUsesTimezoneForTimestamptzFilter", t, func() {
+		globalMetaCache = &MetaCache{}
+
+		const (
+			dbName         = "db"
+			collectionName = "timestamptz_collection"
+			collectionID   = int64(100)
+		)
+		schema := mustNewSchemaInfo(&schemapb.CollectionSchema{
+			Name: collectionName,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: testInt64Field, DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{
+					FieldID:  101,
+					Name:     testFloatVecField,
+					DataType: schemapb.DataType_FloatVector,
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.DimKey, Value: strconv.Itoa(testVecDim)},
+					},
+				},
+				{FieldID: 102, Name: "ts", DataType: schemapb.DataType_Timestamptz},
+			},
+		})
+
+		mockey.Mock((*MetaCache).GetCollectionID).Return(collectionID, nil).Build()
+		mockey.Mock((*MetaCache).GetCollectionInfo).Return(&collectionInfo{
+			updateTimestamp:  100,
+			consistencyLevel: commonpb.ConsistencyLevel_Strong,
+		}, nil).Build()
+		mockey.Mock((*MetaCache).GetCollectionSchema).Return(schema, nil).Build()
+		mockey.Mock(isIgnoreGrowing).Return(false, nil).Build()
+		mockey.Mock((*searchTask).checkNq).Return(int64(1), nil).Build()
+
+		searchParams := append([]*commonpb.KeyValuePair{}, getValidSearchParams()...)
+		searchParams = append(searchParams, &commonpb.KeyValuePair{
+			Key:   common.TimezoneKey,
+			Value: "Asia/Shanghai",
+		})
+		task := &searchTask{
+			Condition:     NewTaskCondition(context.Background()),
+			SearchRequest: &internalpb.SearchRequest{Base: &commonpb.MsgBase{MsgType: commonpb.MsgType_Search}},
+			ctx:           context.Background(),
+			request: &milvuspb.SearchRequest{
+				DbName:         dbName,
+				CollectionName: collectionName,
+				Nq:             1,
+				Dsl:            "ts > ISO '2025-01-01T00:00:00'",
+				SearchParams:   searchParams,
+			},
+			result: &milvuspb.SearchResults{Status: merr.Success()},
+		}
+
+		err := task.PreExecute(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, "Asia/Shanghai", task.resolvedTimezoneStr)
+		plan := &planpb.PlanNode{}
+		require.NoError(t, proto.Unmarshal(task.SerializedExprPlan, plan))
+		rangeExpr := plan.GetVectorAnns().GetPredicates().GetUnaryRangeExpr()
+		require.NotNil(t, rangeExpr)
+		shanghai, err := time.LoadLocation("Asia/Shanghai")
+		require.NoError(t, err)
+		assert.Equal(t, time.Date(2025, 1, 1, 0, 0, 0, 0, shanghai).UnixMicro(), rangeExpr.GetValue().GetInt64Val())
+	})
+}
+
 func TestSearchTask_PostExecute(t *testing.T) {
 	var err error
 


### PR DESCRIPTION
issue: #52112

### What changed

Search `PreExecute` now resolves and validates the request or collection timezone before `initSearchRequest` / `initAdvancedSearchRequest` generates the search plan. This keeps naive `TIMESTAMPTZ` filter literals aligned with the same timezone later used for result formatting.

### Why

Before this change, plan generation could parse a naive `TIMESTAMPTZ` literal with the process local timezone because `t.resolvedTimezoneStr` was still empty. On a `JST+0900` host, a search request with `timezone=Asia/Shanghai` generated the wrong predicate bound:

```text
expected: 1735660800000000
actual:   1735689600000000
```

### Verification

```bash
GOWORK=off \
PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig \
LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib \
LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib \
CGO_LDFLAGS='-Wl,-rpath-link,/home/sheep/workspace/milvus/internal/core/output/lib' \
go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/proxy \
  -run 'TestSearchTaskPreExecuteUsesTimezoneForTimestamptzFilter'
```

```bash
GOWORK=off \
PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig \
LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib \
LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib \
CGO_LDFLAGS='-Wl,-rpath-link,/home/sheep/workspace/milvus/internal/core/output/lib' \
go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/proxy
```

```bash
GOWORK=off \
PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig \
LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib \
LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib \
CGO_LDFLAGS='-Wl,-rpath-link,/home/sheep/workspace/milvus/internal/core/output/lib' \
make static-check
```
