### PR TITLE
fix: keep planparserv2 test field IDs clear of the DataType-derived range

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cockroachdb/errors v1.9.1
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
-	github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260712212354-7efdf25099dd
+	github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260803063812-659295cc95a3
 	github.com/quasilyte/go-ruleguard/dsl v0.3.23
 	github.com/samber/lo v1.52.0
 	github.com/stretchr/testify v1.11.1

--- a/client/go.sum
+++ b/client/go.sum
@@ -158,6 +158,8 @@ github.com/mediocregopher/radix/v3 v3.4.2/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
 github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260712212354-7efdf25099dd h1:q24BFW1uhH7VxueDw3t1V6a9RZuMorjyOya5+oxIUAE=
 github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260712212354-7efdf25099dd/go.mod h1:rbKpv5JToISTKTTLl0duL5r6wbYnjJ9SsD0QgXMzKy0=
+github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260803063812-659295cc95a3 h1:EnDFYLoneAhdn5EyJ1OOTcBXT90d4FgXW9BDRBVngTQ=
+github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260803063812-659295cc95a3/go.mod h1:rbKpv5JToISTKTTLl0duL5r6wbYnjJ9SsD0QgXMzKy0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/client/milvusclient/mock_milvus_server_test.go
+++ b/client/milvusclient/mock_milvus_server_test.go
@@ -2135,6 +2135,65 @@ func (_c *MilvusServiceServer_DeleteCredential_Call) RunAndReturn(run func(conte
 	return _c
 }
 
+// DeleteRLSPrincipalTags provides a mock function with given fields: _a0, _a1
+func (_m *MilvusServiceServer) DeleteRLSPrincipalTags(_a0 context.Context, _a1 *milvuspb.DeleteRLSPrincipalTagsRequest) (*commonpb.Status, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteRLSPrincipalTags")
+	}
+
+	var r0 *commonpb.Status
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.DeleteRLSPrincipalTagsRequest) (*commonpb.Status, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.DeleteRLSPrincipalTagsRequest) *commonpb.Status); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*commonpb.Status)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.DeleteRLSPrincipalTagsRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MilvusServiceServer_DeleteRLSPrincipalTags_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteRLSPrincipalTags'
+type MilvusServiceServer_DeleteRLSPrincipalTags_Call struct {
+	*mock.Call
+}
+
+// DeleteRLSPrincipalTags is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *milvuspb.DeleteRLSPrincipalTagsRequest
+func (_e *MilvusServiceServer_Expecter) DeleteRLSPrincipalTags(_a0 interface{}, _a1 interface{}) *MilvusServiceServer_DeleteRLSPrincipalTags_Call {
+	return &MilvusServiceServer_DeleteRLSPrincipalTags_Call{Call: _e.mock.On("DeleteRLSPrincipalTags", _a0, _a1)}
+}
+
+func (_c *MilvusServiceServer_DeleteRLSPrincipalTags_Call) Run(run func(_a0 context.Context, _a1 *milvuspb.DeleteRLSPrincipalTagsRequest)) *MilvusServiceServer_DeleteRLSPrincipalTags_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.DeleteRLSPrincipalTagsRequest))
+	})
+	return _c
+}
+
+func (_c *MilvusServiceServer_DeleteRLSPrincipalTags_Call) Return(_a0 *commonpb.Status, _a1 error) *MilvusServiceServer_DeleteRLSPrincipalTags_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MilvusServiceServer_DeleteRLSPrincipalTags_Call) RunAndReturn(run func(context.Context, *milvuspb.DeleteRLSPrincipalTagsRequest) (*commonpb.Status, error)) *MilvusServiceServer_DeleteRLSPrincipalTags_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteUserTags provides a mock function with given fields: _a0, _a1
 func (_m *MilvusServiceServer) DeleteUserTags(_a0 context.Context, _a1 *milvuspb.DeleteUserTagsRequest) (*commonpb.Status, error) {
 	ret := _m.Called(_a0, _a1)
@@ -3952,6 +4011,65 @@ func (_c *MilvusServiceServer_GetComponentStates_Call) RunAndReturn(run func(con
 	return _c
 }
 
+// GetExportSnapshotState provides a mock function with given fields: _a0, _a1
+func (_m *MilvusServiceServer) GetExportSnapshotState(_a0 context.Context, _a1 *milvuspb.GetExportSnapshotStateRequest) (*milvuspb.GetExportSnapshotStateResponse, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetExportSnapshotState")
+	}
+
+	var r0 *milvuspb.GetExportSnapshotStateResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.GetExportSnapshotStateRequest) (*milvuspb.GetExportSnapshotStateResponse, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.GetExportSnapshotStateRequest) *milvuspb.GetExportSnapshotStateResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*milvuspb.GetExportSnapshotStateResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.GetExportSnapshotStateRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MilvusServiceServer_GetExportSnapshotState_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetExportSnapshotState'
+type MilvusServiceServer_GetExportSnapshotState_Call struct {
+	*mock.Call
+}
+
+// GetExportSnapshotState is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetExportSnapshotStateRequest
+func (_e *MilvusServiceServer_Expecter) GetExportSnapshotState(_a0 interface{}, _a1 interface{}) *MilvusServiceServer_GetExportSnapshotState_Call {
+	return &MilvusServiceServer_GetExportSnapshotState_Call{Call: _e.mock.On("GetExportSnapshotState", _a0, _a1)}
+}
+
+func (_c *MilvusServiceServer_GetExportSnapshotState_Call) Run(run func(_a0 context.Context, _a1 *milvuspb.GetExportSnapshotStateRequest)) *MilvusServiceServer_GetExportSnapshotState_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.GetExportSnapshotStateRequest))
+	})
+	return _c
+}
+
+func (_c *MilvusServiceServer_GetExportSnapshotState_Call) Return(_a0 *milvuspb.GetExportSnapshotStateResponse, _a1 error) *MilvusServiceServer_GetExportSnapshotState_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MilvusServiceServer_GetExportSnapshotState_Call) RunAndReturn(run func(context.Context, *milvuspb.GetExportSnapshotStateRequest) (*milvuspb.GetExportSnapshotStateResponse, error)) *MilvusServiceServer_GetExportSnapshotState_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetFlushAllState provides a mock function with given fields: _a0, _a1
 func (_m *MilvusServiceServer) GetFlushAllState(_a0 context.Context, _a1 *milvuspb.GetFlushAllStateRequest) (*milvuspb.GetFlushAllStateResponse, error) {
 	ret := _m.Called(_a0, _a1)
@@ -4715,6 +4833,65 @@ func (_c *MilvusServiceServer_GetQuerySegmentInfo_Call) Return(_a0 *milvuspb.Get
 }
 
 func (_c *MilvusServiceServer_GetQuerySegmentInfo_Call) RunAndReturn(run func(context.Context, *milvuspb.GetQuerySegmentInfoRequest) (*milvuspb.GetQuerySegmentInfoResponse, error)) *MilvusServiceServer_GetQuerySegmentInfo_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetRLSPrincipalTags provides a mock function with given fields: _a0, _a1
+func (_m *MilvusServiceServer) GetRLSPrincipalTags(_a0 context.Context, _a1 *milvuspb.GetRLSPrincipalTagsRequest) (*milvuspb.GetRLSPrincipalTagsResponse, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetRLSPrincipalTags")
+	}
+
+	var r0 *milvuspb.GetRLSPrincipalTagsResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.GetRLSPrincipalTagsRequest) (*milvuspb.GetRLSPrincipalTagsResponse, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.GetRLSPrincipalTagsRequest) *milvuspb.GetRLSPrincipalTagsResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*milvuspb.GetRLSPrincipalTagsResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.GetRLSPrincipalTagsRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MilvusServiceServer_GetRLSPrincipalTags_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRLSPrincipalTags'
+type MilvusServiceServer_GetRLSPrincipalTags_Call struct {
+	*mock.Call
+}
+
+// GetRLSPrincipalTags is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetRLSPrincipalTagsRequest
+func (_e *MilvusServiceServer_Expecter) GetRLSPrincipalTags(_a0 interface{}, _a1 interface{}) *MilvusServiceServer_GetRLSPrincipalTags_Call {
+	return &MilvusServiceServer_GetRLSPrincipalTags_Call{Call: _e.mock.On("GetRLSPrincipalTags", _a0, _a1)}
+}
+
+func (_c *MilvusServiceServer_GetRLSPrincipalTags_Call) Run(run func(_a0 context.Context, _a1 *milvuspb.GetRLSPrincipalTagsRequest)) *MilvusServiceServer_GetRLSPrincipalTags_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.GetRLSPrincipalTagsRequest))
+	})
+	return _c
+}
+
+func (_c *MilvusServiceServer_GetRLSPrincipalTags_Call) Return(_a0 *milvuspb.GetRLSPrincipalTagsResponse, _a1 error) *MilvusServiceServer_GetRLSPrincipalTags_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MilvusServiceServer_GetRLSPrincipalTags_Call) RunAndReturn(run func(context.Context, *milvuspb.GetRLSPrincipalTagsRequest) (*milvuspb.GetRLSPrincipalTagsResponse, error)) *MilvusServiceServer_GetRLSPrincipalTags_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -5954,6 +6131,65 @@ func (_c *MilvusServiceServer_ListPrivilegeGroups_Call) Return(_a0 *milvuspb.Lis
 }
 
 func (_c *MilvusServiceServer_ListPrivilegeGroups_Call) RunAndReturn(run func(context.Context, *milvuspb.ListPrivilegeGroupsRequest) (*milvuspb.ListPrivilegeGroupsResponse, error)) *MilvusServiceServer_ListPrivilegeGroups_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListRLSPrincipals provides a mock function with given fields: _a0, _a1
