### PR TITLE
fix: support Text fields in REST v2 APIs

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -898,6 +898,75 @@ func TestDocInDocOutInsert(t *testing.T) {
 	sendReqAndVerify(t, testEngine, testcase.path, http.MethodPost, testcase)
 }
 
+func TestInsertTextField(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	schema := &schemapb.CollectionSchema{
+		Name:   DefaultCollectionName,
+		AutoID: false,
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:      common.StartOfUserFieldID,
+				Name:         "id",
+				DataType:     schemapb.DataType_Int64,
+				IsPrimaryKey: true,
+			},
+			{
+				FieldID:  common.StartOfUserFieldID + 1,
+				Name:     "doc",
+				DataType: schemapb.DataType_Text,
+			},
+			{
+				FieldID:  common.StartOfUserFieldID + 2,
+				Name:     "dense",
+				DataType: schemapb.DataType_FloatVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "2"},
+				},
+			},
+		},
+	}
+
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         schema,
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Once()
+	mp.EXPECT().Insert(mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, req *milvuspb.InsertRequest) (*milvuspb.MutationResult, error) {
+			require.Equal(t, uint32(1), req.GetNumRows())
+			var textField *schemapb.FieldData
+			for _, field := range req.GetFieldsData() {
+				if field.GetFieldName() == "doc" {
+					textField = field
+					break
+				}
+			}
+			require.NotNil(t, textField)
+			assert.Equal(t, schemapb.DataType_Text, textField.GetType())
+			assert.Equal(t, []string{"hello, 世界 🌍"}, textField.GetScalars().GetStringData().GetData())
+			return &milvuspb.MutationResult{
+				Status:    commonSuccessStatus,
+				InsertCnt: 1,
+				IDs:       generateIDs(schemapb.DataType_Int64, 1),
+			}, nil
+		}).Once()
+
+	testEngine := initHTTPServerV2(mp, false)
+	testcase := requestBodyTestCase{
+		path: versionalV2(EntityCategory, InsertAction),
+		requestBody: []byte(`{
+			"collectionName": "book",
+			"data": [{"id": 1, "doc": "hello, 世界 🌍", "dense": [0.1, 0.2]}]
+		}`),
+	}
+	sendReqAndVerify(t, testEngine, testcase.path, http.MethodPost, testcase)
+}
+
 func TestDocInDocOutInsertInvalid(t *testing.T) {
 	paramtable.Init()
 	// disable rate limit

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -3501,7 +3501,7 @@ func fieldDataValueCount(fieldData *schemapb.FieldData) (int64, error) {
 			return int64(len(fieldData.GetScalars().GetTimestamptzData().GetData())), nil
 		}
 		return int64(len(fieldData.GetScalars().GetStringData().GetData())), nil
-	case schemapb.DataType_String, schemapb.DataType_VarChar:
+	case schemapb.DataType_String, schemapb.DataType_VarChar, schemapb.DataType_Text:
 		return int64(len(fieldData.GetScalars().GetStringData().GetData())), nil
 	case schemapb.DataType_Array:
 		return int64(len(fieldData.GetScalars().GetArrayData().GetData())), nil
@@ -3739,9 +3739,7 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 					} else {
 						row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetStringData().GetData()[dataIdx]
 					}
-				case schemapb.DataType_String:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetStringData().GetData()[dataIdx]
-				case schemapb.DataType_VarChar:
+				case schemapb.DataType_String, schemapb.DataType_VarChar, schemapb.DataType_Text:
 					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetStringData().GetData()[dataIdx]
 				case schemapb.DataType_BinaryVector:
 					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetBinaryVector()[dataIdx*(fieldDataList[j].GetVectors().GetDim()/8) : (dataIdx+1)*(fieldDataList[j].GetVectors().GetDim()/8)]

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -1385,7 +1385,7 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 					reallyData[fieldName] = result
 				case schemapb.DataType_Timestamptz:
 					reallyData[fieldName] = dataString
-				case schemapb.DataType_VarChar, schemapb.DataType_String:
+				case schemapb.DataType_VarChar, schemapb.DataType_String, schemapb.DataType_Text:
 					value, err := stringFieldValue(fieldName, fieldValue, compatibilityMode)
 					if err != nil {
 						return reallyDataArray, validDataMap, err
@@ -2780,11 +2780,7 @@ func anyToColumns(rows []map[string]interface{}, validDataMap map[string][]bool,
 			data = make([]float32, 0, rowsLen)
 		case schemapb.DataType_Double:
 			data = make([]float64, 0, rowsLen)
-		case schemapb.DataType_Timestamptz:
-			data = make([]string, 0, rowsLen)
-		case schemapb.DataType_String:
-			data = make([]string, 0, rowsLen)
-		case schemapb.DataType_VarChar:
+		case schemapb.DataType_Timestamptz, schemapb.DataType_String, schemapb.DataType_VarChar, schemapb.DataType_Text:
 			data = make([]string, 0, rowsLen)
 		case schemapb.DataType_Array:
 			data = make([]*schemapb.ScalarField, 0, rowsLen)
@@ -2881,13 +2877,9 @@ func anyToColumns(rows []map[string]interface{}, validDataMap map[string][]bool,
 				nameColumns[field.Name] = append(nameColumns[field.Name].([]int64), candi.v.Interface().(int64))
 			case schemapb.DataType_Float:
 				nameColumns[field.Name] = append(nameColumns[field.Name].([]float32), candi.v.Interface().(float32))
-			case schemapb.DataType_Timestamptz:
-				nameColumns[field.Name] = append(nameColumns[field.Name].([]string), candi.v.Interface().(string))
 			case schemapb.DataType_Double:
 				nameColumns[field.Name] = append(nameColumns[field.Name].([]float64), candi.v.Interface().(float64))
-			case schemapb.DataType_String:
-				nameColumns[field.Name] = append(nameColumns[field.Name].([]string), candi.v.Interface().(string))
-			case schemapb.DataType_VarChar:
+			case schemapb.DataType_Timestamptz, schemapb.DataType_String, schemapb.DataType_VarChar, schemapb.DataType_Text:
 				nameColumns[field.Name] = append(nameColumns[field.Name].([]string), candi.v.Interface().(string))
 			case schemapb.DataType_Array:
 				nameColumns[field.Name] = append(nameColumns[field.Name].([]*schemapb.ScalarField), candi.v.Interface().(*schemapb.ScalarField))
@@ -3062,27 +3054,7 @@ func anyToColumns(rows []map[string]interface{}, validDataMap map[string][]bool,
 					},
 				},
 			}
-		case schemapb.DataType_Timestamptz:
-			colData.Field = &schemapb.FieldData_Scalars{
-				Scalars: &schemapb.ScalarField{
-					Data: &schemapb.ScalarField_StringData{
-						StringData: &schemapb.StringArray{
-							Data: column.([]string),
-						},
-					},
-				},
-			}
-		case schemapb.DataType_String:
-			colData.Field = &schemapb.FieldData_Scalars{
-				Scalars: &schemapb.ScalarField{
-					Data: &schemapb.ScalarField_StringData{
-						StringData: &schemapb.StringArray{
-							Data: column.([]string),
-						},
-					},
-				},
-			}
-		case schemapb.DataType_VarChar:
+		case schemapb.DataType_Timestamptz, schemapb.DataType_String, schemapb.DataType_VarChar, schemapb.DataType_Text:
 			colData.Field = &schemapb.FieldData_Scalars{
 				Scalars: &schemapb.ScalarField{
 					Data: &schemapb.ScalarField_StringData{

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -2066,6 +2066,28 @@ func TestBuildQueryRespDynamicFieldLargeIntPrecision(t *testing.T) {
 	})
 }
 
+func TestBuildQueryRespTextField(t *testing.T) {
+	fieldData := &schemapb.FieldData{
+		Type:      schemapb.DataType_Text,
+		FieldName: FieldBookIntro,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_StringData{
+					StringData: &schemapb.StringArray{Data: []string{"hello", strings.Repeat("文", 32)}},
+				},
+			},
+		},
+		ValidData: []bool{true, false, true},
+	}
+
+	rows, err := buildQueryResp(0, []string{FieldBookIntro}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+	require.NoError(t, err)
+	require.Len(t, rows, 3)
+	assert.Equal(t, "hello", rows[0][FieldBookIntro])
+	assert.Nil(t, rows[1][FieldBookIntro])
+	assert.Equal(t, strings.Repeat("文", 32), rows[2][FieldBookIntro])
+}
+
 func TestBuildQueryRespWithNullableCompactFields(t *testing.T) {
 	t.Run("nullable vector derives logical rows from ValidData", func(t *testing.T) {
 		fieldData := &schemapb.FieldData{

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -627,6 +627,49 @@ func TestPrimaryField(t *testing.T) {
 		values[primaryKeyTemplateVar].GetArrayVal().GetStringData().GetData())
 }
 
+func TestCheckAndSetTextData(t *testing.T) {
+	textField := &schemapb.FieldSchema{
+		FieldID:  common.StartOfUserFieldID + 1,
+		Name:     "doc",
+		DataType: schemapb.DataType_Text,
+	}
+	textSchema := &schemapb.CollectionSchema{
+		Name: DefaultCollectionName,
+		Fields: []*schemapb.FieldSchema{
+			generatePrimaryField(schemapb.DataType_Int64, false),
+			textField,
+		},
+	}
+
+	t.Run("missing required Text field", func(t *testing.T) {
+		_, _, err := checkAndSetData([]byte(`{"data": [{"book_id": 1}]}`), textSchema, false)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterMissing)
+		assert.Contains(t, err.Error(), "doc")
+	})
+
+	t.Run("null required Text field", func(t *testing.T) {
+		_, _, err := checkAndSetData([]byte(`{"data": [{"book_id": 1, "doc": null}]}`), textSchema, false)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "doc")
+	})
+
+	t.Run("explicit empty Text field", func(t *testing.T) {
+		rows, _, err := checkAndSetData([]byte(`{"data": [{"book_id": 1, "doc": ""}]}`), textSchema, false)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.Equal(t, "", rows[0]["doc"])
+	})
+
+	t.Run("missing required Text field in partial update", func(t *testing.T) {
+		rows, _, err := checkAndSetData([]byte(`{"data": [{"book_id": 1}]}`), textSchema, true)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.NotContains(t, rows[0], "doc")
+	})
+}
+
 func TestAnyToColumns(t *testing.T) {
 	t.Run("insert with dynamic field", func(t *testing.T) {
 		body := []byte("{\"data\": {\"id\": 0, \"book_id\": 1, \"book_intro\": [0.1, 0.2], \"word_count\": 2, \"classified\": false, \"databaseID\": null}}")

--- a/internal/proxy/search_pipeline.go
+++ b/internal/proxy/search_pipeline.go
@@ -2755,7 +2755,7 @@ func reorderFieldData(field *schemapb.FieldData, indices []int) error {
 			}
 			data.Data = newData
 		}
-	case schemapb.DataType_VarChar, schemapb.DataType_String:
+	case schemapb.DataType_VarChar, schemapb.DataType_String, schemapb.DataType_Text:
 		if data := field.GetScalars().GetStringData(); data != nil && len(data.Data) > 0 {
 			newData := make([]string, n)
 			for newIdx, oldIdx := range indices {

--- a/internal/proxy/search_pipeline_test.go
+++ b/internal/proxy/search_pipeline_test.go
@@ -6461,6 +6461,46 @@ func (s *SearchPipelineSuite) TestOrderByOperatorVarCharField() {
 	s.Equal(expectedNames, sortedResult.Results.FieldsData[0].GetScalars().GetStringData().Data)
 }
 
+func (s *SearchPipelineSuite) TestOrderByOperatorReordersTextOutputField() {
+	result := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			Ids:    testSearchResultIDs(1, 2, 3),
+			Scores: []float32{0.9, 0.8, 0.7},
+			Topks:  []int64{3},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Float,
+					FieldName: "price",
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_FloatData{FloatData: &schemapb.FloatArray{Data: []float32{3, 1, 2}}},
+					}},
+				},
+				{
+					Type:      schemapb.DataType_Text,
+					FieldName: "content",
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"third", "first", "second"}}},
+					}},
+				},
+			},
+		},
+	}
+
+	op := &orderByOperator{
+		orderByFields:  []OrderByField{{FieldName: "price", Ascending: true}},
+		groupByFieldId: -1,
+	}
+
+	outputs, err := op.run(context.Background(), s.span, result)
+	s.NoError(err)
+	sortedResult := outputs[0].(*milvuspb.SearchResults)
+	s.Equal([]int64{2, 3, 1}, sortedResult.Results.Ids.GetIntId().Data)
+	s.Equal(
+		[]string{"first", "second", "third"},
+		sortedResult.Results.FieldsData[1].GetScalars().GetStringData().Data,
+	)
+}
+
 // Test compareNulls helper function
 func (s *SearchPipelineSuite) TestCompareNulls() {
 	// Empty ValidData - should return (0, false)

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -906,7 +906,7 @@ func GenNullableFieldData(field *schemapb.FieldSchema, upsertIDSize int) (*schem
 			},
 		}, nil
 
