### PR TITLE
enhance: [cp2.6]rewrite storage.MergeSort as a proper k-way merge

### DIFF
--- a/internal/datanode/compactor/merge_sort.go
+++ b/internal/datanode/compactor/merge_sort.go
@@ -120,6 +120,17 @@ func mergeSortMultipleSegments(ctx context.Context,
 	}
 
 	if _, err = storage.MergeSort(compactionParams.BinLogMaxSize, plan.GetSchema(), segmentReaders, writer, predicate, sortByFields); err != nil {
+		// segmentReaders[i] is built from binlogs[i], so the reader index the
+		// error names, when it names one, indexes into this list.
+		segmentIDs := make([]int64, len(binlogs))
+		for i, s := range binlogs {
+			segmentIDs[i] = s.GetSegmentID()
+		}
+		log.Warn("compact wrong, failed to merge sort segments",
+			zap.Int64("collectionID", collectionID),
+			zap.Int64s("segmentIDsByReaderIndex", segmentIDs),
+			zap.Int64s("sortByFields", sortByFields),
+			zap.Error(err))
 		if closeErr := writer.Close(); closeErr != nil {
 			log.Warn("failed to close writer after merge sort error", zap.Error(closeErr))
 		}

--- a/internal/datanode/compactor/mix_compactor.go
+++ b/internal/datanode/compactor/mix_compactor.go
@@ -361,29 +361,23 @@ func (t *mixCompactionTask) Compact() (*datapb.CompactionPlanResult, error) {
 		return nil, merr.WrapErrServiceInternalMsg("illegal compaction plan")
 	}
 
-	sortMergeAppicable := t.compactionParams.UseMergeSort
-	if sortMergeAppicable {
-		for _, segment := range t.plan.GetSegmentBinlogs() {
-			if !segment.GetIsSorted() {
-				sortMergeAppicable = false
-				break
-			}
-		}
-
-		if len(t.plan.GetSegmentBinlogs()) > t.compactionParams.MaxSegmentMergeSort {
-			// sort merge is not applicable if there is only one segment or too many segments
-			sortMergeAppicable = false
-		}
-	}
+	useMergeSort := canMergeSort(t.plan, t.compactionParams)
 
 	var res []*datapb.CompactionSegment
 	var err error
-	if sortMergeAppicable {
+	if useMergeSort {
 		log.Info("compact by merge sort")
 		res, err = mergeSortMultipleSegments(ctxTimeout, t.plan, t.collectionID, t.partitionID, t.maxRows, t.binlogIO,
 			t.plan.GetSegmentBinlogs(), t.tr, t.currentTime, t.plan.GetCollectionTtl(), t.compactionParams, t.sortByFieldIDs)
 		if err != nil {
-			log.Warn("compact wrong, fail to merge sort segments", zap.Error(err))
+			// Compactor-boundary catch-all: mergeSortMultipleSegments can fail
+			// before it ever reaches the merge sort step (reader/writer
+			// construction, deltalog composition, ...), and those paths don't
+			// log on their own, so this line is their only record.
+			log.Warn("compact wrong, merge sort compaction failed (compactor boundary)",
+				zap.Int64("planID", t.GetPlanID()),
+				zap.Int64("collectionID", t.collectionID),
+				zap.Error(err))
 			return nil, err
 		}
 	} else {
@@ -466,6 +460,27 @@ func (t *mixCompactionTask) createTextIndex(ctx context.Context,
 		manifest:      segment.GetManifest(),
 		insertBinlogs: segment.GetInsertLogs(),
 	})
+}
+
+// canMergeSort reports whether this plan is eligible for storage.MergeSort,
+// which merges without sorting and so requires every input to already be
+// ordered by the plan's merge key. A plan that is not eligible falls back to
+// mergeSplit, which does not assume ordering.
+func canMergeSort(plan *datapb.CompactionPlan, params compaction.Params) bool {
+	if !params.UseMergeSort {
+		return false
+	}
+	// The sorted flag records that the compactor which wrote the segment
+	// ordered it by this plan's merge key.
+	for _, segment := range plan.GetSegmentBinlogs() {
+		if !segment.GetIsSorted() {
+			return false
+		}
+	}
+	// Each reader holds a live record, so memory grows with the reader count. A
+	// single segment is allowed: merge sort keeps the output flagged sorted,
+	// whereas mergeSplit emits it unsorted and needs a follow-up sort compaction.
+	return len(plan.GetSegmentBinlogs()) <= params.MaxSegmentMergeSort
 }
 
 func (t *mixCompactionTask) Complete() {

--- a/internal/datanode/compactor/mix_compactor_test.go
+++ b/internal/datanode/compactor/mix_compactor_test.go
@@ -1275,3 +1275,64 @@ func BenchmarkMixCompactor(b *testing.B) {
 
 	s.TearDownTest()
 }
+
+func TestCanMergeSort(t *testing.T) {
+	params := compaction.Params{UseMergeSort: true, MaxSegmentMergeSort: 30}
+	// EnableNamespace is false here, so the merge key is [pk] and IsSorted is
+	// the flag canMergeSort requires. TestCanMergeSortMatchesMergeKey covers
+	// the namespace-enabled half.
+	namespaceDisabledSchema := &schemapb.CollectionSchema{}
+
+	t.Run("disabled by param", func(t *testing.T) {
+		plan := &datapb.CompactionPlan{
+			Schema:         namespaceDisabledSchema,
+			SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{{SegmentID: 1, IsSorted: true}},
+		}
+		assert.False(t, canMergeSort(plan, compaction.Params{UseMergeSort: false, MaxSegmentMergeSort: 30}))
+	})
+
+	t.Run("unsorted segment rejected", func(t *testing.T) {
+		plan := &datapb.CompactionPlan{
+			Schema:         namespaceDisabledSchema,
+			SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{{SegmentID: 1}},
+		}
+		assert.False(t, canMergeSort(plan, params))
+	})
+
+	t.Run("single sorted segment allowed", func(t *testing.T) {
+		plan := &datapb.CompactionPlan{
+			Schema:         namespaceDisabledSchema,
+			SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{{SegmentID: 1, IsSorted: true}},
+		}
+		assert.True(t, canMergeSort(plan, params))
+	})
+
+	t.Run("too many segments rejected", func(t *testing.T) {
+		segs := make([]*datapb.CompactionSegmentBinlogs, params.MaxSegmentMergeSort+1)
+		for i := range segs {
+			segs[i] = &datapb.CompactionSegmentBinlogs{SegmentID: int64(i), IsSorted: true}
+		}
+		plan := &datapb.CompactionPlan{Schema: namespaceDisabledSchema, SegmentBinlogs: segs}
+		assert.False(t, canMergeSort(plan, params))
+	})
+
+	t.Run("exactly max segments allowed", func(t *testing.T) {
+		segs := make([]*datapb.CompactionSegmentBinlogs, params.MaxSegmentMergeSort)
+		for i := range segs {
+			segs[i] = &datapb.CompactionSegmentBinlogs{SegmentID: int64(i), IsSorted: true}
+		}
+		plan := &datapb.CompactionPlan{Schema: namespaceDisabledSchema, SegmentBinlogs: segs}
+		assert.True(t, canMergeSort(plan, params))
+	})
+
+	t.Run("later unsorted segment rejected", func(t *testing.T) {
+		plan := &datapb.CompactionPlan{
+			Schema: namespaceDisabledSchema,
+			SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{
+				{SegmentID: 1, IsSorted: true},
+				{SegmentID: 2},
+			},
+		}
+		assert.False(t, canMergeSort(plan, params))
+	})
+}

--- a/internal/datanode/compactor/namespace_compactor_test.go
+++ b/internal/datanode/compactor/namespace_compactor_test.go
@@ -45,6 +45,10 @@ func (s *NamespaceCompactorTestSuite) SetupSuite() {
 	s.binlogIO = mock_util.NewMockBinlogIO(s.T())
 	s.binlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil)
 	s.schema = &schemapb.CollectionSchema{
+		// NamespaceCompactor is only constructed inside the namespaceEnabled
+		// branch of datanode/services.go, and the merge key below is
+		// [partitionKey, pk] accordingly.
+		EnableNamespace: true,
 		Fields: []*schemapb.FieldSchema{
 			{
 				FieldID:  common.RowIDField,
@@ -63,9 +67,10 @@ func (s *NamespaceCompactorTestSuite) SetupSuite() {
 				IsPrimaryKey: true,
 			},
 			{
-				FieldID:  101,
-				Name:     "namespace",
-				DataType: schemapb.DataType_Int64,
+				FieldID:        101,
+				Name:           "namespace",
+				DataType:       schemapb.DataType_Int64,
+				IsPartitionKey: true,
 			},
 		},
 	}

--- a/internal/storage/sort.go
+++ b/internal/storage/sort.go
@@ -17,7 +17,6 @@
 package storage
 
 import (
-	"container/heap"
 	"io"
 	"sort"
 	"time"
@@ -26,6 +25,12 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+)
+
+// sort key kinds shared by Sort and MergeSort.
+const (
+	keyInt64 = iota
+	keyString
 )
 
 // SortTimings holds phase-level timing information from the Sort function.
@@ -175,54 +180,83 @@ func Sort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordReader
 	return len(indices), timings, nil
 }
 
-// A PriorityQueue implements heap.Interface and holds Items.
-type PriorityQueue[T any] struct {
-	items []*T
-	less  func(x, y *T) bool
+// rowIndex addresses a single row as (record index, row-in-record index). It is
+// stored by value to avoid a per-row heap allocation.
+type rowIndex struct {
+	ri int32
+	i  int32
 }
 
-var _ heap.Interface = (*PriorityQueue[any])(nil)
-
-func (pq PriorityQueue[T]) Len() int { return len(pq.items) }
-
-func (pq PriorityQueue[T]) Less(i, j int) bool {
-	return pq.less(pq.items[i], pq.items[j])
+// rowHeap is a min-heap of rowIndex values. It exists instead of container/heap
+// because heap.Push takes `any`, which boxes the value and costs one allocation
+// per push; MergeSort pushes once per row.
+type rowHeap struct {
+	items []rowIndex
+	less  func(x, y rowIndex) bool
 }
 
-func (pq PriorityQueue[T]) Swap(i, j int) {
-	pq.items[i], pq.items[j] = pq.items[j], pq.items[i]
-}
+func (h *rowHeap) len() int { return len(h.items) }
 
-func (pq *PriorityQueue[T]) Push(x any) {
-	pq.items = append(pq.items, x.(*T))
-}
-
-func (pq *PriorityQueue[T]) Pop() any {
-	old := pq.items
-	n := len(old)
-	x := old[n-1]
-	old[n-1] = nil
-	pq.items = old[0 : n-1]
-	return x
-}
-
-func (pq *PriorityQueue[T]) Enqueue(x *T) {
-	heap.Push(pq, x)
-}
-
-func (pq *PriorityQueue[T]) Dequeue() *T {
-	return heap.Pop(pq).(*T)
-}
-
-func NewPriorityQueue[T any](less func(x, y *T) bool) *PriorityQueue[T] {
-	pq := PriorityQueue[T]{
-		items: make([]*T, 0),
-		less:  less,
+func (h *rowHeap) push(v rowIndex) {
+	h.items = append(h.items, v)
+	i := len(h.items) - 1
+	for i > 0 {
+		p := (i - 1) / 2
+		if !h.less(h.items[i], h.items[p]) {
+			break
+		}
+		h.items[i], h.items[p] = h.items[p], h.items[i]
+		i = p
 	}
-	heap.Init(&pq)
-	return &pq
 }
 
+func (h *rowHeap) pop() rowIndex {
+	top := h.items[0]
+	n := len(h.items) - 1
+	h.items[0] = h.items[n]
+	h.items = h.items[:n]
+	i := 0
+	for {
+		l, r := 2*i+1, 2*i+2
+		m := i
+		if l < n && h.less(h.items[l], h.items[m]) {
+			m = l
+		}
+		if r < n && h.less(h.items[r], h.items[m]) {
+			m = r
+		}
+		if m == i {
+			break
+		}
+		h.items[i], h.items[m] = h.items[m], h.items[i]
+		i = m
+	}
+	return top
+}
+
+// sortKeyCol is a merge key column of the record a reader currently holds.
+// int64 keys reference the arrow buffer directly; varchar keys keep the array
+// pointer so Value(i) stays available without a per-comparison map lookup and
+// type assert. Both are rebuilt when the reader advances to the next record.
+type sortKeyCol struct {
+	kind int
+	i64  []int64
+	str  *array.String
+}
+
+// MergeSort merges rows from rr, which each yield records already sorted by
+// sortedByFieldIDs, into a single sorted stream written through rw in batches
+// of roughly batchSize bytes. Rows for which predicate returns false are
+// skipped; predicate is evaluated exactly once per row.
+//
+// Performance notes (vs. the earlier all-rows-in-the-queue approach):
+//   - The heap holds one entry per reader rather than every in-flight row, so
+//     comparisons per row drop from O(log totalRows) to O(log len(rr)) and the
+//     heap stays small enough to be cache resident.
+//   - Merge keys are resolved once per record in advanceRecord instead of once
+//     per comparison, avoiding a Column() map lookup plus type assert per side.
+//   - The heap stores rowIndex by value, removing the per-row heap allocation
+//     that came from queueing *index through container/heap.
 func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordReader,
 	rw RecordWriter, predicate func(r Record, ri, i int) bool, sortedByFieldIDs []int64,
 ) (numRows int, err error) {
@@ -231,112 +265,133 @@ func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordR
 		return 0, nil
 	}
 
-	type index struct {
-		ri int
-		i  int
-	}
-
+	nk := len(sortedByFieldIDs)
 	recs := make([]Record, len(rr))
-	advanceRecord := func(i int) error {
-		rec, err := rr[i].Next()
-		recs[i] = rec // assign nil if err
-		return err
+	// keys[ri][fp] is the fp-th merge key column of the record reader ri holds.
+	// Allocated once and overwritten in place on every advance; recs[ri] == nil
+	// is the sole exhausted-reader sentinel. keys[ri] stays valid until
+	// seedNext(ri) advances that reader again -- not merely while ri has a heap
+	// entry: the main loop reads keys[ri] in compareWithLast and saveLast after
+	// popping ri's only entry. Moving either of those after seedNext would be a
+	// use-after-advance.
+	keys := make([][]sortKeyCol, len(rr))
+	for i := range keys {
+		keys[i] = make([]sortKeyCol, nk)
+	}
+	// pos[ri] is the next row of that record to consider.
+	pos := make([]int32, len(rr))
+	// recNo[ri] counts the records that reader has produced. It turns an
+	// out-of-order row into a (record, row) coordinate, since pos -- and so
+	// idx.i -- restarts at zero on every record.
+	recNo := make([]int32, len(rr))
+	for i := range recNo {
+		recNo[i] = -1
 	}
 
-	for i := range rr {
-		err := advanceRecord(i)
-		if err == io.EOF {
-			continue
-		}
-		if err != nil {
-			return 0, err
-		}
-	}
-
-	comparators := make([]func(x, y *index) int, 0, len(sortedByFieldIDs))
-	for _, fid := range sortedByFieldIDs {
-		switch recs[0].Column(fid).(type) {
-		case *array.Int64:
-			comparators = append(comparators, func(x, y *index) int {
-				xVal := recs[x.ri].Column(fid).(*array.Int64).Value(x.i)
-				yVal := recs[y.ri].Column(fid).(*array.Int64).Value(y.i)
-				if xVal < yVal {
-					return -1
-				}
-				if xVal > yVal {
-					return 1
-				}
-				return 0
-			})
-		case *array.String:
-			comparators = append(comparators, func(x, y *index) int {
-				xVal := recs[x.ri].Column(fid).(*array.String).Value(x.i)
-				yVal := recs[y.ri].Column(fid).(*array.String).Value(y.i)
-				if xVal < yVal {
-					return -1
-				}
-				if xVal > yVal {
-					return 1
-				}
-				return 0
-			})
-		default:
-			return 0, merr.WrapErrStorageMsg("unsupported type for sorting key")
-		}
-	}
-
-	pq := NewPriorityQueue(func(x, y *index) bool {
-		for _, cmp := range comparators {
-			c := cmp(x, y)
-			if c < 0 {
-				return true
-			}
-			if c > 0 {
-				return false
+	extractKeys := func(ri int) error {
+		cols := keys[ri]
+		for fp, fid := range sortedByFieldIDs {
+			switch a := recs[ri].Column(fid).(type) {
+			case *array.Int64:
+				cols[fp] = sortKeyCol{kind: keyInt64, i64: a.Int64Values()}
+			case *array.String:
+				cols[fp] = sortKeyCol{kind: keyString, str: a}
+			default:
+				return merr.WrapErrStorageMsg("unsupported type for sorting key")
 			}
 		}
-		if x.ri != y.ri {
-			return x.ri < y.ri
-		}
-		return x.i < y.i
-	})
-
-	endPositions := make([]int, len(recs))
-	var enqueueAll func(ri int) error
-	enqueueAll = func(ri int) error {
-		r := recs[ri]
-		hasValid := false
-		endPosition := 0
-		for j := 0; j < r.Len(); j++ {
-			if predicate(r, ri, j) {
-				pq.Enqueue(&index{
-					ri: ri,
-					i:  j,
-				})
-				numRows++
-				hasValid = true
-				endPosition = j
-			}
-		}
-		if !hasValid {
-			err := advanceRecord(ri)
-			if err == io.EOF {
-				return nil
-			}
-			if err != nil {
-				return err
-			}
-			return enqueueAll(ri)
-		}
-		endPositions[ri] = endPosition
 		return nil
 	}
 
-	for i, v := range recs {
-		if v != nil {
-			if err := enqueueAll(i); err != nil {
-				return 0, err
+	advanceRecord := func(ri int) error {
+		rec, err := rr[ri].Next()
+		recs[ri] = rec // assign nil if err
+		if err != nil {
+			return err
+		}
+		pos[ri] = 0
+		recNo[ri]++
+		return extractKeys(ri)
+	}
+
+	// compareKeys orders two rows that are both currently live in the heap.
+	// sortKeyCol is 40 bytes, so take it by pointer: this runs on both sides of
+	// every comparison.
+	compareKeys := func(x, y rowIndex) int {
+		for fp := 0; fp < nk; fp++ {
+			cx, cy := &keys[x.ri][fp], &keys[y.ri][fp]
+			switch cx.kind {
+			case keyInt64:
+				xv, yv := cx.i64[x.i], cy.i64[y.i]
+				if xv != yv {
+					if xv < yv {
+						return -1
+					}
+					return 1
+				}
+			case keyString:
+				xv, yv := cx.str.Value(int(x.i)), cy.str.Value(int(y.i))
+				if xv != yv {
+					if xv < yv {
+						return -1
+					}
+					return 1
+				}
 			}
+		}
+		return 0
+	}
+
+	h := &rowHeap{
+		items: make([]rowIndex, 0, len(rr)),
+		less: func(x, y rowIndex) bool {
+			if c := compareKeys(x, y); c != 0 {
+				return c < 0
+			}
+			// Equal keys break by reader index alone: a reader holds at most one
+			// heap entry, since seedNext pushes a single row and is called again
+			// only after that entry is popped. So x.ri != y.ri always holds here,
+			// and there is no second row of the same reader to order against.
+			// Stability is unaffected -- a reader's equal-key rows are re-seeded
+			// in increasing pos, so they still leave the heap in input order.
+			return x.ri < y.ri
+		},
+	}
+
+	// seedNext pushes reader ri's next qualifying row, advancing across records
+	// as needed. Every (record, row) position is evaluated by predicate exactly
+	// once: pos only moves forward within a record, and is reset only when
+	// advanceRecord installs a new one.
+	seedNext := func(ri int) error {
+		for recs[ri] != nil {
+			r := recs[ri]
+			for int(pos[ri]) < r.Len() {
+				i := pos[ri]
+				if predicate(r, ri, int(i)) {
+					h.push(rowIndex{ri: int32(ri), i: i})
+					return nil
+				}
+				pos[ri]++
+			}
+			if err := advanceRecord(ri); err != nil {
+				if err == io.EOF {
+					return nil
+				}
+				return err
+			}
+		}
+		return nil
+	}
+
+	for i := range rr {
+		if err := advanceRecord(i); err != nil {
+			if err == io.EOF {
+				continue
+			}
+			return 0, err
+		}
+		if err := seedNext(i); err != nil {
+			return 0, err
 		}
 	}
 
@@ -350,9 +405,72 @@ func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordR
 		return nil
 	}
 
-	for pq.Len() > 0 {
-		idx := pq.Dequeue()
-		rb.Append(recs[idx.ri], idx.i, idx.i+1)
+	// The emitted key must never decrease. It can only do so when an input
+	// record is not sorted by the merge key, which this merge relies on. Detect
+	// that explicitly instead of silently emitting rows out of order. The
+	// previous key is kept by value because seedNext may already have advanced
+	// the record it came from, and records are only borrowed from the reader.
+	lastI64 := make([]int64, nk)
+	// varchar keys are copied into reusable buffers rather than cloned per row:
+	// the arrow buffer is only borrowed until the reader advances, but a fresh
+	// string per row would reintroduce exactly the per-row allocation this
+	// rewrite removes. Comparing via string(buf) does not allocate.
+	lastStrBuf := make([][]byte, nk)
+	hasLast := false
+
+	compareWithLast := func(x rowIndex) int {
+		for fp := 0; fp < nk; fp++ {
+			cx := &keys[x.ri][fp]
+			switch cx.kind {
+			case keyInt64:
+				xv := cx.i64[x.i]
+				if xv != lastI64[fp] {
+					if xv < lastI64[fp] {
+						return -1
+					}
+					return 1
+				}
+			case keyString:
+				xv := cx.str.Value(int(x.i))
+				if xv != string(lastStrBuf[fp]) {
+					if xv < string(lastStrBuf[fp]) {
+						return -1
+					}
+					return 1
+				}
+			}
+		}
+		return 0
+	}
+
+	saveLast := func(x rowIndex) {
+		for fp := 0; fp < nk; fp++ {
+			cx := &keys[x.ri][fp]
+			switch cx.kind {
+			case keyInt64:
+				lastI64[fp] = cx.i64[x.i]
+			case keyString:
+				lastStrBuf[fp] = append(lastStrBuf[fp][:0], cx.str.Value(int(x.i))...)
+			}
+		}
+		hasLast = true
+	}
+
+	for h.len() > 0 {
+		idx := h.pop()
+
+		if hasLast && compareWithLast(idx) < 0 {
+			return 0, merr.WrapErrDataIntegrityMsg(
+				"input record is not sorted by the merge key: reader %d record %d row %d out of order, merge key fields %v",
+				idx.ri, recNo[idx.ri], idx.i, sortedByFieldIDs)
+		}
+		saveLast(idx)
+
+		if err := rb.Append(recs[idx.ri], int(idx.i), int(idx.i)+1); err != nil {
+			return 0, err
+		}
+		numRows++
+
 		// Due to current arrow impl (v12), the write performance is largely dependent on the batch size,
 		//	small batch size will cause write performance degradation. To work around this issue, we accumulate
 		//	records and write them in batches. This requires additional memory copy.
@@ -362,18 +480,9 @@ func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordR
 			}
 		}
 
-		// If the popped idx reaches the last valid data of the segment, invalidate the cache and advance to the next record
-		if idx.i == endPositions[idx.ri] {
-			err := advanceRecord(idx.ri)
-			if err == io.EOF {
-				continue
-			}
-			if err != nil {
-				return 0, err
-			}
-			if err := enqueueAll(idx.ri); err != nil {
-				return 0, err
-			}
+		pos[idx.ri]++
+		if err := seedNext(int(idx.ri)); err != nil {
+			return 0, err
 		}
 	}
 

--- a/internal/storage/sort_test.go
+++ b/internal/storage/sort_test.go
@@ -18,14 +18,77 @@ package storage
 
 import (
 	"fmt"
+	"io"
+	"slices"
+	"strconv"
 	"testing"
 
+	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 )
+
+// mergeSortTestRec builds a record with one column per given field. int64Cols
+// and strCols are keyed by FieldID; all columns must have the same length.
+func mergeSortTestRec(t *testing.T, int64Cols map[FieldID][]int64, strCols map[FieldID][]string) Record {
+	t.Helper()
+	fids := make([]FieldID, 0, len(int64Cols)+len(strCols))
+	for fid := range int64Cols {
+		fids = append(fids, fid)
+	}
+	for fid := range strCols {
+		fids = append(fids, fid)
+	}
+	slices.Sort(fids)
+
+	fields := make([]arrow.Field, 0, len(fids))
+	arrs := make([]arrow.Array, 0, len(fids))
+	f2c := make(map[FieldID]int, len(fids))
+	n := 0
+	for _, fid := range fids {
+		if vals, ok := int64Cols[fid]; ok {
+			b := array.NewInt64Builder(memory.DefaultAllocator)
+			b.AppendValues(vals, nil)
+			arrs = append(arrs, b.NewArray())
+			b.Release()
+			fields = append(fields, arrow.Field{Name: strconv.FormatInt(fid, 10), Type: arrow.PrimitiveTypes.Int64})
+			n = len(vals)
+		} else {
+			vals := strCols[fid]
+			b := array.NewStringBuilder(memory.DefaultAllocator)
+			b.AppendValues(vals, nil)
+			arrs = append(arrs, b.NewArray())
+			b.Release()
+			fields = append(fields, arrow.Field{Name: strconv.FormatInt(fid, 10), Type: arrow.BinaryTypes.String})
+			n = len(vals)
+		}
+		f2c[fid] = len(arrs) - 1
+	}
+	return NewSimpleArrowRecord(array.NewRecord(arrow.NewSchema(fields, nil), arrs, int64(n)), f2c)
+}
+
+// sliceRecordReader yields the given records in order.
+type sliceRecordReader struct {
+	recs []Record
+	pos  int
+}
+
+func (r *sliceRecordReader) Next() (Record, error) {
+	if r.pos >= len(r.recs) {
+		return nil, io.EOF
+	}
+	rec := r.recs[r.pos]
+	r.pos++
+	return rec, nil
+}
+
+func (r *sliceRecordReader) Close() error { return nil }
 
 func TestSort(t *testing.T) {
 	const batchSize = 64 * 1024 * 1024
@@ -160,9 +223,15 @@ func TestMergeSort(t *testing.T) {
 	lastPK := int64(-1)
 	rw := &MockRecordWriter{
 		writefn: func(r Record) error {
-			pk := r.Column(common.RowIDField).(*array.Int64).Value(0)
-			assert.Greater(t, pk, lastPK)
-			lastPK = pk
+			// check every row, not just the first of each batch. The two
+			// readers overlap on pk, so the merged order is non-decreasing
+			// rather than strictly increasing.
+			col := r.Column(common.RowIDField).(*array.Int64)
+			for i := 0; i < col.Len(); i++ {
+				pk := col.Value(i)
+				assert.GreaterOrEqual(t, pk, lastPK)
+				lastPK = pk
+			}
 			return nil
 		},
 
@@ -172,7 +241,8 @@ func TestMergeSort(t *testing.T) {
 		},
 	}
 
-	const batchSize = 64 * 1024 * 1024
+	// small enough to force multiple output batches
+	const batchSize = 4096
 
 	t.Run("merge sort", func(t *testing.T) {
 		gotNumRows, err := MergeSort(batchSize, generateTestSchema(), getReaders(), rw, func(r Record, ri, i int) bool {
@@ -231,6 +301,93 @@ func BenchmarkSort(b *testing.B) {
 	})
 }
 
+// Benchmark merge sort
+func BenchmarkMergeSort(b *testing.B) {
+	batch := 100000
+	const batchSize = 64 * 1024 * 1024
+
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error { return nil },
+		closefn: func() error { return nil },
+	}
+
+	// Generate the payload once: it dwarfs the merge itself, and ReportAllocs
+	// counts allocations made inside StopTimer too.
+	blobs10, err := generateTestDataWithSeed(batch, batch)
+	assert.NoError(b, err)
+	blobs20, err := generateTestDataWithSeed(batch*2+1, batch)
+	assert.NoError(b, err)
+	schema := generateTestSchema()
+
+	b.Run("merge_sort", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			// readers are single-use, so only they are rebuilt per iteration
+			reader10 := newIterativeCompositeBinlogRecordReader(schema, nil, MakeBlobsReader(blobs10))
+			reader20 := newIterativeCompositeBinlogRecordReader(schema, nil, MakeBlobsReader(blobs20))
+
+			_, err := MergeSort(batchSize, schema, []RecordReader{reader20, reader10}, rw,
+				func(r Record, ri, i int) bool { return true }, []int64{common.RowIDField})
+			assert.NoError(b, err)
+		}
+	})
+}
+
+// Benchmark merge sort on a varchar key, which takes the string comparison path
+// and the reusable key buffer in the ordering check.
+func BenchmarkMergeSortVarcharKey(b *testing.B) {
+	const strField = FieldID(16)
+	const rowsPerRec = 4096
+	const recsPerReader = 8
+	const batchSize = 64 * 1024 * 1024
+
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: strField, Name: "vc", DataType: schemapb.DataType_VarChar, IsPrimaryKey: true},
+	}}
+
+	// two interleaved ascending key spaces, 32-byte keys
+	build := func(t *testing.B, offset int) []Record {
+		recs := make([]Record, recsPerReader)
+		k := offset
+		for j := range recs {
+			vals := make([]string, rowsPerRec)
+			for i := range vals {
+				vals[i] = fmt.Sprintf("%024d%08d", k, k)
+				k += 2
+			}
+			bld := array.NewStringBuilder(memory.DefaultAllocator)
+			bld.AppendValues(vals, nil)
+			arr := bld.NewArray()
+			bld.Release()
+			recs[j] = NewSimpleArrowRecord(
+				array.NewRecord(arrow.NewSchema([]arrow.Field{{Name: "16", Type: arrow.BinaryTypes.String}}, nil),
+					[]arrow.Array{arr}, int64(rowsPerRec)),
+				map[FieldID]int{strField: 0})
+		}
+		return recs
+	}
+
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error { return nil },
+		closefn: func() error { return nil },
+	}
+
+	// records are read-only here, so build them once and only rewrap per iteration
+	recs0, recs1 := build(b, 0), build(b, 1)
+
+	b.Run("merge_sort_varchar", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			r0 := &sliceRecordReader{recs: recs0}
+			r1 := &sliceRecordReader{recs: recs1}
+
+			_, err := MergeSort(batchSize, schema, []RecordReader{r0, r1}, rw,
+				func(r Record, ri, i int) bool { return true }, []int64{strField})
+			assert.NoError(b, err)
+		}
+	})
+}
+
 func TestSortByMoreThanOneField(t *testing.T) {
 	const batchSize = 10000
 	sortByFieldIDs := []int64{common.RowIDField, common.TimeStampField}
@@ -265,4 +422,235 @@ func TestSortByMoreThanOneField(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, batchSize*2, gotNumRows)
 	assert.NoError(t, rw.Close())
+}
+
+func TestMergeSortVarcharKey(t *testing.T) {
+	const strField = FieldID(16)
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: strField, Name: "vc", DataType: schemapb.DataType_VarChar, IsPrimaryKey: true},
+	}}
+
+	r0 := &sliceRecordReader{recs: []Record{
+		mergeSortTestRec(t, nil, map[FieldID][]string{strField: {"a", "c", "e"}}),
+		mergeSortTestRec(t, nil, map[FieldID][]string{strField: {"g", "i"}}),
+	}}
+	r1 := &sliceRecordReader{recs: []Record{
+		mergeSortTestRec(t, nil, map[FieldID][]string{strField: {"b", "d", "f", "h"}}),
+	}}
+
+	var got []string
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error {
+			col := r.Column(strField).(*array.String)
+			for i := 0; i < col.Len(); i++ {
+				got = append(got, col.Value(i))
+			}
+			return nil
+		},
+		closefn: func() error { return nil },
+	}
+
+	n, err := MergeSort(16, schema, []RecordReader{r0, r1}, rw, func(r Record, ri, i int) bool {
+		return true
+	}, []int64{strField})
+	assert.NoError(t, err)
+	assert.Equal(t, 9, n)
+	assert.NoError(t, rw.Close())
+	assert.Equal(t, []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"}, got)
+}
+
+func TestMergeSortByMoreThanOneField(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: common.RowIDField, Name: "rowid", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+		{FieldID: common.TimeStampField, Name: "ts", DataType: schemapb.DataType_Int64},
+	}}
+
+	// each record is ascending by (rowid, ts)
+	r0 := &sliceRecordReader{recs: []Record{
+		mergeSortTestRec(t, map[FieldID][]int64{
+			common.RowIDField:     {1, 1, 3},
+			common.TimeStampField: {10, 20, 10},
+		}, nil),
+	}}
+	r1 := &sliceRecordReader{recs: []Record{
+		mergeSortTestRec(t, map[FieldID][]int64{
+			common.RowIDField:     {1, 2, 3},
+			common.TimeStampField: {15, 5, 5},
+		}, nil),
+	}}
+
+	type pair struct{ pk, ts int64 }
+	var got []pair
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error {
+			pk := r.Column(common.RowIDField).(*array.Int64)
+			ts := r.Column(common.TimeStampField).(*array.Int64)
+			for i := 0; i < pk.Len(); i++ {
+				got = append(got, pair{pk.Value(i), ts.Value(i)})
+			}
+			return nil
+		},
+		closefn: func() error { return nil },
+	}
+
+	n, err := MergeSort(16, schema, []RecordReader{r0, r1}, rw, func(r Record, ri, i int) bool {
+		return true
+	}, []int64{common.RowIDField, common.TimeStampField})
+	assert.NoError(t, err)
+	assert.Equal(t, 6, n)
+	assert.NoError(t, rw.Close())
+	assert.Equal(t, []pair{{1, 10}, {1, 15}, {1, 20}, {2, 5}, {3, 5}, {3, 10}}, got)
+}
+
+// The predicate carries a side effect in production (segmentTotalRows[ri]++ in
+// merge_sort.go), so every row must be evaluated exactly once.
+func TestMergeSortPredicateCalledOncePerRow(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: common.RowIDField, Name: "rowid", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+	}}
+
+	r0 := &sliceRecordReader{recs: []Record{
+		mergeSortTestRec(t, map[FieldID][]int64{common.RowIDField: {1, 3, 5}}, nil),
+		mergeSortTestRec(t, map[FieldID][]int64{common.RowIDField: {7, 9}}, nil),
+	}}
+	r1 := &sliceRecordReader{recs: []Record{
+		mergeSortTestRec(t, map[FieldID][]int64{common.RowIDField: {2, 4, 6, 8}}, nil),
+	}}
+
+	// pk is unique across all records here, so it identifies a row globally.
+	counts := map[int64]int{}
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error { return nil },
+		closefn: func() error { return nil },
+	}
+
+	_, err := MergeSort(16, schema, []RecordReader{r0, r1}, rw, func(r Record, ri, i int) bool {
+		pk := r.Column(common.RowIDField).(*array.Int64).Value(i)
+		counts[pk]++
+		return pk%3 != 0 // also exercise skipping filtered rows
+	}, []int64{common.RowIDField})
+	assert.NoError(t, err)
+	assert.NoError(t, rw.Close())
+
+	assert.Equal(t, 9, len(counts), "every row must be visited exactly once")
+	for pk, n := range counts {
+		assert.Equalf(t, 1, n, "predicate called %d times for pk %d", n, pk)
+	}
+}
+
+func TestRowHeap(t *testing.T) {
+	h := &rowHeap{less: func(x, y rowIndex) bool {
+		if x.ri != y.ri {
+			return x.ri < y.ri
+		}
+		return x.i < y.i
+	}}
+	assert.Equal(t, 0, h.len())
+
+	in := []rowIndex{{3, 1}, {1, 2}, {2, 0}, {1, 0}, {3, 0}, {2, 1}}
+	for _, v := range in {
+		h.push(v)
+	}
+	assert.Equal(t, len(in), h.len())
+
+	var got []rowIndex
+	for h.len() > 0 {
+		got = append(got, h.pop())
+	}
+	assert.Equal(t, []rowIndex{{1, 0}, {1, 2}, {2, 0}, {2, 1}, {3, 0}, {3, 1}}, got)
+}
+
+func TestRowHeapSingleElement(t *testing.T) {
+	h := &rowHeap{less: func(x, y rowIndex) bool { return x.i < y.i }}
+	h.push(rowIndex{0, 7})
+	assert.Equal(t, 1, h.len())
+	assert.Equal(t, rowIndex{0, 7}, h.pop())
+	assert.Equal(t, 0, h.len())
+}
+
+// A k-way merge relies on each input record being sorted by the merge key.
+// When that does not hold, fail explicitly rather than emitting rows out of
+// order. This is the shape reported in #48322: the last row of a record carries
+// the smallest key, and the next record is shorter.
+func TestMergeSortUnsortedInputReturnsError(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: common.RowIDField, Name: "rowid", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+	}}
+
+	r0 := &sliceRecordReader{recs: []Record{
+		mergeSortTestRec(t, map[FieldID][]int64{common.RowIDField: {50, 60, 1}}, nil),
+		mergeSortTestRec(t, map[FieldID][]int64{common.RowIDField: {70}}, nil),
+	}}
+
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error { return nil },
+		closefn: func() error { return nil },
+	}
+
+	_, err := MergeSort(1024, schema, []RecordReader{r0}, rw, func(r Record, ri, i int) bool {
+		return true
+	}, []int64{common.RowIDField})
+	assert.ErrorContains(t, err, "not sorted by the merge key")
+	assert.ErrorIs(t, err, merr.ErrDataIntegrity)
+	assert.ErrorContains(t, err, "reader 0 record 0 row 2 out of order")
+}
+
+// The disorder in TestMergeSortUnsortedInputReturnsError falls in the reader's
+// first record, so a reported record number of 0 does not prove that number
+// was actually computed rather than hardcoded. This variant keeps the first
+// record in order and puts the offending row in the second record, so the
+// reported record number must be non-zero to be correct.
+func TestMergeSortUnsortedInputReportsLaterRecord(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: common.RowIDField, Name: "rowid", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+	}}
+
+	r0 := &sliceRecordReader{recs: []Record{
+		mergeSortTestRec(t, map[FieldID][]int64{common.RowIDField: {10, 20, 30}}, nil),
+		mergeSortTestRec(t, map[FieldID][]int64{common.RowIDField: {5, 40}}, nil),
+	}}
+
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error { return nil },
+		closefn: func() error { return nil },
+	}
+
+	_, err := MergeSort(1024, schema, []RecordReader{r0}, rw, func(r Record, ri, i int) bool {
+		return true
+	}, []int64{common.RowIDField})
+	assert.ErrorContains(t, err, "not sorted by the merge key")
+	assert.ErrorIs(t, err, merr.ErrDataIntegrity)
+	assert.ErrorContains(t, err, "reader 0 record 1 row 0 out of order")
+}
+
+// Both preceding tests drive a single reader, so idx.ri is always 0 in the
+// error -- a hardcoded 0 in place of idx.ri would pass them too. This variant
+// uses two readers, keeps reader 0 in order throughout, and puts the disorder
+// in reader 1's second record, so the reported reader index and per-reader
+// record number are both load-bearing.
+func TestMergeSortUnsortedInputReportsOffendingReader(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: common.RowIDField, Name: "rowid", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+	}}
+
+	r0 := &sliceRecordReader{recs: []Record{
+		mergeSortTestRec(t, map[FieldID][]int64{common.RowIDField: {10, 20, 30}}, nil),
+		mergeSortTestRec(t, map[FieldID][]int64{common.RowIDField: {40}}, nil),
+	}}
+	r1 := &sliceRecordReader{recs: []Record{
+		mergeSortTestRec(t, map[FieldID][]int64{common.RowIDField: {15, 25}}, nil),
+		mergeSortTestRec(t, map[FieldID][]int64{common.RowIDField: {35, 5}}, nil),
+	}}
+
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error { return nil },
+		closefn: func() error { return nil },
+	}
+
+	_, err := MergeSort(1024, schema, []RecordReader{r0, r1}, rw, func(r Record, ri, i int) bool {
+		return true
+	}, []int64{common.RowIDField})
+	assert.ErrorContains(t, err, "not sorted by the merge key")
+	assert.ErrorIs(t, err, merr.ErrDataIntegrity)
+	assert.ErrorContains(t, err, "reader 1 record 1 row 1 out of order")
 }


