### PR TITLE
test: extend HNSW PQ index build timeout

### DIFF
--- a/tests/python_client/testcases/indexes/test_hnsw_pq.py
+++ b/tests/python_client/testcases/indexes/test_hnsw_pq.py
@@ -12,6 +12,7 @@ pk_field_name = "id"
 vector_field_name = "vector"
 dim = ct.default_dim
 default_nb = ct.default_nb
+index_build_timeout = 600
 default_build_params = {"M": 16, "efConstruction": 200, "m": 64, "nbits": 8}
 default_search_params = {"ef": 64, "refine_k": 1}
 
@@ -50,7 +51,7 @@ class TestHnswPQBuildParams(TestMilvusClientV2Base):
                 client, collection_name, index_params, check_task=CheckTasks.err_res, check_items=params.get("expected")
             )
         else:
-            self.create_index(client, collection_name, index_params)
+            self.create_index(client, collection_name, index_params, timeout=index_build_timeout)
             self.wait_for_index_ready(client, collection_name, index_name=vector_field_name)
 
             # load collection


### PR DESCRIPTION
## What changed

Extend the synchronous index-build timeout to 600 seconds for valid HNSW_PQ build-parameter cases. Invalid-parameter cases retain the existing timeout and error assertions.

## Root cause

`TestMilvusClientV2Base.create_index` forwards its 120-second default timeout to PyMilvus synchronous `create_index`. Under constrained index-worker slots, valid builds can remain queued beyond 120 seconds, so `wait_for_creating_index` raises `Retry timeout: 120s` before this test reaches its later index-ready check. The Milvus process remains healthy and the queued builds continue making progress.

Local reproduction on a healthy standalone with `totalSlots=1`:

- `params16`: 9 failures in 101 runs
- `params21`: 8 failures in 101 runs
- All target failures had the same synchronous create-index timeout signature; there were no network, OOM, or worker-crash failures.

## Verification

- Same constrained-slot pressure and the same `total_runs`: 505/505 node executions passed; `params16` and `params21` each passed 101/101.
- 84 target calls completed successfully after exceeding the old 120-second boundary; the longest was 190.237 seconds.
- Fresh default configuration, confirmed `totalSlots=16`: full 69-case parameter family completed with 68 passed and one existing skip.
- Ruff check, Ruff format check, and `git diff --check` passed.

## Scope note

The existing `params64` skip is unchanged. This PR does not claim to restore that skipped coverage or change index scheduling behavior.