-	case schemapb.DataType_VarChar:
+	case schemapb.DataType_VarChar, schemapb.DataType_Text:
 		return &schemapb.FieldData{
 			FieldId:   field.FieldID,
 			FieldName: field.Name,

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -2843,6 +2843,7 @@ func TestUpsertTask_GenNullableFieldData(t *testing.T) {
 			{"Float", schemapb.DataType_Float},
 			{"Double", schemapb.DataType_Double},
 			{"VarChar", schemapb.DataType_VarChar},
+			{"Text", schemapb.DataType_Text},
 			{"JSON", schemapb.DataType_JSON},
 			{"Array", schemapb.DataType_Array},
 			{"Timestamptz", schemapb.DataType_Timestamptz},
@@ -2858,8 +2859,8 @@ func TestUpsertTask_GenNullableFieldData(t *testing.T) {
 					Nullable: true,
 				}
 				result, err := GenNullableFieldData(field, upsertIDSize)
-				assert.NoError(t, err)
-				assert.NotNil(t, result)
+				require.NoError(t, err)
+				require.NotNil(t, result)
 				assert.Equal(t, field.FieldID, result.FieldId)
 				assert.Equal(t, field.Name, result.FieldName)
 				assert.Equal(t, tc.dataType, result.Type)
@@ -2867,6 +2868,9 @@ func TestUpsertTask_GenNullableFieldData(t *testing.T) {
 				// All ValidData should be false (null)
 				for _, v := range result.ValidData {
 					assert.False(t, v)
+				}
+				if tc.dataType == schemapb.DataType_Text {
+					assert.Len(t, result.GetScalars().GetStringData().GetData(), upsertIDSize)
 				}
 			})
 		}

--- a/tests/restful_client_v2/README.md
+++ b/tests/restful_client_v2/README.md
@@ -5,5 +5,5 @@ install milvus with authentication enabled
 
 ```bash
 pip install -r requirements.txt
-pytest testcases --tags L0 L1 -n 6 -v --endpoint http://127.0.0.1:19530 --minio_host 127.0.0.1
+pytest testcases --tags L0 L1 -n 6 --dist loadgroup -v --endpoint http://127.0.0.1:19530 --minio_host 127.0.0.1
 ```

