### PR TITLE
fix: avoid probing absent TTL during schema bump (#51649)

### DIFF
--- a/internal/datanode/compactor/bump_schema_version_compactor.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor.go
@@ -338,35 +338,35 @@ func (t *bumpSchemaVersionCompactionTask) fullRewriteSegmentID() (int64, error) 
 	return idRange.GetBegin(), nil
 }
 
-func selectFullRewriteRecord(record storage.Record, pkField *schemapb.FieldSchema, entityFilter compaction.EntityFilter, ttlFieldID int64, useTTLField bool, ttlValues []int64) (*recordSelection, []int64, error) {
+func selectFullRewriteRecord(record storage.Record, pkField *schemapb.FieldSchema, entityFilter compaction.EntityFilter, ttlFieldID int64, useTTLField bool) (*recordSelection, error) {
 	pkArray := record.Column(pkField.GetFieldID())
 	var pkAt func(int) any
 	switch pkField.GetDataType() {
 	case schemapb.DataType_Int64:
 		int64Array, ok := pkArray.(*array.Int64)
 		if !ok {
-			return nil, nil, merr.WrapErrServiceInternal("int64 primary key field not found in full schema rewrite record")
+			return nil, merr.WrapErrServiceInternal("int64 primary key field not found in full schema rewrite record")
 		}
 		pkAt = func(i int) any { return int64Array.Value(i) }
 	case schemapb.DataType_VarChar:
 		stringArray, ok := pkArray.(*array.String)
 		if !ok {
-			return nil, nil, merr.WrapErrServiceInternal("varchar primary key field not found in full schema rewrite record")
+			return nil, merr.WrapErrServiceInternal("varchar primary key field not found in full schema rewrite record")
 		}
 		pkAt = func(i int) any { return stringArray.Value(i) }
 	default:
-		return nil, nil, merr.WrapErrServiceInternal("invalid primary key data type for full schema rewrite")
+		return nil, merr.WrapErrServiceInternal("invalid primary key data type for full schema rewrite")
 	}
 
 	timestampArray, ok := record.Column(common.TimeStampField).(*array.Int64)
 	if !ok {
-		return nil, nil, merr.WrapErrServiceInternal("timestamp field not found in full schema rewrite record")
+		return nil, merr.WrapErrServiceInternal("timestamp field not found in full schema rewrite record")
 	}
 	var ttlArray *array.Int64
 	if useTTLField {
 		ttlArray, ok = record.Column(ttlFieldID).(*array.Int64)
 		if !ok {
-			return nil, nil, merr.WrapErrServiceInternal("TTL field not found in full schema rewrite record")
+			return nil, merr.WrapErrServiceInternal("TTL field not found in full schema rewrite record")
 		}
 	}
 
@@ -388,9 +388,6 @@ func selectFullRewriteRecord(record storage.Record, pkField *schemapb.FieldSchem
 			continue
 		}
 
-		if useTTLField && expireTs > 0 {
-			ttlValues = append(ttlValues, expireTs)
-		}
 		if sliceStart == -1 {
 			sliceStart = i
 		}
@@ -400,9 +397,9 @@ func selectFullRewriteRecord(record storage.Record, pkField *schemapb.FieldSchem
 		selection.length += record.Len() - sliceStart
 	}
 	if filteredRows == 0 {
-		return nil, ttlValues, nil
+		return nil, nil
 	}
-	return selection, ttlValues, nil
+	return selection, nil
 }
 
 func (t *bumpSchemaVersionCompactionTask) runSchemaVersionBumpOnly() *datapb.CompactionPlanResult {
@@ -514,6 +511,11 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 		}
 	}()
 
+	// Source TTL presence is decided from existingFields, never by probing the
+	// record: V2/V3 records panic on Column for a field they do not carry.
+	_, sourceHasTTL := existingFields[ttlFieldID]
+	sourceHasTTLField := ttlFieldID >= common.StartOfUserFieldID && sourceHasTTL
+	preMaterializeFilter := len(delta) > 0 || t.plan.GetCollectionTtl() > 0 || sourceHasTTLField
 	var totalRows int64
 	for {
 		record, err := reader.Next()
@@ -524,11 +526,9 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 			return nil, err
 		}
 
-		sourceHasTTLField := ttlFieldID >= common.StartOfUserFieldID && record.Column(ttlFieldID) != nil
-		preMaterializeFilter := len(delta) > 0 || t.plan.GetCollectionTtl() > 0 || sourceHasTTLField
 		var selection *recordSelection
 		if preMaterializeFilter {
-			selection, _, err = selectFullRewriteRecord(record, pkField, entityFilter, ttlFieldID, sourceHasTTLField, nil)
+			selection, err = selectFullRewriteRecord(record, pkField, entityFilter, ttlFieldID, sourceHasTTLField)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/datanode/compactor/bump_schema_version_compactor_test.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor_test.go
@@ -948,12 +948,11 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestSelectFullRewriteRecordDropsD
 	deleteTs := tsoutil.ComposeTSByTime(currentTime.Add(time.Second))
 	entityFilter := compaction.NewEntityFilter(map[any]typeutil.Timestamp{int64(2): deleteTs}, int64(time.Minute), currentTime, 0)
 
-	selection, ttlValues, err := selectFullRewriteRecord(record, pkField, entityFilter, 102, true, nil)
+	selection, err := selectFullRewriteRecord(record, pkField, entityFilter, 102, true)
 	s.Require().NoError(err)
 	s.Require().NotNil(selection)
 	s.Equal(2, selection.Len())
 	s.Equal([]rowRange{{start: 0, end: 1}, {start: 4, end: 5}}, selection.ranges)
-	s.Equal([]int64{keptTTLField, keptTTLField}, ttlValues)
 	s.Equal(1, entityFilter.GetDeletedCount())
 	s.Equal(2, entityFilter.GetExpiredCount())
 }
