### PR TITLE
enhance: add REST query group by and search order by

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -1411,11 +1411,18 @@ func (h *HandlersV2) query(ctx context.Context, c *gin.Context, anyReq any, dbNa
 	if httpReq.Offset > 0 {
 		req.QueryParams = append(req.QueryParams, &commonpb.KeyValuePair{Key: proxy.OffsetKey, Value: strconv.FormatInt(int64(httpReq.Offset), 10)})
 	}
-	if httpReq.Limit > 0 && !matchCountRule(httpReq.OutputFields) {
+	// Keep the legacy global count(*) behavior: REST never forwards its limit
+	// for a lone count(*). GroupByFields is new, so grouped counts still forward
+	// limit and offset to paginate groups.
+	isLegacyGlobalCount := len(httpReq.GroupByFields) == 0 && matchCountRule(httpReq.OutputFields)
+	if httpReq.Limit > 0 && !isLegacyGlobalCount {
 		req.QueryParams = append(req.QueryParams, &commonpb.KeyValuePair{Key: proxy.LimitKey, Value: strconv.FormatInt(int64(httpReq.Limit), 10)})
 	}
 	if len(httpReq.OrderByFields) > 0 {
 		req.QueryParams = append(req.QueryParams, &commonpb.KeyValuePair{Key: proxy.OrderByFieldsKey, Value: strings.Join(httpReq.OrderByFields, ",")})
+	}
+	if len(httpReq.GroupByFields) > 0 {
+		req.QueryParams = append(req.QueryParams, &commonpb.KeyValuePair{Key: proxy.GroupByFieldsKey, Value: strings.Join(httpReq.GroupByFields, ",")})
 	}
 	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/Query", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.Query(reqCtx, req.(*milvuspb.QueryRequest))
@@ -1904,12 +1911,25 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 			return nil, err
 		}
+		if len(httpReq.OrderByFields) > 0 {
+			err := merr.WrapErrParameterInvalidMsg("orderByFields and searchAggregation cannot be used simultaneously")
+			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+			return nil, err
+		}
 		req.SearchAggregation, err = convertSearchAggregationReq(httpReq.SearchAggregation)
 		if err != nil {
 			mlog.Warn(ctx, "high level restful api, convert SearchAggregation failed", mlog.Err(err))
 			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 			return nil, err
 		}
+	}
+
+	// The legacy searchParams.order_by_fields passthrough would silently shadow the
+	// dedicated field (first key wins on the proxy side), so reject the ambiguity.
+	if len(httpReq.OrderByFields) > 0 && searchParamsContainAny(httpReq.SearchParams, proxy.OrderByFieldsKey) {
+		err := merr.WrapErrParameterInvalidMsg("ambiguous order by: use either orderByFields or searchParams.order_by_fields, not both")
+		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		return nil, err
 	}
 
 	searchParams, err := generateSearchParams(httpReq.SearchParams)
