### PR TITLE
fix: pin proxy read metadata snapshot per request

### DIFF
--- a/docs/design-docs/design_docs/20260809-proxy-read-request-snapshot.md
+++ b/docs/design-docs/design_docs/20260809-proxy-read-request-snapshot.md
@@ -1,0 +1,238 @@
+# Proxy request-scoped read snapshot
+
+- Status: Implemented; verification is partially blocked by stale local C++/cgo artifacts
+- Date: 2026-08-09
+- Scope: Proxy Search, Query, HybridSearch, read-side RBAC, rate limiting, partition routing, and internal retries
+
+## 1. Problem
+
+Proxy currently resolves a request's collection name or alias multiple times during one Search or Query:
+
+1. privilege checking may resolve the alias for RBAC;
+2. rate limiting resolves the collection id and sometimes schema/partitions;
+3. `CanSkipAllocTimestamp` resolves collection id and collection properties;
+4. task `PreExecute` separately resolves collection id, schema, collection properties, and partitions;
+5. Search retry, search-by-primary-key, and requery paths may start another read task.
+
+Every individual MetaCache lookup is concurrency-safe, but the sequence is not a request-level transaction. If alias `A` is altered from `C1` to `C2` between lookups, one request can authorize or rate-limit `C1`, build a plan with `C2`'s schema, and send `C1`'s collection id to QueryNode.
+
+The request must select either the old or new alias target. Mixing metadata from both targets is invalid.
+
+### 1.1 Current branch and 2.6 baseline analysis
+
+The comparison uses current-branch baseline `c552dfda0f` and 2.6 baseline `70148472bf`.
+
+Both branches resolve the caller-supplied collection name or alias repeatedly in one logical read request. These are logical cache getter calls; a cache hit may avoid a RootCoord RPC, but it does not make the sequence atomic.
+
+| Path | Current branch before this change | 2.6 before this change |
+|---|---|---|
+| Search timestamp decision | `GetCollectionID` + `GetCollectionInfo` | same |
+| Search `PreExecute` | `GetCollectionID` + `GetCollectionSchema` + `GetCollectionInfo` + `isPartitionKeyMode`, followed by name-based partition routing when needed | same |
+| Query timestamp decision | `GetCollectionID` + `GetCollectionInfo` | same |
+| Query `PreExecute` | collection ID, collection info, schema, partition-key mode, partition routing, then a second collection-info lookup for consistency/TTL | same logical sequence, with schema lookup ordered later |
+| Other consumers | RBAC alias resolution, rate-limit collection/partition lookup, Search-by-PK internal Query, requery, optimized retry, and recall evaluation can resolve again | same categories |
+| Additional branch-specific lookup | none in this area | materialized-view planning performs another `GetCollectionInfo` |
+
+Therefore both branches have a real TOCTOU window. An AlterAlias from `A -> C1` to `A -> C2` can produce combinations such as C1's ID with C2's schema, partitions, consistency level, or RBAC/rate-limit identity.
+
+The current branch already protects cache fill/invalidation ordering with `fillMu`, and AlterAlias expiration carries the new and old target IDs. The 2.6 branch does not have the same complete ordering and by-ID partition behavior. A 2.6 backport must include those prerequisites; cherry-picking only the request object can still allow a pre-alter fill to republish stale alias metadata after invalidation.
+
+## 2. Required semantics
+
+Alias resolution is the request's metadata linearization point:
+
+```text
+Authentication
+      |
+Resolve alias -> immutable CollectionReadSnapshot
+      |                       |
+    RBAC                  RateLimit
+      |                       |
+ allocate read timestamp -> build plan -> route partitions -> execute/requery/retry
+```
+
+The guarantees are:
+
+1. If snapshot resolution happens before AlterAlias, the whole request uses the old collection.
+2. If snapshot resolution happens after AlterAlias completes, the whole request uses the new collection.
+3. A request never combines one collection's id with another collection's schema, properties, or partitions.
+4. RBAC, quota accounting, timestamp selection, plan construction, QueryNode routing, requery, and internal retry use the same collection binding.
+5. A retry must never silently re-resolve an alias to another collection.
+6. Iterator pages remain separate external requests and continue checking the client-carried `collection_id`.
+
+## 3. Data model
+
+Introduce an immutable request-scoped collection binding:
+
+```go
+type CollectionReadSnapshot struct {
+    requestedDBName         string
+    requestedCollectionName string
+    databaseID              int64
+    databaseName            string
+    collectionID            int64
+    canonicalName           string
+    info                    *collectionInfo
+}
+```
+
+`collectionInfo` is the only source of schema, consistency level, update timestamp, query mode, partition-key isolation, and collection properties. The snapshot must not separately acquire those values through name-based getters.
+
+The request-level object additionally owns lazily initialized partition metadata and the pinned data visibility timestamp:
+
+```go
+type ReadRequestSnapshot struct {
+    Collection *CollectionReadSnapshot
+
+    partitionMu sync.Mutex
+    partitions  *partitionInfos
+
+    timestampMu     sync.RWMutex
+    timestampPinned bool
+    consistency     commonpb.ConsistencyLevel
+    requestTS       Timestamp
+    guaranteeTS     Timestamp
+}
+```
+
+Cached `collectionInfo`, `schemaInfo`, and `partitionInfos` values are immutable after publication. Cache invalidation removes map ownership but does not invalidate pointers already held by in-flight requests.
+
+## 4. Resolution and context propagation
+
+Add one MetaCache-facing resolver that performs a single `GetCollectionInfo(database, nameOrAlias, 0)` and builds `CollectionReadSnapshot` from the returned object.
+The resolver treats a missing schema or zero collection id as incomplete internal metadata and fails with `ServiceInternal`; it never builds a routable snapshot from a partial cache object.
+
+Store `{snapshot, err}` in context and make resolution idempotent. The gRPC privilege interceptor pins the snapshot before alias-aware RBAC when that feature is enabled; the rate-limit interceptor ensures it otherwise; Proxy Search, Query, and HybridSearch remain the final fallback for direct/internal callers. A resolution failure is retained in context rather than returned before RBAC, preserving the existing resource-existence protection:
+
+- privilege checking uses the canonical name when resolution succeeded;
+- on resolution failure, privilege checking uses the literal request name;
+- after authorization succeeds, the handler returns the saved resolution error;
+- rate limiting and the handler consume the same context snapshot.
+
+REST V1 pins the snapshot in its DQL interceptor and propagates the context returned by authorization. REST V2 first runs authorization, returns a saved snapshot-resolution error only after authorization succeeds, and pins the snapshot before schema/placeholder preprocessing; the common wrapper checks the same context idempotently. When the request is executed by the current Proxy, schema conversion, limiter accounting, and the Proxy method therefore use the same binding.
+
+This guarantee does not cross the legacy-Proxy forwarding boundary used by standalone rolling upgrades. A REST DQL request forwarded from the current Proxy to a legacy Proxy carries the original protobuf request, but its request-scoped context snapshot cannot cross the gRPC hop. The legacy Proxy therefore resolves the collection name or alias independently. Supporting a pinned binding across that compatibility path requires rewriting the forwarded request to the pinned canonical collection name and is outside the scope of this change.
+
+Direct internal/test calls that do not pass through interceptors use an idempotent `EnsureReadRequestSnapshot` fallback.
+
+## 5. Search and Query task changes
+
+Resolve or obtain the request snapshot before task enqueue. Task construction stores the snapshot pointer.
+
+`CanSkipAllocTimestamp` reads consistency from the snapshot and performs no MetaCache lookup.
+
+`PreExecute` initializes all metadata from the snapshot:
+
+```go
+t.CollectionID = snapshot.CollectionID()
+t.collectionName = snapshot.CanonicalName()
+t.schema = snapshot.Schema()
+collectionInfo := snapshot.Info()
+```
+
+Remove the task-local sequence of:
+
+```text
+GetCollectionID(name)
+GetCollectionSchema(name)
+GetCollectionInfo(name, id)
+isPartitionKeyMode(name)
+```
+
+Schema-derived predicates such as partition-key mode are evaluated directly from `snapshot.Schema()`.
+
+Search-by-primary-key, requery, optimized Search retry, recall evaluation, and Query retry receive the same request snapshot.
+
+## 6. Partition routing
+
+Partition lookup must not re-resolve the alias. Add collection-id-based helpers:
+
+```go
+GetPartitionInfosByID(ctx, database, collectionID)
+```
+
+Refactor `getPartitionIDs`, `assignPartitionKeys`, namespace partition routing, and rate-limit partition accounting to accept `ReadRequestSnapshot` rather than database/collection name strings.
+
+The first successful partition consumer loads the immutable partition list by the pinned collection id. Later consumers reuse the same pointer. A transient fetch failure is returned to that consumer but is not cached, so a rate-limit lookup that fails open cannot poison task execution; the next consumer retries against the same pinned collection id.
+
+For the AlterAlias problem, resolving partitions by collection id is sufficient to prevent cross-collection mixing. A future strict RootCoord-wide snapshot covering concurrent schema and partition DDL would require a combined/versioned RootCoord read API and is outside this change.
+
+## 7. Data visibility timestamp
+
+The collection metadata binding and data MVCC timestamp are separate but belong to the same external request.
+
+The first task computes consistency, its allocated request timestamp, and the base guarantee timestamp from the pinned collection info, including the collection schema update timestamp barrier. The result is stored once in `ReadRequestSnapshot`.
+
+All internal attempts reuse it:
+
+- optimized Search retry;
+- inconsistent-requery retry;
+- recall evaluation;
+- search requery;
+- search-by-primary-key internal Query;
+- Query internal retry.
+
+Subsequent attempts may allocate a new task id, but `PreExecute` restores the pinned request timestamp and must not select a new collection or a new guarantee timestamp. Existing Search requery additionally reuses the per-channel MVCC timestamps returned by the first Search.
+
+Iterator continuation requests keep two timestamp roles separate. Entity-level TTL physical time is derived from the newly computed base guarantee timestamp for the current external request. Only after that derivation does Proxy override the wire guarantee/MVCC timestamp with the client-carried iterator session timestamp. This preserves a stable iterator MVCC view without freezing TTL expiry at the first page's clock.
+
+This change pins the Proxy-visible read contract. For normal non-iterator Eventually/Bounded reads, QueryNode may still choose its actual per-channel MVCC from the channel tSafe when the request carries `mvcc_timestamp=0`; a strict, externally visible, identical per-channel MVCC across every replica failover would require a separate QueryNode response/protocol extension. The implementation does not claim that stronger guarantee.
+
+## 8. AlterAlias interaction
+
+Search and Query do not acquire Streaming Broadcaster resource locks. Holding `SharedDBName` for a long DQL request would block AlterAlias on slow reads and introduce a distributed lock lifecycle into the read path.
+
+Instead, concurrent operations use request binding:
+
+- the request retains an immutable old-target snapshot;
+- AlterAlias commits and invalidates Proxy caches;
+- later requests resolve the new target;
+- the in-flight old request remains valid and cannot switch targets.
+
+The current branch already orders MetaCache fills against invalidations with `fillMu`, and AlterAlias expiration carries both old and new collection ids. Therefore no Streaming message change is required for the current-branch implementation.
+
+For a 2.6 backport, request binding must be accompanied by fill/invalidation ordering and by-id partition fetching; otherwise a pre-alter fill can resurrect an old alias entry after invalidation returns.
+
+## 9. Failure behavior
+
+If the pinned collection is dropped after snapshot creation, the request must continue using the pinned id and fail through the existing by-id/query execution error path. It must not re-resolve the alias and execute against a replacement collection.
+
+Alias changes between iterator pages continue to return the existing collection-id mismatch error.
+
+The request-scoped consistency guarantee applies to metadata consumers in the current Proxy process. Standalone REST DQL requests forwarded to a legacy Proxy during a rolling upgrade retain the legacy path's independent collection-name resolution semantics.
+
+An internal request-snapshot invariant violation is a system failure/TOCTOU bug, never an input error.
+
+## 10. Implementation plan and status
+
+1. [x] Add immutable collection/read snapshot types, context storage, and idempotent resolution helpers.
+2. [x] Integrate snapshot resolution with privilege and rate-limit interceptors without exposing resolution errors before authorization.
+3. [x] Resolve snapshot before Search/Query task enqueue and pass it into Search-by-PK, requery, optimized retry, and recall paths.
+4. [x] Remove repeated collection ID/schema/info lookups from Search and Query `PreExecute`.
+5. [x] Convert partition routing and rate-limit partition accounting to a pinned collection-ID API.
+6. [x] Pin consistency, request timestamp, guarantee timestamp, schema-update barrier, and TTL time basis across internal attempts.
+7. [x] Add a deterministic AlterAlias simulation covering pinned ID/schema, limiter identity, partitions, timestamp pinning, target mismatch, and a later request binding the new target.
+8. [x] Complete executable Proxy verification after rebuilding the local C++/cgo artifacts.
+
+## 11. Verification matrix
+
+Use two collections with deliberately incompatible metadata:
+
+```text
+C1: vector field id 101, dim 128, Strong consistency, partition id 1001
+C2: vector field id 201, dim 256, Bounded consistency, partition id 2001
+```
+
+Verify:
+
+1. Snapshot before AlterAlias gives only C1 values.
+2. Snapshot after AlterAlias gives only C2 values.
+3. AlterAlias between the former ID/schema lookup points cannot produce a mixed plan/request.
+4. RBAC canonical name, limiter collection id, task collection id, and QueryNode request collection id are identical.
+5. Search retry and requery retain collection id and guarantee timestamp.
+6. Search-by-primary-key internal Query retains the same snapshot.
+7. Iterator page two rejects a changed alias target.
+8. A request starting after AlterAlias returns binds the new target.
+9. A parked cache fill cannot survive a completed invalidation in the 2.6 backport.
+
+Local verification completed with `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/proxy`.

--- a/internal/distributed/proxy/httpserver/handler_v1.go
+++ b/internal/distributed/proxy/httpserver/handler_v1.go
@@ -50,12 +50,13 @@ func checkAuthorization(ctx context.Context, c *gin.Context, req interface{}) er
 		HTTPReturn(c, http.StatusUnauthorized, gin.H{HTTPReturnCode: merr.Code(merr.ErrNeedAuthenticate), HTTPReturnMessage: merr.ErrNeedAuthenticate.Error()})
 		return RestRequestInterceptorErr
 	}
-	_, authErr := proxy.PrivilegeInterceptor(ctx, req)
+	ctx, authErr := proxy.PrivilegeInterceptor(ctx, req)
 	if authErr != nil {
 		HTTPReturn(c, http.StatusForbidden, gin.H{HTTPReturnCode: merr.Code(authErr), HTTPReturnMessage: authErr.Error()})
 		return RestRequestInterceptorErr
 	}
 
+	c.Request = c.Request.WithContext(ctx)
 	return nil
 }
 
@@ -81,9 +82,18 @@ func NewHandlersV1(proxyComponent types.ProxyComponent) *HandlersV1 {
 				if err != nil {
 					return nil, err
 				}
-				return handler(ctx, req)
+				return handler(ginCtx.Request.Context(), req)
 			})
 	}
