### PR TITLE
fix: bump default Milvus version to 3.0.1-dev

### DIFF
--- a/pkg/common/version.go
+++ b/pkg/common/version.go
@@ -6,5 +6,5 @@ import semver "github.com/blang/semver/v4"
 var Version semver.Version
 
 func init() {
-	Version = semver.MustParse("3.0.0-beta")
+	Version = semver.MustParse("3.0.1-dev")
 }


### PR DESCRIPTION
issue: #52575

## Summary

- bump the source fallback version from `3.0.0-beta` to `3.0.1-dev`
- allow the scheduler's `3.0.1` worker-version gate to accept DataNodes
  built without an injected version override

## Validation

- `make milvus`
- `git diff --cached --check`
