### PR TITLE
fix: [3.0] Rectify nested index factory to correctly handle hybrid indexes(#52360)

### DIFF
--- a/internal/core/src/index/BitmapIndexArrayTest.cpp
+++ b/internal/core/src/index/BitmapIndexArrayTest.cpp
@@ -807,6 +807,39 @@ TEST(BitmapIndexArrayNestedTest, FactoryCreatesNestedBitmapForStructSubField) {
     boost::filesystem::remove_all(root_path);
 }
 
+TEST(BitmapIndexArrayNestedTest, FactoryCreatesNestedHybridForStructSubField) {
+    proto::schema::FieldSchema field_schema;
+    field_schema.set_name("struct_field[sub]");
+    field_schema.set_data_type(proto::schema::DataType::Array);
+    field_schema.set_element_type(proto::schema::DataType::VarChar);
+
+    auto field_meta = storage::FieldDataMeta{1, 2, 3, 101, field_schema};
+    auto index_meta = storage::IndexMeta{3, 101, 3002, 3002};
+
+    auto root_path =
+        fmt::format("{}/hybrid_nested_array_factory", TestLocalPath);
+    boost::filesystem::remove_all(root_path);
+    storage::StorageConfig storage_config;
+    storage_config.storage_type = "local";
+    storage_config.root_path = root_path;
+    auto chunk_manager = storage::CreateChunkManager(storage_config);
+    auto fs = storage::InitArrowFileSystem(storage_config);
+    storage::FileManagerContext ctx(field_meta, index_meta, chunk_manager, fs);
+
+    index::CreateIndexInfo index_info{};
+    index_info.index_type = milvus::index::HYBRID_INDEX_TYPE;
+    index_info.field_type = DataType::ARRAY;
+    index_info.field_name = "struct_field[sub]";
+    index_info.tantivy_index_version = 7;
+
+    auto index =
+        index::IndexFactory::GetInstance().CreateIndex(index_info, ctx);
+    ASSERT_TRUE(index->IsNestedIndex());
+    ASSERT_EQ(index->Type(), milvus::index::HYBRID_INDEX_TYPE);
+
+    boost::filesystem::remove_all(root_path);
+}
+
 struct BitmapIndexArrayRegressionParam {
     proto::schema::DataType element_type;
     bool use_v3;

--- a/internal/core/src/index/HybridScalarIndex.cpp
+++ b/internal/core/src/index/HybridScalarIndex.cpp
@@ -56,6 +56,14 @@ template <typename T>
 HybridScalarIndex<T>::HybridScalarIndex(
     uint32_t tantivy_index_version,
     const storage::FileManagerContext& file_manager_context)
+    : HybridScalarIndex(tantivy_index_version, file_manager_context, false) {
+}
+
+template <typename T>
+HybridScalarIndex<T>::HybridScalarIndex(
+    uint32_t tantivy_index_version,
+    const storage::FileManagerContext& file_manager_context,
+    bool is_nested_index)
     : ScalarIndex<T>(HYBRID_INDEX_TYPE),
       is_built_(false),
       tantivy_index_version_(tantivy_index_version),
@@ -63,7 +71,8 @@ HybridScalarIndex<T>::HybridScalarIndex(
           DEFAULT_HYBRID_INDEX_BITMAP_CARDINALITY_LIMIT),
       low_cardinality_index_type_(ScalarIndexType::BITMAP),
       high_cardinality_index_type_(ScalarIndexType::STLSORT),
-      file_manager_context_(file_manager_context) {
+      file_manager_context_(file_manager_context),
+      is_nested_index_(is_nested_index) {
     if (file_manager_context.Valid()) {
         this->file_manager_ =
             std::make_shared<storage::MemFileManagerImpl>(file_manager_context);
@@ -181,14 +190,18 @@ HybridScalarIndex<T>::GetInternalIndex() {
         return internal_index_;
     }
     if (internal_index_type_ == ScalarIndexType::BITMAP) {
-        internal_index_ =
-            std::make_shared<BitmapIndex<T>>(this->file_manager_context_);
+        internal_index_ = std::make_shared<BitmapIndex<T>>(
+            this->file_manager_context_, is_nested_index_);
     } else if (internal_index_type_ == ScalarIndexType::STLSORT) {
-        internal_index_ =
-            std::make_shared<ScalarIndexSort<T>>(this->file_manager_context_);
+        internal_index_ = std::make_shared<ScalarIndexSort<T>>(
+            this->file_manager_context_, is_nested_index_);
     } else if (internal_index_type_ == ScalarIndexType::INVERTED) {
         internal_index_ = std::make_shared<InvertedIndexTantivy<T>>(
-            tantivy_index_version_, this->file_manager_context_);
+            tantivy_index_version_,
+            this->file_manager_context_,
+            false,
+            true,
+            is_nested_index_);
     } else {
         ThrowInfo(UnexpectedError,
                   "unknown index type when get internal index");
@@ -205,16 +218,20 @@ HybridScalarIndex<std::string>::GetInternalIndex() {
 
     if (internal_index_type_ == ScalarIndexType::BITMAP) {
         internal_index_ = std::make_shared<BitmapIndex<std::string>>(
-            this->file_manager_context_);
+            this->file_manager_context_, is_nested_index_);
     } else if (internal_index_type_ == ScalarIndexType::MARISA) {
         internal_index_ =
             std::make_shared<StringIndexMarisa>(this->file_manager_context_);
     } else if (internal_index_type_ == ScalarIndexType::STLSORT) {
-        internal_index_ =
-            std::make_shared<StringIndexSort>(this->file_manager_context_);
+        internal_index_ = std::make_shared<StringIndexSort>(
+            this->file_manager_context_, is_nested_index_);
     } else if (internal_index_type_ == ScalarIndexType::INVERTED) {
         internal_index_ = std::make_shared<InvertedIndexTantivy<std::string>>(
-            tantivy_index_version_, this->file_manager_context_);
+            tantivy_index_version_,
+            this->file_manager_context_,
+            false,
+            true,
+            is_nested_index_);
     } else {
         ThrowInfo(UnexpectedError,
                   "unknown index type when get internal index");

--- a/internal/core/src/index/HybridScalarIndex.h
+++ b/internal/core/src/index/HybridScalarIndex.h
@@ -51,6 +51,10 @@ class HybridScalarIndex : public ScalarIndex<T> {
         const storage::FileManagerContext& file_manager_context =
             storage::FileManagerContext());
 
+    HybridScalarIndex(uint32_t tantivy_index_version,
+                      const storage::FileManagerContext& file_manager_context,
+                      bool is_nested_index);
+
     ~HybridScalarIndex() override = default;
 
     BinarySet
@@ -70,6 +74,11 @@ class HybridScalarIndex : public ScalarIndex<T> {
     ScalarIndexType
     GetIndexType() const override {
         return ScalarIndexType::HYBRID;
+    }
+
+    bool
+    IsNestedIndex() const override {
+        return is_nested_index_;
     }
 
     void
@@ -219,6 +228,7 @@ class HybridScalarIndex : public ScalarIndex<T> {
     ScalarIndexType internal_index_type_;
     std::shared_ptr<ScalarIndex<T>> internal_index_{nullptr};
     storage::FileManagerContext file_manager_context_;
+    bool is_nested_index_{false};
 
     // `tantivy_index_version_` is used to control which kind of tantivy index should be used.
     // There could be the case where milvus version of read node is lower than the version of index builder node(and read node

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -1148,6 +1148,10 @@ IndexFactory::CreateNestedIndex(
     if (index_type == BITMAP_INDEX_TYPE) {
         return CreateNestedIndexBitmap(file_manager_context);
     }
+    if (index_type == HYBRID_INDEX_TYPE) {
+        return CreateNestedIndexHybrid(tantivy_index_version,
+                                       file_manager_context);
+    }
 
     return CreateNestedIndexScalarIndexSort(file_manager_context);
 }
@@ -1254,6 +1258,43 @@ IndexFactory::CreateNestedIndexScalarIndexSort(
         case DataType::VARCHAR:
             return std::make_unique<StringIndexSort>(file_manager_context,
                                                      true);
+        default:
+            ThrowInfo(DataTypeInvalid, "Invalid data type:{}", element_type);
+    }
+}
+
+IndexBasePtr
+IndexFactory::CreateNestedIndexHybrid(
+    int32_t tantivy_index_version,
+    const storage::FileManagerContext& file_manager_context) {
+    DataType element_type = static_cast<DataType>(
+        file_manager_context.fieldDataMeta.field_schema.element_type());
+    switch (element_type) {
+        case DataType::BOOL:
+            return std::make_unique<HybridScalarIndex<bool>>(
+                tantivy_index_version, file_manager_context, true);
+        case DataType::INT8:
+            return std::make_unique<HybridScalarIndex<int8_t>>(
+                tantivy_index_version, file_manager_context, true);
+        case DataType::INT16:
+            return std::make_unique<HybridScalarIndex<int16_t>>(
+                tantivy_index_version, file_manager_context, true);
+        case DataType::INT32:
+            return std::make_unique<HybridScalarIndex<int32_t>>(
+                tantivy_index_version, file_manager_context, true);
+        case DataType::INT64:
+            return std::make_unique<HybridScalarIndex<int64_t>>(
+                tantivy_index_version, file_manager_context, true);
+        case DataType::FLOAT:
+            return std::make_unique<HybridScalarIndex<float>>(
+                tantivy_index_version, file_manager_context, true);
+        case DataType::DOUBLE:
+            return std::make_unique<HybridScalarIndex<double>>(
+                tantivy_index_version, file_manager_context, true);
+        case DataType::STRING:
+        case DataType::VARCHAR:
+            return std::make_unique<HybridScalarIndex<std::string>>(
+                tantivy_index_version, file_manager_context, true);
         default:
             ThrowInfo(DataTypeInvalid, "Invalid data type:{}", element_type);
     }

--- a/internal/core/src/index/IndexFactory.h
+++ b/internal/core/src/index/IndexFactory.h
@@ -183,6 +183,12 @@ class IndexFactory {
             storage::FileManagerContext());
 
     IndexBasePtr
+    CreateNestedIndexHybrid(
+        int32_t tantivy_index_version,
+        const storage::FileManagerContext& file_manager_context =
+            storage::FileManagerContext());
+
+    IndexBasePtr
     CreateScalarIndex(const CreateIndexInfo& create_index_info,
                       const storage::FileManagerContext& file_manager_context =
                           storage::FileManagerContext());

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -8161,13 +8161,15 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(
 
     auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::MIDDLE);
     std::vector<std::future<void>> load_group_futures;
-    for (const auto& [cg_index, field_ids] : cg_field_ids) {
+    for (const auto& cg_field_id : cg_field_ids) {
+        const auto cg_index = cg_field_id.first;
+        const auto& field_ids_ref = cg_field_id.second;
         auto size_estimate = size_estimates.at(cg_index);
         auto future = pool.Submit([this,
                                    column_groups,
                                    properties,
                                    cg_index,
-                                   field_ids,
+                                   field_ids = field_ids_ref,
                                    size_estimate = std::move(size_estimate),
                                    &segment_load_info,
                                    schema_snapshot,


### PR DESCRIPTION
Cherry-pick from master
pr: #52360
Related to #52359

Struct sub-field scalar indexes use the nested index factory because their logical field type is an array. That factory handled bitmap and inverted indexes explicitly, but allowed hybrid indexes to fall through to the sort index path.

For varchar array sub-fields, the fallback creates StringIndexSort and loads the hybrid packed meta as a sort index. Hybrid packed meta records the internal index_type and does not contain the sort index version key, so segment loading can fail with "Meta key not found: version".

Create nested HybridScalarIndex instances for hybrid nested indexes and keep the nested flag when the hybrid wrapper creates its internal bitmap, sort, or inverted index. This lets LoadEntries read the persisted hybrid internal type before dispatching to the real nested index loader.