### PR TITLE
fix: add user authentication and RBAC authorization for stream gRPC

### DIFF
--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -285,6 +285,7 @@ func (s *Server) startExternalGrpc(errChan chan error) {
 	log.Debug("Get proxy rate limiter done")
 
 	var unaryServerOption grpc.ServerOption
+	var streamServerOption grpc.ServerOption
 	if enableCustomInterceptor {
 		unaryServerOption = grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			streaming.ForwardLegacyProxyUnaryServerInterceptor(),
@@ -300,8 +301,18 @@ func (s *Server) startExternalGrpc(errChan chan error) {
 			proxy.TraceLogInterceptor,
 			connection.KeepActiveInterceptor,
 		))
+		// Streaming RPCs (e.g. CreateReplicateStream) bypass the unary chain, so they must
+		// be authenticated and authorized through a dedicated stream interceptor chain.
+		// Without this the external server would accept unauthenticated/unauthorized
+		// streaming calls on the client port. The order mirrors the unary chain: first
+		// authenticate (resolve the user into ctx), then enforce RBAC on that user.
+		streamServerOption = grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
+			proxy.GrpcAuthStreamInterceptor(proxy.AuthenticationInterceptor),
+			proxy.PrivilegeStreamInterceptor(proxy.StreamPrivilegeInterceptor),
+		))
 	} else {
 		unaryServerOption = grpc.EmptyServerOption{}
+		streamServerOption = grpc.EmptyServerOption{}
 	}
 
 	grpcOpts := []grpc.ServerOption{
@@ -310,6 +321,7 @@ func (s *Server) startExternalGrpc(errChan chan error) {
 		grpc.MaxRecvMsgSize(Params.ServerMaxRecvSize.GetAsInt()),
 		grpc.MaxSendMsgSize(Params.ServerMaxSendSize.GetAsInt()),
 		unaryServerOption,
+		streamServerOption,
 		grpc.StatsHandler(tracer.GetDynamicOtelGrpcServerStatsHandler()),
 		grpc.StatsHandler(metrics.NewGRPCSizeStatsHandler().
 			// both inbound and outbound

--- a/internal/proxy/authentication_interceptor.go
+++ b/internal/proxy/authentication_interceptor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -49,6 +50,34 @@ func GrpcAuthInterceptor(authFunc grpc_auth.AuthFunc) grpc.UnaryServerIntercepto
 			return nil, err
 		}
 		return handler(newCtx, req)
+	}
+}
+
+// GrpcAuthStreamInterceptor is the streaming counterpart of GrpcAuthInterceptor.
+// The external gRPC server only mounts UnaryInterceptor, so streaming RPCs such as
+// CreateReplicateStream would otherwise skip the authentication chain entirely. This
+// interceptor guarantees streaming calls are authenticated with the same logic as unary
+// calls before the handler observes the stream.
+func GrpcAuthStreamInterceptor(authFunc grpc_auth.AuthFunc) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		var newCtx context.Context
+		var err error
+		if overrideSrv, ok := srv.(grpc_auth.ServiceAuthFuncOverride); ok {
+			newCtx, err = overrideSrv.AuthFuncOverride(ss.Context(), info.FullMethod)
+		} else {
+			newCtx, err = authFunc(ss.Context())
+		}
+		if err != nil {
+			hookutil.GetExtension().ReportAction(context.Background(), nil, &milvuspb.BoolResponse{
+				Status: merr.Status(err),
+			}, err, info.FullMethod, hookutil.ActionAuthorize)
+			return err
+		}
+		// Propagate the authenticated context (which carries the resolved user/token) to
+		// the handler by wrapping the ServerStream.
+		wrapped := grpc_middleware.WrapServerStream(ss)
+		wrapped.WrappedContext = newCtx
+		return handler(srv, wrapped)
 	}
 }
 

