### PR TITLE
enhance: carry analyzer file resources into bump compaction plan (#51649)

### DIFF
--- a/internal/datacoord/compaction_task_bump_schema_version.go
+++ b/internal/datacoord/compaction_task_bump_schema_version.go
@@ -26,15 +26,18 @@ import (
 	"go.uber.org/atomic"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/compaction"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
 	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
+	"github.com/milvus-io/milvus/internal/util/fileresource"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/taskcommon"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 var _ CompactionTask = (*bumpSchemaVersionTask)(nil)
@@ -113,6 +116,26 @@ func (t *bumpSchemaVersionTask) BuildCompactionRequest() (*datapb.CompactionPlan
 		JsonParams:                compactionParams,
 		CurrentScalarIndexVersion: t.ievm.ResolveScalarIndexVersion(),
 	}
+
+	// set analyzer resource for text match index if use ref mode.
+	// Only the full-rewrite path consumes these (inline createTextIndex, mirroring
+	// sort/mix); which path a segment takes is decided on the datanode, so attach
+	// best-effort: on failure keep building the plan without resources instead of
+	// failing tasks (bump-only / partial backfill) that never need them. A
+	// full-rewrite that does need them fails at createTextIndex resource
+	// resolution, next to the actual consumer.
+	if fileresource.IsRefMode(paramtable.Get().CommonCfg.DNFileResourceMode.GetValue()) &&
+		schemaNeedsTextIndex(taskProto.GetSchema()) &&
+		len(taskProto.GetSchema().GetFileResourceIds()) > 0 {
+		resources, err := t.meta.GetFileResources(context.Background(), taskProto.GetSchema().GetFileResourceIds()...)
+		if err != nil {
+			mlog.Warn(context.TODO(), "get file resources for schema bump compaction failed, building plan without them",
+				mlog.Int64("collectionID", taskProto.GetCollectionID()), mlog.Err(err))
+		} else {
+			plan.FileResources = resources
+		}
+	}
+
 	segments := make([]*SegmentInfo, 0, len(taskProto.GetInputSegments()))
 	for _, segID := range taskProto.GetInputSegments() {
 		segInfo := t.meta.GetHealthySegment(context.TODO(), segID)
@@ -145,6 +168,15 @@ func (t *bumpSchemaVersionTask) BuildCompactionRequest() (*datapb.CompactionPlan
 	plan.BeginLogID = logIDRange.Begin
 	WrapPluginContext(taskProto.GetCollectionID(), taskProto.GetSchema().GetProperties(), plan)
 	return plan, nil
+}
+
+func schemaNeedsTextIndex(schema *schemapb.CollectionSchema) bool {
+	for _, field := range schema.GetFields() {
+		if typeutil.CreateFieldSchemaHelper(field).EnableMatch() {
+			return true
+		}
+	}
+	return false
 }
 
 func (t *bumpSchemaVersionTask) GetSlotUsage() int64 {

--- a/internal/datacoord/compaction_task_bump_schema_version_test.go
+++ b/internal/datacoord/compaction_task_bump_schema_version_test.go
@@ -37,8 +37,10 @@ import (
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/objectstorage"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	taskcommon "github.com/milvus-io/milvus/pkg/v3/taskcommon"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 func TestBumpSchemaVersionCompactionTaskSuite(t *testing.T) {
@@ -203,6 +205,108 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestBuildCompactionRequest() {
 	s.Require().NotNil(plan.GetSchema())
 	s.Equal(task.GetTaskProto().GetSchema().GetVersion(), plan.GetSchema().GetVersion())
 	s.Equal(int32(3), plan.GetCurrentScalarIndexVersion())
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) addFlushedSegmentForBuild(segmentID int64) {
+	err := s.meta.AddSegment(context.TODO(), &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  1,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Flushed,
+			NumOfRows:     1000,
+			Binlogs: []*datapb.FieldBinlog{
+				{FieldID: 101, Binlogs: []*datapb.Binlog{{LogID: 1000, EntriesNum: 1000}}},
+			},
+		},
+	})
+	s.NoError(err)
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) taskWithFileResourceIds(ids []int64) *bumpSchemaVersionTask {
+	proto := s.generateBasicTask().GetTaskProto()
+	proto.Schema.FileResourceIds = ids
+	for _, field := range proto.Schema.GetFields() {
+		if field.GetName() == "text" {
+			field.TypeParams = append(field.TypeParams, &commonpb.KeyValuePair{Key: "enable_match", Value: "true"})
+			break
+		}
+	}
+	return newBumpSchemaVersionTask(proto, s.mockAlloc, s.meta, s.ievm)
+}
+
+// TestBuildCompactionRequest_BumpFileResourcesInRefMode covers the ref-mode FileResources
+// branch of bump BuildCompactionRequest: bump full-rewrite rebuilds the text-match index
+// inline (createTextIndex) and must carry the analyzer resources, mirroring sort/mix. Without
+// them ref mode cannot resolve the referenced analyzer resource and the compaction fails.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestBuildCompactionRequest_BumpFileResourcesInRefMode() {
+	expectedResources := []*internalpb.FileResourceInfo{
+		{Id: 7, Name: "dict", Path: "dict.jieba"},
+	}
+
+	s.Run("ref_mode_carries_resources", func() {
+		pt := paramtable.Get()
+		pt.Save(pt.CommonCfg.DNFileResourceMode.Key, "ref")
+		defer pt.Reset(pt.CommonCfg.DNFileResourceMode.Key)
+
+		s.NoError(s.meta.UpdateFileResources(context.TODO(), expectedResources, 1))
+		s.addFlushedSegmentForBuild(101)
+
+		plan, err := s.taskWithFileResourceIds([]int64{7}).BuildCompactionRequest()
+		s.Require().NoError(err)
+		s.Equal(expectedResources, plan.GetFileResources(),
+			"bump full-rewrite must carry FileResources for inline text-index analyzer resources in ref mode")
+		s.NotEmpty(plan.GetSegmentBinlogs(),
+			"BuildCompactionRequest must run to completion (past the segment loop), not early-return")
+	})
+
+	s.Run("sync_mode_skips_resources", func() {
+		pt := paramtable.Get()
+		pt.Save(pt.CommonCfg.DNFileResourceMode.Key, "sync")
+		defer pt.Reset(pt.CommonCfg.DNFileResourceMode.Key)
+
+		s.addFlushedSegmentForBuild(101)
+
+		plan, err := s.taskWithFileResourceIds([]int64{7}).BuildCompactionRequest()
+		s.Require().NoError(err)
+		s.Empty(plan.GetFileResources(),
+			"sync mode pre-syncs resources, so the plan does not carry them")
+	})
+
+	s.Run("ref_mode_missing_resource_is_best_effort", func() {
+		pt := paramtable.Get()
+		pt.Save(pt.CommonCfg.DNFileResourceMode.Key, "ref")
+		defer pt.Reset(pt.CommonCfg.DNFileResourceMode.Key)
+
+		s.addFlushedSegmentForBuild(101)
+
+		// resource id 7 is never registered in meta; datacoord's resource view may
+		// legitimately be unpopulated, and only the full-rewrite path consumes the
+		// resources. Plan building must proceed without them so bump-only / partial
+		// backfill tasks are not failed by a resource they never use.
+		plan, err := s.taskWithFileResourceIds([]int64{7}).BuildCompactionRequest()
+		s.Require().NoError(err)
+		s.Empty(plan.GetFileResources(),
+			"missing resources must degrade to an empty carry, not fail the plan")
+		s.NotEmpty(plan.GetSegmentBinlogs(),
+			"BuildCompactionRequest must run to completion despite the missing resource")
+	})
+
+	s.Run("ref_mode_without_text_index_skips_resources", func() {
+		pt := paramtable.Get()
+		pt.Save(pt.CommonCfg.DNFileResourceMode.Key, "ref")
+		defer pt.Reset(pt.CommonCfg.DNFileResourceMode.Key)
+
+		taskProto := s.generateBasicTask().GetTaskProto()
+		taskProto.Schema.FileResourceIds = []int64{7}
+		s.addFlushedSegmentForBuild(101)
+
+		plan, err := newBumpSchemaVersionTask(taskProto, s.mockAlloc, s.meta, s.ievm).BuildCompactionRequest()
+		s.Require().NoError(err)
+		s.Empty(plan.GetFileResources(), "analyzer resources are unnecessary when no field enables text match")
+	})
 }
 
 func (s *BumpSchemaVersionCompactionTaskSuite) TestBuildCompactionRequestCarriesV3ManifestAndPreAllocatedLogs() {

--- a/internal/datanode/compactor/bump_schema_version_compactor_test.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagecommon"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/internal/util/fileresource"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/internal/util/indexcgowrapper"
 	"github.com/milvus-io/milvus/internal/util/initcore"
@@ -1427,4 +1428,41 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestMaterializationRejectsDropped
 	)
 	s.Error(err)
 	s.ErrorIs(err, merr.ErrServiceInternal)
+}
+
+// CollectionSchema.FileResourceIds is a collection-wide union, not a
+// field-to-resource binding. A match field using the built-in analyzer must not
+// be rejected because an unrelated non-match analyzer field owns a resource.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteDoesNotRejectUnrelatedRefModeResources() {
+	savedManager := fileresource.GlobalFileManager
+	fileresource.GlobalFileManager = fileresource.NewRefManger()
+	defer func() { fileresource.GlobalFileManager = savedManager }()
+
+	schema := s.task.plan.GetSchema()
+	textField := typeutil.GetField(schema, 101)
+	s.Require().NotNil(textField)
+	textField.TypeParams = append(textField.GetTypeParams(),
+		&commonpb.KeyValuePair{Key: common.EnableAnalyzerKey, Value: "true"},
+		&commonpb.KeyValuePair{Key: "enable_match", Value: "true"})
+	schema.Fields = append(schema.GetFields(), &schemapb.FieldSchema{
+		FieldID:  104,
+		Name:     "resource_text",
+		DataType: schemapb.DataType_VarChar,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: common.MaxLengthKey, Value: "128"},
+			{Key: common.EnableAnalyzerKey, Value: "true"},
+			{Key: common.AnalyzerParamKey, Value: `{"tokenizer":{"type":"jieba","dict":["resource://dict"]}}`},
+		},
+	})
+	schema.FileResourceIds = []int64{7}
+	jsonParams, err := compaction.GenerateJSONParams(schema)
+	s.Require().NoError(err)
+	s.task.plan.JsonParams = jsonParams
+	s.task.plan.FileResources = nil
+
+	composePatch := mockey.Mock(compaction.ComposeDeleteFromDeltalogs).Return(nil, assert.AnError).Build()
+	defer composePatch.UnPatch()
+
+	_, err = s.task.runFullSchemaRewrite(collectionSchemaFields(schema))
+	s.ErrorIs(err, assert.AnError)
 }

