### PR TITLE
feat: add segment-scoped manifest commit

### DIFF
--- a/docs/design-docs/design_docs/20260817-datacoord-segment-manifest-commit.md
+++ b/docs/design-docs/design_docs/20260817-datacoord-segment-manifest-commit.md
@@ -1,0 +1,293 @@
+# DataCoord Segment-Scoped Manifest Commit Framework
+
+- **Created:** 2026-08-17
+- **Status:** Draft
+- **Component:** DataCoord / StorageV3
+- **Related work:** StorageV3 manifest index metadata migration
+
+## Summary
+
+StorageV3 uses an immutable, versioned manifest as the source of truth for a
+segment's files.  `SegmentInfo.manifest_path` is the durable pointer that makes
+one manifest revision visible to the rest of Milvus.
+
+This design introduces one DataCoord-owned commit framework for this pair of
+operations.  For a given segment, it serializes the full sequence:
+
+1. read the currently published `SegmentInfo` and manifest;
+2. construct and commit the next manifest revision;
+3. atomically persist the new `manifest_path` together with the associated
+   `SegmentInfo` and/or `SegmentIndex` change; and
+4. update the in-memory metadata only after the catalog write succeeds.
+
+The serialization key is `segmentID`.  Different segments remain concurrent.
+No caller outside the framework may create a manifest revision that is intended
+to update an existing segment, or directly replace that segment's manifest
+pointer in etcd.
+
+The framework must be completed on a clean branch based on `master`.  The
+ongoing manifest-index migration is intentionally **not** its implementation
+branch: after this framework is complete, that work will be rebased/adapted to
+use the framework rather than retain its local publication logic.
+
+## Problem
+
+Today the lifecycle is split across several owners:
+
+- an index worker can append its index entry to a manifest and later report the
+  resulting path to DataCoord;
+- DataCoord GC removes index entries from a manifest, then separately publishes
+  a new path and removes files/`SegmentIndex` metadata;
+- copy/restore appends copied index entries before a later `UpdateManifest`;
+- stats, flush/import, and compaction paths publish manifests through several
+  forms of `UpdateManifest`.
+
+`meta.segMu` protects the in-process execution of `UpdateSegmentsInfo`, but it
+does not cover the object-storage transaction that created the manifest
+revision.  Therefore it is not a segment commit lock.  Two paths can observe
+one pointer, create revisions independently, and later publish their results
+out of order.  A later etcd write can then point backward to an older revision
+or publish a revision that omits a completed change.
+
+The existing `indexMeta.keyLock(BuildID)` has a different responsibility: it
+serializes lifecycle changes for one `SegmentIndex` job.  It cannot serialize a
+manifest shared by all indexes and stats of a segment.  Conversely, a global
+`segMu` held across object storage would serialize unrelated segments and make
+network I/O block all metadata updates.
+
+## Goals
+
+1. A single segment has exactly one in-process manifest commit at a time.
+2. The segment lock covers manifest revision creation **and** catalog
+   publication, not only the etcd write.
+3. DataNode writes physical data, index, and stats files, but DataCoord owns the
+   commit-time manifest transaction and the etcd publication of the result.
+4. A successful visible commit updates all metadata that describes that visible
+   manifest in one catalog transaction.
+5. Failure is retryable and never publishes a manifest pointer before its
+   manifest exists.
+6. All StorageV3 manifest-writer paths eventually use this framework; direct
+   `UpdateManifest` is not an allowed publication mechanism for a V3 segment.
+
+## Non-goals
+
+- A distributed transaction between object storage and etcd.  It is not
+  available and must not be simulated with protobuf-value CAS.
+- A distributed per-segment lock across multiple active DataCoord leaders.
+  Milvus leadership already permits only the active DataCoord to mutate catalog
+  metadata.  Manifest transaction conflict handling remains the protection for
+  leader handoff, retries, and unexpected external writers.
+- Serializing all segment metadata updates.  Non-manifest updates can continue
+  to use `UpdateSegmentsInfo`; only the manifest commit protocol is serialized
+  by this new keyed lock.
+- Changing the manifest format or the storage transaction ABI beyond the
+  structured mutations needed by this framework.
+
+## Ownership Model
+
+```text
+DataNode / compactor
+  writes immutable artifact files
+  returns a structured manifest delta and its expected input manifest
+                      |
+                      v
+DataCoord meta.CommitSegmentManifest(segmentID, request)
+  segment-scoped lock
+    -> read current SegmentInfo
+    -> validate expected base / segment state
+    -> execute packed manifest transaction
+    -> catalog transaction: SegmentInfo + SegmentIndex/task state
+    -> install in-memory result
+                      |
+                      v
+Visible SegmentInfo.manifest_path
+```
+
+The worker must not return a pre-published manifest revision for an existing
+segment.  For example, an index task returns its index files and index metadata,
+not the result of `AddIndexInfoToManifest`.  DataCoord converts it to a
+`ManifestIndexInfo` while holding the segment commit lock and invokes the packed
+transaction itself.
+
+For a newly written segment (flush, import, copy target, or compaction target),
+the same rule applies: the data producer returns the structured column-group,
+delta, stats, and index entries required to create the manifest.  DataCoord
+creates and publishes the initial revision through the framework.  A producer
+may write data files, but does not select a visible manifest revision.
+
+## API Shape
+
+`meta` owns a keyed lock, initialized with the rest of metadata state:
+
+```go
+segmentManifestLocks *lock.KeyLock[int64]
+```
+
+The exported surface should use typed requests rather than an arbitrary callback
+that can do hidden I/O or re-enter `meta`:
+
+```go
+type SegmentManifestCommit struct {
+    SegmentID        int64
+    ExpectedManifest string // empty only for initial-manifest creation
+    Mutation         ManifestMutation
+    CatalogMutation  SegmentManifestCatalogMutation
+}
+
+func (m *meta) CommitSegmentManifest(
+    ctx context.Context,
+    commit SegmentManifestCommit,
+) error
+```
+
+`ManifestMutation` is a closed/typed set, initially including:
+
+- `CreateManifest` — construct the first revision from worker-supplied
+  structured entries;
+- `AddIndexes` and `DropIndexes`;
+- `AddStats`;
+- `AppendData` / `ReplaceData` as needed by flush and compaction;
+- `PublishPreparedManifest` only as a temporary compatibility adapter.  It must
+  validate the base and is removed once every producer returns structured
+  entries.
+
+`CatalogMutation` describes the metadata that must become visible with the
+manifest pointer.  Examples are completing one `SegmentIndex`, creating copied
+target `SegmentIndex` records, updating segment statistics, or changing a
+segment state.  It must produce catalog actions, not perform an independent
+catalog write.
+
+## Commit Protocol and Lock Order
+
+For one segment, the protocol is:
+
+1. Lock `segmentManifestLocks[segmentID]`.
+2. Briefly take `segMu`, clone the current `SegmentInfo`, and release `segMu`.
+   Validate segment existence, StorageV3, health/state, and
+   `ExpectedManifest` where the operation depends on a specific input.
+3. Execute the `packed` transaction using the cloned/current manifest.  The
+   packed resolver is `OVERWRITE`: under the segment lock there is no competing
+   local writer, while the resolver gives a deterministic latest-manifest
+   rebase for retry/leader-handoff races.
+4. Apply the new pointer and catalog mutation to the clone captured in step 2.
+   The segment lock is the sole in-process serialization point for this
+   segment's manifest publication; callers that mutate a StorageV3 manifest
+   must enter this protocol.
+5. Execute one `catalog.Update` / catalog transaction containing the changed
+   `SegmentInfo` and all associated `SegmentIndex` records.  This runs under
+   the segment lock but outside `segMu`, so catalog writes for different
+   segments remain concurrent.  If it fails, do not change memory.
+6. Briefly acquire `segMu` only to install the cloned metadata in memory, then
+   release it and release the segment lock.
+
+The lock ordering is always:
+
+```text
+segmentManifestLock(segmentID) -> segMu -> indexMeta.keyLock(buildID)
+```
+
+`segMu` is never held during object-storage I/O.  A path requiring both segment
+and index state follows this order; no code may take a BuildID lock first and
+then attempt a segment manifest commit.  Multi-segment operations sort segment
+IDs before locking.  Where possible, compaction creates independent target
+segments rather than committing two segments under one lock.
+
+## Failure and Recovery Semantics
+
+Object storage and etcd cannot commit atomically.  The ordering is deliberately
+one-way:
+
+```text
+artifact files -> manifest revision -> etcd/catalog pointer -> memory
+```
+
+- If artifact generation fails, no manifest or etcd change is made.
+- If manifest creation succeeds but catalog publication fails, the revision is
+  orphaned and invisible.  Retrying starts from the still-published pointer;
+  orphan cleanup is safe because no `SegmentInfo` references it.
+- A retry must be idempotent at the logical mutation level.  Adding an index
+  must not create duplicate logical index entries; dropping a deleted logical
+  index may remove every matching historical entry.
+- A stale expected base or changed segment state is a retry/discard result, not
+  an attempt to overwrite the current pointer.
+
+Drop requires a durable cleanup state in addition to serialization:
+
+```text
+commit manifest without index + mark index cleanup pending
+  -> delete index objects (retryable)
+  -> remove SegmentIndex metadata / complete cleanup marker
+```
+
+The framework prevents an interleaved index/stat commit during these steps, but
+it cannot make object deletion and etcd deletion atomic across a process crash.
+The pending state makes the remaining cleanup discoverable and idempotent.
+
+## Required Caller Migration
+
+| Current owner/path | Framework migration |
+|---|---|
+| `task_index.go` / DataNode index task | Return index artifact metadata.  `meta.CommitSegmentManifest(AddIndexes)` creates the revision and atomically completes `SegmentIndex`. |
+| `garbage_collector.go` | Use `DropIndexes`; publish pointer and cleanup intent in one catalog transaction, then perform retryable object cleanup. |
+| `copy_segment_task.go` / restore | Build the target manifest through `CreateManifest` or `AddIndexes`; create target `SegmentIndex` records in the same publication transaction. |
+| `task_stats.go` | Text, JSON, and sort stats all use `AddStats`; remove the bare sort `UpdateManifest` path. |
+| flush, import, `SaveBinlogPaths`, server update paths | Return structured data-manifest deltas and call `CreateManifest`/`AppendData`, not `UpdateManifest`. |
+| compaction | Generate output files in DataNode, return output manifest entries, then publish each output segment through the framework. |
+| snapshot/restore and recovery | Read the published pointer normally; all destination-manifest writes use the framework. |
+
+`UpdateManifest` should be retained only for StorageV1/V2 compatibility while
+the migration is in progress, then made unavailable for StorageV3 callers.  A
+review-time grep of every `UpdateManifest(` and every packed manifest mutation
+is a required migration gate.
+
+## Implementation Plan in the Clean Worktree
+
+1. Add the keyed lock and `CommitSegmentManifest` skeleton in `meta.go`, with
+   lock-order documentation and focused concurrency tests.
+2. Add typed packed mutation adapters and tests for add/drop/stats/create.  The
+   storage transaction uses `OVERWRITE`; do not add a protobuf-serialized
+   `SegmentInfo` value-equality CAS.
+3. Migrate index completion end-to-end: update DataNode result contract, remove
+   worker-side index manifest publication, and atomically publish
+   `SegmentInfo` plus `SegmentIndex` from `meta`.
+4. Migrate GC with the durable cleanup state and crash/retry tests.
+5. Migrate stats, including the sort path, then copy/restore.
+6. Migrate flush/import/compaction and eliminate StorageV3 direct
+   `UpdateManifest` calls.
+7. Add observability: lock wait/hold duration, commit outcomes, stale-base
+   rejections, orphan-manifest count, and cleanup retries.
+8. Run the full affected DataCoord/DataNode test matrix in the Milvus builder
+   container, with race/fault-injection tests covering etcd failure, stale
+   inputs, concurrent index completion, index-vs-GC, stats-vs-index, and
+   restart after each drop stage.
+
+## Integration with the Existing Manifest-Index Work
+
+The existing branch should not be incrementally expanded with this framework.
+After the clean branch is complete:
+
+1. rebase the manifest-index migration onto the framework branch;
+2. replace its local `packed.AddIndexInfosToManifest`,
+   `RemoveIndexInfosFromManifest`, and manifest-pointer publication logic with
+   `CommitSegmentManifest` actions;
+3. preserve the read fallback from legacy `SegmentIndex.IndexFileKeys` to
+   manifest entries for migration compatibility; and
+4. re-run the full lifecycle audit: build, load, query, copy/restore, snapshot,
+   compaction, dropped-segment GC, and recovery.
+
+This ordering avoids stabilizing two competing publication protocols in the
+same release.
+
+## Acceptance Criteria
+
+1. There is no StorageV3 manifest mutation or pointer publication outside the
+   DataCoord segment commit framework.
+2. Two concurrent operations on the same segment cannot publish pointer
+   revisions out of order.
+3. Operations on different segments do not block one another on manifest I/O.
+4. A catalog write failure never updates in-memory metadata and never exposes
+   the orphan manifest revision.
+5. GC after a crash converges without deleting files referenced by the current
+   manifest.
+6. Tests demonstrate each required race and failure case rather than only
+   successful sequential execution.

