### PR TITLE
enhance: [cp3.0] add native snapshot RESTful v2 APIs

### DIFF
--- a/internal/distributed/proxy/httpserver/constant.go
+++ b/internal/distributed/proxy/httpserver/constant.go
@@ -90,6 +90,8 @@ const (
 	GetProgressAction               = "get_progress" // deprecated, keep it for compatibility, use `/v2/vectordb/jobs/import/describe` instead
 	RestoreExternalAction           = "restore_external"
 	RestoreAction                   = "restore"
+	PinAction                       = "pin"
+	UnpinAction                     = "unpin"
 	ExportAction                    = "export"
 	DescribeExportAction            = "export/describe"
 	RefreshAction                   = "refresh"

--- a/internal/distributed/proxy/httpserver/constant.go
+++ b/internal/distributed/proxy/httpserver/constant.go
@@ -35,6 +35,7 @@ const (
 	AliasCategory                 = "/aliases/"
 	ImportJobCategory             = "/jobs/import/"
 	SnapshotJobCategory           = "/jobs/snapshot/"
+	SnapshotCategory              = "/snapshots/"
 	ExternalCollectionJobCategory = "/jobs/external_collection/"
 	PrivilegeGroupCategory        = "/privilege_groups/"
 	CollectionFieldCategory       = "/collections/fields/"

--- a/internal/distributed/proxy/httpserver/constant.go
+++ b/internal/distributed/proxy/httpserver/constant.go
@@ -89,6 +89,7 @@ const (
 	TruncateAction                  = "truncate"
 	GetProgressAction               = "get_progress" // deprecated, keep it for compatibility, use `/v2/vectordb/jobs/import/describe` instead
 	RestoreExternalAction           = "restore_external"
+	RestoreAction                   = "restore"
 	ExportAction                    = "export"
 	RefreshAction                   = "refresh"
 	AddPrivilegesToGroupAction      = "add_privileges_to_group"

--- a/internal/distributed/proxy/httpserver/constant.go
+++ b/internal/distributed/proxy/httpserver/constant.go
@@ -90,6 +90,8 @@ const (
 	GetProgressAction               = "get_progress" // deprecated, keep it for compatibility, use `/v2/vectordb/jobs/import/describe` instead
 	RestoreExternalAction           = "restore_external"
 	RestoreAction                   = "restore"
+	PinAction                       = "pin"
+	UnpinAction                     = "unpin"
 	ExportAction                    = "export"
 	RefreshAction                   = "refresh"
 	AddPrivilegesToGroupAction      = "add_privileges_to_group"

--- a/internal/distributed/proxy/httpserver/constant.go
+++ b/internal/distributed/proxy/httpserver/constant.go
@@ -89,6 +89,7 @@ const (
 	TruncateAction                  = "truncate"
 	GetProgressAction               = "get_progress" // deprecated, keep it for compatibility, use `/v2/vectordb/jobs/import/describe` instead
 	RestoreExternalAction           = "restore_external"
+	RestoreAction                   = "restore"
 	ExportAction                    = "export"
 	DescribeExportAction            = "export/describe"
 	RefreshAction                   = "refresh"

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -182,6 +182,8 @@ var routeToMethod = map[string]string{ //nolint:gosec // not credentials, just a
 	"/v2/vectordb/snapshots/list":                    "ListSnapshots",
 	"/v2/vectordb/snapshots/describe":                "DescribeSnapshot",
 	"/v2/vectordb/snapshots/restore":                 "RestoreSnapshot",
+	"/v2/vectordb/snapshots/pin":                     "PinSnapshotData",
+	"/v2/vectordb/snapshots/unpin":                   "UnpinSnapshotData",
 	"/v2/vectordb/jobs/external_collection/refresh":  "RefreshExternalCollection",
 	"/v2/vectordb/jobs/external_collection/describe": "GetRefreshExternalCollectionProgress",
 	"/v2/vectordb/jobs/external_collection/list":     "ListRefreshExternalCollectionJobs",
@@ -354,6 +356,8 @@ func (h *HandlersV2) RegisterRoutesToV2(router gin.IRouter) {
 	router.POST(SnapshotCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &OptionalCollectionNameReq{} }, wrapperTraceLog(h.listSnapshots))))
 	router.POST(SnapshotCategory+DescribeAction, timeoutMiddleware(wrapperPost(func() any { return &SnapshotReq{} }, wrapperTraceLog(h.describeSnapshot))))
 	router.POST(SnapshotCategory+RestoreAction, timeoutMiddleware(wrapperPost(func() any { return &RestoreSnapshotReq{} }, wrapperTraceLog(h.restoreSnapshot))))
+	router.POST(SnapshotCategory+PinAction, timeoutMiddleware(wrapperPost(func() any { return &PinSnapshotDataReq{} }, wrapperTraceLog(h.pinSnapshotData))))
+	router.POST(SnapshotCategory+UnpinAction, timeoutMiddleware(wrapperPost(func() any { return &UnpinSnapshotDataReq{} }, wrapperTraceLog(h.unpinSnapshotData))))
 	router.POST(ExternalCollectionJobCategory+RefreshAction, timeoutMiddleware(wrapperPost(func() any { return &RefreshExternalCollectionReq{} }, wrapperTraceLog(h.refreshExternalCollection))))
 	router.POST(ExternalCollectionJobCategory+DescribeAction, timeoutMiddleware(wrapperPost(func() any { return &RefreshExternalCollectionProgressReq{} }, wrapperTraceLog(h.getRefreshExternalCollectionProgress))))
 	router.POST(ExternalCollectionJobCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &OptionalCollectionNameReq{} }, wrapperTraceLog(h.listRefreshExternalCollectionJobs))))

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -177,6 +177,10 @@ var routeToMethod = map[string]string{ //nolint:gosec // not credentials, just a
 	"/v2/vectordb/jobs/snapshot/export/describe":     "GetExportSnapshotState",
 	"/v2/vectordb/jobs/snapshot/describe":            "GetRestoreSnapshotState",
 	"/v2/vectordb/jobs/snapshot/list":                "ListRestoreSnapshotJobs",
+	"/v2/vectordb/snapshots/create":                  "CreateSnapshot",
+	"/v2/vectordb/snapshots/drop":                    "DropSnapshot",
+	"/v2/vectordb/snapshots/list":                    "ListSnapshots",
+	"/v2/vectordb/snapshots/describe":                "DescribeSnapshot",
 	"/v2/vectordb/jobs/external_collection/refresh":  "RefreshExternalCollection",
 	"/v2/vectordb/jobs/external_collection/describe": "GetRefreshExternalCollectionProgress",
 	"/v2/vectordb/jobs/external_collection/list":     "ListRefreshExternalCollectionJobs",
@@ -344,6 +348,10 @@ func (h *HandlersV2) RegisterRoutesToV2(router gin.IRouter) {
 	router.POST(SnapshotJobCategory+DescribeExportAction, timeoutMiddleware(wrapperPost(func() any { return &JobIDReq{} }, wrapperTraceLog(h.getExportSnapshotState))))
 	router.POST(SnapshotJobCategory+DescribeAction, timeoutMiddleware(wrapperPost(func() any { return &JobIDReq{} }, wrapperTraceLog(h.getRestoreSnapshotState))))
 	router.POST(SnapshotJobCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &OptionalCollectionNameReq{} }, wrapperTraceLog(h.listRestoreSnapshotJobs))))
+	router.POST(SnapshotCategory+CreateAction, timeoutMiddleware(wrapperPost(func() any { return &CreateSnapshotReq{} }, wrapperTraceLog(h.createSnapshot))))
+	router.POST(SnapshotCategory+DropAction, timeoutMiddleware(wrapperPost(func() any { return &SnapshotReq{} }, wrapperTraceLog(h.dropSnapshot))))
+	router.POST(SnapshotCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &OptionalCollectionNameReq{} }, wrapperTraceLog(h.listSnapshots))))
+	router.POST(SnapshotCategory+DescribeAction, timeoutMiddleware(wrapperPost(func() any { return &SnapshotReq{} }, wrapperTraceLog(h.describeSnapshot))))
 	router.POST(ExternalCollectionJobCategory+RefreshAction, timeoutMiddleware(wrapperPost(func() any { return &RefreshExternalCollectionReq{} }, wrapperTraceLog(h.refreshExternalCollection))))
 	router.POST(ExternalCollectionJobCategory+DescribeAction, timeoutMiddleware(wrapperPost(func() any { return &RefreshExternalCollectionProgressReq{} }, wrapperTraceLog(h.getRefreshExternalCollectionProgress))))
 	router.POST(ExternalCollectionJobCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &OptionalCollectionNameReq{} }, wrapperTraceLog(h.listRefreshExternalCollectionJobs))))

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -178,6 +178,7 @@ var routeToMethod = map[string]string{ //nolint:gosec // not credentials, just a
 	"/v2/vectordb/snapshots/drop":                    "DropSnapshot",
 	"/v2/vectordb/snapshots/list":                    "ListSnapshots",
 	"/v2/vectordb/snapshots/describe":                "DescribeSnapshot",
+	"/v2/vectordb/snapshots/restore":                 "RestoreSnapshot",
 	"/v2/vectordb/jobs/external_collection/refresh":  "RefreshExternalCollection",
 	"/v2/vectordb/jobs/external_collection/describe": "GetRefreshExternalCollectionProgress",
 	"/v2/vectordb/jobs/external_collection/list":     "ListRefreshExternalCollectionJobs",
@@ -348,6 +349,7 @@ func (h *HandlersV2) RegisterRoutesToV2(router gin.IRouter) {
 	router.POST(SnapshotCategory+DropAction, timeoutMiddleware(wrapperPost(func() any { return &SnapshotReq{} }, wrapperTraceLog(h.dropSnapshot))))
 	router.POST(SnapshotCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &OptionalCollectionNameReq{} }, wrapperTraceLog(h.listSnapshots))))
 	router.POST(SnapshotCategory+DescribeAction, timeoutMiddleware(wrapperPost(func() any { return &SnapshotReq{} }, wrapperTraceLog(h.describeSnapshot))))
+	router.POST(SnapshotCategory+RestoreAction, timeoutMiddleware(wrapperPost(func() any { return &RestoreSnapshotReq{} }, wrapperTraceLog(h.restoreSnapshot))))
 	router.POST(ExternalCollectionJobCategory+RefreshAction, timeoutMiddleware(wrapperPost(func() any { return &RefreshExternalCollectionReq{} }, wrapperTraceLog(h.refreshExternalCollection))))
 	router.POST(ExternalCollectionJobCategory+DescribeAction, timeoutMiddleware(wrapperPost(func() any { return &RefreshExternalCollectionProgressReq{} }, wrapperTraceLog(h.getRefreshExternalCollectionProgress))))
 	router.POST(ExternalCollectionJobCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &OptionalCollectionNameReq{} }, wrapperTraceLog(h.listRefreshExternalCollectionJobs))))

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -3894,9 +3894,10 @@ func (h *HandlersV2) restoreExternalSnapshot(ctx context.Context, c *gin.Context
 		return h.proxy.RestoreExternalSnapshot(reqCtx, req.(*milvuspb.RestoreExternalSnapshotRequest))
 	})
 	if err == nil {
+		allowInt64, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
 		HTTPReturn(c, http.StatusOK, gin.H{
 			HTTPReturnCode: merr.Code(nil),
-			HTTPReturnData: gin.H{"jobId": resp.(*milvuspb.RestoreExternalSnapshotResponse).GetJobId()},
+			HTTPReturnData: gin.H{"jobId": formatRESTInt64(resp.(*milvuspb.RestoreExternalSnapshotResponse).GetJobId(), allowInt64)},
 		})
 	}
 	return resp, err
@@ -3971,12 +3972,12 @@ func (h *HandlersV2) getExportSnapshotState(ctx context.Context, c *gin.Context,
 	return resp, err
 }
 
-func restoreSnapshotJobToREST(info *milvuspb.RestoreSnapshotInfo) gin.H {
+func restoreSnapshotJobToREST(info *milvuspb.RestoreSnapshotInfo, allowInt64 bool) gin.H {
 	if info == nil {
 		return gin.H{}
 	}
 	return gin.H{
-		"jobId":          info.GetJobId(),
+		"jobId":          formatRESTInt64(info.GetJobId(), allowInt64),
 		"snapshotName":   info.GetSnapshotName(),
 		"dbName":         info.GetDbName(),
 		"collectionName": info.GetCollectionName(),
@@ -4005,9 +4006,10 @@ func (h *HandlersV2) getRestoreSnapshotState(ctx context.Context, c *gin.Context
 		return h.proxy.GetRestoreSnapshotState(reqCtx, req.(*milvuspb.GetRestoreSnapshotStateRequest))
 	})
 	if err == nil {
+		allowInt64, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
 		HTTPReturn(c, http.StatusOK, gin.H{
 			HTTPReturnCode: merr.Code(nil),
-			HTTPReturnData: restoreSnapshotJobToREST(resp.(*milvuspb.GetRestoreSnapshotStateResponse).GetInfo()),
+			HTTPReturnData: restoreSnapshotJobToREST(resp.(*milvuspb.GetRestoreSnapshotStateResponse).GetInfo(), allowInt64),
 		})
 	}
 	return resp, err
@@ -4026,9 +4028,10 @@ func (h *HandlersV2) listRestoreSnapshotJobs(ctx context.Context, c *gin.Context
 	})
 	if err == nil {
 		jobs := resp.(*milvuspb.ListRestoreSnapshotJobsResponse).GetJobs()
+		allowInt64, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
 		records := make([]gin.H, 0, len(jobs))
 		for _, info := range jobs {
-			records = append(records, restoreSnapshotJobToREST(info))
+			records = append(records, restoreSnapshotJobToREST(info, allowInt64))
 		}
 		HTTPReturn(c, http.StatusOK, gin.H{
 			HTTPReturnCode: merr.Code(nil),

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -353,7 +353,7 @@ func (h *HandlersV2) RegisterRoutesToV2(router gin.IRouter) {
 	router.POST(SnapshotJobCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &OptionalCollectionNameReq{} }, wrapperTraceLog(h.listRestoreSnapshotJobs))))
 	router.POST(SnapshotCategory+CreateAction, timeoutMiddleware(wrapperPost(func() any { return &CreateSnapshotReq{} }, wrapperTraceLog(h.createSnapshot))))
 	router.POST(SnapshotCategory+DropAction, timeoutMiddleware(wrapperPost(func() any { return &SnapshotReq{} }, wrapperTraceLog(h.dropSnapshot))))
-	router.POST(SnapshotCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &OptionalCollectionNameReq{} }, wrapperTraceLog(h.listSnapshots))))
+	router.POST(SnapshotCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &CollectionNameReq{} }, wrapperTraceLog(h.listSnapshots))))
 	router.POST(SnapshotCategory+DescribeAction, timeoutMiddleware(wrapperPost(func() any { return &SnapshotReq{} }, wrapperTraceLog(h.describeSnapshot))))
 	router.POST(SnapshotCategory+RestoreAction, timeoutMiddleware(wrapperPost(func() any { return &RestoreSnapshotReq{} }, wrapperTraceLog(h.restoreSnapshot))))
 	router.POST(SnapshotCategory+PinAction, timeoutMiddleware(wrapperPost(func() any { return &PinSnapshotDataReq{} }, wrapperTraceLog(h.pinSnapshotData))))

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -174,6 +174,10 @@ var routeToMethod = map[string]string{ //nolint:gosec // not credentials, just a
 	"/v2/vectordb/jobs/snapshot/export":              "ExportSnapshot",
 	"/v2/vectordb/jobs/snapshot/describe":            "GetRestoreSnapshotState",
 	"/v2/vectordb/jobs/snapshot/list":                "ListRestoreSnapshotJobs",
+	"/v2/vectordb/snapshots/create":                  "CreateSnapshot",
+	"/v2/vectordb/snapshots/drop":                    "DropSnapshot",
+	"/v2/vectordb/snapshots/list":                    "ListSnapshots",
+	"/v2/vectordb/snapshots/describe":                "DescribeSnapshot",
 	"/v2/vectordb/jobs/external_collection/refresh":  "RefreshExternalCollection",
 	"/v2/vectordb/jobs/external_collection/describe": "GetRefreshExternalCollectionProgress",
 	"/v2/vectordb/jobs/external_collection/list":     "ListRefreshExternalCollectionJobs",
@@ -340,6 +344,10 @@ func (h *HandlersV2) RegisterRoutesToV2(router gin.IRouter) {
 	router.POST(SnapshotJobCategory+ExportAction, timeoutMiddleware(wrapperPost(func() any { return &ExportSnapshotReq{} }, wrapperTraceLog(h.exportSnapshot))))
 	router.POST(SnapshotJobCategory+DescribeAction, timeoutMiddleware(wrapperPost(func() any { return &JobIDReq{} }, wrapperTraceLog(h.getRestoreSnapshotState))))
 	router.POST(SnapshotJobCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &OptionalCollectionNameReq{} }, wrapperTraceLog(h.listRestoreSnapshotJobs))))
+	router.POST(SnapshotCategory+CreateAction, timeoutMiddleware(wrapperPost(func() any { return &CreateSnapshotReq{} }, wrapperTraceLog(h.createSnapshot))))
+	router.POST(SnapshotCategory+DropAction, timeoutMiddleware(wrapperPost(func() any { return &SnapshotReq{} }, wrapperTraceLog(h.dropSnapshot))))
+	router.POST(SnapshotCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &OptionalCollectionNameReq{} }, wrapperTraceLog(h.listSnapshots))))
+	router.POST(SnapshotCategory+DescribeAction, timeoutMiddleware(wrapperPost(func() any { return &SnapshotReq{} }, wrapperTraceLog(h.describeSnapshot))))
 	router.POST(ExternalCollectionJobCategory+RefreshAction, timeoutMiddleware(wrapperPost(func() any { return &RefreshExternalCollectionReq{} }, wrapperTraceLog(h.refreshExternalCollection))))
 	router.POST(ExternalCollectionJobCategory+DescribeAction, timeoutMiddleware(wrapperPost(func() any { return &RefreshExternalCollectionProgressReq{} }, wrapperTraceLog(h.getRefreshExternalCollectionProgress))))
 	router.POST(ExternalCollectionJobCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &OptionalCollectionNameReq{} }, wrapperTraceLog(h.listRefreshExternalCollectionJobs))))

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -3894,10 +3894,9 @@ func (h *HandlersV2) restoreExternalSnapshot(ctx context.Context, c *gin.Context
 		return h.proxy.RestoreExternalSnapshot(reqCtx, req.(*milvuspb.RestoreExternalSnapshotRequest))
 	})
 	if err == nil {
-		allowInt64, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
 		HTTPReturn(c, http.StatusOK, gin.H{
 			HTTPReturnCode: merr.Code(nil),
-			HTTPReturnData: gin.H{"jobId": formatRESTInt64(resp.(*milvuspb.RestoreExternalSnapshotResponse).GetJobId(), allowInt64)},
+			HTTPReturnData: gin.H{"jobId": resp.(*milvuspb.RestoreExternalSnapshotResponse).GetJobId()},
 		})
 	}
 	return resp, err
@@ -3972,12 +3971,12 @@ func (h *HandlersV2) getExportSnapshotState(ctx context.Context, c *gin.Context,
 	return resp, err
 }
 
-func restoreSnapshotJobToREST(info *milvuspb.RestoreSnapshotInfo, allowInt64 bool) gin.H {
+func restoreSnapshotJobToREST(info *milvuspb.RestoreSnapshotInfo) gin.H {
 	if info == nil {
 		return gin.H{}
 	}
 	return gin.H{
-		"jobId":          formatRESTInt64(info.GetJobId(), allowInt64),
+		"jobId":          info.GetJobId(),
 		"snapshotName":   info.GetSnapshotName(),
 		"dbName":         info.GetDbName(),
 		"collectionName": info.GetCollectionName(),
@@ -4006,10 +4005,9 @@ func (h *HandlersV2) getRestoreSnapshotState(ctx context.Context, c *gin.Context
 		return h.proxy.GetRestoreSnapshotState(reqCtx, req.(*milvuspb.GetRestoreSnapshotStateRequest))
 	})
 	if err == nil {
-		allowInt64, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
 		HTTPReturn(c, http.StatusOK, gin.H{
 			HTTPReturnCode: merr.Code(nil),
-			HTTPReturnData: restoreSnapshotJobToREST(resp.(*milvuspb.GetRestoreSnapshotStateResponse).GetInfo(), allowInt64),
+			HTTPReturnData: restoreSnapshotJobToREST(resp.(*milvuspb.GetRestoreSnapshotStateResponse).GetInfo()),
 		})
 	}
 	return resp, err
@@ -4028,10 +4026,9 @@ func (h *HandlersV2) listRestoreSnapshotJobs(ctx context.Context, c *gin.Context
 	})
 	if err == nil {
 		jobs := resp.(*milvuspb.ListRestoreSnapshotJobsResponse).GetJobs()
-		allowInt64, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
 		records := make([]gin.H, 0, len(jobs))
 		for _, info := range jobs {
-			records = append(records, restoreSnapshotJobToREST(info, allowInt64))
+			records = append(records, restoreSnapshotJobToREST(info))
 		}
 		HTTPReturn(c, http.StatusOK, gin.H{
 			HTTPReturnCode: merr.Code(nil),

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -349,7 +349,7 @@ func (h *HandlersV2) RegisterRoutesToV2(router gin.IRouter) {
 	router.POST(SnapshotJobCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &OptionalCollectionNameReq{} }, wrapperTraceLog(h.listRestoreSnapshotJobs))))
 	router.POST(SnapshotCategory+CreateAction, timeoutMiddleware(wrapperPost(func() any { return &CreateSnapshotReq{} }, wrapperTraceLog(h.createSnapshot))))
 	router.POST(SnapshotCategory+DropAction, timeoutMiddleware(wrapperPost(func() any { return &SnapshotReq{} }, wrapperTraceLog(h.dropSnapshot))))
-	router.POST(SnapshotCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &OptionalCollectionNameReq{} }, wrapperTraceLog(h.listSnapshots))))
+	router.POST(SnapshotCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &CollectionNameReq{} }, wrapperTraceLog(h.listSnapshots))))
 	router.POST(SnapshotCategory+DescribeAction, timeoutMiddleware(wrapperPost(func() any { return &SnapshotReq{} }, wrapperTraceLog(h.describeSnapshot))))
 	router.POST(SnapshotCategory+RestoreAction, timeoutMiddleware(wrapperPost(func() any { return &RestoreSnapshotReq{} }, wrapperTraceLog(h.restoreSnapshot))))
 	router.POST(SnapshotCategory+PinAction, timeoutMiddleware(wrapperPost(func() any { return &PinSnapshotDataReq{} }, wrapperTraceLog(h.pinSnapshotData))))

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -181,6 +181,7 @@ var routeToMethod = map[string]string{ //nolint:gosec // not credentials, just a
 	"/v2/vectordb/snapshots/drop":                    "DropSnapshot",
 	"/v2/vectordb/snapshots/list":                    "ListSnapshots",
 	"/v2/vectordb/snapshots/describe":                "DescribeSnapshot",
+	"/v2/vectordb/snapshots/restore":                 "RestoreSnapshot",
 	"/v2/vectordb/jobs/external_collection/refresh":  "RefreshExternalCollection",
 	"/v2/vectordb/jobs/external_collection/describe": "GetRefreshExternalCollectionProgress",
 	"/v2/vectordb/jobs/external_collection/list":     "ListRefreshExternalCollectionJobs",
@@ -352,6 +353,7 @@ func (h *HandlersV2) RegisterRoutesToV2(router gin.IRouter) {
 	router.POST(SnapshotCategory+DropAction, timeoutMiddleware(wrapperPost(func() any { return &SnapshotReq{} }, wrapperTraceLog(h.dropSnapshot))))
 	router.POST(SnapshotCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &OptionalCollectionNameReq{} }, wrapperTraceLog(h.listSnapshots))))
 	router.POST(SnapshotCategory+DescribeAction, timeoutMiddleware(wrapperPost(func() any { return &SnapshotReq{} }, wrapperTraceLog(h.describeSnapshot))))
