### PR TITLE
fix: enforce the add-function backfill gates on the direct RootCoord path (#51649)

### DIFF
--- a/internal/proxy/function_task_test.go
+++ b/internal/proxy/function_task_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/util/function/validator"
+	"github.com/milvus-io/milvus/internal/util/schemautil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -41,35 +43,111 @@ func TestFunctionTask(t *testing.T) {
 	suite.Run(t, new(FunctionTaskSuite))
 }
 
-// TestAddFunctionRequiresStorageV3Gate guards the add_function_field V3 gate (issue #51167):
-// adding a function must be rejected unless StorageV3 (useLoonFFI), the schema-bump compaction
-// (bumpSchemaVersion.enabled), and the storage-version upgrade compaction (storageVersion.enabled)
-// are all on, so the new function output is actually backfilled into pre-existing segments.
-func (f *FunctionTaskSuite) TestAddFunctionRequiresStorageV3Gate() {
+// TestAddFunctionBackfillConfigGate verifies that Proxy wires all four
+// backfill prerequisites into add_function_field pre-execution.
+func (f *FunctionTaskSuite) TestAddFunctionBackfillConfigGate() {
+	compactionEnabled := paramtable.Get().DataCoordCfg.EnableCompaction.Key
+	autoCompactionEnabled := paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key
 	useLoon := paramtable.Get().CommonCfg.UseLoonFFI.Key
 	bumpEnabled := paramtable.Get().DataCoordCfg.BumpSchemaVersionCompactionEnabled.Key
 	svEnabled := paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key
-	defer paramtable.Get().Reset(useLoon)
-	defer paramtable.Get().Reset(bumpEnabled)
-	defer paramtable.Get().Reset(svEnabled)
+	oldCompactionEnabled := paramtable.Get().DataCoordCfg.EnableCompaction.GetValue()
+	oldAutoCompactionEnabled := paramtable.Get().DataCoordCfg.EnableAutoCompaction.GetValue()
+	oldUseLoon := paramtable.Get().CommonCfg.UseLoonFFI.GetValue()
+	oldBumpEnabled := paramtable.Get().DataCoordCfg.BumpSchemaVersionCompactionEnabled.GetValue()
+	oldSVEnabled := paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.GetValue()
+	defer func() {
+		f.NoError(paramtable.Get().Save(compactionEnabled, oldCompactionEnabled))
+		f.NoError(paramtable.Get().Save(autoCompactionEnabled, oldAutoCompactionEnabled))
+		f.NoError(paramtable.Get().Save(useLoon, oldUseLoon))
+		f.NoError(paramtable.Get().Save(bumpEnabled, oldBumpEnabled))
+		f.NoError(paramtable.Get().Save(svEnabled, oldSVEnabled))
+	}()
+
+	buildTask := func() *alterCollectionSchemaTask {
+		return &alterCollectionSchemaTask{
+			AlterCollectionSchemaRequest: &milvuspb.AlterCollectionSchemaRequest{
+				Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+					Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+						AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+							FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+								{
+									FieldSchema: &schemapb.FieldSchema{
+										Name:             "sparse",
+										DataType:         schemapb.DataType_SparseFloatVector,
+										IsFunctionOutput: true,
+									},
+									ExtraParams: []*commonpb.KeyValuePair{
+										{Key: "index_type", Value: "SPARSE_INVERTED_INDEX"},
+										{Key: "metric_type", Value: "BM25"},
+									},
+								},
+							},
+							FuncSchema: []*schemapb.FunctionSchema{
+								{
+									Name:             "bm25",
+									Type:             schemapb.FunctionType_BM25,
+									InputFieldNames:  []string{"text"},
+									OutputFieldNames: []string{"sparse"},
+								},
+							},
+						},
+					},
+				},
+			},
+			oldSchema: &schemapb.CollectionSchema{
+				Fields: []*schemapb.FieldSchema{
+					{
+						FieldID:  100,
+						Name:     "text",
+						DataType: schemapb.DataType_VarChar,
+						TypeParams: []*commonpb.KeyValuePair{
+							{Key: "max_length", Value: "256"},
+							{Key: "enable_analyzer", Value: "true"},
+						},
+					},
+				},
+			},
+		}
+	}
+	validate := func() error {
+		return buildTask().preExecuteAdd(context.Background())
+	}
+	assertConfigError := func(expectedSubstring string) {
+		err := validate()
+		f.ErrorIs(err, merr.ErrServiceUnavailable)
+		f.Equal(merr.SystemError, merr.GetErrorType(err))
+		f.ErrorContains(err, expectedSubstring)
+	}
+
+	// master compaction switch off -> reject
+	f.NoError(paramtable.Get().Save(compactionEnabled, "false"))
+	f.NoError(paramtable.Get().Save(useLoon, "true"))
+	f.NoError(paramtable.Get().Save(bumpEnabled, "true"))
+	f.NoError(paramtable.Get().Save(svEnabled, "true"))
+	assertConfigError("dataCoord.enableCompaction")
 
 	// useLoonFFI off -> reject
-	paramtable.Get().Save(useLoon, "false")
-	f.ErrorContains(validateAddFunctionRequiresStorageV3(), "StorageV3")
+	f.NoError(paramtable.Get().Save(compactionEnabled, "true"))
+	f.NoError(paramtable.Get().Save(useLoon, "false"))
+	f.NoError(paramtable.Get().Save(bumpEnabled, "true"))
+	f.NoError(paramtable.Get().Save(svEnabled, "true"))
+	assertConfigError("StorageV3")
 
 	// useLoonFFI on but bumpSchemaVersion.enabled off -> reject
