### PR TITLE
fix: return element offsets in REST v2 search results

### DIFF
--- a/internal/distributed/proxy/httpserver/constant.go
+++ b/internal/distributed/proxy/httpserver/constant.go
@@ -194,7 +194,8 @@ const (
 	HTTPReturnMaxIndexVersion = "maxIndexVersion"
 	HTTPReturnIndexParams     = "indexParams"
 
-	HTTPReturnDistance = "distance"
+	HTTPReturnDistance      = "distance"
+	HTTPReturnElementOffset = "offset"
 
 	HTTPReturnRowCount = "rowCount"
 

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -2059,12 +2059,13 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 			HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: []interface{}{}, HTTPReturnCost: cost})
 		} else {
 			allowJS, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
-			outputData, err := buildSearchResp(searchResp.Results, allowJS, collSchema)
-			if err != nil {
-				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(err))
+			outputData, buildErr := buildSearchResp(searchResp.Results, allowJS, collSchema)
+			if buildErr != nil {
+				err = buildErr
+				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(buildErr))
 				HTTPReturn(c, http.StatusOK, gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
+					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + buildErr.Error(),
 				})
 			} else {
 				if len(searchResp.Results.Recalls) > 0 {
@@ -2231,12 +2232,13 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 			HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: []interface{}{}, HTTPReturnCost: cost})
 		} else {
 			allowJS, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
-			outputData, err := buildSearchResp(searchResp.Results, allowJS, collSchema)
-			if err != nil {
-				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(err))
+			outputData, buildErr := buildSearchResp(searchResp.Results, allowJS, collSchema)
+			if buildErr != nil {
+				err = buildErr
+				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(buildErr))
 				HTTPReturn(c, http.StatusOK, gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
+					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + buildErr.Error(),
 				})
 			} else {
 				if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() && isValid {

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -1848,6 +1848,24 @@ func invalidSearchResultStatus(buildErr error) *commonpb.Status {
 	return status
 }
 
+func searchResultLogFields(results *schemapb.SearchResultData) []mlog.Field {
+	if results == nil {
+		return []mlog.Field{mlog.Bool("resultNil", true)}
+	}
+	return []mlog.Field{
+		mlog.Int64("nq", results.GetNumQueries()),
+		mlog.Int64("topK", results.GetTopK()),
+		mlog.Int("rowCount", len(results.GetScores())),
+		mlog.Int("outputFieldCount", len(results.GetFieldsData())),
+		mlog.Int("aggregationBucketCount", len(results.GetAggBuckets())),
+	}
+}
+
+func logSearchResultBuildFailure(ctx context.Context, message string, results *schemapb.SearchResultData, buildErr error) {
+	fields := append(searchResultLogFields(results), mlog.Err(buildErr))
+	mlog.Warn(ctx, message, fields...)
+}
+
 func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
 	httpReq := anyReq.(*SearchReqV2)
 	req := &milvuspb.SearchRequest{
@@ -2040,7 +2058,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 			allowJS, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
 			outputData, err := buildSearchAggregationResp(searchResp.Results, allowJS, collSchema)
 			if err != nil {
-				mlog.Warn(ctx, "high level restful api, fail to deal with search aggregation result", mlog.Any("result", searchResp.Results), mlog.Err(err))
+				logSearchResultBuildFailure(ctx, "high level restful api, fail to deal with search aggregation result", searchResp.Results, err)
 				HTTPReturn(c, http.StatusOK, gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
 					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
@@ -2070,7 +2088,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 			if buildErr != nil {
 				searchResp.Status = invalidSearchResultStatus(buildErr)
 				err = merr.Error(searchResp.Status)
-				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(buildErr))
+				logSearchResultBuildFailure(ctx, "high level restful api, fail to deal with search result", searchResp.Results, buildErr)
 				HTTPReturn(c, http.StatusOK, gin.H{
 					HTTPReturnCode:    searchResp.Status.GetCode(),
 					HTTPReturnMessage: searchResp.Status.GetReason(),
@@ -2244,7 +2262,7 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 			if buildErr != nil {
 				searchResp.Status = invalidSearchResultStatus(buildErr)
 				err = merr.Error(searchResp.Status)
-				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(buildErr))
+				logSearchResultBuildFailure(ctx, "high level restful api, fail to deal with search result", searchResp.Results, buildErr)
 				HTTPReturn(c, http.StatusOK, gin.H{
 					HTTPReturnCode:    searchResp.Status.GetCode(),
 					HTTPReturnMessage: searchResp.Status.GetReason(),

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -2053,12 +2053,13 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 			HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: []interface{}{}, HTTPReturnCost: cost})
 		} else {
 			allowJS, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
-			outputData, err := buildSearchResp(searchResp.Results, allowJS, collSchema)
-			if err != nil {
-				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(err))
+			outputData, buildErr := buildSearchResp(searchResp.Results, allowJS, collSchema)
+			if buildErr != nil {
+				err = buildErr
+				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(buildErr))
 				HTTPReturn(c, http.StatusOK, gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
+					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + buildErr.Error(),
 				})
 			} else {
 				if len(searchResp.Results.Recalls) > 0 {
@@ -2225,12 +2226,13 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 			HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: []interface{}{}, HTTPReturnCost: cost})
 		} else {
 			allowJS, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
-			outputData, err := buildSearchResp(searchResp.Results, allowJS, collSchema)
-			if err != nil {
-				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(err))
+			outputData, buildErr := buildSearchResp(searchResp.Results, allowJS, collSchema)
+			if buildErr != nil {
+				err = buildErr
+				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(buildErr))
 				HTTPReturn(c, http.StatusOK, gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
+					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + buildErr.Error(),
 				})
 			} else {
 				if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() && isValid {

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -2053,7 +2053,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 			HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: []interface{}{}, HTTPReturnCost: cost})
 		} else {
 			allowJS, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
-			outputData, err := buildQueryResp(0, searchResp.Results.OutputFields, searchResp.Results.FieldsData, searchResp.Results.Ids, searchResp.Results.Scores, allowJS, collSchema)
+			outputData, err := buildSearchResp(searchResp.Results, allowJS, collSchema)
 			if err != nil {
 				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(err))
 				HTTPReturn(c, http.StatusOK, gin.H{
@@ -2225,7 +2225,7 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 			HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: []interface{}{}, HTTPReturnCost: cost})
 		} else {
 			allowJS, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
-			outputData, err := buildQueryResp(0, searchResp.Results.OutputFields, searchResp.Results.FieldsData, searchResp.Results.Ids, searchResp.Results.Scores, allowJS, collSchema)
+			outputData, err := buildSearchResp(searchResp.Results, allowJS, collSchema)
 			if err != nil {
 				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(err))
 				HTTPReturn(c, http.StatusOK, gin.H{

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -1841,6 +1841,13 @@ func generatePlaceholderGroup(ctx context.Context, body string, collSchema *sche
 	})
 }
 
+func invalidSearchResultStatus(buildErr error) *commonpb.Status {
+	status := merr.Status(merr.ErrInvalidSearchResult)
+	status.Reason += ", error: " + buildErr.Error()
+	status.Detail = status.Reason
+	return status
+}
+
 func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
 	httpReq := anyReq.(*SearchReqV2)
 	req := &milvuspb.SearchRequest{
@@ -2059,13 +2066,14 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 			HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: []interface{}{}, HTTPReturnCost: cost})
 		} else {
 			allowJS, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
-			outputData, buildErr := buildSearchResp(searchResp.Results, allowJS, collSchema)
+			outputData, buildErr := buildSearchResp(searchResp.Results, httpReq.OutputFields, allowJS, collSchema)
 			if buildErr != nil {
-				err = buildErr
+				searchResp.Status = invalidSearchResultStatus(buildErr)
+				err = merr.Error(searchResp.Status)
 				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(buildErr))
 				HTTPReturn(c, http.StatusOK, gin.H{
-					HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + buildErr.Error(),
+					HTTPReturnCode:    searchResp.Status.GetCode(),
+					HTTPReturnMessage: searchResp.Status.GetReason(),
 				})
 			} else {
 				if len(searchResp.Results.Recalls) > 0 {
@@ -2232,13 +2240,14 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 			HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: []interface{}{}, HTTPReturnCost: cost})
 		} else {
 			allowJS, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
-			outputData, buildErr := buildSearchResp(searchResp.Results, allowJS, collSchema)
+			outputData, buildErr := buildSearchResp(searchResp.Results, httpReq.OutputFields, allowJS, collSchema)
 			if buildErr != nil {
-				err = buildErr
+				searchResp.Status = invalidSearchResultStatus(buildErr)
+				err = merr.Error(searchResp.Status)
 				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(buildErr))
 				HTTPReturn(c, http.StatusOK, gin.H{
-					HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + buildErr.Error(),
+					HTTPReturnCode:    searchResp.Status.GetCode(),
+					HTTPReturnMessage: searchResp.Status.GetReason(),
 				})
 			} else {
 				if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() && isValid {

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -2059,7 +2059,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 			HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: []interface{}{}, HTTPReturnCost: cost})
 		} else {
 			allowJS, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
-			outputData, err := buildQueryResp(0, searchResp.Results.OutputFields, searchResp.Results.FieldsData, searchResp.Results.Ids, searchResp.Results.Scores, allowJS, collSchema)
+			outputData, err := buildSearchResp(searchResp.Results, allowJS, collSchema)
 			if err != nil {
 				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(err))
 				HTTPReturn(c, http.StatusOK, gin.H{
@@ -2231,7 +2231,7 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 			HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: []interface{}{}, HTTPReturnCost: cost})
 		} else {
 			allowJS, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
-			outputData, err := buildQueryResp(0, searchResp.Results.OutputFields, searchResp.Results.FieldsData, searchResp.Results.Ids, searchResp.Results.Scores, allowJS, collSchema)
+			outputData, err := buildSearchResp(searchResp.Results, allowJS, collSchema)
 			if err != nil {
 				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(err))
 				HTTPReturn(c, http.StatusOK, gin.H{

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -1085,22 +1085,27 @@ func TestSearchV2RejectsElementOffsetFieldCollision(t *testing.T) {
 		requestBody string
 		method      string
 		hybrid      bool
+		mismatched  bool
+		expected    string
 	}{
 		{
 			name:        "search",
 			path:        versionalV2(EntityCategory, SearchAction),
 			requestBody: `{"collectionName":"book","data":[[0.1,0.2]],"annsField":"book_intro","limit":1}`,
 			method:      "Search",
+			expected:    `field "offset" conflicts with the reserved REST search element offset field`,
 		},
 		{
-			name: "hybrid search",
+			name: "hybrid search with mismatched element offsets",
 			path: versionalV2(EntityCategory, HybridSearchAction),
 			requestBody: `{"collectionName":"book","search":[` +
 				`{"data":[[0.1,0.2]],"annsField":"book_intro","metricType":"L2","limit":1},` +
 				`{"data":[[0.1,0.2]],"annsField":"book_intro","metricType":"L2","limit":1}],` +
 				`"rerank":{"strategy":"weighted","params":{"weights":[0.5,0.5]}},"limit":1}`,
-			method: "HybridSearch",
-			hybrid: true,
+			method:     "HybridSearch",
+			hybrid:     true,
+			mismatched: true,
+			expected:   "element_indices length (0) does not match row count (1)",
 		},
 	}
 
@@ -1109,7 +1114,9 @@ func TestSearchV2RejectsElementOffsetFieldCollision(t *testing.T) {
 			mp := mocks.NewMockProxy(t)
 			testEngine := initHTTPServerV2(mp, false)
 			schema := generateCollectionSchema(schemapb.DataType_Int64, false, false)
-			schema.Fields[0].Name = HTTPReturnElementOffset
+			if !testCase.mismatched {
+				schema.Fields[0].Name = HTTPReturnElementOffset
+			}
 			mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
 				CollectionName: DefaultCollectionName,
 				Schema:         schema,
@@ -1127,6 +1134,9 @@ func TestSearchV2RejectsElementOffsetFieldCollision(t *testing.T) {
 					ElementIndices: &schemapb.LongArray{Data: []int64{0}},
 				},
 			}
+			if testCase.mismatched {
+				searchResult.Results.ElementIndices = &schemapb.LongArray{}
+			}
 			if testCase.hybrid {
 				mp.EXPECT().HybridSearch(mock.Anything, mock.Anything).Return(searchResult, nil).Once()
 			} else {
@@ -1136,8 +1146,8 @@ func TestSearchV2RejectsElementOffsetFieldCollision(t *testing.T) {
 			failureCounter := metrics.ProxyFunctionCall.WithLabelValues(
 				paramtable.GetStringNodeID(),
 				testCase.method,
-				metrics.RejectedLabel,
-				metrics.CauseUser,
+				metrics.FailLabel,
+				metrics.CauseSystem,
 				DefaultDbName,
 				DefaultCollectionName,
 			)
@@ -1151,10 +1161,84 @@ func TestSearchV2RejectsElementOffsetFieldCollision(t *testing.T) {
 			var response ReturnErrMsg
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 			require.Equal(t, merr.Code(merr.ErrInvalidSearchResult), response.Code)
-			require.Contains(t, response.Message, `field "offset" conflicts with the reserved REST search element offset field`)
+			require.Contains(t, response.Message, testCase.expected)
+			require.Equal(t, response.Code, searchResult.GetStatus().GetCode())
+			require.Equal(t, response.Message, searchResult.GetStatus().GetReason())
 			require.Equal(t, beforeFailures+1, testutil.ToFloat64(failureCounter))
 		})
 	}
+}
+
+func TestSearchV2RejectsRequestedElementOffsetAfterReconstruction(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	mp := mocks.NewMockProxy(t)
+	testEngine := initHTTPServerV2(mp, false)
+	schema := generateCollectionSchema(schemapb.DataType_Int64, false, true)
+	schema.StructArrayFields = []*schemapb.StructArrayFieldSchema{
+		{
+			FieldID: common.StartOfUserFieldID + 3,
+			Name:    "chunks",
+			Fields: []*schemapb.FieldSchema{
+				{
+					FieldID:     common.StartOfUserFieldID + 4,
+					Name:        "embeddings",
+					DataType:    schemapb.DataType_ArrayOfVector,
+					ElementType: schemapb.DataType_FloatVector,
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.DimKey, Value: "2"},
+					},
+				},
+			},
+		},
+	}
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         schema,
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Once()
+	searchResult := &milvuspb.SearchResults{
+		Status: commonSuccessStatus,
+		Results: &schemapb.SearchResultData{
+			NumQueries:   1,
+			TopK:         1,
+			Topks:        []int64{1},
+			OutputFields: []string{common.MetaFieldName},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_JSON,
+					FieldName: common.MetaFieldName,
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_JsonData{JsonData: &schemapb.JSONArray{Data: [][]byte{[]byte(`{}`)}}},
+					}},
+					IsDynamic: true,
+				},
+			},
+			Ids:            generateIDs(schemapb.DataType_Int64, 1),
+			Scores:         DefaultScores[:1],
+			ElementIndices: &schemapb.LongArray{Data: []int64{0}},
+		},
+	}
+	mp.EXPECT().Search(mock.Anything, mock.Anything).Return(searchResult, nil).Once()
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		versionalV2(EntityCategory, SearchAction),
+		bytes.NewReader([]byte(`{"collectionName":"book","data":[[0.1,0.2]],"annsField":"book_intro","limit":1,"outputFields":["offset"]}`)),
+	)
+	w := httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var response ReturnErrMsg
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.Equal(t, merr.Code(merr.ErrInvalidSearchResult), response.Code)
+	require.Contains(t, response.Message, `field "offset" conflicts with the reserved REST search element offset field`)
+	require.Equal(t, response.Code, searchResult.GetStatus().GetCode())
+	require.Equal(t, response.Message, searchResult.GetStatus().GetReason())
 }
 
 func TestDocInDocOutSearch(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -1072,6 +1072,48 @@ func TestSearchV2ReturnsElementOffsets(t *testing.T) {
 	}
 }
 
