### PR TITLE
enhance: bump schema version for property schema WAL updates

### DIFF
--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
@@ -123,20 +123,24 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 				header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionConsistencyLevel)
 			}
 		case common.CollectionExternalSource:
-			if udpates.Schema == nil {
-				udpates.Schema = &schemapb.CollectionSchema{}
-			}
-			udpates.Schema.ExternalSource = prop.GetValue()
-			if !funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec) {
-				header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
+			if prop.GetValue() != coll.ExternalSource {
+				if udpates.Schema == nil {
+					udpates.Schema = &schemapb.CollectionSchema{}
+				}
+				udpates.Schema.ExternalSource = prop.GetValue()
+				if !funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec) {
+					header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
+				}
 			}
 		case common.CollectionExternalSpec:
-			if udpates.Schema == nil {
-				udpates.Schema = &schemapb.CollectionSchema{}
-			}
-			udpates.Schema.ExternalSpec = prop.GetValue()
-			if !funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec) {
-				header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
+			if prop.GetValue() != coll.ExternalSpec {
+				if udpates.Schema == nil {
+					udpates.Schema = &schemapb.CollectionSchema{}
+				}
+				udpates.Schema.ExternalSpec = prop.GetValue()
+				if !funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec) {
+					header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
+				}
 			}
 		default:
 			newProperties[prop.GetKey()] = prop.GetValue()
@@ -153,12 +157,15 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 		header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionProperties)
 	}
 
-	// If TTL field is changed through properties, also broadcast an updated schema snapshot and mark it as schema change,
-	// so QueryNode can refresh runtime schema properties without requiring release/load.
+	// If a property alter changes schema payload, broadcast a full schema
+	// snapshot and mark it as schema change so WAL consumers advance by
+	// schema.Version instead of relying on the broadcast timestamp.
 	ttlOld, okOld := oldProperties[common.CollectionTTLFieldKey]
 	ttlNew, okNew := newProperties[common.CollectionTTLFieldKey]
 	needTTLFieldSchemaRefresh := (okOld != okNew) || (okOld && okNew && ttlOld != ttlNew)
-	if needTTLFieldSchemaRefresh {
+	needExternalSpecSchemaRefresh := funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
+	if needTTLFieldSchemaRefresh || needExternalSpecSchemaRefresh {
+		schemaUpdate := udpates.Schema
 		// validate ttl field name exists in schema fields when setting it
 		if okNew {
 			found := false
@@ -178,16 +185,18 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 			header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionSchema)
 		}
 
-		// Build schema snapshot with updated properties (schema version should NOT be changed for properties-only alter).
+		// Build schema snapshot with updated properties. Any schema payload
+		// change must advance schema.Version so WAL consumers can gate on it.
 		schema := coll.ToCollectionSchemaPB()
+		schema.Version = coll.SchemaVersion + 1
 		schema.Properties = newPropsKeyValuePairs
 		// Preserve ExternalSource/ExternalSpec from current collection state
 		// unless this alter is itself updating them (refresh-completion sync).
-		if udpates.Schema != nil && udpates.Schema.ExternalSource != "" {
-			schema.ExternalSource = udpates.Schema.ExternalSource
+		if schemaUpdate != nil && schemaUpdate.ExternalSource != "" {
+			schema.ExternalSource = schemaUpdate.ExternalSource
 		}
-		if udpates.Schema != nil && udpates.Schema.ExternalSpec != "" {
-			schema.ExternalSpec = udpates.Schema.ExternalSpec
+		if schemaUpdate != nil && schemaUpdate.ExternalSpec != "" {
+			schema.ExternalSpec = schemaUpdate.ExternalSpec
 		}
 		udpates.Schema = schema
 	}
@@ -199,6 +208,10 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 
 	// fill the put load config if rg or replica number is changed.
 	udpates.AlterLoadConfig = c.getAlterLoadConfigOfAlterCollection(coll.Properties, udpates.Properties)
+
+	if err := validateAlterCollectionSchemaPayloadVersion(coll.SchemaVersion, header, udpates); err != nil {
+		return err
+	}
 
 	channels := make([]string, 0, len(coll.VirtualChannelNames)+1)
 	channels = append(channels, streaming.WAL().ControlChannel())
@@ -212,6 +225,23 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
 		return err
+	}
+	return nil
+}
+
+func validateAlterCollectionSchemaPayloadVersion(currentVersion int32, header *messagespb.AlterCollectionMessageHeader, updates *messagespb.AlterCollectionMessageUpdates) error {
+	if header == nil || header.GetUpdateMask() == nil || !funcutil.SliceContain(header.GetUpdateMask().GetPaths(), message.FieldMaskCollectionSchema) {
+		return nil
+	}
+	if updates == nil || updates.GetSchema() == nil {
+		return merr.WrapErrServiceInternalMsg("alter collection schema update mask requires schema payload")
+	}
+	if updates.GetSchema().GetVersion() <= currentVersion {
+		return merr.WrapErrServiceInternalMsg(
+			"alter collection schema payload must advance schema version, current=%d, payload=%d",
+			currentVersion,
+			updates.GetSchema().GetVersion(),
+		)
 	}
 	return nil
 }

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -345,6 +346,23 @@ func TestDDLCallbacksAlterCollectionV2AckCallback_UpdateLoadConfigRPCError(t *te
 		Results: map[string]*message.AppendResult{},
 	})
 	require.Error(t, err)
