### PR TITLE
fix: support vector output with order_by

### DIFF
--- a/internal/core/src/query/PlanProto.cpp
+++ b/internal/core/src/query/PlanProto.cpp
@@ -479,8 +479,8 @@ BuildProjectAndAggregationNodes(
 // Helper function to build ProjectNode for ORDER BY queries.
 // Returns {ProjectNode, deferred_field_ids, pipeline_field_ids}.
 // deferred_field_ids is empty for single-project mode (all columns materialized
-// in the first project), or non-empty for two-project mode (variable-width
-// non-sort output columns deferred until after TopK).
+// in the first project), or non-empty for two-project mode (variable-width or
+// vector non-sort output columns deferred until after TopK).
 // pipeline_field_ids mirrors project_ids so FillOrderByResult can stamp
 // the correct field_id on each DataArray produced by the pipeline.
 std::tuple<plan::PlanNodePtr, std::vector<FieldId>, std::vector<FieldId>>
@@ -518,11 +518,13 @@ BuildOrderByProjectNode(const proto::plan::QueryPlanNode& query,
         }
     }
 
-    // Collect non-sort output fields and check for variable-width types.
+    // Collect non-sort output fields and check whether any must be late
+    // materialized. ProjectNode only materializes scalar columns, so vector
+    // outputs must be deferred just like variable-width outputs.
     // Skip system fields (RowFieldID, TimestampFieldID) — they are handled
     // separately in FillTargetEntry and must not enter the pipeline.
     std::vector<FieldId> non_sort_output_fields;
