### PR TITLE
fix: [poc_2.6.17] backport StructArray load & stability fixes (#50141 #49990 #51121 #51474 #50233 #50592)

### DIFF
--- a/internal/core/src/common/Schema.h
+++ b/internal/core/src/common/Schema.h
@@ -289,6 +289,22 @@ class Schema {
         return fields_.size();
     }
 
+    size_t
+    get_field_id_bitset_size() const {
+        size_t bitset_size = 0;
+        for (const auto& field_id : field_ids_) {
+            if (field_id.get() < START_USER_FIELDID) {
+                continue;
+            }
+            auto required_size =
+                static_cast<size_t>(field_id.get() - START_USER_FIELDID + 1);
+            if (required_size > bitset_size) {
+                bitset_size = required_size;
+            }
+        }
+        return bitset_size;
+    }
+
     const FieldMeta&
     operator[](FieldId field_id) const {
         Assert(field_id.get() >= 0);

--- a/internal/core/src/exec/expression/ColumnExpr.cpp
+++ b/internal/core/src/exec/expression/ColumnExpr.cpp
@@ -85,20 +85,19 @@ PhyColumnExpr::DoEval(OffsetVector* input) {
         TargetBitmapView valid_res(res_vec->GetValidRawData(), real_batch_size);
         valid_res.set();
 
-        auto data_barrier = segment_chunk_reader_.segment_->num_chunk_data(
-            expr_->GetColumn().field_id_);
-
         int64_t processed_rows = 0;
-        const auto size_per_chunk = segment_chunk_reader_.SizePerChunk();
         for (auto i = 0; i < real_batch_size; ++i) {
             auto offset = (*input)[i];
             auto [chunk_id,
                   chunk_offset] = [&]() -> std::pair<int64_t, int64_t> {
                 if (segment_chunk_reader_.segment_->type() ==
                     SegmentType::Growing) {
+                    const auto size_per_chunk =
+                        segment_chunk_reader_.SizePerChunk();
                     return {offset / size_per_chunk, offset % size_per_chunk};
                 } else if (segment_chunk_reader_.segment_->is_chunked() &&
-                           data_barrier > 0) {
+                           segment_chunk_reader_.segment_->num_chunk_data(
+                               expr_->GetColumn().field_id_) > 0) {
                     return segment_chunk_reader_.segment_->get_chunk_by_offset(
                         expr_->GetColumn().field_id_, offset);
                 } else {
@@ -109,8 +108,7 @@ PhyColumnExpr::DoEval(OffsetVector* input) {
                 expr_->GetColumn().data_type_,
                 expr_->GetColumn().field_id_,
                 chunk_id,
-                data_barrier,
-                pinned_index_);
+                PinnedIndexForRawLookup());
             auto chunk_data_by_offset = cda(chunk_offset);
             if (!chunk_data_by_offset.has_value()) {
                 valid_res[processed_rows] = false;
@@ -140,7 +138,7 @@ PhyColumnExpr::DoEval(OffsetVector* input) {
             expr_->GetColumn().field_id_,
             current_chunk_id_,
             current_chunk_pos_,
-            pinned_index_);
+            PinnedIndexForRawLookup());
         for (int i = 0; i < real_batch_size; ++i) {
             auto data = cda();
             if (!data.has_value()) {
@@ -162,9 +160,6 @@ PhyColumnExpr::DoEval(OffsetVector* input) {
         TargetBitmapView valid_res(res_vec->GetValidRawData(), real_batch_size);
         valid_res.set();
 
-        auto data_barrier = segment_chunk_reader_.segment_->num_chunk_data(
-            expr_->GetColumn().field_id_);
-
         int64_t processed_rows = 0;
         for (int64_t chunk_id = current_chunk_id_; chunk_id < num_chunk_;
              ++chunk_id) {
@@ -177,8 +172,7 @@ PhyColumnExpr::DoEval(OffsetVector* input) {
                 expr_->GetColumn().data_type_,
                 expr_->GetColumn().field_id_,
                 chunk_id,
-                data_barrier,
-                pinned_index_);
+                PinnedIndexForRawLookup());
 
             for (int i = chunk_id == current_chunk_id_ ? current_chunk_pos_ : 0;
                  i < chunk_size;

--- a/internal/core/src/exec/expression/ColumnExpr.h
+++ b/internal/core/src/exec/expression/ColumnExpr.h
@@ -46,13 +46,16 @@ class PhyColumnExpr : public Expr {
         auto& field_meta = schema[expr_->GetColumn().field_id_];
         pinned_index_ = PinIndex(op_ctx_, segment, field_meta);
         is_indexed_ = pinned_index_.size() > 0;
+        use_index_data_ =
+            is_indexed_ &&
+            segment->HasRawData(expr_->GetColumn().field_id_.get());
         if (segment->is_chunked()) {
             num_chunk_ =
-                is_indexed_
+                use_index_data_
                     ? pinned_index_.size()
                     : segment->num_chunk_data(expr_->GetColumn().field_id_);
         } else {
-            num_chunk_ = is_indexed_
+            num_chunk_ = use_index_data_
                              ? pinned_index_.size()
                              : upper_div(segment_chunk_reader_.active_count_,
                                          segment_chunk_reader_.SizePerChunk());
@@ -70,12 +73,16 @@ class PhyColumnExpr : public Expr {
     MoveCursor() override {
         if (!has_offset_input_) {
             if (segment_chunk_reader_.segment_->is_chunked()) {
-                segment_chunk_reader_.MoveCursorForMultipleChunk(
-                    current_chunk_id_,
-                    current_chunk_pos_,
-                    expr_->GetColumn().field_id_,
-                    num_chunk_,
-                    batch_size_);
+                if (use_index_data_) {
+                    MoveCursorForIndexed();
+                } else {
+                    segment_chunk_reader_.MoveCursorForMultipleChunk(
+                        current_chunk_id_,
+                        current_chunk_pos_,
+                        expr_->GetColumn().field_id_,
+                        num_chunk_,
+                        batch_size_);
+                }
             } else {
                 segment_chunk_reader_.MoveCursorForSingleChunk(
                     current_chunk_id_,
@@ -86,13 +93,21 @@ class PhyColumnExpr : public Expr {
         }
     }
 
+    void
+    MoveCursorForIndexed() {
+        current_chunk_pos_ = current_chunk_pos_ + batch_size_ >=
+                                     segment_chunk_reader_.active_count_
+                                 ? segment_chunk_reader_.active_count_
+                                 : current_chunk_pos_ + batch_size_;
+    }
+
  private:
     int64_t
     GetCurrentRows() const {
         if (segment_chunk_reader_.segment_->is_chunked()) {
             auto current_rows =
-                is_indexed_ && segment_chunk_reader_.segment_->type() ==
-                                   SegmentType::Sealed
+                use_index_data_ && segment_chunk_reader_.segment_->type() ==
+                                       SegmentType::Sealed
                     ? current_chunk_pos_
                     : segment_chunk_reader_.segment_->num_rows_until_chunk(
                           expr_->GetColumn().field_id_, current_chunk_id_) +
@@ -131,7 +146,16 @@ class PhyColumnExpr : public Expr {
     }
 
  private:
+    segcore::PinnedIndexView
+    PinnedIndexForRawLookup() const {
+        if (!use_index_data_) {
+            return {};
+        }
+        return {pinned_index_.data(), pinned_index_.size()};
+    }
+
     bool is_indexed_;
+    bool use_index_data_;
 
     int64_t num_chunk_{0};
     int64_t current_chunk_id_{0};

--- a/internal/core/src/exec/expression/CompareExpr.cpp
+++ b/internal/core/src/exec/expression/CompareExpr.cpp
@@ -54,9 +54,10 @@ PhyCompareFilterExpr::ExecCompareExprDispatcher(OpType op, EvalCtx& context) {
         TargetBitmapView res(res_vec->GetRawData(), real_batch_size);
         TargetBitmapView valid_res(res_vec->GetValidRawData(), real_batch_size);
 
-        auto left_data_barrier = segment_chunk_reader_.segment_->num_chunk_data(
-            expr_->left_field_id_);
-        auto right_data_barrier =
+        auto left_raw_data_chunk_count =
+            segment_chunk_reader_.segment_->num_chunk_data(
+                expr_->left_field_id_);
+        auto right_raw_data_chunk_count =
             segment_chunk_reader_.segment_->num_chunk_data(
                 expr_->right_field_id_);
 
@@ -65,13 +66,13 @@ PhyCompareFilterExpr::ExecCompareExprDispatcher(OpType op, EvalCtx& context) {
         for (auto i = 0; i < real_batch_size; ++i) {
             auto offset = (*input)[i];
             auto get_chunk_id_and_offset =
-                [&](const FieldId field,
-                    const int64_t data_barrier) -> std::pair<int64_t, int64_t> {
+                [&](const FieldId field, const int64_t raw_data_chunk_count)
+                -> std::pair<int64_t, int64_t> {
                 if (segment_chunk_reader_.segment_->type() ==
                     SegmentType::Growing) {
                     return {offset / size_per_chunk, offset % size_per_chunk};
                 } else if (segment_chunk_reader_.segment_->is_chunked() &&
-                           data_barrier > 0) {
+                           raw_data_chunk_count > 0) {
                     return segment_chunk_reader_.segment_->get_chunk_by_offset(
                         field, offset);
                 } else {
@@ -80,21 +81,19 @@ PhyCompareFilterExpr::ExecCompareExprDispatcher(OpType op, EvalCtx& context) {
             };
 
             auto [left_chunk_id, left_chunk_offset] =
-                get_chunk_id_and_offset(left_field_, left_data_barrier);
-            auto [right_chunk_id, right_chunk_offset] =
-                get_chunk_id_and_offset(right_field_, right_data_barrier);
+                get_chunk_id_and_offset(left_field_, left_raw_data_chunk_count);
+            auto [right_chunk_id, right_chunk_offset] = get_chunk_id_and_offset(
+                right_field_, right_raw_data_chunk_count);
             auto left = segment_chunk_reader_.GetChunkDataAccessor(
                 expr_->left_data_type_,
                 expr_->left_field_id_,
                 left_chunk_id,
-                left_data_barrier,
-                pinned_index_left_);
+                LeftPinnedIndexForRawLookup());
             auto right = segment_chunk_reader_.GetChunkDataAccessor(
                 expr_->right_data_type_,
                 expr_->right_field_id_,
                 right_chunk_id,
-                right_data_barrier,
-                pinned_index_right_);
+                RightPinnedIndexForRawLookup());
             auto left_opt = left(left_chunk_offset);
             auto right_opt = right(right_chunk_offset);
             if (!left_opt.has_value() || !right_opt.has_value()) {
@@ -129,13 +128,13 @@ PhyCompareFilterExpr::ExecCompareExprDispatcher(OpType op, EvalCtx& context) {
             expr_->left_field_id_,
             left_current_chunk_id_,
             left_current_chunk_pos_,
-            pinned_index_left_);
+            LeftPinnedIndexForRawLookup());
         auto right = segment_chunk_reader_.GetMultipleChunkDataAccessor(
             expr_->right_data_type_,
             expr_->right_field_id_,
             right_current_chunk_id_,
             right_current_chunk_pos_,
-            pinned_index_right_);
+            RightPinnedIndexForRawLookup());
         for (int i = 0; i < real_batch_size; ++i) {
             auto left_value = left(), right_value = right();
             if (!left_value.has_value() || !right_value.has_value()) {
@@ -161,12 +160,6 @@ PhyCompareFilterExpr::ExecCompareExprDispatcher(OpType op, EvalCtx& context) {
         TargetBitmapView valid_res(res_vec->GetValidRawData(), real_batch_size);
         valid_res.set();
 
-        auto left_data_barrier = segment_chunk_reader_.segment_->num_chunk_data(
-            expr_->left_field_id_);
-        auto right_data_barrier =
-            segment_chunk_reader_.segment_->num_chunk_data(
-                expr_->right_field_id_);
-
         int64_t processed_rows = 0;
         for (int64_t chunk_id = current_chunk_id_; chunk_id < num_chunk_;
              ++chunk_id) {
@@ -179,14 +172,12 @@ PhyCompareFilterExpr::ExecCompareExprDispatcher(OpType op, EvalCtx& context) {
                 expr_->left_data_type_,
                 expr_->left_field_id_,
                 chunk_id,
-                left_data_barrier,
-                pinned_index_left_);
+                LeftPinnedIndexForRawLookup());
             auto right = segment_chunk_reader_.GetChunkDataAccessor(
                 expr_->right_data_type_,
                 expr_->right_field_id_,
                 chunk_id,
-                right_data_barrier,
-                pinned_index_right_);
+                RightPinnedIndexForRawLookup());
 
             for (int i = chunk_id == current_chunk_id_ ? current_chunk_pos_ : 0;
                  i < chunk_size;

--- a/internal/core/src/exec/expression/CompareExpr.h
+++ b/internal/core/src/exec/expression/CompareExpr.h
@@ -149,27 +149,30 @@ class PhyCompareFilterExpr : public Expr {
         pinned_index_right_ = PinIndex(op_ctx_, segment, right_field_meta);
         is_left_indexed_ = pinned_index_left_.size() > 0;
         is_right_indexed_ = pinned_index_right_.size() > 0;
+        left_use_index_data_ =
+            is_left_indexed_ && segment->HasRawData(left_field_.get());
+        right_use_index_data_ =
+            is_right_indexed_ && segment->HasRawData(right_field_.get());
         if (segment->is_chunked()) {
             left_num_chunk_ =
-                is_left_indexed_ ? pinned_index_left_.size()
+                left_use_index_data_ ? pinned_index_left_.size()
                 : segment->type() == SegmentType::Growing
                     ? upper_div(segment_chunk_reader_.active_count_,
                                 segment_chunk_reader_.SizePerChunk())
                     : segment->num_chunk_data(left_field_);
             right_num_chunk_ =
-                is_right_indexed_ ? pinned_index_right_.size()
+                right_use_index_data_ ? pinned_index_right_.size()
                 : segment->type() == SegmentType::Growing
                     ? upper_div(segment_chunk_reader_.active_count_,
                                 segment_chunk_reader_.SizePerChunk())
                     : segment->num_chunk_data(right_field_);
             num_chunk_ = left_num_chunk_;
         } else {
-            num_chunk_ = is_left_indexed_
+            num_chunk_ = left_use_index_data_
                              ? pinned_index_left_.size()
                              : upper_div(segment_chunk_reader_.active_count_,
                                          segment_chunk_reader_.SizePerChunk());
         }
-
         AssertInfo(
             batch_size_ > 0,
             fmt::format("expr batch size should greater than zero, but now: {}",
@@ -190,7 +193,7 @@ class PhyCompareFilterExpr : public Expr {
     MoveCursor() override {
         if (!has_offset_input_) {
             if (segment_chunk_reader_.segment_->is_chunked()) {
-                if (is_left_indexed_) {
+                if (left_use_index_data_) {
                     MoveCursorForIndexed(left_current_chunk_pos_);
                 } else {
                     segment_chunk_reader_.MoveCursorForMultipleChunk(
@@ -200,7 +203,7 @@ class PhyCompareFilterExpr : public Expr {
                         left_num_chunk_,
                         batch_size_);
                 }
-                if (is_right_indexed_) {
+                if (right_use_index_data_) {
                     MoveCursorForIndexed(right_current_chunk_pos_);
                 } else {
                     segment_chunk_reader_.MoveCursorForMultipleChunk(
@@ -236,12 +239,27 @@ class PhyCompareFilterExpr : public Expr {
     }
 
  private:
+    segcore::PinnedIndexView
+    LeftPinnedIndexForRawLookup() const {
+        if (!left_use_index_data_) {
+            return {};
+        }
+        return {pinned_index_left_.data(), pinned_index_left_.size()};
+    }
+
+    segcore::PinnedIndexView
+    RightPinnedIndexForRawLookup() const {
+        if (!right_use_index_data_) {
+            return {};
+        }
+        return {pinned_index_right_.data(), pinned_index_right_.size()};
+    }
+
     int64_t
     GetCurrentRows() {
         if (segment_chunk_reader_.segment_->is_chunked()) {
             auto current_rows =
-                is_left_indexed_ && segment_chunk_reader_.segment_->HasRawData(
-                                        left_field_.get())
+                left_use_index_data_
                     ? left_current_chunk_pos_
                     : segment_chunk_reader_.segment_->num_rows_until_chunk(
                           left_field_, left_current_chunk_id_) +
@@ -543,6 +561,8 @@ class PhyCompareFilterExpr : public Expr {
     const FieldId right_field_;
     bool is_left_indexed_;
     bool is_right_indexed_;
+    bool left_use_index_data_;
+    bool right_use_index_data_;
     int64_t num_chunk_{0};
     int64_t left_num_chunk_{0};
     int64_t right_num_chunk_{0};

--- a/internal/core/src/mmap/ChunkedColumnGroup.h
+++ b/internal/core/src/mmap/ChunkedColumnGroup.h
@@ -63,6 +63,10 @@ class ChunkedColumnGroup {
 
     PinWrapper<GroupChunk*>
     GetGroupChunk(milvus::OpContext* op_ctx, int64_t chunk_id) const {
+        AssertInfo(
+            chunk_id >= 0 && chunk_id < num_chunks_,
+            "[StorageV2] chunk_id out of range: " + std::to_string(chunk_id) +
+                ", num_chunks: " + std::to_string(num_chunks_));
         auto ca = SemiInlineGet(slot_->PinCells(op_ctx, {chunk_id}));
         auto chunk = ca->get_cell_of(chunk_id);
         return PinWrapper<GroupChunk*>(ca, chunk);
@@ -71,6 +75,12 @@ class ChunkedColumnGroup {
     std::shared_ptr<CellAccessor<GroupChunk>>
     GetGroupChunks(milvus::OpContext* op_ctx,
                    const std::vector<int64_t>& chunk_ids) {
+        for (auto chunk_id : chunk_ids) {
+            AssertInfo(chunk_id >= 0 && chunk_id < num_chunks_,
+                       "[StorageV2] chunk_id out of range: " +
+                           std::to_string(chunk_id) +
+                           ", num_chunks: " + std::to_string(num_chunks_));
+        }
         return SemiInlineGet(slot_->PinCells(op_ctx, chunk_ids));
     }
 

--- a/internal/core/src/query/PlanProto.cpp
+++ b/internal/core/src/query/PlanProto.cpp
@@ -324,7 +324,7 @@ ProtoParser::CreatePlan(const proto::plan::PlanNode& plan_node_proto) {
     auto plan_node = PlanNodeFromProto(plan_node_proto);
     plan->plan_node_ = std::move(plan_node);
     plan->tag2field_["$0"] = plan->plan_node_->search_info_.field_id_;
-    ExtractedPlanInfo extra_info(schema->size());
+    ExtractedPlanInfo extra_info(schema->get_field_id_bitset_size());
     extra_info.add_involved_field(plan->plan_node_->search_info_.field_id_);
     plan->extra_info_opt_ = std::move(extra_info);
 

--- a/internal/core/src/query/PlanProtoTest.cpp
+++ b/internal/core/src/query/PlanProtoTest.cpp
@@ -15,6 +15,12 @@
 #include <vector>
 #include <chrono>
 
+#include "common/Schema.h"
+#include "common/Types.h"
+#include "knowhere/comp/index_param.h"
+#include "pb/plan.pb.h"
+#include "pb/schema.pb.h"
+#include "query/Plan.h"
 #include "query/PlanProto.h"
 
 TEST(PlanProto, NotSetUnsupported) {
@@ -29,4 +35,65 @@ TEST(PlanProto, NotSetUnsupported) {
     proto::plan::Expr expr_pb;
     ProtoParser parser(schema);
     ASSERT_ANY_THROW(parser.ParseExprs(expr_pb));
+}
+
+TEST(PlanProto, VectorArrayFieldIdGapInStructArray) {
+    namespace planpb = milvus::proto::plan;
+    namespace schemapb = milvus::proto::schema;
+
+    schemapb::CollectionSchema schema_proto;
+    auto pk = schema_proto.add_fields();
+    pk->set_name("id");
+    pk->set_fieldid(100);
+    pk->set_is_primary_key(true);
+    pk->set_data_type(schemapb::DataType::Int64);
+
+    auto struct_array = schema_proto.add_struct_array_fields();
+    struct_array->set_name("evidence");
+    struct_array->set_fieldid(146);
+
+    auto evidence_item = struct_array->add_fields();
+    evidence_item->set_name("evidence[evidence_item]");
+    evidence_item->set_fieldid(147);
+    evidence_item->set_data_type(schemapb::DataType::Array);
+    evidence_item->set_element_type(schemapb::DataType::VarChar);
+    auto max_length = evidence_item->add_type_params();
+    max_length->set_key("max_length");
+    max_length->set_value("512");
+    auto max_capacity = evidence_item->add_type_params();
+    max_capacity->set_key("max_capacity");
+    max_capacity->set_value("200");
+
+    auto evidence_vector = struct_array->add_fields();
+    evidence_vector->set_name("evidence[evidence_vector]");
+    evidence_vector->set_fieldid(148);
+    evidence_vector->set_data_type(schemapb::DataType::ArrayOfVector);
+    evidence_vector->set_element_type(schemapb::DataType::FloatVector);
+    auto dim = evidence_vector->add_type_params();
+    dim->set_key("dim");
+    dim->set_value("1024");
+    auto vector_max_capacity = evidence_vector->add_type_params();
+    vector_max_capacity->set_key("max_capacity");
+    vector_max_capacity->set_value("200");
+
+    auto schema = milvus::Schema::ParseFrom(schema_proto);
+    ASSERT_EQ(schema->size(), 3);
+    ASSERT_EQ(schema->get_field_id_bitset_size(), 49);
+
+    planpb::PlanNode plan_node;
+    auto vector_anns = plan_node.mutable_vector_anns();
+    vector_anns->set_vector_type(planpb::VectorType::EmbListFloatVector);
+    vector_anns->set_field_id(148);
+    vector_anns->set_placeholder_tag("$0");
+    auto query_info = vector_anns->mutable_query_info();
+    query_info->set_metric_type("MAX_SIM_COSINE");
+    query_info->set_topk(10);
+    query_info->set_round_decimal(-1);
+    query_info->set_search_params(R"({"ef": 200})");
+
+    auto plan = milvus::query::CreateSearchPlanFromPlanNode(schema, plan_node);
+    ASSERT_TRUE(plan->extra_info_opt_.has_value());
+    const auto& involved_fields = plan->extra_info_opt_->involved_fields_;
+    ASSERT_EQ(involved_fields.size(), 49);
+    EXPECT_TRUE(involved_fields[48]);
 }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1463,9 +1463,9 @@ ChunkedSegmentSealedImpl::ChunkedSegmentSealedImpl(
     int64_t segment_id,
     bool is_sorted_by_pk)
     : segcore_config_(segcore_config),
-      field_data_ready_bitset_(schema->size()),
-      index_ready_bitset_(schema->size()),
-      binlog_index_bitset_(schema->size()),
+      field_data_ready_bitset_(schema->get_field_id_bitset_size()),
+      index_ready_bitset_(schema->get_field_id_bitset_size()),
+      binlog_index_bitset_(schema->get_field_id_bitset_size()),
       ngram_fields_(std::unordered_set<FieldId>(schema->size())),
       scalar_indexings_(std::unordered_map<FieldId, index::CacheIndexBasePtr>(
           schema->size())),
@@ -2628,9 +2628,9 @@ void
 ChunkedSegmentSealedImpl::Reopen(SchemaPtr sch) {
     std::unique_lock lck(mutex_);
 
-    field_data_ready_bitset_.resize(sch->size());
-    index_ready_bitset_.resize(sch->size());
-    binlog_index_bitset_.resize(sch->size());
+    field_data_ready_bitset_.resize(sch->get_field_id_bitset_size());
+    index_ready_bitset_.resize(sch->get_field_id_bitset_size());
+    binlog_index_bitset_.resize(sch->get_field_id_bitset_size());
 
     auto absent_fields = sch->AbsentFields(*schema_);
     for (const auto& field_meta : *absent_fields) {

--- a/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
@@ -24,17 +24,23 @@
 #include <cstdint>
 #include <iostream>
 #include <memory>
+#include <numeric>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "common/Consts.h"
 #include "common/FieldDataInterface.h"
 #include "common/Schema.h"
 #include "common/Types.h"
+#include "common/protobuf_utils.h"
+#include "exec/expression/EvalCtx.h"
+#include "exec/expression/Expr.h"
 #include "expr/ITypeExpr.h"
 #include "index/IndexFactory.h"
 #include "index/IndexInfo.h"
 #include "index/Meta.h"
+#include "index/ScalarIndex.h"
 #include "milvus-storage/common/constants.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/packed/writer.h"
@@ -43,6 +49,7 @@
 #include "pb/schema.pb.h"
 #include "query/ExecPlanNodeVisitor.h"
 #include "segcore/SegcoreConfig.h"
+#include "segcore/SegmentChunkReader.h"
 #include "segcore/SegmentSealed.h"
 #include "segcore/ChunkedSegmentSealedImpl.h"
 #include "segcore/SegmentGrowing.h"
@@ -56,6 +63,98 @@
 using namespace milvus;
 using namespace milvus::segcore;
 using namespace milvus::segcore::storagev1translator;
+
+namespace {
+class RawLookupOnlyIndex : public index::ScalarIndex<int64_t> {
+ public:
+    RawLookupOnlyIndex() : index::ScalarIndex<int64_t>("raw_lookup_only") {
+    }
+
+    index::ScalarIndexType
+    GetIndexType() const override {
+        return index::ScalarIndexType::STLSORT;
+    }
+
+    void
+    Build(size_t, const int64_t*, const bool* = nullptr) override {
+    }
+
+    const TargetBitmap
+    In(size_t, const int64_t*) override {
+        return {};
+    }
+
+    const TargetBitmap
+    NotIn(size_t, const int64_t*) override {
+        return {};
+    }
+
+    const TargetBitmap
+    IsNull() override {
+        return {};
+    }
+
+    TargetBitmap
+    IsNotNull() override {
+        return {};
+    }
+
+    const TargetBitmap
+    Range(const int64_t&, OpType) override {
+        return {};
+    }
+
+    const TargetBitmap
+    Range(const int64_t&, bool, const int64_t&, bool) override {
+        return {};
+    }
+
+    std::optional<int64_t>
+    Reverse_Lookup(size_t offset) const override {
+        last_lookup_offset = offset;
+        return static_cast<int64_t>(offset);
+    }
+
+    void
+    Build(const Config& = {}) override {
+    }
+
+    BinarySet
+    Serialize(const Config& = {}) override {
+        return {};
+    }
+
+    void
+    Load(const BinarySet&, const Config& = {}) override {
+    }
+
+    void
+    Load(milvus::tracer::TraceContext, const Config& = {}) override {
+    }
+
+    int64_t
+    Count() override {
+        return 0;
+    }
+
+    int64_t
+    Size() override {
+        return 0;
+    }
+
+    index::IndexStatsPtr
+    Upload(const Config& = {}) override {
+        return nullptr;
+    }
+
+    const bool
+    HasRawData() const override {
+        return true;
+    }
+
+    mutable size_t last_lookup_offset = 0;
+};
+}  // namespace
 
 class TestChunkSegmentStorageV2 : public testing::TestWithParam<bool> {
  protected:
@@ -212,6 +311,78 @@ class TestChunkSegmentStorageV2 : public testing::TestWithParam<bool> {
         ASSERT_TRUE(status.ok());
     }
 
+    int64_t
+    RowCount() const {
+        return chunk_num * test_data_count;
+    }
+
+    void
+    LoadInt64ScalarIndex(const std::string& index_type) {
+        auto fid = fields.at("int64");
+        auto file_manager_ctx = storage::FileManagerContext();
+        file_manager_ctx.fieldDataMeta.field_schema.set_data_type(
+            milvus::proto::schema::Int64);
+        file_manager_ctx.fieldDataMeta.field_schema.set_fieldid(fid.get());
+        file_manager_ctx.fieldDataMeta.field_id = fid.get();
+        milvus::storage::IndexMeta index_meta;
+        index_meta.field_id = fid.get();
+        index_meta.build_id = 1000 + fid.get();
+        index_meta.index_version = 2000 + fid.get();
+        file_manager_ctx.indexMeta = index_meta;
+
+        index::CreateIndexInfo create_index_info;
+        create_index_info.field_type = milvus::DataType::INT64;
+        create_index_info.index_type = index_type;
+        auto index = index::IndexFactory::GetInstance().CreateScalarIndex(
+            create_index_info, file_manager_ctx);
+
+        std::vector<int64_t> data(RowCount());
+        std::iota(data.begin(), data.end(), 0);
+        index->BuildWithRawDataForUT(data.size(), data.data());
+
+        segcore::LoadIndexInfo load_index_info;
+        load_index_info.index_params = GenIndexParams(index.get());
+        load_index_info.cache_index =
+            CreateTestCacheIndex("int64_scalar_index", std::move(index));
+        load_index_info.field_id = fid.get();
+        segment->LoadIndex(load_index_info);
+    }
+
+    void
+    LoadString1ScalarIndex(const std::string& index_type) {
+        auto fid = fields.at("string1");
+        auto file_manager_ctx = storage::FileManagerContext();
+        file_manager_ctx.fieldDataMeta.field_schema.set_data_type(
+            milvus::proto::schema::VarChar);
+        file_manager_ctx.fieldDataMeta.field_schema.set_fieldid(fid.get());
+        file_manager_ctx.fieldDataMeta.field_id = fid.get();
+        milvus::storage::IndexMeta index_meta;
+        index_meta.field_id = fid.get();
+        index_meta.build_id = 1000 + fid.get();
+        index_meta.index_version = 2000 + fid.get();
+        file_manager_ctx.indexMeta = index_meta;
+
+        index::CreateIndexInfo create_index_info;
+        create_index_info.field_type = milvus::DataType::VARCHAR;
+        create_index_info.index_type = index_type;
+        auto index = index::IndexFactory::GetInstance().CreateScalarIndex(
+            create_index_info, file_manager_ctx);
+
+        std::vector<std::string> data;
+        data.reserve(RowCount());
+        for (int64_t i = 0; i < RowCount(); ++i) {
+            data.push_back("test" + std::to_string(i));
+        }
+        index->BuildWithRawDataForUT(data.size(), data.data());
+
+        segcore::LoadIndexInfo load_index_info;
+        load_index_info.index_params = GenIndexParams(index.get());
+        load_index_info.cache_index =
+            CreateTestCacheIndex("string1_scalar_index", std::move(index));
+        load_index_info.field_id = fid.get();
+        segment->LoadIndex(load_index_info);
+    }
+
     segcore::SegmentSealedUPtr segment;
     int chunk_num = 2;
     int test_data_count = 10000;
@@ -349,6 +520,210 @@ TEST_P(TestChunkSegmentStorageV2, TestCompareExpr) {
     final = query::ExecuteQueryExpr(
         plan, segment.get(), chunk_num * test_data_count, MAX_TIMESTAMP);
     ASSERT_EQ(chunk_num * test_data_count, final.count());
+}
+
+TEST_P(TestChunkSegmentStorageV2, TestColumnExprWithScalarIndexRawData) {
+    LoadInt64ScalarIndex(index::ASCENDING_SORT);
+    ASSERT_TRUE(segment->HasRawData(fields.at("int64").get()));
+
+    auto query_config = std::make_shared<exec::QueryConfig>(
+        std::unordered_map<std::string, std::string>{
+            {exec::QueryConfig::kExprEvalBatchSize, "4096"}});
+    exec::QueryContext query_context("column_expr_scalar_index_raw_data",
+                                     segment.get(),
+                                     RowCount(),
+                                     MAX_TIMESTAMP,
+                                     0,
+                                     0,
+                                     query::PlanOptions(),
+                                     query_config);
+    exec::ExecContext exec_context(&query_context);
+
+    std::vector<expr::TypedExprPtr> exprs{std::make_shared<expr::ColumnExpr>(
+        expr::ColumnInfo(fields.at("int64"), milvus::DataType::INT64))};
+    exec::ExprSet expr_set(exprs, &exec_context);
+    exec::EvalCtx eval_context(&exec_context);
+
+    int64_t offset = 0;
+    while (offset < RowCount()) {
+        std::vector<VectorPtr> results;
+        expr_set.Eval(eval_context, results);
+        ASSERT_EQ(1, results.size());
+
+        auto column = std::dynamic_pointer_cast<ColumnVector>(results[0]);
+        ASSERT_NE(column, nullptr);
+        auto expected_batch_size = std::min<int64_t>(4096, RowCount() - offset);
+        ASSERT_EQ(expected_batch_size, column->size());
+
+        auto values = column->RawAsValues<int64_t>();
+        for (int64_t i = 0; i < expected_batch_size; ++i) {
+            ASSERT_TRUE(column->ValidAt(i));
+            ASSERT_EQ(offset + i, values[i]);
+        }
+        offset += expected_batch_size;
+    }
+}
+
+TEST_P(TestChunkSegmentStorageV2,
+       TestChunkDataAccessorFallsBackWhenPinnedIndexViewIsEmpty) {
+    SegmentChunkReader reader(nullptr, segment.get(), RowCount());
+
+    auto accessor = reader.GetChunkDataAccessor(
+        milvus::DataType::INT64, fields.at("int64"), 0, {});
+
+    auto value = accessor(7);
+    ASSERT_TRUE(value.has_value());
+    ASSERT_EQ(7, segcore::get_from_variant<int64_t>(value));
+}
+
+TEST_P(TestChunkSegmentStorageV2,
+       TestChunkDataAccessorUsesGlobalOffsetForFieldLevelScalarIndex) {
+    auto raw_lookup_index = std::make_unique<RawLookupOnlyIndex>();
+    std::vector<PinWrapper<const index::IndexBase*>> pinned_indexes;
+    pinned_indexes.emplace_back(raw_lookup_index.get());
+
+    SegmentChunkReader reader(nullptr, segment.get(), RowCount());
+    auto accessor = reader.GetChunkDataAccessor(
+        milvus::DataType::INT64,
+        fields.at("int64"),
+        1,
+        {pinned_indexes.data(), pinned_indexes.size()});
+
+    auto expected_offset =
+        segment->num_rows_until_chunk(fields.at("int64"), 1) + 7;
+    auto value = accessor(7);
+    ASSERT_TRUE(value.has_value());
+    ASSERT_EQ(expected_offset, segcore::get_from_variant<int64_t>(value));
+    ASSERT_EQ(expected_offset, raw_lookup_index->last_lookup_offset);
+}
+
+TEST_P(TestChunkSegmentStorageV2,
+       TestChunkDataAccessorThrowsWhenPinnedIndexAndRawDataAreUnavailable) {
+    LoadString1ScalarIndex(index::INVERTED_INDEX_TYPE);
+    segment->DropFieldData(fields.at("string1"));
+    ASSERT_FALSE(segment->HasRawData(fields.at("string1").get()));
+    ASSERT_EQ(0, segment->num_chunk_data(fields.at("string1")));
+
+    SegmentChunkReader reader(nullptr, segment.get(), RowCount());
+    EXPECT_THROW(reader.GetChunkDataAccessor(
+                     milvus::DataType::VARCHAR, fields.at("string1"), 0, {}),
+                 SegcoreError);
+}
+
+TEST_P(TestChunkSegmentStorageV2,
+       TestColumnExprOffsetInputFallsBackWhenScalarIndexHasNoRawData) {
+    LoadInt64ScalarIndex(index::INVERTED_INDEX_TYPE);
+    ASSERT_FALSE(segment->HasRawData(fields.at("int64").get()));
+
+    auto query_config = std::make_shared<exec::QueryConfig>(
+        std::unordered_map<std::string, std::string>{
+            {exec::QueryConfig::kExprEvalBatchSize, "4096"}});
+    exec::QueryContext query_context("column_expr_offset_input",
+                                     segment.get(),
+                                     RowCount(),
+                                     MAX_TIMESTAMP,
+                                     0,
+                                     0,
+                                     query::PlanOptions(),
+                                     query_config);
+    exec::ExecContext exec_context(&query_context);
+
+    std::vector<expr::TypedExprPtr> exprs{std::make_shared<expr::ColumnExpr>(
+        expr::ColumnInfo(fields.at("int64"), milvus::DataType::INT64))};
+    exec::ExprSet expr_set(exprs, &exec_context);
+
+    exec::OffsetVector offsets;
+    offsets.push_back(7);
+    offsets.push_back(7000);
+    exec::EvalCtx eval_context(&exec_context, &expr_set, &offsets);
+
+    std::vector<VectorPtr> results;
+    expr_set.Eval(eval_context, results);
+    ASSERT_EQ(1, results.size());
+
+    auto column = std::dynamic_pointer_cast<ColumnVector>(results[0]);
+    ASSERT_NE(column, nullptr);
+    ASSERT_EQ(offsets.size(), column->size());
+
+    auto values = column->RawAsValues<int64_t>();
+    for (size_t i = 0; i < offsets.size(); ++i) {
+        ASSERT_TRUE(column->ValidAt(i));
+        ASSERT_EQ(offsets[i], values[i]);
+    }
+}
+
+TEST_P(TestChunkSegmentStorageV2,
+       TestColumnExprOffsetInputThrowsWhenIndexAndRawDataAreUnavailable) {
+    LoadString1ScalarIndex(index::INVERTED_INDEX_TYPE);
+    segment->DropFieldData(fields.at("string1"));
+    ASSERT_FALSE(segment->HasRawData(fields.at("string1").get()));
+    ASSERT_EQ(0, segment->num_chunk_data(fields.at("string1")));
+
+    auto query_config = std::make_shared<exec::QueryConfig>(
+        std::unordered_map<std::string, std::string>{
+            {exec::QueryConfig::kExprEvalBatchSize, "4096"}});
+    exec::QueryContext query_context("column_expr_offset_input_no_raw_data",
+                                     segment.get(),
+                                     RowCount(),
+                                     MAX_TIMESTAMP,
+                                     0,
+                                     0,
+                                     query::PlanOptions(),
+                                     query_config);
+    exec::ExecContext exec_context(&query_context);
+
+    std::vector<expr::TypedExprPtr> exprs{std::make_shared<expr::ColumnExpr>(
+        expr::ColumnInfo(fields.at("string1"), milvus::DataType::VARCHAR))};
+    exec::ExprSet expr_set(exprs, &exec_context);
+
+    exec::OffsetVector offsets;
+    offsets.push_back(0);
+    exec::EvalCtx eval_context(&exec_context, &expr_set, &offsets);
+
+    std::vector<VectorPtr> results;
+    EXPECT_THROW(expr_set.Eval(eval_context, results), SegcoreError);
+}
+
+TEST_P(TestChunkSegmentStorageV2,
+       TestCompareExprSkippedCursorWithScalarIndexWithoutRawData) {
+    LoadInt64ScalarIndex(index::INVERTED_INDEX_TYPE);
+    ASSERT_FALSE(segment->HasRawData(fields.at("int64").get()));
+
+    proto::plan::GenericValue threshold;
+    threshold.set_int64_val(12000);
+    auto range_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(fields.at("int64"), milvus::DataType::INT64),
+        proto::plan::OpType::GreaterEqual,
+        threshold);
+    auto right_field = GetParam() ? fields.at("int64") : fields.at("pk");
+    auto compare_expr =
+        std::make_shared<expr::CompareExpr>(fields.at("int64"),
+                                            right_field,
+                                            milvus::DataType::INT64,
+                                            milvus::DataType::INT64,
+                                            proto::plan::OpType::Equal);
+    auto conjunct_expr = std::make_shared<expr::LogicalBinaryExpr>(
+        expr::LogicalBinaryExpr::OpType::And, range_expr, compare_expr);
+    auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                       conjunct_expr);
+
+    auto query_config = std::make_shared<exec::QueryConfig>(
+        std::unordered_map<std::string, std::string>{
+            {exec::QueryConfig::kExprEvalBatchSize, "6000"}});
+    auto query_context =
+        std::make_shared<exec::QueryContext>(DEAFULT_QUERY_ID,
+                                             segment.get(),
+                                             RowCount(),
+                                             MAX_TIMESTAMP,
+                                             0,
+                                             0,
+                                             query::PlanOptions(),
+                                             query_config);
+    auto plan_fragment = plan::PlanFragment(plan);
+    auto final =
+        query::ExecPlanNodeVisitor::ExecuteTask(plan_fragment, query_context);
+    final.flip();
+    ASSERT_EQ(RowCount() - threshold.int64_val(), final.count());
 }
 
 // Test DropFieldData behavior based on parquet file structure.

--- a/internal/core/src/segcore/SegmentChunkReader.cpp
+++ b/internal/core/src/segcore/SegmentChunkReader.cpp
@@ -16,19 +16,43 @@
 #include "segcore/SegmentChunkReader.h"
 
 namespace milvus::segcore {
+namespace {
+std::pair<const index::IndexBase*, int64_t>
+GetIndexAndBaseOffset(const SegmentInternalInterface* segment,
+                      FieldId field_id,
+                      int chunk_id,
+                      PinnedIndexView pinned_index) {
+    if (pinned_index.empty()) {
+        return {nullptr, 0};
+    }
+
+    if (chunk_id >= 0 && segment->type() == SegmentType::Sealed &&
+        segment->is_chunked() && pinned_index.size() == 1) {
+        auto base_offset =
+            chunk_id == 0 ? 0
+                          : segment->num_rows_until_chunk(field_id, chunk_id);
+        return {pinned_index[0].get(), base_offset};
+    }
+
+    if (chunk_id >= 0 && static_cast<size_t>(chunk_id) < pinned_index.size()) {
+        return {pinned_index[static_cast<size_t>(chunk_id)].get(), 0};
+    }
+
+    return {nullptr, 0};
+}
+}  // namespace
+
 template <typename T>
 MultipleChunkDataAccessor
 SegmentChunkReader::GetMultipleChunkDataAccessor(
     FieldId field_id,
     int64_t& current_chunk_id,
     int64_t& current_chunk_pos,
-    const std::vector<PinWrapper<const index::IndexBase*>>& pinned_index)
-    const {
+    PinnedIndexView pinned_index) const {
     const index::IndexBase* index = nullptr;
     if (current_chunk_id < pinned_index.size()) {
         index = pinned_index[current_chunk_id].get();
     }
-
     if (index) {
         auto index_ptr = dynamic_cast<const index::ScalarIndex<T>*>(index);
         if (index_ptr->HasRawData()) {
@@ -46,6 +70,12 @@ SegmentChunkReader::GetMultipleChunkDataAccessor(
                 };
         }
     }
+    auto num_chunks = segment_->num_chunk_data(field_id);
+    AssertInfo(current_chunk_id < num_chunks,
+               "field {} cursor chunk_id {} exceeds num_chunks {}",
+               field_id.get(),
+               current_chunk_id,
+               num_chunks);
     // pw is captured by value, each time we need to access a new chunk, we need to
     // pin a new Chunk.
     auto pw = segment_->chunk_data<T>(op_ctx_, field_id, current_chunk_id);
@@ -54,12 +84,18 @@ SegmentChunkReader::GetMultipleChunkDataAccessor(
     auto chunk_valid_data = chunk_info.valid_data();
     auto current_chunk_size = segment_->chunk_size(field_id, current_chunk_id);
     return [=,
+            this,
             pw = std::move(pw),
             &current_chunk_id,
             &current_chunk_pos]() mutable -> const data_access_type {
         if (current_chunk_pos >= current_chunk_size) {
             current_chunk_id++;
             current_chunk_pos = 0;
+            AssertInfo(current_chunk_id < num_chunks,
+                       "field {} cursor chunk_id {} exceeds num_chunks {}",
+                       field_id.get(),
+                       current_chunk_id,
+                       num_chunks);
             // the old chunk will be unpinned, pw will now pin the new chunk.
             pw = segment_->chunk_data<T>(op_ctx_, field_id, current_chunk_id);
             chunk_data = pw.get().data();
@@ -81,13 +117,11 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
     FieldId field_id,
     int64_t& current_chunk_id,
     int64_t& current_chunk_pos,
-    const std::vector<PinWrapper<const index::IndexBase*>>& pinned_index)
-    const {
+    PinnedIndexView pinned_index) const {
     const index::IndexBase* index = nullptr;
     if (current_chunk_id < pinned_index.size()) {
         index = pinned_index[current_chunk_id].get();
     }
-
     if (index) {
         auto index_ptr =
             dynamic_cast<const index::ScalarIndex<std::string>*>(index);
@@ -105,6 +139,12 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
             };
         }
     }
+    auto num_chunks = segment_->num_chunk_data(field_id);
+    AssertInfo(current_chunk_id < num_chunks,
+               "field {} cursor chunk_id {} exceeds num_chunks {}",
+               field_id.get(),
+               current_chunk_id,
+               num_chunks);
     if (segment_->type() == SegmentType::Growing &&
         !storage::MmapManager::GetInstance()
              .GetMmapConfig()
@@ -122,12 +162,18 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
                 chunk_data,
                 chunk_valid_data,
                 current_chunk_size,
+                num_chunks,
                 // pw = std::move(pw),
                 &current_chunk_id,
                 &current_chunk_pos]() mutable -> const data_access_type {
             if (current_chunk_pos >= current_chunk_size) {
                 current_chunk_id++;
                 current_chunk_pos = 0;
+                AssertInfo(current_chunk_id < num_chunks,
+                           "field {} cursor chunk_id {} exceeds num_chunks {}",
+                           field_id.get(),
+                           current_chunk_id,
+                           num_chunks);
                 pw = segment_->chunk_data<std::string>(
                     op_ctx_, field_id, current_chunk_id);
                 chunk_data = pw.get().data();
@@ -148,12 +194,18 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
         auto current_chunk_size =
             segment_->chunk_size(field_id, current_chunk_id);
         return [=,
+                this,
                 pw = std::move(pw),
                 &current_chunk_id,
                 &current_chunk_pos]() mutable -> const data_access_type {
             if (current_chunk_pos >= current_chunk_size) {
                 current_chunk_id++;
                 current_chunk_pos = 0;
+                AssertInfo(current_chunk_id < num_chunks,
+                           "field {} cursor chunk_id {} exceeds num_chunks {}",
+                           field_id.get(),
+                           current_chunk_id,
+                           num_chunks);
                 pw = segment_->chunk_view<std::string_view>(
                     op_ctx_, field_id, current_chunk_id);
                 current_chunk_size =
@@ -177,8 +229,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor(
     FieldId field_id,
     int64_t& current_chunk_id,
     int64_t& current_chunk_pos,
-    const std::vector<PinWrapper<const index::IndexBase*>>& pinned_index)
-    const {
+    PinnedIndexView pinned_index) const {
     switch (data_type) {
         case DataType::BOOL:
             return GetMultipleChunkDataAccessor<bool>(
@@ -215,25 +266,30 @@ SegmentChunkReader::GetMultipleChunkDataAccessor(
 
 template <typename T>
 ChunkDataAccessor
-SegmentChunkReader::GetChunkDataAccessor(
-    FieldId field_id,
-    int chunk_id,
-    int data_barrier,
-    const std::vector<PinWrapper<const index::IndexBase*>>& pinned_index)
-    const {
-    if (chunk_id >= data_barrier) {
-        auto index = pinned_index[chunk_id].get();
-        auto index_ptr = dynamic_cast<const index::ScalarIndex<T>*>(index);
-        if (index->HasRawData()) {
-            return [index_ptr](int i) mutable -> const data_access_type {
-                auto raw = index_ptr->Reverse_Lookup(i);
+SegmentChunkReader::GetChunkDataAccessor(FieldId field_id,
+                                         int chunk_id,
+                                         PinnedIndexView pinned_index) const {
+    auto index_and_base_offset =
+        GetIndexAndBaseOffset(segment_, field_id, chunk_id, pinned_index);
+    auto index = index_and_base_offset.first;
+    auto base_offset = index_and_base_offset.second;
+    auto index_ptr = dynamic_cast<const index::ScalarIndex<T>*>(index);
+    if (index_ptr != nullptr && index_ptr->HasRawData()) {
+        return
+            [index_ptr, base_offset](int i) mutable -> const data_access_type {
+                auto raw = index_ptr->Reverse_Lookup(base_offset + i);
                 if (!raw.has_value()) {
                     return std::nullopt;
                 }
                 return raw.value();
             };
-        }
     }
+    auto num_chunks = segment_->num_chunk_data(field_id);
+    AssertInfo(chunk_id >= 0 && chunk_id < num_chunks,
+               "field {} chunk_id {} exceeds raw data chunks {}",
+               field_id.get(),
+               chunk_id,
+               num_chunks);
     auto pw = segment_->chunk_data<T>(op_ctx_, field_id, chunk_id);
     return [pw = std::move(pw)](int i) mutable -> const data_access_type {
         auto chunk_info = pw.get();
@@ -249,25 +305,29 @@ SegmentChunkReader::GetChunkDataAccessor(
 template <>
 ChunkDataAccessor
 SegmentChunkReader::GetChunkDataAccessor<std::string>(
-    FieldId field_id,
-    int chunk_id,
-    int data_barrier,
-    const std::vector<PinWrapper<const index::IndexBase*>>& pinned_index)
-    const {
-    if (chunk_id >= data_barrier) {
-        auto index = pinned_index[chunk_id].get();
-        auto index_ptr =
-            dynamic_cast<const index::ScalarIndex<std::string>*>(index);
-        if (index_ptr->HasRawData()) {
-            return [index_ptr](int i) mutable -> const data_access_type {
-                auto raw = index_ptr->Reverse_Lookup(i);
+    FieldId field_id, int chunk_id, PinnedIndexView pinned_index) const {
+    auto index_and_base_offset =
+        GetIndexAndBaseOffset(segment_, field_id, chunk_id, pinned_index);
+    auto index = index_and_base_offset.first;
+    auto base_offset = index_and_base_offset.second;
+    auto index_ptr =
+        dynamic_cast<const index::ScalarIndex<std::string>*>(index);
+    if (index_ptr != nullptr && index_ptr->HasRawData()) {
+        return
+            [index_ptr, base_offset](int i) mutable -> const data_access_type {
+                auto raw = index_ptr->Reverse_Lookup(base_offset + i);
                 if (!raw.has_value()) {
                     return std::nullopt;
                 }
                 return raw.value();
             };
-        }
     }
+    auto num_chunks = segment_->num_chunk_data(field_id);
+    AssertInfo(chunk_id >= 0 && chunk_id < num_chunks,
+               "field {} chunk_id {} exceeds raw data chunks {}",
+               field_id.get(),
+               chunk_id,
+               num_chunks);
     if (segment_->type() == SegmentType::Growing &&
         !storage::MmapManager::GetInstance()
              .GetMmapConfig()
@@ -297,40 +357,36 @@ SegmentChunkReader::GetChunkDataAccessor<std::string>(
 }
 
 ChunkDataAccessor
-SegmentChunkReader::GetChunkDataAccessor(
-    DataType data_type,
-    FieldId field_id,
-    int chunk_id,
-    int data_barrier,
-    const std::vector<PinWrapper<const index::IndexBase*>>& pinned_index)
-    const {
+SegmentChunkReader::GetChunkDataAccessor(DataType data_type,
+                                         FieldId field_id,
+                                         int chunk_id,
+                                         PinnedIndexView pinned_index) const {
     switch (data_type) {
         case DataType::BOOL:
-            return GetChunkDataAccessor<bool>(
-                field_id, chunk_id, data_barrier, pinned_index);
+            return GetChunkDataAccessor<bool>(field_id, chunk_id, pinned_index);
         case DataType::INT8:
             return GetChunkDataAccessor<int8_t>(
-                field_id, chunk_id, data_barrier, pinned_index);
+                field_id, chunk_id, pinned_index);
         case DataType::INT16:
             return GetChunkDataAccessor<int16_t>(
-                field_id, chunk_id, data_barrier, pinned_index);
+                field_id, chunk_id, pinned_index);
         case DataType::INT32:
             return GetChunkDataAccessor<int32_t>(
-                field_id, chunk_id, data_barrier, pinned_index);
+                field_id, chunk_id, pinned_index);
         case DataType::TIMESTAMPTZ:
         case DataType::INT64:
             return GetChunkDataAccessor<int64_t>(
-                field_id, chunk_id, data_barrier, pinned_index);
+                field_id, chunk_id, pinned_index);
         case DataType::FLOAT:
             return GetChunkDataAccessor<float>(
-                field_id, chunk_id, data_barrier, pinned_index);
+                field_id, chunk_id, pinned_index);
         case DataType::DOUBLE:
             return GetChunkDataAccessor<double>(
-                field_id, chunk_id, data_barrier, pinned_index);
+                field_id, chunk_id, pinned_index);
         case DataType::VARCHAR:
         case DataType::TEXT: {
             return GetChunkDataAccessor<std::string>(
-                field_id, chunk_id, data_barrier, pinned_index);
+                field_id, chunk_id, pinned_index);
         }
         default:
             ThrowInfo(DataTypeInvalid, "unsupported data type: {}", data_type);

--- a/internal/core/src/segcore/SegmentChunkReader.h
+++ b/internal/core/src/segcore/SegmentChunkReader.h
@@ -16,10 +16,17 @@
 #pragma once
 
 #include <fmt/core.h>
+#include <boost/core/span.hpp>
 #include <boost/variant.hpp>
+#include <functional>
 #include <optional>
+#include <string>
+#include <vector>
 
+#include "cachinglayer/CacheSlot.h"
+#include "common/OpContext.h"
 #include "common/Types.h"
+#include "index/Index.h"
 #include "segcore/SegmentInterface.h"
 
 namespace milvus::segcore {
@@ -36,6 +43,7 @@ using data_access_type = std::optional<boost::variant<bool,
 
 using ChunkDataAccessor = std::function<const data_access_type(int)>;
 using MultipleChunkDataAccessor = std::function<const data_access_type()>;
+using PinnedIndexView = boost::span<const PinWrapper<const index::IndexBase*>>;
 
 // Helper to extract a value of type T from data_access_type.
 // For std::string, handles both std::string and std::string_view in the variant.
@@ -91,21 +99,17 @@ class SegmentChunkReader {
     }
 
     MultipleChunkDataAccessor
-    GetMultipleChunkDataAccessor(
-        DataType data_type,
-        FieldId field_id,
-        int64_t& current_chunk_id,
-        int64_t& current_chunk_pos,
-        const std::vector<PinWrapper<const index::IndexBase*>>& pinned_index)
-        const;
+    GetMultipleChunkDataAccessor(DataType data_type,
+                                 FieldId field_id,
+                                 int64_t& current_chunk_id,
+                                 int64_t& current_chunk_pos,
+                                 PinnedIndexView pinned_index) const;
 
     ChunkDataAccessor
     GetChunkDataAccessor(DataType data_type,
                          FieldId field_id,
                          int chunk_id,
-                         int data_barrier,
-                         const std::vector<PinWrapper<const index::IndexBase*>>&
-                             pinned_index) const;
+                         PinnedIndexView pinned_index) const;
 
     void
     MoveCursorForMultipleChunk(int64_t& current_chunk_id,
@@ -167,20 +171,16 @@ class SegmentChunkReader {
  private:
     template <typename T>
     MultipleChunkDataAccessor
-    GetMultipleChunkDataAccessor(
-        FieldId field_id,
-        int64_t& current_chunk_id,
-        int64_t& current_chunk_pos,
-        const std::vector<PinWrapper<const index::IndexBase*>>& pinned_index)
-        const;
+    GetMultipleChunkDataAccessor(FieldId field_id,
+                                 int64_t& current_chunk_id,
+                                 int64_t& current_chunk_pos,
+                                 PinnedIndexView pinned_index) const;
 
     template <typename T>
     ChunkDataAccessor
     GetChunkDataAccessor(FieldId field_id,
                          int chunk_id,
-                         int data_barrier,
-                         const std::vector<PinWrapper<const index::IndexBase*>>&
-                             pinned_index) const;
+                         PinnedIndexView pinned_index) const;
 
     const int64_t size_per_chunk_;
     milvus::OpContext* op_ctx_;

--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -500,9 +502,10 @@ func (gc *garbageCollector) recycleUnusedBinlogFiles(ctx context.Context) {
 	defer func() { log.Info("recycleUnusedBinlogFiles done", zap.Duration("timeCost", time.Since(start))) }()
 
 	type scanTask struct {
-		prefix  string
-		checker func(objectInfo *storage.ChunkObjectInfo, segment *SegmentInfo) bool
-		label   string
+		prefix            string
+		checker           func(objectInfo *storage.ChunkObjectInfo, segment *SegmentInfo) bool
+		segmentIDFromPath func(rootPath, filePath string) (int64, error)
+		label             string
 	}
 	scanTasks := []scanTask{
 		{
@@ -510,7 +513,8 @@ func (gc *garbageCollector) recycleUnusedBinlogFiles(ctx context.Context) {
 			checker: func(objectInfo *storage.ChunkObjectInfo, segment *SegmentInfo) bool {
 				return segment != nil
 			},
-			label: metrics.InsertFileLabel,
+			segmentIDFromPath: storage.ParseSegmentIDByBinlog,
+			label:             metrics.InsertFileLabel,
 		},
 		{
 			prefix: path.Join(gc.option.cli.RootPath(), common.SegmentStatslogPath),
@@ -522,7 +526,8 @@ func (gc *garbageCollector) recycleUnusedBinlogFiles(ctx context.Context) {
 				}
 				return segment != nil && segment.IsStatsLogExists(logID)
 			},
-			label: metrics.StatFileLabel,
+			segmentIDFromPath: storage.ParseSegmentIDByBinlog,
+			label:             metrics.StatFileLabel,
 		},
 		{
 			prefix: path.Join(gc.option.cli.RootPath(), common.SegmentDeltaLogPath),
@@ -534,19 +539,56 @@ func (gc *garbageCollector) recycleUnusedBinlogFiles(ctx context.Context) {
 				}
 				return segment != nil && segment.IsDeltaLogExists(logID)
 			},
-			label: metrics.DeleteFileLabel,
+			segmentIDFromPath: storage.ParseSegmentIDByBinlog,
+			label:             metrics.DeleteFileLabel,
+		},
+		{
+			prefix: path.Join(gc.option.cli.RootPath(), common.TextIndexPath),
+			checker: func(objectInfo *storage.ChunkObjectInfo, segment *SegmentInfo) bool {
+				if segment == nil {
+					return false
+				}
+				_, ok := getTextLogPaths(segment, gc.option.cli.RootPath())[objectInfo.FilePath]
+				return ok
+			},
+			segmentIDFromPath: parseSegmentIDFromTextIndexPath,
+			label:             common.TextIndexPath,
+		},
+		{
+			prefix: path.Join(gc.option.cli.RootPath(), common.JSONStatsPath),
+			checker: func(objectInfo *storage.ChunkObjectInfo, segment *SegmentInfo) bool {
+				if segment == nil {
+					return false
+				}
+				_, ok := getJSONKeyLogs(segment, gc)[objectInfo.FilePath]
+				return ok
+			},
+			segmentIDFromPath: parseSegmentIDFromJSONStatsPath,
+			label:             common.JSONStatsPath,
+		},
+		{
+			prefix: path.Join(gc.option.cli.RootPath(), common.JSONIndexPath),
+			checker: func(objectInfo *storage.ChunkObjectInfo, segment *SegmentInfo) bool {
+				if segment == nil {
+					return false
+				}
+				_, ok := getJSONKeyLogs(segment, gc)[objectInfo.FilePath]
+				return ok
+			},
+			segmentIDFromPath: parseSegmentIDFromJSONIndexPath,
+			label:             common.JSONIndexPath,
 		},
 	}
 
 	for _, task := range scanTasks {
-		gc.recycleUnusedBinLogWithChecker(ctx, task.prefix, task.label, task.checker)
+		gc.recycleUnusedBinLogWithChecker(ctx, task.prefix, task.label, task.segmentIDFromPath, task.checker)
 	}
 	metrics.GarbageCollectorRunCount.WithLabelValues(fmt.Sprint(paramtable.GetNodeID())).Add(1)
 }
 
 // recycleUnusedBinLogWithChecker scans the prefix and checks the path with checker.
 // GC the file if checker returns false.
-func (gc *garbageCollector) recycleUnusedBinLogWithChecker(ctx context.Context, prefix string, label string, checker func(objectInfo *storage.ChunkObjectInfo, segment *SegmentInfo) bool) {
+func (gc *garbageCollector) recycleUnusedBinLogWithChecker(ctx context.Context, prefix string, label string, segmentIDFromPath func(rootPath, filePath string) (int64, error), checker func(objectInfo *storage.ChunkObjectInfo, segment *SegmentInfo) bool) {
 	logger := log.With(zap.String("prefix", prefix))
 	logger.Info("garbageCollector recycleUnusedBinlogFiles start", zap.String("prefix", prefix))
 	lastFilePath := ""
@@ -569,7 +611,7 @@ func (gc *garbageCollector) recycleUnusedBinLogWithChecker(ctx context.Context, 
 
 		// Parse segmentID from file path.
 		// TODO: Does all files in the same segment have the same segmentID?
-		segmentID, err := storage.ParseSegmentIDByBinlog(gc.option.cli.RootPath(), chunkInfo.FilePath)
+		segmentID, err := segmentIDFromPath(gc.option.cli.RootPath(), chunkInfo.FilePath)
 		if err != nil {
 			unexpectedFailure.Inc()
 			logger.Warn("garbageCollector recycleUnusedBinlogFiles parse segment id error",
@@ -955,6 +997,38 @@ func (gc *garbageCollector) isExpire(dropts Timestamp) bool {
 	return time.Since(droptime) > gc.option.dropTolerance
 }
 
+func parseSegmentIDFromAuxIndexPath(rootPath, filePath string) (int64, error) {
+	if !strings.HasPrefix(filePath, rootPath) {
+		return 0, merr.WrapErrServiceInternal(fmt.Sprintf("path %q does not contain rootPath %q", filePath, rootPath))
+	}
+	p := strings.TrimPrefix(filePath[len(rootPath):], "/")
+	parts := strings.Split(p, "/")
+	if len(parts) < 8 || (parts[0] != common.TextIndexPath && parts[0] != common.JSONIndexPath) {
+		return 0, merr.WrapErrServiceInternal(fmt.Sprintf("not an auxiliary index path: %s", filePath))
+	}
+	return strconv.ParseInt(parts[5], 10, 64)
+}
+
+func parseSegmentIDFromJSONStatsPath(rootPath, filePath string) (int64, error) {
+	if !strings.HasPrefix(filePath, rootPath) {
+		return 0, merr.WrapErrServiceInternal(fmt.Sprintf("path %q does not contain rootPath %q", filePath, rootPath))
+	}
+	p := strings.TrimPrefix(filePath[len(rootPath):], "/")
+	parts := strings.Split(p, "/")
+	if len(parts) < 9 || parts[0] != common.JSONStatsPath {
+		return 0, merr.WrapErrServiceInternal(fmt.Sprintf("not a json stats path: %s", filePath))
+	}
+	return strconv.ParseInt(parts[6], 10, 64)
+}
+
+func parseSegmentIDFromTextIndexPath(rootPath, filePath string) (int64, error) {
+	return parseSegmentIDFromAuxIndexPath(rootPath, filePath)
+}
+
+func parseSegmentIDFromJSONIndexPath(rootPath, filePath string) (int64, error) {
+	return parseSegmentIDFromAuxIndexPath(rootPath, filePath)
+}
+
 func getLogs(sinfo *SegmentInfo) map[string]struct{} {
 	logs := make(map[string]struct{})
 	for _, flog := range sinfo.GetBinlogs() {
@@ -981,9 +1055,24 @@ func getLogs(sinfo *SegmentInfo) map[string]struct{} {
 }
 
 func getTextLogs(sinfo *SegmentInfo) map[string]struct{} {
+	return getTextLogPaths(sinfo, "")
+}
+
+func getTextLogPaths(sinfo *SegmentInfo, rootPath string) map[string]struct{} {
 	textLogs := make(map[string]struct{})
 	for _, flog := range sinfo.GetTextStatsLogs() {
 		for _, file := range flog.GetFiles() {
+			if rootPath != "" {
+				file = path.Join(rootPath, common.TextIndexPath,
+					fmt.Sprintf("%d", flog.GetBuildID()),
+					fmt.Sprintf("%d", flog.GetVersion()),
+					fmt.Sprintf("%d", sinfo.GetCollectionID()),
+					fmt.Sprintf("%d", sinfo.GetPartitionID()),
+					fmt.Sprintf("%d", sinfo.GetID()),
+					fmt.Sprintf("%d", flog.GetFieldID()),
+					file,
+				)
+			}
 			textLogs[file] = struct{}{}
 		}
 	}
@@ -995,8 +1084,23 @@ func getJSONKeyLogs(sinfo *SegmentInfo, gc *garbageCollector) map[string]struct{
 	jsonkeyLogs := make(map[string]struct{})
 	for _, flog := range sinfo.GetJsonKeyStats() {
 		for _, file := range flog.GetFiles() {
-			prefix := fmt.Sprintf("%s/%s/%d/%d/%d/%d/%d/%d", gc.option.cli.RootPath(), common.JSONIndexPath,
-				flog.GetBuildID(), flog.GetVersion(), sinfo.GetCollectionID(), sinfo.GetPartitionID(), sinfo.GetID(), flog.GetFieldID())
+			var prefix string
+			if flog.GetJsonKeyStatsDataFormat() >= 2 {
+				prefix = path.Join(
+					gc.option.cli.RootPath(),
+					common.JSONStatsPath,
+					fmt.Sprintf("%d", flog.GetJsonKeyStatsDataFormat()),
+					fmt.Sprintf("%d", flog.GetBuildID()),
+					fmt.Sprintf("%d", flog.GetVersion()),
+					fmt.Sprintf("%d", sinfo.GetCollectionID()),
+					fmt.Sprintf("%d", sinfo.GetPartitionID()),
+					fmt.Sprintf("%d", sinfo.GetID()),
+					fmt.Sprintf("%d", flog.GetFieldID()),
+				)
+			} else {
+				prefix = fmt.Sprintf("%s/%s/%d/%d/%d/%d/%d/%d", gc.option.cli.RootPath(), common.JSONIndexPath,
+					flog.GetBuildID(), flog.GetVersion(), sinfo.GetCollectionID(), sinfo.GetPartitionID(), sinfo.GetID(), flog.GetFieldID())
+			}
 			file = path.Join(prefix, file)
 			jsonkeyLogs[file] = struct{}{}
 		}

--- a/internal/datacoord/garbage_collector_test.go
+++ b/internal/datacoord/garbage_collector_test.go
@@ -2154,10 +2154,11 @@ func TestGarbageCollector_removeDroppedSegmentFiles_TextAndJSONLogs(t *testing.T
 			},
 			JsonKeyStats: map[int64]*datapb.JsonKeyStats{
 				102: {
-					FieldID: 102,
-					BuildID: 11,
-					Version: 1,
-					Files:   []string{jsonFile},
+					FieldID:                102,
+					BuildID:                11,
+					Version:                1,
+					Files:                  []string{jsonFile},
+					JsonKeyStatsDataFormat: 1,
 				},
 			},
 		},
@@ -2172,4 +2173,191 @@ func TestGarbageCollector_removeDroppedSegmentFiles_TextAndJSONLogs(t *testing.T
 	assert.Contains(t, removed, textFile)
 	assert.Contains(t, removed, expectedJSON)
 	assert.Contains(t, removed, indexFile)
+}
+
+func TestGarbageCollector_removeDroppedSegmentFiles_JSONStatsV2(t *testing.T) {
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+	cm.EXPECT().RootPath().Return("root").Maybe()
+	var mu sync.Mutex
+	removed := make(map[string]struct{})
+	cm.EXPECT().Remove(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, filePath string) error {
+			mu.Lock()
+			defer mu.Unlock()
+			removed[filePath] = struct{}{}
+			return nil
+		}).Maybe()
+
+	gc := newGarbageCollector(nil, nil, GcOption{cli: cm})
+	const jsonFile = "shared_key_index/inverted_index_0"
+	const indexFile = "idx/extra/file-99"
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:           7001,
+			CollectionID: 100,
+			PartitionID:  10,
+			JsonKeyStats: map[int64]*datapb.JsonKeyStats{
+				102: {
+					FieldID:                102,
+					BuildID:                11,
+					Version:                1,
+					Files:                  []string{jsonFile},
+					JsonKeyStatsDataFormat: 3,
+				},
+			},
+		},
+	}
+
+	indexFiles := map[string]struct{}{indexFile: {}}
+	require.NoError(t, gc.removeDroppedSegmentFiles(ctx, segment, indexFiles))
+
+	expectedJSON := path.Join("root", common.JSONStatsPath, "3", "11", "1", "100", "10", "7001", "102", jsonFile)
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Contains(t, removed, expectedJSON)
+	assert.Contains(t, removed, indexFile)
+}
+
+func TestGarbageCollector_recycleUnusedBinlogFiles_TextAndJSONStats(t *testing.T) {
+	ctx := context.Background()
+
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            1003,
+			CollectionID:  100,
+			PartitionID:   10,
+			State:         commonpb.SegmentState_Flushed,
+			InsertChannel: "ch1",
+			TextStatsLogs: map[int64]*datapb.TextIndexStats{
+				101: {
+					FieldID: 101,
+					Version: 1,
+					BuildID: 501,
+					Files:   []string{"text_file_keep"},
+				},
+			},
+			JsonKeyStats: map[int64]*datapb.JsonKeyStats{
+				102: {
+					FieldID:                102,
+					Version:                1,
+					BuildID:                502,
+					Files:                  []string{"json_file_keep"},
+					JsonKeyStatsDataFormat: 1,
+				},
+				103: {
+					FieldID:                103,
+					Version:                1,
+					BuildID:                503,
+					Files:                  []string{"shared_key_index/json_file_keep"},
+					JsonKeyStatsDataFormat: 3,
+				},
+			},
+		},
+	}
+
+	meta := &meta{
+		catalog:   &datacoord.Catalog{},
+		indexMeta: &indexMeta{},
+		segments: &SegmentsInfo{
+			segments: map[int64]*SegmentInfo{1003: segment},
+		},
+		channelCPs: newChannelCps(),
+	}
+
+	cli := storage.NewLocalChunkManager(objectstorage.RootPath("gc"))
+	gc := newGarbageCollector(meta, &ServerHandler{}, GcOption{
+		cli:              cli,
+		enabled:          true,
+		checkInterval:    time.Millisecond * 10,
+		scanInterval:     time.Hour * 7 * 24,
+		missingTolerance: 0,
+		dropTolerance:    time.Hour * 24,
+	})
+
+	removedFiles := []string{}
+	mockRemove := mockey.Mock((*storage.LocalChunkManager).Remove).To(
+		func(cm *storage.LocalChunkManager, ctx context.Context, filePath string) error {
+			removedFiles = append(removedFiles, filePath)
+			return nil
+		}).Build()
+	defer mockRemove.UnPatch()
+
+	mockWalk := mockey.Mock((*storage.LocalChunkManager).WalkWithPrefix).To(
+		func(cm *storage.LocalChunkManager, ctx context.Context, prefix string, recursive bool, fn storage.ChunkObjectWalkFunc) error {
+			switch {
+			case strings.Contains(prefix, common.TextIndexPath):
+				fn(&storage.ChunkObjectInfo{FilePath: "gc/text_log/501/1/100/10/1003/101/text_file_keep", ModifyTime: time.Now().Add(-time.Hour)})
+				fn(&storage.ChunkObjectInfo{FilePath: "gc/text_log/501/1/100/10/1003/101/text_file_gc", ModifyTime: time.Now().Add(-time.Hour)})
+			case strings.Contains(prefix, common.JSONStatsPath):
+				fn(&storage.ChunkObjectInfo{FilePath: "gc/json_stats/3/503/1/100/10/1003/103/shared_key_index/json_file_keep", ModifyTime: time.Now().Add(-time.Hour)})
+				fn(&storage.ChunkObjectInfo{FilePath: "gc/json_stats/3/503/1/100/10/1003/103/shared_key_index/json_file_gc", ModifyTime: time.Now().Add(-time.Hour)})
+			case strings.Contains(prefix, common.JSONIndexPath):
+				fn(&storage.ChunkObjectInfo{FilePath: "gc/json_key_index_log/502/1/100/10/1003/102/json_file_keep", ModifyTime: time.Now().Add(-time.Hour)})
+				fn(&storage.ChunkObjectInfo{FilePath: "gc/json_key_index_log/502/1/100/10/1003/102/json_file_gc", ModifyTime: time.Now().Add(-time.Hour)})
+			}
+			return nil
+		}).Build()
+	defer mockWalk.UnPatch()
+
+	gc.recycleUnusedBinlogFiles(ctx)
+
+	assert.ElementsMatch(t, []string{
+		"gc/text_log/501/1/100/10/1003/101/text_file_gc",
+		"gc/json_stats/3/503/1/100/10/1003/103/shared_key_index/json_file_gc",
+		"gc/json_key_index_log/502/1/100/10/1003/102/json_file_gc",
+	}, removedFiles)
+}
+
+func TestGarbageCollector_recycleUnusedBinlogFiles_TextAndJSONStats_SegmentNil(t *testing.T) {
+	ctx := context.Background()
+
+	meta := &meta{
+		catalog:   &datacoord.Catalog{},
+		indexMeta: &indexMeta{},
+		segments: &SegmentsInfo{
+			segments: map[int64]*SegmentInfo{},
+		},
+		channelCPs: newChannelCps(),
+	}
+
+	cli := storage.NewLocalChunkManager(objectstorage.RootPath("gc"))
+	gc := newGarbageCollector(meta, &ServerHandler{}, GcOption{
+		cli:              cli,
+		enabled:          true,
+		checkInterval:    time.Millisecond * 10,
+		scanInterval:     time.Hour * 7 * 24,
+		missingTolerance: 0,
+		dropTolerance:    time.Hour * 24,
+	})
+
+	removedFiles := []string{}
+	mockRemove := mockey.Mock((*storage.LocalChunkManager).Remove).To(
+		func(cm *storage.LocalChunkManager, ctx context.Context, filePath string) error {
+			removedFiles = append(removedFiles, filePath)
+			return nil
+		}).Build()
+	defer mockRemove.UnPatch()
+
+	mockWalk := mockey.Mock((*storage.LocalChunkManager).WalkWithPrefix).To(
+		func(cm *storage.LocalChunkManager, ctx context.Context, prefix string, recursive bool, fn storage.ChunkObjectWalkFunc) error {
+			switch {
+			case strings.Contains(prefix, common.TextIndexPath):
+				fn(&storage.ChunkObjectInfo{FilePath: "gc/text_log/501/1/100/10/1003/101/text_file_gc", ModifyTime: time.Now().Add(-time.Hour)})
+			case strings.Contains(prefix, common.JSONStatsPath):
+				fn(&storage.ChunkObjectInfo{FilePath: "gc/json_stats/3/503/1/100/10/1003/103/shared_key_index/json_file_gc", ModifyTime: time.Now().Add(-time.Hour)})
+			case strings.Contains(prefix, common.JSONIndexPath):
+				fn(&storage.ChunkObjectInfo{FilePath: "gc/json_key_index_log/502/1/100/10/1003/102/json_file_gc", ModifyTime: time.Now().Add(-time.Hour)})
+			}
+			return nil
+		}).Build()
+	defer mockWalk.UnPatch()
+
+	gc.recycleUnusedBinlogFiles(ctx)
+
+	assert.ElementsMatch(t, []string{
+		"gc/text_log/501/1/100/10/1003/101/text_file_gc",
+		"gc/json_stats/3/503/1/100/10/1003/103/shared_key_index/json_file_gc",
+		"gc/json_key_index_log/502/1/100/10/1003/102/json_file_gc",
+	}, removedFiles)
 }

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1923,15 +1923,81 @@ func checkAndFlattenStructFieldData(schema *schemapb.CollectionSchema, insertMsg
 				structName, schema.Name, len(structArrays.StructArrays.Fields), len(structSchema.GetFields()))
 		}
 
-		// Check the array length of the struct array field data
+		subFieldSchemaByName := make(map[string]*schemapb.FieldSchema, len(structSchema.GetFields()))
+		for _, subFieldSchema := range structSchema.GetFields() {
+			subFieldSchemaByName[subFieldSchema.GetName()] = subFieldSchema
+		}
+
+		vectorElementWidth := func(subField *schemapb.FieldData, subFieldSchema *schemapb.FieldSchema) (int, error) {
+			dim, err := typeutil.GetDim(subFieldSchema)
+			if err != nil {
+				return 0, errors.Wrapf(err, "sub-field '%s' in struct '%s'", subField.GetFieldName(), structName)
+			}
+			if dim <= 0 {
+				return 0, merr.WrapErrParameterInvalidMsg("sub-field '%s' in struct '%s': invalid dim %d", subField.GetFieldName(), structName, dim)
+			}
+			switch subFieldSchema.GetElementType() {
+			case schemapb.DataType_FloatVector, schemapb.DataType_Int8Vector:
+				return int(dim), nil
+			case schemapb.DataType_BinaryVector:
+				return int((dim + 7) / 8), nil
+			case schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector:
+				return int(dim * 2), nil
+			default:
+				return 0, merr.WrapErrParameterInvalidMsg("sub-field '%s' in struct '%s': unsupported array-of-vector element type %s",
+					subField.GetFieldName(), structName, subFieldSchema.GetElementType().String())
+			}
+		}
+
+		type rowElementCounter struct {
+			name  string
+			count func(row int) (int, error)
+		}
+		rowElementCounters := make([]rowElementCounter, 0, len(structArrays.StructArrays.Fields))
+
+		// Check the array length of the struct array field data and the per-row
+		// struct element count of every sub-field.
 		expectedArrayLen := -1
 		for _, subField := range structArrays.StructArrays.Fields {
+			schemaFieldName := typeutil.ConcatStructFieldName(structName, subField.GetFieldName())
+			subFieldSchema := subFieldSchemaByName[schemaFieldName]
+			if subFieldSchema == nil {
+				return merr.WrapErrParameterInvalidMsg("sub-field '%s' not found in struct schema '%s'", subField.GetFieldName(), structName)
+			}
+
 			var currentArrayLen int
 
 			switch subFieldData := subField.Field.(type) {
 			case *schemapb.FieldData_Scalars:
 				if scalarArray := subFieldData.Scalars.GetArrayData(); scalarArray != nil {
 					currentArrayLen = len(scalarArray.Data)
+					if len(structArrays.StructArrays.Fields) > 1 {
+						rowElementCounters = append(rowElementCounters, rowElementCounter{
+							name: subField.GetFieldName(),
+							count: func(row int) (int, error) {
+								array := scalarArray.GetData()[row]
+								if array.GetData() == nil {
+									return 0, merr.WrapErrParameterInvalidMsg("nil array data")
+								}
+								switch subFieldSchema.GetElementType() {
+								case schemapb.DataType_Bool:
+									return len(array.GetBoolData().GetData()), nil
+								case schemapb.DataType_Int8, schemapb.DataType_Int16, schemapb.DataType_Int32:
+									return len(array.GetIntData().GetData()), nil
+								case schemapb.DataType_Int64:
+									return len(array.GetLongData().GetData()), nil
+								case schemapb.DataType_Float:
+									return len(array.GetFloatData().GetData()), nil
+								case schemapb.DataType_Double:
+									return len(array.GetDoubleData().GetData()), nil
+								case schemapb.DataType_VarChar, schemapb.DataType_String:
+									return len(array.GetStringData().GetData()), nil
+								default:
+									return 0, merr.WrapErrParameterInvalidMsg("unsupported array element type %s", subFieldSchema.GetElementType().String())
+								}
+							},
+						})
+					}
 				} else {
 					return fmt.Errorf("scalar array data is nil in struct field '%s', sub-field '%s'",
 						structName, subField.FieldName)
@@ -1939,6 +2005,42 @@ func checkAndFlattenStructFieldData(schema *schemapb.CollectionSchema, insertMsg
 			case *schemapb.FieldData_Vectors:
 				if vectorArray := subFieldData.Vectors.GetVectorArray(); vectorArray != nil {
 					currentArrayLen = len(vectorArray.Data)
+					if len(structArrays.StructArrays.Fields) > 1 {
+						var vectorWidth int
+						rowElementCounters = append(rowElementCounters, rowElementCounter{
+							name: subField.GetFieldName(),
+							count: func(row int) (int, error) {
+								if vectorWidth == 0 {
+									var err error
+									vectorWidth, err = vectorElementWidth(subField, subFieldSchema)
+									if err != nil {
+										return 0, err
+									}
+								}
+								vector := vectorArray.GetData()[row]
+								if vector.GetData() == nil {
+									return 0, merr.WrapErrParameterInvalidMsg("nil vector array data")
+								}
+								var payloadLen int
+								switch subFieldSchema.GetElementType() {
+								case schemapb.DataType_FloatVector:
+									payloadLen = len(vector.GetFloatVector().GetData())
+								case schemapb.DataType_BinaryVector:
+									payloadLen = len(vector.GetBinaryVector())
+								case schemapb.DataType_Float16Vector:
+									payloadLen = len(vector.GetFloat16Vector())
+								case schemapb.DataType_BFloat16Vector:
+									payloadLen = len(vector.GetBfloat16Vector())
+								case schemapb.DataType_Int8Vector:
+									payloadLen = len(vector.GetInt8Vector())
+								}
+								if payloadLen%vectorWidth != 0 {
+									return 0, merr.WrapErrParameterInvalidMsg("payload length %d is not divisible by vector width %d", payloadLen, vectorWidth)
+								}
+								return payloadLen / vectorWidth, nil
+							},
+						})
+					}
 				} else {
 					return fmt.Errorf("vector array data is nil in struct field '%s', sub-field '%s'",
 						structName, subField.FieldName)
@@ -1953,7 +2055,35 @@ func checkAndFlattenStructFieldData(schema *schemapb.CollectionSchema, insertMsg
 				return fmt.Errorf("inconsistent array length in struct field '%s': expected %d, got %d for sub-field '%s'",
 					structName, expectedArrayLen, currentArrayLen, subField.FieldName)
 			}
+		}
 
+		if len(rowElementCounters) > 1 && expectedArrayLen > 0 {
+			refCounter := rowElementCounters[0]
+			refElementCounts := make([]int, expectedArrayLen)
+			for row := 0; row < expectedArrayLen; row++ {
+				count, err := refCounter.count(row)
+				if err != nil {
+					return merr.WrapErrParameterInvalidMsg("struct '%s' row %d sub-field '%s': %s",
+						structName, row, refCounter.name, err.Error())
+				}
+				refElementCounts[row] = count
+			}
+			for _, counter := range rowElementCounters[1:] {
+				for row := 0; row < expectedArrayLen; row++ {
+					count, err := counter.count(row)
+					if err != nil {
+						return merr.WrapErrParameterInvalidMsg("struct '%s' row %d sub-field '%s': %s",
+							structName, row, counter.name, err.Error())
+					}
+					if count != refElementCounts[row] {
+						return merr.WrapErrParameterInvalidMsg("inconsistent struct element count in struct '%s' at row %d: '%s' has %d, '%s' has %d",
+							structName, row, refCounter.name, refElementCounts[row], counter.name, count)
+					}
+				}
+			}
+		}
+
+		for _, subField := range structArrays.StructArrays.Fields {
 			transformedFieldName := typeutil.ConcatStructFieldName(structName, subField.FieldName)
 			subFieldCopy := &schemapb.FieldData{
 				FieldName: transformedFieldName,

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -3437,12 +3437,14 @@ func BenchmarkCheckVarcharFormat(b *testing.B) {
 
 func TestCheckAndFlattenStructFieldData(t *testing.T) {
 	createTestSchema := func(name string, structFields []*schemapb.StructArrayFieldSchema, normalFields []*schemapb.FieldSchema) *schemapb.CollectionSchema {
-		return &schemapb.CollectionSchema{
+		schema := &schemapb.CollectionSchema{
 			Name:              name,
 			Description:       "test collection with struct array fields",
 			StructArrayFields: structFields,
 			Fields:            normalFields,
 		}
+		assert.NoError(t, transformStructFieldNames(schema))
+		return schema
 	}
 
 	createTestInsertMsg := func(collectionName string, fieldsData []*schemapb.FieldData) *msgstream.InsertMsg {
@@ -3596,8 +3598,13 @@ func TestCheckAndFlattenStructFieldData(t *testing.T) {
 		structField2 := &schemapb.StructArrayFieldSchema{
 			Name: "struct2",
 			Fields: []*schemapb.FieldSchema{
-				{Name: "field2", DataType: schemapb.DataType_Array},
-				{Name: "field3", DataType: schemapb.DataType_ArrayOfVector},
+				{Name: "field2", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Int32},
+				{
+					Name:        "field3",
+					DataType:    schemapb.DataType_ArrayOfVector,
+					ElementType: schemapb.DataType_FloatVector,
+					TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "1"}},
+				},
 			},
 		}
 		schema := createTestSchema("test_collection", []*schemapb.StructArrayFieldSchema{structField1, structField2}, nil)
@@ -3628,6 +3635,100 @@ func TestCheckAndFlattenStructFieldData(t *testing.T) {
 		assert.Contains(t, fieldNames, "struct1[field1]")
 		assert.Contains(t, fieldNames, "struct2[field2]")
 		assert.Contains(t, fieldNames, "struct2[field3]")
+	})
+
+	t.Run("error - vector payload length not divisible by dim", func(t *testing.T) {
+		structField := &schemapb.StructArrayFieldSchema{
+			Name: "test_struct",
+			Fields: []*schemapb.FieldSchema{
+				{Name: "field1", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Int32},
+				{
+					Name:        "field2",
+					DataType:    schemapb.DataType_ArrayOfVector,
+					ElementType: schemapb.DataType_FloatVector,
+					TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "768"}},
+				},
+			},
+		}
+		schema := createTestSchema("test_collection", []*schemapb.StructArrayFieldSchema{structField}, nil)
+
+		field1Data := createScalarArrayFieldData("field1", []*schemapb.ScalarField{
+			{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{1}}}},
+		})
+		field2Data := createVectorArrayFieldData("field2", []*schemapb.VectorField{
+			{Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: make([]float32, 512)}}},
+		})
+
+		structFieldData := createStructArrayFieldData("test_struct", []*schemapb.FieldData{field1Data, field2Data})
+		insertMsg := createTestInsertMsg("test_collection", []*schemapb.FieldData{structFieldData})
+
+		err := checkAndFlattenStructFieldData(schema, insertMsg)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "payload length 512 is not divisible by vector width 768")
+	})
+
+	t.Run("error - inconsistent struct element count with vector array", func(t *testing.T) {
+		structField := &schemapb.StructArrayFieldSchema{
+			Name: "test_struct",
+			Fields: []*schemapb.FieldSchema{
+				{Name: "field1", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Int32},
+				{
+					Name:        "field2",
+					DataType:    schemapb.DataType_ArrayOfVector,
+					ElementType: schemapb.DataType_FloatVector,
+					TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "768"}},
+				},
+			},
+		}
+		schema := createTestSchema("test_collection", []*schemapb.StructArrayFieldSchema{structField}, nil)
+
+		field1Data := createScalarArrayFieldData("field1", []*schemapb.ScalarField{
+			{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{1}}}},
+		})
+		field2Data := createVectorArrayFieldData("field2", []*schemapb.VectorField{
+			{Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: make([]float32, 1536)}}},
+		})
+
+		structFieldData := createStructArrayFieldData("test_struct", []*schemapb.FieldData{field1Data, field2Data})
+		insertMsg := createTestInsertMsg("test_collection", []*schemapb.FieldData{structFieldData})
+
+		err := checkAndFlattenStructFieldData(schema, insertMsg)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "inconsistent struct element count")
+		assert.Contains(t, err.Error(), "'field1' has 1, 'field2' has 2")
+	})
+
+	t.Run("success - matching scalar and vector struct element counts", func(t *testing.T) {
+		structField := &schemapb.StructArrayFieldSchema{
+			Name: "test_struct",
+			Fields: []*schemapb.FieldSchema{
+				{Name: "field1", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Int32},
+				{
+					Name:        "field2",
+					DataType:    schemapb.DataType_ArrayOfVector,
+					ElementType: schemapb.DataType_FloatVector,
+					TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "768"}},
+				},
+			},
+		}
+		schema := createTestSchema("test_collection", []*schemapb.StructArrayFieldSchema{structField}, nil)
+
+		field1Data := createScalarArrayFieldData("field1", []*schemapb.ScalarField{
+			{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{1, 2}}}},
+		})
+		field2Data := createVectorArrayFieldData("field2", []*schemapb.VectorField{
+			{Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: make([]float32, 1536)}}},
+		})
+
+		structFieldData := createStructArrayFieldData("test_struct", []*schemapb.FieldData{field1Data, field2Data})
+		insertMsg := createTestInsertMsg("test_collection", []*schemapb.FieldData{structFieldData})
+
+		err := checkAndFlattenStructFieldData(schema, insertMsg)
+
+		assert.NoError(t, err)
+		assert.Len(t, insertMsg.FieldsData, 2)
 	})
 
 	t.Run("success - mixed normal and struct fields", func(t *testing.T) {

--- a/internal/proxy/validate_util.go
+++ b/internal/proxy/validate_util.go
@@ -1073,6 +1073,23 @@ func (v *validateUtil) checkArrayOfVectorFieldData(field *schemapb.FieldData, fi
 		return merr.WrapErrParameterInvalid(expectStr, "got nil", msg)
 	}
 
+	dim, err := typeutil.GetDim(fieldSchema)
+	if err != nil {
+		return err
+	}
+
+	validateVectorCount := func(payloadLength int, elementsPerVector int) error {
+		if elementsPerVector <= 0 {
+			return merr.WrapErrParameterInvalidMsg("invalid dim %d for array of vector field %s", dim, field.GetFieldName())
+		}
+		if payloadLength%elementsPerVector != 0 {
+			return merr.WrapErrParameterInvalidMsg(
+				"array of vector field %s has invalid payload length %d, should be divisible by vector width %d",
+				field.GetFieldName(), payloadLength, elementsPerVector)
+		}
+		return nil
+	}
+
 	switch fieldSchema.GetElementType() {
 	case schemapb.DataType_FloatVector:
 		for _, vector := range data.GetData() {
@@ -1080,6 +1097,9 @@ func (v *validateUtil) checkArrayOfVectorFieldData(field *schemapb.FieldData, fi
 			if floatVector == nil {
 				msg := fmt.Sprintf("array of vector field '%v' is illegal, array type mismatch", field.GetFieldName())
 				return merr.WrapErrParameterInvalid("need float vector array", "got nil", msg)
+			}
+			if err := validateVectorCount(len(floatVector.GetData()), int(dim)); err != nil {
+				return err
 			}
 			if v.checkNAN {
 				if err := typeutil.VerifyFloats32(floatVector.GetData()); err != nil {
@@ -1095,6 +1115,9 @@ func (v *validateUtil) checkArrayOfVectorFieldData(field *schemapb.FieldData, fi
 				msg := fmt.Sprintf("array of vector field '%v' is illegal, array type mismatch", field.GetFieldName())
 				return merr.WrapErrParameterInvalid("need binary vector array", "got nil", msg)
 			}
+			if err := validateVectorCount(len(binaryVector), int((dim+7)/8)); err != nil {
+				return err
+			}
 		}
 		return nil
 	case schemapb.DataType_Float16Vector:
@@ -1103,6 +1126,9 @@ func (v *validateUtil) checkArrayOfVectorFieldData(field *schemapb.FieldData, fi
 			if float16Vector == nil {
 				msg := fmt.Sprintf("array of vector field '%v' is illegal, array type mismatch", field.GetFieldName())
 				return merr.WrapErrParameterInvalid("need float16 vector array", "got nil", msg)
+			}
+			if err := validateVectorCount(len(float16Vector), int(dim)*2); err != nil {
+				return err
 			}
 			if v.checkNAN {
 				if err := typeutil.VerifyFloats16(float16Vector); err != nil {
@@ -1118,6 +1144,9 @@ func (v *validateUtil) checkArrayOfVectorFieldData(field *schemapb.FieldData, fi
 				msg := fmt.Sprintf("array of vector field '%v' is illegal, array type mismatch", field.GetFieldName())
 				return merr.WrapErrParameterInvalid("need bfloat16 vector array", "got nil", msg)
 			}
+			if err := validateVectorCount(len(bfloat16Vector), int(dim)*2); err != nil {
+				return err
+			}
 			if v.checkNAN {
 				if err := typeutil.VerifyBFloats16(bfloat16Vector); err != nil {
 					return err
@@ -1131,6 +1160,9 @@ func (v *validateUtil) checkArrayOfVectorFieldData(field *schemapb.FieldData, fi
 			if int8Vector == nil {
 				msg := fmt.Sprintf("array of vector field '%v' is illegal, array type mismatch", field.GetFieldName())
 				return merr.WrapErrParameterInvalid("need int8 vector array", "got nil", msg)
+			}
+			if err := validateVectorCount(len(int8Vector), int(dim)); err != nil {
+				return err
 			}
 		}
 		return nil

--- a/internal/proxy/validate_util_test.go
+++ b/internal/proxy/validate_util_test.go
@@ -7116,7 +7116,9 @@ func Test_validateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 			},
 		}
 		fieldSchema := &schemapb.FieldSchema{
+			DataType:    schemapb.DataType_ArrayOfVector,
 			ElementType: schemapb.DataType_FloatVector,
+			TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
 		}
 		v := newValidateUtil()
 		err := v.checkArrayOfVectorFieldData(f, fieldSchema)
@@ -7164,7 +7166,9 @@ func Test_validateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 			},
 		}
 		fieldSchema := &schemapb.FieldSchema{
+			DataType:    schemapb.DataType_ArrayOfVector,
 			ElementType: schemapb.DataType_FloatVector,
+			TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "3"}},
 		}
 		v := newValidateUtil()
 		v.checkNAN = false
@@ -7193,7 +7197,9 @@ func Test_validateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 			},
 		}
 		fieldSchema := &schemapb.FieldSchema{
+			DataType:    schemapb.DataType_ArrayOfVector,
 			ElementType: schemapb.DataType_FloatVector,
+			TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "1"}},
 		}
 		v := newValidateUtil(withNANCheck())
 		err := v.checkArrayOfVectorFieldData(f, fieldSchema)
@@ -7228,11 +7234,46 @@ func Test_validateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 			},
 		}
 		fieldSchema := &schemapb.FieldSchema{
+			DataType:    schemapb.DataType_ArrayOfVector,
 			ElementType: schemapb.DataType_FloatVector,
+			TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
 		}
 		v := newValidateUtil(withNANCheck())
 		err := v.checkArrayOfVectorFieldData(f, fieldSchema)
 		assert.NoError(t, err)
+	})
+
+	t.Run("payload length not divisible by dim", func(t *testing.T) {
+		f := &schemapb.FieldData{
+			FieldName: "vec_array",
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Data: &schemapb.VectorField_VectorArray{
+						VectorArray: &schemapb.VectorArray{
+							Data: []*schemapb.VectorField{
+								{
+									Data: &schemapb.VectorField_FloatVector{
+										FloatVector: &schemapb.FloatArray{
+											Data: make([]float32, 512),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		fieldSchema := &schemapb.FieldSchema{
+			DataType:    schemapb.DataType_ArrayOfVector,
+			ElementType: schemapb.DataType_FloatVector,
+			TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "768"}},
+		}
+		v := newValidateUtil()
+		err := v.checkArrayOfVectorFieldData(f, fieldSchema)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "payload length 512")
+		assert.Contains(t, err.Error(), "vector width 768")
 	})
 }
 

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -1001,12 +1001,12 @@ func (sd *shardDelegator) ReleaseSegments(ctx context.Context, req *querypb.Rele
 		if err != nil {
 			log.Warn("delegator failed to find worker", zap.Error(err))
 			releaseErr = err
-		}
-		req.Base.TargetID = targetNodeID
-		err = worker.ReleaseSegments(ctx, req)
-		if err != nil {
-			log.Warn("worker failed to release segments", zap.Error(err))
-			releaseErr = err
+		} else {
+			req.Base.TargetID = targetNodeID
+			if err = worker.ReleaseSegments(ctx, req); err != nil {
+				log.Warn("worker failed to release segments", zap.Error(err))
+				releaseErr = err
+			}
 		}
 	}
 	if len(growing) > 0 {

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -1739,6 +1739,31 @@ func (s *DelegatorDataSuite) TestDelegatorData_ExcludeSegments() {
 	s.True(s.delegator.VerifyExcludedSegments(1, 5))
 }
 
+func (s *DelegatorDataSuite) TestReleaseSegmentsWorkerNotAvailable() {
+	ctx := context.Background()
+	// the target worker is offline/unhealthy, GetWorker returns no worker
+	s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).
+		Return(nil, merr.WrapErrNodeNotAvailable(1))
+
+	err := s.delegator.ReleaseSegments(ctx, &querypb.ReleaseSegmentsRequest{
+		Base:       commonpbutil.NewMsgBase(),
+		NodeID:     1,
+		SegmentIDs: []int64{1000},
+		Scope:      querypb.DataScope_All,
+	}, false)
+	s.Error(err)
+	// pin the contract: GetWorker's error code must reach the caller unmasked
+	s.ErrorIs(err, merr.ErrNodeNotAvailable)
+
+	// growingSegmentLock must be released even when the remote release fails,
+	// otherwise the channel's insert pipeline blocks forever
+	locked := s.delegator.growingSegmentLock.TryLock()
+	s.True(locked, "growingSegmentLock should be released after failed release")
+	if locked {
+		s.delegator.growingSegmentLock.Unlock()
+	}
+}
+
 func TestDelegatorDataSuite(t *testing.T) {
 	suite.Run(t, new(DelegatorDataSuite))
 }

--- a/internal/storage/record_reader.go
+++ b/internal/storage/record_reader.go
@@ -38,10 +38,10 @@ func (pr *packedRecordReader) Next() (Record, error) {
 }
 
 func (pr *packedRecordReader) Close() error {
-	if pr.reader != nil {
-		return pr.reader.Close()
+	if pr == nil || pr.reader == nil {
+		return nil
 	}
-	return nil
+	return pr.reader.Close()
 }
 
 func newPackedRecordReader(
@@ -108,10 +108,19 @@ func (ir *IterativeRecordReader) Next() (Record, error) {
 		if closeErr != nil {
 			return nil, closeErr
 		}
-		ir.cur, err = ir.iterate()
-		if err != nil {
-			return nil, err
+		// Clear cur before iterating: iterate() returns a typed-nil reader
+		// (e.g. a nil *packedRecordReader boxed into the RecordReader
+		// interface) together with an error when opening the next chunk
+		// fails, e.g. a binlog object is missing in object storage. Assigning
+		// that to ir.cur would leave a non-nil interface holding a nil pointer,
+		// and the deferred Close() would then dereference it and panic. Only
+		// publish the reader once iterate() succeeds.
+		ir.cur = nil
+		next, iterErr := ir.iterate()
+		if iterErr != nil {
+			return nil, iterErr
 		}
+		ir.cur = next
 		rec, err = ir.cur.Next()
 	}
 	return rec, err

--- a/internal/storage/record_reader_test.go
+++ b/internal/storage/record_reader_test.go
@@ -1,0 +1,97 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"io"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+// exhaustedChunkReader is a minimal RecordReader that is already at EOF and
+// records whether it was closed. It stands in for a binlog chunk that opened
+// successfully and has been fully consumed.
+type exhaustedChunkReader struct {
+	closed bool
+}
+
+func (r *exhaustedChunkReader) Next() (Record, error) { return nil, io.EOF }
+
+func (r *exhaustedChunkReader) Close() error {
+	r.closed = true
+	return nil
+}
+
+// TestIterativeRecordReader_MissingChunkDoesNotPanic reproduces #50927: when a
+// later binlog chunk's object is missing in object storage, newPackedRecordReader
+// returns a nil *packedRecordReader together with an error, and iterate() boxes
+// that nil pointer into a non-nil RecordReader interface. The reader must surface
+// the error from Next() and must NOT panic on the deferred Close() (previously a
+// nil-pointer dereference that crashed the DataNode into CrashLoopBackOff).
+func TestIterativeRecordReader_MissingChunkDoesNotPanic(t *testing.T) {
+	missingErr := errors.New("IOError: Path does not exist")
+	chunk := &exhaustedChunkReader{}
+	call := 0
+	ir := &IterativeRecordReader{
+		iterate: func() (RecordReader, error) {
+			call++
+			if call == 1 {
+				// first chunk opens fine (and is already exhausted)
+				return chunk, nil
+			}
+			// second chunk's object is missing: mirror newPackedRecordReader
+			// returning a typed-nil *packedRecordReader together with an error.
+			var pr *packedRecordReader
+			return pr, missingErr
+		},
+	}
+
+	// Drive it the way storage.Sort does: read until a non-nil error.
+	var gotErr error
+	for {
+		if _, err := ir.Next(); err != nil {
+			gotErr = err
+			break
+		}
+	}
+	assert.ErrorIs(t, gotErr, missingErr, "the missing-object error must be surfaced, not swallowed/recovered")
+	assert.True(t, chunk.closed, "the exhausted first chunk must have been closed")
+
+	// The deferred Close() in sortSegment must not panic on the failed chunk.
+	assert.NotPanics(t, func() {
+		assert.NoError(t, ir.Close())
+	})
+}
+
+// TestPackedRecordReader_CloseNilReceiverDoesNotPanic pins the defense-in-depth
+// half of the #50927 fix: Close() on a typed-nil reader (the shape produced when
+// newPackedRecordReader fails and its nil result is boxed into a RecordReader
+// interface) must be a safe no-op, not a nil-pointer dereference.
+func TestPackedRecordReader_CloseNilReceiverDoesNotPanic(t *testing.T) {
+	var pr *packedRecordReader
+	assert.NotPanics(t, func() {
+		assert.NoError(t, pr.Close())
+	})
+
+	// Boxed into the interface, exactly as the deferred Close in sortSegment sees it.
+	var rr RecordReader = pr
+	assert.NotPanics(t, func() {
+		assert.NoError(t, rr.Close())
+	})
+}

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array.py
@@ -1515,6 +1515,133 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         assert len(struct_search_results[0]) > 0
 
     @pytest.mark.tags(CaseLabel.L0)
+    def test_search_struct_array_last_vector_subfield(self):
+        """
+        target: test search on a vector sub-field after multiple struct array parent fields
+        method: create multiple struct arrays so parent field IDs create gaps, then search the last vector sub-field
+        expected: search returns results
+        """
+        collection_name = cf.gen_unique_str(f"{prefix}_search_last_subfield")
+
+        client = self._client()
+
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=default_dim)
+
+        person_schema = client.create_struct_field_schema()
+        person_schema.add_field("name", DataType.VARCHAR, max_length=128)
+        person_schema.add_field("name_vector", DataType.FLOAT_VECTOR, dim=default_dim)
+        schema.add_field(
+            "suspects",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=person_schema,
+            max_capacity=20,
+        )
+        schema.add_field(
+            "victims",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=person_schema,
+            max_capacity=20,
+        )
+
+        vehicle_schema = client.create_struct_field_schema()
+        vehicle_schema.add_field("model", DataType.VARCHAR, max_length=128)
+        vehicle_schema.add_field("vehicle_vector", DataType.FLOAT_VECTOR, dim=default_dim)
+        schema.add_field(
+            "vehicles",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=vehicle_schema,
+            max_capacity=20,
+        )
+
+        evidence_schema = client.create_struct_field_schema()
+        evidence_schema.add_field("item", DataType.VARCHAR, max_length=128)
+        evidence_schema.add_field("evidence_vector", DataType.FLOAT_VECTOR, dim=default_dim)
+        schema.add_field(
+            "evidence",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=evidence_schema,
+            max_capacity=20,
+        )
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
+        )
+        index_params.add_index(
+            field_name="suspects[name_vector]",
+            index_type="HNSW",
+            metric_type="MAX_SIM_COSINE",
+            params=INDEX_PARAMS,
+        )
+        index_params.add_index(
+            field_name="victims[name_vector]",
+            index_type="HNSW",
+            metric_type="MAX_SIM_COSINE",
+            params=INDEX_PARAMS,
+        )
+        index_params.add_index(
+            field_name="vehicles[vehicle_vector]",
+            index_type="HNSW",
+            metric_type="MAX_SIM_COSINE",
+            params=INDEX_PARAMS,
+        )
+        index_params.add_index(
+            field_name="evidence[evidence_vector]",
+            index_type="HNSW",
+            metric_type="MAX_SIM_COSINE",
+            params=INDEX_PARAMS,
+        )
+        self.create_collection(client, collection_name, schema=schema, index_params=index_params)
+
+        data = []
+        for i in range(64):
+            data.append(
+                {
+                    "id": i,
+                    "normal_vector": [random.random() for _ in range(default_dim)],
+                    "suspects": [
+                        {"name": f"suspect_{i}", "name_vector": [random.random() for _ in range(default_dim)]}
+                    ],
+                    "victims": [{"name": f"victim_{i}", "name_vector": [random.random() for _ in range(default_dim)]}],
+                    "vehicles": [
+                        {"model": f"vehicle_{i}", "vehicle_vector": [random.random() for _ in range(default_dim)]}
+                    ],
+                    "evidence": [
+                        {"item": f"evidence_{i}", "evidence_vector": [random.random() for _ in range(default_dim)]}
+                    ],
+                }
+            )
+
+        res, check = self.insert(client, collection_name, data)
+        assert check
+        assert res["insert_count"] == 64
+
+        res, check = self.load_collection(client, collection_name)
+        assert check
+
+        search_tensor = EmbeddingList()
+        search_tensor.add([random.random() for _ in range(default_dim)])
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[search_tensor],
+            anns_field="evidence[evidence_vector]",
+            search_params={"metric_type": "MAX_SIM_COSINE"},
+            limit=10,
+        )
+        assert check
+        assert len(results[0]) > 0
+
+    @pytest.mark.tags(CaseLabel.L0)
     def test_search_struct_array_vector_multiple(self):
         """
         target: test search with multiple vectors (EmbeddingList) in struct array


### PR DESCRIPTION
Backport a set of fixes onto `poc_2.6.17`, driven by a customer failure
while migrating a collection schema to StructArray fields. Each fix below
was verified on `poc_2.6.17` itself, not only reviewed.

### StructArray

- **#50141** `size field bitsets by field id range` (issue #50107) — the
three sealed-segment bitsets are indexed by `field_id - START_USER_FIELDID`
but were sized by the number of fields in the schema. A StructArray parent
field consumes a field ID without being a loadable field, so with N struct
fields the highest field IDs index past the end of the bitset. The result
is an out-of-bounds read whose value decides whether `load_field_data_common`
raises `non system field <id> data already loaded`, plus an out-of-bounds
write on the same path.

  Reproduced on `poc_2.6.17` with a schema of 1 PK + 37 scalar fields +
  7 StructArrayFields (VARCHAR/INT64/FLOAT_VECTOR each), 1,500 rows: the
  assertion fires on the first load. Instrumented `get_bit`/`set_bit` to
  log every out-of-bounds access — 480 of them, bitset size 61, accesses at
  index 64 and 65. After the fix: 0 assertions, 0 out-of-bounds accesses.
  Note the bug is not data-volume dependent; 1,500 rows is enough.

- **#49990** `validate StructArray vector dimensions and element counts`
(issue #50595) — proxy-side validation. Verified by negative test on
`poc_2.6.17`: wrong vector dimension, mismatched sub-field element counts,
and array length over `max_capacity` are all silently accepted before the
fix and correctly rejected after.

### Stability

- **#51121** `avoid DataNode panic when a binlog is missing during sort
compaction` (issue #50927) — `iterate()` returns a typed-nil reader boxed
into the RecordReader interface together with an error when opening the
next chunk fails, e.g. a binlog object missing in object storage.
Assigning it to `ir.cur` leaves a non-nil interface holding a nil pointer
and the deferred `Close()` dereferences it. Relevant to deployments with
weak object storage. Verified: both bundled tests panic with a nil pointer
dereference on `poc_2.6.17` and pass after the fix.

- **#51474** `avoid nil worker dereference in delegator ReleaseSegments`
(issue #51472) — verified: `TestReleaseSegmentsWorkerNotAvailable` panics
on `poc_2.6.17` and passes after the fix.

### Correctness & storage hygiene

- **#50233** `align expression cursor with scalar index raw data`
(issue #50197) — for a sealed chunked segment with a field-level scalar
index, `pinned_index.size()` is 1 while the segment has many chunks. The
pre-fix code does `pinned_index[current_chunk_id]` guarded only by a size
check, so every chunk after the first silently loses the index, and chunk 0
uses it without a base-offset translation. The defective code is present
verbatim in `poc_2.6.17` at `SegmentChunkReader.cpp:27-30` and again at
:87-88. All 20 `TestChunkSegmentStorageV2` cases pass after the fix; a
before/after comparison is not possible because the bundled tests are
written against the post-fix `GetChunkDataAccessor` signature.

- **#50592** `handle V1/V2 text and JSON auxiliary paths in datacoord GC`
— text-index and JSON-stats auxiliary files were not recycled, leaking
objects in storage. Verified: the three bundled GC tests fail on
`poc_2.6.17` and pass after the fix.

### Deliberately excluded

`require sufficient rows and vectors before building ArrayOfVector EmbList
indexes` (#50625) conflicts here and depends on
`CalcValidRowCountFromFieldBinLog`, introduced by the nullable-vector
support enhancement (#49848). Backporting the fix would require the
feature, so both are left out rather than partially back-porting.

Co-authored-by: zhuwenxing <wenxing.zhu@zilliz.com>
Co-authored-by: Spade A <71589810+SpadeA-Tang@users.noreply.github.com>
Co-authored-by: congqixia <congqi.xia@zilliz.com>
Co-authored-by: sparknack <shawn.wang@zilliz.com>
Co-authored-by: yihao.dai <yihao.dai@zilliz.com>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
