### PR TITLE
test: make E2E cases compatible with small segment boundaries

### DIFF
--- a/tests/go_client/testcases/groupby_search_test.go
+++ b/tests/go_client/testcases/groupby_search_test.go
@@ -86,6 +86,36 @@ func prepareDataForGroupBySearch(t *testing.T, loopInsert int, insertNi int, idx
 	return mc, ctx, schema.CollectionName
 }
 
+func prepareDataForUnsupportedIndexGroupBySearch(t *testing.T, idx index.Index) (*base.MilvusClient, context.Context, string) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout*5)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+	collName := common.GenRandomString("TestSearchGroupByUnsupportedIndex", 6)
+	schema := entity.NewSchema().WithName(collName).
+		WithField(entity.NewField().WithName(common.DefaultInt64FieldName).WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
+		WithField(entity.NewField().WithName(common.DefaultVarcharFieldName).WithDataType(entity.FieldTypeVarChar).WithMaxLength(common.TestMaxLen)).
+		WithField(entity.NewField().WithName(common.DefaultFloatVecFieldName).WithDataType(entity.FieldTypeFloatVector).WithDim(common.DefaultDim))
+
+	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		common.CheckErr(t, mc.DropCollection(cleanupCtx, client.NewDropCollectionOption(collName)), true)
+	})
+
+	for i := 0; i < 3; i++ {
+		hp.CollPrepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption().TWithNb(1000).TWithStart(i*1000))
+	}
+	hp.CollPrepare.FlushData(ctx, t, mc, collName)
+	hp.CollPrepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema).TWithFieldIndex(map[string]index.Index{common.DefaultFloatVecFieldName: idx}))
+
+	idxTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, common.DefaultVarcharFieldName, index.NewAutoIndex(entity.L2)))
+	common.CheckErr(t, err, true)
+	common.CheckErr(t, idxTask.Await(ctx), true)
+	hp.CollPrepare.Load(ctx, t, mc, hp.NewLoadParams(collName))
+	return mc, ctx, collName
+}
+
 // create coll with all datatype -> build all supported index
 // -> search with WithGroupByField (int* + varchar + bool
 // -> verify every top passage is the top of whole group
