### PR TITLE
fix: [cp 3.0] prevent streaming cutover deadlock

### DIFF
--- a/internal/rootcoord/dml_channels.go
+++ b/internal/rootcoord/dml_channels.go
@@ -36,8 +36,9 @@ import (
 )
 
 type dmlMsgStream struct {
-	ms    msgstream.MsgStream
-	mutex sync.RWMutex
+	ms     msgstream.MsgStream
+	mutex  sync.RWMutex
+	closed bool
 
 	refcnt int64 // current in use count
 	used   int64 // total used counter in current run, not stored in meta so meant to be inaccurate
@@ -82,6 +83,43 @@ func (dms *dmlMsgStream) DecRefCnt() {
 	} else {
 		mlog.Warn(context.TODO(), "Try to remove channel with no ref count", mlog.Int64("idx", dms.idx))
 	}
+}
+
+func (dms *dmlMsgStream) broadcast(ctx context.Context, pack *msgstream.MsgPack) (map[string][]msgstream.MessageID, error) {
+	dms.mutex.RLock()
+	defer dms.mutex.RUnlock()
+
+	if dms.closed {
+		return nil, merr.WrapErrServiceNotReadyMsg("legacy dml msgstream is closed")
+	}
+	if dms.refcnt <= 0 {
+		return nil, nil
+	}
+	return dms.ms.Broadcast(ctx, pack)
+}
+
+func (dms *dmlMsgStream) broadcastMark(ctx context.Context, pack *msgstream.MsgPack) (map[string][]msgstream.MessageID, error) {
+	dms.mutex.RLock()
+	defer dms.mutex.RUnlock()
+
+	if dms.closed {
+		return nil, merr.WrapErrServiceNotReadyMsg("legacy dml msgstream is closed")
+	}
+	if dms.refcnt <= 0 {
+		return nil, merr.WrapErrServiceInternalMsg("channel not in use")
+	}
+	return dms.ms.Broadcast(ctx, pack)
+}
+
+func (dms *dmlMsgStream) close() {
+	dms.mutex.Lock()
+	defer dms.mutex.Unlock()
+
+	if dms.closed {
+		return
+	}
+	dms.closed = true
+	dms.ms.Close()
 }
 
 // channelsHeap implements heap.Interface to performs like an priority queue.
@@ -180,6 +218,7 @@ func newDmlChannels(initCtx context.Context, factory msgstream.Factory, chanName
 
 	for i, name := range names {
 		var ms msgstream.MsgStream
+		var closeNotifier *snmanager.StreamingReadyNotifier
 		if !streamingutil.IsStreamingServiceEnabled() {
 			ms = d.newMsgstream(initCtx, factory, name)
 		} else {
@@ -191,14 +230,7 @@ func newDmlChannels(initCtx context.Context, factory msgstream.Factory, chanName
 			if !notifier.IsReady() {
 				logger.Info(initCtx, "streaming service is not enabled, create a msgstream to use")
 				ms = d.newMsgstream(initCtx, factory, name)
-				go func() {
-					defer notifier.Release()
-					<-notifier.Ready()
-					// release the msgstream.
-					logger.Info(initCtx, "streaming service is enabled, release the msgstream...")
-					ms.Close()
-					logger.Info(initCtx, "streaming service is enabled, release the msgstream done")
-				}()
+				closeNotifier = notifier
 			} else {
 				logger.Info(initCtx, "streaming service has been enabled, msgstream should not be created")
 				notifier.Release()
@@ -213,6 +245,18 @@ func newDmlChannels(initCtx context.Context, factory msgstream.Factory, chanName
 		}
 		d.pool.Insert(name, dms)
 		d.channelsHeap = append(d.channelsHeap, dms)
+
+		if closeNotifier != nil {
+			go func(notifier *snmanager.StreamingReadyNotifier, stream *dmlMsgStream, pchannel string) {
+				defer notifier.Release()
+				<-notifier.Ready()
+				// release the msgstream.
+				logger := mlog.With(mlog.String("pchannel", pchannel))
+				logger.Info(initCtx, "streaming service is enabled, release the msgstream...")
+				stream.close()
+				logger.Info(initCtx, "streaming service is enabled, release the msgstream done")
+			}(closeNotifier, dms, name)
+		}
 	}
 
 	heap.Init(&d.channelsHeap)
@@ -322,15 +366,10 @@ func (d *dmlChannels) broadcast(chanNames []string, pack *msgstream.MsgPack) err
 			return err
 		}
 
-		dms.mutex.RLock()
-		if dms.refcnt > 0 {
-			if _, err := dms.ms.Broadcast(d.ctx, pack); err != nil {
-				mlog.Error(d.ctx, "Broadcast failed", mlog.Err(err), mlog.String("chanName", chanName))
-				dms.mutex.RUnlock()
-				return err
-			}
+		if _, err := dms.broadcast(d.ctx, pack); err != nil {
+			mlog.Error(d.ctx, "Broadcast failed", mlog.Err(err), mlog.String("chanName", chanName))
+			return err
 		}
-		dms.mutex.RUnlock()
 	}
 	return nil
 }
@@ -343,25 +382,17 @@ func (d *dmlChannels) broadcastMark(chanNames []string, pack *msgstream.MsgPack)
 			return result, err
 		}
 
-		dms.mutex.RLock()
-		if dms.refcnt > 0 {
-			ids, err := dms.ms.Broadcast(d.ctx, pack)
-			if err != nil {
-				mlog.Error(d.ctx, "BroadcastMark failed", mlog.Err(err), mlog.String("chanName", chanName))
-				dms.mutex.RUnlock()
-				return result, err
-			}
-			for cn, idList := range ids {
-				// idList should have length 1, just flat by iteration
-				for _, id := range idList {
-					result[cn] = id.Serialize()
-				}
-			}
-		} else {
-			dms.mutex.RUnlock()
-			return nil, merr.WrapErrServiceInternalMsg("channel not in use: %s", chanName)
+		ids, err := dms.broadcastMark(d.ctx, pack)
+		if err != nil {
+			mlog.Error(d.ctx, "BroadcastMark failed", mlog.Err(err), mlog.String("chanName", chanName))
+			return result, merr.Wrapf(err, "channel %s", chanName)
 		}
-		dms.mutex.RUnlock()
+		for cn, idList := range ids {
+			// idList should have length 1, just flat by iteration
+			for _, id := range idList {
+				result[cn] = id.Serialize()
+			}
+		}
 	}
 	return result, nil
 }

