### PR TITLE
enhance: configure External Table read IOPS rates

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1117,6 +1117,15 @@ common:
         threshold: 1024 # split by average size policy threshold(in bytes) in storage v2
     useLoonFFI: false
     enableGrowingSourceFlush: false # enable flushing growing segment payload from QueryNode growing source through StorageV3 manifest path
+    iops:
+      # Initial ObjectStore request rate used by the Lance AIMD limiter for External Table reads.
+      # The value must be greater than 0. Values above a positive maxRate are reduced to maxRate.
+      # The default matches the milvus-storage default.
+      initialRate: 2000
+      # Maximum request rate allowed by the Lance AIMD limiter for External Table reads.
+      # Set to 0 to disable the rate ceiling. This is not a strict aggregate limit across all filesystem instances.
+      # The default matches the milvus-storage default.
+      maxRate: 5000
   # Default value: auto
   # Valid values: [auto, avx512, avx2, avx, sse4_2]
   # This configuration is only used by querynode and indexnode, it selects CPU instruction set for Searching and Index-building.

--- a/internal/core/src/storage/loon_ffi/external_spec_c.h
+++ b/internal/core/src/storage/loon_ffi/external_spec_c.h
@@ -24,7 +24,8 @@ extern "C" {
  * produced by loon_properties_create from StorageConfig), this function
  * parses external_source + external_spec and appends:
  *   - extfs.{collection_id}.* storage-layer properties (credentials,
- *     endpoint, AWS-form rewrite, Tier-1/2 derivation)
+ *     endpoint, process-local IOPS policy, AWS-form rewrite, Tier-1/2
+ *     derivation)
  *   - format-layer properties derived from spec.format (e.g.
  *     iceberg.snapshot_id when format="iceberg-table")
  *
@@ -39,7 +40,9 @@ LoonFFIResult
 loon_properties_inject_external_spec(LoonProperties* properties,
                                      int64_t collection_id,
                                      const char* external_source,
-                                     const char* external_spec);
+                                     const char* external_spec,
+                                     uint32_t iops_initial_rate,
+                                     uint32_t iops_max_rate);
 
 #ifdef __cplusplus
 }

--- a/internal/core/src/storage/loon_ffi/property_singleton.h
+++ b/internal/core/src/storage/loon_ffi/property_singleton.h
@@ -36,6 +36,13 @@ struct ArrowReaderLimits {
     int64_t range_size_limit_bytes = 0;
 };
 
