### PR TITLE
test: fix log-capture races with a shared concurrency-safe mlog sink

### DIFF
--- a/internal/datacoord/compaction_policy_storage_version_test.go
+++ b/internal/datacoord/compaction_policy_storage_version_test.go
@@ -17,7 +17,6 @@
 package datacoord
 
 import (
-	"bytes"
 	"context"
 	"strings"
 	"testing"
@@ -36,14 +35,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
-
-type syncBuffer struct {
-	bytes.Buffer
-}
-
-func (b *syncBuffer) Sync() error {
-	return nil
-}
 
 func TestStorageVersionUpgradePolicySuite(t *testing.T) {
 	suite.Run(t, new(StorageVersionUpgradePolicySuite))
@@ -428,19 +419,13 @@ func (s *StorageVersionUpgradePolicySuite) TestFormatRefreshRespectsSegmentFilte
 
 func (s *StorageVersionUpgradePolicySuite) TestSegmentColumnGroupFormatsAllEqual() {
 	collID := int64(100)
-	var logs syncBuffer
-	oldLogger := mlog.L()
-	oldLevel := mlog.GetAtomicLevel()
-	logger, props, err := mlog.InitLoggerWithWriteSyncer(&mlog.Config{
+	logs := mlog.CaptureGlobalLogs(s.T(), &mlog.Config{
 		Level:             "warn",
 		Format:            "text",
 		DisableCaller:     true,
 		DisableTimestamp:  true,
 		DisableStacktrace: true,
-	}, &logs)
-	s.NoError(err)
-	mlog.ReplaceGlobals(logger, props)
-	defer mlog.ReplaceGlobals(oldLogger, &mlog.ZapProperties{Level: oldLevel})
+	})
 
 	assertLogContains := func(substr string) {
 		s.True(strings.Contains(logs.String(), substr), logs.String())

--- a/internal/datacoord/snapshot_manager_test.go
+++ b/internal/datacoord/snapshot_manager_test.go
@@ -4393,19 +4393,13 @@ func TestSnapshotExportManager_Observability(t *testing.T) {
 	})
 
 	t.Run("failure log uses context and redacts reason", func(t *testing.T) {
-		var logs syncBuffer
-		oldLogger := mlog.L()
-		oldLevel := mlog.GetAtomicLevel()
-		logger, props, err := mlog.InitLoggerWithWriteSyncer(&mlog.Config{
+		logs := mlog.CaptureGlobalLogs(t, &mlog.Config{
 			Level:             "warn",
 			Format:            "text",
 			DisableCaller:     true,
 			DisableTimestamp:  true,
 			DisableStacktrace: true,
-		}, &logs)
-		require.NoError(t, err)
-		mlog.ReplaceGlobals(logger, props)
-		defer mlog.ReplaceGlobals(oldLogger, &mlog.ZapProperties{Level: oldLevel})
+		})
 
 		const secret = "SNAPSHOT_EXPORT_SECRET"
 		externalSpec := `{"extfs":{"access_key_value":"` + secret + `"}}`

--- a/internal/datanode/index/task_stats_test.go
+++ b/internal/datanode/index/task_stats_test.go
@@ -17,7 +17,6 @@
 package index
 
 import (
-	"bytes"
 	"context"
 	"strings"
 	"testing"
@@ -48,33 +47,16 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
-type statsTaskLogBuffer struct {
-	bytes.Buffer
-}
-
-func (*statsTaskLogBuffer) Sync() error {
-	return nil
-}
-
-func captureStatsTaskLogs(t *testing.T) *statsTaskLogBuffer {
+func captureStatsTaskLogs(t *testing.T) *mlog.TestSink {
 	t.Helper()
 
-	oldLogger := mlog.L()
-	oldLevel := mlog.GetAtomicLevel()
-	logs := &statsTaskLogBuffer{}
-	logger, props, err := mlog.InitLoggerWithWriteSyncer(&mlog.Config{
+	return mlog.CaptureGlobalLogs(t, &mlog.Config{
 		Level:             "debug",
 		Format:            "text",
 		DisableCaller:     true,
 		DisableTimestamp:  true,
 		DisableStacktrace: true,
-	}, logs)
-	require.NoError(t, err)
-	mlog.ReplaceGlobals(logger, props)
-	t.Cleanup(func() {
-		mlog.ReplaceGlobals(oldLogger, &mlog.ZapProperties{Level: oldLevel})
 	})
-	return logs
 }
 
 func statsLogSentinel(parts ...string) string {

--- a/internal/datanode/services_test.go
+++ b/internal/datanode/services_test.go
@@ -17,7 +17,6 @@
 package datanode
 
 import (
-	"bytes"
 	"context"
 	"math/rand"
 	"strings"
@@ -1683,33 +1682,16 @@ func (s *DataNodeServicesSuite) TestDropTaskCopySegment() {
 	})
 }
 
-type dataNodeLogBuffer struct {
-	bytes.Buffer
-}
-
-func (*dataNodeLogBuffer) Sync() error {
-	return nil
-}
-
-func captureDataNodeLogs(t *testing.T) *dataNodeLogBuffer {
+func captureDataNodeLogs(t *testing.T) *mlog.TestSink {
 	t.Helper()
 
-	oldLogger := mlog.L()
-	oldLevel := mlog.GetAtomicLevel()
-	logs := &dataNodeLogBuffer{}
-	logger, props, err := mlog.InitLoggerWithWriteSyncer(&mlog.Config{
+	return mlog.CaptureGlobalLogs(t, &mlog.Config{
 		Level:             "debug",
 		Format:            "text",
 		DisableCaller:     true,
 		DisableTimestamp:  true,
 		DisableStacktrace: true,
-	}, logs)
-	require.NoError(t, err)
-	mlog.ReplaceGlobals(logger, props)
-	t.Cleanup(func() {
-		mlog.ReplaceGlobals(oldLogger, &mlog.ZapProperties{Level: oldLevel})
 	})
-	return logs
 }
 
 type failingStorageFactory struct{}

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -85,33 +85,16 @@ func init() {
 	streaming.SetupNoopWALForTest()
 }
 
-type httpServerLogBuffer struct {
-	bytes.Buffer
-}
-
-func (*httpServerLogBuffer) Sync() error {
-	return nil
-}
-
-func captureHTTPServerLogs(t *testing.T) *httpServerLogBuffer {
+func captureHTTPServerLogs(t *testing.T) *mlog.TestSink {
 	t.Helper()
 
-	oldLogger := mlog.L()
-	oldLevel := mlog.GetAtomicLevel()
-	logs := &httpServerLogBuffer{}
-	logger, props, err := mlog.InitLoggerWithWriteSyncer(&mlog.Config{
+	return mlog.CaptureGlobalLogs(t, &mlog.Config{
 		Level:             "debug",
 		Format:            "text",
 		DisableCaller:     true,
 		DisableTimestamp:  true,
 		DisableStacktrace: true,
-	}, logs)
-	require.NoError(t, err)
-	mlog.ReplaceGlobals(logger, props)
-	t.Cleanup(func() {
-		mlog.ReplaceGlobals(oldLogger, &mlog.ZapProperties{Level: oldLevel})
 	})
-	return logs
 }
 
 func sendReqAndVerify(t *testing.T, testEngine *gin.Engine, testName, method string, testcase requestBodyTestCase) {

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -17,12 +17,10 @@
 package proxy
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -59,46 +57,16 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
-type proxyLogBuffer struct {
-	mu     sync.Mutex
-	buffer bytes.Buffer
-}
-
-func (b *proxyLogBuffer) Write(p []byte) (int, error) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.buffer.Write(p)
-}
-
-func (b *proxyLogBuffer) String() string {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.buffer.String()
-}
-
-func (*proxyLogBuffer) Sync() error {
-	return nil
-}
-
-func captureProxyLogs(t *testing.T) *proxyLogBuffer {
+func captureProxyLogs(t *testing.T) *mlog.TestSink {
 	t.Helper()
 
-	oldLogger := mlog.L()
-	oldLevel := mlog.GetAtomicLevel()
-	logs := &proxyLogBuffer{}
-	logger, props, err := mlog.InitLoggerWithWriteSyncer(&mlog.Config{
+	return mlog.CaptureGlobalLogs(t, &mlog.Config{
 		Level:             "debug",
 		Format:            "text",
 		DisableCaller:     true,
 		DisableTimestamp:  true,
 		DisableStacktrace: true,
-	}, logs)
-	require.NoError(t, err)
-	mlog.ReplaceGlobals(logger, props)
-	t.Cleanup(func() {
-		mlog.ReplaceGlobals(oldLogger, &mlog.ZapProperties{Level: oldLevel})
 	})
-	return logs
 }
 
 func TestSearchInfoDetermineSearchTypeWithPluralGroupByFieldIDs(t *testing.T) {

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -59,7 +60,20 @@ import (
 )
 
 type proxyLogBuffer struct {
-	bytes.Buffer
+	mu     sync.Mutex
+	buffer bytes.Buffer
+}
+
+func (b *proxyLogBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buffer.Write(p)
+}
+
+func (b *proxyLogBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buffer.String()
 }
 
 func (*proxyLogBuffer) Sync() error {

--- a/pkg/mlog/init_compat_test.go
+++ b/pkg/mlog/init_compat_test.go
@@ -19,10 +19,12 @@ func (m compatMessage) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 }
 
 func TestInitLoggerWithWriteSyncerReplacesMlogGlobalLogger(t *testing.T) {
-	var buf bytes.Buffer
+	// The sink is installed as the global logger, so it must be concurrency
+	// safe: use TestSink rather than a bare bytes.Buffer.
+	sink := NewTestSink()
 	cfg := &Config{Level: "debug", DisableTimestamp: true}
 
-	logger, props, err := InitLoggerWithWriteSyncer(cfg, zapcore.AddSync(&buf), zap.AddCallerSkip(1))
+	logger, props, err := InitLoggerWithWriteSyncer(cfg, sink, zap.AddCallerSkip(1))
 	require.NoError(t, err)
 	ReplaceGlobals(logger, props)
 	defer resetCompatLogger()
@@ -30,9 +32,9 @@ func TestInitLoggerWithWriteSyncerReplacesMlogGlobalLogger(t *testing.T) {
 	Info(context.Background(), "mlog initialized", String("key", "value"))
 	require.NoError(t, logger.Sync())
 
-	assert.Contains(t, buf.String(), `[INFO]`)
-	assert.Contains(t, buf.String(), `["mlog initialized"]`)
-	assert.Contains(t, buf.String(), `[key=value]`)
+	assert.Contains(t, sink.String(), `[INFO]`)
+	assert.Contains(t, sink.String(), `["mlog initialized"]`)
+	assert.Contains(t, sink.String(), `[key=value]`)
 	assert.Equal(t, DebugLevel, GetLevel())
 }
 

--- a/pkg/mlog/test_sink.go
+++ b/pkg/mlog/test_sink.go
@@ -1,0 +1,78 @@
+package mlog
+
+import (
+	"bytes"
+	"sync"
+)
+
+// TestSink is an in-memory zapcore.WriteSyncer for unit tests that assert on
+// log output.
+//
+// It has to serialize its own access because InitLoggerWithWriteSyncer does not
+// wrap the syncer in zapcore.Lock - textIOCore writes straight through to it.
+// A test that installs its sink as the global logger therefore shares that sink
+// with every background goroutine that logs, while the test itself reads the
+// captured bytes back. A bare bytes.Buffer is not safe for that, and the race
+// detector reports both write/write and read/write races on it.
+type TestSink struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+// NewTestSink returns an empty TestSink.
+func NewTestSink() *TestSink {
+	return &TestSink{}
+}
+
+// Write implements zapcore.WriteSyncer.
+func (s *TestSink) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+// Sync implements zapcore.WriteSyncer. The sink is in memory, so there is
+// nothing to flush.
+func (s *TestSink) Sync() error {
+	return nil
+}
+
+// String returns everything written to the sink so far. It is safe to call
+// while other goroutines are still logging.
+func (s *TestSink) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// TestingTB is the subset of *testing.T that CaptureGlobalLogs needs, declared
+// here so that mlog does not have to import "testing". It mirrors how
+// InitTestLogger takes a zaptest.TestingT.
+type TestingTB interface {
+	Helper()
+	Cleanup(func())
+	Fatalf(format string, args ...any)
+}
+
+// CaptureGlobalLogs installs a TestSink as the sink of the global logger and
+// restores the previous logger when the test finishes.
+//
+// Prefer this over a per-package log buffer: the returned sink is safe to read
+// while unrelated goroutines keep writing to the global logger.
+func CaptureGlobalLogs(t TestingTB, cfg *Config, opts ...Option) *TestSink {
+	t.Helper()
+
+	sink := NewTestSink()
+	oldLogger := L()
+	oldLevel := GetAtomicLevel()
+	logger, props, err := InitLoggerWithWriteSyncer(cfg, sink, opts...)
+	if err != nil {
+		t.Fatalf("mlog: init logger with test sink: %v", err)
+		return nil
+	}
+	ReplaceGlobals(logger, props)
+	t.Cleanup(func() {
+		ReplaceGlobals(oldLogger, &ZapProperties{Level: oldLevel})
+	})
+	return sink
+}

--- a/pkg/mlog/test_sink_test.go
+++ b/pkg/mlog/test_sink_test.go
@@ -1,0 +1,81 @@
+package mlog
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cleanupRecorder captures the cleanups CaptureGlobalLogs registers so that the
+// restore path can be asserted explicitly instead of only at test teardown.
+type cleanupRecorder struct {
+	*testing.T
+	cleanups []func()
+}
+
+func (r *cleanupRecorder) Cleanup(fn func()) {
+	r.cleanups = append(r.cleanups, fn)
+}
+
+func (r *cleanupRecorder) runCleanups() {
+	for i := len(r.cleanups) - 1; i >= 0; i-- {
+		r.cleanups[i]()
+	}
+	r.cleanups = nil
+}
+
+func TestCaptureGlobalLogsCapturesAndRestores(t *testing.T) {
+	before := L()
+	recorder := &cleanupRecorder{T: t}
+	t.Cleanup(recorder.runCleanups)
+
+	sink := CaptureGlobalLogs(recorder, &Config{Level: "debug", DisableTimestamp: true})
+	require.NotNil(t, sink)
+	require.NotSame(t, before, L())
+
+	Info(context.Background(), "captured by test sink", String("key", "value"))
+	assert.Contains(t, sink.String(), "captured by test sink")
+	assert.Contains(t, sink.String(), "key=value")
+
+	recorder.runCleanups()
+	assert.Same(t, before, L())
+}
+
+// TestCaptureGlobalLogsSinkIsConcurrencySafe is the regression test for the
+// race that a bare bytes.Buffer sink produces: the global logger is shared with
+// unrelated goroutines, so writes race with each other and with the test's own
+// reads. It only fails under -race, which is how CI runs the Go unit tests.
+func TestCaptureGlobalLogsSinkIsConcurrencySafe(t *testing.T) {
+	sink := CaptureGlobalLogs(t, &Config{Level: "debug", DisableTimestamp: true})
+
+	const (
+		writers          = 4
+		entriesPerWriter = 100
+		reads            = 200
+	)
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < entriesPerWriter; j++ {
+				Info(ctx, "concurrent background log entry")
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for j := 0; j < reads; j++ {
+			_ = sink.String()
+		}
+	}()
+	wg.Wait()
+
+	assert.Contains(t, sink.String(), "concurrent background log entry")
+}


### PR DESCRIPTION
## What changed

Tests that assert on log output install their own sink as the global mlog logger and then read the captured bytes back. `InitLoggerWithWriteSyncer` does not wrap the syncer in `zapcore.Lock` — `textIOCore` writes straight through to it — so the sink is shared with every background goroutine that logs while the test reads it. A bare `bytes.Buffer` is not safe for that, and `-race` reports both write/write and read/write races on it.

That helper had been copy-pasted five times, each with its own buffer type:

| Site | Type |
| --- | --- |
| `internal/proxy/util_test.go` | `proxyLogBuffer` |
| `internal/datacoord/compaction_policy_storage_version_test.go` | `syncBuffer` |
| `internal/datacoord/snapshot_manager_test.go` | `syncBuffer` |
| `internal/datanode/services_test.go` | `dataNodeLogBuffer` |
| `internal/datanode/index/task_stats_test.go` | `statsTaskLogBuffer` |
| `internal/distributed/proxy/httpserver/handler_v2_test.go` | `httpServerLogBuffer` |
| `pkg/mlog/init_compat_test.go` | `zapcore.AddSync(&bytes.Buffer{})` |

`scripts/run_go_unittest.sh` runs `proxy/...`, `distributed/proxy/...`, `datanode/...` and `datacoord/...` under `-race`, so all of these were reachable by CI, not only the proxy one.

So instead of guarding each copy, the sink moves into `pkg/mlog`:

- `mlog.TestSink` — a `zapcore.WriteSyncer` whose `Write` and `String` are guarded by the same mutex.
- `mlog.CaptureGlobalLogs(t, cfg, opts...)` — installs a `TestSink` as the global sink and restores the previous logger on `t.Cleanup`, replacing the duplicated install/restore boilerplate.

Every call site now uses it and the five per-package buffer types are deleted. This is a test-only change; production logging behaviour is unchanged, and `TestSink` sits next to the existing `InitTestLogger` test helper.

## Root cause

`TestPasswordVerifyDoesNotLogCredential` installs `proxyLogBuffer` as the global mlog sink. The target test and the background config refresher write logs concurrently while the test reads the same `bytes.Buffer` through `String`. Because `bytes.Buffer` is not safe for concurrent use, the race detector intermittently reports write/write and read/write races. The other five sinks have exactly the same shape.

## Reproduction

- Test: `TestPasswordVerifyDoesNotLogCredential`
- Before the fix: 3 race failures in 62 real test runs, reproduced locally with the required `dynamic,test` tags, disabled optimization/inlining, and the race detector.

## Verification

Verified:

- `pkg/mlog` full suite: `go test -race -tags dynamic,test -gcflags="all=-N -l" -count=20 ./mlog/` — pass.
- Negative control for the new regression test: with the mutex removed from `TestSink`, `TestCaptureGlobalLogsSinkIsConcurrencySafe` reports both `write/write` and `read/write` data races; with the mutex it passes. The test fails for the right reason rather than being self-consistent.
- `CaptureGlobalLogs` restores the previous global logger at the end of the individual test, including inside a testify suite method — checked with a purpose-built two-method suite where the second method observes the baseline logger again. The switch from `defer` to `t.Cleanup` is therefore behaviour-preserving.
- Both call shapes (`*testing.T` and `suite.T()`) type-check and run against the exported API from an external package.
- `gofmt` clean. Repo-wide sweep confirms no remaining references to the five deleted buffer types and no remaining bare-buffer log sink in any `_test.go`.
- `internal/http/server_test.go` and `internal/streamingnode/server/wal/metricsutil/wal_write_trace_test.go` also replace the global logger but are deliberately left alone: the former installs an empty syncer and never reads it back, the latter writes to a real file through lumberjack and reads the file.

Not verified locally, relying on CI:

- Compile and `-race` runs of `internal/proxy`, `internal/datacoord`, `internal/datanode`, `internal/datanode/index` and `internal/distributed/proxy/httpserver`. Those packages need a built `libmilvus_core`, which was not available in the environment this change was prepared in.
- `golangci-lint` could not run locally (the installed binary is built with go1.25 while a dependency requires go1.26). The change was hand-checked against the enabled linter set instead.
