### PR TITLE
enhance: improve query result size limit error

### DIFF
--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -240,7 +240,7 @@ SegmentInternalInterface::Retrieve(tracer::TraceContext* trace_ctx,
             "maximum: {} bytes). Reduce output fields or row limit, paginate, "
             "fetch large fields separately, or raise "
             "quotaAndLimits.limits.maxOutputSize only after checking memory "
-            "impact.",
+            "impact",
             output_data_size,
             limit_size);
     }

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -236,7 +236,14 @@ SegmentInternalInterface::Retrieve(tracer::TraceContext* trace_ctx,
     if (output_data_size > limit_size) {
         ThrowInfo(
             RetrieveError,
-            fmt::format("query results exceed the limit size ", limit_size));
+            "Query result byte size exceeds the configured maximum output "
+            "size (estimated: {} bytes, maximum: {} bytes). This byte-size "
+            "limit is separate from the query row limit. Request fewer "
+            "output fields; reduce the row limit or paginate; fetch large "
+            "fields separately; or, only after evaluating the memory impact, "
+            "cautiously increase quotaAndLimits.limits.maxOutputSize.",
+            output_data_size,
+            limit_size);
     }
 
     results->set_all_retrieve_count(retrieve_results.total_data_cnt_);

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -236,12 +236,11 @@ SegmentInternalInterface::Retrieve(tracer::TraceContext* trace_ctx,
     if (output_data_size > limit_size) {
         ThrowInfo(
             RetrieveError,
-            "Query result byte size exceeds the configured maximum output "
-            "size (estimated: {} bytes, maximum: {} bytes). This byte-size "
-            "limit is separate from the query row limit. Request fewer "
-            "output fields; reduce the row limit or paginate; fetch large "
-            "fields separately; or, only after evaluating the memory impact, "
-            "cautiously increase quotaAndLimits.limits.maxOutputSize.",
+            "Query result exceeds the byte-size limit (estimated: {} bytes, "
+            "maximum: {} bytes). Reduce output fields or row limit, paginate, "
+            "fetch large fields separately, or raise "
+            "quotaAndLimits.limits.maxOutputSize only after checking memory "
+            "impact.",
             output_data_size,
             limit_size);
     }

--- a/internal/core/src/segcore/SegmentSealedRetrieveTest.cpp
+++ b/internal/core/src/segcore/SegmentSealedRetrieveTest.cpp
@@ -341,15 +341,13 @@ TEST_P(RetrieveTest, Limit) {
         EXPECT_EQ(error.get_error_code(), RetrieveError);
         EXPECT_EQ(
             std::string(error.what()),
-            "Query result byte size exceeds the configured maximum output "
-            "size (estimated: " +
+            "Query result exceeds the byte-size limit (estimated: " +
                 std::to_string(estimated_output_size) +
                 " bytes, maximum: " + std::to_string(max_output_size) +
-                " bytes). This byte-size limit is separate from the query "
-                "row limit. Request fewer output fields; reduce the row "
-                "limit or paginate; fetch large fields separately; or, only "
-                "after evaluating the memory impact, cautiously increase "
-                "quotaAndLimits.limits.maxOutputSize.");
+                " bytes). Reduce output fields or row limit, paginate, fetch "
+                "large fields separately, or raise "
+                "quotaAndLimits.limits.maxOutputSize only after checking "
+                "memory impact.");
     }
 
     auto retrieve_results = segment->Retrieve(

--- a/internal/core/src/segcore/SegmentSealedRetrieveTest.cpp
+++ b/internal/core/src/segcore/SegmentSealedRetrieveTest.cpp
@@ -347,7 +347,7 @@ TEST_P(RetrieveTest, Limit) {
                 " bytes). Reduce output fields or row limit, paginate, fetch "
                 "large fields separately, or raise "
                 "quotaAndLimits.limits.maxOutputSize only after checking "
-                "memory impact.");
+                "memory impact");
     }
 
     auto retrieve_results = segment->Retrieve(

--- a/internal/core/src/segcore/SegmentSealedRetrieveTest.cpp
+++ b/internal/core/src/segcore/SegmentSealedRetrieveTest.cpp
@@ -325,11 +325,32 @@ TEST_P(RetrieveTest, Limit) {
     plan->plan_node_ = std::make_unique<query::RetrievePlanNode>();
     plan->plan_node_->plannodes_ = milvus::test::CreateRetrievePlanByExpr(expr);
 
-    // test query results exceed the limit size
+    // Test that the byte-size guard reports the estimate and configured
+    // maximum without changing the RetrieveError wire semantics.
     std::vector<FieldId> target_fields{TimestampFieldID, fid_64, fid_vec};
     plan->field_ids_ = target_fields;
-    EXPECT_THROW(segment->Retrieve(nullptr, plan.get(), N, 1, false),
-                 std::runtime_error);
+    constexpr int64_t max_output_size = 1;
+    int64_t estimated_output_size = 0;
+    for (auto field_id : target_fields) {
+        estimated_output_size += segment->get_field_avg_size(field_id) * N;
+    }
+    try {
+        segment->Retrieve(nullptr, plan.get(), N, max_output_size, false);
+        FAIL() << "expected Query result byte-size limit error";
+    } catch (const SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), RetrieveError);
+        EXPECT_EQ(
+            std::string(error.what()),
+            "Query result byte size exceeds the configured maximum output "
+            "size (estimated: " +
+                std::to_string(estimated_output_size) +
+                " bytes, maximum: " + std::to_string(max_output_size) +
+                " bytes). This byte-size limit is separate from the query "
+                "row limit. Request fewer output fields; reduce the row "
+                "limit or paginate; fetch large fields separately; or, only "
+                "after evaluating the memory impact, cautiously increase "
+                "quotaAndLimits.limits.maxOutputSize.");
+    }
 
     auto retrieve_results = segment->Retrieve(
         nullptr, plan.get(), N, DEFAULT_MAX_OUTPUT_SIZE, false);

