### PR TITLE
fix: [cp3.0] propagate swallowed RecordBuilder.Append errors in mix compaction

### DIFF
--- a/internal/datanode/compactor/mix_compactor.go
+++ b/internal/datanode/compactor/mix_compactor.go
@@ -365,7 +365,13 @@ func (t *mixCompactionTask) writeSegment(ctx context.Context,
 					rb = storage.NewRecordBuilder(writerSchema)
 				}
 				if sliceStart != -1 {
-					rb.Append(r, sliceStart, i)
+					// Append is not atomic: a failed builder may hold a partial
+					// row and must never reach Build.
+					if err = rb.Append(r, sliceStart, i); err != nil {
+						rb.Release()
+						cleanupMaterializedRecord(r)
+						return 0, 0, err
+					}
 				}
 				sliceStart = -1
 				continue
@@ -378,7 +384,11 @@ func (t *mixCompactionTask) writeSegment(ctx context.Context,
 
 		if rb != nil {
 			if sliceStart != -1 {
-				rb.Append(r, sliceStart, r.Len())
+				if err = rb.Append(r, sliceStart, r.Len()); err != nil {
+					rb.Release()
+					cleanupMaterializedRecord(r)
+					return 0, 0, err
+				}
 			}
 			if rb.GetRowNum() > 0 {
 				err := func() error {
@@ -391,10 +401,12 @@ func (t *mixCompactionTask) writeSegment(ctx context.Context,
 					return mWriter.Write(out)
 				}()
 				if err != nil {
+					rb.Release()
 					cleanupMaterializedRecord(r)
 					return 0, 0, err
 				}
 			}
+			rb.Release()
 		} else {
 			out := overwriteRecordTimestamps(r, seg.GetCommitTimestamp())
 			err := mWriter.Write(out)

--- a/internal/datanode/compactor/mix_compactor_test.go
+++ b/internal/datanode/compactor/mix_compactor_test.go
@@ -192,6 +192,104 @@ func TestMixCompactionMaterializesMissingFieldWithDeleteFilter(t *testing.T) {
 	s.EqualValues(1, fieldBinlogEntriesForTest(segment.GetInsertLogs(), StringField))
 }
 
+const textFieldForAppendErrorTest = int64(130)
+
+func (s *MixCompactionTaskStorageV1Suite) setupTestWithTextField() {
+	s.mockBinlogIO = mock_util.NewMockBinlogIO(s.T())
+	s.meta = genTestCollectionMeta()
+	s.meta.Schema.Fields = append(s.meta.Schema.Fields, &schemapb.FieldSchema{
+		FieldID:  textFieldForAppendErrorTest,
+		Name:     "text_col",
+		DataType: schemapb.DataType_Text,
+		Nullable: true,
+	})
+	params, err := compaction.GenerateJSONParams(s.meta.GetSchema())
+	s.Require().NoError(err)
+	plan := &datapb.CompactionPlan{
+		PlanID:                 999,
+		Type:                   datapb.CompactionType_MixCompaction,
+		Schema:                 s.meta.GetSchema(),
+		PreAllocatedSegmentIDs: &datapb.IDRange{Begin: 19531, End: math.MaxInt64},
+		PreAllocatedLogIDs:     &datapb.IDRange{Begin: 9530, End: 19530},
+		MaxSize:                64 * 1024 * 1024,
+		JsonParams:             params,
+	}
+	pk, err := typeutil.GetPrimaryFieldSchema(s.meta.GetSchema())
+	s.Require().NoError(err)
+	s.task = NewMixCompactionTask(context.Background(), s.mockBinlogIO, nil, plan, compaction.GenParams(), []int64{pk.FieldID})
+}
+
+// V1 binlogs deserialize TEXT as arrow String while the retained-row rebuilder
+// allocates a Binary builder for TEXT, so with any filtered row rb.Append fails
+// deterministically: the task must fail instead of silently dropping the
+// retained rows of that batch.
+func TestMixCompactionPropagatesRecordBuilderAppendError(t *testing.T) {
+	cases := []struct {
+		name           string
+		deletePKOffset int64
+	}{
+		// deleting the first row leaves the retained range open at record end,
+		// exercising the tail rb.Append; deleting the second row closes the
+		// retained range mid-record, exercising the in-loop rb.Append.
+		{name: "filtered_first_row_hits_tail_append", deletePKOffset: 0},
+		{name: "filtered_second_row_hits_mid_append", deletePKOffset: 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newMixCompactionStorageV1SuiteForDirectTest(t)
+			s.setupTestWithTextField()
+
+			segmentID := int64(700)
+			alloc := allocator.NewLocalAllocator(888888, math.MaxInt64)
+			segWriter, err := NewSegmentWriter(s.meta.GetSchema(), 65535, compactionBatchSize, segmentID, PartitionID, CollectionID, []int64{})
+			s.Require().NoError(err)
+			for i := int64(0); i < 2; i++ {
+				row := getRow(segmentID+i, 0)
+				row[textFieldForAppendErrorTest] = "text-payload"
+				err = segWriter.Write(&storage.Value{
+					PK:        storage.NewInt64PrimaryKey(segmentID + i),
+					Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday())),
+					Value:     row,
+				})
+				s.Require().NoError(err)
+			}
+			segWriter.FlushAndIsFull()
+			s.segWriter = segWriter
+
+			kvs, fBinlogs, err := serializeWrite(context.TODO(), alloc, s.segWriter)
+			s.Require().NoError(err)
+
+			deleteTs := tsoutil.ComposeTSByTime(getMilvusBirthday().Add(10 * time.Second))
+			blob, err := getInt64DeltaBlobs(segmentID, []int64{segmentID + tc.deletePKOffset}, []uint64{deleteTs})
+			s.Require().NoError(err)
+			deltaPath := "deltalog/append-error-" + tc.name
+			s.mockBinlogIO.EXPECT().Download(mock.Anything, []string{deltaPath}).
+				Return([][]byte{blob.GetValue()}, nil).Once()
+			s.mockBinlogIO.EXPECT().Download(mock.Anything, mock.MatchedBy(func(keys []string) bool {
+				left, right := lo.Difference(keys, lo.Keys(kvs))
+				return len(left) == 0 && len(right) == 0
+			})).RunAndReturn(func(ctx context.Context, keys []string) ([][]byte, error) {
+				return downloadValuesForPathsForTest(kvs, keys)
+			}).Once()
+			s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
+
+			s.task.plan.SegmentBinlogs = []*datapb.CompactionSegmentBinlogs{{
+				CollectionID: 1,
+				SegmentID:    segmentID,
+				FieldBinlogs: lo.Values(fBinlogs),
+				Deltalogs: []*datapb.FieldBinlog{{
+					Binlogs: []*datapb.Binlog{{LogPath: deltaPath}},
+				}},
+			}}
+
+			result, err := s.task.Compact()
+			s.Require().Error(err)
+			s.Require().ErrorContains(err, "failed to append value")
+			s.Require().Nil(result)
+		})
+	}
+}
+
 func TestMixCompactionMergeSortMaterializesMissingBM25Output(t *testing.T) {
 	s := newMixCompactionStorageV1SuiteForDirectTest(t)
 	mergeSortKey := paramtable.Get().DataNodeCfg.UseMergeSort.Key
@@ -1050,7 +1148,6 @@ func (s *MixCompactionTaskStorageV1Suite) initMultiRowsSegBuffer(magic, numRows,
 	}
 
 	segWriter.FlushAndIsFull()
-
 	s.segWriter = segWriter
 }
 
