### PR TITLE
fix: [3.0] Wait for Azure blob copy completion

### DIFF
--- a/internal/storage/azure_object_storage.go
+++ b/internal/storage/azure_object_storage.go
@@ -204,6 +204,71 @@ func (AzureObjectStorage *AzureObjectStorage) CopyObject(ctx context.Context, bu
 	srcURL := srcBlobClient.URL()
 
 	// Start copy operation
-	_, err := dstBlobClient.StartCopyFromURL(ctx, srcURL, &blob.StartCopyFromURLOptions{})
-	return mapObjectStorageError(dstObjectName, err)
+	resp, err := dstBlobClient.StartCopyFromURL(ctx, srcURL, &blob.StartCopyFromURLOptions{})
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return mapObjectStorageError(dstObjectName, err)
+	}
+
+	copyID := ""
+	if resp.CopyID != nil {
+		copyID = *resp.CopyID
+	}
+
+	copyStatus := blob.CopyStatusType("")
+	if resp.CopyStatus != nil {
+		copyStatus = *resp.CopyStatus
+	}
+	copyStatusDescription := ""
+
+	if copyStatus == blob.CopyStatusTypePending {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+
+		for copyStatus == blob.CopyStatusTypePending {
+			props, err := dstBlobClient.GetProperties(ctx, &blob.GetPropertiesOptions{})
+			if err != nil {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctxErr
+				}
+				return mapObjectStorageError(dstObjectName, err)
+			}
+
+			copyStatus = blob.CopyStatusType("")
+			if props.CopyStatus != nil {
+				copyStatus = *props.CopyStatus
+			}
+			if props.CopyStatusDescription != nil {
+				copyStatusDescription = *props.CopyStatusDescription
+			}
+
+			if copyStatus != blob.CopyStatusTypePending {
+				break
+			}
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-ticker.C:
+			}
+		}
+	}
+
+	if copyStatus == blob.CopyStatusTypeSuccess {
+		return nil
+	}
+
+	status := string(copyStatus)
+	if status == "" {
+		status = "unknown"
+	}
+	return merr.WrapErrIoFailedMsg(
+		"Azure copy failed for %s: copyID=%s, status=%s, description=%s",
+		dstObjectName,
+		copyID,
+		status,
+		copyStatusDescription,
+	)
 }

--- a/internal/storage/azure_object_storage_test.go
+++ b/internal/storage/azure_object_storage_test.go
@@ -21,12 +21,17 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/service"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -399,6 +404,234 @@ func TestAzureObjectStorage(t *testing.T) {
 			err = testCM.RemoveObject(ctx, config.BucketName, dstKey)
 			assert.NoError(t, err)
 		})
