### PR TITLE
enhance: [proxy] remove global meta cache initialization

### DIFF
--- a/internal/distributed/proxy/httpserver/file_resource_handler_v2.go
+++ b/internal/distributed/proxy/httpserver/file_resource_handler_v2.go
@@ -34,7 +34,7 @@ func (h *HandlersV2) addFileResource(ctx context.Context, c *gin.Context, anyReq
 		Path: httpReq.Path,
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AddFileResource", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AddFileResource", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.AddFileResource(reqCtx, req.(*milvuspb.AddFileResourceRequest))
 	})
 	if err == nil {
@@ -49,7 +49,7 @@ func (h *HandlersV2) removeFileResource(ctx context.Context, c *gin.Context, any
 		Name: httpReq.Name,
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/RemoveFileResource", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/RemoveFileResource", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.RemoveFileResource(reqCtx, req.(*milvuspb.RemoveFileResourceRequest))
 	})
 	if err == nil {
@@ -61,7 +61,7 @@ func (h *HandlersV2) removeFileResource(ctx context.Context, c *gin.Context, any
 func (h *HandlersV2) listFileResources(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
 	req := &milvuspb.ListFileResourcesRequest{}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ListFileResources", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ListFileResources", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.ListFileResources(reqCtx, req.(*milvuspb.ListFileResourcesRequest))
 	})
 	if err == nil {

--- a/internal/distributed/proxy/httpserver/file_resource_handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/file_resource_handler_v2_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/internal/mocks"
+	"github.com/milvus-io/milvus/internal/proxy"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
@@ -287,7 +288,10 @@ func TestFileResourceHandlerV2ChecksQuota(t *testing.T) {
 	mockProxy.EXPECT().ListFileResources(mock.Anything, mock.Anything).Return(&milvuspb.ListFileResourcesResponse{
 		Status: merr.Success(),
 	}, nil).Once()
-	server := initHTTPServerV2(mockProxy, false)
+	server := initHTTPServerV2(proxyComponentWithMetaCache{
+		ProxyComponent: mockProxy,
+		metaCache:      proxy.InitEmptyMetaCacheForTest(),
+	}, false)
 
 	writeCases := []struct {
 		path string

--- a/internal/distributed/proxy/httpserver/handler.go
+++ b/internal/distributed/proxy/httpserver/handler.go
@@ -29,7 +29,7 @@ import (
 // Handlers handles http requests
 type Handlers struct {
 	proxy     types.ProxyComponent
-	metaCache proxy.Cache
+	metaCache func() proxy.Cache
 }
 
 // NewHandlers creates a new Handlers
@@ -40,11 +40,12 @@ func NewHandlers(proxyComponent types.ProxyComponent) *Handlers {
 	}
 }
 
-func getProxyMetaCache(proxyComponent types.ProxyComponent) proxy.Cache {
+func getProxyMetaCache(proxyComponent types.ProxyComponent) func() proxy.Cache {
 	if metaCacheProvider, ok := proxyComponent.(interface{ GetMetaCache() proxy.Cache }); ok {
-		return metaCacheProvider.GetMetaCache()
+		// Resolve lazily so handlers observe the cache initialized by the proxy after startup.
+		return func() proxy.Cache { return metaCacheProvider.GetMetaCache() }
 	}
-	return nil
+	return func() proxy.Cache { return nil }
 }
 
 // RegisterRouters registers routes to given router

--- a/internal/distributed/proxy/httpserver/handler.go
+++ b/internal/distributed/proxy/httpserver/handler.go
@@ -21,20 +21,30 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus/internal/proxy"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // Handlers handles http requests
 type Handlers struct {
-	proxy types.ProxyComponent
+	proxy     types.ProxyComponent
+	metaCache proxy.Cache
 }
 
 // NewHandlers creates a new Handlers
-func NewHandlers(proxy types.ProxyComponent) *Handlers {
+func NewHandlers(proxyComponent types.ProxyComponent) *Handlers {
 	return &Handlers{
-		proxy: proxy,
+		proxy:     proxyComponent,
+		metaCache: getProxyMetaCache(proxyComponent),
 	}
+}
+
+func getProxyMetaCache(proxyComponent types.ProxyComponent) proxy.Cache {
+	if metaCacheProvider, ok := proxyComponent.(interface{ GetMetaCache() proxy.Cache }); ok {
+		return metaCacheProvider.GetMetaCache()
+	}
+	return nil
 }
 
 // RegisterRouters registers routes to given router

--- a/internal/distributed/proxy/httpserver/handler_test.go
+++ b/internal/distributed/proxy/httpserver/handler_test.go
@@ -33,8 +33,21 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
+	"github.com/milvus-io/milvus/internal/proxy"
 	"github.com/milvus-io/milvus/internal/types"
 )
+
+// proxyComponentWithMetaCache wraps a proxy component so the http handlers can
+// resolve a meta cache through GetMetaCache, mirroring the real Proxy which
+// owns its cache instance.
+type proxyComponentWithMetaCache struct {
+	types.ProxyComponent
+	metaCache proxy.Cache
+}
+
+func (p proxyComponentWithMetaCache) GetMetaCache() proxy.Cache {
+	return p.metaCache
+}
 
 func Test_WrappedInsertRequest_JSONMarshal_AsInsertRequest(t *testing.T) {
 	// https://github.com/milvus-io/milvus/issues/20415

--- a/internal/distributed/proxy/httpserver/handler_v1.go
+++ b/internal/distributed/proxy/httpserver/handler_v1.go
@@ -64,7 +64,7 @@ type RestRequestInterceptor func(ctx context.Context, ginCtx *gin.Context, req a
 // HandlersV1 handles http requests
 type HandlersV1 struct {
 	proxy        types.ProxyComponent
-	metaCache    proxy.Cache
+	metaCache    func() proxy.Cache
 	interceptors []RestRequestInterceptor
 }
 
@@ -113,7 +113,7 @@ func (h *HandlersV1) checkDatabase(ctx context.Context, c *gin.Context, dbName s
 	if dbName == DefaultDbName {
 		return nil
 	}
-	if proxy.CheckDatabase(ctx, h.metaCache, dbName) {
+	if proxy.CheckDatabase(ctx, h.metaCache(), dbName) {
 		return nil
 	}
 	response, err := h.proxy.ListDatabases(ctx, &milvuspb.ListDatabasesRequest{})
@@ -137,7 +137,7 @@ func (h *HandlersV1) checkDatabase(ctx context.Context, c *gin.Context, dbName s
 }
 
 func (h *HandlersV1) describeCollection(ctx context.Context, c *gin.Context, dbName string, collectionName string) (*schemapb.CollectionSchema, error) {
-	collSchema, err := proxy.GetCachedCollectionSchema(ctx, h.metaCache, dbName, collectionName)
+	collSchema, err := proxy.GetCachedCollectionSchema(ctx, h.metaCache(), dbName, collectionName)
 	if err == nil {
 		return collSchema.CollectionSchema, nil
 	}

--- a/internal/distributed/proxy/httpserver/handler_v1.go
+++ b/internal/distributed/proxy/httpserver/handler_v1.go
@@ -44,13 +44,13 @@ import (
 
 var RestRequestInterceptorErr = errors.New("interceptor error placeholder")
 
-func checkAuthorization(ctx context.Context, c *gin.Context, req interface{}) error {
+func (h *HandlersV1) checkAuthorization(ctx context.Context, c *gin.Context, req interface{}) error {
 	username, ok := c.Get(ContextUsername)
 	if !ok || username.(string) == "" {
 		HTTPReturn(c, http.StatusUnauthorized, gin.H{HTTPReturnCode: merr.Code(merr.ErrNeedAuthenticate), HTTPReturnMessage: merr.ErrNeedAuthenticate.Error()})
 		return RestRequestInterceptorErr
 	}
-	_, authErr := proxy.PrivilegeInterceptor(ctx, req)
+	_, authErr := proxy.PrivilegeInterceptorWithMetaCache(h.metaCache)(ctx, req)
 	if authErr != nil {
 		HTTPReturn(c, http.StatusForbidden, gin.H{HTTPReturnCode: merr.Code(authErr), HTTPReturnMessage: authErr.Error()})
 		return RestRequestInterceptorErr
@@ -79,7 +79,7 @@ func NewHandlersV1(proxyComponent types.ProxyComponent) *HandlersV1 {
 		h.interceptors = append(h.interceptors,
 			// authorization
 			func(ctx context.Context, ginCtx *gin.Context, req any, handler func(reqCtx context.Context, req any) (any, error)) (any, error) {
-				err := checkAuthorization(ctx, ginCtx, req)
+				err := h.checkAuthorization(ctx, ginCtx, req)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/distributed/proxy/httpserver/handler_v1.go
+++ b/internal/distributed/proxy/httpserver/handler_v1.go
@@ -64,6 +64,7 @@ type RestRequestInterceptor func(ctx context.Context, ginCtx *gin.Context, req a
 // HandlersV1 handles http requests
 type HandlersV1 struct {
 	proxy        types.ProxyComponent
+	metaCache    proxy.Cache
 	interceptors []RestRequestInterceptor
 }
 
@@ -71,6 +72,7 @@ type HandlersV1 struct {
 func NewHandlersV1(proxyComponent types.ProxyComponent) *HandlersV1 {
 	h := &HandlersV1{
 		proxy:        proxyComponent,
+		metaCache:    getProxyMetaCache(proxyComponent),
 		interceptors: []RestRequestInterceptor{},
 	}
 	if proxy.Params.CommonCfg.AuthorizationEnabled.GetAsBool() {
@@ -111,7 +113,7 @@ func (h *HandlersV1) checkDatabase(ctx context.Context, c *gin.Context, dbName s
 	if dbName == DefaultDbName {
 		return nil
 	}
-	if proxy.CheckDatabase(ctx, dbName) {
+	if proxy.CheckDatabase(ctx, h.metaCache, dbName) {
 		return nil
 	}
 	response, err := h.proxy.ListDatabases(ctx, &milvuspb.ListDatabasesRequest{})
@@ -135,7 +137,7 @@ func (h *HandlersV1) checkDatabase(ctx context.Context, c *gin.Context, dbName s
 }
 
 func (h *HandlersV1) describeCollection(ctx context.Context, c *gin.Context, dbName string, collectionName string) (*schemapb.CollectionSchema, error) {
-	collSchema, err := proxy.GetCachedCollectionSchema(ctx, dbName, collectionName)
+	collSchema, err := proxy.GetCachedCollectionSchema(ctx, h.metaCache, dbName, collectionName)
 	if err == nil {
 		return collSchema.CollectionSchema, nil
 	}

--- a/internal/distributed/proxy/httpserver/handler_v1_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v1_test.go
@@ -26,10 +26,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -38,11 +40,14 @@ import (
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/proxy"
+	"github.com/milvus-io/milvus/internal/proxy/privilege"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/util"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 const (
@@ -226,6 +231,129 @@ func TestVectorAuthenticate(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Equal(t, "{\"code\":200,\"data\":[\""+DefaultCollectionName+"\"]}", w.Body.String())
 	})
+}
+
+// newRESTV1ServerForRBACTest builds a v1 REST server whose auth middleware sets
+// the parsed username directly, without re-initializing the proxy privilege
+// cache (genAuthMiddleWare resets it, which would wipe test grants).
+func newRESTV1ServerForRBACTest(t *testing.T, pxy types.ProxyComponent) *gin.Engine {
+	t.Helper()
+	h := NewHandlersV1(pxy)
+	ginHandler := gin.Default()
+	app := ginHandler.Group(URIPrefixV1, func(c *gin.Context) {
+		username, _, ok := ParseUsernamePassword(c)
+		if !ok || username == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{HTTPReturnCode: merr.Code(merr.ErrNeedAuthenticate), HTTPReturnMessage: merr.ErrNeedAuthenticate.Error()})
+			return
+		}
+		c.Set(ContextUsername, username)
+	})
+	h.RegisterRoutesToV1(app)
+	return ginHandler
+}
+
+// TestRESTV1AliasRBAC guards the alias-resolution wiring of the REST v1
+// authorization path (see TestRESTV2AliasRBAC for the shared rationale).
+func TestRESTV1AliasRBAC(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(proxy.Params.CommonCfg.AuthorizationEnabled.Key, "true")
+	t.Cleanup(func() { paramtable.Get().Reset(proxy.Params.CommonCfg.AuthorizationEnabled.Key) })
+	paramtable.Get().Save(proxy.Params.ProxyCfg.ResolveAliasForPrivilege.Key, "true")
+	t.Cleanup(func() { paramtable.Get().Reset(proxy.Params.ProxyCfg.ResolveAliasForPrivilege.Key) })
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	t.Cleanup(func() { paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key) })
+
+	const (
+		username = "alice"
+		role     = "role_reader"
+		alias    = "orders_current"
+		realCol  = "orders"
+	)
+
+	cache := proxy.InitEmptyMetaCacheForTest()
+	require.NotNil(t, cache)
+	patch := mockey.Mock((*proxy.MetaCache).ResolveCollectionAlias).Return(realCol, nil).Build()
+	t.Cleanup(func() { patch.UnPatch() })
+
+	privCache := privilege.GetPrivilegeCache()
+	require.NotNil(t, privCache)
+	require.NoError(t, privCache.RefreshPolicyInfo(typeutil.CacheOp{
+		OpType: typeutil.CacheGrantPrivilege,
+		OpKey:  funcutil.PolicyForPrivilege(role, commonpb.ObjectType_Collection.String(), realCol, commonpb.ObjectPrivilege_PrivilegeQuery.String(), util.DefaultDBName),
+	}))
+	require.NoError(t, privCache.RefreshPolicyInfo(typeutil.CacheOp{
+		OpType: typeutil.CacheAddUserToRole,
+		OpKey:  funcutil.EncodeUserRoleCache(username, role),
+	}))
+
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().Query(mock.Anything, mock.Anything).Return(&milvuspb.QueryResults{Status: &StatusSuccess}, nil).Twice()
+	testEngine := newRESTV1ServerForRBACTest(t, proxyComponentWithMetaCache{ProxyComponent: mp, metaCache: cache})
+
+	queryPath := versional(VectorQueryPath)
+	for _, tc := range []struct {
+		name string
+		coll string
+	}{
+		{"real collection name", realCol},
+		{"alias resolves to the granted collection", alias},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := bytes.NewReader([]byte(`{"collectionName": "` + tc.coll + `", "filter": "pk > 0"}`))
+			req := httptest.NewRequest(http.MethodPost, queryPath, body)
+			req.SetBasicAuth(username, "pwd")
+			w := httptest.NewRecorder()
+			testEngine.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		})
+	}
+}
+
+// TestRESTV1AliasRBAC_GrantOnAliasStringDenied verifies the inverse: a grant
+// scoped to the alias string must NOT authorize access through the alias.
+func TestRESTV1AliasRBAC_GrantOnAliasStringDenied(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(proxy.Params.CommonCfg.AuthorizationEnabled.Key, "true")
+	t.Cleanup(func() { paramtable.Get().Reset(proxy.Params.CommonCfg.AuthorizationEnabled.Key) })
+	paramtable.Get().Save(proxy.Params.ProxyCfg.ResolveAliasForPrivilege.Key, "true")
+	t.Cleanup(func() { paramtable.Get().Reset(proxy.Params.ProxyCfg.ResolveAliasForPrivilege.Key) })
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	t.Cleanup(func() { paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key) })
+
+	const (
+		username = "alice"
+		role     = "role_reader"
+		alias    = "orders_current"
+		realCol  = "orders"
+	)
+
+	cache := proxy.InitEmptyMetaCacheForTest()
+	require.NotNil(t, cache)
+	patch := mockey.Mock((*proxy.MetaCache).ResolveCollectionAlias).Return(realCol, nil).Build()
+	t.Cleanup(func() { patch.UnPatch() })
+
+	privCache := privilege.GetPrivilegeCache()
+	require.NotNil(t, privCache)
+	require.NoError(t, privCache.RefreshPolicyInfo(typeutil.CacheOp{
+		OpType: typeutil.CacheGrantPrivilege,
+		OpKey:  funcutil.PolicyForPrivilege(role, commonpb.ObjectType_Collection.String(), alias, commonpb.ObjectPrivilege_PrivilegeQuery.String(), util.DefaultDBName),
+	}))
+	require.NoError(t, privCache.RefreshPolicyInfo(typeutil.CacheOp{
+		OpType: typeutil.CacheAddUserToRole,
+		OpKey:  funcutil.EncodeUserRoleCache(username, role),
+	}))
+
+	mp := mocks.NewMockProxy(t)
+	testEngine := newRESTV1ServerForRBACTest(t, proxyComponentWithMetaCache{ProxyComponent: mp, metaCache: cache})
+
+	body := bytes.NewReader([]byte(`{"collectionName": "` + alias + `", "filter": "pk > 0"}`))
+	req := httptest.NewRequest(http.MethodPost, versional(VectorQueryPath), body)
+	req.SetBasicAuth(username, "pwd")
+	w := httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code, w.Body.String())
+	mp.AssertNotCalled(t, "Query", mock.Anything, mock.Anything)
 }
 
 func TestVectorListCollection(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/handler_v1_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v1_test.go
@@ -165,7 +165,7 @@ func genAuthMiddleWare(needAuth bool) gin.HandlerFunc {
 }
 
 func InitMockGlobalMetaCache() {
-	proxy.InitEmptyGlobalCache()
+	proxy.InitEmptyMetaCacheForTest()
 }
 
 func Print(code int32, message string) string {

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -63,12 +63,14 @@ import (
 
 type HandlersV2 struct {
 	proxy     types.ProxyComponent
+	metaCache proxy.Cache
 	checkAuth bool
 }
 
 func NewHandlersV2(proxyClient types.ProxyComponent) *HandlersV2 {
 	return &HandlersV2{
 		proxy:     proxyClient,
+		metaCache: getProxyMetaCache(proxyClient),
 		checkAuth: proxy.Params.CommonCfg.AuthorizationEnabled.GetAsBool(),
 	}
 }
@@ -732,7 +734,7 @@ func wrapperProxyWithLimit(ctx context.Context, ginCtx *gin.Context, req any, ch
 func (h *HandlersV2) hasCollection(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
 	getter, _ := anyReq.(requestutil.CollectionNameGetter)
 	collectionName := getter.GetCollectionName()
-	_, err := proxy.GetCachedCollectionSchema(ctx, dbName, collectionName)
+	_, err := proxy.GetCachedCollectionSchema(ctx, h.metaCache, dbName, collectionName)
 	has := true
 	if err != nil {
 		req := &milvuspb.HasCollectionRequest{
@@ -4364,7 +4366,7 @@ func refreshExternalCollectionJobInfoToMap(jobInfo *milvuspb.RefreshExternalColl
 }
 
 func (h *HandlersV2) GetCollectionSchema(ctx context.Context, c *gin.Context, dbName, collectionName string) (*schemapb.CollectionSchema, error) {
-	collSchema, err := proxy.GetCachedCollectionSchema(ctx, dbName, collectionName)
+	collSchema, err := proxy.GetCachedCollectionSchema(ctx, h.metaCache, dbName, collectionName)
 	if err == nil {
 		return collSchema.CollectionSchema, nil
 	}

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -63,7 +63,7 @@ import (
 
 type HandlersV2 struct {
 	proxy     types.ProxyComponent
-	metaCache proxy.Cache
+	metaCache func() proxy.Cache
 	checkAuth bool
 }
 
@@ -734,7 +734,7 @@ func wrapperProxyWithLimit(ctx context.Context, ginCtx *gin.Context, req any, ch
 func (h *HandlersV2) hasCollection(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
 	getter, _ := anyReq.(requestutil.CollectionNameGetter)
 	collectionName := getter.GetCollectionName()
-	_, err := proxy.GetCachedCollectionSchema(ctx, h.metaCache, dbName, collectionName)
+	_, err := proxy.GetCachedCollectionSchema(ctx, h.metaCache(), dbName, collectionName)
 	has := true
 	if err != nil {
 		req := &milvuspb.HasCollectionRequest{
@@ -4366,7 +4366,7 @@ func refreshExternalCollectionJobInfoToMap(jobInfo *milvuspb.RefreshExternalColl
 }
 
 func (h *HandlersV2) GetCollectionSchema(ctx context.Context, c *gin.Context, dbName, collectionName string) (*schemapb.CollectionSchema, error) {
-	collSchema, err := proxy.GetCachedCollectionSchema(ctx, h.metaCache, dbName, collectionName)
+	collSchema, err := proxy.GetCachedCollectionSchema(ctx, h.metaCache(), dbName, collectionName)
 	if err == nil {
 		return collSchema.CollectionSchema, nil
 	}

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -630,7 +630,7 @@ func wrapperTraceLog(v2 handlerFuncV2) handlerFuncV2 {
 	}
 }
 
-func checkAuthorizationV2(ctx context.Context, c *gin.Context, ignoreErr bool, req interface{}) error {
+func (h *HandlersV2) checkAuthorizationV2(ctx context.Context, c *gin.Context, ignoreErr bool, req interface{}) error {
 	username, ok := c.Get(ContextUsername)
 	if !ok || username.(string) == "" {
 		if !ignoreErr {
@@ -639,7 +639,7 @@ func checkAuthorizationV2(ctx context.Context, c *gin.Context, ignoreErr bool, r
 		hookutil.GetExtension().ReportAction(ctx, req, WrapErrorToResponse(merr.ErrNeedAuthenticate), nil, c.FullPath(), hookutil.ActionAuthorize)
 		return merr.ErrNeedAuthenticate
 	}
-	ctx, authErr := proxy.PrivilegeInterceptor(ctx, req)
+	ctx, authErr := proxy.PrivilegeInterceptorWithMetaCache(h.metaCache)(ctx, req)
 	if authErr != nil {
 		if !ignoreErr {
 			HTTPReturn(c, http.StatusForbidden, gin.H{HTTPReturnCode: merr.Code(authErr), HTTPReturnMessage: authErr.Error()})
@@ -652,12 +652,12 @@ func checkAuthorizationV2(ctx context.Context, c *gin.Context, ignoreErr bool, r
 	return nil
 }
 
-func checkAuthorizationHelper(ctx context.Context, c *gin.Context, req interface{}) error {
+func (h *HandlersV2) checkAuthorizationHelper(ctx context.Context, c *gin.Context, req interface{}) error {
 	username, ok := c.Get(ContextUsername)
 	if !ok || username.(string) == "" {
 		return merr.ErrNeedAuthenticate
 	}
-	ctx, authErr := proxy.PrivilegeInterceptor(ctx, req)
+	ctx, authErr := proxy.PrivilegeInterceptorWithMetaCache(h.metaCache)(ctx, req)
 	if authErr != nil {
 		return authErr
 	}
@@ -665,17 +665,17 @@ func checkAuthorizationHelper(ctx context.Context, c *gin.Context, req interface
 	return nil
 }
 
-func wrapperProxy(ctx context.Context, c *gin.Context, req any, checkAuth bool, ignoreErr bool, fullMethod string, handler func(reqCtx context.Context, req any) (any, error)) (interface{}, error) {
-	return wrapperProxyWithLimit(ctx, c, req, checkAuth, ignoreErr, fullMethod, false, nil, handler)
+func (h *HandlersV2) wrapperProxy(ctx context.Context, c *gin.Context, req any, checkAuth bool, ignoreErr bool, fullMethod string, handler func(reqCtx context.Context, req any) (any, error)) (interface{}, error) {
+	return h.wrapperProxyWithLimit(ctx, c, req, checkAuth, ignoreErr, fullMethod, false, nil, handler)
 }
 
-func wrapperProxyWithLimit(ctx context.Context, ginCtx *gin.Context, req any, checkAuth bool, ignoreErr bool, fullMethod string, checkLimit bool, pxy types.ProxyComponent, handler func(reqCtx context.Context, req any) (any, error)) (interface{}, error) {
+func (h *HandlersV2) wrapperProxyWithLimit(ctx context.Context, ginCtx *gin.Context, req any, checkAuth bool, ignoreErr bool, fullMethod string, checkLimit bool, pxy types.ProxyComponent, handler func(reqCtx context.Context, req any) (any, error)) (interface{}, error) {
 	if baseGetter, ok := req.(BaseGetter); ok {
 		span := trace.SpanFromContext(ctx)
 		span.AddEvent(baseGetter.GetBase().GetMsgType().String())
 	}
 	if checkAuth {
-		err := checkAuthorizationV2(ctx, ginCtx, ignoreErr, req)
+		err := h.checkAuthorizationV2(ctx, ginCtx, ignoreErr, req)
 		if err != nil {
 			return nil, err
 		}
@@ -742,7 +742,7 @@ func (h *HandlersV2) hasCollection(ctx context.Context, c *gin.Context, anyReq a
 			CollectionName: collectionName,
 		}
 		// handle at rootcoord side
-		resp, err := wrapperProxy(ctx, c, req, false, false, "/milvus.proto.milvus.MilvusService/HasCollection", func(reqCtx context.Context, req any) (interface{}, error) {
+		resp, err := h.wrapperProxy(ctx, c, req, false, false, "/milvus.proto.milvus.MilvusService/HasCollection", func(reqCtx context.Context, req any) (interface{}, error) {
 			return h.proxy.HasCollection(reqCtx, req.(*milvuspb.HasCollectionRequest))
 		})
 		if err != nil {
@@ -760,7 +760,7 @@ func (h *HandlersV2) listCollections(ctx context.Context, c *gin.Context, anyReq
 	}
 	c.Set(ContextRequest, req)
 	// handle at rootcoord side
-	resp, err := wrapperProxy(ctx, c, req, false, false, "/milvus.proto.milvus.MilvusService/ShowCollections", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, false, false, "/milvus.proto.milvus.MilvusService/ShowCollections", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.ShowCollections(reqCtx, req.(*milvuspb.ShowCollectionsRequest))
 	})
 	if err == nil {
@@ -777,7 +777,7 @@ func (h *HandlersV2) getCollectionDetails(ctx context.Context, c *gin.Context, a
 		CollectionName: collectionName,
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DescribeCollection", func(reqCtx context.Context, req any) (any, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DescribeCollection", func(reqCtx context.Context, req any) (any, error) {
 		return h.proxy.DescribeCollection(reqCtx, req.(*milvuspb.DescribeCollectionRequest))
 	})
 	if err != nil {
@@ -796,7 +796,7 @@ func (h *HandlersV2) getCollectionDetails(ctx context.Context, c *gin.Context, a
 		DbName:         dbName,
 		CollectionName: collectionName,
 	}
-	stateResp, err := wrapperProxy(ctx, c, loadStateReq, h.checkAuth, true, "/milvus.proto.milvus.MilvusService/GetLoadState", func(reqCtx context.Context, req any) (any, error) {
+	stateResp, err := h.wrapperProxy(ctx, c, loadStateReq, h.checkAuth, true, "/milvus.proto.milvus.MilvusService/GetLoadState", func(reqCtx context.Context, req any) (any, error) {
 		return h.proxy.GetLoadState(reqCtx, req.(*milvuspb.GetLoadStateRequest))
 	})
 	collLoadState := ""
@@ -818,7 +818,7 @@ func (h *HandlersV2) getCollectionDetails(ctx context.Context, c *gin.Context, a
 		CollectionName: collectionName,
 		FieldName:      vectorField,
 	}
-	indexResp, err := wrapperProxy(ctx, c, descIndexReq, h.checkAuth, true, "/milvus.proto.milvus.MilvusService/DescribeIndex", func(reqCtx context.Context, req any) (any, error) {
+	indexResp, err := h.wrapperProxy(ctx, c, descIndexReq, h.checkAuth, true, "/milvus.proto.milvus.MilvusService/DescribeIndex", func(reqCtx context.Context, req any) (any, error) {
 		return h.proxy.DescribeIndex(reqCtx, req.(*milvuspb.DescribeIndexRequest))
 	})
 	if err == nil {
@@ -831,7 +831,7 @@ func (h *HandlersV2) getCollectionDetails(ctx context.Context, c *gin.Context, a
 		DbName:         dbName,
 		CollectionName: collectionName,
 	}
-	aliasResp, err := wrapperProxy(ctx, c, aliasReq, h.checkAuth, true, "/milvus.proto.milvus.MilvusService/ListAliases", func(reqCtx context.Context, req any) (interface{}, error) {
+	aliasResp, err := h.wrapperProxy(ctx, c, aliasReq, h.checkAuth, true, "/milvus.proto.milvus.MilvusService/ListAliases", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.ListAliases(reqCtx, req.(*milvuspb.ListAliasesRequest))
 	})
 	if err == nil {
@@ -874,7 +874,7 @@ func (h *HandlersV2) getCollectionStats(ctx context.Context, c *gin.Context, any
 		CollectionName: collectionGetter.GetCollectionName(),
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/GetCollectionStatistics", func(reqCtx context.Context, req any) (any, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/GetCollectionStatistics", func(reqCtx context.Context, req any) (any, error) {
 		return h.proxy.GetCollectionStatistics(reqCtx, req.(*milvuspb.GetCollectionStatisticsRequest))
 	})
 	if err == nil {
@@ -890,7 +890,7 @@ func (h *HandlersV2) getCollectionLoadState(ctx context.Context, c *gin.Context,
 		CollectionName: collectionGetter.GetCollectionName(),
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/GetLoadState", func(reqCtx context.Context, req any) (any, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/GetLoadState", func(reqCtx context.Context, req any) (any, error) {
 		return h.proxy.GetLoadState(reqCtx, req.(*milvuspb.GetLoadStateRequest))
 	})
 	if err != nil {
@@ -913,7 +913,7 @@ func (h *HandlersV2) getCollectionLoadState(ctx context.Context, c *gin.Context,
 		PartitionNames: partitionsGetter.GetPartitionNames(),
 		DbName:         dbName,
 	}
-	progressResp, err := wrapperProxy(ctx, c, progressReq, h.checkAuth, true, "/milvus.proto.milvus.MilvusService/GetLoadingProgress", func(reqCtx context.Context, req any) (any, error) {
+	progressResp, err := h.wrapperProxy(ctx, c, progressReq, h.checkAuth, true, "/milvus.proto.milvus.MilvusService/GetLoadingProgress", func(reqCtx context.Context, req any) (any, error) {
 		return h.proxy.GetLoadingProgress(reqCtx, req.(*milvuspb.GetLoadingProgressRequest))
 	})
 	progress := int64(-1)
@@ -941,7 +941,7 @@ func (h *HandlersV2) dropCollection(ctx context.Context, c *gin.Context, anyReq 
 		CollectionName: getter.GetCollectionName(),
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DropCollection", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DropCollection", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.DropCollection(reqCtx, req.(*milvuspb.DropCollectionRequest))
 	})
 	if err == nil {
@@ -957,7 +957,7 @@ func (h *HandlersV2) truncateCollection(ctx context.Context, c *gin.Context, any
 		CollectionName: getter.GetCollectionName(),
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/TruncateCollection", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/TruncateCollection", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.TruncateCollection(reqCtx, req.(*milvuspb.TruncateCollectionRequest))
 	})
 	if err == nil {
@@ -978,7 +978,7 @@ func (h *HandlersV2) renameCollection(ctx context.Context, c *gin.Context, anyRe
 	if req.NewDBName == "" {
 		req.NewDBName = dbName
 	}
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/RenameCollection", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/RenameCollection", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.RenameCollection(reqCtx, req.(*milvuspb.RenameCollectionRequest))
 	})
 	if err == nil {
@@ -1008,7 +1008,7 @@ func (h *HandlersV2) loadCollection(ctx context.Context, c *gin.Context, anyReq 
 
 func (h *HandlersV2) loadCollectionInternal(ctx context.Context, c *gin.Context, req *milvuspb.LoadCollectionRequest, dbName string) (interface{}, error) {
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/LoadCollection", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/LoadCollection", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.LoadCollection(reqCtx, req.(*milvuspb.LoadCollectionRequest))
 	})
 	if err == nil {
@@ -1024,7 +1024,7 @@ func (h *HandlersV2) releaseCollection(ctx context.Context, c *gin.Context, anyR
 		CollectionName: getter.GetCollectionName(),
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ReleaseCollection", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ReleaseCollection", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.ReleaseCollection(reqCtx, req.(*milvuspb.ReleaseCollectionRequest))
 	})
 	if err == nil {
@@ -1046,7 +1046,7 @@ func (h *HandlersV2) alterCollectionProperties(ctx context.Context, c *gin.Conte
 	req.Properties = properties
 
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterCollection", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterCollection", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.AlterCollection(reqCtx, req.(*milvuspb.AlterCollectionRequest))
 	})
 	if err == nil {
@@ -1072,7 +1072,7 @@ func (h *HandlersV2) addCollectionFunction(ctx context.Context, c *gin.Context, 
 
 	req.FunctionSchema = fSchema
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AddCollectionFunction", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AddCollectionFunction", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.AddCollectionFunction(reqCtx, req.(*milvuspb.AddCollectionFunctionRequest))
 	})
 	if err == nil {
@@ -1099,7 +1099,7 @@ func (h *HandlersV2) alterCollectionFunction(ctx context.Context, c *gin.Context
 
 	req.FunctionSchema = fSchema
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterCollectionFunction", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterCollectionFunction", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.AlterCollectionFunction(reqCtx, req.(*milvuspb.AlterCollectionFunctionRequest))
 	})
 	if err == nil {
@@ -1119,7 +1119,7 @@ func (h *HandlersV2) dropCollectionFunction(ctx context.Context, c *gin.Context,
 		FunctionName:   httpReq.FunctionName,
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DropCollectionFunction", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DropCollectionFunction", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.DropCollectionFunction(reqCtx, req.(*milvuspb.DropCollectionFunctionRequest))
 	})
 	if err == nil {
@@ -1194,7 +1194,7 @@ func (h *HandlersV2) addCollectionFunctionField(ctx context.Context, c *gin.Cont
 		},
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterCollectionSchema", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterCollectionSchema", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		r, callErr := h.proxy.AlterCollectionSchema(reqCtx, req.(*milvuspb.AlterCollectionSchemaRequest))
 		if callErr == nil {
 			callErr = merr.Error(r.GetAlterStatus())
@@ -1226,7 +1226,7 @@ func (h *HandlersV2) dropCollectionFunctionField(ctx context.Context, c *gin.Con
 		},
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterCollectionSchema", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterCollectionSchema", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		r, callErr := h.proxy.AlterCollectionSchema(reqCtx, req.(*milvuspb.AlterCollectionSchemaRequest))
 		if callErr == nil {
 			callErr = merr.Error(r.GetAlterStatus())
@@ -1247,7 +1247,7 @@ func (h *HandlersV2) dropCollectionProperties(ctx context.Context, c *gin.Contex
 		DeleteKeys:     httpReq.PropertyKeys,
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterCollection", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterCollection", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.AlterCollection(reqCtx, req.(*milvuspb.AlterCollectionRequest))
 	})
 	if err == nil {
@@ -1264,7 +1264,7 @@ func (h *HandlersV2) compact(ctx context.Context, c *gin.Context, anyReq any, db
 		MajorCompaction: httpReq.IsClustering,
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ManualCompaction", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ManualCompaction", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.ManualCompaction(reqCtx, req.(*milvuspb.ManualCompactionRequest))
 	})
 	if err == nil {
@@ -1283,7 +1283,7 @@ func (h *HandlersV2) getcompactionState(ctx context.Context, c *gin.Context, any
 		CompactionID: httpReq.JobID,
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/GetCompactionState", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/GetCompactionState", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.GetCompactionState(reqCtx, req.(*milvuspb.GetCompactionStateRequest))
 	})
 	if err == nil {
@@ -1303,7 +1303,7 @@ func (h *HandlersV2) flush(ctx context.Context, c *gin.Context, anyReq any, dbNa
 		CollectionNames: []string{httpReq.CollectionName},
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/Flush", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/Flush", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.Flush(reqCtx, req.(*milvuspb.FlushRequest))
 	})
 	if err == nil {
@@ -1363,7 +1363,7 @@ func (h *HandlersV2) alterCollectionFieldProperties(ctx context.Context, c *gin.
 	req.Properties = properties
 
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterCollectionField", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterCollectionField", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.AlterCollectionField(reqCtx, req.(*milvuspb.AlterCollectionFieldRequest))
 	})
 	if err == nil {
@@ -1402,7 +1402,7 @@ func (h *HandlersV2) addCollectionField(ctx context.Context, c *gin.Context, any
 	}
 
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterCollectionSchema", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterCollectionSchema", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		r, callErr := h.proxy.AlterCollectionSchema(reqCtx, req.(*milvuspb.AlterCollectionSchemaRequest))
 		if callErr == nil {
 			callErr = merr.Error(r.GetAlterStatus())
@@ -1445,7 +1445,7 @@ func (h *HandlersV2) dropCollectionField(ctx context.Context, c *gin.Context, an
 		},
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterCollectionSchema", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterCollectionSchema", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		r, callErr := h.proxy.AlterCollectionSchema(reqCtx, req.(*milvuspb.AlterCollectionSchemaRequest))
 		if callErr == nil {
 			callErr = merr.Error(r.GetAlterStatus())
@@ -1474,7 +1474,7 @@ func (h *HandlersV2) addCollectionStructField(ctx context.Context, c *gin.Contex
 	}
 
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AddCollectionStructField", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AddCollectionStructField", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.AddCollectionStructField(reqCtx, req.(*milvuspb.AddCollectionStructFieldRequest))
 	})
 
@@ -1540,7 +1540,7 @@ func (h *HandlersV2) query(ctx context.Context, c *gin.Context, anyReq any, dbNa
 	if len(httpReq.GroupByFields) > 0 {
 		req.QueryParams = append(req.QueryParams, &commonpb.KeyValuePair{Key: proxy.GroupByFieldsKey, Value: strings.Join(httpReq.GroupByFields, ",")})
 	}
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/Query", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/Query", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.Query(reqCtx, req.(*milvuspb.QueryRequest))
 	})
 	if err == nil {
@@ -1609,7 +1609,7 @@ func (h *HandlersV2) get(ctx context.Context, c *gin.Context, anyReq any, dbName
 		return nil, err
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/Query", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/Query", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.Query(reqCtx, req.(*milvuspb.QueryRequest))
 	})
 	if err == nil {
@@ -1681,7 +1681,7 @@ func (h *HandlersV2) delete(ctx context.Context, c *gin.Context, anyReq any, dbN
 		req.Expr = filter
 		req.ExprTemplateValues = idTemplateValues
 	}
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/Delete", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/Delete", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.Delete(reqCtx, req.(*milvuspb.DeleteRequest))
 	})
 	if err == nil {
@@ -1730,7 +1730,7 @@ func (h *HandlersV2) insert(ctx context.Context, c *gin.Context, anyReq any, dbN
 		})
 		return nil, err
 	}
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/Insert", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/Insert", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.Insert(reqCtx, req.(*milvuspb.InsertRequest))
 	})
 	if err == nil {
@@ -1814,7 +1814,7 @@ func (h *HandlersV2) upsert(ctx context.Context, c *gin.Context, anyReq any, dbN
 		})
 		return nil, err
 	}
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/Upsert", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/Upsert", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.Upsert(reqCtx, req.(*milvuspb.UpsertRequest))
 	})
 	if err == nil {
@@ -2237,7 +2237,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 		return nil, err
 	}
 	req.ExprTemplateValues = templateValues
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/Search", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/Search", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.Search(reqCtx, req.(*milvuspb.SearchRequest))
 	})
 	if err == nil {
@@ -2442,7 +2442,7 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 			return nil, err
 		}
 	}
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/HybridSearch", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/HybridSearch", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.HybridSearch(reqCtx, req.(*milvuspb.HybridSearchRequest))
 	})
 	if err == nil {
@@ -2941,7 +2941,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 		}
 	}
 
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreateCollection", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreateCollection", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.CreateCollection(reqCtx, req.(*milvuspb.CreateCollectionRequest))
 	})
 	if err != nil {
@@ -2955,7 +2955,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 			IndexName:      httpReq.VectorFieldName,
 			ExtraParams:    []*commonpb.KeyValuePair{{Key: common.MetricTypeKey, Value: httpReq.MetricType}},
 		}
-		statusResponse, err := wrapperProxyWithLimit(ctx, c, createIndexReq, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreateIndex", false, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+		statusResponse, err := h.wrapperProxyWithLimit(ctx, c, createIndexReq, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreateIndex", false, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 			return h.proxy.CreateIndex(ctx, req.(*milvuspb.CreateIndexRequest))
 		})
 		if err != nil {
@@ -2991,7 +2991,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 				})
 				return resp, err
 			}
-			statusResponse, err := wrapperProxyWithLimit(ctx, c, createIndexReq, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreateIndex", false, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+			statusResponse, err := h.wrapperProxyWithLimit(ctx, c, createIndexReq, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreateIndex", false, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 				return h.proxy.CreateIndex(ctx, req.(*milvuspb.CreateIndexRequest))
 			})
 			if err != nil {
@@ -3003,7 +3003,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 		DbName:         dbName,
 		CollectionName: httpReq.CollectionName,
 	}
-	statusResponse, err := wrapperProxyWithLimit(ctx, c, loadReq, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/LoadCollection", false, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	statusResponse, err := h.wrapperProxyWithLimit(ctx, c, loadReq, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/LoadCollection", false, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.LoadCollection(ctx, req.(*milvuspb.LoadCollectionRequest))
 	})
 	if err == nil {
@@ -3024,7 +3024,7 @@ func (h *HandlersV2) createDatabase(ctx context.Context, c *gin.Context, anyReq 
 	req.Properties = properties
 
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreateDatabase", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreateDatabase", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.CreateDatabase(reqCtx, req.(*milvuspb.CreateDatabaseRequest))
 	})
 	if err == nil {
@@ -3038,7 +3038,7 @@ func (h *HandlersV2) dropDatabase(ctx context.Context, c *gin.Context, anyReq an
 		DbName: dbName,
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DropDatabase", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DropDatabase", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.DropDatabase(reqCtx, req.(*milvuspb.DropDatabaseRequest))
 	})
 	if err == nil {
@@ -3054,7 +3054,7 @@ func (h *HandlersV2) dropDatabaseProperties(ctx context.Context, c *gin.Context,
 		DeleteKeys: httpReq.PropertyKeys,
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterDatabase", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterDatabase", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.AlterDatabase(reqCtx, req.(*milvuspb.AlterDatabaseRequest))
 	})
 	if err == nil {
@@ -3068,7 +3068,7 @@ func (h *HandlersV2) listDatabases(ctx context.Context, c *gin.Context, anyReq a
 	req := &milvuspb.ListDatabasesRequest{}
 	c.Set(ContextRequest, req)
 	// handle at rootcoord side
-	resp, err := wrapperProxy(ctx, c, req, false, false, "/milvus.proto.milvus.MilvusService/ListDatabases", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, false, false, "/milvus.proto.milvus.MilvusService/ListDatabases", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.ListDatabases(reqCtx, req.(*milvuspb.ListDatabasesRequest))
 	})
 	if err == nil {
@@ -3082,7 +3082,7 @@ func (h *HandlersV2) describeDatabase(ctx context.Context, c *gin.Context, anyRe
 		DbName: dbName,
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DescribeDatabase", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DescribeDatabase", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.DescribeDatabase(reqCtx, req.(*milvuspb.DescribeDatabaseRequest))
 	})
 	if err != nil {
@@ -3113,7 +3113,7 @@ func (h *HandlersV2) alterDatabase(ctx context.Context, c *gin.Context, anyReq a
 	req.Properties = properties
 
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterDatabase", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterDatabase", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.AlterDatabase(reqCtx, req.(*milvuspb.AlterDatabaseRequest))
 	})
 	if err == nil {
@@ -3130,7 +3130,7 @@ func (h *HandlersV2) listPartitions(ctx context.Context, c *gin.Context, anyReq 
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ShowPartitions", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ShowPartitions", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.ShowPartitions(reqCtx, req.(*milvuspb.ShowPartitionsRequest))
 	})
 	if err == nil {
@@ -3148,7 +3148,7 @@ func (h *HandlersV2) hasPartitions(ctx context.Context, c *gin.Context, anyReq a
 		PartitionName:  partitionGetter.GetPartitionName(),
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/HasPartition", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/HasPartition", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.HasPartition(reqCtx, req.(*milvuspb.HasPartitionRequest))
 	})
 	if err == nil {
@@ -3168,7 +3168,7 @@ func (h *HandlersV2) statsPartition(ctx context.Context, c *gin.Context, anyReq 
 		PartitionName:  partitionGetter.GetPartitionName(),
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/GetPartitionStatistics", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/GetPartitionStatistics", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.GetPartitionStatistics(reqCtx, req.(*milvuspb.GetPartitionStatisticsRequest))
 	})
 	if err == nil {
@@ -3186,7 +3186,7 @@ func (h *HandlersV2) createPartition(ctx context.Context, c *gin.Context, anyReq
 		PartitionName:  partitionGetter.GetPartitionName(),
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreatePartition", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreatePartition", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.CreatePartition(reqCtx, req.(*milvuspb.CreatePartitionRequest))
 	})
 	if err == nil {
@@ -3204,7 +3204,7 @@ func (h *HandlersV2) dropPartition(ctx context.Context, c *gin.Context, anyReq a
 		PartitionName:  partitionGetter.GetPartitionName(),
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DropPartition", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DropPartition", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.DropPartition(reqCtx, req.(*milvuspb.DropPartitionRequest))
 	})
 	if err == nil {
@@ -3221,7 +3221,7 @@ func (h *HandlersV2) loadPartitions(ctx context.Context, c *gin.Context, anyReq 
 		PartitionNames: httpReq.PartitionNames,
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/LoadPartitions", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/LoadPartitions", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.LoadPartitions(reqCtx, req.(*milvuspb.LoadPartitionsRequest))
 	})
 	if err == nil {
@@ -3238,7 +3238,7 @@ func (h *HandlersV2) releasePartitions(ctx context.Context, c *gin.Context, anyR
 		PartitionNames: httpReq.PartitionNames,
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ReleasePartitions", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ReleasePartitions", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.ReleasePartitions(reqCtx, req.(*milvuspb.ReleasePartitionsRequest))
 	})
 	if err == nil {
@@ -3250,7 +3250,7 @@ func (h *HandlersV2) releasePartitions(ctx context.Context, c *gin.Context, anyR
 func (h *HandlersV2) listUsers(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
 	req := &milvuspb.ListCredUsersRequest{}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ListCredUsers", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ListCredUsers", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.ListCredUsers(reqCtx, req.(*milvuspb.ListCredUsersRequest))
 	})
 	if err == nil {
@@ -3270,7 +3270,7 @@ func (h *HandlersV2) describeUser(ctx context.Context, c *gin.Context, anyReq an
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/SelectUser", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/SelectUser", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.SelectUser(reqCtx, req.(*milvuspb.SelectUserRequest))
 	})
 	if err == nil {
@@ -3298,7 +3298,7 @@ func (h *HandlersV2) createUser(ctx context.Context, c *gin.Context, anyReq any,
 		Password:    crypto.Base64Encode(httpReq.Password),
 		Description: httpReq.Description,
 	}
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreateCredential", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreateCredential", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.CreateCredential(reqCtx, req.(*milvuspb.CreateCredentialRequest))
 	})
 	if err == nil {
@@ -3317,7 +3317,7 @@ func (h *HandlersV2) updateUser(ctx context.Context, c *gin.Context, anyReq any,
 		req.OldPassword = crypto.Base64Encode(httpReq.Password)
 		req.NewPassword = crypto.Base64Encode(httpReq.NewPassword)
 	}
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/UpdateCredential", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/UpdateCredential", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.UpdateCredential(reqCtx, req.(*milvuspb.UpdateCredentialRequest))
 	})
 	if err == nil {
@@ -3331,7 +3331,7 @@ func (h *HandlersV2) dropUser(ctx context.Context, c *gin.Context, anyReq any, d
 	req := &milvuspb.DeleteCredentialRequest{
 		Username: getter.GetUserName(),
 	}
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DeleteCredential", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DeleteCredential", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.DeleteCredential(reqCtx, req.(*milvuspb.DeleteCredentialRequest))
 	})
 	if err == nil {
@@ -3346,7 +3346,7 @@ func (h *HandlersV2) operateRoleToUser(ctx context.Context, c *gin.Context, user
 		RoleName: roleName,
 		Type:     operateType,
 	}
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/OperateUserRole", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/OperateUserRole", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.OperateUserRole(reqCtx, req.(*milvuspb.OperateUserRoleRequest))
 	})
 	if err == nil {
@@ -3365,7 +3365,7 @@ func (h *HandlersV2) removeRoleFromUser(ctx context.Context, c *gin.Context, any
 
 func (h *HandlersV2) listRoles(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
 	req := &milvuspb.SelectRoleRequest{}
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/SelectRole", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/SelectRole", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.SelectRole(reqCtx, req.(*milvuspb.SelectRoleRequest))
 	})
 	if err == nil {
@@ -3383,7 +3383,7 @@ func (h *HandlersV2) describeRole(ctx context.Context, c *gin.Context, anyReq an
 	roleReq := &milvuspb.SelectRoleRequest{
 		Role: &milvuspb.RoleEntity{Name: getter.GetRoleName()},
 	}
-	roleResp, err := wrapperProxy(ctx, c, roleReq, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/SelectRole", func(reqCtx context.Context, req any) (interface{}, error) {
+	roleResp, err := h.wrapperProxy(ctx, c, roleReq, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/SelectRole", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.SelectRole(reqCtx, req.(*milvuspb.SelectRoleRequest))
 	})
 	if err != nil {
@@ -3396,7 +3396,7 @@ func (h *HandlersV2) describeRole(ctx context.Context, c *gin.Context, anyReq an
 	req := &milvuspb.SelectGrantRequest{
 		Entity: &milvuspb.GrantEntity{Role: &milvuspb.RoleEntity{Name: getter.GetRoleName()}, DbName: dbName},
 	}
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/SelectGrant", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/SelectGrant", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.SelectGrant(reqCtx, req.(*milvuspb.SelectGrantRequest))
 	})
 	if err == nil {
@@ -3421,7 +3421,7 @@ func (h *HandlersV2) createRole(ctx context.Context, c *gin.Context, anyReq any,
 	req := &milvuspb.CreateRoleRequest{
 		Entity: &milvuspb.RoleEntity{Name: httpReq.GetRoleName(), Description: httpReq.GetDescription()},
 	}
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreateRole", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreateRole", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.CreateRole(reqCtx, req.(*milvuspb.CreateRoleRequest))
 	})
 	if err == nil {
@@ -3436,7 +3436,7 @@ func (h *HandlersV2) alterRole(ctx context.Context, c *gin.Context, anyReq any, 
 		RoleName:    httpReq.GetRoleName(),
 		Description: httpReq.GetDescription(),
 	}
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterRole", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterRole", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.AlterRole(reqCtx, req.(*milvuspb.AlterRoleRequest))
 	})
 	if err == nil {
@@ -3450,7 +3450,7 @@ func (h *HandlersV2) dropRole(ctx context.Context, c *gin.Context, anyReq any, d
 	req := &milvuspb.DropRoleRequest{
 		RoleName: getter.GetRoleName(),
 	}
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DropRole", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DropRole", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.DropRole(reqCtx, req.(*milvuspb.DropRoleRequest))
 	})
 	if err == nil {
@@ -3472,7 +3472,7 @@ func (h *HandlersV2) operatePrivilegeToRole(ctx context.Context, c *gin.Context,
 		},
 		Type: operateType,
 	}
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/OperatePrivilege", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/OperatePrivilege", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.OperatePrivilege(reqCtx, req.(*milvuspb.OperatePrivilegeRequest))
 	})
 	if err == nil {
@@ -3491,7 +3491,7 @@ func (h *HandlersV2) operatePrivilegeToRoleV2(ctx context.Context, c *gin.Contex
 		DbName:         httpReq.DbName,
 		CollectionName: httpReq.CollectionName,
 	}
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/OperatePrivilegeV2", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/OperatePrivilegeV2", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.OperatePrivilegeV2(reqCtx, req.(*milvuspb.OperatePrivilegeV2Request))
 	})
 	if err == nil {
@@ -3521,7 +3521,7 @@ func (h *HandlersV2) createPrivilegeGroup(ctx context.Context, c *gin.Context, a
 	req := &milvuspb.CreatePrivilegeGroupRequest{
 		GroupName: httpReq.PrivilegeGroupName,
 	}
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreatePrivilegeGroup", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreatePrivilegeGroup", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.CreatePrivilegeGroup(reqCtx, req.(*milvuspb.CreatePrivilegeGroupRequest))
 	})
 	if err == nil {
@@ -3535,7 +3535,7 @@ func (h *HandlersV2) dropPrivilegeGroup(ctx context.Context, c *gin.Context, any
 	req := &milvuspb.DropPrivilegeGroupRequest{
 		GroupName: httpReq.PrivilegeGroupName,
 	}
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DropPrivilegeGroup", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DropPrivilegeGroup", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.DropPrivilegeGroup(reqCtx, req.(*milvuspb.DropPrivilegeGroupRequest))
 	})
 	if err == nil {
@@ -3546,7 +3546,7 @@ func (h *HandlersV2) dropPrivilegeGroup(ctx context.Context, c *gin.Context, any
 
 func (h *HandlersV2) listPrivilegeGroups(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
 	req := &milvuspb.ListPrivilegeGroupsRequest{}
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ListPrivilegeGroups", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ListPrivilegeGroups", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.ListPrivilegeGroups(reqCtx, req.(*milvuspb.ListPrivilegeGroupsRequest))
 	})
 	if err == nil {
@@ -3586,7 +3586,7 @@ func (h *HandlersV2) operatePrivilegeGroup(ctx context.Context, c *gin.Context, 
 		}),
 		Type: operateType,
 	}
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/OperatePrivilegeGroup", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/OperatePrivilegeGroup", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.OperatePrivilegeGroup(reqCtx, req.(*milvuspb.OperatePrivilegeGroupRequest))
 	})
 	if err == nil {
@@ -3604,7 +3604,7 @@ func (h *HandlersV2) listIndexes(ctx context.Context, c *gin.Context, anyReq any
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DescribeIndex", func(reqCtx context.Context, req any) (any, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DescribeIndex", func(reqCtx context.Context, req any) (any, error) {
 		resp, err := h.proxy.DescribeIndex(reqCtx, req.(*milvuspb.DescribeIndexRequest))
 		if errors.Is(err, merr.ErrIndexNotFound) {
 			return &milvuspb.DescribeIndexResponse{
@@ -3641,7 +3641,7 @@ func (h *HandlersV2) describeIndex(ctx context.Context, c *gin.Context, anyReq a
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DescribeIndex", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DescribeIndex", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.DescribeIndex(reqCtx, req.(*milvuspb.DescribeIndexRequest))
 	})
 	if err == nil {
@@ -3715,7 +3715,7 @@ func (h *HandlersV2) createIndex(ctx context.Context, c *gin.Context, anyReq any
 			})
 			return nil, err
 		}
-		resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreateIndex", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+		resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreateIndex", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 			return h.proxy.CreateIndex(reqCtx, req.(*milvuspb.CreateIndexRequest))
 		})
 		if err != nil {
@@ -3736,7 +3736,7 @@ func (h *HandlersV2) dropIndex(ctx context.Context, c *gin.Context, anyReq any, 
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DropIndex", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DropIndex", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.DropIndex(reqCtx, req.(*milvuspb.DropIndexRequest))
 	})
 	if err == nil {
@@ -3759,7 +3759,7 @@ func (h *HandlersV2) alterIndexProperties(ctx context.Context, c *gin.Context, a
 	req.ExtraParams = extraParams
 
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterIndex", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterIndex", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.AlterIndex(reqCtx, req.(*milvuspb.AlterIndexRequest))
 	})
 	if err == nil {
@@ -3777,7 +3777,7 @@ func (h *HandlersV2) dropIndexProperties(ctx context.Context, c *gin.Context, an
 		IndexName:      httpReq.IndexName,
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterIndex", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterIndex", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.AlterIndex(reqCtx, req.(*milvuspb.AlterIndexRequest))
 	})
 	if err == nil {
@@ -3794,7 +3794,7 @@ func (h *HandlersV2) listAlias(ctx context.Context, c *gin.Context, anyReq any, 
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ListAliases", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ListAliases", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.ListAliases(reqCtx, req.(*milvuspb.ListAliasesRequest))
 	})
 	if err == nil {
@@ -3811,7 +3811,7 @@ func (h *HandlersV2) describeAlias(ctx context.Context, c *gin.Context, anyReq a
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DescribeAlias", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DescribeAlias", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.DescribeAlias(reqCtx, req.(*milvuspb.DescribeAliasRequest))
 	})
 	if err == nil {
@@ -3835,7 +3835,7 @@ func (h *HandlersV2) createAlias(ctx context.Context, c *gin.Context, anyReq any
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreateAlias", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreateAlias", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.CreateAlias(reqCtx, req.(*milvuspb.CreateAliasRequest))
 	})
 	if err == nil {
@@ -3852,7 +3852,7 @@ func (h *HandlersV2) dropAlias(ctx context.Context, c *gin.Context, anyReq any, 
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DropAlias", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DropAlias", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.DropAlias(reqCtx, req.(*milvuspb.DropAliasRequest))
 	})
 	if err == nil {
@@ -3871,7 +3871,7 @@ func (h *HandlersV2) alterAlias(ctx context.Context, c *gin.Context, anyReq any,
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterAlias", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterAlias", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.AlterAlias(reqCtx, req.(*milvuspb.AlterAliasRequest))
 	})
 	if err == nil {
@@ -3891,7 +3891,7 @@ func (h *HandlersV2) listImportJob(ctx context.Context, c *gin.Context, anyReq a
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxy(ctx, c, req, false, false, "/milvus.proto.milvus.MilvusService/ListImports", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, false, false, "/milvus.proto.milvus.MilvusService/ListImports", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.ListImports(reqCtx, req.(*internalpb.ListImportsRequest))
 	})
 	if err == nil {
@@ -3907,7 +3907,7 @@ func (h *HandlersV2) listImportJob(ctx context.Context, c *gin.Context, anyReq a
 		for i, jobID := range jobIDs {
 			collection := collections[i]
 			if h.checkAuth {
-				err = checkAuthorizationHelper(ctx, c, &milvuspb.ImportAuthPlaceholder{
+				err = h.checkAuthorizationHelper(ctx, c, &milvuspb.ImportAuthPlaceholder{
 					DbName:         dbName,
 					CollectionName: collection,
 				})
@@ -3951,7 +3951,7 @@ func (h *HandlersV2) createImportJob(ctx context.Context, c *gin.Context, anyReq
 	c.Set(ContextRequest, req)
 
 	if h.checkAuth {
-		err := checkAuthorizationV2(ctx, c, false, &milvuspb.ImportAuthPlaceholder{
+		err := h.checkAuthorizationV2(ctx, c, false, &milvuspb.ImportAuthPlaceholder{
 			DbName:         dbName,
 			CollectionName: collectionGetter.GetCollectionName(),
 			PartitionName:  partitionGetter.GetPartitionName(),
@@ -3961,7 +3961,7 @@ func (h *HandlersV2) createImportJob(ctx context.Context, c *gin.Context, anyReq
 		}
 		ctx = c.Request.Context()
 	}
-	resp, err := wrapperProxy(ctx, c, req, false, false, "/milvus.proto.milvus.MilvusService/Import", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, false, false, "/milvus.proto.milvus.MilvusService/Import", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.ImportV2(reqCtx, req.(*internalpb.ImportRequest))
 	})
 	if err == nil {
@@ -4026,7 +4026,7 @@ func (h *HandlersV2) getImportProgress(ctx context.Context, c *gin.Context, dbNa
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxy(ctx, c, req, false, false, "/milvus.proto.milvus.MilvusService/GetImportProgress", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, false, false, "/milvus.proto.milvus.MilvusService/GetImportProgress", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.GetImportProgress(reqCtx, req.(*internalpb.GetImportProgressRequest))
 	})
 	if err != nil {
@@ -4040,7 +4040,7 @@ func (h *HandlersV2) checkImportPrivilege(ctx context.Context, c *gin.Context, d
 		return nil
 	}
 
-	authErr := checkAuthorizationHelper(ctx, c, &milvuspb.ImportAuthPlaceholder{
+	authErr := h.checkAuthorizationHelper(ctx, c, &milvuspb.ImportAuthPlaceholder{
 		DbName:         dbName,
 		CollectionName: collectionName,
 	})
@@ -4078,7 +4078,7 @@ func (h *HandlersV2) restoreExternalSnapshot(ctx context.Context, c *gin.Context
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/RestoreExternalSnapshot", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/RestoreExternalSnapshot", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.RestoreExternalSnapshot(reqCtx, req.(*milvuspb.RestoreExternalSnapshotRequest))
 	})
 	if err == nil {
@@ -4101,7 +4101,7 @@ func (h *HandlersV2) exportSnapshot(ctx context.Context, c *gin.Context, anyReq 
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ExportSnapshot", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ExportSnapshot", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.ExportSnapshot(reqCtx, req.(*milvuspb.ExportSnapshotRequest))
 	})
 	if err == nil {
@@ -4147,7 +4147,7 @@ func (h *HandlersV2) getExportSnapshotState(ctx context.Context, c *gin.Context,
 		JobId: jobID,
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/GetExportSnapshotState", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/GetExportSnapshotState", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.GetExportSnapshotState(reqCtx, req.(*milvuspb.GetExportSnapshotStateRequest))
 	})
 	if err == nil {
@@ -4189,7 +4189,7 @@ func (h *HandlersV2) getRestoreSnapshotState(ctx context.Context, c *gin.Context
 		JobId: jobID,
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/GetRestoreSnapshotState", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/GetRestoreSnapshotState", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.GetRestoreSnapshotState(reqCtx, req.(*milvuspb.GetRestoreSnapshotStateRequest))
 	})
 	if err == nil {
@@ -4209,7 +4209,7 @@ func (h *HandlersV2) listRestoreSnapshotJobs(ctx context.Context, c *gin.Context
 		CollectionName: httpReq.GetCollectionName(),
 	}
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ListRestoreSnapshotJobs", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ListRestoreSnapshotJobs", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.ListRestoreSnapshotJobs(reqCtx, req.(*milvuspb.ListRestoreSnapshotJobsRequest))
 	})
 	if err == nil {
@@ -4236,7 +4236,7 @@ func (h *HandlersV2) refreshExternalCollection(ctx context.Context, c *gin.Conte
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/RefreshExternalCollection", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/RefreshExternalCollection", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.RefreshExternalCollection(reqCtx, req.(*milvuspb.RefreshExternalCollectionRequest))
 	})
 	if err == nil {
@@ -4267,7 +4267,7 @@ func (h *HandlersV2) commitImportJob(ctx context.Context, c *gin.Context, anyReq
 	c.Set(ContextRequest, req)
 	// Internal DataCoord-only RPC; not exposed on MilvusService. Use the real
 	// proto package in the trace/metric label so it reflects the actual method.
-	resp, err := wrapperProxy(ctx, c, req, false, false,
+	resp, err := h.wrapperProxy(ctx, c, req, false, false,
 		"/milvus.proto.data.DataCoord/CommitImport",
 		func(reqCtx context.Context, req any) (interface{}, error) {
 			return h.proxy.CommitImport(reqCtx, req.(*datapb.CommitImportRequest))
@@ -4285,7 +4285,7 @@ func (h *HandlersV2) getRefreshExternalCollectionProgress(ctx context.Context, c
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxy(ctx, c, req, false, false, "/milvus.proto.milvus.MilvusService/GetRefreshExternalCollectionProgress", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, false, false, "/milvus.proto.milvus.MilvusService/GetRefreshExternalCollectionProgress", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.GetRefreshExternalCollectionProgress(reqCtx, req.(*milvuspb.GetRefreshExternalCollectionProgressRequest))
 	})
 	if err == nil {
@@ -4313,7 +4313,7 @@ func (h *HandlersV2) abortImportJob(ctx context.Context, c *gin.Context, anyReq 
 	}
 	c.Set(ContextRequest, req)
 	// Internal DataCoord-only RPC; not exposed on MilvusService.
-	resp, err := wrapperProxy(ctx, c, req, false, false,
+	resp, err := h.wrapperProxy(ctx, c, req, false, false,
 		"/milvus.proto.data.DataCoord/AbortImport",
 		func(reqCtx context.Context, req any) (interface{}, error) {
 			return h.proxy.AbortImport(reqCtx, req.(*datapb.AbortImportRequest))
@@ -4332,7 +4332,7 @@ func (h *HandlersV2) listRefreshExternalCollectionJobs(ctx context.Context, c *g
 	}
 	c.Set(ContextRequest, req)
 
-	resp, err := wrapperProxy(ctx, c, req, false, false, "/milvus.proto.milvus.MilvusService/ListRefreshExternalCollectionJobs", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, false, false, "/milvus.proto.milvus.MilvusService/ListRefreshExternalCollectionJobs", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.ListRefreshExternalCollectionJobs(reqCtx, req.(*milvuspb.ListRefreshExternalCollectionJobsRequest))
 	})
 	if err == nil {
@@ -4374,7 +4374,7 @@ func (h *HandlersV2) GetCollectionSchema(ctx context.Context, c *gin.Context, db
 		DbName:         dbName,
 		CollectionName: collectionName,
 	}
-	descResp, err := wrapperProxy(ctx, c, descReq, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DescribeCollection", func(reqCtx context.Context, req any) (interface{}, error) {
+	descResp, err := h.wrapperProxy(ctx, c, descReq, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DescribeCollection", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.DescribeCollection(reqCtx, req.(*milvuspb.DescribeCollectionRequest))
 	})
 	if err != nil {
@@ -4392,7 +4392,7 @@ func (h *HandlersV2) getSegmentsInfo(ctx context.Context, c *gin.Context, anyReq
 		SegmentIDs:   httpReq.GetSegmentIDs(),
 	}
 
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/GetSegmentsInfo", func(reqCtx context.Context, req any) (any, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/GetSegmentsInfo", func(reqCtx context.Context, req any) (any, error) {
 		return h.proxy.GetSegmentsInfo(reqCtx, req.(*internalpb.GetSegmentsInfoRequest))
 	})
 
@@ -4433,7 +4433,7 @@ func (h *HandlersV2) getSegmentsInfo(ctx context.Context, c *gin.Context, anyReq
 
 func (h *HandlersV2) getQuotaMetrics(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
 	req := &internalpb.GetQuotaMetricsRequest{}
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/GetQuotaMetrics", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/GetQuotaMetrics", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.GetQuotaMetrics(reqCtx, req.(*internalpb.GetQuotaMetricsRequest))
 	})
 	if err == nil {
@@ -4465,7 +4465,7 @@ func (h *HandlersV2) runAnalyzer(ctx context.Context, c *gin.Context, anyReq any
 	}
 
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/RunAnalyzer", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/RunAnalyzer", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.RunAnalyzer(reqCtx, req.(*milvuspb.RunAnalyzerRequest))
 	})
 

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -43,6 +44,7 @@ import (
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/proxy"
 	"github.com/milvus-io/milvus/internal/proxy/accesslog"
+	"github.com/milvus-io/milvus/internal/proxy/privilege"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/pkg/v3/common"
@@ -50,8 +52,10 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/crypto"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 const (
@@ -295,6 +299,7 @@ func TestTraceLogRequestFieldRedactsRESTPasswords(t *testing.T) {
 }
 
 func TestHTTPWrapper(t *testing.T) {
+	h := &HandlersV2{metaCache: func() proxy.Cache { return nil }}
 	postTestCases := []requestBodyTestCase{}
 	postTestCasesTrace := []requestBodyTestCase{}
 	ginHandler := gin.Default()
@@ -351,7 +356,7 @@ func TestHTTPWrapper(t *testing.T) {
 	})
 	path = "/wrapper/post/trace/call"
 	app.POST(path, wrapperPost(func() any { return &DefaultReq{} }, wrapperTraceLog(func(ctx context.Context, c *gin.Context, req any, dbName string) (interface{}, error) {
-		return wrapperProxy(ctx, c, req, false, false, "", func(reqctx context.Context, req any) (any, error) {
+		return h.wrapperProxy(ctx, c, req, false, false, "", func(reqctx context.Context, req any) (any, error) {
 			return nil, nil
 		})
 	})))
@@ -399,6 +404,7 @@ func TestHTTPWrapper(t *testing.T) {
 }
 
 func TestGrpcWrapper(t *testing.T) {
+	h := &HandlersV2{metaCache: func() proxy.Cache { return nil }}
 	getTestCases := []rawTestCase{}
 	getTestCasesNeedAuth := []rawTestCase{}
 	needAuthPrefix := "/auth"
@@ -411,12 +417,12 @@ func TestGrpcWrapper(t *testing.T) {
 	}
 	app.GET(path, func(c *gin.Context) {
 		ctx := proxy.NewContextWithMetadata(c, "", DefaultDbName)
-		wrapperProxy(ctx, c, &DefaultReq{}, false, false, "", handle)
+		h.wrapperProxy(ctx, c, &DefaultReq{}, false, false, "", handle)
 	})
 	appNeedAuth.GET(path, func(c *gin.Context) {
 		username, _ := c.Get(ContextUsername)
 		ctx := proxy.NewContextWithMetadata(c, username.(string), DefaultDbName)
-		wrapperProxy(ctx, c, &milvuspb.DescribeCollectionRequest{}, true, false, "", handle)
+		h.wrapperProxy(ctx, c, &milvuspb.DescribeCollectionRequest{}, true, false, "", handle)
 	})
 	getTestCases = append(getTestCases, rawTestCase{
 		path: path,
@@ -430,12 +436,12 @@ func TestGrpcWrapper(t *testing.T) {
 	}
 	app.GET(path, func(c *gin.Context) {
 		ctx := proxy.NewContextWithMetadata(c, "", DefaultDbName)
-		wrapperProxy(ctx, c, &DefaultReq{}, false, false, "", handle)
+		h.wrapperProxy(ctx, c, &DefaultReq{}, false, false, "", handle)
 	})
 	appNeedAuth.GET(path, func(c *gin.Context) {
 		username, _ := c.Get(ContextUsername)
 		ctx := proxy.NewContextWithMetadata(c, username.(string), DefaultDbName)
-		wrapperProxy(ctx, c, &milvuspb.DescribeCollectionRequest{}, true, false, "", handle)
+		h.wrapperProxy(ctx, c, &milvuspb.DescribeCollectionRequest{}, true, false, "", handle)
 	})
 	getTestCases = append(getTestCases, rawTestCase{
 		path:    path,
@@ -452,12 +458,12 @@ func TestGrpcWrapper(t *testing.T) {
 	}
 	app.GET(path, func(c *gin.Context) {
 		ctx := proxy.NewContextWithMetadata(c, "", DefaultDbName)
-		wrapperProxy(ctx, c, &DefaultReq{}, false, false, "", handle)
+		h.wrapperProxy(ctx, c, &DefaultReq{}, false, false, "", handle)
 	})
 	appNeedAuth.GET(path, func(c *gin.Context) {
 		username, _ := c.Get(ContextUsername)
 		ctx := proxy.NewContextWithMetadata(c, username.(string), DefaultDbName)
-		wrapperProxy(ctx, c, &milvuspb.DescribeCollectionRequest{}, true, false, "", handle)
+		h.wrapperProxy(ctx, c, &milvuspb.DescribeCollectionRequest{}, true, false, "", handle)
 	})
 	getTestCases = append(getTestCases, rawTestCase{
 		path: path,
@@ -476,12 +482,12 @@ func TestGrpcWrapper(t *testing.T) {
 	}
 	app.GET(path, func(c *gin.Context) {
 		ctx := proxy.NewContextWithMetadata(c, "", DefaultDbName)
-		wrapperProxy(ctx, c, &DefaultReq{}, false, false, "", handle)
+		h.wrapperProxy(ctx, c, &DefaultReq{}, false, false, "", handle)
 	})
 	appNeedAuth.GET(path, func(c *gin.Context) {
 		username, _ := c.Get(ContextUsername)
 		ctx := proxy.NewContextWithMetadata(c, username.(string), DefaultDbName)
-		wrapperProxy(ctx, c, &milvuspb.DescribeCollectionRequest{}, true, false, "", handle)
+		h.wrapperProxy(ctx, c, &milvuspb.DescribeCollectionRequest{}, true, false, "", handle)
 	})
 	getTestCases = append(getTestCases, rawTestCase{
 		path:    path,
@@ -528,11 +534,11 @@ func TestGrpcWrapper(t *testing.T) {
 
 	path = "/wrapper/grpc/auth"
 	app.GET(path, func(c *gin.Context) {
-		wrapperProxy(context.Background(), c, &milvuspb.DescribeCollectionRequest{}, true, false, "", handle)
+		h.wrapperProxy(context.Background(), c, &milvuspb.DescribeCollectionRequest{}, true, false, "", handle)
 	})
 	appNeedAuth.GET(path, func(c *gin.Context) {
 		ctx := proxy.NewContextWithMetadata(c, "test", DefaultDbName)
-		wrapperProxy(ctx, c, &milvuspb.LoadCollectionRequest{}, true, false, "", handle)
+		h.wrapperProxy(ctx, c, &milvuspb.LoadCollectionRequest{}, true, false, "", handle)
 	})
 	t.Run("check authorization", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, path, nil)
@@ -3995,6 +4001,138 @@ func TestCreateImportJobPreservesRBACRoleContext(t *testing.T) {
 	err := json.Unmarshal(w.Body.Bytes(), returnBody)
 	assert.NoError(t, err)
 	assert.Equal(t, merr.Code(nil), returnBody.Code)
+}
+
+// newRESTV2ServerForRBACTest builds a v2 REST server whose auth middleware sets
+// the parsed username directly, without re-initializing the proxy privilege
+// cache (genAuthMiddleWare resets it, which would wipe test grants).
+func newRESTV2ServerForRBACTest(t *testing.T, pxy types.ProxyComponent) *gin.Engine {
+	t.Helper()
+	h := NewHandlersV2(pxy)
+	ginHandler := gin.Default()
+	appV2 := ginHandler.Group("/v2/vectordb", func(c *gin.Context) {
+		username, _, ok := ParseUsernamePassword(c)
+		if !ok || username == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{HTTPReturnCode: merr.Code(merr.ErrNeedAuthenticate), HTTPReturnMessage: merr.ErrNeedAuthenticate.Error()})
+			return
+		}
+		c.Set(ContextUsername, username)
+	})
+	h.RegisterRoutesToV2(appV2)
+	return ginHandler
+}
+
+// TestRESTV2AliasRBAC guards the alias-resolution wiring of the REST v2
+// authorization path: the handlers must authorize through the injected
+// MetaCache (PrivilegeInterceptorWithMetaCache), not a nil one, so a role
+// granted on the real collection is honored when the request addresses the
+// collection through an alias.
+func TestRESTV2AliasRBAC(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(proxy.Params.CommonCfg.AuthorizationEnabled.Key, "true")
+	t.Cleanup(func() { paramtable.Get().Reset(proxy.Params.CommonCfg.AuthorizationEnabled.Key) })
+	paramtable.Get().Save(proxy.Params.ProxyCfg.ResolveAliasForPrivilege.Key, "true")
+	t.Cleanup(func() { paramtable.Get().Reset(proxy.Params.ProxyCfg.ResolveAliasForPrivilege.Key) })
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	t.Cleanup(func() { paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key) })
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	t.Cleanup(func() { paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key) })
+
+	const (
+		username = "alice"
+		role     = "role_reader"
+		alias    = "orders_current"
+		realCol  = "orders"
+	)
+
+	cache := proxy.InitEmptyMetaCacheForTest()
+	require.NotNil(t, cache)
+	patch := mockey.Mock((*proxy.MetaCache).ResolveCollectionAlias).Return(realCol, nil).Build()
+	t.Cleanup(func() { patch.UnPatch() })
+
+	privCache := privilege.GetPrivilegeCache()
+	require.NotNil(t, privCache)
+	require.NoError(t, privCache.RefreshPolicyInfo(typeutil.CacheOp{
+		OpType: typeutil.CacheGrantPrivilege,
+		OpKey:  funcutil.PolicyForPrivilege(role, commonpb.ObjectType_Collection.String(), realCol, commonpb.ObjectPrivilege_PrivilegeLoad.String(), util.DefaultDBName),
+	}))
+	require.NoError(t, privCache.RefreshPolicyInfo(typeutil.CacheOp{
+		OpType: typeutil.CacheAddUserToRole,
+		OpKey:  funcutil.EncodeUserRoleCache(username, role),
+	}))
+
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().LoadCollection(mock.Anything, mock.Anything).Return(commonSuccessStatus, nil).Twice()
+	testEngine := newRESTV2ServerForRBACTest(t, proxyComponentWithMetaCache{ProxyComponent: mp, metaCache: cache})
+
+	loadPath := versionalV2(CollectionCategory, LoadAction)
+	for _, tc := range []struct {
+		name string
+		coll string
+	}{
+		{"real collection name", realCol},
+		{"alias resolves to the granted collection", alias},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := bytes.NewReader([]byte(`{"collectionName": "` + tc.coll + `"}`))
+			req := httptest.NewRequest(http.MethodPost, loadPath, body)
+			req.SetBasicAuth(username, "pwd")
+			w := httptest.NewRecorder()
+			testEngine.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+			returnBody := &ReturnErrMsg{}
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody))
+			assert.Equal(t, merr.Code(nil), returnBody.Code, w.Body.String())
+		})
+	}
+}
+
+// TestRESTV2AliasRBAC_GrantOnAliasStringDenied verifies the inverse: a grant
+// scoped to the alias string must NOT authorize access through the alias, since
+// the alias is resolved to the real collection before enforcement.
+func TestRESTV2AliasRBAC_GrantOnAliasStringDenied(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(proxy.Params.CommonCfg.AuthorizationEnabled.Key, "true")
+	t.Cleanup(func() { paramtable.Get().Reset(proxy.Params.CommonCfg.AuthorizationEnabled.Key) })
+	paramtable.Get().Save(proxy.Params.ProxyCfg.ResolveAliasForPrivilege.Key, "true")
+	t.Cleanup(func() { paramtable.Get().Reset(proxy.Params.ProxyCfg.ResolveAliasForPrivilege.Key) })
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	t.Cleanup(func() { paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key) })
+
+	const (
+		username = "alice"
+		role     = "role_reader"
+		alias    = "orders_current"
+		realCol  = "orders"
+	)
+
+	cache := proxy.InitEmptyMetaCacheForTest()
+	require.NotNil(t, cache)
+	patch := mockey.Mock((*proxy.MetaCache).ResolveCollectionAlias).Return(realCol, nil).Build()
+	t.Cleanup(func() { patch.UnPatch() })
+
+	privCache := privilege.GetPrivilegeCache()
+	require.NotNil(t, privCache)
+	require.NoError(t, privCache.RefreshPolicyInfo(typeutil.CacheOp{
+		OpType: typeutil.CacheGrantPrivilege,
+		OpKey:  funcutil.PolicyForPrivilege(role, commonpb.ObjectType_Collection.String(), alias, commonpb.ObjectPrivilege_PrivilegeLoad.String(), util.DefaultDBName),
+	}))
+	require.NoError(t, privCache.RefreshPolicyInfo(typeutil.CacheOp{
+		OpType: typeutil.CacheAddUserToRole,
+		OpKey:  funcutil.EncodeUserRoleCache(username, role),
+	}))
+
+	mp := mocks.NewMockProxy(t)
+	testEngine := newRESTV2ServerForRBACTest(t, proxyComponentWithMetaCache{ProxyComponent: mp, metaCache: cache})
+
+	body := bytes.NewReader([]byte(`{"collectionName": "` + alias + `"}`))
+	req := httptest.NewRequest(http.MethodPost, versionalV2(CollectionCategory, LoadAction), body)
+	req.SetBasicAuth(username, "pwd")
+	w := httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code, w.Body.String())
+	mp.AssertNotCalled(t, "LoadCollection", mock.Anything, mock.Anything)
 }
 
 func validateTestCases(t *testing.T, testEngine *gin.Engine, queryTestCases []requestBodyTestCase, allowInt64 bool) {

--- a/internal/distributed/proxy/httpserver/resource_group_handler_v2.go
+++ b/internal/distributed/proxy/httpserver/resource_group_handler_v2.go
@@ -85,7 +85,7 @@ func (h *HandlersV2) createResourceGroup(ctx context.Context, c *gin.Context, an
 		ResourceGroup: httpReq.GetName(),
 		Config:        toPbResourceGroupConfig(httpReq.GetConfig()),
 	}
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreateResourceGroup", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/CreateResourceGroup", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.CreateResourceGroup(reqCtx, req.(*milvuspb.CreateResourceGroupRequest))
 	})
 	if err == nil {
@@ -99,7 +99,7 @@ func (h *HandlersV2) dropResourceGroup(ctx context.Context, c *gin.Context, anyR
 	req := &milvuspb.DropResourceGroupRequest{
 		ResourceGroup: httpReq.GetName(),
 	}
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DropResourceGroup", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DropResourceGroup", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.DropResourceGroup(reqCtx, req.(*milvuspb.DropResourceGroupRequest))
 	})
 	if err == nil {
@@ -110,7 +110,7 @@ func (h *HandlersV2) dropResourceGroup(ctx context.Context, c *gin.Context, anyR
 
 func (h *HandlersV2) listResourceGroups(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
 	req := &milvuspb.ListResourceGroupsRequest{}
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ListResourceGroups", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ListResourceGroups", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.ListResourceGroups(reqCtx, req.(*milvuspb.ListResourceGroupsRequest))
 	})
 	if err == nil {
@@ -124,7 +124,7 @@ func (h *HandlersV2) describeResourceGroup(ctx context.Context, c *gin.Context, 
 	req := &milvuspb.DescribeResourceGroupRequest{
 		ResourceGroup: httpReq.GetName(),
 	}
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DescribeResourceGroup", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DescribeResourceGroup", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.DescribeResourceGroup(reqCtx, req.(*milvuspb.DescribeResourceGroupRequest))
 	})
 	if err == nil {
@@ -143,7 +143,7 @@ func (h *HandlersV2) updateResourceGroup(ctx context.Context, c *gin.Context, an
 			return toPbResourceGroupConfig(config)
 		}),
 	}
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/UpdateResourceGroups", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/UpdateResourceGroups", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.UpdateResourceGroups(reqCtx, req.(*milvuspb.UpdateResourceGroupsRequest))
 	})
 	if err == nil {
@@ -160,7 +160,7 @@ func (h *HandlersV2) transferReplica(ctx context.Context, c *gin.Context, anyReq
 		CollectionName:      httpReq.GetCollectionName(),
 		NumReplica:          httpReq.GetReplicaNum(),
 	}
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/TransferMaster", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := h.wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/TransferMaster", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.TransferReplica(reqCtx, req.(*milvuspb.TransferReplicaRequest))
 	})
 	if err == nil {

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -4479,7 +4479,7 @@ func CheckLimiter(ctx context.Context, req interface{}, pxy types.ProxyComponent
 	}
 
 	metaCache := getProxyMetaCache(pxy)
-	dbID, collectionIDToPartIDs, rt, n, err := proxy.GetRequestInfo(ctx, metaCache, request)
+	dbID, collectionIDToPartIDs, rt, n, err := proxy.GetRequestInfo(ctx, metaCache(), request)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -4478,7 +4478,8 @@ func CheckLimiter(ctx context.Context, req interface{}, pxy types.ProxyComponent
 		return nil, merr.WrapErrParameterInvalidMsg("wrong req format when check limiter")
 	}
 
-	dbID, collectionIDToPartIDs, rt, n, err := proxy.GetRequestInfo(ctx, request)
+	metaCache := getProxyMetaCache(pxy)
+	dbID, collectionIDToPartIDs, rt, n, err := proxy.GetRequestInfo(ctx, metaCache, request)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -311,7 +311,7 @@ func (s *Server) startExternalGrpc(errChan chan error) {
 			proxy.DatabaseInterceptor(),
 			UnaryRequestStatsInterceptor,
 			accesslog.UnaryAccessLogInterceptor,
-			proxy.GrpcAuthInterceptor(proxy.AuthenticationInterceptor),
+			proxy.GrpcAuthInterceptor(proxy.AuthenticationInterceptorWithMetaCache(getMetaCache)),
 			proxy.UnaryServerInterceptor(proxy.PrivilegeInterceptorWithMetaCache(getMetaCache)),
 			proxy.UnaryServerHookInterceptor(),
 			mlog.UnaryServerInterceptor(typeutil.ProxyRole),

--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -290,6 +290,11 @@ func (s *Server) startExternalGrpc(errChan chan error) {
 	}
 	mlog.Debug(context.TODO(), "Get proxy rate limiter done")
 
+	var metaCache proxy.Cache
+	if metaCacheProvider, ok := s.proxy.(interface{ GetMetaCache() proxy.Cache }); ok {
+		metaCache = metaCacheProvider.GetMetaCache()
+	}
+
 	var unaryServerOption grpc.ServerOption
 	if enableCustomInterceptor {
 		unaryServerOption = grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
@@ -298,10 +303,10 @@ func (s *Server) startExternalGrpc(errChan chan error) {
 			UnaryRequestStatsInterceptor,
 			accesslog.UnaryAccessLogInterceptor,
 			proxy.GrpcAuthInterceptor(proxy.AuthenticationInterceptor),
-			proxy.UnaryServerInterceptor(proxy.PrivilegeInterceptor),
+			proxy.UnaryServerInterceptor(proxy.PrivilegeInterceptorWithMetaCache(metaCache)),
 			proxy.UnaryServerHookInterceptor(),
 			mlog.UnaryServerInterceptor(typeutil.ProxyRole),
-			proxy.RateLimitInterceptor(limiter),
+			proxy.RateLimitInterceptorWithMetaCache(metaCache, limiter),
 			accesslog.UnaryUpdateAccessInfoInterceptor,
 			proxy.TraceLogInterceptor,
 			connection.KeepActiveInterceptor,

--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -290,9 +290,18 @@ func (s *Server) startExternalGrpc(errChan chan error) {
 	}
 	mlog.Debug(context.TODO(), "Get proxy rate limiter done")
 
-	var metaCache proxy.Cache
-	if metaCacheProvider, ok := s.proxy.(interface{ GetMetaCache() proxy.Cache }); ok {
-		metaCache = metaCacheProvider.GetMetaCache()
+	// The meta cache is initialized in Proxy.Init(), which runs after this interceptor
+	// chain is constructed. Resolve it per request so rate limiting / privilege checks
+	// observe the live cache instead of a construction-time nil snapshot.
+	var metaCacheProvider interface{ GetMetaCache() proxy.Cache }
+	if provider, ok := s.proxy.(interface{ GetMetaCache() proxy.Cache }); ok {
+		metaCacheProvider = provider
+	}
+	getMetaCache := func() proxy.Cache {
+		if metaCacheProvider == nil {
+			return nil
+		}
+		return metaCacheProvider.GetMetaCache()
 	}
 
 	var unaryServerOption grpc.ServerOption
@@ -303,10 +312,10 @@ func (s *Server) startExternalGrpc(errChan chan error) {
 			UnaryRequestStatsInterceptor,
 			accesslog.UnaryAccessLogInterceptor,
 			proxy.GrpcAuthInterceptor(proxy.AuthenticationInterceptor),
-			proxy.UnaryServerInterceptor(proxy.PrivilegeInterceptorWithMetaCache(metaCache)),
+			proxy.UnaryServerInterceptor(proxy.PrivilegeInterceptorWithMetaCache(getMetaCache)),
 			proxy.UnaryServerHookInterceptor(),
 			mlog.UnaryServerInterceptor(typeutil.ProxyRole),
-			proxy.RateLimitInterceptorWithMetaCache(metaCache, limiter),
+			proxy.RateLimitInterceptorWithMetaCache(getMetaCache, limiter),
 			accesslog.UnaryUpdateAccessInfoInterceptor,
 			proxy.TraceLogInterceptor,
 			connection.KeepActiveInterceptor,

--- a/internal/proxy/alias_rbac_test.go
+++ b/internal/proxy/alias_rbac_test.go
@@ -44,10 +44,6 @@ func TestResolveCollectionAlias_WildcardAndEmptySkippedByInterceptor(t *testing.
 
 	cache := mustNewMetaCacheForTest(mockCoord)
 
-	oldCache := globalMetaCache
-	globalMetaCache = cache
-	defer func() { globalMetaCache = oldCache }()
-
 	// Wildcard "*" should not trigger resolution
 	for _, sentinel := range []string{"*", ""} {
 		// These sentinel values should be caught by the interceptor guard
@@ -67,7 +63,7 @@ func TestResolveCollectionAlias_WildcardAndEmptySkippedByInterceptor(t *testing.
 		Aliases:      []string{"some_alias"},
 	}, nil)
 
-	result, err := resolveCollectionAlias(ctx, "default", "some_alias")
+	result, err := resolveCollectionAlias(ctx, cache, "default", "some_alias")
 	assert.NoError(t, err)
 	assert.Equal(t, "real_col", result)
 	mockCoord.AssertCalled(t, "DescribeCollection", mock.Anything, mock.Anything)
@@ -158,11 +154,8 @@ func TestResolveCollectionAlias_InternalServerError(t *testing.T) {
 
 func TestResolveCollectionAlias_NilGlobalMetaCache(t *testing.T) {
 	ctx := context.Background()
-	oldCache := globalMetaCache
-	globalMetaCache = nil
-	defer func() { globalMetaCache = oldCache }()
 
-	result, err := resolveCollectionAlias(ctx, "default", "test")
+	result, err := resolveCollectionAlias(ctx, nil, "default", "test")
 	assert.Error(t, err)
 	assert.Equal(t, "test", result)
 }
@@ -348,13 +341,12 @@ func TestCreateAliasTask_ResolvesCollectionAlias(t *testing.T) {
 	seedCollection(cache, "default", "real_collection", 1).Aliases = []string{"existing_alias"}
 	cache.SetAliasLockedForTest("default", "existing_alias", "real_collection")
 
-	oldCache := globalMetaCache
-	globalMetaCache = cache
-	defer func() { globalMetaCache = oldCache }()
-
 	paramtable.Init()
 
 	task := &CreateAliasTask{
+		baseTask: baseTask{
+			metaCache: cache,
+		},
 		Condition: NewTaskCondition(ctx),
 		CreateAliasRequest: &milvuspb.CreateAliasRequest{
 			Base:           &commonpb.MsgBase{},
@@ -383,13 +375,12 @@ func TestAlterAliasTask_ResolvesCollectionAlias(t *testing.T) {
 	seedCollection(cache, "default", "real_collection", 1).Aliases = []string{"existing_alias"}
 	cache.SetAliasLockedForTest("default", "existing_alias", "real_collection")
 
-	oldCache := globalMetaCache
-	globalMetaCache = cache
-	defer func() { globalMetaCache = oldCache }()
-
 	paramtable.Init()
 
 	task := &AlterAliasTask{
+		baseTask: baseTask{
+			metaCache: cache,
+		},
 		Condition: NewTaskCondition(ctx),
 		AlterAliasRequest: &milvuspb.AlterAliasRequest{
 			Base:           &commonpb.MsgBase{},
@@ -419,15 +410,14 @@ func TestCreateAliasTask_ResolvesEvenWhenRBACFlagDisabled(t *testing.T) {
 	seedCollection(cache, "default", "real_collection", 1).Aliases = []string{"existing_alias"}
 	cache.SetAliasLockedForTest("default", "existing_alias", "real_collection")
 
-	oldCache := globalMetaCache
-	globalMetaCache = cache
-	defer func() { globalMetaCache = oldCache }()
-
 	paramtable.Init()
 	paramtable.Get().Save(Params.ProxyCfg.ResolveAliasForPrivilege.Key, "false")
 	defer paramtable.Get().Reset(Params.ProxyCfg.ResolveAliasForPrivilege.Key)
 
 	task := &CreateAliasTask{
+		baseTask: baseTask{
+			metaCache: cache,
+		},
 		Condition: NewTaskCondition(ctx),
 		CreateAliasRequest: &milvuspb.CreateAliasRequest{
 			Base:           &commonpb.MsgBase{},
@@ -456,13 +446,12 @@ func TestListAliasesTask_ResolvesCollectionAlias(t *testing.T) {
 	seedCollection(cache, "default", "real_collection", 1).Aliases = []string{"existing_alias"}
 	cache.SetAliasLockedForTest("default", "existing_alias", "real_collection")
 
-	oldCache := globalMetaCache
-	globalMetaCache = cache
-	defer func() { globalMetaCache = oldCache }()
-
 	paramtable.Init()
 
 	task := &ListAliasesTask{
+		baseTask: baseTask{
+			metaCache: cache,
+		},
 		Condition: NewTaskCondition(ctx),
 		ListAliasesRequest: &milvuspb.ListAliasesRequest{
 			Base:           &commonpb.MsgBase{},
@@ -485,13 +474,12 @@ func TestListAliasesTask_NoResolveWhenCollectionNameEmpty(t *testing.T) {
 
 	cache := mustNewMetaCacheForTest(mockCoord)
 
-	oldCache := globalMetaCache
-	globalMetaCache = cache
-	defer func() { globalMetaCache = oldCache }()
-
 	paramtable.Init()
 
 	task := &ListAliasesTask{
+		baseTask: baseTask{
+			metaCache: cache,
+		},
 		Condition: NewTaskCondition(ctx),
 		ListAliasesRequest: &milvuspb.ListAliasesRequest{
 			Base:   &commonpb.MsgBase{},

--- a/internal/proxy/authentication_interceptor.go
+++ b/internal/proxy/authentication_interceptor.go
@@ -51,53 +51,62 @@ func GrpcAuthInterceptor(authFunc grpc_auth.AuthFunc) grpc.UnaryServerIntercepto
 	}
 }
 
-// AuthenticationInterceptor verify based on kv pair <"authorization": "token"> in header
-func AuthenticationInterceptor(ctx context.Context) (context.Context, error) {
-	// The keys within metadata.MD are normalized to lowercase.
-	// See: https://godoc.org/google.golang.org/grpc/metadata#New
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return nil, merr.WrapErrIoKeyNotFound("metadata", "auth check failure, due to occurs inner error: missing metadata")
-	}
-	// check rpc call from sdk
-	if Params.CommonCfg.AuthorizationEnabled.GetAsBool() {
-		authStrArr := md[strings.ToLower(util.HeaderAuthorize)]
-
-		if len(authStrArr) < 1 {
-			mlog.Warn(ctx, "key not found in header")
-			return nil, status.Error(codes.Unauthenticated, "missing authorization in header")
+// AuthenticationInterceptorWithMetaCache returns an authentication interceptor
+// that verifies request identity against the injected meta cache. It also acts
+// as a readiness gate: until the proxy has published its meta cache (in
+// Proxy.Init), all requests are rejected with ServiceUnavailable, mirroring the
+// previous globalMetaCache == nil check that this PR's per-proxy cache removed.
+func AuthenticationInterceptorWithMetaCache(getMetaCache func() Cache) grpc_auth.AuthFunc {
+	return func(ctx context.Context) (context.Context, error) {
+		// The keys within metadata.MD are normalized to lowercase.
+		// See: https://godoc.org/google.golang.org/grpc/metadata#New
+		md, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			return nil, merr.WrapErrIoKeyNotFound("metadata", "auth check failure, due to occurs inner error: missing metadata")
 		}
-
-		// token format: base64<username:password>
-		// token := strings.TrimPrefix(authorization[0], "Bearer ")
-		token := authStrArr[0]
-		rawToken, err := crypto.Base64Decode(token)
-		if err != nil {
-			mlog.Warn(ctx, "fail to decode the token", mlog.Err(err))
-			return nil, status.Error(codes.Unauthenticated, "invalid token format")
+		if getMetaCache() == nil {
+			return nil, merr.WrapErrServiceUnavailable("internal: Milvus Proxy is not ready yet. please wait")
 		}
+		// check rpc call from sdk
+		if Params.CommonCfg.AuthorizationEnabled.GetAsBool() {
+			authStrArr := md[strings.ToLower(util.HeaderAuthorize)]
 
-		if !strings.Contains(rawToken, util.CredentialSeparator) {
-			user, err := VerifyAPIKey(rawToken)
+			if len(authStrArr) < 1 {
+				mlog.Warn(ctx, "key not found in header")
+				return nil, status.Error(codes.Unauthenticated, "missing authorization in header")
+			}
+
+			// token format: base64<username:password>
+			// token := strings.TrimPrefix(authorization[0], "Bearer ")
+			token := authStrArr[0]
+			rawToken, err := crypto.Base64Decode(token)
 			if err != nil {
-				mlog.Warn(ctx, "fail to verify apikey", mlog.Err(err))
-				return nil, status.Error(codes.Unauthenticated, "auth check failure, please check api key is correct")
+				mlog.Warn(ctx, "fail to decode the token", mlog.Err(err))
+				return nil, status.Error(codes.Unauthenticated, "invalid token format")
 			}
-			metrics.UserRPCCounter.WithLabelValues(user).Inc()
-			userToken := fmt.Sprintf("%s%s%s", user, util.CredentialSeparator, util.PasswordHolder)
-			md[strings.ToLower(util.HeaderAuthorize)] = []string{crypto.Base64Encode(userToken)}
-			md[util.HeaderToken] = []string{rawToken}
-			ctx = metadata.NewIncomingContext(ctx, md)
-		} else {
-			// username+password authentication
-			username, password := parseMD(rawToken)
-			if !passwordVerify(ctx, username, password, privilege.GetPrivilegeCache()) {
-				mlog.Warn(ctx, "fail to verify password", mlog.String("username", username))
-				// NOTE: don't use the merr, because it will cause the wrong retry behavior in the sdk
-				return nil, status.Error(codes.Unauthenticated, "auth check failure, please check username and password are correct")
+
+			if !strings.Contains(rawToken, util.CredentialSeparator) {
+				user, err := VerifyAPIKey(rawToken)
+				if err != nil {
+					mlog.Warn(ctx, "fail to verify apikey", mlog.Err(err))
+					return nil, status.Error(codes.Unauthenticated, "auth check failure, please check api key is correct")
+				}
+				metrics.UserRPCCounter.WithLabelValues(user).Inc()
+				userToken := fmt.Sprintf("%s%s%s", user, util.CredentialSeparator, util.PasswordHolder)
+				md[strings.ToLower(util.HeaderAuthorize)] = []string{crypto.Base64Encode(userToken)}
+				md[util.HeaderToken] = []string{rawToken}
+				ctx = metadata.NewIncomingContext(ctx, md)
+			} else {
+				// username+password authentication
+				username, password := parseMD(rawToken)
+				if !passwordVerify(ctx, username, password, privilege.GetPrivilegeCache()) {
+					mlog.Warn(ctx, "fail to verify password", mlog.String("username", username))
+					// NOTE: don't use the merr, because it will cause the wrong retry behavior in the sdk
+					return nil, status.Error(codes.Unauthenticated, "auth check failure, please check username and password are correct")
+				}
+				metrics.UserRPCCounter.WithLabelValues(username).Inc()
 			}
-			metrics.UserRPCCounter.WithLabelValues(username).Inc()
 		}
+		return ctx, nil
 	}
-	return ctx, nil
 }

--- a/internal/proxy/authentication_interceptor.go
+++ b/internal/proxy/authentication_interceptor.go
@@ -59,9 +59,6 @@ func AuthenticationInterceptor(ctx context.Context) (context.Context, error) {
 	if !ok {
 		return nil, merr.WrapErrIoKeyNotFound("metadata", "auth check failure, due to occurs inner error: missing metadata")
 	}
-	if globalMetaCache == nil {
-		return nil, merr.WrapErrServiceUnavailable("internal: Milvus Proxy is not ready yet. please wait")
-	}
 	// check rpc call from sdk
 	if Params.CommonCfg.AuthorizationEnabled.GetAsBool() {
 		authStrArr := md[strings.ToLower(util.HeaderAuthorize)]

--- a/internal/proxy/authentication_interceptor_test.go
+++ b/internal/proxy/authentication_interceptor_test.go
@@ -40,7 +40,7 @@ func TestValidAuth(t *testing.T) {
 	assert.False(t, res)
 	// normal metadata
 	mix := &MockMixCoordClientInterface{}
-	err := InitMetaCache(ctx, mix)
+	_, err := initMetaCache(ctx, mix)
 	assert.NoError(t, err)
 	res = validAuth(ctx, []string{crypto.Base64Encode("mockUser:mockPass")})
 	assert.True(t, res)
@@ -58,7 +58,7 @@ func TestAuthenticationInterceptor(t *testing.T) {
 	assert.Error(t, err)
 	// mock metacache
 	queryCoord := &MockMixCoordClientInterface{}
-	err = InitMetaCache(ctx, queryCoord)
+	_, err = initMetaCache(ctx, queryCoord)
 	assert.NoError(t, err)
 	// with invalid metadata
 	md := metadata.Pairs("xxx", "yyy")

--- a/internal/proxy/authentication_interceptor_test.go
+++ b/internal/proxy/authentication_interceptor_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/crypto"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -53,29 +54,38 @@ func TestAuthenticationInterceptor(t *testing.T) {
 	ctx := context.Background()
 	paramtable.Get().Save(Params.CommonCfg.AuthorizationEnabled.Key, "true") // mock authorization is turned on
 	defer paramtable.Get().Reset(Params.CommonCfg.AuthorizationEnabled.Key)  // mock authorization is turned on
+
+	// proxy not ready: requests must be rejected with ServiceUnavailable
+	notReady := AuthenticationInterceptorWithMetaCache(func() Cache { return nil })
+	mdNoMeta := metadata.NewIncomingContext(ctx, metadata.Pairs(util.HeaderAuthorize, crypto.Base64Encode("mockUser:mockPass")))
+	_, err := notReady(mdNoMeta)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, merr.ErrServiceUnavailable))
+
 	// no metadata
-	_, err := AuthenticationInterceptor(ctx)
+	_, err = notReady(ctx)
 	assert.Error(t, err)
 	// mock metacache
 	queryCoord := &MockMixCoordClientInterface{}
-	_, err = initMetaCache(ctx, queryCoord)
+	cache, err := initMetaCache(ctx, queryCoord)
 	assert.NoError(t, err)
+	authInterceptor := AuthenticationInterceptorWithMetaCache(func() Cache { return cache })
 	// with invalid metadata
 	md := metadata.Pairs("xxx", "yyy")
 	ctx = metadata.NewIncomingContext(ctx, md)
-	_, err = AuthenticationInterceptor(ctx)
+	_, err = authInterceptor(ctx)
 	assert.Error(t, err)
 	// with valid username/password
 	md = metadata.Pairs(util.HeaderAuthorize, crypto.Base64Encode("mockUser:mockPass"))
 	ctx = metadata.NewIncomingContext(ctx, md)
-	_, err = AuthenticationInterceptor(ctx)
+	_, err = authInterceptor(ctx)
 	assert.NoError(t, err)
 
 	{
 		// wrong authorization style
 		md = metadata.Pairs(util.HeaderAuthorize, "123456")
 		ctx = metadata.NewIncomingContext(ctx, md)
-		_, err = AuthenticationInterceptor(ctx)
+		_, err = authInterceptor(ctx)
 		assert.Error(t, err)
 	}
 
@@ -83,7 +93,7 @@ func TestAuthenticationInterceptor(t *testing.T) {
 		// invalid user
 		md = metadata.Pairs(util.HeaderAuthorize, crypto.Base64Encode("mockUser2:mockPass"))
 		ctx = metadata.NewIncomingContext(ctx, md)
-		_, err = AuthenticationInterceptor(ctx)
+		_, err = authInterceptor(ctx)
 		assert.Error(t, err)
 	}
 
@@ -91,7 +101,7 @@ func TestAuthenticationInterceptor(t *testing.T) {
 		// default hook
 		md = metadata.Pairs(util.HeaderAuthorize, crypto.Base64Encode("mockapikey"))
 		ctx = metadata.NewIncomingContext(ctx, md)
-		_, err = AuthenticationInterceptor(ctx)
+		_, err = authInterceptor(ctx)
 		assert.Error(t, err)
 	}
 
@@ -100,7 +110,7 @@ func TestAuthenticationInterceptor(t *testing.T) {
 		hookutil.SetMockAPIHook("", errors.New("err"))
 		md = metadata.Pairs(util.HeaderAuthorize, crypto.Base64Encode("mockapikey"))
 		ctx = metadata.NewIncomingContext(ctx, md)
-		_, err = AuthenticationInterceptor(ctx)
+		_, err = authInterceptor(ctx)
 		assert.Error(t, err)
 	}
 
@@ -108,7 +118,7 @@ func TestAuthenticationInterceptor(t *testing.T) {
 		hookutil.SetMockAPIHook("mockUser", nil)
 		md = metadata.Pairs(util.HeaderAuthorize, crypto.Base64Encode("mockapikey"))
 		ctx = metadata.NewIncomingContext(ctx, md)
-		authCtx, err := AuthenticationInterceptor(ctx)
+		authCtx, err := authInterceptor(ctx)
 		assert.NoError(t, err)
 		md, ok := metadata.FromIncomingContext(authCtx)
 		assert.True(t, ok)

--- a/internal/proxy/function_task.go
+++ b/internal/proxy/function_task.go
@@ -102,7 +102,7 @@ func (t *alterCollectionFunctionTask) PreExecute(ctx context.Context) error {
 	if t.FunctionName != t.FunctionSchema.Name {
 		return merr.WrapErrParameterInvalidMsg("invalid function config, name not match")
 	}
-	coll, err := getCollectionInfo(ctx, t.GetDbName(), t.GetCollectionName())
+	coll, err := getCollectionInfo(ctx, t.getMetaCache(), t.GetDbName(), t.GetCollectionName())
 	if err != nil {
 		mlog.Error(t.ctx, "AddCollectionTask, get collection info failed",
 			mlog.String("dbName", t.GetDbName()),
@@ -154,12 +154,12 @@ func (t *alterCollectionFunctionTask) PostExecute(ctx context.Context) error {
 	return nil
 }
 
-func getCollectionInfo(ctx context.Context, dbName string, collectionName string) (*collectionInfo, error) {
-	collID, err := globalMetaCache.GetCollectionID(ctx, dbName, collectionName)
+func getCollectionInfo(ctx context.Context, metaCache Cache, dbName string, collectionName string) (*collectionInfo, error) {
+	collID, err := metaCache.GetCollectionID(ctx, dbName, collectionName)
 	if err != nil {
 		return nil, err
 	}
-	coll, err := globalMetaCache.GetCollectionInfo(ctx, dbName, collectionName, collID)
+	coll, err := metaCache.GetCollectionInfo(ctx, dbName, collectionName, collID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/proxy/function_task_test.go
+++ b/internal/proxy/function_task_test.go
@@ -135,7 +135,7 @@ func (f *FunctionTaskSuite) TestAlterCollectionFunctionTaskPreExecute() {
 		}
 		cache := NewMockCache(f.T())
 		cache.EXPECT().GetCollectionID(ctx, req.DbName, req.CollectionName).Return(0, fmt.Errorf("Mock Error")).Maybe()
-		globalMetaCache = cache
+		task.metaCache = cache
 
 		err := task.PreExecute(ctx)
 		f.ErrorContains(err, "Mock Error")
@@ -162,7 +162,7 @@ func (f *FunctionTaskSuite) TestAlterCollectionFunctionTaskPreExecute() {
 		cache := NewMockCache(f.T())
 		cache.EXPECT().GetCollectionID(ctx, req.DbName, req.CollectionName).Return(int64(1), nil).Maybe()
 		cache.EXPECT().GetCollectionInfo(ctx, req.DbName, req.CollectionName, int64(1)).Return(nil, fmt.Errorf("Mock info error")).Maybe()
-		globalMetaCache = cache
+		task.metaCache = cache
 
 		err := task.PreExecute(ctx)
 		f.ErrorContains(err, "Mock info error")
@@ -193,7 +193,7 @@ func (f *FunctionTaskSuite) TestAlterCollectionFunctionTaskPreExecute() {
 		cache := NewMockCache(f.T())
 		cache.EXPECT().GetCollectionID(ctx, req.DbName, req.CollectionName).Return(int64(1), nil).Maybe()
 		cache.EXPECT().GetCollectionInfo(ctx, req.DbName, req.CollectionName, int64(1)).Return(nil, nil).Maybe()
-		globalMetaCache = cache
+		task.metaCache = cache
 		err := task.PreExecute(ctx)
 		f.ErrorContains(err, "not support alter BM25")
 	}
@@ -233,7 +233,7 @@ func (f *FunctionTaskSuite) TestAlterCollectionFunctionTaskPreExecute() {
 		}
 
 		cache.EXPECT().GetCollectionInfo(ctx, req.DbName, req.CollectionName, int64(1)).Return(coll, nil).Maybe()
-		globalMetaCache = cache
+		task.metaCache = cache
 		err := task.PreExecute(ctx)
 		f.ErrorContains(err, "not support alter BM25")
 	}
@@ -263,7 +263,7 @@ func (f *FunctionTaskSuite) TestAlterCollectionFunctionTaskPreExecute() {
 		cache := NewMockCache(f.T())
 		cache.EXPECT().GetCollectionID(ctx, req.DbName, req.CollectionName).Return(int64(1), nil).Maybe()
 		cache.EXPECT().GetCollectionInfo(ctx, req.DbName, req.CollectionName, int64(1)).Return(nil, nil).Maybe()
-		globalMetaCache = cache
+		task.metaCache = cache
 		err := task.PreExecute(ctx)
 		f.ErrorContains(err, "invalid function config, name not match")
 	}
@@ -306,7 +306,7 @@ func (f *FunctionTaskSuite) TestAlterCollectionFunctionTaskPreExecute() {
 		cache := NewMockCache(f.T())
 		cache.EXPECT().GetCollectionID(ctx, req.DbName, req.CollectionName).Return(int64(1), nil).Maybe()
 		cache.EXPECT().GetCollectionInfo(ctx, req.DbName, req.CollectionName, int64(1)).Return(coll, nil).Maybe()
-		globalMetaCache = cache
+		task.metaCache = cache
 
 		err := task.PreExecute(ctx)
 		f.ErrorContains(err, externalCollectionFunctionMutationUnsupportedMsg)
@@ -350,7 +350,7 @@ func (f *FunctionTaskSuite) TestAlterCollectionFunctionTaskPreExecute() {
 		cache.EXPECT().GetCollectionInfo(ctx, req.DbName, req.CollectionName, int64(1)).Return(coll, nil).Maybe()
 		m := mockey.Mock(validator.ValidateFunction).Return(nil).Build()
 		defer m.UnPatch()
-		globalMetaCache = cache
+		task.metaCache = cache
 		err := task.PreExecute(ctx)
 		f.NoError(err)
 	}
@@ -384,7 +384,7 @@ func (f *FunctionTaskSuite) TestAlterCollectionFunctionTaskPreExecute() {
 		cache := NewMockCache(f.T())
 		cache.EXPECT().GetCollectionID(ctx, req.DbName, req.CollectionName).Return(int64(1), nil).Maybe()
 		cache.EXPECT().GetCollectionInfo(ctx, req.DbName, req.CollectionName, int64(1)).Return(coll, nil).Maybe()
-		globalMetaCache = cache
+		task.metaCache = cache
 		err := task.PreExecute(ctx)
 		f.ErrorContains(err, "output fields cannot be altered")
 	}
@@ -395,18 +395,16 @@ func (f *FunctionTaskSuite) TestGetCollectionInfo() {
 	{
 		cache := NewMockCache(f.T())
 		cache.EXPECT().GetCollectionID(ctx, "db", "collection").Return(0, fmt.Errorf("Mock Error")).Maybe()
-		globalMetaCache = cache
 
-		_, err := getCollectionInfo(ctx, "db", "collection")
+		_, err := getCollectionInfo(ctx, cache, "db", "collection")
 		f.ErrorContains(err, "Mock Error")
 	}
 	{
 		cache := NewMockCache(f.T())
 		cache.EXPECT().GetCollectionID(ctx, "db", "collection").Return(int64(1), nil).Maybe()
 		cache.EXPECT().GetCollectionInfo(ctx, "db", "collection", int64(1)).Return(nil, fmt.Errorf("Mock info error")).Maybe()
-		globalMetaCache = cache
 
-		_, err := getCollectionInfo(ctx, "db", "collection")
+		_, err := getCollectionInfo(ctx, cache, "db", "collection")
 		f.ErrorContains(err, "Mock info error")
 	}
 }

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -87,8 +87,8 @@ const moduleName = "Proxy"
 
 // checkExternalCollectionBlockedForWrite checks if the collection is external and returns error if so.
 // External collections do not support write operations (insert, delete, upsert, flush, etc).
-func checkExternalCollectionBlockedForWrite(ctx context.Context, dbName, collName, operation string) error {
-	collSchema, _ := globalMetaCache.GetCollectionSchema(ctx, dbName, collName)
+func checkExternalCollectionBlockedForWrite(ctx context.Context, metaCache Cache, dbName, collName, operation string) error {
+	collSchema, _ := metaCache.GetCollectionSchema(ctx, dbName, collName)
 	if collSchema != nil && typeutil.IsExternalCollection(collSchema.CollectionSchema) {
 		return merr.WrapErrParameterInvalidMsg(
 			"%s operation is not supported for external collection %s", operation, collName)
@@ -171,12 +171,12 @@ func (node *Proxy) InvalidateCollectionMetaCache(ctx context.Context, request *p
 		}
 	}
 
-	if globalMetaCache != nil {
+	if node.getMetaCache() != nil {
 		switch msgType {
 		case commonpb.MsgType_DropCollection, commonpb.MsgType_RenameCollection, commonpb.MsgType_DropAlias, commonpb.MsgType_AlterAlias, commonpb.MsgType_CreateAlias:
 			aliasOperation := msgType == commonpb.MsgType_CreateAlias ||
 				msgType == commonpb.MsgType_AlterAlias || msgType == commonpb.MsgType_DropAlias
-			aliasName = globalMetaCache.InvalidateCollectionMeta(
+			aliasName = node.getMetaCache().InvalidateCollectionMeta(
 				ctx, request.GetDbName(), collectionName, collectionID, aliasOperation)
 			deprecateShardCaches(append(aliasName, collectionName)...)
 			if aliasOperation && collectionName != "" {
@@ -195,14 +195,14 @@ func (node *Proxy) InvalidateCollectionMetaCache(ctx context.Context, request *p
 					// resolution is race-free -- nothing re-points an alias
 					// concurrently with its drop), so scanning there would
 					// reintroduce a permanent O(N) stall on the normal path.
-					globalMetaCache.RemoveAliasHolders(ctx, request.GetDbName(), collectionName)
+					node.getMetaCache().RemoveAliasHolders(ctx, request.GetDbName(), collectionName)
 				}
 			}
 			mlog.Info(ctx, "complete to invalidate collection meta cache with collection name", mlog.String("type", request.GetBase().GetMsgType().String()))
 		case commonpb.MsgType_LoadCollection, commonpb.MsgType_ReleaseCollection:
 			// All the request from query use collectionID
 			if request.CollectionID != UniqueID(0) {
-				aliasName = globalMetaCache.InvalidateCollectionMeta(ctx, request.GetDbName(), "", collectionID, false)
+				aliasName = node.getMetaCache().InvalidateCollectionMeta(ctx, request.GetDbName(), "", collectionID, false)
 				deprecateShardCaches(aliasName...)
 			}
 			mlog.Info(ctx, "complete to invalidate collection meta cache", mlog.String("type", request.GetBase().GetMsgType().String()))
@@ -215,20 +215,20 @@ func (node *Proxy) InvalidateCollectionMetaCache(ctx context.Context, request *p
 					mlog.FieldCollectionID(collectionID))
 				return merr.Status(err), nil
 			}
-			globalMetaCache.RemovePartition(ctx, request.GetDbName(), collectionID, collectionName, request.GetPartitionName())
+			node.getMetaCache().RemovePartition(ctx, request.GetDbName(), collectionID, collectionName, request.GetPartitionName())
 			mlog.Info(ctx, "complete to invalidate collection meta cache", mlog.String("type", request.GetBase().GetMsgType().String()))
 		case commonpb.MsgType_DropDatabase:
 			node.shardMgr.RemoveDatabase(request.GetDbName())
-			globalMetaCache.RemoveDatabase(ctx, request.GetDbName())
+			node.getMetaCache().RemoveDatabase(ctx, request.GetDbName())
 		case commonpb.MsgType_AlterDatabase:
-			globalMetaCache.RemoveDatabaseInfo(ctx, request.GetDbName())
+			node.getMetaCache().RemoveDatabaseInfo(ctx, request.GetDbName())
 		case commonpb.MsgType_AlterCollection, commonpb.MsgType_AlterCollectionField:
-			aliasName = globalMetaCache.InvalidateCollectionMeta(ctx, request.GetDbName(), collectionName, collectionID, false)
+			aliasName = node.getMetaCache().InvalidateCollectionMeta(ctx, request.GetDbName(), collectionName, collectionID, false)
 			deprecateShardCaches(append(aliasName, collectionName)...)
 			mlog.Info(ctx, "complete to invalidate collection meta cache", mlog.String("type", request.GetBase().GetMsgType().String()))
 		default:
 			mlog.Warn(ctx, "receive unexpected msgType of invalidate collection meta cache", mlog.String("msgType", request.GetBase().GetMsgType().String()))
-			aliasName = globalMetaCache.InvalidateCollectionMeta(ctx, request.GetDbName(), collectionName, collectionID, false)
+			aliasName = node.getMetaCache().InvalidateCollectionMeta(ctx, request.GetDbName(), collectionName, collectionID, false)
 			deprecateShardCaches(append(aliasName, collectionName)...)
 		}
 	}
@@ -1425,7 +1425,7 @@ func (node *Proxy) AlterCollectionField(ctx context.Context, request *milvuspb.A
 	tr := timerecord.NewTimeRecorder(method)
 
 	// Check for external collection - alter field is not supported
-	if err := checkExternalCollectionBlockedForWrite(ctx, request.GetDbName(), request.GetCollectionName(), "alter field"); err != nil {
+	if err := checkExternalCollectionBlockedForWrite(ctx, node.getMetaCache(), request.GetDbName(), request.GetCollectionName(), "alter field"); err != nil {
 		return merr.Status(err), nil
 	}
 
@@ -1478,7 +1478,7 @@ func (node *Proxy) CreatePartition(ctx context.Context, request *milvuspb.Create
 	}
 
 	// Check for external collection - create partition is not supported
-	if err := checkExternalCollectionBlockedForWrite(ctx, request.GetDbName(), request.GetCollectionName(), "create partition"); err != nil {
+	if err := checkExternalCollectionBlockedForWrite(ctx, node.getMetaCache(), request.GetDbName(), request.GetCollectionName(), "create partition"); err != nil {
 		return merr.Status(err), nil
 	}
 
@@ -1536,7 +1536,7 @@ func (node *Proxy) DropPartition(ctx context.Context, request *milvuspb.DropPart
 	}
 
 	// Check for external collection - drop partition is not supported
-	if err := checkExternalCollectionBlockedForWrite(ctx, request.GetDbName(), request.GetCollectionName(), "drop partition"); err != nil {
+	if err := checkExternalCollectionBlockedForWrite(ctx, node.getMetaCache(), request.GetDbName(), request.GetCollectionName(), "drop partition"); err != nil {
 		return merr.Status(err), nil
 	}
 
@@ -1911,7 +1911,7 @@ func (node *Proxy) GetLoadingProgress(ctx context.Context, request *milvuspb.Get
 	if err := validateCollectionName(request.CollectionName); err != nil {
 		return getErrResponse(err), nil
 	}
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, request.GetDbName(), request.CollectionName)
+	collectionID, err := node.getMetaCache().GetCollectionID(ctx, request.GetDbName(), request.CollectionName)
 	if err != nil {
 		return getErrResponse(err), nil
 	}
@@ -1937,7 +1937,7 @@ func (node *Proxy) GetLoadingProgress(ctx context.Context, request *milvuspb.Get
 			return getErrResponse(err), nil
 		}
 	} else {
-		if loadProgress, refreshProgress, err = getPartitionProgress(ctx, node.mixCoord, request.GetBase(),
+		if loadProgress, refreshProgress, err = getPartitionProgress(ctx, node.getMetaCache(), node.mixCoord, request.GetBase(),
 			request.GetPartitionNames(), request.GetCollectionName(), collectionID, request.GetDbName()); err != nil {
 			return getErrResponse(err), nil
 		}
@@ -1995,7 +1995,7 @@ func (node *Proxy) GetLoadState(ctx context.Context, request *milvuspb.GetLoadSt
 		metrics.ProxyReqLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method).Observe(float64(tr.ElapseSpan().Milliseconds()))
 	}()
 
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, request.GetDbName(), request.CollectionName)
+	collectionID, err := node.getMetaCache().GetCollectionID(ctx, request.GetDbName(), request.CollectionName)
 	if err != nil {
 		mlog.Warn(context.TODO(), "failed to get collection id",
 			mlog.String("dbName", request.GetDbName()),
@@ -2029,7 +2029,7 @@ func (node *Proxy) GetLoadState(ctx context.Context, request *milvuspb.GetLoadSt
 			}, nil
 		}
 	} else {
-		if progress, _, err = getPartitionProgress(ctx, node.mixCoord, request.GetBase(),
+		if progress, _, err = getPartitionProgress(ctx, node.getMetaCache(), node.mixCoord, request.GetBase(),
 			request.GetPartitionNames(), request.GetCollectionName(), collectionID, request.GetDbName()); err != nil {
 			if errors.IsAny(err,
 				merr.ErrCollectionNotLoaded,
@@ -2457,7 +2457,7 @@ func (node *Proxy) Insert(ctx context.Context, request *milvuspb.InsertRequest) 
 	}
 
 	// Check for external collection - insert is not supported
-	if err := checkExternalCollectionBlockedForWrite(ctx, request.GetDbName(), request.GetCollectionName(), "insert"); err != nil {
+	if err := checkExternalCollectionBlockedForWrite(ctx, node.getMetaCache(), request.GetDbName(), request.GetCollectionName(), "insert"); err != nil {
 		return &milvuspb.MutationResult{
 			Status: merr.Status(err),
 		}, nil
@@ -2472,6 +2472,9 @@ func (node *Proxy) Insert(ctx context.Context, request *milvuspb.InsertRequest) 
 		SetCollectionName(request.GetCollectionName())
 
 	it := &insertTask{
+		baseTask: baseTask{
+			metaCache: node.metaCache,
+		},
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
 		insertMsg: &msgstream.InsertMsg{
@@ -2594,7 +2597,7 @@ func (node *Proxy) Delete(ctx context.Context, request *milvuspb.DeleteRequest) 
 	}
 
 	// Check for external collection - delete is not supported
-	if err := checkExternalCollectionBlockedForWrite(ctx, request.GetDbName(), request.GetCollectionName(), "delete"); err != nil {
+	if err := checkExternalCollectionBlockedForWrite(ctx, node.getMetaCache(), request.GetDbName(), request.GetCollectionName(), "delete"); err != nil {
 		return &milvuspb.MutationResult{
 			Status: merr.Status(err),
 		}, nil
@@ -2609,6 +2612,7 @@ func (node *Proxy) Delete(ctx context.Context, request *milvuspb.DeleteRequest) 
 
 	dr := &deleteRunner{
 		req:             request,
+		metaCache:       node.metaCache,
 		idAllocator:     node.rowIDAllocator,
 		tsoAllocatorIns: node.tsoAllocator,
 		chMgr:           node.chMgr,
@@ -2690,7 +2694,7 @@ func (node *Proxy) Upsert(ctx context.Context, request *milvuspb.UpsertRequest) 
 	}
 
 	// Check for external collection - upsert is not supported
-	if err := checkExternalCollectionBlockedForWrite(ctx, request.GetDbName(), request.GetCollectionName(), "upsert"); err != nil {
+	if err := checkExternalCollectionBlockedForWrite(ctx, node.getMetaCache(), request.GetDbName(), request.GetCollectionName(), "upsert"); err != nil {
 		return &milvuspb.MutationResult{
 			Status: merr.Status(err),
 		}, nil
@@ -2711,6 +2715,9 @@ func (node *Proxy) Upsert(ctx context.Context, request *milvuspb.UpsertRequest) 
 	)
 
 	it := &upsertTask{
+		baseTask: baseTask{
+			metaCache: node.metaCache,
+		},
 		baseMsg: msgstream.BaseMsg{
 			HashValues: request.HashKeys,
 		},
@@ -2965,6 +2972,9 @@ func (node *Proxy) search(ctx context.Context, request *milvuspb.SearchRequest, 
 	}
 
 	qt := &searchTask{
+		baseTask: baseTask{
+			metaCache: node.metaCache,
+		},
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
 		SearchRequest: &internalpb.SearchRequest{
@@ -3197,6 +3207,9 @@ func (node *Proxy) hybridSearch(ctx context.Context, request *milvuspb.HybridSea
 	defer sp.End()
 	newSearchReq := convertHybridSearchToSearch(request)
 	qt := &searchTask{
+		baseTask: baseTask{
+			metaCache: node.metaCache,
+		},
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
 		SearchRequest: &internalpb.SearchRequest{
@@ -3414,7 +3427,7 @@ func (node *Proxy) handleIfSearchByPK(ctx context.Context, request *milvuspb.Sea
 	}
 
 	// Get collection schema for validation and plan building
-	collectionInfo, err := globalMetaCache.GetCollectionInfo(ctx,
+	collectionInfo, err := node.getMetaCache().GetCollectionInfo(ctx,
 		request.GetDbName(), request.GetCollectionName(), 0)
 	if err != nil {
 		return nil, err
@@ -3496,6 +3509,9 @@ func (node *Proxy) handleIfSearchByPK(ctx context.Context, request *milvuspb.Sea
 
 	// Create queryTask to execute the retrieval
 	qt := &queryTask{
+		baseTask: baseTask{
+			metaCache: node.metaCache,
+		},
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
 		RetrieveRequest: &internalpb.RetrieveRequest{
@@ -3613,7 +3629,7 @@ func (node *Proxy) Flush(ctx context.Context, request *milvuspb.FlushRequest) (*
 
 	// Check for external collection - flush is not supported
 	for _, collName := range request.GetCollectionNames() {
-		if err := checkExternalCollectionBlockedForWrite(ctx, request.GetDbName(), collName, "flush"); err != nil {
+		if err := checkExternalCollectionBlockedForWrite(ctx, node.getMetaCache(), request.GetDbName(), collName, "flush"); err != nil {
 			resp.Status = merr.Status(err)
 			return resp, nil
 		}
@@ -3777,6 +3793,9 @@ func (node *Proxy) query(ctx context.Context, qt *queryTask, sp trace.Span) (*mi
 // Query get the records by primary keys.
 func (node *Proxy) Query(ctx context.Context, request *milvuspb.QueryRequest) (*milvuspb.QueryResults, error) {
 	qt := &queryTask{
+		baseTask: baseTask{
+			metaCache: node.metaCache,
+		},
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
 		RetrieveRequest: &internalpb.RetrieveRequest{
@@ -4223,7 +4242,7 @@ func (node *Proxy) GetPersistentSegmentInfo(ctx context.Context, req *milvuspb.G
 	tr := timerecord.NewTimeRecorder(method)
 
 	// list segments
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, req.GetDbName(), req.GetCollectionName())
+	collectionID, err := node.getMetaCache().GetCollectionID(ctx, req.GetDbName(), req.GetCollectionName())
 	if err != nil {
 		resp.Status = merr.Status(err)
 		return resp, nil
@@ -4382,7 +4401,7 @@ func (node *Proxy) GetQuerySegmentInfo(ctx context.Context, req *milvuspb.GetQue
 	method := "GetQuerySegmentInfo"
 	tr := timerecord.NewTimeRecorder(method)
 
-	collID, err := globalMetaCache.GetCollectionID(ctx, req.GetDbName(), req.CollectionName)
+	collID, err := node.getMetaCache().GetCollectionID(ctx, req.GetDbName(), req.CollectionName)
 	if err != nil {
 		resp.Status = merr.Status(err)
 		return resp, nil
@@ -4635,7 +4654,7 @@ func (node *Proxy) LoadBalance(ctx context.Context, req *milvuspb.LoadBalanceReq
 
 	status := merr.Success()
 
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, req.GetDbName(), req.GetCollectionName())
+	collectionID, err := node.getMetaCache().GetCollectionID(ctx, req.GetDbName(), req.GetCollectionName())
 	if err != nil {
 		mlog.Warn(context.TODO(), "failed to get collection id",
 			mlog.String("collectionName", req.GetCollectionName()),
@@ -4694,7 +4713,7 @@ func (node *Proxy) GetReplicas(ctx context.Context, req *milvuspb.GetReplicasReq
 
 	if req.GetCollectionName() != "" {
 		var err error
-		req.CollectionID, err = globalMetaCache.GetCollectionID(ctx, req.GetDbName(), req.GetCollectionName())
+		req.CollectionID, err = node.getMetaCache().GetCollectionID(ctx, req.GetDbName(), req.GetCollectionName())
 		if err != nil {
 			resp.Status = merr.Status(err)
 			return resp, nil
@@ -4746,7 +4765,7 @@ func (node *Proxy) ManualCompaction(ctx context.Context, req *milvuspb.ManualCom
 	// before v2.4.18, manual compact request only pass collectionID, should correct sdk's behavior to pass collectionName
 	if req.GetCollectionName() != "" {
 		var err error
-		req.CollectionID, err = globalMetaCache.GetCollectionID(ctx, req.GetDbName(), req.GetCollectionName())
+		req.CollectionID, err = node.getMetaCache().GetCollectionID(ctx, req.GetDbName(), req.GetCollectionName())
 		if err != nil {
 			resp.Status = merr.Status(err)
 			return resp, nil
@@ -4756,7 +4775,7 @@ func (node *Proxy) ManualCompaction(ctx context.Context, req *milvuspb.ManualCom
 	// Check for external collection - manual compaction is not supported
 	// Only check if we have collection identifier (collectionID > 0 or collectionName not empty)
 	if req.GetCollectionID() > 0 || req.GetCollectionName() != "" {
-		collInfo, err := globalMetaCache.GetCollectionInfo(ctx, req.GetDbName(), req.GetCollectionName(), req.GetCollectionID())
+		collInfo, err := node.getMetaCache().GetCollectionInfo(ctx, req.GetDbName(), req.GetCollectionName(), req.GetCollectionID())
 		if err != nil {
 			resp.Status = merr.Status(err)
 			return resp, nil
@@ -4826,7 +4845,7 @@ func (node *Proxy) GetFlushState(ctx context.Context, req *milvuspb.GetFlushStat
 			failResp.Status = merr.Status(err)
 			return failResp, nil
 		}
-		collectionID, err := globalMetaCache.GetCollectionID(ctx, req.GetDbName(), req.GetCollectionName())
+		collectionID, err := node.getMetaCache().GetCollectionID(ctx, req.GetDbName(), req.GetCollectionName())
 		if err != nil {
 			failResp.Status = merr.Status(err)
 			return failResp, nil
@@ -5525,7 +5544,7 @@ func (node *Proxy) OperatePrivilegeV2(ctx context.Context, req *milvuspb.Operate
 	// Resolve alias to actual collection name so grants are stored under the real name
 	if Params.ProxyCfg.ResolveAliasForPrivilege.GetAsBool() &&
 		req.CollectionName != util.AnyWord && req.CollectionName != "" {
-		resolved, resolveErr := globalMetaCache.ResolveCollectionAlias(ctx, req.DbName, req.CollectionName)
+		resolved, resolveErr := node.getMetaCache().ResolveCollectionAlias(ctx, req.DbName, req.CollectionName)
 		if resolveErr != nil {
 			mlog.Warn(context.TODO(), "failed to resolve collection alias for privilege operation",
 				mlog.String("collectionName", req.CollectionName), mlog.String("dbName", req.DbName), mlog.Err(resolveErr))
@@ -5597,7 +5616,7 @@ func (node *Proxy) OperatePrivilege(ctx context.Context, req *milvuspb.OperatePr
 	if Params.ProxyCfg.ResolveAliasForPrivilege.GetAsBool() &&
 		req.Entity.Object != nil && req.Entity.Object.Name == commonpb.ObjectType_Collection.String() &&
 		req.Entity.ObjectName != util.AnyWord && req.Entity.ObjectName != "" {
-		resolved, resolveErr := globalMetaCache.ResolveCollectionAlias(ctx, req.Entity.DbName, req.Entity.ObjectName)
+		resolved, resolveErr := node.getMetaCache().ResolveCollectionAlias(ctx, req.Entity.DbName, req.Entity.ObjectName)
 		if resolveErr != nil {
 			mlog.Warn(context.TODO(), "failed to resolve collection alias for privilege operation",
 				mlog.String("objectName", req.Entity.ObjectName), mlog.String("dbName", req.Entity.DbName), mlog.Err(resolveErr))
@@ -5680,7 +5699,7 @@ func (node *Proxy) SelectGrant(ctx context.Context, req *milvuspb.SelectGrantReq
 	if Params.ProxyCfg.ResolveAliasForPrivilege.GetAsBool() &&
 		req.Entity != nil && req.Entity.Object != nil && req.Entity.Object.Name == commonpb.ObjectType_Collection.String() &&
 		req.Entity.ObjectName != util.AnyWord && req.Entity.ObjectName != "" {
-		resolved, resolveErr := globalMetaCache.ResolveCollectionAlias(ctx, req.Entity.DbName, req.Entity.ObjectName)
+		resolved, resolveErr := node.getMetaCache().ResolveCollectionAlias(ctx, req.Entity.DbName, req.Entity.ObjectName)
 		if resolveErr != nil {
 			mlog.Warn(context.TODO(), "failed to resolve collection alias for select grant",
 				mlog.String("objectName", req.Entity.ObjectName), mlog.String("dbName", req.Entity.DbName), mlog.Err(resolveErr))
@@ -6375,7 +6394,7 @@ func (node *Proxy) ImportV2(ctx context.Context, req *internalpb.ImportRequest) 
 	}
 
 	// Check for external collection - import is not supported
-	if err := checkExternalCollectionBlockedForWrite(ctx, req.GetDbName(), req.GetCollectionName(), "import"); err != nil {
+	if err := checkExternalCollectionBlockedForWrite(ctx, node.getMetaCache(), req.GetDbName(), req.GetCollectionName(), "import"); err != nil {
 		return &internalpb.ImportResponse{Status: merr.Status(err)}, nil
 	}
 
@@ -6464,7 +6483,7 @@ func (node *Proxy) ListImports(ctx context.Context, req *internalpb.ListImportsR
 		collectionID UniqueID
 	)
 	if req.GetCollectionName() != "" {
-		collectionID, err = globalMetaCache.GetCollectionID(ctx, req.GetDbName(), req.GetCollectionName())
+		collectionID, err = node.getMetaCache().GetCollectionID(ctx, req.GetDbName(), req.GetCollectionName())
 		if err != nil {
 			resp.Status = merr.Status(err)
 			return resp, nil
@@ -7395,7 +7414,7 @@ func (node *Proxy) RefreshExternalCollection(ctx context.Context, req *milvuspb.
 	}
 
 	// Get collection info from cache (includes schema for validation)
-	collectionInfo, err := globalMetaCache.GetCollectionInfo(ctx, req.GetDbName(), req.GetCollectionName(), 0)
+	collectionInfo, err := node.getMetaCache().GetCollectionInfo(ctx, req.GetDbName(), req.GetCollectionName(), 0)
 	if err != nil {
 		mlog.Warn(context.TODO(), "failed to get collection info", mlog.Err(err))
 		return &milvuspb.RefreshExternalCollectionResponse{
@@ -7529,7 +7548,7 @@ func (node *Proxy) ListRefreshExternalCollectionJobs(ctx context.Context, req *m
 		}
 
 		// Get collection info from cache and validate it's an external collection
-		collectionInfo, err := globalMetaCache.GetCollectionInfo(ctx, req.GetDbName(), req.GetCollectionName(), 0)
+		collectionInfo, err := node.getMetaCache().GetCollectionInfo(ctx, req.GetDbName(), req.GetCollectionName(), 0)
 		if err != nil {
 			mlog.Warn(context.TODO(), "failed to get collection info", mlog.Err(err))
 			return &milvuspb.ListRefreshExternalCollectionJobsResponse{

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -352,6 +352,7 @@ func (node *Proxy) DropDatabase(ctx context.Context, request *milvuspb.DropDatab
 	tr := timerecord.NewTimeRecorder(method)
 
 	dct := &dropDatabaseTask{
+		baseTask:            baseTask{metaCache: node.metaCache},
 		ctx:                 ctx,
 		Condition:           NewTaskCondition(ctx),
 		DropDatabaseRequest: request,
@@ -597,6 +598,7 @@ func (node *Proxy) DropCollection(ctx context.Context, request *milvuspb.DropCol
 	tr := timerecord.NewTimeRecorder(method)
 
 	dct := &dropCollectionTask{
+		baseTask:              baseTask{metaCache: node.metaCache},
 		ctx:                   ctx,
 		Condition:             NewTaskCondition(ctx),
 		DropCollectionRequest: request,
@@ -655,6 +657,7 @@ func (node *Proxy) TruncateCollection(ctx context.Context, request *milvuspb.Tru
 	tr := timerecord.NewTimeRecorder(method)
 
 	dct := &truncateCollectionTask{
+		baseTask:                  baseTask{metaCache: node.metaCache},
 		ctx:                       ctx,
 		Condition:                 NewTaskCondition(ctx),
 		TruncateCollectionRequest: request,
@@ -721,6 +724,7 @@ func (node *Proxy) HasCollection(ctx context.Context, request *milvuspb.HasColle
 	mlog.Debug(context.TODO(), "HasCollection received")
 
 	hct := &hasCollectionTask{
+		baseTask:             baseTask{metaCache: node.metaCache},
 		ctx:                  ctx,
 		Condition:            NewTaskCondition(ctx),
 		HasCollectionRequest: request,
@@ -777,6 +781,7 @@ func (node *Proxy) LoadCollection(ctx context.Context, request *milvuspb.LoadCol
 	tr := timerecord.NewTimeRecorder(method)
 
 	lct := &loadCollectionTask{
+		baseTask:              baseTask{metaCache: node.metaCache},
 		ctx:                   ctx,
 		Condition:             NewTaskCondition(ctx),
 		LoadCollectionRequest: request,
@@ -829,6 +834,7 @@ func (node *Proxy) ReleaseCollection(ctx context.Context, request *milvuspb.Rele
 	method := "ReleaseCollection"
 	tr := timerecord.NewTimeRecorder(method)
 	rct := &releaseCollectionTask{
+		baseTask:                 baseTask{metaCache: node.metaCache},
 		ctx:                      ctx,
 		Condition:                NewTaskCondition(ctx),
 		ReleaseCollectionRequest: request,
@@ -1123,6 +1129,7 @@ func (node *Proxy) GetStatistics(ctx context.Context, request *milvuspb.GetStati
 	method := "GetStatistics"
 	tr := timerecord.NewTimeRecorder(method)
 	g := &getStatisticsTask{
+		baseTask:  baseTask{metaCache: node.metaCache},
 		request:   request,
 		Condition: NewTaskCondition(ctx),
 		ctx:       ctx,
@@ -1187,6 +1194,7 @@ func (node *Proxy) GetCollectionStatistics(ctx context.Context, request *milvusp
 	method := "GetCollectionStatistics"
 	tr := timerecord.NewTimeRecorder(method)
 	g := &getCollectionStatisticsTask{
+		baseTask:                       baseTask{metaCache: node.metaCache},
 		ctx:                            ctx,
 		Condition:                      NewTaskCondition(ctx),
 		GetCollectionStatisticsRequest: request,
@@ -1244,6 +1252,7 @@ func (node *Proxy) ShowCollections(ctx context.Context, request *milvuspb.ShowCo
 	tr := timerecord.NewTimeRecorder(method)
 
 	sct := &showCollectionsTask{
+		baseTask:               baseTask{metaCache: node.metaCache},
 		ctx:                    ctx,
 		Condition:              NewTaskCondition(ctx),
 		ShowCollectionsRequest: request,
@@ -1298,6 +1307,7 @@ func (node *Proxy) AlterCollection(ctx context.Context, request *milvuspb.AlterC
 	tr := timerecord.NewTimeRecorder(method)
 
 	act := &alterCollectionTask{
+		baseTask:               baseTask{metaCache: node.metaCache},
 		ctx:                    ctx,
 		Condition:              NewTaskCondition(ctx),
 		AlterCollectionRequest: request,
@@ -1363,6 +1373,7 @@ func (node *Proxy) AlterCollectionFunction(ctx context.Context, request *milvusp
 	method := "AlterCollectionFunction"
 	tr := timerecord.NewTimeRecorder(method)
 	task := &alterCollectionFunctionTask{
+		baseTask:                       baseTask{metaCache: node.metaCache},
 		ctx:                            ctx,
 		Condition:                      NewTaskCondition(ctx),
 		AlterCollectionFunctionRequest: request,
@@ -1430,6 +1441,7 @@ func (node *Proxy) AlterCollectionField(ctx context.Context, request *milvuspb.A
 	}
 
 	act := &alterCollectionFieldTask{
+		baseTask:                    baseTask{metaCache: node.metaCache},
 		ctx:                         ctx,
 		Condition:                   NewTaskCondition(ctx),
 		AlterCollectionFieldRequest: request,
@@ -1488,6 +1500,7 @@ func (node *Proxy) CreatePartition(ctx context.Context, request *milvuspb.Create
 	tr := timerecord.NewTimeRecorder(method)
 
 	cpt := &createPartitionTask{
+		baseTask:               baseTask{metaCache: node.metaCache},
 		ctx:                    ctx,
 		Condition:              NewTaskCondition(ctx),
 		CreatePartitionRequest: request,
@@ -1546,6 +1559,7 @@ func (node *Proxy) DropPartition(ctx context.Context, request *milvuspb.DropPart
 	tr := timerecord.NewTimeRecorder(method)
 
 	dpt := &dropPartitionTask{
+		baseTask:             baseTask{metaCache: node.metaCache},
 		ctx:                  ctx,
 		Condition:            NewTaskCondition(ctx),
 		DropPartitionRequest: request,
@@ -1659,6 +1673,7 @@ func (node *Proxy) LoadPartitions(ctx context.Context, request *milvuspb.LoadPar
 	method := "LoadPartitions"
 	tr := timerecord.NewTimeRecorder(method)
 	lpt := &loadPartitionsTask{
+		baseTask:              baseTask{metaCache: node.metaCache},
 		ctx:                   ctx,
 		Condition:             NewTaskCondition(ctx),
 		LoadPartitionsRequest: request,
@@ -1709,6 +1724,7 @@ func (node *Proxy) ReleasePartitions(ctx context.Context, request *milvuspb.Rele
 	defer sp.End()
 
 	rpt := &releasePartitionsTask{
+		baseTask:                 baseTask{metaCache: node.metaCache},
 		ctx:                      ctx,
 		Condition:                NewTaskCondition(ctx),
 		ReleasePartitionsRequest: request,
@@ -1766,6 +1782,7 @@ func (node *Proxy) GetPartitionStatistics(ctx context.Context, request *milvuspb
 	tr := timerecord.NewTimeRecorder(method)
 
 	g := &getPartitionStatisticsTask{
+		baseTask:                      baseTask{metaCache: node.metaCache},
 		ctx:                           ctx,
 		Condition:                     NewTaskCondition(ctx),
 		GetPartitionStatisticsRequest: request,
@@ -1822,6 +1839,7 @@ func (node *Proxy) ShowPartitions(ctx context.Context, request *milvuspb.ShowPar
 	defer sp.End()
 
 	spt := &showPartitionsTask{
+		baseTask:              baseTask{metaCache: node.metaCache},
 		ctx:                   ctx,
 		Condition:             NewTaskCondition(ctx),
 		ShowPartitionsRequest: request,
@@ -2060,6 +2078,7 @@ func (node *Proxy) CreateIndex(ctx context.Context, request *milvuspb.CreateInde
 	defer sp.End()
 
 	cit := &createIndexTask{
+		baseTask:  baseTask{metaCache: node.metaCache},
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
 		req:       request,
@@ -2112,6 +2131,7 @@ func (node *Proxy) AlterIndex(ctx context.Context, request *milvuspb.AlterIndexR
 	defer sp.End()
 
 	task := &alterIndexTask{
+		baseTask:  baseTask{metaCache: node.metaCache},
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
 		req:       request,
@@ -2167,6 +2187,7 @@ func (node *Proxy) DescribeIndex(ctx context.Context, request *milvuspb.Describe
 	defer sp.End()
 
 	dit := &describeIndexTask{
+		baseTask:             baseTask{metaCache: node.metaCache},
 		ctx:                  ctx,
 		Condition:            NewTaskCondition(ctx),
 		DescribeIndexRequest: request,
@@ -2227,6 +2248,7 @@ func (node *Proxy) GetIndexStatistics(ctx context.Context, request *milvuspb.Get
 	defer sp.End()
 
 	dit := &getIndexStatisticsTask{
+		baseTask:                  baseTask{metaCache: node.metaCache},
 		ctx:                       ctx,
 		Condition:                 NewTaskCondition(ctx),
 		GetIndexStatisticsRequest: request,
@@ -2281,6 +2303,7 @@ func (node *Proxy) DropIndex(ctx context.Context, request *milvuspb.DropIndexReq
 	defer sp.End()
 
 	dit := &dropIndexTask{
+		baseTask:         baseTask{metaCache: node.metaCache},
 		ctx:              ctx,
 		Condition:        NewTaskCondition(ctx),
 		DropIndexRequest: request,
@@ -2338,6 +2361,7 @@ func (node *Proxy) GetIndexBuildProgress(ctx context.Context, request *milvuspb.
 	defer sp.End()
 
 	gibpt := &getIndexBuildProgressTask{
+		baseTask:                     baseTask{metaCache: node.metaCache},
 		ctx:                          ctx,
 		Condition:                    NewTaskCondition(ctx),
 		GetIndexBuildProgressRequest: request,
@@ -2398,6 +2422,7 @@ func (node *Proxy) GetIndexState(ctx context.Context, request *milvuspb.GetIndex
 	defer sp.End()
 
 	dipt := &getIndexStateTask{
+		baseTask:             baseTask{metaCache: node.metaCache},
 		ctx:                  ctx,
 		Condition:            NewTaskCondition(ctx),
 		GetIndexStateRequest: request,
@@ -3639,6 +3664,7 @@ func (node *Proxy) Flush(ctx context.Context, request *milvuspb.FlushRequest) (*
 	defer sp.End()
 
 	ft := &flushTask{
+		baseTask:     baseTask{metaCache: node.metaCache},
 		ctx:          ctx,
 		Condition:    NewTaskCondition(ctx),
 		FlushRequest: request,
@@ -3898,6 +3924,7 @@ func (node *Proxy) CreateAlias(ctx context.Context, request *milvuspb.CreateAlia
 	defer sp.End()
 
 	cat := &CreateAliasTask{
+		baseTask:           baseTask{metaCache: node.metaCache},
 		ctx:                ctx,
 		Condition:          NewTaskCondition(ctx),
 		CreateAliasRequest: request,
@@ -4008,6 +4035,7 @@ func (node *Proxy) ListAliases(ctx context.Context, request *milvuspb.ListAliase
 	defer sp.End()
 
 	lat := &ListAliasesTask{
+		baseTask:           baseTask{metaCache: node.metaCache},
 		ctx:                ctx,
 		Condition:          NewTaskCondition(ctx),
 		nodeID:             node.session.ServerID,
@@ -4114,6 +4142,7 @@ func (node *Proxy) AlterAlias(ctx context.Context, request *milvuspb.AlterAliasR
 	defer sp.End()
 
 	aat := &AlterAliasTask{
+		baseTask:          baseTask{metaCache: node.metaCache},
 		ctx:               ctx,
 		Condition:         NewTaskCondition(ctx),
 		AlterAliasRequest: request,
@@ -6128,6 +6157,7 @@ func (node *Proxy) TransferReplica(ctx context.Context, request *milvuspb.Transf
 	defer sp.End()
 	tr := timerecord.NewTimeRecorder(method)
 	t := &TransferReplicaTask{
+		baseTask:               baseTask{metaCache: node.metaCache},
 		ctx:                    ctx,
 		Condition:              NewTaskCondition(ctx),
 		TransferReplicaRequest: request,
@@ -6232,6 +6262,7 @@ func (node *Proxy) DescribeResourceGroup(ctx context.Context, request *milvuspb.
 	defer sp.End()
 	tr := timerecord.NewTimeRecorder(method)
 	t := &DescribeResourceGroupTask{
+		baseTask:                     baseTask{metaCache: node.metaCache},
 		ctx:                          ctx,
 		Condition:                    NewTaskCondition(ctx),
 		DescribeResourceGroupRequest: request,
@@ -6408,6 +6439,7 @@ func (node *Proxy) ImportV2(ctx context.Context, req *internalpb.ImportRequest) 
 	nodeID := paramtable.GetStringNodeID()
 
 	it := &importTask{
+		baseTask:  baseTask{metaCache: node.metaCache},
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
 		req:       req,
@@ -6727,6 +6759,7 @@ func (node *Proxy) RunAnalyzer(ctx context.Context, req *milvuspb.RunAnalyzerReq
 
 	method := "RunAnalyzer"
 	task := &RunAnalyzerTask{
+		baseTask:           baseTask{metaCache: node.metaCache},
 		ctx:                ctx,
 		lb:                 node.lbPolicy,
 		Condition:          NewTaskCondition(ctx),
@@ -7336,6 +7369,7 @@ func (node *Proxy) BatchUpdateManifest(ctx context.Context, req *milvuspb.BatchU
 	nodeID := fmt.Sprint(paramtable.GetNodeID())
 
 	bt := &batchUpdateManifestTask{
+		baseTask:  baseTask{metaCache: node.metaCache},
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
 		req:       req,

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -352,7 +352,7 @@ func (node *Proxy) DropDatabase(ctx context.Context, request *milvuspb.DropDatab
 	tr := timerecord.NewTimeRecorder(method)
 
 	dct := &dropDatabaseTask{
-		baseTask:            baseTask{metaCache: node.metaCache},
+		baseTask:            baseTask{metaCache: node.getMetaCache()},
 		ctx:                 ctx,
 		Condition:           NewTaskCondition(ctx),
 		DropDatabaseRequest: request,
@@ -598,7 +598,7 @@ func (node *Proxy) DropCollection(ctx context.Context, request *milvuspb.DropCol
 	tr := timerecord.NewTimeRecorder(method)
 
 	dct := &dropCollectionTask{
-		baseTask:              baseTask{metaCache: node.metaCache},
+		baseTask:              baseTask{metaCache: node.getMetaCache()},
 		ctx:                   ctx,
 		Condition:             NewTaskCondition(ctx),
 		DropCollectionRequest: request,
@@ -657,7 +657,7 @@ func (node *Proxy) TruncateCollection(ctx context.Context, request *milvuspb.Tru
 	tr := timerecord.NewTimeRecorder(method)
 
 	dct := &truncateCollectionTask{
-		baseTask:                  baseTask{metaCache: node.metaCache},
+		baseTask:                  baseTask{metaCache: node.getMetaCache()},
 		ctx:                       ctx,
 		Condition:                 NewTaskCondition(ctx),
 		TruncateCollectionRequest: request,
@@ -724,7 +724,7 @@ func (node *Proxy) HasCollection(ctx context.Context, request *milvuspb.HasColle
 	mlog.Debug(context.TODO(), "HasCollection received")
 
 	hct := &hasCollectionTask{
-		baseTask:             baseTask{metaCache: node.metaCache},
+		baseTask:             baseTask{metaCache: node.getMetaCache()},
 		ctx:                  ctx,
 		Condition:            NewTaskCondition(ctx),
 		HasCollectionRequest: request,
@@ -781,7 +781,7 @@ func (node *Proxy) LoadCollection(ctx context.Context, request *milvuspb.LoadCol
 	tr := timerecord.NewTimeRecorder(method)
 
 	lct := &loadCollectionTask{
-		baseTask:              baseTask{metaCache: node.metaCache},
+		baseTask:              baseTask{metaCache: node.getMetaCache()},
 		ctx:                   ctx,
 		Condition:             NewTaskCondition(ctx),
 		LoadCollectionRequest: request,
@@ -834,7 +834,7 @@ func (node *Proxy) ReleaseCollection(ctx context.Context, request *milvuspb.Rele
 	method := "ReleaseCollection"
 	tr := timerecord.NewTimeRecorder(method)
 	rct := &releaseCollectionTask{
-		baseTask:                 baseTask{metaCache: node.metaCache},
+		baseTask:                 baseTask{metaCache: node.getMetaCache()},
 		ctx:                      ctx,
 		Condition:                NewTaskCondition(ctx),
 		ReleaseCollectionRequest: request,
@@ -1129,7 +1129,7 @@ func (node *Proxy) GetStatistics(ctx context.Context, request *milvuspb.GetStati
 	method := "GetStatistics"
 	tr := timerecord.NewTimeRecorder(method)
 	g := &getStatisticsTask{
-		baseTask:  baseTask{metaCache: node.metaCache},
+		baseTask:  baseTask{metaCache: node.getMetaCache()},
 		request:   request,
 		Condition: NewTaskCondition(ctx),
 		ctx:       ctx,
@@ -1194,7 +1194,7 @@ func (node *Proxy) GetCollectionStatistics(ctx context.Context, request *milvusp
 	method := "GetCollectionStatistics"
 	tr := timerecord.NewTimeRecorder(method)
 	g := &getCollectionStatisticsTask{
-		baseTask:                       baseTask{metaCache: node.metaCache},
+		baseTask:                       baseTask{metaCache: node.getMetaCache()},
 		ctx:                            ctx,
 		Condition:                      NewTaskCondition(ctx),
 		GetCollectionStatisticsRequest: request,
@@ -1252,7 +1252,7 @@ func (node *Proxy) ShowCollections(ctx context.Context, request *milvuspb.ShowCo
 	tr := timerecord.NewTimeRecorder(method)
 
 	sct := &showCollectionsTask{
-		baseTask:               baseTask{metaCache: node.metaCache},
+		baseTask:               baseTask{metaCache: node.getMetaCache()},
 		ctx:                    ctx,
 		Condition:              NewTaskCondition(ctx),
 		ShowCollectionsRequest: request,
@@ -1307,7 +1307,7 @@ func (node *Proxy) AlterCollection(ctx context.Context, request *milvuspb.AlterC
 	tr := timerecord.NewTimeRecorder(method)
 
 	act := &alterCollectionTask{
-		baseTask:               baseTask{metaCache: node.metaCache},
+		baseTask:               baseTask{metaCache: node.getMetaCache()},
 		ctx:                    ctx,
 		Condition:              NewTaskCondition(ctx),
 		AlterCollectionRequest: request,
@@ -1373,7 +1373,7 @@ func (node *Proxy) AlterCollectionFunction(ctx context.Context, request *milvusp
 	method := "AlterCollectionFunction"
 	tr := timerecord.NewTimeRecorder(method)
 	task := &alterCollectionFunctionTask{
-		baseTask:                       baseTask{metaCache: node.metaCache},
+		baseTask:                       baseTask{metaCache: node.getMetaCache()},
 		ctx:                            ctx,
 		Condition:                      NewTaskCondition(ctx),
 		AlterCollectionFunctionRequest: request,
@@ -1441,7 +1441,7 @@ func (node *Proxy) AlterCollectionField(ctx context.Context, request *milvuspb.A
 	}
 
 	act := &alterCollectionFieldTask{
-		baseTask:                    baseTask{metaCache: node.metaCache},
+		baseTask:                    baseTask{metaCache: node.getMetaCache()},
 		ctx:                         ctx,
 		Condition:                   NewTaskCondition(ctx),
 		AlterCollectionFieldRequest: request,
@@ -1500,7 +1500,7 @@ func (node *Proxy) CreatePartition(ctx context.Context, request *milvuspb.Create
 	tr := timerecord.NewTimeRecorder(method)
 
 	cpt := &createPartitionTask{
-		baseTask:               baseTask{metaCache: node.metaCache},
+		baseTask:               baseTask{metaCache: node.getMetaCache()},
 		ctx:                    ctx,
 		Condition:              NewTaskCondition(ctx),
 		CreatePartitionRequest: request,
@@ -1559,7 +1559,7 @@ func (node *Proxy) DropPartition(ctx context.Context, request *milvuspb.DropPart
 	tr := timerecord.NewTimeRecorder(method)
 
 	dpt := &dropPartitionTask{
-		baseTask:             baseTask{metaCache: node.metaCache},
+		baseTask:             baseTask{metaCache: node.getMetaCache()},
 		ctx:                  ctx,
 		Condition:            NewTaskCondition(ctx),
 		DropPartitionRequest: request,
@@ -1673,7 +1673,7 @@ func (node *Proxy) LoadPartitions(ctx context.Context, request *milvuspb.LoadPar
 	method := "LoadPartitions"
 	tr := timerecord.NewTimeRecorder(method)
 	lpt := &loadPartitionsTask{
-		baseTask:              baseTask{metaCache: node.metaCache},
+		baseTask:              baseTask{metaCache: node.getMetaCache()},
 		ctx:                   ctx,
 		Condition:             NewTaskCondition(ctx),
 		LoadPartitionsRequest: request,
@@ -1724,7 +1724,7 @@ func (node *Proxy) ReleasePartitions(ctx context.Context, request *milvuspb.Rele
 	defer sp.End()
 
 	rpt := &releasePartitionsTask{
-		baseTask:                 baseTask{metaCache: node.metaCache},
+		baseTask:                 baseTask{metaCache: node.getMetaCache()},
 		ctx:                      ctx,
 		Condition:                NewTaskCondition(ctx),
 		ReleasePartitionsRequest: request,
@@ -1782,7 +1782,7 @@ func (node *Proxy) GetPartitionStatistics(ctx context.Context, request *milvuspb
 	tr := timerecord.NewTimeRecorder(method)
 
 	g := &getPartitionStatisticsTask{
-		baseTask:                      baseTask{metaCache: node.metaCache},
+		baseTask:                      baseTask{metaCache: node.getMetaCache()},
 		ctx:                           ctx,
 		Condition:                     NewTaskCondition(ctx),
 		GetPartitionStatisticsRequest: request,
@@ -1839,7 +1839,7 @@ func (node *Proxy) ShowPartitions(ctx context.Context, request *milvuspb.ShowPar
 	defer sp.End()
 
 	spt := &showPartitionsTask{
-		baseTask:              baseTask{metaCache: node.metaCache},
+		baseTask:              baseTask{metaCache: node.getMetaCache()},
 		ctx:                   ctx,
 		Condition:             NewTaskCondition(ctx),
 		ShowPartitionsRequest: request,
@@ -2078,7 +2078,7 @@ func (node *Proxy) CreateIndex(ctx context.Context, request *milvuspb.CreateInde
 	defer sp.End()
 
 	cit := &createIndexTask{
-		baseTask:  baseTask{metaCache: node.metaCache},
+		baseTask:  baseTask{metaCache: node.getMetaCache()},
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
 		req:       request,
@@ -2131,7 +2131,7 @@ func (node *Proxy) AlterIndex(ctx context.Context, request *milvuspb.AlterIndexR
 	defer sp.End()
 
 	task := &alterIndexTask{
-		baseTask:  baseTask{metaCache: node.metaCache},
+		baseTask:  baseTask{metaCache: node.getMetaCache()},
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
 		req:       request,
@@ -2187,7 +2187,7 @@ func (node *Proxy) DescribeIndex(ctx context.Context, request *milvuspb.Describe
 	defer sp.End()
 
 	dit := &describeIndexTask{
-		baseTask:             baseTask{metaCache: node.metaCache},
+		baseTask:             baseTask{metaCache: node.getMetaCache()},
 		ctx:                  ctx,
 		Condition:            NewTaskCondition(ctx),
 		DescribeIndexRequest: request,
@@ -2248,7 +2248,7 @@ func (node *Proxy) GetIndexStatistics(ctx context.Context, request *milvuspb.Get
 	defer sp.End()
 
 	dit := &getIndexStatisticsTask{
-		baseTask:                  baseTask{metaCache: node.metaCache},
+		baseTask:                  baseTask{metaCache: node.getMetaCache()},
 		ctx:                       ctx,
 		Condition:                 NewTaskCondition(ctx),
 		GetIndexStatisticsRequest: request,
@@ -2303,7 +2303,7 @@ func (node *Proxy) DropIndex(ctx context.Context, request *milvuspb.DropIndexReq
 	defer sp.End()
 
 	dit := &dropIndexTask{
-		baseTask:         baseTask{metaCache: node.metaCache},
+		baseTask:         baseTask{metaCache: node.getMetaCache()},
 		ctx:              ctx,
 		Condition:        NewTaskCondition(ctx),
 		DropIndexRequest: request,
@@ -2361,7 +2361,7 @@ func (node *Proxy) GetIndexBuildProgress(ctx context.Context, request *milvuspb.
 	defer sp.End()
 
 	gibpt := &getIndexBuildProgressTask{
-		baseTask:                     baseTask{metaCache: node.metaCache},
+		baseTask:                     baseTask{metaCache: node.getMetaCache()},
 		ctx:                          ctx,
 		Condition:                    NewTaskCondition(ctx),
 		GetIndexBuildProgressRequest: request,
@@ -2422,7 +2422,7 @@ func (node *Proxy) GetIndexState(ctx context.Context, request *milvuspb.GetIndex
 	defer sp.End()
 
 	dipt := &getIndexStateTask{
-		baseTask:             baseTask{metaCache: node.metaCache},
+		baseTask:             baseTask{metaCache: node.getMetaCache()},
 		ctx:                  ctx,
 		Condition:            NewTaskCondition(ctx),
 		GetIndexStateRequest: request,
@@ -2498,7 +2498,7 @@ func (node *Proxy) Insert(ctx context.Context, request *milvuspb.InsertRequest) 
 
 	it := &insertTask{
 		baseTask: baseTask{
-			metaCache: node.metaCache,
+			metaCache: node.getMetaCache(),
 		},
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
@@ -2637,7 +2637,7 @@ func (node *Proxy) Delete(ctx context.Context, request *milvuspb.DeleteRequest) 
 
 	dr := &deleteRunner{
 		req:             request,
-		metaCache:       node.metaCache,
+		metaCache:       node.getMetaCache(),
 		idAllocator:     node.rowIDAllocator,
 		tsoAllocatorIns: node.tsoAllocator,
 		chMgr:           node.chMgr,
@@ -2741,7 +2741,7 @@ func (node *Proxy) Upsert(ctx context.Context, request *milvuspb.UpsertRequest) 
 
 	it := &upsertTask{
 		baseTask: baseTask{
-			metaCache: node.metaCache,
+			metaCache: node.getMetaCache(),
 		},
 		baseMsg: msgstream.BaseMsg{
 			HashValues: request.HashKeys,
@@ -2998,7 +2998,7 @@ func (node *Proxy) search(ctx context.Context, request *milvuspb.SearchRequest, 
 
 	qt := &searchTask{
 		baseTask: baseTask{
-			metaCache: node.metaCache,
+			metaCache: node.getMetaCache(),
 		},
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
@@ -3233,7 +3233,7 @@ func (node *Proxy) hybridSearch(ctx context.Context, request *milvuspb.HybridSea
 	newSearchReq := convertHybridSearchToSearch(request)
 	qt := &searchTask{
 		baseTask: baseTask{
-			metaCache: node.metaCache,
+			metaCache: node.getMetaCache(),
 		},
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
@@ -3535,7 +3535,7 @@ func (node *Proxy) handleIfSearchByPK(ctx context.Context, request *milvuspb.Sea
 	// Create queryTask to execute the retrieval
 	qt := &queryTask{
 		baseTask: baseTask{
-			metaCache: node.metaCache,
+			metaCache: node.getMetaCache(),
 		},
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
@@ -3664,7 +3664,7 @@ func (node *Proxy) Flush(ctx context.Context, request *milvuspb.FlushRequest) (*
 	defer sp.End()
 
 	ft := &flushTask{
-		baseTask:     baseTask{metaCache: node.metaCache},
+		baseTask:     baseTask{metaCache: node.getMetaCache()},
 		ctx:          ctx,
 		Condition:    NewTaskCondition(ctx),
 		FlushRequest: request,
@@ -3820,7 +3820,7 @@ func (node *Proxy) query(ctx context.Context, qt *queryTask, sp trace.Span) (*mi
 func (node *Proxy) Query(ctx context.Context, request *milvuspb.QueryRequest) (*milvuspb.QueryResults, error) {
 	qt := &queryTask{
 		baseTask: baseTask{
-			metaCache: node.metaCache,
+			metaCache: node.getMetaCache(),
 		},
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
@@ -3924,7 +3924,7 @@ func (node *Proxy) CreateAlias(ctx context.Context, request *milvuspb.CreateAlia
 	defer sp.End()
 
 	cat := &CreateAliasTask{
-		baseTask:           baseTask{metaCache: node.metaCache},
+		baseTask:           baseTask{metaCache: node.getMetaCache()},
 		ctx:                ctx,
 		Condition:          NewTaskCondition(ctx),
 		CreateAliasRequest: request,
@@ -4035,7 +4035,7 @@ func (node *Proxy) ListAliases(ctx context.Context, request *milvuspb.ListAliase
 	defer sp.End()
 
 	lat := &ListAliasesTask{
-		baseTask:           baseTask{metaCache: node.metaCache},
+		baseTask:           baseTask{metaCache: node.getMetaCache()},
 		ctx:                ctx,
 		Condition:          NewTaskCondition(ctx),
 		nodeID:             node.session.ServerID,
@@ -4142,7 +4142,7 @@ func (node *Proxy) AlterAlias(ctx context.Context, request *milvuspb.AlterAliasR
 	defer sp.End()
 
 	aat := &AlterAliasTask{
-		baseTask:          baseTask{metaCache: node.metaCache},
+		baseTask:          baseTask{metaCache: node.getMetaCache()},
 		ctx:               ctx,
 		Condition:         NewTaskCondition(ctx),
 		AlterAliasRequest: request,
@@ -6157,7 +6157,7 @@ func (node *Proxy) TransferReplica(ctx context.Context, request *milvuspb.Transf
 	defer sp.End()
 	tr := timerecord.NewTimeRecorder(method)
 	t := &TransferReplicaTask{
-		baseTask:               baseTask{metaCache: node.metaCache},
+		baseTask:               baseTask{metaCache: node.getMetaCache()},
 		ctx:                    ctx,
 		Condition:              NewTaskCondition(ctx),
 		TransferReplicaRequest: request,
@@ -6262,7 +6262,7 @@ func (node *Proxy) DescribeResourceGroup(ctx context.Context, request *milvuspb.
 	defer sp.End()
 	tr := timerecord.NewTimeRecorder(method)
 	t := &DescribeResourceGroupTask{
-		baseTask:                     baseTask{metaCache: node.metaCache},
+		baseTask:                     baseTask{metaCache: node.getMetaCache()},
 		ctx:                          ctx,
 		Condition:                    NewTaskCondition(ctx),
 		DescribeResourceGroupRequest: request,
@@ -6439,7 +6439,7 @@ func (node *Proxy) ImportV2(ctx context.Context, req *internalpb.ImportRequest) 
 	nodeID := paramtable.GetStringNodeID()
 
 	it := &importTask{
-		baseTask:  baseTask{metaCache: node.metaCache},
+		baseTask:  baseTask{metaCache: node.getMetaCache()},
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
 		req:       req,
@@ -6759,7 +6759,7 @@ func (node *Proxy) RunAnalyzer(ctx context.Context, req *milvuspb.RunAnalyzerReq
 
 	method := "RunAnalyzer"
 	task := &RunAnalyzerTask{
-		baseTask:           baseTask{metaCache: node.metaCache},
+		baseTask:           baseTask{metaCache: node.getMetaCache()},
 		ctx:                ctx,
 		lb:                 node.lbPolicy,
 		Condition:          NewTaskCondition(ctx),
@@ -7369,7 +7369,7 @@ func (node *Proxy) BatchUpdateManifest(ctx context.Context, req *milvuspb.BatchU
 	nodeID := fmt.Sprint(paramtable.GetNodeID())
 
 	bt := &batchUpdateManifestTask{
-		baseTask:  baseTask{metaCache: node.metaCache},
+		baseTask:  baseTask{metaCache: node.getMetaCache()},
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
 		req:       req,

--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -96,9 +96,6 @@ func TestProjectSearchResultValidDataForLegacy(t *testing.T) {
 
 func TestProxy_InvalidateCollectionMetaCache_remove_stream(t *testing.T) {
 	paramtable.Init()
-	cache := globalMetaCache
-	globalMetaCache = nil
-	defer func() { globalMetaCache = cache }()
 
 	chMgr := NewMockChannelsMgr(t)
 	chMgr.EXPECT().removeDMLStream(mock.Anything).Return()
@@ -125,17 +122,14 @@ func TestProxy_InvalidateCollectionMetaCache_remove_stream(t *testing.T) {
 // mock fails the test on any unexpected RemoveAliasHolders call.
 func TestProxy_InvalidateCollectionMetaCache_AliasScanGating(t *testing.T) {
 	paramtable.Init()
-	oldCache := globalMetaCache
-	defer func() { globalMetaCache = oldCache }()
 	ctx := context.Background()
 	const ts = uint64(42)
 
 	newNode := func(t *testing.T) (*Proxy, *MockCache) {
 		cache := NewMockCache(t)
-		globalMetaCache = cache
 		shard := shardclient.NewMockShardClientManager(t)
 		shard.EXPECT().InvalidateShardLeaderCache(mock.Anything).Return().Maybe()
-		node := &Proxy{shardMgr: shard}
+		node := &Proxy{metaCache: cache, shardMgr: shard}
 		node.UpdateStateCode(commonpb.StateCode_Healthy)
 		return node, cache
 	}
@@ -179,15 +173,12 @@ func TestProxy_InvalidateCollectionMetaCache_AliasScanGating(t *testing.T) {
 
 func TestProxy_InvalidateCollectionMetaCache_DatabaseInvalidationScope(t *testing.T) {
 	paramtable.Init()
-	oldCache := globalMetaCache
-	defer func() { globalMetaCache = oldCache }()
 
 	t.Run("alter database removes database info only", func(t *testing.T) {
 		cache := NewMockCache(t)
 		cache.EXPECT().RemoveDatabaseInfo(mock.Anything, "db").Return().Once()
-		globalMetaCache = cache
 
-		node := &Proxy{}
+		node := &Proxy{metaCache: cache}
 		node.UpdateStateCode(commonpb.StateCode_Healthy)
 		status, err := node.InvalidateCollectionMetaCache(context.Background(), &proxypb.InvalidateCollMetaCacheRequest{
 			Base:   &commonpb.MsgBase{MsgType: commonpb.MsgType_AlterDatabase},
@@ -200,11 +191,10 @@ func TestProxy_InvalidateCollectionMetaCache_DatabaseInvalidationScope(t *testin
 	t.Run("drop database still removes all database metadata", func(t *testing.T) {
 		cache := NewMockCache(t)
 		cache.EXPECT().RemoveDatabase(mock.Anything, "db").Return().Once()
-		globalMetaCache = cache
 
 		shardMgr := shardclient.NewMockShardClientManager(t)
 		shardMgr.EXPECT().RemoveDatabase("db").Return().Once()
-		node := &Proxy{shardMgr: shardMgr}
+		node := &Proxy{metaCache: cache, shardMgr: shardMgr}
 		assert.NoError(t, node.initRateCollector())
 		node.UpdateStateCode(commonpb.StateCode_Healthy)
 		status, err := node.InvalidateCollectionMetaCache(context.Background(), &proxypb.InvalidateCollMetaCacheRequest{
@@ -218,11 +208,9 @@ func TestProxy_InvalidateCollectionMetaCache_DatabaseInvalidationScope(t *testin
 
 func TestProxy_InvalidateCollectionMetaCache_EmptyPartitionNameReturnsTypedStatus(t *testing.T) {
 	paramtable.Init()
-	oldCache := globalMetaCache
-	defer func() { globalMetaCache = oldCache }()
-	globalMetaCache = NewMockCache(t)
+	cache := NewMockCache(t)
 
-	node := &Proxy{}
+	node := &Proxy{metaCache: cache}
 	node.UpdateStateCode(commonpb.StateCode_Healthy)
 	status, err := node.InvalidateCollectionMetaCache(context.Background(), &proxypb.InvalidateCollMetaCacheRequest{
 		Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_CreatePartition},
@@ -589,7 +577,9 @@ func TestProxy_ResourceGroup(t *testing.T) {
 	defer node.sched.Close()
 
 	// mgr := newShardClientMgr()
-	InitMetaCache(ctx, qc)
+	cache, err := initMetaCache(ctx, qc)
+	assert.NoError(t, err)
+	node.metaCache = cache
 
 	successStatus := &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success}
 
@@ -671,7 +661,9 @@ func TestProxy_InvalidResourceGroupName(t *testing.T) {
 	defer node.sched.Close()
 
 	// mgr := newShardClientMgr()
-	InitMetaCache(ctx, qc)
+	cache, err := initMetaCache(ctx, qc)
+	assert.NoError(t, err)
+	node.metaCache = cache
 
 	t.Run("create resource group", func(t *testing.T) {
 		resp, err := node.CreateResourceGroup(ctx, &milvuspb.CreateResourceGroupRequest{
@@ -730,12 +722,11 @@ func createTestProxy() *Proxy {
 
 func TestProxy_FlushAll_Success(t *testing.T) {
 	mockey.PatchConvey("TestProxy_FlushAll_Success", t, func() {
-		// Mock global meta cache methods
-		globalMetaCache = &MetaCache{}
-		mockey.Mock(globalMetaCache.GetCollectionID).To(func(ctx context.Context, dbName, collectionName string) (UniqueID, error) {
+		metaCache := &MetaCache{}
+		mockey.Mock(metaCache.GetCollectionID).To(func(ctx context.Context, dbName, collectionName string) (UniqueID, error) {
 			return UniqueID(0), nil
 		}).Build()
-		mockey.Mock(globalMetaCache.RemoveDatabase).Return().Build()
+		mockey.Mock(metaCache.RemoveDatabase).Return().Build()
 
 		// Mock paramtable initialization
 		mockey.Mock(paramtable.Init).Return().Build()
@@ -752,6 +743,7 @@ func TestProxy_FlushAll_Success(t *testing.T) {
 
 		// Act: Execute test
 		node := createTestProxy()
+		node.metaCache = metaCache
 		defer node.sched.Close()
 
 		messageID := pulsar2.NewPulsarID(pulsar.EarliestMessageID())
@@ -784,12 +776,11 @@ func TestProxy_FlushAll_Success(t *testing.T) {
 
 func TestProxy_FlushAll_ServerAbnormal(t *testing.T) {
 	mockey.PatchConvey("TestProxy_FlushAll_ServerAbnormal", t, func() {
-		// Mock global meta cache methods
-		globalMetaCache = &MetaCache{}
-		mockey.Mock(globalMetaCache.GetCollectionID).To(func(ctx context.Context, dbName, collectionName string) (UniqueID, error) {
+		metaCache := &MetaCache{}
+		mockey.Mock(metaCache.GetCollectionID).To(func(ctx context.Context, dbName, collectionName string) (UniqueID, error) {
 			return UniqueID(0), nil
 		}).Build()
-		mockey.Mock(globalMetaCache.RemoveDatabase).Return().Build()
+		mockey.Mock(metaCache.RemoveDatabase).Return().Build()
 
 		// Mock paramtable initialization
 		mockey.Mock(paramtable.Init).Return().Build()
@@ -797,6 +788,7 @@ func TestProxy_FlushAll_ServerAbnormal(t *testing.T) {
 
 		// Act: Execute test
 		node := createTestProxy()
+		node.metaCache = metaCache
 		defer node.sched.Close()
 
 		mixcoord := &grpcmixcoordclient.Client{}
@@ -896,15 +888,13 @@ func TestProxy_GetFlushState(t *testing.T) {
 		assert.NoError(t, err)
 		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrParameterInvalid)
 
-		cacheBak := globalMetaCache
-		defer func() { globalMetaCache = cacheBak }()
 		cache := NewMockCache(t)
 		cache.On("GetCollectionID",
 			mock.Anything, // context.Context
 			mock.AnythingOfType("string"),
 			mock.AnythingOfType("string"),
 		).Return(UniqueID(0), nil).Maybe()
-		globalMetaCache = cache
+		node.metaCache = cache
 
 		resp, err = node.GetFlushState(ctx, &milvuspb.GetFlushStateRequest{
 			CollectionName: "collection1",
@@ -1242,11 +1232,9 @@ func TestProxyDropDatabase(t *testing.T) {
 		node.mixCoord = mix
 		node.UpdateStateCode(commonpb.StateCode_Healthy)
 
-		cacheBak := globalMetaCache
-		defer func() { globalMetaCache = cacheBak }()
 		cache := NewMockCache(t)
 		cache.EXPECT().RemoveDatabase(mock.Anything, mock.AnythingOfType("string")).Return()
-		globalMetaCache = cache
+		node.metaCache = cache
 
 		ctx := context.Background()
 
@@ -1449,7 +1437,7 @@ func TestProxyDescribeCollection(t *testing.T) {
 	}, nil).Maybe()
 	mixCoord.On("DescribeCollection", mock.Anything, mock.Anything).Return(nil, merr.ErrCollectionNotFound).Maybe()
 	var err error
-	globalMetaCache, err = NewMetaCache(mixCoord)
+	node.metaCache, err = NewMetaCache(mixCoord)
 	assert.NoError(t, err)
 
 	t.Run("not healthy", func(t *testing.T) {
@@ -1634,7 +1622,6 @@ func TestProxy_Delete(t *testing.T) {
 		cache.On("GetCollectionInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(basicInfo, nil)
 		chMgr.On("getVChannels", mock.Anything).Return(channels, nil)
 		chMgr.On("getChannels", mock.Anything).Return(nil, errors.New("mock error"))
-		globalMetaCache = cache
 		rc := mocks.NewMockRootCoordClient(t)
 		tsoAllocator := &mockTsoAllocator{}
 		idAllocator, err := allocator.NewIDAllocator(ctx, rc, 0)
@@ -1643,7 +1630,7 @@ func TestProxy_Delete(t *testing.T) {
 		queue, err := newTaskScheduler(ctx, tsoAllocator)
 		assert.NoError(t, err)
 
-		node := &Proxy{chMgr: chMgr, rowIDAllocator: idAllocator, sched: queue}
+		node := &Proxy{metaCache: cache, chMgr: chMgr, rowIDAllocator: idAllocator, sched: queue}
 		node.UpdateStateCode(commonpb.StateCode_Healthy)
 		resp, err := node.Delete(ctx, req)
 		assert.NoError(t, err)
@@ -1654,9 +1641,6 @@ func TestProxy_Delete(t *testing.T) {
 func TestProxy_ImportV2(t *testing.T) {
 	ctx := context.Background()
 	mockErr := errors.New("mock error")
-
-	cache := globalMetaCache
-	defer func() { globalMetaCache = cache }()
 
 	t.Run("ImportV2", func(t *testing.T) {
 		// server is not healthy
@@ -1688,7 +1672,7 @@ func TestProxy_ImportV2(t *testing.T) {
 		mc := NewMockCache(t)
 		mc.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(nil, mockErr).Once()
 		mc.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(0, mockErr)
-		globalMetaCache = mc
+		node.metaCache = mc
 		rsp, err = node.ImportV2(ctx, &internalpb.ImportRequest{CollectionName: "aaa"})
 		assert.NoError(t, err)
 		assert.NotEqual(t, int32(0), rsp.GetStatus().GetCode())
@@ -1700,7 +1684,7 @@ func TestProxy_ImportV2(t *testing.T) {
 		mc.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(nil, mockErr).Once()
 		mc.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
 		mc.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(nil, mockErr).Once()
-		globalMetaCache = mc
+		node.metaCache = mc
 		rsp, err = node.ImportV2(ctx, &internalpb.ImportRequest{CollectionName: "aaa"})
 		assert.NoError(t, err)
 		assert.NotEqual(t, int32(0), rsp.GetStatus().GetCode())
@@ -1714,7 +1698,7 @@ func TestProxy_ImportV2(t *testing.T) {
 		mc.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(&schemaInfo{
 			CollectionSchema: &schemapb.CollectionSchema{},
 		}, nil).Once()
-		globalMetaCache = mc
+		node.metaCache = mc
 		rsp, err = node.ImportV2(ctx, &internalpb.ImportRequest{CollectionName: "aaa"})
 		assert.NoError(t, err)
 		assert.NotEqual(t, int32(0), rsp.GetStatus().GetCode())
@@ -1727,7 +1711,7 @@ func TestProxy_ImportV2(t *testing.T) {
 				{IsPartitionKey: true},
 			}},
 		}, nil)
-		globalMetaCache = mc
+		node.metaCache = mc
 		chMgr.EXPECT().getVChannels(mock.Anything).Return(nil, mockErr).Once()
 		rsp, err = node.ImportV2(ctx, &internalpb.ImportRequest{CollectionName: "aaa"})
 		assert.NoError(t, err)
@@ -1750,7 +1734,7 @@ func TestProxy_ImportV2(t *testing.T) {
 			}},
 		}, nil)
 		mc.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(nil, mockErr)
-		globalMetaCache = mc
+		node.metaCache = mc
 		rsp, err = node.ImportV2(ctx, &internalpb.ImportRequest{CollectionName: "aaa"})
 		assert.NoError(t, err)
 		assert.NotEqual(t, int32(0), rsp.GetStatus().GetCode())
@@ -1762,7 +1746,7 @@ func TestProxy_ImportV2(t *testing.T) {
 			CollectionSchema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{{FieldID: 1}}},
 		}, nil)
 		mc.EXPECT().GetPartitionID(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(0, mockErr)
-		globalMetaCache = mc
+		node.metaCache = mc
 		rsp, err = node.ImportV2(ctx, &internalpb.ImportRequest{CollectionName: "aaa", PartitionName: "bbb"})
 		assert.NoError(t, err)
 		assert.NotEqual(t, int32(0), rsp.GetStatus().GetCode())
@@ -1774,7 +1758,7 @@ func TestProxy_ImportV2(t *testing.T) {
 			CollectionSchema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{{FieldID: 1}}},
 		}, nil)
 		mc.EXPECT().GetPartitionID(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
-		globalMetaCache = mc
+		node.metaCache = mc
 		rsp, err = node.ImportV2(ctx, &internalpb.ImportRequest{CollectionName: "aaa", PartitionName: "bbb"})
 		assert.NoError(t, err)
 		assert.NotEqual(t, int32(0), rsp.GetStatus().GetCode())
@@ -1801,7 +1785,7 @@ func TestProxy_ImportV2(t *testing.T) {
 		mc.EXPECT().GetDatabaseInfo(mock.Anything, mock.Anything).Return(&databaseInfo{
 			DBID: 1,
 		}, nil)
-		globalMetaCache = mc
+		node.metaCache = mc
 
 		mixCoord := mocks.NewMockMixCoordClient(t)
 		mixCoord.EXPECT().ImportV2(mock.Anything, mock.Anything).Return(&internalpb.ImportResponse{
@@ -1852,7 +1836,7 @@ func TestProxy_ImportV2(t *testing.T) {
 		// normal case
 		mc := NewMockCache(t)
 		mc.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
-		globalMetaCache = mc
+		node.metaCache = mc
 		mixCoord := mocks.NewMockMixCoordClient(t)
 		mixCoord.EXPECT().ListImports(mock.Anything, mock.Anything).Return(nil, nil)
 		node.mixCoord = mixCoord
@@ -1908,8 +1892,6 @@ func TestProxy_InvalidateShardLeaderCache(t *testing.T) {
 		node := &Proxy{}
 		node.UpdateStateCode(commonpb.StateCode_Healthy)
 
-		cacheBak := globalMetaCache
-		defer func() { globalMetaCache = cacheBak }()
 		// set expectations
 		mockShardClientMgr := shardclient.NewMockShardClientManager(t)
 		mockShardClientMgr.EXPECT().InvalidateShardLeaderCache(mock.Anything).Return()
@@ -1961,10 +1943,6 @@ func TestRunAnalyzer(t *testing.T) {
 	paramtable.Init()
 	ctx := context.Background()
 
-	cache := globalMetaCache
-	globalMetaCache = nil
-	defer func() { globalMetaCache = cache }()
-
 	p := &Proxy{}
 
 	tsoAllocatorIns := newMockTsoAllocator()
@@ -2012,7 +1990,7 @@ func TestRunAnalyzer(t *testing.T) {
 
 	t.Run("run analyzer from loaded collection field", func(t *testing.T) {
 		mockCache := NewMockCache(t)
-		globalMetaCache = mockCache
+		p.metaCache = mockCache
 
 		fieldMap := &typeutil.ConcurrentMap[string, int64]{}
 		fieldMap.Insert("test_text", 100)
@@ -2394,8 +2372,6 @@ func TestHandleIfSearchByPK_BM25Detection(t *testing.T) {
 func TestHandleIfSearchByPK_PreservesNamespaceInInternalQuery(t *testing.T) {
 	mockey.PatchConvey("TestHandleIfSearchByPK_PreservesNamespaceInInternalQuery", t, func() {
 		paramtable.Init()
-		originalCache := globalMetaCache
-		defer func() { globalMetaCache = originalCache }()
 
 		namespace := "tenant_a"
 		schema := &schemapb.CollectionSchema{
@@ -2416,7 +2392,7 @@ func TestHandleIfSearchByPK_PreservesNamespaceInInternalQuery(t *testing.T) {
 		cache.EXPECT().
 			GetCollectionInfo(mock.Anything, "default", "test_collection", int64(0)).
 			Return(&collectionInfo{Schema: mustNewSchemaInfo(schema)}, nil)
-		globalMetaCache = cache
+		node := &Proxy{metaCache: cache}
 
 		var capturedNamespace *string
 		mockey.Mock((*Proxy).query).To(func(_ *Proxy, _ context.Context, qt *queryTask, _ trace.Span) (*milvuspb.QueryResults, segcore.StorageCost, error) {
@@ -2453,7 +2429,6 @@ func TestHandleIfSearchByPK_PreservesNamespaceInInternalQuery(t *testing.T) {
 			}, segcore.StorageCost{}, nil
 		}).Build()
 
-		node := &Proxy{}
 		req := &milvuspb.SearchRequest{
 			DbName:         "default",
 			CollectionName: "test_collection",
@@ -2474,10 +2449,7 @@ func TestHandleIfSearchByPK_PreservesNamespaceInInternalQuery(t *testing.T) {
 }
 
 func TestProxy_ManualCompaction_ExternalCollection(t *testing.T) {
-	// Save and restore globalMetaCache
-	cache := globalMetaCache
-	defer func() { globalMetaCache = cache }()
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
 
 	// Create external collection schema
 	externalSchema := &schemapb.CollectionSchema{
@@ -2495,7 +2467,7 @@ func TestProxy_ManualCompaction_ExternalCollection(t *testing.T) {
 	defer m1.UnPatch()
 	defer m2.UnPatch()
 
-	proxy := &Proxy{}
+	proxy := &Proxy{metaCache: cache}
 	proxy.UpdateStateCode(commonpb.StateCode_Healthy)
 
 	req := &milvuspb.ManualCompactionRequest{
@@ -2509,9 +2481,7 @@ func TestProxy_ManualCompaction_ExternalCollection(t *testing.T) {
 }
 
 func TestProxy_Insert_ExternalCollection(t *testing.T) {
-	cache := globalMetaCache
-	defer func() { globalMetaCache = cache }()
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
 
 	externalSchema := &schemapb.CollectionSchema{
 		Name: "external_col",
@@ -2523,7 +2493,7 @@ func TestProxy_Insert_ExternalCollection(t *testing.T) {
 	m1 := mockey.Mock((*MetaCache).GetCollectionSchema).Return(mustNewSchemaInfo(externalSchema), nil).Build()
 	defer m1.UnPatch()
 
-	proxy := &Proxy{}
+	proxy := &Proxy{metaCache: cache}
 	proxy.UpdateStateCode(commonpb.StateCode_Healthy)
 
 	req := &milvuspb.InsertRequest{
@@ -2538,9 +2508,7 @@ func TestProxy_Insert_ExternalCollection(t *testing.T) {
 }
 
 func TestProxy_Delete_ExternalCollection(t *testing.T) {
-	cache := globalMetaCache
-	defer func() { globalMetaCache = cache }()
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
 
 	externalSchema := &schemapb.CollectionSchema{
 		Name: "external_col",
@@ -2552,7 +2520,7 @@ func TestProxy_Delete_ExternalCollection(t *testing.T) {
 	m1 := mockey.Mock((*MetaCache).GetCollectionSchema).Return(mustNewSchemaInfo(externalSchema), nil).Build()
 	defer m1.UnPatch()
 
-	proxy := &Proxy{}
+	proxy := &Proxy{metaCache: cache}
 	proxy.UpdateStateCode(commonpb.StateCode_Healthy)
 
 	req := &milvuspb.DeleteRequest{
@@ -2568,9 +2536,7 @@ func TestProxy_Delete_ExternalCollection(t *testing.T) {
 }
 
 func TestProxy_Upsert_ExternalCollection(t *testing.T) {
-	cache := globalMetaCache
-	defer func() { globalMetaCache = cache }()
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
 
 	externalSchema := &schemapb.CollectionSchema{
 		Name: "external_col",
@@ -2582,7 +2548,7 @@ func TestProxy_Upsert_ExternalCollection(t *testing.T) {
 	m1 := mockey.Mock((*MetaCache).GetCollectionSchema).Return(mustNewSchemaInfo(externalSchema), nil).Build()
 	defer m1.UnPatch()
 
-	proxy := &Proxy{}
+	proxy := &Proxy{metaCache: cache}
 	proxy.UpdateStateCode(commonpb.StateCode_Healthy)
 
 	req := &milvuspb.UpsertRequest{
@@ -2597,9 +2563,7 @@ func TestProxy_Upsert_ExternalCollection(t *testing.T) {
 }
 
 func TestProxy_Flush_ExternalCollection(t *testing.T) {
-	cache := globalMetaCache
-	defer func() { globalMetaCache = cache }()
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
 
 	externalSchema := &schemapb.CollectionSchema{
 		Name: "external_col",
@@ -2611,7 +2575,7 @@ func TestProxy_Flush_ExternalCollection(t *testing.T) {
 	m1 := mockey.Mock((*MetaCache).GetCollectionSchema).Return(mustNewSchemaInfo(externalSchema), nil).Build()
 	defer m1.UnPatch()
 
-	proxy := &Proxy{}
+	proxy := &Proxy{metaCache: cache}
 	proxy.UpdateStateCode(commonpb.StateCode_Healthy)
 
 	req := &milvuspb.FlushRequest{
@@ -2626,9 +2590,7 @@ func TestProxy_Flush_ExternalCollection(t *testing.T) {
 }
 
 func TestProxy_CreatePartition_ExternalCollection(t *testing.T) {
-	cache := globalMetaCache
-	defer func() { globalMetaCache = cache }()
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
 
 	externalSchema := &schemapb.CollectionSchema{
 		Name: "external_col",
@@ -2640,7 +2602,7 @@ func TestProxy_CreatePartition_ExternalCollection(t *testing.T) {
 	m1 := mockey.Mock((*MetaCache).GetCollectionSchema).Return(mustNewSchemaInfo(externalSchema), nil).Build()
 	defer m1.UnPatch()
 
-	proxy := &Proxy{}
+	proxy := &Proxy{metaCache: cache}
 	proxy.UpdateStateCode(commonpb.StateCode_Healthy)
 
 	req := &milvuspb.CreatePartitionRequest{
@@ -2656,9 +2618,7 @@ func TestProxy_CreatePartition_ExternalCollection(t *testing.T) {
 }
 
 func TestProxy_DropPartition_ExternalCollection(t *testing.T) {
-	cache := globalMetaCache
-	defer func() { globalMetaCache = cache }()
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
 
 	externalSchema := &schemapb.CollectionSchema{
 		Name: "external_col",
@@ -2670,7 +2630,7 @@ func TestProxy_DropPartition_ExternalCollection(t *testing.T) {
 	m1 := mockey.Mock((*MetaCache).GetCollectionSchema).Return(mustNewSchemaInfo(externalSchema), nil).Build()
 	defer m1.UnPatch()
 
-	proxy := &Proxy{}
+	proxy := &Proxy{metaCache: cache}
 	proxy.UpdateStateCode(commonpb.StateCode_Healthy)
 
 	req := &milvuspb.DropPartitionRequest{
@@ -2686,9 +2646,7 @@ func TestProxy_DropPartition_ExternalCollection(t *testing.T) {
 }
 
 func TestProxy_ImportV2_ExternalCollection(t *testing.T) {
-	cache := globalMetaCache
-	defer func() { globalMetaCache = cache }()
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
 
 	externalSchema := &schemapb.CollectionSchema{
 		Name: "external_col",
@@ -2700,7 +2658,7 @@ func TestProxy_ImportV2_ExternalCollection(t *testing.T) {
 	m1 := mockey.Mock((*MetaCache).GetCollectionSchema).Return(mustNewSchemaInfo(externalSchema), nil).Build()
 	defer m1.UnPatch()
 
-	proxy := &Proxy{}
+	proxy := &Proxy{metaCache: cache}
 	proxy.UpdateStateCode(commonpb.StateCode_Healthy)
 
 	req := &internalpb.ImportRequest{
@@ -2953,9 +2911,7 @@ func TestProxy_AddCollectionField_DoesNotBlockOnSchemaVersion(t *testing.T) {
 }
 
 func TestProxy_AlterCollectionField_ExternalCollection(t *testing.T) {
-	cache := globalMetaCache
-	defer func() { globalMetaCache = cache }()
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
 
 	externalSchema := &schemapb.CollectionSchema{
 		Name: "external_col",
@@ -2967,7 +2923,7 @@ func TestProxy_AlterCollectionField_ExternalCollection(t *testing.T) {
 	m1 := mockey.Mock((*MetaCache).GetCollectionSchema).Return(mustNewSchemaInfo(externalSchema), nil).Build()
 	defer m1.UnPatch()
 
-	proxy := &Proxy{}
+	proxy := &Proxy{metaCache: cache}
 	proxy.UpdateStateCode(commonpb.StateCode_Healthy)
 
 	req := &milvuspb.AlterCollectionFieldRequest{
@@ -3108,16 +3064,17 @@ func TestHybridSearchRequestExprLogger_String(t *testing.T) {
 func TestProxy_BatchUpdateManifest(t *testing.T) {
 	t.Run("unhealthy", func(t *testing.T) {
 		mockey.PatchConvey("TestProxy_BatchUpdateManifest_unhealthy", t, func() {
-			globalMetaCache = &MetaCache{}
-			mockey.Mock(globalMetaCache.GetCollectionID).To(func(ctx context.Context, dbName, collectionName string) (UniqueID, error) {
+			metaCache := &MetaCache{}
+			mockey.Mock(metaCache.GetCollectionID).To(func(ctx context.Context, dbName, collectionName string) (UniqueID, error) {
 				return UniqueID(0), nil
 			}).Build()
-			mockey.Mock(globalMetaCache.RemoveDatabase).To(func(ctx context.Context, dbName string) {}).Build()
+			mockey.Mock(metaCache.RemoveDatabase).To(func(ctx context.Context, dbName string) {}).Build()
 
 			mockey.Mock(paramtable.Init).Return().Build()
 			mockey.Mock((*paramtable.ComponentParam).Save).Return().Build()
 
 			node := createTestProxy()
+			node.metaCache = metaCache
 			defer node.sched.Close()
 
 			node.UpdateStateCode(commonpb.StateCode_Abnormal)
@@ -3135,7 +3092,7 @@ func TestProxy_BatchUpdateManifest(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		mockey.PatchConvey("TestProxy_BatchUpdateManifest_success", t, func() {
-			globalMetaCache = &MetaCache{}
+			metaCache := &MetaCache{}
 			mockey.Mock((*MetaCache).GetCollectionID).To(func(m *MetaCache, ctx context.Context, dbName, collectionName string) (UniqueID, error) {
 				return UniqueID(100), nil
 			}).Build()
@@ -3145,6 +3102,7 @@ func TestProxy_BatchUpdateManifest(t *testing.T) {
 			mockey.Mock((*paramtable.ComponentParam).Save).Return().Build()
 
 			node := createTestProxy()
+			node.metaCache = metaCache
 			defer node.sched.Close()
 
 			mixcoord := &grpcmixcoordclient.Client{}
@@ -3449,9 +3407,8 @@ func TestProxy_RefreshExternalCollection_ReusePathRequiresPersistedSourceSpec(t 
 		{"persisted source empty rejected", mkInfo("", `{"format":"parquet"}`), true},
 		{"persisted spec empty rejected", mkInfo("s3://bucket/p", ""), true},
 	}
-	cacheBak := globalMetaCache
-	defer func() { globalMetaCache = cacheBak }()
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
+	node.metaCache = cache
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -3478,9 +3435,8 @@ func TestProxy_ListRefreshExternalCollectionJobs_ListAll(t *testing.T) {
 	node := &Proxy{mixCoord: &MixCoordMock{}}
 	node.UpdateStateCode(commonpb.StateCode_Healthy)
 
-	cacheBak := globalMetaCache
-	globalMetaCache = &MetaCache{}
-	defer func() { globalMetaCache = cacheBak }()
+	cache := &MetaCache{}
+	node.metaCache = cache
 
 	cacheCalled := false
 	mockGetCollectionInfo := mockey.Mock((*MetaCache).GetCollectionInfo).To(
@@ -3535,9 +3491,8 @@ func TestProxy_ListRefreshExternalCollectionJobs_ByCollection(t *testing.T) {
 	node := &Proxy{mixCoord: &MixCoordMock{}}
 	node.UpdateStateCode(commonpb.StateCode_Healthy)
 
-	cacheBak := globalMetaCache
-	globalMetaCache = &MetaCache{}
-	defer func() { globalMetaCache = cacheBak }()
+	cache := &MetaCache{}
+	node.metaCache = cache
 
 	schema := &schemapb.CollectionSchema{
 		Name: "external_collection",

--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -579,7 +579,7 @@ func TestProxy_ResourceGroup(t *testing.T) {
 	// mgr := newShardClientMgr()
 	cache, err := initMetaCache(ctx, qc)
 	assert.NoError(t, err)
-	node.metaCache = cache
+	node.setMetaCache(cache)
 
 	successStatus := &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success}
 
@@ -663,7 +663,7 @@ func TestProxy_InvalidResourceGroupName(t *testing.T) {
 	// mgr := newShardClientMgr()
 	cache, err := initMetaCache(ctx, qc)
 	assert.NoError(t, err)
-	node.metaCache = cache
+	node.setMetaCache(cache)
 
 	t.Run("create resource group", func(t *testing.T) {
 		resp, err := node.CreateResourceGroup(ctx, &milvuspb.CreateResourceGroupRequest{
@@ -743,7 +743,7 @@ func TestProxy_FlushAll_Success(t *testing.T) {
 
 		// Act: Execute test
 		node := createTestProxy()
-		node.metaCache = metaCache
+		node.setMetaCache(metaCache)
 		defer node.sched.Close()
 
 		messageID := pulsar2.NewPulsarID(pulsar.EarliestMessageID())
@@ -788,7 +788,7 @@ func TestProxy_FlushAll_ServerAbnormal(t *testing.T) {
 
 		// Act: Execute test
 		node := createTestProxy()
-		node.metaCache = metaCache
+		node.setMetaCache(metaCache)
 		defer node.sched.Close()
 
 		mixcoord := &grpcmixcoordclient.Client{}
@@ -894,7 +894,7 @@ func TestProxy_GetFlushState(t *testing.T) {
 			mock.AnythingOfType("string"),
 			mock.AnythingOfType("string"),
 		).Return(UniqueID(0), nil).Maybe()
-		node.metaCache = cache
+		node.setMetaCache(cache)
 
 		resp, err = node.GetFlushState(ctx, &milvuspb.GetFlushStateRequest{
 			CollectionName: "collection1",
@@ -1234,7 +1234,7 @@ func TestProxyDropDatabase(t *testing.T) {
 
 		cache := NewMockCache(t)
 		cache.EXPECT().RemoveDatabase(mock.Anything, mock.AnythingOfType("string")).Return()
-		node.metaCache = cache
+		node.setMetaCache(cache)
 
 		ctx := context.Background()
 
@@ -1437,8 +1437,9 @@ func TestProxyDescribeCollection(t *testing.T) {
 	}, nil).Maybe()
 	mixCoord.On("DescribeCollection", mock.Anything, mock.Anything).Return(nil, merr.ErrCollectionNotFound).Maybe()
 	var err error
-	node.metaCache, err = NewMetaCache(mixCoord)
+	mc, err := NewMetaCache(mixCoord)
 	assert.NoError(t, err)
+	node.setMetaCache(mc)
 
 	t.Run("not healthy", func(t *testing.T) {
 		node.UpdateStateCode(commonpb.StateCode_Abnormal)
@@ -1672,7 +1673,7 @@ func TestProxy_ImportV2(t *testing.T) {
 		mc := NewMockCache(t)
 		mc.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(nil, mockErr).Once()
 		mc.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(0, mockErr)
-		node.metaCache = mc
+		node.setMetaCache(mc)
 		rsp, err = node.ImportV2(ctx, &internalpb.ImportRequest{CollectionName: "aaa"})
 		assert.NoError(t, err)
 		assert.NotEqual(t, int32(0), rsp.GetStatus().GetCode())
@@ -1684,7 +1685,7 @@ func TestProxy_ImportV2(t *testing.T) {
 		mc.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(nil, mockErr).Once()
 		mc.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
 		mc.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(nil, mockErr).Once()
-		node.metaCache = mc
+		node.setMetaCache(mc)
 		rsp, err = node.ImportV2(ctx, &internalpb.ImportRequest{CollectionName: "aaa"})
 		assert.NoError(t, err)
 		assert.NotEqual(t, int32(0), rsp.GetStatus().GetCode())
@@ -1698,7 +1699,7 @@ func TestProxy_ImportV2(t *testing.T) {
 		mc.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(&schemaInfo{
 			CollectionSchema: &schemapb.CollectionSchema{},
 		}, nil).Once()
-		node.metaCache = mc
+		node.setMetaCache(mc)
 		rsp, err = node.ImportV2(ctx, &internalpb.ImportRequest{CollectionName: "aaa"})
 		assert.NoError(t, err)
 		assert.NotEqual(t, int32(0), rsp.GetStatus().GetCode())
@@ -1711,7 +1712,7 @@ func TestProxy_ImportV2(t *testing.T) {
 				{IsPartitionKey: true},
 			}},
 		}, nil)
-		node.metaCache = mc
+		node.setMetaCache(mc)
 		chMgr.EXPECT().getVChannels(mock.Anything).Return(nil, mockErr).Once()
 		rsp, err = node.ImportV2(ctx, &internalpb.ImportRequest{CollectionName: "aaa"})
 		assert.NoError(t, err)
@@ -1734,7 +1735,7 @@ func TestProxy_ImportV2(t *testing.T) {
 			}},
 		}, nil)
 		mc.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(nil, mockErr)
-		node.metaCache = mc
+		node.setMetaCache(mc)
 		rsp, err = node.ImportV2(ctx, &internalpb.ImportRequest{CollectionName: "aaa"})
 		assert.NoError(t, err)
 		assert.NotEqual(t, int32(0), rsp.GetStatus().GetCode())
@@ -1746,7 +1747,7 @@ func TestProxy_ImportV2(t *testing.T) {
 			CollectionSchema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{{FieldID: 1}}},
 		}, nil)
 		mc.EXPECT().GetPartitionID(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(0, mockErr)
-		node.metaCache = mc
+		node.setMetaCache(mc)
 		rsp, err = node.ImportV2(ctx, &internalpb.ImportRequest{CollectionName: "aaa", PartitionName: "bbb"})
 		assert.NoError(t, err)
 		assert.NotEqual(t, int32(0), rsp.GetStatus().GetCode())
@@ -1758,7 +1759,7 @@ func TestProxy_ImportV2(t *testing.T) {
 			CollectionSchema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{{FieldID: 1}}},
 		}, nil)
 		mc.EXPECT().GetPartitionID(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
-		node.metaCache = mc
+		node.setMetaCache(mc)
 		rsp, err = node.ImportV2(ctx, &internalpb.ImportRequest{CollectionName: "aaa", PartitionName: "bbb"})
 		assert.NoError(t, err)
 		assert.NotEqual(t, int32(0), rsp.GetStatus().GetCode())
@@ -1785,7 +1786,7 @@ func TestProxy_ImportV2(t *testing.T) {
 		mc.EXPECT().GetDatabaseInfo(mock.Anything, mock.Anything).Return(&databaseInfo{
 			DBID: 1,
 		}, nil)
-		node.metaCache = mc
+		node.setMetaCache(mc)
 
 		mixCoord := mocks.NewMockMixCoordClient(t)
 		mixCoord.EXPECT().ImportV2(mock.Anything, mock.Anything).Return(&internalpb.ImportResponse{
@@ -1836,7 +1837,7 @@ func TestProxy_ImportV2(t *testing.T) {
 		// normal case
 		mc := NewMockCache(t)
 		mc.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
-		node.metaCache = mc
+		node.setMetaCache(mc)
 		mixCoord := mocks.NewMockMixCoordClient(t)
 		mixCoord.EXPECT().ListImports(mock.Anything, mock.Anything).Return(nil, nil)
 		node.mixCoord = mixCoord
@@ -3074,7 +3075,7 @@ func TestProxy_BatchUpdateManifest(t *testing.T) {
 			mockey.Mock((*paramtable.ComponentParam).Save).Return().Build()
 
 			node := createTestProxy()
-			node.metaCache = metaCache
+			node.setMetaCache(metaCache)
 			defer node.sched.Close()
 
 			node.UpdateStateCode(commonpb.StateCode_Abnormal)
@@ -3102,7 +3103,7 @@ func TestProxy_BatchUpdateManifest(t *testing.T) {
 			mockey.Mock((*paramtable.ComponentParam).Save).Return().Build()
 
 			node := createTestProxy()
-			node.metaCache = metaCache
+			node.setMetaCache(metaCache)
 			defer node.sched.Close()
 
 			mixcoord := &grpcmixcoordclient.Client{}
@@ -3408,7 +3409,7 @@ func TestProxy_RefreshExternalCollection_ReusePathRequiresPersistedSourceSpec(t 
 		{"persisted spec empty rejected", mkInfo("s3://bucket/p", ""), true},
 	}
 	cache := &MetaCache{}
-	node.metaCache = cache
+	node.setMetaCache(cache)
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -3436,7 +3437,7 @@ func TestProxy_ListRefreshExternalCollectionJobs_ListAll(t *testing.T) {
 	node.UpdateStateCode(commonpb.StateCode_Healthy)
 
 	cache := &MetaCache{}
-	node.metaCache = cache
+	node.setMetaCache(cache)
 
 	cacheCalled := false
 	mockGetCollectionInfo := mockey.Mock((*MetaCache).GetCollectionInfo).To(
@@ -3492,7 +3493,7 @@ func TestProxy_ListRefreshExternalCollectionJobs_ByCollection(t *testing.T) {
 	node.UpdateStateCode(commonpb.StateCode_Healthy)
 
 	cache := &MetaCache{}
-	node.metaCache = cache
+	node.setMetaCache(cache)
 
 	schema := &schemapb.CollectionSchema{
 		Name: "external_collection",

--- a/internal/proxy/membership_filter_plan_size_test.go
+++ b/internal/proxy/membership_filter_plan_size_test.go
@@ -313,11 +313,10 @@ func TestQueryTaskMembershipFilterPlanSizeLimit(t *testing.T) {
 	cache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).
 		Return(map[string]int64{}, nil)
 
-	oldCache := globalMetaCache
-	globalMetaCache = cache
-	t.Cleanup(func() { globalMetaCache = oldCache })
-
 	task := &queryTask{
+		baseTask: baseTask{
+			metaCache: cache,
+		},
 		ctx: ctx,
 		RetrieveRequest: &internalpb.RetrieveRequest{
 			Base:       &commonpb.MsgBase{},

--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -62,26 +62,21 @@ func parsePartitionsInfo(infos []*partitionInfo, hasPartitionKey bool) *partitio
 	return metacache.ParsePartitionsInfo(infos, hasPartitionKey)
 }
 
-// globalMetaCache is singleton instance of Cache.
-var globalMetaCache Cache
-
-// InitMetaCache initializes globalMetaCache.
-func InitMetaCache(ctx context.Context, mixCoord types.MixCoordClient) error {
+func initMetaCache(ctx context.Context, mixCoord types.MixCoordClient) (Cache, error) {
 	metaCache, err := metacache.NewMetaCache(mixCoord)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	globalMetaCache = metaCache
-	expr.Register("cache", globalMetaCache)
+	expr.Register("cache", metaCache)
 
 	err = privilege.InitPrivilegeCache(ctx, mixCoord)
 	if err != nil {
 		mlog.Error(context.TODO(), "failed to init privilege cache", mlog.Err(err))
-		return err
+		return nil, err
 	}
 
 	internalhttp.RegisterPasswordVerifyFunc(PasswordVerify)
 	internalhttp.RegisterGetUserRoleFunc(GetRole)
 
-	return nil
+	return metaCache, nil
 }

--- a/internal/proxy/meta_cache_test.go
+++ b/internal/proxy/meta_cache_test.go
@@ -981,16 +981,16 @@ func TestMetaCache_GetCollection(t *testing.T) {
 	ctx := context.Background()
 	rootCoord := &MockMixCoordClientInterface{}
 
-	err := InitMetaCache(ctx, rootCoord)
+	cache, err := initMetaCache(ctx, rootCoord)
 	assert.NoError(t, err)
 
-	id, err := globalMetaCache.GetCollectionID(ctx, dbName, "collection1")
+	id, err := cache.GetCollectionID(ctx, dbName, "collection1")
 	assert.NoError(t, err)
 	assert.Equal(t, id, typeutil.UniqueID(1))
 	assert.Equal(t, rootCoord.GetAccessCount(), 1)
 
 	// should'nt be accessed to remote root coord.
-	schema, err := globalMetaCache.GetCollectionSchema(ctx, dbName, "collection1")
+	schema, err := cache.GetCollectionSchema(ctx, dbName, "collection1")
 	assert.Equal(t, rootCoord.GetAccessCount(), 1)
 	assert.NoError(t, err)
 	EqualSchema(t, schema.CollectionSchema, &schemapb.CollectionSchema{
@@ -999,11 +999,11 @@ func TestMetaCache_GetCollection(t *testing.T) {
 		Functions: []*schemapb.FunctionSchema{},
 		Name:      "collection1",
 	})
-	id, err = globalMetaCache.GetCollectionID(ctx, dbName, "collection2")
+	id, err = cache.GetCollectionID(ctx, dbName, "collection2")
 	assert.Equal(t, rootCoord.GetAccessCount(), 2)
 	assert.NoError(t, err)
 	assert.Equal(t, id, typeutil.UniqueID(2))
-	schema, err = globalMetaCache.GetCollectionSchema(ctx, dbName, "collection2")
+	schema, err = cache.GetCollectionSchema(ctx, dbName, "collection2")
 	assert.Equal(t, rootCoord.GetAccessCount(), 2)
 	assert.NoError(t, err)
 	EqualSchema(t, schema.CollectionSchema, &schemapb.CollectionSchema{
@@ -1014,11 +1014,11 @@ func TestMetaCache_GetCollection(t *testing.T) {
 	})
 
 	// test to get from cache, this should trigger root request
-	id, err = globalMetaCache.GetCollectionID(ctx, dbName, "collection1")
+	id, err = cache.GetCollectionID(ctx, dbName, "collection1")
 	assert.Equal(t, rootCoord.GetAccessCount(), 2)
 	assert.NoError(t, err)
 	assert.Equal(t, id, typeutil.UniqueID(1))
-	schema, err = globalMetaCache.GetCollectionSchema(ctx, dbName, "collection1")
+	schema, err = cache.GetCollectionSchema(ctx, dbName, "collection1")
 	assert.Equal(t, rootCoord.GetAccessCount(), 2)
 	assert.NoError(t, err)
 	EqualSchema(t, schema.CollectionSchema, &schemapb.CollectionSchema{
@@ -1033,25 +1033,25 @@ func TestMetaCache_GetCollectionByAliasHitsCache(t *testing.T) {
 	ctx := context.Background()
 	rootCoord := &MockMixCoordClientInterface{}
 
-	err := InitMetaCache(ctx, rootCoord)
+	cache, err := initMetaCache(ctx, rootCoord)
 	assert.NoError(t, err)
 
-	id, err := globalMetaCache.GetCollectionID(ctx, dbName, "collection1_alias")
+	id, err := cache.GetCollectionID(ctx, dbName, "collection1_alias")
 	assert.NoError(t, err)
 	assert.Equal(t, typeutil.UniqueID(1), id)
 	assert.Equal(t, 1, rootCoord.GetAccessCount())
 
-	schema, err := globalMetaCache.GetCollectionSchema(ctx, dbName, "collection1_alias")
+	schema, err := cache.GetCollectionSchema(ctx, dbName, "collection1_alias")
 	assert.NoError(t, err)
 	assert.Equal(t, "collection1", schema.GetName())
 	assert.Equal(t, 1, rootCoord.GetAccessCount())
 
-	info, err := globalMetaCache.GetCollectionInfo(ctx, dbName, "collection1_alias", 0)
+	info, err := cache.GetCollectionInfo(ctx, dbName, "collection1_alias", 0)
 	assert.NoError(t, err)
 	assert.Equal(t, typeutil.UniqueID(1), info.CollID)
 	assert.Equal(t, 1, rootCoord.GetAccessCount())
 
-	metaCache := globalMetaCache.(*MetaCache)
+	metaCache := cache.(*MetaCache)
 	aliasCachedAsCollection := metaCache.HasNameHintForTest(dbName, "collection1_alias")
 	assert.False(t, aliasCachedAsCollection, "the alias must not be registered as a collection-name hint")
 	aliasTarget, ok := metaCache.AliasTargetForTest(dbName, "collection1_alias")
@@ -1063,7 +1063,7 @@ func TestMetaCache_GetBasicCollectionInfo(t *testing.T) {
 	ctx := context.Background()
 	rootCoord := &MockMixCoordClientInterface{}
 
-	err := InitMetaCache(ctx, rootCoord)
+	cache, err := initMetaCache(ctx, rootCoord)
 	assert.NoError(t, err)
 
 	// should be no data race.
@@ -1071,7 +1071,7 @@ func TestMetaCache_GetBasicCollectionInfo(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		info, err := globalMetaCache.GetCollectionInfo(ctx, dbName, "collection1", 1)
+		info, err := cache.GetCollectionInfo(ctx, dbName, "collection1", 1)
 		assert.NoError(t, err)
 		assert.Equal(t, info.CollID, int64(1))
 		_ = info.ConsistencyLevel
@@ -1080,7 +1080,7 @@ func TestMetaCache_GetBasicCollectionInfo(t *testing.T) {
 	}()
 	go func() {
 		defer wg.Done()
-		info, err := globalMetaCache.GetCollectionInfo(ctx, dbName, "collection1", 1)
+		info, err := cache.GetCollectionInfo(ctx, dbName, "collection1", 1)
 		assert.NoError(t, err)
 		assert.Equal(t, info.CollID, int64(1))
 		_ = info.ConsistencyLevel
@@ -1091,12 +1091,10 @@ func TestMetaCache_GetBasicCollectionInfo(t *testing.T) {
 }
 
 func TestMetaCacheGetCollectionWithUpdate(t *testing.T) {
-	cache := globalMetaCache
-	defer func() { globalMetaCache = cache }()
 	ctx := context.Background()
 	rootCoord := mocks.NewMockMixCoordClient(t)
 	rootCoord.EXPECT().ListPolicy(mock.Anything, mock.Anything, mock.Anything).Return(&internalpb.ListPolicyResponse{Status: merr.Success()}, nil)
-	err := InitMetaCache(ctx, rootCoord)
+	cache, err := initMetaCache(ctx, rootCoord)
 	assert.NoError(t, err)
 	t.Run("update with name", func(t *testing.T) {
 		rootCoord.EXPECT().DescribeCollection(mock.Anything, mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
@@ -1119,7 +1117,7 @@ func TestMetaCacheGetCollectionWithUpdate(t *testing.T) {
 			PhysicalChannelNames: []string{"by-dev-rootcoord-dml_1"},
 			VirtualChannelNames:  []string{"by-dev-rootcoord-dml_1_1v0"},
 		}, nil).Once()
-		c, err := globalMetaCache.GetCollectionInfo(ctx, "foo", "bar", 1)
+		c, err := cache.GetCollectionInfo(ctx, "foo", "bar", 1)
 		assert.NoError(t, err)
 		assert.Equal(t, c.CollID, int64(1))
 		assert.Equal(t, c.Schema.Name, "bar")
@@ -1146,7 +1144,7 @@ func TestMetaCacheGetCollectionWithUpdate(t *testing.T) {
 			PhysicalChannelNames: []string{"by-dev-rootcoord-dml_1"},
 			VirtualChannelNames:  []string{"by-dev-rootcoord-dml_1_1v0"},
 		}, nil).Once()
-		c, err := globalMetaCache.GetCollectionInfo(ctx, "foo", "hoo", 0)
+		c, err := cache.GetCollectionInfo(ctx, "foo", "hoo", 0)
 		assert.NoError(t, err)
 		assert.Equal(t, c.CollID, int64(1))
 		assert.Equal(t, c.Schema.Name, "bar")
@@ -1159,7 +1157,7 @@ func TestMetaCache_InitCache(t *testing.T) {
 		rootCoord := mocks.NewMockMixCoordClient(t)
 		rootCoord.EXPECT().ShowLoadCollections(mock.Anything, mock.Anything).Return(&querypb.ShowCollectionsResponse{}, nil).Maybe()
 		rootCoord.EXPECT().ListPolicy(mock.Anything, mock.Anything, mock.Anything).Return(&internalpb.ListPolicyResponse{Status: merr.Success()}, nil).Once()
-		err := InitMetaCache(ctx, rootCoord)
+		_, err := initMetaCache(ctx, rootCoord)
 		assert.NoError(t, err)
 	})
 
@@ -1169,7 +1167,7 @@ func TestMetaCache_InitCache(t *testing.T) {
 		rootCoord.EXPECT().ListPolicy(mock.Anything, mock.Anything, mock.Anything).Return(
 			&internalpb.ListPolicyResponse{Status: merr.Status(errors.New("mock list policy error"))},
 			nil).Once()
-		err := InitMetaCache(ctx, rootCoord)
+		_, err := initMetaCache(ctx, rootCoord)
 		assert.Error(t, err)
 	})
 
@@ -1178,7 +1176,7 @@ func TestMetaCache_InitCache(t *testing.T) {
 		rootCoord := mocks.NewMockMixCoordClient(t)
 		rootCoord.EXPECT().ListPolicy(mock.Anything, mock.Anything, mock.Anything).Return(
 			nil, errors.New("mock list policy rpc errorr")).Once()
-		err := InitMetaCache(ctx, rootCoord)
+		_, err := initMetaCache(ctx, rootCoord)
 		assert.Error(t, err)
 	})
 }
@@ -1407,10 +1405,10 @@ func TestMetaCache_GetCollectionInfoByIDCacheHit(t *testing.T) {
 func TestMetaCache_EmptyDBNameSharesDefaultEntry(t *testing.T) {
 	ctx := context.Background()
 	rootCoord := &MockMixCoordClientInterface{}
-	err := InitMetaCache(ctx, rootCoord)
+	cache, err := initMetaCache(ctx, rootCoord)
 	assert.NoError(t, err)
 
-	id, err := globalMetaCache.GetCollectionID(ctx, "", "collection1")
+	id, err := cache.GetCollectionID(ctx, "", "collection1")
 	assert.NoError(t, err)
 	assert.Equal(t, UniqueID(1), id)
 	assert.Equal(t, 1, rootCoord.GetAccessCount())
@@ -1418,13 +1416,13 @@ func TestMetaCache_EmptyDBNameSharesDefaultEntry(t *testing.T) {
 	// explicit default db, by-id with empty db, and by-id with an unrelated db
 	// (ids are cluster-unique, rootcoord ignores the db for by-id describes)
 	// are all served by the same entry without further RPCs
-	id, err = globalMetaCache.GetCollectionID(ctx, "default", "collection1")
+	id, err = cache.GetCollectionID(ctx, "default", "collection1")
 	assert.NoError(t, err)
 	assert.Equal(t, UniqueID(1), id)
-	name, err := globalMetaCache.GetCollectionName(ctx, "", 1)
+	name, err := cache.GetCollectionName(ctx, "", 1)
 	assert.NoError(t, err)
 	assert.Equal(t, "collection1", name)
-	name, err = globalMetaCache.GetCollectionName(ctx, "some_other_db", 1)
+	name, err = cache.GetCollectionName(ctx, "some_other_db", 1)
 	assert.NoError(t, err)
 	assert.Equal(t, "collection1", name)
 	assert.Equal(t, 1, rootCoord.GetAccessCount())
@@ -1433,16 +1431,16 @@ func TestMetaCache_EmptyDBNameSharesDefaultEntry(t *testing.T) {
 func TestMetaCache_GetCollectionName(t *testing.T) {
 	ctx := context.Background()
 	rootCoord := &MockMixCoordClientInterface{}
-	err := InitMetaCache(ctx, rootCoord)
+	cache, err := initMetaCache(ctx, rootCoord)
 	assert.NoError(t, err)
 
-	collection, err := globalMetaCache.GetCollectionName(ctx, GetCurDBNameFromContextOrDefault(ctx), 1)
+	collection, err := cache.GetCollectionName(ctx, GetCurDBNameFromContextOrDefault(ctx), 1)
 	assert.NoError(t, err)
 	assert.Equal(t, collection, "collection1")
 	assert.Equal(t, rootCoord.GetAccessCount(), 1)
 
 	// should'nt be accessed to remote root coord.
-	schema, err := globalMetaCache.GetCollectionSchema(ctx, dbName, "collection1")
+	schema, err := cache.GetCollectionSchema(ctx, dbName, "collection1")
 	assert.Equal(t, rootCoord.GetAccessCount(), 1)
 	assert.NoError(t, err)
 	EqualSchema(t, schema.CollectionSchema, &schemapb.CollectionSchema{
@@ -1451,11 +1449,11 @@ func TestMetaCache_GetCollectionName(t *testing.T) {
 		Functions: []*schemapb.FunctionSchema{},
 		Name:      "collection1",
 	})
-	collection, err = globalMetaCache.GetCollectionName(ctx, GetCurDBNameFromContextOrDefault(ctx), 1)
+	collection, err = cache.GetCollectionName(ctx, GetCurDBNameFromContextOrDefault(ctx), 1)
 	assert.Equal(t, rootCoord.GetAccessCount(), 1)
 	assert.NoError(t, err)
 	assert.Equal(t, collection, "collection1")
-	schema, err = globalMetaCache.GetCollectionSchema(ctx, dbName, "collection2")
+	schema, err = cache.GetCollectionSchema(ctx, dbName, "collection2")
 	assert.Equal(t, rootCoord.GetAccessCount(), 2)
 	assert.NoError(t, err)
 	EqualSchema(t, schema.CollectionSchema, &schemapb.CollectionSchema{
@@ -1466,11 +1464,11 @@ func TestMetaCache_GetCollectionName(t *testing.T) {
 	})
 
 	// test to get from cache, this should trigger root request
-	collection, err = globalMetaCache.GetCollectionName(ctx, GetCurDBNameFromContextOrDefault(ctx), 1)
+	collection, err = cache.GetCollectionName(ctx, GetCurDBNameFromContextOrDefault(ctx), 1)
 	assert.Equal(t, rootCoord.GetAccessCount(), 2)
 	assert.NoError(t, err)
 	assert.Equal(t, collection, "collection1")
-	schema, err = globalMetaCache.GetCollectionSchema(ctx, dbName, "collection1")
+	schema, err = cache.GetCollectionSchema(ctx, dbName, "collection1")
 	assert.Equal(t, rootCoord.GetAccessCount(), 2)
 	assert.NoError(t, err)
 	EqualSchema(t, schema.CollectionSchema, &schemapb.CollectionSchema{
@@ -1484,17 +1482,17 @@ func TestMetaCache_GetCollectionName(t *testing.T) {
 func TestMetaCache_GetCollectionFailure(t *testing.T) {
 	ctx := context.Background()
 	rootCoord := &MockMixCoordClientInterface{}
-	err := InitMetaCache(ctx, rootCoord)
+	cache, err := initMetaCache(ctx, rootCoord)
 	assert.NoError(t, err)
 	rootCoord.Error = true
 
-	schema, err := globalMetaCache.GetCollectionSchema(ctx, dbName, "collection1")
+	schema, err := cache.GetCollectionSchema(ctx, dbName, "collection1")
 	assert.Error(t, err)
 	assert.Nil(t, schema)
 
 	rootCoord.Error = false
 
-	schema, err = globalMetaCache.GetCollectionSchema(ctx, dbName, "collection1")
+	schema, err = cache.GetCollectionSchema(ctx, dbName, "collection1")
 	assert.NoError(t, err)
 	EqualSchema(t, schema.CollectionSchema, &schemapb.CollectionSchema{
 		AutoID:    true,
@@ -1517,13 +1515,13 @@ func TestMetaCache_GetCollectionFailure(t *testing.T) {
 func TestMetaCache_GetNonExistCollection(t *testing.T) {
 	ctx := context.Background()
 	rootCoord := &MockMixCoordClientInterface{}
-	err := InitMetaCache(ctx, rootCoord)
+	cache, err := initMetaCache(ctx, rootCoord)
 	assert.NoError(t, err)
 
-	id, err := globalMetaCache.GetCollectionID(ctx, dbName, "collection3")
+	id, err := cache.GetCollectionID(ctx, dbName, "collection3")
 	assert.Error(t, err)
 	assert.Equal(t, id, int64(0))
-	schema, err := globalMetaCache.GetCollectionSchema(ctx, dbName, "collection3")
+	schema, err := cache.GetCollectionSchema(ctx, dbName, "collection3")
 	assert.Error(t, err)
 	assert.Nil(t, schema)
 }
@@ -1531,19 +1529,19 @@ func TestMetaCache_GetNonExistCollection(t *testing.T) {
 func TestMetaCache_GetPartitionID(t *testing.T) {
 	ctx := context.Background()
 	rootCoord := &MockMixCoordClientInterface{}
-	err := InitMetaCache(ctx, rootCoord)
+	cache, err := initMetaCache(ctx, rootCoord)
 	assert.NoError(t, err)
 
-	id, err := globalMetaCache.GetPartitionID(ctx, dbName, "collection1", "par1")
+	id, err := cache.GetPartitionID(ctx, dbName, "collection1", "par1")
 	assert.NoError(t, err)
 	assert.Equal(t, id, typeutil.UniqueID(1))
-	id, err = globalMetaCache.GetPartitionID(ctx, dbName, "collection1", "par2")
+	id, err = cache.GetPartitionID(ctx, dbName, "collection1", "par2")
 	assert.NoError(t, err)
 	assert.Equal(t, id, typeutil.UniqueID(2))
-	id, err = globalMetaCache.GetPartitionID(ctx, dbName, "collection2", "par1")
+	id, err = cache.GetPartitionID(ctx, dbName, "collection2", "par1")
 	assert.NoError(t, err)
 	assert.Equal(t, id, typeutil.UniqueID(3))
-	id, err = globalMetaCache.GetPartitionID(ctx, dbName, "collection2", "par2")
+	id, err = cache.GetPartitionID(ctx, dbName, "collection2", "par2")
 	assert.NoError(t, err)
 	assert.Equal(t, id, typeutil.UniqueID(4))
 }
@@ -1551,7 +1549,7 @@ func TestMetaCache_GetPartitionID(t *testing.T) {
 func TestMetaCache_ConcurrentTest1(t *testing.T) {
 	ctx := context.Background()
 	rootCoord := &MockMixCoordClientInterface{}
-	err := InitMetaCache(ctx, rootCoord)
+	cache, err := initMetaCache(ctx, rootCoord)
 	assert.NoError(t, err)
 
 	var wg sync.WaitGroup
@@ -1560,7 +1558,7 @@ func TestMetaCache_ConcurrentTest1(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < cnt; i++ {
 			// GetCollectionSchema will never fail
-			schema, err := globalMetaCache.GetCollectionSchema(ctx, dbName, "collection1")
+			schema, err := cache.GetCollectionSchema(ctx, dbName, "collection1")
 			assert.NoError(t, err)
 			EqualSchema(t, schema.CollectionSchema, &schemapb.CollectionSchema{
 				AutoID:    true,
@@ -1576,7 +1574,7 @@ func TestMetaCache_ConcurrentTest1(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < cnt; i++ {
 			// GetPartitions may fail
-			globalMetaCache.GetPartitions(ctx, dbName, "collection1")
+			cache.GetPartitions(ctx, dbName, "collection1")
 			time.Sleep(10 * time.Millisecond)
 		}
 	}
@@ -1585,7 +1583,7 @@ func TestMetaCache_ConcurrentTest1(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < cnt; i++ {
 			// periodically invalid collection cache
-			globalMetaCache.RemoveCollection(ctx, dbName, "collection1")
+			cache.RemoveCollection(ctx, dbName, "collection1")
 			time.Sleep(10 * time.Millisecond)
 		}
 	}
@@ -1604,25 +1602,25 @@ func TestMetaCache_ConcurrentTest1(t *testing.T) {
 func TestMetaCache_GetPartitionError(t *testing.T) {
 	ctx := context.Background()
 	rootCoord := &MockMixCoordClientInterface{}
-	err := InitMetaCache(ctx, rootCoord)
+	cache, err := initMetaCache(ctx, rootCoord)
 	assert.NoError(t, err)
 
 	// Test the case where ShowPartitionsResponse is not aligned
-	id, err := globalMetaCache.GetPartitionID(ctx, dbName, "errorCollection", "par1")
+	id, err := cache.GetPartitionID(ctx, dbName, "errorCollection", "par1")
 	assert.Error(t, err)
 	assert.Equal(t, id, typeutil.UniqueID(0))
 
-	partitions, err2 := globalMetaCache.GetPartitions(ctx, dbName, "errorCollection")
+	partitions, err2 := cache.GetPartitions(ctx, dbName, "errorCollection")
 	assert.NotNil(t, err2)
 	assert.Equal(t, len(partitions), 0)
 
 	// Test non existed tables
-	id, err = globalMetaCache.GetPartitionID(ctx, dbName, "nonExisted", "par1")
+	id, err = cache.GetPartitionID(ctx, dbName, "nonExisted", "par1")
 	assert.Error(t, err)
 	assert.Equal(t, id, typeutil.UniqueID(0))
 
 	// Test non existed partition
-	id, err = globalMetaCache.GetPartitionID(ctx, dbName, "collection1", "par3")
+	id, err = cache.GetPartitionID(ctx, dbName, "collection1", "par3")
 	assert.Error(t, err)
 	assert.Equal(t, id, typeutil.UniqueID(0))
 }
@@ -1640,11 +1638,11 @@ func TestMetaCache_ClearShards(t *testing.T) {
 func TestMetaCache_PolicyInfo(t *testing.T) {
 	client := &MockMixCoordClientInterface{}
 
-	t.Run("InitMetaCache", func(t *testing.T) {
+	t.Run("initMetaCache", func(t *testing.T) {
 		client.listPolicy = func(ctx context.Context, in *internalpb.ListPolicyRequest) (*internalpb.ListPolicyResponse, error) {
 			return nil, errors.New("mock error")
 		}
-		err := InitMetaCache(context.Background(), client)
+		_, err := initMetaCache(context.Background(), client)
 		assert.Error(t, err)
 
 		client.listPolicy = func(ctx context.Context, in *internalpb.ListPolicyRequest) (*internalpb.ListPolicyResponse, error) {
@@ -1653,7 +1651,7 @@ func TestMetaCache_PolicyInfo(t *testing.T) {
 				PolicyInfos: []string{"policy1", "policy2", "policy3"},
 			}, nil
 		}
-		err = InitMetaCache(context.Background(), client)
+		_, err = initMetaCache(context.Background(), client)
 		assert.NoError(t, err)
 	})
 
@@ -1665,7 +1663,7 @@ func TestMetaCache_PolicyInfo(t *testing.T) {
 				UserRoles:   []string{funcutil.EncodeUserRoleCache("foo", "role1"), funcutil.EncodeUserRoleCache("foo", "role2"), funcutil.EncodeUserRoleCache("foo2", "role2")},
 			}, nil
 		}
-		err := InitMetaCache(context.Background(), client)
+		_, err := initMetaCache(context.Background(), client)
 		assert.NoError(t, err)
 		policyInfos := privilege.GetPrivilegeCache().GetPrivilegeInfo(context.Background())
 		assert.Equal(t, 3, len(policyInfos))
@@ -1681,7 +1679,7 @@ func TestMetaCache_PolicyInfo(t *testing.T) {
 				UserRoles:   []string{funcutil.EncodeUserRoleCache("foo", "role1"), funcutil.EncodeUserRoleCache("foo", "role2"), funcutil.EncodeUserRoleCache("foo2", "role2")},
 			}, nil
 		}
-		err := InitMetaCache(context.Background(), client)
+		_, err := initMetaCache(context.Background(), client)
 		assert.NoError(t, err)
 
 		err = privilege.GetPrivilegeCache().RefreshPolicyInfo(typeutil.CacheOp{OpType: typeutil.CacheGrantPrivilege, OpKey: "policyX"})
@@ -1722,7 +1720,7 @@ func TestMetaCache_PolicyInfo(t *testing.T) {
 				UserRoles: []string{funcutil.EncodeUserRoleCache("foo", "role1"), funcutil.EncodeUserRoleCache("foo", "role2"), funcutil.EncodeUserRoleCache("foo2", "role2"), funcutil.EncodeUserRoleCache("foo2", "role3")},
 			}, nil
 		}
-		err := InitMetaCache(context.Background(), client)
+		_, err := initMetaCache(context.Background(), client)
 		assert.NoError(t, err)
 
 		err = privilege.GetPrivilegeCache().RefreshPolicyInfo(typeutil.CacheOp{OpType: typeutil.CacheDeleteUser, OpKey: "foo"})
@@ -1757,7 +1755,7 @@ func TestMetaCache_PolicyInfo(t *testing.T) {
 func TestMetaCache_RemoveCollection(t *testing.T) {
 	ctx := context.Background()
 	rootCoord := &MockMixCoordClientInterface{}
-	err := InitMetaCache(ctx, rootCoord)
+	cache, err := initMetaCache(ctx, rootCoord)
 	assert.NoError(t, err)
 
 	rootCoord.showLoadCollections = func(ctx context.Context, in *querypb.ShowCollectionsRequest) (*querypb.ShowCollectionsResponse, error) {
@@ -1768,33 +1766,33 @@ func TestMetaCache_RemoveCollection(t *testing.T) {
 		}, nil
 	}
 
-	_, err = globalMetaCache.GetCollectionInfo(ctx, dbName, "collection1", 1)
+	_, err = cache.GetCollectionInfo(ctx, dbName, "collection1", 1)
 	assert.NoError(t, err)
 	// no collectionInfo of collection1, should access RootCoord
 	assert.Equal(t, rootCoord.GetAccessCount(), 1)
 
-	_, err = globalMetaCache.GetCollectionInfo(ctx, dbName, "collection1", 1)
+	_, err = cache.GetCollectionInfo(ctx, dbName, "collection1", 1)
 	assert.NoError(t, err)
 	// shouldn't access RootCoord again
 	assert.Equal(t, rootCoord.GetAccessCount(), 1)
 
-	globalMetaCache.RemoveCollection(ctx, dbName, "collection1")
+	cache.RemoveCollection(ctx, dbName, "collection1")
 	// no collectionInfo of collection2, should access RootCoord
-	_, err = globalMetaCache.GetCollectionInfo(ctx, dbName, "collection1", 1)
+	_, err = cache.GetCollectionInfo(ctx, dbName, "collection1", 1)
 	assert.NoError(t, err)
 	// shouldn't access RootCoord again
 	assert.Equal(t, rootCoord.GetAccessCount(), 2)
 
-	globalMetaCache.RemoveCollectionsByID(ctx, UniqueID(1))
+	cache.RemoveCollectionsByID(ctx, UniqueID(1))
 	// no collectionInfo of collection2, should access RootCoord
-	_, err = globalMetaCache.GetCollectionInfo(ctx, dbName, "collection1", 1)
+	_, err = cache.GetCollectionInfo(ctx, dbName, "collection1", 1)
 	assert.NoError(t, err)
 	// shouldn't access RootCoord again
 	assert.Equal(t, rootCoord.GetAccessCount(), 3)
 
-	globalMetaCache.RemoveCollectionsByID(ctx, UniqueID(1))
+	cache.RemoveCollectionsByID(ctx, UniqueID(1))
 	// no collectionInfo of collection2, should access RootCoord
-	_, err = globalMetaCache.GetCollectionInfo(ctx, dbName, "collection1", 1)
+	_, err = cache.GetCollectionInfo(ctx, dbName, "collection1", 1)
 	assert.NoError(t, err)
 	// no collectionInfo of collection1, should access RootCoord
 	assert.Equal(t, rootCoord.GetAccessCount(), 4)
@@ -1808,16 +1806,16 @@ func TestGlobalMetaCache_ShuffleShardLeaders(t *testing.T) {
 func TestMetaCache_Database(t *testing.T) {
 	ctx := context.Background()
 	rootCoord := &MockMixCoordClientInterface{}
-	err := InitMetaCache(ctx, rootCoord)
+	cache, err := initMetaCache(ctx, rootCoord)
 	assert.NoError(t, err)
-	assert.Equal(t, globalMetaCache.HasDatabase(ctx, dbName), false)
+	assert.Equal(t, cache.HasDatabase(ctx, dbName), false)
 
-	_, err = globalMetaCache.GetCollectionInfo(ctx, dbName, "collection1", 1)
+	_, err = cache.GetCollectionInfo(ctx, dbName, "collection1", 1)
 	assert.NoError(t, err)
-	_, err = GetCachedCollectionSchema(ctx, dbName, "collection1")
+	_, err = GetCachedCollectionSchema(ctx, cache, dbName, "collection1")
 	assert.NoError(t, err)
-	assert.Equal(t, globalMetaCache.HasDatabase(ctx, dbName), true)
-	assert.Equal(t, CheckDatabase(ctx, dbName), true)
+	assert.Equal(t, cache.HasDatabase(ctx, dbName), true)
+	assert.Equal(t, CheckDatabase(ctx, cache, dbName), true)
 }
 
 func TestGetDatabaseInfo(t *testing.T) {
@@ -1994,11 +1992,11 @@ func TestMetaCache_AllocID(t *testing.T) {
 			PolicyInfos: []string{"policy1", "policy2", "policy3"},
 		}, nil)
 
-		err := InitMetaCache(ctx, rootCoord)
+		cache, err := initMetaCache(ctx, rootCoord)
 		assert.NoError(t, err)
-		assert.Equal(t, globalMetaCache.HasDatabase(ctx, dbName), false)
+		assert.Equal(t, cache.HasDatabase(ctx, dbName), false)
 
-		id, err := globalMetaCache.AllocID(ctx)
+		id, err := cache.AllocID(ctx)
 		assert.NoError(t, err)
 		assert.Equal(t, id, int64(11198))
 	})
@@ -2013,11 +2011,11 @@ func TestMetaCache_AllocID(t *testing.T) {
 			PolicyInfos: []string{"policy1", "policy2", "policy3"},
 		}, nil)
 
-		err := InitMetaCache(ctx, rootCoord)
+		cache, err := initMetaCache(ctx, rootCoord)
 		assert.NoError(t, err)
-		assert.Equal(t, globalMetaCache.HasDatabase(ctx, dbName), false)
+		assert.Equal(t, cache.HasDatabase(ctx, dbName), false)
 
-		id, err := globalMetaCache.AllocID(ctx)
+		id, err := cache.AllocID(ctx)
 		assert.Error(t, err)
 		assert.Equal(t, id, int64(0))
 	})
@@ -2032,11 +2030,11 @@ func TestMetaCache_AllocID(t *testing.T) {
 			PolicyInfos: []string{"policy1", "policy2", "policy3"},
 		}, nil)
 
-		err := InitMetaCache(ctx, rootCoord)
+		cache, err := initMetaCache(ctx, rootCoord)
 		assert.NoError(t, err)
-		assert.Equal(t, globalMetaCache.HasDatabase(ctx, dbName), false)
+		assert.Equal(t, cache.HasDatabase(ctx, dbName), false)
 
-		id, err := globalMetaCache.AllocID(ctx)
+		id, err := cache.AllocID(ctx)
 		assert.Error(t, err)
 		assert.Equal(t, id, int64(0))
 	})

--- a/internal/proxy/meta_cache_testonly.go
+++ b/internal/proxy/meta_cache_testonly.go
@@ -24,6 +24,7 @@ package proxy
 import (
 	"context"
 
+	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/milvus-io/milvus/internal/mocks"
@@ -50,22 +51,27 @@ func RemoveRootUserFromAdminRole() {
 	}
 }
 
-func InitEmptyGlobalCache() {
+func InitEmptyMetaCacheForTest() *MetaCache {
 	var err error
 	emptyMock := common.NewEmptyMockT()
 	mixcoord := mocks.NewMockMixCoordClient(emptyMock)
 	mixcoord.EXPECT().DescribeCollection(mock.Anything, mock.Anything, mock.Anything).Return(nil, merr.WrapErrParameterInvalidMsg("collection not found"))
 	mixcoord.EXPECT().DescribeAlias(mock.Anything, mock.Anything, mock.Anything).Return(nil, merr.WrapErrParameterInvalidMsg("alias not found"))
-	globalMetaCache, err = NewMetaCache(mixcoord)
+	metaCache, err := NewMetaCache(mixcoord)
 	if err != nil {
 		panic(err)
 	}
 	mixcoord.EXPECT().ListPolicy(mock.Anything, mock.Anything, mock.Anything).Return(&internalpb.ListPolicyResponse{Status: merr.Success()}, nil)
 	privilege.InitPrivilegeCache(context.Background(), mixcoord)
+	return metaCache
 }
 
-func SetGlobalMetaCache(metaCache *MetaCache) {
-	globalMetaCache = metaCache
+func mustInitMetaCacheForTest(ctx context.Context, mixCoord types.MixCoordClient) Cache {
+	cache, err := initMetaCache(ctx, mixCoord)
+	if err != nil {
+		panic(err)
+	}
+	return cache
 }
 
 func mustNewMetaCacheForTest(mixCoord types.MixCoordClient) *MetaCache {
@@ -82,4 +88,11 @@ func mustNewMetaCacheWithDBInfoForTest(mixCoord types.MixCoordClient, dbInfo map
 		cache.SeedDBInfoForTest(db, info)
 	}
 	return cache
+}
+
+func mockBaseTaskMetaCacheForTest(cache Cache) func() {
+	patch := mockey.Mock((*baseTask).getMetaCache).Return(cache).Build()
+	return func() {
+		patch.UnPatch()
+	}
 }

--- a/internal/proxy/meta_cache_testonly.go
+++ b/internal/proxy/meta_cache_testonly.go
@@ -24,7 +24,6 @@ package proxy
 import (
 	"context"
 
-	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/milvus-io/milvus/internal/mocks"
@@ -88,11 +87,4 @@ func mustNewMetaCacheWithDBInfoForTest(mixCoord types.MixCoordClient, dbInfo map
 		cache.SeedDBInfoForTest(db, info)
 	}
 	return cache
-}
-
-func mockBaseTaskMetaCacheForTest(cache Cache) func() {
-	patch := mockey.Mock((*baseTask).getMetaCache).Return(cache).Build()
-	return func() {
-		patch.UnPatch()
-	}
 }

--- a/internal/proxy/msg_pack_test.go
+++ b/internal/proxy/msg_pack_test.go
@@ -167,9 +167,6 @@ func TestRepackInsertData(t *testing.T) {
 	mix := NewMixCoordMock()
 	defer mix.Close()
 
-	cache := NewMockCache(t)
-	globalMetaCache = cache
-
 	idAllocator, err := allocator.NewIDAllocator(ctx, mix, paramtable.GetNodeID())
 	assert.NoError(t, err)
 	_ = idAllocator.Start()
@@ -239,8 +236,9 @@ func TestRepackInsertDataWithPartitionKey(t *testing.T) {
 
 	mix := NewMixCoordMock()
 
-	err := InitMetaCache(ctx, mix)
+	cache, err := initMetaCache(ctx, mix)
 	assert.NoError(t, err)
+	t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 	idAllocator, err := allocator.NewIDAllocator(ctx, mix, paramtable.GetNodeID())
 	assert.NoError(t, err)

--- a/internal/proxy/msg_pack_test.go
+++ b/internal/proxy/msg_pack_test.go
@@ -236,9 +236,8 @@ func TestRepackInsertDataWithPartitionKey(t *testing.T) {
 
 	mix := NewMixCoordMock()
 
-	cache, err := initMetaCache(ctx, mix)
+	_, err := initMetaCache(ctx, mix)
 	assert.NoError(t, err)
-	t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 	idAllocator, err := allocator.NewIDAllocator(ctx, mix, paramtable.GetNodeID())
 	assert.NoError(t, err)

--- a/internal/proxy/privilege_interceptor.go
+++ b/internal/proxy/privilege_interceptor.go
@@ -55,10 +55,10 @@ func UnaryServerInterceptor(privilegeFunc PrivilegeFunc) grpc.UnaryServerInterce
 }
 
 func PrivilegeInterceptor(ctx context.Context, req interface{}) (context.Context, error) {
-	return PrivilegeInterceptorWithMetaCache(nil)(ctx, req)
+	return PrivilegeInterceptorWithMetaCache(func() Cache { return nil })(ctx, req)
 }
 
-func PrivilegeInterceptorWithMetaCache(metaCache Cache) PrivilegeFunc {
+func PrivilegeInterceptorWithMetaCache(getMetaCache func() Cache) PrivilegeFunc {
 	return func(ctx context.Context, req interface{}) (context.Context, error) {
 		if !Params.CommonCfg.AuthorizationEnabled.GetAsBool() {
 			return ctx, nil
@@ -111,7 +111,7 @@ func PrivilegeInterceptorWithMetaCache(metaCache Cache) PrivilegeFunc {
 		// Resolve alias to actual collection name for RBAC checks
 		if Params.ProxyCfg.ResolveAliasForPrivilege.GetAsBool() && objectType == commonpb.ObjectType_Collection.String() && objectNameIndex != 0 {
 			if objectName != util.AnyWord && objectName != "" {
-				if actualCollectionName, resolveErr := resolveCollectionAlias(ctx, metaCache, dbName, objectName); resolveErr != nil {
+				if actualCollectionName, resolveErr := resolveCollectionAlias(ctx, getMetaCache(), dbName, objectName); resolveErr != nil {
 					mlog.RatedWarn(ctx, rate.Limit(60), "failed to resolve collection alias for RBAC, using original name",
 						mlog.String("objectName", objectName), mlog.FieldDbName(dbName), mlog.Err(resolveErr))
 				} else {
@@ -139,7 +139,7 @@ func PrivilegeInterceptorWithMetaCache(metaCache Cache) PrivilegeFunc {
 					resolvedNames = append(resolvedNames, name)
 					continue
 				}
-				if actualName, resolveErr := resolveCollectionAlias(ctx, metaCache, dbName, name); resolveErr != nil {
+				if actualName, resolveErr := resolveCollectionAlias(ctx, getMetaCache(), dbName, name); resolveErr != nil {
 					mlog.RatedWarn(ctx, rate.Limit(60), "failed to resolve collection alias for RBAC, using original name",
 						mlog.String("objectName", name), mlog.FieldDbName(dbName), mlog.Err(resolveErr))
 					resolvedNames = append(resolvedNames, name)

--- a/internal/proxy/privilege_interceptor.go
+++ b/internal/proxy/privilege_interceptor.go
@@ -55,158 +55,164 @@ func UnaryServerInterceptor(privilegeFunc PrivilegeFunc) grpc.UnaryServerInterce
 }
 
 func PrivilegeInterceptor(ctx context.Context, req interface{}) (context.Context, error) {
-	if !Params.CommonCfg.AuthorizationEnabled.GetAsBool() {
-		return ctx, nil
-	}
-	mlog.RatedDebug(ctx, rate.Limit(60), "PrivilegeInterceptor", mlog.String("type", reflect.TypeOf(req).String()))
-	privilegeExt, err := funcutil.GetPrivilegeExtObj(req)
-	if err != nil {
-		mlog.RatedInfo(ctx, rate.Limit(60), "GetPrivilegeExtObj err", mlog.Err(err))
-		return ctx, nil
-	}
-	username, password, err := contextutil.GetAuthInfoFromContext(ctx)
-	if err != nil {
-		mlog.Warn(ctx, "GetCurUserFromContext fail", mlog.Err(err))
-		return ctx, err
-	}
-	if !Params.CommonCfg.RootShouldBindRole.GetAsBool() && username == util.UserRoot {
-		return ctx, nil
-	}
-	roleNames, err := GetRole(username)
-	if err != nil {
-		mlog.Warn(ctx, "GetRole fail", mlog.String("username", username), mlog.Err(err))
-		return ctx, err
-	}
-	roleNames = append(roleNames, util.RolePublic)
-	ctx = SetRBACRolesToContext(ctx, roleNames)
-	objectType := privilegeExt.ObjectType.String()
-	objectNameIndex := privilegeExt.ObjectNameIndex
-	objectName := funcutil.GetObjectName(req, objectNameIndex)
-	objectPrivilege := privilegeExt.ObjectPrivilege.String()
-	// Authorize against the db the request actually operates on, resolved by
-	// privilege level (mirrors the grant-side validation; see
-	// milvus-io/milvus#50678):
-	//   - Cluster-level privileges (CreateDatabase/ResourceGroup/...) are not
-	//     scoped to a database, so authorize them globally (AnyWord),
-	//     independent of the connection namespace.
-	//   - Database-/Collection-level privileges are scoped to the db the request
-	//     targets: the request-body DbName takes precedence, falling back to the
-	//     connection-context db.
-	dbName := GetCurDBNameFromRequestOrContext(ctx, req)
-	if util.GetPrivilegeLevel(util.MetaStore2API(objectPrivilege)) == milvuspb.PrivilegeLevel_Cluster.String() {
-		dbName = util.AnyWord
-	}
-	// RenameCollection is a database-admin privilege: a same-db rename is
-	// authorized against the target db (database level, handled above), while a
-	// cross-db rename additionally requires a cluster-scoped (global) grant.
-	if r, ok := req.(*milvuspb.RenameCollectionRequest); ok && r.GetDbName() != r.GetNewDBName() {
-		dbName = util.AnyWord
-	}
+	return PrivilegeInterceptorWithMetaCache(nil)(ctx, req)
+}
 
-	// Resolve alias to actual collection name for RBAC checks
-	if Params.ProxyCfg.ResolveAliasForPrivilege.GetAsBool() && objectType == commonpb.ObjectType_Collection.String() && objectNameIndex != 0 {
-		if objectName != util.AnyWord && objectName != "" {
-			if actualCollectionName, resolveErr := resolveCollectionAlias(ctx, dbName, objectName); resolveErr != nil {
-				mlog.RatedWarn(ctx, rate.Limit(60), "failed to resolve collection alias for RBAC, using original name",
-					mlog.String("objectName", objectName), mlog.FieldDbName(dbName), mlog.Err(resolveErr))
-			} else {
-				objectName = actualCollectionName
+func PrivilegeInterceptorWithMetaCache(metaCache Cache) PrivilegeFunc {
+	return func(ctx context.Context, req interface{}) (context.Context, error) {
+		if !Params.CommonCfg.AuthorizationEnabled.GetAsBool() {
+			return ctx, nil
+		}
+		mlog.RatedDebug(ctx, rate.Limit(60), "PrivilegeInterceptor", mlog.String("type", reflect.TypeOf(req).String()))
+		privilegeExt, err := funcutil.GetPrivilegeExtObj(req)
+		if err != nil {
+			mlog.RatedInfo(ctx, rate.Limit(60), "GetPrivilegeExtObj err", mlog.Err(err))
+			return ctx, nil
+		}
+		username, password, err := contextutil.GetAuthInfoFromContext(ctx)
+		if err != nil {
+			mlog.Warn(ctx, "GetCurUserFromContext fail", mlog.Err(err))
+			return ctx, err
+		}
+		if !Params.CommonCfg.RootShouldBindRole.GetAsBool() && username == util.UserRoot {
+			return ctx, nil
+		}
+		roleNames, err := GetRole(username)
+		if err != nil {
+			mlog.Warn(ctx, "GetRole fail", mlog.String("username", username), mlog.Err(err))
+			return ctx, err
+		}
+		roleNames = append(roleNames, util.RolePublic)
+		ctx = SetRBACRolesToContext(ctx, roleNames)
+		objectType := privilegeExt.ObjectType.String()
+		objectNameIndex := privilegeExt.ObjectNameIndex
+		objectName := funcutil.GetObjectName(req, objectNameIndex)
+		objectPrivilege := privilegeExt.ObjectPrivilege.String()
+		// Authorize against the db the request actually operates on, resolved by
+		// privilege level (mirrors the grant-side validation; see
+		// milvus-io/milvus#50678):
+		//   - Cluster-level privileges (CreateDatabase/ResourceGroup/...) are not
+		//     scoped to a database, so authorize them globally (AnyWord),
+		//     independent of the connection namespace.
+		//   - Database-/Collection-level privileges are scoped to the db the request
+		//     targets: the request-body DbName takes precedence, falling back to the
+		//     connection-context db.
+		dbName := GetCurDBNameFromRequestOrContext(ctx, req)
+		if util.GetPrivilegeLevel(util.MetaStore2API(objectPrivilege)) == milvuspb.PrivilegeLevel_Cluster.String() {
+			dbName = util.AnyWord
+		}
+		// RenameCollection is a database-admin privilege: a same-db rename is
+		// authorized against the target db (database level, handled above), while a
+		// cross-db rename additionally requires a cluster-scoped (global) grant.
+		if r, ok := req.(*milvuspb.RenameCollectionRequest); ok && r.GetDbName() != r.GetNewDBName() {
+			dbName = util.AnyWord
+		}
+
+		// Resolve alias to actual collection name for RBAC checks
+		if Params.ProxyCfg.ResolveAliasForPrivilege.GetAsBool() && objectType == commonpb.ObjectType_Collection.String() && objectNameIndex != 0 {
+			if objectName != util.AnyWord && objectName != "" {
+				if actualCollectionName, resolveErr := resolveCollectionAlias(ctx, metaCache, dbName, objectName); resolveErr != nil {
+					mlog.RatedWarn(ctx, rate.Limit(60), "failed to resolve collection alias for RBAC, using original name",
+						mlog.String("objectName", objectName), mlog.FieldDbName(dbName), mlog.Err(resolveErr))
+				} else {
+					objectName = actualCollectionName
+				}
 			}
 		}
-	}
 
-	if isCurUserObject(objectType, username, objectName) {
-		return ctx, nil
-	}
-
-	if isSelectMyRoleGrants(req, roleNames) {
-		return ctx, nil
-	}
-
-	objectNameIndexs := privilegeExt.ObjectNameIndexs
-	objectNames := funcutil.GetObjectNames(req, objectNameIndexs)
-
-	// Resolve aliases for operations that refer to multiple resources
-	if Params.ProxyCfg.ResolveAliasForPrivilege.GetAsBool() && objectType == commonpb.ObjectType_Collection.String() && objectNameIndexs != 0 && len(objectNames) > 0 {
-		resolvedNames := make([]string, 0, len(objectNames))
-		for _, name := range objectNames {
-			if name == util.AnyWord || name == "" {
-				resolvedNames = append(resolvedNames, name)
-				continue
-			}
-			if actualName, resolveErr := resolveCollectionAlias(ctx, dbName, name); resolveErr != nil {
-				mlog.RatedWarn(ctx, rate.Limit(60), "failed to resolve collection alias for RBAC, using original name",
-					mlog.String("objectName", name), mlog.FieldDbName(dbName), mlog.Err(resolveErr))
-				resolvedNames = append(resolvedNames, name)
-			} else {
-				resolvedNames = append(resolvedNames, actualName)
-			}
+		if isCurUserObject(objectType, username, objectName) {
+			return ctx, nil
 		}
-		objectNames = resolvedNames
-	}
 
-	log := mlog.With(mlog.String("username", username), mlog.Strings("role_names", roleNames),
-		mlog.String("object_type", objectType), mlog.String("object_privilege", objectPrivilege),
-		mlog.FieldDbName(dbName),
-		mlog.Int32("object_index", objectNameIndex), mlog.String("object_name", objectName),
-		mlog.Int32("object_indexs", objectNameIndexs), mlog.Strings("object_names", objectNames))
+		if isSelectMyRoleGrants(req, roleNames) {
+			return ctx, nil
+		}
 
-	e := privilege.GetEnforcer()
-	for _, roleName := range roleNames {
-		permitFunc := func(objectName string) (bool, error) {
-			object := funcutil.PolicyForResource(dbName, objectType, objectName)
-			isPermit, cached, version := privilege.GetResultCache(roleName, object, objectPrivilege)
-			if cached {
+		objectNameIndexs := privilegeExt.ObjectNameIndexs
+		objectNames := funcutil.GetObjectNames(req, objectNameIndexs)
+
+		// Resolve aliases for operations that refer to multiple resources
+		if Params.ProxyCfg.ResolveAliasForPrivilege.GetAsBool() && objectType == commonpb.ObjectType_Collection.String() && objectNameIndexs != 0 && len(objectNames) > 0 {
+			resolvedNames := make([]string, 0, len(objectNames))
+			for _, name := range objectNames {
+				if name == util.AnyWord || name == "" {
+					resolvedNames = append(resolvedNames, name)
+					continue
+				}
+				if actualName, resolveErr := resolveCollectionAlias(ctx, metaCache, dbName, name); resolveErr != nil {
+					mlog.RatedWarn(ctx, rate.Limit(60), "failed to resolve collection alias for RBAC, using original name",
+						mlog.String("objectName", name), mlog.FieldDbName(dbName), mlog.Err(resolveErr))
+					resolvedNames = append(resolvedNames, name)
+				} else {
+					resolvedNames = append(resolvedNames, actualName)
+				}
+			}
+			objectNames = resolvedNames
+		}
+
+		log := mlog.With(mlog.String("username", username), mlog.Strings("role_names", roleNames),
+			mlog.String("object_type", objectType), mlog.String("object_privilege", objectPrivilege),
+			mlog.FieldDbName(dbName),
+			mlog.Int32("object_index", objectNameIndex), mlog.String("object_name", objectName),
+			mlog.Int32("object_indexs", objectNameIndexs), mlog.Strings("object_names", objectNames))
+
+		e := privilege.GetEnforcer()
+		for _, roleName := range roleNames {
+			permitFunc := func(objectName string) (bool, error) {
+				object := funcutil.PolicyForResource(dbName, objectType, objectName)
+				isPermit, cached, version := privilege.GetResultCache(roleName, object, objectPrivilege)
+				if cached {
+					return isPermit, nil
+				}
+				isPermit, err := e.Enforce(roleName, object, objectPrivilege)
+				if err != nil {
+					return false, err
+				}
+				privilege.SetResultCache(roleName, object, objectPrivilege, isPermit, version)
 				return isPermit, nil
 			}
-			isPermit, err := e.Enforce(roleName, object, objectPrivilege)
-			if err != nil {
-				return false, err
-			}
-			privilege.SetResultCache(roleName, object, objectPrivilege, isPermit, version)
-			return isPermit, nil
-		}
 
-		if objectNameIndex != 0 {
-			// handle the api which refers one resource
-			permitObject, err := permitFunc(objectName)
-			if err != nil {
-				log.Warn(ctx, "fail to execute permit func", mlog.String("name", objectName), mlog.Err(err))
-				return ctx, err
-			}
-			if permitObject {
-				return ctx, nil
-			}
-		}
-
-		if objectNameIndexs != 0 {
-			// handle the api which refers many resources
-			permitObjects := true
-			for _, name := range objectNames {
-				p, err := permitFunc(name)
+			if objectNameIndex != 0 {
+				// handle the api which refers one resource
+				permitObject, err := permitFunc(objectName)
 				if err != nil {
-					log.Warn(ctx, "fail to execute permit func", mlog.String("name", name), mlog.Err(err))
+					log.Warn(ctx, "fail to execute permit func", mlog.String("name", objectName), mlog.Err(err))
 					return ctx, err
 				}
-				if !p {
-					permitObjects = false
-					break
+				if permitObject {
+					return ctx, nil
 				}
 			}
-			if permitObjects && len(objectNames) != 0 {
-				return ctx, nil
+
+			if objectNameIndexs != 0 {
+				// handle the api which refers many resources
+				permitObjects := true
+				for _, name := range objectNames {
+					p, err := permitFunc(name)
+					if err != nil {
+						log.Warn(ctx, "fail to execute permit func", mlog.String("name", name), mlog.Err(err))
+						return ctx, err
+					}
+					if !p {
+						permitObjects = false
+						break
+					}
+				}
+				if permitObjects && len(objectNames) != 0 {
+					return ctx, nil
+				}
 			}
 		}
+
+		log.Info(ctx, "permission deny", mlog.Strings("roles", roleNames))
+
+		if password == util.PasswordHolder {
+			username = "apikey user"
+		}
+
+		return ctx, status.Error(codes.PermissionDenied,
+			fmt.Sprintf("%s: permission deny to %s in the `%s` database", objectPrivilege, username, dbName))
 	}
-
-	log.Info(ctx, "permission deny", mlog.Strings("roles", roleNames))
-
-	if password == util.PasswordHolder {
-		username = "apikey user"
-	}
-
-	return ctx, status.Error(codes.PermissionDenied,
-		fmt.Sprintf("%s: permission deny to %s in the `%s` database", objectPrivilege, username, dbName))
 }
 
 // isCurUserObject Determine whether it is an Object of type User that operates on its own user information,
@@ -230,10 +236,9 @@ func isSelectMyRoleGrants(req interface{}, roleNames []string) bool {
 }
 
 // resolveCollectionAlias resolves an alias to its actual collection name
-func resolveCollectionAlias(ctx context.Context, dbName, nameOrAlias string) (string, error) {
-	cache := globalMetaCache
-	if cache == nil {
+func resolveCollectionAlias(ctx context.Context, metaCache Cache, dbName, nameOrAlias string) (string, error) {
+	if metaCache == nil {
 		return nameOrAlias, merr.WrapErrServiceInternal("meta cache not initialized")
 	}
-	return cache.ResolveCollectionAlias(ctx, dbName, nameOrAlias)
+	return metaCache.ResolveCollectionAlias(ctx, dbName, nameOrAlias)
 }

--- a/internal/proxy/privilege_interceptor_test.go
+++ b/internal/proxy/privilege_interceptor_test.go
@@ -82,7 +82,7 @@ func TestPrivilegeInterceptor(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		err = InitMetaCache(ctx, client)
+		_, err = initMetaCache(ctx, client)
 		assert.NoError(t, err)
 		_, err = PrivilegeInterceptor(ctx, &milvuspb.HasCollectionRequest{
 			DbName:         "default",
@@ -201,7 +201,7 @@ func TestPrivilegeInterceptorRequestDBName(t *testing.T) {
 			},
 		}, nil
 	}
-	err := InitMetaCache(context.Background(), client)
+	_, err := initMetaCache(context.Background(), client)
 	assert.NoError(t, err)
 
 	// Both users connect WITHOUT useDatabase, so the connection-context db is
@@ -257,7 +257,8 @@ func TestPrivilegeInterceptorStatisticsRBAC(t *testing.T) {
 				},
 			}, nil
 		}
-		require.NoError(t, InitMetaCache(ctx, client))
+		_, err := initMetaCache(ctx, client)
+		require.NoError(t, err)
 	}
 
 	collectionReq := func() *milvuspb.GetCollectionStatisticsRequest {
@@ -328,7 +329,7 @@ func TestPrivilegeInterceptorClusterLevel(t *testing.T) {
 			},
 		}, nil
 	}
-	err := InitMetaCache(context.Background(), client)
+	_, err := initMetaCache(context.Background(), client)
 	assert.NoError(t, err)
 
 	t.Run("cluster grant authorizes CreateDatabase regardless of namespace", func(t *testing.T) {
@@ -381,7 +382,7 @@ func TestPrivilegeInterceptorDatabaseLevel(t *testing.T) {
 			},
 		}, nil
 	}
-	err := InitMetaCache(context.Background(), client)
+	_, err := initMetaCache(context.Background(), client)
 	assert.NoError(t, err)
 
 	// erin connects without useDatabase (context db = default); grant is on db_target.
@@ -438,7 +439,7 @@ func TestPrivilegeInterceptorRenameCollection(t *testing.T) {
 			},
 		}, nil
 	}
-	err := InitMetaCache(context.Background(), client)
+	_, err := initMetaCache(context.Background(), client)
 	assert.NoError(t, err)
 
 	t.Run("same-db rename allowed with database-admin on that db", func(t *testing.T) {
@@ -479,7 +480,7 @@ func TestRootShouldBindRole(t *testing.T) {
 		Params.Save(Params.CommonCfg.RootShouldBindRole.Key, "false")
 		defer Params.Reset(Params.CommonCfg.RootShouldBindRole.Key)
 
-		InitEmptyGlobalCache()
+		InitEmptyMetaCacheForTest()
 		_, err := PrivilegeInterceptor(rootCtx, &milvuspb.LoadCollectionRequest{
 			CollectionName: "col1",
 		})
@@ -490,7 +491,7 @@ func TestRootShouldBindRole(t *testing.T) {
 		Params.Save(Params.CommonCfg.RootShouldBindRole.Key, "true")
 		defer Params.Reset(Params.CommonCfg.RootShouldBindRole.Key)
 
-		InitEmptyGlobalCache()
+		InitEmptyMetaCacheForTest()
 		_, err := PrivilegeInterceptor(rootCtx, &milvuspb.LoadCollectionRequest{
 			CollectionName: "col1",
 		})
@@ -533,7 +534,8 @@ func TestResourceGroupPrivilege(t *testing.T) {
 				},
 			}, nil
 		}
-		InitMetaCache(ctx, client)
+		_, err = initMetaCache(ctx, client)
+		assert.NoError(t, err)
 
 		_, err = PrivilegeInterceptor(GetContext(context.Background(), "fooo:123456"), &milvuspb.CreateResourceGroupRequest{
 			ResourceGroup: "rg",
@@ -583,7 +585,8 @@ func TestPrivilegeGroup(t *testing.T) {
 				},
 			}, nil
 		}
-		InitMetaCache(ctx, client)
+		_, err = initMetaCache(ctx, client)
+		assert.NoError(t, err)
 		defer privilege.CleanPrivilegeCache()
 
 		_, err = PrivilegeInterceptor(GetContext(context.Background(), "fooo:123456"), &milvuspb.QueryRequest{
@@ -639,7 +642,8 @@ func TestPrivilegeGroup(t *testing.T) {
 				},
 			}, nil
 		}
-		InitMetaCache(ctx, client)
+		_, err = initMetaCache(ctx, client)
+		assert.NoError(t, err)
 		defer privilege.CleanPrivilegeCache()
 
 		_, err = PrivilegeInterceptor(GetContext(context.Background(), "fooo:123456"), &milvuspb.QueryRequest{
@@ -695,7 +699,8 @@ func TestPrivilegeGroup(t *testing.T) {
 				},
 			}, nil
 		}
-		InitMetaCache(ctx, client)
+		_, err = initMetaCache(ctx, client)
+		assert.NoError(t, err)
 		defer privilege.CleanPrivilegeCache()
 
 		_, err = PrivilegeInterceptor(GetContext(context.Background(), "fooo:123456"), &milvuspb.QueryRequest{
@@ -799,7 +804,8 @@ func TestPrivilegeGroup(t *testing.T) {
 				},
 			}, nil
 		}
-		InitMetaCache(ctx, client)
+		_, err = initMetaCache(ctx, client)
+		assert.NoError(t, err)
 		defer privilege.CleanPrivilegeCache()
 
 		_, err = PrivilegeInterceptor(GetContext(context.Background(), "fooo:123456"), &milvuspb.QueryRequest{
@@ -865,7 +871,8 @@ func TestPrivilegeGroup(t *testing.T) {
 				},
 			}, nil
 		}
-		InitMetaCache(ctx, client)
+		_, err = initMetaCache(ctx, client)
+		assert.NoError(t, err)
 		defer privilege.CleanPrivilegeCache()
 
 		_, err = PrivilegeInterceptor(GetContext(context.Background(), "fooo:123456"), &milvuspb.QueryRequest{})
@@ -912,7 +919,8 @@ func TestBuiltinPrivilegeGroup(t *testing.T) {
 				},
 			}, nil
 		}
-		InitMetaCache(ctx, client)
+		_, err = initMetaCache(ctx, client)
+		assert.NoError(t, err)
 		defer privilege.CleanPrivilegeCache()
 
 		_, err = PrivilegeInterceptor(GetContext(context.Background(), "fooo:123456"), &milvuspb.SelectUserRequest{})

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -85,8 +85,9 @@ type Proxy struct {
 
 	simpleLimiter *SimpleLimiter
 
-	metaCache Cache
-	chMgr     channelsMgr
+	metaCacheMu sync.RWMutex
+	metaCache   Cache
+	chMgr       channelsMgr
 
 	sched *taskScheduler
 
@@ -154,7 +155,18 @@ func (node *Proxy) GetStateCode() commonpb.StateCode {
 }
 
 func (node *Proxy) getMetaCache() Cache {
+	node.metaCacheMu.RLock()
+	defer node.metaCacheMu.RUnlock()
 	return node.metaCache
+}
+
+// setMetaCache publishes the meta cache. It is called once during Proxy.Init()
+// after the cache is fully initialized, so request-serving goroutines observe it
+// atomically instead of racing with the assignment.
+func (node *Proxy) setMetaCache(cache Cache) {
+	node.metaCacheMu.Lock()
+	defer node.metaCacheMu.Unlock()
+	node.metaCache = cache
 }
 
 func (node *Proxy) GetMetaCache() Cache {
@@ -268,7 +280,7 @@ func (node *Proxy) Init() error {
 		mlog.Warn(node.ctx, "failed to init meta cache", mlog.String("role", typeutil.ProxyRole), mlog.Err(err))
 		return err
 	}
-	node.metaCache = metaCache
+	node.setMetaCache(metaCache)
 	mlog.Debug(node.ctx, "init meta cache done", mlog.String("role", typeutil.ProxyRole))
 
 	node.shardMgr = shardclient.NewShardClientMgr(node.mixCoord)
@@ -357,8 +369,8 @@ func (node *Proxy) Stop() error {
 		node.resourceManager.Close()
 	}
 
-	if node.metaCache != nil {
-		node.metaCache.Close()
+	if metaCache := node.getMetaCache(); metaCache != nil {
+		metaCache.Close()
 	}
 
 	node.cancel()

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -85,7 +85,8 @@ type Proxy struct {
 
 	simpleLimiter *SimpleLimiter
 
-	chMgr channelsMgr
+	metaCache Cache
+	chMgr     channelsMgr
 
 	sched *taskScheduler
 
@@ -150,6 +151,14 @@ func (node *Proxy) UpdateStateCode(code commonpb.StateCode) {
 
 func (node *Proxy) GetStateCode() commonpb.StateCode {
 	return commonpb.StateCode(node.stateCode.Load())
+}
+
+func (node *Proxy) getMetaCache() Cache {
+	return node.metaCache
+}
+
+func (node *Proxy) GetMetaCache() Cache {
+	return node.getMetaCache()
 }
 
 // Register registers proxy at etcd
@@ -254,10 +263,12 @@ func (node *Proxy) Init() error {
 	node.metricsCacheManager = metricsinfo.NewMetricsCacheManager()
 	mlog.Debug(node.ctx, "create metrics cache manager done", mlog.String("role", typeutil.ProxyRole))
 
-	if err := InitMetaCache(node.ctx, node.mixCoord); err != nil {
+	metaCache, err := initMetaCache(node.ctx, node.mixCoord)
+	if err != nil {
 		mlog.Warn(node.ctx, "failed to init meta cache", mlog.String("role", typeutil.ProxyRole), mlog.Err(err))
 		return err
 	}
+	node.metaCache = metaCache
 	mlog.Debug(node.ctx, "init meta cache done", mlog.String("role", typeutil.ProxyRole))
 
 	node.shardMgr = shardclient.NewShardClientMgr(node.mixCoord)
@@ -346,8 +357,8 @@ func (node *Proxy) Stop() error {
 		node.resourceManager.Close()
 	}
 
-	if globalMetaCache != nil {
-		globalMetaCache.Close()
+	if node.metaCache != nil {
+		node.metaCache.Close()
 	}
 
 	node.cancel()

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1202,7 +1202,7 @@ func TestProxy(t *testing.T) {
 			CollectionName: "alias",
 		})
 
-		_, err = globalMetaCache.GetCollectionID(ctx, dbName, "alias")
+		_, err = proxy.getMetaCache().GetCollectionID(ctx, dbName, "alias")
 		assert.Error(t, err)
 	})
 
@@ -1230,7 +1230,7 @@ func TestProxy(t *testing.T) {
 	})
 
 	t.Run("describe collection", func(t *testing.T) {
-		collectionID, err := globalMetaCache.GetCollectionID(ctx, dbName, collectionName)
+		collectionID, err := proxy.getMetaCache().GetCollectionID(ctx, dbName, collectionName)
 		assert.NoError(t, err)
 
 		resp, err := proxy.DescribeCollection(ctx, &milvuspb.DescribeCollectionRequest{
@@ -1414,7 +1414,7 @@ func TestProxy(t *testing.T) {
 	})
 
 	t.Run("show partitions", func(t *testing.T) {
-		collectionID, err := globalMetaCache.GetCollectionID(ctx, dbName, collectionName)
+		collectionID, err := proxy.getMetaCache().GetCollectionID(ctx, dbName, collectionName)
 		assert.NoError(t, err)
 
 		resp, err := proxy.ShowPartitions(ctx, &milvuspb.ShowPartitionsRequest{
@@ -1982,7 +1982,7 @@ func TestProxy(t *testing.T) {
 	})
 
 	t.Run("get replicas", func(t *testing.T) {
-		collectionID, err := globalMetaCache.GetCollectionID(ctx, dbName, collectionName)
+		collectionID, err := proxy.getMetaCache().GetCollectionID(ctx, dbName, collectionName)
 		assert.NoError(t, err)
 
 		resp, err := proxy.GetReplicas(ctx, &milvuspb.GetReplicasRequest{
@@ -2231,7 +2231,7 @@ func TestProxy(t *testing.T) {
 	})
 
 	t.Run("release collection", func(t *testing.T) {
-		_, err := globalMetaCache.GetCollectionID(ctx, dbName, collectionName)
+		_, err := proxy.getMetaCache().GetCollectionID(ctx, dbName, collectionName)
 		assert.NoError(t, err)
 
 		resp, err := proxy.ReleaseCollection(ctx, &milvuspb.ReleaseCollectionRequest{
@@ -2259,7 +2259,7 @@ func TestProxy(t *testing.T) {
 
 	pLoaded := true
 	t.Run("load partitions", func(t *testing.T) {
-		collectionID, err := globalMetaCache.GetCollectionID(ctx, dbName, collectionName)
+		collectionID, err := proxy.getMetaCache().GetCollectionID(ctx, dbName, collectionName)
 		assert.NoError(t, err)
 
 		resp, err := proxy.LoadPartitions(ctx, &milvuspb.LoadPartitionsRequest{
@@ -2309,7 +2309,7 @@ func TestProxy(t *testing.T) {
 	assert.True(t, pLoaded)
 
 	t.Run("show in-memory partitions", func(t *testing.T) {
-		collectionID, err := globalMetaCache.GetCollectionID(ctx, dbName, collectionName)
+		collectionID, err := proxy.getMetaCache().GetCollectionID(ctx, dbName, collectionName)
 		assert.NoError(t, err)
 
 		resp, err := proxy.ShowPartitions(ctx, &milvuspb.ShowPartitionsRequest{
@@ -2556,7 +2556,7 @@ func TestProxy(t *testing.T) {
 	})
 
 	t.Run("show in-memory partitions after release partition", func(t *testing.T) {
-		collectionID, err := globalMetaCache.GetCollectionID(ctx, dbName, collectionName)
+		collectionID, err := proxy.getMetaCache().GetCollectionID(ctx, dbName, collectionName)
 		assert.NoError(t, err)
 
 		resp, err := proxy.ShowPartitions(ctx, &milvuspb.ShowPartitionsRequest{
@@ -2606,7 +2606,7 @@ func TestProxy(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, commonpb.ErrorCode_Success, resp.ErrorCode)
 
-		_, err = globalMetaCache.GetPartitionID(ctx, dbName, collectionName, partitionName)
+		_, err = proxy.getMetaCache().GetPartitionID(ctx, dbName, collectionName, partitionName)
 		assert.Error(t, err)
 
 		// drop non-exist partition -> fail
@@ -2645,7 +2645,7 @@ func TestProxy(t *testing.T) {
 	})
 
 	t.Run("show partitions after drop partition", func(t *testing.T) {
-		collectionID, err := globalMetaCache.GetCollectionID(ctx, dbName, collectionName)
+		collectionID, err := proxy.getMetaCache().GetCollectionID(ctx, dbName, collectionName)
 		assert.NoError(t, err)
 
 		resp, err := proxy.ShowPartitions(ctx, &milvuspb.ShowPartitionsRequest{
@@ -2686,7 +2686,7 @@ func TestProxy(t *testing.T) {
 	})
 
 	t.Run("truncate collection", func(t *testing.T) {
-		_, err := globalMetaCache.GetCollectionID(ctx, dbName, collectionName)
+		_, err := proxy.getMetaCache().GetCollectionID(ctx, dbName, collectionName)
 		assert.NoError(t, err)
 
 		resp, err := proxy.TruncateCollection(ctx, &milvuspb.TruncateCollectionRequest{
@@ -2709,7 +2709,7 @@ func TestProxy(t *testing.T) {
 	})
 
 	t.Run("drop collection", func(t *testing.T) {
-		_, err := globalMetaCache.GetCollectionID(ctx, dbName, collectionName)
+		_, err := proxy.getMetaCache().GetCollectionID(ctx, dbName, collectionName)
 		assert.NoError(t, err)
 
 		resp, err := proxy.DropCollection(ctx, &milvuspb.DropCollectionRequest{
@@ -2731,7 +2731,7 @@ func TestProxy(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, commonpb.ErrorCode_Success, resp.ErrorCode)
 
-		_, err = globalMetaCache.GetCollectionID(ctx, dbName, collectionName)
+		_, err = proxy.getMetaCache().GetCollectionID(ctx, dbName, collectionName)
 		assert.Error(t, err)
 
 		resp, err = proxy.InvalidateCollectionMetaCache(ctx, &proxypb.InvalidateCollMetaCacheRequest{
@@ -2743,7 +2743,7 @@ func TestProxy(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, commonpb.ErrorCode_Success, resp.ErrorCode)
 
-		hasDatabase := globalMetaCache.HasDatabase(ctx, dbName)
+		hasDatabase := proxy.getMetaCache().HasDatabase(ctx, dbName)
 		assert.False(t, hasDatabase)
 	})
 
@@ -4417,20 +4417,15 @@ func Test_GetCompactionStateWithPlans(t *testing.T) {
 
 func Test_GetFlushState(t *testing.T) {
 	t.Run("normal test", func(t *testing.T) {
-		originCache := globalMetaCache
 		m := NewMockCache(t)
 		m.On("GetCollectionID",
 			mock.Anything,
 			mock.AnythingOfType("string"),
 			mock.AnythingOfType("string"),
 		).Return(UniqueID(1), nil)
-		globalMetaCache = m
-		defer func() {
-			globalMetaCache = originCache
-		}()
 
 		mixCoord := &MixCoordMock{}
-		proxy := &Proxy{mixCoord: mixCoord}
+		proxy := &Proxy{mixCoord: mixCoord, metaCache: m}
 		proxy.UpdateStateCode(commonpb.StateCode_Healthy)
 		resp, err := proxy.GetFlushState(context.TODO(), &milvuspb.GetFlushStateRequest{
 			CollectionName: "coll",
@@ -4484,9 +4479,6 @@ func TestProxy_GetComponentStates(t *testing.T) {
 }
 
 func TestProxy_Import(t *testing.T) {
-	cache := globalMetaCache
-	defer func() { globalMetaCache = cache }()
-
 	streaming.SetupNoopWALForTest()
 
 	t.Run("Import failed", func(t *testing.T) {
@@ -4513,7 +4505,7 @@ func TestProxy_Import(t *testing.T) {
 		mc.EXPECT().GetDatabaseInfo(mock.Anything, mock.Anything).Return(&databaseInfo{
 			DBID: 1,
 		}, nil)
-		globalMetaCache = mc
+		proxy.metaCache = mc
 
 		chMgr := NewMockChannelsMgr(t)
 		chMgr.EXPECT().getVChannels(mock.Anything).Return([]string{"foo"}, nil)
@@ -4605,18 +4597,12 @@ func TestProxy_RelatedPrivilege(t *testing.T) {
 	}
 	ctx := GetContext(context.Background(), "root:123456")
 
-	// OperatePrivilege resolves the collection alias before granting (default
-	// ResolveAliasForPrivilege on); pin globalMetaCache to a mock that resolves
-	// "col1" as-is, so the test does not depend on leftover global cache state.
-	originCache := globalMetaCache
 	metaCache := NewMockCache(t)
 	metaCache.EXPECT().ResolveCollectionAlias(mock.Anything, mock.Anything, "col1").Return("col1", nil).Maybe()
-	globalMetaCache = metaCache
-	defer func() { globalMetaCache = originCache }()
 
 	t.Run("related privilege grpc error", func(t *testing.T) {
 		mixCoord := mocks.NewMockMixCoordClient(t)
-		proxy := &Proxy{mixCoord: mixCoord}
+		proxy := &Proxy{mixCoord: mixCoord, metaCache: metaCache}
 		proxy.UpdateStateCode(commonpb.StateCode_Healthy)
 
 		mixCoord.EXPECT().OperatePrivilege(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, request *milvuspb.OperatePrivilegeRequest, option ...grpc.CallOption) (*commonpb.Status, error) {
@@ -4634,7 +4620,7 @@ func TestProxy_RelatedPrivilege(t *testing.T) {
 
 	t.Run("related privilege status error", func(t *testing.T) {
 		mixCoord := mocks.NewMockMixCoordClient(t)
-		proxy := &Proxy{mixCoord: mixCoord}
+		proxy := &Proxy{mixCoord: mixCoord, metaCache: metaCache}
 		proxy.UpdateStateCode(commonpb.StateCode_Healthy)
 
 		mixCoord.EXPECT().OperatePrivilege(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, request *milvuspb.OperatePrivilegeRequest, option ...grpc.CallOption) (*commonpb.Status, error) {
@@ -4656,7 +4642,6 @@ func TestProxy_GetStatistics(t *testing.T) {
 }
 
 func TestProxy_GetLoadState(t *testing.T) {
-	originCache := globalMetaCache
 	m := NewMockCache(t)
 	m.On("GetCollectionID",
 		mock.Anything, // context.Context
@@ -4669,11 +4654,6 @@ func TestProxy_GetLoadState(t *testing.T) {
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("string"),
 	).Return(UniqueID(2), nil)
-	globalMetaCache = m
-	defer func() {
-		globalMetaCache = originCache
-	}()
-
 	{
 		mixCoord := getMixCoordClient()
 		mixCoord.EXPECT().ShowLoadCollections(mock.Anything, mock.Anything).Return(&querypb.ShowCollectionsResponse{
@@ -4681,7 +4661,7 @@ func TestProxy_GetLoadState(t *testing.T) {
 			CollectionIDs:       nil,
 			InMemoryPercentages: []int64{},
 		}, nil)
-		proxy := &Proxy{mixCoord: mixCoord}
+		proxy := &Proxy{mixCoord: mixCoord, metaCache: m}
 		proxy.UpdateStateCode(commonpb.StateCode_Healthy)
 		stateResp, err := proxy.GetLoadState(context.Background(), &milvuspb.GetLoadStateRequest{CollectionName: "foo"})
 		assert.NoError(t, err)
@@ -4696,7 +4676,7 @@ func TestProxy_GetLoadState(t *testing.T) {
 		mixCoord := getMixCoordClient()
 		mixCoord.EXPECT().ShowLoadCollections(mock.Anything, mock.Anything).Return(nil, merr.WrapErrCollectionNotLoaded("foo"))
 		mixCoord.EXPECT().ShowLoadPartitions(mock.Anything, mock.Anything).Return(nil, merr.WrapErrPartitionNotLoaded("p1"))
-		proxy := &Proxy{mixCoord: mixCoord}
+		proxy := &Proxy{mixCoord: mixCoord, metaCache: m}
 		proxy.UpdateStateCode(commonpb.StateCode_Healthy)
 
 		stateResp, err := proxy.GetLoadState(context.Background(), &milvuspb.GetLoadStateRequest{CollectionName: "foo"})

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -4717,7 +4717,7 @@ func TestProxy_GetLoadState(t *testing.T) {
 			CollectionIDs:       nil,
 			InMemoryPercentages: []int64{100},
 		}, nil)
-		proxy := &Proxy{mixCoord: mixc}
+		proxy := &Proxy{mixCoord: mixc, metaCache: m}
 		proxy.UpdateStateCode(commonpb.StateCode_Healthy)
 
 		stateResp, err := proxy.GetLoadState(context.Background(), &milvuspb.GetLoadStateRequest{CollectionName: "foo", Base: &commonpb.MsgBase{}})
@@ -4752,7 +4752,7 @@ func TestProxy_GetLoadState(t *testing.T) {
 			CollectionIDs:       nil,
 			InMemoryPercentages: []int64{50},
 		}, nil)
-		proxy := &Proxy{mixCoord: mixc}
+		proxy := &Proxy{mixCoord: mixc, metaCache: m}
 		proxy.UpdateStateCode(commonpb.StateCode_Healthy)
 
 		stateResp, err := proxy.GetLoadState(context.Background(), &milvuspb.GetLoadStateRequest{CollectionName: "foo"})
@@ -4786,7 +4786,7 @@ func TestProxy_GetLoadState(t *testing.T) {
 		mixc.EXPECT().ShowLoadPartitions(mock.Anything, mock.Anything).Return(&querypb.ShowPartitionsResponse{
 			Status: merr.Status(mockErr),
 		}, nil)
-		proxy := &Proxy{mixCoord: mixc}
+		proxy := &Proxy{mixCoord: mixc, metaCache: m}
 		proxy.UpdateStateCode(commonpb.StateCode_Healthy)
 
 		stateResp, err := proxy.GetLoadState(context.Background(), &milvuspb.GetLoadStateRequest{CollectionName: "foo"})

--- a/internal/proxy/rate_limit_interceptor.go
+++ b/internal/proxy/rate_limit_interceptor.go
@@ -37,12 +37,16 @@ import (
 
 // RateLimitInterceptor returns a new unary server interceptors that performs request rate limiting.
 func RateLimitInterceptor(limiter types.Limiter) grpc.UnaryServerInterceptor {
+	return RateLimitInterceptorWithMetaCache(nil, limiter)
+}
+
+func RateLimitInterceptorWithMetaCache(metaCache Cache, limiter types.Limiter) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		request, ok := req.(proto.Message)
 		if !ok {
 			return nil, merr.WrapErrParameterInvalidMsg("wrong req format when check limiter")
 		}
-		dbID, collectionIDToPartIDs, rt, n, err := GetRequestInfo(ctx, request)
+		dbID, collectionIDToPartIDs, rt, n, err := GetRequestInfo(ctx, metaCache, request)
 		if err != nil {
 			mlog.Warn(context.TODO(), "failed to get request info", mlog.Err(err))
 			return handler(ctx, req)
@@ -107,19 +111,19 @@ func getRequestNamespace(req any) *string {
 	}
 }
 
-func getCollectionAndPartitionID(ctx context.Context, r reqPartName) (int64, map[int64][]int64, error) {
-	db, err := globalMetaCache.GetDatabaseInfo(ctx, r.GetDbName())
+func getCollectionAndPartitionID(ctx context.Context, metaCache Cache, r reqPartName) (int64, map[int64][]int64, error) {
+	db, err := metaCache.GetDatabaseInfo(ctx, r.GetDbName())
 	if err != nil {
 		return 0, nil, err
 	}
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, r.GetDbName(), r.GetCollectionName())
+	collectionID, err := metaCache.GetCollectionID(ctx, r.GetDbName(), r.GetCollectionName())
 	if err != nil {
 		return 0, nil, err
 	}
 
 	var collectionSchema *schemaInfo
 	if namespace := getRequestNamespace(r); namespace != nil {
-		collectionSchema, err = globalMetaCache.GetCollectionSchema(ctx, r.GetDbName(), r.GetCollectionName())
+		collectionSchema, err = metaCache.GetCollectionSchema(ctx, r.GetDbName(), r.GetCollectionName())
 		if err != nil {
 			return 0, nil, err
 		}
@@ -128,7 +132,7 @@ func getCollectionAndPartitionID(ctx context.Context, r reqPartName) (int64, map
 			return 0, nil, err
 		}
 		if namespaceAsPartition {
-			part, err := globalMetaCache.GetPartitionInfo(ctx, r.GetDbName(), r.GetCollectionName(), partitionName)
+			part, err := metaCache.GetPartitionInfo(ctx, r.GetDbName(), r.GetCollectionName(), partitionName)
 			if err != nil {
 				return 0, nil, err
 			}
@@ -138,7 +142,7 @@ func getCollectionAndPartitionID(ctx context.Context, r reqPartName) (int64, map
 
 	if r.GetPartitionName() == "" {
 		if collectionSchema == nil {
-			collectionSchema, err = globalMetaCache.GetCollectionSchema(ctx, r.GetDbName(), r.GetCollectionName())
+			collectionSchema, err = metaCache.GetCollectionSchema(ctx, r.GetDbName(), r.GetCollectionName())
 			if err != nil {
 				return 0, nil, err
 			}
@@ -147,25 +151,25 @@ func getCollectionAndPartitionID(ctx context.Context, r reqPartName) (int64, map
 			return db.DBID, map[int64][]int64{collectionID: {}}, nil
 		}
 	}
-	part, err := globalMetaCache.GetPartitionInfo(ctx, r.GetDbName(), r.GetCollectionName(), r.GetPartitionName())
+	part, err := metaCache.GetPartitionInfo(ctx, r.GetDbName(), r.GetCollectionName(), r.GetPartitionName())
 	if err != nil {
 		return 0, nil, err
 	}
 	return db.DBID, map[int64][]int64{collectionID: {part.PartitionID}}, nil
 }
 
-func getCollectionAndPartitionIDs(ctx context.Context, r reqPartNames) (int64, map[int64][]int64, error) {
-	db, err := globalMetaCache.GetDatabaseInfo(ctx, r.GetDbName())
+func getCollectionAndPartitionIDs(ctx context.Context, metaCache Cache, r reqPartNames) (int64, map[int64][]int64, error) {
+	db, err := metaCache.GetDatabaseInfo(ctx, r.GetDbName())
 	if err != nil {
 		return 0, nil, err
 	}
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, r.GetDbName(), r.GetCollectionName())
+	collectionID, err := metaCache.GetCollectionID(ctx, r.GetDbName(), r.GetCollectionName())
 	if err != nil {
 		return 0, nil, err
 	}
 	partitionNames := r.GetPartitionNames()
 	if namespace := getRequestNamespace(r); namespace != nil {
-		collectionSchema, err := globalMetaCache.GetCollectionSchema(ctx, r.GetDbName(), r.GetCollectionName())
+		collectionSchema, err := metaCache.GetCollectionSchema(ctx, r.GetDbName(), r.GetCollectionName())
 		if err != nil {
 			return 0, nil, err
 		}
@@ -177,7 +181,7 @@ func getCollectionAndPartitionIDs(ctx context.Context, r reqPartNames) (int64, m
 
 	parts := make([]int64, len(partitionNames))
 	for i, s := range partitionNames {
-		part, err := globalMetaCache.GetPartitionInfo(ctx, r.GetDbName(), r.GetCollectionName(), s)
+		part, err := metaCache.GetPartitionInfo(ctx, r.GetDbName(), r.GetCollectionName(), s)
 		if err != nil {
 			return 0, nil, err
 		}
@@ -187,17 +191,17 @@ func getCollectionAndPartitionIDs(ctx context.Context, r reqPartNames) (int64, m
 	return db.DBID, map[int64][]int64{collectionID: parts}, nil
 }
 
-func getCollectionID(r reqCollName) (int64, map[int64][]int64) {
-	db, _ := globalMetaCache.GetDatabaseInfo(context.TODO(), r.GetDbName())
+func getCollectionID(metaCache Cache, r reqCollName) (int64, map[int64][]int64) {
+	db, _ := metaCache.GetDatabaseInfo(context.TODO(), r.GetDbName())
 	if db == nil {
 		return util.InvalidDBID, map[int64][]int64{}
 	}
-	collectionID, _ := globalMetaCache.GetCollectionID(context.TODO(), r.GetDbName(), r.GetCollectionName())
+	collectionID, _ := metaCache.GetCollectionID(context.TODO(), r.GetDbName(), r.GetCollectionName())
 	return db.DBID, map[int64][]int64{collectionID: {}}
 }
 
-func getDatabaseID(dbName string) int64 {
-	db, _ := globalMetaCache.GetDatabaseInfo(context.TODO(), dbName)
+func getDatabaseID(metaCache Cache, dbName string) int64 {
+	db, _ := metaCache.GetDatabaseInfo(context.TODO(), dbName)
 	if db == nil {
 		return util.InvalidDBID
 	}

--- a/internal/proxy/rate_limit_interceptor.go
+++ b/internal/proxy/rate_limit_interceptor.go
@@ -37,16 +37,19 @@ import (
 
 // RateLimitInterceptor returns a new unary server interceptors that performs request rate limiting.
 func RateLimitInterceptor(limiter types.Limiter) grpc.UnaryServerInterceptor {
-	return RateLimitInterceptorWithMetaCache(nil, limiter)
+	return RateLimitInterceptorWithMetaCache(func() Cache { return nil }, limiter)
 }
 
-func RateLimitInterceptorWithMetaCache(metaCache Cache, limiter types.Limiter) grpc.UnaryServerInterceptor {
+// RateLimitInterceptorWithMetaCache returns a new unary server interceptor that performs
+// request rate limiting. getMetaCache is resolved per request so the interceptor observes
+// the meta cache initialized by the proxy after startup instead of a construction-time snapshot.
+func RateLimitInterceptorWithMetaCache(getMetaCache func() Cache, limiter types.Limiter) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		request, ok := req.(proto.Message)
 		if !ok {
 			return nil, merr.WrapErrParameterInvalidMsg("wrong req format when check limiter")
 		}
-		dbID, collectionIDToPartIDs, rt, n, err := GetRequestInfo(ctx, metaCache, request)
+		dbID, collectionIDToPartIDs, rt, n, err := GetRequestInfo(ctx, getMetaCache(), request)
 		if err != nil {
 			mlog.Warn(context.TODO(), "failed to get request info", mlog.Err(err))
 			return handler(ctx, req)

--- a/internal/proxy/rate_limit_interceptor_test.go
+++ b/internal/proxy/rate_limit_interceptor_test.go
@@ -408,7 +408,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		serverInfo := &grpc.UnaryServerInfo{FullMethod: "MockFullMethod"}
 
 		limiter.limit = true
-		interceptorFun := RateLimitInterceptorWithMetaCache(mockCache, &limiter)
+		interceptorFun := RateLimitInterceptorWithMetaCache(func() Cache { return mockCache }, &limiter)
 		rsp, err := interceptorFun(context.Background(), &milvuspb.InsertRequest{
 			CollectionName: "foo",
 			PartitionName:  "p1",
@@ -418,7 +418,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.NoError(t, err)
 
 		limiter.limit = false
-		interceptorFun = RateLimitInterceptorWithMetaCache(mockCache, &limiter)
+		interceptorFun = RateLimitInterceptorWithMetaCache(func() Cache { return mockCache }, &limiter)
 		rsp, err = interceptorFun(context.Background(), &milvuspb.InsertRequest{
 			CollectionName: "foo",
 			PartitionName:  "p1",
@@ -429,7 +429,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 
 		// test 0 rate, force deny
 		limiter.rate = 0
-		interceptorFun = RateLimitInterceptorWithMetaCache(mockCache, &limiter)
+		interceptorFun = RateLimitInterceptorWithMetaCache(func() Cache { return mockCache }, &limiter)
 		rsp, err = interceptorFun(context.Background(), &milvuspb.InsertRequest{}, serverInfo, handler)
 		assert.Equal(t, commonpb.ErrorCode_ForceDeny, rsp.(*milvuspb.MutationResult).GetStatus().GetErrorCode())
 		assert.NoError(t, err)
@@ -447,7 +447,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		serverInfo := &grpc.UnaryServerInfo{FullMethod: "MockFullMethod"}
 
 		limiter.limit = true
-		interceptorFun := RateLimitInterceptorWithMetaCache(mockCache, &limiter)
+		interceptorFun := RateLimitInterceptorWithMetaCache(func() Cache { return mockCache }, &limiter)
 		rsp, err := interceptorFun(context.Background(), &milvuspb.InsertRequest{}, serverInfo, handler)
 		assert.Equal(t, commonpb.ErrorCode_Success, rsp.(*milvuspb.MutationResult).GetStatus().GetErrorCode())
 		assert.NoError(t, err)

--- a/internal/proxy/rate_limit_interceptor_test.go
+++ b/internal/proxy/rate_limit_interceptor_test.go
@@ -70,8 +70,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 			DBID:             100,
 			CreatedTimestamp: 1,
 		}, nil)
-		globalMetaCache = mockCache
-		database, col2part, rt, size, err := GetRequestInfo(context.Background(), &milvuspb.InsertRequest{
+		database, col2part, rt, size, err := GetRequestInfo(context.Background(), mockCache, &milvuspb.InsertRequest{
 			CollectionName: "foo",
 			PartitionName:  "p1",
 			DbName:         "db1",
@@ -87,7 +86,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.True(t, len(col2part) == 1)
 		assert.Equal(t, int64(10), col2part[1][0])
 
-		database, col2part, rt, size, err = GetRequestInfo(context.Background(), &milvuspb.UpsertRequest{
+		database, col2part, rt, size, err = GetRequestInfo(context.Background(), mockCache, &milvuspb.UpsertRequest{
 			CollectionName: "foo",
 			PartitionName:  "p1",
 			DbName:         "db1",
@@ -103,7 +102,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.True(t, len(col2part) == 1)
 		assert.Equal(t, int64(10), col2part[1][0])
 
-		database, col2part, rt, size, err = GetRequestInfo(context.Background(), &milvuspb.DeleteRequest{
+		database, col2part, rt, size, err = GetRequestInfo(context.Background(), mockCache, &milvuspb.DeleteRequest{
 			CollectionName: "foo",
 			PartitionName:  "p1",
 			DbName:         "db1",
@@ -119,7 +118,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.True(t, len(col2part) == 1)
 		assert.Equal(t, int64(10), col2part[1][0])
 
-		database, col2part, rt, size, err = GetRequestInfo(context.Background(), &milvuspb.ImportRequest{
+		database, col2part, rt, size, err = GetRequestInfo(context.Background(), mockCache, &milvuspb.ImportRequest{
 			CollectionName: "foo",
 			PartitionName:  "p1",
 			DbName:         "db1",
@@ -135,7 +134,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.True(t, len(col2part) == 1)
 		assert.Equal(t, int64(10), col2part[1][0])
 
-		database, col2part, rt, size, err = GetRequestInfo(context.Background(), &milvuspb.SearchRequest{
+		database, col2part, rt, size, err = GetRequestInfo(context.Background(), mockCache, &milvuspb.SearchRequest{
 			Nq: 5,
 			PartitionNames: []string{
 				"p1",
@@ -148,7 +147,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.Equal(t, 1, len(col2part))
 		assert.Equal(t, 1, len(col2part[1]))
 
-		database, col2part, rt, size, err = GetRequestInfo(context.Background(), &milvuspb.QueryRequest{
+		database, col2part, rt, size, err = GetRequestInfo(context.Background(), mockCache, &milvuspb.QueryRequest{
 			CollectionName: "foo",
 			PartitionNames: []string{
 				"p1",
@@ -162,7 +161,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.Equal(t, 1, len(col2part))
 		assert.Equal(t, 1, len(col2part[1]))
 
-		database, col2part, rt, size, err = GetRequestInfo(context.Background(), &milvuspb.CreateCollectionRequest{})
+		database, col2part, rt, size, err = GetRequestInfo(context.Background(), mockCache, &milvuspb.CreateCollectionRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLCollection, rt)
@@ -170,7 +169,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.Equal(t, 1, len(col2part))
 		assert.Equal(t, 0, len(col2part[1]))
 
-		database, col2part, rt, size, err = GetRequestInfo(context.Background(), &milvuspb.RestoreExternalSnapshotRequest{
+		database, col2part, rt, size, err = GetRequestInfo(context.Background(), mockCache, &milvuspb.RestoreExternalSnapshotRequest{
 			DbName:               "db1",
 			TargetCollectionName: "restored",
 			SnapshotMetadataUri:  "s3://bucket/export-root/snapshots/100/metadata/1.json",
@@ -181,7 +180,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.Equal(t, database, int64(100))
 		assert.Empty(t, col2part)
 
-		database, col2part, rt, size, err = GetRequestInfo(context.Background(), &milvuspb.ExportSnapshotRequest{
+		database, col2part, rt, size, err = GetRequestInfo(context.Background(), mockCache, &milvuspb.ExportSnapshotRequest{
 			DbName:         "db1",
 			CollectionName: "foo",
 			Name:           "snapshot",
@@ -194,7 +193,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.Equal(t, 1, len(col2part))
 		assert.Equal(t, 0, len(col2part[1]))
 
-		database, col2part, rt, size, err = GetRequestInfo(context.Background(), &milvuspb.LoadCollectionRequest{})
+		database, col2part, rt, size, err = GetRequestInfo(context.Background(), mockCache, &milvuspb.LoadCollectionRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLCollection, rt)
@@ -202,7 +201,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.Equal(t, 1, len(col2part))
 		assert.Equal(t, 0, len(col2part[1]))
 
-		database, col2part, rt, size, err = GetRequestInfo(context.Background(), &milvuspb.ReleaseCollectionRequest{})
+		database, col2part, rt, size, err = GetRequestInfo(context.Background(), mockCache, &milvuspb.ReleaseCollectionRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLCollection, rt)
@@ -210,7 +209,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.Equal(t, 1, len(col2part))
 		assert.Equal(t, 0, len(col2part[1]))
 
-		database, col2part, rt, size, err = GetRequestInfo(context.Background(), &milvuspb.DropCollectionRequest{})
+		database, col2part, rt, size, err = GetRequestInfo(context.Background(), mockCache, &milvuspb.DropCollectionRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLCollection, rt)
@@ -218,7 +217,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.Equal(t, 1, len(col2part))
 		assert.Equal(t, 0, len(col2part[1]))
 
-		database, col2part, rt, size, err = GetRequestInfo(context.Background(), &milvuspb.CreatePartitionRequest{})
+		database, col2part, rt, size, err = GetRequestInfo(context.Background(), mockCache, &milvuspb.CreatePartitionRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLPartition, rt)
@@ -226,7 +225,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.Equal(t, 1, len(col2part))
 		assert.Equal(t, 0, len(col2part[1]))
 
-		database, col2part, rt, size, err = GetRequestInfo(context.Background(), &milvuspb.LoadPartitionsRequest{})
+		database, col2part, rt, size, err = GetRequestInfo(context.Background(), mockCache, &milvuspb.LoadPartitionsRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLPartition, rt)
@@ -234,7 +233,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.Equal(t, 1, len(col2part))
 		assert.Equal(t, 0, len(col2part[1]))
 
-		database, col2part, rt, size, err = GetRequestInfo(context.Background(), &milvuspb.ReleasePartitionsRequest{})
+		database, col2part, rt, size, err = GetRequestInfo(context.Background(), mockCache, &milvuspb.ReleasePartitionsRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLPartition, rt)
@@ -242,7 +241,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.Equal(t, 1, len(col2part))
 		assert.Equal(t, 0, len(col2part[1]))
 
-		database, col2part, rt, size, err = GetRequestInfo(context.Background(), &milvuspb.DropPartitionRequest{})
+		database, col2part, rt, size, err = GetRequestInfo(context.Background(), mockCache, &milvuspb.DropPartitionRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLPartition, rt)
@@ -250,7 +249,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.Equal(t, 1, len(col2part))
 		assert.Equal(t, 0, len(col2part[1]))
 
-		database, col2part, rt, size, err = GetRequestInfo(context.Background(), &milvuspb.CreateIndexRequest{})
+		database, col2part, rt, size, err = GetRequestInfo(context.Background(), mockCache, &milvuspb.CreateIndexRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLIndex, rt)
@@ -258,7 +257,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.Equal(t, 1, len(col2part))
 		assert.Equal(t, 0, len(col2part[1]))
 
-		database, col2part, rt, size, err = GetRequestInfo(context.Background(), &milvuspb.DropIndexRequest{})
+		database, col2part, rt, size, err = GetRequestInfo(context.Background(), mockCache, &milvuspb.DropIndexRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLIndex, rt)
@@ -266,7 +265,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.Equal(t, 1, len(col2part))
 		assert.Equal(t, 0, len(col2part[1]))
 
-		database, col2part, rt, size, err = GetRequestInfo(context.Background(), &milvuspb.FlushRequest{
+		database, col2part, rt, size, err = GetRequestInfo(context.Background(), mockCache, &milvuspb.FlushRequest{
 			CollectionNames: []string{
 				"col1",
 			},
@@ -277,16 +276,16 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.Equal(t, database, int64(100))
 		assert.Equal(t, 1, len(col2part))
 
-		database, _, rt, size, err = GetRequestInfo(context.Background(), &milvuspb.ManualCompactionRequest{})
+		database, _, rt, size, err = GetRequestInfo(context.Background(), mockCache, &milvuspb.ManualCompactionRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, size)
 		assert.Equal(t, internalpb.RateType_DDLCompaction, rt)
 		assert.Equal(t, database, int64(100))
 
-		_, _, _, _, err = GetRequestInfo(context.Background(), nil)
+		_, _, _, _, err = GetRequestInfo(context.Background(), mockCache, nil)
 		assert.Error(t, err)
 
-		_, _, _, _, err = GetRequestInfo(context.Background(), &milvuspb.CalcDistanceRequest{})
+		_, _, _, _, err = GetRequestInfo(context.Background(), mockCache, &milvuspb.CalcDistanceRequest{})
 		assert.NoError(t, err)
 	})
 
@@ -311,9 +310,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 			CreatedTimestamp:    10001,
 			CreatedUtcTimestamp: 10002,
 		}, nil).Times(4)
-		globalMetaCache = mockCache
-
-		database, col2part, rt, _, err := GetRequestInfo(context.Background(), &milvuspb.InsertRequest{
+		database, col2part, rt, _, err := GetRequestInfo(context.Background(), mockCache, &milvuspb.InsertRequest{
 			CollectionName: "foo",
 			DbName:         "db1",
 			Namespace:      &namespace,
@@ -323,7 +320,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.Equal(t, internalpb.RateType_DMLInsert, rt)
 		assert.Equal(t, []int64{20}, col2part[1])
 
-		database, col2part, rt, _, err = GetRequestInfo(context.Background(), &milvuspb.DeleteRequest{
+		database, col2part, rt, _, err = GetRequestInfo(context.Background(), mockCache, &milvuspb.DeleteRequest{
 			CollectionName: "foo",
 			DbName:         "db1",
 			Namespace:      &namespace,
@@ -333,7 +330,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.Equal(t, internalpb.RateType_DMLDelete, rt)
 		assert.Equal(t, []int64{20}, col2part[1])
 
-		database, col2part, rt, size, err := GetRequestInfo(context.Background(), &milvuspb.SearchRequest{
+		database, col2part, rt, size, err := GetRequestInfo(context.Background(), mockCache, &milvuspb.SearchRequest{
 			CollectionName: "foo",
 			DbName:         "db1",
 			Nq:             5,
@@ -345,7 +342,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.Equal(t, 5, size)
 		assert.Equal(t, []int64{20}, col2part[1])
 
-		database, col2part, rt, size, err = GetRequestInfo(context.Background(), &milvuspb.HybridSearchRequest{
+		database, col2part, rt, size, err = GetRequestInfo(context.Background(), mockCache, &milvuspb.HybridSearchRequest{
 			CollectionName: "foo",
 			DbName:         "db1",
 			Namespace:      &namespace,
@@ -401,7 +398,6 @@ func TestRateLimitInterceptor(t *testing.T) {
 			CreatedTimestamp: 1,
 		}, nil)
 		mockCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(&schemaInfo{}, nil)
-		globalMetaCache = mockCache
 
 		limiter := limiterMock{rate: 100}
 		handler := func(ctx context.Context, req interface{}) (interface{}, error) {
@@ -412,7 +408,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		serverInfo := &grpc.UnaryServerInfo{FullMethod: "MockFullMethod"}
 
 		limiter.limit = true
-		interceptorFun := RateLimitInterceptor(&limiter)
+		interceptorFun := RateLimitInterceptorWithMetaCache(mockCache, &limiter)
 		rsp, err := interceptorFun(context.Background(), &milvuspb.InsertRequest{
 			CollectionName: "foo",
 			PartitionName:  "p1",
@@ -422,7 +418,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		assert.NoError(t, err)
 
 		limiter.limit = false
-		interceptorFun = RateLimitInterceptor(&limiter)
+		interceptorFun = RateLimitInterceptorWithMetaCache(mockCache, &limiter)
 		rsp, err = interceptorFun(context.Background(), &milvuspb.InsertRequest{
 			CollectionName: "foo",
 			PartitionName:  "p1",
@@ -433,7 +429,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 
 		// test 0 rate, force deny
 		limiter.rate = 0
-		interceptorFun = RateLimitInterceptor(&limiter)
+		interceptorFun = RateLimitInterceptorWithMetaCache(mockCache, &limiter)
 		rsp, err = interceptorFun(context.Background(), &milvuspb.InsertRequest{}, serverInfo, handler)
 		assert.Equal(t, commonpb.ErrorCode_ForceDeny, rsp.(*milvuspb.MutationResult).GetStatus().GetErrorCode())
 		assert.NoError(t, err)
@@ -442,12 +438,6 @@ func TestRateLimitInterceptor(t *testing.T) {
 	t.Run("request info fail", func(t *testing.T) {
 		mockCache := NewMockCache(t)
 		mockCache.EXPECT().GetDatabaseInfo(mock.Anything, mock.Anything).Return(nil, errors.New("mock error: get database info"))
-		originCache := globalMetaCache
-		globalMetaCache = mockCache
-		defer func() {
-			globalMetaCache = originCache
-		}()
-
 		limiter := limiterMock{rate: 100}
 		handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 			return &milvuspb.MutationResult{
@@ -457,7 +447,7 @@ func TestRateLimitInterceptor(t *testing.T) {
 		serverInfo := &grpc.UnaryServerInfo{FullMethod: "MockFullMethod"}
 
 		limiter.limit = true
-		interceptorFun := RateLimitInterceptor(&limiter)
+		interceptorFun := RateLimitInterceptorWithMetaCache(mockCache, &limiter)
 		rsp, err := interceptorFun(context.Background(), &milvuspb.InsertRequest{}, serverInfo, handler)
 		assert.Equal(t, commonpb.ErrorCode_Success, rsp.(*milvuspb.MutationResult).GetStatus().GetErrorCode())
 		assert.NoError(t, err)
@@ -467,16 +457,11 @@ func TestRateLimitInterceptor(t *testing.T) {
 func TestGetInfo(t *testing.T) {
 	mockCache := NewMockCache(t)
 	ctx := context.Background()
-	originCache := globalMetaCache
-	globalMetaCache = mockCache
-	defer func() {
-		globalMetaCache = originCache
-	}()
 
 	t.Run("fail to get database", func(t *testing.T) {
 		mockCache.EXPECT().GetDatabaseInfo(mock.Anything, mock.Anything).Return(nil, errors.New("mock error: get database info")).Times(5)
 		{
-			_, _, err := getCollectionAndPartitionID(ctx, &milvuspb.InsertRequest{
+			_, _, err := getCollectionAndPartitionID(ctx, mockCache, &milvuspb.InsertRequest{
 				DbName:         "foo",
 				CollectionName: "coo",
 				PartitionName:  "p1",
@@ -484,7 +469,7 @@ func TestGetInfo(t *testing.T) {
 			assert.Error(t, err)
 		}
 		{
-			_, _, err := getCollectionAndPartitionIDs(ctx, &milvuspb.SearchRequest{
+			_, _, err := getCollectionAndPartitionIDs(ctx, mockCache, &milvuspb.SearchRequest{
 				DbName:         "foo",
 				CollectionName: "coo",
 				PartitionNames: []string{"p1"},
@@ -492,17 +477,17 @@ func TestGetInfo(t *testing.T) {
 			assert.Error(t, err)
 		}
 		{
-			_, _, _, _, err := GetRequestInfo(ctx, &milvuspb.FlushRequest{
+			_, _, _, _, err := GetRequestInfo(ctx, mockCache, &milvuspb.FlushRequest{
 				DbName: "foo",
 			})
 			assert.Error(t, err)
 		}
 		{
-			_, _, _, _, err := GetRequestInfo(ctx, &milvuspb.ManualCompactionRequest{})
+			_, _, _, _, err := GetRequestInfo(ctx, mockCache, &milvuspb.ManualCompactionRequest{})
 			assert.Error(t, err)
 		}
 		{
-			dbID, collectionIDInfos := getCollectionID(&milvuspb.CreateCollectionRequest{})
+			dbID, collectionIDInfos := getCollectionID(mockCache, &milvuspb.CreateCollectionRequest{})
 			assert.Equal(t, util.InvalidDBID, dbID)
 			assert.Equal(t, 0, len(collectionIDInfos))
 		}
@@ -515,7 +500,7 @@ func TestGetInfo(t *testing.T) {
 		}, nil).Times(3)
 		mockCache.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(int64(0), errors.New("mock error: get collection id")).Times(3)
 		{
-			_, _, err := getCollectionAndPartitionID(ctx, &milvuspb.InsertRequest{
+			_, _, err := getCollectionAndPartitionID(ctx, mockCache, &milvuspb.InsertRequest{
 				DbName:         "foo",
 				CollectionName: "coo",
 				PartitionName:  "p1",
@@ -523,7 +508,7 @@ func TestGetInfo(t *testing.T) {
 			assert.Error(t, err)
 		}
 		{
-			_, _, err := getCollectionAndPartitionIDs(ctx, &milvuspb.SearchRequest{
+			_, _, err := getCollectionAndPartitionIDs(ctx, mockCache, &milvuspb.SearchRequest{
 				DbName:         "foo",
 				CollectionName: "coo",
 				PartitionNames: []string{"p1"},
@@ -531,7 +516,7 @@ func TestGetInfo(t *testing.T) {
 			assert.Error(t, err)
 		}
 		{
-			_, _, _, _, err := GetRequestInfo(ctx, &milvuspb.FlushRequest{
+			_, _, _, _, err := GetRequestInfo(ctx, mockCache, &milvuspb.FlushRequest{
 				DbName:          "foo",
 				CollectionNames: []string{"coo"},
 			})
@@ -547,7 +532,7 @@ func TestGetInfo(t *testing.T) {
 		mockCache.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil).Once()
 		mockCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("mock error")).Once()
 
-		_, _, err := getCollectionAndPartitionID(ctx, &milvuspb.InsertRequest{
+		_, _, err := getCollectionAndPartitionID(ctx, mockCache, &milvuspb.InsertRequest{
 			DbName:         "foo",
 			CollectionName: "coo",
 		})
@@ -564,7 +549,7 @@ func TestGetInfo(t *testing.T) {
 			HasPartitionKeyField: true,
 		}, nil).Once()
 
-		db, col2par, err := getCollectionAndPartitionID(ctx, &milvuspb.InsertRequest{
+		db, col2par, err := getCollectionAndPartitionID(ctx, mockCache, &milvuspb.InsertRequest{
 			DbName:         "foo",
 			CollectionName: "coo",
 		})
@@ -582,7 +567,7 @@ func TestGetInfo(t *testing.T) {
 		mockCache.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil).Twice()
 		mockCache.EXPECT().GetPartitionInfo(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("mock error: get partition info")).Twice()
 		{
-			_, _, err := getCollectionAndPartitionID(ctx, &milvuspb.InsertRequest{
+			_, _, err := getCollectionAndPartitionID(ctx, mockCache, &milvuspb.InsertRequest{
 				DbName:         "foo",
 				CollectionName: "coo",
 				PartitionName:  "p1",
@@ -590,7 +575,7 @@ func TestGetInfo(t *testing.T) {
 			assert.Error(t, err)
 		}
 		{
-			_, _, err := getCollectionAndPartitionIDs(ctx, &milvuspb.SearchRequest{
+			_, _, err := getCollectionAndPartitionIDs(ctx, mockCache, &milvuspb.SearchRequest{
 				DbName:         "foo",
 				CollectionName: "coo",
 				PartitionNames: []string{"p1"},
@@ -611,7 +596,7 @@ func TestGetInfo(t *testing.T) {
 			PartitionID: 100,
 		}, nil).Times(3)
 		{
-			db, col2par, err := getCollectionAndPartitionID(ctx, &milvuspb.InsertRequest{
+			db, col2par, err := getCollectionAndPartitionID(ctx, mockCache, &milvuspb.InsertRequest{
 				DbName:         "foo",
 				CollectionName: "coo",
 				PartitionName:  "p1",
@@ -622,7 +607,7 @@ func TestGetInfo(t *testing.T) {
 			assert.Equal(t, int64(100), col2par[10][0])
 		}
 		{
-			db, col2par, err := getCollectionAndPartitionID(ctx, &milvuspb.InsertRequest{
+			db, col2par, err := getCollectionAndPartitionID(ctx, mockCache, &milvuspb.InsertRequest{
 				DbName:         "foo",
 				CollectionName: "coo",
 			})
@@ -632,7 +617,7 @@ func TestGetInfo(t *testing.T) {
 			assert.Equal(t, int64(100), col2par[10][0])
 		}
 		{
-			db, col2par, err := getCollectionAndPartitionIDs(ctx, &milvuspb.SearchRequest{
+			db, col2par, err := getCollectionAndPartitionIDs(ctx, mockCache, &milvuspb.SearchRequest{
 				DbName:         "foo",
 				CollectionName: "coo",
 				PartitionNames: []string{"p1"},
@@ -646,7 +631,7 @@ func TestGetInfo(t *testing.T) {
 
 	t.Run("get db request info", func(t *testing.T) {
 		{
-			dbID, collectionInfos, rateType, cost, err := GetRequestInfo(ctx, &milvuspb.CreateDatabaseRequest{
+			dbID, collectionInfos, rateType, cost, err := GetRequestInfo(ctx, mockCache, &milvuspb.CreateDatabaseRequest{
 				DbName: "foo",
 			})
 			assert.NoError(t, err)
@@ -656,7 +641,7 @@ func TestGetInfo(t *testing.T) {
 			assert.Equal(t, 1, cost)
 		}
 		{
-			dbID, collectionInfos, rateType, cost, err := GetRequestInfo(ctx, &milvuspb.DropDatabaseRequest{
+			dbID, collectionInfos, rateType, cost, err := GetRequestInfo(ctx, mockCache, &milvuspb.DropDatabaseRequest{
 				DbName: "foo",
 			})
 			assert.NoError(t, err)
@@ -666,7 +651,7 @@ func TestGetInfo(t *testing.T) {
 			assert.Equal(t, 1, cost)
 		}
 		{
-			dbID, collectionInfos, rateType, cost, err := GetRequestInfo(ctx, &milvuspb.AlterDatabaseRequest{
+			dbID, collectionInfos, rateType, cost, err := GetRequestInfo(ctx, mockCache, &milvuspb.AlterDatabaseRequest{
 				DbName: "foo",
 			})
 			assert.NoError(t, err)
@@ -683,7 +668,7 @@ func TestGetInfo(t *testing.T) {
 			&milvuspb.RemoveFileResourceRequest{},
 		}
 		for _, request := range requests {
-			dbID, collectionInfos, rateType, cost, err := GetRequestInfo(ctx, request)
+			dbID, collectionInfos, rateType, cost, err := GetRequestInfo(ctx, mockCache, request)
 			assert.NoError(t, err)
 			assert.Equal(t, util.InvalidDBID, dbID)
 			assert.Empty(t, collectionInfos)
@@ -691,7 +676,7 @@ func TestGetInfo(t *testing.T) {
 			assert.Equal(t, 1, cost)
 		}
 
-		dbID, collectionInfos, _, cost, err := GetRequestInfo(ctx, &milvuspb.ListFileResourcesRequest{})
+		dbID, collectionInfos, _, cost, err := GetRequestInfo(ctx, mockCache, &milvuspb.ListFileResourcesRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, util.InvalidDBID, dbID)
 		assert.Empty(t, collectionInfos)

--- a/internal/proxy/search_pipeline.go
+++ b/internal/proxy/search_pipeline.go
@@ -1468,6 +1468,9 @@ func (op *requeryOperator) requery(ctx context.Context, span trace.Span, ids *sc
 		preferredNodes[k] = v
 	}
 	qt := &queryTask{
+		baseTask: baseTask{
+			metaCache: op.node.(*Proxy).metaCache,
+		},
 		ctx:       op.traceCtx,
 		Condition: NewTaskCondition(op.traceCtx),
 		RetrieveRequest: &internalpb.RetrieveRequest{

--- a/internal/proxy/search_pipeline.go
+++ b/internal/proxy/search_pipeline.go
@@ -1469,7 +1469,7 @@ func (op *requeryOperator) requery(ctx context.Context, span trace.Span, ids *sc
 	}
 	qt := &queryTask{
 		baseTask: baseTask{
-			metaCache: op.node.(*Proxy).metaCache,
+			metaCache: op.node.(*Proxy).getMetaCache(),
 		},
 		ctx:       op.traceCtx,
 		Condition: NewTaskCondition(op.traceCtx),

--- a/internal/proxy/search_util.go
+++ b/internal/proxy/search_util.go
@@ -716,14 +716,14 @@ func getNq(req *milvuspb.SearchRequest) (int64, error) {
 	return req.GetNq(), nil
 }
 
-func getPartitionIDs(ctx context.Context, dbName string, collectionName string, partitionNames []string) (partitionIDs []UniqueID, err error) {
+func getPartitionIDs(ctx context.Context, metaCache Cache, dbName string, collectionName string, partitionNames []string) (partitionIDs []UniqueID, err error) {
 	for _, tag := range partitionNames {
 		if err := validatePartitionTag(tag, false); err != nil {
 			return nil, err
 		}
 	}
 
-	partitionsMap, err := globalMetaCache.GetPartitions(ctx, dbName, collectionName)
+	partitionsMap, err := metaCache.GetPartitions(ctx, dbName, collectionName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/proxy/service_provider.go
+++ b/internal/proxy/service_provider.go
@@ -278,7 +278,7 @@ func (node *CachedProxyServiceProvider) DescribeCollection(ctx context.Context,
 		// discarded the returned collectionInfo and forced a second describe on a
 		// rolling-upgrade old RootCoord response that omitted DbName (such entries
 		// are deliberately returned uncached because their database is unknown).
-		c, err = globalMetaCache.GetCollectionInfo(ctx, request.DbName, "", collectionID)
+		c, err = node.getMetaCache().GetCollectionInfo(ctx, request.DbName, "", collectionID)
 		if err != nil {
 			resp.Status = describeCollectionErrorStatus(err, request.DbName, collectionName)
 			return resp, nil
@@ -295,12 +295,12 @@ func (node *CachedProxyServiceProvider) DescribeCollection(ctx context.Context,
 	// Resolve the id and complete entry from the name only when the caller did
 	// not provide an id. The id-only path already has the complete entry above.
 	if !resolvedNameByID {
-		collectionID, err = globalMetaCache.GetCollectionID(ctx, request.DbName, collectionName)
+		collectionID, err = node.getMetaCache().GetCollectionID(ctx, request.DbName, collectionName)
 		if err != nil {
 			resp.Status = describeCollectionErrorStatus(err, request.DbName, collectionName)
 			return resp, nil
 		}
-		c, err = globalMetaCache.GetCollectionInfo(ctx, request.DbName, collectionName, collectionID)
+		c, err = node.getMetaCache().GetCollectionInfo(ctx, request.DbName, collectionName, collectionID)
 		if err != nil {
 			resp.Status = describeCollectionErrorStatus(err, request.DbName, collectionName)
 			return resp, nil

--- a/internal/proxy/service_provider_test.go
+++ b/internal/proxy/service_provider_test.go
@@ -42,7 +42,7 @@ func TestNewInterceptor(t *testing.T) {
 	mixCoord := mocks.NewMockMixCoordClient(t)
 	mixCoord.On("DescribeCollection", mock.Anything, mock.Anything).Return(nil, merr.ErrCollectionNotFound).Maybe()
 	var err error
-	globalMetaCache, err = NewMetaCache(mixCoord)
+	node.metaCache = mustNewMetaCacheForTest(mixCoord)
 	assert.NoError(t, err)
 	interceptor, err := NewInterceptor[*milvuspb.DescribeCollectionRequest, *milvuspb.DescribeCollectionResponse](node, "DescribeCollection")
 	assert.NoError(t, err)
@@ -56,9 +56,6 @@ func TestNewInterceptor(t *testing.T) {
 
 func TestCachedProxyServiceProvider_DescribeCollection_IgnoresLegacyDoPhysicalBackfill(t *testing.T) {
 	ctx := context.Background()
-
-	origCache := globalMetaCache
-	defer func() { globalMetaCache = origCache }()
 
 	dbName := "test_db"
 	collectionName := "test_collection"
@@ -81,9 +78,7 @@ func TestCachedProxyServiceProvider_DescribeCollection_IgnoresLegacyDoPhysicalBa
 		Schema:    mustNewSchemaInfo(schema),
 		ShardsNum: common.DefaultShardsNum,
 	}, nil)
-	globalMetaCache = mockCache
-
-	provider := &CachedProxyServiceProvider{Proxy: &Proxy{}}
+	provider := &CachedProxyServiceProvider{Proxy: &Proxy{metaCache: mockCache}}
 	resp, err := provider.DescribeCollection(ctx, &milvuspb.DescribeCollectionRequest{
 		DbName:         dbName,
 		CollectionName: collectionName,
@@ -95,9 +90,6 @@ func TestCachedProxyServiceProvider_DescribeCollection_IgnoresLegacyDoPhysicalBa
 
 func TestCachedProxyServiceProvider_DescribeCollection_ByIDFillsNameAndUsesRequestID(t *testing.T) {
 	ctx := context.Background()
-
-	origCache := globalMetaCache
-	defer func() { globalMetaCache = origCache }()
 
 	dbName := "db1"
 	dbID := int64(3)
@@ -126,9 +118,7 @@ func TestCachedProxyServiceProvider_DescribeCollection_ByIDFillsNameAndUsesReque
 		Schema:    mustNewSchemaInfo(schema),
 		ShardsNum: common.DefaultShardsNum,
 	}, nil)
-	globalMetaCache = mockCache
-
-	provider := &CachedProxyServiceProvider{Proxy: &Proxy{}}
+	provider := &CachedProxyServiceProvider{Proxy: &Proxy{metaCache: mockCache}}
 	request := &milvuspb.DescribeCollectionRequest{
 		CollectionID: collectionID,
 	}
@@ -147,9 +137,6 @@ func TestCachedProxyServiceProvider_DescribeCollection_ByIDFillsNameAndUsesReque
 
 func TestCachedProxyServiceProvider_DescribeCollection_FilterNamespaceField(t *testing.T) {
 	ctx := context.Background()
-
-	origCache := globalMetaCache
-	defer func() { globalMetaCache = origCache }()
 
 	dbName := "test_db"
 	collectionName := "test_collection"
@@ -187,9 +174,7 @@ func TestCachedProxyServiceProvider_DescribeCollection_FilterNamespaceField(t *t
 		Schema:    mustNewSchemaInfo(schema),
 		ShardsNum: common.DefaultShardsNum,
 	}, nil)
-	globalMetaCache = mockCache
-
-	provider := &CachedProxyServiceProvider{Proxy: &Proxy{}}
+	provider := &CachedProxyServiceProvider{Proxy: &Proxy{metaCache: mockCache}}
 	resp, err := provider.DescribeCollection(ctx, &milvuspb.DescribeCollectionRequest{
 		DbName:         dbName,
 		CollectionName: collectionName,
@@ -213,9 +198,6 @@ func TestCachedProxyServiceProvider_DescribeCollection_FilterNamespaceField(t *t
 func TestCachedProxyServiceProvider_DescribeCollection_ByIDReturnsActualDbName(t *testing.T) {
 	ctx := context.Background()
 
-	origCache := globalMetaCache
-	defer func() { globalMetaCache = origCache }()
-
 	collectionID := int64(2000)
 	schema := &schemapb.CollectionSchema{
 		Name: "coll1",
@@ -236,9 +218,7 @@ func TestCachedProxyServiceProvider_DescribeCollection_ByIDReturnsActualDbName(t
 		Schema:    mustNewSchemaInfo(schema),
 		ShardsNum: common.DefaultShardsNum,
 	}, nil)
-	globalMetaCache = mockCache
-
-	provider := &CachedProxyServiceProvider{Proxy: &Proxy{}}
+	provider := &CachedProxyServiceProvider{Proxy: &Proxy{metaCache: mockCache}}
 	// the monitoring http path passes only the collection id, both db name and
 	// collection name are empty
 	resp, err := provider.DescribeCollection(ctx, &milvuspb.DescribeCollectionRequest{CollectionID: collectionID})
@@ -254,16 +234,11 @@ func TestCachedProxyServiceProvider_DescribeCollection_ByIDReturnsActualDbName(t
 func TestCachedProxyServiceProvider_DescribeCollection_ByIDNotFoundUsesCollectionNotExistsCode(t *testing.T) {
 	ctx := context.Background()
 
-	origCache := globalMetaCache
-	defer func() { globalMetaCache = origCache }()
-
 	collectionID := int64(4242)
 	mockCache := &MockCache{}
 	mockCache.EXPECT().GetCollectionInfo(mock.Anything, "", "", collectionID).
 		Return(nil, merr.WrapErrCollectionNotFound(collectionID))
-	globalMetaCache = mockCache
-
-	provider := &CachedProxyServiceProvider{Proxy: &Proxy{}}
+	provider := &CachedProxyServiceProvider{Proxy: &Proxy{metaCache: mockCache}}
 	resp, err := provider.DescribeCollection(ctx, &milvuspb.DescribeCollectionRequest{CollectionID: collectionID})
 	assert.NoError(t, err)
 	assert.Equal(t, commonpb.ErrorCode_CollectionNotExists, resp.GetStatus().GetErrorCode())
@@ -280,13 +255,8 @@ func TestCachedProxyServiceProvider_DescribeCollection_ByIDNotFoundUsesCollectio
 func TestCachedProxyServiceProvider_DescribeCollection_EmptyRequestFailsValidation(t *testing.T) {
 	ctx := context.Background()
 
-	origCache := globalMetaCache
-	defer func() { globalMetaCache = origCache }()
-
 	// no expectations: any cache call is an unexpected-call failure
-	globalMetaCache = &MockCache{}
-
-	provider := &CachedProxyServiceProvider{Proxy: &Proxy{}}
+	provider := &CachedProxyServiceProvider{Proxy: &Proxy{metaCache: &MockCache{}}}
 	resp, err := provider.DescribeCollection(ctx, &milvuspb.DescribeCollectionRequest{})
 	assert.NoError(t, err)
 	assert.NotEqual(t, commonpb.ErrorCode_Success, resp.GetStatus().GetErrorCode(),
@@ -299,9 +269,6 @@ func TestCachedProxyServiceProvider_DescribeCollection_EmptyRequestFailsValidati
 // which the access log and metric labels read after the call.
 func TestCachedProxyServiceProvider_DescribeCollection_NameOnlyDoesNotMutateRequest(t *testing.T) {
 	ctx := context.Background()
-
-	origCache := globalMetaCache
-	defer func() { globalMetaCache = origCache }()
 
 	dbName := "db"
 	collectionName := "coll1"
@@ -323,9 +290,7 @@ func TestCachedProxyServiceProvider_DescribeCollection_NameOnlyDoesNotMutateRequ
 		Schema:    mustNewSchemaInfo(schema),
 		ShardsNum: common.DefaultShardsNum,
 	}, nil)
-	globalMetaCache = mockCache
-
-	provider := &CachedProxyServiceProvider{Proxy: &Proxy{}}
+	provider := &CachedProxyServiceProvider{Proxy: &Proxy{metaCache: mockCache}}
 	request := &milvuspb.DescribeCollectionRequest{DbName: dbName, CollectionName: collectionName}
 	resp, err := provider.DescribeCollection(ctx, request)
 	assert.NoError(t, err)
@@ -337,9 +302,6 @@ func TestCachedProxyServiceProvider_DescribeCollection_NameOnlyDoesNotMutateRequ
 
 func TestCachedProxyServiceProvider_DescribeCollection_IDOnlyOldRootCoordUsesOneDescribeAndKeepsUnknownDB(t *testing.T) {
 	ctx := context.Background()
-	origCache := globalMetaCache
-	defer func() { globalMetaCache = origCache }()
-
 	const collectionID = int64(101)
 	var describeCount atomic.Int32
 	mixCoord := mocks.NewMockMixCoordClient(t)
@@ -363,9 +325,7 @@ func TestCachedProxyServiceProvider_DescribeCollection_IDOnlyOldRootCoordUsesOne
 	cache, err := NewMetaCache(mixCoord)
 	assert.NoError(t, err)
 	defer cache.Close()
-	globalMetaCache = cache
-
-	provider := &CachedProxyServiceProvider{Proxy: &Proxy{}}
+	provider := &CachedProxyServiceProvider{Proxy: &Proxy{metaCache: cache}}
 	request := &milvuspb.DescribeCollectionRequest{CollectionID: collectionID}
 	interceptor := DatabaseInterceptor()
 	result, err := interceptor(ctx, request, &grpc.UnaryServerInfo{}, func(ctx context.Context, req interface{}) (interface{}, error) {
@@ -533,11 +493,7 @@ func TestDescribeCollectionCachedAndRemoteProjectionEquivalent(t *testing.T) {
 		Aliases:             raw.GetAliases(),
 		Properties:          raw.GetProperties(),
 	}, nil)
-	oldCache := globalMetaCache
-	globalMetaCache = cache
-	defer func() { globalMetaCache = oldCache }()
-
-	cachedResp, err := (&CachedProxyServiceProvider{Proxy: &Proxy{}}).DescribeCollection(ctx,
+	cachedResp, err := (&CachedProxyServiceProvider{Proxy: &Proxy{metaCache: cache}}).DescribeCollection(ctx,
 		&milvuspb.DescribeCollectionRequest{DbName: database, CollectionName: collectionName})
 	assert.NoError(t, err)
 	assert.NoError(t, finalizeDescribeCollectionResponse(cachedResp))
@@ -570,10 +526,7 @@ func TestDescribeCollectionCachedAndRemoteNotFoundStatusEquivalent(t *testing.T)
 
 	cache := NewMockCache(t)
 	cache.EXPECT().GetCollectionID(mock.Anything, database, collectionName).Return(int64(0), notFound)
-	oldCache := globalMetaCache
-	globalMetaCache = cache
-	defer func() { globalMetaCache = oldCache }()
-	cachedResp, err := (&CachedProxyServiceProvider{Proxy: &Proxy{}}).DescribeCollection(ctx,
+	cachedResp, err := (&CachedProxyServiceProvider{Proxy: &Proxy{metaCache: cache}}).DescribeCollection(ctx,
 		&milvuspb.DescribeCollectionRequest{DbName: database, CollectionName: collectionName})
 	assert.NoError(t, err)
 
@@ -608,10 +561,7 @@ func TestDescribeCollectionCachedAndRemoteDatabaseNotFoundStatusEquivalent(t *te
 
 	cache := NewMockCache(t)
 	cache.EXPECT().GetCollectionID(mock.Anything, database, collectionName).Return(int64(0), notFound)
-	oldCache := globalMetaCache
-	globalMetaCache = cache
-	defer func() { globalMetaCache = oldCache }()
-	cachedResp, err := (&CachedProxyServiceProvider{Proxy: &Proxy{}}).DescribeCollection(ctx,
+	cachedResp, err := (&CachedProxyServiceProvider{Proxy: &Proxy{metaCache: cache}}).DescribeCollection(ctx,
 		&milvuspb.DescribeCollectionRequest{DbName: database, CollectionName: collectionName})
 	assert.NoError(t, err)
 

--- a/internal/proxy/service_provider_test.go
+++ b/internal/proxy/service_provider_test.go
@@ -42,7 +42,7 @@ func TestNewInterceptor(t *testing.T) {
 	mixCoord := mocks.NewMockMixCoordClient(t)
 	mixCoord.On("DescribeCollection", mock.Anything, mock.Anything).Return(nil, merr.ErrCollectionNotFound).Maybe()
 	var err error
-	node.metaCache = mustNewMetaCacheForTest(mixCoord)
+	node.setMetaCache(mustNewMetaCacheForTest(mixCoord))
 	assert.NoError(t, err)
 	interceptor, err := NewInterceptor[*milvuspb.DescribeCollectionRequest, *milvuspb.DescribeCollectionResponse](node, "DescribeCollection")
 	assert.NoError(t, err)

--- a/internal/proxy/snapshot_impl.go
+++ b/internal/proxy/snapshot_impl.go
@@ -296,7 +296,7 @@ func (node *Proxy) ExportSnapshot(ctx context.Context, req *milvuspb.ExportSnaps
 		return &milvuspb.ExportSnapshotResponse{Status: merr.Status(err)}, nil
 	}
 
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, req.GetDbName(), req.GetCollectionName())
+	collectionID, err := node.getMetaCache().GetCollectionID(ctx, req.GetDbName(), req.GetCollectionName())
 	if err != nil {
 		failStatus, failCause := failMetricLabel(err)
 		metrics.ProxyFunctionCall.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method, failStatus, failCause, req.GetDbName(), req.GetCollectionName()).Inc()

--- a/internal/proxy/snapshot_impl.go
+++ b/internal/proxy/snapshot_impl.go
@@ -49,7 +49,7 @@ func (node *Proxy) CreateSnapshot(ctx context.Context, req *milvuspb.CreateSnaps
 
 	metrics.ProxyFunctionCall.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method, metrics.TotalLabel, metrics.CauseNA, req.GetDbName(), req.GetCollectionName()).Inc()
 	t := &createSnapshotTask{
-		baseTask:  baseTask{metaCache: node.metaCache},
+		baseTask:  baseTask{metaCache: node.getMetaCache()},
 		req:       req,
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
@@ -91,7 +91,7 @@ func (node *Proxy) DropSnapshot(ctx context.Context, req *milvuspb.DropSnapshotR
 
 	metrics.ProxyFunctionCall.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method, metrics.TotalLabel, metrics.CauseNA, req.GetDbName(), req.GetCollectionName()).Inc()
 	t := &dropSnapshotTask{
-		baseTask:  baseTask{metaCache: node.metaCache},
+		baseTask:  baseTask{metaCache: node.getMetaCache()},
 		req:       req,
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
@@ -133,7 +133,7 @@ func (node *Proxy) DescribeSnapshot(ctx context.Context, req *milvuspb.DescribeS
 
 	metrics.ProxyFunctionCall.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method, metrics.TotalLabel, metrics.CauseNA, req.GetDbName(), req.GetCollectionName()).Inc()
 	t := &describeSnapshotTask{
-		baseTask:  baseTask{metaCache: node.metaCache},
+		baseTask:  baseTask{metaCache: node.getMetaCache()},
 		req:       req,
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
@@ -178,7 +178,7 @@ func (node *Proxy) ListSnapshots(ctx context.Context, req *milvuspb.ListSnapshot
 
 	metrics.ProxyFunctionCall.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method, metrics.TotalLabel, metrics.CauseNA, req.GetDbName(), req.GetCollectionName()).Inc()
 	t := &listSnapshotsTask{
-		baseTask:  baseTask{metaCache: node.metaCache},
+		baseTask:  baseTask{metaCache: node.getMetaCache()},
 		req:       req,
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
@@ -454,7 +454,7 @@ func (node *Proxy) RestoreSnapshot(ctx context.Context, req *milvuspb.RestoreSna
 
 	metrics.ProxyFunctionCall.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method, metrics.TotalLabel, metrics.CauseNA, req.GetDbName(), req.GetCollectionName()).Inc()
 	t := &restoreSnapshotTask{
-		baseTask:  baseTask{metaCache: node.metaCache},
+		baseTask:  baseTask{metaCache: node.getMetaCache()},
 		req:       req,
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
@@ -496,7 +496,7 @@ func (node *Proxy) GetRestoreSnapshotState(ctx context.Context, req *milvuspb.Ge
 
 	metrics.ProxyFunctionCall.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method, metrics.TotalLabel, metrics.CauseNA, "", "").Inc()
 	t := &getRestoreSnapshotStateTask{
-		baseTask:  baseTask{metaCache: node.metaCache},
+		baseTask:  baseTask{metaCache: node.getMetaCache()},
 		req:       req,
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
@@ -542,7 +542,7 @@ func (node *Proxy) ListRestoreSnapshotJobs(ctx context.Context, req *milvuspb.Li
 
 	metrics.ProxyFunctionCall.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method, metrics.TotalLabel, metrics.CauseNA, req.GetDbName(), req.GetCollectionName()).Inc()
 	t := &listRestoreSnapshotJobsTask{
-		baseTask:  baseTask{metaCache: node.metaCache},
+		baseTask:  baseTask{metaCache: node.getMetaCache()},
 		req:       req,
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
@@ -590,7 +590,7 @@ func (node *Proxy) PinSnapshotData(ctx context.Context, req *milvuspb.PinSnapsho
 
 	metrics.ProxyFunctionCall.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method, metrics.TotalLabel, metrics.CauseNA, req.GetDbName(), req.GetCollectionName()).Inc()
 	t := &pinSnapshotDataTask{
-		baseTask:  baseTask{metaCache: node.metaCache},
+		baseTask:  baseTask{metaCache: node.getMetaCache()},
 		req:       req,
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),

--- a/internal/proxy/snapshot_impl.go
+++ b/internal/proxy/snapshot_impl.go
@@ -49,6 +49,7 @@ func (node *Proxy) CreateSnapshot(ctx context.Context, req *milvuspb.CreateSnaps
 
 	metrics.ProxyFunctionCall.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method, metrics.TotalLabel, metrics.CauseNA, req.GetDbName(), req.GetCollectionName()).Inc()
 	t := &createSnapshotTask{
+		baseTask:  baseTask{metaCache: node.metaCache},
 		req:       req,
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
@@ -90,6 +91,7 @@ func (node *Proxy) DropSnapshot(ctx context.Context, req *milvuspb.DropSnapshotR
 
 	metrics.ProxyFunctionCall.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method, metrics.TotalLabel, metrics.CauseNA, req.GetDbName(), req.GetCollectionName()).Inc()
 	t := &dropSnapshotTask{
+		baseTask:  baseTask{metaCache: node.metaCache},
 		req:       req,
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
@@ -131,6 +133,7 @@ func (node *Proxy) DescribeSnapshot(ctx context.Context, req *milvuspb.DescribeS
 
 	metrics.ProxyFunctionCall.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method, metrics.TotalLabel, metrics.CauseNA, req.GetDbName(), req.GetCollectionName()).Inc()
 	t := &describeSnapshotTask{
+		baseTask:  baseTask{metaCache: node.metaCache},
 		req:       req,
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
@@ -175,6 +178,7 @@ func (node *Proxy) ListSnapshots(ctx context.Context, req *milvuspb.ListSnapshot
 
 	metrics.ProxyFunctionCall.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method, metrics.TotalLabel, metrics.CauseNA, req.GetDbName(), req.GetCollectionName()).Inc()
 	t := &listSnapshotsTask{
+		baseTask:  baseTask{metaCache: node.metaCache},
 		req:       req,
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
@@ -450,6 +454,7 @@ func (node *Proxy) RestoreSnapshot(ctx context.Context, req *milvuspb.RestoreSna
 
 	metrics.ProxyFunctionCall.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method, metrics.TotalLabel, metrics.CauseNA, req.GetDbName(), req.GetCollectionName()).Inc()
 	t := &restoreSnapshotTask{
+		baseTask:  baseTask{metaCache: node.metaCache},
 		req:       req,
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
@@ -491,6 +496,7 @@ func (node *Proxy) GetRestoreSnapshotState(ctx context.Context, req *milvuspb.Ge
 
 	metrics.ProxyFunctionCall.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method, metrics.TotalLabel, metrics.CauseNA, "", "").Inc()
 	t := &getRestoreSnapshotStateTask{
+		baseTask:  baseTask{metaCache: node.metaCache},
 		req:       req,
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
@@ -536,6 +542,7 @@ func (node *Proxy) ListRestoreSnapshotJobs(ctx context.Context, req *milvuspb.Li
 
 	metrics.ProxyFunctionCall.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method, metrics.TotalLabel, metrics.CauseNA, req.GetDbName(), req.GetCollectionName()).Inc()
 	t := &listRestoreSnapshotJobsTask{
+		baseTask:  baseTask{metaCache: node.metaCache},
 		req:       req,
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),
@@ -583,6 +590,7 @@ func (node *Proxy) PinSnapshotData(ctx context.Context, req *milvuspb.PinSnapsho
 
 	metrics.ProxyFunctionCall.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method, metrics.TotalLabel, metrics.CauseNA, req.GetDbName(), req.GetCollectionName()).Inc()
 	t := &pinSnapshotDataTask{
+		baseTask:  baseTask{metaCache: node.metaCache},
 		req:       req,
 		ctx:       ctx,
 		Condition: NewTaskCondition(ctx),

--- a/internal/proxy/snapshot_impl_test.go
+++ b/internal/proxy/snapshot_impl_test.go
@@ -469,8 +469,10 @@ func TestExportSnapshotTask_Execute_ForwardsForeignStorageFields(t *testing.T) {
 		externalSpec = `{"extfs":{"cloud_provider":"aws","region":"us-west-2","use_iam":"true"}}`
 	)
 
+	metaCache := &MetaCache{}
 	proxy := &Proxy{
-		mixCoord: NewMixCoordMock(),
+		mixCoord:  NewMixCoordMock(),
+		metaCache: metaCache,
 	}
 	req := &milvuspb.ExportSnapshotRequest{
 		Name:           "test_snapshot",
@@ -479,10 +481,6 @@ func TestExportSnapshotTask_Execute_ForwardsForeignStorageFields(t *testing.T) {
 		TargetS3Path:   "s3://foreign-bucket/export-root",
 		ExternalSpec:   externalSpec,
 	}
-
-	oldMetaCache := globalMetaCache
-	globalMetaCache = &MetaCache{}
-	defer func() { globalMetaCache = oldMetaCache }()
 
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 	defer mockGetCollectionID.UnPatch()

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -161,6 +161,7 @@ type task interface {
 	WaitToFinish() error
 	Notify(err error)
 	CanSkipAllocTimestamp() bool
+	getMetaCache() Cache
 	SetOnEnqueueTime()
 	GetDurationInQueue() time.Duration
 	IsSubTask() bool
@@ -171,6 +172,11 @@ type task interface {
 type baseTask struct {
 	onEnqueueTime time.Time
 	executingTime time.Time
+	metaCache     Cache
+}
+
+func (bt *baseTask) getMetaCache() Cache {
+	return bt.metaCache
 }
 
 func (bt *baseTask) CanSkipAllocTimestamp() bool {
@@ -1499,7 +1505,7 @@ func (t *dropCollectionTask) PreExecute(ctx context.Context) error {
 	// No need to check collection name
 	// Validation shall be preformed in `CreateCollection`
 	// also permit drop collection one with bad collection name
-	_, err := globalMetaCache.GetCollectionID(ctx, t.GetDbName(), t.GetCollectionName())
+	_, err := t.getMetaCache().GetCollectionID(ctx, t.GetDbName(), t.GetCollectionName())
 	if err != nil {
 		if errors.Is(err, merr.ErrCollectionNotFound) || errors.Is(err, merr.ErrDatabaseNotFound) {
 			// make dropping collection idempotent.
@@ -1585,7 +1591,7 @@ func (t *truncateCollectionTask) PreExecute(ctx context.Context) error {
 	// putting the collection in an inconsistent state from which the next
 	// load/search would fail. Reject up front; users who want to reset the
 	// view should use RefreshExternalCollection or DropCollection.
-	collSchema, err := globalMetaCache.GetCollectionSchema(ctx, t.GetDbName(), t.GetCollectionName())
+	collSchema, err := t.getMetaCache().GetCollectionSchema(ctx, t.GetDbName(), t.GetCollectionName())
 	if err != nil {
 		return err
 	}
@@ -1667,7 +1673,7 @@ func (t *hasCollectionTask) Execute(ctx context.Context) error {
 	t.result = &milvuspb.BoolResponse{
 		Status: merr.Success(),
 	}
-	_, err := globalMetaCache.GetCollectionID(ctx, t.GetDbName(), t.GetCollectionName())
+	_, err := t.getMetaCache().GetCollectionID(ctx, t.GetDbName(), t.GetCollectionName())
 	// error other than
 	if err != nil && !errors.Is(err, merr.ErrCollectionNotFound) {
 		t.result.Status = merr.Status(err)
@@ -1870,7 +1876,7 @@ func (t *showCollectionsTask) Execute(ctx context.Context) error {
 		}
 		collectionIDs := make([]UniqueID, 0)
 		for _, collectionName := range t.CollectionNames {
-			collectionID, err := globalMetaCache.GetCollectionID(ctx, t.GetDbName(), collectionName)
+			collectionID, err := t.getMetaCache().GetCollectionID(ctx, t.GetDbName(), collectionName)
 			if err != nil {
 				mlog.Debug(ctx, "Failed to get collection id.", mlog.String("collectionName", collectionName),
 					mlog.Int64("requestID", t.Base.MsgID), mlog.String("requestType", "showCollections"))
@@ -1927,7 +1933,7 @@ func (t *showCollectionsTask) Execute(ctx context.Context) error {
 					mlog.Int64("requestID", t.Base.MsgID), mlog.String("requestType", "showCollections"))
 				continue
 			}
-			collectionInfo, err := globalMetaCache.GetCollectionInfo(ctx, t.GetDbName(), collectionName, id)
+			collectionInfo, err := t.getMetaCache().GetCollectionInfo(ctx, t.GetDbName(), collectionName, id)
 			if err != nil {
 				mlog.Debug(ctx, "Failed to get collection info.", mlog.String("collectionName", collectionName),
 					mlog.Int64("requestID", t.Base.MsgID), mlog.String("requestType", "showCollections"))
@@ -2049,8 +2055,8 @@ func hasPropInDeletekeys(keys []string) string {
 
 // checkVectorIndexExist checks if the collection has any vector index.
 // Returns the vector field name that has an index, or empty string if none.
-func checkVectorIndexExist(ctx context.Context, dbName, collectionName string, collectionID int64, mixCoord types.MixCoordClient) (string, error) {
-	collSchema, err := globalMetaCache.GetCollectionSchema(ctx, dbName, collectionName)
+func checkVectorIndexExist(ctx context.Context, metaCache Cache, dbName, collectionName string, collectionID int64, mixCoord types.MixCoordClient) (string, error) {
+	collSchema, err := metaCache.GetCollectionSchema(ctx, dbName, collectionName)
 	if err != nil {
 		return "", err
 	}
@@ -2187,11 +2193,11 @@ func (t *alterCollectionTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 
-	collSchema, err := globalMetaCache.GetCollectionSchema(ctx, t.GetDbName(), t.CollectionName)
+	collSchema, err := t.getMetaCache().GetCollectionSchema(ctx, t.GetDbName(), t.CollectionName)
 	if err != nil {
 		return err
 	}
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, t.GetDbName(), t.CollectionName)
+	collectionID, err := t.getMetaCache().GetCollectionID(ctx, t.GetDbName(), t.CollectionName)
 	if err != nil {
 		return err
 	}
@@ -2296,11 +2302,11 @@ func (t *alterCollectionTask) PreExecute(ctx context.Context) error {
 		}
 	}
 
-	isPartitionKeyMode, err := isPartitionKeyMode(ctx, t.GetDbName(), t.CollectionName)
+	isPartitionKeyMode, err := isPartitionKeyMode(ctx, t.getMetaCache(), t.GetDbName(), t.CollectionName)
 	if err != nil {
 		return err
 	}
-	collBasicInfo, err := globalMetaCache.GetCollectionInfo(t.ctx, t.GetDbName(), t.CollectionName, t.CollectionID)
+	collBasicInfo, err := t.getMetaCache().GetCollectionInfo(t.ctx, t.GetDbName(), t.CollectionName, t.CollectionID)
 	if err != nil {
 		return err
 	}
@@ -2334,7 +2340,7 @@ func (t *alterCollectionTask) PreExecute(ctx context.Context) error {
 	// If partition key isolation or query_mode changed, check for existing vector index.
 	// Changing these properties requires dropping the vector index first.
 	if isoChanged || queryModeChanged {
-		if vecField, err := checkVectorIndexExist(ctx, t.GetDbName(), t.CollectionName, t.CollectionID, t.mixCoord); err != nil {
+		if vecField, err := checkVectorIndexExist(ctx, t.getMetaCache(), t.GetDbName(), t.CollectionName, t.CollectionID, t.mixCoord); err != nil {
 			return err
 		} else if vecField != "" {
 			if isoChanged {
@@ -2523,13 +2529,13 @@ func validateAlterAnalyzerFieldParam(collSchema *schemapb.CollectionSchema, fiel
 }
 
 func (t *alterCollectionFieldTask) PreExecute(ctx context.Context) error {
-	collSchema, err := globalMetaCache.GetCollectionSchema(ctx, t.GetDbName(), t.CollectionName)
+	collSchema, err := t.getMetaCache().GetCollectionSchema(ctx, t.GetDbName(), t.CollectionName)
 	if err != nil {
 		return err
 	}
 
 	isCollectionLoadedFn := func() (bool, error) {
-		collectionID, err := globalMetaCache.GetCollectionID(ctx, t.GetDbName(), t.CollectionName)
+		collectionID, err := t.getMetaCache().GetCollectionID(ctx, t.GetDbName(), t.CollectionName)
 		if err != nil {
 			return false, err
 		}
@@ -2725,7 +2731,7 @@ func (t *createPartitionTask) PreExecute(ctx context.Context) error {
 	}
 
 	// Check partition key mode
-	collSchema, err := globalMetaCache.GetCollectionSchema(ctx, t.GetDbName(), collName)
+	collSchema, err := t.getMetaCache().GetCollectionSchema(ctx, t.GetDbName(), collName)
 	if err != nil {
 		return err
 	}
@@ -2749,7 +2755,7 @@ func (t *createPartitionTask) Execute(ctx context.Context) (err error) {
 	if err := merr.CheckRPCCall(t.result, err); err != nil {
 		return err
 	}
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, t.GetDbName(), t.GetCollectionName())
+	collectionID, err := t.getMetaCache().GetCollectionID(ctx, t.GetDbName(), t.GetCollectionName())
 	if err != nil {
 		t.result = merr.Status(err)
 		return err
@@ -2824,7 +2830,7 @@ func (t *dropPartitionTask) PreExecute(ctx context.Context) error {
 	}
 
 	// Check partition key mode
-	collSchema, err := globalMetaCache.GetCollectionSchema(ctx, t.GetDbName(), collName)
+	collSchema, err := t.getMetaCache().GetCollectionSchema(ctx, t.GetDbName(), collName)
 	if err != nil {
 		return err
 	}
@@ -2836,11 +2842,11 @@ func (t *dropPartitionTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 
-	collID, err := globalMetaCache.GetCollectionID(ctx, t.GetDbName(), t.GetCollectionName())
+	collID, err := t.getMetaCache().GetCollectionID(ctx, t.GetDbName(), t.GetCollectionName())
 	if err != nil {
 		return err
 	}
-	partID, err := globalMetaCache.GetPartitionID(ctx, t.GetDbName(), t.GetCollectionName(), t.GetPartitionName())
+	partID, err := t.getMetaCache().GetPartitionID(ctx, t.GetDbName(), t.GetCollectionName(), t.GetPartitionName())
 	if err != nil {
 		if errors.Is(merr.ErrPartitionNotFound, err) || errors.Is(merr.ErrCollectionNotFound, err) || errors.Is(merr.ErrDatabaseNotFound, err) {
 			return nil
@@ -3020,7 +3026,7 @@ func (t *showPartitionsTask) Execute(ctx context.Context) error {
 
 	if t.GetType() == milvuspb.ShowType_InMemory {
 		collectionName := t.CollectionName
-		collectionID, err := globalMetaCache.GetCollectionID(ctx, t.GetDbName(), collectionName)
+		collectionID, err := t.getMetaCache().GetCollectionID(ctx, t.GetDbName(), collectionName)
 		if err != nil {
 			mlog.Debug(ctx, "Failed to get collection id.", mlog.String("collectionName", collectionName),
 				mlog.Int64("requestID", t.Base.MsgID), mlog.String("requestType", "showPartitions"))
@@ -3033,7 +3039,7 @@ func (t *showPartitionsTask) Execute(ctx context.Context) error {
 		}
 		partitionIDs := make([]UniqueID, 0)
 		for _, partitionName := range t.PartitionNames {
-			partitionID, err := globalMetaCache.GetPartitionID(ctx, t.GetDbName(), collectionName, partitionName)
+			partitionID, err := t.getMetaCache().GetPartitionID(ctx, t.GetDbName(), collectionName, partitionName)
 			if err != nil {
 				mlog.Debug(ctx, "Failed to get partition id.", mlog.String("partitionName", partitionName),
 					mlog.Int64("requestID", t.Base.MsgID), mlog.String("requestType", "showPartitions"))
@@ -3070,7 +3076,7 @@ func (t *showPartitionsTask) Execute(ctx context.Context) error {
 					mlog.Int64("requestID", t.Base.MsgID), mlog.String("requestType", "showPartitions"))
 				return merr.WrapErrParameterInvalidMsg("failed to show partitions")
 			}
-			partitionInfo, err := globalMetaCache.GetPartitionInfo(ctx, t.GetDbName(), collectionName, partitionName)
+			partitionInfo, err := t.getMetaCache().GetPartitionInfo(ctx, t.GetDbName(), collectionName, partitionName)
 			if err != nil {
 				mlog.Debug(ctx, "Failed to get partition id.", mlog.String("partitionName", partitionName),
 					mlog.Int64("requestID", t.Base.MsgID), mlog.String("requestType", "showPartitions"))
@@ -3170,7 +3176,7 @@ func (t *loadCollectionTask) GetLoadPriority() commonpb.LoadPriority {
 }
 
 func (t *loadCollectionTask) Execute(ctx context.Context) (err error) {
-	collID, err := globalMetaCache.GetCollectionID(ctx, t.GetDbName(), t.CollectionName)
+	collID, err := t.getMetaCache().GetCollectionID(ctx, t.GetDbName(), t.CollectionName)
 
 	log := mlog.With(
 		mlog.String("role", typeutil.ProxyRole),
@@ -3182,7 +3188,7 @@ func (t *loadCollectionTask) Execute(ctx context.Context) (err error) {
 	}
 
 	t.collectionID = collID
-	collSchema, err := globalMetaCache.GetCollectionSchema(ctx, t.GetDbName(), t.CollectionName)
+	collSchema, err := t.getMetaCache().GetCollectionSchema(ctx, t.GetDbName(), t.CollectionName)
 	if err != nil {
 		return err
 	}
@@ -3258,7 +3264,7 @@ func (t *loadCollectionTask) Execute(ctx context.Context) (err error) {
 }
 
 func (t *loadCollectionTask) PostExecute(ctx context.Context) error {
-	collID, err := globalMetaCache.GetCollectionID(ctx, t.GetDbName(), t.CollectionName)
+	collID, err := t.getMetaCache().GetCollectionID(ctx, t.GetDbName(), t.CollectionName)
 	mlog.Debug(ctx, "loadCollectionTask PostExecute",
 		mlog.String("role", typeutil.ProxyRole),
 		mlog.Int64("collectionID", collID))
@@ -3331,7 +3337,7 @@ func (t *releaseCollectionTask) PreExecute(ctx context.Context) error {
 }
 
 func (t *releaseCollectionTask) Execute(ctx context.Context) (err error) {
-	collID, err := globalMetaCache.GetCollectionID(ctx, t.GetDbName(), t.CollectionName)
+	collID, err := t.getMetaCache().GetCollectionID(ctx, t.GetDbName(), t.CollectionName)
 	if err != nil {
 		return err
 	}
@@ -3416,7 +3422,7 @@ func (t *loadPartitionsTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 
-	partitionKeyMode, err := isPartitionKeyMode(ctx, t.GetDbName(), collName)
+	partitionKeyMode, err := isPartitionKeyMode(ctx, t.getMetaCache(), t.GetDbName(), collName)
 	if err != nil {
 		return err
 	}
@@ -3438,12 +3444,12 @@ func (t *loadPartitionsTask) GetLoadPriority() commonpb.LoadPriority {
 
 func (t *loadPartitionsTask) Execute(ctx context.Context) error {
 	var partitionIDs []int64
-	collID, err := globalMetaCache.GetCollectionID(ctx, t.GetDbName(), t.CollectionName)
+	collID, err := t.getMetaCache().GetCollectionID(ctx, t.GetDbName(), t.CollectionName)
 	if err != nil {
 		return err
 	}
 	t.collectionID = collID
-	collSchema, err := globalMetaCache.GetCollectionSchema(ctx, t.GetDbName(), t.CollectionName)
+	collSchema, err := t.getMetaCache().GetCollectionSchema(ctx, t.GetDbName(), t.CollectionName)
 	if err != nil {
 		return err
 	}
@@ -3494,7 +3500,7 @@ func (t *loadPartitionsTask) Execute(ctx context.Context) error {
 	}
 
 	for _, partitionName := range t.PartitionNames {
-		partitionID, err := globalMetaCache.GetPartitionID(ctx, t.GetDbName(), t.CollectionName, partitionName)
+		partitionID, err := t.getMetaCache().GetPartitionID(ctx, t.GetDbName(), t.CollectionName, partitionName)
 		if err != nil {
 			return err
 		}
@@ -3593,7 +3599,7 @@ func (t *releasePartitionsTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 
-	partitionKeyMode, err := isPartitionKeyMode(ctx, t.GetDbName(), collName)
+	partitionKeyMode, err := isPartitionKeyMode(ctx, t.getMetaCache(), t.GetDbName(), collName)
 	if err != nil {
 		return err
 	}
@@ -3606,13 +3612,13 @@ func (t *releasePartitionsTask) PreExecute(ctx context.Context) error {
 
 func (t *releasePartitionsTask) Execute(ctx context.Context) (err error) {
 	var partitionIDs []int64
-	collID, err := globalMetaCache.GetCollectionID(ctx, t.GetDbName(), t.CollectionName)
+	collID, err := t.getMetaCache().GetCollectionID(ctx, t.GetDbName(), t.CollectionName)
 	if err != nil {
 		return err
 	}
 	t.collectionID = collID
 	for _, partitionName := range t.PartitionNames {
-		partitionID, err := globalMetaCache.GetPartitionID(ctx, t.GetDbName(), t.CollectionName, partitionName)
+		partitionID, err := t.getMetaCache().GetPartitionID(ctx, t.GetDbName(), t.CollectionName, partitionName)
 		if err != nil {
 			return err
 		}
@@ -3899,7 +3905,7 @@ func (t *DescribeResourceGroupTask) Execute(ctx context.Context) error {
 	getCollectionName := func(collections map[int64]int32) (map[string]int32, error) {
 		ret := make(map[string]int32)
 		for key, value := range collections {
-			name, err := globalMetaCache.GetCollectionName(ctx, "", key)
+			name, err := t.getMetaCache().GetCollectionName(ctx, "", key)
 			if err != nil {
 				mlog.Warn(ctx, "failed to get collection name",
 					mlog.Int64("collectionID", key),
@@ -4078,7 +4084,7 @@ func (t *TransferReplicaTask) PreExecute(ctx context.Context) error {
 
 func (t *TransferReplicaTask) Execute(ctx context.Context) error {
 	var err error
-	collID, err := globalMetaCache.GetCollectionID(ctx, t.GetDbName(), t.CollectionName)
+	collID, err := t.getMetaCache().GetCollectionID(ctx, t.GetDbName(), t.CollectionName)
 	if err != nil {
 		return err
 	}
@@ -4216,14 +4222,14 @@ func (t *RunAnalyzerTask) OnEnqueue() error {
 func (t *RunAnalyzerTask) PreExecute(ctx context.Context) error {
 	t.dbName = t.GetDbName()
 
-	collID, err := globalMetaCache.GetCollectionID(ctx, t.dbName, t.GetCollectionName())
+	collID, err := t.getMetaCache().GetCollectionID(ctx, t.dbName, t.GetCollectionName())
 	if err != nil { // err is not nil if collection not exists
 		return err
 	}
 
 	t.collectionID = collID
 
-	schema, err := globalMetaCache.GetCollectionSchema(ctx, t.dbName, t.GetCollectionName())
+	schema, err := t.getMetaCache().GetCollectionSchema(ctx, t.dbName, t.GetCollectionName())
 	if err != nil { // err is not nil if collection not exists
 		return err
 	}

--- a/internal/proxy/task_alias.go
+++ b/internal/proxy/task_alias.go
@@ -104,7 +104,7 @@ func (t *CreateAliasTask) PreExecute(ctx context.Context) error {
 	// This is needed for correctness: rootcoord's CheckIfAliasCreatable only checks mt.names,
 	// so passing an alias as CollectionName would fail.
 	dbName := t.GetDbName()
-	if resolved, err := resolveCollectionAlias(ctx, dbName, collName); err == nil {
+	if resolved, err := resolveCollectionAlias(ctx, t.getMetaCache(), dbName, collName); err == nil {
 		t.CollectionName = resolved
 	}
 	return nil
@@ -269,7 +269,7 @@ func (t *AlterAliasTask) PreExecute(ctx context.Context) error {
 	// This is needed for correctness: rootcoord's CheckIfAliasAlterable only checks mt.names,
 	// so passing an alias as CollectionName would fail.
 	dbName := t.GetDbName()
-	if resolved, err := resolveCollectionAlias(ctx, dbName, collName); err == nil {
+	if resolved, err := resolveCollectionAlias(ctx, t.getMetaCache(), dbName, collName); err == nil {
 		t.CollectionName = resolved
 	}
 	return nil
@@ -419,7 +419,7 @@ func (a *ListAliasesTask) PreExecute(ctx context.Context) error {
 		// Resolve CollectionName in case the user passed an alias instead of the real name.
 		// rootcoord filters by collection name in mt.names, so an alias would return no results.
 		dbName := a.GetDbName()
-		if resolved, err := resolveCollectionAlias(ctx, dbName, a.GetCollectionName()); err == nil {
+		if resolved, err := resolveCollectionAlias(ctx, a.getMetaCache(), dbName, a.GetCollectionName()); err == nil {
 			a.CollectionName = resolved
 		}
 	}

--- a/internal/proxy/task_alias_test.go
+++ b/internal/proxy/task_alias_test.go
@@ -36,12 +36,6 @@ func TestCreateAlias_all(t *testing.T) {
 	defer rc.Close()
 	ctx := context.Background()
 
-	// Save and clear globalMetaCache to avoid resolveCollectionAlias calling
-	// DescribeAlias on a stale testify mock from a previous test.
-	oldCache := globalMetaCache
-	globalMetaCache = nil
-	defer func() { globalMetaCache = oldCache }()
-
 	prefix := "TestCreateAlias_all"
 	collectionName := prefix + funcutil.GenRandomStr()
 	task := &CreateAliasTask{
@@ -122,12 +116,6 @@ func TestAlterAlias_all(t *testing.T) {
 	rc := NewMixCoordMock()
 	defer rc.Close()
 	ctx := context.Background()
-
-	// Save and clear globalMetaCache to avoid resolveCollectionAlias calling
-	// DescribeAlias on a stale testify mock from a previous test.
-	oldCache := globalMetaCache
-	globalMetaCache = nil
-	defer func() { globalMetaCache = oldCache }()
 
 	prefix := "TestAlterAlias_all"
 	collectionName := prefix + funcutil.GenRandomStr()

--- a/internal/proxy/task_batch_update_manifest.go
+++ b/internal/proxy/task_batch_update_manifest.go
@@ -89,7 +89,7 @@ func (bt *batchUpdateManifestTask) PreExecute(ctx context.Context) error {
 		return merr.WrapErrParameterInvalidMsg("items is empty")
 	}
 
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, req.GetDbName(), req.GetCollectionName())
+	collectionID, err := bt.getMetaCache().GetCollectionID(ctx, req.GetDbName(), req.GetCollectionName())
 	if err != nil {
 		return err
 	}

--- a/internal/proxy/task_database.go
+++ b/internal/proxy/task_database.go
@@ -152,7 +152,7 @@ func (ddt *dropDatabaseTask) Execute(ctx context.Context) error {
 		// Local best-effort cleanup on the issuing proxy; the authoritative
 		// eviction is the DropDatabase broadcast handled in
 		// InvalidateCollectionMetaCache.
-		globalMetaCache.RemoveDatabase(ctx, ddt.DbName)
+		ddt.getMetaCache().RemoveDatabase(ctx, ddt.DbName)
 	}
 	return err
 }

--- a/internal/proxy/task_database_test.go
+++ b/internal/proxy/task_database_test.go
@@ -73,7 +73,15 @@ func TestDropDatabaseTask(t *testing.T) {
 	defer rc.Close()
 
 	ctx := context.Background()
+	cache := NewMockCache(t)
+	cache.On("RemoveDatabase",
+		mock.Anything, // context.Context
+		mock.AnythingOfType("string"),
+	).Maybe()
 	task := &dropDatabaseTask{
+		baseTask: baseTask{
+			metaCache: cache,
+		},
 		Condition: NewTaskCondition(ctx),
 		DropDatabaseRequest: &milvuspb.DropDatabaseRequest{
 			Base: &commonpb.MsgBase{
@@ -87,14 +95,6 @@ func TestDropDatabaseTask(t *testing.T) {
 		mixCoord: rc,
 		result:   nil,
 	}
-
-	cache := NewMockCache(t)
-	cache.On("RemoveDatabase",
-		mock.Anything, // context.Context
-		mock.AnythingOfType("string"),
-	).Maybe()
-	globalMetaCache = cache
-
 	t.Run("ok", func(t *testing.T) {
 		err := task.PreExecute(ctx)
 		assert.NoError(t, err)

--- a/internal/proxy/task_delete.go
+++ b/internal/proxy/task_delete.go
@@ -441,6 +441,7 @@ func (dr *deleteRunner) Run(ctx context.Context) error {
 
 func (dr *deleteRunner) produce(ctx context.Context, primaryKeys *schemapb.IDs, partitionID UniqueID) (*deleteTask, error) {
 	dt := &deleteTask{
+		baseTask:     baseTask{metaCache: dr.getMetaCache()},
 		ctx:          ctx,
 		Condition:    NewTaskCondition(ctx),
 		req:          dr.req,

--- a/internal/proxy/task_delete.go
+++ b/internal/proxy/task_delete.go
@@ -111,7 +111,7 @@ func (dt *deleteTask) OnEnqueue() error {
 }
 
 func (dt *deleteTask) setChannels() error {
-	collID, err := globalMetaCache.GetCollectionID(dt.ctx, dt.req.GetDbName(), dt.req.GetCollectionName())
+	collID, err := dt.getMetaCache().GetCollectionID(dt.ctx, dt.req.GetDbName(), dt.req.GetCollectionName())
 	if err != nil {
 		return err
 	}
@@ -131,7 +131,7 @@ func (dt *deleteTask) PreExecute(ctx context.Context) error {
 	if dt.req.Namespace == nil {
 		return nil
 	}
-	schema, err := globalMetaCache.GetCollectionSchema(ctx, dt.req.GetDbName(), dt.req.GetCollectionName())
+	schema, err := dt.getMetaCache().GetCollectionSchema(ctx, dt.req.GetDbName(), dt.req.GetCollectionName())
 	if err != nil {
 		return err
 	}
@@ -255,8 +255,9 @@ func repackDeleteMsgByHash(
 }
 
 type deleteRunner struct {
-	req    *milvuspb.DeleteRequest
-	result *milvuspb.MutationResult
+	req       *milvuspb.DeleteRequest
+	result    *milvuspb.MutationResult
+	metaCache Cache
 
 	// channel
 	chMgr     channelsMgr
@@ -289,6 +290,10 @@ type deleteRunner struct {
 	scannedTotalBytes  atomic.Int64
 }
 
+func (dr *deleteRunner) getMetaCache() Cache {
+	return dr.metaCache
+}
+
 func (dr *deleteRunner) Init(ctx context.Context) error {
 	var err error
 
@@ -301,18 +306,18 @@ func (dr *deleteRunner) Init(ctx context.Context) error {
 		return ErrWithLog(log, "Invalid collection name", err)
 	}
 
-	db, err := globalMetaCache.GetDatabaseInfo(ctx, dr.req.GetDbName())
+	db, err := dr.getMetaCache().GetDatabaseInfo(ctx, dr.req.GetDbName())
 	if err != nil {
 		return err
 	}
 	dr.dbID = db.DBID
 
-	dr.collectionID, err = globalMetaCache.GetCollectionID(ctx, dr.req.GetDbName(), collName)
+	dr.collectionID, err = dr.getMetaCache().GetCollectionID(ctx, dr.req.GetDbName(), collName)
 	if err != nil {
 		return ErrWithLog(log, "Failed to get collection id", err)
 	}
 
-	dr.schema, err = globalMetaCache.GetCollectionSchema(ctx, dr.req.GetDbName(), collName)
+	dr.schema, err = dr.getMetaCache().GetCollectionSchema(ctx, dr.req.GetDbName(), collName)
 	if err != nil {
 		return ErrWithLog(log, "Failed to get collection schema", err)
 	}
@@ -327,7 +332,7 @@ func (dr *deleteRunner) Init(ctx context.Context) error {
 		dr.req.PartitionName = partitionName
 	}
 
-	colInfo, err := globalMetaCache.GetCollectionInfo(ctx, dr.req.GetDbName(), collName, dr.collectionID)
+	colInfo, err := dr.getMetaCache().GetCollectionInfo(ctx, dr.req.GetDbName(), collName, dr.collectionID)
 	if err != nil {
 		return ErrWithLog(log, "Failed to get collection info", err)
 	}
@@ -359,11 +364,11 @@ func (dr *deleteRunner) Init(ctx context.Context) error {
 		if len(partName) > 0 {
 			return merr.WrapErrParameterInvalidMsg("not support manually specifying the partition names if namespace is used")
 		}
-		hashedPartitionNames, err := assignNamespacePartitionKey(ctx, dr.req.GetDbName(), dr.req.GetCollectionName(), dr.req.Namespace)
+		hashedPartitionNames, err := assignNamespacePartitionKey(ctx, dr.getMetaCache(), dr.req.GetDbName(), dr.req.GetCollectionName(), dr.req.Namespace)
 		if err != nil {
 			return err
 		}
-		dr.partitionIDs, err = getPartitionIDs(ctx, dr.req.GetDbName(), dr.req.GetCollectionName(), hashedPartitionNames)
+		dr.partitionIDs, err = getPartitionIDs(ctx, dr.getMetaCache(), dr.req.GetDbName(), dr.req.GetCollectionName(), hashedPartitionNames)
 		if err != nil {
 			return err
 		}
@@ -376,11 +381,11 @@ func (dr *deleteRunner) Init(ctx context.Context) error {
 			return err
 		}
 		partitionKeys := exprutil.ParseKeys(expr, exprutil.PartitionKey)
-		hashedPartitionNames, err := assignPartitionKeys(ctx, dr.req.GetDbName(), dr.req.GetCollectionName(), partitionKeys)
+		hashedPartitionNames, err := assignPartitionKeys(ctx, dr.getMetaCache(), dr.req.GetDbName(), dr.req.GetCollectionName(), partitionKeys)
 		if err != nil {
 			return err
 		}
-		dr.partitionIDs, err = getPartitionIDs(ctx, dr.req.GetDbName(), dr.req.GetCollectionName(), hashedPartitionNames)
+		dr.partitionIDs, err = getPartitionIDs(ctx, dr.getMetaCache(), dr.req.GetDbName(), dr.req.GetCollectionName(), hashedPartitionNames)
 		if err != nil {
 			return err
 		}
@@ -391,7 +396,7 @@ func (dr *deleteRunner) Init(ctx context.Context) error {
 		}
 
 		// dynamic validation
-		partID, err := globalMetaCache.GetPartitionID(ctx, dr.req.GetDbName(), collName, partName)
+		partID, err := dr.getMetaCache().GetPartitionID(ctx, dr.req.GetDbName(), collName, partName)
 		if err != nil {
 			return ErrWithLog(log, "Failed to get partition id", err)
 		}

--- a/internal/proxy/task_delete_streaming.go
+++ b/internal/proxy/task_delete_streaming.go
@@ -30,9 +30,9 @@ func (dt *deleteTask) Execute(ctx context.Context) (err error) {
 
 	var collectionSchema *schemapb.CollectionSchema
 	if dt.req.Namespace != nil || hookutil.IsClusterEncryptionEnabled() {
-		schema, err := globalMetaCache.GetCollectionSchema(ctx, dt.req.GetDbName(), dt.req.GetCollectionName())
+		schema, err := dt.getMetaCache().GetCollectionSchema(ctx, dt.req.GetDbName(), dt.req.GetCollectionName())
 		if err != nil {
-			mlog.Warn(ctx, "get collection schema from global meta cache failed", mlog.String("collectionName", dt.req.GetCollectionName()), mlog.Err(err))
+			mlog.Warn(ctx, "get collection schema from meta cache failed", mlog.String("collectionName", dt.req.GetCollectionName()), mlog.Err(err))
 			return err
 		}
 		collectionSchema = schema.CollectionSchema

--- a/internal/proxy/task_delete_test.go
+++ b/internal/proxy/task_delete_test.go
@@ -855,6 +855,7 @@ func TestDeleteRunner_Run(t *testing.T) {
 		dr := deleteRunner{
 			idAllocator:     idAllocator,
 			tsoAllocatorIns: tsoAllocator,
+			metaCache:       metaCache,
 			queue:           queue.dmQueue,
 			chMgr:           mockMgr,
 			schema:          schema,
@@ -925,6 +926,7 @@ func TestDeleteRunner_Run(t *testing.T) {
 
 		dr := deleteRunner{
 			queue:           queue.dmQueue,
+			metaCache:       metaCache,
 			chMgr:           mockMgr,
 			schema:          schema,
 			collectionID:    collectionID,
@@ -992,6 +994,7 @@ func TestDeleteRunner_Run(t *testing.T) {
 		dr := deleteRunner{
 			chMgr:           mockMgr,
 			queue:           queue.dmQueue,
+			metaCache:       metaCache,
 			schema:          schema,
 			collectionID:    collectionID,
 			partitionIDs:    []int64{partitionID},
@@ -1055,6 +1058,7 @@ func TestDeleteRunner_Run(t *testing.T) {
 		dr := deleteRunner{
 			chMgr:           mockMgr,
 			queue:           queue.dmQueue,
+			metaCache:       metaCache,
 			schema:          schema,
 			collectionID:    collectionID,
 			partitionIDs:    []int64{partitionID},
@@ -1118,6 +1122,7 @@ func TestDeleteRunner_Run(t *testing.T) {
 
 		dr := deleteRunner{
 			queue:           queue.dmQueue,
+			metaCache:       metaCache,
 			chMgr:           mockMgr,
 			schema:          schema,
 			collectionID:    collectionID,

--- a/internal/proxy/task_delete_test.go
+++ b/internal/proxy/task_delete_test.go
@@ -123,11 +123,11 @@ func TestDeleteTask_GetChannels(t *testing.T) {
 		mock.AnythingOfType("string"),
 	).Return(collectionID, nil)
 
-	globalMetaCache = cache
 	chMgr := NewMockChannelsMgr(t)
 	chMgr.EXPECT().getChannels(mock.Anything).Return(channels, nil)
 	dt := deleteTask{
-		ctx: context.Background(),
+		baseTask: baseTask{metaCache: cache},
+		ctx:      context.Background(),
 		req: &milvuspb.DeleteRequest{
 			CollectionName: collectionName,
 		},
@@ -141,12 +141,6 @@ func TestDeleteTask_GetChannels(t *testing.T) {
 }
 
 func TestDeleteTask_PreExecuteSkipsNamespaceValidationWhenUnset(t *testing.T) {
-	cache := globalMetaCache
-	globalMetaCache = nil
-	defer func() {
-		globalMetaCache = cache
-	}()
-
 	dt := deleteTask{
 		req: &milvuspb.DeleteRequest{},
 	}
@@ -296,7 +290,7 @@ func (s *DeleteRunnerSuite) TestInitSuccess() {
 		s.mockCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"part1": 100, "part2": 101}, nil)
 		mockChMgr.EXPECT().getVChannels(mock.Anything).Return([]string{"vchan1"}, nil)
 
-		globalMetaCache = s.mockCache
+		dr.metaCache = s.mockCache
 		s.NoError(dr.Init(context.Background()))
 
 		s.Require().Equal(1, len(dr.partitionIDs))
@@ -320,7 +314,7 @@ func (s *DeleteRunnerSuite) TestInitSuccess() {
 		s.mockCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"part1": 100, "part2": 101}, nil)
 		mockChMgr.EXPECT().getVChannels(mock.Anything).Return([]string{"vchan1"}, nil)
 
-		globalMetaCache = s.mockCache
+		dr.metaCache = s.mockCache
 		s.NoError(dr.Init(context.Background()))
 
 		s.Require().Equal(0, len(dr.partitionIDs))
@@ -343,7 +337,7 @@ func (s *DeleteRunnerSuite) TestInitSuccess() {
 		s.mockCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"part1": 100, "part2": 101}, nil)
 		mockChMgr.EXPECT().getVChannels(mock.Anything).Return([]string{"vchan1"}, nil)
 
-		globalMetaCache = s.mockCache
+		dr.metaCache = s.mockCache
 		s.NoError(dr.Init(context.Background()))
 
 		s.Require().Equal(0, len(dr.partitionIDs))
@@ -375,7 +369,7 @@ func (s *DeleteRunnerSuite) TestInitSuccess() {
 		s.mockCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(partitionIDs, nil)
 		mockChMgr.EXPECT().getVChannels(mock.Anything).Return([]string{"vchan1"}, nil)
 
-		globalMetaCache = s.mockCache
+		dr.metaCache = s.mockCache
 		s.NoError(dr.Init(context.Background()))
 
 		s.Equal([]int64{expectedNamespacePartitionID(namespace, partitionNames, partitionIDs)}, dr.partitionIDs)
@@ -415,7 +409,7 @@ func (s *DeleteRunnerSuite) TestInitSuccess() {
 		s.mockCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(s.schema, nil).Once()
 		mockChMgr.EXPECT().getVChannels(mock.Anything).Return([]string{"vchan1"}, nil)
 
-		globalMetaCache = s.mockCache
+		dr.metaCache = s.mockCache
 		s.NoError(dr.Init(context.Background()))
 
 		s.Equal(0, len(dr.partitionIDs))
@@ -457,7 +451,7 @@ func (s *DeleteRunnerSuite) TestInitSuccess() {
 		mockChMgr.EXPECT().getVChannels(mock.Anything).Return([]string{"vchan1"}, nil)
 		s.mockCache.EXPECT().GetPartitionID(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(int64(1000), nil)
 
-		globalMetaCache = s.mockCache
+		dr.metaCache = s.mockCache
 		s.NoError(dr.Init(context.Background()))
 
 		s.Equal(1, len(dr.partitionIDs))
@@ -503,7 +497,7 @@ func (s *DeleteRunnerSuite) TestInitSuccess() {
 		s.mockCache.EXPECT().GetPartitionID(mock.Anything, mock.Anything, mock.Anything, namespace).Return(int64(1000), nil)
 		mockChMgr.EXPECT().getVChannels(mock.Anything).Return([]string{"vchan1"}, nil)
 
-		globalMetaCache = s.mockCache
+		dr.metaCache = s.mockCache
 		s.NoError(dr.Init(context.Background()))
 
 		s.Equal(namespace, dr.req.GetPartitionName())
@@ -545,7 +539,7 @@ func (s *DeleteRunnerSuite) TestInitFailure() {
 		s.mockCache.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(s.collectionID, nil)
 		s.mockCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(s.schema, nil)
 
-		globalMetaCache = s.mockCache
+		dr.metaCache = s.mockCache
 		s.Error(dr.Init(context.Background()))
 	})
 
@@ -556,7 +550,7 @@ func (s *DeleteRunnerSuite) TestInitFailure() {
 			},
 		}
 		s.mockCache.EXPECT().GetDatabaseInfo(mock.Anything, mock.Anything).Return(nil, errors.New("mock error"))
-		globalMetaCache = s.mockCache
+		dr.metaCache = s.mockCache
 
 		s.Error(dr.Init(context.Background()))
 	})
@@ -570,7 +564,7 @@ func (s *DeleteRunnerSuite) TestInitFailure() {
 		s.mockCache.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).
 			Return(int64(0), errors.New("mock get collectionID error"))
 
-		globalMetaCache = s.mockCache
+		dr.metaCache = s.mockCache
 		s.Error(dr.Init(context.Background()))
 	})
 
@@ -584,7 +578,7 @@ func (s *DeleteRunnerSuite) TestInitFailure() {
 		s.mockCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).
 			Return(nil, errors.New("mock GetCollectionSchema err"))
 
-		globalMetaCache = s.mockCache
+		dr.metaCache = s.mockCache
 		s.Error(dr.Init(context.Background()))
 	})
 
@@ -602,7 +596,7 @@ func (s *DeleteRunnerSuite) TestInitFailure() {
 		s.mockCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).
 			Return(s.schema, nil)
 
-		globalMetaCache = s.mockCache
+		dr.metaCache = s.mockCache
 		s.Error(dr.Init(context.Background()))
 	})
 	s.Run("delete with always true expression failed", func() {
@@ -619,7 +613,7 @@ func (s *DeleteRunnerSuite) TestInitFailure() {
 		s.mockCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).
 			Return(s.schema, nil)
 
-		globalMetaCache = s.mockCache
+		dr.metaCache = s.mockCache
 		s.Error(dr.Init(context.Background()))
 	})
 
@@ -649,7 +643,7 @@ func (s *DeleteRunnerSuite) TestInitFailure() {
 		s.mockCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).
 			Return(s.schema, nil)
 
-		globalMetaCache = s.mockCache
+		dr.metaCache = s.mockCache
 		err = dr.Init(context.Background())
 		s.Error(err)
 		s.ErrorContains(err, "bloom_match is approximate and cannot be used in delete expressions")
@@ -668,7 +662,7 @@ func (s *DeleteRunnerSuite) TestInitFailure() {
 			Return(s.schema, nil)
 			// The schema enabled partitionKey
 
-		globalMetaCache = s.mockCache
+		dr.metaCache = s.mockCache
 		s.Error(dr.Init(context.Background()))
 	})
 
@@ -706,7 +700,7 @@ func (s *DeleteRunnerSuite) TestInitFailure() {
 		s.mockCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).
 			Return(s.schema, nil)
 
-		globalMetaCache = s.mockCache
+		dr.metaCache = s.mockCache
 		s.Error(dr.Init(context.Background()))
 	})
 
@@ -743,7 +737,7 @@ func (s *DeleteRunnerSuite) TestInitFailure() {
 		s.mockCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(s.schema, nil)
 		s.mockCache.EXPECT().GetPartitionID(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(int64(0), errors.New("mock GetPartitionID err"))
-		globalMetaCache = s.mockCache
+		dr.metaCache = s.mockCache
 		s.Error(dr.Init(context.Background()))
 	})
 
@@ -764,7 +758,7 @@ func (s *DeleteRunnerSuite) TestInitFailure() {
 		s.mockCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"part1": 100, "part2": 101}, nil)
 		mockChMgr.EXPECT().getVChannels(mock.Anything).Return(nil, errors.New("mock error"))
 
-		globalMetaCache = s.mockCache
+		dr.metaCache = s.mockCache
 		s.Error(dr.Init(context.Background()))
 	})
 }
@@ -810,10 +804,6 @@ func TestDeleteRunner_Run(t *testing.T) {
 
 	metaCache := NewMockCache(t)
 	metaCache.EXPECT().GetCollectionID(mock.Anything, dbName, collectionName).Return(collectionID, nil).Maybe()
-	globalMetaCache = metaCache
-	defer func() {
-		globalMetaCache = nil
-	}()
 
 	t.Run("simple delete task failed", func(t *testing.T) {
 		mockMgr := NewMockChannelsMgr(t)
@@ -824,6 +814,7 @@ func TestDeleteRunner_Run(t *testing.T) {
 		require.NoError(t, err)
 
 		dr := deleteRunner{
+			metaCache:       metaCache,
 			chMgr:           mockMgr,
 			schema:          schema,
 			collectionID:    collectionID,
@@ -1192,13 +1183,12 @@ func TestDeleteRunner_Run(t *testing.T) {
 
 		mockCache := NewMockCache(t)
 		mockCache.EXPECT().GetCollectionID(mock.Anything, dbName, collectionName).Return(collectionID, nil).Maybe()
-		globalMetaCache = mockCache
-		defer func() { globalMetaCache = metaCache }()
 		expr := "non_pk in [2, 3]"
 		plan, err := planparserv2.CreateRetrievePlan(schema.SchemaHelper, expr, nil)
 		require.NoError(t, err)
 
 		dr := deleteRunner{
+			metaCache:       mockCache,
 			queue:           queue.dmQueue,
 			chMgr:           mockMgr,
 			schema:          schema,

--- a/internal/proxy/task_flush_streaming.go
+++ b/internal/proxy/task_flush_streaming.go
@@ -44,7 +44,7 @@ func (t *flushTask) Execute(ctx context.Context) error {
 	mlog.Info(ctx, "flushTaskByStreamingService.Execute", mlog.Int("collectionNum", len(t.CollectionNames)), mlog.Uint64("flushTs", flushTs))
 	timeOfSeal, _ := tsoutil.ParseTS(flushTs)
 	for _, collName := range t.CollectionNames {
-		collID, err := globalMetaCache.GetCollectionID(t.ctx, t.DbName, collName)
+		collID, err := t.getMetaCache().GetCollectionID(t.ctx, t.DbName, collName)
 		if err != nil {
 			return err
 		}

--- a/internal/proxy/task_import.go
+++ b/internal/proxy/task_import.go
@@ -91,12 +91,12 @@ func (it *importTask) OnEnqueue() error {
 func (it *importTask) PreExecute(ctx context.Context) error {
 	req := it.req
 	node := it.node
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, req.GetDbName(), req.GetCollectionName())
+	collectionID, err := it.getMetaCache().GetCollectionID(ctx, req.GetDbName(), req.GetCollectionName())
 	if err != nil {
 		return err
 	}
 	it.collectionID = collectionID
-	schema, err := globalMetaCache.GetCollectionSchema(ctx, req.GetDbName(), req.GetCollectionName())
+	schema, err := it.getMetaCache().GetCollectionSchema(ctx, req.GetDbName(), req.GetCollectionName())
 	if err != nil {
 		return err
 	}
@@ -124,7 +124,7 @@ func (it *importTask) PreExecute(ctx context.Context) error {
 			return merr.WrapErrParameterMissingMsg("partition not specified")
 		}
 		// Currently, Backup tool call import must with a partition name, each time restore a partition
-		partitionID, err := globalMetaCache.GetPartitionID(ctx, req.GetDbName(), req.GetCollectionName(), req.GetPartitionName())
+		partitionID, err := it.getMetaCache().GetPartitionID(ctx, req.GetDbName(), req.GetCollectionName(), req.GetPartitionName())
 		if err != nil {
 			return err
 		}
@@ -133,7 +133,7 @@ func (it *importTask) PreExecute(ctx context.Context) error {
 		if req.GetPartitionName() == "" {
 			partitionIDs = []UniqueID{common.AllPartitionsID}
 		} else {
-			partitionID, err := globalMetaCache.GetPartitionID(ctx, req.GetDbName(), req.GetCollectionName(), req.PartitionName)
+			partitionID, err := it.getMetaCache().GetPartitionID(ctx, req.GetDbName(), req.GetCollectionName(), req.PartitionName)
 			if err != nil {
 				return err
 			}
@@ -156,7 +156,7 @@ func (it *importTask) PreExecute(ctx context.Context) error {
 			if req.GetPartitionName() != "" {
 				return merr.WrapErrImportFailed("not allow to set partition name for collection with partition key")
 			}
-			partitions, err := globalMetaCache.GetPartitions(ctx, req.GetDbName(), req.GetCollectionName())
+			partitions, err := it.getMetaCache().GetPartitions(ctx, req.GetDbName(), req.GetCollectionName())
 			if err != nil {
 				return err
 			}
@@ -168,7 +168,7 @@ func (it *importTask) PreExecute(ctx context.Context) error {
 			if req.GetPartitionName() == "" {
 				req.PartitionName = Params.CommonCfg.DefaultPartitionName.GetValue()
 			}
-			partitionID, err := globalMetaCache.GetPartitionID(ctx, req.GetDbName(), req.GetCollectionName(), req.PartitionName)
+			partitionID, err := it.getMetaCache().GetPartitionID(ctx, req.GetDbName(), req.GetCollectionName(), req.PartitionName)
 			if err != nil {
 				return err
 			}
@@ -214,7 +214,7 @@ func (it *importTask) Execute(ctx context.Context) error {
 	// DataCoord will handle validation, broadcasting, and job creation
 
 	// Get database ID from database name
-	dbInfo, err := globalMetaCache.GetDatabaseInfo(ctx, it.req.GetDbName())
+	dbInfo, err := it.getMetaCache().GetDatabaseInfo(ctx, it.req.GetDbName())
 	if err != nil {
 		mlog.Warn(ctx, "failed to get database info", mlog.FieldDbName(it.req.GetDbName()), mlog.Err(err))
 		return err

--- a/internal/proxy/task_import_test.go
+++ b/internal/proxy/task_import_test.go
@@ -53,14 +53,9 @@ func TestImportTaskSuite(t *testing.T) {
 func (s *ImportTaskSuite) TestExecute_GetDatabaseInfoFailsReturnsError() {
 	ctx := context.Background()
 
-	// Mock globalMetaCache.GetDatabaseInfo to fail
+	// Mock database info lookup to fail
 	mockCache := NewMockCache(s.T())
 	mockCache.EXPECT().GetDatabaseInfo(mock.Anything, mock.Anything).Return(nil, errors.New("database not found"))
-
-	oldCache := globalMetaCache
-	globalMetaCache = mockCache
-	defer func() { globalMetaCache = oldCache }()
-
 	task := &importTask{
 		ctx: ctx,
 		req: &internalpb.ImportRequest{
@@ -69,6 +64,7 @@ func (s *ImportTaskSuite) TestExecute_GetDatabaseInfoFailsReturnsError() {
 		},
 		resp: &internalpb.ImportResponse{},
 	}
+	task.metaCache = mockCache
 
 	err := task.Execute(ctx)
 
@@ -79,16 +75,11 @@ func (s *ImportTaskSuite) TestExecute_GetDatabaseInfoFailsReturnsError() {
 func (s *ImportTaskSuite) TestExecute_ImportV2RPCFailsReturnsError() {
 	ctx := context.Background()
 
-	// Mock globalMetaCache.GetDatabaseInfo to succeed
+	// Mock database info lookup to succeed
 	mockCache := NewMockCache(s.T())
 	mockCache.EXPECT().GetDatabaseInfo(mock.Anything, mock.Anything).Return(&databaseInfo{
 		DBID: 1,
 	}, nil)
-
-	oldCache := globalMetaCache
-	globalMetaCache = mockCache
-	defer func() { globalMetaCache = oldCache }()
-
 	// Mock MixCoordClient to return RPC error
 	mockMixCoord := mocks.NewMockMixCoordClient(s.T())
 	mockMixCoord.EXPECT().ImportV2(mock.Anything, mock.Anything).Return(nil, errors.New("rpc error"))
@@ -113,6 +104,7 @@ func (s *ImportTaskSuite) TestExecute_ImportV2RPCFailsReturnsError() {
 		},
 		resp: &internalpb.ImportResponse{},
 	}
+	task.metaCache = mockCache
 
 	err := task.Execute(ctx)
 
@@ -123,16 +115,11 @@ func (s *ImportTaskSuite) TestExecute_ImportV2RPCFailsReturnsError() {
 func (s *ImportTaskSuite) TestExecute_ImportV2ReturnsErrorStatusReturnsError() {
 	ctx := context.Background()
 
-	// Mock globalMetaCache.GetDatabaseInfo to succeed
+	// Mock database info lookup to succeed
 	mockCache := NewMockCache(s.T())
 	mockCache.EXPECT().GetDatabaseInfo(mock.Anything, mock.Anything).Return(&databaseInfo{
 		DBID: 1,
 	}, nil)
-
-	oldCache := globalMetaCache
-	globalMetaCache = mockCache
-	defer func() { globalMetaCache = oldCache }()
-
 	// Mock MixCoordClient to return error status
 	mockMixCoord := mocks.NewMockMixCoordClient(s.T())
 	mockMixCoord.EXPECT().ImportV2(mock.Anything, mock.Anything).Return(&internalpb.ImportResponse{
@@ -159,6 +146,7 @@ func (s *ImportTaskSuite) TestExecute_ImportV2ReturnsErrorStatusReturnsError() {
 		},
 		resp: &internalpb.ImportResponse{},
 	}
+	task.metaCache = mockCache
 
 	err := task.Execute(ctx)
 
@@ -169,16 +157,11 @@ func (s *ImportTaskSuite) TestExecute_ImportV2ReturnsErrorStatusReturnsError() {
 func (s *ImportTaskSuite) TestExecute_SuccessSetsJobID() {
 	ctx := context.Background()
 
-	// Mock globalMetaCache.GetDatabaseInfo to succeed
+	// Mock database info lookup to succeed
 	mockCache := NewMockCache(s.T())
 	mockCache.EXPECT().GetDatabaseInfo(mock.Anything, mock.Anything).Return(&databaseInfo{
 		DBID: 1,
 	}, nil)
-
-	oldCache := globalMetaCache
-	globalMetaCache = mockCache
-	defer func() { globalMetaCache = oldCache }()
-
 	// Mock MixCoordClient to return success
 	mockMixCoord := mocks.NewMockMixCoordClient(s.T())
 	mockMixCoord.EXPECT().ImportV2(mock.Anything, mock.Anything).Return(&internalpb.ImportResponse{
@@ -207,6 +190,7 @@ func (s *ImportTaskSuite) TestExecute_SuccessSetsJobID() {
 		},
 		resp: resp,
 	}
+	task.metaCache = mockCache
 
 	err := task.Execute(ctx)
 
@@ -217,16 +201,11 @@ func (s *ImportTaskSuite) TestExecute_SuccessSetsJobID() {
 func (s *ImportTaskSuite) TestExecute_PassesCorrectRequestParameters() {
 	ctx := context.Background()
 
-	// Mock globalMetaCache.GetDatabaseInfo to succeed
+	// Mock database info lookup to succeed
 	mockCache := NewMockCache(s.T())
 	mockCache.EXPECT().GetDatabaseInfo(mock.Anything, mock.Anything).Return(&databaseInfo{
 		DBID: 42,
 	}, nil)
-
-	oldCache := globalMetaCache
-	globalMetaCache = mockCache
-	defer func() { globalMetaCache = oldCache }()
-
 	// Capture the request to verify parameters
 	var capturedReq *internalpb.ImportRequestInternal
 	mockMixCoord := mocks.NewMockMixCoordClient(s.T())
@@ -262,6 +241,7 @@ func (s *ImportTaskSuite) TestExecute_PassesCorrectRequestParameters() {
 		},
 		resp: &internalpb.ImportResponse{},
 	}
+	task.metaCache = mockCache
 
 	err := task.Execute(ctx)
 
@@ -362,11 +342,6 @@ func (s *ImportTaskSuite) TestExecute_DataTimestampIsAlwaysZero() {
 	mockCache.EXPECT().GetDatabaseInfo(mock.Anything, mock.Anything).Return(&databaseInfo{
 		DBID: 1,
 	}, nil)
-
-	oldCache := globalMetaCache
-	globalMetaCache = mockCache
-	defer func() { globalMetaCache = oldCache }()
-
 	var capturedReq *internalpb.ImportRequestInternal
 	mockMixCoord := mocks.NewMockMixCoordClient(s.T())
 	mockMixCoord.EXPECT().ImportV2(mock.Anything, mock.Anything).RunAndReturn(
@@ -418,11 +393,6 @@ func (s *ImportTaskSuite) TestPreExecute_GetCollectionIDFailsReturnsError() {
 	// Use NewMockCache which is generated by mockery
 	mockCache := NewMockCache(s.T())
 	mockCache.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(int64(0), errors.New("collection not found"))
-
-	oldCache := globalMetaCache
-	globalMetaCache = mockCache
-	defer func() { globalMetaCache = oldCache }()
-
 	task := &importTask{
 		ctx: ctx,
 		req: &internalpb.ImportRequest{
@@ -430,6 +400,7 @@ func (s *ImportTaskSuite) TestPreExecute_GetCollectionIDFailsReturnsError() {
 			CollectionName: "test_collection",
 		},
 	}
+	task.metaCache = mockCache
 
 	err := task.PreExecute(ctx)
 

--- a/internal/proxy/task_import_test.go
+++ b/internal/proxy/task_import_test.go
@@ -373,6 +373,7 @@ func (s *ImportTaskSuite) TestExecute_DataTimestampIsAlwaysZero() {
 		},
 		resp: &internalpb.ImportResponse{},
 	}
+	task.metaCache = mockCache
 
 	task.Execute(ctx)
 

--- a/internal/proxy/task_index.go
+++ b/internal/proxy/task_index.go
@@ -512,7 +512,7 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 }
 
 func (cit *createIndexTask) getIndexedFieldAndFunction(ctx context.Context) error {
-	schema, err := globalMetaCache.GetCollectionSchema(ctx, cit.req.GetDbName(), cit.req.GetCollectionName())
+	schema, err := cit.getMetaCache().GetCollectionSchema(ctx, cit.req.GetDbName(), cit.req.GetCollectionName())
 	if err != nil {
 		mlog.Error(ctx, "failed to get collection schema", mlog.Err(err))
 		return merr.Wrap(err, "failed to get collection schema")
@@ -584,13 +584,13 @@ func checkTrain(ctx context.Context, field *schemapb.FieldSchema, indexParams ma
 func (cit *createIndexTask) PreExecute(ctx context.Context) error {
 	collName := cit.req.GetCollectionName()
 
-	collID, err := globalMetaCache.GetCollectionID(ctx, cit.req.GetDbName(), collName)
+	collID, err := cit.getMetaCache().GetCollectionID(ctx, cit.req.GetDbName(), collName)
 	if err != nil {
 		return err
 	}
 	cit.collectionID = collID
 
-	collInfo, err := globalMetaCache.GetCollectionInfo(ctx, cit.req.GetDbName(), cit.req.GetCollectionName(), cit.collectionID)
+	collInfo, err := cit.getMetaCache().GetCollectionInfo(ctx, cit.req.GetDbName(), cit.req.GetCollectionName(), cit.collectionID)
 	if err != nil {
 		return err
 	}
@@ -722,7 +722,7 @@ func (t *alterIndexTask) PreExecute(ctx context.Context) error {
 
 	collName := t.req.GetCollectionName()
 
-	collection, err := globalMetaCache.GetCollectionID(ctx, t.req.GetDbName(), collName)
+	collection, err := t.getMetaCache().GetCollectionID(ctx, t.req.GetDbName(), collName)
 	if err != nil {
 		return err
 	}
@@ -832,7 +832,7 @@ func (dit *describeIndexTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 
-	collID, err := globalMetaCache.GetCollectionID(ctx, dit.GetDbName(), dit.CollectionName)
+	collID, err := dit.getMetaCache().GetCollectionID(ctx, dit.GetDbName(), dit.CollectionName)
 	if err != nil {
 		return err
 	}
@@ -841,7 +841,7 @@ func (dit *describeIndexTask) PreExecute(ctx context.Context) error {
 }
 
 func (dit *describeIndexTask) Execute(ctx context.Context) error {
-	schema, err := globalMetaCache.GetCollectionSchema(ctx, dit.GetDbName(), dit.GetCollectionName())
+	schema, err := dit.getMetaCache().GetCollectionSchema(ctx, dit.GetDbName(), dit.GetCollectionName())
 	if err != nil {
 		mlog.Error(ctx, "failed to get collection schema", mlog.Err(err))
 		return merr.Wrap(err, "failed to get collection schema")
@@ -972,7 +972,7 @@ func (dit *getIndexStatisticsTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 
-	collID, err := globalMetaCache.GetCollectionID(ctx, dit.GetDbName(), dit.CollectionName)
+	collID, err := dit.getMetaCache().GetCollectionID(ctx, dit.GetDbName(), dit.CollectionName)
 	if err != nil {
 		return err
 	}
@@ -981,7 +981,7 @@ func (dit *getIndexStatisticsTask) PreExecute(ctx context.Context) error {
 }
 
 func (dit *getIndexStatisticsTask) Execute(ctx context.Context) error {
-	schema, err := globalMetaCache.GetCollectionSchema(ctx, dit.GetDbName(), dit.GetCollectionName())
+	schema, err := dit.getMetaCache().GetCollectionSchema(ctx, dit.GetDbName(), dit.GetCollectionName())
 	if err != nil {
 		mlog.Error(ctx, "failed to get collection schema", mlog.String("collection_name", dit.GetCollectionName()), mlog.Err(err))
 		return merr.Wrap(err, "failed to get collection schema")
@@ -1080,7 +1080,7 @@ func (dit *dropIndexTask) OnEnqueue() error {
 }
 
 func (dit *dropIndexTask) PreExecute(ctx context.Context) error {
-	collID, err := globalMetaCache.GetCollectionID(ctx, dit.GetDbName(), dit.CollectionName)
+	collID, err := dit.getMetaCache().GetCollectionID(ctx, dit.GetDbName(), dit.CollectionName)
 	if err != nil {
 		return err
 	}
@@ -1176,7 +1176,7 @@ func (gibpt *getIndexBuildProgressTask) PreExecute(ctx context.Context) error {
 
 func (gibpt *getIndexBuildProgressTask) Execute(ctx context.Context) error {
 	collectionName := gibpt.CollectionName
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, gibpt.GetDbName(), collectionName)
+	collectionID, err := gibpt.getMetaCache().GetCollectionID(ctx, gibpt.GetDbName(), collectionName)
 	if err != nil { // err is not nil if collection not exists
 		return err
 	}
@@ -1263,7 +1263,7 @@ func (gist *getIndexStateTask) PreExecute(ctx context.Context) error {
 }
 
 func (gist *getIndexStateTask) Execute(ctx context.Context) error {
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, gist.GetDbName(), gist.CollectionName)
+	collectionID, err := gist.getMetaCache().GetCollectionID(ctx, gist.GetDbName(), gist.CollectionName)
 	if err != nil {
 		return err
 	}

--- a/internal/proxy/task_index_test.go
+++ b/internal/proxy/task_index_test.go
@@ -145,6 +145,7 @@ func TestDropIndexTask_PreExecute(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	dit.metaCache = mockCache
 	mockCache.On("GetCollectionID",
 		mock.Anything, // context.Context
 		mock.AnythingOfType("string"),

--- a/internal/proxy/task_index_test.go
+++ b/internal/proxy/task_index_test.go
@@ -68,7 +68,11 @@ func TestGetIndexStateTask_Execute(t *testing.T) {
 	ctx := context.Background()
 	queryCoord := NewMixCoordMock()
 
+	cache, err := initMetaCache(ctx, queryCoord)
+	assert.NoError(t, err)
+
 	gist := &getIndexStateTask{
+		baseTask: baseTask{metaCache: cache},
 		GetIndexStateRequest: &milvuspb.GetIndexStateRequest{
 			Base:           &commonpb.MsgBase{},
 			DbName:         dbName,
@@ -86,9 +90,6 @@ func TestGetIndexStateTask_Execute(t *testing.T) {
 	}
 
 	// failed to get collection id.
-	cache, err := initMetaCache(ctx, queryCoord)
-	assert.NoError(t, err)
-	t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 	assert.Error(t, gist.Execute(ctx))
 }
 

--- a/internal/proxy/task_index_test.go
+++ b/internal/proxy/task_index_test.go
@@ -86,8 +86,9 @@ func TestGetIndexStateTask_Execute(t *testing.T) {
 	}
 
 	// failed to get collection id.
-	err := InitMetaCache(ctx, queryCoord)
+	cache, err := initMetaCache(ctx, queryCoord)
 	assert.NoError(t, err)
+	t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 	assert.Error(t, gist.Execute(ctx))
 }
 
@@ -107,10 +108,9 @@ func TestDropIndexTask_PreExecute(t *testing.T) {
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("string"),
 	).Return(collectionID, nil)
-	globalMetaCache = mockCache
-
 	dit := dropIndexTask{
-		ctx: ctx,
+		baseTask: baseTask{metaCache: mockCache},
+		ctx:      ctx,
 		DropIndexRequest: &milvuspb.DropIndexRequest{
 			Base: &commonpb.MsgBase{
 				MsgType:   0,
@@ -140,7 +140,7 @@ func TestDropIndexTask_PreExecute(t *testing.T) {
 			mock.AnythingOfType("string"),
 			mock.AnythingOfType("string"),
 		).Return(UniqueID(0), errors.New("error"))
-		globalMetaCache = mockCache
+		dit.metaCache = mockCache
 		err := dit.PreExecute(ctx)
 		assert.Error(t, err)
 	})
@@ -150,8 +150,6 @@ func TestDropIndexTask_PreExecute(t *testing.T) {
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("string"),
 	).Return(collectionID, nil)
-	globalMetaCache = mockCache
-
 	t.Run("coll has been loaded", func(t *testing.T) {
 		qc := getMockQueryCoord()
 		qc.ExpectedCalls = nil
@@ -222,11 +220,9 @@ func TestCreateIndexTask_PreExecute(t *testing.T) {
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("int64"),
 	).Return(&collectionInfo{}, nil)
-
-	globalMetaCache = mockCache
-
 	cit := createIndexTask{
-		ctx: ctx,
+		baseTask: baseTask{metaCache: mockCache},
+		ctx:      ctx,
 		req: &milvuspb.CreateIndexRequest{
 			Base: &commonpb.MsgBase{
 				MsgType: commonpb.MsgType_CreateIndex,

--- a/internal/proxy/task_insert.go
+++ b/internal/proxy/task_insert.go
@@ -74,7 +74,7 @@ func (it *insertTask) EndTs() Timestamp {
 }
 
 func (it *insertTask) setChannels() error {
-	collID, err := globalMetaCache.GetCollectionID(it.ctx, it.insertMsg.GetDbName(), it.insertMsg.CollectionName)
+	collID, err := it.getMetaCache().GetCollectionID(it.ctx, it.insertMsg.GetDbName(), it.insertMsg.CollectionName)
 	if err != nil {
 		return err
 	}
@@ -128,14 +128,14 @@ func (it *insertTask) PreExecute(ctx context.Context) error {
 		return merr.WrapErrAsInputError(merr.WrapErrParameterTooLarge("insert request size exceeds maxInsertSize"))
 	}
 
-	collID, err := globalMetaCache.GetCollectionID(context.Background(), it.insertMsg.GetDbName(), collectionName)
+	collID, err := it.getMetaCache().GetCollectionID(context.Background(), it.insertMsg.GetDbName(), collectionName)
 	if err != nil {
 		log.Warn(ctx, "fail to get collection id", mlog.Err(err))
 		return err
 	}
 	it.collectionID = collID
 
-	colInfo, err := globalMetaCache.GetCollectionInfo(ctx, it.insertMsg.GetDbName(), collectionName, collID)
+	colInfo, err := it.getMetaCache().GetCollectionInfo(ctx, it.insertMsg.GetDbName(), collectionName, collID)
 	if err != nil {
 		log.Warn(ctx, "fail to get collection info", mlog.Err(err))
 		return err
@@ -153,7 +153,7 @@ func (it *insertTask) PreExecute(ctx context.Context) error {
 		}
 	}
 
-	schema, err := globalMetaCache.GetCollectionSchema(ctx, it.insertMsg.GetDbName(), collectionName)
+	schema, err := it.getMetaCache().GetCollectionSchema(ctx, it.insertMsg.GetDbName(), collectionName)
 	if err != nil {
 		log.Warn(ctx, "get collection schema from global meta cache failed", mlog.String("collectionName", collectionName), mlog.Err(err))
 		return err
@@ -257,7 +257,7 @@ func (it *insertTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 
-	partitionKeyMode, err := isPartitionKeyMode(ctx, it.insertMsg.GetDbName(), collectionName)
+	partitionKeyMode, err := isPartitionKeyMode(ctx, it.getMetaCache(), it.insertMsg.GetDbName(), collectionName)
 	if err != nil {
 		log.Warn(ctx, "check partition key mode failed", mlog.String("collectionName", collectionName), mlog.Err(err))
 		return err
@@ -274,7 +274,7 @@ func (it *insertTask) PreExecute(ctx context.Context) error {
 		// insert to _default partition
 		partitionTag := it.insertMsg.GetPartitionName()
 		if len(partitionTag) <= 0 {
-			pinfo, err := globalMetaCache.GetPartitionInfo(ctx, it.insertMsg.GetDbName(), collectionName, "")
+			pinfo, err := it.getMetaCache().GetPartitionInfo(ctx, it.insertMsg.GetDbName(), collectionName, "")
 			if err != nil {
 				log.Warn(ctx, "get partition info failed", mlog.String("collectionName", collectionName), mlog.Err(err))
 				return err

--- a/internal/proxy/task_insert_streaming.go
+++ b/internal/proxy/task_insert_streaming.go
@@ -33,7 +33,7 @@ func (it *insertTask) Execute(ctx context.Context) error {
 	tr := timerecord.NewTimeRecorder(fmt.Sprintf("proxy execute insert streaming %d", it.ID()))
 
 	collectionName := it.insertMsg.CollectionName
-	collID, err := globalMetaCache.GetCollectionID(it.ctx, it.insertMsg.GetDbName(), collectionName)
+	collID, err := it.getMetaCache().GetCollectionID(it.ctx, it.insertMsg.GetDbName(), collectionName)
 	if err != nil {
 		mlog.Warn(ctx, "fail to get collection id", mlog.Err(err))
 		return err
@@ -64,9 +64,9 @@ func (it *insertTask) Execute(ctx context.Context) error {
 	// start to repack insert data
 	var msgs []message.MutableMessage
 	if it.partitionKeys == nil {
-		msgs, err = repackInsertDataForStreamingService(it.TraceCtx(), channelNames, it.insertMsg, it.result, ez, it.schemaVersion, nil)
+		msgs, err = repackInsertDataForStreamingService(it.TraceCtx(), it.getMetaCache(), channelNames, it.insertMsg, it.result, ez, it.schemaVersion, nil)
 	} else {
-		msgs, err = repackInsertDataWithPartitionKeyForStreamingService(it.TraceCtx(), channelNames, it.insertMsg, it.result, it.partitionKeys, ez, it.schema, it.schemaVersion, nil)
+		msgs, err = repackInsertDataWithPartitionKeyForStreamingService(it.TraceCtx(), it.getMetaCache(), channelNames, it.insertMsg, it.result, it.partitionKeys, ez, it.schema, it.schemaVersion, nil)
 	}
 	if err != nil {
 		mlog.Warn(ctx, "assign segmentID and repack insert data failed", mlog.Err(err))
@@ -89,6 +89,7 @@ func (it *insertTask) Execute(ctx context.Context) error {
 
 func repackInsertDataForStreamingService(
 	ctx context.Context,
+	metaCache Cache,
 	channelNames []string,
 	insertMsg *msgstream.InsertMsg,
 	result *milvuspb.MutationResult,
@@ -104,7 +105,7 @@ func repackInsertDataForStreamingService(
 		return nil, err
 	}
 	partitionName := insertMsg.PartitionName
-	partitionID, err := globalMetaCache.GetPartitionID(ctx, insertMsg.GetDbName(), insertMsg.CollectionName, partitionName)
+	partitionID, err := metaCache.GetPartitionID(ctx, insertMsg.GetDbName(), insertMsg.CollectionName, partitionName)
 	if err != nil {
 		return nil, err
 	}
@@ -138,6 +139,7 @@ func repackInsertDataForStreamingService(
 
 func repackInsertDataWithPartitionKeyForStreamingService(
 	ctx context.Context,
+	metaCache Cache,
 	channelNames []string,
 	insertMsg *msgstream.InsertMsg,
 	result *milvuspb.MutationResult,
@@ -160,7 +162,7 @@ func repackInsertDataWithPartitionKeyForStreamingService(
 	if err != nil {
 		return nil, err
 	}
-	partitionNames, err := getDefaultPartitionsInPartitionKeyMode(ctx, insertMsg.GetDbName(), insertMsg.CollectionName)
+	partitionNames, err := getDefaultPartitionsInPartitionKeyMode(ctx, metaCache, insertMsg.GetDbName(), insertMsg.CollectionName)
 	if err != nil {
 		mlog.Warn(ctx, "get default partition names failed in partition key mode",
 			mlog.FieldCollectionName(insertMsg.CollectionName),
@@ -171,7 +173,7 @@ func repackInsertDataWithPartitionKeyForStreamingService(
 	// Get partition ids
 	partitionIDs := make(map[string]int64, 0)
 	for _, partitionName := range partitionNames {
-		partitionID, err := globalMetaCache.GetPartitionID(ctx, insertMsg.GetDbName(), insertMsg.CollectionName, partitionName)
+		partitionID, err := metaCache.GetPartitionID(ctx, insertMsg.GetDbName(), insertMsg.CollectionName, partitionName)
 		if err != nil {
 			mlog.Warn(ctx, "get partition id failed",
 				mlog.FieldCollectionName(insertMsg.CollectionName),

--- a/internal/proxy/task_insert_test.go
+++ b/internal/proxy/task_insert_test.go
@@ -97,6 +97,7 @@ func TestInsertTaskPreExecuteTextRequiresStorageV3(t *testing.T) {
 			},
 		},
 	}
+	task.metaCache = cache
 
 	err := task.PreExecute(context.Background())
 	assert.Error(t, err)
@@ -487,6 +488,7 @@ func TestInsertTask_KeepUserPK_WhenAllowInsertAutoIDTrue(t *testing.T) {
 		mock.Anything,
 		mock.Anything,
 	).Return(&collectionInfo{Schema: info}, nil)
+	task.metaCache = cache
 	err = task.PreExecute(context.Background())
 	assert.NoError(t, err)
 
@@ -662,6 +664,7 @@ func TestInsertTaskForSchemaMismatch(t *testing.T) {
 				},
 			}),
 		}, nil)
+		it.metaCache = mockCache
 		err := it.PreExecute(ctx)
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, merr.ErrCollectionSchemaMismatch)
@@ -731,6 +734,7 @@ func TestInsertTask_Namespace(t *testing.T) {
 					Version:        msgpb.InsertDataVersion_ColumnBased,
 				},
 			},
+			baseTask:    baseTask{metaCache: cache},
 			schema:      schemaWithNamespaceEnabled,
 			idAllocator: idAllocator,
 		}
@@ -749,6 +753,7 @@ func TestInsertTask_Namespace(t *testing.T) {
 				},
 			},
 			idAllocator: idAllocator,
+			baseTask:    baseTask{metaCache: cache},
 		}
 		err = it.PreExecute(context.Background())
 		assert.Error(t, err)
@@ -776,6 +781,7 @@ func TestInsertTask_Namespace(t *testing.T) {
 					Version:        msgpb.InsertDataVersion_ColumnBased,
 				},
 			},
+			baseTask:    baseTask{metaCache: cache},
 			schema:      schemaWithNamespaceDisabled,
 			idAllocator: idAllocator,
 		}
@@ -795,6 +801,7 @@ func TestInsertTask_Namespace(t *testing.T) {
 				},
 			},
 			idAllocator: idAllocator,
+			baseTask:    baseTask{metaCache: cache},
 		}
 		err = it.PreExecute(context.Background())
 		assert.Error(t, err)

--- a/internal/proxy/task_insert_test.go
+++ b/internal/proxy/task_insert_test.go
@@ -25,13 +25,6 @@ import (
 
 func TestRepackInsertDataForStreamingServicePreservesExplicitZeroSchemaVersion(t *testing.T) {
 	paramtable.Init()
-
-	oldCache := globalMetaCache
-	cache := NewMockCache(t)
-	cache.On("GetPartitionID", mock.Anything, "db", "coll", "_default").Return(int64(200), nil)
-	globalMetaCache = cache
-	defer func() { globalMetaCache = oldCache }()
-
 	insertMsg := &msgstream.InsertMsg{
 		InsertRequest: &msgpb.InsertRequest{
 			Base: &commonpb.MsgBase{
@@ -67,7 +60,9 @@ func TestRepackInsertDataForStreamingServicePreservesExplicitZeroSchemaVersion(t
 		},
 	}
 
-	msgs, err := repackInsertDataForStreamingService(context.Background(), []string{"ch"}, insertMsg, result, nil, 0, nil)
+	mockMetaCache := NewMockCache(t)
+	mockMetaCache.EXPECT().GetPartitionID(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(int64(0), nil)
+	msgs, err := repackInsertDataForStreamingService(context.Background(), mockMetaCache, []string{"ch"}, insertMsg, result, nil, 0, nil)
 	assert.NoError(t, err)
 	assert.Len(t, msgs, 1)
 
@@ -82,12 +77,6 @@ func TestInsertTaskPreExecuteTextRequiresStorageV3(t *testing.T) {
 	t.Cleanup(func() {
 		paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
 	})
-
-	oldCache := globalMetaCache
-	t.Cleanup(func() {
-		globalMetaCache = oldCache
-	})
-
 	const (
 		dbName         = "db"
 		collectionName = "text_collection"
@@ -97,8 +86,6 @@ func TestInsertTaskPreExecuteTextRequiresStorageV3(t *testing.T) {
 	cache.EXPECT().GetCollectionID(mock.Anything, dbName, collectionName).Return(int64(100), nil)
 	cache.EXPECT().GetCollectionInfo(mock.Anything, dbName, collectionName, int64(100)).Return(&collectionInfo{}, nil)
 	cache.EXPECT().GetCollectionSchema(mock.Anything, dbName, collectionName).Return(schema, nil)
-	globalMetaCache = cache
-
 	task := &insertTask{
 		ctx: context.Background(),
 		insertMsg: &BaseInsertTask{
@@ -373,11 +360,11 @@ func TestInsertTask(t *testing.T) {
 			mock.AnythingOfType("string"),
 			mock.AnythingOfType("string"),
 		).Return(collectionID, nil)
-		globalMetaCache = cache
 		chMgr := NewMockChannelsMgr(t)
 		chMgr.EXPECT().getChannels(mock.Anything).Return(channels, nil)
 		it := insertTask{
-			ctx: context.Background(),
+			baseTask: baseTask{metaCache: cache},
+			ctx:      context.Background(),
 			insertMsg: &msgstream.InsertMsg{
 				InsertRequest: &msgpb.InsertRequest{
 					CollectionName: collectionName,
@@ -500,9 +487,6 @@ func TestInsertTask_KeepUserPK_WhenAllowInsertAutoIDTrue(t *testing.T) {
 		mock.Anything,
 		mock.Anything,
 	).Return(&collectionInfo{Schema: info}, nil)
-
-	globalMetaCache = cache
-
 	err = task.PreExecute(context.Background())
 	assert.NoError(t, err)
 
@@ -648,16 +632,13 @@ func TestInsertTask_Function(t *testing.T) {
 		mock.Anything,
 		mock.Anything,
 	).Return(&collectionInfo{Schema: info}, nil)
-	globalMetaCache = cache
+	task.metaCache = cache
 	err = task.PreExecute(ctx)
 	assert.NoError(t, err)
 }
 
 func TestInsertTaskForSchemaMismatch(t *testing.T) {
-	cache := globalMetaCache
-	defer func() { globalMetaCache = cache }()
 	mockCache := NewMockCache(t)
-	globalMetaCache = mockCache
 	ctx := context.Background()
 
 	t.Run("schema ts mismatch", func(t *testing.T) {
@@ -690,7 +671,6 @@ func TestInsertTaskForSchemaMismatch(t *testing.T) {
 func TestInsertTask_Namespace(t *testing.T) {
 	paramtable.Init()
 	cache := NewMockCache(t)
-	globalMetaCache = cache
 	cache.On("GetDatabaseInfo",
 		mock.Anything,
 		mock.Anything,

--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -641,14 +641,14 @@ func (t *queryTask) CanSkipAllocTimestamp() bool {
 		}
 		consistencyLevel = t.request.GetConsistencyLevel()
 	} else {
-		collID, err := globalMetaCache.GetCollectionID(context.Background(), t.request.GetDbName(), t.request.GetCollectionName())
+		collID, err := t.getMetaCache().GetCollectionID(context.Background(), t.request.GetDbName(), t.request.GetCollectionName())
 		if err != nil { // err is not nil if collection not exists
 			mlog.Warn(t.ctx, "query task get collectionID failed, can't skip alloc timestamp",
 				mlog.String("collectionName", t.request.GetCollectionName()), mlog.Err(err))
 			return false
 		}
 
-		collectionInfo, err2 := globalMetaCache.GetCollectionInfo(context.Background(), t.request.GetDbName(), t.request.GetCollectionName(), collID)
+		collectionInfo, err2 := t.getMetaCache().GetCollectionInfo(context.Background(), t.request.GetDbName(), t.request.GetCollectionName(), collID)
 		if err2 != nil {
 			mlog.Warn(t.ctx, "query task get collection info failed, can't skip alloc timestamp",
 				mlog.String("collectionName", t.request.GetCollectionName()), mlog.Err(err))
@@ -676,14 +676,14 @@ func (t *queryTask) PreExecute(ctx context.Context) error {
 	}
 	log.Debug(ctx, "Validate collectionName.")
 
-	collID, err := globalMetaCache.GetCollectionID(ctx, t.request.GetDbName(), collectionName)
+	collID, err := t.getMetaCache().GetCollectionID(ctx, t.request.GetDbName(), collectionName)
 	if err != nil {
 		log.Warn(ctx, "Failed to get collection id.", mlog.String("collectionName", collectionName), mlog.Err(err))
 		return err
 	}
 	t.CollectionID = collID
 
-	colInfo, err := globalMetaCache.GetCollectionInfo(ctx, t.request.GetDbName(), collectionName, t.CollectionID)
+	colInfo, err := t.getMetaCache().GetCollectionInfo(ctx, t.request.GetDbName(), collectionName, t.CollectionID)
 	if err != nil {
 		log.Warn(ctx, "Failed to get collection info.", mlog.String("collectionName", collectionName),
 			mlog.Int64("collectionID", t.CollectionID), mlog.Err(err))
@@ -695,7 +695,7 @@ func (t *queryTask) PreExecute(ctx context.Context) error {
 	}
 	log.Debug(ctx, "Get collection ID by name", mlog.Int64("collectionID", t.CollectionID))
 
-	schema, err := globalMetaCache.GetCollectionSchema(ctx, t.request.GetDbName(), t.collectionName)
+	schema, err := t.getMetaCache().GetCollectionSchema(ctx, t.request.GetDbName(), t.collectionName)
 	if err != nil {
 		log.Warn(ctx, "get collection schema failed", mlog.Err(err))
 		return err
@@ -712,7 +712,7 @@ func (t *queryTask) PreExecute(ctx context.Context) error {
 		t.request.PartitionNames = partitionNames
 	}
 
-	t.partitionKeyMode, err = isPartitionKeyMode(ctx, t.request.GetDbName(), collectionName)
+	t.partitionKeyMode, err = isPartitionKeyMode(ctx, t.getMetaCache(), t.request.GetDbName(), collectionName)
 	if err != nil {
 		log.Warn(ctx, "check partition key mode failed", mlog.Int64("collectionID", t.CollectionID), mlog.Err(err))
 		return err
@@ -807,7 +807,7 @@ func (t *queryTask) PreExecute(ctx context.Context) error {
 	if !t.reQuery {
 		partitionNames := t.request.GetPartitionNames()
 		if namespacePartitionKeyMode(t.schema.CollectionSchema) && t.request.Namespace != nil {
-			hashedPartitionNames, err := assignNamespacePartitionKey(ctx, t.request.GetDbName(), t.request.CollectionName, t.request.Namespace)
+			hashedPartitionNames, err := assignNamespacePartitionKey(ctx, t.getMetaCache(), t.request.GetDbName(), t.request.CollectionName, t.request.Namespace)
 			if err != nil {
 				return err
 			}
@@ -819,14 +819,14 @@ func (t *queryTask) PreExecute(ctx context.Context) error {
 				return err
 			}
 			partitionKeys := exprutil.ParseKeys(expr, exprutil.PartitionKey)
-			hashedPartitionNames, err := assignPartitionKeys(ctx, t.request.GetDbName(), t.request.CollectionName, partitionKeys)
+			hashedPartitionNames, err := assignPartitionKeys(ctx, t.getMetaCache(), t.request.GetDbName(), t.request.CollectionName, partitionKeys)
 			if err != nil {
 				return err
 			}
 
 			partitionNames = append(partitionNames, hashedPartitionNames...)
 		}
-		t.PartitionIDs, err = getPartitionIDs(ctx, t.request.GetDbName(), t.request.CollectionName, partitionNames)
+		t.PartitionIDs, err = getPartitionIDs(ctx, t.getMetaCache(), t.request.GetDbName(), t.request.CollectionName, partitionNames)
 		if err != nil {
 			return err
 		}
@@ -849,7 +849,7 @@ func (t *queryTask) PreExecute(ctx context.Context) error {
 		t.Username = username
 	}
 
-	collectionInfo, err2 := globalMetaCache.GetCollectionInfo(ctx, t.request.GetDbName(), collectionName, t.CollectionID)
+	collectionInfo, err2 := t.getMetaCache().GetCollectionInfo(ctx, t.request.GetDbName(), collectionName, t.CollectionID)
 	if err2 != nil {
 		log.Warn(ctx, "Proxy::queryTask::PreExecute failed to GetCollectionInfo from cache",
 			mlog.String("collectionName", collectionName), mlog.Int64("collectionID", t.CollectionID),

--- a/internal/proxy/task_query_namespace_test.go
+++ b/internal/proxy/task_query_namespace_test.go
@@ -53,8 +53,7 @@ func expectedNamespacePartitionID(namespace string, partitionNames []string, par
 
 func TestQueryTask_PlanNamespace_AfterPreExecute(t *testing.T) {
 	mockey.PatchConvey("TestQueryTask_PlanNamespace_AfterPreExecute", t, func() {
-		// Setup global meta cache and common mocks
-		globalMetaCache = &MetaCache{}
+		cache := &MetaCache{}
 		mockey.Mock((*MetaCache).GetCollectionID).Return(int64(1001), nil).Build()
 		mockey.Mock((*MetaCache).GetCollectionInfo).Return(&collectionInfo{UpdateTimestamp: 12345, ConsistencyLevel: commonpb.ConsistencyLevel_Strong}, nil).Build()
 		mockey.Mock(isPartitionKeyMode).Return(false, nil).Build()
@@ -85,6 +84,7 @@ func TestQueryTask_PlanNamespace_AfterPreExecute(t *testing.T) {
 		}).Build()
 
 		task := &queryTask{
+			baseTask:        baseTask{metaCache: cache},
 			Condition:       NewTaskCondition(context.Background()),
 			RetrieveRequest: &internalpb.RetrieveRequest{QueryLabel: "query", Base: &commonpb.MsgBase{MsgType: commonpb.MsgType_Retrieve}},
 			ctx:             context.Background(),
@@ -115,7 +115,7 @@ func TestQueryTask_PlanNamespace_AfterPreExecute(t *testing.T) {
 
 func TestQueryTask_NamespaceSetsPartitionIDs(t *testing.T) {
 	mockey.PatchConvey("TestQueryTask_NamespaceSetsPartitionIDs", t, func() {
-		globalMetaCache = &MetaCache{}
+		cache := &MetaCache{}
 
 		partitionNames := []string{"_default_0", "_default_1"}
 		partitionIDs := map[string]int64{"_default_0": 101, "_default_1": 102}
@@ -149,6 +149,7 @@ func TestQueryTask_NamespaceSetsPartitionIDs(t *testing.T) {
 		for _, ns := range namespaces {
 			namespace := ns
 			task := &queryTask{
+				baseTask:        baseTask{metaCache: cache},
 				Condition:       NewTaskCondition(context.Background()),
 				RetrieveRequest: &internalpb.RetrieveRequest{QueryLabel: "query", Base: &commonpb.MsgBase{MsgType: commonpb.MsgType_Retrieve}},
 				ctx:             context.Background(),

--- a/internal/proxy/task_query_test.go
+++ b/internal/proxy/task_query_test.go
@@ -82,8 +82,9 @@ func TestQueryTask_all(t *testing.T) {
 	mgr.EXPECT().InvalidateShardLeaderCache(mock.Anything).Return().Maybe()
 	lb := shardclient.NewLBPolicyImpl(mgr)
 
-	err = InitMetaCache(ctx, qc)
+	cache, err := initMetaCache(ctx, qc)
 	assert.NoError(t, err)
+	t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 	fieldName2Types := map[string]schemapb.DataType{
 		testBoolField:     schemapb.DataType_Bool,
@@ -116,7 +117,7 @@ func TestQueryTask_all(t *testing.T) {
 	require.NoError(t, createColT.PreExecute(ctx))
 	require.NoError(t, createColT.Execute(ctx))
 	require.NoError(t, createColT.PostExecute(ctx))
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, GetCurDBNameFromContextOrDefault(ctx), collectionName)
+	collectionID, err := cache.GetCollectionID(ctx, GetCurDBNameFromContextOrDefault(ctx), collectionName)
 	assert.NoError(t, err)
 
 	status, err := qc.LoadCollection(ctx, &querypb.LoadCollectionRequest{
@@ -1772,10 +1773,10 @@ func TestQueryTask_CanSkipAllocTimestamp(t *testing.T) {
 	collName := "test_skip_alloc_timestamp"
 	collID := UniqueID(111)
 	mockMetaCache := NewMockCache(t)
-	globalMetaCache = mockMetaCache
 
 	t.Run("default consistency level", func(t *testing.T) {
 		qt := &queryTask{
+			baseTask: baseTask{metaCache: mockMetaCache},
 			request: &milvuspb.QueryRequest{
 				Base:                  nil,
 				DbName:                dbName,
@@ -1818,6 +1819,7 @@ func TestQueryTask_CanSkipAllocTimestamp(t *testing.T) {
 			}, nil).Times(3)
 
 		qt := &queryTask{
+			baseTask: baseTask{metaCache: mockMetaCache},
 			request: &milvuspb.QueryRequest{
 				Base:                  nil,
 				DbName:                dbName,
@@ -1841,6 +1843,7 @@ func TestQueryTask_CanSkipAllocTimestamp(t *testing.T) {
 
 	t.Run("legacy_guarantee_ts", func(t *testing.T) {
 		qt := &queryTask{
+			baseTask: baseTask{metaCache: mockMetaCache},
 			request: &milvuspb.QueryRequest{
 				Base:                  nil,
 				DbName:                dbName,
@@ -1869,6 +1872,7 @@ func TestQueryTask_CanSkipAllocTimestamp(t *testing.T) {
 			nil, errors.New("mock error")).Once()
 
 		qt := &queryTask{
+			baseTask: baseTask{metaCache: mockMetaCache},
 			request: &milvuspb.QueryRequest{
 				Base:                  nil,
 				DbName:                dbName,
@@ -1893,6 +1897,7 @@ func TestQueryTask_CanSkipAllocTimestamp(t *testing.T) {
 		assert.False(t, skip)
 
 		qt2 := &queryTask{
+			baseTask: baseTask{metaCache: mockMetaCache},
 			request: &milvuspb.QueryRequest{
 				Base:                  nil,
 				DbName:                dbName,

--- a/internal/proxy/task_query_test.go
+++ b/internal/proxy/task_query_test.go
@@ -84,7 +84,6 @@ func TestQueryTask_all(t *testing.T) {
 
 	cache, err := initMetaCache(ctx, qc)
 	assert.NoError(t, err)
-	t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 	fieldName2Types := map[string]schemapb.DataType{
 		testBoolField:     schemapb.DataType_Bool,
@@ -132,6 +131,7 @@ func TestQueryTask_all(t *testing.T) {
 
 	t.Run("test query task parameters", func(t *testing.T) {
 		task := &queryTask{
+			baseTask:  baseTask{metaCache: cache},
 			Condition: NewTaskCondition(ctx),
 			RetrieveRequest: &internalpb.RetrieveRequest{
 				QueryLabel: "query",
@@ -279,6 +279,7 @@ func TestQueryTask_all(t *testing.T) {
 
 	t.Run("test query for iterator", func(t *testing.T) {
 		qt := &queryTask{
+			baseTask:  baseTask{metaCache: cache},
 			Condition: NewTaskCondition(ctx),
 			RetrieveRequest: &internalpb.RetrieveRequest{
 				QueryLabel: "query",
@@ -331,6 +332,7 @@ func TestQueryTask_all(t *testing.T) {
 
 		// next page query task
 		qt = &queryTask{
+			baseTask:  baseTask{metaCache: cache},
 			Condition: NewTaskCondition(ctx),
 			RetrieveRequest: &internalpb.RetrieveRequest{
 				QueryLabel: "query",
@@ -399,6 +401,7 @@ func TestQueryTask_all(t *testing.T) {
 				})
 			}
 			task := &queryTask{
+				baseTask:  baseTask{metaCache: cache},
 				Condition: NewTaskCondition(ctx),
 				RetrieveRequest: &internalpb.RetrieveRequest{
 					QueryLabel: "query",
@@ -498,6 +501,7 @@ func TestQueryTask_all(t *testing.T) {
 	t.Run("test order by without limit", func(t *testing.T) {
 		// ORDER BY without explicit limit should fail with an error
 		task := &queryTask{
+			baseTask:  baseTask{metaCache: cache},
 			Condition: NewTaskCondition(ctx),
 			RetrieveRequest: &internalpb.RetrieveRequest{
 				Base: &commonpb.MsgBase{
@@ -540,6 +544,7 @@ func TestQueryTask_all(t *testing.T) {
 	t.Run("test order by with limit succeeds", func(t *testing.T) {
 		// ORDER BY with explicit limit should pass the validation
 		task := &queryTask{
+			baseTask:  baseTask{metaCache: cache},
 			Condition: NewTaskCondition(ctx),
 			RetrieveRequest: &internalpb.RetrieveRequest{
 				Base: &commonpb.MsgBase{

--- a/internal/proxy/task_scheduler.go
+++ b/internal/proxy/task_scheduler.go
@@ -211,7 +211,7 @@ func (queue *baseTaskQueue) Enqueue(t task) error {
 	var id UniqueID
 	if t.CanSkipAllocTimestamp() {
 		ts = tsoutil.ComposeTS(time.Now().UnixMilli(), 0)
-		id, err = globalMetaCache.AllocID(t.TraceCtx())
+		id, err = t.getMetaCache().AllocID(t.TraceCtx())
 		if err != nil {
 			return err
 		}

--- a/internal/proxy/task_scheduler_test.go
+++ b/internal/proxy/task_scheduler_test.go
@@ -571,7 +571,6 @@ func TestTaskScheduler_concurrentPushAndPop(t *testing.T) {
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("string"),
 	).Return(collectionID, nil)
-	globalMetaCache = cache
 	tsoAllocatorIns := newMockTsoAllocator()
 	scheduler, err := newTaskScheduler(context.Background(), tsoAllocatorIns)
 	assert.NoError(t, err)
@@ -581,7 +580,8 @@ func TestTaskScheduler_concurrentPushAndPop(t *testing.T) {
 		chMgr := NewMockChannelsMgr(t)
 		chMgr.EXPECT().getChannels(mock.Anything).Return(channels, nil)
 		it := &insertTask{
-			ctx: context.Background(),
+			baseTask: baseTask{metaCache: cache},
+			ctx:      context.Background(),
 			insertMsg: &msgstream.InsertMsg{
 				InsertRequest: &msgpb.InsertRequest{
 					Base:           &commonpb.MsgBase{},
@@ -611,7 +611,6 @@ func TestTaskScheduler_SkipAllocTimestamp(t *testing.T) {
 	collName := "test_skip_alloc_timestamp"
 	collID := UniqueID(111)
 	mockMetaCache := NewMockCache(t)
-	globalMetaCache = mockMetaCache
 
 	tsoAllocatorIns := newMockTsoAllocator()
 	queue := newBaseTaskQueue(tsoAllocatorIns)
@@ -630,6 +629,7 @@ func TestTaskScheduler_SkipAllocTimestamp(t *testing.T) {
 
 	t.Run("query", func(t *testing.T) {
 		qt := &queryTask{
+			baseTask: baseTask{metaCache: mockMetaCache},
 			RetrieveRequest: &internalpb.RetrieveRequest{
 				QueryLabel: "query",
 				Base:       &commonpb.MsgBase{},
@@ -647,6 +647,7 @@ func TestTaskScheduler_SkipAllocTimestamp(t *testing.T) {
 
 	t.Run("search", func(t *testing.T) {
 		st := &searchTask{
+			baseTask: baseTask{metaCache: mockMetaCache},
 			SearchRequest: &internalpb.SearchRequest{
 				Base: &commonpb.MsgBase{},
 			},
@@ -664,6 +665,7 @@ func TestTaskScheduler_SkipAllocTimestamp(t *testing.T) {
 	mockMetaCache.EXPECT().AllocID(mock.Anything).Return(0, errors.New("mock error")).Once()
 	t.Run("failed", func(t *testing.T) {
 		st := &searchTask{
+			baseTask: baseTask{metaCache: mockMetaCache},
 			SearchRequest: &internalpb.SearchRequest{
 				Base: &commonpb.MsgBase{},
 			},

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -138,14 +138,14 @@ func (t *searchTask) CanSkipAllocTimestamp() bool {
 		}
 		consistencyLevel = t.request.GetConsistencyLevel()
 	} else {
-		collID, err := globalMetaCache.GetCollectionID(context.Background(), t.request.GetDbName(), t.request.GetCollectionName())
+		collID, err := t.getMetaCache().GetCollectionID(context.Background(), t.request.GetDbName(), t.request.GetCollectionName())
 		if err != nil { // err is not nil if collection not exists
 			mlog.Warn(t.ctx, "search task get collectionID failed, can't skip alloc timestamp",
 				mlog.String("collectionName", t.request.GetCollectionName()), mlog.Err(err))
 			return false
 		}
 
-		collectionInfo, err2 := globalMetaCache.GetCollectionInfo(context.Background(), t.request.GetDbName(), t.request.GetCollectionName(), collID)
+		collectionInfo, err2 := t.getMetaCache().GetCollectionInfo(context.Background(), t.request.GetDbName(), t.request.GetCollectionName(), collID)
 		if err2 != nil {
 			mlog.Warn(t.ctx, "search task get collection info failed, can't skip alloc timestamp",
 				mlog.String("collectionName", t.request.GetCollectionName()), mlog.Err(err))
@@ -166,7 +166,7 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 
 	collectionName := t.request.CollectionName
 	t.collectionName = collectionName
-	collID, err := globalMetaCache.GetCollectionID(ctx, t.request.GetDbName(), collectionName)
+	collID, err := t.getMetaCache().GetCollectionID(ctx, t.request.GetDbName(), collectionName)
 	if err != nil { // err is not nil if collection not exists
 		return err
 	}
@@ -174,7 +174,7 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 	t.DbID = 0 // todo
 	t.CollectionID = collID
 	log := mlog.With(mlog.Int64("collID", collID), mlog.String("collName", collectionName))
-	t.schema, err = globalMetaCache.GetCollectionSchema(ctx, t.request.GetDbName(), collectionName)
+	t.schema, err = t.getMetaCache().GetCollectionSchema(ctx, t.request.GetDbName(), collectionName)
 	if err != nil {
 		log.Warn(ctx, "get collection schema failed", mlog.Err(err))
 		return err
@@ -183,7 +183,7 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 
-	collectionInfo, err2 := globalMetaCache.GetCollectionInfo(ctx, t.request.GetDbName(), collectionName, t.CollectionID)
+	collectionInfo, err2 := t.getMetaCache().GetCollectionInfo(ctx, t.request.GetDbName(), collectionName, t.CollectionID)
 	if err2 != nil {
 		log.Warn(ctx, "Proxy::searchTask::PreExecute failed to GetCollectionInfo from cache",
 			mlog.String("collectionName", collectionName), mlog.Int64("collectionID", t.CollectionID), mlog.Err(err2))
@@ -192,7 +192,7 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 	t.largeTopKEnabled = collectionInfo.QueryMode == common.QueryModeLargeTopK
 	t.partitionKeyIsolation = collectionInfo.PartitionKeyIsolation
 
-	t.partitionKeyMode, err = isPartitionKeyMode(ctx, t.request.GetDbName(), collectionName)
+	t.partitionKeyMode, err = isPartitionKeyMode(ctx, t.getMetaCache(), t.request.GetDbName(), collectionName)
 	if err != nil {
 		log.Warn(ctx, "is partition key mode failed", mlog.Err(err))
 		return err
@@ -214,7 +214,7 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 
 	if !t.partitionKeyMode && len(t.request.GetPartitionNames()) > 0 {
 		// translate partition name to partition ids. Use regex-pattern to match partition name.
-		t.PartitionIDs, err = getPartitionIDs(ctx, t.request.GetDbName(), collectionName, t.request.GetPartitionNames())
+		t.PartitionIDs, err = getPartitionIDs(ctx, t.getMetaCache(), t.request.GetDbName(), collectionName, t.request.GetPartitionNames())
 		if err != nil {
 			log.Warn(ctx, "failed to get partition ids", mlog.Err(err))
 			return err
@@ -1190,13 +1190,13 @@ func (t *searchTask) tryGeneratePlan(params []*commonpb.KeyValuePair, dsl string
 
 func (t *searchTask) tryParsePartitionIDsFromPlan(plan *planpb.PlanNode) ([]int64, error) {
 	if namespacePartitionKeyMode(t.schema.CollectionSchema) && t.request.Namespace != nil {
-		hashedPartitionNames, err := assignNamespacePartitionKey(t.ctx, t.request.GetDbName(), t.collectionName, t.request.Namespace)
+		hashedPartitionNames, err := assignNamespacePartitionKey(t.ctx, t.getMetaCache(), t.request.GetDbName(), t.collectionName, t.request.Namespace)
 		if err != nil {
 			mlog.Warn(t.ctx, "failed to assign namespace partition key", mlog.Err(err))
 			return nil, err
 		}
 		if len(hashedPartitionNames) > 0 {
-			PartitionIDs, err2 := getPartitionIDs(t.ctx, t.request.GetDbName(), t.collectionName, hashedPartitionNames)
+			PartitionIDs, err2 := getPartitionIDs(t.ctx, t.getMetaCache(), t.request.GetDbName(), t.collectionName, hashedPartitionNames)
 			if err2 != nil {
 				mlog.Warn(t.ctx, "failed to get namespace partition ids", mlog.Err(err2))
 				return nil, err2
@@ -1212,7 +1212,7 @@ func (t *searchTask) tryParsePartitionIDsFromPlan(plan *planpb.PlanNode) ([]int6
 		return nil, err
 	}
 	partitionKeys := exprutil.ParseKeys(expr, exprutil.PartitionKey)
-	hashedPartitionNames, err := assignPartitionKeys(t.ctx, t.request.GetDbName(), t.collectionName, partitionKeys)
+	hashedPartitionNames, err := assignPartitionKeys(t.ctx, t.getMetaCache(), t.request.GetDbName(), t.collectionName, partitionKeys)
 	if err != nil {
 		mlog.Warn(t.ctx, "failed to assign partition keys", mlog.Err(err))
 		return nil, err
@@ -1220,7 +1220,7 @@ func (t *searchTask) tryParsePartitionIDsFromPlan(plan *planpb.PlanNode) ([]int6
 
 	if len(hashedPartitionNames) > 0 {
 		// translate partition name to partition ids. Use regex-pattern to match partition name.
-		PartitionIDs, err2 := getPartitionIDs(t.ctx, t.request.GetDbName(), t.collectionName, hashedPartitionNames)
+		PartitionIDs, err2 := getPartitionIDs(t.ctx, t.getMetaCache(), t.request.GetDbName(), t.collectionName, hashedPartitionNames)
 		if err2 != nil {
 			mlog.Warn(t.ctx, "failed to get partition ids", mlog.Err(err2))
 			return nil, err2
@@ -1516,7 +1516,6 @@ func (t *searchTask) searchShard(ctx context.Context, nodeID int64, qn types.Que
 	result, err = qn.Search(ctx, req)
 	if err != nil {
 		log.Warn(ctx, "QueryNode search return error", mlog.Err(err))
-		// globalMetaCache.DeprecateShardCache(t.request.GetDbName(), t.collectionName)
 		t.shardClientMgr.InvalidateShardLeaderCache([]int64{t.GetCollectionID()})
 		return err
 	}

--- a/internal/proxy/task_search_namespace_test.go
+++ b/internal/proxy/task_search_namespace_test.go
@@ -20,8 +20,7 @@ import (
 
 func TestSearchTask_PlanNamespace_AfterPreExecute(t *testing.T) {
 	mockey.PatchConvey("TestSearchTask_PlanNamespace_AfterPreExecute", t, func() {
-		// Setup global meta cache and common mocks
-		globalMetaCache = &MetaCache{}
+		cache := &MetaCache{}
 		mockey.Mock((*MetaCache).GetCollectionID).Return(int64(1001), nil).Build()
 		mockey.Mock((*MetaCache).GetCollectionInfo).Return(&collectionInfo{UpdateTimestamp: 12345, ConsistencyLevel: commonpb.ConsistencyLevel_Strong}, nil).Build()
 		mockey.Mock(isPartitionKeyMode).Return(false, nil).Build()
@@ -53,6 +52,7 @@ func TestSearchTask_PlanNamespace_AfterPreExecute(t *testing.T) {
 
 		// Build task
 		task := &searchTask{
+			baseTask:      baseTask{metaCache: cache},
 			Condition:     NewTaskCondition(context.Background()),
 			SearchRequest: &internalpb.SearchRequest{Base: &commonpb.MsgBase{MsgType: commonpb.MsgType_Search}},
 			ctx:           context.Background(),
@@ -72,7 +72,7 @@ func TestSearchTask_PlanNamespace_AfterPreExecute(t *testing.T) {
 
 func TestSearchTask_NamespaceSetsPartitionIDs(t *testing.T) {
 	mockey.PatchConvey("TestSearchTask_NamespaceSetsPartitionIDs", t, func() {
-		globalMetaCache = &MetaCache{}
+		cache := &MetaCache{}
 
 		partitionNames := []string{"_default_0", "_default_1"}
 		partitionIDs := map[string]int64{"_default_0": 101, "_default_1": 102}
@@ -105,6 +105,7 @@ func TestSearchTask_NamespaceSetsPartitionIDs(t *testing.T) {
 		for _, ns := range namespaces {
 			namespace := ns
 			task := &searchTask{
+				baseTask:      baseTask{metaCache: cache},
 				Condition:     NewTaskCondition(context.Background()),
 				SearchRequest: &internalpb.SearchRequest{Base: &commonpb.MsgBase{MsgType: commonpb.MsgType_Search}},
 				ctx:           context.Background(),

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -87,11 +87,6 @@ func TestSearchTaskPreExecuteTextRequiresStorageV3(t *testing.T) {
 		paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
 	})
 
-	oldCache := globalMetaCache
-	t.Cleanup(func() {
-		globalMetaCache = oldCache
-	})
-
 	const (
 		dbName         = "db"
 		collectionName = "text_collection"
@@ -101,7 +96,7 @@ func TestSearchTaskPreExecuteTextRequiresStorageV3(t *testing.T) {
 	cache := NewMockCache(t)
 	cache.EXPECT().GetCollectionID(mock.Anything, dbName, collectionName).Return(collectionID, nil)
 	cache.EXPECT().GetCollectionSchema(mock.Anything, dbName, collectionName).Return(schema, nil)
-	globalMetaCache = cache
+	t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 	task := &searchTask{
 		ctx:           context.Background(),
@@ -121,8 +116,6 @@ func TestSearchTaskPreExecuteTextRequiresStorageV3(t *testing.T) {
 
 func TestSearchTaskPreExecuteUsesTimezoneForTimestamptzFilter(t *testing.T) {
 	mockey.PatchConvey("TestSearchTaskPreExecuteUsesTimezoneForTimestamptzFilter", t, func() {
-		globalMetaCache = &MetaCache{}
-
 		const (
 			dbName         = "db"
 			collectionName = "timestamptz_collection"
@@ -195,11 +188,13 @@ func TestSearchTask_PostExecute(t *testing.T) {
 
 	require.NoError(t, err)
 
-	err = InitMetaCache(ctx, qc)
+	cache, err := initMetaCache(ctx, qc)
 	require.NoError(t, err)
+	t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 	getSearchTask := func(t *testing.T, collName string) *searchTask {
 		task := &searchTask{
+			baseTask:       baseTask{metaCache: cache},
 			ctx:            ctx,
 			collectionName: collName,
 			SearchRequest: &internalpb.SearchRequest{
@@ -795,9 +790,6 @@ func createCollWithFields(t *testing.T, collName string, rc types.MixCoordClient
 	require.NoError(t, createColT.Execute(ctx))
 	require.NoError(t, createColT.PostExecute(ctx))
 
-	_, err = globalMetaCache.GetCollectionID(ctx, GetCurDBNameFromContextOrDefault(ctx), collName)
-	assert.NoError(t, err)
-
 	fieldNameId := make(map[string]int64)
 	for _, field := range schema.Fields {
 		fieldNameId[field.Name] = field.FieldID
@@ -902,11 +894,13 @@ func TestSearchTask_PreExecute(t *testing.T) {
 		ctx = context.TODO()
 	)
 	require.NoError(t, err)
-	err = InitMetaCache(ctx, qc)
+	cache, err := initMetaCache(ctx, qc)
 	require.NoError(t, err)
+	t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 	getSearchTask := func(t *testing.T, collName string) *searchTask {
 		task := &searchTask{
+			baseTask:       baseTask{metaCache: cache},
 			ctx:            ctx,
 			collectionName: collName,
 			SearchRequest:  &internalpb.SearchRequest{},
@@ -924,6 +918,7 @@ func TestSearchTask_PreExecute(t *testing.T) {
 
 	getSearchTaskWithNq := func(t *testing.T, collName string, nq int64) *searchTask {
 		task := &searchTask{
+			baseTask:       baseTask{metaCache: cache},
 			ctx:            ctx,
 			collectionName: collName,
 			SearchRequest:  &internalpb.SearchRequest{},
@@ -954,6 +949,7 @@ func TestSearchTask_PreExecute(t *testing.T) {
 			},
 		}
 		task := &searchTask{
+			baseTask:       baseTask{metaCache: cache},
 			ctx:            ctx,
 			collectionName: collName,
 			SearchRequest:  &internalpb.SearchRequest{},
@@ -1154,7 +1150,7 @@ func TestSearchTask_PreExecute(t *testing.T) {
 		st.request.UseDefaultConsistency = false
 		st.request.ConsistencyLevel = commonpb.ConsistencyLevel_Eventually
 
-		collInfo, err := globalMetaCache.GetCollectionInfo(ctx, "", collName, 0)
+		collInfo, err := cache.GetCollectionInfo(ctx, "", collName, 0)
 		assert.NoError(t, err)
 
 		assert.NoError(t, st.PreExecute(ctx))
@@ -1481,8 +1477,9 @@ func TestSearchTask_WithFunctions(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	err = InitMetaCache(ctx, qc)
+	cache, err := initMetaCache(ctx, qc)
 	require.NoError(t, err)
+	t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 	getSearchTask := func(t *testing.T, collName string, data []string, withRerank bool) *searchTask {
 		placeholderValue := &commonpb.PlaceholderValue{
@@ -1510,6 +1507,7 @@ func TestSearchTask_WithFunctions(t *testing.T) {
 		}
 
 		task := &searchTask{
+			baseTask:       baseTask{metaCache: cache},
 			ctx:            ctx,
 			collectionName: collectionName,
 			SearchRequest: &internalpb.SearchRequest{
@@ -1542,13 +1540,13 @@ func TestSearchTask_WithFunctions(t *testing.T) {
 	}
 
 	collectionID := UniqueID(1000)
-	cache := NewMockCache(t)
+	mockCache := NewMockCache(t)
 	info := mustNewSchemaInfo(schema)
-	cache.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(collectionID, nil).Maybe()
-	cache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(info, nil).Maybe()
-	cache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"_default": UniqueID(1)}, nil).Maybe()
-	cache.EXPECT().GetCollectionInfo(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&collectionInfo{}, nil).Maybe()
-	globalMetaCache = cache
+	mockCache.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(collectionID, nil).Maybe()
+	mockCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(info, nil).Maybe()
+	mockCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"_default": UniqueID(1)}, nil).Maybe()
+	mockCache.EXPECT().GetCollectionInfo(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&collectionInfo{}, nil).Maybe()
+	t.Cleanup(mockBaseTaskMetaCacheForTest(mockCache))
 
 	{
 		task := getSearchTask(t, collectionName, []string{"sentence"}, false)
@@ -1707,8 +1705,9 @@ func TestSearchTaskV2_Execute(t *testing.T) {
 		collectionName = t.Name() + funcutil.GenRandomStr()
 	)
 
-	err = InitMetaCache(ctx, qc)
+	cache, err := initMetaCache(ctx, qc)
 	require.NoError(t, err)
+	t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 	defer qc.Close()
 
@@ -1775,7 +1774,7 @@ func TestSearchTaskWithInvalidRoundDecimal(t *testing.T) {
 	//
 	// ctx := context.Background()
 	//
-	// err = InitMetaCache(ctx, rc)
+	// err = initMetaCache(ctx, rc)
 	// assert.NoError(t, err)
 	//
 	// shardsNum := int32(2)
@@ -2017,7 +2016,7 @@ func TestSearchTaskV2_all(t *testing.T) {
 	//
 	// ctx := context.Background()
 	//
-	// err = InitMetaCache(ctx, rc)
+	// err = initMetaCache(ctx, rc)
 	// assert.NoError(t, err)
 	//
 	// shardsNum := int32(2)
@@ -2261,7 +2260,7 @@ func TestSearchTaskV2_7803_reduce(t *testing.T) {
 	//
 	// ctx := context.Background()
 	//
-	// err = InitMetaCache(ctx, rc)
+	// err = initMetaCache(ctx, rc)
 	// assert.NoError(t, err)
 	//
 	// shardsNum := int32(2)
@@ -3386,8 +3385,9 @@ func TestSearchTask_ErrExecute(t *testing.T) {
 
 	defer rc.Close()
 
-	err = InitMetaCache(ctx, rc)
+	cache, err := initMetaCache(ctx, rc)
 	assert.NoError(t, err)
+	t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 	fieldName2Types := map[string]schemapb.DataType{
 		testBoolField:     schemapb.DataType_Bool,
@@ -3421,7 +3421,7 @@ func TestSearchTask_ErrExecute(t *testing.T) {
 	require.NoError(t, createColT.Execute(ctx))
 	require.NoError(t, createColT.PostExecute(ctx))
 
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, GetCurDBNameFromContextOrDefault(ctx), collectionName)
+	collectionID, err := cache.GetCollectionID(ctx, GetCurDBNameFromContextOrDefault(ctx), collectionName)
 	assert.NoError(t, err)
 
 	successStatus := &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success}
@@ -4601,7 +4601,7 @@ func TestSearchTask_Requery(t *testing.T) {
 	cache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"_default": UniqueID(1)}, nil).Maybe()
 	cache.EXPECT().GetCollectionInfo(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&collectionInfo{}, nil).Maybe()
 	cache.EXPECT().GetDatabaseInfo(mock.Anything, mock.Anything).Return(&databaseInfo{}, nil).Maybe()
-	globalMetaCache = cache
+	t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 	mgr := shardclient.NewMockShardClientManager(t)
 	// mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(qn, nil).Maybe()
@@ -4889,11 +4889,9 @@ type GetPartitionIDsSuite struct {
 
 func (s *GetPartitionIDsSuite) SetupTest() {
 	s.mockMetaCache = NewMockCache(s.T())
-	globalMetaCache = s.mockMetaCache
 }
 
 func (s *GetPartitionIDsSuite) TearDownTest() {
-	globalMetaCache = nil
 	Params.Reset(Params.ProxyCfg.PartitionNameRegexp.Key)
 }
 
@@ -4906,7 +4904,7 @@ func (s *GetPartitionIDsSuite) TestPlainPartitionNames() {
 	s.mockMetaCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).
 		Return(map[string]int64{"partition_1": 100, "partition_2": 200}, nil).Once()
 
-	result, err := getPartitionIDs(ctx, "default_db", "test_collection", []string{"partition_1", "partition_2"})
+	result, err := getPartitionIDs(ctx, s.mockMetaCache, "default_db", "test_collection", []string{"partition_1", "partition_2"})
 
 	s.NoError(err)
 	s.ElementsMatch([]int64{100, 200}, result)
@@ -4914,12 +4912,12 @@ func (s *GetPartitionIDsSuite) TestPlainPartitionNames() {
 	s.mockMetaCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).
 		Return(map[string]int64{"partition_1": 100}, nil).Once()
 
-	_, err = getPartitionIDs(ctx, "default_db", "test_collection", []string{"partition_1", "partition_2"})
+	_, err = getPartitionIDs(ctx, s.mockMetaCache, "default_db", "test_collection", []string{"partition_1", "partition_2"})
 	s.Error(err)
 
 	s.mockMetaCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, errors.New("mocked")).Once()
-	_, err = getPartitionIDs(ctx, "default_db", "test_collection", []string{"partition_1", "partition_2"})
+	_, err = getPartitionIDs(ctx, s.mockMetaCache, "default_db", "test_collection", []string{"partition_1", "partition_2"})
 	s.Error(err)
 }
 
@@ -4932,7 +4930,7 @@ func (s *GetPartitionIDsSuite) TestRegexpPartitionNames() {
 	s.mockMetaCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).
 		Return(map[string]int64{"partition_1": 100, "partition_2": 200}, nil).Once()
 
-	result, err := getPartitionIDs(ctx, "default_db", "test_collection", []string{"partition_1", "partition_2"})
+	result, err := getPartitionIDs(ctx, s.mockMetaCache, "default_db", "test_collection", []string{"partition_1", "partition_2"})
 
 	s.NoError(err)
 	s.ElementsMatch([]int64{100, 200}, result)
@@ -4940,7 +4938,7 @@ func (s *GetPartitionIDsSuite) TestRegexpPartitionNames() {
 	s.mockMetaCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).
 		Return(map[string]int64{"partition_1": 100, "partition_2": 200}, nil).Once()
 
-	result, err = getPartitionIDs(ctx, "default_db", "test_collection", []string{"partition_.*"})
+	result, err = getPartitionIDs(ctx, s.mockMetaCache, "default_db", "test_collection", []string{"partition_.*"})
 
 	s.NoError(err)
 	s.ElementsMatch([]int64{100, 200}, result)
@@ -4948,12 +4946,12 @@ func (s *GetPartitionIDsSuite) TestRegexpPartitionNames() {
 	s.mockMetaCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).
 		Return(map[string]int64{"partition_1": 100}, nil).Once()
 
-	_, err = getPartitionIDs(ctx, "default_db", "test_collection", []string{"partition_1", "partition_2"})
+	_, err = getPartitionIDs(ctx, s.mockMetaCache, "default_db", "test_collection", []string{"partition_1", "partition_2"})
 	s.Error(err)
 
 	s.mockMetaCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, errors.New("mocked")).Once()
-	_, err = getPartitionIDs(ctx, "default_db", "test_collection", []string{"partition_1", "partition_2"})
+	_, err = getPartitionIDs(ctx, s.mockMetaCache, "default_db", "test_collection", []string{"partition_1", "partition_2"})
 	s.Error(err)
 }
 
@@ -4966,7 +4964,7 @@ func TestSearchTask_CanSkipAllocTimestamp(t *testing.T) {
 	collName := "test_skip_alloc_timestamp"
 	collID := UniqueID(111)
 	mockMetaCache := NewMockCache(t)
-	globalMetaCache = mockMetaCache
+	t.Cleanup(mockBaseTaskMetaCacheForTest(mockMetaCache))
 
 	t.Run("default consistency level", func(t *testing.T) {
 		st := &searchTask{
@@ -5137,11 +5135,7 @@ func (s *MaterializedViewTestSuite) SetupTest() {
 			CollID:                s.colID,
 			PartitionKeyIsolation: true,
 		}, nil)
-	globalMetaCache = s.mockMetaCache
-}
-
-func (s *MaterializedViewTestSuite) TearDownTest() {
-	globalMetaCache = nil
+	s.T().Cleanup(mockBaseTaskMetaCacheForTest(s.mockMetaCache))
 }
 
 func (s *MaterializedViewTestSuite) getSearchTask() *searchTask {

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -152,6 +152,7 @@ func TestSearchTaskPreExecuteUsesTimezoneForTimestamptzFilter(t *testing.T) {
 			Value: "Asia/Shanghai",
 		})
 		task := &searchTask{
+			baseTask:      baseTask{metaCache: &MetaCache{}},
 			Condition:     NewTaskCondition(context.Background()),
 			SearchRequest: &internalpb.SearchRequest{Base: &commonpb.MsgBase{MsgType: commonpb.MsgType_Search}},
 			ctx:           context.Background(),
@@ -1479,7 +1480,6 @@ func TestSearchTask_WithFunctions(t *testing.T) {
 	require.NoError(t, err)
 	cache, err := initMetaCache(ctx, qc)
 	require.NoError(t, err)
-	t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 	getSearchTask := func(t *testing.T, collName string, data []string, withRerank bool) *searchTask {
 		placeholderValue := &commonpb.PlaceholderValue{

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -96,9 +96,9 @@ func TestSearchTaskPreExecuteTextRequiresStorageV3(t *testing.T) {
 	cache := NewMockCache(t)
 	cache.EXPECT().GetCollectionID(mock.Anything, dbName, collectionName).Return(collectionID, nil)
 	cache.EXPECT().GetCollectionSchema(mock.Anything, dbName, collectionName).Return(schema, nil)
-	t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 	task := &searchTask{
+		baseTask:      baseTask{metaCache: cache},
 		ctx:           context.Background(),
 		SearchRequest: &internalpb.SearchRequest{},
 		request: &milvuspb.SearchRequest{
@@ -191,7 +191,6 @@ func TestSearchTask_PostExecute(t *testing.T) {
 
 	cache, err := initMetaCache(ctx, qc)
 	require.NoError(t, err)
-	t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 	getSearchTask := func(t *testing.T, collName string) *searchTask {
 		task := &searchTask{
@@ -268,7 +267,8 @@ func TestSearchTask_PostExecute(t *testing.T) {
 			}
 
 			qt := &searchTask{
-				ctx: ctx,
+				baseTask: baseTask{metaCache: cache},
+				ctx:      ctx,
 				SearchRequest: &internalpb.SearchRequest{
 					Base: &commonpb.MsgBase{
 						MsgType:  commonpb.MsgType_Search,
@@ -361,6 +361,7 @@ func TestSearchTask_PostExecute(t *testing.T) {
 			},
 		}
 		task := &searchTask{
+			baseTask:       baseTask{metaCache: cache},
 			ctx:            ctx,
 			collectionName: collName,
 			SearchRequest: &internalpb.SearchRequest{
@@ -472,6 +473,7 @@ func TestSearchTask_PostExecute(t *testing.T) {
 			},
 		}
 		task := &searchTask{
+			baseTask:       baseTask{metaCache: cache},
 			ctx:            ctx,
 			collectionName: collName,
 			SearchRequest: &internalpb.SearchRequest{
@@ -897,7 +899,6 @@ func TestSearchTask_PreExecute(t *testing.T) {
 	require.NoError(t, err)
 	cache, err := initMetaCache(ctx, qc)
 	require.NoError(t, err)
-	t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 	getSearchTask := func(t *testing.T, collName string) *searchTask {
 		task := &searchTask{
@@ -1478,8 +1479,16 @@ func TestSearchTask_WithFunctions(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	cache, err := initMetaCache(ctx, qc)
+	_, err = initMetaCache(ctx, qc)
 	require.NoError(t, err)
+
+	collectionID := UniqueID(1000)
+	mockCache := NewMockCache(t)
+	info := mustNewSchemaInfo(schema)
+	mockCache.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(collectionID, nil).Maybe()
+	mockCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(info, nil).Maybe()
+	mockCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"_default": UniqueID(1)}, nil).Maybe()
+	mockCache.EXPECT().GetCollectionInfo(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&collectionInfo{}, nil).Maybe()
 
 	getSearchTask := func(t *testing.T, collName string, data []string, withRerank bool) *searchTask {
 		placeholderValue := &commonpb.PlaceholderValue{
@@ -1507,7 +1516,7 @@ func TestSearchTask_WithFunctions(t *testing.T) {
 		}
 
 		task := &searchTask{
-			baseTask:       baseTask{metaCache: cache},
+			baseTask:       baseTask{metaCache: mockCache},
 			ctx:            ctx,
 			collectionName: collectionName,
 			SearchRequest: &internalpb.SearchRequest{
@@ -1538,15 +1547,6 @@ func TestSearchTask_WithFunctions(t *testing.T) {
 		require.NoError(t, task.OnEnqueue())
 		return task
 	}
-
-	collectionID := UniqueID(1000)
-	mockCache := NewMockCache(t)
-	info := mustNewSchemaInfo(schema)
-	mockCache.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(collectionID, nil).Maybe()
-	mockCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(info, nil).Maybe()
-	mockCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"_default": UniqueID(1)}, nil).Maybe()
-	mockCache.EXPECT().GetCollectionInfo(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&collectionInfo{}, nil).Maybe()
-	t.Cleanup(mockBaseTaskMetaCacheForTest(mockCache))
 
 	{
 		task := getSearchTask(t, collectionName, []string{"sentence"}, false)
@@ -1601,6 +1601,7 @@ func TestSearchTask_WithFunctions(t *testing.T) {
 			subReqs = append(subReqs, subReq)
 		}
 		task := &searchTask{
+			baseTask:       baseTask{metaCache: mockCache},
 			ctx:            ctx,
 			collectionName: collectionName,
 			SearchRequest: &internalpb.SearchRequest{
@@ -1705,9 +1706,8 @@ func TestSearchTaskV2_Execute(t *testing.T) {
 		collectionName = t.Name() + funcutil.GenRandomStr()
 	)
 
-	cache, err := initMetaCache(ctx, qc)
+	_, err = initMetaCache(ctx, qc)
 	require.NoError(t, err)
-	t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 	defer qc.Close()
 
@@ -3387,7 +3387,6 @@ func TestSearchTask_ErrExecute(t *testing.T) {
 
 	cache, err := initMetaCache(ctx, rc)
 	assert.NoError(t, err)
-	t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 	fieldName2Types := map[string]schemapb.DataType{
 		testBoolField:     schemapb.DataType_Bool,
@@ -3460,6 +3459,7 @@ func TestSearchTask_ErrExecute(t *testing.T) {
 
 	// test begins
 	task := &searchTask{
+		baseTask:  baseTask{metaCache: cache},
 		Condition: NewTaskCondition(ctx),
 		SearchRequest: &internalpb.SearchRequest{
 			Base: &commonpb.MsgBase{
@@ -4601,7 +4601,7 @@ func TestSearchTask_Requery(t *testing.T) {
 	cache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"_default": UniqueID(1)}, nil).Maybe()
 	cache.EXPECT().GetCollectionInfo(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&collectionInfo{}, nil).Maybe()
 	cache.EXPECT().GetDatabaseInfo(mock.Anything, mock.Anything).Return(&databaseInfo{}, nil).Maybe()
-	t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
+	node.setMetaCache(cache)
 
 	mgr := shardclient.NewMockShardClientManager(t)
 	// mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(qn, nil).Maybe()
@@ -4675,7 +4675,8 @@ func TestSearchTask_Requery(t *testing.T) {
 
 		outputFields := []string{pkField, vecField}
 		qt := &searchTask{
-			ctx: ctx,
+			baseTask: baseTask{metaCache: cache},
+			ctx:      ctx,
 			SearchRequest: &internalpb.SearchRequest{
 				Base: &commonpb.MsgBase{
 					MsgType:  commonpb.MsgType_Search,
@@ -4719,7 +4720,8 @@ func TestSearchTask_Requery(t *testing.T) {
 		node := mocks.NewMockProxy(t)
 
 		qt := &searchTask{
-			ctx: ctx,
+			baseTask: baseTask{metaCache: cache},
+			ctx:      ctx,
 			SearchRequest: &internalpb.SearchRequest{
 				Base: &commonpb.MsgBase{
 					MsgType:  commonpb.MsgType_Search,
@@ -4751,7 +4753,8 @@ func TestSearchTask_Requery(t *testing.T) {
 		node.lbPolicy = lb
 
 		qt := &searchTask{
-			ctx: ctx,
+			baseTask: baseTask{metaCache: cache},
+			ctx:      ctx,
 			SearchRequest: &internalpb.SearchRequest{
 				Base: &commonpb.MsgBase{
 					MsgType:  commonpb.MsgType_Search,
@@ -4796,7 +4799,8 @@ func TestSearchTask_Requery(t *testing.T) {
 		}
 
 		qt := &searchTask{
-			ctx: ctx,
+			baseTask: baseTask{metaCache: cache},
+			ctx:      ctx,
 			SearchRequest: &internalpb.SearchRequest{
 				Base: &commonpb.MsgBase{
 					MsgType:  commonpb.MsgType_Search,
@@ -4964,10 +4968,10 @@ func TestSearchTask_CanSkipAllocTimestamp(t *testing.T) {
 	collName := "test_skip_alloc_timestamp"
 	collID := UniqueID(111)
 	mockMetaCache := NewMockCache(t)
-	t.Cleanup(mockBaseTaskMetaCacheForTest(mockMetaCache))
 
 	t.Run("default consistency level", func(t *testing.T) {
 		st := &searchTask{
+			baseTask: baseTask{metaCache: mockMetaCache},
 			request: &milvuspb.SearchRequest{
 				Base:                  nil,
 				DbName:                dbName,
@@ -5010,6 +5014,7 @@ func TestSearchTask_CanSkipAllocTimestamp(t *testing.T) {
 			}, nil).Times(3)
 
 		st := &searchTask{
+			baseTask: baseTask{metaCache: mockMetaCache},
 			request: &milvuspb.SearchRequest{
 				Base:                  nil,
 				DbName:                dbName,
@@ -5033,6 +5038,7 @@ func TestSearchTask_CanSkipAllocTimestamp(t *testing.T) {
 
 	t.Run("legacy_guarantee_ts", func(t *testing.T) {
 		st := &searchTask{
+			baseTask: baseTask{metaCache: mockMetaCache},
 			request: &milvuspb.SearchRequest{
 				Base:                  nil,
 				DbName:                dbName,
@@ -5061,6 +5067,7 @@ func TestSearchTask_CanSkipAllocTimestamp(t *testing.T) {
 			nil, errors.New("mock error")).Once()
 
 		st := &searchTask{
+			baseTask: baseTask{metaCache: mockMetaCache},
 			request: &milvuspb.SearchRequest{
 				Base:                  nil,
 				DbName:                dbName,
@@ -5085,6 +5092,7 @@ func TestSearchTask_CanSkipAllocTimestamp(t *testing.T) {
 		assert.False(t, skip)
 
 		st2 := &searchTask{
+			baseTask: baseTask{metaCache: mockMetaCache},
 			request: &milvuspb.SearchRequest{
 				Base:                  nil,
 				DbName:                dbName,
@@ -5135,11 +5143,11 @@ func (s *MaterializedViewTestSuite) SetupTest() {
 			CollID:                s.colID,
 			PartitionKeyIsolation: true,
 		}, nil)
-	s.T().Cleanup(mockBaseTaskMetaCacheForTest(s.mockMetaCache))
 }
 
 func (s *MaterializedViewTestSuite) getSearchTask() *searchTask {
 	task := &searchTask{
+		baseTask:       baseTask{metaCache: s.mockMetaCache},
 		ctx:            s.ctx,
 		collectionName: s.colName,
 		SearchRequest:  &internalpb.SearchRequest{},
@@ -5170,6 +5178,7 @@ func (s *MaterializedViewTestSuite) getHybridSearchTask(dsl string) *searchTask 
 	}
 
 	task := &searchTask{
+		baseTask:       baseTask{metaCache: s.mockMetaCache},
 		ctx:            s.ctx,
 		collectionName: s.colName,
 		SearchRequest:  &internalpb.SearchRequest{},

--- a/internal/proxy/task_snapshot.go
+++ b/internal/proxy/task_snapshot.go
@@ -43,11 +43,11 @@ const (
 
 // resolveCollectionNames resolves collection ID to (dbName, collectionName) via MetaCache.
 // Returns empty strings on failure (best-effort for display purposes).
-func resolveCollectionNames(ctx context.Context, collectionID int64) (string, string) {
+func resolveCollectionNames(ctx context.Context, metaCache Cache, collectionID int64) (string, string) {
 	if collectionID == 0 {
 		return "", ""
 	}
-	collInfo, err := globalMetaCache.GetCollectionInfo(ctx, "", "", collectionID)
+	collInfo, err := metaCache.GetCollectionInfo(ctx, "", "", collectionID)
 	if err != nil {
 		mlog.Warn(ctx, "failed to resolve collection names from ID",
 			mlog.FieldCollectionID(collectionID), mlog.Err(err))
@@ -123,7 +123,7 @@ func (cst *createSnapshotTask) PreExecute(ctx context.Context) error {
 		return merr.WrapErrParameterInvalidMsg("compaction_protection_seconds must not exceed %d", maxCompactionProtectionSeconds)
 	}
 
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, cst.req.GetDbName(), cst.req.GetCollectionName())
+	collectionID, err := cst.getMetaCache().GetCollectionID(ctx, cst.req.GetDbName(), cst.req.GetCollectionName())
 	if err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func (dst *dropSnapshotTask) PreExecute(ctx context.Context) error {
 	if dst.req.GetCollectionName() == "" {
 		return merr.WrapErrParameterMissingMsg("collection_name is required for drop snapshot")
 	}
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, dst.req.GetDbName(), dst.req.GetCollectionName())
+	collectionID, err := dst.getMetaCache().GetCollectionID(ctx, dst.req.GetDbName(), dst.req.GetCollectionName())
 	if err != nil {
 		return err
 	}
@@ -315,7 +315,7 @@ func (dst *describeSnapshotTask) PreExecute(ctx context.Context) error {
 	if dst.req.GetCollectionName() == "" {
 		return merr.WrapErrParameterMissingMsg("collection_name is required for describe snapshot")
 	}
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, dst.req.GetDbName(), dst.req.GetCollectionName())
+	collectionID, err := dst.getMetaCache().GetCollectionID(ctx, dst.req.GetDbName(), dst.req.GetCollectionName())
 	if err != nil {
 		return err
 	}
@@ -346,7 +346,7 @@ func (dst *describeSnapshotTask) Execute(ctx context.Context) error {
 
 	snapshotInfo := result.GetSnapshotInfo()
 
-	collectionName, err := globalMetaCache.GetCollectionName(ctx, "", snapshotInfo.GetCollectionId())
+	collectionName, err := dst.getMetaCache().GetCollectionName(ctx, "", snapshotInfo.GetCollectionId())
 	if err != nil {
 		mlog.Warn(ctx, "DescribeSnapshot fail to get collection name",
 			mlog.Err(err))
@@ -354,7 +354,7 @@ func (dst *describeSnapshotTask) Execute(ctx context.Context) error {
 	}
 	var partitionNames []string
 	for _, partitionID := range snapshotInfo.GetPartitionIds() {
-		partitionName, err := globalMetaCache.GetPartitionName(ctx, "", collectionName, partitionID)
+		partitionName, err := dst.getMetaCache().GetPartitionName(ctx, "", collectionName, partitionID)
 		if err != nil {
 			mlog.Warn(ctx, "DescribeSnapshot fail to get partition name",
 				mlog.FieldPartitionID(partitionID),
@@ -436,7 +436,7 @@ func (lst *listSnapshotsTask) OnEnqueue() error {
 func (lst *listSnapshotsTask) PreExecute(ctx context.Context) error {
 	// Resolve database ID for db-level filtering
 	if lst.req.GetDbName() != "" {
-		dbInfo, err := globalMetaCache.GetDatabaseInfo(ctx, lst.req.GetDbName())
+		dbInfo, err := lst.getMetaCache().GetDatabaseInfo(ctx, lst.req.GetDbName())
 		if err != nil {
 			return err
 		}
@@ -447,7 +447,7 @@ func (lst *listSnapshotsTask) PreExecute(ctx context.Context) error {
 		return merr.WrapErrParameterMissingMsg("collection_name is required for ListSnapshots")
 	}
 
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, lst.req.GetDbName(), lst.req.GetCollectionName())
+	collectionID, err := lst.getMetaCache().GetCollectionID(ctx, lst.req.GetDbName(), lst.req.GetCollectionName())
 	if err != nil {
 		return err
 	}
@@ -560,7 +560,7 @@ func (rst *restoreSnapshotTask) PreExecute(ctx context.Context) error {
 	}
 
 	// Resolve source collection ID for per-collection snapshot lookup (RPC call)
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, rst.req.GetDbName(), rst.req.GetCollectionName())
+	collectionID, err := rst.getMetaCache().GetCollectionID(ctx, rst.req.GetDbName(), rst.req.GetCollectionName())
 	if err != nil {
 		return err
 	}
@@ -682,7 +682,7 @@ func (grst *getRestoreSnapshotStateTask) Execute(ctx context.Context) error {
 	info := result.GetInfo()
 	var milvusInfo *milvuspb.RestoreSnapshotInfo
 	if info != nil {
-		dbName, collectionName := resolveCollectionNames(ctx, info.GetCollectionId())
+		dbName, collectionName := resolveCollectionNames(ctx, grst.getMetaCache(), info.GetCollectionId())
 		milvusInfo = &milvuspb.RestoreSnapshotInfo{
 			JobId:          info.GetJobId(),
 			SnapshotName:   info.GetSnapshotName(),
@@ -764,7 +764,7 @@ func (lrst *listRestoreSnapshotJobsTask) OnEnqueue() error {
 func (lrst *listRestoreSnapshotJobsTask) PreExecute(ctx context.Context) error {
 	// Resolve database ID for db-level filtering
 	if lrst.req.GetDbName() != "" {
-		dbInfo, err := globalMetaCache.GetDatabaseInfo(ctx, lrst.req.GetDbName())
+		dbInfo, err := lrst.getMetaCache().GetDatabaseInfo(ctx, lrst.req.GetDbName())
 		if err != nil {
 			return err
 		}
@@ -772,7 +772,7 @@ func (lrst *listRestoreSnapshotJobsTask) PreExecute(ctx context.Context) error {
 	}
 
 	if lrst.req.GetCollectionName() != "" {
-		collectionID, err := globalMetaCache.GetCollectionID(ctx, lrst.req.GetDbName(), lrst.req.GetCollectionName())
+		collectionID, err := lrst.getMetaCache().GetCollectionID(ctx, lrst.req.GetDbName(), lrst.req.GetCollectionName())
 		if err != nil {
 			return err
 		}
@@ -805,7 +805,7 @@ func (lrst *listRestoreSnapshotJobsTask) Execute(ctx context.Context) error {
 	jobs := result.GetJobs()
 	milvusJobs := make([]*milvuspb.RestoreSnapshotInfo, 0, len(jobs))
 	for _, job := range jobs {
-		dbName, collectionName := resolveCollectionNames(ctx, job.GetCollectionId())
+		dbName, collectionName := resolveCollectionNames(ctx, lrst.getMetaCache(), job.GetCollectionId())
 		milvusJobs = append(milvusJobs, &milvuspb.RestoreSnapshotInfo{
 			JobId:          job.GetJobId(),
 			SnapshotName:   job.GetSnapshotName(),
@@ -904,7 +904,7 @@ func (pst *pinSnapshotDataTask) PreExecute(ctx context.Context) error {
 		return merr.WrapErrParameterInvalidMsg("ttl_seconds exceeds maximum of %d (30 days)", maxPinTTLSeconds)
 	}
 
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, pst.req.GetDbName(), pst.req.GetCollectionName())
+	collectionID, err := pst.getMetaCache().GetCollectionID(ctx, pst.req.GetDbName(), pst.req.GetCollectionName())
 	if err != nil {
 		return err
 	}

--- a/internal/proxy/task_snapshot_test.go
+++ b/internal/proxy/task_snapshot_test.go
@@ -73,7 +73,9 @@ func TestCreateSnapshotTask_OnEnqueue_BaseAlreadyExists(t *testing.T) {
 }
 
 func TestCreateSnapshotTask_PreExecute_Success(t *testing.T) {
+	cache := &MetaCache{}
 	task := &createSnapshotTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.CreateSnapshotRequest{
 			Name:           "test_snapshot",
 			DbName:         "default",
@@ -82,8 +84,6 @@ func TestCreateSnapshotTask_PreExecute_Success(t *testing.T) {
 	}
 
 	// Mock meta cache calls
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 	defer mockGetCollectionID.UnPatch()
 
@@ -94,7 +94,9 @@ func TestCreateSnapshotTask_PreExecute_Success(t *testing.T) {
 }
 
 func TestCreateSnapshotTask_PreExecute_CollectionNotFound(t *testing.T) {
+	cache := &MetaCache{}
 	task := &createSnapshotTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.CreateSnapshotRequest{
 			Name:           "test_snapshot",
 			DbName:         "default",
@@ -103,8 +105,6 @@ func TestCreateSnapshotTask_PreExecute_CollectionNotFound(t *testing.T) {
 	}
 
 	// Initialize meta cache
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	expectedError := errors.New("collection not found")
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(0), expectedError).Build()
 	defer mockGetCollectionID.UnPatch()
@@ -146,7 +146,9 @@ func TestCreateSnapshotTask_PreExecute_ProtectionExceedsMax(t *testing.T) {
 }
 
 func TestCreateSnapshotTask_PreExecute_ProtectionZero(t *testing.T) {
+	cache := &MetaCache{}
 	task := &createSnapshotTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.CreateSnapshotRequest{
 			Name:                        "test_snapshot",
 			DbName:                      "default",
@@ -155,8 +157,6 @@ func TestCreateSnapshotTask_PreExecute_ProtectionZero(t *testing.T) {
 		},
 	}
 
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 	defer mockGetCollectionID.UnPatch()
 
@@ -165,7 +165,9 @@ func TestCreateSnapshotTask_PreExecute_ProtectionZero(t *testing.T) {
 }
 
 func TestCreateSnapshotTask_PreExecute_ProtectionValid(t *testing.T) {
+	cache := &MetaCache{}
 	task := &createSnapshotTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.CreateSnapshotRequest{
 			Name:                        "test_snapshot",
 			DbName:                      "default",
@@ -174,8 +176,6 @@ func TestCreateSnapshotTask_PreExecute_ProtectionValid(t *testing.T) {
 		},
 	}
 
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 	defer mockGetCollectionID.UnPatch()
 
@@ -283,7 +283,9 @@ func TestDropSnapshotTask_OnEnqueue_Success(t *testing.T) {
 }
 
 func TestDropSnapshotTask_PreExecute(t *testing.T) {
+	cache := &MetaCache{}
 	task := &dropSnapshotTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.DropSnapshotRequest{
 			Name:           "test_snapshot",
 			DbName:         "default",
@@ -291,8 +293,6 @@ func TestDropSnapshotTask_PreExecute(t *testing.T) {
 		},
 	}
 
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 	defer mockGetCollectionID.UnPatch()
 
@@ -316,7 +316,9 @@ func TestDropSnapshotTask_PreExecute_MissingCollectionName(t *testing.T) {
 }
 
 func TestDropSnapshotTask_PreExecute_CollectionNotFound(t *testing.T) {
+	cache := &MetaCache{}
 	task := &dropSnapshotTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.DropSnapshotRequest{
 			Name:           "test_snapshot",
 			DbName:         "default",
@@ -324,8 +326,6 @@ func TestDropSnapshotTask_PreExecute_CollectionNotFound(t *testing.T) {
 		},
 	}
 
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	expectedError := errors.New("collection not found")
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(0), expectedError).Build()
 	defer mockGetCollectionID.UnPatch()
@@ -393,7 +393,9 @@ func TestDescribeSnapshotTask_OnEnqueue_Success(t *testing.T) {
 
 func TestDescribeSnapshotTask_Execute_Success(t *testing.T) {
 	mockMixCoord := NewMixCoordMock()
+	cache := &MetaCache{}
 	task := &describeSnapshotTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.DescribeSnapshotRequest{
 			Name: "test_snapshot",
 		},
@@ -415,8 +417,6 @@ func TestDescribeSnapshotTask_Execute_Success(t *testing.T) {
 	defer mockDescribeSnapshot.UnPatch()
 
 	// Initialize meta cache
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	// Mock meta cache calls
 	mockGetCollectionName := mockey.Mock((*MetaCache).GetCollectionName).Return("test_collection", nil).Build()
 	defer mockGetCollectionName.UnPatch()
@@ -466,7 +466,9 @@ func TestDescribeSnapshotTask_Execute_MixCoordError(t *testing.T) {
 
 func TestDescribeSnapshotTask_Execute_CollectionNameResolutionError(t *testing.T) {
 	mockMixCoord := NewMixCoordMock()
+	cache := &MetaCache{}
 	task := &describeSnapshotTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.DescribeSnapshotRequest{
 			Name: "test_snapshot",
 		},
@@ -486,8 +488,6 @@ func TestDescribeSnapshotTask_Execute_CollectionNameResolutionError(t *testing.T
 	defer mockDescribeSnapshot.UnPatch()
 
 	// Initialize meta cache
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	// Mock collection name resolution failure
 	expectedError := errors.New("collection name resolution failed")
 	mockGetCollectionName := mockey.Mock((*MetaCache).GetCollectionName).Return("", expectedError).Build()
@@ -501,7 +501,9 @@ func TestDescribeSnapshotTask_Execute_CollectionNameResolutionError(t *testing.T
 
 func TestDescribeSnapshotTask_Execute_PartitionNameResolutionError(t *testing.T) {
 	mockMixCoord := NewMixCoordMock()
+	cache := &MetaCache{}
 	task := &describeSnapshotTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.DescribeSnapshotRequest{
 			Name: "test_snapshot",
 		},
@@ -521,8 +523,6 @@ func TestDescribeSnapshotTask_Execute_PartitionNameResolutionError(t *testing.T)
 	defer mockDescribeSnapshot.UnPatch()
 
 	// Initialize meta cache
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	// Mock successful collection name resolution
 	mockGetCollectionName := mockey.Mock((*MetaCache).GetCollectionName).Return("test_collection", nil).Build()
 	defer mockGetCollectionName.UnPatch()
@@ -559,7 +559,9 @@ func TestListSnapshotsTask_OnEnqueue_Success(t *testing.T) {
 }
 
 func TestListSnapshotsTask_PreExecute_Success(t *testing.T) {
+	cache := &MetaCache{}
 	task := &listSnapshotsTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.ListSnapshotsRequest{
 			DbName:         "default",
 			CollectionName: "test_collection",
@@ -567,8 +569,6 @@ func TestListSnapshotsTask_PreExecute_Success(t *testing.T) {
 	}
 
 	// Initialize meta cache
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetDBInfo := mockey.Mock((*MetaCache).GetDatabaseInfo).Return(&databaseInfo{DBID: 1}, nil).Build()
 	defer mockGetDBInfo.UnPatch()
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
@@ -700,7 +700,9 @@ func TestRestoreSnapshotTask_Execute_StatusError(t *testing.T) {
 
 func TestCreateSnapshotTask_FullLifecycle(t *testing.T) {
 	mockMixCoord := NewMixCoordMock()
+	cache := &MetaCache{}
 	task := &createSnapshotTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.CreateSnapshotRequest{
 			DbName:         "default",
 			CollectionName: "test_collection",
@@ -717,8 +719,6 @@ func TestCreateSnapshotTask_FullLifecycle(t *testing.T) {
 	assert.NotNil(t, task.req.Base)
 
 	// Initialize meta cache
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	// Mock PreExecute dependencies
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 	defer mockGetCollectionID.UnPatch()
@@ -746,7 +746,9 @@ func TestCreateSnapshotTask_FullLifecycle(t *testing.T) {
 // =========================== Edge Cases and Error Scenarios ===========================
 
 func TestCreateSnapshotTask_EmptyPartitionNames(t *testing.T) {
+	cache := &MetaCache{}
 	task := &createSnapshotTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.CreateSnapshotRequest{
 			Name:           "test_snapshot",
 			DbName:         "default",
@@ -755,8 +757,6 @@ func TestCreateSnapshotTask_EmptyPartitionNames(t *testing.T) {
 	}
 
 	// Initialize meta cache
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 	defer mockGetCollectionID.UnPatch()
 
@@ -918,7 +918,9 @@ func TestSnapshotTasks_PreExecute_ValidNames(t *testing.T) {
 	t.Run("CreateSnapshotTask", func(t *testing.T) {
 		for _, tc := range validSnapshotNames {
 			t.Run(tc.name, func(t *testing.T) {
+				cache := &MetaCache{}
 				task := &createSnapshotTask{
+					baseTask: baseTask{metaCache: cache},
 					req: &milvuspb.CreateSnapshotRequest{
 						Name:           tc.snapshotName,
 						DbName:         "default",
@@ -927,8 +929,6 @@ func TestSnapshotTasks_PreExecute_ValidNames(t *testing.T) {
 				}
 
 				// Mock globalMetaCache
-				cache := &MetaCache{}
-				defer mockBaseTaskMetaCacheForTest(cache)()
 				mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 				defer mockGetCollectionID.UnPatch()
 
@@ -943,7 +943,9 @@ func TestSnapshotTasks_PreExecute_ValidNames(t *testing.T) {
 	t.Run("DropSnapshotTask", func(t *testing.T) {
 		for _, tc := range validSnapshotNames {
 			t.Run(tc.name, func(t *testing.T) {
+				cache := &MetaCache{}
 				task := &dropSnapshotTask{
+					baseTask: baseTask{metaCache: cache},
 					req: &milvuspb.DropSnapshotRequest{
 						Name:           tc.snapshotName,
 						DbName:         "default",
@@ -951,8 +953,6 @@ func TestSnapshotTasks_PreExecute_ValidNames(t *testing.T) {
 					},
 				}
 
-				cache := &MetaCache{}
-				defer mockBaseTaskMetaCacheForTest(cache)()
 				mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 				defer mockGetCollectionID.UnPatch()
 
@@ -967,7 +967,9 @@ func TestSnapshotTasks_PreExecute_ValidNames(t *testing.T) {
 	t.Run("DescribeSnapshotTask", func(t *testing.T) {
 		for _, tc := range validSnapshotNames {
 			t.Run(tc.name, func(t *testing.T) {
+				cache := &MetaCache{}
 				task := &describeSnapshotTask{
+					baseTask: baseTask{metaCache: cache},
 					req: &milvuspb.DescribeSnapshotRequest{
 						Name:           tc.snapshotName,
 						DbName:         "default",
@@ -975,8 +977,6 @@ func TestSnapshotTasks_PreExecute_ValidNames(t *testing.T) {
 					},
 				}
 
-				cache := &MetaCache{}
-				defer mockBaseTaskMetaCacheForTest(cache)()
 				mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 				defer mockGetCollectionID.UnPatch()
 
@@ -1002,7 +1002,9 @@ func TestSnapshotTasks_PreExecute_ValidNames(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
+				cache := &MetaCache{}
 				task := &restoreSnapshotTask{
+					baseTask: baseTask{metaCache: cache},
 					req: &milvuspb.RestoreSnapshotRequest{
 						Name:                 tc.snapshotName,
 						CollectionName:       tc.collectionName,
@@ -1010,8 +1012,6 @@ func TestSnapshotTasks_PreExecute_ValidNames(t *testing.T) {
 					},
 				}
 
-				cache := &MetaCache{}
-				defer mockBaseTaskMetaCacheForTest(cache)()
 				mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 				defer mockGetCollectionID.UnPatch()
 
@@ -1026,15 +1026,15 @@ func TestSnapshotTasks_PreExecute_ValidNames(t *testing.T) {
 // =========================== Test for Issue #47066 ===========================
 
 func TestListSnapshotsTask_PreExecute_EmptyCollectionName(t *testing.T) {
+	cache := &MetaCache{}
 	task := &listSnapshotsTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.ListSnapshotsRequest{
 			DbName:         "default",
 			CollectionName: "", // Empty collection name should be rejected
 		},
 	}
 
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetDBInfo := mockey.Mock((*MetaCache).GetDatabaseInfo).Return(&databaseInfo{DBID: 1}, nil).Build()
 	defer mockGetDBInfo.UnPatch()
 
@@ -1114,7 +1114,9 @@ func TestRestoreSnapshotTask_PreExecute_MissingTargetCollectionName(t *testing.T
 }
 
 func TestRestoreSnapshotTask_PreExecute_GetCollectionIDError(t *testing.T) {
+	cache := &MetaCache{}
 	task := &restoreSnapshotTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.RestoreSnapshotRequest{
 			Name:                 "valid_snapshot",
 			CollectionName:       "source_collection",
@@ -1123,8 +1125,6 @@ func TestRestoreSnapshotTask_PreExecute_GetCollectionIDError(t *testing.T) {
 		},
 	}
 
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).
 		Return(int64(0), errors.New("source collection not found")).Build()
 	defer mockGetCollectionID.UnPatch()
@@ -1152,7 +1152,9 @@ func TestDescribeSnapshotTask_PreExecute_MissingCollectionName(t *testing.T) {
 }
 
 func TestDescribeSnapshotTask_PreExecute_GetCollectionIDError(t *testing.T) {
+	cache := &MetaCache{}
 	task := &describeSnapshotTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.DescribeSnapshotRequest{
 			Name:           "valid_snapshot",
 			DbName:         "default",
@@ -1160,8 +1162,6 @@ func TestDescribeSnapshotTask_PreExecute_GetCollectionIDError(t *testing.T) {
 		},
 	}
 
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).
 		Return(int64(0), errors.New("collection not found")).Build()
 	defer mockGetCollectionID.UnPatch()
@@ -1175,14 +1175,14 @@ func TestDescribeSnapshotTask_PreExecute_GetCollectionIDError(t *testing.T) {
 // =========================== listSnapshotsTask.PreExecute Additional Tests ===========================
 
 func TestListSnapshotsTask_PreExecute_GetDatabaseInfoError(t *testing.T) {
+	cache := &MetaCache{}
 	task := &listSnapshotsTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.ListSnapshotsRequest{
 			DbName: "nonexistent_db",
 		},
 	}
 
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetDBInfo := mockey.Mock((*MetaCache).GetDatabaseInfo).
 		Return(nil, errors.New("database not found")).Build()
 	defer mockGetDBInfo.UnPatch()
@@ -1194,15 +1194,15 @@ func TestListSnapshotsTask_PreExecute_GetDatabaseInfoError(t *testing.T) {
 }
 
 func TestListSnapshotsTask_PreExecute_GetCollectionIDError(t *testing.T) {
+	cache := &MetaCache{}
 	task := &listSnapshotsTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.ListSnapshotsRequest{
 			DbName:         "default",
 			CollectionName: "nonexistent_collection",
 		},
 	}
 
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetDBInfo := mockey.Mock((*MetaCache).GetDatabaseInfo).
 		Return(&databaseInfo{DBID: 1}, nil).Build()
 	defer mockGetDBInfo.UnPatch()
@@ -1247,7 +1247,9 @@ func TestGetRestoreSnapshotStateTask_PreExecute(t *testing.T) {
 
 func TestGetRestoreSnapshotStateTask_Execute_Success(t *testing.T) {
 	mockMixCoord := NewMixCoordMock()
+	cache := &MetaCache{}
 	task := &getRestoreSnapshotStateTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.GetRestoreSnapshotStateRequest{
 			JobId: 1,
 		},
@@ -1272,8 +1274,6 @@ func TestGetRestoreSnapshotStateTask_Execute_Success(t *testing.T) {
 	defer mockGetState.UnPatch()
 
 	// Mock resolveCollectionNames via meta cache GetCollectionInfo
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetCollectionInfo := mockey.Mock((*MetaCache).GetCollectionInfo).
 		Return(&collectionInfo{
 			DBName: "test_db",
@@ -1392,14 +1392,14 @@ func TestListRestoreSnapshotJobsTask_OnEnqueue(t *testing.T) {
 }
 
 func TestListRestoreSnapshotJobsTask_PreExecute_DbNameError(t *testing.T) {
+	cache := &MetaCache{}
 	task := &listRestoreSnapshotJobsTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.ListRestoreSnapshotJobsRequest{
 			DbName: "nonexistent_db",
 		},
 	}
 
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetDBInfo := mockey.Mock((*MetaCache).GetDatabaseInfo).
 		Return(nil, errors.New("database not found")).Build()
 	defer mockGetDBInfo.UnPatch()
@@ -1411,15 +1411,15 @@ func TestListRestoreSnapshotJobsTask_PreExecute_DbNameError(t *testing.T) {
 }
 
 func TestListRestoreSnapshotJobsTask_PreExecute_CollectionNameError(t *testing.T) {
+	cache := &MetaCache{}
 	task := &listRestoreSnapshotJobsTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.ListRestoreSnapshotJobsRequest{
 			DbName:         "default",
 			CollectionName: "nonexistent_collection",
 		},
 	}
 
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetDBInfo := mockey.Mock((*MetaCache).GetDatabaseInfo).
 		Return(&databaseInfo{DBID: 1}, nil).Build()
 	defer mockGetDBInfo.UnPatch()
@@ -1434,15 +1434,15 @@ func TestListRestoreSnapshotJobsTask_PreExecute_CollectionNameError(t *testing.T
 }
 
 func TestListRestoreSnapshotJobsTask_PreExecute_BothDbAndCollectionSuccess(t *testing.T) {
+	cache := &MetaCache{}
 	task := &listRestoreSnapshotJobsTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.ListRestoreSnapshotJobsRequest{
 			DbName:         "default",
 			CollectionName: "test_collection",
 		},
 	}
 
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetDBInfo := mockey.Mock((*MetaCache).GetDatabaseInfo).
 		Return(&databaseInfo{DBID: 5}, nil).Build()
 	defer mockGetDBInfo.UnPatch()
@@ -1458,14 +1458,14 @@ func TestListRestoreSnapshotJobsTask_PreExecute_BothDbAndCollectionSuccess(t *te
 }
 
 func TestListRestoreSnapshotJobsTask_PreExecute_OnlyDbName(t *testing.T) {
+	cache := &MetaCache{}
 	task := &listRestoreSnapshotJobsTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.ListRestoreSnapshotJobsRequest{
 			DbName: "default",
 		},
 	}
 
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetDBInfo := mockey.Mock((*MetaCache).GetDatabaseInfo).
 		Return(&databaseInfo{DBID: 5}, nil).Build()
 	defer mockGetDBInfo.UnPatch()
@@ -1491,7 +1491,9 @@ func TestListRestoreSnapshotJobsTask_PreExecute_Empty(t *testing.T) {
 
 func TestListRestoreSnapshotJobsTask_Execute_Success(t *testing.T) {
 	mockMixCoord := NewMixCoordMock()
+	cache := &MetaCache{}
 	task := &listRestoreSnapshotJobsTask{
+		baseTask:     baseTask{metaCache: cache},
 		req:          &milvuspb.ListRestoreSnapshotJobsRequest{},
 		mixCoord:     mockMixCoord,
 		collectionID: 0,
@@ -1523,8 +1525,6 @@ func TestListRestoreSnapshotJobsTask_Execute_Success(t *testing.T) {
 	defer mockListJobs.UnPatch()
 
 	// Mock resolveCollectionNames for both collections
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	callCount := 0
 	mockGetCollectionInfo := mockey.Mock((*MetaCache).GetCollectionInfo).
 		To(func(ctx context.Context, database string, collectionName string, collectionID int64) (*collectionInfo, error) {
@@ -1678,7 +1678,9 @@ func TestListRestoreSnapshotJobsTask_TaskInterface(t *testing.T) {
 // =========================== PinSnapshotDataTask Tests ===========================
 
 func TestPinSnapshotDataTask_PreExecute_Success(t *testing.T) {
+	cache := &MetaCache{}
 	task := &pinSnapshotDataTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.PinSnapshotDataRequest{
 			Name:           "test_snapshot",
 			DbName:         "default",
@@ -1686,8 +1688,6 @@ func TestPinSnapshotDataTask_PreExecute_Success(t *testing.T) {
 		},
 	}
 
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 	defer mockGetCollectionID.UnPatch()
 
@@ -1755,7 +1755,9 @@ func TestPinSnapshotDataTask_PreExecute_TTLExceedsMax(t *testing.T) {
 }
 
 func TestPinSnapshotDataTask_PreExecute_TTLAtMaxBoundary(t *testing.T) {
+	cache := &MetaCache{}
 	task := &pinSnapshotDataTask{
+		baseTask: baseTask{metaCache: cache},
 		req: &milvuspb.PinSnapshotDataRequest{
 			Name:           "test_snapshot",
 			DbName:         "default",
@@ -1764,8 +1766,6 @@ func TestPinSnapshotDataTask_PreExecute_TTLAtMaxBoundary(t *testing.T) {
 		},
 	}
 
-	cache := &MetaCache{}
-	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 	defer mockGetCollectionID.UnPatch()
 

--- a/internal/proxy/task_snapshot_test.go
+++ b/internal/proxy/task_snapshot_test.go
@@ -81,8 +81,9 @@ func TestCreateSnapshotTask_PreExecute_Success(t *testing.T) {
 		},
 	}
 
-	// Mock globalMetaCache calls
-	globalMetaCache = &MetaCache{}
+	// Mock meta cache calls
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 	defer mockGetCollectionID.UnPatch()
 
@@ -101,8 +102,9 @@ func TestCreateSnapshotTask_PreExecute_CollectionNotFound(t *testing.T) {
 		},
 	}
 
-	// Initialize globalMetaCache
-	globalMetaCache = &MetaCache{}
+	// Initialize meta cache
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	expectedError := errors.New("collection not found")
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(0), expectedError).Build()
 	defer mockGetCollectionID.UnPatch()
@@ -153,7 +155,8 @@ func TestCreateSnapshotTask_PreExecute_ProtectionZero(t *testing.T) {
 		},
 	}
 
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 	defer mockGetCollectionID.UnPatch()
 
@@ -171,7 +174,8 @@ func TestCreateSnapshotTask_PreExecute_ProtectionValid(t *testing.T) {
 		},
 	}
 
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 	defer mockGetCollectionID.UnPatch()
 
@@ -287,7 +291,8 @@ func TestDropSnapshotTask_PreExecute(t *testing.T) {
 		},
 	}
 
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 	defer mockGetCollectionID.UnPatch()
 
@@ -319,7 +324,8 @@ func TestDropSnapshotTask_PreExecute_CollectionNotFound(t *testing.T) {
 		},
 	}
 
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	expectedError := errors.New("collection not found")
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(0), expectedError).Build()
 	defer mockGetCollectionID.UnPatch()
@@ -408,9 +414,10 @@ func TestDescribeSnapshotTask_Execute_Success(t *testing.T) {
 	mockDescribeSnapshot := mockey.Mock((*MixCoordMock).DescribeSnapshot).Return(mockResponse, nil).Build()
 	defer mockDescribeSnapshot.UnPatch()
 
-	// Initialize globalMetaCache
-	globalMetaCache = &MetaCache{}
-	// Mock globalMetaCache calls
+	// Initialize meta cache
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
+	// Mock meta cache calls
 	mockGetCollectionName := mockey.Mock((*MetaCache).GetCollectionName).Return("test_collection", nil).Build()
 	defer mockGetCollectionName.UnPatch()
 	mockGetPartitionName := mockey.Mock((*MetaCache).GetPartitionName).To(func(ctx context.Context, database, collectionName string, partitionID int64) (string, error) {
@@ -478,8 +485,9 @@ func TestDescribeSnapshotTask_Execute_CollectionNameResolutionError(t *testing.T
 	mockDescribeSnapshot := mockey.Mock((*MixCoordMock).DescribeSnapshot).Return(mockResponse, nil).Build()
 	defer mockDescribeSnapshot.UnPatch()
 
-	// Initialize globalMetaCache
-	globalMetaCache = &MetaCache{}
+	// Initialize meta cache
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	// Mock collection name resolution failure
 	expectedError := errors.New("collection name resolution failed")
 	mockGetCollectionName := mockey.Mock((*MetaCache).GetCollectionName).Return("", expectedError).Build()
@@ -512,8 +520,9 @@ func TestDescribeSnapshotTask_Execute_PartitionNameResolutionError(t *testing.T)
 	mockDescribeSnapshot := mockey.Mock((*MixCoordMock).DescribeSnapshot).Return(mockResponse, nil).Build()
 	defer mockDescribeSnapshot.UnPatch()
 
-	// Initialize globalMetaCache
-	globalMetaCache = &MetaCache{}
+	// Initialize meta cache
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	// Mock successful collection name resolution
 	mockGetCollectionName := mockey.Mock((*MetaCache).GetCollectionName).Return("test_collection", nil).Build()
 	defer mockGetCollectionName.UnPatch()
@@ -557,8 +566,9 @@ func TestListSnapshotsTask_PreExecute_Success(t *testing.T) {
 		},
 	}
 
-	// Initialize globalMetaCache
-	globalMetaCache = &MetaCache{}
+	// Initialize meta cache
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetDBInfo := mockey.Mock((*MetaCache).GetDatabaseInfo).Return(&databaseInfo{DBID: 1}, nil).Build()
 	defer mockGetDBInfo.UnPatch()
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
@@ -706,8 +716,9 @@ func TestCreateSnapshotTask_FullLifecycle(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, task.req.Base)
 
-	// Initialize globalMetaCache
-	globalMetaCache = &MetaCache{}
+	// Initialize meta cache
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	// Mock PreExecute dependencies
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 	defer mockGetCollectionID.UnPatch()
@@ -743,8 +754,9 @@ func TestCreateSnapshotTask_EmptyPartitionNames(t *testing.T) {
 		},
 	}
 
-	// Initialize globalMetaCache
-	globalMetaCache = &MetaCache{}
+	// Initialize meta cache
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 	defer mockGetCollectionID.UnPatch()
 
@@ -915,7 +927,8 @@ func TestSnapshotTasks_PreExecute_ValidNames(t *testing.T) {
 				}
 
 				// Mock globalMetaCache
-				globalMetaCache = &MetaCache{}
+				cache := &MetaCache{}
+				defer mockBaseTaskMetaCacheForTest(cache)()
 				mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 				defer mockGetCollectionID.UnPatch()
 
@@ -938,7 +951,8 @@ func TestSnapshotTasks_PreExecute_ValidNames(t *testing.T) {
 					},
 				}
 
-				globalMetaCache = &MetaCache{}
+				cache := &MetaCache{}
+				defer mockBaseTaskMetaCacheForTest(cache)()
 				mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 				defer mockGetCollectionID.UnPatch()
 
@@ -961,7 +975,8 @@ func TestSnapshotTasks_PreExecute_ValidNames(t *testing.T) {
 					},
 				}
 
-				globalMetaCache = &MetaCache{}
+				cache := &MetaCache{}
+				defer mockBaseTaskMetaCacheForTest(cache)()
 				mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 				defer mockGetCollectionID.UnPatch()
 
@@ -995,7 +1010,8 @@ func TestSnapshotTasks_PreExecute_ValidNames(t *testing.T) {
 					},
 				}
 
-				globalMetaCache = &MetaCache{}
+				cache := &MetaCache{}
+				defer mockBaseTaskMetaCacheForTest(cache)()
 				mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 				defer mockGetCollectionID.UnPatch()
 
@@ -1017,7 +1033,8 @@ func TestListSnapshotsTask_PreExecute_EmptyCollectionName(t *testing.T) {
 		},
 	}
 
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetDBInfo := mockey.Mock((*MetaCache).GetDatabaseInfo).Return(&databaseInfo{DBID: 1}, nil).Build()
 	defer mockGetDBInfo.UnPatch()
 
@@ -1030,24 +1047,24 @@ func TestListSnapshotsTask_PreExecute_EmptyCollectionName(t *testing.T) {
 // =========================== resolveCollectionNames Tests ===========================
 
 func TestResolveCollectionNames_ZeroCollectionID(t *testing.T) {
-	dbName, collName := resolveCollectionNames(context.Background(), 0)
+	dbName, collName := resolveCollectionNames(context.Background(), nil, 0)
 	assert.Equal(t, "", dbName)
 	assert.Equal(t, "", collName)
 }
 
 func TestResolveCollectionNames_GetCollectionInfoError(t *testing.T) {
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
 	mockGetCollectionInfo := mockey.Mock((*MetaCache).GetCollectionInfo).
 		Return(nil, errors.New("collection not found")).Build()
 	defer mockGetCollectionInfo.UnPatch()
 
-	dbName, collName := resolveCollectionNames(context.Background(), 100)
+	dbName, collName := resolveCollectionNames(context.Background(), cache, 100)
 	assert.Equal(t, "", dbName)
 	assert.Equal(t, "", collName)
 }
 
 func TestResolveCollectionNames_Success(t *testing.T) {
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
 	mockGetCollectionInfo := mockey.Mock((*MetaCache).GetCollectionInfo).
 		Return(&collectionInfo{
 			DBName: "test_db",
@@ -1059,7 +1076,7 @@ func TestResolveCollectionNames_Success(t *testing.T) {
 		}, nil).Build()
 	defer mockGetCollectionInfo.UnPatch()
 
-	dbName, collName := resolveCollectionNames(context.Background(), 100)
+	dbName, collName := resolveCollectionNames(context.Background(), cache, 100)
 	assert.Equal(t, "test_db", dbName)
 	assert.Equal(t, "test_collection", collName)
 }
@@ -1106,7 +1123,8 @@ func TestRestoreSnapshotTask_PreExecute_GetCollectionIDError(t *testing.T) {
 		},
 	}
 
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).
 		Return(int64(0), errors.New("source collection not found")).Build()
 	defer mockGetCollectionID.UnPatch()
@@ -1142,7 +1160,8 @@ func TestDescribeSnapshotTask_PreExecute_GetCollectionIDError(t *testing.T) {
 		},
 	}
 
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).
 		Return(int64(0), errors.New("collection not found")).Build()
 	defer mockGetCollectionID.UnPatch()
@@ -1162,7 +1181,8 @@ func TestListSnapshotsTask_PreExecute_GetDatabaseInfoError(t *testing.T) {
 		},
 	}
 
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetDBInfo := mockey.Mock((*MetaCache).GetDatabaseInfo).
 		Return(nil, errors.New("database not found")).Build()
 	defer mockGetDBInfo.UnPatch()
@@ -1181,7 +1201,8 @@ func TestListSnapshotsTask_PreExecute_GetCollectionIDError(t *testing.T) {
 		},
 	}
 
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetDBInfo := mockey.Mock((*MetaCache).GetDatabaseInfo).
 		Return(&databaseInfo{DBID: 1}, nil).Build()
 	defer mockGetDBInfo.UnPatch()
@@ -1250,8 +1271,9 @@ func TestGetRestoreSnapshotStateTask_Execute_Success(t *testing.T) {
 		Return(mockResponse, nil).Build()
 	defer mockGetState.UnPatch()
 
-	// Mock resolveCollectionNames via globalMetaCache.GetCollectionInfo
-	globalMetaCache = &MetaCache{}
+	// Mock resolveCollectionNames via meta cache GetCollectionInfo
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetCollectionInfo := mockey.Mock((*MetaCache).GetCollectionInfo).
 		Return(&collectionInfo{
 			DBName: "test_db",
@@ -1376,7 +1398,8 @@ func TestListRestoreSnapshotJobsTask_PreExecute_DbNameError(t *testing.T) {
 		},
 	}
 
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetDBInfo := mockey.Mock((*MetaCache).GetDatabaseInfo).
 		Return(nil, errors.New("database not found")).Build()
 	defer mockGetDBInfo.UnPatch()
@@ -1395,7 +1418,8 @@ func TestListRestoreSnapshotJobsTask_PreExecute_CollectionNameError(t *testing.T
 		},
 	}
 
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetDBInfo := mockey.Mock((*MetaCache).GetDatabaseInfo).
 		Return(&databaseInfo{DBID: 1}, nil).Build()
 	defer mockGetDBInfo.UnPatch()
@@ -1417,7 +1441,8 @@ func TestListRestoreSnapshotJobsTask_PreExecute_BothDbAndCollectionSuccess(t *te
 		},
 	}
 
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetDBInfo := mockey.Mock((*MetaCache).GetDatabaseInfo).
 		Return(&databaseInfo{DBID: 5}, nil).Build()
 	defer mockGetDBInfo.UnPatch()
@@ -1439,7 +1464,8 @@ func TestListRestoreSnapshotJobsTask_PreExecute_OnlyDbName(t *testing.T) {
 		},
 	}
 
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetDBInfo := mockey.Mock((*MetaCache).GetDatabaseInfo).
 		Return(&databaseInfo{DBID: 5}, nil).Build()
 	defer mockGetDBInfo.UnPatch()
@@ -1497,7 +1523,8 @@ func TestListRestoreSnapshotJobsTask_Execute_Success(t *testing.T) {
 	defer mockListJobs.UnPatch()
 
 	// Mock resolveCollectionNames for both collections
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	callCount := 0
 	mockGetCollectionInfo := mockey.Mock((*MetaCache).GetCollectionInfo).
 		To(func(ctx context.Context, database string, collectionName string, collectionID int64) (*collectionInfo, error) {
@@ -1659,7 +1686,8 @@ func TestPinSnapshotDataTask_PreExecute_Success(t *testing.T) {
 		},
 	}
 
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 	defer mockGetCollectionID.UnPatch()
 
@@ -1736,7 +1764,8 @@ func TestPinSnapshotDataTask_PreExecute_TTLAtMaxBoundary(t *testing.T) {
 		},
 	}
 
-	globalMetaCache = &MetaCache{}
+	cache := &MetaCache{}
+	defer mockBaseTaskMetaCacheForTest(cache)()
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(100), nil).Build()
 	defer mockGetCollectionID.UnPatch()
 

--- a/internal/proxy/task_statistic.go
+++ b/internal/proxy/task_statistic.go
@@ -110,11 +110,11 @@ func (g *getStatisticsTask) PreExecute(ctx context.Context) error {
 	ctx, sp := otel.Tracer(typeutil.ProxyRole).Start(ctx, "Proxy-GetStatistics-PreExecute")
 	defer sp.End()
 
-	collID, err := globalMetaCache.GetCollectionID(ctx, g.request.GetDbName(), g.collectionName)
+	collID, err := g.getMetaCache().GetCollectionID(ctx, g.request.GetDbName(), g.collectionName)
 	if err != nil { // err is not nil if collection not exists
 		return err
 	}
-	partIDs, err := getPartitionIDs(ctx, g.request.GetDbName(), g.collectionName, g.partitionNames)
+	partIDs, err := getPartitionIDs(ctx, g.getMetaCache(), g.request.GetDbName(), g.collectionName, g.partitionNames)
 	if err != nil { // err is not nil if partition not exists
 		return err
 	}
@@ -131,7 +131,7 @@ func (g *getStatisticsTask) PreExecute(ctx context.Context) error {
 	}
 
 	// check if collection/partitions are loaded into query node
-	loaded, unloaded, err := checkFullLoaded(ctx, g.mixc, g.request.GetDbName(), g.collectionName, g.CollectionID, partIDs)
+	loaded, unloaded, err := checkFullLoaded(ctx, g.getMetaCache(), g.mixc, g.request.GetDbName(), g.collectionName, g.CollectionID, partIDs)
 	log := mlog.With(
 		mlog.String("collectionName", g.collectionName),
 		mlog.Int64("collectionID", g.CollectionID),
@@ -310,16 +310,16 @@ func (g *getStatisticsTask) getStatisticsShard(ctx context.Context, nodeID int64
 
 // checkFullLoaded check if collection / partition was fully loaded into QueryNode
 // return loaded partitions, unloaded partitions and error
-func checkFullLoaded(ctx context.Context, qc types.QueryCoordClient, dbName string, collectionName string, collectionID int64, searchPartitionIDs []UniqueID) ([]UniqueID, []UniqueID, error) {
+func checkFullLoaded(ctx context.Context, metaCache Cache, qc types.QueryCoordClient, dbName string, collectionName string, collectionID int64, searchPartitionIDs []UniqueID) ([]UniqueID, []UniqueID, error) {
 	var loadedPartitionIDs []UniqueID
 	var unloadPartitionIDs []UniqueID
 
 	// TODO: Consider to check if partition loaded from cache to save rpc.
-	info, err := globalMetaCache.GetCollectionInfo(ctx, dbName, collectionName, collectionID)
+	info, err := metaCache.GetCollectionInfo(ctx, dbName, collectionName, collectionID)
 	if err != nil {
 		return nil, nil, merr.Wrapf(err, "GetCollectionInfo failed, dbName = %s, collectionName = %s, collectionID = %d", dbName, collectionName, collectionID)
 	}
-	partitionInfos, err := globalMetaCache.GetPartitions(ctx, dbName, collectionName)
+	partitionInfos, err := metaCache.GetPartitions(ctx, dbName, collectionName)
 	if err != nil {
 		return nil, nil, merr.Wrapf(err, "GetPartitions failed, dbName = %s, collectionName = %s, collectionID = %d", dbName, collectionName, collectionID)
 	}
@@ -643,7 +643,7 @@ func (g *getCollectionStatisticsTask) PreExecute(ctx context.Context) error {
 }
 
 func (g *getCollectionStatisticsTask) Execute(ctx context.Context) error {
-	collID, err := globalMetaCache.GetCollectionID(ctx, g.GetDbName(), g.CollectionName)
+	collID, err := g.getMetaCache().GetCollectionID(ctx, g.GetDbName(), g.CollectionName)
 	if err != nil {
 		return err
 	}
@@ -726,12 +726,12 @@ func (g *getPartitionStatisticsTask) PreExecute(ctx context.Context) error {
 }
 
 func (g *getPartitionStatisticsTask) Execute(ctx context.Context) error {
-	collID, err := globalMetaCache.GetCollectionID(ctx, g.GetDbName(), g.CollectionName)
+	collID, err := g.getMetaCache().GetCollectionID(ctx, g.GetDbName(), g.CollectionName)
 	if err != nil {
 		return err
 	}
 	g.collectionID = collID
-	partitionID, err := globalMetaCache.GetPartitionID(ctx, g.GetDbName(), g.CollectionName, g.PartitionName)
+	partitionID, err := g.getMetaCache().GetPartitionID(ctx, g.GetDbName(), g.CollectionName, g.PartitionName)
 	if err != nil {
 		return err
 	}

--- a/internal/proxy/task_statistic_test.go
+++ b/internal/proxy/task_statistic_test.go
@@ -44,8 +44,9 @@ type StatisticTaskSuite struct {
 	mixc types.MixCoordClient
 	qn   *mocks.MockQueryNodeClient
 
-	lb  shardclient.LBPolicy
-	mgr shardclient.ShardClientMgr
+	lb        shardclient.LBPolicy
+	mgr       shardclient.ShardClientMgr
+	metaCache Cache
 
 	collectionName string
 	collectionID   int64
@@ -94,8 +95,10 @@ func (s *StatisticTaskSuite) SetupTest() {
 	s.mgr = mgr
 	s.lb = shardclient.NewLBPolicyImpl(mgr)
 
-	err := InitMetaCache(context.Background(), s.mixc)
+	cache, err := initMetaCache(context.Background(), s.mixc)
 	s.NoError(err)
+	s.metaCache = cache
+	s.T().Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 	s.collectionName = "test_statistics_task"
 	s.loadCollection()
@@ -135,7 +138,7 @@ func (s *StatisticTaskSuite) loadCollection() {
 	s.NoError(createColT.Execute(ctx))
 	s.NoError(createColT.PostExecute(ctx))
 
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, GetCurDBNameFromContextOrDefault(ctx), s.collectionName)
+	collectionID, err := s.metaCache.GetCollectionID(ctx, GetCurDBNameFromContextOrDefault(ctx), s.collectionName)
 	s.NoError(err)
 
 	status, err := s.mixc.LoadCollection(ctx, &querypb.LoadCollectionRequest{

--- a/internal/proxy/task_statistic_test.go
+++ b/internal/proxy/task_statistic_test.go
@@ -98,7 +98,6 @@ func (s *StatisticTaskSuite) SetupTest() {
 	cache, err := initMetaCache(context.Background(), s.mixc)
 	s.NoError(err)
 	s.metaCache = cache
-	s.T().Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 	s.collectionName = "test_statistics_task"
 	s.loadCollection()
@@ -176,6 +175,7 @@ func (s *StatisticTaskSuite) TestStatisticTask_Timeout() {
 
 func (s *StatisticTaskSuite) getStatisticsTask(ctx context.Context) *getStatisticsTask {
 	return &getStatisticsTask{
+		baseTask:       baseTask{metaCache: s.metaCache},
 		Condition:      NewTaskCondition(ctx),
 		ctx:            ctx,
 		collectionName: s.collectionName,

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -521,7 +521,7 @@ func TestAlterCollection_AllowInsertAutoID_Validation(t *testing.T) {
 
 	buildRoot := func(autoID bool) *mocks.MockMixCoordClient {
 		root := mocks.NewMockMixCoordClient(t)
-		// InitMetaCache requires ListPolicy
+		// initMetaCache requires ListPolicy
 		root.EXPECT().ListPolicy(mock.Anything, mock.Anything, mock.Anything).Return(&internalpb.ListPolicyResponse{Status: merr.Success()}, nil).Once()
 		// Meta cache update path fetches partitions info
 		root.EXPECT().ShowPartitions(mock.Anything, mock.Anything, mock.Anything).Return(&milvuspb.ShowPartitionsResponse{Status: merr.Success()}, nil).Maybe()
@@ -543,11 +543,10 @@ func TestAlterCollection_AllowInsertAutoID_Validation(t *testing.T) {
 	}
 
 	t.Run("success when PK autoID=true and allow_insert_autoid=true", func(t *testing.T) {
-		cache := globalMetaCache
-		defer func() { globalMetaCache = cache }()
 		root := buildRoot(true)
-		err := InitMetaCache(ctx, root)
+		cache, err := initMetaCache(ctx, root)
 		assert.NoError(t, err)
+		t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 		task := &alterCollectionTask{
 			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
@@ -564,11 +563,10 @@ func TestAlterCollection_AllowInsertAutoID_Validation(t *testing.T) {
 	})
 
 	t.Run("error when PK autoID=false and allow_insert_autoid=true", func(t *testing.T) {
-		cache := globalMetaCache
-		defer func() { globalMetaCache = cache }()
 		root := buildRoot(false)
-		err := InitMetaCache(ctx, root)
+		cache, err := initMetaCache(ctx, root)
 		assert.NoError(t, err)
+		t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 		task := &alterCollectionTask{
 			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
@@ -2180,7 +2178,8 @@ func TestHasCollectionTask(t *testing.T) {
 	mixc := NewMixCoordMock()
 	defer mixc.Close()
 	ctx := context.Background()
-	InitMetaCache(ctx, mixc)
+	cache, err := initMetaCache(ctx, mixc)
+	assert.NoError(t, err)
 	prefix := "TestHasCollectionTask"
 	dbName := ""
 	collectionName := prefix + funcutil.GenRandomStr()
@@ -2230,13 +2229,14 @@ func TestHasCollectionTask(t *testing.T) {
 	assert.Equal(t, Timestamp(100), task.BeginTs())
 	assert.Equal(t, Timestamp(100), task.EndTs())
 	assert.Equal(t, paramtable.GetNodeID(), task.GetBase().GetSourceID())
-	// missing collectionID in globalMetaCache
+	// missing collectionID in meta cache
 	err = task.Execute(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, false, task.result.Value)
-	// createIsoCollection in RootCood and fill GlobalMetaCache
+	// createIsoCollection in RootCood and fill meta cache
 	mixc.CreateCollection(ctx, createColReq)
-	globalMetaCache.GetCollectionID(ctx, GetCurDBNameFromContextOrDefault(ctx), collectionName)
+	_, err = cache.GetCollectionID(ctx, GetCurDBNameFromContextOrDefault(ctx), collectionName)
+	assert.NoError(t, err)
 
 	// success to drop collection
 	err = task.Execute(ctx)
@@ -2251,7 +2251,7 @@ func TestHasCollectionTask(t *testing.T) {
 	task.CollectionName = collectionName
 
 	// invalidate collection cache, trigger rootcoord rpc
-	globalMetaCache.RemoveCollection(ctx, dbName, collectionName)
+	cache.RemoveCollection(ctx, dbName, collectionName)
 
 	// rc return collection not found error
 	mixc.describeCollectionFunc = func(ctx context.Context, request *milvuspb.DescribeCollectionRequest) (*milvuspb.DescribeCollectionResponse, error) {
@@ -2276,7 +2276,8 @@ func TestDescribeCollectionTask(t *testing.T) {
 	mixc := NewMixCoordMock()
 	defer mixc.Close()
 	ctx := context.Background()
-	InitMetaCache(ctx, mixc)
+	_, err := initMetaCache(ctx, mixc)
+	assert.NoError(t, err)
 	prefix := "TestDescribeCollectionTask"
 	dbName := ""
 	collectionName := prefix + funcutil.GenRandomStr()
@@ -2305,8 +2306,8 @@ func TestDescribeCollectionTask(t *testing.T) {
 	assert.Equal(t, Timestamp(100), task.BeginTs())
 	assert.Equal(t, Timestamp(100), task.EndTs())
 	assert.Equal(t, paramtable.GetNodeID(), task.GetBase().GetSourceID())
-	// missing collectionID in globalMetaCache
-	err := task.Execute(ctx)
+	// missing collectionID in meta cache
+	err = task.Execute(ctx)
 	assert.NoError(t, err)
 
 	// illegal name
@@ -2335,7 +2336,8 @@ func TestDescribeCollectionTask_ShardsNum1(t *testing.T) {
 	mix := NewMixCoordMock()
 
 	ctx := context.Background()
-	InitMetaCache(ctx, mix)
+	cache, err := initMetaCache(ctx, mix)
+	assert.NoError(t, err)
 	prefix := "TestDescribeCollectionTask"
 	dbName := ""
 	collectionName := prefix + funcutil.GenRandomStr()
@@ -2362,7 +2364,8 @@ func TestDescribeCollectionTask_ShardsNum1(t *testing.T) {
 	}
 
 	mix.CreateCollection(ctx, createColReq)
-	globalMetaCache.GetCollectionID(ctx, GetCurDBNameFromContextOrDefault(ctx), collectionName)
+	_, err = cache.GetCollectionID(ctx, GetCurDBNameFromContextOrDefault(ctx), collectionName)
+	assert.NoError(t, err)
 
 	// CreateCollection
 	task := &describeCollectionTask{
@@ -2393,7 +2396,8 @@ func TestDescribeCollectionTask_ShardsNum1(t *testing.T) {
 func TestDescribeCollectionTask_EnableDynamicSchema(t *testing.T) {
 	mix := NewMixCoordMock()
 	ctx := context.Background()
-	InitMetaCache(ctx, mix)
+	cache, err := initMetaCache(ctx, mix)
+	assert.NoError(t, err)
 	prefix := "TestDescribeCollectionTask"
 	dbName := ""
 	collectionName := prefix + funcutil.GenRandomStr()
@@ -2420,7 +2424,8 @@ func TestDescribeCollectionTask_EnableDynamicSchema(t *testing.T) {
 	}
 
 	mix.CreateCollection(ctx, createColReq)
-	globalMetaCache.GetCollectionID(ctx, dbName, collectionName)
+	_, err = cache.GetCollectionID(ctx, dbName, collectionName)
+	assert.NoError(t, err)
 
 	// CreateCollection
 	task := &describeCollectionTask{
@@ -2452,7 +2457,9 @@ func TestDescribeCollectionTask_EnableDynamicSchema(t *testing.T) {
 func TestDescribeCollectionTask_FilterNamespaceField(t *testing.T) {
 	mix := NewMixCoordMock()
 	ctx := context.Background()
-	InitMetaCache(ctx, mix)
+	cache, err := initMetaCache(ctx, mix)
+	assert.NoError(t, err)
+	_ = cache
 
 	dbName := ""
 	collectionName := "TestDescribeCollectionTask_FilterNamespaceField"
@@ -2519,7 +2526,7 @@ func TestDescribeCollectionTask_FilterNamespaceField(t *testing.T) {
 		mixCoord: mix,
 	}
 
-	err := task.PreExecute(ctx)
+	err = task.PreExecute(ctx)
 	assert.NoError(t, err)
 
 	err = task.Execute(ctx)
@@ -2588,7 +2595,9 @@ func TestDescribeCollectionTask_FillsNameFromResultWhenQueriedByID(t *testing.T)
 func TestDescribeCollectionTask_RedactsExternalSpecCredentials(t *testing.T) {
 	mix := NewMixCoordMock()
 	ctx := context.Background()
-	InitMetaCache(ctx, mix)
+	cache, err := initMetaCache(ctx, mix)
+	assert.NoError(t, err)
+	_ = cache
 
 	collectionName := "TestDescribeCollectionTask_RedactsExternalSpecCredentials"
 
@@ -2645,7 +2654,8 @@ func TestDescribeCollectionTask_RedactsExternalSpecCredentials(t *testing.T) {
 func TestDescribeCollectionTask_ShardsNum2(t *testing.T) {
 	mix := NewMixCoordMock()
 	ctx := context.Background()
-	InitMetaCache(ctx, mix)
+	cache, err := initMetaCache(ctx, mix)
+	assert.NoError(t, err)
 	prefix := "TestDescribeCollectionTask"
 	dbName := ""
 	collectionName := prefix + funcutil.GenRandomStr()
@@ -2670,7 +2680,8 @@ func TestDescribeCollectionTask_ShardsNum2(t *testing.T) {
 	}
 
 	mix.CreateCollection(ctx, createColReq)
-	globalMetaCache.GetCollectionID(ctx, GetCurDBNameFromContextOrDefault(ctx), collectionName)
+	_, err = cache.GetCollectionID(ctx, GetCurDBNameFromContextOrDefault(ctx), collectionName)
+	assert.NoError(t, err)
 
 	// CreateCollection
 	task := &describeCollectionTask{
@@ -2690,7 +2701,7 @@ func TestDescribeCollectionTask_ShardsNum2(t *testing.T) {
 	}
 	task.PreExecute(ctx)
 
-	// missing collectionID in globalMetaCache
+	// missing collectionID in meta cache
 	err = task.Execute(ctx)
 	assert.NoError(t, err)
 
@@ -2712,8 +2723,6 @@ func TestCreatePartitionTask(t *testing.T) {
 			{FieldID: 101, Name: "Vector", DataType: schemapb.DataType_FloatVector},
 		},
 	}), nil)
-	globalMetaCache = mockCache
-
 	ctx := context.Background()
 	prefix := "TestCreatePartitionTask"
 	dbName := ""
@@ -2736,6 +2745,7 @@ func TestCreatePartitionTask(t *testing.T) {
 		mixCoord: rc,
 		result:   nil,
 	}
+	task.metaCache = mockCache
 	task.OnEnqueue()
 	task.PreExecute(ctx)
 
@@ -2790,7 +2800,6 @@ func TestDropPartitionTask(t *testing.T) {
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("string"),
 	).Return(mustNewSchemaInfo(&schemapb.CollectionSchema{}), nil)
-	globalMetaCache = mockCache
 
 	task := &dropPartitionTask{
 		Condition: NewTaskCondition(ctx),
@@ -2808,6 +2817,7 @@ func TestDropPartitionTask(t *testing.T) {
 		mixCoord: mixc,
 		result:   nil,
 	}
+	task.metaCache = mockCache
 	task.OnEnqueue()
 	task.PreExecute(ctx)
 
@@ -2841,7 +2851,7 @@ func TestDropPartitionTask(t *testing.T) {
 			mock.AnythingOfType("string"),
 			mock.AnythingOfType("string"),
 		).Return(mustNewSchemaInfo(&schemapb.CollectionSchema{}), nil)
-		globalMetaCache = mockCache
+		task.metaCache = mockCache
 		task.PartitionName = "partition1"
 		err = task.PreExecute(ctx)
 		assert.Error(t, err)
@@ -2868,7 +2878,7 @@ func TestDropPartitionTask(t *testing.T) {
 			mock.AnythingOfType("string"),
 			mock.AnythingOfType("string"),
 		).Return(mustNewSchemaInfo(&schemapb.CollectionSchema{}), nil)
-		globalMetaCache = mockCache
+		task.metaCache = mockCache
 		err = task.PreExecute(ctx)
 		assert.NoError(t, err)
 	})
@@ -2894,7 +2904,7 @@ func TestDropPartitionTask(t *testing.T) {
 			mock.AnythingOfType("string"),
 			mock.AnythingOfType("string"),
 		).Return(mustNewSchemaInfo(&schemapb.CollectionSchema{}), nil)
-		globalMetaCache = mockCache
+		task.metaCache = mockCache
 		err = task.PreExecute(ctx)
 		assert.Error(t, err)
 	})
@@ -3008,7 +3018,7 @@ func TestTask_Int64PrimaryKey(t *testing.T) {
 	qc := NewMixCoordMock()
 	ctx := context.Background()
 
-	err = InitMetaCache(ctx, qc)
+	cache, err := initMetaCache(ctx, qc)
 	assert.NoError(t, err)
 
 	shardsNum := int32(2)
@@ -3066,7 +3076,7 @@ func TestTask_Int64PrimaryKey(t *testing.T) {
 		PartitionName:  partitionName,
 	})
 
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, dbName, collectionName)
+	collectionID, err := cache.GetCollectionID(ctx, dbName, collectionName)
 	assert.NoError(t, err)
 
 	dmlChannelsFunc := getDmlChannelsFunc(ctx, qc)
@@ -3089,6 +3099,7 @@ func TestTask_Int64PrimaryKey(t *testing.T) {
 	t.Run("insert", func(t *testing.T) {
 		hash := testutils.GenerateHashKeys(nb)
 		task := &insertTask{
+			baseTask: baseTask{metaCache: cache},
 			insertMsg: &BaseInsertTask{
 				BaseMsg: msgstream.BaseMsg{
 					HashValues: hash,
@@ -3139,6 +3150,7 @@ func TestTask_Int64PrimaryKey(t *testing.T) {
 
 	t.Run("simple delete", func(t *testing.T) {
 		task := &deleteTask{
+			baseTask:  baseTask{metaCache: cache},
 			Condition: NewTaskCondition(ctx),
 			req: &milvuspb.DeleteRequest{
 				CollectionName: collectionName,
@@ -3236,7 +3248,7 @@ func TestTask_VarCharPrimaryKey(t *testing.T) {
 
 	ctx := context.Background()
 
-	err = InitMetaCache(ctx, mixc)
+	cache, err := initMetaCache(ctx, mixc)
 	assert.NoError(t, err)
 
 	shardsNum := int32(2)
@@ -3295,7 +3307,7 @@ func TestTask_VarCharPrimaryKey(t *testing.T) {
 		PartitionName:  partitionName,
 	})
 
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, dbName, collectionName)
+	collectionID, err := cache.GetCollectionID(ctx, dbName, collectionName)
 	assert.NoError(t, err)
 
 	dmlChannelsFunc := getDmlChannelsFunc(ctx, mixc)
@@ -3318,6 +3330,7 @@ func TestTask_VarCharPrimaryKey(t *testing.T) {
 	t.Run("insert", func(t *testing.T) {
 		hash := testutils.GenerateHashKeys(nb)
 		task := &insertTask{
+			baseTask: baseTask{metaCache: cache},
 			insertMsg: &BaseInsertTask{
 				BaseMsg: msgstream.BaseMsg{
 					HashValues: hash,
@@ -3371,6 +3384,7 @@ func TestTask_VarCharPrimaryKey(t *testing.T) {
 	t.Run("upsert", func(t *testing.T) {
 		hash := testutils.GenerateHashKeys(nb)
 		task := &upsertTask{
+			baseTask: baseTask{metaCache: cache},
 			upsertMsg: &msgstream.UpsertMsg{
 				InsertMsg: &BaseInsertTask{
 					BaseMsg: msgstream.BaseMsg{
@@ -3454,6 +3468,7 @@ func TestTask_VarCharPrimaryKey(t *testing.T) {
 
 	t.Run("simple delete", func(t *testing.T) {
 		task := &deleteTask{
+			baseTask:  baseTask{metaCache: cache},
 			Condition: NewTaskCondition(ctx),
 			req: &milvuspb.DeleteRequest{
 				CollectionName: collectionName,
@@ -3543,7 +3558,7 @@ func Test_createIndexTask_getIndexedFieldAndFunction(t *testing.T) {
 			},
 		}), nil)
 
-		globalMetaCache = cache
+		cit.metaCache = cache
 		err := cit.getIndexedFieldAndFunction(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, fieldName, cit.fieldSchema.GetName())
@@ -3556,7 +3571,7 @@ func Test_createIndexTask_getIndexedFieldAndFunction(t *testing.T) {
 			mock.AnythingOfType("string"),
 			mock.AnythingOfType("string"),
 		).Return(nil, errors.New("mock"))
-		globalMetaCache = cache
+		cit.metaCache = cache
 		err := cit.getIndexedFieldAndFunction(context.Background())
 		assert.Error(t, err)
 	})
@@ -3575,7 +3590,7 @@ func Test_createIndexTask_getIndexedFieldAndFunction(t *testing.T) {
 				otherField,
 			},
 		}), nil)
-		globalMetaCache = cache
+		cit.metaCache = cache
 		err := cit.getIndexedFieldAndFunction(context.Background())
 		assert.Error(t, err)
 	})
@@ -3742,7 +3757,7 @@ func Test_createIndexTask_PreExecute(t *testing.T) {
 			mock.AnythingOfType("string"),
 			mock.AnythingOfType("int64"),
 		).Return(&collectionInfo{}, nil)
-		globalMetaCache = cache
+		cit.metaCache = cache
 		cit.req.ExtraParams = []*commonpb.KeyValuePair{
 			{
 				Key:   common.IndexTypeKey,
@@ -3767,7 +3782,7 @@ func Test_createIndexTask_PreExecute(t *testing.T) {
 			mock.AnythingOfType("string"),
 			mock.AnythingOfType("string"),
 		).Return(UniqueID(0), errors.New("mock"))
-		globalMetaCache = cache
+		cit.metaCache = cache
 		assert.Error(t, cit.PreExecute(context.Background()))
 	})
 
@@ -3784,7 +3799,7 @@ func Test_createIndexTask_PreExecute(t *testing.T) {
 			mock.AnythingOfType("string"),
 			mock.AnythingOfType("int64"),
 		).Return(&collectionInfo{}, nil)
-		globalMetaCache = cache
+		cit.metaCache = cache
 
 		for i := 0; i < 256; i++ {
 			cit.req.IndexName += "a"
@@ -3815,7 +3830,7 @@ func Test_dropCollectionTask_PreExecute(t *testing.T) {
 		CollectionName: "valid", // invalid
 
 	}}
-	globalMetaCache = &MetaCache{}
+	dct.metaCache = &MetaCache{}
 	mockGetCollectionID := mockey.Mock((*MetaCache).GetCollectionID).To(func(ctx context.Context, dbName, collectionName string) (UniqueID, error) {
 		return 1, nil
 	}).Build()
@@ -3869,7 +3884,8 @@ func Test_dropCollectionTask_PostExecute(t *testing.T) {
 func Test_truncateCollectionTask_PreExecute(t *testing.T) {
 	mix := NewMixCoordMock()
 	ctx := context.Background()
-	require.NoError(t, InitMetaCache(ctx, mix))
+	cache, err := initMetaCache(ctx, mix)
+	require.NoError(t, err)
 
 	dbName := ""
 	regularName := "regular_truncate_" + funcutil.GenRandomStr()
@@ -3908,6 +3924,7 @@ func Test_truncateCollectionTask_PreExecute(t *testing.T) {
 		tct := &truncateCollectionTask{TruncateCollectionRequest: &milvuspb.TruncateCollectionRequest{
 			Base: &commonpb.MsgBase{}, DbName: dbName, CollectionName: regularName,
 		}}
+		tct.metaCache = cache
 		assert.NoError(t, tct.PreExecute(ctx))
 	})
 
@@ -3925,6 +3942,7 @@ func Test_truncateCollectionTask_PreExecute(t *testing.T) {
 		tct := &truncateCollectionTask{TruncateCollectionRequest: &milvuspb.TruncateCollectionRequest{
 			Base: &commonpb.MsgBase{}, DbName: dbName, CollectionName: externalName,
 		}}
+		tct.metaCache = cache
 		err := tct.PreExecute(ctx)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "external collection")
@@ -3984,7 +4002,8 @@ func Test_loadCollectionTask_Execute(t *testing.T) {
 	indexID := int64(1000)
 
 	// failed to get collection id.
-	_ = InitMetaCache(ctx, rc)
+	cache, err := initMetaCache(ctx, rc)
+	assert.NoError(t, err)
 
 	rc.DescribeCollectionFunc = func(ctx context.Context, request *milvuspb.DescribeCollectionRequest, opts ...grpc.CallOption) (*milvuspb.DescribeCollectionResponse, error) {
 		return &milvuspb.DescribeCollectionResponse{
@@ -4013,6 +4032,7 @@ func Test_loadCollectionTask_Execute(t *testing.T) {
 		result:       nil,
 		collectionID: 0,
 	}
+	lct.metaCache = cache
 
 	t.Run("indexcoord describe index error", func(t *testing.T) {
 		err := lct.Execute(ctx)
@@ -4103,11 +4123,6 @@ func TestLoadCollectionTaskExecuteTextRequiresStorageV3(t *testing.T) {
 		paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
 	})
 
-	oldCache := globalMetaCache
-	t.Cleanup(func() {
-		globalMetaCache = oldCache
-	})
-
 	const (
 		dbName         = "db"
 		collectionName = "text_collection"
@@ -4117,7 +4132,6 @@ func TestLoadCollectionTaskExecuteTextRequiresStorageV3(t *testing.T) {
 	cache := NewMockCache(t)
 	cache.EXPECT().GetCollectionID(mock.Anything, dbName, collectionName).Return(collectionID, nil)
 	cache.EXPECT().GetCollectionSchema(mock.Anything, dbName, collectionName).Return(schema, nil)
-	globalMetaCache = cache
 
 	task := &loadCollectionTask{
 		LoadCollectionRequest: &milvuspb.LoadCollectionRequest{
@@ -4127,6 +4141,7 @@ func TestLoadCollectionTaskExecuteTextRequiresStorageV3(t *testing.T) {
 		},
 		ctx: context.Background(),
 	}
+	task.metaCache = cache
 
 	err := task.Execute(context.Background())
 	assert.Error(t, err)
@@ -4146,7 +4161,8 @@ func Test_loadPartitionTask_Execute(t *testing.T) {
 	indexID := int64(1000)
 
 	// failed to get collection id.
-	_ = InitMetaCache(ctx, qc)
+	cache, err := initMetaCache(ctx, qc)
+	assert.NoError(t, err)
 
 	qc.DescribeCollectionFunc = func(ctx context.Context, request *milvuspb.DescribeCollectionRequest, opts ...grpc.CallOption) (*milvuspb.DescribeCollectionResponse, error) {
 		return &milvuspb.DescribeCollectionResponse{
@@ -4175,6 +4191,7 @@ func Test_loadPartitionTask_Execute(t *testing.T) {
 		result:       nil,
 		collectionID: 0,
 	}
+	lpt.metaCache = cache
 
 	t.Run("indexcoord describe index error", func(t *testing.T) {
 		err := lpt.Execute(ctx)
@@ -4229,7 +4246,8 @@ func TestCreateResourceGroupTask(t *testing.T) {
 	defer mixc.Close()
 
 	ctx := context.Background()
-	InitMetaCache(ctx, mixc)
+	_, err := initMetaCache(ctx, mixc)
+	assert.NoError(t, err)
 
 	createRGReq := &milvuspb.CreateResourceGroupRequest{
 		Base: &commonpb.MsgBase{
@@ -4255,7 +4273,7 @@ func TestCreateResourceGroupTask(t *testing.T) {
 	assert.Equal(t, paramtable.GetNodeID(), task.Base.GetSourceID())
 	assert.Equal(t, UniqueID(3), task.Base.GetTargetID())
 
-	err := task.Execute(ctx)
+	err = task.Execute(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, commonpb.ErrorCode_Success, task.result.ErrorCode)
 }
@@ -4266,7 +4284,8 @@ func TestDropResourceGroupTask(t *testing.T) {
 	defer mixc.Close()
 
 	ctx := context.Background()
-	InitMetaCache(ctx, mixc)
+	_, err := initMetaCache(ctx, mixc)
+	assert.NoError(t, err)
 
 	dropRGReq := &milvuspb.DropResourceGroupRequest{
 		Base: &commonpb.MsgBase{
@@ -4292,7 +4311,7 @@ func TestDropResourceGroupTask(t *testing.T) {
 	assert.Equal(t, paramtable.GetNodeID(), task.Base.GetSourceID())
 	assert.Equal(t, UniqueID(3), task.Base.GetTargetID())
 
-	err := task.Execute(ctx)
+	err = task.Execute(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, commonpb.ErrorCode_Success, task.result.ErrorCode)
 }
@@ -4302,7 +4321,8 @@ func TestTransferNodeTask(t *testing.T) {
 
 	defer mixc.Close()
 	ctx := context.Background()
-	InitMetaCache(ctx, mixc)
+	_, err := initMetaCache(ctx, mixc)
+	assert.NoError(t, err)
 
 	req := &milvuspb.TransferNodeRequest{
 		Base: &commonpb.MsgBase{
@@ -4330,7 +4350,7 @@ func TestTransferNodeTask(t *testing.T) {
 	assert.Equal(t, paramtable.GetNodeID(), task.Base.GetSourceID())
 	assert.Equal(t, UniqueID(3), task.Base.GetTargetID())
 
-	err := task.Execute(ctx)
+	err = task.Execute(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, commonpb.ErrorCode_Success, task.result.ErrorCode)
 }
@@ -4339,9 +4359,11 @@ func TestTransferReplicaTask(t *testing.T) {
 	rc := &MockMixCoordClientInterface{}
 
 	ctx := context.Background()
-	InitMetaCache(ctx, rc)
+	cache, err := initMetaCache(ctx, rc)
+	assert.NoError(t, err)
 	// make it avoid remote call on rc
-	globalMetaCache.GetCollectionSchema(context.Background(), GetCurDBNameFromContextOrDefault(ctx), "collection1")
+	_, err = cache.GetCollectionSchema(context.Background(), GetCurDBNameFromContextOrDefault(ctx), "collection1")
+	assert.NoError(t, err)
 
 	req := &milvuspb.TransferReplicaRequest{
 		Base: &commonpb.MsgBase{
@@ -4360,6 +4382,7 @@ func TestTransferReplicaTask(t *testing.T) {
 		ctx:                    ctx,
 		mixCoord:               rc,
 	}
+	task.metaCache = cache
 	task.OnEnqueue()
 	task.PreExecute(ctx)
 
@@ -4370,7 +4393,7 @@ func TestTransferReplicaTask(t *testing.T) {
 	assert.Equal(t, paramtable.GetNodeID(), task.Base.GetSourceID())
 	assert.Equal(t, UniqueID(3), task.Base.GetTargetID())
 
-	err := task.Execute(ctx)
+	err = task.Execute(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, commonpb.ErrorCode_Success, task.result.ErrorCode)
 }
@@ -4386,7 +4409,8 @@ func TestListResourceGroupsTask(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	InitMetaCache(ctx, rc)
+	_, err := initMetaCache(ctx, rc)
+	assert.NoError(t, err)
 
 	req := &milvuspb.ListResourceGroupsRequest{
 		Base: &commonpb.MsgBase{
@@ -4411,7 +4435,7 @@ func TestListResourceGroupsTask(t *testing.T) {
 	assert.Equal(t, paramtable.GetNodeID(), task.Base.GetSourceID())
 	assert.Equal(t, UniqueID(3), task.Base.GetTargetID())
 
-	err := task.Execute(ctx)
+	err = task.Execute(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, commonpb.ErrorCode_Success, task.result.GetStatus().GetErrorCode())
 	groups := task.result.GetResourceGroups()
@@ -4435,10 +4459,13 @@ func TestDescribeResourceGroupTask(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	InitMetaCache(ctx, rc)
+	cache, err := initMetaCache(ctx, rc)
+	assert.NoError(t, err)
 	// make it avoid remote call on rc
-	globalMetaCache.GetCollectionSchema(context.Background(), GetCurDBNameFromContextOrDefault(ctx), "collection1")
-	globalMetaCache.GetCollectionSchema(context.Background(), GetCurDBNameFromContextOrDefault(ctx), "collection2")
+	_, err = cache.GetCollectionSchema(context.Background(), GetCurDBNameFromContextOrDefault(ctx), "collection1")
+	assert.NoError(t, err)
+	_, err = cache.GetCollectionSchema(context.Background(), GetCurDBNameFromContextOrDefault(ctx), "collection2")
+	assert.NoError(t, err)
 
 	req := &milvuspb.DescribeResourceGroupRequest{
 		Base: &commonpb.MsgBase{
@@ -4454,6 +4481,7 @@ func TestDescribeResourceGroupTask(t *testing.T) {
 		ctx:                          ctx,
 		mixCoord:                     rc,
 	}
+	task.metaCache = cache
 	task.OnEnqueue()
 	task.PreExecute(ctx)
 
@@ -4464,7 +4492,7 @@ func TestDescribeResourceGroupTask(t *testing.T) {
 	assert.Equal(t, paramtable.GetNodeID(), task.Base.GetSourceID())
 	assert.Equal(t, UniqueID(3), task.Base.GetTargetID())
 
-	err := task.Execute(ctx)
+	err = task.Execute(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, commonpb.ErrorCode_Success, task.result.GetStatus().GetErrorCode())
 	groupInfo := task.result.GetResourceGroup()
@@ -4484,10 +4512,13 @@ func TestDescribeResourceGroupTaskFailed(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	InitMetaCache(ctx, rc)
+	cache, err := initMetaCache(ctx, rc)
+	assert.NoError(t, err)
 	// make it avoid remote call on rc
-	globalMetaCache.GetCollectionSchema(context.Background(), GetCurDBNameFromContextOrDefault(ctx), "collection1")
-	globalMetaCache.GetCollectionSchema(context.Background(), GetCurDBNameFromContextOrDefault(ctx), "collection2")
+	_, err = cache.GetCollectionSchema(context.Background(), GetCurDBNameFromContextOrDefault(ctx), "collection1")
+	assert.NoError(t, err)
+	_, err = cache.GetCollectionSchema(context.Background(), GetCurDBNameFromContextOrDefault(ctx), "collection2")
+	assert.NoError(t, err)
 
 	req := &milvuspb.DescribeResourceGroupRequest{
 		Base: &commonpb.MsgBase{
@@ -4503,6 +4534,7 @@ func TestDescribeResourceGroupTaskFailed(t *testing.T) {
 		ctx:                          ctx,
 		mixCoord:                     rc,
 	}
+	task.metaCache = cache
 	task.OnEnqueue()
 	task.PreExecute(ctx)
 
@@ -4513,7 +4545,7 @@ func TestDescribeResourceGroupTaskFailed(t *testing.T) {
 	assert.Equal(t, paramtable.GetNodeID(), task.Base.GetSourceID())
 	assert.Equal(t, UniqueID(3), task.Base.GetTargetID())
 
-	err := task.Execute(ctx)
+	err = task.Execute(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, commonpb.ErrorCode_UnexpectedError, task.result.GetStatus().GetErrorCode())
 
@@ -4541,11 +4573,8 @@ func TestCreateCollectionTaskWithPartitionKey(t *testing.T) {
 	paramtable.Init()
 
 	defer rc.Close()
-	cache := globalMetaCache
-	defer func() { globalMetaCache = cache }()
 	mockCache := NewMockCache(t)
 	mockCache.EXPECT().GetDatabaseInfo(mock.Anything, mock.Anything).Return(&databaseInfo{}, nil).Maybe()
-	globalMetaCache = mockCache
 	ctx := context.Background()
 	shardsNum := common.DefaultShardsNum
 	prefix := "TestCreateCollectionTaskWithPartitionKey"
@@ -4615,6 +4644,7 @@ func TestCreateCollectionTaskWithPartitionKey(t *testing.T) {
 		result:   nil,
 		schema:   nil,
 	}
+	task.metaCache = mockCache
 
 	t.Run("PreExecute", func(t *testing.T) {
 		defer Params.Reset(Params.RootCoordCfg.MaxPartitionNum.Key)
@@ -4732,9 +4762,9 @@ func TestCreateCollectionTaskWithPartitionKey(t *testing.T) {
 		assert.NoError(t, err)
 
 		// check default partitions
-		err = InitMetaCache(ctx, rc)
+		cache, err := initMetaCache(ctx, rc)
 		assert.NoError(t, err)
-		partitionNames, err := getDefaultPartitionsInPartitionKeyMode(ctx, "", task.CollectionName)
+		partitionNames, err := getDefaultPartitionsInPartitionKeyMode(ctx, cache, "", task.CollectionName)
 		assert.NoError(t, err)
 		assert.Equal(t, task.GetNumPartitions(), int64(len(partitionNames)))
 
@@ -4811,7 +4841,7 @@ func TestPartitionKey(t *testing.T) {
 	defer qc.Close()
 	ctx := context.Background()
 
-	err := InitMetaCache(ctx, qc)
+	cache, err := initMetaCache(ctx, qc)
 	assert.NoError(t, err)
 
 	shardsNum := common.DefaultShardsNum
@@ -4856,7 +4886,7 @@ func TestPartitionKey(t *testing.T) {
 	err = createCollectionTask.Execute(ctx)
 	assert.NoError(t, err)
 
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, GetCurDBNameFromContextOrDefault(ctx), collectionName)
+	collectionID, err := cache.GetCollectionID(ctx, GetCurDBNameFromContextOrDefault(ctx), collectionName)
 	assert.NoError(t, err)
 
 	dmlChannelsFunc := getDmlChannelsFunc(ctx, qc)
@@ -4876,7 +4906,7 @@ func TestPartitionKey(t *testing.T) {
 	_ = idAllocator.Start()
 	defer idAllocator.Close()
 
-	partitionNames, err := getDefaultPartitionsInPartitionKeyMode(ctx, "", collectionName)
+	partitionNames, err := getDefaultPartitionsInPartitionKeyMode(ctx, cache, "", collectionName)
 	assert.NoError(t, err)
 	assert.Equal(t, common.DefaultPartitionsWithPartitionKey, int64(len(partitionNames)))
 
@@ -5046,7 +5076,7 @@ func TestDefaultPartition(t *testing.T) {
 	qc := NewMixCoordMock()
 	ctx := context.Background()
 
-	err := InitMetaCache(ctx, qc)
+	cache, err := initMetaCache(ctx, qc)
 	assert.NoError(t, err)
 
 	shardsNum := common.DefaultShardsNum
@@ -5085,7 +5115,7 @@ func TestDefaultPartition(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	collectionID, err := globalMetaCache.GetCollectionID(ctx, GetCurDBNameFromContextOrDefault(ctx), collectionName)
+	collectionID, err := cache.GetCollectionID(ctx, GetCurDBNameFromContextOrDefault(ctx), collectionName)
 	assert.NoError(t, err)
 
 	dmlChannelsFunc := getDmlChannelsFunc(ctx, qc)
@@ -5226,7 +5256,7 @@ func TestClusteringKey(t *testing.T) {
 
 	ctx := context.Background()
 
-	err := InitMetaCache(ctx, qc)
+	_, err := initMetaCache(ctx, qc)
 	assert.NoError(t, err)
 
 	shardsNum := common.DefaultShardsNum
@@ -5501,7 +5531,8 @@ func TestClusteringKey(t *testing.T) {
 
 func TestAlterCollectionCheckLoaded(t *testing.T) {
 	qc := NewMixCoordMock()
-	InitMetaCache(context.Background(), qc)
+	_, err := initMetaCache(context.Background(), qc)
+	assert.NoError(t, err)
 	collectionName := "test_alter_collection_check_loaded"
 	createColReq := &milvuspb.CreateCollectionRequest{
 		Base: &commonpb.MsgBase{
@@ -5543,9 +5574,7 @@ func TestAlterCollectionCheckLoaded(t *testing.T) {
 func TestAlterCollectionTaskValidateTTLAndTTLField(t *testing.T) {
 	qc := NewMixCoordMock()
 	ctx := context.Background()
-	cache := globalMetaCache
-	defer func() { globalMetaCache = cache }()
-	err := InitMetaCache(ctx, qc)
+	_, err := initMetaCache(ctx, qc)
 	assert.NoError(t, err)
 
 	createCollectionWithProps := func(colName string, props []*commonpb.KeyValuePair) {
@@ -5669,9 +5698,7 @@ func TestAlterCollectionTaskValidateTTLAndTTLField(t *testing.T) {
 func TestAlterCollectionTaskValidateDescription(t *testing.T) {
 	qc := NewMixCoordMock()
 	ctx := context.Background()
-	cache := globalMetaCache
-	defer func() { globalMetaCache = cache }()
-	err := InitMetaCache(ctx, qc)
+	_, err := initMetaCache(ctx, qc)
 	assert.NoError(t, err)
 
 	maxLen := Params.ProxyCfg.MaxCollectionDescriptionLength.GetAsInt()
@@ -5796,7 +5823,7 @@ func mockVectorIndexForCollection(t *testing.T, ctx context.Context, qc *MixCoor
 func TestTaskPartitionKeyIsolation(t *testing.T) {
 	qc := NewMixCoordMock()
 	ctx := context.Background()
-	err := InitMetaCache(ctx, qc)
+	_, err := initMetaCache(ctx, qc)
 	assert.NoError(t, err)
 	shardsNum := common.DefaultShardsNum
 	prefix := "TestPartitionKeyIsolation"
@@ -6043,7 +6070,7 @@ func TestTaskPartitionKeyIsolation(t *testing.T) {
 func TestAlterCollectionQueryMode(t *testing.T) {
 	qc := NewMixCoordMock()
 	ctx := context.Background()
-	err := InitMetaCache(ctx, qc)
+	_, err := initMetaCache(ctx, qc)
 	assert.NoError(t, err)
 	prefix := "TestQueryMode"
 
@@ -6178,7 +6205,7 @@ func TestAlterCollectionQueryMode(t *testing.T) {
 func TestCollectionNamespaceShardingEnabledValidation(t *testing.T) {
 	qc := NewMixCoordMock()
 	ctx := context.Background()
-	err := InitMetaCache(ctx, qc)
+	_, err := initMetaCache(ctx, qc)
 	assert.NoError(t, err)
 	prefix := "TestNamespaceShardingEnabled"
 
@@ -6281,7 +6308,8 @@ func TestCollectionNamespaceShardingEnabledValidation(t *testing.T) {
 
 func TestAlterCollectionFieldCheckLoaded(t *testing.T) {
 	qc := NewMixCoordMock()
-	InitMetaCache(context.Background(), qc)
+	_, err := initMetaCache(context.Background(), qc)
+	assert.NoError(t, err)
 	collectionName := "test_alter_collection_field_check_loaded"
 	createColReq := &milvuspb.CreateCollectionRequest{
 		Base: &commonpb.MsgBase{
@@ -6335,7 +6363,8 @@ func TestAlterCollectionField(t *testing.T) {
 	paramtable.Init()
 
 	qc := NewMixCoordMock()
-	InitMetaCache(context.Background(), qc)
+	_, err := initMetaCache(context.Background(), qc)
+	assert.NoError(t, err)
 	collectionName := "test_alter_collection_field"
 
 	// Create collection with string and array fields
@@ -6777,11 +6806,8 @@ func constructCollectionSchemaWithStructArrayField(collectionName string, struct
 // TestCreateCollectionTaskWithStructArrayField tests creating collections with StructArrayField
 func TestCreateCollectionTaskWithStructArrayField(t *testing.T) {
 	mix := NewMixCoordMock()
-	cache := globalMetaCache
-	defer func() { globalMetaCache = cache }()
 	mockCache := NewMockCache(t)
 	mockCache.EXPECT().GetDatabaseInfo(mock.Anything, mock.Anything).Return(&databaseInfo{}, nil).Maybe()
-	globalMetaCache = mockCache
 	ctx := context.Background()
 	shardsNum := common.DefaultShardsNum
 	prefix := "TestCreateCollectionTaskWithStructArrayField"
@@ -6807,6 +6833,7 @@ func TestCreateCollectionTaskWithStructArrayField(t *testing.T) {
 		result:   nil,
 		schema:   nil,
 	}
+	task.metaCache = mockCache
 
 	t.Run("create collection with struct array field", func(t *testing.T) {
 		err := task.OnEnqueue()
@@ -7099,7 +7126,8 @@ func TestDescribeCollectionTaskWithStructArrayField(t *testing.T) {
 
 func TestAlterCollection_AllowInsertAutoID_AutoIDFalse(t *testing.T) {
 	qc := NewMixCoordMock()
-	InitMetaCache(context.Background(), qc)
+	_, err := initMetaCache(context.Background(), qc)
+	assert.NoError(t, err)
 	ctx := context.Background()
 	collectionName := "test_alter_allow_insert_autoid_autoid_false"
 

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -546,9 +546,9 @@ func TestAlterCollection_AllowInsertAutoID_Validation(t *testing.T) {
 		root := buildRoot(true)
 		cache, err := initMetaCache(ctx, root)
 		assert.NoError(t, err)
-		t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 		task := &alterCollectionTask{
+			baseTask: baseTask{metaCache: cache},
 			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
 				Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_AlterCollectionField},
 				DbName:         dbName,
@@ -566,9 +566,9 @@ func TestAlterCollection_AllowInsertAutoID_Validation(t *testing.T) {
 		root := buildRoot(false)
 		cache, err := initMetaCache(ctx, root)
 		assert.NoError(t, err)
-		t.Cleanup(mockBaseTaskMetaCacheForTest(cache))
 
 		task := &alterCollectionTask{
+			baseTask: baseTask{metaCache: cache},
 			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
 				Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_AlterCollectionField},
 				DbName:         dbName,

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -2207,6 +2207,7 @@ func TestHasCollectionTask(t *testing.T) {
 
 	// CreateCollection
 	task := &hasCollectionTask{
+		baseTask:  baseTask{metaCache: cache},
 		Condition: NewTaskCondition(ctx),
 		HasCollectionRequest: &milvuspb.HasCollectionRequest{
 			Base: &commonpb.MsgBase{
@@ -4769,6 +4770,7 @@ func TestCreateCollectionTaskWithPartitionKey(t *testing.T) {
 		assert.Equal(t, task.GetNumPartitions(), int64(len(partitionNames)))
 
 		createPartitionTask := &createPartitionTask{
+			baseTask:  baseTask{metaCache: cache},
 			Condition: NewTaskCondition(ctx),
 			CreatePartitionRequest: &milvuspb.CreatePartitionRequest{
 				Base: &commonpb.MsgBase{
@@ -4786,6 +4788,7 @@ func TestCreateCollectionTaskWithPartitionKey(t *testing.T) {
 		assert.Error(t, err)
 
 		dropPartitionTask := &dropPartitionTask{
+			baseTask:  baseTask{metaCache: cache},
 			Condition: NewTaskCondition(ctx),
 			DropPartitionRequest: &milvuspb.DropPartitionRequest{
 				Base: &commonpb.MsgBase{
@@ -4803,6 +4806,7 @@ func TestCreateCollectionTaskWithPartitionKey(t *testing.T) {
 		assert.Error(t, err)
 
 		loadPartitionTask := &loadPartitionsTask{
+			baseTask:  baseTask{metaCache: cache},
 			Condition: NewTaskCondition(ctx),
 			LoadPartitionsRequest: &milvuspb.LoadPartitionsRequest{
 				Base: &commonpb.MsgBase{
@@ -4819,6 +4823,7 @@ func TestCreateCollectionTaskWithPartitionKey(t *testing.T) {
 		assert.Error(t, err)
 
 		releasePartitionsTask := &releasePartitionsTask{
+			baseTask:  baseTask{metaCache: cache},
 			Condition: NewTaskCondition(ctx),
 			ReleasePartitionsRequest: &milvuspb.ReleasePartitionsRequest{
 				Base: &commonpb.MsgBase{
@@ -4922,6 +4927,7 @@ func TestPartitionKey(t *testing.T) {
 
 	t.Run("Insert", func(t *testing.T) {
 		it := &insertTask{
+			baseTask: baseTask{metaCache: cache},
 			insertMsg: &BaseInsertTask{
 				BaseMsg: msgstream.BaseMsg{},
 				InsertRequest: &msgpb.InsertRequest{
@@ -4971,6 +4977,7 @@ func TestPartitionKey(t *testing.T) {
 	t.Run("Upsert", func(t *testing.T) {
 		hash := testutils.GenerateHashKeys(nb)
 		ut := &upsertTask{
+			baseTask:  baseTask{metaCache: cache},
 			ctx:       ctx,
 			Condition: NewTaskCondition(ctx),
 			baseMsg: msgstream.BaseMsg{
@@ -5010,6 +5017,7 @@ func TestPartitionKey(t *testing.T) {
 
 	t.Run("delete", func(t *testing.T) {
 		dt := &deleteTask{
+			baseTask:  baseTask{metaCache: cache},
 			Condition: NewTaskCondition(ctx),
 			req: &milvuspb.DeleteRequest{
 				CollectionName: collectionName,
@@ -5034,7 +5042,8 @@ func TestPartitionKey(t *testing.T) {
 
 	t.Run("search", func(t *testing.T) {
 		searchTask := &searchTask{
-			ctx: ctx,
+			baseTask: baseTask{metaCache: cache},
+			ctx:      ctx,
 			SearchRequest: &internalpb.SearchRequest{
 				Base: &commonpb.MsgBase{},
 			},
@@ -5054,7 +5063,8 @@ func TestPartitionKey(t *testing.T) {
 
 	t.Run("query", func(t *testing.T) {
 		queryTask := &queryTask{
-			ctx: ctx,
+			baseTask: baseTask{metaCache: cache},
+			ctx:      ctx,
 			RetrieveRequest: &internalpb.RetrieveRequest{
 				QueryLabel: "query",
 				Base:       &commonpb.MsgBase{},
@@ -5148,6 +5158,7 @@ func TestDefaultPartition(t *testing.T) {
 
 	t.Run("Insert", func(t *testing.T) {
 		it := &insertTask{
+			baseTask: baseTask{metaCache: cache},
 			insertMsg: &BaseInsertTask{
 				BaseMsg: msgstream.BaseMsg{},
 				InsertRequest: &msgpb.InsertRequest{
@@ -5193,6 +5204,7 @@ func TestDefaultPartition(t *testing.T) {
 	t.Run("Upsert", func(t *testing.T) {
 		hash := testutils.GenerateHashKeys(nb)
 		ut := &upsertTask{
+			baseTask:  baseTask{metaCache: cache},
 			ctx:       ctx,
 			Condition: NewTaskCondition(ctx),
 			baseMsg: msgstream.BaseMsg{
@@ -5228,6 +5240,7 @@ func TestDefaultPartition(t *testing.T) {
 
 	t.Run("delete", func(t *testing.T) {
 		dt := &deleteTask{
+			baseTask:  baseTask{metaCache: cache},
 			Condition: NewTaskCondition(ctx),
 			req: &milvuspb.DeleteRequest{
 				CollectionName: collectionName,
@@ -5531,7 +5544,7 @@ func TestClusteringKey(t *testing.T) {
 
 func TestAlterCollectionCheckLoaded(t *testing.T) {
 	qc := NewMixCoordMock()
-	_, err := initMetaCache(context.Background(), qc)
+	cache, err := initMetaCache(context.Background(), qc)
 	assert.NoError(t, err)
 	collectionName := "test_alter_collection_check_loaded"
 	createColReq := &milvuspb.CreateCollectionRequest{
@@ -5560,6 +5573,7 @@ func TestAlterCollectionCheckLoaded(t *testing.T) {
 	}
 
 	task := &alterCollectionTask{
+		baseTask: baseTask{metaCache: cache},
 		AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
 			Base:           &commonpb.MsgBase{},
 			CollectionName: collectionName,
@@ -5574,7 +5588,7 @@ func TestAlterCollectionCheckLoaded(t *testing.T) {
 func TestAlterCollectionTaskValidateTTLAndTTLField(t *testing.T) {
 	qc := NewMixCoordMock()
 	ctx := context.Background()
-	_, err := initMetaCache(ctx, qc)
+	cache, err := initMetaCache(ctx, qc)
 	assert.NoError(t, err)
 
 	createCollectionWithProps := func(colName string, props []*commonpb.KeyValuePair) {
@@ -5606,6 +5620,7 @@ func TestAlterCollectionTaskValidateTTLAndTTLField(t *testing.T) {
 		col := "alter_ttl_seconds_then_field_" + funcutil.GenRandomStr()
 		createCollectionWithProps(col, []*commonpb.KeyValuePair{{Key: common.CollectionTTLConfigKey, Value: "3600"}})
 		task := &alterCollectionTask{
+			baseTask: baseTask{metaCache: cache},
 			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
 				Base:           &commonpb.MsgBase{},
 				CollectionName: col,
@@ -5622,6 +5637,7 @@ func TestAlterCollectionTaskValidateTTLAndTTLField(t *testing.T) {
 		col := "alter_ttl_field_then_seconds_" + funcutil.GenRandomStr()
 		createCollectionWithProps(col, []*commonpb.KeyValuePair{{Key: common.CollectionTTLFieldKey, Value: "ttl"}})
 		task := &alterCollectionTask{
+			baseTask: baseTask{metaCache: cache},
 			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
 				Base:           &commonpb.MsgBase{},
 				CollectionName: col,
@@ -5638,6 +5654,7 @@ func TestAlterCollectionTaskValidateTTLAndTTLField(t *testing.T) {
 		col := "alter_ttl_field_invalid_" + funcutil.GenRandomStr()
 		createCollectionWithProps(col, nil)
 		task := &alterCollectionTask{
+			baseTask: baseTask{metaCache: cache},
 			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
 				Base:           &commonpb.MsgBase{},
 				CollectionName: col,
@@ -5653,6 +5670,7 @@ func TestAlterCollectionTaskValidateTTLAndTTLField(t *testing.T) {
 		col := "alter_ttl_field_invalid_type_" + funcutil.GenRandomStr()
 		createCollectionWithProps(col, nil)
 		task := &alterCollectionTask{
+			baseTask: baseTask{metaCache: cache},
 			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
 				Base:           &commonpb.MsgBase{},
 				CollectionName: col,
@@ -5668,6 +5686,7 @@ func TestAlterCollectionTaskValidateTTLAndTTLField(t *testing.T) {
 		col := "alter_delete_ttl_seconds_" + funcutil.GenRandomStr()
 		createCollectionWithProps(col, []*commonpb.KeyValuePair{{Key: common.CollectionTTLConfigKey, Value: "3600"}})
 		task := &alterCollectionTask{
+			baseTask: baseTask{metaCache: cache},
 			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
 				Base:           &commonpb.MsgBase{},
 				CollectionName: col,
@@ -5683,6 +5702,7 @@ func TestAlterCollectionTaskValidateTTLAndTTLField(t *testing.T) {
 		col := "alter_delete_ttl_field_" + funcutil.GenRandomStr()
 		createCollectionWithProps(col, []*commonpb.KeyValuePair{{Key: common.CollectionTTLFieldKey, Value: "ttl"}})
 		task := &alterCollectionTask{
+			baseTask: baseTask{metaCache: cache},
 			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
 				Base:           &commonpb.MsgBase{},
 				CollectionName: col,
@@ -5698,7 +5718,7 @@ func TestAlterCollectionTaskValidateTTLAndTTLField(t *testing.T) {
 func TestAlterCollectionTaskValidateDescription(t *testing.T) {
 	qc := NewMixCoordMock()
 	ctx := context.Background()
-	_, err := initMetaCache(ctx, qc)
+	cache, err := initMetaCache(ctx, qc)
 	assert.NoError(t, err)
 
 	maxLen := Params.ProxyCfg.MaxCollectionDescriptionLength.GetAsInt()
@@ -5736,6 +5756,7 @@ func TestAlterCollectionTaskValidateDescription(t *testing.T) {
 
 	runAlter := func(collectionName string, properties []*commonpb.KeyValuePair) error {
 		task := &alterCollectionTask{
+			baseTask: baseTask{metaCache: cache},
 			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
 				Base:           &commonpb.MsgBase{},
 				CollectionName: collectionName,
@@ -5823,7 +5844,7 @@ func mockVectorIndexForCollection(t *testing.T, ctx context.Context, qc *MixCoor
 func TestTaskPartitionKeyIsolation(t *testing.T) {
 	qc := NewMixCoordMock()
 	ctx := context.Background()
-	_, err := initMetaCache(ctx, qc)
+	cache, err := initMetaCache(ctx, qc)
 	assert.NoError(t, err)
 	shardsNum := common.DefaultShardsNum
 	prefix := "TestPartitionKeyIsolation"
@@ -5909,6 +5930,7 @@ func TestTaskPartitionKeyIsolation(t *testing.T) {
 		}
 
 		return &alterCollectionTask{
+			baseTask: baseTask{metaCache: cache},
 			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
 				Base:           &commonpb.MsgBase{},
 				CollectionName: colName,
@@ -5977,6 +5999,7 @@ func TestTaskPartitionKeyIsolation(t *testing.T) {
 		colName := collectionName + "AlterNoIso"
 		createIsoCollection(colName, true, false, true)
 		alterTask := alterCollectionTask{
+			baseTask: baseTask{metaCache: cache},
 			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
 				Base:           &commonpb.MsgBase{},
 				CollectionName: colName,
@@ -6021,6 +6044,7 @@ func TestTaskPartitionKeyIsolation(t *testing.T) {
 		createIsoCollection(colName, true, true, false)
 		mockVectorIndexForCollection(t, ctx, qc, colName)
 		alterTask := &alterCollectionTask{
+			baseTask: baseTask{metaCache: cache},
 			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
 				Base:           &commonpb.MsgBase{},
 				CollectionName: colName,
@@ -6037,6 +6061,7 @@ func TestTaskPartitionKeyIsolation(t *testing.T) {
 		colName := collectionName + "DeleteIsoNoIdx"
 		createIsoCollection(colName, true, true, false)
 		alterTask := &alterCollectionTask{
+			baseTask: baseTask{metaCache: cache},
 			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
 				Base:           &commonpb.MsgBase{},
 				CollectionName: colName,
@@ -6055,6 +6080,7 @@ func TestTaskPartitionKeyIsolation(t *testing.T) {
 		createIsoCollection(colName, true, true, false)
 		mockVectorIndexForCollection(t, ctx, qc, colName)
 		alterTask := &alterCollectionTask{
+			baseTask: baseTask{metaCache: cache},
 			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
 				Base:           &commonpb.MsgBase{},
 				CollectionName: colName,
@@ -6070,7 +6096,7 @@ func TestTaskPartitionKeyIsolation(t *testing.T) {
 func TestAlterCollectionQueryMode(t *testing.T) {
 	qc := NewMixCoordMock()
 	ctx := context.Background()
-	_, err := initMetaCache(ctx, qc)
+	cache, err := initMetaCache(ctx, qc)
 	assert.NoError(t, err)
 	prefix := "TestQueryMode"
 
@@ -6110,6 +6136,7 @@ func TestAlterCollectionQueryMode(t *testing.T) {
 		colName := prefix + funcutil.GenRandomStr()
 		createCollection(colName, false)
 		alterTask := &alterCollectionTask{
+			baseTask: baseTask{metaCache: cache},
 			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
 				Base:           &commonpb.MsgBase{},
 				CollectionName: colName,
@@ -6125,6 +6152,7 @@ func TestAlterCollectionQueryMode(t *testing.T) {
 		colName := prefix + funcutil.GenRandomStr()
 		createCollection(colName, true)
 		alterTask := &alterCollectionTask{
+			baseTask: baseTask{metaCache: cache},
 			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
 				Base:           &commonpb.MsgBase{},
 				CollectionName: colName,
@@ -6141,6 +6169,7 @@ func TestAlterCollectionQueryMode(t *testing.T) {
 		createCollection(colName, false)
 		mockVectorIndexForCollection(t, ctx, qc, colName)
 		alterTask := &alterCollectionTask{
+			baseTask: baseTask{metaCache: cache},
 			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
 				Base:           &commonpb.MsgBase{},
 				CollectionName: colName,
@@ -6158,6 +6187,7 @@ func TestAlterCollectionQueryMode(t *testing.T) {
 		createCollection(colName, true)
 		mockVectorIndexForCollection(t, ctx, qc, colName)
 		alterTask := &alterCollectionTask{
+			baseTask: baseTask{metaCache: cache},
 			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
 				Base:           &commonpb.MsgBase{},
 				CollectionName: colName,
@@ -6174,6 +6204,7 @@ func TestAlterCollectionQueryMode(t *testing.T) {
 		colName := prefix + funcutil.GenRandomStr()
 		createCollection(colName, true)
 		alterTask := &alterCollectionTask{
+			baseTask: baseTask{metaCache: cache},
 			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
 				Base:           &commonpb.MsgBase{},
 				CollectionName: colName,
@@ -6190,6 +6221,7 @@ func TestAlterCollectionQueryMode(t *testing.T) {
 		createCollection(colName, true)
 		mockVectorIndexForCollection(t, ctx, qc, colName)
 		alterTask := &alterCollectionTask{
+			baseTask: baseTask{metaCache: cache},
 			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
 				Base:           &commonpb.MsgBase{},
 				CollectionName: colName,
@@ -6308,7 +6340,7 @@ func TestCollectionNamespaceShardingEnabledValidation(t *testing.T) {
 
 func TestAlterCollectionFieldCheckLoaded(t *testing.T) {
 	qc := NewMixCoordMock()
-	_, err := initMetaCache(context.Background(), qc)
+	cache, err := initMetaCache(context.Background(), qc)
 	assert.NoError(t, err)
 	collectionName := "test_alter_collection_field_check_loaded"
 	createColReq := &milvuspb.CreateCollectionRequest{
@@ -6336,6 +6368,7 @@ func TestAlterCollectionFieldCheckLoaded(t *testing.T) {
 
 	// update property "mmap.enabled" but the collection is loaded
 	task := &alterCollectionFieldTask{
+		baseTask: baseTask{metaCache: cache},
 		AlterCollectionFieldRequest: &milvuspb.AlterCollectionFieldRequest{
 			Base:           &commonpb.MsgBase{},
 			CollectionName: collectionName,
@@ -6348,6 +6381,7 @@ func TestAlterCollectionFieldCheckLoaded(t *testing.T) {
 
 	// delete property "mmap.enabled" but the collection is loaded
 	task = &alterCollectionFieldTask{
+		baseTask: baseTask{metaCache: cache},
 		AlterCollectionFieldRequest: &milvuspb.AlterCollectionFieldRequest{
 			Base:           &commonpb.MsgBase{},
 			CollectionName: collectionName,
@@ -6363,7 +6397,7 @@ func TestAlterCollectionField(t *testing.T) {
 	paramtable.Init()
 
 	qc := NewMixCoordMock()
-	_, err := initMetaCache(context.Background(), qc)
+	cache, err := initMetaCache(context.Background(), qc)
 	assert.NoError(t, err)
 	collectionName := "test_alter_collection_field"
 
@@ -6670,6 +6704,7 @@ func TestAlterCollectionField(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			task := &alterCollectionFieldTask{
+				baseTask: baseTask{metaCache: cache},
 				AlterCollectionFieldRequest: &milvuspb.AlterCollectionFieldRequest{
 					Base:           &commonpb.MsgBase{},
 					CollectionName: collectionName,
@@ -6698,6 +6733,7 @@ func TestAlterCollectionField(t *testing.T) {
 		defer paramtable.Get().Reset(paramtable.Get().ProxyCfg.MaxArrayCapacity.Key)
 
 		task := &alterCollectionFieldTask{
+			baseTask: baseTask{metaCache: cache},
 			AlterCollectionFieldRequest: &milvuspb.AlterCollectionFieldRequest{
 				Base:           &commonpb.MsgBase{},
 				CollectionName: collectionName,
@@ -7126,7 +7162,7 @@ func TestDescribeCollectionTaskWithStructArrayField(t *testing.T) {
 
 func TestAlterCollection_AllowInsertAutoID_AutoIDFalse(t *testing.T) {
 	qc := NewMixCoordMock()
-	_, err := initMetaCache(context.Background(), qc)
+	cache, err := initMetaCache(context.Background(), qc)
 	assert.NoError(t, err)
 	ctx := context.Background()
 	collectionName := "test_alter_allow_insert_autoid_autoid_false"
@@ -7149,6 +7185,7 @@ func TestAlterCollection_AllowInsertAutoID_AutoIDFalse(t *testing.T) {
 	qc.CreateCollection(ctx, createColReq)
 
 	task := &alterCollectionTask{
+		baseTask: baseTask{metaCache: cache},
 		AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
 			Base:           &commonpb.MsgBase{},
 			CollectionName: collectionName,

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -148,7 +148,7 @@ func (it *upsertTask) getPChanStats() (map[pChan]pChanStatistics, error) {
 }
 
 func (it *upsertTask) setChannels() error {
-	collID, err := globalMetaCache.GetCollectionID(it.ctx, it.req.GetDbName(), it.req.CollectionName)
+	collID, err := it.getMetaCache().GetCollectionID(it.ctx, it.req.GetDbName(), it.req.CollectionName)
 	if err != nil {
 		return err
 	}
@@ -216,7 +216,7 @@ func retrieveByPKs(ctx context.Context, t *upsertTask, ids *schemapb.IDs, output
 			log.Warn(ctx, "Invalid partition name", mlog.String("partitionName", partName), mlog.Err(err))
 			return nil, segcore.StorageCost{}, err
 		}
-		partID, err := globalMetaCache.GetPartitionID(ctx, t.req.GetDbName(), t.req.GetCollectionName(), partName)
+		partID, err := t.getMetaCache().GetPartitionID(ctx, t.req.GetDbName(), t.req.GetCollectionName(), partName)
 		if err != nil {
 			log.Warn(ctx, "Failed to get partition id", mlog.String("partitionName", partName), mlog.Err(err))
 			return nil, segcore.StorageCost{}, err
@@ -228,6 +228,9 @@ func retrieveByPKs(ctx context.Context, t *upsertTask, ids *schemapb.IDs, output
 	plan := planparserv2.CreateRequeryPlan(pkField, ids)
 	plan.Namespace = namespaceForPlan(t.schema.CollectionSchema, t.req.Namespace)
 	qt := &queryTask{
+		baseTask: baseTask{
+			metaCache: t.getMetaCache(),
+		},
 		ctx:       t.ctx,
 		Condition: NewTaskCondition(t.ctx),
 		RetrieveRequest: &internalpb.RetrieveRequest{
@@ -1547,7 +1550,7 @@ func (it *upsertTask) deletePreExecute(ctx context.Context) error {
 			log.Warn(ctx, "Invalid partition name", mlog.String("partitionName", partName), mlog.Err(err))
 			return err
 		}
-		partID, err := globalMetaCache.GetPartitionID(ctx, it.req.GetDbName(), collName, partName)
+		partID, err := it.getMetaCache().GetPartitionID(ctx, it.req.GetDbName(), collName, partName)
 		if err != nil {
 			log.Warn(ctx, "Failed to get partition id", mlog.String("collectionName", collName), mlog.String("partitionName", partName), mlog.Err(err))
 			return err
@@ -1582,14 +1585,14 @@ func (it *upsertTask) PreExecute(ctx context.Context) error {
 	}
 
 	// check collection exists
-	collID, err := globalMetaCache.GetCollectionID(context.Background(), it.req.GetDbName(), collectionName)
+	collID, err := it.getMetaCache().GetCollectionID(context.Background(), it.req.GetDbName(), collectionName)
 	if err != nil {
 		log.Warn(ctx, "fail to get collection id", mlog.Err(err))
 		return err
 	}
 	it.collectionID = collID
 
-	colInfo, err := globalMetaCache.GetCollectionInfo(ctx, it.req.GetDbName(), collectionName, collID)
+	colInfo, err := it.getMetaCache().GetCollectionInfo(ctx, it.req.GetDbName(), collectionName, collID)
 	if err != nil {
 		log.Warn(ctx, "fail to get collection info", mlog.Err(err))
 		return err
@@ -1606,7 +1609,7 @@ func (it *upsertTask) PreExecute(ctx context.Context) error {
 		}
 	}
 
-	schema, err := globalMetaCache.GetCollectionSchema(ctx, it.req.GetDbName(), collectionName)
+	schema, err := it.getMetaCache().GetCollectionSchema(ctx, it.req.GetDbName(), collectionName)
 	if err != nil {
 		log.Warn(ctx, "Failed to get collection schema",
 			mlog.String("collectionName", collectionName),
@@ -1639,7 +1642,7 @@ func (it *upsertTask) PreExecute(ctx context.Context) error {
 		it.req.PartitionName = partitionName
 	}
 
-	it.partitionKeyMode, err = isPartitionKeyMode(ctx, it.req.GetDbName(), collectionName)
+	it.partitionKeyMode, err = isPartitionKeyMode(ctx, it.getMetaCache(), it.req.GetDbName(), collectionName)
 	if err != nil {
 		log.Warn(ctx, "check partition key mode failed",
 			mlog.String("collectionName", collectionName),
@@ -1655,7 +1658,7 @@ func (it *upsertTask) PreExecute(ctx context.Context) error {
 		// insert to _default partition
 		partitionTag := it.req.GetPartitionName()
 		if len(partitionTag) <= 0 {
-			pinfo, err := globalMetaCache.GetPartitionInfo(ctx, it.req.GetDbName(), collectionName, "")
+			pinfo, err := it.getMetaCache().GetPartitionInfo(ctx, it.req.GetDbName(), collectionName, "")
 			if err != nil {
 				log.Warn(ctx, "get partition info failed", mlog.String("collectionName", collectionName), mlog.Err(err))
 				return err

--- a/internal/proxy/task_upsert_streaming.go
+++ b/internal/proxy/task_upsert_streaming.go
@@ -201,7 +201,7 @@ func (ut *upsertTask) packInsertMessage(ctx context.Context, ez *message.CipherC
 	defer tr.Elapse("insert execute done when insertExecute")
 
 	collectionName := ut.upsertMsg.InsertMsg.CollectionName
-	collID, err := globalMetaCache.GetCollectionID(ctx, ut.req.GetDbName(), collectionName)
+	collID, err := ut.getMetaCache().GetCollectionID(ctx, ut.req.GetDbName(), collectionName)
 	if err != nil {
 		return nil, err
 	}
@@ -231,9 +231,9 @@ func (ut *upsertTask) packInsertMessage(ctx context.Context, ez *message.CipherC
 	// start to repack insert data
 	var msgs []message.MutableMessage
 	if ut.partitionKeys == nil {
-		msgs, err = repackInsertDataForStreamingService(ut.TraceCtx(), channelNames, ut.upsertMsg.InsertMsg, ut.result, ez, ut.schemaVersion, ut.partialUpdateCASGroups)
+		msgs, err = repackInsertDataForStreamingService(ut.TraceCtx(), ut.getMetaCache(), channelNames, ut.upsertMsg.InsertMsg, ut.result, ez, ut.schemaVersion, ut.partialUpdateCASGroups)
 	} else {
-		msgs, err = repackInsertDataWithPartitionKeyForStreamingService(ut.TraceCtx(), channelNames, ut.upsertMsg.InsertMsg, ut.result, ut.partitionKeys, ez, ut.schema.CollectionSchema, ut.schemaVersion, ut.partialUpdateCASGroups)
+		msgs, err = repackInsertDataWithPartitionKeyForStreamingService(ut.TraceCtx(), ut.getMetaCache(), channelNames, ut.upsertMsg.InsertMsg, ut.result, ut.partitionKeys, ez, ut.schema.CollectionSchema, ut.schemaVersion, ut.partialUpdateCASGroups)
 	}
 	if err != nil {
 		log.Warn(ctx, "assign segmentID and repack insert data failed", mlog.Err(err))

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -1059,9 +1059,7 @@ func partialUpdateCASRealPackTestTask(
 }
 
 func TestRepackInsertDataForStreamingServiceCASMetadata(t *testing.T) {
-	oldMetaCache := globalMetaCache
-	globalMetaCache = &MetaCache{}
-	t.Cleanup(func() { globalMetaCache = oldMetaCache })
+	mockCache := &MetaCache{}
 	partitionPatch := mockey.Mock((*MetaCache).GetPartitionID).Return(int64(200), nil).Build()
 	defer partitionPatch.UnPatch()
 
@@ -1079,6 +1077,7 @@ func TestRepackInsertDataForStreamingServiceCASMetadata(t *testing.T) {
 	task, vchannel, groups := newInput()
 	msgs, err := repackInsertDataForStreamingService(
 		context.Background(),
+		mockCache,
 		[]string{vchannel},
 		task.upsertMsg.InsertMsg,
 		task.result,
@@ -1093,6 +1092,7 @@ func TestRepackInsertDataForStreamingServiceCASMetadata(t *testing.T) {
 	task, vchannel, _ = newInput()
 	_, err = repackInsertDataForStreamingService(
 		context.Background(),
+		mockCache,
 		[]string{vchannel},
 		task.upsertMsg.InsertMsg,
 		task.result,
@@ -1105,6 +1105,7 @@ func TestRepackInsertDataForStreamingServiceCASMetadata(t *testing.T) {
 	task, vchannel, _ = newInput()
 	_, err = repackInsertDataForStreamingService(
 		context.Background(),
+		mockCache,
 		[]string{vchannel},
 		task.upsertMsg.InsertMsg,
 		task.result,
@@ -1118,6 +1119,7 @@ func TestRepackInsertDataForStreamingServiceCASMetadata(t *testing.T) {
 	groups[vchannel].ReadTs = 0
 	_, err = repackInsertDataForStreamingService(
 		context.Background(),
+		mockCache,
 		[]string{vchannel},
 		task.upsertMsg.InsertMsg,
 		task.result,
@@ -1129,9 +1131,7 @@ func TestRepackInsertDataForStreamingServiceCASMetadata(t *testing.T) {
 }
 
 func TestRepackInsertDataForStreamingServiceSplitsOversizedCASMessage(t *testing.T) {
-	oldMetaCache := globalMetaCache
-	globalMetaCache = &MetaCache{}
-	t.Cleanup(func() { globalMetaCache = oldMetaCache })
+	mockCache := &MetaCache{}
 	partitionPatch := mockey.Mock((*MetaCache).GetPartitionID).Return(int64(200), nil).Build()
 	defer partitionPatch.UnPatch()
 
@@ -1147,6 +1147,7 @@ func TestRepackInsertDataForStreamingServiceSplitsOversizedCASMessage(t *testing
 
 	unsplit, err := repackInsertDataForStreamingService(
 		context.Background(),
+		mockCache,
 		[]string{vchannel},
 		task.upsertMsg.InsertMsg,
 		task.result,
@@ -1162,6 +1163,7 @@ func TestRepackInsertDataForStreamingServiceSplitsOversizedCASMessage(t *testing
 
 	msgs, err := repackInsertDataForStreamingService(
 		context.Background(),
+		mockCache,
 		[]string{vchannel},
 		task.upsertMsg.InsertMsg,
 		task.result,
@@ -1186,9 +1188,7 @@ func TestRepackInsertDataForStreamingServiceSplitsOversizedCASMessage(t *testing
 }
 
 func TestRepackInsertDataForStreamingServiceRejectsOversizedSingleRow(t *testing.T) {
-	oldMetaCache := globalMetaCache
-	globalMetaCache = &MetaCache{}
-	t.Cleanup(func() { globalMetaCache = oldMetaCache })
+	mockCache := &MetaCache{}
 	partitionPatch := mockey.Mock((*MetaCache).GetPartitionID).Return(int64(200), nil).Build()
 	defer partitionPatch.UnPatch()
 
@@ -1203,6 +1203,7 @@ func TestRepackInsertDataForStreamingServiceRejectsOversizedSingleRow(t *testing
 
 	baseline, err := repackInsertDataForStreamingService(
 		context.Background(),
+		mockCache,
 		[]string{vchannel},
 		task.upsertMsg.InsertMsg,
 		task.result,
@@ -1217,6 +1218,7 @@ func TestRepackInsertDataForStreamingServiceRejectsOversizedSingleRow(t *testing
 
 	_, err = repackInsertDataForStreamingService(
 		context.Background(),
+		mockCache,
 		[]string{vchannel},
 		task.upsertMsg.InsertMsg,
 		task.result,
@@ -1338,15 +1340,15 @@ func TestRepackInsertDataByPartitionForStreamingServicePreservesEntityPackingOrd
 }
 
 func TestRepackInsertDataWithPartitionKeyForStreamingServiceCASMetadata(t *testing.T) {
-	oldMetaCache := globalMetaCache
-	globalMetaCache = &MetaCache{}
-	t.Cleanup(func() { globalMetaCache = oldMetaCache })
-	partitionsPatch := mockey.Mock((*MetaCache).GetPartitions).
+	mockCache := NewMockCache(t)
+	mockCache.EXPECT().
+		GetPartitions(mock.Anything, mock.Anything, mock.Anything).
 		Return(map[string]int64{"_default_0": 200}, nil).
-		Build()
-	defer partitionsPatch.UnPatch()
-	partitionPatch := mockey.Mock((*MetaCache).GetPartitionID).Return(int64(200), nil).Build()
-	defer partitionPatch.UnPatch()
+		Maybe()
+	mockCache.EXPECT().
+		GetPartitionID(mock.Anything, mock.Anything, mock.Anything, "_default_0").
+		Return(int64(200), nil).
+		Maybe()
 
 	newInput := func() (*upsertTask, string, map[string]*messagespb.PartialUpdateCAS) {
 		task := partialUpdateCASRealPackTestTask(t, []int64{10}, []int64{10}, nil)
@@ -1363,6 +1365,7 @@ func TestRepackInsertDataWithPartitionKeyForStreamingServiceCASMetadata(t *testi
 	task, vchannel, groups := newInput()
 	msgs, err := repackInsertDataWithPartitionKeyForStreamingService(
 		context.Background(),
+		mockCache,
 		[]string{vchannel},
 		task.upsertMsg.InsertMsg,
 		task.result,
@@ -1379,6 +1382,7 @@ func TestRepackInsertDataWithPartitionKeyForStreamingServiceCASMetadata(t *testi
 	task, vchannel, _ = newInput()
 	_, err = repackInsertDataWithPartitionKeyForStreamingService(
 		context.Background(),
+		mockCache,
 		[]string{vchannel},
 		task.upsertMsg.InsertMsg,
 		task.result,
@@ -1393,6 +1397,7 @@ func TestRepackInsertDataWithPartitionKeyForStreamingServiceCASMetadata(t *testi
 	task, vchannel, _ = newInput()
 	_, err = repackInsertDataWithPartitionKeyForStreamingService(
 		context.Background(),
+		mockCache,
 		[]string{vchannel},
 		task.upsertMsg.InsertMsg,
 		task.result,
@@ -1408,6 +1413,7 @@ func TestRepackInsertDataWithPartitionKeyForStreamingServiceCASMetadata(t *testi
 	groups[vchannel].ReadTs = 0
 	_, err = repackInsertDataWithPartitionKeyForStreamingService(
 		context.Background(),
+		mockCache,
 		[]string{vchannel},
 		task.upsertMsg.InsertMsg,
 		task.result,
@@ -1421,15 +1427,15 @@ func TestRepackInsertDataWithPartitionKeyForStreamingServiceCASMetadata(t *testi
 }
 
 func TestRepackInsertDataWithPartitionKeyForStreamingServiceSplitsOversizedCASMessage(t *testing.T) {
-	oldMetaCache := globalMetaCache
-	globalMetaCache = &MetaCache{}
-	t.Cleanup(func() { globalMetaCache = oldMetaCache })
-	partitionsPatch := mockey.Mock((*MetaCache).GetPartitions).
+	mockCache := NewMockCache(t)
+	mockCache.EXPECT().
+		GetPartitions(mock.Anything, mock.Anything, mock.Anything).
 		Return(map[string]int64{"_default_0": 200}, nil).
-		Build()
-	defer partitionsPatch.UnPatch()
-	partitionPatch := mockey.Mock((*MetaCache).GetPartitionID).Return(int64(200), nil).Build()
-	defer partitionPatch.UnPatch()
+		Maybe()
+	mockCache.EXPECT().
+		GetPartitionID(mock.Anything, mock.Anything, mock.Anything, "_default_0").
+		Return(int64(200), nil).
+		Maybe()
 
 	pks := []int64{10, 20}
 	task := partialUpdateCASRealPackTestTask(t, pks, pks, nil)
@@ -1444,6 +1450,7 @@ func TestRepackInsertDataWithPartitionKeyForStreamingServiceSplitsOversizedCASMe
 
 	unsplit, err := repackInsertDataWithPartitionKeyForStreamingService(
 		context.Background(),
+		mockCache,
 		[]string{vchannel},
 		task.upsertMsg.InsertMsg,
 		task.result,
@@ -1461,6 +1468,7 @@ func TestRepackInsertDataWithPartitionKeyForStreamingServiceSplitsOversizedCASMe
 
 	msgs, err := repackInsertDataWithPartitionKeyForStreamingService(
 		context.Background(),
+		mockCache,
 		[]string{vchannel},
 		task.upsertMsg.InsertMsg,
 		task.result,
@@ -1489,9 +1497,6 @@ func TestRepackInsertDataWithPartitionKeyForStreamingServiceSplitsOversizedCASMe
 func TestInsertTaskExecuteSelectsPartitionRouting(t *testing.T) {
 	for _, partitionKey := range []bool{false, true} {
 		t.Run(map[bool]string{false: "primary key", true: "partition key"}[partitionKey], func(t *testing.T) {
-			oldMetaCache := globalMetaCache
-			globalMetaCache = &MetaCache{}
-			t.Cleanup(func() { globalMetaCache = oldMetaCache })
 			collectionPatch := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(1001), nil).Build()
 			defer collectionPatch.UnPatch()
 
@@ -1510,7 +1515,8 @@ func TestInsertTaskExecuteSelectsPartitionRouting(t *testing.T) {
 			t.Cleanup(func() { streaming.SetWALForTest(oldWAL) })
 
 			task := &insertTask{
-				ctx: context.Background(),
+				baseTask: baseTask{metaCache: &MetaCache{}},
+				ctx:      context.Background(),
 				insertMsg: &msgstream.InsertMsg{InsertRequest: &msgpb.InsertRequest{
 					Base:           &commonpb.MsgBase{},
 					DbName:         "test_db",
@@ -1535,9 +1541,6 @@ func TestInsertTaskExecuteSelectsPartitionRouting(t *testing.T) {
 func TestPackInsertMessageUsesPartitionKeyRouting(t *testing.T) {
 	task := partialUpdateCASRealPackTestTask(t, []int64{10}, []int64{10}, nil)
 	task.partitionKeys = partialUpdateCASPKFieldData([]int64{10})
-	oldMetaCache := globalMetaCache
-	globalMetaCache = &MetaCache{}
-	t.Cleanup(func() { globalMetaCache = oldMetaCache })
 	collectionPatch := mockey.Mock((*MetaCache).GetCollectionID).Return(task.collectionID, nil).Build()
 	defer collectionPatch.UnPatch()
 	partitionPatch := mockey.Mock(repackInsertDataWithPartitionKeyForStreamingService).
@@ -1648,11 +1651,8 @@ func TestPartialUpdateAppendPacksMessagesAndAttachesCASMetadata(t *testing.T) {
 	task := partialUpdateCASRealPackTestTask(t, []int64{10, 20, 30}, []int64{20, 10, 30}, []int64{20})
 	fakeWAL := newPartialUpdateCASTestWAL(t, 9)
 	oldWAL := streaming.WAL()
-	oldMetaCache := globalMetaCache
 	streaming.SetWALForTest(fakeWAL)
-	globalMetaCache = &MetaCache{}
 	defer streaming.SetWALForTest(oldWAL)
-	defer func() { globalMetaCache = oldMetaCache }()
 	preparePartialUpdateCASTestGroups(t, task)
 
 	m := mockey.Mock((*MetaCache).GetCollectionID).Return(task.collectionID, nil).Build()
@@ -2416,12 +2416,6 @@ func TestRetrieveByPKsUsesPartialUpdateReadTsAsSnapshotFence(t *testing.T) {
 	).Build()
 	defer m.UnPatch()
 
-	oldMetaCache := globalMetaCache
-	globalMetaCache = &MetaCache{}
-	defer func() {
-		globalMetaCache = oldMetaCache
-	}()
-
 	task := createTestUpdateTask()
 	task.SetTs(beginTS)
 	task.partialUpdateReadTs = readTS
@@ -2789,12 +2783,6 @@ func TestUpdateTask_PreExecute_Success(t *testing.T) {
 }
 
 func TestUpdateTaskPreExecuteSnapshotsOriginalPartialFieldsBeforeMerge(t *testing.T) {
-	oldMetaCache := globalMetaCache
-	globalMetaCache = &MetaCache{}
-	defer func() {
-		globalMetaCache = oldMetaCache
-	}()
-
 	m := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(1001), nil).Build()
 	defer m.UnPatch()
 	schema := createTestSchema()

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -334,12 +334,12 @@ func TestUpsertTask(t *testing.T) {
 			mock.AnythingOfType("string"),
 			mock.AnythingOfType("string"),
 		).Return(collectionID, nil)
-		globalMetaCache = cache
 
 		chMgr := NewMockChannelsMgr(t)
 		chMgr.EXPECT().getChannels(mock.Anything).Return(channels, nil)
 		ut := upsertTask{
-			ctx: context.Background(),
+			baseTask: baseTask{metaCache: cache},
+			ctx:      context.Background(),
 			req: &milvuspb.UpsertRequest{
 				CollectionName: collectionName,
 			},
@@ -442,8 +442,6 @@ func TestUpsertTask_Function(t *testing.T) {
 
 	info := mustNewSchemaInfo(schema)
 	collectionID := UniqueID(0)
-	cache := NewMockCache(t)
-	globalMetaCache = cache
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -458,7 +456,8 @@ func TestUpsertTask_Function(t *testing.T) {
 	defer idAllocator.Close()
 	assert.NoError(t, err)
 	task := upsertTask{
-		ctx: context.Background(),
+		baseTask: baseTask{metaCache: &MetaCache{}},
+		ctx:      context.Background(),
 		req: &milvuspb.UpsertRequest{
 			CollectionName: collectionName,
 		},
@@ -497,15 +496,13 @@ func TestUpsertTask_Function(t *testing.T) {
 }
 
 func TestUpsertTaskForSchemaMismatch(t *testing.T) {
-	cache := globalMetaCache
-	defer func() { globalMetaCache = cache }()
 	mockCache := NewMockCache(t)
-	globalMetaCache = mockCache
 	ctx := context.Background()
 
 	t.Run("schema ts mismatch", func(t *testing.T) {
 		ut := upsertTask{
-			ctx: ctx,
+			baseTask: baseTask{metaCache: mockCache},
+			ctx:      ctx,
 			req: &milvuspb.UpsertRequest{
 				CollectionName: "col-0",
 				NumRows:        10,
@@ -533,7 +530,7 @@ func createTestUpdateTask() *upsertTask {
 	mcClient := &grpcmixcoordclient.Client{}
 
 	upsertTask := &upsertTask{
-		baseTask:  baseTask{},
+		baseTask:  baseTask{metaCache: &MetaCache{}},
 		Condition: NewTaskCondition(context.Background()),
 		req: &milvuspb.UpsertRequest{
 			Base: commonpbutil.NewMsgBase(
@@ -2355,9 +2352,6 @@ func TestRetrieveByPKs_Success(t *testing.T) {
 			},
 		}, segcore.StorageCost{}, nil).Build()
 
-		globalMetaCache = &MetaCache{}
-		mockey.Mock(globalMetaCache.GetPartitionID).Return(int64(1002), nil).Build()
-
 		// Execute test
 		task := createTestUpdateTask()
 		task.partitionKeyMode = false
@@ -2739,9 +2733,6 @@ func TestUpdateTask_queryPreExecute_EmptyOldIDs(t *testing.T) {
 
 func TestUpdateTask_PreExecute_Success(t *testing.T) {
 	mockey.PatchConvey("TestUpdateTask_PreExecute_Success", t, func() {
-		// Setup mocks
-		globalMetaCache = &MetaCache{}
-
 		mockey.Mock((*MetaCache).GetCollectionID).Return(int64(1001), nil).Build()
 
 		schema := createTestSchema()
@@ -2847,8 +2838,6 @@ func TestUpdateTaskPreExecuteSnapshotsOriginalPartialFieldsBeforeMerge(t *testin
 
 func TestUpdateTask_PreExecute_GetCollectionIDError(t *testing.T) {
 	mockey.PatchConvey("TestUpdateTask_PreExecute_GetCollectionIDError", t, func() {
-		globalMetaCache = &MetaCache{}
-
 		expectedErr := merr.WrapErrCollectionNotFound("test_collection")
 		mockey.Mock((*MetaCache).GetCollectionID).Return(int64(0), expectedErr).Build()
 
@@ -2862,8 +2851,6 @@ func TestUpdateTask_PreExecute_GetCollectionIDError(t *testing.T) {
 
 func TestUpdateTask_PreExecute_PartitionKeyModeError(t *testing.T) {
 	mockey.PatchConvey("TestUpdateTask_PreExecute_PartitionKeyModeError", t, func() {
-		globalMetaCache = &MetaCache{}
-
 		schema := createTestSchema()
 		mockey.Mock((*MetaCache).GetCollectionID).Return(int64(1001), nil).Build()
 		mockey.Mock((*MetaCache).GetCollectionInfo).Return(&collectionInfo{
@@ -2886,8 +2873,6 @@ func TestUpdateTask_PreExecute_PartitionKeyModeError(t *testing.T) {
 
 func TestUpdateTask_PreExecute_InvalidNumRows(t *testing.T) {
 	mockey.PatchConvey("TestUpdateTask_PreExecute_InvalidNumRows", t, func() {
-		globalMetaCache = &MetaCache{}
-
 		schema := createTestSchema()
 		mockey.Mock((*MetaCache).GetCollectionID).Return(int64(1001), nil).Build()
 		mockey.Mock((*MetaCache).GetCollectionInfo).Return(&collectionInfo{
@@ -2913,8 +2898,6 @@ func TestUpdateTask_PreExecute_InvalidNumRows(t *testing.T) {
 
 func TestUpdateTask_PreExecute_QueryPreExecuteError(t *testing.T) {
 	mockey.PatchConvey("TestUpdateTask_PreExecute_QueryPreExecuteError", t, func() {
-		globalMetaCache = &MetaCache{}
-
 		schema := createTestSchema()
 		mockey.Mock((*MetaCache).GetCollectionID).Return(int64(1001), nil).Build()
 		mockey.Mock((*MetaCache).GetCollectionInfo).Return(&collectionInfo{
@@ -4196,8 +4179,6 @@ func TestUpsertTask_queryPreExecute_EmptyDataArray(t *testing.T) {
 			mockey.Mock((*MetaCache).GetDatabaseInfo).Return(&databaseInfo{DBID: 0}, nil).Build()
 			mockey.Mock(retrieveByPKs).Return(mockQueryResult, segcore.StorageCost{}, nil).Build()
 
-			globalMetaCache = &MetaCache{}
-
 			// Setup idAllocator
 			ctx := context.Background()
 			rc := mocks.NewMockRootCoordClient(t)
@@ -4212,8 +4193,9 @@ func TestUpsertTask_queryPreExecute_EmptyDataArray(t *testing.T) {
 			defer idAllocator.Close()
 
 			task := &upsertTask{
-				ctx:    ctx,
-				schema: schema,
+				baseTask: baseTask{metaCache: &MetaCache{}},
+				ctx:      ctx,
+				schema:   schema,
 				req: &milvuspb.UpsertRequest{
 					CollectionName: "test_empty_data_array",
 					FieldsData:     upsertData,
@@ -4314,8 +4296,6 @@ func TestUpsertTask_queryPreExecute_EmptyDataArray(t *testing.T) {
 			mockey.Mock((*MetaCache).GetDatabaseInfo).Return(&databaseInfo{DBID: 0}, nil).Build()
 			mockey.Mock(retrieveByPKs).Return(mockQueryResult, segcore.StorageCost{}, nil).Build()
 
-			globalMetaCache = &MetaCache{}
-
 			// Setup idAllocator
 			ctx := context.Background()
 			rc := mocks.NewMockRootCoordClient(t)
@@ -4330,8 +4310,9 @@ func TestUpsertTask_queryPreExecute_EmptyDataArray(t *testing.T) {
 			defer idAllocator.Close()
 
 			task := &upsertTask{
-				ctx:    ctx,
-				schema: schema,
+				baseTask: baseTask{metaCache: &MetaCache{}},
+				ctx:      ctx,
+				schema:   schema,
 				req: &milvuspb.UpsertRequest{
 					CollectionName: "test_empty_data_array_non_nullable",
 					FieldsData:     upsertData,

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -2528,6 +2528,7 @@ func getCollectionProgress(
 
 func getPartitionProgress(
 	ctx context.Context,
+	metaCache Cache,
 	queryCoord types.QueryCoordClient,
 	msgBase *commonpb.MsgBase,
 	partitionNames []string,
@@ -2539,7 +2540,7 @@ func getPartitionProgress(
 	partitionIDs := make([]int64, 0)
 	for _, partitionName := range partitionNames {
 		var partitionID int64
-		partitionID, err = globalMetaCache.GetPartitionID(ctx, dbName, collectionName, partitionName)
+		partitionID, err = metaCache.GetPartitionID(ctx, dbName, collectionName, partitionName)
 		if err != nil {
 			return
 		}
@@ -2586,8 +2587,8 @@ func getPartitionProgress(
 	return
 }
 
-func isPartitionKeyMode(ctx context.Context, dbName string, colName string) (bool, error) {
-	colSchema, err := globalMetaCache.GetCollectionSchema(ctx, dbName, colName)
+func isPartitionKeyMode(ctx context.Context, metaCache Cache, dbName string, colName string) (bool, error) {
+	colSchema, err := metaCache.GetCollectionSchema(ctx, dbName, colName)
 	if err != nil {
 		return false, err
 	}
@@ -2611,8 +2612,8 @@ func hasPartitionKeyModeField(schema *schemapb.CollectionSchema) bool {
 }
 
 // getDefaultPartitionsInPartitionKeyMode only used in partition key mode
-func getDefaultPartitionsInPartitionKeyMode(ctx context.Context, dbName string, collectionName string) ([]string, error) {
-	partitions, err := globalMetaCache.GetPartitions(ctx, dbName, collectionName)
+func getDefaultPartitionsInPartitionKeyMode(ctx context.Context, metaCache Cache, dbName string, collectionName string) ([]string, error) {
+	partitions, err := metaCache.GetPartitions(ctx, dbName, collectionName)
 	if err != nil {
 		return nil, err
 	}
@@ -2684,13 +2685,13 @@ func assignChannelsByChannel(channelID uint32, channelNames []string, insertMsg 
 	return channel2RowOffsets
 }
 
-func assignPartitionKeys(ctx context.Context, dbName string, collName string, keys []*planpb.GenericValue) ([]string, error) {
-	partitionNames, err := globalMetaCache.GetPartitionsIndex(ctx, dbName, collName)
+func assignPartitionKeys(ctx context.Context, metaCache Cache, dbName string, collName string, keys []*planpb.GenericValue) ([]string, error) {
+	partitionNames, err := metaCache.GetPartitionsIndex(ctx, dbName, collName)
 	if err != nil {
 		return nil, err
 	}
 
-	schema, err := globalMetaCache.GetCollectionSchema(ctx, dbName, collName)
+	schema, err := metaCache.GetCollectionSchema(ctx, dbName, collName)
 	if err != nil {
 		return nil, err
 	}
@@ -2704,12 +2705,12 @@ func assignPartitionKeys(ctx context.Context, dbName string, collName string, ke
 	return hashedPartitionNames, err
 }
 
-func assignNamespacePartitionKey(ctx context.Context, dbName string, collName string, namespace *string) ([]string, error) {
+func assignNamespacePartitionKey(ctx context.Context, metaCache Cache, dbName string, collName string, namespace *string) ([]string, error) {
 	if namespace == nil {
 		return nil, nil
 	}
 
-	return assignPartitionKeys(ctx, dbName, collName, []*planpb.GenericValue{
+	return assignPartitionKeys(ctx, metaCache, dbName, collName, []*planpb.GenericValue{
 		{Val: &planpb.GenericValue_StringVal{StringVal: *namespace}},
 	})
 }
@@ -2963,16 +2964,16 @@ func addNamespaceData(schema *schemapb.CollectionSchema, insertMsg *msgstream.In
 	return nil
 }
 
-func GetCachedCollectionSchema(ctx context.Context, dbName string, colName string) (*schemaInfo, error) {
-	if globalMetaCache != nil {
-		return globalMetaCache.GetCollectionSchema(ctx, dbName, colName)
+func GetCachedCollectionSchema(ctx context.Context, metaCache Cache, dbName string, colName string) (*schemaInfo, error) {
+	if metaCache != nil {
+		return metaCache.GetCollectionSchema(ctx, dbName, colName)
 	}
 	return nil, merr.WrapErrServiceNotReady(paramtable.GetRole(), paramtable.GetNodeID(), "initialization")
 }
 
-func CheckDatabase(ctx context.Context, dbName string) bool {
-	if globalMetaCache != nil {
-		return globalMetaCache.HasDatabase(ctx, dbName)
+func CheckDatabase(ctx context.Context, metaCache Cache, dbName string) bool {
+	if metaCache != nil {
+		return metaCache.HasDatabase(ctx, dbName)
 	}
 	return false
 }
@@ -3064,80 +3065,83 @@ func GetStorageCost(status *commonpb.Status) (int64, int64, float64, bool) {
 }
 
 // GetRequestInfo returns collection name and rateType of request and return tokens needed.
-func GetRequestInfo(ctx context.Context, req proto.Message) (int64, map[int64][]int64, internalpb.RateType, int, error) {
+func GetRequestInfo(ctx context.Context, metaCache Cache, req proto.Message) (int64, map[int64][]int64, internalpb.RateType, int, error) {
+	if metaCache == nil {
+		return util.InvalidDBID, map[int64][]int64{}, 0, 0, merr.WrapErrServiceNotReady(paramtable.GetRole(), paramtable.GetNodeID(), "meta cache initialization")
+	}
 	switch r := req.(type) {
 	case *milvuspb.InsertRequest:
-		dbID, collToPartIDs, err := getCollectionAndPartitionID(ctx, req.(reqPartName))
+		dbID, collToPartIDs, err := getCollectionAndPartitionID(ctx, metaCache, req.(reqPartName))
 		return dbID, collToPartIDs, internalpb.RateType_DMLInsert, proto.Size(r), err
 	case *milvuspb.UpsertRequest:
-		dbID, collToPartIDs, err := getCollectionAndPartitionID(ctx, req.(reqPartName))
+		dbID, collToPartIDs, err := getCollectionAndPartitionID(ctx, metaCache, req.(reqPartName))
 		return dbID, collToPartIDs, internalpb.RateType_DMLInsert, proto.Size(r), err
 	case *milvuspb.DeleteRequest:
-		dbID, collToPartIDs, err := getCollectionAndPartitionID(ctx, req.(reqPartName))
+		dbID, collToPartIDs, err := getCollectionAndPartitionID(ctx, metaCache, req.(reqPartName))
 		return dbID, collToPartIDs, internalpb.RateType_DMLDelete, proto.Size(r), err
 	case *milvuspb.ImportRequest:
-		dbID, collToPartIDs, err := getCollectionAndPartitionID(ctx, req.(reqPartName))
+		dbID, collToPartIDs, err := getCollectionAndPartitionID(ctx, metaCache, req.(reqPartName))
 		return dbID, collToPartIDs, internalpb.RateType_DMLBulkLoad, proto.Size(r), err
 	case *milvuspb.SearchRequest:
-		dbID, collToPartIDs, err := getCollectionAndPartitionIDs(ctx, req.(reqPartNames))
+		dbID, collToPartIDs, err := getCollectionAndPartitionIDs(ctx, metaCache, req.(reqPartNames))
 		return dbID, collToPartIDs, internalpb.RateType_DQLSearch, int(r.GetNq()), err
 	case *milvuspb.HybridSearchRequest:
-		dbID, collToPartIDs, err := getCollectionAndPartitionIDs(ctx, req.(reqPartNames))
+		dbID, collToPartIDs, err := getCollectionAndPartitionIDs(ctx, metaCache, req.(reqPartNames))
 		nq := 0
 		for _, subReq := range r.GetRequests() {
 			nq += int(subReq.GetNq())
 		}
 		return dbID, collToPartIDs, internalpb.RateType_DQLSearch, nq, err
 	case *milvuspb.QueryRequest:
-		dbID, collToPartIDs, err := getCollectionAndPartitionIDs(ctx, req.(reqPartNames))
+		dbID, collToPartIDs, err := getCollectionAndPartitionIDs(ctx, metaCache, req.(reqPartNames))
 		return dbID, collToPartIDs, internalpb.RateType_DQLQuery, 1, err // think of the query request's nq as 1
 	case *milvuspb.CreateCollectionRequest:
-		dbID, collToPartIDs := getCollectionID(req.(reqCollName))
+		dbID, collToPartIDs := getCollectionID(metaCache, req.(reqCollName))
 		return dbID, collToPartIDs, internalpb.RateType_DDLCollection, 1, nil
 	case *milvuspb.RefreshExternalCollectionRequest:
-		dbID, collToPartIDs := getCollectionID(req.(reqCollName))
+		dbID, collToPartIDs := getCollectionID(metaCache, req.(reqCollName))
 		return dbID, collToPartIDs, internalpb.RateType_DDLCollection, 1, nil
 	case *milvuspb.RestoreExternalSnapshotRequest:
-		return getDatabaseID(r.GetDbName()), map[int64][]int64{}, internalpb.RateType_DDLCollection, 1, nil
+		return getDatabaseID(metaCache, r.GetDbName()), map[int64][]int64{}, internalpb.RateType_DDLCollection, 1, nil
 	case *milvuspb.ExportSnapshotRequest:
-		dbID, collToPartIDs := getCollectionID(req.(reqCollName))
+		dbID, collToPartIDs := getCollectionID(metaCache, req.(reqCollName))
 		return dbID, collToPartIDs, internalpb.RateType_DDLCollection, 1, nil
 	case *milvuspb.DropCollectionRequest:
-		dbID, collToPartIDs := getCollectionID(req.(reqCollName))
+		dbID, collToPartIDs := getCollectionID(metaCache, req.(reqCollName))
 		return dbID, collToPartIDs, internalpb.RateType_DDLCollection, 1, nil
 	case *milvuspb.LoadCollectionRequest:
-		dbID, collToPartIDs := getCollectionID(req.(reqCollName))
+		dbID, collToPartIDs := getCollectionID(metaCache, req.(reqCollName))
 		return dbID, collToPartIDs, internalpb.RateType_DDLCollection, 1, nil
 	case *milvuspb.ReleaseCollectionRequest:
-		dbID, collToPartIDs := getCollectionID(req.(reqCollName))
+		dbID, collToPartIDs := getCollectionID(metaCache, req.(reqCollName))
 		return dbID, collToPartIDs, internalpb.RateType_DDLCollection, 1, nil
 	case *milvuspb.CreatePartitionRequest:
-		dbID, collToPartIDs := getCollectionID(req.(reqCollName))
+		dbID, collToPartIDs := getCollectionID(metaCache, req.(reqCollName))
 		return dbID, collToPartIDs, internalpb.RateType_DDLPartition, 1, nil
 	case *milvuspb.DropPartitionRequest:
-		dbID, collToPartIDs := getCollectionID(req.(reqCollName))
+		dbID, collToPartIDs := getCollectionID(metaCache, req.(reqCollName))
 		return dbID, collToPartIDs, internalpb.RateType_DDLPartition, 1, nil
 	case *milvuspb.LoadPartitionsRequest:
-		dbID, collToPartIDs := getCollectionID(req.(reqCollName))
+		dbID, collToPartIDs := getCollectionID(metaCache, req.(reqCollName))
 		return dbID, collToPartIDs, internalpb.RateType_DDLPartition, 1, nil
 	case *milvuspb.ReleasePartitionsRequest:
-		dbID, collToPartIDs := getCollectionID(req.(reqCollName))
+		dbID, collToPartIDs := getCollectionID(metaCache, req.(reqCollName))
 		return dbID, collToPartIDs, internalpb.RateType_DDLPartition, 1, nil
 	case *milvuspb.CreateIndexRequest:
-		dbID, collToPartIDs := getCollectionID(req.(reqCollName))
+		dbID, collToPartIDs := getCollectionID(metaCache, req.(reqCollName))
 		return dbID, collToPartIDs, internalpb.RateType_DDLIndex, 1, nil
 	case *milvuspb.DropIndexRequest:
-		dbID, collToPartIDs := getCollectionID(req.(reqCollName))
+		dbID, collToPartIDs := getCollectionID(metaCache, req.(reqCollName))
 		return dbID, collToPartIDs, internalpb.RateType_DDLIndex, 1, nil
 	case *milvuspb.FlushRequest:
-		db, err := globalMetaCache.GetDatabaseInfo(ctx, r.GetDbName())
+		db, err := metaCache.GetDatabaseInfo(ctx, r.GetDbName())
 		if err != nil {
 			return util.InvalidDBID, map[int64][]int64{}, 0, 0, err
 		}
 
 		collToPartIDs := make(map[int64][]int64, 0)
 		for _, collectionName := range r.GetCollectionNames() {
-			collectionID, err := globalMetaCache.GetCollectionID(ctx, r.GetDbName(), collectionName)
+			collectionID, err := metaCache.GetCollectionID(ctx, r.GetDbName(), collectionName)
 			if err != nil {
 				return util.InvalidDBID, map[int64][]int64{}, 0, 0, err
 			}
@@ -3148,7 +3152,7 @@ func GetRequestInfo(ctx context.Context, req proto.Message) (int64, map[int64][]
 		// Use the db the request actually targets (normalized by
 		// DatabaseInterceptor), consistent with the sibling cases, so quota is
 		// accounted against the correct database. See milvus-io/milvus#50678.
-		dbInfo, err := globalMetaCache.GetDatabaseInfo(ctx, r.GetDbName())
+		dbInfo, err := metaCache.GetDatabaseInfo(ctx, r.GetDbName())
 		if err != nil {
 			return util.InvalidDBID, map[int64][]int64{}, 0, 0, err
 		}

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -2532,7 +2532,8 @@ func Test_GetPartitionProgressFailed(t *testing.T) {
 			Reason:    "Unexpected error",
 		},
 	}, nil)
-	_, _, err := getPartitionProgress(context.TODO(), qc, &commonpb.MsgBase{}, []string{}, "", 1, "")
+	metaCache := NewMockCache(t)
+	_, _, err := getPartitionProgress(context.TODO(), metaCache, qc, &commonpb.MsgBase{}, []string{}, "", 1, "")
 	assert.Error(t, err)
 }
 

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -1138,7 +1138,8 @@ func TestVerifyAPIKeyDoesNotExposeSecret(t *testing.T) {
 		util.HeaderAuthorize,
 		encodedToken,
 	))
-	_, err = AuthenticationInterceptor(ctx)
+	authInterceptor := AuthenticationInterceptorWithMetaCache(func() Cache { return InitEmptyMetaCacheForTest() })
+	_, err = authInterceptor(ctx)
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), rawToken)
 	assert.NotContains(t, err.Error(), encodedToken)

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -1130,11 +1130,6 @@ func TestVerifyAPIKeyDoesNotExposeSecret(t *testing.T) {
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), rawToken)
 
-	oldMetaCache := globalMetaCache
-	globalMetaCache = &MetaCache{}
-	t.Cleanup(func() {
-		globalMetaCache = oldMetaCache
-	})
 	require.NoError(t, paramtable.Get().Save(Params.CommonCfg.AuthorizationEnabled.Key, "true"))
 	t.Cleanup(func() {
 		paramtable.Get().Reset(Params.CommonCfg.AuthorizationEnabled.Key)


### PR DESCRIPTION
Related to #44761

Initialize the proxy meta cache locally and pass it through the Proxy instance and tasks instead of relying on a package-level singleton. This makes cache ownership explicit, removes InitMetaCache, and lets tests inject cache state directly.

Update test helpers and callers to use initMetaCache and the returned cache value, including the test-only baseTask cache hook where needed.