### PR TITLE
fix: prevent sensitive credentials from reaching logs

### DIFF
--- a/internal/datanode/index/task_index.go
+++ b/internal/datanode/index/task_index.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
@@ -225,6 +226,23 @@ func (it *indexBuildTask) PreExecute(ctx context.Context) error {
 	return nil
 }
 
+func redactBuildIndexParamsForLog(params *indexcgopb.BuildIndexInfo) *indexcgopb.BuildIndexInfo {
+	if params == nil {
+		return nil
+	}
+
+	redacted := proto.Clone(params).(*indexcgopb.BuildIndexInfo)
+	if config := redacted.GetStorageConfig(); config != nil {
+		redactStorageCredentialsForLog(
+			&config.AccessKeyID,
+			&config.SecretAccessKey,
+			&config.SslCACert,
+			&config.GcpCredentialJSON,
+		)
+	}
+	return redacted
+}
+
 func (it *indexBuildTask) Execute(ctx context.Context) error {
 	log := log.Ctx(ctx).With(
 		zap.String("clusterID", it.req.GetClusterID()),
@@ -326,7 +344,7 @@ func (it *indexBuildTask) Execute(ctx context.Context) error {
 			it.req.GetSegmentID())
 		buildIndexParams.Manifest = it.req.GetManifest()
 	}
-	log.Info("create index", zap.Any("buildIndexParams", buildIndexParams))
+	log.Info("create index", zap.Any("buildIndexParams", redactBuildIndexParamsForLog(buildIndexParams)))
 
 	// set plugin context after logging the indexParams to avoid logging sensitive data
 	if it.pluginContext != nil {

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -141,6 +141,29 @@ func (st *statsTask) IsVectorIndex() bool {
 	return false
 }
 
+func redactStorageCredentialsForLog(accessKeyID, secretAccessKey, sslCACert, gcpCredentialJSON *string) {
+	for _, secret := range []*string{accessKeyID, secretAccessKey, sslCACert, gcpCredentialJSON} {
+		if secret != nil && *secret != "" {
+			*secret = "<redacted>"
+		}
+	}
+}
+
+func redactStorageConfigForLog(config *indexpb.StorageConfig) *indexpb.StorageConfig {
+	if config == nil {
+		return nil
+	}
+
+	redacted := proto.Clone(config).(*indexpb.StorageConfig)
+	redactStorageCredentialsForLog(
+		&redacted.AccessKeyID,
+		&redacted.SecretAccessKey,
+		&redacted.SslCACert,
+		&redacted.GcpCredentialJSON,
+	)
+	return redacted
+}
+
 func (st *statsTask) PreExecute(ctx context.Context) error {
 	ctx, span := otel.Tracer(typeutil.IndexNodeRole).Start(ctx, fmt.Sprintf("Stats-PreExecute-%s-%d", st.req.GetClusterID(), st.req.GetTaskID()))
 	defer span.End()
@@ -183,7 +206,7 @@ func (st *statsTask) PreExecute(ctx context.Context) error {
 		zap.Int64("segmentID", st.req.GetSegmentID()),
 		zap.Int64("storageVersion", st.req.GetStorageVersion()),
 		zap.Int64("preExecuteRecordSpan(ms)", preExecuteRecordSpan.Milliseconds()),
-		zap.Any("storageConfig", st.req.StorageConfig),
+		zap.Any("storageConfig", redactStorageConfigForLog(st.req.GetStorageConfig())),
 	)
 	return nil
 }

--- a/internal/datanode/index/task_stats_test.go
+++ b/internal/datanode/index/task_stats_test.go
@@ -179,6 +179,34 @@ func (s *TaskStatsSuite) TestSortSegmentWithBM25() {
 	})
 }
 
