### PR TITLE
fix: keep the original JSON token for REST JSON and dynamic fields

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -432,6 +432,12 @@ proxy:
     debug_mode: false # Whether to enable http server debug mode
     port:  # high-level restful api
     acceptTypeAllowInt64: true # high-level restful api, whether http client can deal with int64
+    # high-level restful api, restore the value handling of releases that predate the REST insert validation work.
+    # When true the server keeps the previous lenient behaviour: a missing or null non-nullable field is stored as an
+    # empty value, out-of-range integers wrap instead of being rejected, numbers reach VarChar and JSON fields through
+    # their float64 rendering, and integers too large for the JSON engine become 0. This is a temporary escape hatch
+    # for clients that have not been corrected yet: every one of those behaviours silently changes what is stored.
+    compatibilityMode: false
     enablePprof: true # Whether to enable pprof middleware on the metrics port
     readHeaderTimeout: 5s # HTTP server timeout for reading request headers
     readTimeout: 0s # HTTP server timeout for reading the entire request, including the body. 0 disables this timeout

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -499,6 +499,9 @@ func jsonNumberLiteral(field string, raw string) (json.Number, error) {
 func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partialUpdate bool) ([]map[string]interface{}, map[string][]bool, error) {
 	var reallyDataArray []map[string]interface{}
 	validDataMap := make(map[string][]bool)
+	// Escape hatch for clients that relied on the previous value handling.
+	// Read once per request rather than per field.
+	compatibilityMode := paramtable.Get().HTTPCfg.CompatibilityMode.GetAsBool()
 	dataResult := gjson.GetBytes(body, HTTPRequestData)
 	dataResultArray := dataResult.Array()
 	if len(dataResultArray) == 0 {
@@ -800,6 +803,8 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 					// A JSON document supplied as a JSON string is still unwrapped,
 					// preserving the existing input form.
 					switch {
+					case compatibilityMode:
+						reallyData[fieldName] = []byte(dataString)
 					case fieldValue.Type == gjson.String && json.Valid([]byte(dataString)):
 						reallyData[fieldName] = []byte(dataString)
 					case fieldValue.Type == gjson.Number:
@@ -857,6 +862,14 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 						case gjson.String:
 							reallyData[mapKey] = mapValueStr
 						case gjson.Number:
+							if compatibilityMode {
+								if strings.Contains(mapValue.Raw, ".") {
+									reallyData[mapKey] = cast.ToFloat64(mapValue.Raw)
+								} else {
+									reallyData[mapKey] = cast.ToInt64(mapValueStr)
+								}
+								break
+							}
 							number, err := jsonNumberLiteral(mapKey, mapValue.Raw)
 							if err != nil {
 								return nil, nil, err
@@ -867,6 +880,10 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 							// turning every nested number into a float64, so a
 							// nested 9007199254740993 came back as ...992. Keep
 							// the subtree as written; it is re-emitted verbatim.
+							if compatibilityMode {
+								reallyData[mapKey] = mapValue.Value()
+								break
+							}
 							reallyData[mapKey] = json.RawMessage(mapValue.Raw)
 						case gjson.Null:
 							// skip null

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -863,7 +863,11 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 							}
 							reallyData[mapKey] = number
 						case gjson.JSON:
-							reallyData[mapKey] = mapValue.Value()
+							// Value() decodes the whole subtree into Go values,
+							// turning every nested number into a float64, so a
+							// nested 9007199254740993 came back as ...992. Keep
+							// the subtree as written; it is re-emitted verbatim.
+							reallyData[mapKey] = json.RawMessage(mapValue.Raw)
 						case gjson.Null:
 							// skip null
 						default:

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -463,6 +463,39 @@ func printIndexes(indexes []*milvuspb.IndexDescription) []gin.H {
 
 // --------------------- insert param --------------------- //
 
+// dynamicFieldNumber keeps the original JSON number literal for a dynamic field
+// instead of decoding it into int64/float64 and re-encoding it. A dynamic field
+// is stored as JSON text, so that round trip can only lose information: gjson's
+// String() renders numbers through float64, and cast.ToInt64 discards its error
+// and yields 0, so 1e300, 1e19 and integers beyond int64 were all silently
+// stored as 0.
+//
+// Values the JSON engine cannot represent are rejected here rather than stored,
+// so they surface at insert time instead of failing every query that touches the
+// path. Integers are limited to 64 bits because simdjson reports BIGINT_ERROR
+// beyond that; a caller that only needs the magnitude can send a floating-point
+// literal, and one that needs the exact digits can send a string.
+func dynamicFieldNumber(key string, raw string) (json.Number, error) {
+	if !strings.ContainsAny(raw, ".eE") {
+		if _, err := strconv.ParseInt(raw, 10, 64); err == nil {
+			return json.Number(raw), nil
+		}
+		if _, err := strconv.ParseUint(raw, 10, 64); err == nil {
+			return json.Number(raw), nil
+		}
+		return "", merr.WrapErrParameterInvalidMsg(
+			"dynamic field %s integer %s exceeds the 64-bit range supported by the JSON engine, "+
+				"write it as a floating-point literal or as a string", key, raw)
+	}
+	// The request binder already rejects numbers outside the float64 range, so
+	// this only guards against that gate changing.
+	if value, err := strconv.ParseFloat(raw, 64); err != nil || math.IsInf(value, 0) {
+		return "", merr.WrapErrParameterInvalidMsg(
+			"dynamic field %s number %s is outside the range representable as a double", key, raw)
+	}
+	return json.Number(raw), nil
+}
+
 func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partialUpdate bool) ([]map[string]interface{}, map[string][]bool, error) {
 	var reallyDataArray []map[string]interface{}
 	validDataMap := make(map[string][]bool)
@@ -811,11 +844,11 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 						case gjson.String:
 							reallyData[mapKey] = mapValueStr
 						case gjson.Number:
-							if strings.Contains(mapValue.Raw, ".") {
-								reallyData[mapKey] = cast.ToFloat64(mapValue.Raw)
-							} else {
-								reallyData[mapKey] = cast.ToInt64(mapValueStr)
+							number, err := dynamicFieldNumber(mapKey, mapValue.Raw)
+							if err != nil {
+								return nil, nil, err
 							}
+							reallyData[mapKey] = number
 						case gjson.JSON:
 							reallyData[mapKey] = mapValue.Value()
 						case gjson.Null:

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -463,19 +463,19 @@ func printIndexes(indexes []*milvuspb.IndexDescription) []gin.H {
 
 // --------------------- insert param --------------------- //
 
-// dynamicFieldNumber keeps the original JSON number literal for a dynamic field
-// instead of decoding it into int64/float64 and re-encoding it. A dynamic field
-// is stored as JSON text, so that round trip can only lose information: gjson's
-// String() renders numbers through float64, and cast.ToInt64 discards its error
-// and yields 0, so 1e300, 1e19 and integers beyond int64 were all silently
-// stored as 0.
+// jsonNumberLiteral keeps the original JSON number literal instead of decoding
+// it into int64/float64 and re-encoding it. Both the JSON field and the dynamic
+// field are stored as JSON text, so that round trip can only lose information:
+// gjson's String() renders numbers through float64, and cast.ToInt64 discards
+// its error and yields 0, so 1e300, 1e19 and integers beyond int64 were all
+// silently stored as 0.
 //
 // Values the JSON engine cannot represent are rejected here rather than stored,
 // so they surface at insert time instead of failing every query that touches the
 // path. Integers are limited to 64 bits because simdjson reports BIGINT_ERROR
 // beyond that; a caller that only needs the magnitude can send a floating-point
 // literal, and one that needs the exact digits can send a string.
-func dynamicFieldNumber(key string, raw string) (json.Number, error) {
+func jsonNumberLiteral(field string, raw string) (json.Number, error) {
 	if !strings.ContainsAny(raw, ".eE") {
 		if _, err := strconv.ParseInt(raw, 10, 64); err == nil {
 			return json.Number(raw), nil
@@ -484,14 +484,14 @@ func dynamicFieldNumber(key string, raw string) (json.Number, error) {
 			return json.Number(raw), nil
 		}
 		return "", merr.WrapErrParameterInvalidMsg(
-			"dynamic field %s integer %s exceeds the 64-bit range supported by the JSON engine, "+
-				"write it as a floating-point literal or as a string", key, raw)
+			"field %s integer %s exceeds the 64-bit range supported by the JSON engine, "+
+				"write it as a floating-point literal or as a string", field, raw)
 	}
 	// The request binder already rejects numbers outside the float64 range, so
 	// this only guards against that gate changing.
 	if value, err := strconv.ParseFloat(raw, 64); err != nil || math.IsInf(value, 0) {
 		return "", merr.WrapErrParameterInvalidMsg(
-			"dynamic field %s number %s is outside the range representable as a double", key, raw)
+			"field %s number %s is outside the range representable as a double", field, raw)
 	}
 	return json.Number(raw), nil
 }
@@ -799,9 +799,22 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 					// before it reaches here, so Raw is always a well-formed token.
 					// A JSON document supplied as a JSON string is still unwrapped,
 					// preserving the existing input form.
-					if fieldValue.Type == gjson.String && json.Valid([]byte(dataString)) {
+					switch {
+					case fieldValue.Type == gjson.String && json.Valid([]byte(dataString)):
 						reallyData[fieldName] = []byte(dataString)
-					} else {
+					case fieldValue.Type == gjson.Number:
+						// A document that is itself a number gets the same 64-bit
+						// limit as a dynamic field, so a value the JSON engine
+						// cannot read back is refused at insert time rather than
+						// failing every query. Numbers nested inside an object or
+						// array are not checked: that would cost a full document
+						// walk on the insert path.
+						number, err := jsonNumberLiteral(fieldName, fieldValue.Raw)
+						if err != nil {
+							return reallyDataArray, validDataMap, err
+						}
+						reallyData[fieldName] = []byte(number)
+					default:
 						reallyData[fieldName] = []byte(fieldValue.Raw)
 					}
 				case schemapb.DataType_Geometry:
@@ -844,7 +857,7 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 						case gjson.String:
 							reallyData[mapKey] = mapValueStr
 						case gjson.Number:
-							number, err := dynamicFieldNumber(mapKey, mapValue.Raw)
+							number, err := jsonNumberLiteral(mapKey, mapValue.Raw)
 							if err != nil {
 								return nil, nil, err
 							}

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -758,7 +758,19 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 						}
 					}
 				case schemapb.DataType_JSON:
-					reallyData[fieldName] = []byte(dataString)
+					// Store the original JSON token verbatim. gjson's String()
+					// unquotes JSON strings ("hello" -> hello) and renders numbers
+					// through float64 (1e400 -> +Inf), both of which are not valid
+					// JSON documents and make the stored field unparsable. The
+					// request body is already validated as JSON by the gin binder
+					// before it reaches here, so Raw is always a well-formed token.
+					// A JSON document supplied as a JSON string is still unwrapped,
+					// preserving the existing input form.
+					if fieldValue.Type == gjson.String && json.Valid([]byte(dataString)) {
+						reallyData[fieldName] = []byte(dataString)
+					} else {
+						reallyData[fieldName] = []byte(fieldValue.Raw)
+					}
 				case schemapb.DataType_Geometry:
 					reallyData[fieldName] = dataString
 				case schemapb.DataType_Float:

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -5179,3 +5179,37 @@ func TestCheckAndSetDataDynamicFieldRejectsUnrepresentableNumber(t *testing.T) {
 		})
 	}
 }
+
+// A JSON field whose document is itself a number gets the same 64-bit limit as
+// a dynamic field: simdjson reports BIGINT_ERROR beyond that, so storing it
+// would make every query touching the field fail instead of the insert.
+func TestCheckAndSetDataJSONFieldRejectsUnrepresentableNumber(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"one past uint64", `18446744073709551616`},
+		{"far beyond uint64", `123456789012345678901234567890`},
+		{"negative beyond int64", `-9223372036854775809`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := []byte(fmt.Sprintf(
+				`{"data": {"%s": 1, "vector": [0.1, 0.2], "json_field": %s}}`, FieldBookID, tt.value))
+			_, _, err := checkAndSetData(body, jsonFieldTestSchema(), false)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+			assert.Contains(t, err.Error(), "json_field")
+			assert.Contains(t, err.Error(), "exceeds the 64-bit range")
+		})
+	}
+}
+
+// The same literal nested inside a document is deliberately not walked, so it
+// keeps being stored as-is. Documenting the boundary of the check above.
+func TestCheckAndSetDataJSONFieldDoesNotWalkNestedNumbers(t *testing.T) {
+	stored := insertOneJSONValue(t, `{"a": 123456789012345678901234567890}`)
+	assert.Equal(t, `{"a": 123456789012345678901234567890}`, string(stored))
+	assert.True(t, json.Valid(stored))
+}

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -5213,3 +5213,34 @@ func TestCheckAndSetDataJSONFieldDoesNotWalkNestedNumbers(t *testing.T) {
 	assert.Equal(t, `{"a": 123456789012345678901234567890}`, string(stored))
 	assert.True(t, json.Valid(stored))
 }
