### PR TITLE
fix: repair the datacoord typecheck broken by a rebase-time semantic conflict

### DIFF
--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -3504,10 +3504,9 @@ func (m *meta) completeBumpSchemaVersionCompactionMutation(
 	// Clone the segment for update
 	cloned := oldSegment.Clone()
 
-	// SegmentInfo.Binlogs is the input to the index-eligibility gate:
-	// indexInspector.getSegmentBinlogFields derives the set of fields that have
-	// data from this array's ChildFields, and canCreateIndexForSegment refuses
-	// to build an index on a function-output field missing from that set.
+	// SegmentInfo.Binlogs is where a field's data becomes visible: this array's
+	// ChildFields carry the real field IDs of a StorageV2/V3 column group, and a
+	// function-output field with no data here has nothing to index.
 	// Materialization exists precisely to make such a field indexable, and
 	// compaction_task_bump_schema_version enqueues the segment for index
 	// building right after this mutation — so the column groups this run wrote

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -2320,11 +2320,11 @@ func (suite *MetaBasicSuite) TestCompleteBumpSchemaVersionCompactionMutation() {
 	})
 
 	suite.Run("materialized column group is visible to the index-eligibility gate", func() {
-		// Regression pin for the real consumer: indexInspector calls
-		// getSegmentBinlogFields on the segment and canCreateIndexForSegment
-		// refuses to build an index on a function-output field absent from that
-		// set. compaction_task_bump_schema_version enqueues the segment for
-		// index building right after this mutation, so field 102 must be there.
+		// Regression pin: compaction_task_bump_schema_version enqueues the
+		// segment for index building right after this mutation, so the
+		// materialized column group must land in SegmentInfo.Binlogs — a
+		// function-output field with no data there gets no index. StorageV2/V3
+		// column groups report their real field IDs through ChildFields.
 		currentManifest := packed.MarshalManifestPath("/data/segments/1", 10)
 		resultManifest := packed.MarshalManifestPath("/data/segments/1", 12)
 		segs := makeSegments(1, commonpb.SegmentState_Flushed)
@@ -2359,9 +2359,14 @@ func (suite *MetaBasicSuite) TestCompleteBumpSchemaVersionCompactionMutation() {
 		_, _, err := m.completeBumpSchemaVersionCompactionMutation(task, result)
 		suite.NoError(err)
 
-		fields := getSegmentBinlogFields(m.segments.GetSegment(1))
-		suite.Contains(fields, int64(102), "materialized function-output field must be index-eligible")
-		suite.Contains(fields, int64(100), "pre-existing fields must stay index-eligible")
+		fields := make(map[int64]struct{})
+		for _, binlog := range m.segments.GetSegment(1).GetBinlogs() {
+			for _, childFieldID := range binlog.GetChildFields() {
+				fields[childFieldID] = struct{}{}
+			}
+		}
+		suite.Contains(fields, int64(102), "materialized function-output field must have data")
+		suite.Contains(fields, int64(100), "pre-existing fields must keep their data")
 	})
 
 	suite.Run("in-place result with stale base manifest is rejected", func() {

--- a/internal/datanode/compactor/bump_schema_version_compactor.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor.go
@@ -859,9 +859,9 @@ func (t *bumpSchemaVersionCompactionTask) addV3Stats(prefix string, fieldID int6
 // SegmentInfo, and for a StorageV3 segment recovered after a DataCoord restart
 // they are empty (#50410 stopped persisting per-field binlog KVs for V3).
 // The receiver (completeBumpSchemaVersionCompactionMutation in
-// internal/datacoord/meta.go) merges this array onto SegmentInfo.Binlogs; it
-// is the sole input to getSegmentBinlogFields, which canCreateIndexForSegment
-// uses to decide whether a function-output field is eligible for an index.
+// internal/datacoord/meta.go) merges this array onto SegmentInfo.Binlogs,
+// which is where the materialized field's data becomes visible to the rest of
+// DataCoord — including index building.
 // This result is therefore load-bearing: dropping it silently makes the
 // materialized field permanently un-indexable.
 func (t *bumpSchemaVersionCompactionTask) buildNewInsertLogsV3(writerResult *bumpSchemaVersionWriterResult, sparseFieldMemorySizes map[int64]int, totalRows int64) ([]*datapb.FieldBinlog, error) {


### PR DESCRIPTION
master does not typecheck:

```
vet: internal/datacoord/meta_test.go:2362:13: undefined: getSegmentBinlogFields
```

`make static-check`, `go vet` and `go test ./internal/datacoord/...` fail for everyone on master.

## How it happened

Neither PR involved is wrong on its own; they only break in combination, and CI never saw the combination.

| When | What |
|---|---|
| 07-29 | #52006 forks from master at `113c23613a`. `getSegmentBinlogFields` exists in `index_inspector.go`; the PR adds a call to it in `meta_test.go`. |
| 07-31 | #51768 merges — it replaces the binlog-fields index-eligibility check with a schema-version gate and **deletes** the helper, updating its own `index_inspector_test.go`. |
| 08-03 | #52006's final CI run (`ed1766e3e`) is green, correctly: on that branch the helper still exists. |
| 08-06 | #52006 merges. The merge is a **rebase** — `95e3770aff` has a single parent — replaying the PR onto a master where the helper is gone. The rebased tree is never compiled. |

The two PRs touch disjoint files, so git reports no conflict; only the Go compiler does. Worth noting separately from this fix: a PR's CI result is only valid for the tree it ran on, and tide pushes a rebased tree that no CI job has seen.

## The fix

The subtest's underlying property is still real and worth pinning: after schema-bump materialization the segment's `Binlogs` must expose both the newly materialized function-output field and the pre-existing ones. It is computed inline now, with the same `ChildFields` expansion the deleted helper used, rather than resurrecting a helper that production code no longer needs.

Two comments (`meta.go`, `bump_schema_version_compactor.go`) still described the removed helper as the index-eligibility input; they now describe what `SegmentInfo.Binlogs` actually feeds.

## Verification

- `go vet -tags dynamic,test ./internal/datacoord/ ./internal/datanode/compactor/` — clean
- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/datacoord/ ./internal/datanode/compactor/` — both packages pass
- no remaining references to `getSegmentBinlogFields` anywhere in the tree

issue: #52271

🤖 Generated with [Claude Code](https://claude.com/claude-code)