@@ -1066,7 +1163,6 @@ func (s *MixCompactionTaskStorageV1Suite) initSegBufferWithBM25(magic int64) {
 	err = segWriter.Write(&v)
 	s.Require().NoError(err)
 	segWriter.FlushAndIsFull()
-
 	s.segWriter = segWriter
 }
 
@@ -1084,7 +1180,6 @@ func (s *MixCompactionTaskStorageV1Suite) initSegBuffer(size int, seed int64) {
 		s.Require().NoError(err)
 	}
 	segWriter.FlushAndIsFull()
-
 	s.segWriter = segWriter
 }
 


### PR DESCRIPTION
## What this PR does

Cherry-pick of #52179 to 3.0 (clean pick, no conflicts).

Mix compaction discarded both `RecordBuilder.Append` errors on the retained-row rebuild path. `Append` is not atomic and fails deterministically on any Arrow representation divergence, so one swallowed failure silently dropped every retained row of that batch while the task still completed with a non-empty, adoptable result — the DataCoord empty-result guard cannot catch it, the result is adopted and the input segments are dropped. Both call sites now propagate the error and release the poisoned builder (never reaching `Build`); the builder is also released on the normal and writer-error paths. `NamespaceCompactor` inherits the fix.

## Tests

- `TestMixCompactionPropagatesRecordBuilderAppendError` (two subcases covering the mid-record and tail `Append` call sites) passes on 3.0; full `internal/datanode/compactor` suite green with `-tags dynamic,test -gcflags="all=-N -l" -count=1`.

issue: #52178
pr: #52179

🤖 Generated with [Claude Code](https://claude.com/claude-code)
