### PR TITLE
enhance: [hotfix-2.6.22] cache scalar-index IsNotNull() across batches on the ByOffsets paths

### DIFF
--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -329,6 +329,20 @@ class SegmentExpr : public Expr {
         }
     }
 
+    // The IsNotNull() virtual rebuilds a segment-sized bitmap on every
+    // call (allocation + fill + AND); per-batch callers must reuse one
+    // copy. The all-valid flag short-circuits per-row bitmap reads.
+    template <typename Index>
+    const TargetBitmap&
+    GetCachedIndexValidBitmap(Index* index_ptr) {
+        if (!cached_index_valid_res_) {
+            cached_index_valid_res_ =
+                std::make_shared<TargetBitmap>(index_ptr->IsNotNull());
+            cached_index_all_valid_ = cached_index_valid_res_->all();
+        }
+        return *cached_index_valid_res_;
+    }
+
     int64_t
     GetNextBatchSize() {
         if (use_json_stats_) {
@@ -465,9 +479,13 @@ class SegmentExpr : public Expr {
         auto scalar_index = dynamic_cast<const Index*>(pinned_index_[0].get());
         auto* index_ptr = const_cast<Index*>(scalar_index);
 
-        auto valid_result = index_ptr->IsNotNull();
-        for (auto i = 0; i < input->size(); ++i) {
-            valid_res[i] = valid_result[(*input)[i]];
+        const auto& valid_result = GetCachedIndexValidBitmap(index_ptr);
+        if (cached_index_all_valid_) {
+            valid_res.set();
+        } else {
+            for (auto i = 0; i < input->size(); ++i) {
+                valid_res[i] = valid_result[(*input)[i]];
+            }
         }
         auto result = std::move(func.template operator()<FilterType::random>(
             index_ptr, values..., input->data()));
@@ -493,7 +511,8 @@ class SegmentExpr : public Expr {
         using Index = index::ScalarIndex<IndexInnerType>;
         auto scalar_index = dynamic_cast<const Index*>(pinned_index_[0].get());
         auto* index_ptr = const_cast<Index*>(scalar_index);
-        auto valid_result = index_ptr->IsNotNull();
+        const auto& valid_result = GetCachedIndexValidBitmap(index_ptr);
+        const bool all_valid = cached_index_all_valid_;
         auto batch_size = input->size();
 
         if (!skip_func || !skip_func(skip_index, field_id_, 0)) {
@@ -505,7 +524,7 @@ class SegmentExpr : public Expr {
                     continue;
                 }
                 T raw_data = raw.value();
-                bool valid_data = valid_result[offset];
+                bool valid_data = all_valid || valid_result[offset];
                 func.template operator()<FilterType::random>(&raw_data,
                                                              &valid_data,
                                                              nullptr,
@@ -514,10 +533,17 @@ class SegmentExpr : public Expr {
                                                              valid_res + i,
                                                              values...);
             }
+        } else if (all_valid) {
+            res.set(0, batch_size);
+            valid_res.set(0, batch_size);
         } else {
             for (auto i = 0; i < batch_size; ++i) {
                 auto offset = (*input)[i];
-                res[i] = valid_res[i] = valid_result[offset];
+                // materialize the bool once: chaining proxies would read
+                // back the word just stored into valid_res
+                const bool valid = valid_result[offset];
+                valid_res[i] = valid;
+                res[i] = valid;
             }
         }
 
@@ -1265,10 +1291,12 @@ class SegmentExpr : public Expr {
             auto scalar_index =
                 dynamic_cast<const Index*>(pinned_index_[0].get());
             auto* index_ptr = const_cast<Index*>(scalar_index);
-            const auto& res = index_ptr->IsNotNull();
-            for (auto i = 0; i < batch_size; ++i) {
-                valid_result[i] = res[input[i]];
-            }
+            const auto& res = GetCachedIndexValidBitmap(index_ptr);
+            if (!cached_index_all_valid_) {
+                for (auto i = 0; i < batch_size; ++i) {
+                    valid_result[i] = res[input[i]];
+                }
+            }  // else: valid_result is already all-set
         } else {
             for (auto i = 0; i < batch_size; ++i) {
                 auto offset = input[i];
@@ -1664,6 +1692,11 @@ class SegmentExpr : public Expr {
     int64_t current_index_chunk_{0};
     int64_t current_index_chunk_pos_{0};
     int64_t size_per_chunk_{0};
+
+    // Cached scalar-index IsNotNull() bitmap for the ByOffsets paths
+    // (single-index-chunk only); see GetCachedIndexValidBitmap().
+    std::shared_ptr<TargetBitmap> cached_index_valid_res_{nullptr};
+    bool cached_index_all_valid_{false};
 
     // Cache for index scan to avoid search index every batch
     int64_t cached_index_chunk_id_{-1};


### PR DESCRIPTION
Cherry-pick of #52576 (the 2.6 port) onto `hotfix-2.6.22`.

pr: #50447
issue: #50444

> **Note:** #52576 is still open. This is a preemptive backport and should be updated if #52576 changes before merge.

## Provenance

master #50447 → hand-ported to 2.6 in #52576 → cherry-picked here.

The upstream master commit does not cherry-pick onto 2.6.x: its hunks are anchored on the `ExprExecPath` / `SliceCachedResult` refactor that 2.6.x does not have. #52576 reproduces the added code line-for-line on the 2.6 structure; this branch takes that commit unchanged.

## What it does

`ScalarIndex::IsNotNull()` rebuilds a segment-sized bitmap on every call (allocation + fill). The three ByOffsets paths — `ProcessIndexChunksByOffsets`, `ProcessIndexLookupByOffsets`, `ProcessChunksForValidByOffsets` — called it once per 8192-row batch, while the ChunksAll paths already cached it. All three assert `num_index_chunk_ == 1`, so the cached answer cannot change within a query.

Adds `GetCachedIndexValidBitmap()` (expression-instance cache + precomputed all-valid flag), plus the two accompanying optimizations from the upstream PR: all-valid fast paths, and materializing the bool once instead of chaining proxy assignments.

## Verification

| Check | Result |
| --- | --- |
| Cherry-pick | Clean, no conflicts |
| Diff vs the 2.6 commit in #52576 | Identical line-for-line |
| Diff stat | `1 file changed, 43 insertions(+), 10 deletions(-)` — same as #50447 and #52576 |
| `Expr.h` / `bitset.h` on `hotfix-2.6.22` vs 2.6 base | Byte-identical, so the port applies unchanged |
| Conflict markers | None |
| `clang-format` (repo `.clang-format`) | No changes |

- [ ] **Not compiled locally** — this machine only has a master build tree, and 2.6.x pulls `bsoncxx` via `common/bson_view.h`, which is not provisioned here. Relying on CI for the C++ build.
- [ ] **Unit tests not re-run locally.** Upstream #50447 reported `Expr.*:ExprTest.*:*Null*:OffsetMapping.*` passing (2047 tests); not repeated here.
- [ ] `make static-check` not run locally.

## Context

Found while investigating a production instance on v2.6.18 where `InvertedIndexTantivy::IsNotNull()` accounted for **45.9% of querynode CPU** (plus ~15% in the accompanying `memset`), against **1.3%** for the actual vector search, on a collection with 19 nullable fields and 16 scalar indexes.

This addresses only the per-batch recomputation. 2.6.x also lacks the `is_nested_index_` early-return, so ARRAY-typed JSON-path indexes still run the full per-bit loop; that is a separate change.
