### PR TITLE
enhance: unify request timezone resolution for search and query

### DIFF
--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -35,7 +35,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/retry"
 	"github.com/milvus-io/milvus/pkg/v3/util/timerecord"
-	"github.com/milvus-io/milvus/pkg/v3/util/timestamptz"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -104,7 +103,6 @@ type queryParams struct {
 	collectionID        int64
 	groupByFields       []string
 	orderByFields       []string // NEW: ORDER BY field specifications (e.g., "price:desc")
-	timezone            string
 	extractTimeFields   []string
 	queryIteratorCursor *planpb.QueryIteratorCursor
 }
@@ -334,7 +332,6 @@ func parseQueryParams(queryParamsPair []*commonpb.KeyValuePair, largeTopKEnabled
 		isIterator        bool
 		err               error
 		collectionID      int64
-		timezone          string
 		extractTimeFields []string
 	)
 	reduceStopForBestStr, err := funcutil.GetAttrByKeyFromRepeatedKV(ReduceStopForBestKey, queryParamsPair)
@@ -401,11 +398,6 @@ func parseQueryParams(queryParamsPair []*commonpb.KeyValuePair, largeTopKEnabled
 		}
 	}
 
-	timezone, _ = funcutil.TryGetAttrByKeyFromRepeatedKV(common.TimezoneKey, queryParamsPair)
-	if (timezone != "") && !timestamptz.IsTimezoneValid(timezone) {
-		return nil, merr.WrapErrParameterInvalidMsg("unknown or invalid IANA Time Zone ID: %s", timezone)
-	}
-
 	extractTimeFieldsStr, err := funcutil.GetAttrByKeyFromRepeatedKV(TimefieldsKey, queryParamsPair)
 	if err == nil {
 		extractTimeFields = strings.FieldsFunc(extractTimeFieldsStr, func(r rune) bool {
@@ -453,7 +445,6 @@ func parseQueryParams(queryParamsPair []*commonpb.KeyValuePair, largeTopKEnabled
 		groupByFields:       groupByFields,
 		orderByFields:       orderByFields,
 		queryIteratorCursor: queryIteratorCursor,
-		timezone:            timezone,
 		extractTimeFields:   extractTimeFields,
 	}, nil
 }
@@ -775,14 +766,11 @@ func (t *queryTask) PreExecute(ctx context.Context) error {
 		t.request.Expr = IDs2Expr(pkField, t.ids)
 	}
 
-	if t.queryParams.timezone != "" {
-		// validated in queryParams, no need to validate again
-		t.resolvedTimezoneStr = t.queryParams.timezone
-		log.Debug(ctx, "determine timezone from request", mlog.String("user defined timezone", t.resolvedTimezoneStr))
-	} else {
-		t.resolvedTimezoneStr = getColTimezone(colInfo)
-		log.Debug(ctx, "determine timezone from collection", mlog.Any("collection timezone", t.resolvedTimezoneStr))
+	timezone, err := resolveTimezone(ctx, t.request.GetQueryParams(), colInfo)
+	if err != nil {
+		return err
 	}
+	t.resolvedTimezoneStr = timezone
 
 	if err := t.createPlanArgs(ctx, &planparserv2.ParserVisitorArgs{Timezone: t.resolvedTimezoneStr}); err != nil {
 		return err
@@ -1077,7 +1065,7 @@ func (t *queryTask) PostExecute(ctx context.Context) error {
 				return err
 			}
 		} else {
-			log.Debug(ctx, "translate timestamp to ISO string", mlog.String("user define timezone", t.queryParams.timezone))
+			log.Debug(ctx, "translate timestamp to ISO string", mlog.String("timezone", t.resolvedTimezoneStr))
 			err = timestamptzUTC2IsoStr(t.result.GetFieldsData(), t.resolvedTimezoneStr)
 			if err != nil {
 				log.Warn(ctx, "fail to translate timestamp", mlog.Err(err))

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -41,7 +41,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/retry"
 	"github.com/milvus-io/milvus/pkg/v3/util/timerecord"
-	"github.com/milvus-io/milvus/pkg/v3/util/timestamptz"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -263,16 +262,9 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 	// searches with small result size could no longer need requery.
 	traceVal, _ := funcutil.GetAttrByKeyFromRepeatedKV(PipelineTraceKey, t.request.GetSearchParams())
 	t.traceEnabled = strings.EqualFold(traceVal, "true")
-	timezone, exist := funcutil.TryGetAttrByKeyFromRepeatedKV(common.TimezoneKey, t.request.SearchParams)
-	if exist {
-		if !timestamptz.IsTimezoneValid(timezone) {
-			log.Info(ctx, "get invalid timezone from request", mlog.String("timezone", timezone))
-			return merr.WrapErrParameterInvalidMsg("unknown or invalid IANA Time Zone ID: %s", timezone)
-		}
-		log.Debug(ctx, "determine timezone from request", mlog.String("user defined timezone", timezone))
-	} else {
-		timezone = getColTimezone(collectionInfo)
-		log.Debug(ctx, "determine timezone from collection", mlog.Any("collection timezone", timezone))
+	timezone, err := resolveTimezone(ctx, t.request.GetSearchParams(), collectionInfo)
+	if err != nil {
+		return err
 	}
 	t.resolvedTimezoneStr = timezone
 	// initSearchAggregation must run before init{,Advanced}SearchRequest so

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -3348,6 +3348,26 @@ func getColTimezone(colInfo *collectionInfo) string {
 	return timezone
 }
 
+// resolveTimezone returns the effective timezone for a request: the validated
+// request-level timezone when one is specified in params, otherwise the
+// collection timezone (UTC by default). Callers must resolve the timezone
+// before generating any plan that parses naive TIMESTAMPTZ literals, so that
+// filtering and result formatting use the same timezone.
+func resolveTimezone(ctx context.Context, params []*commonpb.KeyValuePair, colInfo *collectionInfo) (string, error) {
+	timezone, _ := funcutil.TryGetAttrByKeyFromRepeatedKV(common.TimezoneKey, params)
+	if timezone != "" {
+		if !timestamptz.IsTimezoneValid(timezone) {
+			mlog.Info(ctx, "get invalid timezone from request", mlog.String("timezone", timezone))
+			return "", merr.WrapErrParameterInvalidMsg("unknown or invalid IANA Time Zone ID: %s", timezone)
+		}
+		mlog.Debug(ctx, "determine timezone from request", mlog.String("user defined timezone", timezone))
+		return timezone, nil
+	}
+	timezone = getColTimezone(colInfo)
+	mlog.Debug(ctx, "determine timezone from collection", mlog.String("collection timezone", timezone))
+	return timezone, nil
+}
+
 // timestamptzUTC2IsoStr converts Timestamptz (Unix Microsecond) data
 // within FieldData results into ISO-8601 strings, applying the correct
 // timezone offset and using the optimized format (microsecond precision, no trailing zeros).

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -6915,3 +6915,46 @@ func TestFailMetricLabel(t *testing.T) {
 	assertLabels(metrics.CauseCancel, context.Canceled)
 	assertLabels(metrics.CauseCancel, errors.Wrap(context.Canceled, "rpc aborted"))
 }
+
+func TestResolveTimezone(t *testing.T) {
+	ctx := context.Background()
+	colInfoWithTz := &collectionInfo{
+		properties: []*commonpb.KeyValuePair{
+			{Key: common.TimezoneKey, Value: "America/New_York"},
+		},
+	}
+	colInfoWithoutTz := &collectionInfo{}
+
+	t.Run("request timezone wins over collection timezone", func(t *testing.T) {
+		params := []*commonpb.KeyValuePair{{Key: common.TimezoneKey, Value: "Asia/Shanghai"}}
+		tz, err := resolveTimezone(ctx, params, colInfoWithTz)
+		assert.NoError(t, err)
+		assert.Equal(t, "Asia/Shanghai", tz)
+	})
+
+	t.Run("invalid request timezone is rejected as ParameterInvalid", func(t *testing.T) {
+		params := []*commonpb.KeyValuePair{{Key: common.TimezoneKey, Value: "Not/AZone"}}
+		_, err := resolveTimezone(ctx, params, colInfoWithTz)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("absent request timezone falls back to collection timezone", func(t *testing.T) {
+		tz, err := resolveTimezone(ctx, nil, colInfoWithTz)
+		assert.NoError(t, err)
+		assert.Equal(t, "America/New_York", tz)
+	})
+
+	t.Run("empty request timezone is treated as unspecified", func(t *testing.T) {
+		params := []*commonpb.KeyValuePair{{Key: common.TimezoneKey, Value: ""}}
+		tz, err := resolveTimezone(ctx, params, colInfoWithTz)
+		assert.NoError(t, err)
+		assert.Equal(t, "America/New_York", tz)
+	})
+
+	t.Run("no request or collection timezone defaults to UTC", func(t *testing.T) {
+		tz, err := resolveTimezone(ctx, nil, colInfoWithoutTz)
+		assert.NoError(t, err)
+		assert.Equal(t, common.DefaultTimezone, tz)
+	})
+}


### PR DESCRIPTION
Follow-up to #52113.

### What changed

Extract the request-level timezone resolution ("request `timezone` param → validate → fall back to collection timezone → UTC") into a single shared helper `resolveTimezone` in `internal/proxy/util.go`, and make both `searchTask.PreExecute` and `queryTask.PreExecute` use it. Remove the now-redundant `timezone` field from `queryParams` and its extraction/validation in `parseQueryParams`.

### Why

The bug fixed by #52113 existed because this resolution logic was inlined twice (search and query) and the two copies drifted independently: the query copy sat before plan generation, the search copy sat after it, so wiring the timezone into the search plan parser (#46546) silently read the zero value. A single helper with an explicit "must be resolved before plan generation" contract removes the duplication that made that drift possible.

### Behavior notes

- Search/query with a valid, absent, or invalid timezone behave exactly as before (same error code/message for invalid IANA IDs).
- One degenerate case is unified: a search request that explicitly passes an **empty** `timezone` value previously resolved to UTC (empty string reached `time.LoadLocation("")`); it now falls back to the collection timezone, matching the existing query semantics ("empty = unspecified").
- For query, the invalid-timezone error is now raised at the resolution point in `PreExecute` instead of inside `parseQueryParams`; both are before plan generation, and the error code and message are unchanged.

### Verification

```bash
go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/proxy
```

including the #52113 regression test `TestSearchTaskPreExecuteUsesTimezoneForTimestamptzFilter` and the new `TestResolveTimezone` unit tests (request wins / invalid rejected as ParameterInvalid / absent falls back to collection / empty treated as unspecified / default UTC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
