### PR TITLE
fix: fuse grouped hybrid results by group key

### DIFF
--- a/internal/util/function/chain/operator_merge.go
+++ b/internal/util/function/chain/operator_merge.go
@@ -74,6 +74,7 @@ type MergeOp struct {
 	strategy       MergeStrategy
 	weights        []float64       // for weighted strategy
 	rrfK           float64         // for rrf strategy, default 60
+	mergeKeyField  string          // optional field used as the cross-input fusion identity
 	sortDescending bool            // pre-computed: true means larger score = better match
 	scoreNormFuncs []normalizeFunc // pre-computed per-input normalization; nil entry = no-op
 }
@@ -87,6 +88,7 @@ type mergeConfig struct {
 	metricTypes     []string
 	normalize       bool
 	forceDescending bool
+	mergeKeyField   string
 }
 
 // MergeOption is a functional option for MergeOp.
@@ -136,6 +138,14 @@ func WithForceDescending(force bool) MergeOption {
 	}
 }
 
+// WithMergeKeyField uses a scalar field instead of the primary key to match
+// rows across inputs. The output still carries a representative primary key.
+func WithMergeKeyField(field string) MergeOption {
+	return func(cfg *mergeConfig) {
+		cfg.mergeKeyField = field
+	}
+}
+
 // NewMergeOp creates a new MergeOp with the given strategy and options.
 // Behavioral fields (sortDescending, scoreNormFuncs) are resolved eagerly
 // so that the execution path is free of metric-type branching.
@@ -160,6 +170,7 @@ func NewMergeOp(strategy MergeStrategy, opts ...MergeOption) *MergeOp {
 		strategy:       strategy,
 		weights:        cfg.weights,
 		rrfK:           cfg.rrfK,
+		mergeKeyField:  cfg.mergeKeyField,
 		sortDescending: sortDesc,
 		scoreNormFuncs: normFuncs,
 	}
@@ -266,6 +277,12 @@ func (op *MergeOp) mergeWithScoreCollector(ctx *types.FuncContext, inputs []*Dat
 		}
 
 		ids, scores, locs := sortAndExtractResults(idScores, idLocs, op.SortDescending())
+		if op.mergeKeyField != "" {
+			ids, err = outputIDsFromLocations(inputs, chunkIdx, locs)
+			if err != nil {
+				return nil, err
+			}
+		}
 		newChunkSizes[chunkIdx] = int64(len(ids))
 
 		idArr, scoreArr, err := op.buildResultArrays(ctx, ids, scores, idType)
@@ -337,15 +354,19 @@ func (op *MergeOp) collectRRFScores(inputs []*DataFrame, chunkIdx int) (map[any]
 			if id == nil {
 				continue
 			}
+			key, err := op.mergeKey(df, chunkIdx, rowIdx, id)
+			if err != nil {
+				return nil, nil, err
+			}
 
 			// RRF score: 1 / (k + rank), rank is 1-based
 			rrfScore := float32(1.0 / (op.rrfK + float64(rowIdx+1)))
 
-			if existingScore, exists := idScores[id]; exists {
-				idScores[id] = existingScore + rrfScore
+			if existingScore, exists := idScores[key]; exists {
+				idScores[key] = existingScore + rrfScore
 			} else {
-				idScores[id] = rrfScore
-				idLocs[id] = idLocation{inputIdx: inputIdx, rowIdx: rowIdx}
+				idScores[key] = rrfScore
+				idLocs[key] = idLocation{inputIdx: inputIdx, rowIdx: rowIdx}
 			}
 		}
 	}
