### PR TITLE
fix: [cp2.6]honor gc pause timeout

### DIFF
--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -88,10 +88,15 @@ type gcCmd struct {
 	collectionID int64
 	ticket       string
 	done         chan error
+	ctx          context.Context
 	timeout      <-chan struct{}
 }
 
 type gcPauseRecord struct {
+	// id uniquely identifies this record within its gcPauseRecords. Tickets are
+	// not unique -- the REST route in restful_mgr_routes.go issues every pause
+	// with an empty ticket -- so rollback must delete by id, not by ticket.
+	id         int64
 	ticket     string
 	pauseUntil time.Time
 }
@@ -99,6 +104,7 @@ type gcPauseRecord struct {
 type gcPauseRecords struct {
 	mut     sync.RWMutex
 	maxLen  int
+	nextID  int64
 	records typeutil.Heap[gcPauseRecord]
 }
 
@@ -117,17 +123,15 @@ func (gc *gcPauseRecords) PauseUntil() time.Time {
 	return gc.records.Peek().pauseUntil
 }
 
-func (gc *gcPauseRecords) Insert(ticket string, pauseUntil time.Time) error {
+// Insert records a pause ticket and returns the id of the record it created, so
+// that a failed pause can roll back exactly its own record via DeleteByID.
+func (gc *gcPauseRecords) Insert(ticket string, pauseUntil time.Time) (int64, error) {
 	gc.mut.Lock()
 	defer gc.mut.Unlock()
 
 	// heap small enough, short path
 	if gc.records.Len() < gc.maxLen {
-		gc.records.Push(gcPauseRecord{
-			ticket:     ticket,
-			pauseUntil: pauseUntil,
-		})
-		return nil
+		return gc.pushLocked(ticket, pauseUntil), nil
 	}
 
 	records := make([]gcPauseRecord, 0, gc.records.Len())
@@ -143,25 +147,46 @@ func (gc *gcPauseRecords) Insert(ticket string, pauseUntil time.Time) error {
 	})
 
 	if gc.records.Len() < gc.maxLen {
-		gc.records.Push(gcPauseRecord{
-			ticket:     ticket,
-			pauseUntil: pauseUntil,
-		})
-		return nil
+		return gc.pushLocked(ticket, pauseUntil), nil
 	}
 
 	// too many pause records, refresh heap
-	return merr.WrapErrTooManyRequests(64, "too many pause records")
+	return 0, merr.WrapErrTooManyRequests(64, "too many pause records")
 }
 
+// pushLocked appends a new record with a freshly allocated id. Caller must hold mut.
+func (gc *gcPauseRecords) pushLocked(ticket string, pauseUntil time.Time) int64 {
+	gc.nextID++
+	gc.records.Push(gcPauseRecord{
+		id:         gc.nextID,
+		ticket:     ticket,
+		pauseUntil: pauseUntil,
+	})
+	return gc.nextID
+}
+
+// Delete drops every record holding the given ticket. This is the user-facing
+// resume semantic ("release my ticket"); use DeleteByID to undo a single record.
 func (gc *gcPauseRecords) Delete(ticket string) {
+	gc.deleteMatching(func(r gcPauseRecord) bool { return r.ticket == ticket })
+}
+
+// DeleteByID drops the single record with the given id, leaving records that
+// merely share its ticket untouched.
+func (gc *gcPauseRecords) DeleteByID(id int64) {
+	gc.deleteMatching(func(r gcPauseRecord) bool { return r.id == id })
+}
+
+// deleteMatching rebuilds the heap without the matching records, dropping
+// already-expired records along the way.
+func (gc *gcPauseRecords) deleteMatching(match func(gcPauseRecord) bool) {
 	gc.mut.Lock()
 	defer gc.mut.Unlock()
 	now := time.Now()
 	records := make([]gcPauseRecord, 0, gc.records.Len())
 	for gc.records.Len() > 0 {
 		record := gc.records.Pop()
-		if now.Before(record.pauseUntil) && record.ticket != ticket {
+		if now.Before(record.pauseUntil) && !match(record) {
 			records = append(records, record)
 		}
 	}
@@ -292,11 +317,17 @@ func (gc *garbageCollector) Pause(ctx context.Context, collectionID int64, ticke
 		collectionID: collectionID,
 		ticket:       ticket,
 		done:         done,
+		ctx:          ctx,
 		timeout:      ctx.Done(),
 	}:
 		return <-done
 	case <-ctx.Done():
 		return ctx.Err()
+	case <-gc.ctx.Done():
+		// cmdCh is unbuffered and startControlLoop has already returned, so the
+		// send above can never be received; without this arm the caller parks
+		// until its own ctx is canceled (forever for a Done()-less ctx).
+		return merr.WrapErrServiceUnavailable("garbage collector is closing")
 	}
 }
 
@@ -318,6 +349,9 @@ func (gc *garbageCollector) Resume(ctx context.Context, collectionID int64, tick
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
+	case <-gc.ctx.Done():
+		// see Pause: the control loop is gone, nothing will receive this send.
+		return merr.WrapErrServiceUnavailable("garbage collector is closing")
 	}
 }
 
