### PR TITLE
fix: [cp 3.0] stream large REST search responses

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -62,14 +62,16 @@ import (
 )
 
 type HandlersV2 struct {
-	proxy     types.ProxyComponent
-	checkAuth bool
+	proxy              types.ProxyComponent
+	checkAuth          bool
+	serverWriteTimeout time.Duration
 }
 
-func NewHandlersV2(proxyClient types.ProxyComponent) *HandlersV2 {
+func NewHandlersV2(proxyClient types.ProxyComponent, serverWriteTimeout time.Duration) *HandlersV2 {
 	return &HandlersV2{
-		proxy:     proxyClient,
-		checkAuth: proxy.Params.CommonCfg.AuthorizationEnabled.GetAsBool(),
+		proxy:              proxyClient,
+		checkAuth:          proxy.Params.CommonCfg.AuthorizationEnabled.GetAsBool(),
+		serverWriteTimeout: serverWriteTimeout,
 	}
 }
 
@@ -196,6 +198,7 @@ var routeToMethod = map[string]string{ //nolint:gosec // not credentials, just a
 }
 
 func (h *HandlersV2) RegisterRoutesToV2(router gin.IRouter) {
+	router.Use(serverWriteTimeoutMiddleware(h.serverWriteTimeout))
 	router.POST(CollectionCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &DatabaseReq{} }, wrapperTraceLog(h.listCollections))))
 	router.POST(CollectionCategory+HasAction, timeoutMiddleware(wrapperPost(func() any { return &CollectionNameReq{} }, wrapperTraceLog(h.hasCollection))))
 	// todo review the return data
@@ -1388,6 +1391,17 @@ func matchCountRule(outputs []string) bool {
 	return len(outputs) == 1 && strings.ToLower(strings.TrimSpace(outputs[0])) == "count(*)"
 }
 
