### PR TITLE
fix: guard delegator helper RPCs during close

### DIFF
--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -709,6 +709,10 @@ func (sd *shardDelegator) Search(ctx context.Context, req *querypb.SearchRequest
 
 func (sd *shardDelegator) QueryStream(ctx context.Context, req *querypb.QueryRequest, srv streamrpc.QueryStreamServer) error {
 	log := sd.getLogger(ctx)
+	if err := sd.lifetime.Add(sd.NotStopped); err != nil {
+		return err
+	}
+	defer sd.lifetime.Done()
 	if !sd.Serviceable() {
 		return merr.WrapErrServiceUnavailable("delegator", "not serviceable")
 	}
@@ -1645,6 +1649,11 @@ func (sd *shardDelegator) runWithAnalyzer(ctx context.Context, fieldID int64, ru
 }
 
 func (sd *shardDelegator) RunAnalyzer(ctx context.Context, req *querypb.RunAnalyzerRequest) ([]*milvuspb.AnalyzerResult, error) {
+	if err := sd.lifetime.Add(sd.NotStopped); err != nil {
+		return nil, err
+	}
+	defer sd.lifetime.Done()
+
 	var result [][]*milvuspb.AnalyzerToken
 	var analyzeErr error
 	texts := lo.Map(req.GetPlaceholder(), func(bytes []byte, _ int) string {

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -1483,6 +1483,11 @@ func (sd *shardDelegator) parseMinHash(req *internalpb.SearchRequest, functionRu
 }
 
 func (sd *shardDelegator) GetHighlight(ctx context.Context, req *querypb.GetHighlightRequest) ([]*querypb.HighlightResult, error) {
+	if err := sd.lifetime.Add(sd.NotStopped); err != nil {
+		return nil, err
+	}
+	defer sd.lifetime.Done()
+
 	result := []*querypb.HighlightResult{}
 	for _, task := range req.GetTasks() {
 		if len(task.GetTexts()) != int(task.GetSearchTextNum()+task.GetCorpusTextNum())+len(task.GetQueries()) {

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -1282,6 +1282,89 @@ func (s *DelegatorSuite) TestQueryStream() {
 	})
 }
 
+func (s *DelegatorSuite) TestQueryStreamCloseWaitsForActiveRequest() {
+	s.delegator.Start()
+	paramtable.SetNodeID(1)
+	s.initSegments()
+
+	defer func() {
+		s.workerManager.AssertExpectations(s.T())
+		s.workerManager.ExpectedCalls = nil
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := streamrpc.NewLocalQueryClient(ctx)
+	server := client.CreateServer()
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	queryDone := make(chan error, 1)
+	closeDone := make(chan struct{})
+	var enteredOnce sync.Once
+
+	worker1 := cluster.NewMockWorker(s.T())
+	worker2 := cluster.NewMockWorker(s.T())
+	workers := map[int64]cluster.Worker{
+		1: worker1,
+		2: worker2,
+	}
+	s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).Call.Return(func(_ context.Context, nodeID int64) cluster.Worker {
+		return workers[nodeID]
+	}, nil)
+
+	blockQueryStream := func(ctx context.Context, req *querypb.QueryRequest, srv streamrpc.QueryStreamServer) error {
+		enteredOnce.Do(func() { close(entered) })
+		select {
+		case <-release:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	worker1.EXPECT().QueryStreamSegments(mock.Anything, mock.AnythingOfType("*querypb.QueryRequest"), mock.Anything).RunAndReturn(blockQueryStream)
+	worker2.EXPECT().QueryStreamSegments(mock.Anything, mock.AnythingOfType("*querypb.QueryRequest"), mock.Anything).RunAndReturn(blockQueryStream)
+
+	go func() {
+		err := s.delegator.QueryStream(ctx, &querypb.QueryRequest{
+			Req:         &internalpb.RetrieveRequest{QueryLabel: "query", Base: commonpbutil.NewMsgBase()},
+			DmlChannels: []string{s.vchannelName},
+		}, server)
+		queryDone <- err
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		s.FailNow("QueryStream did not enter worker call")
+	}
+
+	go func() {
+		s.delegator.Close()
+		close(closeDone)
+	}()
+
+	select {
+	case <-closeDone:
+		s.FailNow("delegator Close returned while QueryStream was still active")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		s.FailNow("delegator Close did not return after QueryStream was released")
+	}
+	select {
+	case err := <-queryDone:
+		s.NoError(err)
+	case <-time.After(time.Second):
+		s.FailNow("QueryStream did not finish")
+	}
+}
+
 func (s *DelegatorSuite) TestGetStats() {
 	s.delegator.Start()
 	// 1 => sealed segment 1000, 1001


### PR DESCRIPTION
issue: #52370

### What changed

`QueryStream`, `RunAnalyzer`, and `GetHighlight` now enter the delegator lifetime tracker while they are active. This prevents `shardDelegator.Close` from releasing per-channel resources while one of these public RPC paths is still running.

`QueryStream` keeps its existing serviceable check after entering the lifetime tracker, so non-working delegators still return the existing not-serviceable path while active requests block `Close` correctly.

### Verification

- Failing proof before fix: `TestDelegatorSuite/TestQueryStreamCloseWaitsForActiveRequest` failed with `delegator Close returned while QueryStream was still active`.
- `GOWORK=off PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig:/home/sheep/workspace/milvus/cmake_build/src:/home/sheep/workspace/milvus/cmake_build/thirdparty/milvus-storage LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:/home/sheep/workspace/milvus/cmake_build/lib LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:/home/sheep/workspace/milvus/cmake_build/lib go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/querynodev2/delegator -run 'TestDelegatorSuite/TestQueryStreamCloseWaitsForActiveRequest'`
- `GOWORK=off PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig:/home/sheep/workspace/milvus/cmake_build/src:/home/sheep/workspace/milvus/cmake_build/thirdparty/milvus-storage LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:/home/sheep/workspace/milvus/cmake_build/lib LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:/home/sheep/workspace/milvus/cmake_build/lib go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/querynodev2/delegator`
- `GOWORK=off PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig:/home/sheep/workspace/milvus/cmake_build/src:/home/sheep/workspace/milvus/cmake_build/thirdparty/milvus-storage LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:/home/sheep/workspace/milvus/cmake_build/lib LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:/home/sheep/workspace/milvus/cmake_build/lib make static-check`

Static-check emitted worktree-local `ldd` warnings for missing `internal/core/output` under the new worktree, but all phases completed with `0 issues`.
