### PR TITLE
fix: [3.0]Raise bcrypt password hashing cost

### DIFF
--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -1151,6 +1151,32 @@ func TestPasswordVerify(t *testing.T) {
 	assert.Equal(t, 2, invokedCount)
 }
 
+func BenchmarkPasswordVerifyCacheHit(b *testing.B) {
+	ctx := context.Background()
+	const (
+		username = "benchmark-user"
+		password = "benchmark-password"
+	)
+
+	privilege.ResetPrivilegeCacheForTest()
+	b.Cleanup(privilege.ResetPrivilegeCacheForTest)
+	require.NoError(b, privilege.InitPrivilegeCache(ctx, NewMixCoordMock()))
+
+	privilegeCache := privilege.GetPrivilegeCache()
+	privilegeCache.UpdateCredential(&internalpb.CredentialInfo{
+		Username:       username,
+		Sha256Password: crypto.SHA256(password, username),
+	})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !passwordVerify(ctx, username, password, privilegeCache) {
+			b.Fatal("cached password verification failed")
+		}
+	}
+}
+
 func Test_isCollectionIsLoaded(t *testing.T) {
 	ctx := context.Background()
 	t.Run("normal", func(t *testing.T) {

--- a/pkg/util/crypto/crypto.go
+++ b/pkg/util/crypto/crypto.go
@@ -20,7 +20,7 @@ func SHA256(src string, salt string) string {
 
 // PasswordEncrypt encrypt password
 func PasswordEncrypt(pwd string) (string, error) {
-	bytes, err := bcrypt.GenerateFromPassword([]byte(pwd), bcrypt.MinCost)
+	bytes, err := bcrypt.GenerateFromPassword([]byte(pwd), bcrypt.DefaultCost)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/util/crypto/crypto_test.go
+++ b/pkg/util/crypto/crypto_test.go
@@ -10,39 +10,83 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-//func BenchmarkPasswordVerify(b *testing.B) {
-//	correctPassword := "test_my_pass_new"
-//	credInfo := &internalpb.CredentialInfo{
-//		Username:       "root",
-//		Sha256Password: "bcca79df9650cef1d7ed9f63449d7f8a27843d2678f5666f38ca65ab77d99a13",
-//	}
-//	b.ResetTimer()
-//	for n := 0; n < b.N; n++ {
-//		PasswordVerify(correctPassword, credInfo)
-//	}
-//}
+func TestPasswordEncryptUsesDefaultBcryptCost(t *testing.T) {
+	encryptedPassword, err := PasswordEncrypt("test-password")
+	require.NoError(t, err)
 
-func TestBcryptCompare(t *testing.T) {
-	wrongPassword := "test_my_name"
-	correctPassword := "test_my_pass_new"
-
-	err := bcrypt.CompareHashAndPassword([]byte("$2a$10$3H9DLiHyPxJ29bMWRNyueOrGkbzJfE3BAR159ju3UetytAoKk7Ne2"), []byte(correctPassword))
-	assert.NoError(t, err)
-
-	err = bcrypt.CompareHashAndPassword([]byte("$2a$10$3H9DLiHyPxJ29bMWRNyueOrGkbzJfE3BAR159ju3UetytAoKk7Ne2"), []byte(wrongPassword))
-	assert.Error(t, err)
+	cost, err := bcrypt.Cost([]byte(encryptedPassword))
+	require.NoError(t, err)
+	assert.Equal(t, bcrypt.DefaultCost, cost)
+	assert.GreaterOrEqual(t, cost, 10)
 }
 
-func TestBcryptCost(t *testing.T) {
-	correctPassword := "test_my_pass_new"
+func TestPasswordEncryptVerification(t *testing.T) {
+	password := "test-password"
+	encryptedPassword, err := PasswordEncrypt(password)
+	require.NoError(t, err)
 
-	bytes, _ := bcrypt.GenerateFromPassword([]byte(correctPassword), bcrypt.DefaultCost)
-	err := bcrypt.CompareHashAndPassword(bytes, []byte(correctPassword))
-	assert.NoError(t, err)
+	assert.NoError(t, bcrypt.CompareHashAndPassword([]byte(encryptedPassword), []byte(password)))
+	assert.Error(t, bcrypt.CompareHashAndPassword([]byte(encryptedPassword), []byte("wrong-password")))
+}
 
-	bytes, _ = bcrypt.GenerateFromPassword([]byte(correctPassword), bcrypt.MinCost)
-	err = bcrypt.CompareHashAndPassword(bytes, []byte(correctPassword))
-	assert.NoError(t, err)
+func TestPasswordEncryptSupportsLegacyBcryptHash(t *testing.T) {
+	const legacyHash = "$2a$04$FDqkwIegT7SfTGRcPyQjk.reG7poJ99Two1jsl2euNBy0Z.e1DiR."
+
+	cost, err := bcrypt.Cost([]byte(legacyHash))
+	require.NoError(t, err)
+	assert.Equal(t, bcrypt.MinCost, cost)
+	assert.NoError(t, bcrypt.CompareHashAndPassword([]byte(legacyHash), []byte("legacy-password")))
+}
+
+func BenchmarkPasswordHashGeneration(b *testing.B) {
+	benchmarkBcryptCosts(b, func(b *testing.B, cost int) {
+		for i := 0; i < b.N; i++ {
+			if _, err := bcrypt.GenerateFromPassword([]byte("benchmark-password"), cost); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkPasswordHashComparison(b *testing.B) {
+	benchmarkBcryptCosts(b, func(b *testing.B, cost int) {
+		hash, err := bcrypt.GenerateFromPassword([]byte("benchmark-password"), cost)
+		require.NoError(b, err)
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			if err := bcrypt.CompareHashAndPassword(hash, []byte("benchmark-password")); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkPasswordHashComparisonParallel(b *testing.B) {
+	benchmarkBcryptCosts(b, func(b *testing.B, cost int) {
+		hash, err := bcrypt.GenerateFromPassword([]byte("benchmark-password"), cost)
+		require.NoError(b, err)
+		b.ResetTimer()
+
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				if err := bcrypt.CompareHashAndPassword(hash, []byte("benchmark-password")); err != nil {
+					b.Error(err)
+					return
+				}
+			}
+		})
+	})
+}
+
+func benchmarkBcryptCosts(b *testing.B, benchmark func(b *testing.B, cost int)) {
+	b.Helper()
+	for _, cost := range []int{bcrypt.MinCost, bcrypt.DefaultCost} {
+		b.Run(fmt.Sprintf("cost_%d", cost), func(b *testing.B) {
+			b.ReportAllocs()
+			benchmark(b, cost)
+		})
+	}
 }
 
 func TestMD5(t *testing.T) {


### PR DESCRIPTION
Use bcrypt.DefaultCost for every password hash produced by the shared Milvus helper. Existing cost-4 hashes remain valid; operators must rotate root, user, and automation credentials to replace legacy hashes because upgrade alone does not rewrite them. No migration, configuration, password-policy, or authentication-cache behavior changes are included.

Add regression coverage for cost 10, correct and incorrect passwords, and a fixed legacy cost-4 hash. Add generation, sequential comparison, parallel comparison, and SHA-256 cache-hit benchmarks.

Benchmark environment: Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz, Go 1.26.5, golang.org/x/crypto v0.52.0.

Benchmark commands:
cd pkg && go test -run '^$' -bench '^BenchmarkPasswordHash' -benchtime=1s -count=1 ./util/crypto
source scripts/setenv.sh && LOCAL_STORAGE_PATH=/tmp/milvus-test go test -tags dynamic,test -gcflags="all=-N -l" -run '^$' -bench '^BenchmarkPasswordVerifyCacheHit$' -benchtime=2s -count=1 ./internal/proxy

Benchmark results:

| Benchmark | Cost 4 | Cost 10 |
|---|---:|---:|
| Hash generation | 821,517 ns/op (0.82 ms) | 49,841,925 ns/op (49.84 ms) |
| Sequential comparison | 816,080 ns/op (0.82 ms) | 49,879,185 ns/op (49.88 ms) |
| Parallel comparison | 79,448 ns/op (79.45 µs) | 4,698,072 ns/op (4.70 ms) |

SHA-256 authentication cache hit: **669.2 ns/op (0.67 µs)**.

Cost 10 bcrypt is roughly **60× slower** than cost 4. Cache-hit verification is roughly **74,500× faster** than sequential cost-10 comparison.

issue: #52142
pr: #52144
Signed-off-by: yangxuan <xuan.yang@zilliz.com>
