### PR TITLE
fix: [3.0] preserve collection metadata during snapshot restore

### DIFF
--- a/internal/datacoord/handler.go
+++ b/internal/datacoord/handler.go
@@ -847,6 +847,8 @@ func (h *ServerHandler) GenSnapshot(ctx context.Context, collectionID UniqueID) 
 			Schema:              schema,
 			NumShards:           int64(resp.GetShardsNum()),
 			NumPartitions:       resp.GetNumPartitions(),
+			ConsistencyLevel:    resp.GetConsistencyLevel(),
+			Properties:          common.CloneKeyValuePairs(resp.GetProperties()),
 			Partitions:          partitionMapping,
 			VirtualChannelNames: resp.GetVirtualChannelNames(),
 		},

--- a/internal/datacoord/handler_test.go
+++ b/internal/datacoord/handler_test.go
@@ -1908,6 +1908,77 @@ func TestGenSnapshot(t *testing.T) {
 	assert.Equal(t, []string{"dml_0_200v0", "dml_1_200v1"}, snapshotData.Collection.VirtualChannelNames)
 }
 
+func TestGenSnapshot_PreservesCollectionMetadata(t *testing.T) {
+	properties := []*commonpb.KeyValuePair{
+		{Key: common.CollectionTTLConfigKey, Value: "360"},
+		{Key: common.CollectionAutoCompactionKey, Value: "false"},
+		{Key: common.MmapEnabledKey, Value: "false"},
+		{Key: common.AllowInsertAutoIDKey, Value: "false"},
+	}
+	schema := newTestSchema()
+	schema.Properties = common.CloneKeyValuePairs(properties)
+
+	mixCoord := newMockMixCoord()
+	mockMeta := &meta{indexMeta: &indexMeta{}}
+	handler := &ServerHandler{
+		s: &Server{
+			broker: broker.NewCoordinatorBroker(mixCoord),
+			meta:   mockMeta,
+		},
+	}
+
+	mockDescribe := mockey.Mock((*mockMixCoord).DescribeCollectionInternal).To(
+		func(_ *mockMixCoord, _ context.Context, _ *milvuspb.DescribeCollectionRequest) (*milvuspb.DescribeCollectionResponse, error) {
+			return &milvuspb.DescribeCollectionResponse{
+				Status:              merr.Success(),
+				Schema:              schema,
+				ShardsNum:           1,
+				NumPartitions:       1,
+				ConsistencyLevel:    commonpb.ConsistencyLevel_Bounded,
+				Properties:          properties,
+				CollectionID:        200,
+				VirtualChannelNames: []string{"ch-1"},
+			}, nil
+		}).Build()
+	defer mockDescribe.UnPatch()
+
+	mockShowPartitions := mockey.Mock((*mockMixCoord).ShowPartitionsInternal).To(
+		func(_ *mockMixCoord, _ context.Context, _ *milvuspb.ShowPartitionsRequest) (*milvuspb.ShowPartitionsResponse, error) {
+			return &milvuspb.ShowPartitionsResponse{
+				Status:         merr.Success(),
+				PartitionIDs:   []int64{0},
+				PartitionNames: []string{"_default"},
+			}, nil
+		}).Build()
+	defer mockShowPartitions.UnPatch()
+
+	mockSeekPositions := mockey.Mock((*ServerHandler).GetSnapshotSeekPositions).To(
+		func(_ *ServerHandler, _ context.Context, _ UniqueID, _ ...UniqueID) ([]*msgpb.MsgPosition, uint64, error) {
+			return []*msgpb.MsgPosition{
+				{ChannelName: "ch-1", Timestamp: 100, MsgID: []byte{1}},
+			}, uint64(100), nil
+		}).Build()
+	defer mockSeekPositions.UnPatch()
+
+	mockIndexes := mockey.Mock((*indexMeta).GetIndexesForCollection).
+		Return([]*model.Index{}).
+		Build()
+	defer mockIndexes.UnPatch()
+
+	mockSelectSegments := mockey.Mock((*meta).SelectSegments).
+		Return([]*SegmentInfo{}).
+		Build()
+	defer mockSelectSegments.UnPatch()
+
+	snapshotData, err := handler.GenSnapshot(context.Background(), 200)
+	require.NoError(t, err)
+	require.NotNil(t, snapshotData.Collection)
+	assert.Equal(t, commonpb.ConsistencyLevel_Bounded, snapshotData.Collection.GetConsistencyLevel())
+	assert.Equal(t, properties, snapshotData.Collection.GetProperties())
+	require.NotEmpty(t, snapshotData.Collection.GetProperties())
+	assert.NotSame(t, properties[0], snapshotData.Collection.GetProperties()[0])
+}
+
 func TestGenSnapshot_UsesPerChannelSeekPositions(t *testing.T) {
 	schema := newTestSchema()
 	segCh1 := NewSegmentInfo(&datapb.SegmentInfo{

--- a/internal/datacoord/snapshot_manager.go
+++ b/internal/datacoord/snapshot_manager.go
@@ -807,7 +807,12 @@ func (sm *snapshotManager) RestoreCollection(
 	}
 
 	// preserve field ids
-	properties := collection.Properties
+	properties := common.CloneKeyValuePairs(collection.GetProperties())
+	if len(properties) == 0 {
+		// Snapshots created before collection metadata was populated in
+		// CollectionDescription keep these values in schema properties.
+		properties = common.CloneKeyValuePairs(schema.GetProperties())
+	}
 	properties = append(properties, &commonpb.KeyValuePair{
 		Key:   util.PreserveFieldIdsKey,
 		Value: strconv.FormatBool(true),

--- a/internal/datacoord/snapshot_manager_test.go
+++ b/internal/datacoord/snapshot_manager_test.go
@@ -19,6 +19,7 @@ package datacoord
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/bytedance/mockey"
@@ -41,6 +42,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/rootcoordpb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -2840,6 +2842,91 @@ func TestSnapshotManager_RestoreCollection_SchemaNameAndDbName(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, targetCollectionName, schema.Name, "schema.Name should be updated to target collection name")
 	assert.Equal(t, targetDbName, schema.DbName, "schema.DbName should be updated to target database name")
+}
+
+func TestSnapshotManager_RestoreCollection_PreservesMetadata(t *testing.T) {
+	for _, legacy := range []bool{false, true} {
+		name := "current snapshot"
+		if legacy {
+			name = "snapshot created before metadata fix"
+		}
+		t.Run(name, func(t *testing.T) {
+			sourceProperties := []*commonpb.KeyValuePair{
+				{Key: common.CollectionTTLConfigKey, Value: "360"},
+				{Key: common.CollectionAutoCompactionKey, Value: "false"},
+				{Key: common.MmapEnabledKey, Value: "false"},
+				{Key: common.AllowInsertAutoIDKey, Value: "false"},
+			}
+			schemaProperties := common.CloneKeyValuePairs(sourceProperties)
+			schemaProperties = append(schemaProperties, &commonpb.KeyValuePair{
+				Key:   common.ConsistencyLevel,
+				Value: strconv.Itoa(int(commonpb.ConsistencyLevel_Bounded)),
+			})
+
+			collection := &datapb.CollectionDescription{
+				Schema: &schemapb.CollectionSchema{
+					Name:       "original_collection",
+					DbName:     "original_db",
+					Properties: schemaProperties,
+					Fields: []*schemapb.FieldSchema{
+						{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+					},
+				},
+				NumShards: 1,
+			}
+			if !legacy {
+				collection.ConsistencyLevel = commonpb.ConsistencyLevel_Bounded
+				collection.Properties = common.CloneKeyValuePairs(sourceProperties)
+			}
+
+			originalCollectionProperties := common.CloneKeyValuePairs(collection.GetProperties())
+			originalSchemaProperties := common.CloneKeyValuePairs(collection.GetSchema().GetProperties())
+
+			var capturedReq *milvuspb.CreateCollectionRequest
+			fakeBroker := &embeddedBroker{}
+			mockCreateCollection := mockey.Mock((*embeddedBroker).CreateCollection).To(
+				func(_ *embeddedBroker, _ context.Context, req *milvuspb.CreateCollectionRequest) error {
+					capturedReq = proto.Clone(req).(*milvuspb.CreateCollectionRequest)
+					return nil
+				}).Build()
+			defer mockCreateCollection.UnPatch()
+
+			mockDescribeCollection := mockey.Mock((*embeddedBroker).DescribeCollectionByName).
+				Return(&milvuspb.DescribeCollectionResponse{
+					Status:       merr.Success(),
+					CollectionID: 12345,
+				}, nil).
+				Build()
+			defer mockDescribeCollection.UnPatch()
+
+			sm := &snapshotManager{broker: fakeBroker}
+			collectionID, err := sm.RestoreCollection(
+				context.Background(),
+				&SnapshotData{Collection: collection},
+				"target_collection",
+				"target_db",
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, int64(12345), collectionID)
+			require.NotNil(t, capturedReq)
+
+			requestProperties := common.KeyValuePairs(capturedReq.GetProperties()).ToMap()
+			for _, property := range sourceProperties {
+				assert.Equal(t, property.GetValue(), requestProperties[property.GetKey()])
+			}
+			assert.Equal(t, "true", requestProperties[util.PreserveFieldIdsKey])
+
+			if legacy {
+				assert.Equal(t, strconv.Itoa(int(commonpb.ConsistencyLevel_Bounded)), requestProperties[common.ConsistencyLevel])
+			} else {
+				assert.Equal(t, commonpb.ConsistencyLevel_Bounded, capturedReq.GetConsistencyLevel())
+			}
+
+			assert.Equal(t, originalCollectionProperties, common.KeyValuePairs(collection.GetProperties()))
+			assert.Equal(t, originalSchemaProperties, common.KeyValuePairs(collection.GetSchema().GetProperties()))
+		})
+	}
 }
 
 // --- Test DropSnapshotsByCollection ---

--- a/internal/datacoord/snapshot_manager_test.go
+++ b/internal/datacoord/snapshot_manager_test.go
@@ -38,6 +38,7 @@ import (
 	catalogmocks "github.com/milvus-io/milvus/internal/metastore/mocks"
 	"github.com/milvus-io/milvus/internal/mocks/distributed/mock_streaming"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/rootcoordpb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"

--- a/tests/go_client/testcases/snapshot_test.go
+++ b/tests/go_client/testcases/snapshot_test.go
@@ -669,8 +669,8 @@ func TestSnapshotRestoreWithMultiFields(t *testing.T) {
 	common.CheckErr(t, err, true)
 }
 
-// TestSnapshotRestoreEmptyCollection tests snapshot and restore of an empty collection
-// Verifies that schema and indexes are preserved correctly without any data
+// TestSnapshotRestoreEmptyCollection tests snapshot and restore of an empty collection.
+// It verifies that collection metadata, schema, and indexes are preserved without any data.
 func TestSnapshotRestoreEmptyCollection(t *testing.T) {
 	t.Parallel()
 
@@ -714,8 +714,19 @@ func TestSnapshotRestoreEmptyCollection(t *testing.T) {
 		WithField(stringArrayField).
 		WithDynamicFieldEnabled(true)
 
-	// Create collection with 3 shards
-	createOpt := client.NewCreateCollectionOption(collName, schema).WithShardNum(3)
+	// Create collection with non-default metadata and 3 shards.
+	expectedProperties := map[string]string{
+		common.CollectionTTLSeconds:         "360",
+		"collection.autocompaction.enabled": "false",
+		common.MmapEnabled:                  "false",
+		"allow_insert_auto_id":              "false",
+	}
+	createOpt := client.NewCreateCollectionOption(collName, schema).
+		WithShardNum(3).
+		WithConsistencyLevel(entity.ClBounded)
+	for key, value := range expectedProperties {
+		createOpt.WithProperty(key, value)
+	}
 	err := mc.CreateCollection(ctx, createOpt)
 	common.CheckErr(t, err, true)
 	collectionsToClean := []string{collName}
@@ -809,6 +820,11 @@ func TestSnapshotRestoreEmptyCollection(t *testing.T) {
 	// Step 10: Get restored collection info
 	restoredColl, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(restoredCollName))
 	common.CheckErr(t, err, true)
+	require.Equal(t, originalColl.ConsistencyLevel, restoredColl.ConsistencyLevel, "Consistency level should match")
+	for key, expectedValue := range expectedProperties {
+		require.Equal(t, expectedValue, originalColl.Properties[key], "Source collection property should match")
+		require.Equal(t, expectedValue, restoredColl.Properties[key], "Restored collection property should match")
+	}
 
 	// Step 11: Verify schema matches
 	mlog.Info(context.TODO(), "Verifying schema consistency")


### PR DESCRIPTION
issue: #52202
pr: #52205

## What changed

Backport the snapshot metadata fix to the 3.0 branch:

- Store the collection consistency level and properties in snapshot metadata.
- Restore those values while isolating restore-only property mutations.
- Recover metadata from schema properties for snapshots created before the
  fix.
- Add regression coverage for current snapshots, legacy snapshots, and the
  Go client restore flow.

## Why

Snapshot generation left the canonical consistency and property fields unset.
Restore consumed those empty fields, causing the target collection to use
Strong consistency and lose source collection settings despite reporting
success.

## Branch notes

The affected snapshot generation and restore paths match master. The change
applies cleanly without 3.0-specific behavior changes.

## Validation

- `git diff --check`
- Build and tests were not run for this 3.0 backport.
