### PR TITLE
enhance: avoid fmt for querynode column names

### DIFF
--- a/internal/querynodev2/tasks/boost_score.go
+++ b/internal/querynodev2/tasks/boost_score.go
@@ -19,6 +19,7 @@ package tasks
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"google.golang.org/protobuf/proto"
@@ -38,7 +39,7 @@ const (
 )
 
 func boostScoreColumn(index int) string {
-	return fmt.Sprintf("%s%d", boostScoreColumnPrefix, index)
+	return boostScoreColumnPrefix + strconv.Itoa(index)
 }
 
 func extractPlanScorers(serializedPlan []byte) ([]*planpb.ScoreFunction, error) {

--- a/internal/querynodev2/tasks/group_by_columns.go
+++ b/internal/querynodev2/tasks/group_by_columns.go
@@ -1,7 +1,6 @@
 package tasks
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -11,7 +10,7 @@ import (
 const groupByColumnPrefix = "$group_by_"
 
 func groupByColumnName(fieldID int64) string {
-	return fmt.Sprintf("%s%d", groupByColumnPrefix, fieldID)
+	return groupByColumnPrefix + strconv.FormatInt(fieldID, 10)
 }
 
 func isGroupByColumnName(name string) bool {


### PR DESCRIPTION
issue: #52342

### What changed

Use `strconv` instead of `fmt.Sprintf` for two internal querynodev2 temporary column-name helpers:

- `groupByColumnName(fieldID)`
- `boostScoreColumn(index)`

Both helpers format a constant prefix plus a decimal integer. This preserves the generated column names while avoiding the generic formatting path.

### Benchmark

Scratch benchmark of the exact primitive, measured back to back in one session with `-benchmem -count=5` on linux/amd64:

| helper | before | after |
|---|---:|---:|
| group-by column name | 87.09 ns/op, 16 B/op, 1 alloc/op | 35.99 ns/op, 3 B/op, 1 alloc/op |
| boost-score column name | 78.92 ns/op, 16 B/op, 1 alloc/op | 15.55 ns/op, 0 B/op, 0 alloc/op |

### Verification

```bash
PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig:/home/sheep/workspace/milvus/cmake_build/src:$PKG_CONFIG_PATH \
LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:/home/sheep/workspace/milvus/internal/core/output/lib64:/home/sheep/workspace/milvus/cmake_build/lib:$LD_LIBRARY_PATH \
GOWORK=off go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/querynodev2/tasks \
  -run 'TestBoostScoreColumn|TestApplyBoostScoresPrunesTempsAndPreservesReduceSystemColumns|TestMarshalReduceResult_GroupBy|TestGoReduceGroupBy'
```

```text
ok  github.com/milvus-io/milvus/internal/querynodev2/tasks  0.628s
```

```bash
PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig:/home/sheep/workspace/milvus/cmake_build/src:$PKG_CONFIG_PATH \
LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:/home/sheep/workspace/milvus/internal/core/output/lib64:/home/sheep/workspace/milvus/cmake_build/lib:$LD_LIBRARY_PATH \
GOWORK=off go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/querynodev2/tasks
```

```text
ok  github.com/milvus-io/milvus/internal/querynodev2/tasks  13.162s
```

```bash
PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig:/home/sheep/workspace/milvus/cmake_build/src:$PKG_CONFIG_PATH \
LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:/home/sheep/workspace/milvus/internal/core/output/lib64:/home/sheep/workspace/milvus/cmake_build/lib:$LD_LIBRARY_PATH \
GOWORK=off make static-check
```

```text
0 issues.
```

Note: this worktree uses the ignored local generated `cmd/tools/migration/legacy/legacypb` package already present in the main checkout so repository-wide static-check can typecheck the migration tool.