### PR TITLE
fix: accumulate RetrieveResultCache size instead of recomputing it per merge

### DIFF
--- a/internal/util/streamrpc/result_cache_size_test.go
+++ b/internal/util/streamrpc/result_cache_size_test.go
@@ -17,6 +17,9 @@
 package streamrpc
 
 import (
+	"context"
+	"math"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,18 +29,48 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 )
 
-func intResult(start, n int64) *internalpb.RetrieveResults {
-	data := make([]int64, n)
-	for i := range data {
-		data[i] = start + int64(i)
+// Auto-id primary keys and TSO timestamps are both large enough that their
+// varints occupy the full 8-9 bytes. Using small values instead would make the
+// Ids column compress far below the FieldsData columns and overstate the effect
+// these tests are about.
+const (
+	firstAutoID    = 458000000000000000
+	firstTimestamp = 460000000000000000
+)
+
+// deleteStyleResult mirrors what querynode actually streams for
+// delete-by-expression: the ID list plus a FieldsData carrying the PK column and
+// common.TimeStampField, because the delete plan asks for both
+// (proxy/task_delete.go) and the stream path never enables ignoreNonPk.
+//
+// merge keeps only the Ids, so a fixture without FieldsData cannot observe how
+// much of an incoming result is charged but discarded.
+func deleteStyleResult(start, n int64) *internalpb.RetrieveResults {
+	pks := make([]int64, n)
+	tss := make([]int64, n)
+	for i := range pks {
+		pks[i] = firstAutoID + start + int64(i)
+		tss[i] = firstTimestamp + start + int64(i)
+	}
+	longCol := func(name string, fieldID int64, data []int64) *schemapb.FieldData {
+		return &schemapb.FieldData{
+			Type:      schemapb.DataType_Int64,
+			FieldName: name,
+			FieldId:   fieldID,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: data}},
+			}},
+		}
 	}
 	return &internalpb.RetrieveResults{
 		Ids: &schemapb.IDs{
-			IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: data}},
+			IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: pks}},
 		},
+		FieldsData:         []*schemapb.FieldData{longCol("pk", 100, pks), longCol("Timestamp", 1, tss)},
 		AllRetrieveCount:   n,
 		ScannedTotalBytes:  n * 8,
 		ScannedRemoteBytes: n * 4,
+		CostAggregation:    &internalpb.CostAggregation{ResponseTime: 1, ServiceTime: 1, TotalNQ: 1},
 	}
 }
 
