### PR TITLE
enhance: refresh query target after compacting import-produced L0 segments

### DIFF
--- a/internal/datacoord/compaction_inspector.go
+++ b/internal/datacoord/compaction_inspector.go
@@ -30,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/task"
+	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
@@ -89,6 +90,7 @@ type compactionInspector struct {
 	handler          Handler
 	scheduler        task.GlobalScheduler
 	ievm             IndexEngineVersionManager
+	mixCoord         types.MixCoord
 
 	stopCh   chan struct{}
 	stopOnce sync.Once
@@ -180,7 +182,7 @@ func (c *compactionInspector) getCompactionTasksNumBySignalID(triggerID int64) i
 }
 
 func newCompactionInspector(meta CompactionMeta,
-	allocator allocator.Allocator, handler Handler, scheduler task.GlobalScheduler, analyzeScheduler task.GlobalScheduler, ievm IndexEngineVersionManager,
+	allocator allocator.Allocator, handler Handler, scheduler task.GlobalScheduler, analyzeScheduler task.GlobalScheduler, ievm IndexEngineVersionManager, mixCoord types.MixCoord,
 ) *compactionInspector {
 	capacity := paramtable.Get().DataCoordCfg.CompactionTaskQueueCapacity.GetAsInt()
 	return &compactionInspector{
@@ -194,6 +196,7 @@ func newCompactionInspector(meta CompactionMeta,
 		scheduler:        scheduler,
 		analyzeScheduler: analyzeScheduler,
 		ievm:             ievm,
+		mixCoord:         mixCoord,
 	}
 }
 
@@ -596,7 +599,7 @@ func (c *compactionInspector) createCompactTask(t *datapb.CompactionTask) (Compa
 	case datapb.CompactionType_MixCompaction, datapb.CompactionType_SortCompaction:
 		task = newMixCompactionTask(t, c.allocator, c.meta, c.ievm)
 	case datapb.CompactionType_Level0DeleteCompaction:
-		task = newL0CompactionTask(t, c.allocator, c.meta)
+		task = newL0CompactionTask(t, c.allocator, c.meta, c.mixCoord)
 	case datapb.CompactionType_ClusteringCompaction:
 		task = newClusteringCompactionTask(t, c.allocator, c.meta, c.handler, c.analyzeScheduler, c.ievm)
 	case datapb.CompactionType_BumpSchemaVersionCompaction:

--- a/internal/datacoord/compaction_inspector_test.go
+++ b/internal/datacoord/compaction_inspector_test.go
@@ -63,7 +63,7 @@ func (s *CompactionPlanHandlerSuite) SetupTest() {
 	mockAlloc.EXPECT().AllocTimestamp(mock.Anything).Return(uint64(1000), nil).Maybe()
 	s.mockAlloc = mockAlloc
 	mockScheduler := task.NewMockGlobalScheduler(s.T())
-	s.handler = newCompactionInspector(s.mockMeta, s.mockAlloc, nil, mockScheduler, mockScheduler, newMockVersionManager())
+	s.handler = newCompactionInspector(s.mockMeta, s.mockAlloc, nil, mockScheduler, mockScheduler, newMockVersionManager(), nil)
 	s.mockHandler = NewNMockHandler(s.T())
 	s.mockHandler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(&collectionInfo{}, nil).Maybe()
 }
@@ -143,14 +143,14 @@ func (s *CompactionPlanHandlerSuite) TestScheduleNodeWith1ParallelTask() {
 					State:   datapb.CompactionTaskState_pipelining,
 					Channel: "ch-10",
 					NodeID:  101,
-				}, nil, s.mockMeta),
+				}, nil, s.mockMeta, nil),
 				newL0CompactionTask(&datapb.CompactionTask{
 					PlanID:  11,
 					Type:    datapb.CompactionType_MixCompaction,
 					State:   datapb.CompactionTaskState_pipelining,
 					Channel: "ch-11",
 					NodeID:  101,
-				}, nil, s.mockMeta),
+				}, nil, s.mockMeta, nil),
 			},
 			[]*datapb.CompactionPlan{
 				{PlanID: 10, Channel: "ch-10", Type: datapb.CompactionType_Level0DeleteCompaction},
@@ -174,7 +174,7 @@ func (s *CompactionPlanHandlerSuite) TestScheduleNodeWith1ParallelTask() {
 					State:   datapb.CompactionTaskState_pipelining,
 					Channel: "ch-11",
 					NodeID:  101,
-				}, nil, s.mockMeta),
+				}, nil, s.mockMeta, nil),
 			},
 			[]*datapb.CompactionPlan{
 				{PlanID: 11, Channel: "ch-11", Type: datapb.CompactionType_MixCompaction},
@@ -251,7 +251,7 @@ func (s *CompactionPlanHandlerSuite) TestScheduleNodeWithL0Executing() {
 					State:   datapb.CompactionTaskState_pipelining,
 					Channel: "ch-10",
 					NodeID:  102,
-				}, nil, s.mockMeta),
+				}, nil, s.mockMeta, nil),
 				newMixCompactionTask(&datapb.CompactionTask{
 					PlanID:  11,
 					Type:    datapb.CompactionType_MixCompaction,
@@ -272,7 +272,7 @@ func (s *CompactionPlanHandlerSuite) TestScheduleNodeWithL0Executing() {
 					State:   datapb.CompactionTaskState_pipelining,
 					Channel: "ch-11",
 					NodeID:  102,
-				}, nil, s.mockMeta),
+				}, nil, s.mockMeta, nil),
 				newMixCompactionTask(&datapb.CompactionTask{
 					PlanID:  11,
 					Type:    datapb.CompactionType_MixCompaction,
@@ -304,21 +304,21 @@ func (s *CompactionPlanHandlerSuite) TestScheduleNodeWithL0Executing() {
 					State:   datapb.CompactionTaskState_pipelining,
 					Channel: "ch-11",
 					NodeID:  102,
-				}, nil, s.mockMeta),
+				}, nil, s.mockMeta, nil),
 				newL0CompactionTask(&datapb.CompactionTask{
 					PlanID:  11,
 					Type:    datapb.CompactionType_Level0DeleteCompaction,
 					State:   datapb.CompactionTaskState_pipelining,
 					Channel: "ch-11",
 					NodeID:  102,
-				}, nil, s.mockMeta),
+				}, nil, s.mockMeta, nil),
 				newL0CompactionTask(&datapb.CompactionTask{
 					PlanID:  12,
 					Type:    datapb.CompactionType_Level0DeleteCompaction,
 					State:   datapb.CompactionTaskState_pipelining,
 					Channel: "ch-11",
 					NodeID:  102,
-				}, nil, s.mockMeta),
+				}, nil, s.mockMeta, nil),
 			},
 			[]*datapb.CompactionPlan{
 				{PlanID: 10, Channel: "ch-3", Type: datapb.CompactionType_Level0DeleteCompaction},
@@ -381,7 +381,7 @@ func (s *CompactionPlanHandlerSuite) TestSchedule_BumpSchemaVersionConflictsWith
 		Channel:     "ch-1",
 		PartitionID: 10,
 		NodeID:      102,
-	}, nil, s.mockMeta)
+	}, nil, s.mockMeta, nil)
 	s.NoError(s.handler.submitTask(newBumpSchemaVersionTask(&datapb.CompactionTask{
 		PlanID:      2,
 		Type:        datapb.CompactionType_BumpSchemaVersionCompaction,
@@ -417,7 +417,7 @@ func (s *CompactionPlanHandlerSuite) TestSchedule_BumpSchemaVersionBlocksQueuedL
 		Channel:     "ch-1",
 		PartitionID: 10,
 		NodeID:      102,
-	}, nil, s.mockMeta)))
+	}, nil, s.mockMeta, nil)))
 
 	gotTasks := s.handler.schedule()
 	s.Equal([]UniqueID{2}, lo.Map(gotTasks, func(t CompactionTask, _ int) int64 {
@@ -506,7 +506,7 @@ func (s *CompactionPlanHandlerSuite) TestGetCompactionTask() {
 		Type:      datapb.CompactionType_Level0DeleteCompaction,
 		Channel:   "ch-02",
 		State:     datapb.CompactionTaskState_failed,
-	}, nil, s.mockMeta)
+	}, nil, s.mockMeta, nil)
 
 	inTasks := map[int64]CompactionTask{
 		1: t1,
@@ -548,7 +548,7 @@ func (s *CompactionPlanHandlerSuite) TestCompactionQueueFull() {
 			t.QueryTaskOnWorker(cluster)
 		}
 	}).Maybe()
