### PR TITLE
enhance: [3.0] enable TiKV 1PC by default (#51915)

### DIFF
--- a/pkg/util/tikv/tikv_util_test.go
+++ b/pkg/util/tikv/tikv_util_test.go
@@ -17,24 +17,23 @@
 package tikv
 
 import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 	"github.com/tikv/client-go/v2/config"
-	"github.com/tikv/client-go/v2/txnkv"
 
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
-func GetTiKVClient(cfg *paramtable.TiKVConfig) (*txnkv.Client, error) {
-	config.UpdateGlobal(func(conf *config.Config) {
-		applyTiKVClientConfig(cfg, conf)
-	})
+func TestApplyTiKVClientConfigEnable1PC(t *testing.T) {
+	cfg := &paramtable.TiKVConfig{}
+	cfg.Init(paramtable.NewBaseTable())
 
-	return txnkv.NewClient([]string{cfg.Endpoints.GetValue()})
-}
+	conf := config.DefaultConfig()
+	conf.EnableAsyncCommit = true
 
-func applyTiKVClientConfig(cfg *paramtable.TiKVConfig, conf *config.Config) {
-	if cfg.TiKVUseSSL.GetAsBool() {
-		conf.Security = config.NewSecurity(cfg.TiKVTLSCACert.GetValue(), cfg.TiKVTLSCert.GetValue(), cfg.TiKVTLSKey.GetValue(), []string{})
-	}
-	conf.Enable1PC = true
-	conf.EnableAsyncCommit = false
+	applyTiKVClientConfig(cfg, &conf)
+
+	assert.True(t, conf.Enable1PC)
+	assert.False(t, conf.EnableAsyncCommit)
 }


### PR DESCRIPTION
Cherry-pick from master
pr: https://github.com/milvus-io/milvus/pull/51915
Related to https://github.com/milvus-io/milvus/issues/51914

Local verification:
- pkg/util/tikv typecheck: passed
- pkg/util/tikv unit test: passed
- make test-metastore: passed
- make fmt: passed
- make static-check: local C++ artifact mismatch in internal/util/initcore, unrelated to this TiKV cherry-pick; per CP workflow, no C++ rebuild was run.