### PR TITLE
fix: [cp2.6] batch backport 6 master fixes

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1024,7 +1024,7 @@ common:
     threshold:
       info: 500 # minimum milliseconds for printing durations in info level
       warn: 1000 # minimum milliseconds for printing durations in warn level
-    maxWLockConditionalWaitTime: 600 # maximum seconds for waiting wlock conditional
+    maxWLockConditionalWaitTime: 600 # seconds before logging a wlock conditional wait that is taking long; the wait itself is not bounded by this value
   storage:
     stv2:
       splitSystemColumn:

--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -88,10 +88,15 @@ type gcCmd struct {
 	collectionID int64
 	ticket       string
 	done         chan error
+	ctx          context.Context
 	timeout      <-chan struct{}
 }
 
 type gcPauseRecord struct {
+	// id uniquely identifies this record within its gcPauseRecords. Tickets are
+	// not unique -- the REST route in restful_mgr_routes.go issues every pause
+	// with an empty ticket -- so rollback must delete by id, not by ticket.
+	id         int64
 	ticket     string
 	pauseUntil time.Time
 }
@@ -99,6 +104,7 @@ type gcPauseRecord struct {
 type gcPauseRecords struct {
 	mut     sync.RWMutex
 	maxLen  int
+	nextID  int64
 	records typeutil.Heap[gcPauseRecord]
 }
 
@@ -117,17 +123,15 @@ func (gc *gcPauseRecords) PauseUntil() time.Time {
 	return gc.records.Peek().pauseUntil
 }
 
-func (gc *gcPauseRecords) Insert(ticket string, pauseUntil time.Time) error {
+// Insert records a pause ticket and returns the id of the record it created, so
+// that a failed pause can roll back exactly its own record via DeleteByID.
+func (gc *gcPauseRecords) Insert(ticket string, pauseUntil time.Time) (int64, error) {
 	gc.mut.Lock()
 	defer gc.mut.Unlock()
 
 	// heap small enough, short path
 	if gc.records.Len() < gc.maxLen {
-		gc.records.Push(gcPauseRecord{
-			ticket:     ticket,
-			pauseUntil: pauseUntil,
-		})
-		return nil
+		return gc.pushLocked(ticket, pauseUntil), nil
 	}
 
 	records := make([]gcPauseRecord, 0, gc.records.Len())
@@ -143,25 +147,46 @@ func (gc *gcPauseRecords) Insert(ticket string, pauseUntil time.Time) error {
 	})
 
 	if gc.records.Len() < gc.maxLen {
-		gc.records.Push(gcPauseRecord{
-			ticket:     ticket,
-			pauseUntil: pauseUntil,
-		})
-		return nil
+		return gc.pushLocked(ticket, pauseUntil), nil
 	}
 
 	// too many pause records, refresh heap
-	return merr.WrapErrTooManyRequests(64, "too many pause records")
+	return 0, merr.WrapErrTooManyRequests(64, "too many pause records")
 }
 
+// pushLocked appends a new record with a freshly allocated id. Caller must hold mut.
+func (gc *gcPauseRecords) pushLocked(ticket string, pauseUntil time.Time) int64 {
+	gc.nextID++
+	gc.records.Push(gcPauseRecord{
+		id:         gc.nextID,
+		ticket:     ticket,
+		pauseUntil: pauseUntil,
+	})
+	return gc.nextID
+}
+
+// Delete drops every record holding the given ticket. This is the user-facing
+// resume semantic ("release my ticket"); use DeleteByID to undo a single record.
 func (gc *gcPauseRecords) Delete(ticket string) {
+	gc.deleteMatching(func(r gcPauseRecord) bool { return r.ticket == ticket })
+}
+
+// DeleteByID drops the single record with the given id, leaving records that
+// merely share its ticket untouched.
+func (gc *gcPauseRecords) DeleteByID(id int64) {
+	gc.deleteMatching(func(r gcPauseRecord) bool { return r.id == id })
+}
+
+// deleteMatching rebuilds the heap without the matching records, dropping
+// already-expired records along the way.
+func (gc *gcPauseRecords) deleteMatching(match func(gcPauseRecord) bool) {
 	gc.mut.Lock()
 	defer gc.mut.Unlock()
 	now := time.Now()
 	records := make([]gcPauseRecord, 0, gc.records.Len())
 	for gc.records.Len() > 0 {
 		record := gc.records.Pop()
-		if now.Before(record.pauseUntil) && record.ticket != ticket {
+		if now.Before(record.pauseUntil) && !match(record) {
 			records = append(records, record)
 		}
 	}
@@ -292,11 +317,17 @@ func (gc *garbageCollector) Pause(ctx context.Context, collectionID int64, ticke
 		collectionID: collectionID,
 		ticket:       ticket,
 		done:         done,
+		ctx:          ctx,
 		timeout:      ctx.Done(),
 	}:
 		return <-done
 	case <-ctx.Done():
 		return ctx.Err()
+	case <-gc.ctx.Done():
+		// cmdCh is unbuffered and startControlLoop has already returned, so the
+		// send above can never be received; without this arm the caller parks
+		// until its own ctx is canceled (forever for a Done()-less ctx).
+		return merr.WrapErrServiceUnavailable("garbage collector is closing")
 	}
 }
 
@@ -318,6 +349,9 @@ func (gc *garbageCollector) Resume(ctx context.Context, collectionID int64, tick
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
+	case <-gc.ctx.Done():
+		// see Pause: the control loop is gone, nothing will receive this send.
+		return merr.WrapErrServiceUnavailable("garbage collector is closing")
 	}
 }
 
@@ -397,8 +431,9 @@ func (gc *garbageCollector) pause(cmd gcCmd) error {
 		zap.Duration("duration", cmd.duration),
 	)
 	var err error
