### PR TITLE
fix: [2.6] restore REST v2 proxy request metrics

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -384,7 +384,7 @@ func wrapperPost(newReq newReqFunc, v2 handlerFuncV2) gin.HandlerFunc {
 			zap.Any("url", gCtx.Request.URL.Path))
 
 		resp, err := v2(ctx, gCtx, req, dbName)
-		methodTag, ok := routeToMethod[gCtx.FullPath()]
+		methodTag, ok := routeToMethod[matchedRoutePath(gCtx)]
 		if !ok {
 			return
 		}
@@ -487,7 +487,7 @@ func checkAuthorizationV2(ctx context.Context, c *gin.Context, ignoreErr bool, r
 		if !ignoreErr {
 			HTTPReturn(c, http.StatusUnauthorized, gin.H{HTTPReturnCode: merr.Code(merr.ErrNeedAuthenticate), HTTPReturnMessage: merr.ErrNeedAuthenticate.Error()})
 		}
-		hookutil.GetExtension().ReportAction(ctx, req, WrapErrorToResponse(merr.ErrNeedAuthenticate), nil, c.FullPath(), hookutil.ActionAuthorize)
+		hookutil.GetExtension().ReportAction(ctx, req, WrapErrorToResponse(merr.ErrNeedAuthenticate), nil, matchedRoutePath(c), hookutil.ActionAuthorize)
 		return merr.ErrNeedAuthenticate
 	}
 	_, authErr := proxy.PrivilegeInterceptor(ctx, req)
@@ -495,7 +495,7 @@ func checkAuthorizationV2(ctx context.Context, c *gin.Context, ignoreErr bool, r
 		if !ignoreErr {
 			HTTPReturn(c, http.StatusForbidden, gin.H{HTTPReturnCode: merr.Code(authErr), HTTPReturnMessage: authErr.Error()})
 		}
-		hookutil.GetExtension().ReportAction(ctx, req, WrapErrorToResponse(authErr), nil, c.FullPath(), hookutil.ActionAuthorize)
+		hookutil.GetExtension().ReportAction(ctx, req, WrapErrorToResponse(authErr), nil, matchedRoutePath(c), hookutil.ActionAuthorize)
 		return authErr
 	}
 
@@ -533,7 +533,7 @@ func wrapperProxyWithLimit(ctx context.Context, ginCtx *gin.Context, req any, ch
 		_, err := CheckLimiter(ctx, req, pxy)
 		if err != nil {
 			log.Warn("high level restful api, fail to check limiter", zap.Error(err), zap.String("method", fullMethod))
-			hookutil.GetExtension().ReportAction(ctx, req, WrapErrorToResponse(merr.ErrHTTPRateLimit), nil, ginCtx.FullPath(), hookutil.ActionAuthorize)
+			hookutil.GetExtension().ReportAction(ctx, req, WrapErrorToResponse(merr.ErrHTTPRateLimit), nil, matchedRoutePath(ginCtx), hookutil.ActionAuthorize)
 			HTTPAbortReturn(ginCtx, http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrHTTPRateLimit),
 				HTTPReturnMessage: merr.ErrHTTPRateLimit.Error() + ", error: " + err.Error(),

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -22,11 +22,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -42,6 +44,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proxy"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v2/util"
 	"github.com/milvus-io/milvus/pkg/v2/util/crypto"
@@ -199,6 +202,39 @@ func TestHTTPWrapper(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestWrapperPostRecordsMetricsThroughTimeoutMiddleware(t *testing.T) {
+	ginHandler := gin.New()
+	app := ginHandler.Group("/v2/vectordb", func(c *gin.Context) {
+		c.Set(ContextUsername, util.UserRoot)
+	})
+	app.POST(CollectionCategory+ListAction, timeoutMiddleware(wrapperPost(
+		func() any { return &DatabaseReq{} },
+		func(ctx context.Context, c *gin.Context, req any, dbName string) (interface{}, error) {
+			HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil)})
+			return merr.Success(), nil
+		},
+	)))
+
+	nodeID := strconv.FormatInt(paramtable.GetNodeID(), 10)
+	total := metrics.ProxyFunctionCall.WithLabelValues(
+		nodeID, "ShowCollections", metrics.TotalLabel, metrics.CauseNA, DefaultDbName, "",
+	)
+	success := metrics.ProxyFunctionCall.WithLabelValues(
+		nodeID, "ShowCollections", metrics.SuccessLabel, metrics.CauseNA, DefaultDbName, "",
+	)
+	totalBefore := testutil.ToFloat64(total)
+	successBefore := testutil.ToFloat64(success)
+
+	req := httptest.NewRequest(http.MethodPost, versionalV2(CollectionCategory, ListAction), bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ginHandler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, float64(1), testutil.ToFloat64(total)-totalBefore)
+	require.Equal(t, float64(1), testutil.ToFloat64(success)-successBefore)
 }
 
 func TestGrpcWrapper(t *testing.T) {
@@ -531,6 +567,22 @@ func TestTimeoutMiddlewareCommitsBufferedResponsesAndMetadata(t *testing.T) {
 			assert.Equal(t, "trace-"+testcase.name, value)
 		})
 	}
