### PR TITLE
enhance: [3.0] Keep nullable chunk validity packed

### DIFF
--- a/internal/core/src/common/ArrayOffsets.cpp
+++ b/internal/core/src/common/ArrayOffsets.cpp
@@ -410,7 +410,7 @@ ArrayOffsetsSealed::BuildFromSegment(const void* segment,
 
             for (size_t i = 0; i < vector_array_views.size(); ++i) {
                 int32_t array_len = 0;
-                if (valid_flags.empty() || valid_flags[i]) {
+                if (!valid_flags || valid_flags[i]) {
                     array_len = vector_array_views[i].length();
                 }
 
@@ -427,7 +427,7 @@ ArrayOffsetsSealed::BuildFromSegment(const void* segment,
 
             for (size_t i = 0; i < array_views.size(); ++i) {
                 int32_t array_len = 0;
-                if (valid_flags.empty() || valid_flags[i]) {
+                if (!valid_flags || valid_flags[i]) {
                     array_len = array_views[i].length();
                 }
 
@@ -492,7 +492,7 @@ ArrayOffsetsSealed::BuildFromColumn(const ChunkedColumnInterface& column,
 
             for (size_t i = 0; i < vector_array_views.size(); ++i) {
                 int32_t array_len = 0;
-                if (valid_flags.empty() || valid_flags[i]) {
+                if (!valid_flags || valid_flags[i]) {
                     array_len = vector_array_views[i].length();
                 }
 
@@ -509,7 +509,7 @@ ArrayOffsetsSealed::BuildFromColumn(const ChunkedColumnInterface& column,
 
             for (size_t i = 0; i < array_views.size(); ++i) {
                 int32_t array_len = 0;
-                if (valid_flags.empty() || valid_flags[i]) {
+                if (!valid_flags || valid_flags[i]) {
                     array_len = array_views[i].length();
                 }
 

--- a/internal/core/src/common/Chunk.cpp
+++ b/internal/core/src/common/Chunk.cpp
@@ -15,7 +15,7 @@
 
 namespace milvus {
 
-std::pair<std::vector<std::string_view>, FixedVector<bool>>
+std::pair<std::vector<std::string_view>, ValidityView>
 StringChunk::StringViews(
     std::optional<std::pair<int64_t, int64_t>> offset_len = std::nullopt) {
     auto start_offset = 0;
@@ -46,12 +46,7 @@ StringChunk::StringViews(
     for (auto i = start_offset; i < end_offset; i++) {
         ret.emplace_back(data_ + offsets_[i], offsets_[i + 1] - offsets_[i]);
     }
-    if (nullable_) {
-        FixedVector<bool> res_valid(valid_.begin() + start_offset,
-                                    valid_.begin() + end_offset);
-        return {ret, std::move(res_valid)};
-    }
-    return {ret, {}};
+    return {std::move(ret), Validity(start_offset)};
 }
 
 std::pair<std::vector<std::string_view>, FixedVector<bool>>

--- a/internal/core/src/common/Chunk.h
+++ b/internal/core/src/common/Chunk.h
@@ -13,6 +13,7 @@
 
 #include <unistd.h>
 #include <algorithm>
+#include <bit>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -85,12 +86,6 @@ class Chunk {
           size_(size),
           nullable_(nullable),
           chunk_mmap_guard_(chunk_mmap_guard) {
-        if (nullable) {
-            valid_.reserve(row_nums);
-            for (int i = 0; i < row_nums; i++) {
-                valid_.push_back((data[i >> 3] >> (i & 0x07)) & 1);
-            }
-        }
     }
     virtual ~Chunk() {
         // The ChunkMmapGuard will handle the unmapping and unlinking of the file if it is file backed
@@ -127,18 +122,68 @@ class Chunk {
         return data_;
     }
 
-    FixedVector<bool>&
-    Valid() {
-        return valid_;
-    }
-
     virtual bool
     isValid(int offset) const {
         if (nullable_) {
-            return valid_[offset];
+            return (static_cast<uint8_t>(data_[offset >> 3]) >>
+                    (offset & 0x07)) &
+                   1;
         }
         return true;
     };
+
+    ValidityView
+    Validity(int64_t offset = 0) const {
+        if (!nullable_) {
+            return {};
+        }
+        return ValidityView::FromPacked(reinterpret_cast<const uint8_t*>(data_))
+            .Subview(offset);
+    }
+
+    void
+    ApplyValidityMask(int64_t offset,
+                      int64_t count,
+                      TargetBitmapView target) const {
+        if (!nullable_ || count == 0) {
+            return;
+        }
+        AssertInfo(offset >= 0 && count >= 0 && offset + count <= row_nums_,
+                   "Invalid validity range, offset: {}, count: {}, rows: {}",
+                   offset,
+                   count,
+                   row_nums_);
+
+        const auto validity = Validity(offset);
+        const auto* packed = validity.packed_data();
+        AssertInfo(packed != nullptr, "Packed validity data is missing");
+        const auto read_word = [packed](int64_t bit_offset, int bit_count) {
+            const auto byte_offset = bit_offset >> 3;
+            const auto shift = static_cast<int>(bit_offset & 0x07);
+            const auto bytes = (shift + bit_count + 7) >> 3;
+            uint64_t word = 0;
+            const auto low_bytes = std::min(bytes, 8);
+            for (int i = 0; i < low_bytes; ++i) {
+                word |= uint64_t(packed[byte_offset + i]) << (i * 8);
+            }
+            word >>= shift;
+            if (bytes > 8) {
+                word |= uint64_t(packed[byte_offset + 8]) << (64 - shift);
+            }
+            if (bit_count < 64) {
+                word &= (uint64_t{1} << bit_count) - 1;
+            }
+            return word;
+        };
+
+        for (int64_t i = 0; i < count; i += 64) {
+            const auto bit_count =
+                static_cast<int>(std::min<int64_t>(count - i, 64));
+            auto word = read_word(validity.bit_offset() + i, bit_count);
+            TargetBitmapView validity_word(&word, bit_count);
+            target.view(i).inplace_and(validity_word, bit_count);
+        }
+    }
 
     int64_t
     PhysicalOffsetOf(int64_t logical_offset) const {
@@ -149,20 +194,36 @@ class Chunk {
         if (!nullable_) {
             return logical_offset;
         }
-        AssertInfo(valid_[logical_offset],
+        AssertInfo(isValid(logical_offset),
                    "Logical offset {} is null",
                    logical_offset);
         BuildValidRankBlocks();
         const auto block_id = logical_offset / kValidRankBlockSize;
         int64_t physical_offset = valid_rank_blocks_[block_id];
         const auto block_start = block_id * kValidRankBlockSize;
-        for (int64_t i = block_start; i < logical_offset; ++i) {
-            physical_offset += valid_[i] ? 1 : 0;
-        }
-        return physical_offset;
+        return physical_offset + CountValidBits(block_start, logical_offset);
     }
 
  protected:
+    int64_t
+    CountValidBits(int64_t begin, int64_t end) const {
+        int64_t count = 0;
+        while (begin < end && (begin & 0x07) != 0) {
+            count += isValid(begin) ? 1 : 0;
+            ++begin;
+        }
+        while (begin + 8 <= end) {
+            count += std::popcount(static_cast<unsigned int>(
+                static_cast<uint8_t>(data_[begin >> 3])));
+            begin += 8;
+        }
+        while (begin < end) {
+            count += isValid(begin) ? 1 : 0;
+            ++begin;
+        }
+        return count;
+    }
+
     void
     BuildValidRankBlocks() const {
         std::call_once(valid_rank_blocks_once_, [&]() {
@@ -175,9 +236,7 @@ class Chunk {
                 const auto block_start = block_id * kValidRankBlockSize;
                 const auto block_end =
                     std::min(block_start + kValidRankBlockSize, row_nums_);
-                for (int64_t i = block_start; i < block_end; ++i) {
-                    valid_count += valid_[i] ? 1 : 0;
-                }
+                valid_count += CountValidBits(block_start, block_end);
             }
             valid_rank_blocks_[num_blocks] = valid_count;
         });
@@ -188,8 +247,6 @@ class Chunk {
     int64_t row_nums_;
     uint64_t size_;
     bool nullable_;
-    FixedVector<bool>
-        valid_;  // parse null bitmap to valid_ to be compatible with SpanBase
 
     std::shared_ptr<ChunkMmapGuard> chunk_mmap_guard_{nullptr};
     mutable std::once_flag valid_rank_blocks_once_;
@@ -215,10 +272,8 @@ class FixedWidthChunk : public Chunk {
 
     milvus::SpanBase
     Span() const {
-        return milvus::SpanBase(data_start_,
-                                nullable_ ? valid_.data() : nullptr,
-                                row_nums_,
-                                element_size_ * dim_);
+        return milvus::SpanBase(
+            data_start_, Validity(), row_nums_, element_size_ * dim_);
     }
 
     const char*
@@ -283,7 +338,7 @@ class StringChunk : public Chunk {
         return {data_ + offsets_[i], offsets_[i + 1] - offsets_[i]};
     }
 
-    std::pair<std::vector<std::string_view>, FixedVector<bool>>
+    std::pair<std::vector<std::string_view>, ValidityView>
     StringViews(std::optional<std::pair<int64_t, int64_t>> offset_len);
 
     int
@@ -444,7 +499,7 @@ class ArrayChunk : public Chunk {
         return {std::move(views), std::move(valid_res)};
     }
 
-    std::pair<std::vector<ArrayView>, FixedVector<bool>>
+    std::pair<std::vector<ArrayView>, ValidityView>
     Views(std::optional<std::pair<int64_t, int64_t>> offset_len =
               std::nullopt) const {
         auto start_offset = 0;
@@ -474,12 +529,7 @@ class ArrayChunk : public Chunk {
         for (auto i = start_offset; i < end_offset; i++) {
             views.emplace_back(View(i));
         }
-        if (nullable_) {
-            FixedVector<bool> res_valid(valid_.begin() + start_offset,
-                                        valid_.begin() + end_offset);
-            return {std::move(views), std::move(res_valid)};
-        }
-        return {std::move(views), {}};
+        return {std::move(views), Validity(start_offset)};
     }
 
     const char*
@@ -540,19 +590,13 @@ class VectorArrayChunk : public Chunk {
                    "rows {}",
                    idx,
                    row_nums_);
-        AssertInfo(!nullable_ || valid_[idx],
+        AssertInfo(!nullable_ || isValid(idx),
                    "VectorArrayChunk::View offset {} is null",
                    idx);
-        int idx_off = 2 * idx;
-        auto offset = offsets_lens_[idx_off];
-        auto len = offsets_lens_[idx_off + 1];
-        auto next_offset = offsets_lens_[idx_off + 2];
-        auto data_ptr = data_ + offset;
-        return VectorArrayView(
-            data_ptr, dim_, len, next_offset - offset, element_type_);
+        return ViewUnchecked(idx);
     }
 
-    std::pair<std::vector<VectorArrayView>, FixedVector<bool>>
+    std::pair<std::vector<VectorArrayView>, ValidityView>
     Views(std::optional<std::pair<int64_t, int64_t>> offset_len =
               std::nullopt) const {
         auto start_offset = 0;
@@ -583,23 +627,15 @@ class VectorArrayChunk : public Chunk {
         std::vector<VectorArrayView> views;
         views.reserve(len);
         auto end_offset = start_offset + len;
+        const auto validity = Validity(start_offset);
         for (int64_t i = start_offset; i < end_offset; i++) {
-            if (nullable_) {
-                if (valid_[i]) {
-                    views.emplace_back(View(i));
-                } else {
-                    views.emplace_back();
-                }
+            if (nullable_ && !validity[i - start_offset]) {
+                views.emplace_back();
             } else {
-                views.emplace_back(View(i));
+                views.emplace_back(ViewUnchecked(i));
             }
         }
-        if (nullable_) {
-            FixedVector<bool> res_valid(valid_.begin() + start_offset,
-                                        valid_.begin() + end_offset);
-            return {std::move(views), std::move(res_valid)};
-        }
-        return {std::move(views), {}};
+        return {std::move(views), validity};
     }
 
     const char*
@@ -619,6 +655,16 @@ class VectorArrayChunk : public Chunk {
     }
 
  private:
+    VectorArrayView
+    ViewUnchecked(int64_t idx) const {
+        int idx_off = 2 * idx;
+        auto offset = offsets_lens_[idx_off];
+        auto len = offsets_lens_[idx_off + 1];
+        auto next_offset = offsets_lens_[idx_off + 2];
+        auto data_ptr = data_ + offset;
+        return VectorArrayView(
+            data_ptr, dim_, len, next_offset - offset, element_type_);
+    }
     int64_t dim_;
     uint32_t* offsets_lens_;
     milvus::DataType element_type_;

--- a/internal/core/src/common/ChunkTest.cpp
+++ b/internal/core/src/common/ChunkTest.cpp
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <initializer_list>
 #include <memory>
+#include <numeric>
 #include <optional>
 #include <string>
 #include <type_traits>
@@ -55,6 +56,35 @@ using namespace milvus;
 
 namespace {
 
+void
+SetPackedValidity(std::vector<char>& data, int64_t offset) {
+    data[offset >> 3] |= static_cast<char>(1U << (offset & 0x07));
+}
+
+void
+WriteUint32(std::vector<char>& data, size_t offset, uint32_t value) {
+    memcpy(data.data() + offset, &value, sizeof(value));
+}
+
+class CountingVectorArrayChunk : public VectorArrayChunk {
+ public:
+    using VectorArrayChunk::VectorArrayChunk;
+
+    bool
+    isValid(int offset) const override {
+        ++validity_checks_;
+        return Chunk::isValid(offset);
+    }
+
+    int64_t
+    validity_checks() const {
+        return validity_checks_;
+    }
+
+ private:
+    mutable int64_t validity_checks_{0};
+};
+
 std::shared_ptr<arrow::BinaryArray>
 BuildBinaryArray(const std::vector<std::optional<std::string>>& values) {
     arrow::BinaryBuilder builder;
@@ -76,6 +106,191 @@ BuildBinaryArray(const std::vector<std::optional<std::string>>& values) {
 }
 
 }  // namespace
+
+TEST(chunk, nullable_fixed_width_span_keeps_validity_packed) {
+    constexpr int64_t row_count = 300;
+    const auto bitmap_bytes = (row_count + 7) / 8;
+    std::vector<char> data(bitmap_bytes + row_count * sizeof(int64_t), 0);
+    FixedVector<bool> expected_validity;
+    expected_validity.reserve(row_count);
+
+    for (int64_t i = 0; i < row_count; ++i) {
+        const bool valid = i % 5 != 1 && i % 7 != 3;
+        expected_validity.push_back(valid);
+        if (valid) {
+            SetPackedValidity(data, i);
+        }
+        const int64_t value = i * 10;
+        memcpy(data.data() + bitmap_bytes + i * sizeof(value),
+               &value,
+               sizeof(value));
+    }
+
+    FixedWidthChunk chunk(
+        row_count, 1, data.data(), data.size(), sizeof(int64_t), true, nullptr);
+
+    for (const auto offset : {0, 63, 64, 255, 256, 257, 299}) {
+        EXPECT_EQ(chunk.isValid(offset), expected_validity[offset]);
+    }
+
+    constexpr int64_t logical_offset = 299;
+    ASSERT_TRUE(expected_validity[logical_offset]);
+    const auto expected_physical_offset =
+        std::count(expected_validity.begin(),
+                   expected_validity.begin() + logical_offset,
+                   true);
+    EXPECT_EQ(chunk.PhysicalOffsetOf(logical_offset), expected_physical_offset);
+
+    const auto span = chunk.Span();
+    ASSERT_TRUE(span.validity());
+    EXPECT_TRUE(span.validity().is_packed());
+    for (int64_t i = 0; i < row_count; ++i) {
+        EXPECT_EQ(span.is_valid(i), expected_validity[i]);
+    }
+
+    const auto second_span = chunk.Span();
+    EXPECT_TRUE(second_span.validity().is_packed());
+}
+
+TEST(chunk, nullable_chunk_bulk_masks_unaligned_range) {
+    constexpr int64_t row_count = 130;
+    constexpr int64_t chunk_offset = 3;
+    constexpr int64_t result_offset = 5;
+    constexpr int64_t count = row_count - chunk_offset;
+    const auto bitmap_bytes = (row_count + 7) / 8;
+    std::vector<char> data(bitmap_bytes + row_count * sizeof(int64_t), 0);
+    FixedVector<bool> expected_validity;
+    expected_validity.reserve(row_count);
+    for (int64_t i = 0; i < row_count; ++i) {
+        const bool valid = i % 5 != 1 && i % 7 != 3;
+        expected_validity.push_back(valid);
+        if (valid) {
+            SetPackedValidity(data, i);
+        }
+    }
+
+    FixedWidthChunk chunk(
+        row_count, 1, data.data(), data.size(), sizeof(int64_t), true, nullptr);
+    TargetBitmap result(count + result_offset + 3, true);
+    chunk.ApplyValidityMask(
+        chunk_offset, count, TargetBitmapView(result).view(result_offset));
+
+    for (int64_t i = 0; i < result_offset; ++i) {
+        EXPECT_TRUE(result[i]);
+    }
+    for (int64_t i = 0; i < count; ++i) {
+        EXPECT_EQ(result[result_offset + i],
+                  expected_validity[chunk_offset + i]);
+    }
+    for (int64_t i = result_offset + count;
+         i < static_cast<int64_t>(result.size());
+         ++i) {
+        EXPECT_TRUE(result[i]);
+    }
+}
+
+TEST(chunk, nullable_string_views_reference_packed_validity) {
+    const std::vector<std::string> values = {"a", "bb", "ccc", "dddd", "eeeee"};
+    constexpr int64_t row_count = 5;
+    constexpr size_t bitmap_bytes = 1;
+    const auto offsets_bytes = (row_count + 1) * sizeof(uint32_t);
+    const auto payload_bytes = std::accumulate(
+        values.begin(),
+        values.end(),
+        size_t{0},
+        [](size_t total, const auto& value) { return total + value.size(); });
+    std::vector<char> data(bitmap_bytes + offsets_bytes + payload_bytes, 0);
+    data[0] = 0x15;
+
+    uint32_t data_offset = bitmap_bytes + offsets_bytes;
+    for (int64_t i = 0; i < row_count; ++i) {
+        WriteUint32(data, bitmap_bytes + i * sizeof(uint32_t), data_offset);
+        memcpy(data.data() + data_offset, values[i].data(), values[i].size());
+        data_offset += values[i].size();
+    }
+    WriteUint32(data, bitmap_bytes + row_count * sizeof(uint32_t), data_offset);
+
+    StringChunk chunk(row_count, data.data(), data.size(), true, nullptr);
+
+    auto [views, validity] = chunk.StringViews(std::make_pair(1, 3));
+    ASSERT_EQ(views.size(), 3);
+    EXPECT_EQ(views[0], values[1]);
+    EXPECT_EQ(views[1], values[2]);
+    EXPECT_EQ(views[2], values[3]);
+    EXPECT_EQ(validity.packed_data(),
+              reinterpret_cast<const uint8_t*>(data.data()));
+    EXPECT_EQ(validity.bit_offset(), 1);
+    EXPECT_FALSE(validity[0]);
+    EXPECT_TRUE(validity[1]);
+    EXPECT_FALSE(validity[2]);
+}
+
+TEST(chunk, nullable_array_views_reference_packed_validity) {
+    constexpr int64_t row_count = 5;
+    constexpr size_t bitmap_bytes = 1;
+    const auto offsets_bytes = (2 * row_count + 1) * sizeof(uint32_t);
+    std::vector<char> data(bitmap_bytes + offsets_bytes, 0);
+    data[0] = 0x15;
+    const auto payload_offset = static_cast<uint32_t>(data.size());
+    for (int64_t i = 0; i <= row_count; ++i) {
+        WriteUint32(
+            data, bitmap_bytes + 2 * i * sizeof(uint32_t), payload_offset);
+        if (i < row_count) {
+            WriteUint32(data, bitmap_bytes + (2 * i + 1) * sizeof(uint32_t), 0);
+        }
+    }
+
+    ArrayChunk chunk(
+        row_count, data.data(), data.size(), DataType::INT32, true, nullptr);
+
+    auto [views, validity] = chunk.Views(std::make_pair(1, 3));
+    ASSERT_EQ(views.size(), 3);
+    EXPECT_EQ(validity.packed_data(),
+              reinterpret_cast<const uint8_t*>(data.data()));
+    EXPECT_EQ(validity.bit_offset(), 1);
+    EXPECT_FALSE(validity[0]);
+    EXPECT_TRUE(validity[1]);
+    EXPECT_FALSE(validity[2]);
+}
+
+TEST(chunk, nullable_vector_array_views_reference_packed_validity) {
+    constexpr int64_t row_count = 5;
+    constexpr size_t bitmap_bytes = 1;
+    const auto offsets_bytes = (2 * row_count + 1) * sizeof(uint32_t);
+    std::vector<char> data(bitmap_bytes + offsets_bytes, 0);
+    data[0] = 0x15;
+    const auto payload_offset = static_cast<uint32_t>(data.size());
+    for (int64_t i = 0; i <= row_count; ++i) {
+        WriteUint32(
+            data, bitmap_bytes + 2 * i * sizeof(uint32_t), payload_offset);
+        if (i < row_count) {
+            WriteUint32(data, bitmap_bytes + (2 * i + 1) * sizeof(uint32_t), 0);
+        }
+    }
+
+    CountingVectorArrayChunk chunk(4,
+                                   row_count,
+                                   data.data(),
+                                   data.size(),
+                                   DataType::VECTOR_FLOAT,
+                                   nullptr,
+                                   true);
+
+    auto [views, validity] = chunk.Views(std::make_pair(1, 3));
+    ASSERT_EQ(views.size(), 3);
+    EXPECT_EQ(chunk.validity_checks(), 0);
+    EXPECT_EQ(validity.packed_data(),
+              reinterpret_cast<const uint8_t*>(data.data()));
+    EXPECT_EQ(validity.bit_offset(), 1);
+    EXPECT_FALSE(validity[0]);
+    EXPECT_TRUE(validity[1]);
+    EXPECT_FALSE(validity[2]);
+
+    EXPECT_EQ(chunk.View(2).length(), 0);
+    EXPECT_EQ(chunk.validity_checks(), 1);
+    EXPECT_ANY_THROW(chunk.View(1));
+    EXPECT_EQ(chunk.validity_checks(), 2);
+}
 
 TEST(chunk, test_int64_field) {
     FixedVector<int64_t> data = {1, 2, 3, 4, 5};
@@ -284,7 +499,6 @@ TEST(chunk, test_variable_field_sliced_binary_batches) {
         std::string_view("delta"),
     };
     ASSERT_EQ(views.size(), expected.size());
-    ASSERT_EQ(valid.size(), expected.size());
     for (size_t i = 0; i < expected.size(); ++i) {
         EXPECT_EQ(valid[i], expected[i].has_value());
         if (expected[i].has_value()) {
@@ -445,7 +659,6 @@ TEST(chunk, test_json_field_sliced_binary_batches) {
         std::string_view(R"({"k":"d"})"),
     };
     ASSERT_EQ(views.size(), expected.size());
-    ASSERT_EQ(valid.size(), expected.size());
     for (size_t i = 0; i < expected.size(); ++i) {
         EXPECT_EQ(valid[i], expected[i].has_value());
         if (expected[i].has_value()) {
@@ -489,7 +702,6 @@ TEST(chunk, test_geometry_field_sliced_binary_batches) {
         std::string_view("wkb-d"),
     };
     ASSERT_EQ(views.size(), expected.size());
-    ASSERT_EQ(valid.size(), expected.size());
     for (size_t i = 0; i < expected.size(); ++i) {
         EXPECT_EQ(valid[i], expected[i].has_value());
         if (expected[i].has_value()) {
@@ -663,7 +875,6 @@ TEST(chunk, test_null_array) {
     auto [views, valid] = array_chunk->Views(std::nullopt);
 
     EXPECT_EQ(views.size(), array_count);
-    EXPECT_EQ(valid.size(), array_count);
 
     // Check validity based on our bitmap pattern (10101)
     EXPECT_TRUE(valid[0]);

--- a/internal/core/src/common/ChunkWriterTest.cpp
+++ b/internal/core/src/common/ChunkWriterTest.cpp
@@ -433,7 +433,7 @@ TEST(VectorArrayChunkWriterTest, NullableRowsRoundTripThroughChunkViews) {
                            true);
     auto [views, valid] = chunk.Views();
     ASSERT_EQ(views.size(), 4);
-    ASSERT_EQ(valid.size(), 4);
+    ASSERT_TRUE(valid);
     EXPECT_TRUE(valid[0]);
     EXPECT_FALSE(valid[1]);
     EXPECT_TRUE(valid[2]);

--- a/internal/core/src/common/Span.h
+++ b/internal/core/src/common/Span.h
@@ -22,6 +22,7 @@
 #include <type_traits>
 
 #include "Types.h"
+#include "ValidityView.h"
 #include "VectorTrait.h"
 #include "TypeTraits.h"
 
@@ -39,7 +40,16 @@ class SpanBase {
                       int64_t row_count,
                       int64_t element_sizeof)
         : data_(data),
-          valid_data_(valid_data),
+          validity_(ValidityView::FromExpanded(valid_data)),
+          row_count_(row_count),
+          element_sizeof_(element_sizeof) {
+    }
+    explicit SpanBase(const void* data,
+                      ValidityView validity,
+                      int64_t row_count,
+                      int64_t element_sizeof)
+        : data_(data),
+          validity_(validity),
           row_count_(row_count),
           element_sizeof_(element_sizeof) {
     }
@@ -59,14 +69,19 @@ class SpanBase {
         return data_;
     }
 
-    const bool*
-    valid_data() const {
-        return valid_data_;
+    ValidityView
+    validity() const {
+        return validity_;
+    }
+
+    bool
+    is_valid(int64_t offset) const {
+        return !validity_ || validity_[offset];
     }
 
  private:
     const void* data_;
-    const bool* valid_data_{nullptr};
+    ValidityView validity_;
     int64_t row_count_;
     int64_t element_sizeof_;
 };
@@ -82,7 +97,11 @@ class Span<T,
  public:
     using embedded_type = T;
     explicit Span(const T* data, const bool* valid_data, int64_t row_count)
-        : data_(data), valid_data_(valid_data), row_count_(row_count) {
+        : Span(data, ValidityView::FromExpanded(valid_data), row_count) {
+    }
+
+    explicit Span(const T* data, ValidityView validity, int64_t row_count)
+        : data_(data), validity_(validity), row_count_(row_count) {
     }
 
     explicit Span(std::string_view data, bool* valid_data) {
@@ -90,12 +109,12 @@ class Span<T,
     }
 
     operator SpanBase() const {
-        return SpanBase(data_, valid_data_, row_count_, sizeof(T));
+        return SpanBase(data_, validity_, row_count_, sizeof(T));
     }
 
     explicit Span(const SpanBase& base)
         : Span(reinterpret_cast<const T*>(base.data()),
-               base.valid_data(),
+               base.validity(),
                base.row_count()) {
         assert(base.element_sizeof() == sizeof(T));
     }
@@ -110,9 +129,14 @@ class Span<T,
         return data_;
     }
 
-    const bool*
-    valid_data() const {
-        return valid_data_;
+    ValidityView
+    validity() const {
+        return validity_;
+    }
+
+    bool
+    is_valid(int64_t offset) const {
+        return !validity_ || validity_[offset];
     }
 
     const T&
@@ -127,7 +151,7 @@ class Span<T,
 
  private:
     const T* data_;
-    const bool* valid_data_;
+    ValidityView validity_;
     int64_t row_count_;
 };
 

--- a/internal/core/src/common/SpanTest.cpp
+++ b/internal/core/src/common/SpanTest.cpp
@@ -23,7 +23,9 @@
 #include "common/Span.h"
 #include "common/Types.h"
 #include "common/Utils.h"
+#include "common/ValidityView.h"
 #include "common/VectorTrait.h"
+#include "exec/expression/Expr.h"
 #include "filemanager/InputStream.h"
 #include "gtest/gtest.h"
 #include "knowhere/comp/index_param.h"
@@ -34,6 +36,12 @@
 #include "test_utils/DataGen.h"
 
 const int64_t ROW_COUNT = 100 * 1000;
+
+template <typename T>
+concept HasMaterializeValidity =
+    requires(T validity) { validity.Materialize(int64_t{1}); };
+
+static_assert(!HasMaterializeValidity<milvus::ValidityView>);
 
 TEST(Common, Span) {
     using namespace milvus;
@@ -48,6 +56,80 @@ TEST(Common, Span) {
     ASSERT_EQ(r1.row_count(), 100);
     ASSERT_EQ(r2.row_count(), 10);
     ASSERT_EQ(r2.element_sizeof(), 16 * sizeof(float));
+}
+
+TEST(Span, ValidityViewSupportsExpandedAndPackedData) {
+    using namespace milvus;
+
+    const bool expanded[] = {true, false, true, false, true};
+    const uint8_t packed[] = {0x15};
+    const auto expanded_view = ValidityView::FromExpanded(expanded);
+    const auto packed_view = ValidityView::FromPacked(packed);
+
+    EXPECT_TRUE(expanded_view);
+    EXPECT_FALSE(expanded_view.is_packed());
+    EXPECT_EQ(expanded_view.expanded_data(), expanded);
+    EXPECT_TRUE(packed_view);
+    EXPECT_TRUE(packed_view.is_packed());
+    EXPECT_EQ(packed_view.expanded_data(), nullptr);
+    for (int64_t i = 0; i < 5; ++i) {
+        EXPECT_EQ(expanded_view[i], expanded[i]);
+        EXPECT_EQ(packed_view[i], expanded[i]);
+    }
+
+    const auto subview = packed_view.Subview(1);
+    EXPECT_FALSE(subview[0]);
+    EXPECT_TRUE(subview[1]);
+    EXPECT_FALSE(subview[2]);
+    EXPECT_EQ(expanded_view.Subview(1).expanded_data(), expanded + 1);
+}
+
+TEST(Span, PackedValidityMasksBitmapsWithoutLosingOffsets) {
+    using namespace milvus;
+    using namespace milvus::exec;
+
+    constexpr int64_t validity_offset = 3;
+    constexpr int64_t result_offset = 5;
+    constexpr int64_t size = 70;
+    const uint8_t packed[] = {
+        0b10110101,
+        0b01011010,
+        0b11110000,
+        0b00111100,
+        0b11000011,
+        0b10011001,
+        0b01100110,
+        0b11111111,
+        0b00010101,
+        0b00011110,
+    };
+    const auto validity =
+        ValidityView::FromPacked(packed).Subview(validity_offset);
+
+    EXPECT_EQ(validity.packed_data(), packed);
+    EXPECT_EQ(validity.bit_offset(), validity_offset);
+
+    TargetBitmap result(size + result_offset + 3, false);
+    TargetBitmap valid_result(size + result_offset + 3, true);
+    for (int64_t i = 0; i < size; ++i) {
+        result[result_offset + i] = (i % 3) != 0;
+    }
+    ApplyValidMask(validity,
+                   TargetBitmapView(result).view(result_offset),
+                   TargetBitmapView(valid_result).view(result_offset),
+                   size);
+
+    for (int64_t i = 0; i < size; ++i) {
+        const bool expected_valid = validity[i];
+        EXPECT_EQ(result[result_offset + i], ((i % 3) != 0) && expected_valid)
+            << "row " << i;
+        EXPECT_EQ(valid_result[result_offset + i], expected_valid)
+            << "row " << i;
+    }
+    for (int64_t i = 0; i < result_offset; ++i) {
+        EXPECT_FALSE(result[i]);
+        EXPECT_TRUE(valid_result[i]);
+    }
 }
 
 TEST(Span, Naive) {
@@ -96,7 +178,7 @@ TEST(Span, Naive) {
         auto begin = chunk_id * size_per_chunk;
         auto end = std::min((chunk_id + 1) * size_per_chunk, N);
         auto size_of_chunk = end - begin;
-        ASSERT_EQ(age_span.get().valid_data(), nullptr);
+        ASSERT_FALSE(age_span.get().validity());
         for (int i = 0; i < size_of_chunk * 512 / 8; ++i) {
             ASSERT_EQ(vec_span.get().data()[i], vec_ptr[i + begin * 512 / 8]);
         }
@@ -111,7 +193,7 @@ TEST(Span, Naive) {
                       nullable_data_ptr[i + begin]);
         }
         for (int i = 0; i < size_of_chunk; ++i) {
-            ASSERT_EQ(null_field_span.get().valid_data()[i],
+            ASSERT_EQ(null_field_span.get().is_valid(i),
                       nullable_valid_data_ptr[i + begin]);
         }
     }

--- a/internal/core/src/common/ValidityView.h
+++ b/internal/core/src/common/ValidityView.h
@@ -1,0 +1,104 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace milvus {
+
+// Non-owning view over either one-byte-per-row bool data or an LSB-first
+// packed bitmap. The underlying buffer must outlive the view.
+class ValidityView {
+ public:
+    ValidityView() = default;
+    ValidityView(std::nullptr_t) {
+    }
+
+    static ValidityView
+    FromExpanded(const bool* data) {
+        return ValidityView(data, Encoding::Expanded, 0);
+    }
+
+    static ValidityView
+    FromPacked(const uint8_t* data) {
+        return ValidityView(data, Encoding::Packed, 0);
+    }
+
+    explicit operator bool() const {
+        return data_ != nullptr;
+    }
+
+    bool
+    operator[](int64_t index) const {
+        const auto offset = offset_ + index;
+        if (encoding_ == Encoding::Expanded) {
+            return static_cast<const bool*>(data_)[offset];
+        }
+        return (static_cast<const uint8_t*>(data_)[offset >> 3] >>
+                (offset & 0x07)) &
+               1;
+    }
+
+    bool
+    is_packed() const {
+        return encoding_ == Encoding::Packed;
+    }
+
+    ValidityView
+    Subview(int64_t offset) const {
+        auto result = *this;
+        result.offset_ += offset;
+        return result;
+    }
+
+    const bool*
+    expanded_data() const {
+        if (encoding_ != Encoding::Expanded) {
+            return nullptr;
+        }
+        return static_cast<const bool*>(data_) + offset_;
+    }
+
+    const uint8_t*
+    packed_data() const {
+        if (encoding_ != Encoding::Packed) {
+            return nullptr;
+        }
+        return static_cast<const uint8_t*>(data_);
+    }
+
+    int64_t
+    bit_offset() const {
+        return offset_;
+    }
+
+ private:
+    enum class Encoding : uint8_t { None, Expanded, Packed };
+
+    ValidityView(const void* data, Encoding encoding, int64_t offset)
+        : data_(data),
+          encoding_(data == nullptr ? Encoding::None : encoding),
+          offset_(offset) {
+    }
+
+    const void* data_{nullptr};
+    Encoding encoding_{Encoding::None};
+    int64_t offset_{0};
+};
+
+}  // namespace milvus

--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
@@ -205,7 +205,7 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForJson(
             if constexpr (filter_type == FilterType::random) {              \
                 offset = (offsets) ? offsets[i] : i;                        \
             }                                                               \
-            if (valid_data != nullptr && !valid_data[offset]) {             \
+            if (valid_data && !valid_data[offset]) {                        \
                 res[i] = false;                                             \
                 valid_res[i] = false;                                       \
                 continue;                                                   \
@@ -240,36 +240,36 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForJson(
         }                                                                   \
     } while (false)
 
-#define BinaryArithRangeJONCompareArrayLength(cmp)              \
-    do {                                                        \
-        for (size_t i = 0; i < size; ++i) {                     \
-            auto offset = i;                                    \
-            if constexpr (filter_type == FilterType::random) {  \
-                offset = (offsets) ? offsets[i] : i;            \
-            }                                                   \
-            if (valid_data != nullptr && !valid_data[offset]) { \
-                res[i] = false;                                 \
-                valid_res[i] = false;                           \
-                continue;                                       \
-            }                                                   \
-            int array_length = 0;                               \
-            auto doc = data[offset].doc();                      \
-            auto array = doc.at_pointer(pointer).get_array();   \
-            if (array.error()) {                                \
-                res[i] = false;                                 \
-                valid_res[i] = false;                           \
-                continue;                                       \
-            }                                                   \
-            array_length = array.count_elements();              \
-            res[i] = (cmp);                                     \
-        }                                                       \
+#define BinaryArithRangeJONCompareArrayLength(cmp)             \
+    do {                                                       \
+        for (size_t i = 0; i < size; ++i) {                    \
+            auto offset = i;                                   \
+            if constexpr (filter_type == FilterType::random) { \
+                offset = (offsets) ? offsets[i] : i;           \
+            }                                                  \
+            if (valid_data && !valid_data[offset]) {           \
+                res[i] = false;                                \
+                valid_res[i] = false;                          \
+                continue;                                      \
+            }                                                  \
+            int array_length = 0;                              \
+            auto doc = data[offset].doc();                     \
+            auto array = doc.at_pointer(pointer).get_array();  \
+            if (array.error()) {                               \
+                res[i] = false;                                \
+                valid_res[i] = false;                          \
+                continue;                                      \
+            }                                                  \
+            array_length = array.count_elements();             \
+            res[i] = (cmp);                                    \
+        }                                                      \
     } while (false)
 
     auto execute_sub_batch =
         [ op_type,
           arith_type ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -707,7 +707,7 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForArray(
             if constexpr (filter_type == FilterType::random) {  \
                 offset = (offsets) ? offsets[i] : i;            \
             }                                                   \
-            if (valid_data != nullptr && !valid_data[offset]) { \
+            if (valid_data && !valid_data[offset]) {            \
                 res[i] = false;                                 \
                 valid_res[i] = false;                           \
                 continue;                                       \
@@ -722,26 +722,26 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForArray(
         }                                                       \
     } while (false)
 
-#define BinaryArithRangeArrayLengthCompate(cmp)                 \
-    do {                                                        \
-        for (size_t i = 0; i < size; ++i) {                     \
-            auto offset = i;                                    \
-            if constexpr (filter_type == FilterType::random) {  \
-                offset = (offsets) ? offsets[i] : i;            \
-            }                                                   \
-            if (valid_data != nullptr && !valid_data[offset]) { \
-                res[i] = valid_res[i] = false;                  \
-                continue;                                       \
-            }                                                   \
-            res[i] = (cmp);                                     \
-        }                                                       \
+#define BinaryArithRangeArrayLengthCompate(cmp)                \
+    do {                                                       \
+        for (size_t i = 0; i < size; ++i) {                    \
+            auto offset = i;                                   \
+            if constexpr (filter_type == FilterType::random) { \
+                offset = (offsets) ? offsets[i] : i;           \
+            }                                                  \
+            if (valid_data && !valid_data[offset]) {           \
+                res[i] = valid_res[i] = false;                 \
+                continue;                                      \
+            }                                                  \
+            res[i] = (cmp);                                    \
+        }                                                      \
     } while (false)
 
     auto execute_sub_batch =
         [ op_type,
           arith_type ]<FilterType filter_type = FilterType::sequential>(
             const ArrayView* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -1188,7 +1188,7 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForVectorArray(
     auto execute_sub_batch = [compare_length]<FilterType filter_type =
                                                   FilterType::sequential>(
         const VectorArrayView* data,
-        const bool* valid_data,
+        ValidityView valid_data,
         const int32_t* offsets,
         const int size,
         TargetBitmapView res,
@@ -1201,7 +1201,7 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForVectorArray(
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -2029,7 +2029,7 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForData(
         [ op_type,
           arith_type ]<FilterType filter_type = FilterType::sequential>(
             const T* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -2552,7 +2552,7 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForData(
         if constexpr (filter_type == FilterType::sequential) {
             // contiguous rows: reuse the vectorized shared helper
             ApplyValidMask(valid_data, res, valid_res, size);
-        } else if (valid_data != nullptr) {
+        } else if (valid_data) {
             // scattered by offsets: gather, keep the per-row loop
             for (int i = 0; i < size; i++) {
                 auto offset = (offsets) ? offsets[i] : i;

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -257,7 +257,7 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonPreciseNumeric(
             &processed_cursor
         ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -272,7 +272,7 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonPreciseNumeric(
             if constexpr (filter_type == FilterType::random) {
                 offset = offsets ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -503,7 +503,7 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
         [ lower_inclusive, upper_inclusive, &processed_cursor, &
           bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const T* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -563,7 +563,7 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
         if constexpr (filter_type == FilterType::sequential) {
             // contiguous rows: reuse the vectorized shared helper
             ApplyValidMask(valid_data, res, valid_res, size);
-        } else if (valid_data != nullptr) {
+        } else if (valid_data) {
             // scattered by offsets: gather, keep the per-row loop
             for (int i = 0; i < size; i++) {
                 auto offset = (offsets) ? offsets[i] : i;
@@ -680,7 +680,7 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJson(EvalCtx& context) {
             &processed_cursor
         ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -834,12 +834,12 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonStats(
                                            &lower_bound,
                                            &upper_bound](
                                               const ColType* src,
-                                              const bool* valid,
+                                              ValidityView valid,
                                               size_t size,
                                               TargetBitmapView res,
                                               TargetBitmapView valid_res) {
                     for (size_t i = 0; i < size; ++i) {
-                        if (valid != nullptr && !valid[i]) {
+                        if (valid && !valid[i]) {
                             res[i] = valid_res[i] = false;
                             continue;
                         }
@@ -1031,7 +1031,7 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForArray(EvalCtx& context) {
         [ lower_inclusive, upper_inclusive, &processed_cursor, &
           bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const milvus::ArrayView* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,

--- a/internal/core/src/exec/expression/BinaryRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.h
@@ -115,7 +115,7 @@ struct BinaryRangeElementFunc {
 // 'cmp' must reference 'value' (int64_t or double depending on the JSON value).
 #define BinaryRangeJSONCompare(cmp)                                    \
     do {                                                               \
-        if (valid_data != nullptr && !valid_data[offset]) {            \
+        if (valid_data && !valid_data[offset]) {                       \
             res[i] = valid_res[i] = false;                             \
             break;                                                     \
         }                                                              \
@@ -162,7 +162,7 @@ struct BinaryRangeElementFuncForJson {
                const ValueType& val2,
                const std::string& pointer,
                const milvus::Json* src,
-               const bool* valid_data,
+               ValidityView valid_data,
                size_t n,
                TargetBitmapView res,
                TargetBitmapView valid_res,
@@ -201,7 +201,7 @@ struct BinaryRangeElementFuncForArray {
                const ValueType& val2,
                int index,
                const milvus::ArrayView* src,
-               const bool* valid_data,
+               ValidityView valid_data,
                size_t n,
                TargetBitmapView res,
                TargetBitmapView valid_res,
@@ -219,7 +219,7 @@ struct BinaryRangeElementFuncForArray {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }

--- a/internal/core/src/exec/expression/CompareExpr.h
+++ b/internal/core/src/exec/expression/CompareExpr.h
@@ -359,9 +359,9 @@ class PhyCompareFilterExpr : public Expr {
             std::optional<PinWrapper<Span<T>>> pw_left;
             std::optional<PinWrapper<Span<U>>> pw_right;
             const T* left_base = nullptr;
-            const bool* left_valid_base = nullptr;
+            ValidityView left_validity;
             const U* right_base = nullptr;
-            const bool* right_valid_base = nullptr;
+            ValidityView right_validity;
             for (auto i = 0; i < size; ++i) {
                 auto offset = (*input)[i];
                 auto [left_chunk_id, left_chunk_offset] =
@@ -375,7 +375,7 @@ class PhyCompareFilterExpr : public Expr {
                             op_ctx_, left_field_, left_chunk_id));
                     auto left_chunk = pw_left->get();
                     left_base = left_chunk.data();
-                    left_valid_base = left_chunk.valid_data();
+                    left_validity = left_chunk.validity();
                     cached_left_chunk_id = left_chunk_id;
                 }
                 if (right_chunk_id != cached_right_chunk_id) {
@@ -384,16 +384,16 @@ class PhyCompareFilterExpr : public Expr {
                             op_ctx_, right_field_, right_chunk_id));
                     auto right_chunk = pw_right->get();
                     right_base = right_chunk.data();
-                    right_valid_base = right_chunk.valid_data();
+                    right_validity = right_chunk.validity();
                     cached_right_chunk_id = right_chunk_id;
                 }
-                if (left_valid_base && !left_valid_base[left_chunk_offset]) {
+                if (left_validity && !left_validity[left_chunk_offset]) {
                     res[processed_size] = false;
                     valid_res[processed_size] = false;
                     processed_size++;
                     continue;
                 }
-                if (right_valid_base && !right_valid_base[right_chunk_offset]) {
+                if (right_validity && !right_validity[right_chunk_offset]) {
                     res[processed_size] = false;
                     valid_res[processed_size] = false;
                     processed_size++;
@@ -420,17 +420,17 @@ class PhyCompareFilterExpr : public Expr {
             auto right_chunk = pw_right.get();
             const T* left_data = left_chunk.data();
             const U* right_data = right_chunk.data();
-            const bool* left_valid_data = left_chunk.valid_data();
-            const bool* right_valid_data = right_chunk.valid_data();
-            if (left_valid_data || right_valid_data) {
+            const auto left_validity = left_chunk.validity();
+            const auto right_validity = right_chunk.validity();
+            if (left_validity || right_validity) {
                 for (int i = 0; i < size; ++i) {
                     auto offset = (*input)[i];
-                    if (left_valid_data && !left_valid_data[offset]) {
+                    if (left_validity && !left_validity[offset]) {
                         res[i] = false;
                         valid_res[i] = false;
                         continue;
                     }
-                    if (right_valid_data && !right_valid_data[offset]) {
+                    if (right_validity && !right_validity[offset]) {
                         res[i] = false;
                         valid_res[i] = false;
                         continue;
@@ -497,20 +497,14 @@ class PhyCompareFilterExpr : public Expr {
                  size,
                  res + processed_size,
                  values...);
-            const bool* left_valid_data = left_chunk.valid_data();
-            const bool* right_valid_data = right_chunk.valid_data();
-            // mask with valid_data
-            for (int i = 0; i < size; ++i) {
-                if (left_valid_data && !left_valid_data[i + data_pos]) {
-                    res[processed_size + i] = false;
-                    valid_res[processed_size + i] = false;
-                    continue;
-                }
-                if (right_valid_data && !right_valid_data[i + data_pos]) {
-                    res[processed_size + i] = false;
-                    valid_res[processed_size + i] = false;
-                }
-            }
+            ApplyValidMask(left_chunk.validity().Subview(data_pos),
+                           res + processed_size,
+                           valid_res + processed_size,
+                           size);
+            ApplyValidMask(right_chunk.validity().Subview(data_pos),
+                           res + processed_size,
+                           valid_res + processed_size,
+                           size);
             processed_size += size;
 
             if (processed_size >= batch_size_) {
@@ -572,20 +566,14 @@ class PhyCompareFilterExpr : public Expr {
                  size,
                  res + processed_size,
                  values...);
-            const bool* left_valid_data = left_chunk.valid_data();
-            const bool* right_valid_data = right_chunk.valid_data();
-            // mask with valid_data
-            for (int i = 0; i < size; ++i) {
-                if (left_valid_data && !left_valid_data[i + data_pos]) {
-                    res[processed_size + i] = false;
-                    valid_res[processed_size + i] = false;
-                    continue;
-                }
-                if (right_valid_data && !right_valid_data[i + data_pos]) {
-                    res[processed_size + i] = false;
-                    valid_res[processed_size + i] = false;
-                }
-            }
+            ApplyValidMask(left_chunk.validity().Subview(data_pos),
+                           res + processed_size,
+                           valid_res + processed_size,
+                           size);
+            ApplyValidMask(right_chunk.validity().Subview(data_pos),
+                           res + processed_size,
+                           valid_res + processed_size,
+                           size);
             processed_size += size;
 
             if (processed_size >= batch_size_) {

--- a/internal/core/src/exec/expression/ExistsExpr.cpp
+++ b/internal/core/src/exec/expression/ExistsExpr.cpp
@@ -162,7 +162,7 @@ PhyExistsFilterExpr::EvalJsonExistsForDataSegment(EvalCtx& context) {
         [&bitmap_input, &
          processed_cursor ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -180,7 +180,7 @@ PhyExistsFilterExpr::EvalJsonExistsForDataSegment(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = false;
                 continue;
             }

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -120,6 +120,53 @@ ApplyValidMask(const bool* valid_data,
     }
 }
 
+inline void
+ApplyValidMask(ValidityView validity,
+               TargetBitmapView res,
+               TargetBitmapView valid_res,
+               const int size) {
+    if (!validity) {
+        return;
+    }
+
+    if (const auto* expanded = validity.expanded_data(); expanded != nullptr) {
+        ApplyValidMask(expanded, res, valid_res, size);
+        return;
+    }
+
+    const auto* packed = validity.packed_data();
+    AssertInfo(packed != nullptr, "Packed validity data is missing");
+
+    const auto read_word = [packed](int64_t bit_offset, int bit_count) {
+        const auto byte_offset = bit_offset >> 3;
+        const auto shift = static_cast<int>(bit_offset & 0x07);
+        const auto bytes = (shift + bit_count + 7) >> 3;
+        uint64_t word = 0;
+        const auto low_bytes = std::min(bytes, 8);
+        for (int i = 0; i < low_bytes; ++i) {
+            word |= uint64_t(packed[byte_offset + i]) << (i * 8);
+        }
+        word >>= shift;
+        if (bytes > 8) {
+            word |= uint64_t(packed[byte_offset + 8]) << (64 - shift);
+        }
+        if (bit_count < 64) {
+            word &= (uint64_t{1} << bit_count) - 1;
+        }
+        return word;
+    };
+
+    for (int i = 0; i < size; i += 64) {
+        const auto bit_count = std::min(size - i, 64);
+        auto word = read_word(validity.bit_offset() + i, bit_count);
+        TargetBitmapView validity_word(&word, bit_count);
+        auto res_block = res.view(i);
+        auto valid_res_block = valid_res.view(i);
+        res_block.inplace_and(validity_word, bit_count);
+        valid_res_block.inplace_and(validity_word, bit_count);
+    }
+}
+
 class Expr : public std::enable_shared_from_this<Expr> {
  public:
     Expr(DataType type,
@@ -425,11 +472,11 @@ class SegmentExpr : public Expr {
     }
 
     void
-    ApplyValidData(const bool* valid_data,
+    ApplyValidData(ValidityView validity,
                    TargetBitmapView res,
                    TargetBitmapView valid_res,
                    const int size) {
-        ApplyValidMask(valid_data, res, valid_res, size);
+        ApplyValidMask(validity, res, valid_res, size);
     }
 
     // Try to load the full bitset from ExprResCache.
@@ -654,7 +701,7 @@ class SegmentExpr : public Expr {
                 res[i] = valid_res[i] = false;
                 evaluate_batch.template operator()<FilterType::random>(
                     nullptr,
-                    nullptr,
+                    ValidityView{},
                     nullptr,
                     1,
                     res + i,
@@ -666,7 +713,7 @@ class SegmentExpr : public Expr {
             bool valid_data = all_valid || valid_result[offset];
             evaluate_batch.template operator()<FilterType::random>(
                 &raw_data,
-                &valid_data,
+                ValidityView::FromExpanded(&valid_data),
                 nullptr,
                 1,
                 res + i,
@@ -718,7 +765,7 @@ class SegmentExpr : public Expr {
                     !skip_func(*skip_index, field_id_, chunk_id)) {
                     evaluate_batch.template operator()<FilterType::random>(
                         data_vec.data(),
-                        valid_data.data(),
+                        valid_data,
                         nullptr,
                         1,
                         res + processed_size,
@@ -729,13 +776,13 @@ class SegmentExpr : public Expr {
                     // callback on a null batch so cursor-tracking callbacks (which index
                     // bitmap_input by batch position via their processed_cursor) stay
                     // aligned — mirrors the ProcessDataChunksForMultipleChunk skip branch.
-                    ApplyValidData(valid_data.data(),
+                    ApplyValidData(valid_data,
                                    res + processed_size,
                                    valid_res + processed_size,
                                    1);
                     evaluate_batch.template operator()<FilterType::random>(
                         nullptr,
-                        nullptr,
+                        ValidityView{},
                         nullptr,
                         1,
                         res + processed_size,
@@ -804,7 +851,9 @@ class SegmentExpr : public Expr {
                             evaluate_batch
                                 .template operator()<FilterType::random>(
                                     data_vec.data() + j,
-                                    valid_ptr,
+                                    valid_ptr == nullptr
+                                        ? ValidityView{}
+                                        : ValidityView::FromExpanded(valid_ptr),
                                     nullptr,
                                     1,
                                     res + processed_size,
@@ -824,7 +873,7 @@ class SegmentExpr : public Expr {
                             evaluate_batch
                                 .template operator()<FilterType::random>(
                                     nullptr,
-                                    nullptr,
+                                    ValidityView{},
                                     nullptr,
                                     1,
                                     res + processed_size,
@@ -843,7 +892,7 @@ class SegmentExpr : public Expr {
             int64_t cached_chunk_id = -1;
             std::optional<PinWrapper<Span<T>>> pw;
             const T* chunk_base = nullptr;
-            const bool* chunk_valid_base = nullptr;
+            ValidityView chunk_validity;
             bool cached_skip = false;
             for (size_t i = 0; i < input->size(); ++i) {
                 int64_t offset = (*input)[i];
@@ -854,7 +903,7 @@ class SegmentExpr : public Expr {
                         segment_->chunk_data<T>(op_ctx_, field_id_, chunk_id));
                     auto chunk = pw->get();
                     chunk_base = chunk.data();
-                    chunk_valid_base = chunk.valid_data();
+                    chunk_validity = chunk.validity();
                     // SkipIndex is keyed by chunk alone; evaluate it once per
                     // chunk instead of once per row.
                     cached_skip = skip_func &&
@@ -862,13 +911,11 @@ class SegmentExpr : public Expr {
                     cached_chunk_id = chunk_id;
                 }
                 const T* data = chunk_base + chunk_offset;
-                const bool* valid_data = chunk_valid_base != nullptr
-                                             ? chunk_valid_base + chunk_offset
-                                             : nullptr;
+                const auto validity = chunk_validity.Subview(chunk_offset);
                 if (!cached_skip) {
                     evaluate_batch.template operator()<FilterType::random>(
                         data,
-                        valid_data,
+                        validity,
                         nullptr,
                         1,
                         res + processed_size,
@@ -879,13 +926,13 @@ class SegmentExpr : public Expr {
                     // callback on a null batch so cursor-tracking callbacks (which index
                     // bitmap_input by batch position via their processed_cursor) stay
                     // aligned — mirrors the ProcessDataChunksForMultipleChunk skip branch.
-                    ApplyValidData(valid_data,
+                    ApplyValidData(validity,
                                    res + processed_size,
                                    valid_res + processed_size,
                                    1);
                     evaluate_batch.template operator()<FilterType::random>(
                         nullptr,
-                        nullptr,
+                        ValidityView{},
                         nullptr,
                         1,
                         res + processed_size,
@@ -903,7 +950,7 @@ class SegmentExpr : public Expr {
             int64_t cached_chunk_id = -1;
             std::optional<PinWrapper<Span<T>>> pw;
             const T* chunk_base = nullptr;
-            const bool* chunk_valid_base = nullptr;
+            ValidityView chunk_validity;
             bool cached_skip = false;
             for (size_t i = 0; i < input->size(); ++i) {
                 int64_t offset = (*input)[i];
@@ -914,7 +961,7 @@ class SegmentExpr : public Expr {
                         segment_->chunk_data<T>(op_ctx_, field_id_, chunk_id));
                     auto chunk = pw->get();
                     chunk_base = chunk.data();
-                    chunk_valid_base = chunk.valid_data();
+                    chunk_validity = chunk.validity();
                     // SkipIndex is keyed by chunk alone; evaluate it once per
                     // chunk instead of once per row.
                     cached_skip = skip_func &&
@@ -922,13 +969,11 @@ class SegmentExpr : public Expr {
                     cached_chunk_id = chunk_id;
                 }
                 const T* data = chunk_base + chunk_offset;
-                const bool* valid_data = chunk_valid_base != nullptr
-                                             ? chunk_valid_base + chunk_offset
-                                             : nullptr;
+                const auto validity = chunk_validity.Subview(chunk_offset);
                 if (!cached_skip) {
                     evaluate_batch.template operator()<FilterType::random>(
                         data,
-                        valid_data,
+                        validity,
                         nullptr,
                         1,
                         res + processed_size,
@@ -939,13 +984,13 @@ class SegmentExpr : public Expr {
                     // callback on a null batch so cursor-tracking callbacks (which index
                     // bitmap_input by batch position via their processed_cursor) stay
                     // aligned — mirrors the ProcessDataChunksForMultipleChunk skip branch.
-                    ApplyValidData(valid_data,
+                    ApplyValidData(validity,
                                    res + processed_size,
                                    valid_res + processed_size,
                                    1);
                     evaluate_batch.template operator()<FilterType::random>(
                         nullptr,
-                        nullptr,
+                        ValidityView{},
                         nullptr,
                         1,
                         res + processed_size,
@@ -1080,7 +1125,7 @@ class SegmentExpr : public Expr {
                             evaluate_batch
                                 .template operator()<FilterType::random>(
                                     &value,
-                                    &is_valid,
+                                    ValidityView::FromExpanded(&is_valid),
                                     nullptr,
                                     1,
                                     res + result_idx,
@@ -1095,7 +1140,7 @@ class SegmentExpr : public Expr {
                             evaluate_batch
                                 .template operator()<FilterType::random>(
                                     nullptr,
-                                    nullptr,
+                                    ValidityView{},
                                     nullptr,
                                     1,
                                     res + result_idx,
@@ -1148,10 +1193,7 @@ class SegmentExpr : public Expr {
                     segment_->chunk_data<Array>(op_ctx_, field_id_, chunk_id);
                 auto chunk = pw.get();
                 const Array* array_ptr = chunk.data() + chunk_offset;
-                const bool* valid_data = chunk.valid_data();
-                if (valid_data != nullptr) {
-                    valid_data += chunk_offset;
-                }
+                const auto validity = chunk.validity().Subview(chunk_offset);
 
                 const bool chunk_active =
                     !skip_func || !skip_func(*skip_index, field_id_, chunk_id);
@@ -1161,11 +1203,11 @@ class SegmentExpr : public Expr {
                         // Extract element from Array
                         auto value = array_ptr->get_data<ElementType>(
                             row.element_index + t);
-                        bool is_valid = !valid_data || valid_data[0];
+                        bool is_valid = !validity || validity[0];
 
                         evaluate_batch.template operator()<FilterType::random>(
                             &value,
-                            &is_valid,
+                            ValidityView::FromExpanded(&is_valid),
                             nullptr,
                             1,
                             res + processed_size,
@@ -1174,13 +1216,13 @@ class SegmentExpr : public Expr {
                     } else {
                         // Keep cursor-tracking evaluators aligned with offset
                         // input.
-                        if (valid_data && !valid_data[0]) {
+                        if (validity && !validity[0]) {
                             res[processed_size] = valid_res[processed_size] =
                                 false;
                         }
                         evaluate_batch.template operator()<FilterType::random>(
                             nullptr,
-                            nullptr,
+                            ValidityView{},
                             nullptr,
                             1,
                             res + processed_size,
@@ -1260,8 +1302,7 @@ class SegmentExpr : public Expr {
                     auto [data_vec, valid_data] = pw.get();
 
                     for (size_t j = 0; j < static_cast<size_t>(size); j++) {
-                        const bool is_row_valid =
-                            !valid_data.data() || valid_data[j];
+                        const bool is_row_valid = !valid_data || valid_data[j];
                         // ArrayOffsets defines a NULL array row as having zero
                         // logical elements even when its physical payload is
                         // non-empty. Keep the flattened result aligned with
@@ -1284,7 +1325,7 @@ class SegmentExpr : public Expr {
                                     ElementType str_val(str_view);
                                     evaluate_batch(
                                         &str_val,
-                                        nullptr,
+                                        ValidityView{},
                                         nullptr,
                                         1,
                                         res + processed_elems + k,
@@ -1308,7 +1349,7 @@ class SegmentExpr : public Expr {
                                                              ElementType>) {
                                     // Types match, batch process
                                     evaluate_batch(raw_data,
-                                                   nullptr,
+                                                   ValidityView{},
                                                    nullptr,
                                                    elem_count,
                                                    res + processed_elems,
@@ -1322,7 +1363,7 @@ class SegmentExpr : public Expr {
                                                 raw_data[k]);
                                         evaluate_batch(
                                             &val,
-                                            nullptr,
+                                            ValidityView{},
                                             nullptr,
                                             1,
                                             res + processed_elems + k,
@@ -1340,13 +1381,10 @@ class SegmentExpr : public Expr {
                         segment_->chunk_data<Array>(op_ctx_, field_id_, i);
                     auto chunk = pw.get();
                     const Array* data = chunk.data() + data_pos;
-                    const bool* valid_data = chunk.valid_data();
-                    if (valid_data != nullptr) {
-                        valid_data += data_pos;
-                    }
+                    const auto validity = chunk.validity().Subview(data_pos);
 
                     for (size_t j = 0; j < static_cast<size_t>(size); j++) {
-                        const bool is_row_valid = !valid_data || valid_data[j];
+                        const bool is_row_valid = !validity || validity[j];
                         // ArrayOffsets defines a NULL array row as having zero
                         // logical elements even when its physical payload is
                         // non-empty. Keep the flattened result aligned with
@@ -1369,7 +1407,7 @@ class SegmentExpr : public Expr {
                                     ElementType str_val(str_view);
                                     evaluate_batch(
                                         &str_val,
-                                        nullptr,
+                                        ValidityView{},
                                         nullptr,
                                         1,
                                         res + processed_elems + k,
@@ -1393,7 +1431,7 @@ class SegmentExpr : public Expr {
                                                              ElementType>) {
                                     // Types match, batch process
                                     evaluate_batch(raw_data,
-                                                   nullptr,
+                                                   ValidityView{},
                                                    nullptr,
                                                    elem_count,
                                                    res + processed_elems,
@@ -1407,7 +1445,7 @@ class SegmentExpr : public Expr {
                                                 raw_data[k]);
                                         evaluate_batch(
                                             &val,
-                                            nullptr,
+                                            ValidityView{},
                                             nullptr,
                                             1,
                                             res + processed_elems + k,
@@ -1438,7 +1476,7 @@ class SegmentExpr : public Expr {
                     int64_t{end_range.first - start_range.first};
                 if (skipped_elems > 0) {
                     evaluate_batch(nullptr,
-                                   nullptr,
+                                   ValidityView{},
                                    nullptr,
                                    skipped_elems,
                                    res + processed_elems,
@@ -1486,7 +1524,7 @@ class SegmentExpr : public Expr {
                 continue;  //do not go empty-loop at the bound of the chunk
 
             auto skip_index = segment_->GetSkipIndex();
-            auto process_chunk = [&](const T* data, const bool* valid_data) {
+            auto process_chunk = [&](const T* data, ValidityView valid_data) {
                 auto skipped =
                     skip_func && skip_func(*skip_index, field_id_, i);
                 if (!skipped) {
@@ -1533,7 +1571,7 @@ class SegmentExpr : public Expr {
                             size_per_chunk_ * i + data_pos + j);
                     }
                     func(nullptr,
-                         nullptr,
+                         ValidityView{},
                          nullptr,
                          segment_offsets_array.data(),
                          size,
@@ -1542,7 +1580,7 @@ class SegmentExpr : public Expr {
                          values...);
                 } else {
                     func(nullptr,
-                         nullptr,
+                         ValidityView{},
                          nullptr,
                          size,
                          res + processed_size,
@@ -1558,15 +1596,12 @@ class SegmentExpr : public Expr {
                 auto pw = segment_->chunk_view<VectorArrayView>(
                     op_ctx_, field_id_, i, std::make_pair(data_pos, size));
                 const auto& [data_vec, valid_data] = pw.get();
-                process_chunk(data_vec.data(), valid_data.data());
+                process_chunk(data_vec.data(), valid_data);
             } else {
                 auto pw = segment_->chunk_data<T>(op_ctx_, field_id_, i);
                 auto chunk = pw.get();
-                const bool* valid_data = chunk.valid_data();
-                if (valid_data != nullptr) {
-                    valid_data += data_pos;
-                }
-                process_chunk(chunk.data() + data_pos, valid_data);
+                const auto validity = chunk.validity().Subview(data_pos);
+                process_chunk(chunk.data() + data_pos, validity);
             }
 
             processed_size += size;
@@ -1637,7 +1672,7 @@ class SegmentExpr : public Expr {
 
                         if constexpr (NeedSegmentOffsets) {
                             func(data_vec.data(),
-                                 valid_data.data(),
+                                 valid_data,
                                  nullptr,
                                  segment_offsets_array.data(),
                                  size,
@@ -1646,7 +1681,7 @@ class SegmentExpr : public Expr {
                                  values...);
                         } else {
                             func(data_vec.data(),
-                                 valid_data.data(),
+                                 valid_data,
                                  nullptr,
                                  size,
                                  res + processed_size,
@@ -1667,15 +1702,13 @@ class SegmentExpr : public Expr {
                             segment_->chunk_data<T>(op_ctx_, field_id_, i);
                         auto chunk = pw.get();
                         const T* data = chunk.data() + data_pos;
-                        const bool* valid_data = chunk.valid_data();
-                        if (valid_data != nullptr) {
-                            valid_data += data_pos;
-                        }
+                        const auto validity =
+                            chunk.validity().Subview(data_pos);
 
                         if constexpr (NeedSegmentOffsets) {
                             // For GIS functions: construct segment offsets array
                             func(data,
-                                 valid_data,
+                                 validity,
                                  nullptr,
                                  segment_offsets_array.data(),
                                  size,
@@ -1684,7 +1717,7 @@ class SegmentExpr : public Expr {
                                  values...);
                         } else {
                             func(data,
-                                 valid_data,
+                                 validity,
                                  nullptr,
                                  size,
                                  res + processed_size,
@@ -1699,26 +1732,20 @@ class SegmentExpr : public Expr {
                 // 1. Apply valid_data to handle nullable fields
                 // 2. Call func with nullptr to update internal cursors
                 //    (e.g., processed_cursor for bitmap_input indexing)
-                const bool* valid_data;
                 if constexpr (std::is_same_v<T, std::string_view> ||
                               std::is_same_v<T, Json> ||
                               std::is_same_v<T, ArrayView> ||
                               std::is_same_v<T, VectorArrayView>) {
                     auto pw = segment_->get_batch_views<T>(
                         op_ctx_, field_id_, i, data_pos, size);
-                    valid_data = pw.get().second.data();
-                    ApplyValidData(valid_data,
+                    ApplyValidData(pw.get().second,
                                    res + processed_size,
                                    valid_res + processed_size,
                                    size);
                 } else {
                     auto pw = segment_->chunk_data<T>(op_ctx_, field_id_, i);
                     auto chunk = pw.get();
-                    valid_data = chunk.valid_data();
-                    if (valid_data != nullptr) {
-                        valid_data += data_pos;
-                    }
-                    ApplyValidData(valid_data,
+                    ApplyValidData(chunk.validity().Subview(data_pos),
                                    res + processed_size,
                                    valid_res + processed_size,
                                    size);
@@ -1726,7 +1753,7 @@ class SegmentExpr : public Expr {
                 // Call func with nullptr to update internal cursors
                 if constexpr (NeedSegmentOffsets) {
                     func(nullptr,
-                         nullptr,
+                         ValidityView{},
                          nullptr,
                          segment_offsets_array.data(),
                          size,
@@ -1735,7 +1762,7 @@ class SegmentExpr : public Expr {
                          values...);
                 } else {
                     func(nullptr,
-                         nullptr,
+                         ValidityView{},
                          nullptr,
                          size,
                          res + processed_size,

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
@@ -42,7 +42,7 @@ namespace exec {
 
 #define GEOMETRY_EXECUTE_SUB_BATCH_WITH_COMPARISON(_DataType, method)       \
     auto execute_sub_batch = [this](const _DataType* data,                  \
-                                    const bool* valid_data,                 \
+                                    ValidityView valid_data,                \
                                     const int32_t* offsets,                 \
                                     const int32_t* segment_offsets,         \
                                     const int size,                         \
@@ -57,7 +57,7 @@ namespace exec {
         if (geometry_cache) {                                               \
             auto cache_lock = geometry_cache->AcquireReadLock();            \
             for (int i = 0; i < size; ++i) {                                \
-                if (valid_data != nullptr && !valid_data[i]) {              \
+                if (valid_data && !valid_data[i]) {                         \
                     res[i] = valid_res[i] = false;                          \
                     continue;                                               \
                 }                                                           \
@@ -71,7 +71,7 @@ namespace exec {
         } else {                                                            \
             GEOSContextHandle_t ctx_ = GEOS_init_r();                       \
             for (int i = 0; i < size; ++i) {                                \
-                if (valid_data != nullptr && !valid_data[i]) {              \
+                if (valid_data && !valid_data[i]) {                         \
                     res[i] = valid_res[i] = false;                          \
                     continue;                                               \
                 }                                                           \
@@ -92,7 +92,7 @@ namespace exec {
 // Specialized macro for distance-based operations (ST_DWITHIN)
 #define GEOMETRY_EXECUTE_SUB_BATCH_WITH_COMPARISON_DISTANCE(_DataType, method) \
     auto execute_sub_batch = [this](const _DataType* data,                     \
-                                    const bool* valid_data,                    \
+                                    ValidityView valid_data,                   \
                                     const int32_t* offsets,                    \
                                     const int32_t* segment_offsets,            \
                                     const int size,                            \
@@ -107,7 +107,7 @@ namespace exec {
         if (geometry_cache) {                                                  \
             auto cache_lock = geometry_cache->AcquireReadLock();               \
             for (int i = 0; i < size; ++i) {                                   \
-                if (valid_data != nullptr && !valid_data[i]) {                 \
+                if (valid_data && !valid_data[i]) {                            \
                     res[i] = valid_res[i] = false;                             \
                     continue;                                                  \
                 }                                                              \
@@ -122,7 +122,7 @@ namespace exec {
         } else {                                                               \
             GEOSContextHandle_t ctx_ = GEOS_init_r();                          \
             for (int i = 0; i < size; ++i) {                                   \
-                if (valid_data != nullptr && !valid_data[i]) {                 \
+                if (valid_data && !valid_data[i]) {                            \
                     res[i] = valid_res[i] = false;                             \
                     continue;                                                  \
                 }                                                              \
@@ -144,7 +144,7 @@ namespace exec {
 // Macro for unary operations (like IsValid) that don't need a right_source
 #define GEOMETRY_EXECUTE_SUB_BATCH_UNARY(_DataType, method)                  \
     auto execute_sub_batch = [this](const _DataType* data,                   \
-                                    const bool* valid_data,                  \
+                                    ValidityView valid_data,                 \
                                     const int32_t* offsets,                  \
                                     const int32_t* segment_offsets,          \
                                     const int size,                          \
@@ -158,7 +158,7 @@ namespace exec {
         if (geometry_cache) {                                                \
             auto cache_lock = geometry_cache->AcquireReadLock();             \
             for (int i = 0; i < size; ++i) {                                 \
-                if (valid_data != nullptr && !valid_data[i]) {               \
+                if (valid_data && !valid_data[i]) {                          \
                     res[i] = valid_res[i] = false;                           \
                     continue;                                                \
                 }                                                            \
@@ -172,7 +172,7 @@ namespace exec {
         } else {                                                             \
             GEOSContextHandle_t ctx_ = GEOS_init_r();                        \
             for (int i = 0; i < size; ++i) {                                 \
-                if (valid_data != nullptr && !valid_data[i]) {               \
+                if (valid_data && !valid_data[i]) {                          \
                     res[i] = valid_res[i] = false;                           \
                     continue;                                                \
                 }                                                            \

--- a/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
+++ b/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
@@ -389,7 +389,7 @@ ReadJsonStatsInt64Equal(JsonKeyStats& stats,
     TargetBitmapView valid_res_view(valid_res);
 
     auto func = [expected](const int64_t* data,
-                           const bool* valid_data,
+                           ValidityView valid_data,
                            const int chunk_size,
                            TargetBitmapView res,
                            TargetBitmapView valid_res) {

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -385,7 +385,7 @@ PhyJsonContainsFilterExpr::ExecArrayContains(EvalCtx& context) {
         [&processed_cursor, &
          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const milvus::ArrayView* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -413,7 +413,7 @@ PhyJsonContainsFilterExpr::ExecArrayContains(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -491,7 +491,7 @@ PhyJsonContainsFilterExpr::ExecJsonContains(EvalCtx& context) {
         [&processed_cursor, &
          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -538,7 +538,7 @@ PhyJsonContainsFilterExpr::ExecJsonContains(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -746,7 +746,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsArray(EvalCtx& context) {
         [&processed_cursor, &
          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -791,7 +791,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsArray(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -983,7 +983,7 @@ PhyJsonContainsFilterExpr::ExecArrayContainsAll(EvalCtx& context) {
         [&processed_cursor, &bitmap_input, &matcher, &
          found_large ]<FilterType filter_type = FilterType::sequential>(
             const milvus::ArrayView* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -1029,7 +1029,7 @@ PhyJsonContainsFilterExpr::ExecArrayContainsAll(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -1115,7 +1115,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAll(EvalCtx& context) {
         [&processed_cursor, &bitmap_input, &matcher, &
          found_large ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -1195,7 +1195,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAll(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -1439,7 +1439,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffType(EvalCtx& context) {
         [&processed_cursor, &
          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -1542,7 +1542,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffType(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -1797,7 +1797,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllArray(EvalCtx& context) {
         [&processed_cursor, &
          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -1847,7 +1847,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllArray(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -2040,7 +2040,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffType(EvalCtx& context) {
         [&processed_cursor, &
          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -2134,7 +2134,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffType(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }

--- a/internal/core/src/exec/expression/JsonContainsExpr.h
+++ b/internal/core/src/exec/expression/JsonContainsExpr.h
@@ -44,12 +44,12 @@ class ShreddingArrayBsonContainsArrayExecutor {
 
     void
     operator()(const std::string_view* src,
-               const bool* valid,
+               ValidityView valid,
                size_t size,
                TargetBitmapView res,
                TargetBitmapView valid_res) {
         for (size_t i = 0; i < size; ++i) {
-            if (valid != nullptr && !valid[i]) {
+            if (valid && !valid[i]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -92,12 +92,12 @@ class ShreddingArrayBsonContainsAllArrayExecutor {
 
     void
     operator()(const std::string_view* src,
-               const bool* valid,
+               ValidityView valid,
                size_t size,
                TargetBitmapView res,
                TargetBitmapView valid_res) {
         for (size_t i = 0; i < size; ++i) {
-            if (valid != nullptr && !valid[i]) {
+            if (valid && !valid[i]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -144,12 +144,12 @@ class ShreddingArrayBsonContainsAnyExecutor {
 
     void
     operator()(const std::string_view* src,
-               const bool* valid,
+               ValidityView valid,
                size_t size,
                TargetBitmapView res,
                TargetBitmapView valid_res) {
         for (size_t i = 0; i < size; ++i) {
-            if (valid != nullptr && !valid[i]) {
+            if (valid && !valid[i]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -198,12 +198,12 @@ class ShreddingArrayBsonContainsAllExecutor {
 
     void
     operator()(const std::string_view* src,
-               const bool* valid,
+               ValidityView valid,
                size_t size,
                TargetBitmapView res,
                TargetBitmapView valid_res) {
         for (size_t i = 0; i < size; ++i) {
-            if (valid != nullptr && !valid[i]) {
+            if (valid && !valid[i]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -252,12 +252,12 @@ class ShreddingArrayBsonContainsAllWithDiffTypeExecutor {
 
     void
     operator()(const std::string_view* src,
-               const bool* valid,
+               ValidityView valid,
                size_t size,
                TargetBitmapView res,
                TargetBitmapView valid_res) {
         for (size_t i = 0; i < size; ++i) {
-            if (valid != nullptr && !valid[i]) {
+            if (valid && !valid[i]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -357,12 +357,12 @@ class ShreddingArrayBsonContainsAnyWithDiffTypeExecutor {
 
     void
     operator()(const std::string_view* src,
-               const bool* valid,
+               ValidityView valid,
                size_t size,
                TargetBitmapView res,
                TargetBitmapView valid_res) {
         for (size_t i = 0; i < size; ++i) {
-            if (valid != nullptr && !valid[i]) {
+            if (valid && !valid[i]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -319,7 +319,7 @@ PhyTermFilterExpr::ExecTermArrayVariableInField(EvalCtx& context) {
         [&processed_cursor, &
          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const ArrayView* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -346,7 +346,7 @@ PhyTermFilterExpr::ExecTermArrayVariableInField(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -420,7 +420,7 @@ PhyTermFilterExpr::ExecTermArrayFieldInVariable(EvalCtx& context) {
         [&processed_cursor, &
          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const ArrayView* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -443,7 +443,7 @@ PhyTermFilterExpr::ExecTermArrayFieldInVariable(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -526,7 +526,7 @@ PhyTermFilterExpr::ExecTermJsonVariableInField(EvalCtx& context) {
         [&processed_cursor, &
          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -562,7 +562,7 @@ PhyTermFilterExpr::ExecTermJsonVariableInField(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -647,12 +647,12 @@ PhyTermFilterExpr::ExecJsonInVariableByStats() {
                 TargetBitmap target_valid(active_count_, true);
                 TargetBitmapView target_valid_view(target_valid);
                 auto shredding_executor = [this](const ColType* src,
-                                                 const bool* valid,
+                                                 ValidityView valid,
                                                  size_t size,
                                                  TargetBitmapView res,
                                                  TargetBitmapView valid_res) {
                     for (size_t i = 0; i < size; ++i) {
-                        if (valid != nullptr && !valid[i]) {
+                        if (valid && !valid[i]) {
                             res[i] = valid_res[i] = false;
                             continue;
                         }
@@ -819,7 +819,7 @@ PhyTermFilterExpr::ExecTermJsonFieldInVariable(EvalCtx& context) {
         [&processed_cursor, &
          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -866,7 +866,7 @@ PhyTermFilterExpr::ExecTermJsonFieldInVariable(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -1115,7 +1115,7 @@ PhyTermFilterExpr::ExecVisitorImplForData(EvalCtx& context) {
         [&processed_cursor, &bitmap_input, &simd_filter_fn,
          str_set_elem ]<FilterType filter_type = FilterType::sequential>(
             const T* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -1131,14 +1131,7 @@ PhyTermFilterExpr::ExecVisitorImplForData(EvalCtx& context) {
         if constexpr (filter_type == FilterType::sequential) {
             if (simd_filter_fn) {
                 simd_filter_fn(data, size, res);
-                // Apply validity mask
-                if (valid_data != nullptr) {
-                    for (int i = 0; i < size; ++i) {
-                        if (!valid_data[i]) {
-                            res[i] = valid_res[i] = false;
-                        }
-                    }
-                }
+                ApplyValidMask(valid_data, res, valid_res, size);
                 // Apply bitmap mask
                 if (has_bitmap_input) {
                     for (int i = 0; i < size; ++i) {
@@ -1159,7 +1152,7 @@ PhyTermFilterExpr::ExecVisitorImplForData(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }

--- a/internal/core/src/exec/expression/TimestamptzArithCompareExpr.cpp
+++ b/internal/core/src/exec/expression/TimestamptzArithCompareExpr.cpp
@@ -291,7 +291,7 @@ PhyTimestamptzArithCompareExpr::ExecCompareVisitorImplForAll(
         [ arith_op,
           compare_op ]<FilterType filter_type = FilterType::sequential>(
             const T* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -303,7 +303,7 @@ PhyTimestamptzArithCompareExpr::ExecCompareVisitorImplForAll(
         }
         const int64_t compare_us = compare_value;
         for (int i = 0; i < size; ++i) {
-            if (valid_data != nullptr && !valid_data[i]) {
+            if (valid_data && !valid_data[i]) {
                 // NULL never matches, under either polarity (three-valued
                 // logic); do not evaluate the storage placeholder value.
                 res[i] = valid_res[i] = false;

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -388,7 +388,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonPreciseNumeric(
         [ pointer, bound, op_type, &bitmap_input, &
           processed_cursor ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -403,7 +403,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonPreciseNumeric(
             if constexpr (filter_type == FilterType::random) {
                 offset = offsets ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -470,7 +470,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplArray(EvalCtx& context) {
         [ op_type, &processed_cursor, &
           bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const milvus::ArrayView* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -919,7 +919,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
         [ op_type, pointer, &processed_cursor, &
           bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -937,7 +937,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                     if constexpr (filter_type == FilterType::random) {
                         offset = (offsets) ? offsets[i] : i;
                     }
-                    if (valid_data != nullptr && !valid_data[offset]) {
+                    if (valid_data && !valid_data[offset]) {
                         res[i] = valid_res[i] = false;
                         continue;
                     }
@@ -959,7 +959,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                     if constexpr (filter_type == FilterType::random) {
                         offset = (offsets) ? offsets[i] : i;
                     }
-                    if (valid_data != nullptr && !valid_data[offset]) {
+                    if (valid_data && !valid_data[offset]) {
                         res[i] = valid_res[i] = false;
                         continue;
                     }
@@ -981,7 +981,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                     if constexpr (filter_type == FilterType::random) {
                         offset = (offsets) ? offsets[i] : i;
                     }
-                    if (valid_data != nullptr && !valid_data[offset]) {
+                    if (valid_data && !valid_data[offset]) {
                         res[i] = valid_res[i] = false;
                         continue;
                     }
@@ -1003,7 +1003,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                     if constexpr (filter_type == FilterType::random) {
                         offset = (offsets) ? offsets[i] : i;
                     }
-                    if (valid_data != nullptr && !valid_data[offset]) {
+                    if (valid_data && !valid_data[offset]) {
                         res[i] = valid_res[i] = false;
                         continue;
                     }
@@ -1025,7 +1025,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                     if constexpr (filter_type == FilterType::random) {
                         offset = (offsets) ? offsets[i] : i;
                     }
-                    if (valid_data != nullptr && !valid_data[offset]) {
+                    if (valid_data && !valid_data[offset]) {
                         res[i] = valid_res[i] = false;
                         continue;
                     }
@@ -1053,7 +1053,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                     if constexpr (filter_type == FilterType::random) {
                         offset = (offsets) ? offsets[i] : i;
                     }
-                    if (valid_data != nullptr && !valid_data[offset]) {
+                    if (valid_data && !valid_data[offset]) {
                         res[i] = valid_res[i] = false;
                         continue;
                     }
@@ -1083,7 +1083,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                     if constexpr (filter_type == FilterType::random) {
                         offset = (offsets) ? offsets[i] : i;
                     }
-                    if (valid_data != nullptr && !valid_data[offset]) {
+                    if (valid_data && !valid_data[offset]) {
                         res[i] = valid_res[i] = false;
                         continue;
                     }
@@ -1108,7 +1108,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                         if constexpr (filter_type == FilterType::random) {
                             offset = (offsets) ? offsets[i] : i;
                         }
-                        if (valid_data != nullptr && !valid_data[offset]) {
+                        if (valid_data && !valid_data[offset]) {
                             res[i] = valid_res[i] = false;
                             continue;
                         }
@@ -1132,7 +1132,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                         if constexpr (filter_type == FilterType::random) {
                             offset = (offsets) ? offsets[i] : i;
                         }
-                        if (valid_data != nullptr && !valid_data[offset]) {
+                        if (valid_data && !valid_data[offset]) {
                             res[i] = valid_res[i] = false;
                             continue;
                         }
@@ -1250,12 +1250,12 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
                 if constexpr (kNumericColumn && kNumericValue) {
                     auto executor = [op_type, &numeric_bound](
                                         const ColType* src,
-                                        const bool* valid,
+                                        ValidityView valid,
                                         size_t size,
                                         TargetBitmapView res,
                                         TargetBitmapView valid_res) {
                         for (size_t i = 0; i < size; ++i) {
-                            if (valid != nullptr && !valid[i]) {
+                            if (valid && !valid[i]) {
                                 res[i] = valid_res[i] = false;
                                 continue;
                             }
@@ -1803,7 +1803,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
             like_matcher_ptr
         ]<FilterType filter_type = FilterType::sequential>(
             const T* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -1951,16 +1951,26 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
         // there is a batch operation in BinaryRangeElementFunc,
         // so not divide data again for the reason that it may reduce performance if the null distribution is scattered
         // but to mask res with valid_data after the batch operation.
-        if (valid_data != nullptr) {
-            bool has_bitmap_input = !bitmap_input.empty();
+        if constexpr (filter_type == FilterType::sequential) {
+            if (bitmap_input.empty()) {
+                ApplyValidMask(valid_data, res, valid_res, size);
+            } else if (valid_data) {
+                for (int i = 0; i < size; i++) {
+                    if (!bitmap_input[i + processed_cursor]) {
+                        continue;
+                    }
+                    if (!valid_data[i]) {
+                        res[i] = valid_res[i] = false;
+                    }
+                }
+            }
+        } else if (valid_data) {
             for (int i = 0; i < size; i++) {
-                if (has_bitmap_input && !bitmap_input[i + processed_cursor]) {
+                if (!bitmap_input.empty() &&
+                    !bitmap_input[i + processed_cursor]) {
                     continue;
                 }
-                auto offset = i;
-                if constexpr (filter_type == FilterType::random) {
-                    offset = (offsets) ? offsets[i] : i;
-                }
+                auto offset = (offsets) ? offsets[i] : i;
                 if (!valid_data[offset]) {
                     res[i] = valid_res[i] = false;
                 }

--- a/internal/core/src/exec/expression/UnaryExpr.h
+++ b/internal/core/src/exec/expression/UnaryExpr.h
@@ -499,7 +499,7 @@ struct UnaryElementFuncForArray {
                                        ValueType>;
     void
     operator()(const ArrayView* src,
-               const bool* valid_data,
+               ValidityView valid_data,
                size_t size,
                const ValueType& val,
                int index,
@@ -532,7 +532,7 @@ struct UnaryElementFuncForArray {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -881,7 +881,7 @@ class ShreddingExecutor {
 
     void
     operator()(const GetType* src,
-               const bool* valid,
+               ValidityView valid,
                size_t size,
                TargetBitmapView res,
                TargetBitmapView valid_res) {
@@ -891,7 +891,7 @@ class ShreddingExecutor {
                       "shredding data");
         } else {
             ExecuteOperation(src, size, res);
-            HandleValidData(valid, size, res, valid_res);
+            ApplyValidMask(valid, res, valid_res, size);
         }
     }
 
@@ -899,20 +899,6 @@ class ShreddingExecutor {
     void
     ExecuteOperation(const GetType* src, size_t size, TargetBitmapView res) {
         BatchUnaryCompare<GetType, InnerType>(src, size, val_, op_type_, res);
-    }
-
-    void
-    HandleValidData(const bool* valid,
-                    size_t size,
-                    TargetBitmapView res,
-                    TargetBitmapView valid_res) {
-        if (valid != nullptr) {
-            for (int i = 0; i < size; ++i) {
-                if (!valid[i]) {
-                    res[i] = valid_res[i] = false;
-                }
-            }
-        }
     }
 
     proto::plan::OpType op_type_;
@@ -932,12 +918,12 @@ class ShreddingArrayBsonExecutor {
 
     void
     operator()(const std::string_view* src,
-               const bool* valid,
+               ValidityView valid,
                size_t size,
                TargetBitmapView res,
                TargetBitmapView valid_res) {
         for (size_t i = 0; i < size; ++i) {
-            if (valid != nullptr && !valid[i]) {
+            if (valid && !valid[i]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }

--- a/internal/core/src/exec/operator/search-groupby/SearchGroupByOperator.h
+++ b/internal/core/src/exec/operator/search-groupby/SearchGroupByOperator.h
@@ -195,7 +195,7 @@ class SealedDataGetter : public DataGetter<OutputType> {
     // shared across queries, this cache must be guarded — data race otherwise.
     mutable std::unordered_map<
         int64_t,
-        PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>>
+        PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>>
         str_pw_map;
 
     PinWrapper<const index::IndexBase*> index_ptr_;
@@ -203,7 +203,7 @@ class SealedDataGetter : public DataGetter<OutputType> {
     // Shares the same single-thread contract as str_pw_map above.
     mutable std::unordered_map<
         int64_t,
-        PinWrapper<std::pair<std::vector<milvus::Json>, FixedVector<bool>>>>
+        PinWrapper<std::pair<std::vector<milvus::Json>, ValidityView>>>
         json_pw_map;
 
  public:
@@ -247,7 +247,7 @@ class SealedDataGetter : public DataGetter<OutputType> {
                 }
                 auto& pw = str_pw_map[chunk_id];
                 auto& [str_chunk_view, valid_data] = pw.get();
-                if (!valid_data.empty() && !valid_data[inner_offset]) {
+                if (valid_data && !valid_data[inner_offset]) {
                     return std::nullopt;
                 }
                 std::string_view str_val_view = str_chunk_view[inner_offset];
@@ -260,7 +260,7 @@ class SealedDataGetter : public DataGetter<OutputType> {
                 }
                 auto& pw = json_pw_map[chunk_id];
                 auto& [json_chunk_view, valid_data] = pw.get();
-                if (!valid_data.empty() && !valid_data[inner_offset]) {
+                if (valid_data && !valid_data[inner_offset]) {
                     return std::nullopt;
                 }
                 auto& json_val = json_chunk_view[inner_offset];
@@ -275,7 +275,7 @@ class SealedDataGetter : public DataGetter<OutputType> {
                 auto pw = segment_.chunk_data<InnerRawType>(
                     op_ctx_, field_id_, chunk_id);
                 auto& span = pw.get();
-                if (span.valid_data() && !span.valid_data()[inner_offset]) {
+                if (!span.is_valid(inner_offset)) {
                     return std::nullopt;
                 }
                 auto raw = span.operator[](inner_offset);

--- a/internal/core/src/index/json_stats/JsonKeyStats.h
+++ b/internal/core/src/index/json_stats/JsonKeyStats.h
@@ -250,20 +250,8 @@ class JsonKeyStats : public ScalarIndex<std::string> {
 
         for (size_t i = 0; i < num_data_chunk; i++) {
             auto chunk_size = column->chunk_row_nums(i);
-            const bool* valid_data;
-            if (GetShreddingJsonType(path) == JSONType::STRING ||
-                GetShreddingJsonType(path) == JSONType::ARRAY) {
-                auto pw = column->StringViews(op_ctx, i);
-                valid_data = pw.get().second.data();
-                ApplyOnlyValidData(
-                    valid_data, valid_res + processed_size, chunk_size);
-            } else {
-                auto pw = column->Span(op_ctx, i);
-                auto chunk = pw.get();
-                valid_data = chunk.valid_data();
-                ApplyOnlyValidData(
-                    valid_data, valid_res + processed_size, chunk_size);
-            }
+            column->ApplyValidDataInChunk(
+                op_ctx, i, 0, chunk_size, valid_res + processed_size);
             processed_size += chunk_size;
         }
         AssertInfo(processed_size == valid_res.size(),
@@ -305,7 +293,7 @@ class JsonKeyStats : public ScalarIndex<std::string> {
                     auto [data_vec, valid_data] = pw.get();
 
                     func(data_vec.data(),
-                         valid_data.data(),
+                         valid_data,
                          chunk_size,
                          res + processed_size,
                          valid_res + processed_size,
@@ -314,31 +302,22 @@ class JsonKeyStats : public ScalarIndex<std::string> {
                     auto pw = column->Span(op_ctx, i);
                     auto chunk = pw.get();
                     const T* data = static_cast<const T*>(chunk.data());
-                    const bool* valid_data = chunk.valid_data();
+                    const auto validity = chunk.validity();
                     func(data,
-                         valid_data,
+                         validity,
                          chunk_size,
                          res + processed_size,
                          valid_res + processed_size,
                          values...);
                 }
             } else {
-                const bool* valid_data;
-                if constexpr (std::is_same_v<T, std::string_view>) {
-                    auto pw = column->StringViews(op_ctx, i);
-                    valid_data = pw.get().second.data();
-                    ApplyValidData(valid_data,
-                                   res + processed_size,
-                                   valid_res + processed_size,
-                                   chunk_size);
-                } else {
-                    auto pw = column->Span(op_ctx, i);
+                if (column->IsNullable()) {
+                    auto pw = column->GetChunk(op_ctx, i);
                     auto chunk = pw.get();
-                    valid_data = chunk.valid_data();
-                    ApplyValidData(valid_data,
-                                   res + processed_size,
-                                   valid_res + processed_size,
-                                   chunk_size);
+                    chunk->ApplyValidityMask(
+                        0, chunk_size, res + processed_size);
+                    chunk->ApplyValidityMask(
+                        0, chunk_size, valid_res + processed_size);
                 }
             }
 
@@ -626,33 +605,6 @@ class JsonKeyStats : public ScalarIndex<std::string> {
     void
     LoadShreddingData(const std::vector<std::string>& index_files,
                       const std::string& warmup_policy = "");
-
-    void
-    ApplyValidData(const bool* valid_data,
-                   TargetBitmapView res,
-                   TargetBitmapView valid_res,
-                   const int size) {
-        if (valid_data != nullptr) {
-            for (int i = 0; i < size; i++) {
-                if (!valid_data[i]) {
-                    res[i] = valid_res[i] = false;
-                }
-            }
-        }
-    }
-
-    void
-    ApplyOnlyValidData(const bool* valid_data,
-                       TargetBitmapView valid_res,
-                       const int size) {
-        if (valid_data != nullptr) {
-            for (int i = 0; i < size; i++) {
-                if (!valid_data[i]) {
-                    valid_res[i] = false;
-                }
-            }
-        }
-    }
 
     void
     GetColumnSchemaFromParquet(int64_t column_group_id,

--- a/internal/core/src/index/skipindex_stats/SkipIndexStats.cpp
+++ b/internal/core/src/index/skipindex_stats/SkipIndexStats.cpp
@@ -163,48 +163,45 @@ SkipIndexStatsBuilder::Build(DataType data_type, const Chunk* chunk) const {
     auto span = fixed_chunk->Span();
 
     const void* chunk_data = span.data();
-    const bool* valid_data = span.valid_data();
+    const auto validity = span.validity();
     int64_t count = span.row_count();
     switch (data_type) {
         case DataType::BOOL: {
             const bool* typedData = static_cast<const bool*>(chunk_data);
-            auto info = ProcessFieldMetrics<bool>(typedData, valid_data, count);
+            auto info = ProcessFieldMetrics<bool>(typedData, validity, count);
             return LoadMetrics<bool>(info);
         }
         case DataType::INT8: {
             const int8_t* typedData = static_cast<const int8_t*>(chunk_data);
-            auto info =
-                ProcessFieldMetrics<int8_t>(typedData, valid_data, count);
+            auto info = ProcessFieldMetrics<int8_t>(typedData, validity, count);
             return LoadMetrics<int8_t>(info);
         }
         case DataType::INT16: {
             const int16_t* typedData = static_cast<const int16_t*>(chunk_data);
             auto info =
-                ProcessFieldMetrics<int16_t>(typedData, valid_data, count);
+                ProcessFieldMetrics<int16_t>(typedData, validity, count);
             return LoadMetrics<int16_t>(info);
         }
         case DataType::INT32: {
             const int32_t* typedData = static_cast<const int32_t*>(chunk_data);
             auto info =
-                ProcessFieldMetrics<int32_t>(typedData, valid_data, count);
+                ProcessFieldMetrics<int32_t>(typedData, validity, count);
             return LoadMetrics<int32_t>(info);
         }
         case DataType::INT64: {
             const int64_t* typedData = static_cast<const int64_t*>(chunk_data);
             auto info =
-                ProcessFieldMetrics<int64_t>(typedData, valid_data, count);
+                ProcessFieldMetrics<int64_t>(typedData, validity, count);
             return LoadMetrics<int64_t>(info);
         }
         case DataType::FLOAT: {
             const float* typedData = static_cast<const float*>(chunk_data);
-            auto info =
-                ProcessFieldMetrics<float>(typedData, valid_data, count);
+            auto info = ProcessFieldMetrics<float>(typedData, validity, count);
             return LoadMetrics<float>(info);
         }
         case DataType::DOUBLE: {
             const double* typedData = static_cast<const double*>(chunk_data);
-            auto info =
-                ProcessFieldMetrics<double>(typedData, valid_data, count);
+            auto info = ProcessFieldMetrics<double>(typedData, validity, count);
             return LoadMetrics<double>(info);
         }
         default:

--- a/internal/core/src/index/skipindex_stats/SkipIndexStats.h
+++ b/internal/core/src/index/skipindex_stats/SkipIndexStats.h
@@ -957,7 +957,7 @@ class SkipIndexStatsBuilder {
     template <typename T>
     metricsInfo<T>
     ProcessFieldMetrics(const T* data,
-                        const bool* valid_data,
+                        ValidityView validity,
                         int64_t count) const {
         bool has_first_valid = false;
         T min{}, max{};
@@ -969,7 +969,7 @@ class SkipIndexStatsBuilder {
 
         for (int64_t i = 0; i < count; i++) {
             T value = data[i];
-            if (valid_data != nullptr && !valid_data[i]) {
+            if (validity && !validity[i]) {
                 null_count++;
                 continue;
             }

--- a/internal/core/src/mmap/ChunkedColumn.h
+++ b/internal/core/src/mmap/ChunkedColumn.h
@@ -285,7 +285,7 @@ class ChunkedColumnBase : public ChunkedColumnInterface {
                   "BulkVectorValueAt only supported for ChunkedColumn");
     }
 
-    PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
     StringViews(milvus::OpContext* op_ctx,
                 int64_t chunk_id,
                 std::optional<std::pair<int64_t, int64_t>> offset_len =
@@ -294,7 +294,7 @@ class ChunkedColumnBase : public ChunkedColumnInterface {
                   "StringViews only supported for VariableColumn");
     }
 
-    PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
     ArrayViews(
         milvus::OpContext* op_ctx,
         int64_t chunk_id,
@@ -303,7 +303,7 @@ class ChunkedColumnBase : public ChunkedColumnInterface {
                   "ArrayViews only supported for ArrayChunkedColumn");
     }
 
-    PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
     VectorArrayViews(
         milvus::OpContext* op_ctx,
         int64_t chunk_id,
@@ -552,7 +552,7 @@ class ChunkedVariableColumn : public ChunkedColumnBase {
         : ChunkedColumnBase(std::move(slot), field_meta) {
     }
 
-    PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
     StringViews(milvus::OpContext* op_ctx,
                 int64_t chunk_id,
                 std::optional<std::pair<int64_t, int64_t>> offset_len =
@@ -560,7 +560,7 @@ class ChunkedVariableColumn : public ChunkedColumnBase {
         auto ca = SemiInlineGet(slot_->PinCells(op_ctx, {chunk_id}));
         auto chunk = ca->get_cell_of(chunk_id);
         return PinWrapper<
-            std::pair<std::vector<std::string_view>, FixedVector<bool>>>(
+            std::pair<std::vector<std::string_view>, ValidityView>>(
             std::move(ca),
             static_cast<StringChunk*>(chunk)->StringViews(offset_len));
     }
@@ -684,7 +684,7 @@ class ChunkedArrayColumn : public ChunkedColumnBase {
         }
     }
 
-    PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
     ArrayViews(milvus::OpContext* op_ctx,
                int64_t chunk_id,
                std::optional<std::pair<int64_t, int64_t>> offset_len =
@@ -692,7 +692,7 @@ class ChunkedArrayColumn : public ChunkedColumnBase {
         auto ca = SemiInlineGet(
             slot_->PinCells(op_ctx, {static_cast<cid_t>(chunk_id)}));
         auto chunk = ca->get_cell_of(chunk_id);
-        return PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>(
+        return PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>(
             std::move(ca), static_cast<ArrayChunk*>(chunk)->Views(offset_len));
     }
 
@@ -731,7 +731,7 @@ class ChunkedVectorArrayColumn : public ChunkedColumnBase {
         }
     }
 
-    PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
     VectorArrayViews(milvus::OpContext* op_ctx,
                      int64_t chunk_id,
                      std::optional<std::pair<int64_t, int64_t>> offset_len =
@@ -740,7 +740,7 @@ class ChunkedVectorArrayColumn : public ChunkedColumnBase {
             slot_->PinCells(op_ctx, {static_cast<cid_t>(chunk_id)}));
         auto chunk = ca->get_cell_of(chunk_id);
         return PinWrapper<
-            std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>(
+            std::pair<std::vector<VectorArrayView>, ValidityView>>(
             std::move(ca),
             static_cast<VectorArrayChunk*>(chunk)->Views(offset_len));
     }

--- a/internal/core/src/mmap/ChunkedColumnGroup.h
+++ b/internal/core/src/mmap/ChunkedColumnGroup.h
@@ -365,7 +365,7 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
             static_cast<FixedWidthChunk*>(chunk.get())->Span());
     }
 
-    PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
     StringViews(milvus::OpContext* op_ctx,
                 int64_t chunk_id,
                 std::optional<std::pair<int64_t, int64_t>> offset_len =
@@ -378,12 +378,12 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
         auto chunk_wrapper = group_->GetGroupChunk(op_ctx, chunk_id);
         auto chunk = chunk_wrapper.get()->GetChunk(field_id_);
         return PinWrapper<
-            std::pair<std::vector<std::string_view>, FixedVector<bool>>>(
+            std::pair<std::vector<std::string_view>, ValidityView>>(
             std::move(chunk_wrapper),
             static_cast<StringChunk*>(chunk.get())->StringViews(offset_len));
     }
 
-    PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
     ArrayViews(milvus::OpContext* op_ctx,
                int64_t chunk_id,
                std::optional<std::pair<int64_t, int64_t>> offset_len =
@@ -395,12 +395,12 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
         }
         auto chunk_wrapper = group_->GetGroupChunk(op_ctx, chunk_id);
         auto chunk = chunk_wrapper.get()->GetChunk(field_id_);
-        return PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>(
+        return PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>(
             std::move(chunk_wrapper),
             static_cast<ArrayChunk*>(chunk.get())->Views(offset_len));
     }
 
-    PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
     VectorArrayViews(milvus::OpContext* op_ctx,
                      int64_t chunk_id,
                      std::optional<std::pair<int64_t, int64_t>> offset_len =
@@ -413,7 +413,7 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
         auto chunk_wrapper = group_->GetGroupChunk(op_ctx, chunk_id);
         auto chunk = chunk_wrapper.get()->GetChunk(field_id_);
         return PinWrapper<
-            std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>(
+            std::pair<std::vector<VectorArrayView>, ValidityView>>(
             std::move(chunk_wrapper),
             static_cast<VectorArrayChunk*>(chunk.get())->Views(offset_len));
     }

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -97,20 +97,18 @@ class ChunkedColumnInterface {
     virtual bool
     CellsLoaded(const int64_t* offsets, int64_t count) const = 0;
 
-    virtual PinWrapper<
-        std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    virtual PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
     StringViews(milvus::OpContext* op_ctx,
                 int64_t chunk_id,
                 std::optional<std::pair<int64_t, int64_t>> offset_len =
                     std::nullopt) const = 0;
 
-    virtual PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    virtual PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
     ArrayViews(milvus::OpContext* op_ctx,
                int64_t chunk_id,
                std::optional<std::pair<int64_t, int64_t>> offset_len) const = 0;
 
-    virtual PinWrapper<
-        std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+    virtual PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
     VectorArrayViews(
         milvus::OpContext* op_ctx,
         int64_t chunk_id,
@@ -165,19 +163,7 @@ class ChunkedColumnInterface {
                    offset,
                    size,
                    chunk->RowNums());
-        const auto& valid_data = chunk->Valid();
-        AssertInfo(
-            offset + size <= static_cast<int64_t>(valid_data.size()),
-            "Valid-data range out of valid-data bounds, offset: {}, size: {}, "
-            "valid-data size: {}",
-            offset,
-            size,
-            valid_data.size());
-        for (int64_t i = 0; i < size; ++i) {
-            if (!valid_data[offset + i]) {
-                valid_result[i] = false;
-            }
-        }
+        chunk->ApplyValidityMask(offset, size, valid_result);
     }
 
     // Get number of rows before a specific chunk

--- a/internal/core/src/mmap/VirtualPKChunkedColumn.h
+++ b/internal/core/src/mmap/VirtualPKChunkedColumn.h
@@ -124,7 +124,7 @@ class VirtualPKChunkedColumn : public ChunkedColumnInterface {
         return true;
     }
 
-    PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
     StringViews(milvus::OpContext* op_ctx,
                 int64_t chunk_id,
                 std::optional<std::pair<int64_t, int64_t>> offset_len =
@@ -133,7 +133,7 @@ class VirtualPKChunkedColumn : public ChunkedColumnInterface {
                   "StringViews not supported for VirtualPKChunkedColumn");
     }
 
-    PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
     ArrayViews(
         milvus::OpContext* op_ctx,
         int64_t chunk_id,
@@ -142,7 +142,7 @@ class VirtualPKChunkedColumn : public ChunkedColumnInterface {
                   "ArrayViews not supported for VirtualPKChunkedColumn");
     }
 
-    PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
     VectorArrayViews(
         milvus::OpContext* op_ctx,
         int64_t chunk_id,

--- a/internal/core/src/query/ScalarIndex.h
+++ b/internal/core/src/query/ScalarIndex.h
@@ -25,7 +25,17 @@ template <typename T>
 inline index::ScalarIndexPtr<T>
 generate_scalar_index(Span<T> data) {
     auto indexing = std::make_unique<index::ScalarIndexSort<T>>();
-    indexing->Build(data.row_count(), data.data(), data.valid_data());
+    const auto validity = data.validity();
+    FixedVector<bool> materialized_validity;
+    const bool* valid_data = validity.expanded_data();
+    if (validity && valid_data == nullptr) {
+        materialized_validity.reserve(data.row_count());
+        for (int64_t i = 0; i < data.row_count(); ++i) {
+            materialized_validity.emplace_back(validity[i]);
+        }
+        valid_data = materialized_validity.data();
+    }
+    indexing->Build(data.row_count(), data.data(), valid_data);
     return indexing;
 }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -3437,7 +3437,7 @@ ChunkedSegmentSealedImpl::chunk_data_impl(milvus::OpContext* op_ctx,
               "chunk_data_impl only used for chunk column field ");
 }
 
-PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
 ChunkedSegmentSealedImpl::chunk_array_view_impl(
     milvus::OpContext* op_ctx,
     FieldId field_id,
@@ -3453,7 +3453,7 @@ ChunkedSegmentSealedImpl::chunk_array_view_impl(
               "chunk_array_view_impl only used for chunk column field ");
 }
 
-PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
 ChunkedSegmentSealedImpl::chunk_vector_array_view_impl(
     milvus::OpContext* op_ctx,
     FieldId field_id,
@@ -3469,7 +3469,7 @@ ChunkedSegmentSealedImpl::chunk_vector_array_view_impl(
               "chunk_vector_array_view_impl only used for chunk column field ");
 }
 
-PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
 ChunkedSegmentSealedImpl::chunk_string_view_impl(
     milvus::OpContext* op_ctx,
     FieldId field_id,
@@ -7960,7 +7960,7 @@ ChunkedSegmentSealedImpl::LoadGeometryCache(
 
             // Add each string view to the geometry cache
             for (size_t i = 0; i < string_views.size(); ++i) {
-                if (valid_data.empty() || valid_data[i]) {
+                if (!valid_data || valid_data[i]) {
                     // Valid geometry data
                     const auto& wkb_data = string_views[i];
                     geometry_cache.AppendData(

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -621,21 +621,21 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                     FieldId field_id,
                     int64_t chunk_id) const override;
 
-    PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
     chunk_string_view_impl(
         milvus::OpContext* op_ctx,
         FieldId field_id,
         int64_t chunk_id,
         std::optional<std::pair<int64_t, int64_t>> offset_len) const override;
 
-    PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
     chunk_array_view_impl(
         milvus::OpContext* op_ctx,
         FieldId field_id,
         int64_t chunk_id,
         std::optional<std::pair<int64_t, int64_t>> offset_len) const override;
 
-    PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
     chunk_vector_array_view_impl(
         milvus::OpContext* op_ctx,
         FieldId field_id,

--- a/internal/core/src/segcore/SegmentChunkReader.cpp
+++ b/internal/core/src/segcore/SegmentChunkReader.cpp
@@ -96,7 +96,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor(
     auto pw = segment_->chunk_data<T>(op_ctx_, field_id, current_chunk_id);
     auto chunk_info = pw.get();
     auto chunk_data = chunk_info.data();
-    auto chunk_valid_data = chunk_info.valid_data();
+    auto chunk_validity = chunk_info.validity();
     auto current_chunk_size = segment_->chunk_size(field_id, current_chunk_id);
     return [=,
             this,
@@ -114,11 +114,11 @@ SegmentChunkReader::GetMultipleChunkDataAccessor(
             // the old chunk will be unpinned, pw will now pin the new chunk.
             pw = segment_->chunk_data<T>(op_ctx_, field_id, current_chunk_id);
             chunk_data = pw.get().data();
-            chunk_valid_data = pw.get().valid_data();
+            chunk_validity = pw.get().validity();
             current_chunk_size =
                 segment_->chunk_size(field_id, current_chunk_id);
         }
-        if (chunk_valid_data && !chunk_valid_data[current_chunk_pos]) {
+        if (chunk_validity && !chunk_validity[current_chunk_pos]) {
             current_chunk_pos++;
             return std::nullopt;
         }
@@ -168,14 +168,14 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
             op_ctx_, field_id, current_chunk_id);
         auto chunk_info = pw.get();
         auto chunk_data = chunk_info.data();
-        auto chunk_valid_data = chunk_info.valid_data();
+        auto chunk_validity = chunk_info.validity();
         auto current_chunk_size =
             segment_->chunk_size(field_id, current_chunk_id);
         return [pw = std::move(pw),
                 this,
                 field_id,
                 chunk_data,
-                chunk_valid_data,
+                chunk_validity,
                 current_chunk_size,
                 num_chunks,
                 // pw = std::move(pw),
@@ -192,11 +192,11 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
                 pw = segment_->chunk_data<std::string>(
                     op_ctx_, field_id, current_chunk_id);
                 chunk_data = pw.get().data();
-                chunk_valid_data = pw.get().valid_data();
+                chunk_validity = pw.get().validity();
                 current_chunk_size =
                     segment_->chunk_size(field_id, current_chunk_id);
             }
-            if (chunk_valid_data && !chunk_valid_data[current_chunk_pos]) {
+            if (chunk_validity && !chunk_validity[current_chunk_pos]) {
                 current_chunk_pos++;
                 return std::nullopt;
             }
@@ -228,8 +228,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
             }
             auto& chunk_data = pw.get().first;
             auto& chunk_valid_data = pw.get().second;
-            if (current_chunk_pos < chunk_valid_data.size() &&
-                !chunk_valid_data[current_chunk_pos]) {
+            if (chunk_valid_data && !chunk_valid_data[current_chunk_pos]) {
                 current_chunk_pos++;
                 return std::nullopt;
             }
@@ -309,8 +308,8 @@ SegmentChunkReader::GetChunkDataAccessor(FieldId field_id,
     return [pw = std::move(pw)](int i) mutable -> const data_access_type {
         auto chunk_info = pw.get();
         auto chunk_data = chunk_info.data();
-        auto chunk_valid_data = chunk_info.valid_data();
-        if (chunk_valid_data && !chunk_valid_data[i]) {
+        auto chunk_validity = chunk_info.validity();
+        if (chunk_validity && !chunk_validity[i]) {
             return std::nullopt;
         }
         return chunk_data[i];
@@ -351,8 +350,8 @@ SegmentChunkReader::GetChunkDataAccessor<std::string>(
             segment_->chunk_data<std::string>(op_ctx_, field_id, chunk_id);
         return [pw = std::move(pw)](int i) mutable -> const data_access_type {
             auto chunk_data = pw.get().data();
-            auto chunk_valid_data = pw.get().valid_data();
-            if (chunk_valid_data && !chunk_valid_data[i]) {
+            auto chunk_validity = pw.get().validity();
+            if (chunk_validity && !chunk_validity[i]) {
                 return std::nullopt;
             }
             return data_access_type(std::string_view(chunk_data[i]));
@@ -363,7 +362,7 @@ SegmentChunkReader::GetChunkDataAccessor<std::string>(
         return [pw = std::move(pw)](int i) mutable -> const data_access_type {
             auto& chunk_data = pw.get().first;
             auto& chunk_valid_data = pw.get().second;
-            if (i < chunk_valid_data.size() && !chunk_valid_data[i]) {
+            if (chunk_valid_data && !chunk_valid_data[i]) {
                 return std::nullopt;
             }
             return data_access_type(chunk_data[i]);

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -1394,7 +1394,7 @@ SegmentGrowingImpl::ApplyFieldValidDataByOffsets(
     }
 }
 
-PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
 SegmentGrowingImpl::chunk_string_view_impl(
     milvus::OpContext* op_ctx,
     FieldId field_id,
@@ -1404,7 +1404,7 @@ SegmentGrowingImpl::chunk_string_view_impl(
               "chunk string view impl not implement for growing segment");
 }
 
-PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
 SegmentGrowingImpl::chunk_array_view_impl(
     milvus::OpContext* op_ctx,
     FieldId field_id,
@@ -1414,7 +1414,7 @@ SegmentGrowingImpl::chunk_array_view_impl(
               "chunk array view impl not implement for growing segment");
 }
 
-PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
 SegmentGrowingImpl::chunk_vector_array_view_impl(
     milvus::OpContext* op_ctx,
     FieldId field_id,
@@ -1471,10 +1471,7 @@ SegmentGrowingImpl::chunk_vector_array_view_impl(
 
     std::vector<VectorArrayView> views;
     views.reserve(len);
-    FixedVector<bool> valid_data;
-    if (field_meta.is_nullable()) {
-        valid_data.reserve(len);
-    }
+    const bool nullable = field_meta.is_nullable();
 
     // One batch conversion for the whole contiguous range instead of a
     // logical->physical search (plus a validity lock) per row: the
@@ -1491,33 +1488,47 @@ SegmentGrowingImpl::chunk_vector_array_view_impl(
         logical_offsets.data(), len, row_valid.get(), physical_offsets);
 
     size_t next_physical = 0;
-    for (int64_t i = 0; i < len; ++i) {
-        if (field_meta.is_nullable()) {
-            valid_data.push_back(row_valid[i]);
-        }
-        if (!row_valid[i]) {
-            AssertInfo(field_meta.is_nullable(),
-                       "Cannot find VECTOR_ARRAY data at segment offset {}",
-                       logical_offsets[i]);
-            views.emplace_back();
-            continue;
-        }
+    auto append_valid_view = [&](int64_t logical_offset) {
         auto vector_array = vector_data->get_physical_element(
             physical_offsets[next_physical++]);
         AssertInfo(vector_array != nullptr,
                    "Cannot find VECTOR_ARRAY data at segment offset {}",
-                   logical_offsets[i]);
+                   logical_offset);
         views.emplace_back(const_cast<char*>(vector_array->data()),
                            vector_array->dim(),
                            vector_array->length(),
                            vector_array->byte_size(),
                            vector_array->get_element_type());
+    };
+
+    if (nullable) {
+        auto valid_data = std::make_shared<FixedVector<bool>>();
+        valid_data->reserve(len);
+        for (int64_t i = 0; i < len; ++i) {
+            valid_data->push_back(row_valid[i]);
+            if (!row_valid[i]) {
+                views.emplace_back();
+                continue;
+            }
+            append_valid_view(logical_offsets[i]);
+        }
+        std::pair<std::vector<VectorArrayView>, ValidityView> content{
+            std::move(views), ValidityView::FromExpanded(valid_data->data())};
+        return PinWrapper<
+            std::pair<std::vector<VectorArrayView>, ValidityView>>(
+            std::move(valid_data), std::move(content));
     }
 
-    std::pair<std::vector<VectorArrayView>, FixedVector<bool>> content{
-        std::move(views), std::move(valid_data)};
-    return PinWrapper<
-        std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>(
+    AssertInfo(physical_offsets.size() == static_cast<size_t>(len),
+               "Cannot find VECTOR_ARRAY data in segment offset range [{}, {})",
+               logical_start,
+               logical_start + len);
+    for (int64_t i = 0; i < len; ++i) {
+        append_valid_view(logical_offsets[i]);
+    }
+    std::pair<std::vector<VectorArrayView>, ValidityView> content{
+        std::move(views), ValidityView{}};
+    return PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>(
         std::move(content));
 }
 

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -736,21 +736,21 @@ class SegmentGrowingImpl : public SegmentGrowing {
                     FieldId field_id,
                     int64_t chunk_id) const override;
 
-    PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
     chunk_string_view_impl(
         milvus::OpContext* op_ctx,
         FieldId field_id,
         int64_t chunk_id,
         std::optional<std::pair<int64_t, int64_t>> offset_len) const override;
 
-    PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
     chunk_array_view_impl(
         milvus::OpContext* op_ctx,
         FieldId field_id,
         int64_t chunk_id,
         std::optional<std::pair<int64_t, int64_t>> offset_len) const override;
 
-    PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
     chunk_vector_array_view_impl(
         milvus::OpContext* op_ctx,
         FieldId field_id,

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -400,7 +400,7 @@ class SegmentInternalInterface : public SegmentInterface {
     }
 
     template <typename ViewType>
-    PinWrapper<std::pair<std::vector<ViewType>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<ViewType>, ValidityView>>
     chunk_view(milvus::OpContext* op_ctx,
                FieldId field_id,
                int64_t chunk_id,
@@ -424,16 +424,15 @@ class SegmentInternalInterface : public SegmentInterface {
             for (const auto& str_view : string_views) {
                 res.emplace_back(Json(str_view));
             }
-            std::pair<std::vector<ViewType>, FixedVector<bool>> content{
+            std::pair<std::vector<ViewType>, ValidityView> content{
                 std::move(res), std::move(valid_data)};
-            return PinWrapper<
-                std::pair<std::vector<ViewType>, FixedVector<bool>>>(
+            return PinWrapper<std::pair<std::vector<ViewType>, ValidityView>>(
                 std::move(pw), std::move(content));
         }
     }
 
     template <typename ViewType>
-    PinWrapper<std::pair<std::vector<ViewType>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<ViewType>, ValidityView>>
     get_batch_views(milvus::OpContext* op_ctx,
                     FieldId field_id,
                     int64_t chunk_id,
@@ -761,23 +760,21 @@ class SegmentInternalInterface : public SegmentInterface {
                     int64_t chunk_id) const = 0;
 
     // internal API: return chunk string views in vector
-    virtual PinWrapper<
-        std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    virtual PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
     chunk_string_view_impl(
         milvus::OpContext* op_ctx,
         FieldId field_id,
         int64_t chunk_id,
         std::optional<std::pair<int64_t, int64_t>> offset_len) const = 0;
 
-    virtual PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    virtual PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
     chunk_array_view_impl(
         milvus::OpContext* op_ctx,
         FieldId field_id,
         int64_t chunk_id,
         std::optional<std::pair<int64_t, int64_t>> offset_len) const = 0;
 
-    virtual PinWrapper<
-        std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+    virtual PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
     chunk_vector_array_view_impl(
         milvus::OpContext* op_ctx,
         FieldId field_id,

--- a/internal/core/src/segcore/storagev1translator/DefaultValueChunkTranslatorTest.cpp
+++ b/internal/core/src/segcore/storagev1translator/DefaultValueChunkTranslatorTest.cpp
@@ -299,8 +299,8 @@ TEST_P(DefaultValueChunkTranslatorTest, TestStringWithoutDefaultValue) {
 
     EXPECT_GT(views.size(), 0);
     // All should be marked as invalid (null)
-    for (const auto& v : valid) {
-        EXPECT_FALSE(v);
+    for (size_t i = 0; i < views.size(); ++i) {
+        EXPECT_FALSE(valid[i]);
     }
 }
 
@@ -977,7 +977,7 @@ TEST_P(DefaultValueChunkTranslatorTest,
         total_rows += views.size();
 
         // All values should be null (invalid)
-        for (size_t i = 0; i < valid.size(); ++i) {
+        for (size_t i = 0; i < views.size(); ++i) {
             EXPECT_FALSE(valid[i])
                 << "Expected null at cell " << cid << " row " << i;
         }

--- a/internal/core/unittest/test_json_stats/test_json_key_stats.cpp
+++ b/internal/core/unittest/test_json_stats/test_json_key_stats.cpp
@@ -308,7 +308,7 @@ TEST_P(JsonKeyStatsTest, TestExecutorForShreddingData) {
     TargetBitmapView valid_res_view(valid_res);
 
     auto func = [](const int64_t* data,
-                   const bool* valid_data,
+                   ValidityView valid_data,
                    const int size,
                    TargetBitmapView res,
                    TargetBitmapView valid_res) {
@@ -332,6 +332,20 @@ TEST_P(JsonKeyStatsTest, TestExecutorForShreddingData) {
     } else {
         EXPECT_EQ(res.count(), 800);
     }
+
+    TargetBitmap skipped_res(size_, true);
+    TargetBitmap skipped_valid_res(size_, true);
+    processed_size = index_->ExecutorForShreddingData<int64_t>(
+        nullptr,
+        field_name,
+        func,
+        [](const SkipIndex&, std::string, int) { return true; },
+        TargetBitmapView(skipped_res),
+        TargetBitmapView(skipped_valid_res));
+    EXPECT_EQ(processed_size, size_);
+    const auto expected_valid_count = nullable_ ? 400 : 800;
+    EXPECT_EQ(skipped_res.count(), expected_valid_count);
+    EXPECT_EQ(skipped_valid_res.count(), expected_valid_count);
 }
 
 TEST_P(JsonKeyStatsTest, TestGetShreddingFields) {

--- a/internal/core/unittest/test_offsets_eval_correctness.cpp
+++ b/internal/core/unittest/test_offsets_eval_correctness.cpp
@@ -153,7 +153,7 @@ VerifySkipCursorContract(SegmentExpr& segment_expr,
     int64_t null_rows = 0;
     auto evaluate_batch = [&]<FilterType filter_type = FilterType::sequential>(
         const T* data,
-        const bool* valid_data,
+        ValidityView valid_data,
         const int32_t* offsets,
         const int size,
         TargetBitmapView res,
@@ -209,7 +209,7 @@ VerifyElementFullScanSkipCursor(SegmentExpr& segment_expr,
     int64_t null_elements = 0;
     auto evaluate_batch = [&]<FilterType filter_type = FilterType::sequential>(
         const int64_t* data,
-        const bool* valid_data,
+        ValidityView valid_data,
         const int32_t* offsets,
         const int size,
         TargetBitmapView res,
@@ -271,15 +271,15 @@ VerifyNullableElementFullScanLogicalCount(
             query_context->get_op_context(), array_fid, 0, 0, 2);
         const auto& [data, valid] = pw.get();
         ASSERT_EQ(data.size(), 2);
-        ASSERT_EQ(valid.size(), 2);
+        ASSERT_TRUE(valid);
         EXPECT_FALSE(valid[1]);
     } else {
         auto pw = segment->chunk_data<Array>(
             query_context->get_op_context(), array_fid, 0);
         auto chunk = pw.get();
         ASSERT_EQ(chunk.row_count(), 2);
-        ASSERT_NE(chunk.valid_data(), nullptr);
-        EXPECT_FALSE(chunk.valid_data()[1]);
+        ASSERT_TRUE(chunk.validity());
+        EXPECT_FALSE(chunk.is_valid(1));
         EXPECT_EQ(chunk.data()[1].length(), 2);
     }
     const auto null_row_range = array_offsets->ElementIDRangeOfRow(1);
@@ -305,7 +305,7 @@ VerifyNullableElementFullScanLogicalCount(
     int64_t live_elements = 0;
     auto evaluate_batch = [&]<FilterType filter_type = FilterType::sequential>(
         const int64_t* data,
-        const bool* valid_data,
+        ValidityView valid_data,
         const int32_t* offsets,
         const int size,
         TargetBitmapView res,
@@ -444,7 +444,7 @@ TEST_F(OffsetsEvalCorrectnessTest, SkipBranchDrivesCallbackPerCandidate) {
     int64_t data_rows = 0;
     auto probe = [&]<FilterType filter_type = FilterType::sequential>(
         const int64_t* data,
-        const bool* valid_data,
+        ValidityView valid_data,
         const int32_t* offsets,
         const int size,
         TargetBitmapView res,
@@ -504,7 +504,7 @@ TEST_F(OffsetsEvalCorrectnessTest, SkipBranchKeepsBitmapCursorAligned) {
     int64_t processed_cursor = 0;
     auto probe = [&]<FilterType filter_type = FilterType::sequential>(
         const int64_t* data,
-        const bool* valid_data,
+        ValidityView valid_data,
         const int32_t* offsets,
         const int size,
         TargetBitmapView res,
@@ -566,7 +566,7 @@ TEST_F(OffsetsEvalCorrectnessTest,
     int64_t null_batches = 0;
     auto evaluate_batch = [&]<FilterType filter_type = FilterType::sequential>(
         const int64_t* data,
-        const bool* valid_data,
+        ValidityView valid_data,
         const int32_t* offsets,
         const int size,
         TargetBitmapView res,
@@ -787,7 +787,7 @@ TEST_F(OffsetsEvalCorrectnessTest,
     int64_t null_rows = 0;
     auto evaluate_batch = [&]<FilterType filter_type = FilterType::sequential>(
         const int64_t* data,
-        const bool* valid_data,
+        ValidityView valid_data,
         const int32_t* offsets,
         const int size,
         TargetBitmapView res,
@@ -1002,7 +1002,7 @@ TEST(OffsetsEvalIndexOnlyCorrectnessTest,
     int64_t null_rows = 0;
     auto evaluate_batch = [&]<FilterType filter_type = FilterType::sequential>(
         const int64_t* data,
-        const bool* valid_data,
+        ValidityView valid_data,
         const int32_t* offsets,
         const int size,
         TargetBitmapView res,

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -1005,51 +1005,42 @@ TEST(Sealed, LoadFieldData) {
     auto valid7 = dataset.get_col_valid(int64_nullable_id);
     auto valid8 = dataset.get_col_valid(double_nullable_id);
     auto valid9 = dataset.get_col_valid(str_nullable_id);
-    ASSERT_EQ(chunk_span1.get().valid_data(), nullptr);
-    ASSERT_EQ(chunk_span2.get().valid_data(), nullptr);
-    ASSERT_EQ(chunk_span3.get().second.size(), 0);
+    ASSERT_FALSE(chunk_span1.get().validity());
+    ASSERT_FALSE(chunk_span2.get().validity());
+    ASSERT_FALSE(chunk_span3.get().second);
     for (int i = 0; i < N; ++i) {
-        if (chunk_span1.get().valid_data() == nullptr ||
-            chunk_span1.get().valid_data()[i]) {
+        if (chunk_span1.get().is_valid(i)) {
             ASSERT_EQ(chunk_span1.get().data()[i], ref1[i]);
         }
-        if (chunk_span2.get().valid_data() == nullptr ||
-            chunk_span2.get().valid_data()[i]) {
+        if (chunk_span2.get().is_valid(i)) {
             ASSERT_EQ(chunk_span2.get().data()[i], ref2[i]);
         }
-        if (chunk_span3.get().second.size() == 0 ||
-            chunk_span3.get().second[i]) {
+        if (!chunk_span3.get().second || chunk_span3.get().second[i]) {
             ASSERT_EQ(chunk_span3.get().first[i], ref3[i]);
         }
-        if (chunk_span4.get().valid_data() == nullptr ||
-            chunk_span4.get().valid_data()[i]) {
+        if (chunk_span4.get().is_valid(i)) {
             ASSERT_EQ(chunk_span4.get().data()[i], ref4[i]);
         }
-        if (chunk_span5.get().valid_data() == nullptr ||
-            chunk_span5.get().valid_data()[i]) {
+        if (chunk_span5.get().is_valid(i)) {
             ASSERT_EQ(chunk_span5.get().data()[i], ref5[i]);
         }
-        if (chunk_span6.get().valid_data() == nullptr ||
-            chunk_span6.get().valid_data()[i]) {
+        if (chunk_span6.get().is_valid(i)) {
             ASSERT_EQ(chunk_span6.get().data()[i], ref6[i]);
         }
-        if (chunk_span7.get().valid_data() == nullptr ||
-            chunk_span7.get().valid_data()[i]) {
+        if (chunk_span7.get().is_valid(i)) {
             ASSERT_EQ(chunk_span7.get().data()[i], ref7[i]);
         }
-        if (chunk_span8.get().valid_data() == nullptr ||
-            chunk_span8.get().valid_data()[i]) {
+        if (chunk_span8.get().is_valid(i)) {
             ASSERT_EQ(chunk_span8.get().data()[i], ref8[i]);
         }
-        if (chunk_span9.get().second.size() == 0 ||
-            chunk_span9.get().second[i]) {
+        if (!chunk_span9.get().second || chunk_span9.get().second[i]) {
             ASSERT_EQ(chunk_span9.get().first[i], ref9[i]);
         }
-        ASSERT_EQ(chunk_span4.get().valid_data()[i], valid4[i]);
-        ASSERT_EQ(chunk_span5.get().valid_data()[i], valid5[i]);
-        ASSERT_EQ(chunk_span6.get().valid_data()[i], valid6[i]);
-        ASSERT_EQ(chunk_span7.get().valid_data()[i], valid7[i]);
-        ASSERT_EQ(chunk_span8.get().valid_data()[i], valid8[i]);
+        ASSERT_EQ(chunk_span4.get().is_valid(i), valid4[i]);
+        ASSERT_EQ(chunk_span5.get().is_valid(i), valid5[i]);
+        ASSERT_EQ(chunk_span6.get().is_valid(i), valid6[i]);
+        ASSERT_EQ(chunk_span7.get().is_valid(i), valid7[i]);
+        ASSERT_EQ(chunk_span8.get().is_valid(i), valid8[i]);
         ASSERT_EQ(chunk_span9.get().second[i], valid9[i]);
     }
 
@@ -1129,7 +1120,7 @@ TEST(Sealed, ClearData) {
     auto ref1 = dataset.get_col<int64_t>(counter_id);
     auto ref2 = dataset.get_col<double>(double_id);
     auto ref3 = dataset.get_col(str_id)->scalars().string_data().data();
-    ASSERT_EQ(chunk_span3.get().second.size(), 0);
+    ASSERT_FALSE(chunk_span3.get().second);
     for (int i = 0; i < N; ++i) {
         ASSERT_EQ(chunk_span1.get()[i], ref1[i]);
         ASSERT_EQ(chunk_span2.get()[i], ref2[i]);
@@ -1215,7 +1206,7 @@ TEST(Sealed, LoadFieldDataMmap) {
     auto ref1 = dataset.get_col<int64_t>(counter_id);
     auto ref2 = dataset.get_col<double>(double_id);
     auto ref3 = dataset.get_col(str_id)->scalars().string_data().data();
-    ASSERT_EQ(chunk_span3.get().second.size(), 0);
+    ASSERT_FALSE(chunk_span3.get().second);
     for (int i = 0; i < N; ++i) {
         ASSERT_EQ(chunk_span1.get()[i], ref1[i]);
         ASSERT_EQ(chunk_span2.get()[i], ref2[i]);


### PR DESCRIPTION
pr: #52354
issue: https://github.com/milvus-io/milvus/issues/52355

## Summary
- Backport packed nullable validity access for chunks, views, expressions, and JSON stats onto the latest 3.0 branch.
- Keep bulk validity masking on packed storage and materialize expanded bool buffers only at legacy interfaces that require them.
- Resolve the SegmentGrowingImpl backport conflict by applying only the feature hunks on top of the current 3.0 implementation.

## Test Plan
- [x] git diff --check
- [x] internal/core/run_clang_format.sh .
- [x] source ./scripts/setenv.sh && make SKIP_3RDPARTY=1 build-cpp-with-unittest
- [x] Targeted nullable-validity C++ tests: 27 passed, 2 existing disabled
- [x] internal/core/output/unittest/json_stats_test: 79 passed
- [x] make verifiers