### PR TITLE
fix: add Go SDK v3 TEXT field support

### DIFF
--- a/client/column/columns.go
+++ b/client/column/columns.go
@@ -461,6 +461,9 @@ func FieldDataColumn(fd *schemapb.FieldData, begin, end int) (Column, error) {
 	case schemapb.DataType_VarChar:
 		return parseScalarData(fd.GetFieldName(), fd.GetScalars().GetStringData().GetData(), begin, end, validData, NewColumnVarChar, NewNullableColumnVarChar)
 
+	case schemapb.DataType_Text:
+		return parseScalarData(fd.GetFieldName(), fd.GetScalars().GetStringData().GetData(), begin, end, validData, NewColumnText, NewNullableColumnText)
+
 	case schemapb.DataType_Array:
 		// handle struct array field (legacy server may use DataType_Array as top-level)
 		if fd.GetStructArrays() != nil {

--- a/client/column/conversion.go
+++ b/client/column/conversion.go
@@ -116,6 +116,7 @@ func values2FieldData[T any](values []T, fieldType entity.FieldType, dim int) *s
 		entity.FieldTypeInt32,
 		entity.FieldTypeInt64,
 		entity.FieldTypeVarChar,
+		entity.FieldTypeText,
 		entity.FieldTypeString,
 		entity.FieldTypeJSON,
 		entity.FieldTypeGeometry,
@@ -175,7 +176,7 @@ func values2Scalars[T any](values []T, fieldType entity.FieldType) *schemapb.Sca
 		scalars.Data = &schemapb.ScalarField_LongData{
 			LongData: &schemapb.LongArray{Data: int64s},
 		}
-	case entity.FieldTypeVarChar, entity.FieldTypeString, entity.FieldTypeTimestamptz:
+	case entity.FieldTypeVarChar, entity.FieldTypeText, entity.FieldTypeString, entity.FieldTypeTimestamptz:
 		var strVals []string
 		strVals, ok = any(values).([]string)
 		scalars.Data = &schemapb.ScalarField_StringData{

--- a/client/column/nullable.go
+++ b/client/column/nullable.go
@@ -32,6 +32,7 @@ var (
 	NewNullableColumnInt32                NullableColumnCreateFunc[int32, *ColumnInt32]                 = NewNullableColumnCreator(NewColumnInt32).New
 	NewNullableColumnInt64                NullableColumnCreateFunc[int64, *ColumnInt64]                 = NewNullableColumnCreator(NewColumnInt64).New
 	NewNullableColumnVarChar              NullableColumnCreateFunc[string, *ColumnVarChar]              = NewNullableColumnCreator(NewColumnVarChar).New
+	NewNullableColumnText                 NullableColumnCreateFunc[string, *ColumnText]                 = NewNullableColumnCreator(NewColumnText).New
 	NewNullableColumnString               NullableColumnCreateFunc[string, *ColumnString]               = NewNullableColumnCreator(NewColumnString).New
 	NewNullableColumnFloat                NullableColumnCreateFunc[float32, *ColumnFloat]               = NewNullableColumnCreator(NewColumnFloat).New
 	NewNullableColumnDouble               NullableColumnCreateFunc[float64, *ColumnDouble]              = NewNullableColumnCreator(NewColumnDouble).New

--- a/client/column/scalar.go
+++ b/client/column/scalar.go
@@ -283,6 +283,30 @@ func (c *ColumnVarChar) Slice(start, end int) Column {
 	}
 }
 
+/* Text */
+
+var _ Column = (*ColumnText)(nil)
+
+type ColumnText struct {
+	*genericColumnBase[string]
+}
+
+func NewColumnText(name string, values []string) *ColumnText {
+	return &ColumnText{
+		genericColumnBase: &genericColumnBase[string]{
+			name:      name,
+			fieldType: entity.FieldTypeText,
+			values:    values,
+		},
+	}
+}
+
+func (c *ColumnText) Slice(start, end int) Column {
+	return &ColumnText{
+		genericColumnBase: c.genericColumnBase.slice(start, end),
+	}
+}
+
 /* String */
 /* NOT USED */
 

--- a/client/column/text_test.go
+++ b/client/column/text_test.go
@@ -1,0 +1,73 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package column
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/client/v3/entity"
+)
+
+func TestColumnTextRoundTrip(t *testing.T) {
+	values := []string{"short text", "a much longer text value"}
+	textColumn := NewColumnText("document", values)
+
+	assert.Equal(t, entity.FieldTypeText, textColumn.Type())
+	assert.Equal(t, values, textColumn.Data())
+
+	fieldData := textColumn.FieldData()
+	assert.Equal(t, schemapb.DataType_Text, fieldData.GetType())
+	assert.Equal(t, values, fieldData.GetScalars().GetStringData().GetData())
+
+	parsed, err := FieldDataColumn(fieldData, 0, -1)
+	require.NoError(t, err)
+	parsedText, ok := parsed.(*ColumnText)
+	require.True(t, ok)
+	assert.Equal(t, entity.FieldTypeText, parsedText.Type())
+	assert.Equal(t, values, parsedText.Data())
+
+	sliced, ok := textColumn.Slice(1, -1).(*ColumnText)
+	require.True(t, ok)
+	assert.Equal(t, values[1:], sliced.Data())
+}
+
+func TestNullableColumnTextRoundTrip(t *testing.T) {
+	values := []string{"first", "third"}
+	validData := []bool{true, false, true}
+	textColumn, err := NewNullableColumnText("document", values, validData)
+	require.NoError(t, err)
+
+	fieldData := textColumn.FieldData()
+	assert.Equal(t, schemapb.DataType_Text, fieldData.GetType())
+	assert.Equal(t, values, fieldData.GetScalars().GetStringData().GetData())
+	assert.Equal(t, validData, fieldData.GetValidData())
+
+	parsed, err := FieldDataColumn(fieldData, 0, -1)
+	require.NoError(t, err)
+	parsedText, ok := parsed.(*ColumnText)
+	require.True(t, ok)
+	assert.Equal(t, entity.FieldTypeText, parsedText.Type())
+	assert.Equal(t, 3, parsedText.Len())
+	assert.Equal(t, values, parsedText.Data())
+	isNull, err := parsedText.IsNull(1)
+	require.NoError(t, err)
+	assert.True(t, isNull)
+}

--- a/client/entity/field.go
+++ b/client/entity/field.go
@@ -52,6 +52,8 @@ func (t FieldType) Name() string {
 		return "String"
 	case FieldTypeVarChar:
 		return "VarChar"
+	case FieldTypeText:
+		return "Text"
 	case FieldTypeArray:
 		return "Array"
 	case FieldTypeJSON:
@@ -95,6 +97,8 @@ func (t FieldType) String() string {
 	case FieldTypeString:
 		return "string"
 	case FieldTypeVarChar:
+		return "string"
+	case FieldTypeText:
 		return "string"
 	case FieldTypeArray:
 		return "Array"
@@ -140,6 +144,8 @@ func (t FieldType) PbFieldType() (string, string) {
 		return "String", "string"
 	case FieldTypeVarChar:
 		return "VarChar", "string"
+	case FieldTypeText:
+		return "Text", "string"
 	case FieldTypeJSON:
 		return "JSON", "JSON"
 	case FieldTypeGeometry:
@@ -187,6 +193,8 @@ const (
 	FieldTypeJSON FieldType = 23
 	// FieldTypeGeometry field type Geometry
 	FieldTypeGeometry FieldType = 24
+	// FieldTypeText field type text
+	FieldTypeText FieldType = 25
 	// FieldTypeTimestamptz field type timestamptz
 	FieldTypeTimestamptz FieldType = 26
 	// FieldTypeBinaryVector field type binary vector

--- a/client/entity/text_test.go
+++ b/client/entity/text_test.go
@@ -1,0 +1,38 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package entity_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/client/v3/entity"
+)
+
+func TestFieldTypeTextIsPublic(t *testing.T) {
+	fieldType := entity.FieldTypeText
+
+	assert.Equal(t, entity.FieldType(25), fieldType)
+	assert.Equal(t, "Text", fieldType.Name())
+	assert.Equal(t, "string", fieldType.String())
+	pbName, pbType := fieldType.PbFieldType()
+	assert.Equal(t, "Text", pbName)
+	assert.Equal(t, "string", pbType)
+	assert.Equal(t, schemapb.DataType_Text, entity.NewField().WithDataType(fieldType).ProtoMessage().GetDataType())
+}

--- a/client/milvusclient/results_test.go
+++ b/client/milvusclient/results_test.go
@@ -189,6 +189,22 @@ func (s *ResultSetSuite) TestResultsetUnmarshalNullablePointer() {
 	s.Nil(receiver[2].Age)
 }
 
+func (s *ResultSetSuite) TestTextResultUnmarshal() {
+	type TextData struct {
+		Document string `milvus:"name:document"`
+	}
+
+	result := DataSet{
+		column.NewColumnText("document", []string{"first", "second"}),
+	}
+	var receiver []*TextData
+	err := result.Unmarshal(&receiver)
+	s.Require().NoError(err)
+	s.Require().Len(receiver, 2)
+	s.Equal("first", receiver[0].Document)
+	s.Equal("second", receiver[1].Document)
+}
+
 func (s *ResultSetSuite) TestSearchResultUnmarshalPointerPK() {
 	type PtrPKData struct {
 		A *int64    `milvus:"name:id"`

--- a/client/milvusclient/write_option_test.go
+++ b/client/milvusclient/write_option_test.go
@@ -47,6 +47,75 @@ func (s *ColumnBasedDataOptionSuite) NullableCompatible() {
 	s.ElementsMatch([]bool{true, true, true}, fd.GetValidData())
 }
 
+func (s *ColumnBasedDataOptionSuite) TestTextInsertAndUpsertRequests() {
+	collectionName := "text_collection"
+	collection := &entity.Collection{
+		Name: collectionName,
+		Schema: entity.NewSchema().WithName(collectionName).
+			WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
+			WithField(entity.NewField().WithName("document").WithDataType(entity.FieldTypeText)),
+	}
+
+	newOption := func() *columnBasedDataOption {
+		return NewColumnBasedInsertOption(collectionName).
+			WithInt64Column("id", []int64{1, 2}).
+			WithTextColumn("document", []string{"first", "second"})
+	}
+	insertRequest, err := newOption().InsertRequest(collection)
+	s.Require().NoError(err)
+	upsertRequest, err := newOption().UpsertRequest(collection)
+	s.Require().NoError(err)
+
+	for _, fieldsData := range [][]*schemapb.FieldData{insertRequest.GetFieldsData(), upsertRequest.GetFieldsData()} {
+		var textData *schemapb.FieldData
+		for _, fieldData := range fieldsData {
+			if fieldData.GetFieldName() == "document" {
+				textData = fieldData
+				break
+			}
+		}
+		s.Require().NotNil(textData)
+		s.Equal(schemapb.DataType_Text, textData.GetType())
+		s.Equal([]string{"first", "second"}, textData.GetScalars().GetStringData().GetData())
+	}
+}
+
+func (s *ColumnBasedDataOptionSuite) TestTextRowInsertAndUpsertRequests() {
+	type TextRow struct {
+		ID       int64  `milvus:"name:id"`
+		Document string `milvus:"name:document"`
+	}
+
+	collectionName := "text_collection"
+	collection := &entity.Collection{
+		Name: collectionName,
+		Schema: entity.NewSchema().WithName(collectionName).
+			WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
+			WithField(entity.NewField().WithName("document").WithDataType(entity.FieldTypeText)),
+	}
+	rows := []any{
+		&TextRow{ID: 1, Document: "first"},
+		&TextRow{ID: 2, Document: "second"},
+	}
+
+	insertRequest, err := NewRowBasedInsertOption(collectionName, rows...).InsertRequest(collection)
+	s.Require().NoError(err)
+	upsertRequest, err := NewRowBasedInsertOption(collectionName, rows...).UpsertRequest(collection)
+	s.Require().NoError(err)
+
+	for _, fieldsData := range [][]*schemapb.FieldData{insertRequest.GetFieldsData(), upsertRequest.GetFieldsData()} {
+		found := false
+		for _, fieldData := range fieldsData {
+			if fieldData.GetFieldName() == "document" {
+				found = true
+				s.Equal(schemapb.DataType_Text, fieldData.GetType())
+				s.Equal([]string{"first", "second"}, fieldData.GetScalars().GetStringData().GetData())
+			}
+		}
+		s.True(found, "TEXT field data not found")
+	}
+}
+
 func (s *ColumnBasedDataOptionSuite) TestWithStructArrayColumn() {
 	dim := 4
 	structSchema := entity.NewStructSchema().

--- a/client/milvusclient/write_option_test.go
+++ b/client/milvusclient/write_option_test.go
@@ -80,6 +80,40 @@ func (s *ColumnBasedDataOptionSuite) TestTextInsertAndUpsertRequests() {
 	}
 }
 
+func (s *ColumnBasedDataOptionSuite) TestTextAndVarCharTypeMismatchError() {
+	tests := []struct {
+		name          string
+		fieldType     entity.FieldType
+		column        column.Column
+		expectedError string
+	}{
+		{
+			name:          "varchar column for text field",
+			fieldType:     entity.FieldTypeText,
+			column:        column.NewColumnVarChar("document", []string{"first"}),
+			expectedError: "param column document has type VarChar but collection field definition is Text",
+		},
+		{
+			name:          "text column for varchar field",
+			fieldType:     entity.FieldTypeVarChar,
+			column:        column.NewColumnText("document", []string{"first"}),
+			expectedError: "param column document has type Text but collection field definition is VarChar",
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			collection := &entity.Collection{
+				Name: "text_collection",
+				Schema: entity.NewSchema().WithName("text_collection").
+					WithField(entity.NewField().WithName("document").WithDataType(test.fieldType)),
+			}
+			_, err := NewColumnBasedInsertOption(collection.Name, test.column).InsertRequest(collection)
+			s.Require().EqualError(err, test.expectedError)
+		})
+	}
+}
+
 func (s *ColumnBasedDataOptionSuite) TestTextRowInsertAndUpsertRequests() {
 	type TextRow struct {
 		ID       int64  `milvus:"name:id"`

--- a/client/milvusclient/write_options.go
+++ b/client/milvusclient/write_options.go
@@ -239,6 +239,11 @@ func (opt *columnBasedDataOption) WithVarcharColumn(colName string, data []strin
 	return opt.WithColumns(column)
 }
 
+func (opt *columnBasedDataOption) WithTextColumn(colName string, data []string) *columnBasedDataOption {
+	column := column.NewColumnText(colName, data)
+	return opt.WithColumns(column)
+}
+
 func (opt *columnBasedDataOption) WithFloatVectorColumn(colName string, dim int, data [][]float32) *columnBasedDataOption {
 	column := column.NewColumnFloatVector(colName, dim, data)
 	return opt.WithColumns(column)

--- a/client/milvusclient/write_options.go
+++ b/client/milvusclient/write_options.go
@@ -119,7 +119,7 @@ func (opt *columnBasedDataOption) processInsertColumns(colSchema *entity.Schema,
 
 		mNameColumn[col.Name()] = col
 		if col.Type() != field.DataType {
-			return nil, 0, fmt.Errorf("param column %s has type %v but collection field definition is %v", col.Name(), col.Type(), field.DataType)
+			return nil, 0, fmt.Errorf("param column %s has type %s but collection field definition is %s", col.Name(), col.Type().Name(), field.DataType.Name())
 		}
 		if field.DataType == entity.FieldTypeFloatVector || field.DataType == entity.FieldTypeBinaryVector ||
 			field.DataType == entity.FieldTypeFloat16Vector || field.DataType == entity.FieldTypeBFloat16Vector ||

--- a/client/row/data.go
+++ b/client/row/data.go
@@ -223,6 +223,9 @@ func getColumnCreators(sch *entity.Schema) map[string]columnCreator {
 			case entity.FieldTypeString, entity.FieldTypeVarChar:
 				data := make([]string, 0, rowsLen)
 				col = column.NewColumnVarChar(field.Name, data)
+			case entity.FieldTypeText:
+				data := make([]string, 0, rowsLen)
+				col = column.NewColumnText(field.Name, data)
 			case entity.FieldTypeJSON:
 				data := make([][]byte, 0, rowsLen)
 				col = column.NewColumnJSONBytes(field.Name, data)

--- a/client/row/data_test.go
+++ b/client/row/data_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/client/v3/entity"
 )
 
@@ -117,6 +118,33 @@ func (s *RowsSuite) TestRowsToColumns() {
 		})
 		s.NotNil(err)
 	})
+}
+
+func (s *RowsSuite) TestTextRowsToColumns() {
+	type TextRow struct {
+		ID       int64  `milvus:"name:id"`
+		Document string `milvus:"name:document"`
+	}
+
+	schema := entity.NewSchema().
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
+		WithField(entity.NewField().WithName("document").WithDataType(entity.FieldTypeText))
+	columns, err := AnyToColumns([]any{
+		&TextRow{ID: 1, Document: "first"},
+		&TextRow{ID: 2, Document: "second"},
+	}, false, schema)
+	s.Require().NoError(err)
+
+	for _, col := range columns {
+		if col.Name() != "document" {
+			continue
+		}
+		s.Equal(entity.FieldTypeText, col.Type())
+		s.Equal(schemapb.DataType_Text, col.FieldData().GetType())
+		s.Equal([]string{"first", "second"}, col.FieldData().GetScalars().GetStringData().GetData())
+		return
+	}
+	s.Fail("TEXT column not found")
 }
 
 func (s *RowsSuite) TestDynamicSchema() {

--- a/tests/go_client/testcases/text_lob_test.go
+++ b/tests/go_client/testcases/text_lob_test.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// L0 coverage for TEXT LOB through the public Go SDK.
+// L0 CRUD coverage for TEXT LOB through the public Go SDK.
 package testcases
 
 import (
@@ -216,6 +216,41 @@ func prepareTextLOBFixture(t *testing.T, ctx context.Context, mc *base.MilvusCli
 	}
 }
 
+func flushAndReloadTextLOBCollection(t *testing.T, ctx context.Context, mc *base.MilvusClient, collectionName string) {
+	t.Helper()
+
+	common.CheckErr(t, flushTextLOBCollectionWithRetry(ctx, mc, collectionName), true)
+
+	common.CheckErr(t, mc.ReleaseCollection(ctx, client.NewReleaseCollectionOption(collectionName)), true)
+	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collectionName))
+	common.CheckErr(t, err, true)
+	common.CheckErr(t, loadTask.Await(ctx), true)
+}
+
+func flushTextLOBCollectionWithRetry(ctx context.Context, mc *base.MilvusClient, collectionName string) error {
+	retryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		flushTask, err := mc.Flush(retryCtx, client.NewFlushOption(collectionName))
+		if err == nil {
+			return flushTask.Await(retryCtx)
+		}
+		if !client.IsRetryableError(err) {
+			return err
+		}
+
+		select {
+		case <-retryCtx.Done():
+			return fmt.Errorf("flush collection %q retry timed out: %w", collectionName, err)
+		case <-ticker.C:
+		}
+	}
+}
+
 func requireExactTextLOB(t *testing.T, expected, actual string) {
 	t.Helper()
 	require.Equal(t, len(expected), len(actual), "TEXT byte length mismatch")
@@ -360,5 +395,95 @@ func TestTextLOBPublicSDKL0(t *testing.T) {
 			}
 		}
 		require.Len(t, seen, len(fixture.rows))
+	})
+
+	t.Run("upsert_payloads", func(t *testing.T) {
+		upsertRows := []textLOBRow{
+			{
+				id:       2,
+				vector:   fixture.rows[2].vector,
+				content:  textLOBValue(makeTextLOB(128*1024, "upsert-null-to-large")),
+				alt:      textLOBValue("upserted multilingual alternate 中文 payload 😀"),
+				sentinel: "sentinel text upsert 2",
+			},
+			{
+				id:       6,
+				vector:   fixture.rows[6].vector,
+				content:  textLOBValue(makeTextLOB(256*1024, "upsert-large")),
+				alt:      nil,
+				sentinel: "sentinel text upsert 6",
+			},
+		}
+		ids := []int64{upsertRows[0].id, upsertRows[1].id}
+		vectors := [][]float32{upsertRows[0].vector, upsertRows[1].vector}
+		sentinels := []string{upsertRows[0].sentinel, upsertRows[1].sentinel}
+		contentColumn := nullableTextLOBColumn(t, textLOBContentField, upsertRows, func(row textLOBRow) *string {
+			return row.content
+		})
+		altColumn := nullableTextLOBColumn(t, textLOBAltField, upsertRows, func(row textLOBRow) *string {
+			return row.alt
+		})
+
+		upsertResult, err := mc.Upsert(ctx, client.NewColumnBasedInsertOption(fixture.collectionName).
+			WithInt64Column(textLOBIDField, ids).
+			WithFloatVectorColumn(textLOBVectorField, textLOBVectorDim, vectors).
+			WithColumns(contentColumn, altColumn).
+			WithTextColumn(textLOBSentinelField, sentinels))
+		common.CheckErr(t, err, true)
+		require.EqualValues(t, len(upsertRows), upsertResult.UpsertCount)
+		flushAndReloadTextLOBCollection(t, ctx, mc, fixture.collectionName)
+
+		expected := make(map[int64]textLOBRow, len(upsertRows))
+		for _, row := range upsertRows {
+			expected[row.id] = row
+		}
+		result, err := mc.Query(ctx, client.NewQueryOption(fixture.collectionName).
+			WithFilter(fmt.Sprintf("%s in [2, 6]", textLOBIDField)).
+			WithOutputFields(textLOBIDField, textLOBContentField, textLOBAltField, textLOBSentinelField).
+			WithConsistencyLevel(entity.ClStrong).
+			WithLimit(len(upsertRows)))
+		common.CheckErr(t, err, true)
+		require.Equal(t, len(upsertRows), result.Len())
+		resultIDs := requireTextLOBResultRows(t, result, result.GetColumn(textLOBIDField), expected)
+		require.ElementsMatch(t, ids, resultIDs)
+
+		for id, row := range expected {
+			fixture.rowsByID[id] = row
+		}
+	})
+
+	t.Run("delete_payloads", func(t *testing.T) {
+		deletedID := int64(7)
+		deleteResult, err := mc.Delete(ctx, client.NewDeleteOption(fixture.collectionName).
+			WithInt64IDs(textLOBIDField, []int64{deletedID}))
+		common.CheckErr(t, err, true)
+		require.EqualValues(t, 1, deleteResult.DeleteCount)
+		flushAndReloadTextLOBCollection(t, ctx, mc, fixture.collectionName)
+
+		deleted, err := mc.Query(ctx, client.NewQueryOption(fixture.collectionName).
+			WithFilter(fmt.Sprintf("%s == %d", textLOBIDField, deletedID)).
+			WithOutputFields(textLOBIDField, textLOBContentField).
+			WithConsistencyLevel(entity.ClStrong))
+		common.CheckErr(t, err, true)
+		require.Zero(t, deleted.ResultCount)
+
+		survivors := make(map[int64]textLOBRow, len(fixture.rowsByID)-1)
+		expectedIDs := make([]int64, 0, len(fixture.rowsByID)-1)
+		for id, row := range fixture.rowsByID {
+			if id == deletedID {
+				continue
+			}
+			survivors[id] = row
+			expectedIDs = append(expectedIDs, id)
+		}
+		result, err := mc.Query(ctx, client.NewQueryOption(fixture.collectionName).
+			WithFilter(fmt.Sprintf("%s >= 0", textLOBIDField)).
+			WithOutputFields(textLOBIDField, textLOBContentField, textLOBAltField, textLOBSentinelField).
+			WithConsistencyLevel(entity.ClStrong).
+			WithLimit(len(survivors)))
+		common.CheckErr(t, err, true)
+		require.Equal(t, len(survivors), result.Len())
+		resultIDs := requireTextLOBResultRows(t, result, result.GetColumn(textLOBIDField), survivors)
+		require.ElementsMatch(t, expectedIDs, resultIDs)
 	})
 }

--- a/tests/go_client/testcases/text_lob_test.go
+++ b/tests/go_client/testcases/text_lob_test.go
@@ -14,7 +14,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// L0 CRUD and execution-path coverage for TEXT LOB through the public Go SDK.
 package testcases
 
 import (
@@ -28,12 +27,14 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus/client/v3/column"
 	"github.com/milvus-io/milvus/client/v3/entity"
 	"github.com/milvus-io/milvus/client/v3/index"
 	client "github.com/milvus-io/milvus/client/v3/milvusclient"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/tests/go_client/base"
 	"github.com/milvus-io/milvus/tests/go_client/common"
 	hp "github.com/milvus-io/milvus/tests/go_client/testcases/helper"
@@ -66,6 +67,7 @@ const (
 )
 
 const (
+	textLOBStorageV3Config      = "common.storage.useLoonFFI"
 	textLOBMinRowsConfig        = "indexCoord.segment.minSegmentNumRowsToEnableIndex"
 	textLOBMinRowsToEnableIndex = 1024
 )
@@ -311,7 +313,7 @@ func prepareTextLOBFixture(t *testing.T, ctx context.Context, mc *base.MilvusCli
 		WithConsistencyLevel(entity.ClStrong))
 	common.CheckErr(t, err, true)
 	t.Cleanup(func() {
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
 		common.CheckErr(t, mc.DropCollection(cleanupCtx, client.NewDropCollectionOption(collectionName)), true)
 	})
@@ -415,10 +417,24 @@ func flushTextLOBCollectionWithRetry(ctx context.Context, mc *base.MilvusClient,
 
 		select {
 		case <-retryCtx.Done():
-			return fmt.Errorf("flush collection %q retry timed out: %w", collectionName, err)
+			return merr.Wrapf(err, "flush collection %q retry timed out", collectionName)
 		case <-ticker.C:
 		}
 	}
+}
+
+func requireTextFieldConfig(t *testing.T) {
+	t.Helper()
+
+	storageV3, err := hp.GetServerConfig(textLOBStorageV3Config)
+	require.NoError(t, err)
+	require.Equal(t, "true", storageV3)
+
+	configuredMinRows, err := hp.GetServerConfig(textLOBMinRowsConfig)
+	require.NoError(t, err)
+	require.Equal(t, strconv.Itoa(textLOBMinRowsToEnableIndex), configuredMinRows)
+	require.Less(t, textLOBUnindexedSealedRows, textLOBMinRowsToEnableIndex)
+	require.GreaterOrEqual(t, textLOBIndexedSealedRows, textLOBMinRowsToEnableIndex)
 }
 
 func requireExactTextLOB(t *testing.T, expected, actual string) {
@@ -459,21 +475,21 @@ func requireTextLOBResultRows(
 		ids[i] = id
 
 		for _, field := range []struct {
-			column   column.Column
+			actual   column.Column
 			expected *string
 		}{
-			{column: contentColumn, expected: row.content},
-			{column: contentZHColumn, expected: row.contentZH},
-			{column: altColumn, expected: row.alt},
+			{actual: contentColumn, expected: row.content},
+			{actual: contentZHColumn, expected: row.contentZH},
+			{actual: altColumn, expected: row.alt},
 		} {
-			isNull, err := field.column.IsNull(i)
+			isNull, err := field.actual.IsNull(i)
 			require.NoError(t, err)
 			if field.expected == nil {
 				require.True(t, isNull)
 				continue
 			}
 			require.False(t, isNull)
-			actual, err := field.column.GetAsString(i)
+			actual, err := field.actual.GetAsString(i)
 			require.NoError(t, err)
 			requireExactTextLOB(t, *field.expected, actual)
 		}
@@ -485,24 +501,15 @@ func requireTextLOBResultRows(
 	return ids
 }
 
-func TestTextLOBPublicSDKL0(t *testing.T) {
+// TestTextFieldCRUD verifies TEXT fields across indexed, sealed, and growing segments.
+func TestTextFieldCRUD(t *testing.T) {
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
-	require.Less(t, textLOBUnindexedSealedRows, textLOBMinRowsToEnableIndex)
-	require.GreaterOrEqual(t, textLOBIndexedSealedRows, textLOBMinRowsToEnableIndex)
-
-	storageV3, err := hp.GetServerConfig("common.storage.useLoonFFI")
-	require.NoError(t, err)
-	require.Equal(t, "true", storageV3)
-
-	minRowsValue := strconv.Itoa(textLOBMinRowsToEnableIndex)
-	configuredMinRows, err := hp.GetServerConfig(textLOBMinRowsConfig)
-	require.NoError(t, err)
-	require.Equal(t, minRowsValue, configuredMinRows)
+	requireTextFieldConfig(t)
 
 	fixture := prepareTextLOBFixture(t, ctx, mc)
 
-	t.Run("schema_and_payloads", func(t *testing.T) {
+	t.Run("schema_and_query", func(t *testing.T) {
 		description, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(fixture.collectionName))
 		common.CheckErr(t, err, true)
 
@@ -577,7 +584,7 @@ func TestTextLOBPublicSDKL0(t *testing.T) {
 		}
 	})
 
-	t.Run("dense_search_output_fields", func(t *testing.T) {
+	t.Run("dense_search", func(t *testing.T) {
 		results, err := mc.Search(ctx, client.NewSearchOption(
 			fixture.collectionName,
 			3,
@@ -593,7 +600,7 @@ func TestTextLOBPublicSDKL0(t *testing.T) {
 		require.ElementsMatch(t, fixture.markerIDs, ids)
 	})
 
-	t.Run("bm25_search_output_fields", func(t *testing.T) {
+	t.Run("bm25_search", func(t *testing.T) {
 		for _, test := range []struct {
 			name     string
 			annField string
@@ -619,7 +626,7 @@ func TestTextLOBPublicSDKL0(t *testing.T) {
 		}
 	})
 
-	t.Run("query_iterator_payloads", func(t *testing.T) {
+	t.Run("query_iterator", func(t *testing.T) {
 		iterator, err := mc.QueryIterator(ctx, client.NewQueryIteratorOption(fixture.collectionName).
 			WithBatchSize(512).
 			WithFilter(fmt.Sprintf("%s >= 0", textLOBIDField)).
@@ -630,7 +637,7 @@ func TestTextLOBPublicSDKL0(t *testing.T) {
 		seen := make(map[int64]struct{}, len(fixture.rows))
 		for {
 			batch, err := iterator.Next(ctx)
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			common.CheckErr(t, err, true)
@@ -646,7 +653,7 @@ func TestTextLOBPublicSDKL0(t *testing.T) {
 		require.Len(t, seen, len(fixture.rows))
 	})
 
-	t.Run("upsert_payloads", func(t *testing.T) {
+	t.Run("upsert", func(t *testing.T) {
 		upsertRows := []textLOBRow{
 			{
 				id:        2,
@@ -706,7 +713,7 @@ func TestTextLOBPublicSDKL0(t *testing.T) {
 		}
 	})
 
-	t.Run("delete_payloads", func(t *testing.T) {
+	t.Run("delete", func(t *testing.T) {
 		deletedID := int64(7)
 		deleteResult, err := mc.Delete(ctx, client.NewDeleteOption(fixture.collectionName).
 			WithInt64IDs(textLOBIDField, []int64{deletedID}))

--- a/tests/go_client/testcases/text_lob_test.go
+++ b/tests/go_client/testcases/text_lob_test.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// L0 CRUD coverage for TEXT LOB through the public Go SDK.
+// L0 CRUD and execution-path coverage for TEXT LOB through the public Go SDK.
 package testcases
 
 import (
@@ -39,29 +39,46 @@ import (
 )
 
 const (
-	textLOBIDField       = "id"
-	textLOBVectorField   = "vector"
-	textLOBContentField  = "content"
-	textLOBAltField      = "content_alt"
-	textLOBSentinelField = "content_sentinel"
-	textLOBSparseField   = "content_sparse"
-	textLOBVectorIndex   = "text_lob_vector_idx"
-	textLOBSparseIndex   = "text_lob_sparse_idx"
-	textLOBVectorDim     = 16
+	textLOBIDField             = "id"
+	textLOBVectorField         = "vector"
+	textLOBContentField        = "content"
+	textLOBZHField             = "content_zh"
+	textLOBAltField            = "content_alt"
+	textLOBSentinelField       = "content_sentinel"
+	textLOBSparseField         = "content_sparse"
+	textLOBZHSparseField       = "content_zh_sparse"
+	textLOBSentinelSparseField = "content_sentinel_sparse"
+	textLOBVectorIndex         = "text_lob_vector_idx"
+	textLOBSparseIndex         = "text_lob_sparse_idx"
+	textLOBZHSparseIndex       = "text_lob_zh_sparse_idx"
+	textLOBSentinelSparseIndex = "text_lob_sentinel_sparse_idx"
+	textLOBVectorDim           = 16
+
+	textLOBIndexedSealedRows   = 3000
+	textLOBUnindexedSealedRows = 500
+	textLOBGrowingRows         = 500
+	textLOBTotalRows           = textLOBIndexedSealedRows + textLOBUnindexedSealedRows + textLOBGrowingRows
+
+	textLOBIndexedMarkerID   = int64(7)
+	textLOBUnindexedMarkerID = int64(textLOBIndexedSealedRows + textLOBUnindexedSealedRows/2)
+	textLOBGrowingMarkerID   = int64(textLOBIndexedSealedRows + textLOBUnindexedSealedRows + textLOBGrowingRows/2)
 )
 
 type textLOBRow struct {
-	id       int64
-	vector   []float32
-	content  *string
-	alt      *string
-	sentinel string
+	id        int64
+	vector    []float32
+	content   *string
+	contentZH *string
+	alt       *string
+	sentinel  string
 }
 
 type textLOBFixture struct {
 	collectionName string
 	rows           []textLOBRow
 	rowsByID       map[int64]textLOBRow
+	markerIDs      []int64
+	sealedIDs      []int64
 }
 
 func textLOBValue(value string) *string {
@@ -76,57 +93,119 @@ func makeTextLOB(size int, seed string) string {
 	return strings.Repeat(base, size/len(base)+1)[:size]
 }
 
-func newTextLOBRows() []textLOBRow {
-	contents := []*string{
-		textLOBValue("vector database milvus text lob smoke"),
-		textLOBValue(""),
-		nil,
-		textLOBValue("Milvus stores multilingual text: English 中文 日本語 Русский العربية emoji 😀🚀 데이터베이스"),
-		textLOBValue(makeTextLOB(64*1024-17, "below-64k")),
-		textLOBValue(makeTextLOB(64*1024, "at-64k")),
-		textLOBValue(makeTextLOB(64*1024+4096, "above-64k")),
-		textLOBValue(makeTextLOB(1024*1024, "one-mib")),
-	}
-	alternates := []*string{
-		textLOBValue("alternate vector database payload"),
-		textLOBValue(""),
-		nil,
-		textLOBValue("alternate multilingual 中文 payload 😀"),
-		textLOBValue("alternate below boundary payload"),
-		textLOBValue("alternate at boundary payload"),
-		textLOBValue("alternate above boundary payload"),
-		textLOBValue(makeTextLOB(128*1024, "alternate-one-mib")),
+func textLOBVector(id int64, marker bool) []float32 {
+	vector := make([]float32, textLOBVectorDim)
+	if marker {
+		vector[0] = 1
+		return vector
 	}
 
-	rows := make([]textLOBRow, len(contents))
-	for i := range contents {
-		vector := make([]float32, textLOBVectorDim)
-		vector[i] = 1
+	state := uint64(19530) + uint64(id)
+	for i := range vector {
+		state = state*6364136223846793005 + 1442695040888963407
+		vector[i] = float32(state>>40) / float32(1<<24)
+	}
+	return vector
+}
+
+func newTextLOBRows() []textLOBRow {
+	rows := make([]textLOBRow, textLOBTotalRows)
+	for i := range rows {
+		id := int64(i)
+		content := textLOBValue(fmt.Sprintf("text lob fixture row %d vector database", id))
+		contentZH := textLOBValue(fmt.Sprintf("向量数据库 中文检索 文本行 %d", id))
+		alt := textLOBValue(fmt.Sprintf("alternate text lob fixture row %d", id))
+		marker := id == textLOBIndexedMarkerID || id == textLOBUnindexedMarkerID || id == textLOBGrowingMarkerID
+
+		switch id {
+		case 0:
+			content = textLOBValue("vector database milvus text lob smoke")
+		case 1:
+			content = textLOBValue("")
+			contentZH = textLOBValue("")
+			alt = textLOBValue("")
+		case 2:
+			content = nil
+			contentZH = nil
+			alt = nil
+		case 3:
+			content = textLOBValue("Milvus stores multilingual text: English 中文 日本語 Русский العربية emoji 😀🚀 데이터베이스")
+			contentZH = textLOBValue("向量数据库 支持 中文检索 和 混合搜索")
+			alt = textLOBValue("alternate multilingual 中文 payload 😀")
+		case 4:
+			content = textLOBValue(makeTextLOB(64*1024-17, "below-64k"))
+			contentZH = nil
+		case 5:
+			content = textLOBValue(makeTextLOB(64*1024, "at-64k"))
+			contentZH = nil
+		case 6:
+			content = textLOBValue(makeTextLOB(64*1024+4096, "above-64k"))
+			contentZH = nil
+		case textLOBIndexedMarkerID:
+			content = textLOBValue(makeTextLOB(1024*1024, "indexed-sealed-one-mib"))
+			contentZH = nil
+			alt = textLOBValue(makeTextLOB(128*1024, "indexed-sealed-alt"))
+		case 8:
+			content = textLOBValue("vector database")
+		case 9:
+			content = textLOBValue(strings.Repeat("vector database ", 4) + "milvus retrieval")
+		case 10:
+			content = textLOBValue(strings.Repeat("vector database ", 12) + "milvus bm25 ranking ranking")
+		case 11:
+			content = textLOBValue("english sidecar text for chinese bm25")
+			contentZH = textLOBValue("向量数据库 支持 中文检索。Milvus 提供 混合搜索 和 稀疏向量 检索。")
+		case textLOBUnindexedMarkerID:
+			content = textLOBValue(makeTextLOB(256*1024, "unindexed-sealed"))
+			contentZH = nil
+			alt = textLOBValue(makeTextLOB(128*1024, "unindexed-sealed-alt"))
+		case textLOBGrowingMarkerID:
+			content = textLOBValue(makeTextLOB(256*1024, "growing"))
+			contentZH = nil
+			alt = textLOBValue(makeTextLOB(128*1024, "growing-alt"))
+		}
+
 		rows[i] = textLOBRow{
-			id:       int64(i),
-			vector:   vector,
-			content:  contents[i],
-			alt:      alternates[i],
-			sentinel: fmt.Sprintf("sentinel text output %d", i),
+			id:        id,
+			vector:    textLOBVector(id, marker),
+			content:   content,
+			contentZH: contentZH,
+			alt:       alt,
+			sentinel:  fmt.Sprintf("sentinel text output %d", id),
 		}
 	}
 	return rows
 }
 
 func textLOBCollectionSchema(collectionName string) *entity.Schema {
-	analyzerParams := map[string]any{"tokenizer": "standard"}
+	standardAnalyzer := map[string]any{"tokenizer": "standard"}
+	jiebaAnalyzer := map[string]any{
+		"tokenizer": map[string]any{
+			"type": "jieba",
+			"dict": []string{"向量数据库", "混合搜索", "稀疏向量"},
+			"mode": "exact",
+			"hmm":  false,
+		},
+	}
 	return entity.NewSchema().WithName(collectionName).
 		WithField(entity.NewField().WithName(textLOBIDField).WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
 		WithField(entity.NewField().WithName(textLOBVectorField).WithDataType(entity.FieldTypeFloatVector).WithDim(textLOBVectorDim)).
 		WithField(entity.NewField().WithName(textLOBContentField).WithDataType(entity.FieldTypeText).WithNullable(true).
-			WithEnableAnalyzer(true).WithEnableMatch(true).WithAnalyzerParams(analyzerParams)).
+			WithEnableAnalyzer(true).WithEnableMatch(true).WithAnalyzerParams(standardAnalyzer)).
+		WithField(entity.NewField().WithName(textLOBZHField).WithDataType(entity.FieldTypeText).WithNullable(true).
+			WithEnableAnalyzer(true).WithEnableMatch(true).WithAnalyzerParams(jiebaAnalyzer)).
 		WithField(entity.NewField().WithName(textLOBAltField).WithDataType(entity.FieldTypeText).WithNullable(true).
-			WithEnableAnalyzer(true).WithEnableMatch(true).WithAnalyzerParams(analyzerParams)).
+			WithEnableAnalyzer(true).WithEnableMatch(true).WithAnalyzerParams(standardAnalyzer)).
 		WithField(entity.NewField().WithName(textLOBSentinelField).WithDataType(entity.FieldTypeText).
-			WithEnableAnalyzer(true).WithEnableMatch(true).WithAnalyzerParams(analyzerParams)).
+			WithEnableAnalyzer(true).WithEnableMatch(true).WithAnalyzerParams(standardAnalyzer)).
 		WithField(entity.NewField().WithName(textLOBSparseField).WithDataType(entity.FieldTypeSparseVector)).
+		WithField(entity.NewField().WithName(textLOBZHSparseField).WithDataType(entity.FieldTypeSparseVector)).
+		WithField(entity.NewField().WithName(textLOBSentinelSparseField).WithDataType(entity.FieldTypeSparseVector)).
 		WithFunction(entity.NewFunction().WithName("content_bm25").WithType(entity.FunctionTypeBM25).
-			WithInputFields(textLOBContentField).WithOutputFields(textLOBSparseField))
+			WithInputFields(textLOBContentField).WithOutputFields(textLOBSparseField)).
+		WithFunction(entity.NewFunction().WithName("content_zh_bm25").WithType(entity.FunctionTypeBM25).
+			WithInputFields(textLOBZHField).WithOutputFields(textLOBZHSparseField)).
+		WithFunction(entity.NewFunction().WithName("content_sentinel_bm25").WithType(entity.FunctionTypeBM25).
+			WithInputFields(textLOBSentinelField).WithOutputFields(textLOBSentinelSparseField))
 }
 
 func nullableTextLOBColumn(t *testing.T, fieldName string, rows []textLOBRow, value func(textLOBRow) *string) *column.ColumnText {
@@ -145,6 +224,78 @@ func nullableTextLOBColumn(t *testing.T, fieldName string, rows []textLOBRow, va
 	return result
 }
 
+func insertTextLOBRows(
+	t *testing.T,
+	ctx context.Context,
+	mc *base.MilvusClient,
+	collectionName string,
+	rows []textLOBRow,
+) {
+	t.Helper()
+
+	ids := make([]int64, len(rows))
+	vectors := make([][]float32, len(rows))
+	sentinels := make([]string, len(rows))
+	for i, row := range rows {
+		ids[i] = row.id
+		vectors[i] = row.vector
+		sentinels[i] = row.sentinel
+	}
+
+	contentColumn := nullableTextLOBColumn(t, textLOBContentField, rows, func(row textLOBRow) *string {
+		return row.content
+	})
+	contentZHColumn := nullableTextLOBColumn(t, textLOBZHField, rows, func(row textLOBRow) *string {
+		return row.contentZH
+	})
+	altColumn := nullableTextLOBColumn(t, textLOBAltField, rows, func(row textLOBRow) *string {
+		return row.alt
+	})
+	insertResult, err := mc.Insert(ctx, client.NewColumnBasedInsertOption(collectionName).
+		WithInt64Column(textLOBIDField, ids).
+		WithFloatVectorColumn(textLOBVectorField, textLOBVectorDim, vectors).
+		WithColumns(contentColumn, contentZHColumn, altColumn).
+		WithTextColumn(textLOBSentinelField, sentinels))
+	common.CheckErr(t, err, true)
+	require.EqualValues(t, len(rows), insertResult.InsertCount)
+}
+
+func waitForTextLOBSealedLayout(
+	t *testing.T,
+	ctx context.Context,
+	mc *base.MilvusClient,
+	collectionName string,
+) []int64 {
+	t.Helper()
+
+	waitCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	var lastSegments []*entity.Segment
+	for {
+		segments, err := mc.GetPersistentSegmentInfo(waitCtx, client.NewGetPersistentSegmentInfoOption(collectionName))
+		if err == nil {
+			lastSegments = segments
+			if len(segments) == 2 {
+				first, second := segments[0], segments[1]
+				hasExpectedRows := first.NumRows == textLOBIndexedSealedRows && second.NumRows == textLOBUnindexedSealedRows ||
+					first.NumRows == textLOBUnindexedSealedRows && second.NumRows == textLOBIndexedSealedRows
+				if hasExpectedRows && first.Flushed() && second.Flushed() {
+					return []int64{first.ID, second.ID}
+				}
+			}
+		}
+
+		select {
+		case <-waitCtx.Done():
+			t.Fatalf("expected 3,000-row and 500-row flushed segments, last segments: %+v", lastSegments)
+		case <-ticker.C:
+		}
+	}
+}
+
 func prepareTextLOBFixture(t *testing.T, ctx context.Context, mc *base.MilvusClient) textLOBFixture {
 	t.Helper()
 
@@ -160,59 +311,72 @@ func prepareTextLOBFixture(t *testing.T, ctx context.Context, mc *base.MilvusCli
 	})
 
 	rows := newTextLOBRows()
-	ids := make([]int64, len(rows))
-	vectors := make([][]float32, len(rows))
-	sentinels := make([]string, len(rows))
 	rowsByID := make(map[int64]textLOBRow, len(rows))
-	for i, row := range rows {
-		ids[i] = row.id
-		vectors[i] = row.vector
-		sentinels[i] = row.sentinel
+	for _, row := range rows {
 		rowsByID[row.id] = row
 	}
 
-	contentColumn := nullableTextLOBColumn(t, textLOBContentField, rows, func(row textLOBRow) *string {
-		return row.content
-	})
-	altColumn := nullableTextLOBColumn(t, textLOBAltField, rows, func(row textLOBRow) *string {
-		return row.alt
-	})
-	insertResult, err := mc.Insert(ctx, client.NewColumnBasedInsertOption(collectionName).
-		WithInt64Column(textLOBIDField, ids).
-		WithFloatVectorColumn(textLOBVectorField, textLOBVectorDim, vectors).
-		WithColumns(contentColumn, altColumn).
-		WithTextColumn(textLOBSentinelField, sentinels))
-	common.CheckErr(t, err, true)
-	require.EqualValues(t, len(rows), insertResult.InsertCount)
-
-	flushTask, err := mc.Flush(ctx, client.NewFlushOption(collectionName))
-	common.CheckErr(t, err, true)
-	common.CheckErr(t, flushTask.Await(ctx), true)
+	insertTextLOBRows(t, ctx, mc, collectionName, rows[:textLOBIndexedSealedRows])
+	common.CheckErr(t, flushTextLOBCollectionWithRetry(ctx, mc, collectionName), true)
+	insertTextLOBRows(t, ctx, mc, collectionName,
+		rows[textLOBIndexedSealedRows:textLOBIndexedSealedRows+textLOBUnindexedSealedRows])
+	common.CheckErr(t, flushTextLOBCollectionWithRetry(ctx, mc, collectionName), true)
 
 	vectorIndexTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(
 		collectionName,
 		textLOBVectorField,
-		index.NewFlatIndex(entity.COSINE),
+		index.NewHNSWIndex(entity.COSINE, 16, 200),
 	).WithIndexName(textLOBVectorIndex))
 	common.CheckErr(t, err, true)
 	common.CheckErr(t, vectorIndexTask.Await(ctx), true)
 
-	sparseIndexTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(
-		collectionName,
-		textLOBSparseField,
-		index.NewSparseInvertedIndex(entity.BM25, 0.1),
-	).WithIndexName(textLOBSparseIndex))
-	common.CheckErr(t, err, true)
-	common.CheckErr(t, sparseIndexTask.Await(ctx), true)
+	for _, sparse := range []struct {
+		fieldName string
+		indexName string
+	}{
+		{fieldName: textLOBSparseField, indexName: textLOBSparseIndex},
+		{fieldName: textLOBZHSparseField, indexName: textLOBZHSparseIndex},
+		{fieldName: textLOBSentinelSparseField, indexName: textLOBSentinelSparseIndex},
+	} {
+		sparseIndexTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(
+			collectionName,
+			sparse.fieldName,
+			index.NewSparseInvertedIndex(entity.BM25, 0.1),
+		).WithIndexName(sparse.indexName))
+		common.CheckErr(t, err, true)
+		common.CheckErr(t, sparseIndexTask.Await(ctx), true)
+	}
 
 	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collectionName))
 	common.CheckErr(t, err, true)
 	common.CheckErr(t, loadTask.Await(ctx), true)
+	sealedIDs := waitForTextLOBSealedLayout(t, ctx, mc, collectionName)
+
+	insertTextLOBRows(t, ctx, mc, collectionName,
+		rows[textLOBIndexedSealedRows+textLOBUnindexedSealedRows:])
+	countResult, err := mc.Query(ctx, client.NewQueryOption(collectionName).
+		WithFilter(fmt.Sprintf("%s >= 0", textLOBIDField)).
+		WithOutputFields("count(*)").
+		WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+	count, err := countResult.GetColumn("count(*)").GetAsInt64(0)
+	common.CheckErr(t, err, true)
+	require.EqualValues(t, textLOBTotalRows, count)
+
+	segmentsAfterGrowing, err := mc.GetPersistentSegmentInfo(ctx, client.NewGetPersistentSegmentInfoOption(collectionName))
+	common.CheckErr(t, err, true)
+	require.Len(t, segmentsAfterGrowing, 2)
+	remainingSealedIDs := []int64{segmentsAfterGrowing[0].ID, segmentsAfterGrowing[1].ID}
+	require.ElementsMatch(t, sealedIDs, remainingSealedIDs)
+	require.EqualValues(t, textLOBIndexedSealedRows+textLOBUnindexedSealedRows,
+		segmentsAfterGrowing[0].NumRows+segmentsAfterGrowing[1].NumRows)
 
 	return textLOBFixture{
 		collectionName: collectionName,
 		rows:           rows,
 		rowsByID:       rowsByID,
+		markerIDs:      []int64{textLOBIndexedMarkerID, textLOBUnindexedMarkerID, textLOBGrowingMarkerID},
+		sealedIDs:      sealedIDs,
 	}
 }
 
@@ -268,12 +432,15 @@ func requireTextLOBResultRows(
 
 	require.NotNil(t, idColumn)
 	contentColumn := result.GetColumn(textLOBContentField)
+	contentZHColumn := result.GetColumn(textLOBZHField)
 	altColumn := result.GetColumn(textLOBAltField)
 	sentinelColumn := result.GetColumn(textLOBSentinelField)
 	require.IsType(t, &column.ColumnText{}, contentColumn)
+	require.IsType(t, &column.ColumnText{}, contentZHColumn)
 	require.IsType(t, &column.ColumnText{}, altColumn)
 	require.IsType(t, &column.ColumnText{}, sentinelColumn)
 	require.Equal(t, entity.FieldTypeText, contentColumn.Type())
+	require.Equal(t, entity.FieldTypeText, contentZHColumn.Type())
 	require.Equal(t, entity.FieldTypeText, altColumn.Type())
 	require.Equal(t, entity.FieldTypeText, sentinelColumn.Type())
 
@@ -290,6 +457,7 @@ func requireTextLOBResultRows(
 			expected *string
 		}{
 			{column: contentColumn, expected: row.content},
+			{column: contentZHColumn, expected: row.contentZH},
 			{column: altColumn, expected: row.alt},
 		} {
 			isNull, err := field.column.IsNull(i)
@@ -329,52 +497,120 @@ func TestTextLOBPublicSDKL0(t *testing.T) {
 		for _, field := range description.Schema.Fields {
 			fields[field.Name] = field
 		}
-		for _, fieldName := range []string{textLOBContentField, textLOBAltField, textLOBSentinelField} {
+		for _, fieldName := range []string{textLOBContentField, textLOBZHField, textLOBAltField, textLOBSentinelField} {
 			require.Contains(t, fields, fieldName)
 			require.Equal(t, entity.FieldTypeText, fields[fieldName].DataType)
 		}
-		require.Len(t, description.Schema.Functions, 1)
-		function := description.Schema.Functions[0]
-		require.Equal(t, entity.FunctionTypeBM25, function.Type)
-		require.Equal(t, []string{textLOBContentField}, function.InputFieldNames)
-		require.Equal(t, []string{textLOBSparseField}, function.OutputFieldNames)
+		require.Len(t, description.Schema.Functions, 3)
+		functions := make(map[string]*entity.Function, len(description.Schema.Functions))
+		for _, function := range description.Schema.Functions {
+			functions[function.Name] = function
+		}
+		for _, expected := range []struct {
+			name        string
+			inputField  string
+			outputField string
+		}{
+			{name: "content_bm25", inputField: textLOBContentField, outputField: textLOBSparseField},
+			{name: "content_zh_bm25", inputField: textLOBZHField, outputField: textLOBZHSparseField},
+			{name: "content_sentinel_bm25", inputField: textLOBSentinelField, outputField: textLOBSentinelSparseField},
+		} {
+			function := functions[expected.name]
+			require.NotNil(t, function)
+			require.Equal(t, entity.FunctionTypeBM25, function.Type)
+			require.Equal(t, []string{expected.inputField}, function.InputFieldNames)
+			require.Equal(t, []string{expected.outputField}, function.OutputFieldNames)
+		}
 
-		sparseIndex, err := mc.DescribeIndex(ctx, client.NewDescribeIndexOption(fixture.collectionName, textLOBSparseIndex))
+		vectorIndex, err := mc.DescribeIndex(ctx, client.NewDescribeIndexOption(fixture.collectionName, textLOBVectorIndex))
 		common.CheckErr(t, err, true)
-		require.Equal(t, index.SparseInverted, sparseIndex.IndexType())
-		require.Equal(t, string(entity.BM25), sparseIndex.Params()[index.MetricTypeKey])
+		require.Equal(t, index.HNSW, vectorIndex.IndexType())
+		require.Equal(t, string(entity.COSINE), vectorIndex.Params()[index.MetricTypeKey])
+		for _, indexName := range []string{textLOBSparseIndex, textLOBZHSparseIndex, textLOBSentinelSparseIndex} {
+			sparseIndex, err := mc.DescribeIndex(ctx, client.NewDescribeIndexOption(fixture.collectionName, indexName))
+			common.CheckErr(t, err, true)
+			require.Equal(t, index.SparseInverted, sparseIndex.IndexType())
+			require.Equal(t, string(entity.BM25), sparseIndex.Params()[index.MetricTypeKey])
+		}
+		require.Len(t, fixture.sealedIDs, 2)
 
 		result, err := mc.Query(ctx, client.NewQueryOption(fixture.collectionName).
 			WithFilter(fmt.Sprintf("%s >= 0", textLOBIDField)).
-			WithOutputFields(textLOBIDField, textLOBContentField, textLOBAltField, textLOBSentinelField).
+			WithOutputFields(textLOBIDField, textLOBContentField, textLOBZHField, textLOBAltField, textLOBSentinelField).
 			WithConsistencyLevel(entity.ClStrong).
 			WithLimit(len(fixture.rows)))
 		common.CheckErr(t, err, true)
 		require.Equal(t, len(fixture.rows), result.Len())
 		ids := requireTextLOBResultRows(t, result, result.GetColumn(textLOBIDField), fixture.rowsByID)
-		require.ElementsMatch(t, []int64{0, 1, 2, 3, 4, 5, 6, 7}, ids)
+		seen := make(map[int64]struct{}, len(ids))
+		pathCounts := [3]int{}
+		for _, id := range ids {
+			_, duplicated := seen[id]
+			require.False(t, duplicated, "duplicate primary key %d", id)
+			seen[id] = struct{}{}
+			switch {
+			case id < textLOBIndexedSealedRows:
+				pathCounts[0]++
+			case id < textLOBIndexedSealedRows+textLOBUnindexedSealedRows:
+				pathCounts[1]++
+			default:
+				pathCounts[2]++
+			}
+		}
+		require.Equal(t, [3]int{textLOBIndexedSealedRows, textLOBUnindexedSealedRows, textLOBGrowingRows}, pathCounts)
+		for _, markerID := range fixture.markerIDs {
+			require.Greater(t, len(*fixture.rowsByID[markerID].content), 64*1024)
+			require.Greater(t, len(*fixture.rowsByID[markerID].alt), 64*1024)
+		}
 	})
 
 	t.Run("dense_search_output_fields", func(t *testing.T) {
 		results, err := mc.Search(ctx, client.NewSearchOption(
 			fixture.collectionName,
 			3,
-			[]entity.Vector{entity.FloatVector(fixture.rows[0].vector)},
+			[]entity.Vector{entity.FloatVector(textLOBVector(textLOBIndexedMarkerID, true))},
 		).WithANNSField(textLOBVectorField).
-			WithOutputFields(textLOBContentField, textLOBAltField, textLOBSentinelField).
+			WithOutputFields(textLOBContentField, textLOBZHField, textLOBAltField, textLOBSentinelField).
+			WithSearchParam("ef", "64").
 			WithConsistencyLevel(entity.ClStrong))
 		common.CheckErr(t, err, true)
 		require.Len(t, results, 1)
 		require.Equal(t, 3, results[0].Len())
 		ids := requireTextLOBResultRows(t, results[0], results[0].IDs, fixture.rowsByID)
-		require.Equal(t, int64(0), ids[0])
+		require.ElementsMatch(t, fixture.markerIDs, ids)
+	})
+
+	t.Run("bm25_search_output_fields", func(t *testing.T) {
+		for _, test := range []struct {
+			name     string
+			annField string
+			query    string
+		}{
+			{name: "standard_analyzer", annField: textLOBSparseField, query: "vector database"},
+			{name: "jieba_analyzer", annField: textLOBZHSparseField, query: "向量数据库 中文检索"},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				results, err := mc.Search(ctx, client.NewSearchOption(
+					fixture.collectionName,
+					3,
+					[]entity.Vector{entity.Text(test.query)},
+				).WithANNSField(test.annField).
+					WithOutputFields(textLOBContentField, textLOBZHField, textLOBAltField, textLOBSentinelField).
+					WithConsistencyLevel(entity.ClStrong))
+				common.CheckErr(t, err, true)
+				require.Len(t, results, 1)
+				require.NotZero(t, results[0].Len())
+				require.LessOrEqual(t, results[0].Len(), 3)
+				requireTextLOBResultRows(t, results[0], results[0].IDs, fixture.rowsByID)
+			})
+		}
 	})
 
 	t.Run("query_iterator_payloads", func(t *testing.T) {
 		iterator, err := mc.QueryIterator(ctx, client.NewQueryIteratorOption(fixture.collectionName).
-			WithBatchSize(3).
+			WithBatchSize(512).
 			WithFilter(fmt.Sprintf("%s >= 0", textLOBIDField)).
-			WithOutputFields(textLOBIDField, textLOBContentField, textLOBAltField, textLOBSentinelField).
+			WithOutputFields(textLOBIDField, textLOBContentField, textLOBZHField, textLOBAltField, textLOBSentinelField).
 			WithConsistencyLevel(entity.ClStrong))
 		common.CheckErr(t, err, true)
 
@@ -386,7 +622,7 @@ func TestTextLOBPublicSDKL0(t *testing.T) {
 			}
 			common.CheckErr(t, err, true)
 			require.NotZero(t, batch.Len())
-			require.LessOrEqual(t, batch.Len(), 3)
+			require.LessOrEqual(t, batch.Len(), 512)
 			ids := requireTextLOBResultRows(t, batch, batch.GetColumn(textLOBIDField), fixture.rowsByID)
 			for _, id := range ids {
 				_, duplicated := seen[id]
@@ -400,18 +636,20 @@ func TestTextLOBPublicSDKL0(t *testing.T) {
 	t.Run("upsert_payloads", func(t *testing.T) {
 		upsertRows := []textLOBRow{
 			{
-				id:       2,
-				vector:   fixture.rows[2].vector,
-				content:  textLOBValue(makeTextLOB(128*1024, "upsert-null-to-large")),
-				alt:      textLOBValue("upserted multilingual alternate 中文 payload 😀"),
-				sentinel: "sentinel text upsert 2",
+				id:        2,
+				vector:    fixture.rows[2].vector,
+				content:   textLOBValue(makeTextLOB(128*1024, "upsert-null-to-large")),
+				contentZH: textLOBValue("更新后的向量数据库 中文检索 文本"),
+				alt:       textLOBValue("upserted multilingual alternate 中文 payload 😀"),
+				sentinel:  "sentinel text upsert 2",
 			},
 			{
-				id:       6,
-				vector:   fixture.rows[6].vector,
-				content:  textLOBValue(makeTextLOB(256*1024, "upsert-large")),
-				alt:      nil,
-				sentinel: "sentinel text upsert 6",
+				id:        6,
+				vector:    fixture.rows[6].vector,
+				content:   textLOBValue(makeTextLOB(256*1024, "upsert-large")),
+				contentZH: nil,
+				alt:       nil,
+				sentinel:  "sentinel text upsert 6",
 			},
 		}
 		ids := []int64{upsertRows[0].id, upsertRows[1].id}
@@ -420,6 +658,9 @@ func TestTextLOBPublicSDKL0(t *testing.T) {
 		contentColumn := nullableTextLOBColumn(t, textLOBContentField, upsertRows, func(row textLOBRow) *string {
 			return row.content
 		})
+		contentZHColumn := nullableTextLOBColumn(t, textLOBZHField, upsertRows, func(row textLOBRow) *string {
+			return row.contentZH
+		})
 		altColumn := nullableTextLOBColumn(t, textLOBAltField, upsertRows, func(row textLOBRow) *string {
 			return row.alt
 		})
@@ -427,7 +668,7 @@ func TestTextLOBPublicSDKL0(t *testing.T) {
 		upsertResult, err := mc.Upsert(ctx, client.NewColumnBasedInsertOption(fixture.collectionName).
 			WithInt64Column(textLOBIDField, ids).
 			WithFloatVectorColumn(textLOBVectorField, textLOBVectorDim, vectors).
-			WithColumns(contentColumn, altColumn).
+			WithColumns(contentColumn, contentZHColumn, altColumn).
 			WithTextColumn(textLOBSentinelField, sentinels))
 		common.CheckErr(t, err, true)
 		require.EqualValues(t, len(upsertRows), upsertResult.UpsertCount)
@@ -439,7 +680,7 @@ func TestTextLOBPublicSDKL0(t *testing.T) {
 		}
 		result, err := mc.Query(ctx, client.NewQueryOption(fixture.collectionName).
 			WithFilter(fmt.Sprintf("%s in [2, 6]", textLOBIDField)).
-			WithOutputFields(textLOBIDField, textLOBContentField, textLOBAltField, textLOBSentinelField).
+			WithOutputFields(textLOBIDField, textLOBContentField, textLOBZHField, textLOBAltField, textLOBSentinelField).
 			WithConsistencyLevel(entity.ClStrong).
 			WithLimit(len(upsertRows)))
 		common.CheckErr(t, err, true)
@@ -478,7 +719,7 @@ func TestTextLOBPublicSDKL0(t *testing.T) {
 		}
 		result, err := mc.Query(ctx, client.NewQueryOption(fixture.collectionName).
 			WithFilter(fmt.Sprintf("%s >= 0", textLOBIDField)).
-			WithOutputFields(textLOBIDField, textLOBContentField, textLOBAltField, textLOBSentinelField).
+			WithOutputFields(textLOBIDField, textLOBContentField, textLOBZHField, textLOBAltField, textLOBSentinelField).
 			WithConsistencyLevel(entity.ClStrong).
 			WithLimit(len(survivors)))
 		common.CheckErr(t, err, true)

--- a/tests/go_client/testcases/text_lob_test.go
+++ b/tests/go_client/testcases/text_lob_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -62,6 +63,11 @@ const (
 	textLOBIndexedMarkerID   = int64(7)
 	textLOBUnindexedMarkerID = int64(textLOBIndexedSealedRows + textLOBUnindexedSealedRows/2)
 	textLOBGrowingMarkerID   = int64(textLOBIndexedSealedRows + textLOBUnindexedSealedRows + textLOBGrowingRows/2)
+)
+
+const (
+	textLOBMinRowsConfig        = "indexCoord.segment.minSegmentNumRowsToEnableIndex"
+	textLOBMinRowsToEnableIndex = 1024
 )
 
 type textLOBRow struct {
@@ -482,11 +488,25 @@ func requireTextLOBResultRows(
 func TestTextLOBPublicSDKL0(t *testing.T) {
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
+	require.Less(t, textLOBUnindexedSealedRows, textLOBMinRowsToEnableIndex)
+	require.GreaterOrEqual(t, textLOBIndexedSealedRows, textLOBMinRowsToEnableIndex)
+
 	previousStorageV3, err := hp.AlterServerConfig("common.storage.useLoonFFI", "true")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_, _ = hp.AlterServerConfig("common.storage.useLoonFFI", previousStorageV3)
 	})
+
+	minRowsValue := strconv.Itoa(textLOBMinRowsToEnableIndex)
+	previousMinRows, err := hp.AlterServerConfig(textLOBMinRowsConfig, minRowsValue)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = hp.AlterServerConfig(textLOBMinRowsConfig, previousMinRows)
+	})
+	configuredMinRows, err := hp.GetServerConfig(textLOBMinRowsConfig)
+	require.NoError(t, err)
+	require.Equal(t, minRowsValue, configuredMinRows)
+
 	fixture := prepareTextLOBFixture(t, ctx, mc)
 
 	t.Run("schema_and_payloads", func(t *testing.T) {

--- a/tests/go_client/testcases/text_lob_test.go
+++ b/tests/go_client/testcases/text_lob_test.go
@@ -491,14 +491,18 @@ func TestTextLOBPublicSDKL0(t *testing.T) {
 	require.Less(t, textLOBUnindexedSealedRows, textLOBMinRowsToEnableIndex)
 	require.GreaterOrEqual(t, textLOBIndexedSealedRows, textLOBMinRowsToEnableIndex)
 
-	previousStorageV3, err := hp.AlterServerConfig("common.storage.useLoonFFI", "true")
+	previousStorageV3, err := hp.GetServerConfig("common.storage.useLoonFFI")
+	require.NoError(t, err)
+	_, err = hp.AlterServerConfig("common.storage.useLoonFFI", "true")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_, _ = hp.AlterServerConfig("common.storage.useLoonFFI", previousStorageV3)
 	})
 
 	minRowsValue := strconv.Itoa(textLOBMinRowsToEnableIndex)
-	previousMinRows, err := hp.AlterServerConfig(textLOBMinRowsConfig, minRowsValue)
+	previousMinRows, err := hp.GetServerConfig(textLOBMinRowsConfig)
+	require.NoError(t, err)
+	_, err = hp.AlterServerConfig(textLOBMinRowsConfig, minRowsValue)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_, _ = hp.AlterServerConfig(textLOBMinRowsConfig, previousMinRows)

--- a/tests/go_client/testcases/text_lob_test.go
+++ b/tests/go_client/testcases/text_lob_test.go
@@ -1,0 +1,364 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// L0 coverage for TEXT LOB through the public Go SDK.
+package testcases
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/client/v3/column"
+	"github.com/milvus-io/milvus/client/v3/entity"
+	"github.com/milvus-io/milvus/client/v3/index"
+	client "github.com/milvus-io/milvus/client/v3/milvusclient"
+	"github.com/milvus-io/milvus/tests/go_client/base"
+	"github.com/milvus-io/milvus/tests/go_client/common"
+	hp "github.com/milvus-io/milvus/tests/go_client/testcases/helper"
+)
+
+const (
+	textLOBIDField       = "id"
+	textLOBVectorField   = "vector"
+	textLOBContentField  = "content"
+	textLOBAltField      = "content_alt"
+	textLOBSentinelField = "content_sentinel"
+	textLOBSparseField   = "content_sparse"
+	textLOBVectorIndex   = "text_lob_vector_idx"
+	textLOBSparseIndex   = "text_lob_sparse_idx"
+	textLOBVectorDim     = 16
+)
+
+type textLOBRow struct {
+	id       int64
+	vector   []float32
+	content  *string
+	alt      *string
+	sentinel string
+}
+
+type textLOBFixture struct {
+	collectionName string
+	rows           []textLOBRow
+	rowsByID       map[int64]textLOBRow
+}
+
+func textLOBValue(value string) *string {
+	return &value
+}
+
+func makeTextLOB(size int, seed string) string {
+	if size == 0 {
+		return ""
+	}
+	base := fmt.Sprintf("seed %s vector database milvus text lob storage bm25 payload boundary checksum %s ", seed, seed)
+	return strings.Repeat(base, size/len(base)+1)[:size]
+}
+
+func newTextLOBRows() []textLOBRow {
+	contents := []*string{
+		textLOBValue("vector database milvus text lob smoke"),
+		textLOBValue(""),
+		nil,
+		textLOBValue("Milvus stores multilingual text: English 中文 日本語 Русский العربية emoji 😀🚀 데이터베이스"),
+		textLOBValue(makeTextLOB(64*1024-17, "below-64k")),
+		textLOBValue(makeTextLOB(64*1024, "at-64k")),
+		textLOBValue(makeTextLOB(64*1024+4096, "above-64k")),
+		textLOBValue(makeTextLOB(1024*1024, "one-mib")),
+	}
+	alternates := []*string{
+		textLOBValue("alternate vector database payload"),
+		textLOBValue(""),
+		nil,
+		textLOBValue("alternate multilingual 中文 payload 😀"),
+		textLOBValue("alternate below boundary payload"),
+		textLOBValue("alternate at boundary payload"),
+		textLOBValue("alternate above boundary payload"),
+		textLOBValue(makeTextLOB(128*1024, "alternate-one-mib")),
+	}
+
+	rows := make([]textLOBRow, len(contents))
+	for i := range contents {
+		vector := make([]float32, textLOBVectorDim)
+		vector[i] = 1
+		rows[i] = textLOBRow{
+			id:       int64(i),
+			vector:   vector,
+			content:  contents[i],
+			alt:      alternates[i],
+			sentinel: fmt.Sprintf("sentinel text output %d", i),
+		}
+	}
+	return rows
+}
+
+func textLOBCollectionSchema(collectionName string) *entity.Schema {
+	analyzerParams := map[string]any{"tokenizer": "standard"}
+	return entity.NewSchema().WithName(collectionName).
+		WithField(entity.NewField().WithName(textLOBIDField).WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
+		WithField(entity.NewField().WithName(textLOBVectorField).WithDataType(entity.FieldTypeFloatVector).WithDim(textLOBVectorDim)).
+		WithField(entity.NewField().WithName(textLOBContentField).WithDataType(entity.FieldTypeText).WithNullable(true).
+			WithEnableAnalyzer(true).WithEnableMatch(true).WithAnalyzerParams(analyzerParams)).
+		WithField(entity.NewField().WithName(textLOBAltField).WithDataType(entity.FieldTypeText).WithNullable(true).
+			WithEnableAnalyzer(true).WithEnableMatch(true).WithAnalyzerParams(analyzerParams)).
+		WithField(entity.NewField().WithName(textLOBSentinelField).WithDataType(entity.FieldTypeText).
+			WithEnableAnalyzer(true).WithEnableMatch(true).WithAnalyzerParams(analyzerParams)).
+		WithField(entity.NewField().WithName(textLOBSparseField).WithDataType(entity.FieldTypeSparseVector)).
+		WithFunction(entity.NewFunction().WithName("content_bm25").WithType(entity.FunctionTypeBM25).
+			WithInputFields(textLOBContentField).WithOutputFields(textLOBSparseField))
+}
+
+func nullableTextLOBColumn(t *testing.T, fieldName string, rows []textLOBRow, value func(textLOBRow) *string) *column.ColumnText {
+	t.Helper()
+
+	values := make([]string, 0, len(rows))
+	validData := make([]bool, len(rows))
+	for i, row := range rows {
+		if text := value(row); text != nil {
+			values = append(values, *text)
+			validData[i] = true
+		}
+	}
+	result, err := column.NewNullableColumnText(fieldName, values, validData)
+	require.NoError(t, err)
+	return result
+}
+
+func prepareTextLOBFixture(t *testing.T, ctx context.Context, mc *base.MilvusClient) textLOBFixture {
+	t.Helper()
+
+	collectionName := common.GenRandomString("text_lob", 6)
+	schema := textLOBCollectionSchema(collectionName)
+	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collectionName, schema).
+		WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		common.CheckErr(t, mc.DropCollection(cleanupCtx, client.NewDropCollectionOption(collectionName)), true)
+	})
+
+	rows := newTextLOBRows()
+	ids := make([]int64, len(rows))
+	vectors := make([][]float32, len(rows))
+	sentinels := make([]string, len(rows))
+	rowsByID := make(map[int64]textLOBRow, len(rows))
+	for i, row := range rows {
+		ids[i] = row.id
+		vectors[i] = row.vector
+		sentinels[i] = row.sentinel
+		rowsByID[row.id] = row
+	}
+
+	contentColumn := nullableTextLOBColumn(t, textLOBContentField, rows, func(row textLOBRow) *string {
+		return row.content
+	})
+	altColumn := nullableTextLOBColumn(t, textLOBAltField, rows, func(row textLOBRow) *string {
+		return row.alt
+	})
+	insertResult, err := mc.Insert(ctx, client.NewColumnBasedInsertOption(collectionName).
+		WithInt64Column(textLOBIDField, ids).
+		WithFloatVectorColumn(textLOBVectorField, textLOBVectorDim, vectors).
+		WithColumns(contentColumn, altColumn).
+		WithTextColumn(textLOBSentinelField, sentinels))
+	common.CheckErr(t, err, true)
+	require.EqualValues(t, len(rows), insertResult.InsertCount)
+
+	flushTask, err := mc.Flush(ctx, client.NewFlushOption(collectionName))
+	common.CheckErr(t, err, true)
+	common.CheckErr(t, flushTask.Await(ctx), true)
+
+	vectorIndexTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(
+		collectionName,
+		textLOBVectorField,
+		index.NewFlatIndex(entity.COSINE),
+	).WithIndexName(textLOBVectorIndex))
+	common.CheckErr(t, err, true)
+	common.CheckErr(t, vectorIndexTask.Await(ctx), true)
+
+	sparseIndexTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(
+		collectionName,
+		textLOBSparseField,
+		index.NewSparseInvertedIndex(entity.BM25, 0.1),
+	).WithIndexName(textLOBSparseIndex))
+	common.CheckErr(t, err, true)
+	common.CheckErr(t, sparseIndexTask.Await(ctx), true)
+
+	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collectionName))
+	common.CheckErr(t, err, true)
+	common.CheckErr(t, loadTask.Await(ctx), true)
+
+	return textLOBFixture{
+		collectionName: collectionName,
+		rows:           rows,
+		rowsByID:       rowsByID,
+	}
+}
+
+func requireExactTextLOB(t *testing.T, expected, actual string) {
+	t.Helper()
+	require.Equal(t, len(expected), len(actual), "TEXT byte length mismatch")
+	require.Equal(t, utf8.RuneCountInString(expected), utf8.RuneCountInString(actual), "TEXT character length mismatch")
+	require.Equal(t, sha256.Sum256([]byte(expected)), sha256.Sum256([]byte(actual)), "TEXT checksum mismatch")
+}
+
+func requireTextLOBResultRows(
+	t *testing.T,
+	result client.ResultSet,
+	idColumn column.Column,
+	expected map[int64]textLOBRow,
+) []int64 {
+	t.Helper()
+
+	require.NotNil(t, idColumn)
+	contentColumn := result.GetColumn(textLOBContentField)
+	altColumn := result.GetColumn(textLOBAltField)
+	sentinelColumn := result.GetColumn(textLOBSentinelField)
+	require.IsType(t, &column.ColumnText{}, contentColumn)
+	require.IsType(t, &column.ColumnText{}, altColumn)
+	require.IsType(t, &column.ColumnText{}, sentinelColumn)
+	require.Equal(t, entity.FieldTypeText, contentColumn.Type())
+	require.Equal(t, entity.FieldTypeText, altColumn.Type())
+	require.Equal(t, entity.FieldTypeText, sentinelColumn.Type())
+
+	ids := make([]int64, result.Len())
+	for i := 0; i < result.Len(); i++ {
+		id, err := idColumn.GetAsInt64(i)
+		require.NoError(t, err)
+		row, ok := expected[id]
+		require.True(t, ok, "unexpected primary key %d", id)
+		ids[i] = id
+
+		for _, field := range []struct {
+			column   column.Column
+			expected *string
+		}{
+			{column: contentColumn, expected: row.content},
+			{column: altColumn, expected: row.alt},
+		} {
+			isNull, err := field.column.IsNull(i)
+			require.NoError(t, err)
+			if field.expected == nil {
+				require.True(t, isNull)
+				continue
+			}
+			require.False(t, isNull)
+			actual, err := field.column.GetAsString(i)
+			require.NoError(t, err)
+			requireExactTextLOB(t, *field.expected, actual)
+		}
+
+		actualSentinel, err := sentinelColumn.GetAsString(i)
+		require.NoError(t, err)
+		requireExactTextLOB(t, row.sentinel, actualSentinel)
+	}
+	return ids
+}
+
+func TestTextLOBPublicSDKL0(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+	previousStorageV3, err := hp.AlterServerConfig("common.storage.useLoonFFI", "true")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = hp.AlterServerConfig("common.storage.useLoonFFI", previousStorageV3)
+	})
+	fixture := prepareTextLOBFixture(t, ctx, mc)
+
+	t.Run("schema_and_payloads", func(t *testing.T) {
+		description, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(fixture.collectionName))
+		common.CheckErr(t, err, true)
+
+		fields := make(map[string]*entity.Field, len(description.Schema.Fields))
+		for _, field := range description.Schema.Fields {
+			fields[field.Name] = field
+		}
+		for _, fieldName := range []string{textLOBContentField, textLOBAltField, textLOBSentinelField} {
+			require.Contains(t, fields, fieldName)
+			require.Equal(t, entity.FieldTypeText, fields[fieldName].DataType)
+		}
+		require.Len(t, description.Schema.Functions, 1)
+		function := description.Schema.Functions[0]
+		require.Equal(t, entity.FunctionTypeBM25, function.Type)
+		require.Equal(t, []string{textLOBContentField}, function.InputFieldNames)
+		require.Equal(t, []string{textLOBSparseField}, function.OutputFieldNames)
+
+		sparseIndex, err := mc.DescribeIndex(ctx, client.NewDescribeIndexOption(fixture.collectionName, textLOBSparseIndex))
+		common.CheckErr(t, err, true)
+		require.Equal(t, index.SparseInverted, sparseIndex.IndexType())
+		require.Equal(t, string(entity.BM25), sparseIndex.Params()[index.MetricTypeKey])
+
+		result, err := mc.Query(ctx, client.NewQueryOption(fixture.collectionName).
+			WithFilter(fmt.Sprintf("%s >= 0", textLOBIDField)).
+			WithOutputFields(textLOBIDField, textLOBContentField, textLOBAltField, textLOBSentinelField).
+			WithConsistencyLevel(entity.ClStrong).
+			WithLimit(len(fixture.rows)))
+		common.CheckErr(t, err, true)
+		require.Equal(t, len(fixture.rows), result.Len())
+		ids := requireTextLOBResultRows(t, result, result.GetColumn(textLOBIDField), fixture.rowsByID)
+		require.ElementsMatch(t, []int64{0, 1, 2, 3, 4, 5, 6, 7}, ids)
+	})
+
+	t.Run("dense_search_output_fields", func(t *testing.T) {
+		results, err := mc.Search(ctx, client.NewSearchOption(
+			fixture.collectionName,
+			3,
+			[]entity.Vector{entity.FloatVector(fixture.rows[0].vector)},
+		).WithANNSField(textLOBVectorField).
+			WithOutputFields(textLOBContentField, textLOBAltField, textLOBSentinelField).
+			WithConsistencyLevel(entity.ClStrong))
+		common.CheckErr(t, err, true)
+		require.Len(t, results, 1)
+		require.Equal(t, 3, results[0].Len())
+		ids := requireTextLOBResultRows(t, results[0], results[0].IDs, fixture.rowsByID)
+		require.Equal(t, int64(0), ids[0])
+	})
+
+	t.Run("query_iterator_payloads", func(t *testing.T) {
+		iterator, err := mc.QueryIterator(ctx, client.NewQueryIteratorOption(fixture.collectionName).
+			WithBatchSize(3).
+			WithFilter(fmt.Sprintf("%s >= 0", textLOBIDField)).
+			WithOutputFields(textLOBIDField, textLOBContentField, textLOBAltField, textLOBSentinelField).
+			WithConsistencyLevel(entity.ClStrong))
+		common.CheckErr(t, err, true)
+
+		seen := make(map[int64]struct{}, len(fixture.rows))
+		for {
+			batch, err := iterator.Next(ctx)
+			if err == io.EOF {
+				break
+			}
+			common.CheckErr(t, err, true)
+			require.NotZero(t, batch.Len())
+			require.LessOrEqual(t, batch.Len(), 3)
+			ids := requireTextLOBResultRows(t, batch, batch.GetColumn(textLOBIDField), fixture.rowsByID)
+			for _, id := range ids {
+				_, duplicated := seen[id]
+				require.False(t, duplicated, "duplicate primary key %d", id)
+				seen[id] = struct{}{}
+			}
+		}
+		require.Len(t, seen, len(fixture.rows))
+	})
+}

--- a/tests/go_client/testcases/text_lob_test.go
+++ b/tests/go_client/testcases/text_lob_test.go
@@ -491,22 +491,11 @@ func TestTextLOBPublicSDKL0(t *testing.T) {
 	require.Less(t, textLOBUnindexedSealedRows, textLOBMinRowsToEnableIndex)
 	require.GreaterOrEqual(t, textLOBIndexedSealedRows, textLOBMinRowsToEnableIndex)
 
-	previousStorageV3, err := hp.GetServerConfig("common.storage.useLoonFFI")
+	storageV3, err := hp.GetServerConfig("common.storage.useLoonFFI")
 	require.NoError(t, err)
-	_, err = hp.AlterServerConfig("common.storage.useLoonFFI", "true")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_, _ = hp.AlterServerConfig("common.storage.useLoonFFI", previousStorageV3)
-	})
+	require.Equal(t, "true", storageV3)
 
 	minRowsValue := strconv.Itoa(textLOBMinRowsToEnableIndex)
-	previousMinRows, err := hp.GetServerConfig(textLOBMinRowsConfig)
-	require.NoError(t, err)
-	_, err = hp.AlterServerConfig(textLOBMinRowsConfig, minRowsValue)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_, _ = hp.AlterServerConfig(textLOBMinRowsConfig, previousMinRows)
-	})
 	configuredMinRows, err := hp.GetServerConfig(textLOBMinRowsConfig)
 	require.NoError(t, err)
 	require.Equal(t, minRowsValue, configuredMinRows)


### PR DESCRIPTION
## What was changed

- Add Go SDK v3 schema and metadata support for the `Text` field type.
- Add scalar and nullable `Text` columns.
- Support `Text` in column-based writes, row conversion, query results, and search results.
- Add unit tests for schema, column conversion, write options, row conversion, and result decoding.
- Add comprehensive Go SDK L0 E2E coverage.

## E2E coverage

The TEXT L0 suite covers:

- 3,000 rows in an indexed sealed segment.
- 500 rows in an unindexed sealed segment.
- 500 rows in a growing segment.
- Standard and Jieba analyzers with BM25 functions and sparse indexes.
- HNSW search across all three execution paths.
- Empty, NULL, multilingual, 64 KiB boundary, and 1 MiB TEXT payloads.
- Exact payload validation using byte length, character count, and SHA-256.
- Query, dense search, BM25 search, and query iterator result decoding.
- Upsert transitions including NULL-to-large-TEXT, TEXT-to-large-TEXT, and TEXT-to-NULL.
- Deletion of a 1 MiB TEXT row and validation of all surviving rows.

## Validation

- Go SDK unit tests passed.
- Go SDK lint passed with 0 issues.
- `TestTextLOBPublicSDKL0` passed against standalone Milvus.
- DCO sign-offs are present.

issue: #52088
