### PR TITLE
fix: Replace external columns on manifest reopen

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2120,6 +2120,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(
     const SegmentLoadInfo& segment_load_info,
     const SchemaPtr& schema_snapshot,
     milvus::OpContext* op_ctx,
+    bool is_replace,
     StagedStateCommitter& committer) {
     auto load_cg_start = std::chrono::high_resolution_clock::now();
     CheckCancellation(
@@ -2273,6 +2274,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(
                                    size_estimate =
                                        std::move(task.size_estimate),
                                    op_ctx,
+                                   is_replace,
                                    &committer]() mutable {
             CheckCancellation(op_ctx,
                               id_,
@@ -2286,7 +2288,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(
                             schema_snapshot,
                             eager_load,
                             op_ctx,
-                            /*is_replace=*/false,
+                            is_replace,
                             committer,
                             std::move(size_estimate));
         });
@@ -7259,7 +7261,11 @@ ChunkedSegmentSealedImpl::PrepareLoadDiffForReopen(
 
     CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
     if (diff.load_external_manifest) {
-        LoadColumnGroups(segment_load_info, schema_snapshot, op_ctx, committer);
+        LoadColumnGroups(segment_load_info,
+                         schema_snapshot,
+                         op_ctx,
+                         /*is_replace=*/diff.manifest_updated,
+                         committer);
     } else {
         bool has_cg_changes = !diff.column_groups_to_load.empty() ||
                               !diff.column_groups_to_replace.empty() ||

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -2003,6 +2003,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     LoadColumnGroups(const SegmentLoadInfo& segment_load_info,
                      const SchemaPtr& schema_snapshot,
                      milvus::OpContext* op_ctx,
+                     bool is_replace,
                      StagedStateCommitter& committer);
 
     void


### PR DESCRIPTION
issue: #52395

### What changed

Propagate the external manifest update state through the column-group load
path. A manifest update now loads existing fields as replacements, while an
initial manifest load continues to reject duplicate field data.

### Why

External segment reopen correctly records that the manifest changed, but the
external column-group helper previously discarded that state and always used
`is_replace=false`. Reloading fields already present in the published segment
state then failed with `field data already loaded`, which could leave the
segment missing or not loaded for query and search.

### Validation

- `make milvus` on the equivalent 3.0 candidate
- `make build-cpp-with-unittest` on the equivalent 3.0 candidate
- `scripts/run_cpp_unittest.sh` with:
  - `SegmentLoadInfoTest.ComputeDiffExternalManifestUpdateReloadsExternalManifest`
  - `SegmentLoadInfoTest.ComputeDiffExternalManifestWithNewIndexDoesNotParseColumnNames`
- `clang-format-12 --dry-run --Werror` on the changed files
- `git diff --check`
