### PR TITLE
test: add REST ordering, aggregation, and schema evolution coverage

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_search_aggregation.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_aggregation.py
@@ -161,6 +161,61 @@ class TestSearchAggregation(TestMilvusClientV2Base):
         prices = [hit.fields[self.price_field] for hit in hits]
         assert prices == sorted(prices)
 
+    @staticmethod
+    def _l2_score(query_vector, vector):
+        return math.fsum((left - right) ** 2 for left, right in zip(query_vector, vector))
+
+    def _expected_brand_aggregation(self, query_vector, bucket_size, top_hit_size):
+        ranked_rows = []
+        for row in self._rows():
+            vector = row[self.vector_field]
+            brand = row[self.brand_field]
+            if vector is None or brand is None:
+                continue
+            ranked_rows.append(
+                (
+                    self._l2_score(query_vector, vector),
+                    row[self.primary_field],
+                    brand,
+                )
+            )
+        ranked_rows.sort()
+
+        expected_groups = {}
+        for score, primary_key, brand in ranked_rows:
+            if brand not in expected_groups:
+                if len(expected_groups) >= bucket_size:
+                    continue
+                expected_groups[brand] = []
+            if len(expected_groups[brand]) < top_hit_size:
+                expected_groups[brand].append((primary_key, score))
+            if len(expected_groups) == bucket_size and all(
+                len(hits) == top_hit_size for hits in expected_groups.values()
+            ):
+                break
+
+        assert len(expected_groups) == bucket_size
+        assert all(len(hits) == top_hit_size for hits in expected_groups.values())
+        return expected_groups
+
+    def _normalize_brand_aggregation(self, buckets):
+        return tuple(
+            (
+                self._key_value(bucket, self.brand_field),
+                bucket.count,
+                bucket.metrics["doc_count"],
+                tuple(
+                    (
+                        hit.pk,
+                        round(float(hit.score), 6),
+                        tuple(sorted(hit.fields.items())),
+                    )
+                    for hit in bucket.hits
+                ),
+            )
+            for bucket in buckets
+        )
+
     @pytest.mark.tags(CaseLabel.L1)
     def test_search_aggregation_minimal_parameters(self):
         """
@@ -189,6 +244,70 @@ class TestSearchAggregation(TestMilvusClientV2Base):
             assert len(buckets) == 1
             assert [entry["field_name"] for entry in buckets[0].key] == [self.brand_field]
             assert buckets[0].count >= 1
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.parametrize(
+        "bucket_size",
+        [2, 4],
+        ids=["two-buckets", "all-four-buckets"],
+    )
+    def test_search_aggregation_limit_and_size_combinations(self, bucket_size):
+        """
+        target: verify ordinary search limit does not change exact search_aggregation buckets or topHits
+        method: compare limit smaller than, equal to, and greater than one bucket size against an independent FLAT/L2 oracle
+        expected: every limit returns identical exact bucket keys, counts, hit IDs, fields, and L2 scores
+        """
+        top_hit_size = 2
+        query_vector = self._query_vectors()[0]
+        limits = [1, bucket_size, bucket_size + 1]
+        expected_groups = self._expected_brand_aggregation(query_vector, bucket_size, top_hit_size)
+        client = self._client(alias=self.shared_alias)
+        normalized_by_limit = {}
+
+        for limit in limits:
+            res, _ = self.search(
+                client,
+                self.collection_name,
+                data=[query_vector],
+                anns_field=self.vector_field,
+                search_params=self._search_params(),
+                limit=limit,
+                filter=self._non_null_expr(self.brand_field),
+                output_fields=[self.brand_field],
+                search_aggregation=SearchAggregation(
+                    fields=[self.brand_field],
+                    size=bucket_size,
+                    metrics={"doc_count": {"count": "*"}},
+                    order=[{"_key": "asc"}],
+                    top_hits=TopHits(size=top_hit_size, sort=[{"_score": "asc"}]),
+                ),
+            )
+
+            assert len(res.agg_buckets) == 1
+            buckets = res.agg_buckets[0]
+            assert len(buckets) == bucket_size
+            keys = [self._key_value(bucket, self.brand_field) for bucket in buckets]
+            assert keys == sorted(expected_groups)
+
+            for bucket in buckets:
+                brand = self._key_value(bucket, self.brand_field)
+                expected_hits = expected_groups[brand]
+                assert bucket.count == top_hit_size
+                assert bucket.metrics["doc_count"] == top_hit_size
+                assert len(bucket.hits) == top_hit_size
+                assert [hit.pk for hit in bucket.hits] == [primary_key for primary_key, _ in expected_hits]
+                assert [hit.score for hit in bucket.hits] == pytest.approx(
+                    [score for _, score in expected_hits],
+                    rel=1e-5,
+                    abs=1e-6,
+                )
+                assert [hit.fields for hit in bucket.hits] == [{self.brand_field: brand}] * top_hit_size
+                self._assert_scores_ascending(bucket.hits)
+
+            normalized_by_limit[limit] = self._normalize_brand_aggregation(buckets)
+
+        baseline = normalized_by_limit[limits[0]]
+        assert all(normalized_by_limit[limit] == baseline for limit in limits[1:])
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_search_aggregation_range_search(self):

--- a/tests/python_client/milvus_client/test_milvus_client_search_aggregation.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_aggregation.py
@@ -277,7 +277,13 @@ class TestSearchAggregation(TestMilvusClientV2Base):
                 search_aggregation=SearchAggregation(
                     fields=[self.brand_field],
                     size=bucket_size,
-                    metrics={"doc_count": {"count": "*"}},
+                    metrics={
+                        "doc_count": {"count": "*"},
+                        "score_sum": {"sum": "_score"},
+                        "score_avg": {"avg": "_score"},
+                        "score_min": {"min": "_score"},
+                        "score_max": {"max": "_score"},
+                    },
                     order=[{"_key": "asc"}],
                     top_hits=TopHits(size=top_hit_size, sort=[{"_score": "asc"}]),
                 ),
@@ -303,6 +309,11 @@ class TestSearchAggregation(TestMilvusClientV2Base):
                 )
                 assert [hit.fields for hit in bucket.hits] == [{self.brand_field: brand}] * top_hit_size
                 self._assert_scores_ascending(bucket.hits)
+                expected_scores = [score for _, score in expected_hits]
+                assert bucket.metrics["score_sum"] == pytest.approx(sum(expected_scores))
+                assert bucket.metrics["score_avg"] == pytest.approx(sum(expected_scores) / len(expected_scores))
+                assert bucket.metrics["score_min"] == pytest.approx(min(expected_scores))
+                assert bucket.metrics["score_max"] == pytest.approx(max(expected_scores))
 
             normalized_by_limit[limit] = self._normalize_brand_aggregation(buckets)
 

--- a/tests/restful_client_v2/api/milvus.py
+++ b/tests/restful_client_v2/api/milvus.py
@@ -559,6 +559,28 @@ class CollectionClient(Requests):
         response = self.post(url, headers=self.update_headers(), data=payload)
         return response.json()
 
+    def add_function_field(self, payload, db_name="default"):
+        """Add a function together with its output field and bound index."""
+        url = f"{self.endpoint}/v2/vectordb/collections/add_function_field"
+        payload = copy.deepcopy(payload)
+        if self.db_name is not None:
+            payload["dbName"] = self.db_name
+        if db_name != "default":
+            payload["dbName"] = db_name
+        response = self.post(url, headers=self.update_headers(), data=payload)
+        return response.json()
+
+    def drop_function_field(self, payload, db_name="default"):
+        """Drop a function together with its output field and bound index."""
+        url = f"{self.endpoint}/v2/vectordb/collections/drop_function_field"
+        payload = copy.deepcopy(payload)
+        if self.db_name is not None:
+            payload["dbName"] = self.db_name
+        if db_name != "default":
+            payload["dbName"] = db_name
+        response = self.post(url, headers=self.update_headers(), data=payload)
+        return response.json()
+
     def add_struct_field(self, collection_name, field_params, db_name="default"):
         """Add struct field"""
         url = f"{self.endpoint}/v2/vectordb/collections/struct_fields/add"

--- a/tests/restful_client_v2/testcases/test_drop_field_operations.py
+++ b/tests/restful_client_v2/testcases/test_drop_field_operations.py
@@ -35,6 +35,53 @@ class TestCollectionDropField(TestBase):
         assert rsp["code"] == 0, rsp
         return collection_name
 
+    def _describe_index_state(self, collection_name, index_name):
+        rsp = self.index_client.index_describe(collection_name=collection_name, index_name=index_name)
+        assert rsp["code"] == 0, rsp
+        assert len(rsp["data"]) == 1, rsp
+        index = rsp["data"][0]
+        assert "fail" not in index["indexState"].lower(), rsp
+        assert index["failReason"] == "", rsp
+        index_params = [(param["key"], param["value"]) for param in index["indexParams"]]
+        index_param_keys = [key for key, _ in index_params]
+        assert len(index_param_keys) == len(set(index_param_keys)), index
+        return {
+            "fieldName": index["fieldName"],
+            "indexName": index["indexName"],
+            "metricType": index["metricType"],
+            "indexType": index["indexType"],
+            "indexParams": sorted(index_params),
+        }
+
+    def _assert_collection_state(self, collection_name, *, expected_fields, expected_indexes):
+        desc = self.collection_client.collection_describe(collection_name)
+        assert desc["code"] == 0, desc
+        raw_fields = desc["data"]["fields"]
+        field_names = [field["name"] for field in raw_fields]
+        assert field_names == list(expected_fields), desc
+        assert len(field_names) == len(set(field_names)), desc
+        fields = {field["name"]: field for field in raw_fields}
+
+        raw_functions = desc["data"].get("functions", [])
+        function_names = [function["name"] for function in raw_functions]
+        assert len(function_names) == len(set(function_names)), desc
+        functions = {function["name"]: function for function in raw_functions}
+        assert set(fields) == set(expected_fields), desc
+        assert functions == {}, desc
+
+        indexes = self.index_client.index_list(collection_name=collection_name)
+        assert indexes["code"] == 0, indexes
+        assert len(indexes["data"]) == len(set(indexes["data"])), indexes
+        assert set(indexes["data"]) == set(expected_indexes), indexes
+        index_metadata = {
+            index_name: self._describe_index_state(collection_name, index_name) for index_name in indexes["data"]
+        }
+        return {
+            "fields": fields,
+            "functions": functions,
+            "indexes": index_metadata,
+        }
+
     @pytest.mark.parametrize(
         "field_name,field_id,expected_message",
         [
@@ -51,8 +98,9 @@ class TestCollectionDropField(TestBase):
         method: omit both identifiers, provide both, or provide a non-positive fieldId
         expected: REST rejects each request before attempting a schema mutation
         """
+        missing_collection_name = gen_collection_name(prefix=f"{self.__class__.__name__}Missing")
         rsp = self.collection_client.drop_field(
-            "drop_field_parameter_validation",
+            missing_collection_name,
             field_name=field_name,
             field_id=field_id,
         )
@@ -76,13 +124,22 @@ class TestCollectionDropField(TestBase):
         """
         collection_name = self._create_collection()
 
+        before_state = self._assert_collection_state(
+            collection_name,
+            expected_fields=["id", "tag", "dense"],
+            expected_indexes=["dense_idx"],
+        )
+
         rsp = self.collection_client.drop_field(collection_name, field_name=field_name)
         assert rsp["code"] == 1100, rsp
         assert expected_message in rsp["message"], rsp
 
-        desc = self.collection_client.collection_describe(collection_name)
-        assert desc["code"] == 0, desc
-        assert {field["name"] for field in desc["data"]["fields"]} == {"id", "tag", "dense"}
+        after_state = self._assert_collection_state(
+            collection_name,
+            expected_fields=["id", "tag", "dense"],
+            expected_indexes=["dense_idx"],
+        )
+        assert after_state == before_state
 
     def test_drop_field_second_request_is_rejected(self):
         """
@@ -92,8 +149,32 @@ class TestCollectionDropField(TestBase):
         """
         collection_name = self._create_collection()
 
+        before_state = self._assert_collection_state(
+            collection_name,
+            expected_fields=["id", "tag", "dense"],
+            expected_indexes=["dense_idx"],
+        )
+
         first = self.collection_client.drop_field(collection_name, field_name="tag")
         assert first["code"] == 0, first
+        after_first_state = self._assert_collection_state(
+            collection_name,
+            expected_fields=["id", "dense"],
+            expected_indexes=["dense_idx"],
+        )
+        expected_after_first_state = {
+            "fields": {name: field for name, field in before_state["fields"].items() if name != "tag"},
+            "functions": before_state["functions"],
+            "indexes": before_state["indexes"],
+        }
+        assert after_first_state == expected_after_first_state
+
         second = self.collection_client.drop_field(collection_name, field_name="tag")
         assert second["code"] == 1100, second
         assert "field not found" in second["message"], second
+        after_second_state = self._assert_collection_state(
+            collection_name,
+            expected_fields=["id", "dense"],
+            expected_indexes=["dense_idx"],
+        )
+        assert after_second_state == after_first_state

--- a/tests/restful_client_v2/testcases/test_drop_field_operations.py
+++ b/tests/restful_client_v2/testcases/test_drop_field_operations.py
@@ -1,0 +1,99 @@
+import pytest
+from base.testbase import TestBase
+from utils.constant import CaseLabel
+from utils.utils import gen_collection_name
+
+
+@pytest.mark.tags(CaseLabel.L1)
+class TestCollectionDropField(TestBase):
+    """Supplemental REST v2 parameter coverage for collection field drops."""
+
+    def _create_collection(self):
+        collection_name = gen_collection_name(prefix=self.__class__.__name__)
+        rsp = self.collection_client.collection_create(
+            {
+                "collectionName": collection_name,
+                "schema": {
+                    "autoId": False,
+                    "enableDynamicField": False,
+                    "fields": [
+                        {"fieldName": "id", "dataType": "Int64", "isPrimary": True},
+                        {"fieldName": "tag", "dataType": "VarChar", "elementTypeParams": {"max_length": "64"}},
+                        {"fieldName": "dense", "dataType": "FloatVector", "elementTypeParams": {"dim": "4"}},
+                    ],
+                },
+                "indexParams": [
+                    {
+                        "fieldName": "dense",
+                        "indexName": "dense_idx",
+                        "indexType": "AUTOINDEX",
+                        "metricType": "L2",
+                    }
+                ],
+            }
+        )
+        assert rsp["code"] == 0, rsp
+        return collection_name
+
+    @pytest.mark.parametrize(
+        "field_name,field_id,expected_message",
+        [
+            (None, None, "exactly one of fieldName or fieldId is required"),
+            ("tag", 101, "exactly one of fieldName or fieldId is required"),
+            (None, 0, "fieldId must be greater than 0"),
+            (None, -1, "fieldId must be greater than 0"),
+        ],
+        ids=["missing-identifier", "both-identifiers", "zero-field-id", "negative-field-id"],
+    )
+    def test_drop_field_identifier_parameter_validation(self, field_name, field_id, expected_message):
+        """
+        target: verify REST drop field requires one valid identifier form
+        method: omit both identifiers, provide both, or provide a non-positive fieldId
+        expected: REST rejects each request before attempting a schema mutation
+        """
+        rsp = self.collection_client.drop_field(
+            "drop_field_parameter_validation",
+            field_name=field_name,
+            field_id=field_id,
+        )
+        assert rsp["code"] == 1100, rsp
+        assert expected_message in rsp["message"], rsp
+
+    @pytest.mark.parametrize(
+        "field_name,expected_message",
+        [
+            ("id", "cannot drop primary key field"),
+            ("dense", "cannot drop the last vector field"),
+            ("missing_field", "field not found"),
+        ],
+        ids=["primary-key", "last-vector", "unknown-field"],
+    )
+    def test_drop_field_rejects_protected_or_unknown_field(self, field_name, expected_message):
+        """
+        target: verify REST surfaces server-side field drop validation
+        method: request a primary-key, last-vector, or unknown field drop by name
+        expected: each request fails without removing any schema field
+        """
+        collection_name = self._create_collection()
+
+        rsp = self.collection_client.drop_field(collection_name, field_name=field_name)
+        assert rsp["code"] == 1100, rsp
+        assert expected_message in rsp["message"], rsp
+
+        desc = self.collection_client.collection_describe(collection_name)
+        assert desc["code"] == 0, desc
+        assert {field["name"] for field in desc["data"]["fields"]} == {"id", "tag", "dense"}
+
+    def test_drop_field_second_request_is_rejected(self):
+        """
+        target: verify REST drop field reports a field that was already removed
+        method: drop the same scalar field twice by name
+        expected: the first request succeeds and the second reports field not found
+        """
+        collection_name = self._create_collection()
+
+        first = self.collection_client.drop_field(collection_name, field_name="tag")
+        assert first["code"] == 0, first
+        second = self.collection_client.drop_field(collection_name, field_name="tag")
+        assert second["code"] == 1100, second
+        assert "field not found" in second["message"], second

--- a/tests/restful_client_v2/testcases/test_drop_field_operations.py
+++ b/tests/restful_client_v2/testcases/test_drop_field_operations.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 from base.testbase import TestBase
 from utils.constant import CaseLabel
@@ -18,8 +20,8 @@ class TestCollectionDropField(TestBase):
                     "enableDynamicField": False,
                     "fields": [
                         {"fieldName": "id", "dataType": "Int64", "isPrimary": True},
-                        {"fieldName": "tag", "dataType": "VarChar", "elementTypeParams": {"max_length": "64"}},
                         {"fieldName": "dense", "dataType": "FloatVector", "elementTypeParams": {"dim": "4"}},
+                        {"fieldName": "tag", "dataType": "VarChar", "elementTypeParams": {"max_length": "64"}},
                     ],
                 },
                 "indexParams": [
@@ -35,13 +37,21 @@ class TestCollectionDropField(TestBase):
         assert rsp["code"] == 0, rsp
         return collection_name
 
+    def _wait_index_ready(self, collection_name, index_name, timeout=30):
+        t0 = time.time()
+        while time.time() - t0 < timeout:
+            rsp = self.index_client.index_describe(collection_name=collection_name, index_name=index_name)
+            assert rsp["code"] == 0, rsp
+            assert len(rsp["data"]) == 1, rsp
+            index = rsp["data"][0]
+            if index["indexState"] == "Finished":
+                return index
+            time.sleep(1)
+        raise AssertionError(f"index {index_name} of collection {collection_name} not ready after {timeout}s")
+
     def _describe_index_state(self, collection_name, index_name):
-        rsp = self.index_client.index_describe(collection_name=collection_name, index_name=index_name)
-        assert rsp["code"] == 0, rsp
-        assert len(rsp["data"]) == 1, rsp
-        index = rsp["data"][0]
-        assert "fail" not in index["indexState"].lower(), rsp
-        assert index["failReason"] == "", rsp
+        index = self._wait_index_ready(collection_name, index_name)
+        assert index["failReason"] == "", index
         index_params = [(param["key"], param["value"]) for param in index["indexParams"]]
         index_param_keys = [key for key, _ in index_params]
         assert len(index_param_keys) == len(set(index_param_keys)), index
@@ -50,6 +60,7 @@ class TestCollectionDropField(TestBase):
             "indexName": index["indexName"],
             "metricType": index["metricType"],
             "indexType": index["indexType"],
+            "indexState": index["indexState"],
             "indexParams": sorted(index_params),
         }
 
@@ -58,9 +69,19 @@ class TestCollectionDropField(TestBase):
         assert desc["code"] == 0, desc
         raw_fields = desc["data"]["fields"]
         field_names = [field["name"] for field in raw_fields]
+        field_ids = [int(field["id"]) for field in raw_fields]
         assert field_names == list(expected_fields), desc
         assert len(field_names) == len(set(field_names)), desc
+        assert all(field_id > 0 for field_id in field_ids), desc
+        assert len(field_ids) == len(set(field_ids)), desc
         fields = {field["name"]: field for field in raw_fields}
+
+        raw_properties = desc["data"].get("properties", [])
+        property_keys = [prop["key"] for prop in raw_properties]
+        assert len(property_keys) == len(set(property_keys)), desc
+        properties = {prop["key"]: prop["value"] for prop in raw_properties}
+        assert "max_field_id" in properties, desc
+        assert int(properties["max_field_id"]) >= max(field_ids), desc
 
         raw_functions = desc["data"].get("functions", [])
         function_names = [function["name"] for function in raw_functions]
@@ -80,6 +101,7 @@ class TestCollectionDropField(TestBase):
             "fields": fields,
             "functions": functions,
             "indexes": index_metadata,
+            "properties": properties,
         }
 
     @pytest.mark.parametrize(
@@ -98,14 +120,25 @@ class TestCollectionDropField(TestBase):
         method: omit both identifiers, provide both, or provide a non-positive fieldId
         expected: REST rejects each request before attempting a schema mutation
         """