--- a/tests/restful_client_v2/testcases/test_text_lob.py
+++ b/tests/restful_client_v2/testcases/test_text_lob.py
@@ -1,0 +1,395 @@
+import hashlib
+import random
+
+import pytest
+from base.testbase import TestBase
+from utils.constant import CaseLabel
+from utils.utils import gen_collection_name
+
+DIM = 16
+ID_FIELD = "id"
+VECTOR_FIELD = "vector"
+CONTENT_FIELD = "content"
+CONTENT_ZH_FIELD = "content_zh"
+CONTENT_ALT_FIELD = "content_alt"
+CONTENT_DEFAULT_FIELD = "content_default"
+VARCHAR_TEXT_FIELD = "varchar_text"
+CONTENT_SPARSE_FIELD = "content_sparse"
+CONTENT_ZH_SPARSE_FIELD = "content_zh_sparse"
+CONTENT_DEFAULT_SPARSE_FIELD = "content_default_sparse"
+
+STANDARD_ANALYZER = {"tokenizer": "standard"}
+JIEBA_ANALYZER = {
+    "tokenizer": {
+        "type": "jieba",
+        "dict": ["向量数据库", "混合搜索", "稀疏向量"],
+        "mode": "exact",
+        "hmm": False,
+    }
+}
+DEFAULT_TEXT = "milvus text lob sentinel vector database"
+EXPLICIT_DEFAULT_TEXT = "explicit default text lob marker atlas"
+TEXT_FIELDS = [CONTENT_FIELD, CONTENT_ZH_FIELD, CONTENT_ALT_FIELD, CONTENT_DEFAULT_FIELD]
+
+
+def make_text(size, seed):
+    """Return deterministic ASCII text with exact byte length."""
+    if size == 0:
+        return ""
+    base = f"seed {seed} vector database milvus text lob storage bm25 payload boundary checksum {seed} "
+    return (base * ((size // len(base)) + 1))[:size]
+
+
+def payload_meta(value):
+    if value is None:
+        return {"state": "null", "bytes": None, "chars": None, "prefix": None, "suffix": None, "sha256": None}
+    encoded = value.encode("utf-8")
+    return {
+        "state": "empty" if value == "" else "value",
+        "bytes": len(encoded),
+        "chars": len(value),
+        "prefix": value[:32],
+        "suffix": value[-32:] if value else "",
+        "sha256": hashlib.sha256(encoded).hexdigest(),
+    }
+
+
+def assert_text_payload(actual, expected):
+    actual_meta = payload_meta(actual)
+    for key in ["state", "bytes", "chars", "prefix", "suffix", "sha256"]:
+        assert actual_meta[key] == expected[key], (
+            f"text payload mismatch on {key}: actual={actual_meta[key]!r}, "
+            f"expected={expected[key]!r}, actual_meta={actual_meta}, expected_meta={expected}"
+        )
+
+
+def vector_for_pk(pk):
+    rng = random.Random(19530 + pk)
+    return [rng.random() for _ in range(DIM)]
+
+
+def build_row(
+    pk,
+    scenario,
+    content,
+    content_zh=None,
+    content_alt=None,
+    varchar_text=None,
+    content_default=DEFAULT_TEXT,
+):
+    if content_zh is None and content is not None and len(content) <= 4096:
+        content_zh = content
+    if content_alt is None and content is not None:
+        content_alt = f"alternate text lob payload for {scenario}: {content[:128]}"
+    if varchar_text is None:
+        varchar_text = content if content is not None and len(content) <= 60000 else f"{scenario} vector database"
+
+    row = {
+        ID_FIELD: pk,
+        VECTOR_FIELD: vector_for_pk(pk),
+        "category": scenario,
+        "score": float(pk) / 10.0,
+        "json_meta": {
+            "scenario": scenario,
+            "content_sha256": None if content is None else hashlib.sha256(content.encode("utf-8")).hexdigest(),
+            "content_bytes": None if content is None else len(content.encode("utf-8")),
+        },
+        CONTENT_FIELD: content,
+        CONTENT_ZH_FIELD: content_zh,
+        CONTENT_ALT_FIELD: content_alt,
+        VARCHAR_TEXT_FIELD: varchar_text,
+        "dynamic_note": f"dynamic-{scenario}",
+    }
+    if content_default is not None:
+        row[CONTENT_DEFAULT_FIELD] = content_default
+    return row
+
+
+def build_text_lob_rows():
+    rows = [
+        build_row(0, "small", "vector database milvus text lob smoke"),
+        build_row(1, "empty", "", content_zh="", content_alt="", varchar_text=""),
+        build_row(2, "null", None, content_zh=None, content_alt=None, varchar_text=None),
+        build_row(
+            3,
+            "unicode",
+            "Milvus stores multilingual text: English 中文 日本語 Русский العربية emoji 😀🚀 데이터베이스",
+            content_zh="向量数据库 支持 中文检索 和 混合搜索",
+            varchar_text="Milvus stores multilingual text vector database emoji",
+        ),
+        build_row(8, "bm25_low", "vector database"),
+        build_row(9, "bm25_mid", "vector database " * 4 + "milvus retrieval"),
+        build_row(10, "bm25_high", "vector database " * 12 + "milvus bm25 ranking ranking"),
+        build_row(
+            11,
+            "chinese",
+            "english sidecar text for chinese bm25",
+            content_zh="向量数据库 支持 中文检索。Milvus 提供 混合搜索 和 稀疏向量 检索。",
+            varchar_text="chinese vector database sidecar",
+        ),
+        build_row(12, "sentinel", "explicit row that verifies sentinel text output"),
+        build_row(
+            13,
+            "default_explicit",
+            "row that explicitly sets default text field",
+            content_default=EXPLICIT_DEFAULT_TEXT,
+        ),
+        build_row(4, "below_64k", make_text(64 * 1024 - 17, "0-below")),
+        build_row(5, "at_64k", make_text(64 * 1024, "0-at")),
+        build_row(6, "above_64k", make_text(64 * 1024 + 4096, "0-above")),
+        build_row(
+            7,
+            "one_mib",
+            make_text(1024 * 1024, "0-one-mib"),
+            content_zh=None,
+            content_alt=make_text(128 * 1024, "0-alt-one-mib"),
+            varchar_text="one mib vector database",
+        ),
+    ]
+    return sorted(rows, key=lambda row: row[ID_FIELD])
+
+
+def expected_payloads(rows):
+    return {
+        row[ID_FIELD]: {field: payload_meta(row.get(field)) for field in TEXT_FIELDS + [VARCHAR_TEXT_FIELD]}
+        for row in rows
+    }
+
+
+def text_field(field_name, analyzer_params):
+    return {
+        "fieldName": field_name,
+        "dataType": "Text",
+        "nullable": True,
+        "elementTypeParams": {
+            "enable_analyzer": True,
+            "enable_match": True,
+            "analyzer_params": analyzer_params,
+        },
+    }
+
+
+def build_collection_payload(collection_name):
+    return {
+        "collectionName": collection_name,
+        "schema": {
+            "autoId": False,
+            "enableDynamicField": True,
+            "fields": [
+                {"fieldName": ID_FIELD, "dataType": "Int64", "isPrimary": True},
+                {"fieldName": VECTOR_FIELD, "dataType": "FloatVector", "elementTypeParams": {"dim": str(DIM)}},
+                {"fieldName": "category", "dataType": "VarChar", "elementTypeParams": {"max_length": "64"}},
+                {"fieldName": "score", "dataType": "Float"},
+                {"fieldName": "json_meta", "dataType": "JSON"},
+                text_field(CONTENT_FIELD, STANDARD_ANALYZER),
+                text_field(CONTENT_ZH_FIELD, JIEBA_ANALYZER),
+                text_field(CONTENT_ALT_FIELD, STANDARD_ANALYZER),
+                text_field(CONTENT_DEFAULT_FIELD, STANDARD_ANALYZER),
+                {
+                    "fieldName": VARCHAR_TEXT_FIELD,
+                    "dataType": "VarChar",
+                    "nullable": True,
+                    "elementTypeParams": {
+                        "max_length": "65535",
+                        "enable_analyzer": True,
+                        "enable_match": True,
+                        "analyzer_params": STANDARD_ANALYZER,
+                    },
+                },
+                {"fieldName": CONTENT_SPARSE_FIELD, "dataType": "SparseFloatVector"},
+                {"fieldName": CONTENT_ZH_SPARSE_FIELD, "dataType": "SparseFloatVector"},
+                {"fieldName": CONTENT_DEFAULT_SPARSE_FIELD, "dataType": "SparseFloatVector"},
+            ],
+            "functions": [
+                {
+                    "name": "content_bm25",
+                    "type": "BM25",
+                    "inputFieldNames": [CONTENT_FIELD],
+                    "outputFieldNames": [CONTENT_SPARSE_FIELD],
+                    "params": {},
+                },
+                {
+                    "name": "content_zh_bm25",
+                    "type": "BM25",
+                    "inputFieldNames": [CONTENT_ZH_FIELD],
+                    "outputFieldNames": [CONTENT_ZH_SPARSE_FIELD],
+                    "params": {},
+                },
+                {
+                    "name": "content_default_bm25",
+                    "type": "BM25",
+                    "inputFieldNames": [CONTENT_DEFAULT_FIELD],
+                    "outputFieldNames": [CONTENT_DEFAULT_SPARSE_FIELD],
+                    "params": {},
+                },
+            ],
+        },
+        "indexParams": [
+            {
+                "fieldName": VECTOR_FIELD,
+                "indexName": VECTOR_FIELD,
+                "indexType": "FLAT",
+                "metricType": "COSINE",
+            },
+            {
+                "fieldName": CONTENT_SPARSE_FIELD,
+                "indexName": CONTENT_SPARSE_FIELD,
+                "indexType": "SPARSE_INVERTED_INDEX",
+                "metricType": "BM25",
+            },
+            {
+                "fieldName": CONTENT_ZH_SPARSE_FIELD,
+                "indexName": CONTENT_ZH_SPARSE_FIELD,
+                "indexType": "SPARSE_INVERTED_INDEX",
+                "metricType": "BM25",
+            },
+            {
+                "fieldName": CONTENT_DEFAULT_SPARSE_FIELD,
+                "indexName": CONTENT_DEFAULT_SPARSE_FIELD,
+                "indexType": "SPARSE_INVERTED_INDEX",
+                "metricType": "BM25",
+            },
+            {
+                "fieldName": VARCHAR_TEXT_FIELD,
+                "indexName": VARCHAR_TEXT_FIELD,
+                "indexType": "AUTOINDEX",
+            },
+        ],
+        "params": {"consistencyLevel": "Strong"},
+    }
+
+
+def assert_rows_payload(rows_by_id, expected, fields):
+    assert set(rows_by_id) == set(expected), f"row ids mismatch: actual={set(rows_by_id)}, expected={set(expected)}"
+    for pk, row in rows_by_id.items():
+        for field in fields:
+            assert_text_payload(row.get(field), expected[pk][field])
+
+
+@pytest.mark.xdist_group("TestTextLOB")
+class TestTextLOB(TestBase):
+    shared_rows = []
+    shared_expected = {}
+    shared_ids = []
+
+    def setup_class(self):
+        self.collection_name = gen_collection_name(prefix="rest_text_lob")
+
+    @pytest.fixture(scope="class", autouse=True)
+    def prepare_text_lob_collection(self, request, init_class_config):
+        collection_client, vector_client = self._class_scope_clients()
+
+        def teardown():
+            collection_client.collection_drop({"collectionName": self.collection_name})
+
+        request.addfinalizer(teardown)
+        self.__class__.shared_rows = build_text_lob_rows()
+        self.__class__.shared_expected = expected_payloads(self.shared_rows)
+        self.__class__.shared_ids = [row[ID_FIELD] for row in self.shared_rows]
+
+        rsp = collection_client.collection_create(build_collection_payload(self.collection_name))
+        assert rsp["code"] == 0, rsp
+        collection_client.wait_load_completed(self.collection_name, timeout=120)
+        rsp = vector_client.vector_insert({"collectionName": self.collection_name, "data": self.shared_rows})
+        assert rsp["code"] == 0, rsp
+        assert rsp["data"]["insertCount"] == len(self.shared_rows)
+        rsp = collection_client.flush(self.collection_name)
+        assert rsp["code"] == 0, rsp
+
+    def query_page(self, output_fields, limit, offset=0):
+        rsp = self.vector_client.vector_query(
+            {
+                "collectionName": self.collection_name,
+                "filter": f"{ID_FIELD} >= 0",
+                "outputFields": list(dict.fromkeys([ID_FIELD] + output_fields)),
+                "limit": limit,
+                "offset": offset,
+            },
+            timeout=30,
+        )
+        assert rsp["code"] == 0, rsp
+        return rsp["data"]
+
+    def query_rows(self, output_fields):
+        rows = self.query_page(output_fields, len(self.shared_rows))
+        return {int(row[ID_FIELD]): row for row in rows}
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_text_lob_shared_schema_and_payloads(self):
+        """
+        target: verify TEXT LOB schema, BM25 indexes, and exact payload retrieval
+        method: describe the shared collection and query every deterministic row
+        expected: TEXT fields and functions exist and payload checksums match inserted data
+        """
+        rsp = self.collection_client.collection_describe(self.collection_name)
+        assert rsp["code"] == 0, rsp
+        fields = {field["name"]: field for field in rsp["data"]["fields"]}
+        for field_name in TEXT_FIELDS:
+            assert fields[field_name]["type"].lower() == "text"
+
+        functions = {function["name"]: function for function in rsp["data"]["functions"]}
+        for function_name, input_field, output_field in [
+            ("content_bm25", CONTENT_FIELD, CONTENT_SPARSE_FIELD),
+            ("content_zh_bm25", CONTENT_ZH_FIELD, CONTENT_ZH_SPARSE_FIELD),
+            ("content_default_bm25", CONTENT_DEFAULT_FIELD, CONTENT_DEFAULT_SPARSE_FIELD),
+        ]:
+            function = functions[function_name]
+            assert function["type"] == 1
+            assert function["inputFieldNames"] == [input_field]
+            assert function["outputFieldNames"] == [output_field]
+
+        for index_name in [CONTENT_SPARSE_FIELD, CONTENT_ZH_SPARSE_FIELD, CONTENT_DEFAULT_SPARSE_FIELD]:
+            rsp = self.index_client.index_describe(self.collection_name, index_name)
+            assert rsp["code"] == 0, rsp
+            index = next(item for item in rsp["data"] if item["indexName"] == index_name)
+            assert index["indexType"] == "SPARSE_INVERTED_INDEX"
+            assert index["metricType"] == "BM25"
+
+        rows_by_id = self.query_rows(TEXT_FIELDS + [VARCHAR_TEXT_FIELD])
+        assert_rows_payload(rows_by_id, self.shared_expected, TEXT_FIELDS + [VARCHAR_TEXT_FIELD])
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_text_lob_dense_search_output_fields(self):
+        """
+        target: verify dense vector search returns TEXT LOB output fields
+        method: search with an exact fixture vector and validate returned TEXT checksums
+        expected: every returned content and content_alt payload matches inserted data
+        """
+        rsp = self.vector_client.vector_search(
+            {
+                "collectionName": self.collection_name,
+                "data": [vector_for_pk(0)],
+                "annsField": VECTOR_FIELD,
+                "limit": 3,
+                "outputFields": [ID_FIELD, CONTENT_FIELD, CONTENT_ALT_FIELD],
+            },
+            timeout=30,
+        )
+        assert rsp["code"] == 0, rsp
+        assert 0 < len(rsp["data"]) <= 3
+        ids = [int(hit[ID_FIELD]) for hit in rsp["data"]]
+        assert len(ids) == len(set(ids))
+        assert 0 in ids
+        for hit in rsp["data"]:
+            pk = int(hit[ID_FIELD])
+            assert_text_payload(hit.get(CONTENT_FIELD), self.shared_expected[pk][CONTENT_FIELD])
+            assert_text_payload(hit.get(CONTENT_ALT_FIELD), self.shared_expected[pk][CONTENT_ALT_FIELD])
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_text_lob_query_iterator_payloads(self):
+        """
+        target: verify REST query returns every TEXT LOB row exactly once
+        method: page through REST query in batches of three because REST v2 has no query iterator endpoint
+        expected: no primary keys are missing or duplicated and every TEXT payload is intact
+        """
+        batch_size = 3
+        rows = []
+        for offset in range(0, len(self.shared_rows), batch_size):
+            page = self.query_page([CONTENT_FIELD], batch_size, offset)
+            assert len(page) == min(batch_size, len(self.shared_rows) - offset)
+            rows.extend(page)
+
+        rows_by_id = {int(row[ID_FIELD]): row for row in rows}
+        assert len(rows) == len(self.shared_rows)
+        assert len(rows_by_id) == len(rows), "REST query pagination returned duplicate primary keys"
+        assert_rows_payload(rows_by_id, self.shared_expected, [CONTENT_FIELD])

--- a/tests/restful_client_v2/testcases/test_text_lob.py
+++ b/tests/restful_client_v2/testcases/test_text_lob.py
@@ -1,8 +1,14 @@
 import hashlib
 import random
+import time
+from urllib.parse import urlsplit, urlunsplit
 
 import pytest
+import requests
+from api.milvus import IndexClient
 from base.testbase import TestBase
+from pymilvus import connections, utility
+from pymilvus.grpc_gen import common_pb2
 from utils.constant import CaseLabel
 from utils.utils import gen_collection_name
 
@@ -30,6 +36,20 @@ JIEBA_ANALYZER = {
 DEFAULT_TEXT = "milvus text lob sentinel vector database"
 EXPLICIT_DEFAULT_TEXT = "explicit default text lob marker atlas"
 TEXT_FIELDS = [CONTENT_FIELD, CONTENT_ZH_FIELD, CONTENT_ALT_FIELD, CONTENT_DEFAULT_FIELD]
+
+INDEXED_SEALED_ROWS = 3000
+UNINDEXED_SEALED_ROWS = 500
+GROWING_ROWS = 500
+TOTAL_ROWS = INDEXED_SEALED_ROWS + UNINDEXED_SEALED_ROWS + GROWING_ROWS
+INDEXED_SEALED_RANGE = range(0, INDEXED_SEALED_ROWS)
+UNINDEXED_SEALED_RANGE = range(INDEXED_SEALED_ROWS, INDEXED_SEALED_ROWS + UNINDEXED_SEALED_ROWS)
+GROWING_RANGE = range(INDEXED_SEALED_ROWS + UNINDEXED_SEALED_ROWS, TOTAL_ROWS)
+LOB_MARKER_IDS = {
+    "sealed_indexed": 7,
+    "sealed_unindexed": INDEXED_SEALED_ROWS + UNINDEXED_SEALED_ROWS // 2,
+    "growing": INDEXED_SEALED_ROWS + UNINDEXED_SEALED_ROWS + GROWING_ROWS // 2,
+}
+LOB_SEARCH_VECTOR = [1.0] + [0.0] * (DIM - 1)
 
 
 def make_text(size, seed):
@@ -76,6 +96,7 @@ def build_row(
     content_alt=None,
     varchar_text=None,
     content_default=DEFAULT_TEXT,
+    vector=None,
 ):
     if content_zh is None and content is not None and len(content) <= 4096:
         content_zh = content
@@ -86,7 +107,7 @@ def build_row(
 
     row = {
         ID_FIELD: pk,
-        VECTOR_FIELD: vector_for_pk(pk),
+        VECTOR_FIELD: vector if vector is not None else vector_for_pk(pk),
         "category": scenario,
         "score": float(pk) / 10.0,
         "json_meta": {
@@ -139,14 +160,43 @@ def build_text_lob_rows():
         build_row(6, "above_64k", make_text(64 * 1024 + 4096, "0-above")),
         build_row(
             7,
-            "one_mib",
+            "sealed_indexed_lob",
             make_text(1024 * 1024, "0-one-mib"),
             content_zh=None,
             content_alt=make_text(128 * 1024, "0-alt-one-mib"),
             varchar_text="one mib vector database",
+            vector=LOB_SEARCH_VECTOR,
         ),
     ]
-    return sorted(rows, key=lambda row: row[ID_FIELD])
+    rows_by_id = {row[ID_FIELD]: row for row in rows}
+    for pk in INDEXED_SEALED_RANGE:
+        rows_by_id.setdefault(
+            pk,
+            build_row(pk, "sealed_indexed", f"indexed sealed text lob fixture row {pk} vector database"),
+        )
+    for pk in UNINDEXED_SEALED_RANGE:
+        rows_by_id[pk] = build_row(
+            pk,
+            "sealed_unindexed_lob" if pk == LOB_MARKER_IDS["sealed_unindexed"] else "sealed_unindexed",
+            make_text(256 * 1024, "1-sealed-unindexed")
+            if pk == LOB_MARKER_IDS["sealed_unindexed"]
+            else f"unindexed sealed text lob fixture row {pk} vector database",
+            content_alt=make_text(128 * 1024, "1-alt-sealed-unindexed")
+            if pk == LOB_MARKER_IDS["sealed_unindexed"]
+            else None,
+            vector=LOB_SEARCH_VECTOR if pk == LOB_MARKER_IDS["sealed_unindexed"] else None,
+        )
+    for pk in GROWING_RANGE:
+        rows_by_id[pk] = build_row(
+            pk,
+            "growing_lob" if pk == LOB_MARKER_IDS["growing"] else "growing",
+            make_text(256 * 1024, "2-growing")
+            if pk == LOB_MARKER_IDS["growing"]
+            else f"growing text lob fixture row {pk} vector database",
+            content_alt=make_text(128 * 1024, "2-alt-growing") if pk == LOB_MARKER_IDS["growing"] else None,
+            vector=LOB_SEARCH_VECTOR if pk == LOB_MARKER_IDS["growing"] else None,
+        )
+    return [rows_by_id[pk] for pk in range(TOTAL_ROWS)]
 
 
 def expected_payloads(rows):
@@ -224,13 +274,29 @@ def build_collection_payload(collection_name):
                 },
             ],
         },
+        "params": {"consistencyLevel": "Strong"},
+    }
+
+
+def build_dense_index_payload(collection_name):
+    return {
+        "collectionName": collection_name,
         "indexParams": [
             {
                 "fieldName": VECTOR_FIELD,
                 "indexName": VECTOR_FIELD,
-                "indexType": "FLAT",
+                "indexType": "HNSW",
                 "metricType": "COSINE",
+                "params": {"M": 16, "efConstruction": 200},
             },
+        ],
+    }
+
+
+def build_text_index_payload(collection_name):
+    return {
+        "collectionName": collection_name,
+        "indexParams": [
             {
                 "fieldName": CONTENT_SPARSE_FIELD,
                 "indexName": CONTENT_SPARSE_FIELD,
@@ -255,8 +321,121 @@ def build_collection_payload(collection_name):
                 "indexType": "AUTOINDEX",
             },
         ],
-        "params": {"consistencyLevel": "Strong"},
     }
+
+
+def management_get(endpoint, api_key, path, params=None):
+    """Read Milvus management metadata from the metrics port."""
+    parsed = urlsplit(endpoint if "://" in endpoint else f"http://{endpoint}")
+    management_endpoint = urlunsplit((parsed.scheme, f"{parsed.hostname}:9091", f"/api/v1{path}", "", ""))
+    rsp = requests.get(
+        management_endpoint,
+        params=params,
+        headers={"Authorization": f"Bearer {api_key}"},
+        timeout=10,
+    )
+    assert rsp.status_code == 200, f"management request failed: status={rsp.status_code}, body={rsp.text}"
+    return rsp.json()
+
+
+def has_materialized_index(segment, field_id):
+    return any(
+        int(index["field_id"]) == field_id
+        and str(index.get("is_loaded", False)).lower() == "true"
+        and int(index.get("index_size", 0)) > 0
+        for index in segment.get("index_fields", [])
+    )
+
+
+def wait_for_segment_paths(
+    collection_name,
+    collection_id,
+    dense_field_id,
+    connection_alias,
+    endpoint,
+    api_key,
+    timeout=120,
+):
+    """Wait until metadata proves the indexed and raw sealed paths."""
+    deadline = time.monotonic() + timeout
+    last_infos = []
+    last_query_node_segments = []
+    while time.monotonic() < deadline:
+        last_infos = utility.get_query_segment_info(collection_name, using=connection_alias)
+        last_query_node_segments = management_get(
+            endpoint,
+            api_key,
+            "/_qn/segments",
+            params={"collection_id": collection_id, "in": "qn"},
+        )
+        indexed = [
+            segment
+            for segment in last_query_node_segments
+            if segment["state"] == "Sealed"
+            and int(segment["loaded_insert_row_count"]) == INDEXED_SEALED_ROWS
+            and has_materialized_index(segment, dense_field_id)
+        ]
+        unindexed = [
+            segment
+            for segment in last_query_node_segments
+            if segment["state"] == "Sealed"
+            and int(segment["loaded_insert_row_count"]) == UNINDEXED_SEALED_ROWS
+            and not has_materialized_index(segment, dense_field_id)
+        ]
+        query_segment_ids = {info.segmentID for info in last_infos}
+        metadata_segment_ids = {int(segment["segment_id"]) for segment in last_query_node_segments}
+        if (
+            len(last_infos) == 2
+            and len(last_query_node_segments) == 2
+            and len(indexed) == 1
+            and len(unindexed) == 1
+            and query_segment_ids == metadata_segment_ids
+        ):
+            assert all(info.state == common_pb2.SegmentState.Sealed for info in last_infos)
+            return last_infos
+        time.sleep(1)
+    raise AssertionError(
+        f"expected indexed and unindexed sealed paths, last segment infos: {last_infos}, "
+        f"last query node segments: {last_query_node_segments}"
+    )
+
+
+def wait_for_growing_path(collection_id, dense_field_id, sealed_segment_ids, endpoint, api_key, timeout=120):
+    """Wait until QueryNode metadata exposes the final 500-row growing path."""
+    deadline = time.monotonic() + timeout
+    last_segments = []
+    while time.monotonic() < deadline:
+        last_segments = management_get(
+            endpoint,
+            api_key,
+            "/_qn/segments",
+            params={"collection_id": collection_id, "in": "qn"},
+        )
+        growing = [
+            segment
+            for segment in last_segments
+            if segment["state"] == "Growing"
+            and int(segment["loaded_insert_row_count"]) == GROWING_ROWS
+            and not has_materialized_index(segment, dense_field_id)
+        ]
+        current_sealed_ids = {int(segment["segment_id"]) for segment in last_segments if segment["state"] == "Sealed"}
+        if len(last_segments) == 3 and len(growing) == 1 and current_sealed_ids == set(sealed_segment_ids):
+            return growing[0]
+        time.sleep(1)
+    raise AssertionError(f"expected 500-row growing path, last query node segments: {last_segments}")
+
+
+def flush_collection(collection_client, collection_name, timeout=30):
+    """Retry only the expected flush rate-limit response within a bounded window."""
+    deadline = time.monotonic() + timeout
+    while True:
+        rsp = collection_client.flush(collection_name)
+        if rsp["code"] == 0:
+            return
+        is_rate_limited = rsp["code"] == 1807 and "rate limit exceeded" in rsp.get("message", "")
+        if not is_rate_limited or time.monotonic() >= deadline:
+            raise AssertionError(f"flush failed: {rsp}")
+        time.sleep(1)
 
 
 def assert_rows_payload(rows_by_id, expected, fields):
@@ -271,6 +450,7 @@ class TestTextLOB(TestBase):
     shared_rows = []
     shared_expected = {}
     shared_ids = []
+    shared_sealed_segment_ids = []
 
     def setup_class(self):
         self.collection_name = gen_collection_name(prefix="rest_text_lob")
@@ -278,23 +458,105 @@ class TestTextLOB(TestBase):
     @pytest.fixture(scope="class", autouse=True)
     def prepare_text_lob_collection(self, request, init_class_config):
         collection_client, vector_client = self._class_scope_clients()
+        index_client = IndexClient(self.endpoint, self.api_key)
+        connection_alias = self.collection_name
+        connections.connect(alias=connection_alias, uri=self.endpoint, token=self.api_key)
 
         def teardown():
             collection_client.collection_drop({"collectionName": self.collection_name})
+            connections.disconnect(connection_alias)
 
         request.addfinalizer(teardown)
         self.__class__.shared_rows = build_text_lob_rows()
         self.__class__.shared_expected = expected_payloads(self.shared_rows)
         self.__class__.shared_ids = [row[ID_FIELD] for row in self.shared_rows]
+        assert len(self.shared_rows) == TOTAL_ROWS
+
+        configs = management_get(self.endpoint, self.api_key, "/_cluster/configs")
+        index_threshold = int(configs["indexcoord.segment.minsegmentnumrowstoenableindex"].split("[", 1)[0])
+        assert UNINDEXED_SEALED_ROWS < index_threshold <= INDEXED_SEALED_ROWS
 
         rsp = collection_client.collection_create(build_collection_payload(self.collection_name))
         assert rsp["code"] == 0, rsp
+
+        indexed_rows = self.shared_rows[:INDEXED_SEALED_ROWS]
+        rsp = vector_client.vector_insert({"collectionName": self.collection_name, "data": indexed_rows})
+        assert rsp["code"] == 0, rsp
+        assert rsp["data"]["insertCount"] == INDEXED_SEALED_ROWS
+        flush_collection(collection_client, self.collection_name)
+
+        unindexed_rows = self.shared_rows[INDEXED_SEALED_ROWS : INDEXED_SEALED_ROWS + UNINDEXED_SEALED_ROWS]
+        rsp = vector_client.vector_insert({"collectionName": self.collection_name, "data": unindexed_rows})
+        assert rsp["code"] == 0, rsp
+        assert rsp["data"]["insertCount"] == UNINDEXED_SEALED_ROWS
+        flush_collection(collection_client, self.collection_name)
+
+        rsp = index_client.index_create(build_dense_index_payload(self.collection_name))
+        assert rsp["code"] == 0, rsp
+        assert utility.wait_for_index_building_complete(
+            self.collection_name,
+            index_name=VECTOR_FIELD,
+            timeout=300,
+            using=connection_alias,
+        )
+
+        rsp = index_client.index_create(build_text_index_payload(self.collection_name))
+        assert rsp["code"] == 0, rsp
+        for index_name in [
+            CONTENT_SPARSE_FIELD,
+            CONTENT_ZH_SPARSE_FIELD,
+            CONTENT_DEFAULT_SPARSE_FIELD,
+            VARCHAR_TEXT_FIELD,
+        ]:
+            assert utility.wait_for_index_building_complete(
+                self.collection_name,
+                index_name=index_name,
+                timeout=300,
+                using=connection_alias,
+            )
+
+        rsp = collection_client.collection_load(collection_name=self.collection_name)
+        assert rsp["code"] == 0, rsp
         collection_client.wait_load_completed(self.collection_name, timeout=120)
-        rsp = vector_client.vector_insert({"collectionName": self.collection_name, "data": self.shared_rows})
+        rsp = collection_client.collection_describe(self.collection_name)
         assert rsp["code"] == 0, rsp
-        assert rsp["data"]["insertCount"] == len(self.shared_rows)
-        rsp = collection_client.flush(self.collection_name)
+        collection_id = int(rsp["data"]["collectionID"])
+        dense_field_id = int(next(field["id"] for field in rsp["data"]["fields"] if field["name"] == VECTOR_FIELD))
+        sealed_infos = wait_for_segment_paths(
+            self.collection_name,
+            collection_id,
+            dense_field_id,
+            connection_alias,
+            self.endpoint,
+            self.api_key,
+        )
+        self.__class__.shared_sealed_segment_ids = [info.segmentID for info in sealed_infos]
+
+        growing_rows = self.shared_rows[INDEXED_SEALED_ROWS + UNINDEXED_SEALED_ROWS :]
+        rsp = vector_client.vector_insert({"collectionName": self.collection_name, "data": growing_rows})
         assert rsp["code"] == 0, rsp
+        assert rsp["data"]["insertCount"] == GROWING_ROWS
+
+        rsp = vector_client.vector_query(
+            {
+                "collectionName": self.collection_name,
+                "filter": f"{ID_FIELD} >= 0",
+                "outputFields": ["count(*)"],
+            }
+        )
+        assert rsp["code"] == 0, rsp
+        assert rsp["data"] == [{"count(*)": TOTAL_ROWS}], rsp
+
+        wait_for_growing_path(
+            collection_id,
+            dense_field_id,
+            self.shared_sealed_segment_ids,
+            self.endpoint,
+            self.api_key,
+        )
+        after_growing_infos = utility.get_query_segment_info(self.collection_name, using=connection_alias)
+        assert {info.segmentID for info in after_growing_infos} == set(self.shared_sealed_segment_ids)
+        assert sum(info.num_rows for info in after_growing_infos) == INDEXED_SEALED_ROWS + UNINDEXED_SEALED_ROWS
 
     def query_page(self, output_fields, limit, offset=0):
         rsp = self.vector_client.vector_query(
@@ -318,8 +580,9 @@ class TestTextLOB(TestBase):
     def test_text_lob_shared_schema_and_payloads(self):
         """
         target: verify TEXT LOB schema, BM25 indexes, and exact payload retrieval
-        method: describe the shared collection and query every deterministic row
-        expected: TEXT fields and functions exist and payload checksums match inserted data
+        method: describe the shared collection and query 4,000 rows across indexed sealed,
+            unindexed sealed, and growing paths
+        expected: every path participates and every TEXT payload checksum matches inserted data
         """
         rsp = self.collection_client.collection_describe(self.collection_name)
         assert rsp["code"] == 0, rsp
@@ -338,6 +601,12 @@ class TestTextLOB(TestBase):
             assert function["inputFieldNames"] == [input_field]
             assert function["outputFieldNames"] == [output_field]
 
+        rsp = self.index_client.index_describe(self.collection_name, VECTOR_FIELD)
+        assert rsp["code"] == 0, rsp
+        dense_index = next(item for item in rsp["data"] if item["indexName"] == VECTOR_FIELD)
+        assert dense_index["indexType"] == "HNSW"
+        assert dense_index["metricType"] == "COSINE"
+
         for index_name in [CONTENT_SPARSE_FIELD, CONTENT_ZH_SPARSE_FIELD, CONTENT_DEFAULT_SPARSE_FIELD]:
             rsp = self.index_client.index_describe(self.collection_name, index_name)
             assert rsp["code"] == 0, rsp
@@ -347,29 +616,36 @@ class TestTextLOB(TestBase):
 
         rows_by_id = self.query_rows(TEXT_FIELDS + [VARCHAR_TEXT_FIELD])
         assert_rows_payload(rows_by_id, self.shared_expected, TEXT_FIELDS + [VARCHAR_TEXT_FIELD])
+        assert len(set(rows_by_id).intersection(INDEXED_SEALED_RANGE)) == INDEXED_SEALED_ROWS
+        assert len(set(rows_by_id).intersection(UNINDEXED_SEALED_RANGE)) == UNINDEXED_SEALED_ROWS
+        assert len(set(rows_by_id).intersection(GROWING_RANGE)) == GROWING_ROWS
+
+        for marker_id in LOB_MARKER_IDS.values():
+            assert self.shared_expected[marker_id][CONTENT_FIELD]["bytes"] > 64 * 1024
+            assert self.shared_expected[marker_id][CONTENT_ALT_FIELD]["bytes"] > 64 * 1024
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_text_lob_dense_search_output_fields(self):
         """
         target: verify dense vector search returns TEXT LOB output fields
-        method: search with an exact fixture vector and validate returned TEXT checksums
-        expected: every returned content and content_alt payload matches inserted data
+        method: search the shared vector used only by one LOB row in each segment path
+        expected: all three paths return intact content and content_alt payloads
         """
         rsp = self.vector_client.vector_search(
             {
                 "collectionName": self.collection_name,
-                "data": [vector_for_pk(0)],
+                "data": [LOB_SEARCH_VECTOR],
                 "annsField": VECTOR_FIELD,
                 "limit": 3,
+                "searchParams": {"metricType": "COSINE", "params": {"ef": 64}},
                 "outputFields": [ID_FIELD, CONTENT_FIELD, CONTENT_ALT_FIELD],
             },
             timeout=30,
         )
         assert rsp["code"] == 0, rsp
-        assert 0 < len(rsp["data"]) <= 3
+        assert len(rsp["data"]) == len(LOB_MARKER_IDS)
         ids = [int(hit[ID_FIELD]) for hit in rsp["data"]]
-        assert len(ids) == len(set(ids))
-        assert 0 in ids
+        assert set(ids) == set(LOB_MARKER_IDS.values())
         for hit in rsp["data"]:
             pk = int(hit[ID_FIELD])
             assert_text_payload(hit.get(CONTENT_FIELD), self.shared_expected[pk][CONTENT_FIELD])

--- a/tests/restful_client_v2/testcases/test_text_lob.py
+++ b/tests/restful_client_v2/testcases/test_text_lob.py
@@ -1,10 +1,8 @@
 import hashlib
 import random
 import time
-from urllib.parse import urlsplit, urlunsplit
 
 import pytest
-import requests
 from api.milvus import IndexClient
 from base.testbase import TestBase
 from pymilvus import connections, utility
@@ -324,105 +322,20 @@ def build_text_index_payload(collection_name):
     }
 
 
-def management_get(endpoint, api_key, path, params=None):
-    """Read Milvus management metadata from the metrics port."""
-    parsed = urlsplit(endpoint if "://" in endpoint else f"http://{endpoint}")
-    management_endpoint = urlunsplit((parsed.scheme, f"{parsed.hostname}:9091", f"/api/v1{path}", "", ""))
-    rsp = requests.get(
-        management_endpoint,
-        params=params,
-        headers={"Authorization": f"Bearer {api_key}"},
-        timeout=10,
-    )
-    assert rsp.status_code == 200, f"management request failed: status={rsp.status_code}, body={rsp.text}"
-    return rsp.json()
-
-
-def has_materialized_index(segment, field_id):
-    return any(
-        int(index["field_id"]) == field_id
-        and str(index.get("is_loaded", False)).lower() == "true"
-        and int(index.get("index_size", 0)) > 0
-        for index in segment.get("index_fields", [])
-    )
-
-
-def wait_for_segment_paths(
-    collection_name,
-    collection_id,
-    dense_field_id,
-    connection_alias,
-    endpoint,
-    api_key,
-    timeout=120,
-):
-    """Wait until metadata proves the indexed and raw sealed paths."""
+def wait_for_sealed_layout(collection_name, connection_alias, timeout=120):
+    """Wait until public segment metadata exposes the 3,000 + 500 sealed layout."""
     deadline = time.monotonic() + timeout
     last_infos = []
-    last_query_node_segments = []
     while time.monotonic() < deadline:
         last_infos = utility.get_query_segment_info(collection_name, using=connection_alias)
-        last_query_node_segments = management_get(
-            endpoint,
-            api_key,
-            "/_qn/segments",
-            params={"collection_id": collection_id, "in": "qn"},
-        )
-        indexed = [
-            segment
-            for segment in last_query_node_segments
-            if segment["state"] == "Sealed"
-            and int(segment["loaded_insert_row_count"]) == INDEXED_SEALED_ROWS
-            and has_materialized_index(segment, dense_field_id)
-        ]
-        unindexed = [
-            segment
-            for segment in last_query_node_segments
-            if segment["state"] == "Sealed"
-            and int(segment["loaded_insert_row_count"]) == UNINDEXED_SEALED_ROWS
-            and not has_materialized_index(segment, dense_field_id)
-        ]
-        query_segment_ids = {info.segmentID for info in last_infos}
-        metadata_segment_ids = {int(segment["segment_id"]) for segment in last_query_node_segments}
-        if (
-            len(last_infos) == 2
-            and len(last_query_node_segments) == 2
-            and len(indexed) == 1
-            and len(unindexed) == 1
-            and query_segment_ids == metadata_segment_ids
-        ):
+        if len(last_infos) == 2 and sorted(info.num_rows for info in last_infos) == [
+            UNINDEXED_SEALED_ROWS,
+            INDEXED_SEALED_ROWS,
+        ]:
             assert all(info.state == common_pb2.SegmentState.Sealed for info in last_infos)
             return last_infos
         time.sleep(1)
-    raise AssertionError(
-        f"expected indexed and unindexed sealed paths, last segment infos: {last_infos}, "
-        f"last query node segments: {last_query_node_segments}"
-    )
-
-
-def wait_for_growing_path(collection_id, dense_field_id, sealed_segment_ids, endpoint, api_key, timeout=120):
-    """Wait until QueryNode metadata exposes the final 500-row growing path."""
-    deadline = time.monotonic() + timeout
-    last_segments = []
-    while time.monotonic() < deadline:
-        last_segments = management_get(
-            endpoint,
-            api_key,
-            "/_qn/segments",
-            params={"collection_id": collection_id, "in": "qn"},
-        )
-        growing = [
-            segment
-            for segment in last_segments
-            if segment["state"] == "Growing"
-            and int(segment["loaded_insert_row_count"]) == GROWING_ROWS
-            and not has_materialized_index(segment, dense_field_id)
-        ]
-        current_sealed_ids = {int(segment["segment_id"]) for segment in last_segments if segment["state"] == "Sealed"}
-        if len(last_segments) == 3 and len(growing) == 1 and current_sealed_ids == set(sealed_segment_ids):
-            return growing[0]
-        time.sleep(1)
-    raise AssertionError(f"expected 500-row growing path, last query node segments: {last_segments}")
+    raise AssertionError(f"expected 3,000 + 500 sealed rows, last segment infos: {last_infos}")
 
 
 def flush_collection(collection_client, collection_name, timeout=30):
@@ -472,10 +385,6 @@ class TestTextLOB(TestBase):
         self.__class__.shared_ids = [row[ID_FIELD] for row in self.shared_rows]
         assert len(self.shared_rows) == TOTAL_ROWS
 
-        configs = management_get(self.endpoint, self.api_key, "/_cluster/configs")
-        index_threshold = int(configs["indexcoord.segment.minsegmentnumrowstoenableindex"].split("[", 1)[0])
-        assert UNINDEXED_SEALED_ROWS < index_threshold <= INDEXED_SEALED_ROWS
-
         rsp = collection_client.collection_create(build_collection_payload(self.collection_name))
         assert rsp["code"] == 0, rsp
 
@@ -518,18 +427,7 @@ class TestTextLOB(TestBase):
         rsp = collection_client.collection_load(collection_name=self.collection_name)
         assert rsp["code"] == 0, rsp
         collection_client.wait_load_completed(self.collection_name, timeout=120)
-        rsp = collection_client.collection_describe(self.collection_name)
-        assert rsp["code"] == 0, rsp
-        collection_id = int(rsp["data"]["collectionID"])
-        dense_field_id = int(next(field["id"] for field in rsp["data"]["fields"] if field["name"] == VECTOR_FIELD))
-        sealed_infos = wait_for_segment_paths(
-            self.collection_name,
-            collection_id,
-            dense_field_id,
-            connection_alias,
-            self.endpoint,
-            self.api_key,
-        )
+        sealed_infos = wait_for_sealed_layout(self.collection_name, connection_alias)
         self.__class__.shared_sealed_segment_ids = [info.segmentID for info in sealed_infos]
 
         growing_rows = self.shared_rows[INDEXED_SEALED_ROWS + UNINDEXED_SEALED_ROWS :]
@@ -547,16 +445,11 @@ class TestTextLOB(TestBase):
         assert rsp["code"] == 0, rsp
         assert rsp["data"] == [{"count(*)": TOTAL_ROWS}], rsp
 
-        wait_for_growing_path(
-            collection_id,
-            dense_field_id,
-            self.shared_sealed_segment_ids,
-            self.endpoint,
-            self.api_key,
-        )
         after_growing_infos = utility.get_query_segment_info(self.collection_name, using=connection_alias)
         assert {info.segmentID for info in after_growing_infos} == set(self.shared_sealed_segment_ids)
-        assert sum(info.num_rows for info in after_growing_infos) == INDEXED_SEALED_ROWS + UNINDEXED_SEALED_ROWS
+        sealed_rows = sum(info.num_rows for info in after_growing_infos)
+        assert sealed_rows == INDEXED_SEALED_ROWS + UNINDEXED_SEALED_ROWS
+        assert TOTAL_ROWS - sealed_rows == GROWING_ROWS
 
     def query_page(self, output_fields, limit, offset=0):
         rsp = self.vector_client.vector_query(

--- a/tests/restful_client_v2/testcases/test_text_lob.py
+++ b/tests/restful_client_v2/testcases/test_text_lob.py
@@ -36,9 +36,10 @@ EXPLICIT_DEFAULT_TEXT = "explicit default text lob marker atlas"
 TEXT_FIELDS = [CONTENT_FIELD, CONTENT_ZH_FIELD, CONTENT_ALT_FIELD, CONTENT_DEFAULT_FIELD]
 
 INDEXED_SEALED_ROWS = 3000
-UNINDEXED_SEALED_ROWS = 500
+UNINDEXED_SEALED_ROWS = 1000
 GROWING_ROWS = 500
 TOTAL_ROWS = INDEXED_SEALED_ROWS + UNINDEXED_SEALED_ROWS + GROWING_ROWS
+TEXT_LOB_SETUP_TIMEOUT = 300
 INDEXED_SEALED_RANGE = range(0, INDEXED_SEALED_ROWS)
 UNINDEXED_SEALED_RANGE = range(INDEXED_SEALED_ROWS, INDEXED_SEALED_ROWS + UNINDEXED_SEALED_ROWS)
 GROWING_RANGE = range(INDEXED_SEALED_ROWS + UNINDEXED_SEALED_ROWS, TOTAL_ROWS)
@@ -204,11 +205,11 @@ def expected_payloads(rows):
     }
 
 
-def text_field(field_name, analyzer_params):
+def text_field(field_name, analyzer_params, nullable=True):
     return {
         "fieldName": field_name,
         "dataType": "Text",
-        "nullable": True,
+        "nullable": nullable,
         "elementTypeParams": {
             "enable_analyzer": True,
             "enable_match": True,
@@ -323,7 +324,7 @@ def build_text_index_payload(collection_name):
 
 
 def wait_for_sealed_layout(collection_name, connection_alias, timeout=120):
-    """Wait until public segment metadata exposes the 3,000 + 500 sealed layout."""
+    """Wait until public segment metadata exposes the 3,000 + 1,000 sealed layout."""
     deadline = time.monotonic() + timeout
     last_infos = []
     while time.monotonic() < deadline:
@@ -351,6 +352,13 @@ def flush_collection(collection_client, collection_name, timeout=30):
         time.sleep(1)
 
 
+def remaining_setup_timeout(deadline, phase, cap):
+    """Return a phase timeout bounded by the shared fixture setup deadline."""
+    remaining = int(deadline - time.monotonic())
+    assert remaining > 0, f"TEXT LOB fixture setup budget exhausted before {phase}"
+    return min(cap, remaining)
+
+
 def assert_rows_payload(rows_by_id, expected, fields):
     assert set(rows_by_id) == set(expected), f"row ids mismatch: actual={set(rows_by_id)}, expected={set(expected)}"
     for pk, row in rows_by_id.items():
@@ -370,6 +378,7 @@ class TestTextLOB(TestBase):
 
     @pytest.fixture(scope="class", autouse=True)
     def prepare_text_lob_collection(self, request, init_class_config):
+        setup_deadline = time.monotonic() + TEXT_LOB_SETUP_TIMEOUT
         collection_client, vector_client = self._class_scope_clients()
         index_client = IndexClient(self.endpoint, self.api_key)
         connection_alias = self.collection_name
@@ -392,22 +401,30 @@ class TestTextLOB(TestBase):
         rsp = vector_client.vector_insert({"collectionName": self.collection_name, "data": indexed_rows})
         assert rsp["code"] == 0, rsp
         assert rsp["data"]["insertCount"] == INDEXED_SEALED_ROWS
-        flush_collection(collection_client, self.collection_name)
+        flush_collection(
+            collection_client,
+            self.collection_name,
+            timeout=remaining_setup_timeout(setup_deadline, "indexed sealed flush", 30),
+        )
 
         unindexed_rows = self.shared_rows[INDEXED_SEALED_ROWS : INDEXED_SEALED_ROWS + UNINDEXED_SEALED_ROWS]
         rsp = vector_client.vector_insert({"collectionName": self.collection_name, "data": unindexed_rows})
         assert rsp["code"] == 0, rsp
         assert rsp["data"]["insertCount"] == UNINDEXED_SEALED_ROWS
-        flush_collection(collection_client, self.collection_name)
+        flush_collection(
+            collection_client,
+            self.collection_name,
+            timeout=remaining_setup_timeout(setup_deadline, "unindexed sealed flush", 30),
+        )
 
         rsp = index_client.index_create(build_dense_index_payload(self.collection_name))
         assert rsp["code"] == 0, rsp
         assert utility.wait_for_index_building_complete(
             self.collection_name,
             index_name=VECTOR_FIELD,
-            timeout=300,
+            timeout=remaining_setup_timeout(setup_deadline, "dense index build", 300),
             using=connection_alias,
-        )
+        ), "dense index did not complete within the shared fixture setup budget"
 
         rsp = index_client.index_create(build_text_index_payload(self.collection_name))
         assert rsp["code"] == 0, rsp
@@ -420,14 +437,21 @@ class TestTextLOB(TestBase):
             assert utility.wait_for_index_building_complete(
                 self.collection_name,
                 index_name=index_name,
-                timeout=300,
+                timeout=remaining_setup_timeout(setup_deadline, f"{index_name} index build", 300),
                 using=connection_alias,
-            )
+            ), f"{index_name} index did not complete within the shared fixture setup budget"
 
         rsp = collection_client.collection_load(collection_name=self.collection_name)
         assert rsp["code"] == 0, rsp
-        collection_client.wait_load_completed(self.collection_name, timeout=120)
-        sealed_infos = wait_for_sealed_layout(self.collection_name, connection_alias)
+        collection_client.wait_load_completed(
+            self.collection_name,
+            timeout=remaining_setup_timeout(setup_deadline, "collection load", 120),
+        )
+        sealed_infos = wait_for_sealed_layout(
+            self.collection_name,
+            connection_alias,
+            timeout=remaining_setup_timeout(setup_deadline, "sealed segment layout", 120),
+        )
         self.__class__.shared_sealed_segment_ids = [info.segmentID for info in sealed_infos]
 
         growing_rows = self.shared_rows[INDEXED_SEALED_ROWS + UNINDEXED_SEALED_ROWS :]
@@ -473,7 +497,7 @@ class TestTextLOB(TestBase):
     def test_text_lob_shared_schema_and_payloads(self):
         """
         target: verify TEXT LOB schema, BM25 indexes, and exact payload retrieval
-        method: describe the shared collection and query 4,000 rows across indexed sealed,
+        method: describe the shared collection and query 4,500 rows across indexed sealed,
             unindexed sealed, and growing paths
         expected: every path participates and every TEXT payload checksum matches inserted data
         """
@@ -532,14 +556,101 @@ class TestTextLOB(TestBase):
                 "limit": 3,
                 "searchParams": {"metricType": "COSINE", "params": {"ef": 64}},
                 "outputFields": [ID_FIELD, CONTENT_FIELD, CONTENT_ALT_FIELD],
+                "orderByFields": [f"{ID_FIELD}:asc"],
             },
             timeout=30,
         )
         assert rsp["code"] == 0, rsp
         assert len(rsp["data"]) == len(LOB_MARKER_IDS)
         ids = [int(hit[ID_FIELD]) for hit in rsp["data"]]
