### PR TITLE
fix: [cp3.0]resolve search timezone before plan generation

### DIFF
--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -263,6 +263,18 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 	// searches with small result size could no longer need requery.
 	traceVal, _ := funcutil.GetAttrByKeyFromRepeatedKV(PipelineTraceKey, t.request.GetSearchParams())
 	t.traceEnabled = strings.EqualFold(traceVal, "true")
+	timezone, exist := funcutil.TryGetAttrByKeyFromRepeatedKV(common.TimezoneKey, t.request.SearchParams)
+	if exist {
+		if !timestamptz.IsTimezoneValid(timezone) {
+			log.Info(ctx, "get invalid timezone from request", mlog.String("timezone", timezone))
+			return merr.WrapErrParameterInvalidMsg("unknown or invalid IANA Time Zone ID: %s", timezone)
+		}
+		log.Debug(ctx, "determine timezone from request", mlog.String("user defined timezone", timezone))
+	} else {
+		timezone = getColTimezone(collectionInfo)
+		log.Debug(ctx, "determine timezone from collection", mlog.Any("collection timezone", timezone))
+	}
+	t.resolvedTimezoneStr = timezone
 	// initSearchAggregation must run before init{,Advanced}SearchRequest so
 	// that t.SearchRequest.GroupByFieldIds and t.aggCtx are populated before
 	// queryInfo is built and captured — otherwise queryInfo.GroupByFieldIds
@@ -339,19 +351,6 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 			return merr.WrapErrServiceInternalMsg("ttl timestamp overflow, base timestamp: %d, ttl duration %v", t.GetBase().GetTimestamp(), collectionInfo.collectionTTL)
 		}
 	}
-
-	timezone, exist := funcutil.TryGetAttrByKeyFromRepeatedKV(common.TimezoneKey, t.request.SearchParams)
-	if exist {
-		if !timestamptz.IsTimezoneValid(timezone) {
-			log.Info(ctx, "get invalid timezone from request", mlog.String("timezone", timezone))
-			return merr.WrapErrParameterInvalidMsg("unknown or invalid IANA Time Zone ID: %s", timezone)
-		}
-		log.Debug(ctx, "determine timezone from request", mlog.String("user defined timezone", timezone))
-	} else {
-		timezone = getColTimezone(collectionInfo)
-		log.Debug(ctx, "determine timezone from collection", mlog.Any("collection timezone", timezone))
-	}
-	t.resolvedTimezoneStr = timezone
 
 	t.resultBuf = typeutil.NewConcurrentSet[*internalpb.SearchResults]()
 

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -119,6 +119,72 @@ func TestSearchTaskPreExecuteTextRequiresStorageV3(t *testing.T) {
 	assert.Contains(t, err.Error(), "TEXT field requires StorageV3")
 }
 
+func TestSearchTaskPreExecuteUsesTimezoneForTimestamptzFilter(t *testing.T) {
+	mockey.PatchConvey("TestSearchTaskPreExecuteUsesTimezoneForTimestamptzFilter", t, func() {
+		globalMetaCache = &MetaCache{}
+
+		const (
+			dbName         = "db"
+			collectionName = "timestamptz_collection"
+			collectionID   = int64(100)
+		)
+		schema := mustNewSchemaInfo(&schemapb.CollectionSchema{
+			Name: collectionName,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: testInt64Field, DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{
+					FieldID:  101,
+					Name:     testFloatVecField,
+					DataType: schemapb.DataType_FloatVector,
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.DimKey, Value: strconv.Itoa(testVecDim)},
+					},
+				},
+				{FieldID: 102, Name: "ts", DataType: schemapb.DataType_Timestamptz},
+			},
+		})
+
+		mockey.Mock((*MetaCache).GetCollectionID).Return(collectionID, nil).Build()
+		mockey.Mock((*MetaCache).GetCollectionInfo).Return(&collectionInfo{
+			updateTimestamp:  100,
+			consistencyLevel: commonpb.ConsistencyLevel_Strong,
+		}, nil).Build()
+		mockey.Mock((*MetaCache).GetCollectionSchema).Return(schema, nil).Build()
+		mockey.Mock(isIgnoreGrowing).Return(false, nil).Build()
+		mockey.Mock((*searchTask).checkNq).Return(int64(1), nil).Build()
+
+		searchParams := append([]*commonpb.KeyValuePair{}, getValidSearchParams()...)
+		searchParams = append(searchParams, &commonpb.KeyValuePair{
+			Key:   common.TimezoneKey,
+			Value: "Asia/Shanghai",
+		})
+		task := &searchTask{
+			Condition:     NewTaskCondition(context.Background()),
+			SearchRequest: &internalpb.SearchRequest{Base: &commonpb.MsgBase{MsgType: commonpb.MsgType_Search}},
+			ctx:           context.Background(),
+			request: &milvuspb.SearchRequest{
+				DbName:         dbName,
+				CollectionName: collectionName,
+				Nq:             1,
+				Dsl:            "ts > ISO '2025-01-01T00:00:00'",
+				SearchParams:   searchParams,
+			},
+			result: &milvuspb.SearchResults{Status: merr.Success()},
+		}
+
+		err := task.PreExecute(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, "Asia/Shanghai", task.resolvedTimezoneStr)
+		plan := &planpb.PlanNode{}
+		require.NoError(t, proto.Unmarshal(task.SerializedExprPlan, plan))
+		rangeExpr := plan.GetVectorAnns().GetPredicates().GetUnaryRangeExpr()
+		require.NotNil(t, rangeExpr)
+		shanghai, err := time.LoadLocation("Asia/Shanghai")
+		require.NoError(t, err)
+		assert.Equal(t, time.Date(2025, 1, 1, 0, 0, 0, 0, shanghai).UnixMicro(), rangeExpr.GetValue().GetInt64Val())
+	})
+}
+
 func TestSearchTask_PostExecute(t *testing.T) {
 	var err error
 


### PR DESCRIPTION
Cherry-pick from master

pr: #52113
issue: #52112

## Summary

Cherry-picked from master PR #52113 (merged)

## Verification

- [x] File count matches original PR
- [x] Code changes verified against master PR diff (line-level comparison)
- [x] No conflict markers
- [ ] make static-check (skipped by cherry-pick workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