-    bool has_variable_width = false;
+    bool requires_late_materialization = false;
     for (auto fid_raw : plan_node_proto.output_field_ids()) {
         if (seen_field_ids.count(fid_raw) == 0) {
             auto fid = FieldId(fid_raw);
@@ -530,14 +532,16 @@ BuildOrderByProjectNode(const proto::plan::QueryPlanNode& query,
                 continue;
             }
             non_sort_output_fields.push_back(fid);
-            if (IsVariableDataType(schema->GetFieldType(fid))) {
-                has_variable_width = true;
+            auto field_type = schema->GetFieldType(fid);
+            if (IsVariableDataType(field_type) ||
+                IsVectorDataType(field_type)) {
+                requires_late_materialization = true;
             }
         }
     }
 
     std::vector<FieldId> deferred_field_ids;
-    if (has_variable_width) {
+    if (requires_late_materialization) {
         // Two-project mode: defer ALL non-sort output fields until after TopK.
         deferred_field_ids = non_sort_output_fields;
     } else {

--- a/internal/core/unittest/test_query_order_by.cpp
+++ b/internal/core/unittest/test_query_order_by.cpp
@@ -144,10 +144,10 @@ class QueryOrderByTest : public testing::TestWithParam<bool> {
         schema_->set_primary_field_id(str_fid);
 
         num_rows_ = 20;
-        auto raw_data =
+        raw_data_ =
             DataGen(schema_, num_rows_, 42, 0, 1, 10, false, false, false);
 
-        auto segment = CreateSealedWithFieldDataLoaded(schema_, raw_data);
+        auto segment = CreateSealedWithFieldDataLoaded(schema_, raw_data_);
         segment_ = SegmentSealedSPtr(segment.release());
 
         milvus::exec::expression::FunctionFactory& factory =
@@ -283,6 +283,7 @@ class QueryOrderByTest : public testing::TestWithParam<bool> {
     SegmentSealedSPtr segment_;
     std::shared_ptr<Schema> schema_;
     std::map<std::string, FieldId> field_map_;
+    GeneratedData raw_data_;
 };
 
 INSTANTIATE_TEST_SUITE_P(QueryOrderBySuite,
@@ -583,30 +584,80 @@ TEST_P(QueryOrderByTest, OrderByWithDeferredFields) {
     EXPECT_GT(count, 0);
 }
 
-TEST_P(QueryOrderByTest, DenseVectorProjectionFailureIsSystemError) {
-    // Dense vectors are fixed-width, so BuildOrderByProjectNode currently puts
-    // them in the first ProjectNode rather than deferring them for late
-    // materialization. ProjectNode cannot materialize vector columns through
-    // bulk_script_field_data yet. This is an internal projection capability
-    // gap for an otherwise valid output field, not invalid caller data.
-    std::vector<FieldId> pipeline_ids;
-    auto top_node = buildOrderByPlan(int64_field,
-                                     {string_field, int64_field, vector_field},
-                                     true,
-                                     false,
-                                     10,
-                                     pipeline_ids);
-    auto plan = createOrderByPlan(top_node, 10, pipeline_ids);
+TEST_P(QueryOrderByTest, OrderByWithDenseVectorOutput) {
+    auto pk_fid = field_map_[string_field];
+    auto double_fid = field_map_[double_field];
+    auto vector_fid = field_map_[vector_field];
 
-    try {
-        segment_->Retrieve(
-            nullptr, plan.get(), MAX_TIMESTAMP, DEFAULT_MAX_OUTPUT_SIZE, false);
-        FAIL() << "expected dense vector projection to fail";
-    } catch (const milvus::ExecOperatorException& e) {
-        EXPECT_EQ(e.get_error_code(), milvus::ErrorCode::UnexpectedError);
-        EXPECT_NE(std::string(e.what()).find("unsupported data type"),
-                  std::string::npos);
+    proto::plan::PlanNode plan_node;
+    plan_node.add_output_field_ids(pk_fid.get());
+    plan_node.add_output_field_ids(vector_fid.get());
+
+    auto* query = plan_node.mutable_query();
+    query->set_limit(10);
+    // Sort on the random double column, not the VARCHAR PK: DataGen pre-sorts
+    // VARCHAR, so a PK sort would make the segment offsets handed to the
+    // deferred bulk fetch the identity permutation and leave the vector
+    // reordering unexercised.
+    auto* order_by = query->add_order_by_fields();
+    order_by->set_field_id(double_fid.get());
+    order_by->set_ascending(true);
+    order_by->set_nulls_first(false);
+
+    auto parser = milvus::query::ProtoParser(schema_);
+    auto plan = parser.CreateRetrievePlan(plan_node);
+    EXPECT_EQ(plan->plan_node_->deferred_field_ids_,
+              std::vector<FieldId>{vector_fid});
+    EXPECT_EQ(plan->plan_node_->pipeline_field_ids_,
+              (std::vector<FieldId>{pk_fid, double_fid, SegmentOffsetFieldID}));
+
+    auto results = segment_->Retrieve(
+        nullptr, plan.get(), MAX_TIMESTAMP, DEFAULT_MAX_OUTPUT_SIZE, false);
+
+    // Pipeline columns [pk, double] + deferred vector.
+    ASSERT_EQ(results->fields_data_size(), 3);
+    const auto& pk_data = results->fields_data(0);
+    const auto& double_data = results->fields_data(1);
+    const auto& vector_data = results->fields_data(2);
+    auto row_count = pk_data.scalars().string_data().data_size();
+    ASSERT_GT(row_count, 0);
+    EXPECT_LE(row_count, query->limit());
+    EXPECT_EQ(vector_data.field_id(), vector_fid.get());
+    EXPECT_EQ(vector_data.vectors().dim(), 16);
+    ASSERT_EQ(vector_data.vectors().float_vector().data_size(), row_count * 16);
+
+    if (!GetParam()) {
+        // Non-nullable double: the returned sort column must be ascending.
+        for (int i = 1; i < row_count; i++) {
+            EXPECT_LE(double_data.scalars().double_data().data(i - 1),
+                      double_data.scalars().double_data().data(i));
+        }
     }
+
+    // Verify each deferred vector row carries the payload of the ORIGINAL row
+    // selected by the sort: map returned PK -> original segment offset, then
+    // compare the vector payload element-wise against the generated data.
+    auto raw_pks = raw_data_.get_col<std::string>(pk_fid);
+    auto raw_vectors = raw_data_.get_col<float>(vector_fid);
+    std::map<std::string, int64_t> pk_to_offset;
+    for (int64_t i = 0; i < num_rows_; i++) {
+        pk_to_offset[raw_pks[i]] = i;
+    }
+    bool permuted = false;
+    for (int i = 0; i < row_count; i++) {
+        auto offset = pk_to_offset.at(pk_data.scalars().string_data().data(i));
+        permuted = permuted || (offset != i);
+        for (int d = 0; d < 16; d++) {
+            EXPECT_EQ(vector_data.vectors().float_vector().data(i * 16 + d),
+                      raw_vectors[offset * 16 + d])
+                << "vector mismatch at result row " << i << " dim " << d
+                << " (segment offset " << offset << ")";
+        }
+    }
+    // The double sort must actually permute rows relative to insertion order;
+    // an identity mapping would mean the deferred fetch path was never
+    // exercised — the exact gap this test guards against.
+    EXPECT_TRUE(permuted);
 }
 
 TEST_P(QueryOrderByTest, OrderByInt16Asc) {


### PR DESCRIPTION
## Summary

- defer vector output fields for order_by plans that require late materialization
- preserve vector field IDs and dimensions through the result pipeline
- add a planner and retrieval regression test

## Root cause

ProjectNode cannot materialize vector columns before TopK, so valid order_by requests with vector output failed during projection.

## Validation

- `make build-cpp-with-unittest` (incremental, max 6 jobs)
- `internal/core/output/unittest/all_tests --gtest_filter="*QueryOrderBy*"` (29/29 passed)
- `clang-format --dry-run --Werror`
- `git diff --check`

Fixes #52463