-	s.handler = newCompactionInspector(s.mockMeta, s.mockAlloc, nil, mockScheduler, mockScheduler, newMockVersionManager())
+	s.handler = newCompactionInspector(s.mockMeta, s.mockAlloc, nil, mockScheduler, mockScheduler, newMockVersionManager(), nil)
 
 	t1 := newMixCompactionTask(&datapb.CompactionTask{
 		TriggerID: 1,
@@ -583,7 +583,7 @@ func (s *CompactionPlanHandlerSuite) TestExecCompactionPlan() {
 			t.QueryTaskOnWorker(cluster)
 		}
 	}).Maybe()
-	handler := newCompactionInspector(s.mockMeta, s.mockAlloc, nil, mockScheduler, mockScheduler, newMockVersionManager())
+	handler := newCompactionInspector(s.mockMeta, s.mockAlloc, nil, mockScheduler, mockScheduler, newMockVersionManager(), nil)
 
 	task := &datapb.CompactionTask{
 		TriggerID: 1,
@@ -885,7 +885,7 @@ func (s *CompactionPlanHandlerSuite) TestCleanCompaction() {
 				NodeID:        1,
 				InputSegments: []UniqueID{1, 2},
 			},
-				nil, s.mockMeta),
+				nil, s.mockMeta, nil),
 		},
 	}
 	for _, test := range tests {
@@ -1105,7 +1105,7 @@ func TestCheckDelay(t *testing.T) {
 	handler.checkDelay(t1)
 	t2 := newL0CompactionTask(&datapb.CompactionTask{
 		StartTime: time.Now().Add(-100 * time.Minute).Unix(),
-	}, nil, nil)
+	}, nil, nil, nil)
 	handler.checkDelay(t2)
 	t3 := newClusteringCompactionTask(&datapb.CompactionTask{
 		StartTime: time.Now().Add(-100 * time.Minute).Unix(),
@@ -1131,7 +1131,7 @@ func TestGetCompactionTasksNum(t *testing.T) {
 			StartTime:    time.Now().Add(-100 * time.Minute).Unix(),
 			CollectionID: 1,
 			Type:         datapb.CompactionType_Level0DeleteCompaction,
-		}, nil, nil),
+		}, nil, nil, nil),
 	)
 	queueTasks.Enqueue(
 		newClusteringCompactionTask(&datapb.CompactionTask{
@@ -1150,7 +1150,7 @@ func TestGetCompactionTasksNum(t *testing.T) {
 		StartTime:    time.Now().Add(-100 * time.Minute).Unix(),
 		CollectionID: 10,
 		Type:         datapb.CompactionType_Level0DeleteCompaction,
-	}, nil, nil)
+	}, nil, nil, nil)
 
 	handler := &compactionInspector{
 		queueTasks:     queueTasks,
@@ -1181,7 +1181,7 @@ func (s *CompactionPlanHandlerSuite) TestCreateCompactTask_BumpSchemaVersionComp
 
 	mockScheduler := task.NewMockGlobalScheduler(s.T())
 	mockScheduler.EXPECT().Enqueue(mock.Anything).Maybe()
-	handler := newCompactionInspector(s.mockMeta, s.mockAlloc, nil, mockScheduler, mockScheduler, newMockVersionManager())
+	handler := newCompactionInspector(s.mockMeta, s.mockAlloc, nil, mockScheduler, mockScheduler, newMockVersionManager(), nil)
 
 	t := &datapb.CompactionTask{
 		TriggerID: 1,
@@ -1229,7 +1229,7 @@ func (s *CompactionPlanHandlerSuite) TestCreateCompactTaskRejectsSnapshotProtect
 				State:        commonpb.SegmentState_Flushed,
 				Level:        datapb.SegmentLevel_L1,
 			}})
