### PR TITLE
fix: only re-prioritize the compaction queue when the config changes

### DIFF
--- a/internal/datacoord/compaction_inspector.go
+++ b/internal/datacoord/compaction_inspector.go
@@ -207,6 +207,13 @@ func (c *compactionInspector) checkSchedule() {
 
 func (c *compactionInspector) schedule() []CompactionTask {
 	selected := make([]CompactionTask, 0)
+
+	// Sync before the empty-queue early return, so a configuration change made
+	// while the queue happens to be empty is still adopted. The cost on an
+	// empty queue is one lock acquisition and one string compare -- the
+	// re-prioritize loop iterates zero times.
+	c.queueTasks.SyncPrioritizer(getPrioritizerName())
+
 	if c.queueTasks.Len() == 0 {
 		return selected
 	}
@@ -239,8 +246,6 @@ func (c *compactionInspector) schedule() []CompactionTask {
 			c.queueTasks.Enqueue(t)
 		}
 	}()
-
-	c.queueTasks.SyncPrioritizer(getPrioritizerName())
 
 	// The schedule loop will stop if either:
 	// 1. no more task to schedule (the task queue is empty)

--- a/internal/datacoord/compaction_inspector.go
+++ b/internal/datacoord/compaction_inspector.go
@@ -240,10 +240,7 @@ func (c *compactionInspector) schedule() []CompactionTask {
 		}
 	}()
 
-	p := getPrioritizer()
-	if &c.queueTasks.prioritizer != &p {
-		c.queueTasks.UpdatePrioritizer(p)
-	}
+	c.queueTasks.SyncPrioritizer(getPrioritizerName())
 
 	// The schedule loop will stop if either:
 	// 1. no more task to schedule (the task queue is empty)

