### PR TITLE
enhance: build the GIS segment-offsets array only for GIS expressions

### DIFF
--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -1646,12 +1646,22 @@ class SegmentExpr : public Expr {
 
             if (size == 0)
                 continue;  //do not go empty-loop at the bound of the chunk
-            std::vector<int32_t> segment_offsets_array(size);
-            auto start_offset =
-                segment_->num_rows_until_chunk(field_id_, i) + data_pos;
-            for (int64_t j = 0; j < size; ++j) {
-                int64_t offset = start_offset + j;
-                segment_offsets_array[j] = static_cast<int32_t>(offset);
+            // Only GIS functions consume the segment offsets. Building the
+            // array unconditionally costs an allocation plus size int32 stores
+            // per batch for every other expression, and the result is never
+            // read. Default-constructing the empty vector is free; it stays in
+            // scope because the three call sites below are in different
+            // branches. Cf. ProcessDataChunksForSingleChunk, which already
+            // builds it inside the guard.
+            std::vector<int32_t> segment_offsets_array;
+            if constexpr (NeedSegmentOffsets) {
+                segment_offsets_array.resize(size);
+                auto start_offset =
+                    segment_->num_rows_until_chunk(field_id_, i) + data_pos;
+                for (int64_t j = 0; j < size; ++j) {
+                    int64_t offset = start_offset + j;
+                    segment_offsets_array[j] = static_cast<int32_t>(offset);
+                }
             }
             auto skip_index = segment_->GetSkipIndex();
             if (!skip_func || !skip_func(*skip_index, field_id_, i)) {


### PR DESCRIPTION
Fixes #52265

## What

`ProcessDataChunksForMultipleChunk` built `segment_offsets_array` unconditionally,
while every consumer of it is behind `if constexpr (NeedSegmentOffsets)`:

```cpp
if (size == 0) continue;
std::vector<int32_t> segment_offsets_array(size);        // for everyone
auto start_offset = segment_->num_rows_until_chunk(field_id_, i) + data_pos;
for (int64_t j = 0; j < size; ++j) {                     // for everyone
    segment_offsets_array[j] = static_cast<int32_t>(start_offset + j);
}
...
if constexpr (NeedSegmentOffsets) {                      // only the *use* was guarded
    func(..., segment_offsets_array.data(), ...);
}
```

`NeedSegmentOffsets = true` has exactly one caller in the tree —
`GISFunctionFilterExpr.cpp` (`:84`, `:135`, `:185`). UnaryExpr, TermExpr,
BinaryRangeExpr, BinaryArithOpEvalRange, JsonContains, Exists and
TimestamptzArithCompare all use the default `false`, and for all of them this array is
written and never read.

**The sibling function already does this correctly.**
`ProcessDataChunksForSingleChunk` builds the array inside the guard, in both branches
(`:1525-1531`, `:1561-1570`). This change makes the multi-chunk path match it.

## Why it matters

`ChunkedSegmentSealedImpl::is_chunked()` returns `true` unconditionally
(`ChunkedSegmentSealedImpl.h:493-496`), so the multi-chunk path is what every
sealed-segment raw-data filter takes.

For a 1M-row INT64 scan with the default `EXEC_EVAL_EXPR_BATCH_SIZE = 8192`
(~123 batches), the discarded work is one 32KB allocation per batch plus ~8 MB of
store traffic (4 MB zero-init + 4 MB fill) — the same order of magnitude as the ~8 MB
the scan actually reads. On narrow columns (`INT8`/`INT16`/`BOOL`, 1–2 B of data per
row against 4 B of offsets per row) the discarded writes exceed the bytes scanned.

## How

Declare the vector empty and populate it inside the guard. It stays declared outside
because the three call sites are in different branches; a default-constructed
`std::vector` performs no allocation.

Hoisting `num_rows_until_chunk()` into the guard as well means non-GIS expressions no
longer make that call per batch either.

## Verification performed

I could not build segcore locally, so **CI must validate this**. What I did check:

- Every use of `segment_offsets_array` in the function is inside
  `if constexpr (NeedSegmentOffsets)` — the only unguarded statement left is the empty
  declaration.
- Compiled the resulting pattern (template with a `bool` non-type parameter, empty
  vector conditionally resized, consumed at three guarded sites) as a standalone TU
  with the same toolchain (`clang++ -std=c++17 -O2 -Wall -Wextra`). Both
  instantiations compile clean and produce correct results.
- Inspected the generated assembly for the `NeedSegmentOffsets = false` instantiation:
  **no `operator new`, no `memset`** — the allocation and the zero-init are gone, not
  merely cheap.

Full-TU syntax checking against this repo's `compile_commands.json` was not conclusive
because the generated `internal/core/src/pb/plan.pb.h` in my build tree predates
`BloomFilterExpr` on master; unmodified master fails identically, so that error is
environmental rather than introduced here.

## What is not claimed

The issue estimates a 20–40% saving on the filter scan phase, with the derivation shown
there. That is an **estimate, not a measurement** — `internal/core/benchmark/` contains
exactly one target (`fastmem_benchmark`, which measures `memcpy`), so there is nothing
in-tree that can measure this today. See #52263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwPz8E9TtKczUVQQAroanY