+func TestSearchV2RejectsElementOffsetFieldCollision(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	mp := mocks.NewMockProxy(t)
+	testEngine := initHTTPServerV2(mp, false)
+	schema := generateCollectionSchema(schemapb.DataType_Int64, false, false)
+	schema.Fields[0].Name = HTTPReturnElementOffset
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         schema,
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Once()
+	mp.EXPECT().Search(mock.Anything, mock.Anything).Return(&milvuspb.SearchResults{
+		Status: commonSuccessStatus,
+		Results: &schemapb.SearchResultData{
+			NumQueries:     1,
+			TopK:           1,
+			Topks:          []int64{1},
+			Ids:            generateIDs(schemapb.DataType_Int64, 1),
+			Scores:         DefaultScores[:1],
+			ElementIndices: &schemapb.LongArray{Data: []int64{0}},
+		},
+	}, nil).Once()
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		versionalV2(EntityCategory, SearchAction),
+		bytes.NewReader([]byte(`{"collectionName":"book","data":[[0.1,0.2]],"annsField":"book_intro","limit":1}`)),
+	)
+	w := httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var response ReturnErrMsg
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.Equal(t, merr.Code(merr.ErrInvalidSearchResult), response.Code)
+	require.Contains(t, response.Message, `field "offset" conflicts with the reserved REST search element offset field`)
+}
+
 func TestDocInDocOutSearch(t *testing.T) {
 	paramtable.Init()
 	// disable rate limit

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -44,6 +45,7 @@ import (
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/crypto"
@@ -1077,41 +1079,82 @@ func TestSearchV2RejectsElementOffsetFieldCollision(t *testing.T) {
 	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
 	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
 
-	mp := mocks.NewMockProxy(t)
-	testEngine := initHTTPServerV2(mp, false)
-	schema := generateCollectionSchema(schemapb.DataType_Int64, false, false)
-	schema.Fields[0].Name = HTTPReturnElementOffset
-	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
-		CollectionName: DefaultCollectionName,
-		Schema:         schema,
-		ShardsNum:      ShardNumDefault,
-		Status:         &StatusSuccess,
-	}, nil).Once()
-	mp.EXPECT().Search(mock.Anything, mock.Anything).Return(&milvuspb.SearchResults{
-		Status: commonSuccessStatus,
-		Results: &schemapb.SearchResultData{
-			NumQueries:     1,
-			TopK:           1,
-			Topks:          []int64{1},
-			Ids:            generateIDs(schemapb.DataType_Int64, 1),
-			Scores:         DefaultScores[:1],
-			ElementIndices: &schemapb.LongArray{Data: []int64{0}},
+	testCases := []struct {
+		name        string
+		path        string
+		requestBody string
+		method      string
+		hybrid      bool
+	}{
+		{
+			name:        "search",
+			path:        versionalV2(EntityCategory, SearchAction),
+			requestBody: `{"collectionName":"book","data":[[0.1,0.2]],"annsField":"book_intro","limit":1}`,
+			method:      "Search",
 		},
-	}, nil).Once()
+		{
+			name: "hybrid search",
+			path: versionalV2(EntityCategory, HybridSearchAction),
+			requestBody: `{"collectionName":"book","search":[` +
+				`{"data":[[0.1,0.2]],"annsField":"book_intro","metricType":"L2","limit":1},` +
+				`{"data":[[0.1,0.2]],"annsField":"book_intro","metricType":"L2","limit":1}],` +
+				`"rerank":{"strategy":"weighted","params":{"weights":[0.5,0.5]}},"limit":1}`,
+			method: "HybridSearch",
+			hybrid: true,
+		},
+	}
 
-	req := httptest.NewRequest(
-		http.MethodPost,
-		versionalV2(EntityCategory, SearchAction),
-		bytes.NewReader([]byte(`{"collectionName":"book","data":[[0.1,0.2]],"annsField":"book_intro","limit":1}`)),
-	)
-	w := httptest.NewRecorder()
-	testEngine.ServeHTTP(w, req)
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			mp := mocks.NewMockProxy(t)
+			testEngine := initHTTPServerV2(mp, false)
+			schema := generateCollectionSchema(schemapb.DataType_Int64, false, false)
+			schema.Fields[0].Name = HTTPReturnElementOffset
+			mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+				CollectionName: DefaultCollectionName,
+				Schema:         schema,
+				ShardsNum:      ShardNumDefault,
+				Status:         &StatusSuccess,
+			}, nil).Once()
+			searchResult := &milvuspb.SearchResults{
+				Status: commonSuccessStatus,
+				Results: &schemapb.SearchResultData{
+					NumQueries:     1,
+					TopK:           1,
+					Topks:          []int64{1},
+					Ids:            generateIDs(schemapb.DataType_Int64, 1),
+					Scores:         DefaultScores[:1],
+					ElementIndices: &schemapb.LongArray{Data: []int64{0}},
+				},
+			}
+			if testCase.hybrid {
+				mp.EXPECT().HybridSearch(mock.Anything, mock.Anything).Return(searchResult, nil).Once()
+			} else {
+				mp.EXPECT().Search(mock.Anything, mock.Anything).Return(searchResult, nil).Once()
+			}
 