--- a/internal/rootcoord/dml_channels.go
+++ b/internal/rootcoord/dml_channels.go
@@ -113,12 +113,13 @@ func (dms *dmlMsgStream) broadcastMark(ctx context.Context, pack *msgstream.MsgP
 
 func (dms *dmlMsgStream) close() {
 	dms.mutex.Lock()
-	defer dms.mutex.Unlock()
-
 	if dms.closed {
+		dms.mutex.Unlock()
 		return
 	}
 	dms.closed = true
+	dms.mutex.Unlock()
+
 	dms.ms.Close()
 }
 

--- a/internal/rootcoord/dml_channels_test.go
+++ b/internal/rootcoord/dml_channels_test.go
@@ -21,8 +21,11 @@ import (
 	"context"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/mq/common"
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -53,6 +57,61 @@ func TestDmlMsgStream(t *testing.T) {
 		assert.Equal(t, int64(0), dms.RefCnt())
 		assert.Equal(t, int64(1), dms.Used())
 	})
+}
+
+func TestDmlMsgStreamCloseWaitsForBroadcast(t *testing.T) {
+	ms := &FailMsgStream{}
+	broadcastStarted := make(chan struct{})
+	releaseBroadcast := make(chan struct{})
+	var broadcastCalls atomic.Int32
+
+	mockBroadcast := mockey.Mock((*FailMsgStream).Broadcast).To(
+		func(_ *FailMsgStream, _ context.Context, _ *msgstream.MsgPack) (map[string][]msgstream.MessageID, error) {
+			broadcastCalls.Add(1)
+			close(broadcastStarted)
+			<-releaseBroadcast
+			return nil, nil
+		}).Build()
+	defer mockBroadcast.UnPatch()
+
+	dms := &dmlMsgStream{
+		ms:     ms,
+		refcnt: 1,
+	}
+
+	broadcastDone := make(chan error, 1)
+	go func() {
+		_, err := dms.broadcast(context.Background(), nil)
+		broadcastDone <- err
+	}()
+	<-broadcastStarted
+
+	closeDone := make(chan struct{})
+	go func() {
+		dms.close()
+		close(closeDone)
+	}()
+
+	select {
+	case <-closeDone:
+		t.Fatal("dml msgstream close finished while a broadcast was still running")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releaseBroadcast)
+	require.NoError(t, <-broadcastDone)
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		t.Fatal("dml msgstream close did not finish")
+	}
+
+	_, err := dms.broadcast(context.Background(), nil)
+	assert.ErrorIs(t, err, merr.ErrServiceNotReady)
+	_, err = dms.broadcastMark(context.Background(), nil)
+	assert.ErrorIs(t, err, merr.ErrServiceNotReady)
+	dms.close()
+	assert.Equal(t, int32(1), broadcastCalls.Load())
 }
 
 func TestChannelsHeap(t *testing.T) {

--- a/internal/rootcoord/dml_channels_test.go
+++ b/internal/rootcoord/dml_channels_test.go
@@ -60,10 +60,29 @@ func TestDmlMsgStream(t *testing.T) {
 }
 
 func TestDmlMsgStreamCloseWaitsForBroadcast(t *testing.T) {
-	ms := &FailMsgStream{}
 	broadcastStarted := make(chan struct{})
 	releaseBroadcast := make(chan struct{})
+	closeStarted := make(chan struct{})
+	releaseClose := make(chan struct{})
 	var broadcastCalls atomic.Int32
+	var closeCalls atomic.Int32
+	var releaseBroadcastOnce sync.Once
+	var releaseCloseOnce sync.Once
+	releaseBlockedBroadcast := func() {
+		releaseBroadcastOnce.Do(func() { close(releaseBroadcast) })
+	}
+	releaseBlockedClose := func() {
+		releaseCloseOnce.Do(func() { close(releaseClose) })
+	}
+	defer releaseBlockedBroadcast()
+	defer releaseBlockedClose()
+	ms := &FailMsgStream{
+		closeHook: func() {
+			closeCalls.Add(1)
+			close(closeStarted)
+			<-releaseClose
+		},
+	}
 
 	mockBroadcast := mockey.Mock((*FailMsgStream).Broadcast).To(
 		func(_ *FailMsgStream, _ context.Context, _ *msgstream.MsgPack) (map[string][]msgstream.MessageID, error) {
@@ -98,20 +117,40 @@ func TestDmlMsgStreamCloseWaitsForBroadcast(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 	}
 
-	close(releaseBroadcast)
+	releaseBlockedBroadcast()
 	require.NoError(t, <-broadcastDone)
 	select {
-	case <-closeDone:
+	case <-closeStarted:
 	case <-time.After(time.Second):
-		t.Fatal("dml msgstream close did not finish")
+		t.Fatal("dml msgstream close did not start")
 	}
 
 	_, err := dms.broadcast(context.Background(), nil)
 	assert.ErrorIs(t, err, merr.ErrServiceNotReady)
 	_, err = dms.broadcastMark(context.Background(), nil)
 	assert.ErrorIs(t, err, merr.ErrServiceNotReady)
+
+	stateReadDone := make(chan [2]int64, 1)
+	go func() {
+		stateReadDone <- [2]int64{dms.RefCnt(), dms.Used()}
+	}()
+	select {
+	case state := <-stateReadDone:
+		assert.Equal(t, [2]int64{1, 0}, state)
+	case <-time.After(time.Second):
+		t.Fatal("dml msgstream state reads blocked on the underlying close")
+	}
+
+	releaseBlockedClose()
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		t.Fatal("dml msgstream close did not finish")
+	}
+
 	dms.close()
 	assert.Equal(t, int32(1), broadcastCalls.Load())
+	assert.Equal(t, int32(1), closeCalls.Load())
 }
 
 func TestChannelsHeap(t *testing.T) {
@@ -334,9 +373,14 @@ func (f *FailMessageStreamFactory) NewTtMsgStream(ctx context.Context) (msgstrea
 type FailMsgStream struct {
 	msgstream.MsgStream
 	errBroadcast bool
+	closeHook    func()
 }
 
-func (ms *FailMsgStream) Close()                                                {}
+func (ms *FailMsgStream) Close() {
+	if ms.closeHook != nil {
+		ms.closeHook()
+	}
+}
 func (ms *FailMsgStream) Chan() <-chan *msgstream.ConsumeMsgPack                { return nil }
 func (ms *FailMsgStream) GetUnmarshalDispatcher() msgstream.UnmarshalDispatcher { return nil }
 func (ms *FailMsgStream) AsProducer(ctx context.Context, channels []string)     {}

--- a/internal/streamingcoord/server/balancer/channel/manager.go
+++ b/internal/streamingcoord/server/balancer/channel/manager.go
@@ -354,6 +354,7 @@ func (cm *ChannelManager) MarkStreamingHasEnabled(ctx context.Context) error {
 		notifier.BlockUntilFinish()
 	}
 	cm.streamingEnableNotifiers = nil
+	cm.cond.UnsafeBroadcast()
 	return nil
 }
 

--- a/internal/streamingcoord/server/balancer/channel/manager.go
+++ b/internal/streamingcoord/server/balancer/channel/manager.go
@@ -330,9 +330,9 @@ func (cm *ChannelManager) TriggerWatchUpdate() {
 // MarkStreamingHasEnabled marks the streaming service has been enabled.
 func (cm *ChannelManager) MarkStreamingHasEnabled(ctx context.Context) error {
 	cm.cond.L.Lock()
+	defer cm.cond.L.Unlock()
 
 	if cm.streamingVersion != nil {
-		cm.cond.L.Unlock()
 		return nil
 	}
 
@@ -342,23 +342,18 @@ func (cm *ChannelManager) MarkStreamingHasEnabled(ctx context.Context) error {
 
 	if err := resource.Resource().StreamingCatalog().SaveVersion(ctx, cm.streamingVersion); err != nil {
 		cm.Logger().Error(ctx, "failed to save streaming version", mlog.Err(err))
-		cm.cond.L.Unlock()
 		return err
 	}
 
-	notifiers := cm.streamingEnableNotifiers
-	cm.streamingEnableNotifiers = nil
-	cm.cond.UnsafeBroadcast()
-	cm.cond.L.Unlock()
-
 	// notify all notifiers that the streaming service has been enabled.
-	for _, notifier := range notifiers {
+	for _, notifier := range cm.streamingEnableNotifiers {
 		notifier.Cancel()
 	}
 	// and block until the listener of notifiers are finished.
-	for _, notifier := range notifiers {
+	for _, notifier := range cm.streamingEnableNotifiers {
 		notifier.BlockUntilFinish()
 	}
+	cm.streamingEnableNotifiers = nil
 	return nil
 }
 

--- a/internal/streamingcoord/server/balancer/channel/manager.go
+++ b/internal/streamingcoord/server/balancer/channel/manager.go
@@ -330,9 +330,9 @@ func (cm *ChannelManager) TriggerWatchUpdate() {
 // MarkStreamingHasEnabled marks the streaming service has been enabled.
 func (cm *ChannelManager) MarkStreamingHasEnabled(ctx context.Context) error {
 	cm.cond.L.Lock()
-	defer cm.cond.L.Unlock()
 
 	if cm.streamingVersion != nil {
+		cm.cond.L.Unlock()
 		return nil
 	}
 
@@ -342,18 +342,23 @@ func (cm *ChannelManager) MarkStreamingHasEnabled(ctx context.Context) error {
 
 	if err := resource.Resource().StreamingCatalog().SaveVersion(ctx, cm.streamingVersion); err != nil {
 		cm.Logger().Error(ctx, "failed to save streaming version", mlog.Err(err))
+		cm.cond.L.Unlock()
 		return err
 	}
 
+	notifiers := cm.streamingEnableNotifiers
+	cm.streamingEnableNotifiers = nil
+	cm.cond.UnsafeBroadcast()
+	cm.cond.L.Unlock()
+
 	// notify all notifiers that the streaming service has been enabled.
-	for _, notifier := range cm.streamingEnableNotifiers {
+	for _, notifier := range notifiers {
 		notifier.Cancel()
 	}
 	// and block until the listener of notifiers are finished.
-	for _, notifier := range cm.streamingEnableNotifiers {
+	for _, notifier := range notifiers {
 		notifier.BlockUntilFinish()
 	}
-	cm.streamingEnableNotifiers = nil
 	return nil
 }
 

--- a/internal/streamingcoord/server/balancer/channel/manager_test.go
+++ b/internal/streamingcoord/server/balancer/channel/manager_test.go
@@ -3,11 +3,14 @@ package channel
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -503,6 +506,90 @@ func TestStreamingEnableChecker(t *testing.T) {
 	m.RegisterStreamingEnabledNotifier(n2)
 	assert.Error(t, n.Context().Err())
 	assert.Error(t, n2.Context().Err())
+}
+
+func TestMarkStreamingHasEnabledDoesNotHoldLockWhileWaiting(t *testing.T) {
+	ctx := context.Background()
+	ResetStaticPChannelStatsManager()
+	RecoverPChannelStatsManager([]string{})
+
+	catalog := mock_metastore.NewMockStreamingCoordCataLog(t)
+	s := sessionutil.NewMockSession(t)
+	s.EXPECT().GetRegisteredRevision().Return(int64(1))
+	resource.InitForTest(resource.OptStreamingCatalog(catalog), resource.OptSession(s))
+	catalog.EXPECT().GetCChannel(mock.Anything).Return(&streamingpb.CChannelMeta{
+		Pchannel: "test-channel",
+	}, nil)
+	catalog.EXPECT().GetVersion(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().SaveVersion(mock.Anything, mock.Anything).Return(nil)
+	catalog.EXPECT().ListPChannel(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().GetReplicateConfiguration(mock.Anything).Return(nil, nil)
+
+	m, err := RecoverChannelManager(ctx, "test-channel")
+	require.NoError(t, err)
+
+	n := syncutil.NewAsyncTaskNotifier[struct{}]()
+	m.RegisterStreamingEnabledNotifier(n)
+	waitDone := make(chan error, 1)
+	go func() {
+		waitDone <- m.WaitUntilStreamingEnabled(ctx)
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	listenerCanceled := make(chan struct{})
+	releaseListener := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(releaseListener)
+		})
+	}
+	t.Cleanup(release)
+
+	go func() {
+		<-n.Context().Done()
+		close(listenerCanceled)
+		<-releaseListener
+		n.Finish(struct{}{})
+	}()
+
+	markDone := make(chan error, 1)
+	go func() {
+		markDone <- m.MarkStreamingHasEnabled(ctx)
+	}()
+	<-listenerCanceled
+
+	select {
+	case err := <-waitDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		release()
+		require.NoError(t, <-markDone)
+		t.Fatal("streaming-enable waiters were not notified after the version was persisted")
+	}
+
+	readDone := make(chan bool, 1)
+	go func() {
+		readDone <- m.IsStreamingEnabledOnce()
+	}()
+
+	select {
+	case enabled := <-readDone:
+		assert.True(t, enabled)
+	case <-time.After(time.Second):
+		release()
+		require.NoError(t, <-markDone)
+		t.Fatal("ChannelManager lock is held while waiting for a streaming-enable listener")
+	}
+
+	select {
+	case err := <-markDone:
+		t.Fatalf("MarkStreamingHasEnabled returned before listener finished: %v", err)
+	default:
+	}
+
+	release()
+	require.NoError(t, <-markDone)
 }
 
 func TestChannelManagerWatch(t *testing.T) {

--- a/internal/streamingcoord/server/balancer/channel/manager_test.go
+++ b/internal/streamingcoord/server/balancer/channel/manager_test.go
@@ -3,7 +3,6 @@ package channel
 import (
 	"context"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -508,7 +507,7 @@ func TestStreamingEnableChecker(t *testing.T) {
 	assert.Error(t, n2.Context().Err())
 }
 
-func TestMarkStreamingHasEnabledDoesNotHoldLockWhileWaiting(t *testing.T) {
+func TestMarkStreamingHasEnabledWaitsForListenersBeforePublishing(t *testing.T) {
 	ctx := context.Background()
 	ResetStaticPChannelStatsManager()
 	RecoverPChannelStatsManager([]string{})
@@ -530,22 +529,9 @@ func TestMarkStreamingHasEnabledDoesNotHoldLockWhileWaiting(t *testing.T) {
 
 	n := syncutil.NewAsyncTaskNotifier[struct{}]()
 	m.RegisterStreamingEnabledNotifier(n)
-	waitDone := make(chan error, 1)
-	go func() {
-		waitDone <- m.WaitUntilStreamingEnabled(ctx)
-	}()
-	time.Sleep(50 * time.Millisecond)
 
 	listenerCanceled := make(chan struct{})
 	releaseListener := make(chan struct{})
-	var releaseOnce sync.Once
-	release := func() {
-		releaseOnce.Do(func() {
-			close(releaseListener)
-		})
-	}
-	t.Cleanup(release)
-
 	go func() {
 		<-n.Context().Done()
 		close(listenerCanceled)
@@ -559,27 +545,17 @@ func TestMarkStreamingHasEnabledDoesNotHoldLockWhileWaiting(t *testing.T) {
 	}()
 	<-listenerCanceled
 
-	select {
-	case err := <-waitDone:
-		require.NoError(t, err)
-	case <-time.After(time.Second):
-		release()
-		require.NoError(t, <-markDone)
-		t.Fatal("streaming-enable waiters were not notified after the version was persisted")
-	}
-
-	readDone := make(chan bool, 1)
+	waitDone := make(chan error, 1)
 	go func() {
-		readDone <- m.IsStreamingEnabledOnce()
+		waitDone <- m.WaitUntilStreamingEnabled(ctx)
 	}()
 
 	select {
-	case enabled := <-readDone:
-		assert.True(t, enabled)
-	case <-time.After(time.Second):
-		release()
+	case err := <-waitDone:
+		close(releaseListener)
 		require.NoError(t, <-markDone)
-		t.Fatal("ChannelManager lock is held while waiting for a streaming-enable listener")
+		t.Fatalf("streaming enabled was published before listener completion: %v", err)
+	case <-time.After(100 * time.Millisecond):
 	}
 
 	select {
@@ -588,8 +564,10 @@ func TestMarkStreamingHasEnabledDoesNotHoldLockWhileWaiting(t *testing.T) {
 	default:
 	}
 
-	release()
+	close(releaseListener)
 	require.NoError(t, <-markDone)
+	require.NoError(t, <-waitDone)
+	assert.True(t, m.IsStreamingEnabledOnce())
 }
 
 func TestChannelManagerWatch(t *testing.T) {

--- a/internal/streamingcoord/server/balancer/channel/manager_test.go
+++ b/internal/streamingcoord/server/balancer/channel/manager_test.go
@@ -570,6 +570,65 @@ func TestMarkStreamingHasEnabledWaitsForListenersBeforePublishing(t *testing.T) 
 	assert.True(t, m.IsStreamingEnabledOnce())
 }
 
+func TestMarkStreamingHasEnabledWakesParkedWaiters(t *testing.T) {
+	ctx := context.Background()
+	ResetStaticPChannelStatsManager()
+	RecoverPChannelStatsManager([]string{})
+
+	catalog := mock_metastore.NewMockStreamingCoordCataLog(t)
+	s := sessionutil.NewMockSession(t)
+	s.EXPECT().GetRegisteredRevision().Return(int64(1))
+	resource.InitForTest(resource.OptStreamingCatalog(catalog), resource.OptSession(s))
+	catalog.EXPECT().GetCChannel(mock.Anything).Return(&streamingpb.CChannelMeta{
+		Pchannel: "test-channel",
+	}, nil)
+	catalog.EXPECT().GetVersion(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().SaveVersion(mock.Anything, mock.Anything).Return(nil)
+	catalog.EXPECT().ListPChannel(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().GetReplicateConfiguration(mock.Anything).Return(nil, nil)
+
+	m, err := RecoverChannelManager(ctx, "test-channel")
+	require.NoError(t, err)
+
+	n := syncutil.NewAsyncTaskNotifier[struct{}]()
+	m.RegisterStreamingEnabledNotifier(n)
+
+	listenerCanceled := make(chan struct{})
+	releaseListener := make(chan struct{})
+	go func() {
+		<-n.Context().Done()
+		close(listenerCanceled)
+		<-releaseListener
+		n.Finish(struct{}{})
+	}()
+
+	m.cond.L.Lock()
+	parkedWaiter := m.cond.WaitChan()
+
+	markDone := make(chan error, 1)
+	go func() {
+		markDone <- m.MarkStreamingHasEnabled(ctx)
+	}()
+	<-listenerCanceled
+
+	select {
+	case <-parkedWaiter:
+		close(releaseListener)
+		require.NoError(t, <-markDone)
+		t.Fatal("streaming enable waiter was woken before listener completion")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releaseListener)
+	require.NoError(t, <-markDone)
+
+	select {
+	case <-parkedWaiter:
+	case <-time.After(time.Second):
+		t.Fatal("streaming enable waiter was not woken after listener completion")
+	}
+}
+
 func TestChannelManagerWatch(t *testing.T) {
 	ResetStaticPChannelStatsManager()
 	RecoverPChannelStatsManager([]string{})


### PR DESCRIPTION
issue: #52086
pr: #52123

- legacy RootCoord DML streams: serialize in-flight broadcasts with close during the streaming-service cutover
- streaming enable barrier: preserve listener completion ordering and wake parked waiters after cutover