### PR TITLE
fix: [2.6] create encrypted index temp directory if missing

### DIFF
--- a/internal/core/src/storage/IndexEntryEncryptedLocalWriter.cpp
+++ b/internal/core/src/storage/IndexEntryEncryptedLocalWriter.cpp
@@ -21,6 +21,8 @@
 #include <cerrno>
 #include <cstring>
 #include <algorithm>
+#include <filesystem>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -56,6 +58,12 @@ IndexEntryEncryptedLocalWriter::IndexEntryEncryptedLocalWriter(
 
     auto uuid = boost::uuids::random_generator()();
     std::string dir = temp_dir.empty() ? "/tmp" : temp_dir;
+    std::error_code ec;
+    std::filesystem::create_directories(dir, ec);
+    AssertInfo(!ec,
+               "Failed to create encrypted index temp directory {}: {}",
+               dir,
+               ec.message());
     local_path_ = dir + "/milvus_enc_" + boost::uuids::to_string(uuid);
 
     local_fd_ = ::open(local_path_.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -19,14 +19,17 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <system_error>
 #include <thread>
 #include <utility>
 #include <vector>
 
+#include "folly/ScopeGuard.h"
 #include "common/Common.h"
 #include "common/EasyAssert.h"
 #include "filemanager/InputStream.h"
@@ -925,6 +928,36 @@ TEST_F(IndexEntryEncryptedV3Test, EncryptedSmallEntryRoundtrip) {
     auto info = fs_->GetFileInfo(file_path);
     ASSERT_TRUE(info.ok());
     EXPECT_GT(info.ValueOrDie().size(), entry_size);  // ciphertext > plaintext
+}
+
+TEST_F(IndexEntryEncryptedV3Test, EncryptedWriterCreatesMissingTempDir) {
+    const std::string file_path = kV3FilePath + "_enc_missing_tmpdir";
+    const std::string missing_tmp = GetRootPath() + "/missing_enc_tmp";
+    std::filesystem::remove_all(missing_tmp);
+    ASSERT_FALSE(std::filesystem::exists(missing_tmp));
+    auto cleanup = folly::makeGuard([&missing_tmp]() {
+        std::error_code ec;
+        std::filesystem::remove_all(missing_tmp, ec);
+    });
+
+    const size_t slice_size = 64 * 1024;
+    auto data = GeneratePattern(1024);
+    {
+        IndexEntryEncryptedLocalWriter writer(file_path,
+                                              fs_,
+                                              mock_cipher_,
+                                              /*ez_id=*/1,
+                                              /*collection_id=*/100,
+                                              missing_tmp,
+                                              slice_size);
+        writer.WriteEntry("enc_entry", data.data(), data.size());
+        writer.Finish();
+    }
+
+    EXPECT_TRUE(std::filesystem::is_directory(missing_tmp));
+    auto info = fs_->GetFileInfo(file_path);
+    ASSERT_TRUE(info.ok());
+    EXPECT_GT(info.ValueOrDie().size(), 1024);  // ciphertext > plaintext
 }
 
 TEST_F(IndexEntryEncryptedV3Test, EncryptedMultiSliceEntry) {


### PR DESCRIPTION
issue: #52558
pr: #52557

`IndexEntryEncryptedLocalWriter` assumed its temp_dir already existed, so writing an encrypted index entry to a non-existent directory failed at `open()`. Create the directory with `std::filesystem::create_directories` and fail fast on error.