@@ -384,6 +405,10 @@ func (op *MergeOp) collectWeightedScores(inputs []*DataFrame, chunkIdx int) (map
 			if id == nil {
 				continue
 			}
+			key, err := op.mergeKey(df, chunkIdx, rowIdx, id)
+			if err != nil {
+				return nil, nil, err
+			}
 
 			score := scoreChunk.Value(rowIdx)
 			if normFunc != nil {
@@ -391,11 +416,11 @@ func (op *MergeOp) collectWeightedScores(inputs []*DataFrame, chunkIdx int) (map
 			}
 			weightedScore := weight * score
 
-			if existingScore, exists := idScores[id]; exists {
-				idScores[id] = existingScore + weightedScore
+			if existingScore, exists := idScores[key]; exists {
+				idScores[key] = existingScore + weightedScore
 			} else {
-				idScores[id] = weightedScore
-				idLocs[id] = idLocation{inputIdx: inputIdx, rowIdx: rowIdx}
+				idScores[key] = weightedScore
+				idLocs[key] = idLocation{inputIdx: inputIdx, rowIdx: rowIdx}
 			}
 		}
 	}
@@ -469,20 +494,24 @@ func (op *MergeOp) collectCombinedScores(inputs []*DataFrame, chunkIdx int, merg
 			if id == nil {
 				continue
 			}
+			key, err := op.mergeKey(df, chunkIdx, rowIdx, id)
+			if err != nil {
+				return nil, nil, nil, err
+			}
 
 			score := scoreChunk.Value(rowIdx)
 			if normFunc != nil {
 				score = normFunc(score)
 			}
 
-			if existingScore, exists := idScores[id]; exists {
-				newScore, newCount := mergeFunc(existingScore, score, idCounts[id])
-				idScores[id] = newScore
-				idCounts[id] = newCount
+			if existingScore, exists := idScores[key]; exists {
+				newScore, newCount := mergeFunc(existingScore, score, idCounts[key])
+				idScores[key] = newScore
+				idCounts[key] = newCount
 			} else {
-				idScores[id] = score
-				idCounts[id] = 1
-				idLocs[id] = idLocation{inputIdx: inputIdx, rowIdx: rowIdx}
+				idScores[key] = score
+				idCounts[key] = 1
+				idLocs[key] = idLocation{inputIdx: inputIdx, rowIdx: rowIdx}
 			}
 		}
 	}
@@ -626,6 +655,29 @@ func getIDValue(arr arrow.Array, idx int) any {
 	default:
 		return nil
 	}
+}
+
+func (op *MergeOp) mergeKey(df *DataFrame, chunkIdx, rowIdx int, id any) (any, error) {
+	if op.mergeKeyField == "" {
+		return id, nil
+	}
+	col := df.Column(op.mergeKeyField)
+	if col == nil {
+		return nil, merr.WrapErrFunctionFailedMsg("merge_op: input missing merge key column %q", op.mergeKeyField)
+	}
+	return getArrayValue(col.Chunk(chunkIdx), rowIdx), nil
+}
+
+func outputIDsFromLocations(inputs []*DataFrame, chunkIdx int, locs []idLocation) ([]any, error) {
+	ids := make([]any, len(locs))
+	for i, loc := range locs {
+		idCol := inputs[loc.inputIdx].Column(types.IDFieldName)
+		if idCol == nil {
+			return nil, merr.WrapErrFunctionFailedMsg("merge_op: input[%d] missing %s column", loc.inputIdx, types.IDFieldName)
+		}
+		ids[i] = getIDValue(idCol.Chunk(chunkIdx), loc.rowIdx)
+	}
+	return ids, nil
 }
 
 // collectOrderedFieldNames returns field names (excluding $id and $score)

--- a/internal/util/function/chain/operator_merge_test.go
+++ b/internal/util/function/chain/operator_merge_test.go
@@ -1512,6 +1512,69 @@ func (s *MergeHelperTestSuite) TestMergeWeightedWithFieldColumns() {
 	s.Equal(int64(3), result.NumRows())
 }
 
