### PR TITLE
fix: [cp3.0]recycle stale analyze stats versions and persist analyze terminal states

### DIFF
--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -1651,7 +1651,8 @@ func (gc *garbageCollector) recycleUnusedAnalyzeFiles(ctx context.Context, signa
 				// process canceled.
 				return
 			}
-			removePrefix := prefix + fmt.Sprintf("%d/", task.Version)
+			// analyze stats files are laid out as analyze_stats/{taskID}/{version}/...
+			removePrefix := prefix + fmt.Sprintf("%d/%d/", taskID, i)
 			if err := gc.option.cli.RemoveWithPrefix(ctx, removePrefix); err != nil {
 				mlog.Warn(ctx, "garbageCollector recycleUnusedAnalyzeFiles remove files with prefix failed",
 					mlog.Int64("taskID", taskID), mlog.String("removePrefix", removePrefix))

--- a/internal/datacoord/garbage_collector_test.go
+++ b/internal/datacoord/garbage_collector_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/objectstorage"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/workerpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/lock"
@@ -3432,6 +3433,66 @@ func TestGarbageCollector_recycleUnusedTextIndexFiles_SnapshotReference(t *testi
 	// Verify - files should NOT be removed
 	assert.Empty(t, removedFiles,
 		"text index files should not be removed when segment is referenced by snapshot")
+}
+
+func TestGarbageCollector_recycleUnusedAnalyzeFiles_StaleVersions(t *testing.T) {
+	ctx := context.Background()
+
+	meta := &meta{
+		catalog: &datacoord.Catalog{},
+		analyzeMeta: &analyzeMeta{
+			ctx: ctx,
+			tasks: map[int64]*indexpb.AnalyzeTask{
+				401: {
+					TaskID:  401,
+					Version: 2,
+					State:   indexpb.JobState_JobStateFinished,
+				},
+			},
+		},
+	}
+
+	cli := storage.NewLocalChunkManager(objectstorage.RootPath("/tmp/test"))
+
+	gc := newGarbageCollector(meta, &ServerHandler{}, GcOption{
+		cli:              cli,
+		enabled:          true,
+		checkInterval:    time.Millisecond * 10,
+		scanInterval:     time.Hour * 7 * 24,
+		missingTolerance: 0,
+		dropTolerance:    time.Hour * 24,
+	})
+
+	// The non-recursive walk lists the per-task top-level dirs under analyze_stats.
+	mockWalk := mockey.Mock((*storage.LocalChunkManager).WalkWithPrefix).To(
+		func(cm *storage.LocalChunkManager, ctx context.Context, prefix string,
+			recursive bool, fn storage.ChunkObjectWalkFunc,
+		) error {
+			if strings.Contains(prefix, common.AnalyzeStatsPath) {
+				fn(&storage.ChunkObjectInfo{
+					FilePath:   path.Join(prefix, "401") + "/",
+					ModifyTime: time.Now().Add(-time.Hour),
+				})
+			}
+			return nil
+		}).Build()
+	defer mockWalk.UnPatch()
+
+	removedPrefixes := []string{}
+	mockRemove := mockey.Mock((*storage.LocalChunkManager).RemoveWithPrefix).To(
+		func(cm *storage.LocalChunkManager, ctx context.Context, prefix string) error {
+			removedPrefixes = append(removedPrefixes, prefix)
+			return nil
+		}).Build()
+	defer mockRemove.UnPatch()
+
+	gc.recycleUnusedAnalyzeFiles(ctx, nil)
+
+	// Analyze files are written under analyze_stats/{taskID}/{version}/... — for a
+	// finished task at Version=2, exactly the stale versions 0 and 1 under the
+	// task's own prefix must be removed, and version 2 must be kept.
+	root := path.Join(cli.RootPath(), common.AnalyzeStatsPath) + "/"
+	assert.ElementsMatch(t, []string{root + "401/0/", root + "401/1/"}, removedPrefixes)
 }
 
 func TestGarbageCollector_recycleUnusedJSONIndexFiles_SnapshotReference(t *testing.T) {

--- a/internal/datacoord/task_analyze.go
+++ b/internal/datacoord/task_analyze.go
@@ -171,7 +171,11 @@ func (at *analyzeTask) CreateTaskOnWorker(nodeID int64, cluster session.Cluster)
 		if info == nil {
 			log.Warn(context.TODO(), "analyze task is processing, but segment is nil, fail the task",
 				mlog.FieldSegmentID(segID))
-			at.SetState(indexpb.JobState_JobStateFailed, fmt.Sprintf("segmentInfo with ID: %d is nil", segID))
+			if err := at.UpdateStateWithMeta(indexpb.JobState_JobStateFailed,
+				fmt.Sprintf("segmentInfo with ID: %d is nil", segID)); err != nil {
+				// State is left untouched, so the scheduler re-enqueues the task and retries.
+				log.Warn(context.TODO(), "failed to persist the failed state of the analyze task", mlog.Err(err))
+			}
 			return
 		}
 		totalSegmentsRows += info.GetNumOfRows()
@@ -202,7 +206,10 @@ func (at *analyzeTask) CreateTaskOnWorker(nodeID int64, cluster session.Cluster)
 						mlog.Float64("raw data size", totalSegmentsRawDataSize),
 						mlog.Int64("num clusters", numClusters),
 						mlog.Int64("minimum num clusters required", Params.DataCoordCfg.ClusteringCompactionMinCentroidsNum.GetAsInt64()))
-					at.SetState(indexpb.JobState_JobStateFinished, "")
+					if err := at.UpdateStateWithMeta(indexpb.JobState_JobStateFinished, ""); err != nil {
+						// State is left untouched, so the scheduler re-enqueues the task and retries.
+						log.Warn(context.TODO(), "failed to persist the finished state of the analyze task", mlog.Err(err))
+					}
 					return
 				}
 				if numClusters > Params.DataCoordCfg.ClusteringCompactionMaxCentroidsNum.GetAsInt64() {

--- a/internal/datacoord/task_analyze_test.go
+++ b/internal/datacoord/task_analyze_test.go
@@ -203,6 +203,12 @@ func (s *analyzeTaskSuite) newTask() *analyzeTask {
 	}, s.mt)
 }
 
