### PR TITLE
fix: [cp3.0]reject invalid import commit timestamp

### DIFF
--- a/internal/datacoord/commit_timestamp_test.go
+++ b/internal/datacoord/commit_timestamp_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
 )
 
@@ -122,9 +123,7 @@ func TestUpdateCommitTimestamp_RejectBelowMaxTimestampTo(t *testing.T) {
 	assert.NoError(t, meta.AddSegment(context.Background(), segWithBinlogs(1, 5000)))
 
 	err = meta.UpdateSegmentsInfo(context.Background(), UpdateCommitTimestamp(1, 3000))
-	// UpdateSegmentsInfo returns nil when the operator returns false (no-op);
-	// the assertion is on the persisted state, not the error.
-	assert.NoError(t, err)
+	assert.ErrorIs(t, err, merr.ErrImportSysFailed)
 	assert.Equal(t, uint64(0), meta.GetSegment(context.Background(), 1).GetCommitTimestamp(),
 		"rejected update must leave commit_timestamp unchanged")
 }

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -1719,6 +1719,27 @@ func UpdateIsImporting(segmentID int64, isImporting bool) UpdateOperator {
 	}
 }
 
+// maxBinlogTimestampTo returns the highest TimestampTo across a segment's insert
+// binlogs, or 0 when the arrays are absent.
+//
+// Absent is not the same as "no rows": a V3 (manifest-backed) segment never
+// persists these arrays -- buildAlterSegmentsKvs skips the per-FieldBinlog KVs
+// for it (kv_catalog.go:357) and the SegmentInfo is written without them -- so a
+// V3 segment reloaded after a DataCoord restart reports 0 here regardless of the
+// row timestamps it actually holds. Callers therefore get a bound that is safe
+// to compare against but that does not fire for reloaded V3 segments.
+func maxBinlogTimestampTo(fieldBinlogs []*datapb.FieldBinlog) uint64 {
+	var maxTsTo uint64
+	for _, fb := range fieldBinlogs {
+		for _, l := range fb.GetBinlogs() {
+			if l.GetTimestampTo() > maxTsTo {
+				maxTsTo = l.GetTimestampTo()
+			}
+		}
+	}
+	return maxTsTo
+}
+
 // UpdateCommitTimestamp sets the commit_timestamp on an import/CDC segment.
 // Non-zero marks it as committed at that transaction time, overriding
 // start_position.Timestamp for all temporal decisions.
@@ -1739,20 +1760,29 @@ func UpdateCommitTimestamp(segmentID int64, ts uint64) UpdateOperator {
 			return false
 		}
 		if ts != 0 {
-			var maxTsTo uint64
-			for _, fieldBinlogs := range segment.GetBinlogs() {
-				for _, l := range fieldBinlogs.GetBinlogs() {
-					if l.GetTimestampTo() > maxTsTo {
-						maxTsTo = l.GetTimestampTo()
-					}
-				}
-			}
+			maxTsTo := maxBinlogTimestampTo(segment.GetBinlogs())
 			if ts < maxTsTo {
 				mlog.Error(context.TODO(), "meta update: update commit timestamp rejected - commit_ts < max(binlog.TimestampTo)",
 					mlog.Int64("segmentID", segmentID),
 					mlog.Uint64("commitTs", ts),
 					mlog.Uint64("maxBinlogTimestampTo", maxTsTo))
-				return false
+				// Fail-stop. Unreachable for a normal import: its rows carry the
+				// Import message's timetick and the commit fence is a later
+				// timetick on the same WAL. Keep the error retriable so the
+				// flusher blocks on the fence instead of failing the job — a
+				// blocked pchannel surfaces as WAL lag, whereas a replica that
+				// commits what the source rejected can no longer be rolled back.
+				//
+				// Recovery from here is out of band. The job is already
+				// Committing by the time this runs -- commitImportV2AckCallback
+				// persists that state on the broadcast FastAck, independent of
+				// this fence -- and Committing is terminal for AbortImport while
+				// tryTimeoutJob never reaches it (TimeoutTs defaults to
+				// math.MaxUint64). Validating earlier does not change that: the
+				// ack path flips the state regardless of what this check says.
+				return modPack.fail(merr.WrapErrImportSysFailedMsg(
+					"commit timestamp %d is less than max binlog timestamp %d for import segment %d",
+					ts, maxTsTo, segmentID))
 			}
 		}
 		segment.CommitTimestamp = ts

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -6015,6 +6015,61 @@ func TestHandleCommitVchannelRPC_StoresCommitTimestamp(t *testing.T) {
 	}
 }
 
