### PR TITLE
enhance: merge ARRAY contains predicates

### DIFF
--- a/internal/parser/planparserv2/rewriter/README.md
+++ b/internal/parser/planparserv2/rewriter/README.md
@@ -15,7 +15,7 @@ The rewriter can be configured via the following parameter (refreshable at runti
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `common.enabledOptimizeExpr` | `true` | Enable query expression optimization including range simplification, IN/NOT IN merge, TEXT_MATCH merge, and all other optimizations |
+| `common.enabledOptimizeExpr` | `true` | Enable query expression optimization including ARRAY contains merge, range simplification, IN/NOT IN merge, TEXT_MATCH merge, and all other optimizations |
 
 **IMPORTANT**: IN/NOT IN value list sorting and deduplication **always** runs regardless of this configuration setting, because the execution engine depends on sorted value lists.
 
@@ -44,7 +44,19 @@ The rewriter can be configured via the following parameter (refreshable at runti
   - Example: `TEXT_MATCH(f, "A C") OR TEXT_MATCH(f, "B D")` → `TEXT_MATCH(f, "A C B D")`
 - If any `TEXT_MATCH` in the group has options (e.g., `minimum_should_match`), this optimization is skipped for that group.
 
-3) Range predicate simplification (`range.go`)
+3) ARRAY contains merge (`array_contains.go`)
+- OR on the same physical ARRAY column:
+  - `array_contains(a, x) OR array_contains(a, y)` → `array_contains_any(a, [x, y])`
+  - Existing `array_contains_any` nodes are absorbed, so arbitrarily long and nested OR chains close into one node.
+- AND on the same physical ARRAY column:
+  - `array_contains(a, x) AND array_contains(a, y)` → `array_contains_all(a, [x, y])`
+  - Existing `array_contains_all` nodes are absorbed, so arbitrarily long and nested AND chains close into one node.
+- At least two compatible source nodes are required. Values retain encounter order without sorting or deduplication, and the merged node is emitted at the group's first position.
+- The rule is keyed by `ColumnInfo`, including nested path and element-level identity. Different fields and the opposite Any/All operator remain separate.
+- Only `ColumnInfo.DataType == Array` participates. JSON columns remain unchanged even though ARRAY and JSON predicates share `JSONContainsExpr` and either function spelling may be used on an ARRAY column.
+- Nil, array-valued, unknown, and NaN elements are excluded from merging. `ElementsSameType` is recomputed and consumed template metadata is cleared on the merged node.
+
+4) Range predicate simplification (`range.go`)
 - AND tighten (same column):
   - Lower bounds: `a > 10 AND a > 20` → `a > 20` (pick strongest lower)
   - Upper bounds: `a < 50 AND a < 60` → `a < 50` (pick strongest upper)