+}
+
+func TestValidateAlterCollectionSchemaPayloadVersion(t *testing.T) {
+	header := &messagespb.AlterCollectionMessageHeader{
+		UpdateMask: &fieldmaskpb.FieldMask{
+			Paths: []string{message.FieldMaskCollectionSchema},
+		},
+	}
+
+	require.NoError(t, validateAlterCollectionSchemaPayloadVersion(10, &messagespb.AlterCollectionMessageHeader{}, nil))
+	require.Error(t, validateAlterCollectionSchemaPayloadVersion(10, header, nil))
+	require.Error(t, validateAlterCollectionSchemaPayloadVersion(10, header, &messagespb.AlterCollectionMessageUpdates{
+		Schema: &schemapb.CollectionSchema{Version: 10},
+	}))
+	require.NoError(t, validateAlterCollectionSchemaPayloadVersion(10, header, &messagespb.AlterCollectionMessageUpdates{
+		Schema: &schemapb.CollectionSchema{Version: 11},
+	}))
 }
 
 func TestDDLCallbacksAlterCollectionV2AckCallback_UpdateLoadConfigNonRGNotFoundError(t *testing.T) {
@@ -685,14 +703,14 @@ func TestDDLCallbacksAlterCollectionProperties_TTLFieldShouldBroadcastSchema(t *
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertSchemaVersion(t, ctx, core, dbName, collectionName, 0)
 
-	// Alter properties to set ttl field should succeed and should NOT change schema version in meta.
+	// Alter properties to set ttl field should bump schema version because it broadcasts a schema payload.
 	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
 		DbName:         dbName,
 		CollectionName: collectionName,
 		Properties:     []*commonpb.KeyValuePair{{Key: common.CollectionTTLFieldKey, Value: "ttl"}},
 	})
 	require.NoError(t, merr.CheckRPCCall(resp, err))
-	assertSchemaVersion(t, ctx, core, dbName, collectionName, 0)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 1)
 }
 
 func TestDDLCallbacksAlterCollectionProperties_TTLFieldPreservesExternalSpec(t *testing.T) {
@@ -738,6 +756,7 @@ func TestDDLCallbacksAlterCollectionProperties_TTLFieldPreservesExternalSpec(t *
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/ttl-path")
 	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1","cloud_provider":"aws"}}`)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 0)
 
 	// Alter TTL field only — must preserve previously persisted external source/spec.
 	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
@@ -750,6 +769,7 @@ func TestDDLCallbacksAlterCollectionProperties_TTLFieldPreservesExternalSpec(t *
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/ttl-path")
 	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1","cloud_provider":"aws"}}`)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 1)
 
 	// TTL with invalid field name still rejected.
 	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
@@ -818,6 +838,7 @@ func TestDDLCallbacksAlterCollectionProperties_AcceptExternalSourceSpec(t *testi
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/new/")
 	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1","cloud_provider":"aws"}}`)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 1)
 }
 
 // Regression for #49335: refresh override path may carry source-only updates
@@ -861,6 +882,7 @@ func TestDDLCallbacksAlterCollectionProperties_PartialExternalUpdatePreservesOth
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/new/")
 	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1","cloud_provider":"aws"}}`)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 1)
 }
 
 // Regression for #49335: alter that mixes external_source with a regular
@@ -905,6 +927,7 @@ func TestDDLCallbacksAlterCollectionProperties_MixedExternalAndRegular(t *testin
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/new/")
 	assertReplicaNumber(t, ctx, core, dbName, collectionName, 2)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 1)
 }
 
 func createCollectionForTest(t *testing.T, ctx context.Context, core *Core, dbName string, collectionName string) {


### PR DESCRIPTION
Ensure alter collection property changes that carry schema payloads advance schema.Version before writing the AlterCollection message to WAL. Cover TTL field and external source/spec updates, and guard against schema update masks without a newer schema payload.

Related to #51796