### PR TITLE
feat: [ElementNull 5] preserve array element validity in segment data paths

### DIFF
--- a/internal/core/src/segcore/ConcurrentVector.cpp
+++ b/internal/core/src/segcore/ConcurrentVector.cpp
@@ -68,7 +68,9 @@ VectorBase::set_data_raw(ssize_t element_offset,
                 if (vector_array.size() == element_count) {
                     for (ssize_t i = 0; i < element_count; ++i) {
                         if (valid_data[i]) {
-                            data_raw.emplace_back(VectorArray(vector_array[i]));
+                            data_raw.emplace_back(
+                                vector_array[i],
+                                field_meta.is_element_nullable());
                         }
                     }
                 } else {
@@ -79,7 +81,8 @@ VectorBase::set_data_raw(ssize_t element_offset,
                         vector_array.size(),
                         valid_count);
                     for (auto& e : vector_array) {
-                        data_raw.emplace_back(VectorArray(e));
+                        data_raw.emplace_back(e,
+                                              field_meta.is_element_nullable());
                     }
                 }
             } else {
@@ -90,7 +93,7 @@ VectorBase::set_data_raw(ssize_t element_offset,
                            element_count);
                 data_raw.reserve(vector_array.size());
                 for (auto& e : vector_array) {
-                    data_raw.emplace_back(VectorArray(e));
+                    data_raw.emplace_back(e, field_meta.is_element_nullable());
                 }
             }
             return set_data_raw(element_offset, data_raw.data(), element_count);