+func isRequestContextError(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+func returnInvalidSearchResult(c *gin.Context, err error) {
+	HTTPReturn(c, http.StatusOK, gin.H{
+		HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
+		HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
+	})
+}
+
 func (h *HandlersV2) query(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
 	httpReq := anyReq.(*QueryReqV2)
 	req := &milvuspb.QueryRequest{
@@ -1436,30 +1450,39 @@ func (h *HandlersV2) query(ctx context.Context, c *gin.Context, anyReq any, dbNa
 	if err == nil {
 		queryResp := resp.(*milvuspb.QueryResults)
 		allowJS, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
-		outputData, err := buildQueryResp(int64(0), queryResp.OutputFields, queryResp.FieldsData, nil, nil, allowJS, collSchema)
-		if err != nil {
-			mlog.Warn(ctx, "high level restful api, fail to deal with query result", mlog.Any("response", resp), mlog.Err(err))
-			HTTPReturn(c, http.StatusOK, gin.H{
-				HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-				HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
-			})
+		outputData, buildErr := newQueryResponseRowsWithContext(ctx, int64(0), queryResp.OutputFields, queryResp.FieldsData, nil, nil, allowJS, collSchema)
+		if buildErr != nil {
+			err = buildErr
+			if isRequestContextError(buildErr) {
+				return resp, err
+			}
+			queryResp.Status = merr.Status(merr.ErrInvalidSearchResult)
+			mlog.Warn(ctx, "high level restful api, fail to deal with query result",
+				mlog.Int32("code", queryResp.GetStatus().GetCode()),
+				mlog.Int("fieldCount", len(queryResp.GetFieldsData())),
+				mlog.Int("outputFieldCount", len(queryResp.GetOutputFields())),
+				mlog.Err(buildErr))
+			returnInvalidSearchResult(c, buildErr)
 		} else {
 			scannedRemoteBytes, scannedTotalBytes, cacheHitRatio, isValid := proxy.GetStorageCost(queryResp.GetStatus())
+			respBody := gin.H{
+				HTTPReturnCode: merr.Code(nil),
+				HTTPReturnData: outputData,
+				HTTPReturnCost: proxy.GetCostValue(queryResp.GetStatus()),
+			}
 			if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() && isValid {
-				HTTPReturnStream(c, http.StatusOK, gin.H{
-					HTTPReturnCode:               merr.Code(nil),
-					HTTPReturnData:               outputData,
-					HTTPReturnCost:               proxy.GetCostValue(queryResp.GetStatus()),
-					HTTPReturnScannedRemoteBytes: scannedRemoteBytes,
-					HTTPReturnScannedTotalBytes:  scannedTotalBytes,
-					HTTPReturnCacheHitRatio:      cacheHitRatio,
-				})
-			} else {
-				HTTPReturnStream(c, http.StatusOK, gin.H{
-					HTTPReturnCode: merr.Code(nil),
-					HTTPReturnData: outputData,
-					HTTPReturnCost: proxy.GetCostValue(queryResp.GetStatus()),
-				})
+				respBody[HTTPReturnScannedRemoteBytes] = scannedRemoteBytes
+				respBody[HTTPReturnScannedTotalBytes] = scannedTotalBytes
+				respBody[HTTPReturnCacheHitRatio] = cacheHitRatio
+			}
+			if renderErr := HTTPReturnStream(c, http.StatusOK, respBody); renderErr != nil {
+				err = renderErr
+				if isRequestContextError(renderErr) {
+					return resp, err
+				}
+				queryResp.Status = merr.Status(merr.ErrInvalidSearchResult)
+				mlog.Warn(ctx, "high level restful api, fail to render query result", mlog.Err(renderErr))
+				returnInvalidSearchResult(c, renderErr)
 			}
 		}
 	}
@@ -1504,30 +1527,39 @@ func (h *HandlersV2) get(ctx context.Context, c *gin.Context, anyReq any, dbName
 	if err == nil {
 		queryResp := resp.(*milvuspb.QueryResults)
 		allowJS, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
-		outputData, err := buildQueryResp(int64(0), queryResp.OutputFields, queryResp.FieldsData, nil, nil, allowJS, collSchema)
-		if err != nil {
-			mlog.Warn(ctx, "high level restful api, fail to deal with get result", mlog.Any("response", resp), mlog.Err(err))
-			HTTPReturn(c, http.StatusOK, gin.H{
-				HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-				HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
-			})
+		outputData, buildErr := newQueryResponseRowsWithContext(ctx, int64(0), queryResp.OutputFields, queryResp.FieldsData, nil, nil, allowJS, collSchema)
+		if buildErr != nil {
+			err = buildErr
+			if isRequestContextError(buildErr) {
+				return resp, err
+			}
+			queryResp.Status = merr.Status(merr.ErrInvalidSearchResult)
+			mlog.Warn(ctx, "high level restful api, fail to deal with get result",
+				mlog.Int32("code", queryResp.GetStatus().GetCode()),
+				mlog.Int("fieldCount", len(queryResp.GetFieldsData())),
+				mlog.Int("outputFieldCount", len(queryResp.GetOutputFields())),
+				mlog.Err(buildErr))
+			returnInvalidSearchResult(c, buildErr)
 		} else {
 			scannedRemoteBytes, scannedTotalBytes, cacheHitRatio, isValid := proxy.GetStorageCost(queryResp.GetStatus())
+			respBody := gin.H{
+				HTTPReturnCode: merr.Code(nil),
+				HTTPReturnData: outputData,
+				HTTPReturnCost: proxy.GetCostValue(queryResp.GetStatus()),
+			}
 			if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() && isValid {
-				HTTPReturnStream(c, http.StatusOK, gin.H{
-					HTTPReturnCode:               merr.Code(nil),
-					HTTPReturnData:               outputData,
-					HTTPReturnCost:               proxy.GetCostValue(queryResp.GetStatus()),
-					HTTPReturnScannedRemoteBytes: scannedRemoteBytes,
-					HTTPReturnScannedTotalBytes:  scannedTotalBytes,
-					HTTPReturnCacheHitRatio:      cacheHitRatio,
-				})
-			} else {
-				HTTPReturnStream(c, http.StatusOK, gin.H{
-					HTTPReturnCode: merr.Code(nil),
-					HTTPReturnData: outputData,
-					HTTPReturnCost: proxy.GetCostValue(queryResp.GetStatus()),
-				})
+				respBody[HTTPReturnScannedRemoteBytes] = scannedRemoteBytes
+				respBody[HTTPReturnScannedTotalBytes] = scannedTotalBytes
+				respBody[HTTPReturnCacheHitRatio] = cacheHitRatio
+			}
+			if renderErr := HTTPReturnStream(c, http.StatusOK, respBody); renderErr != nil {
+				err = renderErr
+				if isRequestContextError(renderErr) {
+					return resp, err
+				}
+				queryResp.Status = merr.Status(merr.ErrInvalidSearchResult)
+				mlog.Warn(ctx, "high level restful api, fail to render get result", mlog.Err(renderErr))
+				returnInvalidSearchResult(c, renderErr)
 			}
 		}
 	}
@@ -2031,13 +2063,20 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 		scannedRemoteBytes, scannedTotalBytes, cacheHitRatio, isValid := proxy.GetStorageCost(searchResp.GetStatus())
 		if hasSearchAggregationResult(searchResp.Results) {
 			allowJS, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
-			outputData, err := buildSearchAggregationResp(searchResp.Results, allowJS, collSchema)
-			if err != nil {
-				mlog.Warn(ctx, "high level restful api, fail to deal with search aggregation result", mlog.Any("result", searchResp.Results), mlog.Err(err))
-				HTTPReturn(c, http.StatusOK, gin.H{
-					HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
-				})
+			outputData, buildErr := buildSearchAggregationResp(ctx, searchResp.Results, allowJS, collSchema)
+			if buildErr != nil {
+				err = buildErr
+				if isRequestContextError(buildErr) {
+					return resp, err
+				}
+				searchResp.Status = merr.Status(merr.ErrInvalidSearchResult)
+				mlog.Warn(ctx, "high level restful api, fail to deal with search aggregation result",
+					mlog.Int32("code", searchResp.GetStatus().GetCode()),
+					mlog.Int64("nq", searchResp.GetResults().GetNumQueries()),
+					mlog.Int("bucketCount", len(searchResp.GetResults().GetAggBuckets())),
+					mlog.Int("aggTopkCount", len(searchResp.GetResults().GetAggTopks())),
+					mlog.Err(buildErr))
+				returnInvalidSearchResult(c, buildErr)
 			} else {
 				respBody := gin.H{
 					HTTPReturnCode:     merr.Code(nil),
@@ -2053,60 +2092,58 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 					respBody[HTTPReturnScannedTotalBytes] = scannedTotalBytes
 					respBody[HTTPReturnCacheHitRatio] = cacheHitRatio
 				}
-				HTTPReturnStream(c, http.StatusOK, respBody)
+				if renderErr := HTTPReturnStream(c, http.StatusOK, respBody); renderErr != nil {
+					err = renderErr
+					if isRequestContextError(renderErr) {
+						return resp, err
+					}
+					searchResp.Status = merr.Status(merr.ErrInvalidSearchResult)
+					mlog.Warn(ctx, "high level restful api, fail to render search aggregation result", mlog.Err(renderErr))
+					returnInvalidSearchResult(c, renderErr)
+				}
 			}
 		} else if searchResp.Results.TopK == int64(0) {
 			HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: []interface{}{}, HTTPReturnCost: cost})
 		} else {
 			allowJS, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
-			outputData, err := buildQueryResp(0, searchResp.Results.OutputFields, searchResp.Results.FieldsData, searchResp.Results.Ids, searchResp.Results.Scores, allowJS, collSchema)
-			if err != nil {
-				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(err))
-				HTTPReturn(c, http.StatusOK, gin.H{
-					HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
-				})
+			outputData, buildErr := newQueryResponseRowsWithContext(ctx, 0, searchResp.Results.OutputFields, searchResp.Results.FieldsData, searchResp.Results.Ids, searchResp.Results.Scores, allowJS, collSchema)
+			if buildErr != nil {
+				err = buildErr
+				if isRequestContextError(buildErr) {
+					return resp, err
+				}
+				searchResp.Status = merr.Status(merr.ErrInvalidSearchResult)
+				mlog.Warn(ctx, "high level restful api, fail to deal with search result",
+					mlog.Int32("code", searchResp.GetStatus().GetCode()),
+					mlog.Int64("nq", searchResp.GetResults().GetNumQueries()),
+					mlog.Int("fieldCount", len(searchResp.GetResults().GetFieldsData())),
+					mlog.Int("idCount", len(searchResp.GetResults().GetIds().GetIntId().GetData())+len(searchResp.GetResults().GetIds().GetStrId().GetData())),
+					mlog.Int("scoreCount", len(searchResp.GetResults().GetScores())),
+					mlog.Err(buildErr))
+				returnInvalidSearchResult(c, buildErr)
 			} else {
+				respBody := gin.H{
+					HTTPReturnCode:  merr.Code(nil),
+					HTTPReturnData:  outputData,
+					HTTPReturnCost:  cost,
+					HTTPReturnTopks: searchResp.Results.Topks,
+				}
 				if len(searchResp.Results.Recalls) > 0 {
-					if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() && isValid {
-						HTTPReturnStream(c, http.StatusOK, gin.H{
-							HTTPReturnCode:               merr.Code(nil),
-							HTTPReturnData:               outputData,
-							HTTPReturnCost:               cost,
-							HTTPReturnRecalls:            searchResp.Results.Recalls,
-							HTTPReturnTopks:              searchResp.Results.Topks,
-							HTTPReturnScannedRemoteBytes: scannedRemoteBytes,
-							HTTPReturnScannedTotalBytes:  scannedTotalBytes,
-							HTTPReturnCacheHitRatio:      cacheHitRatio,
-						})
-					} else {
-						HTTPReturnStream(c, http.StatusOK, gin.H{
-							HTTPReturnCode:    merr.Code(nil),
-							HTTPReturnData:    outputData,
-							HTTPReturnCost:    cost,
-							HTTPReturnRecalls: searchResp.Results.Recalls,
-							HTTPReturnTopks:   searchResp.Results.Topks,
-						})
+					respBody[HTTPReturnRecalls] = searchResp.Results.Recalls
+				}
+				if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() && isValid {
+					respBody[HTTPReturnScannedRemoteBytes] = scannedRemoteBytes
+					respBody[HTTPReturnScannedTotalBytes] = scannedTotalBytes
+					respBody[HTTPReturnCacheHitRatio] = cacheHitRatio
+				}
+				if renderErr := HTTPReturnStream(c, http.StatusOK, respBody); renderErr != nil {
+					err = renderErr
+					if isRequestContextError(renderErr) {
+						return resp, err
 					}
-				} else {
-					if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() && isValid {
-						HTTPReturnStream(c, http.StatusOK, gin.H{
-							HTTPReturnCode:               merr.Code(nil),
-							HTTPReturnData:               outputData,
-							HTTPReturnCost:               cost,
-							HTTPReturnTopks:              searchResp.Results.Topks,
-							HTTPReturnScannedRemoteBytes: scannedRemoteBytes,
-							HTTPReturnScannedTotalBytes:  scannedTotalBytes,
-							HTTPReturnCacheHitRatio:      cacheHitRatio,
-						})
-					} else {
-						HTTPReturnStream(c, http.StatusOK, gin.H{
-							HTTPReturnCode:  merr.Code(nil),
-							HTTPReturnData:  outputData,
-							HTTPReturnCost:  cost,
-							HTTPReturnTopks: searchResp.Results.Topks,
-						})
-					}
+					searchResp.Status = merr.Status(merr.ErrInvalidSearchResult)
+					mlog.Warn(ctx, "high level restful api, fail to render search result", mlog.Err(renderErr))
+					returnInvalidSearchResult(c, renderErr)
 				}
 			}
 		}
@@ -2231,18 +2268,41 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 			HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: []interface{}{}, HTTPReturnCost: cost})
 		} else {
 			allowJS, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
-			outputData, err := buildQueryResp(0, searchResp.Results.OutputFields, searchResp.Results.FieldsData, searchResp.Results.Ids, searchResp.Results.Scores, allowJS, collSchema)
-			if err != nil {
-				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(err))
-				HTTPReturn(c, http.StatusOK, gin.H{
-					HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
-					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
-				})
+			outputData, buildErr := newQueryResponseRowsWithContext(ctx, 0, searchResp.Results.OutputFields, searchResp.Results.FieldsData, searchResp.Results.Ids, searchResp.Results.Scores, allowJS, collSchema)
+			if buildErr != nil {
+				err = buildErr
+				if isRequestContextError(buildErr) {
+					return resp, err
+				}
+				searchResp.Status = merr.Status(merr.ErrInvalidSearchResult)
+				mlog.Warn(ctx, "high level restful api, fail to deal with search result",
+					mlog.Int32("code", searchResp.GetStatus().GetCode()),
+					mlog.Int64("nq", searchResp.GetResults().GetNumQueries()),
+					mlog.Int("fieldCount", len(searchResp.GetResults().GetFieldsData())),
+					mlog.Int("idCount", len(searchResp.GetResults().GetIds().GetIntId().GetData())+len(searchResp.GetResults().GetIds().GetStrId().GetData())),
+					mlog.Int("scoreCount", len(searchResp.GetResults().GetScores())),
+					mlog.Err(buildErr))
+				returnInvalidSearchResult(c, buildErr)
 			} else {
+				respBody := gin.H{
+					HTTPReturnCode:  merr.Code(nil),
+					HTTPReturnData:  outputData,
+					HTTPReturnCost:  cost,
+					HTTPReturnTopks: searchResp.Results.Topks,
+				}
 				if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() && isValid {
-					HTTPReturnStream(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: outputData, HTTPReturnCost: cost, HTTPReturnTopks: searchResp.Results.Topks, HTTPReturnScannedRemoteBytes: scannedRemoteBytes, HTTPReturnScannedTotalBytes: scannedTotalBytes, HTTPReturnCacheHitRatio: cacheHitRatio})
-				} else {
-					HTTPReturnStream(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: outputData, HTTPReturnCost: cost, HTTPReturnTopks: searchResp.Results.Topks})
+					respBody[HTTPReturnScannedRemoteBytes] = scannedRemoteBytes
+					respBody[HTTPReturnScannedTotalBytes] = scannedTotalBytes
+					respBody[HTTPReturnCacheHitRatio] = cacheHitRatio
+				}
+				if renderErr := HTTPReturnStream(c, http.StatusOK, respBody); renderErr != nil {
+					err = renderErr
+					if isRequestContextError(renderErr) {
+						return resp, err
+					}
+					searchResp.Status = merr.Status(merr.ErrInvalidSearchResult)
+					mlog.Warn(ctx, "high level restful api, fail to render hybrid search result", mlog.Err(renderErr))
+					returnInvalidSearchResult(c, renderErr)
 				}
 			}
 		}

--- a/internal/distributed/proxy/httpserver/handler_v2_stream_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_stream_test.go
@@ -1,0 +1,528 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"bytes"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/json"
+	"github.com/milvus-io/milvus/internal/mocks"
+	"github.com/milvus-io/milvus/internal/proxy"
+	"github.com/milvus-io/milvus/pkg/v3/metrics"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+func lazyRouteFieldData() []*schemapb.FieldData {
+	return []*schemapb.FieldData{{
+		Type:      schemapb.DataType_Int64,
+		FieldName: FieldWordCount,
+		Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+			LongData: &schemapb.LongArray{Data: []int64{10, 20}},
+		}}},
+	}}
+}
+
+func TestV2RowResponseRoutesUseLazyStreaming(t *testing.T) {
+	paramtable.Get().Save(proxy.Params.CommonCfg.AuthorizationEnabled.Key, "false")
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	t.Cleanup(func() {
+		paramtable.Get().Reset(proxy.Params.CommonCfg.AuthorizationEnabled.Key)
+		paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+	})
+
+	tests := []struct {
+		name string
+		path string
+		body string
+		mock func(*mocks.MockProxy)
+	}{
+		{
+			name: "query",
+			path: versionalV2(EntityCategory, QueryAction),
+			body: `{"collectionName":"book","filter":"book_id > 0","outputFields":["word_count"]}`,
+			mock: func(mp *mocks.MockProxy) {
+				mp.EXPECT().Query(mock.Anything, mock.Anything).Return(&milvuspb.QueryResults{
+					Status:       commonSuccessStatus,
+					OutputFields: []string{FieldWordCount},
+					FieldsData:   lazyRouteFieldData(),
+				}, nil).Once()
+			},
+		},
+		{
+			name: "get",
+			path: versionalV2(EntityCategory, GetAction),
+			body: `{"collectionName":"book","id":[1,2],"outputFields":["word_count"]}`,
+			mock: func(mp *mocks.MockProxy) {
+				mp.EXPECT().Query(mock.Anything, mock.Anything).Return(&milvuspb.QueryResults{
+					Status:       commonSuccessStatus,
+					OutputFields: []string{FieldWordCount},
+					FieldsData:   lazyRouteFieldData(),
+				}, nil).Once()
+			},
+		},
+		{
+			name: "search",
+			path: versionalV2(EntityCategory, SearchAction),
+			body: `{"collectionName":"book","data":[[0.1,0.2]],"limit":2,"outputFields":["word_count"]}`,
+			mock: func(mp *mocks.MockProxy) {
+				mp.EXPECT().Search(mock.Anything, mock.Anything).Return(&milvuspb.SearchResults{
+					Status: commonSuccessStatus,
+					Results: &schemapb.SearchResultData{
+						TopK:         2,
+						Topks:        []int64{2},
+						OutputFields: []string{FieldWordCount},
+						FieldsData:   lazyRouteFieldData(),
+						Ids:          generateIDs(schemapb.DataType_Int64, 2),
+						Scores:       []float32{0.1, 0.2},
+					},
+				}, nil).Once()
+			},
+		},
+		{
+			name: "hybrid search",
+			path: versionalV2(EntityCategory, HybridSearchAction),
+			body: `{
+				"collectionName":"book",
+				"search":[
+					{"data":[[0.1,0.2]],"annsField":"book_intro","metricType":"L2","limit":2},
+					{"data":[[0.2,0.1]],"annsField":"book_intro","metricType":"L2","limit":2}
+				],
+				"limit":2,
+				"outputFields":["word_count"],
+				"rerank":{"strategy":"rrf","params":{"k":60}}
+			}`,
+			mock: func(mp *mocks.MockProxy) {
+				mp.EXPECT().HybridSearch(mock.Anything, mock.Anything).Return(&milvuspb.SearchResults{
+					Status: commonSuccessStatus,
+					Results: &schemapb.SearchResultData{
+						TopK:         2,
+						Topks:        []int64{2},
+						OutputFields: []string{FieldWordCount},
+						FieldsData:   lazyRouteFieldData(),
+						Ids:          generateIDs(schemapb.DataType_Int64, 2),
+						Scores:       []float32{0.1, 0.2},
+					},
+				}, nil).Once()
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mp := mocks.NewMockProxy(t)
+			mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+				CollectionName: DefaultCollectionName,
+				Schema:         generateCollectionSchema(schemapb.DataType_Int64, false, true),
+				ShardsNum:      ShardNumDefault,
+				Status:         &StatusSuccess,
+			}, nil).Once()
+			test.mock(mp)
+			engine := initHTTPServerV2(mp, false)
+
+			request := httptest.NewRequest(http.MethodPost, test.path, bytes.NewBufferString(test.body))
+			request.Header.Set(HTTPHeaderAllowInt64, "true")
+			response := httptest.NewRecorder()
+			engine.ServeHTTP(response, request)
+
+			assert.Equal(t, http.StatusOK, response.Code)
+			var body struct {
+				Code  int32                    `json:"code"`
+				Data  []map[string]interface{} `json:"data"`
+				Topks []int64                  `json:"topks"`
+			}
+			require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body), response.Body.String())
+			assert.Zero(t, body.Code, response.Body.String())
+			require.Len(t, body.Data, 2)
+			assert.EqualValues(t, 10, body.Data[0][FieldWordCount])
+			assert.EqualValues(t, 20, body.Data[1][FieldWordCount])
+			if test.name == "search" || test.name == "hybrid search" {
+				assert.Equal(t, []int64{2}, body.Topks)
+				assert.EqualValues(t, 1, body.Data[0][FieldBookID])
+				assert.EqualValues(t, 0.1, body.Data[0][HTTPReturnDistance])
+			}
+		})
+	}
+}
+
+func TestV2QueryPreservesAllNullTextRows(t *testing.T) {
+	paramtable.Get().Save(proxy.Params.CommonCfg.AuthorizationEnabled.Key, "false")
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	t.Cleanup(func() {
+		paramtable.Get().Reset(proxy.Params.CommonCfg.AuthorizationEnabled.Key)
+		paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+	})
+
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         generateCollectionSchema(schemapb.DataType_Int64, false, true),
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Once()
+	mp.EXPECT().Query(mock.Anything, mock.Anything).Return(&milvuspb.QueryResults{
+		Status:       commonSuccessStatus,
+		OutputFields: []string{"content"},
+		FieldsData: []*schemapb.FieldData{{
+			Type:      schemapb.DataType_Text,
+			FieldName: "content",
+			ValidData: []bool{false, false},
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{
+				StringData: &schemapb.StringArray{},
+			}}},
+		}},
+	}, nil).Once()
+	engine := initHTTPServerV2(mp, false)
+
+	request := httptest.NewRequest(http.MethodPost, versionalV2(EntityCategory, QueryAction), bytes.NewBufferString(
+		`{"collectionName":"book","filter":"book_id > 0","outputFields":["content"]}`))
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusOK, response.Code)
+	var body struct {
+		Code int32                    `json:"code"`
+		Data []map[string]interface{} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body), response.Body.String())
+	assert.Zero(t, body.Code)
+	require.Len(t, body.Data, 2)
+	assert.Nil(t, body.Data[0]["content"])
+	assert.Nil(t, body.Data[1]["content"])
+}
+
+func TestV2SearchAcceptsEmptyRerankResult(t *testing.T) {
+	paramtable.Get().Save(proxy.Params.CommonCfg.AuthorizationEnabled.Key, "false")
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	t.Cleanup(func() {
+		paramtable.Get().Reset(proxy.Params.CommonCfg.AuthorizationEnabled.Key)
+		paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+	})
+
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         generateCollectionSchema(schemapb.DataType_Int64, false, true),
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Once()
+	mp.EXPECT().Search(mock.Anything, mock.Anything).Return(&milvuspb.SearchResults{
+		Status: commonSuccessStatus,
+		Results: &schemapb.SearchResultData{
+			NumQueries:   1,
+			TopK:         10,
+			Topks:        []int64{0},
+			OutputFields: []string{FieldBookID},
+			FieldsData: []*schemapb.FieldData{{
+				Type:      schemapb.DataType_Int64,
+				FieldName: FieldBookID,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{},
+				}}},
+			}},
+			Ids:    &schemapb.IDs{},
+			Scores: []float32{},
+		},
+	}, nil).Once()
+	engine := initHTTPServerV2(mp, false)
+
+	request := httptest.NewRequest(http.MethodPost, versionalV2(EntityCategory, SearchAction), bytes.NewBufferString(
+		`{"collectionName":"book","data":[[0.1,0.2]],"limit":10,"outputFields":["book_id"]}`))
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusOK, response.Code)
+	var body struct {
+		Code  int32                    `json:"code"`
+		Data  []map[string]interface{} `json:"data"`
+		Topks []int64                  `json:"topks"`
+	}
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body), response.Body.String())
+	assert.Zero(t, body.Code, response.Body.String())
+	assert.Empty(t, body.Data)
+	assert.Equal(t, []int64{0}, body.Topks)
+}
+
+func TestV2SearchRejectsInvalidRowsBeforeStreaming(t *testing.T) {
+	paramtable.Get().Save(proxy.Params.CommonCfg.AuthorizationEnabled.Key, "false")
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	t.Cleanup(func() {
+		paramtable.Get().Reset(proxy.Params.CommonCfg.AuthorizationEnabled.Key)
+		paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+	})
+
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         generateCollectionSchema(schemapb.DataType_Int64, false, true),
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Once()
+	mp.EXPECT().Search(mock.Anything, mock.Anything).Return(&milvuspb.SearchResults{
+		Status: commonSuccessStatus,
+		Results: &schemapb.SearchResultData{
+			TopK:         1,
+			Topks:        []int64{1},
+			OutputFields: []string{FieldWordCount},
+			FieldsData: []*schemapb.FieldData{{
+				Type:      schemapb.DataType_Float,
+				FieldName: FieldWordCount,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_FloatData{
+					FloatData: &schemapb.FloatArray{Data: []float32{float32(math.NaN())}},
+				}}},
+			}},
+			Ids:    generateIDs(schemapb.DataType_Int64, 1),
+			Scores: []float32{0.1},
+		},
+	}, nil).Once()
+	engine := initHTTPServerV2(mp, false)
+
+	request := httptest.NewRequest(http.MethodPost, versionalV2(EntityCategory, SearchAction), bytes.NewBufferString(
+		`{"collectionName":"book","data":[[0.1,0.2]],"limit":1,"outputFields":["word_count"]}`))
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusOK, response.Code)
+	var body ReturnErrMsg
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body), response.Body.String())
+	assert.Equal(t, merr.Code(merr.ErrInvalidSearchResult), body.Code)
+	assert.Contains(t, body.Message, "non-finite")
+	assert.NotContains(t, response.Body.String(), `"data":[`)
+}
+
+func TestV2SearchRejectsRowCountMismatchBeforeStreaming(t *testing.T) {
+	paramtable.Get().Save(proxy.Params.CommonCfg.AuthorizationEnabled.Key, "false")
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	t.Cleanup(func() {
+		paramtable.Get().Reset(proxy.Params.CommonCfg.AuthorizationEnabled.Key)
+		paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+	})
+
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         generateCollectionSchema(schemapb.DataType_Int64, false, true),
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Once()
+	mp.EXPECT().Search(mock.Anything, mock.Anything).Return(&milvuspb.SearchResults{
+		Status: commonSuccessStatus,
+		Results: &schemapb.SearchResultData{
+			TopK:         1,
+			Topks:        []int64{1},
+			OutputFields: []string{FieldWordCount},
+			FieldsData: []*schemapb.FieldData{{
+				Type:      schemapb.DataType_Int64,
+				FieldName: FieldWordCount,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{},
+				}}},
+			}},
+			Ids:    generateIDs(schemapb.DataType_Int64, 1),
+			Scores: []float32{0.1},
+		},
+	}, nil).Once()
+	engine := initHTTPServerV2(mp, false)
+
+	request := httptest.NewRequest(http.MethodPost, versionalV2(EntityCategory, SearchAction), bytes.NewBufferString(
+		`{"collectionName":"book","data":[[0.1,0.2]],"limit":1,"outputFields":["word_count"]}`))
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusOK, response.Code)
+	var body ReturnErrMsg
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body), response.Body.String())
+	assert.Equal(t, merr.Code(merr.ErrInvalidSearchResult), body.Code)
+	assert.Contains(t, body.Message, "expected exactly 1")
+	assert.NotContains(t, response.Body.String(), `"data":[`)
+}
+
+func TestV2ResultConversionFailuresRecordSystemFailureMetrics(t *testing.T) {
+	paramtable.Get().Save(proxy.Params.CommonCfg.AuthorizationEnabled.Key, "false")
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	t.Cleanup(func() {
+		paramtable.Get().Reset(proxy.Params.CommonCfg.AuthorizationEnabled.Key)
+		paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+	})
+
+	malformedFieldData := func() []*schemapb.FieldData {
+		return []*schemapb.FieldData{{
+			Type:      schemapb.DataType_Float,
+			FieldName: FieldWordCount,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_FloatData{
+				FloatData: &schemapb.FloatArray{Data: []float32{float32(math.NaN())}},
+			}}},
+		}}
+	}
+	malformedSearchResult := func() *schemapb.SearchResultData {
+		return &schemapb.SearchResultData{
+			TopK:         1,
+			Topks:        []int64{1},
+			OutputFields: []string{FieldWordCount},
+			FieldsData:   malformedFieldData(),
+			Ids:          generateIDs(schemapb.DataType_Int64, 1),
+			Scores:       []float32{0.1},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		path      string
+		body      string
+		methodTag string
+		mock      func(*mocks.MockProxy)
+	}{
+		{
+			name:      "query",
+			path:      versionalV2(EntityCategory, QueryAction),
+			body:      `{"collectionName":"book","filter":"book_id > 0","outputFields":["word_count"]}`,
+			methodTag: "Query",
+			mock: func(mp *mocks.MockProxy) {
+				mp.EXPECT().Query(mock.Anything, mock.Anything).Return(&milvuspb.QueryResults{
+					Status:       commonSuccessStatus,
+					OutputFields: []string{FieldWordCount},
+					FieldsData:   malformedFieldData(),
+				}, nil).Once()
+			},
+		},
+		{
+			name:      "get",
+			path:      versionalV2(EntityCategory, GetAction),
+			body:      `{"collectionName":"book","id":[1],"outputFields":["word_count"]}`,
+			methodTag: "Query",
+			mock: func(mp *mocks.MockProxy) {
+				mp.EXPECT().Query(mock.Anything, mock.Anything).Return(&milvuspb.QueryResults{
+					Status:       commonSuccessStatus,
+					OutputFields: []string{FieldWordCount},
+					FieldsData:   malformedFieldData(),
+				}, nil).Once()
+			},
+		},
+		{
+			name:      "search",
+			path:      versionalV2(EntityCategory, SearchAction),
+			body:      `{"collectionName":"book","data":[[0.1,0.2]],"limit":1,"outputFields":["word_count"]}`,
+			methodTag: "Search",
+			mock: func(mp *mocks.MockProxy) {
+				mp.EXPECT().Search(mock.Anything, mock.Anything).Return(&milvuspb.SearchResults{
+					Status:  commonSuccessStatus,
+					Results: malformedSearchResult(),
+				}, nil).Once()
+			},
+		},
+		{
+			name:      "search metadata render",
+			path:      versionalV2(EntityCategory, SearchAction),
+			body:      `{"collectionName":"book","data":[[0.1,0.2]],"limit":2,"outputFields":["word_count"]}`,
+			methodTag: "Search",
+			mock: func(mp *mocks.MockProxy) {
+				mp.EXPECT().Search(mock.Anything, mock.Anything).Return(&milvuspb.SearchResults{
+					Status: commonSuccessStatus,
+					Results: &schemapb.SearchResultData{
+						TopK:         2,
+						Topks:        []int64{2},
+						OutputFields: []string{FieldWordCount},
+						FieldsData:   lazyRouteFieldData(),
+						Ids:          generateIDs(schemapb.DataType_Int64, 2),
+						Scores:       []float32{0.1, 0.2},
+						Recalls:      []float32{float32(math.NaN())},
+					},
+				}, nil).Once()
+			},
+		},
+		{
+			name:      "search aggregation",
+			path:      versionalV2(EntityCategory, SearchAction),
+			body:      `{"collectionName":"book","data":[[0.1,0.2]],"limit":1}`,
+			methodTag: "Search",
+			mock: func(mp *mocks.MockProxy) {
+				mp.EXPECT().Search(mock.Anything, mock.Anything).Return(&milvuspb.SearchResults{
+					Status: commonSuccessStatus,
+					Results: &schemapb.SearchResultData{
+						AggTopks: []int64{1},
+					},
+				}, nil).Once()
+			},
+		},
+		{
+			name: "hybrid search",
+			path: versionalV2(EntityCategory, HybridSearchAction),
+			body: `{
+				"collectionName":"book",
+				"search":[
+					{"data":[[0.1,0.2]],"annsField":"book_intro","metricType":"L2","limit":1},
+					{"data":[[0.2,0.1]],"annsField":"book_intro","metricType":"L2","limit":1}
+				],
+				"limit":1,
+				"outputFields":["word_count"],
+				"rerank":{"strategy":"rrf","params":{"k":60}}
+			}`,
+			methodTag: "HybridSearch",
+			mock: func(mp *mocks.MockProxy) {
+				mp.EXPECT().HybridSearch(mock.Anything, mock.Anything).Return(&milvuspb.SearchResults{
+					Status:  commonSuccessStatus,
+					Results: malformedSearchResult(),
+				}, nil).Once()
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mp := mocks.NewMockProxy(t)
+			mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+				CollectionName: DefaultCollectionName,
+				Schema:         generateCollectionSchema(schemapb.DataType_Int64, false, true),
+				ShardsNum:      ShardNumDefault,
+				Status:         &StatusSuccess,
+			}, nil).Once()
+			test.mock(mp)
+			engine := initHTTPServerV2(mp, false)
+
+			nodeID := strconv.FormatInt(paramtable.GetNodeID(), 10)
+			failCounter := metrics.ProxyFunctionCall.WithLabelValues(
+				nodeID, test.methodTag, metrics.FailLabel, metrics.CauseSystem, DefaultDbName, DefaultCollectionName)
+			successCounter := metrics.ProxyFunctionCall.WithLabelValues(
+				nodeID, test.methodTag, metrics.SuccessLabel, metrics.CauseNA, DefaultDbName, DefaultCollectionName)
+			failBefore := testutil.ToFloat64(failCounter)
+			successBefore := testutil.ToFloat64(successCounter)
+
+			request := httptest.NewRequest(http.MethodPost, test.path, bytes.NewBufferString(test.body))
+			response := httptest.NewRecorder()
+			engine.ServeHTTP(response, request)
+
+			assert.Equal(t, http.StatusOK, response.Code)
+			var responseBody ReturnErrMsg
+			require.NoError(t, json.Unmarshal(response.Body.Bytes(), &responseBody), response.Body.String())
+			assert.Equal(t, merr.Code(merr.ErrInvalidSearchResult), responseBody.Code)
+			assert.Equal(t, failBefore+1, testutil.ToFloat64(failCounter))
+			assert.Equal(t, successBefore, testutil.ToFloat64(successCounter))
+		})
+	}
+}

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -474,7 +474,7 @@ func TestTimeoutResponseRecorderIsolation(t *testing.T) {
 	assert.Equal(t, 4, recorder.Size())
 	assert.True(t, recorder.Written())
 
-	assert.NoError(t, recorder.CommitTo(realCtx.Writer))
+	assert.NoError(t, recorder.CommitTo(context.Background(), realCtx.Writer))
 	assert.Equal(t, http.StatusAccepted, realResponse.Code)
 	assert.Equal(t, "value", realResponse.Header().Get("X-Test"))
 	assert.Equal(t, "body", realResponse.Body.String())
@@ -2365,7 +2365,7 @@ func versionalV2(category string, action string) string {
 }
 
 func initHTTPServerV2(proxy types.ProxyComponent, needAuth bool) *gin.Engine {
-	h := NewHandlersV2(proxy)
+	h := NewHandlersV2(proxy, 0)
 	ginHandler := gin.Default()
 	appV2 := ginHandler.Group("/v2/vectordb", genAuthMiddleWare(needAuth))
 	h.RegisterRoutesToV2(appV2)

--- a/internal/distributed/proxy/httpserver/json_render.go
+++ b/internal/distributed/proxy/httpserver/json_render.go
@@ -17,26 +17,241 @@
 package httpserver
 
 import (
+	"bufio"
+	"context"
+	"io"
 	"net/http"
+	"sort"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/render"
 
 	"github.com/milvus-io/milvus/internal/json"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 var jsonContentType = []string{"application/json; charset=utf-8"}
 
+const (
+	streamingJSONBufferSize = 64 * 1024
+)
+
+type deferredRenderWriter interface {
+	DeferRender(render.Render) error
+}
+
+type jsonRowSource interface {
+	Len() int64
+	Row(index int64) (map[string]interface{}, error)
+}
+
+type jsonStreamSource interface {
+	WriteJSON(context.Context, io.Writer) error
+}
+
+type jsonRowStreamSource struct {
+	rows     jsonRowSource
+	rowCount int64
+}
+
+type encodedJSONField struct {
+	key    []byte
+	value  []byte
+	stream jsonStreamSource
+}
+
+type streamingJSONRender struct {
+	ctx    context.Context
+	fields []encodedJSONField
+}
+
 type jsonRender struct {
-	Data any
+	Context context.Context
+	Data    gin.H
 }
 
 // Render writes data with custom ContentType.
 func (r jsonRender) Render(w http.ResponseWriter) error {
 	r.WriteContentType(w)
-	encoder := json.NewEncoder(w)
+	ctx := renderContext(r.Context)
+	streamSource, ok, err := getJSONStreamSource(r.Data[HTTPReturnData])
+	if err != nil {
+		return err
+	}
+	if ok {
+		streamRender, err := newStreamingJSONRender(ctx, r.Data, streamSource)
+		if err != nil {
+			return err
+		}
+		if deferredWriter, ok := w.(deferredRenderWriter); ok {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if err := deferredWriter.DeferRender(streamRender); err != nil {
+				// A timeout may close the recorder between preflight and renderer
+				// registration. Preserve the request cancellation in that race
+				// instead of misclassifying the late registration as an invalid
+				// search result.
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctxErr
+				}
+				return err
+			}
+			return ctx.Err()
+		}
+		return streamRender.Render(w)
+	}
+
+	// Only cooperative stream sources are deferred. Generic JSON encoding may
+	// spend substantial CPU time before its first Write, so keep that work in
+	// the handler goroutine where timeout arbitration still applies.
+	deadlineWriter := newRequestDeadlineWriter(ctx, w)
+	defer deadlineWriter.stopDeadlineInterrupt()
+	encoder := json.NewEncoder(deadlineWriter)
 	return encoder.Encode(r.Data)
+}
+
+func renderContext(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
+}
+
+func getJSONStreamSource(data interface{}) (jsonStreamSource, bool, error) {
+	if source, ok := data.(jsonStreamSource); ok {
+		return source, true, nil
+	}
+	rows, ok := data.(jsonRowSource)
+	if !ok {
+		return nil, false, nil
+	}
+	rowCount := rows.Len()
+	if rowCount < 0 {
+		return nil, false, merr.WrapErrServiceInternalMsg("JSON row source returned negative row count %d", rowCount)
+	}
+	return &jsonRowStreamSource{rows: rows, rowCount: rowCount}, true, nil
+}
+
+func newStreamingJSONRender(ctx context.Context, data gin.H, streamSource jsonStreamSource) (*streamingJSONRender, error) {
+	keys := make([]string, 0, len(data))
+	for key := range data {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	streamRender := &streamingJSONRender{
+		ctx:    ctx,
+		fields: make([]encodedJSONField, 0, len(keys)),
+	}
+	for _, key := range keys {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		encodedKey, err := json.Marshal(key)
+		if err != nil {
+			return nil, err
+		}
+		field := encodedJSONField{key: encodedKey}
+		if key == HTTPReturnData {
+			field.stream = streamSource
+		} else {
+			field.value, err = json.Marshal(data[key])
+			if err != nil {
+				return nil, err
+			}
+		}
+		streamRender.fields = append(streamRender.fields, field)
+	}
+	return streamRender, nil
+}
+
+func (r *streamingJSONRender) Render(w http.ResponseWriter) error {
+	r.WriteContentType(w)
+	if err := r.ctx.Err(); err != nil {
+		return err
+	}
+
+	deadlineWriter := newRequestDeadlineWriter(r.ctx, w)
+	defer deadlineWriter.stopDeadlineInterrupt()
+	bufferedWriter := bufio.NewWriterSize(deadlineWriter, streamingJSONBufferSize)
+	if err := bufferedWriter.WriteByte('{'); err != nil {
+		return err
+	}
+	for index, field := range r.fields {
+		if index > 0 {
+			if err := bufferedWriter.WriteByte(','); err != nil {
+				return err
+			}
+		}
+		if _, err := bufferedWriter.Write(field.key); err != nil {
+			return err
+		}
+		if err := bufferedWriter.WriteByte(':'); err != nil {
+			return err
+		}
+
+		if field.stream == nil {
+			if _, err := bufferedWriter.Write(field.value); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// Keep small responses uncommitted while encoding; large responses
+		// commit naturally when the bounded buffer fills.
+		if err := field.stream.WriteJSON(r.ctx, bufferedWriter); err != nil {
+			return err
+		}
+	}
+	if err := bufferedWriter.WriteByte('}'); err != nil {
+		return err
+	}
+	if err := bufferedWriter.WriteByte('\n'); err != nil {
+		return err
+	}
+	return bufferedWriter.Flush()
+}
+
+func (source *jsonRowStreamSource) WriteJSON(ctx context.Context, w io.Writer) error {
+	if _, err := w.Write([]byte{'['}); err != nil {
+		return err
+	}
+	rowEncoder := json.NewEncoder(w)
+	for rowIndex := int64(0); rowIndex < source.rowCount; rowIndex++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if rowIndex > 0 {
+			if _, err := w.Write([]byte{','}); err != nil {
+				return err
+			}
+		}
+		row, err := source.rows.Row(rowIndex)
+		if err != nil {
+			return err
+		}
+		// Reuse one streaming encoder. Sonic still materializes one encoded row
+		// in scratch, but avoids an additional owned []byte and copy per row.
+		if err := rowEncoder.Encode(row); err != nil {
+			return err
+		}
+	}
+	_, err := w.Write([]byte{']'})
+	return err
+}
+
+// WriteContentType writes JSON ContentType.
+func (r *streamingJSONRender) WriteContentType(w http.ResponseWriter) {
+	writeJSONContentType(w)
 }
 
 // WriteContentType writes JSON ContentType.
 func (r jsonRender) WriteContentType(w http.ResponseWriter) {
+	writeJSONContentType(w)
+}
+
+func writeJSONContentType(w http.ResponseWriter) {
 	header := w.Header()
 	if val := header["Content-Type"]; len(val) == 0 {
 		header["Content-Type"] = jsonContentType

--- a/internal/distributed/proxy/httpserver/json_render_test.go
+++ b/internal/distributed/proxy/httpserver/json_render_test.go
@@ -17,13 +17,23 @@
 package httpserver
 
 import (
+	"bytes"
+	"context"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/render"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/internal/json"
 )
 
 var testResult = gin.H{
@@ -48,6 +58,426 @@ func randomString(length int) string {
 		result.WriteByte(charset[rand.Intn(len(charset))])
 	}
 	return result.String()
+}
+
+type countedJSONValue struct {
+	encodedRows *int
+	value       string
+}
+
+type testJSONRows struct {
+	rows     []map[string]interface{}
+	rowCalls int
+}
+
+func (rows *testJSONRows) Len() int64 {
+	return int64(len(rows.rows))
+}
+
+func (rows *testJSONRows) Row(index int64) (map[string]interface{}, error) {
+	rows.rowCalls++
+	return rows.rows[index], nil
+}
+
+func (v countedJSONValue) MarshalJSON() ([]byte, error) {
+	*v.encodedRows = *v.encodedRows + 1
+	return []byte(strconv.Quote(v.value)), nil
+}
+
+type streamingCaptureWriter struct {
+	header                http.Header
+	body                  bytes.Buffer
+	status                int
+	writeCount            int
+	firstWriteEncodedRows int
+	encodedRows           *int
+}
+
+func newStreamingCaptureWriter(encodedRows *int) *streamingCaptureWriter {
+	return &streamingCaptureWriter{
+		header:                make(http.Header),
+		status:                http.StatusOK,
+		firstWriteEncodedRows: -1,
+		encodedRows:           encodedRows,
+	}
+}
+
+func (w *streamingCaptureWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *streamingCaptureWriter) WriteHeader(status int) {
+	w.status = status
+}
+
+func (w *streamingCaptureWriter) Write(data []byte) (int, error) {
+	if w.firstWriteEncodedRows < 0 {
+		w.firstWriteEncodedRows = *w.encodedRows
+	}
+	w.writeCount++
+	return w.body.Write(data)
+}
+
+func TestJSONRenderStreamsRowsIncrementally(t *testing.T) {
+	encodedRows := 0
+	rows := make([]map[string]interface{}, 256)
+	for i := range rows {
+		rows[i] = map[string]interface{}{
+			"id": i,
+			"value": countedJSONValue{
+				encodedRows: &encodedRows,
+				value:       strings.Repeat("x", 256),
+			},
+		}
+	}
+
+	rowSource := &testJSONRows{rows: rows}
+	w := newStreamingCaptureWriter(&encodedRows)
+	err := (jsonRender{Data: gin.H{
+		HTTPReturnCode: 0,
+		HTTPReturnData: rowSource,
+		HTTPReturnTopks: []int64{
+			int64(len(rows)),
+		},
+	}}).Render(w)
+	require.NoError(t, err)
+	// JSON encoders may invoke a custom Marshaler more than once under race or
+	// coverage instrumentation. Row production itself must still happen once,
+	// and a response larger than the stream buffer must start writing before
+	// all rows have been encoded.
+	assert.GreaterOrEqual(t, encodedRows, len(rows))
+	assert.Equal(t, len(rows), rowSource.rowCalls)
+	assert.Positive(t, w.firstWriteEncodedRows)
+	assert.Less(t, w.firstWriteEncodedRows, encodedRows)
+	assert.Greater(t, w.writeCount, 1)
+	assert.Equal(t, jsonContentType[0], w.header.Get("Content-Type"))
+
+	var response struct {
+		Code  int                      `json:"code"`
+		Data  []map[string]interface{} `json:"data"`
+		Topks []int64                  `json:"topks"`
+	}
+	require.NoError(t, json.Unmarshal(w.body.Bytes(), &response))
+	assert.Zero(t, response.Code)
+	assert.Len(t, response.Data, len(rows))
+	assert.Equal(t, []int64{int64(len(rows))}, response.Topks)
+}
+
+func TestJSONRenderStreamsFewWideRowsWithoutRecorderBuffering(t *testing.T) {
+	encodedRows := 0
+	rows := make([]map[string]interface{}, 3)
+	for i := range rows {
+		rows[i] = map[string]interface{}{
+			"id": i,
+			"vector": countedJSONValue{
+				encodedRows: &encodedRows,
+				value:       strings.Repeat("x", streamingJSONBufferSize*2),
+			},
+		}
+	}
+
+	rowSource := &testJSONRows{rows: rows}
+	recorderBuffer := &bytes.Buffer{}
+	recorder := newTimeoutResponseRecorder(recorderBuffer)
+	require.NoError(t, (jsonRender{Data: gin.H{
+		HTTPReturnCode: 0,
+		HTTPReturnData: rowSource,
+	}}).Render(recorder))
+	assert.Zero(t, recorderBuffer.Len())
+	assert.Zero(t, rowSource.rowCalls)
+
+	networkWriter := newStreamingCaptureWriter(&encodedRows)
+	realCtx, _ := gin.CreateTestContext(networkWriter)
+	require.NoError(t, recorder.CommitTo(context.Background(), realCtx.Writer))
+
+	assert.Equal(t, len(rows), rowSource.rowCalls)
+	assert.GreaterOrEqual(t, encodedRows, len(rows))
+	assert.Positive(t, networkWriter.firstWriteEncodedRows)
+	assert.Less(t, networkWriter.firstWriteEncodedRows, encodedRows)
+	assert.Greater(t, networkWriter.writeCount, 1)
+	assert.Zero(t, recorderBuffer.Len())
+	var response struct {
+		Code int                      `json:"code"`
+		Data []map[string]interface{} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(networkWriter.body.Bytes(), &response))
+	assert.Zero(t, response.Code)
+	assert.Len(t, response.Data, len(rows))
+}
+
+func TestJSONRenderRowSourceEquivalentToMaterializedJSON(t *testing.T) {
+	rows := []map[string]interface{}{
+		{"id": int64(1), "name": "one", "nullable": nil},
+		{"id": int64(2), "name": "two", "vector": []float32{0.1, 0.2}},
+	}
+	data := gin.H{
+		HTTPReturnCode:               int32(0),
+		HTTPReturnData:               &testJSONRows{rows: rows},
+		HTTPReturnCost:               7,
+		HTTPReturnTopks:              []int64{2},
+		HTTPReturnRecalls:            []float32{0.5},
+		HTTPReturnScannedRemoteBytes: int64(11),
+		HTTPReturnScannedTotalBytes:  int64(22),
+		HTTPReturnCacheHitRatio:      0.5,
+	}
+
+	streamed := httptest.NewRecorder()
+	require.NoError(t, (jsonRender{Data: data}).Render(streamed))
+
+	expected, err := json.Marshal(gin.H{
+		HTTPReturnCode:               int32(0),
+		HTTPReturnData:               rows,
+		HTTPReturnCost:               7,
+		HTTPReturnTopks:              []int64{2},
+		HTTPReturnRecalls:            []float32{0.5},
+		HTTPReturnScannedRemoteBytes: int64(11),
+		HTTPReturnScannedTotalBytes:  int64(22),
+		HTTPReturnCacheHitRatio:      0.5,
+	})
+	require.NoError(t, err)
+
+	var streamedValue interface{}
+	var expectedValue interface{}
+	require.NoError(t, json.Unmarshal(streamed.Body.Bytes(), &streamedValue))
+	require.NoError(t, json.Unmarshal(expected, &expectedValue))
+	assert.Equal(t, expectedValue, streamedValue)
+}
+
+func TestJSONRenderRendersEmptyRows(t *testing.T) {
+	response := httptest.NewRecorder()
+	require.NoError(t, (jsonRender{Data: gin.H{
+		HTTPReturnCode: 0,
+		HTTPReturnData: &testJSONRows{},
+	}}).Render(response))
+
+	var body struct {
+		Code int                      `json:"code"`
+		Data []map[string]interface{} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body))
+	assert.Zero(t, body.Code)
+	assert.Empty(t, body.Data)
+}
+
+type failingJSONValue struct {
+	err error
+}
+
+func (value failingJSONValue) MarshalJSON() ([]byte, error) {
+	return nil, value.err
+}
+
+type cancelingDeferredRenderWriter struct {
+	*httptest.ResponseRecorder
+	cancel context.CancelFunc
+	err    error
+}
+
+func (writer *cancelingDeferredRenderWriter) DeferRender(_ render.Render) error {
+	writer.cancel()
+	return writer.err
+}
+
+func TestJSONRenderPrefersContextErrorDuringDeferredRegistrationRace(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	registrationErr := errors.New("response writer closed")
+	writer := &cancelingDeferredRenderWriter{
+		ResponseRecorder: httptest.NewRecorder(),
+		cancel:           cancel,
+		err:              registrationErr,
+	}
+
+	err := (jsonRender{Context: ctx, Data: gin.H{
+		HTTPReturnCode: 0,
+		HTTPReturnData: &testJSONRows{rows: []map[string]interface{}{{"id": 1}}},
+	}}).Render(writer)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.NotErrorIs(t, err, registrationErr)
+}
+
+func TestHTTPReturnStreamReturnsRenderError(t *testing.T) {
+	expectedErr := errors.New("metadata encode failed")
+	response := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(response)
+	c.Request = httptest.NewRequest(http.MethodGet, "/stream", nil)
+
+	err := HTTPReturnStream(c, http.StatusOK, gin.H{
+		HTTPReturnCode: 0,
+		HTTPReturnData: &testJSONRows{rows: []map[string]interface{}{{"id": 1}}},
+		"invalid":      failingJSONValue{err: expectedErr},
+	})
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.True(t, c.IsAborted())
+	assert.Empty(t, response.Body.String())
+}
+
+func TestJSONRenderKeepsGenericEncodingInHandler(t *testing.T) {
+	recorderBuffer := &bytes.Buffer{}
+	recorder := newTimeoutResponseRecorder(recorderBuffer)
+
+	require.NoError(t, (jsonRender{Data: gin.H{
+		HTTPReturnCode: 0,
+		HTTPReturnData: []gin.H{{"id": 1}},
+	}}).Render(recorder))
+
+	assert.Nil(t, recorder.render)
+	assert.NotEmpty(t, recorderBuffer.Bytes())
+}
+
+func TestJSONRenderValidatesMetadataBeforeCommit(t *testing.T) {
+	expectedErr := errors.New("metadata encode failed")
+	for name, rowCount := range map[string]int{
+		"small response": 1,
+		"large response": 256,
+	} {
+		t.Run(name, func(t *testing.T) {
+			recorder := newTimeoutResponseRecorder(&bytes.Buffer{})
+			rowSource := &testJSONRows{rows: make([]map[string]interface{}, rowCount)}
+			err := (jsonRender{Data: gin.H{
+				HTTPReturnCode: 0,
+				HTTPReturnData: rowSource,
+				"invalid":      failingJSONValue{err: expectedErr},
+			}}).Render(recorder)
+
+			require.ErrorIs(t, err, expectedErr)
+			assert.Nil(t, recorder.render)
+			assert.Zero(t, recorder.body.Len())
+			assert.Zero(t, rowSource.rowCalls)
+		})
+	}
+}
+
+type failAfterJSONWrites struct {
+	header http.Header
+	writes int
+	failAt int
+	err    error
+}
+
+func (w *failAfterJSONWrites) Header() http.Header {
+	return w.header
+}
+
+func (w *failAfterJSONWrites) WriteHeader(int) {}
+
+func (w *failAfterJSONWrites) Write(data []byte) (int, error) {
+	w.writes++
+	if w.writes >= w.failAt {
+		return 0, w.err
+	}
+	return len(data), nil
+}
+
+func TestJSONRenderStopsProducingRowsAfterWriteFailure(t *testing.T) {
+	rows := make([]map[string]interface{}, 1000)
+	for index := range rows {
+		rows[index] = map[string]interface{}{
+			"id":    index,
+			"value": strings.Repeat("x", 2048),
+		}
+	}
+	rowSource := &testJSONRows{rows: rows}
+	expectedErr := errors.New("client disconnected")
+	w := &failAfterJSONWrites{
+		header: make(http.Header),
+		failAt: 3,
+		err:    expectedErr,
+	}
+
+	err := (jsonRender{Data: gin.H{
+		HTTPReturnCode: 0,
+		HTTPReturnData: rowSource,
+	}}).Render(w)
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Positive(t, rowSource.rowCalls)
+	assert.Less(t, rowSource.rowCalls, len(rows))
+}
+
+type deadlineBlockingJSONWriter struct {
+	header  http.Header
+	body    bytes.Buffer
+	ctx     *manuallyExpiredContext
+	writes  int
+	blockAt int
+}
+
+type manuallyExpiredContext struct {
+	context.Context
+	done chan struct{}
+}
+
+func newManuallyExpiredContext() *manuallyExpiredContext {
+	return &manuallyExpiredContext{
+		Context: context.Background(),
+		done:    make(chan struct{}),
+	}
+}
+
+func (c *manuallyExpiredContext) Deadline() (time.Time, bool) {
+	return time.Now().Add(time.Hour), true
+}
+
+func (c *manuallyExpiredContext) Done() <-chan struct{} {
+	return c.done
+}
+
+func (c *manuallyExpiredContext) Err() error {
+	select {
+	case <-c.done:
+		return context.DeadlineExceeded
+	default:
+		return nil
+	}
+}
+
+func (c *manuallyExpiredContext) expire() {
+	close(c.done)
+}
+
+func (w *deadlineBlockingJSONWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *deadlineBlockingJSONWriter) WriteHeader(int) {}
+
+func (w *deadlineBlockingJSONWriter) Write(data []byte) (int, error) {
+	w.writes++
+	if w.writes == w.blockAt {
+		w.ctx.expire()
+		return 0, w.ctx.Err()
+	}
+	return w.body.Write(data)
+}
+
+func TestJSONRenderStopsProducingRowsAfterDeadlineDuringStreaming(t *testing.T) {
+	rows := make([]map[string]interface{}, 100)
+	for i := range rows {
+		rows[i] = map[string]interface{}{
+			"id":    i,
+			"value": strings.Repeat("x", streamingJSONBufferSize*2),
+		}
+	}
+	rowSource := &testJSONRows{rows: rows}
+	ctx := newManuallyExpiredContext()
+	w := &deadlineBlockingJSONWriter{
+		header:  make(http.Header),
+		ctx:     ctx,
+		blockAt: 2,
+	}
+
+	err := (jsonRender{Context: ctx, Data: gin.H{
+		HTTPReturnCode: 0,
+		HTTPReturnData: rowSource,
+	}}).Render(w)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 2, w.writes)
+	assert.Positive(t, w.body.Len(), "the first buffered chunk must be written before the deadline")
+	assert.Positive(t, rowSource.rowCalls)
+	assert.Less(t, rowSource.rowCalls, len(rows))
 }
 
 func BenchmarkHTTPReturn(b *testing.B) {

--- a/internal/distributed/proxy/httpserver/query_response_rows_test.go
+++ b/internal/distributed/proxy/httpserver/query_response_rows_test.go
@@ -1,0 +1,697 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"bytes"
+	"context"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/json"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+func materializeQueryResponseRows(t *testing.T, rows *queryResponseRows) []map[string]interface{} {
+	t.Helper()
+	result := make([]map[string]interface{}, 0, rows.Len())
+	for rowIndex := int64(0); rowIndex < rows.Len(); rowIndex++ {
+		row, err := rows.Row(rowIndex)
+		require.NoError(t, err)
+		result = append(result, row)
+	}
+	return result
+}
+
+type cancelAfterErrChecksContext struct {
+	context.Context
+	remaining int
+	done      chan struct{}
+	canceled  bool
+}
+
+func newCancelAfterErrChecksContext(allowed int) *cancelAfterErrChecksContext {
+	return &cancelAfterErrChecksContext{
+		Context:   context.Background(),
+		remaining: allowed,
+		done:      make(chan struct{}),
+	}
+}
+
+func (ctx *cancelAfterErrChecksContext) Done() <-chan struct{} {
+	return ctx.done
+}
+
+func (ctx *cancelAfterErrChecksContext) Err() error {
+	if ctx.canceled {
+		return context.Canceled
+	}
+	if ctx.remaining > 0 {
+		ctx.remaining--
+		return nil
+	}
+	ctx.canceled = true
+	close(ctx.done)
+	return context.Canceled
+}
+
+func TestNullableVectorPreflightObservesCancellationAfterValidDataScan(t *testing.T) {
+	validData := make([]bool, responseContextCheckInterval+1)
+	fieldData := &schemapb.FieldData{
+		Type:      schemapb.DataType_FloatVector,
+		FieldName: "vector",
+		ValidData: validData,
+		Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+			Dim:  2,
+			Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{}},
+		}},
+	}
+	ctx := newCancelAfterErrChecksContext(2)
+
+	_, err := newFieldDataRowAccessorWithContext(ctx, fieldData)
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestQueryResponseRowsMatchesExistingResponseValues(t *testing.T) {
+	outputFields := []string{FieldBookID, FieldWordCount, "author", "date"}
+	rows, err := newQueryResponseRows(
+		0,
+		outputFields,
+		generateFieldData(),
+		generateIDs(schemapb.DataType_Int64, 3),
+		DefaultScores,
+		true,
+		nil,
+	)
+	require.NoError(t, err)
+
+	actual := materializeQueryResponseRows(t, rows)
+	expected := generateSearchResult(schemapb.DataType_Int64)
+	assert.True(t, compareRows(actual, expected, compareRow))
+}
+
+func TestQueryResponseRowsDynamicAndNullableValues(t *testing.T) {
+	dynamicField := &schemapb.FieldData{
+		Type:      schemapb.DataType_JSON,
+		FieldName: "$meta",
+		IsDynamic: true,
+		ValidData: []bool{true, false, true},
+		Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_JsonData{JsonData: &schemapb.JSONArray{Data: [][]byte{
+				[]byte(`{"age": 18, "city": "shanghai"}`),
+				[]byte(`{"age": 20, "city": "hangzhou"}`),
+			}}},
+		}},
+	}
+	nullableVector := &schemapb.FieldData{
+		Type:      schemapb.DataType_FloatVector,
+		FieldName: "vector",
+		ValidData: []bool{true, false, true},
+		Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+			Dim: 2,
+			Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{
+				Data: []float32{0.1, 0.2, 0.3, 0.4},
+			}},
+		}},
+	}
+
+	rows, err := newQueryResponseRows(
+		0,
+		[]string{"age", "vector"},
+		[]*schemapb.FieldData{dynamicField, nullableVector},
+		nil,
+		nil,
+		true,
+		nil,
+	)
+	require.NoError(t, err)
+	actual := materializeQueryResponseRows(t, rows)
+	require.Len(t, actual, 3)
+	assert.EqualValues(t, 18, actual[0]["age"])
+	assert.NotContains(t, actual[0], "city")
+	assert.Equal(t, []float32{0.1, 0.2}, actual[0]["vector"])
+	assert.NotContains(t, actual[1], "age")
+	assert.Nil(t, actual[1]["vector"])
+	assert.EqualValues(t, 20, actual[2]["age"])
+	assert.Equal(t, []float32{0.3, 0.4}, actual[2]["vector"])
+}
+
+func TestQueryResponseRowsStructArrayValues(t *testing.T) {
+	schema := buildStructArrayTestSchema()
+	structSchema := schema.GetStructArrayFields()[0]
+	row, err := parseStructArrayRow(
+		`[{"sub_int": 10, "sub_vec": [1.1, 1.2, 1.3, 1.4]}]`, structSchema)
+	require.NoError(t, err)
+	structField, err := buildStructArrayFieldData(structSchema, []structArrayRow{row})
+	require.NoError(t, err)
+
+	rows, err := newQueryResponseRows(0, []string{"my_struct"}, []*schemapb.FieldData{structField}, nil, nil, true, schema)
+	require.NoError(t, err)
+	actual, err := rows.Row(0)
+	require.NoError(t, err)
+	nested, ok := actual["my_struct"].([]map[string]interface{})
+	require.True(t, ok)
+	require.Len(t, nested, 1)
+	assert.EqualValues(t, 10, nested[0]["sub_int"])
+	assert.Equal(t, []float32{1.1, 1.2, 1.3, 1.4}, nested[0]["sub_vec"])
+}
+
+func TestQueryResponseRowsRejectsMalformedInternalShapes(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields []*schemapb.FieldData
+		ids    *schemapb.IDs
+		scores []float32
+	}{
+		{
+			name: "field row count mismatch",
+			fields: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Int64,
+					FieldName: "first",
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{1, 2}},
+					}}},
+				},
+				{
+					Type:      schemapb.DataType_Int64,
+					FieldName: "short",
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{1}},
+					}}},
+				},
+			},
+		},
+		{
+			name: "vector remainder",
+			fields: []*schemapb.FieldData{{
+				Type:      schemapb.DataType_FloatVector,
+				FieldName: "vector",
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim: 2,
+					Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{
+						Data: []float32{0.1, 0.2, 0.3},
+					}},
+				}},
+			}},
+		},
+		{
+			name: "short IDs",
+			fields: []*schemapb.FieldData{{
+				Type:      schemapb.DataType_Int64,
+				FieldName: "value",
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{1, 2}},
+				}}},
+			}},
+			ids: generateIDs(schemapb.DataType_Int64, 1),
+		},
+		{
+			name: "empty first field with nonempty IDs",
+			fields: []*schemapb.FieldData{{
+				Type:      schemapb.DataType_Int64,
+				FieldName: "empty",
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{},
+				}}},
+			}},
+			ids: generateIDs(schemapb.DataType_Int64, 2),
+		},
+		{
+			name: "empty first field with nonempty second field",
+			fields: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Int64,
+					FieldName: "empty",
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{},
+					}}},
+				},
+				{
+					Type:      schemapb.DataType_Int64,
+					FieldName: "nonempty",
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{1}},
+					}}},
+				},
+			},
+		},
+		{
+			name: "all-null field with inconsistent physical data",
+			fields: []*schemapb.FieldData{{
+				Type:      schemapb.DataType_Int64,
+				FieldName: "nullable",
+				ValidData: []bool{false, false},
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{1}},
+				}}},
+			}},
+		},
+		{
+			name: "struct sub-field has extra logical rows",
+			fields: []*schemapb.FieldData{{
+				Type:      schemapb.DataType_ArrayOfStruct,
+				FieldName: "struct",
+				Field: &schemapb.FieldData_StructArrays{StructArrays: &schemapb.StructArrayField{Fields: []*schemapb.FieldData{
+					{
+						Type:      schemapb.DataType_Array,
+						FieldName: "first",
+						Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_ArrayData{
+							ArrayData: &schemapb.ArrayArray{Data: []*schemapb.ScalarField{{
+								Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{1}}},
+							}}},
+						}}},
+					},
+					{
+						Type:      schemapb.DataType_Array,
+						FieldName: "extra",
+						Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_ArrayData{
+							ArrayData: &schemapb.ArrayArray{Data: []*schemapb.ScalarField{
+								{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{1}}}},
+								{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{2}}}},
+							}},
+						}}},
+					},
+				}}},
+			}},
+			ids: generateIDs(schemapb.DataType_Int64, 1),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := newQueryResponseRows(0, nil, test.fields, test.ids, test.scores, true, nil)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, merr.ErrServiceInternal), "unexpected error classification: %v", err)
+		})
+	}
+}
+
+func TestQueryResponseRowsAcceptsEmptyIDsWrapper(t *testing.T) {
+	emptyPrimaryField := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int64,
+		FieldName: FieldBookID,
+		Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+			LongData: &schemapb.LongArray{},
+		}}},
+	}
+
+	rows, err := newQueryResponseRows(
+		0,
+		[]string{FieldBookID},
+		[]*schemapb.FieldData{emptyPrimaryField},
+		&schemapb.IDs{},
+		[]float32{},
+		true,
+		generateCollectionSchema(schemapb.DataType_Int64, false, true),
+	)
+
+	require.NoError(t, err)
+	assert.Zero(t, rows.Len())
+	assert.Empty(t, materializeQueryResponseRows(t, rows))
+}
+
+func TestQueryResponseRowsExplicitCountPreservesLegacyPrefix(t *testing.T) {
+	rows, err := newQueryResponseRows(
+		1,
+		[]string{FieldWordCount},
+		lazyRouteFieldData(),
+		generateIDs(schemapb.DataType_Int64, 2),
+		[]float32{0.1, 0.2},
+		true,
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), rows.Len())
+	row, err := rows.Row(0)
+	require.NoError(t, err)
+	assert.EqualValues(t, 10, row[FieldWordCount])
+	assert.EqualValues(t, 1, row[DefaultPrimaryFieldName])
+}
+
+func TestQueryResponseRowsPreservesAllNullText(t *testing.T) {
+	field := &schemapb.FieldData{
+		Type:      schemapb.DataType_Text,
+		FieldName: "content",
+		ValidData: []bool{false, false},
+		Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{
+			StringData: &schemapb.StringArray{},
+		}}},
+	}
+
+	rows, err := newQueryResponseRows(0, []string{"content"}, []*schemapb.FieldData{field}, nil, nil, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), rows.Len())
+	for rowIndex := int64(0); rowIndex < rows.Len(); rowIndex++ {
+		row, err := rows.Row(rowIndex)
+		require.NoError(t, err)
+		require.Contains(t, row, "content")
+		require.Nil(t, row["content"])
+	}
+}
+
+func TestQueryResponseRowsStopsPreflightWhenContextIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := newQueryResponseRowsWithContext(ctx, 0, []string{FieldWordCount}, lazyRouteFieldData(), nil, nil, true, nil)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestQueryResponseRowsStopsSparseConversionOnCancellation(t *testing.T) {
+	elemCount := int(responseContextCheckInterval * 2)
+	indices := make([]uint32, elemCount)
+	values := make([]float32, elemCount)
+	for index := 0; index < elemCount; index++ {
+		indices[index] = uint32(index)
+		values[index] = float32(index)
+	}
+	fieldData := &schemapb.FieldData{
+		Type:      schemapb.DataType_SparseFloatVector,
+		FieldName: "sparse",
+		Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+			Data: &schemapb.VectorField_SparseFloatVector{SparseFloatVector: &schemapb.SparseFloatArray{
+				Contents: [][]byte{typeutil.CreateSparseFloatRow(indices, values)},
+			}},
+		}},
+	}
+	ctx := newCancelAfterErrChecksContext(3)
+	rows := &queryResponseRows{
+		ctx:                  ctx,
+		rowsNum:              1,
+		fieldDataList:        []*schemapb.FieldData{fieldData},
+		fieldDataAccessors:   []*fieldDataRowAccessor{{fieldData: fieldData}},
+		structArrayAccessors: make([]*structArrayRowAccessor, 1),
+		enableInt64:          true,
+		pkFieldName:          DefaultPrimaryFieldName,
+	}
+
+	_, err := rows.Row(0)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestQueryResponseRowsRejectsInvalidDynamicJSON(t *testing.T) {
+	for _, raw := range [][]byte{
+		[]byte(`{"unterminated":`),
+		[]byte(`[1, 2, 3]`),
+		[]byte(`{"overflow": 1e400}`),
+	} {
+		t.Run(string(raw), func(t *testing.T) {
+			field := &schemapb.FieldData{
+				Type:      schemapb.DataType_JSON,
+				FieldName: "$meta",
+				IsDynamic: true,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_JsonData{JsonData: &schemapb.JSONArray{Data: [][]byte{raw}}},
+				}},
+			}
+			_, err := newQueryResponseRows(0, []string{"$meta"}, []*schemapb.FieldData{field}, nil, nil, true, nil)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, merr.ErrServiceInternal), "unexpected error classification: %v", err)
+		})
+	}
+
+	nullField := &schemapb.FieldData{
+		Type:      schemapb.DataType_JSON,
+		FieldName: "$meta",
+		IsDynamic: true,
+		Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_JsonData{JsonData: &schemapb.JSONArray{Data: [][]byte{[]byte("null")}}},
+		}},
+	}
+	rows, err := newQueryResponseRows(0, []string{"$meta"}, []*schemapb.FieldData{nullField}, nil, nil, true, nil)
+	require.NoError(t, err)
+	row, err := rows.Row(0)
+	require.NoError(t, err)
+	assert.Empty(t, row)
+}
+
+func TestQueryResponseRowsRejectsDynamicJSONBeyondStreamingEncoderDepth(t *testing.T) {
+	tests := []struct {
+		name    string
+		depth   int
+		wantErr bool
+	}{
+		{name: "maximum encodable depth", depth: maxDynamicJSONValueNestingDepth},
+		{name: "first unsupported depth", depth: maxDynamicJSONValueNestingDepth + 1, wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			raw := []byte(`{"deep":` + strings.Repeat("[", test.depth) + `0` + strings.Repeat("]", test.depth) + `}`)
+			field := &schemapb.FieldData{
+				Type:      schemapb.DataType_JSON,
+				FieldName: "$meta",
+				IsDynamic: true,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_JsonData{JsonData: &schemapb.JSONArray{Data: [][]byte{raw}}},
+				}},
+			}
+
+			rows, err := newQueryResponseRows(0, []string{"$meta"}, []*schemapb.FieldData{field}, nil, nil, true, nil)
+			if test.wantErr {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, merr.ErrServiceInternal)
+				return
+			}
+
+			require.NoError(t, err)
+			row, err := rows.Row(0)
+			require.NoError(t, err)
+			var encoded bytes.Buffer
+			require.NoError(t, json.NewEncoder(&encoded).Encode(row))
+		})
+	}
+}
+
+func TestQueryResponseRowsSkipsJSONValueValidationForNoopFields(t *testing.T) {
+	field := &schemapb.FieldData{
+		Type:      schemapb.DataType_VarChar,
+		FieldName: "text",
+		Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"value"}}},
+		}},
+	}
+	ctx := newCancelAfterErrChecksContext(1)
+	rows := &queryResponseRows{
+		ctx:                ctx,
+		rowsNum:            1,
+		fieldDataList:      []*schemapb.FieldData{field},
+		fieldDataAccessors: []*fieldDataRowAccessor{{fieldData: field}},
+	}
+
+	require.NoError(t, rows.validateJSONValues())
+	assert.False(t, ctx.canceled)
+}
+
+func TestQueryResponseRowsRejectsNonFiniteJSONValues(t *testing.T) {
+	sparseNaN := typeutil.CreateSparseFloatRow([]uint32{1}, []float32{float32(math.NaN())})
+	tests := []struct {
+		name   string
+		field  *schemapb.FieldData
+		scores []float32
+	}{
+		{
+			name: "float scalar",
+			field: &schemapb.FieldData{
+				Type:      schemapb.DataType_Float,
+				FieldName: "float",
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_FloatData{
+					FloatData: &schemapb.FloatArray{Data: []float32{float32(math.NaN())}},
+				}}},
+			},
+		},
+		{
+			name: "float vector",
+			field: &schemapb.FieldData{
+				Type:      schemapb.DataType_FloatVector,
+				FieldName: "vector",
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim: 2,
+					Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{
+						Data: []float32{0.1, float32(math.Inf(1))},
+					}},
+				}},
+			},
+		},
+		{
+			name: "array",
+			field: &schemapb.FieldData{
+				Type:      schemapb.DataType_Array,
+				FieldName: "array",
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_ArrayData{
+					ArrayData: &schemapb.ArrayArray{Data: []*schemapb.ScalarField{{
+						Data: &schemapb.ScalarField_DoubleData{DoubleData: &schemapb.DoubleArray{Data: []float64{math.Inf(-1)}}},
+					}}},
+				}}},
+			},
+		},
+		{
+			name: "sparse vector",
+			field: &schemapb.FieldData{
+				Type:      schemapb.DataType_SparseFloatVector,
+				FieldName: "sparse",
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Data: &schemapb.VectorField_SparseFloatVector{SparseFloatVector: &schemapb.SparseFloatArray{
+						Contents: [][]byte{sparseNaN},
+					}},
+				}},
+			},
+		},
+		{
+			name: "score",
+			field: &schemapb.FieldData{
+				Type:      schemapb.DataType_Int64,
+				FieldName: "value",
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{1}},
+				}}},
+			},
+			scores: []float32{float32(math.NaN())},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := newQueryResponseRows(0, []string{test.field.GetFieldName()}, []*schemapb.FieldData{test.field}, nil, test.scores, true, nil)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, merr.ErrServiceInternal), "unexpected error classification: %v", err)
+		})
+	}
+}
+
+func TestQueryResponseRowsRejectsNonFiniteStructVector(t *testing.T) {
+	schema := buildStructArrayTestSchema()
+	structSchema := schema.GetStructArrayFields()[0]
+	row, err := parseStructArrayRow(
+		`[{"sub_int": 10, "sub_vec": [1.1, 1.2, 1.3, 1.4]}]`, structSchema)
+	require.NoError(t, err)
+	structField, err := buildStructArrayFieldData(structSchema, []structArrayRow{row})
+	require.NoError(t, err)
+	subVector := structField.GetStructArrays().GetFields()[1].GetVectors().GetVectorArray().GetData()[0]
+	subVector.GetFloatVector().Data[0] = float32(math.NaN())
+
+	_, err = newQueryResponseRows(0, []string{"my_struct"}, []*schemapb.FieldData{structField}, nil, nil, true, schema)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, merr.ErrServiceInternal), "unexpected error classification: %v", err)
+}
+
+func TestQueryResponseRowsBounds(t *testing.T) {
+	rows, err := newQueryResponseRows(0, nil, generateFieldData(), nil, nil, true, nil)
+	require.NoError(t, err)
+	_, err = rows.Row(-1)
+	require.Error(t, err)
+	_, err = rows.Row(rows.Len())
+	require.Error(t, err)
+}
+
+func BenchmarkQueryResponseRowsComplexFields(b *testing.B) {
+	const rowCount = 128
+
+	dynamicData := make([][]byte, rowCount)
+	for index := range dynamicData {
+		dynamicData[index] = []byte(`{"category":"benchmark","weight":1.25,"nested":{"rank":7}}`)
+	}
+	dynamicField := &schemapb.FieldData{
+		Type:      schemapb.DataType_JSON,
+		FieldName: "$meta",
+		IsDynamic: true,
+		Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_JsonData{JsonData: &schemapb.JSONArray{Data: dynamicData}},
+		}},
+	}
+
+	b.Run("dynamic_json/preflight", func(b *testing.B) {
+		b.ReportAllocs()
+		for iteration := 0; iteration < b.N; iteration++ {
+			rows, err := newQueryResponseRows(0, []string{"$meta"}, []*schemapb.FieldData{dynamicField}, nil, nil, true, nil)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if rows.Len() != rowCount {
+				b.Fatalf("unexpected row count %d", rows.Len())
+			}
+		}
+	})
+
+	dynamicRows, err := newQueryResponseRows(0, []string{"$meta"}, []*schemapb.FieldData{dynamicField}, nil, nil, true, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Run("dynamic_json/row", func(b *testing.B) {
+		b.ReportAllocs()
+		for iteration := 0; iteration < b.N; iteration++ {
+			if _, err := dynamicRows.Row(int64(iteration % rowCount)); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	schema := buildStructArrayTestSchema()
+	structSchema := schema.GetStructArrayFields()[0]
+	scalar := &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{
+		IntData: &schemapb.IntArray{Data: make([]int32, 32)},
+	}}
+	vector := &schemapb.VectorField{Data: &schemapb.VectorField_FloatVector{
+		FloatVector: &schemapb.FloatArray{Data: make([]float32, 32*4)},
+	}}
+	structRows := make([]structArrayRow, rowCount)
+	for index := range structRows {
+		structRows[index] = structArrayRow{
+			"sub_int": scalar,
+			"sub_vec": vector,
+		}
+	}
+	structField, err := buildStructArrayFieldData(structSchema, structRows)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("array_of_struct/preflight", func(b *testing.B) {
+		b.ReportAllocs()
+		for iteration := 0; iteration < b.N; iteration++ {
+			rows, err := newQueryResponseRows(0, []string{"my_struct"}, []*schemapb.FieldData{structField}, nil, nil, true, schema)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if rows.Len() != rowCount {
+				b.Fatalf("unexpected row count %d", rows.Len())
+			}
+		}
+	})
+
+	complexRows, err := newQueryResponseRows(0, []string{"my_struct"}, []*schemapb.FieldData{structField}, nil, nil, true, schema)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Run("array_of_struct/row", func(b *testing.B) {
+		b.ReportAllocs()
+		for iteration := 0; iteration < b.N; iteration++ {
+			if _, err := complexRows.Row(int64(iteration % rowCount)); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/internal/distributed/proxy/httpserver/rest_large_topk_benchmark_test.go
+++ b/internal/distributed/proxy/httpserver/rest_large_topk_benchmark_test.go
@@ -1,0 +1,318 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/json"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+type discardBenchmarkWriter struct {
+	header http.Header
+	status int
+	bytes  int64
+	writes int64
+	start  time.Time
+	ttfb   time.Duration
+}
+
+func newDiscardBenchmarkWriter() *discardBenchmarkWriter {
+	return &discardBenchmarkWriter{
+		header: make(http.Header),
+		status: http.StatusOK,
+		start:  time.Now(),
+	}
+}
+
+func (w *discardBenchmarkWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *discardBenchmarkWriter) WriteHeader(status int) {
+	w.status = status
+}
+
+func (w *discardBenchmarkWriter) Write(data []byte) (int, error) {
+	if w.writes == 0 {
+		w.ttfb = time.Since(w.start)
+	}
+	w.bytes += int64(len(data))
+	w.writes++
+	return len(data), nil
+}
+
+func (w *discardBenchmarkWriter) Flush() {}
+
+type benchmarkJSONRows struct {
+	rows []map[string]interface{}
+}
+
+func (rows *benchmarkJSONRows) Len() int64 {
+	return int64(len(rows.rows))
+}
+
+func (rows *benchmarkJSONRows) Row(index int64) (map[string]interface{}, error) {
+	return rows.rows[index], nil
+}
+
+// MarshalJSON preserves the baseline behavior: older jsonRender versions see
+// this as a normal value and encode the complete row slice at once. The new
+// renderer recognizes the row-source interface and emits rows incrementally.
+func (rows *benchmarkJSONRows) MarshalJSON() ([]byte, error) {
+	return json.Marshal(rows.rows)
+}
+
+func generateRESTLargeTopKRows(rowCount int) []map[string]interface{} {
+	value := strings.Repeat("x", 48)
+	rows := make([]map[string]interface{}, rowCount)
+	for i := range rows {
+		rows[i] = map[string]interface{}{
+			"primary_key": int64(i),
+			"field_1":     value,
+			"field_2":     value,
+			"field_3":     value,
+			"field_4":     value,
+			"field_5":     value,
+			"distance":    float32(i%1000) / 1000,
+		}
+	}
+	return rows
+}
+
+func benchmarkRESTLargeTopK(b *testing.B, rowCount int, timeoutWrapped bool) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key, "600000")
+	b.Cleanup(func() {
+		paramtable.Get().Reset(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key)
+	})
+
+	rows := generateRESTLargeTopKRows(rowCount)
+	result := gin.H{
+		HTTPReturnCode:  int32(0),
+		HTTPReturnData:  &benchmarkJSONRows{rows: rows},
+		HTTPReturnTopks: []int64{int64(rowCount)},
+	}
+	handler := func(c *gin.Context) {
+		HTTPReturnStream(c, http.StatusOK, result)
+	}
+
+	router := gin.New()
+	if timeoutWrapped {
+		router.POST("/large", timeoutMiddleware(handler))
+	} else {
+		router.POST("/large", handler)
+	}
+	request := httptest.NewRequest(http.MethodPost, "/large", nil)
+
+	runtime.GC()
+	b.ReportAllocs()
+	b.ResetTimer()
+	var totalTTFB time.Duration
+	for i := 0; i < b.N; i++ {
+		writer := newDiscardBenchmarkWriter()
+		router.ServeHTTP(writer, request.Clone(request.Context()))
+		if writer.status != http.StatusOK {
+			b.Fatalf("unexpected status %d", writer.status)
+		}
+		if writer.bytes == 0 {
+			b.Fatal("empty response")
+		}
+		totalTTFB += writer.ttfb
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(rowCount), "rows/op")
+	b.ReportMetric(float64(totalTTFB.Nanoseconds())/float64(b.N), "first-write-ns/op")
+}
+
+func BenchmarkRESTLargeTopK(b *testing.B) {
+	gin.SetMode(gin.TestMode)
+	for _, rowCount := range []int{10, 1_000, 30_000, 300_000} {
+		name := "rows_" + strconv.Itoa(rowCount)
+		b.Run("direct/"+name, func(b *testing.B) {
+			benchmarkRESTLargeTopK(b, rowCount, false)
+		})
+		b.Run("timeout/"+name, func(b *testing.B) {
+			benchmarkRESTLargeTopK(b, rowCount, true)
+		})
+	}
+}
+
+func benchmarkRESTFewWideRows(b *testing.B, timeoutWrapped bool) {
+	// This fixture documents the remaining O(max encoded row) scratch bound.
+	// Reported B/op is cumulative allocation volume, not peak live memory; the
+	// 64 KiB stream buffer only bounds downstream write buffering.
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key, "600000")
+	b.Cleanup(func() {
+		paramtable.Get().Reset(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key)
+	})
+
+	const rowCount = 3
+	vector := make([]float32, 64*1024)
+	for index := range vector {
+		vector[index] = float32(index%1000) / 1000
+	}
+	payload := strings.Repeat("x", 1024*1024)
+	rows := make([]map[string]interface{}, rowCount)
+	for index := range rows {
+		rows[index] = map[string]interface{}{
+			"primary_key": int64(index),
+			"vector":      vector,
+			"payload":     payload,
+		}
+	}
+	result := gin.H{
+		HTTPReturnCode: int32(0),
+		HTTPReturnData: &benchmarkJSONRows{rows: rows},
+	}
+	handler := func(c *gin.Context) {
+		HTTPReturnStream(c, http.StatusOK, result)
+	}
+
+	router := gin.New()
+	if timeoutWrapped {
+		router.POST("/wide", timeoutMiddleware(handler))
+	} else {
+		router.POST("/wide", handler)
+	}
+	request := httptest.NewRequest(http.MethodPost, "/wide", nil)
+
+	runtime.GC()
+	b.ReportAllocs()
+	b.ResetTimer()
+	var responseBytes int64
+	for iteration := 0; iteration < b.N; iteration++ {
+		writer := newDiscardBenchmarkWriter()
+		router.ServeHTTP(writer, request.Clone(request.Context()))
+		if writer.status != http.StatusOK {
+			b.Fatalf("unexpected status %d", writer.status)
+		}
+		if writer.bytes == 0 {
+			b.Fatal("empty response")
+		}
+		responseBytes = writer.bytes
+	}
+	b.StopTimer()
+	b.ReportMetric(rowCount, "rows/op")
+	b.ReportMetric(float64(responseBytes), "response-bytes/op")
+}
+
+func BenchmarkRESTFewWideRows(b *testing.B) {
+	gin.SetMode(gin.TestMode)
+	b.Run("direct", func(b *testing.B) {
+		benchmarkRESTFewWideRows(b, false)
+	})
+	b.Run("timeout", func(b *testing.B) {
+		benchmarkRESTFewWideRows(b, true)
+	})
+}
+
+func generateRESTLargeTopKFieldData(rowCount int) ([]string, []*schemapb.FieldData, *schemapb.IDs, []float32, *schemapb.CollectionSchema) {
+	value := strings.Repeat("x", 48)
+	outputFields := []string{"field_1", "field_2", "field_3", "field_4", "field_5"}
+	fieldData := make([]*schemapb.FieldData, 0, len(outputFields))
+	for _, fieldName := range outputFields {
+		values := make([]string, rowCount)
+		for index := range values {
+			values[index] = value
+		}
+		fieldData = append(fieldData, &schemapb.FieldData{
+			Type:      schemapb.DataType_VarChar,
+			FieldName: fieldName,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{
+				StringData: &schemapb.StringArray{Data: values},
+			}}},
+		})
+	}
+	ids := make([]int64, rowCount)
+	scores := make([]float32, rowCount)
+	for index := range ids {
+		ids[index] = int64(index)
+		scores[index] = float32(index%1000) / 1000
+	}
+	return outputFields, fieldData, &schemapb.IDs{
+			IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: ids}},
+		}, scores, &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{{
+			Name:         "primary_key",
+			DataType:     schemapb.DataType_Int64,
+			IsPrimaryKey: true,
+		}}}
+}
+
+func benchmarkRESTLargeTopKResponsePath(b *testing.B, rowCount int) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key, "600000")
+	b.Cleanup(func() {
+		paramtable.Get().Reset(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key)
+	})
+
+	outputFields, fieldData, ids, scores, schema := generateRESTLargeTopKFieldData(rowCount)
+	handler := func(c *gin.Context) {
+		rows, err := newQueryResponseRows(0, outputFields, fieldData, ids, scores, true, schema)
+		if err != nil {
+			b.Fatal(err)
+		}
+		HTTPReturnStream(c, http.StatusOK, gin.H{
+			HTTPReturnCode:  int32(0),
+			HTTPReturnData:  rows,
+			HTTPReturnTopks: []int64{int64(rowCount)},
+		})
+	}
+
+	router := gin.New()
+	router.POST("/large", timeoutMiddleware(handler))
+	request := httptest.NewRequest(http.MethodPost, "/large", nil)
+
+	runtime.GC()
+	b.ReportAllocs()
+	b.ResetTimer()
+	var totalTTFB time.Duration
+	for iteration := 0; iteration < b.N; iteration++ {
+		writer := newDiscardBenchmarkWriter()
+		router.ServeHTTP(writer, request.Clone(request.Context()))
+		if writer.status != http.StatusOK {
+			b.Fatalf("unexpected status %d", writer.status)
+		}
+		if writer.bytes == 0 {
+			b.Fatal("empty response")
+		}
+		totalTTFB += writer.ttfb
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(rowCount), "rows/op")
+	b.ReportMetric(float64(totalTTFB.Nanoseconds())/float64(b.N), "first-write-ns/op")
+}
+
+func BenchmarkRESTLargeTopKResponsePath(b *testing.B) {
+	gin.SetMode(gin.TestMode)
+	for _, rowCount := range []int{10, 1_000, 30_000, 300_000} {
+		b.Run("rows_"+strconv.Itoa(rowCount), func(b *testing.B) {
+			benchmarkRESTLargeTopKResponsePath(b, rowCount)
+		})
+	}
+}