--- a/internal/datacoord/compaction_queue.go
+++ b/internal/datacoord/compaction_queue.go
@@ -85,10 +85,14 @@ var (
 type Prioritizer func(t CompactionTask) int
 
 type CompactionQueue struct {
-	pq          PriorityQueue[CompactionTask]
-	lock        lock.RWMutex
-	prioritizer Prioritizer
-	capacity    int
+	pq   PriorityQueue[CompactionTask]
+	lock lock.RWMutex
+	// prioritizer and prioritizerName are guarded by lock.
+	// Prioritizer is a func value and therefore cannot be compared with ==,
+	// so the configuration name is kept alongside it as its identity.
+	prioritizer     Prioritizer
+	prioritizerName string
+	capacity        int
 }
 
 func NewCompactionQueue(capacity int, prioritizer Prioritizer) *CompactionQueue {
@@ -124,9 +128,25 @@ func (q *CompactionQueue) Dequeue() (CompactionTask, error) {
 }
 
 func (q *CompactionQueue) UpdatePrioritizer(prioritizer Prioritizer) {
-	q.prioritizer = prioritizer
 	q.lock.Lock()
 	defer q.lock.Unlock()
+	q.updatePrioritizerLocked("", prioritizer)
+}
+
+// SyncPrioritizer re-prioritizes the queue only when the configured prioritizer
+// actually changed. It is safe to call on every scheduling tick.
+func (q *CompactionQueue) SyncPrioritizer(name string) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	if q.prioritizerName == name {
+		return
+	}
+	q.updatePrioritizerLocked(name, getPrioritizerByName(name))
+}
+
+func (q *CompactionQueue) updatePrioritizerLocked(name string, prioritizer Prioritizer) {
+	q.prioritizer = prioritizer
+	q.prioritizerName = name
 	for i := range q.pq {
 		q.pq[i].priority = q.prioritizer(q.pq[i].value)
 	}
@@ -194,9 +214,12 @@ var (
 	}
 )
 
-func getPrioritizer() Prioritizer {
-	p := Params.DataCoordCfg.CompactionTaskPrioritizer.GetValue()
-	switch p {
+func getPrioritizerName() string {
+	return Params.DataCoordCfg.CompactionTaskPrioritizer.GetValue()
+}
+
+func getPrioritizerByName(name string) Prioritizer {
+	switch name {
 	case "level":
 		return LevelPrioritizer
 	case "mix":
@@ -204,4 +227,8 @@ func getPrioritizer() Prioritizer {
 	default:
 		return DefaultPrioritizer
 	}
+}
+
+func getPrioritizer() Prioritizer {
+	return getPrioritizerByName(getPrioritizerName())
 }

--- a/internal/datacoord/compaction_queue.go
+++ b/internal/datacoord/compaction_queue.go
@@ -90,8 +90,16 @@ type CompactionQueue struct {
 	// prioritizer and prioritizerName are guarded by lock.
 	// Prioritizer is a func value and therefore cannot be compared with ==,
 	// so the configuration name is kept alongside it as its identity.
+	//
+	// prioritizerName is nil while prioritizer has not been resolved from the
+	// configuration -- the constructor and UpdatePrioritizer both take a func
+	// directly. It is a pointer rather than a string because "" is itself a
+	// settable configuration value (the RESTful alterConfig contract treats a
+	// present value, including the empty string, as a set and only null as a
+	// reset, and dataCoord.compaction.taskPrioritizer has no Formatter), so a
+	// string zero value cannot stand in for "unset" without colliding with it.
 	prioritizer     Prioritizer
-	prioritizerName string
+	prioritizerName *string
 	capacity        int
 }
 
@@ -127,10 +135,14 @@ func (q *CompactionQueue) Dequeue() (CompactionTask, error) {
 	return item.value, nil
 }
 
+// UpdatePrioritizer sets the prioritizer out of band, so the queue no longer
+// knows which configuration value it corresponds to; the next SyncPrioritizer
+// re-adopts from the configuration whatever name it is given.
 func (q *CompactionQueue) UpdatePrioritizer(prioritizer Prioritizer) {
 	q.lock.Lock()
 	defer q.lock.Unlock()
-	q.updatePrioritizerLocked("", prioritizer)
+	q.prioritizerName = nil
+	q.updatePrioritizerLocked(prioritizer)
 }
 
 // SyncPrioritizer re-prioritizes the queue only when the configured prioritizer
@@ -138,15 +150,15 @@ func (q *CompactionQueue) UpdatePrioritizer(prioritizer Prioritizer) {
 func (q *CompactionQueue) SyncPrioritizer(name string) {
 	q.lock.Lock()
 	defer q.lock.Unlock()
-	if q.prioritizerName == name {
+	if q.prioritizerName != nil && *q.prioritizerName == name {
 		return
 	}
-	q.updatePrioritizerLocked(name, getPrioritizerByName(name))
+	q.prioritizerName = &name
+	q.updatePrioritizerLocked(getPrioritizerByName(name))
 }
 
-func (q *CompactionQueue) updatePrioritizerLocked(name string, prioritizer Prioritizer) {
+func (q *CompactionQueue) updatePrioritizerLocked(prioritizer Prioritizer) {
 	q.prioritizer = prioritizer
-	q.prioritizerName = name
 	for i := range q.pq {
 		q.pq[i].priority = q.prioritizer(q.pq[i].value)
 	}

--- a/internal/datacoord/compaction_queue_test.go
+++ b/internal/datacoord/compaction_queue_test.go
@@ -175,3 +175,81 @@ func TestConcurrency(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// TestCompactionQueue_SyncPrioritizer guards against re-prioritizing the whole
+// queue on every scheduling tick.
+//
+// Prioritizer is a func value and cannot be compared with ==. The previous code
+// compared &q.prioritizer (address of a struct field) against &p (address of a
+// local variable); those addresses are never equal, so the guard was always
+// true and the entire queue was re-prioritized and re-heapified every 500ms.
+func TestCompactionQueue_SyncPrioritizer(t *testing.T) {
+	t1 := &mixCompactionTask{}
+	t1.SetTask(&datapb.CompactionTask{PlanID: 1, Type: datapb.CompactionType_MixCompaction})
+	t2 := &mixCompactionTask{}
+	t2.SetTask(&datapb.CompactionTask{PlanID: 2, Type: datapb.CompactionType_MixCompaction})
+
+	t.Run("same name does not re-prioritize", func(t *testing.T) {
+		var calls int
+		counting := func(task CompactionTask) int {
+			calls++
+			return DefaultPrioritizer(task)
+		}
+
+		cq := NewCompactionQueue(10, counting)
+		assert.NoError(t, cq.Enqueue(t1))
+		assert.NoError(t, cq.Enqueue(t2))
+
+		// First sync adopts the configured prioritizer.
+		cq.SyncPrioritizer("default")
+		calls = 0
+
+		// Subsequent syncs with an unchanged configuration must be no-ops.
+		for i := 0; i < 100; i++ {
+			cq.SyncPrioritizer("default")
+		}
+		assert.Zero(t, calls, "queue was re-prioritized despite unchanged configuration")
+	})
+
+	t.Run("changed name does re-prioritize", func(t *testing.T) {
+		cq := NewCompactionQueue(10, DefaultPrioritizer)
+		assert.NoError(t, cq.Enqueue(t1))
+
+		cq.SyncPrioritizer("level")
+		cq.lock.RLock()
+		assert.Equal(t, "level", cq.prioritizerName)
+		cq.lock.RUnlock()
+
+		cq.SyncPrioritizer("mix")
+		cq.lock.RLock()
+		assert.Equal(t, "mix", cq.prioritizerName)
+		cq.lock.RUnlock()
+	})
+
+	// UpdatePrioritizer used to assign q.prioritizer before acquiring the lock,
+	// racing with concurrent Enqueue/Dequeue which read it under the lock.
+	// Run with -race.
+	t.Run("no data race with concurrent enqueue", func(t *testing.T) {
+		cq := NewCompactionQueue(0, DefaultPrioritizer)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				cq.UpdatePrioritizer(LevelPrioritizer)
+				cq.SyncPrioritizer("mix")
+				cq.SyncPrioritizer("level")
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				task := &mixCompactionTask{}
+				task.SetTask(&datapb.CompactionTask{PlanID: int64(i), Type: datapb.CompactionType_MixCompaction})
+				_ = cq.Enqueue(task)
+				_, _ = cq.Dequeue()
+			}
+		}()
+		wg.Wait()
+	})
+}

--- a/internal/datacoord/compaction_queue_test.go
+++ b/internal/datacoord/compaction_queue_test.go
@@ -223,12 +223,66 @@ func TestCompactionQueue_SyncPrioritizer(t *testing.T) {
 		assert.EqualValues(t, primed, after, "queue was re-prioritized despite unchanged configuration")
 
 		// A changed configuration must still recompute, proving the assertion
-		// above is not vacuous.
-		cq.SyncPrioritizer("mix")
+		// above is not vacuous. It has to switch to "level": MixFirstPrioritizer
+		// also returns 1 for a MixCompaction task, so asserting against "mix"
+		// would pass whether or not updatePrioritizerLocked ran. LevelPrioritizer
+		// returns 10, which makes the three values 1 / 42 / 10 mutually distinct.
+		cq.SyncPrioritizer("level")
 		cq.lock.RLock()
 		recomputed := cq.pq[0].priority
 		cq.lock.RUnlock()
-		assert.EqualValues(t, MixFirstPrioritizer(task), recomputed)
+		assert.EqualValues(t, 10, LevelPrioritizer(task))
+		assert.EqualValues(t, LevelPrioritizer(task), recomputed)
+	})
+
+	// The empty string is a settable configuration value, not "unset": the
+	// RESTful alterConfig contract treats a present value as a set and only
+	// null as a reset, and dataCoord.compaction.taskPrioritizer has no
+	// Formatter, so getWithRaw returns "" verbatim. Holding the name in a
+	// plain string made its zero value collide with that, and a queue that had
+	// not yet adopted a name would silently no-op on SyncPrioritizer("") and
+	// keep the prioritizer it was constructed with.
+	t.Run("empty configuration value is adopted rather than read as unset", func(t *testing.T) {
+		cq := NewCompactionQueue(10, LevelPrioritizer)
+		cq.lock.RLock()
+		assert.Nil(t, cq.prioritizerName, "constructor takes a func, not a configuration name")
+		cq.lock.RUnlock()
+
+		cq.SyncPrioritizer("")
+
+		task := &mixCompactionTask{}
+		task.SetTask(&datapb.CompactionTask{PlanID: 7, Type: datapb.CompactionType_MixCompaction})
+		assert.NoError(t, cq.Enqueue(task))
+
+		cq.lock.RLock()
+		adopted := cq.pq[0].priority
+		cq.lock.RUnlock()
+		// "" resolves to DefaultPrioritizer, i.e. int(PlanID) == 7. Keeping the
+		// constructor's LevelPrioritizer would give 10.
+		assert.EqualValues(t, DefaultPrioritizer(task), adopted,
+			"empty configuration value must resolve to the default prioritizer")
+		assert.NotEqualValues(t, LevelPrioritizer(task), adopted)
+	})
+
+	// UpdatePrioritizer sets the func out of band, so the queue must forget
+	// which configuration value it corresponds to; otherwise the next sync for
+	// that same name would be skipped.
+	t.Run("update forgets the configuration name", func(t *testing.T) {
+		cq := NewCompactionQueue(10, DefaultPrioritizer)
+		cq.SyncPrioritizer("level")
+		cq.UpdatePrioritizer(DefaultPrioritizer)
+		cq.lock.RLock()
+		assert.Nil(t, cq.prioritizerName)
+		cq.lock.RUnlock()
+
+		cq.SyncPrioritizer("level")
+		task := &mixCompactionTask{}
+		task.SetTask(&datapb.CompactionTask{PlanID: 7, Type: datapb.CompactionType_MixCompaction})
+		assert.NoError(t, cq.Enqueue(task))
+		cq.lock.RLock()
+		adopted := cq.pq[0].priority
+		cq.lock.RUnlock()
+		assert.EqualValues(t, LevelPrioritizer(task), adopted)
 	})
 
 	t.Run("changed name does re-prioritize", func(t *testing.T) {
@@ -237,12 +291,12 @@ func TestCompactionQueue_SyncPrioritizer(t *testing.T) {
 
 		cq.SyncPrioritizer("level")
 		cq.lock.RLock()
-		assert.Equal(t, "level", cq.prioritizerName)
+		assert.Equal(t, "level", *cq.prioritizerName)
 		cq.lock.RUnlock()
 
 		cq.SyncPrioritizer("mix")
 		cq.lock.RLock()
-		assert.Equal(t, "mix", cq.prioritizerName)
+		assert.Equal(t, "mix", *cq.prioritizerName)
 		cq.lock.RUnlock()
 	})
 

--- a/internal/datacoord/compaction_queue_test.go
+++ b/internal/datacoord/compaction_queue_test.go
@@ -190,25 +190,45 @@ func TestCompactionQueue_SyncPrioritizer(t *testing.T) {
 	t2.SetTask(&datapb.CompactionTask{PlanID: 2, Type: datapb.CompactionType_MixCompaction})
 
 	t.Run("same name does not re-prioritize", func(t *testing.T) {
-		var calls int
-		counting := func(task CompactionTask) int {
-			calls++
-			return DefaultPrioritizer(task)
-		}
+		// Observe re-prioritization through the stored priorities rather than
+		// through an instrumented Prioritizer: SyncPrioritizer resolves the
+		// prioritizer by name, so any injected closure is discarded on the very
+		// first call and a call counter would stay at zero either way.
+		//
+		// DefaultPrioritizer is int(PlanID), so mutating PlanID after the queue
+		// has been primed makes a recompute observable: the stored priority only
+		// changes if updatePrioritizerLocked runs again.
+		task := &mixCompactionTask{}
+		task.SetTask(&datapb.CompactionTask{PlanID: 1, Type: datapb.CompactionType_MixCompaction})
 
-		cq := NewCompactionQueue(10, counting)
-		assert.NoError(t, cq.Enqueue(t1))
-		assert.NoError(t, cq.Enqueue(t2))
+		cq := NewCompactionQueue(10, DefaultPrioritizer)
+		assert.NoError(t, cq.Enqueue(task))
 
-		// First sync adopts the configured prioritizer.
+		// First sync adopts the configured prioritizer and primes the priority.
 		cq.SyncPrioritizer("default")
-		calls = 0
+		cq.lock.RLock()
+		primed := cq.pq[0].priority
+		cq.lock.RUnlock()
+		assert.EqualValues(t, 1, primed)
+
+		task.SetTask(&datapb.CompactionTask{PlanID: 42, Type: datapb.CompactionType_MixCompaction})
 
 		// Subsequent syncs with an unchanged configuration must be no-ops.
 		for i := 0; i < 100; i++ {
 			cq.SyncPrioritizer("default")
 		}
-		assert.Zero(t, calls, "queue was re-prioritized despite unchanged configuration")
+		cq.lock.RLock()
+		after := cq.pq[0].priority
+		cq.lock.RUnlock()
+		assert.EqualValues(t, primed, after, "queue was re-prioritized despite unchanged configuration")
+
+		// A changed configuration must still recompute, proving the assertion
+		// above is not vacuous.
+		cq.SyncPrioritizer("mix")
+		cq.lock.RLock()
+		recomputed := cq.pq[0].priority
+		cq.lock.RUnlock()
+		assert.EqualValues(t, MixFirstPrioritizer(task), recomputed)
 	})
 
 	t.Run("changed name does re-prioritize", func(t *testing.T) {


### PR DESCRIPTION
Fixes #52259

## What

Two defects in the compaction scheduling path:

**1. The queue was re-prioritized on every tick.**

```go
p := getPrioritizer()
if &c.queueTasks.prioritizer != &p {   // address of a field vs address of a local
    c.queueTasks.UpdatePrioritizer(p)  // -> always taken
}
```

`Prioritizer` is a func value and cannot be compared with `==`, which is presumably
why a pointer comparison was reached for. The two addresses are never equal, so
every 500ms `schedule()` tick re-computed the priority of every queued task and
called `heap.Init`, under the queue write lock.
`dataCoord.compactionTaskQueueCapacity` defaults to 100000.

**2. `UpdatePrioritizer` had a data race.**

```go
q.prioritizer = prioritizer   // before the lock
q.lock.Lock()
```

`Enqueue`/`Dequeue` read `q.prioritizer` under the lock.

## How

- `CompactionQueue` now keeps `prioritizerName` next to `prioritizer`, both guarded
  by `lock`. The configuration name is used as the prioritizer's identity, since the
  func value itself cannot be compared.
- New `SyncPrioritizer(name)` does the compare-and-update atomically under the lock;
  the inspector calls it unconditionally on each tick and it is a no-op unless the
  configuration changed.
- `getPrioritizer()` is split into `getPrioritizerName()` + `getPrioritizerByName()`
  so the name and the func stay in sync. `getPrioritizer()` is kept as a thin wrapper
  (still used by `newCompactionInspector`).
- `UpdatePrioritizer` keeps its signature (used by existing tests) and now assigns
  under the lock.

`NewCompactionQueue` leaves `prioritizerName` empty, so the first `SyncPrioritizer`
adopts the configured value. The queue is empty at that point, so the initial
re-heapify costs nothing.

## Tests

`TestCompactionQueue_SyncPrioritizer`:

- **same name does not re-prioritize** — the actual regression guard. A counter on
  an injected `Prioritizer` would not work here: `SyncPrioritizer` resolves the
  prioritizer *by name*, so any injected closure is discarded on the first call and
  the counter would read zero either way. The test instead primes the queue, mutates
  the task's `PlanID` to 42, runs 100 same-name syncs, and asserts the stored
  priority is unchanged — removing the early return yields 42. The tail then syncs
  to `"level"` (10), so the three values 1 / 42 / 10 are mutually distinct and that
  assertion discriminates.
- **empty configuration value is adopted rather than read as unset** — `""` is a
  settable value, not "unset", so it must resolve to `DefaultPrioritizer` rather
  than matching a not-yet-adopted name and leaving the constructor's prioritizer in
  place.
- **update forgets the configuration name** — `UpdatePrioritizer` sets the func out
  of band, so the next sync must re-adopt rather than skip.
- **changed name does re-prioritize** — asserts the name is adopted.
- **no data race with concurrent enqueue** — hammers `UpdatePrioritizer` /
  `SyncPrioritizer` against `Enqueue` / `Dequeue`; meaningful under `-race`.

Verified locally with `-race`; existing `TestCompactionQueue` subtests still pass.

## Measured

The re-prioritize itself is cheap; this is a correctness fix, not a hot-path win.
Reproducing `heap.Init` plus one prioritizer call per element (Apple M4 Pro,
go1.26.5):

| queue depth | per re-prioritize | duty cycle at the 500ms tick |
|---|---|---|
| 1,000 | 2.4 µs | ~0% |
| 10,000 | 32 µs | 0.006% |
| 100,000 (default `taskQueueCapacity`) | 374 µs | 0.075% |

So even a full queue costs 374 µs every 500 ms. What makes this worth fixing is
that the guard never did what it claimed, and that `UpdatePrioritizer` wrote
`q.prioritizer` outside the lock while `Enqueue` read it inside — a race that fired
every tick precisely because the guard was always true.