+func (_m *MilvusServiceServer) ListRLSPrincipals(_a0 context.Context, _a1 *milvuspb.ListRLSPrincipalsRequest) (*milvuspb.ListRLSPrincipalsResponse, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListRLSPrincipals")
+	}
+
+	var r0 *milvuspb.ListRLSPrincipalsResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.ListRLSPrincipalsRequest) (*milvuspb.ListRLSPrincipalsResponse, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.ListRLSPrincipalsRequest) *milvuspb.ListRLSPrincipalsResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*milvuspb.ListRLSPrincipalsResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.ListRLSPrincipalsRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MilvusServiceServer_ListRLSPrincipals_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListRLSPrincipals'
+type MilvusServiceServer_ListRLSPrincipals_Call struct {
+	*mock.Call
+}
+
+// ListRLSPrincipals is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *milvuspb.ListRLSPrincipalsRequest
+func (_e *MilvusServiceServer_Expecter) ListRLSPrincipals(_a0 interface{}, _a1 interface{}) *MilvusServiceServer_ListRLSPrincipals_Call {
+	return &MilvusServiceServer_ListRLSPrincipals_Call{Call: _e.mock.On("ListRLSPrincipals", _a0, _a1)}
+}
+
+func (_c *MilvusServiceServer_ListRLSPrincipals_Call) Run(run func(_a0 context.Context, _a1 *milvuspb.ListRLSPrincipalsRequest)) *MilvusServiceServer_ListRLSPrincipals_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.ListRLSPrincipalsRequest))
+	})
+	return _c
+}
+
+func (_c *MilvusServiceServer_ListRLSPrincipals_Call) Return(_a0 *milvuspb.ListRLSPrincipalsResponse, _a1 error) *MilvusServiceServer_ListRLSPrincipals_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MilvusServiceServer_ListRLSPrincipals_Call) RunAndReturn(run func(context.Context, *milvuspb.ListRLSPrincipalsRequest) (*milvuspb.ListRLSPrincipalsResponse, error)) *MilvusServiceServer_ListRLSPrincipals_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -7846,6 +8082,65 @@ func (_c *MilvusServiceServer_SelectUser_Call) RunAndReturn(run func(context.Con
 	return _c
 }
 
+// SetRLSPrincipalTags provides a mock function with given fields: _a0, _a1
+func (_m *MilvusServiceServer) SetRLSPrincipalTags(_a0 context.Context, _a1 *milvuspb.SetRLSPrincipalTagsRequest) (*commonpb.Status, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetRLSPrincipalTags")
+	}
+
+	var r0 *commonpb.Status
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.SetRLSPrincipalTagsRequest) (*commonpb.Status, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.SetRLSPrincipalTagsRequest) *commonpb.Status); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*commonpb.Status)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.SetRLSPrincipalTagsRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MilvusServiceServer_SetRLSPrincipalTags_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetRLSPrincipalTags'
+type MilvusServiceServer_SetRLSPrincipalTags_Call struct {
+	*mock.Call
+}
+
+// SetRLSPrincipalTags is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *milvuspb.SetRLSPrincipalTagsRequest
+func (_e *MilvusServiceServer_Expecter) SetRLSPrincipalTags(_a0 interface{}, _a1 interface{}) *MilvusServiceServer_SetRLSPrincipalTags_Call {
+	return &MilvusServiceServer_SetRLSPrincipalTags_Call{Call: _e.mock.On("SetRLSPrincipalTags", _a0, _a1)}
+}
+
+func (_c *MilvusServiceServer_SetRLSPrincipalTags_Call) Run(run func(_a0 context.Context, _a1 *milvuspb.SetRLSPrincipalTagsRequest)) *MilvusServiceServer_SetRLSPrincipalTags_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.SetRLSPrincipalTagsRequest))
+	})
+	return _c
+}
+
+func (_c *MilvusServiceServer_SetRLSPrincipalTags_Call) Return(_a0 *commonpb.Status, _a1 error) *MilvusServiceServer_SetRLSPrincipalTags_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MilvusServiceServer_SetRLSPrincipalTags_Call) RunAndReturn(run func(context.Context, *milvuspb.SetRLSPrincipalTagsRequest) (*commonpb.Status, error)) *MilvusServiceServer_SetRLSPrincipalTags_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ShowCollections provides a mock function with given fields: _a0, _a1
 func (_m *MilvusServiceServer) ShowCollections(_a0 context.Context, _a1 *milvuspb.ShowCollectionsRequest) (*milvuspb.ShowCollectionsResponse, error) {
 	ret := _m.Called(_a0, _a1)
@@ -8373,6 +8668,65 @@ func (_c *MilvusServiceServer_UpdateResourceGroups_Call) Return(_a0 *commonpb.St
 }
 
 func (_c *MilvusServiceServer_UpdateResourceGroups_Call) RunAndReturn(run func(context.Context, *milvuspb.UpdateResourceGroupsRequest) (*commonpb.Status, error)) *MilvusServiceServer_UpdateResourceGroups_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateRowPolicy provides a mock function with given fields: _a0, _a1
+func (_m *MilvusServiceServer) UpdateRowPolicy(_a0 context.Context, _a1 *milvuspb.UpdateRowPolicyRequest) (*commonpb.Status, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateRowPolicy")
+	}
+
+	var r0 *commonpb.Status
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.UpdateRowPolicyRequest) (*commonpb.Status, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.UpdateRowPolicyRequest) *commonpb.Status); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*commonpb.Status)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.UpdateRowPolicyRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MilvusServiceServer_UpdateRowPolicy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateRowPolicy'
+type MilvusServiceServer_UpdateRowPolicy_Call struct {
+	*mock.Call
+}
+
+// UpdateRowPolicy is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *milvuspb.UpdateRowPolicyRequest
+func (_e *MilvusServiceServer_Expecter) UpdateRowPolicy(_a0 interface{}, _a1 interface{}) *MilvusServiceServer_UpdateRowPolicy_Call {
+	return &MilvusServiceServer_UpdateRowPolicy_Call{Call: _e.mock.On("UpdateRowPolicy", _a0, _a1)}
+}
+
+func (_c *MilvusServiceServer_UpdateRowPolicy_Call) Run(run func(_a0 context.Context, _a1 *milvuspb.UpdateRowPolicyRequest)) *MilvusServiceServer_UpdateRowPolicy_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.UpdateRowPolicyRequest))
+	})
+	return _c
+}
+
+func (_c *MilvusServiceServer_UpdateRowPolicy_Call) Return(_a0 *commonpb.Status, _a1 error) *MilvusServiceServer_UpdateRowPolicy_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MilvusServiceServer_UpdateRowPolicy_Call) RunAndReturn(run func(context.Context, *milvuspb.UpdateRowPolicyRequest) (*commonpb.Status, error)) *MilvusServiceServer_UpdateRowPolicy_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/hamba/avro/v2 v2.29.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/magiconair/properties v1.8.7
-	github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260712212354-7efdf25099dd
+	github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260803063812-659295cc95a3
 	github.com/milvus-io/milvus/client/v3 v3.0.0
 	github.com/milvus-io/milvus/pkg/v3 v3.0.0-beta
 	github.com/shirou/gopsutil/v4 v4.25.10