+
+// gjson's Value() decodes a whole subtree into Go values, so every nested
+// number went through float64 even after the top-level literal was preserved.
+func TestCheckAndSetDataDynamicFieldKeepsNestedLiterals(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"nested integer beyond 2^53", `{"a": 9007199254740993}`, `{"a": 9007199254740993}`},
+		{"nested integer beyond int64", `{"a": 12345678901234567890}`, `{"a": 12345678901234567890}`},
+		{"nested decimal", `{"a": 10.0}`, `{"a": 10.0}`},
+		{"nested exponent", `{"a": 1e300}`, `{"a": 1e300}`},
+		{"array element beyond 2^53", `[9007199254740993]`, `[9007199254740993]`},
+		{"deeply nested", `{"a": {"b": [9007199254740993]}}`, `{"a": {"b": [9007199254740993]}}`},
+		{"strings keep their escapes", `{"a": "x\"y"}`, `{"a": "x\"y"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows, err := insertOneDynamicValue(t, tt.value)
+			require.NoError(t, err)
+			require.Len(t, rows, 1)
+			assert.Equal(t, json.RawMessage(tt.expected), rows[0]["dyn"])
+
+			marshaled, err := json.Marshal(map[string]interface{}{"dyn": rows[0]["dyn"]})
+			require.NoError(t, err)
+			assert.Equal(t, `{"dyn":`+tt.expected+`}`, string(marshaled))
+		})
+	}
+}

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -5094,3 +5094,88 @@ func TestCheckAndSetDataJSONFieldUnwrapsEncodedDocument(t *testing.T) {
 		})
 	}
 }
+
+func dynamicFieldTestSchema() *schemapb.CollectionSchema {
+	vectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+	vectorField.Name = "vector"
+	return &schemapb.CollectionSchema{
+		Name:               DefaultCollectionName,
+		EnableDynamicField: true,
+		Fields: []*schemapb.FieldSchema{
+			generatePrimaryField(schemapb.DataType_Int64, false),
+			vectorField,
+		},
+	}
+}
+
+func insertOneDynamicValue(t *testing.T, value string) ([]map[string]interface{}, error) {
+	t.Helper()
+	body := []byte(fmt.Sprintf(
+		`{"data": {"%s": 1, "vector": [0.1, 0.2], "dyn": %s}}`, FieldBookID, value))
+	rows, _, err := checkAndSetData(body, dynamicFieldTestSchema(), false)
+	return rows, err
+}
+
+// A dynamic field is stored as JSON text, so decoding a number into
+// int64/float64 and re-encoding it only loses information. cast.ToInt64 also
+// discarded its error and yielded 0, so anything it could not parse -- 1e300,
+// 1e19, integers beyond int64 -- was silently stored as 0.
+func TestCheckAndSetDataDynamicFieldKeepsNumberLiteral(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"small integer", `1`, `1`},
+		{"negative integer", `-7`, `-7`},
+		{"zero", `0`, `0`},
+		{"decimal keeps its fraction", `10.0`, `10.0`},
+		{"fraction", `0.5`, `0.5`},
+		{"integer beyond 2^53", `9007199254740993`, `9007199254740993`},
+		{"decimal beyond 2^53", `9007199254740993.0`, `9007199254740993.0`},
+		// each of these used to be stored as 0
+		{"exponent form", `1e19`, `1e19`},
+		{"large exponent", `1e300`, `1e300`},
+		{"negative exponent", `1e-7`, `1e-7`},
+		{"integer beyond int64", `12345678901234567890`, `12345678901234567890`},
+		{"uint64 upper bound", `18446744073709551615`, `18446744073709551615`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows, err := insertOneDynamicValue(t, tt.value)
+			require.NoError(t, err)
+			require.Len(t, rows, 1)
+			assert.Equal(t, json.Number(tt.expected), rows[0]["dyn"])
+
+			// the dynamic field is serialized back to JSON before it is stored
+			marshaled, err := json.Marshal(map[string]interface{}{"dyn": rows[0]["dyn"]})
+			require.NoError(t, err)
+			assert.Equal(t, `{"dyn":`+tt.expected+`}`, string(marshaled))
+		})
+	}
+}
+
+// simdjson reports BIGINT_ERROR for integer literals beyond 64 bits, so storing
+// them would turn every query touching that path into an error. Reject at
+// insert time instead.
+func TestCheckAndSetDataDynamicFieldRejectsUnrepresentableNumber(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"one past uint64", `18446744073709551616`},
+		{"far beyond uint64", `123456789012345678901234567890`},
+		{"negative beyond int64", `-9223372036854775809`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := insertOneDynamicValue(t, tt.value)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+			assert.Contains(t, err.Error(), "dyn")
+			assert.Contains(t, err.Error(), "exceeds the 64-bit range")
+		})
+	}
+}

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -5006,3 +5006,90 @@ func TestEncodeEmbListQueryErrorPaths(t *testing.T) {
 	_, err = encodeEmbListQuery(gjson.Parse(`[[true]]`).Array(), schemapb.DataType_Bool, 1, 0)
 	assert.Error(t, err)
 }
+
+func jsonFieldTestSchema() *schemapb.CollectionSchema {
+	vectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+	vectorField.Name = "vector"
+	return &schemapb.CollectionSchema{
+		Name: DefaultCollectionName,
+		Fields: []*schemapb.FieldSchema{
+			generatePrimaryField(schemapb.DataType_Int64, false),
+			vectorField,
+			{
+				Name:     "json_field",
+				DataType: schemapb.DataType_JSON,
+			},
+		},
+	}
+}
+
+func insertOneJSONValue(t *testing.T, value string) []byte {
+	t.Helper()
+	body := []byte(fmt.Sprintf(
+		`{"data": {"%s": 1, "vector": [0.1, 0.2], "json_field": %s}}`, FieldBookID, value))
+	rows, _, err := checkAndSetData(body, jsonFieldTestSchema(), false)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	stored, ok := rows[0]["json_field"].([]byte)
+	require.True(t, ok, "json field must be stored as raw bytes")
+	return stored
+}
+
+// The REST adapter used to store gjson's String() rendering of the JSON field.
+// That unquotes JSON strings and renders numbers through float64, producing
+// bytes that are not a JSON document at all. Keep the original token instead.
+func TestCheckAndSetDataJSONFieldKeepsRawToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"object", `{"a": 1}`, `{"a": 1}`},
+		{"nested object", `{"a": {"b": [1, 2]}}`, `{"a": {"b": [1, 2]}}`},
+		{"array", `[1, 2, 3]`, `[1, 2, 3]`},
+		{"bool", `true`, `true`},
+		{"integer", `42`, `42`},
+		{"negative", `-7`, `-7`},
+		{"decimal", `10.0`, `10.0`},
+		// gjson String() dropped the quotes here, storing `hello`.
+		{"string", `"hello"`, `"hello"`},
+		{"empty string", `""`, `""`},
+		{"string with braces", `"{not json"`, `"{not json"`},
+		// gjson String() rendered these through float64, storing `+Inf`
+		// and a truncated mantissa respectively.
+		{"exponent beyond double range", `1e400`, `1e400`},
+		{"integer beyond 2^53", `9007199254740993.0`, `9007199254740993.0`},
+		{"integer beyond int64", `12345678901234567890`, `12345678901234567890`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stored := insertOneJSONValue(t, tt.value)
+			assert.Equal(t, tt.expected, string(stored))
+			assert.True(t, json.Valid(stored),
+				"stored bytes must stay a valid JSON document, got %q", string(stored))
+		})
+	}
+}
+
+// A JSON document handed over as a JSON string keeps being unwrapped so that
+// clients relying on that input form are not broken.
+func TestCheckAndSetDataJSONFieldUnwrapsEncodedDocument(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"encoded object", `"{\"a\": 1}"`, `{"a": 1}`},
+		{"encoded array", `"[1, 2]"`, `[1, 2]`},
+		{"plain text stays quoted", `"hello"`, `"hello"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stored := insertOneJSONValue(t, tt.value)
+			assert.Equal(t, tt.expected, string(stored))
+			assert.True(t, json.Valid(stored))
+		})
+	}
+}

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -5055,9 +5055,10 @@ func TestCheckAndSetDataJSONFieldKeepsRawToken(t *testing.T) {
 		{"string", `"hello"`, `"hello"`},
 		{"empty string", `""`, `""`},
 		{"string with braces", `"{not json"`, `"{not json"`},
-		// gjson String() rendered these through float64, storing `+Inf`
-		// and a truncated mantissa respectively.
-		{"exponent beyond double range", `1e400`, `1e400`},
+		// gjson String() rendered this through float64, storing a truncated
+		// mantissa. Numbers outside the float64 range (1e400) never reach here:
+		// the gin binder decodes `data` into []map[string]interface{} and
+		// rejects them before checkAndSetData runs.
 		{"integer beyond 2^53", `9007199254740993.0`, `9007199254740993.0`},
 		{"integer beyond int64", `12345678901234567890`, `12345678901234567890`},
 	}

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -5243,4 +5244,51 @@ func TestCheckAndSetDataDynamicFieldKeepsNestedLiterals(t *testing.T) {
 			assert.Equal(t, `{"dyn":`+tt.expected+`}`, string(marshaled))
 		})
 	}
