### PR TITLE
enhance: avoid creating packed writers for zero-row inserts

### DIFF
--- a/internal/flushcommon/syncmgr/pack_writer_v2.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v2.go
@@ -210,13 +210,19 @@ func (bw *BulkPackWriterV2) getTsRange(rec storage.Record) (tsFrom, tsTo uint64)
 }
 
 func (bw *BulkPackWriterV2) writeInserts(ctx context.Context, pack *SyncPack) (map[int64]*datapb.FieldBinlog, string, error) {
-	if len(pack.insertData) == 0 {
+	if len(pack.insertData) == 0 || !hasInsertRows(pack.insertData) {
 		return make(map[int64]*datapb.FieldBinlog), "", nil
 	}
 
 	rec, err := bw.serializeBinlog(ctx, pack)
 	if err != nil {
 		return nil, "", err
+	}
+	if rec == nil || rec.Len() == 0 {
+		if rec != nil {
+			rec.Release()
+		}
+		return make(map[int64]*datapb.FieldBinlog), "", nil
 	}
 	defer rec.Release()
 
@@ -241,6 +247,15 @@ func (bw *BulkPackWriterV2) writeInserts(ctx context.Context, pack *SyncPack) (m
 		return nil, "", err
 	}
 	return logs, manifestPath, nil
+}
+
+func hasInsertRows(insertData []*storage.InsertData) bool {
+	for _, data := range insertData {
+		if data.GetRowNum() > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func (bw *BulkPackWriterV2) writeInsertsIntoStorage(_ context.Context,

--- a/internal/flushcommon/syncmgr/pack_writer_v2_test.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v2_test.go
@@ -271,6 +271,25 @@ func (s *PackWriterV2Suite) TestWriteEmptyInsertData() {
 	s.NoError(err)
 }
 
+func (s *PackWriterV2Suite) TestWriteZeroRowInsertDataSkipsStorageWriter() {
+	s.logIDAlloc = allocator.NewLocalAllocator(1, 1)
+	collectionID := int64(123)
+	partitionID := int64(456)
+	segmentID := int64(789)
+	channelName := fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID)
+
+	pack := new(SyncPack).WithCollectionID(collectionID).WithPartitionID(partitionID).
+		WithSegmentID(segmentID).WithChannelName(channelName).
+		WithInsertData(genEmptyInsertData(s.schema)).
+		WithBatchRows(0)
+	bw := NewBulkPackWriterV2(nil, s.schema, s.cm, s.logIDAlloc, packed.DefaultWriteBufferSize, 0, nil, s.currentSplit)
+
+	gotInserts, manifest, err := bw.writeInserts(context.Background(), pack)
+	s.NoError(err)
+	s.Empty(gotInserts)
+	s.Empty(manifest)
+}
+
 func (s *PackWriterV2Suite) TestNoPkField() {
 	s.schema = &schemapb.CollectionSchema{
 		Name: "no pk field",
@@ -368,5 +387,10 @@ func genInsertData(size int, schema *schemapb.CollectionSchema) []*storage.Inser
 
 		buf.Append(data)
 	}
+	return []*storage.InsertData{buf}
+}
+
+func genEmptyInsertData(schema *schemapb.CollectionSchema) []*storage.InsertData {
+	buf, _ := storage.NewInsertData(schema)
 	return []*storage.InsertData{buf}
 }

--- a/internal/flushcommon/syncmgr/pack_writer_v3.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v3.go
@@ -270,13 +270,19 @@ func classifyLoonErr(err error) error {
 // The returned WriterOutput is owned by the caller and must be Destroy'd
 // after the surrounding commit (success or failure).
 func (bw *BulkPackWriterV3) writeInserts(ctx context.Context, pack *SyncPack, basePath string) (logs map[int64]*datapb.FieldBinlog, files packed.WriterOutput, err error) {
-	if len(pack.insertData) == 0 {
+	if len(pack.insertData) == 0 || !hasInsertRows(pack.insertData) {
 		return make(map[int64]*datapb.FieldBinlog), nil, nil
 	}
 
 	rec, err := bw.serializeBinlog(ctx, pack)
 	if err != nil {
 		return nil, nil, err
+	}
+	if rec == nil || rec.Len() == 0 {
+		if rec != nil {
+			rec.Release()
+		}
+		return make(map[int64]*datapb.FieldBinlog), nil, nil
 	}
 	defer rec.Release()
 

--- a/internal/flushcommon/syncmgr/pack_writer_v3_test.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v3_test.go
@@ -319,6 +319,29 @@ func (s *PackWriterV3Suite) TestWriteEmptyInsertData() {
 	s.NoError(err)
 }
 
+func (s *PackWriterV3Suite) TestWriteZeroRowInsertDataSkipsStorageWriter() {
+	s.logIDAlloc = allocator.NewLocalAllocator(1, 1)
+	collectionID := int64(123)
+	partitionID := int64(456)
+	segmentID := int64(789)
+	channelName := fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID)
+
+	k := metautil.JoinIDPath(collectionID, partitionID, segmentID)
+	basePath := path.Join(common.SegmentInsertLogPath, k)
+	manifestPath := packed.MarshalManifestPath(basePath, packed.ManifestEarliest)
+
+	pack := new(SyncPack).WithCollectionID(collectionID).WithPartitionID(partitionID).
+		WithSegmentID(segmentID).WithChannelName(channelName).
+		WithInsertData(genEmptyInsertData(s.schema)).
+		WithBatchRows(0)
+	bw := NewBulkPackWriterV3(nil, s.schema, s.cm, s.logIDAlloc, packed.DefaultWriteBufferSize, 0, s.storageConfig, s.currentSplit, manifestPath)
+
+	gotInserts, files, err := bw.writeInserts(context.Background(), pack, basePath)
+	s.NoError(err)
+	s.Empty(gotInserts)
+	s.Nil(files)
+}
+
 func (s *PackWriterV3Suite) TestNoPkField() {
 	s.schema = &schemapb.CollectionSchema{
 		Name: "no pk field",

--- a/internal/storagev2/packed/packed_writer.go
+++ b/internal/storagev2/packed/packed_writer.go
@@ -131,7 +131,7 @@ func NewPackedWriter(filePaths []string, schema *arrow.Schema, bufferSize int64,
 }
 
 func (pw *PackedWriter) WriteRecordBatch(recordBatch arrow.Record) error {
-	if recordBatch == nil || recordBatch.NumCols() == 0 {
+	if recordBatch == nil || recordBatch.NumCols() == 0 || recordBatch.NumRows() == 0 {
 		return nil
 	}
 	if pw.cPackedWriter == nil {

--- a/internal/storagev2/packed/packed_writer_ffi.go
+++ b/internal/storagev2/packed/packed_writer_ffi.go
@@ -203,6 +203,10 @@ func (pw *FFIPackedWriter) Destroy() {
 }
 
 func (pw *FFIPackedWriter) WriteRecordBatch(recordBatch arrow.Record) error {
+	if recordBatch == nil || recordBatch.NumCols() == 0 || recordBatch.NumRows() == 0 {
+		return nil
+	}
+
 	var caa cdata.CArrowArray
 	var cas cdata.CArrowSchema
 


### PR DESCRIPTION
This PR skips packed insert writes when the serialized insert record contains zero rows.

Without this guard, a SyncPack may contain non-nil insertData but produce an empty Arrow record. In the StorageV2 packed writer path, Milvus can still create the object writer before writing any rows, which may trigger object-storage multipart init/complete behavior without uploading data parts on some S3-compatible backends.

Changes:
- Skip V2/V3 insert writes before creating packed writers when record row count is zero.
- Add zero-row no-op guards in packed writer WriteRecordBatch paths.
- Add regression tests for non-nil insertData with zero rows.