+	})
+}
+
+func newAzureCopyTestStorage(t *testing.T, handler http.Handler) *AzureObjectStorage {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client, err := service.NewClientWithNoCredential(server.URL, nil)
+	require.NoError(t, err)
+	return &AzureObjectStorage{Client: client}
+}
+
+func writeAzureCopyHeaders(w http.ResponseWriter, status blob.CopyStatusType, description string) {
+	w.Header().Set("ETag", `"etag"`)
+	w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+	w.Header().Set("x-ms-copy-id", "copy-id")
+	w.Header().Set("x-ms-copy-status", string(status))
+	if description != "" {
+		w.Header().Set("x-ms-copy-status-description", description)
+	}
+}
+
+func TestAzureObjectStorageCopyStatus(t *testing.T) {
+	const (
+		bucketName = "bucket"
+		srcKey     = "src"
+		dstKey     = "dst"
+	)
+
+	t.Run("initial success", func(t *testing.T) {
+		var propertiesCalls atomic.Int32
+		storage := newAzureCopyTestStorage(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodPut:
+				writeAzureCopyHeaders(w, blob.CopyStatusTypeSuccess, "")
+				w.WriteHeader(http.StatusAccepted)
+			case http.MethodHead:
+				propertiesCalls.Add(1)
+				w.WriteHeader(http.StatusInternalServerError)
+			default:
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		}))
+
+		err := storage.CopyObject(context.Background(), bucketName, srcKey, dstKey)
+		require.NoError(t, err)
+		assert.Zero(t, propertiesCalls.Load())
+	})
+
+	t.Run("start copy failed", func(t *testing.T) {
+		storage := newAzureCopyTestStorage(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+		}))
+
+		err := storage.CopyObject(context.Background(), bucketName, srcKey, dstKey)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrIoFailed)
+	})
+
+	t.Run("context canceled before start", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		storage := newAzureCopyTestStorage(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+
+		err := storage.CopyObject(ctx, bucketName, srcKey, dstKey)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("missing initial status", func(t *testing.T) {
+		storage := newAzureCopyTestStorage(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("ETag", `"etag"`)
+			w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+			w.Header().Set("x-ms-copy-id", "copy-id")
+			w.WriteHeader(http.StatusAccepted)
+		}))
+
+		err := storage.CopyObject(context.Background(), bucketName, srcKey, dstKey)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrIoFailed)
+		assert.ErrorContains(t, err, "status=unknown")
+	})
+
+	t.Run("pending then success", func(t *testing.T) {
+		var propertiesCalls atomic.Int32
+		storage := newAzureCopyTestStorage(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodPut:
+				writeAzureCopyHeaders(w, blob.CopyStatusTypePending, "")
+				w.WriteHeader(http.StatusAccepted)
+			case http.MethodHead:
+				propertiesCalls.Add(1)
+				writeAzureCopyHeaders(w, blob.CopyStatusTypeSuccess, "")
+				w.WriteHeader(http.StatusOK)
+			default:
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		}))
+
+		err := storage.CopyObject(context.Background(), bucketName, srcKey, dstKey)
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), propertiesCalls.Load())
+	})
+
+	t.Run("pending twice then success", func(t *testing.T) {
+		var propertiesCalls atomic.Int32
+		storage := newAzureCopyTestStorage(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodPut:
+				writeAzureCopyHeaders(w, blob.CopyStatusTypePending, "")
+				w.WriteHeader(http.StatusAccepted)
+			case http.MethodHead:
+				if propertiesCalls.Add(1) == 1 {
+					writeAzureCopyHeaders(w, blob.CopyStatusTypePending, "")
+				} else {
+					writeAzureCopyHeaders(w, blob.CopyStatusTypeSuccess, "")
+				}
+				w.WriteHeader(http.StatusOK)
+			default:
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		}))
+
+		err := storage.CopyObject(context.Background(), bucketName, srcKey, dstKey)
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), propertiesCalls.Load())
+	})
+
+	t.Run("get properties failed", func(t *testing.T) {
+		storage := newAzureCopyTestStorage(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodPut:
+				writeAzureCopyHeaders(w, blob.CopyStatusTypePending, "")
+				w.WriteHeader(http.StatusAccepted)
+			case http.MethodHead:
+				w.WriteHeader(http.StatusBadRequest)
+			default:
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		}))
+
+		err := storage.CopyObject(context.Background(), bucketName, srcKey, dstKey)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrIoFailed)
+	})
+
+	t.Run("pending then failed", func(t *testing.T) {
+		storage := newAzureCopyTestStorage(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodPut:
+				writeAzureCopyHeaders(w, blob.CopyStatusTypePending, "")
+				w.WriteHeader(http.StatusAccepted)
+			case http.MethodHead:
+				writeAzureCopyHeaders(w, blob.CopyStatusTypeFailed, "copy failed by service")
+				w.WriteHeader(http.StatusOK)
+			default:
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		}))
+
+		err := storage.CopyObject(context.Background(), bucketName, srcKey, dstKey)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrIoFailed)
+		assert.ErrorContains(t, err, "status=failed")
+		assert.ErrorContains(t, err, "copy failed by service")
+	})
+
+	t.Run("context canceled while pending", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		propertiesStarted := make(chan struct{})
+		storage := newAzureCopyTestStorage(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodPut:
+				writeAzureCopyHeaders(w, blob.CopyStatusTypePending, "")
+				w.WriteHeader(http.StatusAccepted)
+			case http.MethodHead:
+				close(propertiesStarted)
+				<-r.Context().Done()
+			default:
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		}))
+
+		go func() {
+			<-propertiesStarted
+			cancel()
+		}()
+
+		err := storage.CopyObject(ctx, bucketName, srcKey, dstKey)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("context canceled while waiting", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		propertiesReturned := make(chan struct{})
+		storage := newAzureCopyTestStorage(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodPut:
+				writeAzureCopyHeaders(w, blob.CopyStatusTypePending, "")
+				w.WriteHeader(http.StatusAccepted)
+			case http.MethodHead:
+				writeAzureCopyHeaders(w, blob.CopyStatusTypePending, "")
+				w.WriteHeader(http.StatusOK)
+				if flusher, ok := w.(http.Flusher); ok {
+					flusher.Flush()
+				}
+				close(propertiesReturned)
+			default:
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		}))
+
+		go func() {
+			<-propertiesReturned
+			time.Sleep(20 * time.Millisecond)
+			cancel()
+		}()
+
+		err := storage.CopyObject(ctx, bucketName, srcKey, dstKey)
+		require.ErrorIs(t, err, context.Canceled)
 	})
 }
 


### PR DESCRIPTION
issue: #52125
pr: #52440

## What changed

- Backport Azure copy-status polling to the 3.0 branch.
- Return success only after Azure reports copy success.
- Preserve context cancellation and return an I/O error for failed or
  unknown copy statuses.

## Backport details

Clean cherry-pick of the master fix onto `milvus/3.0` with no conflicts or
target-specific code changes. The feature patch-id matches the master change.

## Validation

- `git diff --check milvus/3.0...HEAD`
- Source change: `GOTOOLCHAIN=auto make build-go`
- Source targeted race tests passed for all 10 Azure copy status cases.
- Source `CopyObject` coverage: 100%.
- No additional build or test was run for the identical 3.0 backport.