+	router.POST(SnapshotCategory+RestoreAction, timeoutMiddleware(wrapperPost(func() any { return &RestoreSnapshotReq{} }, wrapperTraceLog(h.restoreSnapshot))))
 	router.POST(ExternalCollectionJobCategory+RefreshAction, timeoutMiddleware(wrapperPost(func() any { return &RefreshExternalCollectionReq{} }, wrapperTraceLog(h.refreshExternalCollection))))
 	router.POST(ExternalCollectionJobCategory+DescribeAction, timeoutMiddleware(wrapperPost(func() any { return &RefreshExternalCollectionProgressReq{} }, wrapperTraceLog(h.getRefreshExternalCollectionProgress))))
 	router.POST(ExternalCollectionJobCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &OptionalCollectionNameReq{} }, wrapperTraceLog(h.listRefreshExternalCollectionJobs))))

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -179,6 +179,8 @@ var routeToMethod = map[string]string{ //nolint:gosec // not credentials, just a
 	"/v2/vectordb/snapshots/list":                    "ListSnapshots",
 	"/v2/vectordb/snapshots/describe":                "DescribeSnapshot",
 	"/v2/vectordb/snapshots/restore":                 "RestoreSnapshot",
+	"/v2/vectordb/snapshots/pin":                     "PinSnapshotData",
+	"/v2/vectordb/snapshots/unpin":                   "UnpinSnapshotData",
 	"/v2/vectordb/jobs/external_collection/refresh":  "RefreshExternalCollection",
 	"/v2/vectordb/jobs/external_collection/describe": "GetRefreshExternalCollectionProgress",
 	"/v2/vectordb/jobs/external_collection/list":     "ListRefreshExternalCollectionJobs",
@@ -350,6 +352,8 @@ func (h *HandlersV2) RegisterRoutesToV2(router gin.IRouter) {
 	router.POST(SnapshotCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &OptionalCollectionNameReq{} }, wrapperTraceLog(h.listSnapshots))))
 	router.POST(SnapshotCategory+DescribeAction, timeoutMiddleware(wrapperPost(func() any { return &SnapshotReq{} }, wrapperTraceLog(h.describeSnapshot))))
 	router.POST(SnapshotCategory+RestoreAction, timeoutMiddleware(wrapperPost(func() any { return &RestoreSnapshotReq{} }, wrapperTraceLog(h.restoreSnapshot))))
+	router.POST(SnapshotCategory+PinAction, timeoutMiddleware(wrapperPost(func() any { return &PinSnapshotDataReq{} }, wrapperTraceLog(h.pinSnapshotData))))
+	router.POST(SnapshotCategory+UnpinAction, timeoutMiddleware(wrapperPost(func() any { return &UnpinSnapshotDataReq{} }, wrapperTraceLog(h.unpinSnapshotData))))
 	router.POST(ExternalCollectionJobCategory+RefreshAction, timeoutMiddleware(wrapperPost(func() any { return &RefreshExternalCollectionReq{} }, wrapperTraceLog(h.refreshExternalCollection))))
 	router.POST(ExternalCollectionJobCategory+DescribeAction, timeoutMiddleware(wrapperPost(func() any { return &RefreshExternalCollectionProgressReq{} }, wrapperTraceLog(h.getRefreshExternalCollectionProgress))))
 	router.POST(ExternalCollectionJobCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &OptionalCollectionNameReq{} }, wrapperTraceLog(h.listRefreshExternalCollectionJobs))))

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -3861,9 +3861,10 @@ func (h *HandlersV2) restoreExternalSnapshot(ctx context.Context, c *gin.Context
 		return h.proxy.RestoreExternalSnapshot(reqCtx, req.(*milvuspb.RestoreExternalSnapshotRequest))
 	})
 	if err == nil {
+		allowInt64, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
 		HTTPReturn(c, http.StatusOK, gin.H{
 			HTTPReturnCode: merr.Code(nil),
-			HTTPReturnData: gin.H{"jobId": resp.(*milvuspb.RestoreExternalSnapshotResponse).GetJobId()},
+			HTTPReturnData: gin.H{"jobId": formatRESTInt64(resp.(*milvuspb.RestoreExternalSnapshotResponse).GetJobId(), allowInt64)},
 		})
 	}
 	return resp, err
@@ -3892,12 +3893,12 @@ func (h *HandlersV2) exportSnapshot(ctx context.Context, c *gin.Context, anyReq 
 	return resp, err
 }
 