--- a/go.sum
+++ b/go.sum
@@ -802,6 +802,8 @@ github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b h1:TfeY0NxYxZz
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b/go.mod h1:iwW+9cWfIzzDseEBCCeDSN5SD16Tidvy8cwQ7ZY8Qj4=
 github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260712212354-7efdf25099dd h1:q24BFW1uhH7VxueDw3t1V6a9RZuMorjyOya5+oxIUAE=
 github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260712212354-7efdf25099dd/go.mod h1:rbKpv5JToISTKTTLl0duL5r6wbYnjJ9SsD0QgXMzKy0=
+github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260803063812-659295cc95a3 h1:EnDFYLoneAhdn5EyJ1OOTcBXT90d4FgXW9BDRBVngTQ=
+github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260803063812-659295cc95a3/go.mod h1:rbKpv5JToISTKTTLl0duL5r6wbYnjJ9SsD0QgXMzKy0=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 h1:AMFGa4R4MiIpspGNG7Z948v4n35fFGB3RR3G/ry4FWs=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 h1:+n/aFZefKZp7spd8DFdX7uMikMLXX4oubIzJF4kv/wI=

--- a/internal/mocks/mock_proxy.go
+++ b/internal/mocks/mock_proxy.go
@@ -2434,6 +2434,65 @@ func (_c *MockProxy_DeleteCredential_Call) RunAndReturn(run func(context.Context
 	return _c
 }
 
+// DeleteRLSPrincipalTags provides a mock function with given fields: _a0, _a1
+func (_m *MockProxy) DeleteRLSPrincipalTags(_a0 context.Context, _a1 *milvuspb.DeleteRLSPrincipalTagsRequest) (*commonpb.Status, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteRLSPrincipalTags")
+	}
+
+	var r0 *commonpb.Status
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.DeleteRLSPrincipalTagsRequest) (*commonpb.Status, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.DeleteRLSPrincipalTagsRequest) *commonpb.Status); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*commonpb.Status)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.DeleteRLSPrincipalTagsRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockProxy_DeleteRLSPrincipalTags_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteRLSPrincipalTags'
+type MockProxy_DeleteRLSPrincipalTags_Call struct {
+	*mock.Call
+}
+
+// DeleteRLSPrincipalTags is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *milvuspb.DeleteRLSPrincipalTagsRequest
+func (_e *MockProxy_Expecter) DeleteRLSPrincipalTags(_a0 interface{}, _a1 interface{}) *MockProxy_DeleteRLSPrincipalTags_Call {
+	return &MockProxy_DeleteRLSPrincipalTags_Call{Call: _e.mock.On("DeleteRLSPrincipalTags", _a0, _a1)}
+}
+
+func (_c *MockProxy_DeleteRLSPrincipalTags_Call) Run(run func(_a0 context.Context, _a1 *milvuspb.DeleteRLSPrincipalTagsRequest)) *MockProxy_DeleteRLSPrincipalTags_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.DeleteRLSPrincipalTagsRequest))
+	})
+	return _c
+}
+
+func (_c *MockProxy_DeleteRLSPrincipalTags_Call) Return(_a0 *commonpb.Status, _a1 error) *MockProxy_DeleteRLSPrincipalTags_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockProxy_DeleteRLSPrincipalTags_Call) RunAndReturn(run func(context.Context, *milvuspb.DeleteRLSPrincipalTagsRequest) (*commonpb.Status, error)) *MockProxy_DeleteRLSPrincipalTags_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteUserTags provides a mock function with given fields: _a0, _a1
 func (_m *MockProxy) DeleteUserTags(_a0 context.Context, _a1 *milvuspb.DeleteUserTagsRequest) (*commonpb.Status, error) {
 	ret := _m.Called(_a0, _a1)
@@ -4414,6 +4473,65 @@ func (_c *MockProxy_GetDdChannel_Call) RunAndReturn(run func(context.Context, *i
 	return _c
 }
 
+// GetExportSnapshotState provides a mock function with given fields: _a0, _a1
+func (_m *MockProxy) GetExportSnapshotState(_a0 context.Context, _a1 *milvuspb.GetExportSnapshotStateRequest) (*milvuspb.GetExportSnapshotStateResponse, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetExportSnapshotState")
+	}
+
+	var r0 *milvuspb.GetExportSnapshotStateResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.GetExportSnapshotStateRequest) (*milvuspb.GetExportSnapshotStateResponse, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.GetExportSnapshotStateRequest) *milvuspb.GetExportSnapshotStateResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*milvuspb.GetExportSnapshotStateResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.GetExportSnapshotStateRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockProxy_GetExportSnapshotState_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetExportSnapshotState'
+type MockProxy_GetExportSnapshotState_Call struct {
+	*mock.Call
+}
+
+// GetExportSnapshotState is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetExportSnapshotStateRequest
+func (_e *MockProxy_Expecter) GetExportSnapshotState(_a0 interface{}, _a1 interface{}) *MockProxy_GetExportSnapshotState_Call {
+	return &MockProxy_GetExportSnapshotState_Call{Call: _e.mock.On("GetExportSnapshotState", _a0, _a1)}
+}
+
+func (_c *MockProxy_GetExportSnapshotState_Call) Run(run func(_a0 context.Context, _a1 *milvuspb.GetExportSnapshotStateRequest)) *MockProxy_GetExportSnapshotState_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.GetExportSnapshotStateRequest))
+	})
+	return _c
+}
+
+func (_c *MockProxy_GetExportSnapshotState_Call) Return(_a0 *milvuspb.GetExportSnapshotStateResponse, _a1 error) *MockProxy_GetExportSnapshotState_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockProxy_GetExportSnapshotState_Call) RunAndReturn(run func(context.Context, *milvuspb.GetExportSnapshotStateRequest) (*milvuspb.GetExportSnapshotStateResponse, error)) *MockProxy_GetExportSnapshotState_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetFlushAllState provides a mock function with given fields: _a0, _a1
 func (_m *MockProxy) GetFlushAllState(_a0 context.Context, _a1 *milvuspb.GetFlushAllStateRequest) (*milvuspb.GetFlushAllStateResponse, error) {
 	ret := _m.Called(_a0, _a1)
@@ -5354,6 +5472,65 @@ func (_c *MockProxy_GetQuotaMetrics_Call) Return(_a0 *internalpb.GetQuotaMetrics
 }
 
 func (_c *MockProxy_GetQuotaMetrics_Call) RunAndReturn(run func(context.Context, *internalpb.GetQuotaMetricsRequest) (*internalpb.GetQuotaMetricsResponse, error)) *MockProxy_GetQuotaMetrics_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetRLSPrincipalTags provides a mock function with given fields: _a0, _a1
+func (_m *MockProxy) GetRLSPrincipalTags(_a0 context.Context, _a1 *milvuspb.GetRLSPrincipalTagsRequest) (*milvuspb.GetRLSPrincipalTagsResponse, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetRLSPrincipalTags")
+	}
+
+	var r0 *milvuspb.GetRLSPrincipalTagsResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.GetRLSPrincipalTagsRequest) (*milvuspb.GetRLSPrincipalTagsResponse, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.GetRLSPrincipalTagsRequest) *milvuspb.GetRLSPrincipalTagsResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*milvuspb.GetRLSPrincipalTagsResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.GetRLSPrincipalTagsRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockProxy_GetRLSPrincipalTags_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRLSPrincipalTags'
+type MockProxy_GetRLSPrincipalTags_Call struct {
+	*mock.Call
+}
+
+// GetRLSPrincipalTags is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetRLSPrincipalTagsRequest
+func (_e *MockProxy_Expecter) GetRLSPrincipalTags(_a0 interface{}, _a1 interface{}) *MockProxy_GetRLSPrincipalTags_Call {
+	return &MockProxy_GetRLSPrincipalTags_Call{Call: _e.mock.On("GetRLSPrincipalTags", _a0, _a1)}
+}
+
+func (_c *MockProxy_GetRLSPrincipalTags_Call) Run(run func(_a0 context.Context, _a1 *milvuspb.GetRLSPrincipalTagsRequest)) *MockProxy_GetRLSPrincipalTags_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.GetRLSPrincipalTagsRequest))
+	})
+	return _c
+}
+
+func (_c *MockProxy_GetRLSPrincipalTags_Call) Return(_a0 *milvuspb.GetRLSPrincipalTagsResponse, _a1 error) *MockProxy_GetRLSPrincipalTags_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockProxy_GetRLSPrincipalTags_Call) RunAndReturn(run func(context.Context, *milvuspb.GetRLSPrincipalTagsRequest) (*milvuspb.GetRLSPrincipalTagsResponse, error)) *MockProxy_GetRLSPrincipalTags_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -7167,6 +7344,65 @@ func (_c *MockProxy_ListPrivilegeGroups_Call) Return(_a0 *milvuspb.ListPrivilege
 }
 
 func (_c *MockProxy_ListPrivilegeGroups_Call) RunAndReturn(run func(context.Context, *milvuspb.ListPrivilegeGroupsRequest) (*milvuspb.ListPrivilegeGroupsResponse, error)) *MockProxy_ListPrivilegeGroups_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListRLSPrincipals provides a mock function with given fields: _a0, _a1