--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -19,6 +19,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proxy/shardclient"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/exprutil"
+	"github.com/milvus-io/milvus/internal/util/queryutil"
 	"github.com/milvus-io/milvus/internal/util/reduce"
 	"github.com/milvus-io/milvus/internal/util/reduce/orderby"
 	"github.com/milvus-io/milvus/internal/util/segcore"
@@ -1264,7 +1265,7 @@ func reduceRetrieveResults(ctx context.Context, retrieveResults []*internalpb.Re
 
 		// limit retrieve result to avoid oom
 		if retSize > maxOutputSize {
-			return nil, merr.WrapErrParameterInvalidMsg("query results exceed the maxOutputSize Limit %d", maxOutputSize)
+			return nil, queryutil.NewQueryResultSizeLimitExceededError(retSize, maxOutputSize)
 		}
 
 		cursors[sel]++

--- a/internal/querynodev2/segments/ignore_non_pk_ops.go
+++ b/internal/querynodev2/segments/ignore_non_pk_ops.go
@@ -276,7 +276,7 @@ func NewFetchFieldsDataOperator(
 			segmentResOffset[sel.SegmentIndex]++
 
 			if retSize > maxOutputSize {
-				return nil, merr.WrapErrParameterInvalidMsg("query results exceed the maxOutputSize Limit %d", maxOutputSize)
+				return nil, queryutil.NewQueryResultSizeLimitExceededError(retSize, maxOutputSize)
 			}
 		}
 

--- a/internal/util/queryutil/dedup_pk_op.go
+++ b/internal/util/queryutil/dedup_pk_op.go
@@ -125,7 +125,7 @@ func (op *DeduplicatePKOperator) Run(ctx context.Context, span trace.Span, input
 			}
 
 			if op.maxOutputSize > 0 && retSize > op.maxOutputSize {
-				return nil, merr.WrapErrParameterInvalidMsg("query results exceed the maxOutputSize Limit %d", op.maxOutputSize)
+				return nil, NewQueryResultSizeLimitExceededError(retSize, op.maxOutputSize)
 			}
 		}
 	}

