### PR TITLE
enhance: add dedicated priority lane for requery tasks in read scheduler (#52189)

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -662,7 +662,8 @@ queryNode:
     maxDiskUsagePercentageForMmapAlloc: 50 # disk percentage used in mmap chunk manager
   indexOffsetCacheEnabled: false # enable index offset cache for some scalar indexes, now is just for bitmap index, enable this param can improve performance for retrieving raw data from index
   scheduler:
-    unsolvedQueueSize: 1024
+    unsolvedQueueSize: 1024 # Maximum number of regular read tasks waiting in the scheduler. When the dedicated requery lane is enabled under fifo, this is an independent regular-task budget and the effective total capacity is the sum of the regular and requery capacities.
+    requeryUnsolvedQueueSize: 1024 # Maximum number of scheduler-owned requery tasks waiting in the dedicated priority lane when scheduleReadPolicy is fifo, including a task staged for execution handoff. It defaults to an independent capacity of 1024, so the default total waiting-task capacity is 1024 regular tasks plus 1024 requery tasks. A positive integer sets the lane capacity, a value <= 0 disables the lane, and an invalid value emits a warning and falls back to 1024. The lane is disabled when scheduleReadPolicy is user-task-polling.
     # maxReadConcurrentRatio is the concurrency ratio of read task (search task and query task).
     # Max read concurrency would be the value of hardware.GetCPUNum * maxReadConcurrentRatio.
     # It defaults to 2.0, which means max read concurrency would be the value of hardware.GetCPUNum * 2.

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -614,6 +614,7 @@ queryNode:
   indexOffsetCacheEnabled: false # enable index offset cache for some scalar indexes, now is just for bitmap index, enable this param can improve performance for retrieving raw data from index
   scheduler:
     unsolvedQueueSize: 1024
+    requeryUnsolvedQueueSize: 1024 # Maximum number of pending requery tasks in the dedicated requery lane. Requery (the output-field fetch phase of search) bypasses unsolvedQueueSize and is scheduled ahead of regular read tasks, because rejecting it wastes the ANN computation its parent search already completed, while its arrival rate is naturally capped by admitted searches. <= 0 disables the lane.
     # maxReadConcurrentRatio is the concurrency ratio of read task (search task and query task).
     # Max read concurrency would be the value of hardware.GetCPUNum * maxReadConcurrentRatio.
     # It defaults to 2.0, which means max read concurrency would be the value of hardware.GetCPUNum * 2.

--- a/internal/querynodev2/handlers.go
+++ b/internal/querynodev2/handlers.go
@@ -231,15 +231,10 @@ func (node *QueryNode) queryChannel(ctx context.Context, req *querypb.QueryReque
 	}
 	// aggregate cost
 	requestCosts := lo.FilterMap(results, func(result *internalpb.RetrieveResults, _ int) (*internalpb.CostAggregation, bool) {
-		if paramtable.Get().QueryNodeCfg.EnableWorkerSQCostMetrics.GetAsBool() {
-			return result.GetCostAggregation(), true
-		}
-
-		if result.GetBase().GetSourceID() == paramtable.GetNodeID() {
-			return result.GetCostAggregation(), true
-		}
-
-		return nil, false
+		// delegator node won't be used to load sealed segment if stream node is enabled
+		// and if growing segment doesn't exists, delegator won't produce any cost metrics
+		// so all workers' costs are collected (the enableWorkerSQCostMetrics toggle was removed)
+		return result.GetCostAggregation(), true
 	})
 	resp.CostAggregation = segmentutil.MergeRequestCost(requestCosts)
 	if resp.CostAggregation == nil {

--- a/internal/querynodev2/segments/result.go
+++ b/internal/querynodev2/segments/result.go
@@ -110,7 +110,7 @@ func ReduceSearchResults(ctx context.Context, results []*internalpb.SearchResult
 	requestCosts := lo.FilterMap(results, func(result *internalpb.SearchResults, _ int) (*internalpb.CostAggregation, bool) {
 		// delegator node won't be used to load sealed segment if stream node is enabled
 		// and if growing segment doesn't exists, delegator won't produce any cost metrics
-		// so we deprecate the EnableWorkerSQCostMetrics param
+		// so all workers' costs are collected (the enableWorkerSQCostMetrics toggle was removed)
 		return result.GetCostAggregation(), true
 	})
 	searchResults.CostAggregation = mergeRequestCost(requestCosts)
@@ -174,7 +174,7 @@ func ReduceAdvancedSearchResults(ctx context.Context, results []*internalpb.Sear
 	requestCosts := lo.FilterMap(results, func(result *internalpb.SearchResults, _ int) (*internalpb.CostAggregation, bool) {
 		// delegator node won't be used to load sealed segment if stream node is enabled
 		// and if growing segment doesn't exists, delegator won't produce any cost metrics
-		// so we deprecate the EnableWorkerSQCostMetrics param
+		// so all workers' costs are collected (the enableWorkerSQCostMetrics toggle was removed)
 		return result.GetCostAggregation(), true
 	})
 	searchResults.CostAggregation = mergeRequestCost(requestCosts)

--- a/internal/util/searchutil/scheduler/concurrent_safe_scheduler.go
+++ b/internal/util/searchutil/scheduler/concurrent_safe_scheduler.go
@@ -172,7 +172,8 @@ func (s *scheduler) schedule() {
 				// drain policy maintained task
 				for task.valid() {
 					execChan <- task.Task
-					s.updateWaitingTaskCounter(-1, -nq)
+					s.onTaskServed(task)
+					s.onTaskDequeued(task, task.NQ())
 					task = s.produceExecChan(now)
 				}
 				mlog.Info(context.TODO(), "all task put into exeChan, schedule worker exit")
@@ -181,7 +182,7 @@ func (s *scheduler) schedule() {
 			}
 			// Receive add operation request and return the process result.
 			// And consume recv chan as much as possible.
-			s.consumeRecvChan(req, maxReceiveChanBatchConsumeNum, now)
+			s.consumeRecvChan(req, maxReceiveChanBatchConsumeNum, now, &task)
 		case req := <-s.clearChan:
 			var result ClearResult
 			result, task = s.clearQueuedTasks(req.filter, req.reason, task, now)
@@ -189,7 +190,8 @@ func (s *scheduler) schedule() {
 		case execChan <- execTask:
 			// Task sent, drop the ownership of sent task.
 			// Update waiting task counter.
-			s.updateWaitingTaskCounter(-1, -nq)
+			s.onTaskServed(task)
+			s.onTaskDequeued(task, nq)
 			// And produce new task into execChan as much as possible.
 			task = s.produceExecChan(now)
 		}
@@ -197,10 +199,10 @@ func (s *scheduler) schedule() {
 }
 
 // consumeRecvChan consume the recv chan as much as possible.
-func (s *scheduler) consumeRecvChan(req addTaskReq, limit int, now time.Time) {
+func (s *scheduler) consumeRecvChan(req addTaskReq, limit int, now time.Time, staged **queuedTask) {
 	// Check the dynamic wait task limit.
 	maxWaitTaskNum := paramtable.Get().QueryNodeCfg.MaxUnsolvedQueueSize.GetAsInt64()
-	if !s.handleAddTaskRequest(req, maxWaitTaskNum, now) {
+	if !s.handleAddTaskRequest(req, maxWaitTaskNum, now, staged) {
 		return
 	}
 
@@ -211,7 +213,7 @@ func (s *scheduler) consumeRecvChan(req addTaskReq, limit int, now time.Time) {
 			if !ok {
 				return
 			}
-			if !s.handleAddTaskRequest(req, maxWaitTaskNum, now) {
+			if !s.handleAddTaskRequest(req, maxWaitTaskNum, now, staged) {
 				return
 			}
 		default:
@@ -222,33 +224,97 @@ func (s *scheduler) consumeRecvChan(req addTaskReq, limit int, now time.Time) {
 
 // HandleAddTaskRequest handle a add task request.
 // Return true if the process can be continued.
-func (s *scheduler) handleAddTaskRequest(req addTaskReq, maxWaitTaskNum int64, now time.Time) bool {
-	if maxWaitTaskNum > 0 && s.GetWaitingTaskTotal() >= maxWaitTaskNum {
-		s.cleanupExpiredTasks(now)
+func (s *scheduler) handleAddTaskRequest(req addTaskReq, maxWaitTaskNum int64, now time.Time, staged **queuedTask) bool {
+	requery := false
+	if classifier, ok := s.policy.(laneClassifier); ok {
+		requery = classifier.UseLane(req.task)
 	}
 
 	if err := req.task.Context().Err(); err != nil {
 		mlog.Warn(context.TODO(), "task canceled before enqueue", mlog.Err(err))
 		req.err <- err
-	} else if maxWaitTaskNum > 0 && s.GetWaitingTaskTotal() >= maxWaitTaskNum {
-		err := merr.WrapErrTooManyRequests(
-			int32(maxWaitTaskNum),
-			fmt.Sprintf("limit by %s", paramtable.Get().QueryNodeCfg.MaxUnsolvedQueueSize.Key),
-		)
-		req.err <- err
-	} else {
-		// Push the task into the policy to schedule and update the counter of the ready queue.
-		queued := newQueuedTask(req.task, now)
-		nq := queued.NQ()
-		newTaskAdded, err := s.policy.Push(queued)
-		if err == nil {
-			s.updateWaitingTaskCounter(int64(newTaskAdded), nq)
-		}
-		req.err <- err
+		return maxWaitTaskNum <= 0 || s.getRegularWaitingTaskTotal() < maxWaitTaskNum
 	}
 
-	// Continue processing if the queue isn't reach the max limit.
-	return maxWaitTaskNum <= 0 || s.GetWaitingTaskTotal() < maxWaitTaskNum
+	capacity, available := s.waitingTaskCapacityAvailable(requery, maxWaitTaskNum)
+	if !available {
+		s.cleanupExpiredTasks(now, staged)
+		if err := req.task.Context().Err(); err != nil {
+			mlog.Warn(context.TODO(), "task canceled before enqueue", mlog.Err(err))
+			req.err <- err
+			return maxWaitTaskNum <= 0 || s.getRegularWaitingTaskTotal() < maxWaitTaskNum
+		}
+		capacity, available = s.waitingTaskCapacityAvailable(requery, maxWaitTaskNum)
+	}
+	if !available {
+		recordReadTaskReject(requery)
+		if requery {
+			req.err <- requeryLaneCapacityError(capacity)
+		} else {
+			req.err <- merr.WrapErrTooManyRequests(
+				int32(capacity),
+				fmt.Sprintf("limit by %s", paramtable.Get().QueryNodeCfg.MaxUnsolvedQueueSize.Key),
+			)
+		}
+		return false
+	}
+
+	// Allocate only after the common canceled/full rejection paths have passed.
+	queued := newQueuedTask(req.task, now)
+	queued.requery = requery
+	nq := queued.NQ()
+	newTaskAdded, err := s.pushTask(queued, now, staged)
+	if err == nil {
+		s.updateWaitingTaskCounter(queued, int64(newTaskAdded), nq)
+	}
+	req.err <- err
+	if errors.Is(err, merr.ErrServiceTooManyRequests) {
+		recordReadTaskReject(requery)
+		if requery {
+			// The lane remained full after cleanup and retry. Yield the scheduler
+			// loop so execChan handoff can drain work; unread requests remain pending.
+			return false
+		}
+	}
+	// Continue processing only while the regular queue still has room.
+	return maxWaitTaskNum <= 0 || s.getRegularWaitingTaskTotal() < maxWaitTaskNum
+}
+
+func (s *scheduler) waitingTaskCapacityAvailable(requery bool, maxRegular int64) (int64, bool) {
+	if requery {
+		capacity := requeryLaneCapacity()
+		return capacity, capacity > 0 && s.getRequeryWaitingTaskTotal() < capacity
+	}
+	return maxRegular, maxRegular <= 0 || s.getRegularWaitingTaskTotal() < maxRegular
+}
+
+// pushTask retries a requery-lane capacity rejection once after the scheduler
+// has completed expired-task lifecycle handling. pushTaskOnce performs
+// admission before mutating the policy.
+func (s *scheduler) pushTask(task *queuedTask, now time.Time, staged **queuedTask) (int, error) {
+	newTaskAdded, err := s.pushTaskOnce(task)
+	if !task.requery || !errors.Is(err, merr.ErrServiceTooManyRequests) {
+		return newTaskAdded, err
+	}
+
+	if ctxErr := task.Context().Err(); ctxErr != nil {
+		return 0, ctxErr
+	}
+	s.cleanupExpiredTasks(now, staged)
+	if ctxErr := task.Context().Err(); ctxErr != nil {
+		return 0, ctxErr
+	}
+	return s.pushTaskOnce(task)
+}
+
+func (s *scheduler) pushTaskOnce(task *queuedTask) (int, error) {
+	if task.requery {
+		capacity := requeryLaneCapacity()
+		if capacity <= 0 || s.getRequeryWaitingTaskTotal() >= capacity {
+			return 0, requeryLaneCapacityError(capacity)
+		}
+	}
+	return s.policy.Push(task)
 }
 
 // produceExecChan produce task from scheduler into exec chan as much as possible
@@ -266,7 +332,8 @@ func (s *scheduler) produceExecChan(now time.Time) *queuedTask {
 		select {
 		case execChan <- execTask:
 			// Update waiting task counter.
-			s.updateWaitingTaskCounter(-1, -nq)
+			s.onTaskServed(task)
+			s.onTaskDequeued(task, nq)
 			// Task sent, drop the ownership of sent task.
 			task = nil
 		default:
@@ -338,6 +405,26 @@ func readTaskExecuteOutcome(err error) string {
 	return metrics.FailLabel
 }
 
+// onTaskDequeued updates the matching queue-class counters when a task leaves
+// scheduler ownership at execChan handoff, expiration, clear, or shutdown.
+func (s *scheduler) onTaskDequeued(task *queuedTask, nq int64) {
+	if !task.valid() {
+		return
+	}
+	s.updateWaitingTaskCounter(task, -1, -nq)
+}
+
+// onTaskServed reports an execChan handoff to the policy. It runs on the
+// schedule goroutine only, so the policy needs no locking.
+func (s *scheduler) onTaskServed(task *queuedTask) {
+	if !task.valid() {
+		return
+	}
+	if observer, ok := s.policy.(taskServedObserver); ok {
+		observer.onTaskServed(task)
+	}
+}
+
 // setupExecListener setup the execChan and next task to run.
 func (s *scheduler) setupExecListener(lastWaitingTask *queuedTask, now time.Time) (*queuedTask, int64, chan Task) {
 	var execChan chan Task
@@ -350,7 +437,7 @@ func (s *scheduler) setupExecListener(lastWaitingTask *queuedTask, now time.Time
 				break
 			}
 			if err := lastWaitingTask.Context().Err(); err != nil {
-				s.updateWaitingTaskCounter(-1, -lastWaitingTask.NQ())
+				s.onTaskDequeued(lastWaitingTask, lastWaitingTask.NQ())
 				s.recordReadTaskQueueDuration(lastWaitingTask, now, readTaskQueueOutcomeExpired)
 				lastWaitingTask.Done(err)
 				lastWaitingTask = nil
@@ -369,12 +456,19 @@ func (s *scheduler) setupExecListener(lastWaitingTask *queuedTask, now time.Time
 	return lastWaitingTask, nq, execChan
 }
 
-func (s *scheduler) cleanupExpiredTasks(now time.Time) {
+func (s *scheduler) cleanupExpiredTasks(now time.Time, staged **queuedTask) {
 	deadlineAdvance := paramtable.Get().QueryNodeCfg.SchedulePolicyTaskDeadlineAdvance.GetAsDurationByParse()
 	cleanupTime := now.Add(deadlineAdvance)
+	if staged != nil && (*staged).cleanupReady(cleanupTime) {
+		task := *staged
+		*staged = nil
+		s.onTaskDequeued(task, task.NQ())
+		// Queue duration was already recorded when this task was selected by Pop.
+		task.Done(cleanupTaskError(task))
+	}
 	tasks := s.policy.Cleanup(cleanupTime)
 	for _, task := range tasks {
-		s.updateWaitingTaskCounter(-1, -task.NQ())
+		s.onTaskDequeued(task, task.NQ())
 		s.recordReadTaskQueueDuration(task, now, readTaskQueueOutcomeExpired)
 		task.Done(cleanupTaskError(task))
 	}
@@ -396,7 +490,7 @@ func (s *scheduler) clearQueuedTasks(filter TaskFilter, reason string, task *que
 		nq := removedTask.NQ()
 		result.QueuedCleared++
 		result.QueuedNQCleared += nq
-		s.updateWaitingTaskCounter(-1, -nq)
+		s.onTaskDequeued(removedTask, nq)
 		s.recordReadTaskQueueDuration(removedTask, now, readTaskQueueOutcomeCleared)
 		removedTask.Done(clearErr)
 	}
@@ -413,42 +507,86 @@ func clearTaskQueueError(reason string) error {
 // setupReadyLenMetric update the read task ready len metric.
 func (s *scheduler) setupReadyLenMetric() {
 	waitingTaskCount := s.GetWaitingTaskTotal()
+	nodeID := paramtable.GetStringNodeID()
 
 	// Update the ReadyQueue counter for quota.
 	collector.Counter.Set(metricsinfo.ReadyQueueType, waitingTaskCount)
-	// Record the waiting task length of policy as ready task metric.
-	metrics.QueryNodeReadTaskReadyLen.WithLabelValues(paramtable.GetStringNodeID()).Set(float64(waitingTaskCount))
-	metrics.QueryNodeReadTaskReadyNQ.WithLabelValues(paramtable.GetStringNodeID()).Set(float64(s.GetWaitingTaskTotalNQ()))
+	// Aggregate gauges include both regular and requery waiting tasks. The
+	// lane-specific gauge uses the same counter as admission, so a task staged
+	// for execChan handoff remains visible until ownership is transferred.
+	metrics.QueryNodeReadTaskReadyLen.WithLabelValues(nodeID).Set(float64(waitingTaskCount))
+	metrics.QueryNodeReadTaskReadyNQ.WithLabelValues(nodeID).Set(float64(s.GetWaitingTaskTotalNQ()))
+	metrics.QueryNodeReadTaskRequeryReadyLen.WithLabelValues(nodeID).Set(float64(s.getRequeryWaitingTaskTotal()))
 }
 
 func (s *scheduler) recordReadTaskQueueDuration(task *queuedTask, now time.Time, outcome string) {
 	if !task.valid() {
 		return
 	}
-	metrics.QueryNodeReadTaskQueueDuration.WithLabelValues(
-		paramtable.GetStringNodeID(),
-		outcome,
-	).Observe(float64(task.queueDuration(now).Microseconds()) / 1000.0)
+	nodeID := paramtable.GetStringNodeID()
+	durationMs := float64(task.queueDuration(now).Microseconds()) / 1000.0
+	// The aggregate histogram keeps its pre-existing label schema and covers
+	// both classes; the requery-only subset goes to a separate metric.
+	metrics.QueryNodeReadTaskQueueDuration.WithLabelValues(nodeID, outcome).Observe(durationMs)
+	if task.requery {
+		metrics.QueryNodeReadTaskRequeryQueueDuration.WithLabelValues(nodeID, outcome).Observe(durationMs)
+	}
+}
+
+func laneLabel(requery bool) string {
+	if requery {
+		return metrics.ReQueryLabel
+	}
+	return metrics.RegularLabel
+}
+
+func recordReadTaskReject(requery bool) {
+	metrics.QueryNodeReadTaskRejectCnt.WithLabelValues(paramtable.GetStringNodeID(), laneLabel(requery)).Inc()
 }
 
 // scheduler counter implement, concurrent safe.
 type schedulerCounter struct {
-	waitingTaskTotal   atomic.Int64
-	waitingTaskTotalNQ atomic.Int64
+	regularWaitingTaskTotal   atomic.Int64
+	regularWaitingTaskTotalNQ atomic.Int64
+	requeryWaitingTaskTotal   atomic.Int64
+	requeryWaitingTaskTotalNQ atomic.Int64
 }
 
 // GetWaitingTaskTotal get ready task counts.
 func (s *schedulerCounter) GetWaitingTaskTotal() int64 {
-	return s.waitingTaskTotal.Load()
+	return s.regularWaitingTaskTotal.Load() + s.requeryWaitingTaskTotal.Load()
 }
 
 // GetWaitingTaskTotalNQ get ready task NQ.
 func (s *schedulerCounter) GetWaitingTaskTotalNQ() int64 {
-	return s.waitingTaskTotalNQ.Load()
+	return s.regularWaitingTaskTotalNQ.Load() + s.requeryWaitingTaskTotalNQ.Load()
 }
 
-// updateWaitingTaskCounter update the waiting task counter for observing.
-func (s *schedulerCounter) updateWaitingTaskCounter(num int64, nq int64) {
-	s.waitingTaskTotal.Add(num)
-	s.waitingTaskTotalNQ.Add(nq)
+func (s *schedulerCounter) getRegularWaitingTaskTotal() int64 {
+	return s.regularWaitingTaskTotal.Load()
+}
+
+func (s *schedulerCounter) getRegularWaitingTaskTotalNQ() int64 {
+	return s.regularWaitingTaskTotalNQ.Load()
+}
+
+func (s *schedulerCounter) getRequeryWaitingTaskTotal() int64 {
+	return s.requeryWaitingTaskTotal.Load()
+}
+
+func (s *schedulerCounter) getRequeryWaitingTaskTotalNQ() int64 {
+	return s.requeryWaitingTaskTotalNQ.Load()
+}
+
+// updateWaitingTaskCounter dispatches updates by the immutable queue-class
+// stamp so regular admission and exported load accounting can use different
+// views without losing lifecycle symmetry.
+func (s *schedulerCounter) updateWaitingTaskCounter(task *queuedTask, num int64, nq int64) {
+	if task.requery {
+		s.requeryWaitingTaskTotal.Add(num)
+		s.requeryWaitingTaskTotalNQ.Add(nq)
+		return
+	}
+	s.regularWaitingTaskTotal.Add(num)
+	s.regularWaitingTaskTotalNQ.Add(nq)
 }

--- a/internal/util/searchutil/scheduler/concurrent_safe_scheduler.go
+++ b/internal/util/searchutil/scheduler/concurrent_safe_scheduler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/util/conc"
+	"github.com/milvus-io/milvus/pkg/v3/util/contextutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/lifetime"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metricsinfo"
@@ -33,6 +34,7 @@ func newScheduler(policy schedulePolicy) Scheduler {
 	mlog.Info(context.TODO(), "query node use concurrent safe scheduler", mlog.Int("max_concurrency", maxReadConcurrency))
 	return &scheduler{
 		policy:           policy,
+		requeryQueue:     newMergeTaskQueue("requery"),
 		receiveChan:      make(chan addTaskReq),
 		clearChan:        make(chan clearQueuedReq),
 		execChan:         make(chan Task),
@@ -61,12 +63,16 @@ type clearQueuedResp struct {
 
 // scheduler is a general concurrent safe scheduler implementation by wrapping a schedule policy.
 type scheduler struct {
-	policy      schedulePolicy
-	receiveChan chan addTaskReq
-	clearChan   chan clearQueuedReq
-	execChan    chan Task
-	pool        *conc.Pool[any]
-	gpuPool     *conc.Pool[any]
+	policy schedulePolicy
+	// requeryQueue is a bounded lane dispatched ahead of the policy queue; it is
+	// owned by the schedule goroutine and its tasks stay out of the policy
+	// waiting counters. See tryAddRequeryTask for the rationale.
+	requeryQueue *mergeTaskQueue
+	receiveChan  chan addTaskReq
+	clearChan    chan clearQueuedReq
+	execChan     chan Task
+	pool         *conc.Pool[any]
+	gpuPool      *conc.Pool[any]
 
 	// wg is the waitgroup for internal worker goroutine
 	wg sync.WaitGroup
@@ -172,7 +178,7 @@ func (s *scheduler) schedule() {
 				// drain policy maintained task
 				for task.valid() {
 					execChan <- task.Task
-					s.updateWaitingTaskCounter(-1, -nq)
+					s.onTaskDequeued(task, nq)
 					task = s.produceExecChan(now)
 				}
 				mlog.Info(context.TODO(), "all task put into exeChan, schedule worker exit")
@@ -189,7 +195,7 @@ func (s *scheduler) schedule() {
 		case execChan <- execTask:
 			// Task sent, drop the ownership of sent task.
 			// Update waiting task counter.
-			s.updateWaitingTaskCounter(-1, -nq)
+			s.onTaskDequeued(task, nq)
 			// And produce new task into execChan as much as possible.
 			task = s.produceExecChan(now)
 		}
@@ -223,6 +229,10 @@ func (s *scheduler) consumeRecvChan(req addTaskReq, limit int, now time.Time) {
 // HandleAddTaskRequest handle a add task request.
 // Return true if the process can be continued.
 func (s *scheduler) handleAddTaskRequest(req addTaskReq, maxWaitTaskNum int64, now time.Time) bool {
+	if s.tryAddRequeryTask(req, now) {
+		return maxWaitTaskNum <= 0 || s.GetWaitingTaskTotal() < maxWaitTaskNum
+	}
+
 	if maxWaitTaskNum > 0 && s.GetWaitingTaskTotal() >= maxWaitTaskNum {
 		s.cleanupExpiredTasks(now)
 	}
@@ -251,6 +261,38 @@ func (s *scheduler) handleAddTaskRequest(req addTaskReq, maxWaitTaskNum int64, n
 	return maxWaitTaskNum <= 0 || s.GetWaitingTaskTotal() < maxWaitTaskNum
 }
 
+// tryAddRequeryTask admits a requery task through the dedicated bounded lane so
+// that a full unsolved queue cannot reject it: a rejected requery discards the
+// ANN computation its parent search already completed. The lane cannot starve
+// regular tasks because requery arrival rate is capped by upstream search
+// admission. Returns false when the lane is disabled or the task is not requery.
+func (s *scheduler) tryAddRequeryTask(req addTaskReq, now time.Time) bool {
+	laneSize := paramtable.Get().QueryNodeCfg.RequeryUnsolvedQueueSize.GetAsInt64()
+	if laneSize <= 0 || contextutil.GetQueryLabel(req.task.Context()) != metrics.ReQueryLabel {
+		return false
+	}
+
+	if int64(s.requeryQueue.len()) >= laneSize {
+		s.cleanupExpiredTasks(now)
+	}
+
+	if err := req.task.Context().Err(); err != nil {
+		mlog.Warn(context.TODO(), "task canceled before enqueue", mlog.Err(err))
+		req.err <- err
+	} else if int64(s.requeryQueue.len()) >= laneSize {
+		req.err <- merr.WrapErrTooManyRequests(
+			int32(laneSize),
+			fmt.Sprintf("limit by %s", paramtable.Get().QueryNodeCfg.RequeryUnsolvedQueueSize.Key),
+		)
+	} else {
+		queued := newQueuedTask(req.task, now)
+		queued.requery = true
+		s.requeryQueue.push(queued)
+		req.err <- nil
+	}
+	return true
+}
+
 // produceExecChan produce task from scheduler into exec chan as much as possible
 func (s *scheduler) produceExecChan(now time.Time) *queuedTask {
 	var task *queuedTask
@@ -266,7 +308,7 @@ func (s *scheduler) produceExecChan(now time.Time) *queuedTask {
 		select {
 		case execChan <- execTask:
 			// Update waiting task counter.
-			s.updateWaitingTaskCounter(-1, -nq)
+			s.onTaskDequeued(task, nq)
 			// Task sent, drop the ownership of sent task.
 			task = nil
 		default:
@@ -338,6 +380,24 @@ func readTaskExecuteOutcome(err error) string {
 	return metrics.FailLabel
 }
 
+// popTask pops the next task to run: the requery lane first (strict priority —
+// completing a requery salvages already-spent ANN computation), then the policy.
+func (s *scheduler) popTask(now time.Time) *queuedTask {
+	if task := s.requeryQueue.pop(); task.valid() {
+		return task
+	}
+	return s.policy.Pop(now)
+}
+
+// onTaskDequeued updates the policy waiting counters when a task leaves the
+// scheduler; requery-lane tasks are tracked by the lane itself only.
+func (s *scheduler) onTaskDequeued(task *queuedTask, nq int64) {
+	if task.valid() && task.requery {
+		return
+	}
+	s.updateWaitingTaskCounter(-1, -nq)
+}
+
 // setupExecListener setup the execChan and next task to run.
 func (s *scheduler) setupExecListener(lastWaitingTask *queuedTask, now time.Time) (*queuedTask, int64, chan Task) {
 	var execChan chan Task
@@ -345,12 +405,12 @@ func (s *scheduler) setupExecListener(lastWaitingTask *queuedTask, now time.Time
 	if !lastWaitingTask.valid() {
 		// No task is waiting to send to execChan, schedule a new one from queue.
 		for {
-			lastWaitingTask = s.policy.Pop(now)
+			lastWaitingTask = s.popTask(now)
 			if !lastWaitingTask.valid() {
 				break
 			}
 			if err := lastWaitingTask.Context().Err(); err != nil {
-				s.updateWaitingTaskCounter(-1, -lastWaitingTask.NQ())
+				s.onTaskDequeued(lastWaitingTask, lastWaitingTask.NQ())
 				s.recordReadTaskQueueDuration(lastWaitingTask, now, readTaskQueueOutcomeExpired)
 				lastWaitingTask.Done(err)
 				lastWaitingTask = nil
@@ -373,8 +433,9 @@ func (s *scheduler) cleanupExpiredTasks(now time.Time) {
 	deadlineAdvance := paramtable.Get().QueryNodeCfg.SchedulePolicyTaskDeadlineAdvance.GetAsDurationByParse()
 	cleanupTime := now.Add(deadlineAdvance)
 	tasks := s.policy.Cleanup(cleanupTime)
+	tasks = append(tasks, s.requeryQueue.cleanup(cleanupTime)...)
 	for _, task := range tasks {
-		s.updateWaitingTaskCounter(-1, -task.NQ())
+		s.onTaskDequeued(task, task.NQ())
 		s.recordReadTaskQueueDuration(task, now, readTaskQueueOutcomeExpired)
 		task.Done(cleanupTaskError(task))
 	}
@@ -382,6 +443,7 @@ func (s *scheduler) cleanupExpiredTasks(now time.Time) {
 
 func (s *scheduler) clearQueuedTasks(filter TaskFilter, reason string, task *queuedTask, now time.Time) (ClearResult, *queuedTask) {
 	removed := s.policy.Remove(filter, now)
+	removed = append(removed, s.requeryQueue.remove(filter, now)...)
 	if task.valid() && (filter == nil || filter(task.Task)) {
 		removed = append(removed, task)
 		task = nil
@@ -396,7 +458,7 @@ func (s *scheduler) clearQueuedTasks(filter TaskFilter, reason string, task *que
 		nq := removedTask.NQ()
 		result.QueuedCleared++
 		result.QueuedNQCleared += nq
-		s.updateWaitingTaskCounter(-1, -nq)
+		s.onTaskDequeued(removedTask, nq)
 		s.recordReadTaskQueueDuration(removedTask, now, readTaskQueueOutcomeCleared)
 		removedTask.Done(clearErr)
 	}

--- a/internal/util/searchutil/scheduler/concurrent_safe_scheduler_test.go
+++ b/internal/util/searchutil/scheduler/concurrent_safe_scheduler_test.go
@@ -112,6 +112,16 @@ type SchedulerSuite struct {
 	suite.Suite
 }
 
+type doneCallbackTask struct {
+	Task
+	callback func()
+}
+
+func (t *doneCallbackTask) Done(err error) {
+	t.callback()
+	t.Task.Done(err)
+}
+
 func (s *SchedulerSuite) TestConsumeRecvChan() {
 	s.Run("consume_chan_closed", func() {
 		ch := make(chan addTaskReq, 10)
@@ -137,7 +147,7 @@ func (s *SchedulerSuite) TestConsumeRecvChan() {
 			scheduler.consumeRecvChan(addTaskReq{
 				task: task,
 				err:  make(chan error, 1),
-			}, maxReceiveChanBatchConsumeNum, time.Now())
+			}, maxReceiveChanBatchConsumeNum, time.Now(), nil)
 		})
 	})
 }
@@ -161,7 +171,7 @@ func (s *SchedulerSuite) TestConsumeRecvChanUsesLoopTimestampForBatch() {
 	scheduler.consumeRecvChan(addTaskReq{
 		task: newMockTask(mockTaskConfig{nq: 1}),
 		err:  firstErrCh,
-	}, 2, now)
+	}, 2, now, nil)
 
 	s.NoError(<-firstErrCh)
 	s.NoError(<-secondErrCh)
@@ -184,7 +194,7 @@ func (s *SchedulerSuite) TestHandleAddTaskRequestRejectsWhenWaitingQueueFull() {
 	keepConsuming := scheduler.handleAddTaskRequest(addTaskReq{
 		task: newMockTask(mockTaskConfig{nq: 1}),
 		err:  errCh,
-	}, 1, time.Now())
+	}, 1, time.Now(), nil)
 	s.False(keepConsuming)
 	s.NoError(<-errCh)
 	s.Equal(int64(1), scheduler.GetWaitingTaskTotal())
@@ -193,7 +203,7 @@ func (s *SchedulerSuite) TestHandleAddTaskRequestRejectsWhenWaitingQueueFull() {
 	keepConsuming = scheduler.handleAddTaskRequest(addTaskReq{
 		task: newMockTask(mockTaskConfig{nq: 1}),
 		err:  errCh,
-	}, 1, time.Now())
+	}, 1, time.Now(), nil)
 	s.False(keepConsuming)
 	s.ErrorIs(<-errCh, merr.ErrServiceTooManyRequests)
 	s.Equal(int64(1), scheduler.GetWaitingTaskTotal())
@@ -212,17 +222,99 @@ func (s *SchedulerSuite) TestHandleAddTaskRequestCleansExpiredTasksBeforeQueueLi
 	queued := newQueuedTask(expiredTask, now.Add(-time.Second))
 	added, err := scheduler.policy.Push(queued)
 	s.NoError(err)
-	scheduler.updateWaitingTaskCounter(int64(added), queued.NQ())
+	scheduler.updateWaitingTaskCounter(queued, int64(added), queued.NQ())
 
 	errCh := make(chan error, 1)
 	keepConsuming := scheduler.handleAddTaskRequest(addTaskReq{
 		task: newMockTask(mockTaskConfig{nq: 1}),
 		err:  errCh,
-	}, 1, now)
+	}, 1, now, nil)
 
 	s.False(keepConsuming)
 	s.NoError(<-errCh)
 	s.ErrorIs(expiredTask.Wait(), context.DeadlineExceeded)
+	s.Equal(int64(1), scheduler.GetWaitingTaskTotal())
+}
+
+func (s *SchedulerSuite) TestHandleAddTaskRequestRechecksCancellationAfterCleanupBeforeMerge() {
+	now := time.Now()
+	scheduler := &scheduler{
+		policy:           newFIFOPolicy(),
+		schedulerCounter: schedulerCounter{},
+	}
+
+	active := newQueuedTask(newMockTask(mockTaskConfig{mergeAble: true, nq: 1}), now)
+	added, err := scheduler.policy.Push(active)
+	s.NoError(err)
+	scheduler.updateWaitingTaskCounter(active, int64(added), active.NQ())
+
+	incomingCtx, cancelIncoming := context.WithCancel(context.Background())
+	defer cancelIncoming()
+	incoming := newMockTask(mockTaskConfig{ctx: incomingCtx, mergeAble: true, nq: 2})
+
+	expiredCtx, cancelExpired := context.WithDeadline(context.Background(), now.Add(-time.Millisecond))
+	defer cancelExpired()
+	expiredBase := newMockTask(mockTaskConfig{ctx: expiredCtx, nq: 1})
+	expired := newQueuedTask(&doneCallbackTask{
+		Task:     expiredBase,
+		callback: cancelIncoming,
+	}, now.Add(-time.Second))
+	added, err = scheduler.policy.Push(expired)
+	s.NoError(err)
+	scheduler.updateWaitingTaskCounter(expired, int64(added), expired.NQ())
+
+	errCh := make(chan error, 1)
+	keepConsuming := scheduler.handleAddTaskRequest(addTaskReq{
+		task: incoming,
+		err:  errCh,
+	}, 2, now, nil)
+
+	s.True(keepConsuming)
+	s.ErrorIs(<-errCh, context.Canceled)
+	s.ErrorIs(expiredBase.Wait(), context.DeadlineExceeded)
+	remaining := scheduler.policy.Pop(now)
+	s.Equal(int64(1), remaining.NQ())
+	s.Equal(1, remaining.originalRequestCount)
+	s.Equal(int64(1), scheduler.GetWaitingTaskTotal())
+	s.Equal(int64(1), scheduler.GetWaitingTaskTotalNQ())
+}
+
+func (s *SchedulerSuite) TestHandleAddTaskRequestReturnsCancellationWhenCleanupLeavesQueueFull() {
+	now := time.Now()
+	scheduler := &scheduler{
+		policy:           newFIFOPolicy(),
+		schedulerCounter: schedulerCounter{},
+	}
+
+	active := newQueuedTask(newMockTask(mockTaskConfig{nq: 1}), now)
+	added, err := scheduler.policy.Push(active)
+	s.NoError(err)
+	scheduler.updateWaitingTaskCounter(active, int64(added), active.NQ())
+
+	incomingCtx, cancelIncoming := context.WithCancel(context.Background())
+	defer cancelIncoming()
+	incoming := newMockTask(mockTaskConfig{ctx: incomingCtx, nq: 1})
+
+	expiredCtx, cancelExpired := context.WithDeadline(context.Background(), now.Add(-time.Millisecond))
+	defer cancelExpired()
+	expiredBase := newMockTask(mockTaskConfig{ctx: expiredCtx, nq: 1})
+	staged := newQueuedTask(&doneCallbackTask{
+		Task:     expiredBase,
+		callback: cancelIncoming,
+	}, now.Add(-time.Second))
+	scheduler.updateWaitingTaskCounter(staged, 1, staged.NQ())
+
+	errCh := make(chan error, 1)
+	keepConsuming := scheduler.handleAddTaskRequest(addTaskReq{
+		task: incoming,
+		err:  errCh,
+	}, 1, now, &staged)
+
+	s.False(keepConsuming)
+	s.ErrorIs(<-errCh, context.Canceled)
+	s.False(staged.valid())
+	s.ErrorIs(expiredBase.Wait(), context.DeadlineExceeded)
+	s.Equal(1, scheduler.policy.Len())
 	s.Equal(int64(1), scheduler.GetWaitingTaskTotal())
 }
 
@@ -239,13 +331,13 @@ func (s *SchedulerSuite) TestHandleAddTaskRequestSkipsCleanupBeforeQueueFull() {
 	queued := newQueuedTask(expiredTask, now.Add(-time.Second))
 	added, err := scheduler.policy.Push(queued)
 	s.NoError(err)
-	scheduler.updateWaitingTaskCounter(int64(added), queued.NQ())
+	scheduler.updateWaitingTaskCounter(queued, int64(added), queued.NQ())
 
 	errCh := make(chan error, 1)
 	keepConsuming := scheduler.handleAddTaskRequest(addTaskReq{
 		task: newMockTask(mockTaskConfig{nq: 1}),
 		err:  errCh,
-	}, 2, now)
+	}, 2, now, nil)
 
 	s.False(keepConsuming)
 	s.NoError(<-errCh)
@@ -270,18 +362,59 @@ func (s *SchedulerSuite) TestHandleAddTaskRequestCleansTasksNearDeadlineBeforeQu
 	queued := newQueuedTask(nearDeadlineTask, now.Add(-time.Second))
 	added, err := scheduler.policy.Push(queued)
 	s.NoError(err)
-	scheduler.updateWaitingTaskCounter(int64(added), queued.NQ())
+	scheduler.updateWaitingTaskCounter(queued, int64(added), queued.NQ())
 
 	errCh := make(chan error, 1)
 	keepConsuming := scheduler.handleAddTaskRequest(addTaskReq{
 		task: newMockTask(mockTaskConfig{nq: 1}),
 		err:  errCh,
-	}, 1, now)
+	}, 1, now, nil)
 
 	s.False(keepConsuming)
 	s.NoError(<-errCh)
 	s.ErrorIs(nearDeadlineTask.Wait(), context.DeadlineExceeded)
 	s.Equal(int64(1), scheduler.GetWaitingTaskTotal())
+}
+
+func (s *SchedulerSuite) TestHandleAddTaskRequestCleansExpiredStagedTaskBeforeQueueLimit() {
+	paramtable.Init()
+	metrics.QueryNodeReadTaskQueueDuration.Reset()
+	defer metrics.QueryNodeReadTaskQueueDuration.Reset()
+
+	now := time.Now()
+	scheduler := &scheduler{
+		policy:           newFIFOPolicy(),
+		execChan:         make(chan Task),
+		schedulerCounter: schedulerCounter{},
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), now.Add(time.Hour))
+	defer cancel()
+	expiredTask := newMockTask(mockTaskConfig{ctx: ctx, nq: 2})
+	queued := newQueuedTask(expiredTask, now)
+	added, err := scheduler.policy.Push(queued)
+	s.NoError(err)
+	scheduler.updateWaitingTaskCounter(queued, int64(added), queued.NQ())
+
+	staged, _, _ := scheduler.setupExecListener(nil, now)
+	s.True(staged.valid())
+	s.Equal(int64(1), scheduler.GetWaitingTaskTotal())
+
+	errCh := make(chan error, 1)
+	keepConsuming := scheduler.handleAddTaskRequest(addTaskReq{
+		task: newMockTask(mockTaskConfig{nq: 3}),
+		err:  errCh,
+	}, 1, now.Add(2*time.Hour), &staged)
+
+	s.False(keepConsuming)
+	s.NoError(<-errCh)
+	s.False(staged.valid())
+	s.ErrorIs(expiredTask.Wait(), context.DeadlineExceeded)
+	s.Equal(1, scheduler.policy.Len())
+	s.Equal(int64(1), scheduler.GetWaitingTaskTotal())
+	s.Equal(int64(3), scheduler.GetWaitingTaskTotalNQ())
+	s.Equal(uint64(1), readTaskQueueDurationCount(readTaskQueueOutcomeScheduled))
+	s.Equal(uint64(0), readTaskQueueDurationCount(readTaskQueueOutcomeExpired))
 }
 
 func (s *SchedulerSuite) TestAddReturnsContextErrorWhenReceiveBlocks() {
@@ -310,7 +443,7 @@ func (s *SchedulerSuite) TestHandleAddTaskRequestDoesNotRejectByQueueDelayDeadli
 	queued := newQueuedTask(newMockTask(mockTaskConfig{nq: 1}), now.Add(-time.Second))
 	newTaskAdded, err := scheduler.policy.Push(queued)
 	s.NoError(err)
-	scheduler.updateWaitingTaskCounter(int64(newTaskAdded), queued.NQ())
+	scheduler.updateWaitingTaskCounter(queued, int64(newTaskAdded), queued.NQ())
 
 	ctx, cancel := context.WithDeadline(context.Background(), now.Add(100*time.Millisecond))
 	defer cancel()
@@ -319,7 +452,7 @@ func (s *SchedulerSuite) TestHandleAddTaskRequestDoesNotRejectByQueueDelayDeadli
 	keepConsuming := scheduler.handleAddTaskRequest(addTaskReq{
 		task: newMockTask(mockTaskConfig{ctx: ctx, nq: 1}),
 		err:  errCh,
-	}, 0, now)
+	}, 0, now, nil)
 
 	s.True(keepConsuming)
 	s.NoError(<-errCh)
@@ -340,7 +473,7 @@ func (s *SchedulerSuite) TestHandleAddTaskRequestAcceptsDeadlineWhenQueueEmpty()
 	keepConsuming := scheduler.handleAddTaskRequest(addTaskReq{
 		task: newMockTask(mockTaskConfig{ctx: ctx, nq: 1}),
 		err:  errCh,
-	}, 0, now)
+	}, 0, now, nil)
 
 	s.True(keepConsuming)
 	s.NoError(<-errCh)
@@ -365,7 +498,7 @@ func (s *SchedulerSuite) TestSetupExecListenerRecordsPoppedExpiredTask() {
 	queued := newQueuedTask(expiredTask, now.Add(-time.Second))
 	added, err := scheduler.policy.Push(queued)
 	s.NoError(err)
-	scheduler.updateWaitingTaskCounter(int64(added), queued.NQ())
+	scheduler.updateWaitingTaskCounter(queued, int64(added), queued.NQ())
 
 	task, nq, execChan := scheduler.setupExecListener(nil, now)
 
@@ -397,12 +530,12 @@ func (s *SchedulerSuite) TestClearQueuedTasksRemovesPolicyAndCurrentTask() {
 	queuedPolicyTask := newQueuedTask(policyTask, now.Add(-time.Second))
 	added, err := scheduler.policy.Push(queuedPolicyTask)
 	s.NoError(err)
-	scheduler.updateWaitingTaskCounter(int64(added), queuedPolicyTask.NQ())
+	scheduler.updateWaitingTaskCounter(queuedPolicyTask, int64(added), queuedPolicyTask.NQ())
 	queuedKeepTask := newQueuedTask(keepTask, now.Add(-time.Second))
 	added, err = scheduler.policy.Push(queuedKeepTask)
 	s.NoError(err)
-	scheduler.updateWaitingTaskCounter(int64(added), queuedKeepTask.NQ())
-	scheduler.updateWaitingTaskCounter(1, currentTask.NQ())
+	scheduler.updateWaitingTaskCounter(queuedKeepTask, int64(added), queuedKeepTask.NQ())
+	scheduler.updateWaitingTaskCounter(currentTask, 1, currentTask.NQ())
 
 	result, remaining := scheduler.clearQueuedTasks(func(task Task) bool {
 		return task.Username() == "clear"
@@ -488,6 +621,15 @@ func (s *SchedulerSuite) TestRecordReadTaskQueueDurationSkipsInvalidTask() {
 	metric := &dto.Metric{}
 	s.NoError(observer.(interface{ Write(*dto.Metric) error }).Write(metric))
 	s.Equal(uint64(0), metric.GetHistogram().GetSampleCount())
+}
+
+func readTaskRequeryQueueDurationCount(outcome string) uint64 {
+	observer := metrics.QueryNodeReadTaskRequeryQueueDuration.WithLabelValues(paramtable.GetStringNodeID(), outcome)
+	metric := &dto.Metric{}
+	if err := observer.(interface{ Write(*dto.Metric) error }).Write(metric); err != nil {
+		return 0
+	}
+	return metric.GetHistogram().GetSampleCount()
 }
 
 func readTaskExecuteDurationCount(outcome string) uint64 {

--- a/internal/util/searchutil/scheduler/concurrent_safe_scheduler_test.go
+++ b/internal/util/searchutil/scheduler/concurrent_safe_scheduler_test.go
@@ -117,6 +117,7 @@ func (s *SchedulerSuite) TestConsumeRecvChan() {
 		ch := make(chan addTaskReq, 10)
 		close(ch)
 		scheduler := &scheduler{
+			requeryQueue:     newMergeTaskQueue("requery"),
 			policy:           newFIFOPolicy(),
 			receiveChan:      ch,
 			execChan:         make(chan Task),
@@ -145,6 +146,7 @@ func (s *SchedulerSuite) TestConsumeRecvChan() {
 func (s *SchedulerSuite) TestConsumeRecvChanUsesLoopTimestampForBatch() {
 	now := time.Now()
 	scheduler := &scheduler{
+		requeryQueue:     newMergeTaskQueue("requery"),
 		policy:           newFIFOPolicy(),
 		receiveChan:      make(chan addTaskReq, 1),
 		schedulerCounter: schedulerCounter{},
@@ -176,6 +178,7 @@ func (s *SchedulerSuite) TestConsumeRecvChanUsesLoopTimestampForBatch() {
 
 func (s *SchedulerSuite) TestHandleAddTaskRequestRejectsWhenWaitingQueueFull() {
 	scheduler := &scheduler{
+		requeryQueue:     newMergeTaskQueue("requery"),
 		policy:           newFIFOPolicy(),
 		schedulerCounter: schedulerCounter{},
 	}
@@ -202,6 +205,7 @@ func (s *SchedulerSuite) TestHandleAddTaskRequestRejectsWhenWaitingQueueFull() {
 func (s *SchedulerSuite) TestHandleAddTaskRequestCleansExpiredTasksBeforeQueueLimit() {
 	now := time.Now()
 	scheduler := &scheduler{
+		requeryQueue:     newMergeTaskQueue("requery"),
 		policy:           newFIFOPolicy(),
 		schedulerCounter: schedulerCounter{},
 	}
@@ -229,6 +233,7 @@ func (s *SchedulerSuite) TestHandleAddTaskRequestCleansExpiredTasksBeforeQueueLi
 func (s *SchedulerSuite) TestHandleAddTaskRequestSkipsCleanupBeforeQueueFull() {
 	now := time.Now()
 	scheduler := &scheduler{
+		requeryQueue:     newMergeTaskQueue("requery"),
 		policy:           newFIFOPolicy(),
 		schedulerCounter: schedulerCounter{},
 	}
@@ -260,6 +265,7 @@ func (s *SchedulerSuite) TestHandleAddTaskRequestCleansTasksNearDeadlineBeforeQu
 
 	now := time.Now()
 	scheduler := &scheduler{
+		requeryQueue:     newMergeTaskQueue("requery"),
 		policy:           newFIFOPolicy(),
 		schedulerCounter: schedulerCounter{},
 	}
@@ -290,6 +296,7 @@ func (s *SchedulerSuite) TestAddReturnsContextErrorWhenReceiveBlocks() {
 	defer cancel()
 
 	scheduler := &scheduler{
+		requeryQueue:     newMergeTaskQueue("requery"),
 		policy:           newFIFOPolicy(),
 		receiveChan:      make(chan addTaskReq),
 		schedulerCounter: schedulerCounter{},
@@ -303,6 +310,7 @@ func (s *SchedulerSuite) TestAddReturnsContextErrorWhenReceiveBlocks() {
 func (s *SchedulerSuite) TestHandleAddTaskRequestDoesNotRejectByQueueDelayDeadline() {
 	now := time.Now()
 	scheduler := &scheduler{
+		requeryQueue:     newMergeTaskQueue("requery"),
 		policy:           newFIFOPolicy(),
 		schedulerCounter: schedulerCounter{},
 	}
@@ -329,6 +337,7 @@ func (s *SchedulerSuite) TestHandleAddTaskRequestDoesNotRejectByQueueDelayDeadli
 func (s *SchedulerSuite) TestHandleAddTaskRequestAcceptsDeadlineWhenQueueEmpty() {
 	now := time.Now()
 	scheduler := &scheduler{
+		requeryQueue:     newMergeTaskQueue("requery"),
 		policy:           newFIFOPolicy(),
 		schedulerCounter: schedulerCounter{},
 	}
@@ -354,6 +363,7 @@ func (s *SchedulerSuite) TestSetupExecListenerRecordsPoppedExpiredTask() {
 
 	now := time.Now()
 	scheduler := &scheduler{
+		requeryQueue:     newMergeTaskQueue("requery"),
 		policy:           newFIFOPolicy(),
 		execChan:         make(chan Task),
 		schedulerCounter: schedulerCounter{},
@@ -385,6 +395,7 @@ func (s *SchedulerSuite) TestClearQueuedTasksRemovesPolicyAndCurrentTask() {
 
 	now := time.Now()
 	scheduler := &scheduler{
+		requeryQueue:     newMergeTaskQueue("requery"),
 		policy:           newFIFOPolicy(),
 		execChan:         make(chan Task),
 		schedulerCounter: schedulerCounter{},

--- a/internal/util/searchutil/scheduler/queues.go
+++ b/internal/util/searchutil/scheduler/queues.go
@@ -191,6 +191,7 @@ func (q *mergeTaskQueue) tryMerge(task *queuedTask, maxNQ int64, nqMergeRatio fl
 			if (canMergeNQ(taskInQueue, mergeTask, maxNQ, nqMergeRatio) &&
 				canMergeDeadline(q.tasks[i], task, maxDeadlineMergeGap)) &&
 				taskInQueue.MergeWith(mergeTask) {
+				q.tasks[i].originalRequestCount += task.originalRequestCount
 				return true
 			}
 		}

--- a/internal/util/searchutil/scheduler/queues_test.go
+++ b/internal/util/searchutil/scheduler/queues_test.go
@@ -97,6 +97,27 @@ func TestMergeTaskQueueNQMergeRatio(t *testing.T) {
 	assert.Equal(t, int64(6), q.front().NQ())
 }
 
+func TestMergeTaskQueueTracksOriginalRequestCount(t *testing.T) {
+	now := time.Now()
+	q := newMergeTaskQueue("test_user")
+	base := newQueuedTask(newMockTask(mockTaskConfig{mergeAble: true, nq: 1}), now)
+	q.push(base)
+	assert.Equal(t, 1, q.front().originalRequestCount)
+
+	incoming := newQueuedTask(newMockTask(mockTaskConfig{mergeAble: true, nq: 1}), now)
+	assert.True(t, q.tryMerge(incoming, 64, 0, 0))
+	assert.Equal(t, 2, q.front().originalRequestCount)
+
+	groupedIncoming := newQueuedTask(newMockTask(mockTaskConfig{mergeAble: true, nq: 1}), now)
+	groupedIncoming.originalRequestCount = 3
+	assert.True(t, q.tryMerge(groupedIncoming, 64, 0, 0))
+	assert.Equal(t, 5, q.front().originalRequestCount)
+
+	notMergeable := newQueuedTask(newMockTask(mockTaskConfig{nq: 1}), now)
+	assert.False(t, q.tryMerge(notMergeable, 64, 0, 0))
+	assert.Equal(t, 5, q.pop().originalRequestCount)
+}
+
 func TestMergeTaskQueueDeadlineMergeGap(t *testing.T) {
 	now := time.Now()
 	baseDeadline := now.Add(time.Second)

--- a/internal/util/searchutil/scheduler/requery_lane_test.go
+++ b/internal/util/searchutil/scheduler/requery_lane_test.go
@@ -1,0 +1,508 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/pkg/v3/metrics"
+	"github.com/milvus-io/milvus/pkg/v3/util/contextutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+func requeryCtx() context.Context {
+	return contextutil.WithQueryLabel(context.Background(), metrics.ReQueryLabel)
+}
+
+func newUnstartedScheduler() *scheduler {
+	return newScheduler(newRequeryPriorityPolicy(newFIFOPolicy())).(*scheduler)
+}
+
+func addTask(s *scheduler, task Task, now time.Time) error {
+	errCh := make(chan error, 1)
+	s.handleAddTaskRequest(addTaskReq{task: task, err: errCh}, paramtable.Get().QueryNodeCfg.MaxUnsolvedQueueSize.GetAsInt64(), now, nil)
+	return <-errCh
+}
+
+func waitMockTask(t *testing.T, task Task) error {
+	t.Helper()
+	result := make(chan error, 1)
+	go func() {
+		result <- task.Wait()
+	}()
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for task completion")
+		return nil
+	}
+}
+
+func TestRequeryLaneSeparateAdmissionAndExportedCounters(t *testing.T) {
+	paramtable.Init()
+	metrics.QueryNodeReadTaskRejectCnt.Reset()
+	defer metrics.QueryNodeReadTaskRejectCnt.Reset()
+	pt := paramtable.Get()
+	oldMax := pt.QueryNodeCfg.MaxUnsolvedQueueSize.SwapTempValue("2")
+	defer pt.QueryNodeCfg.MaxUnsolvedQueueSize.SwapTempValue(oldMax)
+	oldLane := pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("2")
+	defer pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue(oldLane)
+
+	s := newUnstartedScheduler()
+	policy := s.policy.(*requeryPriorityPolicy)
+	now := time.Now()
+
+	assert.NoError(t, addTask(s, newMockTask(mockTaskConfig{nq: 3}), now))
+	assert.NoError(t, addTask(s, newMockTask(mockTaskConfig{nq: 5}), now))
+	assert.NoError(t, addTask(s, newMockTask(mockTaskConfig{ctx: requeryCtx(), nq: 7}), now))
+
+	assert.Equal(t, int64(2), s.getRegularWaitingTaskTotal())
+	assert.Equal(t, int64(8), s.getRegularWaitingTaskTotalNQ())
+	assert.Equal(t, int64(1), s.getRequeryWaitingTaskTotal())
+	assert.Equal(t, int64(7), s.getRequeryWaitingTaskTotalNQ())
+	assert.Equal(t, int64(3), s.GetWaitingTaskTotal())
+	assert.Equal(t, int64(15), s.GetWaitingTaskTotalNQ())
+	assert.Equal(t, 1, policy.lane.len())
+
+	// Lane backlog is visible externally but does not consume regular capacity.
+	err := addTask(s, newMockTask(mockTaskConfig{}), now)
+	assert.ErrorIs(t, err, merr.ErrServiceTooManyRequests)
+	assert.NoError(t, addTask(s, newMockTask(mockTaskConfig{ctx: requeryCtx(), nq: 11}), now))
+	err = addTask(s, newMockTask(mockTaskConfig{ctx: requeryCtx()}), now)
+	assert.ErrorIs(t, err, merr.ErrServiceTooManyRequests)
+	assert.ErrorContains(t, err, pt.QueryNodeCfg.RequeryUnsolvedQueueSize.Key)
+
+	assert.Equal(t, int64(2), s.getRegularWaitingTaskTotal())
+	assert.Equal(t, int64(2), s.getRequeryWaitingTaskTotal())
+	assert.Equal(t, int64(4), s.GetWaitingTaskTotal())
+	assert.Equal(t, int64(26), s.GetWaitingTaskTotalNQ())
+
+	nodeID := paramtable.GetStringNodeID()
+	assert.Equal(t, float64(1), testutil.ToFloat64(
+		metrics.QueryNodeReadTaskRejectCnt.WithLabelValues(nodeID, metrics.RegularLabel),
+	))
+	assert.Equal(t, float64(1), testutil.ToFloat64(
+		metrics.QueryNodeReadTaskRejectCnt.WithLabelValues(nodeID, metrics.ReQueryLabel),
+	))
+}
+
+func TestRequeryLaneCleanupRetry(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	oldLane := pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("1")
+	defer pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue(oldLane)
+
+	s := newUnstartedScheduler()
+	policy := s.policy.(*requeryPriorityPolicy)
+	now := time.Now()
+	expiredCtx, cancel := context.WithDeadline(context.Background(), now.Add(-time.Millisecond))
+	defer cancel()
+	expiredTask := newMockTask(mockTaskConfig{ctx: expiredCtx, nq: 2})
+	expired := newQueuedTask(expiredTask, now.Add(-time.Second))
+	expired.requery = true
+	added, err := s.policy.Push(expired)
+	require.NoError(t, err)
+	s.updateWaitingTaskCounter(expired, int64(added), expired.NQ())
+
+	fresh := newMockTask(mockTaskConfig{ctx: requeryCtx(), nq: 3})
+	assert.NoError(t, addTask(s, fresh, now))
+	assert.ErrorIs(t, waitMockTask(t, expiredTask), context.DeadlineExceeded)
+	assert.Equal(t, 1, policy.lane.len())
+	assert.Equal(t, int64(1), s.getRequeryWaitingTaskTotal())
+	assert.Equal(t, int64(3), s.getRequeryWaitingTaskTotalNQ())
+	assert.Equal(t, int64(1), s.GetWaitingTaskTotal())
+}
+
+func TestRequeryLaneFullStopsReceiveBatch(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	oldLane := pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("1")
+	defer pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue(oldLane)
+
+	s := newUnstartedScheduler()
+	now := time.Now()
+	require.NoError(t, addTask(s, newMockTask(mockTaskConfig{ctx: requeryCtx()}), now))
+
+	s.receiveChan = make(chan addTaskReq, 2)
+	nextErr1 := make(chan error, 1)
+	nextErr2 := make(chan error, 1)
+	s.receiveChan <- addTaskReq{task: newMockTask(mockTaskConfig{}), err: nextErr1}
+	s.receiveChan <- addTaskReq{task: newMockTask(mockTaskConfig{}), err: nextErr2}
+
+	fullLaneErr := make(chan error, 1)
+	s.consumeRecvChan(
+		addTaskReq{task: newMockTask(mockTaskConfig{ctx: requeryCtx()}), err: fullLaneErr},
+		maxReceiveChanBatchConsumeNum,
+		now,
+		nil,
+	)
+	assert.ErrorIs(t, <-fullLaneErr, merr.ErrServiceTooManyRequests)
+	assert.Len(t, s.receiveChan, 2)
+	select {
+	case err := <-nextErr1:
+		t.Fatalf("next request was unexpectedly consumed: %v", err)
+	default:
+	}
+	select {
+	case err := <-nextErr2:
+		t.Fatalf("next request was unexpectedly consumed: %v", err)
+	default:
+	}
+}
+
+func TestRequeryLaneStagedTaskCountsAgainstCapacity(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	oldLane := pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("2")
+	defer pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue(oldLane)
+
+	s := newUnstartedScheduler()
+	policy := s.policy.(*requeryPriorityPolicy)
+	now := time.Now()
+	first := newMockTask(mockTaskConfig{ctx: requeryCtx(), nq: 2})
+	require.NoError(t, addTask(s, first, now))
+
+	staged, nq, execChan := s.setupExecListener(nil, now)
+	require.True(t, staged.valid())
+	assert.Equal(t, first, staged.Task)
+	assert.Equal(t, int64(2), nq)
+	assert.Equal(t, s.execChan, execChan)
+	assert.Zero(t, policy.lane.len())
+	assert.Equal(t, int64(1), s.getRequeryWaitingTaskTotal())
+
+	second := newMockTask(mockTaskConfig{ctx: requeryCtx()})
+	capacity, available := s.waitingTaskCapacityAvailable(true, 1024)
+	assert.Equal(t, int64(2), capacity)
+	assert.True(t, available)
+
+	pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("1")
+	candidate := newQueuedTask(second, now)
+	candidate.requery = true
+	_, err := s.pushTaskOnce(candidate)
+	assert.ErrorIs(t, err, merr.ErrServiceTooManyRequests)
+	assert.Zero(t, policy.lane.len())
+
+	errCh := make(chan error, 1)
+	s.handleAddTaskRequest(addTaskReq{task: second, err: errCh}, 1024, now, &staged)
+	err = <-errCh
+	assert.ErrorIs(t, err, merr.ErrServiceTooManyRequests)
+	assert.ErrorContains(t, err, pt.QueryNodeCfg.RequeryUnsolvedQueueSize.Key)
+	assert.True(t, staged.valid())
+	assert.Zero(t, policy.lane.len())
+	assert.Equal(t, int64(1), s.getRequeryWaitingTaskTotal())
+
+	s.onTaskDequeued(staged, nq)
+	staged.Done(nil)
+	assert.Zero(t, s.getRequeryWaitingTaskTotal())
+	require.NoError(t, addTask(s, second, now))
+	assert.Equal(t, 1, policy.lane.len())
+	assert.Equal(t, int64(1), s.getRequeryWaitingTaskTotal())
+}
+
+func TestRequeryLaneStagedRegularDroppedGrantsNoCredit(t *testing.T) {
+	paramtable.Init()
+
+	s := newUnstartedScheduler()
+	policy := s.policy.(*requeryPriorityPolicy)
+	now := time.Now()
+
+	expiringCtx, cancel := context.WithDeadline(context.Background(), now.Add(time.Hour))
+	defer cancel()
+	expiringRegular := newMockTask(mockTaskConfig{ctx: expiringCtx, nq: 1})
+	require.NoError(t, addTask(s, expiringRegular, now))
+	require.NoError(t, addTask(s, newMockTask(mockTaskConfig{ctx: requeryCtx(), nq: 1}), now))
+	nextRegular := newMockTask(mockTaskConfig{nq: 1})
+	require.NoError(t, addTask(s, nextRegular, now))
+	policy.requeryCredit = 0
+
+	staged, _, _ := s.setupExecListener(nil, now)
+	require.True(t, staged.valid())
+	require.Same(t, expiringRegular, staged.Task)
+	assert.Zero(t, policy.requeryCredit)
+
+	// The staged regular task expires before handoff; its drop must not open a
+	// lane window, so the next selected task is still the regular one.
+	s.cleanupExpiredTasks(now.Add(2*time.Hour), &staged)
+	require.False(t, staged.valid())
+	assert.ErrorIs(t, waitMockTask(t, expiringRegular), context.DeadlineExceeded)
+	assert.Zero(t, policy.requeryCredit)
+
+	staged, _, _ = s.setupExecListener(nil, now)
+	require.True(t, staged.valid())
+	assert.Same(t, nextRegular, staged.Task)
+
+	// Only a real handoff grants a new lane window.
+	s.onTaskServed(staged)
+	assert.Equal(t, requeryPriorityBaseCredit, policy.requeryCredit)
+}
+
+func TestRequeryLaneCleansExpiredStagedTaskBeforeCapacityReject(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	oldLane := pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("1")
+	defer pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue(oldLane)
+
+	s := newUnstartedScheduler()
+	policy := s.policy.(*requeryPriorityPolicy)
+	now := time.Now()
+	ctx, cancel := context.WithDeadline(requeryCtx(), now.Add(time.Hour))
+	defer cancel()
+	expiredTask := newMockTask(mockTaskConfig{ctx: ctx, nq: 2})
+	require.NoError(t, addTask(s, expiredTask, now))
+
+	staged, _, _ := s.setupExecListener(nil, now)
+	require.True(t, staged.valid())
+	assert.Zero(t, policy.lane.len())
+	assert.Equal(t, int64(1), s.getRequeryWaitingTaskTotal())
+
+	fresh := newMockTask(mockTaskConfig{ctx: requeryCtx(), nq: 3})
+	errCh := make(chan error, 1)
+	s.handleAddTaskRequest(addTaskReq{task: fresh, err: errCh}, 1024, now.Add(2*time.Hour), &staged)
+
+	assert.NoError(t, <-errCh)
+	assert.False(t, staged.valid())
+	assert.ErrorIs(t, waitMockTask(t, expiredTask), context.DeadlineExceeded)
+	assert.Equal(t, 1, policy.lane.len())
+	assert.Equal(t, int64(1), s.getRequeryWaitingTaskTotal())
+	assert.Equal(t, int64(3), s.getRequeryWaitingTaskTotalNQ())
+}
+
+func TestRequeryLaneDepthMetricIncludesStagedTask(t *testing.T) {
+	paramtable.Init()
+	metrics.QueryNodeReadTaskRequeryReadyLen.Reset()
+	defer metrics.QueryNodeReadTaskRequeryReadyLen.Reset()
+	metrics.QueryNodeReadTaskQueueDuration.Reset()
+	defer metrics.QueryNodeReadTaskQueueDuration.Reset()
+	metrics.QueryNodeReadTaskRequeryQueueDuration.Reset()
+	defer metrics.QueryNodeReadTaskRequeryQueueDuration.Reset()
+
+	s := newUnstartedScheduler()
+	now := time.Now()
+	task := newMockTask(mockTaskConfig{ctx: requeryCtx(), nq: 2})
+	require.NoError(t, addTask(s, task, now))
+
+	staged, nq, _ := s.setupExecListener(nil, now)
+	require.True(t, staged.valid())
+	assert.Zero(t, s.policy.(*requeryPriorityPolicy).lane.len())
+	assert.Equal(t, int64(1), s.getRequeryWaitingTaskTotal())
+	// The requery task lands in both the aggregate histogram and the
+	// requery-only subset metric.
+	assert.Equal(t, uint64(1), readTaskQueueDurationCount(readTaskQueueOutcomeScheduled))
+	assert.Equal(t, uint64(1), readTaskRequeryQueueDurationCount(readTaskQueueOutcomeScheduled))
+
+	s.setupReadyLenMetric()
+	nodeID := paramtable.GetStringNodeID()
+	assert.Equal(t, float64(1), testutil.ToFloat64(
+		metrics.QueryNodeReadTaskRequeryReadyLen.WithLabelValues(nodeID),
+	))
+
+	s.onTaskDequeued(staged, nq)
+	staged.Done(nil)
+	s.setupReadyLenMetric()
+	assert.Zero(t, testutil.ToFloat64(
+		metrics.QueryNodeReadTaskRequeryReadyLen.WithLabelValues(nodeID),
+	))
+}
+
+func TestUserTaskPollingQuotaRejectDoesNotTriggerGlobalCleanup(t *testing.T) {
+	paramtable.Init()
+	metrics.QueryNodeReadTaskRejectCnt.Reset()
+	defer metrics.QueryNodeReadTaskRejectCnt.Reset()
+	pt := paramtable.Get()
+	oldLimit := pt.QueryNodeCfg.SchedulePolicyMaxPendingTaskPerUser.SwapTempValue("1")
+	defer pt.QueryNodeCfg.SchedulePolicyMaxPendingTaskPerUser.SwapTempValue(oldLimit)
+
+	now := time.Now()
+	s := &scheduler{
+		policy:           newUserTaskPollingPolicy(),
+		schedulerCounter: schedulerCounter{},
+	}
+	userATask := newMockTask(mockTaskConfig{username: "user-a"})
+	userA := newQueuedTask(userATask, now)
+	added, err := s.policy.Push(userA)
+	require.NoError(t, err)
+	s.updateWaitingTaskCounter(userA, int64(added), userA.NQ())
+
+	expiredCtx, cancel := context.WithDeadline(context.Background(), now.Add(-time.Millisecond))
+	defer cancel()
+	expiredTask := newMockTask(mockTaskConfig{ctx: expiredCtx, username: "user-b"})
+	expired := newQueuedTask(expiredTask, now.Add(-time.Second))
+	added, err = s.policy.Push(expired)
+	require.NoError(t, err)
+	s.updateWaitingTaskCounter(expired, int64(added), expired.NQ())
+
+	fresh := newMockTask(mockTaskConfig{username: "user-a"})
+	errCh := make(chan error, 1)
+	s.handleAddTaskRequest(addTaskReq{task: fresh, err: errCh}, 10, now, nil)
+	assert.ErrorIs(t, <-errCh, merr.ErrServiceTooManyRequests)
+	assert.Equal(t, 2, s.policy.Len())
+	assert.Equal(t, int64(2), s.getRegularWaitingTaskTotal())
+	assert.Zero(t, len(expiredTask.(*MockTask).notifier))
+	assert.Equal(t, float64(1), testutil.ToFloat64(
+		metrics.QueryNodeReadTaskRejectCnt.WithLabelValues(paramtable.GetStringNodeID(), metrics.RegularLabel),
+	))
+}
+
+func TestRequeryLaneDynamicDisableDrainsOldTasksWithoutCapBypass(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	oldMax := pt.QueryNodeCfg.MaxUnsolvedQueueSize.SwapTempValue("1")
+	defer pt.QueryNodeCfg.MaxUnsolvedQueueSize.SwapTempValue(oldMax)
+	oldLane := pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("1")
+	defer pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue(oldLane)
+
+	s := newUnstartedScheduler()
+	now := time.Now()
+	regular := newMockTask(mockTaskConfig{})
+	oldRequery := newMockTask(mockTaskConfig{ctx: requeryCtx()})
+	assert.NoError(t, addTask(s, regular, now))
+	assert.NoError(t, addTask(s, oldRequery, now))
+
+	pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("0")
+	newRequery := newMockTask(mockTaskConfig{ctx: requeryCtx()})
+	err := addTask(s, newRequery, now)
+	assert.ErrorIs(t, err, merr.ErrServiceTooManyRequests)
+
+	popped := s.policy.Pop(now)
+	assert.Equal(t, oldRequery, popped.Task)
+	assert.True(t, popped.requery)
+	assert.Equal(t, int64(1), s.getRequeryWaitingTaskTotal())
+	s.onTaskDequeued(popped, popped.NQ())
+	assert.Zero(t, s.getRequeryWaitingTaskTotal())
+
+	popped = s.policy.Pop(now)
+	assert.Equal(t, regular, popped.Task)
+	assert.False(t, popped.requery)
+}
+
+func TestRequeryLaneClearPoppedCurrentSettlesCounters(t *testing.T) {
+	paramtable.Init()
+	s := newUnstartedScheduler()
+	now := time.Now()
+	task := newMockTask(mockTaskConfig{ctx: requeryCtx(), nq: 7})
+	assert.NoError(t, addTask(s, task, now))
+
+	current, nq, execChan := s.setupExecListener(nil, now)
+	require.True(t, current.valid())
+	assert.True(t, current.requery)
+	assert.Equal(t, int64(7), nq)
+	assert.Equal(t, s.execChan, execChan)
+	assert.Zero(t, s.policy.(*requeryPriorityPolicy).lane.len())
+	assert.Equal(t, int64(1), s.getRequeryWaitingTaskTotal())
+
+	result, remaining := s.clearQueuedTasks(nil, "test clear", current, now)
+	assert.Equal(t, ClearResult{QueuedCleared: 1, QueuedNQCleared: 7}, result)
+	assert.False(t, remaining.valid())
+	assert.ErrorIs(t, waitMockTask(t, task), context.Canceled)
+	assert.Zero(t, s.GetWaitingTaskTotal())
+	assert.Zero(t, s.GetWaitingTaskTotalNQ())
+}
+
+func TestRequeryLaneWiringDisablesLaneForUserTaskPolling(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	oldLane := pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("2")
+	defer pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue(oldLane)
+	oldLimit := pt.QueryNodeCfg.SchedulePolicyMaxPendingTaskPerUser.SwapTempValue("2")
+	defer pt.QueryNodeCfg.SchedulePolicyMaxPendingTaskPerUser.SwapTempValue(oldLimit)
+
+	defaultScheduler := NewScheduler("").(*scheduler)
+	t.Cleanup(defaultScheduler.Stop)
+	_, ok := defaultScheduler.policy.(*requeryPriorityPolicy)
+	assert.True(t, ok)
+	fifoScheduler := NewScheduler(schedulePolicyNameFIFO).(*scheduler)
+	t.Cleanup(fifoScheduler.Stop)
+	_, ok = fifoScheduler.policy.(*requeryPriorityPolicy)
+	assert.True(t, ok)
+	utpScheduler := NewScheduler(schedulePolicyNameUserTaskPolling).(*scheduler)
+	t.Cleanup(utpScheduler.Stop)
+	_, ok = utpScheduler.policy.(*userTaskPollingPolicy)
+	assert.True(t, ok)
+	_, ok = utpScheduler.policy.(laneClassifier)
+	assert.False(t, ok)
+
+	now := time.Now()
+	userA1 := newMockTask(mockTaskConfig{username: "user-a"})
+	userA2 := newMockTask(mockTaskConfig{ctx: requeryCtx(), username: "user-a"})
+	userB1 := newMockTask(mockTaskConfig{ctx: requeryCtx(), username: "user-b"})
+	userB2 := newMockTask(mockTaskConfig{username: "user-b"})
+	assert.NoError(t, addTask(utpScheduler, userA1, now))
+	assert.NoError(t, addTask(utpScheduler, userA2, now))
+	assert.NoError(t, addTask(utpScheduler, userB1, now))
+	assert.NoError(t, addTask(utpScheduler, userB2, now))
+	err := addTask(utpScheduler, newMockTask(mockTaskConfig{ctx: requeryCtx(), username: "user-a"}), now)
+	assert.ErrorIs(t, err, merr.ErrServiceTooManyRequests)
+
+	for _, expected := range []Task{userA1, userB1, userA2, userB2} {
+		popped := utpScheduler.policy.Pop(now)
+		assert.Equal(t, expected, popped.Task)
+		assert.False(t, popped.requery)
+	}
+}
+
+func TestRequeryLaneShutdownDrainsCounters(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	oldConcurrency := pt.QueryNodeCfg.MaxReadConcurrency.SwapTempValue("1")
+	defer pt.QueryNodeCfg.MaxReadConcurrency.SwapTempValue(oldConcurrency)
+	oldLane := pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("4")
+	defer pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue(oldLane)
+
+	s := NewScheduler(schedulePolicyNameFIFO).(*scheduler)
+	s.Start()
+	started := make(chan struct{})
+	gate := make(chan struct{})
+	blocker := newMockTask(mockTaskConfig{
+		executeCost: time.Millisecond,
+		execution: func(context.Context) error {
+			close(started)
+			<-gate
+			return nil
+		},
+	})
+	lane1 := newMockTask(mockTaskConfig{ctx: requeryCtx(), executeCost: time.Millisecond})
+	lane2 := newMockTask(mockTaskConfig{ctx: requeryCtx(), executeCost: time.Millisecond})
+	lane3 := newMockTask(mockTaskConfig{ctx: requeryCtx(), executeCost: time.Millisecond})
+	regular := newMockTask(mockTaskConfig{executeCost: time.Millisecond})
+
+	require.NoError(t, s.Add(blocker))
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for blocker to start")
+	}
+	require.NoError(t, s.Add(lane1))
+	require.NoError(t, s.Add(lane2))
+	require.NoError(t, s.Add(lane3))
+	require.NoError(t, s.Add(regular))
+	require.Eventually(t, func() bool {
+		policy := s.policy.(*requeryPriorityPolicy)
+		return policy.lane.len() > 0 && s.getRequeryWaitingTaskTotal() > 0
+	}, 5*time.Second, 10*time.Millisecond)
+
+	stopped := make(chan struct{})
+	go func() {
+		s.Stop()
+		close(stopped)
+	}()
+	close(gate)
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for scheduler shutdown")
+	}
+
+	assert.NoError(t, waitMockTask(t, blocker))
+	assert.NoError(t, waitMockTask(t, lane1))
+	assert.NoError(t, waitMockTask(t, lane2))
+	assert.NoError(t, waitMockTask(t, lane3))
+	assert.NoError(t, waitMockTask(t, regular))
+	assert.Zero(t, s.GetWaitingTaskTotal())
+	assert.Zero(t, s.GetWaitingTaskTotalNQ())
+}

--- a/internal/util/searchutil/scheduler/requery_lane_test.go
+++ b/internal/util/searchutil/scheduler/requery_lane_test.go
@@ -1,0 +1,148 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v3/metrics"
+	"github.com/milvus-io/milvus/pkg/v3/util/contextutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+func requeryCtx() context.Context {
+	return contextutil.WithQueryLabel(context.Background(), metrics.ReQueryLabel)
+}
+
+func newUnstartedScheduler() *scheduler {
+	return newScheduler(newFIFOPolicy()).(*scheduler)
+}
+
+func addTask(s *scheduler, task Task, now time.Time) error {
+	errCh := make(chan error, 1)
+	s.handleAddTaskRequest(addTaskReq{task: task, err: errCh}, paramtable.Get().QueryNodeCfg.MaxUnsolvedQueueSize.GetAsInt64(), now)
+	return <-errCh
+}
+
+func TestRequeryLaneBypassesFullUnsolvedQueue(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	oldMax := pt.QueryNodeCfg.MaxUnsolvedQueueSize.SwapTempValue("2")
+	defer pt.QueryNodeCfg.MaxUnsolvedQueueSize.SwapTempValue(oldMax)
+	oldLane := pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("2")
+	defer pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue(oldLane)
+
+	s := newUnstartedScheduler()
+	now := time.Now()
+
+	// Fill the regular unsolved queue to its limit.
+	for i := 0; i < 2; i++ {
+		assert.NoError(t, addTask(s, newMockTask(mockTaskConfig{}), now))
+	}
+	// Regular task is rejected when the queue is full.
+	err := addTask(s, newMockTask(mockTaskConfig{}), now)
+	assert.ErrorIs(t, err, merr.ErrServiceTooManyRequests)
+
+	// Requery task is still admitted through the lane.
+	assert.NoError(t, addTask(s, newMockTask(mockTaskConfig{ctx: requeryCtx()}), now))
+	assert.Equal(t, 1, s.requeryQueue.len())
+	// Lane tasks stay out of the policy waiting counters.
+	assert.Equal(t, int64(2), s.GetWaitingTaskTotal())
+
+	// The lane itself is bounded.
+	assert.NoError(t, addTask(s, newMockTask(mockTaskConfig{ctx: requeryCtx()}), now))
+	err = addTask(s, newMockTask(mockTaskConfig{ctx: requeryCtx()}), now)
+	assert.ErrorIs(t, err, merr.ErrServiceTooManyRequests)
+	assert.ErrorContains(t, err, pt.QueryNodeCfg.RequeryUnsolvedQueueSize.Key)
+	assert.Equal(t, 2, s.requeryQueue.len())
+}
+
+func TestRequeryLaneStrictPriority(t *testing.T) {
+	paramtable.Init()
+	s := newUnstartedScheduler()
+	now := time.Now()
+
+	regular1 := newMockTask(mockTaskConfig{})
+	regular2 := newMockTask(mockTaskConfig{})
+	requery := newMockTask(mockTaskConfig{ctx: requeryCtx()})
+	assert.NoError(t, addTask(s, regular1, now))
+	assert.NoError(t, addTask(s, regular2, now))
+	assert.NoError(t, addTask(s, requery, now))
+
+	// The requery task is popped first even though it was queued last.
+	popped := s.popTask(now)
+	assert.True(t, popped.requery)
+	assert.Same(t, requery, popped.Task)
+	assert.Same(t, regular1, s.popTask(now).Task)
+	assert.Same(t, regular2, s.popTask(now).Task)
+	assert.False(t, s.popTask(now).valid())
+}
+
+func TestRequeryLaneDisabled(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	oldLane := pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("0")
+	defer pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue(oldLane)
+
+	s := newUnstartedScheduler()
+	now := time.Now()
+
+	// With the lane disabled the requery task falls back to the policy queue.
+	assert.NoError(t, addTask(s, newMockTask(mockTaskConfig{ctx: requeryCtx()}), now))
+	assert.Equal(t, 0, s.requeryQueue.len())
+	assert.Equal(t, int64(1), s.GetWaitingTaskTotal())
+	assert.False(t, s.popTask(now).requery)
+}
+
+func TestRequeryLaneCleanupExpired(t *testing.T) {
+	paramtable.Init()
+	s := newUnstartedScheduler()
+	now := time.Now()
+
+	ctx, cancel := context.WithCancel(requeryCtx())
+	task := newMockTask(mockTaskConfig{ctx: ctx})
+	assert.NoError(t, addTask(s, task, now))
+	assert.Equal(t, 1, s.requeryQueue.len())
+
+	cancel()
+	s.cleanupExpiredTasks(time.Now())
+	assert.Equal(t, 0, s.requeryQueue.len())
+	assert.ErrorIs(t, task.Wait(), context.Canceled)
+	// Lane cleanup must not corrupt the policy counters.
+	assert.Equal(t, int64(0), s.GetWaitingTaskTotal())
+	assert.Equal(t, int64(0), s.GetWaitingTaskTotalNQ())
+}
+
+func TestRequeryLaneCleared(t *testing.T) {
+	paramtable.Init()
+	s := newUnstartedScheduler()
+	now := time.Now()
+
+	task := newMockTask(mockTaskConfig{ctx: requeryCtx()})
+	assert.NoError(t, addTask(s, task, now))
+
+	result, _ := s.clearQueuedTasks(nil, "test clear", nil, time.Now())
+	assert.Equal(t, int64(1), result.QueuedCleared)
+	assert.Equal(t, 0, s.requeryQueue.len())
+	assert.ErrorIs(t, task.Wait(), context.Canceled)
+	assert.Equal(t, int64(0), s.GetWaitingTaskTotal())
+}
+
+func TestRequeryLaneEndToEnd(t *testing.T) {
+	paramtable.Init()
+	s := newScheduler(newFIFOPolicy())
+	s.Start()
+	defer s.Stop()
+
+	regular := newMockTask(mockTaskConfig{executeCost: 10 * time.Millisecond})
+	requery := newMockTask(mockTaskConfig{ctx: requeryCtx(), executeCost: 10 * time.Millisecond})
+	assert.NoError(t, s.Add(regular))
+	assert.NoError(t, s.Add(requery))
+	assert.NoError(t, regular.Wait())
+	assert.NoError(t, requery.Wait())
+	assert.Equal(t, int64(0), s.GetWaitingTaskTotal())
+	assert.Equal(t, int64(0), s.GetWaitingTaskTotalNQ())
+}

--- a/internal/util/searchutil/scheduler/requery_policy.go
+++ b/internal/util/searchutil/scheduler/requery_policy.go
@@ -1,0 +1,134 @@
+package scheduler
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/milvus-io/milvus/pkg/v3/metrics"
+	"github.com/milvus-io/milvus/pkg/v3/util/contextutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+const requeryPriorityBaseCredit = 3
+
+// laneClassifier lets the scheduler classify a task once before admission.
+// The result is stamped on queuedTask and remains immutable afterwards.
+type laneClassifier interface {
+	UseLane(task Task) bool
+}
+
+// taskServedObserver is probed by the scheduler to report a task that actually
+// left scheduler ownership through execChan handoff. Tasks dropped by
+// expiration or clear are never reported.
+type taskServedObserver interface {
+	onTaskServed(task *queuedTask)
+}
+
+var (
+	_ schedulePolicy     = (*requeryPriorityPolicy)(nil)
+	_ laneClassifier     = (*requeryPriorityPolicy)(nil)
+	_ taskServedObserver = (*requeryPriorityPolicy)(nil)
+)
+
+// requeryPriorityPolicy adds a bounded priority lane to an existing policy.
+// It is owned by the scheduler goroutine, so lane and credit need no locks.
+type requeryPriorityPolicy struct {
+	inner schedulePolicy
+	lane  *mergeTaskQueue
+	// requeryCredit is the number of lane tasks that may be selected before
+	// another live regular task is required. A live regular Pop refreshes it to
+	// max(base credit, task.originalRequestCount).
+	requeryCredit int
+}
+
+func newRequeryPriorityPolicy(inner schedulePolicy) *requeryPriorityPolicy {
+	return &requeryPriorityPolicy{
+		inner:         inner,
+		lane:          newMergeTaskQueue("requery"),
+		requeryCredit: requeryPriorityBaseCredit,
+	}
+}
+
+func (p *requeryPriorityPolicy) UseLane(task Task) bool {
+	return task != nil &&
+		contextutil.GetQueryLabel(task.Context()) == metrics.ReQueryLabel &&
+		requeryLaneCapacity() > 0
+}
+
+func (p *requeryPriorityPolicy) Cleanup(now time.Time) []*queuedTask {
+	removed := p.lane.cleanup(now)
+	return append(removed, p.inner.Cleanup(now)...)
+}
+
+func (p *requeryPriorityPolicy) Remove(filter TaskFilter, now time.Time) []*queuedTask {
+	removed := p.lane.remove(filter, now)
+	return append(removed, p.inner.Remove(filter, now)...)
+}
+
+func (p *requeryPriorityPolicy) Push(task *queuedTask) (int, error) {
+	if !task.requery {
+		return p.inner.Push(task)
+	}
+
+	// The scheduler owns capacity admission because only it can account for
+	// both the physical lane and a scheduler-local staged requery task.
+	p.lane.push(task)
+	return 1, nil
+}
+
+func (p *requeryPriorityPolicy) Pop(now time.Time) *queuedTask {
+	if p.requeryCredit > 0 {
+		if task := p.lane.pop(); task.valid() {
+			p.requeryCredit--
+			return task
+		}
+	}
+
+	// Credit is refreshed in onTaskServed, not here: a popped regular task can
+	// still be dropped by expiration cleanup or clear while staged for handoff,
+	// and such a task must not open a new lane window.
+	if task := p.inner.Pop(now); task.valid() {
+		return task
+	}
+
+	// Do not return nil while the lane still has work. This also lets an
+	// existing lane drain after the feature is disabled dynamically. Count the
+	// fallback task as the first task in a new base-credit window so a regular
+	// task arriving while it is waiting for handoff still observes the bound.
+	task := p.lane.pop()
+	if task.valid() {
+		p.requeryCredit = requeryPriorityBaseCredit - 1
+		return task
+	}
+	p.requeryCredit = requeryPriorityBaseCredit
+	return nil
+}
+
+func (p *requeryPriorityPolicy) Len() int {
+	return p.lane.len() + p.inner.Len()
+}
+
+// onTaskServed refreshes the requery credit window only when a regular task is
+// actually handed to execution. Credit is a backlog-aware weighted burst, not a
+// reservation for a specific parent request; a served regular task refreshes
+// the current window to max(base credit, its merged original request count).
+func (p *requeryPriorityPolicy) onTaskServed(task *queuedTask) {
+	if task.requery {
+		return
+	}
+	p.requeryCredit = max(requeryPriorityBaseCredit, task.originalRequestCount)
+}
+
+func requeryLaneCapacityError(capacity int64) error {
+	return merr.WrapErrTooManyRequests(
+		int32(capacity),
+		fmt.Sprintf("limit by %s", paramtable.Get().QueryNodeCfg.RequeryUnsolvedQueueSize.Key),
+	)
+}
+
+// requeryLaneCapacity uses ParamItem's typed cache, so steady-state scheduler
+// reads do not repeat string normalization or parsing.
+func requeryLaneCapacity() int64 {
+	return paramtable.Get().QueryNodeCfg.RequeryUnsolvedQueueSize.GetAsInt64()
+}

--- a/internal/util/searchutil/scheduler/requery_policy_test.go
+++ b/internal/util/searchutil/scheduler/requery_policy_test.go
@@ -1,0 +1,384 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+func TestRequeryLaneCapacity(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	laneKey := pt.QueryNodeCfg.RequeryUnsolvedQueueSize.Key
+	regularKey := pt.QueryNodeCfg.MaxUnsolvedQueueSize.Key
+	t.Cleanup(func() {
+		assert.NoError(t, pt.Reset(laneKey))
+		assert.NoError(t, pt.Reset(regularKey))
+	})
+
+	require.NoError(t, pt.Reset(laneKey))
+	assert.Equal(t, int64(1024), requeryLaneCapacity())
+	require.NoError(t, pt.Save(regularKey, "7"))
+	assert.Equal(t, int64(1024), requeryLaneCapacity())
+	require.NoError(t, pt.Save(regularKey, "3"))
+	assert.Equal(t, int64(1024), requeryLaneCapacity())
+
+	require.NoError(t, pt.Save(laneKey, "5"))
+	assert.Equal(t, int64(5), requeryLaneCapacity())
+	require.NoError(t, pt.Save(regularKey, "9"))
+	assert.Equal(t, int64(5), requeryLaneCapacity())
+
+	require.NoError(t, pt.Save(laneKey, "0"))
+	assert.Zero(t, requeryLaneCapacity())
+	require.NoError(t, pt.Save(laneKey, "-1"))
+	assert.Equal(t, int64(-1), requeryLaneCapacity())
+
+	for _, invalid := range []string{"invalid", "1.5", "1024x", "AUTO", " 8 "} {
+		require.NoError(t, pt.Save(laneKey, invalid))
+		assert.Equal(t, int64(1024), requeryLaneCapacity(), invalid)
+	}
+	require.NoError(t, pt.Save(regularKey, "4"))
+	assert.Equal(t, int64(1024), requeryLaneCapacity())
+}
+
+func TestRequeryPriorityPolicyUseLane(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	oldLane := pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("2")
+	defer pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue(oldLane)
+
+	policy := newRequeryPriorityPolicy(newFIFOPolicy())
+	assert.False(t, policy.UseLane(newMockTask(mockTaskConfig{})))
+	assert.True(t, policy.UseLane(newMockTask(mockTaskConfig{ctx: requeryCtx()})))
+
+	pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("0")
+	assert.False(t, policy.UseLane(newMockTask(mockTaskConfig{ctx: requeryCtx()})))
+}
+
+func TestRequeryPriorityPolicyRoutesByStamp(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	oldLane := pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("4")
+	defer pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue(oldLane)
+
+	policy := newRequeryPriorityPolicy(newFIFOPolicy())
+	regularTask := newMockTask(mockTaskConfig{ctx: requeryCtx()})
+	laneTask := newMockTask(mockTaskConfig{})
+	regular := newQueuedTask(regularTask, time.Now())
+	lane := newQueuedTask(laneTask, time.Now())
+	lane.requery = true
+
+	added, err := policy.Push(regular)
+	require.NoError(t, err)
+	assert.Equal(t, 1, added)
+	added, err = policy.Push(lane)
+	require.NoError(t, err)
+	assert.Equal(t, 1, added)
+
+	assert.Equal(t, 1, policy.inner.Len())
+	assert.Equal(t, 1, policy.lane.len())
+	assert.Equal(t, laneTask, policy.Pop(time.Now()).Task)
+	assert.Equal(t, regularTask, policy.Pop(time.Now()).Task)
+}
+
+// popServed pops a task and, when it is live, reports it served — mirroring
+// the scheduler, which reports execChan handoff for live tasks and drops
+// canceled ones without serving them.
+func popServed(policy *requeryPriorityPolicy, now time.Time) *queuedTask {
+	task := policy.Pop(now)
+	if task.valid() && task.Context().Err() == nil {
+		policy.onTaskServed(task)
+	}
+	return task
+}
+
+func TestRequeryPriorityPolicyBoundedBurst(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	oldLane := pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("8")
+	defer pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue(oldLane)
+
+	policy := newRequeryPriorityPolicy(newFIFOPolicy())
+	now := time.Now()
+	regular1 := newQueuedTask(newMockTask(mockTaskConfig{}), now)
+	regular2 := newQueuedTask(newMockTask(mockTaskConfig{}), now)
+	laneTasks := make([]*queuedTask, 4)
+	for i := range laneTasks {
+		laneTasks[i] = newQueuedTask(newMockTask(mockTaskConfig{}), now)
+		laneTasks[i].requery = true
+	}
+
+	for _, task := range append([]*queuedTask{regular1, regular2}, laneTasks...) {
+		_, err := policy.Push(task)
+		require.NoError(t, err)
+	}
+
+	expected := []Task{
+		laneTasks[0].Task,
+		laneTasks[1].Task,
+		laneTasks[2].Task,
+		regular1.Task,
+		laneTasks[3].Task,
+		regular2.Task,
+	}
+	for _, expectedTask := range expected {
+		assert.Equal(t, expectedTask, popServed(policy, now).Task)
+	}
+	assert.False(t, policy.Pop(now).valid())
+}
+
+func TestRequeryPriorityPolicyFallsBackAndDrainsWhenDisabled(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	oldLane := pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("4")
+	defer pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue(oldLane)
+
+	policy := newRequeryPriorityPolicy(newFIFOPolicy())
+	now := time.Now()
+	tasks := make([]*queuedTask, 3)
+	for i := range tasks {
+		tasks[i] = newQueuedTask(newMockTask(mockTaskConfig{}), now)
+		tasks[i].requery = true
+		_, err := policy.Push(tasks[i])
+		require.NoError(t, err)
+	}
+	expected := []Task{tasks[0].Task, tasks[1].Task, tasks[2].Task}
+
+	pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("0")
+	for _, expectedTask := range expected {
+		assert.Equal(t, expectedTask, popServed(policy, now).Task)
+	}
+	assert.False(t, policy.Pop(now).valid())
+}
+
+func TestRequeryPriorityPolicyCountsFallbackInNextBurst(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	oldLane := pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("8")
+	defer pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue(oldLane)
+
+	policy := newRequeryPriorityPolicy(newFIFOPolicy())
+	now := time.Now()
+	laneTasks := make([]*queuedTask, 7)
+	laneTaskValues := make([]Task, len(laneTasks))
+	for i := range laneTasks {
+		laneTasks[i] = newQueuedTask(newMockTask(mockTaskConfig{}), now)
+		laneTaskValues[i] = laneTasks[i].Task
+		laneTasks[i].requery = true
+		_, err := policy.Push(laneTasks[i])
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, laneTaskValues[0], popServed(policy, now).Task)
+	assert.Equal(t, laneTaskValues[1], popServed(policy, now).Task)
+	assert.Equal(t, laneTaskValues[2], popServed(policy, now).Task)
+	// inner is empty and base credit is exhausted, so this task is selected
+	// through the fallback path as the first task in a new base window.
+	assert.Equal(t, laneTaskValues[3], popServed(policy, now).Task)
+
+	regular := newQueuedTask(newMockTask(mockTaskConfig{}), now)
+	regularTask := regular.Task
+	_, err := policy.Push(regular)
+	require.NoError(t, err)
+
+	// The fallback task already consumed one of the K=3 base credits. A late
+	// regular task therefore waits for only two additional lane tasks.
+	assert.Equal(t, laneTaskValues[4], popServed(policy, now).Task)
+	assert.Equal(t, laneTaskValues[5], popServed(policy, now).Task)
+	assert.Equal(t, regularTask, popServed(policy, now).Task)
+	assert.Equal(t, laneTaskValues[6], popServed(policy, now).Task)
+}
+
+func TestRequeryPriorityPolicyCanceledRegularDoesNotRefreshCredit(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	oldLane := pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("8")
+	defer pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue(oldLane)
+
+	policy := newRequeryPriorityPolicy(newFIFOPolicy())
+	now := time.Now()
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	canceled := newQueuedTask(newMockTask(mockTaskConfig{ctx: canceledCtx}), now)
+	live := newQueuedTask(newMockTask(mockTaskConfig{}), now)
+	canceledTask := canceled.Task
+	liveTask := live.Task
+	for _, task := range []*queuedTask{canceled, live} {
+		_, err := policy.Push(task)
+		require.NoError(t, err)
+	}
+
+	laneTasks := make([]*queuedTask, 4)
+	laneTaskValues := make([]Task, len(laneTasks))
+	for i := range laneTasks {
+		laneTasks[i] = newQueuedTask(newMockTask(mockTaskConfig{}), now)
+		laneTaskValues[i] = laneTasks[i].Task
+		laneTasks[i].requery = true
+		_, err := policy.Push(laneTasks[i])
+		require.NoError(t, err)
+	}
+	cancel()
+
+	for i := 0; i < 3; i++ {
+		assert.Equal(t, laneTaskValues[i], popServed(policy, now).Task)
+	}
+	assert.Equal(t, canceledTask, popServed(policy, now).Task)
+	assert.Equal(t, liveTask, popServed(policy, now).Task)
+	assert.Equal(t, laneTaskValues[3], popServed(policy, now).Task)
+}
+
+func TestRequeryPriorityPolicyUsesMergedRequestCountAsCredit(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	oldLane := pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("16")
+	defer pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue(oldLane)
+
+	policy := newRequeryPriorityPolicy(newFIFOPolicy())
+	now := time.Now()
+	mergedRegulars := make([]*queuedTask, 5)
+	for i := range mergedRegulars {
+		mergedRegulars[i] = newQueuedTask(newMockTask(mockTaskConfig{mergeAble: true, nq: 1}), now)
+		added, err := policy.Push(mergedRegulars[i])
+		require.NoError(t, err)
+		if i == 0 {
+			assert.Equal(t, 1, added)
+		} else {
+			assert.Zero(t, added)
+		}
+	}
+	nextRegular := newQueuedTask(newMockTask(mockTaskConfig{}), now)
+	mergedRegularTask := mergedRegulars[0].Task
+	nextRegularTask := nextRegular.Task
+	_, err := policy.Push(nextRegular)
+	require.NoError(t, err)
+
+	innerQueue := policy.inner.(*fifoPolicy).queue
+	assert.Equal(t, 5, innerQueue.front().originalRequestCount)
+	assert.Equal(t, 2, innerQueue.len())
+
+	laneTasks := make([]*queuedTask, 9)
+	laneTaskValues := make([]Task, len(laneTasks))
+	for i := range laneTasks {
+		laneTasks[i] = newQueuedTask(newMockTask(mockTaskConfig{}), now)
+		laneTaskValues[i] = laneTasks[i].Task
+		laneTasks[i].requery = true
+		_, err := policy.Push(laneTasks[i])
+		require.NoError(t, err)
+	}
+
+	for i := 0; i < 3; i++ {
+		assert.Equal(t, laneTaskValues[i], popServed(policy, now).Task)
+	}
+	assert.Equal(t, mergedRegularTask, popServed(policy, now).Task)
+	for i := 3; i < 8; i++ {
+		assert.Equal(t, laneTaskValues[i], popServed(policy, now).Task)
+	}
+	assert.Equal(t, nextRegularTask, popServed(policy, now).Task)
+	assert.Equal(t, laneTaskValues[8], popServed(policy, now).Task)
+}
+
+func TestRequeryPriorityPolicyCreditGrantedAtServeNotPop(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	oldLane := pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("8")
+	defer pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue(oldLane)
+
+	policy := newRequeryPriorityPolicy(newFIFOPolicy())
+	policy.requeryCredit = 0
+	now := time.Now()
+	regular1 := newQueuedTask(newMockTask(mockTaskConfig{}), now)
+	regular2 := newQueuedTask(newMockTask(mockTaskConfig{}), now)
+	lane := newQueuedTask(newMockTask(mockTaskConfig{}), now)
+	lane.requery = true
+	regular1Task, regular2Task, laneTask := regular1.Task, regular2.Task, lane.Task
+	for _, task := range []*queuedTask{regular1, regular2, lane} {
+		_, err := policy.Push(task)
+		require.NoError(t, err)
+	}
+
+	// Popping a regular task grants nothing: a staged task can still be
+	// dropped. Until one regular task is actually served, regular tasks keep
+	// absolute priority over the lane.
+	assert.Equal(t, regular1Task, policy.Pop(now).Task)
+	assert.Zero(t, policy.requeryCredit)
+	served := policy.Pop(now)
+	assert.Equal(t, regular2Task, served.Task)
+	assert.Zero(t, policy.requeryCredit)
+
+	policy.onTaskServed(served)
+	assert.Equal(t, requeryPriorityBaseCredit, policy.requeryCredit)
+	assert.Equal(t, laneTask, policy.Pop(now).Task)
+	assert.Equal(t, requeryPriorityBaseCredit-1, policy.requeryCredit)
+}
+
+func TestRequeryPriorityPolicyPreservesInnerMergeAndKeepsLaneSeparate(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	oldLane := pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("4")
+	defer pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue(oldLane)
+
+	policy := newRequeryPriorityPolicy(newFIFOPolicy())
+	now := time.Now()
+	regular1 := newQueuedTask(newMockTask(mockTaskConfig{mergeAble: true, nq: 1}), now)
+	regular2 := newQueuedTask(newMockTask(mockTaskConfig{mergeAble: true, nq: 1}), now)
+	added, err := policy.Push(regular1)
+	require.NoError(t, err)
+	assert.Equal(t, 1, added)
+	added, err = policy.Push(regular2)
+	require.NoError(t, err)
+	assert.Equal(t, 0, added)
+	assert.Equal(t, 1, policy.inner.Len())
+	assert.Equal(t, 2, policy.inner.(*fifoPolicy).queue.front().originalRequestCount)
+
+	lane1 := newQueuedTask(newMockTask(mockTaskConfig{mergeAble: true, nq: 1}), now)
+	lane2 := newQueuedTask(newMockTask(mockTaskConfig{mergeAble: true, nq: 1}), now)
+	lane1.requery = true
+	lane2.requery = true
+	_, err = policy.Push(lane1)
+	require.NoError(t, err)
+	_, err = policy.Push(lane2)
+	require.NoError(t, err)
+	assert.Equal(t, 2, policy.lane.len())
+	assert.Equal(t, 3, policy.Len())
+}
+
+func TestRequeryPriorityPolicyCleanupRemoveAndLen(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	oldLane := pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue("4")
+	defer pt.QueryNodeCfg.RequeryUnsolvedQueueSize.SwapTempValue(oldLane)
+
+	policy := newRequeryPriorityPolicy(newFIFOPolicy())
+	now := time.Now()
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	canceledTask := newMockTask(mockTaskConfig{ctx: canceledCtx, username: "canceled"})
+	removeTask := newMockTask(mockTaskConfig{username: "remove"})
+	keepTask := newMockTask(mockTaskConfig{username: "keep"})
+	canceled := newQueuedTask(canceledTask, now)
+	canceled.requery = true
+	remove := newQueuedTask(removeTask, now)
+	keep := newQueuedTask(keepTask, now)
+	keep.requery = true
+
+	for _, task := range []*queuedTask{canceled, remove, keep} {
+		_, err := policy.Push(task)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 3, policy.Len())
+
+	cancel()
+	cleaned := policy.Cleanup(now)
+	require.Len(t, cleaned, 1)
+	assert.Equal(t, canceledTask, cleaned[0].Task)
+	assert.Equal(t, 2, policy.Len())
+
+	removed := policy.Remove(func(task Task) bool { return task.Username() == "remove" }, now)
+	require.Len(t, removed, 1)
+	assert.Equal(t, removeTask, removed[0].Task)
+	assert.Equal(t, 1, policy.Len())
+	assert.Equal(t, keepTask, policy.Pop(now).Task)
+}

--- a/internal/util/searchutil/scheduler/tasks.go
+++ b/internal/util/searchutil/scheduler/tasks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 )
 
@@ -19,9 +20,10 @@ func NewScheduler(policyName string) Scheduler {
 		fallthrough
 	case schedulePolicyNameFIFO:
 		return newScheduler(
-			newFIFOPolicy(),
+			newRequeryPriorityPolicy(newFIFOPolicy()),
 		)
 	case schedulePolicyNameUserTaskPolling:
+		mlog.Info(context.TODO(), "requery priority lane disabled under user-task-polling")
 		return newScheduler(
 			newUserTaskPollingPolicy(),
 		)
@@ -95,12 +97,21 @@ type queuedTask struct {
 	Task
 
 	enqueueTime time.Time
+	// originalRequestCount is the number of pre-merge scheduler tasks represented
+	// by this queue entry. It starts at 1 and is accumulated only after a
+	// successful MergeWith.
+	originalRequestCount int
+	// requery is the immutable queue-class stamp set once during admission.
+	// It means the task was assigned to the dedicated priority lane, not merely
+	// that its request carries the requery label.
+	requery bool
 }
 
 func newQueuedTask(task Task, enqueueTime time.Time) *queuedTask {
 	return &queuedTask{
-		Task:        task,
-		enqueueTime: enqueueTime,
+		Task:                 task,
+		enqueueTime:          enqueueTime,
+		originalRequestCount: 1,
 	}
 }
 

--- a/internal/util/searchutil/scheduler/tasks.go
+++ b/internal/util/searchutil/scheduler/tasks.go
@@ -95,6 +95,9 @@ type queuedTask struct {
 	Task
 
 	enqueueTime time.Time
+	// requery marks tasks admitted through the dedicated requery lane;
+	// they are excluded from the policy waiting counters.
+	requery bool
 }
 
 func newQueuedTask(task Task, enqueueTime time.Time) *queuedTask {

--- a/internal/util/segmentutil/utils.go
+++ b/internal/util/segmentutil/utils.go
@@ -60,15 +60,29 @@ func CalcDelRowCountFromDeltaLog(seg *datapb.SegmentInfo) int64 {
 }
 
 // MergeRequestCost merges the costs of request; the cost may come from different worker in same channel
-// or different channel in same collection, for now we just choose the part with the highest response time
+// or different channel in same collection. Latency fields come from the snapshot with the highest
+// response time, while totalNQ takes the per-field maximum across workers so one worker's queued
+// backlog cannot be hidden by another worker's slower response. A per-field maximum stays safe
+// against duplicate worker snapshots because it never accumulates them.
 func MergeRequestCost(requestCosts []*internalpb.CostAggregation) *internalpb.CostAggregation {
 	var result *internalpb.CostAggregation
+	var maxTotalNQ int64
 	for _, cost := range requestCosts {
 		if cost == nil {
 			continue
 		}
+		maxTotalNQ = max(maxTotalNQ, cost.GetTotalNQ())
 		if result == nil || result.ResponseTime < cost.ResponseTime {
 			result = cost
+		}
+	}
+	if result != nil && result.GetTotalNQ() < maxTotalNQ {
+		// Copy before overwriting: result aliases a worker's response message.
+		result = &internalpb.CostAggregation{
+			ResponseTime:         result.GetResponseTime(),
+			ServiceTime:          result.GetServiceTime(),
+			TotalNQ:              maxTotalNQ,
+			TotalRelatedDataSize: result.GetTotalRelatedDataSize(),
 		}
 	}
 

--- a/internal/util/segmentutil/utils_test.go
+++ b/internal/util/segmentutil/utils_test.go
@@ -1,0 +1,32 @@
+package segmentutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+)
+
+func TestMergeRequestCost(t *testing.T) {
+	assert.Nil(t, MergeRequestCost(nil))
+	assert.Nil(t, MergeRequestCost([]*internalpb.CostAggregation{nil}))
+
+	slow := &internalpb.CostAggregation{ResponseTime: 800, ServiceTime: 300, TotalNQ: 10, TotalRelatedDataSize: 64}
+	backlogged := &internalpb.CostAggregation{ResponseTime: 200, ServiceTime: 100, TotalNQ: 2000, TotalRelatedDataSize: 32}
+
+	// Latency fields follow the slowest snapshot; totalNQ takes the per-field
+	// maximum so the backlogged worker stays visible to the balancer.
+	merged := MergeRequestCost([]*internalpb.CostAggregation{slow, nil, backlogged})
+	assert.Equal(t, int64(800), merged.GetResponseTime())
+	assert.Equal(t, int64(300), merged.GetServiceTime())
+	assert.Equal(t, int64(2000), merged.GetTotalNQ())
+	assert.Equal(t, int64(64), merged.GetTotalRelatedDataSize())
+	// The overwrite happens on a copy, never on a worker's response message.
+	assert.Equal(t, int64(10), slow.GetTotalNQ())
+
+	// When the slowest snapshot already carries the max totalNQ, it is
+	// returned as-is.
+	both := &internalpb.CostAggregation{ResponseTime: 900, ServiceTime: 400, TotalNQ: 3000}
+	assert.Same(t, both, MergeRequestCost([]*internalpb.CostAggregation{slow, backlogged, both}))
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -62,6 +62,7 @@ const (
 	UpsertQueryLabel = "upsert_query"
 	DeleteQueryLabel = "delete_query"
 	ReQueryLabel     = "requery"
+	RegularLabel     = "regular"
 	CacheHitLabel    = "hit"
 	CacheMissLabel   = "miss"
 	TimetickLabel    = "timetick"
@@ -167,6 +168,7 @@ const (
 	queueTypeLabelName             = `queue_type`
 	poolNameLabelName              = "pool_name"
 	outcomeLabelName               = "outcome"
+	laneLabelName                  = "lane"
 
 	// model function/UDF labels
 	functionTypeName = "function_type_name"

--- a/pkg/metrics/querynode_metrics.go
+++ b/pkg/metrics/querynode_metrics.go
@@ -318,7 +318,7 @@ var (
 			Namespace: milvusNamespace,
 			Subsystem: typeutil.QueryNodeRole,
 			Name:      "read_task_ready_len",
-			Help:      "number of ready read tasks in readyQueue",
+			Help:      "number of read tasks waiting in the scheduler across regular and requery queues",
 		}, []string{
 			nodeIDLabelName,
 		})
@@ -328,9 +328,30 @@ var (
 			Namespace: milvusNamespace,
 			Subsystem: typeutil.QueryNodeRole,
 			Name:      "read_task_ready_nq",
-			Help:      "total NQ of ready read tasks in scheduler queue",
+			Help:      "total NQ of read tasks waiting in the scheduler across regular and requery queues",
 		}, []string{
 			nodeIDLabelName,
+		})
+
+	QueryNodeReadTaskRequeryReadyLen = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "read_task_requery_ready_len",
+			Help:      "number of requery read tasks waiting in the scheduler, including a task staged for execution handoff",
+		}, []string{
+			nodeIDLabelName,
+		})
+
+	QueryNodeReadTaskRejectCnt = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "read_task_reject_total",
+			Help:      "number of read tasks rejected at scheduler admission because the regular or requery queue is full",
+		}, []string{
+			nodeIDLabelName,
+			laneLabelName,
 		})
 
 	QueryNodeReadTaskQueueDuration = prometheus.NewHistogramVec(
@@ -339,6 +360,21 @@ var (
 			Subsystem: typeutil.QueryNodeRole,
 			Name:      "read_task_queue_duration",
 			Help:      "duration in milliseconds that read tasks stay in scheduler policy queue",
+			Buckets:   subMsBuckets,
+		}, []string{
+			nodeIDLabelName,
+			outcomeLabelName,
+		})
+
+	// QueryNodeReadTaskRequeryQueueDuration is the requery-only subset of
+	// QueryNodeReadTaskQueueDuration, kept as a separate metric so the existing
+	// aggregate histogram preserves its label schema.
+	QueryNodeReadTaskRequeryQueueDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "read_task_requery_queue_duration",
+			Help:      "duration in milliseconds that requery read tasks stay in the scheduler requery lane",
 			Buckets:   subMsBuckets,
 		}, []string{
 			nodeIDLabelName,
@@ -1022,6 +1058,9 @@ func RegisterQueryNode(registry *prometheus.Registry) {
 	registry.MustRegister(QueryNodeLoadSegmentLatency)
 	registry.MustRegister(QueryNodeReadTaskReadyLen)
 	registry.MustRegister(QueryNodeReadTaskReadyNQ)
+	registry.MustRegister(QueryNodeReadTaskRequeryReadyLen)
+	registry.MustRegister(QueryNodeReadTaskRejectCnt)
+	registry.MustRegister(QueryNodeReadTaskRequeryQueueDuration)
 	registry.MustRegister(QueryNodeReadTaskQueueDuration)
 	registry.MustRegister(QueryNodeReadTaskExecuteDuration)
 	registry.MustRegister(QueryNodeReadTaskConcurrency)

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/shirou/gopsutil/v4/disk"
 	"go.uber.org/atomic"
+	"golang.org/x/time/rate"
 
 	"github.com/milvus-io/milvus/pkg/v3/config"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -3950,6 +3951,7 @@ type queryNodeConfig struct {
 	ChunkCacheWarmingUp ParamItem `refreshable:"true"`
 
 	MaxUnsolvedQueueSize         ParamItem `refreshable:"true"`
+	RequeryUnsolvedQueueSize     ParamItem `refreshable:"true"`
 	MaxReadConcurrency           ParamItem `refreshable:"true"`
 	MaxGpuReadConcurrency        ParamItem `refreshable:"false"`
 	MaxGroupNQ                   ParamItem `refreshable:"true"`
@@ -4010,8 +4012,6 @@ type queryNodeConfig struct {
 	// Target average byte size per storage v2 cache cell. Parquet row groups
 	// are packed into cells so rgs_per_cell * avg_rg_size ≈ this value.
 	StorageV2CellTargetSizeBytes ParamItem `refreshable:"true"`
-
-	EnableWorkerSQCostMetrics ParamItem `refreshable:"true"`
 
 	ExprEvalBatchSize ParamItem `refreshable:"false"`
 
@@ -4920,9 +4920,35 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 		Key:          "queryNode.scheduler.unsolvedQueueSize",
 		Version:      "2.0.0",
 		DefaultValue: "1024",
-		Export:       true,
+		Doc: "Maximum number of regular read tasks waiting in the scheduler. " +
+			"When the dedicated requery lane is enabled under fifo, this is an independent regular-task budget and the effective total capacity is the sum of the regular and requery capacities.",
+		Export: true,
 	}
 	p.MaxUnsolvedQueueSize.Init(base.mgr)
+
+	const defaultRequeryUnsolvedQueueSize = "1024"
+	p.RequeryUnsolvedQueueSize = ParamItem{
+		Key:          "queryNode.scheduler.requeryUnsolvedQueueSize",
+		Version:      "3.0.0",
+		DefaultValue: defaultRequeryUnsolvedQueueSize,
+		Formatter: func(v string) string {
+			if _, err := strconv.ParseInt(v, 10, 64); err == nil {
+				return v
+			}
+			mlog.RatedWarn(context.TODO(), rate.Limit(1.0/60.0),
+				"invalid requery queue capacity, falling back to default capacity",
+				mlog.String("key", p.RequeryUnsolvedQueueSize.Key),
+				mlog.String("value", v),
+				mlog.Int64("fallbackCapacity", 1024))
+			return defaultRequeryUnsolvedQueueSize
+		},
+		Doc: "Maximum number of scheduler-owned requery tasks waiting in the dedicated priority lane when scheduleReadPolicy is fifo, including a task staged for execution handoff. " +
+			"It defaults to an independent capacity of 1024, so the default total waiting-task capacity is 1024 regular tasks plus 1024 requery tasks. " +
+			"A positive integer sets the lane capacity, a value <= 0 disables the lane, and an invalid value emits a warning and falls back to 1024. " +
+			"The lane is disabled when scheduleReadPolicy is user-task-polling.",
+		Export: true,
+	}
+	p.RequeryUnsolvedQueueSize.Init(base.mgr)
 
 	p.MaxGroupNQ = ParamItem{
 		Key:          "queryNode.grouping.maxNQ",
@@ -5290,14 +5316,6 @@ user-task-polling:
 		},
 	}
 	p.StorageV2CellTargetSizeBytes.Init(base.mgr)
-
-	p.EnableWorkerSQCostMetrics = ParamItem{
-		Key:          "queryNode.enableWorkerSQCostMetrics",
-		Version:      "2.3.0",
-		DefaultValue: "false",
-		Doc:          "whether use worker's cost to measure delegator's workload",
-	}
-	p.EnableWorkerSQCostMetrics.Init(base.mgr)
 
 	p.ExprEvalBatchSize = ParamItem{
 		Key:          "queryNode.segcore.exprEvalBatchSize",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3759,15 +3759,16 @@ type queryNodeConfig struct {
 	ReadAheadPolicy     ParamItem `refreshable:"false"`
 	ChunkCacheWarmingUp ParamItem `refreshable:"true"`
 
-	MaxUnsolvedQueueSize  ParamItem `refreshable:"true"`
-	MaxReadConcurrency    ParamItem `refreshable:"true"`
-	MaxGpuReadConcurrency ParamItem `refreshable:"false"`
-	MaxGroupNQ            ParamItem `refreshable:"true"`
-	NQMergeRatio          ParamItem `refreshable:"true"`
-	MaxDeadlineMergeGap   ParamItem `refreshable:"true"`
-	TopKMergeRatio        ParamItem `refreshable:"true"`
-	CPURatio              ParamItem `refreshable:"true"`
-	GracefulStopTimeout   ParamItem `refreshable:"false"`
+	MaxUnsolvedQueueSize     ParamItem `refreshable:"true"`
+	RequeryUnsolvedQueueSize ParamItem `refreshable:"true"`
+	MaxReadConcurrency       ParamItem `refreshable:"true"`
+	MaxGpuReadConcurrency    ParamItem `refreshable:"false"`
+	MaxGroupNQ               ParamItem `refreshable:"true"`
+	NQMergeRatio             ParamItem `refreshable:"true"`
+	MaxDeadlineMergeGap      ParamItem `refreshable:"true"`
+	TopKMergeRatio           ParamItem `refreshable:"true"`
+	CPURatio                 ParamItem `refreshable:"true"`
+	GracefulStopTimeout      ParamItem `refreshable:"false"`
 
 	EnableResultZeroCopy ParamItem `refreshable:"true"`
 
@@ -4721,6 +4722,18 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 		Export:       true,
 	}
 	p.MaxUnsolvedQueueSize.Init(base.mgr)
+
+	p.RequeryUnsolvedQueueSize = ParamItem{
+		Key:          "queryNode.scheduler.requeryUnsolvedQueueSize",
+		Version:      "3.0.0",
+		DefaultValue: "1024",
+		Doc: "Maximum number of pending requery tasks in the dedicated requery lane. " +
+			"Requery (the output-field fetch phase of search) bypasses unsolvedQueueSize and is scheduled ahead of regular read tasks, " +
+			"because rejecting it wastes the ANN computation its parent search already completed, " +
+			"while its arrival rate is naturally capped by admitted searches. <= 0 disables the lane.",
+		Export: true,
+	}
+	p.RequeryUnsolvedQueueSize.Init(base.mgr)
 
 	p.MaxGroupNQ = ParamItem{
 		Key:          "queryNode.grouping.maxNQ",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -135,6 +135,35 @@ func TestComponentParam_StorageIopsParams(t *testing.T) {
 	}
 }
 
+func TestRequeryUnsolvedQueueSizeInvalidFallback(t *testing.T) {
+	Init()
+	params := Get()
+	laneKey := params.QueryNodeCfg.RequeryUnsolvedQueueSize.Key
+	regularKey := params.QueryNodeCfg.MaxUnsolvedQueueSize.Key
+	assert.NoError(t, params.Reset(laneKey))
+	assert.NoError(t, params.Reset(regularKey))
+	t.Cleanup(func() {
+		assert.NoError(t, params.Reset(laneKey))
+		assert.NoError(t, params.Reset(regularKey))
+	})
+
+	assert.Equal(t, int64(1024), params.QueryNodeCfg.RequeryUnsolvedQueueSize.GetAsInt64())
+	assert.NoError(t, params.Save(regularKey, "7"))
+	assert.Equal(t, int64(1024), params.QueryNodeCfg.RequeryUnsolvedQueueSize.GetAsInt64())
+	assert.NoError(t, params.Save(laneKey, "5"))
+	assert.Equal(t, int64(5), params.QueryNodeCfg.RequeryUnsolvedQueueSize.GetAsInt64())
+	assert.NoError(t, params.Save(regularKey, "3"))
+	assert.Equal(t, int64(5), params.QueryNodeCfg.RequeryUnsolvedQueueSize.GetAsInt64())
+
+	for _, invalid := range []string{"invalid", "1.5", "1024x", "AUTO", " 8 "} {
+		assert.NoError(t, params.Save(laneKey, invalid))
+		assert.Equal(t, int64(1024), params.QueryNodeCfg.RequeryUnsolvedQueueSize.GetAsInt64(), invalid)
+	}
+
+	assert.NoError(t, params.Save(laneKey, "-1"))
+	assert.Equal(t, int64(-1), params.QueryNodeCfg.RequeryUnsolvedQueueSize.GetAsInt64())
+}
+
 func TestComponentParam(t *testing.T) {
 	Init()
 	params := Get()
@@ -648,6 +677,9 @@ func TestComponentParam(t *testing.T) {
 
 		assert.Equal(t, int32(1024), Params.MaxUnsolvedQueueSize.GetAsInt32())
 		assert.Equal(t, "1024", Params.MaxUnsolvedQueueSize.DefaultValue)
+		assert.Equal(t, int64(1024), Params.RequeryUnsolvedQueueSize.GetAsInt64())
+		assert.Equal(t, "1024", Params.RequeryUnsolvedQueueSize.DefaultValue)
+		assert.Empty(t, Params.RequeryUnsolvedQueueSize.FallbackKeys)
 		assert.Equal(t, int64(64), Params.MaxGroupNQ.GetAsInt64())
 		assert.Equal(t, 16.0, Params.NQMergeRatio.GetAsFloat())
 		assert.Equal(t, 20.0, Params.TopKMergeRatio.GetAsFloat())
@@ -705,8 +737,6 @@ func TestComponentParam(t *testing.T) {
 		params.Save("queryNode.gracefulStopTimeout", "100")
 		gracefulStopTimeout := &Params.GracefulStopTimeout
 		assert.Equal(t, int64(100), gracefulStopTimeout.GetAsInt64())
-
-		assert.Equal(t, false, Params.EnableWorkerSQCostMetrics.GetAsBool())
 
 		params.Save("querynode.gracefulStopTimeout", "100")
 		assert.Equal(t, 100*time.Second, Params.GracefulStopTimeout.GetAsDuration(time.Second))

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -535,6 +535,8 @@ func TestComponentParam(t *testing.T) {
 
 		assert.Equal(t, int32(1024), Params.MaxUnsolvedQueueSize.GetAsInt32())
 		assert.Equal(t, "1024", Params.MaxUnsolvedQueueSize.DefaultValue)
+		assert.Equal(t, int32(1024), Params.RequeryUnsolvedQueueSize.GetAsInt32())
+		assert.Equal(t, "1024", Params.RequeryUnsolvedQueueSize.DefaultValue)
 		assert.Equal(t, int64(64), Params.MaxGroupNQ.GetAsInt64())
 		assert.Equal(t, 16.0, Params.NQMergeRatio.GetAsFloat())
 		assert.Equal(t, 20.0, Params.TopKMergeRatio.GetAsFloat())


### PR DESCRIPTION
issue: #52189

### What this PR does

When the QueryNode unsolved queue is full, rejecting the requery phase of
Search/HybridSearch discards ANN work that has already completed and causes a
client retry to repeat that work against an overloaded cluster.

This PR adds a dedicated bounded requery lane as a policy-layer decorator over
the FIFO read scheduler:

- **Identification**: uses the existing `QueryLabel="requery"` carried by
  `RetrieveRequest`; no proto or Proxy plumbing change is required.
- **Admission**: adds refreshable
  `queryNode.scheduler.requeryUnsolvedQueueSize` with an independent default
  of 1024. A positive integer sets the lane capacity, `<= 0` disables it, and
  an invalid value emits a rate-limited warning and falls back to 1024.
- **Full-lane handling**: admission performs one expired-task cleanup and one
  retry. If the retry is still rejected, only the current request fails and
  the current receive batch ends, giving the scheduler a chance to drain work;
  later requests remain pending for the next batch.
- **Dispatch**: replaces strict priority with request-weighted requery credit.
  Credit starts at 3 and each lane pop consumes one. Every queued task tracks
  how many pre-merge scheduler tasks it represents; credit is refreshed to
  `max(3, originalRequestCount)` only when a regular task is actually handed
  to execution, so a staged regular task later dropped by expiration or clear
  opens no lane window, and a task already canceled when popped never counts
  as regular service.
- **Accounting**: regular admission continues to use the regular-only counter,
  while public task/NQ totals include both regular and requery backlog for
  `CostAggregation`, load balancing, and aggregate ReadyLen metrics. The
  delegated query cost path now keeps all workers' costs, finishing the
  `EnableWorkerSQCostMetrics` deprecation declared in #41965 (the search path
  already does), and the merged cost's `totalNQ` takes the per-field maximum
  across workers so a backlogged worker's signal survives response-time
  snapshot selection; remote requery backlog therefore reaches the leader's
  `CostAggregation` and the look-aside balancer. The consumer-less
  `queryNode.enableWorkerSQCostMetrics` parameter is removed (it was never
  exported to milvus.yaml, and unknown keys in existing configs are ignored).
- **Observability**: adds
  `milvus_querynode_read_task_requery_ready_len` for the lane depth, including
  a task staged for execution handoff; adds
  `milvus_querynode_read_task_reject_total{lane=regular|requery}` counting
  admission rejections per class; and adds
  `milvus_querynode_read_task_requery_queue_duration` as the requery-only
  waiting-time subset per outcome, while the existing aggregate
  `read_task_queue_duration` histogram keeps its label schema untouched. `originalRequestCount` is internal
  scheduling metadata and is not exported as a Prometheus metric.
- **Lifecycle**: expiration cleanup covers both policy queues and the
  scheduler-local staged task before capacity enforcement. Admin clear,
  shutdown drain, counter settlement, and queue-duration metrics preserve the
  existing scheduler ownership semantics.
- **Policy compatibility**: the lane wraps FIFO only. It remains disabled under
  `user-task-polling`, preserving per-user round-robin scheduling and
  `maxPendingTaskPerUser`.

### Why weighted priority

Requery has high salvage value because it completes work whose ANN phase has
already run, but strict priority can starve regular reads. A fixed task ratio is
also insufficient because one regular SearchTask may represent several merged
requests while their requeries remain separate tasks. The finite credit window
preserves regular progress, and `originalRequestCount` compensates for the queue
unit mismatch introduced by merging.

### Compatibility

- Requests without the requery label follow the regular path unchanged.
- `user-task-polling` remains unchanged because it is not wrapped.
- Regular and requery capacities are independent. With both defaults, the
  intentional waiting bound is 1024 regular + 1024 requery tasks.
- The scheduler is shared by QueryNode workers and the streaming-node
  delegator, so both FIFO admission points benefit.
- CPU/GPU cross-pool head-of-line blocking needs pool-aware dispatch and is
  tracked separately in #52394.
- The change is complementary to #50454: that work reduces overload traffic;
  this change protects completion of work already performed.

### Tests

Focused policy, scheduler, metric, config, and paramtable tests cover:

- weighted credit and merged-task request counts;
- credit granted at execution handoff rather than Pop, and a staged regular
  task dropped before handoff granting no lane window;
- already-canceled regular tasks not replenishing credit;
- per-lane rejection counting and the requery-only queue-duration subset
  metric;
- merged request cost keeping the per-field maximum `totalNQ` across worker
  snapshots without mutating worker responses;
- lane-full cleanup/retry and receive-batch yielding;
- independent regular/requery admission budgets and aggregate load accounting;
- live staged tasks counting against capacity and expired staged tasks releasing
  capacity for both regular and requery admission;
- fixed default, explicit, disabled, invalid fallback, and independent hot
  update behavior;
- expiration, clear, shutdown, and dynamic disable;
- unchanged `user-task-polling` behavior.

No performance claim is made beyond the scheduling mechanism itself; overload
benchmarking remains follow-up validation.