-	require.Equal(t, http.StatusOK, w.Code)
-	var response ReturnErrMsg
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
-	require.Equal(t, merr.Code(merr.ErrInvalidSearchResult), response.Code)
-	require.Contains(t, response.Message, `field "offset" conflicts with the reserved REST search element offset field`)
+			failureCounter := metrics.ProxyFunctionCall.WithLabelValues(
+				paramtable.GetStringNodeID(),
+				testCase.method,
+				metrics.RejectedLabel,
+				metrics.CauseUser,
+				DefaultDbName,
+				DefaultCollectionName,
+			)
+			beforeFailures := testutil.ToFloat64(failureCounter)
+
+			req := httptest.NewRequest(http.MethodPost, testCase.path, bytes.NewReader([]byte(testCase.requestBody)))
+			w := httptest.NewRecorder()
+			testEngine.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusOK, w.Code)
+			var response ReturnErrMsg
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+			require.Equal(t, merr.Code(merr.ErrInvalidSearchResult), response.Code)
+			require.Contains(t, response.Message, `field "offset" conflicts with the reserved REST search element offset field`)
+			require.Equal(t, beforeFailures+1, testutil.ToFloat64(failureCounter))
+		})
+	}
 }
 
 func TestDocInDocOutSearch(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -1241,6 +1241,29 @@ func TestSearchV2RejectsRequestedElementOffsetAfterReconstruction(t *testing.T) 
 	require.Equal(t, response.Message, searchResult.GetStatus().GetReason())
 }
 
