### PR TITLE
enhance: scope bump partial-backfill materialization to function inputs (#51649)

### DIFF
--- a/internal/datanode/compactor/bump_schema_version_compactor.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor.go
@@ -131,19 +131,19 @@ func (t *bumpSchemaVersionCompactionTask) preCompact() error {
 	return nil
 }
 
-func (t *bumpSchemaVersionCompactionTask) missingFunctionInputSchema(missingFunctions []*schemapb.FunctionSchema) (*schemapb.CollectionSchema, []int64, error) {
+func (t *bumpSchemaVersionCompactionTask) buildFunctionBackfillReadSchema(missingFunctions []*schemapb.FunctionSchema, sourceFields map[int64]struct{}) (*schemapb.CollectionSchema, []int64, error) {
 	schema := t.plan.GetSchema()
 	seen := make(map[int64]struct{})
-	var fields []*schemapb.FieldSchema
-	var fieldIDs []int64
-	addInputField := func(field *schemapb.FieldSchema) {
+	var readFields []*schemapb.FieldSchema
+	var readFieldIDs []int64
+	addReadField := func(field *schemapb.FieldSchema) {
 		fieldID := field.GetFieldID()
 		if _, ok := seen[fieldID]; ok {
 			return
 		}
 		seen[fieldID] = struct{}{}
-		fields = append(fields, field)
-		fieldIDs = append(fieldIDs, fieldID)
+		readFields = append(readFields, field)
+		readFieldIDs = append(readFieldIDs, fieldID)
 	}
 	for _, functionSchema := range missingFunctions {
 		if err := validateSupportedMissingFunctionMaterialization(functionSchema); err != nil {
@@ -157,30 +157,50 @@ func (t *bumpSchemaVersionCompactionTask) missingFunctionInputSchema(missingFunc
 			if err := validateMaterializationInputField(functionSchema, inputField); err != nil {
 				return nil, nil, err
 			}
-			addInputField(inputField)
+			addReadField(inputField)
 
-			additionalFields, err := additionalFunctionInputFields(schema, functionSchema, inputField)
+			implicitFields, err := implicitFunctionInputFields(schema, functionSchema, inputField)
 			if err != nil {
 				return nil, nil, err
 			}
-			for _, additionalField := range additionalFields {
-				if err := validateMaterializationInputField(functionSchema, additionalField); err != nil {
+			for _, implicitField := range implicitFields {
+				if err := validateMaterializationInputField(functionSchema, implicitField); err != nil {
 					return nil, nil, err
 				}
-				addInputField(additionalField)
+				addReadField(implicitField)
+			}
+		}
+	}
+	// If no explicit or implicit input exists physically, the filtered read
+	// schema would be empty. Add one system column as a row-count anchor.
+	hasReadableSourceField := false
+	for _, fieldID := range readFieldIDs {
+		if _, ok := sourceFields[fieldID]; ok {
+			hasReadableSourceField = true
+			break
+		}
+	}
+	if !hasReadableSourceField {
+		for _, fieldID := range []int64{common.RowIDField, common.TimeStampField} {
+			if _, ok := sourceFields[fieldID]; !ok {
+				continue
+			}
+			if field := typeutil.GetField(schema, fieldID); field != nil {
+				addReadField(field)
+				break
 			}
 		}
 	}
 	return &schemapb.CollectionSchema{
 		Name:               schema.GetName(),
 		Description:        schema.GetDescription(),
-		Fields:             fields,
+		Fields:             readFields,
 		EnableDynamicField: schema.GetEnableDynamicField(),
 		Properties:         schema.GetProperties(),
-	}, fieldIDs, nil
+	}, readFieldIDs, nil
 }
 
-func additionalFunctionInputFields(schema *schemapb.CollectionSchema, functionSchema *schemapb.FunctionSchema, inputField *schemapb.FieldSchema) ([]*schemapb.FieldSchema, error) {
+func implicitFunctionInputFields(schema *schemapb.CollectionSchema, functionSchema *schemapb.FunctionSchema, inputField *schemapb.FieldSchema) ([]*schemapb.FieldSchema, error) {
 	switch functionSchema.GetType() {
 	case schemapb.FunctionType_BM25:
 		return bm25AdditionalInputFields(schema, functionSchema, inputField)
@@ -296,16 +316,6 @@ func validateMaterializationOutputField(functionSchema *schemapb.FunctionSchema,
 		}
 	}
 	return nil
-}
-
-func partialMaterializerExistingFields(schema *schemapb.CollectionSchema, missingFunctions []*schemapb.FunctionSchema, existingFields map[int64]struct{}) map[int64]struct{} {
-	fields := collectionSchemaFields(schema)
-	for _, functionSchema := range missingFunctions {
-		for _, outputIndex := range functionOutputIndexesToMaterialize(functionSchema, existingFields) {
-			delete(fields, functionSchema.GetOutputFieldIds()[outputIndex])
-		}
-	}
-	return fields
 }
 
 func (t *bumpSchemaVersionCompactionTask) openRecordReader(segment *datapb.CompactionSegmentBinlogs, schema *schemapb.CollectionSchema) (storage.RecordReader, map[int64]struct{}, error) {
@@ -958,7 +968,7 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 	partitionID := segment.GetPartitionID()
 	segmentID := segment.GetSegmentID()
 
-	inputSchema, inputFieldIDs, err := t.missingFunctionInputSchema(missingFunctions)
+	readSchema, readFieldIDs, err := t.buildFunctionBackfillReadSchema(missingFunctions, existingFields)
 	if err != nil {
 		return nil, err
 	}
@@ -972,13 +982,13 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 		mlog.FieldCollectionID(collectionID),
 		mlog.FieldPartitionID(partitionID),
 		mlog.FieldSegmentID(segmentID),
-		mlog.Int64s("inputFieldIDs", inputFieldIDs),
+		mlog.Int64s("readFieldIDs", readFieldIDs),
 		mlog.Int64s("outputFieldIDs", outputFieldIDs),
 	)
 
 	var readDuration, computeDuration, writeDuration, updateStatsDuration time.Duration
 
-	reader, _, err := t.openRecordReader(segment, inputSchema)
+	reader, _, err := t.openRecordReader(segment, readSchema)
 	if err != nil {
 		return nil, err
 	}
@@ -993,7 +1003,7 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 		mlog.Int64("effectiveStorageVersion", writerResult.storageVersion),
 		mlog.Int64("clusterStorageVersion", t.compactionParams.StorageVersion),
 		mlog.Bool("segmentHasManifest", segment.GetManifest() != ""),
-		mlog.Int64s("inputFieldIDs", inputFieldIDs),
+		mlog.Int64s("readFieldIDs", readFieldIDs),
 		mlog.Int64s("outputFieldIDs", outputFieldIDs),
 	)
 	_, span := otel.Tracer(typeutil.DataNodeRole).Start(ctx, "BumpSchemaVersionCompact.batchProcess")
@@ -1005,8 +1015,7 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 			statsByField[outputFieldID] = storage.NewBM25Stats()
 		}
 	}
-	existingFields = partialMaterializerExistingFields(t.plan.GetSchema(), missingFunctions, existingFields)
-	materializer, err := NewRecordMaterializer(t.plan.GetSchema(), missingFunctions, existingFields)
+	materializer, err := NewFunctionBackfillMaterializer(t.plan.GetSchema(), missingFunctions, existingFields)
 	if err != nil {
 		span.End()
 		return nil, err

--- a/internal/datanode/compactor/bump_schema_version_compactor_test.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor_test.go
@@ -1074,7 +1074,7 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestValidateSupportedMissingFunct
 	s.NoError(err)
 }
 
-func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionInputSchemaIncludesAdditionalInputFields() {
+func (s *BumpSchemaVersionCompactionTaskSuite) TestBuildFunctionBackfillReadSchemaIncludesImplicitInputFields() {
 	s.task.plan.Schema = &schemapb.CollectionSchema{
 		Name: "schema",
 		Fields: []*schemapb.FieldSchema{
@@ -1102,11 +1102,34 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionInputSchemaInc
 		OutputFieldIds:   []int64{102},
 	}}
 
-	inputSchema, inputFieldIDs, err := s.task.missingFunctionInputSchema(missingFunctions)
+	readSchema, readFieldIDs, err := s.task.buildFunctionBackfillReadSchema(missingFunctions, map[int64]struct{}{101: {}, 115: {}})
 	s.NoError(err)
-	s.ElementsMatch([]int64{101, 115}, inputFieldIDs)
-	s.Require().Len(inputSchema.GetFields(), 2)
-	s.ElementsMatch([]string{"text", "lang"}, []string{inputSchema.GetFields()[0].GetName(), inputSchema.GetFields()[1].GetName()})
+	s.ElementsMatch([]int64{101, 115}, readFieldIDs)
+	s.Require().Len(readSchema.GetFields(), 2)
+	s.ElementsMatch([]string{"text", "lang"}, []string{readSchema.GetFields()[0].GetName(), readSchema.GetFields()[1].GetName()})
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestBuildFunctionBackfillReadSchemaAddsRowCountAnchor() {
+	functionSchema := &schemapb.FunctionSchema{
+		Name: "BM25", Type: schemapb.FunctionType_BM25,
+		InputFieldIds: []int64{101}, OutputFieldIds: []int64{102},
+	}
+	s.task.plan.Schema = &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: common.RowIDField, Name: "row_id", DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "new_text", DataType: schemapb.DataType_VarChar, Nullable: true},
+			{FieldID: 102, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector},
+		},
+		Functions: []*schemapb.FunctionSchema{functionSchema},
+	}
+
+	readSchema, readFieldIDs, err := s.task.buildFunctionBackfillReadSchema(
+		[]*schemapb.FunctionSchema{functionSchema},
+		map[int64]struct{}{common.RowIDField: {}},
+	)
+	s.NoError(err)
+	s.Equal([]int64{101, common.RowIDField}, readFieldIDs)
+	s.Require().Len(readSchema.GetFields(), 2)
 }
 
 func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionMissingOutputFieldInMultiOutputFunction() {
@@ -1354,20 +1377,138 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionOutputFieldsSe
 	s.Equal(int64(103), outputFields[1].GetFieldID())
 }
 
-func (s *BumpSchemaVersionCompactionTaskSuite) TestPartialMaterializerExistingFieldsTreatsAllFunctionOutputsAsMissing() {
-	schema := schemaBumpMultiOutputBM25Schema()
-	existingFields := map[int64]struct{}{
+// schemaBumpBM25SchemaWithUnrelatedGeo is a legal single-output BM25 schema
+// (input 101 -> output 102) plus an earlier add_field column that is
+// physically absent from the segment and unrelated to the backfill.
+func schemaBumpBM25SchemaWithUnrelatedGeo() *schemapb.CollectionSchema {
+	fields := append(schemaBumpBaseFields(),
+		&schemapb.FieldSchema{
+			FieldID:  102,
+			Name:     "sparse",
+			DataType: schemapb.DataType_SparseFloatVector,
+		},
+		&schemapb.FieldSchema{
+			FieldID:  110,
+			Name:     "geo_added",
+			DataType: schemapb.DataType_Geometry,
+			Nullable: true,
+			DefaultValue: &schemapb.ValueField{
+				Data: &schemapb.ValueField_StringData{StringData: "POINT (1 2)"},
+			},
+		},
+	)
+	return &schemapb.CollectionSchema{
+		Name:   "schema",
+		Fields: fields,
+		Functions: []*schemapb.FunctionSchema{{
+			Name:             "BM25",
+			Id:               100,
+			Type:             schemapb.FunctionType_BM25,
+			InputFieldNames:  []string{"text"},
+			InputFieldIds:    []int64{101},
+			OutputFieldNames: []string{"sparse"},
+			OutputFieldIds:   []int64{102},
+		}},
+	}
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFunctionBackfillMaterializerPrefillsOnlyAbsentFunctionInputs() {
+	schema := schemaBumpBM25SchemaWithUnrelatedGeo()
+	sourceFields := map[int64]struct{}{
+		common.RowIDField:     {},
+		common.TimeStampField: {},
+		100:                   {},
+	}
+
+	backfill, err := NewFunctionBackfillMaterializer(schema, schema.GetFunctions(), sourceFields)
+	s.Require().NoError(err)
+	defer backfill.Close()
+
+	// prefill scope = the absent function input only; the unrelated absent
+	// field is ignored even though it is missing from storage too
+	s.Require().Len(backfill.missingFields, 1)
+	s.Equal(int64(101), backfill.missingFields[0].GetFieldID())
+	s.Len(backfill.materializers, 1)
+
+	// differential proof: a full materializer over the same storage truth WOULD
+	// prefill the unrelated field — the backfill scoping is what excludes it
+	full, err := NewRecordMaterializer(schema, schema.GetFunctions(), sourceFields)
+	s.Require().NoError(err)
+	defer full.Close()
+	fullPrefillsGeo := false
+	for _, field := range full.missingFields {
+		if field.GetFieldID() == int64(110) {
+			fullPrefillsGeo = true
+		}
+	}
+	s.True(fullPrefillsGeo)
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFunctionBackfillMaterializerNothingToPrefillWhenInputsPresent() {
+	schema := schemaBumpBM25SchemaWithUnrelatedGeo()
+	// input present, output and the unrelated geo absent
+	sourceFields := map[int64]struct{}{
 		common.RowIDField:     {},
 		common.TimeStampField: {},
 		100:                   {},
 		101:                   {},
-		102:                   {},
 	}
 
-	materializerFields := partialMaterializerExistingFields(schema, schema.GetFunctions(), existingFields)
+	backfill, err := NewFunctionBackfillMaterializer(schema, schema.GetFunctions(), sourceFields)
+	s.Require().NoError(err)
+	defer backfill.Close()
 
-	s.NotContains(materializerFields, int64(102))
-	s.NotContains(materializerFields, int64(103))
+	s.Empty(backfill.missingFields, "nothing to prefill when the function inputs are all present")
+	s.Len(backfill.materializers, 1)
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFunctionBackfillMaterializerPrefillsImplicitMultiAnalyzerInput() {
+	schema := &schemapb.CollectionSchema{
+		Name: "schema",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: common.RowIDField, Name: "row_id", DataType: schemapb.DataType_Int64},
+			{FieldID: common.TimeStampField, Name: "Timestamp", DataType: schemapb.DataType_Int64},
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{
+				FieldID:  101,
+				Name:     "text",
+				DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "128"},
+					{Key: common.EnableAnalyzerKey, Value: "true"},
+					{Key: "multi_analyzer_params", Value: `{"by_field":"lang","analyzers":{"default":{"type":"standard"}}}`},
+				},
+			},
+			{FieldID: 115, Name: "lang", DataType: schemapb.DataType_VarChar, Nullable: true, TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "32"}}},
+			{FieldID: 102, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector},
+		},
+		Functions: []*schemapb.FunctionSchema{{
+			Name:             "BM25",
+			Id:               100,
+			Type:             schemapb.FunctionType_BM25,
+			InputFieldNames:  []string{"text"},
+			InputFieldIds:    []int64{101},
+			OutputFieldNames: []string{"sparse"},
+			OutputFieldIds:   []int64{102},
+		}},
+	}
+	// the implicit by_field column (115) was added by an earlier add_field and
+	// is absent from the segment; InputFieldIds only lists the text field
+	sourceFields := map[int64]struct{}{
+		common.RowIDField:     {},
+		common.TimeStampField: {},
+		100:                   {},
+		101:                   {},
+	}
+
+	backfill, err := NewFunctionBackfillMaterializer(schema, schema.GetFunctions(), sourceFields)
+	s.Require().NoError(err)
+	defer backfill.Close()
+
+	// prefill must follow the runner-declared inputs, which include the
+	// implicit multi-analyzer by_field the schema's InputFieldIds never lists
+	s.Require().Len(backfill.missingFields, 1)
+	s.Equal(int64(115), backfill.missingFields[0].GetFieldID())
 }
 
 // Existing BM25 fixtures expose one output; these tests need a partial multi-output state.
@@ -1445,7 +1586,7 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionInputSchemaMal
 		Functions: []*schemapb.FunctionSchema{functionSchema},
 	}
 
