### PR TITLE
fix: [hotfix-2.6.22] propagate collection_id into LoadIndexInfo on index load (#52508)

### DIFF
--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -52,6 +52,7 @@ SegmentLoadInfo::ConvertFieldIndexInfoToLoadIndexInfo(
     // Extract field ID
     auto field_id = FieldId(field_index_info->fieldid());
     load_index_info.field_id = field_id.get();
+    load_index_info.collection_id = GetCollectionID();
     load_index_info.partition_id = GetPartitionID();
 
     // Get field type from schema


### PR DESCRIPTION
issue: #52507

Cherry-pick of #52508 (merged into `2.6` as 75c4181595) onto `hotfix-2.6.22`.

`SegmentLoadInfo::ConvertFieldIndexInfoToLoadIndexInfo()` never sets `collection_id`, and `LoadIndexInfo::collection_id` has no default member initializer, so the field is indeterminate. It reaches the cipher plugin through:

```
Utils.cpp LoadIndexData()            -> FieldDataMeta{collection_id, ...}
SealedIndexTranslator                -> config_[index::COLLECTION_ID]
ScalarIndex::LoadUnified()           -> IndexEntryReader::Open(input, size, collection_id)
IndexEntryReader                     -> cipher_plugin_->GetDecryptor(ez_id_, collection_id_, edek_)
```

With encryption at rest enabled the EDEK is bound to the collection id, so every encrypted V3 packed scalar index fails to load with `Decryption failed: INVALID_ARGUMENT: decryption failed`, and the affected collections can never finish loading.

Every 2.6 release from v2.6.17 (the first tag whose `IndexEntryReader` reads encrypted V3 packed indexes) through v2.6.22 is affected, so `hotfix-2.6.22` needs the same fix as `2.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