-func restoreSnapshotJobToREST(info *milvuspb.RestoreSnapshotInfo) gin.H {
+func restoreSnapshotJobToREST(info *milvuspb.RestoreSnapshotInfo, allowInt64 bool) gin.H {
 	if info == nil {
 		return gin.H{}
 	}
 	return gin.H{
-		"jobId":          info.GetJobId(),
+		"jobId":          formatRESTInt64(info.GetJobId(), allowInt64),
 		"snapshotName":   info.GetSnapshotName(),
 		"dbName":         info.GetDbName(),
 		"collectionName": info.GetCollectionName(),
@@ -3926,9 +3927,10 @@ func (h *HandlersV2) getRestoreSnapshotState(ctx context.Context, c *gin.Context
 		return h.proxy.GetRestoreSnapshotState(reqCtx, req.(*milvuspb.GetRestoreSnapshotStateRequest))
 	})
 	if err == nil {
+		allowInt64, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
 		HTTPReturn(c, http.StatusOK, gin.H{
 			HTTPReturnCode: merr.Code(nil),
-			HTTPReturnData: restoreSnapshotJobToREST(resp.(*milvuspb.GetRestoreSnapshotStateResponse).GetInfo()),
+			HTTPReturnData: restoreSnapshotJobToREST(resp.(*milvuspb.GetRestoreSnapshotStateResponse).GetInfo(), allowInt64),
 		})
 	}
 	return resp, err
@@ -3947,9 +3949,10 @@ func (h *HandlersV2) listRestoreSnapshotJobs(ctx context.Context, c *gin.Context
 	})
 	if err == nil {
 		jobs := resp.(*milvuspb.ListRestoreSnapshotJobsResponse).GetJobs()
+		allowInt64, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
 		records := make([]gin.H, 0, len(jobs))
 		for _, info := range jobs {
-			records = append(records, restoreSnapshotJobToREST(info))
+			records = append(records, restoreSnapshotJobToREST(info, allowInt64))
 		}
 		HTTPReturn(c, http.StatusOK, gin.H{
 			HTTPReturnCode: merr.Code(nil),

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -3180,11 +3180,12 @@ func TestSnapshotRESTV2FormatsInt64Values(t *testing.T) {
 
 	const largeInt64 int64 = 9007199254740993
 	testCases := []struct {
-		name         string
-		path         string
-		body         string
-		responsePath string
-		setup        func(*mocks.MockProxy)
+		name                   string
+		path                   string
+		body                   string
+		responsePath           string
+		preserveReleasedNumber bool
+		setup                  func(*mocks.MockProxy)
 	}{
 		{
 			name:         "describe snapshot create timestamp",
@@ -3223,10 +3224,11 @@ func TestSnapshotRESTV2FormatsInt64Values(t *testing.T) {
 			},
 		},
 		{
-			name:         "restore external snapshot job ID",
-			path:         versionalV2(SnapshotJobCategory, RestoreExternalAction),
-			body:         `{"targetCollectionName":"restored_books","snapshotMetadataURI":"s3://bucket/snapshot.json"}`,
-			responsePath: "data.jobId",
+			name:                   "restore external snapshot job ID",
+			path:                   versionalV2(SnapshotJobCategory, RestoreExternalAction),
+			body:                   `{"targetCollectionName":"restored_books","snapshotMetadataURI":"s3://bucket/snapshot.json"}`,
+			responsePath:           "data.jobId",
+			preserveReleasedNumber: true,
 			setup: func(proxy *mocks.MockProxy) {
 				proxy.EXPECT().RestoreExternalSnapshot(mock.Anything, mock.Anything).Return(&milvuspb.RestoreExternalSnapshotResponse{
 					Status: merr.Success(),
@@ -3235,10 +3237,11 @@ func TestSnapshotRESTV2FormatsInt64Values(t *testing.T) {
 			},
 		},
 		{
-			name:         "describe restore job ID",
-			path:         versionalV2(SnapshotJobCategory, DescribeAction),
-			body:         `{"jobId":"9007199254740993"}`,
-			responsePath: "data.jobId",
+			name:                   "describe restore job ID",
+			path:                   versionalV2(SnapshotJobCategory, DescribeAction),
+			body:                   `{"jobId":"9007199254740993"}`,
+			responsePath:           "data.jobId",
+			preserveReleasedNumber: true,
 			setup: func(proxy *mocks.MockProxy) {
 				proxy.EXPECT().GetRestoreSnapshotState(mock.Anything, mock.Anything).Return(&milvuspb.GetRestoreSnapshotStateResponse{
 					Status: merr.Success(),
@@ -3247,10 +3250,11 @@ func TestSnapshotRESTV2FormatsInt64Values(t *testing.T) {
 			},
 		},
 		{
-			name:         "list restore job ID",
-			path:         versionalV2(SnapshotJobCategory, ListAction),
-			body:         `{}`,
-			responsePath: "data.records.0.jobId",
+			name:                   "list restore job ID",
+			path:                   versionalV2(SnapshotJobCategory, ListAction),
+			body:                   `{}`,
+			responsePath:           "data.records.0.jobId",
+			preserveReleasedNumber: true,
 			setup: func(proxy *mocks.MockProxy) {
 				proxy.EXPECT().ListRestoreSnapshotJobs(mock.Anything, mock.Anything).Return(&milvuspb.ListRestoreSnapshotJobsResponse{
 					Status: merr.Success(),
@@ -3275,7 +3279,7 @@ func TestSnapshotRESTV2FormatsInt64Values(t *testing.T) {
 
 				require.Equal(t, http.StatusOK, recorder.Code)
 				expectedRaw := `"9007199254740993"`
-				if allowInt64 {
+				if testCase.preserveReleasedNumber || allowInt64 {
 					expectedRaw = "9007199254740993"
 				}
 				assert.Equal(t, expectedRaw, gjson.Get(recorder.Body.String(), testCase.responsePath).Raw)
@@ -3457,7 +3461,7 @@ func TestRestoreExternalSnapshotRESTV2(t *testing.T) {
 	assert.Equal(t, "restored_books", proxy.restoreReq.GetTargetCollectionName())
 	assert.Equal(t, "s3://bucket/files/snapshots/meta.json", proxy.restoreReq.GetSnapshotMetadataUri())
 	assert.Equal(t, `{"extfs":{"cloud_provider":"aws","region":"us-west-2","use_iam":"true"}}`, proxy.restoreReq.GetExternalSpec())
-	assert.Contains(t, w.Body.String(), `"jobId":"2001"`)
+	assert.Contains(t, w.Body.String(), `"jobId":2001`)
 }
 
 func TestExportSnapshotRESTV2(t *testing.T) {
@@ -3520,7 +3524,7 @@ func TestRestoreSnapshotJobRESTV2(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, int64(2001), proxy.getRestoreSnapshotStateReq.GetJobId())
-	assert.Contains(t, w.Body.String(), `"jobId":"2001"`)
+	assert.Contains(t, w.Body.String(), `"jobId":2001`)
 	assert.Contains(t, w.Body.String(), `"collectionName":"restored_collection"`)
 	assert.Contains(t, w.Body.String(), `"state":"RestoreSnapshotCompleted"`)
 
@@ -3535,7 +3539,7 @@ func TestRestoreSnapshotJobRESTV2(t *testing.T) {
 	assert.Equal(t, "default", proxy.listRestoreSnapshotJobsReq.GetDbName())
 	assert.Equal(t, "restored_collection", proxy.listRestoreSnapshotJobsReq.GetCollectionName())
 	assert.Contains(t, w.Body.String(), `"records":[`)
-	assert.Contains(t, w.Body.String(), `"jobId":"2001"`)
+	assert.Contains(t, w.Body.String(), `"jobId":2001`)
 	assert.Contains(t, w.Body.String(), `"state":"RestoreSnapshotPending"`)
 }
 

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/tidwall/gjson"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -2385,6 +2386,10 @@ type externalCollectionRESTProxy struct {
 	exportReq                  *milvuspb.ExportSnapshotRequest
 	getRestoreSnapshotStateReq *milvuspb.GetRestoreSnapshotStateRequest
 	listRestoreSnapshotJobsReq *milvuspb.ListRestoreSnapshotJobsRequest
+	createSnapshotReq          *milvuspb.CreateSnapshotRequest
+	dropSnapshotReq            *milvuspb.DropSnapshotRequest
+	listSnapshotsReq           *milvuspb.ListSnapshotsRequest
+	describeSnapshotReq        *milvuspb.DescribeSnapshotRequest
 }
 
 func (m *externalCollectionRESTProxy) CreateCollection(ctx context.Context, request *milvuspb.CreateCollectionRequest) (*commonpb.Status, error) {
@@ -2505,6 +2510,37 @@ func (m *externalCollectionRESTProxy) ListRestoreSnapshotJobs(ctx context.Contex
 			State:          milvuspb.RestoreSnapshotState_RestoreSnapshotPending,
 			Progress:       10,
 		}},
+	}, nil
+}
+
+func (m *externalCollectionRESTProxy) CreateSnapshot(ctx context.Context, request *milvuspb.CreateSnapshotRequest) (*commonpb.Status, error) {
+	m.createSnapshotReq = request
+	return merr.Success(), nil
+}
+
+func (m *externalCollectionRESTProxy) DropSnapshot(ctx context.Context, request *milvuspb.DropSnapshotRequest) (*commonpb.Status, error) {
+	m.dropSnapshotReq = request
+	return merr.Success(), nil
+}
+
+func (m *externalCollectionRESTProxy) ListSnapshots(ctx context.Context, request *milvuspb.ListSnapshotsRequest) (*milvuspb.ListSnapshotsResponse, error) {
+	m.listSnapshotsReq = request
+	return &milvuspb.ListSnapshotsResponse{
+		Status:    merr.Success(),
+		Snapshots: []string{"snapshot_1", "snapshot_2"},
+	}, nil
+}
+
+func (m *externalCollectionRESTProxy) DescribeSnapshot(ctx context.Context, request *milvuspb.DescribeSnapshotRequest) (*milvuspb.DescribeSnapshotResponse, error) {
+	m.describeSnapshotReq = request
+	return &milvuspb.DescribeSnapshotResponse{
+		Status:         merr.Success(),
+		Name:           request.GetName(),
+		Description:    "daily backup",
+		CollectionName: request.GetCollectionName(),
+		PartitionNames: []string{"_default"},
+		CreateTs:       100,
+		S3Location:     "s3://bucket/snapshot_1",
 	}, nil
 }
 
@@ -2699,6 +2735,79 @@ func TestExternalCollectionJobRoutesRESTV2(t *testing.T) {
 	assert.Equal(t, "external_books", proxy.listReq.GetCollectionName())
 	assert.Contains(t, w.Body.String(), `"state":"RefreshCompleted"`)
 	assert.Contains(t, w.Body.String(), `"externalSpec":"{\"format\":\"parquet\"}"`)
+}
+
+func TestSnapshotCRUDRESTV2(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	proxy := &externalCollectionRESTProxy{}
+	testEngine := initHTTPServerV2(proxy, false)
+
+	req := httptest.NewRequest(http.MethodPost, versionalV2(SnapshotCategory, CreateAction), bytes.NewReader([]byte(`{
+		"dbName": "default",
+		"collectionName": "source_books",
+		"snapshotName": "snapshot_1",
+		"description": "daily backup",
+		"compactionProtectionSeconds": 3600
+	}`)))
+	w := httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int64(0), gjson.Get(w.Body.String(), "code").Int())
+	assert.Equal(t, "default", proxy.createSnapshotReq.GetDbName())
+	assert.Equal(t, "source_books", proxy.createSnapshotReq.GetCollectionName())
+	assert.Equal(t, "snapshot_1", proxy.createSnapshotReq.GetName())
+	assert.Equal(t, "daily backup", proxy.createSnapshotReq.GetDescription())
+	assert.Equal(t, int64(3600), proxy.createSnapshotReq.GetCompactionProtectionSeconds())
+
+	req = httptest.NewRequest(http.MethodPost, versionalV2(SnapshotCategory, ListAction), bytes.NewReader([]byte(`{
+		"dbName": "default",
+		"collectionName": "source_books"
+	}`)))
+	w = httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "default", proxy.listSnapshotsReq.GetDbName())
+	assert.Equal(t, "source_books", proxy.listSnapshotsReq.GetCollectionName())
+	assert.Equal(t, "snapshot_1", gjson.Get(w.Body.String(), "data.0").String())
+	assert.Equal(t, "snapshot_2", gjson.Get(w.Body.String(), "data.1").String())
+
+	req = httptest.NewRequest(http.MethodPost, versionalV2(SnapshotCategory, DescribeAction), bytes.NewReader([]byte(`{
+		"dbName": "default",
+		"collectionName": "source_books",
+		"snapshotName": "snapshot_1"
+	}`)))
+	w = httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "default", proxy.describeSnapshotReq.GetDbName())
+	assert.Equal(t, "source_books", proxy.describeSnapshotReq.GetCollectionName())
+	assert.Equal(t, "snapshot_1", proxy.describeSnapshotReq.GetName())
+	assert.Equal(t, "snapshot_1", gjson.Get(w.Body.String(), "data.snapshotName").String())
+	assert.Equal(t, "daily backup", gjson.Get(w.Body.String(), "data.description").String())
+	assert.Equal(t, "source_books", gjson.Get(w.Body.String(), "data.collectionName").String())
+	assert.Equal(t, "_default", gjson.Get(w.Body.String(), "data.partitionNames.0").String())
+	assert.Equal(t, int64(100), gjson.Get(w.Body.String(), "data.createTs").Int())
+	assert.Equal(t, "s3://bucket/snapshot_1", gjson.Get(w.Body.String(), "data.s3Location").String())
+
+	req = httptest.NewRequest(http.MethodPost, versionalV2(SnapshotCategory, DropAction), bytes.NewReader([]byte(`{
+		"dbName": "default",
+		"collectionName": "source_books",
+		"snapshotName": "snapshot_1"
+	}`)))
+	w = httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int64(0), gjson.Get(w.Body.String(), "code").Int())
+	assert.Equal(t, "default", proxy.dropSnapshotReq.GetDbName())
+	assert.Equal(t, "source_books", proxy.dropSnapshotReq.GetCollectionName())
+	assert.Equal(t, "snapshot_1", proxy.dropSnapshotReq.GetName())
 }
 
 func TestRestoreExternalSnapshotRESTV2(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -3323,7 +3323,21 @@ func TestRestoreSnapshotRESTV2(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "source_db", proxy.restoreSnapshotReq.GetDbName())
-	assert.Equal(t, "source_db", proxy.restoreSnapshotReq.GetTargetDbName())
+	assert.Equal(t, "default", proxy.restoreSnapshotReq.GetTargetDbName())
+
+	req = httptest.NewRequest(http.MethodPost, versionalV2(SnapshotCategory, RestoreAction), bytes.NewReader([]byte(`{
+		"sourceDbName": "archive",
+		"sourceCollectionName": "source_books",
+		"targetCollectionName": "restored_books",
+		"snapshotName": "snapshot_1"
+	}`)))
+	req.Header.Set(HTTPHeaderDBName, "tenant_a")
+	w = httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "archive", proxy.restoreSnapshotReq.GetDbName())
+	assert.Equal(t, "tenant_a", proxy.restoreSnapshotReq.GetTargetDbName())
 }
 
 func TestPinSnapshotDataRESTV2(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -3506,6 +3506,7 @@ func TestRestoreSnapshotJobRESTV2(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, int64(2001), proxy.getRestoreSnapshotStateReq.GetJobId())
+	assert.Contains(t, w.Body.String(), `"jobId":"2001"`)
 	assert.Contains(t, w.Body.String(), `"collectionName":"restored_collection"`)
 	assert.Contains(t, w.Body.String(), `"state":"RestoreSnapshotCompleted"`)
 
@@ -3520,6 +3521,7 @@ func TestRestoreSnapshotJobRESTV2(t *testing.T) {
 	assert.Equal(t, "default", proxy.listRestoreSnapshotJobsReq.GetDbName())
 	assert.Equal(t, "restored_collection", proxy.listRestoreSnapshotJobsReq.GetCollectionName())
 	assert.Contains(t, w.Body.String(), `"records":[`)
+	assert.Contains(t, w.Body.String(), `"jobId":"2001"`)
 	assert.Contains(t, w.Body.String(), `"state":"RestoreSnapshotPending"`)
 }
 

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -2834,6 +2834,117 @@ func TestSnapshotCRUDRESTV2(t *testing.T) {
 	assert.Equal(t, "snapshot_1", proxy.dropSnapshotReq.GetName())
 }
 
+func TestSnapshotRESTV2FormatsInt64Values(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	const largeInt64 int64 = 9007199254740993
+	testCases := []struct {
+		name         string
+		path         string
+		body         string
+		responsePath string
+		setup        func(*mocks.MockProxy)
+	}{
+		{
+			name:         "describe snapshot create timestamp",
+			path:         versionalV2(SnapshotCategory, DescribeAction),
+			body:         `{"collectionName":"source_books","snapshotName":"snapshot_1"}`,
+			responsePath: "data.createTs",
+			setup: func(proxy *mocks.MockProxy) {
+				proxy.EXPECT().DescribeSnapshot(mock.Anything, mock.Anything).Return(&milvuspb.DescribeSnapshotResponse{
+					Status:   merr.Success(),
+					CreateTs: largeInt64,
+				}, nil).Once()
+			},
+		},
+		{
+			name:         "restore snapshot job ID",
+			path:         versionalV2(SnapshotCategory, RestoreAction),
+			body:         `{"sourceCollectionName":"source_books","targetCollectionName":"restored_books","snapshotName":"snapshot_1"}`,
+			responsePath: "data.jobId",
+			setup: func(proxy *mocks.MockProxy) {
+				proxy.EXPECT().RestoreSnapshot(mock.Anything, mock.Anything).Return(&milvuspb.RestoreSnapshotResponse{
+					Status: merr.Success(),
+					JobId:  largeInt64,
+				}, nil).Once()
+			},
+		},
+		{
+			name:         "pin snapshot ID",
+			path:         versionalV2(SnapshotCategory, PinAction),
+			body:         `{"collectionName":"source_books","snapshotName":"snapshot_1"}`,
+			responsePath: "data.pinId",
+			setup: func(proxy *mocks.MockProxy) {
+				proxy.EXPECT().PinSnapshotData(mock.Anything, mock.Anything).Return(&milvuspb.PinSnapshotDataResponse{
+					Status: merr.Success(),
+					PinId:  largeInt64,
+				}, nil).Once()
+			},
+		},
+		{
+			name:         "restore external snapshot job ID",
+			path:         versionalV2(SnapshotJobCategory, RestoreExternalAction),
+			body:         `{"targetCollectionName":"restored_books","snapshotMetadataURI":"s3://bucket/snapshot.json"}`,
+			responsePath: "data.jobId",
+			setup: func(proxy *mocks.MockProxy) {
+				proxy.EXPECT().RestoreExternalSnapshot(mock.Anything, mock.Anything).Return(&milvuspb.RestoreExternalSnapshotResponse{
+					Status: merr.Success(),
+					JobId:  largeInt64,
+				}, nil).Once()
+			},
+		},
+		{
+			name:         "describe restore job ID",
+			path:         versionalV2(SnapshotJobCategory, DescribeAction),
+			body:         `{"jobId":"9007199254740993"}`,
+			responsePath: "data.jobId",
+			setup: func(proxy *mocks.MockProxy) {
+				proxy.EXPECT().GetRestoreSnapshotState(mock.Anything, mock.Anything).Return(&milvuspb.GetRestoreSnapshotStateResponse{
+					Status: merr.Success(),
+					Info:   &milvuspb.RestoreSnapshotInfo{JobId: largeInt64},
+				}, nil).Once()
+			},
+		},
+		{
+			name:         "list restore job ID",
+			path:         versionalV2(SnapshotJobCategory, ListAction),
+			body:         `{}`,
+			responsePath: "data.records.0.jobId",
+			setup: func(proxy *mocks.MockProxy) {
+				proxy.EXPECT().ListRestoreSnapshotJobs(mock.Anything, mock.Anything).Return(&milvuspb.ListRestoreSnapshotJobsResponse{
+					Status: merr.Success(),
+					Jobs:   []*milvuspb.RestoreSnapshotInfo{{JobId: largeInt64}},
+				}, nil).Once()
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		for _, allowInt64 := range []bool{false, true} {
+			name := fmt.Sprintf("%s/allow_int64_%t", testCase.name, allowInt64)
+			t.Run(name, func(t *testing.T) {
+				proxy := mocks.NewMockProxy(t)
+				testCase.setup(proxy)
+				server := initHTTPServerV2(proxy, false)
+
+				req := httptest.NewRequest(http.MethodPost, testCase.path, bytes.NewBufferString(testCase.body))
+				req.Header.Set(HTTPHeaderAllowInt64, fmt.Sprintf("%t", allowInt64))
+				recorder := httptest.NewRecorder()
+				server.ServeHTTP(recorder, req)
+
+				require.Equal(t, http.StatusOK, recorder.Code)
+				expectedRaw := `"9007199254740993"`
+				if allowInt64 {
+					expectedRaw = "9007199254740993"
+				}
+				assert.Equal(t, expectedRaw, gjson.Get(recorder.Body.String(), testCase.responsePath).Raw)
+			})
+		}
+	}
+}
+
 func TestRestoreSnapshotRESTV2(t *testing.T) {
 	paramtable.Init()
 	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
@@ -2889,14 +3000,14 @@ func TestPinSnapshotDataRESTV2(t *testing.T) {
 	assert.Equal(t, int64(3600), proxy.pinSnapshotDataReq.GetTtlSeconds())
 
 	req = httptest.NewRequest(http.MethodPost, versionalV2(SnapshotCategory, UnpinAction), bytes.NewReader([]byte(`{
-		"pinId": 300
+		"pinId": "9007199254740993"
 	}`)))
 	w = httptest.NewRecorder()
 	testEngine.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, int64(0), gjson.Get(w.Body.String(), "code").Int())
-	assert.Equal(t, int64(300), proxy.unpinSnapshotDataReq.GetPinId())
+	assert.Equal(t, int64(9007199254740993), proxy.unpinSnapshotDataReq.GetPinId())
 }
 
 func TestSnapshotRESTV2Validation(t *testing.T) {
@@ -2932,7 +3043,17 @@ func TestSnapshotRESTV2Validation(t *testing.T) {
 		{
 			name:   "invalid pin ID",
 			action: UnpinAction,
-			body:   `{"pinId":0}`,
+			body:   `{"pinId":"0"}`,
+		},
+		{
+			name:   "malformed pin ID",
+			action: UnpinAction,
+			body:   `{"pinId":"not-an-int64"}`,
+		},
+		{
+			name:   "numeric pin ID",
+			action: UnpinAction,
+			body:   `{"pinId":300}`,
 		},
 	}
 
@@ -2970,7 +3091,7 @@ func TestRestoreExternalSnapshotRESTV2(t *testing.T) {
 	assert.Equal(t, "restored_books", proxy.restoreReq.GetTargetCollectionName())
 	assert.Equal(t, "s3://bucket/files/snapshots/meta.json", proxy.restoreReq.GetSnapshotMetadataUri())
 	assert.Equal(t, `{"extfs":{"cloud_provider":"aws","region":"us-west-2","use_iam":"true"}}`, proxy.restoreReq.GetExternalSpec())
-	assert.Contains(t, w.Body.String(), `"jobId":2001`)
+	assert.Contains(t, w.Body.String(), `"jobId":"2001"`)
 }
 
 func TestExportSnapshotRESTV2(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -2711,6 +2711,8 @@ type externalCollectionRESTProxy struct {
 	listSnapshotsReq           *milvuspb.ListSnapshotsRequest
 	describeSnapshotReq        *milvuspb.DescribeSnapshotRequest
 	restoreSnapshotReq         *milvuspb.RestoreSnapshotRequest
+	pinSnapshotDataReq         *milvuspb.PinSnapshotDataRequest
+	unpinSnapshotDataReq       *milvuspb.UnpinSnapshotDataRequest
 }
 
 func (m *externalCollectionRESTProxy) CreateCollection(ctx context.Context, request *milvuspb.CreateCollectionRequest) (*commonpb.Status, error) {
@@ -2890,6 +2892,19 @@ func (m *externalCollectionRESTProxy) RestoreSnapshot(ctx context.Context, reque
 		Status: merr.Success(),
 		JobId:  200,
 	}, nil
+}
+
+func (m *externalCollectionRESTProxy) PinSnapshotData(ctx context.Context, request *milvuspb.PinSnapshotDataRequest) (*milvuspb.PinSnapshotDataResponse, error) {
+	m.pinSnapshotDataReq = request
+	return &milvuspb.PinSnapshotDataResponse{
+		Status: merr.Success(),
+		PinId:  300,
+	}, nil
+}
+
+func (m *externalCollectionRESTProxy) UnpinSnapshotData(ctx context.Context, request *milvuspb.UnpinSnapshotDataRequest) (*commonpb.Status, error) {
+	m.unpinSnapshotDataReq = request
+	return merr.Success(), nil
 }
 
 func TestFieldSchemaGetProtoWithExternalField(t *testing.T) {
@@ -3185,6 +3200,86 @@ func TestRestoreSnapshotRESTV2(t *testing.T) {
 	assert.Equal(t, "restored_books", proxy.restoreSnapshotReq.GetTargetCollectionName())
 	assert.Equal(t, "snapshot_1", proxy.restoreSnapshotReq.GetName())
 	assert.False(t, proxy.restoreSnapshotReq.GetRewriteData())
+}
+
+func TestPinSnapshotDataRESTV2(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	proxy := &externalCollectionRESTProxy{}
+	testEngine := initHTTPServerV2(proxy, false)
+
+	req := httptest.NewRequest(http.MethodPost, versionalV2(SnapshotCategory, PinAction), bytes.NewReader([]byte(`{
+		"dbName": "default",
+		"collectionName": "source_books",
+		"snapshotName": "snapshot_1",
+		"ttlSeconds": 3600
+	}`)))
+	w := httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int64(0), gjson.Get(w.Body.String(), "code").Int())
+	assert.Equal(t, int64(300), gjson.Get(w.Body.String(), "data.pinId").Int())
+	assert.Equal(t, "default", proxy.pinSnapshotDataReq.GetDbName())
+	assert.Equal(t, "source_books", proxy.pinSnapshotDataReq.GetCollectionName())
+	assert.Equal(t, "snapshot_1", proxy.pinSnapshotDataReq.GetName())
+	assert.Equal(t, int64(3600), proxy.pinSnapshotDataReq.GetTtlSeconds())
+
+	req = httptest.NewRequest(http.MethodPost, versionalV2(SnapshotCategory, UnpinAction), bytes.NewReader([]byte(`{
+		"pinId": 300
+	}`)))
+	w = httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int64(0), gjson.Get(w.Body.String(), "code").Int())
+	assert.Equal(t, int64(300), proxy.unpinSnapshotDataReq.GetPinId())
+}
+
+func TestSnapshotRESTV2Validation(t *testing.T) {
+	paramtable.Init()
+	proxy := &externalCollectionRESTProxy{}
+	testEngine := initHTTPServerV2(proxy, false)
+
+	tests := []struct {
+		name   string
+		action string
+		body   string
+	}{
+		{
+			name:   "missing snapshot name",
+			action: CreateAction,
+			body:   `{"collectionName":"source_books"}`,
+		},
+		{
+			name:   "negative compaction protection",
+			action: CreateAction,
+			body:   `{"collectionName":"source_books","snapshotName":"snapshot_1","compactionProtectionSeconds":-1}`,
+		},
+		{
+			name:   "negative pin TTL",
+			action: PinAction,
+			body:   `{"collectionName":"source_books","snapshotName":"snapshot_1","ttlSeconds":-1}`,
+		},
+		{
+			name:   "invalid pin ID",
+			action: UnpinAction,
+			body:   `{"pinId":0}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, versionalV2(SnapshotCategory, test.action), bytes.NewReader([]byte(test.body)))
+			w := httptest.NewRecorder()
+			testEngine.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.NotEqual(t, int64(0), gjson.Get(w.Body.String(), "code").Int())
+		})
+	}
 }
 
 func TestRestoreExternalSnapshotRESTV2(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -2390,6 +2390,7 @@ type externalCollectionRESTProxy struct {
 	dropSnapshotReq            *milvuspb.DropSnapshotRequest
 	listSnapshotsReq           *milvuspb.ListSnapshotsRequest
 	describeSnapshotReq        *milvuspb.DescribeSnapshotRequest
+	restoreSnapshotReq         *milvuspb.RestoreSnapshotRequest
 }
 
 func (m *externalCollectionRESTProxy) CreateCollection(ctx context.Context, request *milvuspb.CreateCollectionRequest) (*commonpb.Status, error) {
@@ -2541,6 +2542,14 @@ func (m *externalCollectionRESTProxy) DescribeSnapshot(ctx context.Context, requ
 		PartitionNames: []string{"_default"},
 		CreateTs:       100,
 		S3Location:     "s3://bucket/snapshot_1",
+	}, nil
+}
+
+func (m *externalCollectionRESTProxy) RestoreSnapshot(ctx context.Context, request *milvuspb.RestoreSnapshotRequest) (*milvuspb.RestoreSnapshotResponse, error) {
+	m.restoreSnapshotReq = request
+	return &milvuspb.RestoreSnapshotResponse{
+		Status: merr.Success(),
+		JobId:  200,
 	}, nil
 }
 
@@ -2808,6 +2817,35 @@ func TestSnapshotCRUDRESTV2(t *testing.T) {
 	assert.Equal(t, "default", proxy.dropSnapshotReq.GetDbName())
 	assert.Equal(t, "source_books", proxy.dropSnapshotReq.GetCollectionName())
 	assert.Equal(t, "snapshot_1", proxy.dropSnapshotReq.GetName())
+}
+
+func TestRestoreSnapshotRESTV2(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	proxy := &externalCollectionRESTProxy{}
+	testEngine := initHTTPServerV2(proxy, false)
+
+	req := httptest.NewRequest(http.MethodPost, versionalV2(SnapshotCategory, RestoreAction), bytes.NewReader([]byte(`{
+		"sourceDbName": "source_db",
+		"sourceCollectionName": "source_books",
+		"targetDbName": "target_db",
+		"targetCollectionName": "restored_books",
+		"snapshotName": "snapshot_1"
+	}`)))
+	w := httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int64(0), gjson.Get(w.Body.String(), "code").Int())
+	assert.Equal(t, int64(200), gjson.Get(w.Body.String(), "data.jobId").Int())
+	assert.Equal(t, "source_db", proxy.restoreSnapshotReq.GetDbName())
+	assert.Equal(t, "source_books", proxy.restoreSnapshotReq.GetCollectionName())
+	assert.Equal(t, "target_db", proxy.restoreSnapshotReq.GetTargetDbName())
+	assert.Equal(t, "restored_books", proxy.restoreSnapshotReq.GetTargetCollectionName())
+	assert.Equal(t, "snapshot_1", proxy.restoreSnapshotReq.GetName())
+	assert.False(t, proxy.restoreSnapshotReq.GetRewriteData())
 }
 
 func TestRestoreExternalSnapshotRESTV2(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -2710,6 +2710,7 @@ type externalCollectionRESTProxy struct {
 	dropSnapshotReq            *milvuspb.DropSnapshotRequest
 	listSnapshotsReq           *milvuspb.ListSnapshotsRequest
 	describeSnapshotReq        *milvuspb.DescribeSnapshotRequest
+	restoreSnapshotReq         *milvuspb.RestoreSnapshotRequest
 }
 
 func (m *externalCollectionRESTProxy) CreateCollection(ctx context.Context, request *milvuspb.CreateCollectionRequest) (*commonpb.Status, error) {
@@ -2880,6 +2881,14 @@ func (m *externalCollectionRESTProxy) DescribeSnapshot(ctx context.Context, requ
 		PartitionNames: []string{"_default"},
 		CreateTs:       100,
 		S3Location:     "s3://bucket/snapshot_1",
+	}, nil
+}
+
+func (m *externalCollectionRESTProxy) RestoreSnapshot(ctx context.Context, request *milvuspb.RestoreSnapshotRequest) (*milvuspb.RestoreSnapshotResponse, error) {
+	m.restoreSnapshotReq = request
+	return &milvuspb.RestoreSnapshotResponse{
+		Status: merr.Success(),
+		JobId:  200,
 	}, nil
 }
 
@@ -3147,6 +3156,35 @@ func TestSnapshotCRUDRESTV2(t *testing.T) {
 	assert.Equal(t, "default", proxy.dropSnapshotReq.GetDbName())
 	assert.Equal(t, "source_books", proxy.dropSnapshotReq.GetCollectionName())
 	assert.Equal(t, "snapshot_1", proxy.dropSnapshotReq.GetName())
+}
+
+func TestRestoreSnapshotRESTV2(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	proxy := &externalCollectionRESTProxy{}
+	testEngine := initHTTPServerV2(proxy, false)
+
+	req := httptest.NewRequest(http.MethodPost, versionalV2(SnapshotCategory, RestoreAction), bytes.NewReader([]byte(`{
+		"sourceDbName": "source_db",
+		"sourceCollectionName": "source_books",
+		"targetDbName": "target_db",
+		"targetCollectionName": "restored_books",
+		"snapshotName": "snapshot_1"
+	}`)))
+	w := httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int64(0), gjson.Get(w.Body.String(), "code").Int())
+	assert.Equal(t, int64(200), gjson.Get(w.Body.String(), "data.jobId").Int())
+	assert.Equal(t, "source_db", proxy.restoreSnapshotReq.GetDbName())
+	assert.Equal(t, "source_books", proxy.restoreSnapshotReq.GetCollectionName())
+	assert.Equal(t, "target_db", proxy.restoreSnapshotReq.GetTargetDbName())
+	assert.Equal(t, "restored_books", proxy.restoreSnapshotReq.GetTargetCollectionName())
+	assert.Equal(t, "snapshot_1", proxy.restoreSnapshotReq.GetName())
+	assert.False(t, proxy.restoreSnapshotReq.GetRewriteData())
 }
 
 func TestRestoreExternalSnapshotRESTV2(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -3311,6 +3311,19 @@ func TestRestoreSnapshotRESTV2(t *testing.T) {
 	assert.Equal(t, "restored_books", proxy.restoreSnapshotReq.GetTargetCollectionName())
 	assert.Equal(t, "snapshot_1", proxy.restoreSnapshotReq.GetName())
 	assert.False(t, proxy.restoreSnapshotReq.GetRewriteData())
+
+	req = httptest.NewRequest(http.MethodPost, versionalV2(SnapshotCategory, RestoreAction), bytes.NewReader([]byte(`{
+		"sourceDbName": "source_db",
+		"sourceCollectionName": "source_books",
+		"targetCollectionName": "restored_books",
+		"snapshotName": "snapshot_1"
+	}`)))
+	w = httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "source_db", proxy.restoreSnapshotReq.GetDbName())
+	assert.Equal(t, "source_db", proxy.restoreSnapshotReq.GetTargetDbName())
 }
 
 func TestPinSnapshotDataRESTV2(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -2391,6 +2391,8 @@ type externalCollectionRESTProxy struct {
 	listSnapshotsReq           *milvuspb.ListSnapshotsRequest
 	describeSnapshotReq        *milvuspb.DescribeSnapshotRequest
 	restoreSnapshotReq         *milvuspb.RestoreSnapshotRequest
+	pinSnapshotDataReq         *milvuspb.PinSnapshotDataRequest
+	unpinSnapshotDataReq       *milvuspb.UnpinSnapshotDataRequest
 }
 
 func (m *externalCollectionRESTProxy) CreateCollection(ctx context.Context, request *milvuspb.CreateCollectionRequest) (*commonpb.Status, error) {
@@ -2551,6 +2553,19 @@ func (m *externalCollectionRESTProxy) RestoreSnapshot(ctx context.Context, reque
 		Status: merr.Success(),
 		JobId:  200,
 	}, nil
+}
+
+func (m *externalCollectionRESTProxy) PinSnapshotData(ctx context.Context, request *milvuspb.PinSnapshotDataRequest) (*milvuspb.PinSnapshotDataResponse, error) {
+	m.pinSnapshotDataReq = request
+	return &milvuspb.PinSnapshotDataResponse{
+		Status: merr.Success(),
+		PinId:  300,
+	}, nil
+}
+
+func (m *externalCollectionRESTProxy) UnpinSnapshotData(ctx context.Context, request *milvuspb.UnpinSnapshotDataRequest) (*commonpb.Status, error) {
+	m.unpinSnapshotDataReq = request
+	return merr.Success(), nil
 }
 
 func TestFieldSchemaGetProtoWithExternalField(t *testing.T) {
@@ -2846,6 +2861,86 @@ func TestRestoreSnapshotRESTV2(t *testing.T) {
 	assert.Equal(t, "restored_books", proxy.restoreSnapshotReq.GetTargetCollectionName())
 	assert.Equal(t, "snapshot_1", proxy.restoreSnapshotReq.GetName())
 	assert.False(t, proxy.restoreSnapshotReq.GetRewriteData())
+}
+
+func TestPinSnapshotDataRESTV2(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	proxy := &externalCollectionRESTProxy{}
+	testEngine := initHTTPServerV2(proxy, false)
+
+	req := httptest.NewRequest(http.MethodPost, versionalV2(SnapshotCategory, PinAction), bytes.NewReader([]byte(`{
+		"dbName": "default",
+		"collectionName": "source_books",
+		"snapshotName": "snapshot_1",
+		"ttlSeconds": 3600
+	}`)))
+	w := httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int64(0), gjson.Get(w.Body.String(), "code").Int())
+	assert.Equal(t, int64(300), gjson.Get(w.Body.String(), "data.pinId").Int())
+	assert.Equal(t, "default", proxy.pinSnapshotDataReq.GetDbName())
+	assert.Equal(t, "source_books", proxy.pinSnapshotDataReq.GetCollectionName())
+	assert.Equal(t, "snapshot_1", proxy.pinSnapshotDataReq.GetName())
+	assert.Equal(t, int64(3600), proxy.pinSnapshotDataReq.GetTtlSeconds())
+
+	req = httptest.NewRequest(http.MethodPost, versionalV2(SnapshotCategory, UnpinAction), bytes.NewReader([]byte(`{
+		"pinId": 300
+	}`)))
+	w = httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int64(0), gjson.Get(w.Body.String(), "code").Int())
+	assert.Equal(t, int64(300), proxy.unpinSnapshotDataReq.GetPinId())
+}
+
+func TestSnapshotRESTV2Validation(t *testing.T) {
+	paramtable.Init()
+	proxy := &externalCollectionRESTProxy{}
+	testEngine := initHTTPServerV2(proxy, false)
+
+	tests := []struct {
+		name   string
+		action string
+		body   string
+	}{
+		{
+			name:   "missing snapshot name",
+			action: CreateAction,
+			body:   `{"collectionName":"source_books"}`,
+		},
+		{
+			name:   "negative compaction protection",
+			action: CreateAction,
+			body:   `{"collectionName":"source_books","snapshotName":"snapshot_1","compactionProtectionSeconds":-1}`,
+		},
+		{
+			name:   "negative pin TTL",
+			action: PinAction,
+			body:   `{"collectionName":"source_books","snapshotName":"snapshot_1","ttlSeconds":-1}`,
+		},
+		{
+			name:   "invalid pin ID",
+			action: UnpinAction,
+			body:   `{"pinId":0}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, versionalV2(SnapshotCategory, test.action), bytes.NewReader([]byte(test.body)))
+			w := httptest.NewRecorder()
+			testEngine.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.NotEqual(t, int64(0), gjson.Get(w.Body.String(), "code").Int())
+		})
+	}
 }
 
 func TestRestoreExternalSnapshotRESTV2(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -3173,6 +3173,117 @@ func TestSnapshotCRUDRESTV2(t *testing.T) {
 	assert.Equal(t, "snapshot_1", proxy.dropSnapshotReq.GetName())
 }
 
+func TestSnapshotRESTV2FormatsInt64Values(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	const largeInt64 int64 = 9007199254740993
+	testCases := []struct {
+		name         string
+		path         string
+		body         string
+		responsePath string
+		setup        func(*mocks.MockProxy)
+	}{
+		{
+			name:         "describe snapshot create timestamp",
+			path:         versionalV2(SnapshotCategory, DescribeAction),
+			body:         `{"collectionName":"source_books","snapshotName":"snapshot_1"}`,
+			responsePath: "data.createTs",
+			setup: func(proxy *mocks.MockProxy) {
+				proxy.EXPECT().DescribeSnapshot(mock.Anything, mock.Anything).Return(&milvuspb.DescribeSnapshotResponse{
+					Status:   merr.Success(),
+					CreateTs: largeInt64,
+				}, nil).Once()
+			},
+		},
+		{
+			name:         "restore snapshot job ID",
+			path:         versionalV2(SnapshotCategory, RestoreAction),
+			body:         `{"sourceCollectionName":"source_books","targetCollectionName":"restored_books","snapshotName":"snapshot_1"}`,
+			responsePath: "data.jobId",
+			setup: func(proxy *mocks.MockProxy) {
+				proxy.EXPECT().RestoreSnapshot(mock.Anything, mock.Anything).Return(&milvuspb.RestoreSnapshotResponse{
+					Status: merr.Success(),
+					JobId:  largeInt64,
+				}, nil).Once()
+			},
+		},
+		{
+			name:         "pin snapshot ID",
+			path:         versionalV2(SnapshotCategory, PinAction),
+			body:         `{"collectionName":"source_books","snapshotName":"snapshot_1"}`,
+			responsePath: "data.pinId",
+			setup: func(proxy *mocks.MockProxy) {
+				proxy.EXPECT().PinSnapshotData(mock.Anything, mock.Anything).Return(&milvuspb.PinSnapshotDataResponse{
+					Status: merr.Success(),
+					PinId:  largeInt64,
+				}, nil).Once()
+			},
+		},
+		{
+			name:         "restore external snapshot job ID",
+			path:         versionalV2(SnapshotJobCategory, RestoreExternalAction),
+			body:         `{"targetCollectionName":"restored_books","snapshotMetadataURI":"s3://bucket/snapshot.json"}`,
+			responsePath: "data.jobId",
+			setup: func(proxy *mocks.MockProxy) {
+				proxy.EXPECT().RestoreExternalSnapshot(mock.Anything, mock.Anything).Return(&milvuspb.RestoreExternalSnapshotResponse{
+					Status: merr.Success(),
+					JobId:  largeInt64,
+				}, nil).Once()
+			},
+		},
+		{
+			name:         "describe restore job ID",
+			path:         versionalV2(SnapshotJobCategory, DescribeAction),
+			body:         `{"jobId":"9007199254740993"}`,
+			responsePath: "data.jobId",
+			setup: func(proxy *mocks.MockProxy) {
+				proxy.EXPECT().GetRestoreSnapshotState(mock.Anything, mock.Anything).Return(&milvuspb.GetRestoreSnapshotStateResponse{
+					Status: merr.Success(),
+					Info:   &milvuspb.RestoreSnapshotInfo{JobId: largeInt64},
+				}, nil).Once()
+			},
+		},
+		{
+			name:         "list restore job ID",
+			path:         versionalV2(SnapshotJobCategory, ListAction),
+			body:         `{}`,
+			responsePath: "data.records.0.jobId",
+			setup: func(proxy *mocks.MockProxy) {
+				proxy.EXPECT().ListRestoreSnapshotJobs(mock.Anything, mock.Anything).Return(&milvuspb.ListRestoreSnapshotJobsResponse{
+					Status: merr.Success(),
+					Jobs:   []*milvuspb.RestoreSnapshotInfo{{JobId: largeInt64}},
+				}, nil).Once()
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		for _, allowInt64 := range []bool{false, true} {
+			name := fmt.Sprintf("%s/allow_int64_%t", testCase.name, allowInt64)
+			t.Run(name, func(t *testing.T) {
+				proxy := mocks.NewMockProxy(t)
+				testCase.setup(proxy)
+				server := initHTTPServerV2(proxy, false)
+
+				req := httptest.NewRequest(http.MethodPost, testCase.path, bytes.NewBufferString(testCase.body))
+				req.Header.Set(HTTPHeaderAllowInt64, fmt.Sprintf("%t", allowInt64))
+				recorder := httptest.NewRecorder()
+				server.ServeHTTP(recorder, req)
+
+				require.Equal(t, http.StatusOK, recorder.Code)
+				expectedRaw := `"9007199254740993"`
+				if allowInt64 {
+					expectedRaw = "9007199254740993"
+				}
+				assert.Equal(t, expectedRaw, gjson.Get(recorder.Body.String(), testCase.responsePath).Raw)
+			})
+		}
+	}
+}
+
 func TestRestoreSnapshotRESTV2(t *testing.T) {
 	paramtable.Init()
 	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
@@ -3228,14 +3339,14 @@ func TestPinSnapshotDataRESTV2(t *testing.T) {
 	assert.Equal(t, int64(3600), proxy.pinSnapshotDataReq.GetTtlSeconds())
 
 	req = httptest.NewRequest(http.MethodPost, versionalV2(SnapshotCategory, UnpinAction), bytes.NewReader([]byte(`{
-		"pinId": 300
+		"pinId": "9007199254740993"
 	}`)))
 	w = httptest.NewRecorder()
 	testEngine.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, int64(0), gjson.Get(w.Body.String(), "code").Int())
-	assert.Equal(t, int64(300), proxy.unpinSnapshotDataReq.GetPinId())
+	assert.Equal(t, int64(9007199254740993), proxy.unpinSnapshotDataReq.GetPinId())
 }
 
 func TestSnapshotRESTV2Validation(t *testing.T) {
@@ -3271,7 +3382,17 @@ func TestSnapshotRESTV2Validation(t *testing.T) {
 		{
 			name:   "invalid pin ID",
 			action: UnpinAction,
-			body:   `{"pinId":0}`,
+			body:   `{"pinId":"0"}`,
+		},
+		{
+			name:   "malformed pin ID",
+			action: UnpinAction,
+			body:   `{"pinId":"not-an-int64"}`,
+		},
+		{
+			name:   "numeric pin ID",
+			action: UnpinAction,
+			body:   `{"pinId":300}`,
 		},
 	}
 
@@ -3309,7 +3430,7 @@ func TestRestoreExternalSnapshotRESTV2(t *testing.T) {
 	assert.Equal(t, "restored_books", proxy.restoreReq.GetTargetCollectionName())
 	assert.Equal(t, "s3://bucket/files/snapshots/meta.json", proxy.restoreReq.GetSnapshotMetadataUri())
 	assert.Equal(t, `{"extfs":{"cloud_provider":"aws","region":"us-west-2","use_iam":"true"}}`, proxy.restoreReq.GetExternalSpec())
-	assert.Contains(t, w.Body.String(), `"jobId":2001`)
+	assert.Contains(t, w.Body.String(), `"jobId":"2001"`)
 }
 
 func TestExportSnapshotRESTV2(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -3254,6 +3254,11 @@ func TestSnapshotRESTV2Validation(t *testing.T) {
 			body:   `{"collectionName":"source_books"}`,
 		},
 		{
+			name:   "missing collection name for list",
+			action: ListAction,
+			body:   `{}`,
+		},
+		{
 			name:   "negative compaction protection",
 			action: CreateAction,
 			body:   `{"collectionName":"source_books","snapshotName":"snapshot_1","compactionProtectionSeconds":-1}`,

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -2915,6 +2915,11 @@ func TestSnapshotRESTV2Validation(t *testing.T) {
 			body:   `{"collectionName":"source_books"}`,
 		},
 		{
+			name:   "missing collection name for list",
+			action: ListAction,
+			body:   `{}`,
+		},
+		{
 			name:   "negative compaction protection",
 			action: CreateAction,
 			body:   `{"collectionName":"source_books","snapshotName":"snapshot_1","compactionProtectionSeconds":-1}`,

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/tidwall/gjson"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -2705,6 +2706,10 @@ type externalCollectionRESTProxy struct {
 	getExportSnapshotStateReq  *milvuspb.GetExportSnapshotStateRequest
 	getRestoreSnapshotStateReq *milvuspb.GetRestoreSnapshotStateRequest
 	listRestoreSnapshotJobsReq *milvuspb.ListRestoreSnapshotJobsRequest
+	createSnapshotReq          *milvuspb.CreateSnapshotRequest
+	dropSnapshotReq            *milvuspb.DropSnapshotRequest
+	listSnapshotsReq           *milvuspb.ListSnapshotsRequest
+	describeSnapshotReq        *milvuspb.DescribeSnapshotRequest
 }
 
 func (m *externalCollectionRESTProxy) CreateCollection(ctx context.Context, request *milvuspb.CreateCollectionRequest) (*commonpb.Status, error) {
@@ -2844,6 +2849,37 @@ func (m *externalCollectionRESTProxy) ListRestoreSnapshotJobs(ctx context.Contex
 			State:          milvuspb.RestoreSnapshotState_RestoreSnapshotPending,
 			Progress:       10,
 		}},
+	}, nil
+}
+
+func (m *externalCollectionRESTProxy) CreateSnapshot(ctx context.Context, request *milvuspb.CreateSnapshotRequest) (*commonpb.Status, error) {
+	m.createSnapshotReq = request
+	return merr.Success(), nil
+}
+
+func (m *externalCollectionRESTProxy) DropSnapshot(ctx context.Context, request *milvuspb.DropSnapshotRequest) (*commonpb.Status, error) {
+	m.dropSnapshotReq = request
+	return merr.Success(), nil
+}
+
+func (m *externalCollectionRESTProxy) ListSnapshots(ctx context.Context, request *milvuspb.ListSnapshotsRequest) (*milvuspb.ListSnapshotsResponse, error) {
+	m.listSnapshotsReq = request
+	return &milvuspb.ListSnapshotsResponse{
+		Status:    merr.Success(),
+		Snapshots: []string{"snapshot_1", "snapshot_2"},
+	}, nil
+}
+
+func (m *externalCollectionRESTProxy) DescribeSnapshot(ctx context.Context, request *milvuspb.DescribeSnapshotRequest) (*milvuspb.DescribeSnapshotResponse, error) {
+	m.describeSnapshotReq = request
+	return &milvuspb.DescribeSnapshotResponse{
+		Status:         merr.Success(),
+		Name:           request.GetName(),
+		Description:    "daily backup",
+		CollectionName: request.GetCollectionName(),
+		PartitionNames: []string{"_default"},
+		CreateTs:       100,
+		S3Location:     "s3://bucket/snapshot_1",
 	}, nil
 }
 
@@ -3038,6 +3074,79 @@ func TestExternalCollectionJobRoutesRESTV2(t *testing.T) {
 	assert.Equal(t, "external_books", proxy.listReq.GetCollectionName())
 	assert.Contains(t, w.Body.String(), `"state":"RefreshCompleted"`)
 	assert.Contains(t, w.Body.String(), `"externalSpec":"{\"format\":\"parquet\"}"`)
+}
+
+func TestSnapshotCRUDRESTV2(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	proxy := &externalCollectionRESTProxy{}
+	testEngine := initHTTPServerV2(proxy, false)
+
+	req := httptest.NewRequest(http.MethodPost, versionalV2(SnapshotCategory, CreateAction), bytes.NewReader([]byte(`{
+		"dbName": "default",
+		"collectionName": "source_books",
+		"snapshotName": "snapshot_1",
+		"description": "daily backup",
+		"compactionProtectionSeconds": 3600
+	}`)))
+	w := httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int64(0), gjson.Get(w.Body.String(), "code").Int())
+	assert.Equal(t, "default", proxy.createSnapshotReq.GetDbName())
+	assert.Equal(t, "source_books", proxy.createSnapshotReq.GetCollectionName())
+	assert.Equal(t, "snapshot_1", proxy.createSnapshotReq.GetName())
+	assert.Equal(t, "daily backup", proxy.createSnapshotReq.GetDescription())
+	assert.Equal(t, int64(3600), proxy.createSnapshotReq.GetCompactionProtectionSeconds())
+
+	req = httptest.NewRequest(http.MethodPost, versionalV2(SnapshotCategory, ListAction), bytes.NewReader([]byte(`{
+		"dbName": "default",
+		"collectionName": "source_books"
+	}`)))
+	w = httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "default", proxy.listSnapshotsReq.GetDbName())
+	assert.Equal(t, "source_books", proxy.listSnapshotsReq.GetCollectionName())
+	assert.Equal(t, "snapshot_1", gjson.Get(w.Body.String(), "data.0").String())
+	assert.Equal(t, "snapshot_2", gjson.Get(w.Body.String(), "data.1").String())
+
+	req = httptest.NewRequest(http.MethodPost, versionalV2(SnapshotCategory, DescribeAction), bytes.NewReader([]byte(`{
+		"dbName": "default",
+		"collectionName": "source_books",
+		"snapshotName": "snapshot_1"
+	}`)))
+	w = httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "default", proxy.describeSnapshotReq.GetDbName())
+	assert.Equal(t, "source_books", proxy.describeSnapshotReq.GetCollectionName())
+	assert.Equal(t, "snapshot_1", proxy.describeSnapshotReq.GetName())
+	assert.Equal(t, "snapshot_1", gjson.Get(w.Body.String(), "data.snapshotName").String())
+	assert.Equal(t, "daily backup", gjson.Get(w.Body.String(), "data.description").String())
+	assert.Equal(t, "source_books", gjson.Get(w.Body.String(), "data.collectionName").String())
+	assert.Equal(t, "_default", gjson.Get(w.Body.String(), "data.partitionNames.0").String())
+	assert.Equal(t, int64(100), gjson.Get(w.Body.String(), "data.createTs").Int())
+	assert.Equal(t, "s3://bucket/snapshot_1", gjson.Get(w.Body.String(), "data.s3Location").String())
+
+	req = httptest.NewRequest(http.MethodPost, versionalV2(SnapshotCategory, DropAction), bytes.NewReader([]byte(`{
+		"dbName": "default",
+		"collectionName": "source_books",
+		"snapshotName": "snapshot_1"
+	}`)))
+	w = httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int64(0), gjson.Get(w.Body.String(), "code").Int())
+	assert.Equal(t, "default", proxy.dropSnapshotReq.GetDbName())
+	assert.Equal(t, "source_books", proxy.dropSnapshotReq.GetCollectionName())
+	assert.Equal(t, "snapshot_1", proxy.dropSnapshotReq.GetName())
 }
 
 func TestRestoreExternalSnapshotRESTV2(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -379,6 +379,28 @@ type JobIDReq struct {
 
 func (req *JobIDReq) GetJobID() string { return req.JobID }
 
+type CreateSnapshotReq struct {
+	DbName                      string `json:"dbName"`
+	CollectionName              string `json:"collectionName" binding:"required"`
+	SnapshotName                string `json:"snapshotName" binding:"required"`
+	Description                 string `json:"description"`
+	CompactionProtectionSeconds int64  `json:"compactionProtectionSeconds" binding:"gte=0"`
+}
+
+func (req *CreateSnapshotReq) GetDbName() string { return req.DbName }
+
+func (req *CreateSnapshotReq) GetCollectionName() string { return req.CollectionName }
+
+type SnapshotReq struct {
+	DbName         string `json:"dbName"`
+	CollectionName string `json:"collectionName" binding:"required"`
+	SnapshotName   string `json:"snapshotName" binding:"required"`
+}
+
+func (req *SnapshotReq) GetDbName() string { return req.DbName }
+
+func (req *SnapshotReq) GetCollectionName() string { return req.CollectionName }
+
 type RestoreExternalSnapshotReq struct {
 	DbName               string `json:"dbName"`
 	TargetCollectionName string `json:"targetCollectionName" binding:"required"`

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -413,6 +413,21 @@ func (req *RestoreSnapshotReq) GetDbName() string { return req.SourceDbName }
 
 func (req *RestoreSnapshotReq) GetCollectionName() string { return req.SourceCollectionName }
 
+type PinSnapshotDataReq struct {
+	DbName         string `json:"dbName"`
+	CollectionName string `json:"collectionName" binding:"required"`
+	SnapshotName   string `json:"snapshotName" binding:"required"`
+	TTLSeconds     int64  `json:"ttlSeconds" binding:"gte=0"`
+}
+
+func (req *PinSnapshotDataReq) GetDbName() string { return req.DbName }
+
+func (req *PinSnapshotDataReq) GetCollectionName() string { return req.CollectionName }
+
+type UnpinSnapshotDataReq struct {
+	PinID int64 `json:"pinId" binding:"required,gt=0"`
+}
+
 type RestoreExternalSnapshotReq struct {
 	DbName               string `json:"dbName"`
 	TargetCollectionName string `json:"targetCollectionName" binding:"required"`

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -425,7 +425,7 @@ func (req *PinSnapshotDataReq) GetDbName() string { return req.DbName }
 func (req *PinSnapshotDataReq) GetCollectionName() string { return req.CollectionName }
 
 type UnpinSnapshotDataReq struct {
-	PinID int64 `json:"pinId" binding:"required,gt=0"`
+	PinID string `json:"pinId" binding:"required"`
 }
 
 type RestoreExternalSnapshotReq struct {

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -401,6 +401,18 @@ func (req *SnapshotReq) GetDbName() string { return req.DbName }
 
 func (req *SnapshotReq) GetCollectionName() string { return req.CollectionName }
 
+type RestoreSnapshotReq struct {
+	SourceDbName         string `json:"sourceDbName"`
+	SourceCollectionName string `json:"sourceCollectionName" binding:"required"`
+	TargetDbName         string `json:"targetDbName"`
+	TargetCollectionName string `json:"targetCollectionName" binding:"required"`
+	SnapshotName         string `json:"snapshotName" binding:"required"`
+}
+
+func (req *RestoreSnapshotReq) GetDbName() string { return req.SourceDbName }
+
+func (req *RestoreSnapshotReq) GetCollectionName() string { return req.SourceCollectionName }
+
 type RestoreExternalSnapshotReq struct {
 	DbName               string `json:"dbName"`
 	TargetCollectionName string `json:"targetCollectionName" binding:"required"`

--- a/internal/distributed/proxy/httpserver/snapshot_handler_v2.go
+++ b/internal/distributed/proxy/httpserver/snapshot_handler_v2.go
@@ -134,3 +134,43 @@ func (h *HandlersV2) restoreSnapshot(ctx context.Context, c *gin.Context, anyReq
 	}
 	return resp, err
 }
+
+func (h *HandlersV2) pinSnapshotData(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
+	httpReq := anyReq.(*PinSnapshotDataReq)
+	req := &milvuspb.PinSnapshotDataRequest{
+		Name:           httpReq.SnapshotName,
+		DbName:         dbName,
+		CollectionName: httpReq.CollectionName,
+		TtlSeconds:     httpReq.TTLSeconds,
+	}
+	c.Set(ContextRequest, req)
+
+	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/PinSnapshotData", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+		return h.proxy.PinSnapshotData(reqCtx, req.(*milvuspb.PinSnapshotDataRequest))
+	})
+	if err == nil {
+		HTTPReturn(c, http.StatusOK, gin.H{
+			HTTPReturnCode: merr.Code(nil),
+			HTTPReturnData: gin.H{
+				"pinId": resp.(*milvuspb.PinSnapshotDataResponse).GetPinId(),
+			},
+		})
+	}
+	return resp, err
+}
+
+func (h *HandlersV2) unpinSnapshotData(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
+	httpReq := anyReq.(*UnpinSnapshotDataReq)
+	req := &milvuspb.UnpinSnapshotDataRequest{
+		PinId: httpReq.PinID,
+	}
+	c.Set(ContextRequest, req)
+
+	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/UnpinSnapshotData", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+		return h.proxy.UnpinSnapshotData(reqCtx, req.(*milvuspb.UnpinSnapshotDataRequest))
+	})
+	if err == nil {
+		HTTPReturn(c, http.StatusOK, wrapperReturnDefault())
+	}
+	return resp, err
+}

--- a/internal/distributed/proxy/httpserver/snapshot_handler_v2.go
+++ b/internal/distributed/proxy/httpserver/snapshot_handler_v2.go
@@ -116,7 +116,10 @@ func (h *HandlersV2) restoreSnapshot(ctx context.Context, c *gin.Context, anyReq
 	httpReq := anyReq.(*RestoreSnapshotReq)
 	targetDBName := httpReq.TargetDbName
 	if targetDBName == "" {
-		targetDBName = dbName
+		targetDBName = c.Request.Header.Get(HTTPHeaderDBName)
+		if targetDBName == "" {
+			targetDBName = DefaultDbName
+		}
 	}
 	req := &milvuspb.RestoreSnapshotRequest{
 		Name:                 httpReq.SnapshotName,

--- a/internal/distributed/proxy/httpserver/snapshot_handler_v2.go
+++ b/internal/distributed/proxy/httpserver/snapshot_handler_v2.go
@@ -65,7 +65,7 @@ func (h *HandlersV2) dropSnapshot(ctx context.Context, c *gin.Context, anyReq an
 }
 
 func (h *HandlersV2) listSnapshots(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
-	httpReq := anyReq.(*OptionalCollectionNameReq)
+	httpReq := anyReq.(*CollectionNameReq)
 	req := &milvuspb.ListSnapshotsRequest{
 		DbName:         dbName,
 		CollectionName: httpReq.CollectionName,

--- a/internal/distributed/proxy/httpserver/snapshot_handler_v2.go
+++ b/internal/distributed/proxy/httpserver/snapshot_handler_v2.go
@@ -109,3 +109,28 @@ func (h *HandlersV2) describeSnapshot(ctx context.Context, c *gin.Context, anyRe
 	}
 	return resp, err
 }
+
+func (h *HandlersV2) restoreSnapshot(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
+	httpReq := anyReq.(*RestoreSnapshotReq)
+	req := &milvuspb.RestoreSnapshotRequest{
+		Name:                 httpReq.SnapshotName,
+		DbName:               dbName,
+		CollectionName:       httpReq.SourceCollectionName,
+		TargetDbName:         httpReq.TargetDbName,
+		TargetCollectionName: httpReq.TargetCollectionName,
+	}
+	c.Set(ContextRequest, req)
+
+	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/RestoreSnapshot", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+		return h.proxy.RestoreSnapshot(reqCtx, req.(*milvuspb.RestoreSnapshotRequest))
+	})
+	if err == nil {
+		HTTPReturn(c, http.StatusOK, gin.H{
+			HTTPReturnCode: merr.Code(nil),
+			HTTPReturnData: gin.H{
+				"jobId": resp.(*milvuspb.RestoreSnapshotResponse).GetJobId(),
+			},
+		})
+	}
+	return resp, err
+}

--- a/internal/distributed/proxy/httpserver/snapshot_handler_v2.go
+++ b/internal/distributed/proxy/httpserver/snapshot_handler_v2.go
@@ -114,11 +114,15 @@ func (h *HandlersV2) describeSnapshot(ctx context.Context, c *gin.Context, anyRe
 
 func (h *HandlersV2) restoreSnapshot(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
 	httpReq := anyReq.(*RestoreSnapshotReq)
+	targetDBName := httpReq.TargetDbName
+	if targetDBName == "" {
+		targetDBName = dbName
+	}
 	req := &milvuspb.RestoreSnapshotRequest{
 		Name:                 httpReq.SnapshotName,
 		DbName:               dbName,
 		CollectionName:       httpReq.SourceCollectionName,
-		TargetDbName:         httpReq.TargetDbName,
+		TargetDbName:         targetDBName,
 		TargetCollectionName: httpReq.TargetCollectionName,
 	}
 	c.Set(ContextRequest, req)

--- a/internal/distributed/proxy/httpserver/snapshot_handler_v2.go
+++ b/internal/distributed/proxy/httpserver/snapshot_handler_v2.go
@@ -19,6 +19,7 @@ package httpserver
 import (
 	"context"
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 
@@ -95,6 +96,7 @@ func (h *HandlersV2) describeSnapshot(ctx context.Context, c *gin.Context, anyRe
 	})
 	if err == nil {
 		snapshot := resp.(*milvuspb.DescribeSnapshotResponse)
+		allowInt64, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
 		HTTPReturn(c, http.StatusOK, gin.H{
 			HTTPReturnCode: merr.Code(nil),
 			HTTPReturnData: gin.H{
@@ -102,7 +104,7 @@ func (h *HandlersV2) describeSnapshot(ctx context.Context, c *gin.Context, anyRe
 				"description":    snapshot.GetDescription(),
 				"collectionName": snapshot.GetCollectionName(),
 				"partitionNames": snapshot.GetPartitionNames(),
-				"createTs":       snapshot.GetCreateTs(),
+				"createTs":       formatRESTInt64(snapshot.GetCreateTs(), allowInt64),
 				"s3Location":     snapshot.GetS3Location(),
 			},
 		})
@@ -125,10 +127,11 @@ func (h *HandlersV2) restoreSnapshot(ctx context.Context, c *gin.Context, anyReq
 		return h.proxy.RestoreSnapshot(reqCtx, req.(*milvuspb.RestoreSnapshotRequest))
 	})
 	if err == nil {
+		allowInt64, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
 		HTTPReturn(c, http.StatusOK, gin.H{
 			HTTPReturnCode: merr.Code(nil),
 			HTTPReturnData: gin.H{
-				"jobId": resp.(*milvuspb.RestoreSnapshotResponse).GetJobId(),
+				"jobId": formatRESTInt64(resp.(*milvuspb.RestoreSnapshotResponse).GetJobId(), allowInt64),
 			},
 		})
 	}
@@ -149,10 +152,11 @@ func (h *HandlersV2) pinSnapshotData(ctx context.Context, c *gin.Context, anyReq
 		return h.proxy.PinSnapshotData(reqCtx, req.(*milvuspb.PinSnapshotDataRequest))
 	})
 	if err == nil {
+		allowInt64, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
 		HTTPReturn(c, http.StatusOK, gin.H{
 			HTTPReturnCode: merr.Code(nil),
 			HTTPReturnData: gin.H{
-				"pinId": resp.(*milvuspb.PinSnapshotDataResponse).GetPinId(),
+				"pinId": formatRESTInt64(resp.(*milvuspb.PinSnapshotDataResponse).GetPinId(), allowInt64),
 			},
 		})
 	}
@@ -161,8 +165,14 @@ func (h *HandlersV2) pinSnapshotData(ctx context.Context, c *gin.Context, anyReq
 
 func (h *HandlersV2) unpinSnapshotData(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
 	httpReq := anyReq.(*UnpinSnapshotDataReq)
+	pinID, err := strconv.ParseInt(httpReq.PinID, 10, 64)
+	if err != nil || pinID <= 0 {
+		paramErr := merr.WrapErrParameterInvalidMsg("pinId must be a positive decimal int64, got %q", httpReq.PinID)
+		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(paramErr), HTTPReturnMessage: paramErr.Error()})
+		return nil, paramErr
+	}
 	req := &milvuspb.UnpinSnapshotDataRequest{
-		PinId: httpReq.PinID,
+		PinId: pinID,
 	}
 	c.Set(ContextRequest, req)
 

--- a/internal/distributed/proxy/httpserver/snapshot_handler_v2.go
+++ b/internal/distributed/proxy/httpserver/snapshot_handler_v2.go
@@ -38,7 +38,7 @@ func (h *HandlersV2) createSnapshot(ctx context.Context, c *gin.Context, anyReq 
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreateSnapshot", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreateSnapshot", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.CreateSnapshot(reqCtx, req.(*milvuspb.CreateSnapshotRequest))
 	})
 	if err == nil {
@@ -56,7 +56,7 @@ func (h *HandlersV2) dropSnapshot(ctx context.Context, c *gin.Context, anyReq an
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DropSnapshot", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DropSnapshot", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.DropSnapshot(reqCtx, req.(*milvuspb.DropSnapshotRequest))
 	})
 	if err == nil {
@@ -73,7 +73,7 @@ func (h *HandlersV2) listSnapshots(ctx context.Context, c *gin.Context, anyReq a
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ListSnapshots", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ListSnapshots", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.ListSnapshots(reqCtx, req.(*milvuspb.ListSnapshotsRequest))
 	})
 	if err == nil {
@@ -91,7 +91,7 @@ func (h *HandlersV2) describeSnapshot(ctx context.Context, c *gin.Context, anyRe
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DescribeSnapshot", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DescribeSnapshot", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.DescribeSnapshot(reqCtx, req.(*milvuspb.DescribeSnapshotRequest))
 	})
 	if err == nil {
@@ -130,7 +130,7 @@ func (h *HandlersV2) restoreSnapshot(ctx context.Context, c *gin.Context, anyReq
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/RestoreSnapshot", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/RestoreSnapshot", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.RestoreSnapshot(reqCtx, req.(*milvuspb.RestoreSnapshotRequest))
 	})
 	if err == nil {
@@ -155,7 +155,7 @@ func (h *HandlersV2) pinSnapshotData(ctx context.Context, c *gin.Context, anyReq
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/PinSnapshotData", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/PinSnapshotData", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.PinSnapshotData(reqCtx, req.(*milvuspb.PinSnapshotDataRequest))
 	})
 	if err == nil {
@@ -183,7 +183,7 @@ func (h *HandlersV2) unpinSnapshotData(ctx context.Context, c *gin.Context, anyR
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/UnpinSnapshotData", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/UnpinSnapshotData", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.UnpinSnapshotData(reqCtx, req.(*milvuspb.UnpinSnapshotDataRequest))
 	})
 	if err == nil {

--- a/internal/distributed/proxy/httpserver/snapshot_handler_v2.go
+++ b/internal/distributed/proxy/httpserver/snapshot_handler_v2.go
@@ -1,0 +1,111 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+func (h *HandlersV2) createSnapshot(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
+	httpReq := anyReq.(*CreateSnapshotReq)
+	req := &milvuspb.CreateSnapshotRequest{
+		DbName:                      dbName,
+		CollectionName:              httpReq.CollectionName,
+		Name:                        httpReq.SnapshotName,
+		Description:                 httpReq.Description,
+		CompactionProtectionSeconds: httpReq.CompactionProtectionSeconds,
+	}
+	c.Set(ContextRequest, req)
+
+	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreateSnapshot", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+		return h.proxy.CreateSnapshot(reqCtx, req.(*milvuspb.CreateSnapshotRequest))
+	})
+	if err == nil {
+		HTTPReturn(c, http.StatusOK, wrapperReturnDefault())
+	}
+	return resp, err
+}
+
+func (h *HandlersV2) dropSnapshot(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
+	httpReq := anyReq.(*SnapshotReq)
+	req := &milvuspb.DropSnapshotRequest{
+		DbName:         dbName,
+		CollectionName: httpReq.CollectionName,
+		Name:           httpReq.SnapshotName,
+	}
+	c.Set(ContextRequest, req)
+
+	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DropSnapshot", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+		return h.proxy.DropSnapshot(reqCtx, req.(*milvuspb.DropSnapshotRequest))
+	})
+	if err == nil {
+		HTTPReturn(c, http.StatusOK, wrapperReturnDefault())
+	}
+	return resp, err
+}
+
+func (h *HandlersV2) listSnapshots(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
+	httpReq := anyReq.(*OptionalCollectionNameReq)
+	req := &milvuspb.ListSnapshotsRequest{
+		DbName:         dbName,
+		CollectionName: httpReq.CollectionName,
+	}
+	c.Set(ContextRequest, req)
+
+	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ListSnapshots", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+		return h.proxy.ListSnapshots(reqCtx, req.(*milvuspb.ListSnapshotsRequest))
+	})
+	if err == nil {
+		HTTPReturn(c, http.StatusOK, wrapperReturnList(resp.(*milvuspb.ListSnapshotsResponse).GetSnapshots()))
+	}
+	return resp, err
+}
+
+func (h *HandlersV2) describeSnapshot(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
+	httpReq := anyReq.(*SnapshotReq)
+	req := &milvuspb.DescribeSnapshotRequest{
+		DbName:         dbName,
+		CollectionName: httpReq.CollectionName,
+		Name:           httpReq.SnapshotName,
+	}
+	c.Set(ContextRequest, req)
+
+	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DescribeSnapshot", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+		return h.proxy.DescribeSnapshot(reqCtx, req.(*milvuspb.DescribeSnapshotRequest))
+	})
+	if err == nil {
+		snapshot := resp.(*milvuspb.DescribeSnapshotResponse)
+		HTTPReturn(c, http.StatusOK, gin.H{
+			HTTPReturnCode: merr.Code(nil),
+			HTTPReturnData: gin.H{
+				"snapshotName":   snapshot.GetName(),
+				"description":    snapshot.GetDescription(),
+				"collectionName": snapshot.GetCollectionName(),
+				"partitionNames": snapshot.GetPartitionNames(),
+				"createTs":       snapshot.GetCreateTs(),
+				"s3Location":     snapshot.GetS3Location(),
+			},
+		})
+	}
+	return resp, err
+}

--- a/internal/proxy/database_interceptor.go
+++ b/internal/proxy/database_interceptor.go
@@ -358,6 +358,9 @@ func fillDatabase(ctx context.Context, req interface{}) (context.Context, interf
 		if r.DbName == "" {
 			r.DbName = GetCurDBNameFromContextOrDefault(ctx)
 		}
+		if r.TargetDbName == "" {
+			r.TargetDbName = r.DbName
+		}
 		return ctx, r
 	case *milvuspb.RestoreExternalSnapshotRequest:
 		if r.DbName == "" {

--- a/internal/proxy/database_interceptor.go
+++ b/internal/proxy/database_interceptor.go
@@ -355,11 +355,12 @@ func fillDatabase(ctx context.Context, req interface{}) (context.Context, interf
 		}
 		return ctx, r
 	case *milvuspb.RestoreSnapshotRequest:
+		activeDBName := GetCurDBNameFromContextOrDefault(ctx)
 		if r.DbName == "" {
-			r.DbName = GetCurDBNameFromContextOrDefault(ctx)
+			r.DbName = activeDBName
 		}
 		if r.TargetDbName == "" {
-			r.TargetDbName = r.DbName
+			r.TargetDbName = activeDBName
 		}
 		return ctx, r
 	case *milvuspb.RestoreExternalSnapshotRequest:

--- a/internal/proxy/database_interceptor_test.go
+++ b/internal/proxy/database_interceptor_test.go
@@ -63,6 +63,55 @@ func TestDatabaseInterceptor(t *testing.T) {
 		assert.Equal(t, "db-from-header", req.GetDbName())
 	})
 
+	t.Run("restore snapshot defaults target database to source database", func(t *testing.T) {
+		testCases := []struct {
+			name           string
+			dbName         string
+			targetDBName   string
+			metadataDBName string
+			expectedDBName string
+			expectedTarget string
+		}{
+			{
+				name:           "explicit source database",
+				dbName:         "source_db",
+				expectedDBName: "source_db",
+				expectedTarget: "source_db",
+			},
+			{
+				name:           "source database from metadata",
+				metadataDBName: "tenant_a",
+				expectedDBName: "tenant_a",
+				expectedTarget: "tenant_a",
+			},
+			{
+				name:           "explicit target database is preserved",
+				dbName:         "source_db",
+				targetDBName:   "target_db",
+				expectedDBName: "source_db",
+				expectedTarget: "target_db",
+			},
+		}
+
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				ctx := context.Background()
+				if testCase.metadataDBName != "" {
+					ctx = metadata.NewIncomingContext(ctx, metadata.Pairs(util.HeaderDBName, testCase.metadataDBName))
+				}
+				req := &milvuspb.RestoreSnapshotRequest{
+					DbName:       testCase.dbName,
+					TargetDbName: testCase.targetDBName,
+				}
+
+				_, err := interceptor(ctx, req, &grpc.UnaryServerInfo{}, handler)
+				assert.NoError(t, err)
+				assert.Equal(t, testCase.expectedDBName, req.GetDbName())
+				assert.Equal(t, testCase.expectedTarget, req.GetTargetDbName())
+			})
+		}
+	})
+
 	t.Run("external snapshot requests get db from metadata", func(t *testing.T) {
 		md := metadata.Pairs(util.HeaderDBName, "db")
 		ctx := metadata.NewIncomingContext(context.Background(), md)

--- a/internal/proxy/database_interceptor_test.go
+++ b/internal/proxy/database_interceptor_test.go
@@ -63,7 +63,7 @@ func TestDatabaseInterceptor(t *testing.T) {
 		assert.Equal(t, "db-from-header", req.GetDbName())
 	})
 
-	t.Run("restore snapshot defaults target database to source database", func(t *testing.T) {
+	t.Run("restore snapshot defaults databases independently from active database", func(t *testing.T) {
 		testCases := []struct {
 			name           string
 			dbName         string
@@ -76,7 +76,14 @@ func TestDatabaseInterceptor(t *testing.T) {
 				name:           "explicit source database",
 				dbName:         "source_db",
 				expectedDBName: "source_db",
-				expectedTarget: "source_db",
+				expectedTarget: util.DefaultDBName,
+			},
+			{
+				name:           "explicit source database with different active database",
+				dbName:         "archive",
+				metadataDBName: "tenant_a",
+				expectedDBName: "archive",
+				expectedTarget: "tenant_a",
 			},
 			{
 				name:           "source database from metadata",

--- a/internal/proxy/privilege_interceptor.go
+++ b/internal/proxy/privilege_interceptor.go
@@ -88,9 +88,12 @@ func PrivilegeInterceptorWithMetaCache(getMetaCache func() Cache) PrivilegeFunc 
 		objectNameIndex := privilegeExt.ObjectNameIndex
 		objectName := funcutil.GetObjectName(req, objectNameIndex)
 		objectPrivilege := privilegeExt.ObjectPrivilege.String()
-		// Authorize against the db the request actually operates on, resolved by
-		// privilege level (mirrors the grant-side validation; see
-		// milvus-io/milvus#50678):
+		// Resolve resources against the database the request actually reads from,
+		// while keeping the database used by the policy check separate. Alias
+		// resolution must remain database-scoped even when a cross-database
+		// operation requires a cluster-scoped policy (db="*").
+		//
+		// Policy scope mirrors the grant-side validation (see milvus-io/milvus#50678):
 		//   - Cluster-level privileges (CreateDatabase/ResourceGroup/...) are not
 		//     scoped to a database, so authorize them globally (AnyWord),
 		//     independent of the connection namespace.
@@ -98,14 +101,15 @@ func PrivilegeInterceptorWithMetaCache(getMetaCache func() Cache) PrivilegeFunc 
 		//     targets: the request-body DbName takes precedence, falling back to the
 		//     connection-context db.
 		dbName := GetCurDBNameFromRequestOrContext(ctx, req)
+		policyDBName := dbName
 		if util.GetPrivilegeLevel(util.MetaStore2API(objectPrivilege)) == milvuspb.PrivilegeLevel_Cluster.String() {
-			dbName = util.AnyWord
+			policyDBName = util.AnyWord
 		}
 		// RenameCollection is a database-admin privilege: a same-db rename is
 		// authorized against the target db (database level, handled above), while a
 		// cross-db rename additionally requires a cluster-scoped (global) grant.
 		if r, ok := req.(*milvuspb.RenameCollectionRequest); ok && r.GetDbName() != r.GetNewDBName() {
-			dbName = util.AnyWord
+			policyDBName = util.AnyWord
 		}
 		// RestoreSnapshot is collection-scoped within one database. Restoring into
 		// another database creates a collection there, so require the same privilege
@@ -113,10 +117,10 @@ func PrivilegeInterceptorWithMetaCache(getMetaCache func() Cache) PrivilegeFunc 
 		if r, ok := req.(*milvuspb.RestoreSnapshotRequest); ok {
 			targetDBName := r.GetTargetDbName()
 			if targetDBName == "" {
-				targetDBName = dbName
+				targetDBName = GetCurDBNameFromContextOrDefault(ctx)
 			}
 			if dbName != targetDBName {
-				dbName = util.AnyWord
+				policyDBName = util.AnyWord
 			}
 		}
 
@@ -164,14 +168,14 @@ func PrivilegeInterceptorWithMetaCache(getMetaCache func() Cache) PrivilegeFunc 
 
 		log := mlog.With(mlog.String("username", username), mlog.Strings("role_names", roleNames),
 			mlog.String("object_type", objectType), mlog.String("object_privilege", objectPrivilege),
-			mlog.FieldDbName(dbName),
+			mlog.FieldDbName(policyDBName),
 			mlog.Int32("object_index", objectNameIndex), mlog.String("object_name", objectName),
 			mlog.Int32("object_indexs", objectNameIndexs), mlog.Strings("object_names", objectNames))
 
 		e := privilege.GetEnforcer()
 		for _, roleName := range roleNames {
 			permitFunc := func(objectName string) (bool, error) {
-				object := funcutil.PolicyForResource(dbName, objectType, objectName)
+				object := funcutil.PolicyForResource(policyDBName, objectType, objectName)
 				isPermit, cached, version := privilege.GetResultCache(roleName, object, objectPrivilege)
 				if cached {
 					return isPermit, nil
@@ -223,7 +227,7 @@ func PrivilegeInterceptorWithMetaCache(getMetaCache func() Cache) PrivilegeFunc 
 		}
 
 		return ctx, status.Error(codes.PermissionDenied,
-			fmt.Sprintf("%s: permission deny to %s in the `%s` database", objectPrivilege, username, dbName))
+			fmt.Sprintf("%s: permission deny to %s in the `%s` database", objectPrivilege, username, policyDBName))
 	}
 }
 

--- a/internal/proxy/privilege_interceptor.go
+++ b/internal/proxy/privilege_interceptor.go
@@ -107,6 +107,18 @@ func PrivilegeInterceptorWithMetaCache(getMetaCache func() Cache) PrivilegeFunc 
 		if r, ok := req.(*milvuspb.RenameCollectionRequest); ok && r.GetDbName() != r.GetNewDBName() {
 			dbName = util.AnyWord
 		}
+		// RestoreSnapshot is collection-scoped within one database. Restoring into
+		// another database creates a collection there, so require the same privilege
+		// at cluster scope (db="*") instead of authorizing only against the source.
+		if r, ok := req.(*milvuspb.RestoreSnapshotRequest); ok {
+			targetDBName := r.GetTargetDbName()
+			if targetDBName == "" {
+				targetDBName = dbName
+			}
+			if dbName != targetDBName {
+				dbName = util.AnyWord
+			}
+		}
 
 		// Resolve alias to actual collection name for RBAC checks
 		if Params.ProxyCfg.ResolveAliasForPrivilege.GetAsBool() && objectType == commonpb.ObjectType_Collection.String() && objectNameIndex != 0 {

--- a/internal/proxy/privilege_interceptor_test.go
+++ b/internal/proxy/privilege_interceptor_test.go
@@ -494,14 +494,12 @@ func TestPrivilegeInterceptorRestoreSnapshot(t *testing.T) {
 			},
 		}, nil
 	}
-	require.NoError(t, InitMetaCache(context.Background(), client))
-	cache := globalMetaCache.(*MetaCache)
-	payroll := seedCollection(cache, "tenant_a", "payroll", 100)
-	payroll.aliases = []string{"orders_alias"}
-	cache.setAliasLocked("tenant_a", "orders_alias", "payroll")
+	cache := mustInitMetaCacheForTest(context.Background(), client).(*MetaCache)
+	cache.SeedCollectionForTest("tenant_a", "payroll", 100, "orders_alias")
+	interceptor := PrivilegeInterceptorWithMetaCache(func() Cache { return cache })
 
 	t.Run("same database restore uses collection grant", func(t *testing.T) {
-		_, err := PrivilegeInterceptor(GetContext(context.Background(), "collection_admin:pwd"), &milvuspb.RestoreSnapshotRequest{
+		_, err := interceptor(GetContext(context.Background(), "collection_admin:pwd"), &milvuspb.RestoreSnapshotRequest{
 			DbName:         "tenant_a",
 			CollectionName: "orders",
 			TargetDbName:   "tenant_a",
@@ -510,7 +508,7 @@ func TestPrivilegeInterceptorRestoreSnapshot(t *testing.T) {
 	})
 
 	t.Run("omitted target database uses active database", func(t *testing.T) {
-		_, err := PrivilegeInterceptor(GetContextWithDB(context.Background(), "collection_admin:pwd", "tenant_a"), &milvuspb.RestoreSnapshotRequest{
+		_, err := interceptor(GetContextWithDB(context.Background(), "collection_admin:pwd", "tenant_a"), &milvuspb.RestoreSnapshotRequest{
 			DbName:         "tenant_a",
 			CollectionName: "orders",
 		})
@@ -518,7 +516,7 @@ func TestPrivilegeInterceptorRestoreSnapshot(t *testing.T) {
 	})
 
 	t.Run("omitted target database detects cross database restore", func(t *testing.T) {
-		_, err := PrivilegeInterceptor(GetContextWithDB(context.Background(), "collection_admin:pwd", "tenant_b"), &milvuspb.RestoreSnapshotRequest{
+		_, err := interceptor(GetContextWithDB(context.Background(), "collection_admin:pwd", "tenant_b"), &milvuspb.RestoreSnapshotRequest{
 			DbName:         "tenant_a",
 			CollectionName: "orders",
 		})
@@ -526,7 +524,7 @@ func TestPrivilegeInterceptorRestoreSnapshot(t *testing.T) {
 	})
 
 	t.Run("cross database restore rejects collection grant", func(t *testing.T) {
-		_, err := PrivilegeInterceptor(GetContext(context.Background(), "collection_admin:pwd"), &milvuspb.RestoreSnapshotRequest{
+		_, err := interceptor(GetContext(context.Background(), "collection_admin:pwd"), &milvuspb.RestoreSnapshotRequest{
 			DbName:         "tenant_a",
 			CollectionName: "orders",
 			TargetDbName:   "tenant_b",
@@ -535,7 +533,7 @@ func TestPrivilegeInterceptorRestoreSnapshot(t *testing.T) {
 	})
 
 	t.Run("cross database restore accepts cluster scoped grant", func(t *testing.T) {
-		_, err := PrivilegeInterceptor(GetContext(context.Background(), "cluster_admin:pwd"), &milvuspb.RestoreSnapshotRequest{
+		_, err := interceptor(GetContext(context.Background(), "cluster_admin:pwd"), &milvuspb.RestoreSnapshotRequest{
 			DbName:         "tenant_a",
 			CollectionName: "orders",
 			TargetDbName:   "tenant_b",
@@ -544,7 +542,7 @@ func TestPrivilegeInterceptorRestoreSnapshot(t *testing.T) {
 	})
 
 	t.Run("cross database restore resolves alias in source database", func(t *testing.T) {
-		_, err := PrivilegeInterceptor(GetContext(context.Background(), "cluster_admin:pwd"), &milvuspb.RestoreSnapshotRequest{
+		_, err := interceptor(GetContext(context.Background(), "cluster_admin:pwd"), &milvuspb.RestoreSnapshotRequest{
 			DbName:         "tenant_a",
 			CollectionName: "orders_alias",
 			TargetDbName:   "tenant_b",

--- a/internal/proxy/privilege_interceptor_test.go
+++ b/internal/proxy/privilege_interceptor_test.go
@@ -471,6 +471,66 @@ func TestPrivilegeInterceptorRenameCollection(t *testing.T) {
 	})
 }
 
+// TestPrivilegeInterceptorRestoreSnapshot covers restore authorization across
+// database boundaries. Same-database restore uses the collection-scoped grant,
+// while cross-database restore requires the same privilege at db="*" scope.
+func TestPrivilegeInterceptorRestoreSnapshot(t *testing.T) {
+	paramtable.Init()
+	Params.Save(Params.CommonCfg.AuthorizationEnabled.Key, "true")
+	defer Params.Reset(Params.CommonCfg.AuthorizationEnabled.Key)
+
+	client := &MockMixCoordClientInterface{}
+	client.listPolicy = func(ctx context.Context, in *internalpb.ListPolicyRequest) (*internalpb.ListPolicyResponse, error) {
+		return &internalpb.ListPolicyResponse{
+			Status: merr.Success(),
+			PolicyInfos: []string{
+				funcutil.PolicyForPrivilege("role_collection", commonpb.ObjectType_Collection.String(), "orders", commonpb.ObjectPrivilege_PrivilegeRestoreSnapshot.String(), "tenant_a"),
+				funcutil.PolicyForPrivilege("role_cluster", commonpb.ObjectType_Collection.String(), "orders", commonpb.ObjectPrivilege_PrivilegeRestoreSnapshot.String(), util.AnyWord),
+			},
+			UserRoles: []string{
+				funcutil.EncodeUserRoleCache("collection_admin", "role_collection"),
+				funcutil.EncodeUserRoleCache("cluster_admin", "role_cluster"),
+			},
+		}, nil
+	}
+	require.NoError(t, InitMetaCache(context.Background(), client))
+
+	t.Run("same database restore uses collection grant", func(t *testing.T) {
+		_, err := PrivilegeInterceptor(GetContext(context.Background(), "collection_admin:pwd"), &milvuspb.RestoreSnapshotRequest{
+			DbName:         "tenant_a",
+			CollectionName: "orders",
+			TargetDbName:   "tenant_a",
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("omitted target database is treated as source database", func(t *testing.T) {
+		_, err := PrivilegeInterceptor(GetContext(context.Background(), "collection_admin:pwd"), &milvuspb.RestoreSnapshotRequest{
+			DbName:         "tenant_a",
+			CollectionName: "orders",
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("cross database restore rejects collection grant", func(t *testing.T) {
+		_, err := PrivilegeInterceptor(GetContext(context.Background(), "collection_admin:pwd"), &milvuspb.RestoreSnapshotRequest{
+			DbName:         "tenant_a",
+			CollectionName: "orders",
+			TargetDbName:   "tenant_b",
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("cross database restore accepts cluster scoped grant", func(t *testing.T) {
+		_, err := PrivilegeInterceptor(GetContext(context.Background(), "cluster_admin:pwd"), &milvuspb.RestoreSnapshotRequest{
+			DbName:         "tenant_a",
+			CollectionName: "orders",
+			TargetDbName:   "tenant_b",
+		})
+		assert.NoError(t, err)
+	})
+}
+
 func TestRootShouldBindRole(t *testing.T) {
 	paramtable.Init()
 	Params.Save(Params.CommonCfg.AuthorizationEnabled.Key, "true")

--- a/internal/proxy/privilege_interceptor_test.go
+++ b/internal/proxy/privilege_interceptor_test.go
@@ -486,6 +486,7 @@ func TestPrivilegeInterceptorRestoreSnapshot(t *testing.T) {
 			PolicyInfos: []string{
 				funcutil.PolicyForPrivilege("role_collection", commonpb.ObjectType_Collection.String(), "orders", commonpb.ObjectPrivilege_PrivilegeRestoreSnapshot.String(), "tenant_a"),
 				funcutil.PolicyForPrivilege("role_cluster", commonpb.ObjectType_Collection.String(), "orders", commonpb.ObjectPrivilege_PrivilegeRestoreSnapshot.String(), util.AnyWord),
+				funcutil.PolicyForPrivilege("role_cluster", commonpb.ObjectType_Collection.String(), "payroll", commonpb.ObjectPrivilege_PrivilegeRestoreSnapshot.String(), util.AnyWord),
 			},
 			UserRoles: []string{
 				funcutil.EncodeUserRoleCache("collection_admin", "role_collection"),
@@ -494,6 +495,10 @@ func TestPrivilegeInterceptorRestoreSnapshot(t *testing.T) {
 		}, nil
 	}
 	require.NoError(t, InitMetaCache(context.Background(), client))
+	cache := globalMetaCache.(*MetaCache)
+	payroll := seedCollection(cache, "tenant_a", "payroll", 100)
+	payroll.aliases = []string{"orders_alias"}
+	cache.setAliasLocked("tenant_a", "orders_alias", "payroll")
 
 	t.Run("same database restore uses collection grant", func(t *testing.T) {
 		_, err := PrivilegeInterceptor(GetContext(context.Background(), "collection_admin:pwd"), &milvuspb.RestoreSnapshotRequest{
@@ -504,12 +509,20 @@ func TestPrivilegeInterceptorRestoreSnapshot(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("omitted target database is treated as source database", func(t *testing.T) {
-		_, err := PrivilegeInterceptor(GetContext(context.Background(), "collection_admin:pwd"), &milvuspb.RestoreSnapshotRequest{
+	t.Run("omitted target database uses active database", func(t *testing.T) {
+		_, err := PrivilegeInterceptor(GetContextWithDB(context.Background(), "collection_admin:pwd", "tenant_a"), &milvuspb.RestoreSnapshotRequest{
 			DbName:         "tenant_a",
 			CollectionName: "orders",
 		})
 		assert.NoError(t, err)
+	})
+
+	t.Run("omitted target database detects cross database restore", func(t *testing.T) {
+		_, err := PrivilegeInterceptor(GetContextWithDB(context.Background(), "collection_admin:pwd", "tenant_b"), &milvuspb.RestoreSnapshotRequest{
+			DbName:         "tenant_a",
+			CollectionName: "orders",
+		})
+		assert.Error(t, err)
 	})
 
 	t.Run("cross database restore rejects collection grant", func(t *testing.T) {
@@ -525,6 +538,15 @@ func TestPrivilegeInterceptorRestoreSnapshot(t *testing.T) {
 		_, err := PrivilegeInterceptor(GetContext(context.Background(), "cluster_admin:pwd"), &milvuspb.RestoreSnapshotRequest{
 			DbName:         "tenant_a",
 			CollectionName: "orders",
+			TargetDbName:   "tenant_b",
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("cross database restore resolves alias in source database", func(t *testing.T) {
+		_, err := PrivilegeInterceptor(GetContext(context.Background(), "cluster_admin:pwd"), &milvuspb.RestoreSnapshotRequest{
+			DbName:         "tenant_a",
+			CollectionName: "orders_alias",
 			TargetDbName:   "tenant_b",
 		})
 		assert.NoError(t, err)

--- a/internal/proxy/rate_limit_interceptor_test.go
+++ b/internal/proxy/rate_limit_interceptor_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 
@@ -33,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/requestutil"
 )
 
 type limiterMock struct {
@@ -54,6 +56,34 @@ func (l *limiterMock) Check(dbID int64, collectionIDToPartIDs map[int64][]int64,
 
 func (l *limiterMock) Alloc(ctx context.Context, dbID int64, collectionIDToPartIDs map[int64][]int64, rt internalpb.RateType, n int) error {
 	return l.Check(dbID, collectionIDToPartIDs, rt, n)
+}
+
+type snapshotLimiterCheck struct {
+	dbID            int64
+	collectionCount int
+	rateType        internalpb.RateType
+	n               int
+}
+
+type rejectingSnapshotLimiter struct {
+	checks []snapshotLimiterCheck
+}
+
+func (l *rejectingSnapshotLimiter) Check(dbID int64, collectionIDToPartIDs map[int64][]int64, rateType internalpb.RateType, n int) error {
+	l.checks = append(l.checks, snapshotLimiterCheck{
+		dbID:            dbID,
+		collectionCount: len(collectionIDToPartIDs),
+		rateType:        rateType,
+		n:               n,
+	})
+	if n <= 0 {
+		return nil
+	}
+	return merr.ErrServiceRateLimit
+}
+
+func (l *rejectingSnapshotLimiter) Alloc(ctx context.Context, dbID int64, collectionIDToPartIDs map[int64][]int64, rateType internalpb.RateType, n int) error {
+	return l.Check(dbID, collectionIDToPartIDs, rateType, n)
 }
 
 func TestRateLimitInterceptor(t *testing.T) {
@@ -382,6 +412,115 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.Nil(t, rsp)
 		rsp = GetFailedResponse(nil, merr.OldCodeToMerr(commonpb.ErrorCode_UnexpectedError))
 		assert.Nil(t, rsp)
+	})
+
+	t.Run("snapshot mutations are rate limited", func(t *testing.T) {
+		mockCache := NewMockCache(t)
+		databaseNames := make([]string, 0)
+		mockCache.EXPECT().GetDatabaseInfo(mock.Anything, mock.Anything).
+			Run(func(_ context.Context, database string) {
+				databaseNames = append(databaseNames, database)
+			}).
+			Return(&databaseInfo{
+				dbID:             100,
+				createdTimestamp: 1,
+			}, nil)
+		mockCache.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil)
+		originCache := globalMetaCache
+		globalMetaCache = mockCache
+		defer func() {
+			globalMetaCache = originCache
+		}()
+
+		testCases := []struct {
+			name            string
+			request         proto.Message
+			expectedDBID    int64
+			expectedCollNum int
+		}{
+			{
+				name: "create snapshot",
+				request: &milvuspb.CreateSnapshotRequest{
+					DbName:         "db1",
+					CollectionName: "source",
+				},
+				expectedDBID:    100,
+				expectedCollNum: 1,
+			},
+			{
+				name: "drop snapshot",
+				request: &milvuspb.DropSnapshotRequest{
+					DbName:         "db1",
+					CollectionName: "source",
+				},
+				expectedDBID:    100,
+				expectedCollNum: 1,
+			},
+			{
+				name: "restore snapshot",
+				request: &milvuspb.RestoreSnapshotRequest{
+					DbName:               "source_db",
+					CollectionName:       "source",
+					TargetDbName:         "target_db",
+					TargetCollectionName: "target",
+				},
+				expectedDBID: 100,
+			},
+			{
+				name: "restore snapshot to default database",
+				request: &milvuspb.RestoreSnapshotRequest{
+					DbName:               "source_db",
+					CollectionName:       "source",
+					TargetCollectionName: "target",
+				},
+				expectedDBID: 100,
+			},
+			{
+				name: "pin snapshot",
+				request: &milvuspb.PinSnapshotDataRequest{
+					DbName:         "db1",
+					CollectionName: "source",
+				},
+				expectedDBID:    100,
+				expectedCollNum: 1,
+			},
+			{
+				name:         "unpin snapshot",
+				request:      &milvuspb.UnpinSnapshotDataRequest{PinId: 1},
+				expectedDBID: util.InvalidDBID,
+			},
+		}
+
+		limiter := &rejectingSnapshotLimiter{}
+		handlerCalls := 0
+		handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+			handlerCalls++
+			return merr.Success(), nil
+		}
+		interceptor := RateLimitInterceptor(limiter)
+		serverInfo := &grpc.UnaryServerInfo{FullMethod: "MockSnapshotMethod"}
+
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				response, err := interceptor(context.Background(), testCase.request, serverInfo, handler)
+				require.NoError(t, err)
+				status, ok := requestutil.GetStatusFromResponse(response)
+				require.True(t, ok)
+				assert.Equal(t, commonpb.ErrorCode_RateLimit, status.GetErrorCode())
+			})
+		}
+
+		assert.Zero(t, handlerCalls)
+		require.Len(t, limiter.checks, len(testCases))
+		for i, testCase := range testCases {
+			assert.Equal(t, snapshotLimiterCheck{
+				dbID:            testCase.expectedDBID,
+				collectionCount: testCase.expectedCollNum,
+				rateType:        internalpb.RateType_DDLCollection,
+				n:               1,
+			}, limiter.checks[i])
+		}
+		assert.Equal(t, []string{"db1", "db1", "target_db", util.DefaultDBName, "db1"}, databaseNames)
 	})
 
 	t.Run("test RateLimitInterceptor", func(t *testing.T) {

--- a/internal/proxy/rate_limit_interceptor_test.go
+++ b/internal/proxy/rate_limit_interceptor_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 
@@ -33,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/requestutil"
 )
 
 type limiterMock struct {
@@ -54,6 +56,34 @@ func (l *limiterMock) Check(dbID int64, collectionIDToPartIDs map[int64][]int64,
 
 func (l *limiterMock) Alloc(ctx context.Context, dbID int64, collectionIDToPartIDs map[int64][]int64, rt internalpb.RateType, n int) error {
 	return l.Check(dbID, collectionIDToPartIDs, rt, n)
+}
+
+type snapshotLimiterCheck struct {
+	dbID            int64
+	collectionCount int
+	rateType        internalpb.RateType
+	n               int
+}
+
+type rejectingSnapshotLimiter struct {
+	checks []snapshotLimiterCheck
+}
+
+func (l *rejectingSnapshotLimiter) Check(dbID int64, collectionIDToPartIDs map[int64][]int64, rateType internalpb.RateType, n int) error {
+	l.checks = append(l.checks, snapshotLimiterCheck{
+		dbID:            dbID,
+		collectionCount: len(collectionIDToPartIDs),
+		rateType:        rateType,
+		n:               n,
+	})
+	if n <= 0 {
+		return nil
+	}
+	return merr.ErrServiceRateLimit
+}
+
+func (l *rejectingSnapshotLimiter) Alloc(ctx context.Context, dbID int64, collectionIDToPartIDs map[int64][]int64, rateType internalpb.RateType, n int) error {
+	return l.Check(dbID, collectionIDToPartIDs, rateType, n)
 }
 
 func TestRateLimitInterceptor(t *testing.T) {
@@ -385,6 +415,115 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.Nil(t, rsp)
 		rsp = GetFailedResponse(nil, merr.OldCodeToMerr(commonpb.ErrorCode_UnexpectedError))
 		assert.Nil(t, rsp)
+	})
+
+	t.Run("snapshot mutations are rate limited", func(t *testing.T) {
+		mockCache := NewMockCache(t)
+		databaseNames := make([]string, 0)
+		mockCache.EXPECT().GetDatabaseInfo(mock.Anything, mock.Anything).
+			Run(func(_ context.Context, database string) {
+				databaseNames = append(databaseNames, database)
+			}).
+			Return(&databaseInfo{
+				dbID:             100,
+				createdTimestamp: 1,
+			}, nil)
+		mockCache.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil)
+		originCache := globalMetaCache
+		globalMetaCache = mockCache
+		defer func() {
+			globalMetaCache = originCache
+		}()
+
+		testCases := []struct {
+			name            string
+			request         proto.Message
+			expectedDBID    int64
+			expectedCollNum int
+		}{
+			{
+				name: "create snapshot",
+				request: &milvuspb.CreateSnapshotRequest{
+					DbName:         "db1",
+					CollectionName: "source",
+				},
+				expectedDBID:    100,
+				expectedCollNum: 1,
+			},
+			{
+				name: "drop snapshot",
+				request: &milvuspb.DropSnapshotRequest{
+					DbName:         "db1",
+					CollectionName: "source",
+				},
+				expectedDBID:    100,
+				expectedCollNum: 1,
+			},
+			{
+				name: "restore snapshot",
+				request: &milvuspb.RestoreSnapshotRequest{
+					DbName:               "source_db",
+					CollectionName:       "source",
+					TargetDbName:         "target_db",
+					TargetCollectionName: "target",
+				},
+				expectedDBID: 100,
+			},
+			{
+				name: "restore snapshot to default database",
+				request: &milvuspb.RestoreSnapshotRequest{
+					DbName:               "source_db",
+					CollectionName:       "source",
+					TargetCollectionName: "target",
+				},
+				expectedDBID: 100,
+			},
+			{
+				name: "pin snapshot",
+				request: &milvuspb.PinSnapshotDataRequest{
+					DbName:         "db1",
+					CollectionName: "source",
+				},
+				expectedDBID:    100,
+				expectedCollNum: 1,
+			},
+			{
+				name:         "unpin snapshot",
+				request:      &milvuspb.UnpinSnapshotDataRequest{PinId: 1},
+				expectedDBID: util.InvalidDBID,
+			},
+		}
+
+		limiter := &rejectingSnapshotLimiter{}
+		handlerCalls := 0
+		handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+			handlerCalls++
+			return merr.Success(), nil
+		}
+		interceptor := RateLimitInterceptor(limiter)
+		serverInfo := &grpc.UnaryServerInfo{FullMethod: "MockSnapshotMethod"}
+
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				response, err := interceptor(context.Background(), testCase.request, serverInfo, handler)
+				require.NoError(t, err)
+				status, ok := requestutil.GetStatusFromResponse(response)
+				require.True(t, ok)
+				assert.Equal(t, commonpb.ErrorCode_RateLimit, status.GetErrorCode())
+			})
+		}
+
+		assert.Zero(t, handlerCalls)
+		require.Len(t, limiter.checks, len(testCases))
+		for i, testCase := range testCases {
+			assert.Equal(t, snapshotLimiterCheck{
+				dbID:            testCase.expectedDBID,
+				collectionCount: testCase.expectedCollNum,
+				rateType:        internalpb.RateType_DDLCollection,
+				n:               1,
+			}, limiter.checks[i])
+		}
+		assert.Equal(t, []string{"db1", "db1", "target_db", util.DefaultDBName, "db1"}, databaseNames)
 	})
 
 	t.Run("test RateLimitInterceptor", func(t *testing.T) {

--- a/internal/proxy/rate_limit_interceptor_test.go
+++ b/internal/proxy/rate_limit_interceptor_test.go
@@ -467,7 +467,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 				expectedDBID: 100,
 			},
 			{
-				name: "restore snapshot to default database",
+				name: "restore snapshot to source database",
 				request: &milvuspb.RestoreSnapshotRequest{
 					DbName:               "source_db",
 					CollectionName:       "source",
@@ -520,7 +520,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 				n:               1,
 			}, limiter.checks[i])
 		}
-		assert.Equal(t, []string{"db1", "db1", "target_db", util.DefaultDBName, "db1"}, databaseNames)
+		assert.Equal(t, []string{"db1", "db1", "target_db", "source_db", "db1"}, databaseNames)
 	})
 
 	t.Run("test RateLimitInterceptor", func(t *testing.T) {

--- a/internal/proxy/rate_limit_interceptor_test.go
+++ b/internal/proxy/rate_limit_interceptor_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -434,6 +435,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 
 		testCases := []struct {
 			name            string
+			ctx             context.Context
 			request         proto.Message
 			expectedDBID    int64
 			expectedCollNum int
@@ -467,7 +469,10 @@ func TestRateLimitInterceptor(t *testing.T) {
 				expectedDBID: 100,
 			},
 			{
-				name: "restore snapshot to source database",
+				name: "restore snapshot to active database",
+				ctx: metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+					util.HeaderDBName, "active_db",
+				)),
 				request: &milvuspb.RestoreSnapshotRequest{
 					DbName:               "source_db",
 					CollectionName:       "source",
@@ -502,7 +507,11 @@ func TestRateLimitInterceptor(t *testing.T) {
 
 		for _, testCase := range testCases {
 			t.Run(testCase.name, func(t *testing.T) {
-				response, err := interceptor(context.Background(), testCase.request, serverInfo, handler)
+				testCtx := testCase.ctx
+				if testCtx == nil {
+					testCtx = context.Background()
+				}
+				response, err := interceptor(testCtx, testCase.request, serverInfo, handler)
 				require.NoError(t, err)
 				status, ok := requestutil.GetStatusFromResponse(response)
 				require.True(t, ok)
@@ -520,7 +529,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 				n:               1,
 			}, limiter.checks[i])
 		}
-		assert.Equal(t, []string{"db1", "db1", "target_db", "source_db", "db1"}, databaseNames)
+		assert.Equal(t, []string{"db1", "db1", "target_db", "active_db", "db1"}, databaseNames)
 	})
 
 	t.Run("test RateLimitInterceptor", func(t *testing.T) {

--- a/internal/proxy/rate_limit_interceptor_test.go
+++ b/internal/proxy/rate_limit_interceptor_test.go
@@ -423,15 +423,10 @@ func TestRateLimitInterceptor(t *testing.T) {
 				databaseNames = append(databaseNames, database)
 			}).
 			Return(&databaseInfo{
-				dbID:             100,
-				createdTimestamp: 1,
+				DBID:             100,
+				CreatedTimestamp: 1,
 			}, nil)
 		mockCache.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil)
-		originCache := globalMetaCache
-		globalMetaCache = mockCache
-		defer func() {
-			globalMetaCache = originCache
-		}()
 
 		testCases := []struct {
 			name            string
@@ -502,7 +497,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 			handlerCalls++
 			return merr.Success(), nil
 		}
-		interceptor := RateLimitInterceptor(limiter)
+		interceptor := RateLimitInterceptorWithMetaCache(func() Cache { return mockCache }, limiter)
 		serverInfo := &grpc.UnaryServerInfo{FullMethod: "MockSnapshotMethod"}
 
 		for _, testCase := range testCases {

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -3075,6 +3075,17 @@ func GetRequestInfo(ctx context.Context, metaCache Cache, req proto.Message) (in
 	case *milvuspb.CreateCollectionRequest:
 		dbID, collToPartIDs := getCollectionID(metaCache, req.(reqCollName))
 		return dbID, collToPartIDs, internalpb.RateType_DDLCollection, 1, nil
+	case *milvuspb.CreateSnapshotRequest, *milvuspb.DropSnapshotRequest, *milvuspb.PinSnapshotDataRequest:
+		dbID, collToPartIDs := getCollectionID(req.(reqCollName))
+		return dbID, collToPartIDs, internalpb.RateType_DDLCollection, 1, nil
+	case *milvuspb.RestoreSnapshotRequest:
+		targetDBName := r.GetTargetDbName()
+		if targetDBName == "" {
+			targetDBName = util.DefaultDBName
+		}
+		return getDatabaseID(targetDBName), map[int64][]int64{}, internalpb.RateType_DDLCollection, 1, nil
+	case *milvuspb.UnpinSnapshotDataRequest:
+		return util.InvalidDBID, map[int64][]int64{}, internalpb.RateType_DDLCollection, 1, nil
 	case *milvuspb.RefreshExternalCollectionRequest:
 		dbID, collToPartIDs := getCollectionID(metaCache, req.(reqCollName))
 		return dbID, collToPartIDs, internalpb.RateType_DDLCollection, 1, nil
@@ -3186,8 +3197,18 @@ func GetFailedResponse(req any, err error) any {
 		*milvuspb.CreateIndexRequest, *milvuspb.DropIndexRequest,
 		*milvuspb.CreateDatabaseRequest, *milvuspb.DropDatabaseRequest,
 		*milvuspb.AlterDatabaseRequest,
-		*milvuspb.AddFileResourceRequest, *milvuspb.RemoveFileResourceRequest:
+		*milvuspb.AddFileResourceRequest, *milvuspb.RemoveFileResourceRequest,
+		*milvuspb.CreateSnapshotRequest, *milvuspb.DropSnapshotRequest,
+		*milvuspb.UnpinSnapshotDataRequest:
 		return merr.Status(err)
+	case *milvuspb.RestoreSnapshotRequest:
+		return &milvuspb.RestoreSnapshotResponse{
+			Status: merr.Status(err),
+		}
+	case *milvuspb.PinSnapshotDataRequest:
+		return &milvuspb.PinSnapshotDataResponse{
+			Status: merr.Status(err),
+		}
 	case *milvuspb.RestoreExternalSnapshotRequest:
 		return &milvuspb.RestoreExternalSnapshotResponse{
 			Status: merr.Status(err),

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -3081,10 +3081,7 @@ func GetRequestInfo(ctx context.Context, metaCache Cache, req proto.Message) (in
 	case *milvuspb.RestoreSnapshotRequest:
 		targetDBName := r.GetTargetDbName()
 		if targetDBName == "" {
-			targetDBName = r.GetDbName()
-		}
-		if targetDBName == "" {
-			targetDBName = util.DefaultDBName
+			targetDBName = GetCurDBNameFromContextOrDefault(ctx)
 		}
 		return getDatabaseID(targetDBName), map[int64][]int64{}, internalpb.RateType_DDLCollection, 1, nil
 	case *milvuspb.UnpinSnapshotDataRequest:

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -3067,6 +3067,17 @@ func GetRequestInfo(ctx context.Context, req proto.Message) (int64, map[int64][]
 	case *milvuspb.CreateCollectionRequest:
 		dbID, collToPartIDs := getCollectionID(req.(reqCollName))
 		return dbID, collToPartIDs, internalpb.RateType_DDLCollection, 1, nil
+	case *milvuspb.CreateSnapshotRequest, *milvuspb.DropSnapshotRequest, *milvuspb.PinSnapshotDataRequest:
+		dbID, collToPartIDs := getCollectionID(req.(reqCollName))
+		return dbID, collToPartIDs, internalpb.RateType_DDLCollection, 1, nil
+	case *milvuspb.RestoreSnapshotRequest:
+		targetDBName := r.GetTargetDbName()
+		if targetDBName == "" {
+			targetDBName = util.DefaultDBName
+		}
+		return getDatabaseID(targetDBName), map[int64][]int64{}, internalpb.RateType_DDLCollection, 1, nil
+	case *milvuspb.UnpinSnapshotDataRequest:
+		return util.InvalidDBID, map[int64][]int64{}, internalpb.RateType_DDLCollection, 1, nil
 	case *milvuspb.RefreshExternalCollectionRequest:
 		dbID, collToPartIDs := getCollectionID(req.(reqCollName))
 		return dbID, collToPartIDs, internalpb.RateType_DDLCollection, 1, nil
@@ -3178,8 +3189,18 @@ func GetFailedResponse(req any, err error) any {
 		*milvuspb.CreateIndexRequest, *milvuspb.DropIndexRequest,
 		*milvuspb.CreateDatabaseRequest, *milvuspb.DropDatabaseRequest,
 		*milvuspb.AlterDatabaseRequest,
-		*milvuspb.AddFileResourceRequest, *milvuspb.RemoveFileResourceRequest:
+		*milvuspb.AddFileResourceRequest, *milvuspb.RemoveFileResourceRequest,
+		*milvuspb.CreateSnapshotRequest, *milvuspb.DropSnapshotRequest,
+		*milvuspb.UnpinSnapshotDataRequest:
 		return merr.Status(err)
+	case *milvuspb.RestoreSnapshotRequest:
+		return &milvuspb.RestoreSnapshotResponse{
+			Status: merr.Status(err),
+		}
+	case *milvuspb.PinSnapshotDataRequest:
+		return &milvuspb.PinSnapshotDataResponse{
+			Status: merr.Status(err),
+		}
 	case *milvuspb.RestoreExternalSnapshotRequest:
 		return &milvuspb.RestoreExternalSnapshotResponse{
 			Status: merr.Status(err),

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -3076,14 +3076,14 @@ func GetRequestInfo(ctx context.Context, metaCache Cache, req proto.Message) (in
 		dbID, collToPartIDs := getCollectionID(metaCache, req.(reqCollName))
 		return dbID, collToPartIDs, internalpb.RateType_DDLCollection, 1, nil
 	case *milvuspb.CreateSnapshotRequest, *milvuspb.DropSnapshotRequest, *milvuspb.PinSnapshotDataRequest:
-		dbID, collToPartIDs := getCollectionID(req.(reqCollName))
+		dbID, collToPartIDs := getCollectionID(metaCache, req.(reqCollName))
 		return dbID, collToPartIDs, internalpb.RateType_DDLCollection, 1, nil
 	case *milvuspb.RestoreSnapshotRequest:
 		targetDBName := r.GetTargetDbName()
 		if targetDBName == "" {
 			targetDBName = GetCurDBNameFromContextOrDefault(ctx)
 		}
-		return getDatabaseID(targetDBName), map[int64][]int64{}, internalpb.RateType_DDLCollection, 1, nil
+		return getDatabaseID(metaCache, targetDBName), map[int64][]int64{}, internalpb.RateType_DDLCollection, 1, nil
 	case *milvuspb.UnpinSnapshotDataRequest:
 		return util.InvalidDBID, map[int64][]int64{}, internalpb.RateType_DDLCollection, 1, nil
 	case *milvuspb.RefreshExternalCollectionRequest:

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -3081,6 +3081,9 @@ func GetRequestInfo(ctx context.Context, metaCache Cache, req proto.Message) (in
 	case *milvuspb.RestoreSnapshotRequest:
 		targetDBName := r.GetTargetDbName()
 		if targetDBName == "" {
+			targetDBName = r.GetDbName()
+		}
+		if targetDBName == "" {
 			targetDBName = util.DefaultDBName
 		}
 		return getDatabaseID(targetDBName), map[int64][]int64{}, internalpb.RateType_DDLCollection, 1, nil

--- a/tests/restful_client_v2/api/milvus.py
+++ b/tests/restful_client_v2/api/milvus.py
@@ -1121,6 +1121,18 @@ class SnapshotClient(Requests):
         payload = {"jobId": str(job_id)}
         return self.post(url, headers=self.update_headers(), data=payload).json()
 
+    def list_restore_snapshot_jobs(self, payload):
+        url = f"{self.endpoint}/v2/vectordb/jobs/snapshot/list"
+        return self.post(url, headers=self.update_headers(), data=payload).json()
+
+    def snapshot_export(self, payload):
+        url = f"{self.endpoint}/v2/vectordb/jobs/snapshot/export"
+        return self.post(url, headers=self.update_headers(), data=payload).json()
+
+    def snapshot_restore_external(self, payload):
+        url = f"{self.endpoint}/v2/vectordb/jobs/snapshot/restore_external"
+        return self.post(url, headers=self.update_headers(), data=payload).json()
+
 
 class StorageClient:
     def __init__(self, endpoint, access_key, secret_key, bucket_name, root_path="file"):

--- a/tests/restful_client_v2/api/milvus.py
+++ b/tests/restful_client_v2/api/milvus.py
@@ -1082,6 +1082,46 @@ class FileResourceClient(Requests):
         return self.post(url, headers=self.update_headers(), data={}).json()
 
 
+class SnapshotClient(Requests):
+    def __init__(self, endpoint, token):
+        super().__init__(url=endpoint, api_key=token)
+        self.endpoint = endpoint
+        self.api_key = token
+
+    def snapshot_create(self, payload):
+        url = f"{self.endpoint}/v2/vectordb/snapshots/create"
+        return self.post(url, headers=self.update_headers(), data=payload).json()
+
+    def snapshot_drop(self, payload):
+        url = f"{self.endpoint}/v2/vectordb/snapshots/drop"
+        return self.post(url, headers=self.update_headers(), data=payload).json()
+
+    def snapshot_list(self, payload):
+        url = f"{self.endpoint}/v2/vectordb/snapshots/list"
+        return self.post(url, headers=self.update_headers(), data=payload).json()
+
+    def snapshot_describe(self, payload):
+        url = f"{self.endpoint}/v2/vectordb/snapshots/describe"
+        return self.post(url, headers=self.update_headers(), data=payload).json()
+
+    def snapshot_restore(self, payload):
+        url = f"{self.endpoint}/v2/vectordb/snapshots/restore"
+        return self.post(url, headers=self.update_headers(), data=payload).json()
+
+    def snapshot_pin(self, payload):
+        url = f"{self.endpoint}/v2/vectordb/snapshots/pin"
+        return self.post(url, headers=self.update_headers(), data=payload).json()
+
+    def snapshot_unpin(self, payload):
+        url = f"{self.endpoint}/v2/vectordb/snapshots/unpin"
+        return self.post(url, headers=self.update_headers(), data=payload).json()
+
+    def get_restore_snapshot_state(self, job_id):
+        url = f"{self.endpoint}/v2/vectordb/jobs/snapshot/describe"
+        payload = {"jobId": str(job_id)}
+        return self.post(url, headers=self.update_headers(), data=payload).json()
+
+
 class StorageClient:
     def __init__(self, endpoint, access_key, secret_key, bucket_name, root_path="file"):
         self.endpoint = endpoint

--- a/tests/restful_client_v2/api/milvus.py
+++ b/tests/restful_client_v2/api/milvus.py
@@ -1129,6 +1129,11 @@ class SnapshotClient(Requests):
         url = f"{self.endpoint}/v2/vectordb/jobs/snapshot/export"
         return self.post(url, headers=self.update_headers(), data=payload).json()
 
+    def get_export_snapshot_state(self, job_id):
+        url = f"{self.endpoint}/v2/vectordb/jobs/snapshot/export/describe"
+        payload = {"jobId": str(job_id)}
+        return self.post(url, headers=self.update_headers(), data=payload).json()
+
     def snapshot_restore_external(self, payload):
         url = f"{self.endpoint}/v2/vectordb/jobs/snapshot/restore_external"
         return self.post(url, headers=self.update_headers(), data=payload).json()

--- a/tests/restful_client_v2/base/testbase.py
+++ b/tests/restful_client_v2/base/testbase.py
@@ -14,6 +14,7 @@ from api.milvus import (
     PartitionClient,
     Requests,
     RoleClient,
+    SnapshotClient,
     StorageClient,
     UserClient,
     VectorClient,
@@ -49,6 +50,7 @@ class Base:
     milvus_client = None
     database_client = None
     file_resource_client = None
+    snapshot_client = None
 
 
 class TestBase(Base):
@@ -109,6 +111,7 @@ class TestBase(Base):
         self.storage_client = StorageClient(f"{minio_host}:9000", "minioadmin", "minioadmin", bucket_name, root_path)
         self.database_client = DatabaseClient(self.endpoint, self.api_key)
         self.file_resource_client = FileResourceClient(self.endpoint, self.api_key)
+        self.snapshot_client = SnapshotClient(self.endpoint, self.api_key)
 
         if token is None:
             self.vector_client.api_key = None

--- a/tests/restful_client_v2/testcases/test_snapshot_operations.py
+++ b/tests/restful_client_v2/testcases/test_snapshot_operations.py
@@ -53,7 +53,8 @@ class TestSnapshotOperations(TestBase):
         assert rsp["data"]["collectionName"] == source_collection, rsp
         assert rsp["data"]["description"] == create_payload["description"], rsp
         assert isinstance(rsp["data"]["partitionNames"], list), rsp
-        assert rsp["data"]["createTs"] > 0, rsp
+        create_ts = rsp["data"]["createTs"]
+        assert isinstance(create_ts, str) and int(create_ts) > 0, rsp
         assert rsp["data"]["s3Location"], rsp
 
         rsp = self.snapshot_client.snapshot_export(
@@ -77,7 +78,7 @@ class TestSnapshotOperations(TestBase):
         rsp = self.snapshot_client.snapshot_pin({**snapshot_payload, "ttlSeconds": 60})
         assert rsp["code"] == 0, rsp
         pin_id = rsp["data"]["pinId"]
-        assert isinstance(pin_id, int) and pin_id > 0, rsp
+        assert isinstance(pin_id, str) and int(pin_id) > 0, rsp
 
         rsp = self.snapshot_client.snapshot_unpin({"pinId": pin_id})
         assert rsp["code"] == 0, rsp
@@ -91,7 +92,7 @@ class TestSnapshotOperations(TestBase):
         )
         assert rsp["code"] == 0, rsp
         job_id = rsp["data"]["jobId"]
-        assert isinstance(job_id, int) and job_id > 0, rsp
+        assert isinstance(job_id, str) and int(job_id) > 0, rsp
 
         deadline = time.time() + 180
         while time.time() < deadline:

--- a/tests/restful_client_v2/testcases/test_snapshot_operations.py
+++ b/tests/restful_client_v2/testcases/test_snapshot_operations.py
@@ -1,0 +1,93 @@
+import time
+from uuid import uuid4
+
+import pytest
+from base.testbase import TestBase
+from utils.constant import CaseLabel
+from utils.utils import gen_collection_name
+
+
+class TestSnapshotOperations(TestBase):
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_snapshot_lifecycle_and_restore(self):
+        source_collection = gen_collection_name(prefix="rest_snapshot_src")
+        target_collection = gen_collection_name(prefix="rest_snapshot_dst")
+        snapshot_name = f"rest_snapshot_{uuid4().hex}"
+        snapshot_payload = {
+            "collectionName": source_collection,
+            "snapshotName": snapshot_name,
+        }
+        snapshot_created = False
+
+        self.init_collection(source_collection, dim=8, nb=10)
+        self.collection_client.name_list.append(("default", target_collection))
+        rsp = self.collection_client.flush(source_collection)
+        assert rsp["code"] == 0, rsp
+
+        try:
+            create_payload = {
+                **snapshot_payload,
+                "description": "RESTful v2 snapshot lifecycle coverage",
+                "compactionProtectionSeconds": 60,
+            }
+            rsp = self.snapshot_client.snapshot_create(create_payload)
+            assert rsp["code"] == 0, rsp
+            snapshot_created = True
+
+            rsp = self.snapshot_client.snapshot_list({"collectionName": source_collection})
+            assert rsp["code"] == 0, rsp
+            assert snapshot_name in rsp["data"], rsp
+
+            rsp = self.snapshot_client.snapshot_describe(snapshot_payload)
+            assert rsp["code"] == 0, rsp
+            assert rsp["data"]["snapshotName"] == snapshot_name, rsp
+            assert rsp["data"]["collectionName"] == source_collection, rsp
+            assert rsp["data"]["description"] == create_payload["description"], rsp
+            assert isinstance(rsp["data"]["partitionNames"], list), rsp
+            assert rsp["data"]["createTs"] > 0, rsp
+            assert rsp["data"]["s3Location"], rsp
+
+            rsp = self.snapshot_client.snapshot_pin({**snapshot_payload, "ttlSeconds": 60})
+            assert rsp["code"] == 0, rsp
+            pin_id = rsp["data"]["pinId"]
+            assert isinstance(pin_id, int) and pin_id > 0, rsp
+
+            rsp = self.snapshot_client.snapshot_unpin({"pinId": pin_id})
+            assert rsp["code"] == 0, rsp
+
+            rsp = self.snapshot_client.snapshot_restore(
+                {
+                    "snapshotName": snapshot_name,
+                    "sourceCollectionName": source_collection,
+                    "targetCollectionName": target_collection,
+                }
+            )
+            assert rsp["code"] == 0, rsp
+            job_id = rsp["data"]["jobId"]
+            assert isinstance(job_id, int) and job_id > 0, rsp
+
+            deadline = time.time() + 180
+            while time.time() < deadline:
+                rsp = self.snapshot_client.get_restore_snapshot_state(job_id)
+                assert rsp["code"] == 0, rsp
+                state = rsp["data"]["state"]
+                if state == "RestoreSnapshotCompleted":
+                    break
+                assert state != "RestoreSnapshotFailed", rsp
+                time.sleep(2)
+            else:
+                pytest.fail(f"snapshot restore did not complete: {rsp}")
+
+            rsp = self.collection_client.collection_has(collection_name=target_collection)
+            assert rsp["code"] == 0 and rsp["data"]["has"], rsp
+
+            rsp = self.snapshot_client.snapshot_drop(snapshot_payload)
+            assert rsp["code"] == 0, rsp
+            snapshot_created = False
+
+            rsp = self.snapshot_client.snapshot_list({"collectionName": source_collection})
+            assert rsp["code"] == 0, rsp
+            assert snapshot_name not in rsp["data"], rsp
+        finally:
+            if snapshot_created:
+                self.snapshot_client.snapshot_drop(snapshot_payload)

--- a/tests/restful_client_v2/testcases/test_snapshot_operations.py
+++ b/tests/restful_client_v2/testcases/test_snapshot_operations.py
@@ -22,6 +22,7 @@ class TestSnapshotOperations(TestBase):
     def test_snapshot_lifecycle_and_restore(self):
         source_collection = gen_collection_name(prefix="rest_snapshot_src")
         target_collection = gen_collection_name(prefix="rest_snapshot_dst")
+        external_target_collection = gen_collection_name(prefix="rest_snapshot_external_dst")
         snapshot_name = f"rest_snapshot_{uuid4().hex}"
         snapshot_payload = {
             "collectionName": source_collection,
@@ -29,6 +30,7 @@ class TestSnapshotOperations(TestBase):
         }
         self.init_collection(source_collection, dim=8, nb=10)
         self.collection_client.name_list.append(("default", target_collection))
+        self.collection_client.name_list.append(("default", external_target_collection))
         rsp = self.collection_client.flush(source_collection)
         assert rsp["code"] == 0, rsp
 
@@ -53,6 +55,24 @@ class TestSnapshotOperations(TestBase):
         assert isinstance(rsp["data"]["partitionNames"], list), rsp
         assert rsp["data"]["createTs"] > 0, rsp
         assert rsp["data"]["s3Location"], rsp
+
+        rsp = self.snapshot_client.snapshot_export(
+            {
+                **snapshot_payload,
+                "targetS3Path": "s3://snapshot-export-test/export-root",
+            }
+        )
+        assert rsp["code"] != 0, rsp
+        assert "not implemented" in rsp["message"].lower(), rsp
+
+        rsp = self.snapshot_client.snapshot_restore_external(
+            {
+                "targetCollectionName": external_target_collection,
+                "snapshotMetadataURI": "s3://snapshot-export-test/snapshots/metadata.json",
+            }
+        )
+        assert rsp["code"] != 0, rsp
+        assert "not implemented" in rsp["message"].lower(), rsp
 
         rsp = self.snapshot_client.snapshot_pin({**snapshot_payload, "ttlSeconds": 60})
         assert rsp["code"] == 0, rsp
@@ -84,6 +104,18 @@ class TestSnapshotOperations(TestBase):
             time.sleep(2)
         else:
             pytest.fail(f"snapshot restore did not complete: {rsp}")
+
+        assert rsp["data"]["jobId"] == job_id, rsp
+        assert rsp["data"]["snapshotName"] == snapshot_name, rsp
+        assert rsp["data"]["collectionName"] == target_collection, rsp
+
+        rsp = self.snapshot_client.list_restore_snapshot_jobs({"collectionName": target_collection})
+        assert rsp["code"] == 0, rsp
+        matching_jobs = [record for record in rsp["data"]["records"] if record["jobId"] == job_id]
+        assert len(matching_jobs) == 1, rsp
+        assert matching_jobs[0]["snapshotName"] == snapshot_name, rsp
+        assert matching_jobs[0]["collectionName"] == target_collection, rsp
+        assert matching_jobs[0]["state"] == "RestoreSnapshotCompleted", rsp
 
         rsp = self.collection_client.collection_has(collection_name=target_collection)
         assert rsp["code"] == 0 and rsp["data"]["has"], rsp

--- a/tests/restful_client_v2/testcases/test_snapshot_operations.py
+++ b/tests/restful_client_v2/testcases/test_snapshot_operations.py
@@ -93,6 +93,7 @@ class TestSnapshotOperations(TestBase):
         assert rsp["code"] == 0, rsp
         job_id = rsp["data"]["jobId"]
         assert isinstance(job_id, (int, str)) and int(job_id) > 0, rsp
+        job_id = str(job_id)
 
         deadline = time.time() + 180
         while time.time() < deadline:
@@ -106,13 +107,13 @@ class TestSnapshotOperations(TestBase):
         else:
             pytest.fail(f"snapshot restore did not complete: {rsp}")
 
-        assert rsp["data"]["jobId"] == job_id, rsp
+        assert str(rsp["data"]["jobId"]) == job_id, rsp
         assert rsp["data"]["snapshotName"] == snapshot_name, rsp
         assert rsp["data"]["collectionName"] == target_collection, rsp
 
         rsp = self.snapshot_client.list_restore_snapshot_jobs({"collectionName": target_collection})
         assert rsp["code"] == 0, rsp
-        matching_jobs = [record for record in rsp["data"]["records"] if record["jobId"] == job_id]
+        matching_jobs = [record for record in rsp["data"]["records"] if str(record["jobId"]) == job_id]
         assert len(matching_jobs) == 1, rsp
         assert matching_jobs[0]["snapshotName"] == snapshot_name, rsp
         assert matching_jobs[0]["collectionName"] == target_collection, rsp

--- a/tests/restful_client_v2/testcases/test_snapshot_operations.py
+++ b/tests/restful_client_v2/testcases/test_snapshot_operations.py
@@ -8,6 +8,16 @@ from utils.utils import gen_collection_name
 
 
 class TestSnapshotOperations(TestBase):
+    def setup_method(self):
+        self._snapshots_to_cleanup = []
+
+    def teardown_method(self):
+        try:
+            for snapshot_payload in self._snapshots_to_cleanup:
+                self.snapshot_client.snapshot_drop(snapshot_payload)
+        finally:
+            super().teardown_method()
+
     @pytest.mark.tags(CaseLabel.L0)
     def test_snapshot_lifecycle_and_restore(self):
         source_collection = gen_collection_name(prefix="rest_snapshot_src")
@@ -17,77 +27,71 @@ class TestSnapshotOperations(TestBase):
             "collectionName": source_collection,
             "snapshotName": snapshot_name,
         }
-        snapshot_created = False
-
         self.init_collection(source_collection, dim=8, nb=10)
         self.collection_client.name_list.append(("default", target_collection))
         rsp = self.collection_client.flush(source_collection)
         assert rsp["code"] == 0, rsp
 
-        try:
-            create_payload = {
-                **snapshot_payload,
-                "description": "RESTful v2 snapshot lifecycle coverage",
-                "compactionProtectionSeconds": 60,
+        create_payload = {
+            **snapshot_payload,
+            "description": "RESTful v2 snapshot lifecycle coverage",
+            "compactionProtectionSeconds": 60,
+        }
+        rsp = self.snapshot_client.snapshot_create(create_payload)
+        assert rsp["code"] == 0, rsp
+        self._snapshots_to_cleanup.append(snapshot_payload)
+
+        rsp = self.snapshot_client.snapshot_list({"collectionName": source_collection})
+        assert rsp["code"] == 0, rsp
+        assert snapshot_name in rsp["data"], rsp
+
+        rsp = self.snapshot_client.snapshot_describe(snapshot_payload)
+        assert rsp["code"] == 0, rsp
+        assert rsp["data"]["snapshotName"] == snapshot_name, rsp
+        assert rsp["data"]["collectionName"] == source_collection, rsp
+        assert rsp["data"]["description"] == create_payload["description"], rsp
+        assert isinstance(rsp["data"]["partitionNames"], list), rsp
+        assert rsp["data"]["createTs"] > 0, rsp
+        assert rsp["data"]["s3Location"], rsp
+
+        rsp = self.snapshot_client.snapshot_pin({**snapshot_payload, "ttlSeconds": 60})
+        assert rsp["code"] == 0, rsp
+        pin_id = rsp["data"]["pinId"]
+        assert isinstance(pin_id, int) and pin_id > 0, rsp
+
+        rsp = self.snapshot_client.snapshot_unpin({"pinId": pin_id})
+        assert rsp["code"] == 0, rsp
+
+        rsp = self.snapshot_client.snapshot_restore(
+            {
+                "snapshotName": snapshot_name,
+                "sourceCollectionName": source_collection,
+                "targetCollectionName": target_collection,
             }
-            rsp = self.snapshot_client.snapshot_create(create_payload)
+        )
+        assert rsp["code"] == 0, rsp
+        job_id = rsp["data"]["jobId"]
+        assert isinstance(job_id, int) and job_id > 0, rsp
+
+        deadline = time.time() + 180
+        while time.time() < deadline:
+            rsp = self.snapshot_client.get_restore_snapshot_state(job_id)
             assert rsp["code"] == 0, rsp
-            snapshot_created = True
+            state = rsp["data"]["state"]
+            if state == "RestoreSnapshotCompleted":
+                break
+            assert state != "RestoreSnapshotFailed", rsp
+            time.sleep(2)
+        else:
+            pytest.fail(f"snapshot restore did not complete: {rsp}")
 
-            rsp = self.snapshot_client.snapshot_list({"collectionName": source_collection})
-            assert rsp["code"] == 0, rsp
-            assert snapshot_name in rsp["data"], rsp
+        rsp = self.collection_client.collection_has(collection_name=target_collection)
+        assert rsp["code"] == 0 and rsp["data"]["has"], rsp
 
-            rsp = self.snapshot_client.snapshot_describe(snapshot_payload)
-            assert rsp["code"] == 0, rsp
-            assert rsp["data"]["snapshotName"] == snapshot_name, rsp
-            assert rsp["data"]["collectionName"] == source_collection, rsp
-            assert rsp["data"]["description"] == create_payload["description"], rsp
-            assert isinstance(rsp["data"]["partitionNames"], list), rsp
-            assert rsp["data"]["createTs"] > 0, rsp
-            assert rsp["data"]["s3Location"], rsp
+        rsp = self.snapshot_client.snapshot_drop(snapshot_payload)
+        assert rsp["code"] == 0, rsp
+        self._snapshots_to_cleanup.remove(snapshot_payload)
 
-            rsp = self.snapshot_client.snapshot_pin({**snapshot_payload, "ttlSeconds": 60})
-            assert rsp["code"] == 0, rsp
-            pin_id = rsp["data"]["pinId"]
-            assert isinstance(pin_id, int) and pin_id > 0, rsp
-
-            rsp = self.snapshot_client.snapshot_unpin({"pinId": pin_id})
-            assert rsp["code"] == 0, rsp
-
-            rsp = self.snapshot_client.snapshot_restore(
-                {
-                    "snapshotName": snapshot_name,
-                    "sourceCollectionName": source_collection,
-                    "targetCollectionName": target_collection,
-                }
-            )
-            assert rsp["code"] == 0, rsp
-            job_id = rsp["data"]["jobId"]
-            assert isinstance(job_id, int) and job_id > 0, rsp
-
-            deadline = time.time() + 180
-            while time.time() < deadline:
-                rsp = self.snapshot_client.get_restore_snapshot_state(job_id)
-                assert rsp["code"] == 0, rsp
-                state = rsp["data"]["state"]
-                if state == "RestoreSnapshotCompleted":
-                    break
-                assert state != "RestoreSnapshotFailed", rsp
-                time.sleep(2)
-            else:
-                pytest.fail(f"snapshot restore did not complete: {rsp}")
-
-            rsp = self.collection_client.collection_has(collection_name=target_collection)
-            assert rsp["code"] == 0 and rsp["data"]["has"], rsp
-
-            rsp = self.snapshot_client.snapshot_drop(snapshot_payload)
-            assert rsp["code"] == 0, rsp
-            snapshot_created = False
-
-            rsp = self.snapshot_client.snapshot_list({"collectionName": source_collection})
-            assert rsp["code"] == 0, rsp
-            assert snapshot_name not in rsp["data"], rsp
-        finally:
-            if snapshot_created:
-                self.snapshot_client.snapshot_drop(snapshot_payload)
+        rsp = self.snapshot_client.snapshot_list({"collectionName": source_collection})
+        assert rsp["code"] == 0, rsp
+        assert snapshot_name not in rsp["data"], rsp

--- a/tests/restful_client_v2/testcases/test_snapshot_operations.py
+++ b/tests/restful_client_v2/testcases/test_snapshot_operations.py
@@ -60,20 +60,61 @@ class TestSnapshotOperations(TestBase):
         rsp = self.snapshot_client.snapshot_export(
             {
                 **snapshot_payload,
-                "targetS3Path": "s3://snapshot-export-test/export-root",
+                "targetS3Path": f"snapshot_export_{uuid4().hex}",
             }
         )
-        assert rsp["code"] != 0, rsp
-        assert "not implemented" in rsp["message"].lower(), rsp
+        assert rsp["code"] == 0, rsp
+        export_job_id = rsp["data"]["jobId"]
+        assert isinstance(export_job_id, (int, str)) and int(export_job_id) > 0, rsp
+        export_job_id = str(export_job_id)
+
+        deadline = time.time() + 180
+        while time.time() < deadline:
+            rsp = self.snapshot_client.get_export_snapshot_state(export_job_id)
+            assert rsp["code"] == 0, rsp
+            state = rsp["data"]["state"]
+            if state == "ExportSnapshotCompleted":
+                break
+            assert state != "ExportSnapshotFailed", rsp
+            time.sleep(2)
+        else:
+            pytest.fail(f"snapshot export did not complete: {rsp}")
+
+        assert str(rsp["data"]["jobId"]) == export_job_id, rsp
+        assert rsp["data"]["snapshotName"] == snapshot_name, rsp
+        assert rsp["data"]["collectionName"] == source_collection, rsp
+        assert int(rsp["data"]["totalBytes"]) > 0, rsp
+        snapshot_metadata_uri = rsp["data"]["snapshotMetadataURI"]
+        assert snapshot_metadata_uri, rsp
 
         rsp = self.snapshot_client.snapshot_restore_external(
             {
                 "targetCollectionName": external_target_collection,
-                "snapshotMetadataURI": "s3://snapshot-export-test/snapshots/metadata.json",
+                "snapshotMetadataURI": snapshot_metadata_uri,
             }
         )
-        assert rsp["code"] != 0, rsp
-        assert "not implemented" in rsp["message"].lower(), rsp
+        assert rsp["code"] == 0, rsp
+        external_restore_job_id = rsp["data"]["jobId"]
+        assert isinstance(external_restore_job_id, (int, str)) and int(external_restore_job_id) > 0, rsp
+        external_restore_job_id = str(external_restore_job_id)
+
+        deadline = time.time() + 180
+        while time.time() < deadline:
+            rsp = self.snapshot_client.get_restore_snapshot_state(external_restore_job_id)
+            assert rsp["code"] == 0, rsp
+            state = rsp["data"]["state"]
+            if state == "RestoreSnapshotCompleted":
+                break
+            assert state != "RestoreSnapshotFailed", rsp
+            time.sleep(2)
+        else:
+            pytest.fail(f"external snapshot restore did not complete: {rsp}")
+
+        assert str(rsp["data"]["jobId"]) == external_restore_job_id, rsp
+        assert rsp["data"]["collectionName"] == external_target_collection, rsp
+
+        rsp = self.collection_client.collection_has(collection_name=external_target_collection)
+        assert rsp["code"] == 0 and rsp["data"]["has"], rsp
 
         rsp = self.snapshot_client.snapshot_pin({**snapshot_payload, "ttlSeconds": 60})
         assert rsp["code"] == 0, rsp

--- a/tests/restful_client_v2/testcases/test_snapshot_operations.py
+++ b/tests/restful_client_v2/testcases/test_snapshot_operations.py
@@ -54,7 +54,7 @@ class TestSnapshotOperations(TestBase):
         assert rsp["data"]["description"] == create_payload["description"], rsp
         assert isinstance(rsp["data"]["partitionNames"], list), rsp
         create_ts = rsp["data"]["createTs"]
-        assert isinstance(create_ts, str) and int(create_ts) > 0, rsp
+        assert isinstance(create_ts, (int, str)) and int(create_ts) > 0, rsp
         assert rsp["data"]["s3Location"], rsp
 
         rsp = self.snapshot_client.snapshot_export(
@@ -78,9 +78,9 @@ class TestSnapshotOperations(TestBase):
         rsp = self.snapshot_client.snapshot_pin({**snapshot_payload, "ttlSeconds": 60})
         assert rsp["code"] == 0, rsp
         pin_id = rsp["data"]["pinId"]
-        assert isinstance(pin_id, str) and int(pin_id) > 0, rsp
+        assert isinstance(pin_id, (int, str)) and int(pin_id) > 0, rsp
 
-        rsp = self.snapshot_client.snapshot_unpin({"pinId": pin_id})
+        rsp = self.snapshot_client.snapshot_unpin({"pinId": str(pin_id)})
         assert rsp["code"] == 0, rsp
 
         rsp = self.snapshot_client.snapshot_restore(
@@ -92,7 +92,7 @@ class TestSnapshotOperations(TestBase):
         )
         assert rsp["code"] == 0, rsp
         job_id = rsp["data"]["jobId"]
-        assert isinstance(job_id, str) and int(job_id) > 0, rsp
+        assert isinstance(job_id, (int, str)) and int(job_id) > 0, rsp
 
         deadline = time.time() + 180
         while time.time() < deadline:


### PR DESCRIPTION
pr: #52171
issue: #52163

## What this PR does

This is the 3.0 cherry-pick of #52171.

It adds RESTful v2 endpoints for the collection-scoped native snapshot lifecycle:

- `/v2/vectordb/snapshots/create`
- `/v2/vectordb/snapshots/drop`
- `/v2/vectordb/snapshots/list`
- `/v2/vectordb/snapshots/describe`
- `/v2/vectordb/snapshots/restore`
- `/v2/vectordb/snapshots/pin`
- `/v2/vectordb/snapshots/unpin`

Snapshot names are scoped to their source collections. The request mappings therefore preserve the collection identity required by the native snapshot gRPC APIs.

Native restore returns a `jobId`. Restore job state and history continue to use the existing snapshot job endpoints:

- `/v2/vectordb/jobs/snapshot/describe`
- `/v2/vectordb/jobs/snapshot/list`

The existing `export` and `restore_external` routes remain unchanged and currently return `ServiceUnimplemented` from the backend.

All seven commits are patch-equivalent to the master PR; no 3.0-specific behavior changes were introduced.

## Tests

- Incremental Go unit tests for `internal/distributed/proxy/httpserver` passed with four shards.
- RESTful v2 snapshot lifecycle end-to-end test passed against a 3.0-based build.
- The end-to-end case covers create, list, describe, pin, unpin, restore, restore-state polling, and drop.
- All `/v2/vectordb/jobs/snapshot` routes are covered: `describe` and `list` validate successful restore jobs, while `export` and `restore_external` validate their current unimplemented responses.
- Snapshot cleanup runs in teardown before collection cleanup.
- `git range-diff` confirms that all seven patches match #52171.
