### PR TITLE
enhance: separate and cache index load resource estimates

### DIFF
--- a/internal/core/src/index/BitmapIndexArrayTest.cpp
+++ b/internal/core/src/index/BitmapIndexArrayTest.cpp
@@ -1454,8 +1454,17 @@ TEST(ScalarIndexSortArrayNestedTest, ArraySortIndexDoesNotExposeRawArrayData) {
 
     std::map<std::string, std::string> index_params{
         {index::INDEX_TYPE, index::ASCENDING_SORT}};
-    auto request = index::IndexFactory::GetInstance().ScalarIndexLoadResource(
-        DataType::ARRAY, 0, 1024, index_params, false, 10);
+    auto request = index::IndexFactory::GetInstance().EstimateIndexLoadResource(
+        index::IndexLoadSpec{
+            .field_type = DataType::ARRAY,
+            .element_type = DataType::NONE,
+            .index_version = 0,
+            .index_size_in_bytes = 1024,
+            .index_params = index_params,
+            .mmap_enable = false,
+            .num_rows = 10,
+            .dim = 0,
+        });
     EXPECT_FALSE(request.has_raw_data);
 
     boost::filesystem::remove_all(numeric_root_path);
@@ -1479,8 +1488,17 @@ TEST(BitmapIndexLoadResourceTest,
     std::map<std::string, std::string> index_params{
         {index::INDEX_TYPE, index::BITMAP_INDEX_TYPE},
         {index::SCALAR_INDEX_ENGINE_VERSION, "3"}};
-    auto request = index::IndexFactory::GetInstance().ScalarIndexLoadResource(
-        DataType::INT64, 0, index_size, index_params, false, 1024);
+    auto request = index::IndexFactory::GetInstance().EstimateIndexLoadResource(
+        index::IndexLoadSpec{
+            .field_type = DataType::INT64,
+            .element_type = DataType::NONE,
+            .index_version = 0,
+            .index_size_in_bytes = index_size,
+            .index_params = index_params,
+            .mmap_enable = false,
+            .num_rows = 1024,
+            .dim = 0,
+        });
 
     EXPECT_EQ(request.final_memory_cost, index_size);
     EXPECT_EQ(request.max_memory_cost, 4 * index_size);

--- a/internal/core/src/index/HybridScalarIndexTest.cpp
+++ b/internal/core/src/index/HybridScalarIndexTest.cpp
@@ -650,21 +650,32 @@ TYPED_TEST_P(HybridIndexTestV1, ResourceEstimateUsesInternalIndexType) {
         this->field_meta_, this->index_meta_, this->chunk_manager_, this->fs_);
     ctx.set_for_loading_index(true);
 
-    auto request = index::IndexFactory::GetInstance().ScalarIndexLoadResource(
-        this->type_,
-        0,
-        index_size,
-        index_params,
-        false,
-        this->nb_,
-        this->index_files_,
-        ctx);
+    const auto spec = index::IndexLoadSpec{
+        .field_type = this->type_,
+        .element_type = DataType::NONE,
+        .index_version = 0,
+        .index_size_in_bytes = index_size,
+        .index_params = index_params,
+        .mmap_enable = false,
+        .num_rows = this->nb_,
+        .dim = 0,
+    };
+    auto& factory = index::IndexFactory::GetInstance();
+    auto inspection =
+        factory.InspectScalarIndexFiles(spec,
+                                        index::IndexFileContext{
+                                            .index_files = this->index_files_,
+                                            .file_manager_context = ctx,
+                                        });
+    auto plan = factory.PlanScalarIndexLoad(spec, inspection);
+    const auto& request = plan.request;
 
     EXPECT_EQ(request.final_memory_cost, index_size);
     EXPECT_EQ(request.final_disk_cost, 0);
     EXPECT_EQ(request.max_memory_cost, 2 * index_size);
     EXPECT_EQ(request.max_disk_cost, 0);
     EXPECT_FALSE(request.has_raw_data);
+    EXPECT_FALSE(plan.shared_memory_runtime_unit_bytes.has_value());
 }
 
 TYPED_TEST_P(HybridIndexTestV1, BitmapResourceEstimateKeepsFullStreamOverhead) {
@@ -712,21 +723,30 @@ TYPED_TEST_P(HybridIndexTestV1, BitmapResourceEstimateKeepsFullStreamOverhead) {
     std::map<std::string, std::string> index_params{
         {"index_type", milvus::index::HYBRID_INDEX_TYPE},
         {milvus::index::SCALAR_INDEX_ENGINE_VERSION, "3"}};
-    std::optional<storage::EntryStreamLoadInfo> stream_load_info;
-
-    auto request = index::IndexFactory::GetInstance().ScalarIndexLoadResource(
-        this->type_,
-        0,
-        index_size,
-        index_params,
-        false,
-        this->nb_,
-        {remote_path},
-        ctx,
-        &stream_load_info);
+    const auto spec = index::IndexLoadSpec{
+        .field_type = this->type_,
+        .element_type = DataType::NONE,
+        .index_version = 0,
+        .index_size_in_bytes = index_size,
+        .index_params = index_params,
+        .mmap_enable = false,
+        .num_rows = this->nb_,
+        .dim = 0,
+    };
+    auto& factory = index::IndexFactory::GetInstance();
+    auto inspection =
+        factory.InspectScalarIndexFiles(spec,
+                                        index::IndexFileContext{
+                                            .index_files = {remote_path},
+                                            .file_manager_context = ctx,
+                                        });
+    auto plan = factory.PlanScalarIndexLoad(spec, inspection);
+    const auto& request = plan.request;
+    const auto& stream_load_info = inspection.stream_load_info;
 
     ASSERT_TRUE(stream_load_info.has_value());
     EXPECT_TRUE(stream_load_info->encrypted);
+    EXPECT_FALSE(plan.shared_memory_runtime_unit_bytes.has_value());
     auto bounded_stream_overhead = storage::EntryStreamMaxTransientBytes(
         stream_load_info->total_transient_bytes,
         stream_load_info->max_task_transient_bytes);
@@ -937,21 +957,35 @@ TYPED_TEST_P(HybridIndexTestInverted,
                                     counting_fs);
     ctx.set_for_loading_index(true);
 
-    auto request = index::IndexFactory::GetInstance().ScalarIndexLoadResource(
-        this->type_,
-        0,
-        index_size,
-        index_params,
-        false,
-        this->nb_,
-        this->index_files_,
-        ctx);
+    const auto spec = index::IndexLoadSpec{
+        .field_type = this->type_,
+        .element_type = DataType::NONE,
+        .index_version = 0,
+        .index_size_in_bytes = index_size,
+        .index_params = index_params,
+        .mmap_enable = false,
+        .num_rows = this->nb_,
+        .dim = 0,
+    };
+    auto& factory = index::IndexFactory::GetInstance();
+    auto inspection =
+        factory.InspectScalarIndexFiles(spec,
+                                        index::IndexFileContext{
+                                            .index_files = this->index_files_,
+                                            .file_manager_context = ctx,
+                                        });
+    auto plan = factory.PlanScalarIndexLoad(spec, inspection);
+    const auto& request = plan.request;
 
     EXPECT_EQ(request.final_memory_cost, 0);
     EXPECT_EQ(request.final_disk_cost, index_size);
     EXPECT_EQ(request.max_memory_cost, stream_overhead);
     EXPECT_EQ(request.max_disk_cost, index_size);
     EXPECT_FALSE(request.has_raw_data);
+    ASSERT_TRUE(inspection.stream_load_info.has_value());
+    EXPECT_FALSE(inspection.stream_load_info->encrypted);
+    ASSERT_TRUE(plan.shared_memory_runtime_unit_bytes.has_value());
+    EXPECT_EQ(*plan.shared_memory_runtime_unit_bytes, max_task_transient_bytes);
     EXPECT_EQ(counting_fs->OpenInputFileCount(), 1);
 }
 
@@ -1127,23 +1161,34 @@ TYPED_TEST_P(HybridIndexTestInverted,
     auto file_info = this->fs_->GetFileInfo(remote_path).ValueOrDie();
     auto index_size = static_cast<uint64_t>(file_info.size());
     std::map<std::string, std::string> index_params{
-        {"index_type", milvus::index::HYBRID_INDEX_TYPE},
+        {"index_type", milvus::index::INVERTED_INDEX_TYPE},
         {milvus::index::SCALAR_INDEX_ENGINE_VERSION, "3"}};
-    std::optional<storage::EntryStreamLoadInfo> stream_load_info;
-
-    auto request = index::IndexFactory::GetInstance().ScalarIndexLoadResource(
-        this->type_,
-        0,
-        index_size,
-        index_params,
-        false,
-        this->nb_,
-        {remote_path},
-        ctx,
-        &stream_load_info);
+    const auto spec = index::IndexLoadSpec{
+        .field_type = this->type_,
+        .element_type = DataType::NONE,
+        .index_version = 0,
+        .index_size_in_bytes = index_size,
+        .index_params = index_params,
+        .mmap_enable = false,
+        .num_rows = this->nb_,
+        .dim = 0,
+    };
+    auto& factory = index::IndexFactory::GetInstance();
+    auto inspection =
+        factory.InspectScalarIndexFiles(spec,
+                                        index::IndexFileContext{
+                                            .index_files = {remote_path},
+                                            .file_manager_context = ctx,
+                                        });
+    auto plan = factory.PlanScalarIndexLoad(spec, inspection);
+    const auto& request = plan.request;
+    const auto& stream_load_info = inspection.stream_load_info;
 
     ASSERT_TRUE(stream_load_info.has_value());
     EXPECT_TRUE(stream_load_info->encrypted);
+    ASSERT_TRUE(plan.shared_memory_runtime_unit_bytes.has_value());
+    EXPECT_EQ(*plan.shared_memory_runtime_unit_bytes,
+              stream_load_info->max_task_transient_bytes);
     ASSERT_GT(stream_load_info->total_transient_bytes,
               stream_load_info->max_task_transient_bytes);
     ASSERT_LT(storage::EntryStreamMaxTransientBytes(

--- a/internal/core/src/index/HybridScalarIndexTest.cpp
+++ b/internal/core/src/index/HybridScalarIndexTest.cpp
@@ -91,6 +91,63 @@ class CountingOpenFileSystem : public arrow::fs::SubTreeFileSystem {
     size_t open_input_file_count_{0};
 };
 
+TEST(SealedIndexTranslatorTest, CachedVectorRequestSkipsResourceEstimate) {
+    milvus::segcore::LoadIndexInfo load_info{};
+    load_info.field_type = DataType::VECTOR_FLOAT;
+    load_info.element_type = DataType::NONE;
+    // Deliberately omit index_type: any estimator call would reject this spec.
+    load_info.load_resource_request =
+        LoadResourceRequest{/*max_memory_cost=*/10,
+                            /*max_disk_cost=*/20,
+                            /*final_memory_cost=*/3,
+                            /*final_disk_cost=*/4,
+                            /*has_raw_data=*/true};
+
+    index::CreateIndexInfo index_info{};
+    index_info.index_type = "HNSW";
+    index_info.field_type = DataType::VECTOR_FLOAT;
+
+    Config config{};
+    milvus::segcore::storagev1translator::SealedIndexTranslator translator(
+        index_info,
+        &load_info,
+        milvus::tracer::TraceContext{},
+        storage::FileManagerContext{},
+        std::move(config));
+
+    auto [loaded_resource, loading_overhead] =
+        translator.estimated_byte_size_of_cell(0);
+    EXPECT_EQ(loaded_resource, (milvus::cachinglayer::ResourceUsage{3, 4}));
+    EXPECT_EQ(loading_overhead, (milvus::cachinglayer::ResourceUsage{7, 36}));
+}
+
+TEST(SealedIndexTranslatorTest, CachedRequestDoesNotBypassConfigV3Inspection) {
+    milvus::segcore::LoadIndexInfo load_info{};
+    load_info.field_type = DataType::INT64;
+    load_info.element_type = DataType::NONE;
+    load_info.index_params = {{"index_type", ASCENDING_SORT}};
+    load_info.load_resource_request =
+        LoadResourceRequest{/*max_memory_cost=*/10,
+                            /*max_disk_cost=*/20,
+                            /*final_memory_cost=*/3,
+                            /*final_disk_cost=*/4,
+                            /*has_raw_data=*/true};
+
+    index::CreateIndexInfo index_info{};
+    index_info.index_type = ASCENDING_SORT;
+    index_info.field_type = DataType::INT64;
+
+    Config config = load_info.index_params;
+    config[SCALAR_INDEX_ENGINE_VERSION] = "3";
+    EXPECT_THROW(milvus::segcore::storagev1translator::SealedIndexTranslator(
+                     index_info,
+                     &load_info,
+                     milvus::tracer::TraceContext{},
+                     storage::FileManagerContext{},
+                     std::move(config)),
+                 milvus::SegcoreError);
+}
+
 TEST(HybridScalarIndexPlannerPolicy, ShouldUseOpDelegatesToInternalIndex) {
     HybridScalarIndex<int64_t> int_index(7);
     std::vector<int64_t> int_data{1, 2, 3, 4};

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -25,6 +25,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "common/Consts.h"
@@ -73,60 +74,105 @@ namespace milvus::index {
 
 namespace {
 
+bool
+IsFileStreamIndex(const IndexType& index_type) {
+    return index_type == INVERTED_INDEX_TYPE ||
+           index_type == NGRAM_INDEX_TYPE || index_type == RTREE_INDEX_TYPE;
+}
+
 uint64_t
-ScalarIndexStreamMemoryOverhead(
-    uint64_t index_size_in_bytes,
-    int32_t scalar_version,
-    bool encrypted,
-    bool file_stream,
-    const std::optional<storage::EntryStreamLoadInfo>& stream_load_info =
-        std::nullopt) {
-    if (index_size_in_bytes == 0) {
+EstimateMetadataScalarStreamPeak(const IndexLoadSpec& spec,
+                                 const IndexType& effective_index_type,
+                                 int32_t scalar_version,
+                                 bool encrypted) {
+    if (spec.index_size_in_bytes == 0) {
         return 0;
     }
     if (scalar_version < 3) {
-        return index_size_in_bytes;
-    }
-    size_t total_transient_bytes;
-    size_t max_task_transient_bytes;
-    if (encrypted && stream_load_info.has_value()) {
-        total_transient_bytes = stream_load_info->total_transient_bytes;
-        max_task_transient_bytes = stream_load_info->max_task_transient_bytes;
-    } else {
-        total_transient_bytes = milvus::storage::EntryStreamTransientBytes(
-            index_size_in_bytes, encrypted);
-        max_task_transient_bytes = milvus::storage::EntryStreamTransientBytes(
-            milvus::storage::MaxEntryStreamTaskBytes(), encrypted);
-
-        // Without a concrete encrypted directory there is no trustworthy
-        // ciphertext task bound. When the runtime budget is disabled, keep
-        // the conservative whole-stream fallback instead of applying the
-        // executor bound.
-        if (encrypted &&
-            milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
-                    .CapacityBytes() == 0) {
-            return total_transient_bytes;
-        }
+        return spec.index_size_in_bytes;
     }
 
-    if (file_stream && !encrypted) {
-        total_transient_bytes = milvus::storage::SaturatingMultiply(
-            total_transient_bytes,
-            milvus::storage::kFileStreamBufferMultiplier);
-        max_task_transient_bytes = milvus::storage::SaturatingMultiply(
-            max_task_transient_bytes,
-            milvus::storage::kFileStreamBufferMultiplier);
+    auto total_transient_bytes =
+        storage::EntryStreamTransientBytes(spec.index_size_in_bytes, encrypted);
+    auto max_task_transient_bytes = storage::EntryStreamTransientBytes(
+        storage::MaxEntryStreamTaskBytes(), encrypted);
+
+    // Without a concrete encrypted directory there is no trustworthy
+    // ciphertext task bound. When the runtime budget is disabled, keep the
+    // conservative whole-stream fallback instead of applying the executor
+    // bound.
+    if (encrypted && storage::TransientMemoryBudget::GetLoadTransientBudget()
+                             .CapacityBytes() == 0) {
+        return total_transient_bytes;
+    }
+
+    // Plain file-backed loads may retain both the downloaded slice and a
+    // second aligned buffer used by PositionedFileWriter. Encrypted stream
+    // accounting already includes its output buffer, so only plain streams
+    // need the file-writer multiplier.
+    if (IsFileStreamIndex(effective_index_type) && !encrypted) {
+        total_transient_bytes = storage::SaturatingMultiply(
+            total_transient_bytes, storage::kFileStreamBufferMultiplier);
+        max_task_transient_bytes = storage::SaturatingMultiply(
+            max_task_transient_bytes, storage::kFileStreamBufferMultiplier);
+    }
+
+    return storage::EntryStreamMaxTransientBytes(total_transient_bytes,
+                                                 max_task_transient_bytes);
+}
+
+uint64_t
+EstimateInspectedScalarStreamPeak(
+    const IndexLoadSpec& spec,
+    const IndexType& effective_index_type,
+    const storage::EntryStreamLoadInfo& stream_load_info) {
+    if (spec.index_size_in_bytes == 0) {
+        return 0;
+    }
+
+    auto total_transient_bytes = stream_load_info.encrypted
+                                     ? stream_load_info.total_transient_bytes
+                                     : storage::EntryStreamTransientBytes(
+                                           spec.index_size_in_bytes, false);
+    // Plain file-backed loads may retain both the downloaded slice and a
+    // second aligned buffer used by PositionedFileWriter. Encrypted stream
+    // accounting already includes its output buffer, so only plain streams
+    // need the file-writer multiplier.
+    if (IsFileStreamIndex(effective_index_type) &&
+        !stream_load_info.encrypted) {
+        total_transient_bytes = storage::SaturatingMultiply(
+            total_transient_bytes, storage::kFileStreamBufferMultiplier);
     }
 
     // File-aware estimates must remain valid when a later reload observes a
     // larger transient budget or executor. Grouped loads are capped by the
     // current Group policy; request-local loads reserve this stable full sum.
-    if (stream_load_info.has_value()) {
-        return total_transient_bytes;
+    return total_transient_bytes;
+}
+
+std::optional<int64_t>
+SharedScalarStreamRuntimeUnit(
+    const IndexType& effective_index_type,
+    const storage::EntryStreamLoadInfo& stream_load_info) {
+    if (effective_index_type == BITMAP_INDEX_TYPE ||
+        effective_index_type == HYBRID_INDEX_TYPE) {
+        return std::nullopt;
     }
 
-    return milvus::storage::EntryStreamMaxTransientBytes(
-        total_transient_bytes, max_task_transient_bytes);
+    size_t runtime_unit_bytes;
+    if (stream_load_info.encrypted) {
+        runtime_unit_bytes = stream_load_info.max_task_transient_bytes;
+    } else {
+        // Preserve the current Group task bound for all plaintext scalar V3
+        // streams, including SORT and MARISA.
+        runtime_unit_bytes =
+            storage::SaturatingMultiply(storage::MaxEntryStreamTaskBytes(),
+                                        storage::kFileStreamBufferMultiplier);
+    }
+
+    return static_cast<int64_t>(
+        std::min(runtime_unit_bytes,
+                 static_cast<size_t>(std::numeric_limits<int64_t>::max())));
 }
 
 uint64_t
@@ -316,6 +362,194 @@ InspectScalarIndexStreamLoadInfo(
                                                             input->Size());
 }
 
+IndexType
+ScalarIndexTypeFromSpec(const IndexLoadSpec& spec) {
+    auto index_type_it = spec.index_params.find("index_type");
+    AssertInfo(index_type_it != spec.index_params.end(), "index type is empty");
+    return index_type_it->second;
+}
+
+int32_t
+ScalarIndexVersionFromSpec(const IndexLoadSpec& spec) {
+    auto config = ParseConfigFromIndexParams(spec.index_params);
+    return GetValueFromConfig<int32_t>(config, SCALAR_INDEX_ENGINE_VERSION)
+        .value_or(1);
+}
+
+bool
+HasCipherPlugin() {
+    return storage::PluginLoader::GetInstance().getCipherPlugin() != nullptr;
+}
+
+LoadResourceRequest
+EstimateSortLoadResource(const IndexLoadSpec& spec,
+                         uint64_t stream_peak_bytes) {
+    LoadResourceRequest request{};
+    // Old V3 sort files do not have idx_to_offsets and valid_bitset entries,
+    // so LoadEntries rebuilds them into heap memory.
+    auto legacy_aux_bytes = SortLegacyAuxBytes(spec.num_rows);
+    if (spec.mmap_enable) {
+        // V3 streaming: chunks streamed to disk + mmap. The index data is not
+        // heap-resident, but legacy metadata may be heap-resident.
+        auto resident_bytes = legacy_aux_bytes;
+        request.final_memory_cost = resident_bytes;
+        request.final_disk_cost = spec.index_size_in_bytes;
+        request.max_memory_cost = resident_bytes + stream_peak_bytes;
+        request.max_disk_cost = spec.index_size_in_bytes;
+    } else {
+        // V3 streaming: pre-allocate target, stream into it.
+        request.final_memory_cost = spec.index_size_in_bytes + legacy_aux_bytes;
+        request.final_disk_cost = 0;
+        request.max_memory_cost = request.final_memory_cost + stream_peak_bytes;
+        request.max_disk_cost = 0;
+    }
+    request.has_raw_data = true;
+    return request;
+}
+
+LoadResourceRequest
+EstimateMarisaLoadResource(const IndexLoadSpec& spec,
+                           uint64_t stream_peak_bytes) {
+    LoadResourceRequest request{};
+    if (spec.mmap_enable) {
+        // V3 streaming: trie, str_ids, and persisted CSR are mmap'd. Old V3
+        // files do not have CSR entries, so LoadEntries rebuilds CSR into heap
+        // vectors. Keep the current conservative legacy upper bound.
+        auto legacy_csr_resident_bytes = MarisaLegacyCsrBytes(spec.num_rows, 2);
+        auto legacy_csr_peak_bytes = MarisaLegacyCsrBytes(spec.num_rows, 3);
+        request.final_memory_cost = legacy_csr_resident_bytes;
+        request.final_disk_cost = spec.index_size_in_bytes;
+        request.max_memory_cost = legacy_csr_peak_bytes + stream_peak_bytes;
+        request.max_disk_cost = spec.index_size_in_bytes;
+    } else {
+        // V3 streaming: trie via temp file + read, str_ids pre-allocated.
+        request.final_memory_cost = spec.index_size_in_bytes;
+        request.final_disk_cost = 0;
+        request.max_memory_cost = spec.index_size_in_bytes + stream_peak_bytes;
+        request.max_disk_cost = spec.index_size_in_bytes;  // trie temp file
+    }
+    request.has_raw_data = true;
+    return request;
+}
+
+LoadResourceRequest
+EstimateDiskScalarLoadResource(const IndexLoadSpec& spec,
+                               uint64_t stream_peak_bytes) {
+    return LoadResourceRequest{
+        .max_memory_cost = stream_peak_bytes,
+        .max_disk_cost = spec.index_size_in_bytes,
+        .final_memory_cost = 0,
+        .final_disk_cost = spec.index_size_in_bytes,
+        .has_raw_data = false,
+    };
+}
+
+LoadResourceRequest
+EstimateFMIndexLoadResource(const IndexLoadSpec& spec,
+                            uint64_t stream_peak_bytes) {
+    LoadResourceRequest request{};
+    // FM-index is a single flat blob. A LoadView (mmap) load views every
+    // serialized array in place — wavelet words, sampled bitvector,
+    // sampled-SA values, doc boundaries; nothing is heap-copied. What the
+    // load DOES rebuild on the heap is the rank directories plus small
+    // derived vectors and the wrapper's null bitmap. At the default
+    // fm_block_bytes=64 the wavelet rank directory is roughly 1/8 of its
+    // packed words, so index_size can substantially overstate steady heap
+    // usage, especially when per-row document boundaries dominate the blob.
+    // Keep index_size as the deliberately conservative pre-load admission/peak
+    // bound; after LoadView succeeds FMIndex replaces the cache cell's
+    // memory_bytes with its measured resident heap while retaining file_bytes.
+    if (spec.mmap_enable) {
+        request.final_memory_cost = spec.index_size_in_bytes;
+        request.final_disk_cost = spec.index_size_in_bytes;
+        request.max_memory_cost = spec.index_size_in_bytes + stream_peak_bytes;
+        request.max_disk_cost = spec.index_size_in_bytes;
+    } else {
+        // Deserialize MOVES the reader entry buffer into owned_blob_ (no
+        // intermediate copies), so the resident set is the owned blob (~1x)
+        // plus the rebuilt rank directories (~1x blob): both steady and peak
+        // are ~2x. (Without the move overload the peak was ~4x from three
+        // simultaneous full copies.)
+        request.final_memory_cost = 2 * spec.index_size_in_bytes;
+        request.final_disk_cost = 0;
+        request.max_memory_cost = 2 * spec.index_size_in_bytes;
+        request.max_disk_cost = 0;
+    }
+    request.has_raw_data = false;
+    return request;
+}
+
+LoadResourceRequest
+EstimateBitmapLoadResource(const IndexLoadSpec& spec,
+                           uint64_t stream_peak_bytes) {
+    LoadResourceRequest request{};
+    if (spec.mmap_enable) {
+        // V3 streaming: stream to temp file (mmap'd), then MMapIndexData
+        // converts one bitmap at a time to frozen format. The conversion still
+        // allocates a per-bitmap heap buffer, so reserve for the largest
+        // plausible bitmap in addition to stream buffers.
+        auto resident_bytes = BitsetBytes(spec.num_rows);
+        auto frozen_buffer_bytes = BitmapMmapFrozenBufferBytes(
+            spec.num_rows, spec.index_size_in_bytes);
+        request.final_memory_cost = resident_bytes;
+        request.final_disk_cost = spec.index_size_in_bytes;
+        request.max_memory_cost =
+            resident_bytes + stream_peak_bytes + frozen_buffer_bytes;
+        request.max_disk_cost = 2 * spec.index_size_in_bytes;  // temp + final
+    } else {
+        // V3 streaming: pre-allocate buffer + deserialize.
+        request.final_memory_cost = spec.index_size_in_bytes;
+        request.final_disk_cost = 0;
+        request.max_memory_cost =
+            std::max(2 * spec.index_size_in_bytes,
+                     spec.index_size_in_bytes + stream_peak_bytes);
+        request.max_disk_cost = 0;
+    }
+    request.has_raw_data = false;
+    return request;
+}
+
+LoadResourceRequest
+EstimateHybridFallbackLoadResource(const IndexLoadSpec& spec) {
+    return LoadResourceRequest{
+        .max_memory_cost = 2 * spec.index_size_in_bytes,
+        .max_disk_cost = spec.index_size_in_bytes,
+        .final_memory_cost = spec.index_size_in_bytes,
+        .final_disk_cost = spec.index_size_in_bytes,
+        .has_raw_data = false,
+    };
+}
+
+LoadResourceRequest
+CalculateScalarLoadResourceRequest(const IndexLoadSpec& spec,
+                                   const IndexType& effective_index_type,
+                                   uint64_t stream_peak_bytes) {
+    LoadResourceRequest request{};
+    if (effective_index_type == ASCENDING_SORT) {
+        request = EstimateSortLoadResource(spec, stream_peak_bytes);
+    } else if (effective_index_type == MARISA_TRIE ||
+               effective_index_type == MARISA_TRIE_UPPER) {
+        request = EstimateMarisaLoadResource(spec, stream_peak_bytes);
+    } else if (IsFileStreamIndex(effective_index_type)) {
+        request = EstimateDiskScalarLoadResource(spec, stream_peak_bytes);
+    } else if (effective_index_type == FMINDEX_INDEX_TYPE) {
+        request = EstimateFMIndexLoadResource(spec, stream_peak_bytes);
+    } else if (effective_index_type == BITMAP_INDEX_TYPE) {
+        request = EstimateBitmapLoadResource(spec, stream_peak_bytes);
+    } else if (effective_index_type == HYBRID_INDEX_TYPE) {
+        request = EstimateHybridFallbackLoadResource(spec);
+    } else {
+        LOG_ERROR(
+            "invalid index type to estimate scalar index load resource: {}",
+            effective_index_type);
+        return LoadResourceRequest{0, 0, 0, 0, false};
+    }
+
+    request.has_raw_data = IndexFactory::CanUseIndexRawDataForField(
+        spec.field_type, request.has_raw_data);
+    return request;
+}
+
 }  // namespace
 
 bool
@@ -400,86 +634,30 @@ IndexFactory::CreatePrimitiveScalarIndex<std::string>(
 }
 
 LoadResourceRequest
-IndexFactory::IndexLoadResource(
-    DataType field_type,
-    DataType element_type,
-    IndexVersion index_version,
-    uint64_t index_size_in_bytes,
-    const std::map<std::string, std::string>& index_params,
-    bool mmap_enable,
-    int64_t num_rows,
-    int64_t dim) {
-    if (milvus::IsVectorDataType(field_type)) {
-        return VecIndexLoadResource(field_type,
-                                    element_type,
-                                    index_version,
-                                    index_size_in_bytes,
-                                    index_params,
-                                    mmap_enable,
-                                    num_rows,
-                                    dim);
-    } else {
-        return ScalarIndexLoadResource(field_type,
-                                       index_version,
-                                       index_size_in_bytes,
-                                       index_params,
-                                       mmap_enable,
-                                       num_rows);
+IndexFactory::EstimateIndexLoadResource(const IndexLoadSpec& spec) {
+    if (milvus::IsVectorDataType(spec.field_type)) {
+        return EstimateVectorIndexLoadResource(spec);
     }
+
+    auto scalar_version = ScalarIndexVersionFromSpec(spec);
+    auto effective_index_type = ScalarIndexTypeFromSpec(spec);
+    auto encrypted = scalar_version >= 3 && HasCipherPlugin();
+    auto stream_peak_bytes = EstimateMetadataScalarStreamPeak(
+        spec, effective_index_type, scalar_version, encrypted);
+    return CalculateScalarLoadResourceRequest(
+        spec, effective_index_type, stream_peak_bytes);
 }
 
 LoadResourceRequest
-IndexFactory::IndexLoadResource(
-    DataType field_type,
-    DataType element_type,
-    IndexVersion index_version,
-    uint64_t index_size_in_bytes,
-    const std::map<std::string, std::string>& index_params,
-    bool mmap_enable,
-    int64_t num_rows,
-    int64_t dim,
-    const std::vector<std::string>& index_files,
-    const storage::FileManagerContext& file_manager_context,
-    std::optional<storage::EntryStreamLoadInfo>* stream_load_info,
-    bool* use_shared_memory_overhead_group) {
-    if (stream_load_info != nullptr) {
-        stream_load_info->reset();
-    }
-    if (use_shared_memory_overhead_group != nullptr) {
-        *use_shared_memory_overhead_group = false;
-    }
-    if (milvus::IsVectorDataType(field_type)) {
-        return VecIndexLoadResource(field_type,
-                                    element_type,
-                                    index_version,
-                                    index_size_in_bytes,
-                                    index_params,
-                                    mmap_enable,
-                                    num_rows,
-                                    dim);
-    }
-    return ScalarIndexLoadResource(field_type,
-                                   index_version,
-                                   index_size_in_bytes,
-                                   index_params,
-                                   mmap_enable,
-                                   num_rows,
-                                   index_files,
-                                   file_manager_context,
-                                   stream_load_info,
-                                   use_shared_memory_overhead_group);
-}
-
-LoadResourceRequest
-IndexFactory::VecIndexLoadResource(
-    DataType field_type,
-    DataType element_type,
-    IndexVersion index_version,
-    uint64_t index_size_in_bytes,
-    const std::map<std::string, std::string>& index_params,
-    bool mmap_enable,
-    int64_t num_rows,
-    int64_t dim) {
+IndexFactory::EstimateVectorIndexLoadResource(const IndexLoadSpec& spec) {
+    auto field_type = spec.field_type;
+    auto element_type = spec.element_type;
+    auto index_version = spec.index_version;
+    auto index_size_in_bytes = spec.index_size_in_bytes;
+    const auto& index_params = spec.index_params;
+    auto mmap_enable = spec.mmap_enable;
+    auto num_rows = spec.num_rows;
+    auto dim = spec.dim;
     auto config = milvus::index::ParseConfigFromIndexParams(index_params);
 
     auto index_type_it = index_params.find("index_type");
@@ -682,220 +860,23 @@ IndexFactory::VecIndexLoadResource(
     return request;
 }
 
-LoadResourceRequest
-IndexFactory::ScalarIndexLoadResource(
-    DataType field_type,
-    IndexVersion index_version,
-    uint64_t index_size_in_bytes,
-    const std::map<std::string, std::string>& index_params,
-    bool mmap_enable,
-    int64_t num_rows) {
-    return ScalarIndexLoadResourceImpl(field_type,
-                                       index_version,
-                                       index_size_in_bytes,
-                                       index_params,
-                                       mmap_enable,
-                                       num_rows,
-                                       std::nullopt);
-}
-
-LoadResourceRequest
-IndexFactory::ScalarIndexLoadResourceImpl(
-    DataType field_type,
-    IndexVersion index_version,
-    uint64_t index_size_in_bytes,
-    const std::map<std::string, std::string>& index_params,
-    bool mmap_enable,
-    int64_t num_rows,
-    const std::optional<storage::EntryStreamLoadInfo>& stream_load_info) {
-    auto config = milvus::index::ParseConfigFromIndexParams(index_params);
-
-    auto index_type_it = index_params.find("index_type");
-    AssertInfo(index_type_it != index_params.end(), "index type is empty");
-    const std::string& index_type = index_type_it->second;
-
-    knowhere::expected<knowhere::Resource> resource;
-    auto scalar_version =
-        milvus::index::GetValueFromConfig<int32_t>(
-            config, milvus::index::SCALAR_INDEX_ENGINE_VERSION)
-            .value_or(1);
-    // File-aware callers use the persisted __edek__ marker. Keep plugin state
-    // only as a compatibility fallback for callers without file context.
-    auto encrypted_stream =
-        scalar_version >= 3 &&
-        (stream_load_info.has_value()
-             ? stream_load_info->encrypted
-             : milvus::storage::PluginLoader::GetInstance().getCipherPlugin() !=
-                   nullptr);
-    auto file_stream = index_type == milvus::index::INVERTED_INDEX_TYPE ||
-                       index_type == milvus::index::NGRAM_INDEX_TYPE ||
-                       index_type == milvus::index::RTREE_INDEX_TYPE;
-    auto stream_memory_overhead =
-        ScalarIndexStreamMemoryOverhead(index_size_in_bytes,
-                                        scalar_version,
-                                        encrypted_stream,
-                                        file_stream,
-                                        stream_load_info);
-
-    LoadResourceRequest request{};
-    request.has_raw_data = false;
-
-    if (index_type == milvus::index::ASCENDING_SORT) {
-        // Old V3 sort files do not have idx_to_offsets and valid_bitset
-        // entries, so LoadEntries rebuilds them into heap memory.
-        auto legacy_aux_bytes = SortLegacyAuxBytes(num_rows);
-        if (mmap_enable) {
-            // V3 streaming: chunks streamed to disk + mmap. The index data is
-            // not heap-resident, but legacy metadata may be heap-resident.
-            auto resident_bytes = legacy_aux_bytes;
-            request.final_memory_cost = resident_bytes;
-            request.final_disk_cost = index_size_in_bytes;
-            request.max_memory_cost = resident_bytes + stream_memory_overhead;
-            request.max_disk_cost = index_size_in_bytes;
-        } else {
-            // V3 streaming: pre-allocate target, stream into it
-            request.final_memory_cost = index_size_in_bytes + legacy_aux_bytes;
-            request.final_disk_cost = 0;
-            request.max_memory_cost =
-                request.final_memory_cost + stream_memory_overhead;
-            request.max_disk_cost = 0;
-        }
-        request.has_raw_data = true;
-    } else if (index_type == milvus::index::MARISA_TRIE ||
-               index_type == milvus::index::MARISA_TRIE_UPPER) {
-        if (mmap_enable) {
-            // V3 streaming: trie, str_ids, and persisted CSR are mmap'd.
-            // Old V3 files do not have CSR entries, so LoadEntries rebuilds
-            // CSR into heap vectors. Estimate a conservative legacy upper
-            // bound because resource estimation cannot inspect entries here.
-            auto legacy_csr_resident_bytes = MarisaLegacyCsrBytes(num_rows, 2);
-            auto legacy_csr_peak_bytes = MarisaLegacyCsrBytes(num_rows, 3);
-            request.final_memory_cost = legacy_csr_resident_bytes;
-            request.final_disk_cost = index_size_in_bytes;
-            request.max_memory_cost =
-                legacy_csr_peak_bytes + stream_memory_overhead;
-            request.max_disk_cost = index_size_in_bytes;
-        } else {
-            // V3 streaming: trie via temp file + read, str_ids pre-allocated
-            request.final_memory_cost = index_size_in_bytes;
-            request.final_disk_cost = 0;
-            request.max_memory_cost =
-                index_size_in_bytes + stream_memory_overhead;
-            request.max_disk_cost = index_size_in_bytes;  // trie temp file
-        }
-        request.has_raw_data = true;
-    } else if (index_type == milvus::index::INVERTED_INDEX_TYPE ||
-               index_type == milvus::index::NGRAM_INDEX_TYPE ||
-               index_type == milvus::index::RTREE_INDEX_TYPE) {
-        request.final_memory_cost = 0;
-        request.final_disk_cost = index_size_in_bytes;
-        request.max_memory_cost = stream_memory_overhead;
-        request.max_disk_cost = index_size_in_bytes;
-
-        request.has_raw_data = false;
-    } else if (index_type == milvus::index::FMINDEX_INDEX_TYPE) {
-        // FM-index is a single flat blob. A LoadView (mmap) load views every
-        // serialized array in place — wavelet words, sampled bitvector,
-        // sampled-SA values, doc boundaries; nothing is heap-copied. What the
-        // load DOES rebuild on the heap is the rank directories plus small
-        // derived vectors and the wrapper's null bitmap. At the default
-        // fm_block_bytes=64 the wavelet rank directory is roughly 1/8 of its
-        // packed words, so index_size can substantially overstate steady heap
-        // usage, especially when per-row document boundaries dominate the
-        // blob. Keep index_size as the deliberately conservative pre-load
-        // admission/peak bound; after LoadView succeeds FMIndex replaces the
-        // cache cell's memory_bytes with its measured resident heap while
-        // retaining file_bytes.
-        if (mmap_enable) {
-            request.final_memory_cost = index_size_in_bytes;
-            request.final_disk_cost = index_size_in_bytes;
-            request.max_memory_cost =
-                index_size_in_bytes + stream_memory_overhead;
-            request.max_disk_cost = index_size_in_bytes;
-        } else {
-            // Deserialize MOVES the reader entry buffer into owned_blob_ (no
-            // intermediate copies), so the resident set is the owned blob (~1x)
-            // plus the rebuilt rank directories (~1x blob): both steady and
-            // peak are ~2x. (Without the move overload the peak was ~4x from
-            // three simultaneous full copies.)
-            request.final_memory_cost = 2 * index_size_in_bytes;
-            request.final_disk_cost = 0;
-            request.max_memory_cost = 2 * index_size_in_bytes;
-            request.max_disk_cost = 0;
-        }
-        request.has_raw_data = false;
-    } else if (index_type == milvus::index::BITMAP_INDEX_TYPE) {
-        if (mmap_enable) {
-            // V3 streaming: stream to temp file (mmap'd), then MMapIndexData
-            // converts one bitmap at a time to frozen format. The conversion
-            // still allocates a per-bitmap heap buffer, so reserve for the
-            // largest plausible bitmap in addition to stream buffers.
-            auto resident_bytes = BitsetBytes(num_rows);
-            auto frozen_buffer_bytes =
-                BitmapMmapFrozenBufferBytes(num_rows, index_size_in_bytes);
-            request.final_memory_cost = resident_bytes;
-            request.final_disk_cost = index_size_in_bytes;
-            request.max_memory_cost =
-                resident_bytes + stream_memory_overhead + frozen_buffer_bytes;
-            request.max_disk_cost = 2 * index_size_in_bytes;  // temp + final
-        } else {
-            // V3 streaming: pre-allocate buffer + deserialize
-            request.final_memory_cost = index_size_in_bytes;
-            request.final_disk_cost = 0;
-            request.max_memory_cost =
-                std::max(2 * index_size_in_bytes,
-                         index_size_in_bytes + stream_memory_overhead);
-            request.max_disk_cost = 0;
-        }
-
-        request.has_raw_data = false;
-    } else if (index_type == milvus::index::HYBRID_INDEX_TYPE) {
-        request.final_memory_cost = index_size_in_bytes;
-        request.final_disk_cost = index_size_in_bytes;
-        request.max_memory_cost = 2 * index_size_in_bytes;
-        request.max_disk_cost = index_size_in_bytes;
-        request.has_raw_data = false;
-    } else {
-        LOG_ERROR(
-            "invalid index type to estimate scalar index load resource: {}",
-            index_type);
-        return LoadResourceRequest{0, 0, 0, 0, false};
-    }
-    request.has_raw_data =
-        CanUseIndexRawDataForField(field_type, request.has_raw_data);
-    return request;
-}
-
-LoadResourceRequest
-IndexFactory::ScalarIndexLoadResource(
-    DataType field_type,
-    IndexVersion index_version,
-    uint64_t index_size_in_bytes,
-    const std::map<std::string, std::string>& index_params,
-    bool mmap_enable,
-    int64_t num_rows,
-    const std::vector<std::string>& index_files,
-    const storage::FileManagerContext& file_manager_context,
-    std::optional<storage::EntryStreamLoadInfo>* stream_load_info,
-    bool* use_shared_memory_overhead_group) {
-    auto index_type_it = index_params.find("index_type");
-    AssertInfo(index_type_it != index_params.end(), "index type is empty");
-    std::optional<storage::EntryStreamLoadInfo> inspected_stream_load_info;
-    auto config = milvus::index::ParseConfigFromIndexParams(index_params);
-    auto scalar_version =
-        milvus::index::GetValueFromConfig<int32_t>(
-            config, milvus::index::SCALAR_INDEX_ENGINE_VERSION)
-            .value_or(1);
+ScalarIndexFileInspection
+IndexFactory::InspectScalarIndexFiles(const IndexLoadSpec& spec,
+                                      const IndexFileContext& files) {
+    auto effective_index_type = ScalarIndexTypeFromSpec(spec);
+    auto scalar_version = ScalarIndexVersionFromSpec(spec);
+    std::optional<storage::EntryStreamLoadInfo> stream_load_info;
     std::optional<ScalarIndexType> internal_index_type;
-    if (index_type_it->second == milvus::index::HYBRID_INDEX_TYPE) {
+    if (effective_index_type == HYBRID_INDEX_TYPE) {
         try {
-            internal_index_type = ResolveHybridInternalIndexType(
-                index_files, file_manager_context, &inspected_stream_load_info);
+            internal_index_type =
+                ResolveHybridInternalIndexType(files.index_files,
+                                               files.file_manager_context,
+                                               &stream_load_info);
         } catch (std::exception& e) {
-            if (scalar_version >= 3 &&
-                !inspected_stream_load_info.has_value()) {
-                inspected_stream_load_info = InspectScalarIndexStreamLoadInfo(
-                    index_files, file_manager_context);
+            if (scalar_version >= 3 && !stream_load_info.has_value()) {
+                stream_load_info = InspectScalarIndexStreamLoadInfo(
+                    files.index_files, files.file_manager_context);
             }
             LOG_WARN(
                 "failed to resolve hybrid scalar internal index type, "
@@ -903,46 +884,54 @@ IndexFactory::ScalarIndexLoadResource(
                 e.what());
         }
     } else if (scalar_version >= 3) {
-        inspected_stream_load_info =
-            InspectScalarIndexStreamLoadInfo(index_files, file_manager_context);
-    }
-    if (stream_load_info != nullptr) {
-        *stream_load_info = inspected_stream_load_info;
+        stream_load_info = InspectScalarIndexStreamLoadInfo(
+            files.index_files, files.file_manager_context);
     }
 
-    auto resolved_params = index_params;
     if (internal_index_type.has_value()) {
         auto resolved_index_type =
             HybridInternalIndexTypeToIndexType(internal_index_type.value());
         if (!resolved_index_type.empty()) {
-            resolved_params["index_type"] = resolved_index_type;
+            effective_index_type = std::move(resolved_index_type);
             LOG_INFO(
                 "estimate hybrid scalar index load resource by internal index "
                 "type: {}",
-                resolved_index_type);
+                effective_index_type);
         }
     }
 
-    const auto& resolved_index_type = resolved_params.at("index_type");
-    // BITMAP staging and frozen-conversion buffers are allocated by the
-    // request itself, outside the entry-stream executor and transient budget.
-    // Keep their overhead request-local. An unresolved HYBRID may also select
-    // BITMAP at load time, so it must use the same conservative path.
-    auto use_shared_group =
-        scalar_version >= 3 &&
-        resolved_index_type != milvus::index::BITMAP_INDEX_TYPE &&
-        resolved_index_type != milvus::index::HYBRID_INDEX_TYPE;
-    if (use_shared_memory_overhead_group != nullptr) {
-        *use_shared_memory_overhead_group = use_shared_group;
+    return ScalarIndexFileInspection{
+        .effective_index_type = std::move(effective_index_type),
+        .stream_load_info = std::move(stream_load_info),
+    };
+}
+
+ScalarIndexLoadPlan
+IndexFactory::PlanScalarIndexLoad(const IndexLoadSpec& spec,
+                                  const ScalarIndexFileInspection& inspection) {
+    auto scalar_version = ScalarIndexVersionFromSpec(spec);
+    uint64_t stream_peak_bytes;
+    std::optional<int64_t> shared_memory_runtime_unit_bytes;
+    if (scalar_version < 3) {
+        stream_peak_bytes = spec.index_size_in_bytes;
+    } else {
+        // File-aware planning must not silently fall back to the metadata-only
+        // estimate; the two paths intentionally use different peak formulas.
+        AssertInfo(inspection.stream_load_info.has_value(),
+                   "missing stream load info for packed scalar V3 index");
+        const auto& stream_load_info = *inspection.stream_load_info;
+        stream_peak_bytes = EstimateInspectedScalarStreamPeak(
+            spec, inspection.effective_index_type, stream_load_info);
+        shared_memory_runtime_unit_bytes = SharedScalarStreamRuntimeUnit(
+            inspection.effective_index_type, stream_load_info);
     }
 
-    return ScalarIndexLoadResourceImpl(field_type,
-                                       index_version,
-                                       index_size_in_bytes,
-                                       resolved_params,
-                                       mmap_enable,
-                                       num_rows,
-                                       inspected_stream_load_info);
+    auto request = CalculateScalarLoadResourceRequest(
+        spec, inspection.effective_index_type, stream_peak_bytes);
+    return ScalarIndexLoadPlan{
+        .request = request,
+        .shared_memory_runtime_unit_bytes = shared_memory_runtime_unit_bytes,
+    };
 }
 
 IndexBasePtr

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -633,6 +633,15 @@ IndexFactory::CreatePrimitiveScalarIndex<std::string>(
 #endif
 }
 
+bool
+IndexFactory::RequiresFileContextForLoadResource(const IndexLoadSpec& spec) {
+    if (milvus::IsVectorDataType(spec.field_type)) {
+        return false;
+    }
+    return ScalarIndexVersionFromSpec(spec) >= 3 ||
+           ScalarIndexTypeFromSpec(spec) == HYBRID_INDEX_TYPE;
+}
+
 LoadResourceRequest
 IndexFactory::EstimateIndexLoadResource(const IndexLoadSpec& spec) {
     if (milvus::IsVectorDataType(spec.field_type)) {

--- a/internal/core/src/index/IndexFactory.h
+++ b/internal/core/src/index/IndexFactory.h
@@ -34,6 +34,32 @@
 
 namespace milvus::index {
 
+struct IndexLoadSpec {
+    DataType field_type;
+    DataType element_type;
+    IndexVersion index_version;
+    uint64_t index_size_in_bytes;
+    const std::map<std::string, std::string>& index_params;
+    bool mmap_enable;
+    int64_t num_rows;
+    int64_t dim;
+};
+
+struct IndexFileContext {
+    const std::vector<std::string>& index_files;
+    const storage::FileManagerContext& file_manager_context;
+};
+
+struct ScalarIndexFileInspection {
+    IndexType effective_index_type;
+    std::optional<storage::EntryStreamLoadInfo> stream_load_info;
+};
+
+struct ScalarIndexLoadPlan {
+    LoadResourceRequest request;
+    std::optional<int64_t> shared_memory_runtime_unit_bytes;
+};
+
 class IndexFactory {
  public:
     IndexFactory() = default;
@@ -53,62 +79,23 @@ class IndexFactory {
     static bool
     CanUseIndexRawDataForField(DataType field_type, bool has_raw_data);
 
+    // Metadata-only estimate used by admission and fallback paths. This entry
+    // never opens index files.
     LoadResourceRequest
-    IndexLoadResource(DataType field_type,
-                      DataType element_type,
-                      IndexVersion index_version,
-                      uint64_t index_size_in_bytes,
-                      const std::map<std::string, std::string>& index_params,
-                      bool mmap_enable,
-                      int64_t num_rows,
-                      int64_t dim);
+    EstimateIndexLoadResource(const IndexLoadSpec& spec);
 
-    LoadResourceRequest
-    IndexLoadResource(
-        DataType field_type,
-        DataType element_type,
-        IndexVersion index_version,
-        uint64_t index_size_in_bytes,
-        const std::map<std::string, std::string>& index_params,
-        bool mmap_enable,
-        int64_t num_rows,
-        int64_t dim,
-        const std::vector<std::string>& index_files,
-        const storage::FileManagerContext& file_manager_context,
-        std::optional<storage::EntryStreamLoadInfo>* stream_load_info = nullptr,
-        bool* use_shared_memory_overhead_group = nullptr);
+    // Inspect scalar index files and normalize the effective index type. This
+    // entry performs file I/O but does not calculate a resource request.
+    ScalarIndexFileInspection
+    InspectScalarIndexFiles(const IndexLoadSpec& spec,
+                            const IndexFileContext& files);
 
-    LoadResourceRequest
-    VecIndexLoadResource(DataType field_type,
-                         DataType element_type,
-                         IndexVersion index_version,
-                         uint64_t index_size_in_bytes,
-                         const std::map<std::string, std::string>& index_params,
-                         bool mmap_enable,
-                         int64_t num_rows,
-                         int64_t dim);
-
-    LoadResourceRequest
-    ScalarIndexLoadResource(
-        DataType field_type,
-        IndexVersion index_version,
-        uint64_t index_size_in_bytes,
-        const std::map<std::string, std::string>& index_params,
-        bool mmap_enable,
-        int64_t num_rows);
-
-    LoadResourceRequest
-    ScalarIndexLoadResource(
-        DataType field_type,
-        IndexVersion index_version,
-        uint64_t index_size_in_bytes,
-        const std::map<std::string, std::string>& index_params,
-        bool mmap_enable,
-        int64_t num_rows,
-        const std::vector<std::string>& index_files,
-        const storage::FileManagerContext& file_manager_context,
-        std::optional<storage::EntryStreamLoadInfo>* stream_load_info = nullptr,
-        bool* use_shared_memory_overhead_group = nullptr);
+    // Build a scalar load plan from metadata and an existing file inspection.
+    // This entry performs no file I/O. Packed V3 planning requires persisted
+    // stream metadata and never falls back to the metadata-only estimate.
+    ScalarIndexLoadPlan
+    PlanScalarIndexLoad(const IndexLoadSpec& spec,
+                        const ScalarIndexFileInspection& inspection);
 
     IndexBasePtr
     CreateIndex(const CreateIndexInfo& create_index_info,
@@ -193,14 +180,7 @@ class IndexFactory {
     FRIEND_TEST(StringIndexMarisaTest, Reverse);
 
     LoadResourceRequest
-    ScalarIndexLoadResourceImpl(
-        DataType field_type,
-        IndexVersion index_version,
-        uint64_t index_size_in_bytes,
-        const std::map<std::string, std::string>& index_params,
-        bool mmap_enable,
-        int64_t num_rows,
-        const std::optional<storage::EntryStreamLoadInfo>& stream_load_info);
+    EstimateVectorIndexLoadResource(const IndexLoadSpec& spec);
 
     template <typename T>
     ScalarIndexPtr<T>

--- a/internal/core/src/index/IndexFactory.h
+++ b/internal/core/src/index/IndexFactory.h
@@ -79,6 +79,11 @@ class IndexFactory {
     static bool
     CanUseIndexRawDataForField(DataType field_type, bool has_raw_data);
 
+    // Whether resource planning needs scalar index file inspection instead of
+    // a reusable metadata-only estimate.
+    static bool
+    RequiresFileContextForLoadResource(const IndexLoadSpec& spec);
+
     // Metadata-only estimate used by admission and fallback paths. This entry
     // never opens index files.
     LoadResourceRequest

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -685,16 +685,17 @@ ChunkedSegmentSealedImpl::LoadVecIndex(LoadIndexInfo& info,
     if (info.load_resource_request.has_value()) {
         request = *info.load_resource_request;
     } else {
-        request =
-            milvus::index::IndexFactory::GetInstance().VecIndexLoadResource(
-                field_meta.get_data_type(),
-                info.element_type,
-                info.index_engine_version,
-                info.index_size,
-                info.index_params,
-                info.enable_mmap,
-                info.num_rows,
-                info.dim);
+        request = milvus::index::IndexFactory::GetInstance()
+                      .EstimateIndexLoadResource(milvus::index::IndexLoadSpec{
+                          .field_type = field_meta.get_data_type(),
+                          .element_type = info.element_type,
+                          .index_version = info.index_engine_version,
+                          .index_size_in_bytes = info.index_size,
+                          .index_params = info.index_params,
+                          .mmap_enable = info.enable_mmap,
+                          .num_rows = info.num_rows,
+                          .dim = info.dim,
+                      });
     }
     request.has_raw_data =
         milvus::index::IndexFactory::CanUseIndexRawDataForField(
@@ -888,14 +889,17 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(LoadIndexInfo& info,
     if (info.load_resource_request.has_value()) {
         request = *info.load_resource_request;
     } else {
-        request =
-            milvus::index::IndexFactory::GetInstance().ScalarIndexLoadResource(
-                field_meta.get_data_type(),
-                info.index_engine_version,
-                info.index_size,
-                info.index_params,
-                info.enable_mmap,
-                target_runtime->row_count);
+        request = milvus::index::IndexFactory::GetInstance()
+                      .EstimateIndexLoadResource(milvus::index::IndexLoadSpec{
+                          .field_type = field_meta.get_data_type(),
+                          .element_type = info.element_type,
+                          .index_version = info.index_engine_version,
+                          .index_size_in_bytes = info.index_size,
+                          .index_params = info.index_params,
+                          .mmap_enable = info.enable_mmap,
+                          .num_rows = target_runtime->row_count,
+                          .dim = info.dim,
+                      });
     }
 
     request.has_raw_data =

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -170,15 +170,17 @@ SegmentLoadInfo::CheckIndexHasRawData(const LoadIndexInfo& load_index_info) {
             load_index_info.load_resource_request->has_raw_data);
     } else {
         auto request =
-            milvus::index::IndexFactory::GetInstance().IndexLoadResource(
-                load_index_info.field_type,
-                load_index_info.element_type,
-                load_index_info.index_engine_version,
-                load_index_info.index_size,
-                load_index_info.index_params,
-                load_index_info.enable_mmap,
-                load_index_info.num_rows,
-                load_index_info.dim);
+            milvus::index::IndexFactory::GetInstance()
+                .EstimateIndexLoadResource(milvus::index::IndexLoadSpec{
+                    .field_type = load_index_info.field_type,
+                    .element_type = load_index_info.element_type,
+                    .index_version = load_index_info.index_engine_version,
+                    .index_size_in_bytes = load_index_info.index_size,
+                    .index_params = load_index_info.index_params,
+                    .mmap_enable = load_index_info.enable_mmap,
+                    .num_rows = load_index_info.num_rows,
+                    .dim = load_index_info.dim,
+                });
         return milvus::index::IndexFactory::CanUseIndexRawDataForField(
             load_index_info.field_type, request.has_raw_data);
     }

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -1229,33 +1229,23 @@ class SegmentLoadInfo {
             field_index_id_cache_[field_id].push_back(index_info.indexid());
             auto load_index_info = ConvertFieldIndexInfoToLoadIndexInfo(
                 &index_info, info_.segmentid());
-            auto index_type_it =
-                load_index_info.index_params.find(milvus::index::INDEX_TYPE);
-            auto scalar_version_it = load_index_info.index_params.find(
-                milvus::index::SCALAR_INDEX_ENGINE_VERSION);
-            auto scalar_v3 =
-                !IsVectorDataType(load_index_info.field_type) &&
-                scalar_version_it != load_index_info.index_params.end() &&
-                std::stoi(scalar_version_it->second) >= 3;
-            auto needs_file_context =
-                scalar_v3 ||
-                (!IsVectorDataType(load_index_info.field_type) &&
-                 index_type_it != load_index_info.index_params.end() &&
-                 index_type_it->second == milvus::index::HYBRID_INDEX_TYPE);
-            if (!needs_file_context) {
+            const auto load_spec = milvus::index::IndexLoadSpec{
+                .field_type = load_index_info.field_type,
+                .element_type = load_index_info.element_type,
+                .index_version = load_index_info.index_engine_version,
+                .index_size_in_bytes = load_index_info.index_size,
+                .index_params = load_index_info.index_params,
+                .mmap_enable = load_index_info.enable_mmap,
+                .num_rows = load_index_info.num_rows,
+                .dim = load_index_info.dim,
+            };
+            auto& index_factory = milvus::index::IndexFactory::GetInstance();
+            const auto requires_file_context =
+                milvus::index::IndexFactory::RequiresFileContextForLoadResource(
+                    load_spec);
+            if (!requires_file_context) {
                 load_index_info.load_resource_request =
-                    milvus::index::IndexFactory::GetInstance()
-                        .EstimateIndexLoadResource(milvus::index::IndexLoadSpec{
-                            .field_type = load_index_info.field_type,
-                            .element_type = load_index_info.element_type,
-                            .index_version =
-                                load_index_info.index_engine_version,
-                            .index_size_in_bytes = load_index_info.index_size,
-                            .index_params = load_index_info.index_params,
-                            .mmap_enable = load_index_info.enable_mmap,
-                            .num_rows = load_index_info.num_rows,
-                            .dim = load_index_info.dim,
-                        });
+                    index_factory.EstimateIndexLoadResource(load_spec);
             }
             // Check if index has raw data before moving
             if (CheckIndexHasRawData(load_index_info)) {

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -1245,14 +1245,17 @@ class SegmentLoadInfo {
             if (!needs_file_context) {
                 load_index_info.load_resource_request =
                     milvus::index::IndexFactory::GetInstance()
-                        .IndexLoadResource(load_index_info.field_type,
-                                           load_index_info.element_type,
-                                           load_index_info.index_engine_version,
-                                           load_index_info.index_size,
-                                           load_index_info.index_params,
-                                           load_index_info.enable_mmap,
-                                           load_index_info.num_rows,
-                                           load_index_info.dim);
+                        .EstimateIndexLoadResource(milvus::index::IndexLoadSpec{
+                            .field_type = load_index_info.field_type,
+                            .element_type = load_index_info.element_type,
+                            .index_version =
+                                load_index_info.index_engine_version,
+                            .index_size_in_bytes = load_index_info.index_size,
+                            .index_params = load_index_info.index_params,
+                            .mmap_enable = load_index_info.enable_mmap,
+                            .num_rows = load_index_info.num_rows,
+                            .dim = load_index_info.dim,
+                        });
             }
             // Check if index has raw data before moving
             if (CheckIndexHasRawData(load_index_info)) {

--- a/internal/core/src/segcore/load_index_c.cpp
+++ b/internal/core/src/segcore/load_index_c.cpp
@@ -167,15 +167,17 @@ EstimateLoadIndexResource(CLoadIndexInfo c_load_index_info) {
         // start loading. Keep that admission path metadata-only: exact scalar
         // V3 directory inspection belongs to SealedIndexTranslator, where the
         // result is used for the actual MCL loading reservation.
-        return milvus::index::IndexFactory::GetInstance().IndexLoadResource(
-            field_type,
-            element_type,
-            load_index_info->index_engine_version,
-            load_index_info->index_size,
-            index_params,
-            load_index_info->enable_mmap,
-            load_index_info->num_rows,
-            load_index_info->dim);
+        return milvus::index::IndexFactory::GetInstance()
+            .EstimateIndexLoadResource(milvus::index::IndexLoadSpec{
+                .field_type = field_type,
+                .element_type = element_type,
+                .index_version = load_index_info->index_engine_version,
+                .index_size_in_bytes = load_index_info->index_size,
+                .index_params = index_params,
+                .mmap_enable = load_index_info->enable_mmap,
+                .num_rows = load_index_info->num_rows,
+                .dim = load_index_info->dim,
+            });
     } catch (std::exception& e) {
         ThrowInfo(milvus::UnexpectedError,
                   fmt::format("failed to estimate index load resource, "

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
@@ -93,7 +93,23 @@ SealedIndexTranslator::SealedIndexTranslator(
         .dim = index_load_info_.dim,
     };
     auto& index_factory = milvus::index::IndexFactory::GetInstance();
-    if (IsVectorDataType(index_load_info_.field_type)) {
+    const auto is_vector = IsVectorDataType(index_load_info_.field_type);
+    const auto config_scalar_version =
+        is_vector ? 1
+                  : milvus::index::GetValueFromConfig<int32_t>(
+                        config_, milvus::index::SCALAR_INDEX_ENGINE_VERSION)
+                        .value_or(1);
+    const auto requires_file_context =
+        milvus::index::IndexFactory::RequiresFileContextForLoadResource(
+            load_spec) ||
+        config_scalar_version >= 3;
+    if (index_load_info_.load_resource_request.has_value() &&
+        !requires_file_context) {
+        load_resource_request_ = *index_load_info_.load_resource_request;
+        return;
+    }
+
+    if (is_vector) {
         load_resource_request_ =
             index_factory.EstimateIndexLoadResource(load_spec);
     } else {
@@ -106,11 +122,7 @@ SealedIndexTranslator::SealedIndexTranslator(
         auto plan = index_factory.PlanScalarIndexLoad(load_spec, inspection);
         load_resource_request_ = plan.request;
 
-        auto scalar_version =
-            milvus::index::GetValueFromConfig<int32_t>(
-                config_, milvus::index::SCALAR_INDEX_ENGINE_VERSION)
-                .value_or(1);
-        if (scalar_version >= 3) {
+        if (config_scalar_version >= 3) {
             AssertInfo(inspection.stream_load_info.has_value(),
                        "missing stream load info for packed scalar V3 index");
             if (plan.shared_memory_runtime_unit_bytes.has_value()) {

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
@@ -1,7 +1,6 @@
 #include "segcore/storagev1translator/SealedIndexTranslator.h"
 
 #include <filesystem>
-#include <limits>
 #include <optional>
 #include <utility>
 
@@ -20,21 +19,10 @@
 #include "segcore/Types.h"
 #include "segcore/Utils.h"
 #include "segcore/memory_planner.h"
-#include "storage/EntryStreamUtils.h"
 #include "storage/LoadOverheadController.h"
 #include "storage/ThreadPools.h"
 
 namespace milvus::segcore::storagev1translator {
-
-namespace {
-
-int64_t
-PolicyBytes(size_t bytes) {
-    return static_cast<int64_t>(std::min(
-        bytes, static_cast<size_t>(std::numeric_limits<int64_t>::max())));
-}
-
-}  // namespace
 
 SealedIndexTranslator::SealedIndexTranslator(
     milvus::index::CreateIndexInfo index_info,
@@ -92,66 +80,62 @@ SealedIndexTranslator::SealedIndexTranslator(
                 index_info_.index_type, knowhere::feature::LAZY_LOAD)),
           std::nullopt,
           milvus::segcore::MetricAttributionFromShard(load_index_info->shard)) {
-    std::optional<milvus::storage::EntryStreamLoadInfo> stream_load_info;
-    bool use_shared_memory_overhead_group = false;
-    load_resource_request_ = EstimateLoadResource(
-        &stream_load_info, &use_shared_memory_overhead_group);
+    const auto load_spec = milvus::index::IndexLoadSpec{
+        .field_type = index_load_info_.field_type,
+        .element_type = index_load_info_.element_type,
+        .index_version =
+            static_cast<IndexVersion>(index_load_info_.index_engine_version),
+        .index_size_in_bytes =
+            static_cast<uint64_t>(index_load_info_.index_size),
+        .index_params = index_load_info_.index_params,
+        .mmap_enable = index_load_info_.enable_mmap,
+        .num_rows = index_load_info_.num_rows,
+        .dim = index_load_info_.dim,
+    };
+    auto& index_factory = milvus::index::IndexFactory::GetInstance();
+    if (IsVectorDataType(index_load_info_.field_type)) {
+        load_resource_request_ =
+            index_factory.EstimateIndexLoadResource(load_spec);
+    } else {
+        auto inspection = index_factory.InspectScalarIndexFiles(
+            load_spec,
+            milvus::index::IndexFileContext{
+                .index_files = index_load_info_.index_files,
+                .file_manager_context = file_manager_context_,
+            });
+        auto plan = index_factory.PlanScalarIndexLoad(load_spec, inspection);
+        load_resource_request_ = plan.request;
 
-    auto scalar_version =
-        milvus::index::GetValueFromConfig<int32_t>(
-            config_, milvus::index::SCALAR_INDEX_ENGINE_VERSION)
-            .value_or(1);
-    if (scalar_version >= 3 && !IsVectorDataType(index_load_info_.field_type)) {
-        AssertInfo(stream_load_info.has_value(),
-                   "missing stream load info for packed scalar V3 index");
-        if (use_shared_memory_overhead_group) {
-            auto max_task_overhead =
-                stream_load_info->encrypted
-                    ? stream_load_info->max_task_transient_bytes
-                    : milvus::storage::SaturatingMultiply(
-                          milvus::storage::MaxEntryStreamTaskBytes(),
-                          milvus::storage::kFileStreamBufferMultiplier);
-            auto memory_group =
-                milvus::storage::LoadMemoryOverheadController::GetInstance()
-                    .GetOrCreate(milvus::ThreadPools::GetLoadExecutorWorkers());
-            meta_.loading_overhead_config =
-                milvus::cachinglayer::LoadingOverheadConfig{
-                    milvus::cachinglayer::LoadingOverheadGroupBinding{
-                        std::move(memory_group),
-                        PolicyBytes(max_task_overhead)},
-                    // FIXME: Bind scalar V3 file overhead to the executor-backed
-                    // file group after every file-backed load path writes through
-                    // positioned tasks on the HIGH/LOW load executors. Some paths
-                    // still use FileWriter or its independent worker pool, so
-                    // binding them now would under-reserve concurrent disk
-                    // overhead.
-                    std::nullopt};
+        auto scalar_version =
+            milvus::index::GetValueFromConfig<int32_t>(
+                config_, milvus::index::SCALAR_INDEX_ENGINE_VERSION)
+                .value_or(1);
+        if (scalar_version >= 3) {
+            AssertInfo(inspection.stream_load_info.has_value(),
+                       "missing stream load info for packed scalar V3 index");
+            if (plan.shared_memory_runtime_unit_bytes.has_value()) {
+                auto max_runtime_unit = *plan.shared_memory_runtime_unit_bytes;
+                auto memory_group =
+                    milvus::storage::LoadMemoryOverheadController::GetInstance()
+                        .GetOrCreate(
+                            milvus::ThreadPools::GetLoadExecutorWorkers());
+                meta_.loading_overhead_config =
+                    milvus::cachinglayer::LoadingOverheadConfig{
+                        milvus::cachinglayer::LoadingOverheadGroupBinding{
+                            std::move(memory_group), max_runtime_unit},
+                        // FIXME: Bind scalar V3 file overhead to the
+                        // executor-backed file group after every file-backed
+                        // load path writes through positioned tasks on the
+                        // HIGH/LOW load executors. Some paths still use
+                        // FileWriter or its independent worker pool, so binding
+                        // them now would under-reserve concurrent disk overhead.
+                        std::nullopt};
+            }
         }
     }
-}
-
-LoadResourceRequest
-SealedIndexTranslator::EstimateLoadResource(
-    std::optional<milvus::storage::EntryStreamLoadInfo>* stream_load_info,
-    bool* use_shared_memory_overhead_group) const {
-    auto estimated =
-        milvus::index::IndexFactory::GetInstance().IndexLoadResource(
-            index_load_info_.field_type,
-            index_load_info_.element_type,
-            index_load_info_.index_engine_version,
-            index_load_info_.index_size,
-            index_load_info_.index_params,
-            index_load_info_.enable_mmap,
-            index_load_info_.num_rows,
-            index_load_info_.dim,
-            index_load_info_.index_files,
-            file_manager_context_,
-            stream_load_info,
-            use_shared_memory_overhead_group);
     if (index_load_info_.load_resource_request.has_value()) {
-        return *index_load_info_.load_resource_request;
+        load_resource_request_ = *index_load_info_.load_resource_request;
     }
-    return estimated;
 }
 
 size_t

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.h
@@ -60,11 +60,6 @@ class SealedIndexTranslator
     }
 
  private:
-    LoadResourceRequest
-    EstimateLoadResource(
-        std::optional<milvus::storage::EntryStreamLoadInfo>* stream_load_info,
-        bool* use_shared_memory_overhead_group) const;
-
     struct IndexLoadInfo {
         bool enable_mmap;
         std::string mmap_dir_path;

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -3646,15 +3646,18 @@ TEST(SealedVectorArrayFallback,
 
     auto index_params = GenIndexParams(emb_list_hnsw_sq_index.get());
     index_params["metric_type"] = metric_type;
-    auto request = milvus::index::IndexFactory::GetInstance().IndexLoadResource(
-        DataType::VECTOR_ARRAY,
-        element_type,
-        create_index_info.index_engine_version,
-        0,
-        index_params,
-        false,
-        dataset_size * emb_list_len,
-        dim);
+    auto request =
+        milvus::index::IndexFactory::GetInstance().EstimateIndexLoadResource(
+            milvus::index::IndexLoadSpec{
+                .field_type = DataType::VECTOR_ARRAY,
+                .element_type = element_type,
+                .index_version = create_index_info.index_engine_version,
+                .index_size_in_bytes = 0,
+                .index_params = index_params,
+                .mmap_enable = false,
+                .num_rows = dataset_size * emb_list_len,
+                .dim = dim,
+            });
     ASSERT_FALSE(request.has_raw_data);
 
     LoadIndexInfo load_info;


### PR DESCRIPTION
issue: #48957

- Separate metadata-only index load estimates from scalar file inspection and resource planning.
- Reuse cached estimates only for vector and legacy scalar paths that do not require file context.
- Preserve packed scalar V3 and hybrid file inspection, including shared stream runtime-unit planning, and update callers and tests.