### PR DESCRIPTION
Cherry-pick from master

pr: #51998
issue: #51981

## Summary

Cherry-picked from master PR #51998 (merged): `storage.MergeSort` is rewritten as a proper k-way merge — the heap holds one entry per reader instead of every in-flight row, merge keys are resolved once per record instead of per comparison, and the per-row `pq.Enqueue(&index{...})` allocation is gone.

## Backport adaptations (2.6)

**1. Carries one type definition from #50817, which was never backported.**

`internal/storage/sort.go` gains these 7 lines:

```go
// rowIndex addresses a single row as (record index, row-in-record index). It is
// stored by value to avoid a per-row heap allocation.
type rowIndex struct {
	ri int32
	i  int32
}
```

`rowIndex` was introduced by #50817; the `rowHeap` that #51998 adds is typed over it (`items []rowIndex`, `push(v rowIndex)`, `pop() rowIndex`), so it cannot compile without this declaration. **Nothing else from #50817 is included** — its three `storage.Sort` optimizations (value slice instead of `[]*index`, pre-extracted sort keys, radix sort for a single int64 key) are NOT in this PR, and `Sort` is left exactly as it is on this branch. This PR is deliberately not tagged `pr: #50817`, because #50817 remains un-backported and should stay visible as such.

**2. `canMergeSort` drops the namespace branch.** 2.6 has no `GetIsSortedByNamespace`, so the master form

