### PR TITLE
fix: [2.6] honor partition names in REST hybrid search

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -1779,6 +1779,7 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 	req := &milvuspb.HybridSearchRequest{
 		DbName:         dbName,
 		CollectionName: httpReq.CollectionName,
+		PartitionNames: httpReq.PartitionNames,
 		Requests:       []*milvuspb.SearchRequest{},
 		OutputFields:   httpReq.OutputFields,
 	}

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -911,7 +911,9 @@ func TestHybridSearchWithRerank(t *testing.T) {
 		Status:         &StatusSuccess,
 	}, nil).Once()
 
-	mp.EXPECT().HybridSearch(mock.Anything, mock.Anything).Return(&milvuspb.SearchResults{Status: commonSuccessStatus, Results: &schemapb.SearchResultData{
+	mp.EXPECT().HybridSearch(mock.Anything, mock.MatchedBy(func(req *milvuspb.HybridSearchRequest) bool {
+		return assert.ObjectsAreEqual([]string{"part_a"}, req.GetPartitionNames())
+	})).Return(&milvuspb.SearchResults{Status: commonSuccessStatus, Results: &schemapb.SearchResultData{
 		TopK:         int64(3),
 		OutputFields: []string{FieldWordCount},
 		FieldsData:   generateFieldData(),
@@ -921,7 +923,7 @@ func TestHybridSearchWithRerank(t *testing.T) {
 
 	queryTestCases := requestBodyTestCase{
 		path:        versionalV2(EntityCategory, HybridSearchAction),
-		requestBody: []byte(`{"collectionName": "hello_milvus", "search": [{"data": [[0.1, 0.2]], "annsField": "book_intro", "metricType": "L2", "limit": 3}, {"data": [[0.1, 0.2]], "annsField": "book_intro", "metricType": "L2", "limit": 3}], "functionScore": {"functions": [{"name": "testRank", "type": "Rerank", "inputFieldNames": ["FieldWordCount"], "params": {"name": "decay"}}]}}`),
+		requestBody: []byte(`{"collectionName": "hello_milvus", "partitionNames": ["part_a"], "search": [{"data": [[0.1, 0.2]], "annsField": "book_intro", "metricType": "L2", "limit": 3}, {"data": [[0.1, 0.2]], "annsField": "book_intro", "metricType": "L2", "limit": 3}], "functionScore": {"functions": [{"name": "testRank", "type": "Rerank", "inputFieldNames": ["FieldWordCount"], "params": {"name": "decay"}}]}}`),
 	}
 	sendReqAndVerify(t, testEngine, queryTestCases.path, http.MethodPost, queryTestCases)
 }


### PR DESCRIPTION
issue: #50396
pr: #50569

## What changed

Backport #50569 to the 2.6 branch.

- Propagate the REST v2 hybrid search `partitionNames` field to the top-level `HybridSearchRequest`.
- Extend the handler test to verify that the partition list reaches the Proxy request.

## Why

Without the top-level field, Proxy converts the hybrid request into a search request without partition names, causing REST v2 hybrid search to search the full collection.

## Verification

- `milvus-dev-cli go-ut local . -b 2.6 -n 4 -f`
  - `internal/distributed/proxy/httpserver`: passed