@@ -169,10 +172,44 @@ VectorBase::set_data_raw(ssize_t element_offset,
         }
         case DataType::ARRAY: {
             auto& array_data = FIELD_DATA(data, array);
-            std::vector<Array> data_raw{};
-            data_raw.reserve(array_data.size());
-            for (auto& array_bytes : array_data) {
-                data_raw.emplace_back(Array(array_bytes));
+            const auto& valid_data = GetFieldDataRowValidData(*data);
+            std::vector<Array> data_raw(element_count);
+            if (field_meta.is_nullable() &&
+                valid_data.size() == element_count) {
+                ssize_t valid_count =
+                    std::count(valid_data.begin(), valid_data.end(), true);
+                auto dense_aligned = array_data.size() == element_count;
+                auto compact_nullable = array_data.size() == valid_count;
+                AssertInfo(
+                    dense_aligned || compact_nullable,
+                    "nullable ARRAY data size {} must match element count {} "
+                    "or valid row count {}",
+                    array_data.size(),
+                    element_count,
+                    valid_count);
+                compact_nullable = compact_nullable && !dense_aligned;
+
+                ssize_t physical_row = 0;
+                for (ssize_t logical_row = 0; logical_row < element_count;
+                     ++logical_row) {
+                    if (!valid_data[logical_row]) {
+                        continue;
+                    }
+                    auto source_index =
+                        compact_nullable ? physical_row++ : logical_row;
+                    data_raw[logical_row] =
+                        Array(array_data.Get(source_index),
+                              field_meta.is_element_nullable());
+                }
+            } else {
+                AssertInfo(array_data.size() == element_count,
+                           "ARRAY data size {} must match element count {}",
+                           array_data.size(),
+                           element_count);
+                for (ssize_t i = 0; i < element_count; ++i) {
+                    data_raw[i] = Array(array_data.Get(i),
+                                        field_meta.is_element_nullable());
+                }
             }
 
             return set_data_raw(element_offset, data_raw.data(), element_count);

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -98,6 +98,36 @@ using namespace milvus::cachinglayer;
 
 namespace {
 
+int32_t
+GetScalarArrayLength(const proto::schema::ScalarField& array_value,
+                     DataType element_type) {
+    switch (element_type) {
+        case DataType::BOOL:
+            return array_value.bool_data().data_size();
+        case DataType::INT8:
+        case DataType::INT16:
+        case DataType::INT32:
+            return array_value.int_data().data_size();
+        case DataType::INT64:
+            return array_value.long_data().data_size();
+        case DataType::FLOAT:
+            return array_value.float_data().data_size();
+        case DataType::DOUBLE:
+            return array_value.double_data().data_size();
+        case DataType::TIMESTAMPTZ:
+            return array_value.timestamptz_data().data_size();
+        case DataType::STRING:
+        case DataType::VARCHAR:
+        case DataType::TEXT:
+            return array_value.string_data().data_size();
+        default:
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      "Unexpected array type: {}",
+                      element_type);
+    }
+    return 0;
+}
+
 int64_t
 GetLoadedFieldRows(
     const std::vector<std::unordered_map<FieldId, std::vector<FieldDataPtr>>>&
@@ -283,45 +313,83 @@ ExtractArrayLengths(const proto::schema::FieldData& field_data,
             AssertInfo(source_index < vector_array.data_size(),
                        "VECTOR_ARRAY row {} is missing from field data",
                        source_index);
-            array_lengths[i] = GetVectorArrayLength(
-                vector_array.data(source_index), element_type, dim);
+            const auto& row = vector_array.data(source_index);
+            auto physical_length = GetVectorArrayLength(row, element_type, dim);
+            if (field_meta.is_element_nullable()) {
+                auto valid_count = std::count(
+                    row.valid_data().begin(), row.valid_data().end(), true);
+                AssertInfo(
+                    valid_count == physical_length,
+                    "VECTOR_ARRAY row {} valid element count {} does not match "
+                    "physical vector count {}",
+                    source_index,
+                    valid_count,
+                    physical_length);
+                array_lengths[i] = row.valid_data_size();
+            } else {
+                AssertInfo(row.valid_data_size() == 0,
+                           "non-element-nullable VECTOR_ARRAY row {} cannot "
+                           "carry element valid_data",
+                           source_index);
+                array_lengths[i] = physical_length;
+            }
         }
     } else {
-        // ARRAY: extract from scalars().array_data().data(i)
         const auto& array_data = field_data.scalars().array_data();
         auto element_type = field_meta.get_element_type();
+        bool compact_nullable = false;
+        if (field_meta.is_nullable()) {
+            int64_t valid_count = 0;
+            if (valid_data.size() == num_rows) {
+                valid_count =
+                    std::count(valid_data.begin(), valid_data.end(), true);
+            }
+            auto dense_aligned = array_data.data_size() == num_rows;
+            compact_nullable = valid_data.size() == num_rows &&
+                               array_data.data_size() == valid_count;
+            AssertInfo(
+                dense_aligned || compact_nullable,
+                "nullable ARRAY supports only dense-aligned data "
+                "(data_size == num_rows) or compact data "
+                "(valid_data_size == num_rows and data_size == valid_count), "
+                "got data_size {}, valid_data_size {}, num_rows {}, "
+                "valid_count {}",
+                array_data.data_size(),
+                valid_data.size(),
+                num_rows,
+                valid_count);
+            compact_nullable = compact_nullable && !dense_aligned;
+        } else {
+            AssertInfo(
+                array_data.data_size() == num_rows,
+                "non-nullable ARRAY data size {} must match row count {}",
+                array_data.data_size(),
+                num_rows);
+        }
+
+        int64_t physical_row = 0;
+        auto has_valid_data = valid_data.size() == num_rows;
 
         for (int i = 0; i < num_rows; ++i) {
-            int32_t array_len = 0;
-
-            switch (element_type) {
-                case DataType::BOOL:
-                    array_len = array_data.data(i).bool_data().data_size();
-                    break;
-                case DataType::INT8:
-                case DataType::INT16:
-                case DataType::INT32:
-                    array_len = array_data.data(i).int_data().data_size();
-                    break;
-                case DataType::INT64:
-                    array_len = array_data.data(i).long_data().data_size();
-                    break;
-                case DataType::FLOAT:
-                    array_len = array_data.data(i).float_data().data_size();
-                    break;
-                case DataType::DOUBLE:
-                    array_len = array_data.data(i).double_data().data_size();
-                    break;
-                case DataType::STRING:
-                case DataType::VARCHAR:
-                    array_len = array_data.data(i).string_data().data_size();
-                    break;
-                default:
-                    ThrowInfo(ErrorCode::UnexpectedError,
-                              "Unexpected array type: {}",
-                              element_type);
+            if (field_meta.is_nullable() && has_valid_data && !valid_data[i]) {
+                array_lengths[i] = 0;
+                continue;
             }
 
+            auto source_index = compact_nullable ? physical_row++ : i;
+            AssertInfo(source_index < array_data.data_size(),
+                       "ARRAY row {} is missing from field data",
+                       source_index);
+            const auto& row = array_data.data(source_index);
+            auto array_len = GetScalarArrayLength(row, element_type);
+            AssertInfo(field_meta.is_element_nullable()
+                           ? row.valid_data_size() == array_len
+                           : row.valid_data_size() == 0,
+                       "ARRAY row {} element valid_data size {} does not match "
+                       "schema and logical element count {}",
+                       source_index,
+                       row.valid_data_size(),
+                       array_len);
             array_lengths[i] = array_len;
         }
     }
@@ -960,6 +1028,7 @@ SegmentGrowingImpl::load_field_data_internal(const LoadFieldDataInfo& infos) {
                 storage::CreateFieldData(field_meta.get_data_type(),
                                          field_meta.get_element_type(),
                                          true,
+                                         field_meta.is_element_nullable(),
                                          1,
                                          lack_num);
             field_data->FillFieldData(field_meta.default_value(), lack_num);
@@ -1242,6 +1311,7 @@ SegmentGrowingImpl::load_column_group_data_internal(
                             data_type,
                             field.second.get_element_type(),
                             field.second.is_nullable(),
+                            field.second.is_element_nullable(),
                             IsVectorDataType(data_type) &&
                                     !IsSparseFloatVectorDataType(data_type)
                                 ? field.second.get_dim()
@@ -1423,8 +1493,82 @@ SegmentGrowingImpl::chunk_array_view_impl(
     FieldId field_id,
     int64_t chunk_id,
     std::optional<std::pair<int64_t, int64_t>> offset_len) const {
-    ThrowInfo(ErrorCode::NotImplemented,
-              "chunk array view impl not implement for growing segment");
+    (void)op_ctx;
+
+    auto schema = get_schema_snapshot();
+    auto& field_meta = schema->operator[](field_id);
+    AssertInfo(field_meta.get_data_type() == DataType::ARRAY,
+               "chunk_array_view_impl only supports ARRAY field");
+
+    auto array_data = insert_record_.get_data<Array>(field_id);
+    auto size_per_chunk = array_data->get_size_per_chunk();
+    auto active_count = insert_record_.ack_responder_.GetAck();
+    auto start_offset = int64_t{0};
+    auto len = size_per_chunk;
+    if (offset_len.has_value()) {
+        start_offset = offset_len->first;
+        len = offset_len->second;
+    }
+
+    AssertInfo(
+        start_offset >= 0 && start_offset < size_per_chunk,
+        "Retrieve array views with out-of-bound offset:{}, len:{}, wrong",
+        start_offset,
+        len);
+    AssertInfo(
+        len >= 0 && len <= size_per_chunk,
+        "Retrieve array views with out-of-bound offset:{}, len:{}, wrong",
+        start_offset,
+        len);
+    AssertInfo(
+        start_offset + len <= size_per_chunk,
+        "Retrieve array views with out-of-bound offset:{}, len:{}, wrong",
+        start_offset,
+        len);
+
+    auto logical_start = chunk_id * size_per_chunk + start_offset;
+    AssertInfo(
+        logical_start >= 0 && logical_start <= active_count,
+        "Retrieve array views with out-of-bound offset:{}, len:{}, wrong",
+        start_offset,
+        len);
+    if (offset_len.has_value()) {
+        AssertInfo(
+            logical_start + len <= active_count,
+            "Retrieve array views with out-of-bound offset:{}, len:{}, wrong",
+            start_offset,
+            len);
+    } else {
+        len = std::min(len, active_count - logical_start);
+    }
+
+    std::vector<ArrayView> views;
+    views.reserve(len);
+    FixedVector<bool> valid_data;
+    std::unique_ptr<bool[]> row_valid;
+    if (field_meta.is_nullable()) {
+        valid_data.reserve(len);
+        row_valid = std::make_unique<bool[]>(len);
+        insert_record_.get_valid_data(field_id)->bulk_is_valid_range(
+            logical_start, len, row_valid.get());
+    }
+
+    for (int64_t i = 0; i < len; ++i) {
+        const bool valid = !row_valid || row_valid[i];
+        if (field_meta.is_nullable()) {
+            valid_data.push_back(valid);
+        }
+        if (valid) {
+            views.emplace_back(array_data->view_element(logical_start + i));
+        } else {
+            views.emplace_back();
+        }
+    }
+
+    std::pair<std::vector<ArrayView>, FixedVector<bool>> content{
+        std::move(views), std::move(valid_data)};
+    return PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>(
+        std::move(content));
 }
 
 PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
@@ -1524,7 +1668,11 @@ SegmentGrowingImpl::chunk_vector_array_view_impl(
                            vector_array->dim(),
                            vector_array->length(),
                            vector_array->byte_size(),
-                           vector_array->get_element_type());
+                           vector_array->get_element_type(),
+                           vector_array->is_element_nullable()
+                               ? vector_array->get_element_valid_data().view()
+                               : TargetBitmapView(),
+                           vector_array->is_element_nullable());
     }
 
     std::pair<std::vector<VectorArrayView>, FixedVector<bool>> content{
@@ -1550,9 +1698,54 @@ SegmentGrowingImpl::chunk_array_views_by_offsets(
     FieldId field_id,
     int64_t chunk_id,
     const FixedVector<int32_t>& offsets) const {
-    ThrowInfo(
-        ErrorCode::NotImplemented,
-        "chunk array views by offsets not implemented for growing segment");
+    (void)op_ctx;
+
+    auto schema = get_schema_snapshot();
+    auto& field_meta = schema->operator[](field_id);
+    AssertInfo(field_meta.get_data_type() == DataType::ARRAY,
+               "chunk_array_views_by_offsets only supports ARRAY field");
+
+    auto array_data = insert_record_.get_data<Array>(field_id);
+    auto size_per_chunk = array_data->get_size_per_chunk();
+    auto active_count = insert_record_.ack_responder_.GetAck();
+    std::vector<int64_t> logical_offsets(offsets.size());
+    for (size_t i = 0; i < offsets.size(); ++i) {
+        AssertInfo(offsets[i] >= 0 && offsets[i] < size_per_chunk,
+                   "Retrieve array view with out-of-bound chunk offset:{}",
+                   offsets[i]);
+        logical_offsets[i] = chunk_id * size_per_chunk + offsets[i];
+        AssertInfo(logical_offsets[i] < active_count,
+                   "Retrieve array view with out-of-bound segment offset:{}",
+                   logical_offsets[i]);
+    }
+
+    std::vector<ArrayView> views;
+    views.reserve(offsets.size());
+    FixedVector<bool> valid_data;
+    std::unique_ptr<bool[]> row_valid;
+    if (field_meta.is_nullable()) {
+        valid_data.reserve(offsets.size());
+        row_valid = std::make_unique<bool[]>(offsets.size());
+        insert_record_.get_valid_data(field_id)->bulk_is_valid(
+            logical_offsets.data(), logical_offsets.size(), row_valid.get());
+    }
+
+    for (size_t i = 0; i < logical_offsets.size(); ++i) {
+        const bool valid = !row_valid || row_valid[i];
+        if (field_meta.is_nullable()) {
+            valid_data.push_back(valid);
+        }
+        if (valid) {
+            views.emplace_back(array_data->view_element(logical_offsets[i]));
+        } else {
+            views.emplace_back();
+        }
+    }
+
+    std::pair<std::vector<ArrayView>, FixedVector<bool>> content{
+        std::move(views), std::move(valid_data)};
+    return PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>(
+        std::move(content));
 }
 
 int64_t
@@ -2118,7 +2311,7 @@ SegmentGrowingImpl::bulk_subscript_array_impl(
     for (int64_t i = 0; i < count; ++i) {
         auto offset = seg_offsets[i];
         if (offset != INVALID_SEG_OFFSET) {
-            dst->at(i) = vec[offset].output_data();
+            dst->at(i) = vec.view_element(offset).output_data();
         }
     }
 }
@@ -2306,7 +2499,7 @@ SegmentGrowingImpl::bulk_subscript(milvus::OpContext* op_ctx,
             for (int64_t i = 0; i < count; ++i) {
                 auto offset = seg_offsets[i];
                 if (offset != INVALID_SEG_OFFSET) {
-                    dst[i] = src[offset];
+                    src.view_element(offset).output_data(dst[i]);
                 } else {
                     dst[i] =
                         Array();  // Default-construct empty Array for invalid offsets
@@ -3071,6 +3264,7 @@ SegmentGrowingImpl::LoadColumnGroup(
                     data_type,
                     field.get_element_type(),
                     field.is_nullable(),
+                    field.is_element_nullable(),
                     IsVectorDataType(data_type) &&
                             !IsSparseFloatVectorDataType(data_type)
                         ? field.get_dim()

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -440,8 +440,10 @@ class SegmentInternalInterface : public SegmentInterface {
                     int64_t start_offset,
                     int64_t length) const {
         if (this->type() == SegmentType::Growing) {
-            ThrowInfo(ErrorCode::Unsupported,
-                      "get chunk views not supported for growing segment");
+            if constexpr (!std::is_same_v<ViewType, ArrayView>) {
+                ThrowInfo(ErrorCode::Unsupported,
+                          "get chunk views not supported for growing segment");
+            }
         }
         return chunk_view<ViewType>(
             op_ctx, field_id, chunk_id, std::make_pair(start_offset, length));
@@ -454,8 +456,11 @@ class SegmentInternalInterface : public SegmentInterface {
                          int64_t chunk_id,
                          const FixedVector<int32_t>& offsets) const {
         if (this->type() == SegmentType::Growing) {
-            ThrowInfo(ErrorCode::Unsupported,
-                      "get chunk views not supported for growing segment");
+            if constexpr (!std::is_same_v<ViewType, ArrayView>) {
+                ThrowInfo(
+                    ErrorCode::Unsupported,
+                    "get chunk views not supported for growing segment");
+            }
         }
         if constexpr (std::is_same_v<ViewType, std::string_view>) {
             return chunk_string_views_by_offsets(

--- a/internal/core/src/segcore/flush_growing_segment_test.cpp
+++ b/internal/core/src/segcore/flush_growing_segment_test.cpp
@@ -73,12 +73,14 @@ class FlushGrowingSegmentTest : public ::testing::Test {
                          DataType data_type,
                          bool nullable,
                          int64_t dim,
-                         DataType element_type = DataType::NONE) {
+                         DataType element_type = DataType::NONE,
+                         bool element_nullable = false) {
         auto properties =
             storage::LoonFFIPropertiesSingleton::GetInstance().GetProperties();
         EXPECT_NE(properties, nullptr);
         auto field_meta = gen_field_meta(
             1, 2, 3, field_id.get(), data_type, element_type, nullable);
+        field_meta.field_schema.set_element_nullable(element_nullable);
         std::string manifest_json =
             "{\"base_path\":\"" + segment_path +
             "\",\"ver\":" + std::to_string(result.committed_version) + "}";
@@ -2985,6 +2987,7 @@ TEST_F(FlushGrowingSegmentTest, FlushNullableEmbListMixedRows) {
     // chunk_rows=1: the two physically stored rows land in separate physical
     // chunks, so the flush walk crosses a chunk boundary in compact storage
     // while the logical walk still sees three rows.
+    ScopedSegcoreConfigRestore config_restore;
     SegcoreConfig segcore_config;
     segcore_config.set_chunk_rows(1);
     auto segment =
@@ -3046,6 +3049,142 @@ TEST_F(FlushGrowingSegmentTest, FlushNullableEmbListMixedRows) {
     ASSERT_EQ(target_out.float_vector().data_size(), dim);
     for (int d = 0; d < dim; ++d) {
         EXPECT_FLOAT_EQ(target_out.float_vector().data(d), 1.0f + d);
+    }
+
+    FreeFlushResult(&result);
+}
+
+TEST_F(FlushGrowingSegmentTest, FlushElementNullableEmbListMixedRows) {
+    auto schema = std::make_shared<Schema>();
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    constexpr int dim = 4;
+    auto vec_fid = schema->AddDebugVectorArrayField("structA[array_vec]",
+                                                    DataType::VECTOR_FLOAT,
+                                                    dim,
+                                                    "L2",
+                                                    true,
+                                                    true);
+    schema->set_primary_field_id(pk_fid);
+
+    constexpr int64_t N = 4;
+    VectorFieldProto empty_row;
+    empty_row.set_dim(dim);
+    empty_row.mutable_float_vector();
+
+    VectorFieldProto mixed_row;
+    mixed_row.set_dim(dim);
+    for (int d = 0; d < dim; ++d) {
+        mixed_row.mutable_float_vector()->add_data(20.0F + d);
+    }
+    mixed_row.add_valid_data(false);
+    mixed_row.add_valid_data(true);
+    mixed_row.add_valid_data(false);
+
+    VectorFieldProto valid_row;
+    valid_row.set_dim(dim);
+    for (int vector_idx = 0; vector_idx < 2; ++vector_idx) {
+        for (int d = 0; d < dim; ++d) {
+            valid_row.mutable_float_vector()->add_data(
+                30.0F + vector_idx * dim + d);
+        }
+        valid_row.add_valid_data(true);
+    }
+
+    auto dataset = DataGen(schema, N, 42, 0, 1, 1);
+    for (int i = 0; i < dataset.raw_->fields_data_size(); ++i) {
+        auto* field_data = dataset.raw_->mutable_fields_data(i);
+        if (field_data->field_id() != vec_fid.get()) {
+            continue;
+        }
+        auto* rows = field_data->mutable_vectors()
+                         ->mutable_vector_array()
+                         ->mutable_data();
+        rows->Clear();
+        *rows->Add() = empty_row;  // row 0: null row placeholder
+        *rows->Add() = empty_row;  // row 1: valid empty row
+        *rows->Add() = mixed_row;  // row 2: [null, vector, null]
+        *rows->Add() = valid_row;  // row 3: [vector, vector]
+
+        field_data->clear_valid_data();
+        auto* row_valid_data =
+            field_data->mutable_vectors()->mutable_valid_data();
+        row_valid_data->Clear();
+        row_valid_data->Add(false);
+        row_valid_data->Add(true);
+        row_valid_data->Add(true);
+        row_valid_data->Add(true);
+        break;
+    }
+
+    ScopedSegcoreConfigRestore config_restore;
+    SegcoreConfig segcore_config;
+    segcore_config.set_chunk_rows(1);
+    auto segment =
+        CreateGrowingSegment(schema, empty_index_meta, 1, segcore_config);
+    ASSERT_NE(segment, nullptr);
+    segment->PreInsert(N);
+    segment->Insert(0,
+                    N,
+                    dataset.row_ids_.data(),
+                    dataset.timestamps_.data(),
+                    dataset.raw_);
+
+    C_FLUSH_CONFIG_WITH_SCHEMA(config, schema);
+    std::string segment_path = test_dir_ + "/segment_element_nullable_emblist";
+    config.segment_path = segment_path.c_str();
+    config.read_version = -1;
+    config.retry_limit = 3;
+    config.text_field_ids = nullptr;
+    config.text_lob_paths = nullptr;
+    config.num_text_columns = 0;
+
+    CFlushResult result{};
+    auto status =
+        FlushGrowingSegmentData(segment.get(), 0, N, &config, &result);
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
+    ASSERT_EQ(result.num_rows, N);
+
+    auto field_datas = ReadFlushedFieldData(segment_path,
+                                            result,
+                                            vec_fid,
+                                            DataType::VECTOR_ARRAY,
+                                            true,
+                                            dim,
+                                            DataType::VECTOR_FLOAT,
+                                            true);
+    ASSERT_EQ(field_datas.size(), 1);
+    auto vector_array_data =
+        std::dynamic_pointer_cast<milvus::FieldData<milvus::VectorArray>>(
+            field_datas[0]);
+    ASSERT_NE(vector_array_data, nullptr);
+    ASSERT_EQ(vector_array_data->get_num_rows(), N);
+    ASSERT_EQ(vector_array_data->get_valid_rows(), 3);
+    EXPECT_FALSE(vector_array_data->is_valid(0));
+    EXPECT_TRUE(vector_array_data->is_valid(1));
+    EXPECT_TRUE(vector_array_data->is_valid(2));
+    EXPECT_TRUE(vector_array_data->is_valid(3));
+
+    const auto* restored_empty = vector_array_data->value_at(0);
+    ASSERT_TRUE(restored_empty->is_element_nullable());
+    EXPECT_EQ(restored_empty->length(), 0);
+
+    const auto* restored_mixed = vector_array_data->value_at(1);
+    ASSERT_EQ(restored_mixed->length(), 3);
+    EXPECT_FALSE(restored_mixed->is_element_valid(0));
+    EXPECT_TRUE(restored_mixed->is_element_valid(1));
+    EXPECT_FALSE(restored_mixed->is_element_valid(2));
+    for (int d = 0; d < dim; ++d) {
+        EXPECT_FLOAT_EQ(restored_mixed->get_data<float>(1)[d], 20.0F + d);
+    }
+
+    const auto* restored_valid = vector_array_data->value_at(2);
+    ASSERT_EQ(restored_valid->length(), 2);
+    for (int vector_idx = 0; vector_idx < 2; ++vector_idx) {
+        EXPECT_TRUE(restored_valid->is_element_valid(vector_idx));
+        for (int d = 0; d < dim; ++d) {
+            EXPECT_FLOAT_EQ(restored_valid->get_data<float>(vector_idx)[d],
+                            30.0F + vector_idx * dim + d);
+        }
     }
 
     FreeFlushResult(&result);

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -879,6 +879,7 @@ struct FieldInfo {
     milvus::DataType data_type;
     milvus::DataType element_type;
     bool nullable;
+    bool element_nullable;
     int64_t dim;  // for vector types
     const milvus::segcore::VectorBase* vec_base;
     milvus::segcore::ThreadSafeValidDataPtr valid_data;
@@ -1437,11 +1438,29 @@ BuildVectorArrayForChunk(const FieldInfo& field_info,
         if (vector_array.dim() != field_info.dim) {
             return arrow::Status::Invalid("VECTOR_ARRAY dim mismatch");
         }
+        if (vector_array.is_element_nullable() !=
+            field_info.element_nullable) {
+            return arrow::Status::Invalid(
+                "VECTOR_ARRAY element nullable mismatch");
+        }
 
         ARROW_RETURN_NOT_OK(builder.Append());
-        ARROW_RETURN_NOT_OK(value_builder->AppendValues(
-            reinterpret_cast<const uint8_t*>(vector_array.data()),
-            vector_array.length()));
+        if (field_info.element_nullable) {
+            for (int j = 0; j < vector_array.length(); ++j) {
+                auto data = reinterpret_cast<const uint8_t*>(
+                                vector_array.data()) +
+                            j * byte_width;
+                if (vector_array.is_element_valid(j)) {
+                    ARROW_RETURN_NOT_OK(value_builder->Append(data));
+                } else {
+                    ARROW_RETURN_NOT_OK(value_builder->AppendNull());
+                }
+            }
+        } else {
+            ARROW_RETURN_NOT_OK(value_builder->AppendValues(
+                reinterpret_cast<const uint8_t*>(vector_array.data()),
+                vector_array.length()));
+        }
     }
 
     return builder.Finish();
@@ -2118,6 +2137,7 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
             info.data_type = data_type;
             info.element_type = field_meta.get_element_type();
             info.nullable = field_meta.is_nullable();
+            info.element_nullable = field_meta.is_element_nullable();
             info.dim = dim;
             info.vec_base = vec_base;
             info.valid_data = nullptr;

--- a/internal/core/unittest/test_utils/DataGen.h
+++ b/internal/core/unittest/test_utils/DataGen.h
@@ -1437,35 +1437,42 @@ CreateFieldDataFromDataArray(ssize_t raw_count,
     FieldDataPtr field_data = nullptr;
 
     auto element_type = field_meta.get_element_type();
+    auto element_nullable = field_meta.is_element_nullable();
     const auto& row_valid_data = GetFieldDataRowValidData(*data);
     auto createFieldData =
-        [&field_data, &raw_count, &element_type](
+        [&field_data, &raw_count, &element_type, element_nullable](
             const void* raw_data, DataType data_type, int64_t dim) {
-            field_data =
-                storage::CreateFieldData(data_type, element_type, false, dim);
+            field_data = storage::CreateFieldData(data_type,
+                                                  element_type,
+                                                  false,
+                                                  element_nullable,
+                                                  dim,
+                                                  0);
             field_data->FillFieldData(raw_data, raw_count);
         };
-    auto createNullableFieldData = [&field_data, &raw_count, &element_type](
-                                       const void* raw_data,
-                                       const bool* raw_valid_data,
-                                       DataType data_type,
-                                       int64_t dim) {
-        field_data =
-            storage::CreateFieldData(data_type, element_type, true, dim);
-        int byteSize = (raw_count + 7) / 8;
-        std::vector<uint8_t> valid_data(byteSize);
-        for (int i = 0; i < raw_count; i++) {
-            bool value = raw_valid_data[i];
-            int byteIndex = i / 8;
-            int bitIndex = i % 8;
-            if (value) {
-                valid_data[byteIndex] |= (1 << bitIndex);
-            } else {
-                valid_data[byteIndex] &= ~(1 << bitIndex);
+    auto createNullableFieldData =
+        [&field_data, &raw_count, &element_type, element_nullable](
+            const void* raw_data,
+            const bool* raw_valid_data,
+            DataType data_type,
+            int64_t dim) {
+            field_data = storage::CreateFieldData(
+                data_type, element_type, true, element_nullable, dim, 0);
+            int byteSize = (raw_count + 7) / 8;
+            std::vector<uint8_t> valid_data(byteSize);
+            for (int i = 0; i < raw_count; i++) {
+                bool value = raw_valid_data[i];
+                int byteIndex = i / 8;
+                int bitIndex = i % 8;
+                if (value) {
+                    valid_data[byteIndex] |= (1 << bitIndex);
+                } else {
+                    valid_data[byteIndex] &= ~(1 << bitIndex);
+                }
             }
-        }
-        field_data->FillFieldData(raw_data, valid_data.data(), raw_count, 0);
-    };
+            field_data->FillFieldData(
+                raw_data, valid_data.data(), raw_count, 0);
+        };
 
     if (field_meta.is_vector()) {
         switch (field_meta.get_data_type()) {
@@ -1511,7 +1518,8 @@ CreateFieldDataFromDataArray(ssize_t raw_count,
                 auto dim = field_meta.get_dim();
                 std::vector<VectorArray> data_raw(src_data.size());
                 for (int i = 0; i < src_data.size(); i++) {
-                    data_raw[i] = VectorArray(src_data.at(i));
+                    data_raw[i] =
+                        VectorArray(src_data.at(i), element_nullable);
                 }
                 createFieldData(data_raw.data(), DataType::VECTOR_ARRAY, dim);
                 break;
@@ -1668,7 +1676,7 @@ CreateFieldDataFromDataArray(ssize_t raw_count,
                 auto src_data = data->scalars().array_data().data();
                 std::vector<Array> data_raw(src_data.size());
                 for (int i = 0; i < src_data.size(); i++) {
-                    data_raw[i] = Array(src_data.at(i));
+                    data_raw[i] = Array(src_data.at(i), element_nullable);
                 }
                 if (field_meta.is_nullable()) {
                     auto raw_valid_data = row_valid_data.data();


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/51162

Carries element validity through growing and sealed segment insertion, loading, retrieval, and flushing.