### PR TITLE
fix: [cp 3.0] avoid N+1 RBAC policy metadata scans

### DIFF
--- a/internal/metastore/kv/rootcoord/kv_catalog.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog.go
@@ -1451,6 +1451,7 @@ func logicalGranteeKeyFromEtcdKey(ctx context.Context, granteePrefix string, key
 }
 
 func findOtherGranteeWithIDFromKeys(ctx context.Context, granteePrefix string, granteeKey string, idStr string, keys []string, values []string) (string, error) {
+	var ownerKeys []string
 	for i, key := range keys {
 		if i >= len(values) {
 			mlog.Warn(ctx, "grantee key has no matching id value while checking grantee id sharing",
@@ -1460,6 +1461,13 @@ func findOtherGranteeWithIDFromKeys(ctx context.Context, granteePrefix string, g
 		if values[i] != idStr {
 			continue
 		}
+		ownerKeys = append(ownerKeys, key)
+	}
+	return findOtherGranteeWithIDFromOwnerKeys(ctx, granteePrefix, granteeKey, idStr, ownerKeys)
+}
+
+func findOtherGranteeWithIDFromOwnerKeys(ctx context.Context, granteePrefix string, granteeKey string, idStr string, ownerKeys []string) (string, error) {
+	for _, key := range ownerKeys {
 		logicalKey, ok := logicalGranteeKeyFromEtcdKey(ctx, granteePrefix, key)
 		if !ok {
 			return "", newSharedGranteeIDError(idStr, granteeKey, key)
@@ -1983,6 +1991,31 @@ func (kc *Catalog) ListPolicy(ctx context.Context, tenant string) ([]*milvuspb.G
 		mlog.Error(ctx, "fail to load all grant privilege entities", mlog.String("key", granteeKey), mlog.Err(err))
 		return []*milvuspb.GrantEntity{}, err
 	}
+	granteeOwnerKeys := make(map[string][]string)
+	for i, key := range keys {
+		if i >= len(values) {
+			mlog.Warn(ctx, "grantee key has no matching id value while indexing grantee id owners",
+				mlog.String("key", key), mlog.String("prefix", granteeKey))
+			continue
+		}
+		granteeOwnerKeys[values[i]] = append(granteeOwnerKeys[values[i]], key)
+	}
+
+	granteeIDPrefix := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant)
+	allIDKeys, _, err := kc.Txn.LoadWithPrefix(ctx, granteeIDPrefix)
+	if err != nil {
+		mlog.Error(ctx, "fail to load all grantee ids", mlog.String("key", granteeIDPrefix), mlog.Err(err))
+		return []*milvuspb.GrantEntity{}, err
+	}
+	granteeIDKeys := make(map[string][]string)
+	for _, key := range allIDKeys {
+		granteeIDInfos := typeutil.AfterN(key, granteeIDPrefix, "/")
+		if len(granteeIDInfos) < 2 || funcutil.IsEmptyString(granteeIDInfos[0]) {
+			mlog.Warn(ctx, "invalid grantee id", mlog.String("string", key), mlog.String("sub_string", granteeIDPrefix))
+			continue
+		}
+		granteeIDKeys[granteeIDInfos[0]] = append(granteeIDKeys[granteeIDInfos[0]], key)
+	}
 
 	for i, key := range keys {
 		grantInfos := typeutil.AfterN(key, granteeKey, "/")
@@ -1994,10 +2027,33 @@ func (kc *Catalog) ListPolicy(ctx context.Context, tenant string) ([]*milvuspb.G
 			continue
 		}
 		logicalGranteeKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, grantInfos[0], grantInfos[1], grantInfos[2])
-		idKeys, _, granteeIDKey, err := kc.loadGranteeIDPrefixWithLoadedGrantees(ctx, tenant, logicalGranteeKey, values[i], keys, values)
-		if err != nil {
-			mlog.Error(ctx, "fail to load the grantee ids", mlog.String("key", granteeIDKey), mlog.Err(err))
-			return []*milvuspb.GrantEntity{}, err
+		idStr := values[i]
+		if isLegacyGranteeID(idStr) && idStr != crypto.GranteeID(logicalGranteeKey) {
+			legacyIDPrefix := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, idStr)
+			otherGranteeKey, err := findOtherGranteeWithIDFromOwnerKeys(ctx, granteeKey, logicalGranteeKey, idStr, granteeOwnerKeys[idStr])
+			if err != nil {
+				mlog.Error(ctx, "fail to load the grantee ids", mlog.String("key", legacyIDPrefix), mlog.Err(err))
+				return []*milvuspb.GrantEntity{}, err
+			}
+			if otherGranteeKey != "" {
+				err := newSharedGranteeIDError(idStr, logicalGranteeKey, otherGranteeKey)
+				mlog.Error(ctx, "fail to load the grantee ids", mlog.String("key", legacyIDPrefix), mlog.Err(err))
+				return []*milvuspb.GrantEntity{}, err
+			}
+		}
+
+		var idKeys []string
+		var granteeIDKey string
+		for _, candidate := range granteeIDCandidates(logicalGranteeKey, idStr) {
+			candidatePrefix := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, candidate)
+			if granteeIDKey == "" {
+				granteeIDKey = candidatePrefix
+			}
+			if candidateKeys := granteeIDKeys[candidate]; len(candidateKeys) > 0 {
+				idKeys = candidateKeys
+				granteeIDKey = candidatePrefix
+				break
+			}
 		}
 		for _, idKey := range idKeys {
 			granteeIDInfos := typeutil.AfterN(idKey, granteeIDKey, "/")

--- a/internal/metastore/kv/rootcoord/kv_catalog_test.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -22,6 +23,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
+	memkv "github.com/milvus-io/milvus/internal/kv/mem"
 	"github.com/milvus-io/milvus/internal/kv/mocks"
 	"github.com/milvus-io/milvus/internal/metastore"
 	"github.com/milvus-io/milvus/internal/metastore/model"
@@ -2998,11 +3000,17 @@ func TestRBAC_Grant(t *testing.T) {
 				contains := strings.Contains(key, GranteeIDPrefix)
 				if contains {
 					if secondLoadWithPrefixReturn.Load() {
+						firstID := crypto.MD5(funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant) + "obj1/obj_name1")
+						secondID := crypto.MD5(funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant) + "obj2/obj_name2")
 						return []string{
-							key + "PrivilegeLoad",
-							key + "PrivilegeRelease",
-							key + "random/a/b/c",
-							key + util.AnyWord,
+							key + firstID + "/PrivilegeLoad",
+							key + firstID + "/PrivilegeRelease",
+							key + firstID + "/random/a/b/c",
+							key + firstID + "/" + util.AnyWord,
+							key + secondID + "/PrivilegeLoad",
+							key + secondID + "/PrivilegeRelease",
+							key + secondID + "/random/a/b/c",
+							key + secondID + "/" + util.AnyWord,
 						}
 					}
 					return nil
@@ -3270,15 +3278,20 @@ func TestRBACListPolicyLegacyGranteeIDReusesLoadedGrantKeys(t *testing.T) {
 	firstLegacyID := crypto.MD5(firstLogicalKey)
 	secondLegacyID := crypto.MD5(secondLogicalKey)
 	var granteePrefixLoads atomic.Int32
+	var totalPrefixLoads atomic.Int32
 
 	kvmock.EXPECT().LoadWithPrefix(mock.Anything, mock.Anything).Call.Return(
 		func(ctx context.Context, key string) []string {
+			totalPrefixLoads.Inc()
 			switch {
 			case key == granteePrefix:
 				granteePrefixLoads.Inc()
 				return []string{firstEtcdKey, secondEtcdKey}
-			case strings.HasPrefix(key, granteeIDPrefix):
-				return []string{key + "PrivilegeLoad"}
+			case key == granteeIDPrefix:
+				return []string{
+					key + firstLegacyID + "/PrivilegeLoad",
+					key + secondLegacyID + "/PrivilegeLoad",
+				}
 			default:
 				return nil
 			}
@@ -3302,6 +3315,74 @@ func TestRBACListPolicyLegacyGranteeIDReusesLoadedGrantKeys(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, policies, 2)
 	assert.Equal(t, int32(1), granteePrefixLoads.Load(), "ListPolicy should reuse the initially loaded grantee keys for legacy ID collision checks")
+	assert.Equal(t, int32(2), totalPrefixLoads.Load(), "ListPolicy should load grantees and all grantee IDs with two fixed prefix scans")
+}
+
+func TestRBACListPolicyBulkLoadsGranteeIDs(t *testing.T) {
+	assertBulkLoadCount := func(t *testing.T, idBuilder func(string, int) string) {
+		ctx := context.Background()
+		metaKV := memkv.NewMemoryKV()
+		c := NewCatalog(metaKV)
+		const granteeCount = 1000
+		objectType := commonpb.ObjectType_Collection.String()
+		kvs := make(map[string]string, granteeCount*2)
+		for i := 0; i < granteeCount; i++ {
+			granteeKey := fmt.Sprintf("%s/role-%d/%s/%s", GranteePrefix, i, objectType, funcutil.CombineObjectName(util.DefaultDBName, fmt.Sprintf("coll-%d", i)))
+			idStr := idBuilder(granteeKey, i)
+			kvs[granteeKey] = idStr
+			kvs[buildGranteeIDKey(idStr, "PrivilegeLoad")] = "root"
+		}
+		require.NoError(t, metaKV.MultiSave(ctx, kvs))
+
+		var loadWithPrefixCalls atomic.Int32
+		var origin func(*memkv.MemoryKV, context.Context, string) ([]string, []string, error)
+		patched := mockey.Mock((*memkv.MemoryKV).LoadWithPrefix).To(
+			func(kv *memkv.MemoryKV, ctx context.Context, key string) ([]string, []string, error) {
+				loadWithPrefixCalls.Inc()
+				return origin(kv, ctx, key)
+			}).Origin(&origin).Build()
+		defer patched.UnPatch()
+
+		policies, err := c.ListPolicy(ctx, util.DefaultTenant)
+		require.NoError(t, err)
+		require.Len(t, policies, granteeCount)
+		assert.Equal(t, int32(2), loadWithPrefixCalls.Load())
+	}
+
+	t.Run("prefix load count is independent of grantee count", func(t *testing.T) {
+		assertBulkLoadCount(t, func(granteeKey string, _ int) string {
+			return crypto.GranteeID(granteeKey)
+		})
+	})
+
+	t.Run("legacy grantee ownership is indexed in memory", func(t *testing.T) {
+		assertBulkLoadCount(t, func(_ string, i int) string {
+			return fmt.Sprintf("%016x", i)
+		})
+	})
+
+	t.Run("falls back to computed id and skips malformed privilege keys", func(t *testing.T) {
+		ctx := context.Background()
+		metaKV := memkv.NewMemoryKV()
+		c := NewCatalog(metaKV)
+		objectType := commonpb.ObjectType_Collection.String()
+		granteeKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, "fallback-role", objectType, funcutil.CombineObjectName(util.DefaultDBName, "fallback-coll"))
+		storedID := strings.Repeat("a", 32)
+		computedID := crypto.GranteeID(granteeKey)
+		require.NotEqual(t, storedID, computedID)
+		require.NoError(t, metaKV.MultiSave(ctx, map[string]string{
+			granteeKey: storedID,
+			buildGranteeIDKey(computedID, "PrivilegeLoad"):                                        "root",
+			buildGranteeIDKey(computedID, "invalid/nested"):                                       "root",
+			funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, util.DefaultTenant) + "malformed": "root",
+		}))
+
+		policies, err := c.ListPolicy(ctx, util.DefaultTenant)
+		require.NoError(t, err)
+		require.Len(t, policies, 1)
+		assert.Equal(t, "fallback-role", policies[0].GetRole().GetName())
+		assert.Equal(t, "Load", policies[0].GetGrantor().GetPrivilege().GetName())
+	})
 }
 
 func TestRBACGrantMigrationIgnoresUnreferencedComputedLegacyID(t *testing.T) {
@@ -4222,7 +4303,7 @@ func TestRBACReadSkipsEmptyKeySegments(t *testing.T) {
 
 	t.Run("ListPolicy", func(t *testing.T) {
 		granteePrefix := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
-		validIDPrefix := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, "grant-id")
+		granteeIDPrefix := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant)
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock)
 
@@ -4234,8 +4315,8 @@ func TestRBACReadSkipsEmptyKeySegments(t *testing.T) {
 			[]string{"grant-id", "bad-id"},
 			nil,
 		)
-		kvmock.EXPECT().LoadWithPrefix(mock.Anything, validIDPrefix).Return(
-			[]string{validIDPrefix + "PrivilegeLoad", validIDPrefix},
+		kvmock.EXPECT().LoadWithPrefix(mock.Anything, granteeIDPrefix).Return(
+			[]string{granteeIDPrefix + "grant-id/PrivilegeLoad", granteeIDPrefix + "grant-id/"},
 			nil,
 			nil,
 		)


### PR DESCRIPTION
issue: #52525
pr: #52535

- RBAC policy listing: bulk-load the grantee and privilege subtrees and join them in memory so metadata access uses two fixed prefix scans
- legacy compatibility: index stored grantee ID ownership once while preserving fallback, malformed-key handling, and shared-ID fail-closed behavior