### PR TITLE
fix: store the literal a REST caller wrote in a VARCHAR field

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -432,6 +432,12 @@ proxy:
     debug_mode: false # Whether to enable http server debug mode
     port:  # high-level restful api
     acceptTypeAllowInt64: true # high-level restful api, whether http client can deal with int64
+    # high-level restful api, restore the value handling of releases that predate the REST insert validation work.
+    # When true the server keeps the previous lenient behaviour: a missing or null non-nullable field is stored as an
+    # empty value, out-of-range integers wrap instead of being rejected, numbers reach VarChar and JSON fields through
+    # their float64 rendering, and integers too large for the JSON engine become 0. This is a temporary escape hatch
+    # for clients that have not been corrected yet: every one of those behaviours silently changes what is stored.
+    compatibilityMode: false
     enablePprof: true # Whether to enable pprof middleware on the metrics port
     readHeaderTimeout: 5s # HTTP server timeout for reading request headers
     readTimeout: 0s # HTTP server timeout for reading the entire request, including the body. 0 disables this timeout

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -472,7 +472,13 @@ func printIndexes(indexes []*milvuspb.IndexDescription) []gin.H {
 //
 // An object or an array is rejected. Storing its text is never what the caller
 // meant and it hides the common mistake of addressing the wrong field.
-func stringFieldValue(field string, value gjson.Result) (string, error) {
+//
+// proxy.http.compatibilityMode restores the previous String() rendering for
+// every kind, including the object case.
+func stringFieldValue(field string, value gjson.Result, compatibilityMode bool) (string, error) {
+	if compatibilityMode {
+		return value.String(), nil
+	}
 	switch value.Type {
 	case gjson.Number, gjson.True, gjson.False:
 		return value.Raw, nil
@@ -492,6 +498,9 @@ func stringFieldValue(field string, value gjson.Result) (string, error) {
 func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partialUpdate bool) ([]map[string]interface{}, map[string][]bool, error) {
 	var reallyDataArray []map[string]interface{}
 	validDataMap := make(map[string][]bool)
+	// Escape hatch for clients that relied on the previous value handling.
+	// Read once per request rather than per field.
+	compatibilityMode := paramtable.Get().HTTPCfg.CompatibilityMode.GetAsBool()
 	dataResult := gjson.GetBytes(body, HTTPRequestData)
 	dataResultArray := dataResult.Array()
 	if len(dataResultArray) == 0 {
@@ -802,7 +811,7 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 				case schemapb.DataType_Timestamptz:
 					reallyData[fieldName] = dataString
 				case schemapb.DataType_VarChar, schemapb.DataType_String:
-					value, err := stringFieldValue(fieldName, fieldValue)
+					value, err := stringFieldValue(fieldName, fieldValue, compatibilityMode)
 					if err != nil {
 						return reallyDataArray, validDataMap, err
 					}

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -463,6 +463,32 @@ func printIndexes(indexes []*milvuspb.IndexDescription) []gin.H {
 
 // --------------------- insert param --------------------- //
 
+// stringFieldValue converts a JSON value for a VARCHAR or STRING field.
+//
+// A number is taken from the literal the caller wrote rather than from gjson's
+// String(), which renders it through float64 with the 'f' verb: that turned
+// 1e300 into a 301 byte decimal expansion, dropped the last digit of
+// 9007199254740993.0, and rewrote 1.50 as 1.5.
+//
+// An object or an array is rejected. Storing its text is never what the caller
+// meant and it hides the common mistake of addressing the wrong field.
+func stringFieldValue(field string, value gjson.Result) (string, error) {
+	switch value.Type {
+	case gjson.Number, gjson.True, gjson.False:
+		return value.Raw, nil
+	case gjson.JSON:
+		kind := "object"
+		if value.IsArray() {
+			kind = "array"
+		}
+		return "", merr.WrapErrParameterInvalidMsg(
+			"field %s expects a string, got a JSON %s", field, kind)
+	default:
+		// String, plus Null which the nullable handling above already resolved.
+		return value.String(), nil
+	}
+}
+
 func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partialUpdate bool) ([]map[string]interface{}, map[string][]bool, error) {
 	var reallyDataArray []map[string]interface{}
 	validDataMap := make(map[string][]bool)
@@ -775,10 +801,12 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 					reallyData[fieldName] = result
 				case schemapb.DataType_Timestamptz:
 					reallyData[fieldName] = dataString
-				case schemapb.DataType_VarChar:
-					reallyData[fieldName] = dataString
-				case schemapb.DataType_String:
-					reallyData[fieldName] = dataString
+				case schemapb.DataType_VarChar, schemapb.DataType_String:
+					value, err := stringFieldValue(fieldName, fieldValue)
+					if err != nil {
+						return reallyDataArray, validDataMap, err
+					}
+					reallyData[fieldName] = value
 				default:
 					return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid("", schemapb.DataType_name[int32(fieldType)], "fieldName: "+fieldName)
 				}

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -5088,6 +5089,36 @@ func TestCheckAndSetDataStringFieldRejectsStructures(t *testing.T) {
 			assert.Contains(t, err.Error(), "name")
 			assert.Contains(t, err.Error(), "expects a string")
 			assert.Contains(t, err.Error(), tt.kind)
+		})
+	}
+}
+
+// proxy.http.compatibilityMode restores the previous String() rendering for a
+// string field, including accepting an object as its text.
+func TestCheckAndSetDataStringFieldCompatibilityMode(t *testing.T) {
+	paramtable.Init()
+	key := paramtable.Get().HTTPCfg.CompatibilityMode.Key
+	paramtable.Get().Save(key, "true")
+	defer paramtable.Get().Reset(key)
+
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"object is stringified again", `{"a": 1}`, `{"a": 1}`},
+		{"array is stringified again", `[1, 2]`, `[1, 2]`},
+		{"decimal point is dropped again", `1.0`, `1`},
+		{"exponent is expanded again", `1e19`, `10000000000000000000`},
+		{"string is unchanged", `"abc"`, `abc`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows, err := insertOneStringValue(t, tt.value)
+			require.NoError(t, err)
+			require.Len(t, rows, 1)
+			assert.Equal(t, tt.expected, rows[0]["name"])
 		})
 	}
 }

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -5006,3 +5006,88 @@ func TestEncodeEmbListQueryErrorPaths(t *testing.T) {
 	_, err = encodeEmbListQuery(gjson.Parse(`[[true]]`).Array(), schemapb.DataType_Bool, 1, 0)
 	assert.Error(t, err)
 }