+func TestHandleCommitVchannelRPC_RejectsCommitTimestampBelowBinlogTimestamp(t *testing.T) {
+	ctx := context.Background()
+
+	importMetaMock := NewMockImportMeta(t)
+	importMetaMock.EXPECT().HandleCommitVchannel(mock.Anything, int64(3001), "vchan-0", mock.AnythingOfType("func() error")).
+		RunAndReturn(func(ctx context.Context, jobID int64, vchannel string, callback func() error) error {
+			return callback()
+		})
+
+	segIDs := []int64{10}
+	getSegIDsMock := mockey.Mock((*Server).getImportSegmentIDsByVchannel).
+		Return(segIDs).Build()
+	defer getSegIDsMock.UnPatch()
+
+	segments := NewSegmentsInfo()
+	segments.SetSegment(10, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+		ID:            10,
+		CollectionID:  100,
+		PartitionID:   10,
+		InsertChannel: "vchan-0",
+		State:         commonpb.SegmentState_Flushed,
+		IsImporting:   true,
+		Binlogs: []*datapb.FieldBinlog{{
+			FieldID: 100,
+			Binlogs: []*datapb.Binlog{{
+				LogID:       10,
+				TimestampTo: 500,
+			}},
+		}},
+	}})
+
+	server := &Server{
+		importMeta: importMetaMock,
+		meta: &meta{
+			catalog:  &datacoordkv.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: segments,
+		},
+	}
+	server.stateCode.Store(commonpb.StateCode_Healthy)
+
+	resp, err := server.HandleCommitVchannel(ctx, &datapb.HandleCommitVchannelRequest{
+		JobId:           3001,
+		Vchannel:        "vchan-0",
+		CommitTimestamp: 300,
+	})
+	assert.NoError(t, err)
+	assert.False(t, merr.Ok(resp))
+	assert.ErrorIs(t, merr.Error(resp), merr.ErrImportSysFailed)
+
+	seg := server.meta.GetSegment(ctx, 10)
+	require.NotNil(t, seg)
+	assert.EqualValues(t, 0, seg.GetCommitTimestamp())
+	assert.True(t, seg.GetIsImporting())
+}
+
 func TestHandleCommitVchannelRPC_MissingJobReturnsError(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
Cherry-pick from master

pr: #51589
issue: #51588

## Summary

Cherry-picked from master PR #51589 (merged)

## Deviation from the master PR

One test is **not** picked: `TestHandleCommitVchannelRPC_V3SegmentIsNotFencedYet`.

It builds `datapb.SegmentInfo{Stats: &datapb.Statistics{TimestampTo: 500}}`, but 3.0's `pkg/proto/data_coord.proto` has neither `SegmentInfo.stats` nor `message Statistics` (both are master-only), so the `internal/datacoord` test package failed typecheck and Code-Check errored out:

```
internal/datacoord/services_test.go:5972:3: unknown field Stats in struct literal of type datapb.SegmentInfo
internal/datacoord/services_test.go:5972:26: undefined: datapb.Statistics (typecheck)
```

That test does not cover this PR's fix. It pins a pre-existing gap — a V3 (manifest-backed) segment persists no binlog arrays, so the fence compares against 0 — and its assertions are meant to be flipped by a master-only follow-up that reads `Stats.TimestampTo`. On 3.0 the gap cannot be expressed the same way, and rewriting it without `Stats` would degrade it to a trivial assertion.

Everything else is picked unchanged, including the fix in `meta.go` and its regression test `TestHandleCommitVchannelRPC_RejectsCommitTimestampBelowBinlogTimestamp`.

## Verification

- [x] File count matches original PR
- [x] Code changes verified against master PR diff (line-level comparison)
- [x] No conflict markers
- [x] `go vet -tags dynamic,test ./internal/datacoord/` clean (covers the typecheck failure Code-Check reported)
- [x] Rebased onto latest 3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
