### PR TITLE
fix: preserve described generic index type

### DIFF
--- a/client/index/index.go
+++ b/client/index/index.go
@@ -76,7 +76,8 @@ func (gi GenericIndex) WithMetricType(metricType MetricType) {
 func NewGenericIndex(name string, params map[string]string) GenericIndex {
 	return GenericIndex{
 		baseIndex: baseIndex{
-			name: name,
+			name:      name,
+			indexType: IndexType(params[IndexTypeKey]),
 		},
 		params: params,
 	}

--- a/client/index/index_test.go
+++ b/client/index/index_test.go
@@ -25,7 +25,18 @@ import (
 )
 
 func TestGenericIndex(t *testing.T) {
-	// idx := NewGenericIndex("auto_scalar_index")
+	params := map[string]string{
+		IndexTypeKey: string(FMINDEX),
+		"custom_key": "custom_value",
+	}
+	idx := NewGenericIndex("fm_index", params)
+
+	assert.Equal(t, "fm_index", idx.Name())
+	assert.EqualValues(t, FMINDEX, idx.IndexType())
+	assert.Equal(t, params, idx.Params())
+
+	idxWithoutType := NewGenericIndex("legacy_index", map[string]string{"custom_key": "custom_value"})
+	assert.Empty(t, idxWithoutType.IndexType())
 }
 
 func TestWithExtraIndexParams(t *testing.T) {

--- a/client/milvusclient/index_test.go
+++ b/client/milvusclient/index_test.go
@@ -151,15 +151,17 @@ func (s *IndexSuite) TestDescribeIndex() {
 				Status: merr.Success(),
 				IndexDescriptions: []*milvuspb.IndexDescription{
 					{IndexName: indexName, Params: []*commonpb.KeyValuePair{
-						{Key: index.IndexTypeKey, Value: string(index.HNSW)},
+						{Key: index.IndexTypeKey, Value: string(index.FMINDEX)},
 					}},
 				},
 			}, nil
 		}).Once()
 
-		index, err := s.client.DescribeIndex(ctx, NewDescribeIndexOption(collectionName, indexName))
+		indexDesc, err := s.client.DescribeIndex(ctx, NewDescribeIndexOption(collectionName, indexName))
 		s.NoError(err)
-		s.Equal(indexName, index.Name())
+		s.Equal(indexName, indexDesc.Name())
+		s.EqualValues(index.FMINDEX, indexDesc.IndexType())
+		s.EqualValues(index.FMINDEX, indexDesc.Params()[index.IndexTypeKey])
 	})
 
 	s.Run("no_index_found", func() {


### PR DESCRIPTION
issue: #52095

Follow-up to #52098.

## What changed

- Populate `GenericIndex`'s `indexType` from `params[index_type]`.
- Add constructor-level coverage for present and absent `index_type` values.
- Extend the `DescribeIndex` client test to verify the server-returned type reaches `IndexType()`.

## Why

`Client.DescribeIndex` converts the server response into `NewGenericIndex(name, params)`. The constructor previously copied only the name, so `IndexType()` returned an empty string even though `Params()["index_type"]` contained the correct value. This affected every index returned through this path, including FMINDEX and HNSW.

## Verification

- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./index ./milvusclient`
- `go vet -tags dynamic,test ./index ./milvusclient`
- Live check against local Milvus on port 19540 using a temporary empty FMINDEX: `IndexType() == "FMINDEX"` and `Params()["index_type"] == "FMINDEX"`; the temporary collection was removed afterward.
