### PR TITLE
fix: [cp2.5.13] allocate chunk test buffer with mmap so ~Chunk() can unmap it

### DIFF
--- a/internal/core/unittest/test_chunked_segment.cpp
+++ b/internal/core/unittest/test_chunked_segment.cpp
@@ -79,8 +79,13 @@ TEST(test_chunk_segment, TestSearchOnSealed) {
         auto data = dataset.get_col<float>(fakevec_id);
         auto buf_size = chunk_bitset_size + 4 * data.size();
 
-        char* buf = new char[buf_size];
-        defer.AddDefer([buf]() { delete[] buf; });
+        char* buf = reinterpret_cast<char*>(mmap(nullptr,
+                                                 buf_size,
+                                                 PROT_READ | PROT_WRITE,
+                                                 MAP_PRIVATE | MAP_ANON,
+                                                 -1,
+                                                 0));
+        ASSERT_NE(buf, MAP_FAILED);
         memcpy(buf + chunk_bitset_size, data.data(), 4 * data.size());
 
         auto chunk = std::make_shared<FixedWidthChunk>(


### PR DESCRIPTION
issue: #52479

### What

`TestChunkSegment` fixtures crash with SIGSEGV on 2.5.x hotfix branches — measured **8 crashes in 12 runs (~67%)** with the project's own gtest filter, always stopping at the same point so the remaining suites never run.

### Why

`Chunk` takes ownership of `data_` and releases it in its destructor:

```cpp
// internal/core/src/common/Chunk.h
virtual ~Chunk() { munmap(data_, size_); }
```

That is correct for every production path — both chunk targets allocate through `mmap`:

- `MmapChunkTarget` maps a file
- `MemChunkTarget` maps anonymous memory (despite the name)

The test violated that contract: it passed a `new char[]` buffer and then freed it itself. `~Chunk()` therefore called `munmap()` on a heap address. That fails with `EINVAL` when the address is not page aligned, but **succeeds when it happens to be aligned**, unmapping 8192 bytes of live heap — which is exactly where the intermittency comes from:

```
munmap(0xfcd8d02cac00, 6413) = -1 EINVAL   # not page aligned -> harmless
munmap(0xec0344900000, 6413) = 0           # page aligned -> 2 pages of live heap gone
```

The test's `delete[]` then hands that range back to the allocator, a later allocation reuses it, and the first write faults. The observed fault is inside the *next* fixture's `SetUp` (arrow `StringBuilder` growth going through jemalloc's `arena_ralloc` `memcpy`), which is why the log appears to blame `TestCompareExpr` — gtest prints `[ RUN ]` before calling `SetUp`.

### Fix

Allocate the buffer with anonymous `mmap`, the same way branch `2.5` already does. That change landed on `2.5` in cd931a0388 ("feat: Geospatial Data Type and GIS Function support", #43661) as a drive-by and was never backported; `hotfix-2.5.13` forked before it, which is why only 2.5.x hotfix branches still crash. This PR carries just that hunk, nothing else.

### Verification

On this branch, same machine, same filter:

| | crashes |
|---|---|
| before | **8 / 12** |
| after | **0 / 30** |

```bash
make build-cpp-with-unittest
export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/internal/core/output/lib
internal/core/output/unittest/all_tests \
  --gtest_filter="test_chunk_segment.*:TestChunkSegment.*" --gtest_repeat=30
```

At a 67% per-run crash rate, 30 consecutive clean runs would happen by chance with probability ~1e-15.

### Note

Branches 2.6 / 3.0 / master are unaffected for a second reason as well: there `~Chunk()` is empty and unmapping is handled by `ChunkMmapGuard`, which only releases regions that were actually mapped. Backporting that refactor into a maintenance branch felt disproportionate, so this PR only fixes the contract violation in the test.

/kind bug
