### PR TITLE
enhance: release the bump partial writer on error paths instead of leaking it (#51649)

### DIFF
--- a/internal/datanode/compactor/bump_schema_version_compactor.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor.go
@@ -756,6 +756,41 @@ type bumpSchemaVersionBatchWriter interface {
 	GetWrittenUncompressed() uint64
 	AsNewColumnGroups()
 	Close() (packed.WriterOutput, error)
+	Abort()
+}
+
+type bumpSchemaVersionWriterLease struct {
+	writer    bumpSchemaVersionBatchWriter
+	exhausted bool
+}
+
+func (l *bumpSchemaVersionWriterLease) Close() (packed.WriterOutput, error) {
+	if l.exhausted {
+		// A second Close is always a caller bug: after an error the native
+		// writer must not be touched again (the underlying nil-guard only
+		// covers the success path), and after success there is nothing left
+		// to close. Fail loudly instead of touching the FFI writer.
+		return nil, merr.WrapErrServiceInternalMsg("bump schema version writer lease already consumed")
+	}
+	output, err := l.writer.Close()
+	// Close consumes the native writer even when it returns an error. Never call
+	// it again from deferred cleanup; only the returned output still needs release.
+	l.exhausted = true
+	return output, err
+}
+
+// Cleanup releases an unconsumed writer on error paths via Abort instead of
+// output-finalizing Close. Manifest publication is a separate caller action via
+// packed.CommitManifestUpdates, and this error path never reaches it.
+// It does not guarantee no bytes are written: see packedRecordBatchWriter.Abort
+// for the object-storage residue (a possibly finalized open row group and a
+// dangling multipart upload) that storage-side reclamation must handle.
+func (l *bumpSchemaVersionWriterLease) Cleanup() {
+	if l == nil || l.exhausted {
+		return
+	}
+	l.exhausted = true
+	l.writer.Abort()
 }
 
 type bumpSchemaVersionWriterResult struct {
@@ -988,6 +1023,8 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 	if err != nil {
 		return nil, err
 	}
+	writerLease := &bumpSchemaVersionWriterLease{writer: writerResult.writer}
+	defer writerLease.Cleanup()
 
 	log.Info(ctx, "schema bump writer setup",
 		mlog.Int64("effectiveStorageVersion", writerResult.storageVersion),
@@ -1100,12 +1137,12 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 		return nil, err
 	}
 
-	writerOutput, err := writerResult.writer.Close()
-	if err != nil {
-		return nil, err
-	}
+	writerOutput, err := writerLease.Close()
 	if writerOutput != nil {
 		defer writerOutput.Destroy()
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	manifestPath, err := packed.CommitManifestUpdates(

--- a/internal/datanode/compactor/bump_schema_version_compactor_test.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor_test.go
@@ -106,6 +106,26 @@ func (w *fakeBinlogRecordWriter) FlushChunk() error                  { return ni
 func (w *fakeBinlogRecordWriter) GetBufferUncompressed() uint64      { return 0 }
 func (w *fakeBinlogRecordWriter) Schema() *schemapb.CollectionSchema { return w.schema }
 
+type fakeBumpSchemaVersionBatchWriter struct {
+	closeCalls int
+	abortCalls int
+	output     packed.WriterOutput
+	closeErr   error
+	writeErr   error
+}
+
+func (w *fakeBumpSchemaVersionBatchWriter) Abort() { w.abortCalls++ }
+
+func (w *fakeBumpSchemaVersionBatchWriter) Write(storage.Record) error { return w.writeErr }
+func (w *fakeBumpSchemaVersionBatchWriter) GetWrittenUncompressed() uint64 {
+	return 0
+}
+func (w *fakeBumpSchemaVersionBatchWriter) AsNewColumnGroups() {}
+func (w *fakeBumpSchemaVersionBatchWriter) Close() (packed.WriterOutput, error) {
+	w.closeCalls++
+	return w.output, w.closeErr
+}
+
 type BumpSchemaVersionCompactionTaskSuite struct {
 	suite.Suite
 
@@ -1476,4 +1496,86 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionInputSchemaByF
 	s.ErrorIs(err, merr.ErrDataIntegrity)
 	s.ErrorContains(err, "references by_field lang of type")
 	s.ErrorContains(err, "only VarChar is allowed")
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestPartialWriterLeaseCleanupAbortsOnceWithoutFlush() {
+	writer := &fakeBumpSchemaVersionBatchWriter{output: &packed.ColumnGroups{}}
+	lease := &bumpSchemaVersionWriterLease{writer: writer}
+	lease.Cleanup()
+	lease.Cleanup()
+
+	s.Equal(1, writer.abortCalls)
+	s.Zero(writer.closeCalls, "Cleanup must not finalize the writer: Close flushes pending column groups that will never be committed")
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestPartialWriterLeaseSuccessfulCloseSkipsAbort() {
+	output := &packed.ColumnGroups{}
+	writer := &fakeBumpSchemaVersionBatchWriter{output: output}
+	lease := &bumpSchemaVersionWriterLease{writer: writer}
+
+	gotOutput, err := lease.Close()
+	s.NoError(err)
+	s.Same(output, gotOutput)
+	lease.Cleanup()
+
+	s.Equal(1, writer.closeCalls)
+	s.Zero(writer.abortCalls)
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestPartialWriterLeaseCloseErrorDoesNotDoubleClose() {
+	output := &packed.ColumnGroups{}
+	destroyCalls := 0
+	destroyPatch := mockey.Mock((*packed.ColumnGroups).Destroy).To(func(*packed.ColumnGroups) {
+		destroyCalls++
+	}).Build()
+	defer destroyPatch.UnPatch()
+
+	writer := &fakeBumpSchemaVersionBatchWriter{output: output, closeErr: assert.AnError}
+	lease := &bumpSchemaVersionWriterLease{writer: writer}
+	gotOutput, err := lease.Close()
+	s.ErrorIs(err, assert.AnError)
+	s.Same(output, gotOutput)
+	gotOutput.Destroy()
+	lease.Cleanup()
+
+	s.Equal(1, writer.closeCalls)
+	s.Equal(1, destroyCalls)
+	s.Zero(writer.abortCalls, "explicit Close consumed the writer; Cleanup must not abort it again")
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestPartialWriterLeaseSecondCloseFailsWithoutTouchingWriter() {
+	writer := &fakeBumpSchemaVersionBatchWriter{output: &packed.ColumnGroups{}, closeErr: assert.AnError}
+	lease := &bumpSchemaVersionWriterLease{writer: writer}
+
+	_, err := lease.Close()
+	s.ErrorIs(err, assert.AnError)
+
+	output, err := lease.Close()
+	s.Nil(output)
+	s.ErrorIs(err, merr.ErrServiceInternal)
+	s.Equal(1, writer.closeCalls, "second Close must not touch the consumed native writer")
+	s.Zero(writer.abortCalls)
+}
+
+// Non-vacuous integration guard for the deferred writer lease: it drives
+// runMissingFunctionMaterialization (via Compact) with an injected writer that
+// fails mid-stream, and asserts the error path releases the native writer via
+// Abort — not Close. Deleting `defer writerLease.Cleanup()` in
+// runMissingFunctionMaterialization makes abortCalls stay 0 and fails this test
+// (the isolated lease unit tests above stay green regardless, so they cannot
+// pin the wiring).
+func (s *BumpSchemaVersionCompactionTaskSuite) TestPartialMaterializationAbortsWriterOnMidStreamError() {
+	s.prepareBumpSchemaVersionCompaction()
+
+	fake := &fakeBumpSchemaVersionBatchWriter{writeErr: assert.AnError}
+	patch := mockey.Mock((*bumpSchemaVersionCompactionTask).setupWriter).To(
+		func(*bumpSchemaVersionCompactionTask, []*schemapb.FieldSchema, *datapb.CompactionSegmentBinlogs, int64) (*bumpSchemaVersionWriterResult, error) {
+			return &bumpSchemaVersionWriterResult{writer: fake}, nil
+		}).Build()
+	defer patch.UnPatch()
+
+	_, err := s.task.Compact()
+	s.Error(err, "a mid-stream writer failure must fail the compaction")
+	s.Equal(1, fake.abortCalls, "the error path must release the writer via the deferred lease Cleanup (Abort)")
+	s.Zero(fake.closeCalls, "the error path must not Close the writer, which would commit/flush")
 }

--- a/internal/storage/record_writer.go
+++ b/internal/storage/record_writer.go
@@ -271,6 +271,28 @@ func (pw *packedRecordBatchWriter) Close() (packed.WriterOutput, error) {
 	return out, nil
 }
 
+// Abort releases the underlying FFI writer via Destroy instead of Close. Close
+// finalizes writer output and returns a column-groups payload; the caller
+// separately decides whether to publish it with packed.CommitManifestUpdates.
+// Error paths use Abort because they will not publish that output.
+// Without it a caller that returns on error simply drops the writer, whose C
+// handle and properties have no finalizer, and leaks it. Abort is NOT a clean
+// rollback: Destroy still runs the Arrow ParquetFileWriter destructor, which
+// can finalize the currently open row group. On object storage, the S3 sink has
+// no destructor, so an in-flight multipart upload is left neither completed nor
+// aborted. Bytes
+// already flushed during Write, plus any such trailing row group / dangling
+// multipart upload, remain and need storage-side reclamation (a bucket
+// lifecycle rule for incomplete multipart uploads) until milvus-storage
+// exposes a cascading abort down to the sink.
+func (pw *packedRecordBatchWriter) Abort() {
+	if pw.writer == nil {
+		return
+	}
+	pw.writer.Destroy()
+	pw.writer = nil
+}
+
 func (pw *packedRecordBatchWriter) AsNewColumnGroups() {
 	if pw.writer != nil {
 		pw.writer.AsNewColumnGroups()


### PR DESCRIPTION
### What

Split from #52302 (orthogonal error-path hygiene).

The bump partial-backfill error paths returned between `setupWriter` and the success-path `Close` **without releasing the writer at all**. `FFIPackedWriter` holds a C handle plus `cProperties` with no finalizer, so the native writer **leaked** (master had no cleanup here). This PR wraps it in a `bumpSchemaVersionWriterLease` whose deferred `Cleanup` calls `Abort` (`packedRecordBatchWriter.Abort` → FFI `Destroy`), releasing the native writer without running the output-finalizing `Close`. `Close` returns a column-groups payload; `packed.CommitManifestUpdates` publishes that payload separately. A second `Close` on a consumed lease fails loudly instead of touching the native writer again.

### Boundary (important — not a clean rollback)

`Abort`/`Destroy` is **not** a full rollback:
- `Destroy` still runs the Arrow `ParquetFileWriter` destructor, which can finalize the **currently open row group** (so it is not literally “no flush”);
- on object storage the S3 sink (`CustomOutputStream`) has **no destructor**, so an **in-flight multipart upload is left neither completed nor aborted** — a dangling MPU, invisible to prefix-listing GC (it needs `ListMultipartUploads`).

Bytes already flushed during `Write`, plus any such trailing row group / dangling MPU, remain and need **storage-side reclamation** (a bucket lifecycle rule for incomplete multipart uploads) until milvus-storage exposes a cascading abort down to the sink. This is not a regression — master orphaned the same MPU (and additionally leaked the writer). The value here is the leak fix; the residue is documented, with the cascading abort tracked as a milvus-storage follow-up.

### Tests

`TestPartialMaterializationAbortsWriterOnMidStreamError` drives `runMissingFunctionMaterialization` (via `Compact`) with an injected writer that fails mid-stream and asserts the error path releases the writer via `Abort`, not `Close`. It fails if `defer writerLease.Cleanup()` is removed (the isolated lease unit tests cannot pin that wiring).

issue: #51649