+func (_m *MockProxy) ListRLSPrincipals(_a0 context.Context, _a1 *milvuspb.ListRLSPrincipalsRequest) (*milvuspb.ListRLSPrincipalsResponse, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListRLSPrincipals")
+	}
+
+	var r0 *milvuspb.ListRLSPrincipalsResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.ListRLSPrincipalsRequest) (*milvuspb.ListRLSPrincipalsResponse, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.ListRLSPrincipalsRequest) *milvuspb.ListRLSPrincipalsResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*milvuspb.ListRLSPrincipalsResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.ListRLSPrincipalsRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockProxy_ListRLSPrincipals_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListRLSPrincipals'
+type MockProxy_ListRLSPrincipals_Call struct {
+	*mock.Call
+}
+
+// ListRLSPrincipals is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *milvuspb.ListRLSPrincipalsRequest
+func (_e *MockProxy_Expecter) ListRLSPrincipals(_a0 interface{}, _a1 interface{}) *MockProxy_ListRLSPrincipals_Call {
+	return &MockProxy_ListRLSPrincipals_Call{Call: _e.mock.On("ListRLSPrincipals", _a0, _a1)}
+}
+
+func (_c *MockProxy_ListRLSPrincipals_Call) Run(run func(_a0 context.Context, _a1 *milvuspb.ListRLSPrincipalsRequest)) *MockProxy_ListRLSPrincipals_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.ListRLSPrincipalsRequest))
+	})
+	return _c
+}
+
+func (_c *MockProxy_ListRLSPrincipals_Call) Return(_a0 *milvuspb.ListRLSPrincipalsResponse, _a1 error) *MockProxy_ListRLSPrincipals_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockProxy_ListRLSPrincipals_Call) RunAndReturn(run func(context.Context, *milvuspb.ListRLSPrincipalsRequest) (*milvuspb.ListRLSPrincipalsResponse, error)) *MockProxy_ListRLSPrincipals_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -9321,6 +9557,65 @@ func (_c *MockProxy_SetQueryNodeCreator_Call) RunAndReturn(run func(func(context
 	return _c
 }
 
+// SetRLSPrincipalTags provides a mock function with given fields: _a0, _a1
+func (_m *MockProxy) SetRLSPrincipalTags(_a0 context.Context, _a1 *milvuspb.SetRLSPrincipalTagsRequest) (*commonpb.Status, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetRLSPrincipalTags")
+	}
+
+	var r0 *commonpb.Status
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.SetRLSPrincipalTagsRequest) (*commonpb.Status, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.SetRLSPrincipalTagsRequest) *commonpb.Status); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*commonpb.Status)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.SetRLSPrincipalTagsRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockProxy_SetRLSPrincipalTags_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetRLSPrincipalTags'
+type MockProxy_SetRLSPrincipalTags_Call struct {
+	*mock.Call
+}
+
+// SetRLSPrincipalTags is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *milvuspb.SetRLSPrincipalTagsRequest
+func (_e *MockProxy_Expecter) SetRLSPrincipalTags(_a0 interface{}, _a1 interface{}) *MockProxy_SetRLSPrincipalTags_Call {
+	return &MockProxy_SetRLSPrincipalTags_Call{Call: _e.mock.On("SetRLSPrincipalTags", _a0, _a1)}
+}
+
+func (_c *MockProxy_SetRLSPrincipalTags_Call) Run(run func(_a0 context.Context, _a1 *milvuspb.SetRLSPrincipalTagsRequest)) *MockProxy_SetRLSPrincipalTags_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.SetRLSPrincipalTagsRequest))
+	})
+	return _c
+}
+
+func (_c *MockProxy_SetRLSPrincipalTags_Call) Return(_a0 *commonpb.Status, _a1 error) *MockProxy_SetRLSPrincipalTags_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockProxy_SetRLSPrincipalTags_Call) RunAndReturn(run func(context.Context, *milvuspb.SetRLSPrincipalTagsRequest) (*commonpb.Status, error)) *MockProxy_SetRLSPrincipalTags_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SetRates provides a mock function with given fields: _a0, _a1
 func (_m *MockProxy) SetRates(_a0 context.Context, _a1 *proxypb.SetRatesRequest) (*commonpb.Status, error) {
 	ret := _m.Called(_a0, _a1)
@@ -10056,6 +10351,65 @@ func (_c *MockProxy_UpdateResourceGroups_Call) Return(_a0 *commonpb.Status, _a1 
 }
 
 func (_c *MockProxy_UpdateResourceGroups_Call) RunAndReturn(run func(context.Context, *milvuspb.UpdateResourceGroupsRequest) (*commonpb.Status, error)) *MockProxy_UpdateResourceGroups_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateRowPolicy provides a mock function with given fields: _a0, _a1
+func (_m *MockProxy) UpdateRowPolicy(_a0 context.Context, _a1 *milvuspb.UpdateRowPolicyRequest) (*commonpb.Status, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateRowPolicy")
+	}
+
+	var r0 *commonpb.Status
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.UpdateRowPolicyRequest) (*commonpb.Status, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.UpdateRowPolicyRequest) *commonpb.Status); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*commonpb.Status)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.UpdateRowPolicyRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockProxy_UpdateRowPolicy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateRowPolicy'
+type MockProxy_UpdateRowPolicy_Call struct {
+	*mock.Call
+}
+
+// UpdateRowPolicy is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *milvuspb.UpdateRowPolicyRequest
+func (_e *MockProxy_Expecter) UpdateRowPolicy(_a0 interface{}, _a1 interface{}) *MockProxy_UpdateRowPolicy_Call {
+	return &MockProxy_UpdateRowPolicy_Call{Call: _e.mock.On("UpdateRowPolicy", _a0, _a1)}
+}
+
+func (_c *MockProxy_UpdateRowPolicy_Call) Run(run func(_a0 context.Context, _a1 *milvuspb.UpdateRowPolicyRequest)) *MockProxy_UpdateRowPolicy_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.UpdateRowPolicyRequest))
+	})
+	return _c
+}
+
+func (_c *MockProxy_UpdateRowPolicy_Call) Return(_a0 *commonpb.Status, _a1 error) *MockProxy_UpdateRowPolicy_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockProxy_UpdateRowPolicy_Call) RunAndReturn(run func(context.Context, *milvuspb.UpdateRowPolicyRequest) (*commonpb.Status, error)) *MockProxy_UpdateRowPolicy_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/parser/planparserv2/plan_parser_v2_test.go
+++ b/internal/parser/planparserv2/plan_parser_v2_test.go
@@ -37,6 +37,7 @@ const (
 	structArrayFieldID  = 1002
 	structSubStrFieldID = 1003
 	structSubIntFieldID = 1004
+	legacyNullFieldID   = 1005
 )
 
 func newTestSchema(EnableDynamicField bool) *schemapb.CollectionSchema {
@@ -264,7 +265,7 @@ func TestExpr_NullLiteral_LegacyNullField(t *testing.T) {
 	withNullField := func(dataType schemapb.DataType) *typeutil.SchemaHelper {
 		schema := newTestSchema(true)
 		schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
-			FieldID: 199, Name: "null", Description: "legacy field literally named null", DataType: dataType,
+			FieldID: legacyNullFieldID, Name: "null", Description: "legacy field literally named null", DataType: dataType,
 		})
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)

