### PR TITLE
fix: [2.6] propagate collection_id into LoadIndexInfo on index load

### DIFF
--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -52,6 +52,7 @@ SegmentLoadInfo::ConvertFieldIndexInfoToLoadIndexInfo(
     // Extract field ID
     auto field_id = FieldId(field_index_info->fieldid());
     load_index_info.field_id = field_id.get();
+    load_index_info.collection_id = GetCollectionID();
     load_index_info.partition_id = GetPartitionID();
 
     // Get field type from schema


### PR DESCRIPTION
issue: #52507

`SegmentLoadInfo::ConvertFieldIndexInfoToLoadIndexInfo()` sets `segment_id`, `field_id` and `partition_id` but never sets `collection_id`. `LoadIndexInfo::collection_id` has no default member initializer and the struct uses `LoadIndexInfo() = default;`, so the field is left indeterminate rather than zeroed.

That value is then handed to the cipher plugin:

```
Utils.cpp LoadIndexData()            -> FieldDataMeta{collection_id, ...}
SealedIndexTranslator                -> config_[index::COLLECTION_ID]
ScalarIndex::LoadUnified()           -> IndexEntryReader::Open(input, size, collection_id)
IndexEntryReader                     -> cipher_plugin_->GetDecryptor(ez_id_, collection_id_, edek_)
```

With encryption at rest enabled, the EDEK is bound to the collection id, so a garbage id makes every encrypted V3 packed scalar index fail to load:

```
At LoadSegment: At Load: St13runtime_error :Decryption failed:
INVALID_ARGUMENT: decryption failed: segcore error[segcoreCode=2001]
```

The failure is deterministic — no `LoadUnified` call succeeds — so the affected collections never finish loading and all queries on them return `NoReplicaAvailable`. Config dumps from `SealedIndexTranslator` showed the field taking values like `19`, `1`, `65536`, `139756949667840`. Without encryption the field is only used for bookkeeping, which is why the defect stayed silent.

`master` already has this assignment; it was added by #49325 and was not carried over when the V3 scalar index format was backported to 2.6 in #49566.

This PR only restores the missing assignment, matching master's placement in the same function. Giving the POD members of `LoadIndexInfo` default member initializers would prevent the same class of defect, but that touches both branches and is left out of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
