### PR TITLE
enhance: speed up metacache segment id filters

### DIFF
--- a/internal/flushcommon/metacache/meta_cache.go
+++ b/internal/flushcommon/metacache/meta_cache.go
@@ -248,19 +248,17 @@ func (c *metaCacheImpl) rangeWithFilter(fn func(id int64, info *SegmentInfo), fi
 	}
 
 	for _, candidate := range candidates {
-		var segments map[int64]*SegmentInfo
 		if criterion.ids != nil {
-			segments = lo.SliceToMap(lo.FilterMap(criterion.ids.Collect(), func(id int64, _ int) (*SegmentInfo, bool) {
+			for id := range criterion.ids {
 				segment, ok := candidate[id]
-				return segment, ok
-			}), func(segment *SegmentInfo) (int64, *SegmentInfo) {
-				return segment.SegmentID(), segment
-			})
-		} else {
-			segments = candidate
+				if ok && criterion.Match(segment) {
+					fn(id, segment)
+				}
+			}
+			continue
 		}
 
-		for id, segment := range segments {
+		for id, segment := range candidate {
 			if criterion.Match(segment) {
 				fn(id, segment)
 			}


### PR DESCRIPTION
issue: #52443

## What changed

`metaCacheImpl.rangeWithFilter` now handles `WithSegmentIDs(...)` by iterating the requested IDs and probing each candidate map directly. This avoids materializing an intermediate map before applying the remaining filters.

## Why

ID-filtered metacache lookups are used by DataNode flush and write-buffer paths such as segment state updates and start-position bookkeeping. The existing ID criterion already narrows the candidate set, so a direct lookup preserves behavior while reducing allocation and lookup work.

## Verification

Behavior-pinning tests:

```bash
GOWORK=off PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig \
LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:/home/sheep/workspace/milvus/internal/core/output/lib64:/home/sheep/workspace/milvus/cmake_build/lib \
LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:/home/sheep/workspace/milvus/internal/core/output/lib64:/home/sheep/workspace/milvus/cmake_build/lib \
go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/flushcommon/metacache
```

Result: passed.

Benchmark, median of 5 runs measured before and after in the same session:

| benchmark | before | after |
|---|---:|---:|
| `BenchmarkGetSegmentsBy` time | 1555 ns/op | **684.7 ns/op (2.27x faster)** |
| `BenchmarkGetSegmentsBy` bytes | 480 B/op | **272 B/op (-43%)** |
| `BenchmarkGetSegmentsBy` allocs | 10 allocs/op | **6 allocs/op (-40%)** |

Static check:

```bash
GOWORK=off make static-check
```

Result: passed. Local note: the nested worktree reused the main checkout's C++ `milvus_core.pc`/libraries and a locally generated ignored `cmd/tools/migration/legacy/legacypb` package to satisfy the current static-check environment.
