### PR TITLE
fix: stop the REST API from rewriting the values a caller sends

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -432,6 +432,23 @@ proxy:
     debug_mode: false # Whether to enable http server debug mode
     port:  # high-level restful api
     acceptTypeAllowInt64: true # high-level restful api, whether http client can deal with int64
+    # high-level restful api, restore the value handling of releases that predate the REST insert
+    # validation work. When true the server keeps the previous lenient behavior: a missing or null non-nullable field is
+    # stored as an empty value, out-of-range integers wrap instead of being rejected, numbers reach VarChar and JSON fields
+    # through their float64 rendering, and integers too large for the JSON engine become 0. This is a temporary escape hatch
+    # for clients that have not been corrected yet: every one of those behaviors silently changes what is stored.
+    compatibilityMode: false
+    # high-level restful api, the deepest nesting an expression template parameter may use. Converting a
+    # parameter walks its arrays and objects recursively, so the depth a caller may send has to be bounded; requests past the
+    # bound are rejected as invalid rather than served. Values above 1024 are read as 1024, since past that the recursion
+    # itself is the risk the setting exists to remove; values below 1 are read as 1.
+    maxExprParamsDepth: 100
+    # high-level restful api, return a JSON field as the document it holds rather than as a string.
+    # A JSON field reads back as "{\"a\":1}" by default, while the same value in the dynamic field reads back as {"a":1}.
+    # Turning this on removes that difference. Rows written before the insert path stopped storing non-JSON bytes may not
+    # hold a document; if any row in a response is such a row, every JSON field in that response falls back to the string
+    # form and a warning is logged, so a caller always sees one shape or the other and never a mixture.
+    nativeJSONResponse: false
     enablePprof: true # Whether to enable pprof middleware on the metrics port
     readHeaderTimeout: 5s # HTTP server timeout for reading request headers
     readTimeout: 0s # HTTP server timeout for reading the entire request, including the body. 0 disables this timeout

--- a/internal/distributed/proxy/httpserver/handler_v1.go
+++ b/internal/distributed/proxy/httpserver/handler_v1.go
@@ -601,7 +601,7 @@ func (h *HandlersV1) get(c *gin.Context) {
 			return nil, RestRequestInterceptorErr
 		}
 		body, _ := c.Get(gin.BodyBytesKey)
-		filter, err := checkGetPrimaryKey(collSchema, gjson.Get(string(body.([]byte)), DefaultPrimaryFieldName))
+		filter, idTemplateValues, err := checkGetPrimaryKey(collSchema, gjson.Get(string(body.([]byte)), DefaultPrimaryFieldName))
 		if err != nil {
 			HTTPReturn(c, http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrCheckPrimaryKey),
@@ -618,6 +618,7 @@ func (h *HandlersV1) get(c *gin.Context) {
 			return nil, err
 		}
 		queryReq.Expr = filter
+		queryReq.ExprTemplateValues = idTemplateValues
 		return h.proxy.Query(reqCtx, queryReq)
 	})
 	if err == RestRequestInterceptorErr {
@@ -680,7 +681,7 @@ func (h *HandlersV1) delete(c *gin.Context) {
 		deleteReq.Expr = httpReq.Filter
 		if deleteReq.Expr == "" {
 			body, _ := c.Get(gin.BodyBytesKey)
-			filter, err := checkGetPrimaryKey(collSchema, gjson.Get(string(body.([]byte)), DefaultPrimaryFieldName))
+			filter, idTemplateValues, err := checkGetPrimaryKey(collSchema, gjson.Get(string(body.([]byte)), DefaultPrimaryFieldName))
 			if err != nil {
 				HTTPReturn(c, http.StatusOK, gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrCheckPrimaryKey),
@@ -689,6 +690,7 @@ func (h *HandlersV1) delete(c *gin.Context) {
 				return nil, RestRequestInterceptorErr
 			}
 			deleteReq.Expr = filter
+			deleteReq.ExprTemplateValues = idTemplateValues
 		}
 		if _, err := CheckLimiter(ctx, req, h.proxy); err != nil {
 			c.AbortWithStatusJSON(http.StatusOK, gin.H{

--- a/internal/distributed/proxy/httpserver/handler_v1_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v1_test.go
@@ -869,6 +869,99 @@ func TestInsertForDataType(t *testing.T) {
 	}
 }
 
+func TestNarrowIntegerOverflowV1(t *testing.T) {
+	paramtable.Init()
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         generateNarrowIntegerCollectionSchema(schemapb.DataType_Int8),
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Twice()
+	testEngine := initHTTPServer(mp, true)
+	body := []byte(`{"collectionName":"book","data":[{"book_id":1,"book_intro":[0.1,0.2],"word_count":2,"narrow_int":128}]}`)
+
+	for _, path := range []string{VectorInsertPath, VectorUpsertPath} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, versional(path), bytes.NewReader(body))
+			req.SetBasicAuth(util.UserRoot, getDefaultRootPassword())
+			w := httptest.NewRecorder()
+			testEngine.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			returnBody := &ReturnErrMsg{}
+			assert.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody))
+			assert.Equal(t, merr.Code(merr.ErrInvalidInsertData), returnBody.Code)
+			assert.Contains(t, returnBody.Message, "actual=128")
+			assert.Contains(t, returnBody.Message, "field narrow_int value must be an integer in range [-128, 127]")
+		})
+	}
+}
+
+func TestStructArrayIntegerExponentV1(t *testing.T) {
+	paramtable.Init()
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         buildStructArrayTestSchema(),
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Twice()
+	testEngine := initHTTPServer(mp, true)
+	body := []byte(`{"collectionName":"book","data":[{"id":1,"vec":[0.1,0.2,0.3,0.4],"my_struct":[{"sub_int":1e-999999,"sub_vec":[1.1,1.2,1.3,1.4]}]}]}`)
+
+	for _, path := range []string{VectorInsertPath, VectorUpsertPath} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, versional(path), bytes.NewReader(body))
+			req.SetBasicAuth(util.UserRoot, getDefaultRootPassword())
+			w := httptest.NewRecorder()
+			testEngine.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			returnBody := &ReturnErrMsg{}
+			assert.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody))
+			assert.Equal(t, merr.Code(merr.ErrInvalidInsertData), returnBody.Code)
+			assert.Contains(t, returnBody.Message, "sub-field sub_int")
+			assert.Contains(t, returnBody.Message, "value=1e-999999")
+		})
+	}
+}
+
+func TestStructArrayExactInt64V1(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+	schema := buildStructArrayTestSchema()
+	schema.GetStructArrayFields()[0].GetFields()[0].ElementType = schemapb.DataType_Int64
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         schema,
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Once()
+	mp.EXPECT().Insert(mock.Anything, mock.MatchedBy(func(req *milvuspb.InsertRequest) bool {
+		return hasStructArrayInt64Value(req.GetFieldsData(), "my_struct", "sub_int", 9007199254740993)
+	})).Return(&milvuspb.MutationResult{
+		Status:    &StatusSuccess,
+		InsertCnt: 1,
+		IDs: &schemapb.IDs{IdField: &schemapb.IDs_IntId{
+			IntId: &schemapb.LongArray{Data: []int64{1}},
+		}},
+	}, nil).Once()
+	testEngine := initHTTPServer(mp, true)
+	body := []byte(`{"collectionName":"book","data":[{"id":1,"vec":[0.1,0.2,0.3,0.4],"my_struct":[{"sub_int":9007199254740993.0,"sub_vec":[1.1,1.2,1.3,1.4]}]}]}`)
+	req := httptest.NewRequest(http.MethodPost, versional(VectorInsertPath), bytes.NewReader(body))
+	req.SetBasicAuth(util.UserRoot, getDefaultRootPassword())
+	w := httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	returnBody := &ReturnErrMsg{}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody))
+	assert.Equal(t, int32(http.StatusOK), returnBody.Code)
+}
+
 func TestReturnInt64(t *testing.T) {
 	paramtable.Init()
 	paramtable.Get().Save(proxy.Params.HTTPCfg.AcceptTypeAllowInt64.Key, "false")

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -1412,7 +1412,16 @@ func (h *HandlersV2) query(ctx context.Context, c *gin.Context, anyReq any, dbNa
 		})
 		return nil, err
 	}
-	req.ExprTemplateValues = generateExpressionTemplate(httpReq.ExprParams)
+	templateValues, err := generateExpressionTemplate(httpReq.ExprParams)
+	if err != nil {
+		mlog.Warn(ctx, "high level restful api, invalid expression template parameter", mlog.Err(err))
+		HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPReturnCode:    merr.Code(err),
+			HTTPReturnMessage: err.Error(),
+		})
+		return nil, err
+	}
+	req.ExprTemplateValues = templateValues
 	c.Set(ContextRequest, req)
 	if httpReq.Offset > 0 {
 		req.QueryParams = append(req.QueryParams, &commonpb.KeyValuePair{Key: proxy.OffsetKey, Value: strconv.FormatInt(int64(httpReq.Offset), 10)})
@@ -1473,7 +1482,7 @@ func (h *HandlersV2) get(ctx context.Context, c *gin.Context, anyReq any, dbName
 		return nil, err
 	}
 	body, _ := c.Get(gin.BodyBytesKey)
-	filter, err := checkGetPrimaryKey(collSchema, gjson.Get(string(body.([]byte)), DefaultPrimaryFieldName))
+	filter, idTemplateValues, err := checkGetPrimaryKey(collSchema, gjson.Get(string(body.([]byte)), DefaultPrimaryFieldName))
 	if err != nil {
 		HTTPReturn(c, http.StatusOK, gin.H{
 			HTTPReturnCode:    merr.Code(merr.ErrCheckPrimaryKey),
@@ -1482,11 +1491,12 @@ func (h *HandlersV2) get(ctx context.Context, c *gin.Context, anyReq any, dbName
 		return nil, err
 	}
 	req := &milvuspb.QueryRequest{
-		DbName:         dbName,
-		CollectionName: httpReq.CollectionName,
-		OutputFields:   httpReq.OutputFields,
-		PartitionNames: httpReq.PartitionNames,
-		Expr:           filter,
+		DbName:             dbName,
+		CollectionName:     httpReq.CollectionName,
+		OutputFields:       httpReq.OutputFields,
+		PartitionNames:     httpReq.PartitionNames,
+		Expr:               filter,
+		ExprTemplateValues: idTemplateValues,
 	}
 	req.ConsistencyLevel, req.UseDefaultConsistency, err = convertConsistencyLevel(httpReq.ConsistencyLevel)
 	if err != nil {
@@ -1546,11 +1556,20 @@ func (h *HandlersV2) delete(ctx context.Context, c *gin.Context, anyReq any, dbN
 		PartitionName:  httpReq.PartitionName,
 		Expr:           httpReq.Filter,
 	}
-	req.ExprTemplateValues = generateExpressionTemplate(httpReq.ExprParams)
+	templateValues, err := generateExpressionTemplate(httpReq.ExprParams)
+	if err != nil {
+		mlog.Warn(ctx, "high level restful api, invalid expression template parameter", mlog.Err(err))
+		HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPReturnCode:    merr.Code(err),
+			HTTPReturnMessage: err.Error(),
+		})
+		return nil, err
+	}
+	req.ExprTemplateValues = templateValues
 	c.Set(ContextRequest, req)
 	if req.Expr == "" {
 		body, _ := c.Get(gin.BodyBytesKey)
-		filter, err := checkGetPrimaryKey(collSchema, gjson.Get(string(body.([]byte)), DefaultPrimaryFieldName))
+		filter, idTemplateValues, err := checkGetPrimaryKey(collSchema, gjson.Get(string(body.([]byte)), DefaultPrimaryFieldName))
 		if err != nil {
 			HTTPReturn(c, http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrCheckPrimaryKey),
@@ -1559,6 +1578,7 @@ func (h *HandlersV2) delete(ctx context.Context, c *gin.Context, anyReq any, dbN
 			return nil, err
 		}
 		req.Expr = filter
+		req.ExprTemplateValues = idTemplateValues
 	}
 	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/Delete", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.Delete(reqCtx, req.(*milvuspb.DeleteRequest))
@@ -2021,7 +2041,16 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 	}
 
 	req.SearchParams = searchParams
-	req.ExprTemplateValues = generateExpressionTemplate(httpReq.ExprParams)
+	templateValues, err := generateExpressionTemplate(httpReq.ExprParams)
+	if err != nil {
+		mlog.Warn(ctx, "high level restful api, invalid expression template parameter", mlog.Err(err))
+		HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPReturnCode:    merr.Code(err),
+			HTTPReturnMessage: err.Error(),
+		})
+		return nil, err
+	}
+	req.ExprTemplateValues = templateValues
 	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/Search", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.Search(reqCtx, req.(*milvuspb.SearchRequest))
 	})
@@ -2194,7 +2223,16 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 			PartitionNames: httpReq.PartitionNames,
 			SearchParams:   searchParams,
 		}
-		searchReq.ExprTemplateValues = generateExpressionTemplate(subReq.ExprParams)
+		subTemplateValues, err := generateExpressionTemplate(subReq.ExprParams)
+		if err != nil {
+			mlog.Warn(ctx, "high level restful api, invalid expression template parameter", mlog.Err(err))
+			HTTPAbortReturn(c, http.StatusOK, gin.H{
+				HTTPReturnCode:    merr.Code(err),
+				HTTPReturnMessage: err.Error(),
+			})
+			return nil, err
+		}
+		searchReq.ExprTemplateValues = subTemplateValues
 		req.Requests = append(req.Requests, searchReq)
 	}
 

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -4020,6 +4020,96 @@ func TestAllowInt64(t *testing.T) {
 	validateTestCases(t, testEngine, queryTestCases, true)
 }
 
+func TestNarrowIntegerOverflowV2(t *testing.T) {
+	paramtable.Init()
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         generateNarrowIntegerCollectionSchema(schemapb.DataType_Int8),
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Twice()
+	testEngine := initHTTPServerV2(mp, false)
+	body := []byte(`{"collectionName":"book","data":[{"book_id":1,"book_intro":[0.1,0.2],"word_count":2,"narrow_int":128}]}`)
+
+	for _, action := range []string{InsertAction, UpsertAction} {
+		t.Run(action, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, versionalV2(EntityCategory, action), bytes.NewReader(body))
+			w := httptest.NewRecorder()
+			testEngine.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			returnBody := &ReturnErrMsg{}
+			assert.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody))
+			assert.Equal(t, merr.Code(merr.ErrInvalidInsertData), returnBody.Code)
+			assert.Contains(t, returnBody.Message, "actual=128")
+			assert.Contains(t, returnBody.Message, "field narrow_int value must be an integer in range [-128, 127]")
+		})
+	}
+}
+
+func TestStructArrayIntegerExponentV2(t *testing.T) {
+	paramtable.Init()
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         buildStructArrayTestSchema(),
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Twice()
+	testEngine := initHTTPServerV2(mp, false)
+	body := []byte(`{"collectionName":"book","data":[{"id":1,"vec":[0.1,0.2,0.3,0.4],"my_struct":[{"sub_int":1e-999999,"sub_vec":[1.1,1.2,1.3,1.4]}]}]}`)
+
+	for _, action := range []string{InsertAction, UpsertAction} {
+		t.Run(action, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, versionalV2(EntityCategory, action), bytes.NewReader(body))
+			w := httptest.NewRecorder()
+			testEngine.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			returnBody := &ReturnErrMsg{}
+			assert.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody))
+			assert.Equal(t, merr.Code(merr.ErrInvalidInsertData), returnBody.Code)
+			assert.Contains(t, returnBody.Message, "sub-field sub_int")
+			assert.Contains(t, returnBody.Message, "value=1e-999999")
+		})
+	}
+}
+
+func TestStructArrayExactInt64V2(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+	schema := buildStructArrayTestSchema()
+	schema.GetStructArrayFields()[0].GetFields()[0].ElementType = schemapb.DataType_Int64
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         schema,
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Once()
+	mp.EXPECT().Insert(mock.Anything, mock.MatchedBy(func(req *milvuspb.InsertRequest) bool {
+		return hasStructArrayInt64Value(req.GetFieldsData(), "my_struct", "sub_int", 9007199254740993)
+	})).Return(&milvuspb.MutationResult{
+		Status:    &StatusSuccess,
+		InsertCnt: 1,
+		IDs: &schemapb.IDs{IdField: &schemapb.IDs_IntId{
+			IntId: &schemapb.LongArray{Data: []int64{1}},
+		}},
+	}, nil).Once()
+	testEngine := initHTTPServerV2(mp, false)
+	body := []byte(`{"collectionName":"book","data":[{"id":1,"vec":[0.1,0.2,0.3,0.4],"my_struct":[{"sub_int":9007199254740993.0,"sub_vec":[1.1,1.2,1.3,1.4]}]}]}`)
+	req := httptest.NewRequest(http.MethodPost, versionalV2(EntityCategory, InsertAction), bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	returnBody := &ReturnErrMsg{}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody))
+	assert.Equal(t, merr.Code(nil), returnBody.Code)
+}
+
 func generateCollectionSchemaWithVectorFields() *schemapb.CollectionSchema {
 	collSchema := generateCollectionSchema(schemapb.DataType_Int64, false, true)
 	binaryVectorField := generateVectorFieldSchema(schemapb.DataType_BinaryVector)
@@ -5326,7 +5416,7 @@ func TestSearchByPK(t *testing.T) {
 	queryTestCases = append(queryTestCases, requestBodyTestCase{
 		path:        SearchAction,
 		requestBody: []byte(`{"collectionName": "book", "ids": [1.5, 2.9], "limit": 10, "outputFields": ["word_count"]}`),
-		errMsg:      "has fractional part",
+		errMsg:      "is not an integer in the int64 range",
 		errCode:     1100, // ErrParameterInvalid
 	})
 
@@ -5627,4 +5717,49 @@ func TestAbortImportJob(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, int32(0), returnBody.Code)
 	})
+}
+
+// The insert path stores a JSON or dynamic field from its original token
+// without re-validating it, on the grounds that the binder has already parsed
+// the whole body as JSON. That premise is what makes the passthrough safe, so
+// pin it: a malformed body must be refused before any Insert RPC is issued.
+//
+// The mock carries no Insert expectation, so reaching the proxy fails the test.
+// PostgreSQL's json.sql spends about twenty five cases on this shape of input;
+// here it only has to be established that none of them get through.
+func TestInsertMalformedBodyNeverReachesProxy(t *testing.T) {
+	paramtable.Init()
+
+	malformed := []struct {
+		name string
+		body string
+	}{
+		{"not json at all", `invalid json`},
+		{"unclosed object", `{"collectionName":"book","data":[{"a":1}`},
+		{"trailing comma", `{"collectionName":"book","data":[1,2,]}`},
+		{"single quotes", `{'collectionName':'book'}`},
+		{"unquoted key", `{collectionName:"book"}`},
+		{"leading zero number", `{"collectionName":"book","data":[{"a":01}]}`},
+		{"two values", `{"collectionName":"book"} {"a":1}`},
+		{"empty body", ``},
+		{"whitespace only", `   `},
+	}
+
+	for _, tt := range malformed {
+		t.Run(tt.name, func(t *testing.T) {
+			mp := mocks.NewMockProxy(t)
+			testEngine := initHTTPServerV2(mp, false)
+
+			req := httptest.NewRequest(http.MethodPost,
+				versionalV2(EntityCategory, InsertAction), bytes.NewReader([]byte(tt.body)))
+			w := httptest.NewRecorder()
+			testEngine.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			returnBody := &ReturnErrMsg{}
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody))
+			assert.NotEqual(t, int32(0), returnBody.Code,
+				"a malformed body must not be accepted: %s", tt.body)
+		})
+	}
 }

--- a/internal/distributed/proxy/httpserver/request.go
+++ b/internal/distributed/proxy/httpserver/request.go
@@ -16,6 +16,11 @@
 
 package httpserver
 
