### PR TITLE
test: [skip e2e] restrict Pulsar pod failure chaos to proxy pods

### DIFF
--- a/tests/python_client/chaos/chaos_objects/pod_failure/chaos_pulsar_pod_failure.yaml
+++ b/tests/python_client/chaos/chaos_objects/pod_failure/chaos_pulsar_pod_failure.yaml
@@ -10,6 +10,7 @@ spec:
     labelSelectors:
       release: milvus-chaos
       app: pulsarv3
+      component: proxy
   mode: fixed
   value: "1"
   action: pod-failure


### PR DESCRIPTION
### What changed

- Add `component: proxy` to the Pulsar pod-failure chaos selector.

### Current behavior

The current selector matches all pods labeled with `app=pulsarv3`. When all matched pods are put into pod-failure simultaneously, BookKeeper, brokers, ZooKeeper, and proxies are disrupted together.

After the chaos is removed, Bookie processes may attempt to re-register before their previous ZooKeeper sessions and ephemeral registration nodes have expired. The Bookie readiness health check then remains unhealthy, leaving the pods in `Running 0/1` and preventing the environment from fully recovering.

### Why

This chaos test is intended to interrupt connectivity between Milvus and Pulsar, rather than test the fault tolerance of the entire Pulsar cluster.

### Impact

Only Pulsar proxy pods are eligible for pod-failure injection. BookKeeper, brokers, ZooKeeper, and other Pulsar components remain untouched, while Milvus still loses access to Pulsar when all proxy pods are unavailable.

### Verification

- Parsed the updated Chaos Mesh YAML successfully.
- Applied the existing runtime release, mode, and value overrides and verified that the final selector retains `component: proxy`.
