### PR TITLE
fix: preserve absent TTL as null (#51649)

### DIFF
--- a/internal/datanode/compactor/bump_schema_version_compactor.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor.go
@@ -454,6 +454,10 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 	}
 	entityFilter := compaction.NewEntityFilter(delta, t.plan.GetCollectionTtl(), t.currentTime, segment.GetCommitTimestamp())
 	ttlFieldID := getTTLFieldID(t.plan.GetSchema())
+	var preserveNullFields map[int64]struct{}
+	if ttlFieldID >= common.StartOfUserFieldID {
+		preserveNullFields = map[int64]struct{}{ttlFieldID: {}}
+	}
 	reader, _, err := newCompactionSegmentRecordReaderWithFields(t.ctx, segment, t.plan.GetSchema(), t.compactionParams.StorageConfig, existingFields,
 		storage.WithCollectionID(collectionID),
 		storage.WithVersion(segment.GetStorageVersion()),
@@ -465,7 +469,7 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 	}
 	defer reader.Close()
 
-	materializer, err := NewRecordMaterializer(t.plan.GetSchema(), t.plan.GetSchema().GetFunctions(), existingFields)
+	materializer, err := newRecordMaterializer(t.plan.GetSchema(), t.plan.GetSchema().GetFunctions(), existingFields, preserveNullFields)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/datanode/compactor/bump_schema_version_compactor.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor.go
@@ -514,6 +514,11 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 		}
 	}()
 
+	// Source TTL presence is decided from existingFields, never by probing the
+	// record: V2/V3 records panic on Column for a field they do not carry.
+	_, sourceHasTTL := existingFields[ttlFieldID]
+	sourceHasTTLField := ttlFieldID >= common.StartOfUserFieldID && sourceHasTTL
+	preMaterializeFilter := len(delta) > 0 || t.plan.GetCollectionTtl() > 0 || sourceHasTTLField
 	var totalRows int64
 	for {
 		record, err := reader.Next()
@@ -524,8 +529,6 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 			return nil, err
 		}
 
