### PR TITLE
fix:[3.0] upgrade aws-sdk-cpp to 1.11.842 for checksum retries

### DIFF
--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -130,7 +130,7 @@ class MilvusConan(ConanFile):
         # as a direct dep so CMakeDeps generates standalone cmake config files.
         # Without this, find_package(Azure) can't find include directories.
         self.requires("azure-sdk-for-cpp/1.16.0@milvus/dev#9e2475502f8ee3b284c9e0731a3370c6", force=True)
-        self.requires("aws-sdk-cpp/1.11.692@milvus/dev#c309ce91fa572fff68f9f4e36d477a04")
+        self.requires("aws-sdk-cpp/1.11.842@milvus/dev#363556887f622db23a10168c108dd55d", force=True)
         # Force snappy/lz4 versions to override Arrow's older transitive deps
         # (arrow/*:with_snappy and arrow/*:with_lz4 are enabled for Parquet decoding)
         self.requires("snappy/1.2.1#b940695c64ccbff63c1aabd4b1eee3f3", force=True)


### PR DESCRIPTION
pr: #52193
issue: #50915
aws-sdk-cpp 1.11.692 can reuse checksum state from a partially consumed aws-chunked stream when a PutObject request is retried after a transport or low-speed timeout. The retry sends the complete body with a stale checksum trailer, causing MinIO to reject the write with HTTP 400 XAmzContentChecksumMismatch.

Upgrade the direct Conan dependency to aws-sdk-cpp 1.11.842 and its corresponding recipe revision. This version includes the upstream partially consumed stream fix(aws-sdk-cpp#3706), which only preserves a calculated checksum after the stream reaches EOF and correctly handles a rewound request body during retries.