### PR TITLE
enhance: parallelize QueryNode segment inserts

### DIFF
--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"slices"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -150,6 +151,12 @@ type DeleteBatch struct {
 	Data []*DeleteData
 }
 
+type segmentInsertResult struct {
+	growingSegmentAdded bool
+	err                 error
+	panicValue          any
+}
+
 // Append appends another delete data into this one.
 func (d *DeleteData) Append(ad DeleteData) {
 	d.PrimaryKeys = append(d.PrimaryKeys, ad.PrimaryKeys...)
@@ -161,57 +168,123 @@ func (d *DeleteData) Append(ad DeleteData) {
 func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 	method := "ProcessInsert"
 	tr := timerecord.NewTimeRecorder(method)
-	log := sd.getLogger(context.Background())
+	observeProcessCost := func() {
+		metrics.QueryNodeProcessCost.WithLabelValues(paramtable.GetStringNodeID(), metrics.InsertLabel).
+			Observe(float64(tr.ElapseSpan().Milliseconds()))
+	}
+
+	segmentIDs := make([]int64, 0, len(insertRecords))
+	for segmentID := range insertRecords {
+		segmentIDs = append(segmentIDs, segmentID)
+	}
+	slices.Sort(segmentIDs)
+	if len(segmentIDs) == 0 {
+		observeProcessCost()
+		return
+	}
+
+	results := make([]segmentInsertResult, len(segmentIDs))
+	if len(segmentIDs) == 1 {
+		results[0] = sd.runProcessInsertTask(segmentIDs[0], insertRecords[segmentIDs[0]])
+	} else {
+		futures := make([]*conc.Future[struct{}], len(segmentIDs))
+		pool := segments.GetInsertPool()
+		for index, segmentID := range segmentIDs {
+			index := index
+			segmentID := segmentID
+			futures[index] = pool.Submit(func() (struct{}, error) {
+				results[index] = sd.runProcessInsertTask(segmentID, insertRecords[segmentID])
+				return struct{}{}, nil
+			})
+		}
+		for index, future := range futures {
+			if _, err := future.Await(); err != nil && results[index].err == nil && results[index].panicValue == nil {
+				results[index].err = err
+			}
+		}
+	}
+
 	growingSegmentAdded := false
-	for segmentID, insertData := range insertRecords {
-		growing := sd.segmentManager.GetGrowing(segmentID)
-		newGrowingSegment := false
-		if growing == nil {
-			var err error
-			// TODO: It's a wired implementation that growing segment have load info.
-			// we should separate the growing segment and sealed segment by type system.
-			growing, err = segments.NewSegment(
-				context.Background(),
-				sd.collection,
-				sd.segmentManager,
-				segments.SegmentTypeGrowing,
-				0,
-				&querypb.SegmentLoadInfo{
-					SegmentID:     segmentID,
-					PartitionID:   insertData.PartitionID,
-					CollectionID:  sd.collectionID,
-					InsertChannel: sd.vchannelName,
-					StartPosition: insertData.StartPosition,
-					DeltaPosition: insertData.StartPosition,
-					Level:         datapb.SegmentLevel_L1,
-				},
-			)
-			if err != nil {
-				log.Error(context.TODO(), "failed to create new segment",
-					mlog.FieldSegmentID(segmentID),
-					mlog.Err(err))
-				panic(err)
-			}
-			newGrowingSegment = true
-		}
+	for _, result := range results {
+		growingSegmentAdded = growingSegmentAdded || result.growingSegmentAdded
+	}
+	if growingSegmentAdded {
+		sd.notifyLeaderViewUpdated()
+	}
 
-		err := growing.Insert(context.Background(), insertData.RowIDs, insertData.Timestamps, insertData.InsertRecord)
+	for _, result := range results {
+		if result.panicValue != nil {
+			panic(result.panicValue)
+		}
+		if result.err != nil {
+			panic(result.err)
+		}
+	}
+	observeProcessCost()
+}
+
+func (sd *shardDelegator) runProcessInsertTask(segmentID int64, insertData *InsertData) (result segmentInsertResult) {
+	defer func() {
+		result.panicValue = recover()
+	}()
+	result.growingSegmentAdded, result.err = sd.processInsert(segmentID, insertData)
+	return result
+}
+
+func (sd *shardDelegator) processInsert(segmentID int64, insertData *InsertData) (bool, error) {
+	log := sd.getLogger(context.Background())
+	growing := sd.segmentManager.GetGrowing(segmentID)
+	newGrowingSegment := false
+	if growing == nil {
+		var err error
+		// TODO: It's a wired implementation that growing segment have load info.
+		// we should separate the growing segment and sealed segment by type system.
+		growing, err = segments.NewSegment(
+			context.Background(),
+			sd.collection,
+			sd.segmentManager,
+			segments.SegmentTypeGrowing,
+			0,
+			&querypb.SegmentLoadInfo{
+				SegmentID:     segmentID,
+				PartitionID:   insertData.PartitionID,
+				CollectionID:  sd.collectionID,
+				InsertChannel: sd.vchannelName,
+				StartPosition: insertData.StartPosition,
+				DeltaPosition: insertData.StartPosition,
+				Level:         datapb.SegmentLevel_L1,
+			},
+		)
 		if err != nil {
-			log.Error(context.TODO(), "failed to insert data into growing segment",
+			log.Error(context.TODO(), "failed to create new segment",
 				mlog.FieldSegmentID(segmentID),
-				mlog.Err(err),
-			)
-			if errors.IsAny(err, merr.ErrSegmentNotLoaded, merr.ErrSegmentNotFound) {
-				log.Warn(context.TODO(), "try to insert data into released segment, skip it", mlog.Err(err))
-				continue
-			}
-			// panic here, insert failure
-			panic(err)
+				mlog.Err(err))
+			return false, err
 		}
-		growing.UpdatePkCandidate(insertData.PrimaryKeys)
+		newGrowingSegment = true
+	}
 
-		if newGrowingSegment {
+	err := growing.Insert(context.Background(), insertData.RowIDs, insertData.Timestamps, insertData.InsertRecord)
+	if err != nil {
+		log.Error(context.TODO(), "failed to insert data into growing segment",
+			mlog.FieldSegmentID(segmentID),
+			mlog.Err(err),
+		)
+		if errors.IsAny(err, merr.ErrSegmentNotLoaded, merr.ErrSegmentNotFound) {
+			log.Warn(context.TODO(), "try to insert data into released segment, skip it", mlog.Err(err))
+			return false, nil
+		}
+		return false, err
+	}
+	growing.UpdatePkCandidate(insertData.PrimaryKeys)
+
+	growingSegmentAdded := false
+	excluded := false
+	if newGrowingSegment {
+		func() {
 			sd.growingSegmentLock.Lock()
+			defer sd.growingSegmentLock.Unlock()
+
 			// Forbid create growing segment in excluded segment
 			// 	(Now excluded ts may not worked for growing segment with multiple partition.
 			//	Because use checkpoint ts as excluded ts when add excluded, but it may less than last message ts.
@@ -221,9 +294,8 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 			//	Use right ts when add excluded segment. And Verify with insert ts here.
 			if ok := sd.VerifyExcludedSegments(segmentID, 0); !ok {
 				log.Warn(context.TODO(), "try to insert data into released segment, skip it", mlog.FieldSegmentID(segmentID))
-				sd.growingSegmentLock.Unlock()
-				growing.Release(context.Background())
-				continue
+				excluded = true
+				return
 			}
 
 			if !sd.distribution.GrowingSegmentExists(segmentID) {
@@ -242,23 +314,21 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 				})
 				growingSegmentAdded = true
 			}
-
-			sd.growingSegmentLock.Unlock()
-		} else if idfOracle := sd.getIDFOracle(); idfOracle != nil {
-			idfOracle.UpdateGrowing(growing.ID(), insertData.BM25Stats)
+		}()
+		if excluded {
+			growing.Release(context.Background())
+			return false, nil
 		}
-		log.Info(context.TODO(), "insert into growing segment",
-			mlog.FieldCollectionID(growing.Collection()),
-			mlog.FieldSegmentID(segmentID),
-			mlog.Int("rowCount", len(insertData.RowIDs)),
-			mlog.Uint64("maxTimestamp", insertData.Timestamps[len(insertData.Timestamps)-1]),
-		)
+	} else if idfOracle := sd.getIDFOracle(); idfOracle != nil {
+		idfOracle.UpdateGrowing(growing.ID(), insertData.BM25Stats)
 	}
-	if growingSegmentAdded {
-		sd.notifyLeaderViewUpdated()
-	}
-	metrics.QueryNodeProcessCost.WithLabelValues(paramtable.GetStringNodeID(), metrics.InsertLabel).
-		Observe(float64(tr.ElapseSpan().Milliseconds()))
+	log.Info(context.TODO(), "insert into growing segment",
+		mlog.FieldCollectionID(growing.Collection()),
+		mlog.FieldSegmentID(segmentID),
+		mlog.Int("rowCount", len(insertData.RowIDs)),
+		mlog.Uint64("maxTimestamp", insertData.Timestamps[len(insertData.Timestamps)-1]),
+	)
+	return growingSegmentAdded, nil
 }
 
 // ProcessDelete handles delete data in delegator.

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -217,6 +217,7 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 			panic(result.panicValue)
 		}
 		if result.err != nil {
+			// panic here, insert failure
 			panic(result.err)
 		}
 	}