@@ -50,7 +83,7 @@ func TestRetrieveResultCacheSizeNeverUnderestimates(t *testing.T) {
 
 	cache := &RetrieveResultCache{cap: 1 << 30} // never flushes
 	for i := 0; i < results; i++ {
-		cache.Put(intResult(int64(i*perResult), perResult))
+		cache.Put(deleteStyleResult(int64(i*perResult), perResult))
 		assert.GreaterOrEqual(t, cache.size, proto.Size(cache.result),
 			"reported size must not be below the real encoded size after %d merges", i+1)
 	}
@@ -59,17 +92,20 @@ func TestRetrieveResultCacheSizeNeverUnderestimates(t *testing.T) {
 	got := cache.result.GetIds().GetIntId().GetData()
 	assert.Len(t, got, results*perResult)
 	for i := range got {
-		assert.Equal(t, int64(i), got[i])
+		assert.Equal(t, int64(firstAutoID+i), got[i])
 	}
 	assert.Equal(t, int64(results*perResult), cache.result.GetAllRetrieveCount())
 	assert.Equal(t, int64(results*perResult*8), cache.result.GetScannedTotalBytes())
 	assert.Equal(t, int64(results*perResult*4), cache.result.GetScannedRemoteBytes())
 
-	// The over-estimate stays proportional to the per-result envelope rather
-	// than growing with the payload.
+	// Charging the whole incoming envelope rather than the part merge retains
+	// costs a steady ~3x here, which would flush at a third of cap. The slack
+	// must stay a per-merge constant (the Ids tag and length prefix) plus the
+	// one-off headroom, not a fraction of the payload.
 	real := proto.Size(cache.result)
-	assert.Less(t, cache.size-real, real/10,
-		"over-estimate should stay well under 10%% of the real size")
+	assert.Less(t, cache.size-real, real/100,
+		"over-estimate should stay under 1%% of the real size, got %d of %d",
+		cache.size-real, real)
 }
 
 func TestRetrieveResultCacheSizeStringIDs(t *testing.T) {
@@ -85,27 +121,66 @@ func TestRetrieveResultCacheSizeStringIDs(t *testing.T) {
 	assert.Len(t, cache.result.GetIds().GetStrId().GetData(), 150)
 }
 
+type recordingStreamServer struct {
+	ctx  context.Context
+	sent []*internalpb.RetrieveResults
+}
+
+func (s *recordingStreamServer) Send(result *internalpb.RetrieveResults) error {
+	s.sent = append(s.sent, result)
+	return nil
+}
+
+func (s *recordingStreamServer) Context() context.Context { return s.ctx }
+
+// The size estimate decides when a batch is full, so an estimate that runs high
+// does not just "flush slightly early" — it shrinks every message the stream
+// emits. Proxy turns each received message into one deleteTask
+// (proxy/task_delete.go), so the batch size here is the delete write batch size.
+func TestResultCacheServerFillsBatchesToCapacity(t *testing.T) {
+	const (
+		batchCap   = 4 << 20 // queryNode.queryStreamBatchSize default
+		maxMsgSize = 128 << 20
+		perResult  = 1000
+		results    = 600
+	)
+
+	srv := &recordingStreamServer{ctx: context.Background()}
+	cacheSrv := NewResultCacheServer(srv, batchCap, maxMsgSize)
+	for i := 0; i < results; i++ {
+		assert.NoError(t, cacheSrv.Send(deleteStyleResult(int64(i*perResult), perResult)))
+	}
+	assert.NoError(t, cacheSrv.Flush())
+	assert.NotEmpty(t, srv.sent)
+
+	// Safety first: this is what the estimate exists to guarantee.
+	for i, msg := range srv.sent {
+		assert.LessOrEqual(t, proto.Size(msg), maxMsgSize, "message %d exceeds maxMsgSize", i)
+	}
+
+	// Utilization: every message except the trailing flush should be close to
+	// cap. Charging the full envelope instead of the retained IDs puts these at
+	// roughly cap/3.
+	total := 0
+	for _, msg := range srv.sent[:len(srv.sent)-1] {
+		size := proto.Size(msg)
+		total += size
+		assert.Greater(t, size, batchCap*7/10,
+			"batches should fill cap, got %d of %d", size, batchCap)
+	}
+	assert.Positive(t, total)
+}
+
 // The old implementation was quadratic in the number of merged results.
 func BenchmarkRetrieveResultCacheMerge(b *testing.B) {
 	for _, n := range []int{50, 100, 200} {
-		b.Run(strconvItoa(n), func(b *testing.B) {
+		b.Run(strconv.Itoa(n)+"results", func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				cache := &RetrieveResultCache{cap: 1 << 30}
+				cache := &RetrieveResultCache{cap: math.MaxInt}
 				for j := 0; j < n; j++ {
-					cache.Put(intResult(int64(j*5000), 5000))
+					cache.Put(deleteStyleResult(int64(j*5000), 5000))
 				}
 			}
 		})
-	}
-}
-
-func strconvItoa(n int) string {
-	switch n {
-	case 50:
-		return "50results"
-	case 100:
-		return "100results"
-	default:
-		return "200results"
 	}
 }

--- a/internal/util/streamrpc/result_cache_size_test.go
+++ b/internal/util/streamrpc/result_cache_size_test.go
@@ -1,0 +1,111 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package streamrpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+)
+
+func intResult(start, n int64) *internalpb.RetrieveResults {
+	data := make([]int64, n)
+	for i := range data {
+		data[i] = start + int64(i)
+	}
+	return &internalpb.RetrieveResults{
+		Ids: &schemapb.IDs{
+			IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: data}},
+		},
+		AllRetrieveCount:   n,
+		ScannedTotalBytes:  n * 8,
+		ScannedRemoteBytes: n * 4,
+	}
+}
+
+// RetrieveResultCache.size drives the flush decisions in ResultCacheServer.Send,
+// including the maxMsgSize guard, so it must never under-report. merge used to
+// recompute proto.Size over the whole accumulated message, which is O(N^2) over
+// a stream; it now accumulates instead. This pins the safety property.
+func TestRetrieveResultCacheSizeNeverUnderestimates(t *testing.T) {
+	const results, perResult = 200, 500
+
+	cache := &RetrieveResultCache{cap: 1 << 30} // never flushes
+	for i := 0; i < results; i++ {
+		cache.Put(intResult(int64(i*perResult), perResult))
+		assert.GreaterOrEqual(t, cache.size, proto.Size(cache.result),
+			"reported size must not be below the real encoded size after %d merges", i+1)
+	}
+
+	// Content is still correct.
+	got := cache.result.GetIds().GetIntId().GetData()
+	assert.Len(t, got, results*perResult)
+	for i := range got {
+		assert.Equal(t, int64(i), got[i])
+	}
+	assert.Equal(t, int64(results*perResult), cache.result.GetAllRetrieveCount())
+	assert.Equal(t, int64(results*perResult*8), cache.result.GetScannedTotalBytes())
+	assert.Equal(t, int64(results*perResult*4), cache.result.GetScannedRemoteBytes())
+
+	// The over-estimate stays proportional to the per-result envelope rather
+	// than growing with the payload.
+	real := proto.Size(cache.result)
+	assert.Less(t, cache.size-real, real/10,
+		"over-estimate should stay well under 10%% of the real size")
+}
+
+func TestRetrieveResultCacheSizeStringIDs(t *testing.T) {
+	cache := &RetrieveResultCache{cap: 1 << 30}
+	for i := 0; i < 50; i++ {
+		cache.Put(&internalpb.RetrieveResults{
+			Ids: &schemapb.IDs{IdField: &schemapb.IDs_StrId{
+				StrId: &schemapb.StringArray{Data: []string{"a", "bb", "ccc"}},
+			}},
+		})
+		assert.GreaterOrEqual(t, cache.size, proto.Size(cache.result))
+	}
+	assert.Len(t, cache.result.GetIds().GetStrId().GetData(), 150)
+}
+
+// The old implementation was quadratic in the number of merged results.
+func BenchmarkRetrieveResultCacheMerge(b *testing.B) {
+	for _, n := range []int{50, 100, 200} {
+		b.Run(strconvItoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				cache := &RetrieveResultCache{cap: 1 << 30}
+				for j := 0; j < n; j++ {
+					cache.Put(intResult(int64(j*5000), 5000))
+				}
+			}
+		})
+	}
+}
+
+func strconvItoa(n int) string {
+	switch n {
+	case 50:
+		return "50results"
+	case 100:
+		return "100results"
+	default:
+		return "200results"
+	}
+}

