### PR TITLE
fix: materialize geometry WKT default as WKB for absent columns (#51649)

### DIFF
--- a/internal/storage/arrow_util.go
+++ b/internal/storage/arrow_util.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -326,6 +327,16 @@ func GenerateEmptyArrayFromSchema(schema *schemapb.FieldSchema, numRows int) (ar
 			bd := builder.(*array.BinaryBuilder)
 			bd.AppendValues(
 				lo.RepeatBy(numRows, func(_ int) []byte { return schema.GetDefaultValue().GetBytesData() }),
+				nil)
+		case schemapb.DataType_Geometry:
+			// DDL persists the geometry default as WKT; storage carries WKB.
+			wkb, err := common.ConvertWKTToWKB(schema.GetDefaultValue().GetStringData())
+			if err != nil {
+				return nil, merr.WrapErrServiceInternalErr(err, "convert geometry default value for field %s", schema.GetName())
+			}
+			bd := builder.(*array.BinaryBuilder)
+			bd.AppendValues(
+				lo.RepeatBy(numRows, func(_ int) []byte { return wkb }),
 				nil)
 		default:
 			return nil, merr.WrapErrServiceInternalMsg("Unexpected default value type: %s", schema.GetDataType().String())

--- a/internal/storage/arrow_util_test.go
+++ b/internal/storage/arrow_util_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 )
 
 func TestGenerateEmptyArray(t *testing.T) {
@@ -378,4 +379,26 @@ func TestRecordBuilderBuildReleasesCreatorRefs(t *testing.T) {
 		rec.Release()
 	}()
 	alloc.AssertSize(t, 0)
+}
+
+func TestGenerateEmptyArrayGeometryDefault(t *testing.T) {
+	wkt := "POINT (30 10)"
+	field := &schemapb.FieldSchema{
+		FieldID: 110, Name: "geo", DataType: schemapb.DataType_Geometry, Nullable: true,
+		DefaultValue: &schemapb.ValueField{Data: &schemapb.ValueField_StringData{StringData: wkt}},
+	}
+
+	arr, err := GenerateEmptyArrayFromSchema(field, 3)
+	require.NoError(t, err)
+	defer arr.Release()
+
+	wkb, err := common.ConvertWKTToWKB(wkt)
+	require.NoError(t, err)
+	bin, ok := arr.(*array.Binary)
+	require.True(t, ok)
+	require.Equal(t, 3, bin.Len())
+	for i := 0; i < 3; i++ {
+		require.True(t, bin.IsValid(i))
+		require.Equal(t, wkb, bin.Value(i))
+	}
 }


### PR DESCRIPTION
### What

\`GenerateEmptyArrayFromSchema\` had no branch for Geometry defaults: DDL persists a geometry default as WKT (\`ValueField.StringData\`) while storage carries WKB, so materializing a wholly-absent geometry column during compaction (e.g. a column added by \`add_field\` that old segments never wrote) fell into the default-value switch's error branch and failed the compaction. Add the Geometry case: convert the WKT default to WKB and back the generated array with it.

The sibling path where the geometry column physically exists but a cell is NULL (\`appendValueAt\`) is a separate pre-existing issue tracked by #52105.

Split from #51848.

issue: #51649
related: #52105

### Tests

- New \`TestGenerateEmptyArrayGeometryDefault\`: asserts valid bits and exact WKB bytes for every generated row; green locally under \`-tags dynamic,test\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)