### PR TITLE
test: avoid float-int collision in json_contains_any test data

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_query.py
+++ b/tests/python_client/milvus_client/test_milvus_client_query.py
@@ -2106,7 +2106,7 @@ class TestMilvusClientQueryValid(TestMilvusClientV2Base):
                 "listFlt": [m * 1.0 for m in range(i, i + limit)],
                 "listBool": [bool(i % 2)],
                 "listList": [[i, str(i + 1)], [i * 1.0, i + 1]],
-                "listMix": [i, i * 1.1, str(i), bool(i % 2), [i, str(i)]],
+                "listMix": [i, i + 0.5, str(i), bool(i % 2), [i, str(i)]],
             }
         self.insert(client, collection_name, rows)
         # 3. create index and load
@@ -2175,7 +2175,7 @@ class TestMilvusClientQueryValid(TestMilvusClientV2Base):
                 "listFlt": [m * 1.0 for m in range(i, i + limit)],
                 "listBool": [bool(i % 2)],
                 "listList": [[i, str(i + 1)], [i * 1.0, i + 1]],
-                "listMix": [i, i * 1.1, str(i), bool(i % 2), [i, str(i)]],
+                "listMix": [i, i + 0.5, str(i), bool(i % 2), [i, str(i)]],
             }
         self.insert(client, collection_name, rows)
         # 3. create index and load
@@ -2475,7 +2475,7 @@ class TestMilvusClientQueryValid(TestMilvusClientV2Base):
         flt_data = [[m * 1.0 for m in range(i, i + limit)] for i in range(default_nb)]
         bool_data = [[bool(i % 2)] for i in range(default_nb)]
         list_data = [[[i, str(i + 1)], [i * 1.0, i + 1]] for i in range(default_nb)]
-        mix_data = [[i, i * 1.1, str(i), bool(i % 2), [i, str(i)]] for i in range(default_nb)]
+        mix_data = [[i, i + 0.5, str(i), bool(i % 2), [i, str(i)]] for i in range(default_nb)]
 
         for i in range(default_nb):
             rows[i][ct.default_json_field_name] = {


### PR DESCRIPTION
## Related Issue

Fixes #52594

## What type of PR is this?

- [x] test

## What this PR does

Fixes a flaky test `test_milvus_client_query_expr_all_datatype_json_contains_any` that intermittently fails with `1501 == 1500`.

## Root cause

The JSON field's `listMix` float element was built as `i * 1.1`. Under IEEE 754 double arithmetic, some products round exactly to an integer (e.g. `1190 * 1.1 == 1309.0`). When the random `_id` lands on such a value, segcore's `json_contains_any` (intentionally) matches the JSON double `1309.0` against the int64 query element, so an extra even row satisfies the predicate and the hardcoded `default_nb // 2` assertion fails.

This is a test-data defect, not a product bug — the server result is correct for the inserted data.

## Changes

Replace `i * 1.1` with `i + 0.5` (which can never equal an integer) in the three affected spots in `tests/python_client/milvus_client/test_milvus_client_query.py`:
- `listMix` in `test_milvus_client_query_expr_list_all_datatype_json_contains_all`
- `listMix` in `test_milvus_client_query_expr_all_datatype_json_contains_any` (the flaky test)
- `mix_data` in `test_milvus_client_query_expr_list_all_datatype_json_contains_any`

## Verification

- Reproduced before the fix: `json_contains_any(listMix, [1309, True])` returned 1501 rows (extra even row `int64=1190`).
- After the fix, forcing the previously-colliding `_id=1309` returns exactly 1500 rows.
- `test_milvus_client_query_expr_all_datatype_json_contains_any` passed 5 consecutive rounds (10 parametrized runs).
- The other two touched tests passed as well (2 + 4 parametrized runs).