### PR TITLE
fix: [cp3.0] report a stats increment from schema bump materialization (#52006)

### DIFF
--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -1518,6 +1518,54 @@ func UpdateBinlogsFromSaveBinlogPathsOperator(segmentID int64, binlogs, statslog
 	}
 }
 
+// mergeSegmentColumnGroups upserts incoming column groups into an existing
+// FieldBinlog array: a group whose top-level FieldID already exists is replaced,
+// a new one is appended, and every child field claimed by an incoming group is
+// stripped from whichever other group used to hold it, so that each field lives
+// in exactly one column group. A pre-existing group left with no child fields is
+// dropped and its FieldID returned in droppedFieldIDs, so the caller can have the
+// catalog delete the orphan etcd KV -- otherwise listBinlogs' prefix scan will
+// resurrect the zombie on restart.
+//
+// The result is sorted by FieldID, which makes the merge idempotent down to the
+// serialized bytes: re-applying the same groups yields an identical array, never
+// a reordered or duplicated one.
+//
+// Elements of existing are mutated in place (ChildFields filtering) and the
+// incoming group pointers are stored as-is, so callers must pass an array they
+// own.
+func mergeSegmentColumnGroups(existing []*datapb.FieldBinlog, groups map[int64]*datapb.FieldBinlog) ([]*datapb.FieldBinlog, []int64) {
+	incomingChildFields := typeutil.NewSet[int64]()
+	for _, g := range groups {
+		incomingChildFields.Insert(g.GetChildFields()...)
+	}
+
+	var droppedFieldIDs []int64
+	merged := make([]*datapb.FieldBinlog, 0, len(existing)+len(groups))
+	for _, fb := range existing {
+		if _, replaced := groups[fb.GetFieldID()]; replaced {
+			continue
+		}
+		if len(fb.GetChildFields()) > 0 {
+			fb.ChildFields = lo.Filter(fb.GetChildFields(), func(fid int64, _ int) bool {
+				return !incomingChildFields.Contain(fid)
+			})
+			if len(fb.ChildFields) == 0 {
+				droppedFieldIDs = append(droppedFieldIDs, fb.GetFieldID())
+				continue
+			}
+		}
+		merged = append(merged, fb)
+	}
+	for _, g := range groups {
+		merged = append(merged, g)
+	}
+	sort.Slice(merged, func(i, j int) bool {
+		return merged[i].GetFieldID() < merged[j].GetFieldID()
+	})
+	return merged, droppedFieldIDs
+}
+
 // UpdateSegmentColumnGroupsOperator upserts storage-v2 column groups on a
 // segment's FieldBinlogs and removes the listed child fields from any other
 // pre-existing group whose child_fields contained them, so that every field
@@ -1536,38 +1584,8 @@ func UpdateSegmentColumnGroupsOperator(segmentID int64, groups map[int64]*datapb
 			return false
 		}
 
-		incomingChildFields := typeutil.NewSet[int64]()
-		for _, g := range groups {
-			incomingChildFields.Insert(g.GetChildFields()...)
-		}
-
-		// Strip incoming child fields from any other existing group, then drop
-		// in-place groups that the request is replacing. Also drop groups that
-		// become empty (all ChildFields claimed by incoming groups) and record
-		// their FieldIDs so the catalog removes the orphan etcd KV -- otherwise
-		// listBinlogs' prefix scan will resurrect the zombie on restart.
-		var droppedFieldIDs []int64
-		kept := segment.Binlogs[:0]
-		for _, existing := range segment.Binlogs {
-			if _, replaced := groups[existing.GetFieldID()]; replaced {
-				continue
-			}
-			if len(existing.GetChildFields()) > 0 {
-				existing.ChildFields = lo.Filter(existing.GetChildFields(), func(fid int64, _ int) bool {
-					return !incomingChildFields.Contain(fid)
-				})
-				if len(existing.ChildFields) == 0 {
-					droppedFieldIDs = append(droppedFieldIDs, existing.GetFieldID())
-					continue
-				}
-			}
-			kept = append(kept, existing)
-		}
-		segment.Binlogs = kept
-
-		for _, g := range groups {
-			segment.Binlogs = append(segment.Binlogs, g)
-		}
+		merged, droppedFieldIDs := mergeSegmentColumnGroups(segment.Binlogs, groups)
+		segment.Binlogs = merged
 
 		// Bump DataVersion so querynodes with the segment already loaded will Reopen;
 		// ManifestPath is intentionally not moved here (see segment_checker.isSegmentUpdate).
