### PR TITLE
fix: [cp3.0] remove FieldBinlog emptiness guards that reject V3 segments (#52223)

### DIFF
--- a/internal/datanode/compactor/clustering_compactor.go
+++ b/internal/datanode/compactor/clustering_compactor.go
@@ -592,20 +592,6 @@ func (t *clusteringCompactionTask) mappingSegment(
 		}
 	}
 
-	// Get the number of field binlog files from non-empty segment
-	var binlogNum int
-	for _, b := range segment.GetFieldBinlogs() {
-		if b != nil {
-			binlogNum = len(b.GetBinlogs())
-			break
-		}
-	}
-	// Unable to deal with all empty segments cases, so return error
-	if binlogNum == 0 {
-		mlog.Warn(context.TODO(), "compact wrong, all segments' binlogs are empty")
-		return merr.WrapErrIllegalCompactionPlan()
-	}
-
 	rr, existingFields, err := newCompactionSegmentRecordReader(ctx, segment, t.plan.Schema, t.compactionParams.StorageConfig,
 		storage.WithDownloader(func(ctx context.Context, paths []string) ([][]byte, error) {
 			return t.binlogIO.Download(ctx, paths)
@@ -884,21 +870,6 @@ func (t *clusteringCompactionTask) scalarAnalyzeSegment(
 	ctx, span := otel.Tracer(typeutil.DataNodeRole).Start(ctx, fmt.Sprintf("scalarAnalyzeSegment-%d-%d", t.GetPlanID(), segment.GetSegmentID()))
 	defer span.End()
 	processStart := time.Now()
-
-	// Get the number of field binlog files from non-empty segment
-	var binlogNum int
-	for _, b := range segment.GetFieldBinlogs() {
-		if b != nil {
-			binlogNum = len(b.GetBinlogs())
-			break
-		}
-	}
-	// Unable to deal with all empty segments cases, so return error
-	if binlogNum == 0 {
-		mlog.Warn(context.TODO(), "compact wrong, all segments' binlogs are empty")
-		return nil, merr.WrapErrIllegalCompactionPlan("all segments' binlogs are empty")
-	}
-	mlog.Debug(context.TODO(), "binlogNum", mlog.Int("binlogNum", binlogNum))
 
 	expiredFilter := compaction.NewEntityFilter(nil, t.plan.GetCollectionTtl(), t.currentTime, segment.GetCommitTimestamp())
 	requiredFields := typeutil.NewSet[int64]()

--- a/internal/datanode/compactor/clustering_compactor_test.go
+++ b/internal/datanode/compactor/clustering_compactor_test.go
@@ -156,13 +156,10 @@ func (s *ClusteringCompactionTaskSuite) TestIsVectorClusteringKey() {
 func (s *ClusteringCompactionTaskSuite) TestCompactionWithEmptyBinlog() {
 	s.task.plan.Schema = genCollectionSchema()
 	s.task.plan.ClusteringKeyField = 100
+	s.task.plan.SegmentBinlogs = []*datapb.CompactionSegmentBinlogs{}
 	_, err := s.task.Compact()
 	s.Require().Error(err)
 	s.Equal(true, errors.Is(err, merr.ErrIllegalCompactionPlan))
-	s.task.plan.SegmentBinlogs = []*datapb.CompactionSegmentBinlogs{}
-	_, err2 := s.task.Compact()
-	s.Require().Error(err2)
-	s.Equal(true, errors.Is(err2, merr.ErrIllegalCompactionPlan))
 }
 
 func (s *ClusteringCompactionTaskSuite) TestCompactionWithEmptySchema() {

--- a/internal/datanode/compactor/mix_compactor.go
+++ b/internal/datanode/compactor/mix_compactor.go
@@ -132,15 +132,15 @@ func (t *mixCompactionTask) preCompact() error {
 	for _, segmentBinlog := range t.plan.GetSegmentBinlogs() {
 		for i, fieldBinlog := range segmentBinlog.GetFieldBinlogs() {
 			for _, binlog := range fieldBinlog.GetBinlogs() {
-				// numRows just need to add entries num of ONE field.
 				if i == 0 {
 					t.maxRows += binlog.GetEntriesNum()
 				}
-
-				// MemorySize might be incorrectly
 				currSize += binlog.GetMemorySize()
 			}
 		}
+	}
+	if t.maxRows == 0 {
+		t.maxRows = t.plan.GetTotalRows()
 	}
 
 	t.estimatedOutputSegmentCount = int64(math.Ceil(float64(currSize) / float64(t.targetSize)))
@@ -465,18 +465,6 @@ func (t *mixCompactionTask) Compact() (*datapb.CompactionPlanResult, error) {
 		mlog.Warn(context.TODO(), "compact wrong, fail to decompress compaction binlogs", mlog.Err(err))
 		return nil, err
 	}
-	// Unable to deal with all empty segments cases, so return error
-	isEmpty := lo.EveryBy(lo.FlatMap(t.plan.GetSegmentBinlogs(), func(seg *datapb.CompactionSegmentBinlogs, _ int) []*datapb.FieldBinlog {
-		return seg.GetFieldBinlogs()
-	}), func(field *datapb.FieldBinlog) bool {
-		return len(field.GetBinlogs()) == 0
-	})
-
-	if isEmpty {
-		mlog.Warn(context.TODO(), "compact wrong, all segments' binlogs are empty")
-		return nil, merr.WrapErrServiceInternalMsg("illegal compaction plan")
-	}
-
 	if err := t.ensureLOBCompactionContext(ctx); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Cherry-pick from master
pr: #52223
issue: #50406

Remove FieldBinlog emptiness guards in mix compaction and
GetRecoveryInfo that incorrectly reject V3 segments whose
Binlogs arrays are empty after DataCoord restart.

No conflicts during cherry-pick.