### PR TITLE
fix: account MinHash input analyzer resources without enable_analyzer (#51649)

### DIFF
--- a/internal/rootcoord/create_collection_task.go
+++ b/internal/rootcoord/create_collection_task.go
@@ -935,6 +935,23 @@ func validateMultiAnalyzerParams(params string, coll *schemapb.CollectionSchema,
 	return nil
 }
 
+// isMinHashInputFieldByName reports whether fieldSchema is a MinHash function
+// input, keyed on the field name. Used in the pre-normalization schema
+// validation path where field IDs are not yet canonical.
+func isMinHashInputFieldByName(collSchema *schemapb.CollectionSchema, fieldSchema *schemapb.FieldSchema) bool {
+	for _, fn := range collSchema.GetFunctions() {
+		if fn.GetType() != schemapb.FunctionType_MinHash {
+			continue
+		}
+		for _, name := range fn.GetInputFieldNames() {
+			if name == fieldSchema.GetName() {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func collectAnalyzerInfos(collSchema *schemapb.CollectionSchema) ([]*querypb.AnalyzerInfo, error) {
 	analyzerInfos := make([]*querypb.AnalyzerInfo, 0)
 	for _, field := range collSchema.GetFields() {
@@ -946,7 +963,8 @@ func collectAnalyzerInfos(collSchema *schemapb.CollectionSchema) ([]*querypb.Ana
 }
 
 // validateAnalyzer validates active match/BM25 fields and fields with
-// enable_analyzer=true. Analyzer params are ignored while analyzer is disabled.
+// enable_analyzer=true. Analyzer params are ignored while analyzer is disabled,
+// except for MinHash inputs, which consume them regardless.
 func validateAnalyzer(collSchema *schemapb.CollectionSchema, fieldSchema *schemapb.FieldSchema, analyzerInfos *[]*querypb.AnalyzerInfo) error {
 	h := typeutil.CreateFieldSchemaHelper(fieldSchema)
 	active := h.EnableMatch() || typeutil.IsBm25FunctionInputField(collSchema, fieldSchema)
@@ -954,6 +972,16 @@ func validateAnalyzer(collSchema *schemapb.CollectionSchema, fieldSchema *schema
 		return merr.WrapErrParameterInvalidMsg("field %s which has enable_match or is input of BM25 function must also enable_analyzer", fieldSchema.Name)
 	}
 	if !h.EnableAnalyzer() {
+		// A MinHash input legally keeps enable_analyzer=false yet its runner
+		// consumes analyzer_params. Collect them so any referenced file
+		// resources reach schema.FileResourceIds and ref-counting — otherwise
+		// the DDL gate admits a dependency the ledger never records and
+		// RemoveFileResource can delete a still-required resource. Match by name:
+		// this runs before assignFieldAndFunctionID, so field/function IDs are not
+		// yet canonical and an ID-based check would miss a stale-ID input.
+		if isMinHashInputFieldByName(collSchema, fieldSchema) {
+			appendAnalyzerParams(fieldSchema, analyzerInfos)
+		}
 		return nil
 	}
 
@@ -968,14 +996,18 @@ func validateAnalyzer(collSchema *schemapb.CollectionSchema, fieldSchema *schema
 		return validateMultiAnalyzerParams(params, collSchema, fieldSchema, analyzerInfos)
 	}
 
+	appendAnalyzerParams(fieldSchema, analyzerInfos)
+	// return nil when use default analyzer
+	return nil
+}
+
+func appendAnalyzerParams(fieldSchema *schemapb.FieldSchema, analyzerInfos *[]*querypb.AnalyzerInfo) {
 	for _, kv := range fieldSchema.GetTypeParams() {
-		if kv.GetKey() == "analyzer_params" {
+		if kv.GetKey() == common.AnalyzerParamKey {
 			*analyzerInfos = append(*analyzerInfos, &querypb.AnalyzerInfo{
 				Field:  fieldSchema.GetName(),
 				Params: kv.GetValue(),
 			})
 		}
 	}
-	// return nil when use default analyzer
-	return nil
 }

--- a/internal/rootcoord/create_collection_task_test.go
+++ b/internal/rootcoord/create_collection_task_test.go
@@ -3047,3 +3047,66 @@ func Test_appendConsistecyLevel(t *testing.T) {
 	assert.Equal(t, commonpb.ConsistencyLevel_Session, consistencyLevel)
 	assert.Len(t, properties, 0)
 }
+
+// A MinHash input legally keeps enable_analyzer=false yet consumes its
+// analyzer_params; the collector must still emit its analyzer info, or any
+// referenced file resources never reach schema.FileResourceIds / ref-counting
+// while the runtime keeps depending on them.
+func TestCollectAnalyzerInfosIncludesDisabledMinHashInput(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Name: "coll",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{
+				FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "128"},
+					{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+				},
+			},
+			{FieldID: 102, Name: "sig", DataType: schemapb.DataType_BinaryVector, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "128"}}},
+		},
+		Functions: []*schemapb.FunctionSchema{{
+			Name: "mh", Type: schemapb.FunctionType_MinHash,
+			InputFieldNames: []string{"text"}, InputFieldIds: []int64{101},
+			OutputFieldNames: []string{"sig"}, OutputFieldIds: []int64{102},
+		}},
+	}
+
+	infos, err := collectAnalyzerInfos(schema)
+	assert.NoError(t, err)
+	assert.Len(t, infos, 1)
+	assert.Equal(t, "text", infos[0].GetField())
+}
+
+// collectAnalyzerInfos runs before assignFieldAndFunctionID, so a request may
+// carry non-canonical (stale, mismatched) field IDs. The MinHash input must
+// still be recognized by name — an ID-based check would miss it and silently
+// drop the resource-backed analyzer_params from FileResourceIds/ref-counting.
+func TestCollectAnalyzerInfosMinHashInputMatchedByNameBeforeIDAssignment(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Name: "coll",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{
+				FieldID: 999, Name: "text", DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "128"},
+					{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+				},
+			},
+			{FieldID: 102, Name: "sig", DataType: schemapb.DataType_BinaryVector, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "128"}}},
+		},
+		Functions: []*schemapb.FunctionSchema{{
+			Name: "mh", Type: schemapb.FunctionType_MinHash,
+			// names match the field, IDs are stale and disagree with FieldID above
+			InputFieldNames: []string{"text"}, InputFieldIds: []int64{888},
+			OutputFieldNames: []string{"sig"}, OutputFieldIds: []int64{102},
+		}},
+	}
+
+	infos, err := collectAnalyzerInfos(schema)
+	assert.NoError(t, err)
+	assert.Len(t, infos, 1)
+	assert.Equal(t, "text", infos[0].GetField())
+}