+	var recordID int64
 	if cmd.collectionID <= 0 { // legacy pause all
-		err = gc.pauseUntil.Insert(cmd.ticket, reqPauseUntil)
+		recordID, err = gc.pauseUntil.Insert(cmd.ticket, reqPauseUntil)
 		log.Info("global pause ticket recorded")
 	} else {
 		curr, has := gc.pausedCollection.Get(cmd.collectionID)
@@ -406,7 +441,7 @@ func (gc *garbageCollector) pause(cmd gcCmd) error {
 			curr = NewGCPauseRecords()
 			gc.pausedCollection.Insert(cmd.collectionID, curr)
 		}
-		err = curr.Insert(cmd.ticket, reqPauseUntil)
+		recordID, err = curr.Insert(cmd.ticket, reqPauseUntil)
 		log.Info("collection new pause ticket recorded")
 	}
 	if err != nil {
@@ -421,12 +456,44 @@ func (gc *garbageCollector) pause(cmd gcCmd) error {
 	}
 	select {
 	case signalCh <- signal:
-		<-signal.done
+		select {
+		case <-signal.done:
+		case <-cmd.timeout:
+			gc.rollbackPause(cmd, recordID)
+			return cmd.ctx.Err()
+		}
 	case <-cmd.timeout:
 		// timeout, resume the pause
-		gc.resume(cmd)
+		gc.rollbackPause(cmd, recordID)
+		return cmd.ctx.Err()
+	case <-gc.ctx.Done():
+		// The collector is closing. The meta worker may already have returned on
+		// its own ctx.Done(), and signalCh is unbuffered, so the send above would
+		// never be received: bound the wait by the collector's lifetime instead of
+		// parking this control-loop goroutine and hanging gc.wg.Wait() in close().
+		gc.rollbackPause(cmd, recordID)
+		return merr.WrapErrServiceUnavailable("garbage collector is closing")
 	}
 	return nil
+}
+
+// rollbackPause undoes exactly the record this pause() call inserted. It must not
+// go through resume(), whose delete is ticket-scoped: tickets are not unique --
+// every pause issued by the REST route in restful_mgr_routes.go carries an empty
+// ticket -- so a ticket-scoped delete would also drop a concurrent caller's
+// still-valid pause record and resume GC while that caller believes it is paused.
+func (gc *garbageCollector) rollbackPause(cmd gcCmd, recordID int64) {
+	if cmd.collectionID <= 0 {
+		gc.pauseUntil.DeleteByID(recordID)
+	} else if curr, has := gc.pausedCollection.Get(cmd.collectionID); has {
+		curr.DeleteByID(recordID)
+		if curr.Len() == 0 || time.Now().After(curr.PauseUntil()) {
+			gc.pausedCollection.Remove(cmd.collectionID)
+		}
+	}
+	log.Info("pause rolled back",
+		zap.Int64("collectionID", cmd.collectionID),
+		zap.String("ticket", cmd.ticket))
 }
 
 func (gc *garbageCollector) resume(cmd gcCmd) {

--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -1430,7 +1430,8 @@ func (gc *garbageCollector) recycleUnusedAnalyzeFiles(ctx context.Context, signa
 				// process canceled.
 				return
 			}
-			removePrefix := prefix + fmt.Sprintf("%d/", task.Version)
+			// analyze stats files are laid out as analyze_stats/{taskID}/{version}/...
+			removePrefix := prefix + fmt.Sprintf("%d/%d/", taskID, i)
 			if err := gc.option.cli.RemoveWithPrefix(ctx, removePrefix); err != nil {
 				log.Warn("garbageCollector recycleUnusedAnalyzeFiles remove files with prefix failed",
 					zap.Int64("taskID", taskID), zap.String("removePrefix", removePrefix))

--- a/internal/datacoord/garbage_collector_test.go
+++ b/internal/datacoord/garbage_collector_test.go
@@ -55,6 +55,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/objectstorage"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/workerpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/lock"
@@ -2194,6 +2195,66 @@ func TestGarbageCollector_getDroppedSegmentIndexFiles_EdgeCases(t *testing.T) {
 		assert.Equal(t, segIdx.BuildID, segIndexes[0].BuildID)
 		assert.NotEmpty(t, indexFiles)
 	})
+}
+
+func TestGarbageCollector_recycleUnusedAnalyzeFiles_StaleVersions(t *testing.T) {
+	ctx := context.Background()
+
+	meta := &meta{
+		catalog: &datacoord.Catalog{},
+		analyzeMeta: &analyzeMeta{
+			ctx: ctx,
+			tasks: map[int64]*indexpb.AnalyzeTask{
+				401: {
+					TaskID:  401,
+					Version: 2,
+					State:   indexpb.JobState_JobStateFinished,
+				},
+			},
+		},
+	}
+
+	cli := storage.NewLocalChunkManager(objectstorage.RootPath("/tmp/test"))
+
+	gc := newGarbageCollector(meta, &ServerHandler{}, GcOption{
+		cli:              cli,
+		enabled:          true,
+		checkInterval:    time.Millisecond * 10,
+		scanInterval:     time.Hour * 7 * 24,
+		missingTolerance: 0,
+		dropTolerance:    time.Hour * 24,
+	})
+
+	// The non-recursive walk lists the per-task top-level dirs under analyze_stats.
+	mockWalk := mockey.Mock((*storage.LocalChunkManager).WalkWithPrefix).To(
+		func(cm *storage.LocalChunkManager, ctx context.Context, prefix string,
+			recursive bool, fn storage.ChunkObjectWalkFunc,
+		) error {
+			if strings.Contains(prefix, common.AnalyzeStatsPath) {
+				fn(&storage.ChunkObjectInfo{
+					FilePath:   path.Join(prefix, "401") + "/",
+					ModifyTime: time.Now().Add(-time.Hour),
+				})
+			}
+			return nil
+		}).Build()
+	defer mockWalk.UnPatch()
+
+	removedPrefixes := []string{}
+	mockRemove := mockey.Mock((*storage.LocalChunkManager).RemoveWithPrefix).To(
+		func(cm *storage.LocalChunkManager, ctx context.Context, prefix string) error {
+			removedPrefixes = append(removedPrefixes, prefix)
+			return nil
+		}).Build()
+	defer mockRemove.UnPatch()
+
+	gc.recycleUnusedAnalyzeFiles(ctx, nil)
+
+	// Analyze files are written under analyze_stats/{taskID}/{version}/... — for a
+	// finished task at Version=2, exactly the stale versions 0 and 1 under the
+	// task's own prefix must be removed, and version 2 must be kept.
+	root := path.Join(cli.RootPath(), common.AnalyzeStatsPath) + "/"
+	assert.ElementsMatch(t, []string{root + "401/0/", root + "401/1/"}, removedPrefixes)
 }
 
 // TestGarbageCollector_recycleDroppedSegment_CtxCanceledBeforeDrop covers

--- a/internal/datacoord/garbage_collector_test.go
+++ b/internal/datacoord/garbage_collector_test.go
@@ -1727,6 +1727,119 @@ func (s *GarbageCollectorSuite) TestPauseResume() {
 		s.Zero(gc.pauseUntil.PauseUntil())
 	})
 