+func (s *MergeHelperTestSuite) TestMergeWeightedByGroupKey() {
+	dense := s.createDFWithField(
+		[]int64{1, 3}, []float32{0.95, 0.70},
+		"group_key", []string{"A", "B"}, []int64{2},
+	)
+	sparse := s.createDFWithField(
+		[]int64{2, 3}, []float32{0.95, 0.70},
+		"group_key", []string{"A", "B"}, []int64{2},
+	)
+	defer dense.Release()
+	defer sparse.Release()
+
+	op := NewMergeOp(
+		MergeStrategyWeighted,
+		WithWeights([]float64{0.5, 0.5}),
+		WithNormalize(false),
+		WithMergeKeyField("group_key"),
+	)
+	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
+
+	result, err := op.ExecuteMulti(ctx, []*DataFrame{dense, sparse})
+	s.Require().NoError(err)
+	defer result.Release()
+
+	s.Equal(int64(2), result.NumRows())
+	ids := result.Column(types.IDFieldName).Chunk(0).(*array.Int64)
+	scores := result.Column(types.ScoreFieldName).Chunk(0).(*array.Float32)
+	groups := result.Column("group_key").Chunk(0).(*array.String)
+	s.Equal(int64(1), ids.Value(0))
+	s.Equal("A", groups.Value(0))
+	s.InDelta(0.95, float64(scores.Value(0)), 1e-6)
+	s.Equal("B", groups.Value(1))
+	s.InDelta(0.70, float64(scores.Value(1)), 1e-6)
+}
+
+func (s *MergeHelperTestSuite) TestMergeRRFByGroupKey() {
+	dense := s.createDFWithField(
+		[]int64{1, 3}, []float32{0.95, 0.70},
+		"group_key", []string{"A", "B"}, []int64{2},
+	)
+	sparse := s.createDFWithField(
+		[]int64{2, 3}, []float32{0.95, 0.70},
+		"group_key", []string{"A", "B"}, []int64{2},
+	)
+	defer dense.Release()
+	defer sparse.Release()
+
+	op := NewMergeOp(MergeStrategyRRF, WithRRFK(60), WithMergeKeyField("group_key"))
+	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
+
+	result, err := op.ExecuteMulti(ctx, []*DataFrame{dense, sparse})
+	s.Require().NoError(err)
+	defer result.Release()
+
+	s.Equal(int64(2), result.NumRows())
+	groups := result.Column("group_key").Chunk(0).(*array.String)
+	scores := result.Column(types.ScoreFieldName).Chunk(0).(*array.Float32)
+	s.Equal("A", groups.Value(0))
+	s.InDelta(2.0/61.0, float64(scores.Value(0)), 1e-6)
+	s.Equal("B", groups.Value(1))
+	s.InDelta(2.0/62.0, float64(scores.Value(1)), 1e-6)
+}
+
 func (s *MergeHelperTestSuite) TestMergeSumWithFieldColumns() {
 	df1 := s.createDFWithField([]int64{1}, []float32{0.5}, "tag", []string{"x"}, []int64{1})
 	df2 := s.createDFWithField([]int64{1, 2}, []float32{0.3, 0.8}, "tag", []string{"x", "y"}, []int64{2})

--- a/internal/util/function/chain/rerank_builder.go
+++ b/internal/util/function/chain/rerank_builder.go
@@ -282,16 +282,20 @@ func buildRerankChainInternal(
 		SetName("rerank_chain")
 
 	sortDescending := true // default: larger score = better match
+	mergeKeyField := ""
+	if searchParams.HasGrouping() && searchParams.GroupSize == 1 {
+		mergeKeyField = searchParams.GroupByField
+	}
 
 	switch rerankerName {
 	case RRFRerankerName:
-		if err := buildRRFChain(fc, funcSchema, searchMetrics); err != nil {
+		if err := buildRRFChain(fc, funcSchema, searchMetrics, mergeKeyField); err != nil {
 			return nil, err
 		}
 
 	case WeightedRerankerName:
 		var err error
-		sortDescending, err = buildWeightedChain(fc, funcSchema, searchMetrics)
+		sortDescending, err = buildWeightedChain(fc, funcSchema, searchMetrics, mergeKeyField)
 		if err != nil {
 			return nil, err
 		}
@@ -364,7 +368,7 @@ func buildRerankChainInternal(
 // RRF Builder
 // =============================================================================
 
-func buildRRFChain(fc *FuncChain, funcSchema *schemapb.FunctionSchema, searchMetrics []string) error {
+func buildRRFChain(fc *FuncChain, funcSchema *schemapb.FunctionSchema, searchMetrics []string, mergeKeyField string) error {
 	rrfK, err := parseRRFK(funcSchema)
 	if err != nil {
 		return err
@@ -373,7 +377,8 @@ func buildRRFChain(fc *FuncChain, funcSchema *schemapb.FunctionSchema, searchMet
 	// RRF scores are computed purely from rank position, not from original scores,
 	// so metricTypes and normalize are not needed.
 	fc.Merge(MergeStrategyRRF,
-		WithRRFK(rrfK))
+		WithRRFK(rrfK),
+		WithMergeKeyField(mergeKeyField))
 
 	return nil
 }
@@ -398,7 +403,7 @@ func parseRRFK(funcSchema *schemapb.FunctionSchema) (float64, error) {
 // Weighted Builder
 // =============================================================================
 
-func buildWeightedChain(fc *FuncChain, funcSchema *schemapb.FunctionSchema, searchMetrics []string) (sortDescending bool, err error) {
+func buildWeightedChain(fc *FuncChain, funcSchema *schemapb.FunctionSchema, searchMetrics []string, mergeKeyField string) (sortDescending bool, err error) {
 	weights, normalize, err := parseWeightedParams(funcSchema)
 	if err != nil {
 		return true, err
@@ -415,7 +420,8 @@ func buildWeightedChain(fc *FuncChain, funcSchema *schemapb.FunctionSchema, sear
 	mergeOp := NewMergeOp(MergeStrategyWeighted,
 		WithWeights(weights),
 		WithMetricTypes(searchMetrics),
-		WithNormalize(normalize))
+		WithNormalize(normalize),
+		WithMergeKeyField(mergeKeyField))
 
 	fc.Add(mergeOp)
 

--- a/internal/util/function/chain/rerank_builder_test.go
+++ b/internal/util/function/chain/rerank_builder_test.go
@@ -684,6 +684,25 @@ func (s *RerankBuilderTestSuite) TestBuildRRFChainWithGrouping() {
 	s.Equal("Merge", fc.operators[0].Name())
 	s.Equal("GroupBy", fc.operators[1].Name())
 	s.Equal("Select", fc.operators[2].Name())
+	s.Empty(fc.operators[0].(*MergeOp).mergeKeyField)
+}
+
+func (s *RerankBuilderTestSuite) TestBuildRRFChainWithSingleResultPerGroupFusesByGroupKey() {
+	collSchema := s.createCollectionSchemaWithCategory()
+	searchParams := NewSearchParamsWithGrouping(1, 10, 0, -1, "category", 1)
+	searchMetrics := []string{"COSINE", "IP"}
+	funcScoreSchema := &schemapb.FunctionScore{
+		Functions: []*schemapb.FunctionSchema{{
+			Type: schemapb.FunctionType_Rerank,
+			Params: []*commonpb.KeyValuePair{
+				{Key: "reranker", Value: "rrf"},
+			},
+		}},
+	}
+
+	fc, err := BuildRerankChain(collSchema, funcScoreSchema, searchMetrics, searchParams, s.pool)
+	s.Require().NoError(err)
+	s.Equal("category", fc.operators[0].(*MergeOp).mergeKeyField)
 }
 
 func (s *RerankBuilderTestSuite) createCollectionSchemaWithCategory() *schemapb.CollectionSchema {


### PR DESCRIPTION
Fixes #52531

## What changed

- Use the group-by field as the cross-input fusion key for Weighted and RRF hybrid reranking when `group_size=1`.
- Keep a real primary key and its row fields as the representative output for each group.
- Preserve the existing primary-key fusion path when grouping is disabled or `group_size>1`.

## Why

Each hybrid sub-search groups independently. Dense and sparse routes can therefore retain different entity IDs from the same logical group. Reranking those results by primary key prevents their route scores from being combined and can remove the best logical group from a small final TopK.

## Compatibility

This changes only hybrid searches that enable grouping with `group_size=1`. It does not change schemas, public APIs, non-grouped hybrid search, or multi-result groups.

## Tests

- Added Weighted merge coverage where two entity IDs sharing one group key contribute scores from different routes.
- Added equivalent RRF coverage.
- Added builder coverage for enabling group-key fusion only when `group_size=1`.
- Ran the modified production `MergeOp` and `GroupByOp` together in isolated local tests for both Weighted and RRF paths; both preserve the expected group ranking.
- Verified that omitting the merge-key option preserves the existing primary-key fusion behavior.
- Verified that a missing merge-key column returns an explicit error.
- Ran the isolated tests with Go's race detector; all tests passed.
- `git diff --check` passes.

The full package test requires the Milvus native build environment (`milvus_core` and RocksDB). The focused local tests compile and execute the production files directly; the complete package and integration suites are left to upstream CI.