-        assert set(ids) == set(LOB_MARKER_IDS.values())
+        assert ids == sorted(LOB_MARKER_IDS.values())
         for hit in rsp["data"]:
             pk = int(hit[ID_FIELD])
             assert_text_payload(hit.get(CONTENT_FIELD), self.shared_expected[pk][CONTENT_FIELD])
             assert_text_payload(hit.get(CONTENT_ALT_FIELD), self.shared_expected[pk][CONTENT_ALT_FIELD])
+
+
+class TestTextMutation(TestBase):
+    def create_collection(self, nullable):
+        self.name = gen_collection_name(prefix="rest_text_mutation")
+        rsp = self.collection_client.collection_create(
+            {
+                "collectionName": self.name,
+                "schema": {
+                    "autoId": False,
+                    "enableDynamicField": False,
+                    "fields": [
+                        {"fieldName": ID_FIELD, "dataType": "Int64", "isPrimary": True},
+                        {
+                            "fieldName": VECTOR_FIELD,
+                            "dataType": "FloatVector",
+                            "elementTypeParams": {"dim": str(DIM)},
+                        },
+                        text_field(CONTENT_FIELD, STANDARD_ANALYZER, nullable=nullable),
+                    ],
+                },
+                "indexParams": [
+                    {
+                        "fieldName": VECTOR_FIELD,
+                        "indexName": VECTOR_FIELD,
+                        "metricType": "COSINE",
+                    }
+                ],
+            }
+        )
+        assert rsp["code"] == 0, rsp
+        self.collection_client.wait_load_completed(self.name, timeout=120)
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_text_partial_upsert_omitted_nullable_field(self):
+        """
+        target: verify partial upsert inserts a new row without a nullable TEXT value
+        method: partially upsert an unknown primary key while omitting its nullable TEXT field
+        expected: the row is inserted and querying the TEXT field returns null
+        """
+        self.create_collection(nullable=True)
+        rsp = self.vector_client.vector_upsert(
+            {
+                "collectionName": self.name,
+                "partialUpdate": True,
+                "data": [{ID_FIELD: 100, VECTOR_FIELD: vector_for_pk(100)}],
+            }
+        )
+        assert rsp["code"] == 0, rsp
+        assert rsp["data"]["upsertCount"] == 1
+
+        rsp = self.vector_client.vector_query(
+            {
+                "collectionName": self.name,
+                "filter": f"{ID_FIELD} == 100",
+                "outputFields": [ID_FIELD, CONTENT_FIELD],
+            },
+            timeout=30,
+        )
+        assert rsp["code"] == 0, rsp
+        assert len(rsp["data"]) == 1
+        assert int(rsp["data"][0][ID_FIELD]) == 100
+        assert rsp["data"][0].get(CONTENT_FIELD) is None
+
+    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.parametrize(
+        ("row", "expected_message"),
+        [
+            ({ID_FIELD: 1, VECTOR_FIELD: vector_for_pk(1)}, f"field {CONTENT_FIELD} is required"),
+            (
+                {ID_FIELD: 2, VECTOR_FIELD: vector_for_pk(2), CONTENT_FIELD: None},
+                f"field {CONTENT_FIELD} is not nullable",
+            ),
+        ],
+        ids=["missing", "null"],
+    )
+    def test_text_non_nullable_insert_rejected(self, row, expected_message):
+        """
+        target: verify REST insert rejects absent and null non-nullable TEXT values
+        method: insert one row that omits TEXT or explicitly sends null
+        expected: both requests return the invalid-insert code and a field-specific message
+        """
+        self.create_collection(nullable=False)
+        rsp = self.vector_client.vector_insert({"collectionName": self.name, "data": [row]})
+        assert rsp["code"] == 1804, rsp
+        assert expected_message in rsp["message"]

