### PR TITLE
fix: [3.0] use assigned score as toleration baseline

### DIFF
--- a/internal/querycoordv2/assign/assign_policy_components.go
+++ b/internal/querycoordv2/assign/assign_policy_components.go
@@ -63,8 +63,9 @@ type benefitEvaluator interface {
 	// HasEnoughBenefit checks if the assignment from source to target is beneficial enough
 	// sourceScore: current score of source node
 	// targetScore: current score of target node
+	// targetAssignedScore: assigned (quota) score of target node, always non-negative
 	// resourceScore: score of the resource to be assigned
-	HasEnoughBenefit(sourceScore float64, targetScore float64, resourceScore int64) bool
+	HasEnoughBenefit(sourceScore float64, targetScore float64, targetAssignedScore float64, resourceScore int64) bool
 }
 
 // ============================================================================
@@ -128,10 +129,13 @@ type commonScoreBasedBenefitEvaluator struct{}
 // It considers:
 // 1. Score unbalance toleration factor
 // 2. Reverse unbalance toleration factor (if assignment would reverse the balance)
-func (e *commonScoreBasedBenefitEvaluator) HasEnoughBenefit(sourceScore float64, targetScore float64, resourceScore int64) bool {
-	// Check if the score diff between source and target is below tolerance
+func (e *commonScoreBasedBenefitEvaluator) HasEnoughBenefit(sourceScore float64, targetScore float64, targetAssignedScore float64, resourceScore int64) bool {
+	// Check if the score diff between source and target is below tolerance.
+	// targetAssignedScore (the target's quota) is used as the baseline instead of targetScore
+	// because targetScore is a priority (currentScore - assignedScore) and can be negative for
+	// a balance target, which would make this check pass unconditionally.
 	oldPriorityDiff := math.Abs(sourceScore - targetScore)
-	if oldPriorityDiff < targetScore*params.Params.QueryCoordCfg.ScoreUnbalanceTolerationFactor.GetAsFloat() {
+	if oldPriorityDiff < targetAssignedScore*params.Params.QueryCoordCfg.ScoreUnbalanceTolerationFactor.GetAsFloat() {
 		return false
 	}
 
@@ -154,6 +158,7 @@ func (e *commonScoreBasedBenefitEvaluator) HasEnoughBenefitForNodes(sourceNode *
 	return e.HasEnoughBenefit(
 		float64(sourceNode.getPriority()),
 		float64(targetNode.getPriority()),
+		targetNode.GetAssignedScore(),
 		int64(scoreChanges),
 	)
 }

--- a/internal/querycoordv2/assign/assign_policy_components_test.go
+++ b/internal/querycoordv2/assign/assign_policy_components_test.go
@@ -1,0 +1,50 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package assign
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+// TestHasEnoughBenefitForNodes_NegativeTargetPriority reproduces a case where the target
+// node's priority (currentScore - assignedScore) is negative, which used to make the
+// ScoreUnbalanceTolerationFactor check a no-op regardless of how small the actual diff was.
+func TestHasEnoughBenefitForNodes_NegativeTargetPriority(t *testing.T) {
+	paramtable.Init()
+	evaluator := &commonScoreBasedBenefitEvaluator{}
+
+	// Two nodes with ~6.3M assigned quota each, but current load noise pushes their
+	// priorities apart by ~4%, well under the default 5% toleration.
+	source := NewNodeItem(6417000, 1)
+	source.AssignedScore = 6350000 // priority = +67000
+
+	target := NewNodeItem(6164000, 2)
+	target.AssignedScore = 6350000 // priority = -186000 (negative)
+
+	// diff = |67000 - (-186000)| = 253000, target assigned score * 5% = 317500 -> should be blocked
+	assert.False(t, evaluator.HasEnoughBenefitForNodes(&source, &target, 59000))
+
+	// A genuine imbalance (diff > 5% of assigned score) should still trigger a move
+	bigSource := NewNodeItem(7000000, 3)
+	bigSource.AssignedScore = 6350000 // priority = +650000 (~10%)
+
+	assert.True(t, evaluator.HasEnoughBenefitForNodes(&bigSource, &target, 59000))
+}


### PR DESCRIPTION
issue: #52092
pr: #52093

### What changed

- Backport the ScoreBasedBalancer toleration fix from master to 3.0.
- Use the target node's assigned score as the tolerance baseline.
- Keep small priority differences below the configured factor from
  generating balance plans.
- Retain balancing for genuine differences above the threshold.
- Add regression coverage for a negative target priority.

### Why

The target priority is `currentScore - assignedScore` and is normally
negative for an underloaded balance target. Comparing an absolute
priority difference with this negative value made the toleration check
a no-op, so small segments could move without enough balancing benefit.

### Behavior boundary

Only the score-unbalance toleration baseline changes. The reverse
unbalance check and handling above the configured threshold are
unchanged.

### Branch adaptation

The master patch applies cleanly to 3.0 without branch-specific
changes.

### Validation

- Not run; local validation was explicitly skipped at user request.