@@ -1476,4 +1475,93 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionInputSchemaByF
 	s.ErrorIs(err, merr.ErrDataIntegrity)
 	s.ErrorContains(err, "references by_field lang of type")
 	s.ErrorContains(err, "only VarChar is allowed")
+}
+
+// TestFullRewriteMissingTTLFieldDoesNotProbeRecord is the real-cgo regression
+// for the source-TTL presence check: the target schema designates a TTL field that
+// old segments do not carry, and a dropped field routes them through full rewrite.
+// Presence must be decided from existingFields; probing record.Column(ttlFieldID)
+// panics on V3 records ("no such field") before the materializer can fill the null
+// TTL column.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteMissingTTLFieldDoesNotProbeRecord() {
+	const newTTLFieldID = int64(105)
+	// Target schema gains a nullable Timestamptz field absent from the source
+	// segment and designates it as the collection TTL field.
+	s.task.plan.Schema.Fields = append(s.task.plan.Schema.Fields, &schemapb.FieldSchema{
+		FieldID:  newTTLFieldID,
+		Name:     "expire_at",
+		DataType: schemapb.DataType_Timestamptz,
+		Nullable: true,
+	})
+	s.task.plan.Schema.Properties = append(s.task.plan.Schema.Properties, &commonpb.KeyValuePair{
+		Key:   common.CollectionTTLFieldKey,
+		Value: "expire_at",
+	})
+	params, err := compaction.GenerateJSONParams(s.task.plan.GetSchema())
+	s.Require().NoError(err)
+	s.task.plan.JsonParams = params
+
+	// Source segment carries a dropped field (103) -> droppedFieldIDs>0 -> full rewrite.
+	s.prepareBumpSchemaVersionCompactionWithDroppedField()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+	s.Equal(datapb.CompactionTaskState_completed, result.GetState())
+	s.Require().Len(result.GetSegments(), 1)
+
+	segment := result.GetSegments()[0]
+	s.EqualValues(3, segment.GetNumOfRows())
+}
+
+// TestFullRewriteSourceTTLFieldDropsExpiredRows covers the positive direction of
+// source-TTL presence detection. The source manifest physically carries the TTL
+// column, so existingFields must enable TTL filtering before materialization.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteSourceTTLFieldDropsExpiredRows() {
+	const ttlFieldID = int64(105)
+	now := getMilvusBirthday().Add(time.Hour)
+	ttlField := func() *schemapb.FieldSchema {
+		return &schemapb.FieldSchema{
+			FieldID:  ttlFieldID,
+			Name:     "expire_at",
+			DataType: schemapb.DataType_Timestamptz,
+			Nullable: true,
+		}
+	}
+
+	s.task.plan.Schema.Fields = append(s.task.plan.Schema.Fields, ttlField())
+	s.task.plan.Schema.Properties = append(s.task.plan.Schema.Properties, &commonpb.KeyValuePair{
+		Key:   common.CollectionTTLFieldKey,
+		Value: "expire_at",
+	})
+	params, err := compaction.GenerateJSONParams(s.task.plan.GetSchema())
+	s.Require().NoError(err)
+	s.task.plan.JsonParams = params
+	s.task.currentTime = now
+
+	// The dropped field forces full rewrite; the TTL field is physically present
+	// in the source manifest and contains one expired row and two live rows.
+	fields := append(schemaBumpBaseFields(),
+		&schemapb.FieldSchema{FieldID: 103, Name: "dropped", DataType: schemapb.DataType_Int64},
+		ttlField(),
+	)
+	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
+	s.initSegBufferForSchemaBumpWithFields(100, fields, func(i int, value map[int64]interface{}) {
+		value[103] = int64(i)
+		value[ttlFieldID] = now.Add(time.Hour).UnixMicro()
+		if i == 0 {
+			value[ttlFieldID] = now.Add(-time.Minute).UnixMicro()
+		}
+	})
+	s.finishBumpSchemaVersionSegment()
+
+	existingFields, err := compactionSegmentStorageFields(s.task.plan.GetSegmentBinlogs()[0], s.task.compactionParams.StorageConfig)
+	s.Require().NoError(err)
+	s.Contains(existingFields, ttlFieldID, "source manifest must physically carry the TTL field")
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+	s.Require().Len(result.GetSegments(), 1)
+	s.EqualValues(2, result.GetSegments()[0].GetNumOfRows())
 }


### PR DESCRIPTION
### What

Fix a panic in schema-bump full rewrite when the target schema designates a TTL field that an old segment does not physically contain.

The old code used `record.Column(ttlFieldID)` to determine source-field presence. V2/V3 records panic when `Column` is called for a field they do not carry. Presence now comes from `existingFields`, the physical field set derived from the segment manifest or binlogs, and the loop-invariant filter setup is computed before reading records.

This PR intentionally does not apply the TTL schema default to old rows and does not change TTL expiration semantics.

issue: #51649

### Tests

- `TestFullRewriteMissingTTLFieldDoesNotProbeRecord`: real-cgo regression covering a V3 full rewrite whose source segment lacks the target TTL field; compaction completes and preserves all three rows.
- `TestSelectFullRewriteRecordDropsDeletedAndExpiredRows`: existing physical TTL filtering remains unchanged.
- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/datanode/compactor -run '^TestBumpSchemaVersionCompactionTaskSuite$'`