+func TestSearchResultLogFieldsExcludePayload(t *testing.T) {
+	fields := searchResultLogFields(&schemapb.SearchResultData{
+		NumQueries: 2,
+		TopK:       3,
+		Scores:     []float32{0.9, 0.8},
+		FieldsData: []*schemapb.FieldData{{FieldName: "secret"}},
+		AggBuckets: []*schemapb.AggBucket{{Count: 1}},
+	})
+
+	keys := make([]string, 0, len(fields))
+	for _, field := range fields {
+		keys = append(keys, field.Key)
+	}
+	require.ElementsMatch(t, []string{
+		"nq",
+		"topK",
+		"rowCount",
+		"outputFieldCount",
+		"aggregationBucketCount",
+	}, keys)
+	require.NotContains(t, keys, "result")
+}
+
 func TestDocInDocOutSearch(t *testing.T) {
 	paramtable.Init()
 	// disable rate limit

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -1001,6 +1001,77 @@ func TestHybridSearchWithRerank(t *testing.T) {
 	sendReqAndVerify(t, testEngine, queryTestCases.path, http.MethodPost, queryTestCases)
 }
 
+func TestSearchV2ReturnsElementOffsets(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	testCases := []struct {
+		name        string
+		path        string
+		requestBody string
+		hybrid      bool
+	}{
+		{
+			name:        "search",
+			path:        versionalV2(EntityCategory, SearchAction),
+			requestBody: `{"collectionName":"book","data":[[0.1,0.2]],"annsField":"book_intro","limit":2}`,
+		},
+		{
+			name: "hybrid search",
+			path: versionalV2(EntityCategory, HybridSearchAction),
+			requestBody: `{"collectionName":"book","search":[` +
+				`{"data":[[0.1,0.2]],"annsField":"book_intro","metricType":"L2","limit":2},` +
+				`{"data":[[0.1,0.2]],"annsField":"book_intro","metricType":"L2","limit":2}],` +
+				`"rerank":{"strategy":"weighted","params":{"weights":[0.5,0.5]}},"limit":2,"groupingField":"book_id"}`,
+			hybrid: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			mp := mocks.NewMockProxy(t)
+			testEngine := initHTTPServerV2(mp, false)
+			mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+				CollectionName: DefaultCollectionName,
+				Schema:         generateCollectionSchema(schemapb.DataType_Int64, true, true),
+				ShardsNum:      ShardNumDefault,
+				Status:         &StatusSuccess,
+			}, nil).Once()
+
+			searchResult := &milvuspb.SearchResults{Status: commonSuccessStatus, Results: &schemapb.SearchResultData{
+				NumQueries:     1,
+				TopK:           2,
+				Topks:          []int64{2},
+				Ids:            generateIDs(schemapb.DataType_Int64, 2),
+				Scores:         []float32{0.9, 0.8},
+				ElementIndices: &schemapb.LongArray{Data: []int64{0, 2}},
+			}}
+			if testCase.hybrid {
+				mp.EXPECT().HybridSearch(mock.Anything, mock.Anything).Return(searchResult, nil).Once()
+			} else {
+				mp.EXPECT().Search(mock.Anything, mock.Anything).Return(searchResult, nil).Once()
+			}
+
+			req := httptest.NewRequest(http.MethodPost, testCase.path, bytes.NewReader([]byte(testCase.requestBody)))
+			w := httptest.NewRecorder()
+			testEngine.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusOK, w.Code)
+			var response struct {
+				Code int                      `json:"code"`
+				Data []map[string]interface{} `json:"data"`
+			}
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+			require.Zero(t, response.Code)
+			require.Len(t, response.Data, 2)
+			require.Contains(t, response.Data[0], "offset")
+			require.Equal(t, float64(0), response.Data[0]["offset"])
+			require.Equal(t, float64(2), response.Data[1]["offset"])
+		})
+	}
+}
+
 func TestDocInDocOutSearch(t *testing.T) {
 	paramtable.Init()
 	// disable rate limit

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -2865,10 +2865,11 @@ func buildSearchResp(results *schemapb.SearchResultData, enableInt64 bool, colle
 		return nil, err
 	}
 
-	elementOffsets := results.GetElementIndices().GetData()
-	if len(elementOffsets) == 0 {
+	elementIndices := results.GetElementIndices()
+	if elementIndices == nil {
 		return rows, nil
 	}
+	elementOffsets := elementIndices.GetData()
 	if len(elementOffsets) != len(rows) {
 		return nil, merr.WrapErrServiceInternalMsg(
 			"search result element_indices length (%d) does not match row count (%d)",
@@ -2876,6 +2877,12 @@ func buildSearchResp(results *schemapb.SearchResultData, enableInt64 bool, colle
 		)
 	}
 
+	if containsString(results.GetOutputFields(), HTTPReturnElementOffset) {
+		return nil, merr.WrapErrParameterInvalidMsg(
+			"field %q conflicts with the reserved REST search element offset field",
+			HTTPReturnElementOffset,
+		)
+	}
 	for _, row := range rows {
 		if _, ok := row[HTTPReturnElementOffset]; ok {
 			return nil, merr.WrapErrParameterInvalidMsg(

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -45,6 +45,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proxy/accesslog"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/function/chain"
+	internaltypeutil "github.com/milvus-io/milvus/internal/util/typeutil"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -2852,6 +2853,26 @@ func buildSearchResp(results *schemapb.SearchResultData, requestedOutputFields [
 		return nil, merr.WrapErrServiceInternalMsg("search result is nil")
 	}
 
+	elementIndices := results.GetElementIndices()
+	if elementIndices != nil && searchOutputFieldsContainElementOffset(requestedOutputFields, collectionSchema) {
+		return nil, merr.WrapErrParameterInvalidMsg(
+			"field %q conflicts with the reserved REST search element offset field",
+			HTTPReturnElementOffset,
+		)
+	}
+	if elementIndices != nil && searchOutputFieldsContainElementOffset(results.GetOutputFields(), collectionSchema) {
+		return nil, merr.WrapErrParameterInvalidMsg(
+			"field %q conflicts with the reserved REST search element offset field",
+			HTTPReturnElementOffset,
+		)
+	}
+	if elementIndices != nil && getRESTPrimaryFieldName(collectionSchema) == HTTPReturnElementOffset {
+		return nil, merr.WrapErrParameterInvalidMsg(
+			"field %q conflicts with the reserved REST search element offset field",
+			HTTPReturnElementOffset,
+		)
+	}
+
 	rows, err := buildQueryResp(
 		0,
 		results.GetOutputFields(),
@@ -2865,7 +2886,6 @@ func buildSearchResp(results *schemapb.SearchResultData, requestedOutputFields [
 		return nil, err
 	}
 
-	elementIndices := results.GetElementIndices()
 	if elementIndices == nil {
 		return rows, nil
 	}
@@ -2877,12 +2897,6 @@ func buildSearchResp(results *schemapb.SearchResultData, requestedOutputFields [
 		)
 	}
 
-	if containsString(requestedOutputFields, HTTPReturnElementOffset) || containsString(results.GetOutputFields(), HTTPReturnElementOffset) {
-		return nil, merr.WrapErrParameterInvalidMsg(
-			"field %q conflicts with the reserved REST search element offset field",
-			HTTPReturnElementOffset,
-		)
-	}
 	for _, row := range rows {
 		if _, ok := row[HTTPReturnElementOffset]; ok {
 			return nil, merr.WrapErrParameterInvalidMsg(
@@ -2895,6 +2909,37 @@ func buildSearchResp(results *schemapb.SearchResultData, requestedOutputFields [
 		rows[i][HTTPReturnElementOffset] = offset
 	}
 	return rows, nil
+}
+
+func searchOutputFieldsContainElementOffset(outputFields []string, collectionSchema *schemapb.CollectionSchema) bool {
+	var dynamicField *schemapb.FieldSchema
+	if collectionSchema != nil {
+		for _, field := range collectionSchema.GetFields() {
+			if field.GetIsDynamic() {
+				dynamicField = field
+				break
+			}
+		}
+	}
+
+	for _, outputField := range outputFields {
+		outputField = strings.TrimSpace(outputField)
+		if outputField == HTTPReturnElementOffset {
+			return true
+		}
+		if dynamicField == nil || !strings.Contains(outputField, "[") {
+			continue
+		}
+		nestedPath, err := internaltypeutil.ParseAndVerifyNestedPath(
+			outputField,
+			collectionSchema,
+			dynamicField.GetFieldID(),
+		)
+		if err == nil && nestedPath == "/"+HTTPReturnElementOffset {
+			return true
+		}
+	}
+	return false
 }
 
 func hasSearchAggregationResult(results *schemapb.SearchResultData) bool {

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -2876,6 +2876,14 @@ func buildSearchResp(results *schemapb.SearchResultData, enableInt64 bool, colle
 		)
 	}
 
+	for _, row := range rows {
+		if _, ok := row[HTTPReturnElementOffset]; ok {
+			return nil, merr.WrapErrParameterInvalidMsg(
+				"field %q conflicts with the reserved REST search element offset field",
+				HTTPReturnElementOffset,
+			)
+		}
+	}
 	for i, offset := range elementOffsets {
 		rows[i][HTTPReturnElementOffset] = offset
 	}

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -2847,6 +2847,41 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 	return queryResp, nil
 }
 
+func buildSearchResp(results *schemapb.SearchResultData, enableInt64 bool, collectionSchema *schemapb.CollectionSchema) ([]map[string]interface{}, error) {
+	if results == nil {
+		return nil, merr.WrapErrServiceInternalMsg("search result is nil")
+	}
+
+	rows, err := buildQueryResp(
+		0,
+		results.GetOutputFields(),
+		results.GetFieldsData(),
+		results.GetIds(),
+		results.GetScores(),
+		enableInt64,
+		collectionSchema,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	elementOffsets := results.GetElementIndices().GetData()
+	if len(elementOffsets) == 0 {
+		return rows, nil
+	}
+	if len(elementOffsets) != len(rows) {
+		return nil, merr.WrapErrServiceInternalMsg(
+			"search result element_indices length (%d) does not match row count (%d)",
+			len(elementOffsets), len(rows),
+		)
+	}
+
+	for i, offset := range elementOffsets {
+		rows[i][HTTPReturnElementOffset] = offset
+	}
+	return rows, nil
+}
+
 func hasSearchAggregationResult(results *schemapb.SearchResultData) bool {
 	return results != nil && (len(results.GetAggTopks()) > 0 || len(results.GetAggBuckets()) > 0)
 }

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -2847,7 +2847,7 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 	return queryResp, nil
 }
 
-func buildSearchResp(results *schemapb.SearchResultData, enableInt64 bool, collectionSchema *schemapb.CollectionSchema) ([]map[string]interface{}, error) {
+func buildSearchResp(results *schemapb.SearchResultData, requestedOutputFields []string, enableInt64 bool, collectionSchema *schemapb.CollectionSchema) ([]map[string]interface{}, error) {
 	if results == nil {
 		return nil, merr.WrapErrServiceInternalMsg("search result is nil")
 	}
@@ -2877,7 +2877,7 @@ func buildSearchResp(results *schemapb.SearchResultData, enableInt64 bool, colle
 		)
 	}
 
-	if containsString(results.GetOutputFields(), HTTPReturnElementOffset) {
+	if containsString(requestedOutputFields, HTTPReturnElementOffset) || containsString(results.GetOutputFields(), HTTPReturnElementOffset) {
 		return nil, merr.WrapErrParameterInvalidMsg(
 			"field %q conflicts with the reserved REST search element offset field",
 			HTTPReturnElementOffset,

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -2021,7 +2021,6 @@ func TestBuildSearchResp(t *testing.T) {
 		require.ErrorIs(t, err, merr.ErrParameterInvalid)
 		require.ErrorContains(t, err, `field "offset" conflicts with the reserved REST search element offset field`)
 	})
-
 }
 
 func TestBuildQueryRespWithNullableCompactFields(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -1989,6 +1989,39 @@ func TestBuildSearchResp(t *testing.T) {
 		require.ErrorIs(t, err, merr.ErrParameterInvalid)
 		require.ErrorContains(t, err, `field "offset" conflicts with the reserved REST search element offset field`)
 	})
+
+	t.Run("trimmed requested element offset", func(t *testing.T) {
+		_, err := buildSearchResp(&schemapb.SearchResultData{
+			Ids:            generateIDs(schemapb.DataType_Int64, 1),
+			Scores:         DefaultScores[:1],
+			ElementIndices: &schemapb.LongArray{Data: []int64{0}},
+		}, []string{" offset "}, true, nil)
+		require.ErrorIs(t, err, merr.ErrParameterInvalid)
+		require.ErrorContains(t, err, `field "offset" conflicts with the reserved REST search element offset field`)
+	})
+
+	t.Run("explicit dynamic requested element offset", func(t *testing.T) {
+		schema := generateCollectionSchema(schemapb.DataType_Int64, false, true)
+		_, err := buildSearchResp(&schemapb.SearchResultData{
+			OutputFields: []string{common.MetaFieldName},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_JSON,
+					FieldName: common.MetaFieldName,
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_JsonData{JsonData: &schemapb.JSONArray{Data: [][]byte{[]byte(`{}`)}}},
+					}},
+					IsDynamic: true,
+				},
+			},
+			Ids:            generateIDs(schemapb.DataType_Int64, 1),
+			Scores:         DefaultScores[:1],
+			ElementIndices: &schemapb.LongArray{Data: []int64{0}},
+		}, []string{`$meta["offset"]`}, true, schema)
+		require.ErrorIs(t, err, merr.ErrParameterInvalid)
+		require.ErrorContains(t, err, `field "offset" conflicts with the reserved REST search element offset field`)
+	})
+
 }
 
 func TestBuildQueryRespWithNullableCompactFields(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -1887,6 +1887,24 @@ func TestBuildSearchResp(t *testing.T) {
 		require.ErrorContains(t, err, "element_indices length (1) does not match row count (2)")
 	})
 
+	t.Run("empty element offsets with rows", func(t *testing.T) {
+		_, err := buildSearchResp(&schemapb.SearchResultData{
+			Ids:            generateIDs(schemapb.DataType_Int64, 1),
+			Scores:         DefaultScores[:1],
+			ElementIndices: &schemapb.LongArray{},
+		}, true, nil)
+		require.ErrorIs(t, err, merr.ErrServiceInternal)
+		require.ErrorContains(t, err, "element_indices length (0) does not match row count (1)")
+	})
+
+	t.Run("empty element offsets without rows", func(t *testing.T) {
+		rows, err := buildSearchResp(&schemapb.SearchResultData{
+			ElementIndices: &schemapb.LongArray{},
+		}, true, nil)
+		require.NoError(t, err)
+		require.Empty(t, rows)
+	})
+
 	t.Run("primary key named offset", func(t *testing.T) {
 		_, err := buildSearchResp(&schemapb.SearchResultData{
 			Ids:            generateIDs(schemapb.DataType_Int64, 1),
@@ -1909,6 +1927,25 @@ func TestBuildSearchResp(t *testing.T) {
 					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
 						Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{42}}},
 					}},
+				},
+			},
+			ElementIndices: &schemapb.LongArray{Data: []int64{0}},
+		}, true, nil)
+		require.ErrorIs(t, err, merr.ErrParameterInvalid)
+		require.ErrorContains(t, err, `field "offset" conflicts with the reserved REST search element offset field`)
+	})
+
+	t.Run("absent dynamic output field named offset", func(t *testing.T) {
+		_, err := buildSearchResp(&schemapb.SearchResultData{
+			OutputFields: []string{HTTPReturnElementOffset},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_JSON,
+					FieldName: common.MetaFieldName,
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_JsonData{JsonData: &schemapb.JSONArray{Data: [][]byte{[]byte(`{}`)}}},
+					}},
+					IsDynamic: true,
 				},
 			},
 			ElementIndices: &schemapb.LongArray{Data: []int64{0}},

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -1855,6 +1855,39 @@ func TestBuildQueryResp(t *testing.T) {
 	assert.Equal(t, true, compareRows(rows, exceptRows, compareRow))
 }
 
+func TestBuildSearchResp(t *testing.T) {
+	t.Run("element offsets", func(t *testing.T) {
+		rows, err := buildSearchResp(&schemapb.SearchResultData{
+			Ids:            generateIDs(schemapb.DataType_Int64, 3),
+			Scores:         DefaultScores,
+			ElementIndices: &schemapb.LongArray{Data: []int64{0, 2, 1}},
+		}, true, nil)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), rows[0][HTTPReturnElementOffset])
+		require.Equal(t, int64(2), rows[1][HTTPReturnElementOffset])
+		require.Equal(t, int64(1), rows[2][HTTPReturnElementOffset])
+	})
+
+	t.Run("no element offsets", func(t *testing.T) {
+		rows, err := buildSearchResp(&schemapb.SearchResultData{
+			Ids:    generateIDs(schemapb.DataType_Int64, 1),
+			Scores: DefaultScores[:1],
+		}, true, nil)
+		require.NoError(t, err)
+		require.NotContains(t, rows[0], HTTPReturnElementOffset)
+	})
+
+	t.Run("mismatched element offsets", func(t *testing.T) {
+		_, err := buildSearchResp(&schemapb.SearchResultData{
+			Ids:            generateIDs(schemapb.DataType_Int64, 2),
+			Scores:         DefaultScores[:2],
+			ElementIndices: &schemapb.LongArray{Data: []int64{0}},
+		}, true, nil)
+		require.ErrorIs(t, err, merr.ErrServiceInternal)
+		require.ErrorContains(t, err, "element_indices length (1) does not match row count (2)")
+	})
+}
+
 func TestBuildQueryRespWithNullableCompactFields(t *testing.T) {
 	t.Run("nullable vector derives logical rows from ValidData", func(t *testing.T) {
 		fieldData := &schemapb.FieldData{

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -1886,6 +1886,36 @@ func TestBuildSearchResp(t *testing.T) {
 		require.ErrorIs(t, err, merr.ErrServiceInternal)
 		require.ErrorContains(t, err, "element_indices length (1) does not match row count (2)")
 	})
+
+	t.Run("primary key named offset", func(t *testing.T) {
+		_, err := buildSearchResp(&schemapb.SearchResultData{
+			Ids:            generateIDs(schemapb.DataType_Int64, 1),
+			Scores:         DefaultScores[:1],
+			ElementIndices: &schemapb.LongArray{Data: []int64{0}},
+		}, true, &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+			{Name: HTTPReturnElementOffset, IsPrimaryKey: true},
+		}})
+		require.ErrorIs(t, err, merr.ErrParameterInvalid)
+		require.ErrorContains(t, err, `field "offset" conflicts with the reserved REST search element offset field`)
+	})
+
+	t.Run("output field named offset", func(t *testing.T) {
+		_, err := buildSearchResp(&schemapb.SearchResultData{
+			OutputFields: []string{HTTPReturnElementOffset},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Int64,
+					FieldName: HTTPReturnElementOffset,
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{42}}},
+					}},
+				},
+			},
+			ElementIndices: &schemapb.LongArray{Data: []int64{0}},
+		}, true, nil)
+		require.ErrorIs(t, err, merr.ErrParameterInvalid)
+		require.ErrorContains(t, err, `field "offset" conflicts with the reserved REST search element offset field`)
+	})
 }
 
 func TestBuildQueryRespWithNullableCompactFields(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -1861,7 +1861,7 @@ func TestBuildSearchResp(t *testing.T) {
 			Ids:            generateIDs(schemapb.DataType_Int64, 3),
 			Scores:         DefaultScores,
 			ElementIndices: &schemapb.LongArray{Data: []int64{0, 2, 1}},
-		}, true, nil)
+		}, nil, true, nil)
 		require.NoError(t, err)
 		require.Equal(t, int64(0), rows[0][HTTPReturnElementOffset])
 		require.Equal(t, int64(2), rows[1][HTTPReturnElementOffset])
