### PR TITLE
fix: [cp3.0] pin Knowhere without nullable ID mapping

### DIFF
--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -14,9 +14,9 @@
 # Update KNOWHERE_VERSION for the first occurrence
 milvus_add_pkg_config("knowhere")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-# Includes zilliztech/knowhere#1761, which fixes COSINE/IP CalcDistByIDs
-# when all requested DiskANN vectors are cached.
-set( KNOWHERE_VERSION 6d0f7fe5 )
+# Pins the short zilliztech/knowhere#1761 commit without nullable ID mapping.
+# It retains the COSINE/IP CalcDistByIDs fix for fully cached DiskANN vectors.
+set( KNOWHERE_VERSION 6a3b7df1 )
 set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
 
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")


### PR DESCRIPTION
## What this PR does

Pin Knowhere to `6a3b7df16476cb958d35101844302b158955e141` on the `3.0` branch.

This short Knowhere commit is based before the nullable external ID mapping merge, while retaining the DiskANN `CalcDistByIDs` COSINE/INNER_PRODUCT conversion fix from zilliztech/knowhere#1761.

## Why

The previous pin `6d0f7fe5` includes nullable ID mapping through its parent history. This change temporarily removes that mapping integration without reverting the cached-vector distance fix or the Milvus-side compatibility changes already merged with #52457.

Issue: #52338
pr: #52467

## Verification

- `git diff --check` passed
- Knowhere `6a3b7df1` CPU Release + DiskANN + UT build passed
- Knowhere targeted DiskANN cached-vector regression passed: 1 test case / 8 assertions
- Full Milvus CMake configure was attempted locally but stopped before dependency resolution because `follyConfig.cmake` is not installed in the local environment
