### PR TITLE
fix: pin py for pytest-html to unbreak every e2e pipeline

### DIFF
--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -16,6 +16,9 @@ pytest-assume==2.4.3
 pytest-rerunfailures==14.0
 pytest_tagging==1.6.0
 pytest-html==3.1.1
+# pytest-html 3.1.1 imports py.xml; py used to arrive transitively via
+# pytest-forked until its 1.7.5 release (2026-08-08) dropped the dependency
+py==1.11.0
 delayed-assert==0.3.5
 kubernetes==17.17.0
 PyYAML==6.0.2

--- a/tests/restful_client/requirements.txt
+++ b/tests/restful_client/requirements.txt
@@ -10,6 +10,9 @@ pytest-print==0.2.1
 pytest-level==0.1.1
 pytest-xdist==2.5.0
 pytest-html==3.1.1
+# pytest-html 3.1.1 imports py.xml; py used to arrive transitively via
+# pytest-forked until its 1.7.5 release (2026-08-08) dropped the dependency
+py==1.11.0
 pytest-sugar==0.9.5
 pytest-parallel
 pytest-random-order


### PR DESCRIPTION
Since 2026-08-09 every e2e sub-pipeline dies before running a single test:

```
File ".../pytest_html/plugin.py", line 22, in <module>
ModuleNotFoundError: No module named 'py.xml'; 'py' is not a package
```

The pinned `pytest-html==3.1.1` imports `py.xml`, and the `py` package used to arrive transitively through `pytest-forked` (a dependency of the pinned `pytest-xdist==2.5.0`). **pytest-forked 1.7.5, released 2026-08-08, dropped its `py` dependency**, so a fresh pip resolve no longer installs `py` and the pytest-html plugin fails at import time in every job that installs these requirements.

Confirmed fleet-wide: identical tracebacks with zero collected tests on unrelated PRs (#52261 dispatcher [16874](https://jenkins-milvus-ci.milvus.io/job/MILVUS-CI-V2-PR-PIPELINES/job/milvus-e2e-pipeline-dispatcher/16874/), all 6 sub-pipelines, and #52335 build 39325).

Fix: pin `py==1.11.0` (its final release) next to pytest-html in both requirements files that pin pytest-html 3.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1pij3TGike2nZy7t6oDZY