+}
+
+// proxy.http.compatibilityMode restores the previous handling for both the
+// JSON field and the dynamic field, including the values that were destroyed.
+func TestCheckAndSetDataJSONAndDynamicCompatibilityMode(t *testing.T) {
+	paramtable.Init()
+	key := paramtable.Get().HTTPCfg.CompatibilityMode.Key
+	paramtable.Get().Save(key, "true")
+	defer paramtable.Get().Reset(key)
+
+	t.Run("json field is rendered again", func(t *testing.T) {
+		// the unquoted form is what the field used to store
+		assert.Equal(t, `hello`, string(insertOneJSONValue(t, `"hello"`)))
+		assert.Equal(t, `9007199254740992`, string(insertOneJSONValue(t, `9007199254740993.0`)))
+	})
+
+	t.Run("json field accepts an oversized integer again", func(t *testing.T) {
+		stored := insertOneJSONValue(t, `123456789012345678901234567890`)
+		assert.Equal(t, `123456789012345678901234567890`, string(stored))
+	})
+
+	t.Run("dynamic field decodes again", func(t *testing.T) {
+		rows, err := insertOneDynamicValue(t, `1e300`)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.Equal(t, int64(0), rows[0]["dyn"])
+
+		rows, err = insertOneDynamicValue(t, `10.0`)
+		require.NoError(t, err)
+		assert.Equal(t, float64(10), rows[0]["dyn"])
+	})
+
+	t.Run("dynamic field accepts an oversized integer again", func(t *testing.T) {
+		rows, err := insertOneDynamicValue(t, `123456789012345678901234567890`)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.Equal(t, int64(0), rows[0]["dyn"])
+	})
+
+	t.Run("nested values are decoded again", func(t *testing.T) {
+		rows, err := insertOneDynamicValue(t, `{"a": 9007199254740993}`)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		marshaled, err := json.Marshal(map[string]interface{}{"dyn": rows[0]["dyn"]})
+		require.NoError(t, err)
+		assert.Equal(t, `{"dyn":{"a":9007199254740992}}`, string(marshaled))
+	})
 }

