### PR TITLE
fix: stop the REST group-by knobs from being silently swallowed

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -1861,6 +1861,42 @@ func generatePlaceholderGroup(ctx context.Context, body string, collSchema *sche
 	})
 }
 
+// appendGroupParams validates the grouping knobs and appends them to params.
+//
+// The previous gate forwarded groupSize only when it was greater than zero,
+// which conflated three different requests: an absent groupSize (use the
+// server default), an explicit invalid one (0 or negative -- the server
+// rejects these, but it never saw them), and strictGroupSize on its own
+// (silently dropped because it rode behind the same gate). A knob that is
+// present is now either forwarded or refused; only absence means default.
+func appendGroupParams(params []*commonpb.KeyValuePair, groupByField string, groupSize *int32, strictGroupSize *bool) ([]*commonpb.KeyValuePair, error) {
+	// Trimmed with the same rule the proxy applies when it parses the field
+	// name back out. Without this, a groupingField of blanks counts as
+	// provided here, the proxy trims it to nothing, and the knobs it
+	// authorized are swallowed downstream -- the exact silence this function
+	// exists to remove.
+	groupByField = strings.TrimSpace(groupByField)
+	if groupByField == "" {
+		if groupSize != nil || strictGroupSize != nil {
+			return nil, merr.WrapErrParameterInvalidMsg(
+				"groupSize and strictGroupSize require groupingField")
+		}
+		return params, nil
+	}
+	params = append(params, &commonpb.KeyValuePair{Key: ParamGroupByField, Value: groupByField})
+	if groupSize != nil {
+		if *groupSize <= 0 {
+			return nil, merr.WrapErrParameterInvalidMsg(
+				"groupSize must be a positive integer, got: %d", *groupSize)
+		}
+		params = append(params, &commonpb.KeyValuePair{Key: ParamGroupSize, Value: strconv.FormatInt(int64(*groupSize), 10)})
+	}
+	if strictGroupSize != nil {
+		params = append(params, &commonpb.KeyValuePair{Key: ParamStrictGroupSize, Value: strconv.FormatBool(*strictGroupSize)})
+	}
+	return params, nil
+}
+
 func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
 	httpReq := anyReq.(*SearchReqV2)
 	req := &milvuspb.SearchRequest{
@@ -1927,13 +1963,16 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 			return nil, err
 		}
