### PR TITLE
fix: prevent sensitive credentials from reaching logs

### DIFF
--- a/docs/agent_guides/observability/logging.md
+++ b/docs/agent_guides/observability/logging.md
@@ -72,6 +72,7 @@ Priority: `FieldXxx(val)` > typed constructor like `mlog.String(key, val)` > `ml
 | `FieldPChannel(v)` | string | `pchannel` |
 | `FieldMessageID(v)` | ObjectMarshaler | `messageID` |
 | `FieldMessage(v)` | ObjectMarshaler | `message` |
+| `FieldSchema(v)` | *schemapb.CollectionSchema | `schema` (external credentials redacted) |
 
 **Generic typed constructors** (use when no predefined FieldXxx exists; function names match Go types):
 `String` / `Int64` / `Int` / `Float64` / `Bool` / `Duration` / `Time` / `Stringer` / `Binary` / `Err` (key fixed to `"error"`), etc.

--- a/internal/datacoord/external_collection_refresh_manager.go
+++ b/internal/datacoord/external_collection_refresh_manager.go
@@ -572,8 +572,8 @@ func (m *externalCollectionRefreshManager) handleJobFinished(ctx context.Context
 		mlog.FieldCollectionID(job.GetCollectionId()),
 		mlog.String("oldSource", currentSource),
 		mlog.String("newSource", newSource),
-		mlog.String("oldSpec", externalspec.RedactExternalSpec(currentSpec)),
-		mlog.String("newSpec", externalspec.RedactExternalSpec(newSpec)))
+		mlog.String("oldSpec", externalspec.RedactExternalSpecForLog(currentSpec)),
+		mlog.String("newSpec", externalspec.RedactExternalSpecForLog(newSpec)))
 
 	if err := m.schemaUpdater(ctx, job.GetCollectionId(), newSource, newSpec); err != nil {
 		mlog.Warn(ctx, "failed to update external schema after refresh, schema may be stale until next refresh",

--- a/internal/datacoord/server_external_schema_updater.go
+++ b/internal/datacoord/server_external_schema_updater.go
@@ -52,6 +52,6 @@ func (s *Server) updateExternalSchemaViaWAL(ctx context.Context, collectionID in
 	mlog.Info(ctx, "updated external schema via RootCoord after refresh",
 		mlog.FieldCollectionID(collectionID),
 		mlog.String("externalSource", externalSource),
-		mlog.String("externalSpec", externalspec.RedactExternalSpec(externalSpec)))
+		mlog.String("externalSpec", externalspec.RedactExternalSpecForLog(externalSpec)))
 	return nil
 }

--- a/internal/datanode/importv2/task_import.go
+++ b/internal/datanode/importv2/task_import.go
@@ -166,7 +166,7 @@ func (t *ImportTask) Execute() []*conc.Future[any] {
 		mlog.Int64("bufferSize", bufferSize),
 		mlog.Int64("taskSlot", t.GetSlots()),
 		mlog.Any("files", t.req.GetFiles()),
-		mlog.Any("schema", t.GetSchema()),
+		mlog.FieldSchema(t.GetSchema()),
 	)...)
 	t.manager.Update(t.GetTaskID(), UpdateState(datapb.ImportTaskStateV2_InProgress))
 

--- a/internal/datanode/importv2/task_l0_import.go
+++ b/internal/datanode/importv2/task_l0_import.go
@@ -141,7 +141,7 @@ func (t *L0ImportTask) Execute() []*conc.Future[any] {
 		mlog.Int("bufferSize", bufferSize),
 		mlog.Int64("taskSlot", t.GetSlots()),
 		mlog.Any("files", t.req.GetFiles()),
-		mlog.Any("schema", t.GetSchema()),
+		mlog.FieldSchema(t.GetSchema()),
 	)...)
 	t.manager.Update(t.GetTaskID(), UpdateState(datapb.ImportTaskStateV2_InProgress))
 

--- a/internal/datanode/importv2/task_l0_preimport.go
+++ b/internal/datanode/importv2/task_l0_preimport.go
@@ -129,7 +129,7 @@ func (t *L0PreImportTask) Execute() []*conc.Future[any] {
 		mlog.Int("bufferSize", bufferSize),
 		mlog.Int64("taskSlot", t.GetSlots()),
 		mlog.Any("files", t.req.GetImportFiles()),
-		mlog.Any("schema", t.GetSchema()),
+		mlog.FieldSchema(t.GetSchema()),
 	)...)
 	t.manager.Update(t.GetTaskID(), UpdateState(datapb.ImportTaskStateV2_InProgress))
 	files := lo.Map(t.GetFileStats(),

--- a/internal/datanode/importv2/task_preimport.go
+++ b/internal/datanode/importv2/task_preimport.go
@@ -139,7 +139,7 @@ func (t *PreImportTask) Execute() []*conc.Future[any] {
 		mlog.Int("bufferSize", bufferSize),
 		mlog.Int64("taskSlot", t.GetSlots()),
 		mlog.Any("files", t.req.GetImportFiles()),
-		mlog.Any("schema", t.GetSchema()),
+		mlog.FieldSchema(t.GetSchema()),
 	)...)
 	t.manager.Update(t.GetTaskID(), UpdateState(datapb.ImportTaskStateV2_InProgress))
 	files := lo.Map(t.GetFileStats(),

--- a/internal/datanode/index/task_index.go
+++ b/internal/datanode/index/task_index.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/protobuf/proto"
+
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/datanode/util"
@@ -35,6 +37,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/workerpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/externalspec"
 	"github.com/milvus-io/milvus/pkg/v3/util/indexparams"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
@@ -236,6 +239,25 @@ func (it *indexBuildTask) PreExecute(ctx context.Context) error {
 	return nil
 }
 
+func redactBuildIndexParamsForLog(params *indexcgopb.BuildIndexInfo) *indexcgopb.BuildIndexInfo {
+	if params == nil {
+		return nil
+	}
+
+	redacted := proto.Clone(params).(*indexcgopb.BuildIndexInfo)
+	if config := redacted.GetStorageConfig(); config != nil {
+		redactStorageCredentialsForLog(
+			&config.AccessKeyID,
+			&config.SecretAccessKey,
+			&config.SslCACert,
+			&config.GcpCredentialJSON,
+		)
+	}
+	redacted.ExternalSource = externalspec.RedactExternalSource(redacted.GetExternalSource())
+	redacted.ExternalSpec = externalspec.RedactExternalSpecForLog(redacted.GetExternalSpec())
+	return redacted
+}
+
 func (it *indexBuildTask) Execute(ctx context.Context) error {
 	log := mlog.With(
 		mlog.String("clusterID", it.req.GetClusterID()),
@@ -340,7 +362,7 @@ func (it *indexBuildTask) Execute(ctx context.Context) error {
 		buildIndexParams.ExternalSource = it.req.GetExternalSource()
 		buildIndexParams.ExternalSpec = it.req.GetExternalSpec()
 	}
-	log.Info(ctx, "create index", mlog.Any("buildIndexParams", buildIndexParams))
+	log.Info(ctx, "create index", mlog.Any("buildIndexParams", redactBuildIndexParamsForLog(buildIndexParams)))
 
 	// set plugin context after logging the indexParams to avoid logging sensitive data
 	if it.pluginContext != nil {

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -147,6 +147,29 @@ func (st *statsTask) IsVectorIndex() bool {
 	return false
 }
 
+func redactStorageCredentialsForLog(accessKeyID, secretAccessKey, sslCACert, gcpCredentialJSON *string) {
+	for _, secret := range []*string{accessKeyID, secretAccessKey, sslCACert, gcpCredentialJSON} {
+		if *secret != "" {
+			*secret = "<redacted>"
+		}
+	}
+}
+
+func redactStorageConfigForLog(config *indexpb.StorageConfig) *indexpb.StorageConfig {
+	if config == nil {
+		return nil
+	}
+
+	redacted := proto.Clone(config).(*indexpb.StorageConfig)
+	redactStorageCredentialsForLog(
+		&redacted.AccessKeyID,
+		&redacted.SecretAccessKey,
+		&redacted.SslCACert,
+		&redacted.GcpCredentialJSON,
+	)
+	return redacted
+}
+
 func (st *statsTask) PreExecute(ctx context.Context) error {
 	ctx, span := otel.Tracer(typeutil.IndexNodeRole).Start(ctx, fmt.Sprintf("Stats-PreExecute-%s-%d", st.req.GetClusterID(), st.req.GetTaskID()))
 	defer span.End()
@@ -186,7 +209,7 @@ func (st *statsTask) PreExecute(ctx context.Context) error {
 		mlog.FieldSegmentID(st.req.GetSegmentID()),
 		mlog.Int64("storageVersion", st.req.GetStorageVersion()),
 		mlog.Int64("preExecuteRecordSpan(ms)", preExecuteRecordSpan.Milliseconds()),
-		mlog.Any("storageConfig", st.req.StorageConfig),
+		mlog.Any("storageConfig", redactStorageConfigForLog(st.req.GetStorageConfig())),
 	)
 	return nil
 }

--- a/internal/datanode/index/task_stats_test.go
+++ b/internal/datanode/index/task_stats_test.go
@@ -17,7 +17,9 @@
 package index
 
 import (
+	"bytes"
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -36,6 +38,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/indexcgowrapper"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
@@ -44,6 +47,43 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
+
+type statsTaskLogBuffer struct {
+	bytes.Buffer
+}
+
+func (*statsTaskLogBuffer) Sync() error {
+	return nil
+}
+
+func captureStatsTaskLogs(t *testing.T) *statsTaskLogBuffer {
+	t.Helper()
+
+	oldLogger := mlog.L()
+	oldLevel := mlog.GetAtomicLevel()
+	logs := &statsTaskLogBuffer{}
+	logger, props, err := mlog.InitLoggerWithWriteSyncer(&mlog.Config{
+		Level:             "debug",
+		Format:            "text",
+		DisableCaller:     true,
+		DisableTimestamp:  true,
+		DisableStacktrace: true,
+	}, logs)
+	require.NoError(t, err)
+	mlog.ReplaceGlobals(logger, props)
+	t.Cleanup(func() {
+		mlog.ReplaceGlobals(oldLogger, &mlog.ZapProperties{Level: oldLevel})
+	})
+	return logs
+}
+
+func statsLogSentinel(parts ...string) string {
+	return strings.Join(parts, "_")
+}
+
+func statsLogCredentialJSON(value string) string {
+	return `{"private_key":"` + value + `"}`
+}
 
 func TestTaskStatsSuite(t *testing.T) {
 	suite.Run(t, new(TaskStatsSuite))
@@ -185,6 +225,49 @@ func (s *TaskStatsSuite) TestSortSegmentWithBM25() {
 		_, err = task.sort(ctx)
 		s.Error(err)
 	})
+}
+
+func (s *TaskStatsSuite) TestPreExecuteDoesNotLogStorageCredentials() {
+	logs := captureStatsTaskLogs(s.T())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	accessKey := statsLogSentinel("STORAGE", "ACCESS", "KEY", "SENTINEL")
+	secretKey := statsLogSentinel("STORAGE", "SECRET", "KEY", "SENTINEL")
+	caCert := statsLogSentinel("STORAGE", "CA", "CERT", "SENTINEL")
+	gcpCredential := statsLogSentinel("GCP", "CREDENTIAL", "JSON", "SENTINEL")
+
+	manager := NewTaskManager(ctx)
+	task := NewStatsTask(ctx, cancel, &workerpb.CreateStatsRequest{
+		ClusterID:    s.clusterID,
+		TaskID:       100,
+		CollectionID: s.collectionID,
+		PartitionID:  s.partitionID,
+		SegmentID:    102,
+		StorageConfig: &indexpb.StorageConfig{
+			Address:           "storage.example.test",
+			StorageType:       "s3",
+			BucketName:        "stats-bucket",
+			RootPath:          "stats/root",
+			AccessKeyID:       accessKey,
+			SecretAccessKey:   secretKey,
+			SslCACert:         caCert,
+			GcpCredentialJSON: statsLogCredentialJSON(gcpCredential),
+		},
+	}, manager, s.mockChunkManager, nil)
+
+	err := task.PreExecute(ctx)
+	s.Require().NoError(err)
+	output := logs.String()
+	s.NotContains(output, accessKey)
+	s.NotContains(output, secretKey)
+	s.NotContains(output, caCert)
+	s.NotContains(output, gcpCredential)
+	s.Contains(output, "storageConfig")
+	s.Contains(output, "storage.example.test")
+	s.Contains(output, "stats-bucket")
+	s.Contains(output, "stats/root")
+	s.Contains(output, "s3")
+	s.Contains(output, "<redacted>")
 }
 
 func (s *TaskStatsSuite) TestBuildIndexParams() {

--- a/internal/datanode/index/task_test.go
+++ b/internal/datanode/index/task_test.go
@@ -154,6 +154,78 @@ func (suite *IndexBuildTaskSuite) TestBuildMemoryIndex() {
 	suite.NoError(err)
 }
 
+func (suite *IndexBuildTaskSuite) TestExecuteDoesNotLogStorageCredentials() {
+	logs := captureStatsTaskLogs(suite.T())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	accessKey := statsLogSentinel("INDEX", "ACCESS", "KEY", "SENTINEL")
+	secretKey := statsLogSentinel("INDEX", "SECRET", "KEY", "SENTINEL")
+	caCert := statsLogSentinel("INDEX", "CA", "CERT", "SENTINEL")
+	gcpCredential := statsLogSentinel("INDEX", "GCP", "CREDENTIAL", "SENTINEL")
+	externalSpecSecret := statsLogSentinel("INDEX", "EXTERNAL", "SPEC", "SENTINEL")
+	externalSpec := `{"format":"parquet","extfs":{"future_secret":"` + externalSpecSecret + `"}}`
+
+	createIndexPatch := mockey.Mock(indexcgowrapper.CreateIndex).To(func(_ context.Context, params *indexcgopb.BuildIndexInfo) (indexcgowrapper.CodecIndex, error) {
+		suite.Equal(accessKey, params.GetStorageConfig().GetAccessKeyID())
+		suite.Equal(secretKey, params.GetStorageConfig().GetSecretAccessKey())
+		suite.Equal(caCert, params.GetStorageConfig().GetSslCACert())
+		suite.Contains(params.GetStorageConfig().GetGcpCredentialJSON(), gcpCredential)
+		suite.Equal(externalSpec, params.GetExternalSpec())
+		return nil, nil
+	}).Build()
+	defer createIndexPatch.UnPatch()
+
+	req := &workerpb.CreateJobRequest{
+		ClusterID:    "test-cluster",
+		BuildID:      1,
+		CollectionID: suite.collectionID,
+		PartitionID:  suite.partitionID,
+		SegmentID:    suite.segmentID,
+		NumRows:      int64(suite.numRows),
+		Dim:          int64(suite.dim),
+		Field: &schemapb.FieldSchema{
+			FieldID:  102,
+			Name:     "vec",
+			DataType: schemapb.DataType_FloatVector,
+		},
+		StorageConfig: &indexpb.StorageConfig{
+			Address:           "storage.example.test",
+			StorageType:       "s3",
+			BucketName:        "index-bucket",
+			RootPath:          "index/root",
+			AccessKeyID:       accessKey,
+			SecretAccessKey:   secretKey,
+			SslCACert:         caCert,
+			GcpCredentialJSON: statsLogCredentialJSON(gcpCredential),
+		},
+		StorageVersion: storage.StorageV2,
+		ExternalSource: "s3://index-bucket/data",
+		ExternalSpec:   externalSpec,
+	}
+
+	task := NewIndexBuildTask(ctx, cancel, req, nil, NewTaskManager(ctx), nil)
+	task.newIndexParams = map[string]string{
+		common.IndexTypeKey:  "FLAT",
+		common.MetricTypeKey: metric.L2,
+	}
+	task.newTypeParams = map[string]string{"dim": "128"}
+
+	err := task.Execute(ctx)
+	suite.NoError(err)
+	output := logs.String()
+	suite.NotContains(output, accessKey)
+	suite.NotContains(output, secretKey)
+	suite.NotContains(output, caCert)
+	suite.NotContains(output, gcpCredential)
+	suite.NotContains(output, externalSpecSecret)
+	suite.Contains(output, "storage.example.test")
+	suite.Contains(output, "index-bucket")
+	suite.Contains(output, "index/root")
+	suite.Contains(output, "s3")
+	suite.Contains(output, "<redacted>")
+}
+
 func (suite *IndexBuildTaskSuite) TestPostExecuteAcceptsEmptyIndexStats() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/datanode/index_services.go
+++ b/internal/datanode/index_services.go
@@ -85,8 +85,7 @@ func (node *DataNode) CreateJob(ctx context.Context, req *workerpb.CreateJobRequ
 	}
 	cm, err := node.storageFactory.NewChunkManager(node.ctx, req.GetStorageConfig())
 	if err != nil {
-		mlog.Error(context.TODO(), "create chunk manager failed", mlog.String("bucket", req.GetStorageConfig().GetBucketName()),
-			mlog.String("accessKey", req.GetStorageConfig().GetAccessKeyID()),
+		mlog.Error(ctx, "create chunk manager failed", mlog.String("bucket", req.GetStorageConfig().GetBucketName()),
 			mlog.Err(err),
 		)
 		node.taskManager.DeleteIndexTaskInfos(ctx, []index.Key{{ClusterID: req.GetClusterID(), TaskID: req.GetBuildID()}})
@@ -287,8 +286,7 @@ func (node *DataNode) createIndexTask(ctx context.Context, req *workerpb.CreateJ
 	}
 	cm, err := node.storageFactory.NewChunkManager(node.ctx, req.GetStorageConfig())
 	if err != nil {
-		mlog.Error(context.TODO(), "create chunk manager failed", mlog.String("bucket", req.GetStorageConfig().GetBucketName()),
-			mlog.String("accessKey", req.GetStorageConfig().GetAccessKeyID()),
+		mlog.Error(ctx, "create chunk manager failed", mlog.String("bucket", req.GetStorageConfig().GetBucketName()),
 			mlog.Err(err),
 		)
 		node.taskManager.DeleteIndexTaskInfos(ctx, []index.Key{{ClusterID: req.GetClusterID(), TaskID: req.GetBuildID()}})
@@ -398,8 +396,7 @@ func (node *DataNode) createStatsTask(ctx context.Context, req *workerpb.CreateS
 	}
 	cm, err := node.storageFactory.NewChunkManager(node.ctx, req.GetStorageConfig())
 	if err != nil {
-		mlog.Error(context.TODO(), "create chunk manager failed", mlog.String("bucket", req.GetStorageConfig().GetBucketName()),
-			mlog.String("accessKey", req.GetStorageConfig().GetAccessKeyID()),
+		mlog.Error(ctx, "create chunk manager failed", mlog.String("bucket", req.GetStorageConfig().GetBucketName()),
 			mlog.Err(err),
 		)
 		node.taskManager.DeleteStatsTaskInfos(ctx, []index.Key{{ClusterID: req.GetClusterID(), TaskID: req.GetTaskID()}})

--- a/internal/datanode/services.go
+++ b/internal/datanode/services.go
@@ -370,8 +370,7 @@ func (node *DataNode) PreImport(ctx context.Context, req *datapb.PreImportReques
 
 	cm, err := node.storageFactory.NewChunkManager(node.ctx, req.GetStorageConfig())
 	if err != nil {
-		mlog.Error(context.TODO(), "create chunk manager failed", mlog.String("bucket", req.GetStorageConfig().GetBucketName()),
-			mlog.String("accessKey", req.GetStorageConfig().GetAccessKeyID()),
+		mlog.Error(ctx, "create chunk manager failed", mlog.String("bucket", req.GetStorageConfig().GetBucketName()),
 			mlog.Err(err),
 		)
 		return merr.Status(err), nil
@@ -398,8 +397,7 @@ func (node *DataNode) ImportV2(ctx context.Context, req *datapb.ImportRequest) (
 
 	cm, err := node.storageFactory.NewChunkManager(node.ctx, req.GetStorageConfig())
 	if err != nil {
-		mlog.Error(context.TODO(), "create chunk manager failed", mlog.String("bucket", req.GetStorageConfig().GetBucketName()),
-			mlog.String("accessKey", req.GetStorageConfig().GetAccessKeyID()),
+		mlog.Error(ctx, "create chunk manager failed", mlog.String("bucket", req.GetStorageConfig().GetBucketName()),
 			mlog.Err(err),
 		)
 		return merr.Status(err), nil
@@ -518,9 +516,8 @@ func (node *DataNode) CopySegment(ctx context.Context, req *datapb.CopySegmentRe
 
 	cm, err := node.storageFactory.NewChunkManager(node.ctx, req.GetStorageConfig())
 	if err != nil {
-		mlog.Error(context.TODO(), "create chunk manager failed",
+		mlog.Error(ctx, "create chunk manager failed",
 			mlog.String("bucket", req.GetStorageConfig().GetBucketName()),
-			mlog.String("accessKey", req.GetStorageConfig().GetAccessKeyID()),
 			mlog.Err(err),
 		)
 		return merr.Status(err), nil

--- a/internal/datanode/services_test.go
+++ b/internal/datanode/services_test.go
@@ -17,6 +17,7 @@
 package datanode
 
 import (
+	"bytes"
 	"context"
 	"math/rand"
 	"strings"
@@ -24,6 +25,8 @@ import (
 	"time"
 
 	"github.com/bytedance/mockey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"google.golang.org/protobuf/proto"
@@ -1318,4 +1321,132 @@ func (s *DataNodeServicesSuite) TestDropTaskCopySegment() {
 		status, err := s.node.DropTask(s.ctx, dropReq)
 		s.NoError(merr.CheckRPCCall(status, err))
 	})
+}
+
+type dataNodeLogBuffer struct {
+	bytes.Buffer
+}
+
+func (*dataNodeLogBuffer) Sync() error {
+	return nil
+}
+
+func captureDataNodeLogs(t *testing.T) *dataNodeLogBuffer {
+	t.Helper()
+
+	oldLogger := mlog.L()
+	oldLevel := mlog.GetAtomicLevel()
+	logs := &dataNodeLogBuffer{}
+	logger, props, err := mlog.InitLoggerWithWriteSyncer(&mlog.Config{
+		Level:             "debug",
+		Format:            "text",
+		DisableCaller:     true,
+		DisableTimestamp:  true,
+		DisableStacktrace: true,
+	}, logs)
+	require.NoError(t, err)
+	mlog.ReplaceGlobals(logger, props)
+	t.Cleanup(func() {
+		mlog.ReplaceGlobals(oldLogger, &mlog.ZapProperties{Level: oldLevel})
+	})
+	return logs
+}
+
+type failingStorageFactory struct{}
+
+func (failingStorageFactory) NewChunkManager(context.Context, *indexpb.StorageConfig) (storage.ChunkManager, error) {
+	return nil, merr.WrapErrIoFailedReason("storage factory unavailable")
+}
+
+func TestChunkManagerFailureDoesNotLogStorageAccessKey(t *testing.T) {
+	logs := captureDataNodeLogs(t)
+	ctx := context.Background()
+	node := NewDataNode(ctx)
+	node.UpdateStateCode(commonpb.StateCode_Healthy)
+	node.storageFactory = failingStorageFactory{}
+
+	accessKey := "DATANODE_ACCESS_KEY_SENTINEL"
+	storageConfig := &indexpb.StorageConfig{
+		BucketName:  "audit-bucket",
+		AccessKeyID: accessKey,
+	}
+
+	testCases := []struct {
+		name string
+		call func() (*commonpb.Status, error)
+	}{
+		{
+			name: "legacy index job",
+			call: func() (*commonpb.Status, error) {
+				return node.CreateJob(ctx, &workerpb.CreateJobRequest{
+					ClusterID:     "cluster",
+					BuildID:       1,
+					StorageConfig: storageConfig,
+				})
+			},
+		},
+		{
+			name: "v2 index job",
+			call: func() (*commonpb.Status, error) {
+				return node.CreateJobV2(ctx, &workerpb.CreateJobV2Request{
+					ClusterID: "cluster",
+					TaskID:    2,
+					JobType:   indexpb.JobType_JobTypeIndexJob,
+					Request: &workerpb.CreateJobV2Request_IndexRequest{
+						IndexRequest: &workerpb.CreateJobRequest{
+							ClusterID:     "cluster",
+							BuildID:       2,
+							StorageConfig: storageConfig,
+						},
+					},
+				})
+			},
+		},
+		{
+			name: "stats job",
+			call: func() (*commonpb.Status, error) {
+				return node.CreateJobV2(ctx, &workerpb.CreateJobV2Request{
+					ClusterID: "cluster",
+					TaskID:    3,
+					JobType:   indexpb.JobType_JobTypeStatsJob,
+					Request: &workerpb.CreateJobV2Request_StatsRequest{
+						StatsRequest: &workerpb.CreateStatsRequest{
+							ClusterID:     "cluster",
+							TaskID:        3,
+							StorageConfig: storageConfig,
+						},
+					},
+				})
+			},
+		},
+		{
+			name: "pre-import",
+			call: func() (*commonpb.Status, error) {
+				return node.PreImport(ctx, &datapb.PreImportRequest{TaskID: 4, StorageConfig: storageConfig})
+			},
+		},
+		{
+			name: "import",
+			call: func() (*commonpb.Status, error) {
+				return node.ImportV2(ctx, &datapb.ImportRequest{TaskID: 5, StorageConfig: storageConfig})
+			},
+		},
+		{
+			name: "copy segment",
+			call: func() (*commonpb.Status, error) {
+				return node.CopySegment(ctx, &datapb.CopySegmentRequest{TaskID: 6, StorageConfig: storageConfig})
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			status, err := testCase.call()
+			require.NoError(t, err)
+			assert.Error(t, merr.Error(status))
+		})
+	}
+
+	assert.NotContains(t, logs.String(), accessKey)
+	assert.Contains(t, logs.String(), "audit-bucket")
 }

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -477,19 +477,47 @@ func restfulSizeMiddleware(handler gin.HandlerFunc, observeOutbound bool) gin.Ha
 
 func getTraceLogRequestFieldWithoutSensitiveInfo(req any) mlog.Field {
 	switch request := req.(type) {
+	case *CollectionReq:
+		if request == nil {
+			return proxy.GetRequestFieldWithoutSensitiveInfo(req)
+		}
+		redactedReq := *request
+		redactedReq.Schema.ExternalSource = externalspec.RedactExternalSource(request.Schema.ExternalSource)
+		redactedReq.Schema.ExternalSpec = externalspec.RedactExternalSpecForLog(request.Schema.ExternalSpec)
+		redactedReq.TopLevelExternalSource = externalspec.RedactExternalSource(request.TopLevelExternalSource)
+		redactedReq.TopLevelExternalSpec = externalspec.RedactExternalSpecForLog(request.TopLevelExternalSpec)
+		return mlog.Any("request", &redactedReq)
+	case *RefreshExternalCollectionReq:
+		if request == nil {
+			return proxy.GetRequestFieldWithoutSensitiveInfo(req)
+		}
+		redactedReq := *request
+		redactedReq.ExternalSource = externalspec.RedactExternalSource(request.ExternalSource)
+		redactedReq.ExternalSpec = externalspec.RedactExternalSpecForLog(request.ExternalSpec)
+		return mlog.Any("request", &redactedReq)
+	case *PasswordReq:
+		if request == nil {
+			return proxy.GetRequestFieldWithoutSensitiveInfo(req)
+		}
+		return mlog.Any("request", &UserReq{UserName: request.UserName})
+	case *NewPasswordReq:
+		if request == nil {
+			return proxy.GetRequestFieldWithoutSensitiveInfo(req)
+		}
+		return mlog.Any("request", &UserReq{UserName: request.UserName})
 	case *RestoreExternalSnapshotReq:
 		if request == nil {
 			return proxy.GetRequestFieldWithoutSensitiveInfo(req)
 		}
 		redactedReq := *request
-		redactedReq.ExternalSpec = externalspec.RedactExternalSpec(request.ExternalSpec)
+		redactedReq.ExternalSpec = externalspec.RedactExternalSpecForLog(request.ExternalSpec)
 		return mlog.Any("request", &redactedReq)
 	case *ExportSnapshotReq:
 		if request == nil {
 			return proxy.GetRequestFieldWithoutSensitiveInfo(req)
 		}
 		redactedReq := *request
-		redactedReq.ExternalSpec = externalspec.RedactExternalSpec(request.ExternalSpec)
+		redactedReq.ExternalSpec = externalspec.RedactExternalSpecForLog(request.ExternalSpec)
 		return mlog.Any("request", &redactedReq)
 	default:
 		return proxy.GetRequestFieldWithoutSensitiveInfo(req)
@@ -686,7 +714,7 @@ func (h *HandlersV2) getCollectionDetails(ctx context.Context, c *gin.Context, a
 	primaryField, ok := getPrimaryField(coll.Schema)
 	autoID := false
 	if !ok {
-		mlog.Warn(ctx, "high level restful api, get primary field from collection schema fail", mlog.Any("collection schema", coll.Schema), mlog.Any("request", anyReq))
+		mlog.Warn(ctx, "high level restful api, get primary field from collection schema fail", mlog.FieldSchema(coll.Schema), mlog.Any("request", anyReq))
 	} else {
 		autoID = primaryField.AutoID
 	}
@@ -2316,6 +2344,7 @@ func consistencyLevelForCreateCollection(httpReq *CollectionReq) (commonpb.Consi
 
 func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
 	httpReq := anyReq.(*CollectionReq)
+	requestLogField := getTraceLogRequestFieldWithoutSensitiveInfo(anyReq)
 	req := &milvuspb.CreateCollectionRequest{
 		DbName:         dbName,
 		CollectionName: httpReq.CollectionName,
@@ -2326,7 +2355,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 	if httpReq.HasTopLevelExternalConfig() {
 		err := merr.WrapErrParameterInvalid("schema.externalSource/schema.externalSpec", "top-level externalSource/externalSpec",
 			"externalSource and externalSpec must be set under schema when creating an external collection")
-		mlog.Warn(ctx, "high level restful api, create external collection with top-level external config fail", mlog.Err(err), mlog.Any("request", anyReq))
+		mlog.Warn(ctx, "high level restful api, create external collection with top-level external config fail", mlog.Err(err), requestLogField)
 		HTTPAbortReturn(c, http.StatusOK, gin.H{
 			HTTPReturnCode:    merr.Code(err),
 			HTTPReturnMessage: err.Error(),
@@ -2343,7 +2372,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 		if httpReq.GetExternalSource() != "" || httpReq.GetExternalSpec() != "" {
 			err := merr.WrapErrParameterInvalid("schema.fields", "empty schema fields",
 				"external collection is not supported by quick create; provide schema.fields with externalField")
-			mlog.Warn(ctx, "high level restful api, quickly create external collection fail", mlog.Err(err), mlog.Any("request", anyReq))
+			mlog.Warn(ctx, "high level restful api, quickly create external collection fail", mlog.Err(err), requestLogField)
 			HTTPAbortReturn(c, http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(err),
 				HTTPReturnMessage: err.Error(),
@@ -2353,7 +2382,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 		if len(httpReq.Schema.Functions) > 0 {
 			err := merr.WrapErrParameterInvalid("schema", "functions",
 				"functions are not supported for quickly create collection")
-			mlog.Warn(ctx, "high level restful api, quickly create collection fail", mlog.Err(err), mlog.Any("request", anyReq))
+			mlog.Warn(ctx, "high level restful api, quickly create collection fail", mlog.Err(err), requestLogField)
 			HTTPAbortReturn(c, http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(err),
 				HTTPReturnMessage: err.Error(),
@@ -2375,7 +2404,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 		default:
 			err := merr.WrapErrParameterInvalid("FloatVector, BinaryVector, Float16Vector, BFloat16Vector, SparseFloatVector", httpReq.VectorFieldType,
 				"vectorFieldType can only be [FloatVector, BinaryVector, Float16Vector, BFloat16Vector, SparseFloatVector], default: FloatVector")
-			mlog.Warn(ctx, "high level restful api, quickly create collection fail", mlog.Err(err), mlog.Any("request", anyReq))
+			mlog.Warn(ctx, "high level restful api, quickly create collection fail", mlog.Err(err), requestLogField)
 			HTTPAbortReturn(c, http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(err),
 				HTTPReturnMessage: err.Error(),
@@ -2386,7 +2415,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 		if quickCreateVectorDataType == schemapb.DataType_SparseFloatVector && httpReq.Dimension != 0 {
 			err := merr.WrapErrParameterInvalid(int32(0), httpReq.Dimension,
 				"dimension should not be specified for SparseFloatVector quick create")
-			mlog.Warn(ctx, "high level restful api, quickly create collection fail", mlog.Err(err), mlog.Any("request", anyReq))
+			mlog.Warn(ctx, "high level restful api, quickly create collection fail", mlog.Err(err), requestLogField)
 			HTTPAbortReturn(c, http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(err),
 				HTTPReturnMessage: err.Error(),
@@ -2397,7 +2426,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 		if quickCreateVectorDataType != schemapb.DataType_SparseFloatVector && httpReq.Dimension == 0 {
 			err := merr.WrapErrParameterInvalid("collectionName & dimension", "collectionName",
 				"dimension is required for quickly create collection(default metric type: "+DefaultMetricType+")")
-			mlog.Warn(ctx, "high level restful api, quickly create collection fail", mlog.Err(err), mlog.Any("request", anyReq))
+			mlog.Warn(ctx, "high level restful api, quickly create collection fail", mlog.Err(err), requestLogField)
 			HTTPAbortReturn(c, http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(err),
 				HTTPReturnMessage: err.Error(),
@@ -2408,7 +2437,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 			httpReq.MetricType = defaultMetricTypeForQuickCreate(quickCreateVectorDataType)
 		}
 		if err := validateMetricTypeForQuickCreate(quickCreateVectorDataType, httpReq.MetricType); err != nil {
-			mlog.Warn(ctx, "high level restful api, quickly create collection fail", mlog.Err(err), mlog.Any("request", anyReq))
+			mlog.Warn(ctx, "high level restful api, quickly create collection fail", mlog.Err(err), requestLogField)
 			HTTPAbortReturn(c, http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(err),
 				HTTPReturnMessage: err.Error(),
@@ -2430,7 +2459,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 		default:
 			err := merr.WrapErrParameterInvalid("Int64, Varchar", httpReq.IDType,
 				"idType can only be [Int64, VarChar], default: Int64")
-			mlog.Warn(ctx, "high level restful api, quickly create collection fail", mlog.Err(err), mlog.Any("request", anyReq))
+			mlog.Warn(ctx, "high level restful api, quickly create collection fail", mlog.Err(err), requestLogField)
 			HTTPAbortReturn(c, http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(err),
 				HTTPReturnMessage: err.Error(),
@@ -2447,7 +2476,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 		if enStr, ok := httpReq.Params["enableDynamicField"]; ok {
 			enableDynamic, err = strconv.ParseBool(fmt.Sprintf("%v", enStr))
 			if err != nil {
-				mlog.Warn(ctx, "high level restful api, parse enableDynamicField fail", mlog.Err(err), mlog.Any("request", anyReq))
+				mlog.Warn(ctx, "high level restful api, parse enableDynamicField fail", mlog.Err(err), requestLogField)
 				HTTPAbortReturn(c, http.StatusOK, gin.H{
 					HTTPReturnCode:    merr.Code(err),
 					HTTPReturnMessage: "parse enableDynamicField fail, err:" + err.Error(),
@@ -2585,7 +2614,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 			structField := httpReq.Schema.StructFields[i]
 			if _, dup := fieldNames[structField.FieldName]; dup {
 				err := merr.WrapErrParameterInvalidMsg("duplicated field name: %s", structField.FieldName)
-				mlog.Warn(ctx, "high level restful api, create collection fail", mlog.Err(err), mlog.Any("request", anyReq))
+				mlog.Warn(ctx, "high level restful api, create collection fail", mlog.Err(err), requestLogField)
 				HTTPAbortReturn(c, http.StatusOK, gin.H{
 					HTTPReturnCode:    merr.Code(err),
 					HTTPReturnMessage: err.Error(),
@@ -2612,7 +2641,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 		schema, err = proto.Marshal(&collSchema)
 	}
 	if err != nil {
-		mlog.Warn(ctx, "high level restful api, marshal collection schema fail", mlog.Err(err), mlog.Any("request", anyReq))
+		mlog.Warn(ctx, "high level restful api, marshal collection schema fail", mlog.Err(err), requestLogField)
 		HTTPAbortReturn(c, http.StatusOK, gin.H{
 			HTTPReturnCode:    merr.Code(merr.ErrMarshalCollectionSchema),
 			HTTPReturnMessage: merr.ErrMarshalCollectionSchema.Error() + ", error: " + err.Error(),
@@ -2631,7 +2660,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 
 	consistencyLevel, err := consistencyLevelForCreateCollection(httpReq)
 	if err != nil {
-		mlog.Warn(ctx, "high level restful api, create collection fail", mlog.Err(err), mlog.Any("request", anyReq))
+		mlog.Warn(ctx, "high level restful api, create collection fail", mlog.Err(err), requestLogField)
 		HTTPAbortReturn(c, http.StatusOK, gin.H{
 			HTTPReturnCode:    merr.Code(err),
 			HTTPReturnMessage: err.Error(),
@@ -2749,7 +2778,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 			createIndexReq.ExtraParams, err = convertToExtraParams(indexParam)
 			if err != nil {
 				// will not happen
-				mlog.Warn(ctx, "high level restful api, convertToExtraParams fail", mlog.Err(err), mlog.Any("request", anyReq))
+				mlog.Warn(ctx, "high level restful api, convertToExtraParams fail", mlog.Err(err), requestLogField)
 				HTTPAbortReturn(c, http.StatusOK, gin.H{
 					HTTPReturnCode:    merr.Code(err),
 					HTTPReturnMessage: err.Error(),

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proxy"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/crypto"
@@ -82,6 +83,35 @@ func init() {
 	streaming.SetupNoopWALForTest()
 }
 
+type httpServerLogBuffer struct {
+	bytes.Buffer
+}
+
+func (*httpServerLogBuffer) Sync() error {
+	return nil
+}
+
+func captureHTTPServerLogs(t *testing.T) *httpServerLogBuffer {
+	t.Helper()
+
+	oldLogger := mlog.L()
+	oldLevel := mlog.GetAtomicLevel()
+	logs := &httpServerLogBuffer{}
+	logger, props, err := mlog.InitLoggerWithWriteSyncer(&mlog.Config{
+		Level:             "debug",
+		Format:            "text",
+		DisableCaller:     true,
+		DisableTimestamp:  true,
+		DisableStacktrace: true,
+	}, logs)
+	require.NoError(t, err)
+	mlog.ReplaceGlobals(logger, props)
+	t.Cleanup(func() {
+		mlog.ReplaceGlobals(oldLogger, &mlog.ZapProperties{Level: oldLevel})
+	})
+	return logs
+}
+
 func sendReqAndVerify(t *testing.T, testEngine *gin.Engine, testName, method string, testcase requestBodyTestCase) {
 	t.Run(testName, func(t *testing.T) {
 		req := httptest.NewRequest(method, testcase.path, bytes.NewReader(testcase.requestBody))
@@ -99,7 +129,7 @@ func sendReqAndVerify(t *testing.T, testEngine *gin.Engine, testName, method str
 }
 
 func TestTraceLogRequestFieldRedactsRESTSnapshotExternalSpec(t *testing.T) {
-	externalSpec := `{"extfs":{"cloud_provider":"aws","access_key_id":"AKIAEXAMPLE","access_key_value":"SUPERSECRET","region":"us-west-2"}}`
+	externalSpec := `{"format":"parquet","extfs":{"cloud_provider":"aws","access_key_id":"AKIAEXAMPLE","access_key_value":"SUPERSECRET","future_password":"FUTURE_SECRET_SENTINEL","region":"us-west-2"}}`
 	testCases := []struct {
 		name string
 		req  any
@@ -131,7 +161,149 @@ func TestTraceLogRequestFieldRedactsRESTSnapshotExternalSpec(t *testing.T) {
 			request := fmt.Sprint(field.Interface)
 			assert.NotContains(t, request, "AKIAEXAMPLE")
 			assert.NotContains(t, request, "SUPERSECRET")
+			assert.NotContains(t, request, "FUTURE_SECRET_SENTINEL")
 			assert.Contains(t, request, "***")
+			assert.Contains(t, request, "parquet")
+		})
+	}
+}
+
+func TestTraceLogRequestFieldRedactsRESTExternalCollectionCredentials(t *testing.T) {
+	externalSpec := `{"format":"parquet","extfs":{"cloud_provider":"aws","access_key_id":"AKIA_EXTERNAL_SENTINEL","access_key_value":"SECRET_EXTERNAL_SENTINEL","future_password":"FUTURE_SPEC_REST_SENTINEL","region":"us-east-1"}}`
+	externalSource := "s3://SOURCE_ACCESS_REST_SENTINEL:SOURCE_SECRET_REST_SENTINEL@bucket/path"
+	testCases := []struct {
+		name string
+		req  any
+	}{
+		{
+			name: "create external collection",
+			req: &CollectionReq{
+				CollectionName: "external_collection",
+				Schema: CollectionSchema{
+					ExternalSource: externalSource,
+					ExternalSpec:   externalSpec,
+				},
+				TopLevelExternalSource: externalSource,
+				TopLevelExternalSpec:   externalSpec,
+			},
+		},
+		{
+			name: "refresh external collection",
+			req: &RefreshExternalCollectionReq{
+				CollectionName: "external_collection",
+				ExternalSource: externalSource,
+				ExternalSpec:   externalSpec,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			field := getTraceLogRequestFieldWithoutSensitiveInfo(testCase.req)
+			request := fmt.Sprint(field.Interface)
+			assert.NotContains(t, request, "SOURCE_ACCESS_REST_SENTINEL")
+			assert.NotContains(t, request, "SOURCE_SECRET_REST_SENTINEL")
+			assert.NotContains(t, request, "AKIA_EXTERNAL_SENTINEL")
+			assert.NotContains(t, request, "SECRET_EXTERNAL_SENTINEL")
+			assert.NotContains(t, request, "FUTURE_SPEC_REST_SENTINEL")
+			assert.Contains(t, request, "<redacted>")
+		})
+	}
+}
+
+func TestCreateExternalCollectionValidationDoesNotLogExternalSpec(t *testing.T) {
+	require.NoError(t, paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false"))
+	t.Cleanup(func() {
+		require.NoError(t, paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key))
+	})
+	require.NoError(t, paramtable.Get().Save(proxy.Params.CommonCfg.TraceLogMode.Key, "0"))
+	t.Cleanup(func() {
+		require.NoError(t, paramtable.Get().Reset(proxy.Params.CommonCfg.TraceLogMode.Key))
+	})
+
+	testCases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "top-level config rejected",
+			body: `{
+				"collectionName": "external_books",
+				"externalSource": "s3://bucket/books",
+				"externalSpec": "{\"format\":\"parquet\",\"extfs\":{\"cloud_provider\":\"aws\",\"access_key_id\":\"AKIA_LOG_SENTINEL\",\"access_key_value\":\"SECRET_LOG_SENTINEL\",\"future_password\":\"FUTURE_LOG_SECRET_SENTINEL\",\"region\":\"us-east-1\"}}",
+				"schema": {"fields": []}
+			}`,
+		},
+		{
+			name: "quick create rejected",
+			body: `{
+				"collectionName": "external_books",
+				"dimension": 2,
+				"schema": {
+					"externalSource": "s3://bucket/books",
+					"externalSpec": "{\"format\":\"parquet\",\"extfs\":{\"cloud_provider\":\"aws\",\"access_key_id\":\"AKIA_LOG_SENTINEL\",\"access_key_value\":\"SECRET_LOG_SENTINEL\",\"future_password\":\"FUTURE_LOG_SECRET_SENTINEL\",\"region\":\"us-east-1\"}}"
+				}
+			}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			logs := captureHTTPServerLogs(t)
+			testEngine := initHTTPServerV2(&externalCollectionRESTProxy{}, false)
+			req := httptest.NewRequest(http.MethodPost, versionalV2(CollectionCategory, CreateAction), bytes.NewReader([]byte(testCase.body)))
+			w := httptest.NewRecorder()
+			testEngine.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			output := logs.String()
+			assert.NotContains(t, output, "AKIA_LOG_SENTINEL")
+			assert.NotContains(t, output, "SECRET_LOG_SENTINEL")
+			assert.NotContains(t, output, "FUTURE_LOG_SECRET_SENTINEL")
+			assert.Contains(t, output, "***")
+		})
+	}
+}
+
+func TestTraceLogRequestFieldRedactsRESTPasswords(t *testing.T) {
+	description := "account description"
+	testCases := []struct {
+		name    string
+		req     any
+		secrets []string
+	}{
+		{
+			name: "create user",
+			req: &PasswordReq{
+				UserName:    "alice",
+				Password:    "CREATE_PASSWORD_SENTINEL_DO_NOT_LOG",
+				Description: &description,
+			},
+			secrets: []string{"CREATE_PASSWORD_SENTINEL_DO_NOT_LOG"},
+		},
+		{
+			name: "update password",
+			req: &NewPasswordReq{
+				UserName:    "alice",
+				Password:    "OLD_PASSWORD_SENTINEL_DO_NOT_LOG",
+				NewPassword: "NEW_PASSWORD_SENTINEL_DO_NOT_LOG",
+				Description: &description,
+			},
+			secrets: []string{
+				"OLD_PASSWORD_SENTINEL_DO_NOT_LOG",
+				"NEW_PASSWORD_SENTINEL_DO_NOT_LOG",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			field := getTraceLogRequestFieldWithoutSensitiveInfo(testCase.req)
+			request := fmt.Sprint(field.Interface)
+			assert.Contains(t, request, "alice")
+			for _, secret := range testCase.secrets {
+				assert.NotContains(t, request, secret)
+			}
 		})
 	}
 }