+	s.Run("pause_timeout_after_signal_received", func() {
+		gc := newGarbageCollector(s.meta, newMockHandler(), GcOption{
+			cli:              s.cli,
+			enabled:          true,
+			checkInterval:    time.Hour,
+			scanInterval:     time.Hour * 7 * 24,
+			missingTolerance: time.Hour * 24,
+			dropTolerance:    time.Hour * 24,
+		})
+
+		controlDone := make(chan struct{})
+		go func() {
+			defer close(controlDone)
+			gc.startControlLoop(context.Background())
+		}()
+		defer func() {
+			gc.cancel()
+			<-controlDone
+			gc.option.removeObjectPool.Release()
+		}()
+
+		signalCh := make(chan gcCmd, 1)
+		go func() {
+			signalCh <- <-gc.controlChannels["meta"]
+		}()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		pauseDone := make(chan error, 1)
+		go func() {
+			pauseDone <- gc.Pause(ctx, -1, "timeout-ticket", time.Minute)
+		}()
+
+		// Receiving here means the meta worker already took the signal, so pause()
+		// is past the send and parked in the ack wait.
+		select {
+		case <-signalCh:
+		case <-time.After(time.Second * 5):
+			s.T().Fatal("pause signal was not delivered to meta worker")
+		}
+
+		// Deliberately never close signal.done: canceling only now makes the inner
+		// select take its timeout arm, with no dependency on wall-clock ordering.
+		cancel()
+
+		err := <-pauseDone
+		s.ErrorIs(err, context.Canceled)
+		s.Zero(gc.pauseUntil.PauseUntil())
+	})
+
+	// Tickets are not unique: the REST route in restful_mgr_routes.go issues every
+	// pause with an empty ticket. A failed pause must therefore roll back only its
+	// own record -- a ticket-scoped delete would also wipe a concurrent caller's
+	// still-valid pause and silently resume GC while that caller believes it is
+	// paused.
+	s.Run("pause_rollback_preserves_other_empty_ticket_record", func() {
+		gc := newGarbageCollector(s.meta, newMockHandler(), GcOption{
+			cli:              s.cli,
+			enabled:          true,
+			checkInterval:    time.Hour,
+			scanInterval:     time.Hour * 7 * 24,
+			missingTolerance: time.Hour * 24,
+			dropTolerance:    time.Hour * 24,
+		})
+
+		controlDone := make(chan struct{})
+		go func() {
+			defer close(controlDone)
+			gc.startControlLoop(context.Background())
+		}()
+		defer func() {
+			gc.cancel()
+			<-controlDone
+			gc.option.removeObjectPool.Release()
+		}()
+
+		metaCh := gc.controlChannels["meta"]
+		secondSignal := make(chan struct{})
+		go func() {
+			// Ack the first pause so it completes.
+			cmd := <-metaCh
+			close(cmd.done)
+			// Take the second pause's signal but never ack it, parking pause() in
+			// the inner ack wait so its rollback path is the one exercised.
+			<-metaCh
+			close(secondSignal)
+		}()
+
+		// First caller: a successful global pause with an empty ticket.
+		s.NoError(gc.Pause(context.Background(), -1, "", time.Minute))
+		firstUntil := gc.pauseUntil.PauseUntil()
+		s.NotZero(firstUntil)
+
+		// Second caller: same empty ticket, canceled while waiting for the ack.
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		pauseDone := make(chan error, 1)
+		go func() {
+			pauseDone <- gc.Pause(ctx, -1, "", time.Minute)
+		}()
+
+		select {
+		case <-secondSignal:
+		case <-time.After(time.Second * 5):
+			s.T().Fatal("second pause signal was not delivered to meta worker")
+		}
+		cancel()
+		s.ErrorIs(<-pauseDone, context.Canceled)
+
+		// The first caller's pause must survive the second caller's rollback.
+		s.Equal(firstUntil, gc.pauseUntil.PauseUntil())
+	})
+
 	s.Run("pause_collection", func() {
 		gc := newGarbageCollector(s.meta, newMockHandler(), GcOption{
 			cli:              s.cli,

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -1763,9 +1763,9 @@ func (s *Server) GcControl(ctx context.Context, request *datapb.GcControlRequest
 		ticket, _ := common.GetStringValue(request.GetParams(), "ticket")
 
 		if err := s.garbageCollector.Pause(ctx, collectionID, ticket, time.Duration(pauseSeconds)*time.Second); err != nil {
-			status.ErrorCode = commonpb.ErrorCode_UnexpectedError
-			status.Reason = fmt.Sprintf("failed to pause gc, %s", err.Error())
-			return status, nil
+			// merr.Status keeps Code/Retriable, so callers can tell a timeout or a
+			// transient "collector is closing" apart from a genuine failure.
+			return merr.Status(err), nil
 		}
 	case datapb.GcCommand_Resume:
 		collectionID, err, _ := common.GetInt64Value(request.GetParams(), "collection_id")
@@ -1774,9 +1774,7 @@ func (s *Server) GcControl(ctx context.Context, request *datapb.GcControlRequest
 		}
 		ticket, _ := common.GetStringValue(request.GetParams(), "ticket")
 		if err := s.garbageCollector.Resume(ctx, collectionID, ticket); err != nil {
-			status.ErrorCode = commonpb.ErrorCode_UnexpectedError
-			status.Reason = fmt.Sprintf("failed to pause gc, %s", err.Error())
-			return status, nil
+			return merr.Status(err), nil
 		}
 	default:
 		status.ErrorCode = commonpb.ErrorCode_UnexpectedError

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -1682,6 +1682,53 @@ func (s *GcControlServiceSuite) TestPause() {
 	s.True(merr.Ok(resp))
 }
 
+// A pause that times out inside the collector rolls the ticket back and returns
+// the caller's context error. That error must reach the client as a failed
+// status: the timeout path used to return nil, so GcControl reported Success
+// while garbage collection was in fact never paused.
+func (s *GcControlServiceSuite) TestPauseErrorSurfacesAsFailedStatus() {
+	mockPause := mockey.Mock((*garbageCollector).Pause).Return(context.DeadlineExceeded).Build()
+	defer mockPause.UnPatch()
+
+	resp, err := s.server.GcControl(context.Background(), &datapb.GcControlRequest{
+		Command: datapb.GcCommand_Pause,
+		Params: []*commonpb.KeyValuePair{
+			{Key: "duration", Value: "60"},
+		},
+	})
+	s.NoError(err)
+	s.False(merr.Ok(resp))
+	// merr.Ok alone is satisfied by ErrorCode != Success, so assert the typed code
+	// too: a status that flattens to Code=0 leaves callers unable to tell a timeout
+	// from a real failure. Note merr.Error rebuilds the error from the code rather
+	// than restoring the original sentinel, so assert the code, not errors.Is.
+	s.Equal(merr.TimeoutCode, resp.GetCode())
+	s.Equal(merr.TimeoutCode, merr.Code(merr.Error(resp)))
+	// The proxy handler in proxy/management.go still branches on the deprecated
+	// ErrorCode field, so it must stay non-Success.
+	s.NotEqual(commonpb.ErrorCode_Success, resp.GetErrorCode())
+}
+
+// The "collector is closing" error is transient, so the retriable bit must reach
+// the client: merr.CheckRPCCall in restful_mgr_routes.go is what tells a caller
+// to retry, and a hand-built UnexpectedError status would report retriable=false.
+func (s *GcControlServiceSuite) TestPauseUnavailableStaysRetriable() {
+	mockPause := mockey.Mock((*garbageCollector).Pause).
+		Return(merr.WrapErrServiceUnavailable("garbage collector is closing")).Build()
+	defer mockPause.UnPatch()
+
+	resp, err := s.server.GcControl(context.Background(), &datapb.GcControlRequest{
+		Command: datapb.GcCommand_Pause,
+		Params: []*commonpb.KeyValuePair{
+			{Key: "duration", Value: "60"},
+		},
+	})
+	s.NoError(err)
+	s.False(merr.Ok(resp))
+	s.True(resp.GetRetriable())
+	s.ErrorIs(merr.Error(resp), merr.ErrServiceUnavailable)
+}
+
 func (s *GcControlServiceSuite) TestResume() {
 	resp, err := s.server.GcControl(context.TODO(), &datapb.GcControlRequest{
 		Command: datapb.GcCommand_Resume,

--- a/internal/datacoord/task_analyze.go
+++ b/internal/datacoord/task_analyze.go
@@ -172,7 +172,11 @@ func (at *analyzeTask) CreateTaskOnWorker(nodeID int64, cluster session.Cluster)
 		if info == nil {
 			log.Warn("analyze task is processing, but segment is nil, fail the task",
 				zap.Int64("segmentID", segID))
-			at.SetState(indexpb.JobState_JobStateFailed, fmt.Sprintf("segmentInfo with ID: %d is nil", segID))
+			if err := at.UpdateStateWithMeta(indexpb.JobState_JobStateFailed,
+				fmt.Sprintf("segmentInfo with ID: %d is nil", segID)); err != nil {
+				// State is left untouched, so the scheduler re-enqueues the task and retries.
+				log.Warn("failed to persist the failed state of the analyze task", zap.Error(err))
+			}
 			return
 		}
 		totalSegmentsRows += info.GetNumOfRows()
@@ -203,7 +207,10 @@ func (at *analyzeTask) CreateTaskOnWorker(nodeID int64, cluster session.Cluster)
 						zap.Float64("raw data size", totalSegmentsRawDataSize),
 						zap.Int64("num clusters", numClusters),
 						zap.Int64("minimum num clusters required", Params.DataCoordCfg.ClusteringCompactionMinCentroidsNum.GetAsInt64()))
-					at.SetState(indexpb.JobState_JobStateFinished, "")
+					if err := at.UpdateStateWithMeta(indexpb.JobState_JobStateFinished, ""); err != nil {
+						// State is left untouched, so the scheduler re-enqueues the task and retries.
+						log.Warn("failed to persist the finished state of the analyze task", zap.Error(err))
+					}
 					return
 				}
 				if numClusters > Params.DataCoordCfg.ClusteringCompactionMaxCentroidsNum.GetAsInt64() {

--- a/internal/datacoord/task_analyze_test.go
+++ b/internal/datacoord/task_analyze_test.go
@@ -203,6 +203,12 @@ func (s *analyzeTaskSuite) newTask() *analyzeTask {
 	}, s.mt)
 }
 
+// restoreMetaTask puts back the task the suite was set up with, so a test that
+// persists a state transition does not leak it into the following tests.
+func (s *analyzeTaskSuite) restoreMetaTask(task *indexpb.AnalyzeTask) {
+	s.mt.analyzeMeta.tasks[s.taskID] = task
+}
+
 func (s *analyzeTaskSuite) TestCreateTaskOnWorker_SegmentNil() {
 	// Replace segment 102 with a dropped segment so it's filtered out by isSegmentHealthy
 	s.mt.segments.SetSegment(102, &SegmentInfo{
@@ -230,10 +236,14 @@ func (s *analyzeTaskSuite) TestCreateTaskOnWorker_SegmentNil() {
 	catalog := catalogmocks.NewDataCoordCatalog(s.T())
 	catalog.On("SaveAnalyzeTask", mock.Anything, mock.Anything).Return(nil)
 	s.mt.analyzeMeta.catalog = catalog
+	defer s.restoreMetaTask(s.mt.analyzeMeta.tasks[s.taskID])
 
 	at.CreateTaskOnWorker(1, session.NewMockCluster(s.T()))
 	s.Equal(indexpb.JobState_JobStateFailed, at.GetState())
 	s.Contains(at.GetFailReason(), "102")
+	// The terminal state must be persisted, not only set on the scheduler-owned copy.
+	s.Equal(indexpb.JobState_JobStateFailed, s.mt.analyzeMeta.GetTask(s.taskID).GetState())
+	s.Contains(s.mt.analyzeMeta.GetTask(s.taskID).GetFailReason(), "102")
 }
 
 func (s *analyzeTaskSuite) TestCreateTaskOnWorker_DimExtractionError() {
@@ -274,10 +284,36 @@ func (s *analyzeTaskSuite) TestCreateTaskOnWorker_DataTooSmall() {
 	catalog := catalogmocks.NewDataCoordCatalog(s.T())
 	catalog.On("SaveAnalyzeTask", mock.Anything, mock.Anything).Return(nil)
 	s.mt.analyzeMeta.catalog = catalog
+	defer s.restoreMetaTask(s.mt.analyzeMeta.tasks[s.taskID])
 
 	at.CreateTaskOnWorker(1, session.NewMockCluster(s.T()))
 	// data too small → skip → mark as finished
 	s.Equal(indexpb.JobState_JobStateFinished, at.GetState())
+	// Persisting Finished is what lets the GC recycle the task's analyze stats files.
+	s.Equal(indexpb.JobState_JobStateFinished, s.mt.analyzeMeta.GetTask(s.taskID).GetState())
+}
+
+func (s *analyzeTaskSuite) TestCreateTaskOnWorker_TerminalStateNotPersisted() {
+	// Set MinCentroidsNum very high so data is considered too small
+	origMin := Params.DataCoordCfg.ClusteringCompactionMinCentroidsNum.SwapTempValue("999999999")
+	defer Params.DataCoordCfg.ClusteringCompactionMinCentroidsNum.SwapTempValue(origMin)
+
+	at := s.newTask()
+	catalog := catalogmocks.NewDataCoordCatalog(s.T())
+	// The first save is UpdateVersion, the second one is the terminal state transition.
+	catalog.On("SaveAnalyzeTask", mock.Anything, mock.Anything).Return(nil).Once()
+	catalog.On("SaveAnalyzeTask", mock.Anything, mock.Anything).
+		Return(merr.WrapErrServiceInternalMsg("mock save error")).Once()
+	catalog.On("SaveAnalyzeTask", mock.Anything, mock.Anything).Return(nil)
+	s.mt.analyzeMeta.catalog = catalog
+	defer s.restoreMetaTask(s.mt.analyzeMeta.tasks[s.taskID])
+	stateBefore := s.mt.analyzeMeta.GetTask(s.taskID).GetState()
+
+	at.CreateTaskOnWorker(1, session.NewMockCluster(s.T()))
+	// A failed persistence leaves the task at Init so the scheduler re-enqueues it,
+	// rather than dropping it on an in-memory-only terminal state.
+	s.Equal(indexpb.JobState_JobStateInit, at.GetState())
+	s.Equal(stateBefore, s.mt.analyzeMeta.GetTask(s.taskID).GetState())
 }
 
 func (s *analyzeTaskSuite) TestCreateTaskOnWorker_NumClustersCapped() {

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -231,6 +231,19 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 
 	// Currently, we get vectors by requery. Once we support getting vectors from search,
 	// searches with small result size could no longer need requery.
+	timezone, exist := funcutil.TryGetAttrByKeyFromRepeatedKV(common.TimezoneKey, t.request.SearchParams)
+	if exist {
+		if !timestamptz.IsTimezoneValid(timezone) {
+			log.Info("get invalid timezone from request", zap.String("timezone", timezone))
+			return merr.WrapErrParameterInvalidMsg("unknown or invalid IANA Time Zone ID: %s", timezone)
+		}
+		log.Debug("determine timezone from request", zap.String("user defined timezone", timezone))
+	} else {
+		timezone = getColTimezone(collectionInfo)
+		log.Debug("determine timezone from collection", zap.Any("collection timezone", timezone))
+	}
+	t.resolvedTimezoneStr = timezone
+
 	if t.GetIsAdvanced() {
 		err = t.initAdvancedSearchRequest(ctx)
 	} else {
@@ -294,19 +307,6 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 			return merr.WrapErrServiceInternalMsg("ttl timestamp overflow, base timestamp: %d, ttl duration %v", t.GetBase().GetTimestamp(), collectionInfo.collectionTTL)
 		}
 	}
-
-	timezone, exist := funcutil.TryGetAttrByKeyFromRepeatedKV(common.TimezoneKey, t.request.SearchParams)
-	if exist {
-		if !timestamptz.IsTimezoneValid(timezone) {
-			log.Info("get invalid timezone from request", zap.String("timezone", timezone))
-			return merr.WrapErrParameterInvalidMsg("unknown or invalid IANA Time Zone ID: %s", timezone)
-		}
-		log.Debug("determine timezone from request", zap.String("user defined timezone", timezone))
-	} else {
-		timezone = getColTimezone(collectionInfo)
-		log.Debug("determine timezone from collection", zap.Any("collection timezone", timezone))
-	}
-	t.resolvedTimezoneStr = timezone
 
 	t.resultBuf = typeutil.NewConcurrentSet[*internalpb.SearchResults]()
 

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -61,6 +61,72 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
+func TestSearchTaskPreExecuteUsesTimezoneForTimestamptzFilter(t *testing.T) {
+	mockey.PatchConvey("TestSearchTaskPreExecuteUsesTimezoneForTimestamptzFilter", t, func() {
+		globalMetaCache = &MetaCache{}
+
+		const (
+			dbName         = "db"
+			collectionName = "timestamptz_collection"
+			collectionID   = int64(100)
+		)
+		schema := newSchemaInfo(&schemapb.CollectionSchema{
+			Name: collectionName,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: testInt64Field, DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{
+					FieldID:  101,
+					Name:     testFloatVecField,
+					DataType: schemapb.DataType_FloatVector,
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.DimKey, Value: strconv.Itoa(testVecDim)},
+					},
+				},
+				{FieldID: 102, Name: "ts", DataType: schemapb.DataType_Timestamptz},
+			},
+		})
+
+		mockey.Mock((*MetaCache).GetCollectionID).Return(collectionID, nil).Build()
+		mockey.Mock((*MetaCache).GetCollectionInfo).Return(&collectionInfo{
+			updateTimestamp:  100,
+			consistencyLevel: commonpb.ConsistencyLevel_Strong,
+		}, nil).Build()
+		mockey.Mock((*MetaCache).GetCollectionSchema).Return(schema, nil).Build()
+		mockey.Mock(isIgnoreGrowing).Return(false, nil).Build()
+		mockey.Mock((*searchTask).checkNq).Return(int64(1), nil).Build()
+
+		searchParams := append([]*commonpb.KeyValuePair{}, getValidSearchParams()...)
+		searchParams = append(searchParams, &commonpb.KeyValuePair{
+			Key:   common.TimezoneKey,
+			Value: "Asia/Shanghai",
+		})
+		task := &searchTask{
+			Condition:     NewTaskCondition(context.Background()),
+			SearchRequest: &internalpb.SearchRequest{Base: &commonpb.MsgBase{MsgType: commonpb.MsgType_Search}},
+			ctx:           context.Background(),
+			request: &milvuspb.SearchRequest{
+				DbName:         dbName,
+				CollectionName: collectionName,
+				Nq:             1,
+				Dsl:            "ts > ISO '2025-01-01T00:00:00'",
+				SearchParams:   searchParams,
+			},
+			result: &milvuspb.SearchResults{Status: merr.Success()},
+		}
+
+		err := task.PreExecute(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, "Asia/Shanghai", task.resolvedTimezoneStr)
+		plan := &planpb.PlanNode{}
+		require.NoError(t, proto.Unmarshal(task.SerializedExprPlan, plan))
+		rangeExpr := plan.GetVectorAnns().GetPredicates().GetUnaryRangeExpr()
+		require.NotNil(t, rangeExpr)
+		shanghai, err := time.LoadLocation("Asia/Shanghai")
+		require.NoError(t, err)
+		assert.Equal(t, time.Date(2025, 1, 1, 0, 0, 0, 0, shanghai).UnixMicro(), rangeExpr.GetValue().GetInt64Val())
+	})
+}
+
 func TestSearchTask_PostExecute(t *testing.T) {
 	var err error
 

--- a/internal/proxy/vector_type_convert.go
+++ b/internal/proxy/vector_type_convert.go
@@ -117,6 +117,9 @@ func ConvertPlaceholderGroup(phgBytes []byte, fieldSchema *schemapb.FieldSchema)
 
 	placeholder := phg.Placeholders[0]
 	fieldType := fieldSchema.GetDataType()
+	if fieldType == schemapb.DataType_ArrayOfVector {
+		fieldType = fieldSchema.GetElementType()
+	}
 
 	// Check if types already match
 	if isVectorTypeMatch(placeholder.Type, fieldType) {

--- a/internal/proxy/vector_type_convert_test.go
+++ b/internal/proxy/vector_type_convert_test.go
@@ -452,3 +452,62 @@ func TestConvertPlaceholderGroupIntegration(t *testing.T) {
 		assert.Equal(t, phgBytes, convertedBytes) // Should be unchanged
 	})
 }
+
+// TestConvertPlaceholderIfNeededArrayOfVectorSubField enters through the real
+// search-task call path instead of calling ConvertPlaceholderGroup directly, so
+// it also covers the field lookup. An ArrayOfVector field only ever lives inside
+// a struct array field, so its ID is absent from schema.Fields.
+func TestConvertPlaceholderIfNeededArrayOfVectorSubField(t *testing.T) {
+	const subFieldID = int64(102)
+
+	for _, tt := range []struct {
+		name            string
+		elementType     schemapb.DataType
+		placeholderType commonpb.PlaceholderType
+	}{
+		{
+			name:            "float16 element",
+			elementType:     schemapb.DataType_Float16Vector,
+			placeholderType: commonpb.PlaceholderType_Float16Vector,
+		},
+		{
+			name:            "bfloat16 element",
+			elementType:     schemapb.DataType_BFloat16Vector,
+			placeholderType: commonpb.PlaceholderType_BFloat16Vector,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := &schemapb.CollectionSchema{
+				Name: "test_struct_array_search",
+				Fields: []*schemapb.FieldSchema{
+					{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				},
+				StructArrayFields: []*schemapb.StructArrayFieldSchema{
+					{
+						FieldID: 101,
+						Name:    "struct_array",
+						Fields: []*schemapb.FieldSchema{
+							{
+								FieldID:     subFieldID,
+								Name:        "vector_array",
+								DataType:    schemapb.DataType_ArrayOfVector,
+								ElementType: tt.elementType,
+							},
+						},
+					},
+				},
+			}
+
+			vectors := [][]float32{{0.1, 0.2, 0.3, 0.4}}
+			task := &searchTask{schema: newSchemaInfo(schema)}
+
+			convertedBytes, err := task.convertPlaceholderIfNeeded(createFloat32PlaceholderGroup(vectors), subFieldID)
+			assert.NoError(t, err)
+
+			var resultPhg commonpb.PlaceholderGroup
+			err = proto.Unmarshal(convertedBytes, &resultPhg)
+			assert.NoError(t, err)
+			assertPlaceholderVectorsMatchFloat32(t, tt.placeholderType, tt.elementType, resultPhg.Placeholders, vectors)
+		})
+	}
+}

--- a/internal/proxy/vector_type_convert_test.go
+++ b/internal/proxy/vector_type_convert_test.go
@@ -164,6 +164,56 @@ func TestValidateFloat32ForBFloat16(t *testing.T) {
 	}
 }
 
+func assertFP16BF16BytesMatchFloat32(
+	t *testing.T,
+	dataType schemapb.DataType,
+	floatData []float32,
+	got []byte,
+) {
+	t.Helper()
+	var want []byte
+	var decoded []float32
+	var tolerance float64
+	switch dataType {
+	case schemapb.DataType_Float16Vector:
+		want = typeutil.Float32ArrayToFloat16Bytes(floatData)
+		decoded = typeutil.Float16BytesToFloat32Vector(got)
+		tolerance = 1e-3
+	case schemapb.DataType_BFloat16Vector:
+		want = typeutil.Float32ArrayToBFloat16Bytes(floatData)
+		decoded = typeutil.BFloat16BytesToFloat32Vector(got)
+		tolerance = 1e-2
+	default:
+		t.Fatalf("unsupported data type: %s", dataType.String())
+	}
+	assert.Equal(t, want, got)
+	assert.InDeltaSlice(t, floatData, decoded, tolerance)
+}
+
+func assertPlaceholderVectorsMatchFloat32(
+	t *testing.T,
+	placeholderType commonpb.PlaceholderType,
+	fieldType schemapb.DataType,
+	placeholders []*commonpb.PlaceholderValue,
+	inputs [][]float32,
+) {
+	t.Helper()
+	assert.Len(t, placeholders, 1)
+	placeholder := placeholders[0]
+	assert.Equal(t, placeholderType, placeholder.GetType())
+	assert.Len(t, placeholder.GetValues(), len(inputs))
+	for i, input := range inputs {
+		switch fieldType {
+		case schemapb.DataType_Float16Vector:
+			assertFP16BF16BytesMatchFloat32(t, fieldType, input, placeholder.GetValues()[i])
+		case schemapb.DataType_BFloat16Vector:
+			assertFP16BF16BytesMatchFloat32(t, fieldType, input, placeholder.GetValues()[i])
+		default:
+			assert.Equal(t, typeutil.Float32ArrayToBytes(input), placeholder.GetValues()[i])
+		}
+	}
+}
+
 func createFloat32PlaceholderGroup(vectors [][]float32) []byte {
 	values := make([][]byte, len(vectors))
 	for i, vec := range vectors {
@@ -223,6 +273,42 @@ func TestConvertPlaceholderGroupToBFloat16(t *testing.T) {
 
 	assert.Equal(t, commonpb.PlaceholderType_BFloat16Vector, resultPhg.Placeholders[0].Type)
 	assert.Equal(t, 4*2, len(resultPhg.Placeholders[0].Values[0]))
+}
+
+func TestConvertPlaceholderGroupArrayOfVectorElementType(t *testing.T) {
+	for _, tt := range []struct {
+		name            string
+		elementType     schemapb.DataType
+		placeholderType commonpb.PlaceholderType
+	}{
+		{
+			name:            "float16 element",
+			elementType:     schemapb.DataType_Float16Vector,
+			placeholderType: commonpb.PlaceholderType_Float16Vector,
+		},
+		{
+			name:            "bfloat16 element",
+			elementType:     schemapb.DataType_BFloat16Vector,
+			placeholderType: commonpb.PlaceholderType_BFloat16Vector,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			vectors := [][]float32{{0.1, 0.2, 0.3, 0.4}}
+			phgBytes := createFloat32PlaceholderGroup(vectors)
+			fieldSchema := &schemapb.FieldSchema{
+				DataType:    schemapb.DataType_ArrayOfVector,
+				ElementType: tt.elementType,
+			}
+
+			convertedBytes, err := ConvertPlaceholderGroup(phgBytes, fieldSchema)
+			assert.NoError(t, err)
+
+			var resultPhg commonpb.PlaceholderGroup
+			err = proto.Unmarshal(convertedBytes, &resultPhg)
+			assert.NoError(t, err)
+			assertPlaceholderVectorsMatchFloat32(t, tt.placeholderType, tt.elementType, resultPhg.Placeholders, vectors)
+		})
+	}
 }
 
 func TestConvertPlaceholderGroupTypeMismatch(t *testing.T) {

--- a/internal/querynodev2/segments/state/load_state_lock.go
+++ b/internal/querynodev2/segments/state/load_state_lock.go
@@ -169,13 +169,13 @@ func (ls *LoadStateLock) StartReleaseAll() (g LoadStateLockGuard) {
 	return g
 }
 
-// blockUntilDataLoadedOrReleased blocks until the segment is loaded or released.
-func (ls *LoadStateLock) BlockUntilDataLoadedOrReleased() bool {
-	var ok bool
+// BlockUntilDataLoadedOrReleased blocks until the segment is loaded or released.
+// It has no return value on purpose: waitOrPanic no longer gives up, so any
+// status it could report would be a constant.
+func (ls *LoadStateLock) BlockUntilDataLoadedOrReleased() {
 	ls.waitOrPanic(func(state loadStateEnum) bool {
 		return state == LoadStateDataLoaded || state == LoadStateReleased
-	}, func() { ok = true })
-	return ok
+	}, func() {})
 }
 
 // waitUntilCanReleaseData waits until segment is release data able.
@@ -189,23 +189,22 @@ func (ls *LoadStateLock) canReleaseAll(state loadStateEnum) bool {
 }
 
 func (ls *LoadStateLock) waitOrPanic(ready func(state loadStateEnum) bool, then func()) {
-	ch := make(chan struct{})
 	maxWaitTime := paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.GetAsDuration(time.Second)
-	go func() {
-		ls.cv.L.Lock()
-		defer ls.cv.L.Unlock()
-		defer close(ch)
-		for !ready(ls.state) {
-			ls.cv.Wait()
-		}
-		then()
-	}()
+	// Watchdog only: the wait below is deliberately unbounded so that then() always
+	// runs and native cleanup is never skipped. This fires once, purely to surface
+	// a release that is taking longer than expected.
+	timer := time.AfterFunc(maxWaitTime, func() {
+		log.Warn("load state lock still waiting, the wait is not bounded and continues until the state is ready",
+			zap.Duration("maxWaitTime", maxWaitTime))
+	})
+	defer timer.Stop()
 
-	select {
-	case <-time.After(maxWaitTime):
-		log.Error("load state lock wait timeout", zap.Duration("maxWaitTime", maxWaitTime))
-	case <-ch:
+	ls.cv.L.Lock()
+	defer ls.cv.L.Unlock()
+	for !ready(ls.state) {
+		ls.cv.Wait()
 	}
+	then()
 }
 
 type StatePredicate func(state loadStateEnum) bool

--- a/internal/querynodev2/segments/state/load_state_lock_test.go
+++ b/internal/querynodev2/segments/state/load_state_lock_test.go
@@ -189,6 +189,42 @@ func TestStartReleaseAll(t *testing.T) {
 	assert.Equal(t, LoadStateReleased, l.state)
 }
 
+func TestStartReleaseAllWaitsAfterTimeoutUntilRefCntZero(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.Key, "0.05")
+	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.Key)
+
+	l := NewLoadStateLock(LoadStateDataLoaded)
+	assert.True(t, l.PinIfNotReleased())
+
+	ch := make(chan LoadStateLockGuard, 1)
+	go func() {
+		ch <- l.StartReleaseAll()
+	}()
+
+	select {
+	case g := <-ch:
+		if g != nil {
+			g.Done(nil)
+		}
+		l.Unpin()
+		t.Fatal("StartReleaseAll returned before refcnt dropped to zero")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	l.Unpin()
+
+	select {
+	case g := <-ch:
+		assert.NotNil(t, g)
+		g.Done(nil)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("StartReleaseAll did not return after refcnt dropped to zero")
+	}
+
+	assert.False(t, l.PinIfNotReleased())
+}
+
 func TestWaitOrPanic(t *testing.T) {
 	paramtable.Init()
 
@@ -208,19 +244,39 @@ func TestWaitOrPanic(t *testing.T) {
 		assert.True(t, executed)
 	})
 
-	t.Run("timeout_panic", func(t *testing.T) {
-		paramtable.Get().Save(paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.Key, "1")
+	t.Run("timeout_keeps_waiting", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.Key, "0.05")
 		defer paramtable.Get().Reset(paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.Key)
 
 		l := NewLoadStateLock(LoadStateOnlyMeta)
 		executed := false
+		ch := make(chan struct{})
 
-		assert.NotPanics(t, func() {
+		go func() {
 			l.waitOrPanic(func(state loadStateEnum) bool {
 				return state == LoadStateDataLoaded
-			}, noop)
-		})
+			}, func() { executed = true })
+			close(ch)
+		}()
+
+		select {
+		case <-ch:
+			t.Fatal("waitOrPanic returned before the predicate became ready")
+		case <-time.After(200 * time.Millisecond):
+		}
 		assert.False(t, executed)
+
+		g, err := l.StartLoadData()
+		assert.NoError(t, err)
+		assert.NotNil(t, g)
+		g.Done(nil)
+
+		select {
+		case <-ch:
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("waitOrPanic did not return after the predicate became ready")
+		}
+		assert.True(t, executed)
 	})
 }
 

--- a/internal/util/importutilv2/parquet/leaf_pruning_test.go
+++ b/internal/util/importutilv2/parquet/leaf_pruning_test.go
@@ -1,0 +1,307 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parquet
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"testing"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/apache/arrow/go/v17/parquet/file"
+	"github.com/apache/arrow/go/v17/parquet/pqarrow"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/objectstorage"
+)
+
+// leafPruningTestSchema builds a collection schema whose struct array field has
+// three sub-fields, one of them an ArrayOfVector. Callers should pass a dim large
+// enough that the vector sub-field dominates the on-disk size, otherwise read
+// amplification is not measurable against parquet metadata overhead.
+//
+// Every field is non-nullable. Callers that need null rows must set Nullable on
+// the fields they care about before writing.
+func leafPruningTestSchema(dim string, maxCapacity string) *schemapb.CollectionSchema {
+	return &schemapb.CollectionSchema{
+		Name: "test_leaf_pruning",
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:      100,
+				Name:         "id",
+				IsPrimaryKey: true,
+				DataType:     schemapb.DataType_Int64,
+			},
+			{
+				FieldID:  101,
+				Name:     "varchar_field",
+				DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{
+					// testutil.CreateInsertData fills VarChar via
+					// testutils.GenerateStringArray, which builds 5-10 word
+					// sentences up to roughly 100 characters. A smaller
+					// max_length makes reader.Read fail CheckVarcharLength
+					// before any assertion in these tests is reached.
+					{Key: common.MaxLengthKey, Value: "128"},
+				},
+			},
+		},
+		StructArrayFields: []*schemapb.StructArrayFieldSchema{
+			{
+				FieldID: 200,
+				Name:    "struct_array",
+				Fields: []*schemapb.FieldSchema{
+					{
+						FieldID:     201,
+						Name:        "struct_array[int_array]",
+						DataType:    schemapb.DataType_Array,
+						ElementType: schemapb.DataType_Int32,
+						TypeParams: []*commonpb.KeyValuePair{
+							{Key: common.MaxCapacityKey, Value: maxCapacity},
+						},
+					},
+					{
+						FieldID:     202,
+						Name:        "struct_array[float_array]",
+						DataType:    schemapb.DataType_Array,
+						ElementType: schemapb.DataType_Float,
+						TypeParams: []*commonpb.KeyValuePair{
+							{Key: common.MaxCapacityKey, Value: maxCapacity},
+						},
+					},
+					{
+						FieldID:     203,
+						Name:        "struct_array[vector_array]",
+						DataType:    schemapb.DataType_ArrayOfVector,
+						ElementType: schemapb.DataType_FloatVector,
+						TypeParams: []*commonpb.KeyValuePair{
+							{Key: common.DimKey, Value: dim},
+							{Key: common.MaxCapacityKey, Value: maxCapacity},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// writeLeafPruningParquet writes a parquet file for the given schema and returns
+// its path and on-disk size. The caller is responsible for removing the file.
+//
+// nullPercent is forwarded to testutil.CreateInsertData, which only honors it
+// for fields whose Nullable flag is set. A schema straight from
+// leafPruningTestSchema has no nullable fields, so nullPercent has no effect
+// unless the caller marks fields nullable first.
+func writeLeafPruningParquet(t *testing.T, schema *schemapb.CollectionSchema, numRows int, nullPercent int) (string, int64) {
+	t.Helper()
+
+	filePath := fmt.Sprintf("/tmp/test_leaf_pruning_%d.parquet", rand.Int())
+	f, err := os.Create(filePath)
+	require.NoError(t, err)
+	// writeParquet closes the sink itself: pqarrow.FileWriter.Close calls
+	// file.Writer.Close, which closes the io.Writer it was handed. This deferred
+	// close is only a safety net for the path where a require below aborts first,
+	// so its error is deliberately ignored.
+	defer func() { _ = f.Close() }()
+
+	_, err = writeParquet(f, schema, numRows, nullPercent)
+	require.NoError(t, err)
+
+	info, err := os.Stat(filePath)
+	require.NoError(t, err)
+	return filePath, info.Size()
+}
+
+// findArrowFieldIndex returns the index of the named top-level field in an arrow
+// schema, failing the test if it is absent.
+func findArrowFieldIndex(t *testing.T, schema *arrow.Schema, name string) int {
+	t.Helper()
+	for i, f := range schema.Fields() {
+		if f.Name == name {
+			return i
+		}
+	}
+	require.FailNowf(t, "field not found", "no top-level arrow field named %q", name)
+	return -1
+}
+
+func TestCollectSubFieldLeaves(t *testing.T) {
+	schema := leafPruningTestSchema("8", "4")
+	filePath, _ := writeLeafPruningParquet(t, schema, 20, 0)
+	defer os.Remove(filePath)
+
+	osFile, err := os.Open(filePath)
+	require.NoError(t, err)
+	defer osFile.Close()
+
+	pqReader, err := file.NewParquetReader(osFile)
+	require.NoError(t, err)
+	defer pqReader.Close()
+
+	fileReader, err := pqarrow.NewFileReader(pqReader, pqarrow.ArrowReadProperties{BatchSize: 64}, memory.DefaultAllocator)
+	require.NoError(t, err)
+
+	// Locate the struct_array column among the top-level arrow fields.
+	arrowSchema, err := fileReader.Schema()
+	require.NoError(t, err)
+	columnIndex := findArrowFieldIndex(t, arrowSchema, "struct_array")
+
+	subFieldNames := []string{"int_array", "float_array", "vector_array"}
+	union := make(map[int]bool)
+
+	for fieldIndex, name := range subFieldNames {
+		leaves, err := collectSubFieldLeaves(fileReader.Manifest, columnIndex, fieldIndex)
+		require.NoError(t, err, "sub-field %s", name)
+		require.NotEmpty(t, leaves, "sub-field %s resolved to zero leaves", name)
+
+		for colIdx := range leaves {
+			// Every resolved leaf must actually live under this sub-field.
+			// This is what catches terminating recursion on IsLeaf(): a group
+			// node carries a zero-value ColIndex of 0, which would resolve to
+			// the first leaf in the file ("id") instead of the sub-field.
+			path := pqReader.MetaData().Schema.Column(colIdx).Path()
+			assert.Contains(t, path, name,
+				"sub-field %s resolved to leaf %d whose path is %q", name, colIdx, path)
+
+			assert.False(t, union[colIdx],
+				"leaf %d claimed by more than one sub-field", colIdx)
+			union[colIdx] = true
+		}
+	}
+
+	assert.Len(t, union, len(subFieldNames),
+		"expected one leaf per sub-field for this schema, got %v", union)
+}
+
+func TestCollectSubFieldLeavesRejectsBadIndex(t *testing.T) {
+	schema := leafPruningTestSchema("8", "4")
+	filePath, _ := writeLeafPruningParquet(t, schema, 20, 0)
+	defer os.Remove(filePath)
+
+	osFile, err := os.Open(filePath)
+	require.NoError(t, err)
+	defer osFile.Close()
+
+	pqReader, err := file.NewParquetReader(osFile)
+	require.NoError(t, err)
+	defer pqReader.Close()
+
+	fileReader, err := pqarrow.NewFileReader(pqReader, pqarrow.ArrowReadProperties{BatchSize: 64}, memory.DefaultAllocator)
+	require.NoError(t, err)
+
+	_, err = collectSubFieldLeaves(fileReader.Manifest, -1, 0)
+	assert.Error(t, err)
+
+	_, err = collectSubFieldLeaves(fileReader.Manifest, 9999, 0)
+	assert.Error(t, err)
+
+	_, err = collectSubFieldLeaves(nil, 0, 0)
+	assert.Error(t, err)
+
+	arrowSchema, err := fileReader.Schema()
+	require.NoError(t, err)
+	columnIndex := findArrowFieldIndex(t, arrowSchema, "struct_array")
+
+	_, err = collectSubFieldLeaves(fileReader.Manifest, columnIndex, 9999)
+	assert.Error(t, err, "out-of-range fieldIndex must be rejected")
+}
+
+// countingChunkManager wraps a ChunkManager and counts every byte pulled through
+// the streaming Reader() path, which is the path the parquet import reader uses.
+type countingChunkManager struct {
+	storage.ChunkManager
+	readBytes atomic.Int64
+}
+
+func (c *countingChunkManager) Reader(ctx context.Context, filePath string) (storage.FileReader, error) {
+	r, err := c.ChunkManager.Reader(ctx, filePath)
+	if err != nil {
+		return nil, err
+	}
+	return &countingFileReader{FileReader: r, counter: &c.readBytes}, nil
+}
+
+type countingFileReader struct {
+	storage.FileReader
+	counter *atomic.Int64
+}
+
+func (r *countingFileReader) Read(p []byte) (int, error) {
+	n, err := r.FileReader.Read(p)
+	r.counter.Add(int64(n))
+	return n, err
+}
+
+func (r *countingFileReader) ReadAt(p []byte, off int64) (int, error) {
+	n, err := r.FileReader.ReadAt(p, off)
+	r.counter.Add(int64(n))
+	return n, err
+}
+
+// TestStructArrayReadAmplification guards against the struct array column being
+// decoded once per sub-field. Before leaf pruning this reads roughly 3x the file
+// (one full pass per sub-field); after pruning it reads it about once.
+func TestStructArrayReadAmplification(t *testing.T) {
+	ctx := context.Background()
+
+	// dim 64 x capacity 16 makes the vector sub-field dominate the file, so the
+	// amplification is far larger than parquet footer/page-header overhead.
+	schema := leafPruningTestSchema("64", "16")
+	filePath, fileSize := writeLeafPruningParquet(t, schema, 1000, 0)
+	defer os.Remove(filePath)
+
+	factory := storage.NewChunkManagerFactory("local", objectstorage.RootPath("/tmp"))
+	baseCM, err := factory.NewPersistentStorageChunkManager(ctx)
+	require.NoError(t, err)
+
+	cm := &countingChunkManager{ChunkManager: baseCM}
+
+	reader, err := NewReader(ctx, cm, schema, filePath, 16*1024*1024)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	totalRows := 0
+	for {
+		data, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		totalRows += data.GetRowNum()
+	}
+	require.Equal(t, 1000, totalRows)
+
+	readBytes := cm.readBytes.Load()
+	t.Logf("file size = %d bytes, bytes read = %d (%.2fx)",
+		fileSize, readBytes, float64(readBytes)/float64(fileSize))
+
+	require.Positive(t, readBytes, "counting chunk manager saw no reads")
+	assert.Less(t, readBytes, 2*fileSize,
+		"struct array column is being read more than once: read %d bytes for a %d byte file",
+		readBytes, fileSize)
+}

--- a/internal/util/importutilv2/parquet/struct_field_reader.go
+++ b/internal/util/importutilv2/parquet/struct_field_reader.go
@@ -39,13 +39,72 @@ type StructFieldReader struct {
 	dim          int
 }
 
+// collectSubFieldLeaves returns the parquet leaf column indices belonging to the
+// fieldIndex-th sub-field of the list<struct> column at columnIndex.
+func collectSubFieldLeaves(manifest *pqarrow.SchemaManifest, columnIndex, fieldIndex int) (map[int]bool, error) {
+	if manifest == nil || columnIndex < 0 || columnIndex >= len(manifest.Fields) {
+		return nil, merr.WrapErrImportSysFailedMsg("struct column index %d out of range", columnIndex)
+	}
+	listField := &manifest.Fields[columnIndex]
+	if len(listField.Children) != 1 {
+		return nil, merr.WrapErrImportSysFailedMsg("struct column %d is not a list of structs", columnIndex)
+	}
+	structField := &listField.Children[0]
+	if fieldIndex < 0 || fieldIndex >= len(structField.Children) {
+		return nil, merr.WrapErrImportSysFailedMsg("struct sub-field index %d out of range", fieldIndex)
+	}
+
+	leaves := make(map[int]bool)
+	collectLeafColumnIndices(&structField.Children[fieldIndex], leaves)
+	// Unreachable with the current recursion, which always records at least one
+	// index for any node it is handed. Kept as a guard so a future change to
+	// collectLeafColumnIndices cannot silently hand arrow an empty leaf set,
+	// which GetFieldReader answers with a nil reader rather than an error.
+	if len(leaves) == 0 {
+		return nil, merr.WrapErrImportSysFailedMsg("no leaf column found for struct sub-field index %d", fieldIndex)
+	}
+	return leaves, nil
+}
+
+// collectLeafColumnIndices walks a schema subtree and records every leaf column index.
+//
+// Recursion terminates on len(Children) == 0 rather than SchemaField.IsLeaf():
+// arrow assigns ColIndex only in populateLeaf and zero-initializes every other
+// SchemaField, so IsLeaf() (ColIndex != -1) reports true for group nodes and
+// yields a bogus index of 0. arrow's own getReader guards the same way.
+func collectLeafColumnIndices(field *pqarrow.SchemaField, leaves map[int]bool) {
+	if len(field.Children) == 0 {
+		leaves[field.ColIndex] = true
+		return
+	}
+	for i := range field.Children {
+		collectLeafColumnIndices(&field.Children[i], leaves)
+	}
+}
+
 // NewStructFieldReader creates a reader for extracting a field from nested struct
 func NewStructFieldReader(ctx context.Context, fileReader *pqarrow.FileReader, columnIndex int,
 	fieldIndex int, field *schemapb.FieldSchema,
 ) (*FieldReader, error) {
-	columnReader, err := fileReader.GetColumn(ctx, columnIndex)
+	// Only pull the leaf columns of this sub-field. Using GetColumn here would
+	// decode every leaf of the list<struct> column for every sub-field reader,
+	// reading the whole column N times for N sub-fields.
+	includedLeaves, err := collectSubFieldLeaves(fileReader.Manifest, columnIndex, fieldIndex)
+	if err != nil {
+		return nil, merr.Wrapf(err, "failed to resolve leaf columns for struct sub-field '%s'", field.GetName())
+	}
+
+	rowGroups := make([]int, fileReader.ParquetReader().NumRowGroups())
+	for i := range rowGroups {
+		rowGroups[i] = i
+	}
+
+	columnReader, err := fileReader.GetFieldReader(ctx, columnIndex, includedLeaves, rowGroups)
 	if err != nil {
 		return nil, err
+	}
+	if columnReader == nil {
+		return nil, merr.WrapErrImportSysFailedMsg("no column reader for struct sub-field '%s'", field.GetName())
 	}
 
 	dim := 0
@@ -67,8 +126,11 @@ func NewStructFieldReader(ctx context.Context, fileReader *pqarrow.FileReader, c
 	sfr := &StructFieldReader{
 		columnReader: columnReader,
 		field:        field,
-		fieldIndex:   fieldIndex,
-		dim:          dim,
+		// Leaf pruning leaves exactly one surviving child under the struct, so
+		// the sub-field always sits at position 0 in the arrow struct this
+		// reader produces.
+		fieldIndex: 0,
+		dim:        dim,
 	}
 
 	fr := &FieldReader{

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1080,7 +1080,7 @@ Large numeric passwords require double quotes to avoid yaml parsing precision is
 		Key:          "common.locks.maxWLockConditionalWaitTime",
 		Version:      "2.5.4",
 		DefaultValue: "600",
-		Doc:          "maximum seconds for waiting wlock conditional",
+		Doc:          "seconds before logging a wlock conditional wait that is taking long; the wait itself is not bounded by this value",
 		Export:       true,
 	}
 	p.MaxWLockConditionalWaitTime.Init(base.mgr)

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -2623,10 +2623,17 @@ func GetFieldByName(schema *schemapb.CollectionSchema, fieldName string) *schema
 	return nil
 }
 
-// GetFieldByID returns the field schema with the given field ID, or nil if not found.
+// GetFieldByID returns the field schema with the given field ID, searching both
+// top-level fields and struct array sub-fields, or nil if not found.
 func GetFieldByID(schema *schemapb.CollectionSchema, fieldID int64) *schemapb.FieldSchema {
-	for _, field := range schema.GetFields() {
-		if field.GetFieldID() == fieldID {
+	predicate := func(field *schemapb.FieldSchema) bool {
+		return field.GetFieldID() == fieldID
+	}
+	if field := lo.FindOrElse(schema.GetFields(), nil, predicate); field != nil {
+		return field
+	}
+	for _, structField := range schema.GetStructArrayFields() {
+		if field := lo.FindOrElse(structField.Fields, nil, predicate); field != nil {
 			return field
 		}
 	}

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -5944,3 +5944,35 @@ func TestIsClusteringKeyType(t *testing.T) {
 	assert.False(t, IsClusteringKeyType(schemapb.DataType_Float16Vector))
 	assert.False(t, IsClusteringKeyType(schemapb.DataType_BFloat16Vector))
 }
+
+func TestGetFieldByID_StructArraySubField(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+		},
+		StructArrayFields: []*schemapb.StructArrayFieldSchema{
+			{
+				FieldID: 101,
+				Name:    "struct_array",
+				Fields: []*schemapb.FieldSchema{
+					{
+						FieldID:     102,
+						Name:        "vector_array",
+						DataType:    schemapb.DataType_ArrayOfVector,
+						ElementType: schemapb.DataType_Float16Vector,
+					},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, "pk", GetFieldByID(schema, 100).GetName())
+
+	subField := GetFieldByID(schema, 102)
+	assert.NotNil(t, subField)
+	assert.Equal(t, "vector_array", subField.GetName())
+	assert.Equal(t, schemapb.DataType_ArrayOfVector, subField.GetDataType())
+	assert.Equal(t, schemapb.DataType_Float16Vector, subField.GetElementType())
+
+	assert.Nil(t, GetFieldByID(schema, 999))
+}


### PR DESCRIPTION
Unified batch backport to 2.6 (one CP PR instead of six, to reduce CI load). One commit per master PR, cherry-picked in master merge order.

pr: #51607
pr: #51516
pr: #52046
pr: #51777
pr: #52015
pr: #52113
issue: #51606
issue: #51512
issue: #52045
issue: #51776
issue: #52014
issue: #52112

Supersedes closed per-PR CP PRs: #52418, #52419, #52424, #52423, #52411, #52410 (identical resolved content, verified line-by-line against each master PR diff).

## Included fixes (cherry-pick order)

1. #51607 — honor gc pause timeout. 2.6 adaptation: "pause rolled back" and pause-ticket logs use 2.6's zap-style logging (master uses mlog).
2. #51516 — recycle stale analyze stats versions and persist analyze terminal states. 2.6 adaptation: `indexpb` import uses `pkg/v2`; two persist-failure warns use zap; only this PR's own new GC test is ported (master-only snapshot/commit_ts tests dropped from the conflict hunk).
3. #52046 — read only the needed leaf columns for struct array sub-fields. 2.6 adaptation: new test imports normalized `pkg/v3`→`pkg/v2`, `go-api/v3`→`go-api/v2`.
4. #51777 — wait for segment release after lock timeout. 2.6 adaptation: watchdog log uses zap; configs/milvus.yaml conflict was positional only.
5. #52015 — convert ArrayOfVector element placeholders. 2.6 adaptation: test calls 2.6's 2-value `ConvertPlaceholderGroup` signature; two test helpers ported verbatim from master.
6. #52113 — resolve search timezone before plan generation. 2.6 adaptation: moved timezone block keeps zap-style logging; test uses 2.6's `newSchemaInfo`.
7. `66595ca` — make `typeutil.GetFieldByID` find struct array sub-fields. **2.6-only; no corresponding master PR** — master and 3.0 already walk `StructArrayFields`, so this aligns 2.6 with them rather than back-porting anything. It is the prerequisite for item 5: an ArrayOfVector field can only live inside a struct array field, so without this change `convertPlaceholderIfNeeded` (`internal/proxy/task_search.go:895`) resolves the anns field to `nil` and forwards the placeholder unconverted, leaving the #52015 back-port dead code on this branch. Blast radius is confined to that one call site — `GetFieldByID` has exactly one non-test caller on 2.6.

## Verification

- [x] Items 1-6: each commit's changed lines verified identical to the individually-reviewed CP commits (which were line-level compared against their master PR diffs)
- [x] Item 7 has no master PR diff to compare against; verified instead that the resulting `GetFieldByID` body matches master's current implementation exactly
- [x] Same-file pair #51607/#51516 stacked in master merge order; zero conflicts
- [x] No conflict markers
- [ ] make static-check (skipped by cherry-pick workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

