### PR TITLE
fix: route Tantivy logs through Milvus logging

### DIFF
--- a/internal/core/src/common/logging_c.cpp
+++ b/internal/core/src/common/logging_c.cpp
@@ -169,7 +169,7 @@ InitGoogleLoggingWithoutZapSink() {
         return;
     }
     google::InitGoogleLogging("milvus");
-    // log is caught by zap, so we don't need to log to stderr/stdout/files anymore.
+    // No Zap sink is installed, so route glog output to stdout.
     FLAGS_logtostdout = true;
     FLAGS_logtostderr = false;
     FLAGS_alsologtostderr = false;

--- a/internal/core/src/common/logging_c.cpp
+++ b/internal/core/src/common/logging_c.cpp
@@ -18,9 +18,11 @@
 
 #include <glog/logging.h>
 #include <string.h>
+#include <cstdint>
 #include <string>
 
 #include "glog/log_severity.h"
+#include "tantivy-binding.h"
 
 #ifdef WITHOUT_GO_LOGGING
 
@@ -32,6 +34,19 @@ goZapLogExt(int severity,
             int line,
             const char* msg,
             int msg_len) {
+}
+
+// Go logging is optional in C++ unit-test binaries. This weak fallback tells
+// Rust to keep using env_logger when no Go implementation is linked.
+extern "C" bool __attribute__((weak)) goZapLogTantivy(int severity,
+                                                      const char* target,
+                                                      uintptr_t target_len,
+                                                      const char* file,
+                                                      uintptr_t file_len,
+                                                      uint32_t line,
+                                                      const char* msg,
+                                                      uintptr_t msg_len) {
+    return false;
 }
 
 #elif defined(__APPLE__)
@@ -47,6 +62,17 @@ extern "C" void __attribute__((weak)) goZapLogExt(int severity,
                                                   int msg_len) {
 }
 
+extern "C" bool __attribute__((weak)) goZapLogTantivy(int severity,
+                                                      const char* target,
+                                                      uintptr_t target_len,
+                                                      const char* file,
+                                                      uintptr_t file_len,
+                                                      uint32_t line,
+                                                      const char* msg,
+                                                      uintptr_t msg_len) {
+    return false;
+}
+
 #else
 
 // Go export function.
@@ -59,7 +85,36 @@ goZapLogExt(int severity,
             const char* msg,
             int msg_len);
 
+extern "C" bool
+goZapLogTantivy(int severity,
+                const char* target,
+                uintptr_t target_len,
+                const char* file,
+                uintptr_t file_len,
+                uint32_t line,
+                const char* msg,
+                uintptr_t msg_len);
+
 #endif