-        missing_collection_name = gen_collection_name(prefix=f"{self.__class__.__name__}Missing")
+        collection_name = self._create_collection()
+        before_state = self._assert_collection_state(
+            collection_name,
+            expected_fields=["id", "dense", "tag"],
+            expected_indexes=["dense_idx"],
+        )
         rsp = self.collection_client.drop_field(
-            missing_collection_name,
+            collection_name,
             field_name=field_name,
             field_id=field_id,
         )
         assert rsp["code"] == 1100, rsp
         assert expected_message in rsp["message"], rsp
+        after_state = self._assert_collection_state(
+            collection_name,
+            expected_fields=["id", "dense", "tag"],
+            expected_indexes=["dense_idx"],
+        )
+        assert after_state == before_state
 
     @pytest.mark.parametrize(
         "field_name,expected_message",
@@ -126,7 +159,7 @@ class TestCollectionDropField(TestBase):
 
         before_state = self._assert_collection_state(
             collection_name,
-            expected_fields=["id", "tag", "dense"],
+            expected_fields=["id", "dense", "tag"],
             expected_indexes=["dense_idx"],
         )
 
@@ -136,7 +169,7 @@ class TestCollectionDropField(TestBase):
 
         after_state = self._assert_collection_state(
             collection_name,
-            expected_fields=["id", "tag", "dense"],
+            expected_fields=["id", "dense", "tag"],
             expected_indexes=["dense_idx"],
         )
         assert after_state == before_state
@@ -144,16 +177,18 @@ class TestCollectionDropField(TestBase):
     def test_drop_field_second_request_is_rejected(self):
         """
         target: verify REST drop field reports a field that was already removed
-        method: drop the same scalar field twice by name
-        expected: the first request succeeds and the second reports field not found
+        method: drop the highest-ID scalar field twice by name, then add a new field
+        expected: the first request succeeds, the second is rejected, and the high-water field ID is preserved
         """
         collection_name = self._create_collection()
 
         before_state = self._assert_collection_state(
             collection_name,
-            expected_fields=["id", "tag", "dense"],
+            expected_fields=["id", "dense", "tag"],
             expected_indexes=["dense_idx"],
         )
+        before_max_field_id = int(before_state["properties"]["max_field_id"])
+        assert before_max_field_id == int(before_state["fields"]["tag"]["id"])
 
         first = self.collection_client.drop_field(collection_name, field_name="tag")
         assert first["code"] == 0, first
@@ -162,10 +197,14 @@ class TestCollectionDropField(TestBase):
             expected_fields=["id", "dense"],
             expected_indexes=["dense_idx"],
         )
+        after_first_max_field_id = int(after_first_state["properties"]["max_field_id"])
+        assert after_first_max_field_id == before_max_field_id
+        assert after_first_max_field_id > max(int(field["id"]) for field in after_first_state["fields"].values())
         expected_after_first_state = {
             "fields": {name: field for name, field in before_state["fields"].items() if name != "tag"},
             "functions": before_state["functions"],
             "indexes": before_state["indexes"],
+            "properties": before_state["properties"],
         }
         assert after_first_state == expected_after_first_state
 
@@ -178,3 +217,22 @@ class TestCollectionDropField(TestBase):
             expected_indexes=["dense_idx"],
         )
         assert after_second_state == after_first_state
+
+        rsp = self.collection_client.add_field(
+            collection_name,
+            {
+                "fieldName": "restored_tag",
+                "dataType": "VarChar",
+                "nullable": True,
+                "elementTypeParams": {"max_length": "64"},
+            },
+        )
+        assert rsp["code"] == 0, rsp
+        after_add_state = self._assert_collection_state(
+            collection_name,
+            expected_fields=["id", "dense", "restored_tag"],
+            expected_indexes=["dense_idx"],
+        )
+        restored_tag_id = int(after_add_state["fields"]["restored_tag"]["id"])
+        assert restored_tag_id > before_max_field_id
+        assert int(after_add_state["properties"]["max_field_id"]) == restored_tag_id

--- a/tests/restful_client_v2/testcases/test_function_field_operations.py
+++ b/tests/restful_client_v2/testcases/test_function_field_operations.py
@@ -6,26 +6,35 @@ from utils.utils import gen_collection_name
 FUNCTION_NAME = "bm25_fn"
 OUTPUT_FIELD_NAME = "sparse"
 INDEX_NAME = "sparse_idx"
+KEEP_FUNCTION_NAME = "bm25_keep_fn"
+KEEP_OUTPUT_FIELD_NAME = "sparse_keep"
+KEEP_INDEX_NAME = "sparse_keep_idx"
 BM25_FUNCTION_TYPE = 1
 
 