-		if httpReq.GroupByField != "" || httpReq.GroupSize != 0 || httpReq.StrictGroupSize {
+		if httpReq.GroupByField != "" || httpReq.GroupSize != nil || httpReq.StrictGroupSize != nil {
 			err := merr.WrapErrParameterInvalidMsg("groupingField/groupSize/strictGroupSize and searchAggregation cannot be used simultaneously")
 			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 			return nil, err
 		}
-		if searchParamsContainAny(httpReq.SearchParams, proxy.GroupByFieldKey, proxy.GroupByFieldsKey) {
-			err := merr.WrapErrParameterInvalidMsg("searchParams.group_by_field(s) and searchAggregation cannot be used simultaneously")
+		if searchParamsContainAny(httpReq.SearchParams,
+			proxy.GroupByFieldKey, proxy.GroupByFieldsKey, proxy.GroupSizeKey, proxy.StrictGroupSize) {
+			// wording kept compatible: the group_by_field(s) sentence is what
+			// clients and the REST e2e suite already pin on
+			err := merr.WrapErrParameterInvalidMsg("searchParams.group_by_field(s) and searchAggregation cannot be used simultaneously, and neither can group_size/strict_group_size")
 			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 			return nil, err
 		}
@@ -1958,6 +1997,54 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 		return nil, err
 	}
 
+	// The group knobs have the same two spellings, and the searchParams one is
+	// appended first, so it silently won any disagreement. Same rule: one
+	// spelling per request. Asked of the root keys only: generateSearchParams
+	// itself duplicates root keys into the params JSON, so nested copies are
+	// an artifact of the working spelling, not a spelling of their own.
+	if (httpReq.GroupByField != "" || httpReq.GroupSize != nil || httpReq.StrictGroupSize != nil) &&
+		searchParamsRootContainAny(httpReq.SearchParams,
+			proxy.GroupByFieldKey, proxy.GroupByFieldsKey, proxy.GroupSizeKey, proxy.StrictGroupSize) {
+		err := merr.WrapErrParameterInvalidMsg(
+			"ambiguous grouping: use either the top-level groupingField/groupSize/strictGroupSize or the searchParams group keys, not both")
+		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		return nil, err
+	}
+
+	// The rule that a size knob needs a grouping field holds for the legacy
+	// spelling too: group_size or strict_group_size in searchParams with no
+	// group field anywhere used to parse downstream into a grouping that never
+	// enabled, an ungrouped search reporting success. The field must be a
+	// working spelling -- a field name nested under params is inert.
+	groupingEnabled := httpReq.GroupByField != "" ||
+		searchParamsRootContainAny(httpReq.SearchParams, proxy.GroupByFieldKey, proxy.GroupByFieldsKey)
+	if !groupingEnabled &&
+		searchParamsRootContainAny(httpReq.SearchParams, proxy.GroupSizeKey, proxy.StrictGroupSize) {
+		err := merr.WrapErrParameterInvalidMsg(
+			"searchParams group_size/strict_group_size require a group field")
+		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		return nil, err
+	}
+
+	// Group keys nested under searchParams.params never act -- the proxy reads
+	// only standalone pairs. When a working spelling enables grouping they are
+	// tolerated as the compatibility duplicates generateSearchParams itself
+	// produces; when they are the only grouping in the request, the caller
+	// asked for grouping and would silently not get it, so the request is
+	// refused rather than half-honored.
+	if !groupingEnabled {
+		if nested, ok := httpReq.SearchParams[Params].(map[string]interface{}); ok {
+			for _, key := range []string{proxy.GroupByFieldKey, proxy.GroupByFieldsKey, proxy.GroupSizeKey, proxy.StrictGroupSize} {
+				if _, present := nested[key]; present {
+					err := merr.WrapErrParameterInvalidMsg(
+						"searchParams.params cannot carry %s; use the top-level grouping fields or searchParams.%s", key, key)
+					HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+					return nil, err
+				}
+			}
+		}
+	}
+
 	searchParams, err := generateSearchParams(httpReq.SearchParams)
 	if err != nil {
 		mlog.Warn(ctx, "high level restful api, generate SearchParams failed", mlog.Err(err))
@@ -1969,12 +2056,10 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 	}
 	searchParams = append(searchParams, &commonpb.KeyValuePair{Key: common.TopKKey, Value: strconv.FormatInt(int64(httpReq.Limit), 10)})
 	searchParams = append(searchParams, &commonpb.KeyValuePair{Key: proxy.OffsetKey, Value: strconv.FormatInt(int64(httpReq.Offset), 10)})
-	if httpReq.GroupByField != "" {
-		searchParams = append(searchParams, &commonpb.KeyValuePair{Key: ParamGroupByField, Value: httpReq.GroupByField})
-	}
-	if httpReq.GroupByField != "" && httpReq.GroupSize > 0 {
-		searchParams = append(searchParams, &commonpb.KeyValuePair{Key: ParamGroupSize, Value: strconv.FormatInt(int64(httpReq.GroupSize), 10)})
-		searchParams = append(searchParams, &commonpb.KeyValuePair{Key: ParamStrictGroupSize, Value: strconv.FormatBool(httpReq.StrictGroupSize)})
+	searchParams, err = appendGroupParams(searchParams, httpReq.GroupByField, httpReq.GroupSize, httpReq.StrictGroupSize)
+	if err != nil {
+		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		return nil, err
 	}
 	if len(httpReq.OrderByFields) > 0 {
 		searchParams = append(searchParams, &commonpb.KeyValuePair{Key: proxy.OrderByFieldsKey, Value: strings.Join(httpReq.OrderByFields, ",")})
@@ -2245,12 +2330,10 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 		{Key: proxy.OffsetKey, Value: strconv.FormatInt(int64(httpReq.Offset), 10)},
 		{Key: ParamRoundDecimal, Value: "-1"},
 	}
-	if httpReq.GroupByField != "" {
-		req.RankParams = append(req.RankParams, &commonpb.KeyValuePair{Key: ParamGroupByField, Value: httpReq.GroupByField})
-	}
-	if httpReq.GroupByField != "" && httpReq.GroupSize > 0 {
-		req.RankParams = append(req.RankParams, &commonpb.KeyValuePair{Key: ParamGroupSize, Value: strconv.FormatInt(int64(httpReq.GroupSize), 10)})
-		req.RankParams = append(req.RankParams, &commonpb.KeyValuePair{Key: ParamStrictGroupSize, Value: strconv.FormatBool(httpReq.StrictGroupSize)})
+	req.RankParams, err = appendGroupParams(req.RankParams, httpReq.GroupByField, httpReq.GroupSize, httpReq.StrictGroupSize)
+	if err != nil {
+		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		return nil, err
 	}
 	if len(httpReq.FunctionScore.Functions) != 0 {
 		if req.FunctionScore, err = genFunctionScore(ctx, &httpReq.FunctionScore); err != nil {

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -5762,4 +5763,154 @@ func TestInsertMalformedBodyNeverReachesProxy(t *testing.T) {
 				"a malformed body must not be accepted: %s", tt.body)
 		})
 	}
+}
+
+// The old gate forwarded groupSize only when it was greater than zero, which
+// conflated an absent knob (server default), an explicitly invalid one (the
+// server rejects 0 and negatives, but never saw them), and strictGroupSize on
+// its own (silently dropped behind the same gate).
+func TestAppendGroupParamsValidatesTheKnobs(t *testing.T) {
+	i32 := func(v int32) *int32 { return &v }
+	b := func(v bool) *bool { return &v }
+	kv := func(pairs []*commonpb.KeyValuePair) map[string]string {
+		m := map[string]string{}
+		for _, p := range pairs {
+			m[p.Key] = p.Value
+		}
+		return m
+	}
+
+	t.Run("absent knobs mean the server default", func(t *testing.T) {
+		params, err := appendGroupParams(nil, "cat", nil, nil)
+		require.NoError(t, err)
+		m := kv(params)
+		assert.Equal(t, "cat", m[ParamGroupByField])
+		_, hasSize := m[ParamGroupSize]
+		assert.False(t, hasSize)
+	})
+
+	t.Run("explicit zero and negative are refused, not swallowed", func(t *testing.T) {
+		for _, v := range []int32{0, -1} {
+			_, err := appendGroupParams(nil, "cat", i32(v), nil)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		}
+	})
+
+	t.Run("a positive size is forwarded", func(t *testing.T) {
+		params, err := appendGroupParams(nil, "cat", i32(3), b(true))
+		require.NoError(t, err)
+		m := kv(params)
+		assert.Equal(t, "3", m[ParamGroupSize])
+		assert.Equal(t, "true", m[ParamStrictGroupSize])
+	})
+
+	t.Run("strictGroupSize no longer rides behind groupSize", func(t *testing.T) {
+		params, err := appendGroupParams(nil, "cat", nil, b(true))
+		require.NoError(t, err)
+		assert.Equal(t, "true", kv(params)[ParamStrictGroupSize])
+	})
+
+	t.Run("group knobs without a grouping field are refused", func(t *testing.T) {
+		_, err := appendGroupParams(nil, "", i32(2), nil)
+		require.Error(t, err)
+		_, err = appendGroupParams(nil, "", nil, b(true))
+		require.Error(t, err)
+	})
+
+	t.Run("a grouping field of blanks is absent, not provided", func(t *testing.T) {
+		// the proxy trims the name before resolving it, so blanks must count
+		// as absent here too or the knobs are swallowed downstream again
+		_, err := appendGroupParams(nil, "  ", i32(2), nil)
+		require.Error(t, err)
+
+		params, err := appendGroupParams(nil, " cat ", i32(2), nil)
+		require.NoError(t, err)
+		assert.Equal(t, "cat", kv(params)[ParamGroupByField])
+	})
+}
+
+// The group knobs have two spellings -- the top-level fields and the
+// searchParams keys -- and the searchParams one was appended first, so it
+// silently won any disagreement. The ambiguity is refused now, and the
+// searchParams spelling can no longer smuggle group knobs past the
+// searchAggregation conflict check either.
+func TestGroupKnobSpellingsCannotDisagree(t *testing.T) {
+	postReq := func(body string) (int, string) {
+		paramtable.Init()
+		// tolerated shapes travel the whole handler; keep the limiter out of it
+		quotaKey := paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key
+		paramtable.Get().Save(quotaKey, "false")
+		t.Cleanup(func() { paramtable.Get().Reset(quotaKey) })
+		mp := mocks.NewMockProxy(t)
+		mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+			CollectionName: "book",
+			Schema:         generateCollectionSchema(schemapb.DataType_Int64, false, true),
+			ShardsNum:      ShardNumDefault,
+			Status:         &StatusSuccess,
+		}, nil).Maybe()
+		// requests that pass validation reach the proxy; answer them so the
+		// tolerated shapes complete instead of riding the timeout middleware
+		mp.EXPECT().Search(mock.Anything, mock.Anything).Return(&milvuspb.SearchResults{
+			Status:  &StatusSuccess,
+			Results: &schemapb.SearchResultData{NumQueries: 1, TopK: 0, Topks: []int64{0}, Ids: &schemapb.IDs{}},
+		}, nil).Maybe()
+		testEngine := initHTTPServerV2(mp, false)
+		req := httptest.NewRequest(http.MethodPost, versionalV2(EntityCategory, SearchAction), strings.NewReader(body))
+		req.Header.Set(HTTPHeaderDBName, DefaultDbName)
+		// requests that pass validation ride into the mocked proxy; a short
+		// per-request timeout keeps the tolerated shapes from idling there
+		req.Header.Set(HTTPHeaderRequestTimeout, "1")
+		w := httptest.NewRecorder()
+		testEngine.ServeHTTP(w, req)
+		return w.Code, w.Body.String()
+	}
+
+	t.Run("both spellings at once is ambiguous", func(t *testing.T) {
+		code, body := postReq(`{"collectionName": "book", "data": [[0.1, 0.2]],
+			"groupingField": "cat",
+			"searchParams": {"group_size": 5}}`)
+		assert.Equal(t, http.StatusOK, code)
+		assert.Contains(t, body, "ambiguous grouping")
+	})
+
+	t.Run("searchParams size knobs alone still need a group field", func(t *testing.T) {
+		code, body := postReq(`{"collectionName": "book", "data": [[0.1, 0.2]],
+			"searchParams": {"group_size": 5}}`)
+		assert.Equal(t, http.StatusOK, code)
+		assert.Contains(t, body, "require a group field")
+	})
+
+	t.Run("nested-only group keys are inert and refused", func(t *testing.T) {
+		code, body := postReq(`{"collectionName": "book", "data": [[0.1, 0.2]],
+			"searchParams": {"params": {"group_by_field": "cat", "group_size": 2}}}`)
+		assert.Equal(t, http.StatusOK, code)
+		assert.Contains(t, body, "cannot carry")
+	})
+
+	t.Run("nested copies beside a working root spelling are tolerated", func(t *testing.T) {
+		// generateSearchParams itself duplicates root keys into the params
+		// JSON, so this is the shape a previously-working client sends
+		_, body := postReq(`{"collectionName": "book", "data": [[0.1, 0.2]],
+			"searchParams": {"group_by_field": "cat", "group_size": 5,
+				"params": {"group_by_field": "cat", "group_size": 5}}}`)
+		assert.NotContains(t, body, "cannot carry")
+		assert.NotContains(t, body, "ambiguous grouping")
+	})
+
+	t.Run("nested copies beside the top-level spelling are tolerated", func(t *testing.T) {
+		_, body := postReq(`{"collectionName": "book", "data": [[0.1, 0.2]],
+			"groupingField": "cat",
+			"searchParams": {"params": {"group_size": 5}}}`)
+		assert.NotContains(t, body, "cannot carry")
+		assert.NotContains(t, body, "ambiguous grouping")
+	})
+
+	t.Run("searchParams group size cannot ride under searchAggregation", func(t *testing.T) {
+		code, body := postReq(`{"collectionName": "book", "data": [[0.1, 0.2]],
+			"searchParams": {"strict_group_size": true},
+			"searchAggregation": {"fields": ["cat"], "size": 10}}`)
+		assert.Equal(t, http.StatusOK, code)
+		assert.Contains(t, body, "cannot be used simultaneously")
+	})
 }

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -502,8 +502,8 @@ type SearchReqV2 struct {
 	PartitionNames    []string                   `json:"partitionNames"`
 	Filter            string                     `json:"filter"`
 	GroupByField      string                     `json:"groupingField"`
-	GroupSize         int32                      `json:"groupSize"`
-	StrictGroupSize   bool                       `json:"strictGroupSize"`
+	GroupSize         *int32                     `json:"groupSize"`
+	StrictGroupSize   *bool                      `json:"strictGroupSize"`
 	Limit             int32                      `json:"limit"`
 	Offset            int32                      `json:"offset"`
 	OutputFields      []string                   `json:"outputFields"`
@@ -580,8 +580,8 @@ type HybridSearchReq struct {
 	Limit             int32                 `json:"limit"`
 	Offset            int32                 `json:"offset"`
 	GroupByField      string                `json:"groupingField"`
-	GroupSize         int32                 `json:"groupSize"`
-	StrictGroupSize   bool                  `json:"strictGroupSize"`
+	GroupSize         *int32                `json:"groupSize"`
+	StrictGroupSize   *bool                 `json:"strictGroupSize"`
 	OutputFields      []string              `json:"outputFields"`
 	ConsistencyLevel  string                `json:"consistencyLevel"`
 	FunctionScore     FunctionScore         `json:"functionScore"`

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -4828,6 +4828,19 @@ func WrapErrorToResponse(err error) *milvuspb.BoolResponse {
 	}
 }
 
+// searchParamsRootContainAny asks only the root of searchParams, not the
+// nested params object: the nested copies are inert (the proxy reads only
+// standalone pairs), so the questions "is grouping enabled" and "does a
+// spelling conflict" must be asked of the keys that actually act.
+func searchParamsRootContainAny(reqSearchParams map[string]interface{}, keys ...string) bool {
+	for _, key := range keys {
+		if _, ok := reqSearchParams[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 func searchParamsContainAny(reqSearchParams map[string]interface{}, keys ...string) bool {
 	for _, key := range keys {
 		if _, ok := reqSearchParams[key]; ok {

--- a/internal/proxy/search_util.go
+++ b/internal/proxy/search_util.go
@@ -31,6 +31,34 @@ type rankParams struct {
 	groupByFieldNames []string
 	groupSize         int64
 	strictGroupSize   bool
+	// The JSON group-by attributes ride along for hybrid search: they are
+	// resolved by parseGroupByInfo like everything above, and dropping them
+	// here used to make a hybrid group-by on a dynamic field group by the
+	// whole $meta object instead of the named key.
+	jsonPath   string
+	jsonType   schemapb.DataType
+	strictCast bool
+}
+
+func (r *rankParams) GetJSONPath() string {
+	if r != nil {
+		return r.jsonPath
+	}
+	return ""
+}
+
+func (r *rankParams) GetJSONType() schemapb.DataType {
+	if r != nil {
+		return r.jsonType
+	}
+	return schemapb.DataType_None
+}
+
+func (r *rankParams) GetStrictCast() bool {
+	if r != nil {
+		return r.strictCast
+	}
+	return false
 }
 
 func (r *rankParams) GetLimit() int64 {
@@ -564,6 +592,7 @@ func parseSearchInfo(searchParamsPair []*commonpb.KeyValuePair, schema *schemapb
 	var isIterativeFilter bool
 	if isAdvanced {
 		groupByFieldId, groupByFieldIds, groupSize, strictGroupSize = rankParams.GetGroupByFieldId(), rankParams.GetGroupByFieldIds(), rankParams.GetGroupSize(), rankParams.GetStrictGroupSize()
+		jsonPath, jsonType, strictCast = rankParams.GetJSONPath(), rankParams.GetJSONType(), rankParams.GetStrictCast()
 	} else {
 		groupByInfo, err := parseGroupByInfo(searchParamsPair, schema)
 		if err != nil {
@@ -814,6 +843,40 @@ func (g *groupByInfo) GetStrictCast() bool {
 // 1. Field exists in schema: use the field's ID, set jsonPath if it's a JSON field with brackets
 // 2. Field doesn't exist but dynamic field exists: use dynamic field's ID and set jsonPath
 // 3. Field doesn't exist and no dynamic field: return error
+// checkGroupByFieldType refuses a group-by field of a type the group-by
+// operator cannot hold as a key.
+//
+// The name used to resolve to a field id with no look at the type, so a
+// request grouping by a vector field was accepted here and either degenerated
+// into an ungrouped search or surfaced as an execution error deep in the
+// query, depending on the path. The supported list mirrors the switch in
+// SearchGroupByOperator.cpp: bool, the integer widths, timestamptz, varchar,
+// and json, whose inner value is checked at execution where the path is known.
+func checkGroupByFieldType(field *schemapb.FieldSchema) error {
+	switch field.GetDataType() {
+	case schemapb.DataType_Bool,
+		schemapb.DataType_Int8, schemapb.DataType_Int16,
+		schemapb.DataType_Int32, schemapb.DataType_Int64,
+		schemapb.DataType_Timestamptz,
+		schemapb.DataType_VarChar,
+		schemapb.DataType_JSON:
+		// DataType_String is deliberately absent: the executor's switch has a
+		// VARCHAR case and no STRING case, so admitting it here would only
+		// move the failure back into the execution layer.
+		return nil
+	case schemapb.DataType_BinaryVector:
+		// The executor's own words for this case, kept verbatim: clients pin
+		// on them, and moving the check earlier should not change what the
+		// caller reads.
+		return merr.WrapErrParameterInvalidMsg(
+			"not support search_group_by operation based on binary vector column")
+	default:
+		return merr.WrapErrParameterInvalidMsg(
+			"unsupported data type for group by: field %s is a %s",
+			field.GetName(), field.GetDataType().String())
+	}
+}
+
 func parseGroupByField(groupByFieldName string, schema *schemapb.CollectionSchema) (groupByFieldId int64, jsonPath string, err error) {
 	if groupByFieldName == "" {
 		return -1, "", nil
@@ -838,6 +901,9 @@ func parseGroupByField(groupByFieldName string, schema *schemapb.CollectionSchem
 		// Extract field name (part before the first '[')
 		fieldName := strings.Split(groupByFieldName, "[")[0]
 		if field, exists := fieldNameMap[fieldName]; exists {
+			if err := checkGroupByFieldType(field); err != nil {
+				return -1, "", err
+			}
 			// Field exists in schema
 			groupByFieldId = field.FieldID
 			// If the field is JSON type, set jsonPath to the full groupByFieldName
@@ -861,6 +927,9 @@ func parseGroupByField(groupByFieldName string, schema *schemapb.CollectionSchem
 	} else {
 		// Case 1: Regular field name (no brackets)
 		if field, exists := fieldNameMap[groupByFieldName]; exists {
+			if err := checkGroupByFieldType(field); err != nil {
+				return -1, "", err
+			}
 			groupByFieldId = field.FieldID
 		} else {
 			// Field not found
@@ -902,6 +971,7 @@ func parseGroupByInfo(searchParamsPair []*commonpb.KeyValuePair, schema *schemap
 
 	// Resolve each name to fieldId (and optional jsonPath).
 	// Multi-field + jsonPath is rejected because this layer carries a single jsonPath.
+	jsonGroupFields := 0
 	for _, name := range groupByFieldNames {
 		fieldId, jsonPath, err := parseGroupByField(name, schema)
 		if err != nil {
@@ -909,6 +979,17 @@ func parseGroupByInfo(searchParamsPair []*commonpb.KeyValuePair, schema *schemap
 		}
 		ret.groupByFieldIds = append(ret.groupByFieldIds, fieldId)
 		ret.groupByFieldNames = append(ret.groupByFieldNames, name)
+		// The plan carries a single json_path/json_type, and the executor
+		// asserts at most one JSON group-by field; two bare JSON fields used
+		// to pass here (neither produces a jsonPath) and fail only deep in
+		// execution.
+		if field := typeutil.GetFieldByID(schema, fieldId); field != nil && typeutil.IsJSONType(field.GetDataType()) {
+			jsonGroupFields++
+			if jsonGroupFields > 1 {
+				return nil, merr.WrapErrParameterInvalidMsg(
+					fmt.Sprintf("at most one JSON field can be grouped by, field:%s", name))
+			}
+		}
 		if jsonPath != "" {
 			if len(groupByFieldNames) > 1 {
 				return nil, merr.WrapErrParameterInvalidMsg(
@@ -1033,6 +1114,15 @@ func parseRankParams(rankParamsPair []*commonpb.KeyValuePair, schema *schemapb.C
 		return nil, err
 	}
 
+	// normalized here once, exactly as the single-search path normalizes it
+	jsonPath := groupByInfo.GetJSONPath()
+	if jsonPath != "" {
+		jsonPath, err = typeutil2.ParseAndVerifyNestedPath(jsonPath, schema, groupByInfo.GetGroupByFieldId())
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &rankParams{
 		limit:             limit,
 		offset:            offset,
@@ -1041,6 +1131,9 @@ func parseRankParams(rankParamsPair []*commonpb.KeyValuePair, schema *schemapb.C
 		groupByFieldNames: groupByInfo.GetGroupByFieldNames(),
 		groupSize:         groupByInfo.GetGroupSize(),
 		strictGroupSize:   groupByInfo.GetStrictGroupSize(),
+		jsonPath:          jsonPath,
+		jsonType:          groupByInfo.GetJSONType(),
+		strictCast:        groupByInfo.GetStrictCast(),
 	}, nil
 }
 

--- a/internal/proxy/search_util_test.go
+++ b/internal/proxy/search_util_test.go
@@ -21,7 +21,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func TestConvertHybridSearchToSearchKeepsNamespace(t *testing.T) {
@@ -36,4 +39,98 @@ func TestConvertHybridSearchToSearchKeepsNamespace(t *testing.T) {
 	})
 
 	assert.Equal(t, namespace, searchReq.GetNamespace())
+}
+
+// A group-by field name used to resolve to a field id with no look at the
+// type: grouping by a vector field was accepted here and silently degenerated
+// or failed deep in the query. The supported list mirrors the switch in
+// SearchGroupByOperator.cpp.
+func TestParseGroupByFieldChecksFieldType(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Name: "coll",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, Name: "vec", DataType: schemapb.DataType_FloatVector},
+			{FieldID: 102, Name: "bvec", DataType: schemapb.DataType_BinaryVector},
+			{FieldID: 103, Name: "price", DataType: schemapb.DataType_Double},
+			{FieldID: 104, Name: "ratio", DataType: schemapb.DataType_Float},
+			{FieldID: 105, Name: "tag", DataType: schemapb.DataType_VarChar},
+			{FieldID: 106, Name: "flag", DataType: schemapb.DataType_Bool},
+			{FieldID: 107, Name: "meta", DataType: schemapb.DataType_JSON},
+			{FieldID: 108, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+		},
+	}
+
+	for _, name := range []string{"pk", "tag", "flag", "meta", `meta["k"]`} {
+		_, _, err := parseGroupByField(name, schema)
+		assert.NoError(t, err, name)
+	}
+	// an unknown name still falls through to the dynamic field
+	_, jsonPath, err := parseGroupByField("free_key", schema)
+	assert.NoError(t, err)
+	assert.Equal(t, "free_key", jsonPath)
+
+	// DataType_String has no case in the executor's switch, unlike VarChar
+	schema.Fields = append(schema.Fields,
+		&schemapb.FieldSchema{FieldID: 109, Name: "legacy_str", DataType: schemapb.DataType_String})
+
+	// The wording is what clients read, so it is pinned: the binary-vector case
+	// keeps the executor's own sentence, everything else says why plainly.
+	for _, name := range []string{"vec", "price", "ratio", `vec["x"]`, "legacy_str"} {
+		_, _, err := parseGroupByField(name, schema)
+		assert.Error(t, err, name)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid, name)
+		assert.Contains(t, err.Error(), "unsupported data type for group by", name)
+	}
+	_, _, err = parseGroupByField("bvec", schema)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not support search_group_by operation based on binary vector column")
+}
+
+// The plan carries a single json_path/json_type and the executor asserts at
+// most one JSON group-by field; two bare JSON fields used to pass the proxy
+// (neither produces a jsonPath) and fail only deep in execution.
+func TestParseGroupByInfoRejectsMultipleJSONFields(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 101, Name: "meta1", DataType: schemapb.DataType_JSON},
+			{FieldID: 102, Name: "meta2", DataType: schemapb.DataType_JSON},
+			{FieldID: 103, Name: "tag", DataType: schemapb.DataType_VarChar},
+		},
+	}
+
+	_, err := parseGroupByInfo([]*commonpb.KeyValuePair{
+		{Key: GroupByFieldsKey, Value: "meta1,meta2"},
+	}, schema)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "at most one JSON field")
+
+	info, err := parseGroupByInfo([]*commonpb.KeyValuePair{
+		{Key: GroupByFieldsKey, Value: "meta1,tag"},
+	}, schema)
+	assert.NoError(t, err)
+	assert.Equal(t, []int64{101, 103}, info.groupByFieldIds)
+}
+
+// The JSON group-by attributes resolved by parseGroupByInfo used to be
+// dropped when parseRankParams packed the rank params, so a hybrid group-by
+// on a JSON key grouped by the whole field instead of the key.
+func TestRankParamsCarryJSONGroupAttributes(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 101, Name: "meta", DataType: schemapb.DataType_JSON},
+			{FieldID: 102, Name: "tag", DataType: schemapb.DataType_VarChar},
+		},
+	}
+	pairs := []*commonpb.KeyValuePair{
+		{Key: LimitKey, Value: "10"},
+		{Key: GroupByFieldKey, Value: `meta["brand"]`},
+	}
+	parsed, err := parseRankParams(pairs, schema, false)
+	assert.NoError(t, err)
+	assert.Equal(t, "/brand", parsed.GetJSONPath())
+
+	searchInfo, err := parseSearchInfo(getValidSearchParams(), schema, parsed, false)
+	assert.NoError(t, err)
+	assert.Equal(t, "/brand", searchInfo.planInfo.GetJsonPath())
 }

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -3596,9 +3596,10 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 	t.Run("parseSearchInfo groupBy info for hybrid search", func(t *testing.T) {
 		schema := &schemapb.CollectionSchema{
 			Fields: []*schemapb.FieldSchema{
-				{FieldID: 101, Name: "c1"},
-				{FieldID: 102, Name: "c2"},
-				{FieldID: 103, Name: "c3"},
+				// group-by now checks the field type, so the fixtures carry one
+				{FieldID: 101, Name: "c1", DataType: schemapb.DataType_VarChar},
+				{FieldID: 102, Name: "c2", DataType: schemapb.DataType_Int64},
+				{FieldID: 103, Name: "c3", DataType: schemapb.DataType_VarChar},
 			},
 		}
 		// 1. first parse rank params
@@ -3780,8 +3781,9 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 		})
 		fields := make([]*schemapb.FieldSchema, 0)
 		fields = append(fields, &schemapb.FieldSchema{
-			FieldID: int64(101),
-			Name:    "string_field",
+			FieldID:  int64(101),
+			Name:     "string_field",
+			DataType: schemapb.DataType_VarChar,
 		})
 		schema := &schemapb.CollectionSchema{
 			Fields: fields,
@@ -3799,8 +3801,9 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 		})
 		fields := make([]*schemapb.FieldSchema, 0)
 		fields = append(fields, &schemapb.FieldSchema{
-			FieldID: int64(101),
-			Name:    "string_field",
+			FieldID:  int64(101),
+			Name:     "string_field",
+			DataType: schemapb.DataType_VarChar,
 		})
 		schema := &schemapb.CollectionSchema{
 			Fields: fields,
@@ -3819,6 +3822,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 		fields = append(fields, &schemapb.FieldSchema{
 			FieldID:  int64(101),
 			Name:     "string_field",
+			DataType: schemapb.DataType_VarChar,
 			Nullable: true,
 		})
 		schema := &schemapb.CollectionSchema{
@@ -3837,8 +3841,9 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 		resetSearchParamsValue(normalParam, TopKKey, `1024000`)
 		fields := make([]*schemapb.FieldSchema, 0)
 		fields = append(fields, &schemapb.FieldSchema{
-			FieldID: int64(101),
-			Name:    "string_field",
+			FieldID:  int64(101),
+			Name:     "string_field",
+			DataType: schemapb.DataType_VarChar,
 		})
 		schema := &schemapb.CollectionSchema{
 			Fields: fields,
@@ -3896,8 +3901,9 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 		})
 		fields := make([]*schemapb.FieldSchema, 0)
 		fields = append(fields, &schemapb.FieldSchema{
-			FieldID: int64(101),
-			Name:    "string_field",
+			FieldID:  int64(101),
+			Name:     "string_field",
+			DataType: schemapb.DataType_VarChar,
 		})
 		schema := &schemapb.CollectionSchema{
 			Fields: fields,
@@ -3972,8 +3978,9 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 			})
 			fields := make([]*schemapb.FieldSchema, 0)
 			fields = append(fields, &schemapb.FieldSchema{
-				FieldID: int64(101),
-				Name:    "string_field",
+				FieldID:  int64(101),
+				Name:     "string_field",
+				DataType: schemapb.DataType_VarChar,
 			})
 			schema := &schemapb.CollectionSchema{
 				Fields: fields,

--- a/tests/python_client/milvus_client/test_milvus_client_search_group_by.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_group_by.py
@@ -659,9 +659,12 @@ class TestGroupSearch(TestMilvusClientV2Base):
         search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         search_params = {"metric_type": self.float_vector_metric}
         limit = 1
-        error = {ct.err_code: 999, ct.err_msg: f"unsupported data type {grpby_unsupported_field} for group by operator"}
-        if grpby_unsupported_field == ct.default_float_vec_field_name:
-            error = {ct.err_code: 999, ct.err_msg: "unsupported data type VECTOR_FLOAT for group by operator"}
+        # The rejection now happens at the proxy, which names the field rather
+        # than repeating the executor's C++ type spelling; the executor's own
+        # message is unreachable for these types because the request no longer
+        # gets that far.
+        error = {ct.err_code: 999,
+                 ct.err_msg: f"unsupported data type for group by: field {grpby_unsupported_field}"}
         self.search(
             client,
             self.collection_name,


### PR DESCRIPTION
> Kept in lockstep with the squashed commit message.

Three REST requests were accepted and then quietly did something other than
what they said, all through the same pattern: a parameter that fails a check
is not forwarded rather than refused, so the server that would have rejected
it never sees it and the request reports success.

groupSize was forwarded only when greater than zero, behind a bare int32 that
cannot tell an absent knob from an explicit one. groupSize 0 or -1 was
swallowed and the search ran with the server default; the server-side
rejection ("input group size is negative") exists but was unreachable from
REST. strictGroupSize rode behind the same gate, so setting it without also
setting groupSize dropped it silently. Both knobs are now pointers: absent
means the server default, present means forwarded or refused -- an explicit
non-positive groupSize and any knob without groupingField are errors. The
searchAggregation conflict check asks for presence rather than for the zero
value, so an explicit groupSize: 0 no longer slips past it either.

A group-by field name resolved to a field id with no look at the field type,
so grouping by a vector field was accepted at the proxy and either degenerated
into an ungrouped search or surfaced as an execution error deep in the query.
parseGroupByField now refuses the types the group-by operator cannot hold as
a key; the supported list mirrors the switch in SearchGroupByOperator.cpp --
bool, the integer widths, timestamptz, varchar, and json, whose inner value
is still checked at execution where the path is known. The dynamic-field
fallback is untouched.

The searchParams map is a second spelling of the same knobs, and it was a side
door around both rules above: group_size and strict_group_size inside
searchParams slipped past the searchAggregation conflict check, and when the
two spellings disagreed the searchParams one was appended first and silently
won, since the proxy takes the first matching key. Both ambiguities are
refused now, the same way the order_by_fields passthrough already was: one
spelling per request.

Two edges found in review are folded in. A groupingField of blanks counted as
provided at the REST layer while the proxy trims the name before resolving it,
so the knobs it authorized were swallowed downstream -- the name is now
trimmed with the proxy's rule before anything is decided. And DataType_String
is off the accepted list: the executor's switch has a VARCHAR case and no
STRING case, so admitting it would only move the failure back into the
execution layer.

The legacy spelling obeys the same rules as the dedicated one. A size knob in
searchParams with no group field anywhere is refused rather than parsed into a
grouping that never enables. And group keys nested under searchParams.params
are refused only when they are the request's sole grouping: the proxy reads
standalone pairs, so a nested-only spelling asked for grouping and silently
did not get it. Beside a working spelling the nested copies are tolerated --
generateSearchParams itself duplicates root keys into the params JSON, so
that shape is the pipeline's own artifact and previously-working requests
keep working. The ambiguity rule likewise asks only the root keys. The hybrid-search test fixtures gain
the field types the type gate now demands -- all of them, not only the two
that failed first. The wording the caller reads is preserved rather than
replaced wherever a check moved earlier: a binary vector keeps the executor's
own sentence, and the searchAggregation conflict keeps its group_by_field(s)
sentence with the size knobs appended to it. Moving a check earlier should not
change the answer a client is pinned on -- the go client suite and the REST
e2e suite both pin these.

Two proxy-side gaps in the same territory are closed with the same fail-fast
principle. At most one JSON field can be grouped by: the plan carries a single
json_path/json_type and the executor asserts as much, but two bare JSON fields
passed the proxy and failed only deep in execution. And the JSON group-by
attributes now ride the rank params into hybrid search: parseRankParams
already resolved jsonPath, jsonType and strictCast and then dropped them, so
a hybrid group-by on a JSON key silently grouped by the whole field instead
of the key the caller named.

The unknown-request-key question raised alongside these (a nested SDK-style
groupParams object is silently ignored by the binder) is a policy decision
about every REST endpoint, not a bug in these knobs, and is left alone.

---

issue: #52309
issue: #52311
issue: #52325

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1pij3TGike2nZy7t6oDZY
