### PR TITLE
fix: enforce task timeout on channel, segment and leader operations

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -502,7 +502,7 @@ queryCoord:
   autoBalanceInterval: 3000 # the interval for triggerauto balance
   checkIndexInterval: 10000
   channelTaskTimeout: 120000 # 2 minutes
-  segmentTaskTimeout: 180000 # 3 minutes
+  segmentTaskTimeout: 300000 # 5 minutes
   distPullInterval: 500
   dispatchInterval: 500
   heartbeatAvailableInterval: 10000 # 10s, Only QueryNodes which fetched heartbeats within the duration are available

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -501,8 +501,8 @@ queryCoord:
   checkBalanceInterval: 300
   autoBalanceInterval: 3000 # the interval for triggerauto balance
   checkIndexInterval: 10000
-  channelTaskTimeout: 60000 # 1 minute
-  segmentTaskTimeout: 120000 # 2 minute
+  channelTaskTimeout: 300000 # 5 minutes
+  segmentTaskTimeout: 300000 # 5 minutes
   distPullInterval: 500
   dispatchInterval: 500
   heartbeatAvailableInterval: 10000 # 10s, Only QueryNodes which fetched heartbeats within the duration are available

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -501,8 +501,8 @@ queryCoord:
   checkBalanceInterval: 300
   autoBalanceInterval: 3000 # the interval for triggerauto balance
   checkIndexInterval: 10000
-  channelTaskTimeout: 300000 # 5 minutes
-  segmentTaskTimeout: 300000 # 5 minutes
+  channelTaskTimeout: 120000 # 2 minutes
+  segmentTaskTimeout: 120000 # 2 minutes
   distPullInterval: 500
   dispatchInterval: 500
   heartbeatAvailableInterval: 10000 # 10s, Only QueryNodes which fetched heartbeats within the duration are available

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -502,7 +502,7 @@ queryCoord:
   autoBalanceInterval: 3000 # the interval for triggerauto balance
   checkIndexInterval: 10000
   channelTaskTimeout: 120000 # 2 minutes
-  segmentTaskTimeout: 120000 # 2 minutes
+  segmentTaskTimeout: 180000 # 3 minutes
   distPullInterval: 500
   dispatchInterval: 500
   heartbeatAvailableInterval: 10000 # 10s, Only QueryNodes which fetched heartbeats within the duration are available

