### PR TITLE
fix: stop one unresponsive DataNode from stalling task dispatch for 10 minutes

### DIFF
--- a/internal/datanode/index_services.go
+++ b/internal/datanode/index_services.go
@@ -83,7 +83,7 @@ func (node *DataNode) CreateJob(ctx context.Context, req *workerpb.CreateJobRequ
 		metrics.DataNodeBuildIndexTaskCounter.WithLabelValues(paramtable.GetStringNodeID(), metrics.FailLabel).Inc()
 		return merr.Status(err), nil
 	}
-	cm, err := node.storageFactory.NewChunkManager(node.ctx, req.GetStorageConfig())
+	cm, err := node.storageFactory.NewChunkManager(ctx, req.GetStorageConfig())
 	if err != nil {
 		mlog.Error(context.TODO(), "create chunk manager failed", mlog.String("bucket", req.GetStorageConfig().GetBucketName()),
 			mlog.String("accessKey", req.GetStorageConfig().GetAccessKeyID()),
@@ -285,7 +285,7 @@ func (node *DataNode) createIndexTask(ctx context.Context, req *workerpb.CreateJ
 		metrics.DataNodeBuildIndexTaskCounter.WithLabelValues(paramtable.GetStringNodeID(), metrics.FailLabel).Inc()
 		return merr.Status(err), nil
 	}
-	cm, err := node.storageFactory.NewChunkManager(node.ctx, req.GetStorageConfig())
+	cm, err := node.storageFactory.NewChunkManager(ctx, req.GetStorageConfig())
 	if err != nil {
 		mlog.Error(context.TODO(), "create chunk manager failed", mlog.String("bucket", req.GetStorageConfig().GetBucketName()),
 			mlog.String("accessKey", req.GetStorageConfig().GetAccessKeyID()),
@@ -396,7 +396,7 @@ func (node *DataNode) createStatsTask(ctx context.Context, req *workerpb.CreateS
 		mlog.Warn(context.TODO(), "duplicated stats task", mlog.Err(err))
 		return merr.Status(err), nil
 	}
-	cm, err := node.storageFactory.NewChunkManager(node.ctx, req.GetStorageConfig())
+	cm, err := node.storageFactory.NewChunkManager(ctx, req.GetStorageConfig())
 	if err != nil {
 		mlog.Error(context.TODO(), "create chunk manager failed", mlog.String("bucket", req.GetStorageConfig().GetBucketName()),
 			mlog.String("accessKey", req.GetStorageConfig().GetAccessKeyID()),

--- a/internal/datanode/services.go
+++ b/internal/datanode/services.go
@@ -209,7 +209,7 @@ func (node *DataNode) CompactionV2(ctx context.Context, req *datapb.CompactionPl
 	if err != nil {
 		return merr.Status(err), err
 	}
-	cm, err := node.storageFactory.NewChunkManager(node.ctx, compactionParams.StorageConfig)
+	cm, err := node.storageFactory.NewChunkManager(ctx, compactionParams.StorageConfig)
 	if err != nil {
 		mlog.Error(context.TODO(), "create chunk manager failed",
 			mlog.String("bucket", compactionParams.StorageConfig.GetBucketName()),
@@ -368,7 +368,7 @@ func (node *DataNode) PreImport(ctx context.Context, req *datapb.PreImportReques
 		return merr.Status(err), nil
 	}
 
-	cm, err := node.storageFactory.NewChunkManager(node.ctx, req.GetStorageConfig())
+	cm, err := node.storageFactory.NewChunkManager(ctx, req.GetStorageConfig())
 	if err != nil {
 		mlog.Error(context.TODO(), "create chunk manager failed", mlog.String("bucket", req.GetStorageConfig().GetBucketName()),
 			mlog.String("accessKey", req.GetStorageConfig().GetAccessKeyID()),
@@ -396,7 +396,7 @@ func (node *DataNode) ImportV2(ctx context.Context, req *datapb.ImportRequest) (
 		return merr.Status(err), nil
 	}
 
-	cm, err := node.storageFactory.NewChunkManager(node.ctx, req.GetStorageConfig())
+	cm, err := node.storageFactory.NewChunkManager(ctx, req.GetStorageConfig())
 	if err != nil {
 		mlog.Error(context.TODO(), "create chunk manager failed", mlog.String("bucket", req.GetStorageConfig().GetBucketName()),
 			mlog.String("accessKey", req.GetStorageConfig().GetAccessKeyID()),
@@ -516,7 +516,7 @@ func (node *DataNode) CopySegment(ctx context.Context, req *datapb.CopySegmentRe
 		return merr.Status(err), nil
 	}
 
-	cm, err := node.storageFactory.NewChunkManager(node.ctx, req.GetStorageConfig())
+	cm, err := node.storageFactory.NewChunkManager(ctx, req.GetStorageConfig())
 	if err != nil {
 		mlog.Error(context.TODO(), "create chunk manager failed",
 			mlog.String("bucket", req.GetStorageConfig().GetBucketName()),

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -7062,10 +7062,17 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 	p.JSONStatsTriggerInterval.Init(base.mgr)
 
 	p.RequestTimeoutSeconds = ParamItem{
-		Key:          "dataCoord.requestTimeoutSeconds",
-		Version:      "2.5.5",
-		Doc:          "request timeout interval",
-		DefaultValue: "600",
+		Key:     "dataCoord.requestTimeoutSeconds",
+		Version: "2.5.5",
+		Doc: `Timeout for DataCoord's requests to a worker node.
+
+These are control-plane calls -- create/query/drop a task, query free slots --
+which a healthy node answers in microseconds: creating a task hands it to a
+background queue rather than running it. The timeout therefore only ever
+applies to a node that is already unwell, and there the useful behavior is to
+give up quickly and re-dispatch the task elsewhere. The previous 600s let one
+unresponsive node stall a whole scheduling round instead.`,
+		DefaultValue: "30",
 		PanicIfEmpty: false,
 		Export:       false,
 	}


### PR DESCRIPTION
issue: #52332

## What this PR does

Lower `dataCoord.requestTimeoutSeconds` from 600s to 30s, and pass the request context into `NewChunkManager` on the DataNode task handlers so the timeout actually reaches the one slow step behind them.

## Why 600s was wrong

`dataCoord.requestTimeoutSeconds` bounds every DataCoord-to-worker call: `createTask`, `queryTask`, `dropTask` and `QuerySlot`. All four are control-plane operations that a healthy node answers in microseconds — `CreateTask` hands the plan to a background queue rather than running it, `QueryTask` and `QuerySlot` read in-memory state, `DropTask` removes a map entry. None of them is a slow operation, so the 600s default only ever applied to a node that was already unwell — and there the useful behavior is to give up and re-dispatch elsewhere.

Meanwhile the global task scheduler waits for every RPC it issues in a round, and `QuerySlot` is the first thing `schedule()` does, waiting on **all** nodes. One black-holed DataNode could therefore stall dispatch for every task type — compaction, index, stats, import — for ten minutes per round.

## Why the ctx change is needed for the timeout to matter

Creating a chunk manager is the one genuinely slow step on the `CreateTask` path: it builds a fresh client, probes the bucket with a HEAD request and may create it, all under `retry.Attempts(20)` with backoff topping out near 48s. The seven task handlers passed `node.ctx`, so that probe ignored the caller's deadline entirely — shortening the DataCoord-side timeout alone would only make DataCoord give up while the DataNode kept going and registered the task anyway, turning a slow dispatch into a duplicate/orphan.

The context does not outlive creation — `RemoteChunkManager` stores no ctx and every data operation takes its own — so this bounds only the creation-time probe, which is exactly what should be bounded. The chunk manager built in `data_node.go` keeps `node.ctx`: it belongs to node startup, not to a request.

## Notes

- `dataCoord.requestTimeoutSeconds` is not exported in `milvus.yaml` (`Export: false`), so no existing user configuration is affected; deployments that want the old behavior can still set it explicitly.
- Known limitation, out of scope here: `createRefreshExternalCollectionTask` dispatches through a blocking 8-worker pool and can legitimately exceed this timeout when the pool is saturated; that needs a non-blocking submit and is left as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
