### PR TITLE
fix: [RBAC] avoid repeated backup grantee scans

### DIFF
--- a/internal/metastore/kv/rootcoord/kv_catalog.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog.go
@@ -1514,7 +1514,21 @@ func (kc *Catalog) loadGranteeIDPrefix(ctx context.Context, tenant string, grant
 	return kc.loadGranteeIDPrefixWithLoadedGrantees(ctx, tenant, granteeKey, idStr, nil, nil)
 }
 
+func validateLoadedGrantees(granteeKeys []string, granteeValues []string) error {
+	if (granteeKeys == nil) != (granteeValues == nil) {
+		return merr.WrapErrServiceInternalMsg("loaded grantee keys and values must both be nil or both be non-nil, got keys=%d values=%d", len(granteeKeys), len(granteeValues))
+	}
+	if granteeKeys != nil && len(granteeKeys) != len(granteeValues) {
+		return merr.WrapErrServiceInternalMsg("loaded grantee keys and values must have equal length, got keys=%d values=%d", len(granteeKeys), len(granteeValues))
+	}
+	return nil
+}
+
 func (kc *Catalog) loadGranteeIDPrefixWithLoadedGrantees(ctx context.Context, tenant string, granteeKey string, idStr string, granteeKeys []string, granteeValues []string) ([]string, []string, string, error) {
+	if err := validateLoadedGrantees(granteeKeys, granteeValues); err != nil {
+		return nil, nil, "", err
+	}
+
 	var firstPrefix string
 	newID := crypto.GranteeID(granteeKey)
 	if isLegacyGranteeID(idStr) && idStr != newID {
@@ -1687,6 +1701,14 @@ func (kc *Catalog) AlterGrant(ctx context.Context, tenant string, entity *milvus
 }
 
 func (kc *Catalog) ListGrant(ctx context.Context, tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error) {
+	return kc.listGrantWithLoadedGrantees(ctx, tenant, entity, nil, nil)
+}
+
+func (kc *Catalog) listGrantWithLoadedGrantees(ctx context.Context, tenant string, entity *milvuspb.GrantEntity, granteeKeys []string, granteeValues []string) ([]*milvuspb.GrantEntity, error) {
+	if err := validateLoadedGrantees(granteeKeys, granteeValues); err != nil {
+		return nil, err
+	}
+
 	var entities []*milvuspb.GrantEntity
 
 	var granteeKey string
@@ -1696,7 +1718,7 @@ func (kc *Catalog) ListGrant(ctx context.Context, tenant string, entity *milvusp
 		if dbName != entity.DbName && dbName != util.AnyWord && entity.DbName != util.AnyWord {
 			return nil
 		}
-		keys, values, granteeIDKey, err := kc.loadGranteeIDPrefix(ctx, tenant, granteeKey, v)
+		keys, values, granteeIDKey, err := kc.loadGranteeIDPrefixWithLoadedGrantees(ctx, tenant, granteeKey, v, granteeKeys, granteeValues)
 		if err != nil {
 			mlog.Error(ctx, "fail to load the grantee ids", mlog.String("key", granteeIDKey), mlog.Err(err))
 			return err
@@ -2110,12 +2132,32 @@ func (kc *Catalog) BackupRBAC(ctx context.Context, tenant string) (*milvuspb.RBA
 		return entity.GetRole(), true
 	})
 
+	var granteeKeys []string
+	var granteeValues []string
+	if len(roleEntity) > 0 {
+		granteeKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
+		granteeKeys, granteeValues, err = kc.Txn.LoadWithPrefix(ctx, granteeKey)
+		if err != nil {
+			mlog.Error(ctx, "fail to load all grant privilege entities", mlog.String("key", granteeKey), mlog.Err(err))
+			return nil, err
+		}
+		if err := validateLoadedGrantees(granteeKeys, granteeValues); err != nil {
+			return nil, err
+		}
+		if granteeKeys == nil {
+			granteeKeys = []string{}
+		}
+		if granteeValues == nil {
+			granteeValues = []string{}
+		}
+	}
+
 	grantsEntity := make([]*milvuspb.GrantEntity, 0)
 	for _, role := range roleEntity {
-		grants, err := kc.ListGrant(ctx, tenant, &milvuspb.GrantEntity{
+		grants, err := kc.listGrantWithLoadedGrantees(ctx, tenant, &milvuspb.GrantEntity{
 			Role:   role,
 			DbName: util.AnyWord,
-		})
+		}, granteeKeys, granteeValues)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/metastore/kv/rootcoord/kv_catalog.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog.go
@@ -1524,11 +1524,61 @@ func validateLoadedGrantees(granteeKeys []string, granteeValues []string) error 
 	return nil
 }
 
-func (kc *Catalog) loadGranteeIDPrefixWithLoadedGrantees(ctx context.Context, tenant string, granteeKey string, idStr string, granteeKeys []string, granteeValues []string) ([]string, []string, string, error) {
+type loadedGranteesProvider func(ctx context.Context) ([]string, []string, error)
+
+func newLoadedGranteesProvider(granteeKeys []string, granteeValues []string) (loadedGranteesProvider, error) {
 	if err := validateLoadedGrantees(granteeKeys, granteeValues); err != nil {
+		return nil, err
+	}
+	if granteeKeys == nil {
+		return nil, nil
+	}
+	return func(context.Context) ([]string, []string, error) {
+		return granteeKeys, granteeValues, nil
+	}, nil
+}
+
+func (kc *Catalog) newLazyLoadedGranteesProvider(tenant string) loadedGranteesProvider {
+	var (
+		loaded        bool
+		granteeKeys   []string
+		granteeValues []string
+		loadErr       error
+	)
+	return func(ctx context.Context) ([]string, []string, error) {
+		if loaded {
+			return granteeKeys, granteeValues, loadErr
+		}
+		loaded = true
+
+		granteeKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
+		granteeKeys, granteeValues, loadErr = kc.Txn.LoadWithPrefix(ctx, granteeKey)
+		if loadErr != nil {
+			mlog.Error(ctx, "fail to load all grant privilege entities", mlog.String("key", granteeKey), mlog.Err(loadErr))
+			return nil, nil, loadErr
+		}
+		if loadErr = validateLoadedGrantees(granteeKeys, granteeValues); loadErr != nil {
+			return nil, nil, loadErr
+		}
+		if granteeKeys == nil {
+			granteeKeys = []string{}
+		}
+		if granteeValues == nil {
+			granteeValues = []string{}
+		}
+		return granteeKeys, granteeValues, nil
+	}
+}
+
+func (kc *Catalog) loadGranteeIDPrefixWithLoadedGrantees(ctx context.Context, tenant string, granteeKey string, idStr string, granteeKeys []string, granteeValues []string) ([]string, []string, string, error) {
+	loadedGrantees, err := newLoadedGranteesProvider(granteeKeys, granteeValues)
+	if err != nil {
 		return nil, nil, "", err
 	}
+	return kc.loadGranteeIDPrefixWithLoadedGranteeProvider(ctx, tenant, granteeKey, idStr, loadedGrantees)
+}
 
+func (kc *Catalog) loadGranteeIDPrefixWithLoadedGranteeProvider(ctx context.Context, tenant string, granteeKey string, idStr string, loadedGrantees loadedGranteesProvider) ([]string, []string, string, error) {
 	var firstPrefix string
 	newID := crypto.GranteeID(granteeKey)
 	if isLegacyGranteeID(idStr) && idStr != newID {
@@ -1537,7 +1587,18 @@ func (kc *Catalog) loadGranteeIDPrefixWithLoadedGrantees(ctx context.Context, te
 			otherGranteeKey string
 			err             error
 		)
-		if granteeKeys != nil {
+		if loadedGrantees != nil {
+			var (
+				granteeKeys   []string
+				granteeValues []string
+			)
+			granteeKeys, granteeValues, err = loadedGrantees(ctx)
+			if err != nil {
+				return nil, nil, granteeIDKey, err
+			}
+			if err := validateLoadedGrantees(granteeKeys, granteeValues); err != nil {
+				return nil, nil, granteeIDKey, err
+			}
 			granteePrefix := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
 			otherGranteeKey, err = findOtherGranteeWithIDFromKeys(ctx, granteePrefix, granteeKey, idStr, granteeKeys, granteeValues)
 		} else {
@@ -1705,10 +1766,14 @@ func (kc *Catalog) ListGrant(ctx context.Context, tenant string, entity *milvusp
 }
 
 func (kc *Catalog) listGrantWithLoadedGrantees(ctx context.Context, tenant string, entity *milvuspb.GrantEntity, granteeKeys []string, granteeValues []string) ([]*milvuspb.GrantEntity, error) {
-	if err := validateLoadedGrantees(granteeKeys, granteeValues); err != nil {
+	loadedGrantees, err := newLoadedGranteesProvider(granteeKeys, granteeValues)
+	if err != nil {
 		return nil, err
 	}
+	return kc.listGrantWithLoadedGranteeProvider(ctx, tenant, entity, loadedGrantees)
+}
 
+func (kc *Catalog) listGrantWithLoadedGranteeProvider(ctx context.Context, tenant string, entity *milvuspb.GrantEntity, loadedGrantees loadedGranteesProvider) ([]*milvuspb.GrantEntity, error) {
 	var entities []*milvuspb.GrantEntity
 
 	var granteeKey string
@@ -1718,7 +1783,7 @@ func (kc *Catalog) listGrantWithLoadedGrantees(ctx context.Context, tenant strin
 		if dbName != entity.DbName && dbName != util.AnyWord && entity.DbName != util.AnyWord {
 			return nil
 		}
-		keys, values, granteeIDKey, err := kc.loadGranteeIDPrefixWithLoadedGrantees(ctx, tenant, granteeKey, v, granteeKeys, granteeValues)
+		keys, values, granteeIDKey, err := kc.loadGranteeIDPrefixWithLoadedGranteeProvider(ctx, tenant, granteeKey, v, loadedGrantees)
 		if err != nil {
 			mlog.Error(ctx, "fail to load the grantee ids", mlog.String("key", granteeIDKey), mlog.Err(err))
 			return err
@@ -2132,32 +2197,17 @@ func (kc *Catalog) BackupRBAC(ctx context.Context, tenant string) (*milvuspb.RBA
 		return entity.GetRole(), true
 	})
 
-	var granteeKeys []string
-	var granteeValues []string
+	var loadedGrantees loadedGranteesProvider
 	if len(roleEntity) > 0 {
-		granteeKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
-		granteeKeys, granteeValues, err = kc.Txn.LoadWithPrefix(ctx, granteeKey)
-		if err != nil {
-			mlog.Error(ctx, "fail to load all grant privilege entities", mlog.String("key", granteeKey), mlog.Err(err))
-			return nil, err
-		}
-		if err := validateLoadedGrantees(granteeKeys, granteeValues); err != nil {
-			return nil, err
-		}
-		if granteeKeys == nil {
-			granteeKeys = []string{}
-		}
-		if granteeValues == nil {
-			granteeValues = []string{}
-		}
+		loadedGrantees = kc.newLazyLoadedGranteesProvider(tenant)
 	}
 
 	grantsEntity := make([]*milvuspb.GrantEntity, 0)
 	for _, role := range roleEntity {
-		grants, err := kc.listGrantWithLoadedGrantees(ctx, tenant, &milvuspb.GrantEntity{
+		grants, err := kc.listGrantWithLoadedGranteeProvider(ctx, tenant, &milvuspb.GrantEntity{
 			Role:   role,
 			DbName: util.AnyWord,
-		}, granteeKeys, granteeValues)
+		}, loadedGrantees)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/metastore/kv/rootcoord/kv_catalog_test.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog_test.go
@@ -3282,6 +3282,107 @@ func TestBackupRBACLegacyGranteeIDReusesLoadedGrantKeys(t *testing.T) {
 	assert.Equal(t, int32(1), granteePrefixLoads.Load(), "BackupRBAC should reuse one tenant-wide grantee scan for legacy ID collision checks")
 }
 
+func TestBackupRBACCustomRolesWithoutLegacyIDsDoesNotPreloadAllGrantees(t *testing.T) {
+	ctx := context.Background()
+	tenant := util.DefaultTenant
+	kvmock := mocks.NewTxnKV(t)
+	c := NewCatalog(kvmock)
+
+	rolePrefix := funcutil.HandleTenantForEtcdPrefix(RolePrefix, tenant)
+	granteePrefix := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
+	objectType := commonpb.ObjectType_Collection.String()
+	logicalKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, "role1", objectType, funcutil.CombineObjectName(util.DefaultDBName, "coll1"))
+	roleGranteePrefix := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, "role1")
+	fullID := crypto.GranteeID(logicalKey)
+	idPrefix := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, fullID)
+	var granteePrefixLoads atomic.Int32
+
+	kvmock.EXPECT().LoadWithPrefix(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, key string) ([]string, []string, error) {
+			switch key {
+			case CredentialPrefix + "/":
+				return nil, nil, nil
+			case rolePrefix:
+				return []string{rolePrefix + "role1"}, []string{""}, nil
+			case roleGranteePrefix:
+				return []string{logicalKey}, []string{fullID}, nil
+			case granteePrefix:
+				granteePrefixLoads.Inc()
+				return []string{logicalKey}, []string{fullID}, nil
+			case idPrefix:
+				return []string{idPrefix + "PrivilegeLoad"}, []string{"grantor1"}, nil
+			case PrivilegeGroupPrefix + "/":
+				return nil, nil, nil
+			default:
+				require.Failf(t, "unexpected LoadWithPrefix", "key %q", key)
+				return nil, nil, nil
+			}
+		},
+	)
+
+	backup, err := c.BackupRBAC(ctx, tenant)
+	require.NoError(t, err)
+	require.Len(t, backup.GetGrants(), 1)
+	assert.Equal(t, "grantor1", backup.GetGrants()[0].GetGrantor().GetUser().GetName())
+	assert.Equal(t, int32(0), granteePrefixLoads.Load(), "BackupRBAC should not preload all grantees when no grant carries a legacy ID")
+}
+
+func TestBackupRBACLegacyGranteeIDLoadsTenantSnapshotAfterRoleRead(t *testing.T) {
+	ctx := context.Background()
+	tenant := util.DefaultTenant
+	kvmock := mocks.NewTxnKV(t)
+	c := NewCatalog(kvmock)
+
+	rolePrefix := funcutil.HandleTenantForEtcdPrefix(RolePrefix, tenant)
+	granteePrefix := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
+	objectType := commonpb.ObjectType_Collection.String()
+	objectName := funcutil.CombineObjectName(util.DefaultDBName, "coll1")
+	donorLogicalKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, "donor-role", objectType, objectName)
+	victimLogicalKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, "victim-role", objectType, objectName)
+	donorRolePrefix := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, "donor-role")
+	victimRolePrefix := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, "victim-role")
+	sharedLegacyID := crypto.MD5(victimLogicalKey)
+	victimIDPrefix := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, sharedLegacyID)
+	var roleGrantPrefixReads atomic.Int32
+	var granteePrefixLoads atomic.Int32
+
+	kvmock.EXPECT().LoadWithPrefix(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, key string) ([]string, []string, error) {
+			switch key {
+			case CredentialPrefix + "/":
+				return nil, nil, nil
+			case rolePrefix:
+				return []string{rolePrefix + "donor-role", rolePrefix + "victim-role"}, []string{"", ""}, nil
+			case donorRolePrefix:
+				roleGrantPrefixReads.Inc()
+				return nil, nil, nil
+			case victimRolePrefix:
+				roleGrantPrefixReads.Inc()
+				return []string{victimLogicalKey}, []string{sharedLegacyID}, nil
+			case granteePrefix:
+				granteePrefixLoads.Inc()
+				if roleGrantPrefixReads.Load() == 0 {
+					return []string{donorLogicalKey, victimLogicalKey}, []string{sharedLegacyID, sharedLegacyID}, nil
+				}
+				return []string{victimLogicalKey}, []string{sharedLegacyID}, nil
+			case victimIDPrefix:
+				return []string{victimIDPrefix + "PrivilegeLoad"}, []string{"victim-user"}, nil
+			case PrivilegeGroupPrefix + "/":
+				return nil, nil, nil
+			default:
+				require.Failf(t, "unexpected LoadWithPrefix", "key %q", key)
+				return nil, nil, nil
+			}
+		},
+	)
+
+	backup, err := c.BackupRBAC(ctx, tenant)
+	require.NoError(t, err)
+	require.Len(t, backup.GetGrants(), 1)
+	assert.Equal(t, "victim-user", backup.GetGrants()[0].GetGrantor().GetUser().GetName())
+	assert.Equal(t, int32(1), granteePrefixLoads.Load(), "BackupRBAC should lazily load one tenant-wide grantee snapshot for legacy ID collision checks")
+}
+
 func TestBackupRBACLegacyGranteeIDReuseStillFailsClosedOnSharedID(t *testing.T) {
 	ctx := context.Background()
 	tenant := util.DefaultTenant
@@ -3314,6 +3415,48 @@ func TestBackupRBACLegacyGranteeIDReuseStillFailsClosedOnSharedID(t *testing.T) 
 				return []string{donorLogicalKey, victimLogicalKey}, []string{sharedLegacyID, sharedLegacyID}, nil
 			case donorIDPrefix:
 				return []string{donorIDPrefix + "PrivilegeInsert"}, []string{"donor-user"}, nil
+			case PrivilegeGroupPrefix + "/":
+				return nil, nil, nil
+			default:
+				require.Failf(t, "unexpected LoadWithPrefix", "key %q", key)
+				return nil, nil, nil
+			}
+		},
+	)
+
+	backup, err := c.BackupRBAC(ctx, tenant)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "shared legacy grantee id")
+	assert.Nil(t, backup)
+}
+
+func TestBackupRBACLegacyGranteeIDFailsClosedOnInvalidLoadedTenantKey(t *testing.T) {
+	ctx := context.Background()
+	tenant := util.DefaultTenant
+	kvmock := mocks.NewTxnKV(t)
+	c := NewCatalog(kvmock)
+
+	rolePrefix := funcutil.HandleTenantForEtcdPrefix(RolePrefix, tenant)
+	granteePrefix := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
+	objectType := commonpb.ObjectType_Collection.String()
+	logicalKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, "role1", objectType, funcutil.CombineObjectName(util.DefaultDBName, "coll1"))
+	roleGranteePrefix := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, "role1")
+	legacyID := crypto.MD5(logicalKey)
+	idPrefix := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, legacyID)
+
+	kvmock.EXPECT().LoadWithPrefix(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, key string) ([]string, []string, error) {
+			switch key {
+			case CredentialPrefix + "/":
+				return nil, nil, nil
+			case rolePrefix:
+				return []string{rolePrefix + "role1"}, []string{""}, nil
+			case roleGranteePrefix:
+				return []string{logicalKey}, []string{legacyID}, nil
+			case granteePrefix:
+				return []string{granteePrefix + "malformed"}, []string{legacyID}, nil
+			case idPrefix:
+				return []string{idPrefix + "PrivilegeLoad"}, []string{"grantor1"}, nil
 			case PrivilegeGroupPrefix + "/":
 				return nil, nil, nil
 			default:
@@ -3374,6 +3517,10 @@ func TestBackupRBACRejectsMismatchedLoadedGranteePreload(t *testing.T) {
 
 	rolePrefix := funcutil.HandleTenantForEtcdPrefix(RolePrefix, tenant)
 	granteePrefix := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
+	objectType := commonpb.ObjectType_Collection.String()
+	logicalKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, "role1", objectType, funcutil.CombineObjectName(util.DefaultDBName, "coll1"))
+	roleGranteePrefix := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, "role1")
+	legacyID := crypto.MD5(logicalKey)
 
 	kvmock.EXPECT().LoadWithPrefix(mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, key string) ([]string, []string, error) {
@@ -3382,6 +3529,8 @@ func TestBackupRBACRejectsMismatchedLoadedGranteePreload(t *testing.T) {
 				return nil, nil, nil
 			case rolePrefix:
 				return []string{rolePrefix + "role1"}, []string{""}, nil
+			case roleGranteePrefix:
+				return []string{logicalKey}, []string{legacyID}, nil
 			case granteePrefix:
 				return nil, []string{}, nil
 			default:

--- a/internal/metastore/kv/rootcoord/kv_catalog_test.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog_test.go
@@ -2995,6 +2995,7 @@ func TestRBAC_Grant(t *testing.T) {
 					return []string{
 						crypto.MD5(key + "obj1/obj_name1"),
 						crypto.MD5(key + "obj2/obj_name2"),
+						"invalid",
 					}
 				}
 				return nil
@@ -3226,6 +3227,221 @@ func TestRBACGrantSharedLegacyGranteeIDMigrationFailsClosed(t *testing.T) {
 	assert.Equal(t, "donor-user", donorUser)
 }
 
+func TestBackupRBACLegacyGranteeIDReusesLoadedGrantKeys(t *testing.T) {
+	ctx := context.Background()
+	tenant := util.DefaultTenant
+	kvmock := mocks.NewTxnKV(t)
+	c := NewCatalog(kvmock)
+
+	rolePrefix := funcutil.HandleTenantForEtcdPrefix(RolePrefix, tenant)
+	granteePrefix := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
+	objectType := commonpb.ObjectType_Collection.String()
+	firstLogicalKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, "role1", objectType, funcutil.CombineObjectName(util.DefaultDBName, "coll1"))
+	secondLogicalKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, "role2", objectType, funcutil.CombineObjectName(util.DefaultDBName, "coll2"))
+	firstRolePrefix := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, "role1")
+	secondRolePrefix := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, "role2")
+	firstLegacyID := crypto.MD5(firstLogicalKey)
+	secondLegacyID := crypto.MD5(secondLogicalKey)
+	firstIDPrefix := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, firstLegacyID)
+	secondIDPrefix := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, secondLegacyID)
+	var granteePrefixLoads atomic.Int32
+
+	kvmock.EXPECT().LoadWithPrefix(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, key string) ([]string, []string, error) {
+			switch key {
+			case CredentialPrefix + "/":
+				return nil, nil, nil
+			case rolePrefix:
+				return []string{rolePrefix + "role1", rolePrefix + "role2"}, []string{"", ""}, nil
+			case firstRolePrefix:
+				return []string{firstLogicalKey}, []string{firstLegacyID}, nil
+			case secondRolePrefix:
+				return []string{secondLogicalKey}, []string{secondLegacyID}, nil
+			case granteePrefix:
+				granteePrefixLoads.Inc()
+				return []string{firstLogicalKey, secondLogicalKey}, []string{firstLegacyID, secondLegacyID}, nil
+			case firstIDPrefix:
+				return []string{firstIDPrefix + "PrivilegeLoad"}, []string{"grantor1"}, nil
+			case secondIDPrefix:
+				return []string{secondIDPrefix + "PrivilegeRelease"}, []string{"grantor2"}, nil
+			case PrivilegeGroupPrefix + "/":
+				return nil, nil, nil
+			default:
+				require.Failf(t, "unexpected LoadWithPrefix", "key %q", key)
+				return nil, nil, nil
+			}
+		},
+	)
+
+	backup, err := c.BackupRBAC(ctx, tenant)
+	require.NoError(t, err)
+	require.Len(t, backup.GetGrants(), 2)
+	assert.ElementsMatch(t, []string{"grantor1", "grantor2"}, lo.Map(backup.GetGrants(), func(grant *milvuspb.GrantEntity, _ int) string {
+		return grant.GetGrantor().GetUser().GetName()
+	}))
+	assert.Equal(t, int32(1), granteePrefixLoads.Load(), "BackupRBAC should reuse one tenant-wide grantee scan for legacy ID collision checks")
+}
+
+func TestBackupRBACLegacyGranteeIDReuseStillFailsClosedOnSharedID(t *testing.T) {
+	ctx := context.Background()
+	tenant := util.DefaultTenant
+	kvmock := mocks.NewTxnKV(t)
+	c := NewCatalog(kvmock)
+
+	rolePrefix := funcutil.HandleTenantForEtcdPrefix(RolePrefix, tenant)
+	granteePrefix := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
+	objectType := commonpb.ObjectType_Collection.String()
+	objectName := funcutil.CombineObjectName(util.DefaultDBName, "shared-coll")
+	donorLogicalKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, "donor-role", objectType, objectName)
+	victimLogicalKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, "victim-role", objectType, objectName)
+	donorRolePrefix := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, "donor-role")
+	victimRolePrefix := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, "victim-role")
+	sharedLegacyID := crypto.MD5(donorLogicalKey)
+	donorIDPrefix := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, sharedLegacyID)
+
+	kvmock.EXPECT().LoadWithPrefix(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, key string) ([]string, []string, error) {
+			switch key {
+			case CredentialPrefix + "/":
+				return nil, nil, nil
+			case rolePrefix:
+				return []string{rolePrefix + "donor-role", rolePrefix + "victim-role"}, []string{"", ""}, nil
+			case donorRolePrefix:
+				return []string{donorLogicalKey}, []string{sharedLegacyID}, nil
+			case victimRolePrefix:
+				return []string{victimLogicalKey}, []string{sharedLegacyID}, nil
+			case granteePrefix:
+				return []string{donorLogicalKey, victimLogicalKey}, []string{sharedLegacyID, sharedLegacyID}, nil
+			case donorIDPrefix:
+				return []string{donorIDPrefix + "PrivilegeInsert"}, []string{"donor-user"}, nil
+			case PrivilegeGroupPrefix + "/":
+				return nil, nil, nil
+			default:
+				require.Failf(t, "unexpected LoadWithPrefix", "key %q", key)
+				return nil, nil, nil
+			}
+		},
+	)
+
+	backup, err := c.BackupRBAC(ctx, tenant)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "shared legacy grantee id")
+	assert.Nil(t, backup)
+}
+
+func TestBackupRBACNoCustomRolesSkipsGranteePreload(t *testing.T) {
+	ctx := context.Background()
+	tenant := util.DefaultTenant
+	kvmock := mocks.NewTxnKV(t)
+	c := NewCatalog(kvmock)
+
+	rolePrefix := funcutil.HandleTenantForEtcdPrefix(RolePrefix, tenant)
+	granteePrefix := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
+	var granteePrefixLoads atomic.Int32
+
+	kvmock.EXPECT().LoadWithPrefix(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, key string) ([]string, []string, error) {
+			switch key {
+			case CredentialPrefix + "/":
+				return nil, nil, nil
+			case rolePrefix:
+				return []string{rolePrefix + util.RoleAdmin, rolePrefix + util.RolePublic}, []string{"", ""}, nil
+			case granteePrefix:
+				granteePrefixLoads.Inc()
+				return nil, nil, nil
+			case PrivilegeGroupPrefix + "/":
+				return nil, nil, nil
+			default:
+				require.Failf(t, "unexpected LoadWithPrefix", "key %q", key)
+				return nil, nil, nil
+			}
+		},
+	)
+
+	backup, err := c.BackupRBAC(ctx, tenant)
+	require.NoError(t, err)
+	require.NotNil(t, backup)
+	assert.Empty(t, backup.GetRoles())
+	assert.Empty(t, backup.GetGrants())
+	assert.Equal(t, int32(0), granteePrefixLoads.Load(), "BackupRBAC should not preload grantees when there are no custom roles")
+}
+
+func TestBackupRBACRejectsMismatchedLoadedGranteePreload(t *testing.T) {
+	ctx := context.Background()
+	tenant := util.DefaultTenant
+	kvmock := mocks.NewTxnKV(t)
+	c := NewCatalog(kvmock)
+
+	rolePrefix := funcutil.HandleTenantForEtcdPrefix(RolePrefix, tenant)
+	granteePrefix := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
+
+	kvmock.EXPECT().LoadWithPrefix(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, key string) ([]string, []string, error) {
+			switch key {
+			case CredentialPrefix + "/":
+				return nil, nil, nil
+			case rolePrefix:
+				return []string{rolePrefix + "role1"}, []string{""}, nil
+			case granteePrefix:
+				return nil, []string{}, nil
+			default:
+				require.Failf(t, "unexpected LoadWithPrefix", "key %q", key)
+				return nil, nil, nil
+			}
+		},
+	)
+
+	backup, err := c.BackupRBAC(ctx, tenant)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, merr.ErrServiceInternal)
+	assert.Contains(t, err.Error(), "loaded grantee keys and values")
+	assert.Nil(t, backup)
+}
+
+func TestLoadGranteeIDPrefixWithLoadedGranteesRejectsMismatchedLoadedGrantees(t *testing.T) {
+	ctx := context.Background()
+	tenant := util.DefaultTenant
+	granteeKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, "role1", commonpb.ObjectType_Collection.String(), funcutil.CombineObjectName(util.DefaultDBName, "coll1"))
+	legacyID := crypto.MD5(granteeKey)
+
+	tests := []struct {
+		name          string
+		granteeKeys   []string
+		granteeValues []string
+	}{
+		{
+			name:          "keys without values",
+			granteeKeys:   []string{granteeKey},
+			granteeValues: nil,
+		},
+		{
+			name:          "values without keys",
+			granteeKeys:   nil,
+			granteeValues: []string{legacyID},
+		},
+		{
+			name:          "length mismatch",
+			granteeKeys:   []string{granteeKey},
+			granteeValues: []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			kvmock := mocks.NewTxnKV(t)
+			c := NewCatalog(kvmock).(*Catalog)
+			kvmock.EXPECT().LoadWithPrefix(mock.Anything, mock.Anything).Return(nil, nil, nil).Maybe()
+
+			keys, values, _, err := c.loadGranteeIDPrefixWithLoadedGrantees(ctx, tenant, granteeKey, legacyID, test.granteeKeys, test.granteeValues)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrServiceInternal)
+			assert.Contains(t, err.Error(), "loaded grantee keys and values")
+			assert.Nil(t, keys)
+			assert.Nil(t, values)
+		})
+	}
+}
+
 func TestRBACListPolicyLegacyGranteeIDReusesLoadedGrantKeys(t *testing.T) {
 	ctx := context.Background()
 	tenant := util.DefaultTenant
@@ -3233,7 +3449,6 @@ func TestRBACListPolicyLegacyGranteeIDReusesLoadedGrantKeys(t *testing.T) {
 	c := NewCatalog(kvmock)
 
 	granteePrefix := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
-	granteeIDPrefix := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant)
 	objectType := commonpb.ObjectType_Collection.String()
 	firstLogicalKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, "role1", objectType, funcutil.CombineObjectName(util.DefaultDBName, "coll1"))
 	secondLogicalKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, "role2", objectType, funcutil.CombineObjectName(util.DefaultDBName, "coll2"))
