### PR TITLE
feat: [ElementNull 4] store element validity in array chunks

### DIFF
--- a/internal/core/src/common/Chunk.h
+++ b/internal/core/src/common/Chunk.h
@@ -379,6 +379,10 @@ using GeometryChunk = StringChunk;
 // [null_bitmap][offsets_lens][array_data]
 // [00000000] [29, 3, 41, 2, 49, 4, 65] [1, 2, 3, 4, 5, 6, 7, 8, 9]
 //
+// For element-nullable arrays, each row payload is prefixed with that row's
+// element validity bitmap:
+// [null_bitmap][offsets_lens][row0_element_bitmap][row0_data]...
+//
 // For string arrays, the structure is more complex as each string element needs its own offset:
 // [null_bitmap][offsets_lens][array1_offsets][array1_data][array2_offsets][array2_data][array3_offsets][array3_data]
 // [00000000] [29, 3, 53, 2, 69, 4, 101] [0, 5, 11, 16] ["hello", "world", "!"] [0, 3, 6] ["foo", "bar"] [0, 6, 12, 18, 24] ["apple", "orange", "banana", "grape"]
@@ -398,9 +402,11 @@ class ArrayChunk : public Chunk {
                uint64_t size,
                milvus::DataType element_type,
                bool nullable,
+               bool element_nullable,
                std::shared_ptr<ChunkMmapGuard> chunk_mmap_guard)
         : Chunk(row_nums, data, size, nullable, chunk_mmap_guard),