--- a/internal/util/queryutil/dedup_pk_op_test.go
+++ b/internal/util/queryutil/dedup_pk_op_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // makeTimestampField creates a timestamp field (FieldID=1).
@@ -203,7 +204,10 @@ func TestDeduplicatePKOperator_MaxOutputSize(t *testing.T) {
 	}
 	_, err := op.Run(ctx, nil, []*internalpb.RetrieveResults{r})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "maxOutputSize")
+	assert.Contains(t, err.Error(), "estimated: 8 bytes, maximum: 1 bytes")
+	assert.Contains(t, err.Error(), "separate from the query row limit")
+	assert.Contains(t, err.Error(), "Request fewer output fields")
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 }
 
 func TestDeduplicatePKOperator_HasMoreResult(t *testing.T) {
@@ -376,5 +380,8 @@ func TestDeduplicatePKOperator_MaxOutputSize_OneBelowLimit(t *testing.T) {
 	}
 	_, err := op.Run(ctx, nil, []*internalpb.RetrieveResults{r})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "maxOutputSize")
+	assert.Contains(t, err.Error(), "estimated: 24 bytes, maximum: 23 bytes")
+	assert.Contains(t, err.Error(), "fetch large fields separately")
+	assert.Contains(t, err.Error(), "after evaluating the memory impact")
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 }

--- a/internal/util/queryutil/dedup_pk_op_test.go
+++ b/internal/util/queryutil/dedup_pk_op_test.go
@@ -205,8 +205,7 @@ func TestDeduplicatePKOperator_MaxOutputSize(t *testing.T) {
 	_, err := op.Run(ctx, nil, []*internalpb.RetrieveResults{r})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "estimated: 8 bytes, maximum: 1 bytes")
-	assert.Contains(t, err.Error(), "separate from the query row limit")
-	assert.Contains(t, err.Error(), "Request fewer output fields")
+	assert.Contains(t, err.Error(), "Reduce output fields or row limit")
 	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 }
 
@@ -382,6 +381,6 @@ func TestDeduplicatePKOperator_MaxOutputSize_OneBelowLimit(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "estimated: 24 bytes, maximum: 23 bytes")
 	assert.Contains(t, err.Error(), "fetch large fields separately")
-	assert.Contains(t, err.Error(), "after evaluating the memory impact")
+	assert.Contains(t, err.Error(), "only after checking memory impact")
 	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 }

--- a/internal/util/queryutil/max_output_size.go
+++ b/internal/util/queryutil/max_output_size.go
@@ -1,0 +1,32 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryutil
+
+import "github.com/milvus-io/milvus/pkg/v3/util/merr"
+
+// NewQueryResultSizeLimitExceededError reports the estimated Query result
+// byte size and the configured maximum without conflating this guard with the
+// request's row limit.
+func NewQueryResultSizeLimitExceededError(estimatedOutputSize, maxOutputSize int64) error {
+	return merr.WrapErrParameterInvalidMsg(
+		"Query result byte size exceeds the configured maximum output size (estimated: %d bytes, maximum: %d bytes). "+
+			"This byte-size limit is separate from the query row limit. Request fewer output fields; reduce the row limit or paginate; "+
+			"fetch large fields separately; or, only after evaluating the memory impact, cautiously increase quotaAndLimits.limits.maxOutputSize.",
+		estimatedOutputSize,
+		maxOutputSize,
+	)
+}

