### PR TITLE
enhance: [2.6] compact Tantivy JSON row masks

### DIFF
--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -16,8 +16,11 @@
 
 #include "index/IndexFactory.h"
 #include <cstdlib>
+#include <limits>
 #include <memory>
+#include <optional>
 #include <string>
+#include "common/Consts.h"
 #include "common/EasyAssert.h"
 #include "common/FieldDataInterface.h"
 #include "common/JsonCastType.h"
@@ -44,6 +47,76 @@
 #include "pb/schema.pb.h"
 
 namespace milvus::index {
+
+namespace {
+
+uint64_t
+BitsetBytes(int64_t num_rows) {
+    if (num_rows <= 0) {
+        return 0;
+    }
+    return (static_cast<uint64_t>(num_rows) + 7) / 8;
+}
+
+uint64_t
+SaturatingAdd(uint64_t lhs, uint64_t rhs) {
+    if (lhs > std::numeric_limits<uint64_t>::max() - rhs) {
+        return std::numeric_limits<uint64_t>::max();
+    }
+    return lhs + rhs;
+}
+
+uint64_t
+SaturatingMul(uint64_t lhs, uint64_t rhs) {
+    if (lhs != 0 && rhs > std::numeric_limits<uint64_t>::max() / lhs) {
+        return std::numeric_limits<uint64_t>::max();
+    }
+    return lhs * rhs;
+}
+
+uint64_t
+ScalarRowMaskResidentBytes(
+    DataType field_type,
+    const std::string& index_type,
+    const std::map<std::string, std::string>& index_params,
+    int64_t num_rows) {
+    uint64_t mask_count = 0;
+    uint64_t dense_bitmap_count = 0;
+    if (index_type == INVERTED_INDEX_TYPE || index_type == NGRAM_INDEX_TYPE) {
+        // Tantivy does not retain null rows, so the C++ wrapper keeps one
+        // CRoaring row set beside the mmap'd index.
+        mask_count = 1;
+    }
+
+    const auto is_json_path =
+        field_type == DataType::JSON &&
+        index_params.find(JSON_PATH) != index_params.end();
+    if (is_json_path && index_type != NGRAM_INDEX_TYPE) {
+        // Typed JSON path indexes additionally keep the non-existing rows for
+        // EXISTS semantics. An unresolved HYBRID may select INVERTED, so use
+        // two masks there as a conservative bound.
+        auto cast_type_it = index_params.find(JSON_CAST_TYPE);
+        auto is_flat_json = cast_type_it == index_params.end() ||
+                            cast_type_it->second == "JSON";
+        if (!is_flat_json) {
+            mask_count += 1;
+            dense_bitmap_count = 1;
+            if (index_type == HYBRID_INDEX_TYPE) {
+                mask_count += 1;
+            }
+        }
+    }
+
+    // A CRoaring container is at most roughly one dense bitset plus container
+    // metadata. Reserve 2x the dense bytes per row set to cover that overhead.
+    auto roaring_bytes =
+        SaturatingMul(SaturatingMul(BitsetBytes(num_rows), 2), mask_count);
+    auto dense_bitmap_bytes =
+        SaturatingMul(BitsetBytes(num_rows), dense_bitmap_count);
+    return SaturatingAdd(roaring_bytes, dense_bitmap_bytes);
+}
+
+}  // namespace
 
 bool
 IndexFactory::CanUseIndexRawDataForField(DataType field_type,
@@ -134,7 +207,8 @@ IndexFactory::IndexLoadResource(
                                        index_version,
                                        index_size_in_bytes,
                                        index_params,
-                                       mmap_enable);
+                                       mmap_enable,
+                                       num_rows);
     }
 }
 
@@ -328,7 +402,8 @@ IndexFactory::ScalarIndexLoadResource(
     IndexVersion index_version,
     uint64_t index_size_in_bytes,
     const std::map<std::string, std::string>& index_params,
-    bool mmap_enable) {
+    bool mmap_enable,
+    int64_t num_rows) {
     auto config = milvus::index::ParseConfigFromIndexParams(index_params);
 
     auto index_type_it = index_params.find("index_type");
@@ -395,6 +470,12 @@ IndexFactory::ScalarIndexLoadResource(
             index_type);
         return LoadResourceRequest{0, 0, 0, 0, false};
     }
+    auto row_mask_resident_bytes = ScalarRowMaskResidentBytes(
+        field_type, index_type, index_params, num_rows);
+    request.final_memory_cost =
+        SaturatingAdd(request.final_memory_cost, row_mask_resident_bytes);
+    request.max_memory_cost =
+        SaturatingAdd(request.max_memory_cost, row_mask_resident_bytes);
     request.has_raw_data =
         CanUseIndexRawDataForField(field_type, request.has_raw_data);
     return request;

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -19,6 +19,7 @@
 #include <limits>
 #include <memory>
 #include <optional>
+#include <roaring/roaring.hh>
 #include <string>
 #include "common/Consts.h"
 #include "common/EasyAssert.h"
@@ -75,42 +76,71 @@ SaturatingMul(uint64_t lhs, uint64_t rhs) {
 }
 
 uint64_t