--- a/internal/distributed/proxy/httpserver/timeout_middleware.go
+++ b/internal/distributed/proxy/httpserver/timeout_middleware.go
@@ -27,7 +27,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/render"
 
 	mhttp "github.com/milvus-io/milvus/internal/http"
 	"github.com/milvus-io/milvus/internal/json"
@@ -41,6 +43,8 @@ type BufferPool struct {
 	pool sync.Pool
 }
 
+const maxPooledResponseBufferCapacity = 1024 * 1024
+
 // Get returns a buffer from the buffer pool.
 // If the pool is empty, a new buffer is created and returned.
 func (p *BufferPool) Get() *bytes.Buffer {
@@ -53,7 +57,15 @@ func (p *BufferPool) Get() *bytes.Buffer {
 
 // Put adds a buffer back to the pool.
 func (p *BufferPool) Put(buf *bytes.Buffer) {
+	if !isReusableResponseBuffer(buf) {
+		return
+	}
+	buf.Reset()
 	p.pool.Put(buf)
+}
+
+func isReusableResponseBuffer(buf *bytes.Buffer) bool {
+	return buf != nil && buf.Cap() <= maxPooledResponseBufferCapacity
 }
 
 // Timeout struct
@@ -71,6 +83,15 @@ type timeoutResponseRecorder struct {
 	status      int
 	size        int
 	closeNotify chan bool
+	render      render.Render
+}
+
+type timeoutResponseCommit struct {
+	body    *bytes.Buffer
+	headers http.Header
+	status  int
+	written bool
+	render  render.Render
 }
 
 func newTimeoutResponseRecorder(buf *bytes.Buffer) *timeoutResponseRecorder {
@@ -93,6 +114,9 @@ func (w *timeoutResponseRecorder) Write(data []byte) (int, error) {
 	if w.closed || w.body == nil {
 		return 0, merr.WrapErrServiceInternalMsg("response writer closed")
 	}
+	if w.render != nil {
+		return 0, merr.WrapErrServiceInternalMsg("response renderer already deferred")
+	}
 	if !w.written() {
 		w.size = 0
 	}
@@ -106,6 +130,9 @@ func (w *timeoutResponseRecorder) WriteString(s string) (int, error) {
 	defer w.mu.Unlock()
 	if w.closed || w.body == nil {
 		return 0, merr.WrapErrServiceInternalMsg("response writer closed")
+	}
+	if w.render != nil {
+		return 0, merr.WrapErrServiceInternalMsg("response renderer already deferred")
 	}
 	if !w.written() {
 		w.size = 0
@@ -170,25 +197,262 @@ func (w *timeoutResponseRecorder) Pusher() http.Pusher {
 	return nil
 }
 
-func (w *timeoutResponseRecorder) CommitTo(realWriter gin.ResponseWriter) error {
+func (w *timeoutResponseRecorder) DeferRender(responseRender render.Render) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.closed || w.body == nil {
 		return merr.WrapErrServiceInternalMsg("response writer closed")
 	}
+	if responseRender == nil {
+		return merr.WrapErrServiceInternalMsg("response renderer is nil")
+	}
+	if w.render != nil || w.body.Len() != 0 {
+		return merr.WrapErrServiceInternalMsg("response body already configured")
+	}
+	w.render = responseRender
+	if !w.written() {
+		w.size = 0
+	}
+	return nil
+}
+
+type requestDeadlineWriter struct {
+	http.ResponseWriter
+	ctx                context.Context
+	controller         *http.ResponseController
+	flushController    *http.ResponseController
+	serverWriteTimeout time.Duration
+	prepared           bool
+	writeDeadlineSet   bool
+	stopWriteInterrupt func() bool
+	writeMu            sync.Mutex
+	writeActive        bool
+}
+
+type serverWriteTimeoutContextKey struct{}
+
+func serverWriteTimeoutMiddleware(writeTimeout time.Duration) gin.HandlerFunc {
+	return func(gCtx *gin.Context) {
+		ctx := withServerWriteTimeout(gCtx.Request.Context(), writeTimeout)
+		gCtx.Request = gCtx.Request.WithContext(ctx)
+		gCtx.Next()
+	}
+}
+
+func withServerWriteTimeout(ctx context.Context, writeTimeout time.Duration) context.Context {
+	return context.WithValue(renderContext(ctx), serverWriteTimeoutContextKey{}, writeTimeout)
+}
+
+func serverWriteTimeoutFromContext(ctx context.Context) time.Duration {
+	writeTimeout, _ := renderContext(ctx).Value(serverWriteTimeoutContextKey{}).(time.Duration)
+	return writeTimeout
+}
+
+func newRequestDeadlineWriter(ctx context.Context, writer http.ResponseWriter) *requestDeadlineWriter {
+	if deadlineWriter, ok := writer.(*requestDeadlineWriter); ok {
+		return deadlineWriter
+	}
+	ctx = renderContext(ctx)
+	flushWriter := writer
+	if _, ok := writer.(gin.ResponseWriter); ok {
+		if unwrapper, ok := writer.(interface{ Unwrap() http.ResponseWriter }); ok {
+			if unwrapped := unwrapper.Unwrap(); unwrapped != nil {
+				flushWriter = unwrapped
+			}
+		}
+	}
+	return &requestDeadlineWriter{
+		ResponseWriter:     writer,
+		ctx:                ctx,
+		controller:         http.NewResponseController(writer),
+		flushController:    http.NewResponseController(flushWriter),
+		serverWriteTimeout: serverWriteTimeoutFromContext(ctx),
+	}
+}
+
+func (w *requestDeadlineWriter) prepare() error {
+	if err := w.ctx.Err(); err != nil {
+		return err
+	}
+	if w.prepared {
+		return nil
+	}
+	w.prepared = true
+	_, ok := w.ctx.Deadline()
+	if !ok {
+		return nil
+	}
+	w.stopWriteInterrupt = context.AfterFunc(w.ctx, func() {
+		w.interruptActiveWrite()
+	})
+	// net/http already owns the connection or stream deadline when the startup
+	// WriteTimeout snapshot is positive. Do not replace that deadline because it
+	// may be earlier than the request deadline. Instead, if the request deadline
+	// wins while a write is blocked, force the active write to expire immediately.
+	// Runtime config changes must not alter this ownership for an existing server.
+	if w.serverWriteTimeout > 0 {
+		return w.ctx.Err()
+	}
+	// Keep the transport deadline untouched until the first output operation has
+	// passed its final context check. This preserves the unwritten timeout fallback
+	// if the request expires during preparation. The active-write callback still
+	// interrupts a first output operation that blocks past the request deadline.
+	return w.ctx.Err()
+}
+
+func (w *requestDeadlineWriter) stopDeadlineInterrupt() {
+	if w.stopWriteInterrupt == nil {
+		return
+	}
+	w.stopWriteInterrupt()
+	w.stopWriteInterrupt = nil
+}
+
+func (w *requestDeadlineWriter) beginWrite() error {
+	w.writeMu.Lock()
+	defer w.writeMu.Unlock()
+	if err := w.ctx.Err(); err != nil {
+		return err
+	}
+	w.writeActive = true
+	return nil
+}
+
+func (w *requestDeadlineWriter) endWrite() error {
+	w.writeMu.Lock()
+	defer w.writeMu.Unlock()
+	w.writeActive = false
+	if w.serverWriteTimeout > 0 || w.writeDeadlineSet {
+		return nil
+	}
+	deadline, ok := w.ctx.Deadline()
+	if !ok {
+		return nil
+	}
+	w.writeDeadlineSet = true
+	w.stopDeadlineInterrupt()
+	// Leave the request deadline in place until net/http finishes the response.
+	// The server performs its final buffered flush after the handler returns and
+	// then clears the HTTP/1 connection deadline or closes the HTTP/2 stream.
+	if err := w.controller.SetWriteDeadline(deadline); err != nil && !errors.Is(err, http.ErrNotSupported) {
+		return err
+	}
+	return nil
+}
+
+func (w *requestDeadlineWriter) interruptActiveWrite() {
+	w.writeMu.Lock()
+	defer w.writeMu.Unlock()
+	if errors.Is(w.ctx.Err(), context.DeadlineExceeded) && w.writeActive {
+		_ = w.controller.SetWriteDeadline(time.Now())
+	}
+}
+
+func (w *requestDeadlineWriter) runOutput(operation func() error) (err error) {
+	if err := w.prepare(); err != nil {
+		return err
+	}
+	if err := w.beginWrite(); err != nil {
+		return err
+	}
+	defer func() {
+		deadlineErr := w.endWrite()
+		if ctxErr := w.ctx.Err(); ctxErr != nil {
+			err = ctxErr
+		} else if err == nil {
+			err = deadlineErr
+		}
+	}()
+	return operation()
+}
+
+func (w *requestDeadlineWriter) Write(data []byte) (int, error) {
+	var n int
+	err := w.runOutput(func() error {
+		var err error
+		n, err = w.ResponseWriter.Write(data)
+		return err
+	})
+	return n, err
+}
+
+func (w *requestDeadlineWriter) FlushError() error {
+	flushUnsupported := false
+	err := w.runOutput(func() error {
+		if writer, ok := w.ResponseWriter.(interface{ WriteHeaderNow() }); ok {
+			writer.WriteHeaderNow()
+		}
+		err := w.flushController.Flush()
+		flushUnsupported = errors.Is(err, http.ErrNotSupported)
+		return err
+	})
+	if flushUnsupported {
+		return nil
+	}
+	return err
+}
+
+func (w *requestDeadlineWriter) writeHeaderNow() error {
+	return w.runOutput(func() error {
+		if writer, ok := w.ResponseWriter.(interface{ WriteHeaderNow() }); ok {
+			writer.WriteHeaderNow()
+		}
+		return nil
+	})
+}
+
+func (w *requestDeadlineWriter) Flush() {
+	_ = w.FlushError()
+}
+
+func (w *requestDeadlineWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+func (w *timeoutResponseRecorder) CommitTo(ctx context.Context, realWriter gin.ResponseWriter) error {
+	ctx = renderContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	w.mu.Lock()
+	if w.closed || w.body == nil {
+		w.mu.Unlock()
+		return merr.WrapErrServiceInternalMsg("response writer closed")
+	}
+	commit := timeoutResponseCommit{
+		body:    w.body,
+		headers: w.headers.Clone(),
+		status:  w.status,
+		written: w.written(),
+		render:  w.render,
+	}
+	// Detach recorder-owned state before any network I/O. Late handler writes
+	// must fail immediately instead of blocking behind a slow client, and the
+	// middleware remains the sole owner of the real response writer.
+	w.body = nil
+	w.render = nil
+	w.closed = true
+	w.mu.Unlock()
 
 	dst := realWriter.Header()
-	for k, vv := range w.headers {
+	for k, vv := range commit.headers {
 		dst[k] = append([]string(nil), vv...)
 	}
-	realWriter.WriteHeader(w.status)
-	if w.body.Len() == 0 {
-		if w.written() || w.status != http.StatusOK {
-			realWriter.WriteHeaderNow()
+	realWriter.WriteHeader(commit.status)
+	deadlineWriter := newRequestDeadlineWriter(ctx, realWriter)
+	defer deadlineWriter.stopDeadlineInterrupt()
+	if commit.render != nil {
+		return commit.render.Render(deadlineWriter)
+	}
+	if commit.body.Len() == 0 {
+		if commit.written || commit.status != http.StatusOK {
+			if err := deadlineWriter.writeHeaderNow(); err != nil {
+				return err
+			}
 		}
 		return nil
 	}
-	_, err := realWriter.Write(w.body.Bytes())
+	_, err := deadlineWriter.Write(commit.body.Bytes())
 	return err
 }
 
@@ -199,6 +463,7 @@ func (w *timeoutResponseRecorder) Close() {
 		w.body.Reset()
 		w.body = nil
 	}
+	w.render = nil
 	w.closed = true
 }
 
@@ -230,6 +495,20 @@ func propagateTimeoutContextKeys(dst *gin.Context, src *gin.Context) {
 			dst.Set(key, value)
 		}
 	}
+}
+
+func writeRequestTimeout(gCtx *gin.Context, realWriter gin.ResponseWriter) {
+	gCtx.Abort()
+	gCtx.Set(HTTPReturnCode, merr.TimeoutCode)
+	gCtx.Set(HTTPReturnMessage, "request timeout")
+
+	realWriter.Header().Set("Content-Type", "application/json; charset=utf-8")
+	if traceID, ok := getTraceID(gCtx); ok {
+		setTraceIDHeaderTo(realWriter.Header(), traceID)
+	}
+	realWriter.WriteHeader(http.StatusRequestTimeout)
+	body, _ := json.Marshal(gin.H{HTTPReturnCode: merr.TimeoutCode, HTTPReturnMessage: "request timeout"})
+	realWriter.Write(body)
 }
 
 func timeoutMiddleware(handler gin.HandlerFunc) gin.HandlerFunc {
@@ -297,30 +576,25 @@ func timeoutMiddleware(handler gin.HandlerFunc) gin.HandlerFunc {
 				gCtx.Abort()
 			}
 			gCtx.Next()
-			if err := recorder.CommitTo(realWriter); err != nil {
-				mlog.Warn(context.TODO(), "failed to write response body", mlog.Err(err))
-				recorder.Close()
-				bufPool.Put(buffer)
+			commitErr := func() error {
+				defer bufPool.Put(buffer)
+				defer recorder.Close()
+				return recorder.CommitTo(topCtx, realWriter)
+			}()
+			if commitErr != nil {
+				if errors.Is(commitErr, context.DeadlineExceeded) && !realWriter.Written() {
+					writeRequestTimeout(gCtx, realWriter)
+					return
+				}
+				mlog.Warn(gCtx.Request.Context(), "failed to write response body", mlog.Err(commitErr))
 				return
 			}
-			recorder.Close()
-			bufPool.Put(buffer)
 
 		case <-timer.C:
 			cancel()
-			gCtx.Abort()
-			gCtx.Set(HTTPReturnCode, merr.TimeoutCode)
-			gCtx.Set(HTTPReturnMessage, "request timeout")
 			recorder.CloseForTimeout()
 			bufPool.Put(buffer)
-
-			realWriter.Header().Set("Content-Type", "application/json; charset=utf-8")
-			if traceID, ok := getTraceID(gCtx); ok {
-				setTraceIDHeaderTo(realWriter.Header(), traceID)
-			}
-			realWriter.WriteHeader(http.StatusRequestTimeout)
-			body, _ := json.Marshal(gin.H{HTTPReturnCode: merr.TimeoutCode, HTTPReturnMessage: "request timeout"})
-			realWriter.Write(body)
+			writeRequestTimeout(gCtx, realWriter)
 		}
 	}
 }

--- a/internal/distributed/proxy/httpserver/timeout_middleware_stream_test.go
+++ b/internal/distributed/proxy/httpserver/timeout_middleware_stream_test.go
@@ -1,0 +1,990 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/internal/json"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+func TestTimeoutResponseRecorderDefersStreamRender(t *testing.T) {
+	buffer := &bytes.Buffer{}
+	recorder := newTimeoutResponseRecorder(buffer)
+	recorder.WriteHeader(http.StatusAccepted)
+
+	rows := make([]map[string]interface{}, 3)
+	for index := range rows {
+		rows[index] = map[string]interface{}{"id": float64(index + 1)}
+	}
+	responseRender := jsonRender{Data: gin.H{
+		HTTPReturnCode: 0,
+		HTTPReturnData: &testJSONRows{rows: rows},
+	}}
+	require.NoError(t, responseRender.Render(recorder))
+	assert.Zero(t, buffer.Len())
+	assert.NotNil(t, recorder.render)
+
+	_, err := recorder.Write([]byte("late body"))
+	require.Error(t, err)
+
+	realResponse := httptest.NewRecorder()
+	realCtx, _ := gin.CreateTestContext(realResponse)
+	require.NoError(t, recorder.CommitTo(context.Background(), realCtx.Writer))
+	assert.Equal(t, http.StatusAccepted, realResponse.Code)
+
+	var response struct {
+		Code int                      `json:"code"`
+		Data []map[string]interface{} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(realResponse.Body.Bytes(), &response))
+	assert.Zero(t, response.Code)
+	assert.Equal(t, rows, response.Data)
+}
+
+func TestBufferPoolDropsOversizedBuffers(t *testing.T) {
+	pool := &BufferPool{}
+	large := bytes.NewBuffer(make([]byte, maxPooledResponseBufferCapacity+1))
+	assert.False(t, isReusableResponseBuffer(large))
+	pool.Put(large)
+
+	small := bytes.NewBuffer(make([]byte, 128))
+	assert.True(t, isReusableResponseBuffer(small))
+	pool.Put(small)
+	assert.Zero(t, small.Len())
+	assert.False(t, isReusableResponseBuffer(nil))
+}
+
+type blockingTestRender struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+type contextBoundJSONValue struct {
+	ctx         context.Context
+	started     chan struct{}
+	stopped     chan struct{}
+	startedOnce sync.Once
+	stoppedOnce sync.Once
+}
+
+func (value *contextBoundJSONValue) MarshalJSON() ([]byte, error) {
+	// Sonic deliberately marshals values again with encoding/json under the
+	// race build, so test notifications must tolerate repeated calls.
+	value.startedOnce.Do(func() { close(value.started) })
+	for value.ctx.Err() == nil {
+		runtime.Gosched()
+	}
+	value.stoppedOnce.Do(func() { close(value.stopped) })
+	return nil, value.ctx.Err()
+}
+
+func (r *blockingTestRender) Render(w http.ResponseWriter) error {
+	close(r.started)
+	<-r.release
+	_, err := w.Write([]byte("rendered"))
+	return err
+}
+
+func (r *blockingTestRender) WriteContentType(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/plain")
+}
+
+func TestTimeoutResponseRecorderDoesNotHoldLockDuringRender(t *testing.T) {
+	recorder := newTimeoutResponseRecorder(&bytes.Buffer{})
+	responseRender := &blockingTestRender{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	require.NoError(t, recorder.DeferRender(responseRender))
+
+	realResponse := httptest.NewRecorder()
+	realCtx, _ := gin.CreateTestContext(realResponse)
+	commitDone := make(chan error, 1)
+	go func() {
+		commitDone <- recorder.CommitTo(context.Background(), realCtx.Writer)
+	}()
+	<-responseRender.started
+
+	lateWriteDone := make(chan error, 1)
+	go func() {
+		_, err := recorder.Write([]byte("late"))
+		lateWriteDone <- err
+	}()
+	select {
+	case err := <-lateWriteDone:
+		require.Error(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("late recorder write blocked behind streaming render")
+	}
+
+	close(responseRender.release)
+	require.NoError(t, <-commitDone)
+	assert.Equal(t, "rendered", realResponse.Body.String())
+}
+
+func TestTimeoutMiddlewareUsesContentLengthForSmallStreamResponse(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key, "1000")
+	t.Cleanup(func() {
+		paramtable.Get().Reset(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key)
+	})
+
+	router := gin.New()
+	router.GET("/small-stream", timeoutMiddleware(func(c *gin.Context) {
+		if err := HTTPReturnStream(c, http.StatusOK, gin.H{
+			HTTPReturnCode: 0,
+			HTTPReturnData: &testJSONRows{rows: []map[string]interface{}{{"id": 1}, {"id": 2}}},
+		}); err != nil {
+			panic(err)
+		}
+	}))
+
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+	response, err := server.Client().Get(server.URL + "/small-stream")
+	require.NoError(t, err)
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, 1, response.ProtoMajor)
+	assert.Equal(t, int64(len(body)), response.ContentLength)
+	assert.Empty(t, response.TransferEncoding)
+}
+
+func TestTimeoutMiddlewareReturnsTimeoutWhenSmallStreamExpiresBeforeCommit(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key, "10")
+	t.Cleanup(func() {
+		paramtable.Get().Reset(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key)
+	})
+
+	started := make(chan struct{})
+	stopped := make(chan struct{})
+	router := gin.New()
+	router.POST("/deadline-before-write", timeoutMiddleware(func(c *gin.Context) {
+		if err := HTTPReturnStream(c, http.StatusOK, gin.H{
+			HTTPReturnCode: 0,
+			HTTPReturnData: &testJSONRows{rows: []map[string]interface{}{
+				{
+					"value": &contextBoundJSONValue{
+						ctx:     c.Request.Context(),
+						started: started,
+						stopped: stopped,
+					},
+				},
+				{"value": "second"},
+			}},
+		}); err != nil {
+			panic(err)
+		}
+	}))
+
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/deadline-before-write", nil)
+	router.ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusRequestTimeout, response.Code)
+	var body ReturnErrMsg
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body))
+	assert.Equal(t, merr.TimeoutCode, body.Code)
+	assert.Equal(t, "request timeout", body.Message)
+	assert.NotContains(t, response.Body.String(), `"data"`)
+	select {
+	case <-started:
+	default:
+		t.Fatal("stream row encoding did not start")
+	}
+	select {
+	case <-stopped:
+	default:
+		t.Fatal("stream row encoding did not observe request cancellation")
+	}
+}
+
+func TestTimeoutMiddlewareStopsGenericEncodingBeforeFirstWrite(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key, "10")
+	t.Cleanup(func() {
+		paramtable.Get().Reset(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key)
+	})
+
+	started := make(chan struct{})
+	stopped := make(chan struct{})
+	handlerDone := make(chan struct{})
+	router := gin.New()
+	router.POST("/cpu-before-write", timeoutMiddleware(func(c *gin.Context) {
+		defer close(handlerDone)
+		_ = HTTPReturnStream(c, http.StatusOK, gin.H{
+			HTTPReturnCode: 0,
+			HTTPReturnData: &contextBoundJSONValue{
+				ctx:     c.Request.Context(),
+				started: started,
+				stopped: stopped,
+			},
+		})
+	}))
+
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/cpu-before-write", nil)
+	router.ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusRequestTimeout, response.Code)
+	select {
+	case <-started:
+	default:
+		t.Fatal("generic encoder did not start")
+	}
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("generic encoder did not observe request cancellation")
+	}
+	select {
+	case <-handlerDone:
+	case <-time.After(time.Second):
+		t.Fatal("handler goroutine did not exit after timeout")
+	}
+}
+
+type deadlineTrackingWriter struct {
+	header    http.Header
+	body      bytes.Buffer
+	deadlines []time.Time
+}
+
+type deadlineEnforcingWriter struct {
+	*httptest.ResponseRecorder
+	deadlineArmed   bool
+	deadlineExpired <-chan struct{}
+}
+
+type blockingDeadlineWriter struct {
+	header           http.Header
+	operationStarted chan struct{}
+	deadlineSet      chan time.Time
+	releaseOperation chan struct{}
+	releaseOnce      sync.Once
+}
+
+type manualDeadlineContext struct {
+	context.Context
+	deadline time.Time
+	done     chan struct{}
+	errMu    sync.RWMutex
+	err      error
+	once     sync.Once
+}
+
+type prepareBlockingDeadlineContext struct {
+	context.Context
+	deadline          time.Time
+	done              chan struct{}
+	secondErrEntered  chan struct{}
+	releaseSecondErr  chan struct{}
+	callbackErrCalled chan struct{}
+	errMu             sync.Mutex
+	err               error
+	errCalls          int
+	expireOnce        sync.Once
+	secondErrOnce     sync.Once
+	callbackErrOnce   sync.Once
+	releaseOnce       sync.Once
+}
+
+type afterFuncTrackingContext struct {
+	context.Context
+	done    chan struct{}
+	started int
+	stopped int
+}
+
+type firstWriteSignalWriter struct {
+	*httptest.ResponseRecorder
+	firstWrite chan struct{}
+	once       sync.Once
+}
+
+func (w *firstWriteSignalWriter) Write(data []byte) (int, error) {
+	w.once.Do(func() {
+		close(w.firstWrite)
+	})
+	return w.ResponseRecorder.Write(data)
+}
+
+type requestTimeoutJSONRows struct {
+	ctx         context.Context
+	requestDone <-chan struct{}
+	rowCalls    int
+}
+
+func (rows *requestTimeoutJSONRows) Len() int64 {
+	return 2
+}
+
+func (rows *requestTimeoutJSONRows) Row(index int64) (map[string]interface{}, error) {
+	rows.rowCalls++
+	if index == 0 {
+		return map[string]interface{}{"value": string(bytes.Repeat([]byte{'x'}, streamingJSONBufferSize*2))}, nil
+	}
+	<-rows.requestDone
+	if err := rows.ctx.Err(); err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{"value": "after request timeout"}, nil
+}
+
+func TestTimeoutResponseRecorderKeepsRequestTimeoutAfterCommit(t *testing.T) {
+	requestContext := newManualDeadlineContext()
+	rows := &requestTimeoutJSONRows{
+		ctx:         requestContext,
+		requestDone: requestContext.Done(),
+	}
+	recorder := newTimeoutResponseRecorder(&bytes.Buffer{})
+	require.NoError(t, (jsonRender{Context: requestContext, Data: gin.H{
+		HTTPReturnCode: 0,
+		HTTPReturnData: rows,
+	}}).Render(recorder))
+
+	responseWriter := &firstWriteSignalWriter{
+		ResponseRecorder: httptest.NewRecorder(),
+		firstWrite:       make(chan struct{}),
+	}
+	gCtx, _ := gin.CreateTestContext(responseWriter)
+	commitDone := make(chan error, 1)
+	go func() {
+		commitDone <- recorder.CommitTo(requestContext, gCtx.Writer)
+	}()
+
+	select {
+	case <-responseWriter.firstWrite:
+	case <-time.After(time.Second):
+		t.Fatal("response was not committed")
+	}
+	requestContext.expire()
+	require.ErrorIs(t, <-commitDone, context.DeadlineExceeded)
+	assert.Equal(t, http.StatusOK, responseWriter.Code)
+	assert.GreaterOrEqual(t, rows.rowCalls, 1)
+	assert.Contains(t, responseWriter.Body.String(), `"data":[`)
+	var body map[string]interface{}
+	require.Error(t, json.Unmarshal(responseWriter.Body.Bytes(), &body))
+}
+
+func (w *deadlineTrackingWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *deadlineTrackingWriter) WriteHeader(int) {}
+
+func (w *deadlineTrackingWriter) Write(data []byte) (int, error) {
+	return w.body.Write(data)
+}
+
+func (w *deadlineTrackingWriter) SetWriteDeadline(deadline time.Time) error {
+	w.deadlines = append(w.deadlines, deadline)
+	return nil
+}
+
+func (w *deadlineEnforcingWriter) Write(data []byte) (int, error) {
+	if w.deadlineArmed {
+		select {
+		case <-w.deadlineExpired:
+			return 0, context.DeadlineExceeded
+		default:
+		}
+	}
+	return w.ResponseRecorder.Write(data)
+}
+
+func (w *deadlineEnforcingWriter) SetWriteDeadline(time.Time) error {
+	w.deadlineArmed = true
+	return nil
+}
+
+func (w *blockingDeadlineWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *blockingDeadlineWriter) WriteHeader(int) {}
+
+func (w *blockingDeadlineWriter) Write(data []byte) (int, error) {
+	w.waitForRelease()
+	return len(data), nil
+}
+
+func (w *blockingDeadlineWriter) FlushError() error {
+	w.waitForRelease()
+	return nil
+}
+
+func (w *blockingDeadlineWriter) waitForRelease() {
+	close(w.operationStarted)
+	<-w.releaseOperation
+}
+
+func (w *blockingDeadlineWriter) SetWriteDeadline(deadline time.Time) error {
+	w.deadlineSet <- deadline
+	w.releaseOnce.Do(func() { close(w.releaseOperation) })
+	return nil
+}
+
+func newManualDeadlineContext() *manualDeadlineContext {
+	return &manualDeadlineContext{
+		Context:  context.Background(),
+		deadline: time.Now().Add(time.Hour),
+		done:     make(chan struct{}),
+	}
+}
+
+func (ctx *manualDeadlineContext) Deadline() (time.Time, bool) {
+	return ctx.deadline, true
+}
+
+func (ctx *manualDeadlineContext) Done() <-chan struct{} {
+	return ctx.done
+}
+
+func (ctx *manualDeadlineContext) Err() error {
+	ctx.errMu.RLock()
+	defer ctx.errMu.RUnlock()
+	return ctx.err
+}
+
+func (ctx *manualDeadlineContext) expire() {
+	ctx.once.Do(func() {
+		ctx.errMu.Lock()
+		ctx.err = context.DeadlineExceeded
+		ctx.errMu.Unlock()
+		close(ctx.done)
+	})
+}
+
+func newPrepareBlockingDeadlineContext() *prepareBlockingDeadlineContext {
+	return &prepareBlockingDeadlineContext{
+		Context:           context.Background(),
+		deadline:          time.Now().Add(time.Hour),
+		done:              make(chan struct{}),
+		secondErrEntered:  make(chan struct{}),
+		releaseSecondErr:  make(chan struct{}),
+		callbackErrCalled: make(chan struct{}),
+	}
+}
+
+func (ctx *prepareBlockingDeadlineContext) Deadline() (time.Time, bool) {
+	return ctx.deadline, true
+}
+
+func (ctx *prepareBlockingDeadlineContext) Done() <-chan struct{} {
+	return ctx.done
+}
+
+func (ctx *prepareBlockingDeadlineContext) Err() error {
+	ctx.errMu.Lock()
+	ctx.errCalls++
+	call := ctx.errCalls
+	err := ctx.err
+	ctx.errMu.Unlock()
+
+	if call == 2 {
+		ctx.secondErrOnce.Do(func() { close(ctx.secondErrEntered) })
+		<-ctx.releaseSecondErr
+		ctx.errMu.Lock()
+		err = ctx.err
+		ctx.errMu.Unlock()
+		return err
+	}
+	// The first two Err calls after Done closes propagate cancellation and its
+	// cause into the context.AfterFunc child. The following call comes from the
+	// registered interruptActiveWrite callback itself.
+	if call > 4 {
+		ctx.callbackErrOnce.Do(func() { close(ctx.callbackErrCalled) })
+	}
+	return err
+}
+
+func (ctx *prepareBlockingDeadlineContext) expire() {
+	ctx.expireOnce.Do(func() {
+		ctx.errMu.Lock()
+		ctx.err = context.DeadlineExceeded
+		ctx.errMu.Unlock()
+		close(ctx.done)
+	})
+}
+
+func (ctx *prepareBlockingDeadlineContext) releasePrepare() {
+	ctx.releaseOnce.Do(func() { close(ctx.releaseSecondErr) })
+}
+
+func newAfterFuncTrackingContext() *afterFuncTrackingContext {
+	return &afterFuncTrackingContext{
+		Context: context.Background(),
+		done:    make(chan struct{}),
+	}
+}
+
+func (ctx *afterFuncTrackingContext) Deadline() (time.Time, bool) {
+	return time.Now().Add(time.Hour), true
+}
+
+func (ctx *afterFuncTrackingContext) Done() <-chan struct{} {
+	return ctx.done
+}
+
+func (ctx *afterFuncTrackingContext) Value(key any) any {
+	if _, ok := key.(serverWriteTimeoutContextKey); ok {
+		return time.Minute
+	}
+	return ctx.Context.Value(key)
+}
+
+func (ctx *afterFuncTrackingContext) AfterFunc(func()) func() bool {
+	ctx.started++
+	active := true
+	return func() bool {
+		if !active {
+			return false
+		}
+		active = false
+		ctx.stopped++
+		return true
+	}
+}
+
+func TestRequestDeadlineWriterPreservesServerWriteTimeout(t *testing.T) {
+	paramtable.Init()
+
+	t.Run("request deadline is not cleared before net/http response finalization", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		writer := &deadlineTrackingWriter{header: make(http.Header)}
+		deadlineWriter := newRequestDeadlineWriter(ctx, writer)
+		_, err := deadlineWriter.Write([]byte("ok"))
+		require.NoError(t, err)
+
+		require.Len(t, writer.deadlines, 1)
+		assert.False(t, writer.deadlines[0].IsZero())
+	})
+
+	t.Run("configured server timeout is not overwritten", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(withServerWriteTimeout(context.Background(), 5*time.Second), time.Hour)
+		defer cancel()
+		writer := &deadlineTrackingWriter{header: make(http.Header)}
+		deadlineWriter := newRequestDeadlineWriter(ctx, writer)
+		_, err := deadlineWriter.Write([]byte("ok"))
+		require.NoError(t, err)
+
+		assert.Empty(t, writer.deadlines)
+	})
+
+	t.Run("startup snapshot ignores runtime config changes", func(t *testing.T) {
+		tests := []struct {
+			name            string
+			startupTimeout  time.Duration
+			runtimeTimeout  string
+			expectedUpdates int
+		}{
+			{
+				name:            "server timeout remains enabled",
+				startupTimeout:  5 * time.Second,
+				runtimeTimeout:  "0s",
+				expectedUpdates: 0,
+			},
+			{
+				name:            "server timeout remains disabled",
+				startupTimeout:  0,
+				runtimeTimeout:  "5s",
+				expectedUpdates: 1,
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				params := paramtable.Get()
+				require.NoError(t, params.Save(params.HTTPCfg.WriteTimeout.Key, test.runtimeTimeout))
+				t.Cleanup(func() {
+					params.Reset(params.HTTPCfg.WriteTimeout.Key)
+				})
+
+				var writeErr error
+				writer := &deadlineTrackingWriter{header: make(http.Header)}
+				router := gin.New()
+				router.Use(serverWriteTimeoutMiddleware(test.startupTimeout))
+				router.GET("/write", func(gCtx *gin.Context) {
+					ctx, cancel := context.WithTimeout(gCtx.Request.Context(), time.Hour)
+					defer cancel()
+					deadlineWriter := newRequestDeadlineWriter(ctx, writer)
+					_, writeErr = deadlineWriter.Write([]byte("ok"))
+					gCtx.Status(http.StatusNoContent)
+				})
+				router.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/write", nil))
+
+				require.NoError(t, writeErr)
+				assert.Len(t, writer.deadlines, test.expectedUpdates)
+			})
+		}
+	})
+
+	t.Run("shorter request timeout interrupts active output", func(t *testing.T) {
+		tests := []struct {
+			name string
+			run  func(*requestDeadlineWriter) error
+		}{
+			{
+				name: "write",
+				run: func(writer *requestDeadlineWriter) error {
+					_, err := writer.Write([]byte("blocked"))
+					return err
+				},
+			},
+			{
+				name: "flush",
+				run: func(writer *requestDeadlineWriter) error {
+					return writer.FlushError()
+				},
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				requestCtx := newManualDeadlineContext()
+				writer := &blockingDeadlineWriter{
+					header:           make(http.Header),
+					operationStarted: make(chan struct{}),
+					deadlineSet:      make(chan time.Time, 1),
+					releaseOperation: make(chan struct{}),
+				}
+				t.Cleanup(func() {
+					writer.releaseOnce.Do(func() { close(writer.releaseOperation) })
+				})
+				deadlineWriter := newRequestDeadlineWriter(withServerWriteTimeout(requestCtx, 2*time.Minute), writer)
+				operationDone := make(chan error, 1)
+				go func() {
+					operationDone <- test.run(deadlineWriter)
+				}()
+
+				select {
+				case <-writer.operationStarted:
+				case <-time.After(time.Second):
+					t.Fatal("output operation did not start")
+				}
+				requestCtx.expire()
+
+				select {
+				case deadline := <-writer.deadlineSet:
+					assert.WithinDuration(t, time.Now(), deadline, 100*time.Millisecond)
+				case <-time.After(time.Second):
+					t.Fatal("request deadline did not interrupt active output")
+				}
+
+				select {
+				case err := <-operationDone:
+					require.ErrorIs(t, err, context.DeadlineExceeded)
+				case <-time.After(time.Second):
+					t.Fatal("output remained blocked after the request deadline")
+				}
+			})
+		}
+	})
+
+	t.Run("deadline during prepare does not interrupt inactive output", func(t *testing.T) {
+		requestCtx := newPrepareBlockingDeadlineContext()
+		t.Cleanup(requestCtx.releasePrepare)
+		writer := &deadlineTrackingWriter{header: make(http.Header)}
+		deadlineWriter := newRequestDeadlineWriter(withServerWriteTimeout(requestCtx, 2*time.Minute), writer)
+		operationDone := make(chan error, 1)
+		go func() {
+			_, err := deadlineWriter.Write([]byte("late"))
+			operationDone <- err
+		}()
+
+		select {
+		case <-requestCtx.secondErrEntered:
+		case <-time.After(time.Second):
+			t.Fatal("prepare did not reach its final context check")
+		}
+		deadlineWriter.writeMu.Lock()
+		assert.False(t, deadlineWriter.writeActive)
+		deadlineWriter.writeMu.Unlock()
+
+		requestCtx.expire()
+		select {
+		case <-requestCtx.callbackErrCalled:
+		case <-time.After(time.Second):
+			t.Fatal("deadline callback did not run")
+		}
+		// Synchronize with interruptActiveWrite after its context check.
+		deadlineWriter.writeMu.Lock()
+		assert.False(t, deadlineWriter.writeActive)
+		deadlineWriter.writeMu.Unlock()
+		assert.Empty(t, writer.deadlines)
+		assert.Zero(t, writer.body.Len())
+
+		requestCtx.releasePrepare()
+		select {
+		case err := <-operationDone:
+			require.ErrorIs(t, err, context.DeadlineExceeded)
+		case <-time.After(time.Second):
+			t.Fatal("write did not stop after prepare observed the deadline")
+		}
+	})
+}
+
+func TestRequestDeadlineWriterKeepsTimeoutFallbackWritableBeforeFirstOutput(t *testing.T) {
+	requestCtx := newPrepareBlockingDeadlineContext()
+	t.Cleanup(requestCtx.releasePrepare)
+	writer := &deadlineEnforcingWriter{
+		ResponseRecorder: httptest.NewRecorder(),
+		deadlineExpired:  requestCtx.Done(),
+	}
+	gCtx, _ := gin.CreateTestContext(writer)
+	deadlineWriter := newRequestDeadlineWriter(requestCtx, gCtx.Writer)
+
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := deadlineWriter.Write([]byte("late response"))
+		writeDone <- err
+	}()
+
+	select {
+	case <-requestCtx.secondErrEntered:
+	case <-time.After(time.Second):
+		t.Fatal("write did not reach its final context check")
+	}
+	requestCtx.expire()
+	requestCtx.releasePrepare()
+
+	select {
+	case err := <-writeDone:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(time.Second):
+		t.Fatal("write did not stop after the request deadline")
+	}
+	require.False(t, gCtx.Writer.Written())
+
+	writeRequestTimeout(gCtx, gCtx.Writer)
+
+	assert.Equal(t, http.StatusRequestTimeout, writer.Code)
+	var body ReturnErrMsg
+	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), &body))
+	assert.Equal(t, merr.TimeoutCode, body.Code)
+	assert.Equal(t, "request timeout", body.Message)
+}
+
+func TestRequestDeadlineWriterStopsCallbackAfterOutputOwnershipEnds(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*testing.T, context.Context)
+	}{
+		{
+			name: "generic render",
+			run: func(t *testing.T, ctx context.Context) {
+				render := jsonRender{Context: ctx, Data: gin.H{HTTPReturnCode: 0}}
+				require.NoError(t, render.Render(httptest.NewRecorder()))
+			},
+		},
+		{
+			name: "direct streaming render",
+			run: func(t *testing.T, ctx context.Context) {
+				render := jsonRender{Context: ctx, Data: gin.H{
+					HTTPReturnCode: 0,
+					HTTPReturnData: &testJSONRows{rows: []map[string]interface{}{{"id": 1}}},
+				}}
+				require.NoError(t, render.Render(httptest.NewRecorder()))
+			},
+		},
+		{
+			name: "materialized commit",
+			run: func(t *testing.T, ctx context.Context) {
+				recorder := newTimeoutResponseRecorder(&bytes.Buffer{})
+				_, err := recorder.Write([]byte(`{"code":0}`))
+				require.NoError(t, err)
+				response := httptest.NewRecorder()
+				gCtx, _ := gin.CreateTestContext(response)
+				require.NoError(t, recorder.CommitTo(ctx, gCtx.Writer))
+			},
+		},
+		{
+			name: "deferred streaming commit",
+			run: func(t *testing.T, ctx context.Context) {
+				recorder := newTimeoutResponseRecorder(&bytes.Buffer{})
+				render := jsonRender{Context: ctx, Data: gin.H{
+					HTTPReturnCode: 0,
+					HTTPReturnData: &testJSONRows{rows: []map[string]interface{}{{"id": 1}}},
+				}}
+				require.NoError(t, render.Render(recorder))
+				response := httptest.NewRecorder()
+				gCtx, _ := gin.CreateTestContext(response)
+				require.NoError(t, recorder.CommitTo(ctx, gCtx.Writer))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := newAfterFuncTrackingContext()
+			test.run(t, ctx)
+			assert.Equal(t, 1, ctx.started)
+			assert.Equal(t, 1, ctx.stopped)
+		})
+	}
+}
+
+func TestTimeoutResponseRecorderRenderRegistrationRace(t *testing.T) {
+	for iteration := 0; iteration < 500; iteration++ {
+		recorder := newTimeoutResponseRecorder(&bytes.Buffer{})
+		responseRender := &blockingTestRender{
+			started: make(chan struct{}),
+			release: make(chan struct{}),
+		}
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = recorder.DeferRender(responseRender)
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			recorder.CloseForTimeout()
+		}()
+		close(start)
+		wg.Wait()
+
+		assert.True(t, recorder.closed)
+		assert.Nil(t, recorder.body)
+		assert.Nil(t, recorder.render)
+		_, err := recorder.Write([]byte("late"))
+		require.Error(t, err)
+	}
+}
+
+func TestTimeoutMiddlewareDiscardsLateStreamRenderer(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key, "5")
+	t.Cleanup(func() {
+		paramtable.Get().Reset(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key)
+	})
+
+	rowSource := &testJSONRows{rows: []map[string]interface{}{{"id": 1}}}
+	lateHandlerDone := make(chan struct{}, 1)
+	router := gin.New()
+	router.POST("/late-stream", timeoutMiddleware(func(c *gin.Context) {
+		<-c.Request.Context().Done()
+		HTTPReturnStream(c, http.StatusOK, gin.H{
+			HTTPReturnCode: 0,
+			HTTPReturnData: rowSource,
+		})
+		lateHandlerDone <- struct{}{}
+	}))
+
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/late-stream", nil)
+	router.ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusRequestTimeout, response.Code)
+	var timeoutBody ReturnErrMsg
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &timeoutBody))
+	assert.Equal(t, merr.TimeoutCode, timeoutBody.Code)
+	assert.Equal(t, "request timeout", timeoutBody.Message)
+	select {
+	case <-lateHandlerDone:
+	case <-time.After(time.Second):
+		t.Fatal("late handler did not finish")
+	}
+	assert.Zero(t, rowSource.rowCalls)
+	assert.NotContains(t, response.Body.String(), "\"id\"")
+}
+
+func TestTimeoutStreamPreservesStatusHeadersAndWriterSize(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key, "1000")
+	t.Cleanup(func() {
+		paramtable.Get().Reset(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key)
+	})
+
+	const traceID = "0123456789abcdef0123456789abcdef"
+	rowSource := &testJSONRows{rows: []map[string]interface{}{{"id": 1}, {"id": 2}}}
+	observedSize := -1
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Next()
+		observedSize = c.Writer.Size()
+	})
+	router.POST("/stream", restfulSizeMiddleware(timeoutMiddleware(func(c *gin.Context) {
+		c.Set("traceID", traceID)
+		c.Header("X-Test", "stream")
+		HTTPReturnStream(c, http.StatusAccepted, gin.H{
+			HTTPReturnCode: 0,
+			HTTPReturnData: rowSource,
+			HTTPReturnTopks: []int64{
+				2,
+			},
+		})
+	}), true))
+
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/stream", nil)
+	router.ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusAccepted, response.Code)
+	assert.Equal(t, "stream", response.Header().Get("X-Test"))
+	assert.Equal(t, traceID, response.Header().Get(HTTPHeaderMilvusTraceID))
+	assert.Equal(t, response.Body.Len(), observedSize)
+	assert.Equal(t, len(rowSource.rows), rowSource.rowCalls)
+	var body struct {
+		Code  int                      `json:"code"`
+		Data  []map[string]interface{} `json:"data"`
+		Topks []int64                  `json:"topks"`
+	}
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body))
+	assert.Zero(t, body.Code)
+	assert.Len(t, body.Data, 2)
+	assert.Equal(t, []int64{2}, body.Topks)
+}
+
+func TestTimeoutMiddlewarePreservesPanicPath(t *testing.T) {
+	router := gin.New()
+	router.Use(gin.RecoveryWithWriter(io.Discard))
+	router.POST("/panic", timeoutMiddleware(func(*gin.Context) {
+		panic("handler panic")
+	}))
+
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/panic", nil)
+	router.ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusInternalServerError, response.Code)
+	var body ReturnErrMsg
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body))
+	assert.Equal(t, int32(http.StatusInternalServerError), body.Code)
+}

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"math"
 	"net/http"
 	"reflect"