+// Process-local policy applied only when an External Table filesystem is
+// materialized. These defaults must stay aligned with milvus-storage.
+struct ExternalIopsConfig {
+    uint32_t initial_rate = 2000;
+    uint32_t max_rate = 5000;
+};
+
 class LoonFFIPropertiesSingleton {
  private:
     LoonFFIPropertiesSingleton() = default;
@@ -95,6 +102,18 @@ class LoonFFIPropertiesSingleton {
     GetProperties() const {
         std::shared_lock lck(mutex_);
         return properties_;
+    }
+
+    void
+    SetExternalIopsConfig(uint32_t initial_rate, uint32_t max_rate) {
+        std::unique_lock cfg_lck(config_mutex_);
+        external_iops_config_ = {initial_rate, max_rate};
+    }
+
+    ExternalIopsConfig
+    GetExternalIopsConfig() const {
+        std::shared_lock cfg_lck(config_mutex_);
+        return external_iops_config_;
     }
 
     // Sets the per-round read window (loon's reader.record_batch_max_size)
@@ -160,10 +179,12 @@ class LoonFFIPropertiesSingleton {
  private:
     mutable std::shared_mutex mutex_;
     std::shared_ptr<milvus_storage::api::Properties> properties_ = nullptr;
-    // Guards arrow_reader_limits_ only. Separate from mutex_ so the limits
-    // can be read while mutex_ is held; see ApplyArrowReaderConfig.
+    // Guards configuration snapshots that do not belong to the internal
+    // filesystem properties. Separate from mutex_ so the limits can be read
+    // while mutex_ is held; see ApplyArrowReaderConfig.
     mutable std::shared_mutex config_mutex_;
     ArrowReaderLimits arrow_reader_limits_{};
+    ExternalIopsConfig external_iops_config_{};
     std::atomic<int64_t> index_build_read_window_bytes_{0};
 };
 

--- a/internal/core/src/storage/loon_ffi/util.cpp
+++ b/internal/core/src/storage/loon_ffi/util.cpp
@@ -341,6 +341,17 @@ static const std::vector<std::pair<std::string, bool /*is_bool*/>>
         {"anonymous", true},
 };
 
+static std::string
+ExternalFsPropertyKey(const std::string& extfs_prefix,
+                      const char* fs_property) {
+    constexpr std::string_view fs_prefix = PROPERTY_FS_PREFIX;
+    std::string_view property(fs_property);
+    AssertInfo(property.substr(0, fs_prefix.size()) == fs_prefix,
+               "Invalid filesystem property key: {}",
+               std::string(property));
+    return extfs_prefix + std::string(property.substr(fs_prefix.size()));
+}
+
 // kExtfsInheritedFsFields lists fs.* properties that extfs.{collectionID}.*
 // inherits verbatim from the process-level storage config.
 //
@@ -353,10 +364,8 @@ static const std::vector<std::pair<std::string, bool /*is_bool*/>>
 //
 // These are deliberately NOT in kAllowedExtfsSpecKeys: they come from
 // milvus.yaml, not from a user-supplied external_spec.
-static const std::vector<
-    std::pair<const char* /*fs key*/, const char* /*extfs suffix*/>>
-    kExtfsInheritedFsFields = {
-        {PROPERTY_FS_MAX_CONNECTIONS, "max_connections"},
+static const std::vector<const char*> kExtfsInheritedFsFields = {
+    PROPERTY_FS_MAX_CONNECTIONS,
 };
 
 // PropertyValueAsString renders a PropertyVariant back to the string form
@@ -515,12 +524,15 @@ IsCloudEndpointHost(const std::string& host) {
     return false;
 }
 
-void
-InjectExternalSpecProperties(milvus_storage::api::Properties& properties,
-                             int64_t collection_id,
-                             const std::string& external_source,
-                             const std::string& external_spec) {
-    std::string extfs_prefix = "extfs." + std::to_string(collection_id) + ".";
+static void
+InjectExternalSpecProperties(
+    milvus_storage::api::Properties& properties,
+    int64_t collection_id,
+    const std::string& external_source,
+    const std::string& external_spec,
+    const milvus::storage::ExternalIopsConfig& iops_config) {
+    std::string extfs_prefix = std::string(PROPERTY_EXTFS_PREFIX) +
+                               std::to_string(collection_id) + ".";
 
     // Layer 0: zero-init bool fields only (milvus-storage rejects empty
     // strings on enum-constrained keys like cloud_provider).
@@ -545,15 +557,16 @@ InjectExternalSpecProperties(milvus_storage::api::Properties& properties,
     // internal filesystem. Keep it out of fs.* and stamp it only into the
     // per-collection extfs namespace. These keys are intentionally absent
     // from kAllowedExtfsSpecKeys, so external_spec cannot override them.
-    const auto iops_config =
-        milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
-            .GetExternalIopsConfig();
+    const auto initial_rate_key =
+        ExternalFsPropertyKey(extfs_prefix, PROPERTY_FS_IOPS_INITIAL_RATE);
+    const auto max_rate_key =
+        ExternalFsPropertyKey(extfs_prefix, PROPERTY_FS_IOPS_MAX_RATE);
     milvus_storage::api::SetValue(
         properties,
-        (extfs_prefix + "iops_initial_rate").c_str(),
+        initial_rate_key.c_str(),
         std::to_string(iops_config.initial_rate).c_str());
     milvus_storage::api::SetValue(properties,
-                                  (extfs_prefix + "iops_max_rate").c_str(),
+                                  max_rate_key.c_str(),
                                   std::to_string(iops_config.max_rate).c_str());
 
     // Layer 0b: inherit process-level fs.* tuning. Position relative to the
@@ -570,13 +583,14 @@ InjectExternalSpecProperties(milvus_storage::api::Properties& properties,
     // caps the external S3 client at max(io_capacity, 25). The producers are
     // guarded too; this is the last line of defence for the read path this
     // whole change exists to widen.
-    for (const auto& [fs_key, extfs_suffix] : kExtfsInheritedFsFields) {
+    for (const auto* fs_key : kExtfsInheritedFsFields) {
         auto value = PropertyValueAsString(properties, fs_key);
         if (!value.has_value() || *value == "0") {
             continue;
         }
+        const auto extfs_key = ExternalFsPropertyKey(extfs_prefix, fs_key);
         milvus_storage::api::SetValue(
-            properties, (extfs_prefix + extfs_suffix).c_str(), value->c_str());
+            properties, extfs_key.c_str(), value->c_str());
     }
 
     // Layer 1: derive bucket / address / storage_type / use_ssl from URI.
@@ -811,6 +825,20 @@ InjectExternalSpecProperties(milvus_storage::api::Properties& properties,
     }
 }
 
+void
+InjectExternalSpecProperties(milvus_storage::api::Properties& properties,
+                             int64_t collection_id,
+                             const std::string& external_source,
+                             const std::string& external_spec) {
+    // Native C++ callers rely on the process policy initialized during
+    // component startup.
+    const auto iops_config =
+        milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
+            .GetExternalIopsConfig();
+    InjectExternalSpecProperties(
+        properties, collection_id, external_source, external_spec, iops_config);
+}
+
 std::shared_ptr<milvus_storage::api::Properties>
 MakeInternalLocalProperies(const char* c_path) {
     auto properties_map = std::make_shared<milvus_storage::api::Properties>();
@@ -932,9 +960,6 @@ loon_properties_inject_external_spec(LoonProperties* properties,
                      "external IOPS initial rate must be greater than zero");
     }
     try {
-        milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
-            .SetExternalIopsConfig(iops_initial_rate, iops_max_rate);
-
         // Load existing flat LoonProperties into a typed Properties map.
         milvus_storage::api::Properties props;
         for (size_t i = 0; i < properties->count; ++i) {
@@ -944,10 +969,15 @@ loon_properties_inject_external_spec(LoonProperties* properties,
             }
         }
 
+        // Keep Go-provided values call-local. Publishing them to the singleton
+        // would couple concurrent FFI and native reads through global state.
+        const milvus::storage::ExternalIopsConfig iops_config{iops_initial_rate,
+                                                              iops_max_rate};
         InjectExternalSpecProperties(props,
                                      collection_id,
                                      external_source,
-                                     external_spec ? external_spec : "");
+                                     external_spec ? external_spec : "",
+                                     iops_config);
 
         // Rebuild LoonProperties from the merged map. Free old entries first
         // so ownership stays with loon_properties_free.

--- a/internal/core/src/storage/loon_ffi/util.cpp
+++ b/internal/core/src/storage/loon_ffi/util.cpp
@@ -541,6 +541,21 @@ InjectExternalSpecProperties(milvus_storage::api::Properties& properties,
         }
     }
 
+    // IOPS limiting is an External Table read policy, not an attribute of the
+    // internal filesystem. Keep it out of fs.* and stamp it only into the
+    // per-collection extfs namespace. These keys are intentionally absent
+    // from kAllowedExtfsSpecKeys, so external_spec cannot override them.
+    const auto iops_config =
+        milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
+            .GetExternalIopsConfig();
+    milvus_storage::api::SetValue(
+        properties,
+        (extfs_prefix + "iops_initial_rate").c_str(),
+        std::to_string(iops_config.initial_rate).c_str());
+    milvus_storage::api::SetValue(properties,
+                                  (extfs_prefix + "iops_max_rate").c_str(),
+                                  std::to_string(iops_config.max_rate).c_str());
+
     // Layer 0b: inherit process-level fs.* tuning. Position relative to the
     // later layers is arbitrary — none of these keys is in
     // kAllowedExtfsSpecKeys nor derived from the URI, so no other layer
@@ -903,14 +918,23 @@ extern "C" LoonFFIResult
 loon_properties_inject_external_spec(LoonProperties* properties,
                                      int64_t collection_id,
                                      const char* external_source,
-                                     const char* external_spec) {
+                                     const char* external_spec,
+                                     uint32_t iops_initial_rate,
+                                     uint32_t iops_max_rate) {
     if (properties == nullptr) {
         RETURN_ERROR(LOON_INVALID_ARGS, "properties is null");
     }
     if (external_source == nullptr || external_source[0] == '\0') {
         RETURN_SUCCESS();  // no-op for internal (non-external) collections
     }
+    if (iops_initial_rate == 0) {
+        RETURN_ERROR(LOON_INVALID_ARGS,
+                     "external IOPS initial rate must be greater than zero");
+    }
     try {
+        milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
+            .SetExternalIopsConfig(iops_initial_rate, iops_max_rate);
+
         // Load existing flat LoonProperties into a typed Properties map.
         milvus_storage::api::Properties props;
         for (size_t i = 0; i < properties->count; ++i) {

--- a/internal/core/src/storage/loon_ffi/util.h
+++ b/internal/core/src/storage/loon_ffi/util.h
@@ -99,8 +99,8 @@ GetLoonManifest(
  * Emits two property families from a single external_spec JSON:
  *   - extfs.{collectionID}.* — storage-layer: credentials, endpoint, bucket,
  *     region, SSL, IAM. Three-layer model:
- *       Layer 0: zero-init bool fields (no fs.* inheritance — Milvus-internal
- *                credentials must never leak into external-table scope).
+ *       Layer 0: zero-init bool fields and apply the process-local External
+ *                Table IOPS policy (no fs.* IOPS inheritance).
  *       Layer 1: derive storage_type / use_ssl / bucket_name / address from
  *                the external_source URI (Milvus form by default).
  *       Layer 2: apply external_spec.extfs JSON with allowlist gating.

--- a/internal/core/src/storage/storage_c.cpp
+++ b/internal/core/src/storage/storage_c.cpp
@@ -256,6 +256,22 @@ InitIndexBuildReadWindow(int64_t window_bytes) {
     }
 }
 
+CStatus
+InitExternalIopsConfig(uint32_t initial_rate, uint32_t max_rate) {
+    try {
+        if (initial_rate == 0) {
+            return milvus::FailureCStatus(
+                milvus::ConfigInvalid,
+                "external IOPS initial rate must be greater than zero");
+        }
+        milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
+            .SetExternalIopsConfig(initial_rate, max_rate);
+        return milvus::SuccessCStatus();
+    } catch (std::exception& e) {
+        return milvus::FailureCStatus(&e);
+    }
+}
+
 void
 CleanRemoteChunkManagerSingleton() {
     milvus::storage::RemoteChunkManagerSingleton::GetInstance().Release();

--- a/internal/core/src/storage/storage_c.h
+++ b/internal/core/src/storage/storage_c.h
@@ -61,6 +61,9 @@ GetLoonReaderThreadPoolSize();
 CStatus
 InitIndexBuildReadWindow(int64_t window_bytes);
 
+CStatus
+InitExternalIopsConfig(uint32_t initial_rate, uint32_t max_rate);
+
 // Plugin related APIs
 CStatus
 InitPluginLoader(const char* plugin_path);

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -3375,17 +3375,14 @@ TEST(InjectExtfsInheritedFields, CAbiIopsConfigIsCallLocal) {
 
     auto result = loon_properties_inject_external_spec(
         &properties, 42, "s3://my-bucket/key", "", 3000, 0);
-    const std::string error =
-        result.message != nullptr ? result.message : "";
-    EXPECT_EQ(result.err_code, loon_errcode_success)
-        << error;
+    const std::string error = result.message != nullptr ? result.message : "";
+    EXPECT_EQ(result.err_code, loon_errcode_success) << error;
     loon_ffi_free_result(&result);
 
-    EXPECT_STREQ(loon_properties_get(
-                     &properties, "extfs.42.iops_initial_rate"),
+    EXPECT_STREQ(loon_properties_get(&properties, "extfs.42.iops_initial_rate"),
                  "3000");
-    EXPECT_STREQ(
-        loon_properties_get(&properties, "extfs.42.iops_max_rate"), "0");
+    EXPECT_STREQ(loon_properties_get(&properties, "extfs.42.iops_max_rate"),
+                 "0");
 
     const auto singleton_after =
         milvus::storage::LoonFFIPropertiesSingleton::GetInstance()

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -41,6 +41,7 @@
 #include "segcore/ChunkedSegmentSealedImpl.h"
 #include "segcore/SegmentSealed.h"
 #include "storage/Util.h"
+#include "storage/loon_ffi/external_spec_c.h"
 #include "storage/loon_ffi/property_singleton.h"
 #include "storage/loon_ffi/util.h"
 #include "test_utils/DataGen.h"
@@ -3366,6 +3367,33 @@ TEST(InjectExtfsInheritedFields, ExternalIopsConfiguredAndNotOverridable) {
     EXPECT_EQ(std::get<std::string>(props.at("extfs.7.iops_initial_rate")),
               "3000");
     EXPECT_EQ(std::get<std::string>(props.at("extfs.7.iops_max_rate")), "0");
+}
+
+TEST(InjectExtfsInheritedFields, CAbiIopsConfigIsCallLocal) {
+    ScopedExternalIopsConfig singleton_config(7000, 8000);
+    LoonProperties properties{};
+
+    auto result = loon_properties_inject_external_spec(
+        &properties, 42, "s3://my-bucket/key", "", 3000, 0);
+    const std::string error =
+        result.message != nullptr ? result.message : "";
+    EXPECT_EQ(result.err_code, loon_errcode_success)
+        << error;
+    loon_ffi_free_result(&result);
+
+    EXPECT_STREQ(loon_properties_get(
+                     &properties, "extfs.42.iops_initial_rate"),
+                 "3000");
+    EXPECT_STREQ(
+        loon_properties_get(&properties, "extfs.42.iops_max_rate"), "0");
+
+    const auto singleton_after =
+        milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
+            .GetExternalIopsConfig();
+    EXPECT_EQ(singleton_after.initial_rate, 7000);
+    EXPECT_EQ(singleton_after.max_rate, 8000);
+
+    loon_properties_free(&properties);
 }
 
 // Azure endpoint derivation: AWS-form URI with cp=azure + region resolves via

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -41,6 +41,7 @@
 #include "segcore/ChunkedSegmentSealedImpl.h"
 #include "segcore/SegmentSealed.h"
 #include "storage/Util.h"
+#include "storage/loon_ffi/property_singleton.h"
 #include "storage/loon_ffi/util.h"
 #include "test_utils/DataGen.h"
 #include "test_utils/storage_test_utils.h"
@@ -88,6 +89,25 @@ class ScopedTakeForOutputResultCountLimit {
 
  private:
     int64_t old_value_;
+};
+
+class ScopedExternalIopsConfig {
+ public:
+    ScopedExternalIopsConfig(uint32_t initial_rate, uint32_t max_rate)
+        : old_config_(milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
+                          .GetExternalIopsConfig()) {
+        milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
+            .SetExternalIopsConfig(initial_rate, max_rate);
+    }
+
+    ~ScopedExternalIopsConfig() {
+        milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
+            .SetExternalIopsConfig(old_config_.initial_rate,
+                                   old_config_.max_rate);
+    }
+
+ private:
+    milvus::storage::ExternalIopsConfig old_config_;
 };
 
 std::string
@@ -3319,6 +3339,33 @@ TEST(InjectExtfsInheritedFields, MaxConnectionsNotOverridableBySpec) {
 
     EXPECT_EQ(std::get<std::string>(props.at("extfs.42.max_connections")),
               "100");
+}
+
+TEST(InjectExtfsInheritedFields, ExternalIopsDefaults) {
+    ScopedExternalIopsConfig config(2000, 5000);
+    milvus_storage::api::Properties props;
+
+    ::InjectExternalSpecProperties(props, 42, "s3://my-bucket/key", "");
+
+    EXPECT_EQ(std::get<std::string>(props.at("extfs.42.iops_initial_rate")),
+              "2000");
+    EXPECT_EQ(std::get<std::string>(props.at("extfs.42.iops_max_rate")),
+              "5000");
+    EXPECT_EQ(props.count("fs.iops_initial_rate"), 0u);
+    EXPECT_EQ(props.count("fs.iops_max_rate"), 0u);
+}
+
+TEST(InjectExtfsInheritedFields, ExternalIopsConfiguredAndNotOverridable) {
+    ScopedExternalIopsConfig config(3000, 0);
+    milvus_storage::api::Properties props;
+    std::string spec =
+        R"({"format":"parquet","extfs":{"iops_initial_rate":"9000","iops_max_rate":"10000"}})";
+
+    ::InjectExternalSpecProperties(props, 7, "s3://my-bucket/key", spec);
+
+    EXPECT_EQ(std::get<std::string>(props.at("extfs.7.iops_initial_rate")),
+              "3000");
+    EXPECT_EQ(std::get<std::string>(props.at("extfs.7.iops_max_rate")), "0");
 }
 
 // Azure endpoint derivation: AWS-form URI with cp=azure + region resolves via

--- a/internal/core/unittest/test_storage.cpp
+++ b/internal/core/unittest/test_storage.cpp
@@ -902,6 +902,25 @@ TEST_F(StorageTest, CleanRemoteChunkManagerSingleton) {
     CleanRemoteChunkManagerSingleton();
 }
 
+TEST_F(StorageTest, InitExternalIopsConfig) {
+    auto& singleton = LoonFFIPropertiesSingleton::GetInstance();
+    const auto old_config = singleton.GetExternalIopsConfig();
+
+    auto status = InitExternalIopsConfig(0, old_config.max_rate);
+    EXPECT_EQ(status.error_code, ConfigInvalid);
+    FreeErrorStatus(status);
+
+    status = InitExternalIopsConfig(3000, 0);
+    EXPECT_EQ(status.error_code, Success) << status.error_msg;
+    const auto config = singleton.GetExternalIopsConfig();
+    EXPECT_EQ(config.initial_rate, 3000);
+    EXPECT_EQ(config.max_rate, 0);
+
+    status =
+        InitExternalIopsConfig(old_config.initial_rate, old_config.max_rate);
+    EXPECT_EQ(status.error_code, Success) << status.error_msg;
+}
+
 TEST_F(StorageTest, InitArrowReaderConfig) {
     auto default_cache_options =
         parquet::default_arrow_reader_properties().cache_options();

--- a/internal/datanode/index/init_segcore.go
+++ b/internal/datanode/index/init_segcore.go
@@ -102,6 +102,12 @@ func InitSegcore(nodeID int64) error {
 		return err
 	}
 
+	// Publish the External Table IOPS policy once for native IndexBuilder
+	// readers. Reader config watchers must not rewrite this startup policy.
+	if err := initcore.InitExternalIopsConfig(paramtable.Get()); err != nil {
+		return err
+	}
+
 	// Apply milvus-storage reader concurrency config: the global reader
 	// thread pool (chunk/file-level fan-out) and the index-build read
 	// window (row groups prefetched in parallel per round).

--- a/internal/storagev2/packed/exttable_test.go
+++ b/internal/storagev2/packed/exttable_test.go
@@ -995,6 +995,56 @@ func TestNormalizeExternalPathForStorage_UsesInjectedExtfsEndpoint(t *testing.T)
 	assert.Equal(t, "s3://s3.us-west-2.amazonaws.com/liyiyang-test/a/b/file.parquet?versionId=1", got)
 }
 
+func TestInjectExternalSpecProperties_AppliesExternalIops(t *testing.T) {
+	paramtable.Init()
+	params := paramtable.Get()
+	initialKey := params.CommonCfg.StorageIopsInitialRate.Key
+	maxKey := params.CommonCfg.StorageIopsMaxRate.Key
+	t.Cleanup(func() {
+		params.Reset(initialKey)
+		params.Reset(maxKey)
+	})
+
+	require.NoError(t, params.Save(initialKey, "3000"))
+	require.NoError(t, params.Save(maxKey, "0"))
+	config := &indexpb.StorageConfig{
+		StorageType: "local",
+		BucketName:  t.TempDir(),
+		RootPath:    t.TempDir(),
+	}
+	props, err := MakePropertiesFromStorageConfig(config, nil)
+	require.NoError(t, err)
+	defer FreeProperties(props)
+
+	require.NoError(t, injectExternalSpecProperties(
+		props,
+		42,
+		"s3://my-bucket/key",
+		`{"format":"parquet","extfs":{"iops_initial_rate":"9000","iops_max_rate":"10000"}}`,
+	))
+	prefix := ExtfsPrefixForCollection(42)
+	assert.Equal(t, "3000", loonPropertyString(props, prefix+"iops_initial_rate"))
+	assert.Equal(t, "0", loonPropertyString(props, prefix+"iops_max_rate"))
+	assert.Empty(t, loonPropertyString(props, "fs.iops_initial_rate"))
+	assert.Empty(t, loonPropertyString(props, "fs.iops_max_rate"))
+}
+
+func TestInjectExternalSpecProperties_Boundaries(t *testing.T) {
+	require.Error(t, injectExternalSpecProperties(nil, 42, "s3://my-bucket/key", ""))
+
+	config := &indexpb.StorageConfig{
+		StorageType: "local",
+		BucketName:  t.TempDir(),
+		RootPath:    t.TempDir(),
+	}
+	props, err := MakePropertiesFromStorageConfig(config, nil)
+	require.NoError(t, err)
+	defer FreeProperties(props)
+
+	require.NoError(t, injectExternalSpecProperties(props, 42, "", ""))
+	require.Error(t, injectExternalSpecProperties(props, 42, "invalid", ""))
+}
+
 func TestNormalizeExternalPathForStorage_EndpointFormUnchanged(t *testing.T) {
 	config := &indexpb.StorageConfig{
 		StorageType: "local",

--- a/internal/storagev2/packed/ffi_common.go
+++ b/internal/storagev2/packed/ffi_common.go
@@ -297,10 +297,11 @@ type ExternalSpecContext struct {
 	MilvusTablePKMode MilvusTablePrimaryKeyMode
 }
 
-// injectExternalSpecProperties appends every external_spec-derived property
-// (extfs.<collectionID>.* and format-layer keys) onto an existing
-// LoonProperties via the C++ InjectExternalSpecProperties pipeline. No-op
-// when externalSource is empty.
+// injectExternalSpecProperties appends External Table filesystem and
+// format-layer properties onto an existing LoonProperties via the C++
+// InjectExternalSpecProperties pipeline. The process-local IOPS policy is
+// applied only to the extfs.<collectionID> namespace. No-op when
+// externalSource is empty.
 func injectExternalSpecProperties(properties *C.LoonProperties, collectionID int64,
 	externalSource, externalSpec string,
 ) error {
@@ -310,6 +311,7 @@ func injectExternalSpecProperties(properties *C.LoonProperties, collectionID int
 	if externalSource == "" {
 		return nil
 	}
+	params := paramtable.Get()
 	cSource := C.CString(externalSource)
 	defer C.free(unsafe.Pointer(cSource))
 	var cSpec *C.char
@@ -318,7 +320,13 @@ func injectExternalSpecProperties(properties *C.LoonProperties, collectionID int
 		defer C.free(unsafe.Pointer(cSpec))
 	}
 	result := C.loon_properties_inject_external_spec(
-		properties, C.int64_t(collectionID), cSource, cSpec)
+		properties,
+		C.int64_t(collectionID),
+		cSource,
+		cSpec,
+		C.uint32_t(params.CommonCfg.StorageIopsInitialRate.GetAsUint32()),
+		C.uint32_t(params.CommonCfg.StorageIopsMaxRate.GetAsUint32()),
+	)
 	if err := HandleLoonFFIResult(result); err != nil {
 		return merr.WrapErrStorage(err, "loon inject_external_spec failed")
 	}

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -144,10 +144,30 @@ func callWithTimeout(fn func(), timeoutHandler func(), timeout time.Duration) {
 }
 
 func InitStorageV2FileSystem(params *paramtable.ComponentParam) error {
+	if err := InitExternalIopsConfig(params); err != nil {
+		return err
+	}
 	if params.CommonCfg.StorageType.GetValue() == "local" {
 		return InitLocalArrowFileSystem(params.LocalStorageCfg.Path.GetValue())
 	}
 	return InitRemoteArrowFileSystem(params)
+}
+
+// InitExternalIopsConfig publishes the process-local policy used only when
+// External Table filesystem properties are injected.
+func InitExternalIopsConfig(params *paramtable.ComponentParam) error {
+	return setExternalIopsConfig(
+		params.CommonCfg.StorageIopsInitialRate.GetAsUint32(),
+		params.CommonCfg.StorageIopsMaxRate.GetAsUint32(),
+	)
+}
+
+func setExternalIopsConfig(initialRate, maxRate uint32) error {
+	status := C.InitExternalIopsConfig(
+		C.uint32_t(initialRate),
+		C.uint32_t(maxRate),
+	)
+	return HandleCStatus(&status, "InitExternalIopsConfig failed")
 }
 
 func InitLocalArrowFileSystem(path string) error {
@@ -550,6 +570,9 @@ func InitLoonReaderConfig(params *paramtable.ComponentParam) error {
 		return merr.WrapErrParameterInvalidMsg(
 			"common.storage.indexBuildReadWindowBytes must be in [0, %d], got %d",
 			maxIndexBuildReadWindowBytes, window)
+	}
+	if err := InitExternalIopsConfig(params); err != nil {
+		return err
 	}
 	status := C.InitLoonReaderThreadPool(C.int32_t(poolSize))
 	if err := HandleCStatus(&status, "InitLoonReaderThreadPool failed"); err != nil {

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -144,9 +144,6 @@ func callWithTimeout(fn func(), timeoutHandler func(), timeout time.Duration) {
 }
 
 func InitStorageV2FileSystem(params *paramtable.ComponentParam) error {
-	if err := InitExternalIopsConfig(params); err != nil {
-		return err
-	}
 	if params.CommonCfg.StorageType.GetValue() == "local" {
 		return InitLocalArrowFileSystem(params.LocalStorageCfg.Path.GetValue())
 	}
@@ -156,16 +153,9 @@ func InitStorageV2FileSystem(params *paramtable.ComponentParam) error {
 // InitExternalIopsConfig publishes the process-local policy used only when
 // External Table filesystem properties are injected.
 func InitExternalIopsConfig(params *paramtable.ComponentParam) error {
-	return setExternalIopsConfig(
-		params.CommonCfg.StorageIopsInitialRate.GetAsUint32(),
-		params.CommonCfg.StorageIopsMaxRate.GetAsUint32(),
-	)
-}
-
-func setExternalIopsConfig(initialRate, maxRate uint32) error {
 	status := C.InitExternalIopsConfig(
-		C.uint32_t(initialRate),
-		C.uint32_t(maxRate),
+		C.uint32_t(params.CommonCfg.StorageIopsInitialRate.GetAsUint32()),
+		C.uint32_t(params.CommonCfg.StorageIopsMaxRate.GetAsUint32()),
 	)
 	return HandleCStatus(&status, "InitExternalIopsConfig failed")
 }
@@ -570,9 +560,6 @@ func InitLoonReaderConfig(params *paramtable.ComponentParam) error {
 		return merr.WrapErrParameterInvalidMsg(
 			"common.storage.indexBuildReadWindowBytes must be in [0, %d], got %d",
 			maxIndexBuildReadWindowBytes, window)
-	}
-	if err := InitExternalIopsConfig(params); err != nil {
-		return err
 	}
 	status := C.InitLoonReaderThreadPool(C.int32_t(poolSize))
 	if err := HandleCStatus(&status, "InitLoonReaderThreadPool failed"); err != nil {

--- a/internal/util/initcore/init_core_test.go
+++ b/internal/util/initcore/init_core_test.go
@@ -195,17 +195,6 @@ func TestInitLoonReaderConfig(t *testing.T) {
 		"the reader pool must not be resized when the window is rejected")
 }
 
-func TestSetExternalIopsConfig(t *testing.T) {
-	assert.Error(t, setExternalIopsConfig(0, 5000))
-	assert.NoError(t, setExternalIopsConfig(3000, 0))
-	t.Cleanup(func() {
-		assert.NoError(t, setExternalIopsConfig(
-			paramtable.DefaultStorageIopsInitialRate,
-			paramtable.DefaultStorageIopsMaxRate,
-		))
-	})
-}
-
 // TestInitLoonReaderConfigSerialized pins the read-then-apply critical
 // section. Config-event handlers run inline on the updating goroutine with no
 // cross-handler ordering guarantee, and resizing the reader pool is not

--- a/internal/util/initcore/init_core_test.go
+++ b/internal/util/initcore/init_core_test.go
@@ -195,6 +195,17 @@ func TestInitLoonReaderConfig(t *testing.T) {
 		"the reader pool must not be resized when the window is rejected")
 }
 
+func TestSetExternalIopsConfig(t *testing.T) {
+	assert.Error(t, setExternalIopsConfig(0, 5000))
+	assert.NoError(t, setExternalIopsConfig(3000, 0))
+	t.Cleanup(func() {
+		assert.NoError(t, setExternalIopsConfig(
+			paramtable.DefaultStorageIopsInitialRate,
+			paramtable.DefaultStorageIopsMaxRate,
+		))
+	})
+}
+
 // TestInitLoonReaderConfigSerialized pins the read-then-apply critical
 // section. Config-event handlers run inline on the updating goroutine with no
 // cross-handler ordering guarantee, and resizing the reader pool is not

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -202,6 +202,12 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 		return err
 	}
 
+	// Publish the External Table IOPS policy once for native Segcore readers.
+	err = InitExternalIopsConfig(paramtable.Get())
+	if err != nil {
+		return err
+	}
+
 	err = InitStorageV2FileSystem(paramtable.Get())
 	if err != nil {
 		return err

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1268,7 +1268,7 @@ The default value is 1, which is enough for most cases.`,
 
 	p.StorageIopsInitialRate = ParamItem{
 		Key:          "common.storage.iops.initialRate",
-		Version:      "2.7.0",
+		Version:      "3.0.1",
 		DefaultValue: strconv.FormatUint(uint64(DefaultStorageIopsInitialRate), 10),
 		Doc: `Initial ObjectStore request rate used by the Lance AIMD limiter for External Table reads.
 The value must be greater than 0. Values above a positive maxRate are reduced to maxRate.
@@ -1286,7 +1286,7 @@ The default matches the milvus-storage default.`,
 
 	p.StorageIopsMaxRate = ParamItem{
 		Key:          "common.storage.iops.maxRate",
-		Version:      "2.7.0",
+		Version:      "3.0.1",
 		DefaultValue: strconv.FormatUint(uint64(DefaultStorageIopsMaxRate), 10),
 		Doc: `Maximum request rate allowed by the Lance AIMD limiter for External Table reads.
 Set to 0 to disable the rate ceiling. This is not a strict aggregate limit across all filesystem instances.

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -51,6 +51,8 @@ const (
 	DefaultMiddlePriorityThreadCoreCoefficient = 5
 	DefaultLowPriorityThreadCoreCoefficient    = 1
 	DefaultThreadPoolMaxThreadsSize            = 16
+	DefaultStorageIopsInitialRate              = uint32(2000)
+	DefaultStorageIopsMaxRate                  = uint32(5000)
 
 	DefaultSessionTTL        = 15 // s
 	DefaultSessionRetryTimes = 30
@@ -322,6 +324,8 @@ type commonConfig struct {
 	StoragePathPrefix        ParamItem `refreshable:"false"`
 	StorageZstdConcurrency   ParamItem `refreshable:"false"`
 	StorageReadRetryAttempts ParamItem `refreshable:"true"`
+	StorageIopsInitialRate   ParamItem `refreshable:"false"`
+	StorageIopsMaxRate       ParamItem `refreshable:"false"`
 
 	TraceLogMode              ParamItem `refreshable:"true"`
 	BloomFilterEnabled        ParamItem `refreshable:"false"`
@@ -1261,6 +1265,42 @@ The default value is 1, which is enough for most cases.`,
 		Export:       false,
 	}
 	p.StorageReadRetryAttempts.Init(base.mgr)
+
+	p.StorageIopsInitialRate = ParamItem{
+		Key:          "common.storage.iops.initialRate",
+		Version:      "2.7.0",
+		DefaultValue: strconv.FormatUint(uint64(DefaultStorageIopsInitialRate), 10),
+		Doc: `Initial ObjectStore request rate used by the Lance AIMD limiter for External Table reads.
+The value must be greater than 0. Values above a positive maxRate are reduced to maxRate.
+The default matches the milvus-storage default.`,
+		Formatter: func(value string) string {
+			rate, err := strconv.ParseUint(value, 10, 32)
+			if err != nil || rate == 0 {
+				return strconv.FormatUint(uint64(DefaultStorageIopsInitialRate), 10)
+			}
+			return strconv.FormatUint(rate, 10)
+		},
+		Export: true,
+	}
+	p.StorageIopsInitialRate.Init(base.mgr)
+
+	p.StorageIopsMaxRate = ParamItem{
+		Key:          "common.storage.iops.maxRate",
+		Version:      "2.7.0",
+		DefaultValue: strconv.FormatUint(uint64(DefaultStorageIopsMaxRate), 10),
+		Doc: `Maximum request rate allowed by the Lance AIMD limiter for External Table reads.
+Set to 0 to disable the rate ceiling. This is not a strict aggregate limit across all filesystem instances.
+The default matches the milvus-storage default.`,
+		Formatter: func(value string) string {
+			rate, err := strconv.ParseUint(value, 10, 32)
+			if err != nil {
+				return strconv.FormatUint(uint64(DefaultStorageIopsMaxRate), 10)
+			}
+			return strconv.FormatUint(rate, 10)
+		},
+		Export: true,
+	}
+	p.StorageIopsMaxRate.Init(base.mgr)
 
 	p.TraceLogMode = ParamItem{
 		Key:          "common.traceLogMode",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -111,6 +111,28 @@ func TestMembershipFilterConfig(t *testing.T) {
 	})
 }
 
+func TestComponentParam_StorageIopsParams(t *testing.T) {
+	params := &ComponentParam{}
+	params.Init(NewBaseTable(SkipRemote(true), SkipEnv(true)))
+
+	initialRate := &params.CommonCfg.StorageIopsInitialRate
+	maxRate := &params.CommonCfg.StorageIopsMaxRate
+	assert.Equal(t, DefaultStorageIopsInitialRate, initialRate.GetAsUint32())
+	assert.Equal(t, DefaultStorageIopsMaxRate, maxRate.GetAsUint32())
+
+	assert.NoError(t, params.Save(initialRate.Key, "3000"))
+	assert.NoError(t, params.Save(maxRate.Key, "0"))
+	assert.Equal(t, uint32(3000), initialRate.GetAsUint32())
+	assert.Equal(t, uint32(0), maxRate.GetAsUint32())
+
+	for _, invalid := range []string{"", "-1", "invalid", "4294967296"} {
+		assert.NoError(t, params.Save(initialRate.Key, invalid))
+		assert.Equal(t, DefaultStorageIopsInitialRate, initialRate.GetAsUint32())
+		assert.NoError(t, params.Save(maxRate.Key, invalid))
+		assert.Equal(t, DefaultStorageIopsMaxRate, maxRate.GetAsUint32())
+	}
+}
+
 func TestComponentParam(t *testing.T) {
 	Init()
 	params := Get()

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -117,6 +117,8 @@ func TestComponentParam_StorageIopsParams(t *testing.T) {
 
 	initialRate := &params.CommonCfg.StorageIopsInitialRate
 	maxRate := &params.CommonCfg.StorageIopsMaxRate
+	assert.Equal(t, "3.0.1", initialRate.Version)
+	assert.Equal(t, "3.0.1", maxRate.Version)
 	assert.Equal(t, DefaultStorageIopsInitialRate, initialRate.GetAsUint32())
 	assert.Equal(t, DefaultStorageIopsMaxRate, maxRate.GetAsUint32())
 


### PR DESCRIPTION
issue: #52501

## What changed

- Add `common.storage.iops.initialRate` and
  `common.storage.iops.maxRate`, defaulting to the milvus-storage values
  `2000` and `5000` and marked as introduced in 3.0.1.
- Pass Go FFI rates directly to External Table property injection without
  mutating the process singleton.
- Initialize the native Segcore and IndexBuilder policies once from their
  component startup paths, outside Reader configuration watchers.
- Write the policy only to
  `extfs.<collectionID>.iops_initial_rate/max_rate`, using canonical
  milvus-storage property constants.
- Add C ABI regression coverage proving that per-call injection does not
  change the singleton policy.

## Behavior boundary

This change is limited to the External Table read path. It does not propagate
IOPS fields through `StorageConfig`, internal `fs.*` properties, writers,
compaction, or filesystem metrics. External specifications cannot override the
Milvus-configured rates.

`maxRate: 0` disables the AIMD rate ceiling. These settings tune each Lance
ObjectStore limiter; they are not a strict aggregate IOPS limit across all
filesystem instances.

The current master base already uses milvus-storage `8632a0f`, which contains
the required IOPS properties and Lance AIMD mappings.

## Validation

- Compilation and tests were not rerun for the cleanup, per request
- `gofmt -d` on changed Go files
- `git diff --check`
- Rebased onto `master` at `ea48d3dd4b2b0f1177c7780538a647e85a9e6d45`
  with unchanged feature patch-id and touched paths

Dependency: [milvus-storage PR #618](https://github.com/milvus-io/milvus-storage/pull/618)
