### PR TITLE
test: [cp3.0] make E2E cases compatible with small segment boundaries

### DIFF
--- a/tests/go_client/testcases/groupby_search_test.go
+++ b/tests/go_client/testcases/groupby_search_test.go
@@ -86,6 +86,36 @@ func prepareDataForGroupBySearch(t *testing.T, loopInsert int, insertNi int, idx
 	return mc, ctx, schema.CollectionName
 }
 
+func prepareDataForUnsupportedIndexGroupBySearch(t *testing.T, idx index.Index) (*base.MilvusClient, context.Context, string) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout*5)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+	collName := common.GenRandomString("TestSearchGroupByUnsupportedIndex", 6)
+	schema := entity.NewSchema().WithName(collName).
+		WithField(entity.NewField().WithName(common.DefaultInt64FieldName).WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
+		WithField(entity.NewField().WithName(common.DefaultVarcharFieldName).WithDataType(entity.FieldTypeVarChar).WithMaxLength(common.TestMaxLen)).
+		WithField(entity.NewField().WithName(common.DefaultFloatVecFieldName).WithDataType(entity.FieldTypeFloatVector).WithDim(common.DefaultDim))
+
+	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		common.CheckErr(t, mc.DropCollection(cleanupCtx, client.NewDropCollectionOption(collName)), true)
+	})
+
+	for i := 0; i < 3; i++ {
+		hp.CollPrepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), hp.TNewDataOption().TWithNb(1000).TWithStart(i*1000))
+	}
+	hp.CollPrepare.FlushData(ctx, t, mc, collName)
+	hp.CollPrepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema).TWithFieldIndex(map[string]index.Index{common.DefaultFloatVecFieldName: idx}))
+
+	idxTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, common.DefaultVarcharFieldName, index.NewAutoIndex(entity.L2)))
+	common.CheckErr(t, err, true)
+	common.CheckErr(t, idxTask.Await(ctx), true)
+	hp.CollPrepare.Load(ctx, t, mc, hp.NewLoadParams(collName))
+	return mc, ctx, collName
+}
+
 // create coll with all datatype -> build all supported index
 // -> search with WithGroupByField (int* + varchar + bool
 // -> verify every top passage is the top of whole group