--- a/internal/datanode/compactor/compactor_common.go
+++ b/internal/datanode/compactor/compactor_common.go
@@ -54,6 +54,18 @@ import (
 
 const compactionBatchSize = 100
 
+// schemaNeedsTextIndex reports whether any field enables text match — the
+// condition under which compaction output builds text indexes (and, in ref
+// mode, needs plan-attached analyzer file resources).
+func schemaNeedsTextIndex(schema *schemapb.CollectionSchema) bool {
+	for _, field := range schema.GetFields() {
+		if typeutil.CreateFieldSchemaHelper(field).EnableMatch() {
+			return true
+		}
+	}
+	return false
+}
+
 func createTextIndex(ctx context.Context,
 	cm storage.ChunkManager,
 	plan *datapb.CompactionPlan,
@@ -70,6 +82,13 @@ func createTextIndex(ctx context.Context,
 		mlog.FieldPartitionID(partitionID),
 		mlog.FieldSegmentID(segmentID),
 	)
+
+	// Text indexes are built only for enable_match fields, and the analyzer file
+	// resources below are downloaded solely to build them. If no field enables
+	// match, skip the resource download and all setup entirely.
+	if !schemaNeedsTextIndex(plan.GetSchema()) {
+		return map[int64]*datapb.TextIndexStats{}, nil
+	}
 
 	fieldBinlogs := lo.GroupBy(segment.GetInsertLogs(), func(binlog *datapb.FieldBinlog) int64 {
 		return binlog.GetFieldID()


### PR DESCRIPTION
### What

Two mirrored gaps around analyzer file resources in the schema-bump compaction path, under DataNode file-resource **ref mode**:

- **DataCoord**: bump `BuildCompactionRequest` never attached the schema's `FileResources` to the plan, while sort/mix compactions do. The bump full-rewrite path builds the text-match index inline (`createTextIndex`), which under ref mode resolves analyzer resources from the plan — without them the rebuild cannot resolve a referenced dictionary. Attach them **best-effort**: only when a field enables match and the schema lists resource ids; on lookup failure keep building the plan without them, since bump-only / partial-backfill tasks never consume resources and must not fail over an unused lookup (a full rewrite that does need them still fails next to the actual consumer, `createTextIndex`).
- **DataNode**: `createTextIndex` downloaded the plan's file resources before checking whether any field enables match — the download exists solely to build text-match indexes. Skip all setup when no field enables match (`schemaNeedsTextIndex`), so unrelated resource-owning analyzer fields (the `FileResourceIds` union is collection-wide, not per-field) never block or slow a compaction that builds no text index.

Known limitation, not claimed fixed here: DataCoord's file-resource view has no production population/recovery path yet (`UpdateFileResources` is test-only) — tracked by #51861. This PR wires the plan-side carry so bump matches sort/mix once #51861 lands.

Split from #51848.

issue: #51649

### Tests

- `TestBuildCompactionRequest_BumpFileResourcesInRefMode`: ref mode carries resources; sync mode skips; missing resource degrades to empty carry without failing the plan; no-match schema skips.
- `TestFullRewriteDoesNotRejectUnrelatedRefModeResources`: a match field on the built-in analyzer is not rejected because an unrelated field owns a resource.
- Full datacoord bump suite plus all compactor `*TextIndex*` regressions green locally under `-tags dynamic,test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)