### PR TITLE
test: [cp2.6] relax hybrid-search-as-search assertion to a set comparison

### DIFF
--- a/tests/python_client/milvus_client_v2/test_milvus_client_hybrid_search_v2.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_hybrid_search_v2.py
@@ -929,9 +929,9 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         mid_distances = []
         for i in range(len(field_names)):
             field_name = field_names[i]
-            res_search = self.search(client, self.collection_name, data=search_data,
-                                     anns_field=field_name,
-                                     limit=limit)[0]
+            res_search = self.search(
+                client, self.collection_name, data=search_data, anns_field=field_name, limit=limit
+            )[0]
             field_mid_distances = []
             for j in range(nq):
                 field_mid_distances.append(res_search[j].distances[limit // 2 - 1])
@@ -940,49 +940,66 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         # 1. hybrid search without range search
         req_list = []
         for field_name in field_names:
-            req = AnnSearchRequest(**{
-                "data": search_data,
-                "anns_field": field_name,
-                "param": {},
-                "limit": limit,
-            })
+            req = AnnSearchRequest(
+                **{
+                    "data": search_data,
+                    "anns_field": field_name,
+                    "param": {},
+                    "limit": limit,
+                }
+            )
             req_list.append(req)
-        res1 = self.hybrid_search(client, self.collection_name, reqs=req_list,
-                                  ranker=WeightedRanker(0.5, 0.5),
-                                  limit=limit,
-                                  output_fields=[self.primary_key_field_name, self.string_field_name],
-                                  check_task=CheckTasks.check_search_results,
-                                  check_items={"nq": nq, "ids": self.primary_keys, "limit": limit,
-                                               "enable_milvus_client_api": True,
-                                               "metric": "IP",
-                                               "pk_name": self.primary_key_field_name,
-                                               "output_fields": [self.primary_key_field_name,
-                                                                 self.string_field_name]})[0]
+        res1 = self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=WeightedRanker(0.5, 0.5),
+            limit=limit,
+            output_fields=[self.primary_key_field_name, self.string_field_name],
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "nq": nq,
+                "ids": self.primary_keys,
+                "limit": limit,
+                "enable_milvus_client_api": True,
+                "metric": "IP",
+                "pk_name": self.primary_key_field_name,
+                "output_fields": [self.primary_key_field_name, self.string_field_name],
+            },
+        )[0]
 
         # 2. hybrid search with range search one nq by one nq
         for i in range(nq):
             req_list2 = []
             for j in range(len(field_names)):
                 field_name = field_names[j]
-                req = AnnSearchRequest(**{
-                    "data": [search_data[i]],
-                    "anns_field": field_name,
-                    "param": {"params": {"radius": float(mid_distances[j]), "range_filter": 9999}},
-                    "limit": limit // 2,
-                })
+                req = AnnSearchRequest(
+                    **{
+                        "data": [search_data[i]],
+                        "anns_field": field_name,
+                        "param": {"params": {"radius": float(mid_distances[j]), "range_filter": 9999}},
+                        "limit": limit // 2,
+                    }
+                )
                 req_list2.append(req)
