### PR TITLE
fix: [3.0] enforce partition statistics privilege (#52248)

### DIFF
--- a/client/milvusclient/mock_milvus_server_test.go
+++ b/client/milvusclient/mock_milvus_server_test.go
@@ -6,8 +6,11 @@ import (
 	context "context"
 
 	commonpb "github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+
 	federpb "github.com/milvus-io/milvus-proto/go-api/v3/federpb"
+
 	milvuspb "github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -1559,6 +1562,65 @@ func (_c *MilvusServiceServer_CreateIndex_Call) RunAndReturn(run func(context.Co
 	return _c
 }
 
+// CreateNamespace provides a mock function with given fields: _a0, _a1
+func (_m *MilvusServiceServer) CreateNamespace(_a0 context.Context, _a1 *milvuspb.CreateNamespaceRequest) (*milvuspb.CreateNamespaceResponse, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateNamespace")
+	}
+
+	var r0 *milvuspb.CreateNamespaceResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.CreateNamespaceRequest) (*milvuspb.CreateNamespaceResponse, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.CreateNamespaceRequest) *milvuspb.CreateNamespaceResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*milvuspb.CreateNamespaceResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.CreateNamespaceRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MilvusServiceServer_CreateNamespace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateNamespace'
+type MilvusServiceServer_CreateNamespace_Call struct {
+	*mock.Call
+}
+
+// CreateNamespace is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *milvuspb.CreateNamespaceRequest
+func (_e *MilvusServiceServer_Expecter) CreateNamespace(_a0 interface{}, _a1 interface{}) *MilvusServiceServer_CreateNamespace_Call {
+	return &MilvusServiceServer_CreateNamespace_Call{Call: _e.mock.On("CreateNamespace", _a0, _a1)}
+}
+
+func (_c *MilvusServiceServer_CreateNamespace_Call) Run(run func(_a0 context.Context, _a1 *milvuspb.CreateNamespaceRequest)) *MilvusServiceServer_CreateNamespace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.CreateNamespaceRequest))
+	})
+	return _c
+}
+
+func (_c *MilvusServiceServer_CreateNamespace_Call) Return(_a0 *milvuspb.CreateNamespaceResponse, _a1 error) *MilvusServiceServer_CreateNamespace_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MilvusServiceServer_CreateNamespace_Call) RunAndReturn(run func(context.Context, *milvuspb.CreateNamespaceRequest) (*milvuspb.CreateNamespaceResponse, error)) *MilvusServiceServer_CreateNamespace_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreatePartition provides a mock function with given fields: _a0, _a1
 func (_m *MilvusServiceServer) CreatePartition(_a0 context.Context, _a1 *milvuspb.CreatePartitionRequest) (*commonpb.Status, error) {
 	ret := _m.Called(_a0, _a1)
@@ -2372,6 +2434,124 @@ func (_c *MilvusServiceServer_DescribeIndex_Call) RunAndReturn(run func(context.
 	return _c
 }
 
+// DescribeNamespace provides a mock function with given fields: _a0, _a1
+func (_m *MilvusServiceServer) DescribeNamespace(_a0 context.Context, _a1 *milvuspb.DescribeNamespaceRequest) (*milvuspb.DescribeNamespaceResponse, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DescribeNamespace")
+	}
+
+	var r0 *milvuspb.DescribeNamespaceResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.DescribeNamespaceRequest) (*milvuspb.DescribeNamespaceResponse, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.DescribeNamespaceRequest) *milvuspb.DescribeNamespaceResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*milvuspb.DescribeNamespaceResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.DescribeNamespaceRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MilvusServiceServer_DescribeNamespace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DescribeNamespace'
+type MilvusServiceServer_DescribeNamespace_Call struct {
+	*mock.Call
+}
+
+// DescribeNamespace is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *milvuspb.DescribeNamespaceRequest
+func (_e *MilvusServiceServer_Expecter) DescribeNamespace(_a0 interface{}, _a1 interface{}) *MilvusServiceServer_DescribeNamespace_Call {
+	return &MilvusServiceServer_DescribeNamespace_Call{Call: _e.mock.On("DescribeNamespace", _a0, _a1)}
+}
+
+func (_c *MilvusServiceServer_DescribeNamespace_Call) Run(run func(_a0 context.Context, _a1 *milvuspb.DescribeNamespaceRequest)) *MilvusServiceServer_DescribeNamespace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.DescribeNamespaceRequest))
+	})
+	return _c
+}
+
+func (_c *MilvusServiceServer_DescribeNamespace_Call) Return(_a0 *milvuspb.DescribeNamespaceResponse, _a1 error) *MilvusServiceServer_DescribeNamespace_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MilvusServiceServer_DescribeNamespace_Call) RunAndReturn(run func(context.Context, *milvuspb.DescribeNamespaceRequest) (*milvuspb.DescribeNamespaceResponse, error)) *MilvusServiceServer_DescribeNamespace_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DescribePrewarmTask provides a mock function with given fields: _a0, _a1
+func (_m *MilvusServiceServer) DescribePrewarmTask(_a0 context.Context, _a1 *milvuspb.DescribePrewarmTaskRequest) (*milvuspb.DescribePrewarmTaskResponse, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DescribePrewarmTask")
+	}
+
+	var r0 *milvuspb.DescribePrewarmTaskResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.DescribePrewarmTaskRequest) (*milvuspb.DescribePrewarmTaskResponse, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.DescribePrewarmTaskRequest) *milvuspb.DescribePrewarmTaskResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*milvuspb.DescribePrewarmTaskResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.DescribePrewarmTaskRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MilvusServiceServer_DescribePrewarmTask_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DescribePrewarmTask'
+type MilvusServiceServer_DescribePrewarmTask_Call struct {
+	*mock.Call
+}
+
+// DescribePrewarmTask is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *milvuspb.DescribePrewarmTaskRequest
+func (_e *MilvusServiceServer_Expecter) DescribePrewarmTask(_a0 interface{}, _a1 interface{}) *MilvusServiceServer_DescribePrewarmTask_Call {
+	return &MilvusServiceServer_DescribePrewarmTask_Call{Call: _e.mock.On("DescribePrewarmTask", _a0, _a1)}
+}
+
+func (_c *MilvusServiceServer_DescribePrewarmTask_Call) Run(run func(_a0 context.Context, _a1 *milvuspb.DescribePrewarmTaskRequest)) *MilvusServiceServer_DescribePrewarmTask_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.DescribePrewarmTaskRequest))
+	})
+	return _c
+}
+
+func (_c *MilvusServiceServer_DescribePrewarmTask_Call) Return(_a0 *milvuspb.DescribePrewarmTaskResponse, _a1 error) *MilvusServiceServer_DescribePrewarmTask_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MilvusServiceServer_DescribePrewarmTask_Call) RunAndReturn(run func(context.Context, *milvuspb.DescribePrewarmTaskRequest) (*milvuspb.DescribePrewarmTaskResponse, error)) *MilvusServiceServer_DescribePrewarmTask_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DescribeResourceGroup provides a mock function with given fields: _a0, _a1
 func (_m *MilvusServiceServer) DescribeResourceGroup(_a0 context.Context, _a1 *milvuspb.DescribeResourceGroupRequest) (*milvuspb.DescribeResourceGroupResponse, error) {
 	ret := _m.Called(_a0, _a1)
@@ -2840,6 +3020,65 @@ func (_c *MilvusServiceServer_DropIndex_Call) Return(_a0 *commonpb.Status, _a1 e
 }
 
 func (_c *MilvusServiceServer_DropIndex_Call) RunAndReturn(run func(context.Context, *milvuspb.DropIndexRequest) (*commonpb.Status, error)) *MilvusServiceServer_DropIndex_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DropNamespace provides a mock function with given fields: _a0, _a1
+func (_m *MilvusServiceServer) DropNamespace(_a0 context.Context, _a1 *milvuspb.DropNamespaceRequest) (*milvuspb.DropNamespaceResponse, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DropNamespace")
+	}
+
+	var r0 *milvuspb.DropNamespaceResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.DropNamespaceRequest) (*milvuspb.DropNamespaceResponse, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.DropNamespaceRequest) *milvuspb.DropNamespaceResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*milvuspb.DropNamespaceResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.DropNamespaceRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MilvusServiceServer_DropNamespace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DropNamespace'
+type MilvusServiceServer_DropNamespace_Call struct {
+	*mock.Call
+}
+
+// DropNamespace is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *milvuspb.DropNamespaceRequest
+func (_e *MilvusServiceServer_Expecter) DropNamespace(_a0 interface{}, _a1 interface{}) *MilvusServiceServer_DropNamespace_Call {
+	return &MilvusServiceServer_DropNamespace_Call{Call: _e.mock.On("DropNamespace", _a0, _a1)}
+}
+
+func (_c *MilvusServiceServer_DropNamespace_Call) Run(run func(_a0 context.Context, _a1 *milvuspb.DropNamespaceRequest)) *MilvusServiceServer_DropNamespace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.DropNamespaceRequest))
+	})
+	return _c
+}
+
+func (_c *MilvusServiceServer_DropNamespace_Call) Return(_a0 *milvuspb.DropNamespaceResponse, _a1 error) *MilvusServiceServer_DropNamespace_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MilvusServiceServer_DropNamespace_Call) RunAndReturn(run func(context.Context, *milvuspb.DropNamespaceRequest) (*milvuspb.DropNamespaceResponse, error)) *MilvusServiceServer_DropNamespace_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -4248,6 +4487,65 @@ func (_c *MilvusServiceServer_GetMetrics_Call) RunAndReturn(run func(context.Con
 	return _c
 }
 
+// GetNamespaceStats provides a mock function with given fields: _a0, _a1
+func (_m *MilvusServiceServer) GetNamespaceStats(_a0 context.Context, _a1 *milvuspb.GetNamespaceStatsRequest) (*milvuspb.GetNamespaceStatsResponse, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNamespaceStats")
+	}
+
+	var r0 *milvuspb.GetNamespaceStatsResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.GetNamespaceStatsRequest) (*milvuspb.GetNamespaceStatsResponse, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.GetNamespaceStatsRequest) *milvuspb.GetNamespaceStatsResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*milvuspb.GetNamespaceStatsResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.GetNamespaceStatsRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MilvusServiceServer_GetNamespaceStats_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetNamespaceStats'
+type MilvusServiceServer_GetNamespaceStats_Call struct {
+	*mock.Call
+}
+
+// GetNamespaceStats is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *milvuspb.GetNamespaceStatsRequest
+func (_e *MilvusServiceServer_Expecter) GetNamespaceStats(_a0 interface{}, _a1 interface{}) *MilvusServiceServer_GetNamespaceStats_Call {
+	return &MilvusServiceServer_GetNamespaceStats_Call{Call: _e.mock.On("GetNamespaceStats", _a0, _a1)}
+}
+
+func (_c *MilvusServiceServer_GetNamespaceStats_Call) Run(run func(_a0 context.Context, _a1 *milvuspb.GetNamespaceStatsRequest)) *MilvusServiceServer_GetNamespaceStats_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.GetNamespaceStatsRequest))
+	})
+	return _c
+}
+
+func (_c *MilvusServiceServer_GetNamespaceStats_Call) Return(_a0 *milvuspb.GetNamespaceStatsResponse, _a1 error) *MilvusServiceServer_GetNamespaceStats_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MilvusServiceServer_GetNamespaceStats_Call) RunAndReturn(run func(context.Context, *milvuspb.GetNamespaceStatsRequest) (*milvuspb.GetNamespaceStatsResponse, error)) *MilvusServiceServer_GetNamespaceStats_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetPartitionStatistics provides a mock function with given fields: _a0, _a1
 func (_m *MilvusServiceServer) GetPartitionStatistics(_a0 context.Context, _a1 *milvuspb.GetPartitionStatisticsRequest) (*milvuspb.GetPartitionStatisticsResponse, error) {
 	ret := _m.Called(_a0, _a1)
@@ -4897,6 +5195,65 @@ func (_c *MilvusServiceServer_HasCollection_Call) RunAndReturn(run func(context.
 	return _c
 }
 
+// HasNamespace provides a mock function with given fields: _a0, _a1
+func (_m *MilvusServiceServer) HasNamespace(_a0 context.Context, _a1 *milvuspb.HasNamespaceRequest) (*milvuspb.HasNamespaceResponse, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HasNamespace")
+	}
+
+	var r0 *milvuspb.HasNamespaceResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.HasNamespaceRequest) (*milvuspb.HasNamespaceResponse, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.HasNamespaceRequest) *milvuspb.HasNamespaceResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*milvuspb.HasNamespaceResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.HasNamespaceRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MilvusServiceServer_HasNamespace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HasNamespace'
+type MilvusServiceServer_HasNamespace_Call struct {
+	*mock.Call
+}
+
+// HasNamespace is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *milvuspb.HasNamespaceRequest
+func (_e *MilvusServiceServer_Expecter) HasNamespace(_a0 interface{}, _a1 interface{}) *MilvusServiceServer_HasNamespace_Call {
+	return &MilvusServiceServer_HasNamespace_Call{Call: _e.mock.On("HasNamespace", _a0, _a1)}
+}
+
+func (_c *MilvusServiceServer_HasNamespace_Call) Run(run func(_a0 context.Context, _a1 *milvuspb.HasNamespaceRequest)) *MilvusServiceServer_HasNamespace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.HasNamespaceRequest))
+	})
+	return _c
+}
+
+func (_c *MilvusServiceServer_HasNamespace_Call) Return(_a0 *milvuspb.HasNamespaceResponse, _a1 error) *MilvusServiceServer_HasNamespace_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MilvusServiceServer_HasNamespace_Call) RunAndReturn(run func(context.Context, *milvuspb.HasNamespaceRequest) (*milvuspb.HasNamespaceResponse, error)) *MilvusServiceServer_HasNamespace_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // HasPartition provides a mock function with given fields: _a0, _a1
 func (_m *MilvusServiceServer) HasPartition(_a0 context.Context, _a1 *milvuspb.HasPartitionRequest) (*milvuspb.BoolResponse, error) {
 	ret := _m.Called(_a0, _a1)
@@ -5483,6 +5840,65 @@ func (_c *MilvusServiceServer_ListIndexedSegment_Call) Return(_a0 *federpb.ListI
 }
 
 func (_c *MilvusServiceServer_ListIndexedSegment_Call) RunAndReturn(run func(context.Context, *federpb.ListIndexedSegmentRequest) (*federpb.ListIndexedSegmentResponse, error)) *MilvusServiceServer_ListIndexedSegment_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListNamespaces provides a mock function with given fields: _a0, _a1
+func (_m *MilvusServiceServer) ListNamespaces(_a0 context.Context, _a1 *milvuspb.ListNamespacesRequest) (*milvuspb.ListNamespacesResponse, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListNamespaces")
+	}
+
+	var r0 *milvuspb.ListNamespacesResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.ListNamespacesRequest) (*milvuspb.ListNamespacesResponse, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.ListNamespacesRequest) *milvuspb.ListNamespacesResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*milvuspb.ListNamespacesResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.ListNamespacesRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MilvusServiceServer_ListNamespaces_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListNamespaces'
+type MilvusServiceServer_ListNamespaces_Call struct {
+	*mock.Call
+}
+
+// ListNamespaces is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *milvuspb.ListNamespacesRequest
+func (_e *MilvusServiceServer_Expecter) ListNamespaces(_a0 interface{}, _a1 interface{}) *MilvusServiceServer_ListNamespaces_Call {
+	return &MilvusServiceServer_ListNamespaces_Call{Call: _e.mock.On("ListNamespaces", _a0, _a1)}
+}
+
+func (_c *MilvusServiceServer_ListNamespaces_Call) Run(run func(_a0 context.Context, _a1 *milvuspb.ListNamespacesRequest)) *MilvusServiceServer_ListNamespaces_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.ListNamespacesRequest))
+	})
+	return _c
+}
+
+func (_c *MilvusServiceServer_ListNamespaces_Call) Return(_a0 *milvuspb.ListNamespacesResponse, _a1 error) *MilvusServiceServer_ListNamespaces_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MilvusServiceServer_ListNamespaces_Call) RunAndReturn(run func(context.Context, *milvuspb.ListNamespacesRequest) (*milvuspb.ListNamespacesResponse, error)) *MilvusServiceServer_ListNamespaces_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -6427,6 +6843,65 @@ func (_c *MilvusServiceServer_PinSnapshotData_Call) Return(_a0 *milvuspb.PinSnap
 }
 
 func (_c *MilvusServiceServer_PinSnapshotData_Call) RunAndReturn(run func(context.Context, *milvuspb.PinSnapshotDataRequest) (*milvuspb.PinSnapshotDataResponse, error)) *MilvusServiceServer_PinSnapshotData_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Prewarm provides a mock function with given fields: _a0, _a1