```go
namespaceEnabled := plan.GetSchema().GetEnableNamespace()
sortedByMergeKey := segment.GetIsSorted()
if namespaceEnabled { sortedByMergeKey = segment.GetIsSortedByNamespace() }
```

reduces to checking `GetIsSorted()` only. This is condition-for-condition equivalent to the inline `sortMergeAppicable` logic it replaces on this branch: same `UseMergeSort` gate, same per-segment sorted check, same `<= MaxSegmentMergeSort` bound.

**3. `TestCanMergeSortMatchesMergeKey` is dropped** — it exists solely to pin which sorted flag applies when namespace is enabled, which has no meaning on 2.6. `TestCanMergeSort` is kept and covers the rest.

**4. Logging uses this branch's `log` + `zap`** instead of master's `mlog` (not present on 2.6), in `mix_compactor.go` and `merge_sort.go`.

**5. `storage.PriorityQueue` is removed** along with the old merge loop, as on master — it had no other users in this package.

## Verification

- [x] File count matches original PR (6)
- [x] Conflicts resolved per-block by enclosing function: `Sort`-internal blocks kept at 2.6 side, `MergeSort` blocks taken from master
- [x] No conflict markers; no `pkg/v3` / `go-api/v3` paths; no unused imports
- [x] No dead code carried in from #50817 (`radixSortByInt64` and its test, `oneShotRecordReader` — all unused here — removed)
- [ ] make static-check (skipped by cherry-pick workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