@@ -1872,9 +1872,26 @@ func TestBuildSearchResp(t *testing.T) {
 		rows, err := buildSearchResp(&schemapb.SearchResultData{
 			Ids:    generateIDs(schemapb.DataType_Int64, 1),
 			Scores: DefaultScores[:1],
-		}, true, nil)
+		}, nil, true, nil)
 		require.NoError(t, err)
 		require.NotContains(t, rows[0], HTTPReturnElementOffset)
+	})
+
+	t.Run("requested offset field without element offsets", func(t *testing.T) {
+		rows, err := buildSearchResp(&schemapb.SearchResultData{
+			OutputFields: []string{HTTPReturnElementOffset},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Int64,
+					FieldName: HTTPReturnElementOffset,
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{42}}},
+					}},
+				},
+			},
+		}, []string{HTTPReturnElementOffset}, true, nil)
+		require.NoError(t, err)
+		require.Equal(t, int64(42), rows[0][HTTPReturnElementOffset])
 	})
 
 	t.Run("mismatched element offsets", func(t *testing.T) {
@@ -1882,7 +1899,7 @@ func TestBuildSearchResp(t *testing.T) {
 			Ids:            generateIDs(schemapb.DataType_Int64, 2),
 			Scores:         DefaultScores[:2],
 			ElementIndices: &schemapb.LongArray{Data: []int64{0}},
-		}, true, nil)
+		}, nil, true, nil)
 		require.ErrorIs(t, err, merr.ErrServiceInternal)
 		require.ErrorContains(t, err, "element_indices length (1) does not match row count (2)")
 	})