-	_, _, err := s.task.missingFunctionInputSchema([]*schemapb.FunctionSchema{functionSchema})
+	_, _, err := s.task.buildFunctionBackfillReadSchema([]*schemapb.FunctionSchema{functionSchema}, map[int64]struct{}{101: {}})
 	s.Require().Error(err)
 	s.ErrorIs(err, merr.ErrDataIntegrity)
 	s.ErrorContains(err, "failed to parse multi_analyzer_params for function BM25")
@@ -1471,9 +1612,71 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionInputSchemaByF
 		Functions: []*schemapb.FunctionSchema{functionSchema},
 	}
 
-	_, _, err := s.task.missingFunctionInputSchema([]*schemapb.FunctionSchema{functionSchema})
+	_, _, err := s.task.buildFunctionBackfillReadSchema([]*schemapb.FunctionSchema{functionSchema}, map[int64]struct{}{101: {}})
 	s.Require().Error(err)
 	s.ErrorIs(err, merr.ErrDataIntegrity)
 	s.ErrorContains(err, "references by_field lang of type")
 	s.ErrorContains(err, "only VarChar is allowed")
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) configureMissingBM25InputSchema() int64 {
+	const inputFieldID = int64(104)
+	const outputFieldID = int64(105)
+	inputField := &schemapb.FieldSchema{
+		FieldID: inputFieldID, Name: "new_text", DataType: schemapb.DataType_VarChar, Nullable: true,
+		TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "128"}},
+	}
+	outputField := &schemapb.FieldSchema{
+		FieldID: outputFieldID, Name: "new_sparse", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true,
+	}
+	functionSchema := &schemapb.FunctionSchema{
+		Name: "new_bm25", Type: schemapb.FunctionType_BM25,
+		InputFieldNames: []string{inputField.GetName()}, InputFieldIds: []int64{inputFieldID},
+		OutputFieldNames: []string{outputField.GetName()}, OutputFieldIds: []int64{outputFieldID},
+	}
+	s.task.plan.Schema = &schemapb.CollectionSchema{
+		Name: "missing_function_input", Fields: append(schemaBumpBaseFields(), inputField, outputField),
+		Functions: []*schemapb.FunctionSchema{functionSchema},
+	}
+	s.task.plan.Functions = []*schemapb.FunctionSchema{functionSchema}
+	params, err := compaction.GenerateJSONParams(s.task.plan.GetSchema())
+	s.Require().NoError(err)
+	s.task.plan.JsonParams = params
+	return outputFieldID
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestPartialMaterializationUsesMissingNullableFunctionInput() {
+	outputFieldID := s.configureMissingBM25InputSchema()
+	s.prepareBumpSchemaVersionCompaction()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.Require().Len(result.GetSegments(), 1)
+	s.EqualValues(3, result.GetSegments()[0].GetNumOfRows())
+	var found bool
+	for _, fieldBinlog := range result.GetSegments()[0].GetInsertLogs() {
+		if compactionFieldBinlogReadable(fieldBinlog, map[int64]struct{}{outputFieldID: {}}) {
+			found = true
+			break
+		}
+	}
+	s.True(found, "partial backfill must write the function output computed from the missing nullable input")
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteUsesMissingNullableFunctionInput() {
+	outputFieldID := s.configureMissingBM25InputSchema()
+	s.prepareBumpSchemaVersionCompactionWithDroppedField()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.Require().Len(result.GetSegments(), 1)
+	s.EqualValues(3, result.GetSegments()[0].GetNumOfRows())
+	var found bool
+	for _, fieldBinlog := range result.GetSegments()[0].GetInsertLogs() {
+		if compactionFieldBinlogReadable(fieldBinlog, map[int64]struct{}{outputFieldID: {}}) {
+			found = true
+			break
+		}
+	}
+	s.True(found, "full rewrite must write the function output computed from the missing nullable input")
 }

--- a/internal/datanode/compactor/record_materializer.go
+++ b/internal/datanode/compactor/record_materializer.go
@@ -54,15 +54,56 @@ func (s *recordSelection) Len() int {
 }
 
 type RecordMaterializer struct {
-	materializers  []FunctionMaterializer
-	missingFields  []*schemapb.FieldSchema
-	schema         *schemapb.CollectionSchema
+	materializers []FunctionMaterializer
+	missingFields []*schemapb.FieldSchema
+	schema        *schemapb.CollectionSchema
+	// existingFields is the set of fields physically present in the source
+	// records. Selection slicing is gated on it: probing a record for a field
+	// it does not carry is not an option, since V2/V3 records panic on Column
+	// for an unknown field instead of returning nil.
 	existingFields map[int64]struct{}
 }
 
+// NewRecordMaterializer builds a full materializer: it computes the absent
+// function outputs and prefills every other schema field existingFields does
+// not carry, so the wrapped record covers the whole schema (full rewrites,
+// sort/mix/clustering, which persist every column).
 func NewRecordMaterializer(schema *schemapb.CollectionSchema, functions []*schemapb.FunctionSchema, existingFields map[int64]struct{}) (*RecordMaterializer, error) {
+	materializer, materializedFields, _, err := newRecordMaterializerBase(schema, functions, existingFields)
+	if err != nil {
+		return nil, err
+	}
+	materializer.missingFields = missingNonMaterializedSchemaFields(schema, existingFields, materializedFields)
+	return materializer, nil
+}
+
+// NewFunctionBackfillMaterializer scopes materialization to backfilling the
+// given functions' outputs: it computes those outputs and prefills only their
+// inputs absent from existingFields. Every other absent schema field stays
+// untouched — an added field is nullable by DDL mandate and thus synthesizable
+// at read time, so a version bump never requires materializing it physically
+// (the bump-only path stamps metadata without touching data at all); rewriting
+// compactions materialize such fields only as a byproduct of writing the full
+// schema. existingFields must be the segment's physical storage truth.
+func NewFunctionBackfillMaterializer(schema *schemapb.CollectionSchema, missingFunctions []*schemapb.FunctionSchema, existingFields map[int64]struct{}) (*RecordMaterializer, error) {
+	materializer, _, activeInputFields, err := newRecordMaterializerBase(schema, missingFunctions, existingFields)
+	if err != nil {
+		return nil, err
+	}
+	materializer.missingFields = absentInputFields(activeInputFields, existingFields)
+	return materializer, nil
+}
+
+// newRecordMaterializerBase sets up the function runners for every function
+// with at least one output to materialize, leaving missingFields (the prefill
+// set) to the exported constructors. The returned input fields are the
+// runner-declared reads of those functions — the runner, not the function
+// schema, is the authority on what gets read: it resolves implicit inputs
+// (e.g. the multi-analyzer by_field column) that InputFieldIds never lists.
+func newRecordMaterializerBase(schema *schemapb.CollectionSchema, functions []*schemapb.FunctionSchema, existingFields map[int64]struct{}) (*RecordMaterializer, map[int64]struct{}, []*schemapb.FieldSchema, error) {
 	materializer := &RecordMaterializer{schema: schema, existingFields: existingFields}
 	materializedFields := make(map[int64]struct{})
+	var activeInputFields []*schemapb.FieldSchema
 	for _, functionSchema := range functions {
 		outputIndexes := functionOutputIndexesToMaterialize(functionSchema, existingFields)
 		if len(outputIndexes) == 0 {
@@ -75,22 +116,42 @@ func NewRecordMaterializer(schema *schemapb.CollectionSchema, functions []*schem
 		runner, err := function.NewFunctionRunner(schema, functionSchema)
 		if err != nil {
 			materializer.Close()
-			return nil, err
+			return nil, nil, nil, err
 		}
 		if runner == nil {
 			materializer.Close()
-			return nil, merr.WrapErrFunctionFailedMsg("failed to set up function runner for %s", functionSchema.GetName())
+			return nil, nil, nil, merr.WrapErrFunctionFailedMsg("failed to set up function runner for %s", functionSchema.GetName())
 		}
 		functionMaterializer, err := newFunctionMaterializer(schema, runner, outputIndexes, true)
 		if err != nil {
 			runner.Close()
 			materializer.Close()
-			return nil, err
+			return nil, nil, nil, err
 		}
 		materializer.materializers = append(materializer.materializers, functionMaterializer)
+		activeInputFields = append(activeInputFields, runner.GetInputFields()...)
 	}
-	materializer.missingFields = missingNonMaterializedSchemaFields(schema, existingFields, materializedFields)
-	return materializer, nil
+	return materializer, materializedFields, activeInputFields, nil
+}
+
+// absentInputFields returns the input fields existingFields does not carry —
+// the exact set a backfill materializer must prefill before running the
+// functions.
+func absentInputFields(inputFields []*schemapb.FieldSchema, existingFields map[int64]struct{}) []*schemapb.FieldSchema {
+	seen := make(map[int64]struct{})
+	missing := make([]*schemapb.FieldSchema, 0)
+	for _, field := range inputFields {
+		fieldID := field.GetFieldID()
+		if _, ok := existingFields[fieldID]; ok {
+			continue
+		}
+		if _, dup := seen[fieldID]; dup {
+			continue
+		}
+		seen[fieldID] = struct{}{}
+		missing = append(missing, field)
+	}
+	return missing
 }
 
 func (m *RecordMaterializer) Wrap(rec storage.Record) (storage.Record, error) {
@@ -117,8 +178,23 @@ func (m *RecordMaterializer) WrapWithSelection(rec storage.Record, selection *re
 	}
 
 	computed := make(map[int64]arrow.Array)
+	view := &materializedRecord{base: base, computed: computed}
+
+	// Fill ordinary missing fields before running functions. Function inputs may
+	// themselves be fields added by an earlier schema evolution, so runners must
+	// read through this overlay instead of probing the physical source record.
+	for _, field := range m.missingFields {
+		fieldID := field.GetFieldID()
+		arr, err := storage.GenerateEmptyArrayFromSchema(field, base.Len())
+		if err != nil {
+			releaseArrowArrays(computed)
+			cleanupMaterializedRecord(base)
+			return nil, err
+		}
+		computed[fieldID] = arr
+	}
 	for _, materializer := range m.materializers {
-		arrays, err := materializer.Materialize(base)
+		arrays, err := materializer.Materialize(view)
 		if err != nil {
 			releaseArrowArrays(computed)
 			cleanupMaterializedRecord(base)
@@ -128,23 +204,10 @@ func (m *RecordMaterializer) WrapWithSelection(rec storage.Record, selection *re
 			computed[fieldID] = arr
 		}
 	}
-	for _, field := range m.missingFields {
-		fieldID := field.GetFieldID()
-		if _, ok := computed[fieldID]; ok {
-			continue
-		}
-		arr, err := storage.GenerateEmptyArrayFromSchema(field, base.Len())
-		if err != nil {
-			releaseArrowArrays(computed)
-			cleanupMaterializedRecord(base)
-			return nil, err
-		}
-		computed[fieldID] = arr
-	}
 	if len(computed) == 0 {
 		return base, nil
 	}
-	return &materializedRecord{base: base, computed: computed}, nil
+	return view, nil
 }
 
 func (m *RecordMaterializer) Close() {

--- a/internal/datanode/compactor/record_materializer_test.go
+++ b/internal/datanode/compactor/record_materializer_test.go
@@ -835,3 +835,100 @@ func newInt64Array(t *testing.T, values []int64) *array.Int64 {
 	builder.AppendValues(values, nil)
 	return builder.NewInt64Array()
 }
+
+func TestRecordMaterializerMaterializesFunctionFromMissingNullableInput(t *testing.T) {
+	inputField := &schemapb.FieldSchema{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar, Nullable: true}
+	outputField := &schemapb.FieldSchema{FieldID: 101, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector}
+	functionSchema := &schemapb.FunctionSchema{
+		Name: "bm25", Type: schemapb.FunctionType_BM25,
+		InputFieldIds: []int64{100}, OutputFieldIds: []int64{101},
+	}
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{inputField, outputField}, Functions: []*schemapb.FunctionSchema{functionSchema}}
+	emptyRow := typeutil.CreateSparseFloatRow(nil, nil)
+	runner := &materializerTestFunctionRunner{
+		schema: functionSchema, inputFields: []*schemapb.FieldSchema{inputField}, outputFields: []*schemapb.FieldSchema{outputField},
+		outputs: []any{&schemapb.SparseFloatArray{Contents: [][]byte{emptyRow, emptyRow}}},
+	}
+	functionMaterializer, err := newBM25FunctionMaterializer(schema, runner, []int{0}, false)
+	require.NoError(t, err)
+	materializer := &RecordMaterializer{
+		schema: schema, materializers: []FunctionMaterializer{functionMaterializer}, missingFields: []*schemapb.FieldSchema{inputField},
+	}
+	defer materializer.Close()
+
+	record := &materializerTestRecord{len: 2}
+	wrapped, err := materializer.Wrap(record)
+	require.NoError(t, err)
+	defer cleanupMaterializedRecord(wrapped)
+	require.Equal(t, []any{[]string{"", ""}}, runner.inputs)
+	require.Equal(t, 2, wrapped.Column(outputField.GetFieldID()).Len())
+	require.Equal(t, 0, record.releaseCount)
+}
+
+func TestRecordMaterializerMaterializesFunctionFromMissingDefaultInput(t *testing.T) {
+	inputField := &schemapb.FieldSchema{
+		FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar, Nullable: true,
+		DefaultValue: &schemapb.ValueField{Data: &schemapb.ValueField_StringData{StringData: "fallback"}},
+	}
+	outputField := &schemapb.FieldSchema{FieldID: 101, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector}
+	functionSchema := &schemapb.FunctionSchema{
+		Name: "bm25", Type: schemapb.FunctionType_BM25,
+		InputFieldIds: []int64{100}, OutputFieldIds: []int64{101},
+	}
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{inputField, outputField}, Functions: []*schemapb.FunctionSchema{functionSchema}}
+	emptyRow := typeutil.CreateSparseFloatRow(nil, nil)
+	runner := &materializerTestFunctionRunner{
+		schema: functionSchema, inputFields: []*schemapb.FieldSchema{inputField}, outputFields: []*schemapb.FieldSchema{outputField},
+		outputs: []any{&schemapb.SparseFloatArray{Contents: [][]byte{emptyRow, emptyRow}}},
+	}
+	functionMaterializer, err := newBM25FunctionMaterializer(schema, runner, []int{0}, false)
+	require.NoError(t, err)
+	materializer := &RecordMaterializer{
+		schema: schema, materializers: []FunctionMaterializer{functionMaterializer}, missingFields: []*schemapb.FieldSchema{inputField},
+	}
+	defer materializer.Close()
+
+	record := &materializerTestRecord{len: 2}
+	wrapped, err := materializer.Wrap(record)
+	require.NoError(t, err)
+	defer cleanupMaterializedRecord(wrapped)
+	require.Equal(t, []any{[]string{"fallback", "fallback"}}, runner.inputs)
+	require.Equal(t, 2, wrapped.Column(outputField.GetFieldID()).Len())
+}
+
+// Regression for the eager-selection existence probe: V2/V3 records are
+// simpleArrowRecord, whose Column PANICS for a field absent from the source
+// (e.g. the output field just added by add_function_field). Selection building
+// must consult existingFields and never probe the record. With the old
+// Column()==nil probe this test panics with "no such field: 101".
+func TestRecordMaterializerSelectionSkipsAbsentFieldOnPanickyRecord(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64},
+		{FieldID: 101, Name: "added", DataType: schemapb.DataType_Int64, Nullable: true},
+	}}
+	materializer, err := NewRecordMaterializer(schema, nil, map[int64]struct{}{100: {}})
+	require.NoError(t, err)
+	defer materializer.Close()
+
+	pk := newInt64Array(t, []int64{1, 2, 3})
+	defer pk.Release()
+	arrowSchema := arrow.NewSchema([]arrow.Field{{Name: "pk", Type: arrow.PrimitiveTypes.Int64}}, nil)
+	arrowRecord := array.NewRecord(arrowSchema, []arrow.Array{pk}, 3)
+	defer arrowRecord.Release()
+	record := storage.NewSimpleArrowRecord(arrowRecord, map[storage.FieldID]int{100: 0})
+	selection := &recordSelection{ranges: []rowRange{{start: 1, end: 3}}, length: 2}
+
+	wrapped, err := materializer.WrapWithSelection(record, selection)
+	require.NoError(t, err)
+	require.Equal(t, 2, wrapped.Len())
+
+	pkColumn, ok := wrapped.Column(100).(*array.Int64)
+	require.True(t, ok)
+	require.Equal(t, []int64{2, 3}, []int64{pkColumn.Value(0), pkColumn.Value(1)})
+	addedColumn := wrapped.Column(101)
+	require.NotNil(t, addedColumn)
+	require.Equal(t, 2, addedColumn.Len())
+	require.Equal(t, 2, addedColumn.NullN())
+
+	cleanupMaterializedRecord(wrapped)
+}


