### PR TITLE
fix: preserve commit_timestamp through clustering compaction

### DIFF
--- a/internal/datanode/compactor/clustering_compactor.go
+++ b/internal/datanode/compactor/clustering_compactor.go
@@ -497,16 +497,8 @@ func (t *clusteringCompactionTask) mapping(ctx context.Context,
 	mapStart := time.Now()
 	futures := make([]*conc.Future[any], 0, len(inputSegments))
 	for _, segment := range inputSegments {
-		segmentClone := &datapb.CompactionSegmentBinlogs{
-			SegmentID: segment.SegmentID,
-			// only FieldBinlogs and deltalogs needed
-			Deltalogs:      segment.Deltalogs,
-			FieldBinlogs:   segment.FieldBinlogs,
-			StorageVersion: segment.StorageVersion,
-			Manifest:       segment.GetManifest(),
-		}
 		future := t.mappingPool.Submit(func() (any, error) {
-			err := t.mappingSegment(ctx, segmentClone)
+			err := t.mappingSegment(ctx, segment)
 			return struct{}{}, err
 		})
 		futures = append(futures, future)

--- a/internal/datanode/compactor/clustering_compactor.go
+++ b/internal/datanode/compactor/clustering_compactor.go
@@ -618,6 +618,7 @@ func (t *clusteringCompactionTask) mappingSegment(
 		return err
 	}
 	rr = newMaterializedRecordReader(rr, materializer)
+	rr = wrapReaderWithTimestampOverwrite(rr, segment.GetCommitTimestamp())
 	defer rr.Close()
 
 	hasTTLField := t.ttlFieldID >= common.StartOfUserFieldID
@@ -657,12 +658,6 @@ func (t *clusteringCompactionTask) mappingSegment(
 			}
 			if entityFilter.Filtered(v.PK.GetValue(), uint64(v.Timestamp), expireTs) {
 				continue
-			}
-
-			// Normalize import segment timestamps: overwrite to commit_ts
-			// so the output segment becomes a normal segment (commit_ts = 0).
-			if commitTs := segment.GetCommitTimestamp(); commitTs != 0 {
-				v.Timestamp = int64(commitTs)
 			}
 
 			clusteringKey := row[t.clusteringKeyField.FieldID]

--- a/internal/datanode/compactor/clustering_compactor_test.go
+++ b/internal/datanode/compactor/clustering_compactor_test.go
@@ -537,6 +537,32 @@ func (s *ClusteringCompactionTaskSuite) TestScalarAnalyzeSegmentFiltersDroppedOr
 	s.Equal(map[interface{}]int64{"varchar": 2}, analyzeResult)
 }
 
+// An import segment committed at birthday+2s carries a deltalog entry deleting
+// PK=100 at birthday+1s. That delete predates the commit, so it must not remove
+// the row, and every output row timestamp must be normalized to commit_ts.
+func (s *ClusteringCompactionTaskSuite) TestScalarCompactionPreservesImportCommitTimestamp() {
+	s.preparScalarCompactionNormalTask()
+	commitTs := tsoutil.ComposeTSByTime(getMilvusBirthday().Add(2 * time.Second))
+	s.plan.SegmentBinlogs[0].CommitTimestamp = commitTs
+	s.task.compactionParams = compaction.GenParams()
+
+	compactionResult, err := s.task.Compact()
+	s.Require().NoError(err)
+
+	s.EqualValues(10240, lo.SumBy(compactionResult.GetSegments(), func(seg *datapb.CompactionSegment) int64 {
+		return seg.GetNumOfRows()
+	}))
+
+	for _, seg := range compactionResult.GetSegments() {
+		for _, fieldBinlog := range seg.GetInsertLogs() {
+			for _, b := range fieldBinlog.GetBinlogs() {
+				s.EqualValues(commitTs, b.GetTimestampFrom())
+				s.EqualValues(commitTs, b.GetTimestampTo())
+			}
+		}
+	}
+}
+
 func genRow(magic int64) map[int64]interface{} {
 	ts := tsoutil.ComposeTSByTime(getMilvusBirthday())
 	return map[int64]interface{}{


### PR DESCRIPTION
issue: #52149

## Summary

Clustering compaction handed `mappingSegment()` a hand-built partial copy of `CompactionSegmentBinlogs` that omitted `CommitTimestamp`, so every consumer inside saw 0. Two things went wrong as a result.

**Deletes that predate the commit were applied.** `NewEntityFilter` received `commit_ts = 0`, so `isEntityDeleted` compared delete timestamps against stale row timestamps rather than `max(row_ts, commit_ts)`. Rows an import had legitimately written were dropped while compaction reported success and DataCoord marked the inputs dropped.

**Row-timestamp normalization never reached storage.** It assigned `v.Timestamp`, but `storage.ValueSerializer` builds every column from `vv.Value` and never reads `vv.Timestamp` — the two are separate copies produced at deserialization. Output rows kept stale timestamps even though `completeClusterCompactionMutation` clears `commit_timestamp` on the output on the assumption that they were rewritten, so the output segment lost commit_ts protection permanently.

## Changes

- Drop the partial copy and pass the plan's segment straight to `mappingSegment()`. The copy was shallow — it shared the same `FieldBinlogs`/`Deltalogs` slices and `*datapb.Binlog` pointers, and binlog paths are already materialized in place by `DecompressCompactionBinlogsWithRootPath` at the top of `Compact()` — so it isolated nothing while making it easy to forget a field.
- Replace the ineffective per-value assignment with `wrapReaderWithTimestampOverwrite`, nested exactly as `sort_compaction.go` does it, so the timestamp column itself is rewritten and the entity filter, the stats and the writer all observe one value.

## Test Plan

- [x] New unit test asserts both halves: the pre-commit delete does not remove its row (10240 rows, not 10239), and every output binlog carries `timestamp_from == timestamp_to == commit_ts`. Both assertions fail on master. Removing only the missing field turns the first green and leaves the second red, which is why both are needed.
- [x] `internal/datanode/compactor` and `internal/compaction` package tests pass. Segments with `commit_timestamp == 0` take an unchanged path: `wrapReaderWithTimestampOverwrite` returns the reader untouched when the value is 0.
- [x] `make static-check` clean across core, pkg, client and go_client.
- [x] Audited every construction site of `CompactionSegmentBinlogs` (7 in total) and the `SegmentLoadInfo` chain; this copy was the only place losing the field.
- [ ] Not verified end to end on a live cluster. The delete and TTL failure modes were traced by hand and reproduced in unit tests only.

## Note for reviewers

`DataNodeCompactionMissingDeleteCount` will now count pre-commit deletes on import segments as missing, because they are correctly not applied. Mix compaction already behaves this way; this is expected, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)