### PR TITLE
fix: [3.0] preserve shard cache on query node timeout (#52184)

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -398,6 +398,7 @@ proxy:
   # If the number of derived result entries exceeds this limit, the search aggregation request will be rejected.
   # Disabled if the value is less or equal to 0.
   maxSearchAggregationResultEntries: 10000
+  skipInvalidateShardLeaderCacheOnTimeout: false # Whether to keep shard leader cache when QueryNode RPC is canceled or exceeds the request deadline. NotShardLeader still invalidates shard leader cache.
   accessLog:
     enable: false # Whether to enable the access log feature.
     minioEnable: false # Whether to upload local access log files to MinIO. This parameter can be specified when proxy.accessLog.filename is not empty.

--- a/internal/proxy/shard_cache.go
+++ b/internal/proxy/shard_cache.go
@@ -1,0 +1,53 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+type shardLeaderCacheInvalidator interface {
+	InvalidateShardLeaderCache(collectionIDs []int64)
+}
+
+func invalidateShardLeaderCacheOnQueryNodeError(
+	cache shardLeaderCacheInvalidator,
+	collectionID int64,
+	err error,
+) {
+	if paramtable.Get().ProxyCfg.SkipInvalidateShardLeaderCacheOnTimeout.GetAsBool() && isCanceledOrTimeout(err) {
+		return
+	}
+	cache.InvalidateShardLeaderCache([]int64{collectionID})
+}
+
+func isCanceledOrTimeout(err error) bool {
+	if merr.IsCanceledOrTimeout(err) {
+		return true
+	}
+
+	switch status.Code(err) {
+	case codes.Canceled, codes.DeadlineExceeded:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/proxy/shard_cache_test.go
+++ b/internal/proxy/shard_cache_test.go
@@ -1,0 +1,148 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+type recordingShardLeaderCacheInvalidator struct {
+	collectionIDs [][]int64
+}
+
+func (i *recordingShardLeaderCacheInvalidator) InvalidateShardLeaderCache(collectionIDs []int64) {
+	i.collectionIDs = append(i.collectionIDs, collectionIDs)
+}
+
+func TestInvalidateShardLeaderCacheOnQueryNodeError(t *testing.T) {
+	t.Setenv("localstoragepath", t.TempDir())
+
+	params := paramtable.Get()
+	params.Reset(params.ProxyCfg.SkipInvalidateShardLeaderCacheOnTimeout.Key)
+	t.Cleanup(func() {
+		params.Reset(params.ProxyCfg.SkipInvalidateShardLeaderCacheOnTimeout.Key)
+	})
+
+	tests := []struct {
+		name              string
+		err               error
+		skipTimeoutConfig bool
+		invalidate        bool
+	}{
+		{
+			name:       "context canceled with default config",
+			err:        context.Canceled,
+			invalidate: true,
+		},
+		{
+			name:       "context deadline exceeded with default config",
+			err:        context.DeadlineExceeded,
+			invalidate: true,
+		},
+		{
+			name:       "wrapped context deadline exceeded with default config",
+			err:        errors.Wrap(context.DeadlineExceeded, "query node search failed"),
+			invalidate: true,
+		},
+		{
+			name:       "grpc canceled with default config",
+			err:        status.Error(codes.Canceled, "request canceled"),
+			invalidate: true,
+		},
+		{
+			name:       "grpc deadline exceeded with default config",
+			err:        status.Error(codes.DeadlineExceeded, "request deadline exceeded"),
+			invalidate: true,
+		},
+		{
+			name:       "wrapped grpc deadline exceeded with default config",
+			err:        errors.Wrap(status.Error(codes.DeadlineExceeded, "request deadline exceeded"), "query node search failed"),
+			invalidate: true,
+		},
+		{
+			name:              "context canceled with skip config",
+			err:               context.Canceled,
+			skipTimeoutConfig: true,
+		},
+		{
+			name:              "context deadline exceeded with skip config",
+			err:               context.DeadlineExceeded,
+			skipTimeoutConfig: true,
+		},
+		{
+			name:              "wrapped context deadline exceeded with skip config",
+			err:               errors.Wrap(context.DeadlineExceeded, "query node search failed"),
+			skipTimeoutConfig: true,
+		},
+		{
+			name:              "grpc canceled with skip config",
+			err:               status.Error(codes.Canceled, "request canceled"),
+			skipTimeoutConfig: true,
+		},
+		{
+			name:              "grpc deadline exceeded with skip config",
+			err:               status.Error(codes.DeadlineExceeded, "request deadline exceeded"),
+			skipTimeoutConfig: true,
+		},
+		{
+			name:              "wrapped grpc deadline exceeded with skip config",
+			err:               errors.Wrap(status.Error(codes.DeadlineExceeded, "request deadline exceeded"), "query node search failed"),
+			skipTimeoutConfig: true,
+		},
+		{
+			name:       "other query node error",
+			err:        errors.New("query node unavailable"),
+			invalidate: true,
+		},
+		{
+			name:              "other query node error with skip config",
+			err:               errors.New("query node unavailable"),
+			skipTimeoutConfig: true,
+			invalidate:        true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			params.Reset(params.ProxyCfg.SkipInvalidateShardLeaderCacheOnTimeout.Key)
+			if test.skipTimeoutConfig {
+				params.Save(params.ProxyCfg.SkipInvalidateShardLeaderCacheOnTimeout.Key, "true")
+			}
+
+			cache := &recordingShardLeaderCacheInvalidator{}
+			invalidateShardLeaderCacheOnQueryNodeError(cache, 100, test.err)
+
+			expectedCalls := 0
+			if test.invalidate {
+				expectedCalls = 1
+			}
+			if len(cache.collectionIDs) != expectedCalls {
+				t.Fatalf("expected %d invalidations, got %d", expectedCalls, len(cache.collectionIDs))
+			}
+			if test.invalidate && cache.collectionIDs[0][0] != 100 {
+				t.Fatalf("expected collection 100 to be invalidated, got %v", cache.collectionIDs[0])
+			}
+		})
+	}
+}

--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -1140,7 +1140,7 @@ func (t *queryTask) queryShard(ctx context.Context, nodeID int64, qn types.Query
 	result, err := qn.Query(ctx, req)
 	if err != nil {
 		log.Warn(ctx, "QueryNode query return error", mlog.Err(err))
-		t.shardclientMgr.InvalidateShardLeaderCache([]int64{t.GetCollectionID()})
+		invalidateShardLeaderCacheOnQueryNodeError(t.shardclientMgr, t.GetCollectionID(), err)
 		return err
 	}
 	if result.GetStatus().GetErrorCode() == commonpb.ErrorCode_NotShardLeader {

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -1523,8 +1523,7 @@ func (t *searchTask) searchShard(ctx context.Context, nodeID int64, qn types.Que
 	result, err = qn.Search(ctx, req)
 	if err != nil {
 		log.Warn(ctx, "QueryNode search return error", mlog.Err(err))
-		// globalMetaCache.DeprecateShardCache(t.request.GetDbName(), t.collectionName)
-		t.shardClientMgr.InvalidateShardLeaderCache([]int64{t.GetCollectionID()})
+		invalidateShardLeaderCacheOnQueryNodeError(t.shardClientMgr, t.GetCollectionID(), err)
 		return err
 	}
 	if result.GetStatus().GetErrorCode() == commonpb.ErrorCode_NotShardLeader {

--- a/internal/proxy/task_statistic.go
+++ b/internal/proxy/task_statistic.go
@@ -287,7 +287,7 @@ func (g *getStatisticsTask) getStatisticsShard(ctx context.Context, nodeID int64
 			mlog.Int64("nodeID", nodeID),
 			mlog.String("channel", channel),
 			mlog.Err(err))
-		g.shardclientMgr.InvalidateShardLeaderCache([]int64{g.CollectionID})
+		invalidateShardLeaderCacheOnQueryNodeError(g.shardclientMgr, g.CollectionID, err)
 		return err
 	}
 	if result.GetStatus().GetErrorCode() == commonpb.ErrorCode_NotShardLeader {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2246,6 +2246,8 @@ type proxyConfig struct {
 	EnableCachedServiceProvider       ParamItem `refreshable:"true"`
 	MaxSearchAggregationResultEntries ParamItem `refreshable:"true"`
 
+	SkipInvalidateShardLeaderCacheOnTimeout ParamItem `refreshable:"true"`
+
 	AccessLog AccessLogConfig
 
 	// connection manager
@@ -2604,6 +2606,15 @@ please adjust in embedded Milvus: false`,
 		Doc:          "time interval to update shard leader cache, in seconds",
 	}
 	p.ShardLeaderCacheInterval.Init(base.mgr)
+
+	p.SkipInvalidateShardLeaderCacheOnTimeout = ParamItem{
+		Key:          "proxy.skipInvalidateShardLeaderCacheOnTimeout",
+		Version:      "3.0.1",
+		DefaultValue: "false",
+		Doc:          "Whether to keep shard leader cache when QueryNode RPC is canceled or exceeds the request deadline. NotShardLeader still invalidates shard leader cache.",
+		Export:       true,
+	}
+	p.SkipInvalidateShardLeaderCacheOnTimeout.Init(base.mgr)
 
 	p.ReplicaSelectionPolicy = ParamItem{
 		Key:          "proxy.replicaSelectionPolicy",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -302,6 +302,12 @@ func TestComponentParam(t *testing.T) {
 
 		t.Logf("ShardLeaderCacheInterval: %d", Params.ShardLeaderCacheInterval.GetAsInt64())
 
+		assert.False(t, Params.SkipInvalidateShardLeaderCacheOnTimeout.GetAsBool())
+		params.Save(Params.SkipInvalidateShardLeaderCacheOnTimeout.Key, "true")
+		assert.True(t, Params.SkipInvalidateShardLeaderCacheOnTimeout.GetAsBool())
+		params.Reset(Params.SkipInvalidateShardLeaderCacheOnTimeout.Key)
+		assert.False(t, Params.SkipInvalidateShardLeaderCacheOnTimeout.GetAsBool())
+
 		assert.Equal(t, Params.ReplicaSelectionPolicy.GetValue(), "look_aside")
 		params.Save(Params.ReplicaSelectionPolicy.Key, "round_robin")
 		assert.Equal(t, Params.ReplicaSelectionPolicy.GetValue(), "round_robin")


### PR DESCRIPTION
Keep cached shard leaders when Search, Query, or GetStatistics RPCs are canceled or exceed their request deadline. Continue invalidating the cache for other QueryNode failures and NotShardLeader responses.

issue: #52182

master branch: https://github.com/milvus-io/milvus/pull/52184