### PR TITLE
fix: sync delegator snapshot for delete forwarding

### DIFF
--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -1454,11 +1454,7 @@ func (sd *shardDelegator) Close() {
 		sd.growingSourceProvider.Deactivate()
 	}
 
-	// Stop background snapshot loop before refunding candidates
 	sd.distribution.Close()
-
-	// Refund all sealed segment candidates in distribution
-	sd.distribution.RefundAllCandidates()
 
 	// clean idf oracle
 	if idfOracle := sd.getIDFOracle(); idfOracle != nil {

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -575,7 +575,6 @@ func (s *DelegatorDataSuite) TestProcessDelete() {
 		},
 	}, 10)
 
-	s.delegator.distribution.Flush()
 	s.False(s.delegator.distribution.Serviceable())
 
 	worker1.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).
@@ -598,7 +597,6 @@ func (s *DelegatorDataSuite) TestProcessDelete() {
 		Version: time.Now().UnixNano(),
 	})
 	s.Require().NoError(err)
-	s.delegator.distribution.Flush()
 	s.True(s.delegator.distribution.Serviceable())
 	// Test normal errors with retry and fail
 	worker1.ExpectedCalls = nil
@@ -611,7 +609,6 @@ func (s *DelegatorDataSuite) TestProcessDelete() {
 			RowCount:    1,
 		},
 	}, 10)
-	s.delegator.distribution.Flush()
 	s.False(s.delegator.distribution.Serviceable(), "should retry and failed")
 
 	// refresh
@@ -635,7 +632,6 @@ func (s *DelegatorDataSuite) TestProcessDelete() {
 		Version: time.Now().UnixNano(),
 	})
 	s.Require().NoError(err)
-	s.delegator.distribution.Flush()
 	s.True(s.delegator.distribution.Serviceable())
 
 	s.delegator.Close()
@@ -764,7 +760,6 @@ func (s *DelegatorDataSuite) TestLoadSegmentsWithBm25() {
 		})
 
 		s.NoError(err)
-		s.delegator.distribution.Flush()
 		sealed, _ := s.delegator.GetSegmentInfo(false)
 		s.Require().Equal(1, len(sealed))
 		s.Equal(int64(1), sealed[0].NodeID)
@@ -1092,7 +1087,6 @@ func (s *DelegatorDataSuite) TestLoadSegments() {
 		})
 
 		s.NoError(err)
-		s.delegator.distribution.Flush()
 		sealed, _ := s.delegator.GetSegmentInfo(false)
 		s.Require().Equal(1, len(sealed))
 		s.Equal(int64(1), sealed[0].NodeID)
@@ -1429,7 +1423,6 @@ func (s *DelegatorDataSuite) TestLoadSegmentsWithoutBloomFilter() {
 	})
 
 	s.Require().NoError(err)
-	s.delegator.distribution.Flush()
 	sealed, _ := s.delegator.GetSegmentInfo(false)
 	s.Require().Equal(1, len(sealed))
 	s.Require().Equal(1, len(sealed[0].Segments))
@@ -1819,7 +1812,6 @@ func (s *DelegatorDataSuite) TestReleaseSegment() {
 	})
 	s.Require().NoError(err)
 
-	s.delegator.distribution.Flush()
 	sealed, growing := s.delegator.GetSegmentInfo(false)
 	s.Require().Equal(1, len(sealed))
 	s.Equal(int64(1), sealed[0].NodeID)

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -450,7 +450,6 @@ func (s *DelegatorSuite) TestGetSegmentInfo() {
 		Version:     2001,
 	})
 