@@ -1892,7 +1909,7 @@ func TestBuildSearchResp(t *testing.T) {
 			Ids:            generateIDs(schemapb.DataType_Int64, 1),
 			Scores:         DefaultScores[:1],
 			ElementIndices: &schemapb.LongArray{},
-		}, true, nil)
+		}, nil, true, nil)
 		require.ErrorIs(t, err, merr.ErrServiceInternal)
 		require.ErrorContains(t, err, "element_indices length (0) does not match row count (1)")
 	})
@@ -1900,7 +1917,7 @@ func TestBuildSearchResp(t *testing.T) {
 	t.Run("empty element offsets without rows", func(t *testing.T) {
 		rows, err := buildSearchResp(&schemapb.SearchResultData{
 			ElementIndices: &schemapb.LongArray{},
-		}, true, nil)
+		}, nil, true, nil)
 		require.NoError(t, err)
 		require.Empty(t, rows)
 	})
@@ -1910,7 +1927,7 @@ func TestBuildSearchResp(t *testing.T) {
 			Ids:            generateIDs(schemapb.DataType_Int64, 1),
 			Scores:         DefaultScores[:1],
 			ElementIndices: &schemapb.LongArray{Data: []int64{0}},
-		}, true, &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		}, nil, true, &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
 			{Name: HTTPReturnElementOffset, IsPrimaryKey: true},
 		}})
 		require.ErrorIs(t, err, merr.ErrParameterInvalid)