-	paramtable.Get().Save(useLoon, "true")
-	paramtable.Get().Save(bumpEnabled, "false")
-	f.ErrorContains(validateAddFunctionRequiresStorageV3(), "bumpSchemaVersion.enabled")
+	f.NoError(paramtable.Get().Save(useLoon, "true"))
+	f.NoError(paramtable.Get().Save(bumpEnabled, "false"))
+	assertConfigError("bumpSchemaVersion.enabled")
 
 	// bumpSchemaVersion on but storageVersion.enabled off -> reject
-	paramtable.Get().Save(bumpEnabled, "true")
-	paramtable.Get().Save(svEnabled, "false")
-	f.ErrorContains(validateAddFunctionRequiresStorageV3(), "storageVersion.enabled")
+	f.NoError(paramtable.Get().Save(bumpEnabled, "true"))
+	f.NoError(paramtable.Get().Save(svEnabled, "false"))
+	assertConfigError("storageVersion.enabled")
 
-	// all on -> pass
-	paramtable.Get().Save(svEnabled, "true")
-	f.NoError(validateAddFunctionRequiresStorageV3())
+	// The correctness backfill policy does not depend on ordinary auto-compaction.
+	f.NoError(paramtable.Get().Save(svEnabled, "true"))
+	f.NoError(paramtable.Get().Save(autoCompactionEnabled, "false"))
+	f.NoError(validate())
 }
 
 // TestValidateAddFunctionInputNotText guards the reject of a BM25/MinHash function whose
@@ -86,13 +164,13 @@ func (f *FunctionTaskSuite) TestValidateAddFunctionInputNotText() {
 	}
 
 	// TEXT input rejected for BM25 and MinHash
-	f.ErrorContains(validateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_BM25, "text_in")), "TEXT input field")
-	f.ErrorContains(validateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_MinHash, "text_in")), "TEXT input field")
+	f.ErrorContains(schemautil.ValidateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_BM25, "text_in")), "TEXT input field")
+	f.ErrorContains(schemautil.ValidateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_MinHash, "text_in")), "TEXT input field")
 	// VarChar input allowed
-	f.NoError(validateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_BM25, "varchar_in")))
-	f.NoError(validateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_MinHash, "varchar_in")))
+	f.NoError(schemautil.ValidateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_BM25, "varchar_in")))
+	f.NoError(schemautil.ValidateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_MinHash, "varchar_in")))
 	// non-materialized function type (e.g. TextEmbedding) is out of scope -> allowed even with TEXT input
-	f.NoError(validateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_TextEmbedding, "text_in")))
+	f.NoError(schemautil.ValidateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_TextEmbedding, "text_in")))
 }
 
 func (f *FunctionTaskSuite) TestFunctionOnType() {

--- a/internal/proxy/function_task_test.go
+++ b/internal/proxy/function_task_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/util/function/validator"
+	"github.com/milvus-io/milvus/internal/util/schemautil"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -86,13 +87,13 @@ func (f *FunctionTaskSuite) TestValidateAddFunctionInputNotText() {
 	}
 
 	// TEXT input rejected for BM25 and MinHash
-	f.ErrorContains(validateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_BM25, "text_in")), "TEXT input field")
-	f.ErrorContains(validateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_MinHash, "text_in")), "TEXT input field")
+	f.ErrorContains(schemautil.ValidateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_BM25, "text_in")), "TEXT input field")
+	f.ErrorContains(schemautil.ValidateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_MinHash, "text_in")), "TEXT input field")
 	// VarChar input allowed
-	f.NoError(validateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_BM25, "varchar_in")))
-	f.NoError(validateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_MinHash, "varchar_in")))
+	f.NoError(schemautil.ValidateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_BM25, "varchar_in")))
+	f.NoError(schemautil.ValidateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_MinHash, "varchar_in")))
 	// non-materialized function type (e.g. TextEmbedding) is out of scope -> allowed even with TEXT input