-          element_type_(element_type) {
+          element_type_(element_type),
+          element_nullable_(element_nullable) {
         auto null_bitmap_bytes_num = 0;
         if (nullable) {
             null_bitmap_bytes_num = (row_nums + 7) / 8;
@@ -416,6 +422,13 @@ class ArrayChunk : public Chunk {
         auto len = offsets_lens_[idx_off + 1];
         auto next_offset = offsets_lens_[idx_off + 2];
         auto data_ptr = data_ + offset;
+        TargetBitmapView element_valid_data;
+        uint32_t element_valid_bytes_len = 0;
+        if (element_nullable_) {
+            element_valid_data = TargetBitmapView(data_ptr, len);
+            element_valid_bytes_len = element_valid_data.size_in_bytes();
+            data_ptr += element_valid_bytes_len;
+        }
         uint32_t offsets_bytes_len = 0;
         uint32_t* offsets_ptr = nullptr;
         if (IsStringDataType(element_type_)) {
@@ -423,11 +436,14 @@ class ArrayChunk : public Chunk {
             offsets_ptr = reinterpret_cast<uint32_t*>(data_ptr);
         }
 
-        return ArrayView(data_ptr + offsets_bytes_len,
-                         len,
-                         next_offset - offset - offsets_bytes_len,
-                         element_type_,
-                         offsets_ptr);
+        return ArrayView(
+            data_ptr + offsets_bytes_len,
+            len,
+            next_offset - offset - element_valid_bytes_len - offsets_bytes_len,
+            element_type_,
+            offsets_ptr,
+            element_valid_data,
+            element_nullable_);
     }
 
     std::pair<std::vector<ArrayView>, FixedVector<bool>>
@@ -490,6 +506,7 @@ class ArrayChunk : public Chunk {
 
  private:
     milvus::DataType element_type_;
+    bool element_nullable_;
     uint32_t* offsets_lens_;
 };
 
@@ -501,6 +518,13 @@ class ArrayChunk : public Chunk {
 //
 // Due to these characteristics, the data layout is simpler:
 // [offsets_lens][all_vector_data_concatenated]
+//
+// For element-nullable VectorArray, element validity bitmaps are stored before
+// the dense vector data so VectorArrayChunk::Data() can still return one
+// contiguous vector byte region for search:
+// [null_bitmap][offsets_lens][row0_element_bitmap][row1_element_bitmap]...
+// [all_dense_vector_data]
+// Invalid element slots are zero-filled but retain their fixed-width slot.
 //
 // Example:
 // Suppose we have a data block containing arrays of vectors [[1, 2, 3], [4, 5, 6], [7, 8, 9]], [[10, 11, 12]], and [[13, 14, 15], [16, 17, 18]], and we want to
@@ -516,40 +540,84 @@ class VectorArrayChunk : public Chunk {
                      uint64_t size,
                      milvus::DataType element_type,
                      std::shared_ptr<ChunkMmapGuard> chunk_mmap_guard,
-                     bool nullable)
+                     bool nullable,
+                     bool element_nullable)
         : Chunk(row_nums, data, size, nullable, chunk_mmap_guard),
           dim_(dim),
-          element_type_(element_type) {
+          element_type_(element_type),
+          element_nullable_(element_nullable) {
+        physical_row_nums_ = row_nums_;
+        if (nullable_) {
+            physical_row_nums_ = 0;
+            for (int64_t i = 0; i < row_nums_; ++i) {
+                physical_row_nums_ += valid_[i] ? 1 : 0;
+            }
+        }
+
         auto null_bitmap_bytes_num = nullable_ ? (row_nums_ + 7) / 8 : 0;
         offsets_lens_ =
             reinterpret_cast<uint32_t*>(data + null_bitmap_bytes_num);
 
-        auto offset = 0;
-        offsets_.reserve(row_nums_ + 1);
-        offsets_.push_back(offset);
-        for (int64_t i = 0; i < row_nums_; i++) {
-            offset += offsets_lens_[i * 2 + 1];
-            offsets_.push_back(offset);
+        element_bitmap_offset_ =
+            null_bitmap_bytes_num +
+            sizeof(uint32_t) * (physical_row_nums_ * 2 + 1);
+        vector_data_offset_ = offsets_lens_[0];
+
+        element_bitmap_offsets_.reserve(physical_row_nums_ + 1);
+        element_bitmap_offsets_.push_back(0);
+        size_t current_element_bitmap_offset = 0;
+        for (int64_t i = 0; i < physical_row_nums_; i++) {
+            auto len = offsets_lens_[i * 2 + 1];
+            if (element_nullable_) {
+                current_element_bitmap_offset +=
+                    TargetBitmap::policy_type::get_required_size_in_bytes(len);
+            }
+            element_bitmap_offsets_.push_back(current_element_bitmap_offset);
         }
+
+        size_t element_offset = 0;
+        int64_t physical_row = 0;
+        offsets_.reserve(row_nums_ + 1);
+        offsets_.push_back(element_offset);
+        for (int64_t logical_row = 0; logical_row < row_nums_; ++logical_row) {
+            if (!nullable_ || valid_[logical_row]) {
+                element_offset += offsets_lens_[physical_row * 2 + 1];
+                ++physical_row;
+            }
+            offsets_.push_back(element_offset);
+        }
+        AssertInfo(physical_row == physical_row_nums_,
+                   "VectorArrayChunk physical row count mismatch, expected {}, "
+                   "got {}",
+                   physical_row_nums_,
+                   physical_row);
     }
 
     VectorArrayView
     View(int64_t idx) const {
-        AssertInfo(idx >= 0 && idx < row_nums_,
+        AssertInfo(idx >= 0 && idx < physical_row_nums_,
                    "VectorArrayChunk::View offset {} out of range, "
-                   "rows {}",
+                   "physical rows {}",
                    idx,
-                   row_nums_);
-        AssertInfo(!nullable_ || valid_[idx],
-                   "VectorArrayChunk::View offset {} is null",
-                   idx);
+                   physical_row_nums_);
         int idx_off = 2 * idx;
         auto offset = offsets_lens_[idx_off];
         auto len = offsets_lens_[idx_off + 1];
         auto next_offset = offsets_lens_[idx_off + 2];
         auto data_ptr = data_ + offset;
-        return VectorArrayView(
-            data_ptr, dim_, len, next_offset - offset, element_type_);
+        TargetBitmapView element_valid_data;
+        if (element_nullable_) {
+            element_valid_data = TargetBitmapView(
+                data_ + element_bitmap_offset_ + element_bitmap_offsets_[idx],
+                len);
+        }
+        return VectorArrayView(data_ptr,
+                               dim_,
+                               len,
+                               next_offset - offset,
+                               element_type_,
+                               element_valid_data,
+                               element_nullable_);
     }
 
     std::pair<std::vector<VectorArrayView>, FixedVector<bool>>
@@ -586,7 +654,7 @@ class VectorArrayChunk : public Chunk {
         for (int64_t i = start_offset; i < end_offset; i++) {
             if (nullable_) {
                 if (valid_[i]) {
-                    views.emplace_back(View(i));
+                    views.emplace_back(View(PhysicalOffsetOf(i)));
                 } else {
                     views.emplace_back();
                 }
@@ -610,7 +678,7 @@ class VectorArrayChunk : public Chunk {
 
     const char*
     Data() const override {
-        return data_ + offsets_lens_[0];
+        return data_ + vector_data_offset_;
     }
 
     const size_t*
@@ -622,7 +690,12 @@ class VectorArrayChunk : public Chunk {
     int64_t dim_;
     uint32_t* offsets_lens_;
     milvus::DataType element_type_;
+    bool element_nullable_;
+    uint32_t element_bitmap_offset_ = 0;
+    uint32_t vector_data_offset_ = 0;
+    int64_t physical_row_nums_ = 0;
     std::vector<size_t> offsets_;
+    std::vector<size_t> element_bitmap_offsets_;
 };
 
 class SparseFloatVectorChunk : public Chunk {

--- a/internal/core/src/common/ChunkTest.cpp
+++ b/internal/core/src/common/ChunkTest.cpp
@@ -601,7 +601,7 @@ TEST(chunk, test_array) {
     EXPECT_EQ(views.size(), 1);
     auto& arr = views[0];
     for (size_t i = 0; i < arr.length(); ++i) {
-        auto str = arr.get_data<std::string>(i);
+        auto str = arr.get_data_unchecked<std::string>(i);
         EXPECT_EQ(str, field_string_data.string_data().data(i));
     }
 }
@@ -679,7 +679,7 @@ TEST(chunk, test_null_array) {
             EXPECT_EQ(arr.length(),
                       field_string_data.string_data().data_size());
             for (size_t j = 0; j < arr.length(); j++) {
-                auto str = arr.get_data<std::string>(j);
+                auto str = arr.get_data_unchecked<std::string>(j);
                 EXPECT_EQ(str, field_string_data.string_data().data(j));
             }
         }
@@ -740,7 +740,7 @@ TEST(chunk, test_array_views) {
         for (auto i = 0; i < array_count; i++) {
             auto& arr = views[i];
             for (size_t j = 0; j < arr.length(); ++j) {
-                auto str = arr.get_data<std::string>(j);
+                auto str = arr.get_data_unchecked<std::string>(j);
                 EXPECT_EQ(str, field_string_data.string_data().data(j));
             }
         }
@@ -753,7 +753,7 @@ TEST(chunk, test_array_views) {
         for (auto i = 0; i < len; i++) {
             auto& arr = views[i];
             for (size_t j = 0; j < arr.length(); ++j) {
-                auto str = arr.get_data<std::string>(j);
+                auto str = arr.get_data_unchecked<std::string>(j);
                 EXPECT_EQ(str, field_string_data.string_data().data(j));
             }
         }

--- a/internal/core/src/common/ChunkWriter.cpp
+++ b/internal/core/src/common/ChunkWriter.cpp
@@ -258,13 +258,25 @@ ArrayChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
                    "type id {}; upstream normalizer must coerce to BINARY",
                    data ? static_cast<int>(data->type_id()) : -1);
         for (int64_t i = 0; i < array->length(); ++i) {
+            header_.push_back(static_cast<uint32_t>(cursor));  // off_i
+            if (array->IsNull(i)) {
+                AssertInfo(nullable_,
+                           "ArrayChunkWriter got null row for non-nullable "
+                           "ARRAY field");
+                cached_arrays_.emplace_back();
+                header_.push_back(0);  // len_i
+                continue;
+            }
             auto str = array->GetView(i);
             ScalarFieldProto scalar_array;
-            scalar_array.ParseFromArray(str.data(), str.size());
-            cached_arrays_.emplace_back(scalar_array);
+            auto success = scalar_array.ParseFromArray(str.data(), str.size());
+            AssertInfo(success, "parse array from string failed");
+            cached_arrays_.emplace_back(scalar_array, element_nullable_);
             const auto& arr = cached_arrays_.back();
-            header_.push_back(static_cast<uint32_t>(cursor));        // off_i
             header_.push_back(static_cast<uint32_t>(arr.length()));  // len_i
+            if (element_nullable_) {
+                cursor += arr.get_element_valid_data_byte_size();
+            }
             if (is_string) {
                 cursor += sizeof(uint32_t) * arr.length();
             }
@@ -296,11 +308,22 @@ ArrayChunkWriter::write_to_target(const arrow::ArrayVector& array_vec,
     target->write(header_.data(), header_.size() * sizeof(uint32_t));
 
     for (auto& arr : cached_arrays_) {
-        if (is_string) {
-            target->write(arr.get_offsets_data(),
-                          arr.length() * sizeof(uint32_t));
+        if (element_nullable_) {
+            auto element_valid_bytes = arr.get_element_valid_data_byte_size();
+            if (element_valid_bytes > 0) {
+                target->write(arr.get_element_valid_data().data(),
+                              element_valid_bytes);
+            }
         }
-        target->write(arr.data(), arr.byte_size());
+        if (is_string) {
+            auto offsets_bytes = arr.length() * sizeof(uint32_t);
+            if (offsets_bytes > 0) {
+                target->write(arr.get_offsets_data(), offsets_bytes);
+            }
+        }
+        if (arr.byte_size() > 0) {
+            target->write(arr.data(), arr.byte_size());
+        }
     }
 
     char padding[MMAP_ARRAY_PADDING] = {};
@@ -315,6 +338,7 @@ ArrayChunkWriter::write_to_target(const arrow::ArrayVector& array_vec,
 std::pair<size_t, size_t>
 VectorArrayChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
     size_t total_rows = 0;
+    size_t valid_rows = 0;
     size_t total_size = 0;
 
     for (const auto& array_data : array_vec) {
@@ -336,14 +360,22 @@ VectorArrayChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
                 int byte_width = binary_values->byte_width();
                 const int32_t* list_offsets = list_array->raw_value_offsets();
                 int64_t actual_values_count = 0;
+                int64_t element_bitmap_bytes = 0;
                 for (int64_t i = 0; i < list_array->length(); ++i) {
                     if (nullable_ && list_array->IsNull(i)) {
                         continue;
                     }
-                    actual_values_count +=
-                        list_offsets[i + 1] - list_offsets[i];
+                    ++valid_rows;
+                    auto value_count = list_offsets[i + 1] - list_offsets[i];
+                    actual_values_count += value_count;
+                    if (element_nullable_) {
+                        element_bitmap_bytes +=
+                            TargetBitmap::policy_type::get_required_size_in_bytes(
+                                value_count);
+                    }
                 }
                 total_size += actual_values_count * byte_width;
+                total_size += element_bitmap_bytes;
                 break;
             }
             default:
@@ -354,12 +386,15 @@ VectorArrayChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
     }
 
     row_nums_ = total_rows;
+    valid_row_nums_ = nullable_ ? valid_rows : total_rows;
 
     if (nullable_) {
         total_size += (total_rows + 7) / 8;
     }
-    // Add space for logical-row offset and length arrays.
-    total_size += sizeof(uint32_t) * (row_nums_ * 2 + 1) + MMAP_ARRAY_PADDING;
+    // Nullable rows have no physical payload, so the header only describes
+    // valid rows. Chunk::PhysicalOffsetOf maps logical rows to these entries.
+    total_size +=
+        sizeof(uint32_t) * (valid_row_nums_ * 2 + 1) + MMAP_ARRAY_PADDING;
     return {total_size, total_rows};
 }
 
@@ -368,9 +403,7 @@ VectorArrayChunkWriter::write_to_target(
     const arrow::ArrayVector& array_vec,
     const std::shared_ptr<ChunkTarget>& target) {
     std::vector<uint32_t> offsets_lens;
-    offsets_lens.reserve(row_nums_ * 2 + 1);
-    std::vector<const uint8_t*> vector_data_ptrs;
-    std::vector<size_t> data_sizes;
+    offsets_lens.reserve(valid_row_nums_ * 2 + 1);
 
     if (nullable_) {
         std::vector<std::tuple<const uint8_t*, int64_t, int64_t>> null_bitmaps;
@@ -382,9 +415,28 @@ VectorArrayChunkWriter::write_to_target(
         write_null_bit_maps(null_bitmaps, target);
     }
 
+    uint32_t element_bitmap_total_bytes = 0;
+    if (element_nullable_) {
+        for (const auto& array_data : array_vec) {
+            auto list_array =
+                std::static_pointer_cast<arrow::ListArray>(array_data);
+            const int32_t* list_offsets = list_array->raw_value_offsets();
+            for (int64_t i = 0; i < list_array->length(); ++i) {
+                if (nullable_ && list_array->IsNull(i)) {
+                    continue;
+                }
+                auto vector_count = list_offsets[i + 1] - list_offsets[i];
+                element_bitmap_total_bytes +=
+                    TargetBitmap::policy_type::get_required_size_in_bytes(
+                        vector_count);
+            }
+        }
+    }
+
     uint32_t current_offset =
         (nullable_ ? static_cast<uint32_t>((row_nums_ + 7) / 8) : 0) +
-        sizeof(uint32_t) * (row_nums_ * 2 + 1);
+        sizeof(uint32_t) * (valid_row_nums_ * 2 + 1) +
+        element_bitmap_total_bytes;
 
     for (const auto& array_data : array_vec) {
         auto list_array =
@@ -399,8 +451,6 @@ VectorArrayChunkWriter::write_to_target(
         // Each list contains multiple vectors, each stored as a fixed-size binary chunk
         for (int64_t i = 0; i < list_array->length(); i++) {
             if (nullable_ && list_array->IsNull(i)) {
-                offsets_lens.push_back(current_offset);
-                offsets_lens.push_back(0);
                 continue;
             }
             auto start_idx = list_offsets[i];
@@ -410,12 +460,6 @@ VectorArrayChunkWriter::write_to_target(
 
             offsets_lens.push_back(current_offset);
             offsets_lens.push_back(static_cast<uint32_t>(vector_count));
-
-            for (int32_t j = start_idx; j < end_idx; ++j) {
-                vector_data_ptrs.push_back(binary_values->GetValue(j));
-                data_sizes.push_back(byte_width);
-            }
-
             current_offset += byte_size;
         }
     }
@@ -429,11 +473,67 @@ VectorArrayChunkWriter::write_to_target(
     }
     target->write(&offsets_lens.back(), sizeof(uint32_t));  // final offset
 
-    for (size_t i = 0; i < vector_data_ptrs.size(); i++) {
-        target->write(vector_data_ptrs[i], data_sizes[i]);
+    if (element_nullable_) {
+        for (const auto& array_data : array_vec) {
+            auto list_array =
+                std::static_pointer_cast<arrow::ListArray>(array_data);
+            auto binary_values =
+                std::static_pointer_cast<arrow::FixedSizeBinaryArray>(
+                    list_array->values());
+            const int32_t* list_offsets = list_array->raw_value_offsets();
+
+            for (int64_t i = 0; i < list_array->length(); ++i) {
+                if (nullable_ && list_array->IsNull(i)) {
+                    continue;
+                }
+                auto start_idx = list_offsets[i];
+                auto end_idx = list_offsets[i + 1];
+                auto vector_count = end_idx - start_idx;
+                TargetBitmap element_valid_data(vector_count, true);
+                for (int32_t j = start_idx; j < end_idx; ++j) {
+                    if (binary_values->IsNull(j)) {
+                        element_valid_data.reset(j - start_idx);
+                    }
+                }
+                auto element_valid_bytes = element_valid_data.size_in_bytes();
+                if (element_valid_bytes > 0) {
+                    target->write(element_valid_data.data(),
+                                  element_valid_bytes);
+                }
+            }
+        }
     }
 
-    char padding[MMAP_ARRAY_PADDING];
+    for (const auto& array_data : array_vec) {
+        auto list_array =
+            std::static_pointer_cast<arrow::ListArray>(array_data);
+        auto binary_values =
+            std::static_pointer_cast<arrow::FixedSizeBinaryArray>(
+                list_array->values());
+        const int32_t* list_offsets = list_array->raw_value_offsets();
+        int byte_width = binary_values->byte_width();
+        std::vector<uint8_t> zero_value(byte_width, 0);
+
+        for (int64_t i = 0; i < list_array->length(); ++i) {
+            if (nullable_ && list_array->IsNull(i)) {
+                continue;
+            }
+            auto start_idx = list_offsets[i];
+            auto end_idx = list_offsets[i + 1];
+            for (int32_t j = start_idx; j < end_idx; ++j) {
+                AssertInfo(element_nullable_ || !binary_values->IsNull(j),
+                           "VectorArrayChunkWriter got null child value for "
+                           "non-element-nullable VECTOR_ARRAY field");
+                if (element_nullable_ && binary_values->IsNull(j)) {
+                    target->write(zero_value.data(), byte_width);
+                } else {
+                    target->write(binary_values->GetValue(j), byte_width);
+                }
+            }
+        }
+    }
+
+    char padding[MMAP_ARRAY_PADDING] = {};
     target->write(padding, MMAP_ARRAY_PADDING);
 }
 
@@ -604,12 +704,17 @@ create_chunk_writer(const FieldMeta& field_meta) {
         }
         case milvus::DataType::ARRAY:
             return std::make_shared<ArrayChunkWriter>(
-                field_meta.get_element_type(), nullable);
+                field_meta.get_element_type(),
+                nullable,
+                field_meta.is_element_nullable());
         case milvus::DataType::VECTOR_SPARSE_U32_F32:
             return std::make_shared<SparseFloatVectorChunkWriter>(nullable);
         case milvus::DataType::VECTOR_ARRAY:
             return std::make_shared<VectorArrayChunkWriter>(
-                dim, field_meta.get_element_type(), nullable);
+                dim,
+                field_meta.get_element_type(),
+                nullable,
+                field_meta.is_element_nullable());
         default:
             ThrowInfo(Unsupported, "Unsupported data type");
     }
@@ -744,12 +849,14 @@ make_chunk(const FieldMeta& field_meta,
                 row_nums, data, size, nullable, chunk_mmap_guard);
         }
         case milvus::DataType::ARRAY:
-            return std::make_unique<ArrayChunk>(row_nums,
-                                                data,
-                                                size,
-                                                field_meta.get_element_type(),
-                                                nullable,
-                                                chunk_mmap_guard);
+            return std::make_unique<ArrayChunk>(
+                row_nums,
+                data,
+                size,
+                field_meta.get_element_type(),
+                nullable,
+                field_meta.is_element_nullable(),
+                chunk_mmap_guard);
         case milvus::DataType::VECTOR_SPARSE_U32_F32:
             return std::make_unique<SparseFloatVectorChunk>(
                 row_nums, data, size, nullable, chunk_mmap_guard);
@@ -761,7 +868,8 @@ make_chunk(const FieldMeta& field_meta,
                 size,
                 field_meta.get_element_type(),
                 chunk_mmap_guard,
-                nullable);
+                nullable,
+                field_meta.is_element_nullable());
         default:
             ThrowInfo(DataTypeInvalid, "Unsupported data type");
     }

--- a/internal/core/src/common/ChunkWriter.h
+++ b/internal/core/src/common/ChunkWriter.h
@@ -275,8 +275,12 @@ class GeometryChunkWriter : public ChunkWriterBase {
 
 class ArrayChunkWriter : public ChunkWriterBase {
  public:
-    ArrayChunkWriter(const milvus::DataType element_type, bool nullable)
-        : ChunkWriterBase(nullable), element_type_(element_type) {
+    ArrayChunkWriter(const milvus::DataType element_type,
+                     bool nullable,
+                     bool element_nullable)
+        : ChunkWriterBase(nullable),
+          element_type_(element_type),
+          element_nullable_(element_nullable) {
     }
 
     std::pair<size_t, size_t>
@@ -288,6 +292,7 @@ class ArrayChunkWriter : public ChunkWriterBase {
 
  private:
     const milvus::DataType element_type_;
+    const bool element_nullable_;
     // Parsed protobufs cached by calculate_size so write_to_target does not
     // pay a second ScalarFieldProto parse per row.
     std::vector<Array> cached_arrays_;
@@ -301,8 +306,11 @@ class VectorArrayChunkWriter : public ChunkWriterBase {
  public:
     VectorArrayChunkWriter(int64_t dim,
                            const milvus::DataType element_type,
-                           bool nullable)
-        : ChunkWriterBase(nullable), element_type_(element_type) {
+                           bool nullable,
+                           bool element_nullable)
+        : ChunkWriterBase(nullable),
+          element_type_(element_type),
+          element_nullable_(element_nullable) {
     }
 
     std::pair<size_t, size_t>
@@ -314,6 +322,8 @@ class VectorArrayChunkWriter : public ChunkWriterBase {
 
  private:
     const milvus::DataType element_type_;
+    const bool element_nullable_;
+    size_t valid_row_nums_ = 0;
 };
 
 class SparseFloatVectorChunkWriter : public ChunkWriterBase {

--- a/internal/core/src/common/ChunkWriterTest.cpp
+++ b/internal/core/src/common/ChunkWriterTest.cpp
@@ -19,8 +19,10 @@
 #include <arrow/array/builder_base.h>
 #include <arrow/array/builder_binary.h>
 #include <gtest/gtest.h>
+#include <array>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <optional>
 #include <random>
@@ -37,6 +39,8 @@
 #include "common/Types.h"
 #include "gtest/gtest.h"
 
+using milvus::ArrayChunk;
+using milvus::ArrayChunkWriter;
 using milvus::DataType;
 using milvus::MemChunkTarget;
 using milvus::MMAP_ARRAY_PADDING;
@@ -136,6 +140,143 @@ BuildNullableFloatVectorArrayListArray(
     return std::static_pointer_cast<arrow::ListArray>(result);
 }
 
+std::shared_ptr<arrow::ListArray>
+BuildElementNullableFloatVectorArrayListArray(int dim) {
+    auto value_type = arrow::fixed_size_binary(dim * sizeof(float));
+    arrow::ListBuilder list_builder(
+        arrow::default_memory_pool(),
+        std::make_shared<arrow::FixedSizeBinaryBuilder>(value_type));
+    auto& fsb_builder = dynamic_cast<arrow::FixedSizeBinaryBuilder&>(
+        *list_builder.value_builder());
+
+    auto append_vector = [&](float first) {
+        std::vector<float> vector_data(dim);
+        for (int i = 0; i < dim; ++i) {
+            vector_data[i] = first + i;
+        }
+        EXPECT_TRUE(
+            fsb_builder
+                .Append(reinterpret_cast<const uint8_t*>(vector_data.data()))
+                .ok());
+    };
+
+    EXPECT_TRUE(list_builder.Append().ok());
+    append_vector(1.0F);
+    EXPECT_TRUE(fsb_builder.AppendNull().ok());
+
+    EXPECT_TRUE(list_builder.Append().ok());
+
+    EXPECT_TRUE(list_builder.Append().ok());
+    EXPECT_TRUE(fsb_builder.AppendNull().ok());
+    append_vector(3.0F);
+
+    std::shared_ptr<arrow::Array> result;
+    EXPECT_TRUE(list_builder.Finish(&result).ok());
+    return std::static_pointer_cast<arrow::ListArray>(result);
+}
+
+std::vector<uint8_t>
+BuildVectorBytes(DataType data_type, int dim, int seed) {
+    const auto byte_width = GetByteWidth(data_type, dim);
+    std::vector<uint8_t> bytes(byte_width);
+    if (data_type == DataType::VECTOR_FLOAT) {
+        std::vector<float> values(dim);
+        for (int i = 0; i < dim; ++i) {
+            values[i] = static_cast<float>(seed + i);
+        }
+        std::memcpy(bytes.data(), values.data(), byte_width);
+        return bytes;
+    }
+    for (int i = 0; i < byte_width; ++i) {
+        bytes[i] = static_cast<uint8_t>(seed + i);
+    }
+    return bytes;
+}
+
+std::shared_ptr<arrow::ListArray>
+BuildElementNullableVectorArrayListArray(int dim,
+                                         DataType data_type,
+                                         const std::vector<uint8_t>& first,
+                                         const std::vector<uint8_t>& second) {
+    const auto byte_width = GetByteWidth(data_type, dim);
+    EXPECT_EQ(first.size(), byte_width);
+    EXPECT_EQ(second.size(), byte_width);
+    auto value_type = arrow::fixed_size_binary(byte_width);
+    arrow::ListBuilder list_builder(
+        arrow::default_memory_pool(),
+        std::make_shared<arrow::FixedSizeBinaryBuilder>(value_type));
+    auto& value_builder = dynamic_cast<arrow::FixedSizeBinaryBuilder&>(
+        *list_builder.value_builder());
+
+    EXPECT_TRUE(list_builder.Append().ok());
+    EXPECT_TRUE(value_builder.Append(first.data()).ok());
+    EXPECT_TRUE(value_builder.AppendNull().ok());
+
+    EXPECT_TRUE(list_builder.Append().ok());
+
+    EXPECT_TRUE(list_builder.Append().ok());
+    EXPECT_TRUE(value_builder.AppendNull().ok());
+    EXPECT_TRUE(value_builder.Append(second.data()).ok());
+
+    std::shared_ptr<arrow::Array> result;
+    EXPECT_TRUE(list_builder.Finish(&result).ok());
+    return std::static_pointer_cast<arrow::ListArray>(result);
+}
+
+std::string
+GetVectorPayloadBytes(const milvus::VectorFieldProto& field,
+                      DataType data_type) {
+    switch (data_type) {
+        case DataType::VECTOR_FLOAT: {
+            const auto& data = field.float_vector().data();
+            return {reinterpret_cast<const char*>(data.data()),
+                    data.size() * sizeof(float)};
+        }
+        case DataType::VECTOR_BINARY:
+            return field.binary_vector();
+        case DataType::VECTOR_FLOAT16:
+            return field.float16_vector();
+        case DataType::VECTOR_BFLOAT16:
+            return field.bfloat16_vector();
+        case DataType::VECTOR_INT8:
+            return field.int8_vector();
+        default:
+            ADD_FAILURE() << "unsupported vector type "
+                          << static_cast<int>(data_type);
+            return {};
+    }
+}
+
+std::string
+BuildElementNullableIntArrayRow(const std::vector<int32_t>& values,
+                                const std::vector<bool>& valid_data) {
+    milvus::ScalarFieldProto row;
+    for (auto value : values) {
+        row.mutable_int_data()->add_data(value);
+    }
+    for (auto valid : valid_data) {
+        row.add_valid_data(valid);
+    }
+    std::string serialized;
+    EXPECT_TRUE(row.SerializeToString(&serialized));
+    return serialized;
+}
+
+std::shared_ptr<arrow::BinaryArray>
+BuildBinaryArray(const std::vector<std::optional<std::string>>& values) {
+    arrow::BinaryBuilder builder;
+    for (const auto& value : values) {
+        if (value.has_value()) {
+            EXPECT_TRUE(builder.Append(value.value()).ok());
+        } else {
+            EXPECT_TRUE(builder.AppendNull().ok());
+        }
+    }
+    std::shared_ptr<arrow::Array> result;
+    EXPECT_TRUE(builder.Finish(&result).ok());
+    return std::static_pointer_cast<arrow::BinaryArray>(result);
+}
+
 // Test parameter structure for parameterized tests
 struct VectorArrayWriterTestParam {
     DataType data_type;
@@ -174,7 +315,7 @@ TEST_P(VectorArrayChunkWriterParameterizedTest, BasicNoSlice) {
 
     arrow::ArrayVector vec{list_array};
 
-    VectorArrayChunkWriter writer(dim(), data_type(), false);
+    VectorArrayChunkWriter writer(dim(), data_type(), false, false);
     auto [calculated_size, row_count] = writer.calculate_size(vec);
 
     // Expected size:
@@ -193,8 +334,14 @@ TEST_P(VectorArrayChunkWriterParameterizedTest, BasicNoSlice) {
 
     // Create chunk from target data
     auto* data = target->release();
-    auto chunk = std::make_unique<VectorArrayChunk>(
-        dim(), row_count, data, calculated_size, data_type(), nullptr, false);
+    auto chunk = std::make_unique<VectorArrayChunk>(dim(),
+                                                    row_count,
+                                                    data,
+                                                    calculated_size,
+                                                    data_type(),
+                                                    nullptr,
+                                                    false,
+                                                    false);
     ASSERT_NE(chunk, nullptr);
     EXPECT_EQ(chunk->RowNums(), 5);
 }
@@ -226,7 +373,7 @@ TEST_P(VectorArrayChunkWriterParameterizedTest, SlicedListArray) {
 
     arrow::ArrayVector vec{sliced_array};
 
-    VectorArrayChunkWriter writer(dim(), data_type(), false);
+    VectorArrayChunkWriter writer(dim(), data_type(), false, false);
     auto [calculated_size, row_count] = writer.calculate_size(vec);
 
     // Expected size with the fix:
@@ -245,8 +392,14 @@ TEST_P(VectorArrayChunkWriterParameterizedTest, SlicedListArray) {
 
     // Create chunk from target data
     auto* data = target->release();
-    auto chunk = std::make_unique<VectorArrayChunk>(
-        dim(), row_count, data, calculated_size, data_type(), nullptr, false);
+    auto chunk = std::make_unique<VectorArrayChunk>(dim(),
+                                                    row_count,
+                                                    data,
+                                                    calculated_size,
+                                                    data_type(),
+                                                    nullptr,
+                                                    false,
+                                                    false);
     ASSERT_NE(chunk, nullptr);
     EXPECT_EQ(chunk->RowNums(), 4);
 }
@@ -280,7 +433,7 @@ TEST_P(VectorArrayChunkWriterParameterizedTest, MultipleSlicedArrays) {
 
     arrow::ArrayVector vec{sliced1, sliced2};
 
-    VectorArrayChunkWriter writer(dim(), data_type(), false);
+    VectorArrayChunkWriter writer(dim(), data_type(), false, false);
     auto [calculated_size, row_count] = writer.calculate_size(vec);
 
     int expected_data_size = expected_vectors * byte_width();
@@ -295,8 +448,14 @@ TEST_P(VectorArrayChunkWriterParameterizedTest, MultipleSlicedArrays) {
 
     // Create chunk from target data
     auto* data = target->release();
-    auto chunk = std::make_unique<VectorArrayChunk>(
-        dim(), row_count, data, calculated_size, data_type(), nullptr, false);
+    auto chunk = std::make_unique<VectorArrayChunk>(dim(),
+                                                    row_count,
+                                                    data,
+                                                    calculated_size,
+                                                    data_type(),
+                                                    nullptr,
+                                                    false,
+                                                    false);
     ASSERT_NE(chunk, nullptr);
     EXPECT_EQ(chunk->RowNums(), expected_rows);
 }
@@ -315,7 +474,7 @@ TEST_P(VectorArrayChunkWriterParameterizedTest, SliceFromBeginning) {
 
     arrow::ArrayVector vec{sliced};
 
-    VectorArrayChunkWriter writer(dim(), data_type(), false);
+    VectorArrayChunkWriter writer(dim(), data_type(), false, false);
     auto [calculated_size, row_count] = writer.calculate_size(vec);
 
     int expected_data_size = 5 * byte_width();
@@ -339,7 +498,7 @@ TEST_P(VectorArrayChunkWriterParameterizedTest, SliceToEnd) {
 
     arrow::ArrayVector vec{sliced};
 
-    VectorArrayChunkWriter writer(dim(), data_type(), false);
+    VectorArrayChunkWriter writer(dim(), data_type(), false, false);
     auto [calculated_size, row_count] = writer.calculate_size(vec);
 
     int expected_data_size = 6 * byte_width();
@@ -378,7 +537,7 @@ TEST_P(VectorArrayChunkWriterParameterizedTest, SizeConsistencyWithSlice) {
 
         arrow::ArrayVector vec{sliced};
 
-        VectorArrayChunkWriter writer(test_dim, data_type(), false);
+        VectorArrayChunkWriter writer(test_dim, data_type(), false, false);
         auto [calculated_size, row_count] = writer.calculate_size(vec);
         EXPECT_EQ(row_count, length);
 
@@ -395,11 +554,136 @@ TEST_P(VectorArrayChunkWriterParameterizedTest, SizeConsistencyWithSlice) {
                                                         calculated_size,
                                                         data_type(),
                                                         nullptr,
+                                                        false,
                                                         false);
         ASSERT_NE(chunk, nullptr)
             << "Failed for slice(" << offset << ", " << length << ")";
         EXPECT_EQ(chunk->RowNums(), length);
     }
+}
+
+TEST_P(VectorArrayChunkWriterParameterizedTest,
+       ElementNullableRoundTripThroughChunkViews) {
+    auto first = BuildVectorBytes(data_type(), dim(), 1);
+    auto second = BuildVectorBytes(data_type(), dim(), 33);
+    auto list_array = BuildElementNullableVectorArrayListArray(
+        dim(), data_type(), first, second);
+    ASSERT_EQ(list_array->length(), 3);
+
+    arrow::ArrayVector arrays{list_array};
+    VectorArrayChunkWriter writer(dim(), data_type(), false, true);
+    auto [calculated_size, row_count] = writer.calculate_size(arrays);
+
+    const int expected_vectors = 4;
+    const int expected_element_bitmap_bytes =
+        2 * milvus::TargetBitmap::policy_type::get_required_size_in_bytes(2);
+    const int expected_size =
+        sizeof(uint32_t) * (row_count * 2 + 1) + expected_element_bitmap_bytes +
+        expected_vectors * byte_width() + MMAP_ARRAY_PADDING;
+    EXPECT_EQ(calculated_size, expected_size);
+
+    auto target = std::make_shared<MemChunkTarget>(calculated_size);
+    writer.write_to_target(arrays, target);
+    VectorArrayChunk chunk(dim(),
+                           row_count,
+                           target->release(),
+                           calculated_size,
+                           data_type(),
+                           nullptr,
+                           false,
+                           true);
+
+    const auto* offsets = chunk.Offsets();
+    EXPECT_EQ(offsets[0], 0);
+    EXPECT_EQ(offsets[1], 2);
+    EXPECT_EQ(offsets[2], 2);
+    EXPECT_EQ(offsets[3], 4);
+
+    const auto* dense = reinterpret_cast<const uint8_t*>(chunk.Data());
+    EXPECT_EQ(std::vector<uint8_t>(dense, dense + byte_width()), first);
+    EXPECT_EQ(
+        std::vector<uint8_t>(dense + byte_width(), dense + byte_width() * 2),
+        std::vector<uint8_t>(byte_width(), 0));
+    EXPECT_EQ(std::vector<uint8_t>(dense + byte_width() * 2,
+                                   dense + byte_width() * 3),
+              std::vector<uint8_t>(byte_width(), 0));
+    EXPECT_EQ(std::vector<uint8_t>(dense + byte_width() * 3,
+                                   dense + byte_width() * 4),
+              second);
+
+    auto [views, row_valid] = chunk.Views();
+    ASSERT_TRUE(row_valid.empty());
+    ASSERT_EQ(views.size(), 3);
+    ASSERT_EQ(views[0].length(), 2);
+    EXPECT_TRUE(views[0].is_element_valid(0));
+    EXPECT_FALSE(views[0].is_element_valid(1));
+    EXPECT_EQ(
+        GetVectorPayloadBytes(views[0].output_data(), data_type()),
+        std::string(reinterpret_cast<const char*>(first.data()), first.size()));
+    ASSERT_EQ(views[1].length(), 0);
+    ASSERT_EQ(views[2].length(), 2);
+    EXPECT_FALSE(views[2].is_element_valid(0));
+    EXPECT_TRUE(views[2].is_element_valid(1));
+    EXPECT_EQ(GetVectorPayloadBytes(views[2].output_data(), data_type()),
+              std::string(reinterpret_cast<const char*>(second.data()),
+                          second.size()));
+}
+
+TEST_P(VectorArrayChunkWriterParameterizedTest,
+       ElementNullableSlicedListArraysRoundTrip) {
+    auto first = BuildVectorBytes(data_type(), dim(), 1);
+    auto second = BuildVectorBytes(data_type(), dim(), 33);
+    auto third = BuildVectorBytes(data_type(), dim(), 65);
+    auto fourth = BuildVectorBytes(data_type(), dim(), 97);
+    auto original1 = BuildElementNullableVectorArrayListArray(
+        dim(), data_type(), first, second);
+    auto original2 = BuildElementNullableVectorArrayListArray(
+        dim(), data_type(), third, fourth);
+
+    // Both inputs retain their original child arrays. The writer must use the
+    // sliced list offsets rather than treating values() as slice-local.
+    auto sliced1 =
+        std::static_pointer_cast<arrow::ListArray>(original1->Slice(1, 2));
+    auto sliced2 =
+        std::static_pointer_cast<arrow::ListArray>(original2->Slice(2, 1));
+    arrow::ArrayVector arrays{sliced1, sliced2};
+
+    VectorArrayChunkWriter writer(dim(), data_type(), false, true);
+    auto [calculated_size, row_count] = writer.calculate_size(arrays);
+    ASSERT_EQ(row_count, 3);
+    auto target = std::make_shared<MemChunkTarget>(calculated_size);
+    writer.write_to_target(arrays, target);
+
+    VectorArrayChunk chunk(dim(),
+                           row_count,
+                           target->release(),
+                           calculated_size,
+                           data_type(),
+                           nullptr,
+                           false,
+                           true);
+    const auto* offsets = chunk.Offsets();
+    EXPECT_EQ(offsets[0], 0);
+    EXPECT_EQ(offsets[1], 0);
+    EXPECT_EQ(offsets[2], 2);
+    EXPECT_EQ(offsets[3], 4);
+
+    auto [views, row_valid] = chunk.Views();
+    ASSERT_TRUE(row_valid.empty());
+    ASSERT_EQ(views.size(), 3);
+    EXPECT_EQ(views[0].length(), 0);
+    ASSERT_EQ(views[1].length(), 2);
+    EXPECT_FALSE(views[1].is_element_valid(0));
+    EXPECT_TRUE(views[1].is_element_valid(1));
+    EXPECT_EQ(GetVectorPayloadBytes(views[1].output_data(), data_type()),
+              std::string(reinterpret_cast<const char*>(second.data()),
+                          second.size()));
+    ASSERT_EQ(views[2].length(), 2);
+    EXPECT_FALSE(views[2].is_element_valid(0));
+    EXPECT_TRUE(views[2].is_element_valid(1));
+    EXPECT_EQ(GetVectorPayloadBytes(views[2].output_data(), data_type()),
+              std::string(reinterpret_cast<const char*>(fourth.data()),
+                          fourth.size()));
 }
 
 TEST(VectorArrayChunkWriterTest, NullableRowsRoundTripThroughChunkViews) {
@@ -410,12 +694,13 @@ TEST(VectorArrayChunkWriterTest, NullableRowsRoundTripThroughChunkViews) {
     ASSERT_EQ(list_array->null_count(), 1);
 
     arrow::ArrayVector vec{list_array};
-    VectorArrayChunkWriter writer(dim, DataType::VECTOR_FLOAT, true);
+    VectorArrayChunkWriter writer(dim, DataType::VECTOR_FLOAT, true, false);
     auto [calculated_size, row_count] = writer.calculate_size(vec);
 
+    const int expected_valid_rows = 3;
     const int expected_vectors = 3;
     const int expected_size =
-        (row_count + 7) / 8 + sizeof(uint32_t) * (row_count * 2 + 1) +
+        (row_count + 7) / 8 + sizeof(uint32_t) * (expected_valid_rows * 2 + 1) +
         expected_vectors * dim * sizeof(float) + MMAP_ARRAY_PADDING;
     EXPECT_EQ(calculated_size, expected_size);
     EXPECT_EQ(row_count, 4);
@@ -430,7 +715,8 @@ TEST(VectorArrayChunkWriterTest, NullableRowsRoundTripThroughChunkViews) {
                            calculated_size,
                            DataType::VECTOR_FLOAT,
                            nullptr,
-                           true);
+                           true,
+                           false);
     auto [views, valid] = chunk.Views();
     ASSERT_EQ(views.size(), 4);
     ASSERT_EQ(valid.size(), 4);
@@ -450,8 +736,301 @@ TEST(VectorArrayChunkWriterTest, NullableRowsRoundTripThroughChunkViews) {
     EXPECT_EQ(offsets[3], 1);
     EXPECT_EQ(offsets[4], 3);
 
-    EXPECT_ANY_THROW(chunk.View(1));
-    EXPECT_EQ(chunk.View(2).length(), 0);
+    EXPECT_ANY_THROW(chunk.PhysicalOffsetOf(1));
+    EXPECT_EQ(chunk.View(chunk.PhysicalOffsetOf(2)).length(), 0);
+}
+
+TEST(VectorArrayChunkWriterTest, ElementNullableRoundTripThroughChunkViews) {
+    constexpr int dim = 2;
+    auto list_array = BuildElementNullableFloatVectorArrayListArray(dim);
+    ASSERT_EQ(list_array->length(), 3);
+
+    arrow::ArrayVector vec{list_array};
+    VectorArrayChunkWriter writer(dim, DataType::VECTOR_FLOAT, false, true);
+    auto [calculated_size, row_count] = writer.calculate_size(vec);
+
+    const int expected_vectors = 4;
+    const int expected_element_bitmap_bytes =
+        2 * milvus::TargetBitmap::policy_type::get_required_size_in_bytes(2);
+    const int expected_size =
+        sizeof(uint32_t) * (row_count * 2 + 1) + expected_element_bitmap_bytes +
+        expected_vectors * dim * sizeof(float) + MMAP_ARRAY_PADDING;
+    EXPECT_EQ(calculated_size, expected_size);
+    EXPECT_EQ(row_count, 3);
+
+    auto target = std::make_shared<MemChunkTarget>(calculated_size);
+    writer.write_to_target(vec, target);
+
+    auto* data = target->release();
+    VectorArrayChunk chunk(dim,
+                           row_count,
+                           data,
+                           calculated_size,
+                           DataType::VECTOR_FLOAT,
+                           nullptr,
+                           false,
+                           true);
+    const auto* offsets = chunk.Offsets();
+    EXPECT_EQ(offsets[0], 0);
+    EXPECT_EQ(offsets[1], 2);
+    EXPECT_EQ(offsets[2], 2);
+    EXPECT_EQ(offsets[3], 4);
+
+    auto dense_data = reinterpret_cast<const float*>(chunk.Data());
+    EXPECT_FLOAT_EQ(dense_data[0], 1.0F);
+    EXPECT_FLOAT_EQ(dense_data[1], 2.0F);
+    EXPECT_FLOAT_EQ(dense_data[2], 0.0F);
+    EXPECT_FLOAT_EQ(dense_data[3], 0.0F);
+    EXPECT_FLOAT_EQ(dense_data[4], 0.0F);
+    EXPECT_FLOAT_EQ(dense_data[5], 0.0F);
+    EXPECT_FLOAT_EQ(dense_data[6], 3.0F);
+    EXPECT_FLOAT_EQ(dense_data[7], 4.0F);
+
+    auto [views, valid] = chunk.Views();
+    ASSERT_EQ(views.size(), 3);
+    EXPECT_TRUE(valid.empty());
+
+    ASSERT_TRUE(views[0].is_element_nullable());
+    EXPECT_EQ(views[0].length(), 2);
+    EXPECT_TRUE(views[0].is_element_valid(0));
+    EXPECT_FALSE(views[0].is_element_valid(1));
+    auto row0 = views[0].output_data();
+    EXPECT_EQ(row0.valid_data_size(), 2);
+    EXPECT_EQ(row0.float_vector().data_size(), dim);
+
+    ASSERT_TRUE(views[1].is_element_nullable());
+    EXPECT_EQ(views[1].length(), 0);
+    auto row1 = views[1].output_data();
+    EXPECT_EQ(row1.valid_data_size(), 0);
+    EXPECT_EQ(row1.float_vector().data_size(), 0);
+
+    ASSERT_TRUE(views[2].is_element_nullable());
+    EXPECT_EQ(views[2].length(), 2);
+    EXPECT_FALSE(views[2].is_element_valid(0));
+    EXPECT_TRUE(views[2].is_element_valid(1));
+    auto row2 = views[2].output_data();
+    EXPECT_EQ(row2.valid_data_size(), 2);
+    EXPECT_EQ(row2.float_vector().data_size(), dim);
+}
+
+TEST(VectorArrayChunkWriterTest,
+     RowAndElementNullableRoundTripPreservesLogicalOffsets) {
+    constexpr int dim = 2;
+    auto value_type = arrow::fixed_size_binary(dim * sizeof(float));
+    arrow::ListBuilder list_builder(
+        arrow::default_memory_pool(),
+        std::make_shared<arrow::FixedSizeBinaryBuilder>(value_type));
+    auto& value_builder = dynamic_cast<arrow::FixedSizeBinaryBuilder&>(
+        *list_builder.value_builder());
+
+    auto append_vector = [&](float first) {
+        const std::array<float, dim> vector{first, first + 1.0F};
+        ASSERT_TRUE(value_builder
+                        .Append(reinterpret_cast<const uint8_t*>(vector.data()))
+                        .ok());
+    };
+
+    ASSERT_TRUE(list_builder.Append().ok());
+    append_vector(1.0F);
+    ASSERT_TRUE(value_builder.AppendNull().ok());
+    append_vector(3.0F);
+
+    ASSERT_TRUE(list_builder.AppendNull().ok());
+    ASSERT_TRUE(list_builder.Append().ok());
+
+    ASSERT_TRUE(list_builder.Append().ok());
+    ASSERT_TRUE(value_builder.AppendNull().ok());
+    append_vector(5.0F);
+
+    ASSERT_TRUE(list_builder.Append().ok());
+    append_vector(7.0F);
+    append_vector(9.0F);
+
+    std::shared_ptr<arrow::Array> array;
+    ASSERT_TRUE(list_builder.Finish(&array).ok());
+    auto list_array = std::static_pointer_cast<arrow::ListArray>(array);
+    ASSERT_EQ(list_array->length(), 5);
+    ASSERT_EQ(list_array->null_count(), 1);
+
+    arrow::ArrayVector arrays{list_array};
+    VectorArrayChunkWriter writer(dim, DataType::VECTOR_FLOAT, true, true);
+    auto [calculated_size, row_count] = writer.calculate_size(arrays);
+
+    const size_t element_bitmap_bytes =
+        milvus::TargetBitmap::policy_type::get_required_size_in_bytes(3) +
+        milvus::TargetBitmap::policy_type::get_required_size_in_bytes(0) +
+        milvus::TargetBitmap::policy_type::get_required_size_in_bytes(2) +
+        milvus::TargetBitmap::policy_type::get_required_size_in_bytes(2);
+    const size_t expected_size =
+        (row_count + 7) / 8 + sizeof(uint32_t) * (4 * 2 + 1) +
+        element_bitmap_bytes + 7 * dim * sizeof(float) + MMAP_ARRAY_PADDING;
+    EXPECT_EQ(calculated_size, expected_size);
+
+    auto target = std::make_shared<MemChunkTarget>(calculated_size);
+    writer.write_to_target(arrays, target);
+
+    VectorArrayChunk chunk(dim,
+                           row_count,
+                           target->release(),
+                           calculated_size,
+                           DataType::VECTOR_FLOAT,
+                           nullptr,
+                           true,
+                           true);
+    auto [views, row_valid] = chunk.Views();
+    ASSERT_EQ(views.size(), 5);
+    ASSERT_EQ(row_valid.size(), 5);
+    EXPECT_TRUE(row_valid[0]);
+    EXPECT_FALSE(row_valid[1]);
+    EXPECT_TRUE(row_valid[2]);
+    EXPECT_TRUE(row_valid[3]);
+    EXPECT_TRUE(row_valid[4]);
+
+    const auto* offsets = chunk.Offsets();
+    const std::array<size_t, 6> expected_offsets{0, 3, 3, 3, 5, 7};
+    for (size_t i = 0; i < expected_offsets.size(); ++i) {
+        EXPECT_EQ(offsets[i], expected_offsets[i]);
+    }
+
+    ASSERT_EQ(views[0].length(), 3);
+    EXPECT_TRUE(views[0].is_element_valid(0));
+    EXPECT_FALSE(views[0].is_element_valid(1));
+    EXPECT_TRUE(views[0].is_element_valid(2));
+    EXPECT_EQ(views[1].length(), 0);
+    EXPECT_EQ(views[2].length(), 0);
+    ASSERT_EQ(views[3].length(), 2);
+    EXPECT_FALSE(views[3].is_element_valid(0));
+    EXPECT_TRUE(views[3].is_element_valid(1));
+    ASSERT_EQ(views[4].length(), 2);
+    EXPECT_TRUE(views[4].is_element_valid(0));
+    EXPECT_TRUE(views[4].is_element_valid(1));
+
+    const auto* dense_data = reinterpret_cast<const float*>(chunk.Data());
+    const std::array<float, 14> expected_data{1.0F,
+                                              2.0F,
+                                              0.0F,
+                                              0.0F,
+                                              3.0F,
+                                              4.0F,
+                                              0.0F,
+                                              0.0F,
+                                              5.0F,
+                                              6.0F,
+                                              7.0F,
+                                              8.0F,
+                                              9.0F,
+                                              10.0F};
+    for (size_t i = 0; i < expected_data.size(); ++i) {
+        EXPECT_FLOAT_EQ(dense_data[i], expected_data[i]);
+    }
+}
+
+TEST(ArrayChunkWriterTest, ElementNullableRoundTripThroughChunkViews) {
+    arrow::BinaryBuilder builder;
+    auto row0 =
+        BuildElementNullableIntArrayRow({10, 0, 30}, {true, false, true});
+    auto row2 = BuildElementNullableIntArrayRow({}, {});
+    auto row3 = BuildElementNullableIntArrayRow({40, 50}, {true, true});
+    ASSERT_TRUE(builder.Append(row0).ok());
+    ASSERT_TRUE(builder.AppendNull().ok());
+    ASSERT_TRUE(builder.Append(row2).ok());
+    ASSERT_TRUE(builder.Append(row3).ok());
+
+    std::shared_ptr<arrow::Array> array;
+    ASSERT_TRUE(builder.Finish(&array).ok());
+    arrow::ArrayVector vec{array};
+
+    ArrayChunkWriter writer(DataType::INT32, true, true);
+    auto [calculated_size, row_count] = writer.calculate_size(vec);
+    auto target = std::make_shared<MemChunkTarget>(calculated_size);
+    writer.write_to_target(vec, target);
+
+    auto* data = target->release();
+    ArrayChunk chunk(
+        row_count, data, calculated_size, DataType::INT32, true, true, nullptr);
+    auto [views, valid] = chunk.Views();
+    ASSERT_EQ(views.size(), 4);
+    ASSERT_EQ(valid.size(), 4);
+    EXPECT_TRUE(valid[0]);
+    EXPECT_FALSE(valid[1]);
+    EXPECT_TRUE(valid[2]);
+    EXPECT_TRUE(valid[3]);
+
+    ASSERT_TRUE(views[0].is_element_nullable());
+    ASSERT_EQ(views[0].length(), 3);
+    EXPECT_TRUE(views[0].is_element_valid(0));
+    EXPECT_FALSE(views[0].is_element_valid(1));
+    EXPECT_TRUE(views[0].is_element_valid(2));
+    EXPECT_EQ(views[0].get_data_unchecked<int32_t>(0), 10);
+    EXPECT_EQ(views[0].get_data_unchecked<int32_t>(2), 30);
+
+    EXPECT_EQ(views[1].length(), 0);
+    ASSERT_TRUE(views[2].is_element_nullable());
+    EXPECT_EQ(views[2].length(), 0);
+    ASSERT_TRUE(views[3].is_element_nullable());
+    ASSERT_EQ(views[3].length(), 2);
+    EXPECT_TRUE(views[3].is_element_valid(0));
+    EXPECT_TRUE(views[3].is_element_valid(1));
+    EXPECT_EQ(views[3].get_data_unchecked<int32_t>(0), 40);
+    EXPECT_EQ(views[3].get_data_unchecked<int32_t>(1), 50);
+}
+
+TEST(ArrayChunkWriterTest,
+     ElementNullableSlicedBinaryArraysPreserveRowAndElementNulls) {
+    auto skip0 = BuildElementNullableIntArrayRow({1}, {true});
+    auto row0 = BuildElementNullableIntArrayRow({10, 0}, {true, false});
+    auto empty = BuildElementNullableIntArrayRow({}, {});
+    auto skip1 = BuildElementNullableIntArrayRow({2}, {true});
+    auto batch1 = BuildBinaryArray(
+        {skip0, row0, std::nullopt, empty, skip1});
+
+    auto skip2 = BuildElementNullableIntArrayRow({3}, {true});
+    auto row3 = BuildElementNullableIntArrayRow({0, 30}, {false, true});
+    auto row4 = BuildElementNullableIntArrayRow({40}, {true});
+    auto skip3 = BuildElementNullableIntArrayRow({4}, {true});
+    auto batch2 = BuildBinaryArray({skip2, row3, row4, skip3});
+
+    auto sliced1 =
+        std::static_pointer_cast<arrow::BinaryArray>(batch1->Slice(1, 3));
+    auto sliced2 =
+        std::static_pointer_cast<arrow::BinaryArray>(batch2->Slice(1, 2));
+    arrow::ArrayVector arrays{sliced1, sliced2};
+
+    ArrayChunkWriter writer(DataType::INT32, true, true);
+    auto [calculated_size, row_count] = writer.calculate_size(arrays);
+    ASSERT_EQ(row_count, 5);
+    auto target = std::make_shared<MemChunkTarget>(calculated_size);
+    writer.write_to_target(arrays, target);
+
+    ArrayChunk chunk(row_count,
+                     target->release(),
+                     calculated_size,
+                     DataType::INT32,
+                     true,
+                     true,
+                     nullptr);
+    auto [views, row_valid] = chunk.Views();
+    ASSERT_EQ(views.size(), 5);
+    ASSERT_EQ(row_valid.size(), 5);
+    EXPECT_TRUE(row_valid[0]);
+    EXPECT_FALSE(row_valid[1]);
+    EXPECT_TRUE(row_valid[2]);
+    EXPECT_TRUE(row_valid[3]);
+    EXPECT_TRUE(row_valid[4]);
+
+    ASSERT_EQ(views[0].length(), 2);
+    EXPECT_TRUE(views[0].is_element_valid(0));
+    EXPECT_FALSE(views[0].is_element_valid(1));
+    EXPECT_EQ(views[0].get_data_unchecked<int32_t>(0), 10);
+    EXPECT_EQ(views[1].length(), 0);
+    EXPECT_EQ(views[2].length(), 0);
+    ASSERT_EQ(views[3].length(), 2);
+    EXPECT_FALSE(views[3].is_element_valid(0));
+    EXPECT_TRUE(views[3].is_element_valid(1));
+    EXPECT_EQ(views[3].get_data_unchecked<int32_t>(1), 30);
+    ASSERT_EQ(views[4].length(), 1);
+    EXPECT_TRUE(views[4].is_element_valid(0));
+    EXPECT_EQ(views[4].get_data_unchecked<int32_t>(0), 40);
 }
 
 // Instantiate parameterized tests for all vector types

--- a/internal/core/src/mmap/ChunkData.h
+++ b/internal/core/src/mmap/ChunkData.h
@@ -220,6 +220,9 @@ VariableLengthChunk<Array>::set(
         size_);
     size_t total_size = 0;
     for (auto i = 0; i < length; i++) {
+        if (src[i].is_element_nullable()) {
+            total_size += src[i].get_element_valid_data_byte_size();
+        }
         total_size += src[i].byte_size();
         if (IsVariableDataType(src[i].get_element_type())) {
             total_size += (src[i].length() * sizeof(uint32_t));
@@ -238,6 +241,19 @@ VariableLengthChunk<Array>::set(
         } else {
             int length = src[i].length();
             uint32_t* src_offsets_ptr = src[i].get_offsets_data();
+            TargetBitmapView element_valid_data;
+            if (src[i].is_element_nullable()) {
+                auto element_valid_bytes =
+                    src[i].get_element_valid_data_byte_size();
+                if (element_valid_bytes > 0) {
+                    milvus::fastmem::FastMemcpy(
+                        data_ptr,
+                        src[i].get_element_valid_data().data(),
+                        element_valid_bytes);
+                }
+                element_valid_data = TargetBitmapView(data_ptr, length);
+                data_ptr += element_valid_bytes;
+            }
             // need copy offsets for variable types
             uint32_t* target_offsets_ptr = nullptr;
             if (IsVariableDataType(element_type)) {
@@ -249,8 +265,13 @@ VariableLengthChunk<Array>::set(
             }
             auto data_size = src[i].byte_size();
             milvus::fastmem::FastMemcpy(data_ptr, src[i].data(), data_size);
-            data_[i + begin] = ArrayView(
-                data_ptr, length, data_size, element_type, target_offsets_ptr);
+            data_[i + begin] = ArrayView(data_ptr,
+                                         length,
+                                         data_size,
+                                         element_type,
+                                         target_offsets_ptr,
+                                         element_valid_data,
+                                         src[i].is_element_nullable());
             data_ptr += data_size;
         }
     }

--- a/internal/core/src/mmap/ChunkVector.h
+++ b/internal/core/src/mmap/ChunkVector.h
@@ -386,7 +386,7 @@ class ThreadSafeChunkVector : public ChunkVectorBase<Type> {
 
     SpanBase
     get_span(const ChunkSnapshot& snap, int64_t chunk_id) const override {
-        if constexpr (IsMmap && std::is_same_v<std::string, Type>) {
+        if constexpr (IsMmap && IsVariableTypeSupportInChunk<Type>) {
             return SpanBase(get_chunk_data(snap, chunk_id),
                             get_chunk_size(snap, chunk_id),
                             sizeof(ChunkViewType<Type>));
@@ -400,7 +400,7 @@ class ThreadSafeChunkVector : public ChunkVectorBase<Type> {
     int64_t
     get_element_size() override {
         std::shared_lock<std::shared_mutex> lck(mutex_);
-        if constexpr (IsMmap && std::is_same_v<std::string, Type>) {
+        if constexpr (IsMmap && IsVariableTypeSupportInChunk<Type>) {
             return sizeof(ChunkViewType<Type>);
         }
         return sizeof(Type);
@@ -433,7 +433,7 @@ class ThreadSafeChunkVector : public ChunkVectorBase<Type> {
     SpanBase
     get_span(int64_t chunk_id) override {
         std::shared_lock<std::shared_mutex> lck(mutex_);
-        if constexpr (IsMmap && std::is_same_v<std::string, Type>) {
+        if constexpr (IsMmap && IsVariableTypeSupportInChunk<Type>) {
             return SpanBase(get_chunk_data(chunk_id),
                             get_chunk_size(chunk_id),
                             sizeof(ChunkViewType<Type>));
@@ -482,14 +482,22 @@ class ThreadSafeChunkVector : public ChunkVectorBase<Type> {
                              src.length(),
                              src.byte_size(),
                              src.get_element_type(),
-                             src.get_offsets_data());
+                             src.get_offsets_data(),
+                             src.is_element_nullable()
+                                 ? src.get_element_valid_data().view()
+                                 : TargetBitmapView(),
+                             src.is_element_nullable());
         } else if constexpr (std::is_same_v<VectorArray, Type>) {
             auto& src = chunk[chunk_offset];
             return VectorArrayView(const_cast<char*>(src.data()),
                                    src.dim(),
                                    src.length(),
                                    src.byte_size(),
-                                   src.get_element_type());
+                                   src.get_element_type(),
+                                   src.is_element_nullable()
+                                       ? src.get_element_valid_data().view()
+                                       : TargetBitmapView(),
+                                   src.is_element_nullable());
         } else if constexpr (std::is_same_v<Json, Type>) {
             return Json(chunk[chunk_offset].c_str(),
                         chunk[chunk_offset].size());

--- a/internal/core/src/mmap/ChunkedColumn.h
+++ b/internal/core/src/mmap/ChunkedColumn.h
@@ -726,6 +726,9 @@ class ChunkedVectorArrayColumn : public ChunkedColumnBase {
             auto chunk =
                 static_cast<VectorArrayChunk*>(ca->get_cell_of(cids[i]));
             auto offset = offsets_in_chunk[i];
+            if (nullable_) {
+                offset = chunk->PhysicalOffsetOf(offset);
+            }
             auto array = chunk->View(offset).output_data();
             fn(std::move(array), i);
         }

--- a/internal/core/src/mmap/ChunkedColumnGroup.h
+++ b/internal/core/src/mmap/ChunkedColumnGroup.h
@@ -760,7 +760,13 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
             op_ctx,
             offsets,
             count,
-            [&fn](Chunk* chunk, int64_t offset_in_chunk, int64_t i) {
+            [this, &fn](Chunk* chunk,
+                        int64_t offset_in_chunk,
+                        int64_t i) {
+                if (field_meta_.is_nullable()) {
+                    offset_in_chunk =
+                        chunk->PhysicalOffsetOf(offset_in_chunk);
+                }
                 auto array = static_cast<VectorArrayChunk*>(chunk)
                                  ->View(offset_in_chunk)
                                  .output_data();

--- a/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
@@ -104,7 +104,8 @@ BuildChunkBuffer(int64_t row_num,
 std::vector<char>
 BuildNullableVectorArrayChunkBuffer() {
     const auto bitmap_bytes = (kVectorArrayRows + 7) / 8;
-    const auto header_bytes = sizeof(uint32_t) * (kVectorArrayRows * 2 + 1);
+    constexpr int64_t valid_rows = 3;
+    const auto header_bytes = sizeof(uint32_t) * (valid_rows * 2 + 1);
     const std::array<float, 6> payload{1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F};
     const auto payload_bytes = payload.size() * sizeof(float);
 
@@ -118,11 +119,9 @@ BuildNullableVectorArrayChunkBuffer() {
         payload_offset + static_cast<uint32_t>(kVectorArrayDim * sizeof(float));
     const auto row3_end =
         row0_end + static_cast<uint32_t>(2 * kVectorArrayDim * sizeof(float));
-    const std::array<uint32_t, kVectorArrayRows * 2 + 1> header{
+    const std::array<uint32_t, valid_rows * 2 + 1> header{
         payload_offset,
         1,
-        row0_end,
-        0,
         row0_end,
         0,
         row0_end,
@@ -152,7 +151,8 @@ MakeVectorArrayChunk(char* data, size_t size) {
                                               size,
                                               DataType::VECTOR_FLOAT,
                                               guard,
-                                              /*nullable=*/true);
+                                              /*nullable=*/true,
+                                              /*element_nullable=*/false);
 }
 
 class CountingChunkTranslator : public TestChunkTranslator {

--- a/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
@@ -579,7 +579,9 @@ TEST(test_chunk_segment,
     auto field_meta = schema->operator[](vec_id);
 
     const auto bitmap_bytes = (row_count + 7) / 8;
-    const auto header_bytes = sizeof(uint32_t) * (row_count * 2 + 1);
+    constexpr int64_t valid_row_count = 5;
+    const auto header_bytes =
+        sizeof(uint32_t) * (valid_row_count * 2 + 1);
     const auto payload_offset =
         static_cast<uint32_t>(bitmap_bytes + header_bytes);
     const auto vector_bytes = static_cast<uint32_t>(dim * sizeof(float));
@@ -592,9 +594,7 @@ TEST(test_chunk_segment,
 
     // Logical rows: [NULL, [], [A], [B], [], [C]].
     buffer[0] = 0b00111110;
-    const std::array<uint32_t, row_count * 2 + 1> header{
-        payload_offset,
-        0,
+    const std::array<uint32_t, valid_row_count * 2 + 1> header{
         payload_offset,
         0,
         payload_offset,
@@ -622,7 +622,8 @@ TEST(test_chunk_segment,
                                            buffer.size(),
                                            DataType::VECTOR_FLOAT,
                                            chunk_mmap_guard,
-                                           true));
+                                           true,
+                                           false));
     auto translator = std::make_unique<TestChunkTranslator>(
         std::vector<int64_t>{row_count}, "", std::move(chunks));
     auto slot =


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/51162

Extends array chunk writers, layouts, and mmap readers to store and expose per-element validity.