--- a/internal/datacoord/compaction_task_l0.go
+++ b/internal/datacoord/compaction_task_l0.go
@@ -28,6 +28,7 @@ import (
 	"github.com/milvus-io/milvus/internal/compaction"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
@@ -466,14 +467,24 @@ func buildL0V3DeltaLogEntries(segmentID int64, deltalogs []*datapb.FieldBinlog) 
 }
 
 func (t *l0CompactionTask) saveSegmentMeta(outputSegs []*datapb.CompactionSegment) error {
+	ctx := t.context()
 	var operators []UpdateOperator
-	storageConfig := compaction.CreateStorageConfig()
 	for _, seg := range outputSegs {
 		if len(seg.GetDeltalogs()) > 0 {
+			// The manifest transaction must run outside UpdateSegmentsInfo: that
+			// method holds segMu, whereas CommitSegmentManifest only holds the
+			// per-segment lock while it performs object-storage I/O.
+			current := t.meta.GetSegment(ctx, seg.GetSegmentID())
+			if current != nil && current.GetStorageVersion() == storage.StorageV3 && current.GetManifestPath() != "" {
+				if err := t.commitL0V3Deltalogs(ctx, seg.GetSegmentID(), seg.GetDeltalogs()); err != nil {
+					return err
+				}
+				continue
+			}
 			operators = append(operators, AddL0DeltalogsAndUpdateManifestOperator(
 				seg.GetSegmentID(),
 				seg.GetDeltalogs(),
-				storageConfig,
+				compaction.CreateStorageConfig(),
 				t.committedV3Manifests,
 			))
 		}
@@ -487,7 +498,59 @@ func (t *l0CompactionTask) saveSegmentMeta(outputSegs []*datapb.CompactionSegmen
 		mlog.Int64("planID", t.GetTaskProto().GetPlanID()),
 	)
 
-	return t.meta.UpdateSegmentsInfo(context.TODO(), operators...)
+	return t.meta.UpdateSegmentsInfo(ctx, operators...)
+}
+
+func (t *l0CompactionTask) commitL0V3Deltalogs(ctx context.Context, segmentID int64, deltalogs []*datapb.FieldBinlog) error {
+	current := t.meta.GetSegment(ctx, segmentID)
+	if current == nil {
+		return merr.WrapErrSegmentNotFound(segmentID)
+	}
+	if current.GetStorageVersion() != storage.StorageV3 || current.GetManifestPath() == "" {
+		return merr.WrapErrServiceInternalMsg("L0 StorageV3 manifest commit requires a published manifest, segmentID=%d", segmentID)
+	}
+
+	// L0 compaction does not yet return a structured manifest delta.  Until
+	// that producer contract lands, serialize its metadata visibility through
+	// the framework without manufacturing a manifest revision here.
+	manifestPath := t.committedV3Manifests[segmentID]
+	if manifestPath == "" {
+		manifestPath = current.GetManifestPath()
+	}
+
+	manifestMeta, ok := t.meta.(interface {
+		CommitSegmentManifest(context.Context, SegmentManifestCommit) error
+	})
+	if !ok {
+		return merr.WrapErrServiceInternalMsg("L0 StorageV3 manifest commit requires DataCoord meta implementation")
+	}
+	if err := manifestMeta.CommitSegmentManifest(ctx, SegmentManifestCommit{
+		SegmentID:        segmentID,
+		ExpectedManifest: current.GetManifestPath(),
+		Mutation: ManifestMutation{
+			Type:         ManifestMutationNoop,
+			ManifestPath: manifestPath,
+		},
+		CatalogMutation: SegmentCatalogMutation{
+			// Keep the catalog half of L0 exactly on the established L0
+			// mutation path. The Noop only adapts pointer publication until
+			// the compaction producer returns a structured manifest delta.
+			Operators: []UpdateOperator{AddL0DeltalogsOperator(segmentID, deltalogs)},
+		},
+	}); err != nil {
+		return err
+	}
+	t.committedV3Manifests[segmentID] = t.meta.GetSegment(ctx, segmentID).GetManifestPath()
+	return nil
+}
+
+func (t *l0CompactionTask) context() context.Context {
+	if meta, ok := t.meta.(*meta); ok && meta.ctx != nil {
+		return meta.ctx
+	}
+	// Unit-test CompactionMeta implementations do not own the DataCoord
+	// lifecycle context. Production tasks always take the meta context above.
+	return context.Background()
 }
 
 func (t *l0CompactionTask) GetSlotUsage() int64 {

--- a/internal/datacoord/compaction_task_l0_test.go
+++ b/internal/datacoord/compaction_task_l0_test.go
@@ -66,6 +66,9 @@ func (s *L0CompactionTaskSuite) TestSaveSegmentMetaUsesAtomicDeltalogOperator() 
 			Binlogs: []*datapb.Binlog{{LogID: 9001, LogPath: actualDeltaPath, EntriesNum: 3}},
 		}},
 	}}