@@ -90,6 +102,7 @@ The rewriter can be configured via the following parameter (refreshable at runti
 ### General Notes
 - All merges require operands to target the same column (same `ColumnInfo`, including nested path/element type).
 - Rewrite runs after template value filling; template placeholders do not appear here.
+- Optional visitor rewrites do not descend into `MatchExpr` or `ElementFilterExpr` predicates.
 - Sorting/dedup for IN/NOT IN is deterministic; duplicates are removed post-sort.
 - Numeric-threshold for OR→IN / AND≠→NOT IN is defined in `util.go` (`defaultConvertOrToInNumericLimit`, default 150).
 - Nullable fields keep contradiction/tautology predicates instead of folding to valid `true`/`false`, because NULL must remain unknown under outer logical operators such as `NOT`. Fixed JSON/array paths also avoid domain-wide folds that assume every path/index exists.
@@ -97,30 +110,33 @@ The rewriter can be configured via the following parameter (refreshable at runti
 ### Pass Ordering (current)
 - OR branch:
   1. Flatten
-  2. OR `==` → IN
-  3. TEXT_MATCH merge (no options)
-  4. Range weaken (same-direction bounds)
-  5. BinaryRangeExpr merge (overlapping/adjacent intervals)
-  6. IN with `!=` short-circuiting
-  7. IN ∪ IN union
-  8. IN vs Equal redundancy elimination
-  9. Fold back to BinaryExpr
+  2. ARRAY `Contains` / `ContainsAny` → `ContainsAny`
+  3. OR `==` → IN
+  4. TEXT_MATCH merge (no options)
+  5. Range weaken (same-direction bounds)
+  6. BinaryRangeExpr merge (overlapping/adjacent intervals)
+  7. IN with `!=` short-circuiting
+  8. IN ∪ IN union
+  9. IN vs Equal redundancy elimination
+  10. Fold back to BinaryExpr
 - AND branch:
   1. Flatten
-  2. Range tighten / interval construction
-  3. BinaryRangeExpr merge (intersection, also with UnaryRangeExpr)
-  4. IN ∪ IN intersection (if any)
-  5. IN with `!=` filtering
-  6. IN ∩ range filtering
-  7. IN vs Equal redundancy elimination
-  8. AND `!=` → NOT IN
-  9. Fold back to BinaryExpr
+  2. ARRAY `Contains` / `ContainsAll` → `ContainsAll`
+  3. Range tighten / interval construction
+  4. BinaryRangeExpr merge (intersection, also with UnaryRangeExpr)
+  5. IN ∪ IN intersection (if any)
+  6. IN with `!=` filtering
+  7. IN ∩ range filtering
+  8. IN vs Equal redundancy elimination
+  9. AND `!=` → NOT IN
+  10. Fold back to BinaryExpr
 
 Each construction of IN will be normalized (sorted and deduplicated). TEXT_MATCH OR merge concatenates literals with a single space; no tokenization, deduplication, or sorting is performed.
 
 ### File Structure
 - `entry.go`      — rewrite entry and visitor orchestration
 - `util.go`       — shared helpers (column keying, value classification, sorting/dedup, constructors)
+- `array_contains.go` — physical ARRAY contains Any/All merges
 - `term_in.go`    — IN/NOT IN normalization and conversions
 - `text_match.go` — TEXT_MATCH OR merge (no options)
 - `range.go`      — range tightening/weakening and interval construction

--- a/internal/parser/planparserv2/rewriter/README.md
+++ b/internal/parser/planparserv2/rewriter/README.md
@@ -51,7 +51,7 @@ The rewriter can be configured via the following parameter (refreshable at runti
 - AND on the same physical ARRAY column:
   - `array_contains(a, x) AND array_contains(a, y)` → `array_contains_all(a, [x, y])`
   - Existing `array_contains_all` nodes are absorbed, so arbitrarily long and nested AND chains close into one node.
-- At least two compatible source nodes are required. Values retain encounter order without sorting or deduplication, and the merged node is emitted at the group's first position.
+- At least two compatible source nodes are required. Values retain first-encounter order, duplicates are removed without sorting, and the merged node is emitted at the group's first position.
 - The rule is keyed by `ColumnInfo`, including nested path and element-level identity. Different fields and the opposite Any/All operator remain separate.
 - Only `ColumnInfo.DataType == Array` participates. JSON columns remain unchanged even though ARRAY and JSON predicates share `JSONContainsExpr` and either function spelling may be used on an ARRAY column.
 - Nil, array-valued, unknown, and NaN elements are excluded from merging. `ElementsSameType` is recomputed and consumed template metadata is cleared on the merged node.

--- a/internal/parser/planparserv2/rewriter/array_contains.go
+++ b/internal/parser/planparserv2/rewriter/array_contains.go
@@ -10,8 +10,17 @@ import (
 type arrayContainsGroup struct {
 	columnInfo  *planpb.ColumnInfo
 	elements    []*planpb.GenericValue
+	seen        map[arrayContainsElementKey]struct{}
 	firstIndex  int
 	sourceCount int
+}
+
+type arrayContainsElementKey struct {
+	dataType  schemapb.DataType
+	boolVal   bool
+	int64Val  int64
+	floatVal  float64
+	stringVal string
 }
 
 // combineArrayContains merges compatible ARRAY contains predicates on the same
@@ -35,11 +44,22 @@ func combineArrayContains(parts []*planpb.Expr, targetOp planpb.JSONContainsExpr
 		if group == nil {
 			group = &arrayContainsGroup{
 				columnInfo: contains.GetColumnInfo(),
+				seen:       make(map[arrayContainsElementKey]struct{}),
 				firstIndex: index,
 			}
 			groups[key] = group
 		}
-		group.elements = append(group.elements, contains.GetElements()...)
+		for _, element := range contains.GetElements() {
+			elementKey, ok := arrayContainsDedupKey(group.columnInfo, element)
+			if !ok {
+				continue
+			}
+			if _, exists := group.seen[elementKey]; exists {
+				continue
+			}
+			group.seen[elementKey] = struct{}{}
+			group.elements = append(group.elements, element)
+		}
 		group.sourceCount++
 		memberships[index] = group
 	}
@@ -106,6 +126,44 @@ func arrayContainsElementsSameType(elements []*planpb.GenericValue) bool {
 		}
 	}
 	return true
+}
+
+// arrayContainsDedupKey builds a stable-comparable key. FLOAT and DOUBLE
+// targets are canonicalized using the executor's numeric conversions, while
+// the first encountered GenericValue is retained in the merged plan.
+func arrayContainsDedupKey(column *planpb.ColumnInfo, value *planpb.GenericValue) (arrayContainsElementKey, bool) {
+	valueType, ok := arrayContainsValueType(value)
+	if !ok {
+		return arrayContainsElementKey{}, false
+	}
+
+	key := arrayContainsElementKey{dataType: valueType}
+	switch valueType {
+	case schemapb.DataType_Bool:
+		key.boolVal = value.GetBoolVal()
+	case schemapb.DataType_Int64:
+		switch column.GetElementType() {
+		case schemapb.DataType_Float:
+			key.dataType = schemapb.DataType_Double
+			key.floatVal = float64(float32(value.GetInt64Val()))
+		case schemapb.DataType_Double:
+			key.dataType = schemapb.DataType_Double
+			key.floatVal = float64(value.GetInt64Val())
+		default:
+			key.int64Val = value.GetInt64Val()
+		}
+	case schemapb.DataType_Double:
+		if column.GetElementType() == schemapb.DataType_Float {
+			key.floatVal = float64(float32(value.GetFloatVal()))
+		} else {
+			key.floatVal = value.GetFloatVal()
+		}
+	case schemapb.DataType_VarChar:
+		key.stringVal = value.GetStringVal()
+	default:
+		return arrayContainsElementKey{}, false
+	}
+	return key, true
 }
 
 func arrayContainsValueType(value *planpb.GenericValue) (schemapb.DataType, bool) {

--- a/internal/parser/planparserv2/rewriter/array_contains.go
+++ b/internal/parser/planparserv2/rewriter/array_contains.go
@@ -1,0 +1,128 @@
+package rewriter
+
+import (
+	"math"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+)
+
+type arrayContainsGroup struct {
+	columnInfo  *planpb.ColumnInfo
+	elements    []*planpb.GenericValue
+	firstIndex  int
+	sourceCount int
+}
+
+// combineArrayContains merges compatible ARRAY contains predicates on the same
+// column. OR chains target ContainsAny, while AND chains target ContainsAll.
+// JSON columns deliberately remain unchanged.
+func combineArrayContains(parts []*planpb.Expr, targetOp planpb.JSONContainsExpr_JSONOp) []*planpb.Expr {
+	if len(parts) < 2 || (targetOp != planpb.JSONContainsExpr_ContainsAny && targetOp != planpb.JSONContainsExpr_ContainsAll) {
+		return parts
+	}
+
+	groups := make(map[string]*arrayContainsGroup)
+	memberships := make([]*arrayContainsGroup, len(parts))
+	for index, part := range parts {
+		contains := part.GetJsonContainsExpr()
+		if !canCombineArrayContains(contains, targetOp) {
+			continue
+		}
+
+		key := columnKey(contains.GetColumnInfo())
+		group := groups[key]
+		if group == nil {
+			group = &arrayContainsGroup{
+				columnInfo: contains.GetColumnInfo(),
+				firstIndex: index,
+			}
+			groups[key] = group
+		}
+		group.elements = append(group.elements, contains.GetElements()...)
+		group.sourceCount++
+		memberships[index] = group
+	}
+
+	out := make([]*planpb.Expr, 0, len(parts))
+	for index, part := range parts {
+		group := memberships[index]
+		if group == nil || group.sourceCount < 2 {
+			out = append(out, part)
+			continue
+		}
+		if index != group.firstIndex {
+			continue
+		}
+
+		out = append(out, &planpb.Expr{
+			Expr: &planpb.Expr_JsonContainsExpr{
+				JsonContainsExpr: &planpb.JSONContainsExpr{
+					ColumnInfo:       group.columnInfo,
+					Elements:         group.elements,
+					Op:               targetOp,
+					ElementsSameType: arrayContainsElementsSameType(group.elements),
+				},
+			},
+		})
+	}
+	return out
+}
+
+func canCombineArrayContains(expr *planpb.JSONContainsExpr, targetOp planpb.JSONContainsExpr_JSONOp) bool {
+	if expr == nil || expr.GetColumnInfo() == nil || expr.GetColumnInfo().GetDataType() != schemapb.DataType_Array {
+		return false
+	}
+
+	sourceOp := expr.GetOp()
+	if sourceOp != planpb.JSONContainsExpr_Contains && sourceOp != targetOp {
+		return false
+	}
+	if sourceOp == planpb.JSONContainsExpr_Contains && len(expr.GetElements()) != 1 {
+		return false
+	}
+
+	for _, element := range expr.GetElements() {
+		if _, ok := arrayContainsValueType(element); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func arrayContainsElementsSameType(elements []*planpb.GenericValue) bool {
+	if len(elements) == 0 {
+		return true
+	}
+
+	elementType, ok := arrayContainsValueType(elements[0])
+	if !ok {
+		return false
+	}
+	for _, element := range elements[1:] {
+		currentType, ok := arrayContainsValueType(element)
+		if !ok || currentType != elementType {
+			return false
+		}
+	}
+	return true
+}
+
+func arrayContainsValueType(value *planpb.GenericValue) (schemapb.DataType, bool) {
+	if value == nil {
+		return schemapb.DataType_None, false
+	}
+
+	switch typedValue := value.GetVal().(type) {
+	case *planpb.GenericValue_BoolVal:
+		return schemapb.DataType_Bool, typedValue != nil
+	case *planpb.GenericValue_Int64Val:
+		return schemapb.DataType_Int64, typedValue != nil
+	case *planpb.GenericValue_FloatVal:
+		return schemapb.DataType_Double, typedValue != nil && !math.IsNaN(typedValue.FloatVal)
+	case *planpb.GenericValue_StringVal:
+		return schemapb.DataType_VarChar, typedValue != nil
+	default:
+		return schemapb.DataType_None, false
+	}
+}

--- a/internal/parser/planparserv2/rewriter/array_contains_integration_test.go
+++ b/internal/parser/planparserv2/rewriter/array_contains_integration_test.go
@@ -47,6 +47,13 @@ func TestRewriteArrayContainsChains(t *testing.T) {
 			values:   []int64{4, 1, 3, 2},
 		},
 		{
+			name: "or deduplicates preserving first order",
+			expr: `array_contains(ArrayInt, 2) or ` +
+				`array_contains_any(ArrayInt, [2, 1, 1]) or array_contains(ArrayInt, 1)`,
+			expected: planpb.JSONContainsExpr_ContainsAny,
+			values:   []int64{2, 1},
+		},
+		{
 			name:     "and two contains",
 			expr:     `array_contains(ArrayInt, 1) and array_contains(ArrayInt, 2)`,
 			expected: planpb.JSONContainsExpr_ContainsAll,

--- a/internal/parser/planparserv2/rewriter/array_contains_integration_test.go
+++ b/internal/parser/planparserv2/rewriter/array_contains_integration_test.go
@@ -40,6 +40,13 @@ func TestRewriteArrayContainsChains(t *testing.T) {
 			values:   []int64{3, 1, 2, 4},
 		},
 		{
+			name: "or combines contains any",
+			expr: `array_contains_any(ArrayInt, [4, 1]) or ` +
+				`array_contains_any(ArrayInt, [3, 2])`,
+			expected: planpb.JSONContainsExpr_ContainsAny,
+			values:   []int64{4, 1, 3, 2},
+		},
+		{
 			name:     "and two contains",
 			expr:     `array_contains(ArrayInt, 1) and array_contains(ArrayInt, 2)`,
 			expected: planpb.JSONContainsExpr_ContainsAll,
@@ -58,6 +65,13 @@ func TestRewriteArrayContainsChains(t *testing.T) {
 				`(array_contains_all(ArrayInt, [1, 2]) and array_contains(ArrayInt, 4))`,
 			expected: planpb.JSONContainsExpr_ContainsAll,
 			values:   []int64{3, 1, 2, 4},
+		},
+		{
+			name: "and combines contains all",
+			expr: `array_contains_all(ArrayInt, [4, 1]) and ` +
+				`array_contains_all(ArrayInt, [3, 2])`,
+			expected: planpb.JSONContainsExpr_ContainsAll,
+			values:   []int64{4, 1, 3, 2},
 		},
 		{
 			name:     "json function name on physical array",

--- a/internal/parser/planparserv2/rewriter/array_contains_integration_test.go
+++ b/internal/parser/planparserv2/rewriter/array_contains_integration_test.go
@@ -1,0 +1,250 @@
+package rewriter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	parser "github.com/milvus-io/milvus/internal/parser/planparserv2"
+	"github.com/milvus-io/milvus/internal/parser/planparserv2/rewriter"
+	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+)
+
+func TestRewriteArrayContainsChains(t *testing.T) {
+	helper := buildSchemaHelperWithArraysT(t)
+	testcases := []struct {
+		name     string
+		expr     string
+		expected planpb.JSONContainsExpr_JSONOp
+		values   []int64
+	}{
+		{
+			name:     "or two contains",
+			expr:     `array_contains(ArrayInt, 1) or array_contains(ArrayInt, 2)`,
+			expected: planpb.JSONContainsExpr_ContainsAny,
+			values:   []int64{1, 2},
+		},
+		{
+			name: "or balanced tree",
+			expr: `(array_contains(ArrayInt, 4) or array_contains(ArrayInt, 1)) or ` +
+				`(array_contains(ArrayInt, 3) or array_contains(ArrayInt, 2))`,
+			expected: planpb.JSONContainsExpr_ContainsAny,
+			values:   []int64{4, 1, 3, 2},
+		},
+		{
+			name: "or absorbs contains any",
+			expr: `array_contains(ArrayInt, 3) or ` +
+				`(array_contains_any(ArrayInt, [1, 2]) or array_contains(ArrayInt, 4))`,
+			expected: planpb.JSONContainsExpr_ContainsAny,
+			values:   []int64{3, 1, 2, 4},
+		},
+		{
+			name:     "and two contains",
+			expr:     `array_contains(ArrayInt, 1) and array_contains(ArrayInt, 2)`,
+			expected: planpb.JSONContainsExpr_ContainsAll,
+			values:   []int64{1, 2},
+		},
+		{
+			name: "and balanced tree",
+			expr: `(array_contains(ArrayInt, 4) and array_contains(ArrayInt, 1)) and ` +
+				`(array_contains(ArrayInt, 3) and array_contains(ArrayInt, 2))`,
+			expected: planpb.JSONContainsExpr_ContainsAll,
+			values:   []int64{4, 1, 3, 2},
+		},
+		{
+			name: "and absorbs contains all",
+			expr: `array_contains(ArrayInt, 3) and ` +
+				`(array_contains_all(ArrayInt, [1, 2]) and array_contains(ArrayInt, 4))`,
+			expected: planpb.JSONContainsExpr_ContainsAll,
+			values:   []int64{3, 1, 2, 4},
+		},
+		{
+			name:     "json function name on physical array",
+			expr:     `json_contains(ArrayInt, 5) or array_contains(ArrayInt, 6)`,
+			expected: planpb.JSONContainsExpr_ContainsAny,
+			values:   []int64{5, 6},
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			expr, err := parser.ParseExpr(helper, testcase.expr, nil)
+			require.NoError(t, err)
+			contains := expr.GetJsonContainsExpr()
+			require.NotNil(t, contains)
+			require.Equal(t, schemapb.DataType_Array, contains.GetColumnInfo().GetDataType())
+			require.Equal(t, testcase.expected, contains.GetOp())
+			require.Equal(t, testcase.values, arrayContainsIntegrationIntValues(contains.GetElements()))
+			require.True(t, contains.GetElementsSameType())
+		})
+	}
+}
+
+func TestRewriteArrayContainsKeepsColumnsAndOtherPredicatesSeparate(t *testing.T) {
+	helper := buildSchemaHelperWithArraysT(t)
+	expr, err := parser.ParseExpr(helper,
+		`ArrayInt[0] > 10 or array_contains(ArrayInt, 3) or `+
+			`array_contains(ArrayFloat, 1.5) or array_contains(ArrayInt, 1) or `+
+			`array_contains(ArrayFloat, 2.5)`, nil)
+	require.NoError(t, err)
+
+	containsByField := make(map[int64]*planpb.JSONContainsExpr)
+	var containsCount int
+	var rangeCount int
+	walkExpr(expr, func(current *planpb.Expr) {
+		if contains := current.GetJsonContainsExpr(); contains != nil {
+			containsCount++
+			containsByField[contains.GetColumnInfo().GetFieldId()] = contains
+		}
+		if current.GetUnaryRangeExpr() != nil {
+			rangeCount++
+		}
+	})
+
+	require.Len(t, containsByField, 2)
+	require.Equal(t, 2, containsCount)
+	require.Equal(t, 1, rangeCount)
+	require.Equal(t, planpb.JSONContainsExpr_ContainsAny, containsByField[201].GetOp())
+	require.Equal(t, []int64{3, 1}, arrayContainsIntegrationIntValues(containsByField[201].GetElements()))
+	require.Equal(t, planpb.JSONContainsExpr_ContainsAny, containsByField[202].GetOp())
+	require.Equal(t, []float64{1.5, 2.5}, arrayContainsIntegrationFloatValues(containsByField[202].GetElements()))
+}
+
+func TestRewriteArrayContainsColumnVariants(t *testing.T) {
+	t.Run("nullable array", func(t *testing.T) {
+		helper := buildSchemaHelperWithArraysT(t)
+		expr, err := parser.ParseExpr(helper,
+			`array_contains(NullableArrayInt, 1) and array_contains_all(NullableArrayInt, [2, 3])`, nil)
+		require.NoError(t, err)
+
+		contains := expr.GetJsonContainsExpr()
+		require.NotNil(t, contains)
+		require.Equal(t, planpb.JSONContainsExpr_ContainsAll, contains.GetOp())
+		require.Equal(t, []int64{1, 2, 3}, arrayContainsIntegrationIntValues(contains.GetElements()))
+		require.True(t, contains.GetColumnInfo().GetNullable())
+	})
+
+	t.Run("struct array subfield", func(t *testing.T) {
+		helper := buildSchemaHelperWithStructArrayT(t)
+		expr, err := parser.ParseExpr(helper,
+			`array_contains(struct_array[sub_int], 4) and array_contains(struct_array[sub_int], 5)`, nil)
+		require.NoError(t, err)
+
+		contains := expr.GetJsonContainsExpr()
+		require.NotNil(t, contains)
+		require.Equal(t, planpb.JSONContainsExpr_ContainsAll, contains.GetOp())
+		require.Equal(t, []int64{4, 5}, arrayContainsIntegrationIntValues(contains.GetElements()))
+		require.Equal(t, schemapb.DataType_Array, contains.GetColumnInfo().GetDataType())
+		require.Equal(t, int64(303), contains.GetColumnInfo().GetFieldId())
+	})
+}
+
+func TestRewriteArrayContainsFilledTemplates(t *testing.T) {
+	helper := buildSchemaHelperWithArraysT(t)
+	templateValues := map[string]*schemapb.TemplateValue{
+		"first":  {Val: &schemapb.TemplateValue_Int64Val{Int64Val: 9}},
+		"second": {Val: &schemapb.TemplateValue_Int64Val{Int64Val: 7}},
+	}
+	expr, err := parser.ParseExpr(helper,
+		`array_contains(ArrayInt, {first}) or json_contains(ArrayInt, {second})`, templateValues)
+	require.NoError(t, err)
+
+	contains := expr.GetJsonContainsExpr()
+	require.NotNil(t, contains)
+	require.Equal(t, planpb.JSONContainsExpr_ContainsAny, contains.GetOp())
+	require.Equal(t, []int64{9, 7}, arrayContainsIntegrationIntValues(contains.GetElements()))
+	require.Empty(t, contains.GetTemplateVariableName())
+	require.False(t, expr.GetIsTemplate())
+}
+
+func TestRewriteArrayContainsDoesNotMergeJSONColumns(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+	expr, err := parser.ParseExpr(helper,
+		`json_contains(JSONField["items"], 1) or json_contains(JSONField["items"], 2)`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr.GetBinaryExpr())
+
+	var containsCount int
+	var containsAnyCount int
+	walkExpr(expr, func(current *planpb.Expr) {
+		contains := current.GetJsonContainsExpr()
+		if contains == nil {
+			return
+		}
+		require.Equal(t, schemapb.DataType_JSON, contains.GetColumnInfo().GetDataType())
+		switch contains.GetOp() {
+		case planpb.JSONContainsExpr_Contains:
+			containsCount++
+		case planpb.JSONContainsExpr_ContainsAny:
+			containsAnyCount++
+		}
+	})
+	require.Equal(t, 2, containsCount)
+	require.Zero(t, containsAnyCount)
+}
+
+func TestRewriteArrayContainsDisabledKeepsOriginalTree(t *testing.T) {
+	column := &planpb.ColumnInfo{
+		FieldId:     201,
+		DataType:    schemapb.DataType_Array,
+		ElementType: schemapb.DataType_Int64,
+	}
+	input := &planpb.Expr{
+		Expr: &planpb.Expr_BinaryExpr{
+			BinaryExpr: &planpb.BinaryExpr{
+				Left:  arrayContainsIntegrationExpr(column, 1),
+				Right: arrayContainsIntegrationExpr(column, 2),
+				Op:    planpb.BinaryExpr_LogicalOr,
+			},
+		},
+	}
+
+	result := rewriter.RewriteExprWithConfig(input, false)
+	require.NotNil(t, result.GetBinaryExpr())
+	var containsCount int
+	var containsAnyCount int
+	walkExpr(result, func(current *planpb.Expr) {
+		contains := current.GetJsonContainsExpr()
+		if contains == nil {
+			return
+		}
+		if contains.GetOp() == planpb.JSONContainsExpr_Contains {
+			containsCount++
+		}
+		if contains.GetOp() == planpb.JSONContainsExpr_ContainsAny {
+			containsAnyCount++
+		}
+	})
+	require.Equal(t, 2, containsCount)
+	require.Zero(t, containsAnyCount)
+}
+
+func arrayContainsIntegrationExpr(column *planpb.ColumnInfo, value int64) *planpb.Expr {
+	return &planpb.Expr{
+		Expr: &planpb.Expr_JsonContainsExpr{
+			JsonContainsExpr: &planpb.JSONContainsExpr{
+				ColumnInfo:       column,
+				Elements:         []*planpb.GenericValue{{Val: &planpb.GenericValue_Int64Val{Int64Val: value}}},
+				Op:               planpb.JSONContainsExpr_Contains,
+				ElementsSameType: true,
+			},
+		},
+	}
+}
+
+func arrayContainsIntegrationIntValues(values []*planpb.GenericValue) []int64 {
+	result := make([]int64, 0, len(values))
+	for _, value := range values {
+		result = append(result, value.GetInt64Val())
+	}
+	return result
+}
+
+func arrayContainsIntegrationFloatValues(values []*planpb.GenericValue) []float64 {
+	result := make([]float64, 0, len(values))
+	for _, value := range values {
+		result = append(result, value.GetFloatVal())
+	}
+	return result
+}

--- a/internal/parser/planparserv2/rewriter/array_contains_test.go
+++ b/internal/parser/planparserv2/rewriter/array_contains_test.go
@@ -1,0 +1,280 @@
+package rewriter
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+)
+
+func TestCombineArrayContainsPreservesOrderAndColumnGroups(t *testing.T) {
+	columnA := arrayContainsTestColumn(201, schemapb.DataType_Int64)
+	columnB := arrayContainsTestColumn(202, schemapb.DataType_Int64)
+	before := arrayContainsTestMarker(10)
+	middle := arrayContainsTestMarker(20)
+
+	parts := []*planpb.Expr{
+		before,
+		arrayContainsTestExpr(columnA, planpb.JSONContainsExpr_Contains, arrayContainsTestInt(3)),
+		middle,
+		arrayContainsTestExpr(columnA, planpb.JSONContainsExpr_ContainsAny,
+			arrayContainsTestInt(1), arrayContainsTestInt(2)),
+		arrayContainsTestExpr(columnB, planpb.JSONContainsExpr_Contains, arrayContainsTestInt(7)),
+		arrayContainsTestExpr(columnA, planpb.JSONContainsExpr_Contains, arrayContainsTestInt(4)),
+		arrayContainsTestExpr(columnB, planpb.JSONContainsExpr_Contains, arrayContainsTestInt(8)),
+	}
+
+	result := combineArrayContains(parts, planpb.JSONContainsExpr_ContainsAny)
+	require.Len(t, result, 4)
+	require.Same(t, before, result[0])
+	require.Same(t, middle, result[2])
+
+	mergedA := result[1].GetJsonContainsExpr()
+	require.NotNil(t, mergedA)
+	require.Same(t, columnA, mergedA.GetColumnInfo())
+	require.Equal(t, planpb.JSONContainsExpr_ContainsAny, mergedA.GetOp())
+	require.Equal(t, []int64{3, 1, 2, 4}, arrayContainsTestIntValues(mergedA.GetElements()))
+	require.True(t, mergedA.GetElementsSameType())
+
+	mergedB := result[3].GetJsonContainsExpr()
+	require.NotNil(t, mergedB)
+	require.Same(t, columnB, mergedB.GetColumnInfo())
+	require.Equal(t, []int64{7, 8}, arrayContainsTestIntValues(mergedB.GetElements()))
+}
+
+func TestCombineArrayContainsSelectsCompatibleOperators(t *testing.T) {
+	testcases := []struct {
+		name       string
+		targetOp   planpb.JSONContainsExpr_JSONOp
+		compatible planpb.JSONContainsExpr_JSONOp
+		opposite   planpb.JSONContainsExpr_JSONOp
+	}{
+		{
+			name:       "or absorbs contains any",
+			targetOp:   planpb.JSONContainsExpr_ContainsAny,
+			compatible: planpb.JSONContainsExpr_ContainsAny,
+			opposite:   planpb.JSONContainsExpr_ContainsAll,
+		},
+		{
+			name:       "and absorbs contains all",
+			targetOp:   planpb.JSONContainsExpr_ContainsAll,
+			compatible: planpb.JSONContainsExpr_ContainsAll,
+			opposite:   planpb.JSONContainsExpr_ContainsAny,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			column := arrayContainsTestColumn(201, schemapb.DataType_Int64)
+			opposite := arrayContainsTestExpr(column, testcase.opposite,
+				arrayContainsTestInt(8), arrayContainsTestInt(9))
+			parts := []*planpb.Expr{
+				arrayContainsTestExpr(column, planpb.JSONContainsExpr_Contains, arrayContainsTestInt(1)),
+				opposite,
+				arrayContainsTestExpr(column, testcase.compatible,
+					arrayContainsTestInt(2), arrayContainsTestInt(3)),
+			}
+
+			result := combineArrayContains(parts, testcase.targetOp)
+			require.Len(t, result, 2)
+			merged := result[0].GetJsonContainsExpr()
+			require.NotNil(t, merged)
+			require.Equal(t, testcase.targetOp, merged.GetOp())
+			require.Equal(t, []int64{1, 2, 3}, arrayContainsTestIntValues(merged.GetElements()))
+			require.Same(t, opposite, result[1])
+		})
+	}
+}
+
+func TestCombineArrayContainsSkipsInvalidValues(t *testing.T) {
+	testcases := []struct {
+		name  string
+		build func(*planpb.ColumnInfo) *planpb.Expr
+	}{
+		{
+			name: "contains without element",
+			build: func(column *planpb.ColumnInfo) *planpb.Expr {
+				return arrayContainsTestExpr(column, planpb.JSONContainsExpr_Contains)
+			},
+		},
+		{
+			name: "contains with multiple elements",
+			build: func(column *planpb.ColumnInfo) *planpb.Expr {
+				return arrayContainsTestExpr(column, planpb.JSONContainsExpr_Contains,
+					arrayContainsTestFloat(3), arrayContainsTestFloat(4))
+			},
+		},
+		{
+			name: "nil element",
+			build: func(column *planpb.ColumnInfo) *planpb.Expr {
+				return arrayContainsTestExpr(column, planpb.JSONContainsExpr_Contains, nil)
+			},
+		},
+		{
+			name: "unknown element",
+			build: func(column *planpb.ColumnInfo) *planpb.Expr {
+				return arrayContainsTestExpr(column, planpb.JSONContainsExpr_Contains, &planpb.GenericValue{})
+			},
+		},
+		{
+			name: "bytes element",
+			build: func(column *planpb.ColumnInfo) *planpb.Expr {
+				return arrayContainsTestExpr(column, planpb.JSONContainsExpr_Contains, &planpb.GenericValue{
+					Val: &planpb.GenericValue_BytesVal{BytesVal: []byte("unknown")},
+				})
+			},
+		},
+		{
+			name: "array element",
+			build: func(column *planpb.ColumnInfo) *planpb.Expr {
+				return arrayContainsTestExpr(column, planpb.JSONContainsExpr_Contains, &planpb.GenericValue{
+					Val: &planpb.GenericValue_ArrayVal{ArrayVal: &planpb.Array{}},
+				})
+			},
+		},
+		{
+			name: "nan element",
+			build: func(column *planpb.ColumnInfo) *planpb.Expr {
+				return arrayContainsTestExpr(column, planpb.JSONContainsExpr_Contains,
+					arrayContainsTestFloat(math.NaN()))
+			},
+		},
+		{
+			name: "contains any with an invalid element",
+			build: func(column *planpb.ColumnInfo) *planpb.Expr {
+				return arrayContainsTestExpr(column, planpb.JSONContainsExpr_ContainsAny,
+					arrayContainsTestFloat(3), nil)
+			},
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			column := arrayContainsTestColumn(201, schemapb.DataType_Double)
+			invalid := testcase.build(column)
+			parts := []*planpb.Expr{
+				invalid,
+				arrayContainsTestExpr(column, planpb.JSONContainsExpr_Contains, arrayContainsTestFloat(1)),
+				arrayContainsTestExpr(column, planpb.JSONContainsExpr_Contains, arrayContainsTestFloat(2)),
+			}
+
+			result := combineArrayContains(parts, planpb.JSONContainsExpr_ContainsAny)
+			require.Len(t, result, 2)
+			require.Same(t, invalid, result[0])
+			merged := result[1].GetJsonContainsExpr()
+			require.NotNil(t, merged)
+			require.Equal(t, planpb.JSONContainsExpr_ContainsAny, merged.GetOp())
+			require.Equal(t, []float64{1, 2}, arrayContainsTestFloatValues(merged.GetElements()))
+		})
+	}
+}
+
+func TestCombineArrayContainsRecomputesTypeAndClearsTemplateMetadata(t *testing.T) {
+	column := arrayContainsTestColumn(201, schemapb.DataType_None)
+	first := arrayContainsTestExpr(column, planpb.JSONContainsExpr_Contains, arrayContainsTestInt(1))
+	first.IsTemplate = true
+	first.GetJsonContainsExpr().TemplateVariableName = "first"
+	second := arrayContainsTestExpr(column, planpb.JSONContainsExpr_Contains, arrayContainsTestString("two"))
+	second.IsTemplate = true
+	second.GetJsonContainsExpr().TemplateVariableName = "second"
+
+	result := combineArrayContains([]*planpb.Expr{first, second}, planpb.JSONContainsExpr_ContainsAny)
+	require.Len(t, result, 1)
+	merged := result[0].GetJsonContainsExpr()
+	require.NotNil(t, merged)
+	require.False(t, merged.GetElementsSameType())
+	require.Empty(t, merged.GetTemplateVariableName())
+	require.False(t, result[0].GetIsTemplate())
+
+	require.Equal(t, "first", first.GetJsonContainsExpr().GetTemplateVariableName())
+	require.Equal(t, "second", second.GetJsonContainsExpr().GetTemplateVariableName())
+}
+
+func TestCombineArrayContainsKeepsDuplicateElements(t *testing.T) {
+	column := arrayContainsTestColumn(201, schemapb.DataType_Int64)
+	parts := []*planpb.Expr{
+		arrayContainsTestExpr(column, planpb.JSONContainsExpr_Contains, arrayContainsTestInt(2)),
+		arrayContainsTestExpr(column, planpb.JSONContainsExpr_ContainsAny,
+			arrayContainsTestInt(2), arrayContainsTestInt(1)),
+		arrayContainsTestExpr(column, planpb.JSONContainsExpr_Contains, arrayContainsTestInt(1)),
+	}
+
+	result := combineArrayContains(parts, planpb.JSONContainsExpr_ContainsAny)
+	require.Len(t, result, 1)
+	merged := result[0].GetJsonContainsExpr()
+	require.NotNil(t, merged)
+	require.Equal(t, []int64{2, 2, 1, 1}, arrayContainsTestIntValues(merged.GetElements()))
+}
+
+func TestCombineArrayContainsRequiresAtLeastTwoSources(t *testing.T) {
+	column := arrayContainsTestColumn(201, schemapb.DataType_Int64)
+	single := arrayContainsTestExpr(column, planpb.JSONContainsExpr_Contains, arrayContainsTestInt(1))
+
+	result := combineArrayContains([]*planpb.Expr{single}, planpb.JSONContainsExpr_ContainsAny)
+	require.Len(t, result, 1)
+	require.Same(t, single, result[0])
+}
+
+func arrayContainsTestColumn(fieldID int64, elementType schemapb.DataType) *planpb.ColumnInfo {
+	return &planpb.ColumnInfo{
+		FieldId:     fieldID,
+		DataType:    schemapb.DataType_Array,
+		ElementType: elementType,
+	}
+}
+
+func arrayContainsTestExpr(
+	column *planpb.ColumnInfo,
+	op planpb.JSONContainsExpr_JSONOp,
+	elements ...*planpb.GenericValue,
+) *planpb.Expr {
+	return &planpb.Expr{
+		Expr: &planpb.Expr_JsonContainsExpr{
+			JsonContainsExpr: &planpb.JSONContainsExpr{
+				ColumnInfo:       column,
+				Elements:         elements,
+				Op:               op,
+				ElementsSameType: true,
+			},
+		},
+	}
+}
+
+func arrayContainsTestMarker(value int64) *planpb.Expr {
+	return &planpb.Expr{
+		Expr: &planpb.Expr_ValueExpr{
+			ValueExpr: &planpb.ValueExpr{Value: arrayContainsTestInt(value)},
+		},
+	}
+}
+
+func arrayContainsTestInt(value int64) *planpb.GenericValue {
+	return &planpb.GenericValue{Val: &planpb.GenericValue_Int64Val{Int64Val: value}}
+}
+
+func arrayContainsTestFloat(value float64) *planpb.GenericValue {
+	return &planpb.GenericValue{Val: &planpb.GenericValue_FloatVal{FloatVal: value}}
+}
+
+func arrayContainsTestString(value string) *planpb.GenericValue {
+	return &planpb.GenericValue{Val: &planpb.GenericValue_StringVal{StringVal: value}}
+}
+
+func arrayContainsTestIntValues(values []*planpb.GenericValue) []int64 {
+	result := make([]int64, 0, len(values))
+	for _, value := range values {
+		result = append(result, value.GetInt64Val())
+	}
+	return result
+}
+
+func arrayContainsTestFloatValues(values []*planpb.GenericValue) []float64 {
+	result := make([]float64, 0, len(values))
+	for _, value := range values {
+		result = append(result, value.GetFloatVal())
+	}
+	return result
+}

--- a/internal/parser/planparserv2/rewriter/array_contains_test.go
+++ b/internal/parser/planparserv2/rewriter/array_contains_test.go
@@ -193,20 +193,87 @@ func TestCombineArrayContainsRecomputesTypeAndClearsTemplateMetadata(t *testing.
 	require.Equal(t, "second", second.GetJsonContainsExpr().GetTemplateVariableName())
 }
 
-func TestCombineArrayContainsKeepsDuplicateElements(t *testing.T) {
-	column := arrayContainsTestColumn(201, schemapb.DataType_Int64)
-	parts := []*planpb.Expr{
-		arrayContainsTestExpr(column, planpb.JSONContainsExpr_Contains, arrayContainsTestInt(2)),
-		arrayContainsTestExpr(column, planpb.JSONContainsExpr_ContainsAny,
-			arrayContainsTestInt(2), arrayContainsTestInt(1)),
-		arrayContainsTestExpr(column, planpb.JSONContainsExpr_Contains, arrayContainsTestInt(1)),
+func TestCombineArrayContainsDeduplicatesElementsPreservingOrder(t *testing.T) {
+	testcases := []struct {
+		name       string
+		targetOp   planpb.JSONContainsExpr_JSONOp
+		combinedOp planpb.JSONContainsExpr_JSONOp
+	}{
+		{
+			name:       "contains any",
+			targetOp:   planpb.JSONContainsExpr_ContainsAny,
+			combinedOp: planpb.JSONContainsExpr_ContainsAny,
+		},
+		{
+			name:       "contains all",
+			targetOp:   planpb.JSONContainsExpr_ContainsAll,
+			combinedOp: planpb.JSONContainsExpr_ContainsAll,
+		},
 	}
 
-	result := combineArrayContains(parts, planpb.JSONContainsExpr_ContainsAny)
-	require.Len(t, result, 1)
-	merged := result[0].GetJsonContainsExpr()
-	require.NotNil(t, merged)
-	require.Equal(t, []int64{2, 2, 1, 1}, arrayContainsTestIntValues(merged.GetElements()))
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			column := arrayContainsTestColumn(201, schemapb.DataType_Int64)
+			parts := []*planpb.Expr{
+				arrayContainsTestExpr(column, planpb.JSONContainsExpr_Contains, arrayContainsTestInt(2)),
+				arrayContainsTestExpr(column, testcase.combinedOp,
+					arrayContainsTestInt(2), arrayContainsTestInt(1)),
+				arrayContainsTestExpr(column, planpb.JSONContainsExpr_Contains, arrayContainsTestInt(1)),
+			}
+
+			result := combineArrayContains(parts, testcase.targetOp)
+			require.Len(t, result, 1)
+			merged := result[0].GetJsonContainsExpr()
+			require.NotNil(t, merged)
+			require.Equal(t, []int64{2, 1}, arrayContainsTestIntValues(merged.GetElements()))
+		})
+	}
+}
+
+func TestCombineArrayContainsDeduplicatesAfterNumericCast(t *testing.T) {
+	testcases := []struct {
+		name           string
+		elementType    schemapb.DataType
+		first          *planpb.GenericValue
+		equivalent     *planpb.GenericValue
+		distinct       *planpb.GenericValue
+		distinctSecond *planpb.GenericValue
+	}{
+		{
+			name:           "float32",
+			elementType:    schemapb.DataType_Float,
+			first:          arrayContainsTestInt(16_777_217),
+			equivalent:     arrayContainsTestFloat(16_777_216),
+			distinct:       arrayContainsTestFloat(16_777_218),
+			distinctSecond: arrayContainsTestInt(16_777_218),
+		},
+		{
+			name:           "float64",
+			elementType:    schemapb.DataType_Double,
+			first:          arrayContainsTestInt(9_007_199_254_740_993),
+			equivalent:     arrayContainsTestFloat(9_007_199_254_740_992),
+			distinct:       arrayContainsTestFloat(9_007_199_254_740_994),
+			distinctSecond: arrayContainsTestInt(9_007_199_254_740_994),
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			column := arrayContainsTestColumn(201, testcase.elementType)
+			parts := []*planpb.Expr{
+				arrayContainsTestExpr(column, planpb.JSONContainsExpr_Contains, testcase.first),
+				arrayContainsTestExpr(column, planpb.JSONContainsExpr_ContainsAny,
+					testcase.equivalent, testcase.distinct, testcase.distinctSecond),
+			}
+
+			result := combineArrayContains(parts, planpb.JSONContainsExpr_ContainsAny)
+			require.Len(t, result, 1)
+			elements := result[0].GetJsonContainsExpr().GetElements()
+			require.Len(t, elements, 2)
+			require.Same(t, testcase.first, elements[0])
+			require.Same(t, testcase.distinct, elements[1])
+		})
+	}
 }
 
 func TestCombineArrayContainsRequiresAtLeastTwoSources(t *testing.T) {

--- a/internal/parser/planparserv2/rewriter/entry.go
+++ b/internal/parser/planparserv2/rewriter/entry.go
@@ -62,6 +62,7 @@ func (v *visitor) visitBinaryExpr(expr *planpb.BinaryExpr) interface{} {
 	switch expr.GetOp() {
 	case planpb.BinaryExpr_LogicalOr:
 		parts := flattenOr(left, right)
+		parts = combineArrayContains(parts, planpb.JSONContainsExpr_ContainsAny)
 		parts = v.combineOrEqualsToIn(parts)
 		parts = v.combineOrTextMatchToMerged(parts)
 		parts = v.combineOrRangePredicates(parts)
@@ -72,6 +73,7 @@ func (v *visitor) visitBinaryExpr(expr *planpb.BinaryExpr) interface{} {
 		return foldBinary(planpb.BinaryExpr_LogicalOr, parts)
 	case planpb.BinaryExpr_LogicalAnd:
 		parts := flattenAnd(left, right)
+		parts = combineArrayContains(parts, planpb.JSONContainsExpr_ContainsAll)
 		parts = v.combineAndRangePredicates(parts)
 		parts = v.combineAndBinaryRanges(parts)
 		parts = v.combineAndInWithIn(parts)

--- a/tests/python_client/milvus_client/test_milvus_client_query.py
+++ b/tests/python_client/milvus_client/test_milvus_client_query.py
@@ -5442,6 +5442,99 @@ class TestQueryArray(TestMilvusClientV2Base):
         self.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
+    def test_milvus_client_query_array_contains_merge_equivalence(self):
+        """
+        target: compare merged ARRAY contains predicates with explicit contains_any/contains_all
+        method: query nullable, empty, and duplicate-element arrays in growing and sealed/indexed segments
+        expected: original and explicit predicates return identical primary keys in both execution paths
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        array_field = "array_values"
+
+        schema = self.create_schema(client, enable_dynamic_field=False, auto_id=False)[0]
+        schema.add_field("id", DataType.INT64, is_primary=True)
+        schema.add_field("vector", DataType.FLOAT_VECTOR, dim=default_dim)
+        schema.add_field(
+            array_field,
+            DataType.ARRAY,
+            element_type=DataType.INT64,
+            max_capacity=16,
+            nullable=True,
+        )
+        self.create_collection(client, collection_name, schema=schema, consistency_level="Strong")
+
+        vector_index = self.prepare_index_params(client)[0]
+        vector_index.add_index(field_name="vector", index_type="FLAT", metric_type="L2")
+        self.create_index(client, collection_name, vector_index)
+        self.load_collection(client, collection_name)
+
+        arrays = [[], None, [1], [2], [1, 2], [1, 1, 2], [3]]
+        vectors = cf.gen_vectors(len(arrays), default_dim)
+        rows = [
+            {"id": row_id, "vector": vectors[row_id], array_field: array}
+            for row_id, array in enumerate(arrays)
+        ]
+        self.insert(client, collection_name, rows)
+
+        predicate_cases = [
+            (
+                f"array_contains({array_field}, 1) or array_contains({array_field}, 2)",
+                f"array_contains_any({array_field}, [1, 2])",
+                {2, 3, 4, 5},
+            ),
+            (
+                f"array_contains({array_field}, 1) and array_contains({array_field}, 2)",
+                f"array_contains_all({array_field}, [1, 2])",
+                {4, 5},
+            ),
+            (
+                f"array_contains({array_field}, 1) or array_contains({array_field}, 1)",
+                f"array_contains_any({array_field}, [1, 1])",
+                {2, 4, 5},
+            ),
+            (
+                f"array_contains({array_field}, 1) and array_contains({array_field}, 1)",
+                f"array_contains_all({array_field}, [1, 1])",
+                {2, 4, 5},
+            ),
+        ]
+
+        def assert_equivalent():
+            for original, explicit, expected_ids in predicate_cases:
+                original_result = self.query(
+                    client,
+                    collection_name,
+                    filter=original,
+                    output_fields=["id"],
+                    limit=len(rows),
+                )[0]
+                explicit_result = self.query(
+                    client,
+                    collection_name,
+                    filter=explicit,
+                    output_fields=["id"],
+                    limit=len(rows),
+                )[0]
+                original_ids = {record["id"] for record in original_result}
+                explicit_ids = {record["id"] for record in explicit_result}
+                assert original_ids == explicit_ids == expected_ids
+
+        # Loaded-before-insert data stays in the growing segment.
+        assert_equivalent()
+
+        # Flush and add an ARRAY scalar index to exercise the sealed/indexed path.
+        self.flush(client, collection_name)
+        self.release_collection(client, collection_name)
+        array_index = self.prepare_index_params(client)[0]
+        array_index.add_index(field_name=array_field, index_type="INVERTED")
+        self.create_index(client, collection_name, array_index)
+        self.load_collection(client, collection_name)
+        assert_equivalent()
+
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("use_index", [True, False])
     @pytest.mark.parametrize("index_type", ["INVERTED", "BITMAP"])
     def test_milvus_client_query_array_with_prefix_like(self, use_index, index_type):


### PR DESCRIPTION
issue: #51996

## What

- Merge compatible OR chains on the same physical ARRAY column into one ContainsAny predicate.
- Merge compatible AND chains on the same physical ARRAY column into one ContainsAll predicate.
- Preserve first-encounter order, remove duplicate values, and support nested or balanced logical trees and existing Any or All predicates.
- Keep JSON columns and incompatible values unchanged.
- Add rewriter unit and integration coverage, query-level equivalence coverage, and documentation.

## Testing

- LOCALSTORAGEPATH=/tmp/milvus-codex-array-contains go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/parser/planparserv2/...
- LOCALSTORAGEPATH=/tmp/milvus-codex-array-contains bin/golangci-lint run --build-tags dynamic,test --timeout=10m --config .golangci.yml ./internal/parser/planparserv2/rewriter
- Python AST syntax check for tests/python_client/milvus_client/test_milvus_client_query.py
- cd internal/core && CLANG_FORMAT=/opt/homebrew/opt/llvm@15/bin/clang-format ./run_clang_format.sh .

## Notes

- JSON columns are intentionally excluded from this optimization.
- The query-level growing and sealed/indexed equivalence case was added but not executed locally because no usable Milvus endpoint was available.
- make lint-fix was invoked; its repository-wide golangci phase was blocked by stale local internal/core/output headers, while the scoped rewriter lint completed with zero issues.