### PR TITLE
fix: refresh policy cache when removing privileges from a group (#52472)

### DIFF
--- a/internal/rootcoord/rbac_task.go
+++ b/internal/rootcoord/rbac_task.go
@@ -139,13 +139,18 @@ func executeOperatePrivilegeGroupTaskSteps(ctx context.Context, core *Core, in *
 			}
 			switch operateType {
 			case milvuspb.OperatePrivilegeGroupType_AddPrivilegesToGroup:
-				newPrivs := lo.Union(v, in.Privileges)
+				newPrivs := append(append([]*milvuspb.PrivilegeEntity{}, v...), in.Privileges...)
 				newGroups[k] = lo.UniqBy(newPrivs, func(p *milvuspb.PrivilegeEntity) string {
 					return p.Name
 				})
 			case milvuspb.OperatePrivilegeGroupType_RemovePrivilegesFromGroup:
-				newPrivs, _ := lo.Difference(v, in.Privileges)
-				newGroups[k] = newPrivs
+				removedPrivs := lo.SliceToMap(in.Privileges, func(p *milvuspb.PrivilegeEntity) (string, struct{}) {
+					return p.Name, struct{}{}
+				})
+				newGroups[k] = lo.Filter(v, func(p *milvuspb.PrivilegeEntity, _ int) bool {
+					_, ok := removedPrivs[p.Name]
+					return !ok
+				})
 			default:
 				return merr.WrapErrParameterInvalidMsg("invalid operate type")
 			}

--- a/internal/rootcoord/rbac_task_test.go
+++ b/internal/rootcoord/rbac_task_test.go
@@ -1,0 +1,176 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rootcoord
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus/internal/util/proxyutil"
+	"github.com/milvus-io/milvus/pkg/v3/proto/proxypb"
+	"github.com/milvus-io/milvus/pkg/v3/util"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+func TestExecuteOperatePrivilegeGroupTaskStepsAddPrivilegesByName(t *testing.T) {
+	ctx := context.Background()
+	groupName := "group1"
+	roleName := "role1"
+	dbName := util.DefaultDBName
+	objectName := "collection1"
+
+	meta := newMockMetaTable()
+	meta.ListPrivilegeGroupsFunc = func(ctx context.Context) ([]*milvuspb.PrivilegeGroupInfo, error) {
+		return []*milvuspb.PrivilegeGroupInfo{
+			{
+				GroupName: groupName,
+				Privileges: []*milvuspb.PrivilegeEntity{
+					{Name: "Query"},
+				},
+			},
+		}, nil
+	}
+	meta.GetPrivilegeGroupRolesFunc = func(ctx context.Context, groupName string) ([]*milvuspb.RoleEntity, error) {
+		return []*milvuspb.RoleEntity{{Name: roleName}}, nil
+	}
+	meta.SelectGrantFunc = func(ctx context.Context, tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error) {
+		return []*milvuspb.GrantEntity{
+			{
+				Role:       &milvuspb.RoleEntity{Name: roleName},
+				ObjectName: objectName,
+				Grantor: &milvuspb.GrantorEntity{
+					User:      &milvuspb.UserEntity{Name: "root"},
+					Privilege: &milvuspb.PrivilegeEntity{Name: groupName},
+				},
+				DbName: dbName,
+			},
+		}, nil
+	}
+	meta.OperatePrivilegeGroupFunc = func(ctx context.Context, groupName string, privileges []*milvuspb.PrivilegeEntity, operateType milvuspb.OperatePrivilegeGroupType) error {
+		return nil
+	}
+
+	core := newTestCore(withMeta(meta))
+	core.proxyClientManager = proxyutil.NewProxyClientManager(proxyutil.DefaultProxyCreator)
+
+	var (
+		mu              sync.Mutex
+		refreshRequests []*proxypb.RefreshPolicyInfoCacheRequest
+	)
+	proxy := newMockProxy()
+	proxy.RefreshPolicyInfoCacheFunc = func(ctx context.Context, request *proxypb.RefreshPolicyInfoCacheRequest) (*commonpb.Status, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		refreshRequests = append(refreshRequests, request)
+		return merr.Success(), nil
+	}
+	core.proxyClientManager.GetProxyClients().Insert(TestProxyID, proxy)
+
+	err := executeOperatePrivilegeGroupTaskSteps(ctx, core, &milvuspb.PrivilegeGroupInfo{
+		GroupName: groupName,
+		Privileges: []*milvuspb.PrivilegeEntity{
+			{Name: "Query"},
+		},
+	}, milvuspb.OperatePrivilegeGroupType_AddPrivilegesToGroup)
+
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Empty(t, refreshRequests)
+}
+
+func TestExecuteOperatePrivilegeGroupTaskStepsRemovePrivilegesByName(t *testing.T) {
+	ctx := context.Background()
+	groupName := "group1"
+	roleName := "role1"
+	dbName := util.DefaultDBName
+	objectName := "collection1"
+
+	meta := newMockMetaTable()
+	meta.ListPrivilegeGroupsFunc = func(ctx context.Context) ([]*milvuspb.PrivilegeGroupInfo, error) {
+		return []*milvuspb.PrivilegeGroupInfo{
+			{
+				GroupName: groupName,
+				Privileges: []*milvuspb.PrivilegeEntity{
+					{Name: "Query"},
+					{Name: "Load"},
+				},
+			},
+		}, nil
+	}
+	meta.GetPrivilegeGroupRolesFunc = func(ctx context.Context, groupName string) ([]*milvuspb.RoleEntity, error) {
+		return []*milvuspb.RoleEntity{{Name: roleName}}, nil
+	}
+	meta.SelectGrantFunc = func(ctx context.Context, tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error) {
+		return []*milvuspb.GrantEntity{
+			{
+				Role:       &milvuspb.RoleEntity{Name: roleName},
+				ObjectName: objectName,
+				Grantor: &milvuspb.GrantorEntity{
+					User:      &milvuspb.UserEntity{Name: "root"},
+					Privilege: &milvuspb.PrivilegeEntity{Name: groupName},
+				},
+				DbName: dbName,
+			},
+		}, nil
+	}
+	meta.OperatePrivilegeGroupFunc = func(ctx context.Context, groupName string, privileges []*milvuspb.PrivilegeEntity, operateType milvuspb.OperatePrivilegeGroupType) error {
+		return nil
+	}
+
+	core := newTestCore(withMeta(meta))
+	core.proxyClientManager = proxyutil.NewProxyClientManager(proxyutil.DefaultProxyCreator)
+
+	var (
+		mu              sync.Mutex
+		refreshRequests []*proxypb.RefreshPolicyInfoCacheRequest
+	)
+	proxy := newMockProxy()
+	proxy.RefreshPolicyInfoCacheFunc = func(ctx context.Context, request *proxypb.RefreshPolicyInfoCacheRequest) (*commonpb.Status, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		refreshRequests = append(refreshRequests, request)
+		return merr.Success(), nil
+	}
+	core.proxyClientManager.GetProxyClients().Insert(TestProxyID, proxy)
+
+	err := executeOperatePrivilegeGroupTaskSteps(ctx, core, &milvuspb.PrivilegeGroupInfo{
+		GroupName: groupName,
+		Privileges: []*milvuspb.PrivilegeEntity{
+			{Name: "Query"},
+		},
+	}, milvuspb.OperatePrivilegeGroupType_RemovePrivilegesFromGroup)
+
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, refreshRequests, 1)
+	require.Equal(t, int32(typeutil.CacheRevokePrivilege), refreshRequests[0].GetOpType())
+	require.Equal(t,
+		funcutil.PolicyForPrivilege(roleName, util.GetObjectType("Query"), objectName, util.PrivilegeNameForMetastore("Query"), dbName),
+		refreshRequests[0].GetOpKey(),
+	)
+}


### PR DESCRIPTION
issue: #52471
pr: #52472

Backport #52472 to the 3.0 branch.

## What was changed

- Compare removed privilege group entries by privilege name instead of pointer.
- Build added privileges in a new slice and deduplicate them by privilege name.
- Add regression tests for adding and removing privileges represented by different pointer instances.

## Why

`lo.Difference` compares elements of `[]*milvuspb.PrivilegeEntity` by pointer
address. Privileges loaded from metadata and privileges from the request are
different pointer instances even when their names are equal.

This prevented RootCoord from identifying revoked expanded privileges and
refreshing the proxy policy cache.

## Test
```text
go test -tags dynamic,test -gcflags="all=-N -l" -count=1
./internal/rootcoord
-run 'TestExecuteOperatePrivilegeGroupTaskSteps(Add|Remove)PrivilegesByName$'
```


(cherry picked from commit 53c39a4c156f2515b4807daca5b39f4fca7d8a0a)