--- a/internal/compaction/common.go
+++ b/internal/compaction/common.go
@@ -93,7 +93,7 @@ func readDeltalogsV1(
 
 	for _, deltalog := range deltalogs {
 		for _, binlog := range deltalog.Binlogs {
-			reader, err := storage.NewDeltalogReader(pkType, []string{binlog.GetLogPath()}, option...)
+			reader, err := storage.NewDeltalogReader(ctx, pkType, []string{binlog.GetLogPath()}, option...)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -118,7 +118,7 @@ func readDeltalogsV2(
 	paths []string,
 	option ...storage.RwOption,
 ) ([]storage.PrimaryKey, []typeutil.Timestamp, error) {
-	reader, err := storage.NewDeltalogReader(pkType, paths,
+	reader, err := storage.NewDeltalogReader(ctx, pkType, paths,
 		append(option, storage.WithVersion(storage.StorageV3))...)
 	if err != nil {
 		return nil, nil, err

--- a/internal/datanode/external/milvus_table_deltalog.go
+++ b/internal/datanode/external/milvus_table_deltalog.go
@@ -587,6 +587,7 @@ func (t *RefreshExternalCollectionTask) newMilvusTableSourceDeltalogReader(
 ) (storage.RecordReader, error) {
 	if packed.IsMilvusTableStorageV3DeltalogPath(ref.sourcePath) {
 		return storage.NewDeltalogReader(
+			ctx,
 			sourcePKType,
 			[]string{ref.sourcePath},
 			storage.WithVersion(storage.StorageV3),
@@ -598,6 +599,7 @@ func (t *RefreshExternalCollectionTask) newMilvusTableSourceDeltalogReader(
 		return nil, err
 	}
 	return storage.NewDeltalogReader(
+		ctx,
 		sourcePKType,
 		[]string{ref.sourcePath},
 		storage.WithVersion(storage.StorageV1),

--- a/internal/datanode/external/milvus_table_deltalog_test.go
+++ b/internal/datanode/external/milvus_table_deltalog_test.go
@@ -1313,6 +1313,7 @@ func writeDeltalog(
 func readInt64Deltalog(t *testing.T, storageConfig *indexpb.StorageConfig, path string) ([]int64, []int64) {
 	t.Helper()
 	reader, err := storage.NewDeltalogReader(
+		context.Background(),
 		schemapb.DataType_Int64,
 		[]string{path},
 		storage.WithVersion(storage.StorageV3),

--- a/internal/datanode/external/milvus_table_deltalog_test.go
+++ b/internal/datanode/external/milvus_table_deltalog_test.go
@@ -509,7 +509,7 @@ func (s *RefreshExternalCollectionTaskSuite) TestCreateManifestForSegment_Milvus
 	)
 	s.Require().NoError(err)
 	mockDeltalogReader := mockey.Mock(storage.NewDeltalogReader).
-		To(func(pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
+		To(func(_ context.Context, pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
 			s.Equal(schemapb.DataType_Int64, pkType)
 			s.Equal([]string{sourceDeltalogPath}, paths)
 			return &fakeMilvusTableDeltalogReader{records: []storage.Record{record}}, nil
@@ -1069,7 +1069,7 @@ func (s *RefreshExternalCollectionTaskSuite) TestLoadMilvusTableSourceDeltalogDe
 		s.Require().NoError(err)
 		reader := &fakeMilvusTableDeltalogReader{records: []storage.Record{record}}
 		mockReader := mockey.Mock(storage.NewDeltalogReader).
-			To(func(pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
+			To(func(_ context.Context, pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
 				s.Equal(schemapb.DataType_Int64, pkType)
 				s.Equal([]string{ref.sourcePath}, paths)
 				return reader, nil
@@ -1095,7 +1095,7 @@ func (s *RefreshExternalCollectionTaskSuite) TestLoadMilvusTableSourceDeltalogDe
 		legacyRef := milvusTableDeltalogRef{sourcePath: "files/delta_log/1/2/3/10", logID: 10, numEntries: 2}
 		reader := &fakeMilvusTableDeltalogReader{}
 		mockReader := mockey.Mock(storage.NewDeltalogReader).
-			To(func(pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
+			To(func(_ context.Context, pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
 				s.Equal(schemapb.DataType_Int64, pkType)
 				s.Equal([]string{legacyRef.sourcePath}, paths)
 				return reader, nil

--- a/internal/querycoordv2/checkers/channel_checker.go
+++ b/internal/querycoordv2/checkers/channel_checker.go
@@ -288,6 +288,10 @@ func (c *ChannelChecker) createChannelLoadTask(ctx context.Context, channels []*
 		plans[i].Replica = replica
 	}
 
+	// TODO: same known limitation as SegmentChecker.createSegmentLoadTasks --
+	// a channel whose real watch time (L0/growing backlog, seek distance)
+	// consistently exceeds ChannelTaskTimeout never converges: killed and
+	// rebuilt with the same budget every check tick, no backoff or retry cap.
 	return balance.CreateChannelTasksFromPlans(ctx, c.ID(), Params.QueryCoordCfg.ChannelTaskTimeout.GetAsDuration(time.Millisecond), plans)
 }
 

--- a/internal/querycoordv2/checkers/leader_checker.go
+++ b/internal/querycoordv2/checkers/leader_checker.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
+	. "github.com/milvus-io/milvus/internal/querycoordv2/params"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
@@ -137,6 +138,7 @@ func (c *LeaderChecker) findNeedSyncPartitionStats(ctx context.Context, replica 
 
 		t := task.NewLeaderPartStatsTask(
 			ctx,
+			Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond),
 			c.ID(),
 			leaderView.CollectionID,
 			replica,
@@ -185,6 +187,7 @@ func (c *LeaderChecker) findNeedLoadedSegments(ctx context.Context, replica *met
 			action := task.NewLeaderAction(leaderView.ID, s.Node, task.ActionTypeGrow, s.GetInsertChannel(), s.GetID(), time.Now().UnixNano())
 			t := task.NewLeaderSegmentTask(
 				ctx,
+				Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond),
 				c.ID(),
 				s.GetCollectionID(),
 				replica,
@@ -230,6 +233,7 @@ func (c *LeaderChecker) findNeedRemovedSegments(ctx context.Context, replica *me
 		action := task.NewLeaderAction(leaderView.ID, leaderView.ID, task.ActionTypeReduce, leaderView.Channel, sid, 0)
 		t := task.NewLeaderSegmentTask(
 			ctx,
+			Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond),
 			c.ID(),
 			leaderView.CollectionID,
 			replica,

--- a/internal/querycoordv2/checkers/segment_checker.go
+++ b/internal/querycoordv2/checkers/segment_checker.go
@@ -527,6 +527,13 @@ func (c *SegmentChecker) createSegmentLoadTasks(ctx context.Context, segments []
 		plans = append(plans, shardPlans...)
 	}
 
+	// TODO: this assumes a single segment always finishes loading within
+	// SegmentTaskTimeout (3min default). If a segment's real load time is
+	// consistently longer (large disk-index segment, throttled cold storage),
+	// the task is killed by its deadline every round and rebuilt here with
+	// the same budget on the next check tick -- it never converges. Needs
+	// either backoff/a retry cap on repeated DeadlineExceeded rebuilds, or a
+	// no-progress timeout instead of a flat per-task wall-clock budget.
 	return balance.CreateSegmentTasksFromPlans(ctx, c.ID(), Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond), plans)
 }
 

--- a/internal/querycoordv2/checkers/segment_checker.go
+++ b/internal/querycoordv2/checkers/segment_checker.go
@@ -528,7 +528,7 @@ func (c *SegmentChecker) createSegmentLoadTasks(ctx context.Context, segments []
 	}
 
 	// TODO: this assumes a single segment always finishes loading within
-	// SegmentTaskTimeout (3min default). If a segment's real load time is
+	// SegmentTaskTimeout (5min default). If a segment's real load time is
 	// consistently longer (large disk-index segment, throttled cold storage),
 	// the task is killed by its deadline every round and rebuilt here with
 	// the same budget on the next check tick -- it never converges. Needs

--- a/internal/querycoordv2/handlers.go
+++ b/internal/querycoordv2/handlers.go
@@ -158,12 +158,14 @@ func (s *Server) balanceSegments(ctx context.Context,
 	}
 
 	if sync {
-		// The task's own deadline doesn't start until it's actually dispatched
-		// (see Task.ActivateDeadline), so give this caller's wait window some
-		// slack beyond SegmentTaskTimeout to cover queueing time; otherwise a
-		// busy scheduler could make this synchronous call time out before the
-		// task itself ever gets a chance to fail with the real error.
-		err := task.Wait(ctx, 2*Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond), tasks...)
+		// No extra timeout here: each task already carries its own real
+		// deadline (armed on first dispatch, see Task.ActivateDeadline) and
+		// is guaranteed to finish within it. Bounding this wait with another,
+		// independently-guessed duration would only race against that real
+		// deadline -- as it did before, when both used SegmentTaskTimeout and
+		// this wait usually won, masking the task's actual result. Callers
+		// that want to bound how long they wait should set a deadline on ctx.
+		err := task.Wait(ctx, tasks...)
 		if err != nil {
 			msg := "failed to wait all balance task finished"
 			mlog.Warn(ctx, msg, mlog.Err(err))
@@ -241,10 +243,9 @@ func (s *Server) balanceChannels(ctx context.Context,
 	}
 
 	if sync {
-		// See the matching comment in balanceSegments: give this wait window
-		// slack beyond ChannelTaskTimeout so it doesn't time out purely due to
-		// scheduler queueing before the task's own deadline is even armed.
-		err := task.Wait(ctx, 2*Params.QueryCoordCfg.ChannelTaskTimeout.GetAsDuration(time.Millisecond), tasks...)
+		// See the matching comment in balanceSegments: no extra timeout here,
+		// each task already has a real, guaranteed-to-fire deadline of its own.
+		err := task.Wait(ctx, tasks...)
 		if err != nil {
 			msg := "failed to wait all balance task finished"
 			mlog.Warn(ctx, msg, mlog.Err(err))

--- a/internal/querycoordv2/handlers.go
+++ b/internal/querycoordv2/handlers.go
@@ -158,7 +158,12 @@ func (s *Server) balanceSegments(ctx context.Context,
 	}
 
 	if sync {
-		err := task.Wait(ctx, Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond), tasks...)
+		// The task's own deadline doesn't start until it's actually dispatched
+		// (see Task.ActivateDeadline), so give this caller's wait window some
+		// slack beyond SegmentTaskTimeout to cover queueing time; otherwise a
+		// busy scheduler could make this synchronous call time out before the
+		// task itself ever gets a chance to fail with the real error.
+		err := task.Wait(ctx, 2*Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond), tasks...)
 		if err != nil {
 			msg := "failed to wait all balance task finished"
 			mlog.Warn(ctx, msg, mlog.Err(err))
@@ -236,7 +241,10 @@ func (s *Server) balanceChannels(ctx context.Context,
 	}
 
 	if sync {
-		err := task.Wait(ctx, Params.QueryCoordCfg.ChannelTaskTimeout.GetAsDuration(time.Millisecond), tasks...)
+		// See the matching comment in balanceSegments: give this wait window
+		// slack beyond ChannelTaskTimeout so it doesn't time out purely due to
+		// scheduler queueing before the task's own deadline is even armed.
+		err := task.Wait(ctx, 2*Params.QueryCoordCfg.ChannelTaskTimeout.GetAsDuration(time.Millisecond), tasks...)
 		if err != nil {
 			msg := "failed to wait all balance task finished"
 			mlog.Warn(ctx, msg, mlog.Err(err))

--- a/internal/querycoordv2/handlers.go
+++ b/internal/querycoordv2/handlers.go
@@ -158,14 +158,19 @@ func (s *Server) balanceSegments(ctx context.Context,
 	}
 
 	if sync {
-		// No extra timeout here: each task already carries its own real
-		// deadline (armed on first dispatch, see Task.ActivateDeadline) and
-		// is guaranteed to finish within it. Bounding this wait with another,
-		// independently-guessed duration would only race against that real
-		// deadline -- as it did before, when both used SegmentTaskTimeout and
-		// this wait usually won, masking the task's actual result. Callers
-		// that want to bound how long they wait should set a deadline on ctx.
-		err := task.Wait(ctx, tasks...)
+		// This bound exists for a different reason than the task's own
+		// deadline: a task only gets its real deadline once it's actually
+		// admitted by the executor (see Task.ActivateDeadline). If the target
+		// node's executor stays saturated, the task can sit rejected in the
+		// queue indefinitely without ever being admitted, and callers commonly
+		// pass no deadline of their own (e.g. pymilvus defaults to
+		// timeout=None) -- so without a bound here, this handler could hang
+		// forever. SegmentTaskTimeout is a reasonable ceiling for "how long
+		// this synchronous call is willing to wait" independent of whether it
+		// matches the task's own execution budget.
+		waitCtx, cancel := context.WithTimeout(ctx, Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond))
+		defer cancel()
+		err := task.Wait(waitCtx, tasks...)
 		if err != nil {
 			msg := "failed to wait all balance task finished"
 			mlog.Warn(ctx, msg, mlog.Err(err))
@@ -243,9 +248,10 @@ func (s *Server) balanceChannels(ctx context.Context,
 	}
 
 	if sync {
-		// See the matching comment in balanceSegments: no extra timeout here,
-		// each task already has a real, guaranteed-to-fire deadline of its own.
-		err := task.Wait(ctx, tasks...)
+		// See the matching comment in balanceSegments.
+		waitCtx, cancel := context.WithTimeout(ctx, Params.QueryCoordCfg.ChannelTaskTimeout.GetAsDuration(time.Millisecond))
+		defer cancel()
+		err := task.Wait(waitCtx, tasks...)
 		if err != nil {
 			msg := "failed to wait all balance task finished"
 			mlog.Warn(ctx, msg, mlog.Err(err))

--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -175,6 +175,12 @@ func (ex *Executor) Execute(task Task, step int) bool {
 		}
 	}
 
+	// Only now is the task actually admitted to run: it cleared the wait
+	// queue and the executor's capacity gates above. Arm its deadline here
+	// (no-op after the first action/step) so time spent queued or bounced
+	// by admission doesn't count against the RPC budget.
+	task.ActivateDeadline()
+
 	go func() {
 		mlog.Info(context.TODO(), "execute the action of task")
 		switch task.Actions()[step].(type) {

--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -175,11 +175,13 @@ func (ex *Executor) Execute(task Task, step int) bool {
 		}
 	}
 
-	// Only now is the task actually admitted to run: it cleared the wait
-	// queue and the executor's capacity gates above. Arm its deadline here
-	// (no-op after the first action/step) so time spent queued or bounced
-	// by admission doesn't count against the RPC budget.
-	task.ActivateDeadline()
+	// Only now is this step actually admitted to run: it cleared the wait
+	// queue and the executor's capacity gates above. Arm a fresh deadline for
+	// this step here (no-op if already armed for it) so time spent queued or
+	// bounced by admission doesn't count against the RPC budget, and a
+	// later step in a multi-action task gets its own full budget rather than
+	// sharing whatever was left of an earlier step's.
+	task.ActivateDeadline(step)
 
 	go func() {
 		mlog.Info(context.TODO(), "execute the action of task")

--- a/internal/querycoordv2/task/executor_test.go
+++ b/internal/querycoordv2/task/executor_test.go
@@ -398,7 +398,7 @@ func TestExecutorDeadlockReproduction(t *testing.T) {
 	// In the old single-pool design, this would fail because all 5 slots would need to be full
 	// But with split pools, non-channel has its own capacity of 3
 	leaderAction := NewLeaderAction(1, 1, ActionTypeGrow, "shard-0", 700, 1)
-	leaderTask := NewLeaderSegmentTask(ctx, testSource("test"), 1000, replica, 1, leaderAction)
+	leaderTask := NewLeaderSegmentTask(ctx, 10*time.Second, testSource("test"), 1000, replica, 1, leaderAction)
 	leaderTask.SetID(700)
 
 	// Directly check: can we increment the non-channel counter?

--- a/internal/querycoordv2/task/task.go
+++ b/internal/querycoordv2/task/task.go
@@ -19,6 +19,7 @@ package task
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -88,6 +89,10 @@ type Task interface {
 	SetPriority(priority Priority)
 	Index() string // dedup indexing string
 
+	// ActivateDeadline starts the task's execution timeout the first time it is
+	// actually dispatched to a QueryNode, so time spent waiting for a scheduler
+	// slot doesn't count against the RPC budget. No-op after the first call.
+	ActivateDeadline()
 	// cancel the task as we don't need to continue it
 	Cancel(err error)
 	// fail the task as we encounter some error so be unable to continue,
@@ -111,8 +116,17 @@ type Task interface {
 }
 
 type baseTask struct {
-	ctx      context.Context
-	cancel   context.CancelFunc
+	// ctxMu guards ctx/cancel, which are swapped once by ActivateDeadline
+	// and read concurrently by Context()/Cancel()/Fail() from the scheduler
+	// loop and the executor's per-action goroutines.
+	ctxMu   sync.Mutex
+	ctx     context.Context
+	cancel  context.CancelFunc
+	timeout time.Duration
+	// deadlineOnce ensures the execution timeout is applied at most once,
+	// on the first call to ActivateDeadline.
+	deadlineOnce sync.Once
+
 	doneCh   chan struct{}
 	canceled *atomic.Bool
 
@@ -139,15 +153,13 @@ type baseTask struct {
 }
 
 func newBaseTask(ctx context.Context, timeout time.Duration, source Source, collectionID typeutil.UniqueID, replica *meta.Replica, shard string, taskTag string) *baseTask {
-	var cancel context.CancelFunc
-	if timeout > 0 {
-		// The deadline bounds the action RPCs issued with task.Context() and
-		// propagates through gRPC to the serving node, so a stuck server-side
-		// operation cannot pin the scheduler slot forever.
-		ctx, cancel = context.WithTimeout(ctx, timeout)
-	} else {
-		ctx, cancel = context.WithCancel(ctx)
-	}
+	// The deadline is deliberately NOT applied here: at construction time the
+	// task hasn't been scheduled yet and may sit in the wait queue or be
+	// repeatedly rejected by the executor's admission cap. Starting the clock
+	// now would burn the RPC budget on queueing delay rather than on the
+	// action RPCs it's meant to bound. ActivateDeadline arms it on first
+	// dispatch instead.
+	ctx, cancel := context.WithCancel(ctx)
 	ctx, span := otel.Tracer(typeutil.QueryCoordRole).Start(ctx, taskTag)
 	startTs := atomic.Time{}
 	startTs.Store(time.Now())
@@ -162,6 +174,7 @@ func newBaseTask(ctx context.Context, timeout time.Duration, source Source, coll
 		priority: TaskPriorityNormal,
 		ctx:      ctx,
 		cancel:   cancel,
+		timeout:  timeout,
 		doneCh:   make(chan struct{}),
 		canceled: atomic.NewBool(false),
 		span:     span,
@@ -169,7 +182,34 @@ func newBaseTask(ctx context.Context, timeout time.Duration, source Source, coll
 	}
 }
 
+// ActivateDeadline arms the task's execution timeout, bounding the action
+// RPCs issued with task.Context() from this point on so a stuck server-side
+// operation cannot pin the scheduler slot forever. It is a no-op if the task
+// was constructed with timeout <= 0, or if called more than once (only the
+// first dispatch starts the clock).
+func (task *baseTask) ActivateDeadline() {
+	if task.timeout <= 0 {
+		return
+	}
+	task.deadlineOnce.Do(func() {
+		task.ctxMu.Lock()
+		defer task.ctxMu.Unlock()
+		if task.canceled.Load() {
+			return
+		}
+		parentCtx, parentCancel := task.ctx, task.cancel
+		ctx, cancel := context.WithTimeout(parentCtx, task.timeout)
+		task.ctx = ctx
+		task.cancel = func() {
+			cancel()
+			parentCancel()
+		}
+	})
+}
+
 func (task *baseTask) Context() context.Context {
+	task.ctxMu.Lock()
+	defer task.ctxMu.Unlock()
 	return task.ctx
 }
 
@@ -246,7 +286,10 @@ func (task *baseTask) Err() error {
 
 func (task *baseTask) Cancel(err error) {
 	if task.canceled.CompareAndSwap(false, true) {
-		task.cancel()
+		task.ctxMu.Lock()
+		cancel := task.cancel
+		task.ctxMu.Unlock()
+		cancel()
 		if task.Status() != TaskStatusSucceeded {
 			task.SetStatus(TaskStatusCanceled)
 		}
@@ -260,7 +303,10 @@ func (task *baseTask) Cancel(err error) {
 
 func (task *baseTask) Fail(err error) {
 	if task.canceled.CompareAndSwap(false, true) {
-		task.cancel()
+		task.ctxMu.Lock()
+		cancel := task.cancel
+		task.ctxMu.Unlock()
+		cancel()
 		if task.Status() != TaskStatusSucceeded {
 			task.SetStatus(TaskStatusFailed)
 		}

--- a/internal/querycoordv2/task/task.go
+++ b/internal/querycoordv2/task/task.go
@@ -138,8 +138,16 @@ type baseTask struct {
 	startTs atomic.Time
 }
 
-func newBaseTask(ctx context.Context, source Source, collectionID typeutil.UniqueID, replica *meta.Replica, shard string, taskTag string) *baseTask {
-	ctx, cancel := context.WithCancel(ctx)
+func newBaseTask(ctx context.Context, timeout time.Duration, source Source, collectionID typeutil.UniqueID, replica *meta.Replica, shard string, taskTag string) *baseTask {
+	var cancel context.CancelFunc
+	if timeout > 0 {
+		// The deadline bounds every action RPC of this task (executor uses
+		// task.Context()) and propagates through gRPC to the serving node,
+		// so a stuck server-side operation cannot pin the scheduler slot forever.
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+	} else {
+		ctx, cancel = context.WithCancel(ctx)
+	}
 	ctx, span := otel.Tracer(typeutil.QueryCoordRole).Start(ctx, taskTag)
 	startTs := atomic.Time{}
 	startTs.Store(time.Now())
@@ -361,7 +369,7 @@ func NewSegmentTask(ctx context.Context,
 		}
 	}
 
-	base := newBaseTask(ctx, source, collectionID, replica, shard, fmt.Sprintf("SegmentTask-%s-%d", actions[0].Type().String(), segmentID))
+	base := newBaseTask(ctx, timeout, source, collectionID, replica, shard, fmt.Sprintf("SegmentTask-%s-%d", actions[0].Type().String(), segmentID))
 	base.actions = actions
 	return &SegmentTask{
 		baseTask:      base,
@@ -434,7 +442,7 @@ func NewChannelTask(ctx context.Context,
 		}
 	}
 
-	base := newBaseTask(ctx, source, collectionID, replica, channel, fmt.Sprintf("ChannelTask-%s-%s", actions[0].Type().String(), channel))
+	base := newBaseTask(ctx, timeout, source, collectionID, replica, channel, fmt.Sprintf("ChannelTask-%s-%s", actions[0].Type().String(), channel))
 	base.actions = actions
 	return &ChannelTask{
 		baseTask: base,
@@ -470,6 +478,7 @@ type LeaderTask struct {
 }
 
 func NewLeaderSegmentTask(ctx context.Context,
+	timeout time.Duration,
 	source Source,
 	collectionID typeutil.UniqueID,
 	replica *meta.Replica,
@@ -477,7 +486,7 @@ func NewLeaderSegmentTask(ctx context.Context,
 	action *LeaderAction,
 ) *LeaderTask {
 	segmentID := action.SegmentID()
-	base := newBaseTask(ctx, source, collectionID, replica, action.Shard, fmt.Sprintf("LeaderSegmentTask-%s-%d", action.Type().String(), segmentID))
+	base := newBaseTask(ctx, timeout, source, collectionID, replica, action.Shard, fmt.Sprintf("LeaderSegmentTask-%s-%d", action.Type().String(), segmentID))
 	base.actions = []Action{action}
 	return &LeaderTask{
 		baseTask:  base,
@@ -488,13 +497,14 @@ func NewLeaderSegmentTask(ctx context.Context,
 }
 
 func NewLeaderPartStatsTask(ctx context.Context,
+	timeout time.Duration,
 	source Source,
 	collectionID typeutil.UniqueID,
 	replica *meta.Replica,
 	leaderID int64,
 	action *LeaderAction,
 ) *LeaderTask {
-	base := newBaseTask(ctx, source, collectionID, replica, action.Shard, fmt.Sprintf("LeaderPartitionStatsTask-%s", action.Type().String()))
+	base := newBaseTask(ctx, timeout, source, collectionID, replica, action.Shard, fmt.Sprintf("LeaderPartitionStatsTask-%s", action.Type().String()))
 	base.actions = []Action{action}
 	return &LeaderTask{
 		baseTask:  base,

--- a/internal/querycoordv2/task/task.go
+++ b/internal/querycoordv2/task/task.go
@@ -187,6 +187,13 @@ func newBaseTask(ctx context.Context, timeout time.Duration, source Source, coll
 // operation cannot pin the scheduler slot forever. It is a no-op if the task
 // was constructed with timeout <= 0, or if called more than once (only the
 // first dispatch starts the clock).
+//
+// TODO: this is a flat wall-clock budget covering every remaining action RPC
+// once armed, on the assumption a single segment/channel op always finishes
+// within its configured timeout (segmentTaskTimeout defaults to 3min). A real
+// operation that legitimately runs longer never gets a chance to finish: the
+// checker rebuilds it with the same budget on every check tick, forever. See
+// SegmentChecker.createSegmentLoadTasks / ChannelChecker's equivalent.
 func (task *baseTask) ActivateDeadline() {
 	if task.timeout <= 0 {
 		return

--- a/internal/querycoordv2/task/task.go
+++ b/internal/querycoordv2/task/task.go
@@ -89,10 +89,13 @@ type Task interface {
 	SetPriority(priority Priority)
 	Index() string // dedup indexing string
 
-	// ActivateDeadline starts the task's execution timeout the first time it is
-	// actually dispatched to a QueryNode, so time spent waiting for a scheduler
-	// slot doesn't count against the RPC budget. No-op after the first call.
-	ActivateDeadline()
+	// ActivateDeadline arms a fresh execution timeout for the given step once
+	// it's actually dispatched to a QueryNode, so time spent waiting for a
+	// scheduler slot doesn't count against the RPC budget, and each step of a
+	// multi-action task gets its own full budget instead of sharing one
+	// deadline across the whole task lifetime. No-op if already armed for
+	// this step.
+	ActivateDeadline(step int)
 	// cancel the task as we don't need to continue it
 	Cancel(err error)
 	// fail the task as we encounter some error so be unable to continue,
@@ -116,16 +119,27 @@ type Task interface {
 }
 
 type baseTask struct {
-	// ctxMu guards ctx/cancel, which are swapped once by ActivateDeadline
-	// and read concurrently by Context()/Cancel()/Fail() from the scheduler
-	// loop and the executor's per-action goroutines.
-	ctxMu   sync.Mutex
-	ctx     context.Context
-	cancel  context.CancelFunc
-	timeout time.Duration
-	// deadlineOnce ensures the execution timeout is applied at most once,
-	// on the first call to ActivateDeadline.
-	deadlineOnce sync.Once
+	// ctxMu guards rootCtx/ctx/stepCancel/armedStep, which are read
+	// concurrently by Context()/Cancel()/Fail() from the scheduler loop and
+	// the executor's per-action goroutines, and swapped on every call to
+	// ActivateDeadline.
+	ctxMu sync.Mutex
+	// rootCtx/rootCancel are deadline-free (only canceled by Cancel/Fail/
+	// parent cancellation) and never replaced; every per-step deadline in ctx
+	// is derived from rootCtx, so canceling rootCtx always tears down
+	// whichever per-step deadline is currently active too.
+	rootCtx    context.Context
+	rootCancel context.CancelFunc
+	// ctx is the context task.Context() currently returns: rootCtx itself
+	// before the first ActivateDeadline call, or rootCtx wrapped in a fresh
+	// context.WithTimeout for the step ActivateDeadline was last called for.
+	ctx        context.Context
+	stepCancel context.CancelFunc
+	timeout    time.Duration
+	// armedStep is the step ActivateDeadline last armed a deadline for, or -1
+	// if never armed. Re-arming for the same step is a no-op so repeated
+	// dispatch attempts within one step don't reset the clock.
+	armedStep int
 
 	doneCh   chan struct{}
 	canceled *atomic.Bool
@@ -159,8 +173,8 @@ func newBaseTask(ctx context.Context, timeout time.Duration, source Source, coll
 	// now would burn the RPC budget on queueing delay rather than on the
 	// action RPCs it's meant to bound. ActivateDeadline arms it on first
 	// dispatch instead.
-	ctx, cancel := context.WithCancel(ctx)
-	ctx, span := otel.Tracer(typeutil.QueryCoordRole).Start(ctx, taskTag)
+	rootCtx, rootCancel := context.WithCancel(ctx)
+	rootCtx, span := otel.Tracer(typeutil.QueryCoordRole).Start(rootCtx, taskTag)
 	startTs := atomic.Time{}
 	startTs.Store(time.Now())
 
@@ -170,48 +184,63 @@ func newBaseTask(ctx context.Context, timeout time.Duration, source Source, coll
 		replica:      replica,
 		shard:        shard,
 
-		status:   atomic.NewString(TaskStatusStarted),
-		priority: TaskPriorityNormal,
-		ctx:      ctx,
-		cancel:   cancel,
-		timeout:  timeout,
-		doneCh:   make(chan struct{}),
-		canceled: atomic.NewBool(false),
-		span:     span,
-		startTs:  startTs,
+		status:     atomic.NewString(TaskStatusStarted),
+		priority:   TaskPriorityNormal,
+		rootCtx:    rootCtx,
+		rootCancel: rootCancel,
+		ctx:        rootCtx,
+		armedStep:  -1,
+		timeout:    timeout,
+		doneCh:     make(chan struct{}),
+		canceled:   atomic.NewBool(false),
+		span:       span,
+		startTs:    startTs,
 	}
 }
 
-// ActivateDeadline arms the task's execution timeout, bounding the action
-// RPCs issued with task.Context() from this point on so a stuck server-side
-// operation cannot pin the scheduler slot forever. It is a no-op if the task
-// was constructed with timeout <= 0, or if called more than once (only the
-// first dispatch starts the clock).
+// ActivateDeadline arms a fresh execution timeout for the given step,
+// bounding the action RPC issued with task.Context() for that step so a
+// stuck server-side operation cannot pin the scheduler slot forever. Called
+// by Executor.Execute once a step actually clears admission. It is a no-op
+// if the task was constructed with timeout <= 0, or if already armed for
+// this step (so repeated dispatch attempts within one step don't reset the
+// clock). Each step gets its own full budget rather than sharing one
+// deadline across the whole task lifetime, so an earlier step finishing
+// under budget doesn't eat into a later step's.
 //
-// TODO: this is a flat wall-clock budget covering every remaining action RPC
-// once armed, on the assumption a single segment/channel op always finishes
-// within its configured timeout (segmentTaskTimeout defaults to 3min). A real
-// operation that legitimately runs longer never gets a chance to finish: the
-// checker rebuilds it with the same budget on every check tick, forever. See
+// TODO: the budget still covers the dist-confirmation wait between this
+// step's RPC returning and the step being marked finished (see
+// taskScheduler.checkActionFinish) -- a step whose RPC returns quickly but
+// whose distribution/leader-promotion confirmation is slow can still be
+// starved by a deadline armed for an earlier, already-returned RPC. Fully
+// isolating "wait for dist confirmation" from "RPC in flight" needs its own
+// design, in the same bucket as the no-backoff TODO below.
+//
+// TODO: this is still a flat wall-clock budget per step, on the assumption a
+// single action always finishes within its configured timeout
+// (segmentTaskTimeout defaults to 3min). A real operation that legitimately
+// runs longer never gets a chance to finish: the checker rebuilds it with the
+// same budget on every check tick, forever. See
 // SegmentChecker.createSegmentLoadTasks / ChannelChecker's equivalent.
-func (task *baseTask) ActivateDeadline() {
+func (task *baseTask) ActivateDeadline(step int) {
 	if task.timeout <= 0 {
 		return
 	}
-	task.deadlineOnce.Do(func() {
-		task.ctxMu.Lock()
-		defer task.ctxMu.Unlock()
-		if task.canceled.Load() {
-			return
-		}
-		parentCtx, parentCancel := task.ctx, task.cancel
-		ctx, cancel := context.WithTimeout(parentCtx, task.timeout)
-		task.ctx = ctx
-		task.cancel = func() {
-			cancel()
-			parentCancel()
-		}
-	})
+	task.ctxMu.Lock()
+	defer task.ctxMu.Unlock()
+	if task.canceled.Load() || task.armedStep == step {
+		return
+	}
+	if task.stepCancel != nil {
+		// Release the previous step's timer now that a new step is starting;
+		// rootCtx being canceled would also propagate this, but there's no
+		// need to wait for that to happen.
+		task.stepCancel()
+	}
+	ctx, cancel := context.WithTimeout(task.rootCtx, task.timeout)
+	task.ctx = ctx
+	task.stepCancel = cancel
+	task.armedStep = step
 }
 
 func (task *baseTask) Context() context.Context {
@@ -294,9 +323,9 @@ func (task *baseTask) Err() error {
 func (task *baseTask) Cancel(err error) {
 	if task.canceled.CompareAndSwap(false, true) {
 		task.ctxMu.Lock()
-		cancel := task.cancel
+		rootCancel := task.rootCancel
 		task.ctxMu.Unlock()
-		cancel()
+		rootCancel()
 		if task.Status() != TaskStatusSucceeded {
 			task.SetStatus(TaskStatusCanceled)
 		}
@@ -311,9 +340,9 @@ func (task *baseTask) Cancel(err error) {
 func (task *baseTask) Fail(err error) {
 	if task.canceled.CompareAndSwap(false, true) {
 		task.ctxMu.Lock()
-		cancel := task.cancel
+		rootCancel := task.rootCancel
 		task.ctxMu.Unlock()
-		cancel()
+		rootCancel()
 		if task.Status() != TaskStatusSucceeded {
 			task.SetStatus(TaskStatusFailed)
 		}

--- a/internal/querycoordv2/task/task.go
+++ b/internal/querycoordv2/task/task.go
@@ -218,7 +218,7 @@ func newBaseTask(ctx context.Context, timeout time.Duration, source Source, coll
 //
 // TODO: this is still a flat wall-clock budget per step, on the assumption a
 // single action always finishes within its configured timeout
-// (segmentTaskTimeout defaults to 3min). A real operation that legitimately
+// (segmentTaskTimeout defaults to 5min). A real operation that legitimately
 // runs longer never gets a chance to finish: the checker rebuilds it with the
 // same budget on every check tick, forever. See
 // SegmentChecker.createSegmentLoadTasks / ChannelChecker's equivalent.

--- a/internal/querycoordv2/task/task.go
+++ b/internal/querycoordv2/task/task.go
@@ -141,9 +141,9 @@ type baseTask struct {
 func newBaseTask(ctx context.Context, timeout time.Duration, source Source, collectionID typeutil.UniqueID, replica *meta.Replica, shard string, taskTag string) *baseTask {
 	var cancel context.CancelFunc
 	if timeout > 0 {
-		// The deadline bounds every action RPC of this task (executor uses
-		// task.Context()) and propagates through gRPC to the serving node,
-		// so a stuck server-side operation cannot pin the scheduler slot forever.
+		// The deadline bounds the action RPCs issued with task.Context() and
+		// propagates through gRPC to the serving node, so a stuck server-side
+		// operation cannot pin the scheduler slot forever.
 		ctx, cancel = context.WithTimeout(ctx, timeout)
 	} else {
 		ctx, cancel = context.WithCancel(ctx)
@@ -266,6 +266,9 @@ func (task *baseTask) Fail(err error) {
 		}
 		task.err = err
 		close(task.doneCh)
+		if task.span != nil {
+			task.span.End()
+		}
 	}
 }
 

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -3286,9 +3286,9 @@ func TestChannelTaskTimeoutBoundsTaskContext(t *testing.T) {
 	_, ok := channelTask.Context().Deadline()
 	assert.False(t, ok, "channel task context must not carry a deadline before ActivateDeadline")
 
-	channelTask.ActivateDeadline()
+	channelTask.ActivateDeadline(0)
 	// A second call must be a no-op and not push the deadline out further.
-	channelTask.ActivateDeadline()
+	channelTask.ActivateDeadline(0)
 
 	deadline, ok := channelTask.Context().Deadline()
 	assert.True(t, ok, "channel task context must carry the task timeout as a deadline once activated")
@@ -3315,7 +3315,7 @@ func TestChannelTaskTimeoutBoundsTaskContext(t *testing.T) {
 	defer segmentTask.Cancel(nil)
 	_, ok = segmentTask.Context().Deadline()
 	assert.False(t, ok, "segment task context must not carry a deadline before ActivateDeadline")
-	segmentTask.ActivateDeadline()
+	segmentTask.ActivateDeadline(0)
 	_, ok = segmentTask.Context().Deadline()
 	assert.True(t, ok, "segment task context must carry the task timeout as a deadline once activated")
 
@@ -3331,7 +3331,7 @@ func TestChannelTaskTimeoutBoundsTaskContext(t *testing.T) {
 	defer leaderTask.Cancel(nil)
 	_, ok = leaderTask.Context().Deadline()
 	assert.False(t, ok, "leader task context must not carry a deadline before ActivateDeadline")
-	leaderTask.ActivateDeadline()
+	leaderTask.ActivateDeadline(0)
 	_, ok = leaderTask.Context().Deadline()
 	assert.True(t, ok, "leader task context must carry the task timeout as a deadline once activated")
 }
@@ -3354,7 +3354,7 @@ func TestTaskDeadlineExcludesQueueingTime(t *testing.T) {
 	time.Sleep(80 * time.Millisecond)
 	assert.NoError(t, task.Context().Err(), "queueing time must not count against the deadline")
 
-	task.ActivateDeadline()
+	task.ActivateDeadline(0)
 	assert.NoError(t, task.Context().Err(), "deadline must not have expired immediately on activation")
 
 	select {
@@ -3363,4 +3363,104 @@ func TestTaskDeadlineExcludesQueueingTime(t *testing.T) {
 		t.Fatal("task context did not expire after the task timeout once activated")
 	}
 	assert.ErrorIs(t, task.Context().Err(), context.DeadlineExceeded)
+}
+
+func TestActivateDeadlinePerStepGetsFreshBudget(t *testing.T) {
+	task, err := NewSegmentTask(
+		context.Background(),
+		80*time.Millisecond,
+		WrapIDSource(0),
+		1,
+		meta.NilReplica,
+		commonpb.LoadPriority_LOW,
+		NewSegmentAction(1, ActionTypeGrow, "test-channel", 2),
+		NewSegmentAction(1, ActionTypeReduce, "test-channel", 2),
+	)
+	assert.NoError(t, err)
+	defer task.Cancel(nil)
+
+	task.ActivateDeadline(0)
+	deadline0, _ := task.Context().Deadline()
+
+	// Spend most of step 0's budget before it "finishes" and step 1 is armed.
+	time.Sleep(60 * time.Millisecond)
+	assert.NoError(t, task.Context().Err(), "step 0 must not have expired yet")
+
+	// Re-arming for the same step must be a no-op: the deadline must not move.
+	task.ActivateDeadline(0)
+	sameDeadline, _ := task.Context().Deadline()
+	assert.Equal(t, deadline0, sameDeadline, "re-arming the same step must not reset its deadline")
+
+	// Moving to step 1 must grant a full fresh budget, not inherit whatever
+	// was left of step 0's -- even though step 0 already used most of it.
+	task.ActivateDeadline(1)
+	deadline1, ok := task.Context().Deadline()
+	assert.True(t, ok)
+	assert.True(t, deadline1.After(deadline0), "step 1's deadline must be later than step 0's, not reuse it")
+
+	time.Sleep(60 * time.Millisecond)
+	assert.NoError(t, task.Context().Err(), "step 1 must have its own fresh 80ms budget, not step 0's leftover ~20ms")
+
+	select {
+	case <-task.Context().Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("step 1's context did not expire after its own timeout")
+	}
+	assert.ErrorIs(t, task.Context().Err(), context.DeadlineExceeded)
+}
+
+// TestExecutorActivatesDeadlineOnlyAfterAdmission exercises the real
+// Executor.Execute() wiring end-to-end, rather than calling
+// task.ActivateDeadline() directly the way TestTaskDeadlineExcludesQueueingTime
+// does. It would catch the ActivateDeadline call being removed from Execute,
+// or moved ahead of the admission-cap check, either of which a
+// direct-call-style test cannot detect.
+func TestExecutorActivatesDeadlineOnlyAfterAdmission(t *testing.T) {
+	paramtable.Init()
+	nodeMgr := session.NewNodeManager()
+	broker := meta.NewMockBroker(t)
+	// Any error is fine here: the point is to let the background goroutine
+	// Execute() spawns on successful admission exit quickly via task.Fail,
+	// without touching the nil meta/dist/targetMgr/cluster this test doesn't
+	// otherwise set up.
+	broker.EXPECT().DescribeCollection(mock.Anything, mock.Anything).
+		Return(nil, merr.WrapErrCollectionNotFound(int64(1))).Maybe()
+
+	executor := NewExecutor(1, nil, nil, broker, nil, nil, nodeMgr)
+
+	task, err := NewSegmentTask(
+		context.Background(),
+		80*time.Millisecond,
+		WrapIDSource(0),
+		1,
+		meta.NilReplica,
+		commonpb.LoadPriority_LOW,
+		// Grow routes to loadSegment, which fails gracefully through
+		// getMetaInfo -> getCollectionInfo -> the mocked broker error above.
+		// Reduce routes to releaseSegment, which needs a working dist/cluster
+		// this test doesn't set up and would nil-panic in the background
+		// goroutine instead.
+		NewSegmentAction(1, ActionTypeGrow, "test-channel", 2),
+	)
+	assert.NoError(t, err)
+	defer task.Cancel(nil)
+
+	// Saturate the non-channel admission pool directly so Execute rejects
+	// this task at the capacity gate without ever reaching ActivateDeadline.
+	// (GetNonChannelTaskCap floors to >=1 regardless of config, so it can't
+	// be driven to reject via TaskExecutionCap -- see its doc comment.)
+	executor.nonChannelTaskNum.Store(1 << 20)
+
+	admitted := executor.Execute(task, 0)
+	assert.False(t, admitted, "Execute must reject the task when the admission pool is saturated")
+	_, ok := task.Context().Deadline()
+	assert.False(t, ok, "deadline must not be armed for a task rejected at admission")
+
+	// Clear the pool: the same task, dispatched again, must now be admitted
+	// and get its deadline armed by Execute itself, not by a direct test call.
+	executor.nonChannelTaskNum.Store(0)
+	admitted = executor.Execute(task, 0)
+	assert.True(t, admitted, "Execute must admit the task once the pool is clear")
+	_, ok = task.Context().Deadline()
+	assert.True(t, ok, "Execute must have armed the deadline on successful admission")
 }

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -3368,7 +3368,7 @@ func TestTaskDeadlineExcludesQueueingTime(t *testing.T) {
 func TestActivateDeadlinePerStepGetsFreshBudget(t *testing.T) {
 	task, err := NewSegmentTask(
 		context.Background(),
-		80*time.Millisecond,
+		500*time.Millisecond,
 		WrapIDSource(0),
 		1,
 		meta.NilReplica,
@@ -3383,7 +3383,7 @@ func TestActivateDeadlinePerStepGetsFreshBudget(t *testing.T) {
 	deadline0, _ := task.Context().Deadline()
 
 	// Spend most of step 0's budget before it "finishes" and step 1 is armed.
-	time.Sleep(60 * time.Millisecond)
+	time.Sleep(300 * time.Millisecond)
 	assert.NoError(t, task.Context().Err(), "step 0 must not have expired yet")
 
 	// Re-arming for the same step must be a no-op: the deadline must not move.
@@ -3398,8 +3398,8 @@ func TestActivateDeadlinePerStepGetsFreshBudget(t *testing.T) {
 	assert.True(t, ok)
 	assert.True(t, deadline1.After(deadline0), "step 1's deadline must be later than step 0's, not reuse it")
 
-	time.Sleep(60 * time.Millisecond)
-	assert.NoError(t, task.Context().Err(), "step 1 must have its own fresh 80ms budget, not step 0's leftover ~20ms")
+	time.Sleep(300 * time.Millisecond)
+	assert.NoError(t, task.Context().Err(), "step 1 must have its own fresh 500ms budget, not step 0's leftover ~200ms")
 
 	select {
 	case <-task.Context().Done():

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -305,7 +305,7 @@ func (suite *TaskSuite) TestSubscribeChannelTask() {
 	suite.dispatchAndWait(targetNode)
 	suite.AssertTaskNum(0, 0, 0, 0)
 
-	Wait(ctx, timeout, tasks...)
+	Wait(ctx, tasks...)
 	for _, task := range tasks {
 		suite.Equal(TaskStatusSucceeded, task.Status())
 		suite.NoError(task.Err())

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -1358,6 +1358,7 @@ func (suite *TaskSuite) TestLeaderTaskSet() {
 		})
 		task := NewLeaderSegmentTask(
 			ctx,
+			10*time.Second,
 			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
@@ -1458,7 +1459,7 @@ func (suite *TaskSuite) TestCreateTaskBehavior() {
 	suite.Nil(segmentTask)
 
 	leaderAction := NewLeaderAction(1, 2, ActionTypeGrow, "fake-channel1", 100, 0)
-	leaderTask := NewLeaderSegmentTask(context.TODO(), WrapIDSource(0), 0, meta.NilReplica, 1, leaderAction)
+	leaderTask := NewLeaderSegmentTask(context.TODO(), 10*time.Second, WrapIDSource(0), 0, meta.NilReplica, 1, leaderAction)
 	suite.NotNil(leaderTask)
 }
 
@@ -1692,6 +1693,7 @@ func (suite *TaskSuite) TestLeaderTaskRemove() {
 		view.Segments[segment] = &querypb.SegmentDist{NodeID: targetNode, Version: 0}
 		task := NewLeaderSegmentTask(
 			ctx,
+			10*time.Second,
 			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
@@ -1754,6 +1756,7 @@ func (suite *TaskSuite) TestLeaderTaskUsesLeaderExecutor() {
 
 	task := NewLeaderSegmentTask(
 		ctx,
+		10*time.Second,
 		WrapIDSource(0),
 		suite.collection,
 		suite.replica,
@@ -2315,7 +2318,7 @@ func TestSegmentTaskDeltaDefensiveBranches(t *testing.T) {
 	delta.Sub(segmentTask)
 	assert.Empty(t, delta.records)
 
-	base := newBaseTask(context.Background(), WrapIDSource(0), 100, replica, "ch", "MalformedSegmentTask")
+	base := newBaseTask(context.Background(), 0, WrapIDSource(0), 100, replica, "ch", "MalformedSegmentTask")
 	base.SetID(2)
 	base.actions = []Action{NewChannelAction(1, ActionTypeGrow, "ch")}
 	malformedTask := &SegmentTask{baseTask: base, segmentID: 10}
@@ -2633,6 +2636,7 @@ func (suite *TaskSuite) TestLeaderTaskStaleByRONode() {
 		// After fix: checkStale uses leaderID (1, RW), task should NOT be stale
 		task := NewLeaderSegmentTask(
 			ctx,
+			10*time.Second,
 			WrapIDSource(0),
 			suite.collection,
 			replicaWithRONode,
@@ -2669,6 +2673,7 @@ func (suite *TaskSuite) TestLeaderTaskStaleByRONode() {
 		// Create task with original replica (all RW nodes)
 		task := NewLeaderSegmentTask(
 			ctx,
+			10*time.Second,
 			WrapIDSource(0),
 			suite.collection,
 			suite.replica,
@@ -2727,6 +2732,7 @@ func (suite *TaskSuite) TestLeaderTaskStaleByRONode() {
 		// Create LeaderAction with Reduce type
 		task := NewLeaderSegmentTask(
 			ctx,
+			10*time.Second,
 			WrapIDSource(0),
 			suite.collection,
 			replicaWithLeaderRO,
@@ -3177,7 +3183,7 @@ func (suite *TaskSuite) TestNodeTaskQueueLeaderActionDualNode() {
 	segmentID := int64(300)
 
 	action := NewLeaderAction(leaderID, workerID, ActionTypeGrow, "ch-0", segmentID, 1)
-	task := NewLeaderSegmentTask(suite.ctx, WrapIDSource(0), suite.collection, suite.replica, leaderID, action)
+	task := NewLeaderSegmentTask(suite.ctx, 10*time.Second, WrapIDSource(0), suite.collection, suite.replica, leaderID, action)
 	task.SetID(20)
 
 	queue.Add(task)
@@ -3263,4 +3269,56 @@ func (suite *TaskSuite) TestNodeTaskQueueRangeByNodePriority() {
 		return true
 	})
 	suite.Equal([]Priority{TaskPriorityHigh, TaskPriorityNormal, TaskPriorityLow}, visited)
+}
+
+func TestChannelTaskTimeoutBoundsTaskContext(t *testing.T) {
+	channelTask, err := NewChannelTask(
+		context.Background(),
+		50*time.Millisecond,
+		WrapIDSource(0),
+		1,
+		meta.NilReplica,
+		NewChannelAction(1, ActionTypeReduce, "test-channel"),
+	)
+	assert.NoError(t, err)
+	defer channelTask.Cancel(nil)
+
+	deadline, ok := channelTask.Context().Deadline()
+	assert.True(t, ok, "channel task context must carry the task timeout as a deadline")
+
+	select {
+	case <-channelTask.Context().Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("channel task context did not expire after the task timeout")
+	}
+	assert.ErrorIs(t, channelTask.Context().Err(), context.DeadlineExceeded)
+	assert.WithinDuration(t, time.Now(), deadline, 2*time.Second)
+
+	// Segment tasks are bounded by the same mechanism.
+	segmentTask, err := NewSegmentTask(
+		context.Background(),
+		50*time.Millisecond,
+		WrapIDSource(0),
+		1,
+		meta.NilReplica,
+		commonpb.LoadPriority_LOW,
+		NewSegmentAction(1, ActionTypeReduce, "test-channel", 2),
+	)
+	assert.NoError(t, err)
+	defer segmentTask.Cancel(nil)
+	_, ok = segmentTask.Context().Deadline()
+	assert.True(t, ok, "segment task context must carry the task timeout as a deadline")
+
+	leaderTask := NewLeaderSegmentTask(
+		context.Background(),
+		50*time.Millisecond,
+		WrapIDSource(0),
+		1,
+		meta.NilReplica,
+		1,
+		NewLeaderAction(1, 2, ActionTypeGrow, "test-channel", 3, 0),
+	)
+	defer leaderTask.Cancel(nil)
+	_, ok = leaderTask.Context().Deadline()
+	assert.True(t, ok, "leader task context must carry the task timeout as a deadline")
 }

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -3283,8 +3283,15 @@ func TestChannelTaskTimeoutBoundsTaskContext(t *testing.T) {
 	assert.NoError(t, err)
 	defer channelTask.Cancel(nil)
 
+	_, ok := channelTask.Context().Deadline()
+	assert.False(t, ok, "channel task context must not carry a deadline before ActivateDeadline")
+
+	channelTask.ActivateDeadline()
+	// A second call must be a no-op and not push the deadline out further.
+	channelTask.ActivateDeadline()
+
 	deadline, ok := channelTask.Context().Deadline()
-	assert.True(t, ok, "channel task context must carry the task timeout as a deadline")
+	assert.True(t, ok, "channel task context must carry the task timeout as a deadline once activated")
 
 	select {
 	case <-channelTask.Context().Done():
@@ -3307,7 +3314,10 @@ func TestChannelTaskTimeoutBoundsTaskContext(t *testing.T) {
 	assert.NoError(t, err)
 	defer segmentTask.Cancel(nil)
 	_, ok = segmentTask.Context().Deadline()
-	assert.True(t, ok, "segment task context must carry the task timeout as a deadline")
+	assert.False(t, ok, "segment task context must not carry a deadline before ActivateDeadline")
+	segmentTask.ActivateDeadline()
+	_, ok = segmentTask.Context().Deadline()
+	assert.True(t, ok, "segment task context must carry the task timeout as a deadline once activated")
 
 	leaderTask := NewLeaderSegmentTask(
 		context.Background(),
@@ -3320,5 +3330,37 @@ func TestChannelTaskTimeoutBoundsTaskContext(t *testing.T) {
 	)
 	defer leaderTask.Cancel(nil)
 	_, ok = leaderTask.Context().Deadline()
-	assert.True(t, ok, "leader task context must carry the task timeout as a deadline")
+	assert.False(t, ok, "leader task context must not carry a deadline before ActivateDeadline")
+	leaderTask.ActivateDeadline()
+	_, ok = leaderTask.Context().Deadline()
+	assert.True(t, ok, "leader task context must carry the task timeout as a deadline once activated")
+}
+
+func TestTaskDeadlineExcludesQueueingTime(t *testing.T) {
+	task, err := NewSegmentTask(
+		context.Background(),
+		50*time.Millisecond,
+		WrapIDSource(0),
+		1,
+		meta.NilReplica,
+		commonpb.LoadPriority_LOW,
+		NewSegmentAction(1, ActionTypeReduce, "test-channel", 2),
+	)
+	assert.NoError(t, err)
+	defer task.Cancel(nil)
+
+	// Simulate the task sitting in the wait queue / being bounced by the
+	// executor's admission cap for longer than its configured timeout.
+	time.Sleep(80 * time.Millisecond)
+	assert.NoError(t, task.Context().Err(), "queueing time must not count against the deadline")
+
+	task.ActivateDeadline()
+	assert.NoError(t, task.Context().Err(), "deadline must not have expired immediately on activation")
+
+	select {
+	case <-task.Context().Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("task context did not expire after the task timeout once activated")
+	}
+	assert.ErrorIs(t, task.Context().Err(), context.DeadlineExceeded)
 }

--- a/internal/querycoordv2/task/utils.go
+++ b/internal/querycoordv2/task/utils.go
@@ -55,20 +55,24 @@ func Wait(ctx context.Context, timeout time.Duration, tasks ...Task) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	var err error
+	errCh := make(chan error, 1)
 	go func() {
+		var err error
 		for _, task := range tasks {
 			err = task.Wait()
 			if err != nil {
-				cancel()
 				break
 			}
 		}
-		cancel()
+		errCh <- err
 	}()
-	<-ctx.Done()
 
-	return err
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func SetPriority(priority Priority, tasks ...Task) {

--- a/internal/querycoordv2/task/utils.go
+++ b/internal/querycoordv2/task/utils.go
@@ -51,10 +51,15 @@ func WrapIDSource(id int64) Source {
 	return idSource(id)
 }
 
-func Wait(ctx context.Context, timeout time.Duration, tasks ...Task) error {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
+// Wait blocks until every task in tasks has finished (succeeded, failed, or
+// been canceled) or ctx is done, whichever comes first. It does not impose
+// any timeout of its own: each task already carries its own real deadline
+// (armed on first dispatch, see Task.ActivateDeadline) and is guaranteed to
+// finish within it, so a second, independently-guessed timeout here would
+// only race against that real deadline instead of bounding anything new.
+// Callers that need to bound how long they'll wait should set a deadline on
+// ctx themselves.
+func Wait(ctx context.Context, tasks ...Task) error {
 	errCh := make(chan error, 1)
 	go func() {
 		var err error

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -674,11 +674,16 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 	sLoad := func(ctx context.Context, req *querypb.LoadSegmentsRequest) error {
 		segmentID := req.GetInfos()[0].GetSegmentID()
 		nodeID := req.GetDstNodeID()
-		_, err, _ := sd.sf.Do(fmt.Sprintf("%d-%d", nodeID, segmentID), func() (struct{}, error) {
-			err := worker.LoadSegments(ctx, req)
-			return struct{}{}, err
-		})
-		return err
+		// Join any identical in-flight load, but stop waiting when this
+		// caller's ctx ends; the shared load keeps running for its initiator.
+		select {
+		case res := <-sd.sf.DoChan(fmt.Sprintf("%d-%d", nodeID, segmentID), func() (struct{}, error) {
+			return struct{}{}, worker.LoadSegments(ctx, req)
+		}):
+			return res.Err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 
 	// separate infos into different load task

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -1366,7 +1366,7 @@ func (loader *segmentLoader) loadDeltalogs(ctx context.Context, segment Segment,
 		if len(paths) == 0 {
 			return nil
 		}
-		reader, err := storage.NewDeltalogReader(pkField.DataType, paths, opts...)
+		reader, err := storage.NewDeltalogReader(ctx, pkField.DataType, paths, opts...)
 		if err != nil {
 			return err
 		}
@@ -1409,6 +1409,7 @@ func (loader *segmentLoader) loadDeltalogs(ctx context.Context, segment Segment,
 				}
 				if len(storageV3Paths) > 0 {
 					reader, err := storage.NewDeltalogReader(
+						ctx,
 						pkField.DataType,
 						storageV3Paths,
 						storage.WithVersion(storage.StorageV3),
@@ -1424,6 +1425,7 @@ func (loader *segmentLoader) loadDeltalogs(ctx context.Context, segment Segment,
 				}
 				if len(legacyPaths) > 0 {
 					reader, err := storage.NewDeltalogReader(
+						ctx,
 						pkField.DataType,
 						legacyPaths,
 						storage.WithVersion(storage.StorageV1),

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -139,7 +139,7 @@ func TestLoadDeltalogsExternalRealPKManifestReadsSourceDeltas(t *testing.T) {
 	readerCalled := atomic.NewInt32(0)
 	var gotPathSets [][]string
 	patchReader := mockey.Mock(storage.NewDeltalogReader).To(
-		func(pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
+		func(_ context.Context, pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
 			readerCalled.Inc()
 			gotPathSets = append(gotPathSets, append([]string(nil), paths...))
 			return eofRecordReader{}, nil
@@ -196,7 +196,7 @@ func TestLoadDeltalogsExternalRealPKManifestRejectsTargetDeltas(t *testing.T) {
 
 	readerCalled := atomic.NewInt32(0)
 	patchReader := mockey.Mock(storage.NewDeltalogReader).To(
-		func(pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
+		func(_ context.Context, pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
 			readerCalled.Inc()
 			return eofRecordReader{}, nil
 		},
@@ -889,7 +889,7 @@ func (suite *SegmentLoaderSuite) TestLoadDeltaLogsV3PlaceholderSkipsPathRead() {
 	defer patchManifest.UnPatch()
 
 	patchReader := mockey.Mock(storage.NewDeltalogReader).To(
-		func(pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
+		func(_ context.Context, pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
 			readerCalled.Inc()
 			return nil, errors.New("should not be called when manifest has no delta paths")
 		},
@@ -978,7 +978,7 @@ func (suite *SegmentLoaderSuite) TestLoadDeltaLogsExternalRealPKManifestStorageV
 
 	readerCalled := atomic.NewInt32(0)
 	patchReader := mockey.Mock(storage.NewDeltalogReader).To(
-		func(pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
+		func(_ context.Context, pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
 			readerCalled.Inc()
 			suite.Equal(schemapb.DataType_Int64, pkType)
 			suite.Equal([]string{sourceDeltaPath}, paths)
@@ -1049,7 +1049,7 @@ func (suite *SegmentLoaderSuite) TestLoadDeltaLogsExternalRealPKManifestLegacyL0
 
 	legacyReaderCalled := atomic.NewInt32(0)
 	patchReader := mockey.Mock(storage.NewDeltalogReader).
-		To(func(pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
+		To(func(_ context.Context, pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
 			legacyReaderCalled.Inc()
 			suite.Equal(schemapb.DataType_Int64, pkType)
 			suite.Equal([]string{sourceDeltaPath}, paths)
@@ -1281,7 +1281,7 @@ func (suite *SegmentLoaderSuite) TestLoadDeltaLogsV1StillUsesPathRead() {
 	defer patchManifest.UnPatch()
 
 	patchReader := mockey.Mock(storage.NewDeltalogReader).To(
-		func(pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
+		func(_ context.Context, pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
 			readerCalled.Inc()
 			return nil, io.EOF
 		},
@@ -1351,7 +1351,7 @@ func (suite *SegmentLoaderSuite) TestLoadDeltaLogsLegacyParentLoadsChildManifest
 	defer patchManifest.UnPatch()
 
 	patchReader := mockey.Mock(storage.NewDeltalogReader).To(
-		func(pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
+		func(_ context.Context, pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
 			legacyReaderCalls.Inc()
 			return storage.NewLegacyDeltalogReader(context.Background(), &schemapb.FieldSchema{
 				FieldID:      0,

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -1353,7 +1353,7 @@ func (suite *SegmentLoaderSuite) TestLoadDeltaLogsLegacyParentLoadsChildManifest
 	patchReader := mockey.Mock(storage.NewDeltalogReader).To(
 		func(pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
 			legacyReaderCalls.Inc()
-			return storage.NewLegacyDeltalogReader(&schemapb.FieldSchema{
+			return storage.NewLegacyDeltalogReader(context.Background(), &schemapb.FieldSchema{
 				FieldID:      0,
 				DataType:     pkType,
 				IsPrimaryKey: true,

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -354,6 +354,15 @@ func (node *QueryNode) WatchDmChannels(ctx context.Context, req *querypb.WatchDm
 		return merr.Status(err), nil
 	}
 
+	// The caller may have timed out during the load/seek steps above. Commit
+	// the watch only if it is still wanted: once the pipeline starts, this
+	// node is subscribed while the coordinator has already marked the task
+	// failed, and the re-issued watch would race the stale registration.
+	if err = ctx.Err(); err != nil {
+		log.Warn(ctx, "watch dml channel canceled before commit", mlog.Err(err))
+		return merr.Status(err), nil
+	}
+
 	// start pipeline
 	pipeline.Start()
 	// delegator after all steps done

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -520,6 +520,68 @@ func (suite *ServiceSuite) TestWatchDmChannels_Failed() {
 	suite.Equal(commonpb.ErrorCode_NotReadyServe, status.GetErrorCode())
 }
 
+// TestWatchDmChannels_CanceledContextRollsBack covers the commit-point check
+// added at services.go: WatchDmChannels checks ctx.Err() once, right before
+// pipeline.Start()/delegator.Start(), so a caller whose context is canceled
+// (e.g. the coordinator's task deadline expired while this call was in
+// flight) doesn't leave the node subscribed to a channel the coordinator has
+// already given up on. This asserts the rollback actually happens: the
+// delegator this call registers is not left behind on failure.
+func (suite *ServiceSuite) TestWatchDmChannels_CanceledContextRollsBack() {
+	schema := mock_segcore.GenTestCollectionSchema(suite.collectionName, schemapb.DataType_Int64, false)
+	indexInfos := mock_segcore.GenTestIndexInfoList(suite.collectionID, schema)
+	infos := suite.genSegmentLoadInfos(schema, indexInfos)
+	segmentInfos := lo.SliceToMap(infos, func(info *querypb.SegmentLoadInfo) (int64, *datapb.SegmentInfo) {
+		return info.SegmentID, &datapb.SegmentInfo{
+			ID:            info.SegmentID,
+			CollectionID:  info.CollectionID,
+			PartitionID:   info.PartitionID,
+			InsertChannel: info.InsertChannel,
+			Binlogs:       info.BinlogPaths,
+			Statslogs:     info.Statslogs,
+			Deltalogs:     info.Deltalogs,
+			Level:         info.Level,
+		}
+	})
+
+	req := &querypb.WatchDmChannelsRequest{
+		Base: &commonpb.MsgBase{
+			MsgType:  commonpb.MsgType_WatchDmChannels,
+			MsgID:    rand.Int63(),
+			TargetID: suite.node.session.ServerID,
+		},
+		NodeID:       suite.node.session.ServerID,
+		CollectionID: suite.collectionID,
+		PartitionIDs: suite.partitionIDs,
+		Infos: []*datapb.VchannelInfo{
+			{
+				CollectionID:      suite.collectionID,
+				ChannelName:       suite.vchannel,
+				SeekPosition:      suite.position,
+				FlushedSegmentIds: suite.flushedSegmentIDs,
+				DroppedSegmentIds: suite.droppedSegmentIDs,
+			},
+		},
+		Schema: schema,
+		LoadMeta: &querypb.LoadMetaInfo{
+			MetricType: defaultMetricType,
+		},
+		SegmentInfos:  segmentInfos,
+		IndexInfoList: indexInfos,
+	}
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	status, err := suite.node.WatchDmChannels(canceledCtx, req)
+	suite.NoError(err, "the RPC itself should return a Status, not a transport error")
+	suite.NotEqual(commonpb.ErrorCode_Success, status.GetErrorCode(),
+		"watch must not succeed once its context is already canceled")
+
+	_, ok := suite.node.delegators.Get(suite.vchannel)
+	suite.False(ok, "a canceled watch must not leave its delegator registered")
+}
+
 func (suite *ServiceSuite) TestUnsubDmChannels_Normal() {
 	ctx := context.Background()
 

--- a/internal/storage/rw.go
+++ b/internal/storage/rw.go
@@ -555,6 +555,11 @@ func NewDeltalogReader(
 		}
 		return &IterativeRecordReader{
 			iterate: func() (RecordReader, error) {
+				// The per-file FFI read below cannot be interrupted; honor
+				// cancellation at the file boundary at least.
+				if err := ctx.Err(); err != nil {
+					return nil, err
+				}
 				if pathPos >= len(paths) {
 					return nil, io.EOF
 				}

--- a/internal/storage/rw.go
+++ b/internal/storage/rw.go
@@ -607,6 +607,10 @@ func NewDeltalogReaderFromBinlogs(
 		}
 		return NewLegacyDeltalogReader(ctx, pkField, rwOptions.downloader, paths)
 	case StorageV2, StorageV3:
+		// Unlike NewDeltalogReader, this path builds the FFI reader from all
+		// fragments up front rather than iterating file-by-file, so there is
+		// no per-file boundary to check ctx at; ctx is accepted for signature
+		// symmetry with the V1 branch above but does not bound this call.
 		fragments, err := buildDeltalogFragmentsFromBinlogs(binlogs)
 		if err != nil {
 			return nil, err

--- a/internal/storage/rw.go
+++ b/internal/storage/rw.go
@@ -519,6 +519,7 @@ func NewDeltalogWriter(
 }
 
 func NewDeltalogReader(
+	ctx context.Context,
 	pkType schemapb.DataType,
 	paths []string,
 	option ...RwOption,
@@ -539,7 +540,7 @@ func NewDeltalogReader(
 
 	switch rwOptions.version {
 	case StorageV1:
-		return NewLegacyDeltalogReader(pkField, rwOptions.downloader, paths)
+		return NewLegacyDeltalogReader(ctx, pkField, rwOptions.downloader, paths)
 	case StorageV2, StorageV3:
 		pathPos := 0
 		schema := &schemapb.CollectionSchema{
@@ -571,6 +572,7 @@ func NewDeltalogReader(
 // each binlog's EntriesNum. StorageV3 FFI readers need those row counts to
 // build column groups with stable start/end row offsets.
 func NewDeltalogReaderFromBinlogs(
+	ctx context.Context,
 	pkType schemapb.DataType,
 	binlogs []*datapb.Binlog,
 	option ...RwOption,
@@ -598,7 +600,7 @@ func NewDeltalogReaderFromBinlogs(
 			}
 			paths = append(paths, binlog.GetLogPath())
 		}
-		return NewLegacyDeltalogReader(pkField, rwOptions.downloader, paths)
+		return NewLegacyDeltalogReader(ctx, pkField, rwOptions.downloader, paths)
 	case StorageV2, StorageV3:
 		fragments, err := buildDeltalogFragmentsFromBinlogs(binlogs)
 		if err != nil {

--- a/internal/storage/serde_delta.go
+++ b/internal/storage/serde_delta.go
@@ -688,13 +688,13 @@ func (r *deleteLogToRecordReader) Close() error {
 	return r.reader.Close()
 }
 
-func NewLegacyDeltalogReader(pkField *schemapb.FieldSchema, downloader downloaderFn, paths []string) (RecordReader, error) {
+func NewLegacyDeltalogReader(ctx context.Context, pkField *schemapb.FieldSchema, downloader downloaderFn, paths []string) (RecordReader, error) {
 	if len(paths) == 0 {
 		return newSimpleArrowRecordReader(nil)
 	}
 
 	// Download all blobs first
-	blobData, err := downloader(context.Background(), paths)
+	blobData, err := downloader(ctx, paths)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/serde_events_test.go
+++ b/internal/storage/serde_events_test.go
@@ -547,6 +547,7 @@ func TestDeltalogReaderExternalContext(t *testing.T) {
 	defer mock.UnPatch()
 
 	reader, err := NewDeltalogReader(
+		context.Background(),
 		schemapb.DataType_Int64,
 		[]string{sourcePath},
 		WithVersion(StorageV3),

--- a/internal/util/importutilv2/binlog/l0_reader.go
+++ b/internal/util/importutilv2/binlog/l0_reader.go
@@ -109,7 +109,7 @@ func (r *l0Reader) Read() (*storage.DeleteData, error) {
 	deleteData := storage.NewDeleteData(nil, nil)
 	readInternal := func(path string, opts []storage.RwOption) (*storage.DeleteData, error) {
 		tempData := storage.NewDeleteData(nil, nil)
-		reader, err := storage.NewDeltalogReader(r.pkField.DataType, []string{path}, opts...)
+		reader, err := storage.NewDeltalogReader(r.ctx, r.pkField.DataType, []string{path}, opts...)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/util/importutilv2/binlog/reader.go
+++ b/internal/util/importutilv2/binlog/reader.go
@@ -209,7 +209,7 @@ func (r *reader) readDelete(deltaLogs []string, tsStart, tsEnd uint64) (map[any]
 		if err != nil {
 			return nil, err
 		}
-		reader, err := storage.NewDeltalogReader(pkField.DataType, []string{path}, opts...)
+		reader, err := storage.NewDeltalogReader(r.ctx, pkField.DataType, []string{path}, opts...)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3252,9 +3252,9 @@ If this parameter is set false, Milvus simply searches the growing segments with
 	p.SegmentTaskTimeout = ParamItem{
 		Key:          "queryCoord.segmentTaskTimeout",
 		Version:      "2.0.0",
-		DefaultValue: "120000",
+		DefaultValue: "180000",
 		PanicIfEmpty: true,
-		Doc:          "2 minutes",
+		Doc:          "3 minutes",
 		Export:       true,
 	}
 	p.SegmentTaskTimeout.Init(base.mgr)

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3242,9 +3242,9 @@ If this parameter is set false, Milvus simply searches the growing segments with
 	p.ChannelTaskTimeout = ParamItem{
 		Key:          "queryCoord.channelTaskTimeout",
 		Version:      "2.0.0",
-		DefaultValue: "60000",
+		DefaultValue: "300000",
 		PanicIfEmpty: true,
-		Doc:          "1 minute",
+		Doc:          "5 minutes",
 		Export:       true,
 	}
 	p.ChannelTaskTimeout.Init(base.mgr)
@@ -3252,9 +3252,9 @@ If this parameter is set false, Milvus simply searches the growing segments with
 	p.SegmentTaskTimeout = ParamItem{
 		Key:          "queryCoord.segmentTaskTimeout",
 		Version:      "2.0.0",
-		DefaultValue: "120000",
+		DefaultValue: "300000",
 		PanicIfEmpty: true,
-		Doc:          "2 minute",
+		Doc:          "5 minutes",
 		Export:       true,
 	}
 	p.SegmentTaskTimeout.Init(base.mgr)

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3242,9 +3242,9 @@ If this parameter is set false, Milvus simply searches the growing segments with
 	p.ChannelTaskTimeout = ParamItem{
 		Key:          "queryCoord.channelTaskTimeout",
 		Version:      "2.0.0",
-		DefaultValue: "300000",
+		DefaultValue: "120000",
 		PanicIfEmpty: true,
-		Doc:          "5 minutes",
+		Doc:          "2 minutes",
 		Export:       true,
 	}
 	p.ChannelTaskTimeout.Init(base.mgr)
@@ -3252,9 +3252,9 @@ If this parameter is set false, Milvus simply searches the growing segments with
 	p.SegmentTaskTimeout = ParamItem{
 		Key:          "queryCoord.segmentTaskTimeout",
 		Version:      "2.0.0",
-		DefaultValue: "300000",
+		DefaultValue: "120000",
 		PanicIfEmpty: true,
-		Doc:          "5 minutes",
+		Doc:          "2 minutes",
 		Export:       true,
 	}
 	p.SegmentTaskTimeout.Init(base.mgr)

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3252,9 +3252,9 @@ If this parameter is set false, Milvus simply searches the growing segments with
 	p.SegmentTaskTimeout = ParamItem{
 		Key:          "queryCoord.segmentTaskTimeout",
 		Version:      "2.0.0",
-		DefaultValue: "180000",
+		DefaultValue: "300000",
 		PanicIfEmpty: true,
-		Doc:          "3 minutes",
+		Doc:          "5 minutes",
 		Export:       true,
 	}
 	p.SegmentTaskTimeout.Init(base.mgr)


### PR DESCRIPTION
issue: #52257 related

`queryCoord.channelTaskTimeout` and `queryCoord.segmentTaskTimeout` were passed into `ChannelTask`/`SegmentTask` but never applied, and `LeaderTask` never took a timeout at all: every task context was created with `context.WithCancel`, so the configured timeouts were dead. A stuck `WatchDmChannels` / `UnsubDmChannel` / `LoadSegments` / `SyncDistribution` RPC (e.g. blocked on storage failures) could pin its scheduler slot and the channel/segment forever.

This PR binds the timeout to the task context, so it:

- bounds the task's action RPCs, starting from the moment it's actually dispatched to a QueryNode (see below — **not** from queue-add time);
- propagates through gRPC to the QueryNode and cancels the server-side operation;
- lets the task fail, free its scheduler slot, and be re-generated by the checker from the current distribution instead of hanging forever.

Leader tasks reuse `segmentTaskTimeout`. `channelTaskTimeout` default is unified to **2 minutes** (previously 60s, unenforced). `segmentTaskTimeout` defaults to **5 minutes** (previously 120s, unenforced) — kept longer than the channel timeout because segment loads (large/disk-index segments, S3 throttling) routinely take longer than channel watch/unsub ops. 5 minutes is judged enough headroom for a single segment's load under normal conditions; see the "Known residual gaps" section below for why this is still a flat budget rather than a true fix.

---

**Deadline starts at first dispatch, not at task construction** (added after initial review from bigsheeper/czs007): binding the deadline at `newBaseTask()` construction time meant a task sitting in the wait queue, or repeatedly bounced by the executor's admission cap (`GetChannelTaskCap`/`GetNonChannelTaskCap`), burned its RPC budget on queueing/admission delay rather than on the actual RPC. Under congestion — exactly when the checker's rebuilt-task-retry loop is most likely to spin — this could make a task that would otherwise succeed fail deterministically every round purely due to scheduler load, independent of whether the underlying operation would have completed within the configured timeout.

`Task.ActivateDeadline(step)` now arms a fresh timeout per step, called by `Executor.Execute()` only after that step clears both the wait queue and the admission cap — i.e. at its real dispatch. Queueing and admission-rejection time no longer count against the deadline; only time spent actually executing the action RPC does. A multi-action task (e.g. a move = `[grow, reduce]`) also no longer shares one deadline across both actions: each step gets its own full budget instead of a later step inheriting whatever was left of an earlier one (a slow `grow` could otherwise exhaust the shared budget before `reduce` was ever issued, leaving both the old and new copy live until a later checker round cleaned up the duplicate). `rootCtx`/per-step `ctx` are now guarded by a mutex since (re-)arming can race with `Cancel()`/`Fail()` from the scheduler loop. Known gap, not fixed here: the wait for dist confirmation between a step's RPC returning and the step being marked finished is still covered by whichever deadline was last armed, not its own budget — see the TODOs in `task.go`'s `ActivateDeadline`.

**Synchronous LoadBalance wait bound moved from `task.Wait()`'s parameter to the caller's `ctx`**: `task.Wait()` no longer takes its own timeout parameter -- it just blocks until every task finishes or the caller's `ctx` is done, whichever comes first. The bound that used to live inside it is now applied explicitly at the `handlers.go` call sites via `context.WithTimeout(ctx, SegmentTaskTimeout/ChannelTaskTimeout)`, matching master's pre-PR 1x semantics. This bound is *not* redundant with the task's own deadline, even though a task's deadline is also driven by the same config value: a task's deadline only arms once it clears executor admission (`Task.ActivateDeadline`, called from `Execute()`); if the target node's executor stays saturated (e.g. a large collection's initial load, or bulk rebuild after node recovery), a task can be rejected at admission indefinitely without the deadline ever arming, and nothing else (`checkStale` has no task-age criterion) bounds that wait. Combined with callers that pass no deadline of their own (pymilvus's `utility.load_balance` defaults to `timeout=None`), the handler needs its own explicit bound regardless of the task's deadline -- so this is a genuinely separate concern ("how long is this RPC willing to wait") from the task's own execution budget, not a duplicate guess at it.

**`task.Wait()` (used by the synchronous LoadBalance path) no longer has a false-success race**: it previously wrote its result via a shared `err` variable from a background goroutine with no synchronization and read it after `<-ctx.Done()`; if the outer timeout fired before the goroutine finished, it returned a false `nil` (success) and raced on the variable. Switched to an error channel + `select` so a real timeout is reported as `ctx.Err()`.

---

Two follow-ups from the cancellation audit are folded in as separate commits:

- **Legacy deltalog download honors ctx**: `NewLegacyDeltalogReader` invoked its downloader with `context.Background()`, making the L0/deltalog download during segment load immune to the deadline. `ctx` is now threaded through `NewDeltalogReader`/`NewDeltalogReaderFromBinlogs`/`NewLegacyDeltalogReader` (mechanical; all call sites already had a ctx in scope). Note: `NewDeltalogReaderFromBinlogs`'s StorageV2/V3 branch accepts `ctx` for signature symmetry but doesn't check it (no per-file boundary to check at, and no callers today); its V1 branch and `NewDeltalogReader`'s V2/V3 branch (which does have a per-file boundary) both honor it.
- **Canceled watch is not committed**: `WatchDmChannels` now checks `ctx.Err()` once at the commit point (before `pipeline.Start()`/`delegator.Start()`), so a request whose caller timed out rolls back through the existing cleanup chain instead of leaving the node subscribed and racing the re-issued watch's dispatcher registration.
- **Singleflight join honors the joiner's ctx**: `delegator` `sLoad` joined an identical in-flight load via `singleflight.Do`, which ignores the joiner's context; switched to `DoChan` raced against `ctx.Done()` — the joiner exits on its own deadline while the shared load keeps running for its initiator.
- **Packed deltalog iteration checks ctx at file boundaries**: the StorageV2/V3 per-file FFI read cannot be interrupted mid-file; a canceled load now stops between files.

**Known residual gaps (not addressed here, tracked separately)**:
- Vector index load (`CacheIndexToDisk`/`Deserialize` in knowhere/segcore) has no cancellation token, so a timed-out task's underlying C++ load keeps running in the background for the node it was originally dispatched to (a same-node retry joins the in-flight load; a cross-node retry duplicates memory/bandwidth until the original finishes) — tracked at zilliztech/knowhere#1771.
- `unsub`'s WAL `ManualFlush` append is intentionally `WithoutCancel` (WAL consistency invariant, see #45077/#45078) and can accumulate blocked goroutines during a sustained WAL outage.
- **No backoff on repeated timeout-driven rebuild (TODO'd in code, not fixed here)**: each per-task deadline assumes a segment/channel op finishes within its configured timeout (`segmentTaskTimeout` defaults to 5min, `channelTaskTimeout` to 2min). If the real op time is consistently longer -- a large disk-index segment on throttled cold storage, or a channel with a large L0/growing backlog -- `SegmentChecker`/`ChannelChecker` kills and rebuilds the task with the *same* budget on every check tick (`checkSegmentInterval`/`checkChannelInterval`, default 3s), forever: no backoff, no retry cap, so that segment/channel never converges and the node keeps re-paying the full load I/O every ~timeout+3s. This is not a regression against base (where the timeout never fired, so slow-but-healthy ops eventually succeeded at the cost of never cleaning up genuinely stuck ones) -- this PR makes that tradeoff's cliff real. Fixing it properly means either backoff/a retry cap on `DeadlineExceeded`-driven rebuilds, or redefining the timeout as a no-progress bound instead of a flat wall-clock budget (the latter needs real load-progress reporting from the QueryNode, which doesn't exist today -- estimated as a much larger, separate effort). TODOs left at `task.go`'s `ActivateDeadline`, `SegmentChecker.createSegmentLoadTasks`, and `ChannelChecker`'s equivalent.