-			inspector := newCompactionInspector(meta, nil, nil, nil, nil, newMockVersionManager())
+			inspector := newCompactionInspector(meta, nil, nil, nil, nil, newMockVersionManager(), nil)
 
 			compactTask, err := inspector.createCompactTask(&datapb.CompactionTask{
 				PlanID:        10,
@@ -1249,7 +1249,7 @@ func (s *CompactionPlanHandlerSuite) TestCreateCompactTask_UnknownType() {
 	s.SetupTest()
 
 	mockScheduler := task.NewMockGlobalScheduler(s.T())
-	handler := newCompactionInspector(s.mockMeta, s.mockAlloc, nil, mockScheduler, mockScheduler, newMockVersionManager())
+	handler := newCompactionInspector(s.mockMeta, s.mockAlloc, nil, mockScheduler, mockScheduler, newMockVersionManager(), nil)
 
 	t := &datapb.CompactionTask{
 		TriggerID: 2,

--- a/internal/datacoord/compaction_task_l0.go
+++ b/internal/datacoord/compaction_task_l0.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"go.uber.org/atomic"
 	"google.golang.org/protobuf/proto"
 
@@ -29,11 +30,14 @@ import (
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/taskcommon"
+	"github.com/milvus-io/milvus/pkg/v3/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
@@ -45,6 +49,7 @@ type l0CompactionTask struct {
 
 	allocator allocator.Allocator
 	meta      CompactionMeta
+	mixCoord  types.MixCoord
 
 	times                *taskcommon.Times
 	committedV3Manifests map[int64]string
@@ -176,6 +181,7 @@ func (t *l0CompactionTask) QueryTaskOnWorker(cluster session.Cluster) {
 			return
 		}
 		UpdateCompactionSegmentSizeMetrics(result.GetSegments())
+		t.refreshQueryTargetIfImport()
 		t.processMetaSaved()
 	case datapb.CompactionTaskState_pipelining, datapb.CompactionTaskState_executing:
 		return
@@ -217,10 +223,11 @@ func (t *l0CompactionTask) GetTaskProto() *datapb.CompactionTask {
 	return task.(*datapb.CompactionTask)
 }
 
-func newL0CompactionTask(t *datapb.CompactionTask, allocator allocator.Allocator, meta CompactionMeta) *l0CompactionTask {
+func newL0CompactionTask(t *datapb.CompactionTask, allocator allocator.Allocator, meta CompactionMeta, mixCoord types.MixCoord) *l0CompactionTask {
 	task := &l0CompactionTask{
 		allocator:            allocator,
 		meta:                 meta,
+		mixCoord:             mixCoord,
 		times:                taskcommon.NewTimes(),
 		committedV3Manifests: make(map[int64]string),
 	}
@@ -426,6 +433,41 @@ func (t *l0CompactionTask) hasImportProducedInput() bool {
 		}
 	}
 	return false
+}
+
+// refreshQueryTargetIfImport asks QueryCoord to refresh its next target for
+// this task's collection when the completed compaction's input included an
+// import-produced L0 segment. The RPC runs in a background goroutine; its
+// outcome does not affect the caller.
+func (t *l0CompactionTask) refreshQueryTargetIfImport() {
+	if t.mixCoord == nil {
+		return
+	}
+	if !t.hasImportProducedInput() {
+		return
+	}
+	collectionID := t.GetTaskProto().GetCollectionID()
+	planID := t.GetTaskProto().GetPlanID()
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), paramtable.Get().DataCoordCfg.RequestTimeoutSeconds.GetAsDuration(time.Second))
+		defer cancel()
+		resp, err := t.mixCoord.LoadCollection(ctx, &querypb.LoadCollectionRequest{
+			Base:         commonpbutil.NewMsgBase(commonpbutil.WithMsgType(commonpb.MsgType_LoadCollection)),
+			CollectionID: collectionID,
+			Refresh:      true,
+		})
+		err = merr.CheckRPCCall(resp, err)
+		if err == nil {
+			return
+		}
+		if errors.Is(err, merr.ErrCollectionNotLoaded) {
+			mlog.Info(ctx, "skip query target refresh after l0 compaction, collection not loaded",
+				mlog.Int64("planID", planID), mlog.FieldCollectionID(collectionID), mlog.Err(err))
+			return
+		}
+		mlog.Warn(ctx, "query target refresh after l0 compaction failed",
+			mlog.Int64("planID", planID), mlog.FieldCollectionID(collectionID), mlog.Err(err))
+	}()
 }
 
 func (t *l0CompactionTask) hasAssignedWorker() bool {

--- a/internal/datacoord/compaction_task_l0.go
+++ b/internal/datacoord/compaction_task_l0.go
@@ -413,6 +413,21 @@ func (t *l0CompactionTask) resetSegmentCompacting() {
 	t.meta.SetSegmentsCompacting(context.TODO(), t.GetTaskProto().GetInputSegments(), false)
 }
 
+// hasImportProducedInput reports whether any input L0 segment carries a commit timestamp,
+// which only an import job's segments do.
+func (t *l0CompactionTask) hasImportProducedInput() bool {
+	for _, segID := range t.GetTaskProto().GetInputSegments() {
+		segment := t.meta.GetSegment(context.TODO(), segID)
+		if segment == nil {
+			continue
+		}
+		if segment.GetCommitTimestamp() != 0 {
+			return true
+		}
+	}
+	return false
+}
+
 func (t *l0CompactionTask) hasAssignedWorker() bool {
 	return t.GetTaskProto().GetNodeID() != 0 && t.GetTaskProto().GetNodeID() != NullNodeID
 }

--- a/internal/datacoord/compaction_task_l0_test.go
+++ b/internal/datacoord/compaction_task_l0_test.go
@@ -801,3 +801,71 @@ func TestSelectFlushedSegment_RespectsCommitTimestamp(t *testing.T) {
 		assert.Equal(t, int64(777), selected[0].GetID())
 	})
 }
+
+// TestL0CompactionTask_HasImportProducedInput verifies that hasImportProducedInput
+// distinguishes import-produced L0 segments (non-zero CommitTimestamp, stamped by
+// HandleCommitVchannel) from streaming-produced L0 segments (CommitTimestamp == 0).
+func TestL0CompactionTask_HasImportProducedInput(t *testing.T) {
+	streamingL0 := &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+		ID:              100,
+		Level:           datapb.SegmentLevel_L0,
+		CommitTimestamp: 0,
+	}}
+	importL0 := &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+		ID:              101,
+		Level:           datapb.SegmentLevel_L0,
+		CommitTimestamp: 5000,
+	}}
+	droppedImportL0 := &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+		ID:              102,
+		Level:           datapb.SegmentLevel_L0,
+		State:           commonpb.SegmentState_Dropped,
+		CommitTimestamp: 5000,
+	}}
+	segments := map[int64]*SegmentInfo{
+		100: streamingL0,
+		101: importL0,
+		102: droppedImportL0,
+	}
+
+	makeTask := func(inputSegments []int64) *l0CompactionTask {
+		mockMeta := NewMockCompactionMeta(t)
+		mockMeta.EXPECT().GetSegment(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, segID int64) *SegmentInfo {
+				return segments[segID]
+			},
+		).Maybe()
+		return newL0CompactionTask(&datapb.CompactionTask{
+			PlanID:        1,
+			TriggerID:     19530,
+			CollectionID:  1,
+			PartitionID:   10,
+			Type:          datapb.CompactionType_Level0DeleteCompaction,
+			State:         datapb.CompactionTaskState_executing,
+			InputSegments: inputSegments,
+		}, nil, mockMeta)
+	}
+
+	t.Run("streaming only", func(t *testing.T) {
+		task := makeTask([]int64{100})
+		assert.False(t, task.hasImportProducedInput())
+	})
+
+	t.Run("contains an import L0", func(t *testing.T) {
+		task := makeTask([]int64{100, 101})
+		assert.True(t, task.hasImportProducedInput())
+	})
+
+	t.Run("missing segment", func(t *testing.T) {
+		task := makeTask([]int64{999})
+		assert.False(t, task.hasImportProducedInput())
+	})
+
+	t.Run("dropped but import-produced", func(t *testing.T) {
+		// The predicate must recognize an import-produced L0 even after
+		// saveSegmentMeta has marked it Dropped, since that is the state
+		// it will actually observe when called post-compaction.
+		task := makeTask([]int64{102})
+		assert.True(t, task.hasImportProducedInput())
+	})
+}