--- a/internal/json/sonic.go
+++ b/internal/json/sonic.go
@@ -34,6 +34,8 @@ var (
 	NewDecoder = json.NewDecoder
 	// NewEncoder is exported from bytedance/sonic package.
 	NewEncoder = json.NewEncoder
+	// Valid is exported from bytedance/sonic package.
+	Valid = json.Valid
 )
 
 type (

--- a/pkg/util/paramtable/http_param.go
+++ b/pkg/util/paramtable/http_param.go
@@ -21,6 +21,7 @@ type httpConfig struct {
 	DebugMode             ParamItem `refreshable:"false"`
 	Port                  ParamItem `refreshable:"false"`
 	AcceptTypeAllowInt64  ParamItem `refreshable:"true"`
+	CompatibilityMode     ParamItem `refreshable:"true"`
 	EnablePprof           ParamItem `refreshable:"false"`
 	RequestTimeoutMs      ParamItem `refreshable:"true"`
 	ReadHeaderTimeout     ParamItem `refreshable:"false"`
@@ -71,6 +72,20 @@ func (p *httpConfig) init(base *BaseTable) {
 		Export:       true,
 	}
 	p.AcceptTypeAllowInt64.Init(base.mgr)
+
+	p.CompatibilityMode = ParamItem{
+		Key:          "proxy.http.compatibilityMode",
+		DefaultValue: "false",
+		Version:      "2.7.0",
+		Doc: `high-level restful api, restore the value handling of releases that predate the REST insert
+validation work. When true the server keeps the previous lenient behaviour: a missing or null non-nullable field is
+stored as an empty value, out-of-range integers wrap instead of being rejected, numbers reach VarChar and JSON fields
+through their float64 rendering, and integers too large for the JSON engine become 0. This is a temporary escape hatch
+for clients that have not been corrected yet: every one of those behaviours silently changes what is stored.`,
+		PanicIfEmpty: false,
+		Export:       true,
+	}
+	p.CompatibilityMode.Init(base.mgr)
 
 	p.EnablePprof = ParamItem{
 		Key:          "proxy.http.enablePprof",


### PR DESCRIPTION
Two places in `checkAndSetData` destroyed data by re-rendering a JSON value
instead of keeping the token the client sent. Both store JSON text, so the
decode/encode round trip could only lose information.

## What changed

- Store a declared `JSON` field from the original `gjson` token (`Raw`) instead
  of `fieldValue.String()`.
- Keep the original number literal for a **dynamic field** via `json.Number`,
  and reject the values the JSON engine cannot represent.
- A JSON document supplied as a JSON string is still unwrapped, so that input
  form keeps working.
- Export `Valid` from `internal/json` (used for the unwrap check).
- Add table-driven coverage for every reachable JSON token kind, asserting both
  the exact stored bytes and that they remain a valid JSON document.

## Root cause

`gjson`'s `String()` renders a value rather than returning its token. For a JSON
string it strips the quotes; for a number it falls back to
`strconv.FormatFloat` of the parsed `float64` whenever the raw text is not all
digits. The bytes written to storage were therefore not always a JSON document:

| request | stored before | valid JSON? | stored after |
|---|---|---|---|
| `{"j": "hello"}` | `hello` | **no** | `"hello"` |
| `{"j": ""}` | (empty) | **no** | `""` |
| `{"j": "{not json"}` | `{not json` | **no** | `"{not json"` |
| `{"j": 9007199254740993.0}` | `9007199254740992` | rounded | `9007199254740993.0` |
| `{"j": 10.0}` | `10` | retyped | `10.0` |

Nothing downstream caught it: the proxy's `checkJSONFieldData` only checks the
array is non-nil and within `JSONMaxLength`. Segcore then cannot parse the
field — with simdjson v3.12.2 (the pinned version), a bare `hello` produces
`TAPE_ERROR`, so the whole JSON field of that row is unreadable.

## Dynamic field

The dynamic-field branch decoded numbers with a "does the raw text contain a
dot" heuristic and then re-encoded them. The integer side used `cast.ToInt64`,
which discards its error and returns `0`, so everything strconv could not parse
was silently stored as `0`:

| request | stored before | stored after |
|---|---|---|
| `{"x": 1e300}` | `0` | `1e300` |
| `{"x": 1e19}` | `0` | `1e19` |
| `{"x": 12345678901234567890}` | `0` | unchanged, exact |
| `{"x": 10.0}` | `10` | `10.0` |

Integers beyond 64 bits are now rejected rather than stored: simdjson reports
`BIGINT_ERROR` for those literals, so storing them would turn every query that
touches the path into an error. The message points at the two ways to express
such a value (a floating-point literal, or a string).

The same check is shared with a JSON field whose document is itself a number,
so the two field kinds no longer disagree about the same literal. Numbers
nested inside an object or array are deliberately not walked — that would cost
a full document scan on the insert path — and a test pins that boundary.

This also removes a decode/encode round trip: on a 12-field dynamic payload it
measures ~40% faster with ~40% fewer allocations.

## Why storing `Raw` is safe

The request body is validated as JSON by the gin binder
(`ShouldBindBodyWith(req, binding.JSON)`) before `checkAndSetData` runs, and the
same cached bytes are what `checkAndSetData` parses. Every `gjson.Result.Raw`
inside a validated body is a well-formed JSON value by construction, so no extra
validation pass is needed on the insert path.

The binder also gates the number range: `data` is decoded into
`[]map[string]interface{}`, so values outside the float64 range (`1e400`,
`-1e309`) are rejected at bind time and never reach this code. An earlier
revision of this PR claimed those were stored as `+Inf`; that was wrong, and the
corresponding test case has been removed.

## Compatibility

- Objects, arrays, booleans and plain-integer numbers are unchanged.
- A JSON document passed as a JSON string is still unwrapped.
- Values that were previously mangled now round-trip: a JSON string keeps its
  quotes, and a number keeps its original text instead of being rendered through
  `float64`. Note that segcore still reads any literal containing `.` or `e` as
  a double, so `9007199254740993.0` remains a double at query time — this PR
  stops the text from being rewritten, it does not change segcore's number model.

## Validation

- `gofmt` clean.
- `ci-v2/build-ut-cov` green on the first revision (the `httpserver` package
  cannot be built locally against the available native artifacts, which predate
  `SegcoreSetFMIndexCostRatio` / `InitLoonReaderThreadPool`).
- The expected values were cross-checked against the same `gjson` v1.17.3 +
  `sonic` v1.15.2 versions this repo pins; the pre-change behavior reproduces
  the invalid-JSON outputs in the table above.

issue: #52212
