### PR TITLE
test: [cp 3.0] pin py for pytest-html to restore E2E pipelines

### DIFF
--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -16,6 +16,9 @@ pytest-assume==2.4.3
 pytest-rerunfailures==14.0
 pytest_tagging==1.6.0
 pytest-html==3.1.1
+# pytest-html 3.1.1 imports py.xml; py used to arrive transitively via
+# pytest-forked until its 1.7.5 release (2026-08-08) dropped the dependency
+py==1.11.0
 delayed-assert==0.3.5
 kubernetes==17.17.0
 PyYAML==6.0.2

--- a/tests/restful_client/requirements.txt
+++ b/tests/restful_client/requirements.txt
@@ -10,6 +10,9 @@ pytest-print==0.2.1
 pytest-level==0.1.1
 pytest-xdist==2.5.0
 pytest-html==3.1.1
+# pytest-html 3.1.1 imports py.xml; py used to arrive transitively via
+# pytest-forked until its 1.7.5 release (2026-08-08) dropped the dependency
+py==1.11.0
 pytest-sugar==0.9.5
 pytest-parallel
 pytest-random-order


### PR DESCRIPTION
Backport #52336 (commit `e8cd33bc9c`) to the 3.0 branch.

Fresh dependency resolution installs `pytest-forked==1.7.5`, which no longer depends on the `py` package. However, the pinned `pytest-html==3.1.1` still imports `py.xml`, causing pytest to abort during plugin loading before collecting any tests:

```text
ModuleNotFoundError: No module named 'py.xml'; 'py' is not a package
```

Pin `py==1.11.0` next to `pytest-html` in the Python client and RESTful client requirements files.

### Verification

- Reproduced the import failure with a clean Python 3.12 environment.
- Verified that `pytest_html.plugin` imports successfully after installing `py==1.11.0`.
- Confirmed the backport patch ID matches the master commit.
- `git diff --check` passes.

pr: #52336

/kind bug
