### PR TITLE
fix: isolate streaming insert/delete applies onto a dedicated CGO pool (#49435)

### DIFF
--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -839,7 +839,15 @@ func (s *LocalSegment) Delete(ctx context.Context, primaryKeys storage.PrimaryKe
 	// been applied to this segment, and skipping them causes silent data loss.
 
 	var err error
-	GetDynamicPool().Submit(func() (any, error) {
+	// issue #49435: run the streaming delete-apply on the dedicated deletePool
+	// instead of the shared dynamicPool. dynamicPool is also used by the bulk
+	// deltalog load (C.LoadDeletedRecord in LoadDeltaData), which can take tens
+	// of seconds per call under a segment-load storm. Sharing one pool makes the
+	// tiny (~ms) tsafe-critical forward delete queue behind those giant loads,
+	// starving the delegator's ProcessDelete -> UpdateTSafe and freezing the
+	// channel tsafe (505 channel tsafe stalled). A separate pool keeps the
+	// delete-apply off that queue.
+	GetDeletePool().Submit(func() (struct{}, error) {
 		start := time.Now()
 		defer func() {
 			metrics.QueryNodeCGOCallLatency.WithLabelValues(
@@ -852,7 +860,7 @@ func (s *LocalSegment) Delete(ctx context.Context, primaryKeys storage.PrimaryKe
 			PrimaryKeys: primaryKeys,
 			Timestamps:  timestamps,
 		})
-		return nil, nil
+		return struct{}{}, nil
 	}).Await()
 
 	if err != nil {

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -784,7 +784,17 @@ func (s *LocalSegment) Insert(ctx context.Context, rowIDs []int64, timestamps []
 
 	var result *segcore.InsertResult
 	var err error
-	GetDynamicPool().Submit(func() (any, error) {
+	submitTime := time.Now()
+	// issue #49435: run the tsafe-critical growing-segment insert on the
+	// dedicated deletePool (the streaming-pipeline apply pool, shared with the
+	// delete-apply) rather than the shared dynamicPool that the bulk deltalog
+	// load (C.LoadDeletedRecord) can hold for tens of seconds. insertNode is
+	// upstream of deleteNode on the tsafe pipeline, so a queued insert freezes
+	// tsafe just like a queued delete does.
+	GetDeletePool().Submit(func() (struct{}, error) {
+		metrics.QueryNodeCGOQueueLatency.WithLabelValues(
+			fmt.Sprint(paramtable.GetNodeID()), "Insert", "deletePool",
+		).Observe(float64(time.Since(submitTime).Milliseconds()))
 		start := time.Now()
 		defer func() {
 			metrics.QueryNodeCGOCallLatency.WithLabelValues(
@@ -799,7 +809,7 @@ func (s *LocalSegment) Insert(ctx context.Context, rowIDs []int64, timestamps []
 			Timestamps: timestamps,
 			Record:     record,
 		})
-		return nil, nil
+		return struct{}{}, nil
 	}).Await()
 
 	if err != nil {
@@ -847,7 +857,11 @@ func (s *LocalSegment) Delete(ctx context.Context, primaryKeys storage.PrimaryKe
 	// starving the delegator's ProcessDelete -> UpdateTSafe and freezing the
 	// channel tsafe (505 channel tsafe stalled). A separate pool keeps the
 	// delete-apply off that queue.
+	submitTime := time.Now()
 	GetDeletePool().Submit(func() (struct{}, error) {
+		metrics.QueryNodeCGOQueueLatency.WithLabelValues(
+			fmt.Sprint(paramtable.GetNodeID()), "Delete", "deletePool",
+		).Observe(float64(time.Since(submitTime).Milliseconds()))
 		start := time.Now()
 		defer func() {
 			metrics.QueryNodeCGOCallLatency.WithLabelValues(

--- a/pkg/metrics/querynode_metrics.go
+++ b/pkg/metrics/querynode_metrics.go
@@ -879,6 +879,23 @@ var (
 			cgoTypeLabelName,
 		})
 
+	// QueryNodeCGOQueueLatency measures how long a cgo call waited for a
+	// thread-pool slot before it started executing. issue #49435 instrumentation
+	// (temporary): a large wait on the tsafe-critical Insert/Delete applies means
+	// they were queued behind bulk loads (LoadDeletedRecord) sharing the pool.
+	QueryNodeCGOQueueLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "cgo_queue_latency",
+			Help:      "issue #49435: time a cgo call waited for a thread-pool slot before executing",
+			Buckets:   buckets,
+		}, []string{
+			nodeIDLabelName,
+			cgoNameLabelName,
+			"pool",
+		})
+
 	QueryNodePartialResultCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: milvusNamespace,
@@ -982,6 +999,7 @@ func RegisterQueryNode(registry *prometheus.Registry) {
 	registry.MustRegister(QueryNodeDeleteBufferSize)
 	registry.MustRegister(QueryNodeDeleteBufferRowNum)
 	registry.MustRegister(QueryNodeCGOCallLatency)
+	registry.MustRegister(QueryNodeCGOQueueLatency)
 	registry.MustRegister(QueryNodePartialResultCount)
 	// Pool metrics collector (pull model - collectFn set later via SetPoolCollectFn)
 	registry.MustRegister(&poolMetricsCollector{})


### PR DESCRIPTION
Related issue: #49435

## What & why

The tsafe-critical streaming applies `C.Insert` / `C.Delete` (the insert/delete flowgraph nodes that advance channel tsafe) shared the CPU-core-sized `dynamicPool` with the bulk deltalog apply `C.LoadDeletedRecord`. On a CPU-constrained standalone under a segment-load storm, the giant `LoadDeletedRecord` calls (tens of seconds each, aggravated by CFS throttling) saturate every pool slot, so the tiny insert/delete applies queue behind them, the flowgraph stalls before `UpdateTSafe`, and channel tsafe freezes — surfacing as `code=505 channel tsafe stalled` on concurrent Strong queries during heavy upsert.

This routes the streaming insert/delete applies to the dedicated `deletePool`, separate from the shared `dynamicPool`. They then keep their own pool slots and advance tsafe regardless of how saturated or slow the shared pool gets. It also adds `cgo_queue_latency` (a histogram of pool-slot wait time per cgo call, labelled by `cgo_name`/`pool`) to make the contention observable.

## Validation

fouram concurrent case (heavy upsert + Strong `count(*)`, 8-core standalone), with `dataCoord.sealPolicy.channel.blockingL0EntryNum` left at the default so the delete buffer still peaks ~8.9M and `LoadDeletedRecord` still takes 30–60s (every stall precondition present): **8/8 runs, 0 tsafe stalls**, while CFS throttle stayed 0.62–1.00 and the insert/delete pool-wait dropped to **1–56ms**. Full root-cause analysis and A/B data in #49435.

issue: #49435