--- a/internal/datacoord/compaction_task_l0_test.go
+++ b/internal/datacoord/compaction_task_l0_test.go
@@ -18,7 +18,9 @@ package datacoord
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
@@ -30,7 +32,9 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
+	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
@@ -121,7 +125,7 @@ func (s *L0CompactionTaskSuite) TestProcessRefreshPlan_NormalL0() {
 		NodeID:        1,
 		State:         datapb.CompactionTaskState_executing,
 		InputSegments: []int64{100, 101},
-	}, nil, s.mockMeta)
+	}, nil, s.mockMeta, nil)
 	alloc := allocator.NewMockAllocator(s.T())
 	alloc.EXPECT().AllocN(mock.Anything).Return(100, 200, nil)
 	task.allocator = alloc
@@ -151,7 +155,7 @@ func (s *L0CompactionTaskSuite) TestProcessRefreshPlan_SegmentNotFoundL0() {
 		Type:          datapb.CompactionType_Level0DeleteCompaction,
 		NodeID:        1,
 		State:         datapb.CompactionTaskState_executing,
-	}, nil, s.mockMeta)
+	}, nil, s.mockMeta, nil)
 
 	_, err := task.BuildCompactionRequest()
 	s.Error(err)
@@ -181,7 +185,7 @@ func (s *L0CompactionTaskSuite) TestProcessRefreshPlan_SelectZeroSegmentsL0() {
 		NodeID:        1,
 		State:         datapb.CompactionTaskState_executing,
 		InputSegments: []int64{100, 101},
-	}, nil, s.mockMeta)
+	}, nil, s.mockMeta, nil)
 	plan, err := task.BuildCompactionRequest()
 	// Fast finish: should return a plan with only L0 segments (no error)
 	s.NoError(err)
