### PR TITLE
fix: [hotfix-2.6.21] encrypt every V3 packed index slice with the DEK whose EDEK is persisted

### DIFF
--- a/internal/core/src/storage/IndexEntryEncryptedLocalWriter.cpp
+++ b/internal/core/src/storage/IndexEntryEncryptedLocalWriter.cpp
@@ -52,6 +52,8 @@ IndexEntryEncryptedLocalWriter::IndexEntryEncryptedLocalWriter(
       pool_(ThreadPools::GetThreadPool(ThreadPoolPriority::MIDDLE)) {
     auto [encryptor, edek] =
         cipher_plugin_->GetEncryptor(ez_id_, collection_id_);
+    AssertInfo(encryptor != nullptr, "cipher plugin returned a null encryptor");
+    encryptor_ = std::move(encryptor);
     edek_ = std::move(edek);
 
     auto uuid = boost::uuids::random_generator()();
@@ -129,9 +131,7 @@ IndexEntryEncryptedLocalWriter::WriteEntry(const std::string& name,
             crc = Crc32cUpdate(
                 crc, reinterpret_cast<const uint8_t*>(slice_data.data()), len);
             pending.push_back(pool_.Submit([this, s = std::move(slice_data)]() {
-                auto [enc, unused_edek] =
-                    cipher_plugin_->GetEncryptor(ez_id_, collection_id_);
-                return enc->Encrypt(s);
+                return encryptor_->Encrypt(s);
             }));
             remaining -= len;
         }
@@ -171,9 +171,7 @@ IndexEntryEncryptedLocalWriter::EncryptAndWriteSlices(const std::string& name,
             auto slice_data = std::string(
                 reinterpret_cast<const char*>(data + read_offset), len);
             pending.push_back(pool_.Submit([this, s = std::move(slice_data)]() {
-                auto [enc, unused_edek] =
-                    cipher_plugin_->GetEncryptor(ez_id_, collection_id_);
-                return enc->Encrypt(s);
+                return encryptor_->Encrypt(s);
             }));
             read_offset += len;
             remaining -= len;

--- a/internal/core/src/storage/IndexEntryEncryptedLocalWriter.h
+++ b/internal/core/src/storage/IndexEntryEncryptedLocalWriter.h
@@ -68,6 +68,11 @@ class IndexEntryEncryptedLocalWriter : public IndexEntryWriter {
     std::shared_ptr<plugin::ICipherPlugin> cipher_plugin_;
     int64_t ez_id_;
     int64_t collection_id_;
+    // The DEK that produced edek_. Every slice of this file must be encrypted
+    // with it: the plugin mints a fresh DEK on each GetEncryptor() call, and
+    // only edek_ is persisted in the directory table, so a per-slice encryptor
+    // would leave the data undecryptable.
+    std::shared_ptr<plugin::IEncryptor> encryptor_;
     std::string edek_;
     size_t slice_size_;
 

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -66,6 +66,9 @@ ExpectedEntryStreamBudgetBytes(double ratio) {
     return std::max(capacity, slice_size);
 }
 
+constexpr size_t kMockTagSize = 4;
+constexpr char kMockTag[kMockTagSize] = {'M', 'O', 'C', 'K'};
+
 // Simple XOR-based mock cipher for testing (NOT for production use!)
 class MockEncryptor : public plugin::IEncryptor {
  public:
@@ -84,10 +87,15 @@ class MockEncryptor : public plugin::IEncryptor {
 
     std::string
     Encrypt(const void* data, size_t len) const override {
-        // Format: [1-byte key][XOR'd data]
+        // Mimics an AEAD: a fixed tag is encrypted together with the payload so
+        // that decrypting with the wrong key fails loudly instead of returning
+        // garbage. The ciphertext must NOT carry its own key - the DEK can only
+        // come from the EDEK persisted next to the data.
         std::string result;
-        result.reserve(1 + len);
-        result.push_back(static_cast<char>(key_));
+        result.reserve(kMockTagSize + len);
+        for (size_t i = 0; i < kMockTagSize; i++) {
+            result.push_back(static_cast<char>(kMockTag[i] ^ key_));
+        }
         const auto* src = static_cast<const uint8_t*>(data);
         for (size_t i = 0; i < len; i++) {
             result.push_back(static_cast<char>(src[i] ^ key_));
@@ -106,6 +114,9 @@ class MockEncryptor : public plugin::IEncryptor {
 
 class MockDecryptor : public plugin::IDecryptor {
  public:
+    explicit MockDecryptor(uint8_t key) : key_(key) {
+    }
+
     std::string
     Decrypt(const std::string& ciphertext) const override {
         return Decrypt(ciphertext.data(), ciphertext.size());
@@ -118,23 +129,33 @@ class MockDecryptor : public plugin::IDecryptor {
 
     std::string
     Decrypt(const void* data, size_t len) const override {
-        if (len < 1) {
-            return "";
+        if (len < kMockTagSize) {
+            throw std::runtime_error("Decryption failed: ciphertext too short");
         }
         const auto* src = static_cast<const uint8_t*>(data);
-        uint8_t key = src[0];
+        for (size_t i = 0; i < kMockTagSize; i++) {
+            if (static_cast<uint8_t>(src[i] ^ key_) !=
+                static_cast<uint8_t>(kMockTag[i])) {
+                // Same failure mode as a real AEAD fed the wrong DEK.
+                throw std::runtime_error(
+                    "Decryption failed: mock authentication tag mismatch");
+            }
+        }
         std::string result;
-        result.reserve(len - 1);
-        for (size_t i = 1; i < len; i++) {
-            result.push_back(static_cast<char>(src[i] ^ key));
+        result.reserve(len - kMockTagSize);
+        for (size_t i = kMockTagSize; i < len; i++) {
+            result.push_back(static_cast<char>(src[i] ^ key_));
         }
         return result;
     }
 
     std::string
     GetKey() const override {
-        return "";
+        return std::string(1, static_cast<char>(key_));
     }
+
+ private:
+    uint8_t key_;
 };
 
 class MockCipherPlugin : public plugin::ICipherPlugin {
@@ -148,15 +169,28 @@ class MockCipherPlugin : public plugin::ICipherPlugin {
     Update(int64_t, int64_t, const std::string&) override {
     }
 
+    // Mint a fresh DEK on every call, exactly like the production cipher
+    // plugin does. Whoever encrypts must persist the matching EDEK, otherwise
+    // the data can never be decrypted again.
     std::pair<std::shared_ptr<plugin::IEncryptor>, std::string>
     GetEncryptor(int64_t, int64_t) const override {
-        return {std::make_shared<MockEncryptor>(0x5A), "mock_edek"};
+        // 1..255, never 0: a zero XOR key would turn encryption into a no-op.
+        auto key = static_cast<uint8_t>(1 + next_key_.fetch_add(1) % 255);
+        return {std::make_shared<MockEncryptor>(key),
+                std::string(1, static_cast<char>(key))};
     }
 
     std::shared_ptr<plugin::IDecryptor>
-    GetDecryptor(int64_t, int64_t, const std::string&) const override {
-        return std::make_shared<MockDecryptor>();
+    GetDecryptor(int64_t, int64_t, const std::string& edek) const override {
+        if (edek.size() != 1) {
+            throw std::runtime_error(
+                "Get decryptor failed: mock edek must carry exactly one key");
+        }
+        return std::make_shared<MockDecryptor>(static_cast<uint8_t>(edek[0]));
     }
+
+ private:
+    mutable std::atomic<uint32_t> next_key_{0};
 };
 
 class DelayedFailingInputStream : public milvus::InputStream {
@@ -895,6 +929,30 @@ class IndexEntryEncryptedV3Test : public IndexEntryWriterV3Test {
     SetUp() override {
         IndexEntryWriterV3Test::SetUp();
         mock_cipher_ = std::make_shared<MockCipherPlugin>();
+        // The read path resolves the cipher plugin through the loader
+        // singleton, so the same mock must be visible there.
+        PluginLoader::GetInstance().registerPluginForTest(mock_cipher_);
+    }
+
+    void
+    TearDown() override {
+        PluginLoader::GetInstance().unregisterPluginForTest("CipherPlugin");
+        IndexEntryWriterV3Test::TearDown();
+    }
+
+    // Reads an entry back through the public reader, using nothing but what
+    // the file itself persisted. This is what lets these tests catch a writer
+    // that encrypts with a DEK whose EDEK was never stored.
+    void
+    VerifyEncryptedEntry(const std::string& file_path,
+                         const std::string& entry_name,
+                         size_t expected_size) {
+        auto input = CreateInputStream(file_path);
+        int64_t file_size = GetFileSize(file_path);
+        auto reader = IndexEntryReader::Open(input, file_size, 100);
+        auto entry = reader->ReadEntry(entry_name);
+        ASSERT_EQ(entry.data.size(), expected_size);
+        VerifyPattern(entry.data, expected_size);
     }
 
     std::shared_ptr<MockCipherPlugin> mock_cipher_;
@@ -925,6 +983,8 @@ TEST_F(IndexEntryEncryptedV3Test, EncryptedSmallEntryRoundtrip) {
     auto info = fs_->GetFileInfo(file_path);
     ASSERT_TRUE(info.ok());
     EXPECT_GT(info.ValueOrDie().size(), entry_size);  // ciphertext > plaintext
+
+    VerifyEncryptedEntry(file_path, "enc_entry", entry_size);
 }
 
 TEST_F(IndexEntryEncryptedV3Test, EncryptedMultiSliceEntry) {
@@ -949,6 +1009,8 @@ TEST_F(IndexEntryEncryptedV3Test, EncryptedMultiSliceEntry) {
     auto info = fs_->GetFileInfo(file_path);
     ASSERT_TRUE(info.ok());
     EXPECT_GT(info.ValueOrDie().size(), entry_size);
+
+    VerifyEncryptedEntry(file_path, "large_enc", entry_size);
 }
 
 TEST_F(IndexEntryEncryptedV3Test, EncryptedMultipleEntriesMultiSlice) {
@@ -981,6 +1043,10 @@ TEST_F(IndexEntryEncryptedV3Test, EncryptedMultipleEntriesMultiSlice) {
     auto info = fs_->GetFileInfo(file_path);
     ASSERT_TRUE(info.ok());
     EXPECT_GT(info.ValueOrDie().size(), size_a + size_b + size_c);
+
+    VerifyEncryptedEntry(file_path, "entry_a", size_a);
+    VerifyEncryptedEntry(file_path, "entry_b", size_b);
+    VerifyEncryptedEntry(file_path, "entry_c", size_c);
 }
 
 TEST_F(IndexEntryEncryptedV3Test, EncryptedLargeMetaMultiSlice) {
@@ -1008,6 +1074,13 @@ TEST_F(IndexEntryEncryptedV3Test, EncryptedLargeMetaMultiSlice) {
 
     auto info = fs_->GetFileInfo(file_path);
     ASSERT_TRUE(info.ok());
+
+    VerifyEncryptedEntry(file_path, "data", 256);
+
+    auto input = CreateInputStream(file_path);
+    auto reader = IndexEntryReader::Open(input, GetFileSize(file_path), 100);
+    EXPECT_EQ(reader->GetMeta<std::string>("large_meta"),
+              std::string(5000, 'M'));
 }
 
 TEST_F(IndexEntryEncryptedV3Test, EncryptedFdEntryMultiSlice) {
@@ -1046,6 +1119,8 @@ TEST_F(IndexEntryEncryptedV3Test, EncryptedFdEntryMultiSlice) {
     EXPECT_GT(info.ValueOrDie().size(), entry_size);
 
     ::unlink(tmp_relative.c_str());
+
+    VerifyEncryptedEntry(file_path, "fd_entry", entry_size);
 }
 
 // ---- ReadEntryStream tests ----

--- a/internal/core/src/storage/PluginLoader.h
+++ b/internal/core/src/storage/PluginLoader.h
@@ -89,6 +89,22 @@ class PluginLoader {
         LOG_INFO("Loaded plugin: {}", pluginName);
     }
 
+    // Visible for testing: install a plugin instance directly, bypassing
+    // dlopen, so unit tests can exercise code paths that resolve the cipher
+    // plugin through this singleton.
+    void
+    registerPluginForTest(
+        std::shared_ptr<milvus::storage::plugin::IPlugin> plugin) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        plugins_[plugin->getPluginName()] = std::move(plugin);
+    }
+
+    void
+    unregisterPluginForTest(const std::string& plugin_name) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        plugins_.erase(plugin_name);
+    }
+
     void
     unloadAll() {
         std::lock_guard<std::mutex> lock(mutex_);


### PR DESCRIPTION
issue: #52514
pr: #52515

`IndexEntryEncryptedLocalWriter` obtained an encryptor in its constructor, kept only the EDEK and discarded the encryptor, then called `GetEncryptor()` again inside the per-slice encryption task:

```cpp
// ctor: only edek_ survives, and it is the only EDEK written to the directory
auto [encryptor, edek] = cipher_plugin_->GetEncryptor(ez_id_, collection_id_);
edek_ = std::move(edek);

// WriteEntry() / EncryptAndWriteSlices(): a new DEK for every slice
auto [enc, unused_edek] = cipher_plugin_->GetEncryptor(ez_id_, collection_id_);
return enc->Encrypt(s);          // ...and its EDEK is dropped on the floor
```

The cipher plugin generates a fresh keyset on every `GetEncryptor()` call, so the DEKs that actually encrypted the data existed only for the duration of that call. The result is that **every encrypted V3 packed index file is permanently undecryptable**: unwrapping the stored EDEK succeeds, and decrypting the payload then fails with `Decryption failed: INVALID_ARGUMENT: decryption failed`.

Parsing a real file produced by an affected build shows it plainly — three slices, three distinct tink key ids, one EDEK:

```
entry            slice size   original   tink key id
index_data            82235      82202   2082416872
valid_bitset           2533       2500   3205477861
__meta__                 96         63   3197092361
```

The breakage is unconditional. `slice_size` is 16 MiB and this payload is 82 KB, so every entry is a single slice, and it is still broken — the constructor's encryptor never encrypts a single byte.

Reached from `ScalarIndexCreator::Upload()` (scalar indexes) and `index_c.cpp` (`TextMatchIndex`) when the scalar index engine version is >= 3. Vector indexes use `PutIndexData` → `IndexData::Serialize`, which pairs the encryptor with the EDEK it stores, and are unaffected — as are binlogs and storage-v2 packed data files.

### The fix

Keep the constructor's encryptor as a member and reuse it for every slice, so the persisted EDEK always matches the ciphertext.

### Why the tests did not catch it

The encrypted tests never read anything back. Each one writes a file and then asserts only that it exists and that its size exceeds the plaintext size:

```cpp
auto info = fs_->GetFileInfo(file_path);
ASSERT_TRUE(info.ok());
EXPECT_GT(info.ValueOrDie().size(), entry_size);  // ciphertext > plaintext
```

That assertion is a tautology for this container format — magic + directory table + footer make the file larger than the payload no matter what the cipher does, including a no-op cipher. Line coverage looked fine, the names said `Roundtrip`, and the behavioural coverage of the encrypted read path was zero.

The mock cipher plugin would have masked the bug even with a real round trip: it returned the same key on every call and embedded that key in the ciphertext (`[1-byte key][XOR'd data]`, decryptor reading `src[0]`), so the EDEK was never used.

There was also no way to write such a test: the read path resolves the cipher plugin through the `PluginLoader` singleton, which could only be populated via `dlopen`. This change adds `registerPluginForTest`/`unregisterPluginForTest` so a mock can be installed.

This PR makes the tests able to fail:

- every entry is read back through `IndexEntryReader` and compared byte for byte, using nothing but what the file itself persisted;
- the mock mints a fresh key per `GetEncryptor()` call, keeps the key out of the ciphertext, derives the decryption key solely from the EDEK, and raises an authentication-tag style error when it does not match.

### Verification

Verified end to end on a local cluster with encryption at rest enabled, running the production cipher plugin build against a tink fake KMS:

- before: 0 of 6 `LoadUnified` calls completed, every one raising `Decryption failed: INVALID_ARGUMENT`;
- after: 6 of 6 completed, zero decryption failures, collection loads and queries return correct results;
- index files written by the fixed writer carry a single tink key id across all slices, matching the persisted EDEK.

Unit level, same binary, only the writer changed:

- writer bug restored: all five `IndexEntryEncryptedV3Test` cases fail with `Decryption failed: mock authentication tag mismatch`;
- with the fix: all five pass, together with the 19 `IndexEntryWriterV3Test` plaintext cases.

### Operator note

Existing encrypted V3 packed index files cannot be recovered — the DEKs were never persisted. Affected clusters must rebuild scalar and text-match indexes **after** deploying this fix; rebuilding on an affected binary reproduces the same undecryptable files. User data is unaffected: binlogs decrypt normally and indexes can be rebuilt from them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
