### PR TITLE
test: add e2e for query order by with vector output

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_query_order.py
+++ b/tests/python_client/milvus_client/test_milvus_client_query_order.py
@@ -1548,3 +1548,65 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
             assert ids[i] < ids[i + 1], (
                 f"id not ascending among returned equal-key rows at index {i}: {ids[i]} >= {ids[i + 1]}"
             )
+
+    # ==================== 5.14 L2: Vector Output with ORDER BY ====================
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_query_order_by_vector_output(self):
+        """OB-063: ORDER BY a scalar field with a vector field in output_fields.
+
+        Regression for #52463: dense vector output combined with scalar ORDER BY
+        used to fail with "unsupported data type VECTOR_FLOAT" because the vector
+        was materialized in the pre-TopK ProjectNode (single-project mode). The
+        fix defers vector outputs to late materialization. Covers both explicit
+        and wildcard output_fields.
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        dim = 4
+        nb = 10
+        try:
+            schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+            schema.add_field("id", DataType.INT64, is_primary=True)
+            schema.add_field("rank", DataType.INT64)
+            schema.add_field("vec", DataType.FLOAT_VECTOR, dim=dim)
+
+            index_params = client.prepare_index_params()
+            index_params.add_index(field_name="vec", index_type="HNSW", metric_type="L2", M=16, efConstruction=200)
+
+            client.create_collection(
+                collection_name=collection_name, schema=schema, index_params=index_params, consistency_level="Strong"
+            )
+
+            # Deterministic vectors encode the id (vec[0] == id) so we can verify
+            # each returned vector belongs to the correct row after sorting.
+            # rank = (i * 7) % nb permutes rows (7 coprime with 10), so the
+            # deferred vector reorder path is exercised rather than an identity map.
+            data = [{"id": i, "rank": (i * 7) % nb, "vec": [float(i), float(i), 0.0, 0.0]} for i in range(nb)]
+            client.insert(collection_name=collection_name, data=data)
+            client.flush(collection_name=collection_name)
+
+            # Both explicit vector output and wildcard output exercise the same
+            # single-project path because this schema has no variable-width field.
+            for output_fields in (["id", "rank", "vec"], ["*"]):
+                res = self.query(
+                    client,
+                    collection_name,
+                    filter="",
+                    output_fields=output_fields,
+                    limit=nb,
+                    order_by_fields=[{"field": "rank", "order": "asc"}],
+                    consistency_level="Strong",
+                )[0]
+
+                assert len(res) == nb, f"expected {nb} rows, got {len(res)}"
+                ranks = [r["rank"] for r in res]
+                for i in range(len(ranks) - 1):
+                    assert ranks[i] <= ranks[i + 1], f"rank not ascending at index {i}"
+                for r in res:
+                    vec = r["vec"]
+                    assert isinstance(vec, list) and len(vec) == dim, f"vec not a {dim}-dim list: {vec!r}"
+                    assert vec[0] == float(r["id"]), f"vec mismatched for id {r['id']}: vec[0]={vec[0]}"
+        finally:
+            if client.has_collection(collection_name):
+                client.drop_collection(collection_name)


### PR DESCRIPTION
## Summary

Add E2E regression test OB-063 for #52463: scalar Query ORDER BY combined with a dense vector in `output_fields` used to fail with `unsupported data type VECTOR_FLOAT` (segcoreCode=2001) because the vector was materialized in the pre-TopK ProjectNode (single-project mode). Fixed by #52498, which defers vector outputs to late materialization after TopK.

issue: #52463

### Test design

- All-fixed-width schema (`id` / `rank` / `vec`, no variable-width field), so the pre-fix planner takes the single-project path that triggers the bug
- Sort key `rank = (i*7)%10` is a coprime permutation of 0..9: unique keys, deterministic total order, and a real row permutation, so the deferred post-TopK vector fetch must actually reorder rows (an `id:asc` sort would be an identity permutation and could mask a reordering bug)
- Covers both explicit (`["id","rank","vec"]`) and wildcard (`["*"]`) output_fields
- Asserts ascending rank order and verifies each returned vector's payload against its row id (`vec[0] == id`)

### Test plan

- [x] Fails on pre-fix build `3.0-20260814-566ace73` with the exact issue error: `unsupported data type VECTOR_FLOAT at Utils.cpp:1712`, code=2000
- [x] Passes on post-fix build `master-20260817-c2a92a8a` (contains #52498), cluster mode, both via LB endpoint and port-forward