@@ -238,7 +242,7 @@ func (s *L0CompactionTaskSuite) TestBuildCompactionRequestFailed_AllocFailed() {
 		NodeID:        1,
 		State:         datapb.CompactionTaskState_executing,
 		InputSegments: []int64{100, 101},
-	}, s.mockAlloc, s.mockMeta)
+	}, s.mockAlloc, s.mockMeta, nil)
 
 	s.mockAlloc.EXPECT().AllocN(mock.Anything).Return(0, 0, errors.New("mock alloc err"))
 
@@ -258,7 +262,7 @@ func (s *L0CompactionTaskSuite) generateTestL0Task(state datapb.CompactionTaskSt
 		State:         state,
 		Channel:       "ch-1",
 		InputSegments: []int64{100, 101},
-	}, s.mockAlloc, s.mockMeta)
+	}, s.mockAlloc, s.mockMeta, nil)
 }
 
 func (s *L0CompactionTaskSuite) TestPorcessStateTrans() {
@@ -702,7 +706,7 @@ func (s *L0CompactionTaskSuite) TestSelectFlushedSegment_ForceSelectAllFlag() {
 			State:         datapb.CompactionTaskState_executing,
 			InputSegments: []int64{100, 101},
 			Pos:           triggeredView.latestDeletePos,
-		}, nil, s.mockMeta)
+		}, nil, s.mockMeta, nil)
 
 		flushed, _, err := task.selectFlushedSegment()
 		s.Require().NoError(err)
