### PR TITLE
fix: isolate advanced search pruning snapshots

### DIFF
--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -545,6 +545,15 @@ func (sd *shardDelegator) search(ctx context.Context, req *querypb.SearchRequest
 	return sd.executeSearchSubTasks(ctx, req, sealed, growing, sealedRowCount)
 }
 
+func cloneSnapshotItems(sealed []SnapshotItem) []SnapshotItem {
+	if len(sealed) == 0 {
+		return nil
+	}
+	cloned := make([]SnapshotItem, len(sealed))
+	copy(cloned, sealed)
+	return cloned
+}
+
 // getVectorFieldDim returns the dimension of the vector field with the given field ID.
 // Returns 0 if the field is not found or dim cannot be determined.
 func (sd *shardDelegator) getVectorFieldDim(fieldID int64) int64 {
@@ -668,7 +677,7 @@ func (sd *shardDelegator) Search(ctx context.Context, req *querypb.SearchRequest
 					searchReq.GetReq().MvccTimestamp = tSafe
 				}
 				searchReq.Req.CollectionTtlTimestamps = req.GetReq().GetCollectionTtlTimestamps()
-				results, err := sd.search(ctx, searchReq, sealed, growing, sealedRowCount)
+				results, err := sd.search(ctx, searchReq, cloneSnapshotItems(sealed), growing, sealedRowCount)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/querynodev2/delegator/segment_pruner_test.go
+++ b/internal/querynodev2/delegator/segment_pruner_test.go
@@ -659,6 +659,35 @@ func (sps *SegmentPrunerSuite) TestPruneSegmentsByVectorField() {
 	sps.Equal(int64(3), sps.sealedSegments[1].Segments[0].SegmentID)
 }
 
+func (sps *SegmentPrunerSuite) TestCloneSnapshotItemsIsolatesInPlacePruning() {
+	sps.SetupForClustering("age")
+	paramtable.Init()
+
+	base := make([]SnapshotItem, len(sps.sealedSegments))
+	copy(base, sps.sealedSegments)
+	pruned := cloneSnapshotItems(base)
+
+	schemaHelper, err := typeutil.CreateSchemaHelper(sps.schema)
+	sps.NoError(err)
+	planNode, err := planparserv2.CreateRetrievePlan(schemaHelper, "age==156", nil)
+	sps.NoError(err)
+	serializedPlan, err := proto.Marshal(planNode)
+	sps.NoError(err)
+	queryReq := &internalpb.RetrieveRequest{
+		QueryLabel:         "query",
+		SerializedExprPlan: serializedPlan,
+		PartitionIDs:       []UniqueID{sps.targetPartition},
+	}
+
+	PruneSegments(context.TODO(), sps.partitionStats, nil, queryReq, sps.schema, pruned,
+		PruneInfo{paramtable.Get().QueryNodeCfg.DefaultSegmentFilterRatio.GetAsFloat()})
+
+	sps.Equal(2, len(pruned[0].Segments))
+	sps.Equal(0, len(pruned[1].Segments))
+	sps.Equal(2, len(base[0].Segments))
+	sps.Equal(2, len(base[1].Segments))
+}
+
 func (sps *SegmentPrunerSuite) TestPruneSegmentsVariousIntTypes() {
 	paramtable.Init()
 	collectionName := "test_segment_prune"


### PR DESCRIPTION
issue: #52469

## What changed

Advanced search fans out sub-searches concurrently, but segment pruning mutates the provided sealed `[]SnapshotItem` in place. This PR passes each sub-search its own cloned snapshot view so one sub-request cannot prune the segment set used by another sibling request.

## Verification

- Proof-before-fix repro failed as expected: `TestSegmentPrunerSuite/TestSharedSnapshotItemsContaminateSiblingPruneRepro` showed sibling contamination (`expected: 2`, `actual: 0`).
- `GOWORK=off PKG_CONFIG_PATH=<local core pkgconfig> LD_LIBRARY_PATH=<local core lib> go test -tags dynamic,test -gcflags="all=-N -l" ./internal/querynodev2/delegator -run TestSegmentPrunerSuite/TestCloneSnapshotItemsIsolatesInPlacePruning -count=1`
- `GOWORK=off PKG_CONFIG_PATH=<local core pkgconfig> LD_LIBRARY_PATH=<local core lib> go test -tags dynamic,test -gcflags="all=-N -l" ./internal/querynodev2/delegator -count=1`
- `GOWORK=off PKG_CONFIG_PATH=<local core pkgconfig> LD_LIBRARY_PATH=<local core lib> make static-check`