--- a/internal/kv/etcd/etcd_kv.go
+++ b/internal/kv/etcd/etcd_kv.go
@@ -388,7 +388,7 @@ func (kv *etcdKV) MultiSave(ctx context.Context, kvs map[string]string) error {
 	CheckTnxStringValueSizeAndWarn(ctx, kvs)
 	_, err := kv.executeTxn(kv.getTxnWithCmp(ctx1), ops...)
 	if err != nil {
-		mlog.Warn(ctx, "Etcd MultiSave error", mlog.Any("kvs", kvs), mlog.Int("len", len(kvs)), mlog.Err(err))
+		mlog.Warn(ctx, "Etcd MultiSave error", mlog.Strings("keys", lo.Keys(kvs)), mlog.Int("len", len(kvs)), mlog.Err(err))
 	}
 	CheckElapseAndWarn(ctx, start, "Slow etcd operation multi save", mlog.Strings("keys", keys))
 	return err
@@ -410,7 +410,7 @@ func (kv *etcdKV) MultiSaveBytes(ctx context.Context, kvs map[string][]byte) err
 	CheckTnxBytesValueSizeAndWarn(ctx, kvs)
 	_, err := kv.executeTxn(kv.getTxnWithCmp(ctx1), ops...)
 	if err != nil {
-		mlog.Warn(ctx, "Etcd MultiSaveBytes err", mlog.Any("kvs", kvs), mlog.Int("len", len(kvs)), mlog.Err(err))
+		mlog.Warn(ctx, "Etcd MultiSaveBytes err", mlog.Strings("keys", lo.Keys(kvs)), mlog.Int("len", len(kvs)), mlog.Err(err))
 	}
 	CheckElapseAndWarn(ctx, start, "Slow etcd operation multi save", mlog.Strings("keys", keys))
 	return err
@@ -488,7 +488,7 @@ func (kv *etcdKV) MultiSaveAndRemove(ctx context.Context, saves map[string]strin
 	resp, err := kv.executeTxn(kv.getTxnWithCmp(ctx1, cmps...), ops...)
 	if err != nil {
 		mlog.Warn(ctx, "Etcd MultiSaveAndRemove error",
-			mlog.Any("saves", saves),
+			mlog.Strings("saveKeys", lo.Keys(saves)),
 			mlog.Strings("removes", removals),
 			mlog.Int("saveLength", len(saves)),
 			mlog.Int("removeLength", len(removals)),
@@ -523,7 +523,7 @@ func (kv *etcdKV) MultiSaveBytesAndRemove(ctx context.Context, saves map[string]
 	_, err := kv.executeTxn(kv.getTxnWithCmp(ctx1), ops...)
 	if err != nil {
 		mlog.Warn(ctx, "Etcd MultiSaveBytesAndRemove error",
-			mlog.Any("saves", saves),
+			mlog.Strings("saveKeys", lo.Keys(saves)),
 			mlog.Strings("removes", removals),
 			mlog.Int("saveLength", len(saves)),
 			mlog.Int("removeLength", len(removals)),
@@ -585,7 +585,7 @@ func (kv *etcdKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[st
 	resp, err := kv.executeTxn(kv.getTxnWithCmp(ctx1, cmps...), ops...)
 	if err != nil {
 		mlog.Warn(ctx, "Etcd MultiSaveAndRemoveWithPrefix error",
-			mlog.Any("saves", saves),
+			mlog.Strings("saveKeys", lo.Keys(saves)),
 			mlog.Strings("removes", removals),
 			mlog.Int("saveLength", len(saves)),
 			mlog.Int("removeLength", len(removals)),
@@ -619,7 +619,7 @@ func (kv *etcdKV) MultiSaveBytesAndRemoveWithPrefix(ctx context.Context, saves m
 	_, err := kv.executeTxn(kv.getTxnWithCmp(ctx1), ops...)
 	if err != nil {
 		mlog.Warn(ctx, "Etcd MultiSaveBytesAndRemoveWithPrefix error",
-			mlog.Any("saves", saves),
+			mlog.Strings("saveKeys", lo.Keys(saves)),
 			mlog.Strings("removes", removals),
 			mlog.Int("saveLength", len(saves)),
 			mlog.Int("removeLength", len(removals)),

--- a/internal/kv/tikv/txn_tikv.go
+++ b/internal/kv/tikv/txn_tikv.go
@@ -317,7 +317,7 @@ func (kv *txnTiKV) Save(ctx context.Context, key, value string) error {
 	defer cancel()
 
 	var loggingErr error
-	defer logWarnOnFailure(&loggingErr, "txnTiKV Save() error", mlog.String("key", key), mlog.String("value", value))
+	defer logWarnOnFailure(&loggingErr, "txnTiKV Save() error", mlog.String("key", key))
 
 	loggingErr = kv.putTiKVMeta(ctx, key, value)
 	return loggingErr
@@ -330,7 +330,7 @@ func (kv *txnTiKV) MultiSave(ctx context.Context, kvs map[string]string) error {
 	defer cancel()
 
 	var loggingErr error
-	defer logWarnOnFailure(&loggingErr, "txnTiKV MultiSave() error", mlog.Any("kvs", kvs), mlog.Int("len", len(kvs)))
+	defer logWarnOnFailure(&loggingErr, "txnTiKV MultiSave() error", mlog.Strings("keys", lo.Keys(kvs)), mlog.Int("len", len(kvs)))
 
 	txn, err := beginTxn(kv.txn)
 	if err != nil {
@@ -346,13 +346,13 @@ func (kv *txnTiKV) MultiSave(ctx context.Context, kvs map[string]string) error {
 		// Check if value is empty or taking reserved EmptyValue
 		byteValue, err := convertEmptyStringToByte(value)
 		if err != nil {
-			loggingErr = merr.Wrap(err, fmt.Sprintf("Failed to cast to byte (%s:%s) for MultiSave()", key, value))
+			loggingErr = merr.Wrap(err, fmt.Sprintf("Failed to cast value for key %s in MultiSave()", key))
 			return loggingErr
 		}
 		// Save the value within a transaction
 		err = txn.Set([]byte(key), byteValue)
 		if err != nil {
-			loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set (%s:%s) for MultiSave()", key, value), err.Error())
+			loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set value for key %s in MultiSave()", key), err.Error())
 			return loggingErr
 		}
 	}
@@ -361,7 +361,7 @@ func (kv *txnTiKV) MultiSave(ctx context.Context, kvs map[string]string) error {
 		loggingErr = merr.WrapErrIoFailedReason("Failed to commit for MultiSave()", err.Error())
 		return loggingErr
 	}
-	CheckElapseAndWarn(start, "Slow txnTiKV MultiSave() operation", mlog.Any("kvs", kvs))
+	CheckElapseAndWarn(start, "Slow txnTiKV MultiSave() operation", mlog.Strings("keys", lo.Keys(kvs)))
 	return nil
 }
 
@@ -442,7 +442,7 @@ func (kv *txnTiKV) MultiSaveAndRemove(ctx context.Context, saves map[string]stri
 	defer cancel()
 
 	var loggingErr error
-	defer logWarnOnFailure(&loggingErr, "txnTiKV MultiSaveAndRemove error", mlog.Any("saves", saves), mlog.Strings("removes", removals), mlog.Int("saveLength", len(saves)), mlog.Int("removeLength", len(removals)))
+	defer logWarnOnFailure(&loggingErr, "txnTiKV MultiSaveAndRemove error", mlog.Strings("saveKeys", lo.Keys(saves)), mlog.Strings("removes", removals), mlog.Int("saveLength", len(saves)), mlog.Int("removeLength", len(removals)))
 
 	txn, err := beginTxn(kv.txn)
 	if err != nil {
@@ -484,12 +484,12 @@ func (kv *txnTiKV) MultiSaveAndRemove(ctx context.Context, saves map[string]stri
 		// Check if value is empty or taking reserved EmptyValue
 		byteValue, err := convertEmptyStringToByte(value)
 		if err != nil {
-			loggingErr = merr.Wrap(err, fmt.Sprintf("Failed to cast to byte (%s:%s) for MultiSaveAndRemove", key, value))
+			loggingErr = merr.Wrap(err, fmt.Sprintf("Failed to cast value for key %s in MultiSaveAndRemove", key))
 			return loggingErr
 		}
 		err = txn.Set([]byte(key), byteValue)
 		if err != nil {
-			loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set (%s:%s) for MultiSaveAndRemove", key, value), err.Error())
+			loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set value for key %s in MultiSaveAndRemove", key), err.Error())
 			return loggingErr
 		}
 	}
@@ -499,7 +499,7 @@ func (kv *txnTiKV) MultiSaveAndRemove(ctx context.Context, saves map[string]stri
 		loggingErr = merr.WrapErrIoFailedReason("Failed to commit for MultiSaveAndRemove", err.Error())
 		return loggingErr
 	}
-	CheckElapseAndWarn(start, "Slow txnTiKV MultiSaveAndRemove() operation", mlog.Any("saves", saves), mlog.Strings("removals", removals))
+	CheckElapseAndWarn(start, "Slow txnTiKV MultiSaveAndRemove() operation", mlog.Strings("saveKeys", lo.Keys(saves)), mlog.Strings("removals", removals))
 	return nil
 }
 
@@ -510,7 +510,7 @@ func (kv *txnTiKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[s
 	defer cancel()
 
 	var loggingErr error
-	defer logWarnOnFailure(&loggingErr, "txnTiKV MultiSaveAndRemoveWithPrefix() error", mlog.Any("saves", saves), mlog.Strings("removes", removals), mlog.Int("saveLength", len(saves)), mlog.Int("removeLength", len(removals)))
+	defer logWarnOnFailure(&loggingErr, "txnTiKV MultiSaveAndRemoveWithPrefix() error", mlog.Strings("saveKeys", lo.Keys(saves)), mlog.Strings("removes", removals), mlog.Int("saveLength", len(saves)), mlog.Int("removeLength", len(removals)))
 
 	txn, err := beginTxn(kv.txn)
 	if err != nil {
@@ -572,12 +572,12 @@ func (kv *txnTiKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[s
 		// Check if value is empty or taking reserved EmptyValue
 		byteValue, err := convertEmptyStringToByte(value)
 		if err != nil {
-			loggingErr = merr.Wrap(err, fmt.Sprintf("Failed to cast to byte (%s:%s) for MultiSaveAndRemoveWithPrefix()", key, value))
+			loggingErr = merr.Wrap(err, fmt.Sprintf("Failed to cast value for key %s in MultiSaveAndRemoveWithPrefix()", key))
 			return loggingErr
 		}
 		err = txn.Set([]byte(key), byteValue)
 		if err != nil {
-			loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set (%s:%s) for MultiSaveAndRemoveWithPrefix()", key, value), err.Error())
+			loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set value for key %s in MultiSaveAndRemoveWithPrefix()", key), err.Error())
 			return loggingErr
 		}
 	}
@@ -587,7 +587,7 @@ func (kv *txnTiKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[s
 		loggingErr = merr.WrapErrIoFailedReason("Failed to commit for MultiSaveAndRemoveWithPrefix", err.Error())
 		return loggingErr
 	}
-	CheckElapseAndWarn(start, "Slow txnTiKV MultiSaveAndRemoveWithPrefix() operation", mlog.Any("saves", saves), mlog.Strings("removals", removals))
+	CheckElapseAndWarn(start, "Slow txnTiKV MultiSaveAndRemoveWithPrefix() operation", mlog.Strings("saveKeys", lo.Keys(saves)), mlog.Strings("removals", removals))
 	return nil
 }
 
@@ -700,7 +700,7 @@ func (kv *txnTiKV) putTiKVMeta(ctx context.Context, key, val string) error {
 	// Check if the value being written needs to be empty placeholder
 	byteValue, err := convertEmptyStringToByte(val)
 	if err != nil {
-		return merr.Wrap(err, fmt.Sprintf("Failed to cast to byte (%s:%s) for putTiKVMeta", key, val))
+		return merr.Wrap(err, fmt.Sprintf("Failed to cast value for key %s in putTiKVMeta", key))
 	}
 	err = txn.Set([]byte(key), byteValue)
 	if err != nil {

--- a/internal/proxy/hook_interceptor.go
+++ b/internal/proxy/hook_interceptor.go
@@ -46,7 +46,7 @@ func HookInterceptor(ctx context.Context, req any, userName, fullMethod string, 
 
 	if newCtx, err = hoo.Before(ctx, req, fullMethod); err != nil {
 		mlog.Warn(ctx, "hook before error", mlog.String("user", userName), mlog.String("full method", fullMethod),
-			mlog.Any("request", req), mlog.Err(err))
+			GetRequestFieldWithoutSensitiveInfo(req), mlog.Err(err))
 		metrics.ProxyHookFunc.WithLabelValues(metrics.HookBefore, fullMethod).Inc()
 		updateProxyFunctionCallMetric(fullMethod, err)
 		// NOTE: don't use the merr, because it will cause the wrong retry behavior in the sdk
@@ -55,7 +55,7 @@ func HookInterceptor(ctx context.Context, req any, userName, fullMethod string, 
 	realResp, realErr = handler(newCtx, req)
 	if err = hoo.After(newCtx, realResp, realErr, fullMethod); err != nil {
 		mlog.Warn(ctx, "hook after error", mlog.String("user", userName), mlog.String("full method", fullMethod),
-			mlog.Any("request", req), mlog.Err(err))
+			GetRequestFieldWithoutSensitiveInfo(req), mlog.Err(err))
 		metrics.ProxyHookFunc.WithLabelValues(metrics.HookAfter, fullMethod).Inc()
 		updateProxyFunctionCallMetric(fullMethod, err)
 		// NOTE: don't use the merr, because it will cause the wrong retry behavior in the sdk

--- a/internal/proxy/hook_interceptor_test.go
+++ b/internal/proxy/hook_interceptor_test.go
@@ -2,13 +2,17 @@ package proxy
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/crypto"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
@@ -53,6 +57,20 @@ type afterMock struct {
 	hookutil.DefaultHook
 	method string
 	err    error
+}
+
+type errorHook struct {
+	hookutil.DefaultHook
+	beforeErr error
+	afterErr  error
+}
+
+func (h errorHook) Before(ctx context.Context, req interface{}, fullMethod string) (context.Context, error) {
+	return ctx, h.beforeErr
+}
+
+func (h errorHook) After(ctx context.Context, resp interface{}, err error, fullMethod string) error {
+	return h.afterErr
 }
 
 func (a afterMock) After(ctx context.Context, r interface{}, err error, fullMethod string) error {
@@ -128,6 +146,60 @@ func TestHookInterceptor(t *testing.T) {
 	})
 	assert.Equal(t, res.(*resp).method, r.method)
 	assert.NoError(t, err)
+}
+
+func TestHookInterceptorDoesNotLogCredentialRequests(t *testing.T) {
+	logs := captureProxyLogs(t)
+	hookutil.InitOnceHook()
+	t.Cleanup(func() {
+		hookutil.SetTestHook(hookutil.DefaultHook{})
+	})
+
+	createPassword := "CREATE_PASSWORD_SENTINEL_DO_NOT_LOG"
+	encodedCreatePassword := crypto.Base64Encode(createPassword)
+	hookutil.SetTestHook(errorHook{beforeErr: errors.New("before hook failed")})
+	_, err := HookInterceptor(
+		context.Background(),
+		&milvuspb.CreateCredentialRequest{Username: "alice", Password: encodedCreatePassword},
+		"admin",
+		"/milvus.proto.milvus.MilvusService/CreateCredential",
+		func(ctx context.Context, req interface{}) (interface{}, error) { return nil, nil },
+	)
+	require.Error(t, err)
+
+	oldPassword := "OLD_PASSWORD_SENTINEL_DO_NOT_LOG"
+	newPassword := "NEW_PASSWORD_SENTINEL_DO_NOT_LOG"
+	encodedOldPassword := crypto.Base64Encode(oldPassword)
+	encodedNewPassword := crypto.Base64Encode(newPassword)
+	hookutil.SetTestHook(errorHook{afterErr: errors.New("after hook failed")})
+	_, err = HookInterceptor(
+		context.Background(),
+		&milvuspb.UpdateCredentialRequest{
+			Username:    "alice",
+			OldPassword: encodedOldPassword,
+			NewPassword: encodedNewPassword,
+		},
+		"admin",
+		"/milvus.proto.milvus.MilvusService/UpdateCredential",
+		func(ctx context.Context, req interface{}) (interface{}, error) { return nil, nil },
+	)
+	require.Error(t, err)
+
+	output := logs.String()
+	for _, secret := range []string{
+		createPassword,
+		encodedCreatePassword,
+		oldPassword,
+		encodedOldPassword,
+		newPassword,
+		encodedNewPassword,
+	} {
+		assert.NotContains(t, output, secret)
+	}
+	lowerOutput := strings.ToLower(output)
+	assert.NotContains(t, lowerOutput, "password:")
+	assert.NotContains(t, lowerOutput, "oldpassword")
+	assert.NotContains(t, lowerOutput, "newpassword")
 }
 
 func TestUpdateProxyFunctionCallMetric(t *testing.T) {

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -5680,7 +5680,7 @@ func (node *Proxy) RestoreRBAC(ctx context.Context, req *milvuspb.RestoreRBACMet
 	ctx, sp := otel.Tracer(typeutil.ProxyRole).Start(ctx, "Proxy-RestoreRBAC")
 	defer sp.End()
 
-	mlog.Debug(context.TODO(), "RestoreRBAC", mlog.Any("req", req))
+	mlog.Debug(ctx, "RestoreRBAC", mlog.Any("req", redactRestoreRBACRequestForLog(req)))
 	if err := merr.CheckHealthy(node.GetStateCode()); err != nil {
 		return merr.Status(err), nil
 	}
@@ -7332,8 +7332,8 @@ func (node *Proxy) RefreshExternalCollection(ctx context.Context, req *milvuspb.
 	if srcSet != specSet {
 		return &milvuspb.RefreshExternalCollectionResponse{
 			Status: merr.Status(merr.WrapErrParameterInvalidMsg(
-				"external_source and external_spec must be both provided or both omitted on refresh (got source=%q, spec=%q)",
-				req.GetExternalSource(), req.GetExternalSpec())),
+				"external_source and external_spec must be both provided or both omitted on refresh (source_set=%t, spec_set=%t)",
+				srcSet, specSet)),
 		}, nil
 	}
 

--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -351,6 +351,28 @@ func TestProxyRoleDescriptionValidation(t *testing.T) {
 	assert.NotEqual(t, commonpb.ErrorCode_Success, status.GetErrorCode())
 }
 
+func TestRestoreRBACDoesNotLogPasswordHash(t *testing.T) {
+	logs := captureProxyLogs(t)
+	node := &Proxy{mixCoord: NewMixCoordMock()}
+	node.UpdateStateCode(commonpb.StateCode_Healthy)
+	hashSentinel := "$2a$10$RESTORE_RBAC_DIRECT_LOG_SENTINEL"
+	req := &milvuspb.RestoreRBACMetaRequest{
+		RBACMeta: &milvuspb.RBACMeta{
+			Users: []*milvuspb.UserInfo{{
+				User:     "restore-user",
+				Password: hashSentinel,
+			}},
+		},
+	}
+
+	status, err := node.RestoreRBAC(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, commonpb.ErrorCode_Success, status.GetErrorCode())
+	assert.Equal(t, hashSentinel, req.GetRBACMeta().GetUsers()[0].GetPassword())
+	assert.NotContains(t, logs.String(), hashSentinel)
+	assert.Contains(t, logs.String(), "restore-user")
+}
+
 func TestProxyRoleDescriptionForwarding(t *testing.T) {
 	paramtable.Init()
 	mixCoord := mocks.NewMockMixCoordClient(t)
@@ -3333,17 +3355,20 @@ func TestProxy_RefreshExternalCollection_AtomicSourceSpec(t *testing.T) {
 	node.UpdateStateCode(commonpb.StateCode_Healthy)
 
 	cases := []struct {
-		name       string
-		src, spec  string
-		wantSubstr string
+		name          string
+		src, spec     string
+		wantSubstr    string
+		secretSubstrs []string
 	}{
-		{"source only rejected", "s3://bucket/p", "", "both provided or both omitted"},
-		{"spec only rejected", "", `{"format":"parquet"}`, "both provided or both omitted"},
-		{"http scheme rejected", "http://169.254.169.254/metadata", `{"format":"parquet"}`, "scheme"},
-		{"file scheme rejected", "file:///etc/passwd", `{"format":"parquet"}`, "scheme"},
-		{"ftp scheme rejected", "ftp://internal/data", `{"format":"parquet"}`, "scheme"},
-		{"unknown scheme rejected", "xyz://nope/", `{"format":"parquet"}`, "scheme"},
-		{"userinfo rejected", "s3://ak:sk@bucket/prefix", `{"format":"parquet"}`, ""},
+		{"source only rejected", "s3://SOURCE_ACCESS_SENTINEL:SOURCE_SECRET_SENTINEL@bucket/p", "", "both provided or both omitted", []string{"SOURCE_ACCESS_SENTINEL", "SOURCE_SECRET_SENTINEL"}},
+		{"spec only rejected", "", `{"format":"parquet","extfs":{"access_key_id":"AKIA_ERROR_SENTINEL","access_key_value":"SECRET_ERROR_SENTINEL"}}`, "both provided or both omitted", []string{"AKIA_ERROR_SENTINEL", "SECRET_ERROR_SENTINEL"}},
+		{"http scheme rejected", "http://169.254.169.254/metadata", `{"format":"parquet"}`, "external_source is invalid", nil},
+		{"file scheme rejected", "file:///etc/passwd", `{"format":"parquet"}`, "external_source is invalid", nil},
+		{"ftp scheme rejected", "ftp://internal/data", `{"format":"parquet"}`, "external_source is invalid", nil},
+		{"unknown scheme rejected", "xyz://nope/", `{"format":"parquet"}`, "external_source is invalid", nil},
+		{"userinfo rejected", "s3://ak:sk@bucket/prefix", `{"format":"parquet"}`, "external_source is invalid", nil},
+		{"invalid format includes validation detail", "s3://bucket/prefix", `{"format":"FORMAT_REFRESH_SECRET_SENTINEL"}`, "external_spec is invalid", nil},
+		{"invalid extfs includes validation detail", "s3://bucket/prefix", `{"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK","region":"us-east-1","cloud_provider":"cloud_provider_refresh_secret_sentinel"}}`, "external_spec is invalid", nil},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -3356,6 +3381,9 @@ func TestProxy_RefreshExternalCollection_AtomicSourceSpec(t *testing.T) {
 			require.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrParameterInvalid)
 			if tc.wantSubstr != "" {
 				assert.Contains(t, resp.GetStatus().GetReason(), tc.wantSubstr)
+			}
+			for _, secret := range tc.secretSubstrs {
+				assert.NotContains(t, resp.GetStatus().GetReason(), secret)
 			}
 		})
 	}

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -3248,7 +3248,7 @@ func (t *loadCollectionTask) Execute(ctx context.Context) (err error) {
 		Priority:       t.GetLoadPriority(),
 	}
 	log.Info(ctx, "send LoadCollectionRequest to query coordinator",
-		mlog.Any("schema", request.Schema),
+		mlog.FieldSchema(request.Schema),
 		mlog.Int32("priority", int32(request.GetPriority())))
 	t.result, err = t.mixCoord.LoadCollection(ctx, request)
 	if err = merr.CheckRPCCall(t.result, err); err != nil {
@@ -3520,7 +3520,7 @@ func (t *loadPartitionsTask) Execute(ctx context.Context) error {
 		Priority:       t.GetLoadPriority(),
 	}
 	mlog.Info(context.TODO(), "send LoadPartitionRequest to query coordinator",
-		mlog.Any("schema", request.Schema),
+		mlog.FieldSchema(request.Schema),
 		mlog.Int32("priority", int32(request.GetPriority())))
 	t.result, err = t.mixCoord.LoadPartitions(ctx, request)
 	if err = merr.CheckRPCCall(t.result, err); err != nil {

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -225,7 +225,7 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 	var aggs []agg.AggregateBase
 	t.translatedOutputFields, t.userOutputFields, t.userDynamicFields, aggs, t.userRequestedPkFieldExplicitly, err = translateOutputFields(t.request.OutputFields, t.schema, true)
 	if err != nil {
-		log.Warn(ctx, "translate output fields failed", mlog.Err(err), mlog.Any("schema", t.schema))
+		log.Warn(ctx, "translate output fields failed", mlog.Err(err), mlog.FieldSchema(t.schema.CollectionSchema))
 		return err
 	}
 	if len(aggs) > 0 {

--- a/internal/proxy/trace_log_interceptor.go
+++ b/internal/proxy/trace_log_interceptor.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/util/externalspec"
 	"github.com/milvus-io/milvus/pkg/v3/util/requestutil"
@@ -109,17 +110,68 @@ func GetRequestFieldWithoutSensitiveInfo(req interface{}) mlog.Field {
 			ModifiedUtcTimestamps: updateCredentialReq.ModifiedUtcTimestamps,
 		})
 	}
+	restoreRBACReq, ok := req.(*milvuspb.RestoreRBACMetaRequest)
+	if ok {
+		return mlog.Any("request", redactRestoreRBACRequestForLog(restoreRBACReq))
+	}
+	createCollectionReq, ok := req.(*milvuspb.CreateCollectionRequest)
+	if ok {
+		return mlog.Any("request", redactCreateCollectionRequestForLog(createCollectionReq))
+	}
+	refreshExternalCollectionReq, ok := req.(*milvuspb.RefreshExternalCollectionRequest)
+	if ok {
+		if refreshExternalCollectionReq == nil {
+			return mlog.Any("request", refreshExternalCollectionReq)
+		}
+		redactedReq := proto.Clone(refreshExternalCollectionReq).(*milvuspb.RefreshExternalCollectionRequest)
+		redactedReq.ExternalSource = externalspec.RedactExternalSource(redactedReq.GetExternalSource())
+		redactedReq.ExternalSpec = externalspec.RedactExternalSpecForLog(redactedReq.GetExternalSpec())
+		return mlog.Any("request", redactedReq)
+	}
 	restoreExternalSnapshotReq, ok := req.(*milvuspb.RestoreExternalSnapshotRequest)
 	if ok {
 		redactedReq := proto.Clone(restoreExternalSnapshotReq).(*milvuspb.RestoreExternalSnapshotRequest)
-		redactedReq.ExternalSpec = externalspec.RedactExternalSpec(redactedReq.GetExternalSpec())
+		redactedReq.ExternalSpec = externalspec.RedactExternalSpecForLog(redactedReq.GetExternalSpec())
 		return mlog.Any("request", redactedReq)
 	}
 	exportSnapshotReq, ok := req.(*milvuspb.ExportSnapshotRequest)
 	if ok {
 		redactedReq := proto.Clone(exportSnapshotReq).(*milvuspb.ExportSnapshotRequest)
-		redactedReq.ExternalSpec = externalspec.RedactExternalSpec(redactedReq.GetExternalSpec())
+		redactedReq.ExternalSpec = externalspec.RedactExternalSpecForLog(redactedReq.GetExternalSpec())
 		return mlog.Any("request", redactedReq)
 	}
 	return mlog.Any("request", req)
+}
+
+func redactRestoreRBACRequestForLog(req *milvuspb.RestoreRBACMetaRequest) *milvuspb.RestoreRBACMetaRequest {
+	if req == nil {
+		return nil
+	}
+	redacted := proto.Clone(req).(*milvuspb.RestoreRBACMetaRequest)
+	for _, user := range redacted.GetRBACMeta().GetUsers() {
+		if user != nil {
+			user.Password = sensitiveMark
+		}
+	}
+	return redacted
+}
+
+func redactCreateCollectionRequestForLog(req *milvuspb.CreateCollectionRequest) *milvuspb.CreateCollectionRequest {
+	if req == nil {
+		return nil
+	}
+
+	redactedReq := proto.Clone(req).(*milvuspb.CreateCollectionRequest)
+	schema := &schemapb.CollectionSchema{}
+	if err := proto.Unmarshal(req.GetSchema(), schema); err != nil {
+		redactedReq.Schema = nil
+		return redactedReq
+	}
+	redactedSchema, err := proto.Marshal(externalspec.RedactCollectionSchemaForLog(schema))
+	if err != nil {
+		redactedReq.Schema = nil
+		return redactedReq
+	}
+	redactedReq.Schema = redactedSchema
+	return redactedReq
 }

--- a/internal/proxy/trace_log_interceptor_test.go
+++ b/internal/proxy/trace_log_interceptor_test.go
@@ -26,10 +26,13 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
@@ -84,7 +87,7 @@ func TestTraceLogInterceptor(t *testing.T) {
 		})
 		assert.NotContains(t, strings.ToLower(fmt.Sprint(f2.Interface)), "password")
 
-		externalSpec := `{"extfs":{"cloud_provider":"aws","access_key_id":"AKIAEXAMPLE","access_key_value":"SUPERSECRET","region":"us-west-2"}}`
+		externalSpec := `{"format":"parquet","extfs":{"cloud_provider":"aws","access_key_id":"AKIAEXAMPLE","access_key_value":"SUPERSECRET","future_password":"FUTURE_SECRET_SENTINEL","region":"us-west-2"}}`
 		f3 := GetRequestFieldWithoutSensitiveInfo(&milvuspb.RestoreExternalSnapshotRequest{
 			DbName:               "db",
 			TargetCollectionName: "restored",
@@ -93,7 +96,9 @@ func TestTraceLogInterceptor(t *testing.T) {
 		})
 		assert.NotContains(t, fmt.Sprint(f3.Interface), "AKIAEXAMPLE")
 		assert.NotContains(t, fmt.Sprint(f3.Interface), "SUPERSECRET")
+		assert.NotContains(t, fmt.Sprint(f3.Interface), "FUTURE_SECRET_SENTINEL")
 		assert.Contains(t, fmt.Sprint(f3.Interface), "***")
+		assert.Contains(t, fmt.Sprint(f3.Interface), "parquet")
 
 		f4 := GetRequestFieldWithoutSensitiveInfo(&milvuspb.ExportSnapshotRequest{
 			DbName:         "db",
@@ -104,7 +109,22 @@ func TestTraceLogInterceptor(t *testing.T) {
 		})
 		assert.NotContains(t, fmt.Sprint(f4.Interface), "AKIAEXAMPLE")
 		assert.NotContains(t, fmt.Sprint(f4.Interface), "SUPERSECRET")
+		assert.NotContains(t, fmt.Sprint(f4.Interface), "FUTURE_SECRET_SENTINEL")
 		assert.Contains(t, fmt.Sprint(f4.Interface), "***")
+		assert.Contains(t, fmt.Sprint(f4.Interface), "parquet")
+
+		hashSentinel := "$2a$10$RESTORE_RBAC_HASH_SENTINEL"
+		f5 := GetRequestFieldWithoutSensitiveInfo(&milvuspb.RestoreRBACMetaRequest{
+			RBACMeta: &milvuspb.RBACMeta{
+				Users: []*milvuspb.UserInfo{{
+					User:     "restore-user",
+					Password: hashSentinel,
+				}},
+			},
+		})
+		assert.NotContains(t, fmt.Sprint(f5.Interface), hashSentinel)
+		assert.Contains(t, fmt.Sprint(f5.Interface), "restore-user")
+		assert.Contains(t, fmt.Sprint(f5.Interface), sensitiveMark)
 	}
 
 	_ = paramtable.Get().Save(paramtable.Get().CommonCfg.TraceLogMode.Key, "3")
@@ -153,4 +173,51 @@ func TestTraceLogInterceptor(t *testing.T) {
 		})
 	}
 	_ = paramtable.Get().Save(paramtable.Get().CommonCfg.TraceLogMode.Key, "0")
+}
+
+func TestGetRequestFieldRedactsExternalCollectionCredentials(t *testing.T) {
+	externalSpec := `{"format":"parquet","extfs":{"cloud_provider":"aws","access_key_id":"SPEC_ACCESS_GRPC_SENTINEL","access_key_value":"SPEC_SECRET_GRPC_SENTINEL","future_password":"FUTURE_SPEC_GRPC_SENTINEL","region":"us-east-1"}}`
+	externalSource := "s3://SOURCE_ACCESS_GRPC_SENTINEL:SOURCE_SECRET_GRPC_SENTINEL@bucket/path"
+	schema, err := proto.Marshal(&schemapb.CollectionSchema{
+		Name:           "external_collection",
+		ExternalSource: externalSource,
+		ExternalSpec:   externalSpec,
+	})
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name string
+		req  any
+	}{
+		{
+			name: "create external collection",
+			req: &milvuspb.CreateCollectionRequest{
+				DbName:         "db",
+				CollectionName: "external_collection",
+				Schema:         schema,
+			},
+		},
+		{
+			name: "refresh external collection",
+			req: &milvuspb.RefreshExternalCollectionRequest{
+				DbName:         "db",
+				CollectionName: "external_collection",
+				ExternalSource: externalSource,
+				ExternalSpec:   externalSpec,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			field := GetRequestFieldWithoutSensitiveInfo(testCase.req)
+			request := fmt.Sprint(field.Interface)
+			assert.NotContains(t, request, "SOURCE_ACCESS_GRPC_SENTINEL")
+			assert.NotContains(t, request, "SOURCE_SECRET_GRPC_SENTINEL")
+			assert.NotContains(t, request, "SPEC_ACCESS_GRPC_SENTINEL")
+			assert.NotContains(t, request, "SPEC_SECRET_GRPC_SENTINEL")
+			assert.NotContains(t, request, "FUTURE_SPEC_GRPC_SENTINEL")
+			assert.Contains(t, request, "<redacted>")
+		})
+	}
 }

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1497,11 +1497,10 @@ func PasswordVerify(ctx context.Context, username, rawPwd string) bool {
 }
 
 func VerifyAPIKey(rawToken string) (string, error) {
-	hoo := hookutil.GetHook()
-	user, err := hoo.VerifyAPIKey(rawToken)
+	user, err := hookutil.GetHook().VerifyAPIKey(rawToken)
 	if err != nil {
-		mlog.Warn(context.TODO(), "fail to verify apikey", mlog.String("api_key", rawToken), mlog.Err(err))
-		return "", merr.WrapErrParameterInvalidMsg("invalid apikey: [%s]", rawToken)
+		mlog.Warn(context.TODO(), "fail to verify apikey with hook", mlog.Err(err))
+		return "", merr.WrapErrParameterInvalidMsg("invalid API key")
 	}
 	return user, nil
 }
@@ -1530,7 +1529,7 @@ func passwordVerify(ctx context.Context, username, rawPwd string, privilegeCache
 
 	// update cache after miss cache
 	credInfo.Sha256Password = sha256Pwd
-	mlog.Debug(context.TODO(), "get credential miss cache, update cache with", mlog.Any("credential", credInfo))
+	mlog.Debug(ctx, "credential cache populated")
 	privilegeCache.UpdateCredential(credInfo)
 	return true
 }
@@ -2251,7 +2250,7 @@ func checkPrimaryFieldData(ctx context.Context, allFields []*schemapb.FieldSchem
 
 	primaryFieldSchema, err := typeutil.GetPrimaryFieldSchema(schema)
 	if err != nil {
-		log.Error(ctx, "get primary field schema failed", mlog.Any("schema", schema), mlog.Err(err))
+		log.Error(ctx, "get primary field schema failed", mlog.FieldSchema(schema), mlog.Err(err))
 		return nil, err
 	}
 	if primaryFieldSchema.GetNullable() {
@@ -2397,7 +2396,7 @@ func checkUpsertPrimaryFieldData(ctx context.Context, allFields []*schemapb.Fiel
 
 	primaryFieldSchema, err := typeutil.GetPrimaryFieldSchema(schema)
 	if err != nil {
-		log.Error(ctx, "get primary field schema failed", mlog.Any("schema", schema), mlog.Err(err))
+		log.Error(ctx, "get primary field schema failed", mlog.FieldSchema(schema), mlog.Err(err))
 		return nil, nil, err
 	}
 	if primaryFieldSchema.GetNullable() {

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -17,6 +17,7 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strconv"
@@ -40,6 +41,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proxy/privilege"
 	"github.com/milvus-io/milvus/internal/util/function/embedding"
 	"github.com/milvus-io/milvus/internal/util/function/validator"
+	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -55,6 +57,35 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
+
+type proxyLogBuffer struct {
+	bytes.Buffer
+}
+
+func (*proxyLogBuffer) Sync() error {
+	return nil
+}
+
+func captureProxyLogs(t *testing.T) *proxyLogBuffer {
+	t.Helper()
+
+	oldLogger := mlog.L()
+	oldLevel := mlog.GetAtomicLevel()
+	logs := &proxyLogBuffer{}
+	logger, props, err := mlog.InitLoggerWithWriteSyncer(&mlog.Config{
+		Level:             "debug",
+		Format:            "text",
+		DisableCaller:     true,
+		DisableTimestamp:  true,
+		DisableStacktrace: true,
+	}, logs)
+	require.NoError(t, err)
+	mlog.ReplaceGlobals(logger, props)
+	t.Cleanup(func() {
+		mlog.ReplaceGlobals(oldLogger, &mlog.ZapProperties{Level: oldLevel})
+	})
+	return logs
+}
 
 func TestSearchInfoDetermineSearchTypeWithPluralGroupByFieldIDs(t *testing.T) {
 	info := &SearchInfo{
@@ -1102,6 +1133,76 @@ func TestGetRole(t *testing.T) {
 	roles, err = GetRole("foo")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(roles))
+}
+
+func TestVerifyAPIKeyDoesNotExposeSecret(t *testing.T) {
+	logs := captureProxyLogs(t)
+	rawToken := "API_KEY_SENTINEL_DO_NOT_LOG"
+	encodedToken := crypto.Base64Encode(rawToken)
+	hookutil.SetMockAPIHook("", errors.New("API key provider unavailable"))
+	t.Cleanup(func() {
+		hookutil.SetTestHook(hookutil.DefaultHook{})
+	})
+
+	_, err := VerifyAPIKey(rawToken)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), rawToken)
+
+	oldMetaCache := globalMetaCache
+	globalMetaCache = &MetaCache{}
+	t.Cleanup(func() {
+		globalMetaCache = oldMetaCache
+	})
+	require.NoError(t, paramtable.Get().Save(Params.CommonCfg.AuthorizationEnabled.Key, "true"))
+	t.Cleanup(func() {
+		paramtable.Get().Reset(Params.CommonCfg.AuthorizationEnabled.Key)
+	})
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+		util.HeaderAuthorize,
+		encodedToken,
+	))
+	_, err = AuthenticationInterceptor(ctx)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), rawToken)
+	assert.NotContains(t, err.Error(), encodedToken)
+	output := logs.String()
+	assert.Contains(t, output, "fail to verify apikey")
+	assert.Contains(t, output, "API key provider unavailable")
+	assert.NotContains(t, output, rawToken)
+	assert.NotContains(t, output, encodedToken)
+}
+
+func TestPasswordVerifyDoesNotLogCredential(t *testing.T) {
+	ctx := context.Background()
+	username := "USERNAME_SENTINEL_DO_NOT_LOG"
+	password := "PASSWORD_SENTINEL_DO_NOT_LOG"
+	encryptedPassword, err := crypto.PasswordEncrypt(password)
+	require.NoError(t, err)
+	sha256Password := crypto.SHA256(password, username)
+
+	privilege.ResetPrivilegeCacheForTest()
+	t.Cleanup(privilege.ResetPrivilegeCacheForTest)
+	mockedRootCoord := NewMixCoordMock()
+	mockedRootCoord.GetGetCredentialFunc = func(ctx context.Context, req *rootcoordpb.GetCredentialRequest, opts ...grpc.CallOption) (*rootcoordpb.GetCredentialResponse, error) {
+		return &rootcoordpb.GetCredentialResponse{
+			Status:   merr.Success(),
+			Username: username,
+			Password: encryptedPassword,
+		}, nil
+	}
+	privilege.InitPrivilegeCache(ctx, mockedRootCoord)
+
+	logs := captureProxyLogs(t)
+	assert.True(t, passwordVerify(ctx, username, password, privilege.GetPrivilegeCache()))
+
+	output := logs.String()
+	assert.Contains(t, output, "credential cache populated")
+	assert.NotContains(t, output, username)
+	assert.NotContains(t, output, password)
+	assert.NotContains(t, output, encryptedPassword)
+	assert.NotContains(t, output, sha256Password)
+	assert.NotContains(t, output, "encrypted_password")
+	assert.NotContains(t, output, "sha256_password")
 }
 
 func TestPasswordVerify(t *testing.T) {

--- a/internal/querycoordv2/services.go
+++ b/internal/querycoordv2/services.go
@@ -197,7 +197,7 @@ func (s *Server) LoadCollection(ctx context.Context, req *querypb.LoadCollection
 	)
 
 	logger.Info(ctx, "load collection request received",
-		mlog.Any("schema", req.Schema),
+		mlog.FieldSchema(req.Schema),
 		mlog.Int64s("fieldIndexes", lo.Values(req.GetFieldIndexID())),
 	)
 	metrics.QueryCoordLoadCount.WithLabelValues(metrics.TotalLabel).Inc()
@@ -271,7 +271,7 @@ func (s *Server) LoadPartitions(ctx context.Context, req *querypb.LoadPartitions
 	)
 
 	logger.Info(ctx, "received load partitions request",
-		mlog.Any("schema", req.Schema))
+		mlog.FieldSchema(req.Schema))
 	metrics.QueryCoordLoadCount.WithLabelValues(metrics.TotalLabel).Inc()
 
 	if err := merr.CheckHealthy(s.State()); err != nil {

--- a/internal/querynodev2/segments/collection.go
+++ b/internal/querynodev2/segments/collection.go
@@ -135,9 +135,9 @@ func (m *collectionManager) PutOrRef(collectionID int64, schema *schemapb.Collec
 	}
 	defer m.mut.Unlock()
 
-	mlog.Info(context.TODO(), "put new collection", mlog.Int64("collectionID", collectionID), mlog.Any("schema", schema))
+	mlog.Info(context.TODO(), "put new collection", mlog.Int64("collectionID", collectionID), mlog.FieldSchema(schema))
 	collection, err := NewCollection(collectionID, schema, meta, loadMeta)
-	mlog.Info(context.TODO(), "new collection created", mlog.Int64("collectionID", collectionID), mlog.Any("schema", schema), mlog.Err(err))
+	mlog.Info(context.TODO(), "new collection created", mlog.Int64("collectionID", collectionID), mlog.FieldSchema(schema), mlog.Err(err))
 	if err != nil {
 		return err
 	}
@@ -163,7 +163,7 @@ func (m *collectionManager) putOrRefExisting(collectionID int64, collection *Col
 			mlog.Uint64("schemaVersion", plan.logicalSchemaVersion),
 			mlog.Uint64("schemaBarrierTs", plan.schemaBarrierTs),
 			mlog.Uint64("segcoreSchemaVersion", plan.segcoreSchemaVersion),
-			mlog.Any("schema", schema),
+			mlog.FieldSchema(schema),
 		)
 	}
 	return nil

--- a/internal/rootcoord/create_collection_task_test.go
+++ b/internal/rootcoord/create_collection_task_test.go
@@ -1934,7 +1934,7 @@ func TestPrepareMilvusTableSnapshotSchemaErrors(t *testing.T) {
 		schema.ExternalSource = "file:///tmp/snapshot.json"
 		err := baseTask(schema).prepareMilvusTableSnapshotSchema(context.Background())
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "external_source scheme")
+		assert.Contains(t, err.Error(), "external_source is invalid")
 	})
 
 	t.Run("empty source is noop", func(t *testing.T) {

--- a/pkg/mlog/field_enum.go
+++ b/pkg/mlog/field_enum.go
@@ -3,6 +3,9 @@ package mlog
 import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/externalspec"
 )
 
 // Well-known field keys for consistent logging across Milvus components.
@@ -31,6 +34,7 @@ const (
 	keyPChannel       = "pchannel"
 	keyMessageID      = "messageID"
 	keyMessage        = "message"
+	keySchema         = "schema"
 )
 
 var wellKnownLowerKeyToLogKey = map[string]string{
@@ -56,6 +60,7 @@ var wellKnownLowerKeyToLogKey = map[string]string{
 	"pchannel":       keyPChannel,
 	"messageid":      keyMessageID,
 	"message":        keyMessage,
+	"schema":         keySchema,
 }
 
 func restoreWellKnownLogKey(key string) string {
@@ -233,6 +238,11 @@ func FieldMessageID(val zapcore.ObjectMarshaler) Field { return Object(keyMessag
 
 // FieldMessage creates a field for message content.
 func FieldMessage(val zapcore.ObjectMarshaler) Field { return Object(keyMessage, val) }
+
+// FieldSchema creates a credential-safe field for a collection schema.
+func FieldSchema(val *schemapb.CollectionSchema) Field {
+	return Any(keySchema, externalspec.RedactCollectionSchemaForLog(val))
+}
 
 // FieldMessages creates an array field for message contents.
 func FieldMessages[T zapcore.ObjectMarshaler](msgs []T) Field {

--- a/pkg/mlog/field_test.go
+++ b/pkg/mlog/field_test.go
@@ -3,6 +3,7 @@
 package mlog
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
@@ -10,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 )
 
 // Test all String type field constructors
@@ -434,6 +437,30 @@ func TestStringerField(t *testing.T) {
 	field := Stringer("obj", s)
 	expected := zap.Stringer("obj", s)
 	assert.Equal(t, expected, field)
+}
+
+func TestFieldSchemaRedactsExternalCredentials(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Name:           "external_collection",
+		ExternalSource: "s3://ACCESS_SENTINEL:SECRET_SENTINEL@bucket/path",
+		ExternalSpec:   `{"format":"parquet","extfs":{"access_key_value":"SPEC_SENTINEL"}}`,
+	}
+
+	var output bytes.Buffer
+	encoderConfig := zap.NewProductionEncoderConfig()
+	logger := zap.New(zapcore.NewCore(
+		zapcore.NewJSONEncoder(encoderConfig),
+		zapcore.AddSync(&output),
+		zap.DebugLevel,
+	))
+	logger.Info("schema", FieldSchema(schema))
+
+	assert.Contains(t, output.String(), "external_collection")
+	assert.Contains(t, output.String(), "<redacted>")
+	assert.NotContains(t, output.String(), "ACCESS_SENTINEL")
+	assert.NotContains(t, output.String(), "SECRET_SENTINEL")
+	assert.NotContains(t, output.String(), "SPEC_SENTINEL")
+	assert.Contains(t, schema.GetExternalSource(), "ACCESS_SENTINEL")
 }
 
 // Test all FieldXXX helper functions from field_enum.go

--- a/pkg/util/externalspec/external_spec.go
+++ b/pkg/util/externalspec/external_spec.go
@@ -23,6 +23,9 @@ import (
 	"strconv"
 	"strings"
 
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/util/externalspec/specutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
@@ -176,7 +179,7 @@ func ValidateExternalSource(source string) error {
 	}
 	u, err := url.Parse(source)
 	if err != nil {
-		return merr.Wrap(err, "invalid external_source URL")
+		return merr.WrapErrParameterInvalidMsg("external_source is not a valid URL")
 	}
 	scheme := strings.ToLower(u.Scheme)
 	if scheme == "" {
@@ -196,20 +199,78 @@ func ValidateExternalSource(source string) error {
 }
 
 // ValidateSourceAndSpec validates URL + JSON shape + ValidateExtfsComplete.
-// Errors are wrapped via merr.WrapErrParameterInvalid for direct return.
+// Errors retain their typed validation code while adding field context.
 // Called from Proxy and RootCoord (defense in depth) on create-collection.
 func ValidateSourceAndSpec(externalSource, externalSpec string) error {
 	if err := ValidateExternalSource(externalSource); err != nil {
-		return merr.WrapErrParameterInvalid("valid external_source", externalSource, err.Error())
+		return merr.Wrap(err, "external_source is invalid")
 	}
 	spec, err := ParseExternalSpec(externalSpec)
 	if err != nil {
-		return merr.WrapErrParameterInvalid("valid external_spec", "<redacted>", err.Error())
+		return merr.Wrap(err, "external_spec is invalid")
 	}
 	if err := ValidateExtfsComplete(externalSource, spec.Extfs); err != nil {
-		return merr.WrapErrParameterInvalid("valid external_spec", "<redacted>", err.Error())
+		return merr.Wrap(err, "external_spec is invalid")
 	}
 	return nil
+}
+
+// RedactExternalSource returns a log-safe external source. Normal storage URIs
+// are preserved for diagnostics, while malformed URIs and URI components that
+// can carry credentials (userinfo, query, or fragment) are hidden completely.
+func RedactExternalSource(source string) string {
+	if source == "" {
+		return ""
+	}
+	u, err := url.Parse(source)
+	if err != nil || u.Opaque != "" || u.RawQuery != "" || u.Fragment != "" || ValidateExternalSource(source) != nil {
+		return "<redacted>"
+	}
+	return source
+}
+
+// RedactExternalSpecForLog preserves approved top-level metadata while
+// replacing the complete extfs authentication/configuration object. Unknown
+// top-level fields are dropped because future extensions may carry secrets.
+func RedactExternalSpecForLog(specStr string) string {
+	if specStr == "" {
+		return ""
+	}
+
+	var spec map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(specStr), &spec); err != nil {
+		return "<redacted>"
+	}
+
+	redacted := make(map[string]json.RawMessage, 4)
+	for _, key := range []string{"format", "columns", "snapshot_id"} {
+		if value, ok := spec[key]; ok {
+			redacted[key] = value
+		}
+	}
+	if _, ok := spec["extfs"]; ok {
+		redacted["extfs"] = json.RawMessage(`"***"`)
+	}
+
+	out, err := json.Marshal(redacted)
+	if err != nil {
+		return "<redacted>"
+	}
+	return string(out)
+}
+
+// RedactCollectionSchemaForLog returns a copy of schema with external storage
+// credentials removed. Callers can safely log the result without mutating the
+// schema used by request handling or distributed load paths.
+func RedactCollectionSchemaForLog(schema *schemapb.CollectionSchema) *schemapb.CollectionSchema {
+	if schema == nil {
+		return nil
+	}
+
+	redacted := proto.Clone(schema).(*schemapb.CollectionSchema)
+	redacted.ExternalSource = RedactExternalSource(redacted.GetExternalSource())
+	redacted.ExternalSpec = RedactExternalSpecForLog(redacted.GetExternalSpec())
+	return redacted
 }
 
 // ValidateExtfsComplete requires spec.extfs to be self-sufficient: exactly one
@@ -451,13 +512,13 @@ var awsFamilyScheme = map[string]bool{
 	SchemeAWS: true,
 }
 
-// RedactExternalSpec returns a log-safe representation of an external spec
-// JSON string. Secret extfs values (see secretExtfsKeys) are replaced with
-// "***" so that AK/SK/PEM material never reaches log sinks. Unknown fields
-// are preserved so API callers can still observe extension metadata. On parse
-// failure it returns "<invalid spec>" rather than the raw input — the input
-// itself may already contain a partially-recognized credential blob, so we
-// never echo it back. Empty input returns empty string for log readability.
+// RedactExternalSpec returns a credential-redacted representation of a
+// validated external spec for user-visible responses. Known secret extfs
+// values (see secretExtfsKeys) are replaced with "***", while unknown fields
+// are preserved as extension metadata. Because unknown pre-validation fields
+// may themselves be sensitive, external-collection request logging uses
+// RedactExternalSpecForLog. On parse failure this returns "<invalid spec>"
+// rather than the raw input.
 func RedactExternalSpec(specStr string) string {
 	if specStr == "" {
 		return ""

--- a/pkg/util/externalspec/external_spec_test.go
+++ b/pkg/util/externalspec/external_spec_test.go
@@ -22,6 +22,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func TestParseExternalSpec_Empty(t *testing.T) {
@@ -159,6 +162,31 @@ func TestValidateExternalSource(t *testing.T) {
 	})
 }
 
+func TestRedactExternalSource(t *testing.T) {
+	testCases := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{name: "empty", source: "", want: ""},
+		{name: "normal URI", source: "s3://bucket/path", want: "s3://bucket/path"},
+		{name: "userinfo", source: "s3://ACCESS_SENTINEL:SECRET_SENTINEL@bucket/path", want: "<redacted>"},
+		{name: "query", source: "s3://bucket/path?token=QUERY_SECRET_SENTINEL", want: "<redacted>"},
+		{name: "fragment", source: "s3://bucket/path#FRAGMENT_SECRET_SENTINEL", want: "<redacted>"},
+		{name: "malformed", source: "s3://MALFORMED_SECRET_SENTINEL bad/path", want: "<redacted>"},
+		{name: "opaque URI", source: "s3:ACCESS_SENTINEL:SECRET_SENTINEL@bucket/path", want: "<redacted>"},
+		{name: "scheme-less URI", source: "ACCESS_SENTINEL:SECRET_SENTINEL@bucket/path", want: "<redacted>"},
+		{name: "host-less URI", source: "s3:///ACCESS_SENTINEL/SECRET_SENTINEL", want: "<redacted>"},
+		{name: "unsupported scheme", source: "ftp://ACCESS_SENTINEL:" + "SECRET_SENTINEL@host/path", want: "<redacted>"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.want, RedactExternalSource(testCase.source))
+		})
+	}
+}
+
 // minimalValidSpec returns an extfs block that ValidateExtfsComplete accepts
 // for AWS-family schemes: AK/SK pair + region.
 func minimalValidSpec() string {
@@ -166,6 +194,11 @@ func minimalValidSpec() string {
 }
 
 func TestValidateSourceAndSpec(t *testing.T) {
+	requireParameterInvalid := func(t *testing.T, err error) {
+		t.Helper()
+		require.ErrorIs(t, err, merr.ErrParameterInvalid)
+	}
+
 	t.Run("both_valid", func(t *testing.T) {
 		err := ValidateSourceAndSpec("s3://bucket/prefix", minimalValidSpec())
 		assert.NoError(t, err)
@@ -173,39 +206,73 @@ func TestValidateSourceAndSpec(t *testing.T) {
 
 	t.Run("invalid_source", func(t *testing.T) {
 		err := ValidateSourceAndSpec("file:///tmp/x", minimalValidSpec())
-		require.Error(t, err)
+		requireParameterInvalid(t, err)
 	})
 
-	t.Run("invalid_spec_redacts", func(t *testing.T) {
+	t.Run("source_credentials_rejected", func(t *testing.T) {
+		err := ValidateSourceAndSpec("s3://SOURCE_ACCESS_ERROR_SENTINEL:SOURCE_SECRET_ERROR_SENTINEL@bucket/prefix", minimalValidSpec())
+		requireParameterInvalid(t, err)
+		assert.Contains(t, err.Error(), "external_source is invalid")
+		assert.Contains(t, err.Error(), "must not embed credentials")
+	})
+
+	t.Run("malformed_source_redacts_parse_error", func(t *testing.T) {
+		err := ValidateSourceAndSpec("s3://SOURCE_PARSE_ERROR_SENTINEL bad/prefix", minimalValidSpec())
+		requireParameterInvalid(t, err)
+		assert.NotContains(t, err.Error(), "SOURCE_PARSE_ERROR_SENTINEL")
+		assert.Contains(t, err.Error(), "external_source is invalid")
+		assert.Contains(t, err.Error(), "external_source is not a valid URL")
+	})
+
+	t.Run("invalid_spec_includes_parse_error", func(t *testing.T) {
 		err := ValidateSourceAndSpec("s3://bucket/prefix", `{bad json`)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "<redacted>")
+		requireParameterInvalid(t, err)
+		assert.Contains(t, err.Error(), "external_spec is invalid")
+		assert.Contains(t, err.Error(), "invalid external spec JSON")
+	})
+
+	t.Run("invalid_format_includes_validation_error", func(t *testing.T) {
+		err := ValidateSourceAndSpec("s3://bucket/prefix", `{"format":"FORMAT_VALUE_SECRET_SENTINEL"}`)
+		requireParameterInvalid(t, err)
+		assert.Contains(t, err.Error(), "FORMAT_VALUE_SECRET_SENTINEL")
+		assert.Contains(t, err.Error(), "external_spec is invalid")
+		assert.Contains(t, err.Error(), "unsupported format")
+	})
+
+	t.Run("invalid_extfs_value_includes_validation_error", func(t *testing.T) {
+		err := ValidateSourceAndSpec("s3://bucket/prefix", `{"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK","region":"us-east-1","cloud_provider":"CLOUD_PROVIDER_SECRET_SENTINEL"}}`)
+		requireParameterInvalid(t, err)
+		assert.Contains(t, err.Error(), "CLOUD_PROVIDER_SECRET_SENTINEL")
+		assert.Contains(t, err.Error(), "cloud_provider_secret_sentinel")
+		assert.Contains(t, err.Error(), "external_spec is invalid")
+		assert.Contains(t, err.Error(), "must use the canonical lowercase value")
 	})
 
 	t.Run("missing_credentials_rejected", func(t *testing.T) {
 		err := ValidateSourceAndSpec("s3://bucket/prefix", `{"format":"parquet"}`)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "<redacted>")
+		require.ErrorIs(t, err, merr.ErrParameterMissing)
+		assert.Contains(t, err.Error(), "external_spec is invalid")
+		assert.Contains(t, err.Error(), "cloud_provider is required")
 	})
 
 	t.Run("missing_region_for_aws_scheme_rejected", func(t *testing.T) {
 		err := ValidateSourceAndSpec("s3://bucket/prefix",
 			`{"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK","cloud_provider":"aws"}}`)
-		require.Error(t, err)
+		require.ErrorIs(t, err, merr.ErrParameterMissing)
 	})
 
 	t.Run("missing_cloud_provider_rejected", func(t *testing.T) {
 		err := ValidateSourceAndSpec("s3://bucket/prefix",
 			`{"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK","region":"us-east-1"}}`)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "cloud_provider is required")
+		require.ErrorIs(t, err, merr.ErrParameterMissing)
+		assert.Contains(t, err.Error(), "external_spec is invalid")
 	})
 
 	t.Run("invalid_cloud_provider_rejected", func(t *testing.T) {
 		err := ValidateSourceAndSpec("s3://bucket/prefix",
 			`{"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK","region":"us-east-1","cloud_provider":"unknown"}}`)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "is not supported")
+		requireParameterInvalid(t, err)
+		assert.Contains(t, err.Error(), "external_spec is invalid")
 	})
 
 	t.Run("minio_cloud_provider_milvus_form", func(t *testing.T) {
@@ -223,8 +290,8 @@ func TestValidateSourceAndSpec(t *testing.T) {
 	t.Run("minio_scheme_rejects_non_minio_cloud_provider", func(t *testing.T) {
 		err := ValidateSourceAndSpec("minio://localhost:9000/mybucket/path",
 			`{"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK","region":"us-east-1","cloud_provider":"aws"}}`)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "scheme=minio requires")
+		requireParameterInvalid(t, err)
+		assert.Contains(t, err.Error(), "external_spec is invalid")
 	})
 
 	t.Run("gcs_scheme_does_not_require_region", func(t *testing.T) {
@@ -254,19 +321,19 @@ func TestValidateSourceAndSpec(t *testing.T) {
 	t.Run("ak_without_sk_rejected", func(t *testing.T) {
 		err := ValidateSourceAndSpec("s3://bucket/prefix",
 			`{"format":"parquet","extfs":{"access_key_id":"AK","region":"us-east-1","cloud_provider":"aws"}}`)
-		require.Error(t, err)
+		require.ErrorIs(t, err, merr.ErrParameterMissing)
 	})
 
 	t.Run("anonymous_with_aksk_rejected", func(t *testing.T) {
 		err := ValidateSourceAndSpec("s3://bucket/prefix",
 			`{"format":"parquet","extfs":{"anonymous":"true","access_key_id":"AK","access_key_value":"SK","region":"us-east-1","cloud_provider":"aws"}}`)
-		require.Error(t, err)
+		requireParameterInvalid(t, err)
 	})
 
 	t.Run("multiple_modes_rejected", func(t *testing.T) {
 		err := ValidateSourceAndSpec("s3://bucket/prefix",
 			`{"format":"parquet","extfs":{"role_arn":"arn:aws:iam::1:role/r","access_key_id":"AK","access_key_value":"SK","region":"us-east-1","cloud_provider":"aws"}}`)
-		require.Error(t, err)
+		requireParameterInvalid(t, err)
 	})
 
 	t.Run("gcp_impersonation_mode", func(t *testing.T) {
@@ -284,31 +351,31 @@ func TestValidateSourceAndSpec(t *testing.T) {
 	t.Run("gcp_impersonation_on_aws_scheme_rejected", func(t *testing.T) {
 		err := ValidateSourceAndSpec("s3://bucket/prefix",
 			`{"format":"parquet","extfs":{"gcp_target_service_account":"sa@proj.iam.gserviceaccount.com","region":"us-east-1","cloud_provider":"aws"}}`)
-		require.Error(t, err)
+		requireParameterInvalid(t, err)
 	})
 
 	t.Run("gcp_impersonation_malformed_email_rejected", func(t *testing.T) {
 		err := ValidateSourceAndSpec("gs://bucket/prefix",
 			`{"format":"parquet","extfs":{"gcp_target_service_account":"not-an-email","cloud_provider":"gcp"}}`)
-		require.Error(t, err)
+		requireParameterInvalid(t, err)
 	})
 
 	t.Run("gcp_impersonation_missing_at_sign_rejected", func(t *testing.T) {
 		err := ValidateSourceAndSpec("gs://bucket/prefix",
 			`{"format":"parquet","extfs":{"gcp_target_service_account":"saproj.iam.gserviceaccount.com","cloud_provider":"gcp"}}`)
-		require.Error(t, err)
+		requireParameterInvalid(t, err)
 	})
 
 	t.Run("gcp_impersonation_with_aksk_rejected", func(t *testing.T) {
 		err := ValidateSourceAndSpec("gs://bucket/prefix",
 			`{"format":"parquet","extfs":{"gcp_target_service_account":"sa@proj.iam.gserviceaccount.com","access_key_id":"AK","access_key_value":"SK","cloud_provider":"gcp"}}`)
-		require.Error(t, err)
+		requireParameterInvalid(t, err)
 	})
 
 	t.Run("gcp_impersonation_with_anonymous_rejected", func(t *testing.T) {
 		err := ValidateSourceAndSpec("gs://bucket/prefix",
 			`{"format":"parquet","extfs":{"gcp_target_service_account":"sa@proj.iam.gserviceaccount.com","anonymous":"true","cloud_provider":"gcp"}}`)
-		require.Error(t, err)
+		requireParameterInvalid(t, err)
 	})
 }
 
@@ -390,6 +457,51 @@ func TestRedactExternalSpec(t *testing.T) {
 		assert.Equal(t, "***", extfs["external_id"])
 		assert.NotContains(t, out, "zilliz-external-sO1cjGS2Vgpyan")
 	})
+}
+
+func TestRedactExternalSpecForLog(t *testing.T) {
+	assert.Equal(t, "", RedactExternalSpecForLog(""))
+	redacted := RedactExternalSpecForLog(`{
+		"format":"parquet",
+		"columns":["id","vector"],
+		"snapshot_id":"123",
+		"future_top_level":"TOP_LEVEL_SECRET_SENTINEL",
+		"extfs":{
+			"cloud_provider":"aws",
+			"region":"us-west-2",
+			"future_password":"FUTURE_SECRET_SENTINEL"
+		}
+	}`)
+	assert.JSONEq(t, `{"format":"parquet","columns":["id","vector"],"snapshot_id":"123","extfs":"***"}`, redacted)
+	assert.NotContains(t, redacted, "TOP_LEVEL_SECRET_SENTINEL")
+	assert.NotContains(t, redacted, "FUTURE_SECRET_SENTINEL")
+	assert.Equal(t, "<redacted>", RedactExternalSpecForLog(`{malformed SECRET_SENTINEL`))
+}
+
+func TestRedactCollectionSchemaForLog(t *testing.T) {
+	assert.Nil(t, RedactCollectionSchemaForLog(nil))
+
+	schema := &schemapb.CollectionSchema{
+		Name:           "external_collection",
+		ExternalSource: "s3://ACCESS_SENTINEL:SECRET_SENTINEL@bucket/path",
+		ExternalSpec:   `{"format":"parquet","future_secret":"TOP_LEVEL_SENTINEL","extfs":{"access_key_value":"SPEC_SENTINEL"}}`,
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64},
+		},
+	}
+
+	redacted := RedactCollectionSchemaForLog(schema)
+	require.NotSame(t, schema, redacted)
+	assert.Equal(t, "external_collection", redacted.GetName())
+	assert.Equal(t, schema.GetFields(), redacted.GetFields())
+	assert.Equal(t, "<redacted>", redacted.GetExternalSource())
+	assert.JSONEq(t, `{"format":"parquet","extfs":"***"}`, redacted.GetExternalSpec())
+	assert.NotContains(t, redacted.String(), "ACCESS_SENTINEL")
+	assert.NotContains(t, redacted.String(), "SECRET_SENTINEL")
+	assert.NotContains(t, redacted.String(), "TOP_LEVEL_SENTINEL")
+	assert.NotContains(t, redacted.String(), "SPEC_SENTINEL")
+	assert.Contains(t, schema.GetExternalSource(), "ACCESS_SENTINEL")
+	assert.Contains(t, schema.GetExternalSpec(), "SPEC_SENTINEL")
 }
 
 func TestExternalSpecMarshalJSON(t *testing.T) {

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -2630,8 +2630,8 @@ func NormalizeAndValidateExternalCollectionSchema(schema *schemapb.CollectionSch
 	srcSet := schema.GetExternalSource() != ""
 	specSet := schema.GetExternalSpec() != ""
 	if srcSet != specSet {
-		return merr.WrapErrParameterInvalidMsg("external collection %s requires external_source and external_spec to be both set or both empty (got source=%q, spec=%q)",
-			schema.GetName(), schema.GetExternalSource(), schema.GetExternalSpec())
+		return merr.WrapErrParameterInvalidMsg("external collection %s requires external_source and external_spec to be both set or both empty (source_set=%t, spec_set=%t)",
+			schema.GetName(), srcSet, specSet)
 	}
 
 	if !IsExternalCollection(schema) {

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -5507,10 +5507,11 @@ func TestNormalizeAndValidateExternalCollectionSchema(t *testing.T) {
 
 	t.Run("invalid external spec rejected", func(t *testing.T) {
 		schema := buildSchema()
-		schema.ExternalSpec = `{`
+		schema.ExternalSpec = `{"format":"FORMAT_SCHEMA_SECRET_SENTINEL"}`
 		err := NormalizeAndValidateExternalCollectionSchema(schema)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid external spec JSON")
+		assert.Contains(t, err.Error(), "FORMAT_SCHEMA_SECRET_SENTINEL")
+		assert.Contains(t, err.Error(), "unsupported format")
 	})
 
 	t.Run("partition key disabled", func(t *testing.T) {
@@ -5558,20 +5559,24 @@ func TestNormalizeAndValidateExternalCollectionSchema(t *testing.T) {
 
 	t.Run("source set without spec rejected", func(t *testing.T) {
 		schema := buildSchema()
-		schema.ExternalSource = "s3://bucket/path"
+		schema.ExternalSource = "s3://SOURCE_ACCESS_SENTINEL:SOURCE_SECRET_SENTINEL@bucket/path"
 		schema.ExternalSpec = ""
 		err := NormalizeAndValidateExternalCollectionSchema(schema)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "both set or both empty")
+		assert.NotContains(t, err.Error(), "SOURCE_ACCESS_SENTINEL")
+		assert.NotContains(t, err.Error(), "SOURCE_SECRET_SENTINEL")
 	})
 
 	t.Run("spec set without source rejected", func(t *testing.T) {
 		schema := buildSchema()
 		schema.ExternalSource = ""
-		schema.ExternalSpec = `{"format":"parquet"}`
+		schema.ExternalSpec = `{"format":"parquet","extfs":{"access_key_id":"AKIA_ERROR_SENTINEL","access_key_value":"SECRET_ERROR_SENTINEL"}}`
 		err := NormalizeAndValidateExternalCollectionSchema(schema)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "both set or both empty")
+		assert.NotContains(t, err.Error(), "AKIA_ERROR_SENTINEL")
+		assert.NotContains(t, err.Error(), "SECRET_ERROR_SENTINEL")
 	})
 
 	t.Run("source/spec pair validated without external fields", func(t *testing.T) {

--- a/tests/go_client/testcases/advcases/rbac_test.go
+++ b/tests/go_client/testcases/advcases/rbac_test.go
@@ -71,7 +71,6 @@ func TestRbacDefault(t *testing.T) {
 	userName := common.GenRandomString("user", 6)
 	pwd := common.GenRandomString("pwd", 6)
 	userDescription := "go client user description"
-	mlog.Info(ctx, t.Name(), mlog.String("pwd", pwd))
 	err := mc.CreateUser(ctx, client.NewCreateUserOption(userName, pwd).WithDescription(userDescription))
 	common.CheckErr(t, err, true)
 	users, err := mc.ListUsers(ctx, client.NewListUserOption())
@@ -290,7 +289,6 @@ func TestUpdatePassword(t *testing.T) {
 	oldPwd := newPwd
 	passwords := []string{"中文", "シャオミン", "샤오밍", "ಸೂರ್ಯ", "myPwd@aa.com", "φεγγάρι", "mặt trăng"}
 	for i := 0; i < len(passwords); i++ {
-		mlog.Info(ctx, t.Name(), mlog.String("pwd", passwords[i]))
 		err = mc.UpdatePassword(ctx, client.NewUpdatePasswordOption(userName, oldPwd, passwords[i]))
 		common.CheckErr(t, err, true)
 		oldPwd = passwords[i]


### PR DESCRIPTION
Backport #52039 to 3.0.

Prevent sensitive storage credentials, API keys, RBAC password hashes, and external collection source/spec data from reaching logs or error messages. Preserve detailed external-spec validation errors while logging only approved metadata.

Backport adaptations:

- Keep the 3.0-native TiKV and mlog implementations.
- Exclude master-only expression-template refactors unrelated to credential redaction.

Verification:

- The pkg/util/externalspec full test suite passed with the required dynamic,test tags and disabled optimization/inlining.
- The internal/kv/tikv suite passed.
- Broader proxy and etcd suites reached the unavailable localhost:2379 dependency and were not used as pass evidence.

See also: #52038

pr: #52039
Signed-off-by: yangxuan <xuan.yang@zilliz.com>