### PR DESCRIPTION
### What

A MinHash function input legally keeps `enable_analyzer=false`, yet its runner consumes the field's `analyzer_params` unconditionally (`NewMinHashFunctionRunner` -> `getAnalyzerParams`). The DDL-side collector `validateAnalyzer` however returned early for `enable_analyzer=false` fields, so a resource-backed `analyzer_params` (e.g. `resource://dict`) on a MinHash input never reached `ValidateAnalyzer`, never landed in `schema.FileResourceIds`, and never entered file-resource ref-counting — `RemoveFileResource` could then delete a resource the collection still depends on at runtime.

Fix: in the `enable_analyzer=false` early-return branch, still collect `analyzer_params` when the field is a MinHash function input. Matching is **by name** (`isMinHashInputFieldByName`): this runs before `assignFieldAndFunctionID`, so a direct CreateCollection request may carry stale non-canonical IDs and an ID-based check would silently miss the input.

Split from #51848.

issue: #51649

### Tests

- `TestCollectAnalyzerInfosIncludesDisabledMinHashInput`: disabled-analyzer MinHash input still emits its analyzer info.
- `TestCollectAnalyzerInfosMinHashInputMatchedByNameBeforeIDAssignment`: stale mismatched IDs, matching names — still collected.
- Both plus the existing `Test_validateMultiAnalyzerParams` suite green locally under `-tags dynamic,test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)