### PR TITLE
enhance: support mixed exact and prefix removals in composite txn

### DIFF
--- a/internal/kv/etcd/embed_etcd_kv.go
+++ b/internal/kv/etcd/embed_etcd_kv.go
@@ -27,7 +27,7 @@ import (
 	"go.etcd.io/etcd/server/v3/embed"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/v3client"
 
-	"github.com/milvus-io/milvus/pkg/v3/kv"
+	kvpkg "github.com/milvus-io/milvus/pkg/v3/kv"
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/util"
@@ -37,7 +37,7 @@ import (
 )
 
 // implementation assertion
-var _ kv.MetaKv = (*EmbedEtcdKV)(nil)
+var _ kvpkg.MetaKv = (*EmbedEtcdKV)(nil)
 
 const (
 	defaultRetryCount    = 3
@@ -583,6 +583,9 @@ func (kv *EmbedEtcdKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves m
 // @removals and removes every key under the prefixes in @prefixRemovals, all
 // in one transaction.
 func (kv *EmbedEtcdKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	if err := kvpkg.ValidateNoSaveUnderRemovedPrefix(saves, prefixRemovals); err != nil {
+		return err
+	}
 	cmps, err := parsePredicates(kv.rootPath, preds...)
 	if err != nil {
 		return err

--- a/internal/kv/etcd/embed_etcd_kv.go
+++ b/internal/kv/etcd/embed_etcd_kv.go
@@ -579,6 +579,45 @@ func (kv *EmbedEtcdKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves m
 	return nil
 }
 
+// MultiSaveAndRemoveMixed saves kv in @saves, removes the exact keys in
+// @removals and removes every key under the prefixes in @prefixRemovals, all
+// in one transaction.
+func (kv *EmbedEtcdKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	cmps, err := parsePredicates(kv.rootPath, preds...)
+	if err != nil {
+		return err
+	}
+
+	ops := make([]clientv3.Op, 0, len(saves)+len(removals)+len(prefixRemovals))
+	// use complement to remove keys that are not in saves
+	saveKeys := typeutil.NewSet(lo.Keys(saves)...)
+	removeKeys := typeutil.NewSet(removals...)
+	removals = removeKeys.Complement(saveKeys).Collect()
+	for _, keyDelete := range removals {
+		ops = append(ops, clientv3.OpDelete(kv.GetPath(keyDelete)))
+	}
+	for _, keyDelete := range prefixRemovals {
+		ops = append(ops, clientv3.OpDelete(kv.GetPath(keyDelete), clientv3.WithPrefix()))
+	}
+
+	for key, value := range saves {
+		ops = append(ops, clientv3.OpPut(kv.GetPath(key), value))
+	}
+
+	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
+	defer cancel()
+
+	resp, err := kv.client.Txn(ctx1).If(cmps...).Then(ops...).Commit()
+	if err != nil {
+		return merr.WrapErrIoFailedReason("failed to execute transaction", err.Error())
+	}
+
+	if !resp.Succeeded {
+		return merr.WrapErrIoFailedReason("failed to execute transaction")
+	}
+	return nil
+}
+
 // MultiSaveBytesAndRemoveWithPrefix saves kv in @saves and removes the keys with given prefix in @removals.
 func (kv *EmbedEtcdKV) MultiSaveBytesAndRemoveWithPrefix(ctx context.Context, saves map[string][]byte, removals []string) error {
 	ops := make([]clientv3.Op, 0, len(saves)+len(removals))

--- a/internal/kv/etcd/embed_etcd_kv_test.go
+++ b/internal/kv/etcd/embed_etcd_kv_test.go
@@ -926,6 +926,46 @@ func (s *EmbedEtcdKVSuite) TestTxnWithPredicates() {
 	}
 }
 
+func (s *EmbedEtcdKVSuite) TestMultiSaveAndRemoveMixed() {
+	etcdKV := s.kv
+
+	prepareTests := map[string]string{
+		"mix/a-1":    "1",
+		"mix/a-1/c1": "11",
+		"mix/a-1/c2": "12",
+		"mix/a-10":   "10", // exact-remove canary: a prefix delete of "mix/a-1" would wipe it
+		"mix/b":      "b",
+	}
+	err := etcdKV.MultiSave(context.TODO(), prepareTests)
+	s.Require().NoError(err)
+
+	// failed predicate: the whole mixed txn must be a no-op.
+	err = etcdKV.MultiSaveAndRemoveMixed(context.TODO(),
+		map[string]string{"mix/new": "nv"}, []string{"mix/a-1"}, []string{"mix/a-1/"},
+		predicates.ValueEqual("mix/b", "not-b"))
+	s.Error(err)
+	keys, _, err := etcdKV.LoadWithPrefix(context.TODO(), "mix")
+	s.NoError(err)
+	s.Len(keys, 5)
+
+	err = etcdKV.MultiSaveAndRemoveMixed(context.TODO(),
+		map[string]string{"mix/new": "nv"}, []string{"mix/a-1"}, []string{"mix/a-1/"},
+		predicates.ValueEqual("mix/b", "b"))
+	s.NoError(err)
+
+	keys, vals, err := etcdKV.LoadWithPrefix(context.TODO(), "mix")
+	s.NoError(err)
+	got := make(map[string]string, len(keys))
+	for i, k := range keys {
+		got[k] = vals[i]
+	}
+	s.Equal(map[string]string{
+		etcdKV.GetPath("mix/a-10"): "10",
+		etcdKV.GetPath("mix/b"):    "b",
+		etcdKV.GetPath("mix/new"):  "nv",
+	}, got)
+}
+
 func TestEmbedEtcdKV(t *testing.T) {
 	suite.Run(t, new(EmbedEtcdKVSuite))
 }

--- a/internal/kv/etcd/embed_etcd_kv_test.go
+++ b/internal/kv/etcd/embed_etcd_kv_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/kv"
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
@@ -938,6 +939,11 @@ func (s *EmbedEtcdKVSuite) TestMultiSaveAndRemoveMixed() {
 	}
 	err := etcdKV.MultiSave(context.TODO(), prepareTests)
 	s.Require().NoError(err)
+
+	err = etcdKV.MultiSaveAndRemoveMixed(context.TODO(),
+		map[string]string{"mix/a-1/c3": "new"}, nil, []string{"mix/a-1/"})
+	s.Error(err)
+	s.ErrorIs(err, merr.ErrParameterInvalid)
 
 	// failed predicate: the whole mixed txn must be a no-op.
 	err = etcdKV.MultiSaveAndRemoveMixed(context.TODO(),

--- a/internal/kv/etcd/etcd_kv.go
+++ b/internal/kv/etcd/etcd_kv.go
@@ -607,6 +607,56 @@ func (kv *etcdKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[st
 	return nil
 }
 
+// MultiSaveAndRemoveMixed saves kv in @saves, removes the exact keys in
+// @removals and removes every key under the prefixes in @prefixRemovals, all
+// in one transaction.
+func (kv *etcdKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	cmps, err := parsePredicates(kv.rootPath, preds...)
+	if err != nil {
+		return err
+	}
+
+	start := time.Now()
+	ops := make([]clientv3.Op, 0, len(saves)+len(removals)+len(prefixRemovals))
+	// use complement to remove keys that are not in saves
+	saveKeys := typeutil.NewSet(lo.Keys(saves)...)
+	removeKeys := typeutil.NewSet(removals...)
+	removals = removeKeys.Complement(saveKeys).Collect()
+	for _, keyDelete := range removals {
+		ops = append(ops, clientv3.OpDelete(kv.GetPath(keyDelete)))
+	}
+	for _, keyDelete := range prefixRemovals {
+		ops = append(ops, clientv3.OpDelete(kv.GetPath(keyDelete), clientv3.WithPrefix()))
+	}
+
+	var keys []string
+	for key, value := range saves {
+		keys = append(keys, key)
+		ops = append(ops, clientv3.OpPut(kv.GetPath(key), value))
+	}
+
+	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
+	defer cancel()
+
+	resp, err := kv.executeTxn(kv.getTxnWithCmp(ctx1, cmps...), ops...)
+	if err != nil {
+		mlog.Warn(ctx, "Etcd MultiSaveAndRemoveMixed error",
+			mlog.Any("saves", saves),
+			mlog.Strings("removes", removals),
+			mlog.Strings("prefixRemoves", prefixRemovals),
+			mlog.Int("saveLength", len(saves)),
+			mlog.Int("removeLength", len(removals)),
+			mlog.Int("prefixRemoveLength", len(prefixRemovals)),
+			mlog.Err(err))
+		return err
+	}
+	CheckElapseAndWarn(ctx, start, "Slow etcd operation multi save and remove mixed", mlog.Strings("keys", keys))
+	if !resp.Succeeded {
+		return merr.WrapErrIoFailedReason("failed to execute transaction")
+	}
+	return nil
+}
+
 // MultiSaveBytesAndRemoveWithPrefix saves kv in @saves and removes the keys with given prefix in @removals.
 func (kv *etcdKV) MultiSaveBytesAndRemoveWithPrefix(ctx context.Context, saves map[string][]byte, removals []string) error {
 	start := time.Now()

--- a/internal/kv/etcd/etcd_kv.go
+++ b/internal/kv/etcd/etcd_kv.go
@@ -25,7 +25,7 @@ import (
 	"github.com/samber/lo"
 	clientv3 "go.etcd.io/etcd/client/v3"
 
-	"github.com/milvus-io/milvus/pkg/v3/kv"
+	kvpkg "github.com/milvus-io/milvus/pkg/v3/kv"
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -42,7 +42,7 @@ const (
 )
 
 // implementation assertion
-var _ kv.WatchKV = (*etcdKV)(nil)
+var _ kvpkg.WatchKV = (*etcdKV)(nil)
 
 // etcdKV implements TxnKV interface, it supports to process multiple kvs in a transaction.
 type etcdKV struct {
@@ -611,6 +611,9 @@ func (kv *etcdKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[st
 // @removals and removes every key under the prefixes in @prefixRemovals, all
 // in one transaction.
 func (kv *etcdKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	if err := kvpkg.ValidateNoSaveUnderRemovedPrefix(saves, prefixRemovals); err != nil {
+		return err
+	}
 	cmps, err := parsePredicates(kv.rootPath, preds...)
 	if err != nil {
 		return err

--- a/internal/kv/etcd/etcd_kv_test.go
+++ b/internal/kv/etcd/etcd_kv_test.go
@@ -649,6 +649,54 @@ func (s *EtcdKVSuite) TestMultiSaveAndRemoveWithPrefix() {
 	}
 }
 
+func (s *EtcdKVSuite) TestMultiSaveAndRemoveMixed() {
+	etcdKV := s.etcdKV
+
+	prepareTests := map[string]string{
+		"mix/a-1":    "1",
+		"mix/a-1/c1": "11",
+		"mix/a-1/c2": "12",
+		"mix/a-10":   "10", // exact-remove canary: a prefix delete of "mix/a-1" would wipe it
+		"mix/b":      "b",
+	}
+	err := etcdKV.MultiSave(context.TODO(), prepareTests)
+	s.Require().NoError(err)
+
+	// failed predicate: the whole mixed txn must be a no-op.
+	err = etcdKV.MultiSaveAndRemoveMixed(context.TODO(),
+		map[string]string{"mix/new": "nv"}, []string{"mix/a-1"}, []string{"mix/a-1/"},
+		predicates.ValueEqual("mix/b", "not-b"))
+	s.Error(err)
+	keys, _, err := etcdKV.LoadWithPrefix(context.TODO(), "mix")
+	s.NoError(err)
+	s.ElementsMatch(keys, []string{
+		s.etcdKV.GetPath("mix/a-1"),
+		s.etcdKV.GetPath("mix/a-1/c1"),
+		s.etcdKV.GetPath("mix/a-1/c2"),
+		s.etcdKV.GetPath("mix/a-10"),
+		s.etcdKV.GetPath("mix/b"),
+	})
+
+	// exact removal of "mix/a-1" plus prefix removal of "mix/a-1/" plus a save,
+	// in one txn; "mix/a-10" and "mix/b" must survive.
+	err = etcdKV.MultiSaveAndRemoveMixed(context.TODO(),
+		map[string]string{"mix/new": "nv"}, []string{"mix/a-1"}, []string{"mix/a-1/"},
+		predicates.ValueEqual("mix/b", "b"))
+	s.NoError(err)
+
+	keys, vals, err := etcdKV.LoadWithPrefix(context.TODO(), "mix")
+	s.NoError(err)
+	got := make(map[string]string, len(keys))
+	for i, k := range keys {
+		got[k] = vals[i]
+	}
+	s.Equal(map[string]string{
+		s.etcdKV.GetPath("mix/a-10"): "10",
+		s.etcdKV.GetPath("mix/b"):    "b",
+		s.etcdKV.GetPath("mix/new"):  "nv",
+	}, got)
+}
+
 func (s *EtcdKVSuite) TestWatch() {
 	etcdKV := s.etcdKV
 

--- a/internal/kv/etcd/etcd_kv_test.go
+++ b/internal/kv/etcd/etcd_kv_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -661,6 +662,11 @@ func (s *EtcdKVSuite) TestMultiSaveAndRemoveMixed() {
 	}
 	err := etcdKV.MultiSave(context.TODO(), prepareTests)
 	s.Require().NoError(err)
+
+	err = etcdKV.MultiSaveAndRemoveMixed(context.TODO(),
+		map[string]string{"mix/a-1/c3": "new"}, nil, []string{"mix/a-1/"})
+	s.Error(err)
+	s.ErrorIs(err, merr.ErrParameterInvalid)
 
 	// failed predicate: the whole mixed txn must be a no-op.
 	err = etcdKV.MultiSaveAndRemoveMixed(context.TODO(),

--- a/internal/kv/mem/mem_kv.go
+++ b/internal/kv/mem/mem_kv.go
@@ -333,6 +333,43 @@ func (kv *MemoryKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[
 	return nil
 }
 
+// MultiSaveAndRemoveMixed saves key-value pairs in @saves, removes exact keys
+// in @removals and keys under the prefixes in @prefixRemovals in MemoryKV
+// atomically.
+func (kv *MemoryKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	if len(preds) > 0 {
+		return merr.WrapErrServiceUnavailable("predicates not supported")
+	}
+	kv.Lock()
+	defer kv.Unlock()
+
+	// use complement to remove keys that are not in saves
+	saveKeys := typeutil.NewSet(lo.Keys(saves)...)
+	removeKeys := typeutil.NewSet(removals...)
+	removals = removeKeys.Complement(saveKeys).Collect()
+	for _, key := range removals {
+		kv.tree.Delete(memoryKVItem{key: key})
+	}
+
+	var items []memoryKVItem
+	for _, prefix := range prefixRemovals {
+		kv.tree.Ascend(func(i btree.Item) bool {
+			if strings.HasPrefix(i.(memoryKVItem).key, prefix) {
+				items = append(items, i.(memoryKVItem))
+			}
+			return true
+		})
+	}
+	for _, item := range items {
+		kv.tree.Delete(item)
+	}
+
+	for key, value := range saves {
+		kv.tree.ReplaceOrInsert(memoryKVItem{key, StringValue(value)})
+	}
+	return nil
+}
+
 // MultiSaveBytesAndRemoveWithPrefix saves key-value pairs in @saves, & remove key with prefix in @removals in MemoryKV atomically.
 func (kv *MemoryKV) MultiSaveBytesAndRemoveWithPrefix(ctx context.Context, saves map[string][]byte, removals []string) error {
 	kv.Lock()

--- a/internal/kv/mem/mem_kv.go
+++ b/internal/kv/mem/mem_kv.go
@@ -25,14 +25,14 @@ import (
 	"github.com/google/btree"
 	"github.com/samber/lo"
 
-	"github.com/milvus-io/milvus/pkg/v3/kv"
+	kvpkg "github.com/milvus-io/milvus/pkg/v3/kv"
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 // implementation assertion
-var _ kv.TxnKV = (*MemoryKV)(nil)
+var _ kvpkg.TxnKV = (*MemoryKV)(nil)
 
 // MemoryKV implements BaseKv interface and relies on underling btree.BTree.
 // As its name implies, all data is stored in memory.
@@ -339,6 +339,9 @@ func (kv *MemoryKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[
 func (kv *MemoryKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
 	if len(preds) > 0 {
 		return merr.WrapErrServiceUnavailable("predicates not supported")
+	}
+	if err := kvpkg.ValidateNoSaveUnderRemovedPrefix(saves, prefixRemovals); err != nil {
+		return err
 	}
 	kv.Lock()
 	defer kv.Unlock()

--- a/internal/kv/mem/mem_kv_test.go
+++ b/internal/kv/mem/mem_kv_test.go
@@ -259,3 +259,12 @@ func TestPredicates(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, merr.ErrServiceUnavailable)
 }
+
+func TestMultiSaveAndRemoveMixedRejectsSaveUnderRemovedPrefix(t *testing.T) {
+	kv := NewMemoryKV()
+
+	err := kv.MultiSaveAndRemoveMixed(context.TODO(),
+		map[string]string{"mix/a-1/c3": "new"}, nil, []string{"mix/a-1/"})
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+}

--- a/internal/kv/mocks/meta_kv.go
+++ b/internal/kv/mocks/meta_kv.go
@@ -659,6 +659,70 @@ func (_c *MetaKv_MultiSaveAndRemove_Call) RunAndReturn(run func(context.Context,
 	return _c
 }
 
+// MultiSaveAndRemoveMixed provides a mock function with given fields: ctx, saves, removals, prefixRemovals, preds
+func (_m *MetaKv) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	_va := make([]interface{}, len(preds))
+	for _i := range preds {
+		_va[_i] = preds[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, saves, removals, prefixRemovals)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MultiSaveAndRemoveMixed")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, map[string]string, []string, []string, ...predicates.Predicate) error); ok {
+		r0 = rf(ctx, saves, removals, prefixRemovals, preds...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MetaKv_MultiSaveAndRemoveMixed_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MultiSaveAndRemoveMixed'
+type MetaKv_MultiSaveAndRemoveMixed_Call struct {
+	*mock.Call
+}
+
+// MultiSaveAndRemoveMixed is a helper method to define mock.On call
+//   - ctx context.Context
+//   - saves map[string]string
+//   - removals []string
+//   - prefixRemovals []string
+//   - preds ...predicates.Predicate
+func (_e *MetaKv_Expecter) MultiSaveAndRemoveMixed(ctx interface{}, saves interface{}, removals interface{}, prefixRemovals interface{}, preds ...interface{}) *MetaKv_MultiSaveAndRemoveMixed_Call {
+	return &MetaKv_MultiSaveAndRemoveMixed_Call{Call: _e.mock.On("MultiSaveAndRemoveMixed",
+		append([]interface{}{ctx, saves, removals, prefixRemovals}, preds...)...)}
+}
+
+func (_c *MetaKv_MultiSaveAndRemoveMixed_Call) Run(run func(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate)) *MetaKv_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]predicates.Predicate, len(args)-4)
+		for i, a := range args[4:] {
+			if a != nil {
+				variadicArgs[i] = a.(predicates.Predicate)
+			}
+		}
+		run(args[0].(context.Context), args[1].(map[string]string), args[2].([]string), args[3].([]string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MetaKv_MultiSaveAndRemoveMixed_Call) Return(_a0 error) *MetaKv_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MetaKv_MultiSaveAndRemoveMixed_Call) RunAndReturn(run func(context.Context, map[string]string, []string, []string, ...predicates.Predicate) error) *MetaKv_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MultiSaveAndRemoveWithPrefix provides a mock function with given fields: ctx, saves, removals, preds
 func (_m *MetaKv) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
 	_va := make([]interface{}, len(preds))

--- a/internal/kv/mocks/txn_kv.go
+++ b/internal/kv/mocks/txn_kv.go
@@ -554,6 +554,70 @@ func (_c *TxnKV_MultiSaveAndRemove_Call) RunAndReturn(run func(context.Context, 
 	return _c
 }
 
+// MultiSaveAndRemoveMixed provides a mock function with given fields: ctx, saves, removals, prefixRemovals, preds
+func (_m *TxnKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	_va := make([]interface{}, len(preds))
+	for _i := range preds {
+		_va[_i] = preds[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, saves, removals, prefixRemovals)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MultiSaveAndRemoveMixed")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, map[string]string, []string, []string, ...predicates.Predicate) error); ok {
+		r0 = rf(ctx, saves, removals, prefixRemovals, preds...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// TxnKV_MultiSaveAndRemoveMixed_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MultiSaveAndRemoveMixed'
+type TxnKV_MultiSaveAndRemoveMixed_Call struct {
+	*mock.Call
+}
+
+// MultiSaveAndRemoveMixed is a helper method to define mock.On call
+//   - ctx context.Context
+//   - saves map[string]string
+//   - removals []string
+//   - prefixRemovals []string
+//   - preds ...predicates.Predicate
+func (_e *TxnKV_Expecter) MultiSaveAndRemoveMixed(ctx interface{}, saves interface{}, removals interface{}, prefixRemovals interface{}, preds ...interface{}) *TxnKV_MultiSaveAndRemoveMixed_Call {
+	return &TxnKV_MultiSaveAndRemoveMixed_Call{Call: _e.mock.On("MultiSaveAndRemoveMixed",
+		append([]interface{}{ctx, saves, removals, prefixRemovals}, preds...)...)}
+}
+
+func (_c *TxnKV_MultiSaveAndRemoveMixed_Call) Run(run func(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate)) *TxnKV_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]predicates.Predicate, len(args)-4)
+		for i, a := range args[4:] {
+			if a != nil {
+				variadicArgs[i] = a.(predicates.Predicate)
+			}
+		}
+		run(args[0].(context.Context), args[1].(map[string]string), args[2].([]string), args[3].([]string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *TxnKV_MultiSaveAndRemoveMixed_Call) Return(_a0 error) *TxnKV_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *TxnKV_MultiSaveAndRemoveMixed_Call) RunAndReturn(run func(context.Context, map[string]string, []string, []string, ...predicates.Predicate) error) *TxnKV_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MultiSaveAndRemoveWithPrefix provides a mock function with given fields: ctx, saves, removals, preds
 func (_m *TxnKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
 	_va := make([]interface{}, len(preds))

--- a/internal/kv/mocks/watch_kv.go
+++ b/internal/kv/mocks/watch_kv.go
@@ -661,6 +661,70 @@ func (_c *WatchKV_MultiSaveAndRemove_Call) RunAndReturn(run func(context.Context
 	return _c
 }
 
+// MultiSaveAndRemoveMixed provides a mock function with given fields: ctx, saves, removals, prefixRemovals, preds
+func (_m *WatchKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	_va := make([]interface{}, len(preds))
+	for _i := range preds {
+		_va[_i] = preds[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, saves, removals, prefixRemovals)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MultiSaveAndRemoveMixed")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, map[string]string, []string, []string, ...predicates.Predicate) error); ok {
+		r0 = rf(ctx, saves, removals, prefixRemovals, preds...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// WatchKV_MultiSaveAndRemoveMixed_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MultiSaveAndRemoveMixed'
+type WatchKV_MultiSaveAndRemoveMixed_Call struct {
+	*mock.Call
+}
+
+// MultiSaveAndRemoveMixed is a helper method to define mock.On call
+//   - ctx context.Context
+//   - saves map[string]string
+//   - removals []string
+//   - prefixRemovals []string
+//   - preds ...predicates.Predicate
+func (_e *WatchKV_Expecter) MultiSaveAndRemoveMixed(ctx interface{}, saves interface{}, removals interface{}, prefixRemovals interface{}, preds ...interface{}) *WatchKV_MultiSaveAndRemoveMixed_Call {
+	return &WatchKV_MultiSaveAndRemoveMixed_Call{Call: _e.mock.On("MultiSaveAndRemoveMixed",
+		append([]interface{}{ctx, saves, removals, prefixRemovals}, preds...)...)}
+}
+
+func (_c *WatchKV_MultiSaveAndRemoveMixed_Call) Run(run func(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate)) *WatchKV_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]predicates.Predicate, len(args)-4)
+		for i, a := range args[4:] {
+			if a != nil {
+				variadicArgs[i] = a.(predicates.Predicate)
+			}
+		}
+		run(args[0].(context.Context), args[1].(map[string]string), args[2].([]string), args[3].([]string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *WatchKV_MultiSaveAndRemoveMixed_Call) Return(_a0 error) *WatchKV_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *WatchKV_MultiSaveAndRemoveMixed_Call) RunAndReturn(run func(context.Context, map[string]string, []string, []string, ...predicates.Predicate) error) *WatchKV_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MultiSaveAndRemoveWithPrefix provides a mock function with given fields: ctx, saves, removals, preds
 func (_m *WatchKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
 	_va := make([]interface{}, len(preds))

--- a/internal/kv/tikv/txn_tikv.go
+++ b/internal/kv/tikv/txn_tikv.go
@@ -611,6 +611,99 @@ func (kv *txnTiKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[s
 	return nil
 }
 
+// MultiSaveAndRemoveMixed saves kv in @saves, removes the exact keys in
+// @removals and removes every key under the prefixes in @prefixRemovals, all
+// in one transaction: the prefix scan and its deletes run inside the same txn
+// snapshot as the exact deletes and saves.
+func (kv *txnTiKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(ctx, kv.requestTimeout)
+	defer cancel()
+
+	var loggingErr error
+	defer logWarnOnFailure(&loggingErr, "txnTiKV MultiSaveAndRemoveMixed() error", mlog.Any("saves", saves), mlog.Strings("removes", removals), mlog.Strings("prefixRemoves", prefixRemovals), mlog.Int("saveLength", len(saves)), mlog.Int("removeLength", len(removals)), mlog.Int("prefixRemoveLength", len(prefixRemovals)))
+
+	// use complement to remove keys that are not in saves
+	saveKeys := typeutil.NewSet(lo.Keys(saves)...)
+	removeKeys := typeutil.NewSet(removals...)
+	removals = removeKeys.Complement(saveKeys).Collect()
+
+	loggingErr = kv.runWriteTxnWithRetry(ctx, "MultiSaveAndRemoveMixed", func(txn *transaction.KVTxn) error {
+		for _, pred := range preds {
+			key := kv.GetPath(pred.Key())
+			val, err := txn.Get(ctx, []byte(key))
+			if err != nil {
+				if errors.Is(err, tikverr.ErrNotExist) {
+					return markPredicateNotMet(merr.WrapErrIoFailedReason(fmt.Sprintf("failed to read predicate target (%s:%v) for MultiSaveAndRemoveMixed", pred.Key(), pred.TargetValue()), err.Error()))
+				}
+				return merr.WrapErrIoFailedReason(fmt.Sprintf("failed to read predicate target (%s:%v) for MultiSaveAndRemoveMixed", pred.Key(), pred.TargetValue()), err.Error())
+			}
+			if !pred.IsTrue(val.Value) {
+				return markPredicateNotMet(merr.WrapErrIoFailedReason("failed to meet predicate", fmt.Sprintf("key=%s, value=%v", pred.Key(), pred.TargetValue())))
+			}
+		}
+
+		for _, key := range removals {
+			key = kv.GetPath(key)
+			if err := txn.Delete([]byte(key)); err != nil {
+				return wrapWriteBuildErr(fmt.Sprintf("Failed to delete %s for MultiSaveAndRemoveMixed", key), err)
+			}
+		}
+
+		// Remove keys with prefix
+		for _, prefix := range prefixRemovals {
+			prefix = kv.GetPath(prefix)
+			if err := func(prefix string) error {
+				// Get the start and end keys for the prefix range
+				startKey := []byte(prefix)
+				endKey := tikv.PrefixNextKey([]byte(prefix))
+
+				// Use Scan to iterate over keys in the prefix range
+				iter, err := txn.Iter(startKey, endKey)
+				if err != nil {
+					return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to create iterater for %s during MultiSaveAndRemoveMixed()", prefix), err.Error())
+				}
+				defer iter.Close()
+
+				// Iterate over keys and delete them
+				for iter.Valid() {
+					key := iter.Key()
+					if err = txn.Delete(key); err != nil {
+						return wrapWriteBuildErr(fmt.Sprintf("Failed to delete %s for MultiSaveAndRemoveMixed", string(key)), err)
+					}
+
+					// Move the iterator to the next key
+					if err = iter.Next(); err != nil {
+						return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to move Iterator after key %s for MultiSaveAndRemoveMixed", string(key)), err.Error())
+					}
+				}
+				return nil
+			}(prefix); err != nil {
+				return err
+			}
+		}
+
+		// Save key-value pairs
+		for key, value := range saves {
+			key = kv.GetPath(key)
+			// Check if value is empty or taking reserved EmptyValue
+			byteValue, err := convertEmptyStringToByte(value)
+			if err != nil {
+				return merr.Wrap(err, fmt.Sprintf("Failed to cast to byte (%s:%s) for MultiSaveAndRemoveMixed()", key, value))
+			}
+			if err = txn.Set([]byte(key), byteValue); err != nil {
+				return wrapWriteBuildErr(fmt.Sprintf("Failed to set (%s:%s) for MultiSaveAndRemoveMixed()", key, value), err)
+			}
+		}
+		return nil
+	}, kv.executeTxn)
+	if loggingErr != nil {
+		return loggingErr
+	}
+	CheckElapseAndWarn(start, "Slow txnTiKV MultiSaveAndRemoveMixed() operation", mlog.Any("saves", saves), mlog.Strings("removals", removals), mlog.Strings("prefixRemovals", prefixRemovals))
+	return nil
+}
+
 // WalkWithPrefix visits each kv with input prefix and apply given fn to it.
 func (kv *txnTiKV) WalkWithPrefix(ctx context.Context, prefix string, paginationSize int, fn func([]byte, []byte) error) error {
 	start := time.Now()

--- a/internal/kv/tikv/txn_tikv.go
+++ b/internal/kv/tikv/txn_tikv.go
@@ -31,7 +31,7 @@ import (
 	"github.com/tikv/client-go/v2/txnkv/transaction"
 	"github.com/tikv/client-go/v2/txnkv/txnsnapshot"
 
-	"github.com/milvus-io/milvus/pkg/v3/kv"
+	kvpkg "github.com/milvus-io/milvus/pkg/v3/kv"
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -149,7 +149,7 @@ var (
 )
 
 // implementation assertion
-var _ kv.MetaKv = (*txnTiKV)(nil)
+var _ kvpkg.MetaKv = (*txnTiKV)(nil)
 
 // txnTiKV implements MetaKv and TxnKV interface. It supports processing multiple kvs within one transaction.
 type txnTiKV struct {
@@ -616,6 +616,9 @@ func (kv *txnTiKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[s
 // in one transaction: the prefix scan and its deletes run inside the same txn
 // snapshot as the exact deletes and saves.
 func (kv *txnTiKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	if err := kvpkg.ValidateNoSaveUnderRemovedPrefix(saves, prefixRemovals); err != nil {
+		return err
+	}
 	start := time.Now()
 	ctx, cancel := context.WithTimeout(ctx, kv.requestTimeout)
 	defer cancel()

--- a/internal/kv/tikv/txn_tikv_test.go
+++ b/internal/kv/tikv/txn_tikv_test.go
@@ -315,6 +315,11 @@ func TestTiKVLoad(te *testing.T) {
 		err := kv.MultiSave(context.TODO(), prepareTests)
 		require.NoError(t, err)
 
+		err = kv.MultiSaveAndRemoveMixed(context.TODO(),
+			map[string]string{"mix/a-1/c3": "new"}, nil, []string{"mix/a-1/"})
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+
 		// failed predicate: the whole mixed txn must be a no-op.
 		err = kv.MultiSaveAndRemoveMixed(context.TODO(),
 			map[string]string{"mix/new": "nv"}, []string{"mix/a-1"}, []string{"mix/a-1/"},

--- a/internal/kv/tikv/txn_tikv_test.go
+++ b/internal/kv/tikv/txn_tikv_test.go
@@ -299,6 +299,51 @@ func TestTiKVLoad(te *testing.T) {
 		}
 	})
 
+	te.Run("kv MultiSaveAndRemoveMixed", func(t *testing.T) {
+		rootPath := "/tikv/test/root/multi_remove_mixed"
+		kv := NewTiKV(txnClient, rootPath)
+		defer kv.Close()
+		defer kv.RemoveWithPrefix(context.TODO(), "")
+
+		prepareTests := map[string]string{
+			"mix/a-1":    "1",
+			"mix/a-1/c1": "11",
+			"mix/a-1/c2": "12",
+			"mix/a-10":   "10", // exact-remove canary: a prefix delete of "mix/a-1" would wipe it
+			"mix/b":      "b",
+		}
+		err := kv.MultiSave(context.TODO(), prepareTests)
+		require.NoError(t, err)
+
+		// failed predicate: the whole mixed txn must be a no-op.
+		err = kv.MultiSaveAndRemoveMixed(context.TODO(),
+			map[string]string{"mix/new": "nv"}, []string{"mix/a-1"}, []string{"mix/a-1/"},
+			predicates.ValueEqual("mix/b", "not-b"))
+		assert.Error(t, err)
+		keys, _, err := kv.LoadWithPrefix(context.TODO(), "mix")
+		assert.NoError(t, err)
+		assert.Equal(t, 5, len(keys))
+
+		// exact removal of "mix/a-1" plus prefix removal of "mix/a-1/" plus a
+		// save, in one txn; "mix/a-10" and "mix/b" must survive.
+		err = kv.MultiSaveAndRemoveMixed(context.TODO(),
+			map[string]string{"mix/new": "nv"}, []string{"mix/a-1"}, []string{"mix/a-1/"},
+			predicates.ValueEqual("mix/b", "b"))
+		assert.NoError(t, err)
+
+		keys, vals, err := kv.LoadWithPrefix(context.TODO(), "mix")
+		assert.NoError(t, err)
+		got := make(map[string]string, len(keys))
+		for i, k := range keys {
+			got[k] = vals[i]
+		}
+		assert.Equal(t, map[string]string{
+			kv.GetPath("mix/a-10"): "10",
+			kv.GetPath("mix/b"):    "b",
+			kv.GetPath("mix/new"):  "nv",
+		}, got)
+	})
+
 	te.Run("kv failed to start txn", func(t *testing.T) {
 		origSleep := writeTxnRetrySleep
 		writeTxnRetrySleep = time.Millisecond

--- a/internal/metastore/kv/querycoord/kv_catalog.go
+++ b/internal/metastore/kv/querycoord/kv_catalog.go
@@ -242,14 +242,11 @@ func (s Catalog) GetResourceGroups(ctx context.Context) ([]*querypb.ResourceGrou
 }
 
 func (s Catalog) ReleaseCollection(ctx context.Context, collection int64) error {
-	// remove collection and obtained partitions
+	// remove collection and obtained partitions in one txn, so a crash cannot
+	// leave partitions behind without their collection load info
 	collectionKey := EncodeCollectionLoadInfoKey(collection)
-	err := s.cli.Remove(ctx, collectionKey)
-	if err != nil {
-		return err
-	}
 	partitionsPrefix := fmt.Sprintf("%s/%d/", PartitionLoadInfoPrefix, collection)
-	return s.cli.RemoveWithPrefix(ctx, partitionsPrefix)
+	return s.cli.MultiSaveAndRemoveMixed(ctx, nil, []string{collectionKey}, []string{partitionsPrefix})
 }
 
 func (s Catalog) ReleasePartition(ctx context.Context, collection int64, partitions ...int64) error {

--- a/internal/metastore/kv/querycoord/kv_catalog_test.go
+++ b/internal/metastore/kv/querycoord/kv_catalog_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/milvus-io/milvus/internal/kv/mocks"
 	. "github.com/milvus-io/milvus/internal/querycoordv2/params"
 	"github.com/milvus-io/milvus/pkg/v3/kv"
+	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
@@ -337,6 +338,118 @@ func (suite *CatalogTestSuite) TestRemoveCollectionTargets() {
 
 func (suite *CatalogTestSuite) TestLoadRelease() {
 	// TODO(sunby): add ut
+}
+
+// releaseFailKV wraps a real MetaKv and fails selected removal ops to
+// simulate a crash between the two legacy release steps.
+type releaseFailKV struct {
+	kv.MetaKv
+	removeWithPrefixErr error
+	mixedErr            error
+}
+
+func (f *releaseFailKV) RemoveWithPrefix(ctx context.Context, key string) error {
+	if f.removeWithPrefixErr != nil {
+		return f.removeWithPrefixErr
+	}
+	return f.MetaKv.RemoveWithPrefix(ctx, key)
+}
+
+func (f *releaseFailKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	if f.mixedErr != nil {
+		return f.mixedErr
+	}
+	return f.MetaKv.MultiSaveAndRemoveMixed(ctx, saves, removals, prefixRemovals, preds...)
+}
+
+func (suite *CatalogTestSuite) saveCollectionWithPartitions(ctx context.Context, collection int64, partitions ...int64) {
+	err := suite.catalog.SaveCollection(ctx, &querypb.CollectionLoadInfo{
+		CollectionID: collection,
+	}, lo.Map(partitions, func(partition int64, _ int) *querypb.PartitionLoadInfo {
+		return &querypb.PartitionLoadInfo{
+			CollectionID: collection,
+			PartitionID:  partition,
+		}
+	})...)
+	suite.Require().NoError(err)
+}
+
+func (suite *CatalogTestSuite) TestReleaseCollectionRemovesAllKeys() {
+	ctx := context.Background()
+	suite.saveCollectionWithPartitions(ctx, 1, 100, 101)
+	suite.saveCollectionWithPartitions(ctx, 10, 110)
+
+	otherCollectionValue, err := suite.kv.Load(ctx, EncodeCollectionLoadInfoKey(10))
+	suite.NoError(err)
+	otherPartitionValue, err := suite.kv.Load(ctx, EncodePartitionLoadInfoKey(10, 110))
+	suite.NoError(err)
+
+	suite.NoError(suite.catalog.ReleaseCollection(ctx, 1))
+
+	_, err = suite.kv.Load(ctx, EncodeCollectionLoadInfoKey(1))
+	suite.Error(err)
+	keys, _, err := suite.kv.LoadWithPrefix(ctx, EncodePartitionLoadInfoPrefix(1))
+	suite.NoError(err)
+	suite.Empty(keys)
+
+	// collection 10 shares the "1" digit prefix and must be untouched, byte for byte
+	value, err := suite.kv.Load(ctx, EncodeCollectionLoadInfoKey(10))
+	suite.NoError(err)
+	suite.Equal(otherCollectionValue, value)
+	value, err = suite.kv.Load(ctx, EncodePartitionLoadInfoKey(10, 110))
+	suite.NoError(err)
+	suite.Equal(otherPartitionValue, value)
+}
+
+func (suite *CatalogTestSuite) TestReleaseCollectionAtomicUnderFailure() {
+	ctx := context.Background()
+	injected := errors.New("injected failure")
+
+	assertIntact := func(collection int64, partitions ...int64) {
+		_, err := suite.kv.Load(ctx, EncodeCollectionLoadInfoKey(collection))
+		suite.NoError(err)
+		keys, _, err := suite.kv.LoadWithPrefix(ctx, EncodePartitionLoadInfoPrefix(collection))
+		suite.NoError(err)
+		suite.Len(keys, len(partitions))
+	}
+
+	// prefix removal fails while exact removal would succeed: the release must
+	// not leave partitions behind without the collection load info
+	suite.saveCollectionWithPartitions(ctx, 1, 100, 101)
+	suite.catalog.cli = &releaseFailKV{MetaKv: suite.kv, removeWithPrefixErr: injected}
+	err := suite.catalog.ReleaseCollection(ctx, 1)
+	if err != nil {
+		assertIntact(1, 100, 101)
+	} else {
+		_, err = suite.kv.Load(ctx, EncodeCollectionLoadInfoKey(1))
+		suite.Error(err)
+		keys, _, err := suite.kv.LoadWithPrefix(ctx, EncodePartitionLoadInfoPrefix(1))
+		suite.NoError(err)
+		suite.Empty(keys)
+	}
+
+	// whole transaction fails: nothing may be removed
+	suite.catalog.cli = suite.kv
+	suite.saveCollectionWithPartitions(ctx, 2, 200, 201)
+	suite.catalog.cli = &releaseFailKV{MetaKv: suite.kv, removeWithPrefixErr: injected, mixedErr: injected}
+	err = suite.catalog.ReleaseCollection(ctx, 2)
+	suite.ErrorIs(err, injected)
+	assertIntact(2, 200, 201)
+}
+
+func (suite *CatalogTestSuite) TestReleaseCollectionSingleTxn() {
+	ctx := context.Background()
+	mockStore := mocks.NewMetaKv(suite.T())
+	mockStore.EXPECT().MultiSaveAndRemoveMixed(mock.Anything, mock.Anything,
+		[]string{"querycoord-collection-loadinfo/1"},
+		[]string{"querycoord-partition-loadinfo/1/"}).Return(nil).Once()
+
+	suite.catalog.cli = mockStore
+	suite.NoError(suite.catalog.ReleaseCollection(ctx, 1))
+
+	mockErr := errors.New("failed to access etcd")
+	mockStore.EXPECT().MultiSaveAndRemoveMixed(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(mockErr).Once()
+	suite.ErrorIs(suite.catalog.ReleaseCollection(ctx, 1), mockErr)
 }
 
 func TestCatalogSuite(t *testing.T) {

--- a/internal/metastore/kv/rootcoord/kv_catalog.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog.go
@@ -1237,11 +1237,27 @@ func (kc *Catalog) AlterRole(ctx context.Context, tenant string, entity *milvusp
 }
 
 func (kc *Catalog) DropRole(ctx context.Context, tenant string, roleName string) error {
+	deleteKeys, err := kc.dropRoleRemovals(ctx, tenant, roleName)
+	if err != nil {
+		return err
+	}
+
+	err = kc.Txn.MultiRemove(ctx, deleteKeys)
+	if err != nil {
+		mlog.Warn(ctx, "fail to drop role", mlog.String("key", deleteKeys[0]), mlog.Err(err))
+		return err
+	}
+	return nil
+}
+
+// dropRoleRemovals returns the exact keys DropRole removes: the role record
+// key first, followed by the role's user-role mapping keys.
+func (kc *Catalog) dropRoleRemovals(ctx context.Context, tenant string, roleName string) ([]string, error) {
 	k := RolePrefix + "/" + roleName
 	roleResults, err := kc.ListRole(ctx, tenant, &milvuspb.RoleEntity{Name: roleName}, true)
 	if err != nil && !errors.Is(err, merr.ErrIoKeyNotFound) {
 		mlog.Warn(ctx, "fail to list role", mlog.String("key", k), mlog.Err(err))
-		return err
+		return nil, err
 	}
 
 	deleteKeys := make([]string, 0, len(roleResults)+1)
@@ -1254,13 +1270,7 @@ func (kc *Catalog) DropRole(ctx context.Context, tenant string, roleName string)
 			}
 		}
 	}
-
-	err = kc.Txn.MultiRemove(ctx, deleteKeys)
-	if err != nil {
-		mlog.Warn(ctx, "fail to drop role", mlog.String("key", k), mlog.Err(err))
-		return err
-	}
-	return nil
+	return deleteKeys, nil
 }
 
 func (kc *Catalog) AlterUserRole(ctx context.Context, tenant string, userEntity *milvuspb.UserEntity, roleEntity *milvuspb.RoleEntity, operateType milvuspb.OperateUserRoleType) error {
@@ -1946,6 +1956,21 @@ func (kc *Catalog) MigrateGrantCollectionName(ctx context.Context, tenant string
 }
 
 func (kc *Catalog) DeleteGrant(ctx context.Context, tenant string, role *milvuspb.RoleEntity) error {
+	removeKeys, err := kc.deleteGrantPrefixes(ctx, tenant, role)
+	if err != nil {
+		return err
+	}
+
+	if err = kc.Txn.MultiSaveAndRemoveWithPrefix(ctx, nil, removeKeys); err != nil {
+		mlog.Error(ctx, "fail to remove with the prefix", mlog.String("key", removeKeys[0]), mlog.Err(err))
+	}
+	return err
+}
+
+// deleteGrantPrefixes returns the prefixes DeleteGrant removes: the role's
+// grantee-privileges subtree first, then every grantee-id subtree no
+// surviving grantee still references.
+func (kc *Catalog) deleteGrantPrefixes(ctx context.Context, tenant string, role *milvuspb.RoleEntity) ([]string, error) {
 	var (
 		k          = funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, role.Name)
 		err        error
@@ -1958,7 +1983,7 @@ func (kc *Catalog) DeleteGrant(ctx context.Context, tenant string, role *milvusp
 	keys, values, err := kc.Txn.LoadWithPrefix(ctx, k)
 	if err != nil {
 		mlog.Warn(ctx, "fail to load grant privilege entities", mlog.String("key", k), mlog.Err(err))
-		return err
+		return nil, err
 	}
 	removingGrantees := make(map[string]struct{})
 	keyWithoutTrailingSlash := strings.TrimSuffix(k, "/")
@@ -1979,7 +2004,7 @@ func (kc *Catalog) DeleteGrant(ctx context.Context, tenant string, role *milvusp
 			allKeys, allValues, err = kc.Txn.LoadWithPrefix(ctx, granteePrefix)
 			if err != nil {
 				mlog.Warn(ctx, "fail to load grant privilege entities for shared id check", mlog.String("key", granteePrefix), mlog.Err(err))
-				return err
+				return nil, err
 			}
 		}
 		if !shouldRemoveGranteeIDSubtree(ctx, funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant), v, allKeys, allValues, removingGrantees) {
@@ -1989,10 +2014,7 @@ func (kc *Catalog) DeleteGrant(ctx context.Context, tenant string, role *milvusp
 		removeKeys = append(removeKeys, granteeIDKey)
 	}
 
-	if err = kc.Txn.MultiSaveAndRemoveWithPrefix(ctx, nil, removeKeys); err != nil {
-		mlog.Error(ctx, "fail to remove with the prefix", mlog.String("key", k), mlog.Err(err))
-	}
-	return err
+	return removeKeys, nil
 }
 
 func (kc *Catalog) ListPolicy(ctx context.Context, tenant string) ([]*milvuspb.GrantEntity, error) {

--- a/internal/metastore/kv/rootcoord/update.go
+++ b/internal/metastore/kv/rootcoord/update.go
@@ -19,6 +19,7 @@ package rootcoord
 import (
 	"context"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/internal/metastore"
 	"github.com/milvus-io/milvus/internal/metastore/kv/txn"
 	pb "github.com/milvus-io/milvus/pkg/v3/proto/etcdpb"
@@ -38,49 +39,87 @@ import (
 func (kc *Catalog) Update(ctx context.Context, ts typeutil.Timestamp, actions ...metastore.UpdateAction) error {
 	b := txn.New()
 	for _, action := range actions {
-		ce, ok := action.Entry.(metastore.CollectionEntry)
-		if !ok {
-			return merr.WrapErrServiceInternalMsg("rootcoord catalog cannot apply entry %T", action.Entry)
-		}
-		coll := ce.Collection
-		switch action.Type {
-		case metastore.ActionAdd:
-			// CreateCollection appends the child kvs and the collection
-			// key/value (as the commit marker), using the same encoding as
-			// the legacy Catalog.CreateCollection. It keeps the legacy
-			// overwrite/idempotent-on-retry semantics (a duplicate create
-			// silently overwrites rather than failing). CommitSave marks
-			// the collection key as the visibility point, so children are
-			// persisted before the collection key on the ordered fallback
-			// path.
-			if coll.State != pb.CollectionState_CollectionCreated {
-				return merr.WrapErrServiceInternalMsg("collection state should be created, collection name: %s, collection id: %d, state: %s", coll.Name, coll.CollectionID, coll.State)
-			}
+		switch entry := action.Entry.(type) {
+		case metastore.CollectionEntry:
+			coll := entry.Collection
+			switch action.Type {
+			case metastore.ActionAdd:
+				// CreateCollection appends the child kvs and the collection
+				// key/value (as the commit marker), using the same encoding as
+				// the legacy Catalog.CreateCollection. It keeps the legacy
+				// overwrite/idempotent-on-retry semantics (a duplicate create
+				// silently overwrites rather than failing). CommitSave marks
+				// the collection key as the visibility point, so children are
+				// persisted before the collection key on the ordered fallback
+				// path.
+				if coll.State != pb.CollectionState_CollectionCreated {
+					return merr.WrapErrServiceInternalMsg("collection state should be created, collection name: %s, collection id: %d, state: %s", coll.Name, coll.CollectionID, coll.State)
+				}
 
-			k1, v1, err := buildCollectionKV(coll)
+				k1, v1, err := buildCollectionKV(coll)
+				if err != nil {
+					return err
+				}
+				kvs, err := buildCreateCollectionChildKvs(coll)
+				if err != nil {
+					return err
+				}
+
+				for k, v := range kvs {
+					b.Save(k, v)
+				}
+				b.CommitSave(k1, v1)
+			case metastore.ActionDelete:
+				// DropCollection appends the child metadata removals and the
+				// collection key removal (as the commit marker), using the same
+				// keys as the legacy Catalog.DropCollection.
+				collectionKey, delMetakeysSnap := buildDropCollectionKeys(coll)
+				for _, k := range delMetakeysSnap {
+					b.Remove(k)
+				}
+				b.CommitRemove(collectionKey)
+			default:
+				return merr.WrapErrServiceInternalMsg("rootcoord catalog cannot apply action type %v to CollectionEntry", action.Type)
+			}
+		case metastore.RoleEntry:
+			// DropRole appends the exact same keys as the legacy
+			// Catalog.DropRole: user-role mapping removals first, then the
+			// role record removal as the commit marker, so on the chunked
+			// fallback path the role stays visible (and the drop retryable)
+			// until everything else has landed.
+			if action.Type != metastore.ActionDelete {
+				return merr.WrapErrServiceInternalMsg("rootcoord catalog cannot apply action type %v to RoleEntry", action.Type)
+			}
+			deleteKeys, err := kc.dropRoleRemovals(ctx, entry.Tenant, entry.Name)
 			if err != nil {
 				return err
 			}
-			kvs, err := buildCreateCollectionChildKvs(coll)
-			if err != nil {
-				return err
-			}
-
-			for k, v := range kvs {
-				b.Save(k, v)
-			}
-			b.CommitSave(k1, v1)
-		case metastore.ActionDelete:
-			// DropCollection appends the child metadata removals and the
-			// collection key removal (as the commit marker), using the same
-			// keys as the legacy Catalog.DropCollection.
-			collectionKey, delMetakeysSnap := buildDropCollectionKeys(coll)
-			for _, k := range delMetakeysSnap {
+			for _, k := range deleteKeys[1:] {
 				b.Remove(k)
 			}
-			b.CommitRemove(collectionKey)
+			b.CommitRemove(deleteKeys[0])
+		case metastore.RoleGrantsEntry:
+			// DropRoleGrants appends the exact same prefixes as the legacy
+			// Catalog.DeleteGrant: the grantee-privileges subtree plus the
+			// unshared grantee-id subtrees. The grantee-privileges subtree is
+			// the only index from which a retry can rediscover the grantee-id
+			// subtrees, so on the chunked fallback path it must land last —
+			// otherwise a crash between prefix chunks permanently orphans the
+			// remaining grantee-id subtrees, and a same-name role re-grant
+			// would silently resurrect them (GranteeID is deterministic).
+			if action.Type != metastore.ActionDelete {
+				return merr.WrapErrServiceInternalMsg("rootcoord catalog cannot apply action type %v to RoleGrantsEntry", action.Type)
+			}
+			prefixes, err := kc.deleteGrantPrefixes(ctx, entry.Tenant, &milvuspb.RoleEntity{Name: entry.RoleName})
+			if err != nil {
+				return err
+			}
+			for _, p := range prefixes[1:] {
+				b.RemovePrefix(p)
+			}
+			b.RemovePrefix(prefixes[0])
 		default:
-			return merr.WrapErrServiceInternalMsg("rootcoord catalog cannot apply action type %v to CollectionEntry", action.Type)
+			return merr.WrapErrServiceInternalMsg("rootcoord catalog cannot apply entry %T", action.Entry)
 		}
 	}
 

--- a/internal/metastore/kv/rootcoord/update_test.go
+++ b/internal/metastore/kv/rootcoord/update_test.go
@@ -18,17 +18,22 @@ package rootcoord
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	memkv "github.com/milvus-io/milvus/internal/kv/mem"
 	"github.com/milvus-io/milvus/internal/kv/mocks"
 	"github.com/milvus-io/milvus/internal/metastore"
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 	pb "github.com/milvus-io/milvus/pkg/v3/proto/etcdpb"
+	"github.com/milvus-io/milvus/pkg/v3/util"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
@@ -129,4 +134,334 @@ func TestCatalog_Update_CreateCollectionEncodingMatchesLegacy(t *testing.T) {
 
 	assert.Equal(t, wantSaves, directSaves)
 	assert.Equal(t, wantSaves, compositeSaves)
+}
+
+// seedDropRoleRBAC populates a catalog with the fixture used by the
+// drop-role-with-grants tests: role1 (the drop target) with two user
+// mappings and two grants, plus role10 as the exact-vs-prefix widening
+// canary (a prefix delete of "roles/role1" or "grantee-privileges/role1"
+// without the trailing slash would wipe role10's keys too).
+func seedDropRoleRBAC(t *testing.T, c metastore.RootCoordCatalog) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+	for _, role := range []string{"role1", "role10"} {
+		assert.NoError(t, c.CreateRole(ctx, tenant, &milvuspb.RoleEntity{Name: role}))
+	}
+	assert.NoError(t, c.AlterUserRole(ctx, tenant, &milvuspb.UserEntity{Name: "user1"}, &milvuspb.RoleEntity{Name: "role1"}, milvuspb.OperateUserRoleType_AddUserToRole))
+	assert.NoError(t, c.AlterUserRole(ctx, tenant, &milvuspb.UserEntity{Name: "user2"}, &milvuspb.RoleEntity{Name: "role1"}, milvuspb.OperateUserRoleType_AddUserToRole))
+	assert.NoError(t, c.AlterUserRole(ctx, tenant, &milvuspb.UserEntity{Name: "user1"}, &milvuspb.RoleEntity{Name: "role10"}, milvuspb.OperateUserRoleType_AddUserToRole))
+	grant := func(role, objType, objName, priv string) {
+		assert.NoError(t, c.AlterGrant(ctx, tenant, &milvuspb.GrantEntity{
+			Role:       &milvuspb.RoleEntity{Name: role},
+			Object:     &milvuspb.ObjectEntity{Name: objType},
+			ObjectName: objName,
+			DbName:     "db1",
+			Grantor: &milvuspb.GrantorEntity{
+				User:      &milvuspb.UserEntity{Name: "root"},
+				Privilege: &milvuspb.PrivilegeEntity{Name: priv},
+			},
+		}, milvuspb.OperatePrivilegeType_Grant))
+	}
+	grant("role1", "Collection", "coll1", "Insert")
+	grant("role1", "Global", "*", "CreateCollection")
+	grant("role10", "Collection", "coll1", "Insert")
+}
+
+func dumpKV(t *testing.T, k interface {
+	LoadWithPrefix(ctx context.Context, key string) ([]string, []string, error)
+},
+) map[string]string {
+	keys, vals, err := k.LoadWithPrefix(context.TODO(), "")
+	assert.NoError(t, err)
+	got := make(map[string]string, len(keys))
+	for i, key := range keys {
+		got[key] = vals[i]
+	}
+	return got
+}
+
+// TestCatalog_Update_DropRoleWithGrants_MatchesLegacyBytes proves the new
+// single-txn drop-role path leaves byte-for-byte the same store state as
+// today's two-call path (Catalog.DropRole + Catalog.DeleteGrant): role
+// record, user-role mappings, grantee-privileges subtree and grantee-id
+// subtrees all gone, canary keys of another role untouched.
+func TestCatalog_Update_DropRoleWithGrants_MatchesLegacyBytes(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+	legacyKV := memkv.NewMemoryKV()
+	compositeKV := memkv.NewMemoryKV()
+	legacy := NewCatalog(legacyKV)
+	composite := NewCatalog(compositeKV)
+	seedDropRoleRBAC(t, legacy)
+	seedDropRoleRBAC(t, composite)
+	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, compositeKV))
+
+	// capture role1's grantee ids before the drop, to assert their subtrees die.
+	granteeKeys, granteeIDs, err := compositeKV.LoadWithPrefix(ctx, funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, "role1"))
+	assert.NoError(t, err)
+	assert.Len(t, granteeKeys, 2)
+
+	// today's two-call path.
+	assert.NoError(t, legacy.DropRole(ctx, tenant, "role1"))
+	assert.NoError(t, legacy.DeleteGrant(ctx, tenant, &milvuspb.RoleEntity{Name: "role1"}))
+
+	// new single-txn path.
+	assert.NoError(t, composite.Update(ctx, 0,
+		metastore.DropRoleGrants(tenant, "role1"),
+		metastore.DropRole(tenant, "role1")))
+
+	got := dumpKV(t, compositeKV)
+	assert.Equal(t, dumpKV(t, legacyKV), got)
+
+	// all four key classes of role1 are gone.
+	assert.NotContains(t, got, RolePrefix+"/role1")
+	assert.NotContains(t, got, RoleMappingPrefix+"/user1/role1")
+	assert.NotContains(t, got, RoleMappingPrefix+"/user2/role1")
+	for k := range got {
+		assert.False(t, strings.HasPrefix(k, funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, "role1")), k)
+		for _, id := range granteeIDs {
+			assert.False(t, strings.HasPrefix(k, funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, id)), k)
+		}
+	}
+	// canaries of role10 survive.
+	assert.Contains(t, got, RolePrefix+"/role10")
+	assert.Contains(t, got, RoleMappingPrefix+"/user1/role10")
+	has, err := compositeKV.HasPrefix(ctx, funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, "role10"))
+	assert.NoError(t, err)
+	assert.True(t, has)
+}
+
+// writeRecordingKV records every write-path TxnKV call so a test can assert
+// the composite drop-role issues exactly one transaction.
+type writeRecordingKV struct {
+	*memkv.MemoryKV
+	calls          []string
+	removals       []string
+	prefixRemovals []string
+}
+
+func (w *writeRecordingKV) Save(ctx context.Context, key, value string) error {
+	w.calls = append(w.calls, "Save")
+	return w.MemoryKV.Save(ctx, key, value)
+}
+
+func (w *writeRecordingKV) Remove(ctx context.Context, key string) error {
+	w.calls = append(w.calls, "Remove")
+	return w.MemoryKV.Remove(ctx, key)
+}
+
+func (w *writeRecordingKV) RemoveWithPrefix(ctx context.Context, key string) error {
+	w.calls = append(w.calls, "RemoveWithPrefix")
+	return w.MemoryKV.RemoveWithPrefix(ctx, key)
+}
+
+func (w *writeRecordingKV) MultiSave(ctx context.Context, kvs map[string]string) error {
+	w.calls = append(w.calls, "MultiSave")
+	return w.MemoryKV.MultiSave(ctx, kvs)
+}
+
+func (w *writeRecordingKV) MultiRemove(ctx context.Context, keys []string) error {
+	w.calls = append(w.calls, "MultiRemove")
+	return w.MemoryKV.MultiRemove(ctx, keys)
+}
+
+func (w *writeRecordingKV) MultiSaveAndRemove(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	w.calls = append(w.calls, "MultiSaveAndRemove")
+	return w.MemoryKV.MultiSaveAndRemove(ctx, saves, removals, preds...)
+}
+
+func (w *writeRecordingKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	w.calls = append(w.calls, "MultiSaveAndRemoveWithPrefix")
+	return w.MemoryKV.MultiSaveAndRemoveWithPrefix(ctx, saves, removals, preds...)
+}
+
+func (w *writeRecordingKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	w.calls = append(w.calls, "MultiSaveAndRemoveMixed")
+	w.removals = removals
+	w.prefixRemovals = prefixRemovals
+	return w.MemoryKV.MultiSaveAndRemoveMixed(ctx, saves, removals, prefixRemovals, preds...)
+}
+
+// TestCatalog_Update_DropRoleWithGrants_SingleTxn proves the whole removal is
+// one MultiSaveAndRemoveMixed transaction carrying the role record and the
+// mappings as EXACT removals and the grant subtrees as PREFIX removals.
+func TestCatalog_Update_DropRoleWithGrants_SingleTxn(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+	mk := memkv.NewMemoryKV()
+	seedDropRoleRBAC(t, NewCatalog(mk))
+
+	_, granteeIDs, err := mk.LoadWithPrefix(ctx, funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, "role1"))
+	assert.NoError(t, err)
+	assert.Len(t, granteeIDs, 2)
+
+	rec := &writeRecordingKV{MemoryKV: mk}
+	c := NewCatalog(rec)
+	assert.NoError(t, c.Update(ctx, 0,
+		metastore.DropRoleGrants(tenant, "role1"),
+		metastore.DropRole(tenant, "role1")))
+
+	assert.Equal(t, []string{"MultiSaveAndRemoveMixed"}, rec.calls)
+	assert.ElementsMatch(t, []string{
+		RolePrefix + "/role1",
+		RoleMappingPrefix + "/user1/role1",
+		RoleMappingPrefix + "/user2/role1",
+	}, rec.removals)
+	wantPrefixes := []string{funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, "role1")}
+	for _, id := range granteeIDs {
+		wantPrefixes = append(wantPrefixes, funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, id))
+	}
+	assert.ElementsMatch(t, wantPrefixes, rec.prefixRemovals)
+}
+
+// flakyMixedKV fails the first MultiSaveAndRemoveMixed to simulate a crash of
+// the atomic commit.
+type flakyMixedKV struct {
+	*memkv.MemoryKV
+	failures int
+}
+
+func (f *flakyMixedKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	if f.failures > 0 {
+		f.failures--
+		return errors.New("injected crash")
+	}
+	return f.MemoryKV.MultiSaveAndRemoveMixed(ctx, saves, removals, prefixRemovals, preds...)
+}
+
+// TestCatalog_Update_DropRoleWithGrants_AtomicCrashRetry: a failed atomic
+// commit must leave the store untouched (no partial removal, no orphaned
+// grants), and retrying the same composite drop must converge to exactly the
+// legacy two-call end state.
+func TestCatalog_Update_DropRoleWithGrants_AtomicCrashRetry(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+
+	legacyKV := memkv.NewMemoryKV()
+	legacy := NewCatalog(legacyKV)
+	seedDropRoleRBAC(t, legacy)
+	assert.NoError(t, legacy.DropRole(ctx, tenant, "role1"))
+	assert.NoError(t, legacy.DeleteGrant(ctx, tenant, &milvuspb.RoleEntity{Name: "role1"}))
+
+	fk := &flakyMixedKV{MemoryKV: memkv.NewMemoryKV(), failures: 1}
+	seedDropRoleRBAC(t, NewCatalog(fk.MemoryKV))
+	before := dumpKV(t, fk.MemoryKV)
+
+	c := NewCatalog(fk)
+	drop := func() error {
+		return c.Update(ctx, 0,
+			metastore.DropRoleGrants(tenant, "role1"),
+			metastore.DropRole(tenant, "role1"))
+	}
+	assert.Error(t, drop())
+	// atomic: the failed commit applied nothing.
+	assert.Equal(t, before, dumpKV(t, fk.MemoryKV))
+
+	assert.NoError(t, drop())
+	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, fk.MemoryKV))
+}
+
+// smallTxnFlakyPrefixKV shrinks MaxTxnOps so the composite takes the chunked
+// fallback and fails the first prefix-removal batch, simulating a crash
+// mid-fallback before the commit marker.
+type smallTxnFlakyPrefixKV struct {
+	*memkv.MemoryKV
+	failures int
+}
+
+func (f *smallTxnFlakyPrefixKV) MaxTxnOps() int { return 2 }
+
+func (f *smallTxnFlakyPrefixKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	if f.failures > 0 {
+		f.failures--
+		return errors.New("injected crash")
+	}
+	return f.MemoryKV.MultiSaveAndRemoveWithPrefix(ctx, saves, removals, preds...)
+}
+
+// secondChunkCrashKV shrinks MaxTxnOps so the prefix removals split into two
+// chunks and fails only the second one, simulating a crash between chunks.
+type secondChunkCrashKV struct {
+	*memkv.MemoryKV
+	prefixCalls int
+	failAtCall  int
+}
+
+func (f *secondChunkCrashKV) MaxTxnOps() int { return 2 }
+
+func (f *secondChunkCrashKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	f.prefixCalls++
+	if f.prefixCalls == f.failAtCall {
+		return errors.New("injected crash")
+	}
+	return f.MemoryKV.MultiSaveAndRemoveWithPrefix(ctx, saves, removals, preds...)
+}
+
+// TestCatalog_Update_DropRoleWithGrants_SecondPrefixChunkCrashRetry: on the
+// chunked fallback path the grantee-privileges subtree is the only index from
+// which a retry can rediscover the grantee-id subtrees. A crash between prefix
+// chunks must therefore leave that subtree intact so the retry converges to
+// the legacy end state instead of permanently orphaning grantee-id subtrees
+// (which a same-name role re-grant would silently resurrect).
+func TestCatalog_Update_DropRoleWithGrants_SecondPrefixChunkCrashRetry(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+
+	legacyKV := memkv.NewMemoryKV()
+	legacy := NewCatalog(legacyKV)
+	seedDropRoleRBAC(t, legacy)
+	assert.NoError(t, legacy.DropRole(ctx, tenant, "role1"))
+	assert.NoError(t, legacy.DeleteGrant(ctx, tenant, &milvuspb.RoleEntity{Name: "role1"}))
+
+	fk := &secondChunkCrashKV{MemoryKV: memkv.NewMemoryKV(), failAtCall: 2}
+	seedDropRoleRBAC(t, NewCatalog(fk.MemoryKV))
+
+	c := NewCatalog(fk)
+	drop := func() error {
+		return c.Update(ctx, 0,
+			metastore.DropRoleGrants(tenant, "role1"),
+			metastore.DropRole(tenant, "role1"))
+	}
+	assert.Error(t, drop())
+	// the rediscovery index must have survived the crash.
+	keys, _, err := fk.MemoryKV.LoadWithPrefix(ctx, funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, "role1"))
+	assert.NoError(t, err)
+	assert.NotEmpty(t, keys)
+
+	assert.NoError(t, drop())
+	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, fk.MemoryKV))
+}
+
+// TestCatalog_Update_DropRoleWithGrants_FallbackCrashRetry: on the chunked
+// fallback path a crash before the commit marker must leave the role record
+// visible (so the drop is observably incomplete and retryable, never a
+// role-gone-grants-orphaned state), and the retry must converge to the legacy
+// end state.
+func TestCatalog_Update_DropRoleWithGrants_FallbackCrashRetry(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+
+	legacyKV := memkv.NewMemoryKV()
+	legacy := NewCatalog(legacyKV)
+	seedDropRoleRBAC(t, legacy)
+	assert.NoError(t, legacy.DropRole(ctx, tenant, "role1"))
+	assert.NoError(t, legacy.DeleteGrant(ctx, tenant, &milvuspb.RoleEntity{Name: "role1"}))
+
+	fk := &smallTxnFlakyPrefixKV{MemoryKV: memkv.NewMemoryKV(), failures: 1}
+	seedDropRoleRBAC(t, NewCatalog(fk.MemoryKV))
+
+	c := NewCatalog(fk)
+	drop := func() error {
+		return c.Update(ctx, 0,
+			metastore.DropRoleGrants(tenant, "role1"),
+			metastore.DropRole(tenant, "role1"))
+	}
+	assert.Error(t, drop())
+	// crash-safety: the role record (commit marker) must still be visible.
+	has, err := fk.Has(ctx, RolePrefix+"/role1")
+	assert.NoError(t, err)
+	assert.True(t, has)
+
+	assert.NoError(t, drop())
+	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, fk.MemoryKV))
 }

--- a/internal/metastore/kv/txn/builder.go
+++ b/internal/metastore/kv/txn/builder.go
@@ -64,14 +64,10 @@ func (b *Builder) Remove(key string) {
 
 // RemovePrefix records a prefix delete.
 //
-// Asymmetry to know before mixing: an op set that combines exact removals
-// (Remove) and prefix removals (RemovePrefix) commits fine on the chunked
-// fallback path (each kind is flushed with its own method) but is REJECTED on
-// the atomic path (commitAtomic) - a single etcd txn cannot express both
-// without widening the exact deletes to prefixes. So the same mixed set may
-// succeed or error depending only on whether it fits the txn limit. No Update
-// caller emits RemovePrefix today; if one does, either keep exact and prefix
-// removals in separate Update calls, or teach commitAtomic to split them.
+// Mixing exact removals (Remove) and prefix removals (RemovePrefix) in one op
+// set is supported on both commit paths: the atomic path routes the mix
+// through MultiSaveAndRemoveMixed (one txn, each delete keeps its shape), and
+// the chunked fallback flushes each kind with its own method.
 func (b *Builder) RemovePrefix(prefix string) {
 	b.ops = append(b.ops, op{key: prefix, kind: opDelPrefix})
 }

--- a/internal/metastore/kv/txn/commit.go
+++ b/internal/metastore/kv/txn/commit.go
@@ -83,12 +83,12 @@ func commitAtomic(ctx context.Context, txn kv.TxnKV, b *Builder) error {
 			prefixRemovals = append(prefixRemovals, o.key)
 		}
 	}
-	// A single etcd txn cannot express exact and prefix deletes together:
 	// MultiSaveAndRemoveWithPrefix deletes EVERY listed key by prefix, so an
 	// exact Remove("coll-1") routed through it would also nuke "coll-10" and
-	// "coll-1/x". Reject the mix rather than silently widen the delete.
+	// "coll-1/x". A mixed set therefore routes through MultiSaveAndRemoveMixed,
+	// the one TxnKV call that keeps both delete shapes in a single txn.
 	if len(removals) > 0 && len(prefixRemovals) > 0 {
-		return merr.WrapErrParameterInvalidMsg("composite update cannot mix exact and prefix removals in one atomic transaction")
+		return txn.MultiSaveAndRemoveMixed(ctx, saves, removals, prefixRemovals)
 	}
 	if len(prefixRemovals) > 0 {
 		return txn.MultiSaveAndRemoveWithPrefix(ctx, saves, prefixRemovals)

--- a/internal/metastore/kv/txn/commit_test.go
+++ b/internal/metastore/kv/txn/commit_test.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	memkv "github.com/milvus-io/milvus/internal/kv/mem"
 	kvmocks "github.com/milvus-io/milvus/internal/kv/mocks"
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 )
@@ -92,21 +94,6 @@ func TestCommit_FallbackPutBatchesPreserveOrder(t *testing.T) {
 	}, batches)
 }
 
-// TestCommit_AtomicMixedRemovalsRejected proves FIX 2: a single etcd txn
-// cannot express both exact and prefix deletes via MultiSaveAndRemoveWithPrefix
-// (which deletes every listed key by prefix). Mixing them in the atomic path
-// must return an error and issue no KV call at all.
-func TestCommit_AtomicMixedRemovalsRejected(t *testing.T) {
-	tk := kvmocks.NewTxnKV(t) // no EXPECT: any KV call fails the test
-	tk.EXPECT().MaxTxnOps().Return(64).Maybe()
-
-	b := New()
-	b.Save("a", "1")
-	b.Remove("coll-1")
-	b.RemovePrefix("coll-1/")
-	assert.Error(t, Commit(context.Background(), tk, b))
-}
-
 // TestCommit_AtomicOnlyPrefixRemoval covers the prefix-only atomic path: it
 // must route through MultiSaveAndRemoveWithPrefix with exactly the prefix
 // removals (no exact removals folded in).
@@ -120,6 +107,156 @@ func TestCommit_AtomicOnlyPrefixRemoval(t *testing.T) {
 	b.Save("a", "1")
 	b.RemovePrefix("pfx")
 	assert.NoError(t, Commit(context.Background(), tk, b))
+}
+
+// TestCommit_AtomicMixedRemovals: exact and prefix removals in one
+// within-limit Commit must route through MultiSaveAndRemoveMixed - the one
+// TxnKV call that keeps exact deletes exact - with byte-for-byte the recorded
+// saves/removals, in a single call.
+func TestCommit_AtomicMixedRemovals(t *testing.T) {
+	tk := kvmocks.NewTxnKV(t)
+	tk.EXPECT().MaxTxnOps().Return(64).Maybe()
+	tk.EXPECT().MultiSaveAndRemoveMixed(mock.Anything,
+		map[string]string{"a": "1"}, []string{"coll-1"}, []string{"coll-1/"}).Return(nil).Once()
+
+	b := New()
+	b.Save("a", "1")
+	b.Remove("coll-1")
+	b.RemovePrefix("coll-1/")
+	assert.NoError(t, Commit(context.Background(), tk, b))
+}
+
+// TestCommit_AtomicMixedRemovalsOnMemoryKV drives the mixed-removal atomic
+// path against a real (in-memory) TxnKV: one Commit carrying saves, an exact
+// removal AND a prefix removal must succeed atomically and leave exactly the
+// expected keys behind. "coll-10" is the widening canary: routing the exact
+// Remove("coll-1") through a prefix delete would wrongly wipe it.
+func TestCommit_AtomicMixedRemovalsOnMemoryKV(t *testing.T) {
+	ctx := context.Background()
+	mk := memkv.NewMemoryKV()
+	assert.NoError(t, mk.MultiSave(ctx, map[string]string{
+		"coll-1":       "tombstoned",
+		"coll-1/seg-1": "s1",
+		"coll-1/seg-2": "s2",
+		"coll-10":      "keep",
+	}))
+
+	b := New()
+	b.Save("coll-2", "v2")
+	b.Remove("coll-1")
+	b.RemovePrefix("coll-1/")
+	assert.NoError(t, Commit(ctx, mk, b))
+
+	keys, vals, err := mk.LoadWithPrefix(ctx, "")
+	assert.NoError(t, err)
+	got := make(map[string]string, len(keys))
+	for i, k := range keys {
+		got[k] = vals[i]
+	}
+	assert.Equal(t, map[string]string{
+		"coll-10": "keep",
+		"coll-2":  "v2",
+	}, got)
+}
+
+// TestCommit_FallbackMixedRemovalsMarkerLast: a mixed exact+prefix removal set
+// that exceeds the txn limit must take the chunked fallback - each removal
+// kind flushed with its own method, in recorded order - and the commit marker
+// must still be the final guarded txn.
+func TestCommit_FallbackMixedRemovalsMarkerLast(t *testing.T) {
+	tk := kvmocks.NewTxnKV(t)
+	tk.EXPECT().MaxTxnOps().Return(2).Maybe()
+
+	var calls []string
+	tk.EXPECT().MultiSave(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, kvs map[string]string) error {
+		calls = append(calls, "save")
+		return nil
+	}).Once()
+	tk.EXPECT().MultiSaveAndRemove(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, saves map[string]string, removals []string, _ ...predicates.Predicate) error {
+			if len(saves) == 0 {
+				calls = append(calls, "remove:"+removals[0])
+			} else {
+				calls = append(calls, "commit")
+			}
+			return nil
+		}).Twice()
+	tk.EXPECT().MultiSaveAndRemoveWithPrefix(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ map[string]string, removals []string, _ ...predicates.Predicate) error {
+			calls = append(calls, "removePrefix:"+removals[0])
+			return nil
+		}).Once()
+
+	b := New()
+	b.Save("a1", "1")
+	b.Save("a2", "2")
+	b.Remove("x")
+	b.RemovePrefix("p/")
+	b.CommitSave("marker", "v")
+	assert.NoError(t, Commit(context.Background(), tk, b)) // 5 ops > limit=2 forces fallback
+
+	assert.Equal(t, []string{"save", "remove:x", "removePrefix:p/", "commit"}, calls)
+}
+
+// flakyPrefixKV wraps MemoryKV, failing the first MultiSaveAndRemoveWithPrefix
+// call to simulate a crash mid-fallback, and shrinking MaxTxnOps so Commit
+// takes the chunked path.
+type flakyPrefixKV struct {
+	*memkv.MemoryKV
+	failures int
+}
+
+func (f *flakyPrefixKV) MaxTxnOps() int { return 2 }
+
+func (f *flakyPrefixKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	if f.failures > 0 {
+		f.failures--
+		return errors.New("injected crash")
+	}
+	return f.MemoryKV.MultiSaveAndRemoveWithPrefix(ctx, saves, removals, preds...)
+}
+
+// TestCommit_MixedRemovalsRetryAfterCrashConverges: a fallback flush that dies
+// after the puts but before the prefix removal must leave the commit marker
+// unwritten (the composite write stays invisible), and re-running the same
+// Commit must converge to exactly the intended final state.
+func TestCommit_MixedRemovalsRetryAfterCrashConverges(t *testing.T) {
+	ctx := context.Background()
+	fk := &flakyPrefixKV{MemoryKV: memkv.NewMemoryKV(), failures: 1}
+	assert.NoError(t, fk.MultiSave(ctx, map[string]string{
+		"old":       "gone",
+		"old/sub-1": "gone",
+	}))
+
+	build := func() *Builder {
+		b := New()
+		b.Save("k1", "1")
+		b.Save("k2", "2")
+		b.Save("k3", "3")
+		b.Remove("old")
+		b.RemovePrefix("old/")
+		b.CommitSave("marker", "v")
+		return b
+	}
+
+	assert.Error(t, Commit(ctx, fk, build())) // dies at the prefix-removal batch
+
+	// crash-safety: the commit marker must not have landed.
+	has, err := fk.Has(ctx, "marker")
+	assert.NoError(t, err)
+	assert.False(t, has)
+
+	assert.NoError(t, Commit(ctx, fk, build())) // retry converges
+
+	keys, vals, err := fk.LoadWithPrefix(ctx, "")
+	assert.NoError(t, err)
+	got := make(map[string]string, len(keys))
+	for i, k := range keys {
+		got[k] = vals[i]
+	}
+	assert.Equal(t, map[string]string{
+		"k1": "1", "k2": "2", "k3": "3", "marker": "v",
+	}, got)
 }
 
 // TestCommit_FallbackPreservesOrderAcrossKinds is a self-review addition (not

--- a/internal/metastore/update_action.go
+++ b/internal/metastore/update_action.go
@@ -152,6 +152,19 @@ type ReplicaKeyEntry struct {
 	ReplicaID    int64
 }
 
+// RoleEntry targets a role's record and its user-role mappings.
+type RoleEntry struct {
+	Tenant string
+	Name   string
+}
+
+// RoleGrantsEntry targets every grant of a role: the role's
+// grantee-privileges subtree plus the grantee-id subtrees it references.
+type RoleGrantsEntry struct {
+	Tenant   string
+	RoleName string
+}
+
 func (SegmentEntry) isEntry()               {}
 func (ChannelEntry) isEntry()               {}
 func (CollectionEntry) isEntry()            {}
@@ -162,6 +175,8 @@ func (PartitionStatsEntry) isEntry()        {}
 func (PartitionStatsVersionEntry) isEntry() {}
 func (ReplicaEntry) isEntry()               {}
 func (ReplicaKeyEntry) isEntry()            {}
+func (RoleEntry) isEntry()                  {}
+func (RoleGrantsEntry) isEntry()            {}
 
 // UpdateAction is a single composable write against a metastore catalog,
 // applied via that catalog's composite Update. Type and Entry together
@@ -283,4 +298,23 @@ func SaveReplica(r *querypb.Replica) UpdateAction {
 // ReleaseReplica returns an UpdateAction that removes a replica's kv record.
 func ReleaseReplica(collectionID, replicaID int64) UpdateAction {
 	return UpdateAction{Type: ActionDelete, Entry: ReplicaKeyEntry{CollectionID: collectionID, ReplicaID: replicaID}}
+}
+
+// DropRole returns an UpdateAction that removes a role's record and its
+// user-role mappings. Compose it after DropRoleGrants for the same role: the
+// role record is the visibility marker of the whole removal and must land
+// last on the chunked fallback path, so a crash mid-drop leaves the role
+// visible (and the drop retryable) instead of orphaning its grants.
+func DropRole(tenant string, roleName string) UpdateAction {
+	return UpdateAction{Type: ActionDelete, Entry: RoleEntry{Tenant: tenant, Name: roleName}}
+}
+
+// DropRoleGrants returns an UpdateAction that removes every grant of a role.
+// Both DropRole and DropRoleGrants read the current key set at apply time and
+// commit it without predicate checks, so the caller must serialize them
+// against concurrent grant/user-role writes (rootcoord does this via
+// MetaTable's permission lock); an unserialized caller can lose a concurrent
+// grant or leave one undeleted.
+func DropRoleGrants(tenant string, roleName string) UpdateAction {
+	return UpdateAction{Type: ActionDelete, Entry: RoleGrantsEntry{Tenant: tenant, RoleName: roleName}}
 }

--- a/internal/rootcoord/ddl_callbacks_rbac_role.go
+++ b/internal/rootcoord/ddl_callbacks_rbac_role.go
@@ -116,12 +116,11 @@ func (c *Core) broadcastDropRole(ctx context.Context, in *milvuspb.DropRoleReque
 func (c *DDLCallback) dropRoleV2AckCallback(ctx context.Context, result message.BroadcastResultDropRoleMessageV2) error {
 	// There should always be only one message in the msgs slice.
 	msg := result.Message
+	// DropRole also removes every grant of the role in the same composite
+	// catalog write, so no separate DropGrant call is needed here.
 	err := c.meta.DropRole(ctx, util.DefaultTenant, msg.Header().RoleName)
 	if err != nil {
 		return merr.Wrap(err, "failed to drop role")
-	}
-	if err := c.meta.DropGrant(ctx, util.DefaultTenant, &milvuspb.RoleEntity{Name: msg.Header().RoleName}); err != nil {
-		return merr.Wrap(err, "failed to drop grant")
 	}
 	if err := c.proxyClientManager.RefreshPolicyInfoCache(ctx, &proxypb.RefreshPolicyInfoCacheRequest{
 		OpType: int32(typeutil.CacheDropRole),

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -1999,12 +1999,16 @@ func validateRoleDescription(description string) error {
 	return rbacutil.ValidateRoleDescription(description, Params.ProxyCfg.MaxRoleDescriptionLength.GetAsInt())
 }
 
-// DropRole drop role info
+// DropRole drops the role record, its user-role mappings and every grant of
+// the role in one composite catalog write, so a crash can never leave
+// orphaned grants behind a deleted role.
 func (mt *MetaTable) DropRole(ctx context.Context, tenant string, roleName string) error {
 	mt.permissionLock.Lock()
 	defer mt.permissionLock.Unlock()
 
-	return mt.catalog.DropRole(ctx, tenant, roleName)
+	return mt.catalog.Update(ctx, 0,
+		metastore.DropRoleGrants(tenant, roleName),
+		metastore.DropRole(tenant, roleName))
 }
 
 func (mt *MetaTable) CheckIfOperateUserRole(ctx context.Context, req *milvuspb.OperateUserRoleRequest) error {

--- a/internal/rootcoord/meta_table_test.go
+++ b/internal/rootcoord/meta_table_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
+	memkv "github.com/milvus-io/milvus/internal/kv/mem"
 	"github.com/milvus-io/milvus/internal/metastore"
 	"github.com/milvus-io/milvus/internal/metastore/kv/rootcoord"
 	"github.com/milvus-io/milvus/internal/metastore/mocks"
@@ -589,6 +590,48 @@ func TestRbacDropRole(t *testing.T) {
 	// drop a not exist role
 	err = mt.CheckIfDropRole(context.TODO(), &milvuspb.DropRoleRequest{RoleName: "role_not_exist"})
 	require.ErrorIs(t, err, errRoleNotExists)
+}
+
+// TestRbacDropRoleAlsoDropsGrants: DropRole must take down the whole role
+// chain - role record, user-role mappings AND every grant of the role - in
+// one composite catalog write, so no separate DropGrant call is needed and a
+// crash can never leave orphaned grants behind a deleted role.
+func TestRbacDropRoleAlsoDropsGrants(t *testing.T) {
+	mt := &MetaTable{catalog: rootcoord.NewCatalog(memkv.NewMemoryKV())}
+	ctx := context.TODO()
+	roleName := "role" + funcutil.RandomString(10)
+
+	require.NoError(t, mt.CreateRole(ctx, util.DefaultTenant, &milvuspb.RoleEntity{Name: roleName}))
+	require.NoError(t, mt.OperateUserRole(ctx, util.DefaultTenant,
+		&milvuspb.UserEntity{Name: "user1"}, &milvuspb.RoleEntity{Name: roleName},
+		milvuspb.OperateUserRoleType_AddUserToRole))
+	require.NoError(t, mt.OperatePrivilege(ctx, util.DefaultTenant, &milvuspb.GrantEntity{
+		Role:       &milvuspb.RoleEntity{Name: roleName},
+		Object:     &milvuspb.ObjectEntity{Name: "Collection"},
+		ObjectName: "coll1",
+		DbName:     "db1",
+		Grantor: &milvuspb.GrantorEntity{
+			User:      &milvuspb.UserEntity{Name: "root"},
+			Privilege: &milvuspb.PrivilegeEntity{Name: "Insert"},
+		},
+	}, milvuspb.OperatePrivilegeType_Grant))
+	policies, err := mt.ListPolicy(ctx, util.DefaultTenant)
+	require.NoError(t, err)
+	require.Len(t, policies, 1)
+
+	require.NoError(t, mt.DropRole(ctx, util.DefaultTenant, roleName))
+
+	// role record gone.
+	_, err = mt.SelectRole(ctx, util.DefaultTenant, &milvuspb.RoleEntity{Name: roleName}, false)
+	require.ErrorIs(t, err, merr.ErrIoKeyNotFound)
+	// user-role mappings gone.
+	userRoles, err := mt.ListUserRole(ctx, util.DefaultTenant)
+	require.NoError(t, err)
+	require.Empty(t, userRoles)
+	// grants gone - no orphaned policy survives the drop.
+	policies, err = mt.ListPolicy(ctx, util.DefaultTenant)
+	require.NoError(t, err)
+	require.Empty(t, policies)
 }
 
 func TestRbacOperateRole(t *testing.T) {

--- a/pkg/kv/kv.go
+++ b/pkg/kv/kv.go
@@ -18,10 +18,13 @@ package kv
 
 import (
 	"context"
+	"sort"
+	"strings"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // CompareFailedError is a helper type for checking MetaKv CompareAndSwap series func error type
@@ -66,7 +69,7 @@ type TxnKV interface {
 	// all in one transaction. MultiSaveAndRemoveWithPrefix cannot express this
 	// mix - it widens EVERY removal to a prefix delete. A key present in both
 	// @saves and @removals is saved, not removed; a saved key under a removed
-	// prefix is backend-dependent (etcd rejects the txn) and must be avoided.
+	// prefix is rejected because backend semantics differ for that overlap.
 	MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error
 	// MaxTxnOps reports the maximum number of key operations this store applies
 	// as a single atomic transaction; a batch exceeding it must be split by the
@@ -75,6 +78,29 @@ type TxnKV interface {
 	// rather than a backend-specific constant. It bounds op COUNT only, not the
 	// request's total byte size.
 	MaxTxnOps() int
+}
+
+// ValidateNoSaveUnderRemovedPrefix rejects ambiguous mixed transactions where
+// a saved key also falls under a prefix removal.
+func ValidateNoSaveUnderRemovedPrefix(saves map[string]string, prefixRemovals []string) error {
+	if len(saves) == 0 || len(prefixRemovals) == 0 {
+		return nil
+	}
+
+	saveKeys := make([]string, 0, len(saves))
+	for key := range saves {
+		saveKeys = append(saveKeys, key)
+	}
+	sort.Strings(saveKeys)
+
+	for _, prefix := range prefixRemovals {
+		i := sort.SearchStrings(saveKeys, prefix)
+		if i < len(saveKeys) && strings.HasPrefix(saveKeys[i], prefix) {
+			return merr.WrapErrParameterInvalidMsg(
+				"save key %q conflicts with removed prefix %q", saveKeys[i], prefix)
+		}
+	}
+	return nil
 }
 
 // MetaKv is TxnKV for metadata. It should save data with lease.

--- a/pkg/kv/kv.go
+++ b/pkg/kv/kv.go
@@ -61,6 +61,13 @@ type TxnKV interface {
 	BaseKV
 	MultiSaveAndRemove(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error
 	MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error
+	// MultiSaveAndRemoveMixed saves kv in @saves, removes the exact keys in
+	// @removals AND removes every key under the prefixes in @prefixRemovals,
+	// all in one transaction. MultiSaveAndRemoveWithPrefix cannot express this
+	// mix - it widens EVERY removal to a prefix delete. A key present in both
+	// @saves and @removals is saved, not removed; a saved key under a removed
+	// prefix is backend-dependent (etcd rejects the txn) and must be avoided.
+	MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error
 	// MaxTxnOps reports the maximum number of key operations this store applies
 	// as a single atomic transaction; a batch exceeding it must be split by the
 	// caller. This is a per-store property (etcd's is small, TiKV's is large),

--- a/pkg/kv/kv_test.go
+++ b/pkg/kv/kv_test.go
@@ -1,0 +1,50 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+func TestValidateNoSaveUnderRemovedPrefix(t *testing.T) {
+	t.Run("rejects save under removed prefix", func(t *testing.T) {
+		err := ValidateNoSaveUnderRemovedPrefix(
+			map[string]string{"mix/a-1/c3": "new"}, []string{"mix/a-1/"})
+
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("allows adjacent prefix canary", func(t *testing.T) {
+		err := ValidateNoSaveUnderRemovedPrefix(
+			map[string]string{"mix/a-10": "keep"}, []string{"mix/a-1/"})
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects empty prefix when saves exist", func(t *testing.T) {
+		err := ValidateNoSaveUnderRemovedPrefix(
+			map[string]string{"any/key": "value"}, []string{""})
+
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+}

--- a/pkg/kv/reliable_write_meta_kv.go
+++ b/pkg/kv/reliable_write_meta_kv.go
@@ -68,6 +68,12 @@ func (kv *ReliableWriteMetaKv) MultiSaveAndRemoveWithPrefix(ctx context.Context,
 	})
 }
 
+func (kv *ReliableWriteMetaKv) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	return kv.retryWithBackoff(ctx, func(ctx context.Context) error {
+		return kv.MetaKv.MultiSaveAndRemoveMixed(ctx, saves, removals, prefixRemovals, preds...)
+	})
+}
+
 func (kv *ReliableWriteMetaKv) CompareVersionAndSwap(ctx context.Context, key string, version int64, target string) (bool, error) {
 	var result bool
 	err := kv.retryWithBackoff(ctx, func(ctx context.Context) error {

--- a/pkg/kv/rocksdb/rocksdb_kv.go
+++ b/pkg/kv/rocksdb/rocksdb_kv.go
@@ -456,6 +456,35 @@ func (kv *RocksdbKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map
 	return err
 }
 
+// MultiSaveAndRemoveMixed saves kv in @saves, removes the exact keys in
+// @removals and removes every key under the prefixes in @prefixRemovals in a
+// single write batch.
+func (kv *RocksdbKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	if len(preds) > 0 {
+		return merr.WrapErrServiceUnavailable("predicates not supported")
+	}
+	if kv.DB == nil {
+		return merr.WrapErrServiceInternalMsg("Rocksdb instance is nil when do MultiSaveAndRemoveMixed")
+	}
+	writeBatch := gorocksdb.NewWriteBatch()
+	defer writeBatch.Destroy()
+	// use complement to remove keys that are not in saves
+	saveKeys := typeutil.NewSet(lo.Keys(saves)...)
+	removeKeys := typeutil.NewSet(removals...)
+	removals = removeKeys.Complement(saveKeys).Collect()
+
+	for _, key := range removals {
+		writeBatch.Delete([]byte(key))
+	}
+	kv.prepareRemovePrefix(prefixRemovals, writeBatch)
+	for k, v := range saves {
+		writeBatch.Put([]byte(k), []byte(v))
+	}
+
+	err := kv.DB.Write(kv.WriteOptions, writeBatch)
+	return err
+}
+
 func (kv *RocksdbKV) prepareRemovePrefix(prefixes []string, writeBatch *gorocksdb.WriteBatch) {
 	// check if any empty prefix, if yes then we delete whole table, no more data should be remained
 	for _, prefix := range prefixes {

--- a/pkg/kv/rocksdb/rocksdb_kv.go
+++ b/pkg/kv/rocksdb/rocksdb_kv.go
@@ -23,13 +23,13 @@ import (
 	"github.com/samber/lo"
 	"github.com/tecbot/gorocksdb"
 
-	"github.com/milvus-io/milvus/pkg/v3/kv"
+	kvpkg "github.com/milvus-io/milvus/pkg/v3/kv"
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
-var _ kv.BaseKV = (*RocksdbKV)(nil)
+var _ kvpkg.BaseKV = (*RocksdbKV)(nil)
 
 // RocksdbKV is KV implemented by rocksdb
 type RocksdbKV struct {
@@ -462,6 +462,9 @@ func (kv *RocksdbKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map
 func (kv *RocksdbKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
 	if len(preds) > 0 {
 		return merr.WrapErrServiceUnavailable("predicates not supported")
+	}
+	if err := kvpkg.ValidateNoSaveUnderRemovedPrefix(saves, prefixRemovals); err != nil {
+		return err
 	}
 	if kv.DB == nil {
 		return merr.WrapErrServiceInternalMsg("Rocksdb instance is nil when do MultiSaveAndRemoveMixed")

--- a/pkg/mocks/mock_kv/mock_MetaKv.go
+++ b/pkg/mocks/mock_kv/mock_MetaKv.go
@@ -659,6 +659,70 @@ func (_c *MockMetaKv_MultiSaveAndRemove_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
+// MultiSaveAndRemoveMixed provides a mock function with given fields: ctx, saves, removals, prefixRemovals, preds
+func (_m *MockMetaKv) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	_va := make([]interface{}, len(preds))
+	for _i := range preds {
+		_va[_i] = preds[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, saves, removals, prefixRemovals)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MultiSaveAndRemoveMixed")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, map[string]string, []string, []string, ...predicates.Predicate) error); ok {
+		r0 = rf(ctx, saves, removals, prefixRemovals, preds...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockMetaKv_MultiSaveAndRemoveMixed_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MultiSaveAndRemoveMixed'
+type MockMetaKv_MultiSaveAndRemoveMixed_Call struct {
+	*mock.Call
+}
+
+// MultiSaveAndRemoveMixed is a helper method to define mock.On call
+//   - ctx context.Context
+//   - saves map[string]string
+//   - removals []string
+//   - prefixRemovals []string
+//   - preds ...predicates.Predicate
+func (_e *MockMetaKv_Expecter) MultiSaveAndRemoveMixed(ctx interface{}, saves interface{}, removals interface{}, prefixRemovals interface{}, preds ...interface{}) *MockMetaKv_MultiSaveAndRemoveMixed_Call {
+	return &MockMetaKv_MultiSaveAndRemoveMixed_Call{Call: _e.mock.On("MultiSaveAndRemoveMixed",
+		append([]interface{}{ctx, saves, removals, prefixRemovals}, preds...)...)}
+}
+
+func (_c *MockMetaKv_MultiSaveAndRemoveMixed_Call) Run(run func(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate)) *MockMetaKv_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]predicates.Predicate, len(args)-4)
+		for i, a := range args[4:] {
+			if a != nil {
+				variadicArgs[i] = a.(predicates.Predicate)
+			}
+		}
+		run(args[0].(context.Context), args[1].(map[string]string), args[2].([]string), args[3].([]string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockMetaKv_MultiSaveAndRemoveMixed_Call) Return(_a0 error) *MockMetaKv_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockMetaKv_MultiSaveAndRemoveMixed_Call) RunAndReturn(run func(context.Context, map[string]string, []string, []string, ...predicates.Predicate) error) *MockMetaKv_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MultiSaveAndRemoveWithPrefix provides a mock function with given fields: ctx, saves, removals, preds
 func (_m *MockMetaKv) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
 	_va := make([]interface{}, len(preds))

--- a/pkg/mocks/mock_kv/mock_WatchKV.go
+++ b/pkg/mocks/mock_kv/mock_WatchKV.go
@@ -661,6 +661,70 @@ func (_c *MockWatchKV_MultiSaveAndRemove_Call) RunAndReturn(run func(context.Con
 	return _c
 }
 
+// MultiSaveAndRemoveMixed provides a mock function with given fields: ctx, saves, removals, prefixRemovals, preds
+func (_m *MockWatchKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	_va := make([]interface{}, len(preds))
+	for _i := range preds {
+		_va[_i] = preds[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, saves, removals, prefixRemovals)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MultiSaveAndRemoveMixed")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, map[string]string, []string, []string, ...predicates.Predicate) error); ok {
+		r0 = rf(ctx, saves, removals, prefixRemovals, preds...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockWatchKV_MultiSaveAndRemoveMixed_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MultiSaveAndRemoveMixed'
+type MockWatchKV_MultiSaveAndRemoveMixed_Call struct {
+	*mock.Call
+}
+
+// MultiSaveAndRemoveMixed is a helper method to define mock.On call
+//   - ctx context.Context
+//   - saves map[string]string
+//   - removals []string
+//   - prefixRemovals []string
+//   - preds ...predicates.Predicate
+func (_e *MockWatchKV_Expecter) MultiSaveAndRemoveMixed(ctx interface{}, saves interface{}, removals interface{}, prefixRemovals interface{}, preds ...interface{}) *MockWatchKV_MultiSaveAndRemoveMixed_Call {
+	return &MockWatchKV_MultiSaveAndRemoveMixed_Call{Call: _e.mock.On("MultiSaveAndRemoveMixed",
+		append([]interface{}{ctx, saves, removals, prefixRemovals}, preds...)...)}
+}
+
+func (_c *MockWatchKV_MultiSaveAndRemoveMixed_Call) Run(run func(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate)) *MockWatchKV_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]predicates.Predicate, len(args)-4)
+		for i, a := range args[4:] {
+			if a != nil {
+				variadicArgs[i] = a.(predicates.Predicate)
+			}
+		}
+		run(args[0].(context.Context), args[1].(map[string]string), args[2].([]string), args[3].([]string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockWatchKV_MultiSaveAndRemoveMixed_Call) Return(_a0 error) *MockWatchKV_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockWatchKV_MultiSaveAndRemoveMixed_Call) RunAndReturn(run func(context.Context, map[string]string, []string, []string, ...predicates.Predicate) error) *MockWatchKV_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MultiSaveAndRemoveWithPrefix provides a mock function with given fields: ctx, saves, removals, preds
 func (_m *MockWatchKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
 	_va := make([]interface{}, len(preds))


### PR DESCRIPTION
issue: #51351

## What

The composite-update txn engine (#51624) rejects mixing exact and prefix removals in one atomic transaction, which blocked two call sites that #51624 explicitly deferred:

- **rootcoord `dropRole`**: DropRole (exact removals) + DeleteGrant (prefix removals) were two independent catalog calls — a crash in between leaves orphaned grants.
- **querycoord `ReleaseCollection`**: exact collection-key removal + partition prefix removal were two steps — a crash in between leaves a collection released with partitions still persisted.

This PR adds mixed-removal support to the engine and folds both flows into single composite transactions. Three commits, one concern each:

1. `enhance: support mixed exact and prefix removals in composite txn` — new `TxnKV.MultiSaveAndRemoveMixed`: etcd implements it natively (one txn mixing exact `OpDelete` and `WithPrefix` deletes), TiKV materializes prefixes into exact deletes inside the same transaction snapshot; `txn.Commit` lifts the mix ban on the atomic path. Chunked-fallback semantics (commit marker lands last) unchanged.
2. `enhance: drop role and its grants in one composite txn` — role record + user-role mappings + grantee-privileges/grantee-id subtrees in one composite `Update`; role record remains the visibility marker (lands last on fallback). Persisted keys/values are byte-for-byte identical to the legacy two-call end state.
3. `enhance: release collection load info atomically` — collection load-info exact removal + partition prefix removal in one transaction.

## Crash-safety hardening found in review

Adversarial review with fault injection caught an ordering bug in the drop-role fallback path: the grantee-privileges subtree (the only index from which a retry can rediscover grantee-id subtrees) was removed in the first prefix chunk. A crash between chunks made the retry converge "successfully" while permanently orphaning the remaining grantee-id subtrees — and since `crypto.GranteeID` is deterministic, re-creating a same-name role and granting on the same object silently resurrects the stale privileges. Fixed by ordering the index subtree last; regression test `TestCatalog_Update_DropRoleWithGrants_SecondPrefixChunkCrashRetry` injects a second-chunk crash and asserts retry converges to the legacy end state.

## Testing

TDD throughout (every test was written first and observed failing). Coverage follows the #51624 test bar: byte-for-byte encoding equivalence with the legacy paths, op ordering, atomic/fallback crash injection with retry convergence, idempotent retry. Full `internal/metastore/...`, `internal/kv/...`, `internal/querycoordv2/meta/...` and `internal/rootcoord/...` suites pass locally.

## Notes

- `MetaTable.DropGrant` / `IMetaTable.DropGrant` now have no production callers (the drop-role flow no longer uses them); removal is deferred to a follow-up cleanup to keep this PR focused.
- Concurrency precondition documented on `metastore.DropRoleGrants`: apply-time reads are committed without predicates, callers must serialize against concurrent grant writes (rootcoord does via MetaTable's permission lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