+RoaringRowMaskResidentBytes(int64_t num_rows) {
+    if (num_rows <= 0) {
+        return 0;
+    }
+
+    // Roaring32 partitions values by their high 16 bits, so one low container
+    // covers exactly 2^16 consecutive row offsets.
+    constexpr uint64_t kRowsPerContainer = uint64_t{1} << 16;
+    // After runOptimize(), every container payload is at most 8 KiB: an array
+    // holds at most 4096 uint16_t values, a bitmap holds exactly 2^16 bits,
+    // and a run container is retained only when it is no larger than those
+    // alternatives.
+    constexpr uint64_t kMaxContainerPayloadBytes = 8 * 1024;
+    // RoaringMemoryBytes() also includes the portable-format header. For C
+    // containers it is 8 + 8*C bytes without runs and no more than
+    // 4 + ceil(C/8) + 8*C bytes with runs. Thus 16*C bounds either layout for
+    // every C >= 1.
+    constexpr uint64_t kMaxPortableMetadataBytesPerContainer = 16;
+    const auto rows = static_cast<uint64_t>(num_rows);
+    const auto container_count =
+        rows / kRowsPerContainer + (rows % kRowsPerContainer != 0);
+
+    const auto sparse_container_bound =
+        SaturatingAdd(static_cast<uint64_t>(sizeof(roaring::Roaring)),
+                      SaturatingMul(container_count,
+                                    kMaxContainerPayloadBytes +
+                                        kMaxPortableMetadataBytesPerContainer));
+    const auto dense_container_bound = SaturatingMul(BitsetBytes(num_rows), 2);
+    return std::max(sparse_container_bound, dense_container_bound);
+}
+
+uint64_t
 ScalarRowMaskResidentBytes(
     DataType field_type,
     const std::string& index_type,
     const std::map<std::string, std::string>& index_params,
-    int64_t num_rows) {
-    uint64_t mask_count = 0;
-    uint64_t dense_bitmap_count = 0;
-    if (index_type == INVERTED_INDEX_TYPE || index_type == NGRAM_INDEX_TYPE) {
-        // Tantivy does not retain null rows, so the C++ wrapper keeps one
-        // CRoaring row set beside the mmap'd index.
-        mask_count = 1;
-    }
-
+    int64_t num_rows,
+    std::optional<bool> field_nullable) {
     const auto is_json_path =
         field_type == DataType::JSON &&
         index_params.find(JSON_PATH) != index_params.end();
-    if (is_json_path && index_type != NGRAM_INDEX_TYPE) {
-        // Typed JSON path indexes additionally keep the non-existing rows for
-        // EXISTS semantics. An unresolved HYBRID may select INVERTED, so use
-        // two masks there as a conservative bound.
-        auto cast_type_it = index_params.find(JSON_CAST_TYPE);
-        auto is_flat_json = cast_type_it == index_params.end() ||
-                            cast_type_it->second == "JSON";
-        if (!is_flat_json) {
-            mask_count += 1;
-            dense_bitmap_count = 1;
-            if (index_type == HYBRID_INDEX_TYPE) {
-                mask_count += 1;
-            }
-        }
-    }
+    auto cast_type_it = index_params.find(JSON_CAST_TYPE);
+    const bool is_flat_json =
+        cast_type_it == index_params.end() || cast_type_it->second == "JSON";
+    // Typed JSON path indexes additionally keep the non-existing rows for
+    // EXISTS semantics (plus one dense exists bitmap). NGRAM never applies.
+    const bool typed_json_path =
+        is_json_path && !is_flat_json && index_type != NGRAM_INDEX_TYPE;
 
-    // A CRoaring container is at most roughly one dense bitset plus container
-    // metadata. Reserve 2x the dense bytes per row set to cover that overhead.
+    // Tantivy does not retain null rows, so the wrapper keeps a CRoaring null
+    // offset set beside the mmap'd index. JSON path extraction can produce
+    // null rows even when the source field is non-nullable. An unresolved
+    // HYBRID may select INVERTED, so reserve its null mask conservatively.
+    const bool keeps_null_mask =
+        ((index_type == INVERTED_INDEX_TYPE ||
+          index_type == NGRAM_INDEX_TYPE) &&
+         (is_json_path || field_nullable.value_or(true))) ||
+        (typed_json_path && index_type == HYBRID_INDEX_TYPE);
+
+    const uint64_t mask_count =
+        (keeps_null_mask ? 1 : 0) + (typed_json_path ? 1 : 0);
+    const uint64_t dense_bitmap_count = typed_json_path ? 1 : 0;
+
     auto roaring_bytes =
-        SaturatingMul(SaturatingMul(BitsetBytes(num_rows), 2), mask_count);
+        SaturatingMul(RoaringRowMaskResidentBytes(num_rows), mask_count);
     auto dense_bitmap_bytes =
         SaturatingMul(BitsetBytes(num_rows), dense_bitmap_count);
     return SaturatingAdd(roaring_bytes, dense_bitmap_bytes);
@@ -192,7 +222,8 @@ IndexFactory::IndexLoadResource(
     const std::map<std::string, std::string>& index_params,
     bool mmap_enable,
     int64_t num_rows,
-    int64_t dim) {
+    int64_t dim,
+    std::optional<bool> field_nullable) {
     if (milvus::IsVectorDataType(field_type)) {
         return VecIndexLoadResource(field_type,
                                     element_type,
@@ -203,12 +234,13 @@ IndexFactory::IndexLoadResource(
                                     num_rows,
                                     dim);
     } else {
-        return ScalarIndexLoadResource(field_type,
-                                       index_version,
-                                       index_size_in_bytes,
-                                       index_params,
-                                       mmap_enable,
-                                       num_rows);
+        return ScalarIndexLoadResourceImpl(field_type,
+                                           index_version,
+                                           index_size_in_bytes,
+                                           index_params,
+                                           mmap_enable,
+                                           num_rows,
+                                           field_nullable);
     }
 }
 
@@ -404,6 +436,42 @@ IndexFactory::ScalarIndexLoadResource(
     const std::map<std::string, std::string>& index_params,
     bool mmap_enable,
     int64_t num_rows) {
+    return ScalarIndexLoadResourceImpl(field_type,
+                                       index_version,
+                                       index_size_in_bytes,
+                                       index_params,
+                                       mmap_enable,
+                                       num_rows,
+                                       std::nullopt);
+}
+
+LoadResourceRequest
+IndexFactory::ScalarIndexLoadResource(
+    DataType field_type,
+    IndexVersion index_version,
+    uint64_t index_size_in_bytes,
+    const std::map<std::string, std::string>& index_params,
+    bool mmap_enable,
+    int64_t num_rows,
+    bool field_nullable) {
+    return ScalarIndexLoadResourceImpl(field_type,
+                                       index_version,
+                                       index_size_in_bytes,
+                                       index_params,
+                                       mmap_enable,
+                                       num_rows,
+                                       field_nullable);
+}
+
+LoadResourceRequest
+IndexFactory::ScalarIndexLoadResourceImpl(
+    DataType field_type,
+    IndexVersion index_version,
+    uint64_t index_size_in_bytes,
+    const std::map<std::string, std::string>& index_params,
+    bool mmap_enable,
+    int64_t num_rows,
+    std::optional<bool> field_nullable) {
     auto config = milvus::index::ParseConfigFromIndexParams(index_params);
 
     auto index_type_it = index_params.find("index_type");
@@ -471,7 +539,7 @@ IndexFactory::ScalarIndexLoadResource(
         return LoadResourceRequest{0, 0, 0, 0, false};
     }
     auto row_mask_resident_bytes = ScalarRowMaskResidentBytes(
-        field_type, index_type, index_params, num_rows);
+        field_type, index_type, index_params, num_rows, field_nullable);
     request.final_memory_cost =
         SaturatingAdd(request.final_memory_cost, row_mask_resident_bytes);
     request.max_memory_cost =

--- a/internal/core/src/index/IndexFactory.h
+++ b/internal/core/src/index/IndexFactory.h
@@ -83,7 +83,8 @@ class IndexFactory {
         IndexVersion index_version,
         uint64_t index_size_in_bytes,
         const std::map<std::string, std::string>& index_params,
-        bool mmap_enable);
+        bool mmap_enable,
+        int64_t num_rows);
 
     IndexBasePtr
     CreateIndex(const CreateIndexInfo& create_index_info,

--- a/internal/core/src/index/IndexFactory.h
+++ b/internal/core/src/index/IndexFactory.h
@@ -17,9 +17,10 @@
 #pragma once
 
 #include <memory>
-#include <string>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
+#include <string>
 
 #include "common/JsonCastType.h"
 #include "common/Types.h"
@@ -65,7 +66,8 @@ class IndexFactory {
                       const std::map<std::string, std::string>& index_params,
                       bool mmap_enable,
                       int64_t num_rows,
-                      int64_t dim);
+                      int64_t dim,
+                      std::optional<bool> field_nullable = std::nullopt);
 
     LoadResourceRequest
     VecIndexLoadResource(DataType field_type,
@@ -85,6 +87,16 @@ class IndexFactory {
         const std::map<std::string, std::string>& index_params,
         bool mmap_enable,
         int64_t num_rows);
+
+    LoadResourceRequest
+    ScalarIndexLoadResource(
+        DataType field_type,
+        IndexVersion index_version,
+        uint64_t index_size_in_bytes,
+        const std::map<std::string, std::string>& index_params,
+        bool mmap_enable,
+        int64_t num_rows,
+        bool field_nullable);
 
     IndexBasePtr
     CreateIndex(const CreateIndexInfo& create_index_info,
@@ -145,6 +157,16 @@ class IndexFactory {
     // CreateIndex(DataType dtype, const IndexType& index_type);
  private:
     FRIEND_TEST(StringIndexMarisaTest, Reverse);
+
+    LoadResourceRequest
+    ScalarIndexLoadResourceImpl(
+        DataType field_type,
+        IndexVersion index_version,
+        uint64_t index_size_in_bytes,
+        const std::map<std::string, std::string>& index_params,
+        bool mmap_enable,
+        int64_t num_rows,
+        std::optional<bool> field_nullable);
 
     template <typename T>
     ScalarIndexPtr<T>

--- a/internal/core/src/index/IndexFactoryRawDataTest.cpp
+++ b/internal/core/src/index/IndexFactoryRawDataTest.cpp
@@ -31,11 +31,11 @@ TEST(IndexFactoryRawDataTest, JsonPathIndexCannotReplaceWholeJsonField) {
     auto& factory = IndexFactory::GetInstance();
 
     auto json_request = factory.ScalarIndexLoadResource(
-        DataType::JSON, 0, 1024, index_params, false);
+        DataType::JSON, 0, 1024, index_params, false, 1000);
     EXPECT_FALSE(json_request.has_raw_data);
 
     auto varchar_request = factory.ScalarIndexLoadResource(
-        DataType::VARCHAR, 0, 1024, index_params, false);
+        DataType::VARCHAR, 0, 1024, index_params, false, 1000);
     EXPECT_TRUE(varchar_request.has_raw_data);
 }
 

--- a/internal/core/src/index/IndexFactoryRawDataTest.cpp
+++ b/internal/core/src/index/IndexFactoryRawDataTest.cpp
@@ -15,12 +15,14 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include <roaring/roaring.hh>
 
 #include <map>
 #include <string>
 
 #include "common/Types.h"
 #include "index/IndexFactory.h"
+#include "index/InvertedIndexUtil.h"
 #include "index/Meta.h"
 
 namespace milvus::index {
@@ -37,6 +39,77 @@ TEST(IndexFactoryRawDataTest, JsonPathIndexCannotReplaceWholeJsonField) {
     auto varchar_request = factory.ScalarIndexLoadResource(
         DataType::VARCHAR, 0, 1024, index_params, false, 1000);
     EXPECT_TRUE(varchar_request.has_raw_data);
+}
+
+TEST(IndexFactoryRawDataTest, LoadResourceIncludesResidentRoaringRowMasks) {
+    constexpr int64_t kRowCount = 65536;
+    constexpr uint64_t kIndexSize = 1024;
+    constexpr uint64_t kOneMaskBudget = kRowCount / 4;
+
+    std::map<std::string, std::string> plain_params{
+        {INDEX_TYPE, INVERTED_INDEX_TYPE},
+        {SCALAR_INDEX_ENGINE_VERSION, "3"},
+    };
+    auto plain = IndexFactory::GetInstance().ScalarIndexLoadResource(
+        DataType::INT64, 0, kIndexSize, plain_params, true, kRowCount);
+    EXPECT_EQ(plain.final_memory_cost, kOneMaskBudget);
+
+    std::map<std::string, std::string> json_params{
+        {INDEX_TYPE, INVERTED_INDEX_TYPE},
+        {SCALAR_INDEX_ENGINE_VERSION, "3"},
+        {JSON_PATH, "/a"},
+        {JSON_CAST_TYPE, "DOUBLE"},
+    };
+    auto json = IndexFactory::GetInstance().ScalarIndexLoadResource(
+        DataType::JSON, 0, kIndexSize, json_params, true, kRowCount);
+    EXPECT_EQ(json.final_memory_cost, 2 * kOneMaskBudget + kRowCount / 8);
+}
+
+TEST(IndexFactoryRawDataTest,
+     LoadResourceSkipsRowMaskForNonNullableScalarField) {
+    constexpr int64_t kRowCount = 65536;
+    constexpr uint64_t kIndexSize = 1024;
+    constexpr uint64_t kOneMaskBudget = kRowCount / 4;
+
+    std::map<std::string, std::string> params{
+        {INDEX_TYPE, INVERTED_INDEX_TYPE},
+        {SCALAR_INDEX_ENGINE_VERSION, "3"},
+    };
+    auto non_nullable = IndexFactory::GetInstance().ScalarIndexLoadResource(
+        DataType::INT64, 0, kIndexSize, params, true, kRowCount, false);
+    auto nullable = IndexFactory::GetInstance().ScalarIndexLoadResource(
+        DataType::INT64, 0, kIndexSize, params, true, kRowCount, true);
+
+    EXPECT_EQ(non_nullable.final_memory_cost, 0);
+    EXPECT_EQ(nullable.final_memory_cost, kOneMaskBudget);
+}
+
+TEST(IndexFactoryRawDataTest, LoadResourceCoversSparseRoaringRowMask) {
+    constexpr int64_t kRowCount = 8192;
+
+    roaring::Roaring sparse_offsets;
+    for (uint32_t row = 0; row < kRowCount; row += 2) {
+        sparse_offsets.add(row);
+    }
+    sparse_offsets.runOptimize();
+    sparse_offsets.shrinkToFit();
+
+    std::map<std::string, std::string> params{
+        {INDEX_TYPE, INVERTED_INDEX_TYPE},
+        {SCALAR_INDEX_ENGINE_VERSION, "3"},
+    };
+    auto request = IndexFactory::GetInstance().ScalarIndexLoadResource(
+        DataType::INT64,
+        0,
+        0,
+        params,
+        true,
+        kRowCount,
+        /*field_nullable=*/true);
+    const auto actual_mask_bytes = RoaringMemoryBytes(sparse_offsets);
+
+    EXPECT_GE(request.final_memory_cost, actual_mask_bytes);
+    EXPECT_GE(request.max_memory_cost, actual_mask_bytes);
 }
 
 }  // namespace milvus::index

--- a/internal/core/src/index/InvertedIndexArrayTest.cpp
+++ b/internal/core/src/index/InvertedIndexArrayTest.cpp
@@ -18,6 +18,7 @@
 #include "exec/QueryContext.h"
 #include "exec/expression/EvalCtx.h"
 #include "exec/expression/Expr.h"
+#include "index/InvertedIndexUtil.h"
 #include "pb/plan.pb.h"
 #include "index/InvertedIndexTantivy.h"
 #include "common/Schema.h"
@@ -355,6 +356,46 @@ EvalFilterInBatches(const expr::TypedExprPtr& logical_expr,
                                           std::move(combined_validity));
 }
 
+TEST(InvertedIndexRowMaskUtil, LegacyOffsetsRoundTripThroughRoaring) {
+    const std::vector<size_t> legacy = {1, 3, 5, 7, 9};
+    roaring::Roaring offsets;
+
+    index::LoadLegacyOffsets(offsets,
+                             reinterpret_cast<const uint8_t*>(legacy.data()),
+                             legacy.size() * sizeof(size_t));
+
+    EXPECT_EQ(index::RoaringToLegacyOffsets(offsets), legacy);
+}
+
+TEST(InvertedIndexRowMaskUtil, MaterializesDenseRoaringRows) {
+    roaring::Roaring offsets;
+    offsets.addRange(0, 99);
+    offsets.runOptimize();
+
+    auto rows = index::RoaringToBitset(offsets, 100);
+    EXPECT_EQ(rows.count(), 99);
+    EXPECT_TRUE(rows[0]);
+    EXPECT_TRUE(rows[98]);
+    EXPECT_FALSE(rows[99]);
+
+    auto complement = index::RoaringToBitset(offsets, 100, /*inverted=*/true);
+    EXPECT_EQ(complement.count(), 1);
+    EXPECT_TRUE(complement[99]);
+}
+
+TEST(InvertedIndexRowMaskUtil, ClearsRoaringRowsFromCandidates) {
+    roaring::Roaring offsets;
+    offsets.add(1);
+    offsets.add(5);
+    TargetBitmap candidates(8, true);
+
+    index::ClearRoaringRows(offsets, candidates);
+
+    EXPECT_EQ(candidates.count(), 6);
+    EXPECT_FALSE(candidates[1]);
+    EXPECT_FALSE(candidates[5]);
+}
+
 class NullableInt64ArrayInvertedIndex
     : public index::InvertedIndexTantivy<int64_t> {
  public:
@@ -365,7 +406,10 @@ class NullableInt64ArrayInvertedIndex
 
     void
     SetNullOffsets(std::vector<size_t> offsets) {
-        null_offset_ = std::move(offsets);
+        for (auto offset : offsets) {
+            AddNullOffset(offset);
+        }
+        OptimizeNullOffsets();
     }
 
     void

--- a/internal/core/src/index/InvertedIndexArrayTest.cpp
+++ b/internal/core/src/index/InvertedIndexArrayTest.cpp
@@ -383,6 +383,55 @@ TEST(InvertedIndexRowMaskUtil, MaterializesDenseRoaringRows) {
     EXPECT_TRUE(complement[99]);
 }
 
+TEST(InvertedIndexRowMaskUtil, SelectsContainerAwareMaterialization) {
+    constexpr size_t kRowCount = uint64_t{1} << 16;
+
+    roaring::Roaring sparse_offsets;
+    sparse_offsets.add(1);
+    sparse_offsets.add(4097);
+    sparse_offsets.runOptimize();
+    EXPECT_FALSE(
+        index::ShouldMaterializeRoaringAsBitset(sparse_offsets, kRowCount));
+
+    roaring::Roaring bitmap_offsets;
+    for (uint32_t offset = 0; offset < kRowCount; offset += 2) {
+        bitmap_offsets.add(offset);
+    }
+    bitmap_offsets.runOptimize();
+    EXPECT_TRUE(
+        index::ShouldMaterializeRoaringAsBitset(bitmap_offsets, kRowCount));
+
+    roaring::Roaring run_offsets;
+    run_offsets.addRange(1000, kRowCount - 1000);
+    run_offsets.runOptimize();
+    EXPECT_TRUE(
+        index::ShouldMaterializeRoaringAsBitset(run_offsets, kRowCount));
+
+    run_offsets.add(kRowCount);
+    EXPECT_FALSE(
+        index::ShouldMaterializeRoaringAsBitset(run_offsets, kRowCount));
+}
+
+TEST(InvertedIndexRowMaskUtil, MaterializesBitmapContainerRows) {
+    constexpr size_t kRowCount = uint64_t{1} << 16;
+    roaring::Roaring offsets;
+    for (uint32_t offset = 0; offset < kRowCount; offset += 2) {
+        offsets.add(offset);
+    }
+    offsets.runOptimize();
+
+    auto rows = index::RoaringToBitset(offsets, kRowCount);
+    auto complement =
+        index::RoaringToBitset(offsets, kRowCount, /*inverted=*/true);
+
+    EXPECT_EQ(rows.count(), kRowCount / 2);
+    EXPECT_EQ(complement.count(), kRowCount / 2);
+    for (size_t offset : {size_t{0}, size_t{1}, kRowCount - 2, kRowCount - 1}) {
+        EXPECT_EQ(rows[offset], offset % 2 == 0);
+        EXPECT_EQ(complement[offset], offset % 2 != 0);
+    }
+}
+
 TEST(InvertedIndexRowMaskUtil, ClearsRoaringRowsFromCandidates) {
     roaring::Roaring offsets;
     offsets.add(1);

--- a/internal/core/src/index/InvertedIndexTantivy.cpp
+++ b/internal/core/src/index/InvertedIndexTantivy.cpp
@@ -333,7 +333,7 @@ InvertedIndexTantivy<T>::IsNull() {
     tracer::AutoSpan span("InvertedIndexTantivy::IsNull",
                           tracer::GetRootSpan());
     int64_t count = Count();
-    TargetBitmap bitset(count);
+    TargetBitmap bitset;
 
     auto fill_bitset = [this, count, &bitset]() {
         bitset = RoaringToBitset(null_offsets_, count);

--- a/internal/core/src/index/InvertedIndexTantivy.cpp
+++ b/internal/core/src/index/InvertedIndexTantivy.cpp
@@ -127,6 +127,10 @@ InvertedIndexTantivy<T>::~InvertedIndexTantivy() {
 template <typename T>
 void
 InvertedIndexTantivy<T>::finish() {
+    {
+        std::unique_lock<folly::SharedMutex> lock(mutex_);
+        OptimizeNullOffsets();
+    }
     wrapper_->finish();
 }
 
@@ -134,11 +138,12 @@ template <typename T>
 BinarySet
 InvertedIndexTantivy<T>::Serialize(const Config& config) {
     std::shared_lock<folly::SharedMutex> lock(mutex_);
-    auto index_valid_data_length = null_offset_.size() * sizeof(size_t);
+    auto legacy_offsets = RoaringToLegacyOffsets(null_offsets_);
+    auto index_valid_data_length = legacy_offsets.size() * sizeof(size_t);
     std::shared_ptr<uint8_t[]> index_valid_data(
         new uint8_t[index_valid_data_length]);
     memcpy(
-        index_valid_data.get(), null_offset_.data(), index_valid_data_length);
+        index_valid_data.get(), legacy_offsets.data(), index_valid_data_length);
     lock.unlock();
     BinarySet res_set;
     if (index_valid_data_length > 0) {
@@ -236,9 +241,7 @@ void
 InvertedIndexTantivy<T>::LoadIndexMetas(
     const std::vector<std::string>& index_files, const Config& config) {
     auto fill_null_offsets = [&](const uint8_t* data, int64_t size) {
-        auto prev_size = null_offset_.size();
-        null_offset_.resize(prev_size + (size_t)size / sizeof(size_t));
-        memcpy(null_offset_.data() + prev_size, data, (size_t)size);
+        LoadLegacyOffsets(null_offsets_, data, size);
     };
     auto null_offset_file_itr = std::find_if(
         index_files.begin(), index_files.end(), [&](const std::string& file) {
@@ -333,11 +336,7 @@ InvertedIndexTantivy<T>::IsNull() {
     TargetBitmap bitset(count);
 
     auto fill_bitset = [this, count, &bitset]() {
-        auto end =
-            std::lower_bound(null_offset_.begin(), null_offset_.end(), count);
-        for (auto iter = null_offset_.begin(); iter != end; ++iter) {
-            bitset.set(*iter);
-        }
+        bitset = RoaringToBitset(null_offsets_, count);
     };
 
     if (is_growing_) {
@@ -358,12 +357,8 @@ InvertedIndexTantivy<T>::IsNotNull() {
     int64_t count = Count();
     TargetBitmap bitset(count, true);
 
-    auto fill_bitset = [this, count, &bitset]() {
-        auto end =
-            std::lower_bound(null_offset_.begin(), null_offset_.end(), count);
-        for (auto iter = null_offset_.begin(); iter != end; ++iter) {
-            bitset.reset(*iter);
-        }
+    auto fill_bitset = [this, &bitset]() {
+        ClearRoaringRows(null_offsets_, bitset);
     };
 
     if (is_growing_) {
@@ -411,12 +406,8 @@ InvertedIndexTantivy<T>::NotIn(size_t n, const T* values) {
     // The expression is "not" in, so we flip the bit.
     bitset.flip();
 
-    auto fill_bitset = [this, count, &bitset]() {
-        auto end =
-            std::lower_bound(null_offset_.begin(), null_offset_.end(), count);
-        for (auto iter = null_offset_.begin(); iter != end; ++iter) {
-            bitset.reset(*iter);
-        }
+    auto fill_bitset = [this, &bitset]() {
+        ClearRoaringRows(null_offsets_, bitset);
     };
 
     if (is_growing_) {
@@ -598,13 +589,6 @@ template <typename T>
 void
 InvertedIndexTantivy<T>::BuildWithFieldData(
     const std::vector<std::shared_ptr<FieldDataBase>>& field_datas) {
-    if (schema_.nullable()) {
-        int64_t total = 0;
-        for (const auto& data : field_datas) {
-            total += data->get_null_count();
-        }
-        null_offset_.reserve(total);
-    }
     switch (schema_.data_type()) {
         case proto::schema::DataType::Bool:
         case proto::schema::DataType::Int8:
@@ -624,7 +608,7 @@ InvertedIndexTantivy<T>::BuildWithFieldData(
                         auto n = data->get_num_rows();
                         for (int i = 0; i < n; i++) {
                             if (!data->is_valid(i)) {
-                                null_offset_.push_back(offset);
+                                AddNullOffset(offset);
                             }
                             wrapper_->add_array_data<T>(
                                 static_cast<const T*>(data->RawValue(i)),
@@ -647,7 +631,7 @@ InvertedIndexTantivy<T>::BuildWithFieldData(
                     if (schema_.nullable()) {
                         for (int i = 0; i < n; i++) {
                             if (!data->is_valid(i)) {
-                                null_offset_.push_back(offset);
+                                AddNullOffset(offset);
                             }
                             wrapper_
                                 ->add_array_data_by_single_segment_writer<T>(
@@ -679,6 +663,7 @@ InvertedIndexTantivy<T>::BuildWithFieldData(
                       fmt::format("Inverted index not supported on {}",
                                   schema_.data_type()));
     }
+    OptimizeNullOffsets();
 }
 
 template <typename T>
@@ -695,7 +680,7 @@ InvertedIndexTantivy<T>::build_index_for_array(
         auto array_column = static_cast<const Array*>(data->Data());
         for (int64_t i = 0; i < n; i++) {
             if (schema_.nullable() && !data->is_valid(i)) {
-                null_offset_.push_back(offset);
+                AddNullOffset(offset);
             }
             auto length = data->is_valid(i) ? array_column[i].length() : 0;
             if (!inverted_index_single_segment_) {
@@ -725,7 +710,7 @@ InvertedIndexTantivy<std::string>::build_index_for_array(
         auto array_column = static_cast<const Array*>(data->Data());
         for (int64_t i = 0; i < n; i++) {
             if (schema_.nullable() && !data->is_valid(i)) {
-                null_offset_.push_back(offset);
+                AddNullOffset(offset);
             } else {
                 Assert(IsStringDataType(array_column[i].get_element_type()));
                 Assert(IsStringDataType(
@@ -770,7 +755,7 @@ InvertedIndexTantivy<T>::WriteEntries(storage::IndexEntryWriter* writer) {
     }
 
     std::shared_lock<folly::SharedMutex> lock(mutex_);
-    bool has_null = !null_offset_.empty();
+    bool has_null = !null_offsets_.isEmpty();
     lock.unlock();
 
     writer->PutMeta("file_names", file_names);
@@ -787,9 +772,10 @@ InvertedIndexTantivy<T>::WriteEntries(storage::IndexEntryWriter* writer) {
 
     lock.lock();
     if (has_null) {
+        auto legacy_offsets = RoaringToLegacyOffsets(null_offsets_);
         writer->WriteEntry(INDEX_NULL_OFFSET_FILE_NAME,
-                           null_offset_.data(),
-                           null_offset_.size() * sizeof(size_t));
+                           legacy_offsets.data(),
+                           legacy_offsets.size() * sizeof(size_t));
     }
     lock.unlock();
 }
@@ -812,10 +798,8 @@ InvertedIndexTantivy<T>::LoadEntries(storage::IndexEntryReader& reader,
 
     if (has_null) {
         auto null_entry = reader.ReadEntry(INDEX_NULL_OFFSET_FILE_NAME);
-        null_offset_.resize(null_entry.data.size() / sizeof(size_t));
-        std::memcpy(null_offset_.data(),
-                    null_entry.data.data(),
-                    null_entry.data.size());
+        LoadLegacyOffsets(
+            null_offsets_, null_entry.data.data(), null_entry.data.size());
     }
 
     auto load_in_mmap =

--- a/internal/core/src/index/InvertedIndexTantivy.cpp
+++ b/internal/core/src/index/InvertedIndexTantivy.cpp
@@ -355,10 +355,10 @@ InvertedIndexTantivy<T>::IsNotNull() {
     tracer::AutoSpan span("InvertedIndexTantivy::IsNotNull",
                           tracer::GetRootSpan());
     int64_t count = Count();
-    TargetBitmap bitset(count, true);
 
-    auto fill_bitset = [this, &bitset]() {
-        ClearRoaringRows(null_offsets_, bitset);
+    TargetBitmap bitset;
+    auto fill_bitset = [this, count, &bitset]() {
+        bitset = RoaringToBitset(null_offsets_, count, /*inverted=*/true);
     };
 
     if (is_growing_) {

--- a/internal/core/src/index/InvertedIndexTantivy.h
+++ b/internal/core/src/index/InvertedIndexTantivy.h
@@ -15,11 +15,14 @@
 #include <stdint.h>
 #include <cstddef>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
+
+#include <roaring/roaring.hh>
 
 #include "common/EasyAssert.h"
 #include "common/FieldData.h"
@@ -30,6 +33,7 @@
 #include "common/protobuf_utils.h"
 #include "fmt/core.h"
 #include "index/IndexStats.h"
+#include "index/InvertedIndexUtil.h"
 #include "index/Meta.h"
 #include "index/ScalarIndex.h"
 #include "pb/plan.pb.h"
@@ -216,8 +220,7 @@ class InvertedIndexTantivy : public ScalarIndex<T> {
         // Tantivy index size
         total += wrapper_->index_size_bytes();
 
-        // null_offset_: vector<size_t>
-        total += null_offset_.capacity() * sizeof(size_t);
+        total += RoaringMemoryBytes(null_offsets_);
 
         this->cached_byte_size_ = total;
     }
@@ -318,6 +321,20 @@ class InvertedIndexTantivy : public ScalarIndex<T> {
     virtual void
     RetainTantivyIndexFiles(std::vector<std::string>& index_files);
 
+    void
+    AddNullOffset(size_t offset) {
+        AssertInfo(offset <= std::numeric_limits<uint32_t>::max(),
+                   "row offset {} exceeds uint32 range",
+                   offset);
+        null_offsets_.add(static_cast<uint32_t>(offset));
+    }
+
+    void
+    OptimizeNullOffsets() {
+        null_offsets_.runOptimize();
+        null_offsets_.shrinkToFit();
+    }
+
  protected:
     std::shared_ptr<TantivyIndexWrapper> wrapper_;
     TantivyDataType d_type_;
@@ -334,9 +351,10 @@ class InvertedIndexTantivy : public ScalarIndex<T> {
     DiskFileManagerPtr disk_file_manager_;
 
     folly::SharedMutexWritePriority mutex_{};
-    // all data need to be built to align the offset
-    // so need to store null_offset_ in inverted index additionally
-    std::vector<size_t> null_offset_{};
+    // Tantivy does not retain null rows, so keep their row ids separately.
+    // CRoaring adapts each container between sparse arrays, dense bitmaps and
+    // runs, avoiding the 8-byte-per-row overhead of std::vector<size_t>.
+    roaring::Roaring null_offsets_{};
 
     // `inverted_index_single_segment_` is used to control whether to build tantivy index with single segment.
     //

--- a/internal/core/src/index/InvertedIndexUtil.h
+++ b/internal/core/src/index/InvertedIndexUtil.h
@@ -75,10 +75,54 @@ RoaringToLegacyOffsets(const roaring::Roaring& offsets) {
     return legacy;
 }
 
+inline bool
+ShouldMaterializeRoaringAsBitset(const roaring::Roaring& offsets,
+                                 size_t row_count) {
+    if (offsets.isEmpty() || row_count == 0) {
+        return false;
+    }
+
+    roaring::api::roaring_statistics_t stats{};
+    roaring::api::roaring_bitmap_statistics(&offsets.roaring, &stats);
+    // The dense converter may resize its bitset to cover the largest value.
+    // Keep the iterator path when the row mask extends beyond this result so
+    // out-of-range offsets retain the existing ignore semantics.
+    if (static_cast<uint64_t>(stats.max_value) >= row_count) {
+        return false;
+    }
+
+    const auto word_count =
+        row_count / 64 + static_cast<size_t>(row_count % 64 != 0);
+    const auto dense_container_values =
+        static_cast<uint64_t>(stats.n_values_run_containers) +
+        stats.n_values_bitset_containers;
+    // Materializing run and bitmap containers avoids more scattered bit
+    // updates than the extra word-wise flip needed by the inverted result.
+    // Array-container values stay on the sparse iterator path.
+    return dense_container_values > word_count;
+}
+
 inline TargetBitmap
 RoaringToBitset(const roaring::Roaring& offsets,
                 size_t row_count,
                 bool inverted = false) {
+    if (ShouldMaterializeRoaringAsBitset(offsets, row_count)) {
+        TargetBitmap result(row_count);
+        const auto word_count = result.size_in_elements();
+        // The selection predicate guarantees max(offsets) < row_count, so the
+        // converter cannot grow or reallocate this borrowed target buffer.
+        roaring::api::bitset_t bitset_view{
+            result.data(), word_count, word_count};
+        const auto converted = roaring::api::roaring_bitmap_to_bitset(
+            &offsets.roaring, &bitset_view);
+        AssertInfo(converted,
+                   "failed to materialize roaring row mask as a bitset");
+        if (inverted) {
+            result.flip();
+        }
+        return result;
+    }
+
     TargetBitmap result(row_count, inverted);
     for (auto offset : offsets) {
         if (offset >= row_count) {

--- a/internal/core/src/index/InvertedIndexUtil.h
+++ b/internal/core/src/index/InvertedIndexUtil.h
@@ -11,7 +11,86 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <limits>
+#include <optional>
+#include <vector>
+
+#include <roaring/roaring.hh>
+
+#include "common/EasyAssert.h"
+#include "common/Types.h"
+
 namespace milvus::index {
+
+inline size_t
+RoaringMemoryBytes(const roaring::Roaring& offsets) {
+    roaring::api::roaring_statistics_t stats{};
+    roaring::api::roaring_bitmap_statistics(&offsets.roaring, &stats);
+    const auto container_bytes =
+        static_cast<size_t>(stats.n_bytes_array_containers) +
+        stats.n_bytes_run_containers + stats.n_bytes_bitset_containers;
+    return sizeof(roaring::Roaring) +
+           std::max(container_bytes, offsets.getSizeInBytes());
+}
+
+inline void
+LoadLegacyOffsets(roaring::Roaring& offsets, const uint8_t* data, size_t size) {
+    AssertInfo(size % sizeof(size_t) == 0,
+               "legacy offset payload size {} is not aligned to size_t",
+               size);
+
+    offsets = roaring::Roaring();
+    const auto count = size / sizeof(size_t);
+    for (size_t i = 0; i < count; ++i) {
+        size_t offset;
+        std::memcpy(&offset, data + i * sizeof(size_t), sizeof(size_t));
+        AssertInfo(offset <= std::numeric_limits<uint32_t>::max(),
+                   "row offset {} exceeds uint32 range",
+                   offset);
+        offsets.add(static_cast<uint32_t>(offset));
+    }
+    offsets.runOptimize();
+    offsets.shrinkToFit();
+}
+
+inline std::vector<size_t>
+RoaringToLegacyOffsets(const roaring::Roaring& offsets) {
+    std::vector<size_t> legacy;
+    legacy.reserve(static_cast<size_t>(offsets.cardinality()));
+    for (auto offset : offsets) {
+        legacy.push_back(offset);
+    }
+    return legacy;
+}
+
+inline TargetBitmap
+RoaringToBitset(const roaring::Roaring& offsets,
+                size_t row_count,
+                bool inverted = false) {
+    TargetBitmap result(row_count, inverted);
+    for (auto offset : offsets) {
+        if (offset >= row_count) {
+            break;
+        }
+        result.set(offset, !inverted);
+    }
+    return result;
+}
+
+inline void
+ClearRoaringRows(const roaring::Roaring& offsets, TargetBitmap& target) {
+    for (auto offset : offsets) {
+        if (offset >= target.size()) {
+            break;
+        }
+        target.reset(offset);
+    }
+}
+
 inline void
 apply_hits_with_filter(milvus::TargetBitmap& bitset,
                        const std::function<bool(size_t /* offset */)>& filter) {

--- a/internal/core/src/index/InvertedIndexUtil.h
+++ b/internal/core/src/index/InvertedIndexUtil.h
@@ -45,13 +45,21 @@ LoadLegacyOffsets(roaring::Roaring& offsets, const uint8_t* data, size_t size) {
 
     offsets = roaring::Roaring();
     const auto count = size / sizeof(size_t);
+    // Legacy payload is a sorted size_t[] on disk; roaring stores uint32_t, so
+    // convert once into a dense buffer and bulk-insert with addMany instead of
+    // per-element Roaring::add (each add does a container lookup).
+    std::vector<uint32_t> buf;
+    buf.reserve(count);
     for (size_t i = 0; i < count; ++i) {
         size_t offset;
         std::memcpy(&offset, data + i * sizeof(size_t), sizeof(size_t));
         AssertInfo(offset <= std::numeric_limits<uint32_t>::max(),
                    "row offset {} exceeds uint32 range",
                    offset);
-        offsets.add(static_cast<uint32_t>(offset));
+        buf.push_back(static_cast<uint32_t>(offset));
+    }
+    if (!buf.empty()) {
+        offsets.addMany(buf.size(), buf.data());
     }
     offsets.runOptimize();
     offsets.shrinkToFit();

--- a/internal/core/src/index/JsonFlatIndex.cpp
+++ b/internal/core/src/index/JsonFlatIndex.cpp
@@ -30,7 +30,7 @@ JsonFlatIndex::build_index_for_json(
         auto n = data->get_num_rows();
         for (int i = 0; i < n; i++) {
             if (schema_.nullable() && !data->is_valid(i)) {
-                null_offset_.push_back(offset);
+                AddNullOffset(offset);
                 wrapper_->add_json_array_data(nullptr, 0, offset++);
                 continue;
             }

--- a/internal/core/src/index/JsonFlatIndex.h
+++ b/internal/core/src/index/JsonFlatIndex.h
@@ -804,7 +804,7 @@ class JsonFlatIndex : public InvertedIndexTantivy<std::string> {
 
     void
     finish() {
-        this->wrapper_->finish();
+        InvertedIndexTantivy<std::string>::finish();
     }
 
     void
@@ -824,6 +824,6 @@ JsonFlatIndexQueryExecutor<T>::JsonFlatIndexQueryExecutor(
     json_path_ = json_path;
     use_comparable_value_mask_ = use_comparable_value_mask;
     this->wrapper_ = json_flat_index.wrapper_;
-    this->null_offset_ = json_flat_index.null_offset_;
+    this->null_offsets_ = json_flat_index.null_offsets_;
 }
 }  // namespace milvus::index

--- a/internal/core/src/index/JsonInvertedIndex.cpp
+++ b/internal/core/src/index/JsonInvertedIndex.cpp
@@ -26,6 +26,7 @@
 #include "boost/filesystem/operations.hpp"
 #include "boost/filesystem/path.hpp"
 #include "folly/SharedMutex.h"
+#include "common/Consts.h"
 #include "common/Json.h"
 #include "common/Types.h"
 #include "index/JsonIndexBuilder.h"
@@ -60,6 +61,11 @@ JsonInvertedIndex<T>::build_index_for_json(
     const std::vector<std::shared_ptr<FieldDataBase>>& field_datas) {
     LOG_INFO("Start to build json inverted index for field: {}", nested_path_);
 
+    int64_t total_rows = 0;
+    for (const auto& data : field_datas) {
+        total_rows += data->get_num_rows();
+    }
+
     ProcessJsonFieldData<T>(
         field_datas,
         this->schema_,
@@ -89,28 +95,27 @@ JsonInvertedIndex<T>::build_index_for_json(
     this->OptimizeNullOffsets();
     this->non_exist_offsets_.runOptimize();
     this->non_exist_offsets_.shrinkToFit();
+    BuildExistsBitset(total_rows);
 
     error_recorder_.PrintErrStats();
 }
 
 template <typename T>
+void
+JsonInvertedIndex<T>::Load(milvus::tracer::TraceContext ctx,
+                           const Config& config) {
+    InvertedIndexTantivy<T>::Load(ctx, config);
+    const auto row_count =
+        GetValueFromConfig<int64_t>(config, INDEX_NUM_ROWS_KEY)
+            .value_or(this->Count());
+    BuildExistsBitset(row_count);
+    ComputeByteSize();
+}
+
+template <typename T>
 TargetBitmap
 JsonInvertedIndex<T>::Exists() {
-    int64_t count = this->Count();
-    TargetBitmap bitset(count, true);
-
-    auto fill_bitset = [this, &bitset]() {
-        ClearRoaringRows(non_exist_offsets_, bitset);
-    };
-
-    if (this->is_growing_) {
-        std::shared_lock<folly::SharedMutex> lock(this->mutex_);
-        fill_bitset();
-    } else {
-        fill_bitset();
-    }
-
-    return bitset;
+    return exists_bitset_.clone();
 }
 
 template <typename T>
@@ -286,6 +291,11 @@ JsonInvertedIndex<T>::LoadEntries(storage::IndexEntryReader& reader,
     }
     LOG_INFO("LoadEntries JsonInvertedIndex done, has_non_exist: {}",
              has_non_exist);
+    const auto row_count =
+        GetValueFromConfig<int64_t>(config, INDEX_NUM_ROWS_KEY)
+            .value_or(this->Count());
+    BuildExistsBitset(row_count);
+    ComputeByteSize();
 }
 
 template class JsonInvertedIndex<bool>;

--- a/internal/core/src/index/JsonInvertedIndex.cpp
+++ b/internal/core/src/index/JsonInvertedIndex.cpp
@@ -71,15 +71,24 @@ JsonInvertedIndex<T>::build_index_for_json(
             this->wrapper_->template add_array_data<T>(data, size, offset);
         },
         // handle null
-        [this](int64_t offset) { this->null_offset_.push_back(offset); },
+        [this](int64_t offset) { this->AddNullOffset(offset); },
         // handle non exist
-        [this](int64_t offset) { this->non_exist_offsets_.push_back(offset); },
+        [this](int64_t offset) {
+            AssertInfo(offset <= std::numeric_limits<uint32_t>::max(),
+                       "row offset {} exceeds uint32 range",
+                       offset);
+            this->non_exist_offsets_.add(static_cast<uint32_t>(offset));
+        },
         // handle error
         [this](const Json& json,
                const std::string& nested_path,
                simdjson::error_code error) {
             this->error_recorder_.Record(json, nested_path, error);
         });
+
+    this->OptimizeNullOffsets();
+    this->non_exist_offsets_.runOptimize();
+    this->non_exist_offsets_.shrinkToFit();
 
     error_recorder_.PrintErrStats();
 }
@@ -90,12 +99,8 @@ JsonInvertedIndex<T>::Exists() {
     int64_t count = this->Count();
     TargetBitmap bitset(count, true);
 
-    auto fill_bitset = [this, count, &bitset]() {
-        auto end = std::lower_bound(
-            non_exist_offsets_.begin(), non_exist_offsets_.end(), count);
-        for (auto iter = non_exist_offsets_.begin(); iter != end; ++iter) {
-            bitset.reset(*iter);
-        }
+    auto fill_bitset = [this, &bitset]() {
+        ClearRoaringRows(non_exist_offsets_, bitset);
     };
 
     if (this->is_growing_) {
@@ -164,9 +169,7 @@ JsonInvertedIndex<T>::LoadIndexMetas(
     const std::vector<std::string>& index_files, const Config& config) {
     InvertedIndexTantivy<T>::LoadIndexMetas(index_files, config);
     auto fill_non_exist_offset = [&](const uint8_t* data, int64_t size) {
-        auto prev_size = non_exist_offsets_.size();
-        non_exist_offsets_.resize(prev_size + (size_t)size / sizeof(size_t));
-        memcpy(non_exist_offsets_.data() + prev_size, data, (size_t)size);
+        LoadLegacyOffsets(non_exist_offsets_, data, size);
     };
     auto non_exist_offset_file_itr = std::find_if(
         index_files.begin(), index_files.end(), [&](const std::string& file) {
@@ -226,9 +229,9 @@ JsonInvertedIndex<T>::LoadIndexMetas(
     // 1. Legacy v2.5.x data where non_exist_offset_file doesn't exist
     // 2. All records are valid (no invalid offsets to track)
     //
-    // Use null_offset_ as the source for non_exist_offsets_ to maintain
+    // Use null_offsets_ as the source for non_exist_offsets_ to maintain
     // backward compatibility. This ensures Exists() behaves like v2.5.x IsNotNull().
-    non_exist_offsets_ = this->null_offset_;
+    non_exist_offsets_ = this->null_offsets_;
 }
 
 template <typename T>
@@ -257,12 +260,13 @@ JsonInvertedIndex<T>::WriteEntries(storage::IndexEntryWriter* writer) {
 
     // Write json-specific data (non_exist_offsets)
     std::shared_lock<folly::SharedMutex> lock(this->mutex_);
-    bool has_non_exist = !this->non_exist_offsets_.empty();
+    bool has_non_exist = !this->non_exist_offsets_.isEmpty();
     writer->PutMeta("has_non_exist", has_non_exist);
     if (has_non_exist) {
+        auto legacy_offsets = RoaringToLegacyOffsets(this->non_exist_offsets_);
         writer->WriteEntry(INDEX_NON_EXIST_OFFSET_FILE_NAME,
-                           this->non_exist_offsets_.data(),
-                           this->non_exist_offsets_.size() * sizeof(size_t));
+                           legacy_offsets.data(),
+                           legacy_offsets.size() * sizeof(size_t));
     }
 }
 
@@ -277,9 +281,8 @@ JsonInvertedIndex<T>::LoadEntries(storage::IndexEntryReader& reader,
     bool has_non_exist = reader.GetMeta<bool>("has_non_exist", false);
     if (has_non_exist) {
         auto e = reader.ReadEntry(INDEX_NON_EXIST_OFFSET_FILE_NAME);
-        this->non_exist_offsets_.resize(e.data.size() / sizeof(size_t));
-        std::memcpy(
-            this->non_exist_offsets_.data(), e.data.data(), e.data.size());
+        LoadLegacyOffsets(
+            this->non_exist_offsets_, e.data.data(), e.data.size());
     }
     LOG_INFO("LoadEntries JsonInvertedIndex done, has_non_exist: {}",
              has_non_exist);

--- a/internal/core/src/index/JsonInvertedIndex.h
+++ b/internal/core/src/index/JsonInvertedIndex.h
@@ -114,6 +114,9 @@ class JsonInvertedIndex : public index::InvertedIndexTantivy<T> {
                              field_datas) override;
 
     void
+    Load(milvus::tracer::TraceContext ctx, const Config& config = {}) override;
+
+    void
     finish() {
         this->wrapper_->finish();
     }
@@ -153,7 +156,8 @@ class JsonInvertedIndex : public index::InvertedIndexTantivy<T> {
                null_offsets.data(),
                index_valid_data_length);
 
-        auto non_exist_offsets = RoaringToLegacyOffsets(this->non_exist_offsets_);
+        auto non_exist_offsets =
+            RoaringToLegacyOffsets(this->non_exist_offsets_);
         auto non_exist_data_length = non_exist_offsets.size() * sizeof(size_t);
         std::shared_ptr<uint8_t[]> non_exist_data(
             new uint8_t[non_exist_data_length]);
@@ -181,6 +185,13 @@ class JsonInvertedIndex : public index::InvertedIndexTantivy<T> {
     Exists();
 
     void
+    ComputeByteSize() override {
+        InvertedIndexTantivy<T>::ComputeByteSize();
+        this->cached_byte_size_ += RoaringMemoryBytes(non_exist_offsets_);
+        this->cached_byte_size_ += exists_bitset_.size_in_bytes();
+    }
+
+    void
     WriteEntries(storage::IndexEntryWriter* writer) override;
 
     void
@@ -200,6 +211,12 @@ class JsonInvertedIndex : public index::InvertedIndexTantivy<T> {
     TargetBitmap
     ComparableValueBitset();
 
+    void
+    BuildExistsBitset(size_t count) {
+        exists_bitset_ =
+            RoaringToBitset(non_exist_offsets_, count, /*inverted=*/true);
+    }
+
     std::string nested_path_;
     JsonInvertedIndexParseErrorRecorder error_recorder_;
     JsonCastType cast_type_;
@@ -212,6 +229,7 @@ class JsonInvertedIndex : public index::InvertedIndexTantivy<T> {
     // For example, if the JSON path is "/a", this bitmap will store rows like
     // null, {}, {"a": null}, etc.
     roaring::Roaring non_exist_offsets_;
+    TargetBitmap exists_bitset_;
 };
 
 }  // namespace milvus::index

--- a/internal/core/src/index/JsonInvertedIndex.h
+++ b/internal/core/src/index/JsonInvertedIndex.h
@@ -145,20 +145,20 @@ class JsonInvertedIndex : public index::InvertedIndexTantivy<T> {
     BinarySet
     Serialize(const Config& config) override {
         std::shared_lock<folly::SharedMutex> lock(this->mutex_);
-        auto index_valid_data_length =
-            this->null_offset_.size() * sizeof(size_t);
+        auto null_offsets = RoaringToLegacyOffsets(this->null_offsets_);
+        auto index_valid_data_length = null_offsets.size() * sizeof(size_t);
         std::shared_ptr<uint8_t[]> index_valid_data(
             new uint8_t[index_valid_data_length]);
         memcpy(index_valid_data.get(),
-               this->null_offset_.data(),
+               null_offsets.data(),
                index_valid_data_length);
 
-        auto non_exist_data_length =
-            this->non_exist_offsets_.size() * sizeof(size_t);
+        auto non_exist_offsets = RoaringToLegacyOffsets(this->non_exist_offsets_);
+        auto non_exist_data_length = non_exist_offsets.size() * sizeof(size_t);
         std::shared_ptr<uint8_t[]> non_exist_data(
             new uint8_t[non_exist_data_length]);
         memcpy(non_exist_data.get(),
-               this->non_exist_offsets_.data(),
+               non_exist_offsets.data(),
                non_exist_data_length);
         lock.unlock();
         BinarySet res_set;
@@ -209,9 +209,9 @@ class JsonInvertedIndex : public index::InvertedIndexTantivy<T> {
     // This includes rows that are null, does not have this JSON path, or have
     // null values for this JSON path.
     //
-    // For example, if the JSON path is "/a", this vector will store rows like
+    // For example, if the JSON path is "/a", this bitmap will store rows like
     // null, {}, {"a": null}, etc.
-    std::vector<size_t> non_exist_offsets_;
+    roaring::Roaring non_exist_offsets_;
 };
 
 }  // namespace milvus::index

--- a/internal/core/src/index/JsonInvertedIndexTest.cpp
+++ b/internal/core/src/index/JsonInvertedIndexTest.cpp
@@ -91,6 +91,7 @@ struct ExprBatchSizeGuard {
 
 struct LoadedJsonOffsetStats {
     int64_t count;
+    int64_t exists_size;
     int64_t exists_count;
     int64_t null_count;
 };
@@ -175,6 +176,7 @@ BuildAndLoadJsonInvertedIndexForOffsetRegression(
 
     Config load_config;
     load_config[index::INDEX_FILES] = index_files;
+    load_config[INDEX_NUM_ROWS_KEY] = json_raw_data.size();
     load_config[milvus::LOAD_PRIORITY] =
         milvus::proto::common::LoadPriority::HIGH;
 
@@ -182,6 +184,7 @@ BuildAndLoadJsonInvertedIndexForOffsetRegression(
     auto exists = loaded_json_index->Exists();
     auto nulls = loaded_json_index->IsNull();
     return {loaded_json_index->Count(),
+            static_cast<int64_t>(exists.size()),
             static_cast<int64_t>(exists.count()),
             static_cast<int64_t>(nulls.count())};
 }
@@ -615,16 +618,16 @@ TEST(JsonIndexTest, TestLoadWithOnlySlicedNonExistOffsets) {
     FileSliceSizeGuard slice_size_guard(64);
 
     std::vector<std::string> json_raw_data;
-    for (int i = 0; i < 20; ++i) {
-        json_raw_data.emplace_back(R"({"b": 1})");
-    }
     for (int i = 0; i < 10; ++i) {
         json_raw_data.emplace_back(R"({"a": 1.0})");
+    }
+    for (int i = 0; i < 20; ++i) {
+        json_raw_data.emplace_back(R"({"b": 1})");
     }
 
     auto stats =
         BuildAndLoadJsonInvertedIndexForOffsetRegression(json_raw_data);
-    EXPECT_EQ(stats.count, json_raw_data.size());
+    EXPECT_EQ(stats.exists_size, json_raw_data.size());
     EXPECT_EQ(stats.exists_count, 10);
 }
 
@@ -646,5 +649,6 @@ TEST(JsonIndexTest, TestLoadWithOnlySlicedNullOffsets) {
     auto stats = BuildAndLoadJsonInvertedIndexForOffsetRegression(json_raw_data,
                                                                   &valid_data);
     EXPECT_EQ(stats.count, json_raw_data.size());
+    EXPECT_EQ(stats.exists_size, json_raw_data.size());
     EXPECT_EQ(stats.null_count, 20);
 }

--- a/internal/core/src/index/NgramInvertedIndex.cpp
+++ b/internal/core/src/index/NgramInvertedIndex.cpp
@@ -160,7 +160,7 @@ NgramInvertedIndex::BuildWithJsonFieldData(
             }
         },
         // handle null
-        [this](int64_t offset) { this->null_offset_.push_back(offset); },
+        [this](int64_t offset) { this->AddNullOffset(offset); },
         // handle non exist
         [](int64_t offset) {},
         // handle error
@@ -170,6 +170,7 @@ NgramInvertedIndex::BuildWithJsonFieldData(
             this->error_recorder_.Record(json, nested_path, error);
         });
     avg_row_size_ = total_rows > 0 ? total_bytes / total_rows : 0;
+    OptimizeNullOffsets();
     LOG_INFO("Ngram index (JSON) avg_row_size: {} bytes", avg_row_size_);
     error_recorder_.PrintErrStats();
 }

--- a/internal/core/src/index/NgramInvertedIndex.h
+++ b/internal/core/src/index/NgramInvertedIndex.h
@@ -66,7 +66,7 @@ class NgramInvertedIndex : public InvertedIndexTantivy<std::string> {
 
     void
     finish() {
-        this->wrapper_->finish();
+        InvertedIndexTantivy<std::string>::finish();
     }
 
     void

--- a/internal/core/src/index/TextMatchIndex.cpp
+++ b/internal/core/src/index/TextMatchIndex.cpp
@@ -177,10 +177,9 @@ TextMatchIndex::Load(const Config& config) {
         // clear index_datas to free memory early
         index_datas.clear();
         auto index_valid_data = binary_set.GetByName("index_null_offset");
-        null_offset_.resize((size_t)index_valid_data->size / sizeof(size_t));
-        memcpy(null_offset_.data(),
-               index_valid_data->data.get(),
-               (size_t)index_valid_data->size);
+        LoadLegacyOffsets(null_offsets_,
+                          index_valid_data->data.get(),
+                          index_valid_data->size);
     }
     disk_file_manager_->CacheTextLogToDisk(files_value, load_priority);
     AssertInfo(
@@ -213,7 +212,7 @@ TextMatchIndex::AddTextSealed(const std::string& text,
 // Add null for sealed segment
 void
 TextMatchIndex::AddNullSealed(int64_t offset) {
-    null_offset_.push_back(offset);
+    AddNullOffset(offset);
     // still need to add null to make offset is correct
     static const std::string empty;
     wrapper_->add_array_data(&empty, 0, offset);
@@ -230,7 +229,7 @@ TextMatchIndex::AddTextsGrowing(size_t n,
             auto offset = i + offset_begin;
             if (!valids[i]) {
                 std::unique_lock<folly::SharedMutex> lock(mutex_);
-                null_offset_.push_back(offset);
+                AddNullOffset(offset);
             }
         }
     }
@@ -246,20 +245,12 @@ TextMatchIndex::BuildIndexFromFieldData(
     const std::vector<FieldDataPtr>& field_datas, bool nullable) {
     int64_t offset = 0;
     if (nullable) {
-        int64_t total = 0;
-        for (const auto& data : field_datas) {
-            total += data->get_null_count();
-        }
-        {
-            std::unique_lock<folly::SharedMutex> lock(mutex_);
-            null_offset_.reserve(total);
-        }
         for (const auto& data : field_datas) {
             auto n = data->get_num_rows();
             for (int i = 0; i < n; i++) {
                 if (!data->is_valid(i)) {
                     std::unique_lock<folly::SharedMutex> lock(mutex_);
-                    null_offset_.push_back(offset);
+                    AddNullOffset(offset);
                     // add empty array doc to register offset in tantivy,
                     // same as AddNullSealed
                     static const std::string empty;
@@ -280,6 +271,10 @@ TextMatchIndex::BuildIndexFromFieldData(
                 static_cast<const std::string*>(data->Data()), n, offset);
             offset += n;
         }
+    }
+    {
+        std::unique_lock<folly::SharedMutex> lock(mutex_);
+        OptimizeNullOffsets();
     }
 }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -266,7 +266,8 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(const LoadIndexInfo& info) {
             info.index_size,
             info.index_params,
             info.enable_mmap,
-            info.num_rows);
+            info.num_rows,
+            field_meta.is_nullable());
 
     set_bit(index_ready_bitset_, field_id, true);
     index_has_raw_data_[field_id] = request.has_raw_data;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -265,7 +265,8 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(const LoadIndexInfo& info) {
             info.index_engine_version,
             info.index_size,
             info.index_params,
-            info.enable_mmap);
+            info.enable_mmap,
+            info.num_rows);
 
     set_bit(index_ready_bitset_, field_id, true);
     index_has_raw_data_[field_id] = request.has_raw_data;

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -765,7 +765,8 @@ class SegmentLoadInfo {
                     load_index_info.index_params,
                     load_index_info.enable_mmap,
                     load_index_info.num_rows,
-                    load_index_info.dim);
+                    load_index_info.dim,
+                    load_index_info.schema.nullable());
             if (request.has_raw_data) {
                 field_index_has_raw_data_.insert(field_id);
             }

--- a/internal/core/src/segcore/load_index_c.cpp
+++ b/internal/core/src/segcore/load_index_c.cpp
@@ -173,7 +173,8 @@ EstimateLoadIndexResource(CLoadIndexInfo c_load_index_info) {
                 index_params,
                 load_index_info->enable_mmap,
                 load_index_info->num_rows,
-                load_index_info->dim);
+                load_index_info->dim,
+                load_index_info->schema.nullable());
         return request;
     } catch (std::exception& e) {
         ThrowInfo(milvus::UnexpectedError,

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <utility>
 
+#include "common/Consts.h"
 #include "common/EasyAssert.h"
 #include "common/common_type_c.h"
 #include "common/resource_c.h"
@@ -96,7 +97,8 @@ SealedIndexTranslator::estimated_byte_size_of_cell(
             index_load_info_.index_params,
             index_load_info_.enable_mmap,
             index_load_info_.num_rows,
-            index_load_info_.dim);
+            index_load_info_.dim,
+            file_manager_context_.fieldDataMeta.field_schema.nullable());
     // this is an estimation, error could be up to 20%.
     return {milvus::cachinglayer::ResourceUsage(request.final_memory_cost,
                                                 request.final_disk_cost),
@@ -127,7 +129,8 @@ SealedIndexTranslator::get_cells(milvus::OpContext* ctx,
             index_load_info_.index_params,
             index_load_info_.enable_mmap,
             index_load_info_.num_rows,
-            index_load_info_.dim);
+            index_load_info_.dim,
+            file_manager_context_.fieldDataMeta.field_schema.nullable());
     index->SetCellSize(milvus::cachinglayer::ResourceUsage(
         request.final_memory_cost, request.final_disk_cost));
     if (index_load_info_.enable_mmap && index->IsMmapSupported()) {
@@ -149,6 +152,11 @@ SealedIndexTranslator::get_cells(milvus::OpContext* ctx,
     } else {
         config_[milvus::index::ENABLE_MMAP] = "false";
     }
+
+    // Plumb the segment row count into the load config so JSON typed-path
+    // indexes size their exists bitmap from the true row domain (tantivy
+    // Count() only covers non-null rows).
+    config_[INDEX_NUM_ROWS_KEY] = index_load_info_.num_rows;
 
     // Check for cancellation before loading index data
     CheckCancellation(ctx, segment_id, "LoadIndex");


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/52565
pr: https://github.com/milvus-io/milvus/pull/52529

Store Tantivy null rows and typed JSON path non-exist rows as CRoaring after build and load.
Retain one resident N/8 EXISTS bitmap so the default non-cached query path only clones it.
Preserve legacy size_t[] entries and scalar index versions while accounting for resident row masks in memory estimates.