--- a/internal/proxy/authentication_interceptor_test.go
+++ b/internal/proxy/authentication_interceptor_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/milvus-io/milvus/internal/proxy/privilege"
@@ -15,6 +16,17 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/crypto"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
+
+// mockServerStream is a minimal grpc.ServerStream implementation that only carries a
+// context, which is all the stream authentication interceptor needs.
+type mockServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (m *mockServerStream) Context() context.Context {
+	return m.ctx
+}
 
 // validAuth validates the authentication
 func TestValidAuth(t *testing.T) {
@@ -120,4 +132,62 @@ func TestAuthenticationInterceptor(t *testing.T) {
 		assert.Equal(t, "mockUser", user)
 	}
 	hookutil.SetTestHook(hookutil.DefaultHook{})
+}
+
+func TestGrpcAuthStreamInterceptor(t *testing.T) {
+	paramtable.Get().Save(Params.CommonCfg.AuthorizationEnabled.Key, "true") // mock authorization is turned on
+	defer paramtable.Get().Reset(Params.CommonCfg.AuthorizationEnabled.Key)
+
+	// mock metacache so AuthenticationInterceptor can verify credentials
+	mix := &MockMixCoordClientInterface{}
+	err := InitMetaCache(context.Background(), mix)
+	assert.NoError(t, err)
+
+	info := &grpc.StreamServerInfo{FullMethod: "/milvus.proto.milvus.MilvusService/CreateReplicateStream"}
+	interceptor := GrpcAuthStreamInterceptor(AuthenticationInterceptor)
+
+	t.Run("reject stream without authorization", func(t *testing.T) {
+		called := false
+		handler := func(srv interface{}, ss grpc.ServerStream) error {
+			called = true
+			return nil
+		}
+		ss := &mockServerStream{ctx: context.Background()}
+		err := interceptor(nil, ss, info, handler)
+		// authentication must fail and the handler must never be reached
+		assert.Error(t, err)
+		assert.False(t, called, "handler should not be invoked when authentication fails")
+	})
+
+	t.Run("reject stream with invalid credential", func(t *testing.T) {
+		called := false
+		handler := func(srv interface{}, ss grpc.ServerStream) error {
+			called = true
+			return nil
+		}
+		md := metadata.Pairs(util.HeaderAuthorize, crypto.Base64Encode("mockUser:wrongPass"))
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+		ss := &mockServerStream{ctx: ctx}
+		err := interceptor(nil, ss, info, handler)
+		assert.Error(t, err)
+		assert.False(t, called, "handler should not be invoked when credential is invalid")
+	})
+
+	t.Run("accept stream with valid credential and propagate context", func(t *testing.T) {
+		called := false
+		var handlerCtx context.Context
+		handler := func(srv interface{}, ss grpc.ServerStream) error {
+			called = true
+			handlerCtx = ss.Context()
+			return nil
+		}
+		md := metadata.Pairs(util.HeaderAuthorize, crypto.Base64Encode("mockUser:mockPass"))
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+		ss := &mockServerStream{ctx: ctx}
+		err := interceptor(nil, ss, info, handler)
+		assert.NoError(t, err)
+		assert.True(t, called, "handler should be invoked for an authenticated stream")
+		// the wrapped stream must expose the authenticated context to the handler
+		assert.NotNil(t, handlerCtx)
+	})
 }