+func (s *TaskStatsSuite) TestRedactStorageConfigForLog() {
+	config := &indexpb.StorageConfig{
+		Address:           "storage.example.test",
+		StorageType:       "s3",
+		BucketName:        "stats-bucket",
+		RootPath:          "stats/root",
+		AccessKeyID:       "STORAGE_ACCESS_KEY_SENTINEL",
+		SecretAccessKey:   "STORAGE_SECRET_KEY_SENTINEL",
+		SslCACert:         "STORAGE_CA_CERT_SENTINEL",
+		GcpCredentialJSON: `{"private_key":"GCP_CREDENTIAL_SENTINEL"}`,
+	}
+
+	redacted := redactStorageConfigForLog(config)
+	s.NotSame(config, redacted)
+	s.Equal("storage.example.test", redacted.GetAddress())
+	s.Equal("s3", redacted.GetStorageType())
+	s.Equal("stats-bucket", redacted.GetBucketName())
+	s.Equal("stats/root", redacted.GetRootPath())
+	s.Equal("<redacted>", redacted.GetAccessKeyID())
+	s.Equal("<redacted>", redacted.GetSecretAccessKey())
+	s.Equal("<redacted>", redacted.GetSslCACert())
+	s.Equal("<redacted>", redacted.GetGcpCredentialJSON())
+	s.Equal("STORAGE_ACCESS_KEY_SENTINEL", config.GetAccessKeyID())
+	s.Equal("STORAGE_SECRET_KEY_SENTINEL", config.GetSecretAccessKey())
+	s.Equal("STORAGE_CA_CERT_SENTINEL", config.GetSslCACert())
+	s.Contains(config.GetGcpCredentialJSON(), "GCP_CREDENTIAL_SENTINEL")
+}
+
 func (s *TaskStatsSuite) TestBuildIndexParams() {
 	s.Run("test storage v2 index params", func() {
 		req := &workerpb.CreateStatsRequest{

--- a/internal/datanode/index/task_stats_test.go
+++ b/internal/datanode/index/task_stats_test.go
@@ -180,6 +180,7 @@ func (s *TaskStatsSuite) TestSortSegmentWithBM25() {
 }
 
 func (s *TaskStatsSuite) TestRedactStorageConfigForLog() {
+	// #nosec G101 -- test-only sentinels verify that credentials are redacted.
 	config := &indexpb.StorageConfig{
 		Address:           "storage.example.test",
 		StorageType:       "s3",

--- a/internal/datanode/index_services.go
+++ b/internal/datanode/index_services.go
@@ -93,7 +93,6 @@ func (node *DataNode) CreateJob(ctx context.Context, req *workerpb.CreateJobRequ
 	cm, err := node.storageFactory.NewChunkManager(node.ctx, req.GetStorageConfig())
 	if err != nil {
 		log.Error("create chunk manager failed", zap.String("bucket", req.GetStorageConfig().GetBucketName()),
-			zap.String("accessKey", req.GetStorageConfig().GetAccessKeyID()),
 			zap.Error(err),
 		)
 		node.taskManager.DeleteIndexTaskInfos(ctx, []index.Key{{ClusterID: req.GetClusterID(), TaskID: req.GetBuildID()}})
@@ -304,7 +303,6 @@ func (node *DataNode) createIndexTask(ctx context.Context, req *workerpb.CreateJ
 	cm, err := node.storageFactory.NewChunkManager(node.ctx, req.GetStorageConfig())
 	if err != nil {
 		log.Error("create chunk manager failed", zap.String("bucket", req.GetStorageConfig().GetBucketName()),
-			zap.String("accessKey", req.GetStorageConfig().GetAccessKeyID()),
 			zap.Error(err),
 		)
 		node.taskManager.DeleteIndexTaskInfos(ctx, []index.Key{{ClusterID: req.GetClusterID(), TaskID: req.GetBuildID()}})
@@ -415,7 +413,6 @@ func (node *DataNode) createStatsTask(ctx context.Context, req *workerpb.CreateS
 	cm, err := node.storageFactory.NewChunkManager(node.ctx, req.GetStorageConfig())
 	if err != nil {
 		log.Error("create chunk manager failed", zap.String("bucket", req.GetStorageConfig().GetBucketName()),
-			zap.String("accessKey", req.GetStorageConfig().GetAccessKeyID()),
 			zap.Error(err),
 		)
 		node.taskManager.DeleteStatsTaskInfos(ctx, []index.Key{{ClusterID: req.GetClusterID(), TaskID: req.GetTaskID()}})

--- a/internal/datanode/services.go
+++ b/internal/datanode/services.go
@@ -326,7 +326,6 @@ func (node *DataNode) PreImport(ctx context.Context, req *datapb.PreImportReques
 	cm, err := node.storageFactory.NewChunkManager(node.ctx, req.GetStorageConfig())
 	if err != nil {
 		log.Error("create chunk manager failed", zap.String("bucket", req.GetStorageConfig().GetBucketName()),
-			zap.String("accessKey", req.GetStorageConfig().GetAccessKeyID()),
 			zap.Error(err),
 		)
 		return merr.Status(err), nil
@@ -366,7 +365,6 @@ func (node *DataNode) ImportV2(ctx context.Context, req *datapb.ImportRequest) (
 	cm, err := node.storageFactory.NewChunkManager(node.ctx, req.GetStorageConfig())
 	if err != nil {
 		log.Error("create chunk manager failed", zap.String("bucket", req.GetStorageConfig().GetBucketName()),
-			zap.String("accessKey", req.GetStorageConfig().GetAccessKeyID()),
 			zap.Error(err),
 		)
 		return merr.Status(err), nil

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -448,6 +448,23 @@ func restfulSizeMiddleware(handler gin.HandlerFunc, observeOutbound bool) gin.Ha
 	}
 }
 
+func getTraceLogRequestFieldWithoutSensitiveInfo(req any) zap.Field {
+	switch request := req.(type) {
+	case *PasswordReq:
+		if request == nil {
+			return proxy.GetRequestFieldWithoutSensitiveInfo(req)
+		}
+		return zap.Any("request", &UserReq{UserName: request.UserName})
+	case *NewPasswordReq:
+		if request == nil {
+			return proxy.GetRequestFieldWithoutSensitiveInfo(req)
+		}
+		return zap.Any("request", &UserReq{UserName: request.UserName})
+	default:
+		return proxy.GetRequestFieldWithoutSensitiveInfo(req)
+	}
+}
+
 func wrapperTraceLog(v2 handlerFuncV2) handlerFuncV2 {
 	return func(ctx context.Context, c *gin.Context, req any, dbName string) (interface{}, error) {
 		switch proxy.Params.CommonCfg.TraceLogMode.GetAsInt() {
@@ -460,13 +477,13 @@ func wrapperTraceLog(v2 handlerFuncV2) handlerFuncV2 {
 			fields := proxy.GetRequestBaseInfo(ctx, req, &grpc.UnaryServerInfo{
 				FullMethod: c.Request.URL.Path,
 			}, true)
-			fields = append(fields, proxy.GetRequestFieldWithoutSensitiveInfo(req))
+			fields = append(fields, getTraceLogRequestFieldWithoutSensitiveInfo(req))
 			log.Ctx(ctx).Info("trace info: detail", fields...)
 		case 3: // detail info with request and response
 			fields := proxy.GetRequestBaseInfo(ctx, req, &grpc.UnaryServerInfo{
 				FullMethod: c.Request.URL.Path,
 			}, true)
-			fields = append(fields, proxy.GetRequestFieldWithoutSensitiveInfo(req))
+			fields = append(fields, getTraceLogRequestFieldWithoutSensitiveInfo(req))
 			log.Ctx(ctx).Info("trace info: all request", fields...)
 		}
 		resp, err := v2(ctx, c, req, dbName)

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -97,6 +97,49 @@ func sendReqAndVerify(t *testing.T, testEngine *gin.Engine, testName, method str
 	})
 }
 
+func TestTraceLogRequestFieldRedactsRESTPasswords(t *testing.T) {
+	description := "account description"
+	testCases := []struct {
+		name    string
+		req     any
+		secrets []string
+	}{
+		{
+			name: "create user",
+			req: &PasswordReq{
+				UserName:    "alice",
+				Password:    "CREATE_PASSWORD_SENTINEL_DO_NOT_LOG",
+				Description: &description,
+			},
+			secrets: []string{"CREATE_PASSWORD_SENTINEL_DO_NOT_LOG"},
+		},
+		{
+			name: "update password",
+			req: &NewPasswordReq{
+				UserName:    "alice",
+				Password:    "OLD_PASSWORD_SENTINEL_DO_NOT_LOG",
+				NewPassword: "NEW_PASSWORD_SENTINEL_DO_NOT_LOG",
+				Description: &description,
+			},
+			secrets: []string{
+				"OLD_PASSWORD_SENTINEL_DO_NOT_LOG",
+				"NEW_PASSWORD_SENTINEL_DO_NOT_LOG",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			field := getTraceLogRequestFieldWithoutSensitiveInfo(testCase.req)
+			request := fmt.Sprint(field.Interface)
+			assert.Contains(t, request, "alice")
+			for _, secret := range testCase.secrets {
+				assert.NotContains(t, request, secret)
+			}
+		})
+	}
+}
+
 func TestHTTPWrapper(t *testing.T) {
 	postTestCases := []requestBodyTestCase{}
 	postTestCasesTrace := []requestBodyTestCase{}

--- a/internal/kv/etcd/etcd_kv.go
+++ b/internal/kv/etcd/etcd_kv.go
@@ -389,7 +389,7 @@ func (kv *etcdKV) MultiSave(ctx context.Context, kvs map[string]string) error {
 	CheckTnxStringValueSizeAndWarn(ctx, kvs)
 	_, err := kv.executeTxn(kv.getTxnWithCmp(ctx1), ops...)
 	if err != nil {
-		log.Ctx(ctx).Warn("Etcd MultiSave error", zap.Any("kvs", kvs), zap.Int("len", len(kvs)), zap.Error(err))
+		log.Ctx(ctx).Warn("Etcd MultiSave error", zap.Strings("keys", lo.Keys(kvs)), zap.Int("len", len(kvs)), zap.Error(err))
 	}
 	CheckElapseAndWarn(ctx, start, "Slow etcd operation multi save", zap.Strings("keys", keys))
 	return err
@@ -411,7 +411,7 @@ func (kv *etcdKV) MultiSaveBytes(ctx context.Context, kvs map[string][]byte) err
 	CheckTnxBytesValueSizeAndWarn(ctx, kvs)
 	_, err := kv.executeTxn(kv.getTxnWithCmp(ctx1), ops...)
 	if err != nil {
-		log.Ctx(ctx).Warn("Etcd MultiSaveBytes err", zap.Any("kvs", kvs), zap.Int("len", len(kvs)), zap.Error(err))
+		log.Ctx(ctx).Warn("Etcd MultiSaveBytes err", zap.Strings("keys", lo.Keys(kvs)), zap.Int("len", len(kvs)), zap.Error(err))
 	}
 	CheckElapseAndWarn(ctx, start, "Slow etcd operation multi save", zap.Strings("keys", keys))
 	return err
@@ -489,7 +489,7 @@ func (kv *etcdKV) MultiSaveAndRemove(ctx context.Context, saves map[string]strin
 	resp, err := kv.executeTxn(kv.getTxnWithCmp(ctx1, cmps...), ops...)
 	if err != nil {
 		log.Ctx(ctx).Warn("Etcd MultiSaveAndRemove error",
-			zap.Any("saves", saves),
+			zap.Strings("saveKeys", lo.Keys(saves)),
 			zap.Strings("removes", removals),
 			zap.Int("saveLength", len(saves)),
 			zap.Int("removeLength", len(removals)),
@@ -524,7 +524,7 @@ func (kv *etcdKV) MultiSaveBytesAndRemove(ctx context.Context, saves map[string]
 	_, err := kv.executeTxn(kv.getTxnWithCmp(ctx1), ops...)
 	if err != nil {
 		log.Ctx(ctx).Warn("Etcd MultiSaveBytesAndRemove error",
-			zap.Any("saves", saves),
+			zap.Strings("saveKeys", lo.Keys(saves)),
 			zap.Strings("removes", removals),
 			zap.Int("saveLength", len(saves)),
 			zap.Int("removeLength", len(removals)),
@@ -586,7 +586,7 @@ func (kv *etcdKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[st
 	resp, err := kv.executeTxn(kv.getTxnWithCmp(ctx1, cmps...), ops...)
 	if err != nil {
 		log.Ctx(ctx).Warn("Etcd MultiSaveAndRemoveWithPrefix error",
-			zap.Any("saves", saves),
+			zap.Strings("saveKeys", lo.Keys(saves)),
 			zap.Strings("removes", removals),
 			zap.Int("saveLength", len(saves)),
 			zap.Int("removeLength", len(removals)),
@@ -620,7 +620,7 @@ func (kv *etcdKV) MultiSaveBytesAndRemoveWithPrefix(ctx context.Context, saves m
 	_, err := kv.executeTxn(kv.getTxnWithCmp(ctx1), ops...)
 	if err != nil {
 		log.Ctx(ctx).Warn("Etcd MultiSaveBytesAndRemoveWithPrefix error",
-			zap.Any("saves", saves),
+			zap.Strings("saveKeys", lo.Keys(saves)),
 			zap.Strings("removes", removals),
 			zap.Int("saveLength", len(saves)),
 			zap.Int("removeLength", len(removals)),

--- a/internal/kv/tikv/txn_tikv.go
+++ b/internal/kv/tikv/txn_tikv.go
@@ -317,7 +317,7 @@ func (kv *txnTiKV) Save(ctx context.Context, key, value string) error {
 	defer cancel()
 
 	var loggingErr error
-	defer logWarnOnFailure(&loggingErr, "txnTiKV Save() error", zap.String("key", key), zap.String("value", value))
+	defer logWarnOnFailure(&loggingErr, "txnTiKV Save() error", zap.String("key", key))
 
 	loggingErr = kv.putTiKVMeta(ctx, key, value)
 	return loggingErr
@@ -330,7 +330,7 @@ func (kv *txnTiKV) MultiSave(ctx context.Context, kvs map[string]string) error {
 	defer cancel()
 
 	var loggingErr error
-	defer logWarnOnFailure(&loggingErr, "txnTiKV MultiSave() error", zap.Any("kvs", kvs), zap.Int("len", len(kvs)))
+	defer logWarnOnFailure(&loggingErr, "txnTiKV MultiSave() error", zap.Strings("keys", lo.Keys(kvs)), zap.Int("len", len(kvs)))
 
 	txn, err := beginTxn(kv.txn)
 	if err != nil {
@@ -346,13 +346,13 @@ func (kv *txnTiKV) MultiSave(ctx context.Context, kvs map[string]string) error {
 		// Check if value is empty or taking reserved EmptyValue
 		byteValue, err := convertEmptyStringToByte(value)
 		if err != nil {
-			loggingErr = merr.Wrap(err, fmt.Sprintf("Failed to cast to byte (%s:%s) for MultiSave()", key, value))
+			loggingErr = merr.Wrap(err, fmt.Sprintf("Failed to cast value for key %s in MultiSave()", key))
 			return loggingErr
 		}
 		// Save the value within a transaction
 		err = txn.Set([]byte(key), byteValue)
 		if err != nil {
-			loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set (%s:%s) for MultiSave()", key, value), err.Error())
+			loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set value for key %s in MultiSave()", key), err.Error())
 			return loggingErr
 		}
 	}
@@ -361,7 +361,7 @@ func (kv *txnTiKV) MultiSave(ctx context.Context, kvs map[string]string) error {
 		loggingErr = merr.WrapErrIoFailedReason("Failed to commit for MultiSave()", err.Error())
 		return loggingErr
 	}
-	CheckElapseAndWarn(start, "Slow txnTiKV MultiSave() operation", zap.Any("kvs", kvs))
+	CheckElapseAndWarn(start, "Slow txnTiKV MultiSave() operation", zap.Strings("keys", lo.Keys(kvs)))
 	return nil
 }
 
@@ -442,7 +442,7 @@ func (kv *txnTiKV) MultiSaveAndRemove(ctx context.Context, saves map[string]stri
 	defer cancel()
 
 	var loggingErr error
-	defer logWarnOnFailure(&loggingErr, "txnTiKV MultiSaveAndRemove error", zap.Any("saves", saves), zap.Strings("removes", removals), zap.Int("saveLength", len(saves)), zap.Int("removeLength", len(removals)))
+	defer logWarnOnFailure(&loggingErr, "txnTiKV MultiSaveAndRemove error", zap.Strings("saveKeys", lo.Keys(saves)), zap.Strings("removes", removals), zap.Int("saveLength", len(saves)), zap.Int("removeLength", len(removals)))
 
 	txn, err := beginTxn(kv.txn)
 	if err != nil {
@@ -484,12 +484,12 @@ func (kv *txnTiKV) MultiSaveAndRemove(ctx context.Context, saves map[string]stri
 		// Check if value is empty or taking reserved EmptyValue
 		byteValue, err := convertEmptyStringToByte(value)
 		if err != nil {
-			loggingErr = merr.Wrap(err, fmt.Sprintf("Failed to cast to byte (%s:%s) for MultiSaveAndRemove", key, value))
+			loggingErr = merr.Wrap(err, fmt.Sprintf("Failed to cast value for key %s in MultiSaveAndRemove", key))
 			return loggingErr
 		}
 		err = txn.Set([]byte(key), byteValue)
 		if err != nil {
-			loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set (%s:%s) for MultiSaveAndRemove", key, value), err.Error())
+			loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set value for key %s in MultiSaveAndRemove", key), err.Error())
 			return loggingErr
 		}
 	}
@@ -499,7 +499,7 @@ func (kv *txnTiKV) MultiSaveAndRemove(ctx context.Context, saves map[string]stri
 		loggingErr = merr.WrapErrIoFailedReason("Failed to commit for MultiSaveAndRemove", err.Error())
 		return loggingErr
 	}
-	CheckElapseAndWarn(start, "Slow txnTiKV MultiSaveAndRemove() operation", zap.Any("saves", saves), zap.Strings("removals", removals))
+	CheckElapseAndWarn(start, "Slow txnTiKV MultiSaveAndRemove() operation", zap.Strings("saveKeys", lo.Keys(saves)), zap.Strings("removals", removals))
 	return nil
 }
 
@@ -510,7 +510,7 @@ func (kv *txnTiKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[s
 	defer cancel()
 
 	var loggingErr error
-	defer logWarnOnFailure(&loggingErr, "txnTiKV MultiSaveAndRemoveWithPrefix() error", zap.Any("saves", saves), zap.Strings("removes", removals), zap.Int("saveLength", len(saves)), zap.Int("removeLength", len(removals)))
+	defer logWarnOnFailure(&loggingErr, "txnTiKV MultiSaveAndRemoveWithPrefix() error", zap.Strings("saveKeys", lo.Keys(saves)), zap.Strings("removes", removals), zap.Int("saveLength", len(saves)), zap.Int("removeLength", len(removals)))
 
 	txn, err := beginTxn(kv.txn)
 	if err != nil {
@@ -572,12 +572,12 @@ func (kv *txnTiKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[s
 		// Check if value is empty or taking reserved EmptyValue
 		byteValue, err := convertEmptyStringToByte(value)
 		if err != nil {
-			loggingErr = merr.Wrap(err, fmt.Sprintf("Failed to cast to byte (%s:%s) for MultiSaveAndRemoveWithPrefix()", key, value))
+			loggingErr = merr.Wrap(err, fmt.Sprintf("Failed to cast value for key %s in MultiSaveAndRemoveWithPrefix()", key))
 			return loggingErr
 		}
 		err = txn.Set([]byte(key), byteValue)
 		if err != nil {
-			loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set (%s:%s) for MultiSaveAndRemoveWithPrefix()", key, value), err.Error())
+			loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set value for key %s in MultiSaveAndRemoveWithPrefix()", key), err.Error())
 			return loggingErr
 		}
 	}
@@ -587,7 +587,7 @@ func (kv *txnTiKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[s
 		loggingErr = merr.WrapErrIoFailedReason("Failed to commit for MultiSaveAndRemoveWithPrefix", err.Error())
 		return loggingErr
 	}
-	CheckElapseAndWarn(start, "Slow txnTiKV MultiSaveAndRemoveWithPrefix() operation", zap.Any("saves", saves), zap.Strings("removals", removals))
+	CheckElapseAndWarn(start, "Slow txnTiKV MultiSaveAndRemoveWithPrefix() operation", zap.Strings("saveKeys", lo.Keys(saves)), zap.Strings("removals", removals))
 	return nil
 }
 
@@ -700,7 +700,7 @@ func (kv *txnTiKV) putTiKVMeta(ctx context.Context, key, val string) error {
 	// Check if the value being written needs to be empty placeholder
 	byteValue, err := convertEmptyStringToByte(val)
 	if err != nil {
-		return merr.Wrap(err, fmt.Sprintf("Failed to cast to byte (%s:%s) for putTiKVMeta", key, val))
+		return merr.Wrap(err, fmt.Sprintf("Failed to cast value for key %s in putTiKVMeta", key))
 	}
 	err = txn.Set([]byte(key), byteValue)
 	if err != nil {

--- a/internal/proxy/hook_interceptor.go
+++ b/internal/proxy/hook_interceptor.go
@@ -47,7 +47,7 @@ func HookInterceptor(ctx context.Context, req any, userName, fullMethod string, 
 
 	if newCtx, err = hoo.Before(ctx, req, fullMethod); err != nil {
 		log.Warn("hook before error", zap.String("user", userName), zap.String("full method", fullMethod),
-			zap.Any("request", req), zap.Error(err))
+			GetRequestFieldWithoutSensitiveInfo(req), zap.Error(err))
 		metrics.ProxyHookFunc.WithLabelValues(metrics.HookBefore, fullMethod).Inc()
 		updateProxyFunctionCallMetric(fullMethod, err)
 		// NOTE: don't use the merr, because it will cause the wrong retry behavior in the sdk
@@ -56,7 +56,7 @@ func HookInterceptor(ctx context.Context, req any, userName, fullMethod string, 
 	realResp, realErr = handler(newCtx, req)
 	if err = hoo.After(newCtx, realResp, realErr, fullMethod); err != nil {
 		log.Warn("hook after error", zap.String("user", userName), zap.String("full method", fullMethod),
-			zap.Any("request", req), zap.Error(err))
+			GetRequestFieldWithoutSensitiveInfo(req), zap.Error(err))
 		metrics.ProxyHookFunc.WithLabelValues(metrics.HookAfter, fullMethod).Inc()
 		updateProxyFunctionCallMetric(fullMethod, err)
 		// NOTE: don't use the merr, because it will cause the wrong retry behavior in the sdk

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -5899,7 +5899,7 @@ func (node *Proxy) RestoreRBAC(ctx context.Context, req *milvuspb.RestoreRBACMet
 
 	log := log.Ctx(ctx)
 
-	log.Debug("RestoreRBAC", zap.Any("req", req))
+	log.Debug("RestoreRBAC", zap.Any("req", redactRestoreRBACRequestForLog(req)))
 	if err := merr.CheckHealthy(node.GetStateCode()); err != nil {
 		return merr.Status(err), nil
 	}

--- a/internal/proxy/trace_log_interceptor.go
+++ b/internal/proxy/trace_log_interceptor.go
@@ -24,6 +24,7 @@ import (
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/pkg/v2/log"
@@ -108,5 +109,22 @@ func GetRequestFieldWithoutSensitiveInfo(req interface{}) zap.Field {
 			ModifiedUtcTimestamps: updateCredentialReq.ModifiedUtcTimestamps,
 		})
 	}
+	restoreRBACReq, ok := req.(*milvuspb.RestoreRBACMetaRequest)
+	if ok {
+		return zap.Any("request", redactRestoreRBACRequestForLog(restoreRBACReq))
+	}
 	return zap.Any("request", req)
+}
+
+func redactRestoreRBACRequestForLog(req *milvuspb.RestoreRBACMetaRequest) *milvuspb.RestoreRBACMetaRequest {
+	if req == nil {
+		return nil
+	}
+	redacted := proto.Clone(req).(*milvuspb.RestoreRBACMetaRequest)
+	for _, user := range redacted.GetRBACMeta().GetUsers() {
+		if user != nil {
+			user.Password = sensitiveMark
+		}
+	}
+	return redacted
 }

--- a/internal/proxy/trace_log_interceptor_test.go
+++ b/internal/proxy/trace_log_interceptor_test.go
@@ -83,6 +83,22 @@ func TestTraceLogInterceptor(t *testing.T) {
 			NewPassword: "FOO123456",
 		})
 		assert.NotContains(t, strings.ToLower(fmt.Sprint(f2.Interface)), "password")
+
+		hashSentinel := "$2a$10$RESTORE_RBAC_HASH_SENTINEL"
+		restoreReq := &milvuspb.RestoreRBACMetaRequest{
+			RBACMeta: &milvuspb.RBACMeta{
+				Users: []*milvuspb.UserInfo{{
+					User:     "restore-user",
+					Password: hashSentinel,
+				}},
+			},
+		}
+		f3 := GetRequestFieldWithoutSensitiveInfo(restoreReq)
+		request := fmt.Sprint(f3.Interface)
+		assert.NotContains(t, request, hashSentinel)
+		assert.Contains(t, request, "restore-user")
+		assert.Contains(t, request, sensitiveMark)
+		assert.Equal(t, hashSentinel, restoreReq.GetRBACMeta().GetUsers()[0].GetPassword())
 	}
 
 	_ = paramtable.Get().Save(paramtable.Get().CommonCfg.TraceLogMode.Key, "3")

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1515,11 +1515,10 @@ func PasswordVerify(ctx context.Context, username, rawPwd string) bool {
 }
 
 func VerifyAPIKey(rawToken string) (string, error) {
-	hoo := hookutil.GetHook()
-	user, err := hoo.VerifyAPIKey(rawToken)
+	user, err := hookutil.GetHook().VerifyAPIKey(rawToken)
 	if err != nil {
-		log.Warn("fail to verify apikey", zap.String("api_key", rawToken), zap.Error(err))
-		return "", merr.WrapErrParameterInvalidMsg("invalid apikey: [%s]", rawToken)
+		log.Warn("fail to verify apikey with hook", zap.Error(err))
+		return "", merr.WrapErrParameterInvalidMsg("invalid API key")
 	}
 	return user, nil
 }
@@ -1548,7 +1547,7 @@ func passwordVerify(ctx context.Context, username, rawPwd string, privilegeCache
 
 	// update cache after miss cache
 	credInfo.Sha256Password = sha256Pwd
-	log.Ctx(ctx).Debug("get credential miss cache, update cache with", zap.Any("credential", credInfo))
+	log.Ctx(ctx).Debug("credential cache populated")
 	privilegeCache.UpdateCredential(credInfo)
 	return true
 }

--- a/tests/go_client/testcases/advcases/rbac_test.go
+++ b/tests/go_client/testcases/advcases/rbac_test.go
@@ -72,7 +72,6 @@ func TestRbacDefault(t *testing.T) {
 	userName := common.GenRandomString("user", 6)
 	pwd := common.GenRandomString("pwd", 6)
 	userDescription := "go client user description"
-	log.Info(t.Name(), zap.String("pwd", pwd))
 	err := mc.CreateUser(ctx, client.NewCreateUserOption(userName, pwd).WithDescription(userDescription))
 	common.CheckErr(t, err, true)
 	users, err := mc.ListUsers(ctx, client.NewListUserOption())
@@ -291,7 +290,6 @@ func TestUpdatePassword(t *testing.T) {
 	oldPwd := newPwd
 	passwords := []string{"中文", "シャオミン", "샤오밍", "ಸೂರ್ಯ", "myPwd@aa.com", "φεγγάρι", "mặt trăng"}
 	for i := 0; i < len(passwords); i++ {
-		log.Info(t.Name(), zap.String("pwd", passwords[i]))
 		err = mc.UpdatePassword(ctx, client.NewUpdatePasswordOption(userName, oldPwd, passwords[i]))
 		common.CheckErr(t, err, true)
 		oldPwd = passwords[i]


### PR DESCRIPTION
Backport #52039 to 2.6.

Prevent storage credentials, API keys, RBAC password hashes, etcd/TiKV values, and REST passwords from reaching logs or error messages.

Backport adaptations:

- Use the 2.6 zap logging and pkg/v2 APIs.
- Exclude external-collection and FieldSchema redaction paths whose APIs and helpers do not exist on 2.6.
- Preserve original storage and RBAC request objects by redacting cloned protobuf messages.

Verification:

- Focused proxy RBAC, REST password, and storage-config redaction tests passed with the required dynamic,test tags and disabled optimization/inlining.
- The internal/datanode/index, internal/kv/tikv, and proxy HTTP server focused suites passed.
- Broader proxy, DataNode, and etcd suites reached the unavailable local etcd dependency and were not used as pass evidence.

See also: #52038

pr: #52039
Signed-off-by: yangxuan <xuan.yang@zilliz.com>