### PR TITLE
enhance: stop panicking before growing-source writebuffer retry callback

### DIFF
--- a/internal/flushcommon/writebuffer/l0_write_buffer_test.go
+++ b/internal/flushcommon/writebuffer/l0_write_buffer_test.go
@@ -908,6 +908,10 @@ func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {
 				}, nil
 			},
 		}
+		// Growing-source tasks no longer wire wb.errHandler as their
+		// failureCallback (see getGrowingSourceSyncTask), so this handler is
+		// never invoked for growing-source failures; kept here only to prove
+		// that a customized handler still stays untouched.
 		var errorHandlerCalls atomic.Int32
 		wb, err := NewL0WriteBuffer(s.channelName, metacache, s.syncMgr, &writeBufferOption{
 			idAllocator:                s.allocator,
@@ -951,7 +955,7 @@ func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {
 		s.ErrorContains(conc.AwaitAll(futures...), "mock growing source flush error")
 		firstTask := <-done
 
-		s.EqualValues(1, errorHandlerCalls.Load())
+		s.EqualValues(0, errorHandlerCalls.Load())
 		progress, ok := l0wb.growingSourceProgress[int64(1010)]
 		s.True(ok)
 		s.EqualValues(1, progress.failureCount)
@@ -967,13 +971,92 @@ func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {
 		s.Require().Len(futures, 1)
 		s.NoError(conc.AwaitAll(futures...))
 		secondTask := <-done
-		s.EqualValues(1, errorHandlerCalls.Load())
+		s.EqualValues(0, errorHandlerCalls.Load())
 		s.EqualValues(10, secondTask.BatchRows())
 		segment, ok = metacache.GetSegmentByID(1010)
 		s.True(ok)
 		s.EqualValues(10, segment.FlushedRows())
 		s.EqualValues(0, segment.SyncingRows())
 		s.Equal("manifest-retry", segment.ManifestPath())
+	})
+
+	s.Run("source_task_error_with_default_handler_reaches_retry_callback", func() {
+		textSchema := s.textSchema()
+		metacache := s.newTextRealMetaCache(textSchema)
+		flushCalls := 0
+		source := fakeGrowingFlushSource{
+			flushFunc: func(_ context.Context, _, _ int64, _ *syncmgr.GrowingFlushConfig) (*syncmgr.GrowingFlushResult, error) {
+				flushCalls++
+				return nil, fmt.Errorf("mock growing source flush error")
+			},
+		}
+		wb, err := NewL0WriteBuffer(s.channelName, metacache, s.syncMgr, &writeBufferOption{
+			idAllocator:                s.allocator,
+			growingSourceRetryInterval: time.Hour,
+			// Mirrors defaultWBOption's default error handler, which panics on
+			// any error. GrowingSourceSyncTask must not wire this as its
+			// failureCallback, or Run's own defer would panic before the
+			// writebuffer recovery callback below runs.
+			errorHandler: func(err error) {
+				panic(err)
+			},
+			growingSourceResolver: func(segmentID int64, targetOffset int64, _ *msgpb.MsgPosition) (syncmgr.GrowingFlushSource, syncmgr.GrowingSourceState) {
+				return source, syncmgr.GrowingSourceUsable
+			},
+		})
+		s.NoError(err)
+
+		done := make(chan struct{})
+		s.syncMgr.EXPECT().SyncData(mock.Anything, mock.AnythingOfType("*syncmgr.GrowingSourceSyncTask"), mock.Anything).
+			RunAndReturn(func(ctx context.Context, task syncmgr.Task, callbacks ...func(error) error) (*conc.Future[struct{}], error) {
+				textTask := task.(*syncmgr.GrowingSourceSyncTask)
+				textTask.WithChunkManager(storage.NewLocalChunkManager(objectstorage.RootPath(s.T().TempDir())))
+				return conc.Go(func() (struct{}, error) {
+					defer close(done)
+					err := textTask.Run(ctx)
+					for _, callback := range callbacks {
+						if cbErr := callback(err); cbErr != nil {
+							return struct{}{}, cbErr
+						}
+					}
+					return struct{}{}, err
+				}), nil
+			}).Once()
+
+		_, msg := s.composeTextInsertMsg(1015, 10)
+		insertData, err := PrepareInsert(textSchema, s.pkSchema, []*msgstream.InsertMsg{msg})
+		s.NoError(err)
+		err = wb.BufferData(insertData, nil, &msgpb.MsgPosition{Timestamp: 100}, &msgpb.MsgPosition{Timestamp: 200}, 100)
+		s.NoError(err)
+		l0wb := wb.(*l0WriteBuffer)
+
+		// If the default (panicking) error handler is still wired as the
+		// growing-source task's failureCallback, GrowingSourceSyncTask.Run's
+		// own defer panics here -- inside the background goroutine spawned by
+		// the mocked SyncData -- before the writebuffer recovery callback
+		// below ever runs. conc.Go does not recover panics, so that would
+		// crash this test binary outright rather than merely fail an
+		// assertion.
+		futures := l0wb.syncSegments(context.Background(), []int64{1015})
+		s.Require().Len(futures, 1)
+		s.ErrorContains(conc.AwaitAll(futures...), "mock growing source flush error")
+		<-done
+
+		// The default (panicking) error handler must not preempt the
+		// writebuffer recovery callback: rollback and retry scheduling must
+		// still have run.
+		progress, ok := l0wb.growingSourceProgress[int64(1015)]
+		s.True(ok)
+		s.EqualValues(1, progress.failureCount)
+		s.Contains(progress.lastFailure, "mock growing source flush error")
+		s.True(l0wb.growingSourceRetryScheduled)
+
+		segment, ok := metacache.GetSegmentByID(1015)
+		s.True(ok)
+		s.EqualValues(0, segment.FlushedRows())
+		s.EqualValues(0, segment.SyncingRows())
+		s.EqualValues(10, segment.BufferRows())
+		s.EqualValues(1, flushCalls)
 	})
 
 	s.Run("source_task_layout_mismatch_is_non_retryable", func() {
@@ -984,6 +1067,10 @@ func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {
 				return nil, fmt.Errorf("Invalid: Column group size mismatch: existing has 10 groups, but appended has 1 groups: segcore error[segcoreCode=2001]")
 			},
 		}
+		// Growing-source tasks no longer wire wb.errHandler as their
+		// failureCallback (see getGrowingSourceSyncTask), so this handler is
+		// never invoked for growing-source failures; kept here only to prove
+		// that a customized handler still stays untouched.
 		var errorHandlerCalls atomic.Int32
 		wb, err := NewL0WriteBuffer(s.channelName, metacache, s.syncMgr, &writeBufferOption{
 			idAllocator:                s.allocator,
@@ -1025,7 +1112,7 @@ func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {
 		s.ErrorContains(conc.AwaitAll(futures...), "Column group size mismatch")
 		<-done
 
-		s.EqualValues(1, errorHandlerCalls.Load())
+		s.EqualValues(0, errorHandlerCalls.Load())
 		progress, ok := l0wb.growingSourceProgress[int64(1014)]
 		s.True(ok)
 		s.EqualValues(1, progress.failureCount)
@@ -1057,6 +1144,10 @@ func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {
 			},
 		}
 		metaWriter := syncmgr.NewMockMetaWriter(s.T())
+		// Growing-source tasks no longer wire wb.errHandler as their
+		// failureCallback (see getGrowingSourceSyncTask), so this handler is
+		// never invoked for growing-source failures; kept here only to prove
+		// that a customized handler still stays untouched.
 		var errorHandlerCalls atomic.Int32
 		wb, err := NewL0WriteBuffer(s.channelName, metacache, s.syncMgr, &writeBufferOption{
 			idAllocator:                s.allocator,
@@ -1099,7 +1190,7 @@ func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {
 		s.ErrorContains(conc.AwaitAll(futures...), "row count mismatch")
 		<-done
 
-		s.EqualValues(1, errorHandlerCalls.Load())
+		s.EqualValues(0, errorHandlerCalls.Load())
 		progress, ok := l0wb.growingSourceProgress[int64(1011)]
 		s.True(ok)
 		s.EqualValues(1, progress.failureCount)

--- a/internal/flushcommon/writebuffer/write_buffer.go
+++ b/internal/flushcommon/writebuffer/write_buffer.go
@@ -1565,7 +1565,15 @@ func (wb *writeBufferBase) getGrowingSourceSyncTask(ctx context.Context, segment
 			WithSchema(wb.metaCache.GetSchema(schemaTimestamp)).
 			WithAllocator(wb.allocator).
 			WithStorageConfig(packed.CreateStorageConfig()).
-			WithFailureCallback(wb.errHandler).
+			// Unlike SyncTask, growing-source errors (FlushGrowingData,
+			// UpdateGrowingSourceSync, layout/row-count validation) are not
+			// wrapped in an infinite retry, so they are expected to surface here.
+			// Leave failureCallback unset so Run's own defer does not invoke
+			// wb.errHandler (which panics by default) ahead of the recovery
+			// callback registered by submitSyncTasks -- that callback is what
+			// rolls back SyncingRows, records failureCount/lastFailure, and
+			// schedules the writebuffer-level retry.
+			//
 			// Same as above: keep the critical write path retrying despite the
 			// retry.Do InputError short-circuit.
 			WithWriteRetryOptions(retry.AttemptAlways(), retry.MaxSleepTime(10*time.Second),


### PR DESCRIPTION
Motivation:
GrowingSourceSyncTask.Run's own defer calls HandleError on any returned
error. HandleError invokes the task's failureCallback, which
getGrowingSourceSyncTask wired to wb.errHandler -- the writebuffer's
default error handler, which panics. Because this happens inside Run
itself, the panic escapes before key_lock_dispatcher's dispatchLocked
ever reaches the callback chain (`err := pt.task.Run(pt.ctx); for _, cb
:= range pt.callbacks { ... }`). That callback chain is where
writeBufferBase.submitSyncTasks does the actual recovery: rollback
SyncingRows, record failureCount/lastFailure, and schedule retry.
Ordinary growing-source flush errors (FlushGrowingData failing,
UpdateGrowingSourceSync failing, layout/row-count validation) are not
wrapped in an infinite retry the way the plain SyncTask write path is,
so they routinely reach this defer and panic instead of being handled
by the writebuffer's existing recovery logic.

Approach:
Stop wiring wb.errHandler as the GrowingSourceSyncTask's
failureCallback in getGrowingSourceSyncTask's buildTask closure.
HandleError already guards the callback invocation with a nil check, so
leaving failureCallback unset means Run's defer no longer panics; Run
returns the error normally, and the recovery callback registered by
submitSyncTasks runs as intended. The drop/close path
(Close(ctx, true) -> submitDropSyncTasks) is unaffected: it has its own
explicit panic(err) on AwaitAll failure, independent of failureCallback.

Impact is scoped to growing-source flush errors reaching the
writebuffer's intended rollback/retry path instead of panicking the
DataNode; it does not change behavior for the plain SyncTask write
path, which still wires wb.errHandler via WithErrorHandler for its own
(intentionally never-expected-to-fire) invariant check.

Validation:
Added internal/flushcommon/writebuffer TestBufferDataGrowingSourceMode
subtest source_task_error_with_default_handler_reaches_retry_callback,
modeled on the neighboring source_task_error_retries_without_default_error_handler_panic
test but wiring the writebuffer's actual default (panicking) error
handler instead of a benign stub, matching the issue's own repro. It
drives a growing-source flush failure through the same Run-then-callbacks
ordering used by the real key_lock_dispatcher and asserts the
writebuffer recovery (failureCount, lastFailure, retry scheduling,
SyncingRows/FlushedRows rollback) still ran. Traced by hand against the
current source (growing_source.go's Run/HandleError,
key_lock_dispatcher.go's dispatchLocked, write_buffer.go's
submitSyncTasks/getGrowingSourceSyncTask) that: reverting the
write_buffer.go change reintroduces the WithFailureCallback wiring,
under which this new test's panicking handler would panic inside
GrowingSourceSyncTask.Run's defer -- inside a goroutine spawned via
conc.Go, which does not recover panics -- crashing the test binary
before the recovery assertions ever execute; with the change, the
panic is never wired in and the assertions pass. Also updated three
pre-existing tests in the same file
(source_task_error_retries_without_default_error_handler_panic,
source_task_layout_mismatch_is_non_retryable,
source_task_row_count_mismatch_retries_without_meta_update) whose
errorHandlerCalls assertions depended on the removed wiring, from
expecting 1 call to expecting 0, since wb.errHandler is no longer
invoked for growing-source failures at all.

I was not able to actually run `go test` for this package in this
environment: internal/flushcommon/writebuffer transitively imports
internal/storagev2/packed, which requires cgo linking against a
prebuilt milvus_core/milvus-storage (and other packages in the import
graph need rocksdb), none of which are built in this sandbox, and
building them requires a conan toolchain that this machine's Homebrew
Python refuses to pip-install into globally (PEP 668
externally-managed-environment) -- installing it anyway was avoided
since this is a real developer machine, not disposable CI. No docker
is available either, and no prebuilt core exists anywhere on disk. I
did confirm `gofmt -l` is clean on both changed files, and that
`golangci-lint run --build-tags dynamic,test
./internal/flushcommon/writebuffer/...` reports only pre-existing
cgo-import-resolution failures (rocksdb/milvus_core not found)
unrelated to this diff. The fix and test were verified by careful
manual tracing against the current source rather than by execution,
and by two independent adversarial reviews of the diff.

Report: https://github.com/milvus-io/milvus/issues/51854
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #51854