@@ -781,7 +785,7 @@ func TestSelectFlushedSegment_RespectsCommitTimestamp(t *testing.T) {
 			Type:         datapb.CompactionType_Level0DeleteCompaction,
 			Channel:      channel,
 			Pos:          &msgpb.MsgPosition{Timestamp: triggerTs},
-		}, mockAlloc, mockMeta)
+		}, mockAlloc, mockMeta, nil)
 	}
 
 	t.Run("import segment not selected when trigger pos < commit_timestamp", func(t *testing.T) {
@@ -843,7 +847,7 @@ func TestL0CompactionTask_HasImportProducedInput(t *testing.T) {
 			Type:          datapb.CompactionType_Level0DeleteCompaction,
 			State:         datapb.CompactionTaskState_executing,
 			InputSegments: inputSegments,
-		}, nil, mockMeta)
+		}, nil, mockMeta, nil)
 	}
 
 	t.Run("streaming only", func(t *testing.T) {
@@ -867,5 +871,96 @@ func TestL0CompactionTask_HasImportProducedInput(t *testing.T) {
 		// it will actually observe when called post-compaction.
 		task := makeTask([]int64{102})
 		assert.True(t, task.hasImportProducedInput())
+	})
+}
+
+// TestL0CompactionTask_RefreshQueryTargetIfImport verifies that
+// refreshQueryTargetIfImport asks QueryCoord to refresh the next target exactly
+// when the input L0 segments include an import-produced one, and that the
+// refresh runs asynchronously without affecting the caller.
+func TestL0CompactionTask_RefreshQueryTargetIfImport(t *testing.T) {
+	const collectionID = int64(42)
+
+	streamingL0 := &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+		ID:              100,
+		Level:           datapb.SegmentLevel_L0,
+		CommitTimestamp: 0,
+	}}
+	importL0 := &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+		ID:              101,
+		Level:           datapb.SegmentLevel_L0,
+		CommitTimestamp: 5000,
+	}}
+	segments := map[int64]*SegmentInfo{
+		100: streamingL0,
+		101: importL0,
+	}
+
+	makeTask := func(t *testing.T, inputSegments []int64, mixCoord *mocks.MixCoord) *l0CompactionTask {
+		mockMeta := NewMockCompactionMeta(t)
+		mockMeta.EXPECT().GetSegment(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, segID int64) *SegmentInfo {
+				return segments[segID]
+			},
+		).Maybe()
+		return newL0CompactionTask(&datapb.CompactionTask{
+			PlanID:        1,
+			TriggerID:     19530,
+			CollectionID:  collectionID,
+			PartitionID:   10,
+			Type:          datapb.CompactionType_Level0DeleteCompaction,
+			State:         datapb.CompactionTaskState_executing,
+			InputSegments: inputSegments,
+		}, nil, mockMeta, mixCoord)
+	}
+
+	t.Run("import L0 triggers exactly one refresh", func(t *testing.T) {
+		var calls atomic.Int64
+		mixCoord := mocks.NewMixCoord(t)
+		mixCoord.EXPECT().LoadCollection(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, req *querypb.LoadCollectionRequest) (*commonpb.Status, error) {
+				assert.True(t, req.GetRefresh())
+				assert.EqualValues(t, collectionID, req.GetCollectionID())
+				calls.Add(1)
+				return merr.Success(), nil
+			},
+		).Once()
+
+		task := makeTask(t, []int64{100, 101}, mixCoord)
+		task.refreshQueryTargetIfImport()
+
+		assert.Eventually(t, func() bool {
+			return calls.Load() == 1
+		}, time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("streaming-only L0 triggers no refresh", func(t *testing.T) {
+		// No LoadCollection expectation is registered, so any call fails the test.
+		mixCoord := mocks.NewMixCoord(t)
+		task := makeTask(t, []int64{100}, mixCoord)
+		task.refreshQueryTargetIfImport()
+		time.Sleep(100 * time.Millisecond)
+	})
+
+	t.Run("refresh failure does not affect compaction", func(t *testing.T) {
+		mixCoord := mocks.NewMixCoord(t)
+		called := make(chan struct{})
+		mixCoord.EXPECT().LoadCollection(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, req *querypb.LoadCollectionRequest) (*commonpb.Status, error) {
+				close(called)
+				return nil, errors.New("mock rpc error")
+			},
+		).Once()
+
+		task := makeTask(t, []int64{101}, mixCoord)
+		assert.NotPanics(t, func() {
+			task.refreshQueryTargetIfImport()
+		})
+
+		select {
+		case <-called:
+		case <-time.After(time.Second):
+			t.Fatal("LoadCollection was never called")
+		}
 	})
 }

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -682,7 +682,7 @@ func (s *Server) initExternalCollectionInspector(storageCli storage.ChunkManager
 }
 
 func (s *Server) initCompaction() {
-	cph := newCompactionInspector(s.meta, s.allocator, s.handler, s.globalScheduler, s.globalScheduler, s.indexEngineVersionManager)
+	cph := newCompactionInspector(s.meta, s.allocator, s.handler, s.globalScheduler, s.globalScheduler, s.indexEngineVersionManager, s.mixCoord)
 	cph.loadMeta()
 	s.compactionInspector = cph
 	s.compactionTriggerManager = NewCompactionTriggerManager(s.allocator, s.handler, s.compactionInspector, s.meta, s.indexEngineVersionManager)

--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -1814,7 +1814,7 @@ func TestGetCompactionState(t *testing.T) {
 				{State: datapb.CompactionTaskState_timeout},
 				{State: datapb.CompactionTaskState_timeout},
 			})
