### PR TITLE
enhance: [cp2.6] batch backport highlight row invariant and import retry backoff

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -827,6 +827,13 @@ dataNode:
     readBufferSizeInMB: 16 # The base insert buffer size (in MB) during import. The actual buffer size will be dynamically calculated based on the number of shards.
     readDeleteBufferSizeInMB: 16 # The delete buffer size (in MB) during import.
     memoryLimitPercentage: 10 # The percentage of memory limit for import/pre-import tasks.
+    # Initial backoff interval in seconds for import write retry. Must be a positive integer;
+    # a non-positive or unparseable value falls back to the default.
+    writeRetryInitialInterval: 1
+    # Maximum backoff interval in seconds for import write retry. Must be a positive integer;
+    # a non-positive or unparseable value falls back to the default. Set it to at least twice
+    # writeRetryInitialInterval, otherwise the effective cap is raised to twice the initial interval.
+    writeRetryMaxInterval: 60
   compaction:
     levelZeroBatchMemoryRatio: 0.5 # The minimal memory ratio of free memory for level zero compaction executing in batch mode
     levelZeroMaxBatchSize: -1 # Max batch size refers to the max number of L1/L2 segments in a batch when executing L0 compaction. Default to -1, any value that is less than 1 means no limit. Valid range: >= 1.

--- a/internal/datanode/importv2/util.go
+++ b/internal/datanode/importv2/util.go
@@ -98,19 +98,29 @@ func NewSyncTask(ctx context.Context,
 		syncPack.WithBM25Stats(bm25Stats)
 	}
 
-	writeRetryAttempts := paramtable.Get().DataNodeCfg.ImportMaxWriteRetryAttempts.GetAsUint()
-	retryOpts := []retry.Option{
-		retry.Attempts(writeRetryAttempts), // default retry always
-		retry.MaxSleepTime(10 * time.Second),
-	}
 	task := syncmgr.NewSyncTask().
 		WithAllocator(allocator).
 		WithMetaCache(metaCache).
 		WithSchema(metaCache.GetSchema(0)). // TODO specify import schema if needed
 		WithSyncPack(syncPack).
 		WithStorageConfig(storageConfig).
-		WithWriteRetryOptions(retryOpts...)
+		WithWriteRetryOptions(newWriteRetryOptions()...)
 	return task, nil
