### PR TITLE
fix: [cp 3.0] keep insert message packs separate

### DIFF
--- a/internal/querynodev2/pipeline/insert_node.go
+++ b/internal/querynodev2/pipeline/insert_node.go
@@ -53,12 +53,12 @@ func (iNode *insertNode) addInsertData(insertDatas map[UniqueID]*delegator.Inser
 		panic(err)
 	}
 	if len(skippedFields) > 0 {
-		// Attributing the skip to dropped fields is safe only because a SchemaChange
-		// message never shares a pack with inserts: the WAL adaptor emits every V1/V2
-		// message as its own pack, msgdispatcher never merges packs, and the DML
-		// micro-batcher refuses to merge non-Insert/Delete messages. If that
-		// pack-granularity invariant is ever relaxed, filtering against the current
-		// schema could silently drop fields that exist in a newer schema.
+		// Attributing the skip to dropped fields is safe because the WAL adaptor emits
+		// every V1/V2 message as its own pack, msgdispatcher never merges packs, and the
+		// DML micro-batcher only merges delete-only packs. An Insert message therefore
+		// never shares a pipeline batch with another MsgPack. If that pack-granularity
+		// invariant is ever relaxed, filtering against the current schema could silently
+		// drop fields that exist in a newer schema.
 		mlog.Warn(context.TODO(), "skip insert payload fields absent from current schema, fields are dropped since the message was written",
 			mlog.FieldCollectionID(iNode.collectionID),
 			mlog.FieldSegmentID(msg.SegmentID),

--- a/internal/util/pipeline/stream_pipeline.go
+++ b/internal/util/pipeline/stream_pipeline.go
@@ -220,7 +220,9 @@ func NewDMLMsgPackBatcher(maxMsgNum func() int) MsgPackBatcher {
 
 func (b *dmlMsgPackBatcher) Batch(first *msgstream.MsgPack, input <-chan *msgstream.MsgPack) (*msgstream.MsgPack, *msgstream.MsgPack) {
 	maxMsgNum := b.getMaxMsgNum()
-	if maxMsgNum <= 1 || !isDMLMsgPack(first) {
+	// Preserve original pack boundaries for inserts because insertNode merges
+	// records by segment without normalizing different schema field sets.
+	if maxMsgNum <= 1 || !isDeleteOnlyMsgPack(first) {
 		return first, nil
 	}
 
@@ -232,7 +234,7 @@ func (b *dmlMsgPackBatcher) Batch(first *msgstream.MsgPack, input <-chan *msgstr
 			if !ok {
 				return mergeMsgPacks(packs), nil
 			}
-			if !isDMLMsgPack(next) {
+			if !isDeleteOnlyMsgPack(next) {
 				return mergeMsgPacks(packs), next
 			}
 			if msgNum+len(next.Msgs) > maxMsgNum {
@@ -254,15 +256,13 @@ func (b *dmlMsgPackBatcher) getMaxMsgNum() int {
 	return b.maxMsgNum()
 }
 
-func isDMLMsgPack(pack *msgstream.MsgPack) bool {
+func isDeleteOnlyMsgPack(pack *msgstream.MsgPack) bool {
 	if pack == nil || len(pack.Msgs) == 0 {
 		return false
 	}
 
 	for _, msg := range pack.Msgs {
-		switch msg.Type() {
-		case commonpb.MsgType_Insert, commonpb.MsgType_Delete:
-		default:
+		if msg.Type() != commonpb.MsgType_Delete {
 			return false
 		}
 	}

--- a/internal/util/pipeline/stream_pipeline_test.go
+++ b/internal/util/pipeline/stream_pipeline_test.go
@@ -227,6 +227,12 @@ func TestDMLMsgPackBatcherTreatsInsertPacksAsBarriers(t *testing.T) {
 			wantPending: true,
 		},
 		{
+			name:        "delete batch stops before mixed insert delete pack",
+			first:       newDMLMsgPack(230, 240, newDeleteTsMsg(231)),
+			next:        newDMLMsgPack(241, 250, newInsertTsMsg(245), newDeleteTsMsg(246)),
+			wantPending: true,
+		},
+		{
 			name:  "mixed first pack does not drain next pack",
 			first: newDMLMsgPack(300, 310, newInsertTsMsg(301), newDeleteTsMsg(302)),
 			next:  newDMLMsgPack(311, 320, newDeleteTsMsg(315)),

--- a/internal/util/pipeline/stream_pipeline_test.go
+++ b/internal/util/pipeline/stream_pipeline_test.go
@@ -82,7 +82,7 @@ func (suite *StreamPipelineSuite) TestBasic() {
 	}
 }
 
-func (suite *StreamPipelineSuite) TestDMLMsgPackBatcherMergesBufferedDMLPacks() {
+func (suite *StreamPipelineSuite) TestDMLMsgPackBatcherMergesBufferedDeletePacks() {
 	suite.pipeline = NewPipelineWithStream(
 		suite.msgDispatcher,
 		0,
@@ -105,7 +105,7 @@ func (suite *StreamPipelineSuite) TestDMLMsgPackBatcherMergesBufferedDMLPacks() 
 		BeginTs: 100,
 		EndTs:   110,
 		Msgs: []msgstream.TsMsg{
-			newInsertTsMsg(101),
+			newDeleteTsMsg(101),
 		},
 		StartPositions: []*msgpb.MsgPosition{{Timestamp: 100}},
 		EndPositions:   []*msgpb.MsgPosition{{Timestamp: 110}},
@@ -134,13 +134,49 @@ func (suite *StreamPipelineSuite) TestDMLMsgPackBatcherMergesBufferedDMLPacks() 
 	suite.Empty(received)
 }
 
+func (suite *StreamPipelineSuite) TestDMLMsgPackBatcherKeepsBufferedInsertPacksSeparate() {
+	suite.pipeline = NewPipelineWithStream(
+		suite.msgDispatcher,
+		0,
+		false,
+		suite.channel,
+		staticMVCCGetter{},
+		WithMsgPackBatcher(NewDMLMsgPackBatcher(func() int { return 8 })),
+	)
+
+	received := make(chan *msgstream.MsgPack, 2)
+	suite.pipeline.Add(&captureMsgPackNode{
+		BaseNode:   NewBaseNode("capture-msg-pack", 8),
+		outChannel: received,
+	})
+
+	err := suite.pipeline.ConsumeMsgStream(context2.Background(), &msgpb.MsgPosition{})
+	suite.NoError(err)
+
+	suite.inChannel <- newDMLMsgPack(100, 110, newInsertTsMsg(101))
+	suite.inChannel <- newDMLMsgPack(111, 120, newInsertTsMsg(115))
+
+	suite.pipeline.Start()
+	defer suite.pipeline.Close()
+
+	first := <-received
+	suite.Require().Equal(uint64(100), first.BeginTs)
+	suite.Require().Equal(uint64(110), first.EndTs)
+	suite.Require().Len(first.Msgs, 1)
+
+	second := <-received
+	suite.Equal(uint64(111), second.BeginTs)
+	suite.Equal(uint64(120), second.EndTs)
+	suite.Len(second.Msgs, 1)
+}
+
 func TestDMLMsgPackBatcherLimitsByTotalMessageNum(t *testing.T) {
 	maxMsgNum := 3
 	batcher := NewDMLMsgPackBatcher(func() int { return maxMsgNum })
 	input := make(chan *msgstream.MsgPack, 1)
-	input <- newDMLMsgPack(110, 120, newInsertTsMsg(111), newDeleteTsMsg(112))
+	input <- newDMLMsgPack(110, 120, newDeleteTsMsg(111), newDeleteTsMsg(112))
 
-	merged, pending := batcher.Batch(newDMLMsgPack(100, 109, newInsertTsMsg(101)), input)
+	merged, pending := batcher.Batch(newDMLMsgPack(100, 109, newDeleteTsMsg(101)), input)
 
 	require.NotNil(t, merged)
 	assert.Len(t, merged.Msgs, 3)
@@ -151,7 +187,7 @@ func TestDMLMsgPackBatcherLimitsByTotalMessageNum(t *testing.T) {
 	maxMsgNum = 2
 	input = make(chan *msgstream.MsgPack, 1)
 	input <- newDMLMsgPack(211, 220, newDeleteTsMsg(211))
-	merged, pending = batcher.Batch(newDMLMsgPack(200, 210, newInsertTsMsg(201)), input)
+	merged, pending = batcher.Batch(newDMLMsgPack(200, 210, newDeleteTsMsg(201)), input)
 
 	require.NotNil(t, merged)
 	assert.Len(t, merged.Msgs, 2)
@@ -160,8 +196,8 @@ func TestDMLMsgPackBatcherLimitsByTotalMessageNum(t *testing.T) {
 	assert.Nil(t, pending)
 
 	input = make(chan *msgstream.MsgPack, 1)
-	input <- newDMLMsgPack(311, 320, newDeleteTsMsg(311), newInsertTsMsg(312))
-	merged, pending = batcher.Batch(newDMLMsgPack(300, 310, newInsertTsMsg(301)), input)
+	input <- newDMLMsgPack(311, 320, newDeleteTsMsg(311), newDeleteTsMsg(312))
+	merged, pending = batcher.Batch(newDMLMsgPack(300, 310, newDeleteTsMsg(301)), input)
 
 	require.NotNil(t, merged)
 	assert.Len(t, merged.Msgs, 1)
@@ -170,6 +206,51 @@ func TestDMLMsgPackBatcherLimitsByTotalMessageNum(t *testing.T) {
 	require.NotNil(t, pending)
 	assert.Len(t, pending.Msgs, 2)
 	assert.Equal(t, uint64(311), pending.BeginTs)
+}
+
+func TestDMLMsgPackBatcherTreatsInsertPacksAsBarriers(t *testing.T) {
+	tests := []struct {
+		name        string
+		first       *msgstream.MsgPack
+		next        *msgstream.MsgPack
+		wantPending bool
+	}{
+		{
+			name:  "insert first does not drain next pack",
+			first: newDMLMsgPack(100, 110, newInsertTsMsg(101)),
+			next:  newDMLMsgPack(111, 120, newDeleteTsMsg(115)),
+		},
+		{
+			name:        "delete batch stops before insert",
+			first:       newDMLMsgPack(200, 210, newDeleteTsMsg(201)),
+			next:        newDMLMsgPack(211, 220, newInsertTsMsg(215)),
+			wantPending: true,
+		},
+		{
+			name:  "mixed first pack does not drain next pack",
+			first: newDMLMsgPack(300, 310, newInsertTsMsg(301), newDeleteTsMsg(302)),
+			next:  newDMLMsgPack(311, 320, newDeleteTsMsg(315)),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			batcher := NewDMLMsgPackBatcher(func() int { return 8 })
+			input := make(chan *msgstream.MsgPack, 1)
+			input <- test.next
+
+			merged, pending := batcher.Batch(test.first, input)
+
+			assert.Same(t, test.first, merged)
+			if test.wantPending {
+				assert.Same(t, test.next, pending)
+				assert.Empty(t, input)
+			} else {
+				assert.Nil(t, pending)
+				assert.Len(t, input, 1)
+			}
+		})
+	}
 }
 
 func TestStreamPipeline(t *testing.T) {


### PR DESCRIPTION
issue: #51612
pr: #52362

- querynode data sync: preserve original MsgPack boundaries for packs containing Insert messages
- delete microbatch: retain bounded cross-pack batching for delete-only packs
- upsert batching: preserve original MsgPack boundaries for mixed Delete/Insert packs