### PR TITLE
enhance: extend composite Update coverage across coordinator catalogs

### DIFF
--- a/internal/datacoord/import_checker.go
+++ b/internal/datacoord/import_checker.go
@@ -256,30 +256,32 @@ func (c *importChecker) getLackFilesForImports(job ImportJob) []*datapb.ImportFi
 
 func (c *importChecker) checkPendingJob(job ImportJob) {
 	log := mlog.With(mlog.FieldJobID(job.GetJobID()))
+	// len(lacks) == 0 is NOT an early exit: after a crash between the task
+	// flush and the job commit marker (the chunked-fallback window of
+	// AddTasksToJob), every task already exists while the job is still
+	// Pending, and the retry must still land the PreImporting marker below.
 	lacks := c.getLackFilesForPreImports(job)
-	if len(lacks) == 0 {
-		return
-	}
 	fileGroups := lo.Chunk(lacks, Params.DataCoordCfg.FilesPerPreImportTask.GetAsInt())
 
-	newTasks, err := NewPreImportTasks(fileGroups, job, c.alloc, c.importMeta)
+	var newTasks []ImportTask
+	if len(fileGroups) > 0 {
+		var err error
+		newTasks, err = NewPreImportTasks(fileGroups, job, c.alloc, c.importMeta)
+		if err != nil {
+			log.Warn(c.ctx, "new preimport tasks failed", mlog.Err(err))
+			return
+		}
+	}
+	// The task batch and the job transition persist as one composite write,
+	// job record last as the commit marker, so a crash cannot leave task
+	// records under a job that never observed them.
+	err := c.importMeta.AddTasksToJob(c.ctx, job.GetJobID(), newTasks, UpdateJobState(internalpb.ImportJobState_PreImporting))
 	if err != nil {
-		log.Warn(c.ctx, "new preimport tasks failed", mlog.Err(err))
+		log.Warn(c.ctx, "add preimport tasks failed", mlog.Err(err))
 		return
 	}
 	for _, t := range newTasks {
-		err = c.importMeta.AddTask(c.ctx, t)
-		if err != nil {
-			log.Warn(c.ctx, "add preimport task failed", WrapTaskLog(t, mlog.Err(err))...)
-			return
-		}
 		log.Info(c.ctx, "add new preimport task", WrapTaskLog(t, mlog.Any("fileStats", t.GetFileStats()))...)
-	}
-
-	err = c.importMeta.UpdateJob(c.ctx, job.GetJobID(), UpdateJobState(internalpb.ImportJobState_PreImporting))
-	if err != nil {
-		log.Warn(c.ctx, "failed to update job state to PreImporting", mlog.Err(err))
-		return
 	}
 	pendingDuration := job.GetTR().RecordSpan()
 	metrics.ImportJobLatency.WithLabelValues(metrics.ImportStagePending).Observe(float64(pendingDuration.Milliseconds()))
@@ -326,10 +328,11 @@ func (c *importChecker) checkPreImportingJob(job ImportJob) {
 		return
 	}
 
+	// len(lacks) == 0 is NOT an early exit: after a crash between the task
+	// flush and the job commit marker (the chunked-fallback window of
+	// AddTasksToJob), every task already exists while the job is still
+	// PreImporting, and the retry must still land the Importing marker below.
 	lacks := c.getLackFilesForImports(job)
-	if len(lacks) == 0 {
-		return
-	}
 
 	requestSize, err := CheckDiskQuota(c.ctx, job, c.meta, c.importMeta)
 	if err != nil {
@@ -340,22 +343,44 @@ func (c *importChecker) checkPreImportingJob(job ImportJob) {
 
 	segmentMaxSize := GetSegmentMaxSize(job, c.meta)
 	groups := RegroupImportFiles(job, lacks, segmentMaxSize)
-	newTasks, err := NewImportTasks(groups, job, c.alloc, c.meta, c.importMeta, segmentMaxSize)
+	var newTasks []ImportTask
+	if len(groups) > 0 {
+		newTasks, err = NewImportTasks(groups, job, c.alloc, c.meta, c.importMeta, segmentMaxSize)
+		if err != nil {
+			log.Warn(c.ctx, "new import tasks failed", mlog.Err(err))
+			return
+		}
+	}
+	// The task batch and the job transition persist as one composite write,
+	// job record last as the commit marker, so a crash cannot leave task
+	// records under a job that never observed them.
+	err = c.importMeta.AddTasksToJob(c.ctx, job.GetJobID(), newTasks,
+		UpdateJobState(internalpb.ImportJobState_Importing), UpdateRequestedDiskSize(requestSize))
 	if err != nil {
-		log.Warn(c.ctx, "new import tasks failed", mlog.Err(err))
+		if len(newTasks) == 0 {
+			// Crash-recovery replay: every task already exists and this write
+			// carried the Importing marker alone. The legacy path treated a
+			// failed transition-only write as retriable (warn, next tick
+			// replays it), and a transient store error must not kill the job
+			// - keep that semantic.
+			log.Warn(c.ctx, "update import job state to Importing failed, wait for retry", mlog.Err(err))
+			return
+		}
+		// Task creation failed (the batch was rolled back); mirror the legacy
+		// AddTask-failure semantic and fail the job.
+		log.Warn(c.ctx, "add new import tasks failed", mlog.Err(err))
+		updateJobState(internalpb.ImportJobState_Failed, UpdateJobReason(err.Error()))
 		return
 	}
 	for _, t := range newTasks {
-		err = c.importMeta.AddTask(c.ctx, t)
-		if err != nil {
-			log.Warn(c.ctx, "add new import task failed", WrapTaskLog(t, mlog.Err(err))...)
-			updateJobState(internalpb.ImportJobState_Failed, UpdateJobReason(err.Error()))
-			return
-		}
 		log.Info(c.ctx, "add new import task", WrapTaskLog(t, mlog.Any("fileStats", t.GetFileStats()))...)
 	}
 
-	updateJobState(internalpb.ImportJobState_Importing, UpdateRequestedDiskSize(requestSize))
+	preImportDuration := job.GetTR().RecordSpan()
+	metrics.ImportJobLatency.WithLabelValues(metrics.ImportStagePreImport).Observe(float64(preImportDuration.Milliseconds()))
+	log.Info(c.ctx, "import job preimport done",
+		mlog.String("state", internalpb.ImportJobState_Importing.String()),
+		mlog.Duration("jobTimeCost/preimport", preImportDuration))
 }
 
 func (c *importChecker) checkImportingJob(job ImportJob) {

--- a/internal/datacoord/import_checker_test.go
+++ b/internal/datacoord/import_checker_test.go
@@ -179,6 +179,12 @@ func (s *ImportCheckerSuite) TestCheckJob() {
 		return id, id + n, nil
 	})
 	catalog := s.importMeta.(*importMeta).catalog.(*mocks.DataCoordCatalog)
+	// checkPendingJob persists the task batch and the job transition as one
+	// composite Update: ctx + 2 preimport tasks + job.
+	catalog.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	// the no-lack re-check still lands the job marker alone: ctx + job.
+	catalog.EXPECT().Update(mock.Anything, mock.Anything).Return(nil)
+	// UpdateTask below still persists per-task.
 	catalog.EXPECT().SavePreImportTask(mock.Anything, mock.Anything).Return(nil)
 
 	s.checker.checkPendingJob(job)
@@ -196,6 +202,8 @@ func (s *ImportCheckerSuite) TestCheckJob() {
 			TotalRows: 100,
 		},
 	}
+	// composite Update: ctx + 1 import task + job.
+	catalog.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	catalog.EXPECT().SaveImportTask(mock.Anything, mock.Anything).Return(nil)
 	for _, t := range preimportTasks {
 		err := s.importMeta.UpdateTask(context.TODO(), t.GetTaskID(),
@@ -309,7 +317,11 @@ func (s *ImportCheckerSuite) TestCheckJob_Failed() {
 	alloc := s.alloc
 	alloc.EXPECT().AllocN(mock.Anything).Return(0, 0, nil)
 	catalog := s.importMeta.(*importMeta).catalog.(*mocks.DataCoordCatalog)
-	catalog.EXPECT().SavePreImportTask(mock.Anything, mock.Anything).Return(mockErr)
+	// the composite Update (ctx + 2 preimport tasks + job) fails: nothing is
+	// applied - no orphan tasks, job stays Pending - and the batch's task
+	// records are rolled back (the next tick allocates fresh task IDs).
+	catalog.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(mockErr)
+	catalog.EXPECT().DropPreImportTask(mock.Anything, mock.Anything).Return(nil).Twice()
 
 	s.checker.checkPendingJob(job)
 	preimportTasks := s.importMeta.GetTaskBy(context.TODO(), WithJob(job.GetJobID()), WithType(PreImportTaskType))
@@ -326,7 +338,8 @@ func (s *ImportCheckerSuite) TestCheckJob_Failed() {
 	alloc.ExpectedCalls = nil
 	alloc.EXPECT().AllocN(mock.Anything).Return(0, 0, nil)
 	catalog.ExpectedCalls = nil
-	catalog.EXPECT().SaveImportJob(mock.Anything, mock.Anything).Return(nil)
+	catalog.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	// UpdateTask below still persists per-task.
 	catalog.EXPECT().SavePreImportTask(mock.Anything, mock.Anything).Return(nil)
 	s.checker.checkPendingJob(job)
 	preimportTasks = s.importMeta.GetTaskBy(context.TODO(), WithJob(job.GetJobID()), WithType(PreImportTaskType))
@@ -346,7 +359,13 @@ func (s *ImportCheckerSuite) TestCheckJob_Failed() {
 	}
 
 	catalog.ExpectedCalls = nil
-	catalog.EXPECT().SaveImportTask(mock.Anything, mock.Anything).Return(mockErr)
+	// the composite Update (ctx + 1 import task + job) fails: the read-back
+	// finds no committed job marker, so the batch's task record is rolled
+	// back BEFORE the checker marks the job Failed via SaveImportJob - a job
+	// that will never retry leaves no orphan behind.
+	catalog.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything).Return(mockErr)
+	catalog.EXPECT().ListImportJobs(mock.Anything).Return(nil, nil).Once()
+	catalog.EXPECT().DropImportTask(mock.Anything, mock.Anything).Return(nil).Once()
 	catalog.EXPECT().SaveImportJob(mock.Anything, mock.Anything).Return(nil)
 	s.checker.checkPreImportingJob(job)
 	importTasks := s.importMeta.GetTaskBy(context.TODO(), WithJob(job.GetJobID()), WithType(ImportTaskType))
@@ -362,13 +381,63 @@ func (s *ImportCheckerSuite) TestCheckJob_Failed() {
 	s.Equal(internalpb.ImportJobState_PreImporting, s.importMeta.GetJob(context.TODO(), job.GetJobID()).GetState())
 
 	catalog.ExpectedCalls = nil
-	catalog.EXPECT().SaveImportJob(mock.Anything, mock.Anything).Return(nil)
-	catalog.EXPECT().SaveImportTask(mock.Anything, mock.Anything).Return(nil)
+	catalog.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	alloc.ExpectedCalls = nil
 	alloc.EXPECT().AllocN(mock.Anything).Return(0, 0, nil)
 	s.checker.checkPreImportingJob(job)
 	importTasks = s.importMeta.GetTaskBy(context.TODO(), WithJob(job.GetJobID()), WithType(ImportTaskType))
 	s.Equal(1, len(importTasks))
+	s.Equal(internalpb.ImportJobState_Importing, s.importMeta.GetJob(context.TODO(), job.GetJobID()).GetState())
+}
+
+// TestCheckPreImporting_MarkerOnlyFailureRetries pins the crash-recovery
+// replay path: every import task already exists (lacks==0, newTasks empty)
+// and only the Importing job marker still needs to land. A transient store
+// error on that marker-only write must NOT fail the job - legacy
+// updateJobState(Importing) failures were warn-and-retry, and the next tick
+// replays the same marker write - so the job must stay PreImporting.
+func (s *ImportCheckerSuite) TestCheckPreImporting_MarkerOnlyFailureRetries() {
+	mockErr := errors.New("mock err")
+	job := s.importMeta.GetJob(context.TODO(), s.jobID)
+
+	// Drive the job to Importing the normal way: preimport tasks, complete
+	// them, then import tasks + the Importing marker.
+	alloc := s.alloc
+	alloc.EXPECT().AllocN(mock.Anything).RunAndReturn(func(n int64) (int64, int64, error) {
+		id := rand.Int63()
+		return id, id + n, nil
+	})
+	catalog := s.importMeta.(*importMeta).catalog.(*mocks.DataCoordCatalog)
+	catalog.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	catalog.EXPECT().SavePreImportTask(mock.Anything, mock.Anything).Return(nil)
+	s.checker.checkPendingJob(job)
+	preimportTasks := s.importMeta.GetTaskBy(context.TODO(), WithJob(job.GetJobID()), WithType(PreImportTaskType))
+	s.Equal(2, len(preimportTasks))
+	fileStats := []*datapb.ImportFileStats{{TotalRows: 100}}
+	for _, t := range preimportTasks {
+		s.NoError(s.importMeta.UpdateTask(context.TODO(), t.GetTaskID(),
+			UpdateState(datapb.ImportTaskStateV2_Completed), UpdateFileStats(fileStats)))
+	}
+	catalog.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	s.checker.checkPreImportingJob(job)
+	s.Equal(1, len(s.importMeta.GetTaskBy(context.TODO(), WithJob(job.GetJobID()), WithType(ImportTaskType))))
+
+	// Simulate the crash-replay state: the import tasks are all persisted but
+	// the job is still PreImporting (the marker write is what failed/crashed).
+	s.manuallyUpdateJob(job.GetJobID(), UpdateJobState(internalpb.ImportJobState_PreImporting))
+
+	// The marker-only composite write (ctx + job) fails transiently. No
+	// SaveImportJob expectation: marking the job Failed would fail the mock.
+	catalog.ExpectedCalls = nil
+	catalog.EXPECT().Update(mock.Anything, mock.Anything).Return(mockErr)
+	catalog.EXPECT().ListImportJobs(mock.Anything).Return(nil, nil).Maybe()
+	s.checker.checkPreImportingJob(job)
+	s.Equal(internalpb.ImportJobState_PreImporting, s.importMeta.GetJob(context.TODO(), job.GetJobID()).GetState())
+
+	// The next tick retries the same marker write and succeeds.
+	catalog.ExpectedCalls = nil
+	catalog.EXPECT().Update(mock.Anything, mock.Anything).Return(nil)
+	s.checker.checkPreImportingJob(job)
 	s.Equal(internalpb.ImportJobState_Importing, s.importMeta.GetJob(context.TODO(), job.GetJobID()).GetState())
 }
 
@@ -973,8 +1042,8 @@ func TestImportCheckerCompaction(t *testing.T) {
 		return id, id + n, nil
 	}).Maybe()
 	alloc.EXPECT().AllocID(mock.Anything).Return(rand.Int63(), nil).Maybe()
-	catalog.EXPECT().SavePreImportTask(mock.Anything, mock.Anything).Return(nil).Twice()
-	catalog.EXPECT().SaveImportJob(mock.Anything, mock.Anything).Return(nil).Once()
+	// checkPendingJob: one composite Update (ctx + 2 preimport tasks + job).
+	catalog.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 	assert.Eventually(t, func() bool {
 		job := importMeta.GetJob(context.TODO(), jobID)
 		preimportTasks := importMeta.GetTaskBy(context.TODO(), WithJob(job.GetJobID()), WithType(PreImportTaskType))
@@ -985,9 +1054,10 @@ func TestImportCheckerCompaction(t *testing.T) {
 	mlog.Info(context.TODO(), "job pre-importing")
 
 	// check pre-importing
-	catalog.EXPECT().SaveImportTask(mock.Anything, mock.Anything).Return(nil).Once()
+	// checkPreImportingJob: one composite Update (ctx + 1 import task + job);
+	// the UpdateTask calls below still persist per-task.
+	catalog.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 	catalog.EXPECT().SavePreImportTask(mock.Anything, mock.Anything).Return(nil).Twice()
-	catalog.EXPECT().SaveImportJob(mock.Anything, mock.Anything).Return(nil).Once()
 	preimportTasks := importMeta.GetTaskBy(context.TODO(), WithJob(job.GetJobID()), WithType(PreImportTaskType))
 	fileStats := []*datapb.ImportFileStats{
 		{
@@ -1199,6 +1269,7 @@ func (s *ImportCheckerSuite) TestCheckPreImporting_EmptyImport_AutoCommitFalse()
 		id := rand.Int63()
 		return id, id + n, nil
 	})
+	catalog.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	catalog.EXPECT().SavePreImportTask(mock.Anything, mock.Anything).Return(nil)
 	s.checker.checkPendingJob(s.importMeta.GetJob(context.TODO(), s.jobID))
 	s.Equal(internalpb.ImportJobState_PreImporting, s.importMeta.GetJob(context.TODO(), s.jobID).GetState())
@@ -1233,6 +1304,7 @@ func (s *ImportCheckerSuite) TestCheckPreImporting_EmptyImport_AutoCommitTrue() 
 		id := rand.Int63()
 		return id, id + n, nil
 	})
+	catalog.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	catalog.EXPECT().SavePreImportTask(mock.Anything, mock.Anything).Return(nil)
 	s.checker.checkPendingJob(s.importMeta.GetJob(context.TODO(), s.jobID))
 	s.Equal(internalpb.ImportJobState_PreImporting, s.importMeta.GetJob(context.TODO(), s.jobID).GetState())

--- a/internal/datacoord/import_meta.go
+++ b/internal/datacoord/import_meta.go
@@ -23,10 +23,13 @@ import (
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/samber/lo"
 	"golang.org/x/exp/maps"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/internal/metastore"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/taskcommon"
 	"github.com/milvus-io/milvus/pkg/v3/util/lock"
@@ -44,6 +47,7 @@ type ImportMeta interface {
 	HandleCommitVchannel(ctx context.Context, jobID int64, vchannel string, callback func() error) error
 
 	AddTask(ctx context.Context, task ImportTask) error
+	AddTasksToJob(ctx context.Context, jobID int64, tasks []ImportTask, actions ...UpdateJobAction) error
 	UpdateTask(ctx context.Context, taskID int64, actions ...UpdateAction) error
 	GetTask(ctx context.Context, taskID int64) ImportTask
 	GetTaskBy(ctx context.Context, filters ...ImportTaskFilter) []ImportTask
@@ -254,6 +258,137 @@ func (m *importMeta) AddTask(ctx context.Context, task ImportTask) error {
 		m.tasks.add(task)
 	}
 	return nil
+}
+
+// AddTasksToJob persists a batch of newly-created tasks together with the
+// job's updated record as ONE composite catalog write, then applies the
+// in-memory bookkeeping of both. It replaces the per-task AddTask calls
+// followed by an UpdateJob - which, being N+1 independent txns, could crash
+// in between and leave task records under a job that never observed them.
+//
+// The job record - the failover anchor for its tasks - is written LAST as the
+// commit marker. A failed write recovers along two distinct paths:
+//   - Process crash mid-write (chunked fallback): the flushed task records sit
+//     inert under the un-flipped job; restart reloads them into memory, the
+//     checker's lack computation excludes their files, and the retry persists
+//     only the remainder plus the marker - converging on the same keys.
+//   - In-process failure: memory stays untouched, and the checker's next tick
+//     allocates FRESH task IDs for the recomputed missing set (NewPreImportTasks/
+//     NewImportTasks), retrying under a DIFFERENT key set. The flushed records
+//     of the failed batch would become orphans no memory-driven GC can reach,
+//     so they are rolled back below, best-effort: a drop that fails leaves its
+//     record to the crash path above (restart reload adopts it).
+//
+// A returned error does NOT prove the write missed the store: etcd can apply
+// a txn and still surface a timeout or a leader-switch error to the client.
+// In that ambiguous case the job marker may already reference the batch, and
+// rolling the task records back would leave a PreImporting/Importing job with
+// ZERO tasks on disk - a restarted checker sees totalRows==0 (or no
+// incomplete import task) and completes the job empty. So before any
+// rollback the job record is read back to disambiguate: marker committed ->
+// adopt the write as a success; marker definitively absent -> roll back;
+// read-back failed -> leave the records untouched for restart reload.
+//
+// m.mu serializes the whole read -> compute -> commit -> apply sequence, so no
+// concurrent task or job write can interleave. Terminal jobs (Completed/Failed)
+// reject the batch without a write, mirroring UpdateJob's guard.
+func (m *importMeta) AddTasksToJob(ctx context.Context, jobID int64, tasks []ImportTask, actions ...UpdateJobAction) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	job, ok := m.jobs[jobID]
+	if !ok {
+		return nil
+	}
+	if job.GetState() == internalpb.ImportJobState_Completed ||
+		job.GetState() == internalpb.ImportJobState_Failed {
+		// import job is already completed or failed, no need to update
+		return nil
+	}
+	updatedJob := job.Clone()
+	for _, action := range actions {
+		action(updatedJob)
+	}
+	catalogActions := make([]metastore.UpdateAction, 0, len(tasks)+1)
+	for _, task := range tasks {
+		switch task.GetType() {
+		case PreImportTaskType:
+			catalogActions = append(catalogActions, metastore.AddPreImportTask(task.(*preImportTask).task.Load()))
+		case ImportTaskType:
+			catalogActions = append(catalogActions, metastore.AddImportTask(task.(*importTask).task.Load()))
+		}
+	}
+	catalogActions = append(catalogActions, metastore.SaveImportJob(updatedJob.(*importJob).ImportJob))
+	if err := m.catalog.Update(ctx, catalogActions...); err != nil {
+		switch m.readBackJobMarker(ctx, jobID, updatedJob.(*importJob).ImportJob) {
+		case jobMarkerCommitted:
+			// Ambiguous failure, but the marker is on disk: the composite
+			// write actually landed. Adopt it exactly as a success - rolling
+			// back now would delete task records a committed job references.
+			mlog.Warn(ctx, "composite import write reported an error but its job marker is committed, adopting",
+				mlog.FieldJobID(jobID), mlog.Err(err))
+		case jobMarkerAbsent:
+			// The marker is definitively not on disk, so no job observed the
+			// batch. Roll back any task record the chunked fallback already
+			// flushed: the retry re-allocates task IDs, so these keys would
+			// never be written - or dropped - again by this process.
+			for _, task := range tasks {
+				var dropErr error
+				switch task.GetType() {
+				case PreImportTaskType:
+					dropErr = m.catalog.DropPreImportTask(ctx, task.GetTaskID())
+				case ImportTaskType:
+					dropErr = m.catalog.DropImportTask(ctx, task.GetTaskID())
+				}
+				if dropErr != nil {
+					mlog.Warn(ctx, "roll back flushed import task failed, restart reload will adopt it",
+						mlog.FieldJobID(jobID), mlog.FieldTaskID(task.GetTaskID()), mlog.Err(dropErr))
+				}
+			}
+			return err
+		default: // jobMarkerUnknown
+			// The read-back failed too: neither adopting nor rolling back is
+			// safe. If the marker landed, a rollback would empty a committed
+			// job; if it did not, the flushed records sit inert under the
+			// un-flipped job and restart reload adopts them - the same
+			// terminal state as a failed drop above.
+			mlog.Warn(ctx, "composite import write failed and the job marker could not be read back, skipping rollback",
+				mlog.FieldJobID(jobID), mlog.Err(err))
+			return err
+		}
+	}
+	for _, task := range tasks {
+		m.tasks.add(task)
+	}
+	m.jobs[jobID] = updatedJob
+	return nil
+}
+
+type jobMarkerState int
+
+const (
+	jobMarkerUnknown jobMarkerState = iota
+	jobMarkerCommitted
+	jobMarkerAbsent
+)
+
+// readBackJobMarker reads the job record back from the store to tell an
+// ambiguous composite-write failure (applied-but-timed-out) apart from a real
+// miss: the record equal to the batch's updated job proves the marker - and,
+// by write order, every task record before it - committed.
+func (m *importMeta) readBackJobMarker(ctx context.Context, jobID int64, updatedJob *datapb.ImportJob) jobMarkerState {
+	jobs, err := m.catalog.ListImportJobs(ctx)
+	if err != nil {
+		return jobMarkerUnknown
+	}
+	for _, job := range jobs {
+		if job.GetJobID() == jobID {
+			if proto.Equal(job, updatedJob) {
+				return jobMarkerCommitted
+			}
+			return jobMarkerAbsent
+		}
+	}
+	return jobMarkerAbsent
 }
 
 func (m *importMeta) UpdateTask(ctx context.Context, taskID int64, actions ...UpdateAction) error {

--- a/internal/datacoord/import_meta_test.go
+++ b/internal/datacoord/import_meta_test.go
@@ -25,8 +25,11 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus/internal/json"
+	"github.com/milvus-io/milvus/internal/metastore"
+	kvdatacoord "github.com/milvus-io/milvus/internal/metastore/kv/datacoord"
 	"github.com/milvus-io/milvus/internal/metastore/mocks"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
@@ -512,4 +515,265 @@ func TestHandleCommitVchannelTransitionsUncommittedToCommittingBeforeCallback(t 
 	updated := im.GetJob(context.TODO(), jobID)
 	assert.Equal(t, internalpb.ImportJobState_Committing, updated.GetState())
 	assert.Contains(t, updated.GetCommittedVchannels(), "ch1")
+}
+
+// ---------------------------------------------------------------------------
+// AddTasksToJob - job + task batch persisted as one composite write
+// ---------------------------------------------------------------------------
+
+func newAddTasksToJobMeta(t *testing.T) (*mocks.DataCoordCatalog, ImportMeta) {
+	catalog := mocks.NewDataCoordCatalog(t)
+	catalog.EXPECT().ListImportJobs(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().ListPreImportTasks(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().ListImportTasks(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().SaveImportJob(mock.Anything, mock.Anything).Return(nil)
+
+	im, err := NewImportMeta(context.TODO(), catalog, nil, nil)
+	assert.NoError(t, err)
+
+	var job ImportJob = &importJob{
+		ImportJob: &datapb.ImportJob{
+			JobID:        1,
+			CollectionID: 2,
+			State:        internalpb.ImportJobState_Pending,
+		},
+	}
+	assert.NoError(t, im.AddJob(context.TODO(), job))
+	return catalog, im
+}
+
+func newTestPreImportTask(jobID, taskID int64) ImportTask {
+	task := &preImportTask{}
+	task.task.Store(&datapb.PreImportTask{JobID: jobID, TaskID: taskID, State: datapb.ImportTaskStateV2_Pending})
+	return task
+}
+
+// TestImportMeta_AddTasksToJob proves the task batch and the job update are
+// persisted through ONE composite catalog write, with every task save
+// composed before the job save (the commit marker), and that in-memory state
+// is applied only after the write succeeds.
+func TestImportMeta_AddTasksToJob(t *testing.T) {
+	catalog, im := newAddTasksToJobMeta(t)
+
+	var actions []metastore.UpdateAction
+	catalog.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, acts ...metastore.UpdateAction) error {
+			actions = acts
+			return nil
+		}).Once()
+
+	err := im.AddTasksToJob(context.TODO(), 1,
+		[]ImportTask{newTestPreImportTask(1, 100), newTestPreImportTask(1, 101)},
+		UpdateJobState(internalpb.ImportJobState_PreImporting))
+	assert.NoError(t, err)
+
+	assert.Len(t, actions, 3)
+	for _, action := range actions[:2] {
+		entry, ok := action.Entry.(metastore.ImportTaskEntry)
+		assert.True(t, ok)
+		assert.Equal(t, metastore.ActionAdd, action.Type)
+		assert.NotNil(t, entry.PreImportTask)
+	}
+	jobEntry, ok := actions[2].Entry.(metastore.ImportJobEntry)
+	assert.True(t, ok)
+	assert.Equal(t, metastore.ActionUpdate, actions[2].Type)
+	assert.Equal(t, internalpb.ImportJobState_PreImporting, jobEntry.Job.GetState())
+
+	assert.Len(t, im.GetTaskBy(context.TODO(), WithJob(1)), 2)
+	assert.Equal(t, internalpb.ImportJobState_PreImporting, im.GetJob(context.TODO(), 1).GetState())
+}
+
+// TestImportMeta_AddTasksToJob_FailureLeavesMemoryUntouched proves a failed
+// composite write applies nothing in memory - no tasks appear and the job
+// stays in its previous state - while the batch's task records are rolled
+// back best-effort (a failing drop is ignored, the original error surfaces).
+func TestImportMeta_AddTasksToJob_FailureLeavesMemoryUntouched(t *testing.T) {
+	catalog, im := newAddTasksToJobMeta(t)
+
+	mockErr := errors.New("mock error")
+	catalog.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything).Return(mockErr).Once()
+	catalog.EXPECT().DropPreImportTask(mock.Anything, int64(100)).Return(errors.New("drop failed too")).Once()
+
+	err := im.AddTasksToJob(context.TODO(), 1,
+		[]ImportTask{newTestPreImportTask(1, 100)},
+		UpdateJobState(internalpb.ImportJobState_PreImporting))
+	assert.ErrorIs(t, err, mockErr)
+
+	assert.Empty(t, im.GetTaskBy(context.TODO(), WithJob(1)))
+	assert.Equal(t, internalpb.ImportJobState_Pending, im.GetJob(context.TODO(), 1).GetState())
+}
+
+// TestImportMeta_AddTasksToJob_TerminalJobNoop proves a terminal job
+// (Completed/Failed) rejects the batch without any catalog write, mirroring
+// UpdateJob's guard - no task may be added under a job that already ended.
+func TestImportMeta_AddTasksToJob_TerminalJobNoop(t *testing.T) {
+	_, im := newAddTasksToJobMeta(t)
+
+	err := im.UpdateJob(context.TODO(), 1, UpdateJobState(internalpb.ImportJobState_Failed))
+	assert.NoError(t, err)
+
+	// no catalog.Update expectation: any composite write would fail the mock.
+	err = im.AddTasksToJob(context.TODO(), 1,
+		[]ImportTask{newTestPreImportTask(1, 100)},
+		UpdateJobState(internalpb.ImportJobState_PreImporting))
+	assert.NoError(t, err)
+	assert.Empty(t, im.GetTaskBy(context.TODO(), WithJob(1)))
+	assert.Equal(t, internalpb.ImportJobState_Failed, im.GetJob(context.TODO(), 1).GetState())
+}
+
+// importPartialFlushKV forces the composite import write onto the chunked
+// fallback path (MaxTxnOps=1) and fails one MultiSave chunk, simulating a
+// partial task flush that leaves earlier chunks persisted.
+type importPartialFlushKV struct {
+	*metaMemoryKV
+	multiSaves       int
+	failNthMultiSave int
+}
+
+func (f *importPartialFlushKV) MaxTxnOps() int { return 1 }
+
+func (f *importPartialFlushKV) MultiSave(ctx context.Context, kvs map[string]string) error {
+	f.multiSaves++
+	if f.multiSaves == f.failNthMultiSave {
+		return errors.New("injected partial-flush failure")
+	}
+	return f.metaMemoryKV.MultiSave(ctx, kvs)
+}
+
+// TestImportMeta_AddTasksToJob_PartialFlushLeavesNoOrphanTaskKeys pins the
+// in-process retry path against a real catalog: a composite write that dies
+// mid-flush (first task chunk persisted, second failed) leaves memory
+// untouched, so the checker's next tick re-allocates FRESH task IDs and
+// retries with a different key set - NOT the same composite write. The
+// first-generation records must therefore be rolled back on failure, or they
+// become orphans no memory-driven GC can ever reach.
+func TestImportMeta_AddTasksToJob_PartialFlushLeavesNoOrphanTaskKeys(t *testing.T) {
+	ctx := context.TODO()
+	kv := &importPartialFlushKV{metaMemoryKV: NewMetaMemoryKV(), failNthMultiSave: 2}
+	catalog := kvdatacoord.NewCatalog(kv, "", "")
+	im, err := NewImportMeta(ctx, catalog, nil, nil)
+	assert.NoError(t, err)
+
+	var job ImportJob = &importJob{
+		ImportJob: &datapb.ImportJob{JobID: 1, CollectionID: 2, State: internalpb.ImportJobState_Pending},
+	}
+	assert.NoError(t, im.AddJob(ctx, job))
+
+	// Generation 1: two tasks + the job marker against a 1-op txn limit take
+	// the fallback; chunk 1 (task 1001) lands, chunk 2 (task 1002) fails.
+	err = im.AddTasksToJob(ctx, 1,
+		[]ImportTask{newTestPreImportTask(1, 1001), newTestPreImportTask(1, 1002)},
+		UpdateJobState(internalpb.ImportJobState_PreImporting))
+	assert.Error(t, err)
+	assert.Equal(t, 2, kv.multiSaves)
+
+	// The failed batch's task keys must be rolled back: the retry below will
+	// not reuse them.
+	keys, _, err := kv.LoadWithPrefix(ctx, kvdatacoord.PreImportTaskPrefix)
+	assert.NoError(t, err)
+	assert.Empty(t, keys)
+
+	// Generation 2: the checker recomputes the full missing set and retries
+	// with newly-allocated task IDs; this one succeeds.
+	err = im.AddTasksToJob(ctx, 1,
+		[]ImportTask{newTestPreImportTask(1, 2001), newTestPreImportTask(1, 2002)},
+		UpdateJobState(internalpb.ImportJobState_PreImporting))
+	assert.NoError(t, err)
+
+	// Exactly the second generation is on disk - no first-generation orphans.
+	keys, _, err = kv.LoadWithPrefix(ctx, kvdatacoord.PreImportTaskPrefix)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{
+		fmt.Sprintf("%s/%d", kvdatacoord.PreImportTaskPrefix, 2001),
+		fmt.Sprintf("%s/%d", kvdatacoord.PreImportTaskPrefix, 2002),
+	}, keys)
+
+	// The job marker landed with the surviving generation.
+	value, err := kv.Load(ctx, fmt.Sprintf("%s/%d", kvdatacoord.ImportJobPrefix, 1))
+	assert.NoError(t, err)
+	savedJob := &datapb.ImportJob{}
+	assert.NoError(t, proto.Unmarshal([]byte(value), savedJob))
+	assert.Equal(t, internalpb.ImportJobState_PreImporting, savedJob.GetState())
+}
+
+// TestImportMeta_AddTasksToJob_AmbiguousFailureAdoptsCommittedMarker: an etcd
+// write can be applied on the store while the client still gets an error
+// (applied-but-timed-out, leader switch). The job marker - same txn on the
+// atomic path, last chunk on the fallback - may then already reference the
+// task batch; rolling the task records back would leave a PreImporting job
+// with zero tasks, which a restarted checker completes EMPTY (totalRows==0
+// auto-commit). AddTasksToJob must read the job record back, recognize the
+// committed marker, adopt the write instead of rolling back, and report
+// success.
+func TestImportMeta_AddTasksToJob_AmbiguousFailureAdoptsCommittedMarker(t *testing.T) {
+	catalog := mocks.NewDataCoordCatalog(t)
+	catalog.EXPECT().ListImportJobs(mock.Anything).Return(nil, nil).Once()
+	catalog.EXPECT().ListPreImportTasks(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().ListImportTasks(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().SaveImportJob(mock.Anything, mock.Anything).Return(nil)
+
+	im, err := NewImportMeta(context.TODO(), catalog, nil, nil)
+	assert.NoError(t, err)
+	var job ImportJob = &importJob{
+		ImportJob: &datapb.ImportJob{JobID: 1, CollectionID: 2, State: internalpb.ImportJobState_Pending},
+	}
+	assert.NoError(t, im.AddJob(context.TODO(), job))
+
+	// The composite write COMMITS on the store, but the client sees an error.
+	var committed *datapb.ImportJob
+	catalog.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, acts ...metastore.UpdateAction) error {
+			committed = acts[len(acts)-1].Entry.(metastore.ImportJobEntry).Job
+			return errors.New("etcdserver: request timed out")
+		}).Once()
+	// The read-back sees the committed marker. No DropPreImportTask
+	// expectation: rolling back the committed batch would fail the mock.
+	catalog.EXPECT().ListImportJobs(mock.Anything).
+		RunAndReturn(func(context.Context) ([]*datapb.ImportJob, error) {
+			return []*datapb.ImportJob{committed}, nil
+		}).Once()
+
+	err = im.AddTasksToJob(context.TODO(), 1,
+		[]ImportTask{newTestPreImportTask(1, 100)},
+		UpdateJobState(internalpb.ImportJobState_PreImporting))
+	assert.NoError(t, err)
+
+	// Memory adopted the committed write: task present, job state flipped.
+	assert.Len(t, im.GetTaskBy(context.TODO(), WithJob(1)), 1)
+	assert.Equal(t, internalpb.ImportJobState_PreImporting, im.GetJob(context.TODO(), 1).GetState())
+}
+
+// TestImportMeta_AddTasksToJob_ReadBackFailureSkipsRollback: when the write
+// fails AND the read-back cannot determine whether the marker landed, neither
+// adopting nor rolling back is safe - dropping the task records could empty a
+// committed job. The records must be left alone (restart reload adopts them,
+// same terminal state as a failed drop) and the original error surfaces.
+func TestImportMeta_AddTasksToJob_ReadBackFailureSkipsRollback(t *testing.T) {
+	catalog := mocks.NewDataCoordCatalog(t)
+	catalog.EXPECT().ListImportJobs(mock.Anything).Return(nil, nil).Once()
+	catalog.EXPECT().ListPreImportTasks(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().ListImportTasks(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().SaveImportJob(mock.Anything, mock.Anything).Return(nil)
+
+	im, err := NewImportMeta(context.TODO(), catalog, nil, nil)
+	assert.NoError(t, err)
+	var job ImportJob = &importJob{
+		ImportJob: &datapb.ImportJob{JobID: 1, CollectionID: 2, State: internalpb.ImportJobState_Pending},
+	}
+	assert.NoError(t, im.AddJob(context.TODO(), job))
+
+	mockErr := errors.New("etcdserver: request timed out")
+	catalog.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything).Return(mockErr).Once()
+	// The read-back fails too. No DropPreImportTask expectation: a rollback
+	// under an unknown marker state would fail the mock.
+	catalog.EXPECT().ListImportJobs(mock.Anything).Return(nil, errors.New("read back failed")).Once()
+
+	err = im.AddTasksToJob(context.TODO(), 1,
+		[]ImportTask{newTestPreImportTask(1, 100)},
+		UpdateJobState(internalpb.ImportJobState_PreImporting))
+	assert.ErrorIs(t, err, mockErr)
+
+	// Memory untouched: the next tick retries with fresh task IDs.
+	assert.Empty(t, im.GetTaskBy(context.TODO(), WithJob(1)))
+	assert.Equal(t, internalpb.ImportJobState_Pending, im.GetJob(context.TODO(), 1).GetState())
 }

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -2464,13 +2464,18 @@ func (m *meta) completeClusterCompactionMutation(t *datapb.CompactionTask, resul
 		return info.SegmentInfo
 	})
 
-	binlogs := make([]metastore.BinlogsIncrement, 0)
+	// Only new segments are persisted here - the inputs stay live until the
+	// results are indexed and made visible (markInputSegmentsDropped), so no
+	// deletion ordering applies. A crash mid-write (on the chunked fallback
+	// path) leaves some invisible segment records that the task-level retry -
+	// serialized with every other segment write by m.segMu - rewrites
+	// byte-identically.
+	actions := make([]metastore.UpdateAction, 0, len(compactToInfos))
 	for _, seg := range compactToInfos {
-		binlogs = append(binlogs, metastore.BinlogsIncrement{Segment: seg})
+		actions = append(actions, metastore.AddSegment(seg))
 	}
-	// only add new segments
-	if err := m.catalog.AlterSegments(m.ctx, compactToInfos, binlogs...); err != nil {
-		mlog.Warn(context.TODO(), "fail to alter compactTo segments", mlog.Err(err))
+	if err := m.catalog.Update(m.ctx, actions...); err != nil {
+		mlog.Warn(m.ctx, "fail to update compactTo segments", mlog.Err(err))
 		return nil, nil, err
 	}
 	lo.ForEach(compactToSegInfos, func(info *SegmentInfo, _ int) {
@@ -3377,8 +3382,16 @@ func (m *meta) completeSortCompactionMutation(
 		mlog.Int64("num rows", segment.GetNumOfRows()),
 		mlog.Int64("segment size", segment.getSegmentSize()),
 		mlog.Int64s("expirQuantiles", segment.GetExpirQuantiles()))
-	if err := m.catalog.AlterSegments(m.ctx, []*datapb.SegmentInfo{cloned.SegmentInfo, segment.SegmentInfo}, metastore.BinlogsIncrement{Segment: segment.SegmentInfo}); err != nil {
-		mlog.Warn(context.TODO(), "fail to alter segments and new segment", mlog.Err(err))
+	// Add the compactTo segment before retiring the compactFrom input, so the
+	// ordered-fallback path always publishes the new segment before the old
+	// one is retired (mirrors completeMixCompactionMutation; AlterSegment
+	// keeps the retirement byte-identical to the legacy AlterSegments
+	// encoding, including the handleDroppedSegment GC-compat binlog write).
+	if err := m.catalog.Update(m.ctx,
+		metastore.AddSegment(segment.SegmentInfo),
+		metastore.AlterSegment(cloned.SegmentInfo),
+	); err != nil {
+		mlog.Warn(m.ctx, "fail to update sort compaction segments", mlog.Err(err))
 		return nil, nil, err
 	}
 
@@ -3505,17 +3518,15 @@ func (m *meta) completeBumpSchemaVersionCompactionMutation(
 		cloned.DataVersion = oldSegment.GetDataVersion() + 1
 	}
 
-	// Prepare binlogs increment for catalog update
-	binlogsIncrement := metastore.BinlogsIncrement{
-		Segment: cloned.SegmentInfo,
-	}
-
 	mlog.Info(m.ctx, "meta update: prepare for complete schema bump compaction mutation - complete",
 		mlog.Int64("num rows", cloned.GetNumOfRows()))
 
-	// Save to catalog
-	if err := m.catalog.AlterSegments(m.ctx, []*datapb.SegmentInfo{cloned.SegmentInfo}, binlogsIncrement); err != nil {
-		mlog.Warn(m.ctx, "fail to alter segment for schema bump compaction", mlog.Err(err))
+	// The in-place adoption rewrites the segment record plus its binlog KVs
+	// from the already-mutated value - exactly the write set AddSegment stages
+	// - so this stays byte-identical to the legacy
+	// AlterSegments(cloned, BinlogsIncrement{cloned}) call.
+	if err := m.catalog.Update(m.ctx, metastore.AddSegment(cloned.SegmentInfo)); err != nil {
+		mlog.Warn(m.ctx, "fail to update segment for schema bump compaction", mlog.Err(err))
 		return nil, nil, err
 	}
 
@@ -3584,11 +3595,15 @@ func (m *meta) completeBumpSchemaVersionReplacementMutation(
 		newSegment.DroppedAt = uint64(time.Now().UnixNano())
 	}
 
-	binlogsIncrement := metastore.BinlogsIncrement{Segment: newSegment.SegmentInfo}
 	mlog.Info(m.ctx, "meta update: prepare replacement for schema bump full rewrite", mlog.Int64("num rows", newSegment.GetNumOfRows()))
 
-	if err := m.catalog.AlterSegments(m.ctx, []*datapb.SegmentInfo{dropped.SegmentInfo, newSegment.SegmentInfo}, binlogsIncrement); err != nil {
-		mlog.Warn(m.ctx, "fail to alter replacement segments for schema bump compaction", mlog.Err(err))
+	// Add the replacement segment before retiring the input (see
+	// completeSortCompactionMutation for the ordering rationale).
+	if err := m.catalog.Update(m.ctx,
+		metastore.AddSegment(newSegment.SegmentInfo),
+		metastore.AlterSegment(dropped.SegmentInfo),
+	); err != nil {
+		mlog.Warn(m.ctx, "fail to update replacement segments for schema bump compaction", mlog.Err(err))
 		return nil, nil, err
 	}
 

--- a/internal/datacoord/meta_compaction_update_test.go
+++ b/internal/datacoord/meta_compaction_update_test.go
@@ -1,0 +1,422 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/metastore"
+	"github.com/milvus-io/milvus/internal/metastore/kv/datacoord"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/pkg/v3/kv"
+	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+)
+
+// compactionRecordingKV wraps the in-memory meta KV so a test can assert the
+// call shape of a compaction completion write (composite single-txn vs the
+// legacy chunked MultiSave) and inject crashes on either commit path.
+type compactionRecordingKV struct {
+	*metaMemoryKV
+
+	// txnOpsLimit overrides MaxTxnOps when > 0, to force the chunked
+	// fallback path of the composite txn engine.
+	txnOpsLimit int
+
+	multiSaveCalls          int
+	multiSaveAndRemoveCalls int
+
+	// failNextMultiSaveAndRemove fails the next N MultiSaveAndRemove calls
+	// before touching the store (an atomic-txn crash: nothing persists).
+	failNextMultiSaveAndRemove int
+	// failMultiSaveAtCall fails the Nth MultiSave call (1-based), once,
+	// before touching the store (a mid-fallback crash: earlier chunks stay).
+	failMultiSaveAtCall int
+}
+
+var errInjectedCompactionCrash = errors.New("injected compaction meta write crash")
+
+func (r *compactionRecordingKV) MaxTxnOps() int {
+	if r.txnOpsLimit > 0 {
+		return r.txnOpsLimit
+	}
+	return r.metaMemoryKV.MaxTxnOps()
+}
+
+func (r *compactionRecordingKV) MultiSave(ctx context.Context, kvs map[string]string) error {
+	r.multiSaveCalls++
+	if r.failMultiSaveAtCall > 0 && r.multiSaveCalls == r.failMultiSaveAtCall {
+		r.failMultiSaveAtCall = 0
+		return errInjectedCompactionCrash
+	}
+	return r.metaMemoryKV.MultiSave(ctx, kvs)
+}
+
+func (r *compactionRecordingKV) MultiSaveAndRemove(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	r.multiSaveAndRemoveCalls++
+	if r.failNextMultiSaveAndRemove > 0 {
+		r.failNextMultiSaveAndRemove--
+		return errInjectedCompactionCrash
+	}
+	return r.metaMemoryKV.MultiSaveAndRemove(ctx, saves, removals, preds...)
+}
+
+func dumpMetaStore(t *testing.T, k kv.MetaKv) map[string]string {
+	keys, values, err := k.LoadWithPrefix(context.TODO(), "")
+	require.NoError(t, err)
+	out := make(map[string]string, len(keys))
+	for i := range keys {
+		out[keys[i]] = values[i]
+	}
+	return out
+}
+
+// replayLegacyAlterSegments applies the pre-composite catalog.AlterSegments
+// encoding for the given segments/increments on a fresh store and returns its
+// dump - the byte-for-byte reference every converted completion path must
+// match.
+func replayLegacyAlterSegments(t *testing.T, segments []*datapb.SegmentInfo, increments ...metastore.BinlogsIncrement) map[string]string {
+	refKV := NewMetaMemoryKV()
+	refCatalog := datacoord.NewCatalog(refKV, "", "")
+	require.NoError(t, refCatalog.AlterSegments(context.TODO(), segments, increments...))
+	return dumpMetaStore(t, refKV)
+}
+
+func newCompactionTestMeta(k kv.MetaKv, segments *SegmentsInfo) *meta {
+	return &meta{
+		ctx:      context.TODO(),
+		catalog:  datacoord.NewCatalog(k, "", ""),
+		segments: segments,
+	}
+}
+
+func clusterCompactionInputs() *SegmentsInfo {
+	segments := NewSegmentsInfo()
+	for segID, segment := range map[UniqueID]*SegmentInfo{
+		1: {SegmentInfo: &datapb.SegmentInfo{
+			ID:           1,
+			CollectionID: 100,
+			PartitionID:  10,
+			State:        commonpb.SegmentState_Flushed,
+			Level:        datapb.SegmentLevel_L1,
+			Binlogs:      []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+			Statslogs:    []*datapb.FieldBinlog{getFieldBinlogIDs(0, 20000)},
+			NumOfRows:    2,
+			MaxRowNum:    100,
+		}},
+		2: {SegmentInfo: &datapb.SegmentInfo{
+			ID:           2,
+			CollectionID: 100,
+			PartitionID:  10,
+			State:        commonpb.SegmentState_Flushed,
+			Level:        datapb.SegmentLevel_L1,
+			Binlogs:      []*datapb.FieldBinlog{getFieldBinlogIDs(0, 11000)},
+			Statslogs:    []*datapb.FieldBinlog{getFieldBinlogIDs(0, 21000)},
+			NumOfRows:    2,
+			MaxRowNum:    100,
+		}},
+	} {
+		segments.SetSegment(segID, segment)
+	}
+	return segments
+}
+
+func clusterCompactionTaskAndResult(compactToIDs ...int64) (*datapb.CompactionTask, *datapb.CompactionPlanResult) {
+	task := &datapb.CompactionTask{
+		PlanID:        19530,
+		InputSegments: []UniqueID{1, 2},
+		Type:          datapb.CompactionType_ClusteringCompaction,
+		Channel:       "ch-1",
+		StartTime:     1700000000,
+		Schema:        &schemapb.CollectionSchema{Version: 2},
+	}
+	result := &datapb.CompactionPlanResult{}
+	for _, id := range compactToIDs {
+		result.Segments = append(result.Segments, &datapb.CompactionSegment{
+			SegmentID:           id,
+			InsertLogs:          []*datapb.FieldBinlog{getFieldBinlogIDs(0, id*1000)},
+			Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogIDs(0, id*1000+1)},
+			NumOfRows:           2,
+		})
+	}
+	return task, result
+}
+
+// TestCompleteClusterCompactionMutation_Composite proves the clustering
+// completion persists every compactTo segment through the composite catalog
+// Update - one atomic txn instead of the legacy chunked AlterSegments
+// (SaveByBatch) - while staying byte-for-byte identical to the legacy
+// encoding, and that a crash of the composite write is recoverable: an atomic
+// crash persists nothing (memory untouched), and a retry converges to the
+// legacy bytes.
+func TestCompleteClusterCompactionMutation_Composite(t *testing.T) {
+	t.Run("single atomic txn, bytes match legacy", func(t *testing.T) {
+		rec := &compactionRecordingKV{metaMemoryKV: NewMetaMemoryKV()}
+		m := newCompactionTestMeta(rec, clusterCompactionInputs())
+		task, result := clusterCompactionTaskAndResult(11, 12)
+
+		infos, mutation, err := m.CompleteCompactionMutation(context.TODO(), task, result)
+		require.NoError(t, err)
+		require.Len(t, infos, 2)
+		require.NotNil(t, mutation)
+
+		// The whole write must be one composite txn - no legacy chunked
+		// MultiSave.
+		assert.Equal(t, 0, rec.multiSaveCalls)
+		assert.Equal(t, 1, rec.multiSaveAndRemoveCalls)
+
+		// Byte-for-byte parity with the legacy AlterSegments encoding
+		// (record + binlog KVs per compactTo segment).
+		segments := make([]*datapb.SegmentInfo, 0, len(infos))
+		increments := make([]metastore.BinlogsIncrement, 0, len(infos))
+		for _, info := range infos {
+			segments = append(segments, info.SegmentInfo)
+			increments = append(increments, metastore.BinlogsIncrement{Segment: info.SegmentInfo})
+		}
+		assert.Equal(t, replayLegacyAlterSegments(t, segments, increments...), dumpMetaStore(t, rec.metaMemoryKV))
+	})
+
+	t.Run("atomic crash persists nothing and retry converges", func(t *testing.T) {
+		rec := &compactionRecordingKV{metaMemoryKV: NewMetaMemoryKV(), failNextMultiSaveAndRemove: 1}
+		m := newCompactionTestMeta(rec, clusterCompactionInputs())
+		task, result := clusterCompactionTaskAndResult(11, 12)
+
+		_, _, err := m.CompleteCompactionMutation(context.TODO(), task, result)
+		require.ErrorIs(t, err, errInjectedCompactionCrash)
+		// Atomic all-or-nothing: nothing persisted, memory untouched.
+		assert.Empty(t, dumpMetaStore(t, rec.metaMemoryKV))
+		assert.Nil(t, m.GetSegment(context.TODO(), 11))
+		assert.Equal(t, commonpb.SegmentState_Flushed, m.GetSegment(context.TODO(), 1).GetState())
+
+		// The task-level retry re-runs the mutation with the same result and
+		// must converge to the legacy bytes.
+		infos, _, err := m.CompleteCompactionMutation(context.TODO(), task, result)
+		require.NoError(t, err)
+		require.Len(t, infos, 2)
+		segments := make([]*datapb.SegmentInfo, 0, len(infos))
+		increments := make([]metastore.BinlogsIncrement, 0, len(infos))
+		for _, info := range infos {
+			segments = append(segments, info.SegmentInfo)
+			increments = append(increments, metastore.BinlogsIncrement{Segment: info.SegmentInfo})
+		}
+		assert.Equal(t, replayLegacyAlterSegments(t, segments, increments...), dumpMetaStore(t, rec.metaMemoryKV))
+	})
+
+	t.Run("chunked fallback crash leaves a clean partial state and retry converges", func(t *testing.T) {
+		// 3 compactTo segments x 3 KVs each (record + binlog + statslog)
+		// against a 2-op txn limit forces the ordered chunked fallback; the
+		// injected crash kills the second chunk.
+		rec := &compactionRecordingKV{metaMemoryKV: NewMetaMemoryKV(), txnOpsLimit: 2, failMultiSaveAtCall: 2}
+		m := newCompactionTestMeta(rec, clusterCompactionInputs())
+		task, result := clusterCompactionTaskAndResult(11, 12, 13)
+
+		_, _, err := m.CompleteCompactionMutation(context.TODO(), task, result)
+		require.ErrorIs(t, err, errInjectedCompactionCrash)
+		// Memory is only mutated after a successful persist.
+		assert.Nil(t, m.GetSegment(context.TODO(), 11))
+
+		partial := dumpMetaStore(t, rec.metaMemoryKV)
+
+		// Retry converges to the legacy bytes; the earlier partial chunks are
+		// re-written identically (pure puts, idempotent), never left stale.
+		infos, _, err := m.CompleteCompactionMutation(context.TODO(), task, result)
+		require.NoError(t, err)
+		require.Len(t, infos, 3)
+		segments := make([]*datapb.SegmentInfo, 0, len(infos))
+		increments := make([]metastore.BinlogsIncrement, 0, len(infos))
+		for _, info := range infos {
+			segments = append(segments, info.SegmentInfo)
+			increments = append(increments, metastore.BinlogsIncrement{Segment: info.SegmentInfo})
+		}
+		reference := replayLegacyAlterSegments(t, segments, increments...)
+		assert.Equal(t, reference, dumpMetaStore(t, rec.metaMemoryKV))
+		// Every key the crashed attempt did persist already carried its final
+		// bytes - the fallback never writes a value a retry has to fix up.
+		for k, v := range partial {
+			assert.Equal(t, reference[k], v, "crashed chunk left non-final bytes at %s", k)
+		}
+	})
+}
+
+// TestCompleteSortCompactionMutation_Composite proves the sort completion
+// persists the new segment and retires the input through one composite txn,
+// byte-for-byte identical to the legacy
+// AlterSegments([dropped, new], BinlogsIncrement{new}) call - including the
+// handleDroppedSegment GC-compat binlog write for the dropped input.
+func TestCompleteSortCompactionMutation_Composite(t *testing.T) {
+	segments := NewSegmentsInfo()
+	segments.SetSegment(1, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+		ID:            1,
+		CollectionID:  100,
+		PartitionID:   10,
+		InsertChannel: "ch-1",
+		State:         commonpb.SegmentState_Flushed,
+		Level:         datapb.SegmentLevel_L1,
+		Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+		Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 20000)},
+		NumOfRows:     2,
+		MaxRowNum:     100,
+	}})
+
+	rec := &compactionRecordingKV{metaMemoryKV: NewMetaMemoryKV()}
+	m := newCompactionTestMeta(rec, segments)
+
+	task := &datapb.CompactionTask{
+		PlanID:        19531,
+		InputSegments: []UniqueID{1},
+		Type:          datapb.CompactionType_SortCompaction,
+		Schema:        &schemapb.CollectionSchema{Version: 2},
+	}
+	result := &datapb.CompactionPlanResult{
+		Segments: []*datapb.CompactionSegment{{
+			SegmentID:           3,
+			InsertLogs:          []*datapb.FieldBinlog{getFieldBinlogIDs(0, 50000)},
+			Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogIDs(0, 50001)},
+			NumOfRows:           2,
+			IsSorted:            true,
+		}},
+	}
+
+	infos, _, err := m.CompleteCompactionMutation(context.TODO(), task, result)
+	require.NoError(t, err)
+	require.Len(t, infos, 1)
+
+	assert.Equal(t, 0, rec.multiSaveCalls)
+	assert.Equal(t, 1, rec.multiSaveAndRemoveCalls)
+
+	dropped := m.GetSegment(context.TODO(), 1)
+	require.Equal(t, commonpb.SegmentState_Dropped, dropped.GetState())
+	reference := replayLegacyAlterSegments(t,
+		[]*datapb.SegmentInfo{dropped.SegmentInfo, infos[0].SegmentInfo},
+		metastore.BinlogsIncrement{Segment: infos[0].SegmentInfo})
+	assert.Equal(t, reference, dumpMetaStore(t, rec.metaMemoryKV))
+}
+
+// TestCompleteBumpSchemaVersionCompactionMutation_Composite proves the
+// in-place schema bump adoption persists the mutated segment through one
+// composite txn, byte-for-byte identical to the legacy
+// AlterSegments([cloned], BinlogsIncrement{cloned}) call.
+func TestCompleteBumpSchemaVersionCompactionMutation_Composite(t *testing.T) {
+	currentManifest := packed.MarshalManifestPath("/data/segments/1", 10)
+	resultManifest := packed.MarshalManifestPath("/data/segments/1", 12)
+
+	segments := NewSegmentsInfo()
+	segments.SetSegment(1, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+		ID:             1,
+		CollectionID:   100,
+		PartitionID:    10,
+		State:          commonpb.SegmentState_Flushed,
+		Level:          datapb.SegmentLevel_L1,
+		Binlogs:        []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+		NumOfRows:      5,
+		SchemaVersion:  1,
+		StorageVersion: storage.StorageV3,
+		ManifestPath:   currentManifest,
+	}})
+
+	rec := &compactionRecordingKV{metaMemoryKV: NewMetaMemoryKV()}
+	m := newCompactionTestMeta(rec, segments)
+
+	task := &datapb.CompactionTask{
+		InputSegments: []int64{1},
+		Type:          datapb.CompactionType_BumpSchemaVersionCompaction,
+		Schema:        &schemapb.CollectionSchema{Version: 3},
+	}
+	result := &datapb.CompactionPlanResult{
+		Segments: []*datapb.CompactionSegment{{
+			SegmentID:      1,
+			NumOfRows:      5,
+			InsertLogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10001)},
+			Manifest:       resultManifest,
+			BaseManifest:   currentManifest,
+			StorageVersion: storage.StorageV3,
+		}},
+	}
+
+	infos, _, err := m.CompleteCompactionMutation(context.TODO(), task, result)
+	require.NoError(t, err)
+	require.Len(t, infos, 1)
+
+	assert.Equal(t, 0, rec.multiSaveCalls)
+	assert.Equal(t, 1, rec.multiSaveAndRemoveCalls)
+
+	reference := replayLegacyAlterSegments(t,
+		[]*datapb.SegmentInfo{infos[0].SegmentInfo},
+		metastore.BinlogsIncrement{Segment: infos[0].SegmentInfo})
+	assert.Equal(t, reference, dumpMetaStore(t, rec.metaMemoryKV))
+}
+
+// TestCompleteBumpSchemaVersionReplacementMutation_Composite proves the
+// schema bump full-rewrite replacement persists the new segment and retires
+// the old one through one composite txn, byte-for-byte identical to the
+// legacy AlterSegments([dropped, new], BinlogsIncrement{new}) call.
+func TestCompleteBumpSchemaVersionReplacementMutation_Composite(t *testing.T) {
+	segments := NewSegmentsInfo()
+	segments.SetSegment(1, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+		ID:            1,
+		CollectionID:  100,
+		PartitionID:   10,
+		InsertChannel: "ch-1",
+		State:         commonpb.SegmentState_Flushed,
+		Level:         datapb.SegmentLevel_L1,
+		Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+		Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 20000)},
+		NumOfRows:     5,
+		SchemaVersion: 1,
+	}})
+
+	rec := &compactionRecordingKV{metaMemoryKV: NewMetaMemoryKV()}
+	m := newCompactionTestMeta(rec, segments)
+
+	task := &datapb.CompactionTask{
+		InputSegments:          []int64{1},
+		Type:                   datapb.CompactionType_BumpSchemaVersionCompaction,
+		Schema:                 &schemapb.CollectionSchema{Version: 3},
+		PreAllocatedSegmentIDs: &datapb.IDRange{Begin: 5, End: 6},
+	}
+	result := &datapb.CompactionPlanResult{
+		Segments: []*datapb.CompactionSegment{{
+			SegmentID:      5,
+			NumOfRows:      5,
+			Manifest:       packed.MarshalManifestPath("/data/segments/5", 1),
+			StorageVersion: storage.StorageV3,
+		}},
+	}
+
+	infos, _, err := m.CompleteCompactionMutation(context.TODO(), task, result)
+	require.NoError(t, err)
+	require.Len(t, infos, 1)
+	require.EqualValues(t, 5, infos[0].GetID())
+
+	assert.Equal(t, 0, rec.multiSaveCalls)
+	assert.Equal(t, 1, rec.multiSaveAndRemoveCalls)
+
+	dropped := m.GetSegment(context.TODO(), 1)
+	require.Equal(t, commonpb.SegmentState_Dropped, dropped.GetState())
+	reference := replayLegacyAlterSegments(t,
+		[]*datapb.SegmentInfo{dropped.SegmentInfo, infos[0].SegmentInfo},
+		metastore.BinlogsIncrement{Segment: infos[0].SegmentInfo})
+	assert.Equal(t, reference, dumpMetaStore(t, rec.metaMemoryKV))
+}

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -2957,7 +2957,8 @@ func (suite *MetaBasicSuite) TestCompleteBumpSchemaVersionCompactionMutation() {
 		segment.ManifestPath = currentManifest
 		catalogErr := errors.New("catalog error")
 		metakv := mockkv.NewMetaKv(suite.T())
-		metakv.EXPECT().MultiSave(mock.Anything, mock.Anything).Return(catalogErr).Once()
+		metakv.EXPECT().MaxTxnOps().Return(128).Maybe()
+		metakv.EXPECT().MultiSaveAndRemove(mock.Anything, mock.Anything, mock.Anything).Return(catalogErr).Once()
 		m := &meta{
 			catalog:  datacoord.NewCatalog(metakv, "", ""),
 			segments: segs,
@@ -2992,8 +2993,9 @@ func (suite *MetaBasicSuite) TestCompleteBumpSchemaVersionCompactionMutation() {
 	suite.Run("catalog error replacement does not update memory", func() {
 		catalogErr := errors.New("catalog error")
 		metakv := mockkv.NewMetaKv(suite.T())
+		metakv.EXPECT().MaxTxnOps().Return(128).Maybe()
 		metakv.EXPECT().HasPrefix(mock.Anything, mock.Anything).Return(false, nil).Times(3)
-		metakv.EXPECT().MultiSave(mock.Anything, mock.Anything).Return(catalogErr).Once()
+		metakv.EXPECT().MultiSaveAndRemove(mock.Anything, mock.Anything, mock.Anything).Return(catalogErr).Once()
 		m := &meta{
 			catalog:  datacoord.NewCatalog(metakv, "", ""),
 			segments: makeSegments(1, commonpb.SegmentState_Flushed),

--- a/internal/datacoord/mock_import_meta.go
+++ b/internal/datacoord/mock_import_meta.go
@@ -115,6 +115,69 @@ func (_c *MockImportMeta_AddTask_Call) RunAndReturn(run func(context.Context, Im
 	return _c
 }
 
+// AddTasksToJob provides a mock function with given fields: ctx, jobID, tasks, actions
+func (_m *MockImportMeta) AddTasksToJob(ctx context.Context, jobID int64, tasks []ImportTask, actions ...UpdateJobAction) error {
+	_va := make([]interface{}, len(actions))
+	for _i := range actions {
+		_va[_i] = actions[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, jobID, tasks)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddTasksToJob")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64, []ImportTask, ...UpdateJobAction) error); ok {
+		r0 = rf(ctx, jobID, tasks, actions...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockImportMeta_AddTasksToJob_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddTasksToJob'
+type MockImportMeta_AddTasksToJob_Call struct {
+	*mock.Call
+}
+
+// AddTasksToJob is a helper method to define mock.On call
+//   - ctx context.Context
+//   - jobID int64
+//   - tasks []ImportTask
+//   - actions ...UpdateJobAction
+func (_e *MockImportMeta_Expecter) AddTasksToJob(ctx interface{}, jobID interface{}, tasks interface{}, actions ...interface{}) *MockImportMeta_AddTasksToJob_Call {
+	return &MockImportMeta_AddTasksToJob_Call{Call: _e.mock.On("AddTasksToJob",
+		append([]interface{}{ctx, jobID, tasks}, actions...)...)}
+}
+
+func (_c *MockImportMeta_AddTasksToJob_Call) Run(run func(ctx context.Context, jobID int64, tasks []ImportTask, actions ...UpdateJobAction)) *MockImportMeta_AddTasksToJob_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]UpdateJobAction, len(args)-3)
+		for i, a := range args[3:] {
+			if a != nil {
+				variadicArgs[i] = a.(UpdateJobAction)
+			}
+		}
+		run(args[0].(context.Context), args[1].(int64), args[2].([]ImportTask), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockImportMeta_AddTasksToJob_Call) Return(_a0 error) *MockImportMeta_AddTasksToJob_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockImportMeta_AddTasksToJob_Call) RunAndReturn(run func(context.Context, int64, []ImportTask, ...UpdateJobAction) error) *MockImportMeta_AddTasksToJob_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CountJobBy provides a mock function with given fields: ctx, filters
 func (_m *MockImportMeta) CountJobBy(ctx context.Context, filters ...ImportJobFilter) int {
 	_va := make([]interface{}, len(filters))

--- a/internal/kv/etcd/embed_etcd_kv.go
+++ b/internal/kv/etcd/embed_etcd_kv.go
@@ -27,7 +27,7 @@ import (
 	"go.etcd.io/etcd/server/v3/embed"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/v3client"
 
-	"github.com/milvus-io/milvus/pkg/v3/kv"
+	kvpkg "github.com/milvus-io/milvus/pkg/v3/kv"
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/util"
@@ -37,7 +37,7 @@ import (
 )
 
 // implementation assertion
-var _ kv.MetaKv = (*EmbedEtcdKV)(nil)
+var _ kvpkg.MetaKv = (*EmbedEtcdKV)(nil)
 
 const (
 	defaultRetryCount    = 3
@@ -583,6 +583,9 @@ func (kv *EmbedEtcdKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves m
 // @removals and removes every key under the prefixes in @prefixRemovals, all
 // in one transaction.
 func (kv *EmbedEtcdKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	if err := kvpkg.ValidateNoSaveUnderRemovedPrefix(saves, prefixRemovals); err != nil {
+		return err
+	}
 	cmps, err := parsePredicates(kv.rootPath, preds...)
 	if err != nil {
 		return err

--- a/internal/kv/etcd/embed_etcd_kv.go
+++ b/internal/kv/etcd/embed_etcd_kv.go
@@ -579,6 +579,45 @@ func (kv *EmbedEtcdKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves m
 	return nil
 }
 
+// MultiSaveAndRemoveMixed saves kv in @saves, removes the exact keys in
+// @removals and removes every key under the prefixes in @prefixRemovals, all
+// in one transaction.
+func (kv *EmbedEtcdKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	cmps, err := parsePredicates(kv.rootPath, preds...)
+	if err != nil {
+		return err
+	}
+
+	ops := make([]clientv3.Op, 0, len(saves)+len(removals)+len(prefixRemovals))
+	// use complement to remove keys that are not in saves
+	saveKeys := typeutil.NewSet(lo.Keys(saves)...)
+	removeKeys := typeutil.NewSet(removals...)
+	removals = removeKeys.Complement(saveKeys).Collect()
+	for _, keyDelete := range removals {
+		ops = append(ops, clientv3.OpDelete(kv.GetPath(keyDelete)))
+	}
+	for _, keyDelete := range prefixRemovals {
+		ops = append(ops, clientv3.OpDelete(kv.GetPath(keyDelete), clientv3.WithPrefix()))
+	}
+
+	for key, value := range saves {
+		ops = append(ops, clientv3.OpPut(kv.GetPath(key), value))
+	}
+
+	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
+	defer cancel()
+
+	resp, err := kv.client.Txn(ctx1).If(cmps...).Then(ops...).Commit()
+	if err != nil {
+		return merr.WrapErrIoFailedReason("failed to execute transaction", err.Error())
+	}
+
+	if !resp.Succeeded {
+		return merr.WrapErrIoFailedReason("failed to execute transaction")
+	}
+	return nil
+}
+
 // MultiSaveBytesAndRemoveWithPrefix saves kv in @saves and removes the keys with given prefix in @removals.
 func (kv *EmbedEtcdKV) MultiSaveBytesAndRemoveWithPrefix(ctx context.Context, saves map[string][]byte, removals []string) error {
 	ops := make([]clientv3.Op, 0, len(saves)+len(removals))

--- a/internal/kv/etcd/embed_etcd_kv_test.go
+++ b/internal/kv/etcd/embed_etcd_kv_test.go
@@ -926,6 +926,46 @@ func (s *EmbedEtcdKVSuite) TestTxnWithPredicates() {
 	}
 }
 
+func (s *EmbedEtcdKVSuite) TestMultiSaveAndRemoveMixed() {
+	etcdKV := s.kv
+
+	prepareTests := map[string]string{
+		"mix/a-1":    "1",
+		"mix/a-1/c1": "11",
+		"mix/a-1/c2": "12",
+		"mix/a-10":   "10", // exact-remove canary: a prefix delete of "mix/a-1" would wipe it
+		"mix/b":      "b",
+	}
+	err := etcdKV.MultiSave(context.TODO(), prepareTests)
+	s.Require().NoError(err)
+
+	// failed predicate: the whole mixed txn must be a no-op.
+	err = etcdKV.MultiSaveAndRemoveMixed(context.TODO(),
+		map[string]string{"mix/new": "nv"}, []string{"mix/a-1"}, []string{"mix/a-1/"},
+		predicates.ValueEqual("mix/b", "not-b"))
+	s.Error(err)
+	keys, _, err := etcdKV.LoadWithPrefix(context.TODO(), "mix")
+	s.NoError(err)
+	s.Len(keys, 5)
+
+	err = etcdKV.MultiSaveAndRemoveMixed(context.TODO(),
+		map[string]string{"mix/new": "nv"}, []string{"mix/a-1"}, []string{"mix/a-1/"},
+		predicates.ValueEqual("mix/b", "b"))
+	s.NoError(err)
+
+	keys, vals, err := etcdKV.LoadWithPrefix(context.TODO(), "mix")
+	s.NoError(err)
+	got := make(map[string]string, len(keys))
+	for i, k := range keys {
+		got[k] = vals[i]
+	}
+	s.Equal(map[string]string{
+		etcdKV.GetPath("mix/a-10"): "10",
+		etcdKV.GetPath("mix/b"):    "b",
+		etcdKV.GetPath("mix/new"):  "nv",
+	}, got)
+}
+
 func TestEmbedEtcdKV(t *testing.T) {
 	suite.Run(t, new(EmbedEtcdKVSuite))
 }

--- a/internal/kv/etcd/embed_etcd_kv_test.go
+++ b/internal/kv/etcd/embed_etcd_kv_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/kv"
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
@@ -938,6 +939,11 @@ func (s *EmbedEtcdKVSuite) TestMultiSaveAndRemoveMixed() {
 	}
 	err := etcdKV.MultiSave(context.TODO(), prepareTests)
 	s.Require().NoError(err)
+
+	err = etcdKV.MultiSaveAndRemoveMixed(context.TODO(),
+		map[string]string{"mix/a-1/c3": "new"}, nil, []string{"mix/a-1/"})
+	s.Error(err)
+	s.ErrorIs(err, merr.ErrParameterInvalid)
 
 	// failed predicate: the whole mixed txn must be a no-op.
 	err = etcdKV.MultiSaveAndRemoveMixed(context.TODO(),

--- a/internal/kv/etcd/etcd_kv.go
+++ b/internal/kv/etcd/etcd_kv.go
@@ -607,6 +607,56 @@ func (kv *etcdKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[st
 	return nil
 }
 
+// MultiSaveAndRemoveMixed saves kv in @saves, removes the exact keys in
+// @removals and removes every key under the prefixes in @prefixRemovals, all
+// in one transaction.
+func (kv *etcdKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	cmps, err := parsePredicates(kv.rootPath, preds...)
+	if err != nil {
+		return err
+	}
+
+	start := time.Now()
+	ops := make([]clientv3.Op, 0, len(saves)+len(removals)+len(prefixRemovals))
+	// use complement to remove keys that are not in saves
+	saveKeys := typeutil.NewSet(lo.Keys(saves)...)
+	removeKeys := typeutil.NewSet(removals...)
+	removals = removeKeys.Complement(saveKeys).Collect()
+	for _, keyDelete := range removals {
+		ops = append(ops, clientv3.OpDelete(kv.GetPath(keyDelete)))
+	}
+	for _, keyDelete := range prefixRemovals {
+		ops = append(ops, clientv3.OpDelete(kv.GetPath(keyDelete), clientv3.WithPrefix()))
+	}
+
+	var keys []string
+	for key, value := range saves {
+		keys = append(keys, key)
+		ops = append(ops, clientv3.OpPut(kv.GetPath(key), value))
+	}
+
+	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
+	defer cancel()
+
+	resp, err := kv.executeTxn(kv.getTxnWithCmp(ctx1, cmps...), ops...)
+	if err != nil {
+		mlog.Warn(ctx, "Etcd MultiSaveAndRemoveMixed error",
+			mlog.Any("saves", saves),
+			mlog.Strings("removes", removals),
+			mlog.Strings("prefixRemoves", prefixRemovals),
+			mlog.Int("saveLength", len(saves)),
+			mlog.Int("removeLength", len(removals)),
+			mlog.Int("prefixRemoveLength", len(prefixRemovals)),
+			mlog.Err(err))
+		return err
+	}
+	CheckElapseAndWarn(ctx, start, "Slow etcd operation multi save and remove mixed", mlog.Strings("keys", keys))
+	if !resp.Succeeded {
+		return merr.WrapErrIoFailedReason("failed to execute transaction")
+	}
+	return nil
+}
+
 // MultiSaveBytesAndRemoveWithPrefix saves kv in @saves and removes the keys with given prefix in @removals.
 func (kv *etcdKV) MultiSaveBytesAndRemoveWithPrefix(ctx context.Context, saves map[string][]byte, removals []string) error {
 	start := time.Now()

--- a/internal/kv/etcd/etcd_kv.go
+++ b/internal/kv/etcd/etcd_kv.go
@@ -25,7 +25,7 @@ import (
 	"github.com/samber/lo"
 	clientv3 "go.etcd.io/etcd/client/v3"
 
-	"github.com/milvus-io/milvus/pkg/v3/kv"
+	kvpkg "github.com/milvus-io/milvus/pkg/v3/kv"
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -42,7 +42,7 @@ const (
 )
 
 // implementation assertion
-var _ kv.WatchKV = (*etcdKV)(nil)
+var _ kvpkg.WatchKV = (*etcdKV)(nil)
 
 // etcdKV implements TxnKV interface, it supports to process multiple kvs in a transaction.
 type etcdKV struct {
@@ -611,6 +611,9 @@ func (kv *etcdKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[st
 // @removals and removes every key under the prefixes in @prefixRemovals, all
 // in one transaction.
 func (kv *etcdKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	if err := kvpkg.ValidateNoSaveUnderRemovedPrefix(saves, prefixRemovals); err != nil {
+		return err
+	}
 	cmps, err := parsePredicates(kv.rootPath, preds...)
 	if err != nil {
 		return err

--- a/internal/kv/etcd/etcd_kv_test.go
+++ b/internal/kv/etcd/etcd_kv_test.go
@@ -649,6 +649,54 @@ func (s *EtcdKVSuite) TestMultiSaveAndRemoveWithPrefix() {
 	}
 }
 
+func (s *EtcdKVSuite) TestMultiSaveAndRemoveMixed() {
+	etcdKV := s.etcdKV
+
+	prepareTests := map[string]string{
+		"mix/a-1":    "1",
+		"mix/a-1/c1": "11",
+		"mix/a-1/c2": "12",
+		"mix/a-10":   "10", // exact-remove canary: a prefix delete of "mix/a-1" would wipe it
+		"mix/b":      "b",
+	}
+	err := etcdKV.MultiSave(context.TODO(), prepareTests)
+	s.Require().NoError(err)
+
+	// failed predicate: the whole mixed txn must be a no-op.
+	err = etcdKV.MultiSaveAndRemoveMixed(context.TODO(),
+		map[string]string{"mix/new": "nv"}, []string{"mix/a-1"}, []string{"mix/a-1/"},
+		predicates.ValueEqual("mix/b", "not-b"))
+	s.Error(err)
+	keys, _, err := etcdKV.LoadWithPrefix(context.TODO(), "mix")
+	s.NoError(err)
+	s.ElementsMatch(keys, []string{
+		s.etcdKV.GetPath("mix/a-1"),
+		s.etcdKV.GetPath("mix/a-1/c1"),
+		s.etcdKV.GetPath("mix/a-1/c2"),
+		s.etcdKV.GetPath("mix/a-10"),
+		s.etcdKV.GetPath("mix/b"),
+	})
+
+	// exact removal of "mix/a-1" plus prefix removal of "mix/a-1/" plus a save,
+	// in one txn; "mix/a-10" and "mix/b" must survive.
+	err = etcdKV.MultiSaveAndRemoveMixed(context.TODO(),
+		map[string]string{"mix/new": "nv"}, []string{"mix/a-1"}, []string{"mix/a-1/"},
+		predicates.ValueEqual("mix/b", "b"))
+	s.NoError(err)
+
+	keys, vals, err := etcdKV.LoadWithPrefix(context.TODO(), "mix")
+	s.NoError(err)
+	got := make(map[string]string, len(keys))
+	for i, k := range keys {
+		got[k] = vals[i]
+	}
+	s.Equal(map[string]string{
+		s.etcdKV.GetPath("mix/a-10"): "10",
+		s.etcdKV.GetPath("mix/b"):    "b",
+		s.etcdKV.GetPath("mix/new"):  "nv",
+	}, got)
+}
+
 func (s *EtcdKVSuite) TestWatch() {
 	etcdKV := s.etcdKV
 

--- a/internal/kv/etcd/etcd_kv_test.go
+++ b/internal/kv/etcd/etcd_kv_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -661,6 +662,11 @@ func (s *EtcdKVSuite) TestMultiSaveAndRemoveMixed() {
 	}
 	err := etcdKV.MultiSave(context.TODO(), prepareTests)
 	s.Require().NoError(err)
+
+	err = etcdKV.MultiSaveAndRemoveMixed(context.TODO(),
+		map[string]string{"mix/a-1/c3": "new"}, nil, []string{"mix/a-1/"})
+	s.Error(err)
+	s.ErrorIs(err, merr.ErrParameterInvalid)
 
 	// failed predicate: the whole mixed txn must be a no-op.
 	err = etcdKV.MultiSaveAndRemoveMixed(context.TODO(),

--- a/internal/kv/mem/mem_kv.go
+++ b/internal/kv/mem/mem_kv.go
@@ -333,6 +333,43 @@ func (kv *MemoryKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[
 	return nil
 }
 
+// MultiSaveAndRemoveMixed saves key-value pairs in @saves, removes exact keys
+// in @removals and keys under the prefixes in @prefixRemovals in MemoryKV
+// atomically.
+func (kv *MemoryKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	if len(preds) > 0 {
+		return merr.WrapErrServiceUnavailable("predicates not supported")
+	}
+	kv.Lock()
+	defer kv.Unlock()
+
+	// use complement to remove keys that are not in saves
+	saveKeys := typeutil.NewSet(lo.Keys(saves)...)
+	removeKeys := typeutil.NewSet(removals...)
+	removals = removeKeys.Complement(saveKeys).Collect()
+	for _, key := range removals {
+		kv.tree.Delete(memoryKVItem{key: key})
+	}
+
+	var items []memoryKVItem
+	for _, prefix := range prefixRemovals {
+		kv.tree.Ascend(func(i btree.Item) bool {
+			if strings.HasPrefix(i.(memoryKVItem).key, prefix) {
+				items = append(items, i.(memoryKVItem))
+			}
+			return true
+		})
+	}
+	for _, item := range items {
+		kv.tree.Delete(item)
+	}
+
+	for key, value := range saves {
+		kv.tree.ReplaceOrInsert(memoryKVItem{key, StringValue(value)})
+	}
+	return nil
+}
+
 // MultiSaveBytesAndRemoveWithPrefix saves key-value pairs in @saves, & remove key with prefix in @removals in MemoryKV atomically.
 func (kv *MemoryKV) MultiSaveBytesAndRemoveWithPrefix(ctx context.Context, saves map[string][]byte, removals []string) error {
 	kv.Lock()

--- a/internal/kv/mem/mem_kv.go
+++ b/internal/kv/mem/mem_kv.go
@@ -25,14 +25,14 @@ import (
 	"github.com/google/btree"
 	"github.com/samber/lo"
 
-	"github.com/milvus-io/milvus/pkg/v3/kv"
+	kvpkg "github.com/milvus-io/milvus/pkg/v3/kv"
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 // implementation assertion
-var _ kv.TxnKV = (*MemoryKV)(nil)
+var _ kvpkg.TxnKV = (*MemoryKV)(nil)
 
 // MemoryKV implements BaseKv interface and relies on underling btree.BTree.
 // As its name implies, all data is stored in memory.
@@ -339,6 +339,9 @@ func (kv *MemoryKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[
 func (kv *MemoryKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
 	if len(preds) > 0 {
 		return merr.WrapErrServiceUnavailable("predicates not supported")
+	}
+	if err := kvpkg.ValidateNoSaveUnderRemovedPrefix(saves, prefixRemovals); err != nil {
+		return err
 	}
 	kv.Lock()
 	defer kv.Unlock()

--- a/internal/kv/mem/mem_kv_test.go
+++ b/internal/kv/mem/mem_kv_test.go
@@ -259,3 +259,12 @@ func TestPredicates(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, merr.ErrServiceUnavailable)
 }
+
+func TestMultiSaveAndRemoveMixedRejectsSaveUnderRemovedPrefix(t *testing.T) {
+	kv := NewMemoryKV()
+
+	err := kv.MultiSaveAndRemoveMixed(context.TODO(),
+		map[string]string{"mix/a-1/c3": "new"}, nil, []string{"mix/a-1/"})
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+}

--- a/internal/kv/mocks/meta_kv.go
+++ b/internal/kv/mocks/meta_kv.go
@@ -659,6 +659,70 @@ func (_c *MetaKv_MultiSaveAndRemove_Call) RunAndReturn(run func(context.Context,
 	return _c
 }
 
+// MultiSaveAndRemoveMixed provides a mock function with given fields: ctx, saves, removals, prefixRemovals, preds
+func (_m *MetaKv) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	_va := make([]interface{}, len(preds))
+	for _i := range preds {
+		_va[_i] = preds[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, saves, removals, prefixRemovals)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MultiSaveAndRemoveMixed")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, map[string]string, []string, []string, ...predicates.Predicate) error); ok {
+		r0 = rf(ctx, saves, removals, prefixRemovals, preds...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MetaKv_MultiSaveAndRemoveMixed_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MultiSaveAndRemoveMixed'
+type MetaKv_MultiSaveAndRemoveMixed_Call struct {
+	*mock.Call
+}
+
+// MultiSaveAndRemoveMixed is a helper method to define mock.On call
+//   - ctx context.Context
+//   - saves map[string]string
+//   - removals []string
+//   - prefixRemovals []string
+//   - preds ...predicates.Predicate
+func (_e *MetaKv_Expecter) MultiSaveAndRemoveMixed(ctx interface{}, saves interface{}, removals interface{}, prefixRemovals interface{}, preds ...interface{}) *MetaKv_MultiSaveAndRemoveMixed_Call {
+	return &MetaKv_MultiSaveAndRemoveMixed_Call{Call: _e.mock.On("MultiSaveAndRemoveMixed",
+		append([]interface{}{ctx, saves, removals, prefixRemovals}, preds...)...)}
+}
+
+func (_c *MetaKv_MultiSaveAndRemoveMixed_Call) Run(run func(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate)) *MetaKv_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]predicates.Predicate, len(args)-4)
+		for i, a := range args[4:] {
+			if a != nil {
+				variadicArgs[i] = a.(predicates.Predicate)
+			}
+		}
+		run(args[0].(context.Context), args[1].(map[string]string), args[2].([]string), args[3].([]string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MetaKv_MultiSaveAndRemoveMixed_Call) Return(_a0 error) *MetaKv_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MetaKv_MultiSaveAndRemoveMixed_Call) RunAndReturn(run func(context.Context, map[string]string, []string, []string, ...predicates.Predicate) error) *MetaKv_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MultiSaveAndRemoveWithPrefix provides a mock function with given fields: ctx, saves, removals, preds
 func (_m *MetaKv) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
 	_va := make([]interface{}, len(preds))

--- a/internal/kv/mocks/txn_kv.go
+++ b/internal/kv/mocks/txn_kv.go
@@ -554,6 +554,70 @@ func (_c *TxnKV_MultiSaveAndRemove_Call) RunAndReturn(run func(context.Context, 
 	return _c
 }
 
+// MultiSaveAndRemoveMixed provides a mock function with given fields: ctx, saves, removals, prefixRemovals, preds
+func (_m *TxnKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	_va := make([]interface{}, len(preds))
+	for _i := range preds {
+		_va[_i] = preds[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, saves, removals, prefixRemovals)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MultiSaveAndRemoveMixed")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, map[string]string, []string, []string, ...predicates.Predicate) error); ok {
+		r0 = rf(ctx, saves, removals, prefixRemovals, preds...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// TxnKV_MultiSaveAndRemoveMixed_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MultiSaveAndRemoveMixed'
+type TxnKV_MultiSaveAndRemoveMixed_Call struct {
+	*mock.Call
+}
+
+// MultiSaveAndRemoveMixed is a helper method to define mock.On call
+//   - ctx context.Context
+//   - saves map[string]string
+//   - removals []string
+//   - prefixRemovals []string
+//   - preds ...predicates.Predicate
+func (_e *TxnKV_Expecter) MultiSaveAndRemoveMixed(ctx interface{}, saves interface{}, removals interface{}, prefixRemovals interface{}, preds ...interface{}) *TxnKV_MultiSaveAndRemoveMixed_Call {
+	return &TxnKV_MultiSaveAndRemoveMixed_Call{Call: _e.mock.On("MultiSaveAndRemoveMixed",
+		append([]interface{}{ctx, saves, removals, prefixRemovals}, preds...)...)}
+}
+
+func (_c *TxnKV_MultiSaveAndRemoveMixed_Call) Run(run func(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate)) *TxnKV_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]predicates.Predicate, len(args)-4)
+		for i, a := range args[4:] {
+			if a != nil {
+				variadicArgs[i] = a.(predicates.Predicate)
+			}
+		}
+		run(args[0].(context.Context), args[1].(map[string]string), args[2].([]string), args[3].([]string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *TxnKV_MultiSaveAndRemoveMixed_Call) Return(_a0 error) *TxnKV_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *TxnKV_MultiSaveAndRemoveMixed_Call) RunAndReturn(run func(context.Context, map[string]string, []string, []string, ...predicates.Predicate) error) *TxnKV_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MultiSaveAndRemoveWithPrefix provides a mock function with given fields: ctx, saves, removals, preds
 func (_m *TxnKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
 	_va := make([]interface{}, len(preds))

--- a/internal/kv/mocks/watch_kv.go
+++ b/internal/kv/mocks/watch_kv.go
@@ -661,6 +661,70 @@ func (_c *WatchKV_MultiSaveAndRemove_Call) RunAndReturn(run func(context.Context
 	return _c
 }
 
+// MultiSaveAndRemoveMixed provides a mock function with given fields: ctx, saves, removals, prefixRemovals, preds
+func (_m *WatchKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	_va := make([]interface{}, len(preds))
+	for _i := range preds {
+		_va[_i] = preds[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, saves, removals, prefixRemovals)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MultiSaveAndRemoveMixed")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, map[string]string, []string, []string, ...predicates.Predicate) error); ok {
+		r0 = rf(ctx, saves, removals, prefixRemovals, preds...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// WatchKV_MultiSaveAndRemoveMixed_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MultiSaveAndRemoveMixed'
+type WatchKV_MultiSaveAndRemoveMixed_Call struct {
+	*mock.Call
+}
+
+// MultiSaveAndRemoveMixed is a helper method to define mock.On call
+//   - ctx context.Context
+//   - saves map[string]string
+//   - removals []string
+//   - prefixRemovals []string
+//   - preds ...predicates.Predicate
+func (_e *WatchKV_Expecter) MultiSaveAndRemoveMixed(ctx interface{}, saves interface{}, removals interface{}, prefixRemovals interface{}, preds ...interface{}) *WatchKV_MultiSaveAndRemoveMixed_Call {
+	return &WatchKV_MultiSaveAndRemoveMixed_Call{Call: _e.mock.On("MultiSaveAndRemoveMixed",
+		append([]interface{}{ctx, saves, removals, prefixRemovals}, preds...)...)}
+}
+
+func (_c *WatchKV_MultiSaveAndRemoveMixed_Call) Run(run func(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate)) *WatchKV_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]predicates.Predicate, len(args)-4)
+		for i, a := range args[4:] {
+			if a != nil {
+				variadicArgs[i] = a.(predicates.Predicate)
+			}
+		}
+		run(args[0].(context.Context), args[1].(map[string]string), args[2].([]string), args[3].([]string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *WatchKV_MultiSaveAndRemoveMixed_Call) Return(_a0 error) *WatchKV_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *WatchKV_MultiSaveAndRemoveMixed_Call) RunAndReturn(run func(context.Context, map[string]string, []string, []string, ...predicates.Predicate) error) *WatchKV_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MultiSaveAndRemoveWithPrefix provides a mock function with given fields: ctx, saves, removals, preds
 func (_m *WatchKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
 	_va := make([]interface{}, len(preds))

--- a/internal/kv/tikv/txn_tikv.go
+++ b/internal/kv/tikv/txn_tikv.go
@@ -611,6 +611,99 @@ func (kv *txnTiKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[s
 	return nil
 }
 
+// MultiSaveAndRemoveMixed saves kv in @saves, removes the exact keys in
+// @removals and removes every key under the prefixes in @prefixRemovals, all
+// in one transaction: the prefix scan and its deletes run inside the same txn
+// snapshot as the exact deletes and saves.
+func (kv *txnTiKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(ctx, kv.requestTimeout)
+	defer cancel()
+
+	var loggingErr error
+	defer logWarnOnFailure(&loggingErr, "txnTiKV MultiSaveAndRemoveMixed() error", mlog.Any("saves", saves), mlog.Strings("removes", removals), mlog.Strings("prefixRemoves", prefixRemovals), mlog.Int("saveLength", len(saves)), mlog.Int("removeLength", len(removals)), mlog.Int("prefixRemoveLength", len(prefixRemovals)))
+
+	// use complement to remove keys that are not in saves
+	saveKeys := typeutil.NewSet(lo.Keys(saves)...)
+	removeKeys := typeutil.NewSet(removals...)
+	removals = removeKeys.Complement(saveKeys).Collect()
+
+	loggingErr = kv.runWriteTxnWithRetry(ctx, "MultiSaveAndRemoveMixed", func(txn *transaction.KVTxn) error {
+		for _, pred := range preds {
+			key := kv.GetPath(pred.Key())
+			val, err := txn.Get(ctx, []byte(key))
+			if err != nil {
+				if errors.Is(err, tikverr.ErrNotExist) {
+					return markPredicateNotMet(merr.WrapErrIoFailedReason(fmt.Sprintf("failed to read predicate target (%s:%v) for MultiSaveAndRemoveMixed", pred.Key(), pred.TargetValue()), err.Error()))
+				}
+				return merr.WrapErrIoFailedReason(fmt.Sprintf("failed to read predicate target (%s:%v) for MultiSaveAndRemoveMixed", pred.Key(), pred.TargetValue()), err.Error())
+			}
+			if !pred.IsTrue(val.Value) {
+				return markPredicateNotMet(merr.WrapErrIoFailedReason("failed to meet predicate", fmt.Sprintf("key=%s, value=%v", pred.Key(), pred.TargetValue())))
+			}
+		}
+
+		for _, key := range removals {
+			key = kv.GetPath(key)
+			if err := txn.Delete([]byte(key)); err != nil {
+				return wrapWriteBuildErr(fmt.Sprintf("Failed to delete %s for MultiSaveAndRemoveMixed", key), err)
+			}
+		}
+
+		// Remove keys with prefix
+		for _, prefix := range prefixRemovals {
+			prefix = kv.GetPath(prefix)
+			if err := func(prefix string) error {
+				// Get the start and end keys for the prefix range
+				startKey := []byte(prefix)
+				endKey := tikv.PrefixNextKey([]byte(prefix))
+
+				// Use Scan to iterate over keys in the prefix range
+				iter, err := txn.Iter(startKey, endKey)
+				if err != nil {
+					return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to create iterater for %s during MultiSaveAndRemoveMixed()", prefix), err.Error())
+				}
+				defer iter.Close()
+
+				// Iterate over keys and delete them
+				for iter.Valid() {
+					key := iter.Key()
+					if err = txn.Delete(key); err != nil {
+						return wrapWriteBuildErr(fmt.Sprintf("Failed to delete %s for MultiSaveAndRemoveMixed", string(key)), err)
+					}
+
+					// Move the iterator to the next key
+					if err = iter.Next(); err != nil {
+						return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to move Iterator after key %s for MultiSaveAndRemoveMixed", string(key)), err.Error())
+					}
+				}
+				return nil
+			}(prefix); err != nil {
+				return err
+			}
+		}
+
+		// Save key-value pairs
+		for key, value := range saves {
+			key = kv.GetPath(key)
+			// Check if value is empty or taking reserved EmptyValue
+			byteValue, err := convertEmptyStringToByte(value)
+			if err != nil {
+				return merr.Wrap(err, fmt.Sprintf("Failed to cast to byte (%s:%s) for MultiSaveAndRemoveMixed()", key, value))
+			}
+			if err = txn.Set([]byte(key), byteValue); err != nil {
+				return wrapWriteBuildErr(fmt.Sprintf("Failed to set (%s:%s) for MultiSaveAndRemoveMixed()", key, value), err)
+			}
+		}
+		return nil
+	}, kv.executeTxn)
+	if loggingErr != nil {
+		return loggingErr
+	}
+	CheckElapseAndWarn(start, "Slow txnTiKV MultiSaveAndRemoveMixed() operation", mlog.Any("saves", saves), mlog.Strings("removals", removals), mlog.Strings("prefixRemovals", prefixRemovals))
+	return nil
+}
+
 // WalkWithPrefix visits each kv with input prefix and apply given fn to it.
 func (kv *txnTiKV) WalkWithPrefix(ctx context.Context, prefix string, paginationSize int, fn func([]byte, []byte) error) error {
 	start := time.Now()

--- a/internal/kv/tikv/txn_tikv.go
+++ b/internal/kv/tikv/txn_tikv.go
@@ -31,7 +31,7 @@ import (
 	"github.com/tikv/client-go/v2/txnkv/transaction"
 	"github.com/tikv/client-go/v2/txnkv/txnsnapshot"
 
-	"github.com/milvus-io/milvus/pkg/v3/kv"
+	kvpkg "github.com/milvus-io/milvus/pkg/v3/kv"
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -149,7 +149,7 @@ var (
 )
 
 // implementation assertion
-var _ kv.MetaKv = (*txnTiKV)(nil)
+var _ kvpkg.MetaKv = (*txnTiKV)(nil)
 
 // txnTiKV implements MetaKv and TxnKV interface. It supports processing multiple kvs within one transaction.
 type txnTiKV struct {
@@ -616,6 +616,9 @@ func (kv *txnTiKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[s
 // in one transaction: the prefix scan and its deletes run inside the same txn
 // snapshot as the exact deletes and saves.
 func (kv *txnTiKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	if err := kvpkg.ValidateNoSaveUnderRemovedPrefix(saves, prefixRemovals); err != nil {
+		return err
+	}
 	start := time.Now()
 	ctx, cancel := context.WithTimeout(ctx, kv.requestTimeout)
 	defer cancel()

--- a/internal/kv/tikv/txn_tikv_test.go
+++ b/internal/kv/tikv/txn_tikv_test.go
@@ -315,6 +315,11 @@ func TestTiKVLoad(te *testing.T) {
 		err := kv.MultiSave(context.TODO(), prepareTests)
 		require.NoError(t, err)
 
+		err = kv.MultiSaveAndRemoveMixed(context.TODO(),
+			map[string]string{"mix/a-1/c3": "new"}, nil, []string{"mix/a-1/"})
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+
 		// failed predicate: the whole mixed txn must be a no-op.
 		err = kv.MultiSaveAndRemoveMixed(context.TODO(),
 			map[string]string{"mix/new": "nv"}, []string{"mix/a-1"}, []string{"mix/a-1/"},

--- a/internal/kv/tikv/txn_tikv_test.go
+++ b/internal/kv/tikv/txn_tikv_test.go
@@ -299,6 +299,51 @@ func TestTiKVLoad(te *testing.T) {
 		}
 	})
 
+	te.Run("kv MultiSaveAndRemoveMixed", func(t *testing.T) {
+		rootPath := "/tikv/test/root/multi_remove_mixed"
+		kv := NewTiKV(txnClient, rootPath)
+		defer kv.Close()
+		defer kv.RemoveWithPrefix(context.TODO(), "")
+
+		prepareTests := map[string]string{
+			"mix/a-1":    "1",
+			"mix/a-1/c1": "11",
+			"mix/a-1/c2": "12",
+			"mix/a-10":   "10", // exact-remove canary: a prefix delete of "mix/a-1" would wipe it
+			"mix/b":      "b",
+		}
+		err := kv.MultiSave(context.TODO(), prepareTests)
+		require.NoError(t, err)
+
+		// failed predicate: the whole mixed txn must be a no-op.
+		err = kv.MultiSaveAndRemoveMixed(context.TODO(),
+			map[string]string{"mix/new": "nv"}, []string{"mix/a-1"}, []string{"mix/a-1/"},
+			predicates.ValueEqual("mix/b", "not-b"))
+		assert.Error(t, err)
+		keys, _, err := kv.LoadWithPrefix(context.TODO(), "mix")
+		assert.NoError(t, err)
+		assert.Equal(t, 5, len(keys))
+
+		// exact removal of "mix/a-1" plus prefix removal of "mix/a-1/" plus a
+		// save, in one txn; "mix/a-10" and "mix/b" must survive.
+		err = kv.MultiSaveAndRemoveMixed(context.TODO(),
+			map[string]string{"mix/new": "nv"}, []string{"mix/a-1"}, []string{"mix/a-1/"},
+			predicates.ValueEqual("mix/b", "b"))
+		assert.NoError(t, err)
+
+		keys, vals, err := kv.LoadWithPrefix(context.TODO(), "mix")
+		assert.NoError(t, err)
+		got := make(map[string]string, len(keys))
+		for i, k := range keys {
+			got[k] = vals[i]
+		}
+		assert.Equal(t, map[string]string{
+			kv.GetPath("mix/a-10"): "10",
+			kv.GetPath("mix/b"):    "b",
+			kv.GetPath("mix/new"):  "nv",
+		}, got)
+	})
+
 	te.Run("kv failed to start txn", func(t *testing.T) {
 		origSleep := writeTxnRetrySleep
 		writeTxnRetrySleep = time.Millisecond

--- a/internal/metastore/kv/datacoord/update.go
+++ b/internal/metastore/kv/datacoord/update.go
@@ -99,6 +99,44 @@ func (kc *Catalog) Update(ctx context.Context, actions ...metastore.UpdateAction
 			default:
 				return unsupportedAction(action)
 			}
+		case metastore.ImportTaskEntry:
+			if action.Type != metastore.ActionAdd {
+				return unsupportedAction(action)
+			}
+			switch {
+			case e.Task != nil:
+				// Same encoding as catalog.SaveImportTask.
+				value, err := proto.Marshal(e.Task)
+				if err != nil {
+					return err
+				}
+				b.Save(buildImportTaskKey(e.Task.GetTaskID()), string(value))
+			case e.PreImportTask != nil:
+				// Same encoding as catalog.SavePreImportTask.
+				value, err := proto.Marshal(e.PreImportTask)
+				if err != nil {
+					return err
+				}
+				b.Save(buildPreImportTaskKey(e.PreImportTask.GetTaskID()), string(value))
+			default:
+				return merr.WrapErrServiceInternalMsg("datacoord catalog: nil import task in UpdateAction")
+			}
+		case metastore.ImportJobEntry:
+			if action.Type != metastore.ActionUpdate {
+				return unsupportedAction(action)
+			}
+			if e.Job == nil {
+				return merr.WrapErrServiceInternalMsg("datacoord catalog: nil import job in UpdateAction")
+			}
+			// Same encoding as catalog.SaveImportJob. CommitSave marks the job
+			// save as the visibility point: the job is the failover anchor for
+			// its tasks, so every ImportTaskEntry save above must land before
+			// it on the ordered fallback path.
+			value, err := proto.Marshal(e.Job)
+			if err != nil {
+				return err
+			}
+			b.CommitSave(buildImportJobKey(e.Job.GetJobID()), string(value))
 		case metastore.AnalyzeTaskEntry:
 			if action.Type != metastore.ActionDelete {
 				return unsupportedAction(action)

--- a/internal/metastore/kv/datacoord/update_test.go
+++ b/internal/metastore/kv/datacoord/update_test.go
@@ -26,10 +26,12 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	memkv "github.com/milvus-io/milvus/internal/kv/mem"
 	"github.com/milvus-io/milvus/internal/kv/mocks"
 	"github.com/milvus-io/milvus/internal/metastore"
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
@@ -454,4 +456,253 @@ func TestCatalog_Update_AddPartitionStatsAndVersionEncodingMatchesLegacy(t *test
 
 	assert.Equal(t, legacySaves, compositeSaves)
 	assert.Equal(t, "100", compositeSaves[buildCurrentPartitionStatsVersionPath(1, 2, "ch-1")])
+}
+
+// ---------------------------------------------------------------------------
+// Import job + task composite tests
+// ---------------------------------------------------------------------------
+
+// memMetaKv adapts the in-memory TxnKV to kv.MetaKv so crash-injection tests
+// can replay a retry against real store state (the mocks.MetaKv harness above
+// records calls but keeps no state). Only the read/write surface the import
+// composite touches is implemented.
+type memMetaKv struct {
+	*memkv.MemoryKV
+}
+
+func (m *memMetaKv) GetPath(key string) string { return key }
+
+func (m *memMetaKv) CompareVersionAndSwap(ctx context.Context, key string, version int64, target string) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
+func (m *memMetaKv) WalkWithPrefix(ctx context.Context, prefix string, paginationSize int, fn func([]byte, []byte) error) error {
+	keys, vals, err := m.LoadWithPrefix(ctx, prefix)
+	if err != nil {
+		return err
+	}
+	for i := range keys {
+		if err := fn([]byte(keys[i]), []byte(vals[i])); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func dumpMetaKV(t *testing.T, k *memkv.MemoryKV) map[string]string {
+	keys, vals, err := k.LoadWithPrefix(context.TODO(), "")
+	assert.NoError(t, err)
+	got := make(map[string]string, len(keys))
+	for i, key := range keys {
+		got[key] = vals[i]
+	}
+	return got
+}
+
+// TestCatalog_Update_AddImportTasksAndSaveJobEncodingMatchesLegacy proves the
+// composite import-create write (AddPreImportTask/AddImportTask x N +
+// SaveImportJob) persists byte-identical kvs to the legacy per-object catalog
+// methods (SavePreImportTask + SaveImportTask + SaveImportJob), in a single
+// txn.
+func TestCatalog_Update_AddImportTasksAndSaveJobEncodingMatchesLegacy(t *testing.T) {
+	preTask := &datapb.PreImportTask{JobID: 7, TaskID: 1001, CollectionID: 3, State: datapb.ImportTaskStateV2_Pending}
+	task := &datapb.ImportTaskV2{JobID: 7, TaskID: 1002, CollectionID: 3, State: datapb.ImportTaskStateV2_Pending}
+	job := &datapb.ImportJob{JobID: 7, CollectionID: 3, State: internalpb.ImportJobState_PreImporting}
+
+	// Legacy: three independent Saves.
+	legacySaves := make(map[string]string)
+	metakv := mocks.NewMetaKv(t)
+	metakv.EXPECT().MaxTxnOps().Return(128).Maybe()
+	metakv.EXPECT().Save(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, k string, v string) error {
+		legacySaves[k] = v
+		return nil
+	}).Times(3)
+	c := NewCatalog(metakv, "", "")
+	assert.NoError(t, c.SavePreImportTask(context.TODO(), preTask))
+	assert.NoError(t, c.SaveImportTask(context.TODO(), task))
+	assert.NoError(t, c.SaveImportJob(context.TODO(), job))
+
+	// Composite: one MultiSaveAndRemove.
+	var compositeSaves map[string]string
+	metakv2 := mocks.NewMetaKv(t)
+	metakv2.EXPECT().MaxTxnOps().Return(128).Maybe()
+	metakv2.EXPECT().MultiSaveAndRemove(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, saves map[string]string, removals []string, _ ...predicates.Predicate) error {
+			compositeSaves = saves
+			assert.Empty(t, removals)
+			return nil
+		}).Once()
+	c2 := NewCatalog(metakv2, "", "")
+	assert.NoError(t, c2.Update(context.TODO(),
+		metastore.AddPreImportTask(preTask),
+		metastore.AddImportTask(task),
+		metastore.SaveImportJob(job)))
+
+	assert.Equal(t, legacySaves, compositeSaves)
+	assert.Len(t, compositeSaves, 3)
+}
+
+// TestCatalog_Update_ImportEntries_RejectsUnsupportedTypeAndNil proves an
+// ImportTaskEntry/ImportJobEntry paired with an action type it does not
+// implement, or carrying a nil payload, is rejected with no KV call. An
+// ImportTaskEntry supports ActionAdd only; an ImportJobEntry supports
+// ActionUpdate (upsert) only.
+func TestCatalog_Update_ImportEntries_RejectsUnsupportedTypeAndNil(t *testing.T) {
+	metakv := mocks.NewMetaKv(t)
+	metakv.EXPECT().MaxTxnOps().Return(128).Maybe()
+	c := NewCatalog(metakv, "", "")
+
+	err := c.Update(context.TODO(), metastore.UpdateAction{Type: metastore.ActionUpdate, Entry: metastore.ImportTaskEntry{Task: &datapb.ImportTaskV2{TaskID: 1}}})
+	assert.True(t, errors.Is(err, merr.ErrServiceInternal))
+
+	err = c.Update(context.TODO(), metastore.UpdateAction{Type: metastore.ActionAdd, Entry: metastore.ImportJobEntry{Job: &datapb.ImportJob{JobID: 1}}})
+	assert.True(t, errors.Is(err, merr.ErrServiceInternal))
+
+	err = c.Update(context.TODO(), metastore.UpdateAction{Type: metastore.ActionAdd, Entry: metastore.ImportTaskEntry{}})
+	assert.True(t, errors.Is(err, merr.ErrServiceInternal))
+
+	err = c.Update(context.TODO(), metastore.UpdateAction{Type: metastore.ActionUpdate, Entry: metastore.ImportJobEntry{}})
+	assert.True(t, errors.Is(err, merr.ErrServiceInternal))
+}
+
+// importAtomicCrashKV fails the first MultiSaveAndRemove to simulate a crash
+// of the atomic commit.
+type importAtomicCrashKV struct {
+	*memMetaKv
+	failures int
+}
+
+func (f *importAtomicCrashKV) MultiSaveAndRemove(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	if f.failures > 0 {
+		f.failures--
+		return errors.New("injected crash")
+	}
+	return f.memMetaKv.MultiSaveAndRemove(ctx, saves, removals, preds...)
+}
+
+// TestCatalog_Update_ImportJobAndTasks_AtomicCrashRetry: on the atomic path a
+// failed commit must leave neither task records nor a job-state flip behind
+// (the two key classes live and die together - no task orphans under a job
+// that never left Pending, no PreImporting job without its tasks), and
+// retrying the same composite write must converge to the legacy end state.
+func TestCatalog_Update_ImportJobAndTasks_AtomicCrashRetry(t *testing.T) {
+	ctx := context.TODO()
+	pending := &datapb.ImportJob{JobID: 7, CollectionID: 3, State: internalpb.ImportJobState_Pending}
+	preImporting := &datapb.ImportJob{JobID: 7, CollectionID: 3, State: internalpb.ImportJobState_PreImporting}
+	tasks := []*datapb.PreImportTask{
+		{JobID: 7, TaskID: 1001, CollectionID: 3, State: datapb.ImportTaskStateV2_Pending},
+		{JobID: 7, TaskID: 1002, CollectionID: 3, State: datapb.ImportTaskStateV2_Pending},
+	}
+
+	// Legacy end state: job created, then its tasks and the job transition.
+	legacyKV := &memMetaKv{MemoryKV: memkv.NewMemoryKV()}
+	legacy := NewCatalog(legacyKV, "", "")
+	assert.NoError(t, legacy.SaveImportJob(ctx, pending))
+	for _, task := range tasks {
+		assert.NoError(t, legacy.SavePreImportTask(ctx, task))
+	}
+	assert.NoError(t, legacy.SaveImportJob(ctx, preImporting))
+
+	fk := &importAtomicCrashKV{memMetaKv: &memMetaKv{MemoryKV: memkv.NewMemoryKV()}, failures: 1}
+	c := NewCatalog(fk, "", "")
+	assert.NoError(t, c.SaveImportJob(ctx, pending))
+	before := dumpMetaKV(t, fk.MemoryKV)
+
+	save := func() error {
+		return c.Update(ctx,
+			metastore.AddPreImportTask(tasks[0]),
+			metastore.AddPreImportTask(tasks[1]),
+			metastore.SaveImportJob(preImporting))
+	}
+	assert.Error(t, save())
+	// atomic: the failed commit applied nothing - no orphan task records, and
+	// the job record still carries its pre-transition value.
+	assert.Equal(t, before, dumpMetaKV(t, fk.MemoryKV))
+
+	assert.NoError(t, save())
+	assert.Equal(t, dumpMetaKV(t, legacyKV.MemoryKV), dumpMetaKV(t, fk.MemoryKV))
+}
+
+// importFallbackCommitCrashKV shrinks MaxTxnOps so the composite import write
+// takes the chunked fallback, records which keys each MultiSave chunk
+// carried, and fails the final guarded commit txn - simulating a crash after
+// the task flush but before the job marker lands.
+type importFallbackCommitCrashKV struct {
+	*memMetaKv
+	multiSaveKeys  [][]string
+	commitFailures int
+}
+
+func (f *importFallbackCommitCrashKV) MaxTxnOps() int { return 2 }
+
+func (f *importFallbackCommitCrashKV) MultiSave(ctx context.Context, kvs map[string]string) error {
+	keys := make([]string, 0, len(kvs))
+	for k := range kvs {
+		keys = append(keys, k)
+	}
+	f.multiSaveKeys = append(f.multiSaveKeys, keys)
+	return f.memMetaKv.MultiSave(ctx, kvs)
+}
+
+func (f *importFallbackCommitCrashKV) MultiSaveAndRemove(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	if f.commitFailures > 0 {
+		f.commitFailures--
+		return errors.New("injected crash")
+	}
+	return f.memMetaKv.MultiSaveAndRemove(ctx, saves, removals, preds...)
+}
+
+// TestCatalog_Update_ImportJobMarkerLandsLast_FallbackCrashRetry: on the
+// chunked fallback path the job record is the sole visibility marker of the
+// batch. A crash between the task flush and the final commit txn must leave
+// the job record un-flipped (still Pending) - the flushed task records sit
+// inert under a job that never observed them - and retrying the same
+// composite write must converge to the legacy end state.
+func TestCatalog_Update_ImportJobMarkerLandsLast_FallbackCrashRetry(t *testing.T) {
+	ctx := context.TODO()
+	pending := &datapb.ImportJob{JobID: 7, CollectionID: 3, State: internalpb.ImportJobState_Pending}
+	preImporting := &datapb.ImportJob{JobID: 7, CollectionID: 3, State: internalpb.ImportJobState_PreImporting}
+	tasks := []*datapb.PreImportTask{
+		{JobID: 7, TaskID: 1001, CollectionID: 3, State: datapb.ImportTaskStateV2_Pending},
+		{JobID: 7, TaskID: 1002, CollectionID: 3, State: datapb.ImportTaskStateV2_Pending},
+		{JobID: 7, TaskID: 1003, CollectionID: 3, State: datapb.ImportTaskStateV2_Pending},
+	}
+
+	legacyKV := &memMetaKv{MemoryKV: memkv.NewMemoryKV()}
+	legacy := NewCatalog(legacyKV, "", "")
+	assert.NoError(t, legacy.SaveImportJob(ctx, pending))
+	for _, task := range tasks {
+		assert.NoError(t, legacy.SavePreImportTask(ctx, task))
+	}
+	assert.NoError(t, legacy.SaveImportJob(ctx, preImporting))
+
+	fk := &importFallbackCommitCrashKV{memMetaKv: &memMetaKv{MemoryKV: memkv.NewMemoryKV()}, commitFailures: 1}
+	c := NewCatalog(fk, "", "")
+	assert.NoError(t, c.SaveImportJob(ctx, pending))
+	pendingValue, err := fk.Load(ctx, buildImportJobKey(7))
+	assert.NoError(t, err)
+
+	save := func() error {
+		return c.Update(ctx,
+			metastore.AddPreImportTask(tasks[0]),
+			metastore.AddPreImportTask(tasks[1]),
+			metastore.AddPreImportTask(tasks[2]),
+			metastore.SaveImportJob(preImporting))
+	}
+	// 4 ops against a 2-op txn limit: the task saves flush in chunks, the job
+	// save must ride the final guarded commit txn - which is failed here.
+	assert.Error(t, save())
+
+	// The job marker never rode in a task chunk...
+	assert.NotEmpty(t, fk.multiSaveKeys)
+	for _, keys := range fk.multiSaveKeys {
+		assert.NotContains(t, keys, buildImportJobKey(7))
+	}
+	// ...so the crash left the job record un-flipped.
+	got, err := fk.Load(ctx, buildImportJobKey(7))
+	assert.NoError(t, err)
+	assert.Equal(t, pendingValue, got)
+
+	assert.NoError(t, save())
+	assert.Equal(t, dumpMetaKV(t, legacyKV.MemoryKV), dumpMetaKV(t, fk.MemoryKV))
 }

--- a/internal/metastore/kv/querycoord/kv_catalog.go
+++ b/internal/metastore/kv/querycoord/kv_catalog.go
@@ -242,14 +242,11 @@ func (s Catalog) GetResourceGroups(ctx context.Context) ([]*querypb.ResourceGrou
 }
 
 func (s Catalog) ReleaseCollection(ctx context.Context, collection int64) error {
-	// remove collection and obtained partitions
+	// remove collection and obtained partitions in one txn, so a crash cannot
+	// leave partitions behind without their collection load info
 	collectionKey := EncodeCollectionLoadInfoKey(collection)
-	err := s.cli.Remove(ctx, collectionKey)
-	if err != nil {
-		return err
-	}
 	partitionsPrefix := fmt.Sprintf("%s/%d/", PartitionLoadInfoPrefix, collection)
-	return s.cli.RemoveWithPrefix(ctx, partitionsPrefix)
+	return s.cli.MultiSaveAndRemoveMixed(ctx, nil, []string{collectionKey}, []string{partitionsPrefix})
 }
 
 func (s Catalog) ReleasePartition(ctx context.Context, collection int64, partitions ...int64) error {

--- a/internal/metastore/kv/querycoord/kv_catalog.go
+++ b/internal/metastore/kv/querycoord/kv_catalog.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus/internal/metastore"
 	"github.com/milvus-io/milvus/pkg/v3/kv"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
@@ -51,16 +52,16 @@ func NewCatalog(cli kv.MetaKv) Catalog {
 }
 
 func (s Catalog) SaveCollection(ctx context.Context, collection *querypb.CollectionLoadInfo, partitions ...*querypb.PartitionLoadInfo) error {
-	k := EncodeCollectionLoadInfoKey(collection.GetCollectionID())
-	v, err := proto.Marshal(collection)
-	if err != nil {
-		return err
+	// one composite commit instead of the legacy collection-then-partitions
+	// two-step, so a crash cannot publish a loaded collection with missing
+	// partitions; the collection record - recovery's visibility marker - is
+	// composed last (see SaveCollectionLoadInfo)
+	actions := make([]metastore.UpdateAction, 0, len(partitions)+1)
+	for _, partition := range partitions {
+		actions = append(actions, metastore.SavePartitionLoadInfo(partition))
 	}
-	err = s.cli.Save(ctx, k, string(v))
-	if err != nil {
-		return err
-	}
-	return s.SavePartition(ctx, partitions...)
+	actions = append(actions, metastore.SaveCollectionLoadInfo(collection))
+	return s.Update(ctx, actions...)
 }
 
 func (s Catalog) SavePartition(ctx context.Context, info ...*querypb.PartitionLoadInfo) error {

--- a/internal/metastore/kv/querycoord/kv_catalog_test.go
+++ b/internal/metastore/kv/querycoord/kv_catalog_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/milvus-io/milvus/internal/kv/mocks"
 	. "github.com/milvus-io/milvus/internal/querycoordv2/params"
 	"github.com/milvus-io/milvus/pkg/v3/kv"
+	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
@@ -337,6 +338,118 @@ func (suite *CatalogTestSuite) TestRemoveCollectionTargets() {
 
 func (suite *CatalogTestSuite) TestLoadRelease() {
 	// TODO(sunby): add ut
+}
+
+// releaseFailKV wraps a real MetaKv and fails selected removal ops to
+// simulate a crash between the two legacy release steps.
+type releaseFailKV struct {
+	kv.MetaKv
+	removeWithPrefixErr error
+	mixedErr            error
+}
+
+func (f *releaseFailKV) RemoveWithPrefix(ctx context.Context, key string) error {
+	if f.removeWithPrefixErr != nil {
+		return f.removeWithPrefixErr
+	}
+	return f.MetaKv.RemoveWithPrefix(ctx, key)
+}
+
+func (f *releaseFailKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	if f.mixedErr != nil {
+		return f.mixedErr
+	}
+	return f.MetaKv.MultiSaveAndRemoveMixed(ctx, saves, removals, prefixRemovals, preds...)
+}
+
+func (suite *CatalogTestSuite) saveCollectionWithPartitions(ctx context.Context, collection int64, partitions ...int64) {
+	err := suite.catalog.SaveCollection(ctx, &querypb.CollectionLoadInfo{
+		CollectionID: collection,
+	}, lo.Map(partitions, func(partition int64, _ int) *querypb.PartitionLoadInfo {
+		return &querypb.PartitionLoadInfo{
+			CollectionID: collection,
+			PartitionID:  partition,
+		}
+	})...)
+	suite.Require().NoError(err)
+}
+
+func (suite *CatalogTestSuite) TestReleaseCollectionRemovesAllKeys() {
+	ctx := context.Background()
+	suite.saveCollectionWithPartitions(ctx, 1, 100, 101)
+	suite.saveCollectionWithPartitions(ctx, 10, 110)
+
+	otherCollectionValue, err := suite.kv.Load(ctx, EncodeCollectionLoadInfoKey(10))
+	suite.NoError(err)
+	otherPartitionValue, err := suite.kv.Load(ctx, EncodePartitionLoadInfoKey(10, 110))
+	suite.NoError(err)
+
+	suite.NoError(suite.catalog.ReleaseCollection(ctx, 1))
+
+	_, err = suite.kv.Load(ctx, EncodeCollectionLoadInfoKey(1))
+	suite.Error(err)
+	keys, _, err := suite.kv.LoadWithPrefix(ctx, EncodePartitionLoadInfoPrefix(1))
+	suite.NoError(err)
+	suite.Empty(keys)
+
+	// collection 10 shares the "1" digit prefix and must be untouched, byte for byte
+	value, err := suite.kv.Load(ctx, EncodeCollectionLoadInfoKey(10))
+	suite.NoError(err)
+	suite.Equal(otherCollectionValue, value)
+	value, err = suite.kv.Load(ctx, EncodePartitionLoadInfoKey(10, 110))
+	suite.NoError(err)
+	suite.Equal(otherPartitionValue, value)
+}
+
+func (suite *CatalogTestSuite) TestReleaseCollectionAtomicUnderFailure() {
+	ctx := context.Background()
+	injected := errors.New("injected failure")
+
+	assertIntact := func(collection int64, partitions ...int64) {
+		_, err := suite.kv.Load(ctx, EncodeCollectionLoadInfoKey(collection))
+		suite.NoError(err)
+		keys, _, err := suite.kv.LoadWithPrefix(ctx, EncodePartitionLoadInfoPrefix(collection))
+		suite.NoError(err)
+		suite.Len(keys, len(partitions))
+	}
+
+	// prefix removal fails while exact removal would succeed: the release must
+	// not leave partitions behind without the collection load info
+	suite.saveCollectionWithPartitions(ctx, 1, 100, 101)
+	suite.catalog.cli = &releaseFailKV{MetaKv: suite.kv, removeWithPrefixErr: injected}
+	err := suite.catalog.ReleaseCollection(ctx, 1)
+	if err != nil {
+		assertIntact(1, 100, 101)
+	} else {
+		_, err = suite.kv.Load(ctx, EncodeCollectionLoadInfoKey(1))
+		suite.Error(err)
+		keys, _, err := suite.kv.LoadWithPrefix(ctx, EncodePartitionLoadInfoPrefix(1))
+		suite.NoError(err)
+		suite.Empty(keys)
+	}
+
+	// whole transaction fails: nothing may be removed
+	suite.catalog.cli = suite.kv
+	suite.saveCollectionWithPartitions(ctx, 2, 200, 201)
+	suite.catalog.cli = &releaseFailKV{MetaKv: suite.kv, removeWithPrefixErr: injected, mixedErr: injected}
+	err = suite.catalog.ReleaseCollection(ctx, 2)
+	suite.ErrorIs(err, injected)
+	assertIntact(2, 200, 201)
+}
+
+func (suite *CatalogTestSuite) TestReleaseCollectionSingleTxn() {
+	ctx := context.Background()
+	mockStore := mocks.NewMetaKv(suite.T())
+	mockStore.EXPECT().MultiSaveAndRemoveMixed(mock.Anything, mock.Anything,
+		[]string{"querycoord-collection-loadinfo/1"},
+		[]string{"querycoord-partition-loadinfo/1/"}).Return(nil).Once()
+
+	suite.catalog.cli = mockStore
+	suite.NoError(suite.catalog.ReleaseCollection(ctx, 1))
+
+	mockErr := errors.New("failed to access etcd")
+	mockStore.EXPECT().MultiSaveAndRemoveMixed(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(mockErr).Once()
+	suite.ErrorIs(suite.catalog.ReleaseCollection(ctx, 1), mockErr)
 }
 
 func TestCatalogSuite(t *testing.T) {

--- a/internal/metastore/kv/querycoord/update.go
+++ b/internal/metastore/kv/querycoord/update.go
@@ -34,13 +34,43 @@ import (
 //
 // A ReplicaEntry+ActionUpdate is a replica upsert, encoded exactly like
 // SaveReplica. A ReplicaKeyEntry+ActionDelete removes a replica's kv record,
-// encoded exactly like ReleaseReplica. Entries this catalog does not own, or
-// Type/Entry combinations it does not implement, are a caller programming
-// error and are rejected with a ServiceInternal error and no write.
+// encoded exactly like ReleaseReplica. A CollectionLoadEntry/
+// PartitionLoadEntry+ActionUpdate is a load-info upsert, encoded exactly like
+// the legacy SaveCollection/SavePartition; the collection record is staged as
+// a commit op because it is recovery's visibility marker (GetPartitions reads
+// partitions only for collections whose record exists), so on the chunked
+// fallback path it lands last, after every partition record. Entries this
+// catalog does not own, or Type/Entry combinations it does not implement, are
+// a caller programming error and are rejected with a ServiceInternal error
+// and no write.
 func (s Catalog) Update(ctx context.Context, actions ...metastore.UpdateAction) error {
 	b := txn.New()
 	for _, action := range actions {
 		switch e := action.Entry.(type) {
+		case metastore.CollectionLoadEntry:
+			if action.Type != metastore.ActionUpdate {
+				return unsupportedAction(action)
+			}
+			if e.Collection == nil {
+				return merr.WrapErrServiceInternalMsg("querycoord catalog: nil collection load info in UpdateAction")
+			}
+			value, err := proto.Marshal(e.Collection)
+			if err != nil {
+				return err
+			}
+			b.CommitSave(EncodeCollectionLoadInfoKey(e.Collection.GetCollectionID()), string(value))
+		case metastore.PartitionLoadEntry:
+			if action.Type != metastore.ActionUpdate {
+				return unsupportedAction(action)
+			}
+			if e.Partition == nil {
+				return merr.WrapErrServiceInternalMsg("querycoord catalog: nil partition load info in UpdateAction")
+			}
+			value, err := proto.Marshal(e.Partition)
+			if err != nil {
+				return err
+			}
+			b.Save(EncodePartitionLoadInfoKey(e.Partition.GetCollectionID(), e.Partition.GetPartitionID()), string(value))
 		case metastore.ReplicaEntry:
 			if action.Type != metastore.ActionUpdate {
 				return unsupportedAction(action)

--- a/internal/metastore/kv/querycoord/update_test.go
+++ b/internal/metastore/kv/querycoord/update_test.go
@@ -25,8 +25,10 @@ import (
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/protobuf/proto"
 
+	memkv "github.com/milvus-io/milvus/internal/kv/mem"
 	"github.com/milvus-io/milvus/internal/kv/mocks"
 	"github.com/milvus-io/milvus/internal/metastore"
+	"github.com/milvus-io/milvus/pkg/v3/kv"
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
@@ -172,5 +174,286 @@ func TestCatalog_Update_RejectsNilReplica(t *testing.T) {
 	c := NewCatalog(metakv)
 
 	err := c.Update(context.TODO(), metastore.UpdateAction{Type: metastore.ActionUpdate, Entry: metastore.ReplicaEntry{}})
+	assert.True(t, errors.Is(err, merr.ErrServiceInternal))
+}
+
+// metaMemKV adapts the in-memory TxnKV to the kv.MetaKv interface NewCatalog
+// requires, for tests that need a real (stateful) store.
+type metaMemKV struct {
+	*memkv.MemoryKV
+}
+
+func (m *metaMemKV) GetPath(key string) string { return key }
+
+func (m *metaMemKV) CompareVersionAndSwap(ctx context.Context, key string, version int64, target string) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
+func (m *metaMemKV) WalkWithPrefix(ctx context.Context, prefix string, paginationSize int, fn func([]byte, []byte) error) error {
+	keys, vals, err := m.LoadWithPrefix(ctx, prefix)
+	if err != nil {
+		return err
+	}
+	for i := range keys {
+		if err := fn([]byte(keys[i]), []byte(vals[i])); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func dumpKV(t *testing.T, k interface {
+	LoadWithPrefix(ctx context.Context, key string) ([]string, []string, error)
+},
+) map[string]string {
+	keys, vals, err := k.LoadWithPrefix(context.TODO(), "")
+	assert.NoError(t, err)
+	got := make(map[string]string, len(keys))
+	for i, key := range keys {
+		got[key] = vals[i]
+	}
+	return got
+}
+
+// legacySaveCollection replays today's two-step SaveCollection persistence
+// (collection record via Save, partitions via SavePartition) so tests can
+// compare the composite path's end state byte-for-byte against it.
+func legacySaveCollection(t *testing.T, store kv.MetaKv, coll *querypb.CollectionLoadInfo, parts ...*querypb.PartitionLoadInfo) {
+	v, err := proto.Marshal(coll)
+	assert.NoError(t, err)
+	assert.NoError(t, store.Save(context.TODO(), EncodeCollectionLoadInfoKey(coll.GetCollectionID()), string(v)))
+	assert.NoError(t, NewCatalog(store).SavePartition(context.TODO(), parts...))
+}
+
+// loadInfoFixture returns a collection load info and two partition load infos.
+// The FieldIndexID map carries a single entry so proto.Marshal stays
+// deterministic and byte-for-byte comparisons cannot flake on map order.
+func loadInfoFixture() (*querypb.CollectionLoadInfo, []*querypb.PartitionLoadInfo) {
+	coll := &querypb.CollectionLoadInfo{
+		CollectionID:  1,
+		ReplicaNumber: 2,
+		Status:        querypb.LoadStatus_Loaded,
+		LoadType:      querypb.LoadType_LoadCollection,
+		FieldIndexID:  map[int64]int64{100: 1000},
+	}
+	parts := []*querypb.PartitionLoadInfo{
+		{CollectionID: 1, PartitionID: 11, ReplicaNumber: 2, Status: querypb.LoadStatus_Loaded},
+		{CollectionID: 1, PartitionID: 12, ReplicaNumber: 2, Status: querypb.LoadStatus_Loaded},
+	}
+	return coll, parts
+}
+
+// saveRecordingKV records every write-path call so a test can assert the
+// composite save issues exactly one transaction.
+type saveRecordingKV struct {
+	kv.MetaKv
+	calls []string
+}
+
+func (r *saveRecordingKV) Save(ctx context.Context, key, value string) error {
+	r.calls = append(r.calls, "Save")
+	return r.MetaKv.Save(ctx, key, value)
+}
+
+func (r *saveRecordingKV) MultiSave(ctx context.Context, kvs map[string]string) error {
+	r.calls = append(r.calls, "MultiSave")
+	return r.MetaKv.MultiSave(ctx, kvs)
+}
+
+func (r *saveRecordingKV) MultiSaveAndRemove(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	r.calls = append(r.calls, "MultiSaveAndRemove")
+	return r.MetaKv.MultiSaveAndRemove(ctx, saves, removals, preds...)
+}
+
+func (r *saveRecordingKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	r.calls = append(r.calls, "MultiSaveAndRemoveWithPrefix")
+	return r.MetaKv.MultiSaveAndRemoveWithPrefix(ctx, saves, removals, preds...)
+}
+
+func (r *saveRecordingKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	r.calls = append(r.calls, "MultiSaveAndRemoveMixed")
+	return r.MetaKv.MultiSaveAndRemoveMixed(ctx, saves, removals, prefixRemovals, preds...)
+}
+
+// TestCatalog_SaveCollection_SingleTxnMatchesLegacyBytes proves SaveCollection
+// lands collection and partition load infos in ONE transaction, and that the
+// end state is byte-for-byte the same as today's two-step path (collection
+// record via Save, partitions via MultiSave).
+func TestCatalog_SaveCollection_SingleTxnMatchesLegacyBytes(t *testing.T) {
+	ctx := context.TODO()
+	coll, parts := loadInfoFixture()
+
+	legacyKV := &metaMemKV{MemoryKV: memkv.NewMemoryKV()}
+	legacySaveCollection(t, legacyKV, coll, parts...)
+
+	rec := &saveRecordingKV{MetaKv: &metaMemKV{MemoryKV: memkv.NewMemoryKV()}}
+	c := NewCatalog(rec)
+	assert.NoError(t, c.SaveCollection(ctx, coll, parts...))
+
+	assert.Equal(t, []string{"MultiSaveAndRemove"}, rec.calls)
+	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, rec.MetaKv.(*metaMemKV)))
+}
+
+// TestCatalog_Update_SaveCollectionLoadMatchesLegacyBytes proves the
+// action-level composite (partition saves composed before the collection
+// save) writes byte-for-byte the same store state as the legacy two-step
+// path.
+func TestCatalog_Update_SaveCollectionLoadMatchesLegacyBytes(t *testing.T) {
+	ctx := context.TODO()
+	coll, parts := loadInfoFixture()
+
+	legacyKV := &metaMemKV{MemoryKV: memkv.NewMemoryKV()}
+	legacySaveCollection(t, legacyKV, coll, parts...)
+
+	compositeKV := &metaMemKV{MemoryKV: memkv.NewMemoryKV()}
+	c := NewCatalog(compositeKV)
+	assert.NoError(t, c.Update(ctx,
+		metastore.SavePartitionLoadInfo(parts[0]),
+		metastore.SavePartitionLoadInfo(parts[1]),
+		metastore.SaveCollectionLoadInfo(coll)))
+
+	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, compositeKV))
+}
+
+// flakyWriteKV fails partition-carrying writes (MultiSave on the legacy path,
+// MultiSaveAndRemove on the atomic composite path) while failures remain,
+// simulating a crash mid-save.
+type flakyWriteKV struct {
+	kv.MetaKv
+	failures int
+}
+
+func (f *flakyWriteKV) MultiSave(ctx context.Context, kvs map[string]string) error {
+	if f.failures > 0 {
+		f.failures--
+		return errors.New("injected crash")
+	}
+	return f.MetaKv.MultiSave(ctx, kvs)
+}
+
+func (f *flakyWriteKV) MultiSaveAndRemove(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	if f.failures > 0 {
+		f.failures--
+		return errors.New("injected crash")
+	}
+	return f.MetaKv.MultiSaveAndRemove(ctx, saves, removals, preds...)
+}
+
+// TestCatalog_SaveCollection_AtomicCrashRetry: a crash while persisting the
+// partition load infos must never leave a loaded collection visible with its
+// partitions missing - collection and partition keys either all exist or none
+// do. A retry of the same save must converge to the legacy end state.
+func TestCatalog_SaveCollection_AtomicCrashRetry(t *testing.T) {
+	ctx := context.TODO()
+	coll, parts := loadInfoFixture()
+
+	legacyKV := &metaMemKV{MemoryKV: memkv.NewMemoryKV()}
+	legacySaveCollection(t, legacyKV, coll, parts...)
+
+	fk := &flakyWriteKV{MetaKv: &metaMemKV{MemoryKV: memkv.NewMemoryKV()}, failures: 1}
+	c := NewCatalog(fk)
+	assert.Error(t, c.SaveCollection(ctx, coll, parts...))
+
+	// all-or-nothing: a collection record without its partitions is the
+	// crash window this change closes.
+	store := fk.MetaKv.(*metaMemKV)
+	hasColl, err := store.Has(ctx, EncodeCollectionLoadInfoKey(coll.GetCollectionID()))
+	assert.NoError(t, err)
+	partKeys, _, err := store.LoadWithPrefix(ctx, EncodePartitionLoadInfoPrefix(coll.GetCollectionID()))
+	assert.NoError(t, err)
+	if hasColl {
+		assert.Len(t, partKeys, len(parts), "collection load info visible with missing partitions")
+	} else {
+		assert.Empty(t, partKeys)
+	}
+
+	assert.NoError(t, c.SaveCollection(ctx, coll, parts...))
+	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, store))
+}
+
+// chunkCrashKV shrinks MaxTxnOps so a composite save takes the chunked
+// fallback, and fails the n-th MultiSave chunk to simulate a crash between
+// partition batches.
+type chunkCrashKV struct {
+	kv.MetaKv
+	multiSaveCalls int
+	failAtCall     int
+}
+
+func (f *chunkCrashKV) MaxTxnOps() int { return 2 }
+
+func (f *chunkCrashKV) MultiSave(ctx context.Context, kvs map[string]string) error {
+	f.multiSaveCalls++
+	if f.multiSaveCalls == f.failAtCall {
+		return errors.New("injected crash")
+	}
+	return f.MetaKv.MultiSave(ctx, kvs)
+}
+
+// TestCatalog_SaveCollection_FallbackCrashKeepsCollectionInvisible: when the
+// partition set exceeds the store's txn limit the save must flush partitions
+// first and land the collection record - recovery's visibility marker - last,
+// so a crash between partition chunks leaves the load invisible (recovery
+// reads partitions only for collections whose record exists) instead of
+// publishing a loaded collection with missing partitions. The retry must
+// converge to the legacy end state.
+func TestCatalog_SaveCollection_FallbackCrashKeepsCollectionInvisible(t *testing.T) {
+	ctx := context.TODO()
+	coll := &querypb.CollectionLoadInfo{
+		CollectionID:  1,
+		ReplicaNumber: 1,
+		Status:        querypb.LoadStatus_Loaded,
+		LoadType:      querypb.LoadType_LoadCollection,
+	}
+	parts := make([]*querypb.PartitionLoadInfo, 0, 5)
+	for i := int64(0); i < 5; i++ {
+		parts = append(parts, &querypb.PartitionLoadInfo{
+			CollectionID: 1,
+			PartitionID:  11 + i,
+			Status:       querypb.LoadStatus_Loaded,
+		})
+	}
+
+	legacyKV := &metaMemKV{MemoryKV: memkv.NewMemoryKV()}
+	legacySaveCollection(t, legacyKV, coll, parts...)
+
+	fk := &chunkCrashKV{MetaKv: &metaMemKV{MemoryKV: memkv.NewMemoryKV()}, failAtCall: 2}
+	c := NewCatalog(fk)
+	assert.Error(t, c.SaveCollection(ctx, coll, parts...))
+
+	// crash-safety: the collection record (commit marker) must not be visible.
+	store := fk.MetaKv.(*metaMemKV)
+	hasColl, err := store.Has(ctx, EncodeCollectionLoadInfoKey(coll.GetCollectionID()))
+	assert.NoError(t, err)
+	assert.False(t, hasColl, "collection load info landed before its partitions")
+
+	assert.NoError(t, c.SaveCollection(ctx, coll, parts...))
+	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, store))
+}
+
+// TestCatalog_Update_RejectsBadLoadInfoActions proves load-info entries paired
+// with an action type the catalog does not implement, or carrying nil
+// payloads, are rejected with a merr ServiceInternal error and no KV call.
+func TestCatalog_Update_RejectsBadLoadInfoActions(t *testing.T) {
+	metakv := mocks.NewMetaKv(t)
+	metakv.EXPECT().MaxTxnOps().Return(128).Maybe()
+	c := NewCatalog(metakv)
+
+	err := c.Update(context.TODO(), metastore.UpdateAction{
+		Type:  metastore.ActionDelete,
+		Entry: metastore.CollectionLoadEntry{Collection: &querypb.CollectionLoadInfo{CollectionID: 1}},
+	})
+	assert.True(t, errors.Is(err, merr.ErrServiceInternal))
+
+	err = c.Update(context.TODO(), metastore.UpdateAction{
+		Type:  metastore.ActionDelete,
+		Entry: metastore.PartitionLoadEntry{Partition: &querypb.PartitionLoadInfo{CollectionID: 1, PartitionID: 11}},
+	})
+	assert.True(t, errors.Is(err, merr.ErrServiceInternal))
+
+	err = c.Update(context.TODO(), metastore.UpdateAction{Type: metastore.ActionUpdate, Entry: metastore.CollectionLoadEntry{}})
+	assert.True(t, errors.Is(err, merr.ErrServiceInternal))
+
+	err = c.Update(context.TODO(), metastore.UpdateAction{Type: metastore.ActionUpdate, Entry: metastore.PartitionLoadEntry{}})
 	assert.True(t, errors.Is(err, merr.ErrServiceInternal))
 }

--- a/internal/metastore/kv/rootcoord/kv_catalog.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog.go
@@ -743,12 +743,15 @@ func buildDropCollectionKeys(collectionInfo *model.Collection) (string, []string
 	return collectionKey, delMetakeysSnap
 }
 
-func (kc *Catalog) alterModifyCollection(ctx context.Context, oldColl *model.Collection, newColl *model.Collection, ts typeutil.Timestamp, fieldModify bool) error {
+// alterModifyCollectionKvs computes the kv set an in-place collection
+// modification persists; it is shared by the legacy alterModifyCollection
+// path and the composite Update rename path so both stay byte-identical.
+func alterModifyCollectionKvs(oldColl *model.Collection, newColl *model.Collection, fieldModify bool) (map[string]string, []string, error) {
 	if oldColl.TenantID != newColl.TenantID || oldColl.CollectionID != newColl.CollectionID {
-		return merr.WrapErrParameterInvalidMsg("altering tenant id or collection id is forbidden")
+		return nil, nil, merr.WrapErrParameterInvalidMsg("altering tenant id or collection id is forbidden")
 	}
 	if oldColl.DBID != newColl.DBID {
-		return merr.WrapErrParameterInvalidMsg("altering dbID should use `AlterCollectionDB` interface")
+		return nil, nil, merr.WrapErrParameterInvalidMsg("altering dbID should use `AlterCollectionDB` interface")
 	}
 	oldCollClone := oldColl.Clone()
 	oldCollClone.DBID = newColl.DBID
@@ -775,7 +778,7 @@ func (kc *Catalog) alterModifyCollection(ctx context.Context, oldColl *model.Col
 	newKey := BuildCollectionKey(newColl.DBID, oldColl.CollectionID)
 	value, err := proto.Marshal(model.MarshalCollectionModel(oldCollClone))
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 	saves := map[string]string{newKey: string(value)}
 	removals := []string{}
@@ -789,7 +792,7 @@ func (kc *Catalog) alterModifyCollection(ctx context.Context, oldColl *model.Col
 			fieldInfo := model.MarshalFieldModel(field)
 			v, err := proto.Marshal(fieldInfo)
 			if err != nil {
-				return err
+				return nil, nil, err
 			}
 			saves[k] = string(v)
 		}
@@ -806,7 +809,7 @@ func (kc *Catalog) alterModifyCollection(ctx context.Context, oldColl *model.Col
 			structArrayFieldInfo := model.MarshalStructArrayFieldModel(structArrayField)
 			v, err := proto.Marshal(structArrayFieldInfo)
 			if err != nil {
-				return err
+				return nil, nil, err
 			}
 			saves[k] = string(v)
 		}
@@ -823,7 +826,7 @@ func (kc *Catalog) alterModifyCollection(ctx context.Context, oldColl *model.Col
 			functionInfo := model.MarshalFunctionModel(function)
 			v, err := proto.Marshal(functionInfo)
 			if err != nil {
-				return err
+				return nil, nil, err
 			}
 			saves[k] = string(v)
 		}
@@ -832,6 +835,15 @@ func (kc *Catalog) alterModifyCollection(ctx context.Context, oldColl *model.Col
 				removals = append(removals, BuildFunctionKey(oldColl.CollectionID, function.ID))
 			}
 		}
+	}
+
+	return saves, removals, nil
+}
+
+func (kc *Catalog) alterModifyCollection(ctx context.Context, oldColl *model.Collection, newColl *model.Collection, ts typeutil.Timestamp, fieldModify bool) error {
+	saves, removals, err := alterModifyCollectionKvs(oldColl, newColl, fieldModify)
+	if err != nil {
+		return err
 	}
 
 	maxTxnNum := paramtable.Get().MetaStoreCfg.MaxEtcdTxnNum.GetAsInt()
@@ -855,20 +867,29 @@ func (kc *Catalog) AlterCollection(ctx context.Context, oldColl *model.Collectio
 	}
 }
 
-func (kc *Catalog) AlterCollectionDB(ctx context.Context, oldColl *model.Collection, newColl *model.Collection, ts typeutil.Timestamp) error {
+// alterCollectionDBKvs computes the kv set a collection database move
+// persists; it is shared by the legacy AlterCollectionDB path and the
+// composite Update rename path so both stay byte-identical.
+func alterCollectionDBKvs(oldColl *model.Collection, newColl *model.Collection) (map[string]string, []string, error) {
 	if oldColl.TenantID != newColl.TenantID || oldColl.CollectionID != newColl.CollectionID {
-		return merr.WrapErrParameterInvalidMsg("altering tenant id or collection id is forbidden")
+		return nil, nil, merr.WrapErrParameterInvalidMsg("altering tenant id or collection id is forbidden")
 	}
 	oldKey := BuildCollectionKey(oldColl.DBID, oldColl.CollectionID)
 	newKey := BuildCollectionKey(newColl.DBID, newColl.CollectionID)
 
 	value, err := proto.Marshal(model.MarshalCollectionModel(newColl))
 	if err != nil {
+		return nil, nil, err
+	}
+	return map[string]string{newKey: string(value)}, []string{oldKey}, nil
+}
+
+func (kc *Catalog) AlterCollectionDB(ctx context.Context, oldColl *model.Collection, newColl *model.Collection, ts typeutil.Timestamp) error {
+	saves, removals, err := alterCollectionDBKvs(oldColl, newColl)
+	if err != nil {
 		return err
 	}
-	saves := map[string]string{newKey: string(value)}
-
-	return kc.Txn.MultiSaveAndRemove(ctx, saves, []string{oldKey})
+	return kc.Txn.MultiSaveAndRemove(ctx, saves, removals)
 }
 
 func (kc *Catalog) alterModifyPartition(ctx context.Context, oldPart *model.Partition, newPart *model.Partition, ts typeutil.Timestamp) error {
@@ -1863,17 +1884,25 @@ func (kc *Catalog) DeleteGrantByCollectionName(ctx context.Context, tenant strin
 	return nil
 }
 
-func (kc *Catalog) MigrateGrantCollectionName(ctx context.Context, tenant string, oldDBName string, oldName string, newDBName string, newName string) error {
+// migrateGrantCollectionNameKvs reads the current grantee subtree and computes
+// the rewrite set of a collection rename: saves are the new-name grantee and
+// grantee-id keys, granteeRemovals the old grantee-privileges keys and
+// idRemovals the old grantee-id keys. It is shared by the legacy
+// MigrateGrantCollectionName path and the composite Update rename path so both
+// stay byte-identical. The removals are returned split because the old
+// grantee-privileges keys are the only index from which a retry can recompute
+// this rewrite set (their values reference the grantee-id subtrees), so a
+// non-atomic applier must remove them after every other key.
+func (kc *Catalog) migrateGrantCollectionNameKvs(ctx context.Context, tenant string, oldDBName string, oldName string, newDBName string, newName string) (saves map[string]string, granteeRemovals []string, idRemovals []string, err error) {
 	granteeKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
 	keys, values, err := kc.Txn.LoadWithPrefix(ctx, granteeKey)
 	if err != nil {
 		mlog.Warn(ctx, "fail to load grant privilege entities for collection migration",
 			mlog.String("key", granteeKey), mlog.Err(err))
-		return err
+		return nil, nil, nil, err
 	}
 
-	saves := make(map[string]string)
-	var removeKeys []string
+	saves = make(map[string]string)
 	for i, key := range keys {
 		grantInfos := typeutil.AfterN(key, granteeKey, "/")
 		if len(grantInfos) != 3 {
@@ -1893,11 +1922,11 @@ func (kc *Catalog) MigrateGrantCollectionName(ctx context.Context, tenant string
 			if isLegacyGranteeID(oldIdStr) {
 				otherGranteeKey, err := findOtherGranteeWithIDFromKeys(ctx, granteeKey, oldKey, oldIdStr, keys, values)
 				if err != nil {
-					removeKeys = append(removeKeys, oldKey)
+					granteeRemovals = append(granteeRemovals, oldKey)
 					continue
 				}
 				if otherGranteeKey != "" {
-					removeKeys = append(removeKeys, oldKey)
+					granteeRemovals = append(granteeRemovals, oldKey)
 					continue
 				}
 			}
@@ -1920,7 +1949,7 @@ func (kc *Catalog) MigrateGrantCollectionName(ctx context.Context, tenant string
 			newKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, grantInfos[0], grantInfos[1], newObjName)
 			newIdStr := crypto.GranteeID(newKey)
 			saves[newKey] = newIdStr
-			removeKeys = append(removeKeys, oldKey)
+			granteeRemovals = append(granteeRemovals, oldKey)
 
 			// Migrate GranteeIDPrefix entries from oldIdStr to newIdStr
 			for j, idKey := range idKeys {
@@ -1936,14 +1965,27 @@ func (kc *Catalog) MigrateGrantCollectionName(ctx context.Context, tenant string
 				saves[newIDKey] = idValues[j]
 				// Reconstruct logical key for deletion
 				oldIDKey := fmt.Sprintf("%s/%s/%s", GranteeIDPrefix, oldIdStr, privilegeName)
-				removeKeys = append(removeKeys, oldIDKey)
+				idRemovals = append(idRemovals, oldIDKey)
 			}
 		}
 	}
 
-	if len(removeKeys) == 0 {
+	return saves, granteeRemovals, idRemovals, nil
+}
+
+func (kc *Catalog) MigrateGrantCollectionName(ctx context.Context, tenant string, oldDBName string, oldName string, newDBName string, newName string) error {
+	saves, granteeRemovals, idRemovals, err := kc.migrateGrantCollectionNameKvs(ctx, tenant, oldDBName, oldName, newDBName, newName)
+	if err != nil {
+		return err
+	}
+
+	if len(granteeRemovals)+len(idRemovals) == 0 {
 		return nil
 	}
+
+	removeKeys := make([]string, 0, len(granteeRemovals)+len(idRemovals))
+	removeKeys = append(removeKeys, granteeRemovals...)
+	removeKeys = append(removeKeys, idRemovals...)
 
 	// Use MultiSaveAndRemove (exact deletion) instead of prefix-based deletion
 	// to avoid accidentally matching keys like col1_backup when removing col1

--- a/internal/metastore/kv/rootcoord/kv_catalog.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog.go
@@ -1813,16 +1813,24 @@ func (kc *Catalog) ListGrant(ctx context.Context, tenant string, entity *milvusp
 	return entities, nil
 }
 
-func (kc *Catalog) DeleteGrantByCollectionName(ctx context.Context, tenant string, dbName string, collectionName string) error {
+// deleteGrantByCollectionNameKvs reads the current grantee subtree and
+// computes the removal set of a collection's grants: exactRemoveKeys are the
+// grantee-privileges leaves keyed by (dbName, collectionName) and
+// prefixRemoveKeys the grantee-id subtrees no surviving grantee still
+// references. It is shared by the legacy DeleteGrantByCollectionName path and
+// the composite Update drop path so both stay byte-identical. The removals
+// are returned split because the exact leaves are the only index from which a
+// retry can recompute this removal set (their values reference the grantee-id
+// subtrees), so a non-atomic applier must remove them after the prefixes.
+func (kc *Catalog) deleteGrantByCollectionNameKvs(ctx context.Context, tenant string, dbName string, collectionName string) (exactRemoveKeys []string, prefixRemoveKeys []string, err error) {
 	granteeKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
 	keys, values, err := kc.Txn.LoadWithPrefix(ctx, granteeKey)
 	if err != nil {
 		mlog.Warn(ctx, "fail to load grant privilege entities for collection cleanup",
 			mlog.String("key", granteeKey), mlog.Err(err))
-		return err
+		return nil, nil, err
 	}
 
-	var exactRemoveKeys []string
 	var granteeIDs []string
 	removingGrantees := make(map[string]struct{})
 	for i, key := range keys {
@@ -1847,11 +1855,6 @@ func (kc *Catalog) DeleteGrantByCollectionName(ctx context.Context, tenant strin
 		}
 	}
 
-	if len(exactRemoveKeys) == 0 && len(granteeIDs) == 0 {
-		return nil
-	}
-
-	var prefixRemoveKeys []string
 	for _, idStr := range granteeIDs {
 		if !shouldRemoveGranteeIDSubtree(ctx, granteeKey, idStr, keys, values, removingGrantees) {
 			continue
@@ -1859,6 +1862,15 @@ func (kc *Catalog) DeleteGrantByCollectionName(ctx context.Context, tenant strin
 		// Use prefix deletion for the granteeID key (has sub-keys)
 		granteeIDKey := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, idStr)
 		prefixRemoveKeys = append(prefixRemoveKeys, granteeIDKey)
+	}
+
+	return exactRemoveKeys, prefixRemoveKeys, nil
+}
+
+func (kc *Catalog) DeleteGrantByCollectionName(ctx context.Context, tenant string, dbName string, collectionName string) error {
+	exactRemoveKeys, prefixRemoveKeys, err := kc.deleteGrantByCollectionNameKvs(ctx, tenant, dbName, collectionName)
+	if err != nil {
+		return err
 	}
 
 	// Use prefix deletion for granteeID keys (which have sub-keys underneath).

--- a/internal/metastore/kv/rootcoord/kv_catalog.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog.go
@@ -3,6 +3,7 @@ package rootcoord
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -368,18 +369,28 @@ func (kc *Catalog) CreateAlias(ctx context.Context, alias *model.Alias, ts typeu
 	return kc.Txn.MultiSaveAndRemove(ctx, kvs, []string{oldKBefore210, oldKeyWithoutDb})
 }
 
-func (kc *Catalog) AlterCredential(ctx context.Context, credential *model.Credential) error {
+// buildCredentialKV is the single source of the credential record encoding,
+// shared by AlterCredential and the batched RestoreRBAC.
+func buildCredentialKV(credential *model.Credential) (string, string, error) {
 	k := fmt.Sprintf("%s/%s", CredentialPrefix, credential.Username)
 	credentialInfo := model.MarshalCredentialModel(credential)
 	credentialInfo.Username = ""       // Username is already save in the key, remove it from the value.
 	credentialInfo.Sha256Password = "" // Sha256Password is cache-only, do not persist it.
 	v, err := json.Marshal(credentialInfo)
 	if err != nil {
+		return k, "", err
+	}
+	return k, string(v), nil
+}
+
+func (kc *Catalog) AlterCredential(ctx context.Context, credential *model.Credential) error {
+	k, v, err := buildCredentialKV(credential)
+	if err != nil {
 		mlog.Error(ctx, "create credential marshal fail", mlog.String("key", k), mlog.Err(err))
 		return err
 	}
 
-	err = kc.Txn.Save(ctx, k, string(v))
+	err = kc.Txn.Save(ctx, k, v)
 	if err != nil {
 		mlog.Error(ctx, "create credential persist meta fail", mlog.String("key", k), mlog.Err(err))
 		return err
@@ -1223,12 +1234,22 @@ func (kc *Catalog) remove(ctx context.Context, k string) error {
 	return kc.Txn.Remove(ctx, k)
 }
 
-func (kc *Catalog) CreateRole(ctx context.Context, tenant string, entity *milvuspb.RoleEntity) error {
+// buildRoleKV is the single source of the role record encoding, shared by
+// CreateRole and the batched RestoreRBAC.
+func buildRoleKV(entity *milvuspb.RoleEntity) (string, string, error) {
 	k := RolePrefix + "/" + entity.Name
 	value, err := model.MarshalRoleModel(&model.Role{
 		Name:        entity.GetName(),
 		Description: entity.GetDescription(),
 	})
+	if err != nil {
+		return k, "", err
+	}
+	return k, value, nil
+}
+
+func (kc *Catalog) CreateRole(ctx context.Context, tenant string, entity *milvuspb.RoleEntity) error {
+	k, value, err := buildRoleKV(entity)
 	if err != nil {
 		return err
 	}
@@ -1294,8 +1315,12 @@ func (kc *Catalog) dropRoleRemovals(ctx context.Context, tenant string, roleName
 	return deleteKeys, nil
 }
 
+func buildUserRoleKey(username string, roleName string) string {
+	return fmt.Sprintf("%s/%s/%s", RoleMappingPrefix, username, roleName)
+}
+
 func (kc *Catalog) AlterUserRole(ctx context.Context, tenant string, userEntity *milvuspb.UserEntity, roleEntity *milvuspb.RoleEntity, operateType milvuspb.OperateUserRoleType) error {
-	k := fmt.Sprintf("%s/%s/%s", RoleMappingPrefix, userEntity.Name, roleEntity.Name)
+	k := buildUserRoleKey(userEntity.Name, roleEntity.Name)
 	switch operateType {
 	case milvuspb.OperateUserRoleType_AddUserToRole:
 		return kc.Txn.Save(ctx, k, "")
@@ -1599,18 +1624,20 @@ func (kc *Catalog) findOtherGranteeWithID(ctx context.Context, tenant string, gr
 	return findOtherGranteeWithIDFromKeys(ctx, granteePrefix, granteeKey, idStr, keys, values)
 }
 
-func (kc *Catalog) migrateGranteeID(ctx context.Context, tenant string, granteeKey string, idStr string) (string, error) {
+// migrateGranteeIDKvs computes, without committing, the subtree move of a
+// legacy grantee id to its deterministic replacement: the grantee leaf rewrite
+// plus every grantee-id leaf rekeyed from the old id to the new one, with the
+// old grantee-id keys as removals. The caller commits saves and removals in
+// one transaction together with whatever else the mutation stages.
+func (kc *Catalog) migrateGranteeIDKvs(ctx context.Context, tenant string, granteeKey string, idStr string) (map[string]string, []string, string, error) {
 	newID := crypto.GranteeID(granteeKey)
-	if idStr == newID {
-		return idStr, nil
-	}
 	if isLegacyGranteeID(idStr) {
 		otherGranteeKey, err := kc.findOtherGranteeWithID(ctx, tenant, granteeKey, idStr)
 		if err != nil {
-			return "", err
+			return nil, nil, "", err
 		}
 		if otherGranteeKey != "" {
-			return "", newSharedGranteeIDError(idStr, granteeKey, otherGranteeKey)
+			return nil, nil, "", newSharedGranteeIDError(idStr, granteeKey, otherGranteeKey)
 		}
 	}
 
@@ -1620,7 +1647,7 @@ func (kc *Catalog) migrateGranteeID(ctx context.Context, tenant string, granteeK
 	keys, values, err := kc.Txn.LoadWithPrefix(ctx, granteeIDKey)
 	if err != nil {
 		if !errors.Is(err, merr.ErrIoKeyNotFound) {
-			return "", err
+			return nil, nil, "", err
 		}
 	}
 	for i, key := range keys {
@@ -1633,13 +1660,17 @@ func (kc *Catalog) migrateGranteeID(ctx context.Context, tenant string, granteeK
 		saves[buildGranteeIDKey(newID, privilegeName)] = values[i]
 		removals = append(removals, buildGranteeIDKey(idStr, privilegeName))
 	}
-	if err := kc.Txn.MultiSaveAndRemove(ctx, saves, removals); err != nil {
-		return "", err
-	}
-	return newID, nil
+	return saves, removals, newID, nil
 }
 
-func (kc *Catalog) AlterGrant(ctx context.Context, tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) error {
+// alterGrantOps computes, without committing, the full write/removal set of
+// one AlterGrant mutation: the grantee leaf allocation (grant on a missing
+// leaf), the legacy-grantee-id subtree migration, and the grantee-id leaf
+// write or removal. A returned IgnorableError can carry staged ops - the leaf
+// allocation or migration the old multi-step path would already have persisted
+// before detecting the no-op - which the caller must still commit to land on
+// the same end state.
+func (kc *Catalog) alterGrantOps(ctx context.Context, tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) (map[string]string, []string, error) {
 	var (
 		privilegeName = entity.Grantor.Privilege.Name
 		granteeKey    = fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, entity.Role.Name, entity.Object.Name, funcutil.CombineObjectName(entity.DbName, entity.ObjectName))
@@ -1657,6 +1688,8 @@ func (kc *Catalog) AlterGrant(ctx context.Context, tenant string, entity *milvus
 			granteeKey = legacyKey
 		}
 	}
+	saves := make(map[string]string)
+	var removals []string
 	if idStr == "" {
 		if v, err = kc.Txn.Load(ctx, granteeKey); err == nil {
 			idStr = v
@@ -1664,57 +1697,83 @@ func (kc *Catalog) AlterGrant(ctx context.Context, tenant string, entity *milvus
 			mlog.Warn(ctx, "fail to load grant privilege entity", mlog.String("key", granteeKey), mlog.Any("type", operateType), mlog.Err(err))
 			if funcutil.IsRevoke(operateType) {
 				if errors.Is(err, merr.ErrIoKeyNotFound) {
-					return common.NewIgnorableErrorf("the grant[%s] isn't existed", granteeKey)
+					return nil, nil, common.NewIgnorableErrorf("the grant[%s] isn't existed", granteeKey)
 				}
-				return err
+				return nil, nil, err
 			}
 			if !errors.Is(err, merr.ErrIoKeyNotFound) {
-				return err
+				return nil, nil, err
 			}
 
 			idStr = crypto.GranteeID(granteeKey)
-			err = kc.Txn.Save(ctx, granteeKey, idStr)
-			if err != nil {
-				mlog.Error(ctx, "fail to allocate id when altering the grant", mlog.Err(err))
-				return err
-			}
+			saves[granteeKey] = idStr
 		}
 	}
 	if idStr != crypto.GranteeID(granteeKey) {
-		idStr, err = kc.migrateGranteeID(ctx, tenant, granteeKey, idStr)
+		migSaves, migRemovals, newID, err := kc.migrateGranteeIDKvs(ctx, tenant, granteeKey, idStr)
 		if err != nil {
 			mlog.Error(ctx, "fail to migrate grantee id when altering the grant", mlog.String("key", granteeKey), mlog.Err(err))
-			return err
+			return nil, nil, err
 		}
+		for mk, mv := range migSaves {
+			saves[mk] = mv
+		}
+		removals = append(removals, migRemovals...)
+		idStr = newID
 	}
 	k := buildGranteeIDKey(idStr, privilegeName)
-	_, err = kc.Txn.Load(ctx, k)
-	if err != nil {
-		mlog.Warn(ctx, "fail to load the grantee id", mlog.String("key", k), mlog.Err(err))
-		if !errors.Is(err, merr.ErrIoKeyNotFound) {
-			mlog.Warn(context.TODO(), "fail to load the grantee id", mlog.String("key", k), mlog.Err(err))
-			return err
+	// the staged migration may already carry this privilege under the new id;
+	// checking saves first keeps the decision identical to the old path, which
+	// looked the store up after the migration had committed.
+	_, granted := saves[k]
+	if !granted {
+		if _, err = kc.Txn.Load(ctx, k); err == nil {
+			granted = true
+		} else {
+			mlog.Warn(ctx, "fail to load the grantee id", mlog.String("key", k), mlog.Err(err))
+			if !errors.Is(err, merr.ErrIoKeyNotFound) {
+				return nil, nil, err
+			}
+			mlog.Debug(ctx, "not found the grantee id", mlog.String("key", k))
 		}
-		mlog.Debug(ctx, "not found the grantee id", mlog.String("key", k))
+	}
+	if !granted {
 		if funcutil.IsRevoke(operateType) {
-			return common.NewIgnorableErrorf("the grantee-id[%s] isn't existed", k)
+			return saves, removals, common.NewIgnorableErrorf("the grantee-id[%s] isn't existed", k)
 		}
 		if funcutil.IsGrant(operateType) {
-			if err = kc.Txn.Save(ctx, k, entity.Grantor.User.Name); err != nil {
-				mlog.Error(ctx, "fail to save the grantee id", mlog.String("key", k), mlog.Err(err))
-			}
-			return err
+			saves[k] = entity.Grantor.User.Name
 		}
-		return nil
+		return saves, removals, nil
 	}
 	if funcutil.IsRevoke(operateType) {
-		if err = kc.Txn.Remove(ctx, k); err != nil {
-			mlog.Error(ctx, "fail to remove the grantee id", mlog.String("key", k), mlog.Err(err))
+		// the privilege may sit in the staged migration saves or in the store;
+		// drop the staged write and remove the key so both sources converge to
+		// "absent".
+		delete(saves, k)
+		removals = append(removals, k)
+		return saves, removals, nil
+	}
+	return saves, removals, common.NewIgnorableErrorf("the privilege[%s] has been granted", privilegeName)
+}
+
+// AlterGrant lands the whole mutation - grantee leaf, legacy-id migration and
+// grantee-id leaf - in a single transaction, so a crash can no longer strand
+// the grantee leaf without its grantee-id leaf or leave the grantee-id subtree
+// half-migrated. The read-compute-commit sequence takes no predicates:
+// rootcoord serializes RBAC mutations behind the MetaTable lock.
+func (kc *Catalog) AlterGrant(ctx context.Context, tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) error {
+	saves, removals, opErr := kc.alterGrantOps(ctx, tenant, entity, operateType)
+	if opErr != nil && !common.IsIgnorableError(opErr) {
+		return opErr
+	}
+	if len(saves)+len(removals) > 0 {
+		if err := kc.Txn.MultiSaveAndRemove(ctx, saves, removals); err != nil {
+			mlog.Error(ctx, "fail to commit the grant mutation", mlog.Any("type", operateType), mlog.Err(err))
 			return err
 		}
-		return err
 	}
-	return common.NewIgnorableErrorf("the privilege[%s] has been granted", privilegeName)
+	return opErr
 }
 
 func (kc *Catalog) ListGrant(ctx context.Context, tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error) {
@@ -2211,15 +2270,105 @@ func (kc *Catalog) BackupRBAC(ctx context.Context, tenant string) (*milvuspb.RBA
 	}, nil
 }
 
+// RestoreRBAC replays an RBAC backup in batched composite writes. Kvs are
+// staged in the order the previous per-key loop wrote them (roles, privilege
+// groups, grants, then each user's credential and role mappings) and flushed
+// in transactions of at most MaxTxnOps ops, each batch atomic; an entity
+// whose kvs alone exceed that limit is split across batches (see stage
+// below). The restore as
+// a whole is NOT atomic: a crash leaves a prefix of batches applied. That
+// partial state is safe to re-run - every staged kv is deterministic for a
+// given backup (grantee ids are content hashes of their keys) and an
+// already-granted privilege is skipped instead of failing - so retrying the
+// same restore converges to the same end state.
 func (kc *Catalog) RestoreRBAC(ctx context.Context, tenant string, meta *milvuspb.RBACMeta) error {
+	limit := kc.Txn.MaxTxnOps()
+	if limit <= 0 {
+		return merr.WrapErrParameterInvalidMsg("restore batch limit must be positive")
+	}
+
+	saves := make(map[string]string)
+	var removals []string
+	removalSet := make(map[string]struct{})
+	flush := func() error {
+		if len(saves)+len(removals) == 0 {
+			return nil
+		}
+		if err := kc.Txn.MultiSaveAndRemove(ctx, saves, removals); err != nil {
+			mlog.Warn(ctx, "fail to flush a restore batch", mlog.Err(err))
+			return err
+		}
+		saves = make(map[string]string)
+		removals = nil
+		removalSet = make(map[string]struct{})
+		return nil
+	}
+	// stage adds one entity's kvs to the pending batch, flushing first when
+	// they would not fit. keepExisting makes an already-staged key win,
+	// mirroring the sequential path where the first grant of a privilege lands
+	// and a duplicate is an ignorable no-op; plain saves (roles, groups,
+	// credentials) overwrite, as sequential Saves did. Removals are deduped:
+	// two grants staging the same legacy-id migration must not put the same
+	// delete twice into one txn.
+	//
+	// An entity whose kvs alone exceed the limit cannot be written atomically
+	// at all - one oversized txn is simply rejected by the store, failing the
+	// restore permanently where the legacy per-key path succeeded. Its kvs are
+	// therefore split across batches, saves (in deterministic key order)
+	// before removals, giving up per-entity atomicity for the same
+	// convergence-on-retry guarantee the restore as a whole already relies on.
+	stage := func(addSaves map[string]string, addRemovals []string, keepExisting bool) error {
+		if n := len(saves) + len(removals); n > 0 && n+len(addSaves)+len(addRemovals) > limit {
+			if err := flush(); err != nil {
+				return err
+			}
+		}
+		saveKeys := lo.Keys(addSaves)
+		sort.Strings(saveKeys)
+		for _, k := range saveKeys {
+			if keepExisting {
+				if _, ok := saves[k]; ok {
+					continue
+				}
+			}
+			if len(saves)+len(removals) >= limit {
+				if err := flush(); err != nil {
+					return err
+				}
+			}
+			saves[k] = addSaves[k]
+		}
+		for _, k := range addRemovals {
+			if _, ok := removalSet[k]; ok {
+				continue
+			}
+			if len(saves)+len(removals) >= limit {
+				if err := flush(); err != nil {
+					return err
+				}
+			}
+			removalSet[k] = struct{}{}
+			removals = append(removals, k)
+		}
+		return nil
+	}
+
 	for _, role := range meta.GetRoles() {
-		if err := kc.CreateRole(ctx, tenant, role); err != nil {
+		k, v, err := buildRoleKV(role)
+		if err != nil {
+			return errors.Wrap(err, "failed to create role")
+		}
+		if err := stage(map[string]string{k: v}, nil, false); err != nil {
 			return errors.Wrap(err, "failed to create role")
 		}
 	}
 
 	for _, group := range meta.GetPrivilegeGroups() {
-		if err := kc.SavePrivilegeGroup(ctx, group); err != nil {
+		k, v, err := buildPrivilegeGroupKV(group)
+		if err != nil {
+			return errors.Wrap(err, "failed to save privilege group")
+		}
+		if err := stage(map[string]string{k: v}, nil, false); err != nil {
 			return errors.Wrap(err, "failed to save privilege group")
 		}
 	}
@@ -2233,30 +2382,36 @@ func (kc *Catalog) RestoreRBAC(ctx context.Context, tenant string, meta *milvusp
 		default:
 			grant.Grantor.Privilege.Name = util.PrivilegeGroupNameForMetastore(privName)
 		}
-		if err := kc.AlterGrant(ctx, tenant, grant, milvuspb.OperatePrivilegeType_Grant); err != nil {
+		grantSaves, grantRemovals, err := kc.alterGrantOps(ctx, tenant, grant, milvuspb.OperatePrivilegeType_Grant)
+		if err != nil && !common.IsIgnorableError(err) {
+			return errors.Wrap(err, "failed to alter grant")
+		}
+		// an already-granted privilege (IgnorableError) is skipped rather than
+		// aborting the restore, so re-running an interrupted restore converges;
+		// its staged kvs (a legacy-id migration the sequential path would have
+		// persisted before detecting the duplicate) are still applied.
+		if err := stage(grantSaves, grantRemovals, true); err != nil {
 			return errors.Wrap(err, "failed to alter grant")
 		}
 	}
 
 	for _, user := range meta.GetUsers() {
-		if err := kc.AlterCredential(ctx, &model.Credential{
+		k, v, err := buildCredentialKV(&model.Credential{
 			Username:          user.GetUser(),
 			EncryptedPassword: user.GetPassword(),
-		}); err != nil {
+		})
+		if err != nil {
 			return errors.Wrap(err, "failed to alter credential")
 		}
-
-		// restore user role mapping
-		entity := &milvuspb.UserEntity{
-			Name: user.GetUser(),
-		}
+		userSaves := map[string]string{k: v}
 		for _, role := range user.GetRoles() {
-			if err := kc.AlterUserRole(ctx, tenant, entity, role, milvuspb.OperateUserRoleType_AddUserToRole); err != nil {
-				return errors.Wrap(err, "failed to alter user role")
-			}
+			userSaves[buildUserRoleKey(user.GetUser(), role.GetName())] = ""
+		}
+		if err := stage(userSaves, nil, false); err != nil {
+			return errors.Wrap(err, "failed to restore user")
 		}
 	}
-	return nil
+	return flush()
 }
 
 func (kc *Catalog) GetPrivilegeGroup(ctx context.Context, groupName string) (*milvuspb.PrivilegeGroupInfo, error) {
@@ -2288,7 +2443,9 @@ func (kc *Catalog) DropPrivilegeGroup(ctx context.Context, groupName string) err
 	return nil
 }
 
-func (kc *Catalog) SavePrivilegeGroup(ctx context.Context, data *milvuspb.PrivilegeGroupInfo) error {
+// buildPrivilegeGroupKV is the single source of the privilege group record
+// encoding, shared by SavePrivilegeGroup and the batched RestoreRBAC.
+func buildPrivilegeGroupKV(data *milvuspb.PrivilegeGroupInfo) (string, string, error) {
 	k := BuildPrivilegeGroupkey(data.GroupName)
 	groupInfo := &milvuspb.PrivilegeGroupInfo{
 		GroupName:  data.GroupName,
@@ -2296,10 +2453,18 @@ func (kc *Catalog) SavePrivilegeGroup(ctx context.Context, data *milvuspb.Privil
 	}
 	v, err := proto.Marshal(groupInfo)
 	if err != nil {
+		return k, "", err
+	}
+	return k, string(v), nil
+}
+
+func (kc *Catalog) SavePrivilegeGroup(ctx context.Context, data *milvuspb.PrivilegeGroupInfo) error {
+	k, v, err := buildPrivilegeGroupKV(data)
+	if err != nil {
 		mlog.Error(ctx, "failed to marshal privilege group info", mlog.Err(err))
 		return err
 	}
-	if err = kc.Txn.Save(ctx, k, string(v)); err != nil {
+	if err = kc.Txn.Save(ctx, k, v); err != nil {
 		mlog.Warn(ctx, "fail to put privilege group", mlog.String("key", k), mlog.Err(err))
 		return err
 	}

--- a/internal/metastore/kv/rootcoord/kv_catalog.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog.go
@@ -1237,11 +1237,27 @@ func (kc *Catalog) AlterRole(ctx context.Context, tenant string, entity *milvusp
 }
 
 func (kc *Catalog) DropRole(ctx context.Context, tenant string, roleName string) error {
+	deleteKeys, err := kc.dropRoleRemovals(ctx, tenant, roleName)
+	if err != nil {
+		return err
+	}
+
+	err = kc.Txn.MultiRemove(ctx, deleteKeys)
+	if err != nil {
+		mlog.Warn(ctx, "fail to drop role", mlog.String("key", deleteKeys[0]), mlog.Err(err))
+		return err
+	}
+	return nil
+}
+
+// dropRoleRemovals returns the exact keys DropRole removes: the role record
+// key first, followed by the role's user-role mapping keys.
+func (kc *Catalog) dropRoleRemovals(ctx context.Context, tenant string, roleName string) ([]string, error) {
 	k := RolePrefix + "/" + roleName
 	roleResults, err := kc.ListRole(ctx, tenant, &milvuspb.RoleEntity{Name: roleName}, true)
 	if err != nil && !errors.Is(err, merr.ErrIoKeyNotFound) {
 		mlog.Warn(ctx, "fail to list role", mlog.String("key", k), mlog.Err(err))
-		return err
+		return nil, err
 	}
 
 	deleteKeys := make([]string, 0, len(roleResults)+1)
@@ -1254,13 +1270,7 @@ func (kc *Catalog) DropRole(ctx context.Context, tenant string, roleName string)
 			}
 		}
 	}
-
-	err = kc.Txn.MultiRemove(ctx, deleteKeys)
-	if err != nil {
-		mlog.Warn(ctx, "fail to drop role", mlog.String("key", k), mlog.Err(err))
-		return err
-	}
-	return nil
+	return deleteKeys, nil
 }
 
 func (kc *Catalog) AlterUserRole(ctx context.Context, tenant string, userEntity *milvuspb.UserEntity, roleEntity *milvuspb.RoleEntity, operateType milvuspb.OperateUserRoleType) error {
@@ -1946,6 +1956,21 @@ func (kc *Catalog) MigrateGrantCollectionName(ctx context.Context, tenant string
 }
 
 func (kc *Catalog) DeleteGrant(ctx context.Context, tenant string, role *milvuspb.RoleEntity) error {
+	removeKeys, err := kc.deleteGrantPrefixes(ctx, tenant, role)
+	if err != nil {
+		return err
+	}
+
+	if err = kc.Txn.MultiSaveAndRemoveWithPrefix(ctx, nil, removeKeys); err != nil {
+		mlog.Error(ctx, "fail to remove with the prefix", mlog.String("key", removeKeys[0]), mlog.Err(err))
+	}
+	return err
+}
+
+// deleteGrantPrefixes returns the prefixes DeleteGrant removes: the role's
+// grantee-privileges subtree first, then every grantee-id subtree no
+// surviving grantee still references.
+func (kc *Catalog) deleteGrantPrefixes(ctx context.Context, tenant string, role *milvuspb.RoleEntity) ([]string, error) {
 	var (
 		k          = funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, role.Name)
 		err        error
@@ -1958,7 +1983,7 @@ func (kc *Catalog) DeleteGrant(ctx context.Context, tenant string, role *milvusp
 	keys, values, err := kc.Txn.LoadWithPrefix(ctx, k)
 	if err != nil {
 		mlog.Warn(ctx, "fail to load grant privilege entities", mlog.String("key", k), mlog.Err(err))
-		return err
+		return nil, err
 	}
 	removingGrantees := make(map[string]struct{})
 	keyWithoutTrailingSlash := strings.TrimSuffix(k, "/")
@@ -1979,7 +2004,7 @@ func (kc *Catalog) DeleteGrant(ctx context.Context, tenant string, role *milvusp
 			allKeys, allValues, err = kc.Txn.LoadWithPrefix(ctx, granteePrefix)
 			if err != nil {
 				mlog.Warn(ctx, "fail to load grant privilege entities for shared id check", mlog.String("key", granteePrefix), mlog.Err(err))
-				return err
+				return nil, err
 			}
 		}
 		if !shouldRemoveGranteeIDSubtree(ctx, funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant), v, allKeys, allValues, removingGrantees) {
@@ -1989,10 +2014,7 @@ func (kc *Catalog) DeleteGrant(ctx context.Context, tenant string, role *milvusp
 		removeKeys = append(removeKeys, granteeIDKey)
 	}
 
-	if err = kc.Txn.MultiSaveAndRemoveWithPrefix(ctx, nil, removeKeys); err != nil {
-		mlog.Error(ctx, "fail to remove with the prefix", mlog.String("key", k), mlog.Err(err))
-	}
-	return err
+	return removeKeys, nil
 }
 
 func (kc *Catalog) ListPolicy(ctx context.Context, tenant string) ([]*milvuspb.GrantEntity, error) {

--- a/internal/metastore/kv/rootcoord/kv_catalog_test.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog_test.go
@@ -4686,7 +4686,10 @@ func TestMigrateGrantCollectionName(t *testing.T) {
 				newKey2:   newIdStr2,
 				newIDKey1: "root", newIDKey2a: "root", newIDKey2b: "admin",
 			},
-			[]string{key1, oldIDEntry1, key2, oldIDEntry2a, oldIDEntry2b}).Return(nil)
+			// grantee keys are listed before grantee-id keys (the order within
+			// one txn is irrelevant; migrateGrantCollectionNameKvs returns the
+			// two classes split for the composite Update's fallback ordering).
+			[]string{key1, key2, oldIDEntry1, oldIDEntry2a, oldIDEntry2b}).Return(nil)
 
 		err := c.MigrateGrantCollectionName(ctx, tenant, "default", "old_col", "default", "new_col")
 		assert.NoError(t, err)

--- a/internal/metastore/kv/rootcoord/kv_catalog_test.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog_test.go
@@ -2644,9 +2644,6 @@ func TestRBAC_Grant(t *testing.T) {
 			Return("", func(ctx context.Context, key string) error {
 				return merr.WrapErrIoKeyNotFound(key)
 			})
-		kvmock.EXPECT().Save(mock.Anything, keyNotExistRoleKeyWithDb, mock.Anything).Return(nil)
-		kvmock.EXPECT().Save(mock.Anything, errorSaveRoleKeyWithDb, mock.Anything).Return(errors.New("mock save error role"))
-
 		validPrivilegeKey := fmt.Sprintf("%s/%s/%s", GranteeIDPrefix, validRoleValue, validPrivilege)
 		invalidPrivilegeKey := fmt.Sprintf("%s/%s/%s", GranteeIDPrefix, validRoleValue, invalidPrivilege)
 		keyNotExistPrivilegeKey := fmt.Sprintf("%s/%s/%s", GranteeIDPrefix, validRoleValue, keyNotExistPrivilege)
@@ -2668,10 +2665,30 @@ func TestRBAC_Grant(t *testing.T) {
 			})
 		kvmock.EXPECT().Load(mock.Anything, mock.Anything).Call.Return("", nil)
 
-		t.Run("test Grant", func(t *testing.T) {
-			kvmock.EXPECT().Save(mock.Anything, mock.Anything, validUser).Return(nil)
-			kvmock.EXPECT().Save(mock.Anything, mock.Anything, invalidUser).Return(errors.New("mock save invalid user"))
+		// AlterGrant commits every state (grant, revoke, migration) through a
+		// single MultiSaveAndRemove; the write failures the old per-key mocks
+		// injected are dispatched on the composite call's content instead.
+		invalidPrivilegeRemove := "p-remove"
+		invalidPrivilegeRemoveKey := fmt.Sprintf("%s/%s/%s", GranteeIDPrefix, validRoleValue, invalidPrivilegeRemove)
+		kvmock.EXPECT().MultiSaveAndRemove(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+			func(_ context.Context, saves map[string]string, removals []string, _ ...predicates.Predicate) error {
+				if _, ok := saves[errorSaveRoleKeyWithDb]; ok {
+					return errors.New("mock save error role")
+				}
+				for _, v := range saves {
+					if v == invalidUser {
+						return errors.New("mock save invalid user")
+					}
+				}
+				for _, k := range removals {
+					if k == invalidPrivilegeRemoveKey {
+						return errors.New("mock remove error")
+					}
+				}
+				return nil
+			}).Maybe()
 
+		t.Run("test Grant", func(t *testing.T) {
 			tests := []struct {
 				isValid bool
 
@@ -2726,12 +2743,6 @@ func TestRBAC_Grant(t *testing.T) {
 		})
 
 		t.Run("test Revoke", func(t *testing.T) {
-			invalidPrivilegeRemove := "p-remove"
-			invalidPrivilegeRemoveKey := fmt.Sprintf("%s/%s/%s", GranteeIDPrefix, validRoleValue, invalidPrivilegeRemove)
-
-			kvmock.EXPECT().Load(mock.Anything, invalidPrivilegeRemoveKey).Call.Return("", nil)
-			kvmock.EXPECT().Remove(mock.Anything, invalidPrivilegeRemoveKey).Return(errors.New("mock remove error"))
-			kvmock.EXPECT().Remove(mock.Anything, mock.Anything).Return(nil)
 			tests := []struct {
 				isValid bool
 

--- a/internal/metastore/kv/rootcoord/update.go
+++ b/internal/metastore/kv/rootcoord/update.go
@@ -19,6 +19,7 @@ package rootcoord
 import (
 	"context"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/internal/metastore"
 	"github.com/milvus-io/milvus/internal/metastore/kv/txn"
 	pb "github.com/milvus-io/milvus/pkg/v3/proto/etcdpb"
@@ -38,49 +39,87 @@ import (
 func (kc *Catalog) Update(ctx context.Context, ts typeutil.Timestamp, actions ...metastore.UpdateAction) error {
 	b := txn.New()
 	for _, action := range actions {
-		ce, ok := action.Entry.(metastore.CollectionEntry)
-		if !ok {
-			return merr.WrapErrServiceInternalMsg("rootcoord catalog cannot apply entry %T", action.Entry)
-		}
-		coll := ce.Collection
-		switch action.Type {
-		case metastore.ActionAdd:
-			// CreateCollection appends the child kvs and the collection
-			// key/value (as the commit marker), using the same encoding as
-			// the legacy Catalog.CreateCollection. It keeps the legacy
-			// overwrite/idempotent-on-retry semantics (a duplicate create
-			// silently overwrites rather than failing). CommitSave marks
-			// the collection key as the visibility point, so children are
-			// persisted before the collection key on the ordered fallback
-			// path.
-			if coll.State != pb.CollectionState_CollectionCreated {
-				return merr.WrapErrServiceInternalMsg("collection state should be created, collection name: %s, collection id: %d, state: %s", coll.Name, coll.CollectionID, coll.State)
-			}
+		switch entry := action.Entry.(type) {
+		case metastore.CollectionEntry:
+			coll := entry.Collection
+			switch action.Type {
+			case metastore.ActionAdd:
+				// CreateCollection appends the child kvs and the collection
+				// key/value (as the commit marker), using the same encoding as
+				// the legacy Catalog.CreateCollection. It keeps the legacy
+				// overwrite/idempotent-on-retry semantics (a duplicate create
+				// silently overwrites rather than failing). CommitSave marks
+				// the collection key as the visibility point, so children are
+				// persisted before the collection key on the ordered fallback
+				// path.
+				if coll.State != pb.CollectionState_CollectionCreated {
+					return merr.WrapErrServiceInternalMsg("collection state should be created, collection name: %s, collection id: %d, state: %s", coll.Name, coll.CollectionID, coll.State)
+				}
 
-			k1, v1, err := buildCollectionKV(coll)
+				k1, v1, err := buildCollectionKV(coll)
+				if err != nil {
+					return err
+				}
+				kvs, err := buildCreateCollectionChildKvs(coll)
+				if err != nil {
+					return err
+				}
+
+				for k, v := range kvs {
+					b.Save(k, v)
+				}
+				b.CommitSave(k1, v1)
+			case metastore.ActionDelete:
+				// DropCollection appends the child metadata removals and the
+				// collection key removal (as the commit marker), using the same
+				// keys as the legacy Catalog.DropCollection.
+				collectionKey, delMetakeysSnap := buildDropCollectionKeys(coll)
+				for _, k := range delMetakeysSnap {
+					b.Remove(k)
+				}
+				b.CommitRemove(collectionKey)
+			default:
+				return merr.WrapErrServiceInternalMsg("rootcoord catalog cannot apply action type %v to CollectionEntry", action.Type)
+			}
+		case metastore.RoleEntry:
+			// DropRole appends the exact same keys as the legacy
+			// Catalog.DropRole: user-role mapping removals first, then the
+			// role record removal as the commit marker, so on the chunked
+			// fallback path the role stays visible (and the drop retryable)
+			// until everything else has landed.
+			if action.Type != metastore.ActionDelete {
+				return merr.WrapErrServiceInternalMsg("rootcoord catalog cannot apply action type %v to RoleEntry", action.Type)
+			}
+			deleteKeys, err := kc.dropRoleRemovals(ctx, entry.Tenant, entry.Name)
 			if err != nil {
 				return err
 			}
-			kvs, err := buildCreateCollectionChildKvs(coll)
-			if err != nil {
-				return err
-			}
-
-			for k, v := range kvs {
-				b.Save(k, v)
-			}
-			b.CommitSave(k1, v1)
-		case metastore.ActionDelete:
-			// DropCollection appends the child metadata removals and the
-			// collection key removal (as the commit marker), using the same
-			// keys as the legacy Catalog.DropCollection.
-			collectionKey, delMetakeysSnap := buildDropCollectionKeys(coll)
-			for _, k := range delMetakeysSnap {
+			for _, k := range deleteKeys[1:] {
 				b.Remove(k)
 			}
-			b.CommitRemove(collectionKey)
+			b.CommitRemove(deleteKeys[0])
+		case metastore.RoleGrantsEntry:
+			// DropRoleGrants appends the exact same prefixes as the legacy
+			// Catalog.DeleteGrant: the grantee-privileges subtree plus the
+			// unshared grantee-id subtrees. The grantee-privileges subtree is
+			// the only index from which a retry can rediscover the grantee-id
+			// subtrees, so on the chunked fallback path it must land last —
+			// otherwise a crash between prefix chunks permanently orphans the
+			// remaining grantee-id subtrees, and a same-name role re-grant
+			// would silently resurrect them (GranteeID is deterministic).
+			if action.Type != metastore.ActionDelete {
+				return merr.WrapErrServiceInternalMsg("rootcoord catalog cannot apply action type %v to RoleGrantsEntry", action.Type)
+			}
+			prefixes, err := kc.deleteGrantPrefixes(ctx, entry.Tenant, &milvuspb.RoleEntity{Name: entry.RoleName})
+			if err != nil {
+				return err
+			}
+			for _, p := range prefixes[1:] {
+				b.RemovePrefix(p)
+			}
+			b.RemovePrefix(prefixes[0])
 		default:
-			return merr.WrapErrServiceInternalMsg("rootcoord catalog cannot apply action type %v to CollectionEntry", action.Type)
+			return merr.WrapErrServiceInternalMsg("rootcoord catalog cannot apply entry %T", action.Entry)
 		}
 	}
 

--- a/internal/metastore/kv/rootcoord/update.go
+++ b/internal/metastore/kv/rootcoord/update.go
@@ -81,6 +81,75 @@ func (kc *Catalog) Update(ctx context.Context, ts typeutil.Timestamp, actions ..
 			default:
 				return merr.WrapErrServiceInternalMsg("rootcoord catalog cannot apply action type %v to CollectionEntry", action.Type)
 			}
+		case metastore.CollectionRenameEntry:
+			// RenameCollection rewrites the collection record with the exact
+			// same encoding as the legacy Catalog.AlterCollection(MODIFY) /
+			// AlterCollectionDB pair, routed on whether the database changed.
+			// The record is the visibility marker of the whole rename: it
+			// lands last on the chunked fallback path, so a crash mid-rename
+			// leaves the collection under its old name (and the rename
+			// retryable) instead of publishing a renamed collection whose
+			// grants are still keyed by the old name.
+			if action.Type != metastore.ActionUpdate {
+				return merr.WrapErrServiceInternalMsg("rootcoord catalog cannot apply action type %v to CollectionRenameEntry", action.Type)
+			}
+			if entry.Old.DBID != entry.New.DBID {
+				saves, removals, err := alterCollectionDBKvs(entry.Old, entry.New)
+				if err != nil {
+					return err
+				}
+				// the record move is a single save/remove pair; both sides
+				// flip together in the final guarded txn.
+				for k, v := range saves {
+					b.CommitSave(k, v)
+				}
+				for _, k := range removals {
+					b.CommitRemove(k)
+				}
+			} else {
+				saves, removals, err := alterModifyCollectionKvs(entry.Old, entry.New, entry.FieldModify)
+				if err != nil {
+					return err
+				}
+				collKey := BuildCollectionKey(entry.New.DBID, entry.New.CollectionID)
+				for _, k := range removals {
+					b.Remove(k)
+				}
+				for k, v := range saves {
+					if k != collKey {
+						b.Save(k, v)
+					}
+				}
+				b.CommitSave(collKey, saves[collKey])
+			}
+		case metastore.GrantMigrateEntry:
+			// MigrateCollectionGrants rewrites every grantee (and grantee-id)
+			// key referencing the old (db, collection) name pair, using the
+			// exact same kv set as the legacy MigrateGrantCollectionName.
+			// This is a read-current-state-then-commit rewrite with no
+			// predicate checks; see the MigrateCollectionGrants constructor
+			// for the serialization the caller must provide.
+			if action.Type != metastore.ActionUpdate {
+				return merr.WrapErrServiceInternalMsg("rootcoord catalog cannot apply action type %v to GrantMigrateEntry", action.Type)
+			}
+			saves, granteeRemovals, idRemovals, err := kc.migrateGrantCollectionNameKvs(ctx, entry.Tenant, entry.OldDBName, entry.OldName, entry.NewDBName, entry.NewName)
+			if err != nil {
+				return err
+			}
+			for k, v := range saves {
+				b.Save(k, v)
+			}
+			// the old grantee-privileges keys are the only index from which a
+			// retry can recompute this rewrite set (their values reference the
+			// grantee-id subtrees), so on the chunked fallback path they must
+			// land after the grantee-id removals - otherwise a crash between
+			// removal chunks permanently orphans the remaining old keys.
+			for _, k := range idRemovals {
+				b.Remove(k)
+			}
+			for _, k := range granteeRemovals {
+				b.Remove(k)
+			}
 		case metastore.RoleEntry:
 			// DropRole appends the exact same keys as the legacy
 			// Catalog.DropRole: user-role mapping removals first, then the

--- a/internal/metastore/kv/rootcoord/update.go
+++ b/internal/metastore/kv/rootcoord/update.go
@@ -150,6 +150,33 @@ func (kc *Catalog) Update(ctx context.Context, ts typeutil.Timestamp, actions ..
 			for _, k := range granteeRemovals {
 				b.Remove(k)
 			}
+		case metastore.CollectionGrantsEntry:
+			// DropCollectionGrants appends the exact same keys as the legacy
+			// Catalog.DeleteGrantByCollectionName: the unshared grantee-id
+			// subtrees as prefix removals, then the matching grantee-privileges
+			// leaves as exact removals. The leaves are the only index from
+			// which a retry can recompute this removal set (their values
+			// reference the grantee-id subtrees), so on the chunked fallback
+			// path they must land after the grantee-id subtrees - otherwise a
+			// crash in between permanently orphans the remaining subtrees. The
+			// collection record - the commit marker of the whole drop - is
+			// composed by the caller after this entry and lands last. This is
+			// a read-current-state-then-commit removal with no predicate
+			// checks; see the DropCollectionGrants constructor for the
+			// serialization the caller must provide.
+			if action.Type != metastore.ActionDelete {
+				return merr.WrapErrServiceInternalMsg("rootcoord catalog cannot apply action type %v to CollectionGrantsEntry", action.Type)
+			}
+			exactRemovals, prefixRemovals, err := kc.deleteGrantByCollectionNameKvs(ctx, entry.Tenant, entry.DBName, entry.CollectionName)
+			if err != nil {
+				return err
+			}
+			for _, p := range prefixRemovals {
+				b.RemovePrefix(p)
+			}
+			for _, k := range exactRemovals {
+				b.Remove(k)
+			}
 		case metastore.RoleEntry:
 			// DropRole appends the exact same keys as the legacy
 			// Catalog.DropRole: user-role mapping removals first, then the

--- a/internal/metastore/kv/rootcoord/update_test.go
+++ b/internal/metastore/kv/rootcoord/update_test.go
@@ -18,17 +18,22 @@ package rootcoord
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	memkv "github.com/milvus-io/milvus/internal/kv/mem"
 	"github.com/milvus-io/milvus/internal/kv/mocks"
 	"github.com/milvus-io/milvus/internal/metastore"
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 	pb "github.com/milvus-io/milvus/pkg/v3/proto/etcdpb"
+	"github.com/milvus-io/milvus/pkg/v3/util"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
@@ -129,4 +134,334 @@ func TestCatalog_Update_CreateCollectionEncodingMatchesLegacy(t *testing.T) {
 
 	assert.Equal(t, wantSaves, directSaves)
 	assert.Equal(t, wantSaves, compositeSaves)
+}
+
+// seedDropRoleRBAC populates a catalog with the fixture used by the
+// drop-role-with-grants tests: role1 (the drop target) with two user
+// mappings and two grants, plus role10 as the exact-vs-prefix widening
+// canary (a prefix delete of "roles/role1" or "grantee-privileges/role1"
+// without the trailing slash would wipe role10's keys too).
+func seedDropRoleRBAC(t *testing.T, c metastore.RootCoordCatalog) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+	for _, role := range []string{"role1", "role10"} {
+		assert.NoError(t, c.CreateRole(ctx, tenant, &milvuspb.RoleEntity{Name: role}))
+	}
+	assert.NoError(t, c.AlterUserRole(ctx, tenant, &milvuspb.UserEntity{Name: "user1"}, &milvuspb.RoleEntity{Name: "role1"}, milvuspb.OperateUserRoleType_AddUserToRole))
+	assert.NoError(t, c.AlterUserRole(ctx, tenant, &milvuspb.UserEntity{Name: "user2"}, &milvuspb.RoleEntity{Name: "role1"}, milvuspb.OperateUserRoleType_AddUserToRole))
+	assert.NoError(t, c.AlterUserRole(ctx, tenant, &milvuspb.UserEntity{Name: "user1"}, &milvuspb.RoleEntity{Name: "role10"}, milvuspb.OperateUserRoleType_AddUserToRole))
+	grant := func(role, objType, objName, priv string) {
+		assert.NoError(t, c.AlterGrant(ctx, tenant, &milvuspb.GrantEntity{
+			Role:       &milvuspb.RoleEntity{Name: role},
+			Object:     &milvuspb.ObjectEntity{Name: objType},
+			ObjectName: objName,
+			DbName:     "db1",
+			Grantor: &milvuspb.GrantorEntity{
+				User:      &milvuspb.UserEntity{Name: "root"},
+				Privilege: &milvuspb.PrivilegeEntity{Name: priv},
+			},
+		}, milvuspb.OperatePrivilegeType_Grant))
+	}
+	grant("role1", "Collection", "coll1", "Insert")
+	grant("role1", "Global", "*", "CreateCollection")
+	grant("role10", "Collection", "coll1", "Insert")
+}
+
+func dumpKV(t *testing.T, k interface {
+	LoadWithPrefix(ctx context.Context, key string) ([]string, []string, error)
+},
+) map[string]string {
+	keys, vals, err := k.LoadWithPrefix(context.TODO(), "")
+	assert.NoError(t, err)
+	got := make(map[string]string, len(keys))
+	for i, key := range keys {
+		got[key] = vals[i]
+	}
+	return got
+}
+
+// TestCatalog_Update_DropRoleWithGrants_MatchesLegacyBytes proves the new
+// single-txn drop-role path leaves byte-for-byte the same store state as
+// today's two-call path (Catalog.DropRole + Catalog.DeleteGrant): role
+// record, user-role mappings, grantee-privileges subtree and grantee-id
+// subtrees all gone, canary keys of another role untouched.
+func TestCatalog_Update_DropRoleWithGrants_MatchesLegacyBytes(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+	legacyKV := memkv.NewMemoryKV()
+	compositeKV := memkv.NewMemoryKV()
+	legacy := NewCatalog(legacyKV)
+	composite := NewCatalog(compositeKV)
+	seedDropRoleRBAC(t, legacy)
+	seedDropRoleRBAC(t, composite)
+	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, compositeKV))
+
+	// capture role1's grantee ids before the drop, to assert their subtrees die.
+	granteeKeys, granteeIDs, err := compositeKV.LoadWithPrefix(ctx, funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, "role1"))
+	assert.NoError(t, err)
+	assert.Len(t, granteeKeys, 2)
+
+	// today's two-call path.
+	assert.NoError(t, legacy.DropRole(ctx, tenant, "role1"))
+	assert.NoError(t, legacy.DeleteGrant(ctx, tenant, &milvuspb.RoleEntity{Name: "role1"}))
+
+	// new single-txn path.
+	assert.NoError(t, composite.Update(ctx, 0,
+		metastore.DropRoleGrants(tenant, "role1"),
+		metastore.DropRole(tenant, "role1")))
+
+	got := dumpKV(t, compositeKV)
+	assert.Equal(t, dumpKV(t, legacyKV), got)
+
+	// all four key classes of role1 are gone.
+	assert.NotContains(t, got, RolePrefix+"/role1")
+	assert.NotContains(t, got, RoleMappingPrefix+"/user1/role1")
+	assert.NotContains(t, got, RoleMappingPrefix+"/user2/role1")
+	for k := range got {
+		assert.False(t, strings.HasPrefix(k, funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, "role1")), k)
+		for _, id := range granteeIDs {
+			assert.False(t, strings.HasPrefix(k, funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, id)), k)
+		}
+	}
+	// canaries of role10 survive.
+	assert.Contains(t, got, RolePrefix+"/role10")
+	assert.Contains(t, got, RoleMappingPrefix+"/user1/role10")
+	has, err := compositeKV.HasPrefix(ctx, funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, "role10"))
+	assert.NoError(t, err)
+	assert.True(t, has)
+}
+
+// writeRecordingKV records every write-path TxnKV call so a test can assert
+// the composite drop-role issues exactly one transaction.
+type writeRecordingKV struct {
+	*memkv.MemoryKV
+	calls          []string
+	removals       []string
+	prefixRemovals []string
+}
+
+func (w *writeRecordingKV) Save(ctx context.Context, key, value string) error {
+	w.calls = append(w.calls, "Save")
+	return w.MemoryKV.Save(ctx, key, value)
+}
+
+func (w *writeRecordingKV) Remove(ctx context.Context, key string) error {
+	w.calls = append(w.calls, "Remove")
+	return w.MemoryKV.Remove(ctx, key)
+}
+
+func (w *writeRecordingKV) RemoveWithPrefix(ctx context.Context, key string) error {
+	w.calls = append(w.calls, "RemoveWithPrefix")
+	return w.MemoryKV.RemoveWithPrefix(ctx, key)
+}
+
+func (w *writeRecordingKV) MultiSave(ctx context.Context, kvs map[string]string) error {
+	w.calls = append(w.calls, "MultiSave")
+	return w.MemoryKV.MultiSave(ctx, kvs)
+}
+
+func (w *writeRecordingKV) MultiRemove(ctx context.Context, keys []string) error {
+	w.calls = append(w.calls, "MultiRemove")
+	return w.MemoryKV.MultiRemove(ctx, keys)
+}
+
+func (w *writeRecordingKV) MultiSaveAndRemove(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	w.calls = append(w.calls, "MultiSaveAndRemove")
+	return w.MemoryKV.MultiSaveAndRemove(ctx, saves, removals, preds...)
+}
+
+func (w *writeRecordingKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	w.calls = append(w.calls, "MultiSaveAndRemoveWithPrefix")
+	return w.MemoryKV.MultiSaveAndRemoveWithPrefix(ctx, saves, removals, preds...)
+}
+
+func (w *writeRecordingKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	w.calls = append(w.calls, "MultiSaveAndRemoveMixed")
+	w.removals = removals
+	w.prefixRemovals = prefixRemovals
+	return w.MemoryKV.MultiSaveAndRemoveMixed(ctx, saves, removals, prefixRemovals, preds...)
+}
+
+// TestCatalog_Update_DropRoleWithGrants_SingleTxn proves the whole removal is
+// one MultiSaveAndRemoveMixed transaction carrying the role record and the
+// mappings as EXACT removals and the grant subtrees as PREFIX removals.
+func TestCatalog_Update_DropRoleWithGrants_SingleTxn(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+	mk := memkv.NewMemoryKV()
+	seedDropRoleRBAC(t, NewCatalog(mk))
+
+	_, granteeIDs, err := mk.LoadWithPrefix(ctx, funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, "role1"))
+	assert.NoError(t, err)
+	assert.Len(t, granteeIDs, 2)
+
+	rec := &writeRecordingKV{MemoryKV: mk}
+	c := NewCatalog(rec)
+	assert.NoError(t, c.Update(ctx, 0,
+		metastore.DropRoleGrants(tenant, "role1"),
+		metastore.DropRole(tenant, "role1")))
+
+	assert.Equal(t, []string{"MultiSaveAndRemoveMixed"}, rec.calls)
+	assert.ElementsMatch(t, []string{
+		RolePrefix + "/role1",
+		RoleMappingPrefix + "/user1/role1",
+		RoleMappingPrefix + "/user2/role1",
+	}, rec.removals)
+	wantPrefixes := []string{funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, "role1")}
+	for _, id := range granteeIDs {
+		wantPrefixes = append(wantPrefixes, funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, id))
+	}
+	assert.ElementsMatch(t, wantPrefixes, rec.prefixRemovals)
+}
+
+// flakyMixedKV fails the first MultiSaveAndRemoveMixed to simulate a crash of
+// the atomic commit.
+type flakyMixedKV struct {
+	*memkv.MemoryKV
+	failures int
+}
+
+func (f *flakyMixedKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	if f.failures > 0 {
+		f.failures--
+		return errors.New("injected crash")
+	}
+	return f.MemoryKV.MultiSaveAndRemoveMixed(ctx, saves, removals, prefixRemovals, preds...)
+}
+
+// TestCatalog_Update_DropRoleWithGrants_AtomicCrashRetry: a failed atomic
+// commit must leave the store untouched (no partial removal, no orphaned
+// grants), and retrying the same composite drop must converge to exactly the
+// legacy two-call end state.
+func TestCatalog_Update_DropRoleWithGrants_AtomicCrashRetry(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+
+	legacyKV := memkv.NewMemoryKV()
+	legacy := NewCatalog(legacyKV)
+	seedDropRoleRBAC(t, legacy)
+	assert.NoError(t, legacy.DropRole(ctx, tenant, "role1"))
+	assert.NoError(t, legacy.DeleteGrant(ctx, tenant, &milvuspb.RoleEntity{Name: "role1"}))
+
+	fk := &flakyMixedKV{MemoryKV: memkv.NewMemoryKV(), failures: 1}
+	seedDropRoleRBAC(t, NewCatalog(fk.MemoryKV))
+	before := dumpKV(t, fk.MemoryKV)
+
+	c := NewCatalog(fk)
+	drop := func() error {
+		return c.Update(ctx, 0,
+			metastore.DropRoleGrants(tenant, "role1"),
+			metastore.DropRole(tenant, "role1"))
+	}
+	assert.Error(t, drop())
+	// atomic: the failed commit applied nothing.
+	assert.Equal(t, before, dumpKV(t, fk.MemoryKV))
+
+	assert.NoError(t, drop())
+	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, fk.MemoryKV))
+}
+
+// smallTxnFlakyPrefixKV shrinks MaxTxnOps so the composite takes the chunked
+// fallback and fails the first prefix-removal batch, simulating a crash
+// mid-fallback before the commit marker.
+type smallTxnFlakyPrefixKV struct {
+	*memkv.MemoryKV
+	failures int
+}
+
+func (f *smallTxnFlakyPrefixKV) MaxTxnOps() int { return 2 }
+
+func (f *smallTxnFlakyPrefixKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	if f.failures > 0 {
+		f.failures--
+		return errors.New("injected crash")
+	}
+	return f.MemoryKV.MultiSaveAndRemoveWithPrefix(ctx, saves, removals, preds...)
+}
+
+// secondChunkCrashKV shrinks MaxTxnOps so the prefix removals split into two
+// chunks and fails only the second one, simulating a crash between chunks.
+type secondChunkCrashKV struct {
+	*memkv.MemoryKV
+	prefixCalls int
+	failAtCall  int
+}
+
+func (f *secondChunkCrashKV) MaxTxnOps() int { return 2 }
+
+func (f *secondChunkCrashKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	f.prefixCalls++
+	if f.prefixCalls == f.failAtCall {
+		return errors.New("injected crash")
+	}
+	return f.MemoryKV.MultiSaveAndRemoveWithPrefix(ctx, saves, removals, preds...)
+}
+
+// TestCatalog_Update_DropRoleWithGrants_SecondPrefixChunkCrashRetry: on the
+// chunked fallback path the grantee-privileges subtree is the only index from
+// which a retry can rediscover the grantee-id subtrees. A crash between prefix
+// chunks must therefore leave that subtree intact so the retry converges to
+// the legacy end state instead of permanently orphaning grantee-id subtrees
+// (which a same-name role re-grant would silently resurrect).
+func TestCatalog_Update_DropRoleWithGrants_SecondPrefixChunkCrashRetry(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+
+	legacyKV := memkv.NewMemoryKV()
+	legacy := NewCatalog(legacyKV)
+	seedDropRoleRBAC(t, legacy)
+	assert.NoError(t, legacy.DropRole(ctx, tenant, "role1"))
+	assert.NoError(t, legacy.DeleteGrant(ctx, tenant, &milvuspb.RoleEntity{Name: "role1"}))
+
+	fk := &secondChunkCrashKV{MemoryKV: memkv.NewMemoryKV(), failAtCall: 2}
+	seedDropRoleRBAC(t, NewCatalog(fk.MemoryKV))
+
+	c := NewCatalog(fk)
+	drop := func() error {
+		return c.Update(ctx, 0,
+			metastore.DropRoleGrants(tenant, "role1"),
+			metastore.DropRole(tenant, "role1"))
+	}
+	assert.Error(t, drop())
+	// the rediscovery index must have survived the crash.
+	keys, _, err := fk.MemoryKV.LoadWithPrefix(ctx, funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, "role1"))
+	assert.NoError(t, err)
+	assert.NotEmpty(t, keys)
+
+	assert.NoError(t, drop())
+	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, fk.MemoryKV))
+}
+
+// TestCatalog_Update_DropRoleWithGrants_FallbackCrashRetry: on the chunked
+// fallback path a crash before the commit marker must leave the role record
+// visible (so the drop is observably incomplete and retryable, never a
+// role-gone-grants-orphaned state), and the retry must converge to the legacy
+// end state.
+func TestCatalog_Update_DropRoleWithGrants_FallbackCrashRetry(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+
+	legacyKV := memkv.NewMemoryKV()
+	legacy := NewCatalog(legacyKV)
+	seedDropRoleRBAC(t, legacy)
+	assert.NoError(t, legacy.DropRole(ctx, tenant, "role1"))
+	assert.NoError(t, legacy.DeleteGrant(ctx, tenant, &milvuspb.RoleEntity{Name: "role1"}))
+
+	fk := &smallTxnFlakyPrefixKV{MemoryKV: memkv.NewMemoryKV(), failures: 1}
+	seedDropRoleRBAC(t, NewCatalog(fk.MemoryKV))
+
+	c := NewCatalog(fk)
+	drop := func() error {
+		return c.Update(ctx, 0,
+			metastore.DropRoleGrants(tenant, "role1"),
+			metastore.DropRole(tenant, "role1"))
+	}
+	assert.Error(t, drop())
+	// crash-safety: the role record (commit marker) must still be visible.
+	has, err := fk.Has(ctx, RolePrefix+"/role1")
+	assert.NoError(t, err)
+	assert.True(t, has)
+
+	assert.NoError(t, drop())
+	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, fk.MemoryKV))
 }

--- a/internal/metastore/kv/rootcoord/update_test.go
+++ b/internal/metastore/kv/rootcoord/update_test.go
@@ -432,6 +432,314 @@ func TestCatalog_Update_DropRoleWithGrants_SecondPrefixChunkCrashRetry(t *testin
 	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, fk.MemoryKV))
 }
 
+// seedRenameGrants populates a catalog with the fixture used by the
+// rename-with-grants tests: coll1 in db1 (the rename target, returned) with
+// two grants from different roles, plus three canaries that an exact-match
+// migration must leave untouched: a name-prefix sibling (coll1_backup), the
+// same collection name in another database, and a Global grant.
+func seedRenameGrants(t *testing.T, c metastore.RootCoordCatalog) *model.Collection {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+	for _, role := range []string{"role1", "role2"} {
+		assert.NoError(t, c.CreateRole(ctx, tenant, &milvuspb.RoleEntity{Name: role}))
+	}
+	grant := func(role, objType, dbName, objName, priv string) {
+		assert.NoError(t, c.AlterGrant(ctx, tenant, &milvuspb.GrantEntity{
+			Role:       &milvuspb.RoleEntity{Name: role},
+			Object:     &milvuspb.ObjectEntity{Name: objType},
+			ObjectName: objName,
+			DbName:     dbName,
+			Grantor: &milvuspb.GrantorEntity{
+				User:      &milvuspb.UserEntity{Name: "root"},
+				Privilege: &milvuspb.PrivilegeEntity{Name: priv},
+			},
+		}, milvuspb.OperatePrivilegeType_Grant))
+	}
+	grant("role1", "Collection", "db1", "coll1", "Insert")
+	grant("role2", "Collection", "db1", "coll1", "Delete")
+	// canaries.
+	grant("role1", "Collection", "db1", "coll1_backup", "Insert")
+	grant("role1", "Collection", "db2", "coll1", "Insert")
+	grant("role1", "Global", "db1", "*", "CreateCollection")
+
+	coll := &model.Collection{
+		CollectionID: 1,
+		DBID:         100,
+		Name:         "coll1",
+		DBName:       "db1",
+		State:        pb.CollectionState_CollectionCreated,
+		Partitions:   []*model.Partition{{PartitionID: 10}},
+		Fields:       []*model.Field{{FieldID: 101}},
+	}
+	assert.NoError(t, c.CreateCollection(ctx, coll, 0))
+	return coll
+}
+
+func renamedColl(coll *model.Collection, newDBID int64, newDBName, newName string) *model.Collection {
+	newColl := coll.Clone()
+	newColl.DBID = newDBID
+	newColl.DBName = newDBName
+	newColl.Name = newName
+	newColl.UpdateTimestamp = 100
+	return newColl
+}
+
+// TestCatalog_Update_RenameCollectionWithGrants_MatchesLegacyBytes proves the
+// new single-txn rename path leaves byte-for-byte the same store state as
+// today's multi-call path (Catalog.AlterCollection/AlterCollectionDB +
+// MigrateGrantCollectionName): record rewritten, grantee and grantee-id keys
+// rekeyed to the new name, canaries of other objects untouched.
+func TestCatalog_Update_RenameCollectionWithGrants_MatchesLegacyBytes(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+
+	t.Run("same db", func(t *testing.T) {
+		legacyKV := memkv.NewMemoryKV()
+		compositeKV := memkv.NewMemoryKV()
+		legacy := NewCatalog(legacyKV)
+		composite := NewCatalog(compositeKV)
+		oldColl := seedRenameGrants(t, legacy)
+		seedRenameGrants(t, composite)
+		newColl := renamedColl(oldColl, oldColl.DBID, "db1", "coll1_renamed")
+
+		// today's two-call path.
+		assert.NoError(t, legacy.AlterCollection(ctx, oldColl, newColl, metastore.MODIFY, newColl.UpdateTimestamp, false))
+		assert.NoError(t, legacy.MigrateGrantCollectionName(ctx, tenant, "db1", "coll1", "db1", "coll1_renamed"))
+
+		// new single-txn path.
+		assert.NoError(t, composite.Update(ctx, newColl.UpdateTimestamp,
+			metastore.MigrateCollectionGrants(tenant, "db1", "coll1", "db1", "coll1_renamed"),
+			metastore.RenameCollection(oldColl, newColl, false)))
+
+		got := dumpKV(t, compositeKV)
+		assert.Equal(t, dumpKV(t, legacyKV), got)
+		assert.Contains(t, got, GranteePrefix+"/role1/Collection/db1.coll1_renamed")
+		assert.Contains(t, got, GranteePrefix+"/role2/Collection/db1.coll1_renamed")
+		assert.NotContains(t, got, GranteePrefix+"/role1/Collection/db1.coll1")
+		assert.NotContains(t, got, GranteePrefix+"/role2/Collection/db1.coll1")
+		// canaries survive.
+		assert.Contains(t, got, GranteePrefix+"/role1/Collection/db1.coll1_backup")
+		assert.Contains(t, got, GranteePrefix+"/role1/Collection/db2.coll1")
+		assert.Contains(t, got, GranteePrefix+"/role1/Global/db1.*")
+	})
+
+	t.Run("cross db", func(t *testing.T) {
+		legacyKV := memkv.NewMemoryKV()
+		compositeKV := memkv.NewMemoryKV()
+		legacy := NewCatalog(legacyKV)
+		composite := NewCatalog(compositeKV)
+		oldColl := seedRenameGrants(t, legacy)
+		seedRenameGrants(t, composite)
+		newColl := renamedColl(oldColl, 200, "db2", "coll1_renamed")
+
+		// today's two-call path.
+		assert.NoError(t, legacy.AlterCollectionDB(ctx, oldColl, newColl, newColl.UpdateTimestamp))
+		assert.NoError(t, legacy.MigrateGrantCollectionName(ctx, tenant, "db1", "coll1", "db2", "coll1_renamed"))
+
+		// new single-txn path.
+		assert.NoError(t, composite.Update(ctx, newColl.UpdateTimestamp,
+			metastore.MigrateCollectionGrants(tenant, "db1", "coll1", "db2", "coll1_renamed"),
+			metastore.RenameCollection(oldColl, newColl, false)))
+
+		got := dumpKV(t, compositeKV)
+		assert.Equal(t, dumpKV(t, legacyKV), got)
+		// the record moved to the new database.
+		assert.Contains(t, got, BuildCollectionKey(200, oldColl.CollectionID))
+		assert.NotContains(t, got, BuildCollectionKey(100, oldColl.CollectionID))
+		assert.Contains(t, got, GranteePrefix+"/role1/Collection/db2.coll1_renamed")
+		assert.NotContains(t, got, GranteePrefix+"/role1/Collection/db1.coll1")
+		// canaries survive.
+		assert.Contains(t, got, GranteePrefix+"/role1/Collection/db1.coll1_backup")
+		assert.Contains(t, got, GranteePrefix+"/role1/Collection/db2.coll1")
+	})
+}
+
+// TestCatalog_Update_RenameCollectionWithGrants_SingleTxn proves the whole
+// rename - record rewrite plus grant migration - is one MultiSaveAndRemove
+// transaction.
+func TestCatalog_Update_RenameCollectionWithGrants_SingleTxn(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+	mk := memkv.NewMemoryKV()
+	oldColl := seedRenameGrants(t, NewCatalog(mk))
+	newColl := renamedColl(oldColl, oldColl.DBID, "db1", "coll1_renamed")
+
+	rec := &writeRecordingKV{MemoryKV: mk}
+	c := NewCatalog(rec)
+	assert.NoError(t, c.Update(ctx, 0,
+		metastore.MigrateCollectionGrants(tenant, "db1", "coll1", "db1", "coll1_renamed"),
+		metastore.RenameCollection(oldColl, newColl, false)))
+	assert.Equal(t, []string{"MultiSaveAndRemove"}, rec.calls)
+}
+
+// flakySaveRemoveKV fails the first MultiSaveAndRemove to simulate a crash of
+// the atomic commit.
+type flakySaveRemoveKV struct {
+	*memkv.MemoryKV
+	failures int
+}
+
+func (f *flakySaveRemoveKV) MultiSaveAndRemove(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	if f.failures > 0 {
+		f.failures--
+		return errors.New("injected crash")
+	}
+	return f.MemoryKV.MultiSaveAndRemove(ctx, saves, removals, preds...)
+}
+
+// TestCatalog_Update_RenameCollectionWithGrants_AtomicCrashRetry: a failed
+// atomic commit must leave the store untouched - collection record, database
+// pointer and grant keys all still old - and retrying the same composite
+// rename must converge to exactly the legacy multi-call end state.
+func TestCatalog_Update_RenameCollectionWithGrants_AtomicCrashRetry(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+
+	legacyKV := memkv.NewMemoryKV()
+	legacy := NewCatalog(legacyKV)
+	oldColl := seedRenameGrants(t, legacy)
+	newColl := renamedColl(oldColl, 200, "db2", "coll1_renamed")
+	assert.NoError(t, legacy.AlterCollectionDB(ctx, oldColl, newColl, newColl.UpdateTimestamp))
+	assert.NoError(t, legacy.MigrateGrantCollectionName(ctx, tenant, "db1", "coll1", "db2", "coll1_renamed"))
+
+	fk := &flakySaveRemoveKV{MemoryKV: memkv.NewMemoryKV(), failures: 1}
+	seedRenameGrants(t, NewCatalog(fk.MemoryKV))
+	before := dumpKV(t, fk.MemoryKV)
+
+	c := NewCatalog(fk)
+	rename := func() error {
+		return c.Update(ctx, 0,
+			metastore.MigrateCollectionGrants(tenant, "db1", "coll1", "db2", "coll1_renamed"),
+			metastore.RenameCollection(oldColl, newColl, false))
+	}
+	assert.Error(t, rename())
+	// atomic: the failed commit applied nothing, everything is all-old.
+	assert.Equal(t, before, dumpKV(t, fk.MemoryKV))
+
+	assert.NoError(t, rename())
+	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, fk.MemoryKV))
+}
+
+// commitCrashKV shrinks MaxTxnOps so the composite takes the chunked fallback
+// and fails the final guarded commit txn - the only MultiSaveAndRemove call
+// carrying saves - simulating a crash right before the visibility marker
+// lands.
+type commitCrashKV struct {
+	*memkv.MemoryKV
+	failures int
+}
+
+func (f *commitCrashKV) MaxTxnOps() int { return 2 }
+
+func (f *commitCrashKV) MultiSaveAndRemove(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	if len(saves) > 0 && f.failures > 0 {
+		f.failures--
+		return errors.New("injected crash")
+	}
+	return f.MemoryKV.MultiSaveAndRemove(ctx, saves, removals, preds...)
+}
+
+// TestCatalog_Update_RenameCollectionWithGrants_FallbackCommitCrashRetry: on
+// the chunked fallback path the collection record is the visibility marker of
+// the rename. A crash before the final commit txn must leave the record (and
+// for a database move, the database pointer) all-old - never a renamed record
+// with grants half-migrated - and the retry must converge to the legacy end
+// state.
+func TestCatalog_Update_RenameCollectionWithGrants_FallbackCommitCrashRetry(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+
+	legacyKV := memkv.NewMemoryKV()
+	legacy := NewCatalog(legacyKV)
+	oldColl := seedRenameGrants(t, legacy)
+	newColl := renamedColl(oldColl, 200, "db2", "coll1_renamed")
+	assert.NoError(t, legacy.AlterCollectionDB(ctx, oldColl, newColl, newColl.UpdateTimestamp))
+	assert.NoError(t, legacy.MigrateGrantCollectionName(ctx, tenant, "db1", "coll1", "db2", "coll1_renamed"))
+
+	fk := &commitCrashKV{MemoryKV: memkv.NewMemoryKV(), failures: 1}
+	seedRenameGrants(t, NewCatalog(fk.MemoryKV))
+	before := dumpKV(t, fk.MemoryKV)
+
+	c := NewCatalog(fk)
+	rename := func() error {
+		return c.Update(ctx, 0,
+			metastore.MigrateCollectionGrants(tenant, "db1", "coll1", "db2", "coll1_renamed"),
+			metastore.RenameCollection(oldColl, newColl, false))
+	}
+	assert.Error(t, rename())
+	// crash-safety: the record still sits under the old database with the old
+	// bytes, and nothing was published under the new database.
+	got := dumpKV(t, fk.MemoryKV)
+	oldCollKey := BuildCollectionKey(100, oldColl.CollectionID)
+	assert.Equal(t, before[oldCollKey], got[oldCollKey])
+	assert.NotContains(t, got, BuildCollectionKey(200, oldColl.CollectionID))
+
+	assert.NoError(t, rename())
+	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, fk.MemoryKV))
+}
+
+// granteeChunkCrashKV shrinks MaxTxnOps so the exact-removal run splits into
+// chunks and fails the second one - the chunk carrying the old grantee keys -
+// simulating a crash after the grantee-id removals but before the rediscovery
+// index is gone.
+type granteeChunkCrashKV struct {
+	*memkv.MemoryKV
+	delCalls   int
+	failAtCall int
+}
+
+func (f *granteeChunkCrashKV) MaxTxnOps() int { return 2 }
+
+func (f *granteeChunkCrashKV) MultiSaveAndRemove(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	if len(saves) == 0 {
+		f.delCalls++
+		if f.delCalls == f.failAtCall {
+			return errors.New("injected crash")
+		}
+	}
+	return f.MemoryKV.MultiSaveAndRemove(ctx, saves, removals, preds...)
+}
+
+// TestCatalog_Update_RenameCollectionWithGrants_GranteeIndexChunkCrashRetry:
+// on the chunked fallback path the old grantee-privileges keys are the only
+// index from which a retry can recompute the migration's rewrite set (and
+// reach the grantee-id subtrees via their values), so they must be removed
+// last. A crash between removal chunks must leave them intact so the retry
+// converges to the legacy end state instead of stranding half-renamed grants.
+func TestCatalog_Update_RenameCollectionWithGrants_GranteeIndexChunkCrashRetry(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+
+	legacyKV := memkv.NewMemoryKV()
+	legacy := NewCatalog(legacyKV)
+	oldColl := seedRenameGrants(t, legacy)
+	newColl := renamedColl(oldColl, oldColl.DBID, "db1", "coll1_renamed")
+	assert.NoError(t, legacy.AlterCollection(ctx, oldColl, newColl, metastore.MODIFY, newColl.UpdateTimestamp, false))
+	assert.NoError(t, legacy.MigrateGrantCollectionName(ctx, tenant, "db1", "coll1", "db1", "coll1_renamed"))
+
+	fk := &granteeChunkCrashKV{MemoryKV: memkv.NewMemoryKV(), failAtCall: 2}
+	seedRenameGrants(t, NewCatalog(fk.MemoryKV))
+	before := dumpKV(t, fk.MemoryKV)
+
+	c := NewCatalog(fk)
+	rename := func() error {
+		return c.Update(ctx, 0,
+			metastore.MigrateCollectionGrants(tenant, "db1", "coll1", "db1", "coll1_renamed"),
+			metastore.RenameCollection(oldColl, newColl, false))
+	}
+	assert.Error(t, rename())
+	got := dumpKV(t, fk.MemoryKV)
+	// the rediscovery index must have survived the crash.
+	assert.Contains(t, got, GranteePrefix+"/role1/Collection/db1.coll1")
+	assert.Contains(t, got, GranteePrefix+"/role2/Collection/db1.coll1")
+	// the visibility marker has not flipped: record bytes still old.
+	collKey := BuildCollectionKey(oldColl.DBID, oldColl.CollectionID)
+	assert.Equal(t, before[collKey], got[collKey])
+
+	assert.NoError(t, rename())
+	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, fk.MemoryKV))
+}
+
 // TestCatalog_Update_DropRoleWithGrants_FallbackCrashRetry: on the chunked
 // fallback path a crash before the commit marker must leave the role record
 // visible (so the drop is observably incomplete and retryable, never a

--- a/internal/metastore/kv/rootcoord/update_test.go
+++ b/internal/metastore/kv/rootcoord/update_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 	pb "github.com/milvus-io/milvus/pkg/v3/proto/etcdpb"
 	"github.com/milvus-io/milvus/pkg/v3/util"
+	"github.com/milvus-io/milvus/pkg/v3/util/crypto"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
@@ -1015,4 +1016,453 @@ func TestCatalog_Update_DropRoleWithGrants_FallbackCrashRetry(t *testing.T) {
 
 	assert.NoError(t, drop())
 	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, fk.MemoryKV))
+}
+
+// grantEntity builds one GrantEntity for direct AlterGrant calls.
+func grantEntity(role, objType, dbName, objName, priv, user string) *milvuspb.GrantEntity {
+	return &milvuspb.GrantEntity{
+		Role:       &milvuspb.RoleEntity{Name: role},
+		Object:     &milvuspb.ObjectEntity{Name: objType},
+		ObjectName: objName,
+		DbName:     dbName,
+		Grantor: &milvuspb.GrantorEntity{
+			User:      &milvuspb.UserEntity{Name: user},
+			Privilege: &milvuspb.PrivilegeEntity{Name: priv},
+		},
+	}
+}
+
+// TestCatalog_AlterGrant_Grant_SingleTxnAndBytes proves a grant - the grantee
+// leaf allocation plus the grantee-id leaf - lands in ONE transaction (today
+// it is two independent Saves with a dangling-leaf window in between) and
+// writes byte-for-byte the same kvs as today's multi-step path.
+func TestCatalog_AlterGrant_Grant_SingleTxnAndBytes(t *testing.T) {
+	ctx := context.TODO()
+	rec := &writeRecordingKV{MemoryKV: memkv.NewMemoryKV()}
+	c := NewCatalog(rec)
+
+	assert.NoError(t, c.AlterGrant(ctx, util.DefaultTenant,
+		grantEntity("role1", "Collection", "db1", "coll1", "PrivilegeInsert", "root"),
+		milvuspb.OperatePrivilegeType_Grant))
+	assert.Equal(t, []string{"MultiSaveAndRemove"}, rec.calls)
+
+	granteeKey := GranteePrefix + "/role1/Collection/db1.coll1"
+	id := crypto.GranteeID(granteeKey)
+	assert.Equal(t, map[string]string{
+		granteeKey:                               id,
+		buildGranteeIDKey(id, "PrivilegeInsert"): "root",
+	}, dumpKV(t, rec.MemoryKV))
+
+	// a second privilege on the existing leaf is again one txn adding exactly
+	// one grantee-id leaf.
+	rec.calls = nil
+	assert.NoError(t, c.AlterGrant(ctx, util.DefaultTenant,
+		grantEntity("role1", "Collection", "db1", "coll1", "PrivilegeQuery", "root"),
+		milvuspb.OperatePrivilegeType_Grant))
+	assert.Equal(t, []string{"MultiSaveAndRemove"}, rec.calls)
+	assert.Equal(t, map[string]string{
+		granteeKey:                               id,
+		buildGranteeIDKey(id, "PrivilegeInsert"): "root",
+		buildGranteeIDKey(id, "PrivilegeQuery"):  "root",
+	}, dumpKV(t, rec.MemoryKV))
+}
+
+// TestCatalog_AlterGrant_Revoke_SingleTxnAndBytes proves a revoke commits
+// through the same composite call and leaves byte-for-byte today's end state:
+// the revoked grantee-id leaf gone, the grantee leaf and sibling privileges
+// untouched.
+func TestCatalog_AlterGrant_Revoke_SingleTxnAndBytes(t *testing.T) {
+	ctx := context.TODO()
+	mk := memkv.NewMemoryKV()
+	c0 := NewCatalog(mk)
+	assert.NoError(t, c0.AlterGrant(ctx, util.DefaultTenant,
+		grantEntity("role1", "Collection", "db1", "coll1", "PrivilegeInsert", "root"),
+		milvuspb.OperatePrivilegeType_Grant))
+	assert.NoError(t, c0.AlterGrant(ctx, util.DefaultTenant,
+		grantEntity("role1", "Collection", "db1", "coll1", "PrivilegeQuery", "root"),
+		milvuspb.OperatePrivilegeType_Grant))
+
+	rec := &writeRecordingKV{MemoryKV: mk}
+	c := NewCatalog(rec)
+	assert.NoError(t, c.AlterGrant(ctx, util.DefaultTenant,
+		grantEntity("role1", "Collection", "db1", "coll1", "PrivilegeInsert", "root"),
+		milvuspb.OperatePrivilegeType_Revoke))
+	assert.Equal(t, []string{"MultiSaveAndRemove"}, rec.calls)
+
+	granteeKey := GranteePrefix + "/role1/Collection/db1.coll1"
+	id := crypto.GranteeID(granteeKey)
+	assert.Equal(t, map[string]string{
+		granteeKey:                              id,
+		buildGranteeIDKey(id, "PrivilegeQuery"): "root",
+	}, dumpKV(t, mk))
+}
+
+// seedLegacyGrant writes the pre-refactor grant layout directly: the grantee
+// leaf holds a 16-char legacy id and the grantee-id leaf hangs off that id.
+func seedLegacyGrant(t *testing.T, mk *memkv.MemoryKV, granteeKey, priv, user string) string {
+	legacyID := crypto.MD5(granteeKey)
+	assert.Len(t, legacyID, 16)
+	assert.NoError(t, mk.MultiSave(context.TODO(), map[string]string{
+		granteeKey:                        legacyID,
+		buildGranteeIDKey(legacyID, priv): user,
+	}))
+	return legacyID
+}
+
+// TestCatalog_AlterGrant_LegacyIDMigration_SingleTxnAndBytes proves the
+// legacy-grantee-id migration and the grant (or revoke) it precedes land in
+// ONE transaction - today the migration commits first and the grant write is
+// a separate call, leaving a window where the subtree has moved but the new
+// privilege is lost - with byte-for-byte today's end state.
+func TestCatalog_AlterGrant_LegacyIDMigration_SingleTxnAndBytes(t *testing.T) {
+	ctx := context.TODO()
+	granteeKey := GranteePrefix + "/role1/Collection/db1.coll1"
+	newID := crypto.GranteeID(granteeKey)
+
+	t.Run("grant", func(t *testing.T) {
+		mk := memkv.NewMemoryKV()
+		seedLegacyGrant(t, mk, granteeKey, "PrivilegeLoad", "legacy-user")
+		rec := &writeRecordingKV{MemoryKV: mk}
+		c := NewCatalog(rec)
+		assert.NoError(t, c.AlterGrant(ctx, util.DefaultTenant,
+			grantEntity("role1", "Collection", "db1", "coll1", "PrivilegeInsert", "root"),
+			milvuspb.OperatePrivilegeType_Grant))
+		assert.Equal(t, []string{"MultiSaveAndRemove"}, rec.calls)
+		assert.Equal(t, map[string]string{
+			granteeKey: newID,
+			buildGranteeIDKey(newID, "PrivilegeLoad"):   "legacy-user",
+			buildGranteeIDKey(newID, "PrivilegeInsert"): "root",
+		}, dumpKV(t, mk))
+	})
+
+	t.Run("revoke", func(t *testing.T) {
+		mk := memkv.NewMemoryKV()
+		seedLegacyGrant(t, mk, granteeKey, "PrivilegeLoad", "legacy-user")
+		rec := &writeRecordingKV{MemoryKV: mk}
+		c := NewCatalog(rec)
+		assert.NoError(t, c.AlterGrant(ctx, util.DefaultTenant,
+			grantEntity("role1", "Collection", "db1", "coll1", "PrivilegeLoad", "legacy-user"),
+			milvuspb.OperatePrivilegeType_Revoke))
+		assert.Equal(t, []string{"MultiSaveAndRemove"}, rec.calls)
+		// the leaf is rewritten to the new id, the revoked privilege never
+		// reappears under it, and the old subtree is gone.
+		assert.Equal(t, map[string]string{granteeKey: newID}, dumpKV(t, mk))
+	})
+}
+
+// grantWriteCrashKV fails any write that touches targetKey (in its saves or
+// removals), simulating a crash of the write carrying the grantee-id leaf.
+type grantWriteCrashKV struct {
+	*memkv.MemoryKV
+	targetKey string
+	failures  int
+}
+
+func (f *grantWriteCrashKV) touches(saves map[string]string, removals []string) bool {
+	if _, ok := saves[f.targetKey]; ok {
+		return true
+	}
+	for _, k := range removals {
+		if k == f.targetKey {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *grantWriteCrashKV) Save(ctx context.Context, key, value string) error {
+	if f.failures > 0 && key == f.targetKey {
+		f.failures--
+		return errors.New("injected crash")
+	}
+	return f.MemoryKV.Save(ctx, key, value)
+}
+
+func (f *grantWriteCrashKV) Remove(ctx context.Context, key string) error {
+	if f.failures > 0 && key == f.targetKey {
+		f.failures--
+		return errors.New("injected crash")
+	}
+	return f.MemoryKV.Remove(ctx, key)
+}
+
+func (f *grantWriteCrashKV) MultiSaveAndRemove(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	if f.failures > 0 && f.touches(saves, removals) {
+		f.failures--
+		return errors.New("injected crash")
+	}
+	return f.MemoryKV.MultiSaveAndRemove(ctx, saves, removals, preds...)
+}
+
+// TestCatalog_AlterGrant_GrantCrashAtomicRetry: failing the write that carries
+// the grantee-id leaf must leave the store untouched - today's two-step path
+// strands the grantee leaf without any grantee-id leaf, a grant that lists as
+// nothing - and a retry must land both kvs.
+func TestCatalog_AlterGrant_GrantCrashAtomicRetry(t *testing.T) {
+	ctx := context.TODO()
+	granteeKey := GranteePrefix + "/role1/Collection/db1.coll1"
+	id := crypto.GranteeID(granteeKey)
+	k := buildGranteeIDKey(id, "PrivilegeInsert")
+
+	fk := &grantWriteCrashKV{MemoryKV: memkv.NewMemoryKV(), targetKey: k, failures: 1}
+	c := NewCatalog(fk)
+	grant := func() error {
+		return c.AlterGrant(ctx, util.DefaultTenant,
+			grantEntity("role1", "Collection", "db1", "coll1", "PrivilegeInsert", "root"),
+			milvuspb.OperatePrivilegeType_Grant)
+	}
+	assert.Error(t, grant())
+	// atomic: the failed commit applied nothing, no dangling grantee leaf.
+	assert.Empty(t, dumpKV(t, fk.MemoryKV))
+
+	assert.NoError(t, grant())
+	assert.Equal(t, map[string]string{granteeKey: id, k: "root"}, dumpKV(t, fk.MemoryKV))
+}
+
+// TestCatalog_AlterGrant_MigrationCrashAtomicRetry: failing the write that
+// carries the new privilege's grantee-id leaf while a legacy-id migration is
+// staged must not publish the migration alone - today the migration txn lands
+// first and the store is left half-mutated when the grant write dies - and a
+// retry must converge to the fully migrated + granted end state.
+func TestCatalog_AlterGrant_MigrationCrashAtomicRetry(t *testing.T) {
+	ctx := context.TODO()
+	granteeKey := GranteePrefix + "/role1/Collection/db1.coll1"
+	newID := crypto.GranteeID(granteeKey)
+
+	fk := &grantWriteCrashKV{
+		MemoryKV:  memkv.NewMemoryKV(),
+		targetKey: buildGranteeIDKey(newID, "PrivilegeInsert"),
+		failures:  1,
+	}
+	seedLegacyGrant(t, fk.MemoryKV, granteeKey, "PrivilegeLoad", "legacy-user")
+	before := dumpKV(t, fk.MemoryKV)
+
+	c := NewCatalog(fk)
+	grant := func() error {
+		return c.AlterGrant(ctx, util.DefaultTenant,
+			grantEntity("role1", "Collection", "db1", "coll1", "PrivilegeInsert", "root"),
+			milvuspb.OperatePrivilegeType_Grant)
+	}
+	assert.Error(t, grant())
+	// atomic: the legacy layout is fully intact, not migrated-but-grantless.
+	assert.Equal(t, before, dumpKV(t, fk.MemoryKV))
+
+	assert.NoError(t, grant())
+	assert.Equal(t, map[string]string{
+		granteeKey: newID,
+		buildGranteeIDKey(newID, "PrivilegeLoad"):   "legacy-user",
+		buildGranteeIDKey(newID, "PrivilegeInsert"): "root",
+	}, dumpKV(t, fk.MemoryKV))
+}
+
+// restoreMeta returns a fresh RBAC backup fixture: two roles, one privilege
+// group, three grants (two sharing one grantee leaf) and two users with role
+// mappings. Fresh per call because RestoreRBAC normalizes privilege names in
+// place.
+func restoreMeta() *milvuspb.RBACMeta {
+	return &milvuspb.RBACMeta{
+		Users: []*milvuspb.UserInfo{
+			{User: "user1", Password: "pw1", Roles: []*milvuspb.RoleEntity{{Name: "role1"}}},
+			{User: "user2", Password: "pw2", Roles: []*milvuspb.RoleEntity{{Name: "role1"}, {Name: "role2"}}},
+		},
+		Roles: []*milvuspb.RoleEntity{{Name: "role1"}, {Name: "role2"}},
+		Grants: []*milvuspb.GrantEntity{
+			grantEntity("role1", "Collection", "db1", "coll1", "Insert", "root"),
+			grantEntity("role1", "Collection", "db1", "coll1", "Query", "root"),
+			grantEntity("role2", "Global", "db1", "*", "CreateCollection", "root"),
+		},
+		PrivilegeGroups: []*milvuspb.PrivilegeGroupInfo{
+			{GroupName: "pg1", Privileges: []*milvuspb.PrivilegeEntity{{Name: "Insert"}}},
+		},
+	}
+}
+
+// legacyRestoreRBAC replays meta with today's per-key calls (the current
+// RestoreRBAC body); the batched RestoreRBAC must land byte-for-byte on this
+// end state.
+func legacyRestoreRBAC(t *testing.T, c metastore.RootCoordCatalog, tenant string, meta *milvuspb.RBACMeta) {
+	ctx := context.TODO()
+	for _, role := range meta.GetRoles() {
+		assert.NoError(t, c.CreateRole(ctx, tenant, role))
+	}
+	for _, group := range meta.GetPrivilegeGroups() {
+		assert.NoError(t, c.SavePrivilegeGroup(ctx, group))
+	}
+	for _, grant := range meta.GetGrants() {
+		privName := grant.GetGrantor().GetPrivilege().GetName()
+		switch {
+		case util.IsAnyWord(privName):
+		case util.IsPrivilegeNameDefined(privName):
+			grant.Grantor.Privilege.Name = util.PrivilegeNameForMetastore(privName)
+		default:
+			grant.Grantor.Privilege.Name = util.PrivilegeGroupNameForMetastore(privName)
+		}
+		assert.NoError(t, c.AlterGrant(ctx, tenant, grant, milvuspb.OperatePrivilegeType_Grant))
+	}
+	for _, user := range meta.GetUsers() {
+		assert.NoError(t, c.AlterCredential(ctx, &model.Credential{
+			Username:          user.GetUser(),
+			EncryptedPassword: user.GetPassword(),
+		}))
+		for _, role := range user.GetRoles() {
+			assert.NoError(t, c.AlterUserRole(ctx, tenant, &milvuspb.UserEntity{Name: user.GetUser()}, role, milvuspb.OperateUserRoleType_AddUserToRole))
+		}
+	}
+}
+
+// batchRecordingKV shrinks MaxTxnOps and records every write call plus the op
+// count of each composite batch.
+type batchRecordingKV struct {
+	*memkv.MemoryKV
+	limit      int
+	calls      []string
+	batchSizes []int
+}
+
+func (b *batchRecordingKV) MaxTxnOps() int { return b.limit }
+
+func (b *batchRecordingKV) Save(ctx context.Context, key, value string) error {
+	b.calls = append(b.calls, "Save")
+	return b.MemoryKV.Save(ctx, key, value)
+}
+
+func (b *batchRecordingKV) Remove(ctx context.Context, key string) error {
+	b.calls = append(b.calls, "Remove")
+	return b.MemoryKV.Remove(ctx, key)
+}
+
+func (b *batchRecordingKV) MultiSave(ctx context.Context, kvs map[string]string) error {
+	b.calls = append(b.calls, "MultiSave")
+	return b.MemoryKV.MultiSave(ctx, kvs)
+}
+
+func (b *batchRecordingKV) MultiSaveAndRemove(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	b.calls = append(b.calls, "MultiSaveAndRemove")
+	b.batchSizes = append(b.batchSizes, len(saves)+len(removals))
+	return b.MemoryKV.MultiSaveAndRemove(ctx, saves, removals, preds...)
+}
+
+// TestCatalog_RestoreRBAC_BatchedMatchesLegacyBytes: the batched restore lands
+// byte-for-byte on the legacy per-key loop's end state, writes only composite
+// batches (never per-key Saves), and keeps every batch within the store's txn
+// op limit.
+func TestCatalog_RestoreRBAC_BatchedMatchesLegacyBytes(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+	legacyKV := memkv.NewMemoryKV()
+	legacyRestoreRBAC(t, NewCatalog(legacyKV), tenant, restoreMeta())
+
+	bk := &batchRecordingKV{MemoryKV: memkv.NewMemoryKV(), limit: 4}
+	c := NewCatalog(bk)
+	assert.NoError(t, c.RestoreRBAC(ctx, tenant, restoreMeta()))
+
+	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, bk.MemoryKV))
+	for _, call := range bk.calls {
+		assert.Equal(t, "MultiSaveAndRemove", call)
+	}
+	// the fixture holds more kvs than one batch: it really batched, and every
+	// batch stayed within the limit.
+	assert.GreaterOrEqual(t, len(bk.batchSizes), 2)
+	for _, n := range bk.batchSizes {
+		assert.LessOrEqual(t, n, bk.limit)
+	}
+}
+
+// restoreBatchCrashKV shrinks MaxTxnOps and fails the Nth composite batch,
+// simulating a restore interrupted between batches.
+type restoreBatchCrashKV struct {
+	*memkv.MemoryKV
+	limit      int
+	calls      int
+	failAtCall int
+}
+
+func (f *restoreBatchCrashKV) MaxTxnOps() int { return f.limit }
+
+func (f *restoreBatchCrashKV) MultiSaveAndRemove(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	f.calls++
+	if f.calls == f.failAtCall {
+		return errors.New("injected crash")
+	}
+	return f.MemoryKV.MultiSaveAndRemove(ctx, saves, removals, preds...)
+}
+
+// TestCatalog_RestoreRBAC_InterruptedRetryConverges: the restore is not atomic
+// as a whole - a crash between batches leaves a prefix of batches applied -
+// but re-running the same restore must not abort on the keys the earlier run
+// already landed and must converge to the legacy end state.
+func TestCatalog_RestoreRBAC_InterruptedRetryConverges(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+	legacyKV := memkv.NewMemoryKV()
+	legacyRestoreRBAC(t, NewCatalog(legacyKV), tenant, restoreMeta())
+
+	fk := &restoreBatchCrashKV{MemoryKV: memkv.NewMemoryKV(), limit: 4, failAtCall: 2}
+	c := NewCatalog(fk)
+	assert.Error(t, c.RestoreRBAC(ctx, tenant, restoreMeta()))
+	// interrupted: some batches landed, but not the whole backup.
+	partial := dumpKV(t, fk.MemoryKV)
+	assert.NotEmpty(t, partial)
+	assert.NotEqual(t, dumpKV(t, legacyKV), partial)
+
+	assert.NoError(t, c.RestoreRBAC(ctx, tenant, restoreMeta()))
+	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, fk.MemoryKV))
+}
+
+// TestCatalog_RestoreRBAC_OversizedEntityStaysWithinTxnLimit: a single entity
+// whose kvs alone exceed MaxTxnOps (a user with more role mappings than the
+// limit, or a grant whose legacy-id migration moves a large privilege
+// subtree) must be split across multiple batches instead of being flushed as
+// one oversized MultiSaveAndRemove - etcd rejects a txn above its op limit,
+// which would make the restore permanently fail where the legacy per-key
+// path succeeded. Entity atomicity cannot hold above the limit; convergence
+// on retry is what matters, and the end state must still match the legacy
+// per-key loop byte-for-byte.
+func TestCatalog_RestoreRBAC_OversizedEntityStaysWithinTxnLimit(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+	granteeKey := GranteePrefix + "/role1/Collection/db1.coll1"
+	legacyPrivs := []string{"PrivilegeLoad", "PrivilegeQuery", "PrivilegeDelete"}
+
+	// user1 carries 6 role mappings: 1 credential + 6 user-role kvs = 7 ops,
+	// above the limit of 4. The grant's legacy-id migration moves 3 leaves:
+	// 1 grantee rewrite + 3 new leaves + 1 granted privilege + 3 removals =
+	// 8 ops, also above the limit.
+	roles := make([]*milvuspb.RoleEntity, 0, 6)
+	for _, name := range []string{"role1", "role2", "role3", "role4", "role5", "role6"} {
+		roles = append(roles, &milvuspb.RoleEntity{Name: name})
+	}
+	oversizedMeta := func() *milvuspb.RBACMeta {
+		return &milvuspb.RBACMeta{
+			Users: []*milvuspb.UserInfo{
+				{User: "user1", Password: "pw1", Roles: roles},
+			},
+			Roles: roles,
+			Grants: []*milvuspb.GrantEntity{
+				grantEntity("role1", "Collection", "db1", "coll1", "Insert", "root"),
+			},
+		}
+	}
+	seedLegacy := func(mk *memkv.MemoryKV) {
+		for _, priv := range legacyPrivs {
+			seedLegacyGrant(t, mk, granteeKey, priv, "legacy-user")
+		}
+	}
+
+	legacyKV := memkv.NewMemoryKV()
+	seedLegacy(legacyKV)
+	legacyRestoreRBAC(t, NewCatalog(legacyKV), tenant, oversizedMeta())
+
+	mk := memkv.NewMemoryKV()
+	seedLegacy(mk)
+	bk := &batchRecordingKV{MemoryKV: mk, limit: 4}
+	c := NewCatalog(bk)
+	assert.NoError(t, c.RestoreRBAC(ctx, tenant, oversizedMeta()))
+
+	// Every batch respects the txn op limit - the header contract - and the
+	// end state matches the legacy per-key loop.
+	for _, n := range bk.batchSizes {
+		assert.LessOrEqual(t, n, bk.limit)
+	}
+	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, bk.MemoryKV))
 }

--- a/internal/metastore/kv/rootcoord/update_test.go
+++ b/internal/metastore/kv/rootcoord/update_test.go
@@ -740,6 +740,249 @@ func TestCatalog_Update_RenameCollectionWithGrants_GranteeIndexChunkCrashRetry(t
 	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, fk.MemoryKV))
 }
 
+// addCollectionGrant issues one AlterGrant against c; shared by the
+// drop-collection-with-grants tests to extend the seedRenameGrants fixture.
+func addCollectionGrant(t *testing.T, c metastore.RootCoordCatalog, role, objType, dbName, objName, priv string) {
+	assert.NoError(t, c.AlterGrant(context.TODO(), util.DefaultTenant, &milvuspb.GrantEntity{
+		Role:       &milvuspb.RoleEntity{Name: role},
+		Object:     &milvuspb.ObjectEntity{Name: objType},
+		ObjectName: objName,
+		DbName:     dbName,
+		Grantor: &milvuspb.GrantorEntity{
+			User:      &milvuspb.UserEntity{Name: "root"},
+			Privilege: &milvuspb.PrivilegeEntity{Name: priv},
+		},
+	}, milvuspb.OperatePrivilegeType_Grant))
+}
+
+// TestCatalog_Update_DropCollectionWithGrants_MatchesLegacyBytes proves the
+// new single-txn drop path leaves byte-for-byte the same store state as
+// today's two-call path (Catalog.DropCollection +
+// DeleteGrantByCollectionName): collection record, child keys, grantee leaves
+// and grantee-id subtrees all gone, canaries of other objects untouched.
+func TestCatalog_Update_DropCollectionWithGrants_MatchesLegacyBytes(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+
+	legacyKV := memkv.NewMemoryKV()
+	compositeKV := memkv.NewMemoryKV()
+	legacy := NewCatalog(legacyKV)
+	composite := NewCatalog(compositeKV)
+	coll := seedRenameGrants(t, legacy)
+	seedRenameGrants(t, composite)
+	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, compositeKV))
+
+	// capture coll1's grantee ids before the drop, to assert their subtrees die.
+	granteeIDs := []string{
+		dumpKV(t, compositeKV)[GranteePrefix+"/role1/Collection/db1.coll1"],
+		dumpKV(t, compositeKV)[GranteePrefix+"/role2/Collection/db1.coll1"],
+	}
+
+	// today's two-call path.
+	assert.NoError(t, legacy.DropCollection(ctx, coll, 0))
+	assert.NoError(t, legacy.DeleteGrantByCollectionName(ctx, tenant, "db1", "coll1"))
+
+	// new single-txn path.
+	assert.NoError(t, composite.Update(ctx, 0,
+		metastore.DropCollectionGrants(tenant, "db1", "coll1"),
+		metastore.DropCollection(coll)))
+
+	got := dumpKV(t, compositeKV)
+	assert.Equal(t, dumpKV(t, legacyKV), got)
+
+	// collection record, grantee leaves and grantee-id subtrees are gone.
+	assert.NotContains(t, got, BuildCollectionKey(coll.DBID, coll.CollectionID))
+	assert.NotContains(t, got, GranteePrefix+"/role1/Collection/db1.coll1")
+	assert.NotContains(t, got, GranteePrefix+"/role2/Collection/db1.coll1")
+	for k := range got {
+		for _, id := range granteeIDs {
+			assert.False(t, strings.HasPrefix(k, funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, id)), k)
+		}
+	}
+	// canaries survive: a name-prefix sibling, the same name in another
+	// database, and a Global grant.
+	assert.Contains(t, got, GranteePrefix+"/role1/Collection/db1.coll1_backup")
+	assert.Contains(t, got, GranteePrefix+"/role1/Collection/db2.coll1")
+	assert.Contains(t, got, GranteePrefix+"/role1/Global/db1.*")
+}
+
+// TestCatalog_Update_DropCollectionWithGrants_SingleTxn proves the whole drop
+// is one MultiSaveAndRemoveMixed transaction carrying the collection record,
+// its child keys and the grantee leaves as EXACT removals and the grantee-id
+// subtrees as PREFIX removals.
+func TestCatalog_Update_DropCollectionWithGrants_SingleTxn(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+	mk := memkv.NewMemoryKV()
+	coll := seedRenameGrants(t, NewCatalog(mk))
+
+	before := dumpKV(t, mk)
+	granteeIDs := []string{
+		before[GranteePrefix+"/role1/Collection/db1.coll1"],
+		before[GranteePrefix+"/role2/Collection/db1.coll1"],
+	}
+
+	rec := &writeRecordingKV{MemoryKV: mk}
+	c := NewCatalog(rec)
+	assert.NoError(t, c.Update(ctx, 0,
+		metastore.DropCollectionGrants(tenant, "db1", "coll1"),
+		metastore.DropCollection(coll)))
+
+	assert.Equal(t, []string{"MultiSaveAndRemoveMixed"}, rec.calls)
+	assert.ElementsMatch(t, []string{
+		BuildCollectionKey(coll.DBID, coll.CollectionID),
+		BuildPartitionKey(coll.CollectionID, coll.Partitions[0].PartitionID),
+		BuildFieldKey(coll.CollectionID, coll.Fields[0].FieldID),
+		GranteePrefix + "/role1/Collection/db1.coll1",
+		GranteePrefix + "/role2/Collection/db1.coll1",
+	}, rec.removals)
+	wantPrefixes := make([]string, 0, len(granteeIDs))
+	for _, id := range granteeIDs {
+		wantPrefixes = append(wantPrefixes, funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, id))
+	}
+	assert.ElementsMatch(t, wantPrefixes, rec.prefixRemovals)
+}
+
+// TestCatalog_Update_DropCollectionWithGrants_AtomicCrashRetry: a failed
+// atomic commit must leave the store untouched (collection intact, no partial
+// grant removal), and retrying the same composite drop must converge to
+// exactly the legacy two-call end state.
+func TestCatalog_Update_DropCollectionWithGrants_AtomicCrashRetry(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+
+	legacyKV := memkv.NewMemoryKV()
+	legacy := NewCatalog(legacyKV)
+	coll := seedRenameGrants(t, legacy)
+	assert.NoError(t, legacy.DropCollection(ctx, coll, 0))
+	assert.NoError(t, legacy.DeleteGrantByCollectionName(ctx, tenant, "db1", "coll1"))
+
+	fk := &flakyMixedKV{MemoryKV: memkv.NewMemoryKV(), failures: 1}
+	seedRenameGrants(t, NewCatalog(fk.MemoryKV))
+	before := dumpKV(t, fk.MemoryKV)
+
+	c := NewCatalog(fk)
+	drop := func() error {
+		return c.Update(ctx, 0,
+			metastore.DropCollectionGrants(tenant, "db1", "coll1"),
+			metastore.DropCollection(coll))
+	}
+	assert.Error(t, drop())
+	// atomic: the failed commit applied nothing.
+	assert.Equal(t, before, dumpKV(t, fk.MemoryKV))
+
+	assert.NoError(t, drop())
+	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, fk.MemoryKV))
+}
+
+// markerCrashKV shrinks MaxTxnOps so the composite takes the chunked fallback
+// and fails only the final guarded commit txn - the MultiSaveAndRemove whose
+// removals carry the collection key - simulating a crash right before the
+// visibility marker lands.
+type markerCrashKV struct {
+	*memkv.MemoryKV
+	markerKey string
+	failures  int
+}
+
+func (f *markerCrashKV) MaxTxnOps() int { return 2 }
+
+func (f *markerCrashKV) MultiSaveAndRemove(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	if f.failures > 0 {
+		for _, k := range removals {
+			if k == f.markerKey {
+				f.failures--
+				return errors.New("injected crash")
+			}
+		}
+	}
+	return f.MemoryKV.MultiSaveAndRemove(ctx, saves, removals, preds...)
+}
+
+// TestCatalog_Update_DropCollectionWithGrants_FallbackMarkerCrashRetry: on the
+// chunked fallback path the collection record is the commit marker of the
+// whole drop. A crash before the final commit txn must leave the record
+// visible (so the drop is observably incomplete and retryable, never a
+// collection-gone-grants-orphaned state), and the retry must converge to the
+// legacy end state.
+func TestCatalog_Update_DropCollectionWithGrants_FallbackMarkerCrashRetry(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+
+	legacyKV := memkv.NewMemoryKV()
+	legacy := NewCatalog(legacyKV)
+	coll := seedRenameGrants(t, legacy)
+	assert.NoError(t, legacy.DropCollection(ctx, coll, 0))
+	assert.NoError(t, legacy.DeleteGrantByCollectionName(ctx, tenant, "db1", "coll1"))
+
+	fk := &markerCrashKV{
+		MemoryKV:  memkv.NewMemoryKV(),
+		markerKey: BuildCollectionKey(coll.DBID, coll.CollectionID),
+		failures:  1,
+	}
+	seedRenameGrants(t, NewCatalog(fk.MemoryKV))
+
+	c := NewCatalog(fk)
+	drop := func() error {
+		return c.Update(ctx, 0,
+			metastore.DropCollectionGrants(tenant, "db1", "coll1"),
+			metastore.DropCollection(coll))
+	}
+	assert.Error(t, drop())
+	// crash-safety: the collection record (commit marker) must still be visible.
+	has, err := fk.Has(ctx, BuildCollectionKey(coll.DBID, coll.CollectionID))
+	assert.NoError(t, err)
+	assert.True(t, has)
+
+	assert.NoError(t, drop())
+	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, fk.MemoryKV))
+}
+
+// TestCatalog_Update_DropCollectionWithGrants_GranteeIndexChunkCrashRetry: on
+// the chunked fallback path the grantee-privileges leaves are the only index
+// from which a retry can recompute the removal set (their values reference the
+// grantee-id subtrees), so they must be removed after the grantee-id prefix
+// removals. A crash between prefix chunks must leave every leaf (and the
+// collection marker) intact so the retry converges to the legacy end state
+// instead of permanently orphaning the remaining grantee-id subtrees.
+func TestCatalog_Update_DropCollectionWithGrants_GranteeIndexChunkCrashRetry(t *testing.T) {
+	ctx := context.TODO()
+	tenant := util.DefaultTenant
+
+	legacyKV := memkv.NewMemoryKV()
+	legacy := NewCatalog(legacyKV)
+	coll := seedRenameGrants(t, legacy)
+	// a third grant so the grantee-id prefix run splits into two chunks at
+	// MaxTxnOps=2.
+	assert.NoError(t, legacy.CreateRole(ctx, tenant, &milvuspb.RoleEntity{Name: "role3"}))
+	addCollectionGrant(t, legacy, "role3", "Collection", "db1", "coll1", "Query")
+	assert.NoError(t, legacy.DropCollection(ctx, coll, 0))
+	assert.NoError(t, legacy.DeleteGrantByCollectionName(ctx, tenant, "db1", "coll1"))
+
+	fk := &secondChunkCrashKV{MemoryKV: memkv.NewMemoryKV(), failAtCall: 2}
+	seedRenameGrants(t, NewCatalog(fk.MemoryKV))
+	assert.NoError(t, NewCatalog(fk.MemoryKV).CreateRole(ctx, tenant, &milvuspb.RoleEntity{Name: "role3"}))
+	addCollectionGrant(t, NewCatalog(fk.MemoryKV), "role3", "Collection", "db1", "coll1", "Query")
+
+	c := NewCatalog(fk)
+	drop := func() error {
+		return c.Update(ctx, 0,
+			metastore.DropCollectionGrants(tenant, "db1", "coll1"),
+			metastore.DropCollection(coll))
+	}
+	assert.Error(t, drop())
+	got := dumpKV(t, fk.MemoryKV)
+	// the rediscovery index must have survived the crash.
+	assert.Contains(t, got, GranteePrefix+"/role1/Collection/db1.coll1")
+	assert.Contains(t, got, GranteePrefix+"/role2/Collection/db1.coll1")
+	assert.Contains(t, got, GranteePrefix+"/role3/Collection/db1.coll1")
+	// the visibility marker has not flipped: the collection record survives.
+	assert.Contains(t, got, BuildCollectionKey(coll.DBID, coll.CollectionID))
+
+	assert.NoError(t, drop())
+	assert.Equal(t, dumpKV(t, legacyKV), dumpKV(t, fk.MemoryKV))
+}
+
 // TestCatalog_Update_DropRoleWithGrants_FallbackCrashRetry: on the chunked
 // fallback path a crash before the commit marker must leave the role record
 // visible (so the drop is observably incomplete and retryable, never a

--- a/internal/metastore/kv/streamingcoord/composite_test.go
+++ b/internal/metastore/kv/streamingcoord/composite_test.go
@@ -1,0 +1,463 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package streamingcoord
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	memkv "github.com/milvus-io/milvus/internal/kv/mem"
+	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
+	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
+)
+
+// Frozen copies of today's key layout, so a key-scheme change trips the
+// byte-parity tests below instead of silently moving data.
+const (
+	frozenReplicateConfigKey   = "streamingcoord-meta/replicate-configuration"
+	frozenReplicatePChannelPfx = "streamingcoord-meta/replicating-pchannel/"
+	frozenPChannelPfx          = "streamingcoord-meta/pchannel/"
+	frozenBroadcastTaskPfx     = "streamingcoord-meta/broadcast-task/"
+)
+
+// streamingMetaKV adapts memkv.MemoryKV (a TxnKV) to the kv.MetaKv surface the
+// streamingcoord catalog holds; the extra MetaKv methods are never exercised
+// by the write paths under test.
+type streamingMetaKV struct {
+	*memkv.MemoryKV
+}
+
+func (streamingMetaKV) GetPath(key string) string { return key }
+
+func (streamingMetaKV) CompareVersionAndSwap(ctx context.Context, key string, version int64, target string) (bool, error) {
+	panic("not used by streamingcoord composite tests")
+}
+
+func (streamingMetaKV) WalkWithPrefix(ctx context.Context, prefix string, paginationSize int, fn func([]byte, []byte) error) error {
+	panic("not used by streamingcoord composite tests")
+}
+
+// scWriteRecordingKV records every write-path call (and its payload) so a test
+// can assert call shapes and cross-batch ordering.
+type scWriteRecordingKV struct {
+	streamingMetaKV
+	maxTxnOps        int // 0 = underlying (unlimited)
+	calls            []string
+	multiSaveBatches [][]string          // sorted key set of each MultiSave call, in call order
+	txnSaves         []map[string]string // saves of each MultiSaveAndRemove call, in call order
+	txnRemovals      [][]string          // removals of each MultiSaveAndRemove call, in call order
+}
+
+func (w *scWriteRecordingKV) MaxTxnOps() int {
+	if w.maxTxnOps > 0 {
+		return w.maxTxnOps
+	}
+	return w.streamingMetaKV.MaxTxnOps()
+}
+
+func (w *scWriteRecordingKV) Save(ctx context.Context, key, value string) error {
+	w.calls = append(w.calls, "Save")
+	return w.MemoryKV.Save(ctx, key, value)
+}
+
+func (w *scWriteRecordingKV) Remove(ctx context.Context, key string) error {
+	w.calls = append(w.calls, "Remove")
+	return w.MemoryKV.Remove(ctx, key)
+}
+
+func (w *scWriteRecordingKV) MultiSave(ctx context.Context, kvs map[string]string) error {
+	w.calls = append(w.calls, "MultiSave")
+	keys := make([]string, 0, len(kvs))
+	for k := range kvs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	w.multiSaveBatches = append(w.multiSaveBatches, keys)
+	return w.MemoryKV.MultiSave(ctx, kvs)
+}
+
+func (w *scWriteRecordingKV) MultiSaveAndRemove(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	w.calls = append(w.calls, "MultiSaveAndRemove")
+	w.txnSaves = append(w.txnSaves, saves)
+	w.txnRemovals = append(w.txnRemovals, removals)
+	return w.MemoryKV.MultiSaveAndRemove(ctx, saves, removals, preds...)
+}
+
+// scConfigMarkerCrashKV shrinks MaxTxnOps so SaveReplicateConfiguration takes
+// the chunked fallback and fails the final guarded commit txn - the only
+// MultiSaveAndRemove carrying the config key - simulating a crash right before
+// the visibility marker lands.
+type scConfigMarkerCrashKV struct {
+	streamingMetaKV
+	failures int
+}
+
+func (f *scConfigMarkerCrashKV) MaxTxnOps() int { return 2 }
+
+func (f *scConfigMarkerCrashKV) MultiSaveAndRemove(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	if f.failures > 0 {
+		if _, ok := saves[frozenReplicateConfigKey]; ok {
+			f.failures--
+			return errors.New("injected crash")
+		}
+	}
+	return f.MemoryKV.MultiSaveAndRemove(ctx, saves, removals, preds...)
+}
+
+// scSecondChunkCrashKV shrinks MaxTxnOps so a put run splits into chunks and
+// fails only the given MultiSave call, simulating a crash between chunks.
+type scSecondChunkCrashKV struct {
+	streamingMetaKV
+	saveCalls  int
+	failAtCall int
+}
+
+func (f *scSecondChunkCrashKV) MaxTxnOps() int { return 2 }
+
+func (f *scSecondChunkCrashKV) MultiSave(ctx context.Context, kvs map[string]string) error {
+	f.saveCalls++
+	if f.saveCalls == f.failAtCall {
+		return errors.New("injected crash")
+	}
+	return f.MemoryKV.MultiSave(ctx, kvs)
+}
+
+// scFlakyTxnKV fails the first MultiSaveAndRemove with a transient error; used
+// UNDER the production ReliableWriteMetaKv wrapper to prove the wrapper still
+// retries the engine's txn calls to success.
+type scFlakyTxnKV struct {
+	streamingMetaKV
+	failures int
+}
+
+func (f *scFlakyTxnKV) MultiSaveAndRemove(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	if f.failures > 0 {
+		f.failures--
+		return errors.New("transient error")
+	}
+	return f.MemoryKV.MultiSaveAndRemove(ctx, saves, removals, preds...)
+}
+
+func dumpStore(t *testing.T, store *memkv.MemoryKV) map[string]string {
+	keys, vals, err := store.LoadWithPrefix(context.TODO(), "")
+	require.NoError(t, err)
+	got := make(map[string]string, len(keys))
+	for i, key := range keys {
+		got[key] = vals[i]
+	}
+	return got
+}
+
+// legacySaveReplicateConfiguration is a frozen copy of today's (pre-engine)
+// write encoding: one flat MultiSave of the config record plus every
+// replicating-pchannel record. The engine-backed path must reproduce these
+// keys and bytes exactly.
+func legacySaveReplicateConfiguration(t *testing.T, store *memkv.MemoryKV, config *streamingpb.ReplicateConfigurationMeta, tasks []*streamingpb.ReplicatePChannelMeta) {
+	v, err := proto.Marshal(config)
+	require.NoError(t, err)
+	kvs := map[string]string{frozenReplicateConfigKey: string(v)}
+	for _, task := range tasks {
+		tv, err := proto.Marshal(task)
+		require.NoError(t, err)
+		kvs[frozenReplicatePChannelPfx+task.GetTargetCluster().GetClusterId()+"-"+task.GetSourceChannelName()] = string(tv)
+	}
+	require.NoError(t, store.MultiSave(context.TODO(), kvs))
+}
+
+// legacySavePChannels is a frozen copy of today's SavePChannels encoding.
+func legacySavePChannels(t *testing.T, store *memkv.MemoryKV, infos []*streamingpb.PChannelMeta) {
+	kvs := make(map[string]string, len(infos))
+	for _, info := range infos {
+		v, err := proto.Marshal(info)
+		require.NoError(t, err)
+		kvs[frozenPChannelPfx+info.GetChannel().GetName()] = string(v)
+	}
+	require.NoError(t, store.MultiSave(context.TODO(), kvs))
+}
+
+func replicateFixture(n int) (*streamingpb.ReplicateConfigurationMeta, []*streamingpb.ReplicatePChannelMeta) {
+	config := &streamingpb.ReplicateConfigurationMeta{
+		ReplicateConfiguration: &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: "source-cluster", Pchannels: []string{"source-channel-1"}},
+				{ClusterId: "target-cluster", Pchannels: []string{"target-channel-1"}},
+			},
+			CrossClusterTopology: []*commonpb.CrossClusterTopology{
+				{SourceClusterId: "source-cluster", TargetClusterId: "target-cluster"},
+			},
+		},
+	}
+	tasks := make([]*streamingpb.ReplicatePChannelMeta, 0, n)
+	for i := 0; i < n; i++ {
+		tasks = append(tasks, &streamingpb.ReplicatePChannelMeta{
+			SourceChannelName: fmt.Sprintf("source-channel-%d", i),
+			TargetChannelName: fmt.Sprintf("target-channel-%d", i),
+			TargetCluster:     &commonpb.MilvusCluster{ClusterId: "target-cluster"},
+		})
+	}
+	return config, tasks
+}
+
+func pchannelFixture(n int) []*streamingpb.PChannelMeta {
+	infos := make([]*streamingpb.PChannelMeta, 0, n)
+	for i := 0; i < n; i++ {
+		infos = append(infos, &streamingpb.PChannelMeta{
+			Channel: &streamingpb.PChannelInfo{Name: fmt.Sprintf("pchannel-%d", i), Term: int64(i + 1)},
+			Node:    &streamingpb.StreamingNodeInfo{ServerId: 1},
+		})
+	}
+	return infos
+}
+
+// TestCatalog_SaveReplicateConfiguration_SingleTxnMatchesLegacyBytes proves
+// the config record and every replicating-pchannel record land in ONE
+// transaction (today: raw MultiSave batches with no atomicity across the
+// batch boundary) and byte-for-byte identical to today's encoding.
+func TestCatalog_SaveReplicateConfiguration_SingleTxnMatchesLegacyBytes(t *testing.T) {
+	ctx := context.TODO()
+	config, tasks := replicateFixture(2)
+
+	legacyStore := memkv.NewMemoryKV()
+	legacySaveReplicateConfiguration(t, legacyStore, config, tasks)
+
+	rec := &scWriteRecordingKV{streamingMetaKV: streamingMetaKV{memkv.NewMemoryKV()}}
+	c := NewCataLog(rec)
+	require.NoError(t, c.SaveReplicateConfiguration(ctx, config, tasks))
+
+	assert.Equal(t, []string{"MultiSaveAndRemove"}, rec.calls)
+	require.Len(t, rec.txnRemovals, 1)
+	assert.Empty(t, rec.txnRemovals[0])
+	assert.Equal(t, dumpStore(t, legacyStore), dumpStore(t, rec.MemoryKV))
+}
+
+// TestCatalog_SaveReplicateConfiguration_FallbackOrderConfigLast proves that
+// over the txn limit the replicating-pchannel records flush first, chunked in
+// input order, and the config record - the composite's visibility marker -
+// lands alone in the final guarded txn.
+func TestCatalog_SaveReplicateConfiguration_FallbackOrderConfigLast(t *testing.T) {
+	ctx := context.TODO()
+	config, tasks := replicateFixture(4)
+
+	legacyStore := memkv.NewMemoryKV()
+	legacySaveReplicateConfiguration(t, legacyStore, config, tasks)
+
+	rec := &scWriteRecordingKV{streamingMetaKV: streamingMetaKV{memkv.NewMemoryKV()}, maxTxnOps: 2}
+	c := NewCataLog(rec)
+	require.NoError(t, c.SaveReplicateConfiguration(ctx, config, tasks))
+
+	assert.Equal(t, []string{"MultiSave", "MultiSave", "MultiSaveAndRemove"}, rec.calls)
+	taskKey := func(i int) string {
+		return frozenReplicatePChannelPfx + tasks[i].GetTargetCluster().GetClusterId() + "-" + tasks[i].GetSourceChannelName()
+	}
+	// task chunks preserve the input order across batches.
+	assert.Equal(t, [][]string{
+		{taskKey(0), taskKey(1)},
+		{taskKey(2), taskKey(3)},
+	}, rec.multiSaveBatches)
+	// the final guarded txn carries only the config marker.
+	require.Len(t, rec.txnSaves, 1)
+	assert.Len(t, rec.txnSaves[0], 1)
+	assert.Contains(t, rec.txnSaves[0], frozenReplicateConfigKey)
+	require.Len(t, rec.txnRemovals, 1)
+	assert.Empty(t, rec.txnRemovals[0])
+
+	assert.Equal(t, dumpStore(t, legacyStore), dumpStore(t, rec.MemoryKV))
+}
+
+// TestCatalog_SaveReplicateConfiguration_FallbackMarkerCrashRetry: on the
+// chunked fallback path the config record is the commit marker of the whole
+// configuration update. A crash before the final commit txn must leave the OLD
+// config bytes visible (new task records sit inert), and the retry must
+// converge to the legacy end state.
+//
+// The catalog is built WITHOUT the ReliableWriteMetaKv wrapper: the injected
+// failure models a process crash, which kills the wrapper's in-process retry
+// loop as well; the wrapper would otherwise absorb the injection.
+func TestCatalog_SaveReplicateConfiguration_FallbackMarkerCrashRetry(t *testing.T) {
+	ctx := context.TODO()
+	oldConfig, oldTasks := replicateFixture(1)
+	newConfig, newTasks := replicateFixture(4)
+	newConfig.ForcePromoted = true // make the new config bytes differ from the old
+
+	legacyStore := memkv.NewMemoryKV()
+	legacySaveReplicateConfiguration(t, legacyStore, oldConfig, oldTasks)
+	legacySaveReplicateConfiguration(t, legacyStore, newConfig, newTasks)
+
+	fk := &scConfigMarkerCrashKV{streamingMetaKV: streamingMetaKV{memkv.NewMemoryKV()}, failures: 1}
+	legacySaveReplicateConfiguration(t, fk.MemoryKV, oldConfig, oldTasks)
+	before := dumpStore(t, fk.MemoryKV)
+
+	c := &catalog{metaKV: fk}
+	save := func() error { return c.SaveReplicateConfiguration(ctx, newConfig, newTasks) }
+	assert.Error(t, save())
+	// crash-safety: the marker has not flipped - config bytes are still old.
+	got := dumpStore(t, fk.MemoryKV)
+	assert.Equal(t, before[frozenReplicateConfigKey], got[frozenReplicateConfigKey])
+
+	assert.NoError(t, save())
+	assert.Equal(t, dumpStore(t, legacyStore), dumpStore(t, fk.MemoryKV))
+}
+
+// TestCatalog_SavePChannels_SingleTxnMatchesLegacyBytes proves a pchannel
+// batch within the txn limit lands in ONE transaction, byte-for-byte identical
+// to today's encoding.
+func TestCatalog_SavePChannels_SingleTxnMatchesLegacyBytes(t *testing.T) {
+	ctx := context.TODO()
+	infos := pchannelFixture(3)
+
+	legacyStore := memkv.NewMemoryKV()
+	legacySavePChannels(t, legacyStore, infos)
+
+	rec := &scWriteRecordingKV{streamingMetaKV: streamingMetaKV{memkv.NewMemoryKV()}}
+	c := NewCataLog(rec)
+	require.NoError(t, c.SavePChannels(ctx, infos))
+
+	assert.Equal(t, []string{"MultiSaveAndRemove"}, rec.calls)
+	require.Len(t, rec.txnRemovals, 1)
+	assert.Empty(t, rec.txnRemovals[0])
+	assert.Equal(t, dumpStore(t, legacyStore), dumpStore(t, rec.MemoryKV))
+}
+
+// TestCatalog_SavePChannels_ChunkedKeepsInputOrder proves an over-limit batch
+// is flushed against the store's own txn limit in input-slice order, not the
+// map-iteration order of the legacy paramtable-sized batching.
+func TestCatalog_SavePChannels_ChunkedKeepsInputOrder(t *testing.T) {
+	ctx := context.TODO()
+	infos := pchannelFixture(5)
+
+	rec := &scWriteRecordingKV{streamingMetaKV: streamingMetaKV{memkv.NewMemoryKV()}, maxTxnOps: 2}
+	c := NewCataLog(rec)
+	require.NoError(t, c.SavePChannels(ctx, infos))
+
+	assert.Equal(t, []string{"MultiSave", "MultiSave", "MultiSave"}, rec.calls)
+	assert.Equal(t, [][]string{
+		{frozenPChannelPfx + "pchannel-0", frozenPChannelPfx + "pchannel-1"},
+		{frozenPChannelPfx + "pchannel-2", frozenPChannelPfx + "pchannel-3"},
+		{frozenPChannelPfx + "pchannel-4"},
+	}, rec.multiSaveBatches)
+}
+
+// TestCatalog_SavePChannels_ChunkCrashRetry: a crash between chunks must leave
+// earlier chunks persisted and later ones absent, and the retry (the caller
+// re-issues the same batch) must converge to the legacy end state. Built
+// without the ReliableWriteMetaKv wrapper - see the marker-crash test above.
+func TestCatalog_SavePChannels_ChunkCrashRetry(t *testing.T) {
+	ctx := context.TODO()
+	infos := pchannelFixture(5)
+
+	legacyStore := memkv.NewMemoryKV()
+	legacySavePChannels(t, legacyStore, infos)
+
+	fk := &scSecondChunkCrashKV{streamingMetaKV: streamingMetaKV{memkv.NewMemoryKV()}, failAtCall: 2}
+	c := &catalog{metaKV: fk}
+	save := func() error { return c.SavePChannels(ctx, infos) }
+	assert.Error(t, save())
+	got := dumpStore(t, fk.MemoryKV)
+	// first chunk persisted, everything after the crash absent.
+	assert.Contains(t, got, frozenPChannelPfx+"pchannel-0")
+	assert.Contains(t, got, frozenPChannelPfx+"pchannel-1")
+	assert.NotContains(t, got, frozenPChannelPfx+"pchannel-2")
+	assert.NotContains(t, got, frozenPChannelPfx+"pchannel-3")
+	assert.NotContains(t, got, frozenPChannelPfx+"pchannel-4")
+
+	assert.NoError(t, save())
+	assert.Equal(t, dumpStore(t, legacyStore), dumpStore(t, fk.MemoryKV))
+}
+
+// TestCatalog_SaveCChannelAndVersion_MatchesLegacyBytes pins the
+// canonical-write-plus-legacy-trailing-slash-removal encoding: one
+// MultiSaveAndRemove whose saves and removals are unchanged by the engine
+// move.
+func TestCatalog_SaveCChannelAndVersion_MatchesLegacyBytes(t *testing.T) {
+	ctx := context.TODO()
+
+	t.Run("cchannel", func(t *testing.T) {
+		info := &streamingpb.CChannelMeta{Pchannel: "test-channel"}
+		v, err := proto.Marshal(info)
+		require.NoError(t, err)
+
+		rec := &scWriteRecordingKV{streamingMetaKV: streamingMetaKV{memkv.NewMemoryKV()}}
+		require.NoError(t, rec.MemoryKV.Save(ctx, canonicalCChannelMetaKeyForTest+"/", "legacy"))
+		c := NewCataLog(rec)
+		require.NoError(t, c.SaveCChannel(ctx, info))
+
+		assert.Equal(t, []string{"MultiSaveAndRemove"}, rec.calls)
+		assert.Equal(t, map[string]string{canonicalCChannelMetaKeyForTest: string(v)}, dumpStore(t, rec.MemoryKV))
+	})
+
+	t.Run("version", func(t *testing.T) {
+		version := &streamingpb.StreamingVersion{Version: 7}
+		v, err := proto.Marshal(version)
+		require.NoError(t, err)
+
+		rec := &scWriteRecordingKV{streamingMetaKV: streamingMetaKV{memkv.NewMemoryKV()}}
+		require.NoError(t, rec.MemoryKV.Save(ctx, canonicalVersionKeyForTest+"/", "legacy"))
+		c := NewCataLog(rec)
+		require.NoError(t, c.SaveVersion(ctx, version))
+
+		assert.Equal(t, []string{"MultiSaveAndRemove"}, rec.calls)
+		assert.Equal(t, map[string]string{canonicalVersionKeyForTest: string(v)}, dumpStore(t, rec.MemoryKV))
+	})
+}
+
+// TestCatalog_SaveBroadcastTask_EngineWriteMatchesLegacyBytes proves the save
+// branch goes through the engine's guarded txn while keeping today's key and
+// bytes, and the DONE branch stays a plain Remove (legacy compat logic).
+func TestCatalog_SaveBroadcastTask_EngineWriteMatchesLegacyBytes(t *testing.T) {
+	ctx := context.TODO()
+	task := &streamingpb.BroadcastTask{State: streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING}
+	v, err := proto.Marshal(task)
+	require.NoError(t, err)
+
+	rec := &scWriteRecordingKV{streamingMetaKV: streamingMetaKV{memkv.NewMemoryKV()}}
+	c := NewCataLog(rec)
+	require.NoError(t, c.SaveBroadcastTask(ctx, 1, task))
+	assert.Equal(t, []string{"MultiSaveAndRemove"}, rec.calls)
+	assert.Equal(t, map[string]string{frozenBroadcastTaskPfx + "1": string(v)}, dumpStore(t, rec.MemoryKV))
+
+	// DONE branch: unchanged legacy Remove.
+	require.NoError(t, c.SaveBroadcastTask(ctx, 1, &streamingpb.BroadcastTask{
+		State: streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_DONE,
+	}))
+	assert.Equal(t, []string{"MultiSaveAndRemove", "Remove"}, rec.calls)
+	assert.Empty(t, dumpStore(t, rec.MemoryKV))
+}
+
+// TestCatalog_SaveReplicateConfiguration_ReliableRetryPreserved proves the
+// ReliableWriteMetaKv wrapper still guards the engine's txn calls after the
+// move: a transient MultiSaveAndRemove failure is retried inside the call and
+// the composite write completes with today's bytes.
+func TestCatalog_SaveReplicateConfiguration_ReliableRetryPreserved(t *testing.T) {
+	ctx := context.TODO()
+	config, tasks := replicateFixture(2)
+
+	legacyStore := memkv.NewMemoryKV()
+	legacySaveReplicateConfiguration(t, legacyStore, config, tasks)
+
+	fk := &scFlakyTxnKV{streamingMetaKV: streamingMetaKV{memkv.NewMemoryKV()}, failures: 1}
+	c := NewCataLog(fk)
+	require.NoError(t, c.SaveReplicateConfiguration(ctx, config, tasks))
+	assert.Equal(t, dumpStore(t, legacyStore), dumpStore(t, fk.MemoryKV))
+}

--- a/internal/metastore/kv/streamingcoord/kv_catalog.go
+++ b/internal/metastore/kv/streamingcoord/kv_catalog.go
@@ -10,11 +10,10 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus/internal/metastore"
+	"github.com/milvus-io/milvus/internal/metastore/kv/txn"
 	"github.com/milvus-io/milvus/pkg/v3/kv"
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
-	"github.com/milvus-io/milvus/pkg/v3/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
-	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 // NewCataLog creates a new catalog instance
@@ -135,7 +134,12 @@ func (c *catalog) loadMetaWithLegacyTrailingSlash(ctx context.Context, key strin
 }
 
 func (c *catalog) saveAndRemoveLegacyMeta(ctx context.Context, key, value string) error {
-	return c.metaKV.MultiSaveAndRemove(ctx, map[string]string{key: value}, []string{key + "/"})
+	// canonical save recorded before the legacy-key removal, so even a chunked
+	// flush can never drop the only copy of the value.
+	b := txn.New()
+	b.Save(key, value)
+	b.Remove(key + "/")
+	return txn.Commit(ctx, c.metaKV, b)
 }
 
 // ListPChannels returns all pchannels
@@ -159,19 +163,17 @@ func (c *catalog) ListPChannel(ctx context.Context) ([]*streamingpb.PChannelMeta
 
 // SavePChannels saves a pchannel
 func (c *catalog) SavePChannels(ctx context.Context, infos []*streamingpb.PChannelMeta) error {
-	kvs := make(map[string]string, len(infos))
+	b := txn.New()
 	for _, info := range infos {
-		key := buildPChannelInfoPath(info.GetChannel().GetName())
 		v, err := proto.Marshal(info)
 		if err != nil {
 			return errors.Wrapf(err, "marshal pchannel %s failed", info.GetChannel().GetName())
 		}
-		kvs[key] = string(v)
+		b.Save(buildPChannelInfoPath(info.GetChannel().GetName()), string(v))
 	}
-	maxTxnNum := paramtable.Get().MetaStoreCfg.MaxEtcdTxnNum.GetAsInt()
-	return etcd.SaveByBatchWithLimit(kvs, maxTxnNum, func(partialKvs map[string]string) error {
-		return c.metaKV.MultiSave(ctx, partialKvs)
-	})
+	// within the store's txn limit the batch is one atomic txn; over it, the
+	// engine flushes chunks in the input-slice order
+	return txn.Commit(ctx, c.metaKV, b)
 }
 
 func (c *catalog) ListBroadcastTask(ctx context.Context) ([]*streamingpb.BroadcastTask, error) {
@@ -200,7 +202,9 @@ func (c *catalog) SaveBroadcastTask(ctx context.Context, broadcastID uint64, tas
 	if err != nil {
 		return errors.Wrapf(err, "marshal broadcast task failed")
 	}
-	return c.metaKV.Save(ctx, key, string(v))
+	b := txn.New()
+	b.Save(key, string(v))
+	return txn.Commit(ctx, c.metaKV, b)
 }
 
 // buildPChannelInfoPath builds the path for pchannel info.
@@ -213,27 +217,32 @@ func buildBroadcastTaskPath(id uint64) string {
 	return BroadcastTaskPrefix + strconv.FormatUint(id, 10)
 }
 
+// SaveReplicateConfiguration persists the replicate configuration and the new
+// replicating-pchannel records as one composite commit. The config record is
+// the composite's visibility marker: GetReplicateConfiguration is what makes a
+// configuration update observable, so on the engine's chunked fallback it
+// lands alone in the final guarded txn, after every task record - a crash
+// mid-write leaves the OLD config visible with the new task records inert, and
+// the caller's retry (serialized by ChannelManager's lock) reissues the same
+// composite. The CDC controller watches the replicating-pchannel prefix
+// directly, so task records becoming visible before the config is no wider a
+// window than today's unordered MultiSave batches had.
 func (c *catalog) SaveReplicateConfiguration(ctx context.Context, config *streamingpb.ReplicateConfigurationMeta, replicatingTasks []*streamingpb.ReplicatePChannelMeta) error {
 	v, err := proto.Marshal(config)
 	if err != nil {
 		return errors.Wrapf(err, "marshal replicate configuration failed")
 	}
 
-	kvs := make(map[string]string, len(replicatingTasks)+1)
-	kvs[ReplicateConfigurationKey] = string(v)
-
+	b := txn.New()
 	for _, task := range replicatingTasks {
-		key := buildReplicatePChannelPath(task.GetTargetCluster().GetClusterId(), task.GetSourceChannelName())
-		v, err := proto.Marshal(task)
+		tv, err := proto.Marshal(task)
 		if err != nil {
 			return errors.Wrapf(err, "marshal replicate pchannel meta failed")
 		}
-		kvs[key] = string(v)
+		b.Save(buildReplicatePChannelPath(task.GetTargetCluster().GetClusterId(), task.GetSourceChannelName()), string(tv))
 	}
-	maxTxnNum := paramtable.Get().MetaStoreCfg.MaxEtcdTxnNum.GetAsInt()
-	return etcd.SaveByBatchWithLimit(kvs, maxTxnNum, func(partialKvs map[string]string) error {
-		return c.metaKV.MultiSave(ctx, partialKvs)
-	})
+	b.CommitSave(ReplicateConfigurationKey, string(v))
+	return txn.Commit(ctx, c.metaKV, b)
 }
 
 func (c *catalog) GetReplicateConfiguration(ctx context.Context) (*streamingpb.ReplicateConfigurationMeta, error) {

--- a/internal/metastore/kv/streamingcoord/kv_catalog_test.go
+++ b/internal/metastore/kv/streamingcoord/kv_catalog_test.go
@@ -85,6 +85,7 @@ func newTestCatalog(t *testing.T) (metastore.StreamingCoordCataLog, map[string]s
 		delete(kvStorage, key)
 		return nil
 	}).Maybe()
+	kv.EXPECT().MaxTxnOps().Return(128).Maybe()
 	return NewCataLog(kv), kvStorage, kv
 }
 

--- a/internal/metastore/kv/txn/builder.go
+++ b/internal/metastore/kv/txn/builder.go
@@ -64,14 +64,10 @@ func (b *Builder) Remove(key string) {
 
 // RemovePrefix records a prefix delete.
 //
-// Asymmetry to know before mixing: an op set that combines exact removals
-// (Remove) and prefix removals (RemovePrefix) commits fine on the chunked
-// fallback path (each kind is flushed with its own method) but is REJECTED on
-// the atomic path (commitAtomic) - a single etcd txn cannot express both
-// without widening the exact deletes to prefixes. So the same mixed set may
-// succeed or error depending only on whether it fits the txn limit. No Update
-// caller emits RemovePrefix today; if one does, either keep exact and prefix
-// removals in separate Update calls, or teach commitAtomic to split them.
+// Mixing exact removals (Remove) and prefix removals (RemovePrefix) in one op
+// set is supported on both commit paths: the atomic path routes the mix
+// through MultiSaveAndRemoveMixed (one txn, each delete keeps its shape), and
+// the chunked fallback flushes each kind with its own method.
 func (b *Builder) RemovePrefix(prefix string) {
 	b.ops = append(b.ops, op{key: prefix, kind: opDelPrefix})
 }

--- a/internal/metastore/kv/txn/commit.go
+++ b/internal/metastore/kv/txn/commit.go
@@ -83,12 +83,12 @@ func commitAtomic(ctx context.Context, txn kv.TxnKV, b *Builder) error {
 			prefixRemovals = append(prefixRemovals, o.key)
 		}
 	}
-	// A single etcd txn cannot express exact and prefix deletes together:
 	// MultiSaveAndRemoveWithPrefix deletes EVERY listed key by prefix, so an
 	// exact Remove("coll-1") routed through it would also nuke "coll-10" and
-	// "coll-1/x". Reject the mix rather than silently widen the delete.
+	// "coll-1/x". A mixed set therefore routes through MultiSaveAndRemoveMixed,
+	// the one TxnKV call that keeps both delete shapes in a single txn.
 	if len(removals) > 0 && len(prefixRemovals) > 0 {
-		return merr.WrapErrParameterInvalidMsg("composite update cannot mix exact and prefix removals in one atomic transaction")
+		return txn.MultiSaveAndRemoveMixed(ctx, saves, removals, prefixRemovals)
 	}
 	if len(prefixRemovals) > 0 {
 		return txn.MultiSaveAndRemoveWithPrefix(ctx, saves, prefixRemovals)

--- a/internal/metastore/kv/txn/commit_test.go
+++ b/internal/metastore/kv/txn/commit_test.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	memkv "github.com/milvus-io/milvus/internal/kv/mem"
 	kvmocks "github.com/milvus-io/milvus/internal/kv/mocks"
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 )
@@ -92,21 +94,6 @@ func TestCommit_FallbackPutBatchesPreserveOrder(t *testing.T) {
 	}, batches)
 }
 
-// TestCommit_AtomicMixedRemovalsRejected proves FIX 2: a single etcd txn
-// cannot express both exact and prefix deletes via MultiSaveAndRemoveWithPrefix
-// (which deletes every listed key by prefix). Mixing them in the atomic path
-// must return an error and issue no KV call at all.
-func TestCommit_AtomicMixedRemovalsRejected(t *testing.T) {
-	tk := kvmocks.NewTxnKV(t) // no EXPECT: any KV call fails the test
-	tk.EXPECT().MaxTxnOps().Return(64).Maybe()
-
-	b := New()
-	b.Save("a", "1")
-	b.Remove("coll-1")
-	b.RemovePrefix("coll-1/")
-	assert.Error(t, Commit(context.Background(), tk, b))
-}
-
 // TestCommit_AtomicOnlyPrefixRemoval covers the prefix-only atomic path: it
 // must route through MultiSaveAndRemoveWithPrefix with exactly the prefix
 // removals (no exact removals folded in).
@@ -120,6 +107,156 @@ func TestCommit_AtomicOnlyPrefixRemoval(t *testing.T) {
 	b.Save("a", "1")
 	b.RemovePrefix("pfx")
 	assert.NoError(t, Commit(context.Background(), tk, b))
+}
+
+// TestCommit_AtomicMixedRemovals: exact and prefix removals in one
+// within-limit Commit must route through MultiSaveAndRemoveMixed - the one
+// TxnKV call that keeps exact deletes exact - with byte-for-byte the recorded
+// saves/removals, in a single call.
+func TestCommit_AtomicMixedRemovals(t *testing.T) {
+	tk := kvmocks.NewTxnKV(t)
+	tk.EXPECT().MaxTxnOps().Return(64).Maybe()
+	tk.EXPECT().MultiSaveAndRemoveMixed(mock.Anything,
+		map[string]string{"a": "1"}, []string{"coll-1"}, []string{"coll-1/"}).Return(nil).Once()
+
+	b := New()
+	b.Save("a", "1")
+	b.Remove("coll-1")
+	b.RemovePrefix("coll-1/")
+	assert.NoError(t, Commit(context.Background(), tk, b))
+}
+
+// TestCommit_AtomicMixedRemovalsOnMemoryKV drives the mixed-removal atomic
+// path against a real (in-memory) TxnKV: one Commit carrying saves, an exact
+// removal AND a prefix removal must succeed atomically and leave exactly the
+// expected keys behind. "coll-10" is the widening canary: routing the exact
+// Remove("coll-1") through a prefix delete would wrongly wipe it.
+func TestCommit_AtomicMixedRemovalsOnMemoryKV(t *testing.T) {
+	ctx := context.Background()
+	mk := memkv.NewMemoryKV()
+	assert.NoError(t, mk.MultiSave(ctx, map[string]string{
+		"coll-1":       "tombstoned",
+		"coll-1/seg-1": "s1",
+		"coll-1/seg-2": "s2",
+		"coll-10":      "keep",
+	}))
+
+	b := New()
+	b.Save("coll-2", "v2")
+	b.Remove("coll-1")
+	b.RemovePrefix("coll-1/")
+	assert.NoError(t, Commit(ctx, mk, b))
+
+	keys, vals, err := mk.LoadWithPrefix(ctx, "")
+	assert.NoError(t, err)
+	got := make(map[string]string, len(keys))
+	for i, k := range keys {
+		got[k] = vals[i]
+	}
+	assert.Equal(t, map[string]string{
+		"coll-10": "keep",
+		"coll-2":  "v2",
+	}, got)
+}
+
+// TestCommit_FallbackMixedRemovalsMarkerLast: a mixed exact+prefix removal set
+// that exceeds the txn limit must take the chunked fallback - each removal
+// kind flushed with its own method, in recorded order - and the commit marker
+// must still be the final guarded txn.
+func TestCommit_FallbackMixedRemovalsMarkerLast(t *testing.T) {
+	tk := kvmocks.NewTxnKV(t)
+	tk.EXPECT().MaxTxnOps().Return(2).Maybe()
+
+	var calls []string
+	tk.EXPECT().MultiSave(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, kvs map[string]string) error {
+		calls = append(calls, "save")
+		return nil
+	}).Once()
+	tk.EXPECT().MultiSaveAndRemove(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, saves map[string]string, removals []string, _ ...predicates.Predicate) error {
+			if len(saves) == 0 {
+				calls = append(calls, "remove:"+removals[0])
+			} else {
+				calls = append(calls, "commit")
+			}
+			return nil
+		}).Twice()
+	tk.EXPECT().MultiSaveAndRemoveWithPrefix(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ map[string]string, removals []string, _ ...predicates.Predicate) error {
+			calls = append(calls, "removePrefix:"+removals[0])
+			return nil
+		}).Once()
+
+	b := New()
+	b.Save("a1", "1")
+	b.Save("a2", "2")
+	b.Remove("x")
+	b.RemovePrefix("p/")
+	b.CommitSave("marker", "v")
+	assert.NoError(t, Commit(context.Background(), tk, b)) // 5 ops > limit=2 forces fallback
+
+	assert.Equal(t, []string{"save", "remove:x", "removePrefix:p/", "commit"}, calls)
+}
+
+// flakyPrefixKV wraps MemoryKV, failing the first MultiSaveAndRemoveWithPrefix
+// call to simulate a crash mid-fallback, and shrinking MaxTxnOps so Commit
+// takes the chunked path.
+type flakyPrefixKV struct {
+	*memkv.MemoryKV
+	failures int
+}
+
+func (f *flakyPrefixKV) MaxTxnOps() int { return 2 }
+
+func (f *flakyPrefixKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+	if f.failures > 0 {
+		f.failures--
+		return errors.New("injected crash")
+	}
+	return f.MemoryKV.MultiSaveAndRemoveWithPrefix(ctx, saves, removals, preds...)
+}
+
+// TestCommit_MixedRemovalsRetryAfterCrashConverges: a fallback flush that dies
+// after the puts but before the prefix removal must leave the commit marker
+// unwritten (the composite write stays invisible), and re-running the same
+// Commit must converge to exactly the intended final state.
+func TestCommit_MixedRemovalsRetryAfterCrashConverges(t *testing.T) {
+	ctx := context.Background()
+	fk := &flakyPrefixKV{MemoryKV: memkv.NewMemoryKV(), failures: 1}
+	assert.NoError(t, fk.MultiSave(ctx, map[string]string{
+		"old":       "gone",
+		"old/sub-1": "gone",
+	}))
+
+	build := func() *Builder {
+		b := New()
+		b.Save("k1", "1")
+		b.Save("k2", "2")
+		b.Save("k3", "3")
+		b.Remove("old")
+		b.RemovePrefix("old/")
+		b.CommitSave("marker", "v")
+		return b
+	}
+
+	assert.Error(t, Commit(ctx, fk, build())) // dies at the prefix-removal batch
+
+	// crash-safety: the commit marker must not have landed.
+	has, err := fk.Has(ctx, "marker")
+	assert.NoError(t, err)
+	assert.False(t, has)
+
+	assert.NoError(t, Commit(ctx, fk, build())) // retry converges
+
+	keys, vals, err := fk.LoadWithPrefix(ctx, "")
+	assert.NoError(t, err)
+	got := make(map[string]string, len(keys))
+	for i, k := range keys {
+		got[k] = vals[i]
+	}
+	assert.Equal(t, map[string]string{
+		"k1": "1", "k2": "2", "k3": "3", "marker": "v",
+	}, got)
 }
 
 // TestCommit_FallbackPreservesOrderAcrossKinds is a self-review addition (not

--- a/internal/metastore/update_action.go
+++ b/internal/metastore/update_action.go
@@ -152,6 +152,19 @@ type ReplicaKeyEntry struct {
 	ReplicaID    int64
 }
 
+// RoleEntry targets a role's record and its user-role mappings.
+type RoleEntry struct {
+	Tenant string
+	Name   string
+}
+
+// RoleGrantsEntry targets every grant of a role: the role's
+// grantee-privileges subtree plus the grantee-id subtrees it references.
+type RoleGrantsEntry struct {
+	Tenant   string
+	RoleName string
+}
+
 func (SegmentEntry) isEntry()               {}
 func (ChannelEntry) isEntry()               {}
 func (CollectionEntry) isEntry()            {}
@@ -162,6 +175,8 @@ func (PartitionStatsEntry) isEntry()        {}
 func (PartitionStatsVersionEntry) isEntry() {}
 func (ReplicaEntry) isEntry()               {}
 func (ReplicaKeyEntry) isEntry()            {}
+func (RoleEntry) isEntry()                  {}
+func (RoleGrantsEntry) isEntry()            {}
 
 // UpdateAction is a single composable write against a metastore catalog,
 // applied via that catalog's composite Update. Type and Entry together
@@ -283,4 +298,23 @@ func SaveReplica(r *querypb.Replica) UpdateAction {
 // ReleaseReplica returns an UpdateAction that removes a replica's kv record.
 func ReleaseReplica(collectionID, replicaID int64) UpdateAction {
 	return UpdateAction{Type: ActionDelete, Entry: ReplicaKeyEntry{CollectionID: collectionID, ReplicaID: replicaID}}
+}
+
+// DropRole returns an UpdateAction that removes a role's record and its
+// user-role mappings. Compose it after DropRoleGrants for the same role: the
+// role record is the visibility marker of the whole removal and must land
+// last on the chunked fallback path, so a crash mid-drop leaves the role
+// visible (and the drop retryable) instead of orphaning its grants.
+func DropRole(tenant string, roleName string) UpdateAction {
+	return UpdateAction{Type: ActionDelete, Entry: RoleEntry{Tenant: tenant, Name: roleName}}
+}
+
+// DropRoleGrants returns an UpdateAction that removes every grant of a role.
+// Both DropRole and DropRoleGrants read the current key set at apply time and
+// commit it without predicate checks, so the caller must serialize them
+// against concurrent grant/user-role writes (rootcoord does this via
+// MetaTable's permission lock); an unserialized caller can lose a concurrent
+// grant or leave one undeleted.
+func DropRoleGrants(tenant string, roleName string) UpdateAction {
+	return UpdateAction{Type: ActionDelete, Entry: RoleGrantsEntry{Tenant: tenant, RoleName: roleName}}
 }

--- a/internal/metastore/update_action.go
+++ b/internal/metastore/update_action.go
@@ -38,11 +38,12 @@ const (
 	// because every caller holds the authoritative in-memory object under the
 	// single-writer meta lock and supplies it whole.
 	//
-	// ActionUpdate is a placeholder for a future partial-update (mutator) API:
-	// a transactional read-modify-write that applies a func(current) to a clone
-	// at the apply site, so a caller could touch only the fields it changes
-	// (see the SegmentEntry note on the deferred mutator field). Until such a
-	// caller exists, treat ActionUpdate as replace, not patch.
+	// Partial update is a future direction only, not what ActionUpdate does: a
+	// mutator API would be a transactional read-modify-write that applies a
+	// func(current) to a clone at the apply site, so a caller could touch only
+	// the fields it changes (see the SegmentEntry note on the deferred mutator
+	// field). Until such a caller exists, treat ActionUpdate as replace, not
+	// patch.
 	ActionUpdate
 	// ActionDelete physically removes an entry's keys from the store (e.g.
 	// collection drop; reserved for future segment GC).

--- a/internal/metastore/update_action.go
+++ b/internal/metastore/update_action.go
@@ -175,6 +175,15 @@ type RoleGrantsEntry struct {
 	RoleName string
 }
 
+// CollectionGrantsEntry targets every grant keyed by a collection's
+// (database, collection) name pair: the exact grantee-privileges leaves plus
+// the grantee-id subtrees no surviving grantee still references.
+type CollectionGrantsEntry struct {
+	Tenant         string
+	DBName         string
+	CollectionName string
+}
+
 // CollectionRenameEntry targets a collection's record rewrite for a rename,
 // possibly across databases: Old and New are the collection's before/after
 // values (New already carries the new name and, for a database move, the new
@@ -214,6 +223,7 @@ func (ReplicaEntry) isEntry()               {}
 func (ReplicaKeyEntry) isEntry()            {}
 func (RoleEntry) isEntry()                  {}
 func (RoleGrantsEntry) isEntry()            {}
+func (CollectionGrantsEntry) isEntry()      {}
 func (CollectionRenameEntry) isEntry()      {}
 func (GrantMigrateEntry) isEntry()          {}
 
@@ -392,6 +402,25 @@ func MigrateCollectionGrants(tenant, oldDBName, oldName, newDBName, newName stri
 		OldName:   oldName,
 		NewDBName: newDBName,
 		NewName:   newName,
+	}}
+}
+
+// DropCollectionGrants returns an UpdateAction that removes every grant keyed
+// by a collection's (db, collection) name pair. Compose it before the
+// DropCollection action of the same drop: the collection record is the
+// visibility marker of the whole removal and must land last on the chunked
+// fallback path, so a crash mid-drop leaves the collection visible (and the
+// drop retryable) instead of removed with half-cleaned grants. The removal
+// set is read at apply time and committed without predicate checks, so the
+// caller must serialize it against concurrent grant writes for the same
+// collection; rootcoord drops run under MetaTable's ddLock while grant writes
+// take the permission lock, the same benign window the legacy
+// DeleteGrantByCollectionName call had.
+func DropCollectionGrants(tenant, dbName, collectionName string) UpdateAction {
+	return UpdateAction{Type: ActionDelete, Entry: CollectionGrantsEntry{
+		Tenant:         tenant,
+		DBName:         dbName,
+		CollectionName: collectionName,
 	}}
 }
 

--- a/internal/metastore/update_action.go
+++ b/internal/metastore/update_action.go
@@ -115,6 +115,22 @@ type RefreshJobEntry struct {
 	JobID int64
 }
 
+// ImportTaskEntry targets a single import task record: exactly one of Task
+// (an import task) or PreImportTask (a pre-import task) is set, selecting the
+// key space the record is written under.
+type ImportTaskEntry struct {
+	Task          *datapb.ImportTaskV2
+	PreImportTask *datapb.PreImportTask
+}
+
+// ImportJobEntry targets an import job's record upsert. The job is the
+// failover anchor for its tasks: compose a SaveImportJob action after every
+// AddImportTask/AddPreImportTask action of the same batch, so the job - the
+// commit marker - lands last on the chunked fallback path.
+type ImportJobEntry struct {
+	Job *datapb.ImportJob
+}
+
 // AnalyzeTaskEntry targets a single analyze task's removal.
 type AnalyzeTaskEntry struct {
 	TaskID int64
@@ -214,6 +230,8 @@ func (ChannelEntry) isEntry()               {}
 func (CollectionEntry) isEntry()            {}
 func (RefreshTaskEntry) isEntry()           {}
 func (RefreshJobEntry) isEntry()            {}
+func (ImportTaskEntry) isEntry()            {}
+func (ImportJobEntry) isEntry()             {}
 func (AnalyzeTaskEntry) isEntry()           {}
 func (PartitionStatsEntry) isEntry()        {}
 func (PartitionStatsVersionEntry) isEntry() {}
@@ -305,6 +323,31 @@ func DropRefreshTask(taskID int64) UpdateAction {
 // the job - the failover anchor - is removed last.
 func DropRefreshJob(jobID int64) UpdateAction {
 	return UpdateAction{Type: ActionDelete, Entry: RefreshJobEntry{JobID: jobID}}
+}
+
+// AddPreImportTask returns an UpdateAction that persists task as a new
+// pre-import task record.
+func AddPreImportTask(task *datapb.PreImportTask) UpdateAction {
+	return UpdateAction{Type: ActionAdd, Entry: ImportTaskEntry{PreImportTask: task}}
+}
+
+// AddImportTask returns an UpdateAction that persists task as a new import
+// task record.
+func AddImportTask(task *datapb.ImportTaskV2) UpdateAction {
+	return UpdateAction{Type: ActionAdd, Entry: ImportTaskEntry{Task: task}}
+}
+
+// SaveImportJob returns an UpdateAction that persists job's record (an
+// upsert). Compose it after every AddImportTask/AddPreImportTask action of
+// the same batch, so the job - the failover anchor - is written last as the
+// commit marker: a crash mid-batch leaves the persisted tasks inert under a
+// job that never observed them, and the restart reload adopts them so the
+// post-crash retry persists only the remainder. An in-process retry does NOT
+// reuse the same task keys (datacoord re-allocates task IDs per attempt), so
+// the caller must roll back the batch's task records when the composite write
+// fails - see importMeta.AddTasksToJob.
+func SaveImportJob(job *datapb.ImportJob) UpdateAction {
+	return UpdateAction{Type: ActionUpdate, Entry: ImportJobEntry{Job: job}}
 }
 
 // DropAnalyzeTask returns an UpdateAction that removes an analyze task.

--- a/internal/metastore/update_action.go
+++ b/internal/metastore/update_action.go
@@ -175,6 +175,31 @@ type RoleGrantsEntry struct {
 	RoleName string
 }
 
+// CollectionRenameEntry targets a collection's record rewrite for a rename,
+// possibly across databases: Old and New are the collection's before/after
+// values (New already carries the new name and, for a database move, the new
+// DBID).
+type CollectionRenameEntry struct {
+	Old *model.Collection
+	New *model.Collection
+	// FieldModify mirrors the legacy AlterCollection fieldModify flag: when
+	// set, the per-field/function child keys are rewritten alongside the
+	// record. It is only meaningful for a same-database rename; a database
+	// move never rewrites child keys (legacy AlterCollectionDB parity).
+	FieldModify bool
+}
+
+// GrantMigrateEntry targets every grantee key referencing a collection by its
+// old (database, collection) name pair, rewriting it - and its grantee-id
+// subtree - to the new pair.
+type GrantMigrateEntry struct {
+	Tenant    string
+	OldDBName string
+	OldName   string
+	NewDBName string
+	NewName   string
+}
+
 func (SegmentEntry) isEntry()               {}
 func (ChannelEntry) isEntry()               {}
 func (CollectionEntry) isEntry()            {}
@@ -189,6 +214,8 @@ func (ReplicaEntry) isEntry()               {}
 func (ReplicaKeyEntry) isEntry()            {}
 func (RoleEntry) isEntry()                  {}
 func (RoleGrantsEntry) isEntry()            {}
+func (CollectionRenameEntry) isEntry()      {}
+func (GrantMigrateEntry) isEntry()          {}
 
 // UpdateAction is a single composable write against a metastore catalog,
 // applied via that catalog's composite Update. Type and Entry together
@@ -337,6 +364,35 @@ func ReleaseReplica(collectionID, replicaID int64) UpdateAction {
 // visible (and the drop retryable) instead of orphaning its grants.
 func DropRole(tenant string, roleName string) UpdateAction {
 	return UpdateAction{Type: ActionDelete, Entry: RoleEntry{Tenant: tenant, Name: roleName}}
+}
+
+// RenameCollection returns an UpdateAction that rewrites a collection's
+// record for a rename: a same-database rename overwrites the record in place
+// (legacy AlterCollection MODIFY encoding), a database move (old.DBID !=
+// new.DBID) writes the record under the new database and removes the old one
+// (legacy AlterCollectionDB encoding). The record is the visibility marker of
+// the whole rename and lands last on the chunked fallback path, so compose it
+// after the MigrateCollectionGrants action of the same rename.
+func RenameCollection(oldColl, newColl *model.Collection, fieldModify bool) UpdateAction {
+	return UpdateAction{Type: ActionUpdate, Entry: CollectionRenameEntry{Old: oldColl, New: newColl, FieldModify: fieldModify}}
+}
+
+// MigrateCollectionGrants returns an UpdateAction that rewrites every grant
+// keyed by the old (db, collection) name pair to the new pair. It reads the
+// current grantee key set at apply time and commits the rewrite without
+// predicate checks, so the caller must serialize it against concurrent grant
+// writes for the same collection; rootcoord renames run under MetaTable's
+// ddLock while grant writes take the permission lock, which keeps the same
+// benign window the legacy MigrateGrantCollectionName call had - a grant
+// issued mid-rename against the old name stays keyed by the old name.
+func MigrateCollectionGrants(tenant, oldDBName, oldName, newDBName, newName string) UpdateAction {
+	return UpdateAction{Type: ActionUpdate, Entry: GrantMigrateEntry{
+		Tenant:    tenant,
+		OldDBName: oldDBName,
+		OldName:   oldName,
+		NewDBName: newDBName,
+		NewName:   newName,
+	}}
 }
 
 // DropRoleGrants returns an UpdateAction that removes every grant of a role.

--- a/internal/metastore/update_action.go
+++ b/internal/metastore/update_action.go
@@ -140,6 +140,16 @@ type PartitionStatsVersionEntry struct {
 	Version      int64
 }
 
+// CollectionLoadEntry targets a collection's load-info upsert.
+type CollectionLoadEntry struct {
+	Collection *querypb.CollectionLoadInfo
+}
+
+// PartitionLoadEntry targets a partition's load-info upsert.
+type PartitionLoadEntry struct {
+	Partition *querypb.PartitionLoadInfo
+}
+
 // ReplicaEntry targets a single replica's upsert.
 type ReplicaEntry struct {
 	Replica *querypb.Replica
@@ -173,6 +183,8 @@ func (RefreshJobEntry) isEntry()            {}
 func (AnalyzeTaskEntry) isEntry()           {}
 func (PartitionStatsEntry) isEntry()        {}
 func (PartitionStatsVersionEntry) isEntry() {}
+func (CollectionLoadEntry) isEntry()        {}
+func (PartitionLoadEntry) isEntry()         {}
 func (ReplicaEntry) isEntry()               {}
 func (ReplicaKeyEntry) isEntry()            {}
 func (RoleEntry) isEntry()                  {}
@@ -288,6 +300,24 @@ func SavePartitionStatsVersion(collectionID, partitionID int64, vchannel string,
 		VChannel:     vchannel,
 		Version:      version,
 	}}
+}
+
+// SaveCollectionLoadInfo returns an UpdateAction that persists c's load-info
+// record (an upsert). The collection record is the visibility marker of a
+// collection load - querycoord recovery reads partition load infos only for
+// collections whose record exists - so compose it after every
+// SavePartitionLoadInfo of the same load; the querycoord catalog lands it
+// last on the chunked fallback path, so a crash mid-save leaves the load
+// invisible (and the save retryable) instead of publishing a loaded
+// collection with missing partitions.
+func SaveCollectionLoadInfo(c *querypb.CollectionLoadInfo) UpdateAction {
+	return UpdateAction{Type: ActionUpdate, Entry: CollectionLoadEntry{Collection: c}}
+}
+
+// SavePartitionLoadInfo returns an UpdateAction that persists p's load-info
+// record (an upsert).
+func SavePartitionLoadInfo(p *querypb.PartitionLoadInfo) UpdateAction {
+	return UpdateAction{Type: ActionUpdate, Entry: PartitionLoadEntry{Partition: p}}
 }
 
 // SaveReplica returns an UpdateAction that persists r as a replica upsert.

--- a/internal/rootcoord/ddl_callbacks_rbac_role.go
+++ b/internal/rootcoord/ddl_callbacks_rbac_role.go
@@ -116,12 +116,11 @@ func (c *Core) broadcastDropRole(ctx context.Context, in *milvuspb.DropRoleReque
 func (c *DDLCallback) dropRoleV2AckCallback(ctx context.Context, result message.BroadcastResultDropRoleMessageV2) error {
 	// There should always be only one message in the msgs slice.
 	msg := result.Message
+	// DropRole also removes every grant of the role in the same composite
+	// catalog write, so no separate DropGrant call is needed here.
 	err := c.meta.DropRole(ctx, util.DefaultTenant, msg.Header().RoleName)
 	if err != nil {
 		return merr.Wrap(err, "failed to drop role")
-	}
-	if err := c.meta.DropGrant(ctx, util.DefaultTenant, &milvuspb.RoleEntity{Name: msg.Header().RoleName}); err != nil {
-		return merr.Wrap(err, "failed to drop grant")
 	}
 	if err := c.proxyClientManager.RefreshPolicyInfoCache(ctx, &proxypb.RefreshPolicyInfoCacheRequest{
 		OpType: int32(typeutil.CacheDropRole),

--- a/internal/rootcoord/ddl_callbacks_rbac_role.go
+++ b/internal/rootcoord/ddl_callbacks_rbac_role.go
@@ -117,7 +117,7 @@ func (c *DDLCallback) dropRoleV2AckCallback(ctx context.Context, result message.
 	// There should always be only one message in the msgs slice.
 	msg := result.Message
 	// DropRole also removes every grant of the role in the same composite
-	// catalog write, so no separate DropGrant call is needed here.
+	// catalog write, so no separate grant-cleanup call is needed here.
 	err := c.meta.DropRole(ctx, util.DefaultTenant, msg.Header().RoleName)
 	if err != nil {
 		return merr.Wrap(err, "failed to drop role")

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -1999,12 +1999,16 @@ func validateRoleDescription(description string) error {
 	return rbacutil.ValidateRoleDescription(description, Params.ProxyCfg.MaxRoleDescriptionLength.GetAsInt())
 }
 
-// DropRole drop role info
+// DropRole drops the role record, its user-role mappings and every grant of
+// the role in one composite catalog write, so a crash can never leave
+// orphaned grants behind a deleted role.
 func (mt *MetaTable) DropRole(ctx context.Context, tenant string, roleName string) error {
 	mt.permissionLock.Lock()
 	defer mt.permissionLock.Unlock()
 
-	return mt.catalog.DropRole(ctx, tenant, roleName)
+	return mt.catalog.Update(ctx, 0,
+		metastore.DropRoleGrants(tenant, roleName),
+		metastore.DropRole(tenant, roleName))
 }
 
 func (mt *MetaTable) CheckIfOperateUserRole(ctx context.Context, req *milvuspb.OperateUserRoleRequest) error {

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -139,7 +139,6 @@ type IMetaTable interface {
 	SelectUser(ctx context.Context, tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool) ([]*milvuspb.UserResult, error)
 	OperatePrivilege(ctx context.Context, tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) error
 	SelectGrant(ctx context.Context, tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error)
-	DropGrant(ctx context.Context, tenant string, role *milvuspb.RoleEntity) error
 	ListPolicy(ctx context.Context, tenant string) ([]*milvuspb.GrantEntity, error)
 	ListUserRole(ctx context.Context, tenant string) ([]string, error)
 	BackupRBAC(ctx context.Context, tenant string) (*milvuspb.RBACMeta, error)
@@ -2122,16 +2121,6 @@ func (mt *MetaTable) SelectGrant(ctx context.Context, tenant string, entity *mil
 	defer mt.permissionLock.RUnlock()
 
 	return mt.catalog.ListGrant(ctx, tenant, entity)
-}
-
-func (mt *MetaTable) DropGrant(ctx context.Context, tenant string, role *milvuspb.RoleEntity) error {
-	if role == nil || funcutil.IsEmptyString(role.Name) {
-		return merr.WrapErrParameterInvalidMsg("the role entity is invalid when dropping the grant")
-	}
-	mt.permissionLock.Lock()
-	defer mt.permissionLock.Unlock()
-
-	return mt.catalog.DeleteGrant(ctx, tenant, role)
 }
 
 func (mt *MetaTable) ListPolicy(ctx context.Context, tenant string) ([]*milvuspb.GrantEntity, error) {

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -1096,21 +1096,22 @@ func (mt *MetaTable) AlterCollection(ctx context.Context, result message.Broadca
 	}
 
 	ctx1 := contextutil.WithTenantID(ctx, Params.CommonCfg.ClusterName.GetValue())
-	if !dbChanged {
+	if oldColl.Name != newColl.Name || oldColl.DBName != newColl.DBName {
+		// a rename commits the record rewrite and the grant migration as one
+		// composite txn, so a crash cannot leave the collection renamed with
+		// its grants still keyed by the old name.
+		if err := mt.catalog.Update(ctx1, newColl.UpdateTimestamp,
+			metastore.MigrateCollectionGrants(util.DefaultTenant, oldColl.DBName, oldColl.Name, newColl.DBName, newColl.Name),
+			metastore.RenameCollection(oldColl, newColl, fieldModify)); err != nil {
+			return err
+		}
+	} else if !dbChanged {
 		if err := mt.catalog.AlterCollection(ctx1, oldColl, newColl, metastore.MODIFY, newColl.UpdateTimestamp, fieldModify); err != nil {
 			return err
 		}
 	} else {
 		if err := mt.catalog.AlterCollectionDB(ctx1, oldColl, newColl, newColl.UpdateTimestamp); err != nil {
 			return err
-		}
-	}
-
-	if oldColl.Name != newColl.Name || oldColl.DBName != newColl.DBName {
-		if err := mt.catalog.MigrateGrantCollectionName(ctx1, util.DefaultTenant, oldColl.DBName, oldColl.Name, newColl.DBName, newColl.Name); err != nil {
-			mlog.Warn(ctx, "failed to migrate grants for renamed collection, skipping",
-				mlog.String("oldDBName", oldColl.DBName), mlog.String("oldName", oldColl.Name),
-				mlog.String("newDBName", newColl.DBName), mlog.String("newName", newColl.Name), mlog.Err(err))
 		}
 	}
 

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -745,13 +745,15 @@ func (mt *MetaTable) RemoveCollection(ctx context.Context, collectionID UniqueID
 		Aliases:           aliases,
 		DBID:              coll.DBID,
 	}
-	if err := mt.catalog.DropCollection(ctx1, newColl, ts); err != nil {
+	// The collection removal and its grant cleanup commit as one composite
+	// write; the collection record is the commit marker and lands last, so a
+	// crash leaves the collection visible (and the drop retryable) instead of
+	// removed with orphaned grants. A grant-cleanup failure therefore fails
+	// the drop now, rather than being warn-and-skipped as before.
+	if err := mt.catalog.Update(ctx1, ts,
+		metastore.DropCollectionGrants(util.DefaultTenant, coll.DBName, coll.Name),
+		metastore.DropCollection(newColl)); err != nil {
 		return err
-	}
-
-	if err := mt.catalog.DeleteGrantByCollectionName(ctx1, util.DefaultTenant, coll.DBName, coll.Name); err != nil {
-		mlog.Warn(ctx, "failed to delete grants for dropped collection, skipping",
-			mlog.String("dbName", coll.DBName), mlog.String("collectionName", coll.Name), mlog.Err(err))
 	}
 
 	allNames := common.CloneStringList(aliases)

--- a/internal/rootcoord/meta_table_test.go
+++ b/internal/rootcoord/meta_table_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
+	memkv "github.com/milvus-io/milvus/internal/kv/mem"
 	"github.com/milvus-io/milvus/internal/metastore"
 	"github.com/milvus-io/milvus/internal/metastore/kv/rootcoord"
 	"github.com/milvus-io/milvus/internal/metastore/mocks"
@@ -589,6 +590,48 @@ func TestRbacDropRole(t *testing.T) {
 	// drop a not exist role
 	err = mt.CheckIfDropRole(context.TODO(), &milvuspb.DropRoleRequest{RoleName: "role_not_exist"})
 	require.ErrorIs(t, err, errRoleNotExists)
+}
+
+// TestRbacDropRoleAlsoDropsGrants: DropRole must take down the whole role
+// chain - role record, user-role mappings AND every grant of the role - in
+// one composite catalog write, so no separate DropGrant call is needed and a
+// crash can never leave orphaned grants behind a deleted role.
+func TestRbacDropRoleAlsoDropsGrants(t *testing.T) {
+	mt := &MetaTable{catalog: rootcoord.NewCatalog(memkv.NewMemoryKV())}
+	ctx := context.TODO()
+	roleName := "role" + funcutil.RandomString(10)
+
+	require.NoError(t, mt.CreateRole(ctx, util.DefaultTenant, &milvuspb.RoleEntity{Name: roleName}))
+	require.NoError(t, mt.OperateUserRole(ctx, util.DefaultTenant,
+		&milvuspb.UserEntity{Name: "user1"}, &milvuspb.RoleEntity{Name: roleName},
+		milvuspb.OperateUserRoleType_AddUserToRole))
+	require.NoError(t, mt.OperatePrivilege(ctx, util.DefaultTenant, &milvuspb.GrantEntity{
+		Role:       &milvuspb.RoleEntity{Name: roleName},
+		Object:     &milvuspb.ObjectEntity{Name: "Collection"},
+		ObjectName: "coll1",
+		DbName:     "db1",
+		Grantor: &milvuspb.GrantorEntity{
+			User:      &milvuspb.UserEntity{Name: "root"},
+			Privilege: &milvuspb.PrivilegeEntity{Name: "Insert"},
+		},
+	}, milvuspb.OperatePrivilegeType_Grant))
+	policies, err := mt.ListPolicy(ctx, util.DefaultTenant)
+	require.NoError(t, err)
+	require.Len(t, policies, 1)
+
+	require.NoError(t, mt.DropRole(ctx, util.DefaultTenant, roleName))
+
+	// role record gone.
+	_, err = mt.SelectRole(ctx, util.DefaultTenant, &milvuspb.RoleEntity{Name: roleName}, false)
+	require.ErrorIs(t, err, merr.ErrIoKeyNotFound)
+	// user-role mappings gone.
+	userRoles, err := mt.ListUserRole(ctx, util.DefaultTenant)
+	require.NoError(t, err)
+	require.Empty(t, userRoles)
+	// grants gone - no orphaned policy survives the drop.
+	policies, err = mt.ListPolicy(ctx, util.DefaultTenant)
+	require.NoError(t, err)
+	require.Empty(t, policies)
 }
 
 func TestRbacOperateRole(t *testing.T) {

--- a/internal/rootcoord/meta_table_test.go
+++ b/internal/rootcoord/meta_table_test.go
@@ -1786,11 +1786,12 @@ func TestMetaTable_getLatestCollectionByIDInternal(t *testing.T) {
 func TestMetaTable_RemoveCollection(t *testing.T) {
 	t.Run("catalog error", func(t *testing.T) {
 		catalog := mocks.NewRootCoordCatalog(t)
-		catalog.On("DropCollection",
+		catalog.On("Update",
 			mock.Anything, // context.Context
-			mock.Anything, // model.Collection
 			mock.AnythingOfType("uint64"),
-		).Return(errors.New("error mock DropCollection"))
+			mock.Anything, // metastore.UpdateAction
+			mock.Anything, // metastore.UpdateAction
+		).Return(errors.New("error mock Update"))
 
 		meta := &MetaTable{
 			collID2Meta: map[typeutil.UniqueID]*model.Collection{
@@ -1815,13 +1816,11 @@ func TestMetaTable_RemoveCollection(t *testing.T) {
 
 	t.Run("normal case", func(t *testing.T) {
 		catalog := mocks.NewRootCoordCatalog(t)
-		catalog.On("DropCollection",
+		catalog.On("Update",
 			mock.Anything, // context.Context
-			mock.Anything, // model.Collection
 			mock.AnythingOfType("uint64"),
-		).Return(nil)
-		catalog.On("DeleteGrantByCollectionName",
-			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, // metastore.UpdateAction
+			mock.Anything, // metastore.UpdateAction
 		).Return(nil)
 		meta := &MetaTable{
 			catalog: catalog,
@@ -1842,17 +1841,20 @@ func TestMetaTable_RemoveCollection(t *testing.T) {
 	})
 }
 
-func TestMetaTable_RemoveCollection_GrantDeleteBestEffort(t *testing.T) {
-	// When DeleteGrantByCollectionName fails, RemoveCollection should still succeed (best-effort)
+// TestMetaTable_RemoveCollection_UsesCompositeUpdate proves RemoveCollection
+// issues one composite catalog.Update - grant cleanup composed before the
+// collection removal - instead of the legacy DropCollection +
+// DeleteGrantByCollectionName call pair, so a crash cannot leave the
+// collection removed with its grants orphaned, and a grant-cleanup failure
+// now fails the drop (retryable) instead of being warn-and-skipped.
+func TestMetaTable_RemoveCollection_UsesCompositeUpdate(t *testing.T) {
 	catalog := mocks.NewRootCoordCatalog(t)
-	catalog.On("DropCollection",
-		mock.Anything,
-		mock.Anything,
-		mock.AnythingOfType("uint64"),
-	).Return(nil)
-	catalog.On("DeleteGrantByCollectionName",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-	).Return(errors.New("grant delete failed"))
+	var gotActions []metastore.UpdateAction
+	catalog.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ uint64, actions ...metastore.UpdateAction) error {
+			gotActions = actions
+			return nil
+		}).Once()
 
 	meta := &MetaTable{
 		catalog:            catalog,
@@ -1860,15 +1862,35 @@ func TestMetaTable_RemoveCollection_GrantDeleteBestEffort(t *testing.T) {
 		aliases:            newNameDb(),
 		fileResourceRefCnt: make(map[int64]int),
 		collID2Meta: map[typeutil.UniqueID]*model.Collection{
-			100: {Name: "collection", State: pb.CollectionState_CollectionDropping},
+			100: {
+				CollectionID: 100,
+				Name:         "collection",
+				DBName:       "db1",
+				State:        pb.CollectionState_CollectionDropping,
+			},
 		},
 	}
 	channel.ResetStaticPChannelStatsManager()
 	channel.RecoverPChannelStatsManager([]string{})
-	meta.names.insert("", "collection", 100)
+	meta.names.insert("db1", "collection", 100)
 	ctx := context.Background()
-	err := meta.RemoveCollection(ctx, 100, 9999)
-	assert.NoError(t, err)
+	assert.NoError(t, meta.RemoveCollection(ctx, 100, 9999))
+
+	if assert.Len(t, gotActions, 2) {
+		grants, ok := gotActions[0].Entry.(metastore.CollectionGrantsEntry)
+		if assert.True(t, ok) {
+			assert.Equal(t, metastore.ActionDelete, gotActions[0].Type)
+			assert.Equal(t, "db1", grants.DBName)
+			assert.Equal(t, "collection", grants.CollectionName)
+		}
+		coll, ok := gotActions[1].Entry.(metastore.CollectionEntry)
+		if assert.True(t, ok) {
+			assert.Equal(t, metastore.ActionDelete, gotActions[1].Type)
+			assert.Equal(t, int64(100), coll.Collection.CollectionID)
+		}
+	}
+	_, ok := meta.collID2Meta[100]
+	assert.False(t, ok)
 }
 
 func TestMetaTable_DropCollection_GrantCleanup(t *testing.T) {

--- a/internal/rootcoord/meta_table_test.go
+++ b/internal/rootcoord/meta_table_test.go
@@ -594,7 +594,7 @@ func TestRbacDropRole(t *testing.T) {
 
 // TestRbacDropRoleAlsoDropsGrants: DropRole must take down the whole role
 // chain - role record, user-role mappings AND every grant of the role - in
-// one composite catalog write, so no separate DropGrant call is needed and a
+// one composite catalog write, so no separate grant-cleanup call is needed and a
 // crash can never leave orphaned grants behind a deleted role.
 func TestRbacDropRoleAlsoDropsGrants(t *testing.T) {
 	mt := &MetaTable{catalog: rootcoord.NewCatalog(memkv.NewMemoryKV())}
@@ -895,32 +895,6 @@ func TestRbacSelectGrant(t *testing.T) {
 			if test.isValid {
 				assert.NoError(t, err)
 				assert.Equal(t, 0, len(entities))
-			} else {
-				assert.Error(t, err)
-			}
-		})
-	}
-}
-
-func TestRbacDropGrant(t *testing.T) {
-	mt := generateMetaTable(t)
-
-	tests := []struct {
-		description string
-
-		isValid bool
-		role    *milvuspb.RoleEntity
-	}{
-		{"nil role", false, nil},
-		{"empty Role name", false, &milvuspb.RoleEntity{Name: ""}},
-		{"valid", true, &milvuspb.RoleEntity{Name: "role"}},
-	}
-
-	for _, test := range tests {
-		t.Run(test.description, func(t *testing.T) {
-			err := mt.DropGrant(context.TODO(), util.DefaultTenant, test.role)
-			if test.isValid {
-				assert.NoError(t, err)
 			} else {
 				assert.Error(t, err)
 			}

--- a/internal/rootcoord/meta_table_test.go
+++ b/internal/rootcoord/meta_table_test.go
@@ -1957,6 +1957,84 @@ func buildAlterCollectionSchemaResult(collectionID int64, schema *schemapb.Colle
 	}
 }
 
+func buildAlterCollectionRenameResult(collectionID int64, newName string, timetick uint64) message.BroadcastResultAlterCollectionMessageV2 {
+	controlChannel := funcutil.GetControlChannel("test")
+	raw := message.NewAlterCollectionMessageBuilderV2().
+		WithHeader(&messagespb.AlterCollectionMessageHeader{
+			CollectionId: collectionID,
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{message.FieldMaskCollectionName},
+			},
+		}).
+		WithBody(&messagespb.AlterCollectionMessageBody{
+			Updates: &messagespb.AlterCollectionMessageUpdates{
+				CollectionName: newName,
+			},
+		}).
+		WithBroadcast([]string{controlChannel}).
+		MustBuildBroadcast()
+	return message.BroadcastResultAlterCollectionMessageV2{
+		Message: message.MustAsBroadcastAlterCollectionMessageV2(raw),
+		Results: map[string]*message.AppendResult{
+			controlChannel: {TimeTick: timetick},
+		},
+	}
+}
+
+// TestMetaTable_AlterCollection_RenameUsesCompositeUpdate proves the rename
+// branch of AlterCollection issues one composite catalog.Update - grant
+// migration composed before the record rewrite - instead of the legacy
+// AlterCollection + MigrateGrantCollectionName call pair, so a crash cannot
+// leave the collection renamed with its grants still keyed by the old name.
+func TestMetaTable_AlterCollection_RenameUsesCompositeUpdate(t *testing.T) {
+	catalog := mocks.NewRootCoordCatalog(t)
+	var gotActions []metastore.UpdateAction
+	catalog.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ uint64, actions ...metastore.UpdateAction) error {
+			gotActions = actions
+			return nil
+		}).Once()
+
+	meta := &MetaTable{
+		catalog: catalog,
+		names:   newNameDb(),
+		aliases: newNameDb(),
+		collID2Meta: map[typeutil.UniqueID]*model.Collection{
+			1: {
+				CollectionID: 1,
+				Name:         "old",
+				DBName:       util.DefaultDBName,
+				DBID:         util.DefaultDBID,
+				State:        pb.CollectionState_CollectionCreated,
+			},
+		},
+	}
+	meta.names.insert(util.DefaultDBName, "old", 1)
+
+	err := meta.AlterCollection(context.Background(), buildAlterCollectionRenameResult(1, "new", 100))
+	assert.NoError(t, err)
+
+	if assert.Len(t, gotActions, 2) {
+		mig, ok := gotActions[0].Entry.(metastore.GrantMigrateEntry)
+		if assert.True(t, ok) {
+			assert.Equal(t, util.DefaultDBName, mig.OldDBName)
+			assert.Equal(t, "old", mig.OldName)
+			assert.Equal(t, util.DefaultDBName, mig.NewDBName)
+			assert.Equal(t, "new", mig.NewName)
+		}
+		ren, ok := gotActions[1].Entry.(metastore.CollectionRenameEntry)
+		if assert.True(t, ok) {
+			assert.Equal(t, "old", ren.Old.Name)
+			assert.Equal(t, "new", ren.New.Name)
+		}
+	}
+
+	id, ok := meta.names.get(util.DefaultDBName, "new")
+	assert.True(t, ok)
+	assert.Equal(t, int64(1), id)
+	assert.Equal(t, "new", meta.collID2Meta[1].Name)
+}
+
 func TestMetaTableAlterCollectionFileResourceRefCnt(t *testing.T) {
 	const (
 		collectionID = int64(100)

--- a/internal/rootcoord/mock_test.go
+++ b/internal/rootcoord/mock_test.go
@@ -96,7 +96,6 @@ type mockMetaTable struct {
 	SelectUserFunc                   func(ctx context.Context, tenant string, entity *milvuspb.UserEntity, includeRoleInfo bool) ([]*milvuspb.UserResult, error)
 	OperatePrivilegeFunc             func(ctx context.Context, tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) error
 	SelectGrantFunc                  func(ctx context.Context, tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error)
-	DropGrantFunc                    func(ctx context.Context, tenant string, role *milvuspb.RoleEntity) error
 	ListPolicyFunc                   func(ctx context.Context, tenant string) ([]*milvuspb.GrantEntity, error)
 	ListUserRoleFunc                 func(ctx context.Context, tenant string) ([]string, error)
 	DescribeDatabaseFunc             func(ctx context.Context, dbName string) (*model.Database, error)
@@ -242,10 +241,6 @@ func (m mockMetaTable) OperatePrivilege(ctx context.Context, tenant string, enti
 
 func (m mockMetaTable) SelectGrant(ctx context.Context, tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error) {
 	return m.SelectGrantFunc(ctx, tenant, entity)
-}
-
-func (m mockMetaTable) DropGrant(ctx context.Context, tenant string, role *milvuspb.RoleEntity) error {
-	return m.DropGrantFunc(ctx, tenant, role)
 }
 
 func (m mockMetaTable) ListPolicy(ctx context.Context, tenant string) ([]*milvuspb.GrantEntity, error) {
@@ -546,9 +541,6 @@ func withInvalidMeta() Opt {
 	}
 	meta.SelectGrantFunc = func(ctx context.Context, tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error) {
 		return nil, errors.New("error mock SelectGrant")
-	}
-	meta.DropGrantFunc = func(ctx context.Context, tenant string, role *milvuspb.RoleEntity) error {
-		return errors.New("error mock DropGrant")
 	}
 	meta.ListPolicyFunc = func(ctx context.Context, tenant string) ([]*milvuspb.GrantEntity, error) {
 		return nil, errors.New("error mock ListPolicy")

--- a/internal/rootcoord/mocks/meta_table.go
+++ b/internal/rootcoord/mocks/meta_table.go
@@ -5,16 +5,12 @@ package mockrootcoord
 import (
 	context "context"
 
-	internalpb "github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
-	message "github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
-
-	messagespb "github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
-
 	milvuspb "github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
-
-	mock "github.com/stretchr/testify/mock"
-
 	model "github.com/milvus-io/milvus/internal/metastore/model"
+	internalpb "github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	messagespb "github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
+	message "github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	mock "github.com/stretchr/testify/mock"
 
 	rootcoordpb "github.com/milvus-io/milvus/pkg/v3/proto/rootcoordpb"
 )
@@ -1744,54 +1740,6 @@ func (_c *IMetaTable_DropDatabase_Call) Return(_a0 error) *IMetaTable_DropDataba
 }
 
 func (_c *IMetaTable_DropDatabase_Call) RunAndReturn(run func(context.Context, string, uint64) error) *IMetaTable_DropDatabase_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// DropGrant provides a mock function with given fields: ctx, tenant, role
-func (_m *IMetaTable) DropGrant(ctx context.Context, tenant string, role *milvuspb.RoleEntity) error {
-	ret := _m.Called(ctx, tenant, role)
-
-	if len(ret) == 0 {
-		panic("no return value specified for DropGrant")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, *milvuspb.RoleEntity) error); ok {
-		r0 = rf(ctx, tenant, role)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// IMetaTable_DropGrant_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DropGrant'
-type IMetaTable_DropGrant_Call struct {
-	*mock.Call
-}
-
-// DropGrant is a helper method to define mock.On call
-//   - ctx context.Context
-//   - tenant string
-//   - role *milvuspb.RoleEntity
-func (_e *IMetaTable_Expecter) DropGrant(ctx interface{}, tenant interface{}, role interface{}) *IMetaTable_DropGrant_Call {
-	return &IMetaTable_DropGrant_Call{Call: _e.mock.On("DropGrant", ctx, tenant, role)}
-}
-
-func (_c *IMetaTable_DropGrant_Call) Run(run func(ctx context.Context, tenant string, role *milvuspb.RoleEntity)) *IMetaTable_DropGrant_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(*milvuspb.RoleEntity))
-	})
-	return _c
-}
-
-func (_c *IMetaTable_DropGrant_Call) Return(_a0 error) *IMetaTable_DropGrant_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *IMetaTable_DropGrant_Call) RunAndReturn(run func(context.Context, string, *milvuspb.RoleEntity) error) *IMetaTable_DropGrant_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/kv/kv.go
+++ b/pkg/kv/kv.go
@@ -18,10 +18,13 @@ package kv
 
 import (
 	"context"
+	"sort"
+	"strings"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // CompareFailedError is a helper type for checking MetaKv CompareAndSwap series func error type
@@ -66,7 +69,7 @@ type TxnKV interface {
 	// all in one transaction. MultiSaveAndRemoveWithPrefix cannot express this
 	// mix - it widens EVERY removal to a prefix delete. A key present in both
 	// @saves and @removals is saved, not removed; a saved key under a removed
-	// prefix is backend-dependent (etcd rejects the txn) and must be avoided.
+	// prefix is rejected because backend semantics differ for that overlap.
 	MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error
 	// MaxTxnOps reports the maximum number of key operations this store applies
 	// as a single atomic transaction; a batch exceeding it must be split by the
@@ -75,6 +78,29 @@ type TxnKV interface {
 	// rather than a backend-specific constant. It bounds op COUNT only, not the
 	// request's total byte size.
 	MaxTxnOps() int
+}
+
+// ValidateNoSaveUnderRemovedPrefix rejects ambiguous mixed transactions where
+// a saved key also falls under a prefix removal.
+func ValidateNoSaveUnderRemovedPrefix(saves map[string]string, prefixRemovals []string) error {
+	if len(saves) == 0 || len(prefixRemovals) == 0 {
+		return nil
+	}
+
+	saveKeys := make([]string, 0, len(saves))
+	for key := range saves {
+		saveKeys = append(saveKeys, key)
+	}
+	sort.Strings(saveKeys)
+
+	for _, prefix := range prefixRemovals {
+		i := sort.SearchStrings(saveKeys, prefix)
+		if i < len(saveKeys) && strings.HasPrefix(saveKeys[i], prefix) {
+			return merr.WrapErrParameterInvalidMsg(
+				"save key %q conflicts with removed prefix %q", saveKeys[i], prefix)
+		}
+	}
+	return nil
 }
 
 // MetaKv is TxnKV for metadata. It should save data with lease.

--- a/pkg/kv/kv.go
+++ b/pkg/kv/kv.go
@@ -61,6 +61,13 @@ type TxnKV interface {
 	BaseKV
 	MultiSaveAndRemove(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error
 	MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error
+	// MultiSaveAndRemoveMixed saves kv in @saves, removes the exact keys in
+	// @removals AND removes every key under the prefixes in @prefixRemovals,
+	// all in one transaction. MultiSaveAndRemoveWithPrefix cannot express this
+	// mix - it widens EVERY removal to a prefix delete. A key present in both
+	// @saves and @removals is saved, not removed; a saved key under a removed
+	// prefix is backend-dependent (etcd rejects the txn) and must be avoided.
+	MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error
 	// MaxTxnOps reports the maximum number of key operations this store applies
 	// as a single atomic transaction; a batch exceeding it must be split by the
 	// caller. This is a per-store property (etcd's is small, TiKV's is large),

--- a/pkg/kv/kv_test.go
+++ b/pkg/kv/kv_test.go
@@ -1,0 +1,50 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+func TestValidateNoSaveUnderRemovedPrefix(t *testing.T) {
+	t.Run("rejects save under removed prefix", func(t *testing.T) {
+		err := ValidateNoSaveUnderRemovedPrefix(
+			map[string]string{"mix/a-1/c3": "new"}, []string{"mix/a-1/"})
+
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("allows adjacent prefix canary", func(t *testing.T) {
+		err := ValidateNoSaveUnderRemovedPrefix(
+			map[string]string{"mix/a-10": "keep"}, []string{"mix/a-1/"})
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects empty prefix when saves exist", func(t *testing.T) {
+		err := ValidateNoSaveUnderRemovedPrefix(
+			map[string]string{"any/key": "value"}, []string{""})
+
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+}

--- a/pkg/kv/reliable_write_meta_kv.go
+++ b/pkg/kv/reliable_write_meta_kv.go
@@ -68,6 +68,12 @@ func (kv *ReliableWriteMetaKv) MultiSaveAndRemoveWithPrefix(ctx context.Context,
 	})
 }
 
+func (kv *ReliableWriteMetaKv) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	return kv.retryWithBackoff(ctx, func(ctx context.Context) error {
+		return kv.MetaKv.MultiSaveAndRemoveMixed(ctx, saves, removals, prefixRemovals, preds...)
+	})
+}
+
 func (kv *ReliableWriteMetaKv) CompareVersionAndSwap(ctx context.Context, key string, version int64, target string) (bool, error) {
 	var result bool
 	err := kv.retryWithBackoff(ctx, func(ctx context.Context) error {

--- a/pkg/kv/rocksdb/rocksdb_kv.go
+++ b/pkg/kv/rocksdb/rocksdb_kv.go
@@ -456,6 +456,35 @@ func (kv *RocksdbKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map
 	return err
 }
 
+// MultiSaveAndRemoveMixed saves kv in @saves, removes the exact keys in
+// @removals and removes every key under the prefixes in @prefixRemovals in a
+// single write batch.
+func (kv *RocksdbKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	if len(preds) > 0 {
+		return merr.WrapErrServiceUnavailable("predicates not supported")
+	}
+	if kv.DB == nil {
+		return merr.WrapErrServiceInternalMsg("Rocksdb instance is nil when do MultiSaveAndRemoveMixed")
+	}
+	writeBatch := gorocksdb.NewWriteBatch()
+	defer writeBatch.Destroy()
+	// use complement to remove keys that are not in saves
+	saveKeys := typeutil.NewSet(lo.Keys(saves)...)
+	removeKeys := typeutil.NewSet(removals...)
+	removals = removeKeys.Complement(saveKeys).Collect()
+
+	for _, key := range removals {
+		writeBatch.Delete([]byte(key))
+	}
+	kv.prepareRemovePrefix(prefixRemovals, writeBatch)
+	for k, v := range saves {
+		writeBatch.Put([]byte(k), []byte(v))
+	}
+
+	err := kv.DB.Write(kv.WriteOptions, writeBatch)
+	return err
+}
+
 func (kv *RocksdbKV) prepareRemovePrefix(prefixes []string, writeBatch *gorocksdb.WriteBatch) {
 	// check if any empty prefix, if yes then we delete whole table, no more data should be remained
 	for _, prefix := range prefixes {

--- a/pkg/kv/rocksdb/rocksdb_kv.go
+++ b/pkg/kv/rocksdb/rocksdb_kv.go
@@ -23,13 +23,13 @@ import (
 	"github.com/samber/lo"
 	"github.com/tecbot/gorocksdb"
 
-	"github.com/milvus-io/milvus/pkg/v3/kv"
+	kvpkg "github.com/milvus-io/milvus/pkg/v3/kv"
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
-var _ kv.BaseKV = (*RocksdbKV)(nil)
+var _ kvpkg.BaseKV = (*RocksdbKV)(nil)
 
 // RocksdbKV is KV implemented by rocksdb
 type RocksdbKV struct {
@@ -462,6 +462,9 @@ func (kv *RocksdbKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map
 func (kv *RocksdbKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
 	if len(preds) > 0 {
 		return merr.WrapErrServiceUnavailable("predicates not supported")
+	}
+	if err := kvpkg.ValidateNoSaveUnderRemovedPrefix(saves, prefixRemovals); err != nil {
+		return err
 	}
 	if kv.DB == nil {
 		return merr.WrapErrServiceInternalMsg("Rocksdb instance is nil when do MultiSaveAndRemoveMixed")

--- a/pkg/mocks/mock_kv/mock_MetaKv.go
+++ b/pkg/mocks/mock_kv/mock_MetaKv.go
@@ -659,6 +659,70 @@ func (_c *MockMetaKv_MultiSaveAndRemove_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
+// MultiSaveAndRemoveMixed provides a mock function with given fields: ctx, saves, removals, prefixRemovals, preds
+func (_m *MockMetaKv) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	_va := make([]interface{}, len(preds))
+	for _i := range preds {
+		_va[_i] = preds[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, saves, removals, prefixRemovals)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MultiSaveAndRemoveMixed")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, map[string]string, []string, []string, ...predicates.Predicate) error); ok {
+		r0 = rf(ctx, saves, removals, prefixRemovals, preds...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockMetaKv_MultiSaveAndRemoveMixed_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MultiSaveAndRemoveMixed'
+type MockMetaKv_MultiSaveAndRemoveMixed_Call struct {
+	*mock.Call
+}
+
+// MultiSaveAndRemoveMixed is a helper method to define mock.On call
+//   - ctx context.Context
+//   - saves map[string]string
+//   - removals []string
+//   - prefixRemovals []string
+//   - preds ...predicates.Predicate
+func (_e *MockMetaKv_Expecter) MultiSaveAndRemoveMixed(ctx interface{}, saves interface{}, removals interface{}, prefixRemovals interface{}, preds ...interface{}) *MockMetaKv_MultiSaveAndRemoveMixed_Call {
+	return &MockMetaKv_MultiSaveAndRemoveMixed_Call{Call: _e.mock.On("MultiSaveAndRemoveMixed",
+		append([]interface{}{ctx, saves, removals, prefixRemovals}, preds...)...)}
+}
+
+func (_c *MockMetaKv_MultiSaveAndRemoveMixed_Call) Run(run func(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate)) *MockMetaKv_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]predicates.Predicate, len(args)-4)
+		for i, a := range args[4:] {
+			if a != nil {
+				variadicArgs[i] = a.(predicates.Predicate)
+			}
+		}
+		run(args[0].(context.Context), args[1].(map[string]string), args[2].([]string), args[3].([]string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockMetaKv_MultiSaveAndRemoveMixed_Call) Return(_a0 error) *MockMetaKv_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockMetaKv_MultiSaveAndRemoveMixed_Call) RunAndReturn(run func(context.Context, map[string]string, []string, []string, ...predicates.Predicate) error) *MockMetaKv_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MultiSaveAndRemoveWithPrefix provides a mock function with given fields: ctx, saves, removals, preds
 func (_m *MockMetaKv) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
 	_va := make([]interface{}, len(preds))

--- a/pkg/mocks/mock_kv/mock_WatchKV.go
+++ b/pkg/mocks/mock_kv/mock_WatchKV.go
@@ -661,6 +661,70 @@ func (_c *MockWatchKV_MultiSaveAndRemove_Call) RunAndReturn(run func(context.Con
 	return _c
 }
 
+// MultiSaveAndRemoveMixed provides a mock function with given fields: ctx, saves, removals, prefixRemovals, preds
+func (_m *MockWatchKV) MultiSaveAndRemoveMixed(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate) error {
+	_va := make([]interface{}, len(preds))
+	for _i := range preds {
+		_va[_i] = preds[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, saves, removals, prefixRemovals)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MultiSaveAndRemoveMixed")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, map[string]string, []string, []string, ...predicates.Predicate) error); ok {
+		r0 = rf(ctx, saves, removals, prefixRemovals, preds...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockWatchKV_MultiSaveAndRemoveMixed_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MultiSaveAndRemoveMixed'
+type MockWatchKV_MultiSaveAndRemoveMixed_Call struct {
+	*mock.Call
+}
+
+// MultiSaveAndRemoveMixed is a helper method to define mock.On call
+//   - ctx context.Context
+//   - saves map[string]string
+//   - removals []string
+//   - prefixRemovals []string
+//   - preds ...predicates.Predicate
+func (_e *MockWatchKV_Expecter) MultiSaveAndRemoveMixed(ctx interface{}, saves interface{}, removals interface{}, prefixRemovals interface{}, preds ...interface{}) *MockWatchKV_MultiSaveAndRemoveMixed_Call {
+	return &MockWatchKV_MultiSaveAndRemoveMixed_Call{Call: _e.mock.On("MultiSaveAndRemoveMixed",
+		append([]interface{}{ctx, saves, removals, prefixRemovals}, preds...)...)}
+}
+
+func (_c *MockWatchKV_MultiSaveAndRemoveMixed_Call) Run(run func(ctx context.Context, saves map[string]string, removals []string, prefixRemovals []string, preds ...predicates.Predicate)) *MockWatchKV_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]predicates.Predicate, len(args)-4)
+		for i, a := range args[4:] {
+			if a != nil {
+				variadicArgs[i] = a.(predicates.Predicate)
+			}
+		}
+		run(args[0].(context.Context), args[1].(map[string]string), args[2].([]string), args[3].([]string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockWatchKV_MultiSaveAndRemoveMixed_Call) Return(_a0 error) *MockWatchKV_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockWatchKV_MultiSaveAndRemoveMixed_Call) RunAndReturn(run func(context.Context, map[string]string, []string, []string, ...predicates.Predicate) error) *MockWatchKV_MultiSaveAndRemoveMixed_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MultiSaveAndRemoveWithPrefix provides a mock function with given fields: ctx, saves, removals, preds
 func (_m *MockWatchKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
 	_va := make([]interface{}, len(preds))


### PR DESCRIPTION
issue: #51351
**Stacked on #52214** — the first 3 commits (`support mixed exact and prefix removals` / `drop role and its grants` / `release collection load info`) belong to that PR; review this one from `enhance: persist collection and partition load info atomically` onward (8 commits).

## What

#51624 introduced the composite `Update(actions...)` primitive but migrated only 7 call sites. This PR extends coverage to every remaining "logically one change, persisted as several independent writes" site across the coordinators, so each lands in one composite transaction (atomic when it fits the txn limit; commit-marker-last on the chunked fallback):

1. **querycoord collection load** — load-info + partition load-infos in one txn (was: two steps; a crash left a collection loaded with zero partitions).
2. **rootcoord rename** — collection record + db pointer + grant-key rewrite in one txn (was: three sequential writes).
3. **rootcoord drop collection** — collection drop + its grant cleanup in one txn (was: two orchestrated calls, orphaned grants on crash).
4. **rootcoord grant mutations** — AlterGrant's three modes (grant / revoke / legacy-id migration) each single-txn; RestoreRBAC batched composite (per-batch atomic, oversized single entities split).
5. **datacoord import** — job + first task batch in one txn, job record as commit marker (the intentional per-vchannel 2PC in `HandleCommitVchannel` is untouched).
6. **datacoord compaction completion** — clustering's two-part write unified; sort / bump-schema-version paths moved onto the same composite encoding (byte-for-byte identical to legacy `AlterSegments`).
7. **streamingcoord** — the whole catalog moved onto the shared txn engine (replicate-configuration composite with config as marker); streaming mocks generated.
8. **cleanup** — unreachable legacy methods removed (`MetaTable.DropGrant`/`IMetaTable.DropGrant` and friends); `ActionUpdate` doc corrected to its actual replace/upsert semantics (as discussed in #51624 review).

`DropExternalCollectionRefreshJob/Task` are intentionally left in place: #51892 is rewriting that subsystem; this PR does not touch external-collection-refresh files.

## Crash-safety hardening found in adversarial review

- **Import ambiguous-commit rollback (data-loss class)**: the initial import composite rolled back task records whenever `catalog.Update` returned an error — but on an applied-yet-timed-out etcd txn the job marker was already durable, and the rollback deleted task records a committed job referenced; after a restart the checker would drive a task-less job to "completed" without importing anything. Fixed with a read-back disambiguation (`readBackJobMarker`): marker committed → adopt as success; marker provably absent → roll back; read-back failed → leave for restart adoption. Regression tests inject the ambiguous failure both ways.
- **RestoreRBAC oversized entity**: a single entity exceeding `MaxTxnOps` (e.g. a user with 64+ role mappings) is now split instead of producing a rejected oversized txn.
- **Transient-error handling in import checker**: marker-only write failures retry on the next tick instead of permanently failing the job.

## Testing

TDD throughout (each commit carries tests written first and observed failing). Test bar follows #51624: byte-for-byte encoding equivalence against the legacy paths, ordering, atomic + chunked-fallback crash injection (including second-chunk crashes), idempotent retry, ambiguous-failure injection. Full `internal/metastore/...`, `internal/kv/...`, `internal/querycoordv2/meta/...`, `internal/rootcoord/...`, `internal/datacoord/...` suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
