### PR TITLE
fix: [2.6] prevent streaming query nodes from blocking segment balance

### DIFF
--- a/docs/design-docs/design_docs/20260204-channel_exclusive_mode.md
+++ b/docs/design-docs/design_docs/20260204-channel_exclusive_mode.md
@@ -340,14 +340,16 @@ BalanceReplica(ctx, replica)
 3. Channel-Aware Balancing (Exclusive Mode Enabled)
     For each channel:
         ├─ Get channel's exclusive RW nodes
-        ├─ Identify outbound nodes (nodes no longer in RW node list)
-        ├─ If outbound nodes exist:
-        │  ├─ genChannelPlanForOutboundNodes()
+        ├─ Identify channel and segment outbound nodes independently
+        ├─ In streaming mode, leave channel placement to streaming and stopping balance
+        ├─ If channel outbound nodes exist:
+        │  └─ genChannelPlanForOutboundNodes()
+        ├─ If segment outbound nodes exist:
         │  └─ genSegmentPlanForOutboundNodes()
-        └─ If no outbound nodes:
+        └─ If no channel outbound exists and no executable segment outbound plan exists:
            ├─ If AutoBalanceChannel enabled:
            │  └─ genChannelPlan() - balance channel distribution
-           └─ Else:
+           └─ If no channel plan is generated:
               └─ genSegmentPlan() - balance segments within channel nodes
     ↓
 4. Return Plans
@@ -406,7 +408,9 @@ score = α * CPU% + β * Memory% + γ * DelegatorScore
 
 #### 5.3.3 Outbound Node Handling
 
-**Outbound Node**: A node that was previously assigned to a channel but is no longer in the channel's RW node list (due to node removal or rebalancing)
+**Channel Outbound Node**: In legacy mode, a node that holds a channel but is no longer in the channel's exclusive RW node list.
+
+**Segment Outbound Node**: A node that holds a sealed segment but is outside the channel's exclusive RW node list. With Streaming Service enabled, a valid RWSQ channel holder is not a channel outbound node, but any sealed segment on it is still segment outbound workload.
 
 **genChannelPlanForOutboundNodes()** (`channel_level_score_balancer.go:162-176`)
 

