### PR TITLE
fix: upgrade librdkafka to 2.6.1 for SASL/SCRAM against Kafka 4.x

### DIFF
--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -31,7 +31,7 @@ class MilvusConan(ConanFile):
         "milvus-common/1.0.0-b589c5a@milvus/dev#d431af735c8acb829feb7a94f05daf42",
         "google-cloud-cpp/2.28.0@milvus/dev#468918b43cec43624531a0340398cf43",
         "opentelemetry-cpp/1.23.0@milvus/dev#11bc565ec6e82910ae8f7471da756720",
-        "librdkafka/1.9.1#ec1a00d5414f618555799be9566adfb7",
+        "librdkafka/2.6.1@milvus/dev#a15d9fefad917290d59fa3fcbc144888",
         "roaring/3.0.0#25a703f80eda0764a31ef939229e202d",
         "crc32c/1.1.2",
         "simde/0.8.2#5e1edfd5cba92f25d79bf6ef4616b972",

--- a/pkg/mq/msgstream/mqwrapper/kafka/kafka_consumer_test.go
+++ b/pkg/mq/msgstream/mqwrapper/kafka/kafka_consumer_test.go
@@ -162,9 +162,15 @@ func TestKafkaConsumer_GetLatestMsgID(t *testing.T) {
 	assert.NoError(t, err)
 	defer consumer.Close()
 
+	// GetLatestMsgID queries the watermark offsets without allowing topic
+	// auto-creation, so the topic must exist before the first call. The
+	// mock cluster bundled with older librdkafka (<= 1.9.x, Metadata API
+	// v2) created it implicitly; newer versions follow the request flag.
+	createTopic(t, topic)
+
 	latestMsgID, err := consumer.GetLatestMsgID()
-	assert.Equal(t, int64(0), latestMsgID.(*KafkaID).MessageID)
 	assert.NoError(t, err)
+	assert.Equal(t, int64(0), latestMsgID.(*KafkaID).MessageID)
 
 	data1 := []int{111, 222, 333}
 	data2 := []string{"111", "222", "333"}
@@ -246,6 +252,16 @@ func testKafkaConsumerProduceData(t *testing.T, topic string, data []int, arr []
 	producer.(*kafkaProducer).p.Flush(500)
 }
 
+// createTopic makes sure topic exists on the broker by issuing a metadata
+// request from a producer, which allows automatic topic creation by default.
+func createTopic(t *testing.T, topic string) {
+	p, err := kafka.NewProducer(&kafka.ConfigMap{"bootstrap.servers": getKafkaBrokerList()})
+	assert.NoError(t, err)
+	defer p.Close()
+	_, err = p.GetMetadata(&topic, false, 10000)
+	assert.NoError(t, err)
+}
+
 func createConfig(groupID string) *kafka.ConfigMap {
 	kafkaAddress := getKafkaBrokerList()
 	return &kafka.ConfigMap{
@@ -259,6 +275,10 @@ func TestKafkaConsumer_CheckPreTopicValid(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	groupID := fmt.Sprintf("test-groupid-%d", rand.Int())
 	topic := fmt.Sprintf("test-topicName-%d", rand.Int())
+
+	// CheckTopicValid reports an error for a topic that does not exist on
+	// the broker, so make sure it exists first.
+	createTopic(t, topic)
 
 	config := createConfig(groupID)
 	consumer, err := newKafkaConsumer(config, 16, topic, groupID, mqcommon.SubscriptionPositionEarliest)


### PR DESCRIPTION
issue: #52601

Milvus cannot authenticate to an Apache Kafka 4.x broker when the listener
uses SASL with SCRAM-SHA-256. Every attempt fails with "invalid credentials"
while the Java client authenticates with the same user and password, and the
same Milvus build works against Kafka 3.9.1.

librdkafka appended the client nonce to the server-sent nonce a second time
when building the SCRAM client-final-message, although that nonce already
begins with it. The defect dates back to librdkafka v0.0.99. Kafka tolerated
it and then restored the strict nonce comparison required by RFC 5802, so
brokers on the 4.x line reject the proof. Fixed upstream in librdkafka 2.6.1
(confluentinc/librdkafka#4895).

Tested against the same broker, same user, same password:

  librdkafka 1.9.1   fails
  librdkafka 2.6.0   fails
  librdkafka 2.6.1   works
  Java client        works

2.6.0 still fails, so the threshold is 2.6.1 rather than 2.x generally.

2.6.1 is preferred over the later versions because it is the lowest one
carrying the fix and is a maintenance release. The later feature releases
change the consumer group protocol and deprecate api.version.request, which
Milvus sets explicitly in both the msgstream and streaming Kafka clients.

No Go changes are needed: Milvus builds with -tags dynamic, so
confluent-kafka-go links whatever librdkafka the build provides and only
requires a minimum of 1.9.0.

Verified on this branch: full make milvus succeeds, Milvus starts with zero
SASL errors against Kafka 4.0.0 with SCRAM-SHA-256, and create collection /
insert / flush / load / search all complete through the Kafka WAL.

## Dependency

The recipe has to exist in the Conan remote before this merges. Companion PR:
milvus-io/conanfiles#179 adds `librdkafka/2.6.1` (same source URL, sha256 and
patches as conan-center's own 2.6.1 recipe).

## Other branches

2.5 and 2.6 resolve exclusively from `default-conan-local` (Conan 1,
`conan install ... -r default-conan-local -u`), which carries librdkafka up to
2.2.0. Those lines need the recipe published to that remote separately before the
same one-line bump can be applied there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)