### PR TITLE
test: Add standalone woodpecker embed Helm values

### DIFF
--- a/tests/_helm/values/e2e-amd/standalone-wp-embed
+++ b/tests/_helm/values/e2e-amd/standalone-wp-embed
@@ -1,0 +1,146 @@
+affinity:
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - preference:
+        matchExpressions:
+        - key: jenkins-e2e-amd
+          operator: In
+          values:
+          - "true"
+      weight: 100
+    - preference:
+        matchExpressions:
+        - key: node-role.kubernetes.io/e2e
+          operator: Exists
+      weight: 1
+cluster:
+  enabled: false
+streaming:
+  enabled: true
+service:
+  type: ClusterIP
+woodpecker:
+  enabled: true
+standalone:
+  messageQueue: woodpecker
+  disk:
+    enabled: true
+  resources:
+    limits:
+      cpu: "8"
+      memory: 16Gi
+    requests:
+      cpu: "3"
+      memory: 8Gi
+log:
+  level: debug
+extraConfigFiles:
+  user.yaml: |+
+    common:
+      storage:
+        # enable storage v3
+        useLoonFFI: true
+    dataNode:
+      storage:
+        format: vortex
+    dataCoord:
+      compaction:
+        bumpSchemaVersion:
+          enabled: true
+      gc:
+        interval: 1800
+        missingTolerance: 1800
+        dropTolerance: 1800
+    queryNode:
+      segcore:
+        exprEvalBatchSize: 512
+    quotaAndLimits:
+      flushRate:
+        collection:
+          max: 4
+metrics:
+  serviceMonitor:
+    enabled: true
+etcd:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: jenkins-e2e-amd
+            operator: In
+            values:
+            - "true"
+        weight: 100
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/e2e
+            operator: Exists
+        weight: 1
+  metrics:
+    enabled: true
+    podMonitor:
+      enabled: true
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: "0.2"
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 4Gi
+  tolerations:
+  - effect: PreferNoSchedule
+    key: jenkins-milvus-ci-only
+    operator: Equal
+    value: "true"
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/e2e
+    operator: Exists
+image:
+  all:
+    pullPolicy: Always
+    repository: harbor.milvus.io/milvus/milvus
+    tag: PR-35402-20240812-402f716b5
+minio:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: jenkins-e2e-amd
+            operator: In
+            values:
+            - "true"
+        weight: 100
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/e2e
+            operator: Exists
+        weight: 1
+  mode: standalone
+  resources:
+    requests:
+      cpu: "0.5"
+      memory: 3Gi
+    limits:
+      cpu: "1"
+      memory: 6Gi
+  tolerations:
+  - effect: PreferNoSchedule
+    key: jenkins-milvus-ci-only
+    operator: Equal
+    value: "true"
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/e2e
+    operator: Exists
+pulsarv3:
+  enabled: false
+tolerations:
+- effect: PreferNoSchedule
+  key: jenkins-milvus-ci-only
+  operator: Equal
+  value: "true"
+- effect: NoSchedule
+  key: node-role.kubernetes.io/e2e
+  operator: Exists

--- a/tests/_helm/values/e2e-arm/standalone-wp-embed
+++ b/tests/_helm/values/e2e-arm/standalone-wp-embed
@@ -1,0 +1,96 @@
+nodeSelector:
+  jenkins-e2e-arm: "true"
+cluster:
+  enabled: false
+streaming:
+  enabled: true
+service:
+  type: ClusterIP
+woodpecker:
+  enabled: true
+standalone:
+  messageQueue: woodpecker
+  disk:
+    enabled: true
+  resources:
+    limits:
+      cpu: "8"
+      memory: 16Gi
+    requests:
+      cpu: "3"
+      memory: 8Gi
+log:
+  level: debug
+extraConfigFiles:
+  user.yaml: |+
+    common:
+      storage:
+        # enable storage v3
+        useLoonFFI: true
+    dataNode:
+      storage:
+        format: vortex
+    dataCoord:
+      compaction:
+        bumpSchemaVersion:
+          enabled: true
+      gc:
+        interval: 1800
+        missingTolerance: 1800
+        dropTolerance: 1800
+    queryNode:
+      segcore:
+        exprEvalBatchSize: 512
+metrics:
+  serviceMonitor:
+    enabled: true
+etcd:
+  nodeSelector:
+    jenkins-e2e-arm: "true"
+  metrics:
+    enabled: true
+    podMonitor:
+      enabled: true
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: "0.2"
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 4Gi
+  image:
+    registry: "harbor-us-vdc.zilliz.cc"
+    repository: "milvusdb/etcd"
+  tolerations:
+  - effect: NoSchedule
+    key: jenkins-e2e-arm
+    operator: Exists
+image:
+  all:
+    pullPolicy: Always
+    repository: harbor.milvus.io/milvus/milvus
+    tag: PR-35402-20240812-402f716b5
+minio:
+  nodeSelector:
+    jenkins-e2e-arm: "true"
+  mode: standalone
+  image:
+    repository: "harbor-us-vdc.zilliz.cc/milvusdb/minio"
+  resources:
+    requests:
+      cpu: "0.2"
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 4Gi
+  tolerations:
+  - effect: NoSchedule
+    key: jenkins-e2e-arm
+    operator: Exists
+pulsarv3:
+  enabled: false
+tolerations:
+- effect: NoSchedule
+  key: jenkins-e2e-arm
+  operator: Exists


### PR DESCRIPTION
## Summary

- Add AMD standalone woodpecker embedded Helm values
- Add ARM standalone woodpecker embedded Helm values with ARM scheduling settings
- Keep the new configs aligned with the existing master standalone Helm values

Related to #51791

## Test Plan

- Parse both new Helm values files as YAML
- Verify the AMD file matches the existing AMD standalone values
- Verify the ARM file matches the existing ARM standalone values