+// restoreMetaTask puts back the task the suite was set up with, so a test that
+// persists a state transition does not leak it into the following tests.
+func (s *analyzeTaskSuite) restoreMetaTask(task *indexpb.AnalyzeTask) {
+	s.mt.analyzeMeta.tasks[s.taskID] = task
+}
+
 func (s *analyzeTaskSuite) TestCreateTaskOnWorker_SegmentNil() {
 	// Replace segment 102 with a dropped segment so it's filtered out by isSegmentHealthy
 	s.mt.segments.SetSegment(102, &SegmentInfo{
@@ -230,10 +236,14 @@ func (s *analyzeTaskSuite) TestCreateTaskOnWorker_SegmentNil() {
 	catalog := catalogmocks.NewDataCoordCatalog(s.T())
 	catalog.On("SaveAnalyzeTask", mock.Anything, mock.Anything).Return(nil)
 	s.mt.analyzeMeta.catalog = catalog
+	defer s.restoreMetaTask(s.mt.analyzeMeta.tasks[s.taskID])
 
 	at.CreateTaskOnWorker(1, session.NewMockCluster(s.T()))
 	s.Equal(indexpb.JobState_JobStateFailed, at.GetState())
 	s.Contains(at.GetFailReason(), "102")
+	// The terminal state must be persisted, not only set on the scheduler-owned copy.
+	s.Equal(indexpb.JobState_JobStateFailed, s.mt.analyzeMeta.GetTask(s.taskID).GetState())
+	s.Contains(s.mt.analyzeMeta.GetTask(s.taskID).GetFailReason(), "102")
 }
 
 func (s *analyzeTaskSuite) TestCreateTaskOnWorker_DimExtractionError() {
@@ -274,10 +284,36 @@ func (s *analyzeTaskSuite) TestCreateTaskOnWorker_DataTooSmall() {
 	catalog := catalogmocks.NewDataCoordCatalog(s.T())
 	catalog.On("SaveAnalyzeTask", mock.Anything, mock.Anything).Return(nil)
 	s.mt.analyzeMeta.catalog = catalog
+	defer s.restoreMetaTask(s.mt.analyzeMeta.tasks[s.taskID])
 
 	at.CreateTaskOnWorker(1, session.NewMockCluster(s.T()))
 	// data too small → skip → mark as finished
 	s.Equal(indexpb.JobState_JobStateFinished, at.GetState())
+	// Persisting Finished is what lets the GC recycle the task's analyze stats files.
+	s.Equal(indexpb.JobState_JobStateFinished, s.mt.analyzeMeta.GetTask(s.taskID).GetState())
+}
+
+func (s *analyzeTaskSuite) TestCreateTaskOnWorker_TerminalStateNotPersisted() {
+	// Set MinCentroidsNum very high so data is considered too small
+	origMin := Params.DataCoordCfg.ClusteringCompactionMinCentroidsNum.SwapTempValue("999999999")
+	defer Params.DataCoordCfg.ClusteringCompactionMinCentroidsNum.SwapTempValue(origMin)
+
+	at := s.newTask()
+	catalog := catalogmocks.NewDataCoordCatalog(s.T())
+	// The first save is UpdateVersion, the second one is the terminal state transition.
+	catalog.On("SaveAnalyzeTask", mock.Anything, mock.Anything).Return(nil).Once()
+	catalog.On("SaveAnalyzeTask", mock.Anything, mock.Anything).
+		Return(merr.WrapErrServiceInternalMsg("mock save error")).Once()
+	catalog.On("SaveAnalyzeTask", mock.Anything, mock.Anything).Return(nil)
+	s.mt.analyzeMeta.catalog = catalog
+	defer s.restoreMetaTask(s.mt.analyzeMeta.tasks[s.taskID])
+	stateBefore := s.mt.analyzeMeta.GetTask(s.taskID).GetState()
+
+	at.CreateTaskOnWorker(1, session.NewMockCluster(s.T()))
+	// A failed persistence leaves the task at Init so the scheduler re-enqueues it,
+	// rather than dropping it on an in-memory-only terminal state.
+	s.Equal(indexpb.JobState_JobStateInit, at.GetState())
+	s.Equal(stateBefore, s.mt.analyzeMeta.GetTask(s.taskID).GetState())
 }
 
 func (s *analyzeTaskSuite) TestCreateTaskOnWorker_NumClustersCapped() {


### PR DESCRIPTION
Cherry-pick from master

pr: #51516
issue: #51512

## Summary

Cherry-picked from master PR #51516 (merged)

## Verification

- [x] File count matches original PR
- [x] Code changes verified against master PR diff (line-level comparison)
- [x] No conflict markers
- [ ] make static-check (skipped by cherry-pick workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