--- a/internal/proxy/privilege_interceptor.go
+++ b/internal/proxy/privilege_interceptor.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"sync"
 
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -178,6 +179,119 @@ func PrivilegeInterceptor(ctx context.Context, req interface{}) (context.Context
 
 	return ctx, status.Error(codes.PermissionDenied,
 		fmt.Sprintf("%s: permission deny to %s in the `%s` database", objectPrivilege, username, dbName))
+}
+
+// streamPrivilegeExt describes the RBAC requirement of a streaming RPC. Streaming
+// interceptors have no `req` object to reflect the privilege from (unlike the unary
+// PrivilegeInterceptor which resolves it via funcutil.GetPrivilegeExtObj(req)), so the
+// required privilege is declared statically per full-method name.
+type streamPrivilegeExt struct {
+	objectType      string
+	objectPrivilege string
+}
+
+// streamMethodPrivileges is the static resource-privilege table for streaming RPCs.
+// It maps a streaming RPC's full method name to the cluster-level privilege it requires.
+// Both streaming methods on MilvusService touch the WAL data plane (CreateReplicateStream
+// writes replicate messages; DumpMessages streams messages out for data salvage), so both
+// require the cluster-admin-level replicate privilege. Any streaming method NOT present in
+// this table is denied by default (fail-closed) in StreamPrivilegeInterceptor, which
+// prevents a newly-added stream RPC from silently bypassing the RBAC chain.
+var streamMethodPrivileges = map[string]streamPrivilegeExt{
+	milvuspb.MilvusService_CreateReplicateStream_FullMethodName: {
+		objectType:      commonpb.ObjectType_Global.String(),
+		objectPrivilege: commonpb.ObjectPrivilege_PrivilegeUpdateReplicateConfiguration.String(),
+	},
+	milvuspb.MilvusService_DumpMessages_FullMethodName: {
+		objectType:      commonpb.ObjectType_Global.String(),
+		objectPrivilege: commonpb.ObjectPrivilege_PrivilegeUpdateReplicateConfiguration.String(),
+	},
+}
+
+// StreamPrivilegeFunc is the streaming counterpart of PrivilegeFunc. It authorizes a
+// streaming call using only the context (which already carries the authenticated user)
+// and the full method name (which identifies the required privilege via the static
+// streamMethodPrivileges table), returning the (possibly enriched) context on success.
+type StreamPrivilegeFunc func(ctx context.Context, fullMethod string) (context.Context, error)
+
+// PrivilegeStreamInterceptor returns a new stream server interceptor that performs
+// per-stream privilege access. It mirrors UnaryServerInterceptor: it takes the
+// authorization function as a parameter and wraps it into a grpc.StreamServerInterceptor,
+// propagating the authorized context to the handler via a wrapped ServerStream.
+func PrivilegeStreamInterceptor(privilegeFunc StreamPrivilegeFunc) grpc.StreamServerInterceptor {
+	privilege.InitPrivilegeGroups()
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		newCtx, err := privilegeFunc(ss.Context(), info.FullMethod)
+		if err != nil {
+			return err
+		}
+		wrapped := grpc_middleware.WrapServerStream(ss)
+		wrapped.WrappedContext = newCtx
+		return handler(srv, wrapped)
+	}
+}
+
+// StreamPrivilegeInterceptor is the streaming counterpart of PrivilegeInterceptor. It
+// performs the same role→casbin authorization, but resolves the required privilege from
+// the full method name (via streamMethodPrivileges) instead of the absent request object,
+// and treats the operation as cluster/Global level (objectName == util.AnyWord).
+func StreamPrivilegeInterceptor(ctx context.Context, fullMethod string) (context.Context, error) {
+	if !Params.CommonCfg.AuthorizationEnabled.GetAsBool() {
+		return ctx, nil
+	}
+	log := log.Ctx(ctx)
+
+	ext, ok := streamMethodPrivileges[fullMethod]
+	if !ok {
+		// Unregistered streaming method: deny by default so no stream RPC can slip
+		// through the authorization chain unnoticed.
+		log.Warn("stream method not registered for privilege check, denying", zap.String("method", fullMethod))
+		return ctx, status.Error(codes.PermissionDenied, fmt.Sprintf("streaming method %s is not authorized", fullMethod))
+	}
+
+	username, password, err := contextutil.GetAuthInfoFromContext(ctx)
+	if err != nil {
+		log.Warn("GetAuthInfoFromContext fail for stream", zap.Error(err))
+		return ctx, err
+	}
+	if !Params.CommonCfg.RootShouldBindRole.GetAsBool() && username == util.UserRoot {
+		return ctx, nil
+	}
+	roleNames, err := GetRole(username)
+	if err != nil {
+		log.Warn("GetRole fail for stream", zap.String("username", username), zap.Error(err))
+		return ctx, err
+	}
+	roleNames = append(roleNames, util.RolePublic)
+
+	dbName := GetCurDBNameFromContextOrDefault(ctx)
+	object := funcutil.PolicyForResource(dbName, ext.objectType, util.AnyWord)
+	log = log.With(zap.String("username", username), zap.Strings("role_names", roleNames),
+		zap.String("object_type", ext.objectType), zap.String("object_privilege", ext.objectPrivilege),
+		zap.String("db_name", dbName), zap.String("method", fullMethod))
+
+	e := privilege.GetEnforcer()
+	for _, roleName := range roleNames {
+		isPermit, cached, version := privilege.GetResultCache(roleName, object, ext.objectPrivilege)
+		if !cached {
+			isPermit, err = e.Enforce(roleName, object, ext.objectPrivilege)
+			if err != nil {
+				log.Warn("fail to execute permit func for stream", zap.Error(err))
+				return ctx, err
+			}
+			privilege.SetResultCache(roleName, object, ext.objectPrivilege, isPermit, version)
+		}
+		if isPermit {
+			return ctx, nil
+		}
+	}
+
+	log.Info("permission deny for stream", zap.Strings("roles", roleNames))
+	if password == util.PasswordHolder {
+		username = "apikey user"
+	}
+	return ctx, status.Error(codes.PermissionDenied,
+		fmt.Sprintf("%s: permission deny to %s in the `%s` database", ext.objectPrivilege, username, dbName))
 }
 
 // isCurUserObject Determine whether it is an Object of type User that operates on its own user information,

