### PR TITLE
fix: [cp2.5.13] Skip empty loop for process growing segment (#44608)

### DIFF
--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -343,6 +343,8 @@ class SegmentExpr : public Expr {
         Assert(num_data_chunk_ == 1);
         auto need_size =
             std::min(active_count_ - current_data_chunk_pos_, batch_size_);
+        if (need_size == 0)
+            return 0;  //do not go empty-loop at the bound of the chunk
 
         auto& skip_index = segment_->GetSkipIndex();
         auto views_info = segment_->get_batch_views<T>(
@@ -641,6 +643,8 @@ class SegmentExpr : public Expr {
                     : size_per_chunk_ - data_pos;
 
             size = std::min(size, batch_size_ - processed_size);
+            if (size == 0)
+                continue;  //do not go empty-loop at the bound of the chunk
 
             auto& skip_index = segment_->GetSkipIndex();
             auto chunk = segment_->chunk_data<T>(field_id_, i);


### PR DESCRIPTION
Cherry-pick of 3e5d325741 from the 2.5 branch to hotfix-2.5.13.

issue: #43427
master pr: #44606
2.5 pr: #44608

Completes the empty-loop-at-chunk-bound guard family in Expr.h: the
hotfix-2.5.13 HEAD (9c2afdbc38 / #43483) guards the sealed expression
path; this adds the two remaining guards on the growing-segment
processing path. Four-line change, same file, no dependencies.

Verification: clean cherry-pick, full compile on hotfix-2.5.13 base
(Build Tag v2.5.13-25-g59248aabd9).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
