### PR TITLE
fix: [2.6] enforce partition statistics privilege (#52248)

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/cockroachdb/errors v1.9.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.22
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.23-0.20260806082413-a76db6514428
 	github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251201120310-af64f2acba38
 	github.com/quasilyte/go-ruleguard/dsl v0.3.23
 	github.com/samber/lo v1.27.0

--- a/client/go.sum
+++ b/client/go.sum
@@ -333,6 +333,8 @@ github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/le
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.22 h1:CgX0hk+8ayjAqZYPlOBL/S8IDoTunKReM7Attsr70BY=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.22/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.23-0.20260806082413-a76db6514428 h1:LMJf6KyU/ZuIL4DnTh5AqXKjwLgILfBpMcVi6rprpqQ=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.23-0.20260806082413-a76db6514428/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251201120310-af64f2acba38 h1:75pdNz8Ln9jdBxlkUQRJu+P8tz4q+G48XAybS3O30FQ=
 github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251201120310-af64f2acba38/go.mod h1:ak5nlCCbtImG4/WWcI/csU5ht6EyF/9QQ/tmivMzF4c=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/klauspost/compress v1.18.0
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.22
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.23-0.20260806082413-a76db6514428
 	github.com/minio/minio-go/v7 v7.0.73
 	github.com/panjf2000/ants/v2 v2.11.3 // indirect
 	github.com/pingcap/log v1.1.1-0.20221015072633-39906604fb81 // indirect

--- a/go.sum
+++ b/go.sum
@@ -780,6 +780,8 @@ github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b h1:TfeY0NxYxZz
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b/go.mod h1:iwW+9cWfIzzDseEBCCeDSN5SD16Tidvy8cwQ7ZY8Qj4=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.22 h1:CgX0hk+8ayjAqZYPlOBL/S8IDoTunKReM7Attsr70BY=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.22/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.23-0.20260806082413-a76db6514428 h1:LMJf6KyU/ZuIL4DnTh5AqXKjwLgILfBpMcVi6rprpqQ=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.23-0.20260806082413-a76db6514428/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 h1:AMFGa4R4MiIpspGNG7Z948v4n35fFGB3RR3G/ry4FWs=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 h1:+n/aFZefKZp7spd8DFdX7uMikMLXX4oubIzJF4kv/wI=

--- a/internal/proxy/privilege_interceptor_test.go
+++ b/internal/proxy/privilege_interceptor_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
@@ -169,6 +172,78 @@ func TestPrivilegeInterceptor(t *testing.T) {
 		assert.Panics(t, func() {
 			privilege.GetPolicyModel("foo")
 		})
+	})
+}
+
+func TestPrivilegeInterceptorStatisticsRBAC(t *testing.T) {
+	paramtable.Init()
+	Params.Save(Params.CommonCfg.AuthorizationEnabled.Key, "true")
+	defer Params.Reset(Params.CommonCfg.AuthorizationEnabled.Key)
+	defer privilege.CleanPrivilegeCache()
+
+	const (
+		username       = "stats_user"
+		roleName       = "role_stats"
+		collectionName = "coll_stats"
+		partitionName  = "part_stats"
+	)
+
+	ctx := GetContext(context.Background(), username+":pwd")
+	client := &MockMixCoordClientInterface{}
+
+	initPolicy := func(policyInfos []string) {
+		client.listPolicy = func(ctx context.Context, in *internalpb.ListPolicyRequest) (*internalpb.ListPolicyResponse, error) {
+			return &internalpb.ListPolicyResponse{
+				Status:      merr.Success(),
+				PolicyInfos: policyInfos,
+				UserRoles: []string{
+					funcutil.EncodeUserRoleCache(username, roleName),
+				},
+			}, nil
+		}
+		require.NoError(t, InitMetaCache(ctx, client))
+	}
+
+	collectionReq := func() *milvuspb.GetCollectionStatisticsRequest {
+		return &milvuspb.GetCollectionStatisticsRequest{
+			DbName:         util.DefaultDBName,
+			CollectionName: collectionName,
+		}
+	}
+	partitionReq := func() *milvuspb.GetPartitionStatisticsRequest {
+		return &milvuspb.GetPartitionStatisticsRequest{
+			DbName:         util.DefaultDBName,
+			CollectionName: collectionName,
+			PartitionName:  partitionName,
+		}
+	}
+
+	assertDenied := func(t *testing.T, req interface{}) {
+		_, err := PrivilegeInterceptor(ctx, req)
+		require.Error(t, err)
+		assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	}
+	assertAllowed := func(t *testing.T, req interface{}) {
+		_, err := PrivilegeInterceptor(ctx, req)
+		assert.NoError(t, err)
+	}
+
+	t.Run("authenticated principal without GetStatistics is denied", func(t *testing.T) {
+		initPolicy([]string{
+			funcutil.PolicyForPrivilege(roleName, commonpb.ObjectType_Collection.String(), collectionName, commonpb.ObjectPrivilege_PrivilegeLoad.String(), util.DefaultDBName),
+		})
+
+		assertDenied(t, collectionReq())
+		assertDenied(t, partitionReq())
+	})
+
+	t.Run("GetStatistics grant allows statistics requests", func(t *testing.T) {
+		initPolicy([]string{
+			funcutil.PolicyForPrivilege(roleName, commonpb.ObjectType_Collection.String(), collectionName, commonpb.ObjectPrivilege_PrivilegeGetStatistics.String(), util.DefaultDBName),
+		})
+
+		assertAllowed(t, collectionReq())
+		assertAllowed(t, partitionReq())
 	})
 }
 

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/json-iterator/go v1.1.13-0.20220915233716-71ac16282d12
 	github.com/klauspost/compress v1.18.0
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.22
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.23-0.20260806082413-a76db6514428
 	github.com/minio/minio-go/v7 v7.0.73
 	github.com/panjf2000/ants/v2 v2.11.3
 	github.com/prometheus/client_golang v1.20.5

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -463,6 +463,8 @@ github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b h1:TfeY0NxYxZz
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b/go.mod h1:iwW+9cWfIzzDseEBCCeDSN5SD16Tidvy8cwQ7ZY8Qj4=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.22 h1:CgX0hk+8ayjAqZYPlOBL/S8IDoTunKReM7Attsr70BY=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.22/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.23-0.20260806082413-a76db6514428 h1:LMJf6KyU/ZuIL4DnTh5AqXKjwLgILfBpMcVi6rprpqQ=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.23-0.20260806082413-a76db6514428/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.73 h1:qr2vi96Qm7kZ4v7LLebjte+MQh621fFWnv93p12htEo=