@@ -3245,21 +3460,25 @@ func TestRBACListPolicyLegacyGranteeIDReusesLoadedGrantKeys(t *testing.T) {
 
 	kvmock.EXPECT().LoadWithPrefix(mock.Anything, mock.Anything).Call.Return(
 		func(ctx context.Context, key string) []string {
-			switch {
-			case key == granteePrefix:
+			switch key {
+			case granteePrefix:
 				granteePrefixLoads.Inc()
 				return []string{firstEtcdKey, secondEtcdKey}
-			case strings.HasPrefix(key, granteeIDPrefix):
+			case funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, firstLegacyID):
+				return []string{key + "PrivilegeLoad"}
+			case funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, secondLegacyID):
 				return []string{key + "PrivilegeLoad"}
 			default:
 				return nil
 			}
 		},
 		func(ctx context.Context, key string) []string {
-			switch {
-			case key == granteePrefix:
+			switch key {
+			case granteePrefix:
 				return []string{firstLegacyID, secondLegacyID}
-			case strings.HasPrefix(key, granteeIDPrefix):
+			case funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, firstLegacyID):
+				return []string{"root"}
+			case funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, secondLegacyID):
 				return []string{"root"}
 			default:
 				return nil


### PR DESCRIPTION
- Add a lazy, memoized BackupRBAC grantee provider so tenant-wide `GranteePrefix` data is loaded only when a legacy 16-hex grantee ID needs a shared-ID collision check.
- Keep public `ListGrant` and existing `ListPolicy` behavior unchanged while preserving `Grantor.User` population during RBAC backup.
- Add regression coverage for no-legacy backups avoiding the extra full-tenant scan, lazy snapshot timing after role-local reads, shared legacy ID fail-closed behavior, and invalid loaded grantee data.

related: #52197