--- a/internal/parser/planparserv2/plan_parser_v2_test.go
+++ b/internal/parser/planparserv2/plan_parser_v2_test.go
@@ -21,6 +21,24 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
+// generatedFieldIDBase is the offset newTestSchema adds to each schemapb.DataType
+// enum value to derive that type's field ID, so the generated block spans
+// generatedFieldIDBase+0 .. generatedFieldIDBase+max(DataType) and grows on its
+// own whenever a DataType is added.
+const generatedFieldIDBase = 100
+
+// Field IDs for the fields newTestSchema writes by hand. They must stay clear of
+// the generated block above: these used to start at 130, which collided the
+// moment DataType gained values 30 and 31 (Decimal, UUID). Keep them well past
+// generatedFieldIDBase+max(DataType) -- 301 today, via DataType_Struct(201).
+const (
+	dynamicFieldID      = 1000
+	stringArrayFieldID  = 1001
+	structArrayFieldID  = 1002
+	structSubStrFieldID = 1003
+	structSubIntFieldID = 1004
+)
+
 func newTestSchema(EnableDynamicField bool) *schemapb.CollectionSchema {
 	fields := []*schemapb.FieldSchema{
 		{FieldID: 0, Name: "FieldID", IsPrimaryKey: false, Description: "field no.1", DataType: schemapb.DataType_Int64},
@@ -29,7 +47,7 @@ func newTestSchema(EnableDynamicField bool) *schemapb.CollectionSchema {
 	for name, value := range schemapb.DataType_value {
 		dataType := schemapb.DataType(value)
 		newField := &schemapb.FieldSchema{
-			FieldID: int64(100 + value), Name: name + "Field", IsPrimaryKey: false, Description: "", DataType: dataType,
+			FieldID: int64(generatedFieldIDBase + value), Name: name + "Field", IsPrimaryKey: false, Description: "", DataType: dataType,
 		}
 		if dataType == schemapb.DataType_Array {
 			newField.ElementType = schemapb.DataType_Int64
@@ -38,26 +56,26 @@ func newTestSchema(EnableDynamicField bool) *schemapb.CollectionSchema {
 	}
 	if EnableDynamicField {
 		fields = append(fields, &schemapb.FieldSchema{
-			FieldID: 130, Name: common.MetaFieldName, IsPrimaryKey: false, Description: "dynamic field", DataType: schemapb.DataType_JSON,
+			FieldID: dynamicFieldID, Name: common.MetaFieldName, IsPrimaryKey: false, Description: "dynamic field", DataType: schemapb.DataType_JSON,
 			IsDynamic: true,
 		})
 	}
 
 	fields = append(fields, &schemapb.FieldSchema{
-		FieldID: 131, Name: "StringArrayField", IsPrimaryKey: false, Description: "string array field",
+		FieldID: stringArrayFieldID, Name: "StringArrayField", IsPrimaryKey: false, Description: "string array field",
 		DataType:    schemapb.DataType_Array,
 		ElementType: schemapb.DataType_VarChar,
 	})
 
 	structArrayField := &schemapb.StructArrayFieldSchema{
-		FieldID: 132, Name: "struct_array", Fields: []*schemapb.FieldSchema{
+		FieldID: structArrayFieldID, Name: "struct_array", Fields: []*schemapb.FieldSchema{
 			{
-				FieldID: 133, Name: "struct_array[sub_str]", IsPrimaryKey: false, Description: "sub struct array field for string",
+				FieldID: structSubStrFieldID, Name: "struct_array[sub_str]", IsPrimaryKey: false, Description: "sub struct array field for string",
 				DataType:    schemapb.DataType_Array,
 				ElementType: schemapb.DataType_VarChar,
 			},
 			{
-				FieldID: 134, Name: "struct_array[sub_int]", IsPrimaryKey: false, Description: "sub struct array field for int",
+				FieldID: structSubIntFieldID, Name: "struct_array[sub_int]", IsPrimaryKey: false, Description: "sub struct array field for int",
 				DataType:    schemapb.DataType_Array,
 				ElementType: schemapb.DataType_Int32,
 			},
@@ -1415,7 +1433,7 @@ func TestExpr_StructArrayParentIsNull(t *testing.T) {
 	nullExpr := expr.GetNullExpr()
 	require.NotNil(t, nullExpr)
 	assert.Equal(t, planpb.NullExpr_IsNull, nullExpr.GetOp())
-	assert.Equal(t, int64(133), nullExpr.GetColumnInfo().GetFieldId())
+	assert.Equal(t, int64(structSubStrFieldID), nullExpr.GetColumnInfo().GetFieldId())
 	assert.Equal(t, schemapb.DataType_Array, nullExpr.GetColumnInfo().GetDataType())
 	assert.Equal(t, schemapb.DataType_VarChar, nullExpr.GetColumnInfo().GetElementType())
 	assert.True(t, nullExpr.GetColumnInfo().GetNullable())
@@ -1425,7 +1443,7 @@ func TestExpr_StructArrayParentIsNull(t *testing.T) {
 	nullExpr = expr.GetNullExpr()
 	require.NotNil(t, nullExpr)
 	assert.Equal(t, planpb.NullExpr_IsNotNull, nullExpr.GetOp())
-	assert.Equal(t, int64(133), nullExpr.GetColumnInfo().GetFieldId())
+	assert.Equal(t, int64(structSubStrFieldID), nullExpr.GetColumnInfo().GetFieldId())
 	assert.Equal(t, schemapb.DataType_Array, nullExpr.GetColumnInfo().GetDataType())
 	assert.True(t, nullExpr.GetColumnInfo().GetNullable())
 }
@@ -2688,7 +2706,7 @@ func Test_JSONContainsStructFieldUsesSubFieldNullable(t *testing.T) {
 			require.NotNil(t, jsonContainsExpr)
 			columnInfo := jsonContainsExpr.GetColumnInfo()
 			require.NotNil(t, columnInfo)
-			assert.Equal(t, int64(134), columnInfo.GetFieldId())
+			assert.Equal(t, int64(structSubIntFieldID), columnInfo.GetFieldId())
 			assert.Equal(t, schemapb.DataType_Array, columnInfo.GetDataType())
 			assert.Equal(t, schemapb.DataType_Int32, columnInfo.GetElementType())
 			assert.Equal(t, testcase.wantNullable, columnInfo.GetNullable())
@@ -3945,7 +3963,7 @@ func TestExpr_StructIndexField_PlanShape(t *testing.T) {
 
 	columnInfo := ure.GetColumnInfo()
 	require.NotNil(t, columnInfo)
-	assert.Equal(t, int64(134), columnInfo.GetFieldId())
+	assert.Equal(t, int64(structSubIntFieldID), columnInfo.GetFieldId())
 	assert.Equal(t, schemapb.DataType_Array, columnInfo.GetDataType())
 	assert.Equal(t, schemapb.DataType_Int32, columnInfo.GetElementType())
 	assert.Equal(t, []string{"0"}, columnInfo.GetNestedPath())
@@ -3962,7 +3980,7 @@ func TestExpr_StructIndexField_PlanShape(t *testing.T) {
 
 	columnInfo = te.GetColumnInfo()
 	require.NotNil(t, columnInfo)
-	assert.Equal(t, int64(133), columnInfo.GetFieldId())
+	assert.Equal(t, int64(structSubStrFieldID), columnInfo.GetFieldId())
 	assert.Equal(t, schemapb.DataType_Array, columnInfo.GetDataType())
 	assert.Equal(t, schemapb.DataType_VarChar, columnInfo.GetElementType())
 	assert.Equal(t, []string{"1"}, columnInfo.GetNestedPath())
@@ -3983,7 +4001,7 @@ func TestExpr_StructFieldArrayLength(t *testing.T) {
 
 	columnInfo := bae.GetLeft().GetColumnExpr().GetInfo()
 	require.NotNil(t, columnInfo)
-	assert.Equal(t, int64(133), columnInfo.GetFieldId())
+	assert.Equal(t, int64(structSubStrFieldID), columnInfo.GetFieldId())
 	assert.Equal(t, schemapb.DataType_Array, columnInfo.GetDataType())
 	assert.Equal(t, schemapb.DataType_VarChar, columnInfo.GetElementType())
 	assert.Empty(t, columnInfo.GetNestedPath())
@@ -4000,7 +4018,7 @@ func TestExpr_StructFieldArrayLength(t *testing.T) {
 
 	columnInfo = bae.GetLeft().GetColumnExpr().GetInfo()
 	require.NotNil(t, columnInfo)
-	assert.Equal(t, int64(134), columnInfo.GetFieldId())
+	assert.Equal(t, int64(structSubIntFieldID), columnInfo.GetFieldId())
 	assert.Equal(t, schemapb.DataType_Array, columnInfo.GetDataType())
 	assert.Equal(t, schemapb.DataType_Int32, columnInfo.GetElementType())
 	assert.Empty(t, columnInfo.GetNestedPath())
@@ -4134,7 +4152,7 @@ func TestExpr_StructIndexField_RangeForms(t *testing.T) {
 
 		columnInfo := bre.GetColumnInfo()
 		require.NotNil(t, columnInfo, tc.expr)
-		assert.Equal(t, int64(134), columnInfo.GetFieldId(), tc.expr)
+		assert.Equal(t, int64(structSubIntFieldID), columnInfo.GetFieldId(), tc.expr)
 		assert.Equal(t, schemapb.DataType_Array, columnInfo.GetDataType(), tc.expr)
 		assert.Equal(t, schemapb.DataType_Int32, columnInfo.GetElementType(), tc.expr)
 		assert.Equal(t, []string{"0"}, columnInfo.GetNestedPath(), tc.expr)

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/json-iterator/go v1.1.13-0.20220915233716-71ac16282d12
 	github.com/klauspost/compress v1.18.0
-	github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260712212354-7efdf25099dd
+	github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260803063812-659295cc95a3
 	github.com/minio/minio-go/v7 v7.0.73
 	github.com/panjf2000/ants/v2 v2.11.3
 	github.com/prometheus/client_golang v1.20.5

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -505,6 +505,8 @@ github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b h1:TfeY0NxYxZz
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b/go.mod h1:iwW+9cWfIzzDseEBCCeDSN5SD16Tidvy8cwQ7ZY8Qj4=
 github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260712212354-7efdf25099dd h1:q24BFW1uhH7VxueDw3t1V6a9RZuMorjyOya5+oxIUAE=
 github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260712212354-7efdf25099dd/go.mod h1:rbKpv5JToISTKTTLl0duL5r6wbYnjJ9SsD0QgXMzKy0=
+github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260803063812-659295cc95a3 h1:EnDFYLoneAhdn5EyJ1OOTcBXT90d4FgXW9BDRBVngTQ=
+github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260803063812-659295cc95a3/go.mod h1:rbKpv5JToISTKTTLl0duL5r6wbYnjJ9SsD0QgXMzKy0=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.73 h1:qr2vi96Qm7kZ4v7LLebjte+MQh621fFWnv93p12htEo=

--- a/pkg/util/fastpb/equiv_test.go
+++ b/pkg/util/fastpb/equiv_test.go
@@ -5,6 +5,9 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 
 	schemapb "github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -79,6 +82,55 @@ func TestEquiv_FieldData_ValidData(t *testing.T) {
 func TestEquiv_IDs(t *testing.T) {
 	roundTripSRD(t, &schemapb.SearchResultData{Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{10, 20, 30}}}}})
 	roundTripSRD(t, &schemapb.SearchResultData{Ids: &schemapb.IDs{IdField: &schemapb.IDs_StrId{StrId: &schemapb.StringArray{Data: []string{"k1", "k2"}}}}})
+	roundTripSRD(t, &schemapb.SearchResultData{Ids: &schemapb.IDs{IdField: &schemapb.IDs_UuidId{UuidId: &schemapb.UUIDArray{Data: [][]byte{
+		{0x55, 0x0e, 0x84, 0x00, 0xe2, 0x9b, 0x41, 0xd4, 0xa7, 0x16, 0x44, 0x66, 0x55, 0x44, 0x00, 0x00},
+		{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+	}}}}})
+	// Empty element and empty array: repeated bytes must round-trip both.
+	roundTripSRD(t, &schemapb.SearchResultData{Ids: &schemapb.IDs{IdField: &schemapb.IDs_UuidId{UuidId: &schemapb.UUIDArray{Data: [][]byte{{}}}}}})
+	roundTripSRD(t, &schemapb.SearchResultData{Ids: &schemapb.IDs{IdField: &schemapb.IDs_UuidId{UuidId: &schemapb.UUIDArray{}}}})
+}
+
+// TestEquiv_IDs_OneofLastWins pins that every IDs oneof variant is decoded
+// in-pass. proto.Marshal only ever emits the variant that is set, so a
+// single-variant payload cannot distinguish an in-pass case from the deferred
+// protoMerge fallback -- both produce the same value. The divergence needs two
+// variants on one wire: anything left to the fallback is merged *after* the
+// loop, so it wins regardless of position and breaks oneof last-wins.
+func TestEquiv_IDs_OneofLastWins(t *testing.T) {
+	uuid, err := proto.Marshal(&schemapb.UUIDArray{Data: [][]byte{{0xaa, 0xbb}}})
+	require.NoError(t, err)
+	ints, err := proto.Marshal(&schemapb.LongArray{Data: []int64{7}})
+	require.NoError(t, err)
+	strs, err := proto.Marshal(&schemapb.StringArray{Data: []string{"s"}})
+	require.NoError(t, err)
+
+	// uuid_id (3) first, then the variant that must win by position.
+	for name, last := range map[string][]byte{"int_id": ints, "str_id": strs} {
+		t.Run(name, func(t *testing.T) {
+			lastNum := protowire.Number(1)
+			if name == "str_id" {
+				lastNum = 2
+			}
+			var idsWire []byte
+			idsWire = protowire.AppendTag(idsWire, 3, protowire.BytesType)
+			idsWire = protowire.AppendBytes(idsWire, uuid)
+			idsWire = protowire.AppendTag(idsWire, lastNum, protowire.BytesType)
+			idsWire = protowire.AppendBytes(idsWire, last)
+
+			var wire []byte
+			wire = protowire.AppendTag(wire, 5, protowire.BytesType) // SearchResultData.ids
+			wire = protowire.AppendBytes(wire, idsWire)
+
+			var want schemapb.SearchResultData
+			require.NoError(t, proto.Unmarshal(wire, &want))
+
+			var got schemapb.SearchResultData
+			require.NoError(t, UnmarshalSearchResultData(wire, &got))
+
+			assert.True(t, proto.Equal(&want, &got), "official = %v, fastpb = %v", &want, &got)
+		})
+	}
 }
 
 func TestEquiv_SearchResultData_Full(t *testing.T) {

--- a/pkg/util/fastpb/message_merge_test.go
+++ b/pkg/util/fastpb/message_merge_test.go
@@ -144,6 +144,21 @@ func TestRepeatedMessageOneofMerge(t *testing.T) {
 		assert.True(t, proto.Equal(got, want), "got=%v want=%v", got, want)
 	})
 
+	// uuid_id(3) only started taking this branch in the change that hand-decoded it:
+	// before, a repeated field 3 fell through default -> rest -> protoMerge, an
+	// entirely different path from the duplicate guard it hits now.
+	t.Run("IDs.UuidId", func(t *testing.T) {
+		wire := concat(t,
+			&schemapb.IDs{IdField: &schemapb.IDs_UuidId{UuidId: &schemapb.UUIDArray{Data: [][]byte{{0xaa}}}}},
+			&schemapb.IDs{IdField: &schemapb.IDs_UuidId{UuidId: &schemapb.UUIDArray{Data: [][]byte{{0xbb}}}}},
+		)
+		want := &schemapb.IDs{}
+		require.NoError(t, proto.Unmarshal(wire, want))
+		got := &schemapb.IDs{}
+		require.NoError(t, dec{}.ids(wire, got))
+		assert.True(t, proto.Equal(got, want), "got=%v want=%v", got, want)
+	})
+
 	t.Run("different variants remain last-wins", func(t *testing.T) {
 		wire := concat(t,
 			&schemapb.FieldData{Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{}}},

--- a/pkg/util/fastpb/proto_contract_test.go
+++ b/pkg/util/fastpb/proto_contract_test.go
@@ -75,6 +75,7 @@ func TestProtoContract_FieldSetsPinned(t *testing.T) {
 		{"schemapb.DoubleArray", &schemapb.DoubleArray{}, []int{1}},
 		{"schemapb.BytesArray", &schemapb.BytesArray{}, []int{1}},
 		{"schemapb.JSONArray", &schemapb.JSONArray{}, []int{1}},
+		{"schemapb.UUIDArray", &schemapb.UUIDArray{}, []int{1}},
 		{"schemapb.StringArray", &schemapb.StringArray{}, []int{1}},
 	}
 	for _, c := range cases {

--- a/pkg/util/fastpb/proto_contract_test.go
+++ b/pkg/util/fastpb/proto_contract_test.go
@@ -57,14 +57,14 @@ func TestProtoContract_FieldSetsPinned(t *testing.T) {
 	}{
 		// top-level fast-pathed types (TryUnmarshal dispatch)
 		{"internalpb.RetrieveResults", &internalpb.RetrieveResults{}, []int{1, 2, 3, 4, 5, 6, 7, 8, 13, 14, 15, 16, 17, 18, 19}},
-		{"milvuspb.InsertRequest", &milvuspb.InsertRequest{}, []int{1, 2, 3, 4, 5, 6, 7, 8, 9}},
-		{"milvuspb.UpsertRequest", &milvuspb.UpsertRequest{}, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}},
+		{"milvuspb.InsertRequest", &milvuspb.InsertRequest{}, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}},
+		{"milvuspb.UpsertRequest", &milvuspb.UpsertRequest{}, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}},
 		{"schemapb.SearchResultData", &schemapb.SearchResultData{}, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17, 18, 19}},
 		// nested hand-decoded types (oneof-bearing — highest divergence risk)
 		{"schemapb.FieldData", &schemapb.FieldData{}, []int{1, 2, 3, 4, 5, 6, 7, 8}},
 		{"schemapb.ScalarField", &schemapb.ScalarField{}, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}},
 		{"schemapb.VectorField", &schemapb.VectorField{}, []int{1, 2, 3, 4, 5, 6, 7, 8}},
-		{"schemapb.IDs", &schemapb.IDs{}, []int{1, 2}},
+		{"schemapb.IDs", &schemapb.IDs{}, []int{1, 2, 3}},
 		// leaf arrays with their own hand-written field switches (no unknown-field
 		// fallback in some — a new field here would mis-parse)
 		{"schemapb.SparseFloatArray", &schemapb.SparseFloatArray{}, []int{1, 2}},

--- a/pkg/util/fastpb/searchresult.go
+++ b/pkg/util/fastpb/searchresult.go
@@ -212,7 +212,10 @@ func (d dec) searchResultData(b []byte, srd *schemapb.SearchResultData) error {
 	return nil
 }
 
-// unmarshalIDs decodes schemapb.IDs: oneof int_id (LongArray, 1) / str_id (StringArray, 2).
+// unmarshalIDs decodes schemapb.IDs: oneof int_id (LongArray, 1) / str_id
+// (StringArray, 2) / uuid_id (UUIDArray, 3). All three variants are decoded
+// in-pass -- a variant left to the deferred protoMerge would break oneof
+// last-wins ordering against the ones handled here.
 func (d dec) ids(b []byte, ids *schemapb.IDs) error {
 	full := b
 	var rest []byte
@@ -241,7 +244,7 @@ func (d dec) ids(b []byte, ids *schemapb.IDs) error {
 			return errMalformed
 		}
 		b = b[vn:]
-		if num == 1 || num == 2 {
+		if num == 1 || num == 2 || num == 3 {
 			if oneofNum == num {
 				return fallbackUnmarshal(full, ids)
 			}
@@ -260,6 +263,12 @@ func (d dec) ids(b []byte, ids *schemapb.IDs) error {
 				return err
 			}
 			ids.IdField = &schemapb.IDs_StrId{StrId: sa}
+		case 3:
+			ua := &schemapb.UUIDArray{}
+			if err := decodeRepeatedBytes(v, &ua.Data, ua); err != nil {
+				return err
+			}
+			ids.IdField = &schemapb.IDs_UuidId{UuidId: ua}
 		default:
 			rest = append(rest, start[:tn+vn]...)
 		}

--- a/tests/go_client/go.mod
+++ b/tests/go_client/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 require (
 	github.com/apache/arrow/go/v17 v17.0.0
 	github.com/cockroachdb/errors v1.9.1
-	github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260712212354-7efdf25099dd
+	github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260803063812-659295cc95a3
 	github.com/milvus-io/milvus/client/v3 v3.0.0
 	github.com/milvus-io/milvus/pkg/v3 v3.0.0-beta
 	github.com/minio/minio-go/v7 v7.0.73

--- a/tests/go_client/go.sum
+++ b/tests/go_client/go.sum
@@ -223,6 +223,8 @@ github.com/mediocregopher/radix/v3 v3.4.2/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
 github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260712212354-7efdf25099dd h1:q24BFW1uhH7VxueDw3t1V6a9RZuMorjyOya5+oxIUAE=
 github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260712212354-7efdf25099dd/go.mod h1:rbKpv5JToISTKTTLl0duL5r6wbYnjJ9SsD0QgXMzKy0=
+github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260803063812-659295cc95a3 h1:EnDFYLoneAhdn5EyJ1OOTcBXT90d4FgXW9BDRBVngTQ=
+github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260803063812-659295cc95a3/go.mod h1:rbKpv5JToISTKTTLl0duL5r6wbYnjJ9SsD0QgXMzKy0=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 h1:AMFGa4R4MiIpspGNG7Z948v4n35fFGB3RR3G/ry4FWs=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 h1:+n/aFZefKZp7spd8DFdX7uMikMLXX4oubIzJF4kv/wI=


### PR DESCRIPTION
issue: #52164

## Summary

`newTestSchema` in `planparserv2` derives one field ID per `DataType` enum value as `100+value`, then appends hand-written fields at **130-134**. Both live in one ID space, so the fixture only held while the highest non-vector `DataType` was 29. The proto now has `Decimal = 30` and `UUID = 31`, which generate 130 and 131 and collide with the dynamic field and `StringArrayField` — `CreateSchemaHelper` then rejects every schema the fixture builds, failing 8 tests.

This is latent rather than new: any future `DataType` addition would have hit it.

## Changes

**`internal/parser/planparserv2/plan_parser_v2_test.go`**
Move the hand-written fields to named constants past `100+max(DataType)` (301 today, via `DataType_Struct(201)`), and have the assertions reference those constants instead of repeating the literals.

**`pkg/util/fastpb/`**
Bumping milvus-proto far enough to reach that `DataType` range also trips `TestProtoContract_FieldSetsPinned`, because `schemapb.IDs` gained a third oneof variant, `uuid_id`.

The guard's own guidance requires a new oneof variant to be decoded in-pass: anything left to the deferred `protoMerge` is applied *after* the decode loop, so it wins regardless of wire position and breaks oneof last-wins. Added `case 3`, plus a test that puts `uuid_id` ahead of `int_id`/`str_id` on one wire — a single-variant payload cannot distinguish the two, since `proto.Marshal` only emits the variant that is set.

`InsertRequest` and `UpsertRequest` also gained `rls_principal` / `skip_rls`. Those are plain scalars, correct via the existing `default -> rest -> protoMerge` fallback, so only their golden sets are updated.

**`go.mod` ×4** — bump `milvus-proto/go-api/v3` to `v3.0.0-20260803063812-659295cc95a3`.

## Test Plan

- [x] `./internal/parser/planparserv2/` — ok (was 8 failures)
- [x] `pkg/util/fastpb/` — ok
- [x] `go build -tags dynamic ./internal/...`, `pkg`, `client` — ok
- [x] `gofumpt` / `gci` on all changed files — clean

Both new tests were verified to discriminate, each reverted afterwards:

- Removing `case 3` fails `TestEquiv_IDs_OneofLastWins` (both subtests) and nothing else. Note the plain round-trip cases added alongside it do **not** catch this — they pass with `case 3` removed, which is why the hand-built wire test exists.
- The fixture change is pinned by the existing 8 tests, which fail on the collision without it.

`make static-check` was **not** run: the local golangci-lint binary is incompatible with the current Go toolchain (`unsupported version: 2`). The gofumpt/gci checks above were run directly. Relying on CI for the full lint.

## Note for reviewers

This bump is what several pending PRs need in order to consume `PrivilegeImportBinlog` (milvus-proto#643) — master still pins the 2026-07-12 proto, three weeks behind. The `uuid_id` and RLS fields come from other people's proto changes that landed in between; there is no milvus-side implementation for either on master yet (`DataType_UUID`, `UUIDArray`, `IDs_UuidId` have no non-test usage). Landing this separately keeps the decoder change reviewable on its own rather than buried in an unrelated feature PR.