+
+static bool
+TantivyLog(TantivyLogLevel severity,
+           const char* target,
+           uintptr_t target_len,
+           const char* file,
+           uintptr_t file_len,
+           uint32_t line,
+           const char* msg,
+           uintptr_t msg_len) {
+    return goZapLogTantivy(static_cast<int>(severity),
+                           target,
+                           target_len,
+                           file,
+                           file_len,
+                           line,
+                           msg,
+                           msg_len);
+}
 
 class GoZapSink : public google::LogSink {
     void
@@ -93,13 +148,14 @@ static GoZapSink g_sink;
 extern "C" {
 void
 InitGoogleLoggingWithZapSink() {
+    tantivy_set_log_callback(TantivyLog);
     if (google::IsGoogleLoggingInitialized()) {
         return;
     }
     google::InitGoogleLogging("milvus");
     google::AddLogSink(&g_sink);
 
-    // log is catched by zap, so we don't need to log to stderr/stdout/files anymore.
+    // log is caught by zap, so we don't need to log to stderr/stdout/files anymore.
     FLAGS_logtostdout = false;
     FLAGS_logtostderr = false;
     FLAGS_alsologtostderr = false;
@@ -113,7 +169,7 @@ InitGoogleLoggingWithoutZapSink() {
         return;
     }
     google::InitGoogleLogging("milvus");
-    // log is catched by zap, so we don't need to log to stderr/stdout/files anymore.
+    // log is caught by zap, so we don't need to log to stderr/stdout/files anymore.
     FLAGS_logtostdout = true;
     FLAGS_logtostderr = false;
     FLAGS_alsologtostderr = false;

--- a/internal/core/thirdparty/tantivy/tantivy-binding/include/tantivy-binding.h
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/include/tantivy-binding.h
@@ -618,6 +618,8 @@ void tantivy_set_log_callback(TantivyLogCallback callback);
 
 void tantivy_set_log_level(const char *level);
 
+bool tantivy_test_log_from_background_thread();
+
 void free_rust_string(const char *ptr);
 
 void *tantivy_create_token_stream(void *tokenizer, const char *text);

--- a/internal/core/thirdparty/tantivy/tantivy-binding/include/tantivy-binding.h
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/include/tantivy-binding.h
@@ -22,6 +22,14 @@ enum class TantivyDataType : uint8_t {
   JSON,
 };
 
+enum class TantivyLogLevel {
+  Trace,
+  Debug,
+  Info,
+  Warn,
+  Error,
+};
+
 struct RustArray {
   uint32_t *array;
   size_t len;
@@ -101,6 +109,15 @@ struct RustResult {
 using SetBitsetFn = void(*)(void*, const uint32_t*, uintptr_t);
 
 using RegexMatchFn = bool(*)(void*, const uint8_t*, uintptr_t);
+
+using TantivyLogCallback = bool(*)(TantivyLogLevel level,
+                                   const char *target,
+                                   uintptr_t target_len,
+                                   const char *file,
+                                   uintptr_t file_len,
+                                   uint32_t line,
+                                   const char *message,
+                                   uintptr_t message_len);
 
 struct TantivyToken {
   const char *token;
@@ -596,6 +613,8 @@ RustResult tantivy_create_text_writer(const char *field_name,
                                       uintptr_t overall_memory_budget_in_bytes,
                                       bool in_ram,
                                       bool enable_background_merge);
+
+void tantivy_set_log_callback(TantivyLogCallback callback);
 
 void tantivy_set_log_level(const char *level);
 

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/log.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/log.rs
@@ -1,10 +1,110 @@
-use std::sync::Once;
+use std::ffi::c_char;
+use std::sync::{Once, OnceLock};
+
+use log::{Level, LevelFilter, Log, Metadata, Record};
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TantivyLogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+pub type TantivyLogCallback = unsafe extern "C" fn(
+    level: TantivyLogLevel,
+    target: *const c_char,
+    target_len: usize,
+    file: *const c_char,
+    file_len: usize,
+    line: u32,
+    message: *const c_char,
+    message_len: usize,
+) -> bool;
+
+static LOG_CALLBACK: OnceLock<TantivyLogCallback> = OnceLock::new();
+static LOGGER: OnceLock<TantivyLogger> = OnceLock::new();
+
+struct TantivyLogger {
+    fallback: env_logger::Logger,
+}
+
+impl Log for TantivyLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= log::max_level()
+    }
+
+    fn log(&self, record: &Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        let Some(callback) = LOG_CALLBACK.get().copied() else {
+            self.fallback.log(record);
+            return;
+        };
+
+        let message = record.args().to_string();
+        let target = record.target().as_bytes();
+        let file = record.file().unwrap_or_default().as_bytes();
+        let handled = unsafe {
+            callback(
+                map_level(record.level()),
+                target.as_ptr().cast(),
+                target.len(),
+                file.as_ptr().cast(),
+                file.len(),
+                record.line().unwrap_or_default(),
+                message.as_ptr().cast(),
+                message.len(),
+            )
+        };
+        if !handled {
+            self.fallback.log(record);
+        }
+    }
+
+    fn flush(&self) {
+        self.fallback.flush();
+    }
+}
+
+fn map_level(level: Level) -> TantivyLogLevel {
+    match level {
+        Level::Trace => TantivyLogLevel::Trace,
+        Level::Debug => TantivyLogLevel::Debug,
+        Level::Info => TantivyLogLevel::Info,
+        Level::Warn => TantivyLogLevel::Warn,
+        Level::Error => TantivyLogLevel::Error,
+    }
+}
+
+pub(crate) fn set_log_callback(callback: TantivyLogCallback) {
+    // The bridge function has process lifetime. Repeated Milvus initialization
+    // is idempotent and must not replace a callback while workers are logging.
+    let _ = LOG_CALLBACK.set(callback);
+}
+
+pub(crate) fn set_log_level(level: LevelFilter) {
+    // Finish one-time logger initialization before applying a runtime level so
+    // first use cannot reset a level configured earlier by Milvus startup.
+    init_log();
+    log::set_max_level(level);
+}
 
 pub(crate) fn init_log() {
-    static _INITIALIZED: Once = Once::new();
-    _INITIALIZED.call_once(|| {
-        env_logger::Builder::new()
-            .filter_level(log::LevelFilter::Info)
-            .init();
+    static INITIALIZED: Once = Once::new();
+    INITIALIZED.call_once(|| {
+        let logger = LOGGER.get_or_init(|| TantivyLogger {
+            // The log facade owns runtime filtering. Keeping the fallback open
+            // to all levels allows tantivy_set_log_level to update it later.
+            fallback: env_logger::Builder::new()
+                .filter_level(log::LevelFilter::Trace)
+                .build(),
+        });
+        log::set_logger(logger).expect("failed to initialize Tantivy logger");
+        log::set_max_level(log::LevelFilter::Info);
     });
 }

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/log_c.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/log_c.rs
@@ -1,6 +1,6 @@
 use std::ffi::{c_char, CStr};
 
-use crate::log::{set_log_callback, set_log_level, TantivyLogCallback};
+use crate::log::{init_log, set_log_callback, set_log_level, TantivyLogCallback};
 
 #[no_mangle]
 pub extern "C" fn tantivy_set_log_callback(callback: TantivyLogCallback) {
@@ -22,4 +22,18 @@ pub extern "C" fn tantivy_set_log_level(level: *const c_char) {
     };
 
     set_log_level(filter);
+}
+
+#[no_mangle]
+pub extern "C" fn tantivy_test_log_from_background_thread() -> bool {
+    init_log();
+    std::thread::spawn(|| {
+        log::trace!(target: "tantivy::background", "bridge trace");
+        log::debug!(target: "tantivy::background", "bridge debug");
+        log::info!(target: "tantivy::background", "bridge info");
+        log::warn!(target: "tantivy::background", "bridge warn");
+        log::error!(target: "tantivy::background", "bridge error");
+    })
+    .join()
+    .is_ok()
 }

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/log_c.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/log_c.rs
@@ -1,5 +1,12 @@
 use std::ffi::{c_char, CStr};
 
+use crate::log::{set_log_callback, set_log_level, TantivyLogCallback};
+
+#[no_mangle]
+pub extern "C" fn tantivy_set_log_callback(callback: TantivyLogCallback) {
+    set_log_callback(callback);
+}
+
 #[no_mangle]
 pub extern "C" fn tantivy_set_log_level(level: *const c_char) {
     let level_str = unsafe { CStr::from_ptr(level) }.to_str().unwrap_or("info");
@@ -14,5 +21,5 @@ pub extern "C" fn tantivy_set_log_level(level: *const c_char) {
         _ => log::LevelFilter::Info,
     };
 
-    log::set_max_level(filter);
+    set_log_level(filter);
 }

--- a/internal/core/thirdparty/tantivy/tantivy-binding/tests/log_bridge.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/tests/log_bridge.rs
@@ -29,6 +29,7 @@ extern "C" {
     fn tantivy_index_exist(path: *const c_char) -> bool;
     fn tantivy_set_log_callback(callback: TantivyLogCallback);
     fn tantivy_set_log_level(level: *const c_char);
+    fn tantivy_test_log_from_background_thread() -> bool;
 }
 
 #[derive(Debug)]
@@ -79,15 +80,7 @@ fn forwards_all_severities_from_background_thread() {
         assert!(!tantivy_index_exist(path.as_ptr()));
     }
 
-    std::thread::spawn(|| {
-        log::trace!(target: "tantivy::background", "bridge trace");
-        log::debug!(target: "tantivy::background", "bridge debug");
-        log::info!(target: "tantivy::background", "bridge info");
-        log::warn!(target: "tantivy::background", "bridge warn");
-        log::error!(target: "tantivy::background", "bridge error");
-    })
-    .join()
-    .unwrap();
+    assert!(unsafe { tantivy_test_log_from_background_thread() });
 
     unsafe {
         tantivy_set_log_level(c"info".as_ptr());
@@ -111,7 +104,7 @@ fn forwards_all_severities_from_background_thread() {
         .all(|record| record.target == "tantivy::background"));
     assert!(records
         .iter()
-        .all(|record| record.file.ends_with("tests/log_bridge.rs") && record.line > 0));
+        .all(|record| record.file.ends_with("src/log_c.rs") && record.line > 0));
     assert!(!all_records
         .iter()
         .any(|record| record.message == "filtered debug"));

--- a/internal/core/thirdparty/tantivy/tantivy-binding/tests/log_bridge.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/tests/log_bridge.rs
@@ -1,0 +1,121 @@
+use std::ffi::{c_char, CString};
+use std::slice;
+use std::sync::Mutex;
+
+use tantivy_binding::TantivyIndexVersion;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TantivyLogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+type TantivyLogCallback = unsafe extern "C" fn(
+    level: TantivyLogLevel,
+    target: *const c_char,
+    target_len: usize,
+    file: *const c_char,
+    file_len: usize,
+    line: u32,
+    message: *const c_char,
+    message_len: usize,
+) -> bool;
+
+extern "C" {
+    fn tantivy_index_exist(path: *const c_char) -> bool;
+    fn tantivy_set_log_callback(callback: TantivyLogCallback);
+    fn tantivy_set_log_level(level: *const c_char);
+}
+
+#[derive(Debug)]
+struct CapturedRecord {
+    level: TantivyLogLevel,
+    target: String,
+    file: String,
+    line: u32,
+    message: String,
+}
+
+static RECORDS: Mutex<Vec<CapturedRecord>> = Mutex::new(Vec::new());
+
+unsafe extern "C" fn capture_log(
+    level: TantivyLogLevel,
+    target: *const c_char,
+    target_len: usize,
+    file: *const c_char,
+    file_len: usize,
+    line: u32,
+    message: *const c_char,
+    message_len: usize,
+) -> bool {
+    RECORDS.lock().unwrap().push(CapturedRecord {
+        level,
+        target: copy_string(target, target_len),
+        file: copy_string(file, file_len),
+        line,
+        message: copy_string(message, message_len),
+    });
+    true
+}
+
+unsafe fn copy_string(ptr: *const c_char, len: usize) -> String {
+    String::from_utf8_lossy(slice::from_raw_parts(ptr.cast(), len)).into_owned()
+}
+
+#[test]
+fn forwards_all_severities_from_background_thread() {
+    let _ = TantivyIndexVersion::default_version();
+    unsafe {
+        tantivy_set_log_callback(capture_log);
+        let trace = CString::new("trace").unwrap();
+        tantivy_set_log_level(trace.as_ptr());
+
+        // Milvus configures the level before the first Tantivy operation.
+        let path = CString::new("/nonexistent/path/to/tantivy-index").unwrap();
+        assert!(!tantivy_index_exist(path.as_ptr()));
+    }
+
+    std::thread::spawn(|| {
+        log::trace!(target: "tantivy::background", "bridge trace");
+        log::debug!(target: "tantivy::background", "bridge debug");
+        log::info!(target: "tantivy::background", "bridge info");
+        log::warn!(target: "tantivy::background", "bridge warn");
+        log::error!(target: "tantivy::background", "bridge error");
+    })
+    .join()
+    .unwrap();
+
+    unsafe {
+        tantivy_set_log_level(c"info".as_ptr());
+    }
+    log::debug!(target: "tantivy::background", "filtered debug");
+    log::info!(target: "tantivy::background", "visible info");
+
+    let all_records = RECORDS.lock().unwrap();
+    let records: Vec<_> = all_records
+        .iter()
+        .filter(|record| record.message.starts_with("bridge "))
+        .collect();
+    assert_eq!(records.len(), 5);
+    assert_eq!(records[0].level, TantivyLogLevel::Trace);
+    assert_eq!(records[1].level, TantivyLogLevel::Debug);
+    assert_eq!(records[2].level, TantivyLogLevel::Info);
+    assert_eq!(records[3].level, TantivyLogLevel::Warn);
+    assert_eq!(records[4].level, TantivyLogLevel::Error);
+    assert!(records
+        .iter()
+        .all(|record| record.target == "tantivy::background"));
+    assert!(records
+        .iter()
+        .all(|record| record.file.ends_with("tests/log_bridge.rs") && record.line > 0));
+    assert!(!all_records
+        .iter()
+        .any(|record| record.message == "filtered debug"));
+    assert!(all_records
+        .iter()
+        .any(|record| record.message == "visible info"));
+}

--- a/internal/util/cgo/logging/glog_logging.go
+++ b/internal/util/cgo/logging/glog_logging.go
@@ -21,8 +21,11 @@ package logging
 
 /*
 #cgo pkg-config: milvus_core
+#include <stdbool.h>
 #include <stdlib.h>
 #include "common/logging_c.h"
+
+extern bool tantivy_index_exist(const char* path);
 */
 import "C"
 import "unsafe"
@@ -39,4 +42,10 @@ func InitGoogleLoggingWithZapSink() {
 
 func InitGoogleLogging() {
 	C.InitGoogleLoggingWithoutZapSink()
+}
+
+func tantivyIndexExist(path string) bool {
+	cpath := C.CString(path)
+	defer C.free(unsafe.Pointer(cpath))
+	return bool(C.tantivy_index_exist(cpath))
 }

--- a/internal/util/cgo/logging/glog_logging.go
+++ b/internal/util/cgo/logging/glog_logging.go
@@ -26,6 +26,7 @@ package logging
 #include "common/logging_c.h"
 
 extern bool tantivy_index_exist(const char* path);
+extern bool tantivy_test_log_from_background_thread(void);
 */
 import "C"
 import "unsafe"
@@ -48,4 +49,8 @@ func tantivyIndexExist(path string) bool {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
 	return bool(C.tantivy_index_exist(cpath))
+}
+
+func tantivyTestLogFromBackgroundThread() bool {
+	return bool(C.tantivy_test_log_from_background_thread())
 }

--- a/internal/util/cgo/logging/logging.go
+++ b/internal/util/cgo/logging/logging.go
@@ -17,12 +17,23 @@
 package logging
 
 /*
+#include <stdbool.h>
+#include <stdint.h>
+
 extern void goZapLogExt(int severity,
             char* file,
             int file_len,
             int line,
             char* msg,
             int msg_len);
+extern bool goZapLogTantivy(int severity,
+            char* target,
+            uintptr_t target_len,
+            char* file,
+            uintptr_t file_len,
+            uint32_t line,
+            char* msg,
+            uintptr_t msg_len);
 */
 import "C"
 
@@ -36,6 +47,7 @@ import (
 )
 
 const cgoLoggerName = "CGO"
+const tantivyLoggerName = "Tantivy"
 
 const (
 	glogInfo    glogSeverity = 0
@@ -46,6 +58,16 @@ const (
 
 // glogSeverity describes the GLOG severity level.
 type glogSeverity = int
+
+const (
+	tantivyTrace tantivySeverity = iota
+	tantivyDebug
+	tantivyInfo
+	tantivyWarn
+	tantivyError
+)
+
+type tantivySeverity = int
 
 //export goZapLogExt
 func goZapLogExt(sev C.int,
@@ -106,6 +128,78 @@ func mapGlogSeverity(s int) mlog.Level {
 		// glog fatal will call std::abort,
 		// zap will call os.Exit(1),
 		// we don't want to double exit, so we use error level instead
+		return mlog.ErrorLevel
+	default:
+		return mlog.InfoLevel
+	}
+}
+
+//export goZapLogTantivy
+func goZapLogTantivy(sev C.int,
+	target *C.char,
+	targetLen C.uintptr_t,
+	file *C.char,
+	fileLen C.uintptr_t,
+	line C.uint32_t,
+	msg *C.char,
+	msgLen C.uintptr_t,
+) C.bool {
+	logTantivyRecord(
+		int(sev),
+		copyCString(target, targetLen),
+		copyCString(file, fileLen),
+		int(line),
+		copyCString(msg, msgLen),
+	)
+	return C.bool(true)
+}
+
+func logTantivyRecord(severity int, target, file string, line int, message string) {
+	lv := mapTantivySeverity(severity)
+	core := mlog.L().Core()
+	if !core.Enabled(lv) {
+		return
+	}
+
+	loggerName := tantivyLoggerName
+	if target != "" {
+		loggerName += "/" + target
+	}
+	ent := zapcore.Entry{
+		Level:      lv,
+		Time:       time.Now(),
+		LoggerName: loggerName,
+		Message:    message,
+		Caller: zapcore.EntryCaller{
+			Defined: file != "",
+			File:    file,
+			Line:    line,
+		},
+	}
+	if ce := core.Check(ent, nil); ce != nil {
+		ce.Write()
+	}
+}
+
+func copyCString(ptr *C.char, length C.uintptr_t) string {
+	if length == 0 {
+		return ""
+	}
+	// A zap Core may retain the Entry after Write returns. Copy the FFI memory
+	// so logger implementations never observe a dangling Rust pointer.
+	return string(unsafe.Slice((*byte)(unsafe.Pointer(ptr)), int(length)))
+}
+
+func mapTantivySeverity(s int) mlog.Level {
+	switch s {
+	case tantivyTrace, tantivyDebug:
+		// mlog intentionally treats the configured trace level as debug.
+		return mlog.DebugLevel
+	case tantivyInfo:
+		return mlog.InfoLevel
+	case tantivyWarn:
+		return mlog.WarnLevel
+	case tantivyError:
 		return mlog.ErrorLevel
 	default:
 		return mlog.InfoLevel

--- a/internal/util/cgo/logging/logging.go
+++ b/internal/util/cgo/logging/logging.go
@@ -46,8 +46,10 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 )
 
-const cgoLoggerName = "CGO"
-const tantivyLoggerName = "Tantivy"
+const (
+	cgoLoggerName     = "CGO"
+	tantivyLoggerName = "Tantivy"
+)
 
 const (
 	glogInfo    glogSeverity = 0

--- a/internal/util/cgo/logging/logging_test.go
+++ b/internal/util/cgo/logging/logging_test.go
@@ -20,6 +20,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 )
@@ -30,4 +33,47 @@ func TestLogging(t *testing.T) {
 	require.Equal(t, mlog.ErrorLevel, mapGlogSeverity(2))
 	require.Equal(t, mlog.ErrorLevel, mapGlogSeverity(3))
 	require.Equal(t, mlog.InfoLevel, mapGlogSeverity(4))
+}
+
+func TestMapTantivySeverity(t *testing.T) {
+	require.Equal(t, mlog.DebugLevel, mapTantivySeverity(tantivyTrace))
+	require.Equal(t, mlog.DebugLevel, mapTantivySeverity(tantivyDebug))
+	require.Equal(t, mlog.InfoLevel, mapTantivySeverity(tantivyInfo))
+	require.Equal(t, mlog.WarnLevel, mapTantivySeverity(tantivyWarn))
+	require.Equal(t, mlog.ErrorLevel, mapTantivySeverity(tantivyError))
+	require.Equal(t, mlog.InfoLevel, mapTantivySeverity(99))
+}
+
+func TestLogTantivyRecord(t *testing.T) {
+	oldLogger := mlog.L()
+	core, observed := observer.New(zapcore.DebugLevel)
+	mlog.ReplaceGlobals(zap.New(core), nil)
+	t.Cleanup(func() { mlog.ReplaceGlobals(oldLogger, nil) })
+
+	logTantivyRecord(
+		tantivyDebug,
+		"tantivy::indexer::segment_updater",
+		"tantivy/src/indexer/segment_updater.rs",
+		42,
+		"merge completed",
+	)
+
+	entries := observed.AllUntimed()
+	require.Len(t, entries, 1)
+	require.Equal(t, zapcore.DebugLevel, entries[0].Level)
+	require.Equal(t, "Tantivy/tantivy::indexer::segment_updater", entries[0].LoggerName)
+	require.Equal(t, "merge completed", entries[0].Message)
+	require.True(t, entries[0].Caller.Defined)
+	require.Equal(t, "tantivy/src/indexer/segment_updater.rs", entries[0].Caller.File)
+	require.Equal(t, 42, entries[0].Caller.Line)
+}
+
+func TestLogTantivyRecordRespectsCoreLevel(t *testing.T) {
+	oldLogger := mlog.L()
+	core, observed := observer.New(zapcore.InfoLevel)
+	mlog.ReplaceGlobals(zap.New(core), nil)
+	t.Cleanup(func() { mlog.ReplaceGlobals(oldLogger, nil) })
+
+	logTantivyRecord(tantivyDebug, "tantivy::background", "", 0, "hidden")
+	require.Equal(t, 0, observed.Len())
 }

--- a/internal/util/cgo/logging/logging_test.go
+++ b/internal/util/cgo/logging/logging_test.go
@@ -17,15 +17,74 @@
 package logging
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 )
+
+type capturedLogEntry struct {
+	Level   string `json:"level"`
+	Name    string `json:"name"`
+	Caller  string `json:"caller"`
+	Message string `json:"message"`
+}
+
+func captureMlogEntries(t *testing.T, level string) func() []capturedLogEntry {
+	t.Helper()
+
+	logDir := t.TempDir()
+	logFile := filepath.Join(logDir, "tantivy.log")
+	logger, props, err := mlog.InitLogger(&mlog.Config{
+		Level:             level,
+		Format:            "json",
+		DisableTimestamp:  true,
+		DisableStacktrace: true,
+		File: mlog.FileLogConfig{
+			RootPath: logDir,
+			Filename: "tantivy.log",
+		},
+	})
+	require.NoError(t, err)
+	mlog.ReplaceGlobals(logger, props)
+	t.Cleanup(func() {
+		require.NoError(t, logger.Sync())
+		restoreLogger, restoreProps, err := mlog.InitTestLogger(t, &mlog.Config{
+			Level:             "info",
+			DisableTimestamp:  true,
+			DisableCaller:     true,
+			DisableStacktrace: true,
+		})
+		require.NoError(t, err)
+		mlog.ReplaceGlobals(restoreLogger, restoreProps)
+	})
+
+	return func() []capturedLogEntry {
+		t.Helper()
+		require.NoError(t, logger.Sync())
+		content, err := os.ReadFile(logFile)
+		require.NoError(t, err)
+
+		trimmed := strings.TrimSpace(string(content))
+		if trimmed == "" {
+			return nil
+		}
+
+		lines := strings.Split(trimmed, "\n")
+		entries := make([]capturedLogEntry, 0, len(lines))
+		for _, line := range lines {
+			var entry capturedLogEntry
+			require.NoError(t, json.Unmarshal([]byte(line), &entry))
+			entries = append(entries, entry)
+		}
+		return entries
+	}
+}
 
 func TestLogging(t *testing.T) {
 	require.Equal(t, mlog.InfoLevel, mapGlogSeverity(0))
@@ -45,10 +104,7 @@ func TestMapTantivySeverity(t *testing.T) {
 }
 
 func TestLogTantivyRecord(t *testing.T) {
-	oldLogger := mlog.L()
-	core, observed := observer.New(zapcore.DebugLevel)
-	mlog.ReplaceGlobals(zap.New(core), nil)
-	t.Cleanup(func() { mlog.ReplaceGlobals(oldLogger, nil) })
+	readEntries := captureMlogEntries(t, "debug")
 
 	logTantivyRecord(
 		tantivyDebug,
@@ -58,22 +114,21 @@ func TestLogTantivyRecord(t *testing.T) {
 		"merge completed",
 	)
 
-	entries := observed.AllUntimed()
+	entries := readEntries()
 	require.Len(t, entries, 1)
-	require.Equal(t, zapcore.DebugLevel, entries[0].Level)
-	require.Equal(t, "Tantivy/tantivy::indexer::segment_updater", entries[0].LoggerName)
+	require.Equal(t, "DEBUG", entries[0].Level)
+	require.Equal(t, "Tantivy/tantivy::indexer::segment_updater", entries[0].Name)
 	require.Equal(t, "merge completed", entries[0].Message)
-	require.True(t, entries[0].Caller.Defined)
-	require.Equal(t, "tantivy/src/indexer/segment_updater.rs", entries[0].Caller.File)
-	require.Equal(t, 42, entries[0].Caller.Line)
+	require.True(t, strings.HasSuffix(entries[0].Caller, "indexer/segment_updater.rs:42"))
 }
 
 func TestLogTantivyRecordRespectsCoreLevel(t *testing.T) {
-	oldLogger := mlog.L()
-	core, observed := observer.New(zapcore.InfoLevel)
-	mlog.ReplaceGlobals(zap.New(core), nil)
-	t.Cleanup(func() { mlog.ReplaceGlobals(oldLogger, nil) })
+	readEntries := captureMlogEntries(t, "info")
 
 	logTantivyRecord(tantivyDebug, "tantivy::background", "", 0, "hidden")
-	require.Equal(t, 0, observed.Len())
+	logTantivyRecord(tantivyInfo, "tantivy::background", "", 0, "visible")
+
+	entries := readEntries()
+	require.Len(t, entries, 1)
+	require.Equal(t, "visible", entries[0].Message)
 }

--- a/internal/util/cgo/logging/tantivy_logging_test.go
+++ b/internal/util/cgo/logging/tantivy_logging_test.go
@@ -24,27 +24,22 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
-
-	"github.com/milvus-io/milvus/pkg/v3/mlog"
 )
 
 func TestTantivyLoggingBridge(t *testing.T) {
-	oldLogger := mlog.L()
-	core, observed := observer.New(zapcore.InfoLevel)
-	mlog.ReplaceGlobals(zap.New(core), nil)
-	t.Cleanup(func() { mlog.ReplaceGlobals(oldLogger, nil) })
+	readEntries := captureMlogEntries(t, "info")
 
 	InitGoogleLoggingWithZapSink()
 	require.False(t, tantivyIndexExist("/nonexistent/path/to/tantivy-index"))
 
-	entries := observed.FilterMessageSnippet("failed to open directory").AllUntimed()
-	require.Len(t, entries, 1)
-	require.Equal(t, zapcore.InfoLevel, entries[0].Level)
-	require.Equal(t, "Tantivy/tantivy_binding::util", entries[0].LoggerName)
-	require.True(t, entries[0].Caller.Defined)
-	require.True(t, strings.HasSuffix(entries[0].Caller.File, "src/util.rs"))
-	require.Positive(t, entries[0].Caller.Line)
+	var matchingEntries []capturedLogEntry
+	for _, entry := range readEntries() {
+		if strings.Contains(entry.Message, "failed to open directory") {
+			matchingEntries = append(matchingEntries, entry)
+		}
+	}
+	require.Len(t, matchingEntries, 1)
+	require.Equal(t, "INFO", matchingEntries[0].Level)
+	require.Equal(t, "Tantivy/tantivy_binding::util", matchingEntries[0].Name)
+	require.Regexp(t, `src/util\.rs:\d+$`, matchingEntries[0].Caller)
 }

--- a/internal/util/cgo/logging/tantivy_logging_test.go
+++ b/internal/util/cgo/logging/tantivy_logging_test.go
@@ -31,15 +31,36 @@ func TestTantivyLoggingBridge(t *testing.T) {
 
 	InitGoogleLoggingWithZapSink()
 	require.False(t, tantivyIndexExist("/nonexistent/path/to/tantivy-index"))
+	require.True(t, tantivyTestLogFromBackgroundThread())
 
 	var matchingEntries []capturedLogEntry
+	var backgroundEntries []capturedLogEntry
 	for _, entry := range readEntries() {
 		if strings.Contains(entry.Message, "failed to open directory") {
 			matchingEntries = append(matchingEntries, entry)
+		}
+		if strings.HasPrefix(entry.Message, "bridge ") {
+			backgroundEntries = append(backgroundEntries, entry)
 		}
 	}
 	require.Len(t, matchingEntries, 1)
 	require.Equal(t, "INFO", matchingEntries[0].Level)
 	require.Equal(t, "Tantivy/tantivy_binding::util", matchingEntries[0].Name)
 	require.Regexp(t, `src/util\.rs:\d+$`, matchingEntries[0].Caller)
+
+	require.Len(t, backgroundEntries, 3)
+	require.Equal(t, []string{"bridge info", "bridge warn", "bridge error"}, []string{
+		backgroundEntries[0].Message,
+		backgroundEntries[1].Message,
+		backgroundEntries[2].Message,
+	})
+	require.Equal(t, []string{"INFO", "WARN", "ERROR"}, []string{
+		backgroundEntries[0].Level,
+		backgroundEntries[1].Level,
+		backgroundEntries[2].Level,
+	})
+	for _, entry := range backgroundEntries {
+		require.Equal(t, "Tantivy/tantivy::background", entry.Name)
+		require.Regexp(t, `src/log_c\.rs:\d+$`, entry.Caller)
+	}
 }

--- a/internal/util/cgo/logging/tantivy_logging_test.go
+++ b/internal/util/cgo/logging/tantivy_logging_test.go
@@ -1,0 +1,50 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build test
+// +build test
+
+package logging
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+)
+
+func TestTantivyLoggingBridge(t *testing.T) {
+	oldLogger := mlog.L()
+	core, observed := observer.New(zapcore.InfoLevel)
+	mlog.ReplaceGlobals(zap.New(core), nil)
+	t.Cleanup(func() { mlog.ReplaceGlobals(oldLogger, nil) })
+
+	InitGoogleLoggingWithZapSink()
+	require.False(t, tantivyIndexExist("/nonexistent/path/to/tantivy-index"))
+
+	entries := observed.FilterMessageSnippet("failed to open directory").AllUntimed()
+	require.Len(t, entries, 1)
+	require.Equal(t, zapcore.InfoLevel, entries[0].Level)
+	require.Equal(t, "Tantivy/tantivy_binding::util", entries[0].LoggerName)
+	require.True(t, entries[0].Caller.Defined)
+	require.True(t, strings.HasSuffix(entries[0].Caller.File, "src/util.rs"))
+	require.Positive(t, entries[0].Caller.Line)
+}


### PR DESCRIPTION
## What this PR does

- replaces the Tantivy binding's standalone `env_logger` with a process-wide logger that forwards structured records through the Milvus logging stack
- preserves Tantivy severity, target, source file, line, and message across the Rust/C++/Go boundary
- keeps runtime log-level changes effective, including when Milvus configures the level before the first Tantivy operation
- falls back to `env_logger` when a Go logging sink is unavailable, so C++-only binaries do not silently drop Tantivy logs

The callback is registered once and the logging hot path does not take a shared lock. Strings received by Go are copied before they are passed to Zap because a Core may retain an entry after the FFI callback returns.

## Why

The binding currently installs its own `env_logger`, so Tantivy records bypass Milvus log formatting, level control, and output routing. Its fixed `Info` filter also suppresses later `debug` and `trace` settings even though `tantivy_set_log_level` updates the facade's max level.

## Tests

- `cargo +1.89 test --test log_bridge -- --nocapture`
- `cargo +1.89 fmt --all -- --check`
- `cargo +1.89 check --lib`
- `go test -tags dynamic,test -gcflags='all=-N -l' ./internal/util/cgo/logging -run 'Test(TantivyLoggingBridge|Logging|MapTantivySeverity|LogTantivyRecord|LogTantivyRecordRespectsCoreLevel)$' -count=1 -v`
- the same focused Go tests with `-race`
- `go vet -tags dynamic,test ./internal/util/cgo/logging`
- C++ syntax checks for normal and `WITHOUT_GO_LOGGING` builds on Linux; production and fallback bridge harnesses on macOS

`cargo +1.89 test --lib` is currently blocked on `master` by the existing `create_text_writer` test call in `src/index_reader_text.rs:266`, which is missing the new `enable_background_merge` argument.

Fixes #51912
