### PR TITLE
test: [cp 3.0] support URI and token in Go SDK tests

### DIFF
--- a/tests/go_client/README.md
+++ b/tests/go_client/README.md
@@ -185,6 +185,9 @@ Recommend you to use gotestsum https://github.com/gotestyourself/gotestsum
 # Run all default cases
 gotestsum --format testname --hide-summary=output -v ./testcases/... --addr=127.0.0.1:19530 -timeout=30m
 
+# Run against an endpoint that uses token authentication
+gotestsum --format testname --hide-summary=output -v ./testcases/... --uri=https://example.api.milvus.io --token="${MILVUS_TOKEN}" -timeout=30m
+
 # Run a specified file
 gotestsum --format testname --hide-summary=output ./testcases/collection_test.go ./testcases/main_test.go --addr=127.0.0.1:19530
 

--- a/tests/go_client/testcases/database_test.go
+++ b/tests/go_client/testcases/database_test.go
@@ -226,16 +226,18 @@ func TestClientWithDb(t *testing.T) {
 
 	listCollOpt := client.NewListCollectionOption()
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	newClientConfig := func(dbName string) *client.ClientConfig {
+		cfg := hp.GetDefaultClientConfig()
+		cfg.DBName = dbName
+		return cfg
+	}
 
 	// connect with not existed db
-	_, err := base.NewMilvusClient(ctx, &client.ClientConfig{Address: hp.GetAddr(), DBName: "dbName"})
+	_, err := base.NewMilvusClient(ctx, newClientConfig("dbName"))
 	common.CheckErr(t, err, false, "database not found")
 
 	// connect default db -> create a collection in default db
-	mcDefault, errDefault := base.NewMilvusClient(ctx, &client.ClientConfig{
-		Address: hp.GetAddr(),
-		// DBName:  common.DefaultDb,
-	})
+	mcDefault, errDefault := base.NewMilvusClient(ctx, newClientConfig(""))
 	common.CheckErr(t, errDefault, true)
 	_, defCol1 := hp.CollPrepare.CreateCollection(ctx, t, mcDefault, hp.NewCreateCollectionParams(hp.Int64Vec), hp.TNewFieldsOption(), hp.TNewSchemaOption())
 	defCollections, _ := mcDefault.ListCollections(ctx, listCollOpt)
@@ -248,10 +250,7 @@ func TestClientWithDb(t *testing.T) {
 	common.CheckErr(t, err, true)
 
 	// and connect with db
-	mcDb, err := base.NewMilvusClient(ctx, &client.ClientConfig{
-		Address: hp.GetAddr(),
-		DBName:  dbName,
-	})
+	mcDb, err := base.NewMilvusClient(ctx, newClientConfig(dbName))
 	common.CheckErr(t, err, true)
 	_, dbCol1 := hp.CollPrepare.CreateCollection(ctx, t, mcDb, hp.NewCreateCollectionParams(hp.Int64Vec), hp.TNewFieldsOption(), hp.TNewSchemaOption())
 
@@ -265,10 +264,7 @@ func TestClientWithDb(t *testing.T) {
 	require.NotContains(t, defCollections, dbCol1.CollectionName)
 
 	// connect empty db (actually default db)
-	mcEmpty, err := base.NewMilvusClient(ctx, &client.ClientConfig{
-		Address: hp.GetAddr(),
-		DBName:  "",
-	})
+	mcEmpty, err := base.NewMilvusClient(ctx, newClientConfig(""))
 	common.CheckErr(t, err, true)
 	defCollections, _ = mcEmpty.ListCollections(ctx, listCollOpt)
 	require.Contains(t, defCollections, defCol1.CollectionName)

--- a/tests/go_client/testcases/helper/helper.go
+++ b/tests/go_client/testcases/helper/helper.go
@@ -168,7 +168,7 @@ func CreateMilvusClient(ctx context.Context, t *testing.T, cfg *client.ClientCon
 		mc  *base.MilvusClient
 		err error
 	)
-	mc, err = base.NewMilvusClient(ctx, cfg)
+	mc, err = base.NewMilvusClient(ctx, inheritDefaultConnectionConfig(cfg))
 	common.CheckErr(t, err, true)
 
 	t.Cleanup(func() {

--- a/tests/go_client/testcases/helper/test_setup.go
+++ b/tests/go_client/testcases/helper/test_setup.go
@@ -24,8 +24,10 @@ import (
 
 var (
 	addr                = flag.String("addr", "http://localhost:19530", "server host and port")
+	uri                 = flag.String("uri", "", "Milvus server URI; overrides addr when set")
 	user                = flag.String("user", "root", "user")
 	password            = flag.String("password", "Milvus", "password")
+	token               = flag.String("token", "", "API key or username:password token")
 	logLevel            = flag.String("log.level", "info", "log level for test")
 	teiEndpoint         = flag.String("tei_endpoint", "http://text-embeddings-service.milvus-ci.svc.cluster.local:80", "TEI service endpoint for text embedding tests")
 	teiRerankerEndpoint = flag.String("tei_reranker_uri", "http://text-rerank-service.milvus-ci.svc.cluster.local:80", "TEI reranker service endpoint")
@@ -38,15 +40,18 @@ func setDefaultClientConfig(cfg *client.ClientConfig) {
 }
 
 func GetDefaultClientConfig() *client.ClientConfig {
-	newCfg := *defaultClientConfig
-	dialOptions := newCfg.DialOptions
-	newDialOptions := make([]grpc.DialOption, len(dialOptions))
-	copy(newDialOptions, dialOptions)
-	newCfg.DialOptions = newDialOptions
+	newCfg := cloneClientConfig(defaultClientConfig)
 	return &newCfg
 }
 
 func GetAddr() string {
+	return GetURI()
+}
+
+func GetURI() string {
+	if strings.TrimSpace(*uri) != "" {
+		return *uri
+	}
 	return *addr
 }
 
@@ -56,6 +61,71 @@ func GetUser() string {
 
 func GetPassword() string {
 	return *password
+}
+
+func GetToken() string {
+	return *token
+}
+
+// URIFromTestArgs returns the URI flag when present and otherwise falls back to addr.
+// It is used before flag.Parse by TestMain dependency setup.
+func URIFromTestArgs(args []string) string {
+	var addrValue, uriValue string
+	for i, arg := range args {
+		name, value, hasValue := strings.Cut(strings.TrimLeft(arg, "-"), "=")
+		if name != "addr" && name != "uri" {
+			continue
+		}
+		if !hasValue && i+1 < len(args) {
+			value = args[i+1]
+		}
+		if name == "uri" {
+			uriValue = value
+		} else {
+			addrValue = value
+		}
+	}
+	if strings.TrimSpace(uriValue) != "" {
+		return uriValue
+	}
+	return addrValue
+}
+
+func cloneClientConfig(cfg *client.ClientConfig) client.ClientConfig {
+	newCfg := *cfg
+	newCfg.DialOptions = append([]grpc.DialOption(nil), cfg.DialOptions...)
+	return newCfg
+}
+
+func newDefaultClientConfig() *client.ClientConfig {
+	return &client.ClientConfig{
+		Address:  GetURI(),
+		Username: GetUser(),
+		Password: GetPassword(),
+		APIKey:   GetToken(),
+	}
+}
+
+func inheritDefaultConnectionConfig(cfg *client.ClientConfig) *client.ClientConfig {
+	newCfg := cloneClientConfig(cfg)
+	defaultCfg := GetDefaultClientConfig()
+	if newCfg.Address == "" {
+		newCfg.Address = defaultCfg.Address
+	}
+	if newCfg.APIKey != "" {
+		return &newCfg
+	}
+
+	usesDefaultCredentials := newCfg.Username == defaultCfg.Username && newCfg.Password == defaultCfg.Password
+	if newCfg.Username == "" && newCfg.Password == "" {
+		newCfg.Username = defaultCfg.Username
+		newCfg.Password = defaultCfg.Password
+		usesDefaultCredentials = true
+	}
+	if usesDefaultCredentials {
+		newCfg.APIKey = defaultCfg.APIKey
+	}
+	return &newCfg
 }
 
 func GetTEIEndpoint() string {
@@ -90,10 +160,10 @@ func setup() {
 	mlog.Info(context.TODO(), "Start to setup all......")
 	flag.Parse()
 	parseLogConfig()
-	mlog.Info(context.TODO(), "Parser Milvus address", mlog.String("address", *addr))
+	mlog.Info(context.TODO(), "Parser Milvus address", mlog.String("address", GetURI()))
 
 	// set default milvus client config
-	setDefaultClientConfig(&client.ClientConfig{Address: *addr})
+	setDefaultClientConfig(newDefaultClientConfig())
 }
 
 // Teardown teardown
@@ -101,7 +171,7 @@ func teardown() {
 	mlog.Info(context.TODO(), "Start to tear down all.....")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*common.DefaultTimeout)
 	defer cancel()
-	mc, err := base.NewMilvusClient(ctx, &client.ClientConfig{Address: GetAddr(), Username: GetUser(), Password: GetPassword()})
+	mc, err := base.NewMilvusClient(ctx, GetDefaultClientConfig())
 	if err != nil {
 		mlog.Error(context.TODO(), "teardown failed to connect milvus with error", mlog.Err(err))
 		return
@@ -123,10 +193,10 @@ func teardown() {
 }
 
 // managementBaseURL returns the Milvus management API base URL (port 9091)
-// derived from the gRPC addr flag (e.g. http://host:19530 -> http://host:9091).
+// derived from the configured URI (e.g. http://host:19530 -> http://host:9091).
 func managementBaseURL() string {
 	host := ""
-	rawAddr := strings.TrimSpace(*addr)
+	rawAddr := strings.TrimSpace(GetURI())
 	if rawAddr != "" {
 		parseAddr := rawAddr
 		if !strings.Contains(rawAddr, "://") {

--- a/tests/go_client/testcases/helper/test_setup_test.go
+++ b/tests/go_client/testcases/helper/test_setup_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
+
+	client "github.com/milvus-io/milvus/client/v3/milvusclient"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -28,9 +30,33 @@ func withManagementRoundTripper(t *testing.T, fn roundTripFunc) {
 func withTestAddr(t *testing.T, value string) {
 	t.Helper()
 	prevAddr := *addr
+	prevURI := *uri
 	*addr = value
+	*uri = ""
 	t.Cleanup(func() {
 		*addr = prevAddr
+		*uri = prevURI
+	})
+}
+
+func withTestConnectionFlags(t *testing.T, addrValue, uriValue, userValue, passwordValue, tokenValue string) {
+	t.Helper()
+	prevAddr, prevURI := *addr, *uri
+	prevUser, prevPassword, prevToken := *user, *password, *token
+	*addr, *uri = addrValue, uriValue
+	*user, *password, *token = userValue, passwordValue, tokenValue
+	t.Cleanup(func() {
+		*addr, *uri = prevAddr, prevURI
+		*user, *password, *token = prevUser, prevPassword, prevToken
+	})
+}
+
+func withTestDefaultClientConfig(t *testing.T, cfg *client.ClientConfig) {
+	t.Helper()
+	prevCfg := defaultClientConfig
+	setDefaultClientConfig(cfg)
+	t.Cleanup(func() {
+		setDefaultClientConfig(prevCfg)
 	})
 }
 
@@ -40,6 +66,103 @@ func managementResponse(statusCode int, body string) *http.Response {
 		Header:     make(http.Header),
 		Body:       io.NopCloser(strings.NewReader(body)),
 	}
+}
+
+func TestURIFromTestArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "addr with equals", args: []string{"test", "-addr=http://localhost:19530"}, want: "http://localhost:19530"},
+		{name: "addr with separate value", args: []string{"test", "--addr", "http://localhost:19530"}, want: "http://localhost:19530"},
+		{name: "uri with equals", args: []string{"test", "--uri=https://cloud.example"}, want: "https://cloud.example"},
+		{name: "uri overrides addr", args: []string{"test", "--addr=http://localhost:19530", "--uri", "https://cloud.example"}, want: "https://cloud.example"},
+		{name: "uri before addr", args: []string{"test", "--uri=https://cloud.example", "--addr=http://localhost:19530"}, want: "https://cloud.example"},
+		{name: "empty uri uses addr", args: []string{"test", "--addr=http://localhost:19530", "--uri="}, want: "http://localhost:19530"},
+		{name: "missing", args: []string{"test", "-test.v"}, want: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, URIFromTestArgs(test.args))
+		})
+	}
+}
+
+func TestNewDefaultClientConfig(t *testing.T) {
+	t.Run("uses uri and token", func(t *testing.T) {
+		withTestConnectionFlags(t, "http://localhost:19530", "https://cloud.example", "root", "Milvus", "cloud-token")
+
+		cfg := newDefaultClientConfig()
+		require.Equal(t, "https://cloud.example", cfg.Address)
+		require.Equal(t, "root", cfg.Username)
+		require.Equal(t, "Milvus", cfg.Password)
+		require.Equal(t, "cloud-token", cfg.APIKey)
+	})
+
+	t.Run("falls back to legacy connection flags", func(t *testing.T) {
+		withTestConnectionFlags(t, "http://localhost:19530", "", "legacy-user", "legacy-password", "")
+
+		cfg := newDefaultClientConfig()
+		require.Equal(t, "http://localhost:19530", cfg.Address)
+		require.Equal(t, "legacy-user", cfg.Username)
+		require.Equal(t, "legacy-password", cfg.Password)
+		require.Empty(t, cfg.APIKey)
+	})
+}
+
+func TestInheritDefaultConnectionConfig(t *testing.T) {
+	withTestDefaultClientConfig(t, &client.ClientConfig{
+		Address:  "https://cloud.example",
+		Username: "root",
+		Password: "Milvus",
+		APIKey:   "cloud-token",
+	})
+
+	t.Run("fills empty connection settings", func(t *testing.T) {
+		input := &client.ClientConfig{DBName: "books"}
+		cfg := inheritDefaultConnectionConfig(input)
+
+		require.Equal(t, "https://cloud.example", cfg.Address)
+		require.Equal(t, "root", cfg.Username)
+		require.Equal(t, "Milvus", cfg.Password)
+		require.Equal(t, "cloud-token", cfg.APIKey)
+		require.Empty(t, input.Address)
+		require.Empty(t, input.APIKey)
+	})
+
+	t.Run("adds token for default credentials", func(t *testing.T) {
+		cfg := inheritDefaultConnectionConfig(&client.ClientConfig{
+			Address:  "https://cloud.example",
+			Username: "root",
+			Password: "Milvus",
+		})
+
+		require.Equal(t, "cloud-token", cfg.APIKey)
+	})
+
+	t.Run("preserves custom user credentials", func(t *testing.T) {
+		cfg := inheritDefaultConnectionConfig(&client.ClientConfig{
+			Address:  "https://cloud.example",
+			Username: "test-user",
+			Password: "test-password",
+		})
+
+		require.Empty(t, cfg.APIKey)
+		require.Equal(t, "test-user", cfg.Username)
+		require.Equal(t, "test-password", cfg.Password)
+	})
+
+	t.Run("preserves explicit token", func(t *testing.T) {
+		cfg := inheritDefaultConnectionConfig(&client.ClientConfig{
+			Address: "https://other.example",
+			APIKey:  "other-token",
+		})
+
+		require.Equal(t, "https://other.example", cfg.Address)
+		require.Equal(t, "other-token", cfg.APIKey)
+	})
 }
 
 func TestManagementBaseURL(t *testing.T) {

--- a/tests/go_client/testcases/main_test.go
+++ b/tests/go_client/testcases/main_test.go
@@ -50,25 +50,9 @@ func shouldInstallExternalTablePythonDeps() bool {
 		return true
 	}
 
-	host := hostFromMilvusAddr(addrFromTestArgs(os.Args))
+	host := hostFromMilvusAddr(helper.URIFromTestArgs(os.Args))
 	serviceName, _, _ := strings.Cut(host, ".")
 	return strings.HasPrefix(serviceName, "gosdk-") && strings.HasSuffix(serviceName, "-milvus")
-}
-
-func addrFromTestArgs(args []string) string {
-	for i, arg := range args {
-		switch {
-		case arg == "-addr" || arg == "--addr":
-			if i+1 < len(args) {
-				return args[i+1]
-			}
-		case strings.HasPrefix(arg, "-addr="):
-			return strings.TrimPrefix(arg, "-addr=")
-		case strings.HasPrefix(arg, "--addr="):
-			return strings.TrimPrefix(arg, "--addr=")
-		}
-	}
-	return ""
 }
 
 func isTruthyEnv(key string) bool {


### PR DESCRIPTION
## What changed

- Cherry-pick the Go SDK URI and token test support from #52539 to the 3.0 branch.
- Add `--uri` and `--token` options to the Go SDK test framework.
- Propagate the configured URI and credentials to default and helper-created clients.
- Preserve backward compatibility with `--addr`, `--user`, and `--password`.

## Why

The 3.0 Go SDK test suite needs the same URI and token connection support as master so it can run against authenticated endpoints using the current connection model.

## Validation

- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./testcases/helper`
- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 -exec=true ./testcases/...`
- `golangci-lint run ./...`
- Verified that the cherry-picked patch matches the master merge commit.

pr: #52539
