### PR TITLE
fix: propagate caller context into legacy deltalog downloads

### DIFF
--- a/internal/compaction/common.go
+++ b/internal/compaction/common.go
@@ -93,7 +93,7 @@ func readDeltalogsV1(
 
 	for _, deltalog := range deltalogs {
 		for _, binlog := range deltalog.Binlogs {
-			reader, err := storage.NewDeltalogReader(pkType, []string{binlog.GetLogPath()}, option...)
+			reader, err := storage.NewDeltalogReader(ctx, pkType, []string{binlog.GetLogPath()}, option...)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -118,7 +118,7 @@ func readDeltalogsV2(
 	paths []string,
 	option ...storage.RwOption,
 ) ([]storage.PrimaryKey, []typeutil.Timestamp, error) {
-	reader, err := storage.NewDeltalogReader(pkType, paths,
+	reader, err := storage.NewDeltalogReader(ctx, pkType, paths,
 		append(option, storage.WithVersion(storage.StorageV3))...)
 	if err != nil {
 		return nil, nil, err

--- a/internal/datanode/external/milvus_table_deltalog.go
+++ b/internal/datanode/external/milvus_table_deltalog.go
@@ -587,6 +587,7 @@ func (t *RefreshExternalCollectionTask) newMilvusTableSourceDeltalogReader(
 ) (storage.RecordReader, error) {
 	if packed.IsMilvusTableStorageV3DeltalogPath(ref.sourcePath) {
 		return storage.NewDeltalogReader(
+			ctx,
 			sourcePKType,
 			[]string{ref.sourcePath},
 			storage.WithVersion(storage.StorageV3),
@@ -598,6 +599,7 @@ func (t *RefreshExternalCollectionTask) newMilvusTableSourceDeltalogReader(
 		return nil, err
 	}
 	return storage.NewDeltalogReader(
+		ctx,
 		sourcePKType,
 		[]string{ref.sourcePath},
 		storage.WithVersion(storage.StorageV1),

--- a/internal/datanode/external/milvus_table_deltalog_test.go
+++ b/internal/datanode/external/milvus_table_deltalog_test.go
@@ -1313,6 +1313,7 @@ func writeDeltalog(
 func readInt64Deltalog(t *testing.T, storageConfig *indexpb.StorageConfig, path string) ([]int64, []int64) {
 	t.Helper()
 	reader, err := storage.NewDeltalogReader(
+		context.Background(),
 		schemapb.DataType_Int64,
 		[]string{path},
 		storage.WithVersion(storage.StorageV3),

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -1366,7 +1366,7 @@ func (loader *segmentLoader) loadDeltalogs(ctx context.Context, segment Segment,
 		if len(paths) == 0 {
 			return nil
 		}
-		reader, err := storage.NewDeltalogReader(pkField.DataType, paths, opts...)
+		reader, err := storage.NewDeltalogReader(ctx, pkField.DataType, paths, opts...)
 		if err != nil {
 			return err
 		}
@@ -1409,6 +1409,7 @@ func (loader *segmentLoader) loadDeltalogs(ctx context.Context, segment Segment,
 				}
 				if len(storageV3Paths) > 0 {
 					reader, err := storage.NewDeltalogReader(
+						ctx,
 						pkField.DataType,
 						storageV3Paths,
 						storage.WithVersion(storage.StorageV3),
@@ -1424,6 +1425,7 @@ func (loader *segmentLoader) loadDeltalogs(ctx context.Context, segment Segment,
 				}
 				if len(legacyPaths) > 0 {
 					reader, err := storage.NewDeltalogReader(
+						ctx,
 						pkField.DataType,
 						legacyPaths,
 						storage.WithVersion(storage.StorageV1),

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -1353,7 +1353,7 @@ func (suite *SegmentLoaderSuite) TestLoadDeltaLogsLegacyParentLoadsChildManifest
 	patchReader := mockey.Mock(storage.NewDeltalogReader).To(
 		func(pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
 			legacyReaderCalls.Inc()
-			return storage.NewLegacyDeltalogReader(&schemapb.FieldSchema{
+			return storage.NewLegacyDeltalogReader(context.Background(), &schemapb.FieldSchema{
 				FieldID:      0,
 				DataType:     pkType,
 				IsPrimaryKey: true,

--- a/internal/storage/rw.go
+++ b/internal/storage/rw.go
@@ -519,6 +519,7 @@ func NewDeltalogWriter(
 }
 
 func NewDeltalogReader(
+	ctx context.Context,
 	pkType schemapb.DataType,
 	paths []string,
 	option ...RwOption,
@@ -539,7 +540,7 @@ func NewDeltalogReader(
 
 	switch rwOptions.version {
 	case StorageV1:
-		return NewLegacyDeltalogReader(pkField, rwOptions.downloader, paths)
+		return NewLegacyDeltalogReader(ctx, pkField, rwOptions.downloader, paths)
 	case StorageV2, StorageV3:
 		pathPos := 0
 		schema := &schemapb.CollectionSchema{
@@ -571,6 +572,7 @@ func NewDeltalogReader(
 // each binlog's EntriesNum. StorageV3 FFI readers need those row counts to
 // build column groups with stable start/end row offsets.
 func NewDeltalogReaderFromBinlogs(
+	ctx context.Context,
 	pkType schemapb.DataType,
 	binlogs []*datapb.Binlog,
 	option ...RwOption,
@@ -598,7 +600,7 @@ func NewDeltalogReaderFromBinlogs(
 			}
 			paths = append(paths, binlog.GetLogPath())
 		}
-		return NewLegacyDeltalogReader(pkField, rwOptions.downloader, paths)
+		return NewLegacyDeltalogReader(ctx, pkField, rwOptions.downloader, paths)
 	case StorageV2, StorageV3:
 		fragments, err := buildDeltalogFragmentsFromBinlogs(binlogs)
 		if err != nil {

--- a/internal/storage/serde_delta.go
+++ b/internal/storage/serde_delta.go
@@ -688,13 +688,13 @@ func (r *deleteLogToRecordReader) Close() error {
 	return r.reader.Close()
 }
 
-func NewLegacyDeltalogReader(pkField *schemapb.FieldSchema, downloader downloaderFn, paths []string) (RecordReader, error) {
+func NewLegacyDeltalogReader(ctx context.Context, pkField *schemapb.FieldSchema, downloader downloaderFn, paths []string) (RecordReader, error) {
 	if len(paths) == 0 {
 		return newSimpleArrowRecordReader(nil)
 	}
 
 	// Download all blobs first
-	blobData, err := downloader(context.Background(), paths)
+	blobData, err := downloader(ctx, paths)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/serde_events_test.go
+++ b/internal/storage/serde_events_test.go
@@ -547,6 +547,7 @@ func TestDeltalogReaderExternalContext(t *testing.T) {
 	defer mock.UnPatch()
 
 	reader, err := NewDeltalogReader(
+		context.Background(),
 		schemapb.DataType_Int64,
 		[]string{sourcePath},
 		WithVersion(StorageV3),

--- a/internal/util/importutilv2/binlog/l0_reader.go
+++ b/internal/util/importutilv2/binlog/l0_reader.go
@@ -109,7 +109,7 @@ func (r *l0Reader) Read() (*storage.DeleteData, error) {
 	deleteData := storage.NewDeleteData(nil, nil)
 	readInternal := func(path string, opts []storage.RwOption) (*storage.DeleteData, error) {
 		tempData := storage.NewDeleteData(nil, nil)
-		reader, err := storage.NewDeltalogReader(r.pkField.DataType, []string{path}, opts...)
+		reader, err := storage.NewDeltalogReader(r.ctx, r.pkField.DataType, []string{path}, opts...)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/util/importutilv2/binlog/reader.go
+++ b/internal/util/importutilv2/binlog/reader.go
@@ -209,7 +209,7 @@ func (r *reader) readDelete(deltaLogs []string, tsStart, tsEnd uint64) (map[any]
 		if err != nil {
 			return nil, err
 		}
-		reader, err := storage.NewDeltalogReader(pkField.DataType, []string{path}, opts...)
+		reader, err := storage.NewDeltalogReader(r.ctx, pkField.DataType, []string{path}, opts...)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
issue: #52257 related (follow-up of #52478 cancellation audit)

`NewLegacyDeltalogReader` invoked its downloader with `context.Background()`, severing the caller's context. On QueryNode this makes the L0/deltalog download during segment load and channel watch immune to gRPC deadline cancellation: when the coordinator task times out (#52478), the handler goroutine keeps downloading deltalogs until the object-storage client gives up on its own.

Thread `ctx` through `NewDeltalogReader` / `NewDeltalogReaderFromBinlogs` / `NewLegacyDeltalogReader` so the eager download in the StorageV1 path honors the request context. Mechanical signature change; all call sites already have a context in scope.