@@ -227,11 +228,11 @@ func (sd *shardDelegator) runProcessInsertTask(segmentID int64, insertData *Inse
 	defer func() {
 		result.panicValue = recover()
 	}()
-	result.growingSegmentAdded, result.err = sd.processInsert(segmentID, insertData)
+	result.err = sd.processInsert(segmentID, insertData, &result.growingSegmentAdded)
 	return result
 }
 
-func (sd *shardDelegator) processInsert(segmentID int64, insertData *InsertData) (bool, error) {
+func (sd *shardDelegator) processInsert(segmentID int64, insertData *InsertData, growingSegmentAdded *bool) error {
 	log := sd.getLogger(context.Background())
 	growing := sd.segmentManager.GetGrowing(segmentID)
 	newGrowingSegment := false
@@ -259,7 +260,7 @@ func (sd *shardDelegator) processInsert(segmentID int64, insertData *InsertData)
 			log.Error(context.TODO(), "failed to create new segment",
 				mlog.FieldSegmentID(segmentID),
 				mlog.Err(err))
-			return false, err
+			return err
 		}
 		newGrowingSegment = true
 	}
@@ -272,13 +273,12 @@ func (sd *shardDelegator) processInsert(segmentID int64, insertData *InsertData)
 		)
 		if errors.IsAny(err, merr.ErrSegmentNotLoaded, merr.ErrSegmentNotFound) {
 			log.Warn(context.TODO(), "try to insert data into released segment, skip it", mlog.Err(err))
-			return false, nil
+			return nil
 		}
-		return false, err
+		return err
 	}
 	growing.UpdatePkCandidate(insertData.PrimaryKeys)
 
-	growingSegmentAdded := false
 	excluded := false
 	if newGrowingSegment {
 		func() {
@@ -312,12 +312,12 @@ func (sd *shardDelegator) processInsert(segmentID int64, insertData *InsertData)
 					TargetVersion: initialTargetVersion,
 					Candidate:     growing, // growing segment itself is the Candidate
 				})
-				growingSegmentAdded = true
+				*growingSegmentAdded = true
 			}
 		}()
 		if excluded {
 			growing.Release(context.Background())
-			return false, nil
+			return nil
 		}
 	} else if idfOracle := sd.getIDFOracle(); idfOracle != nil {
 		idfOracle.UpdateGrowing(growing.ID(), insertData.BM25Stats)
@@ -328,7 +328,7 @@ func (sd *shardDelegator) processInsert(segmentID int64, insertData *InsertData)
 		mlog.Int("rowCount", len(insertData.RowIDs)),
 		mlog.Uint64("maxTimestamp", insertData.Timestamps[len(insertData.Timestamps)-1]),
 	)
-	return growingSegmentAdded, nil
+	return nil
 }
 
 // ProcessDelete handles delete data in delegator.

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -155,6 +155,7 @@ type segmentInsertResult struct {
 	growingSegmentAdded bool
 	err                 error
 	panicValue          any
+	panicked            bool
 }
 
 // Append appends another delete data into this one.
