### PR TITLE
fix: make SegcoreConfig members instance members

### DIFF
--- a/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
+++ b/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
@@ -68,10 +68,10 @@ RunFilter(const std::shared_ptr<Schema>& schema,
 // RAII guard so the global segcore flag is always restored, even on failure.
 struct GISSplitFusionGuard {
     explicit GISSplitFusionGuard(bool enable) {
-        SegcoreConfig::default_config().set_enable_gis_split_fusion(enable);
+        SegcoreConfig::mutable_default_config().set_enable_gis_split_fusion(enable);
     }
     ~GISSplitFusionGuard() {
-        SegcoreConfig::default_config().set_enable_gis_split_fusion(false);
+        SegcoreConfig::mutable_default_config().set_enable_gis_split_fusion(false);
     }
 };
 
@@ -106,10 +106,10 @@ struct GISGroupStateCapture {
 // (ChunkedSegmentSealedImpl::LoadFieldData).
 struct GeometryCacheGuard {
     explicit GeometryCacheGuard(bool enable) {
-        SegcoreConfig::default_config().set_enable_geometry_cache(enable);
+        SegcoreConfig::mutable_default_config().set_enable_geometry_cache(enable);
     }
     ~GeometryCacheGuard() {
-        SegcoreConfig::default_config().set_enable_geometry_cache(false);
+        SegcoreConfig::mutable_default_config().set_enable_geometry_cache(false);
     }
 };
 

--- a/internal/core/src/index/RTreeIndexTest.cpp
+++ b/internal/core/src/index/RTreeIndexTest.cpp
@@ -905,11 +905,11 @@ namespace {
 // flag into later tests).
 struct GisSplitFusionFlagGuard {
     explicit GisSplitFusionFlagGuard(bool enable) {
-        milvus::segcore::SegcoreConfig::default_config()
+        milvus::segcore::SegcoreConfig::mutable_default_config()
             .set_enable_gis_split_fusion(enable);
     }
     ~GisSplitFusionFlagGuard() {
-        milvus::segcore::SegcoreConfig::default_config()
+        milvus::segcore::SegcoreConfig::mutable_default_config()
             .set_enable_gis_split_fusion(false);
     }
 };

--- a/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
+++ b/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
@@ -638,7 +638,7 @@ AssertDirectGrowingFallbackUsesACompatibleSnapshot(bool iterator_v2) {
     auto pk_field = schema->AddDebugField("pk", DataType::INT64);
     schema->set_primary_field_id(pk_field);
 
-    auto& config = segcore::SegcoreConfig::default_config();
+    auto& config = segcore::SegcoreConfig::mutable_default_config();
     segcore::ScopedSegcoreConfigRestore config_restore(config);
     config.set_chunk_rows(64);
     config.set_enable_interim_segment_index(false);
@@ -799,7 +799,7 @@ AssertGrowingIndexEmptyBitsetHonorsPlannedPrefix(bool nullable) {
     IndexMetaPtr index_meta =
         std::make_shared<CollectionIndexMeta>(100, std::move(field_map));
 
-    auto& config = segcore::SegcoreConfig::default_config();
+    auto& config = segcore::SegcoreConfig::mutable_default_config();
     segcore::ScopedSegcoreConfigRestore config_restore(config);
     segcore::InterimIndexConfigForTest interim_config;
     interim_config.chunk_rows = 64;

--- a/internal/core/src/segcore/ChunkedSegmentSealedBinlogIndexTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedBinlogIndexTest.cpp
@@ -772,7 +772,7 @@ TEST(test_chunk_segment,
     ASSERT_NO_THROW(segment->LoadIndex(load_info));
     ASSERT_TRUE(segment->HasIndex(vec_field_id));
 
-    auto& segcore_config = milvus::segcore::SegcoreConfig::default_config();
+    auto& segcore_config = milvus::segcore::SegcoreConfig::mutable_default_config();
     auto previous_prefer_field_data =
         segcore_config.get_prefer_field_data_when_index_has_raw_data();
     struct PreferFieldDataGuard {
@@ -830,7 +830,7 @@ TEST_P(BinlogIndexTest, AccuracyWithLoadFieldData) {
     LoadOtherFields();
 
     ApplyBinlogInterimIndexConfigForTest();
-    auto& segcore_config = milvus::segcore::SegcoreConfig::default_config();
+    auto& segcore_config = milvus::segcore::SegcoreConfig::mutable_default_config();
     // 1. load field data, and build binlog index for binlog data
     LoadVectorField();
 
@@ -1106,7 +1106,7 @@ TEST_P(BinlogIndexTest, AccuracyWithMapFieldData) {
     LoadOtherFields();
 
     ApplyBinlogInterimIndexConfigForTest();
-    auto& segcore_config = milvus::segcore::SegcoreConfig::default_config();
+    auto& segcore_config = milvus::segcore::SegcoreConfig::mutable_default_config();
     // 1. load field data, and build binlog index for binlog data
     LoadVectorField("./data/mmap-test");
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
@@ -105,12 +105,12 @@ class ScopedRejectRemoteVectorOutput {
     explicit ScopedRejectRemoteVectorOutput(bool enabled)
         : old_value_(segcore::SegcoreConfig::default_config()
                          .get_reject_remote_vector_output()) {
-        segcore::SegcoreConfig::default_config()
+        segcore::SegcoreConfig::mutable_default_config()
             .set_reject_remote_vector_output(enabled);
     }
 
     ~ScopedRejectRemoteVectorOutput() {
-        segcore::SegcoreConfig::default_config()
+        segcore::SegcoreConfig::mutable_default_config()
             .set_reject_remote_vector_output(old_value_);
     }
 

--- a/internal/core/src/segcore/SegcoreConfig.h
+++ b/internal/core/src/segcore/SegcoreConfig.h
@@ -22,8 +22,20 @@ namespace milvus::segcore {
 
 class SegcoreConfig {
  public:
-    static SegcoreConfig&
+    // Process-wide configuration. Read-only on purpose: every member below used
+    // to be `inline static`, which made `SegcoreConfig cfg; cfg.set_x(...)` on a
+    // *local* object silently write process-global state. Returning a const
+    // reference here turns every "I meant to change the global" site into a
+    // compile error, so the intent has to be spelled out.
+    static const SegcoreConfig&
     default_config() {
+        return mutable_default_config();
+    }
+
+    // The process-wide instance, writable. Only the init-time C API
+    // (segcore_init_c.cpp, driven once from InitQueryNode) should use this.
+    static SegcoreConfig&
+    mutable_default_config() {
         // TODO: remove this when go side is ready
         static SegcoreConfig config;
         return config;
@@ -247,33 +259,34 @@ class SegcoreConfig {
     }
 
  private:
+    // Read-only constant, no leak risk: keep it shared across instances.
     inline static const std::unordered_set<std::string>
         valid_dense_vector_index_type = {
             knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC,
             knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR,
     };
-    inline static bool storage_v3_enabled_ = false;
-    inline static bool enable_interim_segment_index_ = false;
-    inline static bool enable_growing_source_flush_ = false;
-    inline static int64_t chunk_rows_ = 32 * 1024;
-    inline static int64_t nlist_ = 100;
-    inline static int64_t nprobe_ = 4;
-    inline static int64_t sub_dim_ = 2;
-    inline static float refine_ratio_ = 3.0;
-    inline static float build_ratio_ = 0.1;
+    bool storage_v3_enabled_ = false;
+    bool enable_interim_segment_index_ = false;
+    bool enable_growing_source_flush_ = false;
+    int64_t chunk_rows_ = 32 * 1024;
+    int64_t nlist_ = 100;
+    int64_t nprobe_ = 4;
+    int64_t sub_dim_ = 2;
+    float refine_ratio_ = 3.0;
+    float build_ratio_ = 0.1;
     // FM-index guard threshold; overridden from queryNode.fmindexCostRatio.
-    inline static float fmindex_cost_ratio_ = 0.001f;
-    inline static std::string dense_index_type_ =
+    float fmindex_cost_ratio_ = 0.001f;
+    std::string dense_index_type_ =
         knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC;
-    inline static knowhere::RefineType refine_type_ =
+    knowhere::RefineType refine_type_ =
         knowhere::RefineType::DATA_VIEW;
-    inline static bool refine_with_quant_flag_ = false;
-    inline static bool enable_geometry_cache_ = false;
-    inline static bool enable_gis_split_fusion_ = false;
-    inline static bool prefer_field_data_when_index_has_raw_data_ = false;
-    inline static bool reject_remote_vector_output_ = false;
-    inline static float interim_index_mem_expansion_rate_ = 1.15f;
-    inline static int64_t max_group_by_groups_ = kDefaultMaxGroupByGroups;
+    bool refine_with_quant_flag_ = false;
+    bool enable_geometry_cache_ = false;
+    bool enable_gis_split_fusion_ = false;
+    bool prefer_field_data_when_index_has_raw_data_ = false;
+    bool reject_remote_vector_output_ = false;
+    float interim_index_mem_expansion_rate_ = 1.15f;
+    int64_t max_group_by_groups_ = kDefaultMaxGroupByGroups;
 };
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/SegmentChunkReaderTest.cpp
+++ b/internal/core/src/segcore/SegmentChunkReaderTest.cpp
@@ -118,7 +118,7 @@ TEST(SegmentChunkReader, GrowingConjunctSkipKeepsNextBatchCorrect) {
     EXEC_EVAL_EXPR_BATCH_SIZE.store(kBatch);
 
     ScopedSegcoreConfigRestore config_restore;
-    auto& config = SegcoreConfig::default_config();
+    auto& config = SegcoreConfig::mutable_default_config();
     config.set_chunk_rows(kChunkRows);
 
     auto schema = std::make_shared<Schema>();

--- a/internal/core/src/segcore/SegmentGrowingIndexTest.cpp
+++ b/internal/core/src/segcore/SegmentGrowingIndexTest.cpp
@@ -205,7 +205,7 @@ TEST_P(GrowingIndexTest, Correctness) {
         {"dim", std::to_string(dim)}};
     FieldIndexMeta fieldIndexMeta(
         vec, std::move(index_params), std::move(type_params));
-    auto& config = SegcoreConfig::default_config();
+    auto& config = SegcoreConfig::mutable_default_config();
     ScopedSegcoreConfigRestore config_restore(config);
     InterimIndexConfigForTest interim_config;
     interim_config.chunk_rows = 1024;
@@ -464,7 +464,7 @@ class GrowingIndexRawOwnershipTest : public ::testing::Test {
     static constexpr int64_t dim = 4;
     static constexpr int64_t row_count = 100;
 
-    SegcoreConfig& config_ = SegcoreConfig::default_config();
+    SegcoreConfig& config_ = SegcoreConfig::mutable_default_config();
     ScopedSegcoreConfigRestore config_restore_{config_};
     SchemaPtr schema_;
     FieldId pk_;
@@ -661,7 +661,7 @@ TEST(GrowingIndexNullableVectorTest,
     FieldIndexMeta field_index_meta(
         vec, std::move(index_params), std::move(type_params));
 
-    auto& config = SegcoreConfig::default_config();
+    auto& config = SegcoreConfig::mutable_default_config();
     ScopedSegcoreConfigRestore config_restore(config);
     InterimIndexConfigForTest interim_config;
     interim_config.chunk_rows = 1024;
@@ -749,7 +749,7 @@ TEST(GrowingIndexNullableVectorTest,
 }
 
 TEST_P(GrowingIndexTest, MissIndexMeta) {
-    auto& config = SegcoreConfig::default_config();
+    auto& config = SegcoreConfig::mutable_default_config();
     ScopedSegcoreConfigRestore config_restore(config);
 
     auto dim = 4;
@@ -765,7 +765,7 @@ TEST_P(GrowingIndexTest, MissIndexMeta) {
 }
 
 TEST_P(GrowingIndexTest, GetVector) {
-    auto& config = SegcoreConfig::default_config();
+    auto& config = SegcoreConfig::mutable_default_config();
     ScopedSegcoreConfigRestore config_restore(config);
 
     auto dim = 4;

--- a/internal/core/src/segcore/SegmentGrowingTest.cpp
+++ b/internal/core/src/segcore/SegmentGrowingTest.cpp
@@ -1995,7 +1995,7 @@ TEST(Growing, NullableVectorInsertBuildsMonotonicOffsetMapping) {
     IndexMetaPtr index_meta =
         std::make_shared<CollectionIndexMeta>(total_rows, std::move(field_map));
 
-    auto& config = SegcoreConfig::default_config();
+    auto& config = SegcoreConfig::mutable_default_config();
     ScopedSegcoreConfigRestore config_restore(config);
     config.set_chunk_rows(16);
     config.set_nlist(1);
@@ -2105,7 +2105,7 @@ TEST(Growing, ChunkReclamationKeepsSharedStorageAlive) {
     IndexMetaPtr index_meta =
         std::make_shared<CollectionIndexMeta>(max_rows, std::move(field_map));
 
-    auto& config = SegcoreConfig::default_config();
+    auto& config = SegcoreConfig::mutable_default_config();
     ScopedSegcoreConfigRestore config_restore(config);
     config.set_chunk_rows(16);
     config.set_nlist(1);

--- a/internal/core/src/segcore/flush_growing_segment_test.cpp
+++ b/internal/core/src/segcore/flush_growing_segment_test.cpp
@@ -1727,7 +1727,7 @@ TEST_F(FlushGrowingSegmentTest, FlushFloatVectorFromIndexAfterChunksCleared) {
     constexpr int64_t start = 13;
     constexpr int64_t end = 87;
 
-    auto& config = SegcoreConfig::default_config();
+    auto& config = SegcoreConfig::mutable_default_config();
     ScopedSegcoreConfigRestore config_restore(config);
     InterimIndexConfigForTest interim_config;
     interim_config.chunk_rows = 16;
@@ -1806,7 +1806,7 @@ TEST_F(FlushGrowingSegmentTest,
     constexpr int64_t start = 13;
     constexpr int64_t end = 87;
 
-    auto& config = SegcoreConfig::default_config();
+    auto& config = SegcoreConfig::mutable_default_config();
     ScopedSegcoreConfigRestore config_restore(config);
     InterimIndexConfigForTest interim_config;
     interim_config.chunk_rows = 16;
@@ -1914,7 +1914,7 @@ TEST_F(FlushGrowingSegmentTest,
     constexpr int64_t start = 5;
     constexpr int64_t end = 25;
 
-    auto& config = SegcoreConfig::default_config();
+    auto& config = SegcoreConfig::mutable_default_config();
     ScopedSegcoreConfigRestore config_restore(config);
     InterimIndexConfigForTest interim_config;
     interim_config.chunk_rows = 16;

--- a/internal/core/src/segcore/search_result_export_c_test.cpp
+++ b/internal/core/src/segcore/search_result_export_c_test.cpp
@@ -37,6 +37,7 @@
 #include "segcore/reduce/Reduce.h"
 #include "segcore/search_result_export_c.h"
 #include "test_utils/DataGen.h"
+#include "test_utils/SegcoreConfigUtils.h"
 #include "test_utils/storage_test_utils.h"
 
 using milvus::DataType;
@@ -1765,6 +1766,7 @@ TEST(SearchResultExport, GlobalRefine_SkipsDisabledSegmentsDuringRefine) {
 TEST(SearchResultExport, GlobalRefine_EndToEnd_ForcedSealedRefine) {
     using milvus::segcore::DataGen;
     using milvus::segcore::ScopedSchemaHandle;
+    using milvus::segcore::ScopedSegcoreConfigRestore;
     using milvus::segcore::SegcoreConfig;
 
     // --- 1. Schema: int64 PK + 16-dim float vector (L2). ---
@@ -1792,7 +1794,12 @@ TEST(SearchResultExport, GlobalRefine_EndToEnd_ForcedSealedRefine) {
     auto collection_index_meta = std::make_shared<milvus::CollectionIndexMeta>(
         /*max_index_row_cnt=*/226985, std::move(field_map));
 
-    auto& segcore_config = SegcoreConfig::default_config();
+    // These three settings are process-wide. Without the guard they stay in
+    // effect for every later test in the same all_tests process - in
+    // particular enable_interim_segment_index, which changes how later tests
+    // build their indexes.
+    ScopedSegcoreConfigRestore config_restore;
+    auto& segcore_config = SegcoreConfig::mutable_default_config();
     segcore_config.set_enable_interim_segment_index(true);
     segcore_config.set_nlist(16);
     segcore_config.set_chunk_rows(1024);

--- a/internal/core/src/segcore/segcore_init_c.cpp
+++ b/internal/core/src/segcore/segcore_init_c.cpp
@@ -40,42 +40,42 @@ SegcoreInit(const char* conf_file) {
 extern "C" void
 SegcoreSetChunkRows(const int64_t value) {
     milvus::segcore::SegcoreConfig& config =
-        milvus::segcore::SegcoreConfig::default_config();
+        milvus::segcore::SegcoreConfig::mutable_default_config();
     config.set_chunk_rows(value);
 }
 
 extern "C" void
 SegcoreSetEnableInterminSegmentIndex(const bool value) {
     milvus::segcore::SegcoreConfig& config =
-        milvus::segcore::SegcoreConfig::default_config();
+        milvus::segcore::SegcoreConfig::mutable_default_config();
     config.set_enable_interim_segment_index(value);
 }
 
 extern "C" void
 SegcoreSetStorageV3Enabled(const bool value) {
     milvus::segcore::SegcoreConfig& config =
-        milvus::segcore::SegcoreConfig::default_config();
+        milvus::segcore::SegcoreConfig::mutable_default_config();
     config.set_storage_v3_enabled(value);
 }
 
 extern "C" void
 SegcoreSetEnableGrowingSourceFlush(const bool value) {
     milvus::segcore::SegcoreConfig& config =
-        milvus::segcore::SegcoreConfig::default_config();
+        milvus::segcore::SegcoreConfig::mutable_default_config();
     config.set_enable_growing_source_flush(value);
 }
 
 extern "C" void
 SegcoreSetEnableGeometryCache(const bool value) {
     milvus::segcore::SegcoreConfig& config =
-        milvus::segcore::SegcoreConfig::default_config();
+        milvus::segcore::SegcoreConfig::mutable_default_config();
     config.set_enable_geometry_cache(value);
 }
 
 extern "C" void
 SegcoreSetEnableGISSplitFusion(const bool value) {
     milvus::segcore::SegcoreConfig& config =
-        milvus::segcore::SegcoreConfig::default_config();
+        milvus::segcore::SegcoreConfig::mutable_default_config();
     config.set_enable_gis_split_fusion(value);
 }
 
@@ -91,35 +91,35 @@ SegcoreSetVisibilityFilterEnabled(const bool value) {
 extern "C" void
 SegcoreSetPreferFieldDataWhenIndexHasRawData(const bool value) {
     milvus::segcore::SegcoreConfig& config =
-        milvus::segcore::SegcoreConfig::default_config();
+        milvus::segcore::SegcoreConfig::mutable_default_config();
     config.set_prefer_field_data_when_index_has_raw_data(value);
 }
 
 extern "C" void
 SegcoreSetNlist(const int64_t value) {
     milvus::segcore::SegcoreConfig& config =
-        milvus::segcore::SegcoreConfig::default_config();
+        milvus::segcore::SegcoreConfig::mutable_default_config();
     config.set_nlist(value);
 }
 
 extern "C" void
 SegcoreSetFMIndexCostRatio(const float value) {
     milvus::segcore::SegcoreConfig& config =
-        milvus::segcore::SegcoreConfig::default_config();
+        milvus::segcore::SegcoreConfig::mutable_default_config();
     config.set_fmindex_cost_ratio(value);
 }
 
 extern "C" void
 SegcoreSetNprobe(const int64_t value) {
     milvus::segcore::SegcoreConfig& config =
-        milvus::segcore::SegcoreConfig::default_config();
+        milvus::segcore::SegcoreConfig::mutable_default_config();
     config.set_nprobe(value);
 }
 
 extern "C" CStatus
 SegcoreSetDenseVectorInterminIndexType(const char* value) {
     milvus::segcore::SegcoreConfig& config =
-        milvus::segcore::SegcoreConfig::default_config();
+        milvus::segcore::SegcoreConfig::mutable_default_config();
     try {
         config.set_dense_vector_intermin_index_type(std::string(value));
         auto status = CStatus();
@@ -134,7 +134,7 @@ SegcoreSetDenseVectorInterminIndexType(const char* value) {
 extern "C" CStatus
 SegcoreSetDenseVectorInterminIndexRefineQuantType(const char* value) {
     milvus::segcore::SegcoreConfig& config =
-        milvus::segcore::SegcoreConfig::default_config();
+        milvus::segcore::SegcoreConfig::mutable_default_config();
     try {
         config.set_refine_quant_type(std::string(value));
         auto status = CStatus();
@@ -149,42 +149,42 @@ SegcoreSetDenseVectorInterminIndexRefineQuantType(const char* value) {
 extern "C" void
 SegcoreSetDenseVectorInterminIndexRefineWithQuantFlag(const bool value) {
     milvus::segcore::SegcoreConfig& config =
-        milvus::segcore::SegcoreConfig::default_config();
+        milvus::segcore::SegcoreConfig::mutable_default_config();
     config.set_refine_with_quant_flag(value);
 }
 
 extern "C" void
 SegcoreSetInterimIndexMemExpansionRate(const float value) {
     milvus::segcore::SegcoreConfig& config =
-        milvus::segcore::SegcoreConfig::default_config();
+        milvus::segcore::SegcoreConfig::mutable_default_config();
     config.set_interim_index_mem_expansion_rate(value);
 }
 
 extern "C" void
 SegcoreSetMaxGroupByGroups(const int64_t value) {
     milvus::segcore::SegcoreConfig& config =
-        milvus::segcore::SegcoreConfig::default_config();
+        milvus::segcore::SegcoreConfig::mutable_default_config();
     config.set_max_group_by_groups(value);
 }
 
 extern "C" void
 SegcoreSetSubDim(const int64_t value) {
     milvus::segcore::SegcoreConfig& config =
-        milvus::segcore::SegcoreConfig::default_config();
+        milvus::segcore::SegcoreConfig::mutable_default_config();
     config.set_sub_dim(value);
 }
 
 extern "C" void
 SegcoreSetRefineRatio(const float value) {
     milvus::segcore::SegcoreConfig& config =
-        milvus::segcore::SegcoreConfig::default_config();
+        milvus::segcore::SegcoreConfig::mutable_default_config();
     config.set_refine_ratio(value);
 }
 
 extern "C" void
 SegcoreSetIndexBuildRatio(const float value) {
     milvus::segcore::SegcoreConfig& config =
-        milvus::segcore::SegcoreConfig::default_config();
+        milvus::segcore::SegcoreConfig::mutable_default_config();
     config.set_build_ratio(value);
 }
 
@@ -314,7 +314,7 @@ ConfigureTieredStorage(const CacheWarmupPolicy scalarFieldCacheWarmupPolicy,
         std::chrono::milliseconds(loading_timeout_ms),
         std::chrono::milliseconds(warmup_loading_timeout_ms),
         prefetch_pool_threads);
-    milvus::segcore::SegcoreConfig::default_config()
+    milvus::segcore::SegcoreConfig::mutable_default_config()
         .set_reject_remote_vector_output(reject_remote_vector_output);
 }
 
@@ -336,7 +336,7 @@ UpdateTieredStorageConfig(
          vectorFieldCacheWarmupPolicy,
          scalarIndexCacheWarmupPolicy,
          vectorIndexCacheWarmupPolicy});
-    milvus::segcore::SegcoreConfig::default_config()
+    milvus::segcore::SegcoreConfig::mutable_default_config()
         .set_reject_remote_vector_output(reject_remote_vector_output);
 }
 

--- a/internal/core/src/segcore/segment_c_test.cpp
+++ b/internal/core/src/segcore/segment_c_test.cpp
@@ -1871,7 +1871,7 @@ TEST(
     plan->plan_node_->plannodes_ = CreateRetrievePlanByExpr(term_expr);
     plan->field_ids_ = {i32_fid};
 
-    auto& segcore_config = milvus::segcore::SegcoreConfig::default_config();
+    auto& segcore_config = milvus::segcore::SegcoreConfig::mutable_default_config();
     auto previous_prefer_field_data =
         segcore_config.get_prefer_field_data_when_index_has_raw_data();
     segcore_config.set_prefer_field_data_when_index_has_raw_data(true);

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -57,12 +57,12 @@ class ScopedRejectRemoteVectorOutput {
     explicit ScopedRejectRemoteVectorOutput(bool enabled)
         : old_value_(SegcoreConfig::default_config()
                          .get_reject_remote_vector_output()) {
-        SegcoreConfig::default_config().set_reject_remote_vector_output(
+        SegcoreConfig::mutable_default_config().set_reject_remote_vector_output(
             enabled);
     }
 
     ~ScopedRejectRemoteVectorOutput() {
-        SegcoreConfig::default_config().set_reject_remote_vector_output(
+        SegcoreConfig::mutable_default_config().set_reject_remote_vector_output(
             old_value_);
     }
 

--- a/internal/core/unittest/test_utils/SegcoreConfigUtils.h
+++ b/internal/core/unittest/test_utils/SegcoreConfigUtils.h
@@ -39,7 +39,7 @@ RefineTypeToConfigStringForTest(knowhere::RefineType refine_type) {
 class ScopedSegcoreConfigRestore {
  public:
     explicit ScopedSegcoreConfigRestore(
-        SegcoreConfig& config = SegcoreConfig::default_config())
+        SegcoreConfig& config = SegcoreConfig::mutable_default_config())
         : config_(config),
           chunk_rows_(config.get_chunk_rows()),
           nlist_(config.get_nlist()),
@@ -107,7 +107,7 @@ struct InterimIndexConfigForTest {
 inline void
 ApplyInterimIndexConfigForTest(
     const InterimIndexConfigForTest& options,
-    SegcoreConfig& config = SegcoreConfig::default_config()) {
+    SegcoreConfig& config = SegcoreConfig::mutable_default_config()) {
     config.set_chunk_rows(options.chunk_rows);
     config.set_enable_interim_segment_index(
         options.enable_interim_segment_index);


### PR DESCRIPTION
issue: #52511

### What

Every member of `SegcoreConfig` was declared `inline static`, so the class looked like a value
type but was not one — calling a setter on a *local* instance wrote process-global state:

```cpp
SegcoreConfig segcore_config;        // looks local
segcore_config.set_chunk_rows(1);    // writes the process-global value
```

This PR makes the 23 configuration members real instance members, so a local `SegcoreConfig` is
genuinely local and cannot leak.

To keep the "I really do mean the process-wide one" sites explicit, the accessor is split:

- `default_config()` now returns `const SegcoreConfig&`
- `mutable_default_config()` returns the writable process-wide instance

Any site that used to mutate the global through `default_config()` is now a **compile error**
until it says `mutable_default_config()`. That is why the test files below are touched: they
intentionally configure the process-wide instance, and now have to say so.

`valid_dense_vector_index_type` stays `inline static const` — it is a read-only constant with no
leak risk.

### Why it matters

`FlushGrowingSegmentTest.FlushNullableEmbListMixedRows` sets `chunk_rows` to `1` through a local
`SegcoreConfig` and never restores it, so the value stayed at `1` for the rest of the `all_tests`
process and every growing segment created afterwards allocated one chunk per row.

The test itself keeps passing, so CI stays green — only the wall time of *later* tests grows.
Measured with `Query.InnerProduct` (inserts 100k rows into a growing segment), same binary, same
machine, only the preceding filter differs:

| Platform | alone | after the polluting test | slowdown |
| --- | --- | --- | --- |
| x86_64 (Ryzen 9 7945HX) | 113 ms | 2326 ms | 20.6x |
| aarch64 (DGX GB10) | 52 ms | 28900 ms | 555x |

In a 430-test / 47-suite run selected by a change-based filter, `Query.InnerProduct` and
`Query.ExecTerm` together took **57.7 s of the 221 s** the whole gtest stage needed — 26 % of the
stage for two tests that need ~100 ms in isolation.

### Scope

Production code affected: **only `segcore_init_c.cpp`**, the init-time C API driven once from
`InitQueryNode`. Its 20 call sites now use `mutable_default_config()`, so process-wide behaviour
is unchanged. The remaining 13 files are tests that configure the global on purpose.

### Verification

Built and run locally (x86_64, Release):

- `Query.InnerProduct` after the polluting test: **2326 ms -> 100 ms** (95 ms when run alone),
  **with no guard added to the test** — the type change alone removes the pollution
- `FlushNullableEmbListMixedRows` itself still passes
- full `all_tests`: no new failures

### Note on the previous revision of this PR

This PR originally added a one-line `ScopedSegcoreConfigRestore` to the single call site that
happened to be noticed. That fixed the symptom at one place and left the trap in the type. A scan
of the whole C++ test tree found the same "local instance, global effect" shape elsewhere, so the
fix moved to the type itself.

### One more leak found while auditing

Splitting the accessor made every process-global write greppable, and one more test turned up:
`SearchResultExport.GlobalRefine_EndToEnd_ForcedSealedRefine`
(`search_result_export_c_test.cpp:1766`) sets `enable_interim_segment_index`, `nlist` and
`chunk_rows` and never restores them.

That one is a *deliberate* global write rather than the accidental "local instance" form fixed
above, so the type change does not help it — it needs the guard the rest of the tree already uses.
It is included here because it is the same defect class as #52511. Unlike the original, it has no
measurable effect on later test durations (`chunk_rows` 32768 -> 1024 is a 32x change, not the
32768x of `chunk_rows = 1`); the problem is that `enable_interim_segment_index = true` stays on for
every later test in the process.
