### PR TITLE
enhance: optimize bulk import metadata and batching

### DIFF
--- a/internal/datacoord/util.go
+++ b/internal/datacoord/util.go
@@ -400,6 +400,7 @@ func createStorageConfig() *indexpb.StorageConfig {
 			GcpCredentialJSON: Params.MinioCfg.GcpCredentialJSON.GetValue(),
 			SslTlsMinVersion:  Params.MinioCfg.SslTLSMinVersion.GetValue(),
 			UseCrc32CChecksum: Params.MinioCfg.UseCRC32C.GetAsBool(),
+			MaxConnections:    uint32(Params.MinioCfg.MaxConnections.GetAsInt()),
 		}
 	}
 

--- a/internal/datanode/importv2/task_preimport.go
+++ b/internal/datanode/importv2/task_preimport.go
@@ -185,6 +185,54 @@ func (t *PreImportTask) Execute() []*conc.Future[any] {
 	return futures
 }
 
+type numRowsReader interface {
+	NumRows() (int64, bool)
+}
+
+func (t *PreImportTask) canUseMetadataFastPath() bool {
+	if len(t.partitionIDs) != 1 || len(t.vchannels) == 0 {
+		return false
+	}
+	if !isFixedSizeImportSchema(t.GetSchema()) {
+		return false
+	}
+	if _, err := typeutil.GetPartitionKeyFieldSchema(t.GetSchema()); err == nil {
+		return false
+	}
+	pkField, err := typeutil.GetPrimaryFieldSchema(t.GetSchema())
+	if err != nil {
+		return false
+	}
+	return pkField.GetAutoID() || len(t.vchannels) == 1
+}
+
+func isFixedSizeImportSchema(schema *schemapb.CollectionSchema) bool {
+	for _, field := range typeutil.GetAllFieldSchemas(schema) {
+		if field.GetNullable() {
+			return false
+		}
+		switch field.GetDataType() {
+		case schemapb.DataType_Bool,
+			schemapb.DataType_Int8,
+			schemapb.DataType_Int16,
+			schemapb.DataType_Int32,
+			schemapb.DataType_Int64,
+			schemapb.DataType_Float,
+			schemapb.DataType_Double,
+			schemapb.DataType_Timestamptz,
+			schemapb.DataType_BinaryVector,
+			schemapb.DataType_FloatVector,
+			schemapb.DataType_Float16Vector,
+			schemapb.DataType_BFloat16Vector,
+			schemapb.DataType_Int8Vector:
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 func (t *PreImportTask) readFileStat(reader importutilv2.Reader, fileIdx int) error {
 	fileSize, err := reader.Size()
 	if err != nil {
@@ -195,6 +243,56 @@ func (t *PreImportTask) readFileStat(reader importutilv2.Reader, fileIdx int) er
 		return merr.WrapErrParameterInvalidMsg(
 			"The import file size has reached the maximum limit allowed for importing, "+
 				"fileSize=%d, maxSize=%d", fileSize, int64(maxSize))
+	}
+
+	if nrReader, ok := reader.(numRowsReader); ok && t.canUseMetadataFastPath() {
+		numRows, ok := nrReader.NumRows()
+		if ok && numRows >= 0 {
+			sizePerRecord, err := typeutil.EstimateSizePerRecord(t.GetSchema())
+			if err != nil {
+				return err
+			}
+			totalMemorySize := int64(sizePerRecord) * numRows
+			partitionID := t.partitionIDs[0]
+			channelNum := int64(len(t.vchannels))
+			hashedStats := make(map[string]*datapb.PartitionImportStats, len(t.vchannels))
+			assignedRows := int64(0)
+			assignedSize := int64(0)
+			for i, channel := range t.vchannels {
+				rowsForChannel := numRows / channelNum
+				if int64(i) < numRows%channelNum {
+					rowsForChannel++
+				}
+				sizeForChannel := int64(0)
+				if i == len(t.vchannels)-1 {
+					sizeForChannel = totalMemorySize - assignedSize
+				} else if numRows > 0 {
+					sizeForChannel = totalMemorySize * rowsForChannel / numRows
+				}
+				assignedRows += rowsForChannel
+				assignedSize += sizeForChannel
+				hashedStats[channel] = &datapb.PartitionImportStats{
+					PartitionRows:     map[int64]int64{partitionID: rowsForChannel},
+					PartitionDataSize: map[int64]int64{partitionID: sizeForChannel},
+				}
+			}
+			if assignedRows != numRows {
+				return merr.WrapErrImportFailed("preimport metadata fast path row assignment mismatch")
+			}
+			stat := &datapb.ImportFileStats{
+				FileSize:        fileSize,
+				TotalRows:       numRows,
+				TotalMemorySize: totalMemorySize,
+				HashedStats:     hashedStats,
+			}
+			t.manager.Update(t.GetTaskID(), UpdateFileStat(fileIdx, stat))
+			mlog.Info(t.ctx, "preimport fast path used file metadata", WrapLogFields(t,
+				mlog.Int64("numRows", numRows),
+				mlog.Int64("totalMemorySize", totalMemorySize),
+				mlog.Int("vchannelNum", len(t.vchannels)),
+			)...)
+			return nil
+		}
 	}
 
 	totalRows := 0

--- a/internal/util/importutilv2/common/util.go
+++ b/internal/util/importutilv2/common/util.go
@@ -51,10 +51,10 @@ func EstimateReadCountPerBatch(bufferSize int, schema *schemapb.CollectionSchema
 	if sizePerRecord <= 0 || bufferSize <= 0 {
 		return 0, merr.WrapErrParameterInvalidMsg("invalid size, sizePerRecord=%d, bufferSize=%d", sizePerRecord, bufferSize)
 	}
-	if 1000*sizePerRecord <= bufferSize {
-		return 1000, nil
-	}
-	ret := int64(bufferSize) / int64(sizePerRecord)
+	// Import keeps more than the reader-side payload in memory: later stages add
+	// system fields and hash rows into new InsertData objects. Use half of the
+	// task buffer for one read batch to leave headroom for that working set.
+	ret := int64(bufferSize) / int64(sizePerRecord) / 2
 	if ret <= 0 {
 		return 1, nil
 	}

--- a/internal/util/importutilv2/common/util_test.go
+++ b/internal/util/importutilv2/common/util_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 func TestUtil_EstimateReadCountPerBatch(t *testing.T) {
@@ -52,7 +53,10 @@ func TestUtil_EstimateReadCountPerBatch(t *testing.T) {
 	}
 	count, err := EstimateReadCountPerBatch(16*1024*1024, schema)
 	assert.NoError(t, err)
-	assert.Equal(t, int64(1000), count)
+	sizePerRecord, err := typeutil.EstimateMaxSizePerRecord(schema)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(16*1024*1024/sizePerRecord/2), count)
+	assert.Greater(t, count, int64(1000))
 
 	schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
 		FieldID:  102,

--- a/internal/util/importutilv2/numpy/field_reader.go
+++ b/internal/util/importutilv2/numpy/field_reader.go
@@ -142,6 +142,18 @@ func (c *FieldReader) logicalRowCount(readCount int64) int64 {
 	}
 }
 
+func (c *FieldReader) NumRows() int64 {
+	shape := c.npyReader.Header.Descr.Shape
+	if len(shape) == 0 {
+		return 0
+	}
+	total := int64(1)
+	for _, dim := range shape {
+		total *= int64(dim)
+	}
+	return c.logicalRowCount(total)
+}
+
 func (c *FieldReader) Next(count int64) (any, any, error) {
 	readCount := c.getCount(count)
 	if readCount == 0 {

--- a/internal/util/importutilv2/numpy/reader.go
+++ b/internal/util/importutilv2/numpy/reader.go
@@ -18,6 +18,7 @@ package numpy
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/samber/lo"
@@ -26,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/importutilv2/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type reader struct {
@@ -37,8 +39,9 @@ type reader struct {
 	fileSize *atomic.Int64
 	paths    []string
 
-	count int64
-	frs   map[int64]*FieldReader // fieldID -> FieldReader
+	count   int64
+	numRows int64
+	frs     map[int64]*FieldReader // fieldID -> FieldReader
 }
 
 func NewReader(ctx context.Context, cm storage.ChunkManager, schema *schemapb.CollectionSchema, paths []string, bufferSize int) (*reader, error) {
@@ -55,10 +58,24 @@ func NewReader(ctx context.Context, cm storage.ChunkManager, schema *schemapb.Co
 		return nil, err
 	}
 	timezone := common.GetSchemaTimezone(schema)
+	numRows := int64(-1)
 	for fieldID, r := range readers {
 		cr, err := NewFieldReader(r, fields[fieldID], timezone)
 		if err != nil {
+			for _, cmr := range readers {
+				cmr.Close()
+			}
 			return nil, err
+		}
+		fieldRows := cr.NumRows()
+		if numRows < 0 {
+			numRows = fieldRows
+		} else if fieldRows != numRows {
+			for _, cmr := range readers {
+				cmr.Close()
+			}
+			return nil, merr.WrapErrImportFailed(
+				fmt.Sprintf("numpy row count mismatch, fieldID=%d, rowCount=%d, expected=%d", fieldID, fieldRows, numRows))
 		}
 		crs[fieldID] = cr
 	}
@@ -71,6 +88,7 @@ func NewReader(ctx context.Context, cm storage.ChunkManager, schema *schemapb.Co
 		fileSize: atomic.NewInt64(0),
 		paths:    paths,
 		count:    count,
+		numRows:  numRows,
 		frs:      crs,
 	}, nil
 }
@@ -107,6 +125,10 @@ func (r *reader) Size() (int64, error) {
 	}
 	r.fileSize.Store(size)
 	return size, nil
+}
+
+func (r *reader) NumRows() (int64, bool) {
+	return r.numRows, r.numRows >= 0
 }
 
 func (r *reader) Close() {

--- a/internal/util/importutilv2/numpy/reader_test.go
+++ b/internal/util/importutilv2/numpy/reader_test.go
@@ -219,6 +219,9 @@ func (suite *ReaderSuite) run(dt schemapb.DataType) {
 	size2, err := reader.Size() // size is cached
 	suite.NoError(err)
 	suite.Equal(size, size2)
+	numRows, ok := reader.NumRows()
+	suite.True(ok)
+	suite.Equal(int64(suite.numRows), numRows)
 
 	checkFn := func(actualInsertData *storage.InsertData, offsetBegin, expectRows int) {
 		expectInsertData := insertData

--- a/internal/util/importutilv2/parquet/reader.go
+++ b/internal/util/importutilv2/parquet/reader.go
@@ -155,6 +155,10 @@ func (r *reader) Size() (int64, error) {
 	return size, nil
 }
 
+func (r *reader) NumRows() (int64, bool) {
+	return r.r.NumRows(), true
+}
+
 func (r *reader) Close() {
 	err := r.r.Close()
 	if err != nil {

--- a/internal/util/importutilv2/parquet/reader_test.go
+++ b/internal/util/importutilv2/parquet/reader_test.go
@@ -194,6 +194,9 @@ func (s *ReaderSuite) run(dataType schemapb.DataType, elemType schemapb.DataType
 	size2, err := reader.Size() // size is cached
 	s.NoError(err)
 	s.Equal(size, size2)
+	numRows, ok := reader.NumRows()
+	s.True(ok)
+	s.Equal(int64(s.numRows), numRows)
 
 	checkFn := func(actualInsertData *storage.InsertData, offsetBegin, expectRows int) {
 		expectInsertData := insertData


### PR DESCRIPTION
Fixes #52122

## What this PR does

This PR optimizes bulk import performance in three places:

- **PreImport metadata fast path**
  - Adds a `NumRows()` capability for NumPy and Parquet import readers.
  - Lets PreImport derive row count and memory stats from file metadata instead of scanning batches when the schema is safe for this shortcut.
  - Keeps the original scan path for partition-key collections, variable-length or nullable fields, and multi-vchannel non-autoID cases where row-level hashing or exact data sizing is required.

- **Larger import reader batches**
  - Removes the fixed 1000 rows-per-batch cap from `EstimateReadCountPerBatch`.
  - Computes batch rows from `bufferSize / estimatedRecordSize / 2`.
  - Reserves half of the task buffer as headroom for system fields, row hashing, and InsertData copies created after reader output.

- **Import storage connection config**
  - Passes `MinioCfg.MaxConnections` into import `StorageConfig` so import readers use the configured object storage connection limit consistently.

## Measurement

Dataset: `cohere_1M`  
Metric: import task completion time from REST progress `details[*].state=Completed`; post-import Sorting/global job completion is excluded.

| Variant | Import task completion | Relative to baseline | PreImport read stat | Sync task count | Sync task sum |
| --- | ---: | ---: | ---: | ---: | ---: |
| baseline | 339.370s | 1.00x | 35.147s | 1000 | 294.575s |
| PreImport metadata fast path only | 291.181s | 1.17x | 0.051s | 1000 | 282.339s |
| Batch half-buffer only | 150.622s | 2.25x | 30.649s | 368 | 112.205s |
| Storage MaxConnections only | 330.334s | 1.03x | 30.614s | 1000 | 291.669s |
| All optimizations | 117.489s | 2.89x | 0.041s | 368 | 111.563s |

## Tests

- `go test ./internal/util/importutilv2/common ./internal/util/importutilv2/numpy ./internal/util/importutilv2/parquet`
- `go test -tags dynamic,test ./internal/datanode/importv2 ./internal/datacoord -run '^$'`

