### PR TITLE
enhance: compact Tantivy JSON row masks

### DIFF
--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -195,31 +195,27 @@ ScalarRowMaskResidentBytes(
     const auto is_json_path =
         field_type == DataType::JSON &&
         index_params.find(JSON_PATH) != index_params.end();
-    uint64_t mask_count = 0;
-    uint64_t dense_bitmap_count = 0;
-    if ((index_type == INVERTED_INDEX_TYPE || index_type == NGRAM_INDEX_TYPE) &&
-        (is_json_path || field_nullable.value_or(true))) {
-        // Tantivy does not retain null rows, so the C++ wrapper keeps one
-        // CRoaring row set beside the mmap'd index. JSON path extraction can
-        // produce null rows even when the source JSON field is non-nullable.
-        mask_count = 1;
-    }
+    auto cast_type_it = index_params.find(JSON_CAST_TYPE);
+    const bool is_flat_json =
+        cast_type_it == index_params.end() || cast_type_it->second == "JSON";
+    // Typed JSON path indexes additionally keep the non-existing rows for
+    // EXISTS semantics (plus one dense exists bitmap). NGRAM never applies.
+    const bool typed_json_path =
+        is_json_path && !is_flat_json && index_type != NGRAM_INDEX_TYPE;
 
-    if (is_json_path && index_type != NGRAM_INDEX_TYPE) {
-        // Typed JSON path indexes additionally keep the non-existing rows for
-        // EXISTS semantics. An unresolved HYBRID may select INVERTED, so use
-        // two masks there as a conservative bound.
-        auto cast_type_it = index_params.find(JSON_CAST_TYPE);
-        auto is_flat_json = cast_type_it == index_params.end() ||
-                            cast_type_it->second == "JSON";
-        if (!is_flat_json) {
-            mask_count += 1;
-            dense_bitmap_count = 1;
-            if (index_type == HYBRID_INDEX_TYPE) {
-                mask_count += 1;
-            }
-        }
-    }
+    // Tantivy does not retain null rows, so the wrapper keeps a CRoaring null
+    // offset set beside the mmap'd index. JSON path extraction can produce
+    // null rows even when the source field is non-nullable. An unresolved
+    // HYBRID may select INVERTED, so reserve its null mask conservatively.
+    const bool keeps_null_mask =
+        ((index_type == INVERTED_INDEX_TYPE ||
+          index_type == NGRAM_INDEX_TYPE) &&
+         (is_json_path || field_nullable.value_or(true))) ||
+        (typed_json_path && index_type == HYBRID_INDEX_TYPE);
+
+    const uint64_t mask_count =
+        (keeps_null_mask ? 1 : 0) + (typed_json_path ? 1 : 0);
+    const uint64_t dense_bitmap_count = typed_json_path ? 1 : 0;
 
     // A CRoaring container is at most roughly one dense bitset plus container
     // metadata. Reserve 2x the dense bytes per row set to cover that overhead.

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -24,6 +24,7 @@
 #include <limits>
 #include <memory>
 #include <optional>
+#include <roaring/roaring.hh>
 #include <string>
 #include <vector>
 
@@ -186,6 +187,38 @@ SaturatingMul(uint64_t lhs, uint64_t rhs) {
 }
 
 uint64_t
+RoaringRowMaskResidentBytes(int64_t num_rows) {
+    if (num_rows <= 0) {
+        return 0;
+    }
+
+    // Roaring32 partitions values by their high 16 bits, so one low container
+    // covers exactly 2^16 consecutive row offsets.
+    constexpr uint64_t kRowsPerContainer = uint64_t{1} << 16;
+    // After runOptimize(), every container payload is at most 8 KiB: an array
+    // holds at most 4096 uint16_t values, a bitmap holds exactly 2^16 bits,
+    // and a run container is retained only when it is no larger than those
+    // alternatives.
+    constexpr uint64_t kMaxContainerPayloadBytes = 8 * 1024;
+    // RoaringMemoryBytes() also includes the portable-format header. For C
+    // containers it is 8 + 8*C bytes without runs and no more than
+    // 4 + ceil(C/8) + 8*C bytes with runs. Thus 16*C bounds either layout for
+    // every C >= 1.
+    constexpr uint64_t kMaxPortableMetadataBytesPerContainer = 16;
+    const auto rows = static_cast<uint64_t>(num_rows);
+    const auto container_count =
+        rows / kRowsPerContainer + (rows % kRowsPerContainer != 0);
+
+    const auto sparse_container_bound =
+        SaturatingAdd(static_cast<uint64_t>(sizeof(roaring::Roaring)),
+                      SaturatingMul(container_count,
+                                    kMaxContainerPayloadBytes +
+                                        kMaxPortableMetadataBytesPerContainer));
+    const auto dense_container_bound = SaturatingMul(BitsetBytes(num_rows), 2);
+    return std::max(sparse_container_bound, dense_container_bound);
+}
+
+uint64_t
 ScalarRowMaskResidentBytes(
     DataType field_type,
     const std::string& index_type,
@@ -217,10 +250,8 @@ ScalarRowMaskResidentBytes(
         (keeps_null_mask ? 1 : 0) + (typed_json_path ? 1 : 0);
     const uint64_t dense_bitmap_count = typed_json_path ? 1 : 0;
 
-    // A CRoaring container is at most roughly one dense bitset plus container
-    // metadata. Reserve 2x the dense bytes per row set to cover that overhead.
     auto roaring_bytes =
-        SaturatingMul(SaturatingMul(BitsetBytes(num_rows), 2), mask_count);
+        SaturatingMul(RoaringRowMaskResidentBytes(num_rows), mask_count);
     auto dense_bitmap_bytes =
         SaturatingMul(BitsetBytes(num_rows), dense_bitmap_count);
     return SaturatingAdd(roaring_bytes, dense_bitmap_bytes);

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -186,6 +186,48 @@ SaturatingMul(uint64_t lhs, uint64_t rhs) {
 }
 
 uint64_t
+ScalarRowMaskResidentBytes(
+    DataType field_type,
+    const std::string& index_type,
+    const std::map<std::string, std::string>& index_params,
+    int64_t num_rows) {
+    uint64_t mask_count = 0;
+    uint64_t dense_bitmap_count = 0;
+    if (index_type == INVERTED_INDEX_TYPE || index_type == NGRAM_INDEX_TYPE) {
+        // Tantivy does not retain null rows, so the C++ wrapper keeps one
+        // CRoaring row set beside the mmap'd index.
+        mask_count = 1;
+    }
+
+    const auto is_json_path =
+        field_type == DataType::JSON &&
+        index_params.find(JSON_PATH) != index_params.end();
+    if (is_json_path && index_type != NGRAM_INDEX_TYPE) {
+        // Typed JSON path indexes additionally keep the non-existing rows for
+        // EXISTS semantics. An unresolved HYBRID may select INVERTED, so use
+        // two masks there as a conservative bound.
+        auto cast_type_it = index_params.find(JSON_CAST_TYPE);
+        auto is_flat_json = cast_type_it == index_params.end() ||
+                            cast_type_it->second == "JSON";
+        if (!is_flat_json) {
+            mask_count += 1;
+            dense_bitmap_count = 1;
+            if (index_type == HYBRID_INDEX_TYPE) {
+                mask_count += 1;
+            }
+        }
+    }
+
+    // A CRoaring container is at most roughly one dense bitset plus container
+    // metadata. Reserve 2x the dense bytes per row set to cover that overhead.
+    auto roaring_bytes =
+        SaturatingMul(SaturatingMul(BitsetBytes(num_rows), 2), mask_count);
+    auto dense_bitmap_bytes =
+        SaturatingMul(BitsetBytes(num_rows), dense_bitmap_count);
+    return SaturatingAdd(roaring_bytes, dense_bitmap_bytes);
+}
+
+uint64_t
 IdMapMmapDiskCost(const Config& config, int64_t num_rows) {
     if (num_rows <= 0) {
         return 0;
@@ -860,6 +902,12 @@ IndexFactory::ScalarIndexLoadResourceImpl(
             index_type);
         return LoadResourceRequest{0, 0, 0, 0, false};
     }
+    auto row_mask_resident_bytes = ScalarRowMaskResidentBytes(
+        field_type, index_type, index_params, num_rows);
+    request.final_memory_cost =
+        SaturatingAdd(request.final_memory_cost, row_mask_resident_bytes);
+    request.max_memory_cost =
+        SaturatingAdd(request.max_memory_cost, row_mask_resident_bytes);
     request.has_raw_data =
         CanUseIndexRawDataForField(field_type, request.has_raw_data);
     return request;

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -745,6 +745,25 @@ IndexFactory::ScalarIndexLoadResource(
 }
 
 LoadResourceRequest
+IndexFactory::ScalarIndexLoadResource(
+    DataType field_type,
+    IndexVersion index_version,
+    uint64_t index_size_in_bytes,
+    const std::map<std::string, std::string>& index_params,
+    bool mmap_enable,
+    int64_t num_rows,
+    bool field_nullable) {
+    return ScalarIndexLoadResourceImpl(field_type,
+                                       index_version,
+                                       index_size_in_bytes,
+                                       index_params,
+                                       mmap_enable,
+                                       num_rows,
+                                       std::nullopt,
+                                       field_nullable);
+}
+
+LoadResourceRequest
 IndexFactory::ScalarIndexLoadResourceImpl(
     DataType field_type,
     IndexVersion index_version,

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -449,7 +449,8 @@ IndexFactory::IndexLoadResource(
     const std::map<std::string, std::string>& index_params,
     bool mmap_enable,
     int64_t num_rows,
-    int64_t dim) {
+    int64_t dim,
+    std::optional<bool> field_nullable) {
     if (milvus::IsVectorDataType(field_type)) {
         return VecIndexLoadResource(field_type,
                                     element_type,
@@ -460,12 +461,14 @@ IndexFactory::IndexLoadResource(
                                     num_rows,
                                     dim);
     } else {
-        return ScalarIndexLoadResource(field_type,
-                                       index_version,
-                                       index_size_in_bytes,
-                                       index_params,
-                                       mmap_enable,
-                                       num_rows);
+        return ScalarIndexLoadResourceImpl(field_type,
+                                           index_version,
+                                           index_size_in_bytes,
+                                           index_params,
+                                           mmap_enable,
+                                           num_rows,
+                                           std::nullopt,
+                                           field_nullable);
     }
 }
 

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -190,18 +190,21 @@ ScalarRowMaskResidentBytes(
     DataType field_type,
     const std::string& index_type,
     const std::map<std::string, std::string>& index_params,
-    int64_t num_rows) {
-    uint64_t mask_count = 0;
-    uint64_t dense_bitmap_count = 0;
-    if (index_type == INVERTED_INDEX_TYPE || index_type == NGRAM_INDEX_TYPE) {
-        // Tantivy does not retain null rows, so the C++ wrapper keeps one
-        // CRoaring row set beside the mmap'd index.
-        mask_count = 1;
-    }
-
+    int64_t num_rows,
+    std::optional<bool> field_nullable) {
     const auto is_json_path =
         field_type == DataType::JSON &&
         index_params.find(JSON_PATH) != index_params.end();
+    uint64_t mask_count = 0;
+    uint64_t dense_bitmap_count = 0;
+    if ((index_type == INVERTED_INDEX_TYPE || index_type == NGRAM_INDEX_TYPE) &&
+        (is_json_path || field_nullable.value_or(true))) {
+        // Tantivy does not retain null rows, so the C++ wrapper keeps one
+        // CRoaring row set beside the mmap'd index. JSON path extraction can
+        // produce null rows even when the source JSON field is non-nullable.
+        mask_count = 1;
+    }
+
     if (is_json_path && index_type != NGRAM_INDEX_TYPE) {
         // Typed JSON path indexes additionally keep the non-existing rows for
         // EXISTS semantics. An unresolved HYBRID may select INVERTED, so use
@@ -737,6 +740,7 @@ IndexFactory::ScalarIndexLoadResource(
                                        index_params,
                                        mmap_enable,
                                        num_rows,
+                                       std::nullopt,
                                        std::nullopt);
 }
 
@@ -748,7 +752,8 @@ IndexFactory::ScalarIndexLoadResourceImpl(
     const std::map<std::string, std::string>& index_params,
     bool mmap_enable,
     int64_t num_rows,
-    const std::optional<storage::EntryStreamLoadInfo>& stream_load_info) {
+    const std::optional<storage::EntryStreamLoadInfo>& stream_load_info,
+    std::optional<bool> field_nullable) {
     auto config = milvus::index::ParseConfigFromIndexParams(index_params);
 
     auto index_type_it = index_params.find("index_type");
@@ -903,7 +908,7 @@ IndexFactory::ScalarIndexLoadResourceImpl(
         return LoadResourceRequest{0, 0, 0, 0, false};
     }
     auto row_mask_resident_bytes = ScalarRowMaskResidentBytes(
-        field_type, index_type, index_params, num_rows);
+        field_type, index_type, index_params, num_rows, field_nullable);
     request.final_memory_cost =
         SaturatingAdd(request.final_memory_cost, row_mask_resident_bytes);
     request.max_memory_cost =
@@ -983,13 +988,15 @@ IndexFactory::ScalarIndexLoadResource(
         *use_shared_memory_overhead_group = use_shared_group;
     }
 
-    return ScalarIndexLoadResourceImpl(field_type,
-                                       index_version,
-                                       index_size_in_bytes,
-                                       resolved_params,
-                                       mmap_enable,
-                                       num_rows,
-                                       inspected_stream_load_info);
+    return ScalarIndexLoadResourceImpl(
+        field_type,
+        index_version,
+        index_size_in_bytes,
+        resolved_params,
+        mmap_enable,
+        num_rows,
+        inspected_stream_load_info,
+        file_manager_context.fieldDataMeta.field_schema.nullable());
 }
 
 IndexBasePtr

--- a/internal/core/src/index/IndexFactory.h
+++ b/internal/core/src/index/IndexFactory.h
@@ -61,7 +61,8 @@ class IndexFactory {
                       const std::map<std::string, std::string>& index_params,
                       bool mmap_enable,
                       int64_t num_rows,
-                      int64_t dim);
+                      int64_t dim,
+                      std::optional<bool> field_nullable = std::nullopt);
 
     LoadResourceRequest
     IndexLoadResource(

--- a/internal/core/src/index/IndexFactory.h
+++ b/internal/core/src/index/IndexFactory.h
@@ -206,7 +206,8 @@ class IndexFactory {
         const std::map<std::string, std::string>& index_params,
         bool mmap_enable,
         int64_t num_rows,
-        const std::optional<storage::EntryStreamLoadInfo>& stream_load_info);
+        const std::optional<storage::EntryStreamLoadInfo>& stream_load_info,
+        std::optional<bool> field_nullable);
 
     template <typename T>
     ScalarIndexPtr<T>

--- a/internal/core/src/index/IndexFactory.h
+++ b/internal/core/src/index/IndexFactory.h
@@ -105,6 +105,16 @@ class IndexFactory {
         const std::map<std::string, std::string>& index_params,
         bool mmap_enable,
         int64_t num_rows,
+        bool field_nullable);
+
+    LoadResourceRequest
+    ScalarIndexLoadResource(
+        DataType field_type,
+        IndexVersion index_version,
+        uint64_t index_size_in_bytes,
+        const std::map<std::string, std::string>& index_params,
+        bool mmap_enable,
+        int64_t num_rows,
         const std::vector<std::string>& index_files,
         const storage::FileManagerContext& file_manager_context,
         std::optional<storage::EntryStreamLoadInfo>* stream_load_info = nullptr,

--- a/internal/core/src/index/InvertedIndexArrayTest.cpp
+++ b/internal/core/src/index/InvertedIndexArrayTest.cpp
@@ -29,6 +29,7 @@
 #include "exec/expression/ExprBatchTestUtils.h"
 #include "gtest/gtest.h"
 #include "index/InvertedIndexTantivy.h"
+#include "index/InvertedIndexUtil.h"
 #include "knowhere/comp/index_param.h"
 #include "pb/plan.pb.h"
 #include "pb/schema.pb.h"
@@ -354,12 +355,55 @@ INSTANTIATE_TYPED_TEST_SUITE_P(Naive, ArrayInvertedIndexTest, ElementType);
 
 namespace {
 
+TEST(InvertedIndexRowMaskUtil, LegacyOffsetsRoundTripThroughRoaring) {
+    const std::vector<size_t> legacy = {1, 3, 5, 7, 9};
+    roaring::Roaring offsets;
+
+    index::LoadLegacyOffsets(offsets,
+                             reinterpret_cast<const uint8_t*>(legacy.data()),
+                             legacy.size() * sizeof(size_t));
+
+    EXPECT_EQ(index::RoaringToLegacyOffsets(offsets), legacy);
+}
+
+TEST(InvertedIndexRowMaskUtil, MaterializesDenseRoaringRows) {
+    roaring::Roaring offsets;
+    offsets.addRange(0, 99);
+    offsets.runOptimize();
+
+    auto rows = index::RoaringToBitset(offsets, 100);
+    EXPECT_EQ(rows.count(), 99);
+    EXPECT_TRUE(rows[0]);
+    EXPECT_TRUE(rows[98]);
+    EXPECT_FALSE(rows[99]);
+
+    auto complement = index::RoaringToBitset(offsets, 100, /*inverted=*/true);
+    EXPECT_EQ(complement.count(), 1);
+    EXPECT_TRUE(complement[99]);
+}
+
+TEST(InvertedIndexRowMaskUtil, ClearsRoaringRowsFromCandidates) {
+    roaring::Roaring offsets;
+    offsets.add(1);
+    offsets.add(5);
+    TargetBitmap candidates(8, true);
+
+    index::ClearRoaringRows(offsets, candidates);
+
+    EXPECT_EQ(candidates.count(), 6);
+    EXPECT_FALSE(candidates[1]);
+    EXPECT_FALSE(candidates[5]);
+}
+
 class NullableInt64ArrayInvertedIndex
     : public index::InvertedIndexTantivy<int64_t> {
  public:
     void
     SetNullOffsets(std::vector<size_t> offsets) {
-        null_offset_ = std::move(offsets);
+        for (auto offset : offsets) {
+            AddNullOffset(offset);
+        }
+        OptimizeNullOffsets();
     }
 };
 

--- a/internal/core/src/index/InvertedIndexArrayTest.cpp
+++ b/internal/core/src/index/InvertedIndexArrayTest.cpp
@@ -382,6 +382,55 @@ TEST(InvertedIndexRowMaskUtil, MaterializesDenseRoaringRows) {
     EXPECT_TRUE(complement[99]);
 }
 
+TEST(InvertedIndexRowMaskUtil, SelectsContainerAwareMaterialization) {
+    constexpr size_t kRowCount = uint64_t{1} << 16;
+
+    roaring::Roaring sparse_offsets;
+    sparse_offsets.add(1);
+    sparse_offsets.add(4097);
+    sparse_offsets.runOptimize();
+    EXPECT_FALSE(
+        index::ShouldMaterializeRoaringAsBitset(sparse_offsets, kRowCount));
+
+    roaring::Roaring bitmap_offsets;
+    for (uint32_t offset = 0; offset < kRowCount; offset += 2) {
+        bitmap_offsets.add(offset);
+    }
+    bitmap_offsets.runOptimize();
+    EXPECT_TRUE(
+        index::ShouldMaterializeRoaringAsBitset(bitmap_offsets, kRowCount));
+
+    roaring::Roaring run_offsets;
+    run_offsets.addRange(1000, kRowCount - 1000);
+    run_offsets.runOptimize();
+    EXPECT_TRUE(
+        index::ShouldMaterializeRoaringAsBitset(run_offsets, kRowCount));
+
+    run_offsets.add(kRowCount);
+    EXPECT_FALSE(
+        index::ShouldMaterializeRoaringAsBitset(run_offsets, kRowCount));
+}
+
+TEST(InvertedIndexRowMaskUtil, MaterializesBitmapContainerRows) {
+    constexpr size_t kRowCount = uint64_t{1} << 16;
+    roaring::Roaring offsets;
+    for (uint32_t offset = 0; offset < kRowCount; offset += 2) {
+        offsets.add(offset);
+    }
+    offsets.runOptimize();
+
+    auto rows = index::RoaringToBitset(offsets, kRowCount);
+    auto complement =
+        index::RoaringToBitset(offsets, kRowCount, /*inverted=*/true);
+
+    EXPECT_EQ(rows.count(), kRowCount / 2);
+    EXPECT_EQ(complement.count(), kRowCount / 2);
+    for (size_t offset : {size_t{0}, size_t{1}, kRowCount - 2, kRowCount - 1}) {
+        EXPECT_EQ(rows[offset], offset % 2 == 0);
+        EXPECT_EQ(complement[offset], offset % 2 != 0);
+    }
+}
+
 TEST(InvertedIndexRowMaskUtil, ClearsRoaringRowsFromCandidates) {
     roaring::Roaring offsets;
     offsets.add(1);

--- a/internal/core/src/index/InvertedIndexTantivy.cpp
+++ b/internal/core/src/index/InvertedIndexTantivy.cpp
@@ -354,15 +354,15 @@ InvertedIndexTantivy<T>::IsNull() {
     tracer::AutoSpan span("InvertedIndexTantivy::IsNull",
                           tracer::GetRootSpan());
     int64_t count = Count();
-    TargetBitmap bitset(count);
 
     // For nested index, null rows don't have elements in the index,
     // so all elements in the index are valid (none are null).
     // null_offsets_ stores row offsets, not element offsets.
     if (is_nested_index_) {
-        return bitset;  // All false - no element is null
+        return TargetBitmap(count);  // All false - no element is null
     }
 
+    TargetBitmap bitset;
     auto fill_bitset = [this, count, &bitset]() {
         bitset = RoaringToBitset(null_offsets_, count);
     };

--- a/internal/core/src/index/InvertedIndexTantivy.cpp
+++ b/internal/core/src/index/InvertedIndexTantivy.cpp
@@ -383,17 +383,17 @@ InvertedIndexTantivy<T>::IsNotNull() {
     tracer::AutoSpan span("InvertedIndexTantivy::IsNotNull",
                           tracer::GetRootSpan());
     int64_t count = Count();
-    TargetBitmap bitset(count, true);
 
     // For nested index, null rows don't have elements in the index,
     // so all elements in the index are valid.
     // null_offsets_ stores row offsets, not element offsets.
     if (is_nested_index_) {
-        return bitset;  // All true - all elements are valid
+        return TargetBitmap(count, true);  // All elements are valid
     }
 
-    auto fill_bitset = [this, &bitset]() {
-        ClearRoaringRows(null_offsets_, bitset);
+    TargetBitmap bitset;
+    auto fill_bitset = [this, count, &bitset]() {
+        bitset = RoaringToBitset(null_offsets_, count, /*inverted=*/true);
     };
 
     if (is_growing_) {

--- a/internal/core/src/index/InvertedIndexTantivy.cpp
+++ b/internal/core/src/index/InvertedIndexTantivy.cpp
@@ -131,6 +131,10 @@ InvertedIndexTantivy<T>::~InvertedIndexTantivy() {
 template <typename T>
 void
 InvertedIndexTantivy<T>::finish() {
+    {
+        std::unique_lock<folly::SharedMutex> lock(mutex_);
+        OptimizeNullOffsets();
+    }
     wrapper_->finish();
 }
 
@@ -138,11 +142,12 @@ template <typename T>
 BinarySet
 InvertedIndexTantivy<T>::Serialize(const Config& config) {
     std::shared_lock<folly::SharedMutex> lock(mutex_);
-    auto index_valid_data_length = null_offset_.size() * sizeof(size_t);
+    auto legacy_offsets = RoaringToLegacyOffsets(null_offsets_);
+    auto index_valid_data_length = legacy_offsets.size() * sizeof(size_t);
     std::shared_ptr<uint8_t[]> index_valid_data(
         new uint8_t[index_valid_data_length]);
     milvus::fastmem::FastMemcpy(
-        index_valid_data.get(), null_offset_.data(), index_valid_data_length);
+        index_valid_data.get(), legacy_offsets.data(), index_valid_data_length);
     lock.unlock();
     BinarySet res_set;
     if (index_valid_data_length > 0) {
@@ -257,8 +262,7 @@ void
 InvertedIndexTantivy<T>::LoadIndexMetas(
     const std::vector<std::string>& index_files, const Config& config) {
     auto fill_null_offsets = [&](const uint8_t* data, int64_t size) {
-        null_offset_.resize((size_t)size / sizeof(size_t));
-        milvus::fastmem::FastMemcpy(null_offset_.data(), data, (size_t)size);
+        LoadLegacyOffsets(null_offsets_, data, size);
     };
     auto null_offset_file_itr = std::find_if(
         index_files.begin(), index_files.end(), [&](const std::string& file) {
@@ -354,17 +358,13 @@ InvertedIndexTantivy<T>::IsNull() {
 
     // For nested index, null rows don't have elements in the index,
     // so all elements in the index are valid (none are null).
-    // null_offset_ stores row offsets, not element offsets.
+    // null_offsets_ stores row offsets, not element offsets.
     if (is_nested_index_) {
         return bitset;  // All false - no element is null
     }
 
     auto fill_bitset = [this, count, &bitset]() {
-        auto end =
-            std::lower_bound(null_offset_.begin(), null_offset_.end(), count);
-        for (auto iter = null_offset_.begin(); iter != end; ++iter) {
-            bitset.set(*iter);
-        }
+        bitset = RoaringToBitset(null_offsets_, count);
     };
 
     if (is_growing_) {
@@ -387,17 +387,13 @@ InvertedIndexTantivy<T>::IsNotNull() {
 
     // For nested index, null rows don't have elements in the index,
     // so all elements in the index are valid.
-    // null_offset_ stores row offsets, not element offsets.
+    // null_offsets_ stores row offsets, not element offsets.
     if (is_nested_index_) {
         return bitset;  // All true - all elements are valid
     }
 
-    auto fill_bitset = [this, count, &bitset]() {
-        auto end =
-            std::lower_bound(null_offset_.begin(), null_offset_.end(), count);
-        for (auto iter = null_offset_.begin(); iter != end; ++iter) {
-            bitset.reset(*iter);
-        }
+    auto fill_bitset = [this, &bitset]() {
+        ClearRoaringRows(null_offsets_, bitset);
     };
 
     if (is_growing_) {
@@ -445,12 +441,8 @@ InvertedIndexTantivy<T>::NotIn(size_t n, const T* values) {
     // The expression is "not" in, so we flip the bit.
     bitset.flip();
 
-    auto fill_bitset = [this, count, &bitset]() {
-        auto end =
-            std::lower_bound(null_offset_.begin(), null_offset_.end(), count);
-        for (auto iter = null_offset_.begin(); iter != end; ++iter) {
-            bitset.reset(*iter);
-        }
+    auto fill_bitset = [this, &bitset]() {
+        ClearRoaringRows(null_offsets_, bitset);
     };
 
     if (is_growing_) {
@@ -645,13 +637,6 @@ template <typename T>
 void
 InvertedIndexTantivy<T>::BuildWithFieldData(
     const std::vector<std::shared_ptr<FieldDataBase>>& field_datas) {
-    if (schema_.nullable()) {
-        int64_t total = 0;
-        for (const auto& data : field_datas) {
-            total += data->get_null_count();
-        }
-        null_offset_.reserve(total);
-    }
     switch (schema_.data_type()) {
         case proto::schema::DataType::Bool:
         case proto::schema::DataType::Int8:
@@ -672,7 +657,7 @@ InvertedIndexTantivy<T>::BuildWithFieldData(
                         auto n = data->get_num_rows();
                         for (int i = 0; i < n; i++) {
                             if (!data->is_valid(i)) {
-                                null_offset_.push_back(offset);
+                                AddNullOffset(offset);
                             }
                             wrapper_->add_array_data<T>(
                                 static_cast<const T*>(data->RawValue(i)),
@@ -695,7 +680,7 @@ InvertedIndexTantivy<T>::BuildWithFieldData(
                     if (schema_.nullable()) {
                         for (int i = 0; i < n; i++) {
                             if (!data->is_valid(i)) {
-                                null_offset_.push_back(offset);
+                                AddNullOffset(offset);
                             }
                             wrapper_
                                 ->add_array_data_by_single_segment_writer<T>(
@@ -731,6 +716,7 @@ InvertedIndexTantivy<T>::BuildWithFieldData(
                       fmt::format("Inverted index not supported on {}",
                                   schema_.data_type()));
     }
+    OptimizeNullOffsets();
 }
 
 template <typename T>
@@ -747,7 +733,7 @@ InvertedIndexTantivy<T>::build_index_for_array(
         auto array_column = static_cast<const Array*>(data->Data());
         for (int64_t i = 0; i < n; i++) {
             if (schema_.nullable() && !data->is_valid(i)) {
-                null_offset_.push_back(offset);
+                AddNullOffset(offset);
             }
             auto length = data->is_valid(i) ? array_column[i].length() : 0;
             if (!inverted_index_single_segment_) {
@@ -777,7 +763,7 @@ InvertedIndexTantivy<std::string>::build_index_for_array(
         auto array_column = static_cast<const Array*>(data->Data());
         for (int64_t i = 0; i < n; i++) {
             if (schema_.nullable() && !data->is_valid(i)) {
-                null_offset_.push_back(offset);
+                AddNullOffset(offset);
             } else {
                 Assert(IsStringDataType(array_column[i].get_element_type()));
                 Assert(IsStringDataType(
@@ -815,7 +801,7 @@ InvertedIndexTantivy<T>::build_index_for_array_nested(
         for (int64_t i = 0; i < n; i++, row_offset++) {
             if (schema_.nullable() && !data->is_valid(i)) {
                 // Record null row offset, no elements to add
-                null_offset_.push_back(row_offset);
+                AddNullOffset(row_offset);
                 continue;
             }
             // RawValue maps logical->physical so compact nullable array
@@ -843,7 +829,7 @@ InvertedIndexTantivy<std::string>::build_index_for_array_nested(
         for (int64_t i = 0; i < n; i++, row_offset++) {
             if (schema_.nullable() && !data->is_valid(i)) {
                 // Record null row offset, no elements to add
-                null_offset_.push_back(row_offset);
+                AddNullOffset(row_offset);
                 continue;
             }
             // RawValue maps logical->physical so compact nullable array
@@ -893,7 +879,7 @@ InvertedIndexTantivy<T>::WriteEntries(storage::IndexEntryWriter* writer) {
     }
 
     std::shared_lock<folly::SharedMutex> lock(mutex_);
-    bool has_null = !null_offset_.empty();
+    bool has_null = !null_offsets_.isEmpty();
     lock.unlock();
 
     writer->PutMeta("file_names", file_names);
@@ -910,9 +896,10 @@ InvertedIndexTantivy<T>::WriteEntries(storage::IndexEntryWriter* writer) {
 
     lock.lock();
     if (has_null) {
+        auto legacy_offsets = RoaringToLegacyOffsets(null_offsets_);
         writer->WriteEntry(INDEX_NULL_OFFSET_FILE_NAME,
-                           null_offset_.data(),
-                           null_offset_.size() * sizeof(size_t));
+                           legacy_offsets.data(),
+                           legacy_offsets.size() * sizeof(size_t));
     }
     lock.unlock();
 }
@@ -940,10 +927,8 @@ InvertedIndexTantivy<T>::LoadEntries(storage::IndexEntryReader& reader,
 
     if (has_null) {
         auto null_entry = reader.ReadEntry(INDEX_NULL_OFFSET_FILE_NAME);
-        null_offset_.resize(null_entry.data.size() / sizeof(size_t));
-        milvus::fastmem::FastMemcpy(null_offset_.data(),
-                                    null_entry.data.data(),
-                                    null_entry.data.size());
+        LoadLegacyOffsets(
+            null_offsets_, null_entry.data.data(), null_entry.data.size());
     }
 
     auto load_in_mmap =

--- a/internal/core/src/index/InvertedIndexTantivy.h
+++ b/internal/core/src/index/InvertedIndexTantivy.h
@@ -15,11 +15,14 @@
 #include <stdint.h>
 #include <cstddef>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
+
+#include <roaring/roaring.hh>
 
 #include "nlohmann/json_fwd.hpp"
 
@@ -33,6 +36,7 @@
 #include "common/protobuf_utils.h"
 #include "fmt/core.h"
 #include "index/IndexStats.h"
+#include "index/InvertedIndexUtil.h"
 #include "index/Meta.h"
 #include "index/ScalarIndex.h"
 #include "pb/plan.pb.h"
@@ -229,8 +233,7 @@ class InvertedIndexTantivy : public ScalarIndex<T> {
         // Tantivy index size
         total += wrapper_->index_size_bytes();
 
-        // null_offset_: vector<size_t>
-        total += null_offset_.capacity() * sizeof(size_t);
+        total += RoaringMemoryBytes(null_offsets_);
 
         this->cached_byte_size_ = total;
     }
@@ -366,6 +369,20 @@ class InvertedIndexTantivy : public ScalarIndex<T> {
     virtual nlohmann::json
     BuildTantivyMeta(const std::vector<std::string>& file_names, bool has_null);
 
+    void
+    AddNullOffset(size_t offset) {
+        AssertInfo(offset <= std::numeric_limits<uint32_t>::max(),
+                   "row offset {} exceeds uint32 range",
+                   offset);
+        null_offsets_.add(static_cast<uint32_t>(offset));
+    }
+
+    void
+    OptimizeNullOffsets() {
+        null_offsets_.runOptimize();
+        null_offsets_.shrinkToFit();
+    }
+
  protected:
     std::shared_ptr<TantivyIndexWrapper> wrapper_;
     TantivyDataType d_type_;
@@ -382,9 +399,10 @@ class InvertedIndexTantivy : public ScalarIndex<T> {
     DiskFileManagerPtr disk_file_manager_;
 
     folly::SharedMutexWritePriority mutex_{};
-    // all data need to be built to align the offset
-    // so need to store null_offset_ in inverted index additionally
-    std::vector<size_t> null_offset_{};
+    // Tantivy does not retain null rows, so keep their row ids separately.
+    // CRoaring adapts each container between sparse arrays, dense bitmaps and
+    // runs, avoiding the 8-byte-per-row overhead of std::vector<size_t>.
+    roaring::Roaring null_offsets_{};
 
     // `inverted_index_single_segment_` is used to control whether to build tantivy index with single segment.
     //

--- a/internal/core/src/index/InvertedIndexUtil.h
+++ b/internal/core/src/index/InvertedIndexUtil.h
@@ -75,10 +75,54 @@ RoaringToLegacyOffsets(const roaring::Roaring& offsets) {
     return legacy;
 }
 
+inline bool
+ShouldMaterializeRoaringAsBitset(const roaring::Roaring& offsets,
+                                 size_t row_count) {
+    if (offsets.isEmpty() || row_count == 0) {
+        return false;
+    }
+
+    roaring::api::roaring_statistics_t stats{};
+    roaring::api::roaring_bitmap_statistics(&offsets.roaring, &stats);
+    // The dense converter may resize its bitset to cover the largest value.
+    // Keep the iterator path when the row mask extends beyond this result so
+    // out-of-range offsets retain the existing ignore semantics.
+    if (static_cast<uint64_t>(stats.max_value) >= row_count) {
+        return false;
+    }
+
+    const auto word_count =
+        row_count / 64 + static_cast<size_t>(row_count % 64 != 0);
+    const auto dense_container_values =
+        static_cast<uint64_t>(stats.n_values_run_containers) +
+        stats.n_values_bitset_containers;
+    // Materializing run and bitmap containers avoids more scattered bit
+    // updates than the extra word-wise flip needed by the inverted result.
+    // Array-container values stay on the sparse iterator path.
+    return dense_container_values > word_count;
+}
+
 inline TargetBitmap
 RoaringToBitset(const roaring::Roaring& offsets,
                 size_t row_count,
                 bool inverted = false) {
+    if (ShouldMaterializeRoaringAsBitset(offsets, row_count)) {
+        TargetBitmap result(row_count);
+        const auto word_count = result.size_in_elements();
+        // The selection predicate guarantees max(offsets) < row_count, so the
+        // converter cannot grow or reallocate this borrowed target buffer.
+        roaring::api::bitset_t bitset_view{
+            result.data(), word_count, word_count};
+        const auto converted = roaring::api::roaring_bitmap_to_bitset(
+            &offsets.roaring, &bitset_view);
+        AssertInfo(converted,
+                   "failed to materialize roaring row mask as a bitset");
+        if (inverted) {
+            result.flip();
+        }
+        return result;
+    }
+
     TargetBitmap result(row_count, inverted);
     for (auto offset : offsets) {
         if (offset >= row_count) {

--- a/internal/core/src/index/InvertedIndexUtil.h
+++ b/internal/core/src/index/InvertedIndexUtil.h
@@ -11,7 +11,86 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <limits>
+#include <optional>
+#include <vector>
+
+#include <roaring/roaring.hh>
+
+#include "common/EasyAssert.h"
+#include "common/Types.h"
+
 namespace milvus::index {
+
+inline size_t
+RoaringMemoryBytes(const roaring::Roaring& offsets) {
+    roaring::api::roaring_statistics_t stats{};
+    roaring::api::roaring_bitmap_statistics(&offsets.roaring, &stats);
+    const auto container_bytes =
+        static_cast<size_t>(stats.n_bytes_array_containers) +
+        stats.n_bytes_run_containers + stats.n_bytes_bitset_containers;
+    return sizeof(roaring::Roaring) +
+           std::max(container_bytes, offsets.getSizeInBytes());
+}
+
+inline void
+LoadLegacyOffsets(roaring::Roaring& offsets, const uint8_t* data, size_t size) {
+    AssertInfo(size % sizeof(size_t) == 0,
+               "legacy offset payload size {} is not aligned to size_t",
+               size);
+
+    offsets = roaring::Roaring();
+    const auto count = size / sizeof(size_t);
+    for (size_t i = 0; i < count; ++i) {
+        size_t offset;
+        std::memcpy(&offset, data + i * sizeof(size_t), sizeof(size_t));
+        AssertInfo(offset <= std::numeric_limits<uint32_t>::max(),
+                   "row offset {} exceeds uint32 range",
+                   offset);
+        offsets.add(static_cast<uint32_t>(offset));
+    }
+    offsets.runOptimize();
+    offsets.shrinkToFit();
+}
+
+inline std::vector<size_t>
+RoaringToLegacyOffsets(const roaring::Roaring& offsets) {
+    std::vector<size_t> legacy;
+    legacy.reserve(static_cast<size_t>(offsets.cardinality()));
+    for (auto offset : offsets) {
+        legacy.push_back(offset);
+    }
+    return legacy;
+}
+
+inline TargetBitmap
+RoaringToBitset(const roaring::Roaring& offsets,
+                size_t row_count,
+                bool inverted = false) {
+    TargetBitmap result(row_count, inverted);
+    for (auto offset : offsets) {
+        if (offset >= row_count) {
+            break;
+        }
+        result.set(offset, !inverted);
+    }
+    return result;
+}
+
+inline void
+ClearRoaringRows(const roaring::Roaring& offsets, TargetBitmap& target) {
+    for (auto offset : offsets) {
+        if (offset >= target.size()) {
+            break;
+        }
+        target.reset(offset);
+    }
+}
+
 inline void
 apply_hits_with_filter(milvus::TargetBitmap& bitset,
                        const std::function<bool(size_t /* offset */)>& filter) {

--- a/internal/core/src/index/InvertedIndexUtil.h
+++ b/internal/core/src/index/InvertedIndexUtil.h
@@ -45,13 +45,21 @@ LoadLegacyOffsets(roaring::Roaring& offsets, const uint8_t* data, size_t size) {
 
     offsets = roaring::Roaring();
     const auto count = size / sizeof(size_t);
+    // Legacy payload is a sorted size_t[] on disk; roaring stores uint32_t, so
+    // convert once into a dense buffer and bulk-insert with addMany instead of
+    // per-element Roaring::add (each add does a container lookup).
+    std::vector<uint32_t> buf;
+    buf.reserve(count);
     for (size_t i = 0; i < count; ++i) {
         size_t offset;
         std::memcpy(&offset, data + i * sizeof(size_t), sizeof(size_t));
         AssertInfo(offset <= std::numeric_limits<uint32_t>::max(),
                    "row offset {} exceeds uint32 range",
                    offset);
-        offsets.add(static_cast<uint32_t>(offset));
+        buf.push_back(static_cast<uint32_t>(offset));
+    }
+    if (!buf.empty()) {
+        offsets.addMany(buf.size(), buf.data());
     }
     offsets.runOptimize();
     offsets.shrinkToFit();

--- a/internal/core/src/index/JsonFlatIndex.cpp
+++ b/internal/core/src/index/JsonFlatIndex.cpp
@@ -37,7 +37,7 @@ JsonFlatIndex::build_index_for_json(
         auto n = data->get_num_rows();
         for (int i = 0; i < n; i++) {
             if (schema_.nullable() && !data->is_valid(i)) {
-                null_offset_.push_back(offset);
+                AddNullOffset(offset);
                 wrapper_->add_json_array_data(nullptr, 0, offset++);
                 continue;
             }

--- a/internal/core/src/index/JsonFlatIndex.h
+++ b/internal/core/src/index/JsonFlatIndex.h
@@ -780,7 +780,7 @@ class JsonFlatIndex : public InvertedIndexTantivy<std::string> {
 
     void
     finish() {
-        this->wrapper_->finish();
+        InvertedIndexTantivy<std::string>::finish();
     }
 
     void
@@ -800,6 +800,6 @@ JsonFlatIndexQueryExecutor<T>::JsonFlatIndexQueryExecutor(
     json_path_ = json_path;
     use_comparable_value_mask_ = use_comparable_value_mask;
     this->wrapper_ = json_flat_index.wrapper_;
-    this->null_offset_ = json_flat_index.null_offset_;
+    this->null_offsets_ = json_flat_index.null_offsets_;
 }
 }  // namespace milvus::index

--- a/internal/core/src/index/JsonHybridScalarIndex.h
+++ b/internal/core/src/index/JsonHybridScalarIndex.h
@@ -67,7 +67,6 @@ class JsonHybridScalarIndex : public HybridScalarIndex<T> {
         non_exist_offsets_ = std::move(result.non_exist_offsets);
 
         auto n = result.field_data->get_num_rows();
-        non_exist_row_count_ = n;
         std::set<T> distinct_vals;
         for (size_t i = 0; i < n; ++i) {
             if (result.field_data->is_valid(i)) {
@@ -84,7 +83,7 @@ class JsonHybridScalarIndex : public HybridScalarIndex<T> {
         this->BuildInternal({result.field_data});
 
         this->is_built_ = true;
-        BuildExistsBitset(non_exist_row_count_);
+        BuildExistsBitset(n);
         this->ComputeByteSize();
     }
 
@@ -123,7 +122,6 @@ class JsonHybridScalarIndex : public HybridScalarIndex<T> {
         non_exist_offsets_ = std::move(result.non_exist_offsets);
 
         auto n = result.field_data->get_num_rows();
-        non_exist_row_count_ = n;
         // Do cardinality counting that respects is_valid(), unlike the base
         // class SelectBuildTypeForPrimitiveType which counts invalid rows too.
         std::set<T> distinct_vals;
@@ -142,7 +140,7 @@ class JsonHybridScalarIndex : public HybridScalarIndex<T> {
         this->BuildInternal({result.field_data});
 
         this->is_built_ = true;
-        BuildExistsBitset(non_exist_row_count_);
+        BuildExistsBitset(n);
         this->ComputeByteSize();
     }
 
@@ -184,10 +182,10 @@ class JsonHybridScalarIndex : public HybridScalarIndex<T> {
         }
         LOG_INFO("LoadEntries JsonHybridScalarIndex done, has_non_exist: {}",
                  has_non_exist);
-        non_exist_row_count_ =
+        const auto row_count =
             GetValueFromConfig<int64_t>(config, INDEX_NUM_ROWS_KEY)
                 .value_or(this->Count());
-        BuildExistsBitset(non_exist_row_count_);
+        BuildExistsBitset(row_count);
         ComputeByteSize();
     }
 
@@ -209,7 +207,6 @@ class JsonHybridScalarIndex : public HybridScalarIndex<T> {
     proto::schema::FieldSchema json_schema_;
     storage::MemFileManagerImplPtr json_file_manager_;
     roaring::Roaring non_exist_offsets_;
-    size_t non_exist_row_count_{0};
     TargetBitmap exists_bitset_;
 };
 

--- a/internal/core/src/index/JsonHybridScalarIndex.h
+++ b/internal/core/src/index/JsonHybridScalarIndex.h
@@ -67,7 +67,7 @@ class JsonHybridScalarIndex : public HybridScalarIndex<T> {
         non_exist_offsets_ = std::move(result.non_exist_offsets);
 
         auto n = result.field_data->get_num_rows();
-        int64_t total_rows = n;
+        non_exist_row_count_ = n;
         std::set<T> distinct_vals;
         for (size_t i = 0; i < n; ++i) {
             if (result.field_data->is_valid(i)) {
@@ -84,8 +84,8 @@ class JsonHybridScalarIndex : public HybridScalarIndex<T> {
         this->BuildInternal({result.field_data});
 
         this->is_built_ = true;
+        BuildExistsBitset(non_exist_row_count_);
         this->ComputeByteSize();
-        BuildExistsBitset(total_rows);
     }
 
     void
@@ -123,7 +123,7 @@ class JsonHybridScalarIndex : public HybridScalarIndex<T> {
         non_exist_offsets_ = std::move(result.non_exist_offsets);
 
         auto n = result.field_data->get_num_rows();
-        int64_t total_rows = n;
+        non_exist_row_count_ = n;
         // Do cardinality counting that respects is_valid(), unlike the base
         // class SelectBuildTypeForPrimitiveType which counts invalid rows too.
         std::set<T> distinct_vals;
@@ -142,8 +142,8 @@ class JsonHybridScalarIndex : public HybridScalarIndex<T> {
         this->BuildInternal({result.field_data});
 
         this->is_built_ = true;
+        BuildExistsBitset(non_exist_row_count_);
         this->ComputeByteSize();
-        BuildExistsBitset(total_rows);
     }
 
     TargetBitmap
@@ -152,15 +152,23 @@ class JsonHybridScalarIndex : public HybridScalarIndex<T> {
     }
 
     void
+    ComputeByteSize() override {
+        HybridScalarIndex<T>::ComputeByteSize();
+        this->cached_byte_size_ += RoaringMemoryBytes(non_exist_offsets_);
+        this->cached_byte_size_ += exists_bitset_.size_in_bytes();
+    }
+
+    void
     WriteEntries(storage::IndexEntryWriter* writer) override {
         HybridScalarIndex<T>::WriteEntries(writer);
 
-        bool has_non_exist = !non_exist_offsets_.empty();
+        bool has_non_exist = !non_exist_offsets_.isEmpty();
         writer->PutMeta("has_non_exist", has_non_exist);
         if (has_non_exist) {
+            auto legacy_offsets = RoaringToLegacyOffsets(non_exist_offsets_);
             writer->WriteEntry(INDEX_NON_EXIST_OFFSET_FILE_NAME,
-                               non_exist_offsets_.data(),
-                               non_exist_offsets_.size() * sizeof(size_t));
+                               legacy_offsets.data(),
+                               legacy_offsets.size() * sizeof(size_t));
         }
     }
 
@@ -172,13 +180,15 @@ class JsonHybridScalarIndex : public HybridScalarIndex<T> {
         bool has_non_exist = reader.GetMeta<bool>("has_non_exist", false);
         if (has_non_exist) {
             auto e = reader.ReadEntry(INDEX_NON_EXIST_OFFSET_FILE_NAME);
-            non_exist_offsets_.resize(e.data.size() / sizeof(size_t));
-            milvus::fastmem::FastMemcpy(
-                non_exist_offsets_.data(), e.data.data(), e.data.size());
+            LoadLegacyOffsets(non_exist_offsets_, e.data.data(), e.data.size());
         }
         LOG_INFO("LoadEntries JsonHybridScalarIndex done, has_non_exist: {}",
                  has_non_exist);
-        BuildExistsBitset(this->Count());
+        non_exist_row_count_ =
+            GetValueFromConfig<int64_t>(config, INDEX_NUM_ROWS_KEY)
+                .value_or(this->Count());
+        BuildExistsBitset(non_exist_row_count_);
+        ComputeByteSize();
     }
 
     JsonCastType
@@ -188,14 +198,9 @@ class JsonHybridScalarIndex : public HybridScalarIndex<T> {
 
  private:
     void
-    BuildExistsBitset(int64_t count) {
-        exists_bitset_ = TargetBitmap(count, true);
-        for (auto offset : non_exist_offsets_) {
-            if (static_cast<int64_t>(offset) >= count) {
-                break;
-            }
-            exists_bitset_.reset(offset);
-        }
+    BuildExistsBitset(size_t count) {
+        exists_bitset_ =
+            RoaringToBitset(non_exist_offsets_, count, /*inverted=*/true);
     }
 
     JsonCastType cast_type_;
@@ -203,7 +208,8 @@ class JsonHybridScalarIndex : public HybridScalarIndex<T> {
     JsonCastFunction cast_function_;
     proto::schema::FieldSchema json_schema_;
     storage::MemFileManagerImplPtr json_file_manager_;
-    std::vector<size_t> non_exist_offsets_;
+    roaring::Roaring non_exist_offsets_;
+    size_t non_exist_row_count_{0};
     TargetBitmap exists_bitset_;
 };
 

--- a/internal/core/src/index/JsonIndexBuilder.cpp
+++ b/internal/core/src/index/JsonIndexBuilder.cpp
@@ -10,12 +10,14 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include <simdjson.h>
+#include <limits>
 #include <string>
 #include <string_view>
 #include <type_traits>
 
 #include "common/FieldData.h"
 #include "common/FieldDataInterface.h"
+#include "common/EasyAssert.h"
 #include "common/Json.h"
 #include "common/JsonCastType.h"
 #include "common/JsonUtils.h"
@@ -197,7 +199,8 @@ ConvertJsonToTypedFieldData(
     // Use FixedVector to avoid std::vector<bool> specialization
     FixedVector<T> values(total_rows);
     std::vector<uint8_t> valid_data((total_rows + 7) / 8, 0);
-    std::vector<size_t> non_exist_offsets;
+    roaring::Roaring non_exist_offsets;
+    roaring::BulkContext non_exist_context;
 
     ProcessJsonFieldData<T>(
         json_field_datas,
@@ -213,8 +216,12 @@ ConvertJsonToTypedFieldData(
         },
         [](int64_t) {},
         // non_exist_adder: track offsets where the path truly doesn't exist
-        [&non_exist_offsets](int64_t offset) {
-            non_exist_offsets.push_back(offset);
+        [&non_exist_offsets, &non_exist_context](int64_t offset) {
+            AssertInfo(offset <= std::numeric_limits<uint32_t>::max(),
+                       "JSON row offset {} exceeds uint32 range",
+                       offset);
+            non_exist_offsets.addBulk(non_exist_context,
+                                      static_cast<uint32_t>(offset));
         },
         [](const Json&, const std::string&, simdjson::error_code) {});
 
@@ -222,6 +229,9 @@ ConvertJsonToTypedFieldData(
     FieldDataBase* base_ptr = field_data.get();
     base_ptr->FillFieldData(
         data_ptr, valid_data.data(), (ssize_t)total_rows, (ssize_t)0);
+
+    non_exist_offsets.runOptimize();
+    non_exist_offsets.shrinkToFit();
 
     return JsonToTypedResult{
         .field_data = field_data,

--- a/internal/core/src/index/JsonIndexBuilder.h
+++ b/internal/core/src/index/JsonIndexBuilder.h
@@ -16,6 +16,8 @@
 #include <string>
 #include <vector>
 
+#include <roaring/roaring.hh>
+
 #include "common/FieldDataInterface.h"
 #include "common/Json.h"
 #include "common/JsonCastFunction.h"
@@ -55,7 +57,7 @@ struct JsonToTypedResult {
     // in field_data — rows that exist but fail to cast are NOT included.
     // Used for EXISTS queries: Exists() should return true for rows where
     // the path exists, even if the value can't be cast to the index type.
-    std::vector<size_t> non_exist_offsets;
+    roaring::Roaring non_exist_offsets;
 };
 
 // Convert JSON field data into typed FieldData by extracting values at

--- a/internal/core/src/index/JsonPathIndexTest.cpp
+++ b/internal/core/src/index/JsonPathIndexTest.cpp
@@ -10,6 +10,7 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include <gtest/gtest.h>
+#include <roaring/roaring.hh>
 #include <simdjson.h>
 
 #include <algorithm>
@@ -205,6 +206,34 @@ TEST(JsonPathIndexTest, LoadResourceSkipsRowMaskForNonNullableScalarField) {
 
     EXPECT_EQ(non_nullable.final_memory_cost, 0);
     EXPECT_EQ(nullable.final_memory_cost, kOneMaskBudget);
+}
+
+TEST(JsonPathIndexTest, LoadResourceCoversSparseRoaringRowMask) {
+    constexpr int64_t kRowCount = 8192;
+
+    roaring::Roaring sparse_offsets;
+    for (uint32_t row = 0; row < kRowCount; row += 2) {
+        sparse_offsets.add(row);
+    }
+    sparse_offsets.runOptimize();
+    sparse_offsets.shrinkToFit();
+
+    std::map<std::string, std::string> params{
+        {INDEX_TYPE, INVERTED_INDEX_TYPE},
+        {SCALAR_INDEX_ENGINE_VERSION, "3"},
+    };
+    auto request = IndexFactory::GetInstance().ScalarIndexLoadResource(
+        DataType::INT64,
+        0,
+        0,
+        params,
+        true,
+        kRowCount,
+        /*field_nullable=*/true);
+    const auto actual_mask_bytes = RoaringMemoryBytes(sparse_offsets);
+
+    EXPECT_GE(request.final_memory_cost, actual_mask_bytes);
+    EXPECT_GE(request.max_memory_cost, actual_mask_bytes);
 }
 
 TEST(JsonPathIndexTest, ConvertDouble_PathNotExist) {

--- a/internal/core/src/index/JsonPathIndexTest.cpp
+++ b/internal/core/src/index/JsonPathIndexTest.cpp
@@ -189,6 +189,24 @@ TEST(JsonPathIndexTest, LoadResourceIncludesResidentRoaringRowMasks) {
     EXPECT_EQ(json.final_memory_cost, 2 * kOneMaskBudget + kRowCount / 8);
 }
 
+TEST(JsonPathIndexTest, LoadResourceSkipsRowMaskForNonNullableScalarField) {
+    constexpr int64_t kRowCount = 65536;
+    constexpr uint64_t kIndexSize = 1024;
+    constexpr uint64_t kOneMaskBudget = kRowCount / 4;
+
+    std::map<std::string, std::string> params{
+        {INDEX_TYPE, INVERTED_INDEX_TYPE},
+        {SCALAR_INDEX_ENGINE_VERSION, "3"},
+    };
+    auto non_nullable = IndexFactory::GetInstance().ScalarIndexLoadResource(
+        DataType::INT64, 0, kIndexSize, params, true, kRowCount, false);
+    auto nullable = IndexFactory::GetInstance().ScalarIndexLoadResource(
+        DataType::INT64, 0, kIndexSize, params, true, kRowCount, true);
+
+    EXPECT_EQ(non_nullable.final_memory_cost, 0);
+    EXPECT_EQ(nullable.final_memory_cost, kOneMaskBudget);
+}
+
 TEST(JsonPathIndexTest, ConvertDouble_PathNotExist) {
     auto json_fd = MakeJsonFieldData({
         R"({"b": 1})",    // path /a doesn't exist

--- a/internal/core/src/index/JsonPathIndexTest.cpp
+++ b/internal/core/src/index/JsonPathIndexTest.cpp
@@ -13,10 +13,12 @@
 #include <simdjson.h>
 
 #include <algorithm>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "common/Consts.h"
 #include "common/FieldData.h"
 #include "common/Json.h"
 #include "common/JsonCastType.h"
@@ -99,7 +101,92 @@ TEST(JsonPathIndexTest, ConvertDouble_NormalExtraction) {
     for (int i = 0; i < 3; i++) {
         EXPECT_TRUE(fd->is_valid(i));
     }
-    EXPECT_TRUE(result.non_exist_offsets.empty());
+    EXPECT_TRUE(result.non_exist_offsets.isEmpty());
+}
+
+TEST(JsonPathIndexTest, DenseMissingRowsUseCompactRoaringStorage) {
+    constexpr size_t kRowCount = 100000;
+    std::vector<std::string> raw;
+    raw.reserve(kRowCount);
+    for (size_t row = 0; row < kRowCount; ++row) {
+        raw.push_back(row % 100 == 0 ? R"({"a": 1.0})" : R"({"b": 1.0})");
+    }
+
+    auto result = ConvertJsonToTypedFieldData<double>(
+        {MakeJsonFieldData(raw)},
+        MakeJsonSchema(),
+        "/a",
+        JsonCastType::FromString("DOUBLE"),
+        JsonCastFunction::FromString("unknown"));
+
+    EXPECT_EQ(result.non_exist_offsets.cardinality(), 99000);
+    EXPECT_LT(RoaringMemoryBytes(result.non_exist_offsets), kRowCount / 4);
+}
+
+TEST(JsonPathIndexTest, SortExistsKeepsDenseExistsBitmap) {
+    constexpr size_t kRowCount = 100000;
+    std::vector<std::string> raw;
+    raw.reserve(kRowCount);
+    for (size_t row = 0; row < kRowCount; ++row) {
+        raw.push_back(row % 100 == 0 ? R"({"a": 1.0})" : R"({"b": 1.0})");
+    }
+
+    const auto cast_type = JsonCastType::FromString("DOUBLE");
+    const auto cast_function = JsonCastFunction::FromString("unknown");
+    auto typed = ConvertJsonToTypedFieldData<double>({MakeJsonFieldData(raw)},
+                                                     MakeJsonSchema(),
+                                                     "/a",
+                                                     cast_type,
+                                                     cast_function);
+    ScalarIndexSort<double> base_index(
+        MakeJsonCastContext(MakeTestContext(), cast_type));
+    base_index.BuildWithFieldData({typed.field_data});
+
+    JsonScalarIndexWrapper<double, ScalarIndexSort<double>> index(
+        cast_type, "/a", cast_function, MakeJsonSchema(), MakeTestContext());
+    index.BuildWithFieldData({MakeJsonFieldData(raw)});
+
+    const auto bytes_before_exists = index.ByteSize();
+    const auto expected_exists_bytes =
+        TargetBitmap(kRowCount, true).size_in_bytes();
+    EXPECT_EQ(bytes_before_exists,
+              base_index.ByteSize() +
+                  RoaringMemoryBytes(typed.non_exist_offsets) +
+                  expected_exists_bytes);
+
+    auto first_exists = index.Exists();
+    auto second_exists = index.Exists();
+
+    EXPECT_EQ(first_exists.count(), kRowCount / 100);
+    ASSERT_EQ(second_exists.size(), first_exists.size());
+    for (size_t row = 0; row < first_exists.size(); ++row) {
+        EXPECT_EQ(second_exists[row], first_exists[row]) << "row=" << row;
+    }
+    EXPECT_EQ(index.ByteSize(), bytes_before_exists);
+}
+
+TEST(JsonPathIndexTest, LoadResourceIncludesResidentRoaringRowMasks) {
+    constexpr int64_t kRowCount = 65536;
+    constexpr uint64_t kIndexSize = 1024;
+    constexpr uint64_t kOneMaskBudget = kRowCount / 4;
+
+    std::map<std::string, std::string> plain_params{
+        {INDEX_TYPE, INVERTED_INDEX_TYPE},
+        {SCALAR_INDEX_ENGINE_VERSION, "3"},
+    };
+    auto plain = IndexFactory::GetInstance().ScalarIndexLoadResource(
+        DataType::INT64, 0, kIndexSize, plain_params, true, kRowCount);
+    EXPECT_EQ(plain.final_memory_cost, kOneMaskBudget);
+
+    std::map<std::string, std::string> json_params{
+        {INDEX_TYPE, INVERTED_INDEX_TYPE},
+        {SCALAR_INDEX_ENGINE_VERSION, "3"},
+        {JSON_PATH, "/a"},
+        {JSON_CAST_TYPE, "DOUBLE"},
+    };
+    auto json = IndexFactory::GetInstance().ScalarIndexLoadResource(
+        DataType::JSON, 0, kIndexSize, json_params, true, kRowCount);
+    EXPECT_EQ(json.final_memory_cost, 2 * kOneMaskBudget + kRowCount / 8);
 }
 
 TEST(JsonPathIndexTest, ConvertDouble_PathNotExist) {
@@ -123,9 +210,9 @@ TEST(JsonPathIndexTest, ConvertDouble_PathNotExist) {
     EXPECT_FALSE(fd->is_valid(2));  // path not exist
 
     // non_exist_offsets should contain 0 and 2
-    ASSERT_EQ(result.non_exist_offsets.size(), 2);
-    EXPECT_EQ(result.non_exist_offsets[0], 0);
-    EXPECT_EQ(result.non_exist_offsets[1], 2);
+    ASSERT_EQ(result.non_exist_offsets.cardinality(), 2);
+    EXPECT_TRUE(result.non_exist_offsets.contains(0));
+    EXPECT_TRUE(result.non_exist_offsets.contains(2));
 }
 
 TEST(JsonPathIndexTest, ConvertDouble_PathExistsButCastFails) {
@@ -151,7 +238,7 @@ TEST(JsonPathIndexTest, ConvertDouble_PathExistsButCastFails) {
     EXPECT_FALSE(fd->is_valid(3));  // cast fail
 
     // Key: non_exist_offsets should be EMPTY because path exists in all rows
-    EXPECT_TRUE(result.non_exist_offsets.empty());
+    EXPECT_TRUE(result.non_exist_offsets.isEmpty());
 }
 
 TEST(JsonPathIndexTest, ConvertDouble_MixedRows) {
@@ -180,9 +267,9 @@ TEST(JsonPathIndexTest, ConvertDouble_MixedRows) {
 
     // non_exist: only 1 and 4 (path truly missing)
     // offset 2 is NOT in non_exist (path exists but cast fails)
-    ASSERT_EQ(result.non_exist_offsets.size(), 2);
-    EXPECT_EQ(result.non_exist_offsets[0], 1);
-    EXPECT_EQ(result.non_exist_offsets[1], 4);
+    ASSERT_EQ(result.non_exist_offsets.cardinality(), 2);
+    EXPECT_TRUE(result.non_exist_offsets.contains(1));
+    EXPECT_TRUE(result.non_exist_offsets.contains(4));
 }
 
 TEST(JsonPathIndexTest, ConvertVarchar) {
@@ -205,8 +292,8 @@ TEST(JsonPathIndexTest, ConvertVarchar) {
     EXPECT_TRUE(fd->is_valid(1));
     EXPECT_FALSE(fd->is_valid(2));
 
-    ASSERT_EQ(result.non_exist_offsets.size(), 1);
-    EXPECT_EQ(result.non_exist_offsets[0], 2);
+    ASSERT_EQ(result.non_exist_offsets.cardinality(), 1);
+    EXPECT_TRUE(result.non_exist_offsets.contains(2));
 }
 
 // ============================================================

--- a/internal/core/src/index/JsonScalarIndexWrapper.h
+++ b/internal/core/src/index/JsonScalarIndexWrapper.h
@@ -91,9 +91,9 @@ class JsonScalarIndexWrapper : public BaseIndex {
                                                          cast_type_,
                                                          cast_function_);
             non_exist_offsets_ = std::move(result.non_exist_offsets);
-            non_exist_row_count_ = result.field_data->get_num_rows();
+            const auto row_count = result.field_data->get_num_rows();
             BaseIndex::BuildWithFieldData({result.field_data});
-            BuildExistsBitset(non_exist_row_count_);
+            BuildExistsBitset(row_count);
             ComputeByteSize();
         }
     }
@@ -113,9 +113,9 @@ class JsonScalarIndexWrapper : public BaseIndex {
                                                          cast_function_);
 
             non_exist_offsets_ = std::move(result.non_exist_offsets);
-            non_exist_row_count_ = result.field_data->get_num_rows();
+            const auto row_count = result.field_data->get_num_rows();
             BaseIndex::BuildWithFieldData({result.field_data});
-            BuildExistsBitset(non_exist_row_count_);
+            BuildExistsBitset(row_count);
             ComputeByteSize();
         }
     }
@@ -192,10 +192,10 @@ class JsonScalarIndexWrapper : public BaseIndex {
         }
         LOG_INFO("LoadEntries JsonScalarIndexWrapper done, has_non_exist: {}",
                  has_non_exist);
-        non_exist_row_count_ =
+        const auto row_count =
             GetValueFromConfig<int64_t>(config, INDEX_NUM_ROWS_KEY)
                 .value_or(this->Count());
-        BuildExistsBitset(non_exist_row_count_);
+        BuildExistsBitset(row_count);
         ComputeByteSize();
     }
 
@@ -204,10 +204,10 @@ class JsonScalarIndexWrapper : public BaseIndex {
     void
     Load(milvus::tracer::TraceContext ctx, const Config& config = {}) override {
         BaseIndex::Load(ctx, config);
-        non_exist_row_count_ =
+        const auto row_count =
             GetValueFromConfig<int64_t>(config, INDEX_NUM_ROWS_KEY)
                 .value_or(this->Count());
-        BuildExistsBitset(non_exist_row_count_);
+        BuildExistsBitset(row_count);
         ComputeByteSize();
     }
 
@@ -350,9 +350,9 @@ class JsonScalarIndexWrapper : public BaseIndex {
                                                          cast_type_,
                                                          cast_function_);
             non_exist_offsets_ = std::move(result.non_exist_offsets);
-            non_exist_row_count_ = result.field_data->get_num_rows();
+            const auto row_count = result.field_data->get_num_rows();
             BaseIndex::BuildWithFieldData({result.field_data});
-            BuildExistsBitset(non_exist_row_count_);
+            BuildExistsBitset(row_count);
             return;
         }
 
@@ -391,8 +391,7 @@ class JsonScalarIndexWrapper : public BaseIndex {
         this->OptimizeNullOffsets();
         non_exist_offsets_.runOptimize();
         non_exist_offsets_.shrinkToFit();
-        non_exist_row_count_ = total_rows;
-        BuildExistsBitset(non_exist_row_count_);
+        BuildExistsBitset(total_rows);
     }
 
     void
@@ -402,7 +401,6 @@ class JsonScalarIndexWrapper : public BaseIndex {
     }
 
     roaring::Roaring non_exist_offsets_;
-    size_t non_exist_row_count_{0};
     TargetBitmap exists_bitset_;
 
  private:

--- a/internal/core/src/index/JsonScalarIndexWrapper.h
+++ b/internal/core/src/index/JsonScalarIndexWrapper.h
@@ -52,7 +52,7 @@ MakeJsonCastContext(const storage::FileManagerContext& ctx,
         static_cast<proto::schema::DataType>(cast_type.ToMilvusDataType()));
     // JSON path extraction produces nullable data (rows where path is missing
     // or cast fails are marked invalid), so the cast-type schema must be
-    // nullable for base indexes to handle null_offset_ correctly.
+    // nullable for base indexes to handle null_offsets_ correctly.
     modified.fieldDataMeta.field_schema.set_nullable(true);
     return modified;
 }
@@ -91,9 +91,10 @@ class JsonScalarIndexWrapper : public BaseIndex {
                                                          cast_type_,
                                                          cast_function_);
             non_exist_offsets_ = std::move(result.non_exist_offsets);
-            auto total_rows = result.field_data->get_num_rows();
+            non_exist_row_count_ = result.field_data->get_num_rows();
             BaseIndex::BuildWithFieldData({result.field_data});
-            BuildExistsBitset(total_rows);
+            BuildExistsBitset(non_exist_row_count_);
+            ComputeByteSize();
         }
     }
 
@@ -112,20 +113,23 @@ class JsonScalarIndexWrapper : public BaseIndex {
                                                          cast_function_);
 
             non_exist_offsets_ = std::move(result.non_exist_offsets);
-            auto total_rows = result.field_data->get_num_rows();
+            non_exist_row_count_ = result.field_data->get_num_rows();
             BaseIndex::BuildWithFieldData({result.field_data});
-            BuildExistsBitset(total_rows);
+            BuildExistsBitset(non_exist_row_count_);
+            ComputeByteSize();
         }
     }
 
-    // Returns a bitmap indicating which rows have the indexed JSON path
-    // present. Returned by value (the copy cost matches the caller-side
-    // clone that would otherwise be required because TargetBitmap has a
-    // deleted copy constructor, and the caller typically wraps the result
-    // in a shared_ptr anyway).
     TargetBitmap
     Exists() override {
         return exists_bitset_.clone();
+    }
+
+    void
+    ComputeByteSize() override {
+        BaseIndex::ComputeByteSize();
+        this->cached_byte_size_ += RoaringMemoryBytes(non_exist_offsets_);
+        this->cached_byte_size_ += exists_bitset_.size_in_bytes();
     }
 
     // v2 format: serialize non_exist_offsets (and null_offset for inverted).
@@ -134,19 +138,21 @@ class JsonScalarIndexWrapper : public BaseIndex {
         if constexpr (kIsInverted) {
             std::shared_lock<folly::SharedMutex> lock(this->mutex_);
             BinarySet res_set;
-            auto null_len = this->null_offset_.size() * sizeof(size_t);
+            auto null_offsets = RoaringToLegacyOffsets(this->null_offsets_);
+            auto null_len = null_offsets.size() * sizeof(size_t);
             if (null_len > 0) {
                 std::shared_ptr<uint8_t[]> null_data(new uint8_t[null_len]);
                 milvus::fastmem::FastMemcpy(
-                    null_data.get(), this->null_offset_.data(), null_len);
+                    null_data.get(), null_offsets.data(), null_len);
                 res_set.Append(
                     INDEX_NULL_OFFSET_FILE_NAME, null_data, null_len);
             }
-            auto ne_len = non_exist_offsets_.size() * sizeof(size_t);
+            auto non_exist_offsets = RoaringToLegacyOffsets(non_exist_offsets_);
+            auto ne_len = non_exist_offsets.size() * sizeof(size_t);
             if (ne_len > 0) {
                 std::shared_ptr<uint8_t[]> ne_data(new uint8_t[ne_len]);
                 milvus::fastmem::FastMemcpy(
-                    ne_data.get(), non_exist_offsets_.data(), ne_len);
+                    ne_data.get(), non_exist_offsets.data(), ne_len);
                 res_set.Append(
                     INDEX_NON_EXIST_OFFSET_FILE_NAME, ne_data, ne_len);
             }
@@ -158,19 +164,19 @@ class JsonScalarIndexWrapper : public BaseIndex {
         }
     }
 
-    // V3 format: write non_exist_offsets on top of base entries. This is the
-    // sealed-segment entry point, called after the tantivy index is ready —
-    // safe to eagerly compute the exists bitmap.
+    // V3 format: write legacy size_t[] non-exist offsets on top of base
+    // entries. Only the in-memory representation changes in this phase.
     void
     WriteEntries(storage::IndexEntryWriter* writer) override {
         BaseIndex::WriteEntries(writer);
 
-        bool has_non_exist = !non_exist_offsets_.empty();
+        bool has_non_exist = !non_exist_offsets_.isEmpty();
         writer->PutMeta("has_non_exist", has_non_exist);
         if (has_non_exist) {
+            auto legacy_offsets = RoaringToLegacyOffsets(non_exist_offsets_);
             writer->WriteEntry(INDEX_NON_EXIST_OFFSET_FILE_NAME,
-                               non_exist_offsets_.data(),
-                               non_exist_offsets_.size() * sizeof(size_t));
+                               legacy_offsets.data(),
+                               legacy_offsets.size() * sizeof(size_t));
         }
     }
 
@@ -182,25 +188,27 @@ class JsonScalarIndexWrapper : public BaseIndex {
         bool has_non_exist = reader.GetMeta<bool>("has_non_exist", false);
         if (has_non_exist) {
             auto e = reader.ReadEntry(INDEX_NON_EXIST_OFFSET_FILE_NAME);
-            non_exist_offsets_.resize(e.data.size() / sizeof(size_t));
-            milvus::fastmem::FastMemcpy(
-                non_exist_offsets_.data(), e.data.data(), e.data.size());
+            LoadLegacyOffsets(non_exist_offsets_, e.data.data(), e.data.size());
         }
         LOG_INFO("LoadEntries JsonScalarIndexWrapper done, has_non_exist: {}",
                  has_non_exist);
-        // BaseIndex::LoadEntries has fully initialized the base index, so
-        // Count() is safe to call and we can eagerly build the exists bitmap.
-        BuildExistsBitset(this->Count());
+        non_exist_row_count_ =
+            GetValueFromConfig<int64_t>(config, INDEX_NUM_ROWS_KEY)
+                .value_or(this->Count());
+        BuildExistsBitset(non_exist_row_count_);
+        ComputeByteSize();
     }
 
-    // v2 format: override Load() to defer the eager exists bitmap build
-    // until after the base Load finishes. LoadIndexMetas (called from within
-    // base Load) runs before the tantivy reader is initialized, so we can
-    // only safely compute Count() here, not inside LoadIndexMetas.
+    // V2 load initializes the base reader after LoadIndexMetas, so record the
+    // row domain once Count() becomes available.
     void
     Load(milvus::tracer::TraceContext ctx, const Config& config = {}) override {
         BaseIndex::Load(ctx, config);
-        BuildExistsBitset(this->Count());
+        non_exist_row_count_ =
+            GetValueFromConfig<int64_t>(config, INDEX_NUM_ROWS_KEY)
+                .value_or(this->Count());
+        BuildExistsBitset(non_exist_row_count_);
+        ComputeByteSize();
     }
 
     JsonCastType
@@ -218,7 +226,7 @@ class JsonScalarIndexWrapper : public BaseIndex {
     template <typename B = BaseIndex>
     std::enable_if_t<std::is_base_of_v<InvertedIndexTantivy<T>, B>>
     finish() {
-        this->wrapper_->finish();
+        InvertedIndexTantivy<T>::finish();
     }
 
     template <typename B = BaseIndex>
@@ -237,9 +245,7 @@ class JsonScalarIndexWrapper : public BaseIndex {
             InvertedIndexTantivy<T>::LoadIndexMetas(index_files, config);
 
             auto fill = [&](const uint8_t* data, int64_t size) {
-                non_exist_offsets_.resize((size_t)size / sizeof(size_t));
-                milvus::fastmem::FastMemcpy(
-                    non_exist_offsets_.data(), data, (size_t)size);
+                LoadLegacyOffsets(non_exist_offsets_, data, size);
             };
 
             auto load_priority =
@@ -294,8 +300,8 @@ class JsonScalarIndexWrapper : public BaseIndex {
                 return;
             }
 
-            // Fallback: v2.5.x data — use null_offset_ as non_exist_offsets_
-            non_exist_offsets_ = this->null_offset_;
+            // Fallback: v2.5.x data — use null_offsets_ as non-exist rows.
+            non_exist_offsets_ = this->null_offsets_;
         }
     }
 
@@ -306,7 +312,7 @@ class JsonScalarIndexWrapper : public BaseIndex {
             auto meta =
                 InvertedIndexTantivy<T>::BuildTantivyMeta(file_names, has_null);
             std::shared_lock<folly::SharedMutex> lock(this->mutex_);
-            meta["has_non_exist"] = !non_exist_offsets_.empty();
+            meta["has_non_exist"] = !non_exist_offsets_.isEmpty();
             return meta;
         } else {
             return {};
@@ -344,9 +350,9 @@ class JsonScalarIndexWrapper : public BaseIndex {
                                                          cast_type_,
                                                          cast_function_);
             non_exist_offsets_ = std::move(result.non_exist_offsets);
-            auto total_rows = result.field_data->get_num_rows();
+            non_exist_row_count_ = result.field_data->get_num_rows();
             BaseIndex::BuildWithFieldData({result.field_data});
-            BuildExistsBitset(total_rows);
+            BuildExistsBitset(non_exist_row_count_);
             return;
         }
 
@@ -371,29 +377,32 @@ class JsonScalarIndexWrapper : public BaseIndex {
                             data, size);
                 }
             },
-            [this](int64_t offset) { this->null_offset_.push_back(offset); },
-            [this](int64_t offset) { non_exist_offsets_.push_back(offset); },
+            [this](int64_t offset) { this->AddNullOffset(offset); },
+            [this](int64_t offset) {
+                AssertInfo(
+                    offset >= 0 && static_cast<uint64_t>(offset) <=
+                                       std::numeric_limits<uint32_t>::max(),
+                    "JSON row offset {} exceeds uint32 range",
+                    offset);
+                non_exist_offsets_.add(static_cast<uint32_t>(offset));
+            },
             [](const Json&, const std::string&, simdjson::error_code) {});
 
-        BuildExistsBitset(total_rows);
+        this->OptimizeNullOffsets();
+        non_exist_offsets_.runOptimize();
+        non_exist_offsets_.shrinkToFit();
+        non_exist_row_count_ = total_rows;
+        BuildExistsBitset(non_exist_row_count_);
     }
 
-    // Build the exists bitmap. The caller must supply the total row count
-    // explicitly at build time because InvertedIndexTantivy::Count() requires
-    // finish()+create_reader() which haven't been called yet during
-    // Build/BuildWithFieldData.
     void
-    BuildExistsBitset(int64_t count) {
-        exists_bitset_ = TargetBitmap(count, true);
-        for (auto offset : non_exist_offsets_) {
-            if (static_cast<int64_t>(offset) >= count) {
-                break;
-            }
-            exists_bitset_.reset(offset);
-        }
+    BuildExistsBitset(size_t count) {
+        exists_bitset_ =
+            RoaringToBitset(non_exist_offsets_, count, /*inverted=*/true);
     }
 
-    std::vector<size_t> non_exist_offsets_;
+    roaring::Roaring non_exist_offsets_;
+    size_t non_exist_row_count_{0};
     TargetBitmap exists_bitset_;
 
  private:

--- a/internal/core/src/index/NgramInvertedIndex.cpp
+++ b/internal/core/src/index/NgramInvertedIndex.cpp
@@ -182,13 +182,14 @@ NgramInvertedIndex::BuildWithJsonFieldData(
             }
         },
         // handle null
-        [this](int64_t offset) { this->null_offset_.push_back(offset); },
+        [this](int64_t offset) { this->AddNullOffset(offset); },
         // handle non exist
         [](int64_t offset) {},
         // handle error (silently skip — error stats not tracked)
         [](const Json&, const std::string&, simdjson::error_code) {});
 
     avg_row_size_ = total_rows > 0 ? total_bytes / total_rows : 0;
+    OptimizeNullOffsets();
     LOG_INFO("Ngram index (JSON) avg_row_size: {} bytes", avg_row_size_);
 }
 

--- a/internal/core/src/index/NgramInvertedIndex.h
+++ b/internal/core/src/index/NgramInvertedIndex.h
@@ -102,7 +102,7 @@ class NgramInvertedIndex : public InvertedIndexTantivy<std::string> {
 
     void
     finish() {
-        this->wrapper_->finish();
+        InvertedIndexTantivy<std::string>::finish();
     }
 
     void

--- a/internal/core/src/index/TextMatchIndex.cpp
+++ b/internal/core/src/index/TextMatchIndex.cpp
@@ -231,10 +231,9 @@ TextMatchIndex::Load(const Config& config) {
         // clear index_datas to free memory early
         index_datas.clear();
         auto index_valid_data = binary_set.GetByName("index_null_offset");
-        null_offset_.resize((size_t)index_valid_data->size / sizeof(size_t));
-        milvus::fastmem::FastMemcpy(null_offset_.data(),
-                                    index_valid_data->data.get(),
-                                    (size_t)index_valid_data->size);
+        LoadLegacyOffsets(null_offsets_,
+                          index_valid_data->data.get(),
+                          index_valid_data->size);
     }
     disk_file_manager_->CacheTextLogToDisk(files_value, load_priority);
     AssertInfo(
@@ -267,7 +266,7 @@ TextMatchIndex::AddTextSealed(const std::string& text,
 // Add null for sealed segment
 void
 TextMatchIndex::AddNullSealed(int64_t offset) {
-    null_offset_.push_back(offset);
+    AddNullOffset(offset);
     // still need to add null to make offset is correct
     static const std::string empty;
     wrapper_->add_array_data(&empty, 0, offset);
@@ -284,7 +283,7 @@ TextMatchIndex::AddTextsGrowing(size_t n,
             auto offset = i + offset_begin;
             if (!valids[i]) {
                 std::unique_lock<folly::SharedMutex> lock(mutex_);
-                null_offset_.push_back(offset);
+                AddNullOffset(offset);
             }
         }
     }
@@ -300,20 +299,12 @@ TextMatchIndex::BuildIndexFromFieldData(
     const std::vector<FieldDataPtr>& field_datas, bool nullable) {
     int64_t offset = 0;
     if (nullable) {
-        int64_t total = 0;
-        for (const auto& data : field_datas) {
-            total += data->get_null_count();
-        }
-        {
-            std::unique_lock<folly::SharedMutex> lock(mutex_);
-            null_offset_.reserve(total);
-        }
         for (const auto& data : field_datas) {
             auto n = data->get_num_rows();
             for (int i = 0; i < n; i++) {
                 if (!data->is_valid(i)) {
                     std::unique_lock<folly::SharedMutex> lock(mutex_);
-                    null_offset_.push_back(offset);
+                    AddNullOffset(offset);
                     // add empty array doc to register offset in tantivy,
                     // same as AddNullSealed
                     static const std::string empty;
@@ -334,6 +325,10 @@ TextMatchIndex::BuildIndexFromFieldData(
                 static_cast<const std::string*>(data->Data()), n, offset);
             offset += n;
         }
+    }
+    {
+        std::unique_lock<folly::SharedMutex> lock(mutex_);
+        OptimizeNullOffsets();
     }
 }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -895,7 +895,8 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(LoadIndexInfo& info,
                 info.index_size,
                 info.index_params,
                 info.enable_mmap,
-                target_runtime->row_count);
+                target_runtime->row_count,
+                field_meta.is_nullable());
     }
 
     request.has_raw_data =

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -1239,7 +1239,8 @@ class SegmentLoadInfo {
                     load_index_info.index_params,
                     load_index_info.enable_mmap,
                     load_index_info.num_rows,
-                    load_index_info.dim);
+                    load_index_info.dim,
+                    load_index_info.schema.nullable());
             if (!needs_file_context) {
                 load_index_info.load_resource_request = request;
             }

--- a/internal/core/src/segcore/SegmentLoadInfoTest.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfoTest.cpp
@@ -312,6 +312,7 @@ TEST_F(SegmentLoadInfoTest, BuildCacheDefersFileAwareScalarResourceEstimate) {
     auto* legacy_inverted_index = proto.add_index_infos();
     legacy_inverted_index->set_fieldid(110);
     legacy_inverted_index->set_indexid(5003);
+    legacy_inverted_index->set_num_rows(1000);
     legacy_inverted_index->add_index_file_paths(
         "/path/to/legacy_inverted_index");
     auto* legacy_inverted_param = legacy_inverted_index->add_index_params();
@@ -331,6 +332,19 @@ TEST_F(SegmentLoadInfoTest, BuildCacheDefersFileAwareScalarResourceEstimate) {
     auto legacy_inverted_infos = segment_info.GetFieldIndexInfos(FieldId(110));
     ASSERT_EQ(legacy_inverted_infos.size(), 1);
     EXPECT_TRUE(legacy_inverted_infos[0].load_resource_request.has_value());
+    const auto expected_legacy_request =
+        milvus::index::IndexFactory::GetInstance().ScalarIndexLoadResource(
+            legacy_inverted_infos[0].field_type,
+            legacy_inverted_infos[0].index_engine_version,
+            legacy_inverted_infos[0].index_size,
+            legacy_inverted_infos[0].index_params,
+            legacy_inverted_infos[0].enable_mmap,
+            legacy_inverted_infos[0].num_rows,
+            false);
+    EXPECT_EQ(legacy_inverted_infos[0].load_resource_request->final_memory_cost,
+              expected_legacy_request.final_memory_cost);
+    EXPECT_EQ(legacy_inverted_infos[0].load_resource_request->max_memory_cost,
+              expected_legacy_request.max_memory_cost);
 }
 
 TEST_F(SegmentLoadInfoTest, CompactRuntimeInfoForManifest) {

--- a/internal/core/src/segcore/load_index_c.cpp
+++ b/internal/core/src/segcore/load_index_c.cpp
@@ -175,7 +175,8 @@ EstimateLoadIndexResource(CLoadIndexInfo c_load_index_info) {
             index_params,
             load_index_info->enable_mmap,
             load_index_info->num_rows,
-            load_index_info->dim);
+            load_index_info->dim,
+            load_index_info->schema.nullable());
     } catch (std::exception& e) {
         ThrowInfo(milvus::UnexpectedError,
                   fmt::format("failed to estimate index load resource, "

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
@@ -5,6 +5,7 @@
 #include <optional>
 #include <utility>
 
+#include "common/Consts.h"
 #include "common/EasyAssert.h"
 #include "common/common_type_c.h"
 #include "common/resource_c.h"
@@ -215,6 +216,11 @@ SealedIndexTranslator::get_cells(milvus::OpContext* ctx,
     } else {
         config_[milvus::index::ENABLE_MMAP] = "false";
     }
+
+    // Plumb the segment row count into the load config so JSON typed-path
+    // indexes size their exists bitmap from the true row domain (tantivy
+    // Count() only covers non-null rows).
+    config_[INDEX_NUM_ROWS_KEY] = index_load_info_.num_rows;
 
     // Check for cancellation before loading index data
     CheckCancellation(ctx, segment_id, "LoadIndex");


### PR DESCRIPTION
issue: #52565

- Store Tantivy null rows and typed JSON path non-exist rows as CRoaring after build and load.
- Retain one resident N/8 EXISTS bitmap so the default non-cached query path only clones it.
- Preserve legacy `size_t[]` entries and scalar index versions while accounting for resident row masks in memory estimates.