### PR TITLE
fix: the sparse vector heap overflow issue (#52425)

### DIFF
--- a/internal/proxy/search_util.go
+++ b/internal/proxy/search_util.go
@@ -1107,7 +1107,7 @@ func getMetricType(toReduceResults []*internalpb.SearchResults) string {
 
 func validateSparseFloatVectorPlaceholderGroup(placeholderGroup []byte) error {
 	if len(placeholderGroup) == 0 {
-		return nil
+		return merr.WrapErrParameterInvalidMsg("placeholder group is empty")
 	}
 	pb := &commonpb.PlaceholderGroup{}
 	if err := proto.Unmarshal(placeholderGroup, pb); err != nil {

--- a/internal/proxy/search_util.go
+++ b/internal/proxy/search_util.go
@@ -1104,3 +1104,34 @@ func getMetricType(toReduceResults []*internalpb.SearchResults) string {
 	}
 	return ""
 }
+
+func validateSparseFloatVectorPlaceholderGroup(placeholderGroup []byte) error {
+	if len(placeholderGroup) == 0 {
+		return nil
+	}
+	pb := &commonpb.PlaceholderGroup{}
+	if err := proto.Unmarshal(placeholderGroup, pb); err != nil {
+		return merr.WrapErrParameterInvalidMsg("failed to unmarshal placeholder group: %v", err)
+	}
+
+	foundSparse := false
+	for _, h := range pb.GetPlaceholders() {
+		if h.GetType() != commonpb.PlaceholderType_SparseFloatVector {
+			continue
+		}
+		foundSparse = true
+		if len(h.GetValues()) == 0 {
+			return merr.WrapErrParameterInvalidMsg("sparse float vector search request has no query vectors")
+		}
+		if err := typeutil.ValidateSparseFloatRows(h.GetValues()...); err != nil {
+			return merr.WrapErrParameterInvalidMsg("invalid sparse float vector in search request: %v", err)
+		}
+	}
+
+	if !foundSparse {
+		return merr.WrapErrParameterInvalidMsg(
+			"sparse float vector field expects PlaceholderType_SparseFloatVector (%d) placeholders, found none (placeholder count=%d)",
+			int32(commonpb.PlaceholderType_SparseFloatVector), len(pb.GetPlaceholders()))
+	}
+	return nil
+}

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -698,6 +698,9 @@ func (t *searchTask) initAdvancedSearchRequest(ctx context.Context) error {
 			return err
 		}
 		if typeutil.IsFieldSparseFloatVector(t.schema.CollectionSchema, internalSubReq.FieldId) {
+			if err := validateSparseFloatVectorPlaceholderGroup(internalSubReq.GetPlaceholderGroup()); err != nil {
+				return err
+			}
 			metrics.ProxySearchSparseNumNonZeros.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), t.collectionName, metrics.HybridSearchLabel, strconv.FormatInt(internalSubReq.FieldId, 10)).Observe(float64(typeutil.EstimateSparseVectorNNZFromPlaceholderGroup(internalSubReq.PlaceholderGroup, int(internalSubReq.GetNq()))))
 		}
 		internalSubReq.PlaceholderGroup = convertedPlaceholder
@@ -1047,6 +1050,9 @@ func (t *searchTask) initSearchRequest(ctx context.Context) error {
 	}
 	t.PkFilter = checkSegmentFilter(plan)
 	if typeutil.IsFieldSparseFloatVector(t.schema.CollectionSchema, t.FieldId) {
+		if err := validateSparseFloatVectorPlaceholderGroup(t.request.GetPlaceholderGroup()); err != nil {
+			return err
+		}
 		metrics.ProxySearchSparseNumNonZeros.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), t.collectionName, metrics.SearchLabel, strconv.FormatInt(t.FieldId, 10)).Observe(float64(typeutil.EstimateSparseVectorNNZFromPlaceholderGroup(t.request.GetPlaceholderGroup(), int(t.request.GetNq()))))
 	}
 	// Convert placeholder group vector type if needed (e.g., fp32 -> fp16/bf16)

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -7577,3 +7577,79 @@ func TestSearchTask_SearchRequeryPolicy(t *testing.T) {
 		assert.Contains(t, plan.GetOutputFieldIds(), int64(100))
 	})
 }
