### PR TITLE
fix: refund delegator bloom filters on load failure

### DIFF
--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -727,6 +727,17 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 			log.Warn(ctx, "failed to load bloom filter set for segment", mlog.Err(err))
 			return err
 		}
+		candidatesPublished := false
+		defer func() {
+			if candidatesPublished {
+				return
+			}
+			for _, candidate := range candidates {
+				if candidate != nil {
+					candidate.Refund()
+				}
+			}
+		}()
 
 		// Load BM25 stats BEFORE loadStreamDelete so stats are ready before segment becomes visible
 		err = sd.loadBM25Stats(ctx, infos, req)
@@ -767,6 +778,7 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 			// automatically by SyncDistribution when the segment is not in target.
 			return err
 		}
+		candidatesPublished = true
 		log.Debug(ctx, "load stream delete done")
 
 		return nil

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -1289,6 +1289,66 @@ func (s *DelegatorDataSuite) TestLoadSegments() {
 		s.Error(err)
 	})
 
+	s.Run("post_load_failure_refunds_bloom_filter_set", func() {
+		defer func() {
+			s.workerManager.ExpectedCalls = nil
+			s.loader.ExpectedCalls = nil
+		}()
+
+		bfs := pkoracle.NewBloomFilterSet(100, 500, commonpb.SegmentState_Sealed)
+		bf := bloomfilter.NewBloomFilterWithType(
+			paramtable.Get().CommonCfg.BloomFilterSize.GetAsUint(),
+			paramtable.Get().CommonCfg.MaxBloomFalsePositive.GetAsFloat(),
+			paramtable.Get().CommonCfg.BloomFilterType.GetValue())
+		pks := &storage.PkStatistics{
+			PkFilter: bf,
+		}
+		pks.UpdatePKRange(&storage.Int64FieldData{
+			Data: []int64{10, 20, 30},
+		})
+		bfs.AddHistoricalStats(pks)
+		bfs.SetResourceCharged(true)
+		s.True(bfs.IsResourceCharged())
+
+		s.loader.EXPECT().LoadBloomFilterSet(mock.Anything, s.collectionID, mock.Anything).
+			Return([]*pkoracle.BloomFilterSet{bfs}, nil)
+
+		workers := make(map[int64]*cluster.MockWorker)
+		worker1 := &cluster.MockWorker{}
+		workers[1] = worker1
+
+		worker1.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).
+			Return(nil)
+		s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).Call.Return(func(_ context.Context, nodeID int64) cluster.Worker {
+			return workers[nodeID]
+		}, nil)
+
+		s.delegator.schemaBarrierTs = 1
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		err := s.delegator.LoadSegments(ctx, &querypb.LoadSegmentsRequest{
+			Base:         commonpbutil.NewMsgBase(),
+			DstNodeID:    1,
+			CollectionID: s.collectionID,
+			LoadMeta: &querypb.LoadMetaInfo{
+				SchemaBarrierTs: 0,
+			},
+			Infos: []*querypb.SegmentLoadInfo{
+				{
+					SegmentID:     100,
+					PartitionID:   500,
+					StartPosition: &msgpb.MsgPosition{Timestamp: 20000},
+					DeltaPosition: &msgpb.MsgPosition{Timestamp: 20000},
+					Level:         datapb.SegmentLevel_L1,
+					InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
+				},
+			},
+		})
+
+		s.ErrorIs(err, merr.ErrServiceInternal)
+		s.False(bfs.IsResourceCharged())
+	})
+
 	s.Run("worker_load_fail", func() {
 		defer func() {
 			s.workerManager.ExpectedCalls = nil


### PR DESCRIPTION
issue: #52327

## What changed

`LoadSegments` now refunds loaded BF candidates when post-load processing fails before `loadStreamDelete` publishes the segment entries into `distribution`. Once `loadStreamDelete` succeeds, ownership stays with `distribution` as before.

## Why

`LoadBloomFilterSet` may return charged `BloomFilterSet` candidates. If a later pre-publish step fails, such as a schema barrier check, those candidates are not reachable by `distribution` cleanup and remain charged.

## Tests

```bash
conda run -n milvus2 bash -lc 'export GOWORK=off; export PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig:/home/sheep/workspace/milvus/cmake_build/thirdparty/milvus-storage:${PKG_CONFIG_PATH:-}; export LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:/home/sheep/workspace/milvus/cmake_build/lib:${LD_LIBRARY_PATH:-}; go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/querynodev2/delegator -run "TestDelegatorDataSuite/TestLoadSegments/post_load_failure_refunds_bloom_filter_set"'\n```\n\n```bash\nconda run -n milvus2 bash -lc 'export GOWORK=off; export PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig:/home/sheep/workspace/milvus/cmake_build/thirdparty/milvus-storage:${PKG_CONFIG_PATH:-}; export LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:/home/sheep/workspace/milvus/cmake_build/lib:${LD_LIBRARY_PATH:-}; go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/querynodev2/delegator'\n```\n\n```bash\nconda run -n milvus2 bash -lc 'export GOWORK=off; make static-check'\n```\n