### PR TITLE
enhance: resolve the destination column by index in AppendFieldData

### DIFF
--- a/pkg/util/typeutil/append_field_data_test.go
+++ b/pkg/util/typeutil/append_field_data_test.go
@@ -43,6 +43,21 @@ func floatVec(fieldID int64, name string, dim int64, data []float32) *schemapb.F
 	}
 }
 
+// A dst shorter than src violates the caller contract. The pre-existing code
+// wrote dst[i] unguarded and panicked; keep it a hard failure so a broken
+// caller cannot silently drop a column.
+func TestAppendFieldDataPanicsOnShortDst(t *testing.T) {
+	src := []*schemapb.FieldData{
+		scalarInt64(100, "pk", []int64{10}),
+		scalarInt64(101, "age", []int64{20}),
+	}
+	dst := make([]*schemapb.FieldData, 1) // one column short
+
+	assert.PanicsWithValue(t,
+		"AppendFieldData: dst has 1 columns, src has 2; callers must size dst to at least len(src)",
+		func() { AppendFieldData(dst, src, 0) })
+}
+
 // AppendFieldData now resolves the destination column by index and only falls
 // back to a FieldId map when dst and src are not parallel. This checks the two
 // paths agree, including the cases that force the fallback.

--- a/pkg/util/typeutil/append_field_data_test.go
+++ b/pkg/util/typeutil/append_field_data_test.go
@@ -1,0 +1,135 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package typeutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+)
+
+func scalarInt64(fieldID int64, name string, data []int64) *schemapb.FieldData {
+	return &schemapb.FieldData{
+		Type: schemapb.DataType_Int64, FieldId: fieldID, FieldName: name,
+		Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: data}},
+		}},
+	}
+}
+
+func floatVec(fieldID int64, name string, dim int64, data []float32) *schemapb.FieldData {
+	return &schemapb.FieldData{
+		Type: schemapb.DataType_FloatVector, FieldId: fieldID, FieldName: name,
+		Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+			Dim:  dim,
+			Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: data}},
+		}},
+	}
+}
+
+// AppendFieldData now resolves the destination column by index and only falls
+// back to a FieldId map when dst and src are not parallel. This checks the two
+// paths agree, including the cases that force the fallback.
+func TestAppendFieldDataResolvesSameColumnAsFieldIdLookup(t *testing.T) {
+	const rows = 4
+	newSrc := func() []*schemapb.FieldData {
+		return []*schemapb.FieldData{
+			scalarInt64(100, "pk", []int64{10, 11, 12, 13}),
+			scalarInt64(101, "age", []int64{20, 21, 22, 23}),
+			floatVec(102, "vec", 2, []float32{0, 1, 2, 3, 4, 5, 6, 7}),
+		}
+	}
+
+	t.Run("parallel dst (fast path)", func(t *testing.T) {
+		src := newSrc()
+		dst := PrepareResultFieldData(src, rows)
+		for r := int64(0); r < rows; r++ {
+			AppendFieldData(dst, src, r)
+		}
+		assert.Equal(t, []int64{10, 11, 12, 13}, dst[0].GetScalars().GetLongData().GetData())
+		assert.Equal(t, []int64{20, 21, 22, 23}, dst[1].GetScalars().GetLongData().GetData())
+		assert.Equal(t, []float32{0, 1, 2, 3, 4, 5, 6, 7}, dst[2].GetVectors().GetFloatVector().GetData())
+	})
+
+	t.Run("nil dst entries (lazy creation, as insert repack used to do)", func(t *testing.T) {
+		src := newSrc()
+		dst := make([]*schemapb.FieldData, len(src))
+		for r := int64(0); r < rows; r++ {
+			AppendFieldData(dst, src, r)
+		}
+		for i := range dst {
+			assert.NotNil(t, dst[i])
+			assert.Equal(t, src[i].FieldId, dst[i].FieldId)
+		}
+		assert.Equal(t, []int64{10, 11, 12, 13}, dst[0].GetScalars().GetLongData().GetData())
+		assert.Equal(t, []float32{0, 1, 2, 3, 4, 5, 6, 7}, dst[2].GetVectors().GetFloatVector().GetData())
+	})
+
+	t.Run("dst permuted relative to src (forces the map fallback)", func(t *testing.T) {
+		src := newSrc()
+		prepared := PrepareResultFieldData(src, rows)
+		// Reverse dst so index i no longer corresponds to src[i].
+		dst := []*schemapb.FieldData{prepared[2], prepared[1], prepared[0]}
+		for r := int64(0); r < rows; r++ {
+			AppendFieldData(dst, src, r)
+		}
+		// Data must still land in the column with the matching FieldId.
+		byID := map[int64]*schemapb.FieldData{}
+		for _, fd := range dst {
+			byID[fd.FieldId] = fd
+		}
+		assert.Equal(t, []int64{10, 11, 12, 13}, byID[100].GetScalars().GetLongData().GetData())
+		assert.Equal(t, []int64{20, 21, 22, 23}, byID[101].GetScalars().GetLongData().GetData())
+		assert.Equal(t, []float32{0, 1, 2, 3, 4, 5, 6, 7}, byID[102].GetVectors().GetFloatVector().GetData())
+	})
+}
+
+func benchAppend(b *testing.B, src []*schemapb.FieldData, rows int64) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		dst := PrepareResultFieldData(src, rows)
+		for r := int64(0); r < rows; r++ {
+			AppendFieldData(dst, src, r)
+		}
+	}
+}
+
+func BenchmarkAppendFieldDataPerRow(b *testing.B) {
+	const rows = 10000
+	ids := make([]int64, rows)
+
+	// Scalar-only output: the per-row field lookup dominates.
+	b.Run("4_scalars", func(b *testing.B) {
+		benchAppend(b, []*schemapb.FieldData{
+			scalarInt64(100, "pk", ids), scalarInt64(101, "a", ids),
+			scalarInt64(102, "b", ids), scalarInt64(103, "c", ids),
+		}, rows)
+	})
+
+	// Vector output: data movement dominates, so the lookup is a smaller share.
+	b.Run("3_scalars_1_vector_dim768", func(b *testing.B) {
+		const dim = 768
+		benchAppend(b, []*schemapb.FieldData{
+			scalarInt64(100, "pk", ids), scalarInt64(101, "a", ids),
+			scalarInt64(102, "b", ids),
+			floatVec(103, "vec", dim, make([]float32, rows*dim)),
+		}, rows)
+	})
+}

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -1012,18 +1012,38 @@ func (c *FieldDataIdxComputer) Compute(rowIdx int64) []int64 {
 }
 
 func AppendFieldData(dst, src []*schemapb.FieldData, idx int64, fieldIdxs ...int64) (appendSize int64) {
-	dstMap := make(map[int64]*schemapb.FieldData)
-	for _, fieldData := range dst {
-		if fieldData != nil {
-			dstMap[fieldData.FieldId] = fieldData
-		}
-	}
+	// AppendFieldData copies a single row, so reduce loops call it once per row
+	// with the same dst. Building a FieldId index up front therefore repeats
+	// identical work on every row.
+	//
+	// dst and src are index-parallel in every caller -- the lazy-creation
+	// branch below already relies on that when it does `dst[i] = ...` -- so the
+	// column can normally be found by index. The map is only built when that
+	// does not hold for some column, which preserves the previous behavior
+	// without paying for it in the common case.
+	var dstMap map[int64]*schemapb.FieldData
 	for i, fieldData := range src {
 		fieldIdx := idx
 		if i < len(fieldIdxs) {
 			fieldIdx = fieldIdxs[i]
 		}
-		dstFieldData, ok := dstMap[fieldData.FieldId]
+		var (
+			dstFieldData *schemapb.FieldData
+			ok           bool
+		)
+		if i < len(dst) && dst[i] != nil && dst[i].FieldId == fieldData.FieldId {
+			dstFieldData, ok = dst[i], true
+		} else {
+			if dstMap == nil {
+				dstMap = make(map[int64]*schemapb.FieldData, len(dst))
+				for _, fd := range dst {
+					if fd != nil {
+						dstMap[fd.FieldId] = fd
+					}
+				}
+			}
+			dstFieldData, ok = dstMap[fieldData.FieldId]
+		}
 		if !ok {
 			dstFieldData = &schemapb.FieldData{
 				Type:      fieldData.Type,
@@ -1031,7 +1051,11 @@ func AppendFieldData(dst, src []*schemapb.FieldData, idx int64, fieldIdxs ...int
 				FieldId:   fieldData.FieldId,
 				IsDynamic: fieldData.IsDynamic,
 			}
-			dst[i] = dstFieldData
+			// Callers size dst to at least len(src); the bound is explicit here
+			// so the write is provably safe.
+			if i < len(dst) {
+				dst[i] = dstFieldData
+			}
 		}
 		// assign null data
 		if len(fieldData.GetValidData()) != 0 {

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -1051,10 +1051,17 @@ func AppendFieldData(dst, src []*schemapb.FieldData, idx int64, fieldIdxs ...int
 				FieldId:   fieldData.FieldId,
 				IsDynamic: fieldData.IsDynamic,
 			}
-			// Callers size dst to at least len(src); the bound is explicit here
-			// so the write is provably safe.
+			// Callers size dst to at least len(src). Keep that a hard failure
+			// rather than silently dropping the column: the pre-existing code
+			// wrote dst[i] unguarded and panicked here, and a silent drop would
+			// surface much later as missing data. The write stays inside the
+			// bounds-checked branch because gosec's G602 does not treat a
+			// preceding panic as terminating.
 			if i < len(dst) {
 				dst[i] = dstFieldData
+			} else {
+				panic(fmt.Sprintf("AppendFieldData: dst has %d columns, src has %d; "+
+					"callers must size dst to at least len(src)", len(dst), len(src)))
 			}
 		}
 		// assign null data


### PR DESCRIPTION
Fixes #52264

## What

`AppendFieldData` copies **one row**, so reduce loops call it once per row with the same
`dst`. It opened by building a `FieldId -> *FieldData` map over `dst`:

```go
func AppendFieldData(dst, src []*schemapb.FieldData, idx int64, fieldIdxs ...int64) (appendSize int64) {
	dstMap := make(map[int64]*schemapb.FieldData)
	for _, fieldData := range dst {
		if fieldData != nil {
			dstMap[fieldData.FieldId] = fieldData
		}
	}
```

`dst` is loop-invariant across those calls, so that identical map was rebuilt for every
row. There are **31 non-test call sites** on master, spanning QueryNode search reduce,
proxy search/query reduce, requery assembly, and insert repack.

## How

`dst` and `src` are index-parallel in every caller — the lazy-creation branch already
depends on that when it does `dst[i] = dstFieldData`. So the destination column is
normally just `dst[i]`, guarded by a `FieldId` equality check. The map is built lazily,
only when that check fails for some column, which preserves the old behaviour for
permuted or mismatched destinations.

No caller changes and no signature change, so all 31 sites benefit.

## Measured

10,000 rows, Apple M4 Pro / go1.26.5 (`benchstat`-style median of 5; treat the ratio,
not the absolute):

| destination shape | before | after | | per row |
|---|---|---|---|---|
| 4 scalar columns | 0.518 ms | 0.296 ms | **1.75×** | −22 ns |
| 3 scalars + one 768-dim vector | 1.524 ms | 1.098 ms | **1.39×** | −43 ns |

The ratio depends on how much data each row moves — with a 3 KB vector per row, data
movement dominates and the lookup is a smaller share. The per-row saving is the stable
part.

**Correction to the issue text:** #52264 quotes 22.6×. That figure was for the map
rebuild measured *in isolation* (32.2 → 1.4 ns/row), not for `AppendFieldData` as a
whole, and reads as more than it is. The end-to-end numbers are the table above. I have
corrected the issue.

Allocation counts are unchanged: escape analysis already showed the map did not escape
(`schema.go:1015: make(map[int64]*schemapb.FieldData) does not escape`), so this is pure
CPU, not GC pressure.

## Tests

Added `TestAppendFieldDataResolvesSameColumnAsFieldIdLookup`, covering the three shapes
that exercise both paths:

- **parallel dst** — the fast path; verifies scalar and vector columns accumulate
  correctly across rows.
- **nil dst entries** — the lazy-creation path used by insert repack; verifies the
  entries are created with the right `FieldId` and the data lands correctly.
- **dst permuted relative to src** — forces the map fallback; verifies data still lands
  in the column with the matching `FieldId` rather than by position.

Full `pkg/util/typeutil` suite passes.

## What is not claimed

These are component-level numbers. **What share of end-to-end latency this represents
has not been measured** — QueryNode's search work is largely in C++ segcore, where Go
pprof loses samples across the cgo boundary. See #52263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwPz8E9TtKczUVQQAroanY