-		mockHandler := newCompactionInspector(mockMeta, nil, nil, nil, nil, newMockVersionManager())
+		mockHandler := newCompactionInspector(mockMeta, nil, nil, nil, nil, newMockVersionManager(), nil)
 		svr.compactionInspector = mockHandler
 		resp, err := svr.GetCompactionState(context.Background(), &milvuspb.GetCompactionStateRequest{CompactionID: 1})
 		assert.NoError(t, err)


### PR DESCRIPTION
## Summary

Cuts up to five minutes off the time an import-produced delete takes to become visible on a loaded collection, by asking QueryCoord for a fresh target at the moment the delete actually becomes deliverable.

issue: #52567

### The stall

An import-produced delete reaches an **already-loaded** data segment through exactly one chain:

```
L0 compaction folds the delete into the target segment's deltalog
  and advances that segment's manifest
    -> SegmentChecker.isSegmentUpdate compares dist against the target
       and sees the newer manifest
      -> segment Reopen
```

`isSegmentUpdate` reads the **next** target, and the next target is re-pulled only on expiry — `queryCoord.NextTargetSurviveTime`, 300s by default. So a compaction that has already made the delete deliverable can go unnoticed for up to five minutes.

### The change

After `saveSegmentMeta` succeeds in the L0 compaction task — which is the moment the target segments' manifests advance — DataCoord asynchronously calls `LoadCollection(refresh=true)` so QueryCoord re-pulls the target immediately.

