### PR TITLE
fix: [cp3.0] gate V3 function-output index build on segment schema version (#51768)

### DIFF
--- a/internal/datacoord/backfill_result.go
+++ b/internal/datacoord/backfill_result.go
@@ -190,10 +190,9 @@ func buildV2Groups(bucket string, entry *BackfillSegment) (map[int64]*datapb.Fie
 		}
 		out[fid] = &datapb.FieldBinlog{
 			FieldID: fid,
-			// ChildFields carries the real field IDs that index creation
-			// (getSegmentBinlogFields) and backfill-compaction detection
-			// (getMissingFunctions) rely on. Without it the new group is
-			// invisible to both paths; it also lets the operator's strip
+			// ChildFields carries the real field IDs that backfill-compaction
+			// detection (getMissingFunctions) relies on. Without it the new
+			// group is invisible to that path; it also lets the operator's strip
 			// logic reference-count the field out of the old groups.
 			// The backfill invariant guarantees len(g.FieldIDs) == 1.
 			ChildFields: []int64{fid},

--- a/internal/datacoord/index_inspector.go
+++ b/internal/datacoord/index_inspector.go
@@ -154,16 +154,12 @@ func (i *indexInspector) createIndexesForSegment(ctx context.Context, segment *S
 
 	indexes := i.meta.indexMeta.GetIndexesForCollection(segment.CollectionID, "")
 	indexIDToSegIndexes := i.meta.indexMeta.GetSegmentIndexes(segment.CollectionID, segment.ID)
-	var segmentBinlogFields map[int64]struct{}
 
 	for _, index := range indexes {
 		if _, ok := indexIDToSegIndexes[index.IndexID]; ok {
 			continue
 		}
-		if segmentBinlogFields == nil {
-			segmentBinlogFields = getSegmentBinlogFields(segment)
-		}
-		if !i.canCreateIndexForSegment(ctx, segment, index, segmentBinlogFields) {
+		if !i.canCreateIndexForSegment(ctx, segment, index) {
 			continue
 		}
 		if err := i.createIndexForSegment(ctx, segment, index.IndexID); err != nil {
@@ -175,47 +171,26 @@ func (i *indexInspector) createIndexesForSegment(ctx context.Context, segment *S
 	return nil
 }
 
-// getSegmentBinlogFields returns the set of field IDs that have binlog data in the segment.
-// StorageV2/V3 column groups report real field IDs through ChildFields; legacy entries may use FieldID directly.
-func getSegmentBinlogFields(segment *SegmentInfo) map[int64]struct{} {
-	result := make(map[int64]struct{})
-	for _, binlog := range segment.GetBinlogs() {
-		if len(binlog.GetChildFields()) == 0 {
-			if segment.GetStorageVersion() == storage.StorageV1 {
-				result[binlog.GetFieldID()] = struct{}{}
-			}
-			continue
-		}
-		for _, childFieldID := range binlog.GetChildFields() {
-			result[childFieldID] = struct{}{}
-		}
-	}
-	return result
-}
-
-func (i *indexInspector) canCreateIndexForSegment(ctx context.Context, segment *SegmentInfo, index *model.Index, segmentBinlogFields map[int64]struct{}) bool {
-	if _, hasField := segmentBinlogFields[index.FieldID]; hasField {
-		return true
-	}
-	// The segment has no binlog for the indexed field. A function-output field
-	// receives its data only through backfill, so building now is doomed; any
-	// other field may proceed. The schema is resolved through the handler
-	// (lazy-loading on cache miss, e.g. right after a datacoord restart) and the
-	// check fails closed: on an unresolvable or inconsistent view, defer to the
-	// next inspection round instead of trusting a stale schema.
+// canCreateIndexForSegment reports whether the segment is ready to build the
+// index. The schema is resolved through the handler (lazy-loading on cache miss,
+// e.g. right after a datacoord restart); the check fails closed, deferring to
+// the next inspection round on an unresolvable or inconsistent view.
+func (i *indexInspector) canCreateIndexForSegment(ctx context.Context, segment *SegmentInfo, index *model.Index) bool {
 	collection, err := i.handler.GetCollection(ctx, segment.CollectionID)
 	if err != nil || collection == nil || collection.Schema == nil {
 		mlog.Warn(ctx, "cannot resolve collection schema, defer index build",
 			mlog.FieldSegmentID(segment.ID), mlog.FieldFieldID(index.FieldID), mlog.FieldIndexID(index.IndexID), mlog.Err(err))
 		return false
 	}
-	for _, functionSchema := range collection.Schema.GetFunctions() {
-		for _, outputFieldID := range functionSchema.GetOutputFieldIds() {
-			if outputFieldID == index.FieldID {
-				mlog.Debug(ctx, "function output field has no binlog, skip create index", mlog.FieldSegmentID(segment.ID), mlog.FieldFieldID(index.FieldID), mlog.FieldIndexID(index.IndexID))
-				return false
-			}
-		}
+	// Function outputs are materialized by schema-bump reconciliation, which
+	// advances the segment schema version. A segment behind the collection schema
+	// version may lack them, so defer the whole segment until it catches up.
+	if len(collection.Schema.GetFunctions()) > 0 &&
+		segment.GetSchemaVersion() < collection.Schema.GetVersion() {
+		mlog.Debug(ctx, "segment schema behind collection, function outputs may be unmaterialized, defer index build",
+			mlog.FieldSegmentID(segment.ID), mlog.FieldFieldID(index.FieldID), mlog.FieldIndexID(index.IndexID),
+			mlog.Int32("segmentSchemaVersion", segment.GetSchemaVersion()), mlog.Int32("collectionSchemaVersion", collection.Schema.GetVersion()))
+		return false
 	}
 	if typeutil.GetFieldByID(collection.Schema, index.FieldID) == nil {
 		mlog.Warn(ctx, "indexed field not found in cached collection schema, defer index build",

--- a/internal/datacoord/index_inspector_test.go
+++ b/internal/datacoord/index_inspector_test.go
@@ -95,6 +95,12 @@ func TestIndexInspector_inspect(t *testing.T) {
 		// (reloadFromMeta, the ticker, and the notify channel) may invoke the
 		// mocks immediately, and a call racing with EXPECT registration hits
 		// a no-expectation mock and silently aborts the indexing flow.
+		handler.EXPECT().GetCollection(mock.Anything, int64(2)).Return(&collectionInfo{
+			ID: 2,
+			Schema: &schemapb.CollectionSchema{
+				Fields: []*schemapb.FieldSchema{{FieldID: 101, Name: "f101"}},
+			},
+		}, nil).Maybe()
 		alloc.EXPECT().AllocID(mock.Anything).Return(rand.Int63(), nil)
 		catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
 		catalog.EXPECT().AlterSegmentIndexes(mock.Anything, mock.Anything).Return(nil)
@@ -319,6 +325,12 @@ func TestIndexInspector_CreateIndexesForSegment_ExternalUnsorted(t *testing.T) {
 		}
 		m.segments.SetSegment(segment.GetID(), segment)
 
+		handler.EXPECT().GetCollection(mock.Anything, int64(2)).Return(&collectionInfo{
+			ID: 2,
+			Schema: &schemapb.CollectionSchema{
+				Fields: []*schemapb.FieldSchema{{Name: "id", FieldID: 101, DataType: schemapb.DataType_Int64, ExternalField: "id"}},
+			},
+		}, nil).Maybe()
 		alloc.EXPECT().AllocID(mock.Anything).Return(int64(12345), nil)
 		catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
 		scheduler.EXPECT().Enqueue(mock.Anything).Return()
@@ -391,76 +403,7 @@ func TestIndexInspector_CreateIndexForSegment_OverrideIndexType(t *testing.T) {
 	assert.Equal(t, "DISKANN", segIdx.IndexType)
 }
 
-func TestGetSegmentBinlogFields(t *testing.T) {
-	t.Run("uses ChildFields not FieldID", func(t *testing.T) {
-		segment := &SegmentInfo{
-			SegmentInfo: &datapb.SegmentInfo{
-				Binlogs: []*datapb.FieldBinlog{
-					{
-						FieldID:     0, // columnGroupID
-						ChildFields: []int64{100, 101, 102},
-					},
-					{
-						FieldID:     1, // another columnGroupID
-						ChildFields: []int64{200},
-					},
-				},
-			},
-		}
-		fields := getSegmentBinlogFields(segment)
-		assert.Contains(t, fields, int64(100))
-		assert.Contains(t, fields, int64(101))
-		assert.Contains(t, fields, int64(102))
-		assert.Contains(t, fields, int64(200))
-		// columnGroupIDs should NOT be in the result
-		assert.NotContains(t, fields, int64(0))
-		assert.NotContains(t, fields, int64(1))
-	})
-
-	t.Run("legacy FieldID fallback when ChildFields empty", func(t *testing.T) {
-		segment := &SegmentInfo{
-			SegmentInfo: &datapb.SegmentInfo{
-				StorageVersion: storage.StorageV1,
-				Binlogs: []*datapb.FieldBinlog{
-					{FieldID: 101},
-					{FieldID: 0, ChildFields: []int64{100, 102}},
-				},
-			},
-		}
-		fields := getSegmentBinlogFields(segment)
-		assert.Contains(t, fields, int64(101))
-		assert.Contains(t, fields, int64(100))
-		assert.Contains(t, fields, int64(102))
-		assert.NotContains(t, fields, int64(0))
-	})
-
-	t.Run("packed storage ignores FieldID fallback when ChildFields empty", func(t *testing.T) {
-		segment := &SegmentInfo{
-			SegmentInfo: &datapb.SegmentInfo{
-				StorageVersion: storage.StorageV3,
-				Binlogs: []*datapb.FieldBinlog{
-					{FieldID: 101},
-					{FieldID: 0, ChildFields: []int64{100, 102}},
-				},
-			},
-		}
-		fields := getSegmentBinlogFields(segment)
-		assert.NotContains(t, fields, int64(101))
-		assert.Contains(t, fields, int64(100))
-		assert.Contains(t, fields, int64(102))
-		assert.NotContains(t, fields, int64(0))
-	})
-
-	t.Run("empty binlogs", func(t *testing.T) {
-		segment := &SegmentInfo{
-			SegmentInfo: &datapb.SegmentInfo{Binlogs: nil},
-		}
-		fields := getSegmentBinlogFields(segment)
-		assert.Empty(t, fields)
-	})
-}
-
-func TestIndexInspector_FunctionOutputBinlogGate(t *testing.T) {
+func TestIndexInspector_FunctionOutputSchemaVersionGate(t *testing.T) {
 	paramtable.Init()
 	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableSortCompaction.Key, "false")
 	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableSortCompaction.Key)
@@ -505,19 +448,17 @@ func TestIndexInspector_FunctionOutputBinlogGate(t *testing.T) {
 	m.collections.Insert(collID, collInfo)
 	handler.EXPECT().GetCollection(mock.Anything, collID).Return(collInfo, nil).Maybe()
 
-	t.Run("create function output index when binlog exists", func(t *testing.T) {
+	t.Run("build function output index when collection has no schema change", func(t *testing.T) {
 		m.indexMeta.indexes[collID] = map[UniqueID]*model.Index{
 			5: {CollectionID: collID, FieldID: 102, IndexID: 5, IndexName: "bm25_idx"},
 		}
 		segment := &SegmentInfo{
 			SegmentInfo: &datapb.SegmentInfo{
-				ID:           1,
-				CollectionID: collID,
-				State:        commonpb.SegmentState_Flushed,
-				IsSorted:     true,
-				Binlogs: []*datapb.FieldBinlog{
-					{FieldID: 0, ChildFields: []int64{100, 101, 102}},
-				},
+				ID:             1,
+				CollectionID:   collID,
+				State:          commonpb.SegmentState_Flushed,
+				IsSorted:       true,
+				StorageVersion: storage.StorageV3,
 			},
 		}
 		m.segments.SetSegment(segment.GetID(), segment)
@@ -531,41 +472,17 @@ func TestIndexInspector_FunctionOutputBinlogGate(t *testing.T) {
 		assert.Contains(t, m.indexMeta.GetSegmentIndexes(collID, segment.GetID()), UniqueID(5))
 	})
 
-	t.Run("skip function output index when binlog is missing", func(t *testing.T) {
-		m.indexMeta.indexes[collID] = map[UniqueID]*model.Index{
-			6: {CollectionID: collID, FieldID: 102, IndexID: 6, IndexName: "bm25_idx_missing_binlog"},
-		}
-		segment := &SegmentInfo{
-			SegmentInfo: &datapb.SegmentInfo{
-				ID:           2,
-				CollectionID: collID,
-				State:        commonpb.SegmentState_Flushed,
-				IsSorted:     true,
-				Binlogs: []*datapb.FieldBinlog{
-					{FieldID: 0, ChildFields: []int64{100, 101}},
-				},
-			},
-		}
-		m.segments.SetSegment(segment.GetID(), segment)
-
-		err := inspector.createIndexesForSegment(ctx, segment)
-		assert.NoError(t, err)
-		assert.NotContains(t, m.indexMeta.GetSegmentIndexes(collID, segment.GetID()), UniqueID(6))
-	})
-
-	t.Run("create non function output index when binlog is missing", func(t *testing.T) {
+	t.Run("build non function output index", func(t *testing.T) {
 		m.indexMeta.indexes[collID] = map[UniqueID]*model.Index{
 			7: {CollectionID: collID, FieldID: 103, IndexID: 7, IndexName: "new_vector_idx"},
 		}
 		segment := &SegmentInfo{
 			SegmentInfo: &datapb.SegmentInfo{
-				ID:           3,
-				CollectionID: collID,
-				State:        commonpb.SegmentState_Flushed,
-				IsSorted:     true,
-				Binlogs: []*datapb.FieldBinlog{
-					{FieldID: 0, ChildFields: []int64{100, 101}},
-				},
+				ID:             3,
+				CollectionID:   collID,
+				State:          commonpb.SegmentState_Flushed,
+				IsSorted:       true,
+				StorageVersion: storage.StorageV3,
 			},
 		}
 		m.segments.SetSegment(segment.GetID(), segment)
@@ -579,32 +496,31 @@ func TestIndexInspector_FunctionOutputBinlogGate(t *testing.T) {
 		assert.Contains(t, m.indexMeta.GetSegmentIndexes(collID, segment.GetID()), UniqueID(7))
 	})
 
-	t.Run("create ready normal index while skipping missing function output", func(t *testing.T) {
+	// A segment behind the collection schema version defers every index,
+	// including non-function fields.
+	t.Run("skip whole segment when schema behind", func(t *testing.T) {
+		collInfo.Schema.Version = 5
+		defer func() { collInfo.Schema.Version = 0 }()
 		m.indexMeta.indexes[collID] = map[UniqueID]*model.Index{
 			8: {CollectionID: collID, FieldID: 101, IndexID: 8, IndexName: "text_idx"},
-			9: {CollectionID: collID, FieldID: 102, IndexID: 9, IndexName: "bm25_idx_missing_binlog"},
+			9: {CollectionID: collID, FieldID: 102, IndexID: 9, IndexName: "bm25_idx"},
 		}
 		segment := &SegmentInfo{
 			SegmentInfo: &datapb.SegmentInfo{
-				ID:           4,
-				CollectionID: collID,
-				State:        commonpb.SegmentState_Flushed,
-				IsSorted:     true,
-				Binlogs: []*datapb.FieldBinlog{
-					{FieldID: 0, ChildFields: []int64{100, 101}},
-				},
+				ID:             4,
+				CollectionID:   collID,
+				State:          commonpb.SegmentState_Flushed,
+				IsSorted:       true,
+				StorageVersion: storage.StorageV3,
+				SchemaVersion:  3,
 			},
 		}
 		m.segments.SetSegment(segment.GetID(), segment)
 
-		alloc.EXPECT().AllocID(mock.Anything).Return(int64(12348), nil).Once()
-		catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil).Once()
-		scheduler.EXPECT().Enqueue(mock.Anything).Return().Once()
-
 		err := inspector.createIndexesForSegment(ctx, segment)
 		assert.NoError(t, err)
 		segIndexes := m.indexMeta.GetSegmentIndexes(collID, segment.GetID())
-		assert.Contains(t, segIndexes, UniqueID(8))
+		assert.NotContains(t, segIndexes, UniqueID(8))
 		assert.NotContains(t, segIndexes, UniqueID(9))
 	})
 
@@ -653,5 +569,91 @@ func TestIndexInspector_FunctionOutputBinlogGate(t *testing.T) {
 		err := inspector.createIndexesForSegment(ctx, segment)
 		assert.NoError(t, err)
 		assert.NotContains(t, m.indexMeta.GetSegmentIndexes(collID, segment.GetID()), UniqueID(11))
+	})
+
+	t.Run("create V3 function output index when segment schema is caught up", func(t *testing.T) {
+		collInfo.Schema.Version = 5
+		defer func() { collInfo.Schema.Version = 0 }()
+		m.indexMeta.indexes[collID] = map[UniqueID]*model.Index{
+			12: {CollectionID: collID, FieldID: 102, IndexID: 12, IndexName: "bm25_idx_v3_caughtup"},
+		}
+		segment := &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:             7,
+				CollectionID:   collID,
+				State:          commonpb.SegmentState_Flushed,
+				IsSorted:       true,
+				StorageVersion: storage.StorageV3,
+				SchemaVersion:  5,
+				Binlogs: []*datapb.FieldBinlog{
+					{FieldID: 0, ChildFields: []int64{100, 101}},
+				},
+			},
+		}
+		m.segments.SetSegment(segment.GetID(), segment)
+
+		alloc.EXPECT().AllocID(mock.Anything).Return(int64(12349), nil).Once()
+		catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil).Once()
+		scheduler.EXPECT().Enqueue(mock.Anything).Return().Once()
+
+		err := inspector.createIndexesForSegment(ctx, segment)
+		assert.NoError(t, err)
+		assert.Contains(t, m.indexMeta.GetSegmentIndexes(collID, segment.GetID()), UniqueID(12))
+	})
+
+	t.Run("skip V3 function output index when segment schema is behind", func(t *testing.T) {
+		collInfo.Schema.Version = 5
+		defer func() { collInfo.Schema.Version = 0 }()
+		m.indexMeta.indexes[collID] = map[UniqueID]*model.Index{
+			13: {CollectionID: collID, FieldID: 102, IndexID: 13, IndexName: "bm25_idx_v3_behind"},
+		}
+		segment := &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:             8,
+				CollectionID:   collID,
+				State:          commonpb.SegmentState_Flushed,
+				IsSorted:       true,
+				StorageVersion: storage.StorageV3,
+				SchemaVersion:  3,
+				Binlogs: []*datapb.FieldBinlog{
+					{FieldID: 0, ChildFields: []int64{100, 101}},
+				},
+			},
+		}
+		m.segments.SetSegment(segment.GetID(), segment)
+
+		err := inspector.createIndexesForSegment(ctx, segment)
+		assert.NoError(t, err)
+		assert.NotContains(t, m.indexMeta.GetSegmentIndexes(collID, segment.GetID()), UniqueID(13))
+	})
+
+	t.Run("create V3 function output index when segment schema is ahead", func(t *testing.T) {
+		collInfo.Schema.Version = 5
+		defer func() { collInfo.Schema.Version = 0 }()
+		m.indexMeta.indexes[collID] = map[UniqueID]*model.Index{
+			14: {CollectionID: collID, FieldID: 102, IndexID: 14, IndexName: "bm25_idx_v3_ahead"},
+		}
+		segment := &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:             9,
+				CollectionID:   collID,
+				State:          commonpb.SegmentState_Flushed,
+				IsSorted:       true,
+				StorageVersion: storage.StorageV3,
+				SchemaVersion:  6,
+				Binlogs: []*datapb.FieldBinlog{
+					{FieldID: 0, ChildFields: []int64{100, 101}},
+				},
+			},
+		}
+		m.segments.SetSegment(segment.GetID(), segment)
+
+		alloc.EXPECT().AllocID(mock.Anything).Return(int64(12350), nil).Once()
+		catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil).Once()
+		scheduler.EXPECT().Enqueue(mock.Anything).Return().Once()
+
+		err := inspector.createIndexesForSegment(ctx, segment)
+		assert.NoError(t, err)
+		assert.Contains(t, m.indexMeta.GetSegmentIndexes(collID, segment.GetID()), UniqueID(14))
 	})
 }

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -3457,10 +3457,9 @@ func (m *meta) completeBumpSchemaVersionCompactionMutation(
 	// Clone the segment for update
 	cloned := oldSegment.Clone()
 
-	// SegmentInfo.Binlogs is the input to the index-eligibility gate:
-	// indexInspector.getSegmentBinlogFields derives the set of fields that have
-	// data from this array's ChildFields, and canCreateIndexForSegment refuses
-	// to build an index on a function-output field missing from that set.
+	// SegmentInfo.Binlogs is where a field's data becomes visible: this array's
+	// ChildFields carry the real field IDs of a StorageV2/V3 column group, and a
+	// function-output field with no data here has nothing to index.
 	// Materialization exists precisely to make such a field indexable, and
 	// compaction_task_bump_schema_version enqueues the segment for index
 	// building right after this mutation — so the column groups this run wrote

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -2181,11 +2181,11 @@ func (suite *MetaBasicSuite) TestCompleteBumpSchemaVersionCompactionMutation() {
 	})
 
 	suite.Run("materialized column group is visible to the index-eligibility gate", func() {
-		// Regression pin for the real consumer: indexInspector calls
-		// getSegmentBinlogFields on the segment and canCreateIndexForSegment
-		// refuses to build an index on a function-output field absent from that
-		// set. compaction_task_bump_schema_version enqueues the segment for
-		// index building right after this mutation, so field 102 must be there.
+		// Regression pin: compaction_task_bump_schema_version enqueues the
+		// segment for index building right after this mutation, so the
+		// materialized column group must land in SegmentInfo.Binlogs — a
+		// function-output field with no data there gets no index. StorageV2/V3
+		// column groups report their real field IDs through ChildFields.
 		currentManifest := packed.MarshalManifestPath("/data/segments/1", 10)
 		resultManifest := packed.MarshalManifestPath("/data/segments/1", 12)
 		segs := makeSegments(1, commonpb.SegmentState_Flushed)
@@ -2220,9 +2220,14 @@ func (suite *MetaBasicSuite) TestCompleteBumpSchemaVersionCompactionMutation() {
 		_, _, err := m.completeBumpSchemaVersionCompactionMutation(task, result)
 		suite.NoError(err)
 
-		fields := getSegmentBinlogFields(m.segments.GetSegment(1))
-		suite.Contains(fields, int64(102), "materialized function-output field must be index-eligible")
-		suite.Contains(fields, int64(100), "pre-existing fields must stay index-eligible")
+		fields := make(map[int64]struct{})
+		for _, binlog := range m.segments.GetSegment(1).GetBinlogs() {
+			for _, childFieldID := range binlog.GetChildFields() {
+				fields[childFieldID] = struct{}{}
+			}
+		}
+		suite.Contains(fields, int64(102), "materialized function-output field must have data")
+		suite.Contains(fields, int64(100), "pre-existing fields must keep their data")
 	})
 
 	suite.Run("in-place result with stale base manifest is rejected", func() {

--- a/internal/datanode/compactor/bump_schema_version_compactor.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor.go
@@ -859,9 +859,9 @@ func (t *bumpSchemaVersionCompactionTask) addV3Stats(prefix string, fieldID int6
 // SegmentInfo, and for a StorageV3 segment recovered after a DataCoord restart
 // they are empty (#50410 stopped persisting per-field binlog KVs for V3).
 // The receiver (completeBumpSchemaVersionCompactionMutation in
-// internal/datacoord/meta.go) merges this array onto SegmentInfo.Binlogs; it
-// is the sole input to getSegmentBinlogFields, which canCreateIndexForSegment
-// uses to decide whether a function-output field is eligible for an index.
+// internal/datacoord/meta.go) merges this array onto SegmentInfo.Binlogs,
+// which is where the materialized field's data becomes visible to the rest of
+// DataCoord — including index building.
 // This result is therefore load-bearing: dropping it silently makes the
 // materialized field permanently un-indexable.
 func (t *bumpSchemaVersionCompactionTask) buildNewInsertLogsV3(writerResult *bumpSchemaVersionWriterResult, sparseFieldMemorySizes map[int64]int, totalRows int64) ([]*datapb.FieldBinlog, error) {


### PR DESCRIPTION
Cherry-pick from master
pr: #51768
issue: #51727

Gate V3 function-output index build on segment schema
version rather than field binlog presence. Recovered V3
segments have empty Binlogs after #50410, so the previous
gate rejected materialized function-output fields
permanently.

Also cherry-picks #52272 to fix a compilation break:
#52391 (already merged into 3.0) added a call to
getSegmentBinlogFields which this PR deletes. #52272
inlines the helper and updates stale comments.