### PR TITLE
fix: [cp 2.6] pin py for pytest-html to unbreak every e2e pipeline

### DIFF
--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -17,6 +17,9 @@ pytest-xdist==2.5.0
 pytest-rerunfailures==14.0
 pytest_tagging==1.6.0
 pytest-html==3.1.1
+# pytest-html 3.1.1 imports py.xml; py used to arrive transitively via
+# pytest-forked until its 1.7.5 release (2026-08-08) dropped the dependency
+py==1.11.0
 delayed-assert==0.3.5
 kubernetes==17.17.0
 PyYAML==6.0.2

--- a/tests/restful_client/requirements.txt
+++ b/tests/restful_client/requirements.txt
@@ -10,6 +10,9 @@ pytest-print==0.2.1
 pytest-level==0.1.1
 pytest-xdist==2.5.0
 pytest-html==3.1.1
+# pytest-html 3.1.1 imports py.xml; py used to arrive transitively via
+# pytest-forked until its 1.7.5 release (2026-08-08) dropped the dependency
+py==1.11.0
 pytest-sugar==0.9.5
 pytest-parallel
 pytest-random-order


### PR DESCRIPTION
cherry-pick from master #52336 (commit e8cd33bc9c)

Every e2e sub-pipeline on 2.6 dies before running a single test:

```
File ".../pytest_html/plugin.py", line 22, in <module>
    from py.xml import html
ModuleNotFoundError: No module named 'py.xml'; 'py' is not a package
```

The pinned `pytest-html==3.1.1` imports `py.xml`, and the `py` package used to arrive transitively through `pytest-forked` (a dependency of the pinned `pytest-xdist==2.5.0`). **pytest-forked 1.7.5, released 2026-08-08, dropped its `py` dependency**, so a fresh resolve no longer installs `py` and the pytest-html plugin fails at import time in every job that installs these requirements.

This is why every 2.6 PR opened since 2026-08-09 fails `ci-v2/e2e-default` regardless of its content: pytest aborts during plugin loading, with zero tests collected. Runs that completed on 08-07 or earlier passed against the very same base commit (`d85dc9459d`), which has not moved since.

Observed on 2.6: #52334 (dispatcher [16875](https://jenkins-milvus-ci.milvus.io/job/MILVUS-CI-V2-PR-PIPELINES/job/milvus-e2e-pipeline-dispatcher/16875/), sub-job [39324](https://jenkins-milvus-ci.milvus.io/job/MILVUS-CI-V2-PR-PIPELINES/job/milvus-e2e-pipeline-4am/39324/)) and #52337, both with identical tracebacks.

Fix: pin `py==1.11.0` (its final release) next to pytest-html in both requirements files that pin pytest-html 3.1.1. Test-dependency only; no product code touched.

/kind bug