@@ -397,8 +431,9 @@ func (gc *garbageCollector) pause(cmd gcCmd) error {
 		zap.Duration("duration", cmd.duration),
 	)
 	var err error
+	var recordID int64
 	if cmd.collectionID <= 0 { // legacy pause all
-		err = gc.pauseUntil.Insert(cmd.ticket, reqPauseUntil)
+		recordID, err = gc.pauseUntil.Insert(cmd.ticket, reqPauseUntil)
 		log.Info("global pause ticket recorded")
 	} else {
 		curr, has := gc.pausedCollection.Get(cmd.collectionID)
@@ -406,7 +441,7 @@ func (gc *garbageCollector) pause(cmd gcCmd) error {
 			curr = NewGCPauseRecords()
 			gc.pausedCollection.Insert(cmd.collectionID, curr)
 		}
-		err = curr.Insert(cmd.ticket, reqPauseUntil)
+		recordID, err = curr.Insert(cmd.ticket, reqPauseUntil)
 		log.Info("collection new pause ticket recorded")
 	}
 	if err != nil {
@@ -421,12 +456,44 @@ func (gc *garbageCollector) pause(cmd gcCmd) error {
 	}
 	select {
 	case signalCh <- signal:
-		<-signal.done
+		select {
+		case <-signal.done:
+		case <-cmd.timeout:
+			gc.rollbackPause(cmd, recordID)
+			return cmd.ctx.Err()
+		}
 	case <-cmd.timeout:
 		// timeout, resume the pause
-		gc.resume(cmd)
+		gc.rollbackPause(cmd, recordID)
+		return cmd.ctx.Err()
+	case <-gc.ctx.Done():
+		// The collector is closing. The meta worker may already have returned on
+		// its own ctx.Done(), and signalCh is unbuffered, so the send above would
+		// never be received: bound the wait by the collector's lifetime instead of
+		// parking this control-loop goroutine and hanging gc.wg.Wait() in close().
+		gc.rollbackPause(cmd, recordID)
+		return merr.WrapErrServiceUnavailable("garbage collector is closing")
 	}
 	return nil
+}
+
+// rollbackPause undoes exactly the record this pause() call inserted. It must not
+// go through resume(), whose delete is ticket-scoped: tickets are not unique --
+// every pause issued by the REST route in restful_mgr_routes.go carries an empty
+// ticket -- so a ticket-scoped delete would also drop a concurrent caller's
+// still-valid pause record and resume GC while that caller believes it is paused.
+func (gc *garbageCollector) rollbackPause(cmd gcCmd, recordID int64) {
+	if cmd.collectionID <= 0 {
+		gc.pauseUntil.DeleteByID(recordID)
+	} else if curr, has := gc.pausedCollection.Get(cmd.collectionID); has {
+		curr.DeleteByID(recordID)
+		if curr.Len() == 0 || time.Now().After(curr.PauseUntil()) {
+			gc.pausedCollection.Remove(cmd.collectionID)
+		}
+	}
+	log.Info("pause rolled back",
+		zap.Int64("collectionID", cmd.collectionID),
+		zap.String("ticket", cmd.ticket))
 }
 
 func (gc *garbageCollector) resume(cmd gcCmd) {

--- a/internal/datacoord/garbage_collector_test.go
+++ b/internal/datacoord/garbage_collector_test.go
@@ -1727,6 +1727,119 @@ func (s *GarbageCollectorSuite) TestPauseResume() {
 		s.Zero(gc.pauseUntil.PauseUntil())
 	})
 