-            res2 = self.hybrid_search(client, self.collection_name, reqs=req_list2,
-                                      ranker=WeightedRanker(0.5, 0.5),
-                                      limit=limit // 2,
-                                      output_fields=[self.primary_key_field_name, self.string_field_name],
-                                      check_task=CheckTasks.check_search_results,
-                                      check_items={"nq": 1, "ids": self.primary_keys,  # "limit": limit // 2,
-                                                   "enable_milvus_client_api": True,
-                                                   "metric": "IP",
-                                                   "pk_name": self.primary_key_field_name,
-                                                   "output_fields": [self.primary_key_field_name,
-                                                                     self.string_field_name]})[0]
-            hit_rate = len(set(res2[0].ids).intersection(set(res1[i].ids[:limit // 2]))) / len(res2[0].ids)
+            res2 = self.hybrid_search(
+                client,
+                self.collection_name,
+                reqs=req_list2,
+                ranker=WeightedRanker(0.5, 0.5),
+                limit=limit // 2,
+                output_fields=[self.primary_key_field_name, self.string_field_name],
+                check_task=CheckTasks.check_search_results,
+                check_items={
+                    "nq": 1,
+                    "ids": self.primary_keys,  # "limit": limit // 2,
+                    "enable_milvus_client_api": True,
+                    "metric": "IP",
+                    "pk_name": self.primary_key_field_name,
+                    "output_fields": [self.primary_key_field_name, self.string_field_name],
+                },
+            )[0]
+            hit_rate = len(set(res2[0].ids).intersection(set(res1[i].ids[: limit // 2]))) / len(res2[0].ids)
             # log.debug(f"hybrid search with range nq={i} hit hybrid search without rage, hit rate: {hit_rate}")
             assert hit_rate >= 0.7, f"failed in nq={i}"
 

--- a/tests/python_client/milvus_client_v2/test_milvus_client_hybrid_search_v2.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_hybrid_search_v2.py
@@ -734,7 +734,10 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
                 },
             )[0]
             for i in range(nq):
-                assert hybrid_res[i].ids == search_res[i].ids
+                # Compare as sets: when scores are tied the tie-breaking order
+                # is non-deterministic across architectures (x86 vs ARM) and
+                # runs, so asserting a strict ordered list is flaky.
+                assert set(hybrid_res[i].ids) == set(search_res[i].ids)
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_hybrid_search_RRFRanker_default_parameter(self):


### PR DESCRIPTION
Related: #29839

### What

`test_hybrid_search_as_search` asserts that `hybrid_search` and `search` return the **exact same ordered** id list:

```python
assert hybrid_res[i].ids == search_res[i].ids
```

That assumption does not hold when scores are tied, so the test is data-dependent flaky.

master already relaxed this to a set comparison. This PR cherry-picks the same change (comment included verbatim) to the 2.6 test file, which still carries the strict version:

```python
# Compare as sets: when scores are tied the tie-breaking order
# is non-deterministic across architectures (x86 vs ARM) and
# runs, so asserting a strict ordered list is flaky.
assert set(hybrid_res[i].ids) == set(search_res[i].ids)
```

### Why the two paths can legitimately disagree

- plain `search` orders by the raw score coming out of segcore;
- `hybrid_search` goes through the ranker, which normalizes the score with `2*atan(x)/pi` **as float32** before sorting — `internal/util/function/rerank/util.go:587`;
- on equal scores the ranker breaks ties by **ascending primary key** — `internal/util/function/rerank/util.go:226-228` — which has nothing to do with the order segcore produced.

Around this test's tail scores (~10–20) the derivative of `2*atan(x)/pi` is ~1.6e-3 to 6e-3, while the float32 ULP there is ~6e-8. So two distinct raw scores closer than ~1e-5 collapse onto the same float32 value, and the ranker then reorders them by primary key. Whether that happens depends on the randomly generated text/vector data — which is why the failing position moves around.

Note this is only about the *test's* assumption. Set equality still holds, and the scores themselves are unchanged; only the relative order of equal-score entries differs.

### Evidence

Observed twice on 2.6 branches, at different positions, on unrelated PRs:

| Run | Base | Failure |
| --- | --- | --- |
| PR#52496 | `2.6` | `At index 51 diff: 1047 != 3637` |
| PR#52517 | `hotfix-2.6.22` | `At index 66 diff: 1939 != 3455` |

Both runs were on aarch64, which matches the note master added: the tie-breaking order is non-deterministic **across architectures and across runs**.

The same failure was reported in 2024 as #29839 and closed by the stale bot without a fix.

### Alternative considered

`WeightedRanker(1, norm_score=False)` would avoid the normalization entirely and keep the strict ordered assertion. Not chosen here, because master already settled on the set comparison and this PR is meant to be a faithful backport rather than a second, divergent fix.