@@ -65,15 +66,21 @@ func HTTPReturn(c *gin.Context, code int, result gin.H) {
 	c.JSON(code, result)
 }
 
-// HTTPReturnStream uses custom jsonRender that encodes JSON data directly into the response writer.
-// Timeout-wrapped REST routes still buffer encoded bytes before committing them to the client.
-func HTTPReturnStream(c *gin.Context, code int, result gin.H) {
+// HTTPReturnStream uses custom jsonRender to stream row-based JSON data directly
+// into the response writer. Timeout-wrapped routes defer the renderer until the
+// handler wins timeout arbitration, then render into the real writer.
+func HTTPReturnStream(c *gin.Context, code int, result gin.H) error {
 	c.Set(HTTPReturnCode, result[HTTPReturnCode])
 	if errorMsg, ok := result[HTTPReturnMessage]; ok {
 		c.Set(HTTPReturnMessage, errorMsg)
 	}
 	setTraceIDHeader(c)
-	c.Render(code, jsonRender{Data: result})
+	previousErrors := len(c.Errors)
+	c.Render(code, jsonRender{Context: c.Request.Context(), Data: result})
+	if len(c.Errors) > previousErrors {
+		return c.Errors.Last().Err
+	}
+	return nil
 }
 
 func HTTPAbortReturn(c *gin.Context, code int, result gin.H) {
@@ -1408,6 +1415,7 @@ func buildStructArrayFieldDataInternal(structSchema *schemapb.StructArrayFieldSc
 }
 
 type structArrayRowAccessor struct {
+	ctx          context.Context
 	fieldData    *schemapb.FieldData
 	subFields    []*schemapb.FieldData
 	subAccessors []*fieldDataRowAccessor
@@ -1415,8 +1423,14 @@ type structArrayRowAccessor struct {
 }
 
 func newStructArrayRowAccessor(fd *schemapb.FieldData, schema *schemapb.CollectionSchema) (*structArrayRowAccessor, error) {
+	return newStructArrayRowAccessorWithContext(context.Background(), fd, schema)
+}
+
+func newStructArrayRowAccessorWithContext(ctx context.Context, fd *schemapb.FieldData, schema *schemapb.CollectionSchema) (*structArrayRowAccessor, error) {
+	ctx = renderContext(ctx)
 	subs := fd.GetStructArrays().GetFields()
 	accessor := &structArrayRowAccessor{
+		ctx:       ctx,
 		fieldData: fd,
 		subFields: subs,
 	}
@@ -1426,15 +1440,18 @@ func newStructArrayRowAccessor(fd *schemapb.FieldData, schema *schemapb.Collecti
 
 	expectedValidData := subs[0].GetValidData()
 	accessor.subAccessors = make([]*fieldDataRowAccessor, 0, len(subs))
-	for _, sub := range subs {
+	for subIndex, sub := range subs {
+		if err := checkResponseContext(ctx, int64(subIndex)); err != nil {
+			return nil, err
+		}
 		if !slices.Equal(expectedValidData, sub.GetValidData()) {
 			return nil, merr.WrapErrServiceInternalMsg(
 				"struct array field %s sub-field %s has inconsistent valid data",
 				fd.GetFieldName(), sub.GetFieldName())
 		}
-		subAccessor, err := newFieldDataRowAccessor(sub)
+		subAccessor, err := newFieldDataRowAccessorWithContext(ctx, sub)
 		if err != nil {
-			return nil, merr.WrapErrServiceInternalErr(err,
+			return nil, merr.Wrapf(err,
 				"invalid struct array field %s sub-field %s", fd.GetFieldName(), sub.GetFieldName())
 		}
 		accessor.subAccessors = append(accessor.subAccessors, subAccessor)
@@ -1449,6 +1466,9 @@ func newStructArrayRowAccessor(fd *schemapb.FieldData, schema *schemapb.Collecti
 }
 
 func (accessor *structArrayRowAccessor) row(rowIdx int) ([]map[string]interface{}, error) {
+	if err := accessor.ctx.Err(); err != nil {
+		return nil, err
+	}
 	fd := accessor.fieldData
 	subs := accessor.subFields
 	if len(subs) == 0 {
@@ -1457,9 +1477,12 @@ func (accessor *structArrayRowAccessor) row(rowIdx int) ([]map[string]interface{
 	rowIndices := make([]int, len(subs))
 	rowValid := true
 	for idx, sub := range subs {
+		if err := checkResponseContext(accessor.ctx, int64(idx)); err != nil {
+			return nil, err
+		}
 		dataIdx, valid, err := accessor.subAccessors[idx].rowIndex(int64(rowIdx))
 		if err != nil {
-			return nil, merr.WrapErrServiceInternalErr(err,
+			return nil, merr.Wrapf(err,
 				"read struct array field %s sub-field %s", fd.GetFieldName(), sub.GetFieldName())
 		}
 		if idx == 0 {
@@ -1481,53 +1504,136 @@ func (accessor *structArrayRowAccessor) row(rowIdx int) ([]map[string]interface{
 	}
 	out := make([]map[string]interface{}, elemCount)
 	for i := 0; i < elemCount; i++ {
+		if err := checkResponseContext(accessor.ctx, int64(i)); err != nil {
+			return nil, err
+		}
 		out[i] = make(map[string]interface{}, len(subs))
 	}
 	for subIdx, sub := range subs {
+		if err := checkResponseContext(accessor.ctx, int64(subIdx)); err != nil {
+			return nil, err
+		}
 		dataIdx := rowIndices[subIdx]
 		short := structFieldShortName(sub.GetFieldName())
 		switch sub.GetType() {
 		case schemapb.DataType_Array:
 			rowData := sub.GetScalars().GetArrayData().GetData()
 			if dataIdx >= len(rowData) {
-				return nil, merr.WrapErrParameterInvalidMsg("struct sub-field %s missing row %d", short, dataIdx)
+				return nil, merr.WrapErrServiceInternalMsg("struct sub-field %s missing row %d", short, dataIdx)
 			}
 			values := scalarArrayToInterfaces(rowData[dataIdx])
 			if len(values) != elemCount {
-				return nil, merr.WrapErrParameterInvalidMsg("struct sub-field %s element count mismatch: expect %d got %d",
+				return nil, merr.WrapErrServiceInternalMsg("struct sub-field %s element count mismatch: expect %d got %d",
 					short, elemCount, len(values))
 			}
 			for i, v := range values {
+				if err := checkResponseContext(accessor.ctx, int64(i)); err != nil {
+					return nil, err
+				}
 				out[i][short] = v
 			}
 		case schemapb.DataType_ArrayOfVector:
 			va := sub.GetVectors().GetVectorArray()
 			if va == nil {
-				return nil, merr.WrapErrParameterInvalidMsg("struct sub-field %s has no vector array", short)
+				return nil, merr.WrapErrServiceInternalMsg("struct sub-field %s has no vector array", short)
 			}
 			if dataIdx >= len(va.GetData()) {
-				return nil, merr.WrapErrParameterInvalidMsg("struct sub-field %s missing row %d", short, dataIdx)
+				return nil, merr.WrapErrServiceInternalMsg("struct sub-field %s missing row %d", short, dataIdx)
 			}
 			dim, ok := accessor.subDims[short]
 			if !ok || dim <= 0 {
-				return nil, merr.WrapErrParameterInvalidMsg("schema missing dim for struct sub-field %s", short)
+				return nil, merr.WrapErrServiceInternalMsg("schema missing dim for struct sub-field %s", short)
 			}
-			values, err := vectorFieldToInterfaces(va.GetData()[dataIdx], va.GetElementType(), dim)
+			values, err := vectorFieldToInterfaces(accessor.ctx, va.GetData()[dataIdx], va.GetElementType(), dim)
 			if err != nil {
 				return nil, err
 			}
 			if len(values) != elemCount {
-				return nil, merr.WrapErrParameterInvalidMsg("struct sub-field %s vector element count mismatch: expect %d got %d",
+				return nil, merr.WrapErrServiceInternalMsg("struct sub-field %s vector element count mismatch: expect %d got %d",
 					short, elemCount, len(values))
 			}
 			for i, v := range values {
+				if err := checkResponseContext(accessor.ctx, int64(i)); err != nil {
+					return nil, err
+				}
 				out[i][short] = v
 			}
 		default:
-			return nil, merr.WrapErrParameterInvalidMsg("unsupported struct sub-field type %s", sub.GetType())
+			return nil, merr.WrapErrServiceInternalMsg("unsupported struct sub-field type %s", sub.GetType())
 		}
 	}
 	return out, nil
+}
+
+func (accessor *structArrayRowAccessor) validateRow(rowIdx int, responseRowIdx int64) error {
+	if err := accessor.ctx.Err(); err != nil {
+		return err
+	}
+	fd := accessor.fieldData
+	subs := accessor.subFields
+	if len(subs) == 0 {
+		return nil
+	}
+
+	rowValid := true
+	elemCount := -1
+	for subIdx, sub := range subs {
+		if err := checkResponseContext(accessor.ctx, int64(subIdx)); err != nil {
+			return err
+		}
+		dataIdx, valid, err := accessor.subAccessors[subIdx].rowIndex(int64(rowIdx))
+		if err != nil {
+			return merr.Wrapf(err,
+				"read struct array field %s sub-field %s", fd.GetFieldName(), sub.GetFieldName())
+		}
+		if subIdx == 0 {
+			rowValid = valid
+		} else if valid != rowValid {
+			return merr.WrapErrServiceInternalMsg(
+				"struct array field %s sub-field %s has inconsistent null state at row %d",
+				fd.GetFieldName(), sub.GetFieldName(), rowIdx)
+		}
+		if !valid {
+			continue
+		}
+
+		count, err := structSubElemCount(sub, int(dataIdx), accessor.subDims)
+		if err != nil {
+			return err
+		}
+		short := structFieldShortName(sub.GetFieldName())
+		if elemCount < 0 {
+			elemCount = count
+		} else if count != elemCount {
+			return merr.WrapErrServiceInternalMsg(
+				"struct sub-field %s element count mismatch: expect %d got %d",
+				short, elemCount, count)
+		}
+
+		switch sub.GetType() {
+		case schemapb.DataType_Array:
+			scalar := sub.GetScalars().GetArrayData().GetData()[dataIdx]
+			switch scalar.GetData().(type) {
+			case *schemapb.ScalarField_FloatData:
+				if err := validateFiniteJSONValue(accessor.ctx, fieldDataName(fd), responseRowIdx, scalar.GetFloatData().GetData()); err != nil {
+					return err
+				}
+			case *schemapb.ScalarField_DoubleData:
+				if err := validateFiniteJSONValue(accessor.ctx, fieldDataName(fd), responseRowIdx, scalar.GetDoubleData().GetData()); err != nil {
+					return err
+				}
+			}
+		case schemapb.DataType_ArrayOfVector:
+			vectorArray := sub.GetVectors().GetVectorArray()
+			if vectorArray.GetElementType() == schemapb.DataType_FloatVector {
+				vector := vectorArray.GetData()[dataIdx].GetFloatVector().GetData()
+				if err := validateFiniteJSONValue(accessor.ctx, fieldDataName(fd), responseRowIdx, vector); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func structArraySubDims(fieldName string, schema *schemapb.CollectionSchema) (map[string]int64, error) {
@@ -1542,7 +1648,10 @@ func structArraySubDims(fieldName string, schema *schemapb.CollectionSchema) (ma
 			}
 			dim, err := getDim(sub)
 			if err != nil {
-				return nil, merr.WrapErrParameterInvalidErr(err, "schema sub-field %s has no dim", sub.GetName())
+				// getDim normally validates request-provided schema. Here the
+				// schema came from Milvus metadata, so a malformed dimension is
+				// deliberately translated to an internal-result error.
+				return nil, merr.WrapErrServiceInternalErr(err, "schema sub-field %s has no dim", sub.GetName())
 			}
 			subDims[subShortName(sub)] = dim
 		}
@@ -1556,22 +1665,41 @@ func structSubElemCount(sub *schemapb.FieldData, rowIdx int, subDims map[string]
 	case schemapb.DataType_Array:
 		rowData := sub.GetScalars().GetArrayData().GetData()
 		if rowIdx >= len(rowData) {
-			return 0, merr.WrapErrParameterInvalidMsg("struct sub-field %s row %d out of range", sub.GetFieldName(), rowIdx)
+			return 0, merr.WrapErrServiceInternalMsg("struct sub-field %s row %d out of range", sub.GetFieldName(), rowIdx)
 		}
-		return len(scalarArrayToInterfaces(rowData[rowIdx])), nil
+		return scalarFieldElemCount(rowData[rowIdx]), nil
 	case schemapb.DataType_ArrayOfVector:
 		va := sub.GetVectors().GetVectorArray()
 		if va == nil || rowIdx >= len(va.GetData()) {
-			return 0, merr.WrapErrParameterInvalidMsg("struct sub-field %s row %d out of range", sub.GetFieldName(), rowIdx)
+			return 0, merr.WrapErrServiceInternalMsg("struct sub-field %s row %d out of range", sub.GetFieldName(), rowIdx)
 		}
 		short := structFieldShortName(sub.GetFieldName())
 		dim, ok := subDims[short]
 		if !ok || dim <= 0 {
-			return 0, merr.WrapErrParameterInvalidMsg("schema missing dim for struct sub-field %s", short)
+			return 0, merr.WrapErrServiceInternalMsg("schema missing dim for struct sub-field %s", short)
 		}
 		return vectorFieldElemCount(va.GetData()[rowIdx], va.GetElementType(), dim)
 	default:
-		return 0, merr.WrapErrParameterInvalidMsg("unsupported struct sub-field type %s", sub.GetType())
+		return 0, merr.WrapErrServiceInternalMsg("unsupported struct sub-field type %s", sub.GetType())
+	}
+}
+
+func scalarFieldElemCount(sf *schemapb.ScalarField) int {
+	switch sf.GetData().(type) {
+	case *schemapb.ScalarField_BoolData:
+		return len(sf.GetBoolData().GetData())
+	case *schemapb.ScalarField_IntData:
+		return len(sf.GetIntData().GetData())
+	case *schemapb.ScalarField_LongData:
+		return len(sf.GetLongData().GetData())
+	case *schemapb.ScalarField_FloatData:
+		return len(sf.GetFloatData().GetData())
+	case *schemapb.ScalarField_DoubleData:
+		return len(sf.GetDoubleData().GetData())
+	case *schemapb.ScalarField_StringData:
+		return len(sf.GetStringData().GetData())
+	default:
+		return 0
 	}
 }
 
@@ -1625,71 +1753,95 @@ func scalarArrayToInterfaces(sf *schemapb.ScalarField) []interface{} {
 }
 
 func vectorFieldElemCount(vf *schemapb.VectorField, elemType schemapb.DataType, dim int64) (int, error) {
-	if dim <= 0 {
-		return 0, merr.WrapErrParameterInvalidMsg("invalid dim %d", dim)
+	width, err := vectorFieldElementWidth(elemType, dim)
+	if err != nil {
+		return 0, err
 	}
+	var dataLength int
 	switch elemType {
 	case schemapb.DataType_FloatVector:
-		return len(vf.GetFloatVector().GetData()) / int(dim), nil
+		dataLength = len(vf.GetFloatVector().GetData())
 	case schemapb.DataType_Float16Vector:
-		return len(vf.GetFloat16Vector()) / int(dim*2), nil
+		dataLength = len(vf.GetFloat16Vector())
 	case schemapb.DataType_BFloat16Vector:
-		return len(vf.GetBfloat16Vector()) / int(dim*2), nil
+		dataLength = len(vf.GetBfloat16Vector())
 	case schemapb.DataType_BinaryVector:
-		return len(vf.GetBinaryVector()) / int(dim/8), nil
+		dataLength = len(vf.GetBinaryVector())
 	case schemapb.DataType_Int8Vector:
-		return len(vf.GetInt8Vector()) / int(dim), nil
-	default:
-		return 0, merr.WrapErrParameterInvalidMsg("unsupported vector element type %s", elemType)
+		dataLength = len(vf.GetInt8Vector())
 	}
+	if int64(dataLength)%width != 0 {
+		return 0, merr.WrapErrServiceInternalMsg(
+			"struct vector payload length %d is not divisible by row width %d for type %s",
+			dataLength, width, elemType)
+	}
+	return int(int64(dataLength) / width), nil
 }
 
-func vectorFieldToInterfaces(vf *schemapb.VectorField, elemType schemapb.DataType, dim int64) ([]interface{}, error) {
-	if dim <= 0 {
-		return nil, merr.WrapErrParameterInvalidMsg("invalid dim %d", dim)
+func vectorFieldToInterfaces(ctx context.Context, vf *schemapb.VectorField, elemType schemapb.DataType, dim int64) ([]interface{}, error) {
+	ctx = renderContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	count, err := vectorFieldElemCount(vf, elemType, dim)
+	if err != nil {
+		return nil, err
+	}
+	if count == 0 {
+		return []interface{}{}, nil
 	}
 	switch elemType {
 	case schemapb.DataType_FloatVector:
 		buf := vf.GetFloatVector().GetData()
-		count := len(buf) / int(dim)
 		out := make([]interface{}, count)
 		for i := 0; i < count; i++ {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			out[i] = buf[i*int(dim) : (i+1)*int(dim)]
 		}
 		return out, nil
 	case schemapb.DataType_Float16Vector:
 		buf := vf.GetFloat16Vector()
 		step := int(dim * 2)
-		count := len(buf) / step
 		out := make([]interface{}, count)
 		for i := 0; i < count; i++ {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			out[i] = base64.StdEncoding.EncodeToString(buf[i*step : (i+1)*step])
 		}
 		return out, nil
 	case schemapb.DataType_BFloat16Vector:
 		buf := vf.GetBfloat16Vector()
 		step := int(dim * 2)
-		count := len(buf) / step
 		out := make([]interface{}, count)
 		for i := 0; i < count; i++ {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			out[i] = base64.StdEncoding.EncodeToString(buf[i*step : (i+1)*step])
 		}
 		return out, nil
 	case schemapb.DataType_BinaryVector:
 		buf := vf.GetBinaryVector()
 		step := int(dim / 8)
-		count := len(buf) / step
 		out := make([]interface{}, count)
 		for i := 0; i < count; i++ {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			out[i] = base64.StdEncoding.EncodeToString(buf[i*step : (i+1)*step])
 		}
 		return out, nil
 	case schemapb.DataType_Int8Vector:
 		buf := vf.GetInt8Vector()
 		step := int(dim)
-		count := len(buf) / step
 		out := make([]interface{}, count)
 		for i := 0; i < count; i++ {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			seg := buf[i*step : (i+1)*step]
 			row := make([]int8, step)
 			for j, b := range seg {
@@ -1699,7 +1851,29 @@ func vectorFieldToInterfaces(vf *schemapb.VectorField, elemType schemapb.DataTyp
 		}
 		return out, nil
 	default:
-		return nil, merr.WrapErrParameterInvalidMsg("unsupported vector element type %s", elemType)
+		return nil, merr.WrapErrServiceInternalMsg("unsupported vector element type %s", elemType)
+	}
+}
+
+func vectorFieldElementWidth(elemType schemapb.DataType, dim int64) (int64, error) {
+	if dim <= 0 {
+		return 0, merr.WrapErrServiceInternalMsg("invalid struct vector dimension %d for type %s", dim, elemType)
+	}
+	switch elemType {
+	case schemapb.DataType_FloatVector, schemapb.DataType_Int8Vector:
+		return dim, nil
+	case schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector:
+		if dim > math.MaxInt64/2 {
+			return 0, merr.WrapErrServiceInternalMsg("struct vector dimension %d overflows row width for type %s", dim, elemType)
+		}
+		return dim * 2, nil
+	case schemapb.DataType_BinaryVector:
+		if dim%8 != 0 {
+			return 0, merr.WrapErrServiceInternalMsg("binary struct vector dimension %d is not divisible by 8", dim)
+		}
+		return dim / 8, nil
+	default:
+		return 0, merr.WrapErrServiceInternalMsg("unsupported vector element type %s", elemType)
 	}
 }
 
@@ -2487,6 +2661,36 @@ func vectors2PlaceholderGroupBytes(vectors [][]float32) []byte {
 }
 
 // --------------------- get/query/search response --------------------- //
+const responseContextCheckInterval int64 = 256
+
+func checkResponseContext(ctx context.Context, index int64) error {
+	if index%responseContextCheckInterval != 0 {
+		return nil
+	}
+	return renderContext(ctx).Err()
+}
+
+func sparseFloatBytesToMapWithContext(ctx context.Context, contents []byte) (map[uint32]float32, error) {
+	elemCount := len(contents) / 8
+	if err := renderContext(ctx).Err(); err != nil {
+		return nil, err
+	}
+	values := make(map[uint32]float32, elemCount)
+	for elemIndex := 0; elemIndex < elemCount; elemIndex++ {
+		if err := checkResponseContext(ctx, int64(elemIndex)); err != nil {
+			return nil, err
+		}
+		offset := elemIndex * 8
+		index := common.Endian.Uint32(contents[offset : offset+4])
+		value := math.Float32frombits(common.Endian.Uint32(contents[offset+4 : offset+8]))
+		values[index] = value
+	}
+	if err := renderContext(ctx).Err(); err != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
 func genDynamicFields(fields []string, list []*schemapb.FieldData) []string {
 	nonDynamicFieldNames := make(map[string]struct{})
 	for _, field := range list {
@@ -2527,7 +2731,7 @@ func fieldDataValueCount(fieldData *schemapb.FieldData) (int64, error) {
 			return int64(len(fieldData.GetScalars().GetTimestamptzData().GetData())), nil
 		}
 		return int64(len(fieldData.GetScalars().GetStringData().GetData())), nil
-	case schemapb.DataType_String, schemapb.DataType_VarChar:
+	case schemapb.DataType_String, schemapb.DataType_VarChar, schemapb.DataType_Text:
 		return int64(len(fieldData.GetScalars().GetStringData().GetData())), nil
 	case schemapb.DataType_Array:
 		return int64(len(fieldData.GetScalars().GetArrayData().GetData())), nil
@@ -2544,27 +2748,27 @@ func fieldDataValueCount(fieldData *schemapb.FieldData) (int64, error) {
 		dim := fieldData.GetVectors().GetDim()
 		bytesPerRow := dim / 8
 		if bytesPerRow <= 0 {
-			return 0, merr.WrapErrParameterInvalidMsg("invalid binary vector dimension %d for field %s", dim, fieldData.GetFieldName())
+			return 0, merr.WrapErrServiceInternalMsg("invalid binary vector dimension %d for field %s", dim, fieldData.GetFieldName())
 		}
 		return int64(len(fieldData.GetVectors().GetBinaryVector())) / bytesPerRow, nil
 	case schemapb.DataType_FloatVector:
 		dim := fieldData.GetVectors().GetDim()
 		if dim <= 0 {
-			return 0, merr.WrapErrParameterInvalidMsg("invalid float vector dimension %d for field %s", dim, fieldData.GetFieldName())
+			return 0, merr.WrapErrServiceInternalMsg("invalid float vector dimension %d for field %s", dim, fieldData.GetFieldName())
 		}
 		return int64(len(fieldData.GetVectors().GetFloatVector().GetData())) / dim, nil
 	case schemapb.DataType_Float16Vector:
 		dim := fieldData.GetVectors().GetDim()
 		bytesPerRow := dim * 2
 		if bytesPerRow <= 0 {
-			return 0, merr.WrapErrParameterInvalidMsg("invalid float16 vector dimension %d for field %s", dim, fieldData.GetFieldName())
+			return 0, merr.WrapErrServiceInternalMsg("invalid float16 vector dimension %d for field %s", dim, fieldData.GetFieldName())
 		}
 		return int64(len(fieldData.GetVectors().GetFloat16Vector())) / bytesPerRow, nil
 	case schemapb.DataType_BFloat16Vector:
 		dim := fieldData.GetVectors().GetDim()
 		bytesPerRow := dim * 2
 		if bytesPerRow <= 0 {
-			return 0, merr.WrapErrParameterInvalidMsg("invalid bfloat16 vector dimension %d for field %s", dim, fieldData.GetFieldName())
+			return 0, merr.WrapErrServiceInternalMsg("invalid bfloat16 vector dimension %d for field %s", dim, fieldData.GetFieldName())
 		}
 		return int64(len(fieldData.GetVectors().GetBfloat16Vector())) / bytesPerRow, nil
 	case schemapb.DataType_SparseFloatVector:
@@ -2572,7 +2776,7 @@ func fieldDataValueCount(fieldData *schemapb.FieldData) (int64, error) {
 	case schemapb.DataType_Int8Vector:
 		dim := fieldData.GetVectors().GetDim()
 		if dim <= 0 {
-			return 0, merr.WrapErrParameterInvalidMsg("invalid int8 vector dimension %d for field %s", dim, fieldData.GetFieldName())
+			return 0, merr.WrapErrServiceInternalMsg("invalid int8 vector dimension %d for field %s", dim, fieldData.GetFieldName())
 		}
 		return int64(len(fieldData.GetVectors().GetInt8Vector())) / dim, nil
 	case schemapb.DataType_ArrayOfStruct:
@@ -2589,10 +2793,10 @@ func fieldDataValueCount(fieldData *schemapb.FieldData) (int64, error) {
 		case schemapb.DataType_ArrayOfVector:
 			return int64(len(subs[0].GetVectors().GetVectorArray().GetData())), nil
 		default:
-			return 0, merr.WrapErrParameterInvalidMsg("unsupported struct sub-field type %s for field %s", subs[0].GetType(), fieldData.GetFieldName())
+			return 0, merr.WrapErrServiceInternalMsg("unsupported struct sub-field type %s for field %s", subs[0].GetType(), fieldData.GetFieldName())
 		}
 	default:
-		return 0, merr.WrapErrParameterInvalidMsg("the type(%v) of field(%v) is not supported, use other sdk please", fieldData.GetType(), fieldData.GetFieldName())
+		return 0, merr.WrapErrServiceInternalMsg("the type(%v) of field(%v) is not supported, use other sdk please", fieldData.GetType(), fieldData.GetFieldName())
 	}
 }
 
@@ -2603,6 +2807,11 @@ type fieldDataRowAccessor struct {
 }
 
 func newFieldDataRowAccessor(fieldData *schemapb.FieldData) (*fieldDataRowAccessor, error) {
+	return newFieldDataRowAccessorWithContext(context.Background(), fieldData)
+}
+
+func newFieldDataRowAccessorWithContext(ctx context.Context, fieldData *schemapb.FieldData) (*fieldDataRowAccessor, error) {
+	ctx = renderContext(ctx)
 	accessor := &fieldDataRowAccessor{
 		fieldData: fieldData,
 		validData: fieldData.GetValidData(),
@@ -2615,6 +2824,9 @@ func newFieldDataRowAccessor(fieldData *schemapb.FieldData) (*fieldDataRowAccess
 	compactIndices := make([]int64, len(accessor.validData))
 	validCount := int64(0)
 	for i, valid := range accessor.validData {
+		if err := checkResponseContext(ctx, int64(i)); err != nil {
+			return nil, err
+		}
 		if valid {
 			compactIndices[i] = validCount
 			validCount++
@@ -2622,14 +2834,23 @@ func newFieldDataRowAccessor(fieldData *schemapb.FieldData) (*fieldDataRowAccess
 			compactIndices[i] = -1
 		}
 	}
-	if isNullableVector {
-		if err := funcutil.ValidateNullableVectorFieldDataCompact(fieldData, uint64(len(accessor.validData)), true); err != nil {
-			return nil, err
-		}
-		accessor.compactIndices = compactIndices
-		return accessor, nil
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
-	if validCount == 0 {
+	if isNullableVector {
+		physicalRows, err := funcutil.GetVectorFieldPhysicalRows(fieldData.GetFieldName(), fieldData.GetType(), fieldData.GetVectors())
+		if err != nil {
+			// The shared utility classifies malformed caller-provided FieldData
+			// as an input error. Query response FieldData is produced inside
+			// Milvus, so this violation is deliberately system-blame.
+			return nil, merr.WrapErrServiceInternalErr(err,
+				"query response nullable vector field %s has invalid compact data", fieldData.GetFieldName())
+		}
+		if physicalRows != uint64(validCount) {
+			return nil, merr.WrapErrServiceInternalMsg(
+				"query response nullable vector field %s has %d valid rows, but compact physical payload rows is %d",
+				fieldData.GetFieldName(), validCount, physicalRows)
+		}
 		accessor.compactIndices = compactIndices
 		return accessor, nil
 	}
@@ -2642,7 +2863,7 @@ func newFieldDataRowAccessor(fieldData *schemapb.FieldData) (*fieldDataRowAccess
 		return accessor, nil
 	}
 	if valueCount != validCount {
-		return nil, merr.WrapErrParameterInvalidMsg("field %s has %d valid rows, but data length is %d", fieldData.GetFieldName(), validCount, valueCount)
+		return nil, merr.WrapErrServiceInternalMsg("field %s has %d valid rows, but data length is %d", fieldData.GetFieldName(), validCount, valueCount)
 	}
 	accessor.compactIndices = compactIndices
 	return accessor, nil
@@ -2652,8 +2873,8 @@ func (accessor *fieldDataRowAccessor) rowIndex(rowIdx int64) (int64, bool, error
 	if len(accessor.validData) == 0 {
 		return rowIdx, true, nil
 	}
-	if rowIdx >= int64(len(accessor.validData)) {
-		return 0, false, merr.WrapErrParameterInvalidMsg("row index %d out of range for field %s valid data length %d", rowIdx, accessor.fieldData.GetFieldName(), len(accessor.validData))
+	if rowIdx < 0 || rowIdx >= int64(len(accessor.validData)) {
+		return 0, false, merr.WrapErrServiceInternalMsg("row index %d out of range for field %s valid data length %d", rowIdx, accessor.fieldData.GetFieldName(), len(accessor.validData))
 	}
 	if !accessor.validData[rowIdx] {
 		return 0, false, nil
@@ -2664,186 +2885,742 @@ func (accessor *fieldDataRowAccessor) rowIndex(rowIdx int64) (int64, bool, error
 	return rowIdx, true, nil
 }
 
-//nolint:gosec // G602: slice indices are bounded by rowsNum which is derived from the data length
-func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemapb.FieldData, ids *schemapb.IDs,
+type queryResponseRows struct {
+	ctx                  context.Context
+	rowsNum              int64
+	fieldDataList        []*schemapb.FieldData
+	fieldDataAccessors   []*fieldDataRowAccessor
+	structArrayAccessors []*structArrayRowAccessor
+	dynamicOutputFields  []string
+	ids                  *schemapb.IDs
+	scores               []float32
+	enableInt64          bool
+	pkFieldName          string
+}
+
+func queryResponseIDCount(ids *schemapb.IDs) (int64, error) {
+	if ids == nil {
+		return 0, nil
+	}
+	switch ids.GetIdField().(type) {
+	case nil:
+		return 0, nil
+	case *schemapb.IDs_IntId:
+		return int64(len(ids.GetIntId().GetData())), nil
+	case *schemapb.IDs_StrId:
+		return int64(len(ids.GetStrId().GetData())), nil
+	default:
+		return 0, merr.WrapErrServiceInternalMsg("query response primary key has unsupported ID type")
+	}
+}
+
+func newQueryResponseRows(rowsNum int64, needFields []string, fieldDataList []*schemapb.FieldData, ids *schemapb.IDs,
 	scores []float32, enableInt64 bool, collectionSchema *schemapb.CollectionSchema,
-) ([]map[string]interface{}, error) {
+) (*queryResponseRows, error) {
+	return newQueryResponseRowsWithContext(context.Background(), rowsNum, needFields, fieldDataList, ids, scores, enableInt64, collectionSchema)
+}
+
+func newQueryResponseRowsWithContext(ctx context.Context, rowsNum int64, needFields []string, fieldDataList []*schemapb.FieldData, ids *schemapb.IDs,
+	scores []float32, enableInt64 bool, collectionSchema *schemapb.CollectionSchema,
+) (*queryResponseRows, error) {
+	return newQueryResponseRowsWithMode(ctx, rowsNum, needFields, fieldDataList, ids, scores, enableInt64, collectionSchema, true)
+}
+
+func newQueryResponseRowsWithMode(ctx context.Context, rowsNum int64, needFields []string, fieldDataList []*schemapb.FieldData, ids *schemapb.IDs,
+	scores []float32, enableInt64 bool, collectionSchema *schemapb.CollectionSchema, strictInferredRowCount bool,
+) (*queryResponseRows, error) {
+	ctx = renderContext(ctx)
 	columnNum := len(fieldDataList)
-	if rowsNum == int64(0) { // always
-		if columnNum > 0 {
+	for fieldIndex, fieldData := range fieldDataList {
+		if err := checkResponseContext(ctx, int64(fieldIndex)); err != nil {
+			return nil, err
+		}
+		if fieldData == nil {
+			return nil, merr.WrapErrServiceInternalMsg("query response field at index %d is nil", fieldIndex)
+		}
+	}
+	inferredRowCount := rowsNum == 0
+	strictRowCount := inferredRowCount && strictInferredRowCount
+	if inferredRowCount {
+		if strictInferredRowCount && ids != nil {
+			var err error
+			rowsNum, err = queryResponseIDCount(ids)
+			if err != nil {
+				return nil, err
+			}
+		} else if columnNum > 0 {
 			var err error
 			rowsNum, err = fieldDataRowCount(fieldDataList[0])
 			if err != nil {
 				return nil, err
 			}
 		} else if ids != nil {
-			switch ids.GetIdField().(type) {
-			case *schemapb.IDs_IntId:
-				int64Pks := ids.GetIntId().GetData()
-				rowsNum = int64(len(int64Pks))
-			case *schemapb.IDs_StrId:
-				stringPks := ids.GetStrId().GetData()
-				rowsNum = int64(len(stringPks))
-			default:
-				return nil, merr.WrapErrParameterInvalidMsg("the type of primary key(id) is not supported, use other sdk please")
-			}
-		}
-	}
-	if rowsNum == int64(0) {
-		return []map[string]interface{}{}, nil
-	}
-	fieldDataAccessors := make([]*fieldDataRowAccessor, 0, columnNum)
-	structArrayAccessors := make([]*structArrayRowAccessor, columnNum)
-	for idx, fieldData := range fieldDataList {
-		accessor, err := newFieldDataRowAccessor(fieldData)
-		if err != nil {
-			return nil, err
-		}
-		fieldDataAccessors = append(fieldDataAccessors, accessor)
-		if fieldData.GetType() == schemapb.DataType_ArrayOfStruct {
-			structAccessor, err := newStructArrayRowAccessor(fieldData, collectionSchema)
+			var err error
+			rowsNum, err = queryResponseIDCount(ids)
 			if err != nil {
 				return nil, err
 			}
-			structArrayAccessors[idx] = structAccessor
 		}
 	}
-	queryResp := make([]map[string]interface{}, 0, rowsNum)
-	dynamicOutputFields := genDynamicFields(needFields, fieldDataList)
+	if rowsNum < 0 {
+		return nil, merr.WrapErrServiceInternalMsg("query response row count cannot be negative: %d", rowsNum)
+	}
 
-	pkFieldName := DefaultPrimaryFieldName
+	rows := &queryResponseRows{
+		ctx:                  ctx,
+		rowsNum:              rowsNum,
+		fieldDataList:        fieldDataList,
+		fieldDataAccessors:   make([]*fieldDataRowAccessor, 0, columnNum),
+		structArrayAccessors: make([]*structArrayRowAccessor, columnNum),
+		dynamicOutputFields:  genDynamicFields(needFields, fieldDataList),
+		ids:                  ids,
+		scores:               scores,
+		enableInt64:          enableInt64,
+		pkFieldName:          DefaultPrimaryFieldName,
+	}
+	if rowsNum == 0 && !strictInferredRowCount {
+		return rows, nil
+	}
+
+	for idx, fieldData := range fieldDataList {
+		if err := checkResponseContext(ctx, int64(idx)); err != nil {
+			return nil, err
+		}
+		accessor, err := newFieldDataRowAccessorWithContext(ctx, fieldData)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateQueryResponseFieldRows(ctx, fieldData, rowsNum, strictRowCount); err != nil {
+			return nil, err
+		}
+		rows.fieldDataAccessors = append(rows.fieldDataAccessors, accessor)
+		if fieldData.GetType() == schemapb.DataType_ArrayOfStruct {
+			structAccessor, err := newStructArrayRowAccessorWithContext(ctx, fieldData, collectionSchema)
+			if err != nil {
+				return nil, err
+			}
+			if err := validateStructArraySubFieldRows(ctx, fieldData, rowsNum, strictRowCount); err != nil {
+				return nil, err
+			}
+			rows.structArrayAccessors[idx] = structAccessor
+		}
+	}
+
 	if collectionSchema != nil {
 		fieldsSchema := collectionSchema.GetFields()
-		for _, field := range fieldsSchema {
+		for fieldIndex, field := range fieldsSchema {
+			if err := checkResponseContext(ctx, int64(fieldIndex)); err != nil {
+				return nil, err
+			}
 			if field.GetIsPrimaryKey() {
-				pkFieldName = field.GetName()
+				rows.pkFieldName = field.GetName()
 				break
 			}
 		}
 	}
-	for i := int64(0); i < rowsNum; i++ {
-		row := map[string]interface{}{}
-		if columnNum > 0 {
-			for j := 0; j < columnNum; j++ {
-				fieldData := fieldDataList[j]
-				dataIdx, valid, err := fieldDataAccessors[j].rowIndex(i)
+	if err := rows.validateIDs(strictRowCount); err != nil {
+		return nil, err
+	}
+	if err := rows.validateDynamicJSON(); err != nil {
+		return nil, err
+	}
+	if err := rows.validateStructArrays(); err != nil {
+		return nil, err
+	}
+	if err := rows.validateJSONValues(); err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func validateStructArraySubFieldRows(ctx context.Context, fieldData *schemapb.FieldData, rowsNum int64, strictRowCount bool) error {
+	for subIndex, subField := range fieldData.GetStructArrays().GetFields() {
+		if err := checkResponseContext(ctx, int64(subIndex)); err != nil {
+			return err
+		}
+		logicalRows, err := fieldDataRowCount(subField)
+		if err != nil {
+			return merr.Wrapf(err, "read struct array field %s sub-field %s row count",
+				fieldData.GetFieldName(), subField.GetFieldName())
+		}
+		if strictRowCount && logicalRows != rowsNum {
+			return merr.WrapErrServiceInternalMsg(
+				"query response struct array field %s sub-field %s contains %d logical rows, expected exactly %d",
+				fieldData.GetFieldName(), subField.GetFieldName(), logicalRows, rowsNum,
+			)
+		}
+		if !strictRowCount && logicalRows < rowsNum {
+			return merr.WrapErrServiceInternalMsg(
+				"query response struct array field %s sub-field %s contains %d logical rows, expected at least %d",
+				fieldData.GetFieldName(), subField.GetFieldName(), logicalRows, rowsNum,
+			)
+		}
+	}
+	return nil
+}
+
+func validateQueryResponseFieldRows(ctx context.Context, fieldData *schemapb.FieldData, rowsNum int64, strictRowCount bool) error {
+	logicalRows, err := fieldDataRowCount(fieldData)
+	if err != nil {
+		return err
+	}
+	if strictRowCount && logicalRows != rowsNum {
+		return merr.WrapErrServiceInternalMsg(
+			"query response field %s contains %d logical rows, expected exactly %d",
+			fieldData.GetFieldName(), logicalRows, rowsNum,
+		)
+	}
+	if !strictRowCount && logicalRows < rowsNum {
+		return merr.WrapErrServiceInternalMsg(
+			"query response field %s contains %d logical rows, expected at least %d",
+			fieldData.GetFieldName(), logicalRows, rowsNum,
+		)
+	}
+
+	var width int64
+	var dataLength int64
+	switch fieldData.GetType() {
+	case schemapb.DataType_BinaryVector:
+		dim := fieldData.GetVectors().GetDim()
+		if dim <= 0 || dim%8 != 0 {
+			return merr.WrapErrServiceInternalMsg("query response binary vector field %s has invalid dimension %d", fieldData.GetFieldName(), dim)
+		}
+		width = dim / 8
+		dataLength = int64(len(fieldData.GetVectors().GetBinaryVector()))
+	case schemapb.DataType_FloatVector:
+		dim := fieldData.GetVectors().GetDim()
+		if dim <= 0 {
+			return merr.WrapErrServiceInternalMsg("query response float vector field %s has invalid dimension %d", fieldData.GetFieldName(), dim)
+		}
+		width = dim
+		dataLength = int64(len(fieldData.GetVectors().GetFloatVector().GetData()))
+	case schemapb.DataType_Float16Vector:
+		dim := fieldData.GetVectors().GetDim()
+		if dim <= 0 || dim > math.MaxInt64/2 {
+			return merr.WrapErrServiceInternalMsg("query response float16 vector field %s has invalid dimension %d", fieldData.GetFieldName(), dim)
+		}
+		width = dim * 2
+		dataLength = int64(len(fieldData.GetVectors().GetFloat16Vector()))
+	case schemapb.DataType_BFloat16Vector:
+		dim := fieldData.GetVectors().GetDim()
+		if dim <= 0 || dim > math.MaxInt64/2 {
+			return merr.WrapErrServiceInternalMsg("query response bfloat16 vector field %s has invalid dimension %d", fieldData.GetFieldName(), dim)
+		}
+		width = dim * 2
+		dataLength = int64(len(fieldData.GetVectors().GetBfloat16Vector()))
+	case schemapb.DataType_Int8Vector:
+		dim := fieldData.GetVectors().GetDim()
+		if dim <= 0 {
+			return merr.WrapErrServiceInternalMsg("query response int8 vector field %s has invalid dimension %d", fieldData.GetFieldName(), dim)
+		}
+		width = dim
+		dataLength = int64(len(fieldData.GetVectors().GetInt8Vector()))
+	case schemapb.DataType_SparseFloatVector:
+		for rowIndex, contents := range fieldData.GetVectors().GetSparseFloatVector().GetContents() {
+			if err := checkResponseContext(ctx, int64(rowIndex)); err != nil {
+				return err
+			}
+			if len(contents)%8 != 0 {
+				return merr.WrapErrServiceInternalMsg(
+					"query response sparse vector field %s row %d byte length %d is not divisible by 8",
+					fieldData.GetFieldName(), rowIndex, len(contents))
+			}
+		}
+	}
+	if width > 0 && dataLength%width != 0 {
+		return merr.WrapErrServiceInternalMsg(
+			"query response vector field %s data length %d is not divisible by row width %d",
+			fieldData.GetFieldName(), dataLength, width,
+		)
+	}
+	return nil
+}
+
+func (rows *queryResponseRows) Len() int64 {
+	return rows.rowsNum
+}
+
+func (rows *queryResponseRows) validateIDs(strictRowCount bool) error {
+	if err := rows.ctx.Err(); err != nil {
+		return err
+	}
+	if rows.ids == nil {
+		return nil
+	}
+	idCount, err := queryResponseIDCount(rows.ids)
+	if err != nil {
+		return err
+	}
+	if strictRowCount && idCount != rows.rowsNum {
+		return merr.WrapErrServiceInternalMsg("query response contains %d IDs, expected exactly %d", idCount, rows.rowsNum)
+	}
+	if !strictRowCount && idCount < rows.rowsNum {
+		return merr.WrapErrServiceInternalMsg("query response contains %d IDs, expected at least %d", idCount, rows.rowsNum)
+	}
+	return nil
+}
+
+func (rows *queryResponseRows) validateDynamicJSON() error {
+	for fieldIndex, fieldData := range rows.fieldDataList {
+		if err := checkResponseContext(rows.ctx, int64(fieldIndex)); err != nil {
+			return err
+		}
+		if fieldData.GetType() != schemapb.DataType_JSON || !fieldData.GetIsDynamic() {
+			continue
+		}
+		jsonRows := fieldData.GetScalars().GetJsonData().GetData()
+		for rowIndex := int64(0); rowIndex < rows.rowsNum; rowIndex++ {
+			if err := checkResponseContext(rows.ctx, rowIndex); err != nil {
+				return err
+			}
+			dataIndex, valid, err := rows.fieldDataAccessors[fieldIndex].rowIndex(rowIndex)
+			if err != nil {
+				return err
+			}
+			if !valid {
+				continue
+			}
+			raw := jsonRows[dataIndex]
+			if !validDynamicJSONObject(raw) {
+				// Dynamic JSON in a query response is internal component output,
+				// not the original REST request payload.
+				return merr.WrapErrServiceInternalMsg(
+					"query response dynamic field %s row %d must contain a valid, REST-encodable JSON object",
+					fieldData.GetFieldName(), rowIndex)
+			}
+		}
+	}
+	return nil
+}
+
+// Sonic's encoder uses a 4096-entry stack. Dynamic JSON's top-level object is
+// flattened into the response row, so 4093 nested child containers is the last
+// depth that fits once the row map and encoder root state are included.
+const maxDynamicJSONValueNestingDepth = 4093
+
+func validDynamicJSONObject(raw []byte) bool {
+	if !gjson.ValidBytes(raw) {
+		return false
+	}
+	value := gjson.ParseBytes(raw)
+	// Preserve the previous json.Unmarshal behavior: a dynamic field may be
+	// null, in which case it contributes no keys to the REST row.
+	if value.Type == gjson.Null {
+		return true
+	}
+	return value.IsObject() && validDynamicJSONValue(value, 0)
+}
+
+func validDynamicJSONValue(value gjson.Result, nestingDepth int) bool {
+	if value.Type == gjson.Number {
+		return !math.IsNaN(value.Num) && !math.IsInf(value.Num, 0)
+	}
+	if value.Type != gjson.JSON {
+		return true
+	}
+	if nestingDepth > maxDynamicJSONValueNestingDepth {
+		return false
+	}
+	valid := true
+	value.ForEach(func(_, child gjson.Result) bool {
+		childDepth := nestingDepth
+		if child.Type == gjson.JSON {
+			childDepth++
+		}
+		valid = validDynamicJSONValue(child, childDepth)
+		return valid
+	})
+	return valid
+}
+
+func (rows *queryResponseRows) validateStructArrays() error {
+	for fieldIndex, accessor := range rows.structArrayAccessors {
+		if err := checkResponseContext(rows.ctx, int64(fieldIndex)); err != nil {
+			return err
+		}
+		if accessor == nil {
+			continue
+		}
+		for rowIndex := int64(0); rowIndex < rows.rowsNum; rowIndex++ {
+			if err := checkResponseContext(rows.ctx, rowIndex); err != nil {
+				return err
+			}
+			dataIndex, valid, err := rows.fieldDataAccessors[fieldIndex].rowIndex(rowIndex)
+			if err != nil {
+				return err
+			}
+			if !valid {
+				continue
+			}
+			if err := accessor.validateRow(int(dataIndex), rowIndex); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func fieldDataName(fieldData *schemapb.FieldData) string {
+	if fieldData.GetFieldName() == "" {
+		return fieldData.GetType().String()
+	}
+	return fieldData.GetFieldName()
+}
+
+func (rows *queryResponseRows) validateJSONValues() error {
+	for fieldIndex, fieldData := range rows.fieldDataList {
+		if err := checkResponseContext(rows.ctx, int64(fieldIndex)); err != nil {
+			return err
+		}
+		switch fieldData.GetType() {
+		case schemapb.DataType_Float,
+			schemapb.DataType_Double,
+			schemapb.DataType_FloatVector,
+			schemapb.DataType_SparseFloatVector,
+			schemapb.DataType_Array:
+		default:
+			continue
+		}
+		for rowIndex := int64(0); rowIndex < rows.rowsNum; rowIndex++ {
+			if err := checkResponseContext(rows.ctx, rowIndex); err != nil {
+				return err
+			}
+			dataIndex, valid, err := rows.fieldDataAccessors[fieldIndex].rowIndex(rowIndex)
+			if err != nil {
+				return err
+			}
+			if !valid {
+				continue
+			}
+			if err := validateQueryResponseFieldValue(rows.ctx, fieldData, dataIndex, rowIndex); err != nil {
+				return err
+			}
+		}
+	}
+
+	for rowIndex := int64(0); rowIndex < rows.rowsNum && rowIndex < int64(len(rows.scores)); rowIndex++ {
+		if err := checkResponseContext(rows.ctx, rowIndex); err != nil {
+			return err
+		}
+		if !isFiniteFloat32(rows.scores[rowIndex]) {
+			return merr.WrapErrServiceInternalMsg("query response score at row %d is not finite", rowIndex)
+		}
+	}
+	return nil
+}
+
+func validateQueryResponseFieldValue(ctx context.Context, fieldData *schemapb.FieldData, dataIndex, rowIndex int64) error {
+	fieldName := fieldDataName(fieldData)
+	switch fieldData.GetType() {
+	case schemapb.DataType_Float:
+		return validateFiniteJSONValue(ctx, fieldName, rowIndex, fieldData.GetScalars().GetFloatData().GetData()[dataIndex])
+	case schemapb.DataType_Double:
+		return validateFiniteJSONValue(ctx, fieldName, rowIndex, fieldData.GetScalars().GetDoubleData().GetData()[dataIndex])
+	case schemapb.DataType_FloatVector:
+		dim := fieldData.GetVectors().GetDim()
+		data := fieldData.GetVectors().GetFloatVector().GetData()
+		start, end, err := queryResponseSliceBounds(fieldName, rowIndex, dataIndex, dim, int64(len(data)))
+		if err != nil {
+			return err
+		}
+		return validateFiniteJSONValue(ctx, fieldName, rowIndex, data[start:end])
+	case schemapb.DataType_SparseFloatVector:
+		contents := fieldData.GetVectors().GetSparseFloatVector().GetContents()[dataIndex]
+		if len(contents)%8 != 0 {
+			return merr.WrapErrServiceInternalMsg(
+				"query response sparse vector field %s row %d byte length %d is not divisible by 8",
+				fieldName, rowIndex, len(contents))
+		}
+		for offset := 4; offset < len(contents); offset += 8 {
+			if err := checkResponseContext(ctx, int64(offset/8)); err != nil {
+				return err
+			}
+			value := math.Float32frombits(common.Endian.Uint32(contents[offset : offset+4]))
+			if !isFiniteFloat32(value) {
+				return merr.WrapErrServiceInternalMsg("query response field %s row %d contains a non-finite value", fieldName, rowIndex)
+			}
+		}
+	case schemapb.DataType_Array:
+		return validateFiniteJSONValue(ctx, fieldName, rowIndex, fieldData.GetScalars().GetArrayData().GetData()[dataIndex])
+	}
+	return nil
+}
+
+func queryResponseSliceBounds(fieldName string, rowIndex, dataIndex, width, dataLength int64) (int64, int64, error) {
+	if dataIndex < 0 || width <= 0 || dataIndex > math.MaxInt64/width {
+		return 0, 0, merr.WrapErrServiceInternalMsg(
+			"query response field %s row %d has invalid physical index %d or width %d",
+			fieldName, rowIndex, dataIndex, width)
+	}
+	start := dataIndex * width
+	end := start + width
+	if end < start || end > dataLength {
+		return 0, 0, merr.WrapErrServiceInternalMsg(
+			"query response field %s row %d requires data range [%d,%d), length %d",
+			fieldName, rowIndex, start, end, dataLength)
+	}
+	return start, end, nil
+}
+
+func validateFiniteJSONValue(ctx context.Context, fieldName string, rowIndex int64, value interface{}) error {
+	if err := renderContext(ctx).Err(); err != nil {
+		return err
+	}
+	switch data := value.(type) {
+	case float32:
+		if !isFiniteFloat32(data) {
+			return merr.WrapErrServiceInternalMsg("query response field %s row %d contains a non-finite value", fieldName, rowIndex)
+		}
+	case float64:
+		if math.IsNaN(data) || math.IsInf(data, 0) {
+			return merr.WrapErrServiceInternalMsg("query response field %s row %d contains a non-finite value", fieldName, rowIndex)
+		}
+	case []float32:
+		for index, item := range data {
+			if err := checkResponseContext(ctx, int64(index)); err != nil {
+				return err
+			}
+			if !isFiniteFloat32(item) {
+				return merr.WrapErrServiceInternalMsg("query response field %s row %d contains a non-finite value", fieldName, rowIndex)
+			}
+		}
+	case []float64:
+		for index, item := range data {
+			if err := checkResponseContext(ctx, int64(index)); err != nil {
+				return err
+			}
+			if math.IsNaN(item) || math.IsInf(item, 0) {
+				return merr.WrapErrServiceInternalMsg("query response field %s row %d contains a non-finite value", fieldName, rowIndex)
+			}
+		}
+	case map[uint32]float32:
+		itemIndex := int64(0)
+		for _, item := range data {
+			if err := checkResponseContext(ctx, itemIndex); err != nil {
+				return err
+			}
+			if !isFiniteFloat32(item) {
+				return merr.WrapErrServiceInternalMsg("query response field %s row %d contains a non-finite value", fieldName, rowIndex)
+			}
+			itemIndex++
+		}
+	case map[string]interface{}:
+		itemIndex := int64(0)
+		for _, item := range data {
+			if err := checkResponseContext(ctx, itemIndex); err != nil {
+				return err
+			}
+			if err := validateFiniteJSONValue(ctx, fieldName, rowIndex, item); err != nil {
+				return err
+			}
+			itemIndex++
+		}
+	case []interface{}:
+		for index, item := range data {
+			if err := checkResponseContext(ctx, int64(index)); err != nil {
+				return err
+			}
+			if err := validateFiniteJSONValue(ctx, fieldName, rowIndex, item); err != nil {
+				return err
+			}
+		}
+	case []map[string]interface{}:
+		for index, item := range data {
+			if err := checkResponseContext(ctx, int64(index)); err != nil {
+				return err
+			}
+			if err := validateFiniteJSONValue(ctx, fieldName, rowIndex, item); err != nil {
+				return err
+			}
+		}
+	case *schemapb.ScalarField:
+		if data == nil {
+			return nil
+		}
+		switch data.GetData().(type) {
+		case *schemapb.ScalarField_FloatData:
+			return validateFiniteJSONValue(ctx, fieldName, rowIndex, data.GetFloatData().GetData())
+		case *schemapb.ScalarField_DoubleData:
+			return validateFiniteJSONValue(ctx, fieldName, rowIndex, data.GetDoubleData().GetData())
+		case *schemapb.ScalarField_ArrayData:
+			for index, nested := range data.GetArrayData().GetData() {
+				if err := checkResponseContext(ctx, int64(index)); err != nil {
+					return err
+				}
+				if err := validateFiniteJSONValue(ctx, fieldName, rowIndex, nested); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func isFiniteFloat32(value float32) bool {
+	return !math.IsNaN(float64(value)) && !math.IsInf(float64(value), 0)
+}
+
+//nolint:gosec // G602: slice indices are validated when queryResponseRows is constructed.
+func (rows *queryResponseRows) Row(i int64) (map[string]interface{}, error) {
+	if err := rows.ctx.Err(); err != nil {
+		return nil, err
+	}
+	if i < 0 || i >= rows.rowsNum {
+		return nil, merr.WrapErrServiceInternalMsg("query response row index %d out of range [0,%d)", i, rows.rowsNum)
+	}
+	row := map[string]interface{}{}
+	if len(rows.fieldDataList) > 0 {
+		for j, fieldData := range rows.fieldDataList {
+			if err := checkResponseContext(rows.ctx, int64(j)); err != nil {
+				return nil, err
+			}
+			dataIdx, valid, err := rows.fieldDataAccessors[j].rowIndex(i)
+			if err != nil {
+				return nil, err
+			}
+			if !valid {
+				if !fieldData.GetIsDynamic() {
+					row[fieldData.GetFieldName()] = nil
+				}
+				continue
+			}
+			switch fieldData.GetType() {
+			case schemapb.DataType_Bool:
+				row[fieldData.GetFieldName()] = fieldData.GetScalars().GetBoolData().GetData()[dataIdx]
+			case schemapb.DataType_Int8:
+				row[fieldData.GetFieldName()] = int8(fieldData.GetScalars().GetIntData().GetData()[dataIdx])
+			case schemapb.DataType_Int16:
+				row[fieldData.GetFieldName()] = int16(fieldData.GetScalars().GetIntData().GetData()[dataIdx])
+			case schemapb.DataType_Int32:
+				row[fieldData.GetFieldName()] = fieldData.GetScalars().GetIntData().GetData()[dataIdx]
+			case schemapb.DataType_Int64:
+				if rows.enableInt64 {
+					row[fieldData.GetFieldName()] = fieldData.GetScalars().GetLongData().GetData()[dataIdx]
+				} else {
+					row[fieldData.GetFieldName()] = strconv.FormatInt(fieldData.GetScalars().GetLongData().GetData()[dataIdx], 10)
+				}
+			case schemapb.DataType_Float:
+				row[fieldData.GetFieldName()] = fieldData.GetScalars().GetFloatData().GetData()[dataIdx]
+			case schemapb.DataType_Double:
+				row[fieldData.GetFieldName()] = fieldData.GetScalars().GetDoubleData().GetData()[dataIdx]
+			case schemapb.DataType_Timestamptz:
+				if fieldData.GetScalars().GetTimestamptzData() != nil {
+					row[fieldData.FieldName] = fieldData.GetScalars().GetTimestamptzData().GetData()[dataIdx]
+				} else {
+					row[fieldData.FieldName] = fieldData.GetScalars().GetStringData().GetData()[dataIdx]
+				}
+			case schemapb.DataType_String, schemapb.DataType_VarChar, schemapb.DataType_Text:
+				row[fieldData.GetFieldName()] = fieldData.GetScalars().GetStringData().GetData()[dataIdx]
+			case schemapb.DataType_BinaryVector:
+				row[fieldData.GetFieldName()] = fieldData.GetVectors().GetBinaryVector()[dataIdx*(fieldData.GetVectors().GetDim()/8) : (dataIdx+1)*(fieldData.GetVectors().GetDim()/8)]
+			case schemapb.DataType_FloatVector:
+				row[fieldData.GetFieldName()] = fieldData.GetVectors().GetFloatVector().GetData()[dataIdx*fieldData.GetVectors().GetDim() : (dataIdx+1)*fieldData.GetVectors().GetDim()]
+			case schemapb.DataType_Float16Vector:
+				row[fieldData.GetFieldName()] = fieldData.GetVectors().GetFloat16Vector()[dataIdx*(fieldData.GetVectors().GetDim()*2) : (dataIdx+1)*(fieldData.GetVectors().GetDim()*2)]
+			case schemapb.DataType_BFloat16Vector:
+				row[fieldData.GetFieldName()] = fieldData.GetVectors().GetBfloat16Vector()[dataIdx*(fieldData.GetVectors().GetDim()*2) : (dataIdx+1)*(fieldData.GetVectors().GetDim()*2)]
+			case schemapb.DataType_SparseFloatVector:
+				value, err := sparseFloatBytesToMapWithContext(rows.ctx, fieldData.GetVectors().GetSparseFloatVector().Contents[dataIdx])
 				if err != nil {
 					return nil, err
 				}
-				if !valid {
-					if !fieldData.GetIsDynamic() {
-						row[fieldData.GetFieldName()] = nil
-					}
-					continue
-				}
-				switch fieldDataList[j].GetType() {
-				case schemapb.DataType_Bool:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetBoolData().GetData()[dataIdx]
-				case schemapb.DataType_Int8:
-					row[fieldDataList[j].GetFieldName()] = int8(fieldDataList[j].GetScalars().GetIntData().GetData()[dataIdx])
-				case schemapb.DataType_Int16:
-					row[fieldDataList[j].GetFieldName()] = int16(fieldDataList[j].GetScalars().GetIntData().GetData()[dataIdx])
-				case schemapb.DataType_Int32:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetIntData().GetData()[dataIdx]
-				case schemapb.DataType_Int64:
-					if enableInt64 {
-						row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetLongData().GetData()[dataIdx]
-					} else {
-						row[fieldDataList[j].GetFieldName()] = strconv.FormatInt(fieldDataList[j].GetScalars().GetLongData().GetData()[dataIdx], 10)
-					}
-				case schemapb.DataType_Float:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetFloatData().GetData()[dataIdx]
-				case schemapb.DataType_Double:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetDoubleData().GetData()[dataIdx]
-				case schemapb.DataType_Timestamptz:
-					if fieldDataList[j].GetScalars().GetTimestamptzData() != nil {
-						row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetTimestamptzData().GetData()[dataIdx]
-					} else {
-						row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetStringData().GetData()[dataIdx]
-					}
-				case schemapb.DataType_String:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetStringData().GetData()[dataIdx]
-				case schemapb.DataType_VarChar:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetStringData().GetData()[dataIdx]
-				case schemapb.DataType_BinaryVector:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetBinaryVector()[dataIdx*(fieldDataList[j].GetVectors().GetDim()/8) : (dataIdx+1)*(fieldDataList[j].GetVectors().GetDim()/8)]
-				case schemapb.DataType_FloatVector:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetFloatVector().GetData()[dataIdx*fieldDataList[j].GetVectors().GetDim() : (dataIdx+1)*fieldDataList[j].GetVectors().GetDim()]
-				case schemapb.DataType_Float16Vector:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetFloat16Vector()[dataIdx*(fieldDataList[j].GetVectors().GetDim()*2) : (dataIdx+1)*(fieldDataList[j].GetVectors().GetDim()*2)]
-				case schemapb.DataType_BFloat16Vector:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetBfloat16Vector()[dataIdx*(fieldDataList[j].GetVectors().GetDim()*2) : (dataIdx+1)*(fieldDataList[j].GetVectors().GetDim()*2)]
-				case schemapb.DataType_SparseFloatVector:
-					row[fieldDataList[j].GetFieldName()] = typeutil.SparseFloatBytesToMap(fieldDataList[j].GetVectors().GetSparseFloatVector().Contents[dataIdx])
-				case schemapb.DataType_Int8Vector:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetInt8Vector()[dataIdx*fieldDataList[j].GetVectors().GetDim() : (dataIdx+1)*fieldDataList[j].GetVectors().GetDim()]
-				case schemapb.DataType_Array:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetArrayData().GetData()[dataIdx]
-				case schemapb.DataType_JSON:
-					data, ok := fieldDataList[j].GetScalars().GetData().(*schemapb.ScalarField_JsonData)
-					if ok && !fieldDataList[j].GetIsDynamic() {
-						row[fieldDataList[j].GetFieldName()] = string(data.JsonData.GetData()[dataIdx])
-					} else {
-						var dataMap map[string]interface{}
-
-						err := json.Unmarshal(fieldDataList[j].GetScalars().GetJsonData().Data[dataIdx], &dataMap)
-						if err != nil {
-							mlog.Error(context.TODO(),
-								fmt.Sprintf("[BuildQueryResp] Unmarshal error %s", err.Error()))
-							return nil, err
-						}
-
-						if containsString(dynamicOutputFields, fieldDataList[j].GetFieldName()) {
-							for key, value := range dataMap {
-								row[key] = value
-							}
-						} else {
-							for _, dynamicField := range dynamicOutputFields {
-								if _, ok := dataMap[dynamicField]; ok {
-									row[dynamicField] = dataMap[dynamicField]
-								}
-							}
-						}
-					}
-				case schemapb.DataType_Geometry:
-					if fieldDataList[j].GetScalars().GetGeometryData() != nil {
-						row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetGeometryData().GetData()[dataIdx]
-					} else {
-						row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetGeometryWktData().Data[dataIdx]
-					}
-				case schemapb.DataType_ArrayOfStruct:
-					structRow, err := structArrayAccessors[j].row(int(dataIdx))
-					if err != nil {
-						return nil, err
-					}
-					row[fieldDataList[j].GetFieldName()] = structRow
-				default:
-					row[fieldDataList[j].GetFieldName()] = ""
-				}
-			}
-		}
-		if ids != nil {
-			switch ids.GetIdField().(type) {
-			case *schemapb.IDs_IntId:
-				int64Pks := ids.GetIntId().GetData()
-				if enableInt64 {
-					row[pkFieldName] = int64Pks[i]
+				row[fieldData.GetFieldName()] = value
+			case schemapb.DataType_Int8Vector:
+				row[fieldData.GetFieldName()] = fieldData.GetVectors().GetInt8Vector()[dataIdx*fieldData.GetVectors().GetDim() : (dataIdx+1)*fieldData.GetVectors().GetDim()]
+			case schemapb.DataType_Array:
+				row[fieldData.GetFieldName()] = fieldData.GetScalars().GetArrayData().GetData()[dataIdx]
+			case schemapb.DataType_JSON:
+				data, ok := fieldData.GetScalars().GetData().(*schemapb.ScalarField_JsonData)
+				if ok && !fieldData.GetIsDynamic() {
+					row[fieldData.GetFieldName()] = string(data.JsonData.GetData()[dataIdx])
 				} else {
-					row[pkFieldName] = strconv.FormatInt(int64Pks[i], 10)
+					var dataMap map[string]interface{}
+
+					if err := json.Unmarshal(fieldData.GetScalars().GetJsonData().Data[dataIdx], &dataMap); err != nil {
+						// Preflight normally makes this unreachable. If the internal
+						// result changes or is malformed, keep the failure system-blame.
+						return nil, merr.WrapErrServiceInternalErr(err,
+							"query response dynamic field %s row %d could not be decoded",
+							fieldData.GetFieldName(), i)
+					}
+
+					if containsString(rows.dynamicOutputFields, fieldData.GetFieldName()) {
+						dynamicIndex := int64(0)
+						for key, value := range dataMap {
+							if err := checkResponseContext(rows.ctx, dynamicIndex); err != nil {
+								return nil, err
+							}
+							row[key] = value
+							dynamicIndex++
+						}
+					} else {
+						for dynamicIndex, dynamicField := range rows.dynamicOutputFields {
+							if err := checkResponseContext(rows.ctx, int64(dynamicIndex)); err != nil {
+								return nil, err
+							}
+							if _, ok := dataMap[dynamicField]; ok {
+								row[dynamicField] = dataMap[dynamicField]
+							}
+						}
+					}
 				}
-			case *schemapb.IDs_StrId:
-				stringPks := ids.GetStrId().GetData()
-				row[pkFieldName] = stringPks[i]
+			case schemapb.DataType_Geometry:
+				if fieldData.GetScalars().GetGeometryData() != nil {
+					row[fieldData.FieldName] = fieldData.GetScalars().GetGeometryData().GetData()[dataIdx]
+				} else {
+					row[fieldData.FieldName] = fieldData.GetScalars().GetGeometryWktData().Data[dataIdx]
+				}
+			case schemapb.DataType_ArrayOfStruct:
+				structRow, err := rows.structArrayAccessors[j].row(int(dataIdx))
+				if err != nil {
+					return nil, err
+				}
+				row[fieldData.GetFieldName()] = structRow
 			default:
-				return nil, merr.WrapErrParameterInvalidMsg("the type of primary key(id) is not supported, use other sdk please")
+				row[fieldData.GetFieldName()] = ""
 			}
 		}
-		if scores != nil && int64(len(scores)) > i {
-			row[HTTPReturnDistance] = scores[i] // only 8 decimal places
+	}
+	if err := rows.ctx.Err(); err != nil {
+		return nil, err
+	}
+	if rows.ids != nil {
+		switch rows.ids.GetIdField().(type) {
+		case *schemapb.IDs_IntId:
+			int64Pks := rows.ids.GetIntId().GetData()
+			if rows.enableInt64 {
+				row[rows.pkFieldName] = int64Pks[i]
+			} else {
+				row[rows.pkFieldName] = strconv.FormatInt(int64Pks[i], 10)
+			}
+		case *schemapb.IDs_StrId:
+			stringPks := rows.ids.GetStrId().GetData()
+			row[rows.pkFieldName] = stringPks[i]
+		default:
+			return nil, merr.WrapErrServiceInternalMsg("query response primary key has unsupported ID type")
+		}
+	}
+	if rows.scores != nil && int64(len(rows.scores)) > i {
+		row[HTTPReturnDistance] = rows.scores[i] // only 8 decimal places
+	}
+	return row, nil
+}
+
+func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemapb.FieldData, ids *schemapb.IDs,
+	scores []float32, enableInt64 bool, collectionSchema *schemapb.CollectionSchema,
+) ([]map[string]interface{}, error) {
+	rows, err := newQueryResponseRowsWithMode(context.Background(), rowsNum, needFields, fieldDataList, ids, scores, enableInt64, collectionSchema, false)
+	if err != nil {
+		return nil, err
+	}
+	queryResp := make([]map[string]interface{}, 0, rows.Len())
+	for rowIndex := int64(0); rowIndex < rows.Len(); rowIndex++ {
+		row, err := rows.Row(rowIndex)
+		if err != nil {
+			return nil, err
 		}
 		queryResp = append(queryResp, row)
 	}
-
 	return queryResp, nil
 }
 
@@ -2851,7 +3628,62 @@ func hasSearchAggregationResult(results *schemapb.SearchResultData) bool {
 	return results != nil && (len(results.GetAggTopks()) > 0 || len(results.GetAggBuckets()) > 0)
 }
 
-func buildSearchAggregationResp(results *schemapb.SearchResultData, enableInt64 bool, collectionSchema *schemapb.CollectionSchema) ([]gin.H, error) {
+type searchAggregationJSONSource struct {
+	aggTopks []int64
+	buckets  [][]byte
+}
+
+func (source *searchAggregationJSONSource) WriteJSON(ctx context.Context, w io.Writer) error {
+	ctx = renderContext(ctx)
+	if _, err := io.WriteString(w, "["); err != nil {
+		return err
+	}
+	offset := 0
+	for queryIndex, topk := range source.aggTopks {
+		if err := checkResponseContext(ctx, int64(queryIndex)); err != nil {
+			return err
+		}
+		if queryIndex > 0 {
+			if _, err := io.WriteString(w, ","); err != nil {
+				return err
+			}
+		}
+		if _, err := io.WriteString(w, `{"buckets":[`); err != nil {
+			return err
+		}
+		for bucketIndex := int64(0); bucketIndex < topk; bucketIndex++ {
+			if err := checkResponseContext(ctx, bucketIndex); err != nil {
+				return err
+			}
+			if offset >= len(source.buckets) {
+				return merr.WrapErrServiceInternalMsg("search aggregation JSON source exhausted at query %d bucket %d", queryIndex, bucketIndex)
+			}
+			if bucketIndex > 0 {
+				if _, err := io.WriteString(w, ","); err != nil {
+					return err
+				}
+			}
+			if _, err := w.Write(source.buckets[offset]); err != nil {
+				return err
+			}
+			offset++
+		}
+		if _, err := io.WriteString(w, "]}"); err != nil {
+			return err
+		}
+	}
+	if offset != len(source.buckets) {
+		return merr.WrapErrServiceInternalMsg("search aggregation JSON source contains %d unused buckets", len(source.buckets)-offset)
+	}
+	_, err := io.WriteString(w, "]")
+	return err
+}
+
+func buildSearchAggregationResp(ctx context.Context, results *schemapb.SearchResultData, enableInt64 bool, collectionSchema *schemapb.CollectionSchema) (*searchAggregationJSONSource, error) {
+	ctx = renderContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if results == nil {
 		// The aggregation payload is produced by the server-side reduce, never
 		// by the request: a malformed shape is an internal contract violation.
@@ -2870,9 +3702,15 @@ func buildSearchAggregationResp(results *schemapb.SearchResultData, enableInt64 
 	}
 
 	total := int64(0)
-	for _, topk := range aggTopks {
+	for queryIndex, topk := range aggTopks {
+		if err := checkResponseContext(ctx, int64(queryIndex)); err != nil {
+			return nil, err
+		}
 		if topk < 0 {
 			return nil, merr.WrapErrServiceInternalMsg("search_aggregation agg_topks cannot contain negative values")
+		}
+		if topk > math.MaxInt64-total {
+			return nil, merr.WrapErrServiceInternalMsg("search_aggregation agg_topks sum overflows int64")
 		}
 		total += topk
 	}
@@ -2880,37 +3718,59 @@ func buildSearchAggregationResp(results *schemapb.SearchResultData, enableInt64 
 		return nil, merr.WrapErrServiceInternalMsg("search_aggregation agg_topks sum %d does not match bucket count %d", total, len(pbBuckets))
 	}
 
-	output := make([]gin.H, 0, len(aggTopks))
-	offset := 0
-	for _, topk := range aggTopks {
-		buckets := make([]gin.H, 0, int(topk))
-		for i := int64(0); i < topk; i++ {
-			bucket, err := buildAggBucketResp(pbBuckets[offset], enableInt64, collectionSchema)
-			if err != nil {
-				return nil, err
-			}
-			buckets = append(buckets, bucket)
-			offset++
+	encodedBuckets := make([][]byte, 0, len(pbBuckets))
+	for bucketIndex, pbBucket := range pbBuckets {
+		if err := checkResponseContext(ctx, int64(bucketIndex)); err != nil {
+			return nil, err
 		}
-		output = append(output, gin.H{"buckets": buckets})
+		bucket, err := buildAggBucketResp(ctx, pbBucket, enableInt64, collectionSchema)
+		if err != nil {
+			return nil, err
+		}
+		encoded, err := json.Marshal(bucket)
+		if err != nil {
+			return nil, merr.WrapErrServiceInternalErr(err, "encode search aggregation bucket %d", bucketIndex)
+		}
+		encodedBuckets = append(encodedBuckets, encoded)
 	}
-	return output, nil
+	return &searchAggregationJSONSource{
+		aggTopks: append([]int64(nil), aggTopks...),
+		buckets:  encodedBuckets,
+	}, nil
 }
 
-func buildAggBucketResp(pb *schemapb.AggBucket, enableInt64 bool, collectionSchema *schemapb.CollectionSchema) (gin.H, error) {
+func buildAggBucketResp(ctx context.Context, pb *schemapb.AggBucket, enableInt64 bool, collectionSchema *schemapb.CollectionSchema) (gin.H, error) {
+	if err := renderContext(ctx).Err(); err != nil {
+		return nil, err
+	}
 	if pb == nil {
 		return nil, merr.WrapErrServiceInternalMsg("search_aggregation bucket is nil")
 	}
+	keys, err := buildAggBucketKeyResp(ctx, pb.GetKey(), enableInt64)
+	if err != nil {
+		return nil, err
+	}
+	metricsResp, err := buildAggMetricsResp(ctx, pb.GetMetrics(), enableInt64)
+	if err != nil {
+		return nil, err
+	}
+	hits, err := buildAggHitsResp(ctx, pb.GetHits(), enableInt64, collectionSchema)
+	if err != nil {
+		return nil, err
+	}
 	bucket := gin.H{
-		"key":       buildAggBucketKeyResp(pb.GetKey(), enableInt64),
+		"key":       keys,
 		"count":     formatRESTInt64(pb.GetCount(), enableInt64),
-		"metrics":   buildAggMetricsResp(pb.GetMetrics(), enableInt64),
-		"hits":      buildAggHitsResp(pb.GetHits(), enableInt64, collectionSchema),
+		"metrics":   metricsResp,
+		"hits":      hits,
 		"subGroups": []gin.H{},
 	}
 	subGroups := make([]gin.H, 0, len(pb.GetSubGroups()))
-	for _, sub := range pb.GetSubGroups() {
-		subGroup, err := buildAggBucketResp(sub, enableInt64, collectionSchema)
+	for subIndex, sub := range pb.GetSubGroups() {
+		if err := checkResponseContext(ctx, int64(subIndex)); err != nil {
+			return nil, err
+		}
+		subGroup, err := buildAggBucketResp(ctx, sub, enableInt64, collectionSchema)
 		if err != nil {
 			return nil, err
 		}
@@ -2920,9 +3780,12 @@ func buildAggBucketResp(pb *schemapb.AggBucket, enableInt64 bool, collectionSche
 	return bucket, nil
 }
 
-func buildAggBucketKeyResp(keys []*schemapb.BucketKeyEntry, enableInt64 bool) []gin.H {
+func buildAggBucketKeyResp(ctx context.Context, keys []*schemapb.BucketKeyEntry, enableInt64 bool) ([]gin.H, error) {
 	resp := make([]gin.H, 0, len(keys))
-	for _, key := range keys {
+	for keyIndex, key := range keys {
+		if err := checkResponseContext(ctx, int64(keyIndex)); err != nil {
+			return nil, err
+		}
 		if key == nil {
 			resp = append(resp, gin.H{})
 			continue
@@ -2937,21 +3800,29 @@ func buildAggBucketKeyResp(keys []*schemapb.BucketKeyEntry, enableInt64 bool) []
 			"value":     bucketKeyEntryValueToRESTAny(key, enableInt64),
 		})
 	}
-	return resp
+	return resp, nil
 }
 
-func buildAggMetricsResp(metrics map[string]*schemapb.MetricValue, enableInt64 bool) gin.H {
+func buildAggMetricsResp(ctx context.Context, metrics map[string]*schemapb.MetricValue, enableInt64 bool) (gin.H, error) {
 	resp := make(gin.H, len(metrics))
+	metricIndex := int64(0)
 	for alias, metric := range metrics {
+		if err := checkResponseContext(ctx, metricIndex); err != nil {
+			return nil, err
+		}
 		resp[alias] = metricValueToRESTAny(metric, enableInt64)
+		metricIndex++
 	}
-	return resp
+	return resp, nil
 }
 
-func buildAggHitsResp(hits []*schemapb.AggHit, enableInt64 bool, collectionSchema *schemapb.CollectionSchema) []gin.H {
+func buildAggHitsResp(ctx context.Context, hits []*schemapb.AggHit, enableInt64 bool, collectionSchema *schemapb.CollectionSchema) ([]gin.H, error) {
 	resp := make([]gin.H, 0, len(hits))
 	pkFieldName := getRESTPrimaryFieldName(collectionSchema)
-	for _, hit := range hits {
+	for hitIndex, hit := range hits {
+		if err := checkResponseContext(ctx, int64(hitIndex)); err != nil {
+			return nil, err
+		}
 		if hit == nil {
 			resp = append(resp, gin.H{})
 			continue
@@ -2960,7 +3831,10 @@ func buildAggHitsResp(hits []*schemapb.AggHit, enableInt64 bool, collectionSchem
 			pkFieldName:        aggHitPKToRESTAny(hit, enableInt64),
 			HTTPReturnDistance: hit.GetScore(),
 		}
-		for _, field := range hit.GetFields() {
+		for fieldIndex, field := range hit.GetFields() {
+			if err := checkResponseContext(ctx, int64(fieldIndex)); err != nil {
+				return nil, err
+			}
 			if field == nil {
 				continue
 			}
@@ -2972,7 +3846,7 @@ func buildAggHitsResp(hits []*schemapb.AggHit, enableInt64 bool, collectionSchem
 		}
 		resp = append(resp, row)
 	}
-	return resp
+	return resp, nil
 }
 
 func getRESTPrimaryFieldName(collectionSchema *schemapb.CollectionSchema) string {

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -17,6 +17,7 @@
 package httpserver
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -3008,7 +3009,7 @@ func TestBuildQueryResps(t *testing.T) {
 
 	_, err := buildQueryResp(int64(0), outputFields, newFieldData([]*schemapb.FieldData{}, 1000), generateIDs(schemapb.DataType_Int64, 3), DefaultScores, true, nil)
 	assert.Contains(t, err.Error(), "the type(1000) of field(wrong-field-type) is not supported, use other sdk please")
-	assert.True(t, errors.Is(err, merr.ErrParameterInvalid))
+	assert.True(t, errors.Is(err, merr.ErrServiceInternal))
 
 	res, err := buildQueryResp(int64(0), outputFields, []*schemapb.FieldData{}, generateIDs(schemapb.DataType_Int64, 3), DefaultScores, true, nil)
 	assert.Equal(t, 3, len(res))
@@ -3381,48 +3382,52 @@ func TestBuildSearchAggregationResp(t *testing.T) {
 		},
 	}
 
-	resp, err := buildSearchAggregationResp(results, false, generateCollectionSchema(schemapb.DataType_Int64, false, true))
+	resp, err := buildSearchAggregationResp(context.Background(), results, false, generateCollectionSchema(schemapb.DataType_Int64, false, true))
 	require.NoError(t, err)
-	require.Len(t, resp, 1)
-	buckets := resp[0]["buckets"].([]gin.H)
-	require.Len(t, buckets, 1)
-	bucket := buckets[0]
-	require.Equal(t, "3", bucket["count"])
+	var encoded bytes.Buffer
+	require.NoError(t, resp.WriteJSON(context.Background(), &encoded))
+	require.True(t, gjson.ValidBytes(encoded.Bytes()))
+	require.Equal(t, "3", gjson.GetBytes(encoded.Bytes(), "0.buckets.0.count").String())
+	require.Equal(t, "brand", gjson.GetBytes(encoded.Bytes(), "0.buckets.0.key.0.fieldName").String())
+	require.Equal(t, "101", gjson.GetBytes(encoded.Bytes(), "0.buckets.0.key.0.fieldId").String())
+	require.Equal(t, "acme", gjson.GetBytes(encoded.Bytes(), "0.buckets.0.key.0.value").String())
+	require.Equal(t, "9", gjson.GetBytes(encoded.Bytes(), "0.buckets.0.key.1.value").String())
+	require.Equal(t, 12.5, gjson.GetBytes(encoded.Bytes(), "0.buckets.0.metrics.avg_price").Float())
+	require.Equal(t, "7", gjson.GetBytes(encoded.Bytes(), "0.buckets.0.metrics.stock").String())
+	require.Equal(t, "1001", gjson.GetBytes(encoded.Bytes(), "0.buckets.0.hits.0.book_id").String())
+	require.InDelta(t, 0.8, gjson.GetBytes(encoded.Bytes(), "0.buckets.0.hits.0.distance").Float(), 0.0001)
+	require.Equal(t, "99", gjson.GetBytes(encoded.Bytes(), "0.buckets.0.hits.0.price").String())
+	require.Equal(t, "item", gjson.GetBytes(encoded.Bytes(), "0.buckets.0.hits.0.title").String())
+	require.Equal(t, "1", gjson.GetBytes(encoded.Bytes(), "0.buckets.0.subGroups.0.count").String())
 
-	keys := bucket["key"].([]gin.H)
-	require.Equal(t, "brand", keys[0]["fieldName"])
-	require.Equal(t, "101", keys[0]["fieldId"])
-	require.Equal(t, "acme", keys[0]["value"])
-	require.Equal(t, "9", keys[1]["value"])
-
-	metrics := bucket["metrics"].(gin.H)
-	require.Equal(t, 12.5, metrics["avg_price"])
-	require.Equal(t, "7", metrics["stock"])
-
-	hits := bucket["hits"].([]gin.H)
-	require.Equal(t, "1001", hits[0][FieldBookID])
-	require.Equal(t, float32(0.8), hits[0][HTTPReturnDistance])
-	require.Equal(t, "99", hits[0]["price"])
-	require.Equal(t, "item", hits[0]["title"])
-
-	subGroups := bucket["subGroups"].([]gin.H)
-	require.Equal(t, "1", subGroups[0]["count"])
-
-	_, err = buildSearchAggregationResp(&schemapb.SearchResultData{NumQueries: 1, AggBuckets: results.GetAggBuckets()}, true, nil)
+	_, err = buildSearchAggregationResp(context.Background(), &schemapb.SearchResultData{NumQueries: 1, AggBuckets: results.GetAggBuckets()}, true, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "missing agg_topks")
 
-	_, err = buildSearchAggregationResp(&schemapb.SearchResultData{AggTopks: []int64{1}, AggBuckets: results.GetAggBuckets()}, true, nil)
+	_, err = buildSearchAggregationResp(context.Background(), &schemapb.SearchResultData{AggTopks: []int64{1}, AggBuckets: results.GetAggBuckets()}, true, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "missing nq")
 
-	_, err = buildSearchAggregationResp(&schemapb.SearchResultData{NumQueries: 2, AggTopks: []int64{1}, AggBuckets: results.GetAggBuckets()}, true, nil)
+	_, err = buildSearchAggregationResp(context.Background(), &schemapb.SearchResultData{NumQueries: 2, AggTopks: []int64{1}, AggBuckets: results.GetAggBuckets()}, true, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "does not match nq")
 
-	_, err = buildSearchAggregationResp(&schemapb.SearchResultData{NumQueries: 1, AggTopks: []int64{2}, AggBuckets: results.GetAggBuckets()}, true, nil)
+	_, err = buildSearchAggregationResp(context.Background(), &schemapb.SearchResultData{NumQueries: 1, AggTopks: []int64{2}, AggBuckets: results.GetAggBuckets()}, true, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "does not match bucket count")
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = buildSearchAggregationResp(canceledCtx, results, true, nil)
+	require.ErrorIs(t, err, context.Canceled)
+
+	invalidMetric := proto.Clone(results).(*schemapb.SearchResultData)
+	invalidMetric.AggBuckets[0].Metrics["avg_price"] = &schemapb.MetricValue{
+		Value: &schemapb.MetricValue_DoubleVal{DoubleVal: math.NaN()},
+	}
+	_, err = buildSearchAggregationResp(context.Background(), invalidMetric, true, nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, merr.ErrServiceInternal)
 }
 
 func TestGenFunctionSchem(t *testing.T) {
@@ -4738,7 +4743,7 @@ func TestStructArrayHelperValueConversions(t *testing.T) {
 			count, err := vectorFieldElemCount(test.vector, test.elementType, test.dim)
 			require.NoError(t, err)
 			assert.Equal(t, test.count, count)
-			values, err := vectorFieldToInterfaces(test.vector, test.elementType, test.dim)
+			values, err := vectorFieldToInterfaces(context.Background(), test.vector, test.elementType, test.dim)
 			require.NoError(t, err)
 			assert.Len(t, values, test.count)
 		})
@@ -4748,10 +4753,68 @@ func TestStructArrayHelperValueConversions(t *testing.T) {
 	assert.Error(t, err)
 	_, err = vectorFieldElemCount(&schemapb.VectorField{}, schemapb.DataType_JSON, 1)
 	assert.Error(t, err)
-	_, err = vectorFieldToInterfaces(&schemapb.VectorField{}, schemapb.DataType_FloatVector, 0)
+	_, err = vectorFieldToInterfaces(context.Background(), &schemapb.VectorField{}, schemapb.DataType_FloatVector, 0)
 	assert.Error(t, err)
-	_, err = vectorFieldToInterfaces(&schemapb.VectorField{}, schemapb.DataType_JSON, 1)
+	_, err = vectorFieldToInterfaces(context.Background(), &schemapb.VectorField{}, schemapb.DataType_JSON, 1)
 	assert.Error(t, err)
+}
+
+func TestVectorFieldToInterfacesStopsOnCancellation(t *testing.T) {
+	tests := []struct {
+		name        string
+		elementType schemapb.DataType
+		vector      *schemapb.VectorField
+		dim         int64
+	}{
+		{
+			name:        "float",
+			elementType: schemapb.DataType_FloatVector,
+			vector: &schemapb.VectorField{Data: &schemapb.VectorField_FloatVector{
+				FloatVector: &schemapb.FloatArray{Data: make([]float32, 8)},
+			}},
+			dim: 2,
+		},
+		{
+			name:        "float16",
+			elementType: schemapb.DataType_Float16Vector,
+			vector: &schemapb.VectorField{Data: &schemapb.VectorField_Float16Vector{
+				Float16Vector: make([]byte, 16),
+			}},
+			dim: 2,
+		},
+		{
+			name:        "bfloat16",
+			elementType: schemapb.DataType_BFloat16Vector,
+			vector: &schemapb.VectorField{Data: &schemapb.VectorField_Bfloat16Vector{
+				Bfloat16Vector: make([]byte, 16),
+			}},
+			dim: 2,
+		},
+		{
+			name:        "binary",
+			elementType: schemapb.DataType_BinaryVector,
+			vector: &schemapb.VectorField{Data: &schemapb.VectorField_BinaryVector{
+				BinaryVector: make([]byte, 8),
+			}},
+			dim: 16,
+		},
+		{
+			name:        "int8",
+			elementType: schemapb.DataType_Int8Vector,
+			vector: &schemapb.VectorField{Data: &schemapb.VectorField_Int8Vector{
+				Int8Vector: make([]byte, 8),
+			}},
+			dim: 2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := newCancelAfterErrChecksContext(2)
+			_, err := vectorFieldToInterfaces(ctx, test.vector, test.elementType, test.dim)
+			require.ErrorIs(t, err, context.Canceled)
+		})
+	}
 }
 
 func TestStructArrayCheckAndSetPartialUpdate(t *testing.T) {

--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -221,17 +221,18 @@ func (s *Server) startHTTPServer(errChan chan error) {
 	if proxy.Params.CommonCfg.AuthorizationEnabled.GetAsBool() {
 		ginHandler.Use(authenticate)
 	}
+	Params := &proxy.Params.HTTPCfg
+	writeTimeout := Params.WriteTimeout.GetAsDurationByParse()
 	app := ginHandler.Group("/v1")
 	httpserver.NewHandlersV1(s.proxy).RegisterRoutesToV1(app)
 	appV2 := ginHandler.Group("/v2/vectordb")
-	httpserver.NewHandlersV2(s.proxy).RegisterRoutesToV2(appV2)
+	httpserver.NewHandlersV2(s.proxy, writeTimeout).RegisterRoutesToV2(appV2)
 	http2Server := &http2.Server{}
-	Params := &proxy.Params.HTTPCfg
 	s.httpServer = &http.Server{
 		Handler:           h2c.NewHandler(s.httpHandler(ginHandler), http2Server),
 		ReadHeaderTimeout: Params.ReadHeaderTimeout.GetAsDurationByParse(),
 		ReadTimeout:       Params.ReadTimeout.GetAsDurationByParse(),
-		WriteTimeout:      Params.WriteTimeout.GetAsDurationByParse(),
+		WriteTimeout:      writeTimeout,
 		IdleTimeout:       Params.IdleTimeout.GetAsDurationByParse(),
 		MaxHeaderBytes:    Params.MaxHeaderBytes.GetAsInt(),
 	}

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1548,6 +1548,9 @@ func translatePkOutputFields(schema *schemapb.CollectionSchema) ([]string, []int
 }
 
 func recallCal[T string | int64](results []T, gts []T) float32 {
+	if len(results) == 0 {
+		return 0
+	}
 	hit := 0
 	total := 0
 	for _, r := range results {

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -3669,6 +3669,30 @@ func TestComputeRecall(t *testing.T) {
 		assert.Equal(t, result1.Recalls[1], float32(0.8))
 	})
 
+	t.Run("mixed queries with zero-hit result", func(t *testing.T) {
+		result := &schemapb.SearchResultData{
+			NumQueries: 2,
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2}},
+				},
+			},
+			Topks: []int64{2, 0},
+		}
+		gt := &schemapb.SearchResultData{
+			NumQueries: 2,
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 3, 4, 5}},
+				},
+			},
+			Topks: []int64{2, 2},
+		}
+
+		require.NoError(t, computeRecall(result, gt))
+		assert.Equal(t, []float32{0.5, 0}, result.Recalls)
+	})
+
 	t.Run("not match size", func(t *testing.T) {
 		result1 := &schemapb.SearchResultData{
 			NumQueries: 2,


### PR DESCRIPTION
issue: #52188
pr: #52215

## Summary

- Cherry-pick the REST V2 large-response streaming change from #52215 onto the 3.0 branch.
- Carry over the row-streaming, timeout/write-deadline handling, result-conversion propagation, and associated coverage.