Mounting it anywhere earlier would be wrong: at the import's commit fence the L0 has only just landed, compaction has not run, and no target segment's manifest has changed yet.

**The refresh fires only for compactions that consumed an import-produced L0**, identified by a non-zero `CommitTimestamp` on an input segment. The 2PC commit fence stamps every segment of an import job including its L0s; a streaming-produced L0 never carries one. This matters because L0 compaction runs continuously on any write-active collection — refreshing on each one would multiply `GetRecoveryInfoV2` load cluster-wide. A streaming-only compaction does strictly nothing new: no goroutine, no RPC, no extra meta read beyond the predicate.

Best-effort and asynchronous. The compaction result is already durable, so a failed refresh costs only latency — the target still expires on its own. `ErrCollectionNotLoaded` is the ordinary case for a collection nobody queries and is logged at Info; any other failure at Warn.

### Scope

This is independent of the file-based delete/upsert feature in #52570. It keys off `CommitTimestamp` and `LoadCollection`, both already present, so it also shortens the same stall for the existing `l0_import` backup-restore path.

## Test Plan

- [x] Unit tests for the predicate: streaming-only input, mixed input, missing segment, and a Dropped-but-import-produced input (the state the predicate actually sees, since it runs after `saveSegmentMeta` marks inputs Dropped)
- [x] Unit tests for the refresh: exactly one refresh for an import L0, no refresh at all for streaming-only, and a failing refresh neither panicking nor blocking
- [x] `make static-check` — 0 issues across all four modules
- [x] `go test ./internal/datacoord/...` — all packages green

### Evidence boundary, stated rather than glossed

**There is no end-to-end test in this PR, deliberately.** An integration test exists locally but does not demonstrate this change's benefit: a freshly-loaded MiniCluster re-pulls its next target for unrelated reasons, so the 300s expiry this change exists to avoid never arises there. In one such run the delete converged in roughly 21s of polling *without* this change. Logs confirm the refresh fires and precedes the Reopen, but isolating its benefit needs a scenario where the target is otherwise allowed to go stale. Shipping that test here would give false confidence, so it is held back until it can prove something.

### Failure paths traced by hand

- **Compaction failure then retry** — `refreshQueryTargetIfImport` is reachable only after `saveSegmentMeta` succeeds, so a failed compaction cannot refresh a target that has no new manifest to see.
- **Collection not loaded** — `ErrCollectionNotLoaded` is logged at Info and returns; a collection nobody queries does not need refreshing.
- **CDC replica** — a replica's own flusher consumes its replicated `CommitImportMessageV2` and calls its own local `HandleCommitVchannel`, which sets `CommitTimestamp` unconditionally, so the predicate holds on replicas too. Traced through the code; not exercised against a live CDC pair.
- **Reopen storm** — deleting a large fraction of a collection folds nearly every sealed segment on the channel and Reopens them concurrently, and `ReopenSegments` reserves resources for a whole segment and fails fast rather than queuing. A failed Reopen is not lost — `SegmentChecker` re-evaluates every `SegmentCheckInterval` (3s) and re-issues while dist stays stale, the same retry-via-recheck ordinary segment loads rely on. **Code inspection only; concurrent-Reopen resource contention was not stress-tested.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