-		sourceHasTTLField := ttlFieldID >= common.StartOfUserFieldID && record.Column(ttlFieldID) != nil
-		preMaterializeFilter := len(delta) > 0 || t.plan.GetCollectionTtl() > 0 || sourceHasTTLField
 		var selection *recordSelection
 		if preMaterializeFilter {
 			selection, _, err = selectFullRewriteRecord(record, pkField, entityFilter, ttlFieldID, sourceHasTTLField, nil)

--- a/internal/datanode/compactor/bump_schema_version_compactor_test.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor_test.go
@@ -1510,6 +1510,48 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteMissingTTLFieldDoe
 	// Source segment carries a dropped field (103) -> droppedFieldIDs>0 -> full rewrite.
 	s.prepareBumpSchemaVersionCompactionWithDroppedField()
 
+	// Attach a real V3 manifest deltalog so the full rewrite filters one row and
+	// exercises selection/newSelectedRecord against the packed source record.
+	sourceSegment := s.task.plan.GetSegmentBinlogs()[0]
+	const deltaLogID = int64(20000)
+	basePath, _, err := packed.UnmarshalManifestPath(sourceSegment.GetManifest())
+	s.Require().NoError(err)
+	deltaPath := metautil.BuildDeltaLogPathV3(basePath, deltaLogID)
+	deleteRecord, _, _, err := storage.BuildDeleteRecord(
+		[]storage.PrimaryKey{storage.NewInt64PrimaryKey(sourceSegment.GetSegmentID())},
+		[]uint64{tsoutil.ComposeTSByTime(getMilvusBirthday().Add(time.Second))},
+	)
+	s.Require().NoError(err)
+	defer deleteRecord.Release()
+	deltaWriter, err := storage.NewDeltalogWriter(
+		context.Background(),
+		sourceSegment.GetCollectionID(),
+		sourceSegment.GetPartitionID(),
+		sourceSegment.GetSegmentID(),
+		deltaLogID,
+		schemapb.DataType_Int64,
+		deltaPath,
+		storage.WithVersion(storage.StorageV2),
+		storage.WithStorageConfig(s.task.compactionParams.StorageConfig),
+	)
+	s.Require().NoError(err)
+	s.Require().NoError(deltaWriter.Write(deleteRecord))
+	s.Require().NoError(deltaWriter.Close())
+	sourceSegment.Manifest, err = packed.AddDeltaLogsToManifest(
+		sourceSegment.GetManifest(),
+		s.task.compactionParams.StorageConfig,
+		[]packed.DeltaLogEntry{{Path: deltaPath, NumEntries: 1}},
+	)
+	s.Require().NoError(err)
+	sourceSegment.Deltalogs = []*datapb.FieldBinlog{{
+		FieldID: 100,
+		Binlogs: []*datapb.Binlog{{
+			LogID:      deltaLogID,
+			LogPath:    deltaPath,
+			EntriesNum: 1,
+		}},
+	}}
+
 	result, err := s.task.Compact()
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
@@ -1517,7 +1559,7 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteMissingTTLFieldDoe
 	s.Require().Len(result.GetSegments(), 1)
 
 	segment := result.GetSegments()[0]
-	s.EqualValues(3, segment.GetNumOfRows())
+	s.EqualValues(2, segment.GetNumOfRows())
 
 	reader, err := storage.NewManifestRecordReader(
 		context.Background(),
@@ -1534,5 +1576,5 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteMissingTTLFieldDoe
 	s.Require().NoError(err)
 	ttlColumn, ok := record.Column(newTTLFieldID).(*array.Int64)
 	s.Require().True(ok)
-	s.Equal(3, ttlColumn.NullN())
+	s.Equal(2, ttlColumn.NullN())
 }

--- a/internal/datanode/compactor/bump_schema_version_compactor_test.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor_test.go
@@ -1486,6 +1486,8 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionInputSchemaByF
 // TTL column.
 func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteMissingTTLFieldDoesNotProbeRecord() {
 	const newTTLFieldID = int64(105)
+	s.task.currentTime = getMilvusBirthday().Add(time.Hour)
+	expiredDefault := s.task.currentTime.Add(-time.Minute).UnixMicro()
 	// Target schema gains a nullable Timestamptz field absent from the source
 	// segment and designates it as the collection TTL field.
 	s.task.plan.Schema.Fields = append(s.task.plan.Schema.Fields, &schemapb.FieldSchema{
@@ -1493,6 +1495,9 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteMissingTTLFieldDoe
 		Name:     "expire_at",
 		DataType: schemapb.DataType_Timestamptz,
 		Nullable: true,
+		DefaultValue: &schemapb.ValueField{Data: &schemapb.ValueField_TimestamptzData{
+			TimestamptzData: expiredDefault,
+		}},
 	})
 	s.task.plan.Schema.Properties = append(s.task.plan.Schema.Properties, &commonpb.KeyValuePair{
 		Key:   common.CollectionTTLFieldKey,
@@ -1513,4 +1518,21 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteMissingTTLFieldDoe
 
 	segment := result.GetSegments()[0]
 	s.EqualValues(3, segment.GetNumOfRows())
+
+	reader, err := storage.NewManifestRecordReader(
+		context.Background(),
+		segment.GetManifest(),
+		s.task.plan.GetSchema(),
+		storage.WithCollectionID(s.task.plan.GetSegmentBinlogs()[0].GetCollectionID()),
+		storage.WithVersion(segment.GetStorageVersion()),
+		storage.WithStorageConfig(s.task.compactionParams.StorageConfig),
+	)
+	s.Require().NoError(err)
+	defer reader.Close()
+
+	record, err := reader.Next()
+	s.Require().NoError(err)
+	ttlColumn, ok := record.Column(newTTLFieldID).(*array.Int64)
+	s.Require().True(ok)
+	s.Equal(3, ttlColumn.NullN())
 }

--- a/internal/datanode/compactor/bump_schema_version_compactor_test.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor_test.go
@@ -1477,3 +1477,40 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionInputSchemaByF
 	s.ErrorContains(err, "references by_field lang of type")
 	s.ErrorContains(err, "only VarChar is allowed")
 }
+
+// TestFullRewriteMissingTTLFieldDoesNotProbeRecord is the real-cgo regression
+// for the source-TTL presence check: the target schema designates a TTL field that
+// old segments do not carry, and a dropped field routes them through full rewrite.
+// Presence must be decided from existingFields; probing record.Column(ttlFieldID)
+// panics on V3 records ("no such field") before the materializer can fill the null
+// TTL column.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteMissingTTLFieldDoesNotProbeRecord() {
+	const newTTLFieldID = int64(105)
+	// Target schema gains a nullable Timestamptz field absent from the source
+	// segment and designates it as the collection TTL field.
+	s.task.plan.Schema.Fields = append(s.task.plan.Schema.Fields, &schemapb.FieldSchema{
+		FieldID:  newTTLFieldID,
+		Name:     "expire_at",
+		DataType: schemapb.DataType_Timestamptz,
+		Nullable: true,
+	})
+	s.task.plan.Schema.Properties = append(s.task.plan.Schema.Properties, &commonpb.KeyValuePair{
+		Key:   common.CollectionTTLFieldKey,
+		Value: "expire_at",
+	})
+	params, err := compaction.GenerateJSONParams(s.task.plan.GetSchema())
+	s.Require().NoError(err)
+	s.task.plan.JsonParams = params
+
+	// Source segment carries a dropped field (103) -> droppedFieldIDs>0 -> full rewrite.
+	s.prepareBumpSchemaVersionCompactionWithDroppedField()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+	s.Equal(datapb.CompactionTaskState_completed, result.GetState())
+	s.Require().Len(result.GetSegments(), 1)
+
+	segment := result.GetSegments()[0]
+	s.EqualValues(3, segment.GetNumOfRows())
+}

--- a/internal/datanode/compactor/record_materializer.go
+++ b/internal/datanode/compactor/record_materializer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/apache/arrow/go/v17/arrow/memory"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
@@ -54,14 +55,23 @@ func (s *recordSelection) Len() int {
 }
 
 type RecordMaterializer struct {
-	materializers  []FunctionMaterializer
-	missingFields  []*schemapb.FieldSchema
-	schema         *schemapb.CollectionSchema
-	existingFields map[int64]struct{}
+	materializers      []FunctionMaterializer
+	missingFields      []*schemapb.FieldSchema
+	schema             *schemapb.CollectionSchema
+	existingFields     map[int64]struct{}
+	preserveNullFields map[int64]struct{}
 }
 
 func NewRecordMaterializer(schema *schemapb.CollectionSchema, functions []*schemapb.FunctionSchema, existingFields map[int64]struct{}) (*RecordMaterializer, error) {
-	materializer := &RecordMaterializer{schema: schema, existingFields: existingFields}
+	return newRecordMaterializer(schema, functions, existingFields, nil)
+}
+
+func newRecordMaterializer(schema *schemapb.CollectionSchema, functions []*schemapb.FunctionSchema, existingFields, preserveNullFields map[int64]struct{}) (*RecordMaterializer, error) {
+	materializer := &RecordMaterializer{
+		schema:             schema,
+		existingFields:     existingFields,
+		preserveNullFields: preserveNullFields,
+	}
 	materializedFields := make(map[int64]struct{})
 	for _, functionSchema := range functions {
 		outputIndexes := functionOutputIndexesToMaterialize(functionSchema, existingFields)
@@ -106,7 +116,7 @@ func (m *RecordMaterializer) Wrap(rec storage.Record) (storage.Record, error) {
 func (m *RecordMaterializer) WrapWithSelection(rec storage.Record, selection *recordSelection) (storage.Record, error) {
 	base := rec
 	if selection != nil {
-		selected, err := newSelectedRecord(rec, m.schema, m.existingFields, selection)
+		selected, err := newSelectedRecord(rec, m.schema, m.existingFields, m.preserveNullFields, selection)
 		if err != nil {
 			return nil, err
 		}
@@ -133,7 +143,7 @@ func (m *RecordMaterializer) WrapWithSelection(rec storage.Record, selection *re
 		if _, ok := computed[fieldID]; ok {
 			continue
 		}
-		arr, err := storage.GenerateEmptyArrayFromSchema(field, base.Len())
+		arr, err := storage.GenerateEmptyArrayFromSchema(fieldForMaterialization(field, m.preserveNullFields), base.Len())
 		if err != nil {
 			releaseArrowArrays(computed)
 			cleanupMaterializedRecord(base)
@@ -158,6 +168,21 @@ func (m *RecordMaterializer) Close() {
 
 func (m *RecordMaterializer) hasMaterialization() bool {
 	return m != nil && (len(m.materializers) > 0 || len(m.missingFields) > 0)
+}
+
+// fieldForMaterialization returns a schema view that preserves physical NULLs
+// for fields whose defaults must not be applied during compaction. The shared
+// collection schema remains unchanged for all other consumers.
+func fieldForMaterialization(field *schemapb.FieldSchema, preserveNullFields map[int64]struct{}) *schemapb.FieldSchema {
+	if field.GetDefaultValue() == nil {
+		return field
+	}
+	if _, ok := preserveNullFields[field.GetFieldID()]; !ok {
+		return field
+	}
+	cloned := proto.Clone(field).(*schemapb.FieldSchema)
+	cloned.DefaultValue = nil
+	return cloned
 }
 
 type materializedRecord struct {
@@ -215,14 +240,14 @@ var _ storage.Record = (*selectedRecord)(nil)
 // (e.g. timestampOverwriteRecord) would escape the snapshot and be released
 // once more than it was retained. Presence is decided by existingFields, never
 // by probing base.Column: V2/V3 records panic on Column for absent fields.
-func newSelectedRecord(base storage.Record, schema *schemapb.CollectionSchema, existingFields map[int64]struct{}, selection *recordSelection) (*selectedRecord, error) {
+func newSelectedRecord(base storage.Record, schema *schemapb.CollectionSchema, existingFields, preserveNullFields map[int64]struct{}, selection *recordSelection) (*selectedRecord, error) {
 	columns := make(map[int64]arrow.Array)
 	for _, field := range typeutil.GetAllFieldSchemas(schema) {
 		fieldID := field.GetFieldID()
 		if _, ok := existingFields[fieldID]; !ok {
 			continue
 		}
-		col, err := buildSelectedColumn(base, field, selection)
+		col, err := buildSelectedColumn(base, fieldForMaterialization(field, preserveNullFields), selection)
 		if err != nil {
 			releaseArrowArrays(columns)
 			return nil, err

--- a/internal/datanode/compactor/record_materializer_test.go
+++ b/internal/datanode/compactor/record_materializer_test.go
@@ -151,6 +151,95 @@ func TestRecordMaterializerWrapFillsNullableMissingFields(t *testing.T) {
 	require.Equal(t, 0, record.releaseCount)
 }
 
+func TestRecordMaterializerPreservesMissingProtectedFieldAsNull(t *testing.T) {
+	ttlDefault := &schemapb.ValueField{
+		Data: &schemapb.ValueField_TimestamptzData{TimestamptzData: 123},
+	}
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64},
+		{FieldID: 101, Name: "ttl", DataType: schemapb.DataType_Timestamptz, Nullable: true, DefaultValue: ttlDefault},
+		{
+			FieldID: 102, Name: "regular_default", DataType: schemapb.DataType_Int64, Nullable: true,
+			DefaultValue: &schemapb.ValueField{Data: &schemapb.ValueField_LongData{LongData: 7}},
+		},
+	}}
+	materializer, err := newRecordMaterializer(
+		schema,
+		nil,
+		map[int64]struct{}{100: {}},
+		map[int64]struct{}{101: {}},
+	)
+	require.NoError(t, err)
+	defer materializer.Close()
+
+	record := &materializerTestRecord{len: 3}
+	wrapped, err := materializer.Wrap(record)
+	require.NoError(t, err)
+
+	ttlColumn := wrapped.Column(101).(*array.Int64)
+	require.Equal(t, 3, ttlColumn.NullN())
+	regularColumn := wrapped.Column(102).(*array.Int64)
+	require.Zero(t, regularColumn.NullN())
+	require.Equal(t, []int64{7, 7, 7}, regularColumn.Int64Values())
+	require.Same(t, ttlDefault, schema.GetFields()[1].GetDefaultValue())
+
+	cleanupMaterializedRecord(wrapped)
+	require.Equal(t, 0, record.releaseCount)
+
+	defaultMaterializer, err := NewRecordMaterializer(schema, nil, map[int64]struct{}{100: {}})
+	require.NoError(t, err)
+	defer defaultMaterializer.Close()
+	defaultWrapped, err := defaultMaterializer.Wrap(record)
+	require.NoError(t, err)
+	defaultTTLColumn := defaultWrapped.Column(101).(*array.Int64)
+	require.Zero(t, defaultTTLColumn.NullN())
+	require.Equal(t, []int64{123, 123, 123}, defaultTTLColumn.Int64Values())
+	cleanupMaterializedRecord(defaultWrapped)
+	require.Equal(t, 0, record.releaseCount)
+}
+
+func TestRecordMaterializerSelectionPreservesProtectedNulls(t *testing.T) {
+	futureTTL := int64(456)
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64},
+		{
+			FieldID: 101, Name: "ttl", DataType: schemapb.DataType_Timestamptz, Nullable: true,
+			DefaultValue: &schemapb.ValueField{Data: &schemapb.ValueField_TimestamptzData{TimestamptzData: 123}},
+		},
+	}}
+	materializer, err := newRecordMaterializer(
+		schema,
+		nil,
+		map[int64]struct{}{100: {}, 101: {}},
+		map[int64]struct{}{101: {}},
+	)
+	require.NoError(t, err)
+	defer materializer.Close()
+
+	pk := newInt64Array(t, []int64{1, 2, 3})
+	defer pk.Release()
+	ttl := newNullableInt64Array(t, []int64{futureTTL, 0, 789}, []bool{true, false, true})
+	defer ttl.Release()
+	record := &materializerTestRecord{
+		len: 3,
+		columns: map[storage.FieldID]arrow.Array{
+			100: pk,
+			101: ttl,
+		},
+	}
+	selection := &recordSelection{ranges: []rowRange{{start: 0, end: 2}}, length: 2}
+
+	wrapper, err := materializer.WrapWithSelection(record, selection)
+	require.NoError(t, err)
+	selectedTTL := wrapper.Column(101).(*array.Int64)
+	require.True(t, selectedTTL.IsValid(0))
+	require.Equal(t, futureTTL, selectedTTL.Value(0))
+	require.True(t, selectedTTL.IsNull(1))
+
+	cleanupMaterializedRecord(wrapper)
+	require.Equal(t, 0, record.releaseCount)
+}
+
 func TestRecordMaterializerWrapFillsNullableMissingTextFieldAsBinary(t *testing.T) {
 	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
 		{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64},
@@ -833,5 +922,12 @@ func newInt64Array(t *testing.T, values []int64) *array.Int64 {
 	builder := array.NewInt64Builder(memory.DefaultAllocator)
 	t.Cleanup(builder.Release)
 	builder.AppendValues(values, nil)
+	return builder.NewInt64Array()
+}
+
+func newNullableInt64Array(t *testing.T, values []int64, valid []bool) *array.Int64 {
+	builder := array.NewInt64Builder(memory.DefaultAllocator)
+	t.Cleanup(builder.Release)
+	builder.AppendValues(values, valid)
 	return builder.NewInt64Array()
 }


### PR DESCRIPTION
issue: #51649

Depends on #52301.

## Summary

- In BumpSchemaVersionCompaction full rewrite, materialize a TTL field that is configured in the task schema but absent from the source segment as physical NULL, rather than its schema default.
- Preserve an existing physical NULL TTL when RecordMaterializer rebuilds a filtered Bump record.
- Keep RecordMaterializer's default-materialization behavior unchanged for non-TTL fields and callers that do not opt into the Bump-specific policy.

## Safety invariant

Within BumpSchemaVersion full rewrite, an absent TTL field already configured in the task schema must materialize as NULL. The rewrite must not persist the TTL schema default into historical rows.

## Scope

- This PR covers only BumpSchemaVersionCompaction full rewrite and its RecordMaterializer policy.
- Cross-compaction preservation of physical or absent NULL TTL values in Mix, Sort, MergeSort, and Clustering is tracked in #52328.
- `ttl_field` activation/repoint semantics and read/query-side handling of historical defaults are tracked in #52333.

## Verification

- `go test -tags dynamic,test -gcflags='all=-N -l' -count=1 ./internal/datanode/compactor -run '^TestBumpSchemaVersionCompactionTaskSuite/TestFullRewriteMissingTTLFieldDoesNotProbeRecord$'`
- `go test -tags dynamic,test -gcflags='all=-N -l' -count=1 ./internal/datanode/compactor`