@@ -454,7 +484,7 @@ func TestSearchGroupByUnsupportedIndex(t *testing.T) {
 	t.Parallel()
 	for _, idx := range genUnsupportedFloatGroupByIndex() {
 		t.Run(string(idx.IndexType()), func(t *testing.T) {
-			mc, ctx, collName := prepareDataForGroupBySearch(t, 3, 1000, idx, false)
+			mc, ctx, collName := prepareDataForUnsupportedIndexGroupBySearch(t, idx)
 			// groupBy search
 			queryVec := hp.GenSearchVectors(common.DefaultNq, common.DefaultDim, entity.FieldTypeFloatVector)
 			_, err := mc.Search(ctx, client.NewSearchOption(collName, common.DefaultLimit, queryVec).WithGroupByField(common.DefaultVarcharFieldName).WithANNSField(common.DefaultFloatVecFieldName))

--- a/tests/python_client/common/milvus_sys.py
+++ b/tests/python_client/common/milvus_sys.py
@@ -11,9 +11,9 @@ sys_logs_req = ujson.dumps({"metric_type": "system_logs"})
 
 
 class MilvusSys:
-    def __init__(self, alias="default"):
+    def __init__(self, alias="default", client=None):
         self.alias = alias
-        self.handler = connections._fetch_handler(alias=self.alias)
+        self.handler = client._get_connection() if client is not None else connections._fetch_handler(alias=self.alias)
         if self.handler is None:
             raise Exception(f"Connection {alias} is disconnected or nonexistent")
 

--- a/tests/python_client/milvus_client/test_milvus_client_force_merge.py
+++ b/tests/python_client/milvus_client/test_milvus_client_force_merge.py
@@ -24,6 +24,7 @@ from common import common_func as cf
 from common import common_type as ct
 from common.common_type import CaseLabel, CheckTasks
 from common.constants import *  # noqa: F403
+from common.milvus_sys import MilvusSys
 from minio import Minio
 from pymilvus import DataType
 from utils.util_log import test_log as log
@@ -48,7 +49,6 @@ default_string_field_name = ct.default_string_field_name
 # ForceMerge specific constants
 max_int64 = (1 << 63) - 1
 auto_target_size_mb = max_int64 // (1024 * 1024) + 1  # Triggers server auto target-size mode.
-default_max_size_mb = 1024  # Default segment max size in MB
 actual_output_size_tolerance = 0.10
 
 
@@ -89,6 +89,15 @@ def get_insert_log_sizes(minio_client, bucket, collection_id, segment_ids):
     return {int(segment_id): size for segment_id, size in sizes.items()}
 
 
+def get_segment_max_size_mb(client):
+    for node in MilvusSys(client=client).get_nodes_by_type("datacoord"):
+        configurations = node.get("infos", {}).get("system_configurations", {})
+        max_size = configurations.get("segment_max_size")
+        if max_size is not None:
+            return int(max_size)
+    return None
+
+
 class TestMilvusClientForceMergeInvalid(TestMilvusClientV2Base):
     """Test cases for ForceMerge with invalid parameters"""
 
@@ -121,18 +130,31 @@ class TestMilvusClientForceMergeInvalid(TestMilvusClientV2Base):
         )
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("target_size", [100, 512, 1000])
-    def test_force_merge_target_size_less_than_max_size(self, target_size):
+    @pytest.mark.parametrize(
+        "target_size_ratio",
+        [
+            pytest.param(0.1, id="low"),
+            pytest.param(0.5, id="half"),
+            pytest.param(0.99, id="near-max"),
+        ],
+    )
+    def test_force_merge_target_size_less_than_max_size(self, target_size_ratio):
         """
         target: test ForceMerge with target_size less than config maxSize
-        method: create collection, call compact with target_size < 1024 MB
+        method: read the server maxSize and call compact with a strictly smaller target_size
         expected: Raise exception
         """
         client = self._client()
         collection_name = cf.gen_unique_str(prefix)
         # 1. create collection
         self.create_collection(client, collection_name, default_dim)
-        # 2. compact with target_size less than maxSize
+        # 2. compact with target_size less than the active server maxSize
+        segment_max_size_mb = get_segment_max_size_mb(client)
+        assert segment_max_size_mb is not None and segment_max_size_mb > 1
+        target_size = max(
+            1,
+            min(segment_max_size_mb - 1, int(segment_max_size_mb * target_size_ratio)),
+        )
         error = {ct.err_code: 1100, ct.err_msg: "targetSize"}
         self.compact(
             client,

--- a/tests/python_client/milvus_client/test_milvus_client_query.py
+++ b/tests/python_client/milvus_client/test_milvus_client_query.py
@@ -6346,7 +6346,7 @@ class TestQueryCount(TestMilvusClientV2Base):
         # 3. create index and load
         index_params = self.prepare_index_params(client)[0]
         index_params.add_index(
-            field_name=ct.default_float_vec_field_name, index_type="IVF_SQ8", metric_type="L2", params={"nlist": 64}
+            field_name=ct.default_float_vec_field_name, index_type="FLAT", metric_type="L2", params={}
         )
         self.create_index(client, collection_name, index_params)
         self.load_collection(client, collection_name)

--- a/tests/python_client/testcases/test_index.py
+++ b/tests/python_client/testcases/test_index.py
@@ -2789,10 +2789,15 @@ class TestBitmapIndex(TestcaseBase):
         # load collection
         self.collection_wrap.load()
 
-        # prepare 3k data (> 1024 triggering index building)
-        self.collection_wrap.insert(
-            data=cf.gen_values(self.collection_wrap.schema, nb=nb), check_task=CheckTasks.check_insert_result
-        )
+        # prepare 3k data (> 1024 triggering index building). Keep each insert
+        # below small segment boundaries while preserving the total row count.
+        insert_batch_size = 500
+        for start_id in range(0, nb, insert_batch_size):
+            batch_size = min(insert_batch_size, nb - start_id)
+            self.collection_wrap.insert(
+                data=cf.gen_values(self.collection_wrap.schema, nb=batch_size, start_id=start_id),
+                check_task=CheckTasks.check_insert_result,
+            )
 
         # check no indexed segments
         res, _ = self.utility_wrap.get_query_segment_info(collection_name=collection_name)


### PR DESCRIPTION
## What this PR does

Make E2E cases use the active server configuration and preserve their intended assertions when Milvus runs with small segment boundaries.

- Read DataCoord's effective `segment_max_size` before generating invalid ForceMerge targets.
- Insert bitmap test data in 500-row batches while preserving the original 3,000-row post-load scenario.
- Use FLAT/L2 for a JSON expression correctness test so ANN recall does not affect the expression assertion.
- Use a minimal Go schema for unsupported IVF_PQ group-by coverage so the segment exceeds the 1,024-row indexing threshold even when boundary sealing is enabled.

This keeps default configuration behavior unchanged while covering the 64 MiB / 5% seal boundary configuration.

## Context

The changes address test/configuration failures found in [3.0 branch CI build 237](https://jenkins-milvus-ci.milvus.io/job/MILVUS-CI-V2-PR-PIPELINES/job/MILVUS-CI-V2-BRANCH-TRIGGER/job/3.0/237/).

Two independent server bugs from the same run were reported separately and their strict assertions are not relaxed by this PR:

issue: #52278
issue: #52279

## Test plan

- [x] Python target set on boundary config: 8 passed in 95.39s
- [x] Python target set on default config: 8 passed in 105.10s
- [x] Go `TestSearchGroupByUnsupportedIndex` on boundary config: passed in 16.97s
- [x] Go `TestSearchGroupByUnsupportedIndex` on default config: passed in 16.27s
- [x] `gofumpt` on the changed Go file
- [x] `gci diff` on the changed Go file
- [x] Python bytecode compilation for changed Python files
- [x] `git diff --check`