+}
+
+func TestTimeoutMiddlewarePreservesMatchedRoutePath(t *testing.T) {
+	ginHandler := gin.New()
+	path := "/middleware/timeout/routes/:id"
+	matchedPath := make(chan string, 1)
+	ginHandler.GET(path, timeoutMiddleware(func(c *gin.Context) {
+		matchedPath <- matchedRoutePath(c)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/middleware/timeout/routes/42", nil)
+	w := httptest.NewRecorder()
+	ginHandler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, path, <-matchedPath)
 }
 
 func TestTimeoutMiddlewarePropagatesAbortToOriginalContext(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/timeout_middleware.go
+++ b/internal/distributed/proxy/httpserver/timeout_middleware.go
@@ -225,6 +225,15 @@ var timeoutContextKeysToPropagate = []string{
 	"traceID",
 }
 
+const copiedContextRoutePathKey = "milvus_copied_context_route_path"
+
+func matchedRoutePath(c *gin.Context) string {
+	if path := c.FullPath(); path != "" {
+		return path
+	}
+	return c.GetString(copiedContextRoutePathKey)
+}
+
 func propagateTimeoutContextKeys(dst *gin.Context, src *gin.Context) {
 	for _, key := range timeoutContextKeysToPropagate {
 		if value, ok := src.Get(key); ok {
@@ -256,7 +265,12 @@ func timeoutMiddleware(handler gin.HandlerFunc) gin.HandlerFunc {
 		buffer := bufPool.Get()
 		buffer.Reset()
 		recorder := newTimeoutResponseRecorder(buffer)
+		// gin.Context.Copy did not retain the matched route path before Gin 1.11.
+		// Preserve the registered route pattern for metrics and audit hooks running
+		// on the copied context; Request.URL.Path is unsuitable for dynamic routes.
+		routePath := matchedRoutePath(gCtx)
 		handlerCtx := gCtx.Copy()
+		handlerCtx.Set(copiedContextRoutePathKey, routePath)
 		handlerCtx.Request = req
 		handlerCtx.Writer = recorder
 

--- a/internal/distributed/proxy/httpserver/timeout_middleware.go
+++ b/internal/distributed/proxy/httpserver/timeout_middleware.go
@@ -265,7 +265,7 @@ func timeoutMiddleware(handler gin.HandlerFunc) gin.HandlerFunc {
 		buffer := bufPool.Get()
 		buffer.Reset()
 		recorder := newTimeoutResponseRecorder(buffer)
-		// gin.Context.Copy did not retain the matched route path before Gin 1.11.
+		// gin.Context.Copy did not retain the matched route path before Gin 1.10.
 		// Preserve the registered route pattern for metrics and audit hooks running
 		// on the copied context; Request.URL.Path is unsuitable for dynamic routes.
 		routePath := matchedRoutePath(gCtx)


### PR DESCRIPTION
issue: #52177
pr: #47943

## What changed

- preserve the registered Gin route pattern when the timeout middleware copies the request context
- use the preserved route for REST v2 proxy metrics and the affected authorization/rate-limit audit hooks
- add regression coverage through the real `timeoutMiddleware(wrapperPost(...))` chain and a dynamic-route case

## Root cause

Milvus 2.6 uses Gin v1.9.1. In that version, `Context.Copy()` does not retain Gin's private `fullPath` field. REST v2 handlers run on a copied context, so `gCtx.FullPath()` becomes empty inside `wrapperPost`. The route-to-method lookup then misses and returns before incrementing `milvus_proxy_req_count`, even though the request itself succeeds.

The middleware now captures the registered route pattern before copying the context and makes it available to downstream handlers. It intentionally does not fall back to `Request.URL.Path`, because dynamic routes need the stable registered template rather than high-cardinality concrete paths.

Master is already unaffected through #47943, which upgraded Gin to v1.11.0. Gin v1.11.0 copies `fullPath` in `Context.Copy()`; the 2.6 branch remains on v1.9.1 and needs this scoped compatibility fix.

## Validation

- negative regression check: restoring the old `gCtx.FullPath()` lookup returned HTTP 200 but produced metric delta `0` instead of `1`
- focused regression tests: PASS with `-race` (`2/2` tests)
- full `internal/distributed/proxy/httpserver` package: PASS with `-race`, `89.9%` statement coverage
- repository-pinned `golangci-lint v2.11.3` on the changed package: `0 issues`
- repository format target and `git diff --check`: PASS
- C++ `milvus_core` production target linked successfully for the cgo-backed Go tests; unrelated C++ unit-test executables were not run

Closes #52177