--- a/tests/go_client/go.mod
+++ b/tests/go_client/go.mod
@@ -3,7 +3,7 @@ module github.com/milvus-io/milvus/tests/go_client
 go 1.25.8
 
 require (
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.22
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.23-0.20260806082413-a76db6514428
 	github.com/milvus-io/milvus/client/v2 v2.0.0-20241125024034-0b9edb62a92d
 	github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251202033909-b71a123d25ad
 	github.com/peterstace/simplefeatures v0.54.0

--- a/tests/go_client/go.sum
+++ b/tests/go_client/go.sum
@@ -335,6 +335,8 @@ github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/le
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.22 h1:CgX0hk+8ayjAqZYPlOBL/S8IDoTunKReM7Attsr70BY=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.22/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.23-0.20260806082413-a76db6514428 h1:LMJf6KyU/ZuIL4DnTh5AqXKjwLgILfBpMcVi6rprpqQ=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.23-0.20260806082413-a76db6514428/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251202033909-b71a123d25ad h1:pjSurtVnX3VLLdjUg3HKMpILDv/ZEfSI1rZLsTd+h1U=
 github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251202033909-b71a123d25ad/go.mod h1:ak5nlCCbtImG4/WWcI/csU5ht6EyF/9QQ/tmivMzF4c=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=


### PR DESCRIPTION
Cherry-pick from master
pr: https://github.com/milvus-io/milvus/pull/52248
Related to https://github.com/milvus-io/milvus/issues/52251

Release-branch adaptation:
2.6 stays on `github.com/milvus-io/milvus-proto/go-api/v2`; this uses the 2.6 proto-branch pseudo-version `v2.6.23-0.20260806082413-a76db6514428` instead of the master `go-api/v3` bump. Local descriptor verification confirms both `GetCollectionStatisticsRequest` and `GetPartitionStatisticsRequest` carry `PrivilegeGetStatistics`; `make fmt`, client typecheck, and `pkg/util/funcutil` privilege-extension test passed. `make static-check` and proxy package build are blocked locally by symlinked C++ artifacts that do not match 2.6 headers in untouched cgo paths (`internal/storagev2/packed`, `internal/util/initcore`, `internal/util/analyzer/canalyzer`).