@@ -1929,6 +1949,9 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 	if httpReq.GroupByField != "" && httpReq.GroupSize > 0 {
 		searchParams = append(searchParams, &commonpb.KeyValuePair{Key: ParamGroupSize, Value: strconv.FormatInt(int64(httpReq.GroupSize), 10)})
 		searchParams = append(searchParams, &commonpb.KeyValuePair{Key: ParamStrictGroupSize, Value: strconv.FormatBool(httpReq.StrictGroupSize)})
+	}
+	if len(httpReq.OrderByFields) > 0 {
+		searchParams = append(searchParams, &commonpb.KeyValuePair{Key: proxy.OrderByFieldsKey, Value: strings.Join(httpReq.OrderByFields, ",")})
 	}
 	if len(httpReq.FunctionScore.Functions) != 0 {
 		if req.FunctionScore, err = genFunctionScore(ctx, &httpReq.FunctionScore); err != nil {

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -3761,6 +3761,136 @@ func TestQueryOrderByFields(t *testing.T) {
 	assert.Equal(t, []string{"word_count:desc,book_id:asc"}, orderByValues)
 }
 
+func TestQueryGroupByFields(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         generateCollectionSchema(schemapb.DataType_Int64, false, true),
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Times(6)
+
+	queryParams := make([]map[string]string, 0, 6)
+	mp.EXPECT().Query(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, req *milvuspb.QueryRequest) (*milvuspb.QueryResults, error) {
+		params := make(map[string]string, len(req.GetQueryParams()))
+		for _, pair := range req.GetQueryParams() {
+			params[pair.GetKey()] = pair.GetValue()
+		}
+		queryParams = append(queryParams, params)
+		return &milvuspb.QueryResults{Status: commonSuccessStatus, OutputFields: []string{}, FieldsData: []*schemapb.FieldData{}}, nil
+	}).Times(6)
+
+	testEngine := initHTTPServerV2(mp, false)
+	validateTestCases(t, testEngine, []requestBodyTestCase{
+		{
+			path:        QueryAction,
+			requestBody: []byte(`{"collectionName": "book", "filter": "book_id > 0", "outputFields": ["count(*)"], "groupByFields": ["word_count", "book_id"]}`),
+		},
+		{
+			path:        QueryAction,
+			requestBody: []byte(`{"collectionName": "book", "filter": "book_id > 0", "outputFields": ["count(*)"], "groupByFields": ["word_count"], "limit": 10, "offset": 2}`),
+		},
+		{
+			// Preserve the master REST behavior for a global lone count(*).
+			path:        QueryAction,
+			requestBody: []byte(`{"collectionName": "book", "filter": "book_id > 0", "outputFields": ["count(*)"], "limit": 10}`),
+		},
+		{
+			// Global mixed count aggregates keep master behavior: REST forwards its
+			// default limit and Proxy rejects count(*) pagination.
+			path:        QueryAction,
+			requestBody: []byte(`{"collectionName": "book", "filter": "book_id > 0", "outputFields": ["count(*)", "sum(word_count)"]}`),
+		},
+		{
+			path:        QueryAction,
+			requestBody: []byte(`{"collectionName": "book", "filter": "book_id > 0", "outputFields": ["count(*)", "sum(word_count)"], "groupByFields": ["word_count"], "limit": 10}`),
+		},
+		{
+			path:        QueryAction,
+			requestBody: []byte(`{"collectionName": "book", "filter": "book_id > 0", "outputFields": ["count(*)"], "groupByFields": ["word_count"], "orderByFields": ["word_count:asc"]}`),
+		},
+	}, false)
+
+	require.Len(t, queryParams, 6)
+	assert.Equal(t, "word_count,book_id", queryParams[0][proxy.GroupByFieldsKey])
+	assert.Equal(t, "100", queryParams[0][proxy.LimitKey])
+	assert.Equal(t, "word_count", queryParams[1][proxy.GroupByFieldsKey])
+	assert.Equal(t, "10", queryParams[1][proxy.LimitKey])
+	assert.Equal(t, "2", queryParams[1][proxy.OffsetKey])
+	assert.NotContains(t, queryParams[2], proxy.GroupByFieldsKey)
+	assert.NotContains(t, queryParams[2], proxy.LimitKey)
+	assert.NotContains(t, queryParams[3], proxy.GroupByFieldsKey)
+	assert.Equal(t, "100", queryParams[3][proxy.LimitKey])
+	assert.Equal(t, "word_count", queryParams[4][proxy.GroupByFieldsKey])
+	assert.Equal(t, "10", queryParams[4][proxy.LimitKey])
+	assert.Equal(t, "word_count", queryParams[5][proxy.GroupByFieldsKey])
+	assert.Equal(t, "word_count:asc", queryParams[5][proxy.OrderByFieldsKey])
+}
+
+func TestSearchOrderByFields(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         generateCollectionSchema(schemapb.DataType_Int64, false, true),
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Times(6)
+
+	orderByValues := []string{}
+	mp.EXPECT().Search(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, req *milvuspb.SearchRequest) (*milvuspb.SearchResults, error) {
+		for _, pair := range req.GetSearchParams() {
+			if pair.GetKey() == proxy.OrderByFieldsKey {
+				orderByValues = append(orderByValues, pair.GetValue())
+			}
+		}
+		return &milvuspb.SearchResults{Status: commonSuccessStatus, Results: &schemapb.SearchResultData{TopK: int64(0)}}, nil
+	}).Times(4)
+
+	testEngine := initHTTPServerV2(mp, false)
+	searchAggregation := `"searchAggregation": {"fields": ["word_count"], "size": 1}`
+	validateTestCases(t, testEngine, []requestBodyTestCase{
+		{
+			path:        SearchAction,
+			requestBody: []byte(`{"collectionName": "book", "data": [[0.1, 0.2]], "annsField": "book_intro", "limit": 4, "orderByFields": ["word_count:desc", "book_id:asc"]}`),
+		},
+		{
+			path:        SearchAction,
+			requestBody: []byte(`{"collectionName": "book", "data": [[0.1, 0.2]], "annsField": "book_intro", "limit": 4}`),
+		},
+		{
+			// The legacy searchParams passthrough remains unchanged.
+			path:        SearchAction,
+			requestBody: []byte(`{"collectionName": "book", "data": [[0.1, 0.2]], "annsField": "book_intro", "limit": 4, "searchParams": {"order_by_fields": "book_id:asc"}}`),
+		},
+		{
+			path:        SearchAction,
+			requestBody: []byte(`{"collectionName": "book", "data": [[0.1, 0.2]], "annsField": "book_intro", "limit": 4, "orderByFields": ["word_count:desc"], "searchParams": {"order_by_fields": "book_id:asc"}}`),
+			errCode:     1100,
+			errMsg:      "ambiguous order by: use either orderByFields or searchParams.order_by_fields, not both",
+		},
+		{
+			path:        SearchAction,
+			requestBody: []byte(`{"collectionName": "book", "data": [[0.1, 0.2]], "annsField": "book_intro", "limit": 4, "orderByFields": ["word_count:desc"], ` + searchAggregation + `}`),
+			errCode:     1100,
+			errMsg:      "orderByFields and searchAggregation cannot be used simultaneously",
+		},
+		{
+			// This legacy combination was accepted by master, so it must stay accepted.
+			path:        SearchAction,
+			requestBody: []byte(`{"collectionName": "book", "data": [[0.1, 0.2]], "annsField": "book_intro", "limit": 4, "searchParams": {"order_by_fields": "book_id:asc"}, ` + searchAggregation + `}`),
+		},
+	}, false)
+	assert.Equal(t, []string{"word_count:desc,book_id:asc", "book_id:asc", "book_id:asc"}, orderByValues)
+}
+
 func TestAllowInt64(t *testing.T) {
 	paramtable.Init()
 	// disable rate limit

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -406,7 +406,10 @@ type QueryReqV2 struct {
 	Offset         int32    `json:"offset"`
 	// OrderByFields sorts query results by scalar fields; each item is
 	// "fieldName" or "fieldName:asc" / "fieldName:desc" (default asc).
-	OrderByFields    []string               `json:"orderByFields"`
+	OrderByFields []string `json:"orderByFields"`
+	// GroupByFields groups query results by scalar fields; used together with
+	// aggregation expressions (e.g. count(*), sum(price)) in outputFields.
+	GroupByFields    []string               `json:"groupByFields"`
 	ExprParams       map[string]interface{} `json:"exprParams"`
 	ConsistencyLevel string                 `json:"consistencyLevel"`
 }
@@ -508,6 +511,9 @@ type SearchReqV2 struct {
 	FunctionScore     FunctionScore          `json:"functionScore"`
 	FunctionChains    []FunctionChainReq     `json:"functionChains"`
 	SearchAggregation *SearchAggregationReq  `json:"searchAggregation"`
+	// OrderByFields re-sorts the final search results by scalar fields; each item
+	// is "fieldName" or "fieldName:asc" / "fieldName:desc" (default asc).
+	OrderByFields []string `json:"orderByFields"`
 	// not use Params any more, just for compatibility
 	Params map[string]float64 `json:"params"`
 }


### PR DESCRIPTION
## Summary

Cherry-pick of #52071 for the 3.0 branch.

- Adds REST v2 `groupByFields` for query aggregation.
- Adds REST v2 `orderByFields` for search.
- Preserves existing count(*) and legacy search parameter behavior.

## Verification

- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/distributed/proxy/httpserver -run "Test(QueryGroupByFields|SearchOrderByFields)$"`

## Related

pr: #52071