### PR TITLE
fix: upgrade azure-sdk-for-cpp to 1.16.4

### DIFF
--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -129,7 +129,7 @@ class MilvusConan(ConanFile):
         # azure-sdk-for-cpp is a transitive dep of Arrow, but must be declared
         # as a direct dep so CMakeDeps generates standalone cmake config files.
         # Without this, find_package(Azure) can't find include directories.
-        self.requires("azure-sdk-for-cpp/1.16.0@milvus/dev#9e2475502f8ee3b284c9e0731a3370c6", force=True)
+        self.requires("azure-sdk-for-cpp/1.16.4@milvus/dev#7c95e3df67cfea28b3cf6dbd60fbf137", force=True)
         self.requires("aws-sdk-cpp/1.11.842@milvus/dev#363556887f622db23a10168c108dd55d", force=True)
         # Force snappy/lz4 versions to override Arrow's older transitive deps
         # (arrow/*:with_snappy and arrow/*:with_lz4 are enabled for Parquet decoding)


### PR DESCRIPTION
issue: #52033
Pin the published 1.16.4 Conan recipe revision. Azure Core 1.16.4 contains the CURL transport lifetime fix that destroys the easy handle before the shared SSL handle, resolving the ASAN failure seen with 1.16.1.