### PR TITLE
fix: [cp2.6]convert ArrayOfVector element placeholders

### DIFF
--- a/internal/proxy/vector_type_convert.go
+++ b/internal/proxy/vector_type_convert.go
@@ -117,6 +117,9 @@ func ConvertPlaceholderGroup(phgBytes []byte, fieldSchema *schemapb.FieldSchema)
 
 	placeholder := phg.Placeholders[0]
 	fieldType := fieldSchema.GetDataType()
+	if fieldType == schemapb.DataType_ArrayOfVector {
+		fieldType = fieldSchema.GetElementType()
+	}
 
 	// Check if types already match
 	if isVectorTypeMatch(placeholder.Type, fieldType) {

--- a/internal/proxy/vector_type_convert_test.go
+++ b/internal/proxy/vector_type_convert_test.go
@@ -164,6 +164,56 @@ func TestValidateFloat32ForBFloat16(t *testing.T) {
 	}
 }
 
+func assertFP16BF16BytesMatchFloat32(
+	t *testing.T,
+	dataType schemapb.DataType,
+	floatData []float32,
+	got []byte,
+) {
+	t.Helper()
+	var want []byte
+	var decoded []float32
+	var tolerance float64
+	switch dataType {
+	case schemapb.DataType_Float16Vector:
+		want = typeutil.Float32ArrayToFloat16Bytes(floatData)
+		decoded = typeutil.Float16BytesToFloat32Vector(got)
+		tolerance = 1e-3
+	case schemapb.DataType_BFloat16Vector:
+		want = typeutil.Float32ArrayToBFloat16Bytes(floatData)
+		decoded = typeutil.BFloat16BytesToFloat32Vector(got)
+		tolerance = 1e-2
+	default:
+		t.Fatalf("unsupported data type: %s", dataType.String())
+	}
+	assert.Equal(t, want, got)
+	assert.InDeltaSlice(t, floatData, decoded, tolerance)
+}
+
+func assertPlaceholderVectorsMatchFloat32(
+	t *testing.T,
+	placeholderType commonpb.PlaceholderType,
+	fieldType schemapb.DataType,
+	placeholders []*commonpb.PlaceholderValue,
+	inputs [][]float32,
+) {
+	t.Helper()
+	assert.Len(t, placeholders, 1)
+	placeholder := placeholders[0]
+	assert.Equal(t, placeholderType, placeholder.GetType())
+	assert.Len(t, placeholder.GetValues(), len(inputs))
+	for i, input := range inputs {
+		switch fieldType {
+		case schemapb.DataType_Float16Vector:
+			assertFP16BF16BytesMatchFloat32(t, fieldType, input, placeholder.GetValues()[i])
+		case schemapb.DataType_BFloat16Vector:
+			assertFP16BF16BytesMatchFloat32(t, fieldType, input, placeholder.GetValues()[i])
+		default:
+			assert.Equal(t, typeutil.Float32ArrayToBytes(input), placeholder.GetValues()[i])
+		}
+	}
+}
+
 func createFloat32PlaceholderGroup(vectors [][]float32) []byte {
 	values := make([][]byte, len(vectors))
 	for i, vec := range vectors {
@@ -223,6 +273,42 @@ func TestConvertPlaceholderGroupToBFloat16(t *testing.T) {
 
 	assert.Equal(t, commonpb.PlaceholderType_BFloat16Vector, resultPhg.Placeholders[0].Type)
 	assert.Equal(t, 4*2, len(resultPhg.Placeholders[0].Values[0]))
+}
+
+func TestConvertPlaceholderGroupArrayOfVectorElementType(t *testing.T) {
+	for _, tt := range []struct {
+		name            string
+		elementType     schemapb.DataType
+		placeholderType commonpb.PlaceholderType
+	}{
+		{
+			name:            "float16 element",
+			elementType:     schemapb.DataType_Float16Vector,
+			placeholderType: commonpb.PlaceholderType_Float16Vector,
+		},
+		{
+			name:            "bfloat16 element",
+			elementType:     schemapb.DataType_BFloat16Vector,
+			placeholderType: commonpb.PlaceholderType_BFloat16Vector,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			vectors := [][]float32{{0.1, 0.2, 0.3, 0.4}}
+			phgBytes := createFloat32PlaceholderGroup(vectors)
+			fieldSchema := &schemapb.FieldSchema{
+				DataType:    schemapb.DataType_ArrayOfVector,
+				ElementType: tt.elementType,
+			}
+
+			convertedBytes, err := ConvertPlaceholderGroup(phgBytes, fieldSchema)
+			assert.NoError(t, err)
+
+			var resultPhg commonpb.PlaceholderGroup
+			err = proto.Unmarshal(convertedBytes, &resultPhg)
+			assert.NoError(t, err)
+			assertPlaceholderVectorsMatchFloat32(t, tt.placeholderType, tt.elementType, resultPhg.Placeholders, vectors)
+		})
+	}
 }
 
 func TestConvertPlaceholderGroupTypeMismatch(t *testing.T) {


### PR DESCRIPTION
Cherry-pick from master

pr: #52015
issue: #52014

## Summary

Cherry-picked from master PR #52015 (merged)

## Backport adaptations (2.6)

- 2.6's `ConvertPlaceholderGroup` returns 2 values (no PlaceholderType), so the new test calls the 2-value signature.
- Test helpers `assertPlaceholderVectorsMatchFloat32` / `assertFP16BF16BytesMatchFloat32` do not exist on 2.6 and are ported verbatim from master's vector_type_convert_test.go.

## Verification

- [x] File count matches original PR
- [x] Code changes verified against master PR diff (line-level comparison)
- [x] No conflict markers
- [ ] make static-check (skipped by cherry-pick workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
