### PR TITLE
fix: pin dynamic pthread OpenBLAS recipe on Linux

### DIFF
--- a/internal/core/CMakeLists.txt
+++ b/internal/core/CMakeLists.txt
@@ -70,6 +70,12 @@ if (CMAKE_COMPILER_IS_GNUCC)
 endif ()
 
 set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake" )
+if (LINUX)
+    # Knowhere v2.6.18 still uses CMake's FindBLAS/FindLAPACK modules.  Add
+    # the Conan OpenBLAS compatibility modules before the system modules.
+    list(PREPEND CMAKE_MODULE_PATH
+         "${CMAKE_CURRENT_SOURCE_DIR}/cmake/openblas_compat")
+endif()
 include( Utils )
 
 # **************************** Build time, type and code version ****************************

--- a/internal/core/cmake/openblas_compat/FindBLAS.cmake
+++ b/internal/core/cmake/openblas_compat/FindBLAS.cmake
@@ -1,0 +1,13 @@
+# Knowhere v2.6.18 uses find_package(BLAS), while OpenBLAS is provided by
+# Conan.  Preserve the conventional FindBLAS variables and target by mapping
+# them to Conan's OpenBLAS target.
+find_package(OpenBLAS REQUIRED)
+
+set(BLAS_FOUND TRUE)
+set(BLAS_LIBRARIES OpenBLAS::OpenBLAS)
+
+if(NOT TARGET BLAS::BLAS)
+    add_library(BLAS::BLAS INTERFACE IMPORTED)
+    set_target_properties(BLAS::BLAS PROPERTIES
+        INTERFACE_LINK_LIBRARIES OpenBLAS::OpenBLAS)
+endif()

--- a/internal/core/cmake/openblas_compat/FindLAPACK.cmake
+++ b/internal/core/cmake/openblas_compat/FindLAPACK.cmake
@@ -1,0 +1,12 @@
+# OpenBLAS provides the LAPACK symbols required by Knowhere's Faiss build.
+# Keep the legacy FindLAPACK interface while linking Conan's OpenBLAS target.
+find_package(OpenBLAS REQUIRED)
+
+set(LAPACK_FOUND TRUE)
+set(LAPACK_LIBRARIES OpenBLAS::OpenBLAS)
+
+if(NOT TARGET LAPACK::LAPACK)
+    add_library(LAPACK::LAPACK INTERFACE IMPORTED)
+    set_target_properties(LAPACK::LAPACK PROPERTIES
+        INTERFACE_LINK_LIBRARIES OpenBLAS::OpenBLAS)
+endif()

--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -84,11 +84,12 @@ class MilvusConan(ConanFile):
         "glog:shared": True,
         "prometheus-cpp:with_pull": False,
         "fmt:header_only": True,
+        "openblas:dynamic_arch": True,
+        "openblas:shared": False,
         "onetbb:tbbmalloc": False,
         "onetbb:tbbproxy": False,
         "gdal:shared": True,
         "gdal:fPIC": True,
-        "openblas:use_openmp": True,
     }
 
     def configure(self):
@@ -100,6 +101,8 @@ class MilvusConan(ConanFile):
             self.options["arrow"].with_jemalloc = False
 
     def requirements(self):
+        if self.settings.os == "Linux":
+            self.requires("openblas/0.3.30#b818732ec6d4be12891e042d331a7e48")
         if self.settings.os != "Macos":
             self.requires("libunwind/1.7.2")
         # Override s2n 1.4.1 (from aws-c-io) to 1.6.0 for OpenSSL 3.x FIPS detection


### PR DESCRIPTION
## Summary

Backport the OpenBLAS 0.3.30 fix to Milvus 2.6 in Conan 1 syntax:

- require the known-good recipe revision `openblas/0.3.30#b818732ec6d4be12891e042d331a7e48` on Linux
- enable `dynamic_arch` for runtime CPU dispatch
- link OpenBLAS statically
- remove the stale `use_openmp` setting; this recipe uses the native pthread backend

Pinning the recipe revision prevents `conan install --update` from selecting the newer OpenMP recipe revision. `dynamic_arch` avoids the generic ARMv8 kernel path observed on AWS Graviton4 / Neoverse-V2.

issue: #50892
pr: #49912