-	s.delegator.(*shardDelegator).distribution.Flush()
 	sealed, growing = s.delegator.GetSegmentInfo(false)
 	s.EqualValues([]SnapshotItem{
 		{
@@ -782,7 +781,6 @@ func (s *DelegatorSuite) TestSearch() {
 		sd, ok := s.delegator.(*shardDelegator)
 		s.Require().True(ok)
 		sd.distribution.MarkOfflineSegments(1001)
-		sd.distribution.Flush()
 
 		_, err := s.delegator.Search(ctx, &querypb.SearchRequest{
 			Req: &internalpb.SearchRequest{
@@ -971,7 +969,6 @@ func (s *DelegatorSuite) TestQuery() {
 		sd, ok := s.delegator.(*shardDelegator)
 		s.Require().True(ok)
 		sd.distribution.MarkOfflineSegments(1001)
-		sd.distribution.Flush()
 
 		_, err := s.delegator.Query(ctx, &querypb.QueryRequest{
 			Req:         &internalpb.RetrieveRequest{QueryLabel: "query", Base: commonpbutil.NewMsgBase()},
@@ -1255,7 +1252,6 @@ func (s *DelegatorSuite) TestQueryStream() {
 		sd, ok := s.delegator.(*shardDelegator)
 		s.Require().True(ok)
 		sd.distribution.MarkOfflineSegments(1001)
-		sd.distribution.Flush()
 
 		client := streamrpc.NewLocalQueryClient(ctx)
 		server := client.CreateServer()
@@ -1433,7 +1429,6 @@ func (s *DelegatorSuite) TestGetStats() {
 		sd, ok := s.delegator.(*shardDelegator)
 		s.Require().True(ok)
 		sd.distribution.MarkOfflineSegments(1001)
-		sd.distribution.Flush()
 
 		_, err := s.delegator.GetStatistics(ctx, &querypb.GetStatisticsRequest{
 			Req:         &internalpb.GetStatisticsRequest{Base: commonpbutil.NewMsgBase()},
@@ -1569,7 +1564,6 @@ func (s *DelegatorSuite) TestUpdateSchema() {
 		sd, ok := s.delegator.(*shardDelegator)
 		s.Require().True(ok)
 		sd.distribution.MarkOfflineSegments(1001)
-		sd.distribution.Flush()
 
 		err := s.delegator.UpdateSchema(ctx, newFunctionRuntimeTestSchemaWithVersion(s.nextSchemaVersion()), 100)
 		s.Error(err)

--- a/internal/querynodev2/delegator/distribution.go
+++ b/internal/querynodev2/delegator/distribution.go
@@ -122,13 +122,9 @@ type distribution struct {
 	idfOracle IDFOracle
 	// protects current & segments
 	mut sync.RWMutex
-
-	// async snapshot generation
-	snapshotNotifier chan struct{} // capacity 1, notify background goroutine to regenerate snapshot
-	snapshotClose    chan struct{} // closed to stop background goroutine
-	snapshotDone     chan struct{} // closed when background goroutine exits
-	closed           *atomic.Bool
-	closeOnce        sync.Once
+	// closed rejects late distribution updates after delegator shutdown.
+	// It is protected by mut so AddDistributions and Close are ordered.
+	closed bool
 
 	// distribution info
 	channelName string
@@ -156,50 +152,17 @@ type SegmentEntry struct {
 
 func NewDistribution(channelName string, queryView *channelQueryView) *distribution {
 	dist := &distribution{
-		channelName:      channelName,
-		growingSegments:  make(map[UniqueID]SegmentEntry),
-		sealedSegments:   make(map[UniqueID]SegmentEntry),
-		snapshots:        typeutil.NewConcurrentMap[int64, *snapshot](),
-		current:          atomic.NewPointer[snapshot](nil),
-		queryView:        queryView,
-		snapshotNotifier: make(chan struct{}, 1),
-		snapshotClose:    make(chan struct{}),
-		snapshotDone:     make(chan struct{}),
-		closed:           atomic.NewBool(false),
+		channelName:     channelName,
+		growingSegments: make(map[UniqueID]SegmentEntry),
+		sealedSegments:  make(map[UniqueID]SegmentEntry),
+		snapshots:       typeutil.NewConcurrentMap[int64, *snapshot](),
+		current:         atomic.NewPointer[snapshot](nil),
+		queryView:       queryView,
 	}
 	// generate initial snapshot synchronously
 	dist.genSnapshot()
 	dist.updateServiceable("NewDistribution")
-	// start background snapshot loop
-	go dist.snapshotLoop()
 	return dist
-}
-
-// notifySnapshotUpdate sends a non-blocking notification to regenerate snapshot.
-func (d *distribution) notifySnapshotUpdate() {
-	if d.closed.Load() {
-		return
-	}
-	select {
-	case d.snapshotNotifier <- struct{}{}:
-	default:
-	}
-}
-
-// snapshotLoop runs in a background goroutine, regenerating snapshot on notification.
-func (d *distribution) snapshotLoop() {
-	defer close(d.snapshotDone)
-	for {
-		select {
-		case <-d.snapshotClose:
-			return
-		case <-d.snapshotNotifier:
-			d.mut.Lock()
-			d.genSnapshot()
-			d.updateServiceable("snapshotLoop")
-			d.mut.Unlock()
-		}
-	}
 }
 
 func (d *distribution) SetIDFOracle(idfOracle IDFOracle) {
@@ -395,19 +358,20 @@ func (d *distribution) updateServiceable(triggerAction string) {
 
 // AddDistributions add multiple segment entries.
 func (d *distribution) AddDistributions(entries ...SegmentEntry) {
+	d.mut.Lock()
 	var toRefund []pkoracle.Candidate
-
-	if d.closed.Load() {
+	updated := false
+	if d.closed {
 		for _, entry := range entries {
 			if entry.Candidate != nil {
 				toRefund = append(toRefund, entry.Candidate)
 			}
 		}
+		d.mut.Unlock()
 		refundCandidates(toRefund)
 		return
 	}
 
-	d.mut.Lock()
 	for _, entry := range entries {
 		oldEntry, ok := d.sealedSegments[entry.SegmentID]
 		if ok && oldEntry.Version >= entry.Version {
@@ -433,10 +397,15 @@ func (d *distribution) AddDistributions(entries ...SegmentEntry) {
 			entry.TargetVersion = unreadableTargetVersion
 		}
 		d.sealedSegments[entry.SegmentID] = entry
+		updated = true
+	}
+
+	if updated {
+		d.genSnapshot()
+		d.updateServiceable("AddDistributions")
 	}
 	d.mut.Unlock()
 
-	d.notifySnapshotUpdate()
 	refundCandidates(toRefund)
 }
 
@@ -449,9 +418,7 @@ func refundCandidates(candidates []pkoracle.Candidate) {
 
 // AddGrowing adds growing segment distribution.
 // genSnapshot is called synchronously so that the growing segment is
-// immediately visible to searches. Growing segments are created
-// infrequently (only on the first insert for each segment), so this
-// does not regress the lock-contention optimization.
+// immediately visible to searches.
 func (d *distribution) AddGrowing(entries ...SegmentEntry) {
 	d.mut.Lock()
 	for _, entry := range entries {
@@ -464,6 +431,8 @@ func (d *distribution) AddGrowing(entries ...SegmentEntry) {
 // AddOffline set segmentIDs to offlines.
 func (d *distribution) MarkOfflineSegments(segmentIDs ...int64) {
 	d.mut.Lock()
+	defer d.mut.Unlock()
+
 	updated := false
 	for _, segmentID := range segmentIDs {
 		entry, ok := d.sealedSegments[segmentID]
@@ -476,13 +445,13 @@ func (d *distribution) MarkOfflineSegments(segmentIDs ...int64) {
 		entry.NodeID = -1
 		d.sealedSegments[segmentID] = entry
 	}
-	d.mut.Unlock()
 
 	if updated {
 		mlog.Info(context.TODO(), "mark sealed segment offline from distribution",
 			mlog.String("channelName", d.channelName),
 			mlog.Int64s("segmentIDs", segmentIDs))
-		d.notifySnapshotUpdate()
+		d.genSnapshot()
+		d.updateServiceable("MarkOfflineSegments")
 	}
 }
 
@@ -599,17 +568,6 @@ func (d *distribution) RemoveDistributions(sealedSegments []SegmentEntry, growin
 		delete(d.growingSegments, growing.SegmentID)
 	}
 
-	// Capture current snapshot's cleared channel. The next genSnapshot will
-	// create a new snapshot and expire this one, closing the channel.
-	var signal chan struct{}
-	if current := d.current.Load(); current != nil {
-		signal = current.cleared
-	} else {
-		signal = make(chan struct{})
-		close(signal)
-	}
-	d.mut.Unlock()
-
 	mlog.Info(context.TODO(), "remove segments from distribution",
 		mlog.String("channelName", d.channelName),
 		mlog.Int64s("growing", lo.Map(growingSegments, func(s SegmentEntry, _ int) int64 { return s.SegmentID })),
@@ -617,7 +575,12 @@ func (d *distribution) RemoveDistributions(sealedSegments []SegmentEntry, growin
 		mlog.Int("sealedCandidatesRefunded", len(toRefund)),
 	)
 
-	d.notifySnapshotUpdate()
+	d.updateServiceable("RemoveDistributions")
+	// wait previous read even not distribution changed
+	// in case of segment balance caused segment lost track
+	signal := d.genSnapshot()
+	d.mut.Unlock()
+
 	refundCandidates(toRefund)
 
 	return signal
@@ -803,32 +766,18 @@ func BatchGetFromSegments(pks []storage.PrimaryKey, partitionID int64, sealed []
 	return result
 }
 
-// Flush synchronously generates a snapshot so that subsequent reads
-// (e.g. PeekSegments) see the latest distribution state.
-// This is useful in tests and in scenarios that require immediate consistency.
-func (d *distribution) Flush() {
-	d.mut.Lock()
-	d.genSnapshot()
-	d.updateServiceable("Flush")
-	d.mut.Unlock()
-}
-
-// Close stops the background snapshot loop and waits for it to exit.
+// Close marks distribution closed and refunds all sealed segment candidates.
 func (d *distribution) Close() {
-	d.closeOnce.Do(func() {
-		d.closed.Store(true)
-		close(d.snapshotClose)
-	})
-	<-d.snapshotDone
+	d.mut.Lock()
+	d.closed = true
+	toRefund := d.drainSealedCandidatesLocked()
+	d.mut.Unlock()
+
+	refundCandidates(toRefund)
 }
 
-// RefundAllCandidates refunds resources for all sealed segment candidates.
-// Used during shutdown to clean up and refund resources.
-// Note: Growing segment candidates (LocalSegment) are managed by segmentManager.
-func (d *distribution) RefundAllCandidates() {
-	d.mut.Lock()
-	var toRefund []pkoracle.Candidate
-
+func (d *distribution) drainSealedCandidatesLocked() []pkoracle.Candidate {
+	toRefund := make([]pkoracle.Candidate, 0)
 	// Only refund sealed segment candidates
 	// Growing segment candidates (LocalSegment) are managed by segmentManager
 	for segmentID, entry := range d.sealedSegments {
@@ -838,7 +787,5 @@ func (d *distribution) RefundAllCandidates() {
 			d.sealedSegments[segmentID] = entry
 		}
 	}
-	d.mut.Unlock()
-
-	refundCandidates(toRefund)
+	return toRefund
 }

--- a/internal/querynodev2/delegator/distribution_test.go
+++ b/internal/querynodev2/delegator/distribution_test.go
@@ -17,6 +17,7 @@
 package delegator
 
 import (
+	"runtime"
 	"testing"
 	"time"
 
@@ -43,10 +44,34 @@ func (s *DistributionSuite) SetupTest() {
 }
 
 func (s *DistributionSuite) TearDownTest() {
-	if s.dist != nil {
-		s.dist.Close()
-	}
 	s.dist = nil
+}
+
+func TestAddDistributionsPublishesSnapshotSynchronously(t *testing.T) {
+	oldProcs := runtime.GOMAXPROCS(1)
+	defer runtime.GOMAXPROCS(oldProcs)
+
+	paramtable.Init()
+	dist := NewDistribution("channel-1", NewChannelQueryView(nil, nil, []int64{1}, initialTargetVersion))
+
+	dist.AddDistributions(SegmentEntry{
+		NodeID:      1,
+		SegmentID:   1,
+		PartitionID: 1,
+	})
+
+	sealed, _, version := dist.PinOnlineSegments()
+	defer dist.Unpin(version)
+
+	requireSnapshot := assert.New(t)
+	if requireSnapshot.Len(sealed, 1) {
+		requireSnapshot.ElementsMatch([]SegmentEntry{{
+			NodeID:        1,
+			SegmentID:     1,
+			PartitionID:   1,
+			TargetVersion: unreadableTargetVersion,
+		}}, sealed[0].Segments)
+	}
 }
 
 func (s *DistributionSuite) TestAddDistribution() {
@@ -196,7 +221,6 @@ func (s *DistributionSuite) TestAddDistribution() {
 			_, _, _, version, err := s.dist.PinReadableSegments(1.0, 1)
 			s.Require().NoError(err)
 			s.dist.AddDistributions(tc.input...)
-			s.dist.Flush()
 			sealed, _ := s.dist.PeekSegments(false)
 			s.compareSnapshotItems(tc.expected, sealed)
 			s.dist.Unpin(version)
@@ -633,7 +657,6 @@ func (s *DistributionSuite) TestPeek() {
 			defer s.TearDownTest()
 
 			s.dist.AddDistributions(tc.input...)
-			s.dist.Flush()
 			sealed, _ := s.dist.PeekSegments(tc.readable)
 			s.compareSnapshotItems(tc.expected, sealed)
 		})
@@ -707,7 +730,6 @@ func (s *DistributionSuite) TestMarkOfflineSegments() {
 				notifiedChannels = append(notifiedChannels, channel)
 			}
 			s.dist.MarkOfflineSegments(tc.offlines...)
-			s.dist.Flush()
 			s.Equal(tc.serviceable, s.dist.Serviceable())
 			if tc.notify {
 				s.Equal([]string{s.dist.channelName}, notifiedChannels)
@@ -841,13 +863,12 @@ func TestDistribution_NewDistribution(t *testing.T) {
 	assert.NotNil(t, dist.current)
 }
 
-func TestDistribution_NotifyAfterClose(t *testing.T) {
+func TestDistribution_AddDistributionsAfterClose(t *testing.T) {
 	dist := NewDistribution("test_channel", NewChannelQueryView(nil, nil, []int64{1}, initialTargetVersion))
 	dist.Close()
-	refunded := false
+	refundCount := 0
 
 	assert.NotPanics(t, func() {
-		dist.notifySnapshotUpdate()
 		dist.AddDistributions(SegmentEntry{
 			NodeID:      1,
 			SegmentID:   1,
@@ -855,12 +876,39 @@ func TestDistribution_NotifyAfterClose(t *testing.T) {
 			Version:     1,
 			Candidate: &refundTrackingCandidate{
 				mockCandidate: mockCandidate{id: 1, partition: 1},
-				refunded:      &refunded,
+				refundCount:   &refundCount,
 			},
 		})
 	})
-	assert.True(t, refunded)
+	assert.Equal(t, 1, refundCount)
 	assert.False(t, dist.SealedSegmentExists(1))
+}
+
+func TestDistribution_CloseRefundsExistingCandidate(t *testing.T) {
+	dist := NewDistribution("test_channel", NewChannelQueryView(nil, nil, []int64{1}, initialTargetVersion))
+	refundCount := 0
+	dist.AddDistributions(SegmentEntry{
+		NodeID:      1,
+		SegmentID:   1,
+		PartitionID: 1,
+		Version:     1,
+		Candidate: &refundTrackingCandidate{
+			mockCandidate: mockCandidate{id: 1, partition: 1},
+			refundCount:   &refundCount,
+		},
+	})
+
+	assert.True(t, dist.SealedSegmentExists(1))
+	assert.Zero(t, refundCount)
+
+	dist.Close()
+
+	assert.Equal(t, 1, refundCount)
+	dist.mut.RLock()
+	entry, ok := dist.sealedSegments[1]
+	dist.mut.RUnlock()
+	assert.True(t, ok)
+	assert.Nil(t, entry.Candidate)
 }
 
 func TestDistribution_UpdateServiceable(t *testing.T) {
@@ -1502,10 +1550,6 @@ func TestPinReadableSegments(t *testing.T) {
 			SealedSegmentRowCount: map[int64]int64{1: 100, 2: 100},
 			GrowingInTarget:       []int64{},
 		}, []int64{1})
-		// Flush pending snapshot and stop background goroutine to avoid
-		// data race with mockey patches in sub-tests.
-		dist.Flush()
-		dist.Close()
 		return dist
 	}
 
@@ -1589,10 +1633,6 @@ func TestPinReadableSegments_ServiceableLogic(t *testing.T) {
 		GrowingInTarget:       []int64{},
 	}, []int64{1})
 
-	// Stop background goroutine to avoid data race with mockey patches.
-	dist.Flush()
-	dist.Close()
-
 	// Test case: requireFullResult=true, Serviceable=false, GetLoadedRatio=1.0
 	// This tests the case where load ratio is satisfied but serviceable is false
 	mockServiceable := mockey.Mock((*channelQueryView).Serviceable).Return(false).Build()
@@ -1625,10 +1665,6 @@ func TestPinReadableSegments_LoadRatioLogic(t *testing.T) {
 		GrowingInTarget:       []int64{},
 	}, []int64{1})
 
-	// Stop background goroutine to avoid data race with mockey patches.
-	dist.Flush()
-	dist.Close()
-
 	// Test case: requireFullResult=false, loadRatioSatisfy=false
 	// This tests the case where partial result is requested but load ratio is insufficient
 	mockGetLoadedRatio := mockey.Mock((*channelQueryView).GetLoadedRatio).Return(0.3).Build()
@@ -1658,10 +1694,6 @@ func TestPinReadableSegments_EdgeCases(t *testing.T) {
 		SealedSegmentRowCount: map[int64]int64{1: 100},
 		GrowingInTarget:       []int64{},
 	}, []int64{1})
-
-	// Stop background goroutine to avoid data race with mockey patches.
-	dist.Flush()
-	dist.Close()
 
 	// Test case 1: requiredLoadRatio = 0.0 (edge case)
 	mockGetLoadedRatio := mockey.Mock((*channelQueryView).GetLoadedRatio).Return(0.0).Build()
@@ -1723,10 +1755,6 @@ func TestPinReadableSegments_PartialResultNotEmpty(t *testing.T) {
 		GrowingInTarget:       []int64{},
 	}, []int64{1})
 
-	// Stop background goroutine to avoid data race with mockey patches.
-	dist.Flush()
-	dist.Close()
-
 	// Call PinReadableSegments with partial result enabled (requiredLoadRatio < 1.0)
 	sealed, growing, _, _, err := dist.PinReadableSegments(0.8, 1)
 
@@ -1784,11 +1812,11 @@ func (m *mockCandidate) Refund()                                  {}
 
 type refundTrackingCandidate struct {
 	mockCandidate
-	refunded *bool
+	refundCount *int
 }
 
 func (m *refundTrackingCandidate) Refund() {
-	*m.refunded = true
+	(*m.refundCount)++
 }
 
 func TestBatchGetFromSegments(t *testing.T) {


### PR DESCRIPTION
issue: #52166

## What this PR does

This PR restores synchronous publication of delegator distribution snapshots after sealed segment add, remove, and offline updates.

It closes the visibility gap where a sealed segment had completed load-time delete replay and was present in the live distribution map, but a subsequent streaming delete could still pin the previous snapshot and skip that segment before the asynchronous snapshot loop published the update.

The change also removes the background snapshot loop and test-only flush path, and serializes distribution shutdown with late sealed candidate additions so Bloom filter resource accounting is refunded correctly.

## Why

`loadStreamDelete` publishes a newly loaded sealed segment while holding the final `deleteMut.RLock` barrier. Snapshot publication must complete before that barrier is released so the next `ProcessDelete` call observes the segment through `PinOnlineSegments`.

Updating only the live distribution map and notifying an asynchronous snapshot worker breaks that atomic contract.

## Test Plan

- [x] `git diff --check upstream/master...HEAD`
- [x] `make static-check`
- [x] `go test -v -count=1 -tags dynamic,test -gcflags="all=-N -l" ./internal/querynodev2/delegator -run 'Test(AddDistributionsPublishesSnapshotSynchronously|Distribution_AddDistributionsAfterClose|Distribution_CloseRefundsExistingCandidate)$|TestStreamingForward/(TestBFStreamingForward|TestDirectStreamingForward)$|TestDistributionSuite/(TestRemoveDistribution|TestMarkOfflineSegments)$'`