@@ -3438,7 +3456,28 @@ func (m *meta) completeBumpSchemaVersionCompactionMutation(
 	// Clone the segment for update
 	cloned := oldSegment.Clone()
 
-	cloned.Binlogs = resultSegment.GetInsertLogs()
+	// SegmentInfo.Binlogs is the input to the index-eligibility gate:
+	// indexInspector.getSegmentBinlogFields derives the set of fields that have
+	// data from this array's ChildFields, and canCreateIndexForSegment refuses
+	// to build an index on a function-output field missing from that set.
+	// Materialization exists precisely to make such a field indexable, and
+	// compaction_task_bump_schema_version enqueues the segment for index
+	// building right after this mutation — so the column groups this run wrote
+	// must land here, or the index on the materialized field is never built.
+	//
+	// This is an upsert, not an assignment: the compactor ships only the groups
+	// it just wrote, so overwriting would drop the segment's other groups. Same
+	// semantics as the backfill path's UpdateSegmentColumnGroupsOperator, shared
+	// through mergeSegmentColumnGroups. The merge is idempotent (groups are
+	// upserted by FieldID and the result is FieldID-sorted), so unlike the
+	// additive Stats increment below it needs no manifest gate: re-applying a
+	// replayed result cannot double-count.
+	var droppedBinlogFieldIDs []int64
+	if newGroups := resultSegment.GetInsertLogs(); len(newGroups) > 0 {
+		cloned.Binlogs, droppedBinlogFieldIDs = mergeSegmentColumnGroups(cloned.GetBinlogs(),
+			lo.KeyBy(newGroups, func(fb *datapb.FieldBinlog) int64 { return fb.GetFieldID() }))
+	}
+
 	if newSchemaVersion > cloned.GetSchemaVersion() {
 		cloned.SchemaVersion = newSchemaVersion
 		mlog.Info(m.ctx, "meta update: update schema version for schema bump compaction",
@@ -3449,23 +3488,41 @@ func (m *meta) completeBumpSchemaVersionCompactionMutation(
 
 	cloned.StorageVersion = resultSegment.GetStorageVersion()
 	cloned.ManifestPath = resultManifest
-	// Statistics is computed at the compactor and shipped on the
-	// CompactionSegment. Materialization grows Binlogs and ships a freshly
-	// computed Stats, which must be adopted. The schema-bump-only path rewrites
-	// no data and deliberately ships Stats=nil to preserve oldSegment.Stats —
-	// overwriting with nil would zero the durable summary (V3 skips per-field
-	// KVs, so it cannot be rebuilt from arrays after a restart). Only adopt a
-	// non-nil result Stats.
-	if s := resultSegment.GetStats(); s != nil {
-		cloned.Stats = s
+	// Statistics semantics depend on the adoption path: this branch updates an
+	// existing SegmentInfo, so a non-nil result Stats is an INCREMENT to add
+	// onto the segment's current value. See CompactionSegment.stats.
+	//
+	// The gate is the exactly-once token. resultManifest != currentManifest is
+	// the forward-commit branch of the CAS above; result == current is a replay
+	// of an adoption that already persisted, and its increment is already in
+	// Stats. Loosening the CAS silently double-counts.
+	//
+	// runSchemaVersionBumpOnly ships nil, which preserves oldSegment.Stats.
+	if resultManifest != currentManifest {
+		if delta := resultSegment.GetStats(); delta != nil {
+			cloned.Stats = addStatsDelta(m.ctx, segmentID, cloned.GetStats(), delta)
+			mlog.Info(m.ctx, "meta update: applied schema bump stats increment",
+				mlog.Int64("segmentID", segmentID),
+				mlog.String("baseManifest", baseManifest),
+				mlog.String("resultManifest", resultManifest),
+				mlog.Int64("deltaInsertBinlogSize", delta.GetInsertBinlogSize()),
+				mlog.Int64("deltaInsertBinlogCount", delta.GetInsertBinlogCount()),
+				mlog.Int64("deltaStatsBinlogSize", delta.GetStatsBinlogSize()),
+				mlog.Int64("insertBinlogSize", cloned.GetStats().GetInsertBinlogSize()),
+				mlog.Int64("insertBinlogCount", cloned.GetStats().GetInsertBinlogCount()),
+				mlog.Int64("statsBinlogSize", cloned.GetStats().GetStatsBinlogSize()))
+		}
 	}
 	if !proto.Equal(oldSegment.SegmentInfo, cloned.SegmentInfo) {
 		cloned.DataVersion = oldSegment.GetDataVersion() + 1
 	}
 
-	// Prepare binlogs increment for catalog update
+	// Prepare binlogs increment for catalog update. droppedBinlogFieldIDs is
+	// empty unless the merge above emptied a pre-existing group; when it is not,
+	// the catalog must delete that group's KV or listBinlogs resurrects it.
 	binlogsIncrement := metastore.BinlogsIncrement{
-		Segment: cloned.SegmentInfo,
+		Segment:               cloned.SegmentInfo,
+		DroppedBinlogFieldIDs: droppedBinlogFieldIDs,
 	}
 
 	mlog.Info(m.ctx, "meta update: prepare for complete schema bump compaction mutation - complete",

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"math"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 	"time"

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -2013,16 +2013,23 @@ func (suite *MetaBasicSuite) TestCompleteBumpSchemaVersionCompactionMutation() {
 		suite.EqualValues(3, infos[0].GetStats().GetDeleteNumRows())
 	})
 
-	suite.Run("materialization non-nil result stats overwrites old stats", func() {
-		// runMissingFunctionMaterialization grows Binlogs and ships a freshly
-		// computed Stats; the receiver must adopt it, not keep the pre-bump value.
+	suite.Run("in-place result stats is added onto existing stats", func() {
 		currentManifest := packed.MarshalManifestPath("/data/segments/1", 10)
 		resultManifest := packed.MarshalManifestPath("/data/segments/1", 12)
 		segs := makeSegments(1, commonpb.SegmentState_Flushed)
 		old := segs.GetSegment(1)
 		old.StorageVersion = storage.StorageV3
 		old.ManifestPath = currentManifest
-		old.Stats = &datapb.Statistics{InsertBinlogSize: 1234, InsertBinlogCount: 7}
+		old.Stats = &datapb.Statistics{
+			InsertBinlogSize:  1000,
+			InsertBinlogCount: 4,
+			StatsBinlogSize:   20,
+			DeleteNumRows:     3,
+			DeltaBinlogSize:   77,
+			TimestampFrom:     10,
+			TimestampTo:       50,
+			NullCounts:        map[int64]int64{100: 0},
+		}
 		m := &meta{
 			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
 			segments: segs,
@@ -2041,16 +2048,181 @@ func (suite *MetaBasicSuite) TestCompleteBumpSchemaVersionCompactionMutation() {
 					Manifest:       resultManifest,
 					BaseManifest:   currentManifest,
 					StorageVersion: storage.StorageV3,
-					Stats:          &datapb.Statistics{InsertBinlogSize: 9999, InsertBinlogCount: 9},
+					Stats: &datapb.Statistics{
+						InsertBinlogSize:  300,
+						InsertBinlogCount: 1,
+						StatsBinlogSize:   5,
+						NullCounts:        map[int64]int64{102: 0},
+					},
 				},
 			},
 		}
 		infos, _, err := m.completeBumpSchemaVersionCompactionMutation(task, result)
 		suite.NoError(err)
 		suite.Require().Len(infos, 1)
-		suite.Require().NotNil(infos[0].GetStats())
-		suite.EqualValues(9999, infos[0].GetStats().GetInsertBinlogSize())
-		suite.EqualValues(9, infos[0].GetStats().GetInsertBinlogCount())
+
+		got := infos[0].GetStats()
+		suite.EqualValues(1300, got.GetInsertBinlogSize())
+		suite.EqualValues(5, got.GetInsertBinlogCount())
+		suite.EqualValues(25, got.GetStatsBinlogSize())
+		// Untouched by the increment.
+		suite.EqualValues(3, got.GetDeleteNumRows())
+		suite.EqualValues(77, got.GetDeltaBinlogSize())
+		suite.EqualValues(10, got.GetTimestampFrom())
+		suite.EqualValues(50, got.GetTimestampTo())
+		suite.Equal(map[int64]int64{100: 0, 102: 0}, got.GetNullCounts())
+	})
+
+	suite.Run("replayed in-place result does not accumulate twice", func() {
+		// result == current means a prior adoption already persisted this
+		// manifest, so the increment is already in Stats. Accumulating again
+		// would double-count. This test guards the coupling between the
+		// accumulation and the forward-commit branch of the manifest CAS.
+		manifest := packed.MarshalManifestPath("/data/segments/1", 12)
+		segs := makeSegments(1, commonpb.SegmentState_Flushed)
+		old := segs.GetSegment(1)
+		old.StorageVersion = storage.StorageV3
+		old.ManifestPath = manifest
+		old.Stats = &datapb.Statistics{InsertBinlogSize: 1300, InsertBinlogCount: 5}
+		m := &meta{
+			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: segs,
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []int64{1},
+			Type:          datapb.CompactionType_BumpSchemaVersionCompaction,
+			Schema:        &schemapb.CollectionSchema{Version: 3},
+		}
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{
+				{
+					SegmentID:      1,
+					NumOfRows:      5,
+					Manifest:       manifest, // == current pointer: replay
+					BaseManifest:   packed.MarshalManifestPath("/data/segments/1", 10),
+					StorageVersion: storage.StorageV3,
+					Stats: &datapb.Statistics{
+						InsertBinlogSize:  300,
+						InsertBinlogCount: 1,
+					},
+				},
+			},
+		}
+		infos, _, err := m.completeBumpSchemaVersionCompactionMutation(task, result)
+		suite.NoError(err)
+		suite.Require().Len(infos, 1)
+
+		got := infos[0].GetStats()
+		suite.EqualValues(1300, got.GetInsertBinlogSize())
+		suite.EqualValues(5, got.GetInsertBinlogCount())
+	})
+
+	suite.Run("in-place result merges column groups into Binlogs", func() {
+		// The compactor ships only the groups this run wrote, so the receiver
+		// must upsert them: assigning the array would drop the segment's other
+		// column groups. Replaying the same result must not duplicate them.
+		currentManifest := packed.MarshalManifestPath("/data/segments/1", 10)
+		resultManifest := packed.MarshalManifestPath("/data/segments/1", 12)
+		segs := makeSegments(1, commonpb.SegmentState_Flushed)
+		old := segs.GetSegment(1)
+		old.StorageVersion = storage.StorageV3
+		old.ManifestPath = currentManifest
+		old.Binlogs = []*datapb.FieldBinlog{
+			{FieldID: 0, ChildFields: []int64{0, 1, 100}, Binlogs: []*datapb.Binlog{{LogID: 10000}}},
+		}
+		m := &meta{
+			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: segs,
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []int64{1},
+			Type:          datapb.CompactionType_BumpSchemaVersionCompaction,
+			Schema:        &schemapb.CollectionSchema{Version: 3},
+		}
+		newGroup := &datapb.FieldBinlog{
+			FieldID:     102,
+			ChildFields: []int64{102},
+			Binlogs:     []*datapb.Binlog{{LogID: 10002, EntriesNum: 5, MemorySize: 512}},
+		}
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{
+				{
+					SegmentID:      1,
+					NumOfRows:      5,
+					InsertLogs:     []*datapb.FieldBinlog{newGroup},
+					Manifest:       resultManifest,
+					BaseManifest:   currentManifest,
+					StorageVersion: storage.StorageV3,
+					Stats:          &datapb.Statistics{InsertBinlogSize: 1},
+				},
+			},
+		}
+		infos, _, err := m.completeBumpSchemaVersionCompactionMutation(task, result)
+		suite.NoError(err)
+		suite.Require().Len(infos, 1)
+		// Pre-existing group survives, the materialized group is present.
+		suite.ElementsMatch([]int64{0, 102},
+			lo.Map(infos[0].GetBinlogs(), func(fb *datapb.FieldBinlog, _ int) int64 { return fb.GetFieldID() }))
+		for _, fb := range infos[0].GetBinlogs() {
+			if fb.GetFieldID() == 0 {
+				suite.ElementsMatch([]int64{0, 1, 100}, fb.GetChildFields(),
+					"no child collision, so the pre-existing group keeps its fields")
+			}
+		}
+
+		// Replay: the segment now sits at resultManifest, so this is the
+		// idempotent-adoption branch. The merge must not duplicate the group.
+		replayed, _, err := m.completeBumpSchemaVersionCompactionMutation(task, result)
+		suite.NoError(err)
+		suite.Require().Len(replayed, 1)
+		suite.Require().Len(replayed[0].GetBinlogs(), 2)
+		suite.ElementsMatch([]int64{0, 102},
+			lo.Map(replayed[0].GetBinlogs(), func(fb *datapb.FieldBinlog, _ int) int64 { return fb.GetFieldID() }))
+	})
+
+	suite.Run("materialized column group is visible to the index-eligibility gate", func() {
+		// Regression pin for the real consumer: indexInspector calls
+		// getSegmentBinlogFields on the segment and canCreateIndexForSegment
+		// refuses to build an index on a function-output field absent from that
+		// set. compaction_task_bump_schema_version enqueues the segment for
+		// index building right after this mutation, so field 102 must be there.
+		currentManifest := packed.MarshalManifestPath("/data/segments/1", 10)
+		resultManifest := packed.MarshalManifestPath("/data/segments/1", 12)
+		segs := makeSegments(1, commonpb.SegmentState_Flushed)
+		old := segs.GetSegment(1)
+		old.StorageVersion = storage.StorageV3
+		old.ManifestPath = currentManifest
+		old.Binlogs = []*datapb.FieldBinlog{
+			{FieldID: 0, ChildFields: []int64{0, 1, 100}, Binlogs: []*datapb.Binlog{{LogID: 10000}}},
+		}
+		m := &meta{
+			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: segs,
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []int64{1},
+			Type:          datapb.CompactionType_BumpSchemaVersionCompaction,
+			Schema:        &schemapb.CollectionSchema{Version: 3},
+		}
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{
+				{
+					SegmentID:      1,
+					NumOfRows:      5,
+					InsertLogs:     []*datapb.FieldBinlog{{FieldID: 102, ChildFields: []int64{102}, Binlogs: []*datapb.Binlog{{LogID: 10002}}}},
+					Manifest:       resultManifest,
+					BaseManifest:   currentManifest,
+					StorageVersion: storage.StorageV3,
+					Stats:          &datapb.Statistics{InsertBinlogSize: 1},
+				},
+			},
+		}
+		_, _, err := m.completeBumpSchemaVersionCompactionMutation(task, result)
+		suite.NoError(err)
+
+		fields := getSegmentBinlogFields(m.segments.GetSegment(1))
+		suite.Contains(fields, int64(102), "materialized function-output field must be index-eligible")
+		suite.Contains(fields, int64(100), "pre-existing fields must stay index-eligible")
 	})
 
 	suite.Run("in-place result with stale base manifest is rejected", func() {
@@ -2667,7 +2839,7 @@ func (suite *MetaBasicSuite) TestCompleteBumpSchemaVersionCompactionMutation() {
 		suite.EqualValues(3, infos[0].GetSchemaVersion())
 	})
 
-	suite.Run("v3 in-place applies shipped stats", func() {
+	suite.Run("v3 in-place adds shipped stats increment", func() {
 		currentManifest := packed.MarshalManifestPath("/data/segments/1", 10)
 		newerManifest := packed.MarshalManifestPath("/data/segments/1", 11)
 		segs := makeSegments(1, commonpb.SegmentState_Flushed)
@@ -2675,7 +2847,7 @@ func (suite *MetaBasicSuite) TestCompleteBumpSchemaVersionCompactionMutation() {
 		segment.SchemaVersion = 1
 		segment.StorageVersion = storage.StorageV3
 		segment.ManifestPath = currentManifest
-		// Pre-bump Stats under-counts once materialization grows Binlogs.
+		// Footprint of the segment before materialization appended columns.
 		segment.Stats = &datapb.Statistics{InsertBinlogSize: 100, InsertBinlogCount: 1}
 		m := &meta{
 			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
@@ -2686,8 +2858,9 @@ func (suite *MetaBasicSuite) TestCompleteBumpSchemaVersionCompactionMutation() {
 			Type:          datapb.CompactionType_BumpSchemaVersionCompaction,
 			Schema:        &schemapb.CollectionSchema{Version: 3},
 		}
-		// Materialization adds a function-output column: Binlogs and the
-		// shipped Stats both grow; the receiver must copy the shipped Stats.
+		// Materialization adds a function-output column and ships the
+		// footprint of just that column; the receiver adds it onto the
+		// segment's current Stats.
 		shippedStats := &datapb.Statistics{InsertBinlogSize: 250, InsertBinlogCount: 2}
 		result := &datapb.CompactionPlanResult{
 			Segments: []*datapb.CompactionSegment{
@@ -2706,8 +2879,9 @@ func (suite *MetaBasicSuite) TestCompleteBumpSchemaVersionCompactionMutation() {
 		suite.NoError(err)
 		suite.NotNil(mutation)
 		suite.Require().Len(infos, 1)
-		suite.EqualValues(250, infos[0].GetStats().GetInsertBinlogSize())
-		suite.EqualValues(250, m.segments.GetSegment(1).getSegmentSize())
+		suite.EqualValues(350, infos[0].GetStats().GetInsertBinlogSize())
+		suite.EqualValues(3, infos[0].GetStats().GetInsertBinlogCount())
+		suite.EqualValues(350, m.segments.GetSegment(1).getSegmentSize())
 	})
 
 	suite.Run("v3 same manifest and same task schema accepted", func() {
@@ -3054,6 +3228,75 @@ func (suite *MetaBasicSuite) TestCompleteBumpSchemaVersionCompactionMutation() {
 		suite.Nil(infos)
 		suite.Nil(mutation)
 		suite.Equal(currentManifest, m.segments.GetSegment(1).GetManifestPath())
+	})
+
+	suite.Run("post-restart segment accumulates successive increments", func() {
+		// The recovered StorageV3 shape: per-field binlog KVs were skipped, so
+		// Binlogs/Deltalogs come back empty, and Stats is the only durable
+		// record of the segment's footprint. Two successive materializations
+		// must both land on top of it.
+		segs := NewSegmentsInfo()
+		segs.SetSegment(1, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+			ID:             1,
+			CollectionID:   100,
+			PartitionID:    10,
+			State:          commonpb.SegmentState_Flushed,
+			Level:          datapb.SegmentLevel_L1,
+			NumOfRows:      5,
+			SchemaVersion:  1,
+			StorageVersion: storage.StorageV3,
+			ManifestPath:   packed.MarshalManifestPath("/data/segments/1", 10),
+			Binlogs:        nil, // recovered V3: arrays are gone
+			Deltalogs:      nil,
+			Stats: &datapb.Statistics{
+				InsertBinlogSize:  10_000,
+				InsertBinlogCount: 8,
+				StatsBinlogSize:   100,
+				DeleteNumRows:     42,
+				NullCounts:        map[int64]int64{100: 0},
+			},
+		}})
+		m := &meta{
+			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: segs,
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []int64{1},
+			Type:          datapb.CompactionType_BumpSchemaVersionCompaction,
+			Schema:        &schemapb.CollectionSchema{Version: 3},
+		}
+
+		apply := func(baseVer, resultVer int64, fieldID int64, size int64) {
+			result := &datapb.CompactionPlanResult{
+				Segments: []*datapb.CompactionSegment{
+					{
+						SegmentID:      1,
+						NumOfRows:      5,
+						Manifest:       packed.MarshalManifestPath("/data/segments/1", resultVer),
+						BaseManifest:   packed.MarshalManifestPath("/data/segments/1", baseVer),
+						StorageVersion: storage.StorageV3,
+						Stats: &datapb.Statistics{
+							InsertBinlogSize:  size,
+							InsertBinlogCount: 1,
+							StatsBinlogSize:   10,
+							NullCounts:        map[int64]int64{fieldID: 0},
+						},
+					},
+				},
+			}
+			_, _, err := m.completeBumpSchemaVersionCompactionMutation(task, result)
+			suite.NoError(err)
+		}
+
+		apply(10, 11, 102, 2_000)
+		apply(11, 12, 103, 3_000)
+
+		got := m.segments.GetSegment(1).GetStats()
+		suite.EqualValues(15_000, got.GetInsertBinlogSize())
+		suite.EqualValues(10, got.GetInsertBinlogCount())
+		suite.EqualValues(120, got.GetStatsBinlogSize())
+		suite.EqualValues(42, got.GetDeleteNumRows())
+		suite.Equal(map[int64]int64{100: 0, 102: 0, 103: 0}, got.GetNullCounts())
 	})
 }
 

--- a/internal/datacoord/stats_delta.go
+++ b/internal/datacoord/stats_delta.go
@@ -1,0 +1,104 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"context"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+)
+
+// addStatsDelta folds an increment into a segment's existing Statistics and
+// returns a fresh object; neither input is mutated, and the result never
+// aliases base or delta — including when delta is nil, in which case an
+// independent copy of base is returned rather than base itself — so a
+// caller mutating the result cannot corrupt the segment's previous state.
+//
+// Only the additive fields participate: insert_binlog_size,
+// insert_binlog_count, stats_binlog_size, and a union over null_counts.
+// Everything else — delta_*, timestamp_from/to, delta_timestamp_from/to,
+// timestamp_quantiles — is carried over from base untouched, so a malformed
+// increment cannot overwrite aggregates it has no business changing.
+//
+// Producers of an increment are in-place compaction outputs, which only ever
+// add columns, so every field is expected to be non-negative. Each result is
+// clamped at zero anyway: nothing emits a negative increment today, and the
+// clamp keeps a future producer that does from silently corrupting Stats.
+func addStatsDelta(ctx context.Context, segmentID int64, base, delta *datapb.Statistics) *datapb.Statistics {
+	if delta == nil {
+		// Still hand back an independent copy: the caller may freely mutate
+		// the result, and that must never reach back into the segment's
+		// current Statistics.
+		return copyStatistics(base)
+	}
+
+	out := copyStatistics(base)
+	if out == nil {
+		mlog.Warn(ctx, "applying stats delta onto a segment with no existing Statistics",
+			mlog.FieldSegmentID(segmentID))
+		out = &datapb.Statistics{}
+	}
+
+	out.InsertBinlogSize = clampStatsField(ctx, segmentID, "insert_binlog_size",
+		out.InsertBinlogSize+delta.GetInsertBinlogSize())
+	out.InsertBinlogCount = clampStatsField(ctx, segmentID, "insert_binlog_count",
+		out.InsertBinlogCount+delta.GetInsertBinlogCount())
+	out.StatsBinlogSize = clampStatsField(ctx, segmentID, "stats_binlog_size",
+		out.StatsBinlogSize+delta.GetStatsBinlogSize())
+
+	if nc := delta.GetNullCounts(); len(nc) > 0 {
+		if out.NullCounts == nil {
+			out.NullCounts = make(map[int64]int64, len(nc))
+		}
+		for f, n := range nc {
+			out.NullCounts[f] = clampStatsField(ctx, segmentID, "null_counts", out.NullCounts[f]+n)
+		}
+	}
+
+	return out
+}
+
+// copyStatistics returns an independent copy of base — nil in, nil out —
+// so neither the nil-delta pass-through nor the additive path in
+// addStatsDelta ever hands the caller a pointer that aliases base.
+//
+// Uses proto.Clone rather than a field-by-field copy: the result is
+// persisted, so a hand-rolled copy would silently drop any field added to
+// the Statistics message in the future (no compile error, no test failure)
+// and would drop unknown fields when talking to a mixed-version fleet.
+// proto.Clone deep-copies every field, known and unknown, so it stays
+// correct as the message evolves.
+func copyStatistics(base *datapb.Statistics) *datapb.Statistics {
+	if base == nil {
+		return nil
+	}
+	return proto.Clone(base).(*datapb.Statistics)
+}
+
+func clampStatsField(ctx context.Context, segmentID int64, field string, v int64) int64 {
+	if v < 0 {
+		mlog.Warn(ctx, "stats delta drove aggregate below zero, clamping",
+			mlog.FieldSegmentID(segmentID),
+			mlog.String("field", field),
+			mlog.Int64("value", v))
+		return 0
+	}
+	return v
+}

--- a/internal/datacoord/stats_delta_test.go
+++ b/internal/datacoord/stats_delta_test.go
@@ -1,0 +1,171 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+)
+
+func TestAddStatsDelta(t *testing.T) {
+	cases := []struct {
+		name   string
+		base   *datapb.Statistics
+		delta  *datapb.Statistics
+		expect *datapb.Statistics
+	}{
+		{
+			name:   "nil delta returns base unchanged",
+			base:   &datapb.Statistics{InsertBinlogSize: 100, InsertBinlogCount: 2},
+			delta:  nil,
+			expect: &datapb.Statistics{InsertBinlogSize: 100, InsertBinlogCount: 2},
+		},
+		{
+			name:   "nil base adopts delta values",
+			base:   nil,
+			delta:  &datapb.Statistics{InsertBinlogSize: 50, InsertBinlogCount: 1, StatsBinlogSize: 7},
+			expect: &datapb.Statistics{InsertBinlogSize: 50, InsertBinlogCount: 1, StatsBinlogSize: 7},
+		},
+		{
+			name: "additive scalars accumulate",
+			base: &datapb.Statistics{
+				InsertBinlogSize: 1000, InsertBinlogCount: 4, StatsBinlogSize: 20,
+			},
+			delta: &datapb.Statistics{
+				InsertBinlogSize: 300, InsertBinlogCount: 2, StatsBinlogSize: 5,
+			},
+			expect: &datapb.Statistics{
+				InsertBinlogSize: 1300, InsertBinlogCount: 6, StatsBinlogSize: 25,
+			},
+		},
+		{
+			name: "delta and timestamp fields are never touched",
+			base: &datapb.Statistics{
+				InsertBinlogSize:   1000,
+				DeltaBinlogSize:    77,
+				DeltaBinlogCount:   3,
+				DeleteNumRows:      9,
+				TimestampFrom:      10,
+				TimestampTo:        50,
+				DeltaTimestampFrom: 11,
+				DeltaTimestampTo:   49,
+				TimestampQuantiles: []int64{1, 2, 3, 4, 5},
+			},
+			// A malformed increment carrying these fields must be ignored.
+			delta: &datapb.Statistics{
+				InsertBinlogSize:   1,
+				DeltaBinlogSize:    999,
+				DeltaBinlogCount:   999,
+				DeleteNumRows:      999,
+				TimestampFrom:      999,
+				TimestampTo:        999,
+				DeltaTimestampFrom: 999,
+				DeltaTimestampTo:   999,
+				TimestampQuantiles: []int64{9, 9, 9, 9, 9},
+			},
+			expect: &datapb.Statistics{
+				InsertBinlogSize:   1001,
+				DeltaBinlogSize:    77,
+				DeltaBinlogCount:   3,
+				DeleteNumRows:      9,
+				TimestampFrom:      10,
+				TimestampTo:        50,
+				DeltaTimestampFrom: 11,
+				DeltaTimestampTo:   49,
+				TimestampQuantiles: []int64{1, 2, 3, 4, 5},
+			},
+		},
+		{
+			name: "null counts union: new field added, existing field accumulates",
+			base: &datapb.Statistics{
+				NullCounts: map[int64]int64{100: 0, 101: 5},
+			},
+			delta: &datapb.Statistics{
+				NullCounts: map[int64]int64{101: 2, 102: 0},
+			},
+			expect: &datapb.Statistics{
+				NullCounts: map[int64]int64{100: 0, 101: 7, 102: 0},
+			},
+		},
+		{
+			name:   "negative increment clamps at zero",
+			base:   &datapb.Statistics{InsertBinlogSize: 10, InsertBinlogCount: 1, StatsBinlogSize: 3},
+			delta:  &datapb.Statistics{InsertBinlogSize: -50, InsertBinlogCount: -9, StatsBinlogSize: -8},
+			expect: &datapb.Statistics{InsertBinlogSize: 0, InsertBinlogCount: 0, StatsBinlogSize: 0},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := addStatsDelta(context.TODO(), 1, tc.base, tc.delta)
+			assert.Equal(t, tc.expect.GetInsertBinlogSize(), got.GetInsertBinlogSize())
+			assert.Equal(t, tc.expect.GetInsertBinlogCount(), got.GetInsertBinlogCount())
+			assert.Equal(t, tc.expect.GetStatsBinlogSize(), got.GetStatsBinlogSize())
+			assert.Equal(t, tc.expect.GetDeltaBinlogSize(), got.GetDeltaBinlogSize())
+			assert.Equal(t, tc.expect.GetDeltaBinlogCount(), got.GetDeltaBinlogCount())
+			assert.Equal(t, tc.expect.GetDeleteNumRows(), got.GetDeleteNumRows())
+			assert.Equal(t, tc.expect.GetTimestampFrom(), got.GetTimestampFrom())
+			assert.Equal(t, tc.expect.GetTimestampTo(), got.GetTimestampTo())
+			assert.Equal(t, tc.expect.GetDeltaTimestampFrom(), got.GetDeltaTimestampFrom())
+			assert.Equal(t, tc.expect.GetDeltaTimestampTo(), got.GetDeltaTimestampTo())
+			assert.Equal(t, tc.expect.GetTimestampQuantiles(), got.GetTimestampQuantiles())
+			assert.Equal(t, tc.expect.GetNullCounts(), got.GetNullCounts())
+		})
+	}
+}
+
+// TestAddStatsDeltaDoesNotAliasBase pins that the returned Statistics is
+// independent of the input, so a caller mutating the result cannot corrupt
+// the segment's previous state.
+func TestAddStatsDeltaDoesNotAliasBase(t *testing.T) {
+	base := &datapb.Statistics{
+		InsertBinlogSize: 100,
+		NullCounts:       map[int64]int64{100: 1},
+	}
+	got := addStatsDelta(context.TODO(), 1, base, &datapb.Statistics{
+		InsertBinlogSize: 10,
+		NullCounts:       map[int64]int64{101: 0},
+	})
+
+	got.InsertBinlogSize = 999
+	got.NullCounts[100] = 999
+
+	assert.EqualValues(t, 100, base.GetInsertBinlogSize())
+	assert.EqualValues(t, 1, base.GetNullCounts()[100])
+}
+
+// TestAddStatsDeltaDoesNotAliasBaseNilDelta pins that the nil-delta
+// pass-through also returns an object independent of base, not base itself
+// — a caller mutating the result on this path must not corrupt the
+// segment's previous state either.
+func TestAddStatsDeltaDoesNotAliasBaseNilDelta(t *testing.T) {
+	base := &datapb.Statistics{
+		InsertBinlogSize: 100,
+		NullCounts:       map[int64]int64{100: 1},
+	}
+	got := addStatsDelta(context.TODO(), 1, base, nil)
+
+	got.InsertBinlogSize = 999
+	got.NullCounts[100] = 999
+
+	assert.EqualValues(t, 100, base.GetInsertBinlogSize())
+	assert.EqualValues(t, 1, base.GetNullCounts()[100])
+}

--- a/internal/datanode/compactor/bump_schema_version_compactor.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor.go
@@ -99,7 +99,7 @@ func (t *bumpSchemaVersionCompactionTask) Compact() (*datapb.CompactionPlanResul
 	} else if len(droppedFieldIDs) > 0 {
 		result, err = t.runFullSchemaRewrite(existingFields)
 	} else {
-		result, err = t.runMissingFunctionMaterialization(ctx, missingFunctions, existingFields)
+		result, err = t.runMissingFunctionMaterialization(ctx, missingFunctions, droppedFieldIDs, existingFields)
 	}
 	if err != nil {
 		log.Warn(ctx, "schema bump compact failed", mlog.Err(err), mlog.Duration("compact cost", time.Since(compactStart)))
@@ -853,15 +853,26 @@ func (t *bumpSchemaVersionCompactionTask) addV3Stats(prefix string, fieldID int6
 	return nil
 }
 
-func (t *bumpSchemaVersionCompactionTask) buildMergedLogsV3(segment *datapb.CompactionSegmentBinlogs, writerResult *bumpSchemaVersionWriterResult, sparseFieldMemorySizes map[int64]int, totalRows int64) ([]*datapb.FieldBinlog, error) {
+// buildNewInsertLogsV3 returns FieldBinlogs for the column groups this run
+// wrote, and nothing else. It deliberately does not merge the input segment's
+// FieldBinlogs: those come from the compaction plan, which copies them off
+// SegmentInfo, and for a StorageV3 segment recovered after a DataCoord restart
+// they are empty (#50410 stopped persisting per-field binlog KVs for V3).
+// The receiver (completeBumpSchemaVersionCompactionMutation in
+// internal/datacoord/meta.go) merges this array onto SegmentInfo.Binlogs; it
+// is the sole input to getSegmentBinlogFields, which canCreateIndexForSegment
+// uses to decide whether a function-output field is eligible for an index.
+// This result is therefore load-bearing: dropping it silently makes the
+// materialized field permanently un-indexable.
+func (t *bumpSchemaVersionCompactionTask) buildNewInsertLogsV3(writerResult *bumpSchemaVersionWriterResult, sparseFieldMemorySizes map[int64]int, totalRows int64) ([]*datapb.FieldBinlog, error) {
 	logIDStart, _, err := t.logIDAlloc.Alloc(uint32(len(writerResult.columnGroups)))
 	if err != nil {
 		return nil, err
 	}
-	newInsertLogs := make(map[int64]*datapb.FieldBinlog)
+	newInsertLogs := make(map[int64]*datapb.FieldBinlog, len(writerResult.columnGroups))
 	for i, columnGroup := range writerResult.columnGroups {
 		fieldID := columnGroup.GroupID
-		fieldBinlog := &datapb.FieldBinlog{
+		newInsertLogs[fieldID] = &datapb.FieldBinlog{
 			FieldID:     fieldID,
 			ChildFields: columnGroup.Fields,
 			Format:      columnGroup.Format,
@@ -873,10 +884,9 @@ func (t *bumpSchemaVersionCompactionTask) buildMergedLogsV3(segment *datapb.Comp
 				},
 			},
 		}
-		newInsertLogs[fieldID] = fieldBinlog
 	}
 
-	return t.finalizeMergedLogs(segment, newInsertLogs)
+	return storage.SortFieldBinlogs(newInsertLogs), nil
 }
 
 func (t *bumpSchemaVersionCompactionTask) preserveDeltaLogsV3(segment *datapb.CompactionSegmentBinlogs, manifestPath string) (string, error) {
@@ -921,29 +931,18 @@ func (t *bumpSchemaVersionCompactionTask) preserveDeltaLogsV3(segment *datapb.Co
 	return newManifest, nil
 }
 
-func (t *bumpSchemaVersionCompactionTask) finalizeMergedLogs(segment *datapb.CompactionSegmentBinlogs, newInsertLogs map[int64]*datapb.FieldBinlog) ([]*datapb.FieldBinlog, error) {
-	newFieldIDs := make(map[int64]struct{}, len(newInsertLogs)*2)
-	for _, fb := range newInsertLogs {
-		newFieldIDs[fb.GetFieldID()] = struct{}{}
-		for _, childID := range fb.GetChildFields() {
-			newFieldIDs[childID] = struct{}{}
-		}
-	}
-	mergedInsertLogs := make(map[int64]*datapb.FieldBinlog, len(segment.GetFieldBinlogs())+len(newInsertLogs))
-	for _, fb := range segment.GetFieldBinlogs() {
-		if compactionFieldBinlogReadable(fb, newFieldIDs) {
-			continue
-		}
-		mergedInsertLogs[fb.GetFieldID()] = fb
-	}
-	for fieldID, fb := range newInsertLogs {
-		mergedInsertLogs[fieldID] = fb
+func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx context.Context, missingFunctions []*schemapb.FunctionSchema, droppedFieldIDs []int64, existingFields map[int64]struct{}) (*datapb.CompactionPlanResult, error) {
+	// Materialization reports a Statistics INCREMENT, which is only valid
+	// because this path adds columns and never removes them. Dropped fields
+	// must go to runFullSchemaRewrite, which ships an absolute Stats. The
+	// dispatch in Compact already guarantees this; assert it so a future edit
+	// cannot silently produce an over-estimating increment.
+	if len(droppedFieldIDs) > 0 {
+		return nil, merr.WrapErrServiceInternalMsg(
+			"schema bump materialization cannot run with dropped fields, planID = %d, droppedFieldIDs = %v",
+			t.GetPlanID(), droppedFieldIDs)
 	}
 
-	return storage.SortFieldBinlogs(mergedInsertLogs), nil
-}
-
-func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx context.Context, missingFunctions []*schemapb.FunctionSchema, existingFields map[int64]struct{}) (*datapb.CompactionPlanResult, error) {
 	segment := t.plan.GetSegmentBinlogs()[0]
 	collectionID := segment.GetCollectionID()
 	partitionID := segment.GetPartitionID()
@@ -990,6 +989,7 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 	_, span := otel.Tracer(typeutil.DataNodeRole).Start(ctx, "BumpSchemaVersionCompact.batchProcess")
 	statsByField := make(map[int64]*storage.BM25Stats)
 	fieldMemorySizeByField := make(map[int64]int, len(outputFieldIDs))
+	fieldNullCountByField := make(map[int64]int64, len(outputFieldIDs))
 	for _, outputFieldID := range outputFieldIDs {
 		if isBM25MaterializedOutputField(t.plan.GetSchema(), outputFieldID) {
 			statsByField[outputFieldID] = storage.NewBM25Stats()
@@ -1046,6 +1046,7 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 				batchMemSize = bm25MemSize
 			}
 			fieldMemorySizeByField[outputFieldID] += batchMemSize
+			fieldNullCountByField[outputFieldID] += int64(outputCol.NullN())
 		}
 
 		writeStart := time.Now()
@@ -1084,7 +1085,7 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 		mlog.Int("v3StatsCount", len(writerResult.v3Stats)),
 	)
 
-	mergedInsertLogs, err := t.buildMergedLogsV3(segment, writerResult, fieldMemorySizeByField, totalRows)
+	newInsertLogs, err := t.buildNewInsertLogsV3(writerResult, fieldMemorySizeByField, totalRows)
 	if err != nil {
 		return nil, err
 	}
@@ -1112,7 +1113,7 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 	log.Info(ctx, "[schema-bump-partial-writer] writer output and bm25 stats committed",
 		mlog.String("manifestPath", manifestPath),
 		mlog.Int64("totalRows", totalRows),
-		mlog.Int("mergedInsertLogsCount", len(mergedInsertLogs)),
+		mlog.Int("newInsertLogsCount", len(newInsertLogs)),
 		mlog.Int("v3StatsCount", len(writerResult.v3Stats)),
 	)
 
@@ -1121,23 +1122,23 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 		State:  datapb.CompactionTaskState_completed,
 		Segments: []*datapb.CompactionSegment{
 			{
-				SegmentID:           segmentID,
-				NumOfRows:           totalRows,
-				InsertLogs:          mergedInsertLogs,
-				Field2StatslogPaths: segment.GetField2StatslogPaths(),
-				Deltalogs:           segment.GetDeltalogs(),
-				Channel:             segment.GetInsertChannel(),
-				StorageVersion:      writerResult.storageVersion,
-				Manifest:            manifestPath,
-				BaseManifest:        segment.GetManifest(),
-				// Partial-writer path merges new inserts with the
-				// input's existing statslogs and deltalogs. statsBlobSize
-				// comes from the freshly committed V3 stats (tracked on
-				// writerResult); insert/delta aggregates come from the
-				// merged arrays.
-				Stats: buildCompactionOutputStats(
-					mergedInsertLogs,
-					segment.GetDeltalogs(),
+				SegmentID:      segmentID,
+				NumOfRows:      totalRows,
+				InsertLogs:     newInsertLogs,
+				Channel:        segment.GetInsertChannel(),
+				StorageVersion: writerResult.storageVersion,
+				Manifest:       manifestPath,
+				BaseManifest:   segment.GetManifest(),
+				// In-place materialization ships an INCREMENT, not an absolute
+				// footprint: DataCoord adds it onto the segment's existing
+				// Stats. Field2StatslogPaths and Deltalogs are deliberately
+				// absent — they were echoes of the plan that the in-place
+				// receiver never reads, and the plan's arrays are empty for a
+				// recovered StorageV3 segment anyway.
+				Stats: buildMaterializationStatsDelta(
+					writerResult.columnGroups,
+					fieldMemorySizeByField,
+					fieldNullCountByField,
 					writerResult.statsBlobSize,
 				),
 			},
@@ -1146,7 +1147,7 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 	}
 	log.Info(ctx, "[schema-bump-partial-writer] compaction completed",
 		mlog.Int64("numOfRows", totalRows),
-		mlog.Int("mergedInsertLogsCount", len(mergedInsertLogs)),
+		mlog.Int("newInsertLogsCount", len(newInsertLogs)),
 		mlog.String("manifestPath", manifestPath),
 		mlog.Int64("effectiveStorageVersion", writerResult.storageVersion),
 		mlog.Int32("collectionSchemaVersion", t.plan.GetSchema().GetVersion()),

--- a/internal/datanode/compactor/bump_schema_version_compactor_test.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/etcdpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
@@ -278,6 +279,23 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionMa
 		}
 	}
 	s.True(found, "MinHash output field should be materialized into insert logs")
+
+	// The in-place receiver reads neither of these; they were echoes of the
+	// plan, whose arrays are empty for a recovered StorageV3 segment.
+	s.Empty(segment.GetDeltalogs())
+	s.Empty(segment.GetField2StatslogPaths())
+
+	// Stats is an INCREMENT: it describes only the columns this run wrote, so
+	// it carries no delete or timestamp aggregates for DataCoord to adopt.
+	stats := segment.GetStats()
+	s.Require().NotNil(stats)
+	s.Greater(stats.GetInsertBinlogSize(), int64(0))
+	s.EqualValues(1, stats.GetInsertBinlogCount())
+	s.EqualValues(0, stats.GetDeleteNumRows())
+	s.EqualValues(0, stats.GetDeltaBinlogSize())
+	s.EqualValues(0, stats.GetTimestampFrom())
+	s.EqualValues(0, stats.GetTimestampTo())
+	s.Contains(stats.GetNullCounts(), minHashOutputFieldID)
 }
 
 func (s *BumpSchemaVersionCompactionTaskSuite) SetupTest() {
@@ -1268,125 +1286,51 @@ func TestBumpSchemaVersionCompactionTaskBasic(t *testing.T) {
 	assert.Equal(t, int64(1), task.GetSlotUsage())
 }
 
-func (s *BumpSchemaVersionCompactionTaskSuite) TestFinalizeMergedLogs() {
+// TestBuildNewInsertLogsV3ReturnsOnlyNewGroups pins that the result carries
+// only what this run wrote. The plan's FieldBinlogs are irrelevant — for a
+// StorageV3 segment recovered after a DataCoord restart they are empty. The
+// returned groups are what the receiver merges onto SegmentInfo.Binlogs, and
+// that merge is what makes a materialized function-output field eligible for
+// index creation (see completeBumpSchemaVersionCompactionMutation in
+// internal/datacoord/meta.go); it must not be dropped.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestBuildNewInsertLogsV3ReturnsOnlyNewGroups() {
 	s.setupTest()
 
-	segment := &datapb.CompactionSegmentBinlogs{
-		SegmentID: 1,
-		FieldBinlogs: []*datapb.FieldBinlog{
-			{
-				FieldID: 100,
-				Binlogs: []*datapb.Binlog{
-					{LogPath: "original/100", EntriesNum: 1000},
-				},
-			},
-		},
-	}
-	newInsertLogs := map[int64]*datapb.FieldBinlog{
-		102: {
-			FieldID: 102,
-			Binlogs: []*datapb.Binlog{
-				{LogPath: "new/102", EntriesNum: 1000, MemorySize: 500},
-			},
-		},
-	}
-	mergedInsert, err := s.task.finalizeMergedLogs(segment, newInsertLogs)
-	s.NoError(err)
-
-	s.Equal(2, len(mergedInsert))
-	s.Equal(int64(100), mergedInsert[0].GetFieldID())
-	s.Equal(int64(102), mergedInsert[1].GetFieldID())
-}
-
-// TestFinalizeMergedLogsCrashReplay verifies that retrying finalizeMergedLogs replaces rewritten output logs without duplicates.
-func (s *BumpSchemaVersionCompactionTaskSuite) TestFinalizeMergedLogsCrashReplay() {
-	s.setupTest()
-
-	// Segment state after first successful run: field 102 already present in etcd.
-	segment := &datapb.CompactionSegmentBinlogs{
-		SegmentID: 1,
-		FieldBinlogs: []*datapb.FieldBinlog{
-			{FieldID: 100, Binlogs: []*datapb.Binlog{{LogPath: "original/100", EntriesNum: 1000}}},
-			{FieldID: 102, Binlogs: []*datapb.Binlog{{LogPath: "first-run/102", EntriesNum: 1000, LogID: 99}}},
-		},
-	}
-	// Second run allocates a new logID for the same output field.
-	newInsertLogs := map[int64]*datapb.FieldBinlog{
-		102: {FieldID: 102, Binlogs: []*datapb.Binlog{{LogPath: "second-run/102", EntriesNum: 1000, LogID: 100}}},
-	}
-
-	mergedInsert, err := s.task.finalizeMergedLogs(segment, newInsertLogs)
-	s.NoError(err)
-
-	s.Require().Equal(2, len(mergedInsert))
-	var fieldIDs []int64
-	for _, fb := range mergedInsert {
-		fieldIDs = append(fieldIDs, fb.GetFieldID())
-	}
-	s.ElementsMatch([]int64{100, 102}, fieldIDs)
-	for _, fb := range mergedInsert {
-		if fb.GetFieldID() == 102 {
-			s.Equal("second-run/102", fb.GetBinlogs()[0].GetLogPath())
-		}
-	}
-}
-
-// TestFinalizeMergedLogsV3CrashReplay verifies V3 column-group replacement through ChildFields.
-func (s *BumpSchemaVersionCompactionTaskSuite) TestFinalizeMergedLogsV3CrashReplay() {
-	s.setupTest()
-
-	// V3: column group 102 already present in segment after first run.
-	segment := &datapb.CompactionSegmentBinlogs{
-		SegmentID: 1,
-		FieldBinlogs: []*datapb.FieldBinlog{
-			{FieldID: 100, Binlogs: []*datapb.Binlog{{LogPath: "original/100"}}},
-			{FieldID: 102, ChildFields: []int64{102}, Binlogs: []*datapb.Binlog{{LogPath: "first-run/cg102"}}},
-		},
-	}
-	newInsertLogs := map[int64]*datapb.FieldBinlog{
-		102: {FieldID: 102, ChildFields: []int64{102}, Binlogs: []*datapb.Binlog{{LogPath: "second-run/cg102"}}},
-	}
-
-	mergedInsert, err := s.task.finalizeMergedLogs(segment, newInsertLogs)
-	s.NoError(err)
-
-	s.Require().Equal(2, len(mergedInsert))
-	for _, fb := range mergedInsert {
-		if fb.GetFieldID() == 102 {
-			s.Equal("second-run/cg102", fb.GetBinlogs()[0].GetLogPath())
-		}
-	}
-}
-
-func (s *BumpSchemaVersionCompactionTaskSuite) TestBuildMergedLogsV3() {
-	s.setupTest()
-
-	segment := &datapb.CompactionSegmentBinlogs{
-		SegmentID: 1,
-		FieldBinlogs: []*datapb.FieldBinlog{
-			{FieldID: 100, Binlogs: []*datapb.Binlog{{LogPath: "original/100", EntriesNum: 1000}}},
-		},
-	}
 	writerResult := &bumpSchemaVersionWriterResult{
-		columnGroups: []storagecommon.ColumnGroup{
-			{GroupID: 102, Fields: []int64{102}, Format: "vortex"},
-		},
+		columnGroups: []storagecommon.ColumnGroup{{GroupID: 102, Fields: []int64{102}}},
 	}
 
-	mergedInsert, err := s.task.buildMergedLogsV3(segment, writerResult, map[int64]int{102: 512}, 1000)
+	newInsert, err := s.task.buildNewInsertLogsV3(writerResult, map[int64]int{102: 512}, 1000)
 	s.NoError(err)
 
-	// Original + new
-	s.Equal(2, len(mergedInsert))
-	s.Equal(int64(100), mergedInsert[0].GetFieldID())
-	s.Equal(int64(102), mergedInsert[1].GetFieldID())
-	s.Equal("vortex", mergedInsert[1].GetFormat())
-	s.Equal(int64(512), mergedInsert[1].GetBinlogs()[0].GetMemorySize())
-	s.Equal(int64(1000), mergedInsert[1].GetBinlogs()[0].GetEntriesNum())
-	// V3 binlog presence marker must carry a non-zero LogID so buildBinlogKvs validation
-	// passes (requires LogID!=0 AND LogPath=="" for V3 segments).
-	s.NotZero(mergedInsert[1].GetBinlogs()[0].GetLogID(),
-		"V3 schema bump binlog presence marker must have non-zero LogID")
+	s.Require().Len(newInsert, 1)
+	s.EqualValues(102, newInsert[0].GetFieldID())
+	s.EqualValues(512, newInsert[0].GetBinlogs()[0].GetMemorySize())
+	s.EqualValues(1000, newInsert[0].GetBinlogs()[0].GetEntriesNum())
+}
+
+// TestMaterializationStatsDeltaIgnoresPlanArrays is the regression test for
+// issue #51729: the increment must be identical whether or not the plan
+// carries the input segment's FieldBinlog arrays. After #50410 a recovered
+// StorageV3 segment ships empty arrays, and the old absolute-Stats
+// implementation silently undercounted the whole segment.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestMaterializationStatsDeltaIgnoresPlanArrays() {
+	s.setupTest()
+
+	columnGroups := []storagecommon.ColumnGroup{{GroupID: 102, Fields: []int64{102}}}
+	memorySizes := map[int64]int{102: 4096}
+	nullCounts := map[int64]int64{102: 0}
+
+	// The builder takes no plan input at all, which is the property under test:
+	// there is no argument through which an empty or populated plan array could
+	// change the answer.
+	got := buildMaterializationStatsDelta(columnGroups, memorySizes, nullCounts, 256)
+
+	s.EqualValues(4096, got.GetInsertBinlogSize())
+	s.EqualValues(1, got.GetInsertBinlogCount())
+	s.EqualValues(256, got.GetStatsBinlogSize())
+	s.EqualValues(0, got.GetDeleteNumRows())
+	s.EqualValues(0, got.GetDeltaBinlogSize())
 }
 
 func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionOutputFieldsSelectsAllOutputsOnPartialState() {
@@ -1424,33 +1368,6 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestPartialMaterializerExistingFi
 
 	s.NotContains(materializerFields, int64(102))
 	s.NotContains(materializerFields, int64(103))
-}
-
-func (s *BumpSchemaVersionCompactionTaskSuite) TestFinalizeMergedLogsReplacesExistingOutputFieldLogs() {
-	s.setupTest()
-
-	segment := &datapb.CompactionSegmentBinlogs{
-		SegmentID: 1,
-		FieldBinlogs: []*datapb.FieldBinlog{
-			{FieldID: 100, Binlogs: []*datapb.Binlog{{LogPath: "original/100"}}},
-			{FieldID: 102, ChildFields: []int64{102}, Binlogs: []*datapb.Binlog{{LogPath: "old/cg102"}}},
-		},
-	}
-	newInsertLogs := map[int64]*datapb.FieldBinlog{
-		102: {FieldID: 102, ChildFields: []int64{102}, Binlogs: []*datapb.Binlog{{LogPath: "new/cg102"}}},
-		103: {FieldID: 103, ChildFields: []int64{103}, Binlogs: []*datapb.Binlog{{LogPath: "new/cg103"}}},
-	}
-
-	mergedInsert, err := s.task.finalizeMergedLogs(segment, newInsertLogs)
-	s.NoError(err)
-
-	s.Require().Len(mergedInsert, 3)
-	s.Equal(int64(100), mergedInsert[0].GetFieldID())
-	s.Equal("original/100", mergedInsert[0].GetBinlogs()[0].GetLogPath())
-	s.Equal(int64(102), mergedInsert[1].GetFieldID())
-	s.Equal("new/cg102", mergedInsert[1].GetBinlogs()[0].GetLogPath())
-	s.Equal(int64(103), mergedInsert[2].GetFieldID())
-	s.Equal("new/cg103", mergedInsert[2].GetBinlogs()[0].GetLogPath())
 }
 
 // Existing BM25 fixtures expose one output; these tests need a partial multi-output state.
@@ -1492,4 +1409,22 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestCompleteAndStop() {
 func (s *BumpSchemaVersionCompactionTaskSuite) TestGetStorageConfig() {
 	s.setupTest()
 	s.NotNil(s.task.GetStorageConfig())
+}
+
+// TestMaterializationRejectsDroppedFields pins the add-only invariant the
+// stats increment depends on. Dropped fields must route to
+// runFullSchemaRewrite, which ships an absolute Stats; reaching
+// materialization with drops would produce an increment that over-estimates
+// the segment, because the removed columns' bytes are never subtracted.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestMaterializationRejectsDroppedFields() {
+	s.setupTest()
+
+	_, err := s.task.runMissingFunctionMaterialization(
+		context.Background(),
+		nil,
+		[]int64{101},
+		map[int64]struct{}{},
+	)
+	s.Error(err)
+	s.ErrorIs(err, merr.ErrServiceInternal)
 }

--- a/internal/datanode/compactor/stats.go
+++ b/internal/datanode/compactor/stats.go
@@ -18,6 +18,7 @@ package compactor
 
 import (
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagecommon"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 )
 
@@ -42,5 +43,39 @@ import (
 func buildCompactionOutputStats(insertLogs, deltalogs []*datapb.FieldBinlog, statsBlobSize int64) *datapb.Statistics {
 	s := storage.BuildStatsFromFieldBinlogs(insertLogs, nil, nil, deltalogs)
 	s.StatsBinlogSize = statsBlobSize
+	return s
+}
+
+// buildMaterializationStatsDelta produces the Statistics INCREMENT that ships
+// on an in-place schema-bump materialization result. DataCoord adds it onto
+// the segment's existing SegmentInfo.Stats rather than replacing it — see the
+// contract on CompactionSegment.stats in data_coord.proto.
+//
+// Materialization appends function-output columns to an existing segment: it
+// writes no rows, no deletes and no new timestamps, so only the additive
+// fields are populated. Everything else is deliberately left zero, which is
+// what tells the receiver to leave those aggregates alone.
+//
+// memorySizes and nullCounts are keyed by output field ID, which equals
+// ColumnGroup.GroupID for the one-field-per-group layout setupWriter builds.
+// A group with no recorded memory size still counts as one binlog and still
+// gets a null_counts entry: the field is physically present in the segment,
+// and the presence contract in storage.BuildStatsFromFieldBinlogs requires an
+// entry for every such field, zero included.
+func buildMaterializationStatsDelta(
+	columnGroups []storagecommon.ColumnGroup,
+	memorySizes map[int64]int,
+	nullCounts map[int64]int64,
+	statsBlobSize int64,
+) *datapb.Statistics {
+	s := &datapb.Statistics{
+		StatsBinlogSize: statsBlobSize,
+		NullCounts:      make(map[int64]int64, len(columnGroups)),
+	}
+	for _, group := range columnGroups {
+		s.InsertBinlogSize += int64(memorySizes[group.GroupID])
+		s.InsertBinlogCount++
+		s.NullCounts[group.GroupID] = nullCounts[group.GroupID]
+	}
 	return s
 }

--- a/internal/datanode/compactor/stats_test.go
+++ b/internal/datanode/compactor/stats_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/milvus-io/milvus/internal/storagecommon"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 )
 
@@ -46,4 +47,46 @@ func TestBuildCompactionOutputStats_NullCounts(t *testing.T) {
 		s := buildCompactionOutputStats(nil, deltalogs, 0)
 		assert.Nil(t, s.GetNullCounts())
 	})
+}
+
+func TestBuildMaterializationStatsDelta(t *testing.T) {
+	columnGroups := []storagecommon.ColumnGroup{
+		{GroupID: 102, Fields: []int64{102}},
+		{GroupID: 103, Fields: []int64{103}},
+	}
+	memorySizes := map[int64]int{102: 4096, 103: 2048}
+	nullCounts := map[int64]int64{102: 0, 103: 7}
+
+	got := buildMaterializationStatsDelta(columnGroups, memorySizes, nullCounts, 512)
+
+	assert.EqualValues(t, 6144, got.GetInsertBinlogSize())
+	assert.EqualValues(t, 2, got.GetInsertBinlogCount())
+	assert.EqualValues(t, 512, got.GetStatsBinlogSize())
+	assert.Equal(t, map[int64]int64{102: 0, 103: 7}, got.GetNullCounts())
+
+	// Fields materialization does not change must be absent from the increment,
+	// so the receiver's accumulation leaves the segment's values untouched.
+	assert.EqualValues(t, 0, got.GetDeltaBinlogSize())
+	assert.EqualValues(t, 0, got.GetDeltaBinlogCount())
+	assert.EqualValues(t, 0, got.GetDeleteNumRows())
+	assert.EqualValues(t, 0, got.GetTimestampFrom())
+	assert.EqualValues(t, 0, got.GetTimestampTo())
+	assert.EqualValues(t, 0, got.GetDeltaTimestampFrom())
+	assert.EqualValues(t, 0, got.GetDeltaTimestampTo())
+	assert.Empty(t, got.GetTimestampQuantiles())
+}
+
+// TestBuildMaterializationStatsDeltaMissingMemorySize pins that a column group
+// with no recorded memory size contributes zero bytes but still counts as a
+// binlog and still gets a null_counts entry — the presence contract in
+// storage.BuildStatsFromFieldBinlogs requires an entry for every field
+// physically present in the segment.
+func TestBuildMaterializationStatsDeltaMissingMemorySize(t *testing.T) {
+	columnGroups := []storagecommon.ColumnGroup{{GroupID: 104, Fields: []int64{104}}}
+
+	got := buildMaterializationStatsDelta(columnGroups, map[int64]int{}, map[int64]int64{104: 0}, 0)
+
+	assert.EqualValues(t, 0, got.GetInsertBinlogSize())
+	assert.EqualValues(t, 1, got.GetInsertBinlogCount())
+	assert.Equal(t, map[int64]int64{104: 0}, got.GetNullCounts())
 }

--- a/pkg/proto/data_coord.proto
+++ b/pkg/proto/data_coord.proto
@@ -855,13 +855,26 @@ message CompactionSegment {
   // equals the segment's current manifest (optimistic-concurrency CAS),
   // mirroring StatsResult.base_manifest.
   string base_manifest = 15;
-  // Aggregate footprint of this compaction output. Populated by the
-  // compactor (mix / sort / bump-schema / L0) at write completion and
-  // copied verbatim onto SegmentInfo.Stats by the DataCoord receiver,
-  // so the receiver never recomputes from FieldBinlog arrays for
-  // compaction results. For V3 outputs whose stats blob lives in the
-  // manifest, this is the only authoritative source for
-  // stats_binlog_size.
+  // Aggregate footprint of this compaction output. Its meaning depends on
+  // how the receiver adopts the result:
+  //   - receiver builds a NEW SegmentInfo (mix / sort / clustering /
+  //     schema-bump full rewrite) -> ABSOLUTE footprint, copied verbatim
+  //     onto SegmentInfo.Stats.
+  //   - receiver updates an EXISTING SegmentInfo in place (schema-bump
+  //     materialization) -> an INCREMENT, added onto that segment's current
+  //     Stats via addStatsDelta.
+  //   - L0 compaction also adopts in place, onto the existing L1
+  //     SegmentInfo(s) it targets, but today the receiver
+  //     (addDeltalogsToSegment in internal/datacoord/meta.go) does not read
+  //     this field at all: it derives its own delta Stats directly from the
+  //     deltalogs array. L0 is therefore neither of the two buckets above in
+  //     practice; do not assume this field is consumed on that path.
+  // nil always means "no change". A producer that writes only part of a
+  // segment must ship an increment: it cannot compute an absolute value,
+  // because the input's FieldBinlog arrays are empty for StorageV3 segments
+  // recovered after a DataCoord restart.
+  // For V3 outputs whose stats blob lives in the manifest, this is the only
+  // authoritative source for stats_binlog_size.
   Statistics stats = 16;
 }
 

--- a/pkg/proto/datapb/data_coord.pb.go
+++ b/pkg/proto/datapb/data_coord.pb.go
@@ -6029,13 +6029,27 @@ type CompactionSegment struct {
 	// equals the segment's current manifest (optimistic-concurrency CAS),
 	// mirroring StatsResult.base_manifest.
 	BaseManifest string `protobuf:"bytes,15,opt,name=base_manifest,json=baseManifest,proto3" json:"base_manifest,omitempty"`
-	// Aggregate footprint of this compaction output. Populated by the
-	// compactor (mix / sort / bump-schema / L0) at write completion and
-	// copied verbatim onto SegmentInfo.Stats by the DataCoord receiver,
-	// so the receiver never recomputes from FieldBinlog arrays for
-	// compaction results. For V3 outputs whose stats blob lives in the
-	// manifest, this is the only authoritative source for
-	// stats_binlog_size.
+	// Aggregate footprint of this compaction output. Its meaning depends on
+	// how the receiver adopts the result:
+	//   - receiver builds a NEW SegmentInfo (mix / sort / clustering /
+	//     schema-bump full rewrite) -> ABSOLUTE footprint, copied verbatim
+	//     onto SegmentInfo.Stats.
+	//   - receiver updates an EXISTING SegmentInfo in place (schema-bump
+	//     materialization) -> an INCREMENT, added onto that segment's current
+	//     Stats via addStatsDelta.
+	//   - L0 compaction also adopts in place, onto the existing L1
+	//     SegmentInfo(s) it targets, but today the receiver
+	//     (addDeltalogsToSegment in internal/datacoord/meta.go) does not read
+	//     this field at all: it derives its own delta Stats directly from the
+	//     deltalogs array. L0 is therefore neither of the two buckets above in
+	//     practice; do not assume this field is consumed on that path.
+	//
+	// nil always means "no change". A producer that writes only part of a
+	// segment must ship an increment: it cannot compute an absolute value,
+	// because the input's FieldBinlog arrays are empty for StorageV3 segments
+	// recovered after a DataCoord restart.
+	// For V3 outputs whose stats blob lives in the manifest, this is the only
+	// authoritative source for stats_binlog_size.
 	Stats *Statistics `protobuf:"bytes,16,opt,name=stats,proto3" json:"stats,omitempty"`
 }
 


### PR DESCRIPTION
Cherry-pick from master
pr: #52006
issue: #51729

Schema-bump materialization now reports an incremental
Statistics delta instead of an absolute one, so DataCoord
can accumulate it correctly on V3 segments whose
FieldBinlog arrays are empty after restart.

Depends on #50410 cherry-pick (PR #52389). This branch
includes #50410 as a base commit; merge #52389 first.