-def _function_field_payload(collection_name):
+def _function_field_payload(
+    collection_name,
+    *,
+    function_name=FUNCTION_NAME,
+    output_field_name=OUTPUT_FIELD_NAME,
+    index_name=INDEX_NAME,
+):
     return {
         "collectionName": collection_name,
         "function": {
-            "name": FUNCTION_NAME,
+            "name": function_name,
             "type": "BM25",
             "inputFieldNames": ["text"],
-            "outputFieldNames": [OUTPUT_FIELD_NAME],
+            "outputFieldNames": [output_field_name],
             "params": {},
         },
         "outputField": {
-            "fieldName": OUTPUT_FIELD_NAME,
+            "fieldName": output_field_name,
             "dataType": "SparseFloatVector",
         },
         "indexParams": {
-            "fieldName": OUTPUT_FIELD_NAME,
-            "indexName": INDEX_NAME,
+            "fieldName": output_field_name,
+            "indexName": index_name,
             "metricType": "BM25",
             "indexType": "SPARSE_INVERTED_INDEX",
             "params": {},
@@ -72,19 +81,160 @@ class TestCollectionFunctionField(TestBase):
         assert rsp["code"] == 0, rsp
         return collection_name
 
-    def _add_bm25_function_field(self, collection_name):
-        rsp = self.collection_client.add_function_field(_function_field_payload(collection_name))
+    def _add_bm25_function_field(
+        self,
+        collection_name,
+        *,
+        function_name=FUNCTION_NAME,
+        output_field_name=OUTPUT_FIELD_NAME,
+        index_name=INDEX_NAME,
+    ):
+        rsp = self.collection_client.add_function_field(
+            _function_field_payload(
+                collection_name,
+                function_name=function_name,
+                output_field_name=output_field_name,
+                index_name=index_name,
+            )
+        )
         assert rsp["code"] == 0, rsp
+
+    def _describe_index_state(self, collection_name, index_name):
+        rsp = self.index_client.index_describe(collection_name=collection_name, index_name=index_name)
+        assert rsp["code"] == 0, rsp
+        assert len(rsp["data"]) == 1, rsp
+        index = rsp["data"][0]
+        assert "fail" not in index["indexState"].lower(), rsp
+        assert index["failReason"] == "", rsp
+        index_params = [(param["key"], param["value"]) for param in index["indexParams"]]
+        index_param_keys = [key for key, _ in index_params]
+        assert len(index_param_keys) == len(set(index_param_keys)), index
+        return {
+            "fieldName": index["fieldName"],
+            "indexName": index["indexName"],
+            "metricType": index["metricType"],
+            "indexType": index["indexType"],
+            "indexParams": sorted(index_params),
+        }
 
     def _assert_base_schema_state(self, collection_name):
         desc = self.collection_client.collection_describe(collection_name)
         assert desc["code"] == 0, desc
-        assert {field["name"] for field in desc["data"]["fields"]} == {"id", "text", "dense"}
-        assert desc["data"].get("functions", []) == []
+        raw_fields = desc["data"]["fields"]
+        field_names = [field["name"] for field in raw_fields]
+        assert field_names == ["id", "text", "dense"]
+        assert len(field_names) == len(set(field_names)), desc
+        fields = {field["name"]: field for field in raw_fields}
+
+        raw_functions = desc["data"].get("functions", [])
+        function_names = [function["name"] for function in raw_functions]
+        assert len(function_names) == len(set(function_names)), desc
+        functions = {function["name"]: function for function in raw_functions}
+        assert set(fields) == {"id", "text", "dense"}
+        assert functions == {}
 
         indexes = self.index_client.index_list(collection_name=collection_name)
         assert indexes["code"] == 0, indexes
-        assert indexes["data"] == ["dense_idx"]
+        assert len(indexes["data"]) == len(set(indexes["data"])), indexes
+        assert set(indexes["data"]) == {"dense_idx"}
+
+        dense_index = self._describe_index_state(collection_name, "dense_idx")
+        assert dense_index["fieldName"] == "dense"
+        assert dense_index["indexName"] == "dense_idx"
+        assert dense_index["metricType"] == "L2"
+        assert dense_index["indexType"] == "AUTOINDEX"
+
+        return {
+            "fields": fields,
+            "functions": functions,
+            "indexes": {"dense_idx": dense_index},
+        }
+
+    def _assert_bm25_function_schema_state(
+        self,
+        collection_name,
+        expected_bindings=None,
+        expected_index_types=None,
+    ):
+        if expected_bindings is None:
+            expected_bindings = [(FUNCTION_NAME, OUTPUT_FIELD_NAME, INDEX_NAME)]
+        if expected_index_types is None:
+            expected_index_types = {}
+
+        desc = self.collection_client.collection_describe(collection_name)
+        assert desc["code"] == 0, desc
+        raw_fields = desc["data"]["fields"]
+        field_names = [field["name"] for field in raw_fields]
+        expected_output_fields_in_order = [output_field_name for _, output_field_name, _ in expected_bindings]
+        assert field_names == ["id", "text", "dense", *expected_output_fields_in_order]
+        assert len(field_names) == len(set(field_names)), desc
+        fields = {field["name"]: field for field in raw_fields}
+        expected_output_fields = {output_field_name for _, output_field_name, _ in expected_bindings}
+        assert set(fields) == {"id", "text", "dense"} | expected_output_fields
+
+        raw_functions = desc["data"].get("functions", [])
+        function_names = [function["name"] for function in raw_functions]
+        expected_function_names_in_order = [function_name for function_name, _, _ in expected_bindings]
+        assert function_names == expected_function_names_in_order
+        assert len(function_names) == len(set(function_names)), desc
+        functions = {function["name"]: function for function in raw_functions}
+        assert set(functions) == {function_name for function_name, _, _ in expected_bindings}
+
+        indexes = self.index_client.index_list(collection_name=collection_name)
+        assert indexes["code"] == 0, indexes
+        assert len(indexes["data"]) == len(set(indexes["data"])), indexes
+        expected_index_names = {index_name for _, _, index_name in expected_bindings}
+        assert set(indexes["data"]) == {"dense_idx"} | expected_index_names
+
+        dense_index = self._describe_index_state(collection_name, "dense_idx")
+        assert dense_index["fieldName"] == "dense"
+        assert dense_index["indexName"] == "dense_idx"
+        assert dense_index["metricType"] == "L2"
+        assert dense_index["indexType"] == "AUTOINDEX"
+        index_metadata = {"dense_idx": dense_index}
+        for function_name, output_field_name, index_name in expected_bindings:
+            output_field = {key: value for key, value in fields[output_field_name].items() if key != "id"}
+            assert output_field == {
+                "autoId": False,
+                "clusteringKey": False,
+                "description": "",
+                "isFunctionOutput": True,
+                "name": output_field_name,
+                "nullable": False,
+                "partitionKey": False,
+                "primaryKey": False,
+                "type": "SparseFloatVector",
+            }
+
+            function = {key: value for key, value in functions[function_name].items() if key != "id"}
+            assert function == {
+                "description": "",
+                "inputFieldNames": ["text"],
+                "name": function_name,
+                "outputFieldNames": [output_field_name],
+                "params": None,
+                "type": BM25_FUNCTION_TYPE,
+            }
+
+            index = self._describe_index_state(collection_name, index_name)
+            expected_index_type = expected_index_types.get(index_name, "SPARSE_INVERTED_INDEX")
+            assert index["fieldName"] == output_field_name
+            assert index["indexName"] == index_name
+            assert index["metricType"] == "BM25"
+            assert index["indexType"] == expected_index_type
+            assert index["indexParams"] == sorted(
+                [
+                    ("index_type", expected_index_type),
+                    ("metric_type", "BM25"),
+                ]
+            )
+            index_metadata[index_name] = index
+
+        return {
+            "fields": fields,
+            "functions": functions,
+            "indexes": index_metadata,
+        }
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_add_function_field_creates_function_output_field_and_index(self):
@@ -94,27 +244,14 @@ class TestCollectionFunctionField(TestBase):
         expected: describe endpoints expose the exact function, field, and index metadata
         """
         collection_name = self._create_base_collection()
+        before_state = self._assert_base_schema_state(collection_name)
 
         rsp = self.collection_client.add_function_field(_function_field_payload(collection_name))
         assert rsp["code"] == 0, rsp
 
-        desc = self.collection_client.collection_describe(collection_name)
-        assert desc["code"] == 0, desc
-        fields = {field["name"]: field for field in desc["data"]["fields"]}
-        functions = {function["name"]: function for function in desc["data"].get("functions", [])}
-        assert fields[OUTPUT_FIELD_NAME]["type"] == "SparseFloatVector"
-        assert functions[FUNCTION_NAME]["type"] == BM25_FUNCTION_TYPE
-        assert functions[FUNCTION_NAME]["inputFieldNames"] == ["text"]
-        assert functions[FUNCTION_NAME]["outputFieldNames"] == [OUTPUT_FIELD_NAME]
-
-        index_desc = self.index_client.index_describe(collection_name=collection_name, index_name=INDEX_NAME)
-        assert index_desc["code"] == 0, index_desc
-        assert len(index_desc["data"]) == 1, index_desc
-        index = index_desc["data"][0]
-        assert index["fieldName"] == OUTPUT_FIELD_NAME
-        assert index["indexName"] == INDEX_NAME
-        assert index["metricType"] == "BM25"
-        assert index["indexType"] == "SPARSE_INVERTED_INDEX"
+        after_state = self._assert_bm25_function_schema_state(collection_name)
+        assert {name: after_state["fields"][name] for name in before_state["fields"]} == before_state["fields"]
+        assert after_state["indexes"]["dense_idx"] == before_state["indexes"]["dense_idx"]
 
     @pytest.mark.parametrize(
         "function_output,index_field,expected_message",
@@ -136,6 +273,7 @@ class TestCollectionFunctionField(TestBase):
         expected: request fails as invalid input without changing the collection schema
         """
         collection_name = self._create_base_collection()
+        before_state = self._assert_base_schema_state(collection_name)
         payload = _function_field_payload(collection_name)
         payload["function"]["outputFieldNames"] = function_output
         payload["indexParams"]["fieldName"] = index_field
@@ -144,26 +282,51 @@ class TestCollectionFunctionField(TestBase):
         assert rsp["code"] == 1100, rsp
         assert expected_message in rsp["message"], rsp
 
-        self._assert_base_schema_state(collection_name)
+        after_state = self._assert_base_schema_state(collection_name)
+        assert after_state == before_state
 
     @pytest.mark.parametrize(
         "missing_key",
-        ["function", "outputField", "indexParams"],
+        ["function", "outputField"],
     )
     def test_add_function_field_requires_atomic_request_parts(self, missing_key):
         """
-        target: verify all atomic add_function_field request parts are required
-        method: omit the function, outputField, or indexParams object
+        target: verify the function and output field parts of add_function_field are required
+        method: omit either the function or outputField object
         expected: REST binding rejects each incomplete request
         """
         collection_name = self._create_base_collection()
+        before_state = self._assert_base_schema_state(collection_name)
         payload = _function_field_payload(collection_name)
         del payload[missing_key]
 
         rsp = self.collection_client.add_function_field(payload)
         assert rsp["code"] == 1802, rsp
         assert "required" in rsp["message"], rsp
-        self._assert_base_schema_state(collection_name)
+        after_state = self._assert_base_schema_state(collection_name)
+        assert after_state == before_state
+
+    def test_add_function_field_without_index_params_uses_autoindex(self):
+        """
+        target: verify REST add_function_field supplies a bound AutoIndex when indexParams is omitted
+        method: add a BM25 function and sparse output field without an indexParams object
+        expected: the request succeeds and describe endpoints expose a same-name AUTOINDEX with BM25 metric
+        """
+        collection_name = self._create_base_collection()
+        before_state = self._assert_base_schema_state(collection_name)
+        payload = _function_field_payload(collection_name)
+        del payload["indexParams"]
+
+        rsp = self.collection_client.add_function_field(payload)
+        assert rsp["code"] == 0, rsp
+
+        after_state = self._assert_bm25_function_schema_state(
+            collection_name,
+            expected_bindings=[(FUNCTION_NAME, OUTPUT_FIELD_NAME, OUTPUT_FIELD_NAME)],
+            expected_index_types={OUTPUT_FIELD_NAME: "AUTOINDEX"},
+        )
+        assert {name: after_state["fields"][name] for name in before_state["fields"]} == before_state["fields"]
+        assert after_state["indexes"]["dense_idx"] == before_state["indexes"]["dense_idx"]
 
     def test_add_function_field_rejects_unsupported_function_type(self):
         """
@@ -172,6 +335,7 @@ class TestCollectionFunctionField(TestBase):
         expected: REST returns invalid parameter instead of creating partial schema objects
         """
         collection_name = self._create_base_collection()
+        before_state = self._assert_base_schema_state(collection_name)
         payload = _function_field_payload(collection_name)
         payload["function"].update(
             {
@@ -195,30 +359,55 @@ class TestCollectionFunctionField(TestBase):
         rsp = self.collection_client.add_function_field(payload)
         assert rsp["code"] == 1100, rsp
         assert "only BM25 and MinHash functions are supported" in rsp["message"], rsp
-        self._assert_base_schema_state(collection_name)
+        after_state = self._assert_base_schema_state(collection_name)
+        assert after_state == before_state
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_drop_function_field_removes_function_output_field_and_index(self):
         """
-        target: verify REST drop_function_field performs the documented cascade
-        method: add a BM25 function field and then drop it by function name
-        expected: function, sparse output field, and bound index all disappear
+        target: verify REST drop_function_field cascades only through the named function binding
+        method: add two BM25 bindings, drop one by name, and compare the surviving field/function/index metadata
+        expected: only the selected function, output field, and index disappear; the other binding is unchanged
         """
         collection_name = self._create_base_collection()
         self._add_bm25_function_field(collection_name)
+        self._add_bm25_function_field(
+            collection_name,
+            function_name=KEEP_FUNCTION_NAME,
+            output_field_name=KEEP_OUTPUT_FIELD_NAME,
+            index_name=KEEP_INDEX_NAME,
+        )
+        before_state = self._assert_bm25_function_schema_state(
+            collection_name,
+            expected_bindings=[
+                (FUNCTION_NAME, OUTPUT_FIELD_NAME, INDEX_NAME),
+                (KEEP_FUNCTION_NAME, KEEP_OUTPUT_FIELD_NAME, KEEP_INDEX_NAME),
+            ],
+        )
 
         rsp = self.collection_client.drop_function_field(
             {"collectionName": collection_name, "functionName": FUNCTION_NAME}
         )
         assert rsp["code"] == 0, rsp
 
-        self._assert_base_schema_state(collection_name)
+        after_state = self._assert_bm25_function_schema_state(
+            collection_name,
+            expected_bindings=[(KEEP_FUNCTION_NAME, KEEP_OUTPUT_FIELD_NAME, KEEP_INDEX_NAME)],
+        )
+        expected_after_state = {
+            "fields": {name: field for name, field in before_state["fields"].items() if name != OUTPUT_FIELD_NAME},
+            "functions": {
+                name: function for name, function in before_state["functions"].items() if name != FUNCTION_NAME
+            },
+            "indexes": {name: index for name, index in before_state["indexes"].items() if name != INDEX_NAME},
+        }
+        assert after_state == expected_after_state
 
     @pytest.mark.parametrize(
-        "function_name,expected_code,expected_message",
+        "function_name,expected_code,expected_message,seed_function",
         [
-            ("", 1802, "required"),
-            ("missing_fn", 1100, "function not found"),
+            ("", 1802, "required", False),
+            ("missing_fn", 1100, "function not found", True),
         ],
         ids=["empty-name", "unknown-function"],
     )
@@ -227,13 +416,19 @@ class TestCollectionFunctionField(TestBase):
         function_name,
         expected_code,
         expected_message,
+        seed_function,
     ):
         """
         target: verify drop_function_field validates the functionName parameter
-        method: send an empty name and a name absent from the collection schema
-        expected: REST returns binding or invalid-parameter errors respectively
+        method: send an empty name or seed BM25 and send a different, absent function name
+        expected: REST returns the expected error without changing any field, function, or index
         """
         collection_name = self._create_base_collection()
+        if seed_function:
+            self._add_bm25_function_field(collection_name)
+            before_state = self._assert_bm25_function_schema_state(collection_name)
+        else:
+            before_state = self._assert_base_schema_state(collection_name)
 
         rsp = self.collection_client.drop_function_field(
             {"collectionName": collection_name, "functionName": function_name}
@@ -241,21 +436,33 @@ class TestCollectionFunctionField(TestBase):
         assert rsp["code"] == expected_code, rsp
         assert expected_message in rsp["message"], rsp
 
+        if seed_function:
+            after_state = self._assert_bm25_function_schema_state(collection_name)
+        else:
+            after_state = self._assert_base_schema_state(collection_name)
+        assert after_state == before_state
+
     def test_drop_function_field_second_request_is_rejected(self):
         """
-        target: verify drop_function_field is not silently idempotent
-        method: drop the same function field twice
-        expected: the second request reports that the function no longer exists
+        target: verify repeated drop_function_field is rejected and remains atomic
+        method: drop once and assert base state, then drop again and assert rejection plus the same base state
+        expected: the first drop removes all bound objects and the rejected second drop changes nothing
         """
         collection_name = self._create_base_collection()
+        base_state = self._assert_base_schema_state(collection_name)
         self._add_bm25_function_field(collection_name)
         payload = {"collectionName": collection_name, "functionName": FUNCTION_NAME}
 
         first = self.collection_client.drop_function_field(payload)
         assert first["code"] == 0, first
+        after_first_state = self._assert_base_schema_state(collection_name)
+        assert after_first_state == base_state
+
         second = self.collection_client.drop_function_field(payload)
         assert second["code"] == 1100, second
         assert "function not found" in second["message"], second
+        after_second_state = self._assert_base_schema_state(collection_name)
+        assert after_second_state == after_first_state
 
     def test_drop_field_rejects_function_input_until_function_field_is_dropped(self):
         """
@@ -265,14 +472,41 @@ class TestCollectionFunctionField(TestBase):
         """
         collection_name = self._create_base_collection()
         self._add_bm25_function_field(collection_name)
+        before_blocked_state = self._assert_bm25_function_schema_state(collection_name)
 
         blocked = self.collection_client.drop_field(collection_name, field_name="text")
         assert blocked["code"] == 1100, blocked
         assert "referenced by function" in blocked["message"], blocked
+        after_blocked_state = self._assert_bm25_function_schema_state(collection_name)
+        assert after_blocked_state == before_blocked_state
 
         dropped = self.collection_client.drop_function_field(
             {"collectionName": collection_name, "functionName": FUNCTION_NAME}
         )
         assert dropped["code"] == 0, dropped
+        before_unblocked_state = self._assert_base_schema_state(collection_name)
+
         unblocked = self.collection_client.drop_field(collection_name, field_name="text")
         assert unblocked["code"] == 0, unblocked
+
+        desc = self.collection_client.collection_describe(collection_name)
+        assert desc["code"] == 0, desc
+        fields = {field["name"]: field for field in desc["data"]["fields"]}
+        functions = {function["name"]: function for function in desc["data"].get("functions", [])}
+        assert set(fields) == {"id", "dense"}
+        assert functions == {}
+
+        indexes = self.index_client.index_list(collection_name=collection_name)
+        assert indexes["code"] == 0, indexes
+        assert set(indexes["data"]) == {"dense_idx"}
+        after_unblocked_state = {
+            "fields": fields,
+            "functions": functions,
+            "indexes": {"dense_idx": self._describe_index_state(collection_name, "dense_idx")},
+        }
+        expected_after_unblocked_state = {
+            "fields": {name: field for name, field in before_unblocked_state["fields"].items() if name != "text"},
+            "functions": before_unblocked_state["functions"],
+            "indexes": before_unblocked_state["indexes"],
+        }
+        assert after_unblocked_state == expected_after_unblocked_state

--- a/tests/restful_client_v2/testcases/test_function_field_operations.py
+++ b/tests/restful_client_v2/testcases/test_function_field_operations.py
@@ -1,5 +1,8 @@
+import time
+
 import pytest
 from base.testbase import TestBase
+from pymilvus import MilvusClient
 from utils.constant import CaseLabel
 from utils.utils import gen_collection_name
 
@@ -10,6 +13,12 @@ KEEP_FUNCTION_NAME = "bm25_keep_fn"
 KEEP_OUTPUT_FIELD_NAME = "sparse_keep"
 KEEP_INDEX_NAME = "sparse_keep_idx"
 BM25_FUNCTION_TYPE = 1
+MINHASH_FUNCTION_NAME = "minhash_fn"
+MINHASH_OUTPUT_FIELD_NAME = "minhash_signature"
+MINHASH_INDEX_NAME = "minhash_idx"
+MINHASH_FUNCTION_TYPE = 4
+MINHASH_NUM_HASHES = 16
+MINHASH_DIM = MINHASH_NUM_HASHES * 32
 
 
 def _function_field_payload(
@@ -38,6 +47,38 @@ def _function_field_payload(
             "metricType": "BM25",
             "indexType": "SPARSE_INVERTED_INDEX",
             "params": {},
+        },
+    }
+
+
+def _minhash_function_field_payload(
+    collection_name,
+    *,
+    function_name=MINHASH_FUNCTION_NAME,
+    output_field_name=MINHASH_OUTPUT_FIELD_NAME,
+    index_name=MINHASH_INDEX_NAME,
+    num_hashes=MINHASH_NUM_HASHES,
+):
+    return {
+        "collectionName": collection_name,
+        "function": {
+            "name": function_name,
+            "type": "MinHash",
+            "inputFieldNames": ["text"],
+            "outputFieldNames": [output_field_name],
+            "params": {"num_hashes": num_hashes, "shingle_size": 3},
+        },
+        "outputField": {
+            "fieldName": output_field_name,
+            "dataType": "BinaryVector",
+            "elementTypeParams": {"dim": f"{num_hashes * 32}"},
+        },
+        "indexParams": {
+            "fieldName": output_field_name,
+            "indexName": index_name,
+            "metricType": "MHJACCARD",
+            "indexType": "MINHASH_LSH",
+            "params": {"mh_lsh_band": 8},
         },
     }
 
@@ -99,13 +140,21 @@ class TestCollectionFunctionField(TestBase):
         )
         assert rsp["code"] == 0, rsp
 
+    def _wait_index_ready(self, collection_name, index_name, timeout=30):
+        t0 = time.time()
+        while time.time() - t0 < timeout:
+            rsp = self.index_client.index_describe(collection_name=collection_name, index_name=index_name)
+            assert rsp["code"] == 0, rsp
+            assert len(rsp["data"]) == 1, rsp
+            index = rsp["data"][0]
+            if index["indexState"] == "Finished":
+                return index
+            time.sleep(1)
+        raise AssertionError(f"index {index_name} of collection {collection_name} not ready after {timeout}s")
+
     def _describe_index_state(self, collection_name, index_name):
-        rsp = self.index_client.index_describe(collection_name=collection_name, index_name=index_name)
-        assert rsp["code"] == 0, rsp
-        assert len(rsp["data"]) == 1, rsp
-        index = rsp["data"][0]
-        assert "fail" not in index["indexState"].lower(), rsp
-        assert index["failReason"] == "", rsp
+        index = self._wait_index_ready(collection_name, index_name)
+        assert index["failReason"] == "", index
         index_params = [(param["key"], param["value"]) for param in index["indexParams"]]
         index_param_keys = [key for key, _ in index_params]
         assert len(index_param_keys) == len(set(index_param_keys)), index
@@ -114,7 +163,23 @@ class TestCollectionFunctionField(TestBase):
             "indexName": index["indexName"],
             "metricType": index["metricType"],
             "indexType": index["indexType"],
+            "indexState": index["indexState"],
             "indexParams": sorted(index_params),
+        }
+
+    def _capture_sdk_function_binding(self, collection_name, function_name, output_field_name):
+        sdk_client = MilvusClient(uri=self.endpoint, token=self.api_key)
+        try:
+            sdk_desc = sdk_client.describe_collection(collection_name)
+        finally:
+            sdk_client.close()
+        sdk_fields = {field["name"]: field for field in sdk_desc["fields"]}
+        sdk_functions = {function["name"]: function for function in sdk_desc.get("functions", [])}
+        return {
+            "function_id": sdk_functions[function_name]["id"],
+            "input_field_ids": sdk_functions[function_name]["input_field_ids"],
+            "output_field_ids": sdk_functions[function_name]["output_field_ids"],
+            "output_field_id": sdk_fields[output_field_name]["field_id"],
         }
 
     def _assert_base_schema_state(self, collection_name):
@@ -122,9 +187,19 @@ class TestCollectionFunctionField(TestBase):
         assert desc["code"] == 0, desc
         raw_fields = desc["data"]["fields"]
         field_names = [field["name"] for field in raw_fields]
+        field_ids = [int(field["id"]) for field in raw_fields]
         assert field_names == ["id", "text", "dense"]
         assert len(field_names) == len(set(field_names)), desc
+        assert all(field_id > 0 for field_id in field_ids), desc
+        assert len(field_ids) == len(set(field_ids)), desc
         fields = {field["name"]: field for field in raw_fields}
+
+        raw_properties = desc["data"].get("properties", [])
+        property_keys = [prop["key"] for prop in raw_properties]
+        assert len(property_keys) == len(set(property_keys)), desc
+        properties = {prop["key"]: prop["value"] for prop in raw_properties}
+        assert "max_field_id" in properties, desc
+        assert int(properties["max_field_id"]) >= max(field_ids), desc
 
         raw_functions = desc["data"].get("functions", [])
         function_names = [function["name"] for function in raw_functions]
@@ -148,6 +223,7 @@ class TestCollectionFunctionField(TestBase):
             "fields": fields,
             "functions": functions,
             "indexes": {"dense_idx": dense_index},
+            "properties": properties,
         }
 
     def _assert_bm25_function_schema_state(
@@ -165,18 +241,31 @@ class TestCollectionFunctionField(TestBase):
         assert desc["code"] == 0, desc
         raw_fields = desc["data"]["fields"]
         field_names = [field["name"] for field in raw_fields]
+        field_ids = [int(field["id"]) for field in raw_fields]
         expected_output_fields_in_order = [output_field_name for _, output_field_name, _ in expected_bindings]
         assert field_names == ["id", "text", "dense", *expected_output_fields_in_order]
         assert len(field_names) == len(set(field_names)), desc
+        assert all(field_id > 0 for field_id in field_ids), desc
+        assert len(field_ids) == len(set(field_ids)), desc
         fields = {field["name"]: field for field in raw_fields}
         expected_output_fields = {output_field_name for _, output_field_name, _ in expected_bindings}
         assert set(fields) == {"id", "text", "dense"} | expected_output_fields
 
+        raw_properties = desc["data"].get("properties", [])
+        property_keys = [prop["key"] for prop in raw_properties]
+        assert len(property_keys) == len(set(property_keys)), desc
+        properties = {prop["key"]: prop["value"] for prop in raw_properties}
+        assert "max_field_id" in properties, desc
+        assert int(properties["max_field_id"]) == max(field_ids), desc
+
         raw_functions = desc["data"].get("functions", [])
         function_names = [function["name"] for function in raw_functions]
+        function_ids = [int(function["id"]) for function in raw_functions]
         expected_function_names_in_order = [function_name for function_name, _, _ in expected_bindings]
         assert function_names == expected_function_names_in_order
         assert len(function_names) == len(set(function_names)), desc
+        assert all(function_id > 0 for function_id in function_ids), desc
+        assert len(function_ids) == len(set(function_ids)), desc
         functions = {function["name"]: function for function in raw_functions}
         assert set(functions) == {function_name for function_name, _, _ in expected_bindings}
 
@@ -193,6 +282,7 @@ class TestCollectionFunctionField(TestBase):
         assert dense_index["indexType"] == "AUTOINDEX"
         index_metadata = {"dense_idx": dense_index}
         for function_name, output_field_name, index_name in expected_bindings:
+            assert int(fields[output_field_name]["id"]) > 0
             output_field = {key: value for key, value in fields[output_field_name].items() if key != "id"}
             assert output_field == {
                 "autoId": False,
@@ -206,6 +296,7 @@ class TestCollectionFunctionField(TestBase):
                 "type": "SparseFloatVector",
             }
 
+            assert int(functions[function_name]["id"]) > 0
             function = {key: value for key, value in functions[function_name].items() if key != "id"}
             assert function == {
                 "description": "",
@@ -234,6 +325,7 @@ class TestCollectionFunctionField(TestBase):
             "fields": fields,
             "functions": functions,
             "indexes": index_metadata,
+            "properties": properties,
         }
 
     @pytest.mark.tags(CaseLabel.L0)
@@ -245,13 +337,34 @@ class TestCollectionFunctionField(TestBase):
         """
         collection_name = self._create_base_collection()
         before_state = self._assert_base_schema_state(collection_name)
+        before_max_field_id = int(before_state["properties"]["max_field_id"])
+        before_function_ids = {int(function["id"]) for function in before_state["functions"].values()}
 
         rsp = self.collection_client.add_function_field(_function_field_payload(collection_name))
         assert rsp["code"] == 0, rsp
 
         after_state = self._assert_bm25_function_schema_state(collection_name)
+        output_field_id = int(after_state["fields"][OUTPUT_FIELD_NAME]["id"])
+        function_id = int(after_state["functions"][FUNCTION_NAME]["id"])
+        assert output_field_id > before_max_field_id
+        assert int(after_state["properties"]["max_field_id"]) == output_field_id
+        assert function_id > 0
+        assert function_id not in before_function_ids
         assert {name: after_state["fields"][name] for name in before_state["fields"]} == before_state["fields"]
         assert after_state["indexes"]["dense_idx"] == before_state["indexes"]["dense_idx"]
+
+        sdk_client = MilvusClient(uri=self.endpoint, token=self.api_key)
+        try:
+            sdk_desc = sdk_client.describe_collection(collection_name)
+        finally:
+            sdk_client.close()
+        sdk_fields = {field["name"]: field for field in sdk_desc["fields"]}
+        sdk_functions = {function["name"]: function for function in sdk_desc.get("functions", [])}
+        assert sdk_fields[OUTPUT_FIELD_NAME]["field_id"] == output_field_id
+        assert sdk_fields[OUTPUT_FIELD_NAME]["is_function_output"] is True
+        assert sdk_functions[FUNCTION_NAME]["id"] == function_id
+        assert sdk_functions[FUNCTION_NAME]["input_field_ids"] == [sdk_fields["text"]["field_id"]]
+        assert sdk_functions[FUNCTION_NAME]["output_field_ids"] == [output_field_id]
 
     @pytest.mark.parametrize(
         "function_output,index_field,expected_message",
@@ -384,6 +497,7 @@ class TestCollectionFunctionField(TestBase):
                 (KEEP_FUNCTION_NAME, KEEP_OUTPUT_FIELD_NAME, KEEP_INDEX_NAME),
             ],
         )
+        before_binding = self._capture_sdk_function_binding(collection_name, KEEP_FUNCTION_NAME, KEEP_OUTPUT_FIELD_NAME)
 
         rsp = self.collection_client.drop_function_field(
             {"collectionName": collection_name, "functionName": FUNCTION_NAME}
@@ -400,8 +514,11 @@ class TestCollectionFunctionField(TestBase):
                 name: function for name, function in before_state["functions"].items() if name != FUNCTION_NAME
             },
             "indexes": {name: index for name, index in before_state["indexes"].items() if name != INDEX_NAME},
+            "properties": before_state["properties"],
         }
         assert after_state == expected_after_state
+        after_binding = self._capture_sdk_function_binding(collection_name, KEEP_FUNCTION_NAME, KEEP_OUTPUT_FIELD_NAME)
+        assert after_binding == before_binding
 
     @pytest.mark.parametrize(
         "function_name,expected_code,expected_message,seed_function",
@@ -451,12 +568,19 @@ class TestCollectionFunctionField(TestBase):
         collection_name = self._create_base_collection()
         base_state = self._assert_base_schema_state(collection_name)
         self._add_bm25_function_field(collection_name)
+        added_state = self._assert_bm25_function_schema_state(collection_name)
         payload = {"collectionName": collection_name, "functionName": FUNCTION_NAME}
 
         first = self.collection_client.drop_function_field(payload)
         assert first["code"] == 0, first
         after_first_state = self._assert_base_schema_state(collection_name)
-        assert after_first_state == base_state
+        expected_after_first_state = {
+            "fields": base_state["fields"],
+            "functions": base_state["functions"],
+            "indexes": base_state["indexes"],
+            "properties": added_state["properties"],
+        }
+        assert after_first_state == expected_after_first_state
 
         second = self.collection_client.drop_function_field(payload)
         assert second["code"] == 1100, second
@@ -496,6 +620,13 @@ class TestCollectionFunctionField(TestBase):
         assert set(fields) == {"id", "dense"}
         assert functions == {}
 
+        raw_properties = desc["data"].get("properties", [])
+        property_keys = [prop["key"] for prop in raw_properties]
+        assert len(property_keys) == len(set(property_keys)), desc
+        properties = {prop["key"]: prop["value"] for prop in raw_properties}
+        assert "max_field_id" in properties, desc
+        assert int(properties["max_field_id"]) >= max(int(field["id"]) for field in fields.values()), desc
+
         indexes = self.index_client.index_list(collection_name=collection_name)
         assert indexes["code"] == 0, indexes
         assert set(indexes["data"]) == {"dense_idx"}
@@ -503,10 +634,65 @@ class TestCollectionFunctionField(TestBase):
             "fields": fields,
             "functions": functions,
             "indexes": {"dense_idx": self._describe_index_state(collection_name, "dense_idx")},
+            "properties": properties,
         }
         expected_after_unblocked_state = {
             "fields": {name: field for name, field in before_unblocked_state["fields"].items() if name != "text"},
             "functions": before_unblocked_state["functions"],
             "indexes": before_unblocked_state["indexes"],
+            "properties": before_unblocked_state["properties"],
         }
         assert after_unblocked_state == expected_after_unblocked_state
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_add_and_drop_minhash_function_field(self):
+        """
+        target: verify REST add_function_field supports a positive MinHash binding path
+        method: add a MinHash function, BinaryVector output field, and MINHASH_LSH index in one request, then drop it
+        expected: describe endpoints expose exact BinaryVector, MINHASH_LSH, MHJACCARD, field/function ID binding,
+                 and the cascade drop restores the base schema state
+        """
+        collection_name = self._create_base_collection()
+        before_state = self._assert_base_schema_state(collection_name)
+
+        rsp = self.collection_client.add_function_field(_minhash_function_field_payload(collection_name))
+        assert rsp["code"] == 0, rsp
+
+        desc = self.collection_client.collection_describe(collection_name)
+        assert desc["code"] == 0, desc
+        fields = {field["name"]: field for field in desc["data"]["fields"]}
+        functions = {function["name"]: function for function in desc["data"].get("functions", [])}
+        assert fields[MINHASH_OUTPUT_FIELD_NAME]["type"] == "BinaryVector"
+        assert functions[MINHASH_FUNCTION_NAME]["type"] == MINHASH_FUNCTION_TYPE
+        assert functions[MINHASH_FUNCTION_NAME]["inputFieldNames"] == ["text"]
+        assert functions[MINHASH_FUNCTION_NAME]["outputFieldNames"] == [MINHASH_OUTPUT_FIELD_NAME]
+
+        output_field_id = int(fields[MINHASH_OUTPUT_FIELD_NAME]["id"])
+        function_id = int(functions[MINHASH_FUNCTION_NAME]["id"])
+        assert output_field_id > int(before_state["properties"]["max_field_id"])
+        assert function_id > 0
+
+        index_desc = self.index_client.index_describe(collection_name=collection_name, index_name=MINHASH_INDEX_NAME)
+        assert index_desc["code"] == 0, index_desc
+        assert len(index_desc["data"]) == 1, index_desc
+        index = index_desc["data"][0]
+        assert index["fieldName"] == MINHASH_OUTPUT_FIELD_NAME
+        assert index["indexName"] == MINHASH_INDEX_NAME
+        assert index["metricType"] == "MHJACCARD"
+        assert index["indexType"] == "MINHASH_LSH"
+
+        binding = self._capture_sdk_function_binding(collection_name, MINHASH_FUNCTION_NAME, MINHASH_OUTPUT_FIELD_NAME)
+        assert binding["output_field_id"] == output_field_id
+        assert binding["function_id"] == function_id
+        assert binding["input_field_ids"] == [int(fields["text"]["id"])]
+        assert binding["output_field_ids"] == [output_field_id]
+
+        rsp = self.collection_client.drop_function_field(
+            {"collectionName": collection_name, "functionName": MINHASH_FUNCTION_NAME}
+        )
+        assert rsp["code"] == 0, rsp
+        after_drop_state = self._assert_base_schema_state(collection_name)
+        assert after_drop_state["fields"] == before_state["fields"]
+        assert after_drop_state["functions"] == before_state["functions"]
+        assert after_drop_state["indexes"] == before_state["indexes"]
+        assert int(after_drop_state["properties"]["max_field_id"]) >= int(before_state["properties"]["max_field_id"])

--- a/tests/restful_client_v2/testcases/test_function_field_operations.py
+++ b/tests/restful_client_v2/testcases/test_function_field_operations.py
@@ -1,0 +1,278 @@
+import pytest
+from base.testbase import TestBase
+from utils.constant import CaseLabel
+from utils.utils import gen_collection_name
+
+FUNCTION_NAME = "bm25_fn"
+OUTPUT_FIELD_NAME = "sparse"
+INDEX_NAME = "sparse_idx"
+BM25_FUNCTION_TYPE = 1
+
+
+def _function_field_payload(collection_name):
+    return {
+        "collectionName": collection_name,
+        "function": {
+            "name": FUNCTION_NAME,
+            "type": "BM25",
+            "inputFieldNames": ["text"],
+            "outputFieldNames": [OUTPUT_FIELD_NAME],
+            "params": {},
+        },
+        "outputField": {
+            "fieldName": OUTPUT_FIELD_NAME,
+            "dataType": "SparseFloatVector",
+        },
+        "indexParams": {
+            "fieldName": OUTPUT_FIELD_NAME,
+            "indexName": INDEX_NAME,
+            "metricType": "BM25",
+            "indexType": "SPARSE_INVERTED_INDEX",
+            "params": {},
+        },
+    }
+
+
+@pytest.mark.tags(CaseLabel.L1)
+class TestCollectionFunctionField(TestBase):
+    """REST v2 contract tests for atomic function-field schema operations."""
+
+    def _create_base_collection(self):
+        collection_name = gen_collection_name(prefix=self.__class__.__name__)
+        rsp = self.collection_client.collection_create(
+            {
+                "collectionName": collection_name,
+                "schema": {
+                    "autoId": False,
+                    "enableDynamicField": False,
+                    "fields": [
+                        {"fieldName": "id", "dataType": "Int64", "isPrimary": True},
+                        {
+                            "fieldName": "text",
+                            "dataType": "VarChar",
+                            "elementTypeParams": {
+                                "max_length": "1024",
+                                "enable_analyzer": True,
+                                "analyzer_params": {"tokenizer": "standard"},
+                            },
+                        },
+                        {"fieldName": "dense", "dataType": "FloatVector", "elementTypeParams": {"dim": "4"}},
+                    ],
+                },
+                "indexParams": [
+                    {
+                        "fieldName": "dense",
+                        "indexName": "dense_idx",
+                        "indexType": "AUTOINDEX",
+                        "metricType": "L2",
+                    }
+                ],
+            }
+        )
+        assert rsp["code"] == 0, rsp
+        return collection_name
+
+    def _add_bm25_function_field(self, collection_name):
+        rsp = self.collection_client.add_function_field(_function_field_payload(collection_name))
+        assert rsp["code"] == 0, rsp
+
+    def _assert_base_schema_state(self, collection_name):
+        desc = self.collection_client.collection_describe(collection_name)
+        assert desc["code"] == 0, desc
+        assert {field["name"] for field in desc["data"]["fields"]} == {"id", "text", "dense"}
+        assert desc["data"].get("functions", []) == []
+
+        indexes = self.index_client.index_list(collection_name=collection_name)
+        assert indexes["code"] == 0, indexes
+        assert indexes["data"] == ["dense_idx"]
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_add_function_field_creates_function_output_field_and_index(self):
+        """
+        target: verify REST add_function_field atomically creates all bound schema objects
+        method: add a BM25 function, sparse output field, and sparse index in one request
+        expected: describe endpoints expose the exact function, field, and index metadata
+        """
+        collection_name = self._create_base_collection()
+
+        rsp = self.collection_client.add_function_field(_function_field_payload(collection_name))
+        assert rsp["code"] == 0, rsp
+
+        desc = self.collection_client.collection_describe(collection_name)
+        assert desc["code"] == 0, desc
+        fields = {field["name"]: field for field in desc["data"]["fields"]}
+        functions = {function["name"]: function for function in desc["data"].get("functions", [])}
+        assert fields[OUTPUT_FIELD_NAME]["type"] == "SparseFloatVector"
+        assert functions[FUNCTION_NAME]["type"] == BM25_FUNCTION_TYPE
+        assert functions[FUNCTION_NAME]["inputFieldNames"] == ["text"]
+        assert functions[FUNCTION_NAME]["outputFieldNames"] == [OUTPUT_FIELD_NAME]
+
+        index_desc = self.index_client.index_describe(collection_name=collection_name, index_name=INDEX_NAME)
+        assert index_desc["code"] == 0, index_desc
+        assert len(index_desc["data"]) == 1, index_desc
+        index = index_desc["data"][0]
+        assert index["fieldName"] == OUTPUT_FIELD_NAME
+        assert index["indexName"] == INDEX_NAME
+        assert index["metricType"] == "BM25"
+        assert index["indexType"] == "SPARSE_INVERTED_INDEX"
+
+    @pytest.mark.parametrize(
+        "function_output,index_field,expected_message",
+        [
+            (["other_sparse"], OUTPUT_FIELD_NAME, "function output field"),
+            ([OUTPUT_FIELD_NAME], "other_sparse", "must match outputField.fieldName"),
+        ],
+        ids=["function-output-mismatch", "index-field-mismatch"],
+    )
+    def test_add_function_field_rejects_inconsistent_field_names(
+        self,
+        function_output,
+        index_field,
+        expected_message,
+    ):
+        """
+        target: verify REST validates the three field-name bindings in add_function_field
+        method: mismatch either function output or index target from the output field
+        expected: request fails as invalid input without changing the collection schema
+        """
+        collection_name = self._create_base_collection()
+        payload = _function_field_payload(collection_name)
+        payload["function"]["outputFieldNames"] = function_output
+        payload["indexParams"]["fieldName"] = index_field
+
+        rsp = self.collection_client.add_function_field(payload)
+        assert rsp["code"] == 1100, rsp
+        assert expected_message in rsp["message"], rsp
+
+        self._assert_base_schema_state(collection_name)
+
+    @pytest.mark.parametrize(
+        "missing_key",
+        ["function", "outputField", "indexParams"],
+    )
+    def test_add_function_field_requires_atomic_request_parts(self, missing_key):
+        """
+        target: verify all atomic add_function_field request parts are required
+        method: omit the function, outputField, or indexParams object
+        expected: REST binding rejects each incomplete request
+        """
+        collection_name = self._create_base_collection()
+        payload = _function_field_payload(collection_name)
+        del payload[missing_key]
+
+        rsp = self.collection_client.add_function_field(payload)
+        assert rsp["code"] == 1802, rsp
+        assert "required" in rsp["message"], rsp
+        self._assert_base_schema_state(collection_name)
+
+    def test_add_function_field_rejects_unsupported_function_type(self):
+        """
+        target: verify add_function_field accepts only function types supported by schema backfill
+        method: send a TextEmbedding function with a newly-defined dense output field and index
+        expected: REST returns invalid parameter instead of creating partial schema objects
+        """
+        collection_name = self._create_base_collection()
+        payload = _function_field_payload(collection_name)
+        payload["function"].update(
+            {
+                "type": "TextEmbedding",
+                "outputFieldNames": ["embedding"],
+            }
+        )
+        payload["outputField"] = {
+            "fieldName": "embedding",
+            "dataType": "FloatVector",
+            "elementTypeParams": {"dim": "4"},
+        }
+        payload["indexParams"] = {
+            "fieldName": "embedding",
+            "indexName": "embedding_idx",
+            "metricType": "L2",
+            "indexType": "HNSW",
+            "params": {"M": 8, "efConstruction": 64},
+        }
+
+        rsp = self.collection_client.add_function_field(payload)
+        assert rsp["code"] == 1100, rsp
+        assert "only BM25 and MinHash functions are supported" in rsp["message"], rsp
+        self._assert_base_schema_state(collection_name)
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_drop_function_field_removes_function_output_field_and_index(self):
+        """
+        target: verify REST drop_function_field performs the documented cascade
+        method: add a BM25 function field and then drop it by function name
+        expected: function, sparse output field, and bound index all disappear
+        """
+        collection_name = self._create_base_collection()
+        self._add_bm25_function_field(collection_name)
+
+        rsp = self.collection_client.drop_function_field(
+            {"collectionName": collection_name, "functionName": FUNCTION_NAME}
+        )
+        assert rsp["code"] == 0, rsp
+
+        self._assert_base_schema_state(collection_name)
+
+    @pytest.mark.parametrize(
+        "function_name,expected_code,expected_message",
+        [
+            ("", 1802, "required"),
+            ("missing_fn", 1100, "function not found"),
+        ],
+        ids=["empty-name", "unknown-function"],
+    )
+    def test_drop_function_field_rejects_invalid_function_name(
+        self,
+        function_name,
+        expected_code,
+        expected_message,
+    ):
+        """
+        target: verify drop_function_field validates the functionName parameter
+        method: send an empty name and a name absent from the collection schema
+        expected: REST returns binding or invalid-parameter errors respectively
+        """
+        collection_name = self._create_base_collection()
+
+        rsp = self.collection_client.drop_function_field(
+            {"collectionName": collection_name, "functionName": function_name}
+        )
+        assert rsp["code"] == expected_code, rsp
+        assert expected_message in rsp["message"], rsp
+
+    def test_drop_function_field_second_request_is_rejected(self):
+        """
+        target: verify drop_function_field is not silently idempotent
+        method: drop the same function field twice
+        expected: the second request reports that the function no longer exists
+        """
+        collection_name = self._create_base_collection()
+        self._add_bm25_function_field(collection_name)
+        payload = {"collectionName": collection_name, "functionName": FUNCTION_NAME}
+
+        first = self.collection_client.drop_function_field(payload)
+        assert first["code"] == 0, first
+        second = self.collection_client.drop_function_field(payload)
+        assert second["code"] == 1100, second
+        assert "function not found" in second["message"], second
+
+    def test_drop_field_rejects_function_input_until_function_field_is_dropped(self):
+        """
+        target: verify REST drop field honors function input dependencies
+        method: drop the BM25 input field before and after dropping its function field
+        expected: the dependency blocks the first drop; the same field is removable after the cascade
+        """
+        collection_name = self._create_base_collection()
+        self._add_bm25_function_field(collection_name)
+
+        blocked = self.collection_client.drop_field(collection_name, field_name="text")
+        assert blocked["code"] == 1100, blocked
+        assert "referenced by function" in blocked["message"], blocked
+
+        dropped = self.collection_client.drop_function_field(
+            {"collectionName": collection_name, "functionName": FUNCTION_NAME}
+        )
+        assert dropped["code"] == 0, dropped
+        unblocked = self.collection_client.drop_field(collection_name, field_name="text")
+        assert unblocked["code"] == 0, unblocked

--- a/tests/restful_client_v2/testcases/test_query_aggregation.py
+++ b/tests/restful_client_v2/testcases/test_query_aggregation.py
@@ -131,9 +131,13 @@ class TestQueryAggregation(TestBase):
     def test_query_group_by_nullable_count_min_max_avg(self):
         """
         target: verify REST query supports count(field), min, max, and avg aggregation expressions
-        method: group nullable numeric values by category and request all four aggregate functions together
-        expected: field count excludes NULL values; min, max, and avg match the non-NULL source values
+        method: filter an uneven prefix, group nullable numeric values by category, and request four aggregate functions
+        expected: non-uniform group counts and each aggregate match the filtered non-NULL source values
         """
+
+        def row_filter(row):
+            return row["id"] < 97
+
         aggregate_fields = (
             "count(*)",
             "count(nullable_value)",
@@ -144,7 +148,7 @@ class TestQueryAggregation(TestBase):
         rows = self._query(
             {
                 "collectionName": self.collection_name,
-                "filter": "id >= 0",
+                "filter": "id < 97",
                 "limit": 10,
                 "outputFields": ["category", *aggregate_fields],
                 "groupByFields": ["category"],
@@ -153,7 +157,11 @@ class TestQueryAggregation(TestBase):
         )
 
         expected = sorted(
-            _expected_grouped_rows(["category"], aggregate_fields=aggregate_fields),
+            _expected_grouped_rows(
+                ["category"],
+                aggregate_fields=aggregate_fields,
+                row_filter=row_filter,
+            ),
             key=lambda row: row["category"],
         )
         assert len(rows) == len(expected)
@@ -238,9 +246,9 @@ class TestQueryAggregation(TestBase):
     @pytest.mark.tags(CaseLabel.L0)
     def test_query_group_by_count_with_limit_offset(self):
         """
-        target: verify grouped count(*) forwards limit and offset for pagination
-        method: order category groups, skip the first group, and return the next two groups
-        expected: REST returns the exact ordered page instead of applying global count(*) behavior
+        target: verify grouped aggregates apply limit and offset after explicit group ordering
+        method: order category groups descending, skip the first group, and return two count/sum rows
+        expected: REST returns exact category_3 and category_2 aggregate rows in that order
         """
         rows = self._query(
             {
@@ -248,15 +256,16 @@ class TestQueryAggregation(TestBase):
                 "filter": "id >= 0",
                 "limit": 2,
                 "offset": 1,
-                "outputFields": ["category", "count(*)"],
+                "outputFields": ["category", "count(*)", "sum(score)"],
                 "groupByFields": ["category"],
-                "orderByFields": ["category:asc"],
+                "orderByFields": ["category:desc"],
             }
         )
 
-        expected = sorted(_expected_grouped_rows(["category"]), key=lambda row: row["category"])[1:3]
-        expected = [{"category": row["category"], "count(*)": row["count(*)"]} for row in expected]
-        assert rows == expected
+        assert rows == [
+            {"category": "category_3", "count(*)": 40, "sum(score)": 3980},
+            {"category": "category_2", "count(*)": 40, "sum(score)": 3900},
+        ]
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_query_global_count_star_keeps_legacy_limit_behavior(self):

--- a/tests/restful_client_v2/testcases/test_query_aggregation.py
+++ b/tests/restful_client_v2/testcases/test_query_aggregation.py
@@ -127,6 +127,33 @@ class TestQueryAggregation(TestBase):
         assert [row["category"] for row in rows] == ["category_1", "category_3"]
         assert rows == expected
 
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_query_group_by_omits_group_key_from_output_fields(self):
+        """
+        target: verify REST query remaps grouped aggregate results without injecting omitted group keys
+        method: group by category while requesting only count(*) and sum(score) in outputFields
+        expected: each result contains exactly the requested aggregates and matches the category-group oracle order
+        """
+        rows = self._query(
+            {
+                "collectionName": self.collection_name,
+                "filter": SELECTIVE_FILTER,
+                "limit": 10,
+                "outputFields": ["count(*)", "sum(score)"],
+                "groupByFields": ["category"],
+                "orderByFields": ["category:asc"],
+            }
+        )
+        expected = sorted(
+            _expected_grouped_rows(
+                ["category"],
+                row_filter=lambda row: row["category"] in {"category_1", "category_3"} and 20 <= row["id"] < 90,
+            ),
+            key=lambda row: row["category"],
+        )
+        assert [set(row) for row in rows] == [{"count(*)", "sum(score)"}] * len(expected)
+        assert rows == [{key: row[key] for key in ("count(*)", "sum(score)")} for row in expected]
+
     @pytest.mark.tags(CaseLabel.L0)
     def test_query_group_by_nullable_count_min_max_avg(self):
         """

--- a/tests/restful_client_v2/testcases/test_query_aggregation.py
+++ b/tests/restful_client_v2/testcases/test_query_aggregation.py
@@ -1,0 +1,313 @@
+import pytest
+from base.testbase import TestBase
+from utils.constant import CaseLabel
+from utils.utils import gen_collection_name
+
+DIM = 4
+NB = 200
+SELECTIVE_FILTER = 'category in ["category_1", "category_3"] && id >= 20 && id < 90'
+
+
+def _rows():
+    return [
+        {
+            "id": i,
+            "price": 10 + ((i // 5) % 10),
+            "score": (i * 17 + 11) % NB,
+            "nullable_value": None if i % 4 == 0 else (i * 7) % 31,
+            "category": f"category_{i % 5}",
+            "vector": [float(i), 0.0, 0.0, 0.0],
+        }
+        for i in range(NB)
+    ]
+
+
+def _expected_grouped_rows(group_by_fields, aggregate_fields=("count(*)", "sum(score)"), row_filter=None):
+    groups = {}
+    for row in _rows():
+        if row_filter is not None and not row_filter(row):
+            continue
+        key = tuple(row[field] for field in group_by_fields)
+        groups.setdefault(key, []).append(row)
+
+    expected_rows = []
+    for key, grouped_rows in groups.items():
+        expected = dict(zip(group_by_fields, key))
+        for aggregate_field in aggregate_fields:
+            if aggregate_field == "count(*)":
+                expected[aggregate_field] = len(grouped_rows)
+                continue
+
+            aggregate_function, field_name = aggregate_field[:-1].split("(", 1)
+            values = [row[field_name] for row in grouped_rows if row[field_name] is not None]
+            if aggregate_function == "count":
+                expected[aggregate_field] = len(values)
+            elif aggregate_function == "sum":
+                expected[aggregate_field] = sum(values)
+            elif aggregate_function == "min":
+                expected[aggregate_field] = min(values)
+            elif aggregate_function == "max":
+                expected[aggregate_field] = max(values)
+            elif aggregate_function == "avg":
+                expected[aggregate_field] = sum(values) / len(values)
+            else:
+                raise AssertionError(f"Unsupported aggregate expression: {aggregate_field}")
+        expected_rows.append(expected)
+    return expected_rows
+
+
+class TestQueryAggregation(TestBase):
+    @pytest.fixture(scope="class", autouse=True)
+    def prepare_shared_query_aggregation_collection(self, request, init_class_config):
+        collection_name = gen_collection_name(prefix=request.cls.__name__)
+        request.cls.collection_name = collection_name
+        collection_client, vector_client = self._class_scope_clients()
+
+        def teardown():
+            collection_client.collection_drop({"collectionName": collection_name})
+
+        request.addfinalizer(teardown)
+        payload = {
+            "collectionName": collection_name,
+            "schema": {
+                "autoId": False,
+                "enableDynamicField": False,
+                "fields": [
+                    {"fieldName": "id", "dataType": "Int64", "isPrimary": True},
+                    {"fieldName": "price", "dataType": "Int64"},
+                    {"fieldName": "score", "dataType": "Int64"},
+                    {"fieldName": "nullable_value", "dataType": "Int64", "nullable": True},
+                    {"fieldName": "category", "dataType": "VarChar", "elementTypeParams": {"max_length": "64"}},
+                    {"fieldName": "vector", "dataType": "FloatVector", "elementTypeParams": {"dim": str(DIM)}},
+                ],
+            },
+            "indexParams": [{"fieldName": "vector", "indexName": "vector_index", "metricType": "L2"}],
+        }
+        rsp = collection_client.collection_create(payload)
+        assert rsp["code"] == 0, rsp
+        collection_client.wait_load_completed(collection_name, timeout=60)
+
+        rows = _rows()
+        rsp = vector_client.vector_insert({"collectionName": collection_name, "data": rows})
+        assert rsp["code"] == 0, rsp
+        assert rsp["data"]["insertCount"] == len(rows)
+        rsp = collection_client.flush(collection_name)
+        assert rsp["code"] == 0, rsp
+
+    def _query(self, payload, timeout=1):
+        rsp = self.vector_client.vector_query(payload, timeout=timeout)
+        assert rsp["code"] == 0, rsp
+        return rsp.get("data", [])
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_query_group_by_single_field_count_sum(self):
+        """
+        target: verify REST query supports groupByFields with aggregation expressions
+        method: selectively filter IDs and categories, then group by category and calculate count(*) and sum(score)
+        expected: only filtered categories return their exact filtered count and sum
+        """
+        rows = self._query(
+            {
+                "collectionName": self.collection_name,
+                "filter": SELECTIVE_FILTER,
+                "limit": 10,
+                "outputFields": ["category", "count(*)", "sum(score)"],
+                "groupByFields": ["category"],
+                "orderByFields": ["category:asc"],
+            }
+        )
+
+        expected = sorted(
+            _expected_grouped_rows(
+                ["category"],
+                row_filter=lambda row: row["category"] in {"category_1", "category_3"} and 20 <= row["id"] < 90,
+            ),
+            key=lambda row: row["category"],
+        )
+        assert [row["category"] for row in rows] == ["category_1", "category_3"]
+        assert rows == expected
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_query_group_by_nullable_count_min_max_avg(self):
+        """
+        target: verify REST query supports count(field), min, max, and avg aggregation expressions
+        method: group nullable numeric values by category and request all four aggregate functions together
+        expected: field count excludes NULL values; min, max, and avg match the non-NULL source values
+        """
+        aggregate_fields = (
+            "count(*)",
+            "count(nullable_value)",
+            "min(nullable_value)",
+            "max(nullable_value)",
+            "avg(nullable_value)",
+        )
+        rows = self._query(
+            {
+                "collectionName": self.collection_name,
+                "filter": "id >= 0",
+                "limit": 10,
+                "outputFields": ["category", *aggregate_fields],
+                "groupByFields": ["category"],
+                "orderByFields": ["category:asc"],
+            }
+        )
+
+        expected = sorted(
+            _expected_grouped_rows(["category"], aggregate_fields=aggregate_fields),
+            key=lambda row: row["category"],
+        )
+        assert len(rows) == len(expected)
+        for actual, expected_row in zip(rows, expected):
+            assert set(actual) == {"category", *aggregate_fields}
+            assert actual["category"] == expected_row["category"]
+            assert actual["count(*)"] == expected_row["count(*)"]
+            assert actual["count(nullable_value)"] == expected_row["count(nullable_value)"]
+            assert actual["count(nullable_value)"] < actual["count(*)"]
+            assert actual["min(nullable_value)"] == expected_row["min(nullable_value)"]
+            assert actual["max(nullable_value)"] == expected_row["max(nullable_value)"]
+            assert actual["avg(nullable_value)"] == pytest.approx(expected_row["avg(nullable_value)"])
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_query_group_by_nullable_field(self):
+        """
+        target: verify REST query returns a group for a nullable groupByFields key
+        method: group all rows by nullable_value and calculate count(*) and sum(score)
+        expected: every numeric key and the NULL key return the exact aggregate values
+        """
+        rows = self._query(
+            {
+                "collectionName": self.collection_name,
+                "filter": "id >= 0",
+                "limit": 40,
+                "outputFields": ["nullable_value", "count(*)", "sum(score)"],
+                "groupByFields": ["nullable_value"],
+            }
+        )
+
+        expected = _expected_grouped_rows(["nullable_value"])
+        actual_by_key = {row["nullable_value"]: row for row in rows}
+        expected_by_key = {row["nullable_value"]: row for row in expected}
+        assert len(rows) == len(expected)
+        assert None in actual_by_key
+        assert actual_by_key == expected_by_key
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_query_group_by_without_order_by(self):
+        """
+        target: verify REST query supports groupByFields without orderByFields
+        method: group by category and calculate count(*) and sum(score) without requesting group ordering
+        expected: every group and aggregate value matches the source rows regardless of response order
+        """
+        rows = self._query(
+            {
+                "collectionName": self.collection_name,
+                "filter": "id >= 0",
+                "limit": 10,
+                "outputFields": ["category", "count(*)", "sum(score)"],
+                "groupByFields": ["category"],
+            }
+        )
+
+        expected = _expected_grouped_rows(["category"])
+        assert sorted(rows, key=lambda row: row["category"]) == sorted(expected, key=lambda row: row["category"])
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_query_group_by_multi_fields_with_order_by(self):
+        """
+        target: verify REST query forwards multiple groupByFields with orderByFields
+        method: group by category and price, then order groups by category asc and price desc
+        expected: group keys, aggregate values, and ordering all match the source rows
+        """
+        rows = self._query(
+            {
+                "collectionName": self.collection_name,
+                "filter": "id >= 0",
+                "limit": 20,
+                "outputFields": ["category", "price", "count(*)", "sum(score)"],
+                "groupByFields": ["category", "price"],
+                "orderByFields": ["category:asc", "price:desc"],
+            }
+        )
+
+        expected = sorted(
+            _expected_grouped_rows(["category", "price"]),
+            key=lambda row: (row["category"], -row["price"]),
+        )[:20]
+        assert rows == expected
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_query_group_by_count_with_limit_offset(self):
+        """
+        target: verify grouped count(*) forwards limit and offset for pagination
+        method: order category groups, skip the first group, and return the next two groups
+        expected: REST returns the exact ordered page instead of applying global count(*) behavior
+        """
+        rows = self._query(
+            {
+                "collectionName": self.collection_name,
+                "filter": "id >= 0",
+                "limit": 2,
+                "offset": 1,
+                "outputFields": ["category", "count(*)"],
+                "groupByFields": ["category"],
+                "orderByFields": ["category:asc"],
+            }
+        )
+
+        expected = sorted(_expected_grouped_rows(["category"]), key=lambda row: row["category"])[1:3]
+        expected = [{"category": row["category"], "count(*)": row["count(*)"]} for row in expected]
+        assert rows == expected
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_query_global_count_star_keeps_legacy_limit_behavior(self):
+        """
+        target: verify global count(*) behavior remains unchanged after adding groupByFields
+        method: query count(*) without groupByFields while sending limit and offset
+        expected: one global row returns the full collection count
+        """
+        rows = self._query(
+            {
+                "collectionName": self.collection_name,
+                "filter": "id >= 0",
+                "limit": 1,
+                "offset": 10,
+                "outputFields": ["count(*)"],
+            }
+        )
+        assert rows == [{"count(*)": NB}]
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_query_global_mixed_count_aggregates_keep_legacy_limit_behavior(self):
+        """
+        target: verify mixed global count aggregates retain the legacy REST default-limit behavior
+        method: query count(*) and sum(score) without groupByFields or an explicit limit
+        expected: Proxy rejects the REST default limit because global count(*) cannot use pagination
+        """
+        rsp = self.vector_client.vector_query(
+            {
+                "collectionName": self.collection_name,
+                "filter": "id >= 0",
+                "outputFields": ["count(*)", "sum(score)"],
+            }
+        )
+        assert rsp["code"] == 1100, rsp
+        assert "count entities with pagination is not allowed" in rsp["message"], rsp
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_query_group_by_invalid_field(self):
+        """
+        target: verify REST query reports server validation for an invalid groupByFields entry
+        method: group count(*) by a field absent from the collection schema
+        expected: request fails with parameter error code 1100
+        """
+        rsp = self.vector_client.vector_query(
+            {
+                "collectionName": self.collection_name,
+                "filter": "id >= 0",
+                "limit": 10,
+                "outputFields": ["count(*)"],
+                "groupByFields": ["unknown_group_field"],
+            }
+        )
+        assert rsp["code"] == 1100, rsp
+        assert "unknown_group_field" in rsp["message"], rsp

--- a/tests/restful_client_v2/testcases/test_query_order_by.py
+++ b/tests/restful_client_v2/testcases/test_query_order_by.py
@@ -44,8 +44,8 @@ def _parse_order_by_field(order_by_field):
 def _expected_rows(order_by_fields, limit, row_filter=None, offset=0):
     """Build a deterministic reference order for local assertions.
 
-    Query ORDER BY uses the primary key as a stable tie-breaker when all
-    explicit sort fields match, so the reference order includes the ID key.
+    The final ID key stabilizes this test helper only. Query ORDER BY does not
+    guarantee an implicit PK tie-breaker when all explicit sort fields match.
     """
     rows = [row for row in _rows() if row_filter is None or row_filter(row)]
     order_specs = [_parse_order_by_field(field) for field in order_by_fields]
@@ -139,6 +139,14 @@ class TestQueryOrderBy(TestBase):
         assert actual == expected
 
     @staticmethod
+    def _assert_expected_members(rows, expected_rows, fields):
+        actual_ids = [row["id"] for row in rows]
+        assert len(actual_ids) == len(set(actual_ids)), f"duplicate IDs returned: {actual_ids}"
+        actual = {(row["id"], *(row[field] for field in fields)) for row in rows}
+        expected = {(row["id"], *(row[field] for field in fields)) for row in expected_rows}
+        assert actual == expected
+
+    @staticmethod
     def _assert_nulls_at_end(values):
         first_null = next((i for i, value in enumerate(values) if value is None), len(values))
         non_nulls = values[:first_null]
@@ -206,8 +214,8 @@ class TestQueryOrderBy(TestBase):
     def test_query_order_by_multi_fields(self):
         """
         target: verify REST query supports multi-field orderByFields
-        method: sort by price ascending and rating descending
-        expected: primary and secondary sort orders are both respected
+        method: sort 80 rows by price ascending and rating descending across four complete tied-price groups
+        expected: primary and secondary value order is correct and the exact row members are returned once each
         """
         rows = self._query(
             {
@@ -230,7 +238,7 @@ class TestQueryOrderBy(TestBase):
         assert secondary_sort_tested, "No duplicate price values found; secondary sort was not verified"
         expected = _expected_rows(["price:asc", "rating:desc"], limit=80)
         self._assert_expected_values(rows, expected, ["price", "rating"])
-        self._assert_expected_ids(rows, expected)
+        self._assert_expected_members(rows, expected, ["price", "rating"])
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_query_order_by_with_filter(self):
@@ -283,15 +291,15 @@ class TestQueryOrderBy(TestBase):
     def test_query_order_by_with_offset(self):
         """
         target: verify REST query applies offset after ordering
-        method: compare the second ordered page with a larger ordered baseline
-        expected: offset page equals the matching slice of the baseline result
+        method: use an explicit id tie-breaker and compare the second ordered page with a larger baseline
+        expected: offset is applied after a deterministic global order and repeated requests return the same page
         """
         base_payload = {
             "collectionName": self.collection_name,
             "filter": "id >= 0",
             "limit": 20,
             "outputFields": ["id", "price"],
-            "orderByFields": ["price:asc"],
+            "orderByFields": ["price:asc", "id:asc"],
         }
         baseline = self._query(base_payload)
         page_payload = {**base_payload, "limit": 10, "offset": 10}
@@ -302,7 +310,7 @@ class TestQueryOrderBy(TestBase):
         assert len({row["price"] for row in baseline}) == 1
         assert [row["id"] for row in page] == [row["id"] for row in baseline[10:20]]
         assert [row["id"] for row in repeated_page] == [row["id"] for row in page]
-        expected = _expected_rows(["price:asc"], limit=10, offset=10)
+        expected = _expected_rows(["price:asc", "id:asc"], limit=10, offset=10)
         self._assert_expected_ids(page, expected)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -325,6 +333,7 @@ class TestQueryOrderBy(TestBase):
         asc_non_nulls = self._assert_nulls_at_end([row["nullable_score"] for row in asc_rows])
         for i in range(len(asc_non_nulls) - 1):
             assert asc_non_nulls[i] <= asc_non_nulls[i + 1]
+        self._assert_expected_members(asc_rows, _rows(), ["nullable_score"])
 
         desc_rows = self._query(
             {
@@ -339,6 +348,7 @@ class TestQueryOrderBy(TestBase):
         desc_non_nulls = self._assert_nulls_at_beginning([row["nullable_score"] for row in desc_rows])
         for i in range(len(desc_non_nulls) - 1):
             assert desc_non_nulls[i] >= desc_non_nulls[i + 1]
+        self._assert_expected_members(desc_rows, _rows(), ["nullable_score"])
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_query_order_by_nulls_override(self):
@@ -360,6 +370,7 @@ class TestQueryOrderBy(TestBase):
         non_nulls = self._assert_nulls_at_beginning([row["nullable_score"] for row in nulls_first_rows])
         for i in range(len(non_nulls) - 1):
             assert non_nulls[i] <= non_nulls[i + 1]
+        self._assert_expected_members(nulls_first_rows, _rows(), ["nullable_score"])
 
         nulls_last_rows = self._query(
             {
@@ -374,6 +385,27 @@ class TestQueryOrderBy(TestBase):
         non_nulls = self._assert_nulls_at_end([row["nullable_score"] for row in nulls_last_rows])
         for i in range(len(non_nulls) - 1):
             assert non_nulls[i] >= non_nulls[i + 1]
+        self._assert_expected_members(nulls_last_rows, _rows(), ["nullable_score"])
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_query_order_by_varchar_desc(self):
+        """
+        target: verify REST query orders VarChar fields in descending lexical order
+        method: sort category descending with an explicit descending ID tie-breaker opposing insertion order
+        expected: exact IDs and categories follow both explicit comparators without relying on stable input order
+        """
+        rows = self._query(
+            {
+                "collectionName": self.collection_name,
+                "filter": "id >= 0",
+                "limit": 80,
+                "outputFields": ["id", "category"],
+                "orderByFields": ["category:desc", "id:desc"],
+            }
+        )
+        expected_ids = sorted(range(NB), key=lambda row_id: (-(row_id % 5), -row_id))[:80]
+        assert [row["id"] for row in rows] == expected_ids
+        assert [row["category"] for row in rows] == [f"category_{row_id % 5}" for row_id in expected_ids]
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_query_order_by_sort_field_not_in_output(self):
@@ -395,6 +427,7 @@ class TestQueryOrderBy(TestBase):
         assert all(set(row) == {"id", "category"} for row in rows)
         expected = _expected_rows(["price:asc"], limit=20)
         expected_prices = [row["price"] for row in expected]
+        self._assert_expected_members(rows, expected, ["category"])
 
         ids = [row["id"] for row in rows]
         verify_rows = self._query(

--- a/tests/restful_client_v2/testcases/test_query_order_by.py
+++ b/tests/restful_client_v2/testcases/test_query_order_by.py
@@ -44,8 +44,8 @@ def _parse_order_by_field(order_by_field):
 def _expected_rows(order_by_fields, limit, row_filter=None, offset=0):
     """Build a deterministic reference order for local assertions.
 
-    The final ID key stabilizes this test helper only. Query ORDER BY does not
-    guarantee an implicit PK tie-breaker when all explicit sort fields match.
+    Query ORDER BY uses the primary key as a stable tie-breaker when all
+    explicit sort fields match, so the reference order includes the ID key.
     """
     rows = [row for row in _rows() if row_filter is None or row_filter(row)]
     order_specs = [_parse_order_by_field(field) for field in order_by_fields]
@@ -66,18 +66,17 @@ def _expected_rows(order_by_fields, limit, row_filter=None, offset=0):
 
 
 class TestQueryOrderBy(TestBase):
-    def setup_class(self):
-        self.collection_name = self.__class__.__name__ + gen_collection_name()
-
     @pytest.fixture(scope="class", autouse=True)
     def prepare_shared_query_order_collection(self, request, init_class_config):
+        collection_name = gen_collection_name(prefix=request.cls.__name__)
+        request.cls.collection_name = collection_name
         collection_client, vector_client = self._class_scope_clients()
 
         def teardown():
-            collection_client.collection_drop({"collectionName": self.collection_name})
+            collection_client.collection_drop({"collectionName": collection_name})
 
         request.addfinalizer(teardown)
-        self._create_query_order_collection(self.collection_name, collection_client, vector_client)
+        self._create_query_order_collection(collection_name, collection_client, vector_client)
 
     def _create_query_order_collection(self, name, collection_client, vector_client):
         payload = {
@@ -115,9 +114,6 @@ class TestQueryOrderBy(TestBase):
         rsp = collection_client.flush(name)
         assert rsp["code"] == 0, rsp
 
-    def _shared_collection(self):
-        return self.collection_name
-
     def _query(self, payload, timeout=1):
         rsp = self.vector_client.vector_query(payload, timeout=timeout)
         assert rsp["code"] == 0, rsp
@@ -141,13 +137,6 @@ class TestQueryOrderBy(TestBase):
         actual = [tuple(row[field] for field in fields) for row in rows]
         expected = [tuple(row[field] for field in fields) for row in expected_rows]
         assert actual == expected
-
-    @staticmethod
-    def _assert_returned_ties_pk_monotonic(rows, fields):
-        """Check the current returned subset without asserting exact tie selection."""
-        for current, following in zip(rows, rows[1:]):
-            if all(current[field] == following[field] for field in fields):
-                assert current["id"] < following["id"], rows
 
     @staticmethod
     def _assert_nulls_at_end(values):
@@ -178,7 +167,7 @@ class TestQueryOrderBy(TestBase):
         """
         rows = self._query(
             {
-                "collectionName": self._shared_collection(),
+                "collectionName": self.collection_name,
                 "filter": "id >= 0",
                 "limit": 20,
                 "outputFields": ["id", "score"],
@@ -200,7 +189,7 @@ class TestQueryOrderBy(TestBase):
         """
         rows = self._query(
             {
-                "collectionName": self._shared_collection(),
+                "collectionName": self.collection_name,
                 "filter": "id >= 0",
                 "limit": 20,
                 "outputFields": ["id", "score"],
@@ -222,7 +211,7 @@ class TestQueryOrderBy(TestBase):
         """
         rows = self._query(
             {
-                "collectionName": self._shared_collection(),
+                "collectionName": self.collection_name,
                 "filter": "id >= 0",
                 "limit": 80,
                 "outputFields": ["id", "price", "rating"],
@@ -247,28 +236,28 @@ class TestQueryOrderBy(TestBase):
     def test_query_order_by_with_filter(self):
         """
         target: verify REST query applies filter before orderByFields
-        method: filter a price range and sort by price ascending
-        expected: all rows match the filter and are sorted by price
+        method: filter a price range and sort by price ascending with an explicit id tie-breaker
+        expected: all rows match the filter and return the exact globally ordered ids
         """
         rows = self._query(
             {
-                "collectionName": self._shared_collection(),
+                "collectionName": self.collection_name,
                 "filter": "price >= 12 && price <= 16",
                 "limit": 50,
                 "outputFields": ["id", "price"],
-                "orderByFields": ["price:asc"],
+                "orderByFields": ["price:asc", "id:asc"],
             }
         )
         assert len(rows) == 50
         assert all(12 <= row["price"] <= 16 for row in rows)
         self._assert_ordered(rows, "price")
         expected = _expected_rows(
-            ["price:asc"],
+            ["price:asc", "id:asc"],
             limit=50,
             row_filter=lambda row: 12 <= row["price"] <= 16,
         )
         self._assert_expected_values(rows, expected, ["price"])
-        self._assert_returned_ties_pk_monotonic(rows, ["price"])
+        self._assert_expected_ids(rows, expected)
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_query_order_by_default_limit(self):
@@ -279,7 +268,7 @@ class TestQueryOrderBy(TestBase):
         """
         rows = self._query(
             {
-                "collectionName": self._shared_collection(),
+                "collectionName": self.collection_name,
                 "filter": "id >= 0",
                 "outputFields": ["id", "score"],
                 "orderByFields": ["score:desc"],
@@ -298,7 +287,7 @@ class TestQueryOrderBy(TestBase):
         expected: offset page equals the matching slice of the baseline result
         """
         base_payload = {
-            "collectionName": self._shared_collection(),
+            "collectionName": self.collection_name,
             "filter": "id >= 0",
             "limit": 20,
             "outputFields": ["id", "price"],
@@ -325,7 +314,7 @@ class TestQueryOrderBy(TestBase):
         """
         asc_rows = self._query(
             {
-                "collectionName": self._shared_collection(),
+                "collectionName": self.collection_name,
                 "filter": "id >= 0",
                 "limit": NB,
                 "outputFields": ["id", "nullable_score"],
@@ -339,7 +328,7 @@ class TestQueryOrderBy(TestBase):
 
         desc_rows = self._query(
             {
-                "collectionName": self._shared_collection(),
+                "collectionName": self.collection_name,
                 "filter": "id >= 0",
                 "limit": NB,
                 "outputFields": ["id", "nullable_score"],
@@ -360,7 +349,7 @@ class TestQueryOrderBy(TestBase):
         """
         nulls_first_rows = self._query(
             {
-                "collectionName": self._shared_collection(),
+                "collectionName": self.collection_name,
                 "filter": "id >= 0",
                 "limit": NB,
                 "outputFields": ["id", "nullable_score"],
@@ -374,7 +363,7 @@ class TestQueryOrderBy(TestBase):
 
         nulls_last_rows = self._query(
             {
-                "collectionName": self._shared_collection(),
+                "collectionName": self.collection_name,
                 "filter": "id >= 0",
                 "limit": NB,
                 "outputFields": ["id", "nullable_score"],
@@ -395,7 +384,7 @@ class TestQueryOrderBy(TestBase):
         """
         rows = self._query(
             {
-                "collectionName": self._shared_collection(),
+                "collectionName": self.collection_name,
                 "filter": "id >= 0",
                 "limit": 20,
                 "outputFields": ["id", "category"],
@@ -403,14 +392,14 @@ class TestQueryOrderBy(TestBase):
             }
         )
         assert len(rows) == 20
-        assert all("price" not in row for row in rows)
+        assert all(set(row) == {"id", "category"} for row in rows)
         expected = _expected_rows(["price:asc"], limit=20)
         expected_prices = [row["price"] for row in expected]
 
         ids = [row["id"] for row in rows]
         verify_rows = self._query(
             {
-                "collectionName": self._shared_collection(),
+                "collectionName": self.collection_name,
                 "filter": f"id in {ids}",
                 "limit": len(ids),
                 "outputFields": ["id", "price"],
@@ -432,7 +421,7 @@ class TestQueryOrderBy(TestBase):
         """
         rows = self._query(
             {
-                "collectionName": self._shared_collection(),
+                "collectionName": self.collection_name,
                 "filter": "score > 999999",
                 "limit": 10,
                 "outputFields": ["id", "score"],
@@ -462,7 +451,7 @@ class TestQueryOrderBy(TestBase):
         """
         rsp = self.vector_client.vector_query(
             {
-                "collectionName": self._shared_collection(),
+                "collectionName": self.collection_name,
                 "filter": "id >= 0",
                 "limit": 10,
                 "outputFields": ["id"],

--- a/tests/restful_client_v2/testcases/test_search_aggregation.py
+++ b/tests/restful_client_v2/testcases/test_search_aggregation.py
@@ -1,0 +1,285 @@
+import pytest
+from base.testbase import TestBase
+from utils.constant import CaseLabel
+from utils.utils import gen_collection_name
+
+ROWS = [
+    {"id": 1, "category": "A", "brand": "X", "price": 30, "vector": [1.0, 0.0]},
+    {"id": 2, "category": "A", "brand": "Y", "price": 10, "vector": [0.9, 0.0]},
+    {"id": 3, "category": "B", "brand": "X", "price": 20, "vector": [0.8, 0.0]},
+    {"id": 4, "category": "C", "brand": "Y", "price": 40, "vector": [0.7, 0.0]},
+    {"id": 5, "category": "A", "brand": "X", "price": 5, "vector": [0.6, 0.0]},
+]
+SEARCH_LIMIT = 3
+SEARCH_FILTER = "id <= 3"
+# The selective filter establishes the exact aggregation candidates as IDs 1, 2, and 3.
+# IDs 4 and 5 must not contribute to buckets, metrics, or topHits even though they exist in the collection.
+CANDIDATE_ROWS = ROWS[:SEARCH_LIMIT]
+LEGACY_CANDIDATE_ROWS = [ROWS[0], ROWS[2]]
+LEGACY_SEARCH_FILTER = "id in [1, 3]"
+
+
+class TestSearchAggregation(TestBase):
+    @pytest.fixture(scope="class", autouse=True)
+    def prepare_shared_search_aggregation_collection(self, request, init_class_config):
+        collection_name = gen_collection_name(prefix=request.cls.__name__)
+        request.cls.collection_name = collection_name
+        collection_client, vector_client = self._class_scope_clients()
+
+        def teardown():
+            collection_client.collection_drop({"collectionName": collection_name})
+
+        request.addfinalizer(teardown)
+        payload = {
+            "collectionName": collection_name,
+            "schema": {
+                "autoId": False,
+                "enableDynamicField": False,
+                "fields": [
+                    {"fieldName": "id", "dataType": "Int64", "isPrimary": True},
+                    {"fieldName": "category", "dataType": "VarChar", "elementTypeParams": {"max_length": "16"}},
+                    {"fieldName": "brand", "dataType": "VarChar", "elementTypeParams": {"max_length": "16"}},
+                    {"fieldName": "price", "dataType": "Int64"},
+                    {"fieldName": "vector", "dataType": "FloatVector", "elementTypeParams": {"dim": "2"}},
+                ],
+            },
+            "indexParams": [
+                {
+                    "fieldName": "vector",
+                    "indexName": "vector_index",
+                    "indexType": "FLAT",
+                    "metricType": "IP",
+                }
+            ],
+        }
+        rsp = collection_client.collection_create(payload)
+        assert rsp["code"] == 0, rsp
+        collection_client.wait_load_completed(collection_name, timeout=60)
+
+        rsp = vector_client.vector_insert({"collectionName": collection_name, "data": ROWS})
+        assert rsp["code"] == 0, rsp
+        assert rsp["data"]["insertCount"] == len(ROWS)
+        rsp = collection_client.flush(collection_name)
+        assert rsp["code"] == 0, rsp
+
+    @staticmethod
+    def _bucket_key(bucket, field_name):
+        for key in bucket["key"]:
+            if key["fieldName"] == field_name:
+                return key["value"]
+        raise AssertionError(f"field {field_name} not found in bucket key {bucket['key']}")
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_aggregation_single_field_with_all_metrics(self):
+        """
+        target: verify all supported metric operations with one grouping field
+        method: retain all bucket rows with topHits, then group by category and calculate count/sum/avg/min/max
+        expected: every bucket key, count, and metric matches the inserted rows
+        """
+        rsp = self.vector_client.vector_search(
+            {
+                "collectionName": self.collection_name,
+                "data": [[1.0, 0.0]],
+                "annsField": "vector",
+                "limit": SEARCH_LIMIT,
+                "filter": SEARCH_FILTER,
+                "outputFields": ["category", "price"],
+                "searchAggregation": {
+                    "fields": ["category"],
+                    "size": 3,
+                    "metrics": {
+                        "item_count": {"op": "count", "fieldName": "*"},
+                        "total_price": {"op": "sum", "fieldName": "price"},
+                        "average_price": {"op": "avg", "fieldName": "price"},
+                        "minimum_price": {"op": "min", "fieldName": "price"},
+                        "maximum_price": {"op": "max", "fieldName": "price"},
+                    },
+                    "order": [{"key": "_key", "direction": "asc"}],
+                    "topHits": {"size": SEARCH_LIMIT, "sort": [{"fieldName": "price", "direction": "asc"}]},
+                },
+            }
+        )
+        assert rsp["code"] == 0, rsp
+        assert rsp["aggTopks"] == [2]
+
+        buckets = rsp["data"][0]["buckets"]
+        assert [self._bucket_key(bucket, "category") for bucket in buckets] == ["A", "B"]
+        for bucket in buckets:
+            category = self._bucket_key(bucket, "category")
+            expected_rows = [row for row in CANDIDATE_ROWS if row["category"] == category]
+            expected_prices = [row["price"] for row in expected_rows]
+            metrics = bucket["metrics"]
+            assert int(bucket["count"]) == len(expected_prices)
+            assert int(metrics["item_count"]) == len(expected_prices)
+            assert int(metrics["total_price"]) == sum(expected_prices)
+            assert metrics["average_price"] == pytest.approx(sum(expected_prices) / len(expected_prices))
+            assert int(metrics["minimum_price"]) == min(expected_prices)
+            assert int(metrics["maximum_price"]) == max(expected_prices)
+            expected_hits = sorted(expected_rows, key=lambda row: row["price"])
+            assert [int(hit["id"]) for hit in bucket["hits"]] == [row["id"] for row in expected_hits]
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_aggregation_composite_fields_ordered_by_metric(self):
+        """
+        target: verify composite grouping fields and metric-based bucket ordering
+        method: group by category and brand, then order the buckets by total price descending
+        expected: composite keys and total prices follow the requested order
+        """
+        rsp = self.vector_client.vector_search(
+            {
+                "collectionName": self.collection_name,
+                "data": [[1.0, 0.0]],
+                "annsField": "vector",
+                "limit": SEARCH_LIMIT,
+                "filter": SEARCH_FILTER,
+                "outputFields": ["category", "brand", "price"],
+                "searchAggregation": {
+                    "fields": ["category", "brand"],
+                    "size": SEARCH_LIMIT,
+                    "metrics": {"total_price": {"op": "sum", "fieldName": "price"}},
+                    "order": [{"key": "total_price", "direction": "desc"}],
+                    "topHits": {"size": 2, "sort": [{"fieldName": "price", "direction": "asc"}]},
+                },
+            }
+        )
+        assert rsp["code"] == 0, rsp
+
+        expected_groups = {}
+        for row in CANDIDATE_ROWS:
+            expected_groups.setdefault((row["category"], row["brand"]), []).append(row)
+        assert rsp["aggTopks"] == [len(expected_groups)]
+
+        buckets = rsp["data"][0]["buckets"]
+        actual = [
+            (
+                self._bucket_key(bucket, "category"),
+                self._bucket_key(bucket, "brand"),
+                int(bucket["metrics"]["total_price"]),
+                int(bucket["count"]),
+            )
+            for bucket in buckets
+        ]
+        assert all([key["fieldName"] for key in bucket["key"]] == ["category", "brand"] for bucket in buckets)
+        expected = sorted(
+            [
+                (category, brand, sum(row["price"] for row in grouped_rows), len(grouped_rows))
+                for (category, brand), grouped_rows in expected_groups.items()
+            ],
+            key=lambda item: item[2],
+            reverse=True,
+        )
+        assert actual == expected
+        for bucket in buckets:
+            group_key = (self._bucket_key(bucket, "category"), self._bucket_key(bucket, "brand"))
+            expected_prices = sorted(row["price"] for row in expected_groups[group_key])
+            assert [int(hit["price"]) for hit in bucket["hits"]] == expected_prices
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_aggregation_nested_groups_with_top_hits(self):
+        """
+        target: verify nested grouping and topHits through the REST request and response
+        method: group by category, subgroup by brand, and sort representative hits by price
+        expected: parent and child buckets contain the correct rows and sorted top hits
+        """
+        rsp = self.vector_client.vector_search(
+            {
+                "collectionName": self.collection_name,
+                "data": [[1.0, 0.0]],
+                "annsField": "vector",
+                "limit": SEARCH_LIMIT,
+                "filter": SEARCH_FILTER,
+                "outputFields": ["category", "brand", "price"],
+                "searchAggregation": {
+                    "fields": ["category"],
+                    "size": 3,
+                    "metrics": {"item_count": {"op": "count", "fieldName": "*"}},
+                    "order": [{"key": "_key", "direction": "asc"}],
+                    "topHits": {"size": 2, "sort": [{"fieldName": "price", "direction": "asc"}]},
+                    "subAggregation": {
+                        "fields": ["brand"],
+                        "size": 2,
+                        "metrics": {"total_price": {"op": "sum", "fieldName": "price"}},
+                        "order": [{"key": "_key", "direction": "asc"}],
+                        "topHits": {"size": 1, "sort": [{"fieldName": "price", "direction": "asc"}]},
+                    },
+                },
+            }
+        )
+        assert rsp["code"] == 0, rsp
+        assert rsp["aggTopks"] == [2]
+
+        buckets = rsp["data"][0]["buckets"]
+        assert [self._bucket_key(bucket, "category") for bucket in buckets] == ["A", "B"]
+        for bucket in buckets:
+            category = self._bucket_key(bucket, "category")
+            category_rows = [row for row in CANDIDATE_ROWS if row["category"] == category]
+            assert int(bucket["count"]) == len(category_rows)
+            assert int(bucket["metrics"]["item_count"]) == len(category_rows)
+            expected_parent_hits = sorted(category_rows, key=lambda row: row["price"])[:2]
+            assert [int(hit["id"]) for hit in bucket["hits"]] == [row["id"] for row in expected_parent_hits]
+            assert [int(hit["price"]) for hit in bucket["hits"]] == [row["price"] for row in expected_parent_hits]
+            assert all(hit["category"] == category for hit in bucket["hits"])
+
+            sub_groups = bucket["subGroups"]
+            expected_brands = sorted({row["brand"] for row in category_rows})
+            assert [self._bucket_key(sub_group, "brand") for sub_group in sub_groups] == expected_brands
+            for sub_group in sub_groups:
+                brand = self._bucket_key(sub_group, "brand")
+                expected_rows = [row for row in category_rows if row["brand"] == brand]
+                assert int(sub_group["count"]) == len(expected_rows)
+                assert int(sub_group["metrics"]["total_price"]) == sum(row["price"] for row in expected_rows)
+                expected_child_hit = min(expected_rows, key=lambda row: row["price"])
+                assert [int(hit["id"]) for hit in sub_group["hits"]] == [expected_child_hit["id"]]
+                assert [int(hit["price"]) for hit in sub_group["hits"]] == [expected_child_hit["price"]]
+                assert all(hit["category"] == category and hit["brand"] == brand for hit in sub_group["hits"])
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_aggregation_with_top_level_order_by_rejected(self):
+        """
+        target: verify searchAggregation cannot be combined with top-level orderByFields
+        method: send both new REST parameters in one search request
+        expected: REST rejects the unsupported combination with code 1100
+        """
+        rsp = self.vector_client.vector_search(
+            {
+                "collectionName": self.collection_name,
+                "data": [[1.0, 0.0]],
+                "annsField": "vector",
+                "limit": SEARCH_LIMIT,
+                "orderByFields": ["price:asc"],
+                "searchAggregation": {"fields": ["category"], "size": 3},
+            }
+        )
+        assert rsp["code"] == 1100, rsp
+        assert "orderByFields and searchAggregation cannot be used simultaneously" in rsp["message"], rsp
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_aggregation_with_legacy_order_by_compatible(self):
+        """
+        target: verify searchAggregation remains compatible with legacy searchParams.order_by_fields
+        method: use the legacy order_by_fields location with an exact two-ID candidate filter
+        expected: request succeeds and returns the exact aggregation buckets for the filtered candidates
+        """
+        rsp = self.vector_client.vector_search(
+            {
+                "collectionName": self.collection_name,
+                "data": [[1.0, 0.0]],
+                "annsField": "vector",
+                "limit": len(LEGACY_CANDIDATE_ROWS),
+                "filter": LEGACY_SEARCH_FILTER,
+                "searchParams": {"order_by_fields": "price:asc"},
+                "searchAggregation": {
+                    "fields": ["category"],
+                    "size": 3,
+                    "order": [{"key": "_key", "direction": "asc"}],
+                },
+            }
+        )
+        assert rsp["code"] == 0, rsp
+        assert rsp["aggTopks"] == [2]
+        buckets = rsp["data"][0]["buckets"]
+        assert [bucket["key"][0]["value"] for bucket in buckets] == ["A", "B"]
+        expected_counts = {
+            category: sum(row["category"] == category for row in LEGACY_CANDIDATE_ROWS) for category in {"A", "B"}
+        }
+        assert {bucket["key"][0]["value"]: int(bucket["count"]) for bucket in buckets} == expected_counts

--- a/tests/restful_client_v2/testcases/test_search_aggregation.py
+++ b/tests/restful_client_v2/testcases/test_search_aggregation.py
@@ -97,6 +97,10 @@ class TestSearchAggregation(TestBase):
                         "average_price": {"op": "avg", "fieldName": "price"},
                         "minimum_price": {"op": "min", "fieldName": "price"},
                         "maximum_price": {"op": "max", "fieldName": "price"},
+                        "score_sum": {"op": "sum", "fieldName": "_score"},
+                        "score_avg": {"op": "avg", "fieldName": "_score"},
+                        "score_min": {"op": "min", "fieldName": "_score"},
+                        "score_max": {"op": "max", "fieldName": "_score"},
                     },
                     "order": [{"key": "_key", "direction": "asc"}],
                     "topHits": {"size": retained_size, "sort": [{"fieldName": "price", "direction": "asc"}]},
@@ -124,6 +128,7 @@ class TestSearchAggregation(TestBase):
             category = self._bucket_key(bucket, "category")
             expected_rows = expected_by_category[category]
             expected_prices = [row["price"] for row in expected_rows]
+            expected_scores = [self._ip_score(row, query_vector) for row in expected_rows]
             metrics = bucket["metrics"]
             assert int(bucket["count"]) == len(expected_prices)
             assert int(metrics["item_count"]) == len(expected_prices)
@@ -131,6 +136,10 @@ class TestSearchAggregation(TestBase):
             assert metrics["average_price"] == pytest.approx(sum(expected_prices) / len(expected_prices))
             assert int(metrics["minimum_price"]) == min(expected_prices)
             assert int(metrics["maximum_price"]) == max(expected_prices)
+            assert metrics["score_sum"] == pytest.approx(sum(expected_scores))
+            assert metrics["score_avg"] == pytest.approx(sum(expected_scores) / len(expected_scores))
+            assert metrics["score_min"] == pytest.approx(min(expected_scores))
+            assert metrics["score_max"] == pytest.approx(max(expected_scores))
             expected_hits = sorted(expected_rows, key=lambda row: row["price"])
             assert [int(hit["id"]) for hit in bucket["hits"]] == [row["id"] for row in expected_hits]
             assert [int(hit["price"]) for hit in bucket["hits"]] == [row["price"] for row in expected_hits]
@@ -218,6 +227,7 @@ class TestSearchAggregation(TestBase):
             ("A", "Y", 10, [2], [10], [0.9]),
         ]
         assert all([key["fieldName"] for key in bucket["key"]] == ["category", "brand"] for bucket in buckets)
+        assert len(buckets) == len(expected)
         for bucket, (category, brand, total_price, hit_ids, hit_prices, hit_scores) in zip(buckets, expected):
             assert self._bucket_key(bucket, "category") == category
             assert self._bucket_key(bucket, "brand") == brand

--- a/tests/restful_client_v2/testcases/test_search_aggregation.py
+++ b/tests/restful_client_v2/testcases/test_search_aggregation.py
@@ -9,14 +9,12 @@ ROWS = [
     {"id": 3, "category": "B", "brand": "X", "price": 20, "vector": [0.8, 0.0]},
     {"id": 4, "category": "C", "brand": "Y", "price": 40, "vector": [0.7, 0.0]},
     {"id": 5, "category": "A", "brand": "X", "price": 5, "vector": [0.6, 0.0]},
+    {"id": 6, "category": "A", "brand": "Z", "price": -100, "vector": [-1.0, 0.0]},
+    {"id": 7, "category": "Z", "brand": "Q", "price": 50, "vector": [0.5, 0.0]},
+    {"id": 8, "category": "A", "brand": "X", "price": 15, "vector": [0.4, 0.0]},
+    {"id": 9, "category": "Z", "brand": "R", "price": 60, "vector": [1.5, 0.0]},
+    {"id": 10, "category": "A", "brand": "W", "price": -1000, "vector": [2.0, 0.0]},
 ]
-SEARCH_LIMIT = 3
-SEARCH_FILTER = "id <= 3"
-# The selective filter establishes the exact aggregation candidates as IDs 1, 2, and 3.
-# IDs 4 and 5 must not contribute to buckets, metrics, or topHits even though they exist in the collection.
-CANDIDATE_ROWS = ROWS[:SEARCH_LIMIT]
-LEGACY_CANDIDATE_ROWS = [ROWS[0], ROWS[2]]
-LEGACY_SEARCH_FILTER = "id in [1, 3]"
 
 
 class TestSearchAggregation(TestBase):
@@ -69,20 +67,26 @@ class TestSearchAggregation(TestBase):
                 return key["value"]
         raise AssertionError(f"field {field_name} not found in bucket key {bucket['key']}")
 
+    @staticmethod
+    def _ip_score(row, query_vector):
+        return sum(left * right for left, right in zip(query_vector, row["vector"]))
+
     @pytest.mark.tags(CaseLabel.L1)
     def test_search_aggregation_single_field_with_all_metrics(self):
         """
-        target: verify all supported metric operations with one grouping field
-        method: retain all bucket rows with topHits, then group by category and calculate count/sum/avg/min/max
-        expected: every bucket key, count, and metric matches the inserted rows
+        target: verify filtering precedes aggregation and the ordinary search limit does not cap aggregation results
+        method: exclude the highest-IP row by filter, request limit 1, and retain three ANN rows per category
+        expected: exact buckets, metrics, topHits, fields, and scores come only from filtered candidates
         """
+        query_vector = [1.0, 0.0]
+        retained_size = 3
         rsp = self.vector_client.vector_search(
             {
                 "collectionName": self.collection_name,
-                "data": [[1.0, 0.0]],
+                "data": [query_vector],
                 "annsField": "vector",
-                "limit": SEARCH_LIMIT,
-                "filter": SEARCH_FILTER,
+                "limit": 1,
+                "filter": "id <= 6",
                 "outputFields": ["category", "price"],
                 "searchAggregation": {
                     "fields": ["category"],
@@ -95,18 +99,30 @@ class TestSearchAggregation(TestBase):
                         "maximum_price": {"op": "max", "fieldName": "price"},
                     },
                     "order": [{"key": "_key", "direction": "asc"}],
-                    "topHits": {"size": SEARCH_LIMIT, "sort": [{"fieldName": "price", "direction": "asc"}]},
+                    "topHits": {"size": retained_size, "sort": [{"fieldName": "price", "direction": "asc"}]},
                 },
             }
         )
         assert rsp["code"] == 0, rsp
-        assert rsp["aggTopks"] == [2]
+        assert rsp["aggTopks"] == [3]
 
         buckets = rsp["data"][0]["buckets"]
-        assert [self._bucket_key(bucket, "category") for bucket in buckets] == ["A", "B"]
+        assert [self._bucket_key(bucket, "category") for bucket in buckets] == ["A", "B", "C"]
+        eligible_rows = [row for row in ROWS if row["id"] <= 6]
+        ranked_rows = sorted(
+            eligible_rows,
+            key=lambda row: (-self._ip_score(row, query_vector), row["id"]),
+        )
+        expected_by_category = {}
+        for row in ranked_rows:
+            retained_rows = expected_by_category.setdefault(row["category"], [])
+            if len(retained_rows) < retained_size:
+                retained_rows.append(row)
+
+        assert [row["id"] for row in expected_by_category["A"]] == [1, 2, 5]
         for bucket in buckets:
             category = self._bucket_key(bucket, "category")
-            expected_rows = [row for row in CANDIDATE_ROWS if row["category"] == category]
+            expected_rows = expected_by_category[category]
             expected_prices = [row["price"] for row in expected_rows]
             metrics = bucket["metrics"]
             assert int(bucket["count"]) == len(expected_prices)
@@ -117,25 +133,74 @@ class TestSearchAggregation(TestBase):
             assert int(metrics["maximum_price"]) == max(expected_prices)
             expected_hits = sorted(expected_rows, key=lambda row: row["price"])
             assert [int(hit["id"]) for hit in bucket["hits"]] == [row["id"] for row in expected_hits]
+            assert [int(hit["price"]) for hit in bucket["hits"]] == [row["price"] for row in expected_hits]
+            assert [hit["distance"] for hit in bucket["hits"]] == pytest.approx(
+                [self._ip_score(row, query_vector) for row in expected_hits]
+            )
+            assert all(set(hit) == {"id", "distance", "category", "price"} for hit in bucket["hits"])
+            assert all(hit["category"] == category for hit in bucket["hits"])
+
+        all_hit_ids = {int(hit["id"]) for bucket in buckets for hit in bucket["hits"]}
+        assert all_hit_ids == {1, 2, 3, 4, 5}
+        assert {6, 10}.isdisjoint(all_hit_ids)
 
     @pytest.mark.tags(CaseLabel.L1)
-    def test_search_aggregation_composite_fields_ordered_by_metric(self):
+    def test_search_aggregation_size_search_size_and_key_order(self):
         """
-        target: verify composite grouping fields and metric-based bucket ordering
-        method: group by category and brand, then order the buckets by total price descending
-        expected: composite keys and total prices follow the requested order
+        target: verify REST searchAggregation applies searchSize, final size, and bucket-key ordering independently
+        method: collect four distinct candidate buckets, keep three, and order their keys descending
+        expected: the exact retained buckets are Z, C, and B with their corresponding hits and scores
         """
         rsp = self.vector_client.vector_search(
             {
                 "collectionName": self.collection_name,
                 "data": [[1.0, 0.0]],
                 "annsField": "vector",
-                "limit": SEARCH_LIMIT,
-                "filter": SEARCH_FILTER,
+                "limit": 1,
+                "filter": "id in [1, 3, 4, 7]",
+                "outputFields": ["category", "price"],
+                "searchAggregation": {
+                    "fields": ["category"],
+                    "size": 3,
+                    "searchSize": 4,
+                    "order": [{"key": "_key", "direction": "desc"}],
+                    "topHits": {"size": 1},
+                },
+            }
+        )
+        assert rsp["code"] == 0, rsp
+        assert rsp["aggTopks"] == [3]
+
+        buckets = rsp["data"][0]["buckets"]
+        assert [self._bucket_key(bucket, "category") for bucket in buckets] == ["Z", "C", "B"]
+        expected = [(7, 0.5), (4, 0.7), (3, 0.8)]
+        for bucket, (expected_id, expected_score) in zip(buckets, expected):
+            assert int(bucket["count"]) == 1
+            assert len(bucket["hits"]) == 1
+            hit = bucket["hits"][0]
+            assert int(hit["id"]) == expected_id
+            assert hit["distance"] == pytest.approx(expected_score)
+            assert hit["category"] == self._bucket_key(bucket, "category")
+            assert set(hit) == {"id", "distance", "category", "price"}
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_aggregation_composite_fields_ordered_by_metric(self):
+        """
+        target: verify composite grouping fields and metric-based bucket ordering
+        method: group four exact candidates by category and brand, then order buckets by total price descending
+        expected: the repeated A/X key merges two rows and every bucket exposes exact metrics, hits, fields, and scores
+        """
+        rsp = self.vector_client.vector_search(
+            {
+                "collectionName": self.collection_name,
+                "data": [[1.0, 0.0]],
+                "annsField": "vector",
+                "limit": 4,
+                "filter": "id in [1, 2, 3, 5]",
                 "outputFields": ["category", "brand", "price"],
                 "searchAggregation": {
                     "fields": ["category", "brand"],
-                    "size": SEARCH_LIMIT,
+                    "size": 3,
                     "metrics": {"total_price": {"op": "sum", "fieldName": "price"}},
                     "order": [{"key": "total_price", "direction": "desc"}],
                     "topHits": {"size": 2, "sort": [{"fieldName": "price", "direction": "asc"}]},
@@ -144,94 +209,240 @@ class TestSearchAggregation(TestBase):
         )
         assert rsp["code"] == 0, rsp
 
-        expected_groups = {}
-        for row in CANDIDATE_ROWS:
-            expected_groups.setdefault((row["category"], row["brand"]), []).append(row)
-        assert rsp["aggTopks"] == [len(expected_groups)]
+        assert rsp["aggTopks"] == [3]
 
         buckets = rsp["data"][0]["buckets"]
-        actual = [
-            (
-                self._bucket_key(bucket, "category"),
-                self._bucket_key(bucket, "brand"),
-                int(bucket["metrics"]["total_price"]),
-                int(bucket["count"]),
-            )
-            for bucket in buckets
+        expected = [
+            ("A", "X", 35, [5, 1], [5, 30], [0.6, 1.0]),
+            ("B", "X", 20, [3], [20], [0.8]),
+            ("A", "Y", 10, [2], [10], [0.9]),
         ]
         assert all([key["fieldName"] for key in bucket["key"]] == ["category", "brand"] for bucket in buckets)
-        expected = sorted(
-            [
-                (category, brand, sum(row["price"] for row in grouped_rows), len(grouped_rows))
-                for (category, brand), grouped_rows in expected_groups.items()
-            ],
-            key=lambda item: item[2],
-            reverse=True,
-        )
-        assert actual == expected
-        for bucket in buckets:
-            group_key = (self._bucket_key(bucket, "category"), self._bucket_key(bucket, "brand"))
-            expected_prices = sorted(row["price"] for row in expected_groups[group_key])
-            assert [int(hit["price"]) for hit in bucket["hits"]] == expected_prices
+        for bucket, (category, brand, total_price, hit_ids, hit_prices, hit_scores) in zip(buckets, expected):
+            assert self._bucket_key(bucket, "category") == category
+            assert self._bucket_key(bucket, "brand") == brand
+            assert int(bucket["count"]) == len(hit_ids)
+            assert int(bucket["metrics"]["total_price"]) == total_price
+            assert [int(hit["id"]) for hit in bucket["hits"]] == hit_ids
+            assert [int(hit["price"]) for hit in bucket["hits"]] == hit_prices
+            assert [hit["distance"] for hit in bucket["hits"]] == pytest.approx(hit_scores)
+            assert all(set(hit) == {"id", "distance", "category", "brand", "price"} for hit in bucket["hits"])
+            assert all(hit["category"] == category and hit["brand"] == brand for hit in bucket["hits"])
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_search_aggregation_nested_groups_with_top_hits(self):
         """
-        target: verify nested grouping and topHits through the REST request and response
-        method: group by category, subgroup by brand, and sort representative hits by price
-        expected: parent and child buckets contain the correct rows and sorted top hits
+        target: verify nested bucket final size, ordering, metrics, and topHits are applied per level
+        method: aggregate three categories and three A-brand candidates, then retain only two A-brand subgroups
+        expected: parent buckets are C/B/A; A children are Z/Y and the X subgroup is truncated
         """
         rsp = self.vector_client.vector_search(
             {
                 "collectionName": self.collection_name,
                 "data": [[1.0, 0.0]],
                 "annsField": "vector",
-                "limit": SEARCH_LIMIT,
-                "filter": SEARCH_FILTER,
+                "limit": 6,
+                "filter": "id <= 6",
                 "outputFields": ["category", "brand", "price"],
                 "searchAggregation": {
                     "fields": ["category"],
                     "size": 3,
+                    "searchSize": 3,
                     "metrics": {"item_count": {"op": "count", "fieldName": "*"}},
-                    "order": [{"key": "_key", "direction": "asc"}],
-                    "topHits": {"size": 2, "sort": [{"fieldName": "price", "direction": "asc"}]},
+                    "order": [{"key": "_key", "direction": "desc"}],
+                    "topHits": {"size": 1, "sort": [{"fieldName": "price", "direction": "asc"}]},
                     "subAggregation": {
                         "fields": ["brand"],
                         "size": 2,
+                        "searchSize": 3,
                         "metrics": {"total_price": {"op": "sum", "fieldName": "price"}},
-                        "order": [{"key": "_key", "direction": "asc"}],
-                        "topHits": {"size": 1, "sort": [{"fieldName": "price", "direction": "asc"}]},
+                        "order": [{"key": "_key", "direction": "desc"}],
+                        "topHits": {"size": 2, "sort": [{"fieldName": "price", "direction": "asc"}]},
                     },
                 },
             }
         )
         assert rsp["code"] == 0, rsp
-        assert rsp["aggTopks"] == [2]
+        assert rsp["aggTopks"] == [3]
 
         buckets = rsp["data"][0]["buckets"]
-        assert [self._bucket_key(bucket, "category") for bucket in buckets] == ["A", "B"]
+        assert [self._bucket_key(bucket, "category") for bucket in buckets] == ["C", "B", "A"]
+        expected_parents = {
+            "C": (1, 4, 40, 0.7, [("Y", 1, 40, [4], [40], [0.7])]),
+            "B": (1, 3, 20, 0.8, [("X", 1, 20, [3], [20], [0.8])]),
+            "A": (
+                4,
+                6,
+                -100,
+                -1.0,
+                [
+                    ("Z", 1, -100, [6], [-100], [-1.0]),
+                    ("Y", 1, 10, [2], [10], [0.9]),
+                ],
+            ),
+        }
         for bucket in buckets:
             category = self._bucket_key(bucket, "category")
-            category_rows = [row for row in CANDIDATE_ROWS if row["category"] == category]
-            assert int(bucket["count"]) == len(category_rows)
-            assert int(bucket["metrics"]["item_count"]) == len(category_rows)
-            expected_parent_hits = sorted(category_rows, key=lambda row: row["price"])[:2]
-            assert [int(hit["id"]) for hit in bucket["hits"]] == [row["id"] for row in expected_parent_hits]
-            assert [int(hit["price"]) for hit in bucket["hits"]] == [row["price"] for row in expected_parent_hits]
+            expected_count, parent_id, parent_price, parent_score, expected_children = expected_parents[category]
+            assert int(bucket["count"]) == expected_count
+            assert int(bucket["metrics"]["item_count"]) == expected_count
+            assert [int(hit["id"]) for hit in bucket["hits"]] == [parent_id]
+            assert [int(hit["price"]) for hit in bucket["hits"]] == [parent_price]
+            assert [hit["distance"] for hit in bucket["hits"]] == pytest.approx([parent_score])
             assert all(hit["category"] == category for hit in bucket["hits"])
 
             sub_groups = bucket["subGroups"]
-            expected_brands = sorted({row["brand"] for row in category_rows})
-            assert [self._bucket_key(sub_group, "brand") for sub_group in sub_groups] == expected_brands
-            for sub_group in sub_groups:
-                brand = self._bucket_key(sub_group, "brand")
-                expected_rows = [row for row in category_rows if row["brand"] == brand]
-                assert int(sub_group["count"]) == len(expected_rows)
-                assert int(sub_group["metrics"]["total_price"]) == sum(row["price"] for row in expected_rows)
-                expected_child_hit = min(expected_rows, key=lambda row: row["price"])
-                assert [int(hit["id"]) for hit in sub_group["hits"]] == [expected_child_hit["id"]]
-                assert [int(hit["price"]) for hit in sub_group["hits"]] == [expected_child_hit["price"]]
+            assert [self._bucket_key(sub_group, "brand") for sub_group in sub_groups] == [
+                child[0] for child in expected_children
+            ]
+            for sub_group, (brand, count, total_price, hit_ids, hit_prices, hit_scores) in zip(
+                sub_groups, expected_children
+            ):
+                assert int(sub_group["count"]) == count
+                assert int(sub_group["metrics"]["total_price"]) == total_price
+                assert [int(hit["id"]) for hit in sub_group["hits"]] == hit_ids
+                assert [int(hit["price"]) for hit in sub_group["hits"]] == hit_prices
+                assert [hit["distance"] for hit in sub_group["hits"]] == pytest.approx(hit_scores)
                 assert all(hit["category"] == category and hit["brand"] == brand for hit in sub_group["hits"])
+
+        a_bucket = next(bucket for bucket in buckets if self._bucket_key(bucket, "category") == "A")
+        assert "X" not in {self._bucket_key(sub_group, "brand") for sub_group in a_bucket["subGroups"]}
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_aggregation_nested_child_search_size(self):
+        """
+        target: verify child searchSize expands the nested ANN candidate window before child size and ordering
+        method: retain three A-brand candidates by child searchSize, then return two brand keys in descending order
+        expected: Z and Y are returned; defaulting searchSize to size would instead return Y and X
+        """
+        rsp = self.vector_client.vector_search(
+            {
+                "collectionName": self.collection_name,
+                "data": [[1.0, 0.0]],
+                "annsField": "vector",
+                "limit": 1,
+                "filter": "id in [1, 2, 6]",
+                "outputFields": ["category", "brand", "price"],
+                "searchAggregation": {
+                    "fields": ["category"],
+                    "size": 1,
+                    "searchSize": 1,
+                    "subAggregation": {
+                        "fields": ["brand"],
+                        "size": 2,
+                        "searchSize": 3,
+                        "metrics": {"item_count": {"op": "count", "fieldName": "*"}},
+                        "order": [{"key": "_key", "direction": "desc"}],
+                        "topHits": {"size": 1},
+                    },
+                },
+            }
+        )
+        assert rsp["code"] == 0, rsp
+        assert rsp["aggTopks"] == [1]
+
+        bucket = rsp["data"][0]["buckets"][0]
+        assert self._bucket_key(bucket, "category") == "A"
+        assert int(bucket["count"]) == 3
+        sub_groups = bucket["subGroups"]
+        assert [self._bucket_key(sub_group, "brand") for sub_group in sub_groups] == ["Z", "Y"]
+        expected = [("Z", 6, -1.0), ("Y", 2, 0.9)]
+        for sub_group, (brand, hit_id, score) in zip(sub_groups, expected):
+            assert int(sub_group["count"]) == 1
+            assert int(sub_group["metrics"]["item_count"]) == 1
+            assert len(sub_group["hits"]) == 1
+            hit = sub_group["hits"][0]
+            assert int(hit["id"]) == hit_id
+            assert hit["distance"] == pytest.approx(score)
+            assert hit["brand"] == brand
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_aggregation_child_top_hits_size(self):
+        """
+        target: verify child topHits.size truncates hits without changing the child bucket metrics
+        method: aggregate three rows in the same A/X composite bucket and request only two child top hits
+        expected: the child count and sum cover all rows while its sorted hits contain only IDs 5 and 8
+        """
+        rsp = self.vector_client.vector_search(
+            {
+                "collectionName": self.collection_name,
+                "data": [[1.0, 0.0]],
+                "annsField": "vector",
+                "limit": 3,
+                "filter": "id in [1, 5, 8]",
+                "outputFields": ["category", "brand", "price"],
+                "searchAggregation": {
+                    "fields": ["category"],
+                    "size": 1,
+                    "searchSize": 1,
+                    "topHits": {"size": 3, "sort": [{"fieldName": "price", "direction": "asc"}]},
+                    "subAggregation": {
+                        "fields": ["brand"],
+                        "size": 1,
+                        "searchSize": 1,
+                        "metrics": {"total_price": {"op": "sum", "fieldName": "price"}},
+                        "topHits": {"size": 2, "sort": [{"fieldName": "price", "direction": "asc"}]},
+                    },
+                },
+            }
+        )
+        assert rsp["code"] == 0, rsp
+        assert rsp["aggTopks"] == [1]
+
+        bucket = rsp["data"][0]["buckets"][0]
+        assert self._bucket_key(bucket, "category") == "A"
+        assert int(bucket["count"]) == 3
+        assert [int(hit["id"]) for hit in bucket["hits"]] == [5, 8, 1]
+        assert [int(hit["price"]) for hit in bucket["hits"]] == [5, 15, 30]
+
+        assert len(bucket["subGroups"]) == 1
+        sub_group = bucket["subGroups"][0]
+        assert self._bucket_key(sub_group, "brand") == "X"
+        assert int(sub_group["count"]) == 3
+        assert int(sub_group["metrics"]["total_price"]) == 50
+        assert [int(hit["id"]) for hit in sub_group["hits"]] == [5, 8]
+        assert [int(hit["price"]) for hit in sub_group["hits"]] == [5, 15]
+        assert [hit["distance"] for hit in sub_group["hits"]] == pytest.approx([0.6, 0.4])
+        assert 1 not in {int(hit["id"]) for hit in sub_group["hits"]}
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_aggregation_multiple_query_vectors(self):
+        """
+        target: verify REST searchAggregation returns independent aggregation results for every query vector
+        method: search the same filtered rows with opposite IP query vectors and retain one category and hit per query
+        expected: the first query returns category A/ID 1 and the second returns category C/ID 4
+        """
+        rsp = self.vector_client.vector_search(
+            {
+                "collectionName": self.collection_name,
+                "data": [[1.0, 0.0], [-1.0, 0.0]],
+                "annsField": "vector",
+                "limit": 1,
+                "filter": "id <= 4",
+                "outputFields": ["category", "price"],
+                "searchAggregation": {
+                    "fields": ["category"],
+                    "size": 1,
+                    "searchSize": 1,
+                    "topHits": {"size": 1},
+                },
+            }
+        )
+        assert rsp["code"] == 0, rsp
+        assert rsp["aggTopks"] == [1, 1]
+        assert len(rsp["data"]) == 2
+
+        expected = [("A", 1, 1.0), ("C", 4, -0.7)]
+        for result, (category, hit_id, score) in zip(rsp["data"], expected):
+            assert len(result["buckets"]) == 1
+            bucket = result["buckets"][0]
+            assert self._bucket_key(bucket, "category") == category
+            assert int(bucket["count"]) == 1
+            assert len(bucket["hits"]) == 1
+            hit = bucket["hits"][0]
+            assert int(hit["id"]) == hit_id
+            assert hit["distance"] == pytest.approx(score)
+            assert hit["category"] == category
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_search_aggregation_with_top_level_order_by_rejected(self):
@@ -245,7 +456,7 @@ class TestSearchAggregation(TestBase):
                 "collectionName": self.collection_name,
                 "data": [[1.0, 0.0]],
                 "annsField": "vector",
-                "limit": SEARCH_LIMIT,
+                "limit": 3,
                 "orderByFields": ["price:asc"],
                 "searchAggregation": {"fields": ["category"], "size": 3},
             }
@@ -265,8 +476,8 @@ class TestSearchAggregation(TestBase):
                 "collectionName": self.collection_name,
                 "data": [[1.0, 0.0]],
                 "annsField": "vector",
-                "limit": len(LEGACY_CANDIDATE_ROWS),
-                "filter": LEGACY_SEARCH_FILTER,
+                "limit": 2,
+                "filter": "id in [1, 3]",
                 "searchParams": {"order_by_fields": "price:asc"},
                 "searchAggregation": {
                     "fields": ["category"],
@@ -279,7 +490,8 @@ class TestSearchAggregation(TestBase):
         assert rsp["aggTopks"] == [2]
         buckets = rsp["data"][0]["buckets"]
         assert [bucket["key"][0]["value"] for bucket in buckets] == ["A", "B"]
+        candidate_rows = [row for row in ROWS if row["id"] in {1, 3}]
         expected_counts = {
-            category: sum(row["category"] == category for row in LEGACY_CANDIDATE_ROWS) for category in {"A", "B"}
+            category: sum(row["category"] == category for row in candidate_rows) for category in {"A", "B"}
         }
         assert {bucket["key"][0]["value"]: int(bucket["count"]) for bucket in buckets} == expected_counts

--- a/tests/restful_client_v2/testcases/test_search_order_by.py
+++ b/tests/restful_client_v2/testcases/test_search_order_by.py
@@ -1,0 +1,199 @@
+import pytest
+from base.testbase import TestBase
+from utils.constant import CaseLabel
+from utils.utils import gen_collection_name
+
+ROWS = [
+    {"id": 1, "category": "A", "price": 30, "rating": 1.0, "vector": [1.0, 0.0]},
+    {"id": 2, "category": "A", "price": 10, "rating": 3.0, "vector": [0.9, 0.0]},
+    {"id": 3, "category": "B", "price": 20, "rating": 2.0, "vector": [0.8, 0.0]},
+    {"id": 4, "category": "C", "price": 5, "rating": 4.0, "vector": [0.7, 0.0]},
+]
+EXPECTED_DISTANCE_BY_ID = {1: 1.0, 2: 0.9, 3: 0.8, 4: 0.7}
+
+
+class TestSearchOrderBy(TestBase):
+    @pytest.fixture(scope="class", autouse=True)
+    def prepare_shared_search_order_collection(self, request, init_class_config):
+        collection_name = gen_collection_name(prefix=request.cls.__name__)
+        request.cls.collection_name = collection_name
+        collection_client, vector_client = self._class_scope_clients()
+
+        def teardown():
+            collection_client.collection_drop({"collectionName": collection_name})
+
+        request.addfinalizer(teardown)
+        payload = {
+            "collectionName": collection_name,
+            "schema": {
+                "autoId": False,
+                "enableDynamicField": False,
+                "fields": [
+                    {"fieldName": "id", "dataType": "Int64", "isPrimary": True},
+                    {"fieldName": "category", "dataType": "VarChar", "elementTypeParams": {"max_length": "16"}},
+                    {"fieldName": "price", "dataType": "Int64"},
+                    {"fieldName": "rating", "dataType": "Double"},
+                    {"fieldName": "vector", "dataType": "FloatVector", "elementTypeParams": {"dim": "2"}},
+                ],
+            },
+            "indexParams": [
+                {
+                    "fieldName": "vector",
+                    "indexName": "vector_index",
+                    "indexType": "FLAT",
+                    "metricType": "IP",
+                }
+            ],
+        }
+        rsp = collection_client.collection_create(payload)
+        assert rsp["code"] == 0, rsp
+        collection_client.wait_load_completed(collection_name, timeout=60)
+
+        rsp = vector_client.vector_insert({"collectionName": collection_name, "data": ROWS})
+        assert rsp["code"] == 0, rsp
+        assert rsp["data"]["insertCount"] == len(ROWS)
+        rsp = collection_client.flush(collection_name)
+        assert rsp["code"] == 0, rsp
+
+    def _search(self, **overrides):
+        payload = {
+            "collectionName": self.collection_name,
+            "data": [[1.0, 0.0]],
+            "annsField": "vector",
+            "limit": len(ROWS),
+            "outputFields": ["id", "category", "price", "rating"],
+            "consistencyLevel": "Strong",
+        }
+        payload.update(overrides)
+        rsp = self.vector_client.vector_search(payload)
+        assert rsp["code"] == 0, rsp
+        rows = rsp.get("data", [])
+        self._assert_id_distance_association(rows)
+        return rows
+
+    @staticmethod
+    def _assert_id_distance_association(rows):
+        for row in rows:
+            assert row["id"] in EXPECTED_DISTANCE_BY_ID
+            assert row["distance"] == pytest.approx(EXPECTED_DISTANCE_BY_ID[row["id"]])
+
+    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.parametrize(
+        "order_by,field_name,expected_values,expected_ids",
+        [
+            (["price"], "price", [5, 10, 20, 30], [4, 2, 3, 1]),
+            (["rating:desc"], "rating", [4.0, 3.0, 2.0, 1.0], [4, 2, 3, 1]),
+        ],
+    )
+    def test_search_order_by_single_field(self, order_by, field_name, expected_values, expected_ids):
+        """
+        target: verify REST search supports top-level orderByFields in ascending and descending order
+        method: search all deterministic ANN candidates and sort them by one scalar field
+        expected: result values follow the requested scalar order
+        """
+        rows = self._search(orderByFields=order_by)
+        assert [row[field_name] for row in rows] == expected_values
+        assert [row["id"] for row in rows] == expected_ids
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_search_order_by_with_filter(self):
+        """
+        target: verify REST search combines filter with top-level orderByFields
+        method: restrict results to category A and sort the matching rows by price ascending
+        expected: filtering happens before ordering and returns ids 2 and 1
+        """
+        rows = self._search(filter='category == "A"', orderByFields=["price:asc"])
+        assert [row["id"] for row in rows] == [2, 1]
+        assert [row["price"] for row in rows] == [10, 30]
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_order_by_sort_field_not_in_output(self):
+        """
+        target: verify REST search can sort by a field omitted from outputFields
+        method: sort by price while requesting only id and category
+        expected: ids follow price order and the response does not expose price or vector
+        """
+        rows = self._search(outputFields=["id", "category"], orderByFields=["price:asc"])
+        assert [row["id"] for row in rows] == [4, 2, 3, 1]
+        assert all(set(row) == {"id", "category", "distance"} for row in rows)
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_search_order_by_multi_fields(self):
+        """
+        target: verify REST search supports multiple top-level orderByFields
+        method: sort by category ascending and price descending
+        expected: secondary sorting is applied within the duplicate category
+        """
+        rows = self._search(orderByFields=["category:asc", "price:desc"])
+        assert [row["id"] for row in rows] == [1, 2, 3, 4]
+        assert [(row["category"], row["price"]) for row in rows] == [
+            ("A", 30),
+            ("A", 10),
+            ("B", 20),
+            ("C", 5),
+        ]
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_order_by_with_offset(self):
+        """
+        target: verify REST search applies offset after top-level orderByFields
+        method: take the top three ANN candidates, sort by price ascending, skip one, and return two
+        expected: pagination returns ids 3 and 1 after scalar ordering
+        """
+        rows = self._search(limit=2, offset=1, orderByFields=["price:asc"])
+        assert [row["id"] for row in rows] == [3, 1]
+        assert [row["price"] for row in rows] == [20, 30]
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.parametrize(
+        "search_params",
+        [
+            {"order_by_fields": "price:desc"},
+            {"params": {"order_by_fields": "price:desc"}},
+        ],
+    )
+    def test_search_order_by_with_legacy_parameter_rejected(self, search_params):
+        """
+        target: verify top-level orderByFields rejects ambiguous legacy order_by_fields
+        method: provide the same semantic parameter at the top level and in either legacy location
+        expected: REST rejects both ambiguous payload forms with code 1100
+        """
+        rsp = self.vector_client.vector_search(
+            {
+                "collectionName": self.collection_name,
+                "data": [[1.0, 0.0]],
+                "annsField": "vector",
+                "limit": len(ROWS),
+                "orderByFields": ["price:asc"],
+                "searchParams": search_params,
+            }
+        )
+        assert rsp["code"] == 1100, rsp
+        assert "ambiguous order by" in rsp["message"], rsp
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.parametrize(
+        "order_by,message",
+        [
+            (["unknown_field:asc"], "does not exist"),
+            (["vector:asc"], "unsortable type"),
+            (["price:invalid"], "invalid order direction"),
+        ],
+    )
+    def test_search_order_by_invalid_params(self, order_by, message):
+        """
+        target: verify REST search surfaces server validation for invalid orderByFields
+        method: send an unknown field, vector field, and invalid direction
+        expected: each request fails with parameter error code 1100
+        """
+        rsp = self.vector_client.vector_search(
+            {
+                "collectionName": self.collection_name,
+                "data": [[1.0, 0.0]],
+                "annsField": "vector",
+                "limit": len(ROWS),
+                "orderByFields": order_by,
+            }
+        )
+        assert rsp["code"] == 1100, rsp
+        assert message in rsp["message"], rsp

--- a/tests/restful_client_v2/testcases/test_search_order_by.py
+++ b/tests/restful_client_v2/testcases/test_search_order_by.py
@@ -4,12 +4,13 @@ from utils.constant import CaseLabel
 from utils.utils import gen_collection_name
 
 ROWS = [
-    {"id": 1, "category": "A", "price": 30, "rating": 1.0, "vector": [1.0, 0.0]},
-    {"id": 2, "category": "A", "price": 10, "rating": 3.0, "vector": [0.9, 0.0]},
-    {"id": 3, "category": "B", "price": 20, "rating": 2.0, "vector": [0.8, 0.0]},
-    {"id": 4, "category": "C", "price": 5, "rating": 4.0, "vector": [0.7, 0.0]},
+    {"id": 1, "category": "A", "price": 30, "rating": 5.0, "vector": [0.8, 0.0]},
+    {"id": 2, "category": "A", "price": 10, "rating": 2.0, "vector": [0.7, 0.0]},
+    {"id": 3, "category": "B", "price": 20, "rating": 1.0, "vector": [1.0, 0.0]},
+    {"id": 4, "category": "C", "price": 5, "rating": 4.0, "vector": [0.9, 0.0]},
+    {"id": 5, "category": "A", "price": 25, "rating": 3.0, "vector": [0.6, 0.0]},
 ]
-EXPECTED_DISTANCE_BY_ID = {1: 1.0, 2: 0.9, 3: 0.8, 4: 0.7}
+EXPECTED_DISTANCE_BY_ID = {1: 0.8, 2: 0.7, 3: 1.0, 4: 0.9, 5: 0.6}
 
 
 class TestSearchOrderBy(TestBase):
@@ -81,15 +82,15 @@ class TestSearchOrderBy(TestBase):
     @pytest.mark.parametrize(
         "order_by,field_name,expected_values,expected_ids",
         [
-            (["price"], "price", [5, 10, 20, 30], [4, 2, 3, 1]),
-            (["rating:desc"], "rating", [4.0, 3.0, 2.0, 1.0], [4, 2, 3, 1]),
+            (["price"], "price", [5, 10, 20, 25, 30], [4, 2, 3, 5, 1]),
+            (["rating:desc"], "rating", [5.0, 4.0, 3.0, 2.0, 1.0], [1, 4, 5, 2, 3]),
         ],
     )
     def test_search_order_by_single_field(self, order_by, field_name, expected_values, expected_ids):
         """
         target: verify REST search supports top-level orderByFields in ascending and descending order
-        method: search all deterministic ANN candidates and sort them by one scalar field
-        expected: result values follow the requested scalar order
+        method: search deterministic candidates whose ANN, price, and rating orders are deliberately distinct
+        expected: each scalar field produces its own exact requested value and ID order
         """
         rows = self._search(orderByFields=order_by)
         assert [row[field_name] for row in rows] == expected_values
@@ -99,12 +100,14 @@ class TestSearchOrderBy(TestBase):
     def test_search_order_by_with_filter(self):
         """
         target: verify REST search combines filter with top-level orderByFields
-        method: restrict results to category A and sort the matching rows by price ascending
-        expected: filtering happens before ordering and returns ids 2 and 1
+        method: request three category-A rows even though the global top-three ANN candidates include B and C
+        expected: filtering happens before candidate selection, then price ordering returns ids 2, 5, and 1
         """
-        rows = self._search(filter='category == "A"', orderByFields=["price:asc"])
-        assert [row["id"] for row in rows] == [2, 1]
-        assert [row["price"] for row in rows] == [10, 30]
+        rows = self._search(limit=3, filter='category == "A"', orderByFields=["price:asc"])
+        assert len(rows) == 3
+        assert all(row["category"] == "A" for row in rows)
+        assert [row["id"] for row in rows] == [2, 5, 1]
+        assert [row["price"] for row in rows] == [10, 25, 30]
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_search_order_by_sort_field_not_in_output(self):
@@ -114,21 +117,23 @@ class TestSearchOrderBy(TestBase):
         expected: ids follow price order and the response does not expose price or vector
         """
         rows = self._search(outputFields=["id", "category"], orderByFields=["price:asc"])
-        assert [row["id"] for row in rows] == [4, 2, 3, 1]
+        expected_rows = sorted(ROWS, key=lambda row: row["price"])
+        assert [(row["id"], row["category"]) for row in rows] == [(row["id"], row["category"]) for row in expected_rows]
         assert all(set(row) == {"id", "category", "distance"} for row in rows)
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_search_order_by_multi_fields(self):
         """
         target: verify REST search supports multiple top-level orderByFields
-        method: sort by category ascending and price descending
-        expected: secondary sorting is applied within the duplicate category
+        method: sort by category and price so the secondary key differs from ANN, rating, and PK order within category A
+        expected: both sort keys are applied and return ids 2, 5, 1, 3, and 4
         """
-        rows = self._search(orderByFields=["category:asc", "price:desc"])
-        assert [row["id"] for row in rows] == [1, 2, 3, 4]
+        rows = self._search(orderByFields=["category:asc", "price:asc"])
+        assert [row["id"] for row in rows] == [2, 5, 1, 3, 4]
         assert [(row["category"], row["price"]) for row in rows] == [
-            ("A", 30),
             ("A", 10),
+            ("A", 25),
+            ("A", 30),
             ("B", 20),
             ("C", 5),
         ]

--- a/tests/restful_client_v2/testcases/test_search_order_by.py
+++ b/tests/restful_client_v2/testcases/test_search_order_by.py
@@ -72,6 +72,47 @@ class TestSearchOrderBy(TestBase):
         self._assert_id_distance_association(rows)
         return rows
 
+    def _create_tied_order_collection(self):
+        collection_name = gen_collection_name(prefix=f"{self.__class__.__name__}Tied")
+        collection_client, vector_client = self._class_scope_clients()
+        rows = [
+            {"id": 20, "price": 10, "vector": [1.0, 0.0]},
+            {"id": 30, "price": 10, "vector": [0.9, 0.0]},
+            {"id": 10, "price": 10, "vector": [0.8, 0.0]},
+            {"id": 40, "price": 20, "vector": [0.7, 0.0]},
+            {"id": 50, "price": 30, "vector": [0.6, 0.0]},
+        ]
+        rsp = collection_client.collection_create(
+            {
+                "collectionName": collection_name,
+                "schema": {
+                    "autoId": False,
+                    "enableDynamicField": False,
+                    "fields": [
+                        {"fieldName": "id", "dataType": "Int64", "isPrimary": True},
+                        {"fieldName": "price", "dataType": "Int64"},
+                        {"fieldName": "vector", "dataType": "FloatVector", "elementTypeParams": {"dim": "2"}},
+                    ],
+                },
+                "indexParams": [
+                    {
+                        "fieldName": "vector",
+                        "indexName": "vector_index",
+                        "indexType": "FLAT",
+                        "metricType": "IP",
+                    }
+                ],
+            }
+        )
+        assert rsp["code"] == 0, rsp
+        rsp = vector_client.vector_insert({"collectionName": collection_name, "data": rows})
+        assert rsp["code"] == 0, rsp
+        assert rsp["data"]["insertCount"] == len(rows)
+        rsp = collection_client.flush(collection_name)
+        assert rsp["code"] == 0, rsp
+        collection_client.wait_load_completed(collection_name, timeout=60)
+        return collection_name
+
     @staticmethod
     def _assert_id_distance_association(rows):
         for row in rows:
@@ -148,6 +189,45 @@ class TestSearchOrderBy(TestBase):
         rows = self._search(limit=2, offset=1, orderByFields=["price:asc"])
         assert [row["id"] for row in rows] == [3, 1]
         assert [row["price"] for row in rows] == [20, 30]
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_order_by_tied_keys_and_pagination(self):
+        """
+        target: verify explicit tie-break ordering and pagination across an equal-key block
+        method: use equal prices whose ANN and primary-key orders differ, then sort by price and id
+        expected: the full ordered result is stable and offset/limit returns the exact tied-block page
+        """
+        collection_name = self._create_tied_order_collection()
+        try:
+            payload = {
+                "collectionName": collection_name,
+                "data": [[1.0, 0.0]],
+                "annsField": "vector",
+                "outputFields": ["id", "price"],
+                "consistencyLevel": "Strong",
+                "limit": 4,
+                "orderByFields": ["price:asc", "id:asc"],
+            }
+            baseline_rsp = self.vector_client.vector_search(payload)
+            assert baseline_rsp["code"] == 0, baseline_rsp
+            baseline = baseline_rsp["data"]
+            assert [row["id"] for row in baseline] == [10, 20, 30, 40]
+            assert [row["price"] for row in baseline] == [10, 10, 10, 20]
+            assert [row["distance"] for row in baseline] == pytest.approx([0.8, 1.0, 0.9, 0.7])
+            assert len({row["id"] for row in baseline}) == len(baseline)
+            assert {row["id"] for row in baseline} == {10, 20, 30, 40}
+
+            page_payload = {**payload, "limit": 2, "offset": 2}
+            for _ in range(3):
+                page_rsp = self.vector_client.vector_search(page_payload)
+                assert page_rsp["code"] == 0, page_rsp
+                page = page_rsp["data"]
+                assert [row["id"] for row in page] == [30, 40]
+                assert [row["price"] for row in page] == [10, 20]
+                assert [row["distance"] for row in page] == pytest.approx([0.9, 0.7])
+                assert [row["id"] for row in page] == [row["id"] for row in baseline[2:4]]
+        finally:
+            self.collection_client.collection_drop({"collectionName": collection_name})
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Add REST v2 query and search coverage for `orderByFields`, query aggregation, and `searchAggregation`.
- Add REST v2 schema-evolution coverage for drop field and atomic add/drop function-field operations.
- Extend the REST test client with `add_function_field` and `drop_function_field` helpers.
- Keep schema-evolution cases focused on REST request parameters and resulting metadata, without duplicating segment lifecycle or multi-replica coverage.

## Coverage

- Query/search ordering with filters, pagination, nullable fields, deterministic member assertions, and deliberately distinct ANN/scalar/PK ordering.
- Query/search aggregation with exact metrics and hit-score oracles, nullable group keys, composite/nested groups, `searchSize`, `topHits`, and multi-query ownership.
- Drop field invalid identifier combinations, protected or unknown fields, repeated drops, and complete before/after schema-index snapshots.
- Add function field required objects, field-name binding, default AutoIndex behavior, output-field/function/index metadata, and rejected-request atomicity.
- Drop function field selective cascade across two bindings, invalid or repeated drops, and field dependency validation.

Related changes: #52071, #51360, #51411

## Test Plan

- `python3 -m pytest testcases/test_query_order_by.py testcases/test_search_order_by.py testcases/test_query_aggregation.py testcases/test_search_aggregation.py testcases/test_drop_field_operations.py testcases/test_function_field_operations.py --endpoint http://127.0.0.1:19530 --token root:Milvus --minio_host 127.0.0.1 -q -s`
  - 66 passed
- `python3 -m pytest milvus_client/test_milvus_client_search_aggregation.py --host 127.0.0.1 --port 19530 --user root --password Milvus --token root:Milvus -q -s`
  - 51 passed, 1 existing xfailed
- `ruff check` on all seven changed test files
- `ruff format --check` on all seven changed test files
- `git diff --check`