+func (_m *MilvusServiceServer) Prewarm(_a0 context.Context, _a1 *milvuspb.PrewarmRequest) (*milvuspb.PrewarmResponse, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Prewarm")
+	}
+
+	var r0 *milvuspb.PrewarmResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.PrewarmRequest) (*milvuspb.PrewarmResponse, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.PrewarmRequest) *milvuspb.PrewarmResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*milvuspb.PrewarmResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.PrewarmRequest) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MilvusServiceServer_Prewarm_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Prewarm'
+type MilvusServiceServer_Prewarm_Call struct {
+	*mock.Call
+}
+
+// Prewarm is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *milvuspb.PrewarmRequest
+func (_e *MilvusServiceServer_Expecter) Prewarm(_a0 interface{}, _a1 interface{}) *MilvusServiceServer_Prewarm_Call {
+	return &MilvusServiceServer_Prewarm_Call{Call: _e.mock.On("Prewarm", _a0, _a1)}
+}
+
+func (_c *MilvusServiceServer_Prewarm_Call) Run(run func(_a0 context.Context, _a1 *milvuspb.PrewarmRequest)) *MilvusServiceServer_Prewarm_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.PrewarmRequest))
+	})
+	return _c
+}
+
+func (_c *MilvusServiceServer_Prewarm_Call) Return(_a0 *milvuspb.PrewarmResponse, _a1 error) *MilvusServiceServer_Prewarm_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MilvusServiceServer_Prewarm_Call) RunAndReturn(run func(context.Context, *milvuspb.PrewarmRequest) (*milvuspb.PrewarmResponse, error)) *MilvusServiceServer_Prewarm_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -7970,8 +8445,7 @@ func (_c *MilvusServiceServer_Upsert_Call) RunAndReturn(run func(context.Context
 func NewMilvusServiceServer(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MilvusServiceServer {
+}) *MilvusServiceServer {
 	mock := &MilvusServiceServer{}
 	mock.Mock.Test(t)
 

--- a/internal/mocks/mock_proxy.go
+++ b/internal/mocks/mock_proxy.go
@@ -5,10 +5,11 @@ package mocks
 import (
 	context "context"
 
+	mock "github.com/stretchr/testify/mock"
+
 	commonpb "github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	federpb "github.com/milvus-io/milvus-proto/go-api/v3/federpb"
 	milvuspb "github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
-	mock "github.com/stretchr/testify/mock"
 
 	types "github.com/milvus-io/milvus/internal/types"
 	datapb "github.com/milvus-io/milvus/pkg/v3/proto/datapb"

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -1139,6 +1139,9 @@ func TestVerifyAPIKeyDoesNotExposeSecret(t *testing.T) {
 	logs := captureProxyLogs(t)
 	rawToken := "API_KEY_SENTINEL_DO_NOT_LOG"
 	encodedToken := crypto.Base64Encode(rawToken)
+	// initHook() installs the default hook, so consume it before installing the
+	// mock, otherwise the mock is clobbered on the first GetHook() call.
+	hookutil.InitOnceHook()
 	hookutil.SetMockAPIHook("", errors.New("API key provider unavailable"))
 	t.Cleanup(func() {
 		hookutil.SetTestHook(hookutil.DefaultHook{})
@@ -1148,11 +1151,7 @@ func TestVerifyAPIKeyDoesNotExposeSecret(t *testing.T) {
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), rawToken)
 
-	oldMetaCache := globalMetaCache
-	globalMetaCache = &MetaCache{}
-	t.Cleanup(func() {
-		globalMetaCache = oldMetaCache
-	})
+	metaCache := InitEmptyMetaCacheForTest()
 	require.NoError(t, paramtable.Get().Save(Params.CommonCfg.AuthorizationEnabled.Key, "true"))
 	t.Cleanup(func() {
 		paramtable.Get().Reset(Params.CommonCfg.AuthorizationEnabled.Key)
@@ -1161,7 +1160,7 @@ func TestVerifyAPIKeyDoesNotExposeSecret(t *testing.T) {
 		util.HeaderAuthorize,
 		encodedToken,
 	))
-	_, err = AuthenticationInterceptor(ctx)
+	_, err = AuthenticationInterceptorWithMetaCache(func() Cache { return metaCache })(ctx)
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), rawToken)
 	assert.NotContains(t, err.Error(), encodedToken)


### PR DESCRIPTION
Cherry-pick from master
pr: https://github.com/milvus-io/milvus/pull/52248
Related to https://github.com/milvus-io/milvus/issues/52251

Release-branch adaptation:
Resolved the proto bump to the 3.0-lineage github.com/milvus-io/milvus-proto/go-api/v3 v3.0.1-0.20260806084013-cef495bd49af, regenerated the Go client MilvusServiceServer test mock for that interface, and kept pkg/util/fastpb absent because it is not present on the 3.0 branch.
Local Gate A: make fmt passed; targeted client/internal-mocks/tests-go-client/pkg typechecks passed. make static-check and proxy package execution are blocked locally by a C++ artifact/header mismatch in symlinked internal/core output unrelated to this cherry-pick.
