### PR TITLE
fix: [3.0] reconcile absent ordinary fields during schema bump

### DIFF
--- a/internal/datanode/compactor/bump_readback_oracle_test.go
+++ b/internal/datanode/compactor/bump_readback_oracle_test.go
@@ -1,0 +1,789 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compactor
+
+// Real-path read-back oracle (UT_ENHANCEMENT_PLAN §2). Reads a bumped segment
+// back through the PRODUCTION read path and returns fieldID->logical-value rows
+// so S0 tests can diff actual materialized content, not counts. Row order is the
+// read order — bump routes (additive append / fullRewrite selection / bumpOnly)
+// preserve source row order, so the default oracle is order-sensitive.
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/compaction"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/internal/util/function"
+	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+// readBackRowsFromBinlogs reads seg via newCompactionSegmentRecordReader (prod
+// read path) + ValueDeserializerWithSchema, returning rows in read order. Each
+// row is a fieldID->logical-value map (nil = physically-null cell).
+func (s *BumpSchemaVersionCompactionTaskSuite) readBackRowsFromBinlogs(seg *datapb.CompactionSegmentBinlogs, schema *schemapb.CollectionSchema) []map[int64]interface{} {
+	reader, _, err := newCompactionSegmentRecordReader(context.Background(), seg, schema, s.task.compactionParams.StorageConfig,
+		storage.WithVersion(seg.GetStorageVersion()),
+		storage.WithDownloader(s.task.chunkManager.MultiRead),
+		storage.WithStorageConfig(s.task.compactionParams.StorageConfig),
+	)
+	s.Require().NoError(err)
+	defer reader.Close()
+
+	rows := make([]map[int64]interface{}, 0)
+	for {
+		rec, err := reader.Next()
+		if err == io.EOF {
+			break
+		}
+		s.Require().NoError(err)
+		vs := make([]*storage.Value, rec.Len())
+		s.Require().NoError(storage.ValueDeserializerWithSchema(rec, vs, schema, true))
+		for _, v := range vs {
+			row, ok := v.Value.(map[typeutil.UniqueID]interface{})
+			s.Require().True(ok, "deserialized value is not a field map")
+			m := make(map[int64]interface{}, len(row))
+			for k, val := range row {
+				m[k] = val
+			}
+			rows = append(rows, m)
+		}
+	}
+	return rows
+}
+
+// readBackResultSegment adapts a bump result segment to the reader input; the
+// reader stack follows the result segment's StorageVersion (bump is V3-only;
+// downstream consumers may be V2 — §9).
+func (s *BumpSchemaVersionCompactionTaskSuite) readBackResultSegment(seg *datapb.CompactionSegment, schema *schemapb.CollectionSchema) []map[int64]interface{} {
+	return s.readBackRowsFromBinlogs(&datapb.CompactionSegmentBinlogs{
+		SegmentID:      seg.GetSegmentID(),
+		CollectionID:   1,
+		PartitionID:    1,
+		FieldBinlogs:   seg.GetInsertLogs(),
+		InsertChannel:  "test_channel",
+		StorageVersion: seg.GetStorageVersion(),
+		Manifest:       seg.GetManifest(),
+	}, schema)
+}
+
+// assertFieldMaterialized asserts a field is PHYSICALLY present in the result
+// segment's insert logs with the expected entry count — the "physical existence"
+// pillar. It distinguishes a materialized null column from a field that was never
+// written (pre-fix metadata-only bump), which a logical null read-back alone cannot.
+func (s *BumpSchemaVersionCompactionTaskSuite) assertFieldMaterialized(seg *datapb.CompactionSegment, fieldID int64, wantEntries int64) {
+	for _, fl := range seg.GetInsertLogs() {
+		if fl.GetFieldID() == fieldID {
+			s.Require().NotEmpty(fl.GetBinlogs(), "field %d present but has no binlog entry", fieldID)
+			s.EqualValues(wantEntries, fl.GetBinlogs()[0].GetEntriesNum(), "field %d entry count", fieldID)
+			return
+		}
+	}
+	s.Require().Fail("field not physically materialized", "fieldID %d absent from result insert logs", fieldID)
+}
+
+// assertSameInsertLogIDs asserts two insert-log sets carry identical fieldID→LogID
+// mappings — i.e. zero new writes (bump-only passthrough), the replay invariant.
+func (s *BumpSchemaVersionCompactionTaskSuite) assertSameInsertLogIDs(a, b []*datapb.FieldBinlog) {
+	idOf := func(fbs []*datapb.FieldBinlog) map[int64][]int64 {
+		m := make(map[int64][]int64)
+		for _, fb := range fbs {
+			for _, bl := range fb.GetBinlogs() {
+				m[fb.GetFieldID()] = append(m[fb.GetFieldID()], bl.GetLogID())
+			}
+		}
+		return m
+	}
+	s.Equal(idOf(a), idOf(b), "insert log IDs must be unchanged (bump-only = zero new writes)")
+}
+
+// assertManifestContainsField asserts a field is in the COMMITTED MANIFEST
+// (storage truth), not merely reported in insert logs. Closes FS-1: for a nullable
+// absent field, the null read-back + insert-log EntriesNum pillars are both blind to
+// a "reported but manifest-dropped column" bug (the read path silently filters
+// schema-has/manifest-missing fields, so a dropped column reads back as null just
+// like a real null). This pillar reads the manifest field set directly.
+func (s *BumpSchemaVersionCompactionTaskSuite) assertManifestContainsField(seg *datapb.CompactionSegment, fieldID int64) {
+	ids, err := packed.GetManifestFieldIDs(seg.GetManifest(), s.task.compactionParams.StorageConfig)
+	s.Require().NoError(err)
+	_, ok := ids[fieldID]
+	s.True(ok, "field %d must be in the committed manifest (storage truth), not just the insert-log report", fieldID)
+}
+
+// assertRowsOrdered diffs got against expected in read order (S0 default). A
+// nil expected value means the cell must be physically null/absent.
+func (s *BumpSchemaVersionCompactionTaskSuite) assertRowsOrdered(expected []map[int64]interface{}, got []map[int64]interface{}) {
+	s.Require().Equal(len(expected), len(got), "row count mismatch")
+	for i := range expected {
+		for fid, want := range expected[i] {
+			if want == nil {
+				gv, present := got[i][fid]
+				s.True(!present || gv == nil, "row %d field %d expected null, got %v", i, fid, gv)
+				continue
+			}
+			s.EqualValues(want, got[i][fid], "row %d field %d value mismatch", i, fid)
+		}
+	}
+}
+
+// assertRowsByPK diffs by primary key — ONLY for consumers legally allowed to
+// reorder (sort/merge_sort/clustering); bump paths must use assertRowsOrdered.
+func (s *BumpSchemaVersionCompactionTaskSuite) assertRowsByPK(pkFieldID int64, expected []map[int64]interface{}, got []map[int64]interface{}) {
+	s.Require().Equal(len(expected), len(got), "row count mismatch")
+	index := make(map[interface{}]map[int64]interface{}, len(got))
+	for _, r := range got {
+		index[r[pkFieldID]] = r
+	}
+	for _, want := range expected {
+		gr, ok := index[want[pkFieldID]]
+		s.Require().True(ok, "pk %v missing in result", want[pkFieldID])
+		for fid, wv := range want {
+			if wv == nil {
+				gv, present := gr[fid]
+				s.True(!present || gv == nil, "pk %v field %d expected null, got %v", want[pkFieldID], fid, gv)
+				continue
+			}
+			s.EqualValues(wv, gr[fid], "pk %v field %d value mismatch", want[pkFieldID], fid)
+		}
+	}
+}
+
+// TestReadBackOracleSelfBootstrap bootstraps the oracle on a hand-built segment
+// with KNOWN constant values (expected = the constants written, never a
+// production-path product) so a harness bug cannot hide behind a self-referential
+// expectation.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestReadBackOracleSelfBootstrap() {
+	segID := int64(100)
+	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
+	s.initSegBufferForSchemaBumpWithFields(segID, schemaBumpBaseFields(), nil)
+	s.finishBumpSchemaVersionSegment()
+
+	// initSegBufferForSchemaBumpWithFields writes, per row i in [0,3):
+	//   field 100 (pk)   = segID + i
+	//   field 101 (text) = "test string " + rune('0'+i)
+	schema := &schemapb.CollectionSchema{Fields: schemaBumpBaseFields()}
+	rows := s.readBackRowsFromBinlogs(s.task.plan.SegmentBinlogs[0], schema)
+	s.Require().Len(rows, 3)
+	for i := 0; i < 3; i++ {
+		s.EqualValues(segID+int64(i), rows[i][100], "pk row %d", i)
+		s.Equal("test string "+string(rune('0'+i)), rows[i][101], "text row %d", i)
+		// system columns present and non-null
+		s.NotNil(rows[i][common.RowIDField], "row_id row %d", i)
+		s.NotNil(rows[i][common.TimeStampField], "ts row %d", i)
+	}
+}
+
+// TestAdditiveAbsentNullableField_ReadBack — S0. Adding a nullable ordinary
+// field to a sealed segment must materialize it as physical NULL on every row,
+// while preserved fields and system columns stay byte-identical and row order
+// is kept. Pre-fix this routed to metadata-only bump (field never written);
+// count-only tests cannot see that the synthesized column is actually null.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestAdditiveAbsentNullableField_ReadBack() {
+	segID := int64(100)
+	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
+	s.initSegBufferForSchemaBumpWithFields(segID, schemaBumpBaseFields(), nil)
+	s.finishBumpSchemaVersionSegment()
+
+	baseSchema := &schemapb.CollectionSchema{Fields: schemaBumpBaseFields()}
+	srcRows := s.readBackRowsFromBinlogs(s.task.plan.SegmentBinlogs[0], baseSchema)
+	s.Require().Len(srcRows, 3)
+
+	const absentID = int64(103)
+	targetFields := append(schemaBumpBaseFields(), &schemapb.FieldSchema{
+		FieldID: absentID, Name: "added_nullable", DataType: schemapb.DataType_Int64, Nullable: true,
+	})
+	s.task.plan.Schema = &schemapb.CollectionSchema{Name: "bump_absent_nullable", Fields: targetFields}
+	s.task.plan.Functions = nil
+	targetSchema := &schemapb.CollectionSchema{Fields: targetFields}
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.Require().Len(result.GetSegments(), 1)
+	// Physical-existence pillar first: the field must be a real materialized
+	// column (distinguishes null column from never-written pre-fix bump).
+	s.assertFieldMaterialized(result.GetSegments()[0], absentID, 3)
+	// FS-1 storage-truth pillar: a nullable null read-back cannot tell a real null
+	// from a manifest-dropped column; assert the manifest actually carries the field.
+	s.assertManifestContainsField(result.GetSegments()[0], absentID)
+	dstRows := s.readBackResultSegment(result.GetSegments()[0], targetSchema)
+
+	s.Require().Len(dstRows, 3, "row count preserved")
+	for i := 0; i < 3; i++ {
+		s.Nil(dstRows[i][absentID], "row %d: absent nullable field must be physical NULL", i)
+		s.EqualValues(srcRows[i][100], dstRows[i][100], "row %d: pk preserved", i)
+		s.EqualValues(srcRows[i][101], dstRows[i][101], "row %d: text preserved", i)
+		s.EqualValues(srcRows[i][common.RowIDField], dstRows[i][common.RowIDField], "row %d: row_id conserved byte-for-byte", i)
+		s.EqualValues(srcRows[i][common.TimeStampField], dstRows[i][common.TimeStampField], "row %d: ts conserved byte-for-byte", i)
+	}
+}
+
+// TestAdditiveAbsentDefaultField_ReadBack — S0. Absent field WITH a default must
+// be materialized as the default value on every historical row (not null).
+func (s *BumpSchemaVersionCompactionTaskSuite) TestAdditiveAbsentDefaultField_ReadBack() {
+	segID := int64(100)
+	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
+	s.initSegBufferForSchemaBumpWithFields(segID, schemaBumpBaseFields(), nil)
+	s.finishBumpSchemaVersionSegment()
+
+	baseSchema := &schemapb.CollectionSchema{Fields: schemaBumpBaseFields()}
+	srcRows := s.readBackRowsFromBinlogs(s.task.plan.SegmentBinlogs[0], baseSchema)
+
+	const defID = int64(103)
+	targetFields := append(schemaBumpBaseFields(), &schemapb.FieldSchema{
+		FieldID: defID, Name: "added_default", DataType: schemapb.DataType_Int64, Nullable: true,
+		DefaultValue: &schemapb.ValueField{Data: &schemapb.ValueField_LongData{LongData: 42}},
+	})
+	s.task.plan.Schema = &schemapb.CollectionSchema{Name: "bump_absent_default", Fields: targetFields}
+	s.task.plan.Functions = nil
+	targetSchema := &schemapb.CollectionSchema{Fields: targetFields}
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.Require().Len(result.GetSegments(), 1)
+	s.assertFieldMaterialized(result.GetSegments()[0], defID, 3)
+	dstRows := s.readBackResultSegment(result.GetSegments()[0], targetSchema)
+
+	s.Require().Len(dstRows, 3)
+	for i := 0; i < 3; i++ {
+		s.EqualValues(42, dstRows[i][defID], "row %d: absent field must carry default value 42", i)
+		s.EqualValues(srcRows[i][100], dstRows[i][100], "row %d: pk preserved", i)
+		s.EqualValues(srcRows[i][common.RowIDField], dstRows[i][common.RowIDField], "row %d: row_id conserved", i)
+	}
+}
+
+// TestAdditiveAbsentStructArrayVectorSubfield_52555 — verifies our fix covers
+// issue #52555: adding a nullable struct-array field with a vector sub-field
+// (fieldID 106) to a sealed segment. Because GetAllFieldSchemas expands struct
+// sub-fields, absentOrdinarySchemaFields includes 106, so the additive path must
+// materialize 106's binlog. #52555's root cause is that the (pre-fix) bump-only
+// path wrote NO binlog for the added field, so the index pre-check reported
+// "vector array field binlog not found; fieldID=106". If additive materializes it,
+// the pre-check finds the binlog and create_index no longer fails.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestAdditiveAbsentStructArrayVectorSubfield_52555() {
+	segID := int64(100)
+	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
+	s.initSegBufferForSchemaBumpWithFields(segID, schemaBumpBaseFields(), nil)
+	s.finishBumpSchemaVersionSegment()
+
+	const structFieldID = int64(104)
+	const vecSubFieldID = int64(106)
+	targetSchema := &schemapb.CollectionSchema{
+		Name:   "bump_struct_array",
+		Fields: schemaBumpBaseFields(),
+		StructArrayFields: []*schemapb.StructArrayFieldSchema{{
+			FieldID: structFieldID,
+			Name:    "profile",
+			Fields: []*schemapb.FieldSchema{{
+				FieldID:     vecSubFieldID,
+				Name:        "p_vec",
+				DataType:    schemapb.DataType_ArrayOfVector,
+				ElementType: schemapb.DataType_FloatVector,
+				Nullable:    true,
+				TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "8"}},
+			}},
+		}},
+	}
+	s.task.plan.Schema = targetSchema
+	s.task.plan.Functions = nil
+	params, err := compaction.GenerateJSONParams(targetSchema)
+	s.Require().NoError(err)
+	s.task.plan.JsonParams = params
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err, "additive must materialize absent struct-array vector sub-field, not fail (#52555)")
+	s.Require().Len(result.GetSegments(), 1)
+
+	// 106 must have a materialized binlog (top-level or as a struct child field) —
+	// exactly what #52555's index pre-check looks for.
+	seg := result.GetSegments()[0]
+	found := false
+	for _, fb := range seg.GetInsertLogs() {
+		if fb.GetFieldID() == vecSubFieldID {
+			found = true
+		}
+		for _, cf := range fb.GetChildFields() {
+			if cf == vecSubFieldID {
+				found = true
+			}
+		}
+	}
+	s.True(found, "struct-array vector sub-field %d must be materialized into insert logs (#52555)", vecSubFieldID)
+	s.assertManifestContainsField(seg, vecSubFieldID)
+}
+
+// TestAdditiveStructArrayThreeChildFields_FillEmpty — verifies additive fills empty
+// for EVERY child of a struct-array field (not just one vector sub-field). Since
+// GetAllFieldSchemas expands all struct sub-fields, absentOrdinarySchemaFields must
+// contain all 3, and each must be materialized (its own column group + binlog).
+func (s *BumpSchemaVersionCompactionTaskSuite) TestAdditiveStructArrayThreeChildFields_FillEmpty() {
+	segID := int64(100)
+	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
+	s.initSegBufferForSchemaBumpWithFields(segID, schemaBumpBaseFields(), nil)
+	s.finishBumpSchemaVersionSegment()
+
+	const structFieldID = int64(104)
+	childIDs := []int64{106, 107, 108}
+	targetSchema := &schemapb.CollectionSchema{
+		Name:   "bump_struct_3child",
+		Fields: schemaBumpBaseFields(),
+		StructArrayFields: []*schemapb.StructArrayFieldSchema{{
+			FieldID: structFieldID,
+			Name:    "profile",
+			Fields: []*schemapb.FieldSchema{
+				{
+					FieldID: 106, Name: "p_vec", DataType: schemapb.DataType_ArrayOfVector,
+					ElementType: schemapb.DataType_FloatVector, Nullable: true,
+					TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "8"}},
+				},
+				{
+					FieldID: 107, Name: "p_tags", DataType: schemapb.DataType_Array,
+					ElementType: schemapb.DataType_VarChar, Nullable: true,
+					TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "64"}},
+				},
+				{
+					FieldID: 108, Name: "p_nums", DataType: schemapb.DataType_Array,
+					ElementType: schemapb.DataType_Int64, Nullable: true,
+				},
+			},
+		}},
+	}
+	s.task.plan.Schema = targetSchema
+	s.task.plan.Functions = nil
+	params, err := compaction.GenerateJSONParams(targetSchema)
+	s.Require().NoError(err)
+	s.task.plan.JsonParams = params
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err, "additive must fill empty for EACH struct child, not fail")
+	s.Require().Len(result.GetSegments(), 1)
+	seg := result.GetSegments()[0]
+
+	for _, cid := range childIDs {
+		found := false
+		for _, fb := range seg.GetInsertLogs() {
+			if fb.GetFieldID() == cid {
+				found = true
+			}
+			for _, cf := range fb.GetChildFields() {
+				if cf == cid {
+					found = true
+				}
+			}
+		}
+		s.True(found, "struct child field %d must be filled empty + materialized into insert logs", cid)
+		s.assertManifestContainsField(seg, cid)
+	}
+}
+
+// TestAdditiveAbsentTextFieldAsBinary_ReadBack — S0/S2. Adding a nullable TEXT
+// field routes additive through setupWriter's WithTextRefsAsBinary branch (the
+// plain partial writer REJECTS TEXT via validatePackedRecordBatchWriterSchema).
+// Without that writer this Compact would fail; the materializer must also fill the
+// absent TEXT column as a binary null (a utf8 fill panics array.NewRecord). Prior
+// tests only covered the fullRewrite TEXT path + Int64 additive — the additive
+// TEXT path (this exact writer branch) was uncovered.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestAdditiveAbsentTextFieldAsBinary_ReadBack() {
+	segID := int64(100)
+	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
+	s.initSegBufferForSchemaBumpWithFields(segID, schemaBumpBaseFields(), nil)
+	s.finishBumpSchemaVersionSegment()
+
+	baseSchema := &schemapb.CollectionSchema{Fields: schemaBumpBaseFields()}
+	srcRows := s.readBackRowsFromBinlogs(s.task.plan.SegmentBinlogs[0], baseSchema)
+	s.Require().Len(srcRows, 3)
+
+	const textID = int64(105)
+	targetFields := append(schemaBumpBaseFields(), &schemapb.FieldSchema{
+		FieldID: textID, Name: "note", DataType: schemapb.DataType_Text, Nullable: true,
+		TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "65535"}},
+	})
+	s.task.plan.Schema = &schemapb.CollectionSchema{Name: "bump_absent_text", Fields: targetFields}
+	s.task.plan.Functions = nil
+	params, err := compaction.GenerateJSONParams(s.task.plan.GetSchema())
+	s.Require().NoError(err)
+	s.task.plan.JsonParams = params
+	targetSchema := &schemapb.CollectionSchema{Fields: targetFields}
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err, "additive must route TEXT schema through WithTextRefsAsBinary, not fail")
+	s.Require().Len(result.GetSegments(), 1)
+	s.assertFieldMaterialized(result.GetSegments()[0], textID, 3)
+	s.assertManifestContainsField(result.GetSegments()[0], textID)
+
+	dstRows := s.readBackResultSegment(result.GetSegments()[0], targetSchema)
+	s.Require().Len(dstRows, 3)
+	for i := 0; i < 3; i++ {
+		s.Nil(dstRows[i][textID], "row %d: absent TEXT field must be physical NULL (binary LOB-ref)", i)
+		s.EqualValues(srcRows[i][100], dstRows[i][100], "row %d: pk preserved", i)
+		s.EqualValues(srcRows[i][common.RowIDField], dstRows[i][common.RowIDField], "row %d: row_id conserved", i)
+	}
+}
+
+// TestAdditiveBM25Output_ReadBack — S0. Backfilling a BM25 function output
+// (sparse) must physically materialize it on every row, with the input text and
+// system columns conserved. Sparse content correctness is pinned at unit level
+// (mock-runner byte oracle); this integration test pins physical-existence +
+// non-null + no row loss/misalignment through the real loon-FFI write/read path.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestAdditiveBM25Output_ReadBack() {
+	s.prepareBumpSchemaVersionCompaction() // source: base fields (text 101), no sparse 102
+
+	srcSchema := &schemapb.CollectionSchema{Fields: schemaBumpBaseFields()}
+	srcRows := s.readBackRowsFromBinlogs(s.task.plan.SegmentBinlogs[0], srcSchema)
+	s.Require().Len(srcRows, 3)
+
+	const sparseID = int64(102)
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.Require().Len(result.GetSegments(), 1)
+	s.assertFieldMaterialized(result.GetSegments()[0], sparseID, 3)
+
+	dstRows := s.readBackResultSegment(result.GetSegments()[0], s.task.plan.GetSchema())
+	s.Require().Len(dstRows, 3)
+
+	// mirror-oracle: run the SAME BM25 runner over the source text; the materialized
+	// sparse must equal it byte-for-byte per row. Catches row rotation/misalignment
+	// that a NotNil check cannot (v3 B2b). Bound: pins materialize-path vs runner-path
+	// consistency, NOT BM25 math itself (v3 §9).
+	coll := s.task.plan.GetSchema()
+	runner, err := function.NewFunctionRunner(coll, coll.GetFunctions()[0])
+	s.Require().NoError(err)
+	defer runner.Close()
+	texts := make([]string, len(srcRows))
+	for i := range srcRows {
+		texts[i] = srcRows[i][101].(string)
+	}
+	out, err := runner.BatchRun(texts)
+	s.Require().NoError(err)
+	expected, ok := out[0].(*schemapb.SparseFloatArray)
+	s.Require().True(ok)
+	s.Require().Len(expected.GetContents(), 3)
+
+	for i := 0; i < 3; i++ {
+		gotSparse, ok := dstRows[i][sparseID].([]byte)
+		s.Require().True(ok, "row %d: sparse must be []byte", i)
+		s.Equal(expected.GetContents()[i], gotSparse, "row %d: sparse must match mirror-oracle (byte-for-byte, catches rotation)", i)
+		s.EqualValues(srcRows[i][100], dstRows[i][100], "row %d: pk preserved", i)
+		s.EqualValues(srcRows[i][101], dstRows[i][101], "row %d: text input preserved", i)
+		s.EqualValues(srcRows[i][common.RowIDField], dstRows[i][common.RowIDField], "row %d: row_id conserved", i)
+	}
+}
+
+// TestEnsureAdditiveReadAnchor_Branches — S3. The additive read must always
+// carry a physical row-count anchor: RowID preferred, else Timestamp, else a
+// deterministic error (never a stuck/zero-row bump).
+func (s *BumpSchemaVersionCompactionTaskSuite) TestEnsureAdditiveReadAnchor_Branches() {
+	s.task.plan.Schema = &schemapb.CollectionSchema{Fields: schemaBumpBaseFields()}
+	empty := func() *schemapb.CollectionSchema {
+		return &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{}}
+	}
+
+	_, ids, err := s.task.ensureAdditiveReadAnchor(empty(), nil, map[int64]struct{}{common.RowIDField: {}, common.TimeStampField: {}})
+	s.Require().NoError(err)
+	s.Contains(ids, int64(common.RowIDField), "RowID preferred as anchor")
+
+	_, ids, err = s.task.ensureAdditiveReadAnchor(empty(), nil, map[int64]struct{}{common.TimeStampField: {}})
+	s.Require().NoError(err)
+	s.Contains(ids, int64(common.TimeStampField), "Timestamp fallback anchor")
+
+	_, _, err = s.task.ensureAdditiveReadAnchor(empty(), nil, map[int64]struct{}{100: {}})
+	s.Require().Error(err, "neither RowID nor Timestamp physically present -> deterministic error, no stuck bump")
+
+	// already carrying an anchor -> unchanged
+	_, ids, err = s.task.ensureAdditiveReadAnchor(empty(), []int64{common.RowIDField}, map[int64]struct{}{})
+	s.Require().NoError(err)
+	s.Equal([]int64{common.RowIDField}, ids)
+}
+
+// TestAdditiveReplayBumpOnly_ReadBack — S3, REAL replay vector. After the first
+// additive bump commits (materializes 103), a crash-after-commit re-triggers the
+// plan on the ADVANCED manifest (already carrying 103). The second run must route
+// bump-only: manifest unchanged, insert logs passed through with identical LogIDs
+// (zero new writes), data identical. The prior version re-ran the same original
+// plan (tested determinism, not the real advanced-manifest replay).
+func (s *BumpSchemaVersionCompactionTaskSuite) TestAdditiveReplayBumpOnly_ReadBack() {
+	segID := int64(100)
+	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
+	s.initSegBufferForSchemaBumpWithFields(segID, schemaBumpBaseFields(), nil)
+	s.finishBumpSchemaVersionSegment()
+
+	const absentID = int64(103)
+	targetFields := append(schemaBumpBaseFields(), &schemapb.FieldSchema{
+		FieldID: absentID, Name: "added_nullable", DataType: schemapb.DataType_Int64, Nullable: true,
+	})
+	s.task.plan.Schema = &schemapb.CollectionSchema{Name: "bump_replay", Fields: targetFields}
+	s.task.plan.Functions = nil
+	targetSchema := &schemapb.CollectionSchema{Fields: targetFields}
+
+	// First bump: additive materializes 103.
+	res1, err := s.task.Compact()
+	s.Require().NoError(err)
+	seg1 := res1.GetSegments()[0]
+	s.assertManifestContainsField(seg1, absentID) // FS-1: seg1 manifest truly carries the field before replay
+	rows1 := s.readBackResultSegment(seg1, targetSchema)
+	s.Require().Len(rows1, 3)
+
+	// Real replay: feed the advanced manifest (contains 103) back as plan input.
+	s.task.plan.SegmentBinlogs = []*datapb.CompactionSegmentBinlogs{{
+		SegmentID:      seg1.GetSegmentID(),
+		CollectionID:   1,
+		PartitionID:    1,
+		FieldBinlogs:   seg1.GetInsertLogs(),
+		InsertChannel:  "test_channel",
+		StorageVersion: seg1.GetStorageVersion(),
+		Manifest:       seg1.GetManifest(),
+	}}
+	s.task.plan.TotalRows = seg1.GetNumOfRows()
+
+	// Real replay is a FRESH task object on the advanced manifest (crash-after-commit
+	// meta re-trigger), not the same in-memory task — build a new one over the same plan.
+	task2 := NewBumpSchemaVersionCompactionTask(context.Background(), s.task.chunkManager, s.task.plan, s.task.compactionParams)
+	res2, err := task2.Compact()
+	s.Require().NoError(err)
+	seg2 := res2.GetSegments()[0]
+
+	// 103 already present -> bump-only: zero new writes, data unchanged.
+	s.Equal(seg1.GetManifest(), seg2.GetManifest(), "replay must not rewrite manifest (bump-only)")
+	s.assertSameInsertLogIDs(seg1.GetInsertLogs(), seg2.GetInsertLogs())
+	rows2 := s.readBackResultSegment(seg2, targetSchema)
+	s.assertRowsOrdered(rows1, rows2)
+}
+
+// TestFullRewriteDropsField_ReadBack — S0/S1. Dropping a field routes to
+// fullRewrite; the result must physically lose the dropped column while every
+// kept row's other columns stay byte-identical and no row is lost (no delete).
+// This drives the fullRewrite data flow through the REAL writer + read-back,
+// replacing the mock-writer-only coverage.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteDropsField_ReadBack() {
+	segID := int64(100)
+	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
+	srcFields := append(schemaBumpBaseFields(), &schemapb.FieldSchema{
+		FieldID: 104, Name: "to_drop", DataType: schemapb.DataType_Int64, Nullable: true,
+	})
+	s.initSegBufferForSchemaBumpWithFields(segID, srcFields, func(i int, v map[int64]interface{}) {
+		v[104] = int64(1000 + i)
+	})
+	s.finishBumpSchemaVersionSegment()
+
+	srcSchema := &schemapb.CollectionSchema{Fields: srcFields}
+	srcRows := s.readBackRowsFromBinlogs(s.task.plan.SegmentBinlogs[0], srcSchema)
+	s.Require().Len(srcRows, 3)
+	s.EqualValues(1000, srcRows[0][104], "sanity: source carried field 104")
+
+	// target drops 104 -> droppedFieldIDs -> fullRewrite route
+	s.task.plan.Schema = &schemapb.CollectionSchema{Name: "bump_drop", Fields: schemaBumpBaseFields()}
+	s.task.plan.Functions = nil
+	targetSchema := &schemapb.CollectionSchema{Fields: schemaBumpBaseFields()}
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.Require().Len(result.GetSegments(), 1)
+	dstRows := s.readBackResultSegment(result.GetSegments()[0], targetSchema)
+
+	s.Require().Len(dstRows, 3, "no delete -> all rows kept")
+	for i := 0; i < 3; i++ {
+		_, has104 := dstRows[i][104]
+		s.False(has104, "row %d: dropped field 104 must be physically gone", i)
+		s.EqualValues(srcRows[i][100], dstRows[i][100], "row %d: pk preserved", i)
+		s.EqualValues(srcRows[i][101], dstRows[i][101], "row %d: text preserved", i)
+		s.EqualValues(srcRows[i][common.RowIDField], dstRows[i][common.RowIDField], "row %d: row_id conserved", i)
+		s.EqualValues(srcRows[i][common.TimeStampField], dstRows[i][common.TimeStampField], "row %d: ts conserved", i)
+	}
+}
+
+// TestDeclaredFunctionOutputFields_Branches — S0. A field flagged
+// IsFunctionOutput with no producing function is persisted-schema corruption and
+// MUST error, never be silently backfilled as an ordinary (a non-nullable sparse
+// vector "default/NULL" fill would corrupt/panic).
+func (s *BumpSchemaVersionCompactionTaskSuite) TestDeclaredFunctionOutputFields_Branches() {
+	ok := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			{FieldID: 102, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
+		},
+		Functions: []*schemapb.FunctionSchema{{Name: "bm25", Type: schemapb.FunctionType_BM25, InputFieldIds: []int64{101}, OutputFieldIds: []int64{102}}},
+	}
+	declared, err := declaredFunctionOutputFields(ok)
+	s.Require().NoError(err)
+	s.Contains(declared, int64(102))
+
+	orphan := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 102, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
+		},
+	}
+	_, err = declaredFunctionOutputFields(orphan)
+	s.Require().Error(err, "orphan function-output field must error, not be backfilled as ordinary")
+}
+
+// TestAbsentOrdinarySchemaFields_Classification — S0. Exactly the non-system,
+// non-function-output, physically-absent fields are classified as absent
+// ordinary (mis-classification either drops a real field or backfills a vector).
+func (s *BumpSchemaVersionCompactionTaskSuite) TestAbsentOrdinarySchemaFields_Classification() {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: common.RowIDField, DataType: schemapb.DataType_Int64},
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			{FieldID: 102, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
+			{FieldID: 103, Name: "added", DataType: schemapb.DataType_Int64, Nullable: true},
+		},
+	}
+	existing := map[int64]struct{}{common.RowIDField: {}, 100: {}, 101: {}}
+	funcOut := map[int64]struct{}{102: {}}
+	absent := absentOrdinarySchemaFields(schema, existing, funcOut)
+	s.Require().Len(absent, 1, "only 103 is absent ordinary")
+	s.EqualValues(103, absent[0].GetFieldID())
+}
+
+// TestAdditiveMinHashOutput_ReadBack — S0. Symmetric to BM25: backfilling a
+// MinHash binary-vector function output must physically materialize it non-null
+// on every row with inputs/system columns conserved.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestAdditiveMinHashOutput_ReadBack() {
+	s.setupMinHashTest()
+	s.prepareMinHashBumpSchemaVersionCompaction()
+
+	srcSchema := &schemapb.CollectionSchema{Fields: schemaBumpBaseFields()}
+	srcRows := s.readBackRowsFromBinlogs(s.task.plan.SegmentBinlogs[0], srcSchema)
+	s.Require().Len(srcRows, 3)
+
+	const minhashID = int64(102)
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.Require().Len(result.GetSegments(), 1)
+	s.assertFieldMaterialized(result.GetSegments()[0], minhashID, 3)
+
+	dstRows := s.readBackResultSegment(result.GetSegments()[0], s.task.plan.GetSchema())
+	s.Require().Len(dstRows, 3)
+
+	// mirror-oracle: run the SAME MinHash runner over source text; materialized
+	// binary output must equal it byte-for-byte per row (catches rotation). Bound:
+	// pins materialize-path vs runner-path consistency, not MinHash math (v3 §9).
+	coll := s.task.plan.GetSchema()
+	runner, err := function.NewFunctionRunner(coll, coll.GetFunctions()[0])
+	s.Require().NoError(err)
+	defer runner.Close()
+	texts := make([]string, len(srcRows))
+	for i := range srcRows {
+		texts[i] = srcRows[i][101].(string)
+	}
+	out, err := runner.BatchRun(texts)
+	s.Require().NoError(err)
+	fd, ok := out[0].(*schemapb.FieldData)
+	s.Require().True(ok)
+	binVec := fd.GetVectors().GetBinaryVector()
+	bytesPerRow := int(fd.GetVectors().GetDim()) / 8
+	s.Require().Equal(3*bytesPerRow, len(binVec))
+
+	for i := 0; i < 3; i++ {
+		gotBin, ok := dstRows[i][minhashID].([]byte)
+		s.Require().True(ok, "row %d: minhash must be []byte", i)
+		s.Equal(binVec[i*bytesPerRow:(i+1)*bytesPerRow], gotBin, "row %d: minhash must match mirror-oracle (byte-for-byte, catches rotation)", i)
+		s.EqualValues(srcRows[i][100], dstRows[i][100], "row %d: pk preserved", i)
+		s.EqualValues(srcRows[i][101], dstRows[i][101], "row %d: text input preserved", i)
+		s.EqualValues(srcRows[i][common.RowIDField], dstRows[i][common.RowIDField], "row %d: row_id conserved", i)
+	}
+}
+
+// TestFullRewriteTTLExpiresAllRows — S0/S1. When a fullRewrite (dropped field)
+// coincides with a collection TTL that expires every row, the result must be a
+// clean empty segment (0 rows), not a malformed manifest or a crash. Exercises
+// the selectFullRewriteRecord Filtered branch + runFullSchemaRewrite empty path.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteTTLExpiresAllRows() {
+	segID := int64(100)
+	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
+	srcFields := append(schemaBumpBaseFields(), &schemapb.FieldSchema{
+		FieldID: 104, Name: "to_drop", DataType: schemapb.DataType_Int64, Nullable: true,
+	})
+	s.initSegBufferForSchemaBumpWithFields(segID, srcFields, func(i int, v map[int64]interface{}) {
+		v[104] = int64(1000 + i)
+	})
+	s.finishBumpSchemaVersionSegment()
+
+	// drop 104 -> fullRewrite; rows carry getMilvusBirthday() ts (years old), so
+	// a 1s collection TTL expires all of them.
+	s.task.plan.Schema = &schemapb.CollectionSchema{Name: "bump_ttl_all", Fields: schemaBumpBaseFields()}
+	s.task.plan.Functions = nil
+	s.task.plan.CollectionTtl = int64(time.Second)
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.Require().Len(result.GetSegments(), 1)
+	// Empty-segment BOUNDARY case: all rows expired -> 0 rows is the correct
+	// oracle here (no rows exist to read back); the row-selection correctness is
+	// pinned by TestFullRewritePartialTTL_ReadBack below, so this is not count-only.
+	seg := result.GetSegments()[0]
+	s.EqualValues(0, seg.GetNumOfRows(), "all rows TTL-expired -> empty result segment")
+	// Close the former over-claim: actually assert the manifest, don't just say it.
+	// An all-expired fullRewrite must not emit a partial/malformed manifest — here
+	// the correct oracle is an empty manifest (verified: probe showed "").
+	s.Empty(seg.GetManifest(), "empty segment must carry no (malformed/partial) manifest")
+}
+
+// TestFullRewritePartialTTL_ReadBack — S0/S1. Replaces the earlier count-only TTL
+// check: with rows at MIXED timestamps and a collection TTL that expires only some,
+// the result must keep exactly the non-expired rows and drop the field — verified by
+// reading the kept row's actual pk/text (a "keep wrong row" bug would slip past a
+// count==1 check).
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewritePartialTTL_ReadBack() {
+	segID := int64(100)
+	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	// Pin task time; rows 0,1 are old (expired under a 1h TTL), row 2 is recent (kept).
+	currentTime := getMilvusBirthday().Add(time.Hour)
+	s.task.currentTime = currentTime
+	insertTs := int64(tsoutil.ComposeTSByTime(currentTime))
+	oldTs := int64(tsoutil.ComposeTSByTime(currentTime.Add(-2 * time.Hour)))
+
+	srcFields := append(schemaBumpBaseFields(), &schemapb.FieldSchema{
+		FieldID: 104, Name: "to_drop", DataType: schemapb.DataType_Int64, Nullable: true,
+	})
+	s.initSegBufferForSchemaBumpWithFields(segID, srcFields, func(i int, v map[int64]interface{}) {
+		v[104] = int64(1000 + i)
+		if i < 2 {
+			v[common.TimeStampField] = oldTs
+		} else {
+			v[common.TimeStampField] = insertTs
+		}
+	})
+	s.finishBumpSchemaVersionSegment()
+
+	// drop 104 -> fullRewrite; collectionTTL=1h expires rows 0,1 only.
+	s.task.plan.Schema = &schemapb.CollectionSchema{Name: "bump_partial_ttl", Fields: schemaBumpBaseFields()}
+	s.task.plan.Functions = nil
+	s.task.plan.CollectionTtl = int64(time.Hour)
+	targetSchema := &schemapb.CollectionSchema{Fields: schemaBumpBaseFields()}
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.Require().Len(result.GetSegments(), 1)
+	dstRows := s.readBackResultSegment(result.GetSegments()[0], targetSchema)
+
+	s.Require().Len(dstRows, 1, "exactly the one non-expired row is kept")
+	s.EqualValues(segID+2, dstRows[0][100], "kept row must be the recent one (pk=102), not an expired one")
+	s.Equal("test string 2", dstRows[0][101], "kept row text must match the recent row")
+	_, has104 := dstRows[0][104]
+	s.False(has104, "dropped field 104 must be physically gone")
+}