+	h.interceptors = append(h.interceptors,
+		// Pin DQL collection metadata before REST request preprocessing. When
+		// authorization is enabled, the preceding interceptor has already
+		// resolved the same snapshot for alias-aware RBAC.
+		func(ctx context.Context, ginCtx *gin.Context, req any, handler func(reqCtx context.Context, req any) (any, error)) (any, error) {
+			ctx, _, _ = proxy.EnsureReadRequestSnapshotForRequest(ctx, req)
+			ginCtx.Request = ginCtx.Request.WithContext(ctx)
+			return handler(ctx, req)
+		})
 	h.interceptors = append(h.interceptors,
 		// check database
 		func(ctx context.Context, ginCtx *gin.Context, req any, handler func(reqCtx context.Context, req any) (any, error)) (any, error) {
@@ -532,7 +542,7 @@ func (h *HandlersV1) query(c *gin.Context) {
 	username, _ := c.Get(ContextUsername)
 	ctx := proxy.NewContextWithMetadata(c, username.(string), req.DbName)
 	response, err := h.executeRestRequestInterceptor(ctx, c, req, func(reqCtx context.Context, req any) (any, error) {
-		if _, err := CheckLimiter(ctx, req, h.proxy); err != nil {
+		if _, err := CheckLimiter(reqCtx, req, h.proxy); err != nil {
 			c.AbortWithStatusJSON(http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(err),
 				HTTPReturnMessage: err.Error() + ", error: " + err.Error(),
@@ -596,7 +606,7 @@ func (h *HandlersV1) get(c *gin.Context) {
 	username, _ := c.Get(ContextUsername)
 	ctx := proxy.NewContextWithMetadata(c, username.(string), req.DbName)
 	response, err := h.executeRestRequestInterceptor(ctx, c, req, func(reqCtx context.Context, req any) (any, error) {
-		collSchema, err := h.describeCollection(ctx, c, httpReq.DbName, httpReq.CollectionName)
+		collSchema, err := h.describeCollection(reqCtx, c, httpReq.DbName, httpReq.CollectionName)
 		if err != nil || collSchema == nil {
 			return nil, RestRequestInterceptorErr
 		}
@@ -610,7 +620,7 @@ func (h *HandlersV1) get(c *gin.Context) {
 			return nil, RestRequestInterceptorErr
 		}
 		queryReq := req.(*milvuspb.QueryRequest)
-		if _, err := CheckLimiter(ctx, req, h.proxy); err != nil {
+		if _, err := CheckLimiter(reqCtx, req, h.proxy); err != nil {
 			c.AbortWithStatusJSON(http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(err),
 				HTTPReturnMessage: err.Error() + ", error: " + err.Error(),
@@ -1008,14 +1018,14 @@ func (h *HandlersV1) search(c *gin.Context) {
 	username, _ := c.Get(ContextUsername)
 	ctx := proxy.NewContextWithMetadata(c, username.(string), req.DbName)
 	response, err := h.executeRestRequestInterceptor(ctx, c, req, func(reqCtx context.Context, req any) (any, error) {
-		if _, err := CheckLimiter(ctx, req, h.proxy); err != nil {
+		if _, err := CheckLimiter(reqCtx, req, h.proxy); err != nil {
 			c.AbortWithStatusJSON(http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(err),
 				HTTPReturnMessage: err.Error() + ", error: " + err.Error(),
 			})
 			return nil, err
 		}
-		return h.proxy.Search(ctx, req.(*milvuspb.SearchRequest))
+		return h.proxy.Search(reqCtx, req.(*milvuspb.SearchRequest))
 	})
 	if err == RestRequestInterceptorErr {
 		return

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -564,6 +564,33 @@ func checkAuthorizationHelper(ctx context.Context, c *gin.Context, req interface
 	return nil
 }
 
+func prepareReadRequestSnapshot(ctx context.Context, c *gin.Context, req any, checkAuth bool) (context.Context, error) {
+	if checkAuth {
+		if err := checkAuthorizationV2(ctx, c, false, req); err != nil {
+			return ctx, err
+		}
+		ctx = c.Request.Context()
+	}
+
+	ctx, err, _ := proxy.EnsureReadRequestSnapshotForRequest(ctx, req)
+	if err != nil {
+		status := merr.Status(err)
+		dbGetter, hasDB := req.(requestutil.DBNameGetter)
+		collectionGetter, hasCollection := req.(requestutil.CollectionNameGetter)
+		if hasDB && hasCollection {
+			status = proxy.CollectionLookupErrorStatus(err, dbGetter.GetDbName(), collectionGetter.GetCollectionName())
+		}
+		responseErr := merr.Error(status)
+		HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPReturnCode:    status.GetCode(),
+			HTTPReturnMessage: status.GetReason(),
+		})
+		return ctx, responseErr
+	}
+	c.Request = c.Request.WithContext(ctx)
+	return ctx, nil
+}
+
 func wrapperProxy(ctx context.Context, c *gin.Context, req any, checkAuth bool, ignoreErr bool, fullMethod string, handler func(reqCtx context.Context, req any) (any, error)) (interface{}, error) {
 	return wrapperProxyWithLimit(ctx, c, req, checkAuth, ignoreErr, fullMethod, false, nil, handler)
 }
@@ -580,7 +607,11 @@ func wrapperProxyWithLimit(ctx context.Context, ginCtx *gin.Context, req any, ch
 		}
 		ctx = ginCtx.Request.Context()
 	}
-	if checkLimit {
+	ctx, snapshotErr, isReadRequest := proxy.EnsureReadRequestSnapshotForRequest(ctx, req)
+	if isReadRequest {
+		ginCtx.Request = ginCtx.Request.WithContext(ctx)
+	}
+	if checkLimit && snapshotErr == nil {
 		_, err := CheckLimiter(ctx, req, pxy)
 		if err != nil {
 			mlog.Warn(context.TODO(), "high level restful api, fail to check limiter", mlog.Err(err), mlog.String("method", fullMethod))
@@ -1399,6 +1430,10 @@ func (h *HandlersV2) query(ctx context.Context, c *gin.Context, anyReq any, dbNa
 		QueryParams:    []*commonpb.KeyValuePair{},
 	}
 	var err error
+	ctx, err = prepareReadRequestSnapshot(ctx, c, req, h.checkAuth)
+	if err != nil {
+		return nil, err
+	}
 	collSchema, err := h.GetCollectionSchema(ctx, c, dbName, httpReq.CollectionName)
 	if err != nil {
 		return nil, err
@@ -1439,7 +1474,7 @@ func (h *HandlersV2) query(ctx context.Context, c *gin.Context, anyReq any, dbNa
 	if len(httpReq.GroupByFields) > 0 {
 		req.QueryParams = append(req.QueryParams, &commonpb.KeyValuePair{Key: proxy.GroupByFieldsKey, Value: strings.Join(httpReq.GroupByFields, ",")})
 	}
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/Query", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := wrapperProxyWithLimit(ctx, c, req, false, false, "/milvus.proto.milvus.MilvusService/Query", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.Query(reqCtx, req.(*milvuspb.QueryRequest))
 	})
 	if err == nil {
@@ -1477,6 +1512,16 @@ func (h *HandlersV2) query(ctx context.Context, c *gin.Context, anyReq any, dbNa
 
 func (h *HandlersV2) get(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
 	httpReq := anyReq.(*CollectionIDReq)
+	req := &milvuspb.QueryRequest{
+		DbName:         dbName,
+		CollectionName: httpReq.CollectionName,
+		OutputFields:   httpReq.OutputFields,
+		PartitionNames: httpReq.PartitionNames,
+	}
+	ctx, err := prepareReadRequestSnapshot(ctx, c, req, h.checkAuth)
+	if err != nil {
+		return nil, err
+	}
 	collSchema, err := h.GetCollectionSchema(ctx, c, dbName, httpReq.CollectionName)
 	if err != nil {
 		return nil, err
@@ -1490,14 +1535,8 @@ func (h *HandlersV2) get(ctx context.Context, c *gin.Context, anyReq any, dbName
 		})
 		return nil, err
 	}
-	req := &milvuspb.QueryRequest{
-		DbName:             dbName,
-		CollectionName:     httpReq.CollectionName,
-		OutputFields:       httpReq.OutputFields,
-		PartitionNames:     httpReq.PartitionNames,
-		Expr:               filter,
-		ExprTemplateValues: idTemplateValues,
-	}
+	req.Expr = filter
+	req.ExprTemplateValues = idTemplateValues
 	req.ConsistencyLevel, req.UseDefaultConsistency, err = convertConsistencyLevel(httpReq.ConsistencyLevel)
 	if err != nil {
 		mlog.Warn(ctx, "high level restful api, query with consistency_level invalid", mlog.Err(err))
@@ -1508,7 +1547,7 @@ func (h *HandlersV2) get(ctx context.Context, c *gin.Context, anyReq any, dbName
 		return nil, err
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/Query", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := wrapperProxyWithLimit(ctx, c, req, false, false, "/milvus.proto.milvus.MilvusService/Query", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.Query(reqCtx, req.(*milvuspb.QueryRequest))
 	})
 	if err == nil {
@@ -1881,6 +1920,10 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 		})
 		return nil, err
 	}
+	ctx, err = prepareReadRequestSnapshot(ctx, c, req, h.checkAuth)
+	if err != nil {
+		return nil, err
+	}
 	c.Set(ContextRequest, req)
 
 	collSchema, err := h.GetCollectionSchema(ctx, c, dbName, httpReq.CollectionName)
@@ -2051,7 +2094,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 		return nil, err
 	}
 	req.ExprTemplateValues = templateValues
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/Search", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := wrapperProxyWithLimit(ctx, c, req, false, false, "/milvus.proto.milvus.MilvusService/Search", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.Search(reqCtx, req.(*milvuspb.SearchRequest))
 	})
 	if err == nil {
@@ -2162,6 +2205,10 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 		})
 		return nil, err
 	}
+	ctx, err = prepareReadRequestSnapshot(ctx, c, req, h.checkAuth)
+	if err != nil {
+		return nil, err
+	}
 	c.Set(ContextRequest, req)
 
 	if httpReq.SearchAggregation != nil {
@@ -2258,7 +2305,7 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 			return nil, err
 		}
 	}
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/HybridSearch", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := wrapperProxyWithLimit(ctx, c, req, false, false, "/milvus.proto.milvus.MilvusService/HybridSearch", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.HybridSearch(reqCtx, req.(*milvuspb.HybridSearchRequest))
 	})
 	if err == nil {

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -2465,13 +2465,71 @@ func versionalV2(category string, action string) string {
 	return "/v2/vectordb" + category + action
 }
 
-func initHTTPServerV2(proxy types.ProxyComponent, needAuth bool) *gin.Engine {
-	h := NewHandlersV2(proxy)
+func initHTTPServerV2(proxyComponent types.ProxyComponent, needAuth bool) *gin.Engine {
+	h := NewHandlersV2(proxyComponent)
 	ginHandler := gin.Default()
 	appV2 := ginHandler.Group("/v2/vectordb", genAuthMiddleWare(needAuth))
+	proxy.InitGlobalCacheFromProxyForTest(proxyComponent)
 	h.RegisterRoutesToV2(appV2)
 
 	return ginHandler
+}
+
+func TestPrepareReadRequestSnapshotPreservesCollectionNotFoundMessage(t *testing.T) {
+	paramtable.Init()
+	proxy.InitEmptyGlobalCache()
+	t.Cleanup(proxy.InitEmptyGlobalCache)
+
+	snapshotErr := merr.WrapErrCollectionNotFound("missing_collection")
+	proxyComponent := mocks.NewMockProxy(t)
+	proxyComponent.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(
+		&milvuspb.DescribeCollectionResponse{Status: merr.Status(snapshotErr)},
+		nil,
+	).Once()
+	proxy.InitGlobalCacheFromProxyForTest(proxyComponent)
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+	_, err := prepareReadRequestSnapshot(c.Request.Context(), c, &milvuspb.SearchRequest{
+		DbName:         DefaultDbName,
+		CollectionName: "missing_collection",
+	}, false)
+	require.ErrorIs(t, err, merr.ErrCollectionNotFound)
+	assert.Equal(t, "can't find collection[database=default][collection=missing_collection]", err.Error())
+
+	var response ReturnErrMsg
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, merr.Code(snapshotErr), response.Code)
+	assert.Equal(t, "can't find collection[database=default][collection=missing_collection]", response.Message)
+}
+
+func TestSearchV2PreservesCollectionNotFoundMessage(t *testing.T) {
+	paramtable.Init()
+	proxy.InitEmptyGlobalCache()
+	t.Cleanup(proxy.InitEmptyGlobalCache)
+
+	const collectionName = "missing_collection"
+	snapshotErr := merr.WrapErrCollectionNotFoundWithDB(DefaultDbName, collectionName)
+	proxyComponent := mocks.NewMockProxy(t)
+	proxyComponent.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(
+		&milvuspb.DescribeCollectionResponse{Status: merr.Status(snapshotErr)},
+		nil,
+	).Once()
+	testEngine := initHTTPServerV2(proxyComponent, false)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		versionalV2(EntityCategory, SearchAction),
+		bytes.NewReader([]byte(`{"collectionName":"missing_collection","data":[[0.1,0.2]],"limit":10}`)),
+	)
+	recorder := httptest.NewRecorder()
+	testEngine.ServeHTTP(recorder, req)
+
+	var response ReturnErrMsg
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, merr.Code(snapshotErr), response.Code)
+	assert.Equal(t, "can't find collection[database=default][collection=missing_collection]", response.Message)
 }
 
 type externalCollectionRESTProxy struct {
@@ -4691,15 +4749,6 @@ func TestSearchAggregationV2UnsupportedCombinations(t *testing.T) {
 	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
 	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
 
-	mp := mocks.NewMockProxy(t)
-	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
-		CollectionName: DefaultCollectionName,
-		Schema:         generateCollectionSchema(schemapb.DataType_Int64, false, true),
-		ShardsNum:      ShardNumDefault,
-		Status:         &StatusSuccess,
-	}, nil).Times(5)
-	testEngine := initHTTPServerV2(mp, false)
-
 	searchAggregation := `"searchAggregation": {"fields": ["brand"], "size": 1}`
 	testCases := []requestBodyTestCase{
 		{
@@ -4745,6 +4794,16 @@ func TestSearchAggregationV2UnsupportedCombinations(t *testing.T) {
 			errMsg:      "searchAggregation is not supported for hybrid search",
 		},
 	}
+
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         generateCollectionSchema(schemapb.DataType_Int64, false, true),
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Times(len(testCases))
+	testEngine := initHTTPServerV2(mp, false)
+
 	validateTestCases(t, testEngine, testCases, false)
 }
 

--- a/internal/proxy/bloom_filter_plan_size_test.go
+++ b/internal/proxy/bloom_filter_plan_size_test.go
@@ -250,11 +250,8 @@ func TestQueryTaskBloomFilterPlanSizeLimit(t *testing.T) {
 	ctx := context.Background()
 	schema, templateValues := bloomPlanSizeIntegrationFixture(t)
 	cache := NewMockCache(t)
-	cache.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil)
 	cache.EXPECT().GetCollectionInfo(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(&collectionInfo{}, nil).Maybe()
-	cache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).
-		Return(schema, nil).Maybe()
+		Return(&collectionInfo{collID: 1, schema: schema}, nil)
 	cache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).
 		Return(map[string]int64{}, nil)
 

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -2813,11 +2813,36 @@ func GetCollectionRateSubLabel(req any) string {
 	return ratelimitutil.GetCollectionSubLabel(dbName.(string), collectionName.(string))
 }
 
+func setReadRequestStats(ctx context.Context, inboundLabel, databaseName, collectionName string) {
+	metrics.GetStats(ctx).
+		SetNodeID(paramtable.GetNodeID()).
+		SetInboundLabel(inboundLabel).
+		SetDatabaseName(databaseName).
+		SetCollectionName(collectionName)
+}
+
 // Search searches the most similar records of requests.
 func (node *Proxy) Search(ctx context.Context, request *milvuspb.SearchRequest) (*milvuspb.SearchResults, error) {
 	var err error
 	rsp := &milvuspb.SearchResults{
 		Status: merr.Success(),
+	}
+	setReadRequestStats(ctx, metrics.SearchLabel, request.GetDbName(), request.GetCollectionName())
+	metrics.ProxyReceivedNQ.WithLabelValues(
+		strconv.FormatInt(paramtable.GetNodeID(), 10),
+		metrics.SearchLabel,
+		request.GetDbName(),
+		request.GetCollectionName(),
+	).Add(float64(request.GetNq()))
+
+	if err := merr.CheckHealthy(node.GetStateCode()); err != nil {
+		rsp.Status = merr.Status(err)
+		return rsp, nil
+	}
+	ctx, _, err = ensureReadRequestSnapshot(ctx, request.GetDbName(), request.GetCollectionName())
+	if err != nil {
+		rsp.Status = merr.Status(err)
+		return rsp, nil
 	}
 
 	optimizedSearch := true
@@ -2881,20 +2906,13 @@ func (node *Proxy) Search(ctx context.Context, request *milvuspb.SearchRequest) 
 }
 
 func (node *Proxy) search(ctx context.Context, request *milvuspb.SearchRequest, optimizedSearch bool, isRecallEvaluation bool) (*milvuspb.SearchResults, bool, bool, bool, error) {
-	metrics.GetStats(ctx).
-		SetNodeID(paramtable.GetNodeID()).
-		SetInboundLabel(metrics.SearchLabel).
-		SetDatabaseName(request.GetDbName()).
-		SetCollectionName(request.GetCollectionName())
-
-	metrics.ProxyReceivedNQ.WithLabelValues(
-		strconv.FormatInt(paramtable.GetNodeID(), 10),
-		metrics.SearchLabel,
-		request.GetDbName(),
-		request.GetCollectionName(),
-	).Add(float64(request.GetNq()))
-
 	if err := merr.CheckHealthy(node.GetStateCode()); err != nil {
+		return &milvuspb.SearchResults{
+			Status: merr.Status(err),
+		}, false, false, false, nil
+	}
+	ctx, readSnapshot, err := ensureReadRequestSnapshot(ctx, request.GetDbName(), request.GetCollectionName())
+	if err != nil {
 		return &milvuspb.SearchResults{
 			Status: merr.Status(err),
 		}, false, false, false, nil
@@ -2942,6 +2960,7 @@ func (node *Proxy) search(ctx context.Context, request *milvuspb.SearchRequest, 
 			IsRecallEvaluation: isRecallEvaluation,
 		},
 		request:                request,
+		readSnapshot:           readSnapshot,
 		tr:                     timerecord.NewTimeRecorder("search"),
 		mixCoord:               node.mixCoord,
 		node:                   node,
@@ -3089,6 +3108,17 @@ func (node *Proxy) HybridSearch(ctx context.Context, request *milvuspb.HybridSea
 	rsp := &milvuspb.SearchResults{
 		Status: merr.Success(),
 	}
+	setReadRequestStats(ctx, metrics.HybridSearchLabel, request.GetDbName(), request.GetCollectionName())
+
+	if err := merr.CheckHealthy(node.GetStateCode()); err != nil {
+		rsp.Status = merr.Status(err)
+		return rsp, nil
+	}
+	ctx, _, err = ensureReadRequestSnapshot(ctx, request.GetDbName(), request.GetCollectionName())
+	if err != nil {
+		rsp.Status = merr.Status(err)
+		return rsp, nil
+	}
 	optimizedSearch := true
 	resultSizeInsufficient := false
 	isTopkReduce := false
@@ -3141,13 +3171,13 @@ func (l *hybridSearchRequestExprLogger) String() string {
 }
 
 func (node *Proxy) hybridSearch(ctx context.Context, request *milvuspb.HybridSearchRequest, optimizedSearch bool) (*milvuspb.SearchResults, bool, bool, error) {
-	metrics.GetStats(ctx).
-		SetNodeID(paramtable.GetNodeID()).
-		SetInboundLabel(metrics.HybridSearchLabel).
-		SetDatabaseName(request.GetDbName()).
-		SetCollectionName(request.GetCollectionName())
-
 	if err := merr.CheckHealthy(node.GetStateCode()); err != nil {
+		return &milvuspb.SearchResults{
+			Status: merr.Status(err),
+		}, false, false, nil
+	}
+	ctx, readSnapshot, err := ensureReadRequestSnapshot(ctx, request.GetDbName(), request.GetCollectionName())
+	if err != nil {
 		return &milvuspb.SearchResults{
 			Status: merr.Status(err),
 		}, false, false, nil
@@ -3171,6 +3201,7 @@ func (node *Proxy) hybridSearch(ctx context.Context, request *milvuspb.HybridSea
 			IsTopkReduce: optimizedSearch,
 		},
 		request:             newSearchReq,
+		readSnapshot:        readSnapshot,
 		tr:                  timerecord.NewTimeRecorder(method),
 		mixCoord:            node.mixCoord,
 		node:                node,
@@ -3376,11 +3407,11 @@ func (node *Proxy) handleIfSearchByPK(ctx context.Context, request *milvuspb.Sea
 	}
 
 	// Get collection schema for validation and plan building
-	collectionInfo, err := globalMetaCache.GetCollectionInfo(ctx,
-		request.GetDbName(), request.GetCollectionName(), 0)
+	ctx, readSnapshot, err := ensureReadRequestSnapshot(ctx, request.GetDbName(), request.GetCollectionName())
 	if err != nil {
 		return nil, err
 	}
+	collectionInfo := readSnapshot.Collection().Info()
 
 	// Get anns_field from search params, or infer from schema if only one vector field exists
 	annsFieldName, err := funcutil.GetAttrByKeyFromRepeatedKV(AnnsFieldKey, request.SearchParams)
@@ -3470,6 +3501,7 @@ func (node *Proxy) handleIfSearchByPK(ctx context.Context, request *milvuspb.Sea
 			QueryLabel:       metrics.QueryLabel,
 		},
 		request:             queryReq,
+		readSnapshot:        readSnapshot,
 		plan:                plan,
 		mixCoord:            node.mixCoord,
 		lb:                  node.lbPolicy,
@@ -3777,6 +3809,16 @@ func (node *Proxy) Query(ctx context.Context, request *milvuspb.QueryRequest) (*
 			Status: merr.Status(err),
 		}, nil
 	}
+
+	ctx, readSnapshot, err := ensureReadRequestSnapshot(ctx, request.GetDbName(), request.GetCollectionName())
+	if err != nil {
+		return &milvuspb.QueryResults{
+			Status: merr.Status(err),
+		}, nil
+	}
+	qt.ctx = ctx
+	qt.Condition = NewTaskCondition(ctx)
+	qt.readSnapshot = readSnapshot
 
 	ctx, sp := otel.Tracer(typeutil.ProxyRole).Start(ctx, "Proxy-Query")
 	defer sp.End()

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -3809,6 +3809,15 @@ func (node *Proxy) Query(ctx context.Context, request *milvuspb.QueryRequest) (*
 			Status: merr.Status(err),
 		}, nil
 	}
+	// Preserve Query's established validation precedence over a cached metadata
+	// lookup result populated by an interceptor (for example, privilege or rate
+	// limiting). Search and HybridSearch intentionally use metadata lookup
+	// precedence for compatibility with their collection-not-found contract.
+	if err := validateCollectionName(request.GetCollectionName()); err != nil {
+		return &milvuspb.QueryResults{
+			Status: merr.Status(err),
+		}, nil
+	}
 
 	ctx, readSnapshot, err := ensureReadRequestSnapshot(ctx, request.GetDbName(), request.GetCollectionName())
 	if err != nil {

--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -2364,7 +2364,11 @@ func TestHandleIfSearchByPK_PreservesNamespaceInInternalQuery(t *testing.T) {
 		cache := NewMockCache(t)
 		cache.EXPECT().
 			GetCollectionInfo(mock.Anything, "default", "test_collection", int64(0)).
-			Return(&collectionInfo{schema: mustNewSchemaInfo(schema)}, nil)
+			Return(&collectionInfo{
+				collID: 1,
+				dbName: "default",
+				schema: mustNewSchemaInfo(schema),
+			}, nil)
 		globalMetaCache = cache
 
 		var capturedNamespace *string

--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -1069,13 +1069,26 @@ func (m *MetaCache) GetPartitionsIndex(ctx context.Context, database, collection
 }
 
 func (m *MetaCache) GetPartitionInfos(ctx context.Context, database, collectionName string) (*partitionInfos, error) {
-	method := "GetPartitionInfo"
 	// See resolvePartitionCollection: entries are keyed by the collection id, so
 	// they have exactly one location and invalidation stales exact id-keys.
 	collectionID, rpcDB, rpcName, err := m.resolvePartitionCollection(ctx, database, collectionName)
 	if err != nil {
 		return nil, err
 	}
+	return m.getPartitionInfosByID(ctx, rpcDB, collectionID, rpcName)
+}
+
+func (m *MetaCache) GetPartitionInfosByID(ctx context.Context, database string, collectionID int64) (*partitionInfos, error) {
+	return m.getPartitionInfosByID(ctx, normalizeDBName(database), collectionID, "")
+}
+
+func (m *MetaCache) getPartitionInfosByID(
+	ctx context.Context,
+	rpcDB string,
+	collectionID int64,
+	collectionName string,
+) (*partitionInfos, error) {
+	method := "GetPartitionInfo"
 	key := buildPartitionCacheKey(collectionID)
 	m.mu.RLock()
 	cached, ok := m.partitionCache[key]
@@ -1104,7 +1117,11 @@ func (m *MetaCache) GetPartitionInfos(ctx context.Context, database, collectionN
 		}
 		if collection.GetCollectionID() != collectionID {
 			// defense: the id and the returned collection must be the same one
-			return nil, merr.WrapErrCollectionNotFound(rpcName)
+			identifier := collectionName
+			if identifier == "" {
+				identifier = fmt.Sprintf("id=%d", collectionID)
+			}
+			return nil, merr.WrapErrCollectionNotFound(identifier)
 		}
 		schemaInfo, err := newSchemaInfo(collection.Schema)
 		if err != nil {

--- a/internal/proxy/meta_cache_testonly.go
+++ b/internal/proxy/meta_cache_testonly.go
@@ -25,9 +25,12 @@ import (
 	"context"
 
 	"github.com/stretchr/testify/mock"
+	"google.golang.org/protobuf/proto"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/proxy/privilege"
+	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
@@ -61,6 +64,67 @@ func InitEmptyGlobalCache() {
 	}
 	mixcoord.EXPECT().ListPolicy(mock.Anything, mock.Anything, mock.Anything).Return(&internalpb.ListPolicyResponse{Status: merr.Success()}, nil)
 	privilege.InitPrivilegeCache(context.Background(), mixcoord)
+}
+
+type proxyComponentReadCache struct {
+	Cache
+	proxy types.ProxyComponent
+}
+
+func (c *proxyComponentReadCache) GetCollectionInfo(
+	ctx context.Context,
+	database string,
+	collectionName string,
+	collectionID int64,
+) (*collectionInfo, error) {
+	resp, err := c.proxy.DescribeCollection(ctx, &milvuspb.DescribeCollectionRequest{
+		DbName:         database,
+		CollectionName: collectionName,
+		CollectionID:   collectionID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, merr.WrapErrServiceInternalMsg("test proxy returned a nil DescribeCollection response")
+	}
+	if err := merr.Error(resp.GetStatus()); err != nil {
+		return nil, err
+	}
+	schema, err := newSchemaInfo(resp.GetSchema())
+	if err != nil {
+		return nil, err
+	}
+
+	// HTTP tests historically obtain schema through the mocked Proxy instead of
+	// a real MetaCache. Supply stable non-zero identities when old mock responses
+	// omit them; production never installs this test-only adapter.
+	normalized := proto.Clone(resp).(*milvuspb.DescribeCollectionResponse)
+	if normalized.CollectionID == 0 {
+		normalized.CollectionID = 1
+	}
+	if normalized.DbId == 0 {
+		normalized.DbId = 1
+	}
+	if normalized.DbName == "" {
+		normalized.DbName = normalizeDBName(database)
+	}
+	if normalized.CollectionName == "" {
+		normalized.CollectionName = schema.GetName()
+	}
+	if normalized.CollectionName == "" {
+		normalized.CollectionName = collectionName
+	}
+	return newCollectionInfo(normalized, schema, false, ""), nil
+}
+
+// InitGlobalCacheFromProxyForTest lets HTTP tests exercise request-snapshot
+// preprocessing while keeping their existing Proxy DescribeCollection mocks.
+func InitGlobalCacheFromProxyForTest(proxyComponent types.ProxyComponent) {
+	globalMetaCache = &proxyComponentReadCache{
+		Cache: globalMetaCache,
+		proxy: proxyComponent,
+	}
 }
 
 func SetGlobalMetaCache(metaCache *MetaCache) {

--- a/internal/proxy/privilege_interceptor.go
+++ b/internal/proxy/privilege_interceptor.go
@@ -106,7 +106,17 @@ func PrivilegeInterceptor(ctx context.Context, req interface{}) (context.Context
 	// Resolve alias to actual collection name for RBAC checks
 	if Params.ProxyCfg.ResolveAliasForPrivilege.GetAsBool() && objectType == commonpb.ObjectType_Collection.String() && objectNameIndex != 0 {
 		if objectName != util.AnyWord && objectName != "" {
-			if actualCollectionName, resolveErr := resolveCollectionAlias(ctx, dbName, objectName); resolveErr != nil {
+			if _, _, isReadRequest := getReadRequestTarget(req); isReadRequest {
+				var snapshot *readRequestSnapshot
+				var resolveErr error
+				ctx, snapshot, resolveErr = ensureReadRequestSnapshot(ctx, dbName, objectName)
+				if resolveErr != nil {
+					mlog.RatedWarn(ctx, rate.Limit(60), "failed to resolve collection alias for RBAC, using original name",
+						mlog.String("objectName", objectName), mlog.FieldDbName(dbName), mlog.Err(resolveErr))
+				} else {
+					objectName = snapshot.Collection().CanonicalName()
+				}
+			} else if actualCollectionName, resolveErr := resolveCollectionAlias(ctx, dbName, objectName); resolveErr != nil {
 				mlog.RatedWarn(ctx, rate.Limit(60), "failed to resolve collection alias for RBAC, using original name",
 					mlog.String("objectName", objectName), mlog.FieldDbName(dbName), mlog.Err(resolveErr))
 			} else {

--- a/internal/proxy/rate_limit_interceptor.go
+++ b/internal/proxy/rate_limit_interceptor.go
@@ -42,6 +42,10 @@ func RateLimitInterceptor(limiter types.Limiter) grpc.UnaryServerInterceptor {
 		if !ok {
 			return nil, merr.WrapErrParameterInvalidMsg("wrong req format when check limiter")
 		}
+		ctx, _, snapshotErr, isReadRequest := ensureReadRequestSnapshotForRequest(ctx, req)
+		if isReadRequest && snapshotErr != nil {
+			return handler(ctx, req)
+		}
 		dbID, collectionIDToPartIDs, rt, n, err := GetRequestInfo(ctx, request)
 		if err != nil {
 			mlog.Warn(context.TODO(), "failed to get request info", mlog.Err(err))
@@ -155,6 +159,15 @@ func getCollectionAndPartitionID(ctx context.Context, r reqPartName) (int64, map
 }
 
 func getCollectionAndPartitionIDs(ctx context.Context, r reqPartNames) (int64, map[int64][]int64, error) {
+	if snapshot, snapshotErr, ok := readRequestSnapshotFromContext(ctx); ok {
+		if snapshotErr != nil {
+			return 0, nil, snapshotErr
+		}
+		if err := snapshot.validateTarget(r.GetDbName(), r.GetCollectionName()); err != nil {
+			return 0, nil, err
+		}
+		return getCollectionAndPartitionIDsFromSnapshot(ctx, snapshot, r)
+	}
 	db, err := globalMetaCache.GetDatabaseInfo(ctx, r.GetDbName())
 	if err != nil {
 		return 0, nil, err
@@ -185,6 +198,29 @@ func getCollectionAndPartitionIDs(ctx context.Context, r reqPartNames) (int64, m
 	}
 
 	return db.dbID, map[int64][]int64{collectionID: parts}, nil
+}
+
+func getCollectionAndPartitionIDsFromSnapshot(ctx context.Context, snapshot *readRequestSnapshot, r reqPartNames) (int64, map[int64][]int64, error) {
+	collection := snapshot.Collection()
+	partitionNames := r.GetPartitionNames()
+	if namespace := getRequestNamespace(r); namespace != nil {
+		resolvedNames, _, err := resolveNamespacePartitionNames(collection.Schema().CollectionSchema, namespace, partitionNames)
+		if err != nil {
+			return 0, nil, err
+		}
+		partitionNames = resolvedNames
+	}
+
+	parts := make([]int64, len(partitionNames))
+	for i, name := range partitionNames {
+		part, err := snapshot.PartitionInfo(ctx, name)
+		if err != nil {
+			return 0, nil, err
+		}
+		parts[i] = part.partitionID
+	}
+
+	return collection.DatabaseID(), map[int64][]int64{collection.CollectionID(): parts}, nil
 }
 
 func getCollectionID(r reqCollName) (int64, map[int64][]int64) {

--- a/internal/proxy/read_request_metrics_test.go
+++ b/internal/proxy/read_request_metrics_test.go
@@ -1,0 +1,179 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus/pkg/v3/metrics"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+func TestProxySearchMetricsRecordedBeforeEarlyReturn(t *testing.T) {
+	paramtable.Init()
+	const (
+		databaseName   = "search_metrics_early_return_db"
+		collectionName = "search_metrics_early_return_collection"
+		nq             = int64(3)
+	)
+
+	request := &milvuspb.SearchRequest{
+		DbName:         databaseName,
+		CollectionName: collectionName,
+		Nq:             nq,
+	}
+
+	run := func(t *testing.T, node *Proxy) {
+		ctx := metrics.WrapRestfulContext(context.Background(), 1)
+		receivedBytes := metrics.ProxyReceiveBytes.WithLabelValues(
+			paramtable.GetStringNodeID(), metrics.SearchLabel, databaseName, collectionName,
+		)
+		receivedNQ := metrics.ProxyReceivedNQ.WithLabelValues(
+			paramtable.GetStringNodeID(), metrics.SearchLabel, databaseName, collectionName,
+		)
+		bytesBefore := testutil.ToFloat64(receivedBytes)
+		nqBefore := testutil.ToFloat64(receivedNQ)
+
+		response, err := node.Search(ctx, request)
+		require.NoError(t, err)
+		require.Error(t, merr.Error(response.GetStatus()))
+		metrics.RecordRestfulMetrics(ctx, 0, false)
+
+		assert.Equal(t, bytesBefore+1, testutil.ToFloat64(receivedBytes))
+		assert.Equal(t, nqBefore+float64(nq), testutil.ToFloat64(receivedNQ))
+	}
+
+	t.Run("unhealthy", func(t *testing.T) {
+		node := &Proxy{}
+		node.UpdateStateCode(commonpb.StateCode_Abnormal)
+		run(t, node)
+	})
+
+	t.Run("snapshot resolution failure", func(t *testing.T) {
+		oldCache := globalMetaCache
+		defer func() { globalMetaCache = oldCache }()
+
+		cache := NewMockCache(t)
+		cache.EXPECT().
+			GetCollectionInfo(mock.Anything, databaseName, collectionName, int64(0)).
+			Return(nil, merr.ErrCollectionNotFound)
+		globalMetaCache = cache
+
+		node := &Proxy{}
+		node.UpdateStateCode(commonpb.StateCode_Healthy)
+		run(t, node)
+	})
+}
+
+func TestProxyHybridSearchStatsRecordedBeforeEarlyReturn(t *testing.T) {
+	paramtable.Init()
+	const (
+		databaseName   = "hybrid_metrics_early_return_db"
+		collectionName = "hybrid_metrics_early_return_collection"
+	)
+
+	request := &milvuspb.HybridSearchRequest{
+		DbName:         databaseName,
+		CollectionName: collectionName,
+	}
+
+	run := func(t *testing.T, node *Proxy) {
+		ctx := metrics.WrapRestfulContext(context.Background(), 1)
+		receivedBytes := metrics.ProxyReceiveBytes.WithLabelValues(
+			paramtable.GetStringNodeID(), metrics.HybridSearchLabel, databaseName, collectionName,
+		)
+		before := testutil.ToFloat64(receivedBytes)
+
+		response, err := node.HybridSearch(ctx, request)
+		require.NoError(t, err)
+		require.Error(t, merr.Error(response.GetStatus()))
+		metrics.RecordRestfulMetrics(ctx, 0, false)
+
+		assert.Equal(t, before+1, testutil.ToFloat64(receivedBytes))
+	}
+
+	t.Run("unhealthy", func(t *testing.T) {
+		node := &Proxy{}
+		node.UpdateStateCode(commonpb.StateCode_Abnormal)
+		run(t, node)
+	})
+
+	t.Run("snapshot resolution failure", func(t *testing.T) {
+		oldCache := globalMetaCache
+		defer func() { globalMetaCache = oldCache }()
+
+		cache := NewMockCache(t)
+		cache.EXPECT().
+			GetCollectionInfo(mock.Anything, databaseName, collectionName, int64(0)).
+			Return(nil, merr.ErrCollectionNotFound)
+		globalMetaCache = cache
+
+		node := &Proxy{}
+		node.UpdateStateCode(commonpb.StateCode_Healthy)
+		run(t, node)
+	})
+}
+
+func TestSearchTaskSparseNNZMetricKeepsRequestedCollectionName(t *testing.T) {
+	paramtable.Init()
+
+	histogramCount := func(t *testing.T, observer prometheus.Observer) uint64 {
+		metric, ok := observer.(prometheus.Metric)
+		require.True(t, ok)
+		value := &dto.Metric{}
+		require.NoError(t, metric.Write(value))
+		return value.GetHistogram().GetSampleCount()
+	}
+
+	for _, queryType := range []string{metrics.SearchLabel, metrics.HybridSearchLabel} {
+		t.Run(queryType, func(t *testing.T) {
+			requestedName := "requested_alias_" + queryType
+			canonicalName := "canonical_collection_" + queryType
+			fieldID := int64(101)
+			requestedMetric := metrics.ProxySearchSparseNumNonZeros.WithLabelValues(
+				paramtable.GetStringNodeID(), requestedName, queryType, "101",
+			)
+			canonicalMetric := metrics.ProxySearchSparseNumNonZeros.WithLabelValues(
+				paramtable.GetStringNodeID(), canonicalName, queryType, "101",
+			)
+			requestedBefore := histogramCount(t, requestedMetric)
+			canonicalBefore := histogramCount(t, canonicalMetric)
+
+			task := &searchTask{
+				collectionName: canonicalName,
+				request: &milvuspb.SearchRequest{
+					CollectionName: requestedName,
+				},
+			}
+			task.observeSparseVectorNNZ(queryType, fieldID, make([]byte, 18), 1)
+
+			assert.Equal(t, requestedBefore+1, histogramCount(t, requestedMetric))
+			assert.Equal(t, canonicalBefore, histogramCount(t, canonicalMetric))
+		})
+	}
+}

--- a/internal/proxy/read_snapshot.go
+++ b/internal/proxy/read_snapshot.go
@@ -218,9 +218,6 @@ func readRequestSnapshotFromContext(ctx context.Context) (*readRequestSnapshot, 
 }
 
 func resolveCollectionReadSnapshot(ctx context.Context, database, collectionName string) (*collectionReadSnapshot, error) {
-	if err := validateCollectionName(collectionName); err != nil {
-		return nil, err
-	}
 	if globalMetaCache == nil {
 		return nil, merr.WrapErrServiceNotReady(paramtable.GetRole(), paramtable.GetNodeID(), "initialization")
 	}
@@ -295,6 +292,16 @@ func ensureReadRequestSnapshotForRequest(ctx context.Context, req any) (context.
 	database, collectionName, ok := getReadRequestTarget(req)
 	if !ok {
 		return ctx, nil, nil, false
+	}
+	// Query has historically validated the collection name before consulting
+	// the metadata cache. Keep that request-specific ordering even when an
+	// interceptor has already cached a lookup result in the context. Search and
+	// HybridSearch intentionally leave lookup ordering to the metadata cache so
+	// invalid, non-existent names retain their collection-not-found contract.
+	if _, isQuery := req.(*milvuspb.QueryRequest); isQuery {
+		if err := validateCollectionName(collectionName); err != nil {
+			return ctx, nil, err, true
+		}
 	}
 	ctx, snapshot, err := ensureReadRequestSnapshot(ctx, database, collectionName)
 	return ctx, snapshot, err, true

--- a/internal/proxy/read_snapshot.go
+++ b/internal/proxy/read_snapshot.go
@@ -1,0 +1,311 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package proxy
+
+import (
+	"context"
+	"sync"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+// collectionReadSnapshot is an immutable, request-scoped binding from the
+// caller supplied collection name (which may be an alias) to one concrete
+// collection.  All collection metadata used by a read request must come from
+// info; callers must not independently resolve the alias again for schema or
+// collection properties.
+type collectionReadSnapshot struct {
+	requestedDBName         string
+	requestedCollectionName string
+	databaseID              UniqueID
+	databaseName            string
+	collectionID            UniqueID
+	canonicalName           string
+	info                    *collectionInfo
+}
+
+func (s *collectionReadSnapshot) CollectionID() UniqueID {
+	return s.collectionID
+}
+
+func (s *collectionReadSnapshot) DatabaseID() UniqueID {
+	return s.databaseID
+}
+
+func (s *collectionReadSnapshot) DatabaseName() string {
+	return s.databaseName
+}
+
+func (s *collectionReadSnapshot) RequestedCollectionName() string {
+	return s.requestedCollectionName
+}
+
+func (s *collectionReadSnapshot) CanonicalName() string {
+	return s.canonicalName
+}
+
+func (s *collectionReadSnapshot) Schema() *schemaInfo {
+	return s.info.schema
+}
+
+func (s *collectionReadSnapshot) Info() *collectionInfo {
+	return s.info
+}
+
+func (s *collectionReadSnapshot) matches(database, collectionName string) bool {
+	return normalizeDBName(s.requestedDBName) == normalizeDBName(database) &&
+		s.requestedCollectionName == collectionName
+}
+
+// readRequestSnapshot owns all state that must remain pinned across the
+// internal attempts of one external Search/Query request.  The collection
+// binding is available before task enqueue; the read timestamp is initialized
+// once the first task has a BeginTs.
+type readRequestSnapshot struct {
+	collection *collectionReadSnapshot
+
+	timestampMu      sync.RWMutex
+	timestampPinned  bool
+	consistencyLevel commonpb.ConsistencyLevel
+	requestTS        Timestamp
+	guaranteeTS      Timestamp
+
+	partitionMu sync.Mutex
+	partitions  *partitionInfos
+}
+
+func newReadRequestSnapshot(collection *collectionReadSnapshot) *readRequestSnapshot {
+	return &readRequestSnapshot{collection: collection}
+}
+
+func (s *readRequestSnapshot) Collection() *collectionReadSnapshot {
+	return s.collection
+}
+
+func (s *readRequestSnapshot) validateTarget(database, collectionName string) error {
+	if s == nil || s.collection == nil {
+		return merr.WrapErrServiceInternalMsg("read request snapshot has no collection binding")
+	}
+	if s.collection.matches(database, collectionName) {
+		return nil
+	}
+	return merr.WrapErrServiceInternalMsg(
+		"read request snapshot target mismatch: pinned %s/%s, requested %s/%s",
+		s.collection.DatabaseName(), s.collection.RequestedCollectionName(), normalizeDBName(database), collectionName)
+}
+
+func (s *readRequestSnapshot) GetPinnedTimestamp() (commonpb.ConsistencyLevel, Timestamp, Timestamp, bool) {
+	s.timestampMu.RLock()
+	defer s.timestampMu.RUnlock()
+	return s.consistencyLevel, s.requestTS, s.guaranteeTS, s.timestampPinned
+}
+
+func (s *readRequestSnapshot) PinTimestamp(consistencyLevel commonpb.ConsistencyLevel, requestTS, guaranteeTS Timestamp) {
+	s.timestampMu.Lock()
+	defer s.timestampMu.Unlock()
+	if s.timestampPinned {
+		return
+	}
+	s.consistencyLevel = consistencyLevel
+	s.requestTS = requestTS
+	s.guaranteeTS = guaranteeTS
+	s.timestampPinned = true
+}
+
+type partitionInfosByIDCache interface {
+	GetPartitionInfosByID(ctx context.Context, database string, collectionID int64) (*partitionInfos, error)
+}
+
+func (s *readRequestSnapshot) Partitions(ctx context.Context) (*partitionInfos, error) {
+	if s == nil || s.collection == nil {
+		return nil, merr.WrapErrServiceInternalMsg("read request snapshot has no collection binding")
+	}
+	s.partitionMu.Lock()
+	defer s.partitionMu.Unlock()
+	if s.partitions != nil {
+		return s.partitions, nil
+	}
+	if globalMetaCache == nil {
+		return nil, merr.WrapErrServiceNotReady(paramtable.GetRole(), paramtable.GetNodeID(), "initialization")
+	}
+
+	var partitions *partitionInfos
+	var err error
+	if cache, ok := globalMetaCache.(partitionInfosByIDCache); ok {
+		partitions, err = cache.GetPartitionInfosByID(
+			ctx,
+			s.collection.DatabaseName(),
+			s.collection.CollectionID(),
+		)
+	} else {
+		// Generated test mocks implement Cache only. Keep their fallback bound
+		// to the canonical collection name; production MetaCache always uses the
+		// id-only path above.
+		partitionMap, fetchErr := globalMetaCache.GetPartitions(
+			ctx,
+			s.collection.DatabaseName(),
+			s.collection.CanonicalName(),
+		)
+		if fetchErr != nil {
+			return nil, fetchErr
+		}
+		infos := make([]*partitionInfo, 0, len(partitionMap))
+		for name, id := range partitionMap {
+			infos = append(infos, &partitionInfo{name: name, partitionID: id})
+		}
+		partitions = parsePartitionsInfo(infos, s.collection.Schema().IsPartitionKeyCollection())
+	}
+	if err != nil {
+		return nil, err
+	}
+	if partitions == nil {
+		return nil, merr.WrapErrServiceInternalMsg(
+			"partition metadata snapshot is incomplete for collection %d", s.collection.CollectionID())
+	}
+	s.partitions = partitions
+	return s.partitions, nil
+}
+
+func (s *readRequestSnapshot) PartitionInfo(ctx context.Context, partitionName string) (*partitionInfo, error) {
+	if partitionName == "" {
+		partitionName = Params.CommonCfg.DefaultPartitionName.GetValue()
+	}
+	partitions, err := s.Partitions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if info, ok := partitions.name2Info[partitionName]; ok {
+		return info, nil
+	}
+	return nil, merr.WrapErrAsInputError(merr.WrapErrPartitionNotFound(partitionName))
+}
+
+type readRequestSnapshotContextKey struct{}
+
+type readRequestSnapshotResult struct {
+	snapshot *readRequestSnapshot
+	err      error
+}
+
+func withReadRequestSnapshotResult(ctx context.Context, result *readRequestSnapshotResult) context.Context {
+	return context.WithValue(ctx, readRequestSnapshotContextKey{}, result)
+}
+
+func readRequestSnapshotFromContext(ctx context.Context) (*readRequestSnapshot, error, bool) {
+	result, ok := ctx.Value(readRequestSnapshotContextKey{}).(*readRequestSnapshotResult)
+	if !ok || result == nil {
+		return nil, nil, false
+	}
+	return result.snapshot, result.err, true
+}
+
+func resolveCollectionReadSnapshot(ctx context.Context, database, collectionName string) (*collectionReadSnapshot, error) {
+	if err := validateCollectionName(collectionName); err != nil {
+		return nil, err
+	}
+	if globalMetaCache == nil {
+		return nil, merr.WrapErrServiceNotReady(paramtable.GetRole(), paramtable.GetNodeID(), "initialization")
+	}
+	info, err := globalMetaCache.GetCollectionInfo(ctx, database, collectionName, 0)
+	if err != nil {
+		return nil, err
+	}
+	if info == nil || !info.isCollectionCached() || info.schema.CollectionSchema == nil {
+		return nil, merr.WrapErrServiceInternalMsg(
+			"collection metadata snapshot is incomplete for %s/%s",
+			normalizeDBName(database), collectionName)
+	}
+
+	canonicalName := collectionName
+	if info.schema != nil && info.schema.GetName() != "" {
+		canonicalName = info.schema.GetName()
+	}
+	databaseName := info.dbName
+	if databaseName == "" {
+		databaseName = normalizeDBName(database)
+	}
+
+	return &collectionReadSnapshot{
+		requestedDBName:         database,
+		requestedCollectionName: collectionName,
+		databaseID:              info.dbID,
+		databaseName:            databaseName,
+		collectionID:            info.collID,
+		canonicalName:           canonicalName,
+		info:                    info,
+	}, nil
+}
+
+func ensureReadRequestSnapshot(ctx context.Context, database, collectionName string) (context.Context, *readRequestSnapshot, error) {
+	if snapshot, err, ok := readRequestSnapshotFromContext(ctx); ok {
+		if snapshot == nil {
+			if err == nil {
+				err = merr.WrapErrServiceInternalMsg("read request snapshot result has neither snapshot nor error")
+			}
+			return ctx, snapshot, err
+		}
+		if targetErr := snapshot.validateTarget(database, collectionName); targetErr != nil {
+			return ctx, nil, targetErr
+		}
+		return ctx, snapshot, err
+	}
+
+	collection, err := resolveCollectionReadSnapshot(ctx, database, collectionName)
+	if err != nil {
+		ctx = withReadRequestSnapshotResult(ctx, &readRequestSnapshotResult{err: err})
+		return ctx, nil, err
+	}
+	snapshot := newReadRequestSnapshot(collection)
+	ctx = withReadRequestSnapshotResult(ctx, &readRequestSnapshotResult{snapshot: snapshot})
+	return ctx, snapshot, nil
+}
+
+func getReadRequestTarget(req any) (string, string, bool) {
+	switch request := req.(type) {
+	case *milvuspb.SearchRequest:
+		return request.GetDbName(), request.GetCollectionName(), true
+	case *milvuspb.QueryRequest:
+		return request.GetDbName(), request.GetCollectionName(), true
+	case *milvuspb.HybridSearchRequest:
+		return request.GetDbName(), request.GetCollectionName(), true
+	default:
+		return "", "", false
+	}
+}
+
+func ensureReadRequestSnapshotForRequest(ctx context.Context, req any) (context.Context, *readRequestSnapshot, error, bool) {
+	database, collectionName, ok := getReadRequestTarget(req)
+	if !ok {
+		return ctx, nil, nil, false
+	}
+	ctx, snapshot, err := ensureReadRequestSnapshot(ctx, database, collectionName)
+	return ctx, snapshot, err, true
+}
+
+// EnsureReadRequestSnapshotForRequest pins the collection metadata used by a
+// Search, Query, or HybridSearch request and returns the context that carries
+// that binding. HTTP adapters use this before request preprocessing so schema
+// conversion, RBAC, rate limiting, and the Proxy method all observe the same
+// alias target. Non-read requests are returned unchanged.
+func EnsureReadRequestSnapshotForRequest(ctx context.Context, req any) (context.Context, error, bool) {
+	ctx, _, err, ok := ensureReadRequestSnapshotForRequest(ctx, req)
+	return ctx, err, ok
+}

--- a/internal/proxy/read_snapshot_test.go
+++ b/internal/proxy/read_snapshot_test.go
@@ -34,6 +34,7 @@ type readSnapshotTestCache struct {
 	Cache
 
 	current        *collectionInfo
+	infoErr        error
 	infoCalls      int
 	partitions     map[UniqueID]*partitionInfos
 	partitionErrs  []error
@@ -47,7 +48,7 @@ func (c *readSnapshotTestCache) GetCollectionInfo(
 	int64,
 ) (*collectionInfo, error) {
 	c.infoCalls++
-	return c.current, nil
+	return c.current, c.infoErr
 }
 
 func (c *readSnapshotTestCache) GetPartitionInfosByID(
@@ -216,6 +217,84 @@ func TestReadRequestSnapshotRejectsIncompleteMetadata(t *testing.T) {
 			require.Equal(t, 1, cache.infoCalls)
 		})
 	}
+}
+
+func TestSearchAndHybridSearchInvalidCollectionNameCompatibility(t *testing.T) {
+	oldCache := globalMetaCache
+	t.Cleanup(func() {
+		globalMetaCache = oldCache
+	})
+
+	node := &Proxy{}
+	node.UpdateStateCode(commonpb.StateCode_Healthy)
+
+	tests := map[string]func(context.Context) (*milvuspb.SearchResults, error){
+		"search": func(ctx context.Context) (*milvuspb.SearchResults, error) {
+			return node.Search(ctx, &milvuspb.SearchRequest{
+				DbName:         "default",
+				CollectionName: "12-s",
+			})
+		},
+		"hybrid search": func(ctx context.Context) (*milvuspb.SearchResults, error) {
+			return node.HybridSearch(ctx, &milvuspb.HybridSearchRequest{
+				DbName:         "default",
+				CollectionName: "12-s",
+			})
+		},
+	}
+	for name, call := range tests {
+		t.Run(name, func(t *testing.T) {
+			cache := &readSnapshotTestCache{
+				infoErr: merr.WrapErrAsInputError(
+					merr.WrapErrCollectionNotFoundWithDB("default", "12-s")),
+			}
+			globalMetaCache = cache
+
+			response, err := call(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, merr.Code(merr.ErrCollectionNotFound), response.GetStatus().GetCode())
+			require.Equal(t, "collection not found[database=default][collection=12-s]", response.GetStatus().GetReason())
+			require.Equal(t, 1, cache.infoCalls)
+		})
+	}
+}
+
+func TestReadRequestSnapshotQueryValidationPrecedesCachedLookupError(t *testing.T) {
+	ctx := withReadRequestSnapshotResult(context.Background(), &readRequestSnapshotResult{
+		err: merr.WrapErrCollectionNotFoundWithDB("default", "12-s"),
+	})
+
+	ctx, snapshot, err, ok := ensureReadRequestSnapshotForRequest(ctx, &milvuspb.QueryRequest{
+		DbName:         "default",
+		CollectionName: "12-s",
+	})
+	require.True(t, ok)
+	require.Nil(t, snapshot)
+	require.ErrorIs(t, err, merr.ErrParameterInvalid)
+	require.Contains(t, err.Error(), "Invalid collection name: 12-s")
+	require.NotNil(t, ctx)
+}
+
+func TestQueryInvalidCollectionNamePrecedesCachedLookupError(t *testing.T) {
+	oldRateCol := rateCol
+	node := &Proxy{}
+	require.NoError(t, node.initRateCollector())
+	t.Cleanup(func() {
+		rateCol = oldRateCol
+	})
+	node.UpdateStateCode(commonpb.StateCode_Healthy)
+
+	ctx := withReadRequestSnapshotResult(context.Background(), &readRequestSnapshotResult{
+		err: merr.WrapErrAsInputError(
+			merr.WrapErrCollectionNotFoundWithDB("default", "12-s")),
+	})
+	response, err := node.Query(ctx, &milvuspb.QueryRequest{
+		DbName:         "default",
+		CollectionName: "12-s",
+	})
+	require.NoError(t, err)
+	require.Equal(t, merr.Code(merr.ErrParameterInvalid), response.GetStatus().GetCode())
+	require.Contains(t, response.GetStatus().GetReason(), "Invalid collection name: 12-s")
 }
 
 func TestReadRequestSnapshotRetriesPartitionFetchAfterTransientFailure(t *testing.T) {

--- a/internal/proxy/read_snapshot_test.go
+++ b/internal/proxy/read_snapshot_test.go
@@ -1,0 +1,250 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package proxy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+type readSnapshotTestCache struct {
+	Cache
+
+	current        *collectionInfo
+	infoCalls      int
+	partitions     map[UniqueID]*partitionInfos
+	partitionErrs  []error
+	partitionCalls []UniqueID
+}
+
+func (c *readSnapshotTestCache) GetCollectionInfo(
+	context.Context,
+	string,
+	string,
+	int64,
+) (*collectionInfo, error) {
+	c.infoCalls++
+	return c.current, nil
+}
+
+func (c *readSnapshotTestCache) GetPartitionInfosByID(
+	_ context.Context,
+	_ string,
+	collectionID int64,
+) (*partitionInfos, error) {
+	c.partitionCalls = append(c.partitionCalls, collectionID)
+	if len(c.partitionErrs) > 0 {
+		err := c.partitionErrs[0]
+		c.partitionErrs = c.partitionErrs[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.partitions[collectionID], nil
+}
+
+func newAliasSnapshotCollectionInfo(
+	dbID UniqueID,
+	collectionID UniqueID,
+	name string,
+	consistencyLevel commonpb.ConsistencyLevel,
+) *collectionInfo {
+	return &collectionInfo{
+		dbID:             dbID,
+		dbName:           "db",
+		collID:           collectionID,
+		consistencyLevel: consistencyLevel,
+		schema: &schemaInfo{
+			CollectionSchema: &schemapb.CollectionSchema{Name: name},
+		},
+	}
+}
+
+func TestReadRequestSnapshotPinsAliasTargetAcrossConsumers(t *testing.T) {
+	c1 := newAliasSnapshotCollectionInfo(10, 101, "collection_1", commonpb.ConsistencyLevel_Strong)
+	c2 := newAliasSnapshotCollectionInfo(10, 202, "collection_2", commonpb.ConsistencyLevel_Bounded)
+	cache := &readSnapshotTestCache{
+		current: c1,
+		partitions: map[UniqueID]*partitionInfos{
+			101: parsePartitionsInfo([]*partitionInfo{
+				{name: Params.CommonCfg.DefaultPartitionName.GetValue(), partitionID: 1000},
+				{name: "p1", partitionID: 1001},
+			}, false),
+			202: parsePartitionsInfo([]*partitionInfo{{name: "p2", partitionID: 2001}}, false),
+		},
+	}
+	oldCache := globalMetaCache
+	globalMetaCache = cache
+	t.Cleanup(func() {
+		globalMetaCache = oldCache
+	})
+
+	ctx, snapshot, err := ensureReadRequestSnapshot(context.Background(), "db", "alias")
+	require.NoError(t, err)
+	require.Equal(t, UniqueID(101), snapshot.Collection().CollectionID())
+	require.Equal(t, "collection_1", snapshot.Collection().CanonicalName())
+	require.Same(t, c1.schema, snapshot.Collection().Schema())
+
+	// Simulate AlterAlias after this request's linearization point.
+	cache.current = c2
+	schema, err := GetCachedCollectionSchema(ctx, "db", "alias")
+	require.NoError(t, err)
+	require.Same(t, c1.schema, schema)
+
+	ctx, sameSnapshot, err := ensureReadRequestSnapshot(ctx, "db", "alias")
+	require.NoError(t, err)
+	require.Same(t, snapshot, sameSnapshot)
+	require.Equal(t, 1, cache.infoCalls)
+
+	request := &milvuspb.SearchRequest{
+		DbName:         "db",
+		CollectionName: "alias",
+		PartitionNames: []string{"p1"},
+		Nq:             3,
+	}
+	dbID, collectionToPartitions, rateType, n, err := GetRequestInfo(ctx, request)
+	require.NoError(t, err)
+	require.Equal(t, int64(10), dbID)
+	require.Equal(t, map[int64][]int64{101: {1001}}, collectionToPartitions)
+	require.Equal(t, internalpb.RateType_DQLSearch, rateType)
+	require.Equal(t, 3, n)
+	require.Equal(t, []UniqueID{101}, cache.partitionCalls)
+	require.Equal(t, 1, cache.infoCalls)
+	defaultPartition, err := snapshot.PartitionInfo(ctx, "")
+	require.NoError(t, err)
+	require.Equal(t, UniqueID(1000), defaultPartition.partitionID)
+	require.Equal(t, []UniqueID{101}, cache.partitionCalls)
+
+	search := &searchTask{
+		request: &milvuspb.SearchRequest{
+			DbName:                "db",
+			CollectionName:        "alias",
+			UseDefaultConsistency: true,
+		},
+		readSnapshot: snapshot,
+	}
+	query := &queryTask{
+		request: &milvuspb.QueryRequest{
+			DbName:                "db",
+			CollectionName:        "alias",
+			UseDefaultConsistency: true,
+		},
+		readSnapshot: snapshot,
+	}
+	require.False(t, search.CanSkipAllocTimestamp())
+	require.False(t, query.CanSkipAllocTimestamp())
+	require.Equal(t, 1, cache.infoCalls)
+
+	snapshot.PinTimestamp(commonpb.ConsistencyLevel_Strong, 11111, 12345)
+	snapshot.PinTimestamp(commonpb.ConsistencyLevel_Bounded, 22222, 67890)
+	consistencyLevel, requestTS, guaranteeTS, pinned := snapshot.GetPinnedTimestamp()
+	require.True(t, pinned)
+	require.Equal(t, commonpb.ConsistencyLevel_Strong, consistencyLevel)
+	require.Equal(t, Timestamp(11111), requestTS)
+	require.Equal(t, Timestamp(12345), guaranteeTS)
+	require.True(t, search.CanSkipAllocTimestamp())
+	require.True(t, query.CanSkipAllocTimestamp())
+
+	_, _, err = ensureReadRequestSnapshot(ctx, "db", "another_alias")
+	require.Error(t, err)
+	require.Equal(t, 1, cache.infoCalls)
+	_, _, _, _, err = GetRequestInfo(ctx, &milvuspb.SearchRequest{
+		DbName:         "db",
+		CollectionName: "another_alias",
+	})
+	require.ErrorIs(t, err, merr.ErrServiceInternal)
+	require.Equal(t, 1, cache.infoCalls)
+
+	mismatchedTask := &searchTask{
+		SearchRequest: &internalpb.SearchRequest{Base: &commonpb.MsgBase{}},
+		request: &milvuspb.SearchRequest{
+			DbName:         "db",
+			CollectionName: "another_alias",
+		},
+		readSnapshot: snapshot,
+	}
+	require.ErrorIs(t, mismatchedTask.PreExecute(context.Background()), merr.ErrServiceInternal)
+	require.Equal(t, 1, cache.infoCalls)
+
+	_, nextSnapshot, err := ensureReadRequestSnapshot(context.Background(), "db", "alias")
+	require.NoError(t, err)
+	require.Equal(t, UniqueID(202), nextSnapshot.Collection().CollectionID())
+	require.Equal(t, "collection_2", nextSnapshot.Collection().CanonicalName())
+	require.Equal(t, 2, cache.infoCalls)
+}
+
+func TestReadRequestSnapshotRejectsIncompleteMetadata(t *testing.T) {
+	tests := map[string]*collectionInfo{
+		"missing schema":        {},
+		"missing collection id": {schema: mustNewSchemaInfo(&schemapb.CollectionSchema{Name: "collection"})},
+	}
+	for name, info := range tests {
+		t.Run(name, func(t *testing.T) {
+			cache := &readSnapshotTestCache{current: info}
+			oldCache := globalMetaCache
+			globalMetaCache = cache
+			t.Cleanup(func() {
+				globalMetaCache = oldCache
+			})
+
+			_, snapshot, err := ensureReadRequestSnapshot(context.Background(), "db", "alias")
+			require.Nil(t, snapshot)
+			require.ErrorIs(t, err, merr.ErrServiceInternal)
+			require.Equal(t, 1, cache.infoCalls)
+		})
+	}
+}
+
+func TestReadRequestSnapshotRetriesPartitionFetchAfterTransientFailure(t *testing.T) {
+	collection := newAliasSnapshotCollectionInfo(10, 101, "collection", commonpb.ConsistencyLevel_Strong)
+	cache := &readSnapshotTestCache{
+		current: collection,
+		partitions: map[UniqueID]*partitionInfos{
+			101: parsePartitionsInfo([]*partitionInfo{{name: "p1", partitionID: 1001}}, false),
+		},
+		partitionErrs: []error{merr.WrapErrServiceUnavailable("proxy", "transient partition fetch failure")},
+	}
+	oldCache := globalMetaCache
+	globalMetaCache = cache
+	t.Cleanup(func() {
+		globalMetaCache = oldCache
+	})
+
+	ctx, snapshot, err := ensureReadRequestSnapshot(context.Background(), "db", "alias")
+	require.NoError(t, err)
+
+	_, err = snapshot.Partitions(ctx)
+	require.ErrorContains(t, err, "transient partition fetch failure")
+
+	partitions, err := snapshot.Partitions(ctx)
+	require.NoError(t, err)
+	require.Equal(t, UniqueID(1001), partitions.name2ID["p1"])
+	require.Equal(t, []UniqueID{101, 101}, cache.partitionCalls)
+
+	_, err = snapshot.Partitions(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []UniqueID{101, 101}, cache.partitionCalls)
+}

--- a/internal/proxy/search_pipeline.go
+++ b/internal/proxy/search_pipeline.go
@@ -1354,6 +1354,7 @@ func (op *rerankOperator) run(ctx context.Context, span trace.Span, inputs ...an
 
 type requeryOperator struct {
 	traceCtx         context.Context
+	readSnapshot     *readRequestSnapshot
 	outputFieldNames []string
 
 	timestamp          uint64
@@ -1406,6 +1407,7 @@ func newRequeryOperator(t *searchTask, _ map[string]any) (operator, error) {
 	}
 	return &requeryOperator{
 		traceCtx:           t.TraceCtx(),
+		readSnapshot:       t.readSnapshot,
 		outputFieldNames:   outputFieldNames.Collect(),
 		timestamp:          t.BeginTs(),
 		dbName:             t.request.GetDbName(),
@@ -1481,6 +1483,7 @@ func (op *requeryOperator) requery(ctx context.Context, span trace.Span, ids *sc
 			QueryLabel:       metrics.ReQueryLabel,
 		},
 		request:        queryReq,
+		readSnapshot:   op.readSnapshot,
 		plan:           plan,
 		mixCoord:       op.node.(*Proxy).mixCoord,
 		lb:             op.node.(*Proxy).lbPolicy,

--- a/internal/proxy/search_util.go
+++ b/internal/proxy/search_util.go
@@ -688,15 +688,26 @@ func getNq(req *milvuspb.SearchRequest) (int64, error) {
 }
 
 func getPartitionIDs(ctx context.Context, dbName string, collectionName string, partitionNames []string) (partitionIDs []UniqueID, err error) {
+	partitionsMap, err := globalMetaCache.GetPartitions(ctx, dbName, collectionName)
+	if err != nil {
+		return nil, err
+	}
+	return getPartitionIDsFromMap(partitionsMap, partitionNames)
+}
+
+func getPartitionIDsFromSnapshot(ctx context.Context, snapshot *readRequestSnapshot, partitionNames []string) ([]UniqueID, error) {
+	partitions, err := snapshot.Partitions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return getPartitionIDsFromMap(partitions.name2ID, partitionNames)
+}
+
+func getPartitionIDsFromMap(partitionsMap map[string]UniqueID, partitionNames []string) ([]UniqueID, error) {
 	for _, tag := range partitionNames {
 		if err := validatePartitionTag(tag, false); err != nil {
 			return nil, err
 		}
-	}
-
-	partitionsMap, err := globalMetaCache.GetPartitions(ctx, dbName, collectionName)
-	if err != nil {
-		return nil, err
 	}
 
 	useRegexp := Params.ProxyCfg.PartitionNameRegexp.GetAsBool()

--- a/internal/proxy/service_provider.go
+++ b/internal/proxy/service_provider.go
@@ -153,7 +153,10 @@ type CachedProxyServiceProvider struct {
 	*Proxy
 }
 
-func describeCollectionErrorStatus(err error, database, collectionName string) *commonpb.Status {
+// CollectionLookupErrorStatus converts a user-facing collection name lookup
+// failure to its public wire representation, including the established
+// collection-not-found message kept for SDK compatibility.
+func CollectionLookupErrorStatus(err error, database, collectionName string) *commonpb.Status {
 	// A user-facing DescribeCollection miss is an input error, but keep the
 	// precise source code: a missing database is ErrDatabaseNotFound while a
 	// missing collection is ErrCollectionNotFound. The sentinels remain system
@@ -280,7 +283,7 @@ func (node *CachedProxyServiceProvider) DescribeCollection(ctx context.Context,
 		// are deliberately returned uncached because their database is unknown).
 		c, err = globalMetaCache.GetCollectionInfo(ctx, request.DbName, "", collectionID)
 		if err != nil {
-			resp.Status = describeCollectionErrorStatus(err, request.DbName, collectionName)
+			resp.Status = CollectionLookupErrorStatus(err, request.DbName, collectionName)
 			return resp, nil
 		}
 		collectionName = c.schema.GetName()
@@ -288,7 +291,7 @@ func (node *CachedProxyServiceProvider) DescribeCollection(ctx context.Context,
 
 	// validate collection name, ref describeCollectionTask.PreExecute
 	if err = validateCollectionName(collectionName); err != nil {
-		resp.Status = describeCollectionErrorStatus(err, request.DbName, collectionName)
+		resp.Status = CollectionLookupErrorStatus(err, request.DbName, collectionName)
 		return resp, nil
 	}
 
@@ -297,12 +300,12 @@ func (node *CachedProxyServiceProvider) DescribeCollection(ctx context.Context,
 	if !resolvedNameByID {
 		collectionID, err = globalMetaCache.GetCollectionID(ctx, request.DbName, collectionName)
 		if err != nil {
-			resp.Status = describeCollectionErrorStatus(err, request.DbName, collectionName)
+			resp.Status = CollectionLookupErrorStatus(err, request.DbName, collectionName)
 			return resp, nil
 		}
 		c, err = globalMetaCache.GetCollectionInfo(ctx, request.DbName, collectionName, collectionID)
 		if err != nil {
-			resp.Status = describeCollectionErrorStatus(err, request.DbName, collectionName)
+			resp.Status = CollectionLookupErrorStatus(err, request.DbName, collectionName)
 			return resp, nil
 		}
 	}

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -1759,7 +1759,7 @@ func (t *describeCollectionTask) Execute(ctx context.Context) error {
 	}
 
 	if !merr.Ok(result.GetStatus()) {
-		t.result.Status = describeCollectionErrorStatus(
+		t.result.Status = CollectionLookupErrorStatus(
 			merr.Error(result.GetStatus()), t.GetDbName(), t.GetCollectionName())
 		return nil
 	}

--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -57,6 +57,7 @@ type queryTask struct {
 	ctx            context.Context
 	result         *milvuspb.QueryResults
 	request        *milvuspb.QueryRequest
+	readSnapshot   *readRequestSnapshot
 	mixCoord       types.MixCoordClient
 	ids            *schemapb.IDs
 	collectionName string
@@ -620,6 +621,11 @@ func (t *queryTask) hasCountStar() bool {
 
 func (t *queryTask) CanSkipAllocTimestamp() bool {
 	var consistencyLevel commonpb.ConsistencyLevel
+	if t.readSnapshot != nil {
+		if _, _, _, pinned := t.readSnapshot.GetPinnedTimestamp(); pinned {
+			return true
+		}
+	}
 	useDefaultConsistency := t.request.GetUseDefaultConsistency()
 	if !useDefaultConsistency {
 		// legacy SDK & resultful behavior
@@ -628,6 +634,10 @@ func (t *queryTask) CanSkipAllocTimestamp() bool {
 		}
 		consistencyLevel = t.request.GetConsistencyLevel()
 	} else {
+		if t.readSnapshot != nil {
+			consistencyLevel = t.readSnapshot.Collection().Info().consistencyLevel
+			return consistencyLevel != commonpb.ConsistencyLevel_Strong
+		}
 		collID, err := globalMetaCache.GetCollectionID(context.Background(), t.request.GetDbName(), t.request.GetCollectionName())
 		if err != nil { // err is not nil if collection not exists
 			mlog.Warn(t.ctx, "query task get collectionID failed, can't skip alloc timestamp",
@@ -650,44 +660,36 @@ func (t *queryTask) PreExecute(ctx context.Context) error {
 	t.Base.MsgType = commonpb.MsgType_Retrieve
 	t.Base.SourceID = paramtable.GetNodeID()
 
-	collectionName := t.request.CollectionName
-	t.collectionName = collectionName
-
-	log := mlog.With(mlog.String("collectionName", collectionName),
+	requestedCollectionName := t.request.CollectionName
+	log := mlog.With(mlog.String("collectionName", requestedCollectionName),
 		mlog.Strings("partitionNames", t.request.GetPartitionNames()),
 		mlog.String("requestType", t.getQueryLabel()))
 
-	if err := validateCollectionName(collectionName); err != nil {
+	if err := validateCollectionName(requestedCollectionName); err != nil {
 		log.Warn(ctx, "Invalid collectionName.")
 		return err
 	}
 	log.Debug(ctx, "Validate collectionName.")
 
-	collID, err := globalMetaCache.GetCollectionID(ctx, t.request.GetDbName(), collectionName)
-	if err != nil {
-		log.Warn(ctx, "Failed to get collection id.", mlog.String("collectionName", collectionName), mlog.Err(err))
+	if t.readSnapshot == nil {
+		_, snapshot, err := ensureReadRequestSnapshot(ctx, t.request.GetDbName(), requestedCollectionName)
+		if err != nil {
+			return err
+		}
+		t.readSnapshot = snapshot
+	}
+	if err := t.readSnapshot.validateTarget(t.request.GetDbName(), requestedCollectionName); err != nil {
 		return err
 	}
-	t.CollectionID = collID
-
-	colInfo, err := globalMetaCache.GetCollectionInfo(ctx, t.request.GetDbName(), collectionName, t.CollectionID)
-	if err != nil {
-		log.Warn(ctx, "Failed to get collection info.", mlog.String("collectionName", collectionName),
-			mlog.Int64("collectionID", t.CollectionID), mlog.Err(err))
-		// The name was already resolved above (GetCollectionID succeeded), so a
-		// not-found here means the collection was concurrently dropped between the
-		// two lookups — a TOCTOU race, not the caller's input error. Leave it as the
-		// default SystemError; do not stamp InputError.
-		return err
-	}
-	log.Debug(ctx, "Get collection ID by name", mlog.Int64("collectionID", t.CollectionID))
-
-	schema, err := globalMetaCache.GetCollectionSchema(ctx, t.request.GetDbName(), t.collectionName)
-	if err != nil {
-		log.Warn(ctx, "get collection schema failed", mlog.Err(err))
-		return err
-	}
+	collectionSnapshot := t.readSnapshot.Collection()
+	collectionName := collectionSnapshot.CanonicalName()
+	t.collectionName = collectionName
+	t.CollectionID = collectionSnapshot.CollectionID()
+	colInfo := collectionSnapshot.Info()
+	schema := collectionSnapshot.Schema()
 	t.schema = schema
+	log.Debug(ctx, "Use collection read snapshot", mlog.Int64("collectionID", t.CollectionID))
+
 	if err := validateTextStorageV3Enabled(t.schema.CollectionSchema); err != nil {
 		return err
 	}
@@ -699,11 +701,7 @@ func (t *queryTask) PreExecute(ctx context.Context) error {
 		t.request.PartitionNames = partitionNames
 	}
 
-	t.partitionKeyMode, err = isPartitionKeyMode(ctx, t.request.GetDbName(), collectionName)
-	if err != nil {
-		log.Warn(ctx, "check partition key mode failed", mlog.Int64("collectionID", t.CollectionID), mlog.Err(err))
-		return err
-	}
+	t.partitionKeyMode = t.schema.IsPartitionKeyCollection()
 	if t.partitionKeyMode && len(t.request.GetPartitionNames()) != 0 {
 		return merr.WrapErrParameterInvalidMsg("not support manually specifying the partition names if partition key mode is used")
 	}
@@ -794,7 +792,7 @@ func (t *queryTask) PreExecute(ctx context.Context) error {
 	if !t.reQuery {
 		partitionNames := t.request.GetPartitionNames()
 		if namespacePartitionKeyMode(t.schema.CollectionSchema) && t.request.Namespace != nil {
-			hashedPartitionNames, err := assignNamespacePartitionKey(ctx, t.request.GetDbName(), t.request.CollectionName, t.request.Namespace)
+			hashedPartitionNames, err := assignNamespacePartitionKeyFromSnapshot(ctx, t.readSnapshot, t.request.Namespace)
 			if err != nil {
 				return err
 			}
@@ -806,14 +804,14 @@ func (t *queryTask) PreExecute(ctx context.Context) error {
 				return err
 			}
 			partitionKeys := exprutil.ParseKeys(expr, exprutil.PartitionKey)
-			hashedPartitionNames, err := assignPartitionKeys(ctx, t.request.GetDbName(), t.request.CollectionName, partitionKeys)
+			hashedPartitionNames, err := assignPartitionKeysFromSnapshot(ctx, t.readSnapshot, partitionKeys)
 			if err != nil {
 				return err
 			}
 
 			partitionNames = append(partitionNames, hashedPartitionNames...)
 		}
-		t.PartitionIDs, err = getPartitionIDs(ctx, t.request.GetDbName(), t.request.CollectionName, partitionNames)
+		t.PartitionIDs, err = getPartitionIDsFromSnapshot(ctx, t.readSnapshot, partitionNames)
 		if err != nil {
 			return err
 		}
@@ -836,46 +834,44 @@ func (t *queryTask) PreExecute(ctx context.Context) error {
 		t.Username = username
 	}
 
-	collectionInfo, err2 := globalMetaCache.GetCollectionInfo(ctx, t.request.GetDbName(), collectionName, t.CollectionID)
-	if err2 != nil {
-		log.Warn(ctx, "Proxy::queryTask::PreExecute failed to GetCollectionInfo from cache",
-			mlog.String("collectionName", collectionName), mlog.Int64("collectionID", t.CollectionID),
-			mlog.Err(err2))
-		return err2
-	}
-
-	guaranteeTs := t.request.GetGuaranteeTimestamp()
-	var consistencyLevel commonpb.ConsistencyLevel
-	useDefaultConsistency := t.request.GetUseDefaultConsistency()
-	t.ConsistencyLevel = t.request.GetConsistencyLevel()
-	if useDefaultConsistency {
-		consistencyLevel = collectionInfo.consistencyLevel
-		guaranteeTs = parseGuaranteeTsFromConsistency(guaranteeTs, t.BeginTs(), consistencyLevel)
-	} else {
-		consistencyLevel = t.request.GetConsistencyLevel()
-		// Compatibility logic, parse guarantee timestamp
-		if consistencyLevel == 0 && guaranteeTs > 0 {
-			guaranteeTs = parseGuaranteeTs(guaranteeTs, t.BeginTs())
-		} else {
-			// parse from guarantee timestamp and user input consistency level
+	consistencyLevel, requestTS, guaranteeTs, timestampPinned := t.readSnapshot.GetPinnedTimestamp()
+	if !timestampPinned {
+		requestTS = t.BeginTs()
+		guaranteeTs = t.request.GetGuaranteeTimestamp()
+		useDefaultConsistency := t.request.GetUseDefaultConsistency()
+		if useDefaultConsistency {
+			consistencyLevel = colInfo.consistencyLevel
 			guaranteeTs = parseGuaranteeTsFromConsistency(guaranteeTs, t.BeginTs(), consistencyLevel)
+		} else {
+			consistencyLevel = t.request.GetConsistencyLevel()
+			// Compatibility logic, parse guarantee timestamp
+			if consistencyLevel == 0 && guaranteeTs > 0 {
+				guaranteeTs = parseGuaranteeTs(guaranteeTs, t.BeginTs())
+			} else {
+				// parse from guarantee timestamp and user input consistency level
+				guaranteeTs = parseGuaranteeTsFromConsistency(guaranteeTs, t.BeginTs(), consistencyLevel)
+			}
 		}
+
+		// use collection schema updated timestamp if it's greater than calculate guarantee timestamp
+		// this make query view updated happens before new read request happens
+		// see also schema change design
+		if colInfo.updateTimestamp > guaranteeTs {
+			guaranteeTs = colInfo.updateTimestamp
+		}
+		t.readSnapshot.PinTimestamp(consistencyLevel, requestTS, guaranteeTs)
+		consistencyLevel, requestTS, guaranteeTs, _ = t.readSnapshot.GetPinnedTimestamp()
 	}
+	t.Base.Timestamp = requestTS
 
 	// update actual consistency level
 	accesslog.SetActualConsistencyLevel(ctx, consistencyLevel)
-
-	// use collection schema updated timestamp if it's greater than calculate guarantee timestamp
-	// this make query view updated happens before new read request happens
-	// see also schema change design
-	if collectionInfo.updateTimestamp > guaranteeTs {
-		guaranteeTs = collectionInfo.updateTimestamp
-	}
 
 	t.GuaranteeTimestamp = guaranteeTs
 	// Extract physical time for entity-level TTL (issue #47413)
 	physicalTimeMs, _ := tsoutil.ParseHybridTs(guaranteeTs)
 	t.EntityTtlPhysicalTime = uint64(physicalTimeMs * 1000)
+	t.ConsistencyLevel = consistencyLevel
 	// need modify mvccTs and guaranteeTs for iterator specially
 	if t.queryParams.isIterator && t.request.GetGuaranteeTimestamp() > 0 {
 		t.MvccTimestamp = t.request.GetGuaranteeTimestamp()
@@ -883,13 +879,13 @@ func (t *queryTask) PreExecute(ctx context.Context) error {
 	}
 	t.IsIterator = queryParams.isIterator
 
-	if collectionInfo.collectionTTL != 0 {
+	if colInfo.collectionTTL != 0 {
 		physicalTime := tsoutil.PhysicalTime(t.GetBase().GetTimestamp())
-		expireTime := physicalTime.Add(-time.Duration(collectionInfo.collectionTTL))
+		expireTime := physicalTime.Add(-time.Duration(colInfo.collectionTTL))
 		t.CollectionTtlTimestamps = tsoutil.ComposeTSByTime(expireTime)
 		// preventing overflow, abort
 		if t.CollectionTtlTimestamps > t.GetBase().GetTimestamp() {
-			return merr.WrapErrServiceInternalMsg("ttl timestamp overflow, base timestamp: %d, ttl duration %v", t.GetBase().GetTimestamp(), collectionInfo.collectionTTL)
+			return merr.WrapErrServiceInternalMsg("ttl timestamp overflow, base timestamp: %d, ttl duration %v", t.GetBase().GetTimestamp(), colInfo.collectionTTL)
 		}
 	}
 	deadline, ok := t.TraceCtx().Deadline()
@@ -1048,7 +1044,7 @@ func (t *queryTask) PostExecute(ctx context.Context) error {
 		reconstructStructFieldDataForQuery(t.result, t.schema.CollectionSchema)
 	}
 
-	t.result.CollectionName = t.collectionName
+	t.result.CollectionName = t.request.GetCollectionName()
 	t.result.PrimaryFieldName = primaryFieldSchema.GetName()
 	metrics.ProxyReduceResultLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), t.getQueryLabel()).Observe(float64(tr.RecordSpan().Microseconds()) / 1000.0)
 

--- a/internal/proxy/task_query_namespace_test.go
+++ b/internal/proxy/task_query_namespace_test.go
@@ -55,24 +55,25 @@ func TestQueryTask_PlanNamespace_AfterPreExecute(t *testing.T) {
 	mockey.PatchConvey("TestQueryTask_PlanNamespace_AfterPreExecute", t, func() {
 		// Setup global meta cache and common mocks
 		globalMetaCache = &MetaCache{}
-		mockey.Mock((*MetaCache).GetCollectionID).Return(int64(1001), nil).Build()
-		mockey.Mock((*MetaCache).GetCollectionInfo).Return(&collectionInfo{updateTimestamp: 12345, consistencyLevel: commonpb.ConsistencyLevel_Strong}, nil).Build()
-		mockey.Mock(isPartitionKeyMode).Return(false, nil).Build()
 		mockey.Mock(validatePartitionTag).Return(nil).Build()
 		mockey.Mock(isIgnoreGrowing).Return(false, nil).Build()
 
 		// Schema with namespace enabled
-		mockey.Mock((*MetaCache).GetCollectionSchema).To(func(_ *MetaCache, _ context.Context, _ string, _ string) (*schemaInfo, error) {
-			schema := &schemapb.CollectionSchema{
-				Name: "test_collection",
-				Fields: []*schemapb.FieldSchema{
-					{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
-					{FieldID: 101, Name: "value", DataType: schemapb.DataType_Int32},
-				},
-				EnableNamespace: true,
-			}
-			return mustNewSchemaInfo(schema), nil
-		}).Build()
+		schema := mustNewSchemaInfo(&schemapb.CollectionSchema{
+			Name: "test_collection",
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 101, Name: "value", DataType: schemapb.DataType_Int32},
+			},
+			EnableNamespace: true,
+		})
+		mockey.Mock((*MetaCache).GetCollectionInfo).Return(&collectionInfo{
+			collID:           1001,
+			dbName:           defaultDB,
+			schema:           schema,
+			updateTimestamp:  12345,
+			consistencyLevel: commonpb.ConsistencyLevel_Strong,
+		}, nil).Build()
 
 		// Capture plan to verify namespace by mocking plan creation inside createPlan
 		var capturedPlan *planpb.PlanNode
@@ -125,11 +126,19 @@ func TestQueryTask_NamespaceSetsPartitionIDs(t *testing.T) {
 			&schemapb.FieldSchema{FieldID: 101, Name: "value", DataType: schemapb.DataType_Int64},
 		)
 
-		mockey.Mock((*MetaCache).GetCollectionID).Return(int64(1001), nil).Build()
-		mockey.Mock((*MetaCache).GetCollectionInfo).Return(&collectionInfo{updateTimestamp: 12345, consistencyLevel: commonpb.ConsistencyLevel_Strong}, nil).Build()
-		mockey.Mock((*MetaCache).GetCollectionSchema).Return(mustNewSchemaInfo(schema), nil).Build()
-		mockey.Mock((*MetaCache).GetPartitionsIndex).Return(partitionNames, nil).Build()
-		mockey.Mock((*MetaCache).GetPartitions).Return(partitionIDs, nil).Build()
+		schemaInfo := mustNewSchemaInfo(schema)
+		mockey.Mock((*MetaCache).GetCollectionInfo).Return(&collectionInfo{
+			collID:           1001,
+			dbName:           defaultDB,
+			schema:           schemaInfo,
+			updateTimestamp:  12345,
+			consistencyLevel: commonpb.ConsistencyLevel_Strong,
+		}, nil).Build()
+		mockey.Mock((*MetaCache).GetPartitionInfosByID).Return(
+			parsePartitionsInfo([]*partitionInfo{
+				{name: partitionNames[0], partitionID: partitionIDs[partitionNames[0]]},
+				{name: partitionNames[1], partitionID: partitionIDs[partitionNames[1]]},
+			}, true), nil).Build()
 		mockey.Mock(validatePartitionTag).Return(nil).Build()
 		mockey.Mock(isIgnoreGrowing).Return(false, nil).Build()
 

--- a/internal/proxy/task_query_test.go
+++ b/internal/proxy/task_query_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/testutils"
+	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -350,18 +351,23 @@ func TestQueryTask_all(t *testing.T) {
 						Value: "True",
 					},
 				},
-				GuaranteeTimestamp: enqueTs,
+				GuaranteeTimestamp:    enqueTs,
+				UseDefaultConsistency: true,
 			},
 			mixCoord:       qc,
 			lb:             lb,
 			shardclientMgr: mgr,
 			resultBuf:      &typeutil.ConcurrentSet[*internalpb.RetrieveResults]{},
 		}
+		secondPageTs := tsoutil.ComposeTSByTime(time.Now())
+		qt.SetTs(secondPageTs)
 		qtErr = qt.PreExecute(context.TODO())
 		assert.Nil(t, qtErr)
 		assert.True(t, qt.queryParams.isIterator)
 		// from the second page, the mvccTs is set to the sessionTs init in the first page
 		assert.Equal(t, enqueTs, qt.GetMvccTimestamp())
+		expectedPhysicalMs, _ := tsoutil.ParseHybridTs(secondPageTs)
+		assert.Equal(t, uint64(expectedPhysicalMs*1000), qt.GetEntityTtlPhysicalTime())
 	})
 
 	t.Run("test count(*) with aggregation validation rules", func(t *testing.T) {

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -69,6 +69,9 @@ type searchTask struct {
 
 	result  *milvuspb.SearchResults
 	request *milvuspb.SearchRequest
+	// readSnapshot pins alias resolution and collection metadata for the whole
+	// external Search request, including internal retries and requery.
+	readSnapshot *readRequestSnapshot
 
 	tr                     *timerecord.TimeRecorder
 	collectionName         string
@@ -130,6 +133,11 @@ type searchTask struct {
 
 func (t *searchTask) CanSkipAllocTimestamp() bool {
 	var consistencyLevel commonpb.ConsistencyLevel
+	if t.readSnapshot != nil {
+		if _, _, _, pinned := t.readSnapshot.GetPinnedTimestamp(); pinned {
+			return true
+		}
+	}
 	useDefaultConsistency := t.request.GetUseDefaultConsistency()
 	if !useDefaultConsistency {
 		// legacy SDK & restful behavior
@@ -138,6 +146,10 @@ func (t *searchTask) CanSkipAllocTimestamp() bool {
 		}
 		consistencyLevel = t.request.GetConsistencyLevel()
 	} else {
+		if t.readSnapshot != nil {
+			consistencyLevel = t.readSnapshot.Collection().Info().consistencyLevel
+			return consistencyLevel != commonpb.ConsistencyLevel_Strong
+		}
 		collID, err := globalMetaCache.GetCollectionID(context.Background(), t.request.GetDbName(), t.request.GetCollectionName())
 		if err != nil { // err is not nil if collection not exists
 			mlog.Warn(t.ctx, "search task get collectionID failed, can't skip alloc timestamp",
@@ -164,39 +176,35 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 	t.Base.MsgType = commonpb.MsgType_Search
 	t.Base.SourceID = paramtable.GetNodeID()
 
-	collectionName := t.request.CollectionName
-	t.collectionName = collectionName
-	collID, err := globalMetaCache.GetCollectionID(ctx, t.request.GetDbName(), collectionName)
-	if err != nil { // err is not nil if collection not exists
+	requestedCollectionName := t.request.CollectionName
+	if t.readSnapshot == nil {
+		_, snapshot, err := ensureReadRequestSnapshot(ctx, t.request.GetDbName(), requestedCollectionName)
+		if err != nil {
+			return err
+		}
+		t.readSnapshot = snapshot
+	}
+	if err := t.readSnapshot.validateTarget(t.request.GetDbName(), requestedCollectionName); err != nil {
 		return err
 	}
+	collectionSnapshot := t.readSnapshot.Collection()
+	collectionName := collectionSnapshot.CanonicalName()
+	t.collectionName = collectionName
+	collID := collectionSnapshot.CollectionID()
 
 	t.DbID = 0 // todo
 	t.CollectionID = collID
 	log := mlog.With(mlog.Int64("collID", collID), mlog.String("collName", collectionName))
-	t.schema, err = globalMetaCache.GetCollectionSchema(ctx, t.request.GetDbName(), collectionName)
-	if err != nil {
-		log.Warn(ctx, "get collection schema failed", mlog.Err(err))
-		return err
-	}
+	t.schema = collectionSnapshot.Schema()
 	if err := validateTextStorageV3Enabled(t.schema.CollectionSchema); err != nil {
 		return err
 	}
 
-	collectionInfo, err2 := globalMetaCache.GetCollectionInfo(ctx, t.request.GetDbName(), collectionName, t.CollectionID)
-	if err2 != nil {
-		log.Warn(ctx, "Proxy::searchTask::PreExecute failed to GetCollectionInfo from cache",
-			mlog.String("collectionName", collectionName), mlog.Int64("collectionID", t.CollectionID), mlog.Err(err2))
-		return err2
-	}
+	collectionInfo := collectionSnapshot.Info()
 	t.largeTopKEnabled = collectionInfo.queryMode == common.QueryModeLargeTopK
 	t.partitionKeyIsolation = collectionInfo.partitionKeyIsolation
 
-	t.partitionKeyMode, err = isPartitionKeyMode(ctx, t.request.GetDbName(), collectionName)
-	if err != nil {
-		log.Warn(ctx, "is partition key mode failed", mlog.Err(err))
-		return err
-	}
+	t.partitionKeyMode = t.schema.IsPartitionKeyCollection()
 	partitionNames, namespaceAsPartition, err := resolveNamespacePartitionNames(t.schema.CollectionSchema, t.request.Namespace, t.request.GetPartitionNames())
 	if err != nil {
 		return err
@@ -214,7 +222,7 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 
 	if !t.partitionKeyMode && len(t.request.GetPartitionNames()) > 0 {
 		// translate partition name to partition ids. Use regex-pattern to match partition name.
-		t.PartitionIDs, err = getPartitionIDs(ctx, t.request.GetDbName(), collectionName, t.request.GetPartitionNames())
+		t.PartitionIDs, err = getPartitionIDsFromSnapshot(ctx, t.readSnapshot, t.request.GetPartitionNames())
 		if err != nil {
 			log.Warn(ctx, "failed to get partition ids", mlog.Err(err))
 			return err
@@ -287,32 +295,38 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 
-	guaranteeTs := t.request.GetGuaranteeTimestamp()
-	var consistencyLevel commonpb.ConsistencyLevel
+	consistencyLevel, requestTS, guaranteeTs, timestampPinned := t.readSnapshot.GetPinnedTimestamp()
 	useDefaultConsistency := t.request.GetUseDefaultConsistency()
-	if useDefaultConsistency {
-		consistencyLevel = collectionInfo.consistencyLevel
-		guaranteeTs = parseGuaranteeTsFromConsistency(guaranteeTs, t.BeginTs(), consistencyLevel)
-	} else {
-		consistencyLevel = t.request.GetConsistencyLevel()
-		// Compatibility logic, parse guarantee timestamp
-		if consistencyLevel == 0 && guaranteeTs > 0 {
-			guaranteeTs = parseGuaranteeTs(guaranteeTs, t.BeginTs())
-		} else {
-			// parse from guarantee timestamp and user input consistency level
+	if !timestampPinned {
+		requestTS = t.BeginTs()
+		guaranteeTs = t.request.GetGuaranteeTimestamp()
+		if useDefaultConsistency {
+			consistencyLevel = collectionInfo.consistencyLevel
 			guaranteeTs = parseGuaranteeTsFromConsistency(guaranteeTs, t.BeginTs(), consistencyLevel)
+		} else {
+			consistencyLevel = t.request.GetConsistencyLevel()
+			// Compatibility logic, parse guarantee timestamp
+			if consistencyLevel == 0 && guaranteeTs > 0 {
+				guaranteeTs = parseGuaranteeTs(guaranteeTs, t.BeginTs())
+			} else {
+				// parse from guarantee timestamp and user input consistency level
+				guaranteeTs = parseGuaranteeTsFromConsistency(guaranteeTs, t.BeginTs(), consistencyLevel)
+			}
 		}
+
+		// use collection schema updated timestamp if it's greater than calculate guarantee timestamp
+		// this make query view updated happens before new read request happens
+		// see also schema change design
+		if collectionInfo.updateTimestamp > guaranteeTs {
+			guaranteeTs = collectionInfo.updateTimestamp
+		}
+		t.readSnapshot.PinTimestamp(consistencyLevel, requestTS, guaranteeTs)
+		consistencyLevel, requestTS, guaranteeTs, _ = t.readSnapshot.GetPinnedTimestamp()
 	}
+	t.Base.Timestamp = requestTS
 
 	// update actual consistency level
 	accesslog.SetActualConsistencyLevel(ctx, consistencyLevel)
-
-	// use collection schema updated timestamp if it's greater than calculate guarantee timestamp
-	// this make query view updated happens before new read request happens
-	// see also schema change design
-	if collectionInfo.updateTimestamp > guaranteeTs {
-		guaranteeTs = collectionInfo.updateTimestamp
-	}
 
 	t.GuaranteeTimestamp = guaranteeTs
 	// Extract physical time for entity-level TTL (issue #47413)
@@ -689,7 +703,7 @@ func (t *searchTask) initAdvancedSearchRequest(ctx context.Context) error {
 			return err
 		}
 		if typeutil.IsFieldSparseFloatVector(t.schema.CollectionSchema, internalSubReq.FieldId) {
-			metrics.ProxySearchSparseNumNonZeros.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), t.collectionName, metrics.HybridSearchLabel, strconv.FormatInt(internalSubReq.FieldId, 10)).Observe(float64(typeutil.EstimateSparseVectorNNZFromPlaceholderGroup(internalSubReq.PlaceholderGroup, int(internalSubReq.GetNq()))))
+			t.observeSparseVectorNNZ(metrics.HybridSearchLabel, internalSubReq.FieldId, internalSubReq.PlaceholderGroup, int(internalSubReq.GetNq()))
 		}
 		internalSubReq.PlaceholderGroup = convertedPlaceholder
 		t.SubReqs[index] = internalSubReq
@@ -1038,7 +1052,7 @@ func (t *searchTask) initSearchRequest(ctx context.Context) error {
 	}
 	t.PkFilter = checkSegmentFilter(plan)
 	if typeutil.IsFieldSparseFloatVector(t.schema.CollectionSchema, t.FieldId) {
-		metrics.ProxySearchSparseNumNonZeros.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), t.collectionName, metrics.SearchLabel, strconv.FormatInt(t.FieldId, 10)).Observe(float64(typeutil.EstimateSparseVectorNNZFromPlaceholderGroup(t.request.GetPlaceholderGroup(), int(t.request.GetNq()))))
+		t.observeSparseVectorNNZ(metrics.SearchLabel, t.FieldId, t.request.GetPlaceholderGroup(), int(t.request.GetNq()))
 	}
 	// Convert placeholder group vector type if needed (e.g., fp32 -> fp16/bf16)
 	var placeholderType commonpb.PlaceholderType
@@ -1120,6 +1134,15 @@ func (t *searchTask) initSearchRequest(ctx context.Context) error {
 	return nil
 }
 
+func (t *searchTask) observeSparseVectorNNZ(queryType string, fieldID int64, placeholderGroup []byte, nq int) {
+	metrics.ProxySearchSparseNumNonZeros.WithLabelValues(
+		strconv.FormatInt(paramtable.GetNodeID(), 10),
+		t.request.GetCollectionName(),
+		queryType,
+		strconv.FormatInt(fieldID, 10),
+	).Observe(float64(typeutil.EstimateSparseVectorNNZFromPlaceholderGroup(placeholderGroup, nq)))
+}
+
 func (t *searchTask) skipRequeryByNamespacePartitionMode() bool {
 	return t.schema != nil &&
 		t.schema.CollectionSchema != nil &&
@@ -1190,13 +1213,13 @@ func (t *searchTask) tryGeneratePlan(params []*commonpb.KeyValuePair, dsl string
 
 func (t *searchTask) tryParsePartitionIDsFromPlan(plan *planpb.PlanNode) ([]int64, error) {
 	if namespacePartitionKeyMode(t.schema.CollectionSchema) && t.request.Namespace != nil {
-		hashedPartitionNames, err := assignNamespacePartitionKey(t.ctx, t.request.GetDbName(), t.collectionName, t.request.Namespace)
+		hashedPartitionNames, err := assignNamespacePartitionKeyFromSnapshot(t.ctx, t.readSnapshot, t.request.Namespace)
 		if err != nil {
 			mlog.Warn(t.ctx, "failed to assign namespace partition key", mlog.Err(err))
 			return nil, err
 		}
 		if len(hashedPartitionNames) > 0 {
-			PartitionIDs, err2 := getPartitionIDs(t.ctx, t.request.GetDbName(), t.collectionName, hashedPartitionNames)
+			PartitionIDs, err2 := getPartitionIDsFromSnapshot(t.ctx, t.readSnapshot, hashedPartitionNames)
 			if err2 != nil {
 				mlog.Warn(t.ctx, "failed to get namespace partition ids", mlog.Err(err2))
 				return nil, err2
@@ -1212,7 +1235,7 @@ func (t *searchTask) tryParsePartitionIDsFromPlan(plan *planpb.PlanNode) ([]int6
 		return nil, err
 	}
 	partitionKeys := exprutil.ParseKeys(expr, exprutil.PartitionKey)
-	hashedPartitionNames, err := assignPartitionKeys(t.ctx, t.request.GetDbName(), t.collectionName, partitionKeys)
+	hashedPartitionNames, err := assignPartitionKeysFromSnapshot(t.ctx, t.readSnapshot, partitionKeys)
 	if err != nil {
 		mlog.Warn(t.ctx, "failed to assign partition keys", mlog.Err(err))
 		return nil, err
@@ -1220,7 +1243,7 @@ func (t *searchTask) tryParsePartitionIDsFromPlan(plan *planpb.PlanNode) ([]int6
 
 	if len(hashedPartitionNames) > 0 {
 		// translate partition name to partition ids. Use regex-pattern to match partition name.
-		PartitionIDs, err2 := getPartitionIDs(t.ctx, t.request.GetDbName(), t.collectionName, hashedPartitionNames)
+		PartitionIDs, err2 := getPartitionIDsFromSnapshot(t.ctx, t.readSnapshot, hashedPartitionNames)
 		if err2 != nil {
 			mlog.Warn(t.ctx, "failed to get partition ids", mlog.Err(err2))
 			return nil, err2

--- a/internal/proxy/task_search_namespace_test.go
+++ b/internal/proxy/task_search_namespace_test.go
@@ -22,23 +22,24 @@ func TestSearchTask_PlanNamespace_AfterPreExecute(t *testing.T) {
 	mockey.PatchConvey("TestSearchTask_PlanNamespace_AfterPreExecute", t, func() {
 		// Setup global meta cache and common mocks
 		globalMetaCache = &MetaCache{}
-		mockey.Mock((*MetaCache).GetCollectionID).Return(int64(1001), nil).Build()
-		mockey.Mock((*MetaCache).GetCollectionInfo).Return(&collectionInfo{updateTimestamp: 12345, consistencyLevel: commonpb.ConsistencyLevel_Strong}, nil).Build()
-		mockey.Mock(isPartitionKeyMode).Return(false, nil).Build()
 		mockey.Mock(isIgnoreGrowing).Return(false, nil).Build()
 
 		// Schema with namespace enabled and a vector field
-		mockey.Mock((*MetaCache).GetCollectionSchema).To(func(_ *MetaCache, _ context.Context, _ string, _ string) (*schemaInfo, error) {
-			schema := &schemapb.CollectionSchema{
-				Name: "test_collection",
-				Fields: []*schemapb.FieldSchema{
-					{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
-					{FieldID: 101, Name: "vec", DataType: schemapb.DataType_FloatVector, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "4"}}},
-				},
-				EnableNamespace: true,
-			}
-			return mustNewSchemaInfo(schema), nil
-		}).Build()
+		schema := mustNewSchemaInfo(&schemapb.CollectionSchema{
+			Name: "test_collection",
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 101, Name: "vec", DataType: schemapb.DataType_FloatVector, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "4"}}},
+			},
+			EnableNamespace: true,
+		})
+		mockey.Mock((*MetaCache).GetCollectionInfo).Return(&collectionInfo{
+			collID:           1001,
+			dbName:           defaultDB,
+			schema:           schema,
+			updateTimestamp:  12345,
+			consistencyLevel: commonpb.ConsistencyLevel_Strong,
+		}, nil).Build()
 
 		// Patch checkNq to bypass placeholder parsing
 		mockey.Mock((*searchTask).checkNq).Return(int64(1), nil).Build()
@@ -83,11 +84,19 @@ func TestSearchTask_NamespaceSetsPartitionIDs(t *testing.T) {
 			&schemapb.FieldSchema{FieldID: 102, Name: "value", DataType: schemapb.DataType_Int64},
 		)
 
-		mockey.Mock((*MetaCache).GetCollectionID).Return(int64(1001), nil).Build()
-		mockey.Mock((*MetaCache).GetCollectionInfo).Return(&collectionInfo{updateTimestamp: 12345, consistencyLevel: commonpb.ConsistencyLevel_Strong}, nil).Build()
-		mockey.Mock((*MetaCache).GetCollectionSchema).Return(mustNewSchemaInfo(schema), nil).Build()
-		mockey.Mock((*MetaCache).GetPartitionsIndex).Return(partitionNames, nil).Build()
-		mockey.Mock((*MetaCache).GetPartitions).Return(partitionIDs, nil).Build()
+		schemaInfo := mustNewSchemaInfo(schema)
+		mockey.Mock((*MetaCache).GetCollectionInfo).Return(&collectionInfo{
+			collID:           1001,
+			dbName:           defaultDB,
+			schema:           schemaInfo,
+			updateTimestamp:  12345,
+			consistencyLevel: commonpb.ConsistencyLevel_Strong,
+		}, nil).Build()
+		mockey.Mock((*MetaCache).GetPartitionInfosByID).Return(
+			parsePartitionsInfo([]*partitionInfo{
+				{name: partitionNames[0], partitionID: partitionIDs[partitionNames[0]]},
+				{name: partitionNames[1], partitionID: partitionIDs[partitionNames[1]]},
+			}, true), nil).Build()
 		mockey.Mock(isIgnoreGrowing).Return(false, nil).Build()
 		mockey.Mock((*searchTask).checkNq).Return(int64(1), nil).Build()
 		mockey.Mock((*searchTask).tryGeneratePlan).To(func(_ *searchTask, _ []*commonpb.KeyValuePair, _ string, _ map[string]*schemapb.TemplateValue) (*planpb.PlanNode, *planpb.QueryInfo, int64, bool, []OrderByField, internalpb.SearchType, error) {

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -99,8 +99,11 @@ func TestSearchTaskPreExecuteTextRequiresStorageV3(t *testing.T) {
 	)
 	schema := mustNewSchemaInfo(newTextSchemaForStorageV3Test(collectionName))
 	cache := NewMockCache(t)
-	cache.EXPECT().GetCollectionID(mock.Anything, dbName, collectionName).Return(collectionID, nil)
-	cache.EXPECT().GetCollectionSchema(mock.Anything, dbName, collectionName).Return(schema, nil)
+	cache.EXPECT().GetCollectionInfo(mock.Anything, dbName, collectionName, int64(0)).Return(&collectionInfo{
+		collID: collectionID,
+		dbName: dbName,
+		schema: schema,
+	}, nil)
 	globalMetaCache = cache
 
 	task := &searchTask{
@@ -144,12 +147,13 @@ func TestSearchTaskPreExecuteUsesTimezoneForTimestamptzFilter(t *testing.T) {
 			},
 		})
 
-		mockey.Mock((*MetaCache).GetCollectionID).Return(collectionID, nil).Build()
 		mockey.Mock((*MetaCache).GetCollectionInfo).Return(&collectionInfo{
+			collID:           collectionID,
+			dbName:           dbName,
+			schema:           schema,
 			updateTimestamp:  100,
 			consistencyLevel: commonpb.ConsistencyLevel_Strong,
 		}, nil).Build()
-		mockey.Mock((*MetaCache).GetCollectionSchema).Return(schema, nil).Build()
 		mockey.Mock(isIgnoreGrowing).Return(false, nil).Build()
 		mockey.Mock((*searchTask).checkNq).Return(int64(1), nil).Build()
 
@@ -1082,6 +1086,7 @@ func TestSearchTask_PreExecute(t *testing.T) {
 			Value: "True",
 		})
 		st.request.GuaranteeTimestamp = 1000
+		st.request.UseDefaultConsistency = true
 		st.request.DslType = commonpb.DslType_BoolExprV1
 
 		ctxTimeout, cancel := context.WithTimeout(ctx, time.Second)
@@ -1093,6 +1098,8 @@ func TestSearchTask_PreExecute(t *testing.T) {
 		assert.True(t, st.isIterator)
 		assert.True(t, st.GetMvccTimestamp() > 0)
 		assert.Equal(t, uint64(1000), st.GetGuaranteeTimestamp())
+		expectedPhysicalMs, _ := tsoutil.ParseHybridTs(st.BeginTs())
+		assert.Equal(t, uint64(expectedPhysicalMs*1000), st.GetEntityTtlPhysicalTime())
 	})
 
 	t.Run("search consistent iterator post_ts", func(t *testing.T) {
@@ -1547,7 +1554,10 @@ func TestSearchTask_WithFunctions(t *testing.T) {
 	cache.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(collectionID, nil).Maybe()
 	cache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(info, nil).Maybe()
 	cache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"_default": UniqueID(1)}, nil).Maybe()
-	cache.EXPECT().GetCollectionInfo(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&collectionInfo{}, nil).Maybe()
+	cache.EXPECT().GetCollectionInfo(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&collectionInfo{
+		collID: collectionID,
+		schema: info,
+	}, nil).Maybe()
 	globalMetaCache = cache
 
 	{
@@ -4585,14 +4595,17 @@ func TestSearchTask_Requery(t *testing.T) {
 	node.mixCoord = mocks.NewMockMixCoordClient(t)
 
 	collectionName := "col"
-	collectionID := UniqueID(0)
+	collectionID := UniqueID(1000)
 	cache := NewMockCache(t)
 	collSchema := constructCollectionSchema(pkField, vecField, dim, collection)
 	schema := mustNewSchemaInfo(collSchema)
 	cache.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(collectionID, nil).Maybe()
 	cache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(schema, nil).Maybe()
 	cache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"_default": UniqueID(1)}, nil).Maybe()
-	cache.EXPECT().GetCollectionInfo(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&collectionInfo{}, nil).Maybe()
+	cache.EXPECT().GetCollectionInfo(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&collectionInfo{
+		collID: collectionID,
+		schema: schema,
+	}, nil).Maybe()
 	cache.EXPECT().GetDatabaseInfo(mock.Anything, mock.Anything).Return(&databaseInfo{}, nil).Maybe()
 	globalMetaCache = cache
 
@@ -4693,9 +4706,10 @@ func TestSearchTask_Requery(t *testing.T) {
 		}
 		qt.queryChannelsNode.Insert("mock_qn", 1)
 		op, err := newRequeryOperator(qt, nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		queryResult, storageCost, err := op.(*requeryOperator).requery(ctx, nil, qt.result.Results.Ids, outputFields)
-		assert.NoError(t, err)
+		require.NoError(t, err)
+		require.NotNil(t, queryResult)
 		assert.Equal(t, int64(0), storageCost.ScannedRemoteBytes)
 		assert.Equal(t, int64(0), storageCost.ScannedTotalBytes)
 		assert.Len(t, queryResult.FieldsData, 2)
@@ -5124,17 +5138,21 @@ func (s *MaterializedViewTestSuite) TearDownSuite() {
 
 func (s *MaterializedViewTestSuite) SetupTest() {
 	s.mockMetaCache = NewMockCache(s.T())
-	s.mockMetaCache.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(s.colID, nil)
-	s.mockMetaCache.EXPECT().GetCollectionInfo(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
-		&collectionInfo{
-			collID:                s.colID,
-			partitionKeyIsolation: true,
-		}, nil)
 	globalMetaCache = s.mockMetaCache
 }
 
 func (s *MaterializedViewTestSuite) TearDownTest() {
 	globalMetaCache = nil
+}
+
+func (s *MaterializedViewTestSuite) expectCollectionSnapshot(schema *schemaInfo) {
+	s.mockMetaCache.EXPECT().GetCollectionInfo(mock.Anything, mock.Anything, mock.Anything, int64(0)).Return(
+		&collectionInfo{
+			collID:                s.colID,
+			dbName:                s.dbName,
+			schema:                schema,
+			partitionKeyIsolation: true,
+		}, nil)
 }
 
 func (s *MaterializedViewTestSuite) getSearchTask() *searchTask {
@@ -5192,7 +5210,7 @@ func (s *MaterializedViewTestSuite) TestMvNotEnabledWithNoPartitionKey() {
 
 	schema := constructCollectionSchemaByDataType(s.colName, s.fieldName2Types, testInt64Field, false)
 	schemaInfo := mustNewSchemaInfo(schema)
-	s.mockMetaCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(schemaInfo, nil)
+	s.expectCollectionSnapshot(schemaInfo)
 
 	err := task.PreExecute(s.ctx)
 	s.NoError(err)
@@ -5207,9 +5225,8 @@ func (s *MaterializedViewTestSuite) TestMvNotEnabledWithPartitionKey() {
 	task.request.Dsl = testInt64Field + " == 1"
 	schema := ConstructCollectionSchemaWithPartitionKey(s.colName, s.fieldName2Types, testInt64Field, testInt64Field, false)
 	schemaInfo := mustNewSchemaInfo(schema)
-	s.mockMetaCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(schemaInfo, nil)
-	s.mockMetaCache.EXPECT().GetPartitionsIndex(mock.Anything, mock.Anything, mock.Anything).Return([]string{"partition_1", "partition_2"}, nil)
-	s.mockMetaCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"partition_1": 1, "partition_2": 2}, nil)
+	s.expectCollectionSnapshot(schemaInfo)
+	s.mockMetaCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"partition_0": 1, "partition_1": 2}, nil)
 
 	err := task.PreExecute(s.ctx)
 	s.NoError(err)
@@ -5223,7 +5240,7 @@ func (s *MaterializedViewTestSuite) TestMvEnabledNoPartitionKey() {
 	task.enableMaterializedView = true
 	schema := constructCollectionSchemaByDataType(s.colName, s.fieldName2Types, testInt64Field, false)
 	schemaInfo := mustNewSchemaInfo(schema)
-	s.mockMetaCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(schemaInfo, nil)
+	s.expectCollectionSnapshot(schemaInfo)
 
 	err := task.PreExecute(s.ctx)
 	s.NoError(err)
@@ -5238,9 +5255,8 @@ func (s *MaterializedViewTestSuite) TestMvEnabledPartitionKeyOnInt64() {
 	task.request.Dsl = testInt64Field + " == 1"
 	schema := ConstructCollectionSchemaWithPartitionKey(s.colName, s.fieldName2Types, testInt64Field, testInt64Field, false)
 	schemaInfo := mustNewSchemaInfo(schema)
-	s.mockMetaCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(schemaInfo, nil)
-	s.mockMetaCache.EXPECT().GetPartitionsIndex(mock.Anything, mock.Anything, mock.Anything).Return([]string{"partition_1", "partition_2"}, nil)
-	s.mockMetaCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"partition_1": 1, "partition_2": 2}, nil)
+	s.expectCollectionSnapshot(schemaInfo)
+	s.mockMetaCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"partition_0": 1, "partition_1": 2}, nil)
 
 	err := task.PreExecute(s.ctx)
 	s.NoError(err)
@@ -5255,9 +5271,8 @@ func (s *MaterializedViewTestSuite) TestMvEnabledPartitionKeyOnVarChar() {
 	task.request.Dsl = testVarCharField + " == \"a\""
 	schema := ConstructCollectionSchemaWithPartitionKey(s.colName, s.fieldName2Types, testInt64Field, testVarCharField, false)
 	schemaInfo := mustNewSchemaInfo(schema)
-	s.mockMetaCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(schemaInfo, nil)
-	s.mockMetaCache.EXPECT().GetPartitionsIndex(mock.Anything, mock.Anything, mock.Anything).Return([]string{"partition_1", "partition_2"}, nil)
-	s.mockMetaCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"partition_1": 1, "partition_2": 2}, nil)
+	s.expectCollectionSnapshot(schemaInfo)
+	s.mockMetaCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"partition_0": 1, "partition_1": 2}, nil)
 
 	err := task.PreExecute(s.ctx)
 	s.NoError(err)
@@ -5275,9 +5290,8 @@ func (s *MaterializedViewTestSuite) TestMvEnabledPartitionKeyOnVarCharWithIsolat
 		task.IsAdvanced = isAdvanced
 		schema := ConstructCollectionSchemaWithPartitionKey(s.colName, s.fieldName2Types, testInt64Field, testVarCharField, false)
 		schemaInfo := mustNewSchemaInfo(schema)
-		s.mockMetaCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(schemaInfo, nil)
-		s.mockMetaCache.EXPECT().GetPartitionsIndex(mock.Anything, mock.Anything, mock.Anything).Return([]string{"partition_1", "partition_2"}, nil)
-		s.mockMetaCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"partition_1": 1, "partition_2": 2}, nil)
+		s.expectCollectionSnapshot(schemaInfo)
+		s.mockMetaCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"partition_0": 1, "partition_1": 2}, nil)
 		err := task.PreExecute(s.ctx)
 		s.NoError(err)
 		s.NotZero(len(task.queryInfos))
@@ -5295,7 +5309,7 @@ func (s *MaterializedViewTestSuite) TestMvEnabledPartitionKeyOnVarCharWithIsolat
 		task.request.Dsl = testVarCharField + " in [\"a\", \"b\", \"c\"]"
 		schema := ConstructCollectionSchemaWithPartitionKey(s.colName, s.fieldName2Types, testInt64Field, testVarCharField, false)
 		schemaInfo := mustNewSchemaInfo(schema)
-		s.mockMetaCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(schemaInfo, nil)
+		s.expectCollectionSnapshot(schemaInfo)
 		s.ErrorContains(task.PreExecute(s.ctx), "partition key isolation does not support IN")
 	}
 }
@@ -5303,9 +5317,8 @@ func (s *MaterializedViewTestSuite) TestMvEnabledPartitionKeyOnVarCharWithIsolat
 func (s *MaterializedViewTestSuite) TestHybridSearchPartitionKeyIsolationWithoutMaterializedView() {
 	schema := ConstructCollectionSchemaWithPartitionKey(s.colName, s.fieldName2Types, testInt64Field, testVarCharField, false)
 	schemaInfo := mustNewSchemaInfo(schema)
-	s.mockMetaCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(schemaInfo, nil).Maybe()
-	s.mockMetaCache.EXPECT().GetPartitionsIndex(mock.Anything, mock.Anything, mock.Anything).Return([]string{"partition_1", "partition_2"}, nil).Maybe()
-	s.mockMetaCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"partition_1": 1, "partition_2": 2}, nil).Maybe()
+	s.expectCollectionSnapshot(schemaInfo)
+	s.mockMetaCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"partition_0": 1, "partition_1": 2}, nil).Maybe()
 
 	testCases := []struct {
 		name     string
@@ -5343,7 +5356,7 @@ func (s *MaterializedViewTestSuite) TestMvEnabledPartitionKeyOnVarCharWithIsolat
 		task.request.Dsl = testVarCharField + " == \"a\" || " + testVarCharField + "  == \"b\" || " + testVarCharField + " == \"c\""
 		schema := ConstructCollectionSchemaWithPartitionKey(s.colName, s.fieldName2Types, testInt64Field, testVarCharField, false)
 		schemaInfo := mustNewSchemaInfo(schema)
-		s.mockMetaCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(schemaInfo, nil)
+		s.expectCollectionSnapshot(schemaInfo)
 		s.ErrorContains(task.PreExecute(s.ctx), "partition key isolation does not support IN")
 	}
 }

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -2677,6 +2677,31 @@ func assignPartitionKeys(ctx context.Context, dbName string, collName string, ke
 	return hashedPartitionNames, err
 }
 
+func assignPartitionKeysFromSnapshot(ctx context.Context, snapshot *readRequestSnapshot, keys []*planpb.GenericValue) ([]string, error) {
+	partitions, err := snapshot.Partitions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if partitions.indexedPartitionNames == nil {
+		return nil, merr.WrapErrServiceInternal("partitions not in partition key naming pattern")
+	}
+	partitionKeyFieldSchema, err := typeutil.GetPartitionKeyFieldSchema(snapshot.Collection().Schema().CollectionSchema)
+	if err != nil {
+		return nil, err
+	}
+	return typeutil2.HashKey2Partitions(partitionKeyFieldSchema, keys, partitions.indexedPartitionNames)
+}
+
+func assignNamespacePartitionKeyFromSnapshot(ctx context.Context, snapshot *readRequestSnapshot, namespace *string) ([]string, error) {
+	if namespace == nil {
+		return nil, nil
+	}
+
+	return assignPartitionKeysFromSnapshot(ctx, snapshot, []*planpb.GenericValue{
+		{Val: &planpb.GenericValue_StringVal{StringVal: *namespace}},
+	})
+}
+
 func assignNamespacePartitionKey(ctx context.Context, dbName string, collName string, namespace *string) ([]string, error) {
 	if namespace == nil {
 		return nil, nil
@@ -2937,6 +2962,15 @@ func addNamespaceData(schema *schemapb.CollectionSchema, insertMsg *msgstream.In
 }
 
 func GetCachedCollectionSchema(ctx context.Context, dbName string, colName string) (*schemaInfo, error) {
+	if snapshot, snapshotErr, ok := readRequestSnapshotFromContext(ctx); ok {
+		if snapshotErr != nil {
+			return nil, snapshotErr
+		}
+		if err := snapshot.validateTarget(dbName, colName); err != nil {
+			return nil, err
+		}
+		return snapshot.Collection().Schema(), nil
+	}
 	if globalMetaCache != nil {
 		return globalMetaCache.GetCollectionSchema(ctx, dbName, colName)
 	}


### PR DESCRIPTION
Related to #52351

Resolve aliases once for Search, Query, and HybridSearch requests. Reuse the pinned collection metadata, partition routing, and timestamps across RBAC, rate limiting, requery, and internal retries.

Fetch partition metadata by collection ID to prevent concurrent AlterAlias operations from mixing collection IDs and schemas.