+import (
+	"github.com/milvus-io/milvus/internal/json"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
 type CreateCollectionReq struct {
 	DbName             string `json:"dbName"`
 	CollectionName     string `json:"collectionName" validate:"required"`
@@ -83,6 +88,82 @@ type SingleUpsertReq struct {
 	FieldOps       []FieldPartialUpdateOpReq `json:"fieldOps"`
 }
 
+// FloatVectorQuery is a search vector that refuses a null coordinate.
+//
+// Decoding straight into []float32 turns a null into 0, which is a coordinate
+// the caller never sent and which takes full part in the distance computation,
+// so the search silently runs against a different point. A vector is a dense
+// fixed-width array of numbers with no per-element validity to record "absent"
+// in, so there is nothing to store but a number: the only honest answer is to
+// refuse. The v2 path applies the same rule in serializeFloatVectors.
+type FloatVectorQuery []float32
+
+func (v *FloatVectorQuery) UnmarshalJSON(data []byte) error {
+	var elements []*float32
+	if err := json.Unmarshal(data, &elements); err != nil {
+		return err
+	}
+	if elements == nil {
+		// A whole-value null decodes to a nil slice without an error, and the
+		// loop below would then hand back a non-nil empty vector -- which is
+		// how a null used to slip past the callers' required-field checks.
+		return merr.WrapErrParameterInvalidMsg("a vector cannot be null")
+	}
+	parsed := make([]float32, 0, len(elements))
+	for idx, element := range elements {
+		if element == nil {
+			return merr.WrapErrParameterInvalidMsg(
+				"search vector has a null at index %d; a vector element cannot be null", idx)
+		}
+		parsed = append(parsed, *element)
+	}
+	*v = parsed
+	return nil
+}
+
+// Int64ListQuery is a list of int64 that refuses a null element, for the same
+// reason FloatVectorQuery does: encoding/json leaves a null as 0, which names
+// a different row than the caller did. See FloatVectorQuery.
+type Int64ListQuery []int64
+
+func (v *Int64ListQuery) UnmarshalJSON(data []byte) error {
+	var elements []*int64
+	if err := json.Unmarshal(data, &elements); err != nil {
+		return err
+	}
+	if elements == nil {
+		// same rule as FloatVectorQuery: a null is not an empty list
+		return merr.WrapErrParameterInvalidMsg("an id list cannot be null")
+	}
+	parsed := make([]int64, 0, len(elements))
+	for idx, element := range elements {
+		if element == nil {
+			return merr.WrapErrParameterInvalidMsg(
+				"id list has a null at index %d; an id cannot be null", idx)
+		}
+		parsed = append(parsed, *element)
+	}
+	*v = parsed
+	return nil
+}
+
+// Base64VectorQuery is a base64-spelled vector that refuses a null. Decoding
+// straight into []byte turns a null into an empty slice, which then travels as
+// a zero-length vector rather than being reported.
+type Base64VectorQuery []byte
+
+func (v *Base64VectorQuery) UnmarshalJSON(data []byte) error {
+	var decoded *[]byte
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	if decoded == nil {
+		return merr.WrapErrParameterInvalidMsg("a vector cannot be null")
+	}
+	*v = *decoded
+	return nil
+}
+
 type SearchReq struct {
 	DbName            string                `json:"dbName"`
 	CollectionName    string                `json:"collectionName" validate:"required"`
@@ -90,7 +171,7 @@ type SearchReq struct {
 	Limit             int32                 `json:"limit"`
 	Offset            int32                 `json:"offset"`
 	OutputFields      []string              `json:"outputFields"`
-	Vector            []float32             `json:"vector"`
+	Vector            FloatVectorQuery      `json:"vector"`
 	Params            map[string]float64    `json:"params"`
 	SearchAggregation *SearchAggregationReq `json:"searchAggregation"`
 }

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -411,9 +411,9 @@ type QueryReqV2 struct {
 	OrderByFields []string `json:"orderByFields"`
 	// GroupByFields groups query results by scalar fields; used together with
 	// aggregation expressions (e.g. count(*), sum(price)) in outputFields.
-	GroupByFields    []string               `json:"groupByFields"`
-	ExprParams       map[string]interface{} `json:"exprParams"`
-	ConsistencyLevel string                 `json:"consistencyLevel"`
+	GroupByFields    []string                   `json:"groupByFields"`
+	ExprParams       map[string]json.RawMessage `json:"exprParams"`
+	ConsistencyLevel string                     `json:"consistencyLevel"`
 }
 
 func (req *QueryReqV2) GetDbName() string         { return req.DbName }
@@ -433,11 +433,11 @@ func (req *CollectionIDReq) GetDbName() string         { return req.DbName }
 func (req *CollectionIDReq) GetCollectionName() string { return req.CollectionName }
 
 type CollectionFilterReq struct {
-	DbName         string                 `json:"dbName"`
-	CollectionName string                 `json:"collectionName" binding:"required"`
-	PartitionName  string                 `json:"partitionName"`
-	Filter         string                 `json:"filter" binding:"required"`
-	ExprParams     map[string]interface{} `json:"exprParams"`
+	DbName         string                     `json:"dbName"`
+	CollectionName string                     `json:"collectionName" binding:"required"`
+	PartitionName  string                     `json:"partitionName"`
+	Filter         string                     `json:"filter" binding:"required"`
+	ExprParams     map[string]json.RawMessage `json:"exprParams"`
 }
 
 func (req *CollectionFilterReq) GetDbName() string         { return req.DbName }
@@ -494,25 +494,25 @@ func parseFieldPartialUpdateOp(op string) (schemapb.FieldPartialUpdateOp_OpType,
 }
 
 type SearchReqV2 struct {
-	DbName            string                 `json:"dbName"`
-	CollectionName    string                 `json:"collectionName" binding:"required"`
-	Data              []interface{}          `json:"data"`
-	Ids               []interface{}          `json:"ids"`
-	AnnsField         string                 `json:"annsField"`
-	PartitionNames    []string               `json:"partitionNames"`
-	Filter            string                 `json:"filter"`
-	GroupByField      string                 `json:"groupingField"`
-	GroupSize         int32                  `json:"groupSize"`
-	StrictGroupSize   bool                   `json:"strictGroupSize"`
-	Limit             int32                  `json:"limit"`
-	Offset            int32                  `json:"offset"`
-	OutputFields      []string               `json:"outputFields"`
-	SearchParams      map[string]interface{} `json:"searchParams"`
-	ConsistencyLevel  string                 `json:"consistencyLevel"`
-	ExprParams        map[string]interface{} `json:"exprParams"`
-	FunctionScore     FunctionScore          `json:"functionScore"`
-	FunctionChains    []FunctionChainReq     `json:"functionChains"`
-	SearchAggregation *SearchAggregationReq  `json:"searchAggregation"`
+	DbName            string                     `json:"dbName"`
+	CollectionName    string                     `json:"collectionName" binding:"required"`
+	Data              []interface{}              `json:"data"`
+	Ids               []json.RawMessage          `json:"ids"`
+	AnnsField         string                     `json:"annsField"`
+	PartitionNames    []string                   `json:"partitionNames"`
+	Filter            string                     `json:"filter"`
+	GroupByField      string                     `json:"groupingField"`
+	GroupSize         int32                      `json:"groupSize"`
+	StrictGroupSize   bool                       `json:"strictGroupSize"`
+	Limit             int32                      `json:"limit"`
+	Offset            int32                      `json:"offset"`
+	OutputFields      []string                   `json:"outputFields"`
+	SearchParams      map[string]interface{}     `json:"searchParams"`
+	ConsistencyLevel  string                     `json:"consistencyLevel"`
+	ExprParams        map[string]json.RawMessage `json:"exprParams"`
+	FunctionScore     FunctionScore              `json:"functionScore"`
+	FunctionChains    []FunctionChainReq         `json:"functionChains"`
+	SearchAggregation *SearchAggregationReq      `json:"searchAggregation"`
 	// OrderByFields re-sorts the final search results by scalar fields; each item
 	// is "fieldName" or "fieldName:asc" / "fieldName:desc" (default asc).
 	OrderByFields []string `json:"orderByFields"`
@@ -559,16 +559,16 @@ type Rand struct {
 }
 
 type SubSearchReq struct {
-	Data              []interface{}          `json:"data" binding:"required"`
-	AnnsField         string                 `json:"annsField"`
-	Filter            string                 `json:"filter"`
-	GroupByField      string                 `json:"groupingField"`
-	MetricType        string                 `json:"metricType"`
-	Limit             int32                  `json:"limit"`
-	Offset            int32                  `json:"offset"`
-	SearchParams      map[string]interface{} `json:"params"`
-	ExprParams        map[string]interface{} `json:"exprParams"`
-	SearchAggregation *SearchAggregationReq  `json:"searchAggregation"`
+	Data              []interface{}              `json:"data" binding:"required"`
+	AnnsField         string                     `json:"annsField"`
+	Filter            string                     `json:"filter"`
+	GroupByField      string                     `json:"groupingField"`
+	MetricType        string                     `json:"metricType"`
+	Limit             int32                      `json:"limit"`
+	Offset            int32                      `json:"offset"`
+	SearchParams      map[string]interface{}     `json:"params"`
+	ExprParams        map[string]json.RawMessage `json:"exprParams"`
+	SearchAggregation *SearchAggregationReq      `json:"searchAggregation"`
 }
 
 type HybridSearchReq struct {
@@ -1101,10 +1101,6 @@ func wrapperReturnRowCount(pairs []*commonpb.KeyValuePair) gin.H {
 
 func wrapperReturnDefault() gin.H {
 	return gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: gin.H{}}
-}
-
-func wrapperReturnDefaultWithCost(cost int) gin.H {
-	return gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: gin.H{}, HTTPReturnCost: cost}
 }
 
 type ResourceGroupNodeFilter struct {

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -17,9 +17,12 @@
 package httpserver
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
+	gojson "encoding/json"
 	"fmt"
+	"io"
 	"math"
 	"net/http"
 	"reflect"
@@ -27,6 +30,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gin-gonic/gin"
 	"github.com/spf13/cast"
@@ -162,95 +166,148 @@ func getPrimaryField(schema *schemapb.CollectionSchema) (*schemapb.FieldSchema, 
 	return nil, false
 }
 
-func joinArray(data interface{}) string {
-	if data == nil {
-		return ""
-	}
-	var builder strings.Builder
-	switch arr := data.(type) {
-	case []int64:
-		for i, v := range arr {
-			if i > 0 {
-				builder.WriteString(",")
-			}
-			builder.WriteString(strconv.FormatInt(v, 10))
-		}
-	case []string:
-		for i, v := range arr {
-			if i > 0 {
-				builder.WriteString(",")
-			}
-			builder.WriteString(v)
-		}
-	default:
-		rv := reflect.ValueOf(data)
-		if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
-			return ""
-		}
-		for i := 0; i < rv.Len(); i++ {
-			if i > 0 {
-				builder.WriteString(",")
-			}
-			fmt.Fprintf(&builder, "%v", rv.Index(i))
-		}
-	}
-	return builder.String()
-}
+// primaryKeyTemplateVar is the template variable the generated primary key
+// filter binds its id list to. It is deliberately not a name a caller could
+// collide with from exprParams, which this path does not read anyway.
+const primaryKeyTemplateVar = "__pk_ids"
 
-func convertRange(field *schemapb.FieldSchema, result gjson.Result) (string, error) {
-	var resultStr string
-	fieldType := field.DataType
-
-	switch fieldType {
-	case schemapb.DataType_Int64:
-		dataArray := make([]int64, 0, len(result.Array()))
-		for _, data := range result.Array() {
-			if data.Type == gjson.String {
-				value, err := cast.ToInt64E(data.Str)
-				if err != nil {
-					return "", err
-				}
-				dataArray = append(dataArray, value)
-			} else {
-				value, err := cast.ToInt64E(data.Raw)
-				if err != nil {
-					return "", err
-				}
-				dataArray = append(dataArray, value)
-			}
-		}
-		resultStr = joinArray(dataArray)
-	case schemapb.DataType_VarChar:
-		dataArray := make([]string, 0, len(result.Array()))
-		for _, data := range result.Array() {
-			value, err := cast.ToStringE(data.Str)
-			if err != nil {
-				return "", err
-			}
-			dataArray = append(dataArray, fmt.Sprintf(`"%s"`, value))
-		}
-		resultStr = joinArray(dataArray)
-	}
-	return resultStr, nil
-}
-
-// generate the expression: $primaryFieldName in [1,2,3]
-func checkGetPrimaryKey(coll *schemapb.CollectionSchema, idResult gjson.Result) (string, error) {
+// checkGetPrimaryKey builds the filter for the id based get and delete
+// endpoints: `pk in {__pk_ids}`, with the ids carried as a template value.
+//
+// The ids used to be formatted into the expression text, a VARCHAR id as
+// fmt.Sprintf("%q") with no escaping. A quote in an id therefore reached the
+// parser as syntax:
+//
+//	id ["alice\", \"bob"]  ->  pk in ["alice", "bob"]
+//
+// so one named id matched two rows, and on the v1 delete endpoint removed a row
+// the caller never named. An id that merely contained a quote as data, such as
+// `say "hi"`, could not be fetched at all because the generated expression did
+// not parse.
+//
+// Passing the ids as a template value removes the text entirely: nothing the
+// caller sends is parsed as expression syntax.
+func checkGetPrimaryKey(coll *schemapb.CollectionSchema, idResult gjson.Result) (string, map[string]*schemapb.TemplateValue, error) {
 	primaryField, ok := getPrimaryField(coll)
 	if !ok {
-		return "", merr.WrapErrParameterInvalidMsg("collection: %s has no primary field", coll.Name)
+		return "", nil, merr.WrapErrParameterInvalidMsg("collection: %s has no primary field", coll.Name)
 	}
-	resultStr, err := convertRange(primaryField, idResult)
+
+	ids, err := primaryKeyTemplateValue(primaryField, idResult)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
-	filter := primaryField.Name + " in [" + resultStr + "]"
-	return filter, nil
+	filter := fmt.Sprintf("%s in {%s}", primaryField.Name, primaryKeyTemplateVar)
+	return filter, map[string]*schemapb.TemplateValue{primaryKeyTemplateVar: ids}, nil
 }
 
-// convertIDsToSchemapbIDs converts a slice of interface{} (JSON ids) to schemapb.IDs
-// based on the primary key field type
-func convertIDsToSchemapbIDs(ids []interface{}, pkField *schemapb.FieldSchema) (*schemapb.IDs, error) {
+// primaryKeyTemplateValue converts the id list into a typed template array.
+//
+// An id that is absent, or null, is a malformed request: on the delete
+// endpoints it means the caller named neither a filter nor an id. An id that is
+// an empty list is a different thing and stays what it was -- it used to build
+// the filter `pk in []`, which the planner accepts and which matches nothing,
+// so a batch loop handed an empty batch did nothing and reported success. The
+// element type comes from the schema rather than from the elements, so the
+// empty list still produces a well-typed array.
+func primaryKeyTemplateValue(field *schemapb.FieldSchema, result gjson.Result) (*schemapb.TemplateValue, error) {
+	if !result.Exists() || result.Type == gjson.Null {
+		return nil, merr.WrapErrParameterInvalidMsg("%s is required", DefaultPrimaryFieldName)
+	}
+	elements := result.Array()
+
+	switch field.DataType {
+	case schemapb.DataType_Int64:
+		values := make([]int64, 0, len(elements))
+		for _, element := range elements {
+			value, err := primaryKeyInt64(element)
+			if err != nil {
+				return nil, err
+			}
+			values = append(values, value)
+		}
+		return &schemapb.TemplateValue{
+			Val: &schemapb.TemplateValue_ArrayVal{
+				ArrayVal: &schemapb.TemplateArrayValue{
+					Data: &schemapb.TemplateArrayValue_LongData{
+						LongData: &schemapb.LongArray{Data: values},
+					},
+				},
+			},
+		}, nil
+
+	case schemapb.DataType_VarChar:
+		values := make([]string, 0, len(elements))
+		for _, element := range elements {
+			switch element.Type {
+			case gjson.String:
+				values = append(values, element.Str)
+			case gjson.Number:
+				// The same reading convertIDsToSchemapbIDs gives an id and
+				// stringFieldValue gives a VarChar field: the literal, not a
+				// float64 rendering of it. Refusing it here instead would make
+				// a row that insert stores and search-by-id finds impossible to
+				// get or delete by the id it was stored under.
+				values = append(values, element.Raw)
+			default:
+				return nil, merr.WrapErrParameterInvalidMsg(
+					"%s must be a string or a number for a VarChar primary key, got: %s",
+					DefaultPrimaryFieldName, element.Raw)
+			}
+		}
+		return &schemapb.TemplateValue{
+			Val: &schemapb.TemplateValue_ArrayVal{
+				ArrayVal: &schemapb.TemplateArrayValue{
+					Data: &schemapb.TemplateArrayValue_StringData{
+						StringData: &schemapb.StringArray{Data: values},
+					},
+				},
+			},
+		}, nil
+
+	default:
+		return nil, merr.WrapErrParameterInvalidMsg(
+			"unsupported primary key type: %s", field.DataType.String())
+	}
+}
+
+// primaryKeyInt64 reads one id for an Int64 primary key.
+//
+// A quoted id is read as base 10. cast used strconv's base detection here too,
+// so a zero-padded id such as "010" looked up primary key 8.
+func primaryKeyInt64(element gjson.Result) (int64, error) {
+	switch element.Type {
+	case gjson.Number:
+		value, ok := parseJSONInteger(element.Raw, 64)
+		if !ok {
+			return 0, merr.WrapErrParameterInvalidMsg(
+				"%s must be an integer in the int64 range, got: %s", DefaultPrimaryFieldName, element.Raw)
+		}
+		return value, nil
+	case gjson.String:
+		value, err := strconv.ParseInt(element.Str, 10, 64)
+		if err != nil {
+			return 0, merr.WrapErrParameterInvalidMsg(
+				"%s must be an integer for an Int64 primary key, got: %q", DefaultPrimaryFieldName, element.Str)
+		}
+		return value, nil
+	default:
+		return 0, merr.WrapErrParameterInvalidMsg(
+			"%s must be an integer for an Int64 primary key, got: %s", DefaultPrimaryFieldName, element.Raw)
+	}
+}
+
+// convertIDsToSchemapbIDs reads the id list for search-by-id from the literals
+// the caller wrote.
+//
+// The ids used to arrive already decoded into []interface{}, so every number
+// had been through float64 before it was examined. Two things followed. An id
+// past 2^53 lost its low bits, so the search ran against a primary key the
+// caller never asked for. And an id that was not an integer at all could round
+// to one on the way in: 4503599627370496.5 becomes 4503599627370496.0, which
+// then passes a fractional-part check. For a VarChar key the float was
+// formatted with %v, so the id 1000000 was searched for as "1e+06".
+func convertIDsToSchemapbIDs(ids []json.RawMessage, pkField *schemapb.FieldSchema) (*schemapb.IDs, error) {
 	if len(ids) == 0 {
 		return nil, merr.WrapErrParameterMissingMsg("ids array cannot be empty")
 	}
@@ -258,52 +315,47 @@ func convertIDsToSchemapbIDs(ids []interface{}, pkField *schemapb.FieldSchema) (
 	switch pkField.DataType {
 	case schemapb.DataType_Int64:
 		int64IDs := make([]int64, 0, len(ids))
-		for i, id := range ids {
-			var int64ID int64
-			switch v := id.(type) {
-			case int64:
-				int64ID = v
-			case int:
-				int64ID = int64(v)
-			case float64:
-				// JSON numbers are decoded as float64
-				// Check if the float has a fractional part
-				if v != math.Trunc(v) {
-					return nil, merr.WrapErrParameterInvalidMsg("invalid int64 id at index %d: %v has fractional part", i, v)
+		for i, raw := range ids {
+			value := gjson.ParseBytes(raw)
+			switch value.Type {
+			case gjson.Number:
+				parsed, ok := parseJSONInteger(value.Raw, 64)
+				if !ok {
+					return nil, merr.WrapErrParameterInvalidMsg(
+						"invalid int64 id at index %d: %s is not an integer in the int64 range", i, value.Raw)
 				}
-				int64ID = int64(v)
-			case string:
-				// Try to parse string as int64
-				parsed, err := strconv.ParseInt(v, 10, 64)
+				int64IDs = append(int64IDs, parsed)
+			case gjson.String:
+				parsed, err := strconv.ParseInt(value.Str, 10, 64)
 				if err != nil {
-					return nil, merr.WrapErrParameterInvalidErr(err, "invalid int64 id at index %d: %v", i, id)
+					return nil, merr.WrapErrParameterInvalidErr(err, "invalid int64 id at index %d: %q", i, value.Str)
 				}
-				int64ID = parsed
+				int64IDs = append(int64IDs, parsed)
 			default:
-				return nil, merr.WrapErrParameterInvalidMsg("invalid id type at index %d: expected int64, got %T", i, id)
+				return nil, merr.WrapErrParameterInvalidMsg(
+					"invalid id type at index %d: expected an integer, got %s", i, value.Raw)
 			}
-			int64IDs = append(int64IDs, int64ID)
 		}
 		return &schemapb.IDs{
 			IdField: &schemapb.IDs_IntId{
-				IntId: &schemapb.LongArray{
-					Data: int64IDs,
-				},
+				IntId: &schemapb.LongArray{Data: int64IDs},
 			},
 		}, nil
 
 	case schemapb.DataType_VarChar:
 		stringIDs := make([]string, 0, len(ids))
-		for i, id := range ids {
+		for i, raw := range ids {
+			value := gjson.ParseBytes(raw)
 			var stringID string
-			switch v := id.(type) {
-			case string:
-				stringID = v
-			case int64, int, float64:
-				// Convert number to string
-				stringID = fmt.Sprintf("%v", v)
+			switch value.Type {
+			case gjson.String:
+				stringID = value.Str
+			case gjson.Number:
+				// the literal, not a float64 rendering of it
+				stringID = value.Raw
 			default:
-				return nil, merr.WrapErrParameterInvalidMsg("invalid id type at index %d: expected string, got %T", i, id)
+				return nil, merr.WrapErrParameterInvalidMsg(
+					"invalid id type at index %d: expected a string, got %s", i, value.Raw)
 			}
 			if stringID == "" {
 				return nil, merr.WrapErrParameterInvalidMsg("empty string id at index %d", i)
@@ -312,14 +364,13 @@ func convertIDsToSchemapbIDs(ids []interface{}, pkField *schemapb.FieldSchema) (
 		}
 		return &schemapb.IDs{
 			IdField: &schemapb.IDs_StrId{
-				StrId: &schemapb.StringArray{
-					Data: stringIDs,
-				},
+				StrId: &schemapb.StringArray{Data: stringIDs},
 			},
 		}, nil
 
 	default:
-		return nil, merr.WrapErrParameterInvalidMsg("unsupported primary key type: %s", pkField.DataType.String())
+		return nil, merr.WrapErrParameterInvalidMsg(
+			"unsupported primary key type: %s", pkField.DataType.String())
 	}
 }
 
@@ -463,9 +514,383 @@ func printIndexes(indexes []*milvuspb.IndexDescription) []gin.H {
 
 // --------------------- insert param --------------------- //
 
+// maxJSONDepth is where simdjson's DOM parser gives up with DEPTH_ERROR. The
+// on-demand parser used by ordinary filters copes with far more, but the JSON
+// index and JSON_CONTAINS build a DOM, so a deeper document is readable by some
+// queries and not others. The request binder allows 9997 levels, so the gap is
+// reachable.
+const maxJSONDepth = 1024
+
+// checkEngineCompatible reports the first reason the storage engine would not be
+// able to read a document back, in one pass over it.
+//
+// Keeping the caller's bytes is only safe for values the engine can actually
+// read. The request binder guarantees the body is syntactically valid JSON, but
+// that is a weaker guarantee than it looks:
+//
+//   - it accepts an integer beyond 64 bits, which simdjson reports as
+//     BIGINT_ERROR
+//   - it accepts invalid UTF-8, replacing it with U+FFFD when it decodes, while
+//     the raw bytes keep the offending byte and simdjson reports UTF8_ERROR
+//   - it accepts nesting up to 9997 levels, past the DOM limit above
+//   - it accepts an object that declares the same key twice, where the readers
+//     disagree about which value wins: encoding/json, Python and PostgreSQL's
+//     jsonb keep the last, gjson and simdjson keep the first
+//
+// The duplicate-key scan needs a full walk anyway, so the rest costs nothing on
+// top of it.
+func checkEngineCompatible(field string, document string) error {
+	if !utf8.ValidString(document) {
+		return merr.WrapErrParameterInvalidMsg(
+			"field %s contains invalid UTF-8, which the JSON engine cannot read", field)
+	}
+
+	// One pass of the standard library's tokenizer, chosen over a recursive
+	// gjson walk on purpose. gjson's ForEach re-scans each child's whole
+	// subtree to find its extent, so a deep document with a wide leaf cost
+	// O(depth * bytes) -- benchmarked at 37x on 500 levels around a 2KB leaf
+	// -- and the only ways to keep that walk were a depth line the engine
+	// does not have or a work budget with a tunable, both of them complexity
+	// wearing a smaller number. The tokenizer reads every byte once; its
+	// price is an allocation per token, about two extra microseconds on an
+	// ordinary value, paid for never having to think about document shape
+	// again. Sonic is not an option because its Decoder has no Token. With
+	// UseNumber the tokenizer hands back each number's exact literal, which
+	// is what the number check needs.
+	//
+	// The depth rule is simdjson's: it counts containers, not values, so 1023
+	// arrays holding a scalar and 1024 empty arrays both parse while 1024
+	// arrays holding a scalar do not -- the limit is on a node sitting past
+	// maxJSONDepth, not on reaching it. Anything after the first complete
+	// value is ignored, as the previous walk ignored it: every caller hands
+	// over exactly one token.
+	decoder := gojson.NewDecoder(strings.NewReader(document))
+	decoder.UseNumber()
+
+	type frame struct {
+		isObject  bool
+		expectKey bool
+		seen      map[string]struct{}
+	}
+	var stack []frame
+
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			if err == io.EOF && len(stack) == 0 {
+				return nil
+			}
+			return merr.WrapErrParameterInvalidMsg(
+				"field %s is not a readable JSON document: %s", field, err.Error())
+		}
+
+		if delim, ok := token.(gojson.Delim); ok && (delim == ']' || delim == '}') {
+			stack = stack[:len(stack)-1]
+			if len(stack) == 0 {
+				return nil // first value complete
+			}
+			top := &stack[len(stack)-1]
+			if top.isObject {
+				top.expectKey = true
+			}
+			continue
+		}
+
+		// a key, or a value node at depth len(stack)+1
+		if len(stack) > 0 {
+			top := &stack[len(stack)-1]
+			if top.isObject && top.expectKey {
+				name := token.(string)
+				if _, dup := top.seen[name]; dup {
+					return merr.WrapErrParameterInvalidMsg(
+						"field %s declares the key %s twice; JSON object names must be unique",
+						field, name)
+				}
+				top.seen[name] = struct{}{}
+				top.expectKey = false
+				continue
+			}
+			if top.isObject {
+				top.expectKey = true
+			}
+		}
+
+		switch value := token.(type) {
+		case gojson.Delim: // '[' or '{'
+			if len(stack)+1 > maxJSONDepth {
+				return merr.WrapErrParameterInvalidMsg(
+					"field %s nests deeper than %d levels, which the JSON engine cannot read",
+					field, maxJSONDepth)
+			}
+			next := frame{isObject: value == '{', expectKey: value == '{'}
+			if next.isObject {
+				next.seen = make(map[string]struct{})
+			}
+			stack = append(stack, next)
+		case gojson.Number:
+			if len(stack)+1 > maxJSONDepth {
+				return merr.WrapErrParameterInvalidMsg(
+					"field %s nests deeper than %d levels, which the JSON engine cannot read",
+					field, maxJSONDepth)
+			}
+			if _, err := jsonNumberLiteral(field, value.String()); err != nil {
+				return err
+			}
+		default: // string, bool, nil
+			if len(stack)+1 > maxJSONDepth {
+				return merr.WrapErrParameterInvalidMsg(
+					"field %s nests deeper than %d levels, which the JSON engine cannot read",
+					field, maxJSONDepth)
+			}
+		}
+		if len(stack) == 0 {
+			return nil // scalar document, complete
+		}
+	}
+}
+
+// jsonDocumentForStorage returns the bytes to store for a JSON document,
+// rejecting what the engine cannot read.
+//
+// A lone surrogate is the one case that falls back rather than being rejected.
+// The binder accepts it and replaces it with U+FFFD when it decodes, so the
+// value was readable before the token was kept; decoding and re-encoding
+// reproduces exactly what used to be stored.
+func jsonDocumentForStorage(field string, document string) ([]byte, error) {
+	// Check the document the caller actually sent. Checking the normalized form
+	// instead is too late: decoding resolves a duplicate key to one value and
+	// turns an oversized integer into a float, so both would pass.
+	if err := checkEngineCompatible(field, document); err != nil {
+		return nil, err
+	}
+
+	if hasLoneSurrogate(document) {
+		// Decode with UseNumber so every number keeps its literal. Going through
+		// float64 would rewrite the ones that need more than 53 bits, and an
+		// earlier version tried to predict which those were: it asked whether the
+		// literal fit an int64, so 2^63 was judged safe and came back as
+		// 9223372036854776000, while 9007199254740994 was refused even though it
+		// round-trips exactly. Not converting at all removes the question.
+		decoder := json.NewDecoder(bytes.NewReader([]byte(document)))
+		decoder.UseNumber()
+		var decoded interface{}
+		if err := decoder.Decode(&decoded); err != nil {
+			return nil, merr.WrapErrParameterInvalidMsg(
+				"field %s is not a readable JSON document: %s", field, err.Error())
+		}
+		normalized, err := json.Marshal(decoded)
+		if err != nil {
+			return nil, merr.WrapErrParameterInvalidMsg(
+				"field %s is not a readable JSON document: %s", field, err.Error())
+		}
+		if err := checkEngineCompatible(field, string(normalized)); err != nil {
+			return nil, err
+		}
+		return normalized, nil
+	}
+
+	return []byte(document), nil
+}
+
+// hasLoneSurrogate reports whether raw contains a \uXXXX escape that is half of
+// a surrogate pair without its partner.
+//
+// Such an escape is accepted by the request binder, which silently replaces it
+// with U+FFFD, but simdjson refuses to decode the string it belongs to and
+// reports STRING_ERROR. Storing the document verbatim would therefore make that
+// value unreadable, so the callers fall back to the decoded form, which is what
+// was stored before the token was kept.
+//
+// The scan is skipped entirely for a document with no \u escape at all, which is
+// the overwhelmingly common case.
+func hasLoneSurrogate(raw string) bool {
+	if !strings.Contains(raw, `\u`) {
+		return false
+	}
+	for i := 0; i+5 < len(raw); i++ {
+		if raw[i] != '\\' || raw[i+1] != 'u' {
+			continue
+		}
+		// A backslash that is itself escaped does not start an escape.
+		backslashes := 0
+		for j := i - 1; j >= 0 && raw[j] == '\\'; j-- {
+			backslashes++
+		}
+		if backslashes%2 == 1 {
+			continue
+		}
+		code, err := strconv.ParseUint(raw[i+2:i+6], 16, 32)
+		if err != nil {
+			continue
+		}
+		if code < 0xD800 || code > 0xDFFF {
+			continue
+		}
+		if code >= 0xDC00 {
+			// a low surrogate can never come first
+			return true
+		}
+		// a high surrogate must be followed by a low one
+		if i+11 >= len(raw) || raw[i+6] != '\\' || raw[i+7] != 'u' {
+			return true
+		}
+		low, err := strconv.ParseUint(raw[i+8:i+12], 16, 32)
+		if err != nil || low < 0xDC00 || low > 0xDFFF {
+			return true
+		}
+		i += 11
+	}
+	return false
+}
+
+// jsonNumberLiteral keeps the original JSON number literal instead of decoding
+// it into int64/float64 and re-encoding it. Both the JSON field and the dynamic
+// field are stored as JSON text, so that round trip can only lose information:
+// gjson's String() renders numbers through float64, and cast.ToInt64 discards
+// its error and yields 0, so 1e300, 1e19 and integers beyond int64 were all
+// silently stored as 0.
+//
+// Values the JSON engine cannot represent are rejected here rather than stored,
+// so they surface at insert time instead of failing every query that touches the
+// path. Integers are limited to 64 bits because simdjson reports BIGINT_ERROR
+// beyond that; a caller that only needs the magnitude can send a floating-point
+// literal, and one that needs the exact digits can send a string.
+func jsonNumberLiteral(field string, raw string) (json.Number, error) {
+	if !strings.ContainsAny(raw, ".eE") {
+		if _, err := strconv.ParseInt(raw, 10, 64); err == nil {
+			return json.Number(raw), nil
+		}
+		if _, err := strconv.ParseUint(raw, 10, 64); err == nil {
+			return json.Number(raw), nil
+		}
+		return "", merr.WrapErrParameterInvalidMsg(
+			"field %s integer %s exceeds the 64-bit range supported by the JSON engine, "+
+				"write it as a floating-point literal or as a string", field, raw)
+	}
+	// The request binder already rejects numbers outside the float64 range, so
+	// this only guards against that gate changing.
+	if value, err := strconv.ParseFloat(raw, 64); err != nil || math.IsInf(value, 0) {
+		return "", merr.WrapErrParameterInvalidMsg(
+			"field %s number %s is outside the range representable as a double", field, raw)
+	}
+	return json.Number(raw), nil
+}
+
+// stringFieldValue converts a JSON value for a VARCHAR or STRING field.
+//
+// A number is taken from the literal the caller wrote rather than from gjson's
+// String(), which renders it through float64 with the 'f' verb: that turned
+// 1e300 into a 301 byte decimal expansion, dropped the last digit of
+// 9007199254740993.0, and rewrote 1.50 as 1.5.
+//
+// An object or an array is rejected. Storing its text is never what the caller
+// meant and it hides the common mistake of addressing the wrong field.
+//
+// proxy.http.compatibilityMode restores the previous String() rendering for
+// every kind, including the object case.
+func stringFieldValue(field string, value gjson.Result, compatibilityMode bool) (string, error) {
+	if compatibilityMode {
+		return value.String(), nil
+	}
+	switch value.Type {
+	case gjson.Number, gjson.True, gjson.False:
+		return value.Raw, nil
+	case gjson.JSON:
+		kind := "object"
+		if value.IsArray() {
+			kind = "array"
+		}
+		return "", merr.WrapErrParameterInvalidMsg(
+			"field %s expects a string, got a JSON %s", field, kind)
+	default:
+		// String, plus Null which the nullable handling above already resolved.
+		return value.String(), nil
+	}
+}
+
+// checkVectorSpelling refuses a vector handed over as the text of its own JSON
+// shape: "[0.1, 0.2]" where [0.1, 0.2] was meant.
+//
+// gjson's String() hands back a string node's content with the quotes removed,
+// so the two reach the decoder as the same bytes and the difference is gone
+// before the field type is consulted. Nothing decided that a vector may be
+// spelled as text; the three branches that read String() rather than the node
+// simply could not tell.
+//
+// Every neighbor that does read the node already refuses it: BinaryVector and
+// the two 16-bit floats take a string as their base64 spelling, struct
+// sub-vectors ask IsArray, and search reads the raw element -- so a row written
+// with the quoted form could not be looked up with it, which is REST
+// disagreeing with itself rather than being generous.
+//
+// A string is a vector only where the type has a base64 spelling for one.
+func checkVectorSpelling(field string, dataType schemapb.DataType, value gjson.Result) error {
+	if value.Type != gjson.String || vectorAcceptsBase64(dataType) {
+		return nil
+	}
+	return merr.WrapErrParameterInvalidMsg(
+		"field %s expects a vector, got the text of one: %s", field, value.Raw)
+}
+
+// vectorAcceptsBase64 reports whether a vector of this type may arrive as a
+// base64 string rather than as an array of numbers.
+//
+// Int8Vector is deliberately absent, having been listed here at first: neither
+// the insert branch nor serializeInt8Vectors can read base64 for it, and the
+// entry exempted it from the check below, where "null" decodes to a nil slice
+// without an error and was stored as an empty vector. The list has to say what
+// the decoders do, not what the type name suggests.
+func vectorAcceptsBase64(dataType schemapb.DataType) bool {
+	switch dataType {
+	case schemapb.DataType_BinaryVector,
+		schemapb.DataType_Float16Vector,
+		schemapb.DataType_BFloat16Vector:
+		return true
+	default:
+		return false
+	}
+}
+
+// nullElementIn returns the position of the first null element in an array
+// value. An array has no element-level validity in Milvus, so a null can only
+// be stored as the element type's zero value and is never recoverable.
+func nullElementIn(value gjson.Result) (int, bool) {
+	// A null element can only exist where the letters "null" appear in the
+	// text, and a vector's text is digits, brackets and commas. The substring
+	// scan is vectorized and the walk below is not, so the walk runs only for
+	// the rare value that could contain one; benchmarked, this is the
+	// difference between the null rule being free and it doubling the parse.
+	if !strings.Contains(value.Raw, "null") {
+		return 0, false
+	}
+	// Only an array has elements to look at. gjson dispatches on the first
+	// character, so text that is not JSON at all can still come back as a
+	// literal: a base64 binary vector starting with "nu" is read as a partial
+	// null, and that result hands itself to ForEach as a single element, which
+	// looked like a null at index 0.
+	if !value.IsArray() {
+		return 0, false
+	}
+
+	idx, found := 0, false
+	position := 0
+	value.ForEach(func(_, element gjson.Result) bool {
+		if element.Type == gjson.Null {
+			idx, found = position, true
+			return false
+		}
+		position++
+		return true
+	})
+	return idx, found
+}
+
 func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partialUpdate bool) ([]map[string]interface{}, map[string][]bool, error) {
 	var reallyDataArray []map[string]interface{}
 	validDataMap := make(map[string][]bool)
+	// Escape hatch for clients that relied on the previous value handling.
+	// Read once per request rather than per field.
+	compatibilityMode := paramtable.Get().HTTPCfg.CompatibilityMode.GetAsBool()
 	dataResult := gjson.GetBytes(body, HTTPRequestData)
 	dataResultArray := dataResult.Array()
 	if len(dataResultArray) == 0 {
@@ -488,17 +913,32 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 		if data.Type == gjson.JSON {
 			for _, structField := range collSchema.StructArrayFields {
 				rawValue := gjson.Get(data.Raw, structField.GetName())
-				if partialUpdate && !rawValue.Exists() {
-					continue
-				}
-				if structField.GetNullable() {
-					if rawValue.Type == gjson.Null {
+				if !rawValue.Exists() {
+					if partialUpdate {
+						continue
+					}
+					if structField.GetNullable() {
 						validDataMap[structField.GetName()] = append(validDataMap[structField.GetName()], false)
 						continue
 					}
+					// Not gated by compatibilityMode: a missing struct array field
+					// already failed before this change, in parseStructArrayRow,
+					// so there is no lenient behavior to fall back to.
+					return reallyDataArray, validDataMap, merr.WrapErrParameterMissingMsg(
+						"field %s is required", structField.GetName())
+				}
+				if rawValue.Type == gjson.Null {
+					if structField.GetNullable() {
+						validDataMap[structField.GetName()] = append(validDataMap[structField.GetName()], false)
+						continue
+					}
+					return reallyDataArray, validDataMap, merr.WrapErrParameterInvalidMsg(
+						"field %s is not nullable", structField.GetName())
+				}
+				if structField.GetNullable() {
 					validDataMap[structField.GetName()] = append(validDataMap[structField.GetName()], true)
 				}
-				structRow, err := parseStructArrayRow(rawValue.Raw, structField)
+				structRow, err := parseStructArrayRow(rawValue.Raw, structField, compatibilityMode)
 				if err != nil {
 					return reallyDataArray, validDataMap, err
 				}
@@ -528,6 +968,36 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 				}
 
 				dataString := fieldValue.String()
+				// A vector element cannot be null either: the decoder turns one
+				// into 0, which is a coordinate the caller never sent. Not gated
+				// by compatibilityMode -- a vector is a dense array of numbers
+				// with nowhere to record "absent", so there is no previous
+				// handling worth restoring, only a silently different point.
+				if typeutil.IsVectorType(fieldType) {
+					// A whole value of "null" decodes to a nil slice without an
+					// error, which is stored as an empty vector -- an empty
+					// sparse row for a sparse field. A vector sent as base64
+					// never reads as this literal, so nothing legitimate is
+					// caught here.
+					// "null" is also valid base64 -- it decodes to the three
+					// bytes 9e e9 65, a whole dim-24 binary vector -- so only
+					// ask this of the types that have no base64 spelling.
+					if !compatibilityMode && !vectorAcceptsBase64(fieldType) &&
+						strings.TrimSpace(dataString) == "null" {
+						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalidMsg(
+							"field %s is null; a vector cannot be null", fieldName)
+					}
+					if idx, found := nullElementIn(gjson.Parse(dataString)); found {
+						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalidMsg(
+							"field %s has a null at index %d; a vector element cannot be null",
+							fieldName, idx)
+					}
+					if !compatibilityMode {
+						if err := checkVectorSpelling(fieldName, fieldType, fieldValue); err != nil {
+							return reallyDataArray, validDataMap, err
+						}
+					}
+				}
 				// if has pass pk than just to try to set it
 				if field.IsPrimaryKey && field.AutoID && len(dataString) == 0 {
 					continue
@@ -537,6 +1007,15 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 				// let proxy validate when data is provided
 				if field.GetIsFunctionOutput() && dataString == "" {
 					continue
+				}
+
+				if !compatibilityMode {
+					if !fieldValue.Exists() {
+						return reallyDataArray, validDataMap, merr.WrapErrParameterMissingMsg("field %s is required", fieldName)
+					}
+					if fieldValue.Type == gjson.Null {
+						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalidMsg("field %s is not nullable", fieldName)
+					}
 				}
 
 				switch fieldType {
@@ -619,30 +1098,105 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 					}
 					reallyData[fieldName] = result
 				case schemapb.DataType_Int8:
-					result, err := cast.ToInt8E(dataString)
-					if err != nil {
-						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error())
+					if compatibilityMode {
+						legacy, err := cast.ToInt8E(dataString)
+						if err != nil {
+							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error())
+						}
+						reallyData[fieldName] = legacy
+						break
 					}
-					reallyData[fieldName] = result
+					result, actual, ok := parseRESTInteger(fieldValue, 8)
+					if !ok {
+						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(
+							schemapb.DataType_name[int32(fieldType)], actual,
+							fmt.Sprintf("field %s value must be an integer in range [%d, %d]", fieldName, math.MinInt8, math.MaxInt8))
+					}
+					reallyData[fieldName] = int8(result)
 				case schemapb.DataType_Int16:
-					result, err := cast.ToInt16E(dataString)
-					if err != nil {
-						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error())
+					if compatibilityMode {
+						legacy, err := cast.ToInt16E(dataString)
+						if err != nil {
+							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error())
+						}
+						reallyData[fieldName] = legacy
+						break
 					}
-					reallyData[fieldName] = result
+					result, actual, ok := parseRESTInteger(fieldValue, 16)
+					if !ok {
+						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(
+							schemapb.DataType_name[int32(fieldType)], actual,
+							fmt.Sprintf("field %s value must be an integer in range [%d, %d]", fieldName, math.MinInt16, math.MaxInt16))
+					}
+					reallyData[fieldName] = int16(result)
 				case schemapb.DataType_Int32:
-					result, err := cast.ToInt32E(dataString)
-					if err != nil {
-						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error())
+					if compatibilityMode {
+						legacy, err := cast.ToInt32E(dataString)
+						if err != nil {
+							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error())
+						}
+						reallyData[fieldName] = legacy
+						break
 					}
-					reallyData[fieldName] = result
+					result, actual, ok := parseRESTInteger(fieldValue, 32)
+					if !ok {
+						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(
+							schemapb.DataType_name[int32(fieldType)], actual,
+							fmt.Sprintf("field %s value must be an integer in range [%d, %d]", fieldName, math.MinInt32, math.MaxInt32))
+					}
+					reallyData[fieldName] = int32(result)
 				case schemapb.DataType_Int64:
-					result, err := json.Number(dataString).Int64()
-					if err != nil {
-						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error())
+					// Only the JSON-number form goes through the raw literal.
+					// gjson's String() renders a number through float64 as soon
+					// as the raw text is not all digits, so 9007199254740993.0
+					// reached json.Number as 9007199254740992 and was accepted.
+					// Quoted integers keep their base-10 parsing: this path also
+					// carries Int64 primary keys, and strconv's base detection
+					// would silently reinterpret a zero-padded id such as "010".
+					var result int64
+					if fieldValue.Type == gjson.Number && !compatibilityMode {
+						parsed, ok := parseJSONInteger(fieldValue.Raw, 64)
+						if !ok {
+							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(
+								schemapb.DataType_name[int32(fieldType)], fieldValue.Raw,
+								fmt.Sprintf("field %s value must be an integer in range [%d, %d]",
+									fieldName, int64(math.MinInt64), int64(math.MaxInt64)))
+						}
+						result = parsed
+					} else {
+						parsed, err := json.Number(dataString).Int64()
+						if err != nil {
+							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error())
+						}
+						result = parsed
 					}
 					reallyData[fieldName] = result
 				case schemapb.DataType_Array:
+					// A null element has nowhere to go: an array has no
+					// element-level validity, so it can only be dropped into the
+					// element's zero value. sonic already refuses one for an
+					// integer or string element, but accepts it for a boolean or
+					// a float, where it silently became false or 0. Refuse it for
+					// every element type, and say which position it was at.
+					if !compatibilityMode {
+						// Parse dataString, not fieldValue: an array handed over as
+						// a JSON string is unwrapped before it is decoded, and
+						// checking the wrapper found no elements to look at.
+						//
+						// Require an array first. A whole value of "null" decodes
+						// to a nil slice without an error and was stored as an
+						// empty array, and the element scan below has nothing to
+						// look at when the value is not an array at all.
+						if !gjson.Parse(dataString).IsArray() {
+							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalidMsg(
+								"field %s is an array field, but the value sent is not an array", fieldName)
+						}
+						if idx, found := nullElementIn(gjson.Parse(dataString)); found {
+							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalidMsg(
+								"field %s has a null at index %d; an array element cannot be null",
+								fieldName, idx)
+						}
+					}
 					switch field.ElementType {
 					case schemapb.DataType_Bool:
 						arr := make([]bool, 0)
@@ -758,10 +1312,66 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 						}
 					}
 				case schemapb.DataType_JSON:
-					reallyData[fieldName] = []byte(dataString)
+					// Store the original JSON token verbatim. gjson's String()
+					// unquotes JSON strings ("hello" -> hello) and renders numbers
+					// through float64 (1e400 -> +Inf), both of which are not valid
+					// JSON documents and make the stored field unparsable. The
+					// request body is already validated as JSON by the gin binder
+					// before it reaches here, so Raw is always a well-formed token.
+					// A JSON document supplied as a JSON string is still unwrapped,
+					// preserving the existing input form.
+					if compatibilityMode {
+						reallyData[fieldName] = []byte(dataString)
+						break
+					}
+					// A JSON document supplied as a JSON string is unwrapped, as
+					// it always has been. The unwrapped token is then validated
+					// like any other: it used to be trusted, which let an
+					// oversized integer, a duplicate key or a lone surrogate in
+					// through the string form.
+					document := fieldValue.Raw
+					if fieldValue.Type == gjson.String && json.Valid([]byte(dataString)) {
+						document = dataString
+					}
+					stored, err := jsonDocumentForStorage(fieldName, document)
+					if err != nil {
+						return reallyDataArray, validDataMap, err
+					}
+					reallyData[fieldName] = stored
 				case schemapb.DataType_Geometry:
 					reallyData[fieldName] = dataString
 				case schemapb.DataType_Float:
+					if !compatibilityMode && fieldValue.Type == gjson.Number {
+						// Read through float64 and narrowed, the way every path
+						// this value will be compared against reads it: the
+						// expression parser, an exprParams value carried as a
+						// double, and a row written through pymilvus, whose
+						// Python float is a double before it becomes a float32.
+						// Parsing straight to float32 rounds once and is the
+						// more faithful reading of the decimal, but it lands a
+						// literal sitting on a float32 rounding midpoint on a
+						// different value than any of those paths produce, and
+						// the row cannot then be found with the literal that
+						// wrote it. The same dialect everywhere wins.
+						//
+						// What that costs is one check the float32 parser would
+						// have made for free: 3.5e38 is finite as a float64, so
+						// the parse succeeds and the narrowing silently yields
+						// +Inf -- a value no caller sent. The range is checked
+						// here, before the cast destroys the evidence.
+						parsed, err := strconv.ParseFloat(fieldValue.Raw, 64)
+						if err != nil || math.IsInf(parsed, 0) {
+							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(
+								schemapb.DataType_name[int32(fieldType)], fieldValue.Raw, "invalid float value")
+						}
+						if math.Abs(parsed) > math.MaxFloat32 {
+							return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(
+								schemapb.DataType_name[int32(fieldType)], fieldValue.Raw,
+								"value is outside the float32 range")
+						}
+						reallyData[fieldName] = float32(parsed)
+						break
+					}
 					result, err := cast.ToFloat32E(dataString)
 					if err != nil {
 						return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(fieldType)], dataString, err.Error())
@@ -775,10 +1385,12 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 					reallyData[fieldName] = result
 				case schemapb.DataType_Timestamptz:
 					reallyData[fieldName] = dataString
-				case schemapb.DataType_VarChar:
-					reallyData[fieldName] = dataString
-				case schemapb.DataType_String:
-					reallyData[fieldName] = dataString
+				case schemapb.DataType_VarChar, schemapb.DataType_String:
+					value, err := stringFieldValue(fieldName, fieldValue, compatibilityMode)
+					if err != nil {
+						return reallyDataArray, validDataMap, err
+					}
+					reallyData[fieldName] = value
 				default:
 					return reallyDataArray, validDataMap, merr.WrapErrParameterInvalid("", schemapb.DataType_name[int32(fieldType)], "fieldName: "+fieldName)
 				}
@@ -786,28 +1398,98 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 
 			// fill dynamic schema
 
+			// Two keys that differ only in a lone surrogate escape both decode to
+			// U+FFFD, so Map() collapses them and one field disappears without a
+			// word. The decoded key passes utf8.ValidString, so it has to be
+			// caught on the raw text before the map is built.
+			if !compatibilityMode {
+				var keyErr error
+				data.ForEach(func(key, _ gjson.Result) bool {
+					if hasLoneSurrogate(key.Raw) {
+						keyErr = merr.WrapErrParameterInvalidMsg(
+							"field name %s contains an unpaired surrogate, which the JSON engine cannot read", key.Raw)
+						return false
+					}
+					return true
+				})
+				if keyErr != nil {
+					return nil, nil, keyErr
+				}
+			}
+
+			// Map() keeps the first occurrence when a row declares the same key
+			// twice, so {"dyn": 1, "dyn": 2} silently stores 1. Duplicate keys
+			// *inside* a dynamic value are rejected, which makes the two
+			// inconsistent, but catching this one needs a scan of the whole row
+			// before the map is built and the behavior predates this change, so
+			// it is left alone deliberately.
 			for mapKey, mapValue := range data.Map() {
 				if !containsString(fieldNames, mapKey) {
 					if collSchema.EnableDynamicField {
 						if mapKey == common.MetaFieldName {
 							return nil, nil, merr.WrapErrParameterInvalidMsg("use the invalid field name(%s) when enable dynamicField", mapKey)
 						}
+						// A key is re-encoded with the wrapper below, which turns
+						// invalid UTF-8 into U+FFFD. Two different keys can then
+						// normalize to the same one, so the stored document ends
+						// up declaring a key twice.
+						if !compatibilityMode && !utf8.ValidString(mapKey) {
+							return nil, nil, merr.WrapErrParameterInvalidMsg(
+								"dynamic field name contains invalid UTF-8, which the JSON engine cannot read")
+						}
 						mapValueStr := mapValue.String()
 						switch mapValue.Type {
 						case gjson.True, gjson.False:
 							reallyData[mapKey] = cast.ToBool(mapValueStr)
 						case gjson.String:
+							// The value is re-encoded on the way out, which would
+							// replace invalid UTF-8 with U+FFFD and silently
+							// rewrite what the caller sent.
+							if !compatibilityMode && !utf8.ValidString(mapValueStr) {
+								return nil, nil, merr.WrapErrParameterInvalidMsg(
+									"dynamic field %s contains invalid UTF-8, which the JSON engine cannot read", mapKey)
+							}
 							reallyData[mapKey] = mapValueStr
 						case gjson.Number:
-							if strings.Contains(mapValue.Raw, ".") {
-								reallyData[mapKey] = cast.ToFloat64(mapValue.Raw)
-							} else {
-								reallyData[mapKey] = cast.ToInt64(mapValueStr)
+							if compatibilityMode {
+								if strings.Contains(mapValue.Raw, ".") {
+									reallyData[mapKey] = cast.ToFloat64(mapValue.Raw)
+								} else {
+									reallyData[mapKey] = cast.ToInt64(mapValueStr)
+								}
+								break
 							}
+							number, err := jsonNumberLiteral(mapKey, mapValue.Raw)
+							if err != nil {
+								return nil, nil, err
+							}
+							reallyData[mapKey] = number
 						case gjson.JSON:
-							reallyData[mapKey] = mapValue.Value()
+							// Value() decodes the whole subtree into Go values,
+							// turning every nested number into a float64, so a
+							// nested 9007199254740993 came back as ...992. Keep
+							// the subtree as written, once it is known to be
+							// readable.
+							if compatibilityMode {
+								reallyData[mapKey] = mapValue.Value()
+								break
+							}
+							document, err := jsonDocumentForStorage(mapKey, mapValue.Raw)
+							if err != nil {
+								return nil, nil, err
+							}
+							reallyData[mapKey] = json.RawMessage(document)
 						case gjson.Null:
-							// skip null
+							// An absent key and an explicit null are different
+							// requests: the first says nothing about the field,
+							// the second says it should be null. Skipping the
+							// null collapsed them, so a partial update could not
+							// clear a dynamic field -- {"tag": null} merged to
+							// nothing and the old value survived.
+							if compatibilityMode {
+								break
+							}
+							reallyData[mapKey] = json.RawMessage("null")
 						default:
 							mlog.Warn(context.TODO(), "unknown json type found", mlog.Int("mapValue.Type", int(mapValue.Type)))
 						}
@@ -860,7 +1542,7 @@ func subShortName(sub *schemapb.FieldSchema) string {
 	return structFieldShortName(sub.GetName())
 }
 
-func parseStructArrayRow(rawJSON string, structSchema *schemapb.StructArrayFieldSchema) (structArrayRow, error) {
+func parseStructArrayRow(rawJSON string, structSchema *schemapb.StructArrayFieldSchema, compatibilityMode bool) (structArrayRow, error) {
 	if rawJSON == "" {
 		return nil, merr.WrapErrParameterInvalidMsg("missing struct array field: %s", structSchema.GetName())
 	}
@@ -909,7 +1591,7 @@ func parseStructArrayRow(rawJSON string, structSchema *schemapb.StructArrayField
 		vals := collected[key]
 		switch sub.GetDataType() {
 		case schemapb.DataType_Array:
-			scalar, err := buildStructSubArrayScalar(sub, vals)
+			scalar, err := buildStructSubArrayScalar(sub, vals, compatibilityMode)
 			if err != nil {
 				return nil, err
 			}
@@ -929,7 +1611,183 @@ func parseStructArrayRow(rawJSON string, structSchema *schemapb.StructArrayField
 	return row, nil
 }
 
-func buildStructSubArrayScalar(sub *schemapb.FieldSchema, vals []gjson.Result) (*schemapb.ScalarField, error) {
+func isJSONDigit(ch byte) bool {
+	return ch >= '0' && ch <= '9'
+}
+
+// parseJSONInteger parses an exact integer from a JSON number literal.
+// Integer-valued decimal and exponent forms are accepted without converting
+// through float64 or computing attacker-controlled arbitrary-precision powers.
+func parseJSONInteger(raw string, bitSize int) (int64, bool) {
+	switch bitSize {
+	case 8, 16, 32, 64:
+	default:
+		return 0, false
+	}
+	if raw == "" {
+		return 0, false
+	}
+
+	i := 0
+	negative := false
+	if raw[i] == '-' {
+		negative = true
+		i++
+		if i == len(raw) {
+			return 0, false
+		}
+	}
+
+	// An int64 has at most 19 decimal digits. Keep only the prefix that can
+	// possibly survive decimal scaling; the remaining input is still scanned
+	// to validate syntax and count significant/trailing digits.
+	var significantPrefix [19]byte
+	prefixLen := 0
+	significantDigits := 0
+	trailingZeros := 0
+	coefficientIsZero := true
+	recordDigit := func(ch byte) {
+		if coefficientIsZero {
+			if ch == '0' {
+				return
+			}
+			coefficientIsZero = false
+		}
+		significantDigits++
+		if prefixLen < len(significantPrefix) {
+			significantPrefix[prefixLen] = ch
+			prefixLen++
+		}
+		if ch == '0' {
+			trailingZeros++
+		} else {
+			trailingZeros = 0
+		}
+	}
+
+	// JSON integer part: 0 or a non-zero digit followed by digits.
+	if raw[i] == '0' {
+		recordDigit(raw[i])
+		i++
+		if i < len(raw) && isJSONDigit(raw[i]) {
+			return 0, false
+		}
+	} else if raw[i] >= '1' && raw[i] <= '9' {
+		for i < len(raw) && isJSONDigit(raw[i]) {
+			recordDigit(raw[i])
+			i++
+		}
+	} else {
+		return 0, false
+	}
+
+	fractionDigits := 0
+	if i < len(raw) && raw[i] == '.' {
+		i++
+		fractionStart := i
+		for i < len(raw) && isJSONDigit(raw[i]) {
+			recordDigit(raw[i])
+			fractionDigits++
+			i++
+		}
+		if i == fractionStart {
+			return 0, false
+		}
+	}
+
+	exponentAbs := 0
+	exponentNegative := false
+	if i < len(raw) && (raw[i] == 'e' || raw[i] == 'E') {
+		i++
+		if i < len(raw) && (raw[i] == '+' || raw[i] == '-') {
+			exponentNegative = raw[i] == '-'
+			i++
+		}
+		exponentStart := i
+		// Values beyond this limit cannot bring a non-zero coefficient into
+		// the int64 range. Saturating avoids integer overflow while preserving
+		// work proportional to the input length.
+		exponentLimit := len(raw) + 20
+		for i < len(raw) && isJSONDigit(raw[i]) {
+			digit := int(raw[i] - '0')
+			if exponentAbs < exponentLimit {
+				if exponentAbs > (exponentLimit-digit)/10 {
+					exponentAbs = exponentLimit
+				} else {
+					exponentAbs = exponentAbs*10 + digit
+				}
+			}
+			i++
+		}
+		if i == exponentStart {
+			return 0, false
+		}
+	}
+	if i != len(raw) {
+		return 0, false
+	}
+	if coefficientIsZero {
+		return 0, true
+	}
+
+	trimDigits, appendZeros := 0, 0
+	if exponentNegative {
+		trimDigits = exponentAbs + fractionDigits
+	} else if exponentAbs >= fractionDigits {
+		appendZeros = exponentAbs - fractionDigits
+	} else {
+		trimDigits = fractionDigits - exponentAbs
+	}
+	if trimDigits > trailingZeros {
+		return 0, false
+	}
+
+	keptDigits := significantDigits - trimDigits
+	if keptDigits <= 0 || keptDigits > prefixLen || appendZeros > len(significantPrefix)-keptDigits {
+		return 0, false
+	}
+
+	var integerLiteral [20]byte
+	integerLen := 0
+	if negative {
+		integerLiteral[integerLen] = '-'
+		integerLen++
+	}
+	copy(integerLiteral[integerLen:], significantPrefix[:keptDigits])
+	integerLen += keptDigits
+	for idx := 0; idx < appendZeros; idx++ {
+		integerLiteral[integerLen] = '0'
+		integerLen++
+	}
+
+	value, err := strconv.ParseInt(string(integerLiteral[:integerLen]), 10, bitSize)
+	if err != nil {
+		return 0, false
+	}
+	return value, true
+}
+
+// parseRESTInteger preserves the raw token for JSON numbers so validation runs
+// before gjson can normalize decimal or exponent forms through float64.
+//
+// Quoted integers are read as base 10. cast used strconv's base detection, so
+// a zero-padded id such as "010" became 8 in an Int8/Int16/Int32 field while
+// the Int64 field read the same string as 10 through json.Number. Decimal is
+// the only reading a REST caller can have meant, and it makes the integer
+// types agree.
+func parseRESTInteger(value gjson.Result, bitSize int) (int64, string, bool) {
+	actual := value.String()
+	if value.Type == gjson.Number {
+		actual = value.Raw
+		parsed, ok := parseJSONInteger(actual, bitSize)
+		return parsed, actual, ok
+	}
+
+	parsed, err := strconv.ParseInt(actual, 10, bitSize)
+	return parsed, actual, err == nil
+}
+
+func buildStructSubArrayScalar(sub *schemapb.FieldSchema, vals []gjson.Result, compatibilityMode bool) (*schemapb.ScalarField, error) {
 	switch sub.GetElementType() {
 	case schemapb.DataType_Bool:
 		arr := make([]bool, 0, len(vals))
@@ -943,12 +1801,31 @@ func buildStructSubArrayScalar(sub *schemapb.FieldSchema, vals []gjson.Result) (
 			Data: &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{Data: arr}},
 		}, nil
 	case schemapb.DataType_Int8, schemapb.DataType_Int16, schemapb.DataType_Int32:
+		bitSize := 32
+		minValue, maxValue := int64(math.MinInt32), int64(math.MaxInt32)
+		switch sub.GetElementType() {
+		case schemapb.DataType_Int8:
+			bitSize = 8
+			minValue, maxValue = math.MinInt8, math.MaxInt8
+		case schemapb.DataType_Int16:
+			bitSize = 16
+			minValue, maxValue = math.MinInt16, math.MaxInt16
+		}
 		arr := make([]int32, 0, len(vals))
 		for _, v := range vals {
 			if v.Type != gjson.Number {
 				return nil, wrapStructSubParseError(sub, v, "expect integer")
 			}
-			arr = append(arr, int32(v.Int()))
+			if compatibilityMode {
+				arr = append(arr, int32(v.Int()))
+				continue
+			}
+			value, ok := parseJSONInteger(v.Raw, bitSize)
+			if !ok {
+				return nil, wrapStructSubParseError(sub, v,
+					fmt.Sprintf("expect integer in range [%d, %d]", minValue, maxValue))
+			}
+			arr = append(arr, int32(value))
 		}
 		return &schemapb.ScalarField{
 			Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: arr}},
@@ -959,7 +1836,16 @@ func buildStructSubArrayScalar(sub *schemapb.FieldSchema, vals []gjson.Result) (
 			if v.Type != gjson.Number {
 				return nil, wrapStructSubParseError(sub, v, "expect integer")
 			}
-			arr = append(arr, v.Int())
+			if compatibilityMode {
+				arr = append(arr, v.Int())
+				continue
+			}
+			value, ok := parseJSONInteger(v.Raw, 64)
+			if !ok {
+				return nil, wrapStructSubParseError(sub, v,
+					fmt.Sprintf("expect integer in range [%d, %d]", int64(math.MinInt64), int64(math.MaxInt64)))
+			}
+			arr = append(arr, value)
 		}
 		return &schemapb.ScalarField{
 			Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: arr}},
@@ -970,7 +1856,18 @@ func buildStructSubArrayScalar(sub *schemapb.FieldSchema, vals []gjson.Result) (
 			if v.Type != gjson.Number {
 				return nil, wrapStructSubParseError(sub, v, "expect float")
 			}
-			arr = append(arr, float32(v.Float()))
+			if compatibilityMode {
+				arr = append(arr, float32(v.Float()))
+				continue
+			}
+			// through float64 like every path this value will be compared
+			// against, with the range checked before the cast; see the Float
+			// case in checkAndSetData
+			parsed, err := strconv.ParseFloat(v.Raw, 64)
+			if err != nil || math.IsInf(parsed, 0) || math.Abs(parsed) > math.MaxFloat32 {
+				return nil, wrapStructSubParseError(sub, v, "expect float in the float32 range")
+			}
+			arr = append(arr, float32(parsed))
 		}
 		return &schemapb.ScalarField{
 			Data: &schemapb.ScalarField_FloatData{FloatData: &schemapb.FloatArray{Data: arr}},
@@ -1010,6 +1907,24 @@ func buildStructSubVectorField(sub *schemapb.FieldSchema, vals []gjson.Result) (
 		return nil, merr.WrapErrParameterInvalidMsg(
 			"sub-field %s: %s", sub.GetName(), err.Error())
 	}
+
+	// A null coordinate decodes to 0, which is a coordinate the caller never
+	// sent and which takes full part in the distance computation. A vector is a
+	// dense fixed-width array of numbers with no per-element validity to record
+	// "absent" in -- VectorField carries only a dim and a packed array -- so
+	// there is nothing to store but a number. Not gated by compatibilityMode:
+	// there is no such thing as a null coordinate to stay compatible with.
+	//
+	// The check on top-level vectors runs in checkAndSetData, which never sees
+	// these: a struct's sub-vectors are decoded here instead. nullElementIn
+	// ignores anything that is not an array, so a base64 row is left alone.
+	for _, v := range vals {
+		if idx, found := nullElementIn(v); found {
+			return nil, wrapStructSubParseError(sub, v,
+				fmt.Sprintf("null at index %d; a vector element cannot be null", idx))
+		}
+	}
+
 	switch sub.GetElementType() {
 	case schemapb.DataType_FloatVector:
 		packed := &schemapb.FloatArray{}
@@ -1219,6 +2134,18 @@ func embListPlaceholderType(elemType schemapb.DataType) (commonpb.PlaceholderTyp
 }
 
 func encodeEmbListQuery(vecs []gjson.Result, elemType schemapb.DataType, dim int64, qIdx int) ([]byte, error) {
+	// Same rule as a plain search vector: a null coordinate decodes to 0 and
+	// then passes the dimension check, so the search runs against a point the
+	// caller never sent. nullElementIn ignores anything that is not an array, so
+	// a base64 row is left alone.
+	for vIdx, v := range vecs {
+		if idx, found := nullElementIn(v); found {
+			return nil, merr.WrapErrParameterInvalidMsg(
+				"search data[%d][%d] has a null at index %d; a vector element cannot be null",
+				qIdx, vIdx, idx)
+		}
+	}
+
 	switch elemType {
 	case schemapb.DataType_FloatVector:
 		buf := make([]byte, 0, int(dim*4)*len(vecs))
@@ -2020,6 +2947,16 @@ func anyToColumns(rows []map[string]interface{}, validDataMap map[string][]bool,
 			if err != nil {
 				return nil, merr.WrapErrParameterInvalidErr(err, "failed to marshal dynamic field")
 			}
+			// The values were checked individually, but this wrapper is what is
+			// stored: it adds a level of nesting, and re-encoding can turn two
+			// distinct keys into one. Check the bytes that actually land.
+			// Gated like the per-value checks above: compatibilityMode restores
+			// the previous handling, which stored the wrapper unexamined.
+			if !paramtable.Get().HTTPCfg.CompatibilityMode.GetAsBool() {
+				if err := checkEngineCompatible(common.MetaFieldName, string(bs)); err != nil {
+					return nil, err
+				}
+			}
 			dynamicCol = append(dynamicCol, bs)
 		}
 	}
@@ -2338,7 +3275,37 @@ func anyToColumns(rows []map[string]interface{}, validDataMap map[string][]bool,
 	return columns, nil
 }
 
+// rejectNullCoordinates refuses a null inside any vector of a search request.
+//
+// A null coordinate decodes to 0 and then passes the dimension check, so the
+// search ran against a point the caller never asked for. This is the query side
+// of the same rule insert applies to a vector field, and like it is not gated by
+// compatibilityMode: a vector is a dense fixed-width array of numbers with no
+// per-element validity to record "absent" in, so there are no null coordinates
+// to stay compatible with.
+func rejectNullCoordinates(vectorStr string, dataType schemapb.DataType) error {
+	// same screen as nullElementIn, one level up: skip the row walk entirely
+	// for the overwhelming majority of requests that carry no "null" at all
+	if !strings.Contains(vectorStr, "null") {
+		return nil
+	}
+	var nullErr error
+	gjson.Parse(vectorStr).ForEach(func(row, vector gjson.Result) bool {
+		if idx, found := nullElementIn(vector); found {
+			nullErr = merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(dataType)], vector.Raw,
+				fmt.Sprintf("null at index %d of vector %s; a vector element cannot be null", idx, row.Raw))
+			return false
+		}
+		return true
+	})
+	return nullErr
+}
+
 func serializeFloatVectors(vectorStr string, dataType schemapb.DataType, dimension, bytesLen int64, fpArrayToBytesFunc func([]float32) []byte) ([][]byte, error) {
+	if err := rejectNullCoordinates(vectorStr, dataType); err != nil {
+		return nil, err
+	}
+
 	var fp32Values [][]float32
 	err := json.Unmarshal([]byte(vectorStr), &fp32Values)
 	if err != nil {
@@ -2390,9 +3357,26 @@ func serializeFloatOrByteVectors(jsonResult gjson.Result, dataType schemapb.Data
 }
 
 func serializeSparseFloatVectors(vectors []gjson.Result, dataType schemapb.DataType) ([][]byte, error) {
+	compatibilityMode := paramtable.Get().HTTPCfg.CompatibilityMode.GetAsBool()
 	values := make([][]byte, 0, len(vectors))
 	for _, vector := range vectors {
 		vectorBytes := []byte(vector.String())
+		// "null" is accepted as an empty sparse row, so the search ran against
+		// an empty vector instead of reporting the mistake. A real JSON null
+		// renders through String() as the empty string, so it is asked of the
+		// node type; the literal comparison catches the quoted spelling.
+		if !compatibilityMode &&
+			(vector.Type == gjson.Null || strings.TrimSpace(string(vectorBytes)) == "null") {
+			return nil, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(dataType)], vector.Raw,
+				"a sparse vector cannot be null")
+		}
+		// The float and int8 query paths read the raw element and so refuse the
+		// quoted form already; this one reads String() and did not.
+		if !compatibilityMode {
+			if err := checkVectorSpelling(HTTPRequestData, dataType, vector); err != nil {
+				return nil, err
+			}
+		}
 		sparseVector, err := typeutil.CreateSparseFloatRowFromJSON(vectorBytes)
 		if err != nil {
 			return nil, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(dataType)], vector.String(), err.Error())
@@ -2403,6 +3387,10 @@ func serializeSparseFloatVectors(vectors []gjson.Result, dataType schemapb.DataT
 }
 
 func serializeInt8Vectors(vectorStr string, dataType schemapb.DataType, dimension int64, int8ArrayToBytesFunc func([]int8) []byte) ([][]byte, error) {
+	if err := rejectNullCoordinates(vectorStr, dataType); err != nil {
+		return nil, err
+	}
+
 	var int8Values [][]int8
 	err := json.Unmarshal([]byte(vectorStr), &int8Values)
 	if err != nil {
@@ -2447,7 +3435,21 @@ func convertQueries2Placeholder(body string, dataType schemapb.DataType, dimensi
 		valueType = commonpb.PlaceholderType_VarChar
 		res := gjson.Get(body, HTTPRequestData).Array()
 		values = make([][]byte, 0, len(res))
+		compatibilityMode := paramtable.Get().HTTPCfg.CompatibilityMode.GetAsBool()
 		for _, v := range res {
+			// String() renders whatever it is given rather than returning a
+			// string the caller sent, so 1.50 searched for "1.5", null searched
+			// for "", and an object searched for its own JSON text.
+			//
+			// Stricter than insert on purpose: stringFieldValue keeps the
+			// literal of a number written into a VarChar field, because there
+			// the caller is naming the text to store. A query is naming text to
+			// find, and a number there is a mistake worth reporting rather than
+			// a search for its own digits.
+			if !compatibilityMode && v.Type != gjson.String {
+				return nil, merr.WrapErrParameterInvalid(schemapb.DataType_name[int32(dataType)], v.Raw,
+					"a text query must be a string")
+			}
 			values = append(values, []byte(v.String()))
 		}
 	}
@@ -2668,6 +3670,10 @@ func (accessor *fieldDataRowAccessor) rowIndex(rowIdx int64) (int64, bool, error
 func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemapb.FieldData, ids *schemapb.IDs,
 	scores []float32, enableInt64 bool, collectionSchema *schemapb.CollectionSchema,
 ) ([]map[string]interface{}, error) {
+	nativeJSON := paramtable.Get().HTTPCfg.NativeJSONResponse.GetAsBool()
+	jsonFieldNames := make(map[string]struct{})
+	jsonAllValid := true
+
 	columnNum := len(fieldDataList)
 	if rowsNum == int64(0) { // always
 		if columnNum > 0 {
@@ -2782,11 +3788,57 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 				case schemapb.DataType_JSON:
 					data, ok := fieldDataList[j].GetScalars().GetData().(*schemapb.ScalarField_JsonData)
 					if ok && !fieldDataList[j].GetIsDynamic() {
-						row[fieldDataList[j].GetFieldName()] = string(data.JsonData.GetData()[dataIdx])
+						// A JSON field reads back as a string by default, which
+						// is why the same value in a dynamic field reads back as a
+						// document. proxy.http.nativeJSONResponse returns the
+						// document instead; jsonFieldsToStrings below undoes it for
+						// the whole response if any row turns out not to hold one.
+						raw := data.JsonData.GetData()[dataIdx]
+						if nativeJSON {
+							row[fieldDataList[j].GetFieldName()] = json.RawMessage(raw)
+							jsonFieldNames[fieldDataList[j].GetFieldName()] = struct{}{}
+							// json.Valid accepts invalid UTF-8, which the encoder
+							// would replace with U+FFFD without saying so
+							if !json.Valid(raw) || !utf8.Valid(raw) {
+								jsonAllValid = false
+							}
+						} else {
+							row[fieldDataList[j].GetFieldName()] = string(raw)
+						}
 					} else {
 						var dataMap map[string]interface{}
 
-						err := json.Unmarshal(fieldDataList[j].GetScalars().GetJsonData().Data[dataIdx], &dataMap)
+						// Decode with UseNumber so numeric dynamic-field values are kept as
+						// json.Number instead of float64. float64 only has a 53-bit mantissa,
+						// so integers larger than 2^53 (e.g. 9223372036854775807) silently lose
+						// precision when round-tripped through the REST response. json.Number
+						// preserves the exact digits and serializes back as the same integer.
+						raw := fieldDataList[j].GetScalars().GetJsonData().Data[dataIdx]
+
+						// A Decoder reads one value and ignores whatever follows
+						// it, where the Unmarshal this replaced rejected trailing
+						// content. A second Decode on the same decoder restores
+						// that in the same pass: only whitespace to the end
+						// answers io.EOF, anything else answers a value or an
+						// error. An earlier version ran json.Valid first, which
+						// read every row twice; the ways to avoid the second
+						// call are all closed -- Token is not in sonic's
+						// Decoder, which this build uses everywhere, More
+						// answers false at a closing bracket because it exists
+						// to iterate inside one, and Buffered only exposes the
+						// window the decoder happened to pre-read, so a second
+						// document past four kilobytes of padding sat outside
+						// it and was silently dropped.
+						decoder := json.NewDecoder(bytes.NewReader(raw))
+						decoder.UseNumber()
+						err := decoder.Decode(&dataMap)
+						if err == nil {
+							var trailing interface{}
+							if trailingErr := decoder.Decode(&trailing); trailingErr != io.EOF {
+								err = merr.WrapErrParameterInvalidMsg(
+									"dynamic field does not hold a single JSON document")
+							}
+						}
 						if err != nil {
 							mlog.Error(context.TODO(),
 								fmt.Sprintf("[BuildQueryResp] Unmarshal error %s", err.Error()))
@@ -2844,7 +3896,31 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 		queryResp = append(queryResp, row)
 	}
 
+	if nativeJSON && !jsonAllValid {
+		// Rows written before the insert path was fixed can hold bytes that are
+		// not a JSON document. Embedding one of those natively makes the whole
+		// response fail to marshal, so a single legacy row would break every
+		// query that selects it. Degrade the whole response instead of part of
+		// it: a caller can handle "always a document" or "always a string", but
+		// not one field that is sometimes each.
+		mlog.Warn(context.TODO(),
+			"a JSON field holds bytes that are not a JSON document, returning JSON fields as strings for this response",
+			mlog.Int("rows", len(queryResp)))
+		jsonFieldsToStrings(queryResp, jsonFieldNames)
+	}
+
 	return queryResp, nil
+}
+
+// jsonFieldsToStrings turns the named fields back into their textual form.
+func jsonFieldsToStrings(rows []map[string]interface{}, fields map[string]struct{}) {
+	for _, row := range rows {
+		for name := range fields {
+			if raw, ok := row[name].(json.RawMessage); ok {
+				row[name] = string(raw)
+			}
+		}
+	}
 }
 
 func hasSearchAggregationResult(results *schemapb.SearchResultData) bool {
@@ -3379,171 +4455,371 @@ func RequestHandlerFunc(c *gin.Context) {
 	c.Next()
 }
 
-func generateTemplateArrayData(list []interface{}) *schemapb.TemplateArrayValue {
-	dtype := getTemplateArrayType(list)
-	var data *schemapb.TemplateArrayValue
-	switch dtype {
-	case schemapb.DataType_Bool:
-		result := make([]bool, len(list))
-		for i, item := range list {
-			result[i] = item.(bool)
+// templateValueFromJSON converts one expression template parameter from the
+// literal the caller wrote.
+//
+// The values used to arrive already decoded into interface{}, which meant every
+// number had been through float64: a filter parameter of 9007199254740993
+// silently matched 9007199254740992, while the same value written as a literal
+// in the filter string matched correctly. Reading the raw token keeps integers
+// exact.
+//
+// The previous version also panicked on anything it did not expect, so a null,
+// an empty array or an object in exprParams reached the recovery handler and
+// the caller got a 500.
+func templateValueFromJSON(name string, value gjson.Result, depth, maxDepth int) (*schemapb.TemplateValue, error) {
+	switch value.Type {
+	case gjson.True, gjson.False:
+		return &schemapb.TemplateValue{Val: &schemapb.TemplateValue_BoolVal{BoolVal: value.Bool()}}, nil
+
+	case gjson.String:
+		return &schemapb.TemplateValue{Val: &schemapb.TemplateValue_StringVal{StringVal: value.Str}}, nil
+
+	case gjson.Number:
+		if parsed, ok := parseJSONInteger(value.Raw, 64); ok {
+			return &schemapb.TemplateValue{Val: &schemapb.TemplateValue_Int64Val{Int64Val: parsed}}, nil
 		}
-		data = &schemapb.TemplateArrayValue{
-			Data: &schemapb.TemplateArrayValue_BoolData{
-				BoolData: &schemapb.BoolArray{
-					Data: result,
-				},
-			},
+		// A whole number sitting among the 64-bit integers must not become a
+		// float: comparing 9223372036854775809 as a double matches ...808
+		// instead, so the filter silently returns the wrong rows. Asked of the
+		// value rather than the spelling, so 9223372036854775809.0 and ...809e0
+		// are refused too, while 1e20 and 1e300 pass as the doubles they are --
+		// see wholeNumberInExactIntegerRange for the bounds and what they cost.
+		if err := checkTemplateIntegerRange(name, value, depth, maxDepth); err != nil {
+			return nil, err
 		}
-	case schemapb.DataType_String:
-		result := make([]string, len(list))
-		for i, item := range list {
-			result[i] = item.(string)
+		floating, err := strconv.ParseFloat(value.Raw, 64)
+		if err != nil || math.IsInf(floating, 0) {
+			return nil, merr.WrapErrParameterInvalidMsg(
+				"expression template parameter %s has an unrepresentable number %s", name, value.Raw)
 		}
-		data = &schemapb.TemplateArrayValue{
-			Data: &schemapb.TemplateArrayValue_StringData{
-				StringData: &schemapb.StringArray{
-					Data: result,
-				},
-			},
-		}
-	case schemapb.DataType_Int64:
-		result := make([]int64, len(list))
-		for i, item := range list {
-			result[i] = int64(item.(float64))
-		}
-		data = &schemapb.TemplateArrayValue{
-			Data: &schemapb.TemplateArrayValue_LongData{
-				LongData: &schemapb.LongArray{
-					Data: result,
-				},
-			},
-		}
-	case schemapb.DataType_Float:
-		result := make([]float64, len(list))
-		for i, item := range list {
-			result[i] = item.(float64)
-		}
-		data = &schemapb.TemplateArrayValue{
-			Data: &schemapb.TemplateArrayValue_DoubleData{
-				DoubleData: &schemapb.DoubleArray{
-					Data: result,
-				},
-			},
-		}
-	case schemapb.DataType_Array:
-		result := make([]*schemapb.TemplateArrayValue, len(list))
-		for i, item := range list {
-			result[i] = generateTemplateArrayData(item.([]interface{}))
-		}
-		data = &schemapb.TemplateArrayValue{
-			Data: &schemapb.TemplateArrayValue_ArrayData{
-				ArrayData: &schemapb.TemplateArrayValueArray{
-					Data: result,
-				},
-			},
-		}
-	case schemapb.DataType_JSON:
-		result := make([][]byte, len(list))
-		for i, item := range list {
-			bytes, err := json.Marshal(item)
-			// won't happen
+		return &schemapb.TemplateValue{Val: &schemapb.TemplateValue_FloatVal{FloatVal: floating}}, nil
+
+	case gjson.JSON:
+		if value.IsArray() {
+			array, err := templateArrayFromJSON(name, value, depth, maxDepth)
 			if err != nil {
-				panic(fmt.Sprintf("marshal data(%v) fail, please check it!", item))
+				return nil, err
 			}
-			result[i] = bytes
+			return &schemapb.TemplateValue{Val: &schemapb.TemplateValue_ArrayVal{ArrayVal: array}}, nil
 		}
-		data = &schemapb.TemplateArrayValue{
-			Data: &schemapb.TemplateArrayValue_JsonData{
-				JsonData: &schemapb.JSONArray{
-					Data: result,
-				},
-			},
-		}
-	// won't happen
+		return nil, merr.WrapErrParameterInvalidMsg(
+			"expression template parameter %s must be a bool, number, string or array", name)
+
 	default:
-		panic(fmt.Sprintf("Unexpected data(%v) type when generateTemplateArrayData, please check it!", list))
+		// gjson.Null, which also covers an absent member
+		return nil, merr.WrapErrParameterInvalidMsg(
+			"expression template parameter %s must not be null", name)
 	}
-	return data
 }
 
-func getTemplateArrayType(value []interface{}) schemapb.DataType {
-	dtype := getTemplateType(value[0])
-
-	for _, v := range value {
-		if getTemplateType(v) != dtype {
-			return schemapb.DataType_JSON
-		}
-	}
-	return dtype
-}
-
-func getTemplateType(value interface{}) schemapb.DataType {
-	switch v := value.(type) {
-	case bool:
+// templateElementType reports the element type an array member contributes. A
+// mixed array falls back to JSON, matching what the typed-array branches below
+// can hold.
+func templateElementType(value gjson.Result) schemapb.DataType {
+	switch value.Type {
+	case gjson.True, gjson.False:
 		return schemapb.DataType_Bool
-	case string:
+	case gjson.String:
 		return schemapb.DataType_String
-	case float64:
-		// note: all passed number is float64 type
-		// if field type is float64, but value in ExpressionTemplate is int64, it's ok to use TemplateValue_Int64Val to store it
-		// it will convert to float64 in ./internal/parser/planparserv2/utils.go, Line 233
-		if v == math.Trunc(v) && v >= math.MinInt64 && v <= math.MaxInt64 {
+	case gjson.Number:
+		if _, ok := parseJSONInteger(value.Raw, 64); ok {
 			return schemapb.DataType_Int64
 		}
 		return schemapb.DataType_Float
-	// it won't happen
-	// case int64:
-	case []interface{}:
-		return schemapb.DataType_Array
+	case gjson.JSON:
+		if value.IsArray() {
+			return schemapb.DataType_Array
+		}
+		return schemapb.DataType_JSON
 	default:
-		panic(fmt.Sprintf("Unexpected data(%v) when getTemplateType, please check it!", value))
+		return schemapb.DataType_JSON
 	}
 }
 
-func generateExpressionTemplate(params map[string]interface{}) map[string]*schemapb.TemplateValue {
-	expressionTemplate := make(map[string]*schemapb.TemplateValue, len(params))
-
-	for name, value := range params {
-		dtype := getTemplateType(value)
-		var data *schemapb.TemplateValue
-		switch dtype {
-		case schemapb.DataType_Bool:
-			data = &schemapb.TemplateValue{
-				Val: &schemapb.TemplateValue_BoolVal{
-					BoolVal: value.(bool),
-				},
-			}
-		case schemapb.DataType_String:
-			data = &schemapb.TemplateValue{
-				Val: &schemapb.TemplateValue_StringVal{
-					StringVal: value.(string),
-				},
-			}
-		case schemapb.DataType_Int64:
-			data = &schemapb.TemplateValue{
-				Val: &schemapb.TemplateValue_Int64Val{
-					Int64Val: int64(value.(float64)),
-				},
-			}
-		case schemapb.DataType_Float:
-			data = &schemapb.TemplateValue{
-				Val: &schemapb.TemplateValue_FloatVal{
-					FloatVal: value.(float64),
-				},
-			}
-		case schemapb.DataType_Array:
-			data = &schemapb.TemplateValue{
-				Val: &schemapb.TemplateValue_ArrayVal{
-					ArrayVal: generateTemplateArrayData(value.([]interface{})),
-				},
-			}
-		default:
-			panic(fmt.Sprintf("Unexpected data(%v) when generateExpressionTemplate, please check it!", data))
+// templateArrayFromJSON converts an array parameter. An empty array used to
+// index element zero and panic.
+// checkTemplateIntegerRange rejects a whole-number literal that cannot survive
+// the trip to a double, anywhere inside an expression template parameter.
+//
+// Such a literal is only ever carried as a double, which the planner compares
+// against exact integers, so a value the conversion rounds silently matches a
+// neighboring row instead of nothing.
+//
+// The question is asked of the value, not of the spelling. An earlier version
+// skipped anything containing "." or "e" on the grounds that the caller had
+// asked for a double, but that made the same number behave two ways:
+// 9223372036854775809 was refused while 9223372036854775809.0 was accepted and
+// then matched the row holding 9223372036854775808. A whole number written with
+// a zero fraction is still a whole number.
+//
+// The version after that refused every whole number outside int64, which also
+// refused values that are honest doubles: 1e20 is far past any 64-bit integer
+// and can only mean the double, so refusing it protected nothing. The refusal
+// is now scoped to the range where it protects something -- see
+// wholeNumberInExactIntegerRange, which also states what the scoping costs.
+func checkTemplateIntegerRange(name string, value gjson.Result, depth, maxDepth int) error {
+	switch {
+	case value.IsArray(), value.IsObject():
+		if depth >= maxDepth {
+			return templateDepthExceeded(name, maxDepth)
 		}
-		expressionTemplate[name] = data
+		var err error
+		value.ForEach(func(_, element gjson.Result) bool {
+			err = checkTemplateIntegerRange(name, element, depth+1, maxDepth)
+			return err == nil
+		})
+		return err
+
+	case value.Type == gjson.Number:
+		if _, ok := parseJSONInteger(value.Raw, 64); ok {
+			return nil
+		}
+		if !wholeNumberInExactIntegerRange(value.Raw) {
+			return nil
+		}
+		return merr.WrapErrParameterInvalidMsg(
+			"expression template parameter %s has a whole number %s that can only be carried as a double, "+
+				"where it can no longer be told apart from neighboring 64-bit integers", name, value.Raw)
 	}
-	return expressionTemplate
+	return nil
+}
+
+// wholeNumberInExactIntegerRange reports whether a number literal that is not
+// an int64 is a whole number that lands, as a double, among the values the
+// engine holds as exact 64-bit integers.
+//
+// What this rests on: parseJSONInteger reads the literal exactly, in every
+// notation, so every whole number an int64 can hold has already been taken
+// before this is asked. A whole number arriving here therefore has a magnitude
+// of at least 2^63, and the only question left is whether it is still close
+// enough to the 64-bit integers to be confused with one. The magnitude is read
+// from the double, which is what makes the bounds exact: a literal that rounds
+// onto 2^63 or 2^64 answers with that value and is caught, however it was
+// spelled.
+//
+// What it costs, stated plainly. Telling a whole number the double carries
+// exactly from one it rounds needs exact arithmetic on the literal, which is
+// precisely what this no longer does -- an arbitrary-precision expansion turns
+// a dozen bytes such as 1e-1000000 into a million-digit rational, and a body
+// full of them into minutes of CPU and gigabytes of allocation. So the whole
+// window is refused rather than only its unsafe half, and the values that pay
+// for it are the ones a double happens to carry exactly: 2^63 and 2^64
+// themselves, and the one round magnitude between them, 1e19.
+//
+// Where that leaves the caller, measured against the filter text rather than
+// assumed. Written as an integer, 9223372036854775809 is refused there too --
+// the parser reads it with ParseInt and reports an overflow -- so the two
+// paths now agree, and this closes a hole where the template path was the more
+// permissive of the two while quietly answering with the wrong rows. Written
+// with a point or an exponent the parser takes the same magnitude as a double
+// and accepts it, so the paths part company there and this one is the stricter:
+// that acceptance is the ambiguity being refused here, not a workaround to
+// point the caller at.
+//
+// Below 2^63 every whole number is an int64, and above 2^64 both sides of the
+// comparison are doubles that went through the same rounding, so nothing
+// outside the window changes.
+func wholeNumberInExactIntegerRange(raw string) bool {
+	floating, err := strconv.ParseFloat(raw, 64)
+	if err != nil || math.IsInf(floating, 0) {
+		// unrepresentable as a double at all; the caller reports that instead
+		return false
+	}
+	magnitude := math.Abs(floating)
+	if magnitude < math.Ldexp(1, 63) || magnitude > math.Ldexp(1, 64) {
+		return false
+	}
+	return isWholeNumberLiteral(raw)
+}
+
+// isWholeNumberLiteral reports whether a JSON number denotes a whole number,
+// whatever notation it is written in: 5, 5.0, 5e0, 500e-2 and 1e300 all do,
+// while 1.5 and 1e-3 do not.
+//
+// The literal is read rather than evaluated: the exponent moves the decimal
+// point through the mantissa's digits, and whatever lands to the right of it
+// must be zeros. Nothing is computed, so the work is one pass over the literal
+// and a hostile exponent buys the sender nothing.
+func isWholeNumberLiteral(raw string) bool {
+	mantissa := raw
+	exponent := 0
+	if at := strings.IndexAny(raw, "eE"); at >= 0 {
+		mantissa = raw[:at]
+		parsed, err := strconv.Atoi(raw[at+1:])
+		if err != nil {
+			// Too many exponent digits to hold in an int, so only the sign
+			// matters: every digit ends up left of the point, or the value
+			// ends up strictly between zero and one. A zero coefficient
+			// cannot reach here -- parseJSONInteger reads it as the integer 0.
+			return !strings.HasPrefix(raw[at+1:], "-")
+		}
+		exponent = parsed
+	}
+	mantissa = strings.TrimPrefix(mantissa, "-")
+
+	integer, fraction := mantissa, ""
+	if at := strings.IndexByte(mantissa, '.'); at >= 0 {
+		integer, fraction = mantissa[:at], mantissa[at+1:]
+	}
+	digits := integer + fraction
+	point := len(integer) + exponent
+	if point >= len(digits) {
+		return true
+	}
+	if point < 0 {
+		point = 0
+	}
+	for _, digit := range []byte(digits[point:]) {
+		if digit != '0' {
+			return false
+		}
+	}
+	return true
+}
+
+// templateDepthExceeded is the one answer every walk gives past the bound, so
+// the caller sees the same refusal wherever the depth is discovered.
+func templateDepthExceeded(name string, maxDepth int) error {
+	return merr.WrapErrParameterInvalidMsg(
+		"expression template parameter %s exceeds the maximum nesting depth %d", name, maxDepth)
+}
+
+func templateArrayFromJSON(name string, value gjson.Result, depth, maxDepth int) (*schemapb.TemplateArrayValue, error) {
+	if depth >= maxDepth {
+		return nil, templateDepthExceeded(name, maxDepth)
+	}
+	elements := value.Array()
+	if len(elements) == 0 {
+		return nil, merr.WrapErrParameterInvalidMsg(
+			"expression template parameter %s must not be an empty array", name)
+	}
+
+	dtype := templateElementType(elements[0])
+	for _, element := range elements {
+		if element.Type == gjson.Null {
+			return nil, merr.WrapErrParameterInvalidMsg(
+				"expression template parameter %s must not contain null", name)
+		}
+		// Check every element before the array's type is inferred, and look
+		// inside the ones that nest. An integer that does not fit an int64 is
+		// classified as a float, so in a mixed array it reaches the JSON branch
+		// and is compared as a double: 9223372036854775809 matched ...808. The
+		// same holds one level down, where [[9223372036854775809], "x"] made the
+		// array mixed and carried the integer along unchecked.
+		if err := checkTemplateIntegerRange(name, element, depth+1, maxDepth); err != nil {
+			return nil, err
+		}
+		if templateElementType(element) != dtype {
+			dtype = schemapb.DataType_JSON
+		}
+	}
+
+	switch dtype {
+	case schemapb.DataType_Bool:
+		result := make([]bool, len(elements))
+		for i, element := range elements {
+			result[i] = element.Bool()
+		}
+		return &schemapb.TemplateArrayValue{
+			Data: &schemapb.TemplateArrayValue_BoolData{BoolData: &schemapb.BoolArray{Data: result}},
+		}, nil
+
+	case schemapb.DataType_String:
+		result := make([]string, len(elements))
+		for i, element := range elements {
+			result[i] = element.Str
+		}
+		return &schemapb.TemplateArrayValue{
+			Data: &schemapb.TemplateArrayValue_StringData{StringData: &schemapb.StringArray{Data: result}},
+		}, nil
+
+	case schemapb.DataType_Int64:
+		result := make([]int64, len(elements))
+		for i, element := range elements {
+			parsed, ok := parseJSONInteger(element.Raw, 64)
+			if !ok {
+				return nil, merr.WrapErrParameterInvalidMsg(
+					"expression template parameter %s has an integer %s outside the 64-bit range",
+					name, element.Raw)
+			}
+			result[i] = parsed
+		}
+		return &schemapb.TemplateArrayValue{
+			Data: &schemapb.TemplateArrayValue_LongData{LongData: &schemapb.LongArray{Data: result}},
+		}, nil
+
+	case schemapb.DataType_Float:
+		result := make([]float64, len(elements))
+		for i, element := range elements {
+			floating, err := strconv.ParseFloat(element.Raw, 64)
+			if err != nil || math.IsInf(floating, 0) {
+				return nil, merr.WrapErrParameterInvalidMsg(
+					"expression template parameter %s has an unrepresentable number %s", name, element.Raw)
+			}
+			result[i] = floating
+		}
+		return &schemapb.TemplateArrayValue{
+			Data: &schemapb.TemplateArrayValue_DoubleData{DoubleData: &schemapb.DoubleArray{Data: result}},
+		}, nil
+
+	case schemapb.DataType_Array:
+		result := make([]*schemapb.TemplateArrayValue, len(elements))
+		for i, element := range elements {
+			nested, err := templateArrayFromJSON(name, element, depth+1, maxDepth)
+			if err != nil {
+				return nil, err
+			}
+			result[i] = nested
+		}
+		return &schemapb.TemplateArrayValue{
+			Data: &schemapb.TemplateArrayValue_ArrayData{ArrayData: &schemapb.TemplateArrayValueArray{Data: result}},
+		}, nil
+
+	default:
+		// Mixed element types travel as raw JSON documents.
+		result := make([][]byte, len(elements))
+		for i, element := range elements {
+			result[i] = []byte(element.Raw)
+		}
+		return &schemapb.TemplateArrayValue{
+			Data: &schemapb.TemplateArrayValue_JsonData{JsonData: &schemapb.JSONArray{Data: result}},
+		}, nil
+	}
+}
+
+// maxExprParamsDepthCeiling bounds the configurable bound. The recursion the
+// setting protects is the reason it exists; a configuration cannot be allowed
+// to configure the protection away.
+const maxExprParamsDepthCeiling = 1024
+
+// generateExpressionTemplate converts every expression template parameter,
+// reporting the first one that cannot be represented instead of panicking.
+//
+// The walk is recursive over the caller's nesting, so the depth is bounded --
+// by proxy.http.maxExprParamsDepth, read once per request and clamped to a
+// ceiling the configuration cannot raise. Arrays and objects both count. Not
+// gated by compatibilityMode: this is a resource bound, not a value rule, and
+// the previous handling it would restore is a stack overflow.
+func generateExpressionTemplate(params map[string]json.RawMessage) (map[string]*schemapb.TemplateValue, error) {
+	maxDepth := paramtable.Get().HTTPCfg.MaxExprParamsDepth.GetAsInt()
+	if maxDepth > maxExprParamsDepthCeiling {
+		maxDepth = maxExprParamsDepthCeiling
+	}
+	if maxDepth < 1 {
+		// zero or negative cannot mean "most permissive"; a bound set below
+		// the smallest usable value falls back to the smallest usable value
+		maxDepth = 1
+	}
+	expressionTemplate := make(map[string]*schemapb.TemplateValue, len(params))
+	for name, raw := range params {
+		value, err := templateValueFromJSON(name, gjson.ParseBytes(raw), 0, maxDepth)
+		if err != nil {
+			return nil, err
+		}
+		expressionTemplate[name] = value
+	}
+	return expressionTemplate, nil
 }
 
 func WrapErrorToResponse(err error) *milvuspb.BoolResponse {

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -46,6 +47,7 @@ const (
 	FieldBookID    = "book_id"
 	FieldBookIntro = "book_intro"
 	FieldVarchar   = "varchar_field"
+	FieldNarrowInt = "narrow_int"
 )
 
 var DefaultScores = []float32{0.01, 0.04, 0.09}
@@ -147,6 +149,32 @@ func generateCollectionSchema(primaryDataType schemapb.DataType, autoID bool, is
 		Fields:             fields,
 		EnableDynamicField: isDynamic,
 	}
+}
+
+func generateNarrowIntegerCollectionSchema(dataType schemapb.DataType) *schemapb.CollectionSchema {
+	schema := generateCollectionSchema(schemapb.DataType_Int64, false, false)
+	schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
+		FieldID:  common.StartOfUserFieldID + 100,
+		Name:     FieldNarrowInt,
+		DataType: dataType,
+	})
+	return schema
+}
+
+func hasStructArrayInt64Value(fieldsData []*schemapb.FieldData, structName, subName string, expected int64) bool {
+	for _, fieldData := range fieldsData {
+		if fieldData.GetFieldName() != structName {
+			continue
+		}
+		for _, subFieldData := range fieldData.GetStructArrays().GetFields() {
+			if subFieldData.GetFieldName() != subName {
+				continue
+			}
+			rows := subFieldData.GetScalars().GetArrayData().GetData()
+			return len(rows) == 1 && len(rows[0].GetLongData().GetData()) == 1 && rows[0].GetLongData().GetData()[0] == expected
+		}
+	}
+	return false
 }
 
 func generateDocInDocOutCollectionSchema(primaryDataType schemapb.DataType) *schemapb.CollectionSchema {
@@ -579,28 +607,24 @@ func TestPrimaryField(t *testing.T) {
 	assert.Equal(t, true, ok)
 	assert.EqualExportedValues(t, primaryField, field)
 
-	assert.Equal(t, "1,2,3", joinArray([]int64{1, 2, 3}))
-	assert.Equal(t, "1,2,3", joinArray([]string{"1", "2", "3"}))
-
+	// the ids are carried as a template value, so the expression text no longer
+	// contains anything the caller sent
 	jsonStr := "{\"id\": [1, 2, 3]}"
 	idStr := gjson.Get(jsonStr, "id")
-	rangeStr, err := convertRange(primaryField, idStr)
+	filter, values, err := checkGetPrimaryKey(coll, idStr)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "1,2,3", rangeStr)
-	filter, err := checkGetPrimaryKey(coll, idStr)
-	assert.Equal(t, nil, err)
-	assert.Equal(t, "book_id in [1,2,3]", filter)
+	assert.Equal(t, "book_id in {"+primaryKeyTemplateVar+"}", filter)
+	assert.Equal(t, []int64{1, 2, 3},
+		values[primaryKeyTemplateVar].GetArrayVal().GetLongData().GetData())
 
-	primaryField = generatePrimaryField(schemapb.DataType_VarChar, false)
 	jsonStr = "{\"id\": [\"1\", \"2\", \"3\"]}"
 	idStr = gjson.Get(jsonStr, "id")
-	rangeStr, err = convertRange(primaryField, idStr)
-	assert.Equal(t, nil, err)
-	assert.Equal(t, `"1","2","3"`, rangeStr)
 	coll2 := generateCollectionSchema(schemapb.DataType_VarChar, false, true)
-	filter, err = checkGetPrimaryKey(coll2, idStr)
+	filter, values, err = checkGetPrimaryKey(coll2, idStr)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, `book_id in ["1","2","3"]`, filter)
+	assert.Equal(t, "book_id in {"+primaryKeyTemplateVar+"}", filter)
+	assert.Equal(t, []string{"1", "2", "3"},
+		values[primaryKeyTemplateVar].GetArrayVal().GetStringData().GetData())
 }
 
 func TestAnyToColumns(t *testing.T) {
@@ -611,14 +635,14 @@ func TestAnyToColumns(t *testing.T) {
 		var err error
 		req.Data, _, err = checkAndSetData(body, coll, false)
 		assert.Equal(t, nil, err)
-		assert.Equal(t, int64(0), req.Data[0]["id"])
+		assert.Equal(t, json.Number("0"), req.Data[0]["id"]) // a dynamic key keeps its literal
 		assert.Equal(t, int64(1), req.Data[0]["book_id"])
 		assert.Equal(t, int64(2), req.Data[0]["word_count"])
 		fieldsData, err := anyToColumns(req.Data, nil, coll, true, false)
 		assert.Equal(t, nil, err)
 		assert.Equal(t, true, fieldsData[len(fieldsData)-1].IsDynamic)
 		assert.Equal(t, schemapb.DataType_JSON, fieldsData[len(fieldsData)-1].Type)
-		assert.Equal(t, "{\"classified\":false,\"id\":0}", string(fieldsData[len(fieldsData)-1].GetScalars().GetJsonData().GetData()[0]))
+		assert.Equal(t, "{\"classified\":false,\"databaseID\":null,\"id\":0}", string(fieldsData[len(fieldsData)-1].GetScalars().GetJsonData().GetData()[0]))
 	})
 
 	t.Run("upsert with dynamic field", func(t *testing.T) {
@@ -628,14 +652,14 @@ func TestAnyToColumns(t *testing.T) {
 		var err error
 		req.Data, _, err = checkAndSetData(body, coll, false)
 		assert.Equal(t, nil, err)
-		assert.Equal(t, int64(0), req.Data[0]["id"])
+		assert.Equal(t, json.Number("0"), req.Data[0]["id"]) // a dynamic key keeps its literal
 		assert.Equal(t, int64(1), req.Data[0]["book_id"])
 		assert.Equal(t, int64(2), req.Data[0]["word_count"])
 		fieldsData, err := anyToColumns(req.Data, nil, coll, false, false)
 		assert.Equal(t, nil, err)
 		assert.Equal(t, true, fieldsData[len(fieldsData)-1].IsDynamic)
 		assert.Equal(t, schemapb.DataType_JSON, fieldsData[len(fieldsData)-1].Type)
-		assert.Equal(t, "{\"classified\":false,\"id\":0}", string(fieldsData[len(fieldsData)-1].GetScalars().GetJsonData().GetData()[0]))
+		assert.Equal(t, "{\"classified\":false,\"databaseID\":null,\"id\":0}", string(fieldsData[len(fieldsData)-1].GetScalars().GetJsonData().GetData()[0]))
 	})
 
 	t.Run("insert with dynamic field, but pass pk when autoid==true", func(t *testing.T) {
@@ -645,7 +669,7 @@ func TestAnyToColumns(t *testing.T) {
 		var err error
 		req.Data, _, err = checkAndSetData(body, coll, false)
 		assert.Equal(t, nil, err)
-		assert.Equal(t, int64(0), req.Data[0]["id"])
+		assert.Equal(t, json.Number("0"), req.Data[0]["id"]) // a dynamic key keeps its literal
 		assert.Equal(t, int64(1), req.Data[0]["book_id"])
 		assert.Equal(t, int64(2), req.Data[0]["word_count"])
 		_, err = anyToColumns(req.Data, nil, coll, true, false)
@@ -664,7 +688,7 @@ func TestAnyToColumns(t *testing.T) {
 		var err error
 		req.Data, _, err = checkAndSetData(body, coll, false)
 		assert.Equal(t, nil, err)
-		assert.Equal(t, int64(0), req.Data[0]["id"])
+		assert.Equal(t, json.Number("0"), req.Data[0]["id"]) // a dynamic key keeps its literal
 		assert.Equal(t, int64(1), req.Data[0]["book_id"])
 		assert.Equal(t, int64(2), req.Data[0]["word_count"])
 		t.Log(req.Data)
@@ -702,8 +726,50 @@ func TestAnyToColumns(t *testing.T) {
 		coll := generateCollectionSchema(schemapb.DataType_Int64, false, false)
 		var err error
 		_, _, err = checkAndSetData(body, coll, false)
-		assert.Error(t, err)
-		assert.Equal(t, true, strings.HasPrefix(err.Error(), "strconv.ParseInt: parsing \"\": invalid syntax"))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterMissing)
+		assert.Contains(t, err.Error(), FieldBookID)
+	})
+
+	t.Run("insert with varchar pk missing when autoid==false", func(t *testing.T) {
+		body := []byte("{\"data\": {\"book_intro\": [0.1, 0.2], \"word_count\": 2}}")
+		coll := generateCollectionSchema(schemapb.DataType_VarChar, false, false)
+
+		_, _, err := checkAndSetData(body, coll, false)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterMissing)
+		assert.Contains(t, err.Error(), FieldBookID)
+	})
+
+	t.Run("insert with null varchar pk when autoid==false", func(t *testing.T) {
+		body := []byte("{\"data\": {\"book_id\": null, \"book_intro\": [0.1, 0.2], \"word_count\": 2}}")
+		coll := generateCollectionSchema(schemapb.DataType_VarChar, false, false)
+
+		_, _, err := checkAndSetData(body, coll, false)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), FieldBookID)
+		assert.Contains(t, err.Error(), "not nullable")
+	})
+
+	t.Run("insert with varchar pk missing when autoid==true", func(t *testing.T) {
+		body := []byte("{\"data\": {\"book_intro\": [0.1, 0.2], \"word_count\": 2}}")
+		coll := generateCollectionSchema(schemapb.DataType_VarChar, true, false)
+
+		data, validData, err := checkAndSetData(body, coll, false)
+
+		require.NoError(t, err)
+		require.Len(t, data, 1)
+		assert.NotContains(t, data[0], FieldBookID)
+		assert.Empty(t, validData)
+
+		fieldsData, err := anyToColumns(data, validData, coll, true, false)
+		require.NoError(t, err)
+		for _, fieldData := range fieldsData {
+			assert.NotEqual(t, FieldBookID, fieldData.GetFieldName())
+		}
 	})
 
 	t.Run("insert with autoid==true", func(t *testing.T) {
@@ -1008,6 +1074,112 @@ func TestAnyToColumns(t *testing.T) {
 }
 
 func TestCheckAndSetData(t *testing.T) {
+	t.Run("integer range validation", func(t *testing.T) {
+		tests := []struct {
+			name              string
+			dataType          schemapb.DataType
+			min               int64
+			max               int64
+			invalidValues     []int64
+			invalidJSONValues []string
+		}{
+			{
+				name: "int8", dataType: schemapb.DataType_Int8, min: math.MinInt8, max: math.MaxInt8,
+				invalidValues: []int64{-129, 128, 200, 256, 1000, 65535},
+				invalidJSONValues: []string{
+					"127.00000000000000000000000000001",
+					"-128.00000000000000000000000000001",
+					"1e-999999",
+				},
+			},
+			{
+				name: "int16", dataType: schemapb.DataType_Int16, min: math.MinInt16, max: math.MaxInt16,
+				invalidValues: []int64{-32769, 32768, 65535, 100000},
+				invalidJSONValues: []string{
+					"32767.00000000000000000000000000001",
+					"-32768.00000000000000000000000000001",
+					"1e-999999",
+				},
+			},
+			{
+				name: "int32", dataType: schemapb.DataType_Int32, min: math.MinInt32, max: math.MaxInt32,
+				invalidValues: []int64{-2147483649, 2147483648, 4294967295},
+				invalidJSONValues: []string{
+					"2147483647.00000000000000000001",
+					"-2147483648.00000000000000000001",
+					"1e-999999",
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				schema := generateNarrowIntegerCollectionSchema(test.dataType)
+
+				for _, value := range []int64{test.min, test.max} {
+					literal := strconv.FormatInt(value, 10)
+					for _, valueJSON := range []string{literal, strconv.Quote(literal)} {
+						body := []byte(fmt.Sprintf(`{"data":[{"book_id":1,"book_intro":[0.1,0.2],"word_count":2,"%s":%s}]}`, FieldNarrowInt, valueJSON))
+						rows, validData, err := checkAndSetData(body, schema, false)
+						require.NoError(t, err)
+						require.Len(t, rows, 1)
+						assert.EqualValues(t, value, rows[0][FieldNarrowInt])
+
+						fieldsData, err := anyToColumns(rows, validData, schema, true, false)
+						require.NoError(t, err)
+						var narrowFieldData *schemapb.FieldData
+						for _, fieldData := range fieldsData {
+							if fieldData.GetFieldName() == FieldNarrowInt {
+								narrowFieldData = fieldData
+								break
+							}
+						}
+						require.NotNil(t, narrowFieldData)
+						assert.Equal(t, []int32{int32(value)}, narrowFieldData.GetScalars().GetIntData().GetData())
+					}
+				}
+
+				for _, input := range []struct {
+					raw      string
+					expected int64
+				}{
+					{raw: "100.0", expected: 100},
+					{raw: "1e2", expected: 100},
+					{raw: strconv.Quote("100"), expected: 100},
+				} {
+					body := []byte(fmt.Sprintf(`{"data":[{"book_id":1,"book_intro":[0.1,0.2],"word_count":2,"%s":%s}]}`, FieldNarrowInt, input.raw))
+					rows, _, err := checkAndSetData(body, schema, false)
+					require.NoError(t, err)
+					require.Len(t, rows, 1)
+					assert.EqualValues(t, input.expected, rows[0][FieldNarrowInt])
+				}
+
+				for _, value := range test.invalidValues {
+					literal := strconv.FormatInt(value, 10)
+					for _, valueJSON := range []string{literal, strconv.Quote(literal)} {
+						body := []byte(fmt.Sprintf(`{"data":[{"book_id":1,"book_intro":[0.1,0.2],"word_count":2,"%s":%s}]}`, FieldNarrowInt, valueJSON))
+						_, _, err := checkAndSetData(body, schema, false)
+						require.Error(t, err)
+						assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+						assert.Contains(t, err.Error(), fmt.Sprintf("actual=%d", value))
+						assert.Contains(t, err.Error(), FieldNarrowInt)
+						assert.Contains(t, err.Error(), fmt.Sprintf("[%d, %d]", test.min, test.max))
+					}
+				}
+
+				for _, valueJSON := range test.invalidJSONValues {
+					body := []byte(fmt.Sprintf(`{"data":[{"book_id":1,"book_intro":[0.1,0.2],"word_count":2,"%s":%s}]}`, FieldNarrowInt, valueJSON))
+					_, _, err := checkAndSetData(body, schema, false)
+					require.Error(t, err)
+					assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+					assert.Contains(t, err.Error(), "actual="+valueJSON)
+					assert.Contains(t, err.Error(), FieldNarrowInt)
+					assert.Contains(t, err.Error(), fmt.Sprintf("[%d, %d]", test.min, test.max))
+				}
+			})
+		}
+	})
+
 	t.Run("invalid field name with dynamic field", func(t *testing.T) {
 		body := []byte("{\"data\": {\"id\": 0,\"$meta\": 2,\"book_id\": 1, \"book_intro\": [0.1, 0.2], \"word_count\": 2, \"classified\": false, \"databaseID\": null}}")
 		coll := generateCollectionSchema(schemapb.DataType_Int64, false, true)
@@ -1018,7 +1190,6 @@ func TestCheckAndSetData(t *testing.T) {
 	})
 	t.Run("without vector", func(t *testing.T) {
 		body := []byte("{\"data\": {}}")
-		var err error
 		primaryField := generatePrimaryField(schemapb.DataType_Int64, true)
 		floatVectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
 		floatVectorField.Name = "floatVector"
@@ -1030,51 +1201,25 @@ func TestCheckAndSetData(t *testing.T) {
 		bfloat16VectorField.Name = "bfloat16Vector"
 		int8VectorField := generateVectorFieldSchema(schemapb.DataType_Int8Vector)
 		int8VectorField.Name = "int8Vector"
-		_, _, err = checkAndSetData(body, &schemapb.CollectionSchema{
-			Name: DefaultCollectionName,
-			Fields: []*schemapb.FieldSchema{
-				primaryField, floatVectorField,
-			},
-			EnableDynamicField: true,
-		}, false)
-		assert.Error(t, err)
-		assert.Equal(t, true, strings.HasPrefix(err.Error(), "missing vector field"))
-		_, _, err = checkAndSetData(body, &schemapb.CollectionSchema{
-			Name: DefaultCollectionName,
-			Fields: []*schemapb.FieldSchema{
-				primaryField, binaryVectorField,
-			},
-			EnableDynamicField: true,
-		}, false)
-		assert.Error(t, err)
-		assert.Equal(t, true, strings.HasPrefix(err.Error(), "missing vector field"))
-		_, _, err = checkAndSetData(body, &schemapb.CollectionSchema{
-			Name: DefaultCollectionName,
-			Fields: []*schemapb.FieldSchema{
-				primaryField, float16VectorField,
-			},
-			EnableDynamicField: true,
-		}, false)
-		assert.Error(t, err)
-		assert.Equal(t, true, strings.HasPrefix(err.Error(), "missing vector field"))
-		_, _, err = checkAndSetData(body, &schemapb.CollectionSchema{
-			Name: DefaultCollectionName,
-			Fields: []*schemapb.FieldSchema{
-				primaryField, bfloat16VectorField,
-			},
-			EnableDynamicField: true,
-		}, false)
-		assert.Error(t, err)
-		assert.Equal(t, true, strings.HasPrefix(err.Error(), "missing vector field"))
-		_, _, err = checkAndSetData(body, &schemapb.CollectionSchema{
-			Name: DefaultCollectionName,
-			Fields: []*schemapb.FieldSchema{
-				primaryField, int8VectorField,
-			},
-			EnableDynamicField: true,
-		}, false)
-		assert.Error(t, err)
-		assert.Equal(t, true, strings.HasPrefix(err.Error(), "missing vector field"))
+
+		for _, vectorField := range []*schemapb.FieldSchema{
+			floatVectorField,
+			binaryVectorField,
+			float16VectorField,
+			bfloat16VectorField,
+			int8VectorField,
+		} {
+			_, _, err := checkAndSetData(body, &schemapb.CollectionSchema{
+				Name: DefaultCollectionName,
+				Fields: []*schemapb.FieldSchema{
+					primaryField, vectorField,
+				},
+				EnableDynamicField: true,
+			}, false)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterMissing)
+			assert.Contains(t, err.Error(), vectorField.GetName())
+		}
 	})
 
 	t.Run("with pk when autoID == True when upsert", func(t *testing.T) {
@@ -1165,7 +1310,8 @@ func TestInsertWithNullableField(t *testing.T) {
 	assert.Equal(t, int64(9999999999999999), data[0][FieldBookID])
 	arr, _ := data[0][arrayFieldName].(*schemapb.ScalarField)
 	assert.Equal(t, int64(9999999999999999), arr.GetLongData().GetData()[0])
-	assert.Equal(t, 4, len(data[0]))
+	// the row carries an explicit null for a dynamic key, which used to be dropped
+	assert.Equal(t, 5, len(data[0]))
 	assert.Equal(t, 5, len(data[1]))
 
 	fieldData, err := anyToColumns(data, validData, coll, true, false)
@@ -1456,7 +1602,8 @@ func TestInsertWithDefaultValueField(t *testing.T) {
 	assert.Equal(t, int64(9999999999999999), data[0][FieldBookID])
 	arr, _ := data[0][arrayFieldName].(*schemapb.ScalarField)
 	assert.Equal(t, int64(9999999999999999), arr.GetLongData().GetData()[0])
-	assert.Equal(t, 4, len(data[0]))
+	// the row carries an explicit null for a dynamic key, which used to be dropped
+	assert.Equal(t, 5, len(data[0]))
 	assert.Equal(t, 5, len(data[1]))
 
 	fieldData, err := anyToColumns(data, validData, coll, true, false)
@@ -1789,6 +1936,26 @@ func compareRow64(m1 map[string]interface{}, m2 map[string]interface{}) bool {
 	return true
 }
 
+// sameValue compares two response values. Dynamic-field numbers are decoded
+// with UseNumber so that an integer past 2^53 keeps its digits, which makes
+// them json.Number rather than the native type the expected rows carry.
+func sameValue(a interface{}, b interface{}) bool {
+	if a == b {
+		return true
+	}
+	an, aok := a.(json.Number)
+	bn, bok := b.(json.Number)
+	switch {
+	case aok && bok:
+		return an == bn
+	case aok:
+		return an.String() == fmt.Sprintf("%v", b)
+	case bok:
+		return bn.String() == fmt.Sprintf("%v", a)
+	}
+	return false
+}
+
 func compareRow(m1 map[string]interface{}, m2 map[string]interface{}) bool {
 	for key, value := range m1 {
 		if key == FieldBookIntro {
@@ -1816,7 +1983,7 @@ func compareRow(m1 map[string]interface{}, m2 map[string]interface{}) bool {
 			}
 		} else if strings.HasPrefix(key, "array-") {
 			continue
-		} else if value != m2[key] {
+		} else if !sameValue(value, m2[key]) {
 			return false
 		}
 	}
@@ -1826,7 +1993,7 @@ func compareRow(m1 map[string]interface{}, m2 map[string]interface{}) bool {
 			continue
 		} else if strings.HasPrefix(key, "array-") {
 			continue
-		} else if value != m1[key] {
+		} else if !sameValue(value, m1[key]) {
 			return false
 		}
 	}
@@ -1853,6 +2020,50 @@ func TestBuildQueryResp(t *testing.T) {
 	assert.Equal(t, nil, err)
 	exceptRows := generateSearchResult(schemapb.DataType_Int64)
 	assert.Equal(t, true, compareRows(rows, exceptRows, compareRow))
+}
+
+func TestBuildQueryRespDynamicFieldLargeIntPrecision(t *testing.T) {
+	t.Run("dynamic field integers above 2^53 keep exact precision", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{
+			Type:      schemapb.DataType_JSON,
+			FieldName: FieldBookIntro,
+			IsDynamic: true,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_JsonData{
+						JsonData: &schemapb.JSONArray{
+							Data: [][]byte{
+								[]byte(`{"big_val":9223372036854775807,"dyn_int":9007199254740993,"small":42}`),
+							},
+						},
+					},
+				},
+			},
+		}
+
+		rows, err := buildQueryResp(0, []string{"big_val", "dyn_int", "small"}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+
+		row := rows[0]
+		bigVal, ok := row["big_val"].(json.Number)
+		require.True(t, ok, "big_val should be json.Number, got %T", row["big_val"])
+		assert.Equal(t, "9223372036854775807", bigVal.String())
+
+		dynInt, ok := row["dyn_int"].(json.Number)
+		require.True(t, ok, "dyn_int should be json.Number, got %T", row["dyn_int"])
+		assert.Equal(t, "9007199254740993", dynInt.String())
+
+		small, ok := row["small"].(json.Number)
+		require.True(t, ok, "small should be json.Number, got %T", row["small"])
+		assert.Equal(t, "42", small.String())
+
+		// Serializing the row back must emit the exact digits, not a float64-rounded value.
+		out, err := json.Marshal(row)
+		require.NoError(t, err)
+		assert.Contains(t, string(out), "9223372036854775807")
+		assert.Contains(t, string(out), "9007199254740993")
+	})
 }
 
 func TestBuildQueryRespWithNullableCompactFields(t *testing.T) {
@@ -2442,250 +2653,6 @@ func newFieldData(fieldDatas []*schemapb.FieldData, firstFieldType schemapb.Data
 	}
 }
 
-func newNullableFieldData(fieldDatas []*schemapb.FieldData, firstFieldType schemapb.DataType) []*schemapb.FieldData {
-	fieldData1 := schemapb.FieldData{
-		Type:      schemapb.DataType_Bool,
-		FieldName: "field-bool",
-		Field: &schemapb.FieldData_Scalars{
-			Scalars: &schemapb.ScalarField{
-				Data: &schemapb.ScalarField_BoolData{
-					BoolData: &schemapb.BoolArray{
-						Data: []bool{true, true, true},
-					},
-				},
-			},
-		},
-		ValidData: []bool{true, false, true},
-		IsDynamic: false,
-	}
-	fieldDatas = append(fieldDatas, &fieldData1)
-
-	fieldData2 := schemapb.FieldData{
-		Type:      schemapb.DataType_Int8,
-		FieldName: "field-int8",
-		Field: &schemapb.FieldData_Scalars{
-			Scalars: &schemapb.ScalarField{
-				Data: &schemapb.ScalarField_IntData{
-					IntData: &schemapb.IntArray{
-						Data: []int32{0, 1, 2},
-					},
-				},
-			},
-		},
-		ValidData: []bool{true, false, true},
-		IsDynamic: false,
-	}
-	fieldDatas = append(fieldDatas, &fieldData2)
-
-	fieldData3 := schemapb.FieldData{
-		Type:      schemapb.DataType_Int16,
-		FieldName: "field-int16",
-		Field: &schemapb.FieldData_Scalars{
-			Scalars: &schemapb.ScalarField{
-				Data: &schemapb.ScalarField_IntData{
-					IntData: &schemapb.IntArray{
-						Data: []int32{0, 1, 2},
-					},
-				},
-			},
-		},
-		ValidData: []bool{true, false, true},
-		IsDynamic: false,
-	}
-	fieldDatas = append(fieldDatas, &fieldData3)
-
-	fieldData4 := schemapb.FieldData{
-		Type:      schemapb.DataType_Int32,
-		FieldName: "field-int32",
-		Field: &schemapb.FieldData_Scalars{
-			Scalars: &schemapb.ScalarField{
-				Data: &schemapb.ScalarField_IntData{
-					IntData: &schemapb.IntArray{
-						Data: []int32{0, 1, 2},
-					},
-				},
-			},
-		},
-		ValidData: []bool{true, false, true},
-		IsDynamic: false,
-	}
-	fieldDatas = append(fieldDatas, &fieldData4)
-
-	fieldData5 := schemapb.FieldData{
-		Type:      schemapb.DataType_Float,
-		FieldName: "field-float",
-		Field: &schemapb.FieldData_Scalars{
-			Scalars: &schemapb.ScalarField{
-				Data: &schemapb.ScalarField_FloatData{
-					FloatData: &schemapb.FloatArray{
-						Data: []float32{0, 1, 2},
-					},
-				},
-			},
-		},
-		ValidData: []bool{true, false, true},
-		IsDynamic: false,
-	}
-	fieldDatas = append(fieldDatas, &fieldData5)
-
-	fieldData6 := schemapb.FieldData{
-		Type:      schemapb.DataType_Double,
-		FieldName: "field-double",
-		Field: &schemapb.FieldData_Scalars{
-			Scalars: &schemapb.ScalarField{
-				Data: &schemapb.ScalarField_DoubleData{
-					DoubleData: &schemapb.DoubleArray{
-						Data: []float64{0, 1, 2},
-					},
-				},
-			},
-		},
-		ValidData: []bool{true, false, true},
-		IsDynamic: false,
-	}
-	fieldDatas = append(fieldDatas, &fieldData6)
-
-	fieldData7 := schemapb.FieldData{
-		Type:      schemapb.DataType_String,
-		FieldName: "field-string",
-		Field: &schemapb.FieldData_Scalars{
-			Scalars: &schemapb.ScalarField{
-				Data: &schemapb.ScalarField_StringData{
-					StringData: &schemapb.StringArray{
-						Data: []string{"0", "1", "2"},
-					},
-				},
-			},
-		},
-		ValidData: []bool{true, false, true},
-		IsDynamic: false,
-	}
-	fieldDatas = append(fieldDatas, &fieldData7)
-
-	fieldData8 := schemapb.FieldData{
-		Type:      schemapb.DataType_VarChar,
-		FieldName: "field-varchar",
-		Field: &schemapb.FieldData_Scalars{
-			Scalars: &schemapb.ScalarField{
-				Data: &schemapb.ScalarField_StringData{
-					StringData: &schemapb.StringArray{
-						Data: []string{"0", "1", "2"},
-					},
-				},
-			},
-		},
-		ValidData: []bool{true, false, true},
-		IsDynamic: false,
-	}
-	fieldDatas = append(fieldDatas, &fieldData8)
-
-	fieldData9 := schemapb.FieldData{
-		Type:      schemapb.DataType_JSON,
-		FieldName: "field-json",
-		Field: &schemapb.FieldData_Scalars{
-			Scalars: &schemapb.ScalarField{
-				Data: &schemapb.ScalarField_JsonData{
-					JsonData: &schemapb.JSONArray{
-						Data: [][]byte{[]byte(`{"XXX": 0}`), []byte(`{"XXX": 0}`), []byte(`{"XXX": 0}`)},
-					},
-				},
-			},
-		},
-		ValidData: []bool{true, false, true},
-		IsDynamic: false,
-	}
-	fieldDatas = append(fieldDatas, &fieldData9)
-
-	fieldData10 := schemapb.FieldData{
-		Type:      schemapb.DataType_Array,
-		FieldName: "field-array",
-		Field: &schemapb.FieldData_Scalars{
-			Scalars: &schemapb.ScalarField{
-				Data: &schemapb.ScalarField_ArrayData{
-					ArrayData: &schemapb.ArrayArray{
-						Data: []*schemapb.ScalarField{
-							{Data: &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{Data: []bool{true}}}},
-							{Data: &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{Data: []bool{true}}}},
-							{Data: &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{Data: []bool{true}}}},
-						},
-					},
-				},
-			},
-		},
-		ValidData: []bool{true, false, true},
-		IsDynamic: false,
-	}
-
-	fieldData11 := schemapb.FieldData{
-		Type:      schemapb.DataType_Int64,
-		FieldName: "field-int64",
-		Field: &schemapb.FieldData_Scalars{
-			Scalars: &schemapb.ScalarField{
-				Data: &schemapb.ScalarField_LongData{
-					LongData: &schemapb.LongArray{
-						Data: []int64{0, 1, 2},
-					},
-				},
-			},
-		},
-		ValidData: []bool{true, false, true},
-		IsDynamic: false,
-	}
-	fieldDatas = append(fieldDatas, &fieldData11)
-
-	switch firstFieldType {
-	case schemapb.DataType_None:
-		return fieldDatas
-	case schemapb.DataType_Bool:
-		return []*schemapb.FieldData{&fieldData1}
-	case schemapb.DataType_Int8:
-		return []*schemapb.FieldData{&fieldData2}
-	case schemapb.DataType_Int16:
-		return []*schemapb.FieldData{&fieldData3}
-	case schemapb.DataType_Int32:
-		return []*schemapb.FieldData{&fieldData4}
-	case schemapb.DataType_Float:
-		return []*schemapb.FieldData{&fieldData5}
-	case schemapb.DataType_Double:
-		return []*schemapb.FieldData{&fieldData6}
-	case schemapb.DataType_String:
-		return []*schemapb.FieldData{&fieldData7}
-	case schemapb.DataType_VarChar:
-		return []*schemapb.FieldData{&fieldData8}
-	case schemapb.DataType_BinaryVector:
-		vectorField := generateVectorFieldData(firstFieldType)
-		return []*schemapb.FieldData{&vectorField}
-	case schemapb.DataType_FloatVector:
-		vectorField := generateVectorFieldData(firstFieldType)
-		return []*schemapb.FieldData{&vectorField}
-	case schemapb.DataType_Float16Vector:
-		vectorField := generateVectorFieldData(firstFieldType)
-		return []*schemapb.FieldData{&vectorField}
-	case schemapb.DataType_BFloat16Vector:
-		vectorField := generateVectorFieldData(firstFieldType)
-		return []*schemapb.FieldData{&vectorField}
-	case schemapb.DataType_Int8Vector:
-		vectorField := generateVectorFieldData(firstFieldType)
-		return []*schemapb.FieldData{&vectorField}
-	case schemapb.DataType_Array:
-		return []*schemapb.FieldData{&fieldData10}
-	case schemapb.DataType_JSON:
-		return []*schemapb.FieldData{&fieldData9}
-	case schemapb.DataType_SparseFloatVector:
-		vectorField := generateVectorFieldData(firstFieldType)
-		return []*schemapb.FieldData{&vectorField}
-	case schemapb.DataType_Int64:
-		return []*schemapb.FieldData{&fieldData11}
-	default:
-		return []*schemapb.FieldData{
-			{
-				FieldName: "wrong-field-type",
-				Type:      firstFieldType,
-			},
-		}
-	}
-}
-
 func newSearchResult(results []map[string]interface{}) []map[string]interface{} {
 	for i, result := range results {
 		result["field-bool"] = true
@@ -3068,12 +3035,7 @@ func TestConvertToExtraParams(t *testing.T) {
 }
 
 func TestGenerateExpressionTemplate(t *testing.T) {
-	var mixedList []interface{}
 	var mixedAns [][]byte
-
-	mixedList = append(mixedList, float64(1))
-	mixedList = append(mixedList, "10")
-	mixedList = append(mixedList, true)
 
 	val, _ := json.Marshal(1)
 	mixedAns = append(mixedAns, val)
@@ -3081,18 +3043,20 @@ func TestGenerateExpressionTemplate(t *testing.T) {
 	mixedAns = append(mixedAns, val)
 	val, _ = json.Marshal(true)
 	mixedAns = append(mixedAns, val)
-	// all passed number is float64 type, so all the number type has convert to float64
-	expressionTemplates := []map[string]interface{}{
-		{"str": "10"},
-		{"min": float64(1), "max": float64(10)},
-		{"bool": true},
-		{"float64": 1.1},
-		{"int64": float64(1)},
-		{"list_of_str": []interface{}{"1", "10", "100"}},
-		{"list_of_bool": []interface{}{true, false, true}},
-		{"list_of_float": []interface{}{1.1, 10.1, 100.1}},
-		{"list_of_int": []interface{}{float64(1), float64(10), float64(100)}},
-		{"list_of_json": mixedList},
+	// the parameters now arrive as the raw JSON the caller wrote; the expected
+	// values below are unchanged, so the classification has to match what the
+	// previous already-decoded path produced
+	expressionTemplates := []map[string]string{
+		{"str": `"10"`},
+		{"min": `1`, "max": `10`},
+		{"bool": `true`},
+		{"float64": `1.1`},
+		{"int64": `1`},
+		{"list_of_str": `["1","10","100"]`},
+		{"list_of_bool": `[true,false,true]`},
+		{"list_of_float": `[1.1,10.1,100.1]`},
+		{"list_of_int": `[1,10,100]`},
+		{"list_of_json": `[1,"10",true]`},
 	}
 	ans := []map[string]*schemapb.TemplateValue{
 		{
@@ -3202,8 +3166,9 @@ func TestGenerateExpressionTemplate(t *testing.T) {
 		},
 	}
 	for i, template := range expressionTemplates {
-		actual := generateExpressionTemplate(template)
-		assert.Equal(t, actual, ans[i])
+		actual, err := generateExpressionTemplate(rawParams(t, template))
+		require.NoError(t, err)
+		assert.Equal(t, ans[i], actual)
 	}
 }
 
@@ -3639,14 +3604,14 @@ func TestConvertIDsToSchemapbIDs(t *testing.T) {
 	}
 
 	t.Run("empty ids array", func(t *testing.T) {
-		_, err := convertIDsToSchemapbIDs([]interface{}{}, int64PkField)
+		_, err := convertIDsToSchemapbIDs(nil, int64PkField)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "ids array cannot be empty")
 	})
 
 	t.Run("int64 pk with float64 values (whole numbers)", func(t *testing.T) {
 		// JSON numbers are decoded as float64
-		ids := []interface{}{float64(1), float64(2), float64(3)}
+		ids := rawIDs(`1`, `2`, `3`)
 		result, err := convertIDsToSchemapbIDs(ids, int64PkField)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
@@ -3656,22 +3621,22 @@ func TestConvertIDsToSchemapbIDs(t *testing.T) {
 	})
 
 	t.Run("int64 pk with float64 values having fractional part", func(t *testing.T) {
-		ids := []interface{}{float64(1.5)}
+		ids := rawIDs(`1.5`)
 		_, err := convertIDsToSchemapbIDs(ids, int64PkField)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "has fractional part")
+		assert.Contains(t, err.Error(), "is not an integer in the int64 range")
 	})
 
 	t.Run("int64 pk with float64 values - second element has fractional part", func(t *testing.T) {
-		ids := []interface{}{float64(1), float64(2.9)}
+		ids := rawIDs(`1`, `2.9`)
 		_, err := convertIDsToSchemapbIDs(ids, int64PkField)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "index 1")
-		assert.Contains(t, err.Error(), "has fractional part")
+		assert.Contains(t, err.Error(), "is not an integer in the int64 range")
 	})
 
 	t.Run("int64 pk with int64 values", func(t *testing.T) {
-		ids := []interface{}{int64(100), int64(200)}
+		ids := rawIDs(`100`, `200`)
 		result, err := convertIDsToSchemapbIDs(ids, int64PkField)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
@@ -3681,7 +3646,7 @@ func TestConvertIDsToSchemapbIDs(t *testing.T) {
 	})
 
 	t.Run("int64 pk with int values", func(t *testing.T) {
-		ids := []interface{}{int(10), int(20)}
+		ids := rawIDs(`10`, `20`)
 		result, err := convertIDsToSchemapbIDs(ids, int64PkField)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
@@ -3691,7 +3656,7 @@ func TestConvertIDsToSchemapbIDs(t *testing.T) {
 	})
 
 	t.Run("int64 pk with valid string values", func(t *testing.T) {
-		ids := []interface{}{"123", "456"}
+		ids := rawIDs(`"123"`, `"456"`)
 		result, err := convertIDsToSchemapbIDs(ids, int64PkField)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
@@ -3701,21 +3666,21 @@ func TestConvertIDsToSchemapbIDs(t *testing.T) {
 	})
 
 	t.Run("int64 pk with invalid string values", func(t *testing.T) {
-		ids := []interface{}{"not_a_number"}
+		ids := rawIDs(`"not_a_number"`)
 		_, err := convertIDsToSchemapbIDs(ids, int64PkField)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid int64 id")
 	})
 
 	t.Run("int64 pk with invalid type", func(t *testing.T) {
-		ids := []interface{}{true}
+		ids := rawIDs(`true`)
 		_, err := convertIDsToSchemapbIDs(ids, int64PkField)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid id type")
 	})
 
 	t.Run("varchar pk with string values", func(t *testing.T) {
-		ids := []interface{}{"abc", "def", "ghi"}
+		ids := rawIDs(`"abc"`, `"def"`, `"ghi"`)
 		result, err := convertIDsToSchemapbIDs(ids, varcharPkField)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
@@ -3725,14 +3690,14 @@ func TestConvertIDsToSchemapbIDs(t *testing.T) {
 	})
 
 	t.Run("varchar pk with empty string", func(t *testing.T) {
-		ids := []interface{}{""}
+		ids := rawIDs(`""`)
 		_, err := convertIDsToSchemapbIDs(ids, varcharPkField)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "empty string id")
 	})
 
 	t.Run("varchar pk with number values", func(t *testing.T) {
-		ids := []interface{}{float64(123), int64(456), int(789)}
+		ids := rawIDs(`123`, `456`, `789`)
 		result, err := convertIDsToSchemapbIDs(ids, varcharPkField)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
@@ -3742,7 +3707,7 @@ func TestConvertIDsToSchemapbIDs(t *testing.T) {
 	})
 
 	t.Run("varchar pk with invalid type", func(t *testing.T) {
-		ids := []interface{}{[]int{1, 2, 3}}
+		ids := rawIDs(`[1,2,3]`)
 		_, err := convertIDsToSchemapbIDs(ids, varcharPkField)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid id type")
@@ -3755,7 +3720,7 @@ func TestConvertIDsToSchemapbIDs(t *testing.T) {
 			IsPrimaryKey: true,
 			DataType:     schemapb.DataType_Bool,
 		}
-		ids := []interface{}{float64(1)}
+		ids := rawIDs(`1`)
 		_, err := convertIDsToSchemapbIDs(ids, boolPkField)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported primary key type")
@@ -3932,7 +3897,7 @@ func TestParseStructArrayRowScalar(t *testing.T) {
 	schema := buildStructArrayTestSchema().GetStructArrayFields()[0]
 	raw := `[{"sub_int": 1, "sub_vec": [0.1, 0.2, 0.3, 0.4]},
 	         {"sub_int": 2, "sub_vec": [0.5, 0.6, 0.7, 0.8]}]`
-	row, err := parseStructArrayRow(raw, schema)
+	row, err := parseStructArrayRow(raw, schema, false)
 	require.NoError(t, err)
 	require.Len(t, row, 2)
 
@@ -3949,22 +3914,22 @@ func TestParseStructArrayRowScalar(t *testing.T) {
 
 func TestParseStructArrayRowMissingField(t *testing.T) {
 	schema := buildStructArrayTestSchema().GetStructArrayFields()[0]
-	_, err := parseStructArrayRow(`[{"sub_int": 1}]`, schema)
+	_, err := parseStructArrayRow(`[{"sub_int": 1}]`, schema, false)
 	assert.Error(t, err)
 }
 
 func TestParseStructArrayRowNotArray(t *testing.T) {
 	schema := buildStructArrayTestSchema().GetStructArrayFields()[0]
-	_, err := parseStructArrayRow(`{"sub_int": 1}`, schema)
+	_, err := parseStructArrayRow(`{"sub_int": 1}`, schema, false)
 	assert.Error(t, err)
 }
 
 func TestBuildStructArrayFieldDataRoundTrip(t *testing.T) {
 	schema := buildStructArrayTestSchema().GetStructArrayFields()[0]
 	r1, err := parseStructArrayRow(`[{"sub_int": 1, "sub_vec": [0.1, 0.2, 0.3, 0.4]},
-	                                 {"sub_int": 2, "sub_vec": [0.5, 0.6, 0.7, 0.8]}]`, schema)
+	                                 {"sub_int": 2, "sub_vec": [0.5, 0.6, 0.7, 0.8]}]`, schema, false)
 	require.NoError(t, err)
-	r2, err := parseStructArrayRow(`[{"sub_int": 3, "sub_vec": [0.9, 1.0, 1.1, 1.2]}]`, schema)
+	r2, err := parseStructArrayRow(`[{"sub_int": 3, "sub_vec": [0.9, 1.0, 1.1, 1.2]}]`, schema, false)
 	require.NoError(t, err)
 
 	fd, err := buildStructArrayFieldData(schema, []structArrayRow{r1, r2})
@@ -4208,9 +4173,9 @@ func TestBuildQueryRespNullableStructArrayCompact(t *testing.T) {
 	structSchema := schema.GetStructArrayFields()[0]
 	structSchema.Nullable = true
 	first, err := parseStructArrayRow(
-		`[{"sub_int": 10, "sub_vec": [1.1, 1.2, 1.3, 1.4]}]`, structSchema)
+		`[{"sub_int": 10, "sub_vec": [1.1, 1.2, 1.3, 1.4]}]`, structSchema, false)
 	require.NoError(t, err)
-	third, err := parseStructArrayRow(`[]`, structSchema)
+	third, err := parseStructArrayRow(`[]`, structSchema, false)
 	require.NoError(t, err)
 	structFD, err := buildNullableStructArrayFieldData(
 		structSchema, []structArrayRow{first, third}, []bool{true, false, true})
@@ -4229,12 +4194,12 @@ func TestBuildQueryRespNullableStructArrayDense(t *testing.T) {
 	structSchema := schema.GetStructArrayFields()[0]
 	structSchema.Nullable = true
 	first, err := parseStructArrayRow(
-		`[{"sub_int": 10, "sub_vec": [1.1, 1.2, 1.3, 1.4]}]`, structSchema)
+		`[{"sub_int": 10, "sub_vec": [1.1, 1.2, 1.3, 1.4]}]`, structSchema, false)
 	require.NoError(t, err)
-	nullPlaceholder, err := parseStructArrayRow(`[]`, structSchema)
+	nullPlaceholder, err := parseStructArrayRow(`[]`, structSchema, false)
 	require.NoError(t, err)
 	third, err := parseStructArrayRow(
-		`[{"sub_int": 30, "sub_vec": [3.1, 3.2, 3.3, 3.4]}]`, structSchema)
+		`[{"sub_int": 30, "sub_vec": [3.1, 3.2, 3.3, 3.4]}]`, structSchema, false)
 	require.NoError(t, err)
 	structFD, err := buildStructArrayFieldData(
 		structSchema, []structArrayRow{first, nullPlaceholder, third})
@@ -4255,7 +4220,7 @@ func TestBuildQueryRespNullableStructArrayRejectsMismatchedValidData(t *testing.
 	schema := buildStructArrayTestSchema()
 	structSchema := schema.GetStructArrayFields()[0]
 	row, err := parseStructArrayRow(
-		`[{"sub_int": 10, "sub_vec": [1.1, 1.2, 1.3, 1.4]}]`, structSchema)
+		`[{"sub_int": 10, "sub_vec": [1.1, 1.2, 1.3, 1.4]}]`, structSchema, false)
 	require.NoError(t, err)
 	structFD, err := buildStructArrayFieldData(structSchema, []structArrayRow{row})
 	require.NoError(t, err)
@@ -4303,6 +4268,65 @@ func TestPrintStructArrayFieldsV2(t *testing.T) {
 	assert.Equal(t, schemapb.DataType_FloatVector.String(), subs[1][HTTPReturnFieldElementType])
 }
 
+func TestParseJSONInteger(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		bitSize int
+		value   int64
+		ok      bool
+	}{
+		{name: "int8 max decimal", raw: "127.0", bitSize: 8, value: 127, ok: true},
+		{name: "int8 exponent", raw: "1e2", bitSize: 8, value: 100, ok: true},
+		{name: "negative scale integer", raw: "100e-2", bitSize: 8, value: 1, ok: true},
+		{name: "decimal exponent integer", raw: "1.2300e2", bitSize: 8, value: 123, ok: true},
+		{name: "exact beyond float64", raw: "9007199254740993.0", bitSize: 64, value: 9007199254740993, ok: true},
+		{name: "int64 max decimal", raw: "9223372036854775807.0", bitSize: 64, value: math.MaxInt64, ok: true},
+		{name: "int64 min decimal", raw: "-9223372036854775808.0", bitSize: 64, value: math.MinInt64, ok: true},
+		{name: "int64 max scaled", raw: "92233720368547758070e-1", bitSize: 64, value: math.MaxInt64, ok: true},
+		{name: "int64 min scaled", raw: "-92233720368547758080e-1", bitSize: 64, value: math.MinInt64, ok: true},
+		{name: "zero huge positive exponent", raw: "0.0e999999", bitSize: 64, value: 0, ok: true},
+		{name: "negative zero huge negative exponent", raw: "-0e-999999", bitSize: 64, value: 0, ok: true},
+		{name: "int8 overflow after scaling", raw: "1280e-1", bitSize: 8, ok: false},
+		{name: "fraction", raw: "127.5", bitSize: 8, ok: false},
+		{name: "negative scale fraction", raw: "100e-3", bitSize: 8, ok: false},
+		{name: "precision-sensitive fraction", raw: "1.00000000000000000000000000001", bitSize: 64, ok: false},
+		{name: "int64 max adjacent fraction", raw: "9223372036854775806.9", bitSize: 64, ok: false},
+		{name: "int64 max scaled overflow", raw: "92233720368547758080e-1", bitSize: 64, ok: false},
+		{name: "int64 min scaled overflow", raw: "-92233720368547758090e-1", bitSize: 64, ok: false},
+		{name: "huge positive exponent", raw: "1e999999", bitSize: 64, ok: false},
+		{name: "huge negative exponent", raw: "1e-999999", bitSize: 64, ok: false},
+		{name: "leading plus", raw: "+1", bitSize: 64, ok: false},
+		{name: "leading zero", raw: "01", bitSize: 64, ok: false},
+		{name: "missing integer part", raw: ".1", bitSize: 64, ok: false},
+		{name: "missing fraction", raw: "1.", bitSize: 64, ok: false},
+		{name: "missing exponent", raw: "1e", bitSize: 64, ok: false},
+		{name: "invalid bit size", raw: "1", bitSize: 7, ok: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			value, ok := parseJSONInteger(test.raw, test.bitSize)
+			assert.Equal(t, test.ok, ok)
+			if test.ok {
+				assert.Equal(t, test.value, value)
+			}
+		})
+	}
+
+	largeScaledInteger := "1" + strings.Repeat("0", 4096) + "e-4096"
+	value, ok := parseJSONInteger(largeScaledInteger, 64)
+	require.True(t, ok)
+	assert.Equal(t, int64(1), value)
+
+	_, ok = parseJSONInteger("1e-999999", 64)
+	assert.False(t, ok)
+	allocations := testing.AllocsPerRun(1000, func() {
+		parseJSONInteger("1e-999999", 64)
+	})
+	assert.LessOrEqual(t, allocations, float64(2))
+}
+
 func TestStructArrayScalarSubFieldTypes(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -4319,11 +4343,35 @@ func TestStructArrayScalarSubFieldTypes(t *testing.T) {
 			},
 		},
 		{
+			name:        "int8",
+			elementType: schemapb.DataType_Int8,
+			raw:         `[-128,127,127.0,1e2]`,
+			assertFn: func(t *testing.T, sf *schemapb.ScalarField) {
+				assert.Equal(t, []int32{-128, 127, 127, 100}, sf.GetIntData().GetData())
+			},
+		},
+		{
+			name:        "int16",
+			elementType: schemapb.DataType_Int16,
+			raw:         `[-32768,32767]`,
+			assertFn: func(t *testing.T, sf *schemapb.ScalarField) {
+				assert.Equal(t, []int32{-32768, 32767}, sf.GetIntData().GetData())
+			},
+		},
+		{
+			name:        "int32",
+			elementType: schemapb.DataType_Int32,
+			raw:         `[-2147483648,2147483647]`,
+			assertFn: func(t *testing.T, sf *schemapb.ScalarField) {
+				assert.Equal(t, []int32{math.MinInt32, math.MaxInt32}, sf.GetIntData().GetData())
+			},
+		},
+		{
 			name:        "int64",
 			elementType: schemapb.DataType_Int64,
-			raw:         `[10,20]`,
+			raw:         `[-9223372036854775808,9223372036854775807,9007199254740993.0]`,
 			assertFn: func(t *testing.T, sf *schemapb.ScalarField) {
-				assert.Equal(t, []int64{10, 20}, sf.GetLongData().GetData())
+				assert.Equal(t, []int64{math.MinInt64, math.MaxInt64, 9007199254740993}, sf.GetLongData().GetData())
 			},
 		},
 		{
@@ -4355,17 +4403,53 @@ func TestStructArrayScalarSubFieldTypes(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			sub := &schemapb.FieldSchema{Name: test.name, ElementType: test.elementType}
-			got, err := buildStructSubArrayScalar(sub, gjson.Parse(test.raw).Array())
+			got, err := buildStructSubArrayScalar(sub, gjson.Parse(test.raw).Array(), false)
 			require.NoError(t, err)
 			test.assertFn(t, got)
 		})
 	}
 
-	_, err := buildStructSubArrayScalar(&schemapb.FieldSchema{Name: "bad", ElementType: schemapb.DataType_JSON}, gjson.Parse(`[{}]`).Array())
+	_, err := buildStructSubArrayScalar(&schemapb.FieldSchema{Name: "bad", ElementType: schemapb.DataType_JSON}, gjson.Parse(`[{}]`).Array(), false)
 	assert.Error(t, err)
 
-	_, err = buildStructSubArrayScalar(&schemapb.FieldSchema{Name: "bad_bool", ElementType: schemapb.DataType_Bool}, gjson.Parse(`[1]`).Array())
+	_, err = buildStructSubArrayScalar(&schemapb.FieldSchema{Name: "bad_bool", ElementType: schemapb.DataType_Bool}, gjson.Parse(`[1]`).Array(), false)
 	assert.Error(t, err)
+}
+
+func TestStructArrayNarrowIntegerSubFieldValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		elementType schemapb.DataType
+		raw         string
+		rangeText   string
+	}{
+		{name: "int8 above max", elementType: schemapb.DataType_Int8, raw: `[128]`, rangeText: "[-128, 127]"},
+		{name: "int8 below min", elementType: schemapb.DataType_Int8, raw: `[-129]`, rangeText: "[-128, 127]"},
+		{name: "int8 int32 wraparound", elementType: schemapb.DataType_Int8, raw: `[4294967296]`, rangeText: "[-128, 127]"},
+		{name: "int8 fraction", elementType: schemapb.DataType_Int8, raw: `[127.5]`, rangeText: "[-128, 127]"},
+		{name: "int16 above max", elementType: schemapb.DataType_Int16, raw: `[32768]`, rangeText: "[-32768, 32767]"},
+		{name: "int16 below min", elementType: schemapb.DataType_Int16, raw: `[-32769]`, rangeText: "[-32768, 32767]"},
+		{name: "int16 int32 wraparound", elementType: schemapb.DataType_Int16, raw: `[4294967296]`, rangeText: "[-32768, 32767]"},
+		{name: "int32 above max", elementType: schemapb.DataType_Int32, raw: `[2147483648]`, rangeText: "[-2147483648, 2147483647]"},
+		{name: "int32 below min", elementType: schemapb.DataType_Int32, raw: `[-2147483649]`, rangeText: "[-2147483648, 2147483647]"},
+		{name: "int64 above max", elementType: schemapb.DataType_Int64, raw: `[9223372036854775808]`, rangeText: "[-9223372036854775808, 9223372036854775807]"},
+		{name: "int64 below min", elementType: schemapb.DataType_Int64, raw: `[-9223372036854775809]`, rangeText: "[-9223372036854775808, 9223372036854775807]"},
+		{name: "int64 fraction", elementType: schemapb.DataType_Int64, raw: `[127.5]`, rangeText: "[-9223372036854775808, 9223372036854775807]"},
+		{name: "int64 huge positive exponent", elementType: schemapb.DataType_Int64, raw: `[1e999999]`, rangeText: "[-9223372036854775808, 9223372036854775807]"},
+		{name: "int64 huge negative exponent", elementType: schemapb.DataType_Int64, raw: `[1e-999999]`, rangeText: "[-9223372036854775808, 9223372036854775807]"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sub := &schemapb.FieldSchema{Name: "narrow", ElementType: test.elementType}
+			_, err := buildStructSubArrayScalar(sub, gjson.Parse(test.raw).Array(), false)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+			assert.Contains(t, err.Error(), "sub-field narrow")
+			assert.Contains(t, err.Error(), "value="+strings.TrimSuffix(strings.TrimPrefix(test.raw, "["), "]"))
+			assert.Contains(t, err.Error(), test.rangeText)
+		})
+	}
 }
 
 func TestStructArrayVectorSubFieldTypes(t *testing.T) {
@@ -4591,7 +4675,7 @@ func TestExtractStructArrayRowErrorPaths(t *testing.T) {
 	assert.Empty(t, empty)
 
 	schema := buildStructArrayTestSchema()
-	row, err := parseStructArrayRow(`[{"sub_int": 1, "sub_vec": [0.1, 0.2, 0.3, 0.4]}]`, schema.GetStructArrayFields()[0])
+	row, err := parseStructArrayRow(`[{"sub_int": 1, "sub_vec": [0.1, 0.2, 0.3, 0.4]}]`, schema.GetStructArrayFields()[0], false)
 	require.NoError(t, err)
 	fd, err := buildStructArrayFieldData(schema.GetStructArrayFields()[0], []structArrayRow{row})
 	require.NoError(t, err)
@@ -4772,7 +4856,7 @@ func TestStructArrayCheckAndSetPartialUpdate(t *testing.T) {
 
 func TestStructArrayFieldDataValueCount(t *testing.T) {
 	schema := buildStructArrayTestSchema().GetStructArrayFields()[0]
-	row, err := parseStructArrayRow(`[{"sub_int": 1, "sub_vec": [0.1,0.2,0.3,0.4]}]`, schema)
+	row, err := parseStructArrayRow(`[{"sub_int": 1, "sub_vec": [0.1,0.2,0.3,0.4]}]`, schema, false)
 	require.NoError(t, err)
 	fd, err := buildStructArrayFieldData(schema, []structArrayRow{row})
 	require.NoError(t, err)
@@ -4946,8 +5030,45 @@ func TestCheckAndSetDataStructArrayRows(t *testing.T) {
 	assert.Contains(t, structRow, "sub_int")
 	assert.Contains(t, structRow, "sub_vec")
 
+	int64Schema := buildStructArrayTestSchema()
+	int64Schema.GetStructArrayFields()[0].GetFields()[0].ElementType = schemapb.DataType_Int64
+	int64Body := []byte(`{"data":[{"id":1,"vec":[0.1,0.2,0.3,0.4],"my_struct":[{"sub_int":9007199254740993.0,"sub_vec":[1.1,1.2,1.3,1.4]}]}]}`)
+	int64Rows, _, err := checkAndSetData(int64Body, int64Schema, false)
+	require.NoError(t, err)
+	int64StructRow, ok := int64Rows[0]["my_struct"].(structArrayRow)
+	require.True(t, ok)
+	int64Scalar, ok := int64StructRow["sub_int"].(*schemapb.ScalarField)
+	require.True(t, ok)
+	assert.Equal(t, []int64{9007199254740993}, int64Scalar.GetLongData().GetData())
+
 	_, _, err = checkAndSetData([]byte(`{"data": [{"id": 1, "vec": [0.1,0.2,0.3,0.4], "my_struct": [1]}]}`), schema, false)
 	assert.Error(t, err)
+
+	for _, test := range []struct {
+		name        string
+		elementType schemapb.DataType
+		value       string
+		rangeText   string
+	}{
+		{name: "int8 int32 wraparound", elementType: schemapb.DataType_Int8, value: "4294967296", rangeText: "[-128, 127]"},
+		{name: "int16 int32 wraparound", elementType: schemapb.DataType_Int16, value: "4294967296", rangeText: "[-32768, 32767]"},
+		{name: "int32 overflow", elementType: schemapb.DataType_Int32, value: "2147483648", rangeText: "[-2147483648, 2147483647]"},
+		{name: "fraction", elementType: schemapb.DataType_Int8, value: "127.5", rangeText: "[-128, 127]"},
+		{name: "int64 overflow", elementType: schemapb.DataType_Int64, value: "9223372036854775808", rangeText: "[-9223372036854775808, 9223372036854775807]"},
+		{name: "int64 fraction", elementType: schemapb.DataType_Int64, value: "127.5", rangeText: "[-9223372036854775808, 9223372036854775807]"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			testSchema := buildStructArrayTestSchema()
+			testSchema.GetStructArrayFields()[0].GetFields()[0].ElementType = test.elementType
+			invalidBody := []byte(fmt.Sprintf(`{"data":[{"id":1,"vec":[0.1,0.2,0.3,0.4],"my_struct":[{"sub_int":%s,"sub_vec":[1.1,1.2,1.3,1.4]}]}]}`, test.value))
+			_, _, err := checkAndSetData(invalidBody, testSchema, false)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+			assert.Contains(t, err.Error(), "sub-field sub_int")
+			assert.Contains(t, err.Error(), "value="+test.value)
+			assert.Contains(t, err.Error(), test.rangeText)
+		})
+	}
 }
 
 func TestParseStructArrayRowQualifiedSchemaNames(t *testing.T) {
@@ -4967,7 +5088,7 @@ func TestParseStructArrayRowQualifiedSchemaNames(t *testing.T) {
 			},
 		},
 	}
-	row, err := parseStructArrayRow(`[{"sub_int": 1, "sub_vec": [0.1,0.2], "unknown": "ignored"}]`, schema)
+	row, err := parseStructArrayRow(`[{"sub_int": 1, "sub_vec": [0.1,0.2], "unknown": "ignored"}]`, schema, false)
 	require.NoError(t, err)
 	assert.Contains(t, row, "sub_int")
 	assert.Contains(t, row, "sub_vec")
@@ -4975,7 +5096,7 @@ func TestParseStructArrayRowQualifiedSchemaNames(t *testing.T) {
 
 	unsupported := proto.Clone(schema).(*schemapb.StructArrayFieldSchema)
 	unsupported.Fields = append(unsupported.Fields, &schemapb.FieldSchema{Name: "bad", DataType: schemapb.DataType_Bool})
-	_, err = parseStructArrayRow(`[{"sub_int": 1, "sub_vec": [0.1,0.2], "bad": true}]`, unsupported)
+	_, err = parseStructArrayRow(`[{"sub_int": 1, "sub_vec": [0.1,0.2], "bad": true}]`, unsupported, false)
 	assert.Error(t, err)
 }
 
@@ -5005,4 +5126,2334 @@ func TestEncodeEmbListQueryErrorPaths(t *testing.T) {
 
 	_, err = encodeEmbListQuery(gjson.Parse(`[[true]]`).Array(), schemapb.DataType_Bool, 1, 0)
 	assert.Error(t, err)
+}
+
+func int64FieldTestSchema() *schemapb.CollectionSchema {
+	vectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+	vectorField.Name = "vector"
+	return &schemapb.CollectionSchema{
+		Name: DefaultCollectionName,
+		Fields: []*schemapb.FieldSchema{
+			generatePrimaryField(schemapb.DataType_Int64, false),
+			vectorField,
+			{
+				Name:     "count",
+				DataType: schemapb.DataType_Int64,
+			},
+		},
+	}
+}
+
+func insertOneInt64Value(t *testing.T, value string) ([]map[string]interface{}, error) {
+	t.Helper()
+	body := []byte(fmt.Sprintf(
+		`{"data": {"%s": 1, "vector": [0.1, 0.2], "count": %s}}`, FieldBookID, value))
+	rows, _, err := checkAndSetData(body, int64FieldTestSchema(), false)
+	return rows, err
+}
+
+// gjson's String() renders a number through float64 as soon as the raw text is
+// not all digits, so a decimal or exponent form lost precision before reaching
+// json.Number and was then accepted as a valid int64.
+func TestCheckAndSetDataInt64FieldParsesRawLiteral(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected int64
+	}{
+		{"plain integer", `42`, 42},
+		{"negative", `-7`, -7},
+		{"int64 upper bound", `9223372036854775807`, 9223372036854775807},
+		{"int64 lower bound", `-9223372036854775808`, -9223372036854775808},
+		{"integer valued decimal", `1.0`, 1},
+		{"integer valued exponent", `1e3`, 1000},
+		{"negative exponent that is exact", `100e-2`, 1},
+		{"beyond 2^53 as a plain integer", `9007199254740993`, 9007199254740993},
+		// this used to be stored as 9007199254740992
+		{"beyond 2^53 as a decimal", `9007199254740993.0`, 9007199254740993},
+		{"quoted integer", `"42"`, 42},
+		// base-10, not strconv base detection: this path carries Int64 primary keys
+		{"quoted zero padded integer", `"010"`, 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows, err := insertOneInt64Value(t, tt.value)
+			require.NoError(t, err)
+			require.Len(t, rows, 1)
+			assert.Equal(t, tt.expected, rows[0]["count"])
+		})
+	}
+}
+
+func TestCheckAndSetDataInt64FieldRejectsNonIntegers(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"fraction", `1.5`},
+		{"exponent past int64", `1e19`},
+		{"integer past int64", `9223372036854775808`},
+		{"integer below int64", `-9223372036854775809`},
+		// used to be stored as 0 because String() rendered it to "0"
+		{"underflow to zero", `1e-400`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := insertOneInt64Value(t, tt.value)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+			assert.Contains(t, err.Error(), "count")
+		})
+	}
+}
+
+// Quoted integers are read as base 10 for every integer width. cast relied on
+// strconv's base detection, so "010" meant 8 in a narrow integer field and 10
+// in an Int64 field.
+func TestCheckAndSetDataQuotedIntegerIsDecimal(t *testing.T) {
+	narrowSchema := func(dataType schemapb.DataType) *schemapb.CollectionSchema {
+		vectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+		vectorField.Name = "vector"
+		return &schemapb.CollectionSchema{
+			Name: DefaultCollectionName,
+			Fields: []*schemapb.FieldSchema{
+				generatePrimaryField(schemapb.DataType_Int64, false),
+				vectorField,
+				{Name: "narrow", DataType: dataType},
+			},
+		}
+	}
+
+	for _, dataType := range []schemapb.DataType{
+		schemapb.DataType_Int8, schemapb.DataType_Int16, schemapb.DataType_Int32,
+	} {
+		t.Run(dataType.String()+" zero padded", func(t *testing.T) {
+			body := []byte(fmt.Sprintf(
+				`{"data": {"%s": 1, "vector": [0.1, 0.2], "narrow": "010"}}`, FieldBookID))
+			rows, _, err := checkAndSetData(body, narrowSchema(dataType), false)
+			require.NoError(t, err)
+			require.Len(t, rows, 1)
+			switch dataType {
+			case schemapb.DataType_Int8:
+				assert.Equal(t, int8(10), rows[0]["narrow"])
+			case schemapb.DataType_Int16:
+				assert.Equal(t, int16(10), rows[0]["narrow"])
+			case schemapb.DataType_Int32:
+				assert.Equal(t, int32(10), rows[0]["narrow"])
+			}
+		})
+
+		t.Run(dataType.String()+" hex prefix is rejected", func(t *testing.T) {
+			body := []byte(fmt.Sprintf(
+				`{"data": {"%s": 1, "vector": [0.1, 0.2], "narrow": "0x10"}}`, FieldBookID))
+			_, _, err := checkAndSetData(body, narrowSchema(dataType), false)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		})
+	}
+}
+
+// proxy.http.compatibilityMode restores the previous integer handling,
+// including the two's complement wraparound this PR removes.
+func TestCheckAndSetDataIntegerCompatibilityMode(t *testing.T) {
+	paramtable.Init()
+	key := paramtable.Get().HTTPCfg.CompatibilityMode.Key
+	paramtable.Get().Save(key, "true")
+	defer paramtable.Get().Reset(key)
+
+	narrowSchema := func(dataType schemapb.DataType) *schemapb.CollectionSchema {
+		vectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+		vectorField.Name = "vector"
+		return &schemapb.CollectionSchema{
+			Name: DefaultCollectionName,
+			Fields: []*schemapb.FieldSchema{
+				generatePrimaryField(schemapb.DataType_Int64, false),
+				vectorField,
+				{Name: "narrow", DataType: dataType},
+			},
+		}
+	}
+	insert := func(t *testing.T, schema *schemapb.CollectionSchema, value string) map[string]interface{} {
+		t.Helper()
+		body := []byte(fmt.Sprintf(
+			`{"data": {"%s": 1, "vector": [0.1, 0.2], "narrow": %s}}`, FieldBookID, value))
+		rows, _, err := checkAndSetData(body, schema, false)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		return rows[0]
+	}
+
+	t.Run("int8 wraps again", func(t *testing.T) {
+		assert.Equal(t, int8(-128), insert(t, narrowSchema(schemapb.DataType_Int8), `128`)["narrow"])
+	})
+
+	t.Run("int32 wraps again", func(t *testing.T) {
+		assert.Equal(t, int32(0), insert(t, narrowSchema(schemapb.DataType_Int32), `4294967296`)["narrow"])
+	})
+
+	t.Run("quoted integer uses base detection again", func(t *testing.T) {
+		assert.Equal(t, int8(8), insert(t, narrowSchema(schemapb.DataType_Int8), `"010"`)["narrow"])
+	})
+
+	t.Run("int64 loses precision again", func(t *testing.T) {
+		rows, err := insertOneInt64Value(t, `9007199254740993.0`)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.Equal(t, int64(9007199254740992), rows[0]["count"])
+	})
+}
+
+// proxy.http.compatibilityMode restores the behavior a client saw before a
+// missing non-nullable field was rejected: the value was silently stored empty.
+func TestCheckAndSetDataCompatibilityModeSwitch(t *testing.T) {
+	paramtable.Init()
+	key := paramtable.Get().HTTPCfg.CompatibilityMode.Key
+
+	schema := func() *schemapb.CollectionSchema {
+		vectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+		vectorField.Name = "vector"
+		return &schemapb.CollectionSchema{
+			Name: DefaultCollectionName,
+			Fields: []*schemapb.FieldSchema{
+				generatePrimaryField(schemapb.DataType_Int64, false),
+				vectorField,
+				{Name: "name", DataType: schemapb.DataType_VarChar},
+			},
+		}
+	}
+	missing := []byte(fmt.Sprintf(`{"data": {"%s": 1, "vector": [0.1, 0.2]}}`, FieldBookID))
+	explicitNull := []byte(fmt.Sprintf(`{"data": {"%s": 1, "vector": [0.1, 0.2], "name": null}}`, FieldBookID))
+
+	t.Run("default rejects a missing field", func(t *testing.T) {
+		_, _, err := checkAndSetData(missing, schema(), false)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterMissing)
+	})
+
+	t.Run("default rejects an explicit null", func(t *testing.T) {
+		_, _, err := checkAndSetData(explicitNull, schema(), false)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("enabled stores the empty value again", func(t *testing.T) {
+		paramtable.Get().Save(key, "true")
+		defer paramtable.Get().Reset(key)
+
+		rows, _, err := checkAndSetData(missing, schema(), false)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.Equal(t, "", rows[0]["name"])
+
+		rows, _, err = checkAndSetData(explicitNull, schema(), false)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.Equal(t, "", rows[0]["name"])
+	})
+
+	t.Run("enabled does not weaken nullable handling", func(t *testing.T) {
+		paramtable.Get().Save(key, "true")
+		defer paramtable.Get().Reset(key)
+
+		nullableSchema := schema()
+		nullableSchema.Fields[2].Nullable = true
+		rows, validData, err := checkAndSetData(explicitNull, nullableSchema, false)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.Equal(t, []bool{false}, validData["name"])
+	})
+}
+
+func jsonFieldTestSchema() *schemapb.CollectionSchema {
+	vectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+	vectorField.Name = "vector"
+	return &schemapb.CollectionSchema{
+		Name: DefaultCollectionName,
+		Fields: []*schemapb.FieldSchema{
+			generatePrimaryField(schemapb.DataType_Int64, false),
+			vectorField,
+			{
+				Name:     "json_field",
+				DataType: schemapb.DataType_JSON,
+			},
+		},
+	}
+}
+
+func insertOneJSONValue(t *testing.T, value string) []byte {
+	t.Helper()
+	body := []byte(fmt.Sprintf(
+		`{"data": {"%s": 1, "vector": [0.1, 0.2], "json_field": %s}}`, FieldBookID, value))
+	rows, _, err := checkAndSetData(body, jsonFieldTestSchema(), false)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	stored, ok := rows[0]["json_field"].([]byte)
+	require.True(t, ok, "json field must be stored as raw bytes")
+	return stored
+}
+
+// The REST adapter used to store gjson's String() rendering of the JSON field.
+// That unquotes JSON strings and renders numbers through float64, producing
+// bytes that are not a JSON document at all. Keep the original token instead.
+func TestCheckAndSetDataJSONFieldKeepsRawToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"object", `{"a": 1}`, `{"a": 1}`},
+		{"nested object", `{"a": {"b": [1, 2]}}`, `{"a": {"b": [1, 2]}}`},
+		{"array", `[1, 2, 3]`, `[1, 2, 3]`},
+		{"bool", `true`, `true`},
+		{"integer", `42`, `42`},
+		{"negative", `-7`, `-7`},
+		{"decimal", `10.0`, `10.0`},
+		// gjson String() dropped the quotes here, storing `hello`.
+		{"string", `"hello"`, `"hello"`},
+		{"empty string", `""`, `""`},
+		{"string with braces", `"{not json"`, `"{not json"`},
+		// gjson String() rendered this through float64, storing a truncated
+		// mantissa. Numbers outside the float64 range (1e400) never reach here:
+		// the gin binder decodes `data` into []map[string]interface{} and
+		// rejects them before checkAndSetData runs.
+		{"integer beyond 2^53", `9007199254740993.0`, `9007199254740993.0`},
+		{"integer beyond int64", `12345678901234567890`, `12345678901234567890`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stored := insertOneJSONValue(t, tt.value)
+			assert.Equal(t, tt.expected, string(stored))
+			assert.True(t, json.Valid(stored),
+				"stored bytes must stay a valid JSON document, got %q", string(stored))
+		})
+	}
+}
+
+// A JSON document handed over as a JSON string keeps being unwrapped so that
+// clients relying on that input form are not broken.
+func TestCheckAndSetDataJSONFieldUnwrapsEncodedDocument(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"encoded object", `"{\"a\": 1}"`, `{"a": 1}`},
+		{"encoded array", `"[1, 2]"`, `[1, 2]`},
+		{"plain text stays quoted", `"hello"`, `"hello"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stored := insertOneJSONValue(t, tt.value)
+			assert.Equal(t, tt.expected, string(stored))
+			assert.True(t, json.Valid(stored))
+		})
+	}
+}
+
+func dynamicFieldTestSchema() *schemapb.CollectionSchema {
+	vectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+	vectorField.Name = "vector"
+	return &schemapb.CollectionSchema{
+		Name:               DefaultCollectionName,
+		EnableDynamicField: true,
+		Fields: []*schemapb.FieldSchema{
+			generatePrimaryField(schemapb.DataType_Int64, false),
+			vectorField,
+		},
+	}
+}
+
+func insertOneDynamicValue(t *testing.T, value string) ([]map[string]interface{}, error) {
+	t.Helper()
+	body := []byte(fmt.Sprintf(
+		`{"data": {"%s": 1, "vector": [0.1, 0.2], "dyn": %s}}`, FieldBookID, value))
+	rows, _, err := checkAndSetData(body, dynamicFieldTestSchema(), false)
+	return rows, err
+}
+
+// A dynamic field is stored as JSON text, so decoding a number into
+// int64/float64 and re-encoding it only loses information. cast.ToInt64 also
+// discarded its error and yielded 0, so anything it could not parse -- 1e300,
+// 1e19, integers beyond int64 -- was silently stored as 0.
+func TestCheckAndSetDataDynamicFieldKeepsNumberLiteral(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"small integer", `1`, `1`},
+		{"negative integer", `-7`, `-7`},
+		{"zero", `0`, `0`},
+		{"decimal keeps its fraction", `10.0`, `10.0`},
+		{"fraction", `0.5`, `0.5`},
+		{"integer beyond 2^53", `9007199254740993`, `9007199254740993`},
+		{"decimal beyond 2^53", `9007199254740993.0`, `9007199254740993.0`},
+		// each of these used to be stored as 0
+		{"exponent form", `1e19`, `1e19`},
+		{"large exponent", `1e300`, `1e300`},
+		{"negative exponent", `1e-7`, `1e-7`},
+		{"integer beyond int64", `12345678901234567890`, `12345678901234567890`},
+		{"uint64 upper bound", `18446744073709551615`, `18446744073709551615`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows, err := insertOneDynamicValue(t, tt.value)
+			require.NoError(t, err)
+			require.Len(t, rows, 1)
+			assert.Equal(t, json.Number(tt.expected), rows[0]["dyn"])
+
+			// the dynamic field is serialized back to JSON before it is stored
+			marshaled, err := json.Marshal(map[string]interface{}{"dyn": rows[0]["dyn"]})
+			require.NoError(t, err)
+			assert.Equal(t, `{"dyn":`+tt.expected+`}`, string(marshaled))
+		})
+	}
+}
+
+// simdjson reports BIGINT_ERROR for integer literals beyond 64 bits, so storing
+// them would turn every query touching that path into an error. Reject at
+// insert time instead.
+func TestCheckAndSetDataDynamicFieldRejectsUnrepresentableNumber(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"one past uint64", `18446744073709551616`},
+		{"far beyond uint64", `123456789012345678901234567890`},
+		{"negative beyond int64", `-9223372036854775809`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := insertOneDynamicValue(t, tt.value)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+			assert.Contains(t, err.Error(), "dyn")
+			assert.Contains(t, err.Error(), "exceeds the 64-bit range")
+		})
+	}
+}
+
+// A JSON field whose document is itself a number gets the same 64-bit limit as
+// a dynamic field: simdjson reports BIGINT_ERROR beyond that, so storing it
+// would make every query touching the field fail instead of the insert.
+func TestCheckAndSetDataJSONFieldRejectsUnrepresentableNumber(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"one past uint64", `18446744073709551616`},
+		{"far beyond uint64", `123456789012345678901234567890`},
+		{"negative beyond int64", `-9223372036854775809`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := []byte(fmt.Sprintf(
+				`{"data": {"%s": 1, "vector": [0.1, 0.2], "json_field": %s}}`, FieldBookID, tt.value))
+			_, _, err := checkAndSetData(body, jsonFieldTestSchema(), false)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+			assert.Contains(t, err.Error(), "json_field")
+			assert.Contains(t, err.Error(), "exceeds the 64-bit range")
+		})
+	}
+}
+
+// Nested numbers get the same walk as top-level ones: an earlier version
+// checked only the top level, so an oversized integer one brace deep was
+// stored and made the row unreadable all the same.
+func TestCheckAndSetDataJSONFieldRejectsNestedUnreadableNumbers(t *testing.T) {
+	// nested numbers used to be left unchecked; they are now covered by the same
+	// walk the duplicate-key scan makes
+	body := []byte(fmt.Sprintf(
+		`{"data": {"%s": 1, "vector": [0.1, 0.2], "json_field": {"a": 123456789012345678901234567890}}}`, FieldBookID))
+	_, _, err := checkAndSetData(body, jsonFieldTestSchema(), false)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	assert.Contains(t, err.Error(), "exceeds the 64-bit range")
+}
+
+// gjson's Value() decodes a whole subtree into Go values, so every nested
+// number went through float64 even after the top-level literal was preserved.
+func TestCheckAndSetDataDynamicFieldKeepsNestedLiterals(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		// the value is kept as written; the encoder only compacts whitespace on
+		// the way out, which the marshaled expectation below accounts for
+		{"nested integer beyond 2^53", `{"a": 9007199254740993}`, `{"a":9007199254740993}`},
+		{"nested integer beyond int64", `{"a": 12345678901234567890}`, `{"a":12345678901234567890}`},
+		{"nested decimal", `{"a": 10.0}`, `{"a":10.0}`},
+		{"nested exponent", `{"a": 1e300}`, `{"a":1e300}`},
+		{"array element beyond 2^53", `[9007199254740993]`, `[9007199254740993]`},
+		{"deeply nested", `{"a": {"b": [9007199254740993]}}`, `{"a":{"b":[9007199254740993]}}`},
+		{"strings keep their escapes", `{"a": "x\"y"}`, `{"a":"x\"y"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows, err := insertOneDynamicValue(t, tt.value)
+			require.NoError(t, err)
+			require.Len(t, rows, 1)
+			// stored exactly as the caller wrote it, whitespace included
+			assert.Equal(t, json.RawMessage(tt.value), rows[0]["dyn"])
+
+			// and every value survives the encoder, which compacts whitespace
+			marshaled, err := json.Marshal(map[string]interface{}{"dyn": rows[0]["dyn"]})
+			require.NoError(t, err)
+			assert.Equal(t, `{"dyn":`+tt.expected+`}`, string(marshaled))
+		})
+	}
+}
+
+// proxy.http.compatibilityMode restores the previous handling for both the
+// JSON field and the dynamic field, including the values that were destroyed.
+func TestCheckAndSetDataJSONAndDynamicCompatibilityMode(t *testing.T) {
+	paramtable.Init()
+	key := paramtable.Get().HTTPCfg.CompatibilityMode.Key
+	paramtable.Get().Save(key, "true")
+	defer paramtable.Get().Reset(key)
+
+	t.Run("json field is rendered again", func(t *testing.T) {
+		// the unquoted form is what the field used to store
+		assert.Equal(t, `hello`, string(insertOneJSONValue(t, `"hello"`)))
+		assert.Equal(t, `9007199254740992`, string(insertOneJSONValue(t, `9007199254740993.0`)))
+	})
+
+	t.Run("json field accepts an oversized integer again", func(t *testing.T) {
+		stored := insertOneJSONValue(t, `123456789012345678901234567890`)
+		assert.Equal(t, `123456789012345678901234567890`, string(stored))
+	})
+
+	t.Run("dynamic field decodes again", func(t *testing.T) {
+		rows, err := insertOneDynamicValue(t, `1e300`)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.Equal(t, int64(0), rows[0]["dyn"])
+
+		rows, err = insertOneDynamicValue(t, `10.0`)
+		require.NoError(t, err)
+		assert.Equal(t, float64(10), rows[0]["dyn"])
+	})
+
+	t.Run("dynamic field accepts an oversized integer again", func(t *testing.T) {
+		rows, err := insertOneDynamicValue(t, `123456789012345678901234567890`)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.Equal(t, int64(0), rows[0]["dyn"])
+	})
+
+	t.Run("nested values are decoded again", func(t *testing.T) {
+		rows, err := insertOneDynamicValue(t, `{"a": 9007199254740993}`)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		marshaled, err := json.Marshal(map[string]interface{}{"dyn": rows[0]["dyn"]})
+		require.NoError(t, err)
+		assert.Equal(t, `{"dyn":{"a":9007199254740992}}`, string(marshaled))
+	})
+}
+
+// The engine-compatibility check on the assembled dynamic wrapper is gated on
+// compatibilityMode like the per-value checks are: the wrapper adds one level
+// of nesting, so a value nested to the per-document limit fails only once it
+// is wrapped, and the previous handling stored that wrapper unexamined.
+func TestDynamicWrapperCheckHonorsCompatibilityMode(t *testing.T) {
+	paramtable.Init()
+
+	// passes the per-value depth check on its own, fails once the wrapper's
+	// object adds a level
+	deep := strings.Repeat("[", 1023) + "1" + strings.Repeat("]", 1023)
+
+	toColumns := func(t *testing.T) error {
+		t.Helper()
+		rows, err := insertOneDynamicValue(t, deep)
+		require.NoError(t, err)
+		_, err = anyToColumns(rows, nil, dynamicFieldTestSchema(), true, false)
+		return err
+	}
+
+	t.Run("strict mode refuses the wrapped document", func(t *testing.T) {
+		err := toColumns(t)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "nests deeper")
+	})
+
+	t.Run("compatibility mode stores it as before", func(t *testing.T) {
+		key := paramtable.Get().HTTPCfg.CompatibilityMode.Key
+		paramtable.Get().Save(key, "true")
+		defer paramtable.Get().Reset(key)
+		require.NoError(t, toColumns(t))
+	})
+}
+
+func stringFieldTestSchema() *schemapb.CollectionSchema {
+	vectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+	vectorField.Name = "vector"
+	return &schemapb.CollectionSchema{
+		Name: DefaultCollectionName,
+		Fields: []*schemapb.FieldSchema{
+			generatePrimaryField(schemapb.DataType_Int64, false),
+			vectorField,
+			{Name: "name", DataType: schemapb.DataType_VarChar},
+		},
+	}
+}
+
+func insertOneStringValue(t *testing.T, value string) ([]map[string]interface{}, error) {
+	t.Helper()
+	body := []byte(fmt.Sprintf(
+		`{"data": {"%s": 1, "vector": [0.1, 0.2], "name": %s}}`, FieldBookID, value))
+	rows, _, err := checkAndSetData(body, stringFieldTestSchema(), false)
+	return rows, err
+}
+
+// gjson's String() renders a number through float64 with the 'f' verb, so the
+// stored text was not the text the caller wrote.
+func TestCheckAndSetDataStringFieldKeepsNumberLiteral(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"string passes through", `"abc"`, `abc`},
+		{"escapes are decoded once", `"a\"b"`, `a"b`},
+		{"empty string", `""`, ``},
+		{"integer", `12345`, `12345`},
+		{"negative", `-7`, `-7`},
+		{"bool", `true`, `true`},
+		// each of these used to be rewritten
+		{"trailing zero is kept", `1.50`, `1.50`},
+		{"decimal point is kept", `1.0`, `1.0`},
+		{"exponent is kept", `1e19`, `1e19`},
+		{"large exponent is not expanded", `1e300`, `1e300`},
+		{"precision is kept", `9007199254740993.0`, `9007199254740993.0`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows, err := insertOneStringValue(t, tt.value)
+			require.NoError(t, err)
+			require.Len(t, rows, 1)
+			assert.Equal(t, tt.expected, rows[0]["name"])
+		})
+	}
+}
+
+// 1e300 used to be stored as its full decimal expansion: five bytes in, 301
+// bytes stored, and a max_length error that named a size the caller never sent.
+func TestCheckAndSetDataStringFieldDoesNotExpandExponents(t *testing.T) {
+	rows, err := insertOneStringValue(t, `1e300`)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Len(t, rows[0]["name"], len("1e300"))
+}
+
+func TestCheckAndSetDataStringFieldRejectsStructures(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		kind  string
+	}{
+		{"object", `{"a": 1}`, "object"},
+		{"array", `[1, 2]`, "array"},
+		{"empty object", `{}`, "object"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := insertOneStringValue(t, tt.value)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+			assert.Contains(t, err.Error(), "name")
+			assert.Contains(t, err.Error(), "expects a string")
+			assert.Contains(t, err.Error(), tt.kind)
+		})
+	}
+}
+
+// proxy.http.compatibilityMode restores the previous String() rendering for a
+// string field, including accepting an object as its text.
+func TestCheckAndSetDataStringFieldCompatibilityMode(t *testing.T) {
+	paramtable.Init()
+	key := paramtable.Get().HTTPCfg.CompatibilityMode.Key
+	paramtable.Get().Save(key, "true")
+	defer paramtable.Get().Reset(key)
+
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"object is stringified again", `{"a": 1}`, `{"a": 1}`},
+		{"array is stringified again", `[1, 2]`, `[1, 2]`},
+		{"decimal point is dropped again", `1.0`, `1`},
+		{"exponent is expanded again", `1e19`, `10000000000000000000`},
+		{"string is unchanged", `"abc"`, `abc`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows, err := insertOneStringValue(t, tt.value)
+			require.NoError(t, err)
+			require.Len(t, rows, 1)
+			assert.Equal(t, tt.expected, rows[0]["name"])
+		})
+	}
+}
+
+// Dimensions a JSON test suite is expected to cover (compare the PostgreSQL
+// json/jsonb regression tests): escapes, non-ASCII, duplicate keys, key order,
+// empty containers, deep nesting and number spellings. The dynamic field now
+// stores the document as written, so all of them survive verbatim. Four of
+// these used to be normalized by the decode and re-encode round trip, and the
+// normalized form is what a client got back.
+func TestCheckAndSetDataDynamicFieldDocumentFidelity(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		// these were normalized before (duplicate keys are covered separately,
+		// they are now rejected outright)
+		{"key order is kept", `{"z":1,"m":2,"a":3}`},
+		{"escaped solidus is kept", `{"a":"x\/y"}`},
+		{"negative zero is kept", `{"a":-0}`},
+
+		{"unicode escape", `{"a":"café"}`},
+		{"non ascii utf8", `{"a":"café"}`},
+		{"escaped control chars", `{"a":"l1\nl2\tx"}`},
+		{"escaped nul", "{\"a\":\"x\\u0000y\"}"},
+		{"emoji", `{"a":"🙂"}`},
+		{"empty object", `{}`},
+		{"empty array", `[]`},
+		{"empty key", `{"":1}`},
+		{"deep nesting", `{"a":{"b":{"c":[1]}}}`},
+		{"mixed array", `[1,"a",true,null,{"b":2}]`},
+		{"null member", `{"a":null}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows, err := insertOneDynamicValue(t, tt.value)
+			require.NoError(t, err)
+			require.Len(t, rows, 1)
+
+			marshaled, err := json.Marshal(map[string]interface{}{"dyn": rows[0]["dyn"]})
+			require.NoError(t, err)
+			assert.Equal(t, `{"dyn":`+tt.value+`}`, string(marshaled))
+		})
+	}
+}
+
+// The same fidelity requirement for a declared JSON field.
+func TestCheckAndSetDataJSONFieldDocumentFidelity(t *testing.T) {
+	values := []string{
+		`{"z":1,"m":2,"a":3}`,
+		`{"a":"x\/y"}`,
+		`{"a":-0}`,
+		`{"a":"café"}`,
+		`{"a":"café"}`,
+		`{"a":"l1\nl2\tx"}`,
+		"{\"a\":\"x\\u0000y\"}",
+		`{"a":"🙂"}`,
+		`{}`,
+		`[]`,
+		`{"":1}`,
+		`{"a":{"b":{"c":[1]}}}`,
+		`[1,"a",true,null,{"b":2}]`,
+		`{"a":null}`,
+	}
+
+	for _, value := range values {
+		t.Run(value, func(t *testing.T) {
+			stored := insertOneJSONValue(t, value)
+			assert.Equal(t, value, string(stored))
+			assert.True(t, json.Valid(stored))
+		})
+	}
+}
+
+// The surrogate shapes PostgreSQL's json_encoding.sql exercises. The request
+// binder accepts a lone surrogate and replaces it with U+FFFD, but simdjson
+// refuses to decode the string it belongs to and reports STRING_ERROR, so
+// keeping the token verbatim would make the value unreadable. These documents
+// therefore fall back to the decoded form.
+func TestCheckAndSetDataLoneSurrogateFallsBack(t *testing.T) {
+	replacement := "�"
+
+	t.Run("a valid pair is kept verbatim", func(t *testing.T) {
+		const value = `{"a":"😄"}`
+		rows, err := insertOneDynamicValue(t, value)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.Equal(t, json.RawMessage(value), rows[0]["dyn"])
+	})
+
+	for _, tt := range []struct {
+		name  string
+		value string
+	}{
+		{"two high surrogates in a row", `{"a":"\ud83d\ud83d"}`},
+		{"surrogates in the wrong order", `{"a":"\ude04\ud83d"}`},
+		{"orphan high surrogate", `{"a":"\ud83dX"}`},
+		{"orphan low surrogate", `{"a":"\ude04X"}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			rows, err := insertOneDynamicValue(t, tt.value)
+			require.NoError(t, err)
+			require.Len(t, rows, 1)
+
+			// not the raw token: it would be unreadable
+			assert.NotEqual(t, json.RawMessage(tt.value), rows[0]["dyn"])
+
+			marshaled, err := json.Marshal(map[string]interface{}{"dyn": rows[0]["dyn"]})
+			require.NoError(t, err)
+			assert.Contains(t, string(marshaled), replacement)
+			assert.True(t, json.Valid(marshaled))
+		})
+	}
+
+	t.Run("a json field falls back the same way", func(t *testing.T) {
+		stored := insertOneJSONValue(t, `{"a":"\ud83dX"}`)
+		assert.NotEqual(t, `{"a":"\ud83dX"}`, string(stored))
+		assert.True(t, json.Valid(stored))
+		assert.Contains(t, string(stored), replacement)
+	})
+}
+
+func TestHasLoneSurrogate(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want bool
+	}{
+		{`{"a":"😄"}`, false},
+		{`{"a":"😄🐶"}`, false},
+		{`{"a":"\ud83d\ud83d"}`, true},
+		{`{"a":"\ude04\ud83d"}`, true},
+		{`{"a":"\ud83dX"}`, true},
+		{`{"a":"\ude04X"}`, true},
+		{`{"a":"café"}`, false},
+		{"{\"a\":\"x\\u0000y\"}", false},
+		{`{"a":"plain"}`, false},
+		{`{"a":1,"b":[1,2]}`, false},
+		// an escaped backslash does not start an escape
+		{`{"a":"esc \\u0024 not an escape"}`, false},
+		// truncated escape at the end of the document
+		{`{"a":"trailing \ud8"}`, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			assert.Equal(t, tt.want, hasLoneSurrogate(tt.raw))
+		})
+	}
+}
+
+// RFC 8259 says an object name SHOULD be unique, and the readers disagree when
+// it is not: encoding/json, Python and PostgreSQL's jsonb keep the last value,
+// while gjson and simdjson keep the first. A caller who stored a duplicate
+// would read the document back, parse it with their own library and disagree
+// with what a Milvus filter matches, so the document is rejected.
+func TestCheckAndSetDataRejectsDuplicateKeys(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		key   string
+	}{
+		{"top level", `{"a":1,"a":2}`, "a"},
+		{"same value twice", `{"a":1,"a":1}`, "a"},
+		{"nested object", `{"a":{"b":1,"b":2}}`, "b"},
+		{"inside an array element", `{"a":[{"c":1,"c":2}]}`, "c"},
+		{"deeply nested", `{"x":{"y":{"z":1,"z":2}}}`, "z"},
+	}
+
+	for _, tt := range tests {
+		t.Run("dynamic field "+tt.name, func(t *testing.T) {
+			_, err := insertOneDynamicValue(t, tt.value)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+			assert.Contains(t, err.Error(), "dyn")
+			assert.Contains(t, err.Error(), tt.key)
+			assert.Contains(t, err.Error(), "twice")
+		})
+	}
+
+	t.Run("json field", func(t *testing.T) {
+		body := []byte(fmt.Sprintf(
+			`{"data": {"%s": 1, "vector": [0.1, 0.2], "json_field": {"a":1,"a":2}}}`, FieldBookID))
+		_, _, err := checkAndSetData(body, jsonFieldTestSchema(), false)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "json_field")
+	})
+
+	t.Run("the same key in sibling array elements is fine", func(t *testing.T) {
+		const value = `[{"d":1},{"d":2}]`
+		rows, err := insertOneDynamicValue(t, value)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.Equal(t, json.RawMessage(value), rows[0]["dyn"])
+	})
+
+	t.Run("compatibility mode keeps the old silent dedup", func(t *testing.T) {
+		paramtable.Init()
+		key := paramtable.Get().HTTPCfg.CompatibilityMode.Key
+		paramtable.Get().Save(key, "true")
+		defer paramtable.Get().Reset(key)
+
+		rows, err := insertOneDynamicValue(t, `{"a":1,"a":2}`)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		marshaled, err := json.Marshal(map[string]interface{}{"dyn": rows[0]["dyn"]})
+		require.NoError(t, err)
+		assert.Equal(t, `{"dyn":{"a":1}}`, string(marshaled))
+	})
+}
+
+func TestCheckEngineCompatible(t *testing.T) {
+	tests := []struct {
+		name     string
+		document string
+		wantErr  string
+	}{
+		{"unique keys", `{"a":1,"b":2}`, ""},
+		{"sibling array elements repeat a key", `[{"d":1},{"d":2}]`, ""},
+		{"nested but unique", `{"a":[1,2],"b":{"c":[{"e":1}]}}`, ""},
+		{"empty object", `{}`, ""},
+		{"empty array", `[]`, ""},
+		{"scalar document", `"scalar"`, ""},
+		{"exact int64", `{"a":9007199254740993}`, ""},
+		{"uint64 upper bound", `{"a":18446744073709551615}`, ""},
+
+		{"duplicate at the top level", `{"a":1,"a":2}`, "declares the key a twice"},
+		{"duplicate nested", `{"a":{"b":1,"b":2}}`, "declares the key b twice"},
+		{"duplicate inside an array element", `{"a":[{"c":1,"c":2}]}`, "declares the key c twice"},
+		{"duplicate empty key", `{"":1,"":2}`, "twice"},
+		{"integer past 64 bits", `{"a":18446744073709551616}`, "exceeds the 64-bit range"},
+		{"integer past 64 bits, nested", `{"a":[{"b":123456789012345678901234567890}]}`, "exceeds the 64-bit range"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkEngineCompatible("f", tt.document)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+
+	t.Run("invalid UTF-8", func(t *testing.T) {
+		err := checkEngineCompatible("f", "{\"a\":\"x\xffy\"}")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid UTF-8")
+	})
+
+	// simdjson counts containers: 1023 arrays holding a scalar and 1024 empty
+	// arrays both parse, 1024 arrays holding a scalar do not
+	t.Run("depth", func(t *testing.T) {
+		assert.NoError(t, checkEngineCompatible("f", strings.Repeat("[", 1023)+"5"+strings.Repeat("]", 1023)))
+		assert.NoError(t, checkEngineCompatible("f", strings.Repeat("[", 1024)+strings.Repeat("]", 1024)))
+		require.Error(t, checkEngineCompatible("f", strings.Repeat("[", 1024)+"5"+strings.Repeat("]", 1024)))
+	})
+}
+
+// The same declarations must answer the same with or without a fat sibling
+// pushing the document to a very different size -- the tokenizer has no size
+// regimes, and this pins that it never grows one.
+func TestCheckEngineCompatibleSizeIndifferent(t *testing.T) {
+	pad := `"` + strings.Repeat("x", 1024) + `"`
+	for name, tc := range map[string]struct {
+		small    string
+		rejected bool
+	}{
+		"duplicate key":     {`{"a": 1, "a": 2}`, true},
+		"oversized integer": {`{"n": 18446744073709551616}`, true},
+		"clean document":    {`{"a": 1, "b": [true, "x", 1.5]}`, false},
+		"nested dup":        {`{"o": {"k": 1, "k": 2}}`, true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			smallErr := checkEngineCompatible("f", tc.small)
+			// same declarations plus a fat sibling to cross the size gate
+			large := `{"pad": ` + pad + `, "doc": ` + tc.small + `}`
+			require.Greater(t, len(large), 1024)
+			largeErr := checkEngineCompatible("f", large)
+			if tc.rejected {
+				require.Error(t, smallErr, "small document")
+				require.Error(t, largeErr, "large document")
+			} else {
+				require.NoError(t, smallErr, "small document")
+				require.NoError(t, largeErr, "large document")
+			}
+		})
+	}
+
+	t.Run("invalid utf-8 past the gate", func(t *testing.T) {
+		require.Error(t, checkEngineCompatible("f", `{"pad": `+pad+`, "a": "x\xffy"}`))
+	})
+}
+
+// PostgreSQL's json.sql has a -- Recursion section that feeds it
+// repeat('[', 10000). The duplicate-key check walks the document recursively,
+// so the depth it can be handed matters: the request binder decodes into
+// []map[string]interface{} first and encoding/json refuses to nest deeper than
+// 10000, which leaves 9997 levels once the request envelope is accounted for.
+// The walk has to survive everything the binder lets past it.
+func TestCheckEngineCompatibleHandlesDeepNestingWithoutPanicking(t *testing.T) {
+	// the walk is recursive and the binder allows 9997 levels, so it has to
+	// survive whatever gets past the binder
+	for _, depth := range []int{100, 1000, 5000, 9997} {
+		t.Run(fmt.Sprintf("depth %d", depth), func(t *testing.T) {
+			doc := strings.Repeat("[", depth) + strings.Repeat("]", depth)
+			assert.NotPanics(t, func() {
+				_ = checkEngineCompatible("f", doc)
+			})
+		})
+	}
+}
+
+// PostgreSQL accepts a bare scalar as a whole JSON document, including null.
+// A JSON field given a null is resolved by the nullable handling before the
+// value ever reaches the JSON branch, so it must not be confused with a
+// document whose text is the four letters n-u-l-l.
+func TestCheckAndSetDataJSONFieldNullVersusNullDocument(t *testing.T) {
+	t.Run("a JSON null is a missing value, not a document", func(t *testing.T) {
+		body := []byte(fmt.Sprintf(
+			`{"data": {"%s": 1, "vector": [0.1, 0.2], "json_field": null}}`, FieldBookID))
+		_, _, err := checkAndSetData(body, jsonFieldTestSchema(), false)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "not nullable")
+	})
+
+	// A JSON string whose content is itself a JSON document is unwrapped, which
+	// predates this change, so "null" reaches storage as the null document and
+	// the string "null" cannot be expressed. Recorded rather than changed: the
+	// unwrapping is the documented way to hand over a JSON document as a string.
+	t.Run("a string holding a document is unwrapped", func(t *testing.T) {
+		assert.Equal(t, `null`, string(insertOneJSONValue(t, `"null"`)))
+		assert.Equal(t, `true`, string(insertOneJSONValue(t, `"true"`)))
+		assert.Equal(t, `123`, string(insertOneJSONValue(t, `"123"`)))
+		// text that is not a document keeps its quotes
+		assert.Equal(t, `"hello"`, string(insertOneJSONValue(t, `"hello"`)))
+	})
+
+	t.Run("a nullable field accepts the null", func(t *testing.T) {
+		schema := jsonFieldTestSchema()
+		schema.Fields[2].Nullable = true
+		body := []byte(fmt.Sprintf(
+			`{"data": {"%s": 1, "vector": [0.1, 0.2], "json_field": null}}`, FieldBookID))
+		_, validData, err := checkAndSetData(body, schema, false)
+		require.NoError(t, err)
+		assert.Equal(t, []bool{false}, validData["json_field"])
+	})
+}
+
+func rawParams(t *testing.T, params map[string]string) map[string]json.RawMessage {
+	t.Helper()
+	out := make(map[string]json.RawMessage, len(params))
+	for k, v := range params {
+		out[k] = json.RawMessage(v)
+	}
+	return out
+}
+
+// An expression template parameter used to be handed over already decoded into
+// interface{}, so every number had been through float64.
+func TestGenerateExpressionTemplateKeepsIntegersExact(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want int64
+	}{
+		{"small", `42`, 42},
+		{"negative", `-7`, -7},
+		// this used to become 9007199254740992
+		{"beyond 2^53", `9007199254740993`, 9007199254740993},
+		{"int64 upper bound", `9223372036854775807`, 9223372036854775807},
+		{"int64 lower bound", `-9223372036854775808`, -9223372036854775808},
+		// integer valued spellings stay integers, as before
+		{"integer valued decimal", `1.0`, 1},
+		{"integer valued exponent", `1e3`, 1000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, err := generateExpressionTemplate(rawParams(t, map[string]string{"v": tt.raw}))
+			require.NoError(t, err)
+			require.Contains(t, values, "v")
+			assert.Equal(t, tt.want, values["v"].GetInt64Val())
+		})
+	}
+
+	t.Run("a real fraction stays a float", func(t *testing.T) {
+		values, err := generateExpressionTemplate(rawParams(t, map[string]string{"v": `1.5`}))
+		require.NoError(t, err)
+		assert.Equal(t, 1.5, values["v"].GetFloatVal())
+	})
+}
+
+// null, an empty array and an object all reached a panic, so the caller got a
+// 500 from a plain parameter mistake.
+func TestGenerateExpressionTemplateRejectsInsteadOfPanicking(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		message string
+	}{
+		{"null", `null`, "must not be null"},
+		{"empty array", `[]`, "must not be an empty array"},
+		{"object", `{"a":1}`, "must be a bool, number, string or array"},
+		{"null inside an array", `[1,null,2]`, "must not contain null"},
+		{"empty nested array", `[[]]`, "must not be an empty array"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				values, err := generateExpressionTemplate(rawParams(t, map[string]string{"v": tt.raw}))
+				require.Error(t, err)
+				assert.Nil(t, values)
+				assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+				assert.Contains(t, err.Error(), "v")
+				assert.Contains(t, err.Error(), tt.message)
+			})
+		})
+	}
+}
+
+func TestGenerateExpressionTemplateArrays(t *testing.T) {
+	t.Run("integer array stays exact", func(t *testing.T) {
+		values, err := generateExpressionTemplate(rawParams(t, map[string]string{
+			"v": `[1, 9007199254740993, -7]`,
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, []int64{1, 9007199254740993, -7},
+			values["v"].GetArrayVal().GetLongData().GetData())
+	})
+
+	t.Run("string array", func(t *testing.T) {
+		values, err := generateExpressionTemplate(rawParams(t, map[string]string{"v": `["a","b"]`}))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"a", "b"}, values["v"].GetArrayVal().GetStringData().GetData())
+	})
+
+	t.Run("bool array", func(t *testing.T) {
+		values, err := generateExpressionTemplate(rawParams(t, map[string]string{"v": `[true,false]`}))
+		require.NoError(t, err)
+		assert.Equal(t, []bool{true, false}, values["v"].GetArrayVal().GetBoolData().GetData())
+	})
+
+	t.Run("float array", func(t *testing.T) {
+		values, err := generateExpressionTemplate(rawParams(t, map[string]string{"v": `[1.5, 2.5]`}))
+		require.NoError(t, err)
+		assert.Equal(t, []float64{1.5, 2.5}, values["v"].GetArrayVal().GetDoubleData().GetData())
+	})
+
+	t.Run("mixed types fall back to json", func(t *testing.T) {
+		values, err := generateExpressionTemplate(rawParams(t, map[string]string{"v": `[1,"a"]`}))
+		require.NoError(t, err)
+		assert.Equal(t, [][]byte{[]byte("1"), []byte(`"a"`)},
+			values["v"].GetArrayVal().GetJsonData().GetData())
+	})
+
+	t.Run("nested arrays", func(t *testing.T) {
+		values, err := generateExpressionTemplate(rawParams(t, map[string]string{"v": `[[1,2],[3]]`}))
+		require.NoError(t, err)
+		nested := values["v"].GetArrayVal().GetArrayData().GetData()
+		require.Len(t, nested, 2)
+		assert.Equal(t, []int64{1, 2}, nested[0].GetLongData().GetData())
+	})
+}
+
+// An empty id list used to build `pk in []`, which the planner accepts and
+// which matches nothing, so a batch loop handed an empty batch did nothing and
+// reported success. Moving the ids into a template value must not turn that
+// into an error -- but an id that is absent, or null, still is one: on the
+// delete endpoints it means the caller named neither a filter nor an id.
+func TestCheckGetPrimaryKeyEmptyVersusAbsent(t *testing.T) {
+	for _, pk := range []schemapb.DataType{schemapb.DataType_Int64, schemapb.DataType_VarChar} {
+		t.Run(pk.String(), func(t *testing.T) {
+			coll := generateCollectionSchema(pk, false, true)
+
+			t.Run("an empty list stays a no-op", func(t *testing.T) {
+				_, values, err := checkGetPrimaryKey(coll, gjson.Get(`{"id": []}`, "id"))
+				require.NoError(t, err)
+				array := values[primaryKeyTemplateVar].GetArrayVal()
+				require.NotNil(t, array, "the element type comes from the schema, so it survives an empty list")
+				assert.Empty(t, array.GetLongData().GetData())
+				assert.Empty(t, array.GetStringData().GetData())
+			})
+
+			for name, body := range map[string]string{
+				"an absent id is still required": `{}`,
+				"a null id is still required":    `{"id": null}`,
+			} {
+				t.Run(name, func(t *testing.T) {
+					_, _, err := checkGetPrimaryKey(coll, gjson.Get(body, "id"))
+					require.Error(t, err)
+					assert.Contains(t, err.Error(), "is required")
+				})
+			}
+		})
+	}
+}
+
+// The id list used to be formatted into the expression text with no escaping,
+// so a quote in an id was parsed as syntax. A caller naming one id could match
+// several rows, which on the delete endpoint removed rows they never named.
+func TestCheckGetPrimaryKeyIsNotInjectable(t *testing.T) {
+	varcharColl := generateCollectionSchema(schemapb.DataType_VarChar, false, true)
+
+	t.Run("a quote and comma stay one id", func(t *testing.T) {
+		// produced `book_id in ["alice", "bob"]` before
+		idStr := gjson.Get(`{"id": ["alice\", \"bob"]}`, "id")
+		filter, values, err := checkGetPrimaryKey(varcharColl, idStr)
+		require.NoError(t, err)
+		assert.Equal(t, "book_id in {"+primaryKeyTemplateVar+"}", filter)
+
+		ids := values[primaryKeyTemplateVar].GetArrayVal().GetStringData().GetData()
+		require.Len(t, ids, 1, "one id in must stay one id out")
+		assert.Equal(t, `alice", "bob`, ids[0])
+	})
+
+	t.Run("a bracket cannot close the list", func(t *testing.T) {
+		idStr := gjson.Get(`{"id": ["a\"] or book_id != [\"z"]}`, "id")
+		_, values, err := checkGetPrimaryKey(varcharColl, idStr)
+		require.NoError(t, err)
+		ids := values[primaryKeyTemplateVar].GetArrayVal().GetStringData().GetData()
+		require.Len(t, ids, 1)
+		assert.Equal(t, `a"] or book_id != ["z`, ids[0])
+	})
+
+	t.Run("a quote as ordinary data is usable", func(t *testing.T) {
+		// `book_id in ["say "hi""]` did not parse, so the id was unfetchable
+		idStr := gjson.Get(`{"id": ["say \"hi\""]}`, "id")
+		_, values, err := checkGetPrimaryKey(varcharColl, idStr)
+		require.NoError(t, err)
+		assert.Equal(t, []string{`say "hi"`},
+			values[primaryKeyTemplateVar].GetArrayVal().GetStringData().GetData())
+	})
+
+	t.Run("a backslash is not an escape", func(t *testing.T) {
+		idStr := gjson.Get(`{"id": ["back\\slash"]}`, "id")
+		_, values, err := checkGetPrimaryKey(varcharColl, idStr)
+		require.NoError(t, err)
+		assert.Equal(t, []string{`back\slash`},
+			values[primaryKeyTemplateVar].GetArrayVal().GetStringData().GetData())
+	})
+}
+
+func TestCheckGetPrimaryKeyTyping(t *testing.T) {
+	int64Coll := generateCollectionSchema(schemapb.DataType_Int64, false, true)
+	varcharColl := generateCollectionSchema(schemapb.DataType_VarChar, false, true)
+
+	t.Run("a quoted integer is base 10", func(t *testing.T) {
+		// cast used strconv base detection, so "010" looked up primary key 8
+		idStr := gjson.Get(`{"id": ["010", "9"]}`, "id")
+		_, values, err := checkGetPrimaryKey(int64Coll, idStr)
+		require.NoError(t, err)
+		assert.Equal(t, []int64{10, 9},
+			values[primaryKeyTemplateVar].GetArrayVal().GetLongData().GetData())
+	})
+
+	t.Run("an integer beyond 2^53 keeps its value", func(t *testing.T) {
+		idStr := gjson.Get(`{"id": [9007199254740993]}`, "id")
+		_, values, err := checkGetPrimaryKey(int64Coll, idStr)
+		require.NoError(t, err)
+		assert.Equal(t, []int64{9007199254740993},
+			values[primaryKeyTemplateVar].GetArrayVal().GetLongData().GetData())
+	})
+
+	for _, tt := range []struct {
+		name string
+		coll *schemapb.CollectionSchema
+		ids  string
+	}{
+		{"missing id", int64Coll, `{}`},
+		{"a fraction for an Int64 key", int64Coll, `{"id": [1.5]}`},
+		{"a non-integer string for an Int64 key", int64Coll, `{"id": ["abc"]}`},
+		{"an integer past int64", int64Coll, `{"id": [9223372036854775808]}`},
+		{"an object for a VarChar key", varcharColl, `{"id": [{"a":1}]}`},
+		{"a bool for a VarChar key", varcharColl, `{"id": [true]}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := checkGetPrimaryKey(tt.coll, gjson.Get(tt.ids, "id"))
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		})
+	}
+}
+
+func rawIDs(raws ...string) []json.RawMessage {
+	out := make([]json.RawMessage, 0, len(raws))
+	for _, r := range raws {
+		out = append(out, json.RawMessage(r))
+	}
+	return out
+}
+
+// An array has no element-level validity, so a null element could only be
+// stored as the element type's zero value. sonic already refused one for an
+// integer or string element; a boolean or float element silently became false
+// or 0.
+func TestCheckAndSetDataRejectsNullArrayElements(t *testing.T) {
+	elementTypes := map[string]schemapb.DataType{
+		"bool":    schemapb.DataType_Bool,
+		"int32":   schemapb.DataType_Int32,
+		"int64":   schemapb.DataType_Int64,
+		"float":   schemapb.DataType_Float,
+		"double":  schemapb.DataType_Double,
+		"varchar": schemapb.DataType_VarChar,
+	}
+	values := map[schemapb.DataType]string{
+		schemapb.DataType_Bool:    `[true, null]`,
+		schemapb.DataType_Int32:   `[1, null]`,
+		schemapb.DataType_Int64:   `[1, null]`,
+		schemapb.DataType_Float:   `[1.5, null]`,
+		schemapb.DataType_Double:  `[1.5, null]`,
+		schemapb.DataType_VarChar: `["a", null]`,
+	}
+
+	for name, elementType := range elementTypes {
+		t.Run(name, func(t *testing.T) {
+			vectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+			vectorField.Name = "vector"
+			schema := &schemapb.CollectionSchema{
+				Name: DefaultCollectionName,
+				Fields: []*schemapb.FieldSchema{
+					generatePrimaryField(schemapb.DataType_Int64, false),
+					vectorField,
+					{Name: "arr", DataType: schemapb.DataType_Array, ElementType: elementType},
+				},
+			}
+			body := []byte(fmt.Sprintf(
+				`{"data": {"%s": 1, "vector": [0.1, 0.2], "arr": %s}}`, FieldBookID, values[elementType]))
+			_, _, err := checkAndSetData(body, schema, false)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+			assert.Contains(t, err.Error(), "index 1")
+			assert.Contains(t, err.Error(), "cannot be null")
+		})
+	}
+}
+
+// An absent key and an explicit null are different requests: the first says
+// nothing about the field, the second says it should be null. Collapsing them
+// meant a partial update could not clear a dynamic field.
+func TestCheckAndSetDataDynamicExplicitNull(t *testing.T) {
+	schema := dynamicFieldTestSchema()
+
+	t.Run("an explicit null is carried", func(t *testing.T) {
+		body := []byte(fmt.Sprintf(
+			`{"data": {"%s": 1, "vector": [0.1, 0.2], "dyn": null}}`, FieldBookID))
+		rows, _, err := checkAndSetData(body, schema, false)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.Equal(t, json.RawMessage("null"), rows[0]["dyn"])
+	})
+
+	t.Run("an absent key stays absent", func(t *testing.T) {
+		body := []byte(fmt.Sprintf(
+			`{"data": {"%s": 1, "vector": [0.1, 0.2]}}`, FieldBookID))
+		rows, _, err := checkAndSetData(body, schema, false)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.NotContains(t, rows[0], "dyn")
+	})
+
+	t.Run("compatibility mode drops it again", func(t *testing.T) {
+		paramtable.Init()
+		key := paramtable.Get().HTTPCfg.CompatibilityMode.Key
+		paramtable.Get().Save(key, "true")
+		defer paramtable.Get().Reset(key)
+
+		body := []byte(fmt.Sprintf(
+			`{"data": {"%s": 1, "vector": [0.1, 0.2], "dyn": null}}`, FieldBookID))
+		rows, _, err := checkAndSetData(body, schema, false)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.NotContains(t, rows[0], "dyn")
+	})
+}
+
+func jsonRespFieldData(docs ...string) *schemapb.FieldData {
+	data := make([][]byte, 0, len(docs))
+	for _, d := range docs {
+		data = append(data, []byte(d))
+	}
+	return &schemapb.FieldData{
+		Type:      schemapb.DataType_JSON,
+		FieldName: "meta",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_JsonData{
+					JsonData: &schemapb.JSONArray{Data: data},
+				},
+			},
+		},
+	}
+}
+
+// A JSON field reads back as a string by default, while the same value in the
+// dynamic field reads back as a document. proxy.http.nativeJSONResponse removes
+// that difference, and degrades the whole response rather than part of it when a
+// row written before the insert path was fixed does not hold a document.
+func TestBuildQueryRespNativeJSON(t *testing.T) {
+	paramtable.Init()
+	key := paramtable.Get().HTTPCfg.NativeJSONResponse.Key
+
+	t.Run("off by default: strings", func(t *testing.T) {
+		rows, err := buildQueryResp(0, []string{"meta"},
+			[]*schemapb.FieldData{jsonRespFieldData(`{"a":1}`, `{"b":2}`)}, nil, nil, true, nil)
+		require.NoError(t, err)
+		require.Len(t, rows, 2)
+		assert.Equal(t, `{"a":1}`, rows[0]["meta"])
+		assert.Equal(t, `{"b":2}`, rows[1]["meta"])
+	})
+
+	t.Run("on: documents", func(t *testing.T) {
+		paramtable.Get().Save(key, "true")
+		defer paramtable.Get().Reset(key)
+
+		rows, err := buildQueryResp(0, []string{"meta"},
+			[]*schemapb.FieldData{jsonRespFieldData(`{"a":1}`, `{"b":2}`)}, nil, nil, true, nil)
+		require.NoError(t, err)
+		require.Len(t, rows, 2)
+		assert.Equal(t, json.RawMessage(`{"a":1}`), rows[0]["meta"])
+
+		// the whole response marshals as documents
+		out, err := json.Marshal(map[string]interface{}{"data": rows})
+		require.NoError(t, err)
+		assert.Contains(t, string(out), `"meta":{"a":1}`)
+		assert.NotContains(t, string(out), `"meta":"{`)
+	})
+
+	t.Run("on, one legacy row: the whole response degrades", func(t *testing.T) {
+		paramtable.Get().Save(key, "true")
+		defer paramtable.Get().Reset(key)
+
+		// `hello` is what a pre-fix insert of {"meta": "hello"} stored
+		rows, err := buildQueryResp(0, []string{"meta"},
+			[]*schemapb.FieldData{jsonRespFieldData(`{"a":1}`, `hello`, `{"b":2}`)}, nil, nil, true, nil)
+		require.NoError(t, err)
+		require.Len(t, rows, 3)
+
+		// every row is a string, not just the bad one, so a caller never sees a
+		// mixture
+		for i, row := range rows {
+			_, isString := row["meta"].(string)
+			assert.True(t, isString, "row %d should have degraded to a string", i)
+		}
+		assert.Equal(t, `hello`, rows[1]["meta"])
+
+		// and the response still marshals, which it would not have done natively
+		out, err := json.Marshal(map[string]interface{}{"data": rows})
+		require.NoError(t, err)
+		assert.Contains(t, string(out), `"meta":"hello"`)
+	})
+}
+
+// An expression template array is typed from its first element, and an integer
+// too large for an int64 is classified as a float. In a mixed array that sent
+// the whole array down the JSON branch, where the value was compared as a
+// double, so 9223372036854775809 matched the row holding ...808.
+func TestTemplateArrayChecksEveryElement(t *testing.T) {
+	t.Run("an oversized integer after a float is rejected", func(t *testing.T) {
+		_, err := templateValueFromJSON("v", gjson.Parse(`[1.5, 9223372036854775809]`), 0, maxExprParamsDepthCeiling)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "9223372036854775809")
+	})
+
+	t.Run("an oversized integer after a string is rejected", func(t *testing.T) {
+		_, err := templateValueFromJSON("v", gjson.Parse(`["a", 18446744073709551615]`), 0, maxExprParamsDepthCeiling)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("a whole number far beyond the 64-bit integers passes as a double", func(t *testing.T) {
+		value, err := templateValueFromJSON("v", gjson.Parse(`["a", 99999999999999999999]`), 0, maxExprParamsDepthCeiling)
+		require.NoError(t, err)
+		assert.NotNil(t, value.GetArrayVal())
+	})
+
+	t.Run("a mixed array of representable values still works", func(t *testing.T) {
+		value, err := templateValueFromJSON("v", gjson.Parse(`[1.5, 9223372036854775807]`), 0, maxExprParamsDepthCeiling)
+		require.NoError(t, err)
+		assert.NotNil(t, value.GetArrayVal())
+	})
+}
+
+// A vector handed over as the text of its own JSON shape used to be accepted on
+// insert and refused on search, because insert read gjson's String() -- which
+// drops a string node's quotes -- while search reads the raw element. The row
+// could be written with a spelling that could not look it up again.
+func TestCheckAndSetDataRejectsStringWrappedVector(t *testing.T) {
+	paramtable.Init()
+
+	schemaFor := func(dataType schemapb.DataType, dim string) *schemapb.CollectionSchema {
+		field := generateVectorFieldSchema(dataType)
+		field.Name = "f"
+		for _, param := range field.TypeParams {
+			if param.Key == common.DimKey {
+				param.Value = dim
+			}
+		}
+		anchor := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+		anchor.Name = "anchor"
+		return &schemapb.CollectionSchema{
+			Name: DefaultCollectionName,
+			Fields: []*schemapb.FieldSchema{
+				generatePrimaryField(schemapb.DataType_Int64, false), anchor, field,
+			},
+		}
+	}
+	insert := func(t *testing.T, schema *schemapb.CollectionSchema, value string) error {
+		t.Helper()
+		body := []byte(fmt.Sprintf(
+			`{"data": {"%s": 1, "anchor": [0.1, 0.2], "f": %s}}`, FieldBookID, value))
+		_, _, err := checkAndSetData(body, schema, false)
+		return err
+	}
+
+	for _, tt := range []struct {
+		name     string
+		dataType schemapb.DataType
+		dim      string
+		natural  string
+		text     string
+	}{
+		{"float vector", schemapb.DataType_FloatVector, "2", `[0.1, 0.2]`, `"[0.1, 0.2]"`},
+		{"int8 vector", schemapb.DataType_Int8Vector, "2", `[1, 2]`, `"[1, 2]"`},
+		{"sparse vector", schemapb.DataType_SparseFloatVector, "2", `{"1": 0.5}`, `"{\"1\": 0.5}"`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := schemaFor(tt.dataType, tt.dim)
+			require.NoError(t, insert(t, schema, tt.natural))
+
+			err := insert(t, schema, tt.text)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+			assert.Contains(t, err.Error(), "the text of one")
+
+			// the search side already refused it, which is how the two came to
+			// disagree; assert they now agree
+			if tt.dataType == schemapb.DataType_SparseFloatVector {
+				_, err = convertQueries2Placeholder(
+					fmt.Sprintf(`{"data": [%s]}`, tt.text), tt.dataType, 2)
+				require.Error(t, err)
+			}
+		})
+	}
+
+	// Int8Vector was listed as accepting base64 and so skipped the null-literal
+	// check, where "null" decodes to a nil slice without an error; it went in as
+	// an empty vector. No decoder reads base64 for it, so it is not on the list.
+	t.Run("a null literal is refused for every type without base64", func(t *testing.T) {
+		for _, dataType := range []schemapb.DataType{
+			schemapb.DataType_Int8Vector, schemapb.DataType_FloatVector,
+		} {
+			t.Run(dataType.String(), func(t *testing.T) {
+				err := insert(t, schemaFor(dataType, "2"), `"null"`)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "cannot be null")
+			})
+		}
+	})
+
+	// a type whose string spelling is base64 keeps taking one
+	t.Run("base64 spellings still work", func(t *testing.T) {
+		require.NoError(t, insert(t, schemaFor(schemapb.DataType_BinaryVector, "8"), `"AQ=="`))
+		require.NoError(t, insert(t, schemaFor(schemapb.DataType_Float16Vector, "2"), `[0.1, 0.2]`))
+	})
+
+	t.Run("compatibility mode takes the text back", func(t *testing.T) {
+		key := paramtable.Get().HTTPCfg.CompatibilityMode.Key
+		paramtable.Get().Save(key, "true")
+		defer paramtable.Get().Reset(key)
+		require.NoError(t, insert(t, schemaFor(schemapb.DataType_FloatVector, "2"), `"[0.1, 0.2]"`))
+	})
+}
+
+// The null-element check used to run on the wrapper rather than on the text the
+// decoder consumes, so an array handed over as a JSON string had no elements to
+// look at and every null in it reached the decoder.
+func TestCheckAndSetDataRejectsNullInStringWrappedArray(t *testing.T) {
+	vectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+	vectorField.Name = "vector"
+	schema := &schemapb.CollectionSchema{
+		Name: DefaultCollectionName,
+		Fields: []*schemapb.FieldSchema{
+			generatePrimaryField(schemapb.DataType_Int64, false),
+			vectorField,
+			{Name: "arr", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Bool},
+		},
+	}
+
+	t.Run("a null in a quoted array is rejected", func(t *testing.T) {
+		body := []byte(fmt.Sprintf(
+			`{"data": {"%s": 1, "vector": [0.1, 0.2], "arr": "[true, null]"}}`, FieldBookID))
+		_, _, err := checkAndSetData(body, schema, false)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "cannot be null")
+	})
+
+	t.Run("a quoted array without nulls still works", func(t *testing.T) {
+		body := []byte(fmt.Sprintf(
+			`{"data": {"%s": 1, "vector": [0.1, 0.2], "arr": "[true, false]"}}`, FieldBookID))
+		_, _, err := checkAndSetData(body, schema, false)
+		require.NoError(t, err)
+	})
+}
+
+// A null in a vector reached the decoder the same way and became 0, which is a
+// coordinate the caller never sent.
+func TestCheckAndSetDataRejectsNullVectorElements(t *testing.T) {
+	vectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+	vectorField.Name = "vector"
+	schema := &schemapb.CollectionSchema{
+		Name: DefaultCollectionName,
+		Fields: []*schemapb.FieldSchema{
+			generatePrimaryField(schemapb.DataType_Int64, false),
+			vectorField,
+		},
+	}
+
+	body := []byte(fmt.Sprintf(`{"data": {"%s": 1, "vector": [0.1, null]}}`, FieldBookID))
+	_, _, err := checkAndSetData(body, schema, false)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	assert.Contains(t, err.Error(), "index 1")
+
+	// A vector is a dense array of numbers with no per-element validity, so a
+	// null coordinate has no representation other than a number the caller did
+	// not send. There is no previous handling worth restoring, so the escape
+	// hatch deliberately does not cover it.
+	t.Run("compatibility mode does not bring it back", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().HTTPCfg.CompatibilityMode.Key, "true")
+		defer paramtable.Get().Reset(paramtable.Get().HTTPCfg.CompatibilityMode.Key)
+
+		_, _, err := checkAndSetData(body, schema, false)
+		require.Error(t, err)
+	})
+}
+
+// Normalizing a lone surrogate used to send every number through float64, and
+// an earlier version tried to predict which literals survived that. It asked
+// whether the literal fit an int64, so 2^63 was judged safe and came back as
+// 9223372036854776000, while 9007199254740994 was refused even though it
+// round-trips exactly. Decoding with UseNumber keeps every literal as written,
+// so there is nothing left to predict.
+func TestJSONDocumentForStorageKeepsNumbersThroughNormalization(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		document string
+		stored   string
+	}{
+		{"an integer past int64 keeps its digits", `{"s":"\ud800","n":9223372036854775808}`, `9223372036854775808`},
+		{"a uint64 maximum keeps its digits", `{"s":"\ud800","n":18446744073709551615}`, `18446744073709551615`},
+		{"an exactly representable integer is not refused", `{"s":"\ud800","n":9007199254740994}`, `9007199254740994`},
+		{"an integer past 2^53 keeps its digits", `{"s":"\ud800","n":9007199254740993}`, `9007199254740993`},
+		{"a float keeps its literal", `{"s":"\ud800","n":1.50}`, `1.50`},
+		{"unsorted keys are not a problem", `{"b":"\ud800","a":1}`, `1`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			stored, err := jsonDocumentForStorage("j", tt.document)
+			require.NoError(t, err)
+			assert.Contains(t, string(stored), tt.stored)
+			// the surrogate is what forced the normalization in the first place
+			assert.NotContains(t, string(stored), `\ud800`)
+		})
+	}
+
+	t.Run("an integer beyond uint64 is still refused", func(t *testing.T) {
+		_, err := jsonDocumentForStorage("j", `{"s":"\ud800","n":184467440737095516150}`)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+}
+
+// Two dynamic keys that differ only in a lone surrogate escape both decode to
+// U+FFFD, so building the map collapsed them and one field vanished silently.
+func TestCheckAndSetDataRejectsLoneSurrogateDynamicKeys(t *testing.T) {
+	schema := dynamicFieldTestSchema()
+
+	t.Run("colliding keys are rejected", func(t *testing.T) {
+		body := []byte(fmt.Sprintf(
+			`{"data": {"%s": 1, "vector": [0.1, 0.2], "\ud800": 1, "\ud801": 2}}`, FieldBookID))
+		_, _, err := checkAndSetData(body, schema, false)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "surrogate")
+	})
+
+	t.Run("a single such key is rejected too", func(t *testing.T) {
+		body := []byte(fmt.Sprintf(
+			`{"data": {"%s": 1, "vector": [0.1, 0.2], "\ud800": 1}}`, FieldBookID))
+		_, _, err := checkAndSetData(body, schema, false)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("a well-formed surrogate pair is a normal key", func(t *testing.T) {
+		body := []byte(fmt.Sprintf(
+			`{"data": {"%s": 1, "vector": [0.1, 0.2], "😀": 1}}`, FieldBookID))
+		_, _, err := checkAndSetData(body, schema, false)
+		require.NoError(t, err)
+	})
+
+	t.Run("compatibility mode keeps the old handling", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().HTTPCfg.CompatibilityMode.Key, "true")
+		defer paramtable.Get().Reset(paramtable.Get().HTTPCfg.CompatibilityMode.Key)
+
+		body := []byte(fmt.Sprintf(
+			`{"data": {"%s": 1, "vector": [0.1, 0.2], "\ud800": 1, "\ud801": 2}}`, FieldBookID))
+		_, _, err := checkAndSetData(body, schema, false)
+		require.NoError(t, err)
+	})
+}
+
+// json.Valid only checks syntax, and a JSON string is allowed to hold any bytes
+// as far as it is concerned. The encoder does mind: it replaces invalid UTF-8
+// with U+FFFD, so the caller would get bytes the row does not hold, reported as
+// a document rather than degraded.
+func TestBuildQueryRespNativeJSONInvalidUTF8Degrades(t *testing.T) {
+	paramtable.Init()
+	key := paramtable.Get().HTTPCfg.NativeJSONResponse.Key
+	paramtable.Get().Save(key, "true")
+	defer paramtable.Get().Reset(key)
+
+	bad := "{\"a\":\"\xff\"}"
+	require.True(t, json.Valid([]byte(bad)), "the point of the test is that this is valid JSON")
+
+	rows, err := buildQueryResp(0, []string{"meta"},
+		[]*schemapb.FieldData{jsonRespFieldData(`{"a":1}`, bad)}, nil, nil, true, nil)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	for i, row := range rows {
+		_, isString := row["meta"].(string)
+		assert.True(t, isString, "row %d should have degraded to a string", i)
+	}
+	assert.Equal(t, bad, rows[1]["meta"])
+}
+
+// A Decoder reads one value and stops, so anything after it went unnoticed where
+// the Unmarshal this replaced returned an error. A dynamic field holding two
+// documents would have had the second one dropped without a word.
+func TestBuildQueryRespDynamicFieldRejectsTrailingContent(t *testing.T) {
+	dynamicData := func(values ...string) *schemapb.FieldData {
+		data := make([][]byte, 0, len(values))
+		for _, value := range values {
+			data = append(data, []byte(value))
+		}
+		return &schemapb.FieldData{
+			Type:      schemapb.DataType_JSON,
+			FieldName: "$meta",
+			IsDynamic: true,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_JsonData{
+						JsonData: &schemapb.JSONArray{Data: data},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("a second document is an error", func(t *testing.T) {
+		_, err := buildQueryResp(0, []string{"a"},
+			[]*schemapb.FieldData{dynamicData(`{"a":1} {"a":2}`)}, nil, nil, true, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("trailing garbage is an error", func(t *testing.T) {
+		_, err := buildQueryResp(0, []string{"a"},
+			[]*schemapb.FieldData{dynamicData(`{"a":1}]`)}, nil, nil, true, nil)
+		require.Error(t, err)
+	})
+
+	// Buffered() only exposes the decoder's pre-read window, so a second
+	// document past a page of padding sat outside it and slipped through an
+	// earlier version of this check.
+	t.Run("a second document past 4KB of whitespace is still an error", func(t *testing.T) {
+		_, err := buildQueryResp(0, []string{"a"},
+			[]*schemapb.FieldData{dynamicData(`{"a":1}` + strings.Repeat(" ", 4096) + `{"a":2}`)}, nil, nil, true, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("trailing garbage past 4KB of whitespace is still an error", func(t *testing.T) {
+		_, err := buildQueryResp(0, []string{"a"},
+			[]*schemapb.FieldData{dynamicData(`{"a":1}` + strings.Repeat(" ", 4096) + `]`)}, nil, nil, true, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("4KB of pure trailing whitespace is fine", func(t *testing.T) {
+		rows, err := buildQueryResp(0, []string{"a"},
+			[]*schemapb.FieldData{dynamicData(`{"a":1}` + strings.Repeat(" ", 4096))}, nil, nil, true, nil)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+	})
+
+	t.Run("trailing whitespace is not", func(t *testing.T) {
+		rows, err := buildQueryResp(0, []string{"a"},
+			[]*schemapb.FieldData{dynamicData("{\"a\":1}\n  ")}, nil, nil, true, nil)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.True(t, sameValue(json.Number("1"), rows[0]["a"]))
+	})
+}
+
+// A binary vector arrives as base64, which is not JSON. gjson dispatches on the
+// first character, so a value starting with "nu" is read as a partial `null`
+// literal: the result has type Null and, unlike other unparseable text, hands
+// itself to ForEach as a single element. The null-element check then saw a null
+// at index 0 and rejected the insert.
+//
+// About one random base64 value in 3500 starts that way, so a 3000-row batch hit
+// it more often than not. That is why the REST e2e suite caught it and the unit
+// tests did not; the value below is one that actually triggers it.
+func TestCheckAndSetDataAcceptsBase64BinaryVector(t *testing.T) {
+	binaryField := generateVectorFieldSchema(schemapb.DataType_BinaryVector)
+	binaryField.Name = "binary_vector"
+	schema := &schemapb.CollectionSchema{
+		Name: DefaultCollectionName,
+		Fields: []*schemapb.FieldSchema{
+			generatePrimaryField(schemapb.DataType_Int64, false),
+			binaryField,
+		},
+	}
+
+	for _, value := range []string{
+		"nuZovXeZEPU3g9F5HSEOdQ==", // reads as a partial null literal
+		"mx+eKBD8Je63ZE/9iTwtyg==", // from the e2e run that failed
+		"4NQaryMbp3Igb/eAcN6FuQ==", // reads as a number
+	} {
+		t.Run(value, func(t *testing.T) {
+			body := []byte(fmt.Sprintf(
+				`{"data": {"%s": 1, "binary_vector": %q}}`, FieldBookID, value))
+			rows, _, err := checkAndSetData(body, schema, false)
+			require.NoError(t, err)
+			require.Len(t, rows, 1)
+			assert.NotNil(t, rows[0]["binary_vector"])
+		})
+	}
+}
+
+// An expression template array is typed from its elements, and a value that
+// nests hid an oversized integer from the check: [[9223372036854775809], "x"]
+// is mixed because of the string, so it was carried as raw JSON and the planner
+// compared the inner integer as a double, matching ...808.
+func TestTemplateArrayChecksNestedIntegers(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		value    string
+		rejected bool
+	}{
+		{"an oversized integer inside an array", `[[9223372036854775809], "x"]`, true},
+		{"an oversized integer inside an object", `[{"a": 9223372036854775809}, "x"]`, true},
+		{"two levels down", `[[[9223372036854775809]], "x"]`, true},
+		{"an oversized integer in a plain nested array", `[[1, 9223372036854775809]]`, true},
+		{"int64 boundaries are fine", `[[9223372036854775807, -9223372036854775808], "x"]`, false},
+		{"ordinary nesting is fine", `[[1, 2], {"a": 3}, "x"]`, false},
+		// the check is on the value, not the spelling: a whole number written
+		// with a zero fraction is still a whole number
+		{"a whole number with a zero fraction", `[9223372036854775809.0, "x"]`, true},
+		{"a whole number with an exponent", `[9223372036854775809e0, "x"]`, true},
+		{"a genuine fraction is left alone", `[1.5, 2.5]`, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := templateValueFromJSON("v", gjson.Parse(tt.value), 0, maxExprParamsDepthCeiling)
+			if tt.rejected {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// A whole value of "null" decodes to a nil slice without an error, so it was
+// stored as an empty array -- or an empty sparse row -- rather than refused.
+// The element scan could not catch it: the parsed value is not an array, so it
+// has no elements to look at.
+func TestCheckAndSetDataRejectsNullValuedArrayAndVector(t *testing.T) {
+	vectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+	vectorField.Name = "vector"
+
+	t.Run("array", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name: DefaultCollectionName,
+			Fields: []*schemapb.FieldSchema{
+				generatePrimaryField(schemapb.DataType_Int64, false), vectorField,
+				{Name: "arr", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Bool},
+			},
+		}
+		for _, tt := range []struct {
+			value    string
+			rejected bool
+		}{
+			{`"null"`, true},
+			{`"5"`, true},
+			{`"[true,false]"`, false},
+			{`[true,false]`, false},
+			{`[]`, false},
+		} {
+			t.Run(tt.value, func(t *testing.T) {
+				body := []byte(fmt.Sprintf(
+					`{"data": {"%s": 1, "vector": [0.1, 0.2], "arr": %s}}`, FieldBookID, tt.value))
+				_, _, err := checkAndSetData(body, schema, false)
+				if tt.rejected {
+					require.Error(t, err)
+					assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+				} else {
+					require.NoError(t, err)
+				}
+			})
+		}
+	})
+
+	t.Run("sparse vector", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name: DefaultCollectionName,
+			Fields: []*schemapb.FieldSchema{
+				generatePrimaryField(schemapb.DataType_Int64, false),
+				{Name: "sparse", DataType: schemapb.DataType_SparseFloatVector},
+			},
+		}
+		body := []byte(fmt.Sprintf(`{"data": {"%s": 1, "sparse": "null"}}`, FieldBookID))
+		_, _, err := checkAndSetData(body, schema, false)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+
+		body = []byte(fmt.Sprintf(`{"data": {"%s": 1, "sparse": {"1": 0.5}}}`, FieldBookID))
+		_, _, err = checkAndSetData(body, schema, false)
+		require.NoError(t, err)
+	})
+}
+
+// A struct's sub-vectors are decoded in buildStructSubVectorField, which the
+// top-level vector check never reaches, so a null coordinate there still became
+// a 0 the caller never sent.
+func TestCheckAndSetDataRejectsNullStructSubVectorElements(t *testing.T) {
+	schema := buildStructArrayTestSchema()
+
+	t.Run("a null coordinate is rejected", func(t *testing.T) {
+		body := []byte(`{"data":[{"id":1,"vec":[0.1,0.2,0.3,0.4],` +
+			`"my_struct":[{"sub_int":10,"sub_vec":[1.1,null,1.3,1.4]}]}]}`)
+		_, _, err := checkAndSetData(body, schema, false)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "index 1")
+	})
+
+	t.Run("an ordinary sub-vector still works", func(t *testing.T) {
+		body := []byte(`{"data":[{"id":1,"vec":[0.1,0.2,0.3,0.4],` +
+			`"my_struct":[{"sub_int":10,"sub_vec":[1.1,1.2,1.3,1.4]}]}]}`)
+		_, _, err := checkAndSetData(body, schema, false)
+		require.NoError(t, err)
+	})
+
+	t.Run("compatibility mode does not bring it back", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().HTTPCfg.CompatibilityMode.Key, "true")
+		defer paramtable.Get().Reset(paramtable.Get().HTTPCfg.CompatibilityMode.Key)
+
+		body := []byte(`{"data":[{"id":1,"vec":[0.1,0.2,0.3,0.4],` +
+			`"my_struct":[{"sub_int":10,"sub_vec":[1.1,null,1.3,1.4]}]}]}`)
+		_, _, err := checkAndSetData(body, schema, false)
+		require.Error(t, err)
+	})
+}
+
+// The query side of the rule insert applies to a vector field: a null
+// coordinate decodes to 0 and then passes the dimension check, so the search ran
+// against a point the caller never asked for.
+func TestSearchVectorRejectsNullCoordinates(t *testing.T) {
+	paramtable.Init()
+
+	t.Run("float vector", func(t *testing.T) {
+		for _, tt := range []struct {
+			value    string
+			rejected bool
+		}{
+			{`[[0.1, 0.2]]`, false},
+			{`[[0.1, null]]`, true},
+			{`[[null, null]]`, true},
+			{`[[0.1, 0.2], [0.3, null]]`, true},
+		} {
+			t.Run(tt.value, func(t *testing.T) {
+				_, err := serializeFloatVectors(tt.value, schemapb.DataType_FloatVector, 2, 8,
+					typeutil.Float32ArrayToBytes)
+				if tt.rejected {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+			})
+		}
+	})
+
+	t.Run("sparse vector", func(t *testing.T) {
+		// "null" was accepted as an empty sparse row
+		_, err := serializeSparseFloatVectors(
+			[]gjson.Result{gjson.Parse(`"null"`)}, schemapb.DataType_SparseFloatVector)
+		require.Error(t, err)
+
+		_, err = serializeSparseFloatVectors(
+			[]gjson.Result{gjson.Parse(`{"1": 0.5}`)}, schemapb.DataType_SparseFloatVector)
+		require.NoError(t, err)
+	})
+
+	// A vector is a dense array of numbers with no per-element validity, so a
+	// null coordinate has no representation other than a number the caller did
+	// not send. There is no previous handling worth restoring, so the escape
+	// hatch deliberately does not cover it.
+	t.Run("compatibility mode does not bring it back", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().HTTPCfg.CompatibilityMode.Key, "true")
+		defer paramtable.Get().Reset(paramtable.Get().HTTPCfg.CompatibilityMode.Key)
+
+		_, err := serializeFloatVectors(`[[0.1, null]]`, schemapb.DataType_FloatVector, 2, 8,
+			typeutil.Float32ArrayToBytes)
+		require.Error(t, err)
+	})
+}
+
+// A text query goes through gjson's String(), which renders whatever it is
+// given rather than returning a string the caller sent: 1.50 searched for "1.5",
+// null searched for "", and an object searched for its own JSON text. Insert
+// applies the same rule to a VarChar field.
+func TestTextQueryMustBeAString(t *testing.T) {
+	paramtable.Init()
+
+	for _, tt := range []struct {
+		data     string
+		rejected bool
+	}{
+		{`["hello"]`, false},
+		{`["hello", "world"]`, false},
+		{`[123]`, true},
+		{`[1.50]`, true},
+		{`[null]`, true},
+		{`[true]`, true},
+		{`[{"a": 1}]`, true},
+		{`[["x"]]`, true},
+		{`["ok", 1]`, true},
+	} {
+		t.Run(tt.data, func(t *testing.T) {
+			body := fmt.Sprintf(`{"data": %s}`, tt.data)
+			_, err := convertQueries2Placeholder(body, schemapb.DataType_VarChar, 0)
+			if tt.rejected {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+
+	t.Run("compatibility mode keeps the old handling", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().HTTPCfg.CompatibilityMode.Key, "true")
+		defer paramtable.Get().Reset(paramtable.Get().HTTPCfg.CompatibilityMode.Key)
+
+		phv, err := convertQueries2Placeholder(`{"data": [1.50]}`, schemapb.DataType_VarChar, 0)
+		require.NoError(t, err)
+		require.Len(t, phv.GetValues(), 1)
+		assert.Equal(t, "1.5", string(phv.GetValues()[0]))
+	})
+}
+
+// A value like 3.5e38 is finite as a float64, so the infinity check on the
+// parse result passes, and narrowing then manufactures +Inf -- a value the
+// caller never sent, which the gRPC path refuses. The float32 range check has
+// to run before the cast destroys the evidence.
+func TestFloatInsertRejectsFloat32Overflow(t *testing.T) {
+	vectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+	vectorField.Name = "vector"
+	schema := &schemapb.CollectionSchema{
+		Name: DefaultCollectionName,
+		Fields: []*schemapb.FieldSchema{
+			generatePrimaryField(schemapb.DataType_Int64, false),
+			vectorField,
+			{Name: "f", DataType: schemapb.DataType_Float},
+		},
+	}
+	insert := func(t *testing.T, value string) error {
+		t.Helper()
+		body := []byte(fmt.Sprintf(
+			`{"data": {"%s": 1, "vector": [0.1, 0.2], "f": %s}}`, FieldBookID, value))
+		_, _, err := checkAndSetData(body, schema, false)
+		return err
+	}
+
+	for _, value := range []string{`3.5e38`, `-3.5e38`, `1e39`} {
+		t.Run(value, func(t *testing.T) {
+			err := insert(t, value)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		})
+	}
+	for _, value := range []string{`3.4e38`, `-3.4e38`, `1.5`} {
+		t.Run(value+" fits", func(t *testing.T) {
+			require.NoError(t, insert(t, value))
+		})
+	}
+
+	t.Run("struct sub-field float overflows are refused too", func(t *testing.T) {
+		sub := &schemapb.FieldSchema{Name: "sf", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Float}
+		_, err := buildStructSubArrayScalar(sub, []gjson.Result{gjson.Parse(`3.5e38`)}, false)
+		require.Error(t, err)
+		_, err = buildStructSubArrayScalar(sub, []gjson.Result{gjson.Parse(`3.4e38`)}, false)
+		require.NoError(t, err)
+	})
+}
+
+// A Float column is read through float64 and then narrowed, the way every path
+// this value will be compared against reads it: the expression parser, an
+// exprParams value carried as a double, and a row written through pymilvus
+// whose Python float is a double first. Parsing straight to float32 rounds
+// once and reads the decimal more faithfully, but for a literal sitting on a
+// float32 rounding midpoint it stores a value none of those paths produce, so
+// the row could not be found with the literal that wrote it.
+func TestFloatInsertSpeaksTheQueryDialect(t *testing.T) {
+	const literal = "1.000000059604644775390625000001"
+
+	double, err := strconv.ParseFloat(literal, 64)
+	require.NoError(t, err)
+	queryDialect := float32(double)
+
+	single, err := strconv.ParseFloat(literal, 32)
+	require.NoError(t, err)
+	require.NotEqual(t, float32(single), queryDialect,
+		"the literal must sit on a rounding midpoint, or this test proves nothing")
+
+	vectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+	vectorField.Name = "vector"
+	schema := &schemapb.CollectionSchema{
+		Name: DefaultCollectionName,
+		Fields: []*schemapb.FieldSchema{
+			generatePrimaryField(schemapb.DataType_Int64, false),
+			vectorField,
+			{Name: "f", DataType: schemapb.DataType_Float},
+		},
+	}
+	body := []byte(fmt.Sprintf(
+		`{"data": {"%s": 1, "vector": [0.1, 0.2], "f": %s}}`, FieldBookID, literal))
+	rows, _, err := checkAndSetData(body, schema, false)
+	require.NoError(t, err)
+	assert.Equal(t, queryDialect, rows[0]["f"],
+		"insert must store what a query for the same literal will look for")
+
+	// the template path carries the double the executor narrows
+	tmpl, err := templateValueFromJSON("v", gjson.Parse(literal), 0, maxExprParamsDepthCeiling)
+	require.NoError(t, err)
+	assert.Equal(t, double, tmpl.GetFloatVal())
+	assert.Equal(t, queryDialect, float32(tmpl.GetFloatVal()))
+}
+
+// Converting an expression template parameter walks the caller's nesting
+// recursively, so the depth is bounded by proxy.http.maxExprParamsDepth --
+// arrays and objects both count, the bound is read once per request, and a
+// configuration past the ceiling is read as the ceiling.
+func TestTemplateDepthBound(t *testing.T) {
+	paramtable.Init()
+
+	nest := func(depth int, core string) string {
+		return strings.Repeat("[", depth) + core + strings.Repeat("]", depth)
+	}
+	convert := func(t *testing.T, value string) error {
+		t.Helper()
+		_, err := generateExpressionTemplate(map[string]json.RawMessage{"v": json.RawMessage(value)})
+		return err
+	}
+
+	t.Run("the default admits 100 and refuses 101", func(t *testing.T) {
+		require.NoError(t, convert(t, nest(100, "1")))
+		err := convert(t, nest(101, "1"))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "nesting depth")
+	})
+
+	t.Run("objects count too", func(t *testing.T) {
+		// an object can only appear inside a mixed array, where the raw-JSON
+		// walk still has to bound it
+		deep := `[` + strings.Repeat(`{"a":`, 100) + `1` + strings.Repeat(`}`, 100) + `, "x"]`
+		err := convert(t, deep)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nesting depth")
+	})
+
+	t.Run("the bound is configurable", func(t *testing.T) {
+		key := paramtable.Get().HTTPCfg.MaxExprParamsDepth.Key
+		paramtable.Get().Save(key, "3")
+		defer paramtable.Get().Reset(key)
+		require.NoError(t, convert(t, nest(3, "1")))
+		require.Error(t, convert(t, nest(4, "1")))
+	})
+
+	t.Run("the ceiling holds against misconfiguration", func(t *testing.T) {
+		key := paramtable.Get().HTTPCfg.MaxExprParamsDepth.Key
+		paramtable.Get().Save(key, "100000")
+		defer paramtable.Get().Reset(key)
+		require.NoError(t, convert(t, nest(1024, "1")))
+		require.Error(t, convert(t, nest(1025, "1")))
+	})
+
+	t.Run("a bound below one clamps to one, not to the ceiling", func(t *testing.T) {
+		key := paramtable.Get().HTTPCfg.MaxExprParamsDepth.Key
+		paramtable.Get().Save(key, "0")
+		defer paramtable.Get().Reset(key)
+		require.NoError(t, convert(t, nest(1, "1")))
+		require.Error(t, convert(t, nest(2, "1")))
+	})
+}
+
+// The whole-number check is asked of the value, not of the spelling. An earlier
+// version skipped anything containing "." or "e", so 9223372036854775809 was
+// refused while 9223372036854775809.0 was accepted and then matched the row
+// holding 9223372036854775808.
+//
+// The boundary is stated here in full because it is a deliberate trade: the
+// refusal covers the whole range where a double can be mistaken for a 64-bit
+// integer rather than only the part of it that actually rounds, which buys a
+// check that reads the literal instead of expanding it.
+func TestTemplateWholeNumberCheckIgnoresSpelling(t *testing.T) {
+	for _, tt := range []struct {
+		value    string
+		rejected bool
+	}{
+		{`9223372036854775809`, true},
+		{`9223372036854775809.0`, true},
+		{`9223372036854775809e0`, true},
+		{`92233720368547758.09e2`, true},
+		{`-9223372036854775809`, true},
+		{`18446744073709551615`, true}, // uint64 max rounds onto 2^64
+		{`18446744073709551617`, true}, // 2^64+1 rounds onto 2^64 as well
+		// The whole [2^63, 2^64] window is refused, including the values a
+		// double happens to carry exactly: telling those apart needs exact
+		// arithmetic on the literal, which is the cost this check refuses to
+		// pay. Each still works written into the filter text.
+		{`9223372036854775808`, true},  // 2^63, exact but refused
+		{`18446744073709551616`, true}, // 2^64, exact but refused
+		{`1e19`, true},                 // the one round magnitude in the window
+		// below 2^63 every whole number is an int64, above 2^64 both sides of
+		// the comparison are doubles; neither can be confused with a neighbor
+		{`1e20`, false},
+		{`1e300`, false},
+		{`99999999999999999999`, false},
+		{`9223372036854775807`, false},
+		{`-9223372036854775808`, false},
+		{`9223372036854775807.5`, false}, // a fraction, however close
+		{`1.5`, false},
+		{`100e-2`, false},
+		{`1e-3`, false},
+		// underflows to zero, nowhere near the window; costs one ParseFloat
+		// rather than the million-digit rational an exact reading would build
+		{`1e-1000000`, false},
+	} {
+		t.Run(tt.value, func(t *testing.T) {
+			_, err := templateValueFromJSON("v", gjson.Parse(tt.value), 0, maxExprParamsDepthCeiling)
+			if tt.rejected {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// The first version of the vector null check only covered plain float search
+// vectors. Int8 vectors, the embedding-list form used by ArrayOfVector, and the
+// v1 search endpoint each decoded a null to 0 by their own route.
+func TestVectorNullRejectedOnEveryQueryEntryPoint(t *testing.T) {
+	paramtable.Init()
+
+	t.Run("int8 search vector", func(t *testing.T) {
+		_, err := serializeInt8Vectors(`[[1, null]]`, schemapb.DataType_Int8Vector, 2,
+			typeutil.Int8ArrayToBytes)
+		require.Error(t, err)
+
+		_, err = serializeInt8Vectors(`[[1, 2]]`, schemapb.DataType_Int8Vector, 2,
+			typeutil.Int8ArrayToBytes)
+		require.NoError(t, err)
+	})
+
+	t.Run("embedding list", func(t *testing.T) {
+		for _, elemType := range []schemapb.DataType{
+			schemapb.DataType_FloatVector,
+			schemapb.DataType_Float16Vector,
+			schemapb.DataType_BFloat16Vector,
+			schemapb.DataType_Int8Vector,
+		} {
+			t.Run(elemType.String(), func(t *testing.T) {
+				_, err := encodeEmbListQuery(gjson.Parse(`[[0.1, null]]`).Array(), elemType, 2, 0)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "null")
+			})
+		}
+
+		_, err := encodeEmbListQuery(gjson.Parse(`[[0.1, 0.2]]`).Array(),
+			schemapb.DataType_FloatVector, 2, 0)
+		require.NoError(t, err)
+	})
+
+	t.Run("v1 search vector", func(t *testing.T) {
+		var vector FloatVectorQuery
+		err := json.Unmarshal([]byte(`[0.1, null]`), &vector)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "index 1")
+
+		require.NoError(t, json.Unmarshal([]byte(`[0.1, 0.2]`), &vector))
+		assert.Equal(t, FloatVectorQuery{0.1, 0.2}, vector)
+	})
+}
+
+// "null" is also valid base64: it decodes to the three bytes 9e e9 65, which is
+// a whole dim-24 binary vector. Refusing every vector spelled "null" refused
+// that too.
+func TestBase64NullIsAValidBinaryVector(t *testing.T) {
+	binaryField := &schemapb.FieldSchema{
+		Name:       "bv",
+		DataType:   schemapb.DataType_BinaryVector,
+		TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "24"}},
+	}
+	schema := &schemapb.CollectionSchema{
+		Name: DefaultCollectionName,
+		Fields: []*schemapb.FieldSchema{
+			generatePrimaryField(schemapb.DataType_Int64, false), binaryField,
+		},
+	}
+	body := []byte(fmt.Sprintf(`{"data": {"%s": 1, "bv": "null"}}`, FieldBookID))
+	rows, _, err := checkAndSetData(body, schema, false)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, []byte{0x9e, 0xe9, 0x65}, rows[0]["bv"])
+
+	// a float vector has no base64 spelling, so "null" there is still a null
+	floatField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+	floatField.Name = "fv"
+	floatSchema := &schemapb.CollectionSchema{
+		Name: DefaultCollectionName,
+		Fields: []*schemapb.FieldSchema{
+			generatePrimaryField(schemapb.DataType_Int64, false), floatField,
+		},
+	}
+	_, _, err = checkAndSetData(
+		[]byte(fmt.Sprintf(`{"data": {"%s": 1, "fv": "null"}}`, FieldBookID)), floatSchema, false)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 }

--- a/internal/distributed/proxy/httpserver/wrap_request.go
+++ b/internal/distributed/proxy/httpserver/wrap_request.go
@@ -17,6 +17,7 @@
 package httpserver
 
 import (
+	"github.com/tidwall/gjson"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -24,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -110,6 +112,53 @@ func (f *FieldData) makePbFloat16OrBfloat16Array(raw json.RawMessage, serializeF
 	return data, int64(dim), nil
 }
 
+// rejectNullInFieldPayload refuses a null anywhere inside a low-level /api/v1
+// field payload.
+//
+// The typed decoders below unmarshal straight into []bool, []float32 and
+// friends, and encoding/json leaves a null element as the zero value -- false,
+// 0, an empty string -- so what was stored is a value the caller never sent.
+// This is the low-level twin of the rule the high-level handlers apply in
+// checkAndSetData and rejectNullCoordinates.
+//
+// The two halves of that rule are gated differently, for the same reason they
+// are one level up. A vector has no per-element validity anywhere in the
+// system, so a null coordinate has no representation to fall back to and the
+// refusal is unconditional. A scalar column can be nullable, and it is only
+// this wire format that cannot say so -- FieldData carries no valid_data --
+// so the refusal there is an improvement on storing a zero rather than the
+// only possible answer, and compatibilityMode restores the zero for a client
+// that has not been corrected yet.
+func rejectNullInFieldPayload(dataType schemapb.DataType, fieldName string, raw json.RawMessage) error {
+	if len(raw) == 0 {
+		// absent; the typed decoder reports its own error
+		return nil
+	}
+	if !typeutil.IsVectorType(dataType) && paramtable.Get().HTTPCfg.CompatibilityMode.GetAsBool() {
+		return nil
+	}
+	var nullErr error
+	var walk func(node gjson.Result) bool
+	walk = func(node gjson.Result) bool {
+		switch {
+		case node.Type == gjson.Null:
+			nullErr = merr.WrapErrParameterInvalidMsg(
+				"field %s contains a null, which this API cannot represent; a null would silently become the element type's zero value", fieldName)
+			return false
+		case node.IsArray(), node.IsObject():
+			ok := true
+			node.ForEach(func(_, child gjson.Result) bool {
+				ok = walk(child)
+				return ok
+			})
+			return ok
+		}
+		return true
+	}
+	walk(gjson.Parse(string(raw)))
+	return nullErr
+}
+
 // AsSchemapb converts the FieldData to schemapb.FieldData
 func (f *FieldData) AsSchemapb() (*schemapb.FieldData, error) {
 	// is scarlar
@@ -117,6 +166,10 @@ func (f *FieldData) AsSchemapb() (*schemapb.FieldData, error) {
 		Type:      f.Type,
 		FieldName: f.FieldName,
 		FieldId:   f.FieldID,
+	}
+
+	if err := rejectNullInFieldPayload(f.Type, f.FieldName, f.Field); err != nil {
+		return nil, err
 	}
 
 	raw := f.Field
@@ -379,14 +432,18 @@ func convertFieldDataArray(input []*FieldData) ([]*schemapb.FieldData, error) {
 
 // SearchRequest is the RESTful request body for search
 type SearchRequest struct {
-	Base                   *commonpb.MsgBase        `protobuf:"bytes,1,opt,name=base,proto3" json:"base,omitempty"`
-	DbName                 string                   `protobuf:"bytes,2,opt,name=db_name,json=dbName,proto3" json:"db_name,omitempty"`
-	CollectionName         string                   `protobuf:"bytes,3,opt,name=collection_name,json=collectionName,proto3" json:"collection_name,omitempty"`
-	PartitionNames         []string                 `protobuf:"bytes,4,rep,name=partition_names,json=partitionNames,proto3" json:"partition_names,omitempty"`
-	Dsl                    string                   `protobuf:"bytes,5,opt,name=dsl,proto3" json:"dsl,omitempty"`
-	DslType                commonpb.DslType         `protobuf:"varint,7,opt,name=dsl_type,json=dslType,proto3,enum=milvus.proto.common.DslType" json:"dsl_type,omitempty"`
-	BinaryVectors          [][]byte                 `json:"binary_vectors,omitempty"`
-	Vectors                [][]float32              `json:"vectors,omitempty"`
+	Base           *commonpb.MsgBase `protobuf:"bytes,1,opt,name=base,proto3" json:"base,omitempty"`
+	DbName         string            `protobuf:"bytes,2,opt,name=db_name,json=dbName,proto3" json:"db_name,omitempty"`
+	CollectionName string            `protobuf:"bytes,3,opt,name=collection_name,json=collectionName,proto3" json:"collection_name,omitempty"`
+	PartitionNames []string          `protobuf:"bytes,4,rep,name=partition_names,json=partitionNames,proto3" json:"partition_names,omitempty"`
+	Dsl            string            `protobuf:"bytes,5,opt,name=dsl,proto3" json:"dsl,omitempty"`
+	DslType        commonpb.DslType  `protobuf:"varint,7,opt,name=dsl_type,json=dslType,proto3,enum=milvus.proto.common.DslType" json:"dsl_type,omitempty"`
+	// Base64VectorQuery rather than []byte: a null decodes to an empty slice
+	// and would travel as a zero-length vector
+	BinaryVectors []Base64VectorQuery `json:"binary_vectors,omitempty"`
+	// FloatVectorQuery rather than []float32: a null coordinate must be
+	// refused, not silently decoded to 0 and searched
+	Vectors                []FloatVectorQuery       `json:"vectors,omitempty"`
 	OutputFields           []string                 `protobuf:"bytes,8,rep,name=output_fields,json=outputFields,proto3" json:"output_fields,omitempty"`
 	SearchParams           []*commonpb.KeyValuePair `protobuf:"bytes,9,rep,name=search_params,json=searchParams,proto3" json:"search_params,omitempty"`
 	TravelTimestamp        uint64                   `protobuf:"varint,10,opt,name=travel_timestamp,json=travelTimestamp,proto3" json:"travel_timestamp,omitempty"`
@@ -400,13 +457,15 @@ func (r *SearchRequest) HasSearchAggregation() bool {
 	return r.SearchAggregation != nil || r.SearchAggregationSnake != nil
 }
 
-func binaryVector2Bytes(vectors [][]byte) []byte {
+func binaryVector2Bytes(vectors []Base64VectorQuery) []byte {
 	ph := &commonpb.PlaceholderValue{
 		Tag:    "$0",
 		Type:   commonpb.PlaceholderType_BinaryVector,
 		Values: make([][]byte, 0, len(vectors)),
 	}
-	ph.Values = append(ph.Values, vectors...)
+	for _, vector := range vectors {
+		ph.Values = append(ph.Values, vector)
+	}
 	phg := &commonpb.PlaceholderGroup{
 		Placeholders: []*commonpb.PlaceholderValue{
 			ph,
@@ -416,7 +475,7 @@ func binaryVector2Bytes(vectors [][]byte) []byte {
 	return ret
 }
 
-func vector2Bytes(vectors [][]float32) []byte {
+func vector2Bytes(vectors []FloatVectorQuery) []byte {
 	ph := &commonpb.PlaceholderValue{
 		Tag:    "$0",
 		Type:   commonpb.PlaceholderType_FloatVector,
@@ -448,10 +507,13 @@ type WrappedCalcDistanceRequest struct {
 type VectorsArray struct {
 	// Dim of vectors or binary_vectors, not needed when use ids
 	Dim int64 `json:"dim,omitempty"`
-	// Vectors is an array of vector divided by given dim. Disabled when ids or binary_vectors is set
-	Vectors []float32 `json:"vectors,omitempty"`
-	// Vectors is an array of binary vector divided by given dim. Disabled when IDs is set
-	BinaryVectors []byte `json:"binary_vectors,omitempty"`
+	// Vectors is an array of vector divided by given dim. Disabled when ids or binary_vectors is set.
+	// FloatVectorQuery rather than []float32: a null coordinate must be
+	// refused, not silently decoded to 0 and measured against.
+	Vectors FloatVectorQuery `json:"vectors,omitempty"`
+	// Vectors is an array of binary vector divided by given dim. Disabled when IDs is set.
+	// Base64VectorQuery rather than []byte, for the same reason as above.
+	BinaryVectors Base64VectorQuery `json:"binary_vectors,omitempty"`
 	// IDs of vector field in milvus, if not nil, vectors will be ignored
 	IDs *VectorIDs `json:"ids,omitempty"`
 }
@@ -514,5 +576,7 @@ type VectorIDs struct {
 	CollectionName string   `protobuf:"bytes,1,opt,name=collection_name,json=collectionName,proto3" json:"collection_name,omitempty"`
 	FieldName      string   `protobuf:"bytes,2,opt,name=field_name,json=fieldName,proto3" json:"field_name,omitempty"`
 	PartitionNames []string `json:"partition_names"`
-	IDArray        []int64  `json:"id_array,omitempty"`
+	// Int64ListQuery rather than []int64: a null decodes to 0, which names a
+	// vector the caller never asked for
+	IDArray Int64ListQuery `json:"id_array,omitempty"`
 }

--- a/internal/distributed/proxy/httpserver/wrap_request_test.go
+++ b/internal/distributed/proxy/httpserver/wrap_request_test.go
@@ -20,10 +20,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 func TestFieldData_AsSchemapb(t *testing.T) {
@@ -405,12 +407,12 @@ func TestFieldData_AsSchemapb(t *testing.T) {
 }
 
 func Test_vector2Bytes(t *testing.T) {
-	ret := vector2Bytes([][]float32{{1.1, 1.2}})
+	ret := vector2Bytes([]FloatVectorQuery{{1.1, 1.2}})
 	assert.NotEmpty(t, ret)
 }
 
 func Test_binaryVector2Bytes(t *testing.T) {
-	ret := binaryVector2Bytes([][]byte{
+	ret := binaryVector2Bytes([]Base64VectorQuery{
 		[]byte("somebytes"),
 	})
 	assert.NotEmpty(t, ret)
@@ -465,5 +467,139 @@ func TestVectorsArray_AsPbVectorArray(t *testing.T) {
 		ints, ok := ia.IdArray.IdArray.IdField.(*schemapb.IDs_IntId)
 		assert.True(t, ok)
 		assert.Equal(t, ids, ints.IntId.Data)
+	})
+}
+
+// The low-level /api/v1 API decoded straight into []bool, []float32 and
+// friends, so a null element silently became the zero value -- false, 0, an
+// empty string -- and was stored, searched or measured as a value the caller
+// never sent.
+func TestLowLevelAPIRejectsNull(t *testing.T) {
+	t.Run("insert field payloads", func(t *testing.T) {
+		for name, tt := range map[string]struct {
+			dtype schemapb.DataType
+			field string
+		}{
+			"bool null":          {schemapb.DataType_Bool, `[null]`},
+			"varchar null":       {schemapb.DataType_VarChar, `[null]`},
+			"int32 null":         {schemapb.DataType_Int32, `[null]`},
+			"int64 null":         {schemapb.DataType_Int64, `[null]`},
+			"float null":         {schemapb.DataType_Float, `[null]`},
+			"double null":        {schemapb.DataType_Double, `[null]`},
+			"float vector null":  {schemapb.DataType_FloatVector, `[[0.1, null]]`},
+			"fp16 vector null":   {schemapb.DataType_Float16Vector, `[[0.1, null]]`},
+			"bf16 vector null":   {schemapb.DataType_BFloat16Vector, `[[0.1, null]]`},
+			"int8 vector null":   {schemapb.DataType_Int8Vector, `[[1, null]]`},
+			"sparse value null":  {schemapb.DataType_SparseFloatVector, `[{"1": null}]`},
+			"whole payload null": {schemapb.DataType_Float, `null`},
+		} {
+			t.Run(name, func(t *testing.T) {
+				fieldData := FieldData{Type: tt.dtype, FieldName: "f", Field: []byte(tt.field)}
+				_, err := fieldData.AsSchemapb()
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "null")
+			})
+		}
+
+		// the same payloads without the null still convert
+		for name, tt := range map[string]struct {
+			dtype schemapb.DataType
+			field string
+		}{
+			"bool":         {schemapb.DataType_Bool, `[true]`},
+			"float vector": {schemapb.DataType_FloatVector, `[[0.1, 0.2]]`},
+		} {
+			t.Run(name+" without null", func(t *testing.T) {
+				fieldData := FieldData{Type: tt.dtype, FieldName: "f", Field: []byte(tt.field)}
+				_, err := fieldData.AsSchemapb()
+				assert.NoError(t, err)
+			})
+		}
+	})
+
+	// A scalar column can be nullable, so refusing the null there is an
+	// improvement on storing a zero rather than the only possible answer:
+	// compatibilityMode brings the zero back. A vector has no per-element
+	// validity to restore, so it stays refused either way.
+	t.Run("compatibility mode restores the zero for scalars only", func(t *testing.T) {
+		paramtable.Init()
+		key := paramtable.Get().HTTPCfg.CompatibilityMode.Key
+		paramtable.Get().Save(key, "true")
+		defer paramtable.Get().Reset(key)
+
+		// bool and float are the ones the decoder silently zeroed; it already
+		// refused a null for an integer or a string element
+		boolean := FieldData{Type: schemapb.DataType_Bool, FieldName: "f", Field: []byte(`[true, null]`)}
+		converted, err := boolean.AsSchemapb()
+		require.NoError(t, err)
+		assert.Equal(t, []bool{true, false}, converted.GetScalars().GetBoolData().GetData())
+
+		double := FieldData{Type: schemapb.DataType_Double, FieldName: "d", Field: []byte(`[1.5, null]`)}
+		converted, err = double.AsSchemapb()
+		require.NoError(t, err)
+		assert.Equal(t, []float64{1.5, 0}, converted.GetScalars().GetDoubleData().GetData())
+
+		vector := FieldData{Type: schemapb.DataType_FloatVector, FieldName: "v", Field: []byte(`[[0.1, null]]`)}
+		_, err = vector.AsSchemapb()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "null")
+	})
+
+	t.Run("search vectors", func(t *testing.T) {
+		var req SearchRequest
+		err := json.Unmarshal([]byte(`{"vectors": [[0.1, null]]}`), &req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "null")
+
+		assert.NoError(t, json.Unmarshal([]byte(`{"vectors": [[0.1, 0.2]]}`), &req))
+	})
+
+	// A whole-value null used to decode to a non-nil empty slice, which slipped
+	// past the callers' required-field checks: {"vector": null} passed the v1
+	// Vector == nil test with a vector that held nothing.
+	t.Run("whole-value null is refused, not emptied", func(t *testing.T) {
+		var vec FloatVectorQuery
+		err := json.Unmarshal([]byte(`null`), &vec)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "null")
+
+		var ids Int64ListQuery
+		err = json.Unmarshal([]byte(`null`), &ids)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "null")
+
+		// an empty list is a different thing and still decodes
+		require.NoError(t, json.Unmarshal([]byte(`[]`), &vec))
+		require.NotNil(t, vec)
+		require.NoError(t, json.Unmarshal([]byte(`[]`), &ids))
+		require.NotNil(t, ids)
+	})
+
+	t.Run("distance ids", func(t *testing.T) {
+		var v VectorsArray
+		err := json.Unmarshal([]byte(`{"ids": {"collection_name": "c", "field_name": "f", "id_array": [1, null, 3]}}`), &v)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "null")
+
+		require.NoError(t, json.Unmarshal(
+			[]byte(`{"ids": {"collection_name": "c", "field_name": "f", "id_array": [1, 3]}}`), &v))
+	})
+
+	t.Run("binary search vectors", func(t *testing.T) {
+		var req SearchRequest
+		err := json.Unmarshal([]byte(`{"binary_vectors": [null]}`), &req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "null")
+
+		require.NoError(t, json.Unmarshal([]byte(`{"binary_vectors": ["AQI="]}`), &req))
+	})
+
+	t.Run("distance vectors", func(t *testing.T) {
+		var v VectorsArray
+		err := json.Unmarshal([]byte(`{"dim": 2, "vectors": [0.1, null]}`), &v)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "null")
+
+		assert.NoError(t, json.Unmarshal([]byte(`{"dim": 2, "vectors": [0.1, 0.2]}`), &v))
 	})
 }

--- a/internal/json/sonic.go
+++ b/internal/json/sonic.go
@@ -34,6 +34,8 @@ var (
 	NewDecoder = json.NewDecoder
 	// NewEncoder is exported from bytedance/sonic package.
 	NewEncoder = json.NewEncoder
+	// Valid is exported from bytedance/sonic package.
+	Valid = json.Valid
 )
 
 type (

--- a/internal/parser/planparserv2/primary_key_template_test.go
+++ b/internal/parser/planparserv2/primary_key_template_test.go
@@ -1,0 +1,65 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package planparserv2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+)
+
+// The REST id-based get and delete endpoints build their filter as
+// `pk in {__pk_ids}` and pass the ids as a template value, rather than
+// formatting them into the expression text where a quote in an id was parsed as
+// syntax. This is the parser side of that contract.
+func TestPrimaryKeyIDsAsTemplateValue(t *testing.T) {
+	helper := newTestSchemaHelper(t)
+
+	t.Run("int64 ids", func(t *testing.T) {
+		mv := map[string]*schemapb.TemplateValue{"__pk_ids": {
+			Val: &schemapb.TemplateValue_ArrayVal{ArrayVal: &schemapb.TemplateArrayValue{
+				Data: &schemapb.TemplateArrayValue_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2, 9007199254740993}}},
+			}},
+		}}
+		_, err := CreateRetrievePlan(helper, "Int64Field in {__pk_ids}", mv)
+		require.NoError(t, err)
+	})
+
+	t.Run("varchar ids with quotes and backslashes", func(t *testing.T) {
+		mv := map[string]*schemapb.TemplateValue{"__pk_ids": {
+			Val: &schemapb.TemplateValue_ArrayVal{ArrayVal: &schemapb.TemplateArrayValue{
+				Data: &schemapb.TemplateArrayValue_StringData{StringData: &schemapb.StringArray{
+					Data: []string{`alice", "bob`, `say "hi"`, `back\slash`},
+				}},
+			}},
+		}}
+		plan, err := CreateRetrievePlan(helper, "VarCharField in {__pk_ids}", mv)
+		require.NoError(t, err)
+		require.NotNil(t, plan)
+		// the crafted id must survive as ONE term, not become expression syntax
+		values := plan.GetQuery().GetPredicates().GetTermExpr().GetValues()
+		require.Len(t, values, 3, "three ids in, three terms out")
+		got := make([]string, 0, len(values))
+		for _, v := range values {
+			got = append(got, v.GetStringVal())
+		}
+		assert.ElementsMatch(t, []string{`alice", "bob`, `say "hi"`, `back\slash`}, got)
+	})
+}

--- a/pkg/util/paramtable/http_param.go
+++ b/pkg/util/paramtable/http_param.go
@@ -21,6 +21,9 @@ type httpConfig struct {
 	DebugMode             ParamItem `refreshable:"false"`
 	Port                  ParamItem `refreshable:"false"`
 	AcceptTypeAllowInt64  ParamItem `refreshable:"true"`
+	CompatibilityMode     ParamItem `refreshable:"true"`
+	MaxExprParamsDepth    ParamItem `refreshable:"true"`
+	NativeJSONResponse    ParamItem `refreshable:"true"`
 	EnablePprof           ParamItem `refreshable:"false"`
 	RequestTimeoutMs      ParamItem `refreshable:"true"`
 	ReadHeaderTimeout     ParamItem `refreshable:"false"`
@@ -71,6 +74,45 @@ func (p *httpConfig) init(base *BaseTable) {
 		Export:       true,
 	}
 	p.AcceptTypeAllowInt64.Init(base.mgr)
+
+	p.CompatibilityMode = ParamItem{
+		Key:          "proxy.http.compatibilityMode",
+		DefaultValue: "false",
+		Version:      "2.7.0",
+		Doc: `high-level restful api, restore the value handling of releases that predate the REST insert
+validation work. When true the server keeps the previous lenient behavior: a missing or null non-nullable field is
+stored as an empty value, out-of-range integers wrap instead of being rejected, numbers reach VarChar and JSON fields
+through their float64 rendering, and integers too large for the JSON engine become 0. This is a temporary escape hatch
+for clients that have not been corrected yet: every one of those behaviors silently changes what is stored.`,
+		PanicIfEmpty: false,
+		Export:       true,
+	}
+	p.CompatibilityMode.Init(base.mgr)
+	p.MaxExprParamsDepth = ParamItem{
+		Key:          "proxy.http.maxExprParamsDepth",
+		DefaultValue: "100",
+		Version:      "2.7.0",
+		Doc: `high-level restful api, the deepest nesting an expression template parameter may use. Converting a
+parameter walks its arrays and objects recursively, so the depth a caller may send has to be bounded; requests past the
+bound are rejected as invalid rather than served. Values above 1024 are read as 1024, since past that the recursion
+itself is the risk the setting exists to remove; values below 1 are read as 1.`,
+		PanicIfEmpty: false,
+		Export:       true,
+	}
+	p.MaxExprParamsDepth.Init(base.mgr)
+	p.NativeJSONResponse = ParamItem{
+		Key:          "proxy.http.nativeJSONResponse",
+		DefaultValue: "false",
+		Version:      "2.7.0",
+		Doc: `high-level restful api, return a JSON field as the document it holds rather than as a string.
+A JSON field reads back as "{\"a\":1}" by default, while the same value in the dynamic field reads back as {"a":1}.
+Turning this on removes that difference. Rows written before the insert path stopped storing non-JSON bytes may not
+hold a document; if any row in a response is such a row, every JSON field in that response falls back to the string
+form and a warning is logged, so a caller always sees one shape or the other and never a mixture.`,
+		PanicIfEmpty: false,
+		Export:       true,
+	}
+	p.NativeJSONResponse.Init(base.mgr)
 
 	p.EnablePprof = ParamItem{
 		Key:          "proxy.http.enablePprof",

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -1755,23 +1755,9 @@ func UpdateFieldData(base, update []*schemapb.FieldData, baseIdx, updateIdx int6
 					if baseFieldData.GetIsDynamic() {
 						// dynamic field is a json with only 1 level nested struct,
 						// so we need to unmarshal and iterate updateData's key value, and update the baseData's key value
-						var baseMap map[string]interface{}
-						var updateMap map[string]interface{}
-						// unmarshal base and update
-						if err := json.Unmarshal(baseData.Data[baseIdx], &baseMap); err != nil {
-							return merr.Wrap(err, "failed to unmarshal base json")
-						}
-						if err := json.Unmarshal(updateData.Data[updateIdx], &updateMap); err != nil {
-							return merr.Wrap(err, "failed to unmarshal update json")
-						}
-						// merge
-						for k, v := range updateMap {
-							baseMap[k] = v
-						}
-						// marshal back
-						newJSON, err := json.Marshal(baseMap)
+						newJSON, err := mergeDynamicJSON(baseData.Data[baseIdx], updateData.Data[updateIdx])
 						if err != nil {
-							return merr.Wrap(err, "failed to marshal merged json")
+							return err
 						}
 						baseScalar.GetJsonData().Data[baseIdx] = newJSON
 					} else {
@@ -2021,23 +2007,9 @@ func UpdateFieldDataByColumn(base, update *schemapb.FieldData, baseIndices, upda
 				// so we need to unmarshal and iterate updateData's key value, and update the baseData's key value
 				for i, baseIdx := range baseIndices {
 					updateIdx := updateIndices[i]
-					var baseMap map[string]interface{}
-					var updateMap map[string]interface{}
-					// unmarshal base and update
-					if err := json.Unmarshal(baseData[baseIdx], &baseMap); err != nil {
-						return merr.Wrap(err, "failed to unmarshal base json")
-					}
-					if err := json.Unmarshal(updateData[updateIdx], &updateMap); err != nil {
-						return merr.Wrap(err, "failed to unmarshal update json")
-					}
-					// merge
-					for k, v := range updateMap {
-						baseMap[k] = v
-					}
-					// marshal back
-					newJSON, err := json.Marshal(baseMap)
+					newJSON, err := mergeDynamicJSON(baseData[baseIdx], updateData[updateIdx])
 					if err != nil {
-						return merr.Wrap(err, "failed to marshal merged json")
+						return err
 					}
 					baseData[baseIdx] = newJSON
 				}
@@ -2344,6 +2316,40 @@ func countValid(validData []bool) int {
 		}
 	}
 	return validCount
+}
+
+// mergeDynamicJSON merges an update document over a base document without
+// decoding the values.
+//
+// Decoding into map[string]interface{} rounds every number to float64, so a
+// partial update of one key silently rewrote every other key in the row:
+// 9007199254740993 came back as ...992 even though the caller never touched it.
+// json.RawMessage keeps each value as the bytes it already was.
+func mergeDynamicJSON(base []byte, update []byte) ([]byte, error) {
+	baseMap := make(map[string]json.RawMessage)
+	updateMap := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(base, &baseMap); err != nil {
+		return nil, merr.Wrap(err, "failed to unmarshal base json")
+	}
+	if err := json.Unmarshal(update, &updateMap); err != nil {
+		return nil, merr.Wrap(err, "failed to unmarshal update json")
+	}
+	// A literal null unmarshals into a map as nil with no error -- the one
+	// non-object document the error paths above do not catch -- and writing
+	// into the nil map then panics. Such a row is insertable through the
+	// dynamic-field validation, so merging over it must work: an empty base
+	// lets the update repair the row, and a null update simply says nothing.
+	if baseMap == nil {
+		baseMap = make(map[string]json.RawMessage, len(updateMap))
+	}
+	for k, v := range updateMap {
+		baseMap[k] = v
+	}
+	merged, err := json.Marshal(baseMap)
+	if err != nil {
+		return nil, merr.Wrap(err, "failed to marshal merged json")
+	}
+	return merged, nil
 }
 
 // MergeFieldData appends fields data to dst

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -3194,6 +3194,36 @@ func TestGetDataIterator(t *testing.T) {
 	}
 }
 
+// A literal null unmarshals into a map as nil with no error, and the merge
+// then wrote into a nil map and panicked. A row whose dynamic field holds null
+// is insertable, so merging over it has to work rather than crash the proxy.
+func TestMergeDynamicJSONNullDocuments(t *testing.T) {
+	t.Run("null base is repaired by the update", func(t *testing.T) {
+		merged, err := mergeDynamicJSON([]byte(`null`), []byte(`{"a":1}`))
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{"a":1}`, string(merged))
+	})
+
+	t.Run("null update says nothing", func(t *testing.T) {
+		merged, err := mergeDynamicJSON([]byte(`{"a":1}`), []byte(`null`))
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{"a":1}`, string(merged))
+	})
+
+	t.Run("non-object documents still error", func(t *testing.T) {
+		_, err := mergeDynamicJSON([]byte(`[1]`), []byte(`{"a":1}`))
+		assert.Error(t, err)
+		_, err = mergeDynamicJSON([]byte(`{"a":1}`), []byte(`"x"`))
+		assert.Error(t, err)
+	})
+
+	t.Run("large integers survive an untouched key", func(t *testing.T) {
+		merged, err := mergeDynamicJSON([]byte(`{"big":9007199254740993}`), []byte(`{"b":2}`))
+		assert.NoError(t, err)
+		assert.Contains(t, string(merged), "9007199254740993")
+	})
+}
+
 func TestUpdateFieldData(t *testing.T) {
 	const (
 		Dim                  = 8
@@ -7115,4 +7145,16 @@ func TestGetTotalFieldsNumIncludesStructParent(t *testing.T) {
 
 	assert.Equal(t, 5, GetTotalFieldsNum(schema))
 	assert.Len(t, GetAllFieldSchemas(schema), 4)
+}
+
+// Decoding a dynamic field into map[string]interface{} rounds every number to
+// float64, so a partial update of one key silently rewrote the others.
+func TestMergeDynamicJSONKeepsUntouchedValues(t *testing.T) {
+	merged, err := mergeDynamicJSON(
+		[]byte(`{"untouched":9007199254740993,"big":12345678901234567890,"tag":"old"}`),
+		[]byte(`{"tag":"new"}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(merged), `"untouched":9007199254740993`)
+	assert.Contains(t, string(merged), `"big":12345678901234567890`)
+	assert.Contains(t, string(merged), `"tag":"new"`)
 }


### PR DESCRIPTION
> The description below is kept in lockstep with the squashed commit message; earlier revisions of this PR described earlier code.

The REST layer read values through gjson's String(), which renders a value
rather than returning the token the caller sent: it unquotes a JSON string, and
it formats a number by parsing it into a float64 and printing it with the 'f'
verb. The failures were then swallowed, since cast.ToInt8E narrows without a
range check and cast.ToInt64 discards its error and returns 0.

The same shape appeared on every path a value can travel.

What was stored. 128 in an Int8 field became -128 and reported success, so a
later i8 == 128 found nothing. 9007199254740993.0 in an Int64 field became
...992. A field that was neither nullable nor had a default was stored empty
when it was missing. 1e300 in a VARCHAR field became 301 bytes of digits, and
an object was flattened into its own text. {"j": "hello"} in a JSON field was
stored as the bytes `hello`, which is not a JSON document, and the row then
matched no JSON predicate at all -- not even an exact match on what was written
-- with nothing logged and the JSON index reporting every row as indexed. In a
dynamic field 1e300, 1e19 and any integer beyond int64 were stored as 0, and a
nested 9007199254740993 came back as ...992.

What came back. A dynamic field above 2^53 lost precision on the way out, and a
partial upsert of one key rewrote every other key in the row, so an untouched
9007199254740993 became ...992.

What a filter matched. exprParams arrived already decoded, so a parameter of
9007199254740993 silently matched 9007199254740992 while the same value written
as a literal matched correctly, and an integer past int64 fell back to a double
and matched a different row again. null, an empty array and an object each
panicked into an HTTP 500.

A whole number a double cannot be trusted with is now refused rather than
carried. The refusal covers the whole range where a double can be mistaken for
a 64-bit integer, 2^63 through 2^64, rather than only the part of it that
actually rounds: separating the two needs exact arithmetic on the literal, and
that turns a dozen bytes such as 1e-1000000 into a million-digit rational. The
question is asked of the value rather than the spelling, so 9223372036854775809
and ...809.0 are refused alike, and the price of the wider range is that 2^63,
2^64 and 1e19 are refused as parameters although a double carries them exactly.
Written as an integer, such a value is refused by the expression parser too, so
the two paths agree there; written with a point or an exponent the parser takes
it as a double and accepts it, and this path is the stricter of the two.

What an id list turned into. The primary key filter was built by formatting the
ids into the expression text with no escaping, so {"id": ["alice\", \"bob"]}
deleted two rows on v1 and returned two rows on v2 get, and an id containing a
quote could not be fetched at all. Search-by-id lost precision past 2^53 and
formatted a numeric id for a VARCHAR key as "1e+06".

Every path now reads the literal. Static columns convert from value.Raw, with
integers parsed exactly by parseJSONInteger, so 1.0, 1e3 and 100e-2 keep working
while out-of-range and fractional values are rejected. A Float column is read
through float64 and then narrowed, the way every path this value will be
compared against reads it -- the expression parser, an exprParams value
carried as a double, a row written through pymilvus whose Python float is a
double before it becomes a float32. Parsing straight to float32 rounds once
and reads the decimal more faithfully, but a literal sitting on a float32
rounding midpoint then stores a value none of those paths produce and the row
cannot be found with the literal that wrote it. What the shared dialect costs
is the one check the float32 parser makes for free: 3.5e38 is finite as a
float64, so the parse succeeds and the narrowing silently yields +Inf. The
range is checked before the cast instead, in both places a float is narrowed.
JSON and dynamic columns
keep the caller's text rather than being decoded and re-encoded, since that
round trip could only lose information; what they hold is validated by a walk
of its own, described below, which reads the bytes without rewriting them --
nested numbers included. Ids and filter parameters travel as template
values, so nothing a caller sends is parsed as expression syntax.

Values the storage engine cannot read back are rejected at insert time rather
than stored. The binder guarantees syntactically valid JSON and nothing more: it
accepts an integer beyond 64 bits (BIGINT_ERROR), invalid UTF-8, which it
replaces with U+FFFD on decode while the raw bytes keep the offending byte
(UTF8_ERROR), nesting past the 1024 levels the DOM parser behind the JSON index
allows (DEPTH_ERROR), and an object that declares the same key twice, where the
readers disagree about which value wins. All of it -- duplicate keys, depth,
oversized integers, UTF-8 -- is checked in one pass of the standard library's
tokenizer per document, over the bytes that actually land. The pass is new
and is a real cost this change takes on -- linear in the document, an
allocation per token -- which is what rejecting these at the door costs. A
recursive walk was tried first and re-scanned each child's subtree to find
its extent, O(depth * bytes) on a deep document with a wide leaf; one engine
that reads every byte once beats two engines or a tuned budget. The assembled dynamic wrapper adds a level
of nesting and can turn two keys with invalid UTF-8 into one, so it gets the
same walk. A lone surrogate is the one case
that falls back rather than being rejected, and the fallback is refused if
normalizing would change a number the document carries.

proxy.http.compatibilityMode restores the previous handling for all of it. It
defaults to false and is refreshable, so an operator can unblock clients without
downgrading. It is an escape hatch rather than a supported mode: every behavior
it restores silently changes what is stored, and the tests assert that turning it
on brings the wrong values back.

A vector can no longer be handed over as the text of its own JSON shape.
"[0.1, 0.2]" was accepted where [0.1, 0.2] was meant, because three of the
insert branches read gjson's String(), which returns a string node's content
with the quotes removed: the difference was gone before the field type was
consulted. Nothing had decided to allow it. Every neighbor that reads the node
instead refuses it -- BinaryVector and the two 16-bit floats take a string as
their base64 spelling, struct sub-vectors ask IsArray, and the float and int8
query paths read the raw element, so a row written with the quoted form could
not be looked up with it. The rule is now the same everywhere: a string is a
vector only where the type has a base64 spelling for one, restorable through
compatibilityMode like every other tightening here.

Applying that rule turned up an error in the list it reads. Int8Vector was
recorded as having a base64 spelling, which no decoder implements, and the
entry exempted it from the null-literal check -- so "null" in an Int8 vector
field decoded to a nil slice without an error and was stored as an empty
vector. It is off the list.

A query-side list can no longer be null where its callers test for absence. The
UnmarshalJSON that rejects a null element decoded a whole-value null to a nil
slice without an error and then handed back a non-nil empty one, so
{"vector": null} slipped past the v1 required-field check with a vector that
held nothing. A whole-value null is now refused outright, for the vector and
the id list both; an empty list stays what it was.

Converting an expression template parameter walks the caller's nesting
recursively, so the depth is now bounded: proxy.http.maxExprParamsDepth,
default 100, read once per request and clamped to a ceiling of 1024 that
configuration cannot raise, counting arrays and objects both. Not gated by
compatibilityMode -- it is a resource bound, not a value rule, and the
handling it would restore is a stack overflow.

The null rules are screened by a substring scan before any walk runs: a null
can only exist where the letters "null" appear, and a vector's text is digits,
brackets and commas, so the request that carries no null -- which is nearly
every request -- pays a vectorized memchr and nothing else. Benchmarked
against master on the same inputs: query-vector parsing (4x768 floats) and a
scalar+vector insert row land at or slightly below the old cost, and a row
carrying a 500-byte JSON document pays about eight percent for the document
walk described above, which is the one cost this change keeps on purpose.

An array element can no longer be null. An array has no element-level validity,
so a null could only be stored as the element type's zero value and was never
recoverable. sonic already refused one for an integer or string element, so this
only changes a boolean element, which silently became false, and a float, which
became 0. The error now names the position.

An absent key and an explicit null in a dynamic field are no longer the same
request. Skipping the null collapsed them, so a partial update could not clear a
dynamic field: {"tag": null} merged to nothing and the old value survived. The
null is now carried, which is what the partial update end-to-end test expects.

A JSON field can read back as the document it holds rather than as a string,
under proxy.http.nativeJSONResponse, which also defaults to false. Returning the
string is not a design choice: the stored bytes are not guaranteed to be a
document, and embedding one of those natively makes the marshal of the whole
response fail, so a single legacy row would break every query that selects it.
The flag therefore comes with the check that makes it safe to turn on with
existing data -- each value is validated as the response is built, and if any row
does not hold a document then every JSON field in that response falls back to the
string form with a warning. Degrading the whole response rather than the one row
is deliberate: a caller can handle "always a document" or "always a string", but
a field that is sometimes each is worse than the shape being fixed.

A JSON field holding a string reads back differently than it did, and that is
accepted rather than papered over. The bytes stored for one now carry their
quotes, so through the default string form -- which returns the stored bytes --
a value written as "hello" comes back as "\"hello\"" where it used to come back
as hello, and a row written before this change reads unlike a row written after
it. Unwrapping the string on the way out would hide both, but only by changing
what a row written through gRPC reads back as, since those always stored the
quotes and always read back with them. There is no rendering that leaves every
caller where it was, because the two writers did not agree in the first place --
that disagreement is the bug being fixed. The correct bytes win, and
nativeJSONResponse returns the value rather than its storage for callers who
want it. Worth a release note.

One thing is left alone deliberately and documented where it lives: a row that
declares the same key twice is still resolved to the first occurrence, which
would need a scan of the whole row before the map is built.

The low-level /api/v1 wrapper that registerHTTPServer mounts on the metrics
port decoded its payloads straight into []bool, []float32 and friends, so a
null element silently became the zero value -- false or 0 -- and was then
stored by insert, searched, or measured by calc_distance. A null anywhere in
those payloads is now refused, the same rule the high-level handlers apply:
this API has no way to express validity, so there is nothing a null could
honestly become. The rest of that wrapper's value handling reads typed JSON
directly rather than rendering through String(), so it is left unchanged.

Supersedes #52097, #52099, #52213, #52256 and #52103; the response-side fix is
taken from #52103.

---

Fixes the REST value-handling reports: #52049 #52050 #52212 #52255 #52307 #52313 #52315

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1pij3TGike2nZy7t6oDZY