+
+func stringFieldTestSchema() *schemapb.CollectionSchema {
+	vectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+	vectorField.Name = "vector"
+	return &schemapb.CollectionSchema{
+		Name: DefaultCollectionName,
+		Fields: []*schemapb.FieldSchema{
+			generatePrimaryField(schemapb.DataType_Int64, false),
+			vectorField,
+			{Name: "name", DataType: schemapb.DataType_VarChar},
+		},
+	}
+}
+
+func insertOneStringValue(t *testing.T, value string) ([]map[string]interface{}, error) {
+	t.Helper()
+	body := []byte(fmt.Sprintf(
+		`{"data": {"%s": 1, "vector": [0.1, 0.2], "name": %s}}`, FieldBookID, value))
+	rows, _, err := checkAndSetData(body, stringFieldTestSchema(), false)
+	return rows, err
+}
+
+// gjson's String() renders a number through float64 with the 'f' verb, so the
+// stored text was not the text the caller wrote.
+func TestCheckAndSetDataStringFieldKeepsNumberLiteral(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"string passes through", `"abc"`, `abc`},
+		{"escapes are decoded once", `"a\"b"`, `a"b`},
+		{"empty string", `""`, ``},
+		{"integer", `12345`, `12345`},
+		{"negative", `-7`, `-7`},
+		{"bool", `true`, `true`},
+		// each of these used to be rewritten
+		{"trailing zero is kept", `1.50`, `1.50`},
+		{"decimal point is kept", `1.0`, `1.0`},
+		{"exponent is kept", `1e19`, `1e19`},
+		{"large exponent is not expanded", `1e300`, `1e300`},
+		{"precision is kept", `9007199254740993.0`, `9007199254740993.0`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows, err := insertOneStringValue(t, tt.value)
+			require.NoError(t, err)
+			require.Len(t, rows, 1)
+			assert.Equal(t, tt.expected, rows[0]["name"])
+		})
+	}
+}
+
+// 1e300 used to be stored as its full decimal expansion: five bytes in, 301
+// bytes stored, and a max_length error that named a size the caller never sent.
+func TestCheckAndSetDataStringFieldDoesNotExpandExponents(t *testing.T) {
+	rows, err := insertOneStringValue(t, `1e300`)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Len(t, rows[0]["name"], len("1e300"))
+}
+
+func TestCheckAndSetDataStringFieldRejectsStructures(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		kind  string
+	}{
+		{"object", `{"a": 1}`, "object"},
+		{"array", `[1, 2]`, "array"},
+		{"empty object", `{}`, "object"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := insertOneStringValue(t, tt.value)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+			assert.Contains(t, err.Error(), "name")
+			assert.Contains(t, err.Error(), "expects a string")
+			assert.Contains(t, err.Error(), tt.kind)
+		})
+	}
+}