--- a/tests/restful_client_v2/testcases/test_text_lob.py
+++ b/tests/restful_client_v2/testcases/test_text_lob.py
@@ -374,22 +374,3 @@ class TestTextLOB(TestBase):
             pk = int(hit[ID_FIELD])
             assert_text_payload(hit.get(CONTENT_FIELD), self.shared_expected[pk][CONTENT_FIELD])
             assert_text_payload(hit.get(CONTENT_ALT_FIELD), self.shared_expected[pk][CONTENT_ALT_FIELD])
-
-    @pytest.mark.tags(CaseLabel.L0)
-    def test_text_lob_query_iterator_payloads(self):
-        """
-        target: verify REST query returns every TEXT LOB row exactly once
-        method: page through REST query in batches of three because REST v2 has no query iterator endpoint
-        expected: no primary keys are missing or duplicated and every TEXT payload is intact
-        """
-        batch_size = 3
-        rows = []
-        for offset in range(0, len(self.shared_rows), batch_size):
-            page = self.query_page([CONTENT_FIELD], batch_size, offset)
-            assert len(page) == min(batch_size, len(self.shared_rows) - offset)
-            rows.extend(page)
-
-        rows_by_id = {int(row[ID_FIELD]): row for row in rows}
-        assert len(rows) == len(self.shared_rows)
-        assert len(rows_by_id) == len(rows), "REST query pagination returned duplicate primary keys"
-        assert_rows_payload(rows_by_id, self.shared_expected, [CONTENT_FIELD])

