### PR TITLE
fix: skip zero-row packed insert writes

### DIFF
--- a/internal/flushcommon/syncmgr/pack_writer_v2.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v2.go
@@ -218,6 +218,12 @@ func (bw *BulkPackWriterV2) writeInserts(ctx context.Context, pack *SyncPack) (m
 	if err != nil {
 		return nil, "", err
 	}
+	if rec == nil || rec.Len() == 0 {
+		if rec != nil {
+			rec.Release()
+		}
+		return make(map[int64]*datapb.FieldBinlog), "", nil
+	}
 	defer rec.Release()
 
 	tsFrom, tsTo := bw.getTsRange(rec)

--- a/internal/flushcommon/syncmgr/pack_writer_v2_test.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v2_test.go
@@ -271,6 +271,32 @@ func (s *PackWriterV2Suite) TestWriteEmptyInsertData() {
 	s.NoError(err)
 }
 
+func (s *PackWriterV2Suite) TestWriteZeroRowInsertDataSkipsStorageWriter() {
+	s.logIDAlloc = allocator.NewLocalAllocator(1, 1)
+	collectionID := int64(123)
+	partitionID := int64(456)
+	segmentID := int64(789)
+	channelName := fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID)
+
+	bfs := pkoracle.NewBloomFilterSet()
+	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{}, bfs, nil, metacache.NewEmptySegmentStats())
+	mc := metacache.NewMockMetaCache(s.T())
+	mc.EXPECT().GetSchema(mock.Anything).Return(s.schema).Maybe()
+	mc.EXPECT().GetSegmentByID(segmentID).Return(seg, true).Maybe()
+
+	pack := new(SyncPack).WithCollectionID(collectionID).WithPartitionID(partitionID).
+		WithSegmentID(segmentID).WithChannelName(channelName).
+		WithInsertData(genEmptyInsertData(s.schema)).
+		WithBatchRows(0)
+	bw := NewBulkPackWriterV2(mc, s.schema, s.cm, s.logIDAlloc, packed.DefaultWriteBufferSize, 0, nil, s.currentSplit)
+
+	gotInserts, _, _, _, manifest, size, _, err := bw.Write(context.Background(), pack)
+	s.NoError(err)
+	s.Empty(gotInserts)
+	s.Empty(manifest)
+	s.Zero(size)
+}
+
 func (s *PackWriterV2Suite) TestNoPkField() {
 	s.schema = &schemapb.CollectionSchema{
 		Name: "no pk field",
@@ -368,5 +394,10 @@ func genInsertData(size int, schema *schemapb.CollectionSchema) []*storage.Inser
 
 		buf.Append(data)
 	}
+	return []*storage.InsertData{buf}
+}
+
+func genEmptyInsertData(schema *schemapb.CollectionSchema) []*storage.InsertData {
+	buf, _ := storage.NewInsertData(schema)
 	return []*storage.InsertData{buf}
 }

--- a/internal/flushcommon/syncmgr/pack_writer_v3.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v3.go
@@ -278,6 +278,12 @@ func (bw *BulkPackWriterV3) writeInserts(ctx context.Context, pack *SyncPack, ba
 	if err != nil {
 		return nil, nil, err
 	}
+	if rec == nil || rec.Len() == 0 {
+		if rec != nil {
+			rec.Release()
+		}
+		return make(map[int64]*datapb.FieldBinlog), nil, nil
+	}
 	defer rec.Release()
 
 	tsFrom, tsTo := bw.getTsRange(rec)

--- a/internal/flushcommon/syncmgr/pack_writer_v3_test.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v3_test.go
@@ -319,6 +319,35 @@ func (s *PackWriterV3Suite) TestWriteEmptyInsertData() {
 	s.NoError(err)
 }
 
+func (s *PackWriterV3Suite) TestWriteZeroRowInsertDataSkipsStorageWriter() {
+	s.logIDAlloc = allocator.NewLocalAllocator(1, 1)
+	collectionID := int64(123)
+	partitionID := int64(456)
+	segmentID := int64(789)
+	channelName := fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID)
+
+	k := metautil.JoinIDPath(collectionID, partitionID, segmentID)
+	basePath := path.Join(common.SegmentInsertLogPath, k)
+	manifestPath := packed.MarshalManifestPath(basePath, packed.ManifestEarliest)
+
+	bfs := pkoracle.NewBloomFilterSet()
+	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{ManifestPath: manifestPath}, bfs, nil, metacache.NewEmptySegmentStats())
+	mc := metacache.NewMockMetaCache(s.T())
+	mc.EXPECT().GetSchema(mock.Anything).Return(s.schema).Maybe()
+	mc.EXPECT().GetSegmentByID(segmentID).Return(seg, true).Maybe()
+
+	pack := new(SyncPack).WithCollectionID(collectionID).WithPartitionID(partitionID).
+		WithSegmentID(segmentID).WithChannelName(channelName).
+		WithInsertData(genEmptyInsertData(s.schema)).
+		WithBatchRows(0)
+	bw := NewBulkPackWriterV3(mc, s.schema, s.cm, s.logIDAlloc, packed.DefaultWriteBufferSize, 0, s.storageConfig, s.currentSplit, manifestPath)
+
+	gotInserts, _, _, _, _, size, _, err := bw.Write(context.Background(), pack)
+	s.NoError(err)
+	s.Empty(gotInserts)
+	s.Zero(size)
+}
+
 func (s *PackWriterV3Suite) TestNoPkField() {
 	s.schema = &schemapb.CollectionSchema{
 		Name: "no pk field",

--- a/internal/storagev2/packed/packed_writer.go
+++ b/internal/storagev2/packed/packed_writer.go
@@ -131,7 +131,7 @@ func NewPackedWriter(filePaths []string, schema *arrow.Schema, bufferSize int64,
 }
 
 func (pw *PackedWriter) WriteRecordBatch(recordBatch arrow.Record) error {
-	if recordBatch == nil || recordBatch.NumCols() == 0 {
+	if recordBatch == nil || recordBatch.NumCols() == 0 || recordBatch.NumRows() == 0 {
 		return nil
 	}
 	if pw.cPackedWriter == nil {

--- a/internal/storagev2/packed/packed_writer_ffi.go
+++ b/internal/storagev2/packed/packed_writer_ffi.go
@@ -203,6 +203,10 @@ func (pw *FFIPackedWriter) Destroy() {
 }
 
 func (pw *FFIPackedWriter) WriteRecordBatch(recordBatch arrow.Record) error {
+	if recordBatch == nil || recordBatch.NumCols() == 0 || recordBatch.NumRows() == 0 {
+		return nil
+	}
+
 	var caa cdata.CArrowArray
 	var cas cdata.CArrowSchema
 


### PR DESCRIPTION
This PR skips packed insert writes when the serialized insert record contains zero rows.

Without this guard, a SyncPack may contain non-nil insertData but produce an empty Arrow record. In the StorageV2 packed writer path, Milvus can still create the object writer before writing any rows, which may trigger object-storage multipart init/complete behavior without uploading data parts on some S3-compatible backends.

Changes:
- Skip V2/V3 insert writes before creating packed writers when record row count is zero.
- Add zero-row no-op guards in packed writer WriteRecordBatch paths.
- Add regression tests for non-nil insertData with zero rows.