--- a/internal/proxy/privilege_interceptor_test.go
+++ b/internal/proxy/privilege_interceptor_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
@@ -621,5 +622,147 @@ func TestBuiltinPrivilegeGroup(t *testing.T) {
 
 		_, err = PrivilegeInterceptor(GetContext(context.Background(), "fooo:123456"), &milvuspb.CreateResourceGroupRequest{})
 		assert.Error(t, err)
+	})
+}
+
+// grantReplicateToRole builds a mock policy client that grants the given role the
+// cluster-level replicate privilege (PrivilegeUpdateReplicateConfiguration), which is
+// what StreamPrivilegeInterceptor requires for CreateReplicateStream.
+func grantReplicateToRole(user, role string) *MockMixCoordClientInterface {
+	client := &MockMixCoordClientInterface{}
+	client.listPolicy = func(ctx context.Context, in *internalpb.ListPolicyRequest) (*internalpb.ListPolicyResponse, error) {
+		return &internalpb.ListPolicyResponse{
+			Status: merr.Success(),
+			PolicyInfos: []string{
+				funcutil.PolicyForPrivilege(role, commonpb.ObjectType_Global.String(), "*",
+					commonpb.ObjectPrivilege_PrivilegeUpdateReplicateConfiguration.String(), "default"),
+			},
+			UserRoles: []string{
+				funcutil.EncodeUserRoleCache(user, role),
+			},
+		}, nil
+	}
+	return client
+}
+
+// TestPrivilegeStreamInterceptor verifies the high-order wrapper mirrors
+// UnaryServerInterceptor: it wraps a StreamPrivilegeFunc, blocks the handler on auth
+// failure, and propagates the authorized context to the handler on success.
+func TestPrivilegeStreamInterceptor(t *testing.T) {
+	interceptor := PrivilegeStreamInterceptor(StreamPrivilegeInterceptor)
+	assert.NotNil(t, interceptor)
+
+	info := &grpc.StreamServerInfo{FullMethod: milvuspb.MilvusService_CreateReplicateStream_FullMethodName}
+
+	t.Run("deny blocks handler", func(t *testing.T) {
+		paramtable.Get().Save(Params.CommonCfg.AuthorizationEnabled.Key, "true")
+		defer paramtable.Get().Reset(Params.CommonCfg.AuthorizationEnabled.Key)
+		InitEmptyGlobalCache()
+
+		called := false
+		handler := func(srv interface{}, ss grpc.ServerStream) error {
+			called = true
+			return nil
+		}
+		ss := &mockServerStream{ctx: GetContext(context.Background(), "foo:123456")}
+		err := interceptor(nil, ss, info, handler)
+		assert.Error(t, err)
+		assert.False(t, called, "handler must not run when authorization fails")
+	})
+
+	t.Run("permit propagates authorized context", func(t *testing.T) {
+		paramtable.Get().Save(Params.CommonCfg.AuthorizationEnabled.Key, "true")
+		defer paramtable.Get().Reset(Params.CommonCfg.AuthorizationEnabled.Key)
+		privilege.InitPrivilegeGroups()
+		InitMetaCache(context.Background(), grantReplicateToRole("alice", "role1"))
+		defer privilege.CleanPrivilegeCache()
+
+		called := false
+		var handlerCtx context.Context
+		handler := func(srv interface{}, ss grpc.ServerStream) error {
+			called = true
+			handlerCtx = ss.Context()
+			return nil
+		}
+		ss := &mockServerStream{ctx: GetContext(context.Background(), "alice:123456")}
+		err := interceptor(nil, ss, info, handler)
+		assert.NoError(t, err)
+		assert.True(t, called, "handler must run for an authorized stream")
+		assert.NotNil(t, handlerCtx, "authorized context must be propagated to the handler")
+	})
+}
+
+// TestStreamPrivilegeInterceptor exercises the authorization core: authorization
+// disabled, unregistered method (fail-closed), missing privilege, granted privilege,
+// and the root bypass.
+func TestStreamPrivilegeInterceptor(t *testing.T) {
+	createStream := milvuspb.MilvusService_CreateReplicateStream_FullMethodName
+
+	t.Run("authorization disabled passes", func(t *testing.T) {
+		paramtable.Get().Save(Params.CommonCfg.AuthorizationEnabled.Key, "false")
+		defer paramtable.Get().Reset(Params.CommonCfg.AuthorizationEnabled.Key)
+
+		_, err := StreamPrivilegeInterceptor(context.Background(), createStream)
+		assert.NoError(t, err)
+	})
+
+	t.Run("unregistered method denied (fail-closed)", func(t *testing.T) {
+		paramtable.Get().Save(Params.CommonCfg.AuthorizationEnabled.Key, "true")
+		defer paramtable.Get().Reset(Params.CommonCfg.AuthorizationEnabled.Key)
+		InitEmptyGlobalCache()
+
+		ctx := GetContext(context.Background(), "root:123456")
+		_, err := StreamPrivilegeInterceptor(ctx, "/milvus.proto.milvus.MilvusService/SomeUnknownStream")
+		assert.Error(t, err)
+	})
+
+	t.Run("missing privilege denied", func(t *testing.T) {
+		paramtable.Get().Save(Params.CommonCfg.AuthorizationEnabled.Key, "true")
+		defer paramtable.Get().Reset(Params.CommonCfg.AuthorizationEnabled.Key)
+		privilege.InitPrivilegeGroups()
+		// grant replicate to role1/alice only; bob has no such privilege
+		InitMetaCache(context.Background(), grantReplicateToRole("alice", "role1"))
+		defer privilege.CleanPrivilegeCache()
+
+		_, err := StreamPrivilegeInterceptor(GetContext(context.Background(), "bob:123456"), createStream)
+		assert.Error(t, err)
+	})
+
+	t.Run("granted privilege permitted", func(t *testing.T) {
+		paramtable.Get().Save(Params.CommonCfg.AuthorizationEnabled.Key, "true")
+		defer paramtable.Get().Reset(Params.CommonCfg.AuthorizationEnabled.Key)
+		privilege.InitPrivilegeGroups()
+		InitMetaCache(context.Background(), grantReplicateToRole("alice", "role1"))
+		defer privilege.CleanPrivilegeCache()
+
+		_, err := StreamPrivilegeInterceptor(GetContext(context.Background(), "alice:123456"), createStream)
+		assert.NoError(t, err)
+	})
+
+	t.Run("dump messages shares the replicate privilege", func(t *testing.T) {
+		paramtable.Get().Save(Params.CommonCfg.AuthorizationEnabled.Key, "true")
+		defer paramtable.Get().Reset(Params.CommonCfg.AuthorizationEnabled.Key)
+		privilege.InitPrivilegeGroups()
+		InitMetaCache(context.Background(), grantReplicateToRole("alice", "role1"))
+		defer privilege.CleanPrivilegeCache()
+
+		dumpStream := milvuspb.MilvusService_DumpMessages_FullMethodName
+		// the same replicate privilege authorizes DumpMessages ...
+		_, err := StreamPrivilegeInterceptor(GetContext(context.Background(), "alice:123456"), dumpStream)
+		assert.NoError(t, err)
+		// ... while a user without it is denied.
+		_, err = StreamPrivilegeInterceptor(GetContext(context.Background(), "bob:123456"), dumpStream)
+		assert.Error(t, err)
+	})
+
+	t.Run("root bypass", func(t *testing.T) {
+		paramtable.Get().Save(Params.CommonCfg.AuthorizationEnabled.Key, "true")
+		defer paramtable.Get().Reset(Params.CommonCfg.AuthorizationEnabled.Key)
+		paramtable.Get().Save(Params.CommonCfg.RootShouldBindRole.Key, "false")
+		defer paramtable.Get().Reset(Params.CommonCfg.RootShouldBindRole.Key)
+		InitEmptyGlobalCache()
+
+		_, err := StreamPrivilegeInterceptor(GetContext(context.Background(), "root:123456"), createStream)
+		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
## Background
Streaming RPCs (e.g. CreateReplicateStream, DumpMessages) were not going through the unary interceptor chain on the external client-facing gRPC port. Only Authentication (credential verification) was added to the stream path, RBAC authorization was missing, so authenticated users could bypass role-based access checks for stream-type resource operations.

## Changes
1. Authentication: add proxy.GrpcAuthStreamInterceptor that validates username+password (bcrypt/SHA-256) on external streaming calls:
   - reject missing Authorization metadata
   - reject bad credentials
   - accept valid credentials and propagate username/sha256_password via contextutil.SetAuthInfo. When CommonCfg.AuthorizationEnabled is false the behavior is skipped, consistent with the unary chain. Register the stream interceptor in startExternalGrpc for the external gRPC server with explicit comment explaining why stream must be wired separately (streaming RPCs bypass the unary chain).
2. RBAC authorization: add the stream counterpart of proxy.UnaryServerInterceptor(proxy.PrivilegeInterceptor), i.e. proxy.StreamServerInterceptor(proxy.PrivilegeInterceptor). For stream RPCs described in privilege.Ext (CreateReplicateStream and DumpMessages), the interceptor runs Casbin Enforce against Global-default
   + PrivilegeUpdateReplicateConfiguration so role bindings correctly allow/deny stream calls. UTs verify deny-blocks-handler path and the permit path that propagates the authorized context.