--- a/tests/scripts/ci_e2e_4am.sh
+++ b/tests/scripts/ci_e2e_4am.sh
@@ -82,11 +82,12 @@ fi
 # Run restful test v2
 cd ${ROOT}/tests/restful_client_v2
 
+# Keep tests sharing expensive class-scoped fixtures on the same xdist worker.
 if [[ -n "${TEST_TIMEOUT:-}" ]]; then
 
-  timeout "${TEST_TIMEOUT}" pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x --tags L0 L1 -n 6 --timeout 360
+  timeout "${TEST_TIMEOUT}" pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x --tags L0 L1 -n 6 --dist loadgroup --timeout 360
 else
-  pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x --tags L0 L1 -n 6 --timeout 360
+  pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x --tags L0 L1 -n 6 --dist loadgroup --timeout 360
 fi
 
 cd ${ROOT}/tests/python_client

--- a/tests/scripts/ci_e2e_with_restful.sh
+++ b/tests/scripts/ci_e2e_with_restful.sh
@@ -82,11 +82,12 @@ fi
 # Run restful test v2
 cd ${ROOT}/tests/restful_client_v2
 
+# Keep tests sharing expensive class-scoped fixtures on the same xdist worker.
 if [[ -n "${TEST_TIMEOUT:-}" ]]; then
 