--- a/internal/util/streamrpc/streamer.go
+++ b/internal/util/streamrpc/streamer.go
@@ -45,6 +45,21 @@ func NewConcurrentQueryStreamServer(srv QueryStreamServer) *ConcurrentQueryStrea
 	}
 }
 
+// sizeGrowthHeadroom covers the parts of the accumulated message that grow
+// without any single merge accounting for them:
+//
+//   - the varint length prefixes of the nested Ids / LongArray messages widen as
+//     the payload grows (at most 4 bytes each, and monotonically, so the whole
+//     stream is bounded by a constant rather than a per-merge cost);
+//   - AllRetrieveCount / ScannedRemoteBytes / ScannedTotalBytes are summed, so
+//     their varints widen (at most 10 bytes plus a tag each);
+//   - CostAggregation may be absent in the first result and present after a
+//     merge, appearing as a whole submessage.
+//
+// Those add up to well under 128 bytes for an entire accumulation; 256 is taken
+// once, at Put, so that the per-merge charge below can stay tight.
+const sizeGrowthHeadroom = 256
+
 type RetrieveResultCache struct {
 	result *internalpb.RetrieveResults
 	size   int
@@ -54,11 +69,27 @@ type RetrieveResultCache struct {
 func (c *RetrieveResultCache) Put(result *internalpb.RetrieveResults) {
 	if c.result == nil {
 		c.result = result
-		c.size = proto.Size(result)
+		c.size = proto.Size(result) + sizeGrowthHeadroom
 		return
 	}
 
 	c.merge(result)
+}
+
+// mergedSize reports what result will contribute to the accumulated message
+// once merge folds it in.
+//
+// merge keeps only the IDs and the counters and drops the rest of the envelope,
+// so charging proto.Size(result) is not "slightly" conservative: the sole
+// production caller is delete-by-expression, whose plan asks for the PK column
+// plus common.TimeStampField and never sets ignoreNonPk on the stream path, so
+// every incoming result carries that same PK data three times over — once in
+// Ids and twice more in FieldsData. Measured on realistic auto-id PKs and TSO
+// timestamps that is a steady 3.0x over-estimate, which would trip the 4 MiB
+// queryStreamBatchSize at ~1.3 MiB of real payload and fragment delete batches
+// (proxy produces one deleteTask per received message) by the same factor.
+func mergedSize(result *internalpb.RetrieveResults) int {
+	return proto.Size(result.GetIds())
 }
 
 func (c *RetrieveResultCache) Flush() *internalpb.RetrieveResults {
@@ -69,7 +100,12 @@ func (c *RetrieveResultCache) Flush() *internalpb.RetrieveResults {
 }
 
 func (c *RetrieveResultCache) Alloc(result *internalpb.RetrieveResults) bool {
-	return proto.Size(result)+c.size <= c.cap
+	// Charge what Put will actually charge, so the flush decision here and the
+	// accounting in merge cannot disagree about the same message.
+	if c.result == nil {
+		return proto.Size(result)+sizeGrowthHeadroom+c.size <= c.cap
+	}
+	return mergedSize(result)+c.size <= c.cap
 }
 
 func (c *RetrieveResultCache) IsFull() bool {
@@ -95,12 +131,13 @@ func (c *RetrieveResultCache) merge(result *internalpb.RetrieveResults) {
 	// the whole accumulated message on every merge, making a stream of N
 	// results O(N^2) in the total number of IDs.
 	//
-	// This can only over-estimate: proto.Size(result) accounts for the incoming
-	// message in full, while merge carries over only its IDs and counters and
-	// drops the rest of the envelope. Over-estimating flushes slightly early;
-	// under-estimating would let a message exceed maxMsgSize, which the caller
-	// relies on this value to prevent.
-	c.size += proto.Size(result)
+	// mergedSize still over-estimates, by the Ids submessage's own tag and
+	// length prefix (>= 4 bytes) which appending does not duplicate. That slack
+	// is what keeps the total conservative: c.size must never fall below
+	// proto.Size(c.result), because Send uses it to hold messages under
+	// maxMsgSize. Under-estimating would emit an oversized message; the
+	// remaining sources of growth are covered once by sizeGrowthHeadroom.
+	c.size += mergedSize(result)
 }
 
 func mergeCostAggregation(a *internalpb.CostAggregation, b *internalpb.CostAggregation) *internalpb.CostAggregation {

--- a/internal/util/streamrpc/streamer.go
+++ b/internal/util/streamrpc/streamer.go
@@ -91,7 +91,16 @@ func (c *RetrieveResultCache) merge(result *internalpb.RetrieveResults) {
 	c.result.CostAggregation = mergeCostAggregation(c.result.GetCostAggregation(), result.GetCostAggregation())
 	c.result.ScannedRemoteBytes = c.result.GetScannedRemoteBytes() + result.GetScannedRemoteBytes()
 	c.result.ScannedTotalBytes = c.result.GetScannedTotalBytes() + result.GetScannedTotalBytes()
-	c.size = proto.Size(c.result)
+	// Accumulate rather than recompute. `c.size = proto.Size(c.result)` walked
+	// the whole accumulated message on every merge, making a stream of N
+	// results O(N^2) in the total number of IDs.
+	//
+	// This can only over-estimate: proto.Size(result) accounts for the incoming
+	// message in full, while merge carries over only its IDs and counters and
+	// drops the rest of the envelope. Over-estimating flushes slightly early;
+	// under-estimating would let a message exceed maxMsgSize, which the caller
+	// relies on this value to prevent.
+	c.size += proto.Size(result)
 }
 
 func mergeCostAggregation(a *internalpb.CostAggregation, b *internalpb.CostAggregation) *internalpb.CostAggregation {
@@ -132,7 +141,6 @@ func (s *ResultCacheServer) splitMsgToMaxSize(result *internalpb.RetrieveResults
 	case *schemapb.IDs_IntId:
 		pks := result.GetIds().GetIntId().Data
 		batch := s.maxMsgSize / 8
-		print(batch)
 		for start := 0; start < len(pks); start += batch {
 			newpks = append(newpks, &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: pks[start:min(start+batch, len(pks))]}}})
 		}


### PR DESCRIPTION
Fixes #52273

## What

`RetrieveResultCache.merge` set `c.size = proto.Size(c.result)`, walking the whole
accumulated message on every merge. Over a stream of N results that is **O(N²)** in the
total number of IDs — the k-th merge visits `k·R` elements, so the stream touches
`R·N(N+1)/2` instead of `R·N`. At N=200 that is 100.5M element visits instead of 1M.

This sits inside the lock every segment's result has to pass through:
`segments/retrieve.go:141` sends one result per segment from one goroutine each
(`:125-127`), all serializing on `ResultCacheServer.mu` (`streamer.go:172`).

The only non-test caller of this path is `internal/proxy/task_delete.go:503`, i.e.
delete-by-expression.

## How

Accumulate instead of recomputing.

**What to charge.** `merge` keeps only the IDs and the counters and drops the rest of
the envelope, so the charge has to be the retained part, not the whole message. The
sole production caller is delete-by-expression, whose plan asks for the PK column plus
`common.TimeStampField` (`task_delete.go:463-465`) and which never sets `ignoreNonPk`
on the stream path — so every incoming result carries that PK data three times over,
once in `Ids` and twice more in `FieldsData`. Measured on auto-id PKs and TSO
timestamps:

| IDs per result | full message | `Ids` only | charged / retained |
|---|---|---|---|
| 100 | 2756 B | 906 B | 3.04× |
| 1000 | 27056 B | 9006 B | 3.00× |
| 5000 | 135067 B | 45008 B | 3.00× |

Charging the full envelope would trip the 4 MiB `queryStreamBatchSize` at ~1.3 MiB of
real payload, so querynode→proxy would emit 3× as many messages at a third of the size;
proxy produces one `deleteTask` per received message (`task_delete.go:574`), so delete
write batches would fragment by the same factor. Hence `proto.Size(result.GetIds())`,
with `Alloc` using the same rule so the two cannot disagree about one message.

**Direction still matters.** `Send` uses `c.size` to keep messages under `maxMsgSize`;
under-estimating would emit an oversized message. The `Ids` submessage's own tag and
length prefix (≥ 4 bytes) are not duplicated by appending, so every per-merge charge
stays conservative. The remaining sources of growth — widening length prefixes, summed
counters, a `CostAggregation` that appears only after a merge — are bounded by a
constant for the whole accumulation, not per merge, and are taken once as a fixed
headroom at `Put`. The tests pin both the safety property and the utilization.

## Measured

Real code, 5000 IDs per result (Apple M4 Pro, go1.26.5, median of 3 — treat the ratio):

| results merged | before | after | |
|---|---|---|---|
| 50 | 3.37 ms | 0.93 ms | 3.6× |
| 100 | 10.68 ms | 1.71 ms | 6.3× |
| 200 | 39.81 ms | 3.24 ms | **12.3×** |

Doubling N multiplies the old time by ~3.2 then ~3.7 (approaching 4× — quadratic) and
the new time by ~1.8 then ~1.9 (linear).

Note these merge counts exceed what one flush cycle sees in production: with `cap` at
4 MiB, 5000 auto-id PKs per result flushes at N≈93. The bound that matters is per flush
cycle, `(cap_in_IDs / 2) × N` wasted element visits, which grows linearly in N — so the
smaller each result is, the worse the old behaviour got.

## Also removed: a debug statement in production code

```go
batch := s.maxMsgSize / 8
print(batch)          // Go's builtin print -> unbuffered stderr
```

`splitMsgToMaxSize:135`. It ran on every oversized-message split.

## Tests

- `TestRetrieveResultCacheSizeNeverUnderestimates` — 200 merges × 500 IDs, asserting
  after **every** merge that the reported size is `>= proto.Size(c.result)`. This is the
  safety property the `maxMsgSize` guard depends on. Also verifies the merged IDs and
  the summed counters, and that the over-estimate stays under 1% of the real size
  rather than growing with the payload. The fixture carries the PK and timestamp
  columns a real delete stream sends — without them none of the accounting question
  above is observable.
- `TestRetrieveResultCacheSizeStringIDs` — same property on the `IDs_StrId` branch.
- `TestResultCacheServerFillsBatchesToCapacity` — drives `ResultCacheServer.Send` at
  the default 4 MiB `cap`, asserting both that no emitted message exceeds `maxMsgSize`
  and that batches fill the cap. Charging the full envelope puts them at ~33%.
- `BenchmarkRetrieveResultCacheMerge` at 50/100/200 results, so the scaling shape is
  visible in-tree.

Existing `internal/util/streamrpc` tests pass.

## What is not claimed

The numbers are for the merge loop in isolation. **What share of end-to-end
delete-by-expression latency this represents has not been measured.** See #52263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwPz8E9TtKczUVQQAroanY

