### PR TITLE
fix: [3.0] bump default Milvus version to 3.0.1-dev

### DIFF
--- a/pkg/common/version.go
+++ b/pkg/common/version.go
@@ -6,5 +6,5 @@ import semver "github.com/blang/semver/v4"
 var Version semver.Version
 
 func init() {
-	Version = semver.MustParse("3.0.0")
+	Version = semver.MustParse("3.0.1-dev")
 }


### PR DESCRIPTION
issue: #52575
pr: #52589

## Summary

- backport the default version bump to the 3.0 branch
- report `3.0.1-dev` when no build-time version override is present
- allow the `3.0.1` worker-version gate to accept capable DataNodes

## Conflict resolution

The cherry-pick conflicted only in `pkg/common/version.go` because master still used `3.0.0-beta` while the 3.0 branch had already released `3.0.0`. The resolution preserves the 3.0 branch and replaces its `3.0.0` fallback with `3.0.1-dev`; no other source was changed.

## Validation

- `git diff --cached --check`
