### PR TITLE
enhance: [3.0] log actual consistency in slow logs (#52556)

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/proxy"
+	"github.com/milvus-io/milvus/internal/proxy/accesslog"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
@@ -646,6 +647,40 @@ func TestTimeoutMiddlewareLateHandlerWritesUseCopiedContext(t *testing.T) {
 	value, ok = ctx.Get(HTTPReturnMessage)
 	assert.True(t, ok)
 	assert.Equal(t, "request timeout", value)
+}
+
+func TestAccessLogConsistencyLevelAfterTimeout(t *testing.T) {
+	// enable access log with a formatter that reads $consistency_level so the
+	// write path formats the resolved consistency level
+	paramtable.Get().Save(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key, "10")
+	paramtable.Get().Save("proxy.accessLog.enable", "true")
+	paramtable.Get().Save("proxy.accessLog.formatters.base.format", "$consistency_level")
+	t.Cleanup(func() {
+		paramtable.Get().Reset(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key)
+		paramtable.Get().Reset("proxy.accessLog.enable")
+		paramtable.Get().Reset("proxy.accessLog.formatters.base.format")
+	})
+	accesslog.InitAccessLogger(paramtable.Get())
+
+	ginHandler := gin.New()
+	path := "/middleware/accesslog-timeout"
+	ginHandler.Use(accesslog.AccessLogMiddleware)
+	ginHandler.POST(path, timeoutMiddleware(func(c *gin.Context) {
+		// late task PreExecute: keep resolving the consistency level after the
+		// client has already seen the timeout response. The access log is
+		// written concurrently by AccessLogMiddleware, so actualConsistencyLevel
+		// must be read/written in a race-free way.
+		<-c.Request.Context().Done()
+		for i := 0; i < 50; i++ {
+			accesslog.SetActualConsistencyLevel(c.Request.Context(), commonpb.ConsistencyLevel_Bounded)
+		}
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, path, nil)
+	w := httptest.NewRecorder()
+	ginHandler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusRequestTimeout, w.Code)
 }
 
 func TestRestfulSizeMiddlewarePreservesRequestContextCancel(t *testing.T) {

--- a/internal/proxy/accesslog/info/grpc_info.go
+++ b/internal/proxy/accesslog/info/grpc_info.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"path"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/samber/lo"
@@ -53,7 +54,7 @@ type GrpcAccessInfo struct {
 	end      time.Time
 
 	// runtime set info
-	actualConsistencyLevel *commonpb.ConsistencyLevel
+	actualConsistencyLevel atomic.Pointer[commonpb.ConsistencyLevel]
 }
 
 func NewGrpcAccessInfo(ctx context.Context, grpcInfo *grpc.UnaryServerInfo, req interface{}) *GrpcAccessInfo {
@@ -323,8 +324,8 @@ func (i *GrpcAccessInfo) OutputFields() string {
 
 func (i *GrpcAccessInfo) ConsistencyLevel() string {
 	// return actual consistency level if set
-	if i.actualConsistencyLevel != nil {
-		return i.actualConsistencyLevel.String()
+	if acl := i.actualConsistencyLevel.Load(); acl != nil {
+		return acl.String()
 	}
 	level, ok := requestutil.GetConsistencyLevelFromRequst(i.req)
 	if ok {
@@ -386,7 +387,7 @@ func (i *GrpcAccessInfo) ClientRequestTime() string {
 }
 
 func (i *GrpcAccessInfo) SetActualConsistencyLevel(acl commonpb.ConsistencyLevel) {
-	i.actualConsistencyLevel = &acl
+	i.actualConsistencyLevel.Store(&acl)
 }
 
 func (i *GrpcAccessInfo) TemplateValueLength() string {

--- a/internal/proxy/accesslog/info/restful_info.go
+++ b/internal/proxy/accesslog/info/restful_info.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -53,7 +54,7 @@ type RestfulInfo struct {
 	req    interface{}
 
 	// runtime set info
-	actualConsistencyLevel *commonpb.ConsistencyLevel
+	actualConsistencyLevel atomic.Pointer[commonpb.ConsistencyLevel]
 }
 
 func NewRestfulInfo(ctx *gin.Context) *RestfulInfo {
@@ -259,8 +260,8 @@ func (i *RestfulInfo) OutputFields() string {
 
 func (i *RestfulInfo) ConsistencyLevel() string {
 	// return actual consistency level if set
-	if i.actualConsistencyLevel != nil {
-		return i.actualConsistencyLevel.String()
+	if acl := i.actualConsistencyLevel.Load(); acl != nil {
+		return acl.String()
 	}
 	level, ok := requestutil.GetConsistencyLevelFromRequst(i.req)
 	if ok {
@@ -327,7 +328,7 @@ func (i *RestfulInfo) ClientRequestTime() string {
 }
 
 func (i *RestfulInfo) SetActualConsistencyLevel(acl commonpb.ConsistencyLevel) {
-	i.actualConsistencyLevel = &acl
+	i.actualConsistencyLevel.Store(&acl)
 }
 
 func (i *RestfulInfo) TemplateValueLength() string {

--- a/internal/proxy/accesslog/util.go
+++ b/internal/proxy/accesslog/util.go
@@ -18,6 +18,7 @@ package accesslog
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -53,6 +54,15 @@ func UnaryUpdateAccessInfoInterceptor(ctx context.Context, req any, rpcInfonfo *
 func AccessLogMiddleware(ctx *gin.Context) {
 	accessInfo := info.NewRestfulInfo(ctx)
 	ctx.Set(ContextLogKey, accessInfo)
+	// Bridge the access info into the standard request context. The gRPC
+	// interceptor injects the same AccessKey value for grpc traffic; without
+	// this, REST handlers reach the Proxy through the hook interceptor with a
+	// context lacking AccessKey, so task PreExecute (SetActualConsistencyLevel)
+	// and slow logs fall back to the raw request consistency level.
+	if ctx.Request != nil {
+		reqCtx := context.WithValue(ctx.Request.Context(), AccessKey{}, accessInfo)
+		ctx.Request = ctx.Request.WithContext(reqCtx)
+	}
 	ctx.Next()
 	accessInfo.InitReq()
 	_globalL.Write(accessInfo)
@@ -99,4 +109,35 @@ func SetActualConsistencyLevel(ctx context.Context, acl commonpb.ConsistencyLeve
 			info.SetActualConsistencyLevel(acl)
 		}
 	}
+}
+
+type ConsistencyLevelCarrier interface {
+	GetConsistencyLevel() commonpb.ConsistencyLevel
+}
+
+type ConsistencyLevelHelper struct {
+	accessInfo  info.AccessInfo
+	clvlCarrier ConsistencyLevelCarrier
+}
+
+func (clHelper *ConsistencyLevelHelper) String() string {
+	if clHelper.accessInfo != nil {
+		return fmt.Sprintf("ACT-%s", clHelper.accessInfo.ConsistencyLevel())
+	}
+	if clHelper.clvlCarrier == nil {
+		return info.Unknown
+	}
+	return fmt.Sprintf("REQ-%s", clHelper.clvlCarrier.GetConsistencyLevel().String())
+}
+
+func NewConsistencyLevelHelper(ctx context.Context, clvlCarrier ConsistencyLevelCarrier) *ConsistencyLevelHelper {
+	cc := &ConsistencyLevelHelper{clvlCarrier: clvlCarrier}
+	if ctx != nil {
+		v := ctx.Value(AccessKey{})
+		info, ok := v.(info.AccessInfo)
+		if ok && info != nil {
+			cc.accessInfo = info
+		}
+	}
+	return cc
 }

--- a/internal/proxy/accesslog/util_test.go
+++ b/internal/proxy/accesslog/util_test.go
@@ -17,12 +17,116 @@
 package accesslog
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus/internal/proxy/accesslog/info"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 func TestJoin(t *testing.T) {
 	assert.Equal(t, "a/b", join("a", "b"))
 	assert.Equal(t, "a/b", join("a/", "b"))
+}
+
+func newTestGrpcAccessInfo(req any) *info.GrpcAccessInfo {
+	return info.NewGrpcAccessInfo(context.Background(), &grpc.UnaryServerInfo{}, req)
+}
+
+func TestConsistencyLevelHelperFallbackToCarrier(t *testing.T) {
+	carrier := &milvuspb.SearchRequest{ConsistencyLevel: commonpb.ConsistencyLevel_Bounded}
+	want := "REQ-" + commonpb.ConsistencyLevel_Bounded.String()
+
+	// ctx without access info
+	helper := NewConsistencyLevelHelper(context.Background(), carrier)
+	assert.Equal(t, want, helper.String())
+
+	// nil ctx
+	//nolint:staticcheck // exercising the nil-context fallback path
+	helper = NewConsistencyLevelHelper(nil, carrier)
+	assert.Equal(t, want, helper.String())
+
+	// ctx carries a value that is not an AccessInfo
+	ctx := context.WithValue(context.Background(), AccessKey{}, "not-an-access-info")
+	helper = NewConsistencyLevelHelper(ctx, carrier)
+	assert.Equal(t, want, helper.String())
+
+	// nil carrier
+	helper = NewConsistencyLevelHelper(context.Background(), nil)
+	assert.Equal(t, info.Unknown, helper.String())
+}
+
+func TestConsistencyLevelHelperUsesActualLevel(t *testing.T) {
+	req := &milvuspb.SearchRequest{ConsistencyLevel: commonpb.ConsistencyLevel_Strong}
+	accessInfo := newTestGrpcAccessInfo(req)
+	accessInfo.SetActualConsistencyLevel(commonpb.ConsistencyLevel_Eventually)
+	ctx := context.WithValue(context.Background(), AccessKey{}, accessInfo)
+
+	helper := NewConsistencyLevelHelper(ctx, req)
+	assert.Equal(t, "ACT-"+commonpb.ConsistencyLevel_Eventually.String(), helper.String())
+}
+
+func TestConsistencyLevelHelperAccessInfoFallback(t *testing.T) {
+	// actual level not set, access info itself falls back to the request level
+	req := &milvuspb.QueryRequest{ConsistencyLevel: commonpb.ConsistencyLevel_Bounded}
+	accessInfo := newTestGrpcAccessInfo(req)
+	ctx := context.WithValue(context.Background(), AccessKey{}, accessInfo)
+
+	helper := NewConsistencyLevelHelper(ctx, req)
+	assert.Equal(t, "ACT-"+commonpb.ConsistencyLevel_Bounded.String(), helper.String())
+}
+
+func TestConsistencyLevelHelperQueryRequestCarrier(t *testing.T) {
+	// QueryRequest implements ConsistencyLevelCarrier
+	req := &milvuspb.QueryRequest{ConsistencyLevel: commonpb.ConsistencyLevel_Eventually}
+	helper := NewConsistencyLevelHelper(context.Background(), req)
+	assert.Equal(t, "REQ-"+commonpb.ConsistencyLevel_Eventually.String(), helper.String())
+}
+
+func newRESTTestContext(t *testing.T) *gin.Context {
+	gin.SetMode(gin.TestMode)
+	paramtable.Init()
+	if _globalL == nil {
+		_globalL = NewAccessLogger()
+	}
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/v2/vectordb/entities/search", nil)
+	c.Keys = make(map[any]any)
+	AccessLogMiddleware(c)
+	return c
+}
+
+func TestAccessLogMiddlewareBridgesAccessKey(t *testing.T) {
+	c := newRESTTestContext(t)
+
+	v, ok := c.Request.Context().Value(AccessKey{}).(info.AccessInfo)
+	assert.True(t, ok)
+	assert.NotNil(t, v)
+	got, _ := c.Get(ContextLogKey)
+	assert.Equal(t, got, v)
+}
+
+func TestConsistencyLevelHelperRESTPath(t *testing.T) {
+	// REST request relying on the default consistency: the protobuf field is
+	// the zero value (Strong), while the collection default resolves to Bounded.
+	req := &milvuspb.SearchRequest{
+		ConsistencyLevel:      commonpb.ConsistencyLevel_Strong,
+		UseDefaultConsistency: true,
+	}
+	c := newRESTTestContext(t)
+
+	// task PreExecute resolves the actual level and records it on the REST access info
+	SetActualConsistencyLevel(c.Request.Context(), commonpb.ConsistencyLevel_Bounded)
+
+	helper := NewConsistencyLevelHelper(c.Request.Context(), req)
+	assert.Equal(t, "ACT-"+commonpb.ConsistencyLevel_Bounded.String(), helper.String())
+	assert.NotEqual(t, "REQ-"+commonpb.ConsistencyLevel_Strong.String(), helper.String())
 }

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -46,6 +46,7 @@ import (
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/http"
 	"github.com/milvus-io/milvus/internal/parser/planparserv2"
+	"github.com/milvus-io/milvus/internal/proxy/accesslog"
 	"github.com/milvus-io/milvus/internal/proxy/connection"
 	"github.com/milvus-io/milvus/internal/proxy/privilege"
 	"github.com/milvus-io/milvus/internal/proxy/replicate"
@@ -2983,7 +2984,8 @@ func (node *Proxy) search(ctx context.Context, request *milvuspb.SearchRequest, 
 		}
 		if spanPerNq >= paramtable.Get().ProxyCfg.SlowQuerySpanInSeconds.GetAsDuration(time.Second) {
 			mlog.Info(ctx, rpcSlow(method), mlog.Uint64("guarantee_timestamp", qt.GetGuaranteeTimestamp()),
-				mlog.Int64("nq", qt.GetNq()), mlog.Duration("duration", span), mlog.Duration("durationPerNq", spanPerNq))
+				mlog.Int64("nq", qt.GetNq()), mlog.Duration("duration", span), mlog.Duration("durationPerNq", spanPerNq),
+				mlog.Stringer("consistency_level", accesslog.NewConsistencyLevelHelper(ctx, request)))
 			user, _ := GetCurUserFromContext(ctx)
 			traceID := ""
 			if sp != nil {
@@ -3215,7 +3217,8 @@ func (node *Proxy) hybridSearch(ctx context.Context, request *milvuspb.HybridSea
 		}
 		if spanPerNq >= paramtable.Get().ProxyCfg.SlowQuerySpanInSeconds.GetAsDuration(time.Second) {
 			mlog.Info(ctx, rpcSlow(method), mlog.Uint64("guarantee_timestamp", qt.GetGuaranteeTimestamp()),
-				mlog.Int64("totalNq", totalNq), mlog.Duration("duration", span), mlog.Duration("durationPerNq", spanPerNq))
+				mlog.Int64("totalNq", totalNq), mlog.Duration("duration", span), mlog.Duration("durationPerNq", spanPerNq),
+				mlog.Stringer("consistency_level", accesslog.NewConsistencyLevelHelper(ctx, newSearchReq)))
 			user, _ := GetCurUserFromContext(ctx)
 			traceID := ""
 			if sp != nil {
@@ -3686,7 +3689,8 @@ func (node *Proxy) query(ctx context.Context, qt *queryTask, sp trace.Span) (*mi
 				mlog.Strings("OutputFields", request.OutputFields),
 				mlog.Uint64("travel_timestamp", request.TravelTimestamp),
 				mlog.Uint64("guarantee_timestamp", qt.GetGuaranteeTimestamp()),
-				mlog.Duration("duration", span))
+				mlog.Duration("duration", span),
+				mlog.Stringer("consistency_level", accesslog.NewConsistencyLevelHelper(ctx, request)))
 			user, _ := GetCurUserFromContext(ctx)
 			traceID := ""
 			if sp != nil {


### PR DESCRIPTION
Cherry-pick from master
pr: #52556
Related to #44703

Slow query logs printed the raw request consistency level. When a client relies on the default consistency (use_default_consistency=true), the request field stays at the protobuf zero value (Strong), so the log did not reflect the level actually used, which comes from the collection's configuration.

Reuse the accesslog mechanism: the actual level is already resolved in task PreExecute and stored on the access info carried by the context. Add ConsistencyLevelHelper that lazily prints that value (ACT-) through mlog.Stringer, falling back to the request level (REQ-) when no access info is available, and wire it into the Search, HybridSearch, and Query slow logs.

Cover the helper with unit tests.

---------