+	s.Run("pause_timeout_after_signal_received", func() {
+		gc := newGarbageCollector(s.meta, newMockHandler(), GcOption{
+			cli:              s.cli,
+			enabled:          true,
+			checkInterval:    time.Hour,
+			scanInterval:     time.Hour * 7 * 24,
+			missingTolerance: time.Hour * 24,
+			dropTolerance:    time.Hour * 24,
+		})
+
+		controlDone := make(chan struct{})
+		go func() {
+			defer close(controlDone)
+			gc.startControlLoop(context.Background())
+		}()
+		defer func() {
+			gc.cancel()
+			<-controlDone
+			gc.option.removeObjectPool.Release()
+		}()
+
+		signalCh := make(chan gcCmd, 1)
+		go func() {
+			signalCh <- <-gc.controlChannels["meta"]
+		}()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		pauseDone := make(chan error, 1)
+		go func() {
+			pauseDone <- gc.Pause(ctx, -1, "timeout-ticket", time.Minute)
+		}()
+
+		// Receiving here means the meta worker already took the signal, so pause()
+		// is past the send and parked in the ack wait.
+		select {
+		case <-signalCh:
+		case <-time.After(time.Second * 5):
+			s.T().Fatal("pause signal was not delivered to meta worker")
+		}
+
+		// Deliberately never close signal.done: canceling only now makes the inner
+		// select take its timeout arm, with no dependency on wall-clock ordering.
+		cancel()
+
+		err := <-pauseDone
+		s.ErrorIs(err, context.Canceled)
+		s.Zero(gc.pauseUntil.PauseUntil())
+	})
+
+	// Tickets are not unique: the REST route in restful_mgr_routes.go issues every
+	// pause with an empty ticket. A failed pause must therefore roll back only its
+	// own record -- a ticket-scoped delete would also wipe a concurrent caller's
+	// still-valid pause and silently resume GC while that caller believes it is
+	// paused.
+	s.Run("pause_rollback_preserves_other_empty_ticket_record", func() {
+		gc := newGarbageCollector(s.meta, newMockHandler(), GcOption{
+			cli:              s.cli,
+			enabled:          true,
+			checkInterval:    time.Hour,
+			scanInterval:     time.Hour * 7 * 24,
+			missingTolerance: time.Hour * 24,
+			dropTolerance:    time.Hour * 24,
+		})
+
+		controlDone := make(chan struct{})
+		go func() {
+			defer close(controlDone)
+			gc.startControlLoop(context.Background())
+		}()
+		defer func() {
+			gc.cancel()
+			<-controlDone
+			gc.option.removeObjectPool.Release()
+		}()
+
+		metaCh := gc.controlChannels["meta"]
+		secondSignal := make(chan struct{})
+		go func() {
+			// Ack the first pause so it completes.
+			cmd := <-metaCh
+			close(cmd.done)
+			// Take the second pause's signal but never ack it, parking pause() in
+			// the inner ack wait so its rollback path is the one exercised.
+			<-metaCh
+			close(secondSignal)
+		}()
+
+		// First caller: a successful global pause with an empty ticket.
+		s.NoError(gc.Pause(context.Background(), -1, "", time.Minute))
+		firstUntil := gc.pauseUntil.PauseUntil()
+		s.NotZero(firstUntil)
+
+		// Second caller: same empty ticket, canceled while waiting for the ack.
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		pauseDone := make(chan error, 1)
+		go func() {
+			pauseDone <- gc.Pause(ctx, -1, "", time.Minute)
+		}()
+
+		select {
+		case <-secondSignal:
+		case <-time.After(time.Second * 5):
+			s.T().Fatal("second pause signal was not delivered to meta worker")
+		}
+		cancel()
+		s.ErrorIs(<-pauseDone, context.Canceled)
+
+		// The first caller's pause must survive the second caller's rollback.
+		s.Equal(firstUntil, gc.pauseUntil.PauseUntil())
+	})
+
 	s.Run("pause_collection", func() {
 		gc := newGarbageCollector(s.meta, newMockHandler(), GcOption{
 			cli:              s.cli,

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -1763,9 +1763,9 @@ func (s *Server) GcControl(ctx context.Context, request *datapb.GcControlRequest
 		ticket, _ := common.GetStringValue(request.GetParams(), "ticket")
 
 		if err := s.garbageCollector.Pause(ctx, collectionID, ticket, time.Duration(pauseSeconds)*time.Second); err != nil {
-			status.ErrorCode = commonpb.ErrorCode_UnexpectedError
-			status.Reason = fmt.Sprintf("failed to pause gc, %s", err.Error())
-			return status, nil
+			// merr.Status keeps Code/Retriable, so callers can tell a timeout or a
+			// transient "collector is closing" apart from a genuine failure.
+			return merr.Status(err), nil
 		}
 	case datapb.GcCommand_Resume:
 		collectionID, err, _ := common.GetInt64Value(request.GetParams(), "collection_id")
@@ -1774,9 +1774,7 @@ func (s *Server) GcControl(ctx context.Context, request *datapb.GcControlRequest
 		}
 		ticket, _ := common.GetStringValue(request.GetParams(), "ticket")
 		if err := s.garbageCollector.Resume(ctx, collectionID, ticket); err != nil {
-			status.ErrorCode = commonpb.ErrorCode_UnexpectedError
-			status.Reason = fmt.Sprintf("failed to pause gc, %s", err.Error())
-			return status, nil
+			return merr.Status(err), nil
 		}
 	default:
 		status.ErrorCode = commonpb.ErrorCode_UnexpectedError

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -1682,6 +1682,53 @@ func (s *GcControlServiceSuite) TestPause() {
 	s.True(merr.Ok(resp))
 }
 
+// A pause that times out inside the collector rolls the ticket back and returns
+// the caller's context error. That error must reach the client as a failed
+// status: the timeout path used to return nil, so GcControl reported Success
+// while garbage collection was in fact never paused.
+func (s *GcControlServiceSuite) TestPauseErrorSurfacesAsFailedStatus() {
+	mockPause := mockey.Mock((*garbageCollector).Pause).Return(context.DeadlineExceeded).Build()
+	defer mockPause.UnPatch()
+
+	resp, err := s.server.GcControl(context.Background(), &datapb.GcControlRequest{
+		Command: datapb.GcCommand_Pause,
+		Params: []*commonpb.KeyValuePair{
+			{Key: "duration", Value: "60"},
+		},
+	})
+	s.NoError(err)
+	s.False(merr.Ok(resp))
+	// merr.Ok alone is satisfied by ErrorCode != Success, so assert the typed code
+	// too: a status that flattens to Code=0 leaves callers unable to tell a timeout
+	// from a real failure. Note merr.Error rebuilds the error from the code rather
+	// than restoring the original sentinel, so assert the code, not errors.Is.
+	s.Equal(merr.TimeoutCode, resp.GetCode())
+	s.Equal(merr.TimeoutCode, merr.Code(merr.Error(resp)))
+	// The proxy handler in proxy/management.go still branches on the deprecated
+	// ErrorCode field, so it must stay non-Success.
+	s.NotEqual(commonpb.ErrorCode_Success, resp.GetErrorCode())
+}
+
+// The "collector is closing" error is transient, so the retriable bit must reach
+// the client: merr.CheckRPCCall in restful_mgr_routes.go is what tells a caller
+// to retry, and a hand-built UnexpectedError status would report retriable=false.
+func (s *GcControlServiceSuite) TestPauseUnavailableStaysRetriable() {
+	mockPause := mockey.Mock((*garbageCollector).Pause).
+		Return(merr.WrapErrServiceUnavailable("garbage collector is closing")).Build()
+	defer mockPause.UnPatch()
+
+	resp, err := s.server.GcControl(context.Background(), &datapb.GcControlRequest{
+		Command: datapb.GcCommand_Pause,
+		Params: []*commonpb.KeyValuePair{
+			{Key: "duration", Value: "60"},
+		},
+	})
+	s.NoError(err)
+	s.False(merr.Ok(resp))
+	s.True(resp.GetRetriable())
+	s.ErrorIs(merr.Error(resp), merr.ErrServiceUnavailable)
+}
+
 func (s *GcControlServiceSuite) TestResume() {
 	resp, err := s.server.GcControl(context.TODO(), &datapb.GcControlRequest{
 		Command: datapb.GcCommand_Resume,


### PR DESCRIPTION
Cherry-pick from master

pr: #51607
issue: #51606

## Summary

Cherry-picked from master PR #51607 (merged)

## Backport adaptations (2.6)

- The "pause rolled back" log in `rollbackPause` uses 2.6's `zap`-style logging (master uses `mlog` with ctx, which 2.6 does not have); same for the two pause-ticket logs kept in 2.6 style.

## Verification

- [x] File count matches original PR
- [x] Code changes verified against master PR diff (line-level comparison)
- [x] No conflict markers
- [ ] make static-check (skipped by cherry-pick workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