@@ -198,7 +199,7 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 			})
 		}
 		for index, future := range futures {
-			if _, err := future.Await(); err != nil && results[index].err == nil && results[index].panicValue == nil {
+			if _, err := future.Await(); err != nil && !results[index].panicked && results[index].err == nil {
 				results[index].err = err
 			}
 		}
@@ -213,7 +214,7 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 	}
 
 	for _, result := range results {
-		if result.panicValue != nil {
+		if result.panicked {
 			panic(result.panicValue)
 		}
 		if result.err != nil {
@@ -225,10 +226,15 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 }
 
 func (sd *shardDelegator) runProcessInsertTask(segmentID int64, insertData *InsertData) (result segmentInsertResult) {
+	completed := false
 	defer func() {
-		result.panicValue = recover()
+		if !completed {
+			result.panicked = true
+			result.panicValue = recover()
+		}
 	}()
 	result.err = sd.processInsert(segmentID, insertData, &result.growingSegmentAdded)
+	completed = true
 	return result
 }
 

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -467,15 +467,19 @@ func (s *DelegatorDataSuite) TestProcessInsertRunsDistinctSegmentsConcurrently()
 
 func (s *DelegatorDataSuite) TestProcessInsertMixedSkipAndSuccess() {
 	const (
-		excludedSegmentID = int64(201)
-		releasedSegmentID = int64(202)
-		successSegmentID  = int64(203)
+		excludedSegmentID  = int64(201)
+		notLoadedSegmentID = int64(202)
+		notFoundSegmentID  = int64(203)
+		successSegmentID   = int64(204)
 	)
 	s.delegator.AddExcludedSegments(map[int64]uint64{excludedSegmentID: 1})
 
 	patch := mockey.Mock((*segments.LocalSegment).Insert).To(func(segment *segments.LocalSegment, _ context.Context, _ []int64, _ []typeutil.Timestamp, _ *segcorepb.InsertRecord) error {
-		if segment.ID() == releasedSegmentID {
-			return merr.WrapErrSegmentNotLoaded(releasedSegmentID, "test segment released")
+		switch segment.ID() {
+		case notLoadedSegmentID:
+			return merr.WrapErrSegmentNotLoaded(notLoadedSegmentID, "test segment released")
+		case notFoundSegmentID:
+			return merr.WrapErrSegmentNotFound(notFoundSegmentID, "test segment not found")
 		}
 		return nil
 	}).Build()
@@ -483,13 +487,15 @@ func (s *DelegatorDataSuite) TestProcessInsertMixedSkipAndSuccess() {
 
 	s.NotPanics(func() {
 		s.delegator.ProcessInsert(map[int64]*InsertData{
-			excludedSegmentID: validInsertData(),
-			releasedSegmentID: validInsertData(),
-			successSegmentID:  validInsertData(),
+			excludedSegmentID:  validInsertData(),
+			notLoadedSegmentID: validInsertData(),
+			notFoundSegmentID:  validInsertData(),
+			successSegmentID:   validInsertData(),
 		})
 	})
 	s.Nil(s.manager.Segment.GetGrowing(excludedSegmentID))
-	s.Nil(s.manager.Segment.GetGrowing(releasedSegmentID))
+	s.Nil(s.manager.Segment.GetGrowing(notLoadedSegmentID))
+	s.Nil(s.manager.Segment.GetGrowing(notFoundSegmentID))
 	s.NotNil(s.manager.Segment.GetGrowing(successSegmentID))
 }
 
@@ -621,6 +627,97 @@ func (s *DelegatorDataSuite) TestProcessInsertPreservesWorkerPanicValueAfterAllT
 	s.Equal(int32(1), notifyCount.Load(), "leader view callback must run before propagating the worker panic")
 }
 
+func (s *DelegatorDataSuite) TestProcessInsertNotifiesAfterPostRegistrationPanic() {
+	const (
+		panicSegmentID   = int64(451)
+		blockedSegmentID = int64(452)
+	)
+
+	setupPatch := mockey.Mock((*segments.LocalSegment).Insert).Return(nil).Build()
+	s.delegator.ProcessInsert(map[int64]*InsertData{blockedSegmentID: validInsertData()})
+	setupPatch.UnPatch()
+	s.Require().NotNil(s.manager.Segment.GetGrowing(blockedSegmentID))
+
+	panicValue := &struct{ name string }{name: "post-registration panic"}
+	panicInsertEntered := make(chan struct{})
+	blockedInsertEntered := make(chan struct{})
+	releaseBlocked := make(chan struct{})
+	insertPatch := mockey.Mock((*segments.LocalSegment).Insert).To(func(segment *segments.LocalSegment, _ context.Context, _ []int64, _ []typeutil.Timestamp, _ *segcorepb.InsertRecord) error {
+		switch segment.ID() {
+		case panicSegmentID:
+			close(panicInsertEntered)
+		case blockedSegmentID:
+			close(blockedInsertEntered)
+			<-releaseBlocked
+		}
+		return nil
+	}).Build()
+	defer insertPatch.UnPatch()
+	collectionPatch := mockey.Mock((*segments.LocalSegment).Collection).To(func(segment *segments.LocalSegment) int64 {
+		if segment.ID() == panicSegmentID && s.delegator.distribution.GrowingSegmentExists(panicSegmentID) {
+			panic(panicValue)
+		}
+		return s.collectionID
+	}).Build()
+	defer collectionPatch.UnPatch()
+
+	var notifyCount atomic.Int32
+	s.delegator.leaderViewUpdatedCallback = func(string) { notifyCount.Add(1) }
+	defer func() { s.delegator.leaderViewUpdatedCallback = nil }()
+
+	done := processInsertAsync(s.delegator, map[int64]*InsertData{
+		panicSegmentID:   validInsertData(),
+		blockedSegmentID: validInsertData(),
+	})
+	waitSignal := func(ch <-chan struct{}) bool {
+		select {
+		case <-ch:
+			return true
+		case <-time.After(500 * time.Millisecond):
+			return false
+		}
+	}
+	panicStarted := waitSignal(panicInsertEntered)
+	blockedStarted := waitSignal(blockedInsertEntered)
+
+	registeredBeforeRelease := false
+	deadline := time.After(500 * time.Millisecond)
+
+waitForRegistration:
+	for !registeredBeforeRelease {
+		registeredBeforeRelease = s.delegator.distribution.GrowingSegmentExists(panicSegmentID)
+		if registeredBeforeRelease {
+			break
+		}
+		select {
+		case <-deadline:
+			break waitForRegistration
+		case <-time.After(time.Millisecond):
+		}
+	}
+	panickedBeforeRelease := false
+	select {
+	case <-done:
+		panickedBeforeRelease = true
+	case <-time.After(100 * time.Millisecond):
+	}
+	s.Zero(notifyCount.Load(), "leader view callback must wait for every segment task")
+	close(releaseBlocked)
+
+	var result processInsertResult
+	select {
+	case result = <-done:
+	case <-time.After(5 * time.Second):
+		s.FailNow("ProcessInsert did not finish after releasing the existing segment insert")
+	}
+	s.True(panicStarted, "post-registration panic segment insert did not start")
+	s.True(blockedStarted, "existing segment insert did not block concurrently")
+	s.True(registeredBeforeRelease, "new segment was not registered before its post-registration panic")
+	s.False(panickedBeforeRelease, "ProcessInsert propagated panic before the blocked task completed")
+	s.Same(panicValue, result.panicValue)
+	s.Equal(int32(1), notifyCount.Load(), "registered segment must notify before propagating its later panic")
+}
+
 func (s *DelegatorDataSuite) TestProcessInsertRegistersParallelBM25Stats() {
 	s.genCollectionWithFunction()
 	const (
@@ -675,6 +772,18 @@ func (s *DelegatorDataSuite) TestProcessInsertRegistersParallelBM25Stats() {
 	s.NotNil(s.manager.Segment.GetGrowing(firstSegmentID))
 	s.NotNil(s.manager.Segment.GetGrowing(secondSegmentID))
 	oracle := s.getIDFOracleForTest()
+	firstGrowingStats, ok := oracle.growing[firstSegmentID]
+	s.Require().True(ok)
+	firstFieldStats, ok := firstGrowingStats.bm25Stats[bm25FieldID]
+	s.Require().True(ok)
+	s.Equal(int64(2), firstFieldStats.NumRow())
+	s.Equal(int64(2), firstFieldStats.NumToken())
+	secondGrowingStats, ok := oracle.growing[secondSegmentID]
+	s.Require().True(ok)
+	secondFieldStats, ok := secondGrowingStats.bm25Stats[bm25FieldID]
+	s.Require().True(ok)
+	s.Equal(int64(3), secondFieldStats.NumRow())
+	s.Equal(int64(3), secondFieldStats.NumToken())
 	fieldStats, err := oracle.current.GetStats(bm25FieldID)
 	s.Require().NoError(err)
 	s.Equal(int64(5), fieldStats.NumRow())

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"sync"
@@ -352,17 +353,23 @@ func validInsertData() *InsertData {
 
 type processInsertResult struct {
 	panicValue any
+	panicked   bool
 }
 
 func processInsertAsync(sd *shardDelegator, insertRecords map[int64]*InsertData) <-chan processInsertResult {
 	done := make(chan processInsertResult, 1)
 	go func() {
 		var result processInsertResult
+		completed := false
 		defer func() {
-			result.panicValue = recover()
+			if !completed {
+				result.panicked = true
+				result.panicValue = recover()
+			}
 			done <- result
 		}()
 		sd.ProcessInsert(insertRecords)
+		completed = true
 	}()
 	return done
 }
@@ -442,10 +449,15 @@ func (s *DelegatorDataSuite) TestProcessInsertRunsDistinctSegmentsConcurrently()
 		select {
 		case segmentID := <-entered:
 			enteredIDs = append(enteredIDs, segmentID)
-		case <-time.After(500 * time.Millisecond):
+		case <-time.After(5 * time.Second):
 			close(release)
-			result := <-done
-			s.Nil(result.panicValue)
+			select {
+			case result := <-done:
+				s.False(result.panicked)
+				s.Nil(result.panicValue)
+			case <-time.After(5 * time.Second):
+				s.Fail("ProcessInsert did not finish during overlap-test cleanup")
+			}
 			s.Fail("distinct segment inserts did not overlap")
 			return
 		}
@@ -454,6 +466,7 @@ func (s *DelegatorDataSuite) TestProcessInsertRunsDistinctSegmentsConcurrently()
 
 	select {
 	case result := <-done:
+		s.False(result.panicked)
 		s.Nil(result.panicValue)
 	case <-time.After(5 * time.Second):
 		s.FailNow("ProcessInsert did not finish after releasing inserts")
@@ -623,8 +636,76 @@ func (s *DelegatorDataSuite) TestProcessInsertPreservesWorkerPanicValueAfterAllT
 	s.True(panicStarted, "panicking insert did not start while the other insert was blocked")
 	s.True(blockedStarted, "blocked insert did not start while the panicking insert ran")
 	s.False(panickedBeforeRelease, "ProcessInsert propagated worker panic before all tasks completed")
+	s.True(result.panicked)
 	s.Same(panicValue, result.panicValue)
 	s.Equal(int32(1), notifyCount.Load(), "leader view callback must run before propagating the worker panic")
+}
+
+func (s *DelegatorDataSuite) TestProcessInsertPreservesNilWorkerPanicAfterAllTasks() {
+	const (
+		panicSegmentID   = int64(425)
+		blockedSegmentID = int64(426)
+	)
+
+	panicEntered := make(chan struct{})
+	blockedEntered := make(chan struct{})
+	releaseBlocked := make(chan struct{})
+	patch := mockey.Mock((*segments.LocalSegment).Insert).To(func(segment *segments.LocalSegment, _ context.Context, _ []int64, _ []typeutil.Timestamp, _ *segcorepb.InsertRecord) error {
+		switch segment.ID() {
+		case panicSegmentID:
+			close(panicEntered)
+			panic(nil)
+		case blockedSegmentID:
+			close(blockedEntered)
+			<-releaseBlocked
+		}
+		return nil
+	}).Build()
+	defer patch.UnPatch()
+
+	var notifyCount atomic.Int32
+	s.delegator.leaderViewUpdatedCallback = func(string) { notifyCount.Add(1) }
+	defer func() { s.delegator.leaderViewUpdatedCallback = nil }()
+
+	done := processInsertAsync(s.delegator, map[int64]*InsertData{
+		panicSegmentID:   validInsertData(),
+		blockedSegmentID: validInsertData(),
+	})
+	waitSignal := func(ch <-chan struct{}) bool {
+		select {
+		case <-ch:
+			return true
+		case <-time.After(5 * time.Second):
+			return false
+		}
+	}
+	panicStarted := waitSignal(panicEntered)
+	blockedStarted := waitSignal(blockedEntered)
+	panickedBeforeRelease := false
+	if panicStarted && blockedStarted {
+		select {
+		case <-done:
+			panickedBeforeRelease = true
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	s.Zero(notifyCount.Load(), "leader view callback must wait for the blocked segment task")
+	close(releaseBlocked)
+
+	var result processInsertResult
+	select {
+	case result = <-done:
+	case <-time.After(5 * time.Second):
+		s.FailNow("ProcessInsert did not finish after releasing the blocked nil-panic batch")
+	}
+	s.True(panicStarted, "nil-panicking insert did not start while the other insert was blocked")
+	s.True(blockedStarted, "blocked insert did not start while the nil-panicking insert ran")
+	s.False(panickedBeforeRelease, "ProcessInsert propagated nil panic before all tasks completed")
+	s.True(result.panicked, "caller goroutine must re-panic even when the panic value is nil")
+	if os.Getenv("GODEBUG") == "panicnil=1" {
+		s.Nil(result.panicValue, "panic(nil) must remain nil when panicnil=1")
+	}
+	s.Equal(int32(1), notifyCount.Load(), "leader view callback must run before propagating nil panic")
 }
 
 func (s *DelegatorDataSuite) TestProcessInsertNotifiesAfterPostRegistrationPanic() {
@@ -633,9 +714,11 @@ func (s *DelegatorDataSuite) TestProcessInsertNotifiesAfterPostRegistrationPanic
 		blockedSegmentID = int64(452)
 	)
 
-	setupPatch := mockey.Mock((*segments.LocalSegment).Insert).Return(nil).Build()
-	s.delegator.ProcessInsert(map[int64]*InsertData{blockedSegmentID: validInsertData()})
-	setupPatch.UnPatch()
+	func() {
+		setupPatch := mockey.Mock((*segments.LocalSegment).Insert).Return(nil).Build()
+		defer setupPatch.UnPatch()
+		s.delegator.ProcessInsert(map[int64]*InsertData{blockedSegmentID: validInsertData()})
+	}()
 	s.Require().NotNil(s.manager.Segment.GetGrowing(blockedSegmentID))
 
 	panicValue := &struct{ name string }{name: "post-registration panic"}
@@ -714,6 +797,7 @@ waitForRegistration:
 	s.True(blockedStarted, "existing segment insert did not block concurrently")
 	s.True(registeredBeforeRelease, "new segment was not registered before its post-registration panic")
 	s.False(panickedBeforeRelease, "ProcessInsert propagated panic before the blocked task completed")
+	s.True(result.panicked)
 	s.Same(panicValue, result.panicValue)
 	s.Equal(int32(1), notifyCount.Load(), "registered segment must notify before propagating its later panic")
 }
@@ -753,9 +837,13 @@ func (s *DelegatorDataSuite) TestProcessInsertRegistersParallelBM25Stats() {
 		select {
 		case segmentID := <-entered:
 			enteredIDs = append(enteredIDs, segmentID)
-		case <-time.After(500 * time.Millisecond):
+		case <-time.After(5 * time.Second):
 			close(release)
-			<-done
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				s.Fail("ProcessInsert did not finish during BM25 overlap-test cleanup")
+			}
 			s.Fail("BM25 segment inserts did not overlap")
 			return
 		}
@@ -764,6 +852,7 @@ func (s *DelegatorDataSuite) TestProcessInsertRegistersParallelBM25Stats() {
 
 	select {
 	case result := <-done:
+		s.False(result.panicked)
 		s.Nil(result.panicValue)
 	case <-time.After(5 * time.Second):
 		s.FailNow("ProcessInsert did not finish BM25 inserts")

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -375,7 +375,6 @@ func processInsertAsync(sd *shardDelegator, insertRecords map[int64]*InsertData)
 }
 
 func (s *DelegatorDataSuite) TestProcessInsert() {
-
 	s.Run("normal_insert", func() {
 		s.delegator.ProcessInsert(map[int64]*InsertData{
 			100: validInsertData(),
@@ -654,7 +653,7 @@ func (s *DelegatorDataSuite) TestProcessInsertPreservesNilWorkerPanicAfterAllTas
 		switch segment.ID() {
 		case panicSegmentID:
 			close(panicEntered)
-			panic(nil)
+			panic(nil) //nolint:govet // Exercise panic(nil) compatibility semantics explicitly.
 		case blockedSegmentID:
 			close(blockedEntered)
 			<-releaseBlocked

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -307,48 +308,66 @@ func (s *DelegatorDataSuite) allocFunctionRunnersForTest() {
 	s.Require().NoError(function.GetManager().Update(s.collectionID, delegatorFunctionRunnerKey(s.vchannelName), s.delegator.collection.Schema()))
 }
 
-func (s *DelegatorDataSuite) TestProcessInsert() {
-	validInsertData := func() *InsertData {
-		return &InsertData{
-			RowIDs:        []int64{0, 1},
-			PrimaryKeys:   []storage.PrimaryKey{storage.NewInt64PrimaryKey(1), storage.NewInt64PrimaryKey(2)},
-			Timestamps:    []uint64{10, 10},
-			PartitionID:   500,
-			StartPosition: &msgpb.MsgPosition{},
-			InsertRecord: &segcorepb.InsertRecord{
-				FieldsData: []*schemapb.FieldData{
-					{
-						Type:      schemapb.DataType_Int64,
-						FieldName: "id",
-						Field: &schemapb.FieldData_Scalars{
-							Scalars: &schemapb.ScalarField{
-								Data: &schemapb.ScalarField_LongData{
-									LongData: &schemapb.LongArray{
-										Data: []int64{1, 2},
-									},
+func validInsertData() *InsertData {
+	return &InsertData{
+		RowIDs:        []int64{0, 1},
+		PrimaryKeys:   []storage.PrimaryKey{storage.NewInt64PrimaryKey(1), storage.NewInt64PrimaryKey(2)},
+		Timestamps:    []uint64{10, 10},
+		PartitionID:   500,
+		StartPosition: &msgpb.MsgPosition{},
+		InsertRecord: &segcorepb.InsertRecord{
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Int64,
+					FieldName: "id",
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_LongData{
+								LongData: &schemapb.LongArray{
+									Data: []int64{1, 2},
 								},
 							},
 						},
-						FieldId: 100,
 					},
-					{
-						Type:      schemapb.DataType_FloatVector,
-						FieldName: "vector",
-						Field: &schemapb.FieldData_Vectors{
-							Vectors: &schemapb.VectorField{
-								Dim: 128,
-								Data: &schemapb.VectorField_FloatVector{
-									FloatVector: &schemapb.FloatArray{Data: make([]float32, 128*2)},
-								},
-							},
-						},
-						FieldId: 101,
-					},
+					FieldId: 100,
 				},
-				NumRows: 2,
+				{
+					Type:      schemapb.DataType_FloatVector,
+					FieldName: "vector",
+					Field: &schemapb.FieldData_Vectors{
+						Vectors: &schemapb.VectorField{
+							Dim: 128,
+							Data: &schemapb.VectorField_FloatVector{
+								FloatVector: &schemapb.FloatArray{Data: make([]float32, 128*2)},
+							},
+						},
+					},
+					FieldId: 101,
+				},
 			},
-		}
+			NumRows: 2,
+		},
 	}
+}
+
+type processInsertResult struct {
+	panicValue any
+}
+
+func processInsertAsync(sd *shardDelegator, insertRecords map[int64]*InsertData) <-chan processInsertResult {
+	done := make(chan processInsertResult, 1)
+	go func() {
+		var result processInsertResult
+		defer func() {
+			result.panicValue = recover()
+			done <- result
+		}()
+		sd.ProcessInsert(insertRecords)
+	}()
+	return done
+}
+
+func (s *DelegatorDataSuite) TestProcessInsert() {
 
 	s.Run("normal_insert", func() {
 		s.delegator.ProcessInsert(map[int64]*InsertData{
@@ -380,37 +399,285 @@ func (s *DelegatorDataSuite) TestProcessInsert() {
 	})
 
 	s.Run("insert_bad_data", func() {
+		badInsertData := validInsertData()
+		badInsertData.InsertRecord.FieldsData = badInsertData.InsertRecord.FieldsData[:1]
 		s.Panics(func() {
 			s.delegator.ProcessInsert(map[int64]*InsertData{
-				100: {
-					RowIDs:        []int64{0, 1},
-					PrimaryKeys:   []storage.PrimaryKey{storage.NewInt64PrimaryKey(1), storage.NewInt64PrimaryKey(2)},
-					Timestamps:    []uint64{10, 10},
-					PartitionID:   500,
-					StartPosition: &msgpb.MsgPosition{},
-					InsertRecord: &segcorepb.InsertRecord{
-						FieldsData: []*schemapb.FieldData{
-							{
-								Type:      schemapb.DataType_Int64,
-								FieldName: "id",
-								Field: &schemapb.FieldData_Scalars{
-									Scalars: &schemapb.ScalarField{
-										Data: &schemapb.ScalarField_LongData{
-											LongData: &schemapb.LongArray{
-												Data: []int64{1, 2},
-											},
-										},
-									},
-								},
-								FieldId: 100,
-							},
-						},
-						NumRows: 2,
-					},
-				},
+				100: badInsertData,
 			})
 		})
 	})
+}
+
+func (s *DelegatorDataSuite) TestProcessInsertRunsDistinctSegmentsConcurrently() {
+	const (
+		firstSegmentID  = int64(101)
+		secondSegmentID = int64(102)
+	)
+
+	entered := make(chan int64, 2)
+	release := make(chan struct{})
+	patch := mockey.Mock((*segments.LocalSegment).Insert).To(func(segment *segments.LocalSegment, _ context.Context, _ []int64, _ []typeutil.Timestamp, _ *segcorepb.InsertRecord) error {
+		entered <- segment.ID()
+		<-release
+		return nil
+	}).Build()
+	defer patch.UnPatch()
+
+	var notifyCount atomic.Int32
+	notifiedChannels := make(chan string, 2)
+	s.delegator.leaderViewUpdatedCallback = func(channel string) {
+		notifiedChannels <- channel
+		notifyCount.Add(1)
+	}
+	defer func() { s.delegator.leaderViewUpdatedCallback = nil }()
+
+	done := processInsertAsync(s.delegator, map[int64]*InsertData{
+		firstSegmentID:  validInsertData(),
+		secondSegmentID: validInsertData(),
+	})
+
+	enteredIDs := make([]int64, 0, 2)
+	for len(enteredIDs) < 2 {
+		select {
+		case segmentID := <-entered:
+			enteredIDs = append(enteredIDs, segmentID)
+		case <-time.After(500 * time.Millisecond):
+			close(release)
+			result := <-done
+			s.Nil(result.panicValue)
+			s.Fail("distinct segment inserts did not overlap")
+			return
+		}
+	}
+	close(release)
+
+	select {
+	case result := <-done:
+		s.Nil(result.panicValue)
+	case <-time.After(5 * time.Second):
+		s.FailNow("ProcessInsert did not finish after releasing inserts")
+	}
+	s.ElementsMatch([]int64{firstSegmentID, secondSegmentID}, enteredIDs)
+	s.NotNil(s.manager.Segment.GetGrowing(firstSegmentID))
+	s.NotNil(s.manager.Segment.GetGrowing(secondSegmentID))
+	s.Equal(int32(1), notifyCount.Load())
+	s.Equal(s.vchannelName, <-notifiedChannels)
+}
+
+func (s *DelegatorDataSuite) TestProcessInsertMixedSkipAndSuccess() {
+	const (
+		excludedSegmentID = int64(201)
+		releasedSegmentID = int64(202)
+		successSegmentID  = int64(203)
+	)
+	s.delegator.AddExcludedSegments(map[int64]uint64{excludedSegmentID: 1})
+
+	patch := mockey.Mock((*segments.LocalSegment).Insert).To(func(segment *segments.LocalSegment, _ context.Context, _ []int64, _ []typeutil.Timestamp, _ *segcorepb.InsertRecord) error {
+		if segment.ID() == releasedSegmentID {
+			return merr.WrapErrSegmentNotLoaded(releasedSegmentID, "test segment released")
+		}
+		return nil
+	}).Build()
+	defer patch.UnPatch()
+
+	s.NotPanics(func() {
+		s.delegator.ProcessInsert(map[int64]*InsertData{
+			excludedSegmentID: validInsertData(),
+			releasedSegmentID: validInsertData(),
+			successSegmentID:  validInsertData(),
+		})
+	})
+	s.Nil(s.manager.Segment.GetGrowing(excludedSegmentID))
+	s.Nil(s.manager.Segment.GetGrowing(releasedSegmentID))
+	s.NotNil(s.manager.Segment.GetGrowing(successSegmentID))
+}
+
+func (s *DelegatorDataSuite) TestProcessInsertWaitsForAllTasksBeforePanickingOnError() {
+	const (
+		errorSegmentID   = int64(301)
+		blockedSegmentID = int64(302)
+	)
+
+	unexpectedErr := errors.New("unexpected insert error")
+	errorEntered := make(chan struct{})
+	blockedEntered := make(chan struct{})
+	releaseBlocked := make(chan struct{})
+	patch := mockey.Mock((*segments.LocalSegment).Insert).To(func(segment *segments.LocalSegment, _ context.Context, _ []int64, _ []typeutil.Timestamp, _ *segcorepb.InsertRecord) error {
+		switch segment.ID() {
+		case errorSegmentID:
+			close(errorEntered)
+			return unexpectedErr
+		case blockedSegmentID:
+			close(blockedEntered)
+			<-releaseBlocked
+		}
+		return nil
+	}).Build()
+	defer patch.UnPatch()
+	var notifyCount atomic.Int32
+	s.delegator.leaderViewUpdatedCallback = func(string) { notifyCount.Add(1) }
+	defer func() { s.delegator.leaderViewUpdatedCallback = nil }()
+
+	done := processInsertAsync(s.delegator, map[int64]*InsertData{
+		errorSegmentID:   validInsertData(),
+		blockedSegmentID: validInsertData(),
+	})
+
+	waitSignal := func(ch <-chan struct{}) bool {
+		select {
+		case <-ch:
+			return true
+		case <-time.After(500 * time.Millisecond):
+			return false
+		}
+	}
+	errorStarted := waitSignal(errorEntered)
+	blockedStarted := waitSignal(blockedEntered)
+	panickedBeforeRelease := false
+	if errorStarted && blockedStarted {
+		select {
+		case <-done:
+			panickedBeforeRelease = true
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	close(releaseBlocked)
+
+	var result processInsertResult
+	select {
+	case result = <-done:
+	case <-time.After(5 * time.Second):
+		s.FailNow("ProcessInsert did not finish after releasing blocked insert")
+	}
+	s.True(errorStarted, "erroring insert did not start while the other insert was blocked")
+	s.True(blockedStarted, "blocked insert did not start while the erroring insert ran")
+	s.False(panickedBeforeRelease, "ProcessInsert panicked before all segment tasks completed")
+	s.Same(unexpectedErr, result.panicValue)
+	s.Equal(int32(1), notifyCount.Load(), "leader view callback must run before propagating the batch error")
+}
+
+func (s *DelegatorDataSuite) TestProcessInsertPreservesWorkerPanicValueAfterAllTasks() {
+	const (
+		panicSegmentID   = int64(401)
+		blockedSegmentID = int64(402)
+	)
+
+	panicValue := &struct{ name string }{name: "unique worker panic"}
+	panicEntered := make(chan struct{})
+	blockedEntered := make(chan struct{})
+	releaseBlocked := make(chan struct{})
+	patch := mockey.Mock((*segments.LocalSegment).Insert).To(func(segment *segments.LocalSegment, _ context.Context, _ []int64, _ []typeutil.Timestamp, _ *segcorepb.InsertRecord) error {
+		switch segment.ID() {
+		case panicSegmentID:
+			close(panicEntered)
+			panic(panicValue)
+		case blockedSegmentID:
+			close(blockedEntered)
+			<-releaseBlocked
+		}
+		return nil
+	}).Build()
+	defer patch.UnPatch()
+	var notifyCount atomic.Int32
+	s.delegator.leaderViewUpdatedCallback = func(string) { notifyCount.Add(1) }
+	defer func() { s.delegator.leaderViewUpdatedCallback = nil }()
+
+	done := processInsertAsync(s.delegator, map[int64]*InsertData{
+		panicSegmentID:   validInsertData(),
+		blockedSegmentID: validInsertData(),
+	})
+
+	waitSignal := func(ch <-chan struct{}) bool {
+		select {
+		case <-ch:
+			return true
+		case <-time.After(500 * time.Millisecond):
+			return false
+		}
+	}
+	panicStarted := waitSignal(panicEntered)
+	blockedStarted := waitSignal(blockedEntered)
+	panickedBeforeRelease := false
+	if panicStarted && blockedStarted {
+		select {
+		case <-done:
+			panickedBeforeRelease = true
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	close(releaseBlocked)
+
+	var result processInsertResult
+	select {
+	case result = <-done:
+	case <-time.After(5 * time.Second):
+		s.FailNow("ProcessInsert did not finish after releasing blocked insert")
+	}
+	s.True(panicStarted, "panicking insert did not start while the other insert was blocked")
+	s.True(blockedStarted, "blocked insert did not start while the panicking insert ran")
+	s.False(panickedBeforeRelease, "ProcessInsert propagated worker panic before all tasks completed")
+	s.Same(panicValue, result.panicValue)
+	s.Equal(int32(1), notifyCount.Load(), "leader view callback must run before propagating the worker panic")
+}
+
+func (s *DelegatorDataSuite) TestProcessInsertRegistersParallelBM25Stats() {
+	s.genCollectionWithFunction()
+	const (
+		firstSegmentID  = int64(501)
+		secondSegmentID = int64(502)
+		bm25FieldID     = int64(101)
+	)
+
+	firstStats := storage.NewBM25Stats()
+	firstStats.Append(map[uint32]float32{1: 1}, map[uint32]float32{2: 1})
+	secondStats := storage.NewBM25Stats()
+	secondStats.Append(map[uint32]float32{3: 1}, map[uint32]float32{4: 1}, map[uint32]float32{5: 1})
+	firstInsert := validInsertData()
+	firstInsert.BM25Stats = map[int64]*storage.BM25Stats{bm25FieldID: firstStats}
+	secondInsert := validInsertData()
+	secondInsert.BM25Stats = map[int64]*storage.BM25Stats{bm25FieldID: secondStats}
+
+	entered := make(chan int64, 2)
+	release := make(chan struct{})
+	patch := mockey.Mock((*segments.LocalSegment).Insert).To(func(segment *segments.LocalSegment, _ context.Context, _ []int64, _ []typeutil.Timestamp, _ *segcorepb.InsertRecord) error {
+		entered <- segment.ID()
+		<-release
+		return nil
+	}).Build()
+	defer patch.UnPatch()
+
+	done := processInsertAsync(s.delegator, map[int64]*InsertData{
+		firstSegmentID:  firstInsert,
+		secondSegmentID: secondInsert,
+	})
+	enteredIDs := make([]int64, 0, 2)
+	for len(enteredIDs) < 2 {
+		select {
+		case segmentID := <-entered:
+			enteredIDs = append(enteredIDs, segmentID)
+		case <-time.After(500 * time.Millisecond):
+			close(release)
+			<-done
+			s.Fail("BM25 segment inserts did not overlap")
+			return
+		}
+	}
+	close(release)
+
+	select {
+	case result := <-done:
+		s.Nil(result.panicValue)
+	case <-time.After(5 * time.Second):
+		s.FailNow("ProcessInsert did not finish BM25 inserts")
+	}
+	s.ElementsMatch([]int64{firstSegmentID, secondSegmentID}, enteredIDs)
+	s.NotNil(s.manager.Segment.GetGrowing(firstSegmentID))
+	s.NotNil(s.manager.Segment.GetGrowing(secondSegmentID))
+	oracle := s.getIDFOracleForTest()
+	fieldStats, err := oracle.current.GetStats(bm25FieldID)
+	s.Require().NoError(err)
+	s.Equal(int64(5), fieldStats.NumRow())
 }
 
 func (s *DelegatorDataSuite) TestProcessDelete() {

--- a/internal/querynodev2/segments/pool.go
+++ b/internal/querynodev2/segments/pool.go
@@ -61,6 +61,12 @@ var (
 	mutatePool     atomic.Pointer[conc.Pool[any]]
 	mutatePoolOnce sync.Once
 
+	// insertPool is the outer ProcessInsert fan-out pool. It MUST stay separate
+	// from mutatePool because Segment.Insert submits to mutatePool and waits, so
+	// sharing one pool would risk a nested-submit deadlock.
+	insertPool     atomic.Pointer[conc.Pool[struct{}]]
+	insertPoolOnce sync.Once
+
 	// deletePool is the outer dispatch pool for DeleteBatch fan-out across
 	// segments. It MUST stay separate from mutatePool: each dispatched task
 	// calls segment.Delete which submits the CGO onto mutatePool and waits, so
@@ -177,6 +183,21 @@ func initMutatePool() {
 	})
 }
 
+func insertPoolSize() int {
+	return mutatePoolSize()
+}
+
+func initInsertPool() {
+	insertPoolOnce.Do(func() {
+		pt := paramtable.Get()
+		size := insertPoolSize()
+		pool := conc.NewPool[struct{}](size)
+		insertPool.Store(pool)
+		pt.Watch(pt.QueryNodeCfg.MutatePoolSizeFactor.Key, config.NewHandler("qn.insertpool.sizefactor", ResizeInsertPool))
+		mlog.Info(context.TODO(), "init insertPool done", mlog.Int("size", size))
+	})
+}
+
 func initBFApplyPool() {
 	bfApplyOnce.Do(func() {
 		pt := paramtable.Get()
@@ -243,6 +264,12 @@ func GetMutatePool() *conc.Pool[any] {
 	return mutatePool.Load()
 }
 
+// GetInsertPool returns the singleton pool for ProcessInsert fan-out.
+func GetInsertPool() *conc.Pool[struct{}] {
+	initInsertPool()
+	return insertPool.Load()
+}
+
 func ResizeSQPool(evt *config.Event) {
 	if evt.HasUpdated {
 		pt := paramtable.Get()
@@ -275,6 +302,12 @@ func ResizeMutatePool(evt *config.Event) {
 	}
 }
 
+func ResizeInsertPool(evt *config.Event) {
+	if evt.HasUpdated {
+		resizePool(GetInsertPool(), insertPoolSize(), "InsertPool")
+	}
+}
+
 func ResizeDynamicPool(evt *config.Event) {
 	if evt.HasUpdated {
 		resizePool(GetDynamicPool(), dynamicPoolSize(), "DynamicPool")
@@ -304,6 +337,7 @@ func CollectPoolStats() []metrics.PoolStats {
 		{"DynamicPool", GetDynamicPool()},
 		{"LoadPool", GetLoadPool()},
 		{"MutatePool", GetMutatePool()},
+		{"InsertPool", GetInsertPool()},
 		{"BFApplyPool", GetBFApplyPool()},
 		{"DeletePool", GetDeletePool()},
 	}

--- a/internal/querynodev2/segments/pool.go
+++ b/internal/querynodev2/segments/pool.go
@@ -194,6 +194,11 @@ func initInsertPool() {
 		pool := conc.NewPool[struct{}](size)
 		insertPool.Store(pool)
 		pt.Watch(pt.QueryNodeCfg.MutatePoolSizeFactor.Key, config.NewHandler("qn.insertpool.sizefactor", ResizeInsertPool))
+		// Reconcile a config update between the initial size read and watcher registration.
+		currentSize := insertPoolSize()
+		if currentSize != size {
+			resizePool(pool, currentSize, "InsertPool")
+		}
 		mlog.Info(context.TODO(), "init insertPool done", mlog.Int("size", size))
 	})
 }

--- a/internal/querynodev2/segments/pool_test.go
+++ b/internal/querynodev2/segments/pool_test.go
@@ -106,6 +106,23 @@ func TestResizePools(t *testing.T) {
 		assert.Equal(t, hardware.GetCPUNum(), GetMutatePool().Cap())
 	})
 
+	t.Run("InsertPool", func(t *testing.T) {
+		defer pt.Save(pt.QueryNodeCfg.MutatePoolSizeFactor.Key, "2")
+
+		pt.Save(pt.QueryNodeCfg.MutatePoolSizeFactor.Key, "3")
+		ResizeInsertPool(&config.Event{
+			HasUpdated: true,
+		})
+		assert.Equal(t, hardware.GetCPUNum()*3, GetInsertPool().Cap())
+
+		// factor <= 0 clamps to CPUNum.
+		pt.Save(pt.QueryNodeCfg.MutatePoolSizeFactor.Key, "0")
+		ResizeInsertPool(&config.Event{
+			HasUpdated: true,
+		})
+		assert.Equal(t, hardware.GetCPUNum(), GetInsertPool().Cap())
+	})
+
 	t.Run("DynamicPool", func(t *testing.T) {
 		defer pt.Save(pt.QueryNodeCfg.DynamicPoolSizeFactor.Key, "1")
 

--- a/internal/querynodev2/segments/pool_test.go
+++ b/internal/querynodev2/segments/pool_test.go
@@ -108,19 +108,14 @@ func TestResizePools(t *testing.T) {
 
 	t.Run("InsertPool", func(t *testing.T) {
 		defer pt.Save(pt.QueryNodeCfg.MutatePoolSizeFactor.Key, "2")
+		pool := GetInsertPool()
 
 		pt.Save(pt.QueryNodeCfg.MutatePoolSizeFactor.Key, "3")
-		ResizeInsertPool(&config.Event{
-			HasUpdated: true,
-		})
-		assert.Equal(t, hardware.GetCPUNum()*3, GetInsertPool().Cap())
+		assert.Equal(t, hardware.GetCPUNum()*3, pool.Cap())
 
 		// factor <= 0 clamps to CPUNum.
 		pt.Save(pt.QueryNodeCfg.MutatePoolSizeFactor.Key, "0")
-		ResizeInsertPool(&config.Event{
-			HasUpdated: true,
-		})
-		assert.Equal(t, hardware.GetCPUNum(), GetInsertPool().Cap())
+		assert.Equal(t, hardware.GetCPUNum(), pool.Cap())
 	})
 
 	t.Run("DynamicPool", func(t *testing.T) {


### PR DESCRIPTION
issue: #52029

- QueryNode insert dispatch: add a dedicated bounded pool that follows the segcore mutate pool sizing factor
- delegator insert processing: process distinct growing segments concurrently while preserving registration, PK and BM25 updates, and deterministic wait-all failure semantics