+}
+
+// newWriteRetryOptions builds the retry options for import writes. The options are
+// order-sensitive: retry.Sleep raises maxSleepTime to 2*initial, so MaxSleepTime must
+// be applied last. The paramtable formatters guarantee both intervals are positive,
+// which keeps retry.Do from degenerating into a zero-delay loop under attempts=0.
+func newWriteRetryOptions() []retry.Option {
+	params := &paramtable.Get().DataNodeCfg
+	initialInterval := time.Duration(params.ImportWriteRetryInitialInterval.GetAsInt()) * time.Second
+	maxInterval := time.Duration(params.ImportWriteRetryMaxInterval.GetAsInt()) * time.Second
+	return []retry.Option{
+		retry.Attempts(params.ImportMaxWriteRetryAttempts.GetAsUint()), // 0 = unlimited, preserved on purpose
+		retry.Sleep(initialInterval),
+		retry.MaxSleepTime(maxInterval),
+	}
 }
 
 func NewImportSegmentInfo(syncTask syncmgr.Task, metaCaches map[string]metacache.MetaCache) (*datapb.ImportSegmentInfo, error) {

--- a/internal/datanode/importv2/util_test.go
+++ b/internal/datanode/importv2/util_test.go
@@ -17,9 +17,12 @@
 package importv2
 
 import (
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -29,6 +32,8 @@ import (
 	"github.com/milvus-io/milvus/internal/util/testutil"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/retry"
 )
 
 func Test_AppendSystemFieldsData(t *testing.T) {
@@ -720,4 +725,37 @@ func TestUtil_FillDynamicData(t *testing.T) {
 	err = FillDynamicData(schema, insertData, count)
 	assert.NoError(t, err)
 	assert.Equal(t, count, insertData.Data[dynamicFieldID].RowNum())
+}
+
+func TestNewWriteRetryOptions(t *testing.T) {
+	paramtable.Init()
+	params := paramtable.Get()
+
+	// A failing write under the shipped defaults must back off, not spin: the first
+	// sleep is writeRetryInitialInterval (1s), so a ctx canceled well before that
+	// lets exactly one attempt through.
+	runUntilCancel := func() int {
+		// Mirror the import task ctx (task_import.go): cancellable but without a
+		// deadline, so retry.Do's deadline escape hatch cannot end the loop.
+		ctx, cancel := context.WithCancel(context.Background())
+		time.AfterFunc(100*time.Millisecond, cancel)
+		defer cancel()
+		calls := 0
+		err := retry.Do(ctx, func() error {
+			calls++
+			return errors.New("write failed")
+		}, newWriteRetryOptions()...)
+		assert.Error(t, err)
+		return calls
+	}
+	assert.LessOrEqual(t, runUntilCancel(), 2)
+
+	// A non-positive interval is rejected by the paramtable formatter, so it cannot
+	// degenerate into retry.Sleep(0) — which, combined with the default
+	// maxWriteRetryAttempts=0 (unlimited), would spin with zero delay.
+	params.Save(params.DataNodeCfg.ImportWriteRetryInitialInterval.Key, "0")
+	params.Save(params.DataNodeCfg.ImportWriteRetryMaxInterval.Key, "0")
+	defer params.Reset(params.DataNodeCfg.ImportWriteRetryInitialInterval.Key)
+	defer params.Reset(params.DataNodeCfg.ImportWriteRetryMaxInterval.Key)
+	assert.LessOrEqual(t, runUntilCancel(), 2)
 }

--- a/internal/proxy/highlighter.go
+++ b/internal/proxy/highlighter.go
@@ -548,6 +548,7 @@ func (op *semanticHighlightOperator) run(ctx context.Context, span trace.Span, i
 	}
 	highlightResults := []*commonpb.HighlightResult{}
 	topks := result.Results.GetTopks()
+	rowNum := searchResultHitCount(result.GetResults())
 
 	// Process schema fields
 	for _, fieldID := range op.highlight.FieldIDs() {
@@ -555,7 +556,10 @@ func (op *semanticHighlightOperator) run(ctx context.Context, span trace.Span, i
 		if !ok {
 			return nil, merr.WrapErrParameterInvalidMsg("get highlight failed, text field not in output field %d", fieldID)
 		}
-		texts := fieldDatas.GetScalars().GetStringData().GetData()
+		texts, err := rowAlignedStringFieldData(fieldDatas, rowNum)
+		if err != nil {
+			return nil, err
+		}
 		fieldName := op.highlight.GetFieldName(fieldID)
 
 		highlightResult, err := op.processFieldHighlight(ctx, fieldName, texts, topks)
@@ -596,6 +600,14 @@ func (op *semanticHighlightOperator) run(ctx context.Context, span trace.Span, i
 
 		for _, dynFieldName := range dynFieldNames {
 			texts := allDynFieldTexts[dynFieldName]
+			// Process slices documents by topks without checking that they sum to
+			// len(documents), so an undersized $meta payload would go out of range
+			// there. Fail with the same error the schema branch returns instead.
+			if len(texts) != rowNum {
+				return nil, merr.WrapErrServiceInternalMsg(
+					"get highlight failed, dynamic field %s has %d rows, expected %d",
+					dynFieldName, len(texts), rowNum)
+			}
 
 			highlightResult, err := op.processFieldHighlight(ctx, dynFieldName, texts, topks)
 			if err != nil {

--- a/internal/proxy/search_pipeline_test.go
+++ b/internal/proxy/search_pipeline_test.go
@@ -1268,6 +1268,79 @@ func (s *SearchPipelineSuite) TestSemanticHighlightOp() {
 	s.Equal([]string{"<em>highlighted</em> text 3"}, highlightResult.Datas[2].Fragments)
 }
 
+func (s *SearchPipelineSuite) TestSemanticHighlightOpNullableStringAlignsRows() {
+	ctx := context.Background()
+
+	mockProcess := mockey.Mock((*highlight.SemanticHighlight).Process).To(
+		func(h *highlight.SemanticHighlight, ctx context.Context, topks []int64, texts []string) ([][]string, [][]float32, error) {
+			s.Equal([]int64{3}, topks)
+			s.Equal([]string{"text 1", "", "text 3"}, texts)
+			return [][]string{
+					{"highlighted text 1"},
+					{},
+					{"highlighted text 3"},
+				}, [][]float32{
+					{0.9},
+					{},
+					{0.7},
+				}, nil
+		}).Build()
+	defer mockProcess.UnPatch()
+
+	mockFieldIDs := mockey.Mock((*highlight.SemanticHighlight).FieldIDs).Return([]int64{101}).Build()
+	defer mockFieldIDs.UnPatch()
+
+	mockGetFieldName := mockey.Mock((*highlight.SemanticHighlight).GetFieldName).Return(testVarCharField).Build()
+	defer mockGetFieldName.UnPatch()
+
+	op := &semanticHighlightOperator{
+		highlight: &highlight.SemanticHighlight{},
+	}
+
+	searchResults := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			NumQueries: 1,
+			TopK:       3,
+			Topks:      []int64{3},
+			Ids:        testSearchResultIDs(1, 2, 3),
+			FieldsData: []*schemapb.FieldData{
+				{
+					FieldId:   101,
+					FieldName: testVarCharField,
+					Type:      schemapb.DataType_VarChar,
+					ValidData: []bool{true, false, true},
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_StringData{
+								StringData: &schemapb.StringArray{
+									Data: []string{"text 1", "text 3"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	results, err := op.run(ctx, s.span, searchResults)
+	s.NoError(err)
+	s.Require().Len(results, 1)
+
+	result := results[0].(*milvuspb.SearchResults)
+	s.Require().Len(result.GetResults().GetHighlightResults(), 1)
+	highlightResult := result.GetResults().GetHighlightResults()[0]
+	// The fix under test is the row alignment feeding Process: the NULL row
+	// materializes as "" at its own index, asserted on `texts` inside the mock
+	// above. Here we only verify the per-row results survive alignment 1:1 —
+	// the row-1 payload is whatever the mock returned, not a NULL-semantics
+	// guarantee, so we assert positional pass-through across all three rows.
+	s.Require().Len(highlightResult.GetDatas(), 3)
+	s.Equal([]string{"highlighted text 1"}, highlightResult.GetDatas()[0].GetFragments())
+	s.Equal([]string{}, highlightResult.GetDatas()[1].GetFragments())
+	s.Equal([]string{"highlighted text 3"}, highlightResult.GetDatas()[2].GetFragments())
+}
+
 func (s *SearchPipelineSuite) TestSemanticHighlightOpMissingField() {
 	ctx := context.Background()
 
@@ -1636,6 +1709,72 @@ func (s *SearchPipelineSuite) TestSemanticHighlightOpMixedFields() {
 	// Dynamic field result
 	s.Equal("dyn_content", result.Results.HighlightResults[1].FieldName)
 	s.Equal([]string{"<em>dynamic</em> text"}, result.Results.HighlightResults[1].Datas[0].Fragments)
+}
+
+// Process slices documents by topks without checking that they sum to
+// len(documents), so a $meta payload shorter than the hit count would go out of
+// range there. The dynamic-field branch must reject it up front, the same way
+// the schema branch does.
+func (s *SearchPipelineSuite) TestSemanticHighlightOpDynamicFieldRowCountMismatch() {
+	ctx := context.Background()
+
+	mockProcess := mockey.Mock((*highlight.SemanticHighlight).Process).To(
+		func(h *highlight.SemanticHighlight, ctx context.Context, topks []int64, texts []string) ([][]string, [][]float32, error) {
+			s.Fail("Process must not be called with a row-count mismatch")
+			return nil, nil, nil
+		}).Build()
+	defer mockProcess.UnPatch()
+
+	mockFieldIDs := mockey.Mock((*highlight.SemanticHighlight).FieldIDs).Return([]int64{}).Build()
+	defer mockFieldIDs.UnPatch()
+
+	mockHasDynamicFields := mockey.Mock((*highlight.SemanticHighlight).HasDynamicFields).Return(true).Build()
+	defer mockHasDynamicFields.UnPatch()
+
+	mockDynamicFieldNames := mockey.Mock((*highlight.SemanticHighlight).DynamicFieldNames).Return([]string{"dyn_content"}).Build()
+	defer mockDynamicFieldNames.UnPatch()
+
+	mockDynamicFieldID := mockey.Mock((*highlight.SemanticHighlight).DynamicFieldID).Return(int64(102)).Build()
+	defer mockDynamicFieldID.UnPatch()
+
+	op := &semanticHighlightOperator{
+		highlight: &highlight.SemanticHighlight{},
+	}
+
+	// Topks says 3 hits, $meta carries only 2 rows.
+	searchResults := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			NumQueries: 1,
+			TopK:       3,
+			Topks:      []int64{3},
+			Ids:        testSearchResultIDs(1, 2, 3),
+			Scores:     []float32{0.9, 0.8, 0.7},
+			FieldsData: []*schemapb.FieldData{
+				{
+					FieldId:   102,
+					FieldName: "$meta",
+					Type:      schemapb.DataType_JSON,
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_JsonData{
+								JsonData: &schemapb.JSONArray{
+									Data: [][]byte{
+										[]byte(`{"dyn_content": "dynamic content 1"}`),
+										[]byte(`{"dyn_content": "dynamic content 2"}`),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	results, err := op.run(ctx, s.span, searchResults)
+	s.Error(err)
+	s.Nil(results)
+	s.Contains(err.Error(), "dynamic field dyn_content has 2 rows, expected 3")
 }
 
 func (s *SearchPipelineSuite) TestExtractMultipleDynamicFieldTexts() {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -6434,12 +6434,14 @@ type dataNodeConfig struct {
 	ChannelCheckpointUpdateTickInSeconds ParamItem `refreshable:"true"`
 
 	// import
-	ImportConcurrencyPerCPUCore ParamItem `refreshable:"true"`
-	MaxImportFileSizeInGB       ParamItem `refreshable:"true"`
-	ImportBaseBufferSize        ParamItem `refreshable:"true"`
-	ImportDeleteBufferSize      ParamItem `refreshable:"true"`
-	ImportMemoryLimitPercentage ParamItem `refreshable:"true"`
-	ImportMaxWriteRetryAttempts ParamItem `refreshable:"true"`
+	ImportConcurrencyPerCPUCore     ParamItem `refreshable:"true"`
+	MaxImportFileSizeInGB           ParamItem `refreshable:"true"`
+	ImportBaseBufferSize            ParamItem `refreshable:"true"`
+	ImportDeleteBufferSize          ParamItem `refreshable:"true"`
+	ImportMemoryLimitPercentage     ParamItem `refreshable:"true"`
+	ImportMaxWriteRetryAttempts     ParamItem `refreshable:"true"`
+	ImportWriteRetryInitialInterval ParamItem `refreshable:"true"`
+	ImportWriteRetryMaxInterval     ParamItem `refreshable:"true"`
 
 	// Compaction
 	L0BatchMemoryRatio       ParamItem `refreshable:"true"`
@@ -6800,6 +6802,43 @@ if this parameter <= 0, will set it as 10`,
 		DefaultValue: "0",
 	}
 	p.ImportMaxWriteRetryAttempts.Init(base.mgr)
+
+	p.ImportWriteRetryInitialInterval = ParamItem{
+		Key:     "dataNode.import.writeRetryInitialInterval",
+		Version: "2.6.9",
+		Doc: `Initial backoff interval in seconds for import write retry. Must be a positive integer;
+a non-positive or unparseable value falls back to the default.`,
+		DefaultValue: "1",
+		Export:       true,
+		Formatter: func(v string) string {
+			interval := getAsInt(v)
+			if interval <= 0 {
+				log.Warn("invalid import write retry initial interval, using default 1s")
+				return "1"
+			}
+			return strconv.Itoa(interval)
+		},
+	}
+	p.ImportWriteRetryInitialInterval.Init(base.mgr)
+
+	p.ImportWriteRetryMaxInterval = ParamItem{
+		Key:     "dataNode.import.writeRetryMaxInterval",
+		Version: "2.6.9",
+		Doc: `Maximum backoff interval in seconds for import write retry. Must be a positive integer;
+a non-positive or unparseable value falls back to the default. Set it to at least twice
+writeRetryInitialInterval, otherwise the effective cap is raised to twice the initial interval.`,
+		DefaultValue: "60",
+		Export:       true,
+		Formatter: func(v string) string {
+			interval := getAsInt(v)
+			if interval <= 0 {
+				log.Warn("invalid import write retry max interval, using default 60s")
+				return "60"
+			}
+			return strconv.Itoa(interval)
+		},
+	}
+	p.ImportWriteRetryMaxInterval.Init(base.mgr)
 
 	p.L0BatchMemoryRatio = ParamItem{
 		Key:          "dataNode.compaction.levelZeroBatchMemoryRatio",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -717,6 +717,22 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 16*1024*1024, Params.ImportDeleteBufferSize.GetAsInt())
 		assert.Equal(t, 10.0, Params.ImportMemoryLimitPercentage.GetAsFloat())
 		assert.Equal(t, 0, Params.ImportMaxWriteRetryAttempts.GetAsInt())
+		assert.Equal(t, 1, Params.ImportWriteRetryInitialInterval.GetAsInt())
+		assert.Equal(t, 60, Params.ImportWriteRetryMaxInterval.GetAsInt())
+		// a non-positive or unparseable interval must fall back to the default,
+		// otherwise retry.Sleep(0) yields a zero-delay unbounded retry loop.
+		for _, invalid := range []string{"0", "-1", "1s"} {
+			params.Save(Params.ImportWriteRetryInitialInterval.Key, invalid)
+			assert.Equal(t, 1, Params.ImportWriteRetryInitialInterval.GetAsInt())
+			params.Save(Params.ImportWriteRetryMaxInterval.Key, invalid)
+			assert.Equal(t, 60, Params.ImportWriteRetryMaxInterval.GetAsInt())
+		}
+		params.Save(Params.ImportWriteRetryInitialInterval.Key, "2")
+		assert.Equal(t, 2, Params.ImportWriteRetryInitialInterval.GetAsInt())
+		params.Save(Params.ImportWriteRetryMaxInterval.Key, "120")
+		assert.Equal(t, 120, Params.ImportWriteRetryMaxInterval.GetAsInt())
+		params.Reset(Params.ImportWriteRetryInitialInterval.Key)
+		params.Reset(Params.ImportWriteRetryMaxInterval.Key)
 		params.Save("datanode.gracefulStopTimeout", "100")
 		assert.Equal(t, 100*time.Second, Params.GracefulStopTimeout.GetAsDuration(time.Second))
 		assert.Equal(t, 16, Params.SlotCap.GetAsInt())

--- a/pkg/util/retry/options_test.go
+++ b/pkg/util/retry/options_test.go
@@ -14,6 +14,7 @@ package retry
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -50,4 +51,32 @@ func TestMaxAttemptsFromContextOrDefault(t *testing.T) {
 	// Zero in ctx — returns 0, not default
 	ctx = WithMaxAttemptsContext(context.Background(), 0)
 	assert.Equal(t, uint(0), MaxAttemptsFromContextOrDefault(ctx, 10))
+}
+
+// TestSleepAndMaxSleepTimeOrder pins the order-sensitive interaction between Sleep
+// and MaxSleepTime that the import write-retry path (internal/datanode/importv2)
+// depends on: it applies Sleep(initial) before MaxSleepTime(max).
+func TestSleepAndMaxSleepTimeOrder(t *testing.T) {
+	effective := func(initial, max time.Duration) *config {
+		c := newDefaultConfig()
+		for _, opt := range []Option{Attempts(0), Sleep(initial), MaxSleepTime(max)} {
+			opt(c)
+		}
+		return c
+	}
+
+	// The shipped import defaults produce exactly the advertised 1s -> 60s schedule.
+	c := effective(time.Second, 60*time.Second)
+	assert.Equal(t, time.Second, c.sleep)
+	assert.Equal(t, 60*time.Second, c.maxSleepTime)
+
+	// A zero initial interval is never clamped by either option, so it would yield a
+	// zero-delay retry loop -- callers must reject it before building the options.
+	c = effective(0, 60*time.Second)
+	assert.Equal(t, time.Duration(0), c.sleep)
+
+	// Sleep runs first and raises maxSleepTime to 2*initial, so a configured max
+	// below that floor is not a hard cap.
+	c = effective(60*time.Second, 60*time.Second)
+	assert.Equal(t, 120*time.Second, c.maxSleepTime)
 }


### PR DESCRIPTION
Unified batch backport to 2.6 (one CP PR instead of two, to reduce CI load). One commit per master PR, cherry-picked in master merge order.

pr: #51575
pr: #51823
issue: #51574
issue: #51824

Supersedes closed per-PR CP PRs: #52412, #52428 (identical resolved content, verified line-by-line against each master PR diff).

## Included enhancements (cherry-pick order)

1. #51575 — enforce row-count invariant for semantic highlight inputs (guards an out-of-range on nullable/dynamic text fields). Clean pick, no adaptation.
2. #51823 — configurable backoff for import write retry. 2.6 adaptation: test imports normalized to `pkg/v2` (unused master-only imports dropped); paramtable formatter warns use 2.6's `log.Warn`.

## Verification

- [x] Each commit's changed lines verified identical to the individually-reviewed CP commits (which were line-level compared against their master PR diffs)
- [x] No conflict markers
- [ ] make static-check (skipped by cherry-pick workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
