### PR TITLE
feat: [ElementNull 8] support null elements in array-of-vector search

### DIFF
--- a/internal/core/src/index/VectorMemIndex.cpp
+++ b/internal/core/src/index/VectorMemIndex.cpp
@@ -575,7 +575,7 @@ VectorMemIndex<T>::Build(const Config& config) {
             BuildValidData(valid_data.get(), total_num_rows);
             return;
         }
-        auto buf = std::shared_ptr<uint8_t[]>(new uint8_t[total_size]);
+        std::shared_ptr<uint8_t[]> buf;
 
         size_t lim_offset = 0;
         std::vector<size_t> offsets;
@@ -583,6 +583,7 @@ VectorMemIndex<T>::Build(const Config& config) {
         int64_t offset = 0;
         // For embedding list index, elem_type_ is not NONE
         if (elem_type_ == DataType::NONE) {
+            buf = std::shared_ptr<uint8_t[]>(new uint8_t[total_size]);
             // TODO: avoid copying
             for (auto& data : field_datas) {
                 auto valid_size = data->DataSize();
@@ -595,6 +596,31 @@ VectorMemIndex<T>::Build(const Config& config) {
             offsets.reserve((nullable ? total_valid_rows : total_num_rows) + 1);
             offsets.push_back(lim_offset);
             auto bytes_per_vec = vector_bytes_per_element(elem_type_, dim);
+            total_size = 0;
+            for (const auto& data : field_datas) {
+                auto vec_array_data =
+                    dynamic_cast<FieldData<VectorArray>*>(data.get());
+                AssertInfo(vec_array_data != nullptr,
+                           "failed to cast field data to vector array");
+                for (int64_t physical_row = 0;
+                     physical_row < vec_array_data->get_valid_rows();
+                     ++physical_row) {
+                    const auto* vec_array =
+                        vec_array_data->value_at(physical_row);
+                    if (!vec_array->has_invalid_element()) {
+                        total_size += vec_array->byte_size();
+                        continue;
+                    }
+                    for (int64_t elem_idx = 0;
+                         elem_idx < vec_array->length();
+                         ++elem_idx) {
+                        if (vec_array->is_element_valid(elem_idx)) {
+                            total_size += bytes_per_vec;
+                        }
+                    }
+                }
+            }
+            buf = std::shared_ptr<uint8_t[]>(new uint8_t[total_size]);
             for (auto& data : field_datas) {
                 auto vec_array_data =
                     dynamic_cast<FieldData<VectorArray>*>(data.get());
@@ -602,32 +628,44 @@ VectorMemIndex<T>::Build(const Config& config) {
                            "failed to cast field data to vector array");
 
                 auto rows = vec_array_data->get_num_rows();
-                auto data_offset_before = offset;
                 int64_t physical_row = 0;
                 for (auto i = 0; i < rows; ++i) {
                     if (vec_array_data->IsNullable() &&
                         !vec_array_data->is_valid(i)) {
                         continue;
                     }
-                    auto size = vec_array_data->DataSize(physical_row);
-                    assert(size % bytes_per_vec == 0);
                     assert(bytes_per_vec != 0);
 
                     auto vec_array = vec_array_data->value_at(physical_row);
-
-                    if (size > 0) {
-                        milvus::fastmem::FastMemcpy(
-                            buf.get() + offset, vec_array->data(), size);
+                    int64_t valid_vectors = 0;
+                    if (!vec_array->has_invalid_element()) {
+                        auto size = vec_array->byte_size();
+                        if (size > 0) {
+                            milvus::fastmem::FastMemcpy(
+                                buf.get() + offset, vec_array->data(), size);
+                        }
+                        offset += size;
+                        valid_vectors = vec_array->length();
+                    } else {
+                        for (int64_t elem_idx = 0;
+                             elem_idx < vec_array->length();
+                             ++elem_idx) {
+                            if (!vec_array->is_element_valid(elem_idx)) {
+                                continue;
+                            }
+                            milvus::fastmem::FastMemcpy(
+                                buf.get() + offset,
+                                vec_array->data() + elem_idx * bytes_per_vec,
+                                bytes_per_vec);
+                            offset += bytes_per_vec;
+                            ++valid_vectors;
+                        }
                     }
-                    offset += size;
 
-                    lim_offset += size / bytes_per_vec;
+                    lim_offset += valid_vectors;
                     offsets.push_back(lim_offset);
                     physical_row++;
                 }
-
-                AssertInfo(data->DataSize() == offset - data_offset_before,
-                           "inconsistent vector array data size");
 
                 data.reset();
             }

--- a/internal/core/src/query/SearchOnGrowing.cpp
+++ b/internal/core/src/query/SearchOnGrowing.cpp
@@ -93,6 +93,49 @@ RunAfterChunkSnapshotHookForTest() {
     }
 }
 
+TargetBitmap
+BuildGrowingVectorArrayInvalidElementFilter(
+    const segcore::VectorBase* vec_data,
+    const ChunkSnapshot& chunks,
+    const milvus::IArrayOffsets& array_offsets,
+    int64_t logical_row_count,
+    int64_t physical_row_count) {
+    const auto total_elements =
+        GetElementCountForRows(array_offsets, logical_row_count);
+    TargetBitmap invalid_elements(total_elements, false);
+
+    const auto size_per_chunk = vec_data->get_size_per_chunk();
+    const auto num_chunks = std::min<int64_t>(
+        chunks.count, upper_div(physical_row_count, size_per_chunk));
+    int64_t element_offset = 0;
+    for (int64_t chunk_id = 0; chunk_id < num_chunks; ++chunk_id) {
+        auto chunk_data = vec_data->get_chunk_data(chunks, chunk_id);
+        auto vector_arrays = reinterpret_cast<const VectorArray*>(chunk_data);
+        const auto row_begin = chunk_id * size_per_chunk;
+        const auto chunk_rows =
+            std::min({size_per_chunk,
+                      physical_row_count - row_begin,
+                      vec_data->get_chunk_size(chunks, chunk_id)});
+        for (int64_t row_idx = 0; row_idx < chunk_rows; ++row_idx) {
+            const auto& vector_array = vector_arrays[row_idx];
+            for (int64_t elem_idx = 0; elem_idx < vector_array.length();
+                 ++elem_idx) {
+                if (vector_array.is_element_nullable() &&
+                    !vector_array.is_element_valid(elem_idx)) {
+                    invalid_elements.set(element_offset + elem_idx);
+                }
+            }
+            element_offset += vector_array.length();
+        }
+    }
+
+    AssertInfo(element_offset == total_elements,
+               "VECTOR_ARRAY element count mismatch, expected {}, got {}",
+               total_elements,
+               element_offset);
+    return invalid_elements;
+}
+
 }  // namespace
 
 void
@@ -345,6 +388,17 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
             search_bitset =
                 search_result.PinBitset(std::move(transformed_bitset));
         }
+        if (is_element_level_search && field.is_element_nullable()) {
+            search_bitset = MergeSearchFilterBitset(
+                search_result,
+                search_bitset,
+                BuildGrowingVectorArrayInvalidElementFilter(
+                    vec_ptr,
+                    chunks,
+                    *info.array_offsets_,
+                    logical_bound,
+                    active_count));
+        }
 
         // Element-level search (embedding-search-embedding): knowhere sees
         // a scalar vector type and the per-chunk size must be measured in
@@ -414,9 +468,22 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                 // data to a contiguous memory buffer. This is inefficient and
                 // will be optimized in the future.
                 auto vec_ptr = reinterpret_cast<const VectorArray*>(chunk_data);
+                const auto bytes_per_vector =
+                    vector_bytes_per_element(element_type, dim);
                 auto size = 0;
                 for (int i = 0; i < size_per_chunk; ++i) {
-                    size += vec_ptr[i].byte_size();
+                    if (is_element_level_search ||
+                        !vec_ptr[i].has_invalid_element()) {
+                        size += vec_ptr[i].byte_size();
+                        continue;
+                    }
+                    for (int64_t elem_idx = 0;
+                         elem_idx < vec_ptr[i].length();
+                         ++elem_idx) {
+                        if (vec_ptr[i].is_element_valid(elem_idx)) {
+                            size += bytes_per_vector;
+                        }
+                    }
                 }
 
                 buf = std::make_unique<uint8_t[]>(size);
@@ -441,11 +508,32 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                     auto offset = 0;
                     auto ptr = buf.get();
                     for (int i = 0; i < size_per_chunk; ++i) {
-                        milvus::fastmem::FastMemcpy(
-                            ptr, vec_ptr[i].data(), vec_ptr[i].byte_size());
-                        ptr += vec_ptr[i].byte_size();
+                        int64_t valid_vectors = 0;
+                        if (!vec_ptr[i].has_invalid_element()) {
+                            milvus::fastmem::FastMemcpy(
+                                ptr,
+                                vec_ptr[i].data(),
+                                vec_ptr[i].byte_size());
+                            ptr += vec_ptr[i].byte_size();
+                            valid_vectors = vec_ptr[i].length();
+                        } else {
+                            for (int64_t elem_idx = 0;
+                                 elem_idx < vec_ptr[i].length();
+                                 ++elem_idx) {
+                                if (!vec_ptr[i].is_element_valid(elem_idx)) {
+                                    continue;
+                                }
+                                milvus::fastmem::FastMemcpy(
+                                    ptr,
+                                    vec_ptr[i].data() +
+                                        elem_idx * bytes_per_vector,
+                                    bytes_per_vector);
+                                ptr += bytes_per_vector;
+                                ++valid_vectors;
+                            }
+                        }
 
-                        offset += vec_ptr[i].length();
+                        offset += valid_vectors;
                         offsets.push_back(offset);
                     }
                     sub_data = query::dataset::RawDataset{row_begin,
@@ -454,6 +542,12 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                                                           buf.get(),
                                                           offsets.data()};
                 }
+            }
+
+            if (data_type == DataType::VECTOR_ARRAY &&
+                !is_element_level_search &&
+                sub_data.raw_data_offsets[size_per_chunk] == 0) {
+                continue;
             }
 
             if (use_vector_iterator) {

--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -47,6 +47,51 @@
 #include "segcore/SealedIndexingRecord.h"
 
 namespace milvus::query {
+namespace {
+
+TargetBitmap
+BuildVectorArrayInvalidElementFilter(ChunkedColumnInterface* column,
+                                     milvus::OpContext* op_context,
+                                     const milvus::IArrayOffsets& array_offsets,
+                                     int64_t row_count) {
+    const auto total_elements = GetElementCountForRows(array_offsets, row_count);
+    TargetBitmap invalid_elements(total_elements, false);
+
+    int64_t element_offset = 0;
+    int64_t remaining_rows = row_count;
+    const auto num_chunks = column->num_chunks();
+    for (int64_t chunk_id = 0; chunk_id < num_chunks && remaining_rows > 0;
+         ++chunk_id) {
+        auto views_pw =
+            column->VectorArrayViews(op_context, chunk_id, std::nullopt);
+        const auto& views = views_pw.get().first;
+        const auto& valid_data = views_pw.get().second;
+        const auto rows_to_scan =
+            std::min<int64_t>(remaining_rows, views.size());
+        for (int64_t row_idx = 0; row_idx < rows_to_scan; ++row_idx) {
+            if (!valid_data.empty() && !valid_data[row_idx]) {
+                continue;
+            }
+            const auto& view = views[row_idx];
+            for (int64_t elem_idx = 0; elem_idx < view.length(); ++elem_idx) {
+                if (view.is_element_nullable() &&
+                    !view.is_element_valid(elem_idx)) {
+                    invalid_elements.set(element_offset + elem_idx);
+                }
+            }
+            element_offset += view.length();
+        }
+        remaining_rows -= rows_to_scan;
+    }
+
+    AssertInfo(element_offset == total_elements,
+               "VECTOR_ARRAY element count mismatch, expected {}, got {}",
+               total_elements,
+               element_offset);
+    return invalid_elements;
+}
+
+}  // namespace
 
 void
 SearchOnSealedIndex(const Schema& schema,
@@ -222,6 +267,14 @@ SearchOnSealedColumn(const Schema& schema,
         }
     }
 
+    if (is_element_level_search && field.is_element_nullable()) {
+        search_bitview = MergeSearchFilterBitset(
+            result,
+            search_bitview,
+            BuildVectorArrayInvalidElementFilter(
+                column, op_context, *search_info.array_offsets_, row_count));
+    }
+
     // For element-level search (embedding-search-embedding), the underlying
     // knowhere search is keyed by the scalar element type rather than
     // VECTOR_ARRAY, and per-chunk sizes must be counted in elements.
@@ -280,13 +333,71 @@ SearchOnSealedColumn(const Schema& schema,
             query::dataset::RawDataset{offset, dim, chunk_size, vec_data};
 
         PinWrapper<const size_t*> offsets_pw;
+        std::unique_ptr<uint8_t[]> compact_vector_array_data;
+        std::vector<size_t> compact_vector_array_offsets;
         if (data_type == DataType::VECTOR_ARRAY) {
             AssertInfo(
                 query_offsets != nullptr,
                 "query_offsets is nullptr, but data_type is vector array");
 
-            offsets_pw = column->VectorArrayOffsets(op_context, i);
-            raw_dataset.raw_data_offsets = offsets_pw.get();
+            if (field.is_element_nullable()) {
+                auto views_pw =
+                    column->VectorArrayViews(op_context, i, std::nullopt);
+                const auto& views = views_pw.get().first;
+                const auto& valid_data = views_pw.get().second;
+                const auto bytes_per_vector =
+                    vector_bytes_per_element(element_type, dim);
+                size_t compact_size = 0;
+                for (int64_t row_idx = 0; row_idx < views.size(); ++row_idx) {
+                    if (!valid_data.empty() && !valid_data[row_idx]) {
+                        continue;
+                    }
+                    const auto& view = views[row_idx];
+                    for (int64_t elem_idx = 0; elem_idx < view.length();
+                         ++elem_idx) {
+                        if (view.is_element_valid(elem_idx)) {
+                            compact_size += bytes_per_vector;
+                        }
+                    }
+                }
+
+                compact_vector_array_data =
+                    std::make_unique<uint8_t[]>(compact_size);
+                compact_vector_array_offsets.reserve(chunk_size + 1);
+                compact_vector_array_offsets.push_back(0);
+                auto* dst = compact_vector_array_data.get();
+                size_t valid_vector_count = 0;
+                for (int64_t row_idx = 0; row_idx < views.size(); ++row_idx) {
+                    if (valid_data.empty() || valid_data[row_idx]) {
+                        const auto& view = views[row_idx];
+                        for (int64_t elem_idx = 0; elem_idx < view.length();
+                             ++elem_idx) {
+                            if (!view.is_element_valid(elem_idx)) {
+                                continue;
+                            }
+                            milvus::fastmem::FastMemcpy(
+                                dst,
+                                static_cast<const char*>(view.data()) +
+                                    elem_idx * bytes_per_vector,
+                                bytes_per_vector);
+                            dst += bytes_per_vector;
+                            ++valid_vector_count;
+                        }
+                    }
+                    compact_vector_array_offsets.push_back(valid_vector_count);
+                }
+                AssertInfo(views.size() == chunk_size,
+                           "VECTOR_ARRAY logical row count mismatch, expected "
+                           "{}, got {}",
+                           chunk_size,
+                           views.size());
+                raw_dataset.raw_data = compact_vector_array_data.get();
+                raw_dataset.raw_data_offsets =
+                    compact_vector_array_offsets.data();
+            } else {
+                offsets_pw = column->VectorArrayOffsets(op_context, i);
+                raw_dataset.raw_data_offsets = offsets_pw.get();
+            }
             if (raw_dataset.raw_data_offsets[chunk_size] == 0) {
                 offset += chunk_size;
                 continue;

--- a/internal/core/src/query/Utils.h
+++ b/internal/core/src/query/Utils.h
@@ -93,6 +93,36 @@ FinalizeVectorSearchOffsets(SearchResult& result,
     }
 }
 
+inline int64_t
+GetElementCountForRows(const milvus::IArrayOffsets& array_offsets,
+                       int64_t row_count) {
+    if (row_count <= 0) {
+        return 0;
+    }
+    return array_offsets.ElementIDRangeOfRow(row_count).first;
+}
+
+inline BitsetView
+MergeSearchFilterBitset(SearchResult& result,
+                        const BitsetView& bitset,
+                        TargetBitmap&& extra_filter) {
+    if (extra_filter.none()) {
+        return bitset;
+    }
+    if (!bitset.empty()) {
+        AssertInfo(bitset.size() == extra_filter.size(),
+                   "search bitset size {} does not match extra filter size {}",
+                   bitset.size(),
+                   extra_filter.size());
+        for (size_t i = 0; i < bitset.size(); ++i) {
+            if (bitset.test(i)) {
+                extra_filter.set(i);
+            }
+        }
+    }
+    return result.PinBitset(std::move(extra_filter));
+}
+
 template <typename T, typename U>
 inline bool
 Match(const T& x, const U& y, OpType op) {

--- a/internal/core/src/segcore/ChunkedSegmentSealedBinlogIndexTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedBinlogIndexTest.cpp
@@ -801,12 +801,12 @@ TEST(test_chunk_segment,
     auto result = sealed->bulk_subscript(
         nullptr, vec_field_id, offsets.data(), offsets.size());
 
-    const auto& valid_data = GetFieldDataRowValidData(*result);
-    ASSERT_EQ(valid_data.size(), offsets.size());
-    EXPECT_FALSE(valid_data[0]);
-    EXPECT_TRUE(valid_data[1]);
-    EXPECT_FALSE(valid_data[2]);
-    EXPECT_TRUE(valid_data[3]);
+    const auto& result_valid_data = GetFieldDataRowValidData(*result);
+    ASSERT_EQ(result_valid_data.size(), offsets.size());
+    EXPECT_FALSE(result_valid_data[0]);
+    EXPECT_TRUE(result_valid_data[1]);
+    EXPECT_FALSE(result_valid_data[2]);
+    EXPECT_TRUE(result_valid_data[3]);
 
     const auto& returned = result->vectors().float_vector().data();
     ASSERT_EQ(returned.size(), 2 * dim);

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
+#include <cstring>
 #include <ctime>
 #include <exception>
 #include <future>
@@ -3662,7 +3663,13 @@ ChunkedSegmentSealedImpl::vector_search(SearchInfo& search_info,
     AssertInfo(field_meta.is_vector(),
                "The meta type of vector field is not vector type");
 
-    if (get_bit(snapshot->binlog_index_bitset, field_id)) {
+    const bool requires_raw_element_search =
+        field_meta.get_data_type() == DataType::VECTOR_ARRAY &&
+        field_meta.is_element_nullable() &&
+        search_info.array_offsets_ != nullptr;
+
+    if (!requires_raw_element_search &&
+        get_bit(snapshot->binlog_index_bitset, field_id)) {
         auto config_it = runtime->vec_binlog_config.find(field_id);
         AssertInfo(config_it != runtime->vec_binlog_config.end(),
                    "The binlog params is not generate.");
@@ -3683,7 +3690,8 @@ ChunkedSegmentSealedImpl::vector_search(SearchInfo& search_info,
                                    output);
         milvus::tracer::AddEvent(
             "finish_searching_vector_temperate_binlog_index");
-    } else if (get_bit(snapshot->index_ready_bitset, field_id)) {
+    } else if (!requires_raw_element_search &&
+               get_bit(snapshot->index_ready_bitset, field_id)) {
         if (search_info.global_refine_enable_ &&
             IsIndexRefineEnabledLocked(op_context, field_id, runtime)) {
             search_info.topk_ = GetEffectiveSearchTopk(search_info);
@@ -3879,6 +3887,23 @@ ChunkedSegmentSealedImpl::get_emb_list(milvus::OpContext* op_ctx,
                "get_emb_list called on vector index without raw data");
 
     auto metric_type = vec_index->GetMetricType();
+
+    if (field_meta.is_element_nullable()) {
+        auto column = get_column(snapshot->runtime, field_id);
+        if (column != nullptr) {
+            CheckVectorOutputCellsLoaded(id_,
+                                         field_id,
+                                         field_meta,
+                                         column.get(),
+                                         seg_offsets,
+                                         count);
+            return get_raw_data(
+                op_ctx, field_id, field_meta, seg_offsets, count);
+        }
+        ThrowInfo(ErrorCode::UnexpectedError,
+                  "element-nullable VECTOR_ARRAY requires raw field data to "
+                  "preserve element validity");
+    }
 
     ValidResult filter_result;
     int64_t valid_count = count;
@@ -8740,6 +8765,14 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
             AssertInfo(field_exists_in_schema(schema_snapshot, field_id),
                        "field {} not found in schema when loading field data",
                        field_id.get());
+            const auto& field_meta = schema_snapshot->operator[](field_id);
+            if (field_meta.is_element_nullable() &&
+                segment_load_info.GetStorageVersion() < STORAGE_V2) {
+                ThrowInfo(
+                    ErrorCode::Unsupported,
+                    "Storage V1 does not support element-nullable field {}",
+                    field_id.get());
+            }
         }
 
         auto snapshot = CapturePublishedState();
@@ -9376,21 +9409,70 @@ ChunkedSegmentSealedImpl::ArrowToDataArray(
                     outer_list->values());
             int dim = field_meta.get_dim();
             auto element_type = field_meta.get_element_type();
-            auto* va = data_array->mutable_vectors()
-                           ->mutable_vector_array()
-                           ->mutable_data();
+            auto* vector_array =
+                data_array->mutable_vectors()->mutable_vector_array();
+            vector_array->set_dim(dim);
+            vector_array->set_element_type(
+                static_cast<proto::schema::DataType>(element_type));
             data_array->mutable_vectors()->set_dim(dim);
+            auto bytes_per_vector =
+                milvus::vector_bytes_per_element(element_type, dim);
             for (int64_t i = 0; i < size; i++) {
                 auto idx = result_mapping[i];
+                if (outer_list->IsNull(idx)) {
+                    VectorArray empty(nullptr,
+                                      0,
+                                      dim,
+                                      element_type,
+                                      TargetBitmapView(),
+                                      field_meta.is_element_nullable());
+                    *vector_array->mutable_data()->Add() = empty.output_data();
+                    continue;
+                }
                 int64_t start = outer_list->value_offset(idx);
                 int64_t end = outer_list->value_offset(idx + 1);
                 int64_t num_vectors = end - start;
-                VectorArray vec_arr(inner_values->GetValue(start),
-                                    num_vectors,
-                                    dim,
-                                    element_type);
-                auto* vf = va->Add();
-                *vf = vec_arr.output_data();
+                if (field_meta.is_element_nullable()) {
+                    std::vector<uint8_t> row_data(num_vectors *
+                                                  bytes_per_vector);
+                    TargetBitmap element_valid_data(num_vectors, true);
+                    for (int64_t j = 0; j < num_vectors; ++j) {
+                        auto child_idx = start + j;
+                        auto* dst = row_data.data() + j * bytes_per_vector;
+                        if (inner_values->IsNull(child_idx)) {
+                            element_valid_data.reset(j);
+                            std::memset(dst, 0, bytes_per_vector);
+                            continue;
+                        }
+                        milvus::fastmem::FastMemcpy(
+                            dst,
+                            inner_values->GetValue(child_idx),
+                            bytes_per_vector);
+                    }
+                    VectorArray vec_arr(row_data.data(),
+                                        num_vectors,
+                                        dim,
+                                        element_type,
+                                        element_valid_data.view(),
+                                        true);
+                    *vector_array->mutable_data()->Add() =
+                        vec_arr.output_data();
+                } else {
+                    for (int64_t j = 0; j < num_vectors; ++j) {
+                        AssertInfo(
+                            !inner_values->IsNull(start + j),
+                            "VECTOR_ARRAY child value is null but field is "
+                            "not element nullable");
+                    }
+                    VectorArray vec_arr(num_vectors > 0
+                                            ? inner_values->GetValue(start)
+                                            : nullptr,
+                                        num_vectors,
+                                        dim,
+                                        element_type);
+                    *vector_array->mutable_data()->Add() =
+                        vec_arr.output_data();
+                }
             }
             break;
         }

--- a/internal/core/unittest/test_element_filter.cpp
+++ b/internal/core/unittest/test_element_filter.cpp
@@ -4286,6 +4286,162 @@ MakeNullableElementSearchWithOnlyNullRowsFixture() {
     return f;
 }
 
+inline NullableElementSearchFixture
+MakeElementNullableVectorSearchFixture() {
+    constexpr int kRows = 4;
+
+    NullableElementSearchFixture f;
+    f.schema = std::make_shared<Schema>();
+    f.vec_fid = f.schema->AddDebugVectorArrayField("structA[array_vec]",
+                                                   DataType::VECTOR_FLOAT,
+                                                   kNullableElemDim,
+                                                   knowhere::metric::L2,
+                                                   /*nullable=*/true,
+                                                   /*element_nullable=*/true);
+    f.int64_fid = f.schema->AddDebugField("id", DataType::INT64);
+    f.schema->set_primary_field_id(f.int64_fid);
+    f.raw_data = DataGen(f.schema, kRows, 42, 0, 1, kNullableElemArrayLen);
+
+    for (int i = 0; i < f.raw_data.raw_->fields_data_size(); ++i) {
+        auto* field_data = f.raw_data.raw_->mutable_fields_data(i);
+        if (field_data->field_id() != f.vec_fid.get()) {
+            continue;
+        }
+
+        field_data->clear_valid_data();
+        auto* vectors = field_data->mutable_vectors();
+        vectors->mutable_valid_data()->Clear();
+        vectors->add_valid_data(true);
+        vectors->add_valid_data(false);
+        vectors->add_valid_data(true);
+        vectors->add_valid_data(true);
+
+        auto* vector_array = vectors->mutable_vector_array();
+        vector_array->set_dim(kNullableElemDim);
+        vector_array->set_element_type(proto::schema::DataType::FloatVector);
+        vector_array->mutable_data()->Clear();
+
+        auto append_row = [&](const std::vector<bool>& valid_data,
+                              const std::vector<float>& compact_payload) {
+            auto* row = vector_array->add_data();
+            row->set_dim(kNullableElemDim);
+            row->mutable_float_vector()->mutable_data()->Add(
+                compact_payload.begin(), compact_payload.end());
+            row->mutable_valid_data()->Add(valid_data.begin(),
+                                           valid_data.end());
+        };
+
+        // Logical row 0 is [null, target]. Only target is present in the
+        // child payload, so a physical-index result of zero must still map to
+        // logical element index one.
+        append_row({false, true}, {7.0F, 7.0F, 7.0F, 7.0F});
+        // Logical row 1 is row-null and is omitted from the top-level compact
+        // VectorArray payload. Logical row 2 is a valid empty list.
+        append_row({}, {});
+        // Logical row 3 is [valid, null, valid].
+        append_row({true, false, true},
+                   {1.0F, 0.0F, 0.0F, 0.0F, 5.0F, 5.0F, 5.0F, 5.0F});
+        break;
+    }
+
+    f.flat_data = {
+        7.0F,
+        7.0F,
+        7.0F,
+        7.0F,
+        1.0F,
+        0.0F,
+        0.0F,
+        0.0F,
+        5.0F,
+        5.0F,
+        5.0F,
+        5.0F,
+    };
+    f.query_data = {7.0F, 7.0F, 7.0F, 7.0F};
+    return f;
+}
+
+inline NullableElementSearchFixture
+MakeElementNullableRowSearchFixture() {
+    constexpr int kRows = 3;
+
+    NullableElementSearchFixture f;
+    f.schema = std::make_shared<Schema>();
+    f.vec_fid = f.schema->AddDebugVectorArrayField("structA[array_vec]",
+                                                   DataType::VECTOR_FLOAT,
+                                                   kNullableElemDim,
+                                                   knowhere::metric::MAX_SIM_L2,
+                                                   /*nullable=*/true,
+                                                   /*element_nullable=*/true);
+    f.int64_fid = f.schema->AddDebugField("id", DataType::INT64);
+    f.schema->set_primary_field_id(f.int64_fid);
+    f.raw_data = DataGen(f.schema, kRows, 42, 0, 1, kNullableElemArrayLen);
+
+    for (int i = 0; i < f.raw_data.raw_->fields_data_size(); ++i) {
+        auto* field_data = f.raw_data.raw_->mutable_fields_data(i);
+        if (field_data->field_id() != f.vec_fid.get()) {
+            continue;
+        }
+
+        field_data->clear_valid_data();
+        auto* vectors = field_data->mutable_vectors();
+        vectors->mutable_valid_data()->Clear();
+        vectors->add_valid_data(true);
+        vectors->add_valid_data(false);
+        vectors->add_valid_data(true);
+
+        auto* vector_array = vectors->mutable_vector_array();
+        vector_array->set_dim(kNullableElemDim);
+        vector_array->set_element_type(proto::schema::DataType::FloatVector);
+        vector_array->mutable_data()->Clear();
+
+        auto append_row = [&](const std::vector<bool>& valid_data,
+                              const std::vector<float>& compact_payload) {
+            auto* row = vector_array->add_data();
+            row->set_dim(kNullableElemDim);
+            row->mutable_float_vector()->mutable_data()->Add(
+                compact_payload.begin(), compact_payload.end());
+            row->mutable_valid_data()->Add(valid_data.begin(),
+                                           valid_data.end());
+        };
+
+        // With a zero query, a dense null placeholder would make row 0 look
+        // better than row 2. Row-level search must compact it away first.
+        append_row({false, true}, {10.0F, 10.0F, 10.0F, 10.0F});
+        // Logical row 1 is row-null and is omitted from the compact payload.
+        append_row({true}, {1.0F, 0.0F, 0.0F, 0.0F});
+        break;
+    }
+
+    f.query_data.assign(kNullableElemDim, 0.0F);
+    return f;
+}
+
+inline NullableElementSearchFixture
+MakeElementNullableAllNullRowSearchFixture() {
+    auto f = MakeElementNullableRowSearchFixture();
+    for (int i = 0; i < f.raw_data.raw_->fields_data_size(); ++i) {
+        auto* field_data = f.raw_data.raw_->mutable_fields_data(i);
+        if (field_data->field_id() != f.vec_fid.get()) {
+            continue;
+        }
+
+        auto* rows = field_data->mutable_vectors()
+                         ->mutable_vector_array()
+                         ->mutable_data();
+        for (auto& row : *rows) {
+            for (int elem_idx = 0; elem_idx < row.valid_data_size();
+                 ++elem_idx) {
+                row.set_valid_data(elem_idx, false);
+            }
+            row.mutable_float_vector()->mutable_data()->Clear();
+        }
+        break;
+    }
+    return f;
+}
+
 inline proto::common::PlaceholderGroup
 MakeElementLevelPlaceholder(const std::vector<float>& query_data) {
     auto raw = CreatePlaceholderGroupFromBlob<milvus::FloatVector>(
@@ -4319,24 +4475,42 @@ CreateNullableSealedSegment(const NullableElementSearchFixture& f) {
     LoadGeneratedDataIntoSegment(
         f.raw_data, segment.get(), false, GetExcludedFieldIds(f.schema, {}));
 
-    auto vec_array_values = f.raw_data.get_col<VectorFieldProto>(f.vec_fid);
     auto valid_bitmap = BuildFieldValidBitmap(f.raw_data, f.vec_fid);
+    const auto& field_meta = (*f.schema)[f.vec_fid];
     std::vector<milvus::VectorArray> vector_arrays;
-    vector_arrays.reserve(vec_array_values.size());
-    for (int64_t row = 0; row < f.raw_data.raw_->num_rows(); ++row) {
-        if (IsBitmapRowValid(valid_bitmap, row)) {
-            vector_arrays.emplace_back(vec_array_values[row]);
+    const auto row_count = f.raw_data.raw_->num_rows();
+    for (int i = 0; i < f.raw_data.raw_->fields_data_size(); ++i) {
+        const auto& field_data = f.raw_data.raw_->fields_data(i);
+        if (field_data.field_id() != f.vec_fid.get()) {
+            continue;
         }
+
+        const auto& rows = field_data.vectors().vector_array().data();
+        const bool dense_rows = rows.size() == row_count;
+        int64_t physical_row = 0;
+        vector_arrays.reserve(rows.size());
+        for (int64_t logical_row = 0; logical_row < row_count; ++logical_row) {
+            if (!IsBitmapRowValid(valid_bitmap, logical_row)) {
+                continue;
+            }
+            const auto source_row = dense_rows ? logical_row : physical_row++;
+            AssertInfo(source_row < rows.size(),
+                       "VECTOR_ARRAY row {} is missing from test fixture",
+                       source_row);
+            vector_arrays.emplace_back(rows.Get(source_row),
+                                       field_meta.is_element_nullable());
+        }
+        break;
     }
 
     auto field_data = storage::CreateFieldData(DataType::VECTOR_ARRAY,
                                                DataType::VECTOR_FLOAT,
                                                /*nullable=*/true,
-                                               kNullableElemDim);
-    field_data->FillFieldData(vector_arrays.data(),
-                              valid_bitmap.data(),
-                              f.raw_data.raw_->num_rows(),
-                              0);
+                                               field_meta.is_element_nullable(),
+                                               kNullableElemDim,
+                                               0);
+    field_data->FillFieldData(
+        vector_arrays.data(), valid_bitmap.data(), row_count, 0);
 
     auto storage_config = gen_local_storage_config(TestLocalPath);
     auto cm = CreateChunkManager(storage_config);
@@ -4489,6 +4663,26 @@ RunNullableElementSearch(SegmentInterface* segment,
     return segment->Search(plan.get(), ph_group.get(), 1L << 63);
 }
 
+inline std::unique_ptr<SearchResult>
+RunNullableRowSearch(SegmentInterface* segment,
+                     const NullableElementSearchFixture& f) {
+    ScopedSchemaHandle handle(*f.schema);
+    auto plan_bytes = handle.ParseSearch("",
+                                         "structA[array_vec]",
+                                         /*topK=*/2,
+                                         knowhere::metric::MAX_SIM_L2,
+                                         R"({})",
+                                         3);
+    auto plan =
+        CreateSearchPlanByExpr(f.schema, plan_bytes.data(), plan_bytes.size());
+    std::vector<size_t> query_offsets{0, 1};
+    auto ph_group_raw = CreatePlaceholderGroupFromBlob<EmbListFloatVector>(
+        1, kNullableElemDim, f.query_data.data(), query_offsets);
+    auto ph_group =
+        ParsePlaceholderGroup(plan.get(), ph_group_raw.SerializeAsString());
+    return segment->Search(plan.get(), ph_group.get(), 1L << 63);
+}
+
 inline void
 ExpectNullableTargetTopOne(const milvus::SearchResult& sr) {
     ASSERT_TRUE(sr.element_level_);
@@ -4501,12 +4695,73 @@ ExpectNullableTargetTopOne(const milvus::SearchResult& sr) {
 inline void
 ExpectTopOne(const milvus::SearchResult& sr,
              int64_t expected_doc,
-             int32_t expected_elem) {
+             int32_t expected_elem,
+             float expected_distance = 0.0F) {
     ASSERT_TRUE(sr.element_level_);
     ASSERT_FALSE(sr.seg_offsets_.empty());
     ASSERT_EQ(sr.seg_offsets_[0], expected_doc);
     ASSERT_EQ(sr.element_indices_[0], expected_elem);
-    ASSERT_NEAR(sr.distances_[0], 0.0f, 1e-5f);
+    ASSERT_NEAR(sr.distances_[0], expected_distance, 1e-5f);
+}
+
+inline void
+ExpectOnlyElementNullableHits(const milvus::SearchResult& sr) {
+    ExpectElementLevelShape(sr);
+    std::set<std::pair<int64_t, int32_t>> actual;
+    for (size_t i = 0; i < sr.seg_offsets_.size(); ++i) {
+        if (sr.seg_offsets_[i] == INVALID_SEG_OFFSET) {
+            continue;
+        }
+        actual.emplace(sr.seg_offsets_[i], sr.element_indices_[i]);
+    }
+    const std::set<std::pair<int64_t, int32_t>> expected{
+        {0, 1}, {3, 0}, {3, 2}};
+    EXPECT_EQ(actual, expected);
+}
+
+inline void
+ExpectElementNullableVectorArrayRetrieve(const milvus::DataArray& data_array) {
+    const auto& row_valid_data = GetFieldDataRowValidData(data_array);
+    ASSERT_EQ(row_valid_data.size(), 4);
+    EXPECT_TRUE(row_valid_data[0]);
+    EXPECT_FALSE(row_valid_data[1]);
+    EXPECT_TRUE(row_valid_data[2]);
+    EXPECT_TRUE(row_valid_data[3]);
+
+    const auto& vector_array = data_array.vectors().vector_array();
+    EXPECT_EQ(vector_array.dim(), kNullableElemDim);
+    EXPECT_EQ(vector_array.element_type(),
+              proto::schema::DataType::FloatVector);
+    ASSERT_EQ(vector_array.data_size(), 4);
+
+    const auto& row0 = vector_array.data(0);
+    ASSERT_EQ(row0.valid_data_size(), 2);
+    EXPECT_FALSE(row0.valid_data(0));
+    EXPECT_TRUE(row0.valid_data(1));
+    ASSERT_EQ(row0.float_vector().data_size(), kNullableElemDim);
+    for (int i = 0; i < kNullableElemDim; ++i) {
+        EXPECT_FLOAT_EQ(row0.float_vector().data(i), 7.0F);
+    }
+
+    const auto& row1 = vector_array.data(1);
+    EXPECT_EQ(row1.valid_data_size(), 0);
+    EXPECT_EQ(row1.float_vector().data_size(), 0);
+
+    const auto& row2 = vector_array.data(2);
+    EXPECT_EQ(row2.valid_data_size(), 0);
+    EXPECT_EQ(row2.float_vector().data_size(), 0);
+
+    const auto& row3 = vector_array.data(3);
+    ASSERT_EQ(row3.valid_data_size(), 3);
+    EXPECT_TRUE(row3.valid_data(0));
+    EXPECT_FALSE(row3.valid_data(1));
+    EXPECT_TRUE(row3.valid_data(2));
+    ASSERT_EQ(row3.float_vector().data_size(), 2 * kNullableElemDim);
+    for (int i = 0; i < kNullableElemDim; ++i) {
+        EXPECT_FLOAT_EQ(row3.float_vector().data(i),
+                        i == 0 ? 1.0F : 0.0F);
+        EXPECT_FLOAT_EQ(row3.float_vector().data(kNullableElemDim + i), 5.0F);
+    }
 }
 
 }  // namespace
@@ -4586,6 +4841,299 @@ TEST(ElementVectorSearch, NullableGrowingBruteForce_ElementBitset) {
     auto sr = RunNullableElementSearch(segment.get(), f);
     ASSERT_NE(sr, nullptr);
     ExpectNullableTargetTopOne(*sr);
+}
+
+TEST(ElementVectorSearch,
+     ElementNullableGrowingBruteForcePreservesLogicalElementIds) {
+    auto f = MakeElementNullableVectorSearchFixture();
+    const auto row_count = f.raw_data.raw_->num_rows();
+    ScopedSegcoreConfigRestore config_restore;
+    SegcoreConfig config = SegcoreConfig::default_config();
+    config.set_chunk_rows(2);
+    auto segment = CreateGrowingSegment(f.schema, empty_index_meta, 1, config);
+    segment->PreInsert(row_count);
+    segment->Insert(0,
+                    row_count,
+                    f.raw_data.row_ids_.data(),
+                    f.raw_data.timestamps_.data(),
+                    f.raw_data.raw_);
+    ASSERT_EQ(segment->num_chunk_data(f.vec_fid), 2);
+
+    const int64_t seg_offsets[] = {0, 1, 2, 3};
+    auto retrieved = segment->bulk_subscript(
+        /*op_ctx=*/nullptr, f.vec_fid, seg_offsets, row_count);
+    ASSERT_NE(retrieved, nullptr);
+    ExpectElementNullableVectorArrayRetrieve(*retrieved);
+
+    auto sr = RunNullableElementSearch(segment.get(), f);
+    ASSERT_NE(sr, nullptr);
+    ExpectTopOne(*sr, /*expected_doc=*/0, /*expected_elem=*/1);
+
+    // Null elements have dense zero placeholders internally. A zero query
+    // must return the nearest valid vector, not either null placeholder.
+    f.query_data.assign(kNullableElemDim, 0.0F);
+    sr = RunNullableElementSearch(segment.get(), f);
+    ASSERT_NE(sr, nullptr);
+    ExpectTopOne(*sr,
+                 /*expected_doc=*/3,
+                 /*expected_elem=*/0,
+                 /*expected_distance=*/1.0F);
+}
+
+TEST(ElementVectorSearch,
+     ElementNullableSealedBruteForcePreservesLogicalElementIds) {
+    auto f = MakeElementNullableVectorSearchFixture();
+    auto segment = CreateNullableSealedSegment(f);
+
+    const int64_t seg_offsets[] = {0, 1, 2, 3};
+    auto retrieved = segment->bulk_subscript(
+        /*op_ctx=*/nullptr, f.vec_fid, seg_offsets, 4);
+    ASSERT_NE(retrieved, nullptr);
+    ExpectElementNullableVectorArrayRetrieve(*retrieved);
+
+    auto views_pw = segment->chunk_view<VectorArrayView>(
+        nullptr, f.vec_fid, 0, std::nullopt);
+    const auto& [views, row_valid_data] = views_pw.get();
+    ASSERT_EQ(views.size(), 4);
+    ASSERT_EQ(row_valid_data.size(), 4);
+    EXPECT_TRUE(row_valid_data[0]);
+    EXPECT_FALSE(row_valid_data[1]);
+    EXPECT_TRUE(row_valid_data[2]);
+    EXPECT_TRUE(row_valid_data[3]);
+    ASSERT_EQ(views[0].length(), 2);
+    EXPECT_FALSE(views[0].is_element_valid(0));
+    EXPECT_TRUE(views[0].is_element_valid(1));
+    for (int i = 0; i < kNullableElemDim; ++i) {
+        EXPECT_FLOAT_EQ(views[0].get_data<float>(1)[i], 7.0F);
+    }
+    ASSERT_EQ(views[3].length(), 3);
+    EXPECT_TRUE(views[3].is_element_valid(0));
+    EXPECT_FALSE(views[3].is_element_valid(1));
+    EXPECT_TRUE(views[3].is_element_valid(2));
+    EXPECT_FLOAT_EQ(views[3].get_data<float>(0)[0], 1.0F);
+    EXPECT_FLOAT_EQ(views[3].get_data<float>(2)[0], 5.0F);
+
+    auto sr = RunNullableElementSearch(segment.get(), f);
+    ASSERT_NE(sr, nullptr);
+    ExpectTopOne(*sr, /*expected_doc=*/0, /*expected_elem=*/1);
+
+    f.query_data.assign(kNullableElemDim, 0.0F);
+    sr = RunNullableElementSearch(segment.get(), f);
+    ASSERT_NE(sr, nullptr);
+    ExpectTopOne(*sr,
+                 /*expected_doc=*/3,
+                 /*expected_elem=*/0,
+                 /*expected_distance=*/1.0F);
+}
+
+TEST(ElementVectorSearch,
+     ElementNullableSealedLoadedIndexFallsBackToDenseRawData) {
+    auto f = MakeElementNullableVectorSearchFixture();
+    auto segment = CreateNullableSealedSegment(f);
+    LoadNullableElementFlatIndexWithValidRows(
+        segment.get(), f.vec_fid, f.flat_data, {true, true, true});
+
+    auto sr = RunNullableElementSearch(segment.get(), f);
+    ASSERT_NE(sr, nullptr);
+    ExpectTopOne(*sr, /*expected_doc=*/0, /*expected_elem=*/1);
+
+    f.query_data.assign(kNullableElemDim, 0.0F);
+    sr = RunNullableElementSearch(segment.get(), f);
+    ASSERT_NE(sr, nullptr);
+    ExpectTopOne(*sr,
+                 /*expected_doc=*/3,
+                 /*expected_elem=*/0,
+                 /*expected_distance=*/1.0F);
+}
+
+TEST(ElementVectorSearch, ElementNullableGrowingBruteForceRangeSearch) {
+    auto f = MakeElementNullableVectorSearchFixture();
+    const auto row_count = f.raw_data.raw_->num_rows();
+    auto segment = CreateGrowingSegment(f.schema, empty_index_meta);
+    segment->PreInsert(row_count);
+    segment->Insert(0,
+                    row_count,
+                    f.raw_data.row_ids_.data(),
+                    f.raw_data.timestamps_.data(),
+                    f.raw_data.raw_);
+
+    ScopedSchemaHandle handle(*f.schema);
+    const float radius = 1e6F;
+    const std::string search_params =
+        R"({"radius": )" + std::to_string(radius) + R"(, "range_filter": 0.0})";
+    auto plan_bytes = handle.ParseSearch(
+        "", "structA[array_vec]", kElemTopK, "L2", search_params, 3);
+    auto plan =
+        CreateSearchPlanByExpr(f.schema, plan_bytes.data(), plan_bytes.size());
+    auto ph_group_raw = MakeElementLevelPlaceholder(f.query_data);
+    auto ph_group =
+        ParsePlaceholderGroup(plan.get(), ph_group_raw.SerializeAsString());
+
+    auto sr = segment->Search(plan.get(), ph_group.get(), 1L << 63);
+    ASSERT_NE(sr, nullptr);
+    ExpectOnlyElementNullableHits(*sr);
+    ExpectTopOne(*sr, /*expected_doc=*/0, /*expected_elem=*/1);
+}
+
+TEST(ElementVectorSearch, ElementNullableGrowingBruteForceIteratorV2) {
+    auto f = MakeElementNullableVectorSearchFixture();
+    const auto row_count = f.raw_data.raw_->num_rows();
+    auto segment = CreateGrowingSegment(f.schema, empty_index_meta);
+    segment->PreInsert(row_count);
+    segment->Insert(0,
+                    row_count,
+                    f.raw_data.row_ids_.data(),
+                    f.raw_data.timestamps_.data(),
+                    f.raw_data.raw_);
+
+    ScopedSchemaHandle handle(*f.schema);
+    auto plan_bytes =
+        handle.ParseSearchIterator("",
+                                   "structA[array_vec]",
+                                   kElemTopK,
+                                   "L2",
+                                   R"({"ef": 50})",
+                                   static_cast<uint32_t>(kElemTopK),
+                                   "",
+                                   std::nullopt,
+                                   3);
+    auto plan =
+        CreateSearchPlanByExpr(f.schema, plan_bytes.data(), plan_bytes.size());
+    auto ph_group_raw = MakeElementLevelPlaceholder(f.query_data);
+    auto ph_group =
+        ParsePlaceholderGroup(plan.get(), ph_group_raw.SerializeAsString());
+
+    auto sr = segment->Search(plan.get(), ph_group.get(), 1L << 63);
+    ASSERT_NE(sr, nullptr);
+    ExpectOnlyElementNullableHits(*sr);
+    ExpectSortedAscending(*sr);
+    ExpectTopOne(*sr, /*expected_doc=*/0, /*expected_elem=*/1);
+}
+
+TEST(ElementVectorSearch, ElementNullableSealedBruteForceRangeSearch) {
+    auto f = MakeElementNullableVectorSearchFixture();
+    auto segment = CreateNullableSealedSegment(f);
+    LoadNullableElementFlatIndexWithValidRows(
+        segment.get(), f.vec_fid, f.flat_data, {true, true, true});
+
+    ScopedSchemaHandle handle(*f.schema);
+    const float radius = 1e6F;
+    const std::string search_params =
+        R"({"radius": )" + std::to_string(radius) + R"(, "range_filter": 0.0})";
+    auto plan_bytes = handle.ParseSearch(
+        "", "structA[array_vec]", kElemTopK, "L2", search_params, 3);
+    auto plan =
+        CreateSearchPlanByExpr(f.schema, plan_bytes.data(), plan_bytes.size());
+    auto ph_group_raw = MakeElementLevelPlaceholder(f.query_data);
+    auto ph_group =
+        ParsePlaceholderGroup(plan.get(), ph_group_raw.SerializeAsString());
+
+    auto sr = segment->Search(plan.get(), ph_group.get(), 1L << 63);
+    ASSERT_NE(sr, nullptr);
+    ExpectOnlyElementNullableHits(*sr);
+    ExpectTopOne(*sr, /*expected_doc=*/0, /*expected_elem=*/1);
+}
+
+TEST(ElementVectorSearch, ElementNullableSealedBruteForceIteratorV2) {
+    auto f = MakeElementNullableVectorSearchFixture();
+    auto segment = CreateNullableSealedSegment(f);
+    LoadNullableElementFlatIndexWithValidRows(
+        segment.get(), f.vec_fid, f.flat_data, {true, true, true});
+
+    ScopedSchemaHandle handle(*f.schema);
+    auto plan_bytes =
+        handle.ParseSearchIterator("",
+                                   "structA[array_vec]",
+                                   kElemTopK,
+                                   "L2",
+                                   R"({"ef": 50})",
+                                   static_cast<uint32_t>(kElemTopK),
+                                   "",
+                                   std::nullopt,
+                                   3);
+    auto plan =
+        CreateSearchPlanByExpr(f.schema, plan_bytes.data(), plan_bytes.size());
+    auto ph_group_raw = MakeElementLevelPlaceholder(f.query_data);
+    auto ph_group =
+        ParsePlaceholderGroup(plan.get(), ph_group_raw.SerializeAsString());
+
+    auto sr = segment->Search(plan.get(), ph_group.get(), 1L << 63);
+    ASSERT_NE(sr, nullptr);
+    ExpectOnlyElementNullableHits(*sr);
+    ExpectSortedAscending(*sr);
+    ExpectTopOne(*sr, /*expected_doc=*/0, /*expected_elem=*/1);
+}
+
+TEST(ElementVectorSearch, ElementNullableGrowingRowSearchSkipsNullPlaceholder) {
+    auto f = MakeElementNullableRowSearchFixture();
+    const auto row_count = f.raw_data.raw_->num_rows();
+    ScopedSegcoreConfigRestore config_restore;
+    SegcoreConfig config = SegcoreConfig::default_config();
+    config.set_chunk_rows(2);
+    auto segment = CreateGrowingSegment(f.schema, empty_index_meta, 1, config);
+    segment->PreInsert(row_count);
+    segment->Insert(0,
+                    row_count,
+                    f.raw_data.row_ids_.data(),
+                    f.raw_data.timestamps_.data(),
+                    f.raw_data.raw_);
+    ASSERT_EQ(segment->num_chunk_data(f.vec_fid), 2);
+
+    auto sr = RunNullableRowSearch(segment.get(), f);
+    ASSERT_NE(sr, nullptr);
+    ASSERT_FALSE(sr->element_level_);
+    ASSERT_FALSE(sr->seg_offsets_.empty());
+    EXPECT_EQ(sr->seg_offsets_[0], 2);
+}
+
+TEST(ElementVectorSearch, ElementNullableSealedRowSearchSkipsNullPlaceholder) {
+    auto f = MakeElementNullableRowSearchFixture();
+    auto segment = CreateNullableSealedSegment(f);
+
+    auto sr = RunNullableRowSearch(segment.get(), f);
+    ASSERT_NE(sr, nullptr);
+    ASSERT_FALSE(sr->element_level_);
+    ASSERT_FALSE(sr->seg_offsets_.empty());
+    EXPECT_EQ(sr->seg_offsets_[0], 2);
+}
+
+TEST(ElementVectorSearch,
+     ElementNullableGrowingRowSearchWithOnlyNullElementsReturnsEmpty) {
+    auto f = MakeElementNullableAllNullRowSearchFixture();
+    const auto row_count = f.raw_data.raw_->num_rows();
+    auto segment = CreateGrowingSegment(f.schema, empty_index_meta);
+    segment->PreInsert(row_count);
+    segment->Insert(0,
+                    row_count,
+                    f.raw_data.row_ids_.data(),
+                    f.raw_data.timestamps_.data(),
+                    f.raw_data.raw_);
+
+    std::unique_ptr<SearchResult> sr;
+    ASSERT_NO_THROW(sr = RunNullableRowSearch(segment.get(), f));
+    ASSERT_NE(sr, nullptr);
+    ASSERT_FALSE(sr->element_level_);
+    ASSERT_EQ(sr->seg_offsets_.size(), 2);
+    EXPECT_TRUE(std::all_of(
+        sr->seg_offsets_.begin(), sr->seg_offsets_.end(), [](int64_t offset) {
+            return offset == INVALID_SEG_OFFSET;
+        }));
+}
+
+TEST(ElementVectorSearch,
+     ElementNullableSealedRowSearchWithOnlyNullElementsReturnsEmpty) {
+    auto f = MakeElementNullableAllNullRowSearchFixture();
+    auto segment = CreateNullableSealedSegment(f);
+
+    std::unique_ptr<SearchResult> sr;
+    ASSERT_NO_THROW(sr = RunNullableRowSearch(segment.get(), f));
+    ASSERT_NE(sr, nullptr);
+    ASSERT_FALSE(sr->element_level_);
+    ASSERT_EQ(sr->seg_offsets_.size(), 2);
+    EXPECT_TRUE(std::all_of(
+        sr->seg_offsets_.begin(), sr->seg_offsets_.end(), [](int64_t offset) {
+            return offset == INVALID_SEG_OFFSET;
+        }));
 }
 
 TEST(ElementVectorSearch, GrowingBruteForce_RangeSearch) {


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/51162

Updates growing and sealed array-of-vector search paths to preserve validity and exclude null vector elements.