--- a/internal/util/queryutil/max_output_size.go
+++ b/internal/util/queryutil/max_output_size.go
@@ -23,9 +23,9 @@ import "github.com/milvus-io/milvus/pkg/v3/util/merr"
 // request's row limit.
 func NewQueryResultSizeLimitExceededError(estimatedOutputSize, maxOutputSize int64) error {
 	return merr.WrapErrParameterInvalidMsg(
-		"Query result byte size exceeds the configured maximum output size (estimated: %d bytes, maximum: %d bytes). "+
-			"This byte-size limit is separate from the query row limit. Request fewer output fields; reduce the row limit or paginate; "+
-			"fetch large fields separately; or, only after evaluating the memory impact, cautiously increase quotaAndLimits.limits.maxOutputSize.",
+		"Query result exceeds the byte-size limit (estimated: %d bytes, maximum: %d bytes). "+
+			"Reduce output fields or row limit, paginate, fetch large fields separately, or raise "+
+			"quotaAndLimits.limits.maxOutputSize only after checking memory impact.",
 		estimatedOutputSize,
 		maxOutputSize,
 	)

--- a/internal/util/queryutil/max_output_size.go
+++ b/internal/util/queryutil/max_output_size.go
@@ -25,7 +25,7 @@ func NewQueryResultSizeLimitExceededError(estimatedOutputSize, maxOutputSize int
 	return merr.WrapErrParameterInvalidMsg(
 		"Query result exceeds the byte-size limit (estimated: %d bytes, maximum: %d bytes). "+
 			"Reduce output fields or row limit, paginate, fetch large fields separately, or raise "+
-			"quotaAndLimits.limits.maxOutputSize only after checking memory impact.",
+			"quotaAndLimits.limits.maxOutputSize only after checking memory impact",
 		estimatedOutputSize,
 		maxOutputSize,
 	)

--- a/internal/util/queryutil/reduce_by_pk_op.go
+++ b/internal/util/queryutil/reduce_by_pk_op.go
@@ -294,7 +294,7 @@ func (op *ReduceByPKWithTimestampOperator) mergeByPKWithTimestamp(results []*tim
 		}
 
 		if op.maxOutputSize > 0 && retSize > op.maxOutputSize {
-			return nil, merr.WrapErrParameterInvalidMsg("query results exceed the maxOutputSize Limit %d", op.maxOutputSize)
+			return nil, NewQueryResultSizeLimitExceededError(retSize, op.maxOutputSize)
 		}
 
 		// Early termination when limit reached

--- a/internal/util/queryutil/reduce_by_pk_op_test.go
+++ b/internal/util/queryutil/reduce_by_pk_op_test.go
@@ -914,7 +914,6 @@ func TestReduceByPKWithTimestampOperator_MaxOutputSize_Exceeded(t *testing.T) {
 	_, err := op.Run(ctx, nil, []*internalpb.RetrieveResults{r})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "estimated: 24 bytes, maximum: 23 bytes")
-	assert.Contains(t, err.Error(), "separate from the query row limit")
-	assert.Contains(t, err.Error(), "Request fewer output fields")
+	assert.Contains(t, err.Error(), "Reduce output fields or row limit")
 	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 }

--- a/internal/util/queryutil/reduce_by_pk_op_test.go
+++ b/internal/util/queryutil/reduce_by_pk_op_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/reduce"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func TestReduceByPKOperator_Name(t *testing.T) {
@@ -912,5 +913,8 @@ func TestReduceByPKWithTimestampOperator_MaxOutputSize_Exceeded(t *testing.T) {
 	}
 	_, err := op.Run(ctx, nil, []*internalpb.RetrieveResults{r})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "maxOutputSize")
+	assert.Contains(t, err.Error(), "estimated: 24 bytes, maximum: 23 bytes")
+	assert.Contains(t, err.Error(), "separate from the query row limit")
+	assert.Contains(t, err.Error(), "Request fewer output fields")
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 }


### PR DESCRIPTION
issue: #52587

- segcore retrieve: report estimated and maximum byte sizes with concise mitigation guidance while preserving the existing size limit
- query reduction: share the actionable size-limit error across QueryNode, Proxy, and ORDER BY reduction paths