### PR TITLE
fix: avoid legacy stats paths after V3 manifest failures

### DIFF
--- a/internal/util/segcore/segment.go
+++ b/internal/util/segcore/segment.go
@@ -71,7 +71,10 @@ func CreateCSegment(req *CreateCSegmentRequest) (CSegment, error) {
 	var ptr C.CSegmentInterface
 	var status C.CStatus
 	if req.LoadInfo != nil {
-		segLoadInfo := ConvertToSegcoreSegmentLoadInfo(req.LoadInfo)
+		segLoadInfo, err := ConvertToSegcoreSegmentLoadInfo(req.LoadInfo)
+		if err != nil {
+			return nil, merr.Wrap(err, "failed to convert segment load info")
+		}
 		loadInfoBlob, err := proto.Marshal(segLoadInfo)
 		if err != nil {
 			return nil, err
@@ -356,7 +359,10 @@ func (s *cSegmentImpl) Reopen(ctx context.Context, req *ReopenRequest) error {
 	defer runtime.KeepAlive(traceCtx)
 	defer runtime.KeepAlive(req)
 
-	segLoadInfo := ConvertToSegcoreSegmentLoadInfo(req.LoadInfo)
+	segLoadInfo, err := ConvertToSegcoreSegmentLoadInfo(req.LoadInfo)
+	if err != nil {
+		return merr.Wrap(err, "failed to convert reopen load info")
+	}
 	loadInfoBlob, err := proto.Marshal(segLoadInfo)
 	if err != nil {
 		return err
@@ -409,15 +415,18 @@ func (s *cSegmentImpl) SetCommitTimestamp(ts uint64) error {
 // ConvertToSegcoreSegmentLoadInfo converts querypb.SegmentLoadInfo to segcorepb.SegmentLoadInfo.
 // This function is needed because segcorepb.SegmentLoadInfo is a simplified version that doesn't
 // depend on data_coord.proto and excludes fields like start_position, delta_position, and level.
-func ConvertToSegcoreSegmentLoadInfo(src *querypb.SegmentLoadInfo) *segcorepb.SegmentLoadInfo {
+func ConvertToSegcoreSegmentLoadInfo(src *querypb.SegmentLoadInfo) (*segcorepb.SegmentLoadInfo, error) {
 	if src == nil {
-		return nil
+		return nil, nil
 	}
 
 	// Resolve text/json stats with basePaths.
 	// V2: stats come from src proto fields, basePaths computed from metadata + rootPath.
 	// V3: stats resolved from manifest (src proto fields are empty), basePaths from manifest paths.
-	textStats, jsonStats, textBasePaths, jsonBasePaths := resolveStatsWithBasePaths(src)
+	textStats, jsonStats, textBasePaths, jsonBasePaths, err := resolveStatsWithBasePaths(src)
+	if err != nil {
+		return nil, err
+	}
 
 	return &segcorepb.SegmentLoadInfo{
 		SegmentID:            src.GetSegmentID(),
@@ -444,17 +453,20 @@ func ConvertToSegcoreSegmentLoadInfo(src *querypb.SegmentLoadInfo) *segcorepb.Se
 		UseTakeForOutput:     src.GetUseTakeForOutput(),
 		EstimatedBytesPerRow: src.GetEstimatedBytesPerRow(),
 		CommitTimestamp:      src.GetCommitTimestamp(),
-	}
+	}, nil
 }
 
 // resolveStatsWithBasePaths resolves text/json stats and computes basePaths.
 // V2: stats from src proto fields, basePaths computed from rootPath + metadata.
 // V3: stats resolved from manifest via StatsResolver, basePaths extracted from manifest paths.
+// A V3 manifest error does not fall back to V2 path construction because the
+// legacy prefixes are incompatible with manifest-backed stat files.
 func resolveStatsWithBasePaths(src *querypb.SegmentLoadInfo) (
 	map[int64]*datapb.TextIndexStats,
 	map[int64]*datapb.JsonKeyStats,
 	map[int64]string, // textBasePaths
 	map[int64]string, // jsonBasePaths
+	error,
 ) {
 	textStats := src.GetTextStatsLogs()
 	jsonStats := src.GetJsonKeyStatsLogs()
@@ -467,8 +479,9 @@ func resolveStatsWithBasePaths(src *querypb.SegmentLoadInfo) (
 				mlog.Int64("segmentID", src.GetSegmentID()),
 				mlog.String("manifestPath", src.GetManifestPath()),
 				mlog.Err(result.Err()))
+			return nil, nil, nil, nil, merr.Wrap(result.Err(), "failed to resolve V3 stats from manifest")
 		} else {
-			return result.TextIndexStats, result.JSONKeyStats, result.TextBasePaths, result.JSONBasePaths
+			return result.TextIndexStats, result.JSONKeyStats, result.TextBasePaths, result.JSONBasePaths, nil
 		}
 	}
 
@@ -489,7 +502,7 @@ func resolveStatsWithBasePaths(src *querypb.SegmentLoadInfo) (
 			src.GetCollectionID(), src.GetPartitionID(), src.GetSegmentID(), fieldID)
 	}
 
-	return textStats, jsonStats, textBasePaths, jsonBasePaths
+	return textStats, jsonStats, textBasePaths, jsonBasePaths, nil
 }
 
 // convertFieldBinlogs converts datapb.FieldBinlog to segcorepb.FieldBinlog.

--- a/internal/util/segcore/segment_test.go
+++ b/internal/util/segcore/segment_test.go
@@ -160,7 +160,8 @@ func TestConvertToSegcoreSegmentLoadInfo_CommitTimestamp(t *testing.T) {
 		PartitionID:     2,
 		CommitTimestamp: 9999,
 	}
-	result := segcore.ConvertToSegcoreSegmentLoadInfo(info)
+	result, err := segcore.ConvertToSegcoreSegmentLoadInfo(info)
+	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, int64(42), result.GetSegmentID(),
 		"SegmentID must be preserved through conversion")
@@ -176,7 +177,8 @@ func TestConvertToSegcoreSegmentLoadInfo_CommitTimestamp(t *testing.T) {
 		PartitionID:  2,
 		// CommitTimestamp = 0
 	}
-	result2 := segcore.ConvertToSegcoreSegmentLoadInfo(info2)
+	result2, err := segcore.ConvertToSegcoreSegmentLoadInfo(info2)
+	assert.NoError(t, err)
 	assert.NotNil(t, result2)
 	assert.Equal(t, int64(43), result2.GetSegmentID(),
 		"SegmentID must be preserved through conversion when CommitTimestamp is zero")
@@ -184,13 +186,15 @@ func TestConvertToSegcoreSegmentLoadInfo_CommitTimestamp(t *testing.T) {
 
 func TestConvertToSegcoreSegmentLoadInfo(t *testing.T) {
 	t.Run("nil input", func(t *testing.T) {
-		result := segcore.ConvertToSegcoreSegmentLoadInfo(nil)
+		result, err := segcore.ConvertToSegcoreSegmentLoadInfo(nil)
+		assert.NoError(t, err)
 		assert.Nil(t, result)
 	})
 
 	t.Run("empty input", func(t *testing.T) {
 		src := &querypb.SegmentLoadInfo{}
-		result := segcore.ConvertToSegcoreSegmentLoadInfo(src)
+		result, err := segcore.ConvertToSegcoreSegmentLoadInfo(src)
+		assert.NoError(t, err)
 		assert.NotNil(t, result)
 		assert.Equal(t, int64(0), result.SegmentID)
 		assert.Equal(t, int64(0), result.PartitionID)
@@ -319,7 +323,8 @@ func TestConvertToSegcoreSegmentLoadInfo(t *testing.T) {
 		}
 
 		// Convert to segcorepb.SegmentLoadInfo
-		result := segcore.ConvertToSegcoreSegmentLoadInfo(src)
+		result, err := segcore.ConvertToSegcoreSegmentLoadInfo(src)
+		assert.NoError(t, err)
 
 		// Validate basic fields
 		assert.NotNil(t, result)
@@ -425,7 +430,8 @@ func TestConvertToSegcoreSegmentLoadInfo(t *testing.T) {
 			},
 		}
 
-		result := segcore.ConvertToSegcoreSegmentLoadInfo(src)
+		result, err := segcore.ConvertToSegcoreSegmentLoadInfo(src)
+		assert.NoError(t, err)
 
 		assert.NotNil(t, result)
 		assert.Equal(t, 1, len(result.BinlogPaths))
@@ -458,8 +464,27 @@ func TestConvertToSegcoreSegmentLoadInfo_IndexStorePathVersion(t *testing.T) {
 		},
 	}
 
-	result := segcore.ConvertToSegcoreSegmentLoadInfo(src)
+	result, err := segcore.ConvertToSegcoreSegmentLoadInfo(src)
+	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Len(t, result.GetIndexInfos(), 1)
 	assert.Equal(t, indexpb.IndexStorePathVersion_INDEX_STORE_PATH_VERSION_COLLECTION_ROOTED, result.GetIndexInfos()[0].GetIndexStorePathVersion())
+}
+
+func TestConvertToSegcoreSegmentLoadInfo_V3ManifestErrorReturnsError(t *testing.T) {
+	src := &querypb.SegmentLoadInfo{
+		StorageVersion: storage.StorageV3,
+		ManifestPath:   "not-a-valid-manifest-path",
+		TextStatsLogs: map[int64]*datapb.TextIndexStats{
+			100: {FieldID: 100, BuildID: 200, Version: 1, Files: []string{"text.index"}},
+		},
+		JsonKeyStatsLogs: map[int64]*datapb.JsonKeyStats{
+			101: {FieldID: 101, BuildID: 201, Version: 1, Files: []string{"json.stats"}},
+		},
+	}
+
+	result, err := segcore.ConvertToSegcoreSegmentLoadInfo(src)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
 }


### PR DESCRIPTION
issue: #52623

## What this PR does

Prevent Storage V3 segment load-info conversion from falling through to Storage V2 text-index and JSON-stats path construction when manifest resolution fails.

A V3 manifest failure now propagates an error through `ConvertToSegcoreSegmentLoadInfo`, `CreateCSegment`, and `Reopen`. This prevents segcore from interpreting a failed stats resolution as stats deletion or rebuilding indexes from raw data. Reopen fails before mutating the existing segment state, allowing the caller to retry the transient manifest failure.

## Test Plan

- `go test -count=1 -tags dynamic,test -gcflags=\"all=-N -l\" ./internal/util/segcore` with the required macOS rpaths
- Targeted `golangci-lint` for `internal/util/segcore` (`0 issues`)
- `make static-check` passed before the final error-propagation follow-up
- `gofumpt` and `git diff --check`