+
+func buildSparsePlaceholderGroup(t *testing.T, rows [][]byte) []byte {
+	pg := &commonpb.PlaceholderGroup{
+		Placeholders: []*commonpb.PlaceholderValue{
+			{
+				Tag:    "$0",
+				Type:   commonpb.PlaceholderType_SparseFloatVector,
+				Values: rows,
+			},
+		},
+	}
+	blob, err := proto.Marshal(pg)
+	require.NoError(t, err)
+	return blob
+}
+
+func misalignedSparseRow(size int, fill byte) []byte {
+	b := make([]byte, size)
+	for i := range b {
+		b[i] = fill
+	}
+	return b
+}
+
+func TestValidateSparseFloatVectorPlaceholderGroup(t *testing.T) {
+	validRow := typeutil.CreateSparseFloatRow([]uint32{1, 30, 200}, []float32{1.1, 2.2, 3.3})
+
+	t.Run("empty placeholder group is allowed", func(t *testing.T) {
+		assert.NoError(t, validateSparseFloatVectorPlaceholderGroup(nil))
+		assert.NoError(t, validateSparseFloatVectorPlaceholderGroup([]byte{}))
+	})
+
+	t.Run("valid single sparse row", func(t *testing.T) {
+		blob := buildSparsePlaceholderGroup(t, [][]byte{validRow})
+		assert.NoError(t, validateSparseFloatVectorPlaceholderGroup(blob))
+	})
+
+	t.Run("valid multiple sparse rows (nq>1)", func(t *testing.T) {
+		row2 := typeutil.CreateSparseFloatRow([]uint32{5, 9}, []float32{0.5, 0.9})
+		blob := buildSparsePlaceholderGroup(t, [][]byte{validRow, row2})
+		assert.NoError(t, validateSparseFloatVectorPlaceholderGroup(blob))
+	})
+
+	t.Run("non-sparse placeholder triggers 'found none' error", func(t *testing.T) {
+		pg := &commonpb.PlaceholderGroup{
+			Placeholders: []*commonpb.PlaceholderValue{
+				{
+					Tag:    "$0",
+					Type:   commonpb.PlaceholderType_FloatVector,
+					Values: [][]byte{misalignedSparseRow(9, 0x41)},
+				},
+			},
+		}
+		blob, err := proto.Marshal(pg)
+		require.NoError(t, err)
+		e := validateSparseFloatVectorPlaceholderGroup(blob)
+		assert.Error(t, e)
+		assert.ErrorIs(t, e, merr.ErrParameterInvalid)
+		assert.Contains(t, e.Error(), "expects PlaceholderType_SparseFloatVector")
+		assert.Contains(t, e.Error(), "found none")
+	})
+
+	t.Run("no query vectors", func(t *testing.T) {
+		blob := buildSparsePlaceholderGroup(t, [][]byte{})
+		err := validateSparseFloatVectorPlaceholderGroup(blob)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("misaligned size=9 sparse row (core PoC, 8B alignment violation)", func(t *testing.T) {
+		blob := buildSparsePlaceholderGroup(t, [][]byte{misalignedSparseRow(9, 0x41)})
+		err := validateSparseFloatVectorPlaceholderGroup(blob)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+}


### PR DESCRIPTION
issue: #52425

## Background
On the Search / HybridSearch request path, the sparse float vector query payload is delivered to proxy as a serialized commonpb.PlaceholderGroup blob. The downstream C++ accessor helpers SparseFloatRowIndexAt / SparseFloatRowValueAt are explicitly documented as // does not check for out-of-range access : each sparse element is expected to be 8-byte aligned ( uint32 idx + float32 val ). If a malformed row of length 9 bytes (or any other non-8B-aligned length) reaches segcore, indexing at position i * 8 reads past the heap allocation, producing an out-of-bounds read.

Insert / Upsert / Bulkload paths already call typeutil.ValidateSparseFloatRows inside validate_util.go on the FieldData and are therefore protected. Search / HybridSearch had zero validation on the PlaceholderGroup blob before this fix.

## Changes
### 1. Add a single, focused validation gate (three-defense layered check)
File: search_util.go

Added validateSparseFloatVectorPlaceholderGroup(placeholderGroup []byte) error :

- ① Placeholder type filter : iterate the deserialized PlaceholderGroup, only process entries whose Type == PlaceholderType_SparseFloatVector ; wrong types are silently skipped (combined with tail check below, they fail closed).
- ② Per-row 8B alignment gate : for every sparse value in the placeholder, feed it through typeutil.ValidateSparseFloatRows (the same validator used by the Insert path). Returns ErrParameterInvalid on nil / misaligned length / unsorted indices / negative values.
- ③ Found-none tail check : if the placeholder group blob is non-empty but contains zero SparseFloatVector placeholders (e.g. FloatVector / BinaryVector payloads masquerading as a sparse field), return ErrParameterInvalid with a descriptive message.
### 2. Wire the gate into both reachable Search paths
File: task_search.go

- HybridSearch / SubSearch ( L700-L705 ): guard after IsFieldSparseFloatVector and before the NNZ metric + convertPlaceholder .
- Plain Search ( L1052-L1057 ): identical guard on t.FieldId and t.request.GetPlaceholderGroup() .
The ordering ( IsFieldSparse → validate → NNZ metric → convertPlaceholder ) is intentionally kept the same as the Insert-side "validate before use" policy.

### 3. unit tests
File: task_search_test.go

Added 2 helpers ( buildSparsePlaceholderGroup , misalignedSparseRow ) and 6 subtests:

- empty placeholder group (allowed)
- single / multiple valid rows (allowed, nq=1 / nq>1)
- wrong placeholder type → found none ErrParameterInvalid
- no query vectors → ErrParameterInvalid
- PoC : a 9-byte misaligned sparse row (the user-chosen canonical 8B violation payload) → correctly rejected with ErrParameterInvalid before the request reaches segcore.