### PR TITLE
fix: do not commit a canceled watch channel request

### DIFF
--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -354,6 +354,15 @@ func (node *QueryNode) WatchDmChannels(ctx context.Context, req *querypb.WatchDm
 		return merr.Status(err), nil
 	}
 
+	// The caller may have timed out during the load/seek steps above. Commit
+	// the watch only if it is still wanted: once the pipeline starts, this
+	// node is subscribed while the coordinator has already marked the task
+	// failed, and the re-issued watch would race the stale registration.
+	if err = ctx.Err(); err != nil {
+		log.Warn(ctx, "watch dml channel canceled before commit", mlog.Err(err))
+		return merr.Status(err), nil
+	}
+
 	// start pipeline
 	pipeline.Start()
 	// delegator after all steps done


### PR DESCRIPTION
issue: #52257 related (follow-up of #52478 cancellation audit)

`WatchDmChannels` never re-checks its context between phases: a request whose caller already timed out (channel task timeout, #52478) could still start the pipeline and delegator, leaving the node subscribed while the coordinator has marked the task failed and regenerated it. The re-issued watch then races the stale dispatcher registration (`vchannel already exists`).

Check `ctx.Err()` once at the commit point — before `pipeline.Start()` / `delegator.Start()` — so a canceled request rolls back through the existing deferred cleanup chain (delegator removal, pipeline/dispatcher deregistration, collection unref, growing cleanup) instead of committing a watch nobody wants.