@@ -454,7 +484,7 @@ func TestSearchGroupByUnsupportedIndex(t *testing.T) {
 	t.Parallel()
 	for _, idx := range genUnsupportedFloatGroupByIndex() {
 		t.Run(string(idx.IndexType()), func(t *testing.T) {
-			mc, ctx, collName := prepareDataForGroupBySearch(t, 3, 1000, idx, false)
+			mc, ctx, collName := prepareDataForUnsupportedIndexGroupBySearch(t, idx)
 			// groupBy search
 			queryVec := hp.GenSearchVectors(common.DefaultNq, common.DefaultDim, entity.FieldTypeFloatVector)
 			_, err := mc.Search(ctx, client.NewSearchOption(collName, common.DefaultLimit, queryVec).WithGroupByField(common.DefaultVarcharFieldName).WithANNSField(common.DefaultFloatVecFieldName))

--- a/tests/python_client/common/index_version.py
+++ b/tests/python_client/common/index_version.py
@@ -5,3 +5,13 @@ def get_resolved_scalar_index_version(nodes):
         if version is not None:
             return int(version)
     return None
+
+
+def get_segment_max_size(nodes):
+    """Return DataCoord's configured segment max size in MiB."""
+    for node in nodes:
+        configurations = node.get("infos", {}).get("system_configurations", {})
+        max_size = configurations.get("segment_max_size")
+        if max_size is not None:
+            return int(max_size)
+    return None

--- a/tests/python_client/common/milvus_sys.py
+++ b/tests/python_client/common/milvus_sys.py
@@ -1,7 +1,7 @@
 import json
 
 import ujson
-from common.index_version import get_resolved_scalar_index_version
+from common.index_version import get_resolved_scalar_index_version, get_segment_max_size
 from pymilvus import connections
 from pymilvus.grpc_gen import milvus_pb2 as milvus_types
 
@@ -12,9 +12,9 @@ sys_logs_req = ujson.dumps({"metric_type": "system_logs"})
 
 
 class MilvusSys:
-    def __init__(self, alias="default"):
+    def __init__(self, alias="default", client=None):
         self.alias = alias
-        self.handler = connections._fetch_handler(alias=self.alias)
+        self.handler = client._get_connection() if client is not None else connections._fetch_handler(alias=self.alias)
         if self.handler is None:
             raise Exception(f"Connection {alias} is disconnected or nonexistent")
 
@@ -71,6 +71,11 @@ class MilvusSys:
     def resolved_scalar_index_version(self):
         """Get DataCoord's effective scalar index engine version."""
         return get_resolved_scalar_index_version(self.nodes)
+
+    @property
+    def segment_max_size(self):
+        """Get DataCoord's configured segment max size in MiB."""
+        return get_segment_max_size(self.nodes)
 
     @property
     def query_nodes(self):

--- a/tests/python_client/common/test_index_version.py
+++ b/tests/python_client/common/test_index_version.py
@@ -1,6 +1,6 @@
 import unittest
 
-from common.index_version import get_resolved_scalar_index_version
+from common.index_version import get_resolved_scalar_index_version, get_segment_max_size
 
 
 class IndexVersionTestCase(unittest.TestCase):
@@ -30,6 +30,23 @@ class IndexVersionTestCase(unittest.TestCase):
         ]
 
         self.assertIsNone(get_resolved_scalar_index_version(nodes))
+
+    def test_get_segment_max_size(self):
+        nodes = [
+            {
+                "infos": {
+                    "type": "datacoord",
+                    "system_configurations": {"segment_max_size": "64"},
+                }
+            }
+        ]
+
+        self.assertEqual(64, get_segment_max_size(nodes))
+
+    def test_get_segment_max_size_returns_none_when_unavailable(self):
+        nodes = [{"infos": {"type": "querynode", "system_configurations": {}}}]
+
+        self.assertIsNone(get_segment_max_size(nodes))
 
 
 if __name__ == "__main__":

--- a/tests/python_client/milvus_client/test_milvus_client_force_merge.py
+++ b/tests/python_client/milvus_client/test_milvus_client_force_merge.py
@@ -21,6 +21,7 @@ from common import common_func as cf
 from common import common_type as ct
 from common.common_type import CaseLabel, CheckTasks
 from common.constants import *  # noqa: F403
+from common.milvus_sys import MilvusSys
 from pymilvus import DataType
 from utils.util_log import test_log as log
 from utils.util_pymilvus import *  # noqa: F403
@@ -44,7 +45,6 @@ default_string_field_name = ct.default_string_field_name
 # ForceMerge specific constants
 max_int64 = (1 << 63) - 1
 auto_target_size_mb = max_int64 // (1024 * 1024) + 1  # Triggers server auto target-size mode.
-default_max_size_mb = 1024  # Default segment max size in MB
 
 
 class TestMilvusClientForceMergeInvalid(TestMilvusClientV2Base):
@@ -79,18 +79,31 @@ class TestMilvusClientForceMergeInvalid(TestMilvusClientV2Base):
         )
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("target_size", [100, 512, 1000])
-    def test_force_merge_target_size_less_than_max_size(self, target_size):
+    @pytest.mark.parametrize(
+        "target_size_ratio",
+        [
+            pytest.param(0.1, id="low"),
+            pytest.param(0.5, id="half"),
+            pytest.param(0.99, id="near-max"),
+        ],
+    )
+    def test_force_merge_target_size_less_than_max_size(self, target_size_ratio):
         """
         target: test ForceMerge with target_size less than config maxSize
-        method: create collection, call compact with target_size < 1024 MB
+        method: read the server maxSize and call compact with a strictly smaller target_size
         expected: Raise exception
         """
         client = self._client()
         collection_name = cf.gen_unique_str(prefix)
         # 1. create collection
         self.create_collection(client, collection_name, default_dim)
-        # 2. compact with target_size less than maxSize
+        # 2. compact with target_size less than the active server maxSize
+        segment_max_size_mb = MilvusSys(client=client).segment_max_size
+        assert segment_max_size_mb is not None and segment_max_size_mb > 1
+        target_size = max(
+            1,
+            min(segment_max_size_mb - 1, int(segment_max_size_mb * target_size_ratio)),
+        )
         error = {ct.err_code: 1100, ct.err_msg: "targetSize"}
         self.compact(
             client,

--- a/tests/python_client/milvus_client/test_milvus_client_query.py
+++ b/tests/python_client/milvus_client/test_milvus_client_query.py
@@ -6350,7 +6350,7 @@ class TestQueryCount(TestMilvusClientV2Base):
         # 3. create index and load
         index_params = self.prepare_index_params(client)[0]
         index_params.add_index(
-            field_name=ct.default_float_vec_field_name, index_type="IVF_SQ8", metric_type="L2", params={"nlist": 64}
+            field_name=ct.default_float_vec_field_name, index_type="FLAT", metric_type="L2", params={}
         )
         self.create_index(client, collection_name, index_params)
         self.load_collection(client, collection_name)

--- a/tests/python_client/testcases/test_index.py
+++ b/tests/python_client/testcases/test_index.py
@@ -2789,10 +2789,15 @@ class TestBitmapIndex(TestcaseBase):
         # load collection
         self.collection_wrap.load()
 
-        # prepare 3k data (> 1024 triggering index building)
-        self.collection_wrap.insert(
-            data=cf.gen_values(self.collection_wrap.schema, nb=nb), check_task=CheckTasks.check_insert_result
-        )
+        # prepare 3k data (> 1024 triggering index building). Keep each insert
+        # below small segment boundaries while preserving the total row count.
+        insert_batch_size = 500
+        for start_id in range(0, nb, insert_batch_size):
+            batch_size = min(insert_batch_size, nb - start_id)
+            self.collection_wrap.insert(
+                data=cf.gen_values(self.collection_wrap.schema, nb=batch_size, start_id=start_id),
+                check_task=CheckTasks.check_insert_result,
+            )
 
         # check no indexed segments
         res, _ = self.utility_wrap.get_query_segment_info(collection_name=collection_name)


### PR DESCRIPTION
Cherry-pick from master
pr: #52280

## What this PR does

Backport the E2E compatibility fixes for Milvus deployments that use small segment boundaries.

- Read DataCoord's effective `segment_max_size` before generating invalid ForceMerge targets.
- Insert bitmap test data in 500-row batches while preserving the original 3,000-row scenario.
- Use FLAT/L2 for the JSON expression correctness test so ANN recall does not affect its assertion.
- Build a real IVF_PQ index on a minimal Go test schema for unsupported group-by coverage.
- Adapt the segment-size configuration helper to the `3.0` branch structure and cover it with unit tests.

issue: #52278
issue: #52279

## Test plan

- [x] `ruff check` on all changed Python files
- [x] `ruff format --check` on all changed Python files
- [x] Python 3.12 bytecode compilation on all changed Python files
- [x] `common/test_index_version.py`: 4 tests passed with Python 3.12
- [x] `gofumpt` and `gci diff` on the changed Go file
- [x] Go test package compilation with `-tags dynamic,test -gcflags="all=-N -l"`
- [x] `git diff --check`
- [ ] Target E2E cases: delegated to PR CI (no local Milvus service on `127.0.0.1:19530`)
