### PR TITLE
enhance: allow external gRPC connection construction

### DIFF
--- a/client/milvusclient/client.go
+++ b/client/milvusclient/client.go
@@ -77,10 +77,10 @@ func New(ctx context.Context, config *ClientConfig) (*Client, error) {
 	// parse authentication parameters
 	c.parseAuthentication()
 	// Parse grpc options
-	options := c.dialOptions()
+	options := c.connectionOptions()
 
 	// Connect the grpc server.
-	if err := c.connect(ctx, addr, options...); err != nil {
+	if err := c.connect(ctx, addr, options); err != nil {
 		return nil, err
 	}
 
@@ -95,39 +95,53 @@ func New(ctx context.Context, config *ClientConfig) (*Client, error) {
 	return c, nil
 }
 
-func (c *Client) dialOptions() []grpc.DialOption {
-	var options []grpc.DialOption
+func (c *Client) connectionOptions() ConnectionOptions {
+	var transportCredentials credentials.TransportCredentials
 	// Construct dial option.
 	if c.config.EnableTLSAuth {
 		if c.config.tlsConfig != nil {
-			options = append(options, grpc.WithTransportCredentials(credentials.NewTLS(c.config.tlsConfig)))
+			transportCredentials = credentials.NewTLS(c.config.tlsConfig)
 		} else {
-			options = append(options, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))
+			transportCredentials = credentials.NewTLS(&tls.Config{})
 		}
 	} else {
-		options = append(options, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		transportCredentials = insecure.NewCredentials()
 	}
 
-	// Always apply default connection options first, then let caller override/extend.
-	options = append(options, DefaultGrpcOpts...)
-	options = append(options, c.config.DialOptions...)
+	dialOptions := append([]grpc.DialOption(nil), c.config.DialOptions...)
 
-	options = append(options,
-		grpc.WithChainUnaryInterceptor(grpc_retry.UnaryClientInterceptor(
-			grpc_retry.WithMax(6),
+	var unaryInterceptors []grpc.UnaryClientInterceptor
+	transportRetry := c.config.retryTransportOption()
+	if transportRetry.MaxRetry > 0 {
+		unaryInterceptors = append(unaryInterceptors, grpc_retry.UnaryClientInterceptor(
+			grpc_retry.WithMax(transportRetry.MaxRetry),
 			grpc_retry.WithBackoff(func(attempt uint) time.Duration {
 				return 60 * time.Millisecond * time.Duration(math.Pow(3, float64(attempt)))
 			}),
-			grpc_retry.WithCodes(codes.Unavailable, codes.ResourceExhausted)),
+			grpc_retry.WithCodes(codes.Unavailable, codes.ResourceExhausted)))
+	}
 
-		// c.getRetryOnRateLimitInterceptor(),
-		))
+	// c.getRetryOnRateLimitInterceptor(),
+	unaryInterceptors = append(unaryInterceptors, c.MetadataUnaryInterceptor())
 
-	options = append(options, grpc.WithChainUnaryInterceptor(
-		c.MetadataUnaryInterceptor(),
-	))
+	return ConnectionOptions{
+		TransportCredentials: transportCredentials,
+		DialOptions:          dialOptions,
+		UnaryInterceptors:    unaryInterceptors,
+	}
+}
 
-	return options
+func defaultConnectionFactory(ctx context.Context, target string, options ConnectionOptions) (*grpc.ClientConn, error) {
+	dialOptions := []grpc.DialOption{grpc.WithTransportCredentials(options.TransportCredentials)}
+	dialOptions = append(dialOptions, DefaultGrpcOpts...)
+	dialOptions = append(dialOptions, options.DialOptions...)
+	if len(options.UnaryInterceptors) > 0 {
+		dialOptions = append(dialOptions, grpc.WithChainUnaryInterceptor(options.UnaryInterceptors...))
+	}
+	if len(options.StreamInterceptors) > 0 {
+		dialOptions = append(dialOptions, grpc.WithChainStreamInterceptor(options.StreamInterceptors...))
+	}
+	return grpc.DialContext(ctx, target, dialOptions...)
 }
 
 // parseAuthentication prepares authentication headers for grpc inteceptors based on the provided username, password or API key.
@@ -181,11 +195,15 @@ func (c *Client) setIdentifier(identifier string) {
 	c.identifier = identifier
 }
 
-func (c *Client) connect(ctx context.Context, addr string, options ...grpc.DialOption) error {
+func (c *Client) connect(ctx context.Context, addr string, options ConnectionOptions) error {
 	if addr == "" {
 		return errors.New("address is empty")
 	}
-	conn, err := grpc.DialContext(ctx, addr, options...)
+	connectionFactory := c.config.ConnectionFactory
+	if connectionFactory == nil {
+		connectionFactory = defaultConnectionFactory
+	}
+	conn, err := connectionFactory(ctx, addr, options)
 	if err != nil {
 		return err
 	}

--- a/client/milvusclient/client_config.go
+++ b/client/milvusclient/client_config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 )
 
@@ -47,6 +48,23 @@ var DefaultGrpcOpts = []grpc.DialOption{
 	),
 }
 
+// ConnectionOptions contains the settings required to create the Milvus gRPC
+// connection. DialOptions contains only the options explicitly supplied through
+// ClientConfig. ConnectionFactory implementations are responsible for their own
+// default connection policy, but must preserve the effective transport security,
+// apply DialOptions, and install the unary and stream interceptors in the order
+// provided.
+type ConnectionOptions struct {
+	TransportCredentials credentials.TransportCredentials
+	DialOptions          []grpc.DialOption
+	UnaryInterceptors    []grpc.UnaryClientInterceptor
+	StreamInterceptors   []grpc.StreamClientInterceptor
+}
+
+// ConnectionFactory creates the gRPC connection used by a Client. The Client
+// owns the returned connection and closes it when Client.Close is called.
+type ConnectionFactory func(context.Context, string, ConnectionOptions) (*grpc.ClientConn, error)
+
 // ClientConfig for milvus client.
 type ClientConfig struct {
 	Address  string // Remote address, "localhost:19530".
@@ -60,6 +78,17 @@ type ClientConfig struct {
 	tlsConfig *tls.Config // Custom TLS config, set via WithTLSConfig method.
 
 	DialOptions []grpc.DialOption // Dial options for GRPC.
+
+	// ConnectionFactory creates the underlying gRPC client connection. When nil,
+	// the client uses grpc.DialContext. A custom factory can integrate the Milvus
+	// client with a platform-specific gRPC connection framework while preserving
+	// the Milvus transport settings and interceptors.
+	ConnectionFactory ConnectionFactory
+
+	// RetryTransport configures retries for Unavailable and ResourceExhausted
+	// gRPC errors. When nil, the client uses the default policy. Set MaxRetry to
+	// 0 to disable transport retries.
+	RetryTransport *RetryTransportOption
 
 	RetryRateLimit *RetryRateLimitOption // option for retry on rate limit inteceptor
 
@@ -76,6 +105,11 @@ type ClientConfig struct {
 type RetryRateLimitOption struct {
 	MaxRetry   uint
 	MaxBackoff time.Duration
+}
+
+// RetryTransportOption configures retries for retriable gRPC transport errors.
+type RetryTransportOption struct {
+	MaxRetry uint
 }
 
 func (cfg *ClientConfig) parse() error {
@@ -139,6 +173,13 @@ func (c *ClientConfig) defaultRetryRateLimitOption() *RetryRateLimitOption {
 	}
 }
 
+func (c *ClientConfig) retryTransportOption() *RetryTransportOption {
+	if c.RetryTransport != nil {
+		return c.RetryTransport
+	}
+	return &RetryTransportOption{MaxRetry: 6}
+}
+
 // addFlags set internal flags
 func (c *ClientConfig) addFlags(flags uint64) {
 	c.flags |= flags
@@ -162,7 +203,7 @@ func (c *ClientConfig) WithTLSConfig(tlsConfig *tls.Config) *ClientConfig {
 }
 
 // WithGrpcAuthority sets the gRPC :authority header, used for proxy-based routing.
-// DefaultGrpcOpts are always applied by dialOptions(), so only the authority option is needed here.
+// DefaultGrpcOpts are applied separately, so only the authority option is needed here.
 func (c *ClientConfig) WithGrpcAuthority(authority string) *ClientConfig {
 	c.DialOptions = []grpc.DialOption{grpc.WithAuthority(authority)}
 	return c

--- a/client/milvusclient/client_config_test.go
+++ b/client/milvusclient/client_config_test.go
@@ -1,25 +1,137 @@
 package milvusclient
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
-func TestDialOptionsAlwaysIncludesDefaults(t *testing.T) {
+func TestConnectionOptionsIncludesCallerDialOptions(t *testing.T) {
 	c := &Client{config: &ClientConfig{
 		DialOptions: []grpc.DialOption{grpc.WithAuthority("test")},
 	}}
-	opts := c.dialOptions()
-	// TLS/insecure (1) + DefaultGrpcOpts (len) + user option (1) + interceptors (2)
-	assert.True(t, len(opts) >= len(DefaultGrpcOpts)+1, "dialOptions should include DefaultGrpcOpts plus user options")
+	opts := c.connectionOptions()
+	assert.Len(t, opts.DialOptions, 1)
+	assert.Len(t, opts.UnaryInterceptors, 2)
+	assert.NotNil(t, opts.TransportCredentials)
 }
 
-func TestDialOptionsWithNilDialOptions(t *testing.T) {
+func TestConnectionOptionsWithNilDialOptions(t *testing.T) {
 	c := &Client{config: &ClientConfig{}}
-	opts := c.dialOptions()
-	assert.True(t, len(opts) >= len(DefaultGrpcOpts), "dialOptions should include DefaultGrpcOpts even when DialOptions is nil")
+	opts := c.connectionOptions()
+	assert.Empty(t, opts.DialOptions)
+	assert.Len(t, opts.UnaryInterceptors, 2)
+	assert.NotNil(t, opts.TransportCredentials)
+}
+
+func TestRetryConfiguration(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        *ClientConfig
+		wantCalls     int
+		wantChainSize int
+	}{
+		{
+			name:          "default retry remains enabled",
+			config:        &ClientConfig{},
+			wantCalls:     6,
+			wantChainSize: 2,
+		},
+		{
+			name:          "retry count is configurable",
+			config:        &ClientConfig{RetryTransport: &RetryTransportOption{MaxRetry: 3}},
+			wantCalls:     3,
+			wantChainSize: 2,
+		},
+		{
+			name:          "zero disables retry",
+			config:        &ClientConfig{RetryTransport: &RetryTransportOption{MaxRetry: 0}},
+			wantCalls:     1,
+			wantChainSize: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &Client{config: test.config}
+			options := client.connectionOptions()
+			require.Len(t, options.UnaryInterceptors, test.wantChainSize)
+
+			calls := 0
+			invoker := func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+				calls++
+				return status.Error(codes.Unavailable, "unavailable")
+			}
+			err := invokeUnaryInterceptors(
+				options.UnaryInterceptors,
+				invoker,
+				nil,
+				grpc_retry.WithBackoff(func(uint) time.Duration { return 0 }),
+			)
+			assert.Equal(t, codes.Unavailable, status.Code(err))
+			assert.Equal(t, test.wantCalls, calls)
+		})
+	}
+}
+
+func TestRetryTransportCodes(t *testing.T) {
+	tests := []struct {
+		name      string
+		code      codes.Code
+		wantCalls int
+	}{
+		{name: "unavailable", code: codes.Unavailable, wantCalls: 2},
+		{name: "resource exhausted", code: codes.ResourceExhausted, wantCalls: 2},
+		{name: "non-retriable", code: codes.InvalidArgument, wantCalls: 1},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &Client{config: &ClientConfig{
+				RetryTransport: &RetryTransportOption{MaxRetry: 2},
+			}}
+			options := client.connectionOptions()
+
+			calls := 0
+			invoker := func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+				calls++
+				return status.Error(test.code, test.code.String())
+			}
+
+			err := invokeUnaryInterceptors(
+				options.UnaryInterceptors,
+				invoker,
+				nil,
+				grpc_retry.WithBackoff(func(uint) time.Duration { return 0 }),
+			)
+			assert.Equal(t, test.code, status.Code(err))
+			assert.Equal(t, test.wantCalls, calls)
+		})
+	}
+}
+
+func invokeUnaryInterceptors(
+	interceptors []grpc.UnaryClientInterceptor,
+	invoker grpc.UnaryInvoker,
+	reply any,
+	callOptions ...grpc.CallOption,
+) error {
+	chainedInvoker := invoker
+	for i := len(interceptors) - 1; i >= 0; i-- {
+		interceptor := interceptors[i]
+		next := chainedInvoker
+		chainedInvoker = func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+			return interceptor(ctx, method, req, reply, cc, next, opts...)
+		}
+	}
+	return chainedInvoker(context.Background(), "/test.Service/Method", nil, reply, nil, callOptions...)
 }
 
 func TestWithGrpcAuthority(t *testing.T) {
@@ -28,7 +140,7 @@ func TestWithGrpcAuthority(t *testing.T) {
 		result := config.WithGrpcAuthority("proxy.example.com")
 
 		assert.Same(t, config, result)
-		// Only grpc.WithAuthority; DefaultGrpcOpts are applied by dialOptions()
+		// Only grpc.WithAuthority; DefaultGrpcOpts are applied separately.
 		assert.Equal(t, 1, len(config.DialOptions))
 	})
 

--- a/client/milvusclient/client_test.go
+++ b/client/milvusclient/client_test.go
@@ -31,6 +31,28 @@ func (s *ClientSuite) TestNewClient() {
 		s.NotNil(c)
 	})
 
+	s.Run("custom connection factory", func() {
+		var called bool
+		c, err := New(ctx, &ClientConfig{
+			Address: "bufnet",
+			DialOptions: []grpc.DialOption{
+				grpc.WithBlock(),
+				grpc.WithContextDialer(s.mockDialer),
+			},
+			ConnectionFactory: func(factoryCtx context.Context, target string, options ConnectionOptions) (*grpc.ClientConn, error) {
+				called = true
+				s.Equal("bufnet", target)
+				s.NotNil(options.TransportCredentials)
+				s.Len(options.DialOptions, 2)
+				s.Len(options.UnaryInterceptors, 2)
+				return defaultConnectionFactory(factoryCtx, target, options)
+			},
+		})
+		s.NoError(err)
+		s.NotNil(c)
+		s.True(called)
+	})
+
 	s.Run("empty_addr", func() {
 		_, err := New(ctx, &ClientConfig{})
 		s.Error(err)


### PR DESCRIPTION
Milvus previously assembled grpc.DialOptions and called grpc.DialContext directly. That made it impossible for a downstream integration to create the channel through a platform gRPC library whose observability, adaptive throttling, resolver behavior, and middleware policy are installed as part of its own dial operation rather than exposed as ordinary grpc.DialOptions.

Add an optional ConnectionFactory to ClientConfig so connection construction can occur outside the Milvus library. The factory receives the resolved target and a ConnectionOptions value containing effective transport credentials, explicitly configured DialOptions, and Milvus unary and stream interceptors. This lets an external dialer translate each part into its supported APIs while preserving Milvus authentication and database metadata. Milvus continues to own and close the returned connection and initializes its service clients exactly as before.

Keep the factory boundary intentionally small: ConnectionOptions exposes one DialOptions slice containing only caller-provided options. The built-in factory continues to apply DefaultGrpcOpts before that slice, while an external factory owns its own default connection policy. This avoids requiring alternate dialers to inspect opaque grpc.DialOption values or distinguish SDK policy from caller intent.

Make the existing transport retry attempt limit configurable through RetryTransportOption. A nil option preserves the existing six-attempt policy for Unavailable and ResourceExhausted responses, a positive value selects another limit, and zero omits the retry interceptor. This allows an external connection stack to own retry policy and coordinate it with admission control without forcing existing clients to change.

The extension is opt-in. When ConnectionFactory is nil, the built-in path still calls grpc.DialContext with transport credentials, Milvus defaults, caller options, transport retry, and the metadata interceptor in the same effective order. Existing TLS selection, default retry count and backoff, metadata propagation, initial Milvus Connect behavior, service construction, and connection ownership remain unchanged.

Add coverage for custom connection construction, caller option forwarding, the preserved default retry count, configurable and disabled retries, retryable status codes, and non-retryable failures.