-  timeout "${TEST_TIMEOUT}" pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x --tags L0 L1 -n 6 --timeout 360
+  timeout "${TEST_TIMEOUT}" pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x --tags L0 L1 -n 6 --dist loadgroup --timeout 360
 else
-  pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x --tags L0 L1 -n 6 --timeout 360
+  pytest testcases --endpoint http://${MILVUS_SERVICE_NAME}:${MILVUS_SERVICE_PORT} --minio_host ${MINIO_SERVICE_NAME} -v -x --tags L0 L1 -n 6 --dist loadgroup --timeout 360
 fi
 
 cd ${ROOT}/tests/python_client


### PR DESCRIPTION
issue: #52087

## What was changed

- Support `Text` fields in REST v2 insert and upsert requests.
- Return `Text` fields from REST v2 query and search responses.
- Reject missing or null values for non-nullable `Text` fields while preserving explicit empty strings and partial-update semantics.
- Add REST L0 coverage using 3,000 indexed sealed rows, 500 unindexed sealed rows, and 500 growing rows, with long `Text` payloads in every segment state.
- Add Go regression tests for request conversion and response serialization.

## Why this change

REST v2 did not recognize `Text` as a string-backed field during request conversion or response formatting, causing valid inserts to fail with error code `1804`.

## Validation

- HTTP server Go unit-test package passed across four workers.
- REST v2 Text LOB E2E tests passed.
- Verified insert and upsert behavior for missing, null, and explicit empty `Text` values.