-	f.NoError(validateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_TextEmbedding, "text_in")))
+	f.NoError(schemautil.ValidateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_TextEmbedding, "text_in")))
 }
 
 func (f *FunctionTaskSuite) TestFunctionOnType() {

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -212,64 +212,6 @@ func validateTextStorageV3Enabled(schema *schemapb.CollectionSchema) error {
 	return nil
 }
 
-// validateAddFunctionRequiresStorageV3 rejects adding a function to an existing collection
-// unless the compaction infrastructure that backfills its output field into pre-existing
-// sealed segments is enabled. The new function-output field is materialized only by
-// compaction (bump_schema_version compaction requires a StorageV3 segment):
-//   - common.storage.useLoonFFI: StorageV3 mode (bump works only on V3 segments; TEXT needs V3).
-//   - dataCoord.compaction.bumpSchemaVersion.enabled: the bumpSchemaVersionPolicy that directly
-//     backfills pre-existing V3 segments; it defaults to false, and there is no direct trigger
-//     on the add-function DDL, so without it an already-V3 old segment never receives the output.
-//   - dataCoord.compaction.storageVersion.enabled: the storageVersionUpgradePolicy that first
-//     mix-upgrades a pre-existing V2 segment to V3 so it can be bumped.
-//
-// Without all three, the DDL would succeed while old rows silently never get the function output.
-// New writes always compute the function output at flush, so create_collection with a function is
-// unaffected; this guard applies only to add-function on an existing collection. See issue #51167.
-func validateAddFunctionRequiresStorageV3() error {
-	if !Params.CommonCfg.UseLoonFFI.GetAsBool() {
-		return merr.WrapErrParameterInvalidMsg("adding a function field requires StorageV3; enable common.storage.useLoonFFI")
-	}
-	if !Params.DataCoordCfg.BumpSchemaVersionCompactionEnabled.GetAsBool() {
-		return merr.WrapErrParameterInvalidMsg("adding a function field requires schema-bump compaction to backfill existing segments; enable dataCoord.compaction.bumpSchemaVersion.enabled")
-	}
-	if !Params.DataCoordCfg.StorageVersionCompactionEnabled.GetAsBool() {
-		return merr.WrapErrParameterInvalidMsg("adding a function field requires the storage-version upgrade compaction; enable dataCoord.compaction.storageVersion.enabled")
-	}
-	return nil
-}
-
-// validateAddFunctionInputNotText rejects adding a BM25/MinHash function whose input is a
-// TEXT field. TEXT columns are stored as binary LOB references, so when the async backfill
-// compaction materializes the function output for pre-existing segments it reads the input
-// back as *array.Binary and hard-fails in stringInputsFromRecord ("cannot materialize bm25
-// from text binary values without lob decoding"); the add-function DDL would return success
-// while the backfill silently fails and old rows never get the output. Reject it up front
-// (fail-fast). VarChar inputs stay allowed, and create_collection with such a function is
-// unaffected -- its output is computed at flush from the raw text. Distinct from the
-// storage-version gate (validateAddFunctionRequiresStorageV3): this is a request-content
-// input-type constraint, not an environment/config check. See issue #51167.
-func validateAddFunctionInputNotText(schema *schemapb.CollectionSchema, function *schemapb.FunctionSchema) error {
-	switch function.GetType() {
-	case schemapb.FunctionType_BM25, schemapb.FunctionType_MinHash:
-	default:
-		// Only BM25/MinHash are materialized from string input during backfill.
-		return nil
-	}
-	fieldByName := make(map[string]*schemapb.FieldSchema, len(schema.GetFields()))
-	for _, f := range schema.GetFields() {
-		fieldByName[f.GetName()] = f
-	}
-	for _, name := range function.GetInputFieldNames() {
-		if f, ok := fieldByName[name]; ok && f.GetDataType() == schemapb.DataType_Text {
-			return merr.WrapErrParameterInvalidMsg(
-				"adding a %s function with a TEXT input field (%s) is not supported: its output cannot be backfilled into existing segments; use a VARCHAR input field",
-				function.GetType().String(), name)
-		}
-	}
-	return nil
-}
-
 type createCollectionTask struct {
 	baseTask
 	Condition
@@ -1158,6 +1100,7 @@ func (t *alterCollectionSchemaTask) preExecuteAdd(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	isExternalCollection := typeutil.IsExternalCollection(t.oldSchema)
 
 	if plan.HasField() {
 		if err := validateAddFieldRequest(t.oldSchema, plan.Field); err != nil {
@@ -1175,8 +1118,15 @@ func (t *alterCollectionSchemaTask) preExecuteAdd(ctx context.Context) error {
 		}
 	}
 	if plan.HasFunction() {
-		if err := validateAddFunctionRequiresStorageV3(); err != nil {
-			return err
+		if !isExternalCollection {
+			if err := schemautil.ValidateAddFunctionBackfillConfig(
+				Params.DataCoordCfg.EnableCompaction.GetAsBool(),
+				Params.CommonCfg.UseLoonFFI.GetAsBool(),
+				Params.DataCoordCfg.BumpSchemaVersionCompactionEnabled.GetAsBool(),
+				Params.DataCoordCfg.StorageVersionCompactionEnabled.GetAsBool(),
+			); err != nil {
+				return err
+			}
 		}
 		if err := schemautil.ValidateAlterSchemaAddFunctionPlan(plan); err != nil {
 			return err
@@ -1219,8 +1169,10 @@ func (t *alterCollectionSchemaTask) preExecuteAdd(ctx context.Context) error {
 		mergedSchema.Fields = append(mergedSchema.Fields, proto.Clone(plan.Field).(*schemapb.FieldSchema))
 	}
 	mergedSchema.Functions = append(mergedSchema.Functions, plan.Function)
-	if err := validateAddFunctionInputNotText(mergedSchema, plan.Function); err != nil {
-		return err
+	if !isExternalCollection || typeutil.NewStorageColumnResolver(mergedSchema).IsMilvusTable() {
+		if err := schemautil.ValidateAddFunctionInputNotText(mergedSchema, plan.Function); err != nil {
+			return err
+		}
 	}
 	if err := validator.ValidateFunction(mergedSchema, plan.Function.GetName(), false); err != nil {
 		return err

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -239,37 +239,6 @@ func validateAddFunctionRequiresStorageV3() error {
 	return nil
 }
 
-// validateAddFunctionInputNotText rejects adding a BM25/MinHash function whose input is a
-// TEXT field. TEXT columns are stored as binary LOB references, so when the async backfill
-// compaction materializes the function output for pre-existing segments it reads the input
-// back as *array.Binary and hard-fails in stringInputsFromRecord ("cannot materialize bm25
-// from text binary values without lob decoding"); the add-function DDL would return success
-// while the backfill silently fails and old rows never get the output. Reject it up front
-// (fail-fast). VarChar inputs stay allowed, and create_collection with such a function is
-// unaffected -- its output is computed at flush from the raw text. Distinct from the
-// storage-version gate (validateAddFunctionRequiresStorageV3): this is a request-content
-// input-type constraint, not an environment/config check. See issue #51167.
-func validateAddFunctionInputNotText(schema *schemapb.CollectionSchema, function *schemapb.FunctionSchema) error {
-	switch function.GetType() {
-	case schemapb.FunctionType_BM25, schemapb.FunctionType_MinHash:
-	default:
-		// Only BM25/MinHash are materialized from string input during backfill.
-		return nil
-	}
-	fieldByName := make(map[string]*schemapb.FieldSchema, len(schema.GetFields()))
-	for _, f := range schema.GetFields() {
-		fieldByName[f.GetName()] = f
-	}
-	for _, name := range function.GetInputFieldNames() {
-		if f, ok := fieldByName[name]; ok && f.GetDataType() == schemapb.DataType_Text {
-			return merr.WrapErrParameterInvalidMsg(
-				"adding a %s function with a TEXT input field (%s) is not supported: its output cannot be backfilled into existing segments; use a VARCHAR input field",
-				function.GetType().String(), name)
-		}
-	}
-	return nil
-}
-
 type createCollectionTask struct {
 	baseTask
 	Condition
@@ -1219,7 +1188,7 @@ func (t *alterCollectionSchemaTask) preExecuteAdd(ctx context.Context) error {
 		mergedSchema.Fields = append(mergedSchema.Fields, proto.Clone(plan.Field).(*schemapb.FieldSchema))
 	}
 	mergedSchema.Functions = append(mergedSchema.Functions, plan.Function)
-	if err := validateAddFunctionInputNotText(mergedSchema, plan.Function); err != nil {
+	if err := schemautil.ValidateAddFunctionInputNotText(mergedSchema, plan.Function); err != nil {
 		return err
 	}
 	if err := validator.ValidateFunction(mergedSchema, plan.Function.GetName(), false); err != nil {

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -7763,13 +7763,17 @@ func TestValidateAddFieldRequest(t *testing.T) {
 }
 
 func TestAlterCollectionSchemaTask(t *testing.T) {
-	// Add-function cases require StorageV3 + schema-bump/storage-version compaction enabled
-	// (validateAddFunctionRequiresStorageV3). storageVersion.enabled defaults true;
+	// Add-function cases require compaction + StorageV3 + schema-bump/storage-version compaction enabled
+	// (schemautil.ValidateAddFunctionBackfillConfig). storageVersion.enabled defaults true;
 	// bumpSchemaVersion.enabled defaults false, so it must be set explicitly.
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableCompaction.Key, "true")
 	paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "true")
 	paramtable.Get().Save(paramtable.Get().DataCoordCfg.BumpSchemaVersionCompactionEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableCompaction.Key)
 	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
 	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.BumpSchemaVersionCompactionEnabled.Key)
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key)
 	rc := NewMixCoordMock()
 	ctx := context.Background()
 	prefix := "TestAlterCollectionSchemaTask"

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
@@ -130,6 +130,26 @@ func (c *Core) broadcastAlterCollectionSchemaAdd(ctx context.Context, broadcaste
 		if err := validator.ValidateFunction(schema, plan.Function.GetName(), true); err != nil {
 			return merr.Wrap(err, "invalid function schema")
 		}
+		isExternalCollection := typeutil.IsExternalCollection(schema)
+		// Non-milvus-table external sources expose TEXT as ordinary UTF8 input.
+		// Internal and milvus-table manifests expose TEXT as binary LOB references.
+		if !isExternalCollection || typeutil.NewStorageColumnResolver(schema).IsMilvusTable() {
+			if err := schemautil.ValidateAddFunctionInputNotText(schema, plan.Function); err != nil {
+				return err
+			}
+		}
+		// External collections materialize function outputs during refresh, not
+		// through internal schema-bump/storage-version compaction.
+		if !isExternalCollection {
+			if err := schemautil.ValidateAddFunctionBackfillConfig(
+				Params.DataCoordCfg.EnableCompaction.GetAsBool(),
+				Params.CommonCfg.UseLoonFFI.GetAsBool(),
+				Params.DataCoordCfg.BumpSchemaVersionCompactionEnabled.GetAsBool(),
+				Params.DataCoordCfg.StorageVersionCompactionEnabled.GetAsBool(),
+			); err != nil {
+				return err
+			}
+		}
 	}
 	if err := typeutil.ValidateExternalCollectionResolvedSchema(schema); err != nil {
 		return err

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
@@ -130,6 +130,9 @@ func (c *Core) broadcastAlterCollectionSchemaAdd(ctx context.Context, broadcaste
 		if err := validator.ValidateFunction(schema, plan.Function.GetName(), true); err != nil {
 			return merr.Wrap(err, "invalid function schema")
 		}
+		if err := schemautil.ValidateAddFunctionInputNotText(schema, plan.Function); err != nil {
+			return err
+		}
 	}
 	if err := typeutil.ValidateExternalCollectionResolvedSchema(schema); err != nil {
 		return err

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
@@ -89,6 +89,29 @@ func buildAlterSchemaReq(dbName, collName, inputField, outputField, funcName str
 	}
 }
 
+func setAddFunctionBackfillConfig(t *testing.T, compactionEnabled, storageV3Enabled, bumpSchemaVersionEnabled, storageVersionEnabled bool) {
+	t.Helper()
+	params := paramtable.Get()
+	configs := []struct {
+		key      string
+		oldValue string
+		value    string
+	}{
+		{params.DataCoordCfg.EnableCompaction.Key, params.DataCoordCfg.EnableCompaction.GetValue(), strconv.FormatBool(compactionEnabled)},
+		{params.CommonCfg.UseLoonFFI.Key, params.CommonCfg.UseLoonFFI.GetValue(), strconv.FormatBool(storageV3Enabled)},
+		{params.DataCoordCfg.BumpSchemaVersionCompactionEnabled.Key, params.DataCoordCfg.BumpSchemaVersionCompactionEnabled.GetValue(), strconv.FormatBool(bumpSchemaVersionEnabled)},
+		{params.DataCoordCfg.StorageVersionCompactionEnabled.Key, params.DataCoordCfg.StorageVersionCompactionEnabled.GetValue(), strconv.FormatBool(storageVersionEnabled)},
+	}
+	for _, config := range configs {
+		require.NoError(t, params.Save(config.key, config.value))
+	}
+	t.Cleanup(func() {
+		for _, config := range configs {
+			require.NoError(t, params.Save(config.key, config.oldValue))
+		}
+	})
+}
+
 func buildAlterSchemaAddFieldReq(dbName, collName, fieldName string, doBackfill bool) *milvuspb.AlterCollectionSchemaRequest {
 	return buildAlterSchemaAddFieldSchemaReq(dbName, collName, &schemapb.FieldSchema{
 		Name:     fieldName,
@@ -132,6 +155,7 @@ func buildAlterSchemaAddFunctionReq(dbName, collName string, functionSchema *sch
 }
 
 func TestDDLCallbacksBroadcastAlterCollectionSchema(t *testing.T) {
+	setAddFunctionBackfillConfig(t, true, true, true, true)
 	core := initStreamingSystemAndCore(t)
 
 	ctx := context.Background()
@@ -1011,6 +1035,7 @@ func TestDDLCallbacksAlterCollectionDropFieldWaitsForSchemaDropReady(t *testing.
 }
 
 func TestDDLCallbacksAlterCollectionSchemaAddSkipsSchemaDropReady(t *testing.T) {
+	setAddFunctionBackfillConfig(t, true, true, true, true)
 	core := initStreamingSystemAndCore(t)
 
 	ctx := context.Background()
@@ -1923,5 +1948,179 @@ func TestApplyBoundFieldIndexesInline(t *testing.T) {
 		err := cb.applyBoundFieldIndexesInline(context.Background(), buildResult([]*indexpb.FieldIndex{boundFieldIndex}))
 		require.Error(t, err)
 		require.ErrorContains(t, err, "failed to apply bound field index")
+	})
+}
+
+// The proxy runs this gate in alterCollectionSchemaTask.preExecuteAdd, but a
+// request hitting RootCoord directly bypasses the proxy entirely — the
+// broadcast callback must enforce it too.
+func TestDDLCallbacksAlterCollectionSchemaRejectsTextFunctionInput(t *testing.T) {
+	coll := &model.Collection{
+		CollectionID: 1,
+		Name:         "coll",
+		Fields: []*model.Field{
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{
+				FieldID: 101, Name: "text_input", DataType: schemapb.DataType_Text, Nullable: true,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.EnableAnalyzerKey, Value: "true"},
+					{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+				},
+			},
+		},
+	}
+	core := &Core{}
+
+	bm25Req := buildAlterSchemaReq("db", coll.Name, "text_input", "sparse_from_text", "bm25_from_text")
+	bm25Err := core.broadcastAlterCollectionSchemaAdd(context.Background(), nil, coll, bm25Req)
+	require.ErrorIs(t, bm25Err, merr.ErrParameterInvalid)
+	require.ErrorContains(t, bm25Err, "TEXT input field")
+}
+
+func TestDDLCallbacksAlterCollectionSchemaExternalFunctionGates(t *testing.T) {
+	buildCollection := func(inputType schemapb.DataType, externalSpec string) *model.Collection {
+		typeParams := []*commonpb.KeyValuePair{
+			{Key: common.EnableAnalyzerKey, Value: "true"},
+		}
+		if inputType == schemapb.DataType_Text {
+			typeParams = append(typeParams, &commonpb.KeyValuePair{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`})
+		} else {
+			typeParams = append(typeParams, &commonpb.KeyValuePair{Key: common.MaxLengthKey, Value: "256"})
+		}
+		return &model.Collection{
+			CollectionID:   1,
+			Name:           "external_coll",
+			ExternalSource: "s3://bucket/source",
+			ExternalSpec:   externalSpec,
+			Fields: []*model.Field{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{
+					FieldID:       101,
+					Name:          "text_input",
+					DataType:      inputType,
+					Nullable:      true,
+					ExternalField: "source_text",
+					TypeParams:    typeParams,
+				},
+			},
+		}
+	}
+	assertGatesSkipped := func(t *testing.T, coll *model.Collection) {
+		t.Helper()
+		gateReachedErr := errors.New("reached bound-index preparation")
+		mixc := imocks.NewMixCoord(t)
+		mixc.EXPECT().DescribeIndex(mock.Anything, mock.Anything).Return(nil, gateReachedErr)
+		core := newTestCore(withMixCoord(mixc))
+		err := core.broadcastAlterCollectionSchemaAdd(
+			context.Background(),
+			nil,
+			coll,
+			buildAlterSchemaReq("db", coll.Name, "text_input", "sparse", "bm25"),
+		)
+		require.ErrorIs(t, err, gateReachedErr)
+	}
+
+	t.Run("external parquet skips backfill config gate", func(t *testing.T) {
+		setAddFunctionBackfillConfig(t, false, false, false, false)
+		assertGatesSkipped(t, buildCollection(schemapb.DataType_VarChar, `{"format":"parquet"}`))
+	})
+
+	t.Run("external parquet TEXT skips both add-function gates", func(t *testing.T) {
+		// Keep the separate, pre-existing TEXT/StorageV3 validation satisfied;
+		// this test is scoped to the two add-function gates introduced by #52220.
+		setAddFunctionBackfillConfig(t, false, true, false, false)
+		assertGatesSkipped(t, buildCollection(schemapb.DataType_Text, `{"format":"parquet"}`))
+	})
+
+	t.Run("milvus-table keeps TEXT gate but skips config gate", func(t *testing.T) {
+		setAddFunctionBackfillConfig(t, false, true, false, false)
+		coll := buildCollection(schemapb.DataType_Text, `{"format":"milvus-table"}`)
+		err := (&Core{}).broadcastAlterCollectionSchemaAdd(
+			context.Background(),
+			nil,
+			coll,
+			buildAlterSchemaReq("db", coll.Name, "text_input", "sparse", "bm25"),
+		)
+		require.ErrorIs(t, err, merr.ErrParameterInvalid)
+		require.Equal(t, merr.InputError, merr.GetErrorType(err))
+		require.ErrorContains(t, err, "TEXT input field")
+	})
+}
+
+func TestDDLCallbacksAlterCollectionSchemaRequiresBackfillConfig(t *testing.T) {
+	coll := &model.Collection{
+		CollectionID: 1,
+		Name:         "coll",
+		Fields: []*model.Field{
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{
+				FieldID: 101, Name: "text_input", DataType: schemapb.DataType_VarChar, Nullable: true,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "256"},
+					{Key: common.EnableAnalyzerKey, Value: "true"},
+				},
+			},
+		},
+	}
+	tests := []struct {
+		name                     string
+		compactionEnabled        bool
+		storageV3Enabled         bool
+		bumpSchemaVersionEnabled bool
+		storageVersionEnabled    bool
+		expectedErrorSubstring   string
+	}{
+		{"compaction disabled", false, true, true, true, "dataCoord.enableCompaction"},
+		{"StorageV3 disabled", true, false, true, true, "common.storage.useLoonFFI"},
+		{"schema-version bump disabled", true, true, false, true, "dataCoord.compaction.bumpSchemaVersion.enabled"},
+		{"storage-version compaction disabled", true, true, true, false, "dataCoord.compaction.storageVersion.enabled"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setAddFunctionBackfillConfig(t, test.compactionEnabled, test.storageV3Enabled, test.bumpSchemaVersionEnabled, test.storageVersionEnabled)
+			// A nil Core dependency set and nil broadcaster are intentional: the
+			// gate must return before bound-index allocation, resource reservation,
+			// or WAL broadcast touches any of them.
+			err := (&Core{}).broadcastAlterCollectionSchemaAdd(
+				context.Background(),
+				nil,
+				coll,
+				buildAlterSchemaReq("db", coll.Name, "text_input", "sparse", "bm25"),
+			)
+			require.ErrorIs(t, err, merr.ErrServiceUnavailable)
+			require.Equal(t, merr.SystemError, merr.GetErrorType(err))
+			require.ErrorContains(t, err, test.expectedErrorSubstring)
+		})
+	}
+
+	t.Run("all enabled", func(t *testing.T) {
+		setAddFunctionBackfillConfig(t, true, true, true, true)
+		params := paramtable.Get()
+		oldAutoCompaction := params.DataCoordCfg.EnableAutoCompaction.GetValue()
+		require.NoError(t, params.Save(params.DataCoordCfg.EnableAutoCompaction.Key, "false"))
+		t.Cleanup(func() {
+			require.NoError(t, params.Save(params.DataCoordCfg.EnableAutoCompaction.Key, oldAutoCompaction))
+		})
+		core := initStreamingSystemAndCore(t)
+		ctx := context.Background()
+		dbName := "testDB" + funcutil.RandomString(10)
+		collectionName := "testCollection" + funcutil.RandomString(10)
+		createCollectionForTest(t, ctx, core, dbName, collectionName)
+
+		resp, err := core.AlterCollectionSchema(ctx, buildAlterSchemaAddFieldSchemaReq(dbName, collectionName, &schemapb.FieldSchema{
+			Name:     "text_input",
+			DataType: schemapb.DataType_VarChar,
+			Nullable: true,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.MaxLengthKey, Value: "256"},
+				{Key: common.EnableAnalyzerKey, Value: "true"},
+			},
+		}, false))
+		require.NoError(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
+
+		resp, err = core.AlterCollectionSchema(ctx, buildAlterSchemaReq(dbName, collectionName, "text_input", "sparse", "bm25"))
+		require.NoError(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
+		assertSchemaVersion(t, ctx, core, dbName, collectionName, 2)
 	})
 }

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
@@ -1925,3 +1925,29 @@ func TestApplyBoundFieldIndexesInline(t *testing.T) {
 		require.ErrorContains(t, err, "failed to apply bound field index")
 	})
 }
+
+// The proxy runs this gate in alterCollectionSchemaTask.preExecuteAdd, but a
+// request hitting RootCoord directly bypasses the proxy entirely — the
+// broadcast callback must enforce it too.
+func TestDDLCallbacksAlterCollectionSchemaRejectsTextFunctionInput(t *testing.T) {
+	coll := &model.Collection{
+		CollectionID: 1,
+		Name:         "coll",
+		Fields: []*model.Field{
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{
+				FieldID: 101, Name: "text_input", DataType: schemapb.DataType_Text, Nullable: true,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.EnableAnalyzerKey, Value: "true"},
+					{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+				},
+			},
+		},
+	}
+	core := &Core{}
+
+	bm25Req := buildAlterSchemaReq("db", coll.Name, "text_input", "sparse_from_text", "bm25_from_text")
+	bm25Err := core.broadcastAlterCollectionSchemaAdd(context.Background(), nil, coll, bm25Req)
+	require.ErrorIs(t, bm25Err, merr.ErrParameterInvalid)
+	require.ErrorContains(t, bm25Err, "TEXT input field")
+}

--- a/internal/rootcoord/ddl_callbacks_schema_validation_test.go
+++ b/internal/rootcoord/ddl_callbacks_schema_validation_test.go
@@ -130,6 +130,7 @@ func TestDDLCallbacksSchemaEvolutionRejectsInPlaceFieldMutation(t *testing.T) {
 }
 
 func TestDDLCallbacksSchemaEvolutionRejectsGraphBreakingAlterCollectionSchemaDrop(t *testing.T) {
+	setAddFunctionBackfillConfig(t, true, true, true, true)
 	core := initStreamingSystemAndCore(t)
 	ctx := context.Background()
 	dbName := "testDB" + funcutil.RandomString(10)

--- a/internal/util/schemautil/alter_schema_add.go
+++ b/internal/util/schemautil/alter_schema_add.go
@@ -140,6 +140,53 @@ func ValidateAlterSchemaAddFunctionPlan(plan *AlterSchemaAddPlan) error {
 	}
 }
 
+// ValidateAddFunctionBackfillConfig rejects adding a function to an existing
+// collection unless the storage and compaction paths that materialize its
+// output for pre-existing sealed segments are enabled. New writes compute the
+// function output at flush, so this guard applies only to add_function_field:
+//   - Compaction must be enabled so the backfill infrastructure is running.
+//   - StorageV3 is required because schema-version bump works only on V3 segments.
+//   - schema-version bump compaction backfills pre-existing V3 segments.
+//   - storage-version compaction upgrades pre-existing V2 segments before backfill.
+func ValidateAddFunctionBackfillConfig(compactionEnabled, storageV3Enabled, bumpSchemaVersionEnabled, storageVersionEnabled bool) error {
+	if !compactionEnabled {
+		return merr.WrapErrServiceUnavailableMsg("adding a function field requires compaction; enable dataCoord.enableCompaction")
+	}
+	if !storageV3Enabled {
+		return merr.WrapErrServiceUnavailableMsg("adding a function field requires StorageV3; enable common.storage.useLoonFFI")
+	}
+	if !bumpSchemaVersionEnabled {
+		return merr.WrapErrServiceUnavailableMsg("adding a function field requires schema-bump compaction to backfill existing segments; enable dataCoord.compaction.bumpSchemaVersion.enabled")
+	}
+	if !storageVersionEnabled {
+		return merr.WrapErrServiceUnavailableMsg("adding a function field requires the storage-version upgrade compaction; enable dataCoord.compaction.storageVersion.enabled")
+	}
+	return nil
+}
+
+// ValidateAddFunctionInputNotText rejects BM25/MinHash backfill from TEXT
+// fields because existing TEXT values are stored as binary LOB references.
+func ValidateAddFunctionInputNotText(schema *schemapb.CollectionSchema, function *schemapb.FunctionSchema) error {
+	switch function.GetType() {
+	case schemapb.FunctionType_BM25, schemapb.FunctionType_MinHash:
+	default:
+		return nil
+	}
+
+	fieldByName := make(map[string]*schemapb.FieldSchema, len(schema.GetFields()))
+	for _, field := range schema.GetFields() {
+		fieldByName[field.GetName()] = field
+	}
+	for _, inputFieldName := range function.GetInputFieldNames() {
+		if field, ok := fieldByName[inputFieldName]; ok && field.GetDataType() == schemapb.DataType_Text {
+			return merr.WrapErrParameterInvalidMsg(
+				"adding a %s function with a TEXT input field (%s) is not supported: its output cannot be backfilled into existing segments; use a VARCHAR input field",
+				function.GetType().String(), inputFieldName)
+		}
+	}
+	return nil
+}
+
 func validateAddFunctionFieldAllowed(function *schemapb.FunctionSchema) error {
 	switch function.GetType() {
 	case schemapb.FunctionType_BM25, schemapb.FunctionType_MinHash:

--- a/internal/util/schemautil/alter_schema_add.go
+++ b/internal/util/schemautil/alter_schema_add.go
@@ -140,6 +140,29 @@ func ValidateAlterSchemaAddFunctionPlan(plan *AlterSchemaAddPlan) error {
 	}
 }
 
+// ValidateAddFunctionInputNotText rejects BM25/MinHash backfill from TEXT
+// fields because existing TEXT values are stored as binary LOB references.
+func ValidateAddFunctionInputNotText(schema *schemapb.CollectionSchema, function *schemapb.FunctionSchema) error {
+	switch function.GetType() {
+	case schemapb.FunctionType_BM25, schemapb.FunctionType_MinHash:
+	default:
+		return nil
+	}
+
+	fieldByName := make(map[string]*schemapb.FieldSchema, len(schema.GetFields()))
+	for _, field := range schema.GetFields() {
+		fieldByName[field.GetName()] = field
+	}
+	for _, inputFieldName := range function.GetInputFieldNames() {
+		if field, ok := fieldByName[inputFieldName]; ok && field.GetDataType() == schemapb.DataType_Text {
+			return merr.WrapErrParameterInvalidMsg(
+				"adding a %s function with a TEXT input field (%s) is not supported: its output cannot be backfilled into existing segments; use a VARCHAR input field",
+				function.GetType().String(), inputFieldName)
+		}
+	}
+	return nil
+}
+
 func validateAddFunctionFieldAllowed(function *schemapb.FunctionSchema) error {
 	switch function.GetType() {
 	case schemapb.FunctionType_BM25, schemapb.FunctionType_MinHash:

--- a/internal/util/schemautil/alter_schema_add_test.go
+++ b/internal/util/schemautil/alter_schema_add_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func TestValidateAlterSchemaAddFunctionPlan_StandaloneAddRejected(t *testing.T) {
@@ -53,6 +54,72 @@ func TestValidateAlterSchemaAddFunctionPlan_EmptyIndexParamsAllowed(t *testing.T
 	assert.NoError(t, ValidateAlterSchemaAddFunctionPlan(plan))
 }
 
+func TestValidateAddFunctionBackfillConfig(t *testing.T) {
+	tests := []struct {
+		name                     string
+		compactionEnabled        bool
+		storageV3Enabled         bool
+		bumpSchemaVersionEnabled bool
+		storageVersionEnabled    bool
+		expectedErrorSubstring   string
+	}{
+		{
+			name:                     "compaction disabled",
+			storageV3Enabled:         true,
+			bumpSchemaVersionEnabled: true,
+			storageVersionEnabled:    true,
+			expectedErrorSubstring:   "dataCoord.enableCompaction",
+		},
+		{
+			name:                     "StorageV3 disabled",
+			compactionEnabled:        true,
+			bumpSchemaVersionEnabled: true,
+			storageVersionEnabled:    true,
+			expectedErrorSubstring:   "common.storage.useLoonFFI",
+		},
+		{
+			name:                   "schema-version bump disabled",
+			compactionEnabled:      true,
+			storageV3Enabled:       true,
+			storageVersionEnabled:  true,
+			expectedErrorSubstring: "dataCoord.compaction.bumpSchemaVersion.enabled",
+		},
+		{
+			name:                     "storage-version compaction disabled",
+			compactionEnabled:        true,
+			storageV3Enabled:         true,
+			bumpSchemaVersionEnabled: true,
+			expectedErrorSubstring:   "dataCoord.compaction.storageVersion.enabled",
+		},
+		{
+			name:                     "all enabled",
+			compactionEnabled:        true,
+			storageV3Enabled:         true,
+			bumpSchemaVersionEnabled: true,
+			storageVersionEnabled:    true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateAddFunctionBackfillConfig(
+				test.compactionEnabled,
+				test.storageV3Enabled,
+				test.bumpSchemaVersionEnabled,
+				test.storageVersionEnabled,
+			)
+			if test.expectedErrorSubstring == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorIs(t, err, merr.ErrServiceUnavailable)
+			assert.Equal(t, merr.SystemError, merr.GetErrorType(err))
+			assert.True(t, merr.Status(err).GetRetriable())
+			assert.ErrorContains(t, err, test.expectedErrorSubstring)
+		})
+	}
+}
+
 func TestCheckNoFunctionCascade(t *testing.T) {
 	existing := []*schemapb.FunctionSchema{
 		{Name: "bm25", OutputFieldNames: []string{"sparse"}},
@@ -73,4 +140,27 @@ func TestCheckNoFunctionCascade(t *testing.T) {
 	t.Run("nil function -> ok", func(t *testing.T) {
 		assert.NoError(t, CheckNoFunctionCascade(existing, nil))
 	})
+}
+
+func TestValidateAddFunctionInputNotText(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "varchar_in", DataType: schemapb.DataType_VarChar},
+		{FieldID: 101, Name: "text_in", DataType: schemapb.DataType_Text},
+	}}
+	function := func(functionType schemapb.FunctionType, input string) *schemapb.FunctionSchema {
+		return &schemapb.FunctionSchema{
+			Name:            "fn",
+			Type:            functionType,
+			InputFieldNames: []string{input},
+		}
+	}
+
+	for _, functionType := range []schemapb.FunctionType{schemapb.FunctionType_BM25, schemapb.FunctionType_MinHash} {
+		err := ValidateAddFunctionInputNotText(schema, function(functionType, "text_in"))
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Equal(t, merr.InputError, merr.GetErrorType(err))
+		assert.ErrorContains(t, err, "TEXT input field")
+		assert.NoError(t, ValidateAddFunctionInputNotText(schema, function(functionType, "varchar_in")))
+	}
+	assert.NoError(t, ValidateAddFunctionInputNotText(schema, function(schemapb.FunctionType_TextEmbedding, "text_in")))
 }

--- a/internal/util/schemautil/alter_schema_add_test.go
+++ b/internal/util/schemautil/alter_schema_add_test.go
@@ -74,3 +74,24 @@ func TestCheckNoFunctionCascade(t *testing.T) {
 		assert.NoError(t, CheckNoFunctionCascade(existing, nil))
 	})
 }
+
+func TestValidateAddFunctionInputNotText(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "varchar_in", DataType: schemapb.DataType_VarChar},
+		{FieldID: 101, Name: "text_in", DataType: schemapb.DataType_Text},
+	}}
+	function := func(functionType schemapb.FunctionType, input string) *schemapb.FunctionSchema {
+		return &schemapb.FunctionSchema{
+			Name:            "fn",
+			Type:            functionType,
+			InputFieldNames: []string{input},
+		}
+	}
+
+	for _, functionType := range []schemapb.FunctionType{schemapb.FunctionType_BM25, schemapb.FunctionType_MinHash} {
+		err := ValidateAddFunctionInputNotText(schema, function(functionType, "text_in"))
+		assert.ErrorContains(t, err, "TEXT input field")
+		assert.NoError(t, ValidateAddFunctionInputNotText(schema, function(functionType, "varchar_in")))
+	}
+	assert.NoError(t, ValidateAddFunctionInputNotText(schema, function(schemapb.FunctionType_TextEmbedding, "text_in")))
+}


### PR DESCRIPTION
### What

The add-function backfill prerequisites — the TEXT-input rejection **and** the StorageV3 / schema-bump-compaction / storage-version-compaction requirements — lived as proxy-private functions, so they only guarded requests entering through the proxy. A request hitting RootCoord`"'s `add_function_field` DDL directly bypassed them and could register a BM25/MinHash function whose backfill compaction is impossible, leaving pre-existing segments unable to materialize the output (old and new rows with inconsistent function data).

- Move both gates to schemautil (`ValidateAddFunctionInputNotText`, `ValidateAddFunctionBackfillConfig`), each with its test, so they are callable outside the proxy.
- Enforce both in `broadcastAlterCollectionSchemaAdd`, right after function-schema validation — the direct path now rejects the same configurations as the proxy path.
- Switch the proxy call sites to the schemautil symbols and drop the private copies.

Split from #51848.

issue: #51649

### Tests

- `TestDDLCallbacksAlterCollectionSchemaRejectsTextFunctionInput`: direct path rejects a BM25 add over a TEXT input.
- `TestDDLCallbacksAlterCollectionSchemaRequiresBackfillConfig`: direct path rejects an add when any of StorageV3 / bump-schema / storage-version compaction is disabled.
- `TestValidateAddFunctionInputNotText`, `TestValidateAddFunctionBackfillConfig` moved/added in schemautil.
- rootcoord + schemautil + proxy tests green locally under `-tags dynamic,test`; residual references to the old proxy-private symbols grep to zero.