--- a/internal/datanode/compactor/bump_schema_version_compactor.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor.go
@@ -80,7 +80,7 @@ func (t *bumpSchemaVersionCompactionTask) Compact() (*datapb.CompactionPlanResul
 		mlog.FieldCollectionID(t.GetCollection()),
 	)
 
-	missingFunctions, droppedFieldIDs, existingFields, err := t.schemaBumpDecision()
+	missingFunctions, droppedFieldIDs, absentOrdinaryFields, existingFields, err := t.schemaBumpDecision()
 	if err != nil {
 		log.Warn(ctx, "failed to decide schema bump action", mlog.Err(err))
 		return nil, err
@@ -90,16 +90,17 @@ func (t *bumpSchemaVersionCompactionTask) Compact() (*datapb.CompactionPlanResul
 		mlog.FieldSegmentID(t.plan.GetSegmentBinlogs()[0].GetSegmentID()),
 		mlog.Int32("collectionSchemaVersion", t.plan.GetSchema().GetVersion()),
 		mlog.Int("missingFunctionCount", len(missingFunctions)),
+		mlog.Int("absentOrdinaryFieldCount", len(absentOrdinaryFields)),
 		mlog.Int64s("droppedFieldIDs", droppedFieldIDs),
 	)
 
 	var result *datapb.CompactionPlanResult
-	if len(missingFunctions) == 0 && len(droppedFieldIDs) == 0 {
+	if len(missingFunctions) == 0 && len(absentOrdinaryFields) == 0 && len(droppedFieldIDs) == 0 {
 		result = t.runSchemaVersionBumpOnly()
 	} else if len(droppedFieldIDs) > 0 {
 		result, err = t.runFullSchemaRewrite(existingFields)
 	} else {
-		result, err = t.runMissingFunctionMaterialization(ctx, missingFunctions, existingFields)
+		result, err = t.runMissingFunctionMaterialization(ctx, missingFunctions, absentOrdinaryFields, existingFields)
 	}
 	if err != nil {
 		log.Warn(ctx, "schema bump compact failed", mlog.Err(err), mlog.Duration("compact cost", time.Since(compactStart)))
@@ -218,7 +219,11 @@ func (t *bumpSchemaVersionCompactionTask) missingFunctionOutputFields(missingFun
 		if err := validateSupportedMissingFunctionMaterialization(functionSchema); err != nil {
 			return nil, nil, err
 		}
-		for _, outputIndex := range functionOutputIndexesToMaterialize(functionSchema, existingFields) {
+		outputIndexes, err := functionOutputIndexesToMaterialize(functionSchema, existingFields)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, outputIndex := range outputIndexes {
 			outputFieldID := functionSchema.GetOutputFieldIds()[outputIndex]
 			outputField := typeutil.GetField(schema, outputFieldID)
 			if outputField == nil {
@@ -288,14 +293,31 @@ func validateMaterializationOutputField(functionSchema *schemapb.FunctionSchema,
 	return nil
 }
 
-func partialMaterializerExistingFields(schema *schemapb.CollectionSchema, missingFunctions []*schemapb.FunctionSchema, existingFields map[int64]struct{}) map[int64]struct{} {
-	fields := collectionSchemaFields(schema)
-	for _, functionSchema := range missingFunctions {
-		for _, outputIndex := range functionOutputIndexesToMaterialize(functionSchema, existingFields) {
-			delete(fields, functionSchema.GetOutputFieldIds()[outputIndex])
+// ensureAdditiveReadAnchor appends a physical anchor column (RowID, else
+// Timestamp) to the additive read schema when none is present, so the reader
+// yields the segment's rows even for a pure ordinary-field bump that reads no
+// function input. The anchor is read for row cardinality only; it is never in
+// outputFields and therefore never rewritten.
+func (t *bumpSchemaVersionCompactionTask) ensureAdditiveReadAnchor(inputSchema *schemapb.CollectionSchema, inputFieldIDs []int64, existingFields map[int64]struct{}) (*schemapb.CollectionSchema, []int64, error) {
+	for _, id := range inputFieldIDs {
+		if id == common.RowIDField || id == common.TimeStampField {
+			return inputSchema, inputFieldIDs, nil
 		}
 	}
-	return fields
+	anchorID := int64(common.RowIDField)
+	if _, ok := existingFields[common.RowIDField]; !ok {
+		if _, ok := existingFields[common.TimeStampField]; !ok {
+			return nil, nil, merr.WrapErrServiceInternalMsg("schema bump additive materialization requires a physical RowID or Timestamp anchor")
+		}
+		anchorID = common.TimeStampField
+	}
+	anchorField := typeutil.GetField(t.plan.GetSchema(), anchorID)
+	if anchorField == nil {
+		return nil, nil, merr.WrapErrServiceInternalMsg("schema bump additive materialization anchor field %d not found in schema", anchorID)
+	}
+	inputSchema.Fields = append(inputSchema.Fields, anchorField)
+	inputFieldIDs = append(inputFieldIDs, anchorID)
+	return inputSchema, inputFieldIDs, nil
 }
 
 func (t *bumpSchemaVersionCompactionTask) openRecordReader(segment *datapb.CompactionSegmentBinlogs, schema *schemapb.CollectionSchema) (storage.RecordReader, map[int64]struct{}, error) {
@@ -311,13 +333,73 @@ func (t *bumpSchemaVersionCompactionTask) openRecordReader(segment *datapb.Compa
 	return reader, existingFields, err
 }
 
-func (t *bumpSchemaVersionCompactionTask) schemaBumpDecision() ([]*schemapb.FunctionSchema, []int64, map[int64]struct{}, error) {
+func (t *bumpSchemaVersionCompactionTask) schemaBumpDecision() ([]*schemapb.FunctionSchema, []int64, []*schemapb.FieldSchema, map[int64]struct{}, error) {
 	segment := t.plan.GetSegmentBinlogs()[0]
 	existingFields, err := compactionSegmentStorageFields(segment, t.compactionParams.StorageConfig)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
-	return missingSchemaFunctions(t.plan.GetSchema(), existingFields), droppedSchemaFieldIDs(t.plan.GetSchema(), existingFields), existingFields, nil
+	schema := t.plan.GetSchema()
+	functionOutputFields, err := declaredFunctionOutputFields(schema)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	return missingSchemaFunctions(schema, existingFields), droppedSchemaFieldIDs(schema, existingFields), absentOrdinarySchemaFields(schema, existingFields, functionOutputFields), existingFields, nil
+}
+
+// declaredFunctionOutputFields returns the output field IDs declared by the
+// schema's functions. A field marked IsFunctionOutput that no function declares
+// is persisted-schema corruption: fail instead of silently backfilling a
+// non-nullable vector as an ordinary field.
+func declaredFunctionOutputFields(schema *schemapb.CollectionSchema) (map[int64]struct{}, error) {
+	declared := make(map[int64]struct{})
+	for _, functionSchema := range schema.GetFunctions() {
+		for _, outputFieldID := range functionSchema.GetOutputFieldIds() {
+			declared[outputFieldID] = struct{}{}
+		}
+	}
+	for _, field := range typeutil.GetAllFieldSchemas(schema) {
+		if field.GetIsFunctionOutput() {
+			if _, hasProducer := declared[field.GetFieldID()]; !hasProducer {
+				return nil, merr.WrapErrDataIntegrityMsg(
+					"function output field %d has no producing function", field.GetFieldID())
+			}
+		}
+	}
+	return declared, nil
+}
+
+// absentOrdinarySchemaFields lists target-schema ordinary fields (non-system,
+// non-function-output) that are physically absent from the manifest. Before
+// #52159 such a field routed to a metadata-only bump and was never physically
+// written; it must instead be materialized as default/NULL so the bumped
+// segment stays physically complete. Function outputs are excluded by the
+// declared set (not the IsFunctionOutput flag) so a declared output is never
+// double-classified as both missing-function output and absent ordinary field.
+func absentOrdinarySchemaFields(schema *schemapb.CollectionSchema, existingFields, functionOutputFields map[int64]struct{}) []*schemapb.FieldSchema {
+	absent := make([]*schemapb.FieldSchema, 0)
+	for _, field := range typeutil.GetAllFieldSchemas(schema) {
+		fieldID := field.GetFieldID()
+		if common.IsSystemField(fieldID) {
+			continue
+		}
+		if _, isFunctionOutput := functionOutputFields[fieldID]; isFunctionOutput {
+			continue
+		}
+		if _, present := existingFields[fieldID]; !present {
+			absent = append(absent, field)
+		}
+	}
+	return absent
+}
+
+func schemaContainsTextField(schema *schemapb.CollectionSchema) bool {
+	for _, field := range typeutil.GetAllFieldSchemas(schema) {
+		if field.GetDataType() == schemapb.DataType_Text {
+			return true
+		}
+	}
+	return false
 }
 
 func (t *bumpSchemaVersionCompactionTask) fullRewriteSegmentID() (int64, error) {
@@ -328,35 +410,35 @@ func (t *bumpSchemaVersionCompactionTask) fullRewriteSegmentID() (int64, error) 
 	return idRange.GetBegin(), nil
 }
 
-func selectFullRewriteRecord(record storage.Record, pkField *schemapb.FieldSchema, entityFilter compaction.EntityFilter, ttlFieldID int64, useTTLField bool, ttlValues []int64) (*recordSelection, []int64, error) {
+func selectFullRewriteRecord(record storage.Record, pkField *schemapb.FieldSchema, entityFilter compaction.EntityFilter, ttlFieldID int64, useTTLField bool) (*recordSelection, error) {
 	pkArray := record.Column(pkField.GetFieldID())
 	var pkAt func(int) any
 	switch pkField.GetDataType() {
 	case schemapb.DataType_Int64:
 		int64Array, ok := pkArray.(*array.Int64)
 		if !ok {
-			return nil, nil, merr.WrapErrServiceInternal("int64 primary key field not found in full schema rewrite record")
+			return nil, merr.WrapErrServiceInternal("int64 primary key field not found in full schema rewrite record")
 		}
 		pkAt = func(i int) any { return int64Array.Value(i) }
 	case schemapb.DataType_VarChar:
 		stringArray, ok := pkArray.(*array.String)
 		if !ok {
-			return nil, nil, merr.WrapErrServiceInternal("varchar primary key field not found in full schema rewrite record")
+			return nil, merr.WrapErrServiceInternal("varchar primary key field not found in full schema rewrite record")
 		}
 		pkAt = func(i int) any { return stringArray.Value(i) }
 	default:
-		return nil, nil, merr.WrapErrServiceInternal("invalid primary key data type for full schema rewrite")
+		return nil, merr.WrapErrServiceInternal("invalid primary key data type for full schema rewrite")
 	}
 
 	timestampArray, ok := record.Column(common.TimeStampField).(*array.Int64)
 	if !ok {
-		return nil, nil, merr.WrapErrServiceInternal("timestamp field not found in full schema rewrite record")
+		return nil, merr.WrapErrServiceInternal("timestamp field not found in full schema rewrite record")
 	}
 	var ttlArray *array.Int64
 	if useTTLField {
 		ttlArray, ok = record.Column(ttlFieldID).(*array.Int64)
 		if !ok {
-			return nil, nil, merr.WrapErrServiceInternal("TTL field not found in full schema rewrite record")
+			return nil, merr.WrapErrServiceInternal("TTL field not found in full schema rewrite record")
 		}
 	}
 
@@ -378,9 +460,6 @@ func selectFullRewriteRecord(record storage.Record, pkField *schemapb.FieldSchem
 			continue
 		}
 
-		if useTTLField && expireTs > 0 {
-			ttlValues = append(ttlValues, expireTs)
-		}
 		if sliceStart == -1 {
 			sliceStart = i
 		}
@@ -390,9 +469,9 @@ func selectFullRewriteRecord(record storage.Record, pkField *schemapb.FieldSchem
 		selection.length += record.Len() - sliceStart
 	}
 	if filteredRows == 0 {
-		return nil, ttlValues, nil
+		return nil, nil
 	}
-	return selection, ttlValues, nil
+	return selection, nil
 }
 
 func (t *bumpSchemaVersionCompactionTask) runSchemaVersionBumpOnly() *datapb.CompactionPlanResult {
@@ -438,6 +517,11 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 	}
 	entityFilter := compaction.NewEntityFilter(delta, t.plan.GetCollectionTtl(), t.currentTime, segment.GetCommitTimestamp())
 	ttlFieldID := getTTLFieldID(t.plan.GetSchema())
+	// Physical presence must come from the manifest, not record.Column: a TTL
+	// field that is itself an absent ordinary field is missing from the raw
+	// read record, and simpleArrowRecord.Column panics on an absent field
+	// (#52159). The map lookup is panic-safe.
+	_, ttlFieldPhysicallyPresent := existingFields[ttlFieldID]
 	reader, _, err := newCompactionSegmentRecordReaderWithFields(t.ctx, segment, t.plan.GetSchema(), t.compactionParams.StorageConfig, existingFields,
 		storage.WithCollectionID(collectionID),
 		storage.WithVersion(segment.GetStorageVersion()),
@@ -508,11 +592,11 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 			return nil, err
 		}
 
-		sourceHasTTLField := ttlFieldID >= common.StartOfUserFieldID && record.Column(ttlFieldID) != nil
+		sourceHasTTLField := ttlFieldID >= common.StartOfUserFieldID && ttlFieldPhysicallyPresent
 		preMaterializeFilter := len(delta) > 0 || t.plan.GetCollectionTtl() > 0 || sourceHasTTLField
 		var selection *recordSelection
 		if preMaterializeFilter {
-			selection, _, err = selectFullRewriteRecord(record, pkField, entityFilter, ttlFieldID, sourceHasTTLField, nil)
+			selection, err = selectFullRewriteRecord(record, pkField, entityFilter, ttlFieldID, sourceHasTTLField)
 			if err != nil {
 				return nil, err
 			}
@@ -789,7 +873,16 @@ func (t *bumpSchemaVersionCompactionTask) newV3WriterResult(schema *schemapb.Col
 	writerFormat := paramtable.Get().DataNodeCfg.StorageFormat.GetValue()
 	columnGroups = storagecommon.FillColumnGroupFormats(columnGroups, writerFormat)
 	schemaBasedFormats := storagecommon.ColumnGroupFormats(columnGroups, writerFormat)
-	writer, err := storage.NewPartialPackedRecordBatchWriter(basePath, schema, int64(t.compactionParams.BinLogMaxSize), packed.DefaultMultiPartUploadSize, columnGroups, t.compactionParams.StorageConfig, pluginContext, writerFormat, schemaBasedFormats)
+	// Newly added TEXT ordinary fields have no historical LOB data; their
+	// absent values are materialized as binary LOB-reference NULLs, so the
+	// writer must use the text-refs-as-binary path (the plain partial writer
+	// rejects TEXT columns). Mirrors the full-rewrite REUSE_ALL handling.
+	var writer bumpSchemaVersionBatchWriter
+	if schemaContainsTextField(schema) {
+		writer, err = storage.NewPartialPackedRecordBatchWriterWithTextRefsAsBinary(basePath, schema, int64(t.compactionParams.BinLogMaxSize), packed.DefaultMultiPartUploadSize, columnGroups, t.compactionParams.StorageConfig, pluginContext, writerFormat, schemaBasedFormats)
+	} else {
+		writer, err = storage.NewPartialPackedRecordBatchWriter(basePath, schema, int64(t.compactionParams.BinLogMaxSize), packed.DefaultMultiPartUploadSize, columnGroups, t.compactionParams.StorageConfig, pluginContext, writerFormat, schemaBasedFormats)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -927,7 +1020,7 @@ func (t *bumpSchemaVersionCompactionTask) finalizeMergedLogs(segment *datapb.Com
 	return storage.SortFieldBinlogs(mergedInsertLogs), nil
 }
 
-func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx context.Context, missingFunctions []*schemapb.FunctionSchema, existingFields map[int64]struct{}) (*datapb.CompactionPlanResult, error) {
+func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx context.Context, missingFunctions []*schemapb.FunctionSchema, absentOrdinaryFields []*schemapb.FieldSchema, existingFields map[int64]struct{}) (*datapb.CompactionPlanResult, error) {
 	segment := t.plan.GetSegmentBinlogs()[0]
 	collectionID := segment.GetCollectionID()
 	partitionID := segment.GetPartitionID()
@@ -937,9 +1030,30 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 	if err != nil {
 		return nil, err
 	}
-	outputFields, outputFieldIDs, err := t.missingFunctionOutputFields(missingFunctions, existingFields)
+	// Absent ordinary fields have no function input to read; guarantee a
+	// physical anchor column so the reader still yields the segment's rows
+	// (pure ordinary-field bump reads nothing otherwise).
+	inputSchema, inputFieldIDs, err = t.ensureAdditiveReadAnchor(inputSchema, inputFieldIDs, existingFields)
 	if err != nil {
 		return nil, err
+	}
+
+	var outputFields []*schemapb.FieldSchema
+	var outputFieldIDs []int64
+	if len(missingFunctions) > 0 {
+		outputFields, outputFieldIDs, err = t.missingFunctionOutputFields(missingFunctions, existingFields)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// #52159: absent ordinary fields must be physically materialized (default/NULL),
+	// not silently left to a metadata-only bump.
+	for _, field := range absentOrdinaryFields {
+		outputFields = append(outputFields, field)
+		outputFieldIDs = append(outputFieldIDs, field.GetFieldID())
+	}
+	if len(outputFields) == 0 {
+		return nil, merr.WrapErrServiceInternalMsg("schema bump additive materialization has no fields to append")
 	}
 
 	log := mlog.With(
@@ -979,7 +1093,10 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 			statsByField[outputFieldID] = storage.NewBM25Stats()
 		}
 	}
-	existingFields = partialMaterializerExistingFields(t.plan.GetSchema(), missingFunctions, existingFields)
+	// existingFields is the manifest-derived physical field set; passing it
+	// directly lets the materializer synthesize every absent field (missing
+	// function outputs AND absent ordinary fields, including a function input
+	// added after sealing — #52159).
 	materializer, err := NewRecordMaterializer(t.plan.GetSchema(), missingFunctions, existingFields)
 	if err != nil {
 		span.End()

--- a/internal/datanode/compactor/bump_schema_version_compactor_test.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/etcdpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
@@ -276,6 +277,51 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionMa
 		}
 	}
 	s.True(found, "MinHash output field should be materialized into insert logs")
+}
+
+// TestBumpSchemaVersionMaterializesAbsentOrdinaryField pins the #52159 core fix:
+// a target ordinary field (no function attached) that is physically absent from
+// the source manifest must be materialized as default/NULL through the additive
+// path. Before the fix it routed to a metadata-only bump and was never written.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionMaterializesAbsentOrdinaryField() {
+	segID := int64(100)
+	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
+	s.initSegBufferForSchemaBump(segID) // source physically has {row_id, ts, 100, 101}
+	s.finishBumpSchemaVersionSegment()
+
+	// Target adds an absent ordinary field (103) and declares no function, so the
+	// only reason to touch data is the ordinary field itself.
+	const absentOrdinaryID = int64(103)
+	s.task.plan.Schema = &schemapb.CollectionSchema{
+		Name: "schema_bump_absent_ordinary",
+		Fields: append(schemaBumpBaseFields(), &schemapb.FieldSchema{
+			FieldID:  absentOrdinaryID,
+			Name:     "added_nullable",
+			DataType: schemapb.DataType_Int64,
+			Nullable: true,
+		}),
+	}
+	s.task.plan.Functions = nil
+
+	result, err := s.task.Compact()
+	s.NoError(err)
+	s.NotNil(result)
+	s.Equal(datapb.CompactionTaskState_completed, result.GetState())
+	s.Require().Len(result.GetSegments(), 1)
+
+	segment := result.GetSegments()[0]
+	s.EqualValues(3, segment.GetNumOfRows())
+	s.NotEmpty(segment.GetManifest())
+
+	found := false
+	for _, fl := range segment.GetInsertLogs() {
+		if fl.GetFieldID() == absentOrdinaryID {
+			found = true
+			s.Require().Len(fl.GetBinlogs(), 1)
+			s.EqualValues(3, fl.GetBinlogs()[0].GetEntriesNum())
+		}
+	}
+	s.True(found, "absent ordinary field must be materialized into insert logs")
 }
 
 func (s *BumpSchemaVersionCompactionTaskSuite) SetupTest() {
@@ -893,12 +939,11 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestSelectFullRewriteRecordDropsD
 	deleteTs := tsoutil.ComposeTSByTime(currentTime.Add(time.Second))
 	entityFilter := compaction.NewEntityFilter(map[any]typeutil.Timestamp{int64(2): deleteTs}, int64(time.Minute), currentTime, 0)
 
-	selection, ttlValues, err := selectFullRewriteRecord(record, pkField, entityFilter, 102, true, nil)
+	selection, err := selectFullRewriteRecord(record, pkField, entityFilter, 102, true)
 	s.Require().NoError(err)
 	s.Require().NotNil(selection)
 	s.Equal(2, selection.Len())
 	s.Equal([]rowRange{{start: 0, end: 1}, {start: 4, end: 5}}, selection.ranges)
-	s.Equal([]int64{keptTTLField, keptTTLField}, ttlValues)
 	s.Equal(1, entityFilter.GetDeletedCount())
 	s.Equal(2, entityFilter.GetExpiredCount())
 }
@@ -971,6 +1016,7 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionWi
 	s.prepareBumpSchemaVersionCompaction()
 
 	s.task.plan.Schema.Functions = []*schemapb.FunctionSchema{}
+	s.task.plan.Schema.Fields = s.task.plan.Schema.Fields[:4]
 	result, err := s.task.Compact()
 	s.NoError(err)
 	s.NotNil(result)
@@ -994,15 +1040,29 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionIn
 }
 
 func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionInvalidOutputField() {
-	s.prepareBumpSchemaVersionCompaction()
+	segID := int64(100)
+	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
+	s.initSegBufferForSchemaBumpWithFields(segID, schemaBumpBaseFields(), nil)
+	s.finishBumpSchemaVersionSegment()
 
-	// Test with wrong output field type (VarChar instead of SparseFloatVector)
-	s.task.plan.Schema.Functions = []*schemapb.FunctionSchema{{
-		Name:           "BM25",
-		Type:           schemapb.FunctionType_BM25,
-		InputFieldIds:  []int64{101},
-		OutputFieldIds: []int64{101, 102},
-	}}
+	// A physically-absent BM25 output declared with the wrong type (VarChar
+	// instead of SparseFloatVector) must be rejected at output-type validation.
+	// A single absent output keeps this on the type-check path, not the
+	// partial-materialization guard.
+	const badOut = int64(105)
+	fields := append(schemaBumpBaseFields(), &schemapb.FieldSchema{
+		FieldID: badOut, Name: "bad_output", DataType: schemapb.DataType_VarChar, IsFunctionOutput: true,
+	})
+	s.task.plan.Schema = &schemapb.CollectionSchema{
+		Name:   "bump_invalid_output",
+		Fields: fields,
+		Functions: []*schemapb.FunctionSchema{{
+			Name:           "BM25",
+			Type:           schemapb.FunctionType_BM25,
+			InputFieldIds:  []int64{101},
+			OutputFieldIds: []int64{badOut},
+		}},
+	}
 
 	_, err := s.task.Compact()
 	s.Error(err)
@@ -1352,10 +1412,14 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestBuildMergedLogsV3() {
 		"V3 schema bump binlog presence marker must have non-zero LogID")
 }
 
-func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionOutputFieldsSelectsAllOutputsOnPartialState() {
+func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionOutputFieldsRejectsPartialState() {
 	s.setupTest()
 	schema := schemaBumpMultiOutputBM25Schema()
 	s.task.plan.Schema = schema
+	// Output 102 present, 103 absent: a partially materialized function is
+	// persisted-schema corruption. It must fail loud (DataIntegrity) rather than
+	// silently re-select the already-present output (which would append a
+	// duplicate column group in the additive path).
 	existingFields := map[int64]struct{}{
 		common.RowIDField:     {},
 		common.TimeStampField: {},
@@ -1364,29 +1428,10 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionOutputFieldsSe
 		102:                   {},
 	}
 
-	outputFields, outputFieldIDs, err := s.task.missingFunctionOutputFields(schema.GetFunctions(), existingFields)
-	s.NoError(err)
-
-	s.Equal([]int64{102, 103}, outputFieldIDs)
-	s.Require().Len(outputFields, 2)
-	s.Equal(int64(102), outputFields[0].GetFieldID())
-	s.Equal(int64(103), outputFields[1].GetFieldID())
-}
-
-func (s *BumpSchemaVersionCompactionTaskSuite) TestPartialMaterializerExistingFieldsTreatsAllFunctionOutputsAsMissing() {
-	schema := schemaBumpMultiOutputBM25Schema()
-	existingFields := map[int64]struct{}{
-		common.RowIDField:     {},
-		common.TimeStampField: {},
-		100:                   {},
-		101:                   {},
-		102:                   {},
-	}
-
-	materializerFields := partialMaterializerExistingFields(schema, schema.GetFunctions(), existingFields)
-
-	s.NotContains(materializerFields, int64(102))
-	s.NotContains(materializerFields, int64(103))
+	_, _, err := s.task.missingFunctionOutputFields(schema.GetFunctions(), existingFields)
+	s.Require().Error(err)
+	s.ErrorIs(err, merr.ErrDataIntegrity)
+	s.Contains(err.Error(), "partially materialized output fields")
 }
 
 func (s *BumpSchemaVersionCompactionTaskSuite) TestFinalizeMergedLogsReplacesExistingOutputFieldLogs() {

--- a/internal/datanode/compactor/compactor_storage_fields_readback_test.go
+++ b/internal/datanode/compactor/compactor_storage_fields_readback_test.go
@@ -1,0 +1,188 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compactor
+
+// Real write + real read-back direct tests for compactionSegmentStorageFields
+// and its public wrapper newCompactionSegmentRecordReader. NO mock of the tested
+// logic: segments are written by the real writers to real storage and read back
+// through the production read path. Both tests pin the dispatch invariant
+// (manifest present -> manifest field set; manifest empty -> binlog field set) so
+// a branch flip goes RED — the gap the 100%-statement-coverage-but-no-oracle
+// state left open.
+
+import (
+	"context"
+	"io"
+	"math"
+
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/allocator"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
+)
+
+// TestCompactionSegmentStorageFields_V3ManifestBranch_RealReadWrite — the manifest
+// branch. A real StorageV3 segment is written to disk (MultiSegmentWriter); the
+// method's field set must equal the committed manifest read back from disk, and
+// the public reader must physically read the rows back. Dispatch invariant: with a
+// manifest present, FieldBinlogs must be ignored — a flip to the binlog branch
+// would surface a field that only lives in FieldBinlogs.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestCompactionSegmentStorageFields_V3ManifestBranch_RealReadWrite() {
+	segID := int64(100)
+	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
+	s.initSegBufferForSchemaBumpWithFields(segID, schemaBumpBaseFields(), nil)
+	s.finishBumpSchemaVersionSegment()
+
+	seg := s.task.plan.SegmentBinlogs[0]
+	cfg := s.task.compactionParams.StorageConfig
+	s.Require().NotEmpty(seg.GetManifest(), "V3 segment must carry a real manifest")
+
+	// Method under test — no mock.
+	got, err := compactionSegmentStorageFields(seg, cfg)
+	s.Require().NoError(err)
+
+	// Independent storage truth: read the real manifest file back off disk.
+	truth, err := packed.GetManifestFieldIDs(seg.GetManifest(), cfg)
+	s.Require().NoError(err)
+	s.Equal(truth, got, "V3 branch must return exactly the committed-manifest field set")
+	for _, fid := range []int64{common.RowIDField, common.TimeStampField, 100, 101} {
+		s.Contains(got, fid, "physical field %d must be present", fid)
+	}
+
+	// Public wrapper end-to-end: open + physically read every row back off disk.
+	reader, existing, err := newCompactionSegmentRecordReader(context.Background(), seg,
+		&schemapb.CollectionSchema{Fields: schemaBumpBaseFields()}, cfg,
+		storage.WithVersion(seg.GetStorageVersion()),
+		storage.WithDownloader(s.task.chunkManager.MultiRead),
+		storage.WithStorageConfig(cfg),
+	)
+	s.Require().NoError(err)
+	defer reader.Close()
+	s.Equal(got, existing, "wrapper must surface the same field set the method computed")
+	rows := 0
+	for {
+		rec, err := reader.Next()
+		if err == io.EOF {
+			break
+		}
+		s.Require().NoError(err)
+		rows += rec.Len()
+	}
+	s.Equal(3, rows, "3 rows physically read back from the V3 segment")
+
+	// Dispatch invariant (mutation-tight): same real manifest, but FieldBinlogs
+	// carry a bogus field 777. The manifest branch must ignore FieldBinlogs; a flip
+	// to the binlog branch would surface 777. Still a real manifest read.
+	seg2 := proto.Clone(seg).(*datapb.CompactionSegmentBinlogs)
+	seg2.FieldBinlogs = []*datapb.FieldBinlog{{FieldID: 777}}
+	got2, err := compactionSegmentStorageFields(seg2, cfg)
+	s.Require().NoError(err)
+	s.NotContains(got2, int64(777), "manifest branch must not consult FieldBinlogs (dispatch invariant)")
+	s.Equal(truth, got2, "manifest branch stays anchored to the committed manifest")
+}
+
+// TestCompactionSegmentStorageFields_V2BinlogBranch_RealReadWrite — the binlog
+// branch. A real StorageV2 segment is serialized by the real writer; the method
+// must derive its field set from the writer-produced FieldBinlogs and the public
+// reader must physically read the rows back off the serialized bytes. Dispatch
+// invariant: with an empty manifest the method must route to the binlog branch and
+// succeed — a flip to the manifest branch would call GetManifestFieldIDs("") and
+// error, which the NoError assertion catches.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestCompactionSegmentStorageFields_V2BinlogBranch_RealReadWrite() {
+	cfg := s.task.compactionParams.StorageConfig
+	schema := &schemapb.CollectionSchema{Fields: schemaBumpBaseFields()}
+	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	// Real StorageV2 write to the suite's real local storage. V2 has no manifest,
+	// so writer.GetLogs() yields Manifest=="" + per-field binlogs on disk.
+	const v2SegID = int64(200)
+	segIDAlloc := allocator.NewLocalAllocator(v2SegID, math.MaxInt64)
+	logIDAlloc := allocator.NewLocalAllocator(20000, 30000)
+	v2Params := s.task.compactionParams
+	v2Params.StorageVersion = storage.StorageV2
+	writer, err := NewMultiSegmentWriter(context.Background(), s.mockBinlogIO,
+		NewCompactionAllocator(segIDAlloc, logIDAlloc), 64*1024*1024, schema, v2Params,
+		1000, PartitionID, CollectionID, "test_channel", compactionBatchSize,
+		storage.WithStorageConfig(cfg), storage.WithVersion(storage.StorageV2))
+	s.Require().NoError(err)
+	for i := 0; i < 3; i++ {
+		ts := int64(tsoutil.ComposeTSByTime(getMilvusBirthday()))
+		s.Require().NoError(writer.WriteValue(&storage.Value{
+			PK:        storage.NewInt64PrimaryKey(int64(i)),
+			Timestamp: ts,
+			Value: map[int64]interface{}{
+				common.RowIDField:     int64(i),
+				common.TimeStampField: ts,
+				100:                   int64(i),
+				101:                   "v2 string " + string(rune('0'+i)),
+			},
+		}))
+	}
+	s.Require().NoError(writer.Close())
+	written := writer.GetCompactionSegments()
+	s.Require().Len(written, 1)
+	s.Require().Empty(written[0].GetManifest(), "V2 segment must carry no manifest")
+
+	seg := &datapb.CompactionSegmentBinlogs{
+		CollectionID:   CollectionID,
+		PartitionID:    PartitionID,
+		SegmentID:      written[0].GetSegmentID(),
+		FieldBinlogs:   written[0].GetInsertLogs(),
+		InsertChannel:  "test_channel",
+		Manifest:       "", // V2: no manifest -> binlog branch
+		StorageVersion: storage.StorageV2,
+	}
+
+	// Method under test — no mock. The binlog branch is metadata-only -> NoError.
+	got, err := compactionSegmentStorageFields(seg, cfg)
+	s.Require().NoError(err)
+	for _, fid := range []int64{common.RowIDField, common.TimeStampField, 100, 101} {
+		s.Contains(got, fid, "V2 branch must surface writer-produced binlog field %d", fid)
+	}
+	s.NotContains(got, int64(777), "no phantom fields")
+
+	// Public wrapper end-to-end: physically read every row back off disk.
+	reader, existing, err := newCompactionSegmentRecordReader(context.Background(), seg, schema, cfg,
+		storage.WithVersion(storage.StorageV2),
+		storage.WithDownloader(s.task.chunkManager.MultiRead),
+		storage.WithStorageConfig(cfg),
+	)
+	s.Require().NoError(err)
+	defer reader.Close()
+	s.Equal(got, existing, "wrapper must surface the same field set the method computed")
+	rows := 0
+	for {
+		rec, err := reader.Next()
+		if err == io.EOF {
+			break
+		}
+		s.Require().NoError(err)
+		rows += rec.Len()
+	}
+	s.Equal(3, rows, "3 rows physically read back from the real V2 segment")
+
+	// Dispatch invariant (mutation-tight): empty manifest MUST route to the binlog
+	// branch. A flip would call GetManifestFieldIDs("") and error; the NoError above
+	// is the RED trip-wire. Assert the discriminating precondition explicitly.
+	s.Empty(seg.GetManifest(), "V2 segment carries no manifest -> binlog branch is the only correct route")
+}

--- a/internal/datanode/compactor/record_materializer.go
+++ b/internal/datanode/compactor/record_materializer.go
@@ -64,7 +64,11 @@ func NewRecordMaterializer(schema *schemapb.CollectionSchema, functions []*schem
 	materializer := &RecordMaterializer{schema: schema, existingFields: existingFields}
 	materializedFields := make(map[int64]struct{})
 	for _, functionSchema := range functions {
-		outputIndexes := functionOutputIndexesToMaterialize(functionSchema, existingFields)
+		outputIndexes, err := functionOutputIndexesToMaterialize(functionSchema, existingFields)
+		if err != nil {
+			materializer.Close()
+			return nil, err
+		}
 		if len(outputIndexes) == 0 {
 			continue
 		}
@@ -116,35 +120,44 @@ func (m *RecordMaterializer) WrapWithSelection(rec storage.Record, selection *re
 		return base, nil
 	}
 
-	computed := make(map[int64]arrow.Array)
-	for _, materializer := range m.materializers {
-		arrays, err := materializer.Materialize(base)
+	ordinaryFields := make(map[int64]arrow.Array, len(m.missingFields))
+	for _, field := range m.missingFields {
+		arr, err := storage.GenerateEmptyArrayFromSchema(field, base.Len())
 		if err != nil {
-			releaseArrowArrays(computed)
+			releaseArrowArrays(ordinaryFields)
 			cleanupMaterializedRecord(base)
+			return nil, err
+		}
+		ordinaryFields[field.GetFieldID()] = arr
+	}
+
+	// Functions must see the target-schema values of ordinary fields, including
+	// defaults and nulls for fields absent from the physical record. Keep this
+	// input view immutable so function execution order cannot affect results.
+	inputView := base
+	if len(ordinaryFields) > 0 {
+		inputView = &materializedRecord{base: base, computed: ordinaryFields}
+	}
+
+	functionOutputs := make(map[int64]arrow.Array)
+	for _, materializer := range m.materializers {
+		arrays, err := materializer.Materialize(inputView)
+		if err != nil {
+			releaseArrowArrays(functionOutputs)
+			cleanupMaterializedRecord(inputView)
 			return nil, err
 		}
 		for fieldID, arr := range arrays {
-			computed[fieldID] = arr
+			functionOutputs[fieldID] = arr
 		}
 	}
-	for _, field := range m.missingFields {
-		fieldID := field.GetFieldID()
-		if _, ok := computed[fieldID]; ok {
-			continue
-		}
-		arr, err := storage.GenerateEmptyArrayFromSchema(field, base.Len())
-		if err != nil {
-			releaseArrowArrays(computed)
-			cleanupMaterializedRecord(base)
-			return nil, err
-		}
-		computed[fieldID] = arr
+	if len(functionOutputs) == 0 {
+		return inputView, nil
 	}
-	if len(computed) == 0 {
-		return base, nil
+	if len(ordinaryFields) == 0 {
+		return &materializedRecord{base: base, computed: functionOutputs}, nil
 	}
-	return &materializedRecord{base: base, computed: computed}, nil
+	return &materializedRecord{base: inputView, computed: functionOutputs}, nil
 }
 
 func (m *RecordMaterializer) Close() {
@@ -549,20 +562,26 @@ func (m *minHashFunctionMaterializer) Close() {
 	}
 }
 
-func functionOutputIndexesToMaterialize(functionSchema *schemapb.FunctionSchema, existingFields map[int64]struct{}) []int {
+func functionOutputIndexesToMaterialize(functionSchema *schemapb.FunctionSchema, existingFields map[int64]struct{}) ([]int, error) {
 	outputFieldIDs := functionSchema.GetOutputFieldIds()
 	indexes := make([]int, 0, len(outputFieldIDs))
-	hasMissingOutput := false
+	presentCount := 0
 	for idx, outputFieldID := range outputFieldIDs {
 		indexes = append(indexes, idx)
-		if _, ok := existingFields[outputFieldID]; !ok {
-			hasMissingOutput = true
+		if _, ok := existingFields[outputFieldID]; ok {
+			presentCount++
 		}
 	}
-	if !hasMissingOutput {
-		return nil
+	if presentCount == len(outputFieldIDs) {
+		return nil, nil
 	}
-	return indexes
+	if presentCount != 0 {
+		return nil, merr.WrapErrDataIntegrityMsg(
+			"function %s has partially materialized output fields: %d of %d are physically present",
+			functionSchema.GetName(), presentCount, len(outputFieldIDs),
+		)
+	}
+	return indexes, nil
 }
 
 func missingNonMaterializedSchemaFields(schema *schemapb.CollectionSchema, existingFields map[int64]struct{}, materializedFields map[int64]struct{}) []*schemapb.FieldSchema {

--- a/internal/datanode/compactor/record_materializer_enhance_test.go
+++ b/internal/datanode/compactor/record_materializer_enhance_test.go
@@ -1,0 +1,123 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compactor
+
+// RecordMaterializer white-box unit tests — UT_ENHANCEMENT_PLAN Part A gaps.
+// The pre-existing record_materializer_test.go already pins BM25/MinHash output
+// bytes (mock-runner oracle) and selection lifecycle; this file closes the gaps
+// the design flagged as uncovered at unit level:
+//   A1  absent nullable field: bit-by-bit null bitmap + preserved-column byte identity
+//       (existing test only checked Len()/NullN() counts — S0).
+//   A1b absent field WITH default: per-row default value (existing had none).
+//   A7  stringInputsFromRecord null-cell branch (RM-15b) and missing-column error
+//       (RM-15a) — S0/S2.
+// A2/A3/A4 (inputView immutability + selection×function composition) run through
+// the REAL function runner, which unit tests deliberately avoid (runner needs
+// tokenizer init); they are covered end-to-end by the bump integration read-back
+// tests (TestAdditiveBM25Output_ReadBack / TestAdditiveMinHashOutput_ReadBack).
+
+import (
+	"testing"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/storage"
+)
+
+// TestMaterializerAbsentNullableBitmapExact — A1/S0. Every row of a synthesized
+// absent nullable field must be NULL bit-by-bit, and the preserved column must be
+// byte-identical. Count-only (Len/NullN) checks cannot catch a corrupt bitmap.
+func TestMaterializerAbsentNullableBitmapExact(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+		{FieldID: 103, Name: "added", DataType: schemapb.DataType_Int64, Nullable: true},
+	}}
+	m, err := NewRecordMaterializer(schema, nil, map[int64]struct{}{100: {}})
+	require.NoError(t, err)
+	defer m.Close()
+
+	pk := newInt64Array(t, []int64{7, 8, 9})
+	defer pk.Release()
+	rec := &materializerTestRecord{len: 3, columns: map[storage.FieldID]arrow.Array{100: pk}}
+
+	wrapped, err := m.Wrap(rec)
+	require.NoError(t, err)
+	defer cleanupMaterializedRecord(wrapped)
+
+	col := wrapped.Column(103)
+	require.NotNil(t, col)
+	require.Equal(t, 3, col.Len())
+	for i := 0; i < 3; i++ {
+		require.True(t, col.IsNull(i), "row %d of absent nullable field must be null (bitmap bit)", i)
+	}
+	pkOut, ok := wrapped.Column(100).(*array.Int64)
+	require.True(t, ok)
+	require.Equal(t, []int64{7, 8, 9}, []int64{pkOut.Value(0), pkOut.Value(1), pkOut.Value(2)}, "preserved pk must be byte-identical")
+}
+
+// TestMaterializerAbsentDefaultValueExact — A1b/S0. Absent field WITH a default
+// must materialize the default value on every row (non-null), not null.
+func TestMaterializerAbsentDefaultValueExact(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+		{FieldID: 103, Name: "added", DataType: schemapb.DataType_Int64, Nullable: true, DefaultValue: &schemapb.ValueField{Data: &schemapb.ValueField_LongData{LongData: 42}}},
+	}}
+	m, err := NewRecordMaterializer(schema, nil, map[int64]struct{}{100: {}})
+	require.NoError(t, err)
+	defer m.Close()
+
+	pk := newInt64Array(t, []int64{1, 2})
+	defer pk.Release()
+	rec := &materializerTestRecord{len: 2, columns: map[storage.FieldID]arrow.Array{100: pk}}
+
+	wrapped, err := m.Wrap(rec)
+	require.NoError(t, err)
+	defer cleanupMaterializedRecord(wrapped)
+
+	col, ok := wrapped.Column(103).(*array.Int64)
+	require.True(t, ok)
+	require.Equal(t, 2, col.Len())
+	for i := 0; i < 2; i++ {
+		require.True(t, col.IsValid(i), "default row %d must be non-null", i)
+		require.Equal(t, int64(42), col.Value(i), "default row %d value", i)
+	}
+}
+
+// TestStringInputsFromRecordNullAndMissing — A7/S0+S2. A null text cell must
+// become an empty string (not panic, not garbage); a missing input column must
+// error deterministically.
+func TestStringInputsFromRecordNullAndMissing(t *testing.T) {
+	b := array.NewStringBuilder(memory.DefaultAllocator)
+	defer b.Release()
+	b.Append("a")
+	b.AppendNull()
+	b.Append("c")
+	arr := b.NewArray()
+	defer arr.Release()
+
+	rec := &materializerTestRecord{len: 3, columns: map[storage.FieldID]arrow.Array{100: arr}}
+	got, err := stringInputsFromRecord(rec, 100)
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "", "c"}, got, "null cell must map to empty string")
+
+	_, err = stringInputsFromRecord(&materializerTestRecord{len: 1}, 999)
+	require.Error(t, err, "missing input column must error, not panic")
+}

--- a/internal/datanode/compactor/record_materializer_test.go
+++ b/internal/datanode/compactor/record_materializer_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/function"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -541,10 +542,24 @@ func TestBM25FunctionMaterializerRejectsBadRunnerOutput(t *testing.T) {
 	})
 }
 
-func TestFunctionOutputIndexesToMaterializePartialStateReturnsAllOutputs(t *testing.T) {
-	functionSchema := &schemapb.FunctionSchema{OutputFieldIds: []int64{101, 102}}
-	require.Nil(t, functionOutputIndexesToMaterialize(functionSchema, map[int64]struct{}{101: {}, 102: {}}))
-	require.Equal(t, []int{0, 1}, functionOutputIndexesToMaterialize(functionSchema, map[int64]struct{}{101: {}}))
+func TestFunctionOutputIndexesToMaterialize(t *testing.T) {
+	functionSchema := &schemapb.FunctionSchema{Name: "f", OutputFieldIds: []int64{101, 102}}
+
+	// All outputs physically present -> nothing to materialize.
+	idx, err := functionOutputIndexesToMaterialize(functionSchema, map[int64]struct{}{101: {}, 102: {}})
+	require.NoError(t, err)
+	require.Nil(t, idx)
+
+	// All outputs absent -> materialize every index.
+	idx, err = functionOutputIndexesToMaterialize(functionSchema, map[int64]struct{}{})
+	require.NoError(t, err)
+	require.Equal(t, []int{0, 1}, idx)
+
+	// Partial presence (101 present, 102 absent) is persisted-schema corruption
+	// and must fail loud, not silently re-materialize the present output.
+	_, err = functionOutputIndexesToMaterialize(functionSchema, map[int64]struct{}{101: {}})
+	require.ErrorIs(t, err, merr.ErrDataIntegrity)
+	require.ErrorContains(t, err, "partially materialized output fields")
 }
 
 func TestMaterializedRecordReaderReleasesPreviousRecordOnNextAndClose(t *testing.T) {

--- a/internal/storage/record_writer.go
+++ b/internal/storage/record_writer.go
@@ -271,6 +271,17 @@ func (pw *packedRecordBatchWriter) Close() (packed.WriterOutput, error) {
 	return out, nil
 }
 
+// Abort releases the underlying FFI writer without producing column groups for
+// CommitManifestUpdates. It prevents metadata publication; storage already
+// flushed before the abort remains subject to normal orphan-file reclamation.
+func (pw *packedRecordBatchWriter) Abort() {
+	if pw.writer == nil {
+		return
+	}
+	pw.writer.Destroy()
+	pw.writer = nil
+}
+
 func (pw *packedRecordBatchWriter) AsNewColumnGroups() {
 	if pw.writer != nil {
 		pw.writer.AsNewColumnGroups()
@@ -303,6 +314,25 @@ func NewPartialPackedRecordBatchWriter(
 	schemaBasedFormats []string,
 ) (*packedRecordBatchWriter, error) {
 	return newPackedRecordBatchWriter(basePath, schema, bufferSize, multiPartUploadSize, columnGroups, storageConfig, storagePluginContext, false, false, writerFormat, schemaBasedFormats)
+}
+
+// NewPartialPackedRecordBatchWriterWithTextRefsAsBinary creates a partial
+// column-group writer whose TEXT columns use the binary LOB-reference Arrow
+// representation. Schema-bump reconciliation uses this for newly added,
+// nullable TEXT columns, whose historical values are materialized as binary
+// NULLs without rewriting any existing LOB data.
+func NewPartialPackedRecordBatchWriterWithTextRefsAsBinary(
+	basePath string,
+	schema *schemapb.CollectionSchema,
+	bufferSize int64,
+	multiPartUploadSize int64,
+	columnGroups []storagecommon.ColumnGroup,
+	storageConfig *indexpb.StorageConfig,
+	storagePluginContext *indexcgopb.StoragePluginContext,
+	writerFormat string,
+	schemaBasedFormats []string,
+) (*packedRecordBatchWriter, error) {
+	return newPackedRecordBatchWriter(basePath, schema, bufferSize, multiPartUploadSize, columnGroups, storageConfig, storagePluginContext, false, true, writerFormat, schemaBasedFormats)
 }
 
 func validatePackedRecordBatchWriterSchema(schema *schemapb.CollectionSchema) error {


### PR DESCRIPTION
Native 3.0 re-implementation of the core fix from #52484.

A schema bump that only adds a plain ordinary field (nullable/default, no function attached) previously routed to a metadata-only bump, leaving the field physically absent from the segment. This classifies such absent ordinary fields in the bump decision and materializes them as default/NULL through the additive path, so the bumped segment stays physically complete.

Kept on 3.0's merge-in-datanode additive contract (no dependency on the master-only #52006 reshape). The master PR's decision-model reshape, enhancement items, and full UT suite are intentionally not backported here.

issue: #52159
pr: #52484