### PR TITLE
fix: [cp2.6]wait for segment release after lock timeout

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1024,7 +1024,7 @@ common:
     threshold:
       info: 500 # minimum milliseconds for printing durations in info level
       warn: 1000 # minimum milliseconds for printing durations in warn level
-    maxWLockConditionalWaitTime: 600 # maximum seconds for waiting wlock conditional
+    maxWLockConditionalWaitTime: 600 # seconds before logging a wlock conditional wait that is taking long; the wait itself is not bounded by this value
   storage:
     stv2:
       splitSystemColumn:

--- a/internal/querynodev2/segments/state/load_state_lock.go
+++ b/internal/querynodev2/segments/state/load_state_lock.go
@@ -169,13 +169,13 @@ func (ls *LoadStateLock) StartReleaseAll() (g LoadStateLockGuard) {
 	return g
 }
 
-// blockUntilDataLoadedOrReleased blocks until the segment is loaded or released.
-func (ls *LoadStateLock) BlockUntilDataLoadedOrReleased() bool {
-	var ok bool
+// BlockUntilDataLoadedOrReleased blocks until the segment is loaded or released.
+// It has no return value on purpose: waitOrPanic no longer gives up, so any
+// status it could report would be a constant.
+func (ls *LoadStateLock) BlockUntilDataLoadedOrReleased() {
 	ls.waitOrPanic(func(state loadStateEnum) bool {
 		return state == LoadStateDataLoaded || state == LoadStateReleased
-	}, func() { ok = true })
-	return ok
+	}, func() {})
 }
 
 // waitUntilCanReleaseData waits until segment is release data able.
@@ -189,23 +189,22 @@ func (ls *LoadStateLock) canReleaseAll(state loadStateEnum) bool {
 }
 
 func (ls *LoadStateLock) waitOrPanic(ready func(state loadStateEnum) bool, then func()) {
-	ch := make(chan struct{})
 	maxWaitTime := paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.GetAsDuration(time.Second)
-	go func() {
-		ls.cv.L.Lock()
-		defer ls.cv.L.Unlock()
-		defer close(ch)
-		for !ready(ls.state) {
-			ls.cv.Wait()
-		}
-		then()
-	}()
+	// Watchdog only: the wait below is deliberately unbounded so that then() always
+	// runs and native cleanup is never skipped. This fires once, purely to surface
+	// a release that is taking longer than expected.
+	timer := time.AfterFunc(maxWaitTime, func() {
+		log.Warn("load state lock still waiting, the wait is not bounded and continues until the state is ready",
+			zap.Duration("maxWaitTime", maxWaitTime))
+	})
+	defer timer.Stop()
 
-	select {
-	case <-time.After(maxWaitTime):
-		log.Error("load state lock wait timeout", zap.Duration("maxWaitTime", maxWaitTime))
-	case <-ch:
+	ls.cv.L.Lock()
+	defer ls.cv.L.Unlock()
+	for !ready(ls.state) {
+		ls.cv.Wait()
 	}
+	then()
 }
 
 type StatePredicate func(state loadStateEnum) bool

--- a/internal/querynodev2/segments/state/load_state_lock_test.go
+++ b/internal/querynodev2/segments/state/load_state_lock_test.go
@@ -189,6 +189,42 @@ func TestStartReleaseAll(t *testing.T) {
 	assert.Equal(t, LoadStateReleased, l.state)
 }
 
+func TestStartReleaseAllWaitsAfterTimeoutUntilRefCntZero(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.Key, "0.05")
+	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.Key)
+
+	l := NewLoadStateLock(LoadStateDataLoaded)
+	assert.True(t, l.PinIfNotReleased())
+
+	ch := make(chan LoadStateLockGuard, 1)
+	go func() {
+		ch <- l.StartReleaseAll()
+	}()
+
+	select {
+	case g := <-ch:
+		if g != nil {
+			g.Done(nil)
+		}
+		l.Unpin()
+		t.Fatal("StartReleaseAll returned before refcnt dropped to zero")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	l.Unpin()
+
+	select {
+	case g := <-ch:
+		assert.NotNil(t, g)
+		g.Done(nil)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("StartReleaseAll did not return after refcnt dropped to zero")
+	}
+
+	assert.False(t, l.PinIfNotReleased())
+}
+
 func TestWaitOrPanic(t *testing.T) {
 	paramtable.Init()
 
@@ -208,19 +244,39 @@ func TestWaitOrPanic(t *testing.T) {
 		assert.True(t, executed)
 	})
 
-	t.Run("timeout_panic", func(t *testing.T) {
-		paramtable.Get().Save(paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.Key, "1")
+	t.Run("timeout_keeps_waiting", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.Key, "0.05")
 		defer paramtable.Get().Reset(paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.Key)
 
 		l := NewLoadStateLock(LoadStateOnlyMeta)
 		executed := false
+		ch := make(chan struct{})
 
-		assert.NotPanics(t, func() {
+		go func() {
 			l.waitOrPanic(func(state loadStateEnum) bool {
 				return state == LoadStateDataLoaded
-			}, noop)
-		})
+			}, func() { executed = true })
+			close(ch)
+		}()
+
+		select {
+		case <-ch:
+			t.Fatal("waitOrPanic returned before the predicate became ready")
+		case <-time.After(200 * time.Millisecond):
+		}
 		assert.False(t, executed)
+
+		g, err := l.StartLoadData()
+		assert.NoError(t, err)
+		assert.NotNil(t, g)
+		g.Done(nil)
+
+		select {
+		case <-ch:
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("waitOrPanic did not return after the predicate became ready")
+		}
+		assert.True(t, executed)
 	})
 }
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1080,7 +1080,7 @@ Large numeric passwords require double quotes to avoid yaml parsing precision is
 		Key:          "common.locks.maxWLockConditionalWaitTime",
 		Version:      "2.5.4",
 		DefaultValue: "600",
-		Doc:          "maximum seconds for waiting wlock conditional",
+		Doc:          "seconds before logging a wlock conditional wait that is taking long; the wait itself is not bounded by this value",
 		Export:       true,
 	}
 	p.MaxWLockConditionalWaitTime.Init(base.mgr)


### PR DESCRIPTION
Cherry-pick from master

pr: #51777
issue: #51776

## Summary

Cherry-picked from master PR #51777 (merged)

## Backport adaptations (2.6)

- The watchdog log in `waitOrPanic` uses 2.6's `zap`-style logging (master uses `mlog` with ctx, which 2.6 does not have).
- The configs/milvus.yaml conflict was purely positional (2.6 has extra keys after `maxWLockConditionalWaitTime`); only the doc comment is updated, surrounding 2.6 keys untouched.

## Verification

- [x] File count matches original PR
- [x] Code changes verified against master PR diff (line-level comparison)
- [x] No conflict markers
- [ ] make static-check (skipped by cherry-pick workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