--- a/pkg/util/paramtable/http_param.go
+++ b/pkg/util/paramtable/http_param.go
@@ -21,6 +21,7 @@ type httpConfig struct {
 	DebugMode             ParamItem `refreshable:"false"`
 	Port                  ParamItem `refreshable:"false"`
 	AcceptTypeAllowInt64  ParamItem `refreshable:"true"`
+	CompatibilityMode     ParamItem `refreshable:"true"`
 	EnablePprof           ParamItem `refreshable:"false"`
 	RequestTimeoutMs      ParamItem `refreshable:"true"`
 	ReadHeaderTimeout     ParamItem `refreshable:"false"`
@@ -71,6 +72,20 @@ func (p *httpConfig) init(base *BaseTable) {
 		Export:       true,
 	}
 	p.AcceptTypeAllowInt64.Init(base.mgr)
+
+	p.CompatibilityMode = ParamItem{
+		Key:          "proxy.http.compatibilityMode",
+		DefaultValue: "false",
+		Version:      "2.7.0",
+		Doc: `high-level restful api, restore the value handling of releases that predate the REST insert
+validation work. When true the server keeps the previous lenient behaviour: a missing or null non-nullable field is
+stored as an empty value, out-of-range integers wrap instead of being rejected, numbers reach VarChar and JSON fields
+through their float64 rendering, and integers too large for the JSON engine become 0. This is a temporary escape hatch
+for clients that have not been corrected yet: every one of those behaviours silently changes what is stored.`,
+		PanicIfEmpty: false,
+		Export:       true,
+	}
+	p.CompatibilityMode.Init(base.mgr)
 
 	p.EnablePprof = ParamItem{
 		Key:          "proxy.http.enablePprof",


### PR DESCRIPTION
## What changed

- Build a VARCHAR / STRING value from the original token: `value.Raw` for
  numbers and booleans, the decoded string for strings.
- Reject a JSON object or array for a string field.
- Add coverage for every JSON value kind, for the exponent expansion, and for
  the rejected structures.

## Root cause

The branch stored `fieldValue.String()`, which is a rendering rather than the
token. gjson formats a number by parsing it into `float64` and printing it with
the `'f'` verb, which never uses exponent notation:

| request | stored before | stored after |
|---|---|---|
| `{"name": 1.50}` | `1.5` | `1.50` |
| `{"name": 1.0}` | `1` | `1.0` |
| `{"name": 9007199254740993.0}` | `9007199254740992` | `9007199254740993.0` |
| `{"name": 1e19}` | `10000000000000000000` | `1e19` |
| `{"name": 1e300}` | 301 bytes of digits | `1e300` |
| `{"name": {"a": 1}}` | `{"a":1}` | rejected |

Measured expansion: `1e19` -> 20 bytes, `1e100` -> 101, `1e300` -> 301,
`1e308` -> 309. Bounded by the float64 range, so not a denial-of-service, but a
field whose `max_length` is below the expansion fails with a size the caller
never sent.

The object case hides a different problem: addressing the wrong field is a
common client mistake, and storing the object's text swallows it.

## Compatibility

This changes what is stored for inputs that already worked, so it is worth
calling out explicitly:

- **A number in a string field keeps its literal form.** `{"sku": 12345}` is
  unchanged, since a plain integer renders to itself. Inputs written with a
  decimal point or an exponent change: `1.0` was stored as `1` and is now
  stored as `1.0`. A client that round-trips through this field and compares
  strings will see the difference.
- **An object or an array is now rejected** instead of stored as its text.
- Strings, plain integers, negatives and booleans are untouched.

Geometry and Timestamptz share the code path and are deliberately left alone:
`ConvertWKTToWKB` and `ParseTimeTz` already reject anything that does not
parse, so those two never store a silently mangled value.

## Validation

- `gofmt` clean.
- The expected values were cross-checked against the `gjson` v1.17.3 this repo
  pins; all 14 cases match and the pre-change behavior reproduces every row of
  the table above.
- The `httpserver` package cannot be compiled locally against the available
  native artifacts (they predate `SegcoreSetFMIndexCostRatio` /
  `InitLoonReaderThreadPool`), so the package tests are left to CI.

issue: #52255