### PR DESCRIPTION
### What

Hardens the schema-bump partial-backfill path (`runMissingFunctionMaterialization`) — the path that computes missing function outputs for pre-existing segments after `add_function_field`. Scoped down after splitting two orthogonal concerns out: the writer abort/lease moved to #52352, the `multi_analyzer_params` error reclassification moved to #52353.

- **Backfill-scoped materializer.** `NewFunctionBackfillMaterializer` replaces the `partialMaterializerExistingFields` detour: backfill prefills only the functions' absent *input* fields and computes their outputs; every other absent schema field stays untouched — an added field is nullable by DDL mandate and thus synthesizable at read time, so backfill never needs to materialize it physically. The prefill set follows the **runner-declared** inputs (`runner.GetInputFields()`), which resolve implicit inputs such as the multi-analyzer `by_field` column that `InputFieldIds` never lists.
- **Overlay before compute.** `WrapWithSelection` now fills missing fields *before* running the functions and hands the runners the overlaid view: a function input may itself be a field added by an earlier schema evolution, absent from the physical record. Previously the runners probed the raw source record — V2/V3 records panic on `Column` for an unknown field.
- **Row-count anchor.** When no explicit or implicit input exists physically, the filtered read schema would be empty; `buildFunctionBackfillReadSchema` adds one system column (RowID/Timestamp) as a row-count anchor so the backfill still sees the segment's rows.
- Renames along the same seam: `missingFunctionInputSchema` → `buildFunctionBackfillReadSchema`, `additionalFunctionInputFields` → `implicitFunctionInputFields`.

Cumulative-stats reporting is intentionally untouched here — #52006 already moved it to increment-based reporting.

issue: #51649