+	// A legacy/non-manifest destination continues through the compatibility
+	// operator. StorageV3 destinations are committed by meta directly.
+	s.mockMeta.EXPECT().GetSegment(mock.Anything, int64(200)).Return(nil).Once()
 
 	s.mockMeta.EXPECT().UpdateSegmentsInfo(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, operators ...UpdateOperator) error {

--- a/internal/datacoord/copy_segment_task.go
+++ b/internal/datacoord/copy_segment_task.go
@@ -37,6 +37,7 @@ import (
 	"github.com/milvus-io/milvus/internal/datacoord/task"
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	snapshotstorage "github.com/milvus-io/milvus/internal/snapshotio/storage"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
@@ -904,10 +905,24 @@ func SyncCopySegmentTask(task CopySegmentTask, resp *datapb.QueryCopySegmentResp
 			op2 := UpdateStatusOperator(result.GetSegmentId(), commonpb.SegmentState_Flushed)
 			op3 := UpdateIsImporting(result.GetSegmentId(), false)
 			operators := []UpdateOperator{op1, op2, op3}
-			if manifestPath := result.GetManifestPath(); manifestPath != "" {
-				operators = append(operators, UpdateManifest(result.GetSegmentId(), manifestPath))
+			segment := meta.GetSegment(ctx, result.GetSegmentId())
+			v3ManifestCommit := segment != nil && segment.GetStorageVersion() == storage.StorageV3 && result.GetManifestPath() != ""
+			if !v3ManifestCommit && result.GetManifestPath() != "" {
+				operators = append(operators, UpdateManifest(result.GetSegmentId(), result.GetManifestPath()))
 			}
-			err = meta.UpdateSegmentsInfo(ctx, operators...)
+			if v3ManifestCommit {
+				err = meta.CommitSegmentManifest(ctx, SegmentManifestCommit{
+					SegmentID:        result.GetSegmentId(),
+					ExpectedManifest: segment.GetManifestPath(),
+					Mutation: ManifestMutation{
+						Type:         ManifestMutationNoop,
+						ManifestPath: result.GetManifestPath(),
+					},
+					CatalogMutation: SegmentCatalogMutation{Operators: operators},
+				})
+			} else {
+				err = meta.UpdateSegmentsInfo(ctx, operators...)
+			}
 			if err != nil {
 				// On error, mark task and job as failed
 				updateErr := copyMeta.UpdateTask(ctx, task.GetTaskId(),

--- a/internal/datacoord/ddl_callbacks_batch_update_manifest.go
+++ b/internal/datacoord/ddl_callbacks_batch_update_manifest.go
@@ -19,6 +19,8 @@ package datacoord
 import (
 	"context"
 
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 )
@@ -44,7 +46,28 @@ func (c *DDLCallbacks) batchUpdateManifestV2AckCallback(ctx context.Context, res
 			operators = append(operators, UpdateSegmentColumnGroupsOperator(segID, cg.GetColumnGroups()))
 			v2Count++
 		case hasV3:
-			operators = append(operators, UpdateManifestVersion(segID, item.GetManifestVersion()))
+			segment := c.meta.GetSegment(ctx, segID)
+			if segment == nil || segment.GetStorageVersion() != storage.StorageV3 || segment.GetManifestPath() == "" {
+				mlog.Warn(ctx, "batch update manifest V3 item has no published StorageV3 segment; skipping", mlog.FieldSegmentID(segID))
+				continue
+			}
+			basePath, currentVersion, err := packed.UnmarshalManifestPath(segment.GetManifestPath())
+			if err != nil {
+				return err
+			}
+			if item.GetManifestVersion() <= currentVersion {
+				continue
+			}
+			if err := c.meta.CommitSegmentManifest(ctx, SegmentManifestCommit{
+				SegmentID:        segID,
+				ExpectedManifest: segment.GetManifestPath(),
+				Mutation: ManifestMutation{
+					Type:         ManifestMutationNoop,
+					ManifestPath: packed.MarshalManifestPath(basePath, item.GetManifestVersion()),
+				},
+			}); err != nil {
+				return err
+			}
 			v3Count++
 		default:
 			mlog.Warn(ctx, "batch update manifest item has no payload; skipping",

--- a/internal/datacoord/import_task_import.go
+++ b/internal/datacoord/import_task_import.go
@@ -156,6 +156,7 @@ func (t *importTask) CreateTaskOnWorker(nodeID int64, cluster session.Cluster) {
 }
 
 func (t *importTask) QueryTaskOnWorker(cluster session.Cluster) {
+	ctx := t.meta.ctx
 	req := &datapb.QueryImportRequest{
 		JobID:  t.GetJobID(),
 		TaskID: t.GetTaskID(),
@@ -198,7 +199,7 @@ func (t *importTask) QueryTaskOnWorker(cluster session.Cluster) {
 
 	if resp.GetState() == datapb.ImportTaskStateV2_InProgress || resp.GetState() == datapb.ImportTaskStateV2_Completed {
 		for _, info := range resp.GetImportSegmentsInfo() {
-			segment := t.meta.GetSegment(context.TODO(), info.GetSegmentID())
+			segment := t.meta.GetSegment(ctx, info.GetSegmentID())
 			if info.GetImportedRows() <= segment.GetNumOfRows() {
 				continue // rows not changed, no need to update
 			}
@@ -249,14 +250,27 @@ func (t *importTask) QueryTaskOnWorker(cluster session.Cluster) {
 			}
 
 			opBinlog := UpdateBinlogsOperator(info.GetSegmentID(), info.GetBinlogs(), info.GetStatslogs(), info.GetDeltalogs(), info.GetBm25Logs())
-			opManifest := UpdateManifest(info.GetSegmentID(), info.GetManifestPath())
 			opState := UpdateStatusOperator(info.GetSegmentID(), commonpb.SegmentState_Flushed)
 			opPosition := UpdateImportSegmentPosition(info.GetSegmentID(), minTs, maxTs)
 			// Persist the producer-built Statistics wholesale (chained after
 			// UpdateBinlogsOperator so it wins over the array-derived value);
 			// when nil it array-derives from the arrays just set above.
 			opStats := UpdateSegmentStats(info.GetSegmentID(), info.GetStats())
-			err = t.meta.UpdateSegmentsInfo(context.TODO(), opBinlog, opManifest, opState, opPosition, opStats)
+			segment := t.meta.GetSegment(ctx, info.GetSegmentID())
+			v3ManifestCommit := segment != nil && segment.GetStorageVersion() == storage.StorageV3 && info.GetManifestPath() != ""
+			if v3ManifestCommit {
+				err = t.meta.CommitSegmentManifest(ctx, SegmentManifestCommit{
+					SegmentID:        info.GetSegmentID(),
+					ExpectedManifest: segment.GetManifestPath(),
+					Mutation: ManifestMutation{
+						Type:         ManifestMutationNoop,
+						ManifestPath: info.GetManifestPath(),
+					},
+					CatalogMutation: SegmentCatalogMutation{Operators: []UpdateOperator{opBinlog, opState, opPosition, opStats}},
+				})
+			} else {
+				err = t.meta.UpdateSegmentsInfo(ctx, opBinlog, UpdateManifest(info.GetSegmentID(), info.GetManifestPath()), opState, opPosition, opStats)
+			}
 			if err != nil {
 				updateErr := t.importMeta.UpdateJob(context.TODO(), t.GetJobID(), UpdateJobState(internalpb.ImportJobState_Failed), UpdateJobReason(err.Error()))
 				if updateErr != nil {

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -97,6 +97,10 @@ type meta struct {
 
 	segMu    lock.RWMutex
 	segments *SegmentsInfo // segment id to segment info
+	// segmentManifestLocks serializes the full StorageV3 manifest commit for a
+	// segment. It must be acquired before segMu; segMu must never be held while
+	// a manifest transaction performs object-storage I/O.
+	segmentManifestLocks *lock.KeyLock[int64]
 
 	channelCPs   *channelCPs // vChannel -> channel checkpoint/see position
 	chunkManager storage.ChunkManager
@@ -276,15 +280,16 @@ func newMeta(ctx context.Context, catalog metastore.DataCoordCatalog, chunkManag
 	// Construct meta struct first so reloadFromKV can run in parallel with sub-meta loading.
 	// reloadFromKV uses m.catalog/m.segments/m.channelCPs which are independent of sub-metas.
 	mt := &meta{
-		ctx:             ctx,
-		catalog:         catalog,
-		collections:     typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
-		segments:        NewSegmentsInfo(),
-		channelCPs:      newChannelCps(),
-		chunkManager:    chunkManager,
-		resourceIDMap:   make(map[int64]*internalpb.FileResourceInfo),
-		resourceVersion: 0,
-		resourceLock:    lock.RWMutex{},
+		ctx:                  ctx,
+		catalog:              catalog,
+		collections:          typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+		segments:             NewSegmentsInfo(),
+		segmentManifestLocks: lock.NewKeyLock[int64](),
+		channelCPs:           newChannelCps(),
+		chunkManager:         chunkManager,
+		resourceIDMap:        make(map[int64]*internalpb.FileResourceInfo),
+		resourceVersion:      0,
+		resourceLock:         lock.RWMutex{},
 	}
 
 	g, _ := errgroup.WithContext(ctx)
@@ -1308,6 +1313,9 @@ func (u *l0ManifestUpdate) prepare(modPack *updateSegmentPack) bool {
 	if len(u.deltalogs) == 0 {
 		return false
 	}
+	if u.segment.GetStorageVersion() == storage.StorageV3 && u.segment.GetManifestPath() != "" {
+		return modPack.fail(merr.WrapErrServiceInternalMsg("StorageV3 L0 manifest publication must use CommitSegmentManifest, segmentID=%d", u.segmentID))
+	}
 
 	if u.segment.GetManifestPath() == "" {
 		if err := binlog.CompressFieldBinlogs(u.deltalogs); err != nil {
@@ -1412,9 +1420,32 @@ func (u *l0ManifestUpdate) apply(modPack *updateSegmentPack) bool {
 		if err := updateManifestPathIfNewer(u.segment, u.manifestPath); err != nil {
 			return modPack.fail(err)
 		}
-		clearBinlogPaths(u.deltalogs)
 	}
-	return addDeltalogsToSegment(modPack, u.segmentID, u.segment, u.deltalogs)
+	return applyL0Deltalogs(modPack, u.segmentID, u.segment, u.deltalogs)
+}
+
+// applyL0Deltalogs is the catalog half of an L0 result. Both the legacy L0
+// manifest writer and the segment-manifest commit adapter use it, so merging,
+// statistics accumulation, retry deduplication, and path elision are shared.
+func applyL0Deltalogs(modPack *updateSegmentPack, segmentID int64, segment *SegmentInfo, deltalogs []*datapb.FieldBinlog) bool {
+	if segment.GetManifestPath() != "" {
+		clearBinlogPaths(deltalogs)
+	}
+	return addDeltalogsToSegment(modPack, segmentID, segment, deltalogs)
+}
+
+// AddL0DeltalogsOperator applies an L0 result after its manifest pointer has
+// been published separately. It deliberately does not perform manifest I/O.
+func AddL0DeltalogsOperator(segmentID int64, deltalogs []*datapb.FieldBinlog) UpdateOperator {
+	return func(modPack *updateSegmentPack) bool {
+		segment := modPack.Get(segmentID)
+		if segment == nil {
+			mlog.Warn(modPack.meta.ctx, "meta update: add L0 deltalog failed - segment not found",
+				mlog.Int64("segmentID", segmentID))
+			return false
+		}
+		return applyL0Deltalogs(modPack, segmentID, segment, deltalogs)
+	}
 }
 
 func AddL0DeltalogsAndUpdateManifestOperator(
@@ -1705,6 +1736,9 @@ func UpdateManifest(segmentID int64, manifestPath string) UpdateOperator {
 		if manifestPath == "" || segment.ManifestPath == manifestPath {
 			return false
 		}
+		if segment.GetStorageVersion() == storage.StorageV3 {
+			return modPack.fail(merr.WrapErrServiceInternalMsg("StorageV3 manifest publication must use CommitSegmentManifest, segmentID=%d", segmentID))
+		}
 		segment.ManifestPath = manifestPath
 		return true
 	}
@@ -1742,6 +1776,9 @@ func UpdateManifestVersion(segmentID int64, manifestVersion int64) UpdateOperato
 					mlog.Int64("incomingVer", manifestVersion))
 			}
 			return false
+		}
+		if segment.GetStorageVersion() == storage.StorageV3 {
+			return modPack.fail(merr.WrapErrServiceInternalMsg("StorageV3 manifest publication must use CommitSegmentManifest, segmentID=%d", segmentID))
 		}
 		segment.ManifestPath = packed.MarshalManifestPath(basePath, manifestVersion)
 		return true

--- a/internal/datacoord/segment_manifest_commit.go
+++ b/internal/datacoord/segment_manifest_commit.go
@@ -1,0 +1,342 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus/internal/metastore"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/lock"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+// ManifestMutationType is deliberately a closed set.  Callers supply data;
+// they do not supply a callback which could do additional I/O or re-enter
+// meta while the segment commit lock is held.
+type ManifestMutationType int
+
+const (
+	// ManifestMutationCommitUpdates creates a new revision from structured
+	// packed updates.  It is the normal StorageV3 publication path.
+	ManifestMutationCommitUpdates ManifestMutationType = iota + 1
+	// ManifestMutationNoop publishes a manifest path that was prepared by an
+	// existing producer.  It intentionally performs no object-storage I/O;
+	// migration patches use it to move pointer publication into this framework
+	// before the producer learns to return a structured delta.
+	ManifestMutationNoop
+)
+
+// ManifestMutation is the object-storage part of a segment manifest commit.
+// NewFiles, when present in Updates, remains owned by the caller and must be
+// destroyed after CommitSegmentManifest returns.
+type ManifestMutation struct {
+	Type    ManifestMutationType
+	Updates *packed.ManifestUpdates
+	// ManifestPath is the published result of a Noop mutation.
+	ManifestPath string
+}
+
+// SegmentCatalogMutation contains the segment fields that become visible with
+// the manifest pointer. Each addition here is a reviewable catalog contract.
+type SegmentCatalogMutation struct {
+	TextStats    map[int64]*datapb.TextIndexStats
+	JSONKeyStats map[int64]*datapb.JsonKeyStats
+	State        *commonpb.SegmentState
+	IsImporting  *bool
+	// NewSegment supplies the complete initial catalog record when this commit
+	// creates a segment. Its ManifestPath must be empty: the ManifestMutation
+	// below is the sole publisher of the first manifest pointer.
+	NewSegment *datapb.SegmentInfo
+	// Operators are existing DataCoord segment mutations applied to a clone
+	// under segMu.  They are a migration adapter: callers retain their current
+	// metadata contract while the manifest mutation is Noop.  They must not
+	// perform manifest I/O or include UpdateManifest.
+	Operators []UpdateOperator
+}
+
+// SegmentManifestCommit describes one segment-scoped StorageV3 commit.
+// ExpectedManifest is an optional optimistic CAS condition. When non-empty,
+// publication proceeds only if the current pointer matches it. When empty,
+// the per-segment transaction lock serializes publication without requiring a
+// caller to know the current pointer.
+type SegmentManifestCommit struct {
+	SegmentID        int64
+	ExpectedManifest string
+	StorageConfig    *indexpb.StorageConfig
+	Mutation         ManifestMutation
+	CatalogMutation  SegmentCatalogMutation
+}
+
+// CommitSegmentManifest is the only DataCoord primitive that both creates a
+// StorageV3 manifest revision and advances SegmentInfo.manifest_path.  Lock
+// order is segmentManifestLocks[segmentID] -> segMu -> indexMeta.keyLock. No
+// caller may enter this protocol while holding segMu; multi-segment paths must
+// acquire segmentManifestLocks in ascending SegmentID order before segMu. This
+// function does not acquire an index lock; a caller that needs one must acquire
+// it only after entering this protocol.
+func (m *meta) CommitSegmentManifest(ctx context.Context, commit SegmentManifestCommit) error {
+	if commit.SegmentID == 0 {
+		return merr.WrapErrServiceInternalMsg("segment manifest commit requires a segment ID")
+	}
+
+	// KeyLock.Lock is synchronous: a caller blocks here only when another
+	// transaction for this segment is in flight. There is no asynchronous
+	// queue or goroutine. Different segment IDs have independent locks, so
+	// their manifest I/O continues concurrently; lockWait records same-segment
+	// contention while lockHold below records the serialized transaction time.
+	locks := m.getSegmentManifestLocks()
+	lockStart := time.Now()
+	locks.Lock(commit.SegmentID)
+	defer locks.Unlock(commit.SegmentID)
+	lockWait := time.Since(lockStart)
+	holdStart := time.Now()
+	defer func() {
+		mlog.Debug(ctx, "segment manifest commit completed",
+			mlog.Int64("segmentID", commit.SegmentID),
+			mlog.Duration("lockWait", lockWait),
+			mlog.Duration("lockHold", time.Since(holdStart)))
+	}()
+
+	// Snapshot the currently published pointer under segMu, then release it
+	// before opening the (potentially slow) object-storage transaction.
+	m.segMu.RLock()
+	segment := m.segments.GetSegment(commit.SegmentID)
+	if segment != nil {
+		segment = segment.Clone()
+	}
+	m.segMu.RUnlock()
+
+	isNewSegment := segment == nil
+	if isNewSegment {
+		if commit.CatalogMutation.NewSegment == nil {
+			return merr.WrapErrSegmentNotFound(commit.SegmentID)
+		}
+		if commit.ExpectedManifest != "" {
+			return merr.WrapErrServiceInternalMsg("new segment manifest commit cannot set expected manifest, segmentID=%d", commit.SegmentID)
+		}
+		if commit.CatalogMutation.NewSegment.GetID() != commit.SegmentID {
+			return merr.WrapErrServiceInternalMsg("new segment ID %d does not match manifest commit segmentID %d", commit.CatalogMutation.NewSegment.GetID(), commit.SegmentID)
+		}
+		if commit.CatalogMutation.NewSegment.GetManifestPath() != "" {
+			return merr.WrapErrServiceInternalMsg("new segment manifest path must be empty, segmentID=%d", commit.SegmentID)
+		}
+		segment = NewSegmentInfo(proto.Clone(commit.CatalogMutation.NewSegment).(*datapb.SegmentInfo))
+	} else if commit.CatalogMutation.NewSegment != nil {
+		return merr.WrapErrServiceInternalMsg("existing segment manifest commit cannot include a new segment, segmentID=%d", commit.SegmentID)
+	}
+	if segment.GetStorageVersion() != storage.StorageV3 {
+		return merr.WrapErrServiceInternalMsg("segment manifest commit requires StorageV3, segmentID=%d", commit.SegmentID)
+	}
+	if !isSegmentHealthy(segment) {
+		return merr.WrapErrServiceInternalMsg("segment manifest commit requires a healthy segment, segmentID=%d", commit.SegmentID)
+	}
+	if !matchesExpectedManifest(commit.ExpectedManifest, segment.GetManifestPath()) {
+		return staleSegmentManifestError(commit.SegmentID, commit.ExpectedManifest, segment.GetManifestPath())
+	}
+
+	manifestPath, err := commitManifestMutation(segment.GetManifestPath(), commit)
+	if err != nil {
+		return err
+	}
+
+	// segmentManifestLocks owns this segment's publication sequence, including
+	// the catalog write below. Use the snapshot taken after acquiring that lock;
+	// do not re-enter segMu or re-load the segment after manifest I/O.
+	updated, metricMutation, err := m.applySegmentCatalogMutation(segment, commit.CatalogMutation)
+	if err != nil {
+		// Preserve UpdateSegmentsInfo's contract for stale SaveBinlogPaths
+		// requests: the prepared immutable revision remains unpublished and
+		// the caller need not retry an operation that is no longer applicable.
+		if errors.Is(err, errIgnoredSegmentMetaOperation) {
+			mlog.Info(ctx, "segment manifest commit ignored stale segment meta operation", mlog.Err(err))
+			return nil
+		}
+		return err
+	}
+	updated.ManifestPath = manifestPath
+	var action metastore.UpdateAction
+	if isNewSegment {
+		action = metastore.AddSegment(updated.SegmentInfo)
+		metricMutation.addNewSeg(
+			updated.GetState(),
+			updated.GetLevel(),
+			updated.GetIsSorted(),
+			updated.GetStorageVersion(),
+			segmentMetricFormatLabel(updated),
+			updated.GetNumOfRows(),
+		)
+	} else {
+		action = metastore.AlterSegment(updated.SegmentInfo)
+	}
+
+	if err := m.catalog.Update(ctx, action); err != nil {
+		return merr.Wrap(err, "publish segment manifest")
+	}
+	metricMutation.commit()
+	// Memory is installed only after the catalog write has succeeded. This
+	// short critical section protects SegmentsInfo's map; it does not include
+	// any etcd or object-storage operation.
+	m.segMu.Lock()
+	m.segments.SetSegment(commit.SegmentID, updated)
+	m.segMu.Unlock()
+	return nil
+}
+
+// getSegmentManifestLocks also supports focused unit tests that construct a
+// lightweight meta directly instead of calling newMeta.
+func (m *meta) getSegmentManifestLocks() *lock.KeyLock[int64] {
+	m.segMu.Lock()
+	defer m.segMu.Unlock()
+	if m.segmentManifestLocks == nil {
+		m.segmentManifestLocks = lock.NewKeyLock[int64]()
+	}
+	return m.segmentManifestLocks
+}
+
+func commitManifestMutation(baseManifest string, commit SegmentManifestCommit) (string, error) {
+	switch commit.Mutation.Type {
+	case ManifestMutationCommitUpdates:
+		if baseManifest == "" {
+			return "", merr.WrapErrServiceInternalMsg("cannot update an empty manifest for segmentID=%d", commit.SegmentID)
+		}
+		if commit.Mutation.Updates == nil {
+			return "", merr.WrapErrServiceInternalMsg("manifest updates are nil for segmentID=%d", commit.SegmentID)
+		}
+		basePath, version, err := packed.UnmarshalManifestPath(baseManifest)
+		if err != nil {
+			return "", merr.Wrap(err, "parse expected manifest")
+		}
+		manifestPath, err := packed.CommitManifestUpdates(basePath, version, commit.StorageConfig, commit.Mutation.Updates)
+		if err != nil {
+			return "", merr.Wrap(err, "commit segment manifest")
+		}
+		return manifestPath, nil
+	case ManifestMutationNoop:
+		if commit.Mutation.ManifestPath == "" {
+			return "", merr.WrapErrServiceInternalMsg("noop manifest mutation has no manifest path for segmentID=%d", commit.SegmentID)
+		}
+		if err := validatePreparedManifest(baseManifest, commit.Mutation.ManifestPath); err != nil {
+			return "", merr.Wrap(err, "validate noop manifest")
+		}
+		return commit.Mutation.ManifestPath, nil
+	default:
+		return "", merr.WrapErrServiceInternalMsg("unsupported segment manifest mutation %d", commit.Mutation.Type)
+	}
+}
+
+// validatePreparedManifest makes the Noop/compatibility path obey the same
+// monotonic pointer rule as a packed mutation. An equal version is an
+// idempotent retry; a first publication has no prior base to compare.
+func validatePreparedManifest(baseManifest, preparedManifest string) error {
+	preparedBase, preparedVersion, err := packed.UnmarshalManifestPath(preparedManifest)
+	if err != nil {
+		return err
+	}
+	if baseManifest == "" {
+		return nil
+	}
+	basePath, baseVersion, err := packed.UnmarshalManifestPath(baseManifest)
+	if err != nil {
+		return err
+	}
+	if preparedBase != basePath {
+		return merr.WrapErrServiceInternalMsg("prepared manifest base %q does not match expected base %q", preparedBase, basePath)
+	}
+	if preparedVersion < baseVersion {
+		return merr.WrapErrServiceUnavailableMsg("prepared manifest version %d regresses expected version %d", preparedVersion, baseVersion)
+	}
+	return nil
+}
+
+func (m *meta) applySegmentCatalogMutation(current *SegmentInfo, mutation SegmentCatalogMutation) (*SegmentInfo, *segMetricMutation, error) {
+	pack := &updateSegmentPack{
+		meta:       m,
+		segments:   make(map[int64]*SegmentInfo),
+		increments: make(map[int64]metastore.BinlogsIncrement),
+		metricMutation: &segMetricMutation{
+			stateChange:             make(segmentMetricStateChange),
+			deferSegmentLabelChange: true,
+		},
+	}
+	// Always seed the pack from the segment-lock snapshot. Operators then never
+	// re-read the shared SegmentsInfo map while catalog I/O is intentionally
+	// outside segMu. This also lets creation commits use the same machinery
+	// before their segment is visible in meta.
+	pack.segments[current.GetID()] = current.Clone()
+	for _, operator := range mutation.Operators {
+		operator(pack)
+		if pack.err != nil {
+			return nil, nil, pack.err
+		}
+	}
+	if len(pack.l0ManifestUpdates) > 0 {
+		return nil, nil, merr.WrapErrServiceInternalMsg("segment manifest commit catalog mutation must not contain L0 manifest updates")
+	}
+	segment := pack.Get(current.GetID())
+	if segment == nil {
+		segment = current.Clone()
+	}
+	if len(mutation.TextStats) > 0 {
+		if segment.TextStatsLogs == nil {
+			segment.TextStatsLogs = make(map[int64]*datapb.TextIndexStats)
+		}
+		for fieldID, stats := range mutation.TextStats {
+			segment.TextStatsLogs[fieldID] = proto.Clone(stats).(*datapb.TextIndexStats)
+		}
+	}
+	if len(mutation.JSONKeyStats) > 0 {
+		if segment.JsonKeyStats == nil {
+			segment.JsonKeyStats = make(map[int64]*datapb.JsonKeyStats)
+		}
+		for fieldID, stats := range mutation.JSONKeyStats {
+			segment.JsonKeyStats[fieldID] = proto.Clone(stats).(*datapb.JsonKeyStats)
+		}
+	}
+	if mutation.State != nil {
+		segment.State = *mutation.State
+	}
+	if mutation.IsImporting != nil {
+		segment.IsImporting = *mutation.IsImporting
+	}
+	if err := pack.Validate(); err != nil {
+		return nil, nil, err
+	}
+	// Operators prepare metric transitions as part of UpdateSegmentsInfo.
+	// Do this after applying the typed fields too, so a state mutation is
+	// reflected only once the catalog write succeeds.
+	pack.prepareSegmentMetricUpdates()
+	return segment, pack.metricMutation, nil
+}
+
+func staleSegmentManifestError(segmentID int64, expected, current string) error {
+	return merr.WrapErrServiceUnavailableMsg(
+		"stale segment manifest, segmentID=%d expected=%q current=%q", segmentID, expected, current)
+}
+
+func matchesExpectedManifest(expected, current string) bool {
+	return expected == "" || expected == current
+}

--- a/internal/datacoord/segment_manifest_commit_test.go
+++ b/internal/datacoord/segment_manifest_commit_test.go
@@ -1,0 +1,466 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bytedance/mockey"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus/internal/metastore"
+	metastoremocks "github.com/milvus-io/milvus/internal/metastore/mocks"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+func TestCommitSegmentManifestPublishesOnlyAfterCatalogSuccess(t *testing.T) {
+	basePath := "/tmp/milvus/insert_log/1/10/200"
+	oldManifest := packed.MarshalManifestPath(basePath, 7)
+	newManifest := packed.MarshalManifestPath(basePath, 8)
+	meta, err := newMemoryMeta(t)
+	require.NoError(t, err)
+	require.NoError(t, meta.AddSegment(context.Background(), NewSegmentInfo(&datapb.SegmentInfo{
+		ID:             200,
+		State:          commonpb.SegmentState_Flushed,
+		StorageVersion: storage.StorageV3,
+		ManifestPath:   oldManifest,
+	})))
+
+	commit := mockey.Mock(packed.CommitManifestUpdates).To(
+		func(base string, version int64, _ *indexpb.StorageConfig, updates *packed.ManifestUpdates) (string, error) {
+			require.Equal(t, basePath, base)
+			require.EqualValues(t, 7, version)
+			require.Len(t, updates.DeltaLogs, 1)
+			return newManifest, nil
+		},
+	).Build()
+	defer commit.UnPatch()
+
+	err = meta.CommitSegmentManifest(context.Background(), SegmentManifestCommit{
+		SegmentID:        200,
+		ExpectedManifest: oldManifest,
+		StorageConfig:    &indexpb.StorageConfig{},
+		Mutation: ManifestMutation{
+			Type: ManifestMutationCommitUpdates,
+			Updates: &packed.ManifestUpdates{DeltaLogs: []packed.DeltaLogEntry{{
+				Path:       basePath + "/_delta/9001",
+				NumEntries: 3,
+			}}},
+		},
+		CatalogMutation: SegmentCatalogMutation{Operators: []UpdateOperator{AddL0DeltalogsOperator(200, []*datapb.FieldBinlog{{
+			Binlogs: []*datapb.Binlog{{LogID: 9001, LogPath: basePath + "/_delta/9001", EntriesNum: 3, MemorySize: 128}},
+		}})}},
+	})
+	require.NoError(t, err)
+
+	updated := meta.GetSegment(context.Background(), 200)
+	require.Equal(t, newManifest, updated.GetManifestPath())
+	require.EqualValues(t, 3, updated.GetStats().GetDeleteNumRows())
+	require.Empty(t, updated.GetDeltalogs()[0].GetBinlogs()[0].GetLogPath())
+	manifest9 := packed.MarshalManifestPath(basePath, 9)
+	require.NoError(t, meta.CommitSegmentManifest(context.Background(), SegmentManifestCommit{
+		SegmentID:        200,
+		ExpectedManifest: newManifest,
+		Mutation: ManifestMutation{
+			Type:         ManifestMutationNoop,
+			ManifestPath: manifest9,
+		},
+		CatalogMutation: SegmentCatalogMutation{Operators: []UpdateOperator{
+			UpdateIsImporting(200, true),
+		}},
+	}))
+	require.Equal(t, manifest9, meta.GetSegment(context.Background(), 200).GetManifestPath())
+	require.True(t, meta.GetSegment(context.Background(), 200).GetIsImporting())
+
+	// The stale caller must not publish a later transaction on the old base.
+	err = meta.CommitSegmentManifest(context.Background(), SegmentManifestCommit{
+		SegmentID:        200,
+		ExpectedManifest: oldManifest,
+		Mutation: ManifestMutation{
+			Type:         ManifestMutationNoop,
+			ManifestPath: packed.MarshalManifestPath(basePath, 10),
+		},
+	})
+	require.ErrorIs(t, err, merr.ErrServiceUnavailable)
+	require.Equal(t, manifest9, meta.GetSegment(context.Background(), 200).GetManifestPath())
+
+	err = meta.CommitSegmentManifest(context.Background(), SegmentManifestCommit{
+		SegmentID:        200,
+		ExpectedManifest: manifest9,
+		Mutation: ManifestMutation{
+			Type:         ManifestMutationNoop,
+			ManifestPath: newManifest,
+		},
+	})
+	require.ErrorIs(t, err, merr.ErrServiceUnavailable)
+	require.Equal(t, manifest9, meta.GetSegment(context.Background(), 200).GetManifestPath())
+}
+
+func TestCommitSegmentManifestNoopReusesL0CatalogMutation(t *testing.T) {
+	basePath := "/tmp/milvus/insert_log/1/10/208"
+	manifest := packed.MarshalManifestPath(basePath, 7)
+	meta, err := newMemoryMeta(t)
+	require.NoError(t, err)
+	require.NoError(t, meta.AddSegment(context.Background(), NewSegmentInfo(&datapb.SegmentInfo{
+		ID:             208,
+		State:          commonpb.SegmentState_Flushed,
+		StorageVersion: storage.StorageV3,
+		ManifestPath:   manifest,
+		Stats: &datapb.Statistics{
+			DeltaBinlogSize:    4096,
+			DeleteNumRows:      1000,
+			DeltaBinlogCount:   10,
+			DeltaTimestampFrom: 100,
+			DeltaTimestampTo:   900,
+		},
+	})))
+
+	deltalogs := []*datapb.FieldBinlog{{
+		Binlogs: []*datapb.Binlog{{
+			LogID:         9001,
+			LogPath:       basePath + "/_delta/9001",
+			EntriesNum:    50,
+			MemorySize:    256,
+			TimestampFrom: 950,
+			TimestampTo:   1000,
+		}},
+	}}
+	commit := SegmentManifestCommit{
+		SegmentID:        208,
+		ExpectedManifest: manifest,
+		Mutation: ManifestMutation{
+			Type:         ManifestMutationNoop,
+			ManifestPath: manifest,
+		},
+		CatalogMutation: SegmentCatalogMutation{Operators: []UpdateOperator{
+			AddL0DeltalogsOperator(208, deltalogs),
+		}},
+	}
+
+	require.NoError(t, meta.CommitSegmentManifest(context.Background(), commit))
+	updated := meta.GetSegment(context.Background(), 208)
+	require.Equal(t, manifest, updated.GetManifestPath())
+	require.EqualValues(t, 1050, updated.GetStats().GetDeleteNumRows())
+	require.EqualValues(t, 4096+256, updated.GetStats().GetDeltaBinlogSize())
+	require.EqualValues(t, 11, updated.GetStats().GetDeltaBinlogCount())
+	require.EqualValues(t, 100, updated.GetStats().GetDeltaTimestampFrom())
+	require.EqualValues(t, 1000, updated.GetStats().GetDeltaTimestampTo())
+	require.Empty(t, updated.GetDeltalogs()[0].GetBinlogs()[0].GetLogPath())
+
+	// Retrying the same Noop must retain the L0 path's deduplication semantics.
+	require.NoError(t, meta.CommitSegmentManifest(context.Background(), commit))
+	updated = meta.GetSegment(context.Background(), 208)
+	require.EqualValues(t, 1050, updated.GetStats().GetDeleteNumRows())
+	require.EqualValues(t, 4096+256, updated.GetStats().GetDeltaBinlogSize())
+	require.EqualValues(t, 11, updated.GetStats().GetDeltaBinlogCount())
+	require.Len(t, updated.GetDeltalogs()[0].GetBinlogs(), 1)
+}
+
+func TestCommitSegmentManifestAllowsOmittedExpectedManifest(t *testing.T) {
+	basePath := "/tmp/milvus/insert_log/1/10/209"
+	manifest7 := packed.MarshalManifestPath(basePath, 7)
+	manifest8 := packed.MarshalManifestPath(basePath, 8)
+	meta, err := newMemoryMeta(t)
+	require.NoError(t, err)
+	require.NoError(t, meta.AddSegment(context.Background(), NewSegmentInfo(&datapb.SegmentInfo{
+		ID:             209,
+		State:          commonpb.SegmentState_Flushed,
+		StorageVersion: storage.StorageV3,
+		ManifestPath:   manifest7,
+	})))
+
+	// No ExpectedManifest means this caller deliberately opts out of pointer
+	// CAS, while the per-segment transaction lock still serializes publication.
+	require.NoError(t, meta.CommitSegmentManifest(context.Background(), SegmentManifestCommit{
+		SegmentID: 209,
+		Mutation: ManifestMutation{
+			Type:         ManifestMutationNoop,
+			ManifestPath: manifest8,
+		},
+	}))
+	require.Equal(t, manifest8, meta.GetSegment(context.Background(), 209).GetManifestPath())
+
+	manifest9 := packed.MarshalManifestPath(basePath, 9)
+	require.NoError(t, meta.CommitSegmentManifest(context.Background(), SegmentManifestCommit{
+		SegmentID: 209,
+		Mutation: ManifestMutation{
+			Type:         ManifestMutationNoop,
+			ManifestPath: manifest9,
+		},
+		CatalogMutation: SegmentCatalogMutation{Operators: []UpdateOperator{
+			UpdateIsImporting(209, true),
+		}},
+	}))
+	updated := meta.GetSegment(context.Background(), 209)
+	require.Equal(t, manifest9, updated.GetManifestPath())
+	require.True(t, updated.GetIsImporting())
+}
+
+func TestCommitSegmentManifestCreatesSegmentWithInitialPointer(t *testing.T) {
+	meta, err := newMemoryMeta(t)
+	require.NoError(t, err)
+	manifest := packed.MarshalManifestPath("/tmp/milvus/insert_log/1/10/210", 1)
+
+	require.NoError(t, meta.CommitSegmentManifest(context.Background(), SegmentManifestCommit{
+		SegmentID: 210,
+		Mutation: ManifestMutation{
+			Type:         ManifestMutationNoop,
+			ManifestPath: manifest,
+		},
+		CatalogMutation: SegmentCatalogMutation{NewSegment: &datapb.SegmentInfo{
+			ID:             210,
+			State:          commonpb.SegmentState_Flushed,
+			StorageVersion: storage.StorageV3,
+		}},
+	}))
+
+	segment := meta.GetSegment(context.Background(), 210)
+	require.NotNil(t, segment)
+	require.Equal(t, manifest, segment.GetManifestPath())
+	require.Equal(t, storage.StorageV3, segment.GetStorageVersion())
+}
+
+func TestCommitSegmentManifestLeavesMemoryUntouchedOnCatalogFailure(t *testing.T) {
+	basePath := "/tmp/milvus/insert_log/1/10/201"
+	oldManifest := packed.MarshalManifestPath(basePath, 7)
+	newManifest := packed.MarshalManifestPath(basePath, 8)
+	meta, err := newMemoryMeta(t)
+	require.NoError(t, err)
+	require.NoError(t, meta.AddSegment(context.Background(), NewSegmentInfo(&datapb.SegmentInfo{
+		ID:             201,
+		State:          commonpb.SegmentState_Flushed,
+		StorageVersion: storage.StorageV3,
+		ManifestPath:   oldManifest,
+	})))
+	catalog := metastoremocks.NewDataCoordCatalog(t)
+	catalog.EXPECT().Update(mock.Anything, mock.Anything).Return(merr.WrapErrServiceUnavailableMsg("catalog unavailable")).Once()
+	meta.catalog = catalog
+
+	commit := mockey.Mock(packed.CommitManifestUpdates).Return(newManifest, nil).Build()
+	defer commit.UnPatch()
+
+	err = meta.CommitSegmentManifest(context.Background(), SegmentManifestCommit{
+		SegmentID:        201,
+		ExpectedManifest: oldManifest,
+		StorageConfig:    &indexpb.StorageConfig{},
+		Mutation: ManifestMutation{
+			Type:    ManifestMutationCommitUpdates,
+			Updates: &packed.ManifestUpdates{DeltaLogs: []packed.DeltaLogEntry{{Path: basePath + "/_delta/9001", NumEntries: 1}}},
+		},
+	})
+	require.ErrorIs(t, err, merr.ErrServiceUnavailable)
+	require.Equal(t, oldManifest, meta.GetSegment(context.Background(), 201).GetManifestPath())
+}
+
+func TestCommitSegmentManifestDoesNotSerializeDifferentSegments(t *testing.T) {
+	meta, err := newMemoryMeta(t)
+	require.NoError(t, err)
+	basePaths := map[int64]string{
+		202: "/tmp/milvus/insert_log/1/10/202",
+		203: "/tmp/milvus/insert_log/1/10/203",
+	}
+	for segmentID, basePath := range basePaths {
+		require.NoError(t, meta.AddSegment(context.Background(), NewSegmentInfo(&datapb.SegmentInfo{
+			ID:             segmentID,
+			State:          commonpb.SegmentState_Flushed,
+			StorageVersion: storage.StorageV3,
+			ManifestPath:   packed.MarshalManifestPath(basePath, 1),
+		})))
+	}
+
+	entered := make(chan string, 2)
+	release := make(chan struct{})
+	commit := mockey.Mock(packed.CommitManifestUpdates).To(
+		func(base string, version int64, _ *indexpb.StorageConfig, _ *packed.ManifestUpdates) (string, error) {
+			entered <- base
+			<-release
+			return packed.MarshalManifestPath(base, version+1), nil
+		},
+	).Build()
+	defer commit.UnPatch()
+
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for segmentID, basePath := range basePaths {
+		wg.Add(1)
+		go func(segmentID int64, basePath string) {
+			defer wg.Done()
+			baseManifest := packed.MarshalManifestPath(basePath, 1)
+			errs <- meta.CommitSegmentManifest(context.Background(), SegmentManifestCommit{
+				SegmentID:        segmentID,
+				ExpectedManifest: baseManifest,
+				StorageConfig:    &indexpb.StorageConfig{},
+				Mutation: ManifestMutation{
+					Type:    ManifestMutationCommitUpdates,
+					Updates: &packed.ManifestUpdates{DeltaLogs: []packed.DeltaLogEntry{{Path: basePath + "/_delta/1", NumEntries: 1}}},
+				},
+			})
+		}(segmentID, basePath)
+	}
+
+	for range basePaths {
+		select {
+		case <-entered:
+		case <-time.After(time.Second):
+			require.FailNow(t, "different segments blocked before manifest I/O")
+		}
+	}
+	close(release)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}
+
+func TestCommitSegmentManifestDoesNotSerializeCatalogWritesForDifferentSegments(t *testing.T) {
+	meta, err := newMemoryMeta(t)
+	require.NoError(t, err)
+	basePaths := map[int64]string{
+		206: "/tmp/milvus/insert_log/1/10/206",
+		207: "/tmp/milvus/insert_log/1/10/207",
+	}
+	for segmentID, basePath := range basePaths {
+		require.NoError(t, meta.AddSegment(context.Background(), NewSegmentInfo(&datapb.SegmentInfo{
+			ID:             segmentID,
+			State:          commonpb.SegmentState_Flushed,
+			StorageVersion: storage.StorageV3,
+			ManifestPath:   packed.MarshalManifestPath(basePath, 1),
+		})))
+	}
+
+	entered := make(chan struct{}, len(basePaths))
+	release := make(chan struct{})
+	meta.catalog = &blockingManifestCatalog{
+		entered: entered,
+		release: release,
+	}
+
+	errs := make(chan error, len(basePaths))
+	for segmentID, basePath := range basePaths {
+		go func(segmentID int64, basePath string) {
+			errs <- meta.CommitSegmentManifest(context.Background(), SegmentManifestCommit{
+				SegmentID:        segmentID,
+				ExpectedManifest: packed.MarshalManifestPath(basePath, 1),
+				Mutation: ManifestMutation{
+					Type:         ManifestMutationNoop,
+					ManifestPath: packed.MarshalManifestPath(basePath, 2),
+				},
+			})
+		}(segmentID, basePath)
+	}
+
+	for range basePaths {
+		select {
+		case <-entered:
+		case <-time.After(time.Second):
+			require.FailNow(t, "different segments serialized catalog writes behind segMu")
+		}
+	}
+	close(release)
+	for range basePaths {
+		require.NoError(t, <-errs)
+	}
+}
+
+type blockingManifestCatalog struct {
+	metastore.DataCoordCatalog
+	entered chan<- struct{}
+	release <-chan struct{}
+}
+
+func (c *blockingManifestCatalog) Update(context.Context, ...metastore.UpdateAction) error {
+	c.entered <- struct{}{}
+	<-c.release
+	return nil
+}
+
+func TestCommitSegmentManifestSerializesSameSegment(t *testing.T) {
+	const segmentID = 204
+	basePath := "/tmp/milvus/insert_log/1/10/204"
+	oldManifest := packed.MarshalManifestPath(basePath, 1)
+	newManifest := packed.MarshalManifestPath(basePath, 2)
+	meta, err := newMemoryMeta(t)
+	require.NoError(t, err)
+	require.NoError(t, meta.AddSegment(context.Background(), NewSegmentInfo(&datapb.SegmentInfo{
+		ID:             segmentID,
+		State:          commonpb.SegmentState_Flushed,
+		StorageVersion: storage.StorageV3,
+		ManifestPath:   oldManifest,
+	})))
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	commit := mockey.Mock(packed.CommitManifestUpdates).To(
+		func(string, int64, *indexpb.StorageConfig, *packed.ManifestUpdates) (string, error) {
+			close(entered)
+			<-release
+			return newManifest, nil
+		},
+	).Build()
+	defer commit.UnPatch()
+
+	request := SegmentManifestCommit{
+		SegmentID:        segmentID,
+		ExpectedManifest: oldManifest,
+		StorageConfig:    &indexpb.StorageConfig{},
+		Mutation: ManifestMutation{
+			Type:    ManifestMutationCommitUpdates,
+			Updates: &packed.ManifestUpdates{},
+		},
+	}
+	results := make(chan error, 2)
+	go func() { results <- meta.CommitSegmentManifest(context.Background(), request) }()
+	<-entered
+	go func() { results <- meta.CommitSegmentManifest(context.Background(), request) }()
+	close(release)
+
+	first, second := <-results, <-results
+	require.True(t, first == nil || second == nil)
+	stale := first
+	if stale == nil {
+		stale = second
+	}
+	require.ErrorIs(t, stale, merr.ErrServiceUnavailable)
+	require.Equal(t, newManifest, meta.GetSegment(context.Background(), segmentID).GetManifestPath())
+}
+
+func TestUpdateManifestRejectsStorageV3(t *testing.T) {
+	meta, err := newMemoryMeta(t)
+	require.NoError(t, err)
+	oldManifest := packed.MarshalManifestPath("/tmp/milvus/insert_log/1/10/205", 1)
+	newManifest := packed.MarshalManifestPath("/tmp/milvus/insert_log/1/10/205", 2)
+	require.NoError(t, meta.AddSegment(context.Background(), NewSegmentInfo(&datapb.SegmentInfo{
+		ID:             205,
+		State:          commonpb.SegmentState_Flushed,
+		StorageVersion: storage.StorageV3,
+		ManifestPath:   oldManifest,
+	})))
+
+	err = meta.UpdateSegmentsInfo(context.Background(), UpdateManifest(205, newManifest))
+	require.Error(t, err)
+	require.Equal(t, oldManifest, meta.GetSegment(context.Background(), 205).GetManifestPath())
+}

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -697,9 +697,14 @@ func (s *Server) SaveBinlogPaths(ctx context.Context, req *datapb.SaveBinlogPath
 			UpdateCheckPointOperator(req.GetSegmentID(), req.GetCheckPoints()))
 	}
 
-	// save manifest, start positions and checkpoints
+	// Save all metadata with the manifest pointer.  V3 pointer publication is
+	// serialized by CommitSegmentManifest; older formats retain UpdateManifest.
+	manifestSegment := s.meta.GetSegment(ctx, req.GetSegmentID())
+	v3ManifestCommit := manifestSegment != nil && manifestSegment.GetStorageVersion() == storage.StorageV3 && req.GetManifestPath() != ""
+	if !v3ManifestCommit {
+		operators = append(operators, UpdateManifest(req.GetSegmentID(), req.GetManifestPath()))
+	}
 	operators = append(operators,
-		UpdateManifest(req.GetSegmentID(), req.GetManifestPath()),
 		UpdateStartPosition(req.GetStartPositions()),
 		UpdateAsDroppedIfEmptyWhenFlushing(req.GetSegmentID()),
 		// The request ships the complete cumulative Statistics published
@@ -713,9 +718,23 @@ func (s *Server) SaveBinlogPaths(ctx context.Context, req *datapb.SaveBinlogPath
 	// Update segment info in memory and meta. Stale updates (segment already
 	// flushed / outdated time tick) are swallowed inside UpdateSegmentsInfo as
 	// benign no-ops, so any error here is a real failure.
-	if err := s.meta.UpdateSegmentsInfo(ctx, operators...); err != nil {
-		mlog.Error(context.TODO(), "save binlog and checkpoints failed", mlog.Err(err))
-		return merr.Status(err), nil
+	var updateErr error
+	if v3ManifestCommit {
+		updateErr = s.meta.CommitSegmentManifest(ctx, SegmentManifestCommit{
+			SegmentID:        req.GetSegmentID(),
+			ExpectedManifest: manifestSegment.GetManifestPath(),
+			Mutation: ManifestMutation{
+				Type:         ManifestMutationNoop,
+				ManifestPath: req.GetManifestPath(),
+			},
+			CatalogMutation: SegmentCatalogMutation{Operators: operators},
+		})
+	} else {
+		updateErr = s.meta.UpdateSegmentsInfo(ctx, operators...)
+	}
+	if updateErr != nil {
+		mlog.Error(ctx, "save binlog and checkpoints failed", mlog.Err(updateErr))
+		return merr.Status(updateErr), nil
 	}
 
 	s.meta.SetLastWrittenTime(req.GetSegmentID())

--- a/internal/datacoord/task_refresh_external_collection.go
+++ b/internal/datacoord/task_refresh_external_collection.go
@@ -27,7 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
 	globalTask "github.com/milvus-io/milvus/internal/datacoord/task"
-	"github.com/milvus-io/milvus/internal/metastore"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/internal/util/segmentutil"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -345,10 +345,60 @@ func applyExternalCollectionSegmentUpdateForBaseline(
 	}
 	upsertSegmentMap = normalizedUpsertSegmentMap
 
-	// Build update operators
-	var operators []UpdateOperator
-	alreadyAppliedNewSegments := make(map[int64]struct{})
+	// Each upsert performs the old operator's validation and metadata patch in
+	// the CatalogMutation, then publishes the prepared manifest in the same
+	// segment-scoped catalog write. NewSegment retains the old creation and
+	// metric behavior inside CommitSegmentManifest. External collections are
+	// StorageV3-only, so the worker's prepared manifest is a Noop mutation
+	// until it emits packed manifest deltas directly.
+	for _, incoming := range normalizedUpdatedSegments {
+		_, isPatch := baselineSegmentMap[incoming.GetID()]
+		existing := mt.GetSegment(ctx, incoming.GetID())
+		if !isPatch && existing != nil {
+			if externalRefreshNewSegmentAlreadyApplied(existing, incoming) {
+				mlog.Info(ctx, "new external refresh segment already applied, skipping replay",
+					mlog.FieldSegmentID(incoming.GetID()))
+				continue
+			}
+			return merr.WrapErrServiceInternalMsg("new external refresh segment %d collides with existing metadata", incoming.GetID())
+		}
+		if isPatch && existing == nil {
+			return merr.WrapErrServiceInternalMsg("baseline segment %d not found", incoming.GetID())
+		}
 
+		catalogMutation := SegmentCatalogMutation{}
+		if isPatch {
+			catalogMutation.Operators = []UpdateOperator{externalRefreshPatchOperator(ctx, incoming, collectionID)}
+		} else {
+			initial := proto.Clone(incoming).(*datapb.SegmentInfo)
+			initial.ManifestPath = ""
+			catalogMutation.NewSegment = initial
+		}
+		mlog.Info(ctx, "committing external refresh segment",
+			mlog.FieldSegmentID(incoming.GetID()),
+			mlog.Int64("numRows", incoming.GetNumOfRows()),
+			mlog.String("manifestPath", incoming.GetManifestPath()),
+			mlog.Bool("newSegment", catalogMutation.NewSegment != nil))
+		if err := mt.CommitSegmentManifest(ctx, SegmentManifestCommit{
+			SegmentID: incoming.GetID(),
+			Mutation: ManifestMutation{
+				Type:         ManifestMutationNoop,
+				ManifestPath: incoming.GetManifestPath(),
+			},
+			CatalogMutation: catalogMutation,
+		}); err != nil {
+			mlog.Warn(ctx, "failed to commit external refresh segment",
+				mlog.FieldSegmentID(incoming.GetID()), mlog.Err(err))
+			return err
+		}
+	}
+
+	// Apply destructive drops only after all replacement segments are durable.
+	// For an ownership plan this list is limited to its immutable baseline.
+	// Re-run the ownership validation while UpdateSegmentsInfo holds segMu.  The
+	// manifest commits above serialize each individual replacement, but cannot
+	// make the whole refresh atomic; this preserves the baseline/replay checks
+	// that the former all-in-one update performed immediately before dropping.
 	validationOperator := func(modPack *updateSegmentPack) bool {
 		for segmentID := range baselineSegmentMap {
 			existing := modPack.meta.segments.GetSegment(segmentID)
@@ -381,38 +431,11 @@ func applyExternalCollectionSegmentUpdateForBaseline(
 				continue
 			}
 			if err := validateExternalRefreshPatch(existing, incoming, collectionID); err != nil {
-				mlog.Warn(ctx, "invalid external refresh segment patch",
-					mlog.FieldSegmentID(incoming.GetID()),
-					mlog.Err(err))
 				return modPack.fail(err)
 			}
 		}
-
-		for segmentID := range upsertSegmentMap {
-			if _, isPatch := baselineSegmentMap[segmentID]; isPatch {
-				continue
-			}
-			existing := modPack.meta.segments.GetSegment(segmentID)
-			if existing == nil {
-				continue
-			}
-			if externalRefreshNewSegmentAlreadyApplied(existing, upsertSegmentMap[segmentID]) {
-				alreadyAppliedNewSegments[segmentID] = struct{}{}
-				mlog.Info(ctx, "new external refresh segment already applied, skipping replay",
-					mlog.FieldSegmentID(segmentID))
-				continue
-			}
-			return modPack.fail(merr.WrapErrServiceInternalMsg(
-				"new external refresh segment %d collides with existing metadata",
-				segmentID,
-			))
-		}
 		return true
 	}
-	operators = append(operators, validationOperator)
-
-	// Operator 1: Drop only the segment IDs selected during validation. For an
-	// ownership plan this list is limited to its immutable baseline.
 	dropOperator := func(modPack *updateSegmentPack) bool {
 		for _, segmentID := range segmentsToDrop {
 			current := modPack.meta.segments.GetSegment(segmentID)
@@ -429,56 +452,8 @@ func applyExternalCollectionSegmentUpdateForBaseline(
 		}
 		return true
 	}
-	operators = append(operators, dropOperator)
-
-	// Operator 2: Add new segments or patch existing active segments.
-	for _, seg := range normalizedUpdatedSegments {
-		incoming := seg
-		upsertOperator := func(modPack *updateSegmentPack) bool {
-			if _, ok := alreadyAppliedNewSegments[incoming.GetID()]; ok {
-				return true
-			}
-			existing := modPack.Get(incoming.GetID())
-			if existing != nil {
-				patched := applyExternalRefreshPatch(existing, incoming)
-				modPack.segments[incoming.GetID()] = patched
-				modPack.increments[incoming.GetID()] = metastore.BinlogsIncrement{
-					Segment: patched.SegmentInfo,
-				}
-				mlog.Info(ctx, "patching existing segment",
-					mlog.FieldSegmentID(incoming.GetID()),
-					mlog.Int64("numRows", incoming.GetNumOfRows()),
-					mlog.String("manifestPath", incoming.GetManifestPath()))
-				return true
-			}
-
-			segInfo := NewSegmentInfo(incoming)
-			modPack.segments[incoming.GetID()] = segInfo
-
-			modPack.increments[incoming.GetID()] = metastore.BinlogsIncrement{
-				Segment: incoming,
-			}
-
-			modPack.metricMutation.addNewSeg(
-				commonpb.SegmentState_Flushed,
-				incoming.GetLevel(),
-				incoming.GetIsSorted(),
-				incoming.GetStorageVersion(),
-				segmentMetricFormatLabel(segInfo),
-				incoming.GetNumOfRows(),
-			)
-
-			mlog.Info(ctx, "adding new segment",
-				mlog.FieldSegmentID(incoming.GetID()),
-				mlog.Int64("numRows", incoming.GetNumOfRows()))
-			return true
-		}
-		operators = append(operators, upsertOperator)
-	}
-
-	// Execute all operators atomically
-	if err := mt.UpdateSegmentsInfo(ctx, operators...); err != nil {
-		mlog.Warn(ctx, "failed to update segments atomically", mlog.Err(err))
+	if err := mt.UpdateSegmentsInfo(ctx, validationOperator, dropOperator); err != nil {
+		mlog.Warn(ctx, "failed to finalize external refresh segments", mlog.Err(err))
 		return err
 	}
 
@@ -496,6 +471,9 @@ func validateExternalRefreshUpdatedSegment(incoming *datapb.SegmentInfo, collect
 	}
 	if incoming.GetManifestPath() == "" {
 		return merr.WrapErrServiceInternalMsg("updated segment %d has empty manifest path", incoming.GetID())
+	}
+	if incoming.GetStorageVersion() != storage.StorageV3 {
+		return merr.WrapErrServiceInternalMsg("external collection segment %d must use StorageV3, got %d", incoming.GetID(), incoming.GetStorageVersion())
 	}
 	if len(incoming.GetBinlogs()) == 0 {
 		return merr.WrapErrServiceInternalMsg("updated segment %d has empty fake binlogs", incoming.GetID())
@@ -604,7 +582,6 @@ func validateExternalRefreshBinlogRowCount(segment *datapb.SegmentInfo, expected
 
 func applyExternalRefreshPatch(oldSeg *SegmentInfo, incoming *datapb.SegmentInfo) *SegmentInfo {
 	cloned := oldSeg.Clone()
-	cloned.ManifestPath = incoming.GetManifestPath()
 	cloned.SchemaVersion = incoming.GetSchemaVersion()
 	cloned.Binlogs = incoming.GetBinlogs()
 	cloned.TextStatsLogs = nil
@@ -613,6 +590,23 @@ func applyExternalRefreshPatch(oldSeg *SegmentInfo, incoming *datapb.SegmentInfo
 		cloned.StorageVersion = incoming.GetStorageVersion()
 	}
 	return cloned
+}
+
+func externalRefreshPatchOperator(ctx context.Context, incoming *datapb.SegmentInfo, collectionID int64) UpdateOperator {
+	return func(modPack *updateSegmentPack) bool {
+		existing := modPack.Get(incoming.GetID())
+		if err := validateExternalRefreshPatch(existing, incoming, collectionID); err != nil {
+			mlog.Warn(ctx, "invalid external refresh segment patch",
+				mlog.FieldSegmentID(incoming.GetID()), mlog.Err(err))
+			return modPack.fail(err)
+		}
+		modPack.segments[incoming.GetID()] = applyExternalRefreshPatch(existing, incoming)
+		mlog.Info(ctx, "patched external refresh segment",
+			mlog.FieldSegmentID(incoming.GetID()),
+			mlog.Int64("numRows", incoming.GetNumOfRows()),
+			mlog.String("manifestPath", incoming.GetManifestPath()))
+		return true
+	}
 }
 
 // getExternalRefreshSegmentSnapshots returns clones in the same order as

--- a/internal/datacoord/task_stats.go
+++ b/internal/datacoord/task_stats.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
 	globalTask "github.com/milvus-io/milvus/internal/datacoord/task"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -507,14 +508,38 @@ func (st *statsTask) SetJobInfo(ctx context.Context, result *workerpb.StatsResul
 	var err error
 	switch st.GetSubJobType() {
 	case indexpb.StatsSubJob_TextIndexJob:
-		err = st.meta.UpdateSegmentsInfo(ctx, updateStatsResultIfManifestMatches(ctx, st.GetSegmentID(), st.GetTaskID(), result))
+		if st.shouldPublishPreparedManifest(ctx, st.GetSegmentID(), result) {
+			err = st.meta.CommitSegmentManifest(ctx, SegmentManifestCommit{
+				SegmentID:        st.GetSegmentID(),
+				ExpectedManifest: result.GetBaseManifest(),
+				Mutation: ManifestMutation{
+					Type:         ManifestMutationNoop,
+					ManifestPath: result.GetManifest(),
+				},
+				CatalogMutation: SegmentCatalogMutation{TextStats: result.GetTextStatsLogs()},
+			})
+		} else {
+			err = st.meta.UpdateSegmentsInfo(ctx, updateStatsResultIfManifestMatches(ctx, st.GetSegmentID(), st.GetTaskID(), result))
+		}
 		if err != nil {
 			mlog.Warn(ctx, "save text index stats result failed", mlog.FieldTaskID(st.GetTaskID()),
 				mlog.FieldSegmentID(st.GetSegmentID()), mlog.Err(err))
 			break
 		}
 	case indexpb.StatsSubJob_JsonKeyIndexJob:
-		err = st.meta.UpdateSegmentsInfo(ctx, updateStatsResultIfManifestMatches(ctx, st.GetSegmentID(), st.GetTaskID(), result))
+		if st.shouldPublishPreparedManifest(ctx, st.GetSegmentID(), result) {
+			err = st.meta.CommitSegmentManifest(ctx, SegmentManifestCommit{
+				SegmentID:        st.GetSegmentID(),
+				ExpectedManifest: result.GetBaseManifest(),
+				Mutation: ManifestMutation{
+					Type:         ManifestMutationNoop,
+					ManifestPath: result.GetManifest(),
+				},
+				CatalogMutation: SegmentCatalogMutation{JSONKeyStats: result.GetJsonKeyStatsLogs()},
+			})
+		} else {
+			err = st.meta.UpdateSegmentsInfo(ctx, updateStatsResultIfManifestMatches(ctx, st.GetSegmentID(), st.GetTaskID(), result))
+		}
 		if err != nil {
 			mlog.Warn(ctx, "save json key index stats result failed", mlog.Int64("taskId", st.GetTaskID()),
 				mlog.FieldSegmentID(st.GetSegmentID()), mlog.Err(err))
@@ -561,7 +586,20 @@ func (st *statsTask) SetJobInfo(ctx context.Context, result *workerpb.StatsResul
 		if st.GetSubJobType() == indexpb.StatsSubJob_Sort {
 			segID = st.GetTargetSegmentID()
 		}
-		if updateErr := st.meta.UpdateSegmentsInfo(ctx, UpdateManifest(segID, manifest)); updateErr != nil {
+		var updateErr error
+		if st.shouldPublishPreparedManifest(ctx, segID, result) {
+			updateErr = st.meta.CommitSegmentManifest(ctx, SegmentManifestCommit{
+				SegmentID:        segID,
+				ExpectedManifest: result.GetBaseManifest(),
+				Mutation: ManifestMutation{
+					Type:         ManifestMutationNoop,
+					ManifestPath: manifest,
+				},
+			})
+		} else {
+			updateErr = st.meta.UpdateSegmentsInfo(ctx, UpdateManifest(segID, manifest))
+		}
+		if updateErr != nil {
 			mlog.Warn(ctx, "failed to update manifest after stats task",
 				mlog.FieldTaskID(st.GetTaskID()),
 				mlog.FieldSegmentID(segID),
@@ -576,6 +614,17 @@ func (st *statsTask) SetJobInfo(ctx context.Context, result *workerpb.StatsResul
 		mlog.Int64("oldSegmentID", st.GetSegmentID()), mlog.Int64("targetSegmentID", st.GetTargetSegmentID()),
 		mlog.String("subJobType", st.GetSubJobType().String()), mlog.String("state", st.GetState().String()))
 	return nil
+}
+
+// shouldPublishPreparedManifest identifies the temporary compatibility path
+// for workers which still return a prepared stats manifest, including the
+// first manifest. The Noop adapter keeps pointer publication serialized while
+// a follow-up changes workers to return structured deltas.
+func (st *statsTask) shouldPublishPreparedManifest(ctx context.Context, segmentID int64, result *workerpb.StatsResult) bool {
+	segment := st.meta.GetSegment(ctx, segmentID)
+	return segment != nil &&
+		segment.GetStorageVersion() == storage.StorageV3 &&
+		result.GetManifest() != ""
 }
 
 func updateStatsResultIfManifestMatches(ctx context.Context, segmentID, taskID int64, result *workerpb.StatsResult) UpdateOperator {
@@ -603,6 +652,10 @@ func updateStatsResultIfManifestMatches(ctx context.Context, segmentID, taskID i
 		manifestChanged := result.GetManifest() != "" && current.GetManifestPath() != result.GetManifest()
 		if !hasTextStats && !hasJSONStats && !manifestChanged {
 			return false
+		}
+		if manifestChanged && current.GetStorageVersion() == storage.StorageV3 {
+			return modPack.fail(merr.WrapErrServiceInternalMsg(
+				"StorageV3 stats manifest publication must use CommitSegmentManifest, segmentID=%d", segmentID))
 		}
 
 		segment := modPack.Get(segmentID)


### PR DESCRIPTION
issue: #51723

design: docs/design-docs/design_docs/20260817-datacoord-segment-manifest-commit.md

## What this PR does

- adds a per-segment StorageV3 manifest-commit protocol that serializes object-store mutation and catalog publication while keeping `segMu` out of manifest I/O;
- makes catalog mutation and visible manifest pointer one catalog write, including initial segment creation;
- routes current DataCoord StorageV3 writers through a validated `Noop` adapter while their producers still return prepared manifests;
- rejects direct StorageV3 `UpdateManifest` publication and adds lock/contention, stale-base, catalog-failure, and initial-publication coverage.

## Compatibility

StorageV1/V2 keep their existing `UpdateManifest` path. The compatibility adapter is intentionally temporary: producer-side structured manifest mutations are a follow-up.

## Validation

- `make test-datacoord` (Milvus builder container)
- `make verifiers` (Milvus builder container)
- `git diff --check`

## Follow-up

This PR does not change how workers generate a manifest. It only centralizes validation and publication of their prepared result, as scoped by the accompanying design.