### PR TITLE
fix: [3.0] Preserve geometry defaults in rebuilds (#52204)

### DIFF
--- a/internal/storage/arrow_util.go
+++ b/internal/storage/arrow_util.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -43,8 +44,27 @@ func isNullableDenseVectorArrowType(dataType schemapb.DataType) bool {
 	}
 }
 
-func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *schemapb.ValueField) (uint64, error) {
+type appendValueDefault struct {
+	value       *schemapb.ValueField
+	geometryWKB []byte
+}
+
+func newAppendValueDefault(field *schemapb.FieldSchema) (appendValueDefault, error) {
+	defaultValue := field.GetDefaultValue()
+	ret := appendValueDefault{value: defaultValue}
+	if defaultValue != nil && field.GetDataType() == schemapb.DataType_Geometry {
+		val, err := common.ConvertWKTToWKB(defaultValue.GetStringData())
+		if err != nil {
+			return ret, merr.WrapErrServiceInternalErr(err, "invalid default value for geometry field %s", field.GetName())
+		}
+		ret.geometryWKB = val
+	}
+	return ret, nil
+}
+
+func appendValueAt(builder array.Builder, a arrow.Array, idx int, field *schemapb.FieldSchema, appendDefault appendValueDefault) (uint64, error) {
 	// a could never be nil here
+	defaultValue := appendDefault.value
 	switch b := builder.(type) {
 	case *array.BooleanBuilder:
 		ba, ok := a.(*array.Boolean)
@@ -189,6 +209,10 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 		if ba.IsNull(idx) {
 			// could be internal $meta json
 			if defaultValue != nil {
+				if field.GetDataType() == schemapb.DataType_Geometry {
+					b.Append(appendDefault.geometryWKB)
+					return uint64(len(appendDefault.geometryWKB)), nil
+				}
 				val := defaultValue.GetBytesData()
 				b.Append(val)
 				return uint64(len(val)), nil
@@ -327,6 +351,15 @@ func GenerateEmptyArrayFromSchema(schema *schemapb.FieldSchema, numRows int) (ar
 			bd.AppendValues(
 				lo.RepeatBy(numRows, func(_ int) []byte { return schema.GetDefaultValue().GetBytesData() }),
 				nil)
+		case schemapb.DataType_Geometry:
+			bd := builder.(*array.BinaryBuilder)
+			defaultValue, err := common.ConvertWKTToWKB(schema.GetDefaultValue().GetStringData())
+			if err != nil {
+				return nil, merr.WrapErrServiceInternalErr(err, "invalid default value for geometry field %s", schema.GetName())
+			}
+			bd.AppendValues(
+				lo.RepeatBy(numRows, func(_ int) []byte { return defaultValue }),
+				nil)
 		default:
 			return nil, merr.WrapErrServiceInternalMsg("Unexpected default value type: %s", schema.GetDataType().String())
 		}
@@ -345,17 +378,37 @@ type RecordBuilder struct {
 	fields      []*schemapb.FieldSchema
 	arrowFields []arrow.Field
 	builders    []array.Builder
+	defaults    []appendValueDefault
 
 	nRows int
 	size  uint64
 }
 
+func (b *RecordBuilder) prepareAppendDefaults() error {
+	if b.defaults != nil {
+		return nil
+	}
+	defaults := make([]appendValueDefault, len(b.fields))
+	for i, field := range b.fields {
+		appendDefault, err := newAppendValueDefault(field)
+		if err != nil {
+			return err
+		}
+		defaults[i] = appendDefault
+	}
+	b.defaults = defaults
+	return nil
+}
+
 func (b *RecordBuilder) Append(rec Record, start, end int) error {
+	if err := b.prepareAppendDefaults(); err != nil {
+		return err
+	}
 	for offset := start; offset < end; offset++ {
 		for i, builder := range b.builders {
 			f := b.fields[i]
 			col := rec.Column(f.FieldID)
-			size, err := appendValueAt(builder, col, offset, f.GetDefaultValue())
+			size, err := appendValueAt(builder, col, offset, f, b.defaults[i])
 			if err != nil {
 				return merr.Wrapf(err, "failed to append value at offset %d for field %s", offset, f.GetName())
 			}

--- a/internal/storage/arrow_util_test.go
+++ b/internal/storage/arrow_util_test.go
@@ -23,11 +23,13 @@ import (
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 )
 
 func TestGenerateEmptyArray(t *testing.T) {
@@ -208,6 +210,23 @@ func TestGenerateEmptyArray(t *testing.T) {
 			},
 			expectValue: []byte(`{}`),
 		},
+		{
+			tag: "geometry",
+			field: &schemapb.FieldSchema{
+				DataType: schemapb.DataType_Geometry,
+				Nullable: true,
+				DefaultValue: &schemapb.ValueField{
+					Data: &schemapb.ValueField_StringData{
+						StringData: "POINT (1 2)",
+					},
+				},
+			},
+			expectValue: func() []byte {
+				wkb, err := common.ConvertWKTToWKB("POINT (1 2)")
+				require.NoError(t, err)
+				return wkb
+			}(),
+		},
 	}
 
 	for _, tc := range cases {
@@ -234,6 +253,99 @@ func TestGenerateEmptyArray(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestRecordBuilderFillsNullableGeometryDefault(t *testing.T) {
+	const defaultWKT = "POINT (1 2)"
+	defaultWKB, err := common.ConvertWKTToWKB(defaultWKT)
+	require.NoError(t, err)
+
+	field := &schemapb.FieldSchema{
+		FieldID:  100,
+		Name:     "geom",
+		DataType: schemapb.DataType_Geometry,
+		Nullable: true,
+		DefaultValue: &schemapb.ValueField{
+			Data: &schemapb.ValueField_StringData{StringData: defaultWKT},
+		},
+	}
+
+	builder := array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
+	defer builder.Release()
+	builder.AppendNull()
+	srcArr := builder.NewArray()
+	defer srcArr.Release()
+
+	src := NewSimpleArrowRecord(array.NewRecord(
+		arrow.NewSchema([]arrow.Field{{Name: field.Name, Type: arrow.BinaryTypes.Binary, Nullable: true}}, nil),
+		[]arrow.Array{srcArr},
+		int64(srcArr.Len()),
+	), map[FieldID]int{field.FieldID: 0})
+	defer src.Release()
+
+	rb := NewRecordBuilder(&schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{field}})
+	defer rb.Release()
+	require.NoError(t, rb.Append(src, 0, 1))
+
+	rebuilt := rb.Build()
+	defer rebuilt.Release()
+	out := rebuilt.Column(field.FieldID).(*array.Binary)
+	require.True(t, out.IsValid(0))
+	require.Equal(t, defaultWKB, out.Value(0))
+	require.NotEmpty(t, out.Value(0))
+	_, err = common.ConvertWKBToWKT(out.Value(0))
+	require.NoError(t, err)
+}
+
+func TestRecordBuilderCachesNullableGeometryDefaultWKB(t *testing.T) {
+	const defaultWKT = "POINT (1 2)"
+	defaultWKB, err := common.ConvertWKTToWKB(defaultWKT)
+	require.NoError(t, err)
+
+	convertCalls := 0
+	patch := mockey.Mock(common.ConvertWKTToWKB).To(func(wkt string) ([]byte, error) {
+		convertCalls++
+		require.Equal(t, defaultWKT, wkt)
+		return defaultWKB, nil
+	}).Build()
+	defer patch.UnPatch()
+
+	field := &schemapb.FieldSchema{
+		FieldID:  100,
+		Name:     "geom",
+		DataType: schemapb.DataType_Geometry,
+		Nullable: true,
+		DefaultValue: &schemapb.ValueField{
+			Data: &schemapb.ValueField_StringData{StringData: defaultWKT},
+		},
+	}
+
+	builder := array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
+	defer builder.Release()
+	builder.AppendNulls(5)
+	srcArr := builder.NewArray()
+	defer srcArr.Release()
+
+	src := NewSimpleArrowRecord(array.NewRecord(
+		arrow.NewSchema([]arrow.Field{{Name: field.Name, Type: arrow.BinaryTypes.Binary, Nullable: true}}, nil),
+		[]arrow.Array{srcArr},
+		int64(srcArr.Len()),
+	), map[FieldID]int{field.FieldID: 0})
+	defer src.Release()
+
+	rb := NewRecordBuilder(&schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{field}})
+	defer rb.Release()
+	require.NoError(t, rb.Append(src, 0, 2))
+	require.NoError(t, rb.Append(src, 2, 5))
+	require.Equal(t, 1, convertCalls)
+
+	rebuilt := rb.Build()
+	defer rebuilt.Release()
+	out := rebuilt.Column(field.FieldID).(*array.Binary)
+	for i := 0; i < out.Len(); i++ {
+		require.True(t, out.IsValid(i))
+		require.Equal(t, defaultWKB, out.Value(i))
 	}
 }
 

--- a/internal/storage/sort.go
+++ b/internal/storage/sort.go
@@ -164,11 +164,13 @@ func Sort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordReader
 
 	phaseStart = time.Now()
 	rb := NewRecordBuilder(schema)
+	if err := rb.prepareAppendDefaults(); err != nil {
+		return 0, nil, err
+	}
 
 	// Resolve each output column's source array once per input record (instead
 	// of once per row, as RecordBuilder.Append would).
 	srcByField := make([][]arrow.Array, len(rb.builders))
-	defaults := make([]*schemapb.ValueField, len(rb.builders))
 	for fi := range rb.builders {
 		fid := rb.fields[fi].FieldID
 		cols := make([]arrow.Array, len(records))
@@ -176,7 +178,6 @@ func Sort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordReader
 			cols[ri] = records[ri].Column(fid)
 		}
 		srcByField[fi] = cols
-		defaults[fi] = rb.fields[fi].GetDefaultValue()
 	}
 
 	writeRecord := func() error {
@@ -190,7 +191,7 @@ func Sort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordReader
 
 	for _, idx := range indices {
 		for fi, builder := range rb.builders {
-			size, err := appendValueAt(builder, srcByField[fi][idx.ri], int(idx.i), defaults[fi])
+			size, err := appendValueAt(builder, srcByField[fi][idx.ri], int(idx.i), rb.fields[fi], rb.defaults[fi])
 			if err != nil {
 				return 0, nil, merr.Wrapf(err, "failed to append value at row %d for field %s", idx.i, rb.fields[fi].GetName())
 			}

--- a/internal/storage/sort_test.go
+++ b/internal/storage/sort_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
@@ -213,6 +214,82 @@ func TestSort(t *testing.T) {
 		assert.Equal(t, 0, gotNumRows)
 		assert.Nil(t, timings)
 	})
+}
+
+func TestSortCachesNullableGeometryDefaultWKB(t *testing.T) {
+	const defaultWKT = "POINT (1 2)"
+	defaultWKB, err := common.ConvertWKTToWKB(defaultWKT)
+	require.NoError(t, err)
+
+	convertCalls := 0
+	patch := mockey.Mock(common.ConvertWKTToWKB).To(func(wkt string) ([]byte, error) {
+		convertCalls++
+		require.Equal(t, defaultWKT, wkt)
+		return defaultWKB, nil
+	}).Build()
+	defer patch.UnPatch()
+
+	pkField := &schemapb.FieldSchema{
+		FieldID:      100,
+		Name:         "pk",
+		DataType:     schemapb.DataType_Int64,
+		IsPrimaryKey: true,
+	}
+	geomField := &schemapb.FieldSchema{
+		FieldID:  101,
+		Name:     "geom",
+		DataType: schemapb.DataType_Geometry,
+		Nullable: true,
+		DefaultValue: &schemapb.ValueField{
+			Data: &schemapb.ValueField_StringData{StringData: defaultWKT},
+		},
+	}
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{pkField, geomField}}
+
+	pkBuilder := array.NewInt64Builder(memory.DefaultAllocator)
+	defer pkBuilder.Release()
+	pkBuilder.AppendValues([]int64{3, 1, 2}, nil)
+	pkColumn := pkBuilder.NewArray()
+	defer pkColumn.Release()
+
+	geomBuilder := array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
+	defer geomBuilder.Release()
+	geomBuilder.AppendNulls(3)
+	geomColumn := geomBuilder.NewArray()
+	defer geomColumn.Release()
+
+	rec := NewSimpleArrowRecord(array.NewRecord(
+		arrow.NewSchema([]arrow.Field{
+			{Name: pkField.Name, Type: arrow.PrimitiveTypes.Int64},
+			{Name: geomField.Name, Type: arrow.BinaryTypes.Binary, Nullable: true},
+		}, nil),
+		[]arrow.Array{pkColumn, geomColumn},
+		3,
+	), map[FieldID]int{pkField.FieldID: 0, geomField.FieldID: 1})
+	defer rec.Release()
+
+	writer := &MockRecordWriter{
+		writefn: func(r Record) error {
+			out := r.Column(geomField.FieldID).(*array.Binary)
+			require.Equal(t, 3, out.Len())
+			for i := 0; i < out.Len(); i++ {
+				require.True(t, out.IsValid(i))
+				require.Equal(t, defaultWKB, out.Value(i))
+			}
+			return nil
+		},
+		closefn: func() error {
+			return nil
+		},
+	}
+
+	gotNumRows, timings, err := Sort(64*1024*1024, schema, []RecordReader{&oneShotRecordReader{rec: rec}}, writer, func(r Record, ri, i int) bool {
+		return true
+	}, []int64{pkField.FieldID})
+	require.NoError(t, err)
+	require.Equal(t, 3, gotNumRows)
+	require.NotNil(t, timings)
+	require.Equal(t, 1, convertCalls)
 }
 
 func TestMergeSort(t *testing.T) {

--- a/internal/util/importutilv2/parquet/field_reader.go
+++ b/internal/util/importutilv2/parquet/field_reader.go
@@ -820,22 +820,23 @@ func ReadNullableGeometryData(pcr *FieldReader, count int64) (any, []bool, error
 	if data == nil {
 		return nil, nil, nil
 	}
-	wkbValues := make([][]byte, 0)
-	defaultValueStr := pcr.field.GetDefaultValue().GetStringData()
-	defaultValue := []byte(nil)
-	if defaultValueStr != "" {
-		defaultValue, _ = pkgcommon.ConvertWKTToWKB(defaultValueStr)
-	}
+	wkbValues := make([][]byte, len(data))
 	for i, wktValue := range data {
 		if !validData[i] {
-			wkbValues = append(wkbValues, defaultValue)
 			continue
 		}
 		wkbValue, err := pkgcommon.ConvertWKTToWKB(wktValue)
 		if err != nil {
 			return nil, nil, err
 		}
-		wkbValues = append(wkbValues, wkbValue)
+		wkbValues[i] = wkbValue
+	}
+	if pcr.field.GetDefaultValue() != nil {
+		defaultValue, err := pkgcommon.ConvertWKTToWKB(pcr.field.GetDefaultValue().GetStringData())
+		if err != nil {
+			return nil, nil, merr.WrapErrImportSysFailedMsg("invalid default value for geometry field %s", pcr.field.GetName())
+		}
+		return fillWithDefaultValueImpl(wkbValues, defaultValue, validData, pcr.field)
 	}
 	return wkbValues, validData, nil
 }

--- a/internal/util/importutilv2/parquet/field_reader_test.go
+++ b/internal/util/importutilv2/parquet/field_reader_test.go
@@ -165,6 +165,80 @@ func TestReadTextFieldData(t *testing.T) {
 	assert.Equal(t, numRows, insertData.Data[fieldID].RowNum())
 }
 
+func TestReadNullableGeometryDataFillsDefaultAndValidData(t *testing.T) {
+	const (
+		pkFieldID   = int64(100)
+		geomFieldID = int64(101)
+		numRows     = 3
+		defaultWKT  = "POINT (1 2)"
+	)
+	defaultWKB, err := common.ConvertWKTToWKB(defaultWKT)
+	require.NoError(t, err)
+
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: pkFieldID, Name: "pk", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			{
+				FieldID:  geomFieldID,
+				Name:     "geom",
+				DataType: schemapb.DataType_Geometry,
+				Nullable: true,
+				DefaultValue: &schemapb.ValueField{
+					Data: &schemapb.ValueField_StringData{StringData: defaultWKT},
+				},
+			},
+		},
+	}
+	pqSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "pk", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "geom", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+
+	filePath := fmt.Sprintf("/tmp/test_%d_nullable_geometry_default_reader.parquet", rand.Int())
+	defer os.Remove(filePath)
+	wf, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0o666)
+	require.NoError(t, err)
+	fw, err := pqarrow.NewFileWriter(pqSchema, wf,
+		parquet.NewWriterProperties(parquet.WithMaxRowGroupLength(numRows)), pqarrow.DefaultWriterProps())
+	require.NoError(t, err)
+
+	pkBuilder := array.NewInt64Builder(memory.DefaultAllocator)
+	defer pkBuilder.Release()
+	pkBuilder.AppendValues([]int64{1, 2, 3}, nil)
+	pkArr := pkBuilder.NewArray()
+	defer pkArr.Release()
+
+	geomBuilder := array.NewStringBuilder(memory.DefaultAllocator)
+	defer geomBuilder.Release()
+	geomBuilder.Append("POINT (0 0)")
+	geomBuilder.AppendNull()
+	geomBuilder.Append("POINT (3 3)")
+	geomArr := geomBuilder.NewArray()
+	defer geomArr.Release()
+
+	recordBatch := array.NewRecord(pqSchema, []arrow.Array{pkArr, geomArr}, numRows)
+	require.NoError(t, fw.Write(recordBatch))
+	recordBatch.Release()
+	require.NoError(t, fw.Close())
+
+	ctx := context.Background()
+	f := storage.NewChunkManagerFactory("local", objectstorage.RootPath(testOutputPath))
+	cm, err := f.NewPersistentStorageChunkManager(ctx)
+	require.NoError(t, err)
+	reader, err := NewReader(ctx, cm, schema, filePath, 64*1024*1024)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	insertData, err := reader.Read()
+	require.NoError(t, err)
+	geomData := insertData.Data[geomFieldID].(*storage.GeometryFieldData)
+	require.Equal(t, []bool{true, true, true}, geomData.ValidData)
+	require.Equal(t, defaultWKB, geomData.Data[1])
+	require.NotEmpty(t, geomData.Data[1])
+	_, err = common.ConvertWKBToWKT(geomData.Data[1])
+	require.NoError(t, err)
+}
+
 // TestParseSparseFloatRowVector tests the parseSparseFloatRowVector function
 func TestParseSparseFloatRowVector(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Cherry-pick from master
pr: #52204
issue: #52105

Geometry fields store defaults as WKT strings, while JSON fields use byte defaults. Row-copy rebuilds only read binary defaults from BytesData, so null geometry cells could be rewritten as valid empty WKB values during compaction.

Pass the field schema into the row-copy helper so geometry defaults are converted from WKT to WKB before appending. Also make the Parquet geometry reader mark default-filled null rows valid, matching the generic nullable default handling used by other scalar readers.

Add regression coverage for geometry defaults in empty-array generation, RecordBuilder rebuilds, and Parquet nullable geometry imports.

---------