### PR TITLE
fix: return error when RollbackImport ACK arrives before replicated import job exists [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/internal/datacoord/ddl_callbacks_import.go
+++ b/internal/datacoord/ddl_callbacks_import.go
@@ -297,8 +297,8 @@ func (c *DDLCallbacks) rollbackImportV2AckCallback(ctx context.Context, result m
 
 	job := c.importMeta.GetJob(ctx, jobID)
 	if job == nil {
-		mlog.Warn(ctx, "RollbackImport: job not found, skipping", mlog.FieldJobID(jobID))
-		return nil
+		mlog.Info(ctx, "RollbackImport: job not found, retry later", mlog.FieldJobID(jobID))
+		return merr.WrapErrImportSysFailedMsg("job %d not found, waiting for import job creation", jobID)
 	}
 	state := job.GetState()
 	if state == internalpb.ImportJobState_Committing ||


### PR DESCRIPTION
Fixes #52254

## Problem
In the replicated import 2PC path, `rollbackImportV2AckCallback` returns `nil` when the import job does not exist yet. The broadcaster marks an ACK callback complete when the callback returns nil, so a RollbackImport message that arrives before the replicated Import message creates the local job can be consumed permanently.

After consumption, the target later creates the job and waits in `Uncommitted` for an explicit commit/abort that will never be replayed.

## Fix
Return `merr.WrapErrImportSysFailedMsg` when the job is not found, mirroring the exact pattern in `commitImportV2AckCallback`. This keeps the broadcast task alive so the callback retries after the import task finishes writing local meta.

## Change
`internal/datacoord/ddl_callbacks_import.go`: replace `return nil` with `return merr.WrapErrImportSysFailedMsg(...)` in the nil-job guard of `rollbackImportV2AckCallback`.