### PR TITLE
enhance: [cp 2.6] cache scalar-index IsNotNull() across batches on the ByOffsets paths

### DIFF
--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -383,6 +383,20 @@ class SegmentExpr : public Expr {
         ApplyValidMask(validity, res, valid_res, size);
     }
 
+    // The IsNotNull() virtual rebuilds a segment-sized bitmap on every
+    // call (allocation + fill + AND); per-batch callers must reuse one
+    // copy. The all-valid flag short-circuits per-row bitmap reads.
+    template <typename Index>
+    const TargetBitmap&
+    GetCachedIndexValidBitmap(Index* index_ptr) {
+        if (!cached_index_valid_res_) {
+            cached_index_valid_res_ =
+                std::make_shared<TargetBitmap>(index_ptr->IsNotNull());
+            cached_index_all_valid_ = cached_index_valid_res_->all();
+        }
+        return *cached_index_valid_res_;
+    }
+
     int64_t
     GetNextBatchSize() {
         if (use_json_stats_) {
@@ -522,9 +536,13 @@ class SegmentExpr : public Expr {
         auto scalar_index = dynamic_cast<const Index*>(pinned_index_[0].get());
         auto* index_ptr = const_cast<Index*>(scalar_index);
 
-        auto valid_result = index_ptr->IsNotNull();
-        for (auto i = 0; i < input->size(); ++i) {
-            valid_res[i] = valid_result[(*input)[i]];
+        const auto& valid_result = GetCachedIndexValidBitmap(index_ptr);
+        if (cached_index_all_valid_) {
+            valid_res.set();
+        } else {
+            for (auto i = 0; i < input->size(); ++i) {
+                valid_res[i] = valid_result[(*input)[i]];
+            }
         }
         auto result = std::move(func.template operator()<FilterType::random>(
             index_ptr, values..., input->data()));
@@ -550,7 +568,8 @@ class SegmentExpr : public Expr {
         using Index = index::ScalarIndex<IndexInnerType>;
         auto scalar_index = dynamic_cast<const Index*>(pinned_index_[0].get());
         auto* index_ptr = const_cast<Index*>(scalar_index);
-        auto valid_result = index_ptr->IsNotNull();
+        const auto& valid_result = GetCachedIndexValidBitmap(index_ptr);
+        const bool all_valid = cached_index_all_valid_;
         auto batch_size = input->size();
 
         if (!skip_func || !skip_func(skip_index, field_id_, 0)) {
@@ -562,7 +581,7 @@ class SegmentExpr : public Expr {
                     continue;
                 }
                 T raw_data = raw.value();
-                bool valid_data = valid_result[offset];
+                bool valid_data = all_valid || valid_result[offset];
                 func.template operator()<FilterType::random>(
                     &raw_data,
                     ValidityView::FromExpanded(&valid_data),
@@ -572,10 +591,17 @@ class SegmentExpr : public Expr {
                     valid_res + i,
                     values...);
             }
+        } else if (all_valid) {
+            res.set(0, batch_size);
+            valid_res.set(0, batch_size);
         } else {
             for (auto i = 0; i < batch_size; ++i) {
                 auto offset = (*input)[i];
-                res[i] = valid_res[i] = valid_result[offset];
+                // materialize the bool once: chaining proxies would read
+                // back the word just stored into valid_res
+                const bool valid = valid_result[offset];
+                valid_res[i] = valid;
+                res[i] = valid;
             }
         }
 
@@ -1309,10 +1335,12 @@ class SegmentExpr : public Expr {
             auto scalar_index =
                 dynamic_cast<const Index*>(pinned_index_[0].get());
             auto* index_ptr = const_cast<Index*>(scalar_index);
-            const auto& res = index_ptr->IsNotNull();
-            for (auto i = 0; i < batch_size; ++i) {
-                valid_result[i] = res[input[i]];
-            }
+            const auto& res = GetCachedIndexValidBitmap(index_ptr);
+            if (!cached_index_all_valid_) {
+                for (auto i = 0; i < batch_size; ++i) {
+                    valid_result[i] = res[input[i]];
+                }
+            }  // else: valid_result is already all-set
         } else {
             for (auto i = 0; i < batch_size; ++i) {
                 auto offset = input[i];
@@ -1708,6 +1736,11 @@ class SegmentExpr : public Expr {
     int64_t current_index_chunk_{0};
     int64_t current_index_chunk_pos_{0};
     int64_t size_per_chunk_{0};
+
+    // Cached scalar-index IsNotNull() bitmap for the ByOffsets paths
+    // (single-index-chunk only); see GetCachedIndexValidBitmap().
+    std::shared_ptr<TargetBitmap> cached_index_valid_res_{nullptr};
+    bool cached_index_all_valid_{false};
 
     // Cache for index scan to avoid search index every batch
     int64_t cached_index_chunk_id_{-1};


### PR DESCRIPTION
Port of master PR #50447 to the 2.6 branch.

pr: #50447
issue: #50444

## Why this is a port, not a cherry-pick

`git cherry-pick e2887dfe99` conflicts on 2.6. The conflicts are at the **anchor** level, not the content level: the upstream hunks are positioned against the `ExprExecPath` / `SliceCachedResult` / `cached_result_` refactor, none of which exists on 2.6 (`apply_field_valid_data`, `SliceCachedResult`, `cached_result_`, `cached_valid_result_`, `EnsureExecPathDetermined`, `ExprExecPath` — all 0 occurrences on 2.6, all present on master).

The code the PR *adds* is self-contained and does not depend on that refactor, so it is reproduced here line-for-line.

## What it does

`ScalarIndex::IsNotNull()` rebuilds a segment-sized bitmap on every call (allocation + fill). The three ByOffsets paths — `ProcessIndexChunksByOffsets`, `ProcessIndexLookupByOffsets`, `ProcessChunksForValidByOffsets` — called it once per 8192-row batch, while the ChunksAll paths already cached it. All three assert `num_index_chunk_ == 1`, so the cached answer cannot change within a query.

Adds `GetCachedIndexValidBitmap()` (expression-instance cache + precomputed all-valid flag), plus the two accompanying optimizations from the upstream PR: all-valid fast paths, and materializing the bool once instead of chaining proxy assignments.

## Equivalence with #50447

| Check | Result |
| --- | --- |
| Added / removed lines vs #50447 | Identical line-for-line after stripping indentation |
| Indentation delta | Only at `ProcessChunksForValidByOffsets`, which sits one nesting level shallower on 2.6 |
| Diff stat | `1 file changed, 43 insertions(+), 10 deletions(-)` — same as #50447 |
| `clang-format` (repo `.clang-format`) | No changes |
| Bitset API used (`all()`, `set()`, `set(start, size)`) | Present on 2.6 `BitsetBase` with identical signatures |

## Verification status

- [x] Diff verified line-for-line against #50447
- [x] `clang-format` clean
- [x] API availability on 2.6 verified by reading `bitset.h`
- [ ] **Not compiled locally** — this machine only has a master build tree, and 2.6 pulls `bsoncxx` via `common/bson_view.h`, which is not provisioned here. Relying on CI for the C++ build.
- [ ] **Unit tests not re-run locally.** Upstream #50447 reported `Expr.*:ExprTest.*:*Null*:OffsetMapping.*` passing (2047 tests); not repeated here.
- [ ] `make static-check` not run locally.

## Context

Found while investigating a production instance on v2.6.18 where `InvertedIndexTantivy::IsNotNull()` accounted for **45.9% of querynode CPU** (plus ~15% in the accompanying `memset`), against **1.3%** for the actual vector search, on a collection with 19 nullable fields and 16 scalar indexes.

Note that this PR addresses only the per-batch recomputation. On 2.6 the `is_nested_index_` early-return is also absent, so ARRAY-typed JSON-path indexes still run the full per-bit loop; that is a separate change.