--- a/internal/datanode/index/task_analyze.go
+++ b/internal/datanode/index/task_analyze.go
@@ -118,6 +118,7 @@ func (at *analyzeTask) Execute(ctx context.Context) error {
 		Region:            at.req.GetStorageConfig().GetRegion(),
 		CloudProvider:     at.req.GetStorageConfig().GetCloudProvider(),
 		RequestTimeoutMs:  at.req.GetStorageConfig().GetRequestTimeoutMs(),
+		MaxConnections:    at.req.GetStorageConfig().GetMaxConnections(),
 		SslCACert:         at.req.GetStorageConfig().GetSslCACert(),
 		GcpCredentialJSON: at.req.GetStorageConfig().GetGcpCredentialJSON(),
 		SslTlsMinVersion:  at.req.GetStorageConfig().GetSslTlsMinVersion(),

--- a/internal/datanode/index/task_test.go
+++ b/internal/datanode/index/task_test.go
@@ -20,14 +20,18 @@ import (
 	"context"
 	"testing"
 
+	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/analyzecgowrapper"
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/proto/clusteringpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/etcdpb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/workerpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/metautil"
@@ -231,6 +235,44 @@ func (suite *AnalyzeTaskSuite) TestAnalyze() {
 
 	err = t.PreExecute(context.Background())
 	suite.NoError(err)
+}
+
+func (suite *AnalyzeTaskSuite) TestMaxConnectionsReachesAnalyze() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var capturedMaxConnections uint32
+	patch := mockey.Mock(analyzecgowrapper.Analyze).To(
+		func(_ context.Context, info *clusteringpb.AnalyzeInfo, _ *indexcgopb.StoragePluginContext) (analyzecgowrapper.CodecAnalyze, error) {
+			capturedMaxConnections = info.GetStorageConfig().GetMaxConnections()
+			return nil, nil
+		}).Build()
+	defer patch.UnPatch()
+
+	req := &workerpb.AnalyzeRequest{
+		TaskID:       suite.taskID,
+		CollectionID: suite.collectionID,
+		PartitionID:  suite.partitionID,
+		FieldID:      suite.fieldID,
+		FieldName:    "vec",
+		FieldType:    schemapb.DataType_FloatVector,
+		Dim:          128,
+		StorageConfig: &indexpb.StorageConfig{
+			StorageType:    "minio",
+			RootPath:       "files",
+			MaxConnections: 237,
+		},
+	}
+	task := &analyzeTask{
+		ctx:    ctx,
+		cancel: cancel,
+		req:    req,
+		tr:     timerecord.NewTimeRecorder("test-analyze-max-connections"),
+	}
+
+	err := task.Execute(ctx)
+	suite.NoError(err)
+	suite.Equal(uint32(237), capturedMaxConnections)
 }
 
 func TestAnalyzeTaskSuite(t *testing.T) {

--- a/internal/querycoordv2/balance/channel_level_score_balancer.go
+++ b/internal/querycoordv2/balance/channel_level_score_balancer.go
@@ -83,7 +83,8 @@ func (b *ChannelLevelScoreBalancer) BalanceReplica(ctx context.Context, replica 
 		}
 	}()
 
-	if streamingutil.IsStreamingServiceEnabled() {
+	streamingEnabled := streamingutil.IsStreamingServiceEnabled()
+	if streamingEnabled {
 		// Make a plan to rebalance the channel first.
 		// The Streaming QueryNode doesn't make the channel level score, so just fallback to the ScoreBasedBalancer.
 		channelPlan := b.balanceChannels(ctx, br, replica)
@@ -116,43 +117,56 @@ func (b *ChannelLevelScoreBalancer) BalanceReplica(ctx context.Context, replica 
 		}
 
 		channelRwNodes := replica.GetChannelRWNodes(channelName)
-		channelRONodes := make([]int64, 0)
-		// mark channel's outbound access node as offline
-		channelRWNode := typeutil.NewUniqueSet(channelRwNodes...)
-		channelDist := b.dist.ChannelDistManager.GetByFilter(meta.WithChannelName2Channel(channelName), meta.WithReplica2Channel(replica))
-		for _, channel := range channelDist {
-			if !channelRWNode.Contain(channel.Node) {
-				channelRONodes = append(channelRONodes, channel.Node)
+		channelRWNodeSet := typeutil.NewUniqueSet(channelRwNodes...)
+		channelOutboundNodes := typeutil.NewUniqueSet()
+		segmentOutboundNodes := typeutil.NewUniqueSet()
+
+		// Streaming channel placement is handled by score-based channel balance
+		// and stopping balance. Only derive channel outbound nodes from channel
+		// distribution in legacy mode.
+		if !streamingEnabled {
+			channelDist := b.dist.ChannelDistManager.GetByFilter(meta.WithChannelName2Channel(channelName), meta.WithReplica2Channel(replica))
+			for _, channel := range channelDist {
+				if !channelRWNodeSet.Contain(channel.Node) {
+					channelOutboundNodes.Insert(channel.Node)
+				}
 			}
 		}
+
+		// Sealed segments outside the channel's exclusive RW node set are true
+		// outbound workloads regardless of whether streaming service is enabled.
 		segmentDist := b.dist.SegmentDistManager.GetByFilter(meta.WithChannel(channelName), meta.WithReplica(replica))
 		for _, segment := range segmentDist {
-			if !channelRWNode.Contain(segment.Node) {
-				channelRONodes = append(channelRONodes, segment.Node)
+			if !channelRWNodeSet.Contain(segment.Node) {
+				segmentOutboundNodes.Insert(segment.Node)
 			}
 		}
 
-		if len(channelRwNodes) == 0 {
-			// no available nodes to balance
-			return nil, nil
+		hasChannelOutbound := channelOutboundNodes.Len() != 0
+		hasSegmentOutbound := segmentOutboundNodes.Len() != 0
+		if channelOutboundNodes.Len() != 0 {
+			channelPlans = append(channelPlans, b.genChannelPlanForOutboundNodes(ctx, replica, channelName, channelRwNodes, channelOutboundNodes.Collect())...)
 		}
 
-		if len(channelRONodes) != 0 {
-			if !streamingutil.IsStreamingServiceEnabled() {
-				channelPlans = append(channelPlans, b.genChannelPlanForOutboundNodes(ctx, replica, channelName, channelRwNodes, channelRONodes)...)
-			}
+		outboundSegmentPlans := make([]assign.SegmentAssignPlan, 0)
+		if hasSegmentOutbound && len(channelPlans) == 0 {
+			outboundSegmentPlans = b.genSegmentPlanForOutboundNodes(ctx, replica, channelName, channelRwNodes, segmentOutboundNodes.Collect())
+			segmentPlans = append(segmentPlans, outboundSegmentPlans...)
+		}
 
-			if len(channelPlans) == 0 {
-				segmentPlans = append(segmentPlans, b.genSegmentPlanForOutboundNodes(ctx, replica, channelName, channelRwNodes, channelRONodes)...)
-			}
-		} else {
-			if paramtable.Get().QueryCoordCfg.AutoBalanceChannel.GetAsBool() && !streamingutil.IsStreamingServiceEnabled() {
-				channelPlans = append(channelPlans, b.genChannelPlan(ctx, replica, channelName, channelRwNodes)...)
-			}
+		// Keep channel outbound evacuation and executable segment outbound plans
+		// ahead of normal balancing. If no segment outbound plan can be generated,
+		// continue with normal segment balancing for the channel.
+		if hasChannelOutbound || (hasSegmentOutbound && (len(channelPlans) != 0 || len(outboundSegmentPlans) != 0)) {
+			continue
+		}
 
-			if len(channelPlans) == 0 {
-				segmentPlans = append(segmentPlans, b.genSegmentPlan(ctx, br, replica, channelName, channelRwNodes)...)
-			}
+		if paramtable.Get().QueryCoordCfg.AutoBalanceChannel.GetAsBool() && !streamingEnabled {
+			channelPlans = append(channelPlans, b.genChannelPlan(ctx, replica, channelName, channelRwNodes)...)
+		}
+
+		if len(channelPlans) == 0 {
+			segmentPlans = append(segmentPlans, b.genSegmentPlan(ctx, br, replica, channelName, channelRwNodes)...)
 		}
 	}
 

--- a/internal/querycoordv2/balance/channel_level_score_balancer_streaming_test.go
+++ b/internal/querycoordv2/balance/channel_level_score_balancer_streaming_test.go
@@ -1,0 +1,292 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package balance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bytedance/mockey"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/internal/coordinator/snmanager"
+	"github.com/milvus-io/milvus/internal/querycoordv2/assign"
+	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
+	"github.com/milvus-io/milvus/internal/querycoordv2/session"
+	"github.com/milvus-io/milvus/internal/querycoordv2/task"
+	"github.com/milvus-io/milvus/internal/util/streamingutil"
+	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+)
+
+func TestChannelLevelScoreBalancer_StreamingRWSQDoesNotBlockSegmentBalance(t *testing.T) {
+	ctx := context.Background()
+	collectionID := int64(1)
+	replica := meta.NewReplica(&querypb.Replica{
+		ID:            1,
+		CollectionID:  collectionID,
+		ResourceGroup: meta.DefaultResourceGroupName,
+		Nodes:         []int64{344, 345, 346, 347},
+		RwSqNodes:     []int64{339, 333},
+		ChannelNodeInfos: map[string]*querypb.ChannelNodeInfo{
+			"channel1": {RwNodes: []int64{344, 345}},
+			"channel2": {RwNodes: []int64{346, 347}},
+		},
+	})
+	targetChannels := map[string]*meta.DmChannel{
+		"channel1": newTestChannel(collectionID, "channel1", 0),
+		"channel2": newTestChannel(collectionID, "channel2", 0),
+	}
+
+	balancer, dist := newStreamingChannelLevelBalancer(t, replica)
+	mockGetChannels := mockey.Mock((*meta.TargetManager).GetDmChannelsByCollection).Return(targetChannels).Build()
+	defer mockGetChannels.UnPatch()
+	mockCanMove := mockey.Mock((*meta.TargetManager).CanSegmentBeMoved).Return(true).Build()
+	defer mockCanMove.UnPatch()
+
+	dist.ChannelDistManager.Update(339, newTestChannel(collectionID, "channel1", 339))
+	dist.ChannelDistManager.Update(333, newTestChannel(collectionID, "channel2", 333))
+	dist.SegmentDistManager.Update(344,
+		newTestSegment(collectionID, 1, "channel1", 344),
+		newTestSegment(collectionID, 2, "channel1", 344),
+	)
+	dist.SegmentDistManager.Update(346,
+		newTestSegment(collectionID, 3, "channel2", 346),
+		newTestSegment(collectionID, 4, "channel2", 346),
+	)
+
+	segmentPlans, channelPlans := balancer.BalanceReplica(ctx, replica)
+
+	require.Empty(t, channelPlans)
+	require.NotEmpty(t, segmentPlans)
+	rwSQNodes := typeutil.NewUniqueSet(replica.GetRWSQNodes()...)
+	for _, plan := range segmentPlans {
+		require.False(t, rwSQNodes.Contain(plan.From))
+		require.False(t, rwSQNodes.Contain(plan.To))
+		channelRWNodes := typeutil.NewUniqueSet(replica.GetChannelRWNodes(plan.Segment.GetInsertChannel())...)
+		require.True(t, channelRWNodes.Contain(plan.From))
+		require.True(t, channelRWNodes.Contain(plan.To))
+	}
+}
+
+func TestChannelLevelScoreBalancer_StreamingTrueSegmentOutboundFirst(t *testing.T) {
+	ctx := context.Background()
+	collectionID := int64(1)
+	replica := meta.NewReplica(&querypb.Replica{
+		ID:            1,
+		CollectionID:  collectionID,
+		ResourceGroup: meta.DefaultResourceGroupName,
+		Nodes:         []int64{344, 345},
+		RwSqNodes:     []int64{339},
+		ChannelNodeInfos: map[string]*querypb.ChannelNodeInfo{
+			"channel1": {RwNodes: []int64{344, 345}},
+		},
+	})
+	targetChannels := map[string]*meta.DmChannel{
+		"channel1": newTestChannel(collectionID, "channel1", 0),
+	}
+
+	balancer, dist := newStreamingChannelLevelBalancer(t, replica)
+	mockGetChannels := mockey.Mock((*meta.TargetManager).GetDmChannelsByCollection).Return(targetChannels).Build()
+	defer mockGetChannels.UnPatch()
+	mockCanMove := mockey.Mock((*meta.TargetManager).CanSegmentBeMoved).Return(true).Build()
+	defer mockCanMove.UnPatch()
+
+	dist.ChannelDistManager.Update(339, newTestChannel(collectionID, "channel1", 339))
+	dist.SegmentDistManager.Update(339, newTestSegment(collectionID, 1, "channel1", 339))
+	dist.SegmentDistManager.Update(344,
+		newTestSegment(collectionID, 2, "channel1", 344),
+		newTestSegment(collectionID, 3, "channel1", 344),
+	)
+
+	segmentPlans, channelPlans := balancer.BalanceReplica(ctx, replica)
+
+	require.Empty(t, channelPlans)
+	require.Len(t, segmentPlans, 1)
+	require.Equal(t, int64(1), segmentPlans[0].Segment.GetID())
+	require.Equal(t, int64(339), segmentPlans[0].From)
+	require.Contains(t, replica.GetChannelRWNodes("channel1"), segmentPlans[0].To)
+}
+
+func TestChannelLevelScoreBalancer_StreamingEmptyOutboundPlanFallsBackToSegmentBalance(t *testing.T) {
+	ctx := context.Background()
+	collectionID := int64(1)
+	replica := meta.NewReplica(&querypb.Replica{
+		ID:            1,
+		CollectionID:  collectionID,
+		ResourceGroup: meta.DefaultResourceGroupName,
+		Nodes:         []int64{344, 345},
+		RwSqNodes:     []int64{339},
+		ChannelNodeInfos: map[string]*querypb.ChannelNodeInfo{
+			"channel1": {RwNodes: []int64{344, 345}},
+		},
+	})
+	targetChannels := map[string]*meta.DmChannel{
+		"channel1": newTestChannel(collectionID, "channel1", 0),
+	}
+
+	balancer, dist := newStreamingChannelLevelBalancer(t, replica)
+	mockGetChannels := mockey.Mock((*meta.TargetManager).GetDmChannelsByCollection).Return(targetChannels).Build()
+	defer mockGetChannels.UnPatch()
+	mockCanMove := mockey.Mock((*meta.TargetManager).CanSegmentBeMoved).
+		To(func(_ *meta.TargetManager, _ context.Context, _, segmentID int64) bool {
+			return segmentID != 1
+		}).Build()
+	defer mockCanMove.UnPatch()
+
+	dist.ChannelDistManager.Update(339, newTestChannel(collectionID, "channel1", 339))
+	dist.SegmentDistManager.Update(339, newTestSegment(collectionID, 1, "channel1", 339))
+	dist.SegmentDistManager.Update(344,
+		newTestSegment(collectionID, 2, "channel1", 344),
+		newTestSegment(collectionID, 3, "channel1", 344),
+	)
+
+	segmentPlans, channelPlans := balancer.BalanceReplica(ctx, replica)
+
+	require.Empty(t, channelPlans)
+	require.Len(t, segmentPlans, 1)
+	require.NotEqual(t, int64(1), segmentPlans[0].Segment.GetID())
+	require.Equal(t, int64(344), segmentPlans[0].From)
+	require.Equal(t, int64(345), segmentPlans[0].To)
+}
+
+func TestChannelLevelScoreBalancer_StreamingChannelPlanTakesPriority(t *testing.T) {
+	ctx := context.Background()
+	collectionID := int64(1)
+	replica := meta.NewReplica(&querypb.Replica{
+		ID:            1,
+		CollectionID:  collectionID,
+		ResourceGroup: meta.DefaultResourceGroupName,
+		Nodes:         []int64{344, 345},
+		RwSqNodes:     []int64{339, 333},
+		ChannelNodeInfos: map[string]*querypb.ChannelNodeInfo{
+			"channel1": {RwNodes: []int64{344}},
+			"channel2": {RwNodes: []int64{345}},
+		},
+	})
+
+	balancer, dist := newStreamingChannelLevelBalancer(t, replica)
+	mockSQNodes := mockey.Mock((*snmanager.StreamingNodeManager).GetStreamingQueryNodeIDs).
+		Return(typeutil.NewUniqueSet(339, 333)).Build()
+	defer mockSQNodes.UnPatch()
+	mockWALLocated := mockey.Mock((*snmanager.StreamingNodeManager).GetWALLocated).Return(int64(333)).Build()
+	defer mockWALLocated.UnPatch()
+
+	dist.ChannelDistManager.Update(339,
+		newTestChannel(collectionID, "channel1", 339),
+		newTestChannel(collectionID, "channel2", 339),
+	)
+
+	segmentPlans, channelPlans := balancer.BalanceReplica(ctx, replica)
+
+	require.Empty(t, segmentPlans)
+	require.NotEmpty(t, channelPlans)
+	for _, plan := range channelPlans {
+		require.Equal(t, int64(339), plan.From)
+		require.Equal(t, int64(333), plan.To)
+	}
+}
+
+func TestChannelLevelScoreBalancer_NoNormalNodes(t *testing.T) {
+	ctx := context.Background()
+	collectionID := int64(1)
+	replica := meta.NewReplica(&querypb.Replica{
+		ID:            1,
+		CollectionID:  collectionID,
+		ResourceGroup: meta.DefaultResourceGroupName,
+		ChannelNodeInfos: map[string]*querypb.ChannelNodeInfo{
+			"channel1": {RwNodes: []int64{344}},
+		},
+	})
+	targetChannels := map[string]*meta.DmChannel{
+		"channel1": newTestChannel(collectionID, "channel1", 0),
+	}
+
+	balancer, _ := newStreamingChannelLevelBalancer(t, replica)
+	mockGetChannels := mockey.Mock((*meta.TargetManager).GetDmChannelsByCollection).Return(targetChannels).Build()
+	defer mockGetChannels.UnPatch()
+
+	segmentPlans, channelPlans := balancer.BalanceReplica(ctx, replica)
+
+	require.Empty(t, segmentPlans)
+	require.Empty(t, channelPlans)
+}
+
+func newStreamingChannelLevelBalancer(t *testing.T, replica *meta.Replica) (*ChannelLevelScoreBalancer, *meta.DistributionManager) {
+	t.Helper()
+	paramtable.Init()
+
+	streamingutil.SetStreamingServiceEnabled()
+	t.Cleanup(streamingutil.UnsetStreamingServiceEnabled)
+	assign.ResetGlobalAssignPolicyFactoryForTest()
+	t.Cleanup(assign.ResetGlobalAssignPolicyFactoryForTest)
+
+	nodeManager := session.NewNodeManager()
+	for _, nodeID := range replica.GetNodes() {
+		node := session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   nodeID,
+			Address:  "127.0.0.1:0",
+			Hostname: "localhost",
+			Version:  common.Version,
+		})
+		node.SetState(session.NodeStateNormal)
+		nodeManager.Add(node)
+	}
+
+	var nextID int64
+	idAllocator := func() (int64, error) {
+		nextID++
+		return nextID, nil
+	}
+	testMeta := meta.NewMeta(idAllocator, nil, nodeManager)
+	targetMgr := meta.NewTargetManager(nil, testMeta)
+	dist := meta.NewDistributionManager(nodeManager)
+	scheduler := task.NewScheduler(context.Background(), testMeta, dist, targetMgr, nil, nil, nodeManager)
+	assign.InitGlobalAssignPolicyFactory(scheduler, nodeManager, dist, testMeta, targetMgr)
+
+	return NewChannelLevelScoreBalancer(scheduler, nodeManager, dist, testMeta, targetMgr), dist
+}
+
+func newTestChannel(collectionID int64, channelName string, nodeID int64) *meta.DmChannel {
+	return &meta.DmChannel{
+		VchannelInfo: &datapb.VchannelInfo{
+			CollectionID: collectionID,
+			ChannelName:  channelName,
+		},
+		Node: nodeID,
+		View: &meta.LeaderView{
+			ID:           nodeID,
+			CollectionID: collectionID,
+		},
+	}
+}
+
+func newTestSegment(collectionID, segmentID int64, channelName string, nodeID int64) *meta.Segment {
+	return &meta.Segment{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  collectionID,
+			PartitionID:   1,
+			InsertChannel: channelName,
+			NumOfRows:     100,
+		},
+		Node: nodeID,
+	}
+}


### PR DESCRIPTION
issue: #52139
pr: #52148
pr: #52140

### What changed

Squash-backport both changes from the 2.6 fix into one hotfix commit.

- Separate channel outbound detection from sealed-segment outbound
  detection.
- Continue normal segment balancing when outbound evacuation produces no
  executable plan.
- Propagate analyze storage MaxConnections.
- Retain only the scalar connection limit inside the Mockey callback.
- Include the Streaming Service regression coverage and design document
  update.

### Why

With Streaming Service enabled, valid RWSQ channel holders were treated
as sealed-segment outbound nodes. The resulting empty evacuation path
permanently skipped normal segment balancing.

The analyze task also failed to propagate the requested storage
connection limit.

### Branch adaptation

hotfix-2.6.22 contains one hotfix-only proxy cache commit and lacks six
later commits from the source 2.6 branch.

Both source commits apply without conflicts. They are squashed into one
commit without changing the combined patch.

### Validation

- `git diff --check`
- Combined stable patch ID:
  `b0b564f72612d5ef82465cf5f9eb8fec70dce824`
- No hotfix-specific Go or C++ tests were run. The source PR passed CI,
  and this backport preserves the source patch unchanged.