@@ -1930,7 +1947,7 @@ func TestBuildSearchResp(t *testing.T) {
 				},
 			},
 			ElementIndices: &schemapb.LongArray{Data: []int64{0}},
-		}, true, nil)
+		}, nil, true, nil)
 		require.ErrorIs(t, err, merr.ErrParameterInvalid)
 		require.ErrorContains(t, err, `field "offset" conflicts with the reserved REST search element offset field`)
 	})
@@ -1949,7 +1966,26 @@ func TestBuildSearchResp(t *testing.T) {
 				},
 			},
 			ElementIndices: &schemapb.LongArray{Data: []int64{0}},
-		}, true, nil)
+		}, nil, true, nil)
+		require.ErrorIs(t, err, merr.ErrParameterInvalid)
+		require.ErrorContains(t, err, `field "offset" conflicts with the reserved REST search element offset field`)
+	})
+
+	t.Run("requested dynamic output field lost after reconstruction", func(t *testing.T) {
+		_, err := buildSearchResp(&schemapb.SearchResultData{
+			OutputFields: []string{common.MetaFieldName},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_JSON,
+					FieldName: common.MetaFieldName,
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_JsonData{JsonData: &schemapb.JSONArray{Data: [][]byte{[]byte(`{}`)}}},
+					}},
+					IsDynamic: true,
+				},
+			},
+			ElementIndices: &schemapb.LongArray{Data: []int64{0}},
+		}, []string{HTTPReturnElementOffset}, true, nil)
 		require.ErrorIs(t, err, merr.ErrParameterInvalid)
 		require.ErrorContains(t, err, `field "offset" conflicts with the reserved REST search element offset field`)
 	})

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -1067,6 +1067,9 @@ func (t *searchTask) initSearchRequest(ctx context.Context) error {
 	annsField := typeutil.GetField(t.schema.CollectionSchema, t.FieldId)
 	if annsField != nil && annsField.GetDataType() == schemapb.DataType_ArrayOfVector {
 		isEmbList := isEmbeddingListPlaceholderType(placeholderType)
+		if err := validateSearchAggregationTopHitsElementOffsets(t.aggCtx, annsField, placeholderType); err != nil {
+			return err
+		}
 
 		if isEmbList {
 			if gjson.Get(queryInfo.GetSearchParams(), radiusKey).Exists() {
@@ -1325,6 +1328,24 @@ func isEmbeddingListPlaceholderType(pt commonpb.PlaceholderType) bool {
 	default:
 		return false
 	}
+}
+
+func validateSearchAggregationTopHitsElementOffsets(
+	aggCtx *search_agg.SearchAggregationContext,
+	annsField *schemapb.FieldSchema,
+	placeholderType commonpb.PlaceholderType,
+) error {
+	if aggCtx == nil || annsField == nil || annsField.GetDataType() != schemapb.DataType_ArrayOfVector || isEmbeddingListPlaceholderType(placeholderType) {
+		return nil
+	}
+	for _, level := range aggCtx.Levels {
+		if level.TopHits != nil {
+			return merr.WrapErrParameterInvalidMsg(
+				"search_aggregation top_hits is not supported for element-level search on ArrayOfVector fields because element offsets cannot be represented",
+			)
+		}
+	}
+	return nil
 }
 
 func validateElementFilterVectorSearch(plan *planpb.PlanNode, schema *schemapb.CollectionSchema, fieldID int64, placeholderType commonpb.PlaceholderType) error {

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -6563,6 +6563,72 @@ func TestIsEmbeddingListPlaceholderType(t *testing.T) {
 	}
 }
 
+func TestValidateSearchAggregationTopHitsElementOffsets(t *testing.T) {
+	arrayOfVectorField := &schemapb.FieldSchema{DataType: schemapb.DataType_ArrayOfVector}
+	regularVectorField := &schemapb.FieldSchema{DataType: schemapb.DataType_FloatVector}
+	withTopHits := &search_agg.SearchAggregationContext{
+		Levels: []search_agg.LevelContext{{}, {TopHits: &search_agg.TopHitsConfig{Size: 1}}},
+	}
+	withoutTopHits := &search_agg.SearchAggregationContext{
+		Levels: []search_agg.LevelContext{{}},
+	}
+
+	testCases := []struct {
+		name            string
+		aggCtx          *search_agg.SearchAggregationContext
+		annsField       *schemapb.FieldSchema
+		placeholderType commonpb.PlaceholderType
+		wantErr         bool
+	}{
+		{
+			name:            "element-level top hits",
+			aggCtx:          withTopHits,
+			annsField:       arrayOfVectorField,
+			placeholderType: commonpb.PlaceholderType_FloatVector,
+			wantErr:         true,
+		},
+		{
+			name:            "element-level aggregation without top hits",
+			aggCtx:          withoutTopHits,
+			annsField:       arrayOfVectorField,
+			placeholderType: commonpb.PlaceholderType_FloatVector,
+		},
+		{
+			name:            "embedding-list top hits",
+			aggCtx:          withTopHits,
+			annsField:       arrayOfVectorField,
+			placeholderType: commonpb.PlaceholderType_EmbListFloatVector,
+		},
+		{
+			name:            "regular vector top hits",
+			aggCtx:          withTopHits,
+			annsField:       regularVectorField,
+			placeholderType: commonpb.PlaceholderType_FloatVector,
+		},
+		{
+			name:            "no aggregation",
+			annsField:       arrayOfVectorField,
+			placeholderType: commonpb.PlaceholderType_FloatVector,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := validateSearchAggregationTopHitsElementOffsets(
+				testCase.aggCtx,
+				testCase.annsField,
+				testCase.placeholderType,
+			)
+			if testCase.wantErr {
+				require.ErrorIs(t, err, merr.ErrParameterInvalid)
+				require.ErrorContains(t, err, "element offsets cannot be represented")
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestSearchTask_ArrayOfVectorGroupBy(t *testing.T) {
 	paramtable.Init()
 	ctx := context.Background()
@@ -6681,6 +6747,25 @@ func TestSearchTask_ArrayOfVectorGroupBy(t *testing.T) {
 		task := makeTask("emb_vec", "", commonpb.PlaceholderType_FloatVector)
 		err := task.initSearchRequest(ctx)
 		assert.NoError(t, err)
+	})
+
+	t.Run("element-level search aggregation top hits should fail", func(t *testing.T) {
+		task := makeTask("emb_vec", "", commonpb.PlaceholderType_FloatVector)
+		aggCtx, err := search_agg.NewContext(1, []search_agg.LevelContext{
+			{
+				OwnFieldIDs: []int64{100},
+				Size:        1,
+				SearchSize:  1,
+				TopHits:     &search_agg.TopHitsConfig{Size: 1},
+			},
+		}, nil, nil)
+		require.NoError(t, err)
+		task.aggCtx = aggCtx
+		task.GroupByFieldIds = []int64{100}
+
+		err = task.initSearchRequest(ctx)
+		require.ErrorIs(t, err, merr.ErrParameterInvalid)
+		require.ErrorContains(t, err, "element offsets cannot be represented")
 	})
 
 	t.Run("regular vector with group by non-PK should succeed", func(t *testing.T) {

--- a/tests/restful_client_v2/testcases/test_vector_operations.py
+++ b/tests/restful_client_v2/testcases/test_vector_operations.py
@@ -3616,6 +3616,108 @@ class TestHybridSearchVector(TestBase):
         assert rsp["code"] == 0
         assert len(rsp["data"]) == 10
 
+    @pytest.mark.parametrize("dim", [128])
+    def test_hybrid_search_struct_array_vector_returns_element_offset(self, dim):
+        """
+        target: test element offsets in REST v2 Struct Array hybrid search results
+        method: hybrid search an ArrayOfVector sub-field and group hits by the row primary key
+        expected: each row-level hit returns the offset of its selected Struct Array element
+        """
+        # create a collection
+        name = gen_collection_name()
+        self.name = name
+        payload = {
+            "collectionName": name,
+            "schema": {
+                "autoId": False,
+                "enableDynamicField": False,
+                "fields": [
+                    {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True},
+                ],
+                "structFields": [
+                    {
+                        "fieldName": "objects",
+                        "typeParams": {"max_capacity": "2"},
+                        "fields": [
+                            {
+                                "fieldName": "embedding",
+                                "dataType": "ArrayOfVector",
+                                "elementDataType": "FloatVector",
+                                "elementTypeParams": {
+                                    "dim": f"{dim}",
+                                    "max_capacity": "2",
+                                },
+                            }
+                        ],
+                    }
+                ],
+            },
+            "indexParams": [
+                {
+                    "fieldName": "objects[embedding]",
+                    "indexName": "objects_embedding",
+                    "indexType": "HNSW",
+                    "metricType": "COSINE",
+                    "params": {"M": 8, "efConstruction": 64},
+                }
+            ],
+            "params": {"consistencyLevel": "Strong"},
+        }
+        rsp = self.collection_client.collection_create(payload)
+        assert rsp["code"] == 0
+        self.wait_load_completed(name, timeout=60)
+
+        # insert data
+        query_vector = [1.0] + [0.0] * (dim - 1)
+        negative_vector = [-1.0] + [0.0] * (dim - 1)
+        orthogonal_vector = [0.0, 1.0] + [0.0] * (dim - 2)
+        data = [
+            {
+                "book_id": 1,
+                "objects": [
+                    {"embedding": negative_vector},
+                    {"embedding": query_vector},
+                ],
+            },
+            {
+                "book_id": 2,
+                "objects": [
+                    {"embedding": orthogonal_vector},
+                ],
+            },
+        ]
+        rsp = self.vector_client.vector_insert({"collectionName": name, "data": data})
+        assert rsp["code"] == 0
+        assert rsp["data"]["insertCount"] == len(data)
+
+        rsp = self.collection_client.flush(name)
+        assert rsp["code"] == 0
+
+        # hybrid search with Struct Array vector sub-field
+        search = {
+            "data": [query_vector],
+            "annsField": "objects[embedding]",
+            "metricType": "COSINE",
+            "limit": 3,
+            "params": {"ef": 32},
+        }
+        payload = {
+            "collectionName": name,
+            "search": [search, search],
+            "rerank": {
+                "strategy": "weighted",
+                "params": {"weights": [0.5, 0.5], "norm_score": True},
+            },
+            "limit": 2,
+            "outputFields": ["book_id"],
+            "groupingField": "book_id",
+            "consistencyLevel": "Strong",
+        }
+        rsp = self.vector_client.vector_hybrid_search(payload)
+        assert rsp["code"] == 0
+        assert rsp["topks"] == [2]
+        assert [(hit["book_id"], hit["offset"]) for hit in rsp["data"]] == [(1, 1), (2, 0)]
+
     @pytest.mark.xfail(reason="issue: https://github.com/milvus-io/milvus/issues/50396")
     def test_minhash_hybrid_search_with_partition(self):
         """


### PR DESCRIPTION
issue: #52135

## What this PR does

- Exposes `SearchResultData.element_indices` as `offset` on each REST v2 search hit.
- Covers both `/v2/vectordb/entities/search` and `/v2/vectordb/entities/hybrid_search`.
- Leaves non-element-level search responses unchanged.
- Returns an internal error if element offsets are not aligned with serialized hits.
- Adds handler, conversion, and RESTful v2 E2E regression coverage.

## Why

The search pipeline preserves Struct Array element indices through search, hybrid reranking, and group-by. The REST v2 response conversion previously serialized IDs, scores, and output fields without element indices, so callers could identify the row but not the matched Struct Array element.

## Tests

- `TestSearchV2ReturnsElementOffsets`
- `TestBuildSearchResp`
- Full `internal/distributed/proxy/httpserver` Go unit-test package
- `tests/restful_client_v2/testcases/test_vector_operations.py::TestHybridSearchVector::test_hybrid_search_struct_array_vector_returns_element_offset[128]`
