### PR TITLE
enhance: [2.6] Keep nullable chunk validity packed

### DIFF
--- a/internal/core/src/common/ArrayOffsets.cpp
+++ b/internal/core/src/common/ArrayOffsets.cpp
@@ -170,7 +170,7 @@ ArrayOffsetsSealed::BuildFromSegment(const void* segment,
 
             for (size_t i = 0; i < vector_array_views.size(); ++i) {
                 int32_t array_len = 0;
-                if (valid_flags.empty() || valid_flags[i]) {
+                if (!valid_flags || valid_flags[i]) {
                     array_len = vector_array_views[i].length();
                 }
 
@@ -187,7 +187,7 @@ ArrayOffsetsSealed::BuildFromSegment(const void* segment,
 
             for (size_t i = 0; i < array_views.size(); ++i) {
                 int32_t array_len = 0;
-                if (valid_flags.empty() || valid_flags[i]) {
+                if (!valid_flags || valid_flags[i]) {
                     array_len = array_views[i].length();
                 }
 

--- a/internal/core/src/common/Chunk.cpp
+++ b/internal/core/src/common/Chunk.cpp
@@ -15,7 +15,7 @@
 
 namespace milvus {
 
-std::pair<std::vector<std::string_view>, FixedVector<bool>>
+std::pair<std::vector<std::string_view>, ValidityView>
 StringChunk::StringViews(
     std::optional<std::pair<int64_t, int64_t>> offset_len = std::nullopt) {
     auto start_offset = 0;
@@ -46,12 +46,7 @@ StringChunk::StringViews(
     for (auto i = start_offset; i < end_offset; i++) {
         ret.emplace_back(data_ + offsets_[i], offsets_[i + 1] - offsets_[i]);
     }
-    if (nullable_) {
-        FixedVector<bool> res_valid(valid_.begin() + start_offset,
-                                    valid_.begin() + end_offset);
-        return {ret, std::move(res_valid)};
-    }
-    return {ret, {}};
+    return {std::move(ret), Validity(start_offset)};
 }
 
 std::pair<std::vector<std::string_view>, FixedVector<bool>>

--- a/internal/core/src/common/Chunk.h
+++ b/internal/core/src/common/Chunk.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <sys/types.h>
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -87,12 +88,6 @@ class Chunk {
           size_(size),
           nullable_(nullable),
           chunk_mmap_guard_(chunk_mmap_guard) {
-        if (nullable) {
-            valid_.reserve(row_nums);
-            for (int i = 0; i < row_nums; i++) {
-                valid_.push_back((data[i >> 3] >> (i & 0x07)) & 1);
-            }
-        }
     }
     virtual ~Chunk() {
         // The ChunkMmapGuard will handle the unmapping and unlinking of the file if it is file backed
@@ -129,18 +124,68 @@ class Chunk {
         return data_;
     }
 
-    FixedVector<bool>&
-    Valid() {
-        return valid_;
-    }
-
     virtual bool
     isValid(int offset) const {
         if (nullable_) {
-            return valid_[offset];
+            return (static_cast<uint8_t>(data_[offset >> 3]) >>
+                    (offset & 0x07)) &
+                   1;
         }
         return true;
     };
+
+    ValidityView
+    Validity(int64_t offset = 0) const {
+        if (!nullable_) {
+            return {};
+        }
+        return ValidityView::FromPacked(reinterpret_cast<const uint8_t*>(data_))
+            .Subview(offset);
+    }
+
+    void
+    ApplyValidityMask(int64_t offset,
+                      int64_t count,
+                      TargetBitmapView target) const {
+        if (!nullable_ || count == 0) {
+            return;
+        }
+        AssertInfo(offset >= 0 && count >= 0 && offset + count <= row_nums_,
+                   "Invalid validity range, offset: {}, count: {}, rows: {}",
+                   offset,
+                   count,
+                   row_nums_);
+
+        const auto validity = Validity(offset);
+        const auto* packed = validity.packed_data();
+        AssertInfo(packed != nullptr, "Packed validity data is missing");
+        const auto read_word = [packed](int64_t bit_offset, int bit_count) {
+            const auto byte_offset = bit_offset >> 3;
+            const auto shift = static_cast<int>(bit_offset & 0x07);
+            const auto bytes = (shift + bit_count + 7) >> 3;
+            uint64_t word = 0;
+            const auto low_bytes = std::min(bytes, 8);
+            for (int i = 0; i < low_bytes; ++i) {
+                word |= uint64_t(packed[byte_offset + i]) << (i * 8);
+            }
+            word >>= shift;
+            if (bytes > 8) {
+                word |= uint64_t(packed[byte_offset + 8]) << (64 - shift);
+            }
+            if (bit_count < 64) {
+                word &= (uint64_t{1} << bit_count) - 1;
+            }
+            return word;
+        };
+
+        for (int64_t i = 0; i < count; i += 64) {
+            const auto bit_count =
+                static_cast<int>(std::min<int64_t>(count - i, 64));
+            auto word = read_word(validity.bit_offset() + i, bit_count);
+            TargetBitmapView validity_word(&word, bit_count);
+            target.view(i).inplace_and(validity_word, bit_count);
+        }
+    }
 
     int64_t
     PhysicalOffsetOf(int64_t logical_offset) const {
@@ -151,20 +196,36 @@ class Chunk {
         if (!nullable_) {
             return logical_offset;
         }
-        AssertInfo(valid_[logical_offset],
+        AssertInfo(isValid(logical_offset),
                    "Logical offset {} is null",
                    logical_offset);
         BuildValidRankBlocks();
         const auto block_id = logical_offset / kValidRankBlockSize;
         int64_t physical_offset = valid_rank_blocks_[block_id];
         const auto block_start = block_id * kValidRankBlockSize;
-        for (int64_t i = block_start; i < logical_offset; ++i) {
-            physical_offset += valid_[i] ? 1 : 0;
-        }
-        return physical_offset;
+        return physical_offset + CountValidBits(block_start, logical_offset);
     }
 
  protected:
+    int64_t
+    CountValidBits(int64_t begin, int64_t end) const {
+        int64_t count = 0;
+        while (begin < end && (begin & 0x07) != 0) {
+            count += isValid(begin) ? 1 : 0;
+            ++begin;
+        }
+        while (begin + 8 <= end) {
+            count += __builtin_popcount(static_cast<unsigned int>(
+                static_cast<uint8_t>(data_[begin >> 3])));
+            begin += 8;
+        }
+        while (begin < end) {
+            count += isValid(begin) ? 1 : 0;
+            ++begin;
+        }
+        return count;
+    }
+
     void
     BuildValidRankBlocks() const {
         std::call_once(valid_rank_blocks_once_, [&]() {
@@ -177,9 +238,7 @@ class Chunk {
                 const auto block_start = block_id * kValidRankBlockSize;
                 const auto block_end =
                     std::min(block_start + kValidRankBlockSize, row_nums_);
-                for (int64_t i = block_start; i < block_end; ++i) {
-                    valid_count += valid_[i] ? 1 : 0;
-                }
+                valid_count += CountValidBits(block_start, block_end);
             }
             valid_rank_blocks_[num_blocks] = valid_count;
         });
@@ -190,8 +249,6 @@ class Chunk {
     int64_t row_nums_;
     uint64_t size_;
     bool nullable_;
-    FixedVector<bool>
-        valid_;  // parse null bitmap to valid_ to be compatible with SpanBase
 
     std::shared_ptr<ChunkMmapGuard> chunk_mmap_guard_{nullptr};
     mutable std::once_flag valid_rank_blocks_once_;
@@ -217,10 +274,8 @@ class FixedWidthChunk : public Chunk {
 
     milvus::SpanBase
     Span() const {
-        return milvus::SpanBase(data_start_,
-                                nullable_ ? valid_.data() : nullptr,
-                                row_nums_,
-                                element_size_ * dim_);
+        return milvus::SpanBase(
+            data_start_, Validity(), row_nums_, element_size_ * dim_);
     }
 
     const char*
@@ -285,7 +340,7 @@ class StringChunk : public Chunk {
         return {data_ + offsets_[i], offsets_[i + 1] - offsets_[i]};
     }
 
-    std::pair<std::vector<std::string_view>, FixedVector<bool>>
+    std::pair<std::vector<std::string_view>, ValidityView>
     StringViews(std::optional<std::pair<int64_t, int64_t>> offset_len);
 
     int
@@ -446,7 +501,7 @@ class ArrayChunk : public Chunk {
         return {std::move(views), std::move(valid_res)};
     }
 
-    std::pair<std::vector<ArrayView>, FixedVector<bool>>
+    std::pair<std::vector<ArrayView>, ValidityView>
     Views(std::optional<std::pair<int64_t, int64_t>> offset_len =
               std::nullopt) const {
         auto start_offset = 0;
@@ -476,12 +531,7 @@ class ArrayChunk : public Chunk {
         for (auto i = start_offset; i < end_offset; i++) {
             views.emplace_back(View(i));
         }
-        if (nullable_) {
-            FixedVector<bool> res_valid(valid_.begin() + start_offset,
-                                        valid_.begin() + end_offset);
-            return {std::move(views), std::move(res_valid)};
-        }
-        return {std::move(views), {}};
+        return {std::move(views), Validity(start_offset)};
     }
 
     const char*
@@ -543,7 +593,7 @@ class VectorArrayChunk : public Chunk {
             data_ptr, dim_, len, next_offset - offset, element_type_);
     }
 
-    std::pair<std::vector<VectorArrayView>, FixedVector<bool>>
+    std::pair<std::vector<VectorArrayView>, ValidityView>
     Views(std::optional<std::pair<int64_t, int64_t>> offset_len =
               std::nullopt) const {
         auto start_offset = 0;

--- a/internal/core/src/common/ChunkTest.cpp
+++ b/internal/core/src/common/ChunkTest.cpp
@@ -15,9 +15,12 @@
 #include <arrow/io/memory.h>
 #include <parquet/arrow/reader.h>
 #include <unistd.h>
+#include <algorithm>
 #include <memory>
+#include <numeric>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "boost/filesystem/operations.hpp"
 #include "boost/filesystem/path.hpp"
@@ -35,6 +38,166 @@
 #include "test_utils/DataGen.h"
 
 using namespace milvus;
+
+namespace {
+
+void
+SetPackedValidity(std::vector<char>& data, int64_t offset) {
+    data[offset >> 3] |= static_cast<char>(1U << (offset & 0x07));
+}
+
+void
+WriteUint32(std::vector<char>& data, size_t offset, uint32_t value) {
+    memcpy(data.data() + offset, &value, sizeof(value));
+}
+
+}  // namespace
+
+TEST(chunk, nullable_fixed_width_span_keeps_validity_packed) {
+    constexpr int64_t row_count = 300;
+    const auto bitmap_bytes = (row_count + 7) / 8;
+    std::vector<char> data(bitmap_bytes + row_count * sizeof(int64_t), 0);
+    FixedVector<bool> expected_validity;
+    expected_validity.reserve(row_count);
+
+    for (int64_t i = 0; i < row_count; ++i) {
+        const bool valid = i % 5 != 1 && i % 7 != 3;
+        expected_validity.push_back(valid);
+        if (valid) {
+            SetPackedValidity(data, i);
+        }
+        const int64_t value = i * 10;
+        memcpy(data.data() + bitmap_bytes + i * sizeof(value),
+               &value,
+               sizeof(value));
+    }
+
+    FixedWidthChunk chunk(
+        row_count, 1, data.data(), data.size(), sizeof(int64_t), true, nullptr);
+
+    for (const auto offset : {0, 63, 64, 255, 256, 257, 299}) {
+        EXPECT_EQ(chunk.isValid(offset), expected_validity[offset]);
+    }
+
+    constexpr int64_t logical_offset = 299;
+    ASSERT_TRUE(expected_validity[logical_offset]);
+    const auto expected_physical_offset =
+        std::count(expected_validity.begin(),
+                   expected_validity.begin() + logical_offset,
+                   true);
+    EXPECT_EQ(chunk.PhysicalOffsetOf(logical_offset), expected_physical_offset);
+
+    const auto span = chunk.Span();
+    ASSERT_TRUE(span.validity());
+    EXPECT_TRUE(span.validity().is_packed());
+    for (int64_t i = 0; i < row_count; ++i) {
+        EXPECT_EQ(span.is_valid(i), expected_validity[i]);
+    }
+
+    const auto second_span = chunk.Span();
+    EXPECT_TRUE(second_span.validity().is_packed());
+}
+
+TEST(chunk, nullable_chunk_bulk_masks_unaligned_range) {
+    constexpr int64_t row_count = 130;
+    constexpr int64_t chunk_offset = 3;
+    constexpr int64_t result_offset = 5;
+    constexpr int64_t count = row_count - chunk_offset;
+    const auto bitmap_bytes = (row_count + 7) / 8;
+    std::vector<char> data(bitmap_bytes + row_count * sizeof(int64_t), 0);
+    FixedVector<bool> expected_validity;
+    expected_validity.reserve(row_count);
+    for (int64_t i = 0; i < row_count; ++i) {
+        const bool valid = i % 5 != 1 && i % 7 != 3;
+        expected_validity.push_back(valid);
+        if (valid) {
+            SetPackedValidity(data, i);
+        }
+    }
+
+    FixedWidthChunk chunk(
+        row_count, 1, data.data(), data.size(), sizeof(int64_t), true, nullptr);
+    TargetBitmap result(count + result_offset + 3, true);
+    chunk.ApplyValidityMask(
+        chunk_offset, count, TargetBitmapView(result).view(result_offset));
+
+    for (int64_t i = 0; i < result_offset; ++i) {
+        EXPECT_TRUE(result[i]);
+    }
+    for (int64_t i = 0; i < count; ++i) {
+        EXPECT_EQ(result[result_offset + i],
+                  expected_validity[chunk_offset + i]);
+    }
+    for (int64_t i = result_offset + count;
+         i < static_cast<int64_t>(result.size());
+         ++i) {
+        EXPECT_TRUE(result[i]);
+    }
+}
+
+TEST(chunk, nullable_string_views_reference_packed_validity) {
+    const std::vector<std::string> values = {"a", "bb", "ccc", "dddd", "eeeee"};
+    constexpr int64_t row_count = 5;
+    constexpr size_t bitmap_bytes = 1;
+    const auto offsets_bytes = (row_count + 1) * sizeof(uint32_t);
+    const auto payload_bytes = std::accumulate(
+        values.begin(),
+        values.end(),
+        size_t{0},
+        [](size_t total, const auto& value) { return total + value.size(); });
+    std::vector<char> data(bitmap_bytes + offsets_bytes + payload_bytes, 0);
+    data[0] = 0x15;
+
+    uint32_t data_offset = bitmap_bytes + offsets_bytes;
+    for (int64_t i = 0; i < row_count; ++i) {
+        WriteUint32(data, bitmap_bytes + i * sizeof(uint32_t), data_offset);
+        memcpy(data.data() + data_offset, values[i].data(), values[i].size());
+        data_offset += values[i].size();
+    }
+    WriteUint32(data, bitmap_bytes + row_count * sizeof(uint32_t), data_offset);
+
+    StringChunk chunk(row_count, data.data(), data.size(), true, nullptr);
+
+    auto [views, validity] = chunk.StringViews(std::make_pair(1, 3));
+    ASSERT_EQ(views.size(), 3);
+    EXPECT_EQ(views[0], values[1]);
+    EXPECT_EQ(views[1], values[2]);
+    EXPECT_EQ(views[2], values[3]);
+    EXPECT_EQ(validity.packed_data(),
+              reinterpret_cast<const uint8_t*>(data.data()));
+    EXPECT_EQ(validity.bit_offset(), 1);
+    EXPECT_FALSE(validity[0]);
+    EXPECT_TRUE(validity[1]);
+    EXPECT_FALSE(validity[2]);
+}
+
+TEST(chunk, nullable_array_views_reference_packed_validity) {
+    constexpr int64_t row_count = 5;
+    constexpr size_t bitmap_bytes = 1;
+    const auto offsets_bytes = (2 * row_count + 1) * sizeof(uint32_t);
+    std::vector<char> data(bitmap_bytes + offsets_bytes, 0);
+    data[0] = 0x15;
+    const auto payload_offset = static_cast<uint32_t>(data.size());
+    for (int64_t i = 0; i <= row_count; ++i) {
+        WriteUint32(
+            data, bitmap_bytes + 2 * i * sizeof(uint32_t), payload_offset);
+        if (i < row_count) {
+            WriteUint32(data, bitmap_bytes + (2 * i + 1) * sizeof(uint32_t), 0);
+        }
+    }
+
+    ArrayChunk chunk(
+        row_count, data.data(), data.size(), DataType::INT32, true, nullptr);
+
+    auto [views, validity] = chunk.Views(std::make_pair(1, 3));
+    ASSERT_EQ(views.size(), 3);
+    EXPECT_EQ(validity.packed_data(),
+              reinterpret_cast<const uint8_t*>(data.data()));
+    EXPECT_EQ(validity.bit_offset(), 1);
+    EXPECT_FALSE(validity[0]);
+    EXPECT_TRUE(validity[1]);
+    EXPECT_FALSE(validity[2]);
+}
 
 TEST(chunk, test_int64_field) {
     FixedVector<int64_t> data = {1, 2, 3, 4, 5};
@@ -493,7 +656,6 @@ TEST(chunk, test_null_array) {
     auto [views, valid] = array_chunk->Views(std::nullopt);
 
     EXPECT_EQ(views.size(), array_count);
-    EXPECT_EQ(valid.size(), array_count);
 
     // Check validity based on our bitmap pattern (10101)
     EXPECT_TRUE(valid[0]);

--- a/internal/core/src/common/Span.h
+++ b/internal/core/src/common/Span.h
@@ -22,6 +22,7 @@
 #include <type_traits>
 
 #include "Types.h"
+#include "ValidityView.h"
 #include "VectorTrait.h"
 #include "TypeTraits.h"
 
@@ -39,7 +40,16 @@ class SpanBase {
                       int64_t row_count,
                       int64_t element_sizeof)
         : data_(data),
-          valid_data_(valid_data),
+          validity_(ValidityView::FromExpanded(valid_data)),
+          row_count_(row_count),
+          element_sizeof_(element_sizeof) {
+    }
+    explicit SpanBase(const void* data,
+                      ValidityView validity,
+                      int64_t row_count,
+                      int64_t element_sizeof)
+        : data_(data),
+          validity_(validity),
           row_count_(row_count),
           element_sizeof_(element_sizeof) {
     }
@@ -59,14 +69,19 @@ class SpanBase {
         return data_;
     }
 
-    const bool*
-    valid_data() const {
-        return valid_data_;
+    ValidityView
+    validity() const {
+        return validity_;
+    }
+
+    bool
+    is_valid(int64_t offset) const {
+        return !validity_ || validity_[offset];
     }
 
  private:
     const void* data_;
-    const bool* valid_data_{nullptr};
+    ValidityView validity_;
     int64_t row_count_;
     int64_t element_sizeof_;
 };
@@ -82,7 +97,11 @@ class Span<T,
  public:
     using embedded_type = T;
     explicit Span(const T* data, const bool* valid_data, int64_t row_count)
-        : data_(data), valid_data_(valid_data), row_count_(row_count) {
+        : Span(data, ValidityView::FromExpanded(valid_data), row_count) {
+    }
+
+    explicit Span(const T* data, ValidityView validity, int64_t row_count)
+        : data_(data), validity_(validity), row_count_(row_count) {
     }
 
     explicit Span(std::string_view data, bool* valid_data) {
@@ -90,12 +109,12 @@ class Span<T,
     }
 
     operator SpanBase() const {
-        return SpanBase(data_, valid_data_, row_count_, sizeof(T));
+        return SpanBase(data_, validity_, row_count_, sizeof(T));
     }
 
     explicit Span(const SpanBase& base)
         : Span(reinterpret_cast<const T*>(base.data()),
-               base.valid_data(),
+               base.validity(),
                base.row_count()) {
         assert(base.element_sizeof() == sizeof(T));
     }
@@ -110,9 +129,14 @@ class Span<T,
         return data_;
     }
 
-    const bool*
-    valid_data() const {
-        return valid_data_;
+    ValidityView
+    validity() const {
+        return validity_;
+    }
+
+    bool
+    is_valid(int64_t offset) const {
+        return !validity_ || validity_[offset];
     }
 
     const T&
@@ -127,7 +151,7 @@ class Span<T,
 
  private:
     const T* data_;
-    const bool* valid_data_;
+    ValidityView validity_;
     int64_t row_count_;
 };
 

--- a/internal/core/src/common/SpanTest.cpp
+++ b/internal/core/src/common/SpanTest.cpp
@@ -14,7 +14,9 @@
 #include "common/Types.h"
 #include "common/Utils.h"
 #include "common/Span.h"
+#include "common/ValidityView.h"
 #include "common/VectorTrait.h"
+#include "exec/expression/Expr.h"
 #include "segcore/SegmentGrowing.h"
 #include "test_utils/DataGen.h"
 
@@ -33,6 +35,80 @@ TEST(Common, Span) {
     ASSERT_EQ(r1.row_count(), 100);
     ASSERT_EQ(r2.row_count(), 10);
     ASSERT_EQ(r2.element_sizeof(), 16 * sizeof(float));
+}
+
+TEST(Span, ValidityViewSupportsExpandedAndPackedData) {
+    using namespace milvus;
+
+    const bool expanded[] = {true, false, true, false, true};
+    const uint8_t packed[] = {0x15};
+    const auto expanded_view = ValidityView::FromExpanded(expanded);
+    const auto packed_view = ValidityView::FromPacked(packed);
+
+    EXPECT_TRUE(expanded_view);
+    EXPECT_FALSE(expanded_view.is_packed());
+    EXPECT_EQ(expanded_view.expanded_data(), expanded);
+    EXPECT_TRUE(packed_view);
+    EXPECT_TRUE(packed_view.is_packed());
+    EXPECT_EQ(packed_view.expanded_data(), nullptr);
+    for (int64_t i = 0; i < 5; ++i) {
+        EXPECT_EQ(expanded_view[i], expanded[i]);
+        EXPECT_EQ(packed_view[i], expanded[i]);
+    }
+
+    const auto subview = packed_view.Subview(1);
+    EXPECT_FALSE(subview[0]);
+    EXPECT_TRUE(subview[1]);
+    EXPECT_FALSE(subview[2]);
+    EXPECT_EQ(expanded_view.Subview(1).expanded_data(), expanded + 1);
+}
+
+TEST(Span, PackedValidityMasksBitmapsWithoutLosingOffsets) {
+    using namespace milvus;
+    using namespace milvus::exec;
+
+    constexpr int64_t validity_offset = 3;
+    constexpr int64_t result_offset = 5;
+    constexpr int64_t size = 70;
+    const uint8_t packed[] = {
+        0b10110101,
+        0b01011010,
+        0b11110000,
+        0b00111100,
+        0b11000011,
+        0b10011001,
+        0b01100110,
+        0b11111111,
+        0b00010101,
+        0b00011110,
+    };
+    const auto validity =
+        ValidityView::FromPacked(packed).Subview(validity_offset);
+
+    EXPECT_EQ(validity.packed_data(), packed);
+    EXPECT_EQ(validity.bit_offset(), validity_offset);
+
+    TargetBitmap result(size + result_offset + 3, false);
+    TargetBitmap valid_result(size + result_offset + 3, true);
+    for (int64_t i = 0; i < size; ++i) {
+        result[result_offset + i] = (i % 3) != 0;
+    }
+    ApplyValidMask(validity,
+                   TargetBitmapView(result).view(result_offset),
+                   TargetBitmapView(valid_result).view(result_offset),
+                   size);
+
+    for (int64_t i = 0; i < size; ++i) {
+        const bool expected_valid = validity[i];
+        EXPECT_EQ(result[result_offset + i], ((i % 3) != 0) && expected_valid)
+            << "row " << i;
+        EXPECT_EQ(valid_result[result_offset + i], expected_valid)
+            << "row " << i;
+    }
+    for (int64_t i = 0; i < result_offset; ++i) {
+        EXPECT_FALSE(result[i]);
+        EXPECT_TRUE(valid_result[i]);
+    }
 }
 
 TEST(Span, Naive) {
@@ -81,7 +157,7 @@ TEST(Span, Naive) {
         auto begin = chunk_id * size_per_chunk;
         auto end = std::min((chunk_id + 1) * size_per_chunk, N);
         auto size_of_chunk = end - begin;
-        ASSERT_EQ(age_span.get().valid_data(), nullptr);
+        ASSERT_FALSE(age_span.get().validity());
         for (int i = 0; i < size_of_chunk * 512 / 8; ++i) {
             ASSERT_EQ(vec_span.get().data()[i], vec_ptr[i + begin * 512 / 8]);
         }
@@ -96,7 +172,7 @@ TEST(Span, Naive) {
                       nullable_data_ptr[i + begin]);
         }
         for (int i = 0; i < size_of_chunk; ++i) {
-            ASSERT_EQ(null_field_span.get().valid_data()[i],
+            ASSERT_EQ(null_field_span.get().is_valid(i),
                       nullable_valid_data_ptr[i + begin]);
         }
     }

--- a/internal/core/src/common/ValidityView.h
+++ b/internal/core/src/common/ValidityView.h
@@ -1,0 +1,104 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace milvus {
+
+// Non-owning view over either one-byte-per-row bool data or an LSB-first
+// packed bitmap. The underlying buffer must outlive the view.
+class ValidityView {
+ public:
+    ValidityView() = default;
+    ValidityView(std::nullptr_t) {
+    }
+
+    static ValidityView
+    FromExpanded(const bool* data) {
+        return ValidityView(data, Encoding::Expanded, 0);
+    }
+
+    static ValidityView
+    FromPacked(const uint8_t* data) {
+        return ValidityView(data, Encoding::Packed, 0);
+    }
+
+    explicit operator bool() const {
+        return data_ != nullptr;
+    }
+
+    bool
+    operator[](int64_t index) const {
+        const auto offset = offset_ + index;
+        if (encoding_ == Encoding::Expanded) {
+            return static_cast<const bool*>(data_)[offset];
+        }
+        return (static_cast<const uint8_t*>(data_)[offset >> 3] >>
+                (offset & 0x07)) &
+               1;
+    }
+
+    bool
+    is_packed() const {
+        return encoding_ == Encoding::Packed;
+    }
+
+    ValidityView
+    Subview(int64_t offset) const {
+        auto result = *this;
+        result.offset_ += offset;
+        return result;
+    }
+
+    const bool*
+    expanded_data() const {
+        if (encoding_ != Encoding::Expanded) {
+            return nullptr;
+        }
+        return static_cast<const bool*>(data_) + offset_;
+    }
+
+    const uint8_t*
+    packed_data() const {
+        if (encoding_ != Encoding::Packed) {
+            return nullptr;
+        }
+        return static_cast<const uint8_t*>(data_);
+    }
+
+    int64_t
+    bit_offset() const {
+        return offset_;
+    }
+
+ private:
+    enum class Encoding : uint8_t { None, Expanded, Packed };
+
+    ValidityView(const void* data, Encoding encoding, int64_t offset)
+        : data_(data),
+          encoding_(data == nullptr ? Encoding::None : encoding),
+          offset_(offset) {
+    }
+
+    const void* data_{nullptr};
+    Encoding encoding_{Encoding::None};
+    int64_t offset_{0};
+};
+
+}  // namespace milvus

--- a/internal/core/src/common/ValidityView.h
+++ b/internal/core/src/common/ValidityView.h
@@ -66,6 +66,8 @@ class ValidityView {
         return result;
     }
 
+    // Returns a pointer to the first expanded validity entry in this view.
+    // Any Subview offset is already applied to the returned pointer.
     const bool*
     expanded_data() const {
         if (encoding_ != Encoding::Expanded) {
@@ -74,6 +76,8 @@ class ValidityView {
         return static_cast<const bool*>(data_) + offset_;
     }
 
+    // Returns the base address of the packed bitmap. A Subview offset may not
+    // be byte-aligned, so it is exposed separately through bit_offset().
     const uint8_t*
     packed_data() const {
         if (encoding_ != Encoding::Packed) {
@@ -82,6 +86,8 @@ class ValidityView {
         return static_cast<const uint8_t*>(data_);
     }
 
+    // For a packed view, returns the bit offset of the first entry relative to
+    // packed_data().
     int64_t
     bit_offset() const {
         return offset_;

--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
@@ -180,7 +180,7 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForJson(
             if constexpr (filter_type == FilterType::random) {              \
                 offset = (offsets) ? offsets[i] : i;                        \
             }                                                               \
-            if (valid_data != nullptr && !valid_data[offset]) {             \
+            if (valid_data && !valid_data[offset]) {                        \
                 res[i] = false;                                             \
                 valid_res[i] = false;                                       \
                 continue;                                                   \
@@ -215,36 +215,36 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForJson(
         }                                                                   \
     } while (false)
 
-#define BinaryArithRangeJONCompareArrayLength(cmp)              \
-    do {                                                        \
-        for (size_t i = 0; i < size; ++i) {                     \
-            auto offset = i;                                    \
-            if constexpr (filter_type == FilterType::random) {  \
-                offset = (offsets) ? offsets[i] : i;            \
-            }                                                   \
-            if (valid_data != nullptr && !valid_data[offset]) { \
-                res[i] = false;                                 \
-                valid_res[i] = false;                           \
-                continue;                                       \
-            }                                                   \
-            int array_length = 0;                               \
-            auto doc = data[offset].doc();                      \
-            auto array = doc.at_pointer(pointer).get_array();   \
-            if (array.error()) {                                \
-                res[i] = false;                                 \
-                valid_res[i] = false;                           \
-                continue;                                       \
-            }                                                   \
-            array_length = array.count_elements();              \
-            res[i] = (cmp);                                     \
-        }                                                       \
+#define BinaryArithRangeJONCompareArrayLength(cmp)             \
+    do {                                                       \
+        for (size_t i = 0; i < size; ++i) {                    \
+            auto offset = i;                                   \
+            if constexpr (filter_type == FilterType::random) { \
+                offset = (offsets) ? offsets[i] : i;           \
+            }                                                  \
+            if (valid_data && !valid_data[offset]) {           \
+                res[i] = false;                                \
+                valid_res[i] = false;                          \
+                continue;                                      \
+            }                                                  \
+            int array_length = 0;                              \
+            auto doc = data[offset].doc();                     \
+            auto array = doc.at_pointer(pointer).get_array();  \
+            if (array.error()) {                               \
+                res[i] = false;                                \
+                valid_res[i] = false;                          \
+                continue;                                      \
+            }                                                  \
+            array_length = array.count_elements();             \
+            res[i] = (cmp);                                    \
+        }                                                      \
     } while (false)
 
     auto execute_sub_batch =
         [ op_type,
           arith_type ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -592,7 +592,7 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForArray(
             if constexpr (filter_type == FilterType::random) {  \
                 offset = (offsets) ? offsets[i] : i;            \
             }                                                   \
-            if (valid_data != nullptr && !valid_data[offset]) { \
+            if (valid_data && !valid_data[offset]) {            \
                 res[i] = false;                                 \
                 valid_res[i] = false;                           \
                 continue;                                       \
@@ -607,26 +607,26 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForArray(
         }                                                       \
     } while (false)
 
-#define BinaryArithRangeArrayLengthCompate(cmp)                 \
-    do {                                                        \
-        for (size_t i = 0; i < size; ++i) {                     \
-            auto offset = i;                                    \
-            if constexpr (filter_type == FilterType::random) {  \
-                offset = (offsets) ? offsets[i] : i;            \
-            }                                                   \
-            if (valid_data != nullptr && !valid_data[offset]) { \
-                res[i] = valid_res[i] = false;                  \
-                continue;                                       \
-            }                                                   \
-            res[i] = (cmp);                                     \
-        }                                                       \
+#define BinaryArithRangeArrayLengthCompate(cmp)                \
+    do {                                                       \
+        for (size_t i = 0; i < size; ++i) {                    \
+            auto offset = i;                                   \
+            if constexpr (filter_type == FilterType::random) { \
+                offset = (offsets) ? offsets[i] : i;           \
+            }                                                  \
+            if (valid_data && !valid_data[offset]) {           \
+                res[i] = valid_res[i] = false;                 \
+                continue;                                      \
+            }                                                  \
+            res[i] = (cmp);                                    \
+        }                                                      \
     } while (false)
 
     auto execute_sub_batch =
         [ op_type,
           arith_type ]<FilterType filter_type = FilterType::sequential>(
             const ArrayView* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -1495,7 +1495,7 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForData(
         [ op_type,
           arith_type ]<FilterType filter_type = FilterType::sequential>(
             const T* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -1853,12 +1853,11 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForData(
         // there is a batch operation in ArithOpElementFunc,
         // so not divide data again for the reason that it may reduce performance if the null distribution is scattered
         // but to mask res with valid_data after the batch operation.
-        if (valid_data != nullptr) {
+        if constexpr (filter_type == FilterType::sequential) {
+            ApplyValidMask(valid_data, res, valid_res, size);
+        } else if (valid_data) {
             for (int i = 0; i < size; i++) {
-                auto offset = i;
-                if constexpr (filter_type == FilterType::random) {
-                    offset = (offsets) ? offsets[i] : i;
-                }
+                auto offset = (offsets) ? offsets[i] : i;
                 if (!valid_data[offset]) {
                     res[i] = valid_res[i] = false;
                 }

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -244,7 +244,7 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonPreciseNumeric(
             &processed_cursor
         ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -255,7 +255,7 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonPreciseNumeric(
             if constexpr (filter_type == FilterType::random) {
                 offset = offsets ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -494,7 +494,7 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
         [ lower_inclusive, upper_inclusive, &processed_cursor, &
           bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const T* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -551,12 +551,11 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
         // there is a batch operation in BinaryRangeElementFunc,
         // so not divide data again for the reason that it may reduce performance if the null distribution is scattered
         // but to mask res with valid_data after the batch operation.
-        if (valid_data != nullptr) {
+        if constexpr (filter_type == FilterType::sequential) {
+            ApplyValidMask(valid_data, res, valid_res, size);
+        } else if (valid_data) {
             for (int i = 0; i < size; i++) {
-                auto offset = i;
-                if constexpr (filter_type == FilterType::random) {
-                    offset = (offsets) ? offsets[i] : i;
-                }
+                auto offset = (offsets) ? offsets[i] : i;
                 if (!valid_data[offset]) {
                     res[i] = valid_res[i] = false;
                 }
@@ -655,7 +654,7 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJson(EvalCtx& context) {
             &processed_cursor
         ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -807,12 +806,12 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonStats(
                                            &lower_bound,
                                            &upper_bound](
                                               const ColType* src,
-                                              const bool* valid,
+                                              ValidityView valid,
                                               size_t size,
                                               TargetBitmapView res,
                                               TargetBitmapView valid_res) {
                     for (size_t i = 0; i < size; ++i) {
-                        if (valid != nullptr && !valid[i]) {
+                        if (valid && !valid[i]) {
                             res[i] = valid_res[i] = false;
                             continue;
                         }
@@ -1000,7 +999,7 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForArray(EvalCtx& context) {
         [ lower_inclusive, upper_inclusive, &processed_cursor, &
           bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const milvus::ArrayView* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,

--- a/internal/core/src/exec/expression/BinaryRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.h
@@ -100,7 +100,7 @@ struct BinaryRangeElementFunc {
 // 'cmp' must reference 'value' (int64_t or double depending on the JSON value).
 #define BinaryRangeJSONCompare(cmp)                                    \
     do {                                                               \
-        if (valid_data != nullptr && !valid_data[offset]) {            \
+        if (valid_data && !valid_data[offset]) {                       \
             res[i] = valid_res[i] = false;                             \
             break;                                                     \
         }                                                              \
@@ -147,7 +147,7 @@ struct BinaryRangeElementFuncForJson {
                ValueType val2,
                const std::string& pointer,
                const milvus::Json* src,
-               const bool* valid_data,
+               ValidityView valid_data,
                size_t n,
                TargetBitmapView res,
                TargetBitmapView valid_res,
@@ -186,7 +186,7 @@ struct BinaryRangeElementFuncForArray {
                ValueType val2,
                int index,
                const milvus::ArrayView* src,
-               const bool* valid_data,
+               ValidityView valid_data,
                size_t n,
                TargetBitmapView res,
                TargetBitmapView valid_res,
@@ -204,7 +204,7 @@ struct BinaryRangeElementFuncForArray {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }

--- a/internal/core/src/exec/expression/CompareExpr.h
+++ b/internal/core/src/exec/expression/CompareExpr.h
@@ -348,15 +348,15 @@ class PhyCompareFilterExpr : public Expr {
                     1,
                     res + processed_size,
                     values...);
-                const bool* left_valid_data = left_chunk.valid_data();
-                const bool* right_valid_data = right_chunk.valid_data();
+                const auto left_validity = left_chunk.validity();
+                const auto right_validity = right_chunk.validity();
                 // mask with valid_data
-                if (left_valid_data && !left_valid_data[left_chunk_offset]) {
+                if (left_validity && !left_validity[left_chunk_offset]) {
                     res[processed_size] = false;
                     valid_res[processed_size] = false;
                     continue;
                 }
-                if (right_valid_data && !right_valid_data[right_chunk_offset]) {
+                if (right_validity && !right_validity[right_chunk_offset]) {
                     res[processed_size] = false;
                     valid_res[processed_size] = false;
                 }
@@ -374,16 +374,16 @@ class PhyCompareFilterExpr : public Expr {
             const U* right_data = right_chunk.data();
             func.template operator()<FilterType::random>(
                 left_data, right_data, input->data(), size, res, values...);
-            const bool* left_valid_data = left_chunk.valid_data();
-            const bool* right_valid_data = right_chunk.valid_data();
+            const auto left_validity = left_chunk.validity();
+            const auto right_validity = right_chunk.validity();
             // mask with valid_data
             for (int i = 0; i < size; ++i) {
-                if (left_valid_data && !left_valid_data[(*input)[i]]) {
+                if (left_validity && !left_validity[(*input)[i]]) {
                     res[i] = false;
                     valid_res[i] = false;
                     continue;
                 }
-                if (right_valid_data && !right_valid_data[(*input)[i]]) {
+                if (right_validity && !right_validity[(*input)[i]]) {
                     res[i] = false;
                     valid_res[i] = false;
                 }
@@ -437,20 +437,14 @@ class PhyCompareFilterExpr : public Expr {
                  size,
                  res + processed_size,
                  values...);
-            const bool* left_valid_data = left_chunk.valid_data();
-            const bool* right_valid_data = right_chunk.valid_data();
-            // mask with valid_data
-            for (int i = 0; i < size; ++i) {
-                if (left_valid_data && !left_valid_data[i + data_pos]) {
-                    res[processed_size + i] = false;
-                    valid_res[processed_size + i] = false;
-                    continue;
-                }
-                if (right_valid_data && !right_valid_data[i + data_pos]) {
-                    res[processed_size + i] = false;
-                    valid_res[processed_size + i] = false;
-                }
-            }
+            ApplyValidMask(left_chunk.validity().Subview(data_pos),
+                           res + processed_size,
+                           valid_res + processed_size,
+                           size);
+            ApplyValidMask(right_chunk.validity().Subview(data_pos),
+                           res + processed_size,
+                           valid_res + processed_size,
+                           size);
             processed_size += size;
 
             if (processed_size >= batch_size_) {
@@ -512,20 +506,14 @@ class PhyCompareFilterExpr : public Expr {
                  size,
                  res + processed_size,
                  values...);
-            const bool* left_valid_data = left_chunk.valid_data();
-            const bool* right_valid_data = right_chunk.valid_data();
-            // mask with valid_data
-            for (int i = 0; i < size; ++i) {
-                if (left_valid_data && !left_valid_data[i + data_pos]) {
-                    res[processed_size + i] = false;
-                    valid_res[processed_size + i] = false;
-                    continue;
-                }
-                if (right_valid_data && !right_valid_data[i + data_pos]) {
-                    res[processed_size + i] = false;
-                    valid_res[processed_size + i] = false;
-                }
-            }
+            ApplyValidMask(left_chunk.validity().Subview(data_pos),
+                           res + processed_size,
+                           valid_res + processed_size,
+                           size);
+            ApplyValidMask(right_chunk.validity().Subview(data_pos),
+                           res + processed_size,
+                           valid_res + processed_size,
+                           size);
             processed_size += size;
 
             if (processed_size >= batch_size_) {

--- a/internal/core/src/exec/expression/ExistsExpr.cpp
+++ b/internal/core/src/exec/expression/ExistsExpr.cpp
@@ -150,7 +150,7 @@ PhyExistsFilterExpr::EvalJsonExistsForDataSegment(EvalCtx& context) {
         [&bitmap_input, &
          processed_cursor ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -168,7 +168,7 @@ PhyExistsFilterExpr::EvalJsonExistsForDataSegment(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = false;
                 continue;
             }

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -62,6 +62,66 @@ PinIndex(milvus::OpContext* op_ctx,
     }
 }
 
+inline void
+ApplyValidMask(const bool* valid_data,
+               TargetBitmapView res,
+               TargetBitmapView valid_res,
+               const int size) {
+    if (valid_data == nullptr) {
+        return;
+    }
+    for (int i = 0; i < size; ++i) {
+        if (!valid_data[i]) {
+            res[i] = valid_res[i] = false;
+        }
+    }
+}
+
+inline void
+ApplyValidMask(ValidityView validity,
+               TargetBitmapView res,
+               TargetBitmapView valid_res,
+               const int size) {
+    if (!validity) {
+        return;
+    }
+
+    if (const auto* expanded = validity.expanded_data(); expanded != nullptr) {
+        ApplyValidMask(expanded, res, valid_res, size);
+        return;
+    }
+
+    const auto* packed = validity.packed_data();
+    AssertInfo(packed != nullptr, "Packed validity data is missing");
+
+    const auto read_word = [packed](int64_t bit_offset, int bit_count) {
+        const auto byte_offset = bit_offset >> 3;
+        const auto shift = static_cast<int>(bit_offset & 0x07);
+        const auto bytes = (shift + bit_count + 7) >> 3;
+        uint64_t word = 0;
+        const auto low_bytes = std::min(bytes, 8);
+        for (int i = 0; i < low_bytes; ++i) {
+            word |= uint64_t(packed[byte_offset + i]) << (i * 8);
+        }
+        word >>= shift;
+        if (bytes > 8) {
+            word |= uint64_t(packed[byte_offset + 8]) << (64 - shift);
+        }
+        if (bit_count < 64) {
+            word &= (uint64_t{1} << bit_count) - 1;
+        }
+        return word;
+    };
+
+    for (int i = 0; i < size; i += 64) {
+        const auto bit_count = std::min(size - i, 64);
+        auto word = read_word(validity.bit_offset() + i, bit_count);
+        TargetBitmapView validity_word(&word, bit_count);
+        res.view(i).inplace_and(validity_word, bit_count);
+        valid_res.view(i).inplace_and(validity_word, bit_count);
+    }
+}
+
 class Expr {
  public:
     Expr(DataType type,
@@ -316,17 +376,11 @@ class SegmentExpr : public Expr {
     }
 
     void
-    ApplyValidData(const bool* valid_data,
+    ApplyValidData(ValidityView validity,
                    TargetBitmapView res,
                    TargetBitmapView valid_res,
                    const int size) {
-        if (valid_data != nullptr) {
-            for (int i = 0; i < size; i++) {
-                if (!valid_data[i]) {
-                    res[i] = valid_res[i] = false;
-                }
-            }
-        }
+        ApplyValidMask(validity, res, valid_res, size);
     }
 
     int64_t
@@ -393,7 +447,7 @@ class SegmentExpr : public Expr {
                         static_cast<int32_t>(current_data_chunk_pos_ + j);
                 }
                 func(views_info.first.data(),
-                     views_info.second.data(),
+                     views_info.second,
                      nullptr,
                      segment_offsets_array.data(),
                      need_size,
@@ -402,7 +456,7 @@ class SegmentExpr : public Expr {
                      values...);
             } else {
                 func(views_info.first.data(),
-                     views_info.second.data(),
+                     views_info.second,
                      nullptr,
                      need_size,
                      res,
@@ -410,7 +464,7 @@ class SegmentExpr : public Expr {
                      values...);
             }
         } else {
-            ApplyValidData(views_info.second.data(), res, valid_res, need_size);
+            ApplyValidData(views_info.second, res, valid_res, need_size);
         }
         current_data_chunk_pos_ += need_size;
         return need_size;
@@ -439,14 +493,17 @@ class SegmentExpr : public Expr {
         auto [data_vec, valid_data] = pw.get();
         if (!skip_func || !skip_func(skip_index, field_id_, 0)) {
             func(data_vec.data(),
-                 valid_data.data(),
+                 ValidityView::FromExpanded(valid_data.data()),
                  nullptr,
                  input->size(),
                  res,
                  valid_res,
                  values...);
         } else {
-            ApplyValidData(valid_data.data(), res, valid_res, input->size());
+            ApplyValidData(ValidityView::FromExpanded(valid_data.data()),
+                           res,
+                           valid_res,
+                           input->size());
         }
         return input->size();
     }
@@ -506,13 +563,14 @@ class SegmentExpr : public Expr {
                 }
                 T raw_data = raw.value();
                 bool valid_data = valid_result[offset];
-                func.template operator()<FilterType::random>(&raw_data,
-                                                             &valid_data,
-                                                             nullptr,
-                                                             1,
-                                                             res + i,
-                                                             valid_res + i,
-                                                             values...);
+                func.template operator()<FilterType::random>(
+                    &raw_data,
+                    ValidityView::FromExpanded(&valid_data),
+                    nullptr,
+                    1,
+                    res + i,
+                    valid_res + i,
+                    values...);
             }
         } else {
             for (auto i = 0; i < batch_size; ++i) {
@@ -566,7 +624,7 @@ class SegmentExpr : public Expr {
                             !skip_func(skip_index, field_id_, chunk_id)) {
                             func.template operator()<FilterType::random>(
                                 data_vec.data(),
-                                valid_data.data(),
+                                ValidityView::FromExpanded(valid_data.data()),
                                 nullptr,
                                 1,
                                 res + processed_size,
@@ -590,22 +648,20 @@ class SegmentExpr : public Expr {
                         segment_->chunk_data<T>(op_ctx_, field_id_, chunk_id);
                     auto chunk = pw.get();
                     const T* data = chunk.data() + chunk_offset;
-                    const bool* valid_data = chunk.valid_data();
-                    if (valid_data != nullptr) {
-                        valid_data += chunk_offset;
-                    }
+                    const auto validity =
+                        chunk.validity().Subview(chunk_offset);
                     if (!skip_func ||
                         !skip_func(skip_index, field_id_, chunk_id)) {
                         func.template operator()<FilterType::random>(
                             data,
-                            valid_data,
+                            validity,
                             nullptr,
                             1,
                             res + processed_size,
                             valid_res + processed_size,
                             values...);
                     } else {
-                        ApplyValidData(valid_data,
+                        ApplyValidData(validity,
                                        res + processed_size,
                                        valid_res + processed_size,
                                        1);
@@ -623,17 +679,17 @@ class SegmentExpr : public Expr {
                 auto pw = segment_->chunk_data<T>(op_ctx_, field_id_, 0);
                 auto chunk = pw.get();
                 const T* data = chunk.data();
-                const bool* valid_data = chunk.valid_data();
+                const auto validity = chunk.validity();
                 if (!skip_func || !skip_func(skip_index, field_id_, 0)) {
                     func.template operator()<FilterType::random>(data,
-                                                                 valid_data,
+                                                                 validity,
                                                                  input->data(),
                                                                  input->size(),
                                                                  res,
                                                                  valid_res,
                                                                  values...);
                 } else {
-                    ApplyValidData(valid_data, res, valid_res, input->size());
+                    ApplyValidData(validity, res, valid_res, input->size());
                 }
                 return input->size();
             }
@@ -646,21 +702,18 @@ class SegmentExpr : public Expr {
                 auto pw = segment_->chunk_data<T>(op_ctx_, field_id_, chunk_id);
                 auto chunk = pw.get();
                 const T* data = chunk.data() + chunk_offset;
-                const bool* valid_data = chunk.valid_data();
-                if (valid_data != nullptr) {
-                    valid_data += chunk_offset;
-                }
+                const auto validity = chunk.validity().Subview(chunk_offset);
                 if (!skip_func || !skip_func(skip_index, field_id_, chunk_id)) {
                     func.template operator()<FilterType::random>(
                         data,
-                        valid_data,
+                        validity,
                         nullptr,
                         1,
                         res + processed_size,
                         valid_res + processed_size,
                         values...);
                 } else {
-                    ApplyValidData(valid_data,
+                    ApplyValidData(validity,
                                    res + processed_size,
                                    valid_res + processed_size,
                                    1);
@@ -711,10 +764,7 @@ class SegmentExpr : public Expr {
             auto& skip_index = segment_->GetSkipIndex();
             auto pw = segment_->chunk_data<T>(op_ctx_, field_id_, i);
             auto chunk = pw.get();
-            const bool* valid_data = chunk.valid_data();
-            if (valid_data != nullptr) {
-                valid_data += data_pos;
-            }
+            const auto validity = chunk.validity().Subview(data_pos);
 
             if (!skip_func || !skip_func(skip_index, field_id_, i)) {
                 const T* data = chunk.data() + data_pos;
@@ -727,7 +777,7 @@ class SegmentExpr : public Expr {
                             size_per_chunk_ * i + data_pos + j);
                     }
                     func(data,
-                         valid_data,
+                         validity,
                          nullptr,
                          segment_offsets_array.data(),
                          size,
@@ -736,7 +786,7 @@ class SegmentExpr : public Expr {
                          values...);
                 } else {
                     func(data,
-                         valid_data,
+                         validity,
                          nullptr,
                          size,
                          res + processed_size,
@@ -749,7 +799,7 @@ class SegmentExpr : public Expr {
                 // 1. Apply valid_data to handle nullable fields
                 // 2. Call func with nullptr to update internal cursors
                 //    (e.g., processed_cursor for bitmap_input indexing)
-                ApplyValidData(valid_data,
+                ApplyValidData(validity,
                                res + processed_size,
                                valid_res + processed_size,
                                size);
@@ -761,7 +811,7 @@ class SegmentExpr : public Expr {
                             size_per_chunk_ * i + data_pos + j);
                     }
                     func(nullptr,
-                         nullptr,
+                         ValidityView{},
                          nullptr,
                          segment_offsets_array.data(),
                          size,
@@ -770,7 +820,7 @@ class SegmentExpr : public Expr {
                          values...);
                 } else {
                     func(nullptr,
-                         nullptr,
+                         ValidityView{},
                          nullptr,
                          size,
                          res + processed_size,
@@ -846,7 +896,7 @@ class SegmentExpr : public Expr {
 
                         if constexpr (NeedSegmentOffsets) {
                             func(data_vec.data(),
-                                 valid_data.data(),
+                                 valid_data,
                                  nullptr,
                                  segment_offsets_array.data(),
                                  size,
@@ -855,7 +905,7 @@ class SegmentExpr : public Expr {
                                  values...);
                         } else {
                             func(data_vec.data(),
-                                 valid_data.data(),
+                                 valid_data,
                                  nullptr,
                                  size,
                                  res + processed_size,
@@ -870,15 +920,12 @@ class SegmentExpr : public Expr {
                     auto pw = segment_->chunk_data<T>(op_ctx_, field_id_, i);
                     auto chunk = pw.get();
                     const T* data = chunk.data() + data_pos;
-                    const bool* valid_data = chunk.valid_data();
-                    if (valid_data != nullptr) {
-                        valid_data += data_pos;
-                    }
+                    const auto validity = chunk.validity().Subview(data_pos);
 
                     if constexpr (NeedSegmentOffsets) {
                         // For GIS functions: construct segment offsets array
                         func(data,
-                             valid_data,
+                             validity,
                              nullptr,
                              segment_offsets_array.data(),
                              size,
@@ -887,7 +934,7 @@ class SegmentExpr : public Expr {
                              values...);
                     } else {
                         func(data,
-                             valid_data,
+                             validity,
                              nullptr,
                              size,
                              res + processed_size,
@@ -901,25 +948,22 @@ class SegmentExpr : public Expr {
                 // 1. Apply valid_data to handle nullable fields
                 // 2. Call func with nullptr to update internal cursors
                 //    (e.g., processed_cursor for bitmap_input indexing)
-                const bool* valid_data;
+                ValidityView validity;
                 if constexpr (std::is_same_v<T, std::string_view> ||
                               std::is_same_v<T, Json> ||
                               std::is_same_v<T, ArrayView>) {
                     auto pw = segment_->get_batch_views<T>(
                         op_ctx_, field_id_, i, data_pos, size);
-                    valid_data = pw.get().second.data();
-                    ApplyValidData(valid_data,
+                    validity = pw.get().second;
+                    ApplyValidData(validity,
                                    res + processed_size,
                                    valid_res + processed_size,
                                    size);
                 } else {
                     auto pw = segment_->chunk_data<T>(op_ctx_, field_id_, i);
                     auto chunk = pw.get();
-                    valid_data = chunk.valid_data();
-                    if (valid_data != nullptr) {
-                        valid_data += data_pos;
-                    }
-                    ApplyValidData(valid_data,
+                    validity = chunk.validity().Subview(data_pos);
+                    ApplyValidData(validity,
                                    res + processed_size,
                                    valid_res + processed_size,
                                    size);
@@ -927,7 +971,7 @@ class SegmentExpr : public Expr {
                 // Call func with nullptr to update internal cursors
                 if constexpr (NeedSegmentOffsets) {
                     func(nullptr,
-                         nullptr,
+                         ValidityView{},
                          nullptr,
                          segment_offsets_array.data(),
                          size,
@@ -936,7 +980,7 @@ class SegmentExpr : public Expr {
                          values...);
                 } else {
                     func(nullptr,
-                         nullptr,
+                         ValidityView{},
                          nullptr,
                          size,
                          res + processed_size,
@@ -1285,9 +1329,9 @@ class SegmentExpr : public Expr {
                 }();
                 auto pw = segment_->chunk_data<T>(op_ctx_, field_id_, chunk_id);
                 auto chunk = pw.get();
-                const bool* valid_data = chunk.valid_data();
-                if (valid_data != nullptr) {
-                    valid_result[i] = valid_data[chunk_offset];
+                const auto validity = chunk.validity();
+                if (validity) {
+                    valid_result[i] = validity[chunk_offset];
                 } else {
                     break;
                 }

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
@@ -23,7 +23,7 @@ namespace exec {
 
 #define GEOMETRY_EXECUTE_SUB_BATCH_WITH_COMPARISON(_DataType, method)       \
     auto execute_sub_batch = [this](const _DataType* data,                  \
-                                    const bool* valid_data,                 \
+                                    ValidityView valid_data,                \
                                     const int32_t* offsets,                 \
                                     const int32_t* segment_offsets,         \
                                     const int size,                         \
@@ -38,7 +38,7 @@ namespace exec {
         if (geometry_cache) {                                               \
             auto cache_lock = geometry_cache->AcquireReadLock();            \
             for (int i = 0; i < size; ++i) {                                \
-                if (valid_data != nullptr && !valid_data[i]) {              \
+                if (valid_data && !valid_data[i]) {                         \
                     res[i] = valid_res[i] = false;                          \
                     continue;                                               \
                 }                                                           \
@@ -52,7 +52,7 @@ namespace exec {
         } else {                                                            \
             GEOSContextHandle_t ctx_ = GEOS_init_r();                       \
             for (int i = 0; i < size; ++i) {                                \
-                if (valid_data != nullptr && !valid_data[i]) {              \
+                if (valid_data && !valid_data[i]) {                         \
                     res[i] = valid_res[i] = false;                          \
                     continue;                                               \
                 }                                                           \
@@ -73,7 +73,7 @@ namespace exec {
 // Specialized macro for distance-based operations (ST_DWITHIN)
 #define GEOMETRY_EXECUTE_SUB_BATCH_WITH_COMPARISON_DISTANCE(_DataType, method) \
     auto execute_sub_batch = [this](const _DataType* data,                     \
-                                    const bool* valid_data,                    \
+                                    ValidityView valid_data,                   \
                                     const int32_t* offsets,                    \
                                     const int32_t* segment_offsets,            \
                                     const int size,                            \
@@ -88,7 +88,7 @@ namespace exec {
         if (geometry_cache) {                                                  \
             auto cache_lock = geometry_cache->AcquireReadLock();               \
             for (int i = 0; i < size; ++i) {                                   \
-                if (valid_data != nullptr && !valid_data[i]) {                 \
+                if (valid_data && !valid_data[i]) {                            \
                     res[i] = valid_res[i] = false;                             \
                     continue;                                                  \
                 }                                                              \
@@ -103,7 +103,7 @@ namespace exec {
         } else {                                                               \
             GEOSContextHandle_t ctx_ = GEOS_init_r();                          \
             for (int i = 0; i < size; ++i) {                                   \
-                if (valid_data != nullptr && !valid_data[i]) {                 \
+                if (valid_data && !valid_data[i]) {                            \
                     res[i] = valid_res[i] = false;                             \
                     continue;                                                  \
                 }                                                              \

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -333,7 +333,7 @@ PhyJsonContainsFilterExpr::ExecArrayContains(EvalCtx& context) {
         [&processed_cursor, &
          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const milvus::ArrayView* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -360,7 +360,7 @@ PhyJsonContainsFilterExpr::ExecArrayContains(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -439,7 +439,7 @@ PhyJsonContainsFilterExpr::ExecJsonContains(EvalCtx& context) {
         [&processed_cursor, &
          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -486,7 +486,7 @@ PhyJsonContainsFilterExpr::ExecJsonContains(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -705,7 +705,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsArray(EvalCtx& context) {
         [&processed_cursor, &
          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -750,7 +750,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsArray(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -934,7 +934,7 @@ PhyJsonContainsFilterExpr::ExecArrayContainsAll(EvalCtx& context) {
         [&processed_cursor, &
          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const milvus::ArrayView* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -963,7 +963,7 @@ PhyJsonContainsFilterExpr::ExecArrayContainsAll(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -1050,7 +1050,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAll(EvalCtx& context) {
         [&processed_cursor, &bitmap_input, &matcher, &
          found_large ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -1131,7 +1131,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAll(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -1389,7 +1389,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffType(EvalCtx& context) {
         [&processed_cursor, &
          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -1492,7 +1492,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffType(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -1754,7 +1754,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllArray(EvalCtx& context) {
         [&processed_cursor, &
          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -1804,7 +1804,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllArray(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -1994,7 +1994,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffType(EvalCtx& context) {
         [&processed_cursor, &
          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -2088,7 +2088,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffType(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }

--- a/internal/core/src/exec/expression/JsonContainsExpr.h
+++ b/internal/core/src/exec/expression/JsonContainsExpr.h
@@ -39,12 +39,12 @@ class ShreddingArrayBsonContainsArrayExecutor {
 
     void
     operator()(const std::string_view* src,
-               const bool* valid,
+               ValidityView valid,
                size_t size,
                TargetBitmapView res,
                TargetBitmapView valid_res) {
         for (size_t i = 0; i < size; ++i) {
-            if (valid != nullptr && !valid[i]) {
+            if (valid && !valid[i]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -87,12 +87,12 @@ class ShreddingArrayBsonContainsAllArrayExecutor {
 
     void
     operator()(const std::string_view* src,
-               const bool* valid,
+               ValidityView valid,
                size_t size,
                TargetBitmapView res,
                TargetBitmapView valid_res) {
         for (size_t i = 0; i < size; ++i) {
-            if (valid != nullptr && !valid[i]) {
+            if (valid && !valid[i]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -141,12 +141,12 @@ class ShreddingArrayBsonContainsAnyExecutor {
 
     void
     operator()(const std::string_view* src,
-               const bool* valid,
+               ValidityView valid,
                size_t size,
                TargetBitmapView res,
                TargetBitmapView valid_res) {
         for (size_t i = 0; i < size; ++i) {
-            if (valid != nullptr && !valid[i]) {
+            if (valid && !valid[i]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -197,12 +197,12 @@ class ShreddingArrayBsonContainsAllExecutor {
 
     void
     operator()(const std::string_view* src,
-               const bool* valid,
+               ValidityView valid,
                size_t size,
                TargetBitmapView res,
                TargetBitmapView valid_res) {
         for (size_t i = 0; i < size; ++i) {
-            if (valid != nullptr && !valid[i]) {
+            if (valid && !valid[i]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -244,12 +244,12 @@ class ShreddingArrayBsonContainsAllWithDiffTypeExecutor {
 
     void
     operator()(const std::string_view* src,
-               const bool* valid,
+               ValidityView valid,
                size_t size,
                TargetBitmapView res,
                TargetBitmapView valid_res) {
         for (size_t i = 0; i < size; ++i) {
-            if (valid != nullptr && !valid[i]) {
+            if (valid && !valid[i]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -356,12 +356,12 @@ class ShreddingArrayBsonContainsAnyWithDiffTypeExecutor {
 
     void
     operator()(const std::string_view* src,
-               const bool* valid,
+               ValidityView valid,
                size_t size,
                TargetBitmapView res,
                TargetBitmapView valid_res) {
         for (size_t i = 0; i < size; ++i) {
-            if (valid != nullptr && !valid[i]) {
+            if (valid && !valid[i]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -284,7 +284,7 @@ PhyTermFilterExpr::ExecTermArrayVariableInField(EvalCtx& context) {
         [&processed_cursor, &
          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const ArrayView* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -311,7 +311,7 @@ PhyTermFilterExpr::ExecTermArrayVariableInField(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -385,7 +385,7 @@ PhyTermFilterExpr::ExecTermArrayFieldInVariable(EvalCtx& context) {
         [&processed_cursor, &
          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const ArrayView* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -408,7 +408,7 @@ PhyTermFilterExpr::ExecTermArrayFieldInVariable(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -491,7 +491,7 @@ PhyTermFilterExpr::ExecTermJsonVariableInField(EvalCtx& context) {
         [&processed_cursor, &
          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -527,7 +527,7 @@ PhyTermFilterExpr::ExecTermJsonVariableInField(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -622,12 +622,12 @@ PhyTermFilterExpr::ExecJsonInVariableByStats() {
                 TargetBitmap target_valid(active_count_, true);
                 TargetBitmapView target_valid_view(target_valid);
                 auto shredding_executor = [this](const ColType* src,
-                                                 const bool* valid,
+                                                 ValidityView valid,
                                                  size_t size,
                                                  TargetBitmapView res,
                                                  TargetBitmapView valid_res) {
                     for (size_t i = 0; i < size; ++i) {
-                        if (valid != nullptr && !valid[i]) {
+                        if (valid && !valid[i]) {
                             res[i] = valid_res[i] = false;
                             continue;
                         }
@@ -770,7 +770,7 @@ PhyTermFilterExpr::ExecTermJsonFieldInVariable(EvalCtx& context) {
         [&processed_cursor, &
          bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -817,7 +817,7 @@ PhyTermFilterExpr::ExecTermJsonFieldInVariable(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -1049,7 +1049,7 @@ PhyTermFilterExpr::ExecVisitorImplForData(EvalCtx& context) {
         [&processed_cursor, &bitmap_input, &simd_filter_fn,
          str_set_elem ]<FilterType filter_type = FilterType::sequential>(
             const T* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -1065,14 +1065,7 @@ PhyTermFilterExpr::ExecVisitorImplForData(EvalCtx& context) {
         if constexpr (filter_type == FilterType::sequential) {
             if (simd_filter_fn) {
                 simd_filter_fn(data, size, res);
-                // Apply validity mask
-                if (valid_data != nullptr) {
-                    for (int i = 0; i < size; ++i) {
-                        if (!valid_data[i]) {
-                            res[i] = valid_res[i] = false;
-                        }
-                    }
-                }
+                ApplyValidMask(valid_data, res, valid_res, size);
                 // Apply bitmap mask
                 if (has_bitmap_input) {
                     for (int i = 0; i < size; ++i) {
@@ -1093,7 +1086,7 @@ PhyTermFilterExpr::ExecVisitorImplForData(EvalCtx& context) {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }

--- a/internal/core/src/exec/expression/TimestamptzArithCompareExpr.cpp
+++ b/internal/core/src/exec/expression/TimestamptzArithCompareExpr.cpp
@@ -287,7 +287,7 @@ PhyTimestamptzArithCompareExpr::ExecCompareVisitorImplForAll(
         [ arith_op,
           compare_op ]<FilterType filter_type = FilterType::sequential>(
             const T* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -300,7 +300,7 @@ PhyTimestamptzArithCompareExpr::ExecCompareVisitorImplForAll(
         const int64_t compare_us = compare_value;
         for (int i = 0; i < size; ++i) {
             const auto offset = offsets == nullptr ? i : offsets[i];
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 // NULL never matches, under either polarity (three-valued
                 // logic); do not evaluate the storage placeholder value.
                 res[i] = valid_res[i] = false;

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -376,7 +376,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonPreciseNumeric(
         [ pointer, bound, op_type, &bitmap_input, &
           processed_cursor ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -387,7 +387,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonPreciseNumeric(
             if constexpr (filter_type == FilterType::random) {
                 offset = offsets ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -454,7 +454,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplArray(EvalCtx& context) {
         [ op_type, &processed_cursor, &
           bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const milvus::ArrayView* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -900,7 +900,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
         [ op_type, pointer, &processed_cursor, &
           bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -914,7 +914,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                     if constexpr (filter_type == FilterType::random) {
                         offset = (offsets) ? offsets[i] : i;
                     }
-                    if (valid_data != nullptr && !valid_data[offset]) {
+                    if (valid_data && !valid_data[offset]) {
                         res[i] = valid_res[i] = false;
                         continue;
                     }
@@ -936,7 +936,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                     if constexpr (filter_type == FilterType::random) {
                         offset = (offsets) ? offsets[i] : i;
                     }
-                    if (valid_data != nullptr && !valid_data[offset]) {
+                    if (valid_data && !valid_data[offset]) {
                         res[i] = valid_res[i] = false;
                         continue;
                     }
@@ -958,7 +958,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                     if constexpr (filter_type == FilterType::random) {
                         offset = (offsets) ? offsets[i] : i;
                     }
-                    if (valid_data != nullptr && !valid_data[offset]) {
+                    if (valid_data && !valid_data[offset]) {
                         res[i] = valid_res[i] = false;
                         continue;
                     }
@@ -980,7 +980,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                     if constexpr (filter_type == FilterType::random) {
                         offset = (offsets) ? offsets[i] : i;
                     }
-                    if (valid_data != nullptr && !valid_data[offset]) {
+                    if (valid_data && !valid_data[offset]) {
                         res[i] = valid_res[i] = false;
                         continue;
                     }
@@ -1002,7 +1002,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                     if constexpr (filter_type == FilterType::random) {
                         offset = (offsets) ? offsets[i] : i;
                     }
-                    if (valid_data != nullptr && !valid_data[offset]) {
+                    if (valid_data && !valid_data[offset]) {
                         res[i] = valid_res[i] = false;
                         continue;
                     }
@@ -1030,7 +1030,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                     if constexpr (filter_type == FilterType::random) {
                         offset = (offsets) ? offsets[i] : i;
                     }
-                    if (valid_data != nullptr && !valid_data[offset]) {
+                    if (valid_data && !valid_data[offset]) {
                         res[i] = valid_res[i] = false;
                         continue;
                     }
@@ -1060,7 +1060,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                     if constexpr (filter_type == FilterType::random) {
                         offset = (offsets) ? offsets[i] : i;
                     }
-                    if (valid_data != nullptr && !valid_data[offset]) {
+                    if (valid_data && !valid_data[offset]) {
                         res[i] = valid_res[i] = false;
                         continue;
                     }
@@ -1086,7 +1086,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                     if constexpr (filter_type == FilterType::random) {
                         offset = (offsets) ? offsets[i] : i;
                     }
-                    if (valid_data != nullptr && !valid_data[offset]) {
+                    if (valid_data && !valid_data[offset]) {
                         res[i] = valid_res[i] = false;
                         continue;
                     }
@@ -1724,7 +1724,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
         [ expr_type, &processed_cursor, &
           bitmap_input ]<FilterType filter_type = FilterType::sequential>(
             const T* data,
-            const bool* valid_data,
+            ValidityView valid_data,
             const int32_t* offsets,
             const int size,
             TargetBitmapView res,
@@ -1858,16 +1858,26 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
         // there is a batch operation in BinaryRangeElementFunc,
         // so not divide data again for the reason that it may reduce performance if the null distribution is scattered
         // but to mask res with valid_data after the batch operation.
-        if (valid_data != nullptr) {
-            bool has_bitmap_input = !bitmap_input.empty();
+        if constexpr (filter_type == FilterType::sequential) {
+            if (bitmap_input.empty()) {
+                ApplyValidMask(valid_data, res, valid_res, size);
+            } else if (valid_data) {
+                for (int i = 0; i < size; i++) {
+                    if (!bitmap_input[i + processed_cursor]) {
+                        continue;
+                    }
+                    if (!valid_data[i]) {
+                        res[i] = valid_res[i] = false;
+                    }
+                }
+            }
+        } else if (valid_data) {
             for (int i = 0; i < size; i++) {
-                if (has_bitmap_input && !bitmap_input[i + processed_cursor]) {
+                if (!bitmap_input.empty() &&
+                    !bitmap_input[i + processed_cursor]) {
                     continue;
                 }
-                auto offset = i;
-                if constexpr (filter_type == FilterType::random) {
-                    offset = (offsets) ? offsets[i] : i;
-                }
+                auto offset = (offsets) ? offsets[i] : i;
                 if (!valid_data[offset]) {
                     res[i] = valid_res[i] = false;
                 }

--- a/internal/core/src/exec/expression/UnaryExpr.h
+++ b/internal/core/src/exec/expression/UnaryExpr.h
@@ -341,7 +341,7 @@ struct UnaryElementFuncForArray {
                                        ValueType>;
     void
     operator()(const ArrayView* src,
-               const bool* valid_data,
+               ValidityView valid_data,
                size_t size,
                ValueType val,
                int index,
@@ -360,7 +360,7 @@ struct UnaryElementFuncForArray {
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
             }
-            if (valid_data != nullptr && !valid_data[offset]) {
+            if (valid_data && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
@@ -657,7 +657,7 @@ class ShreddingExecutor {
 
     void
     operator()(const GetType* src,
-               const bool* valid,
+               ValidityView valid,
                size_t size,
                TargetBitmapView res,
                TargetBitmapView valid_res) {
@@ -667,7 +667,7 @@ class ShreddingExecutor {
                       "shredding data");
         } else {
             ExecuteOperation(src, size, res);
-            HandleValidData(valid, size, res, valid_res);
+            ApplyValidMask(valid, res, valid_res, size);
         }
     }
 
@@ -675,20 +675,6 @@ class ShreddingExecutor {
     void
     ExecuteOperation(const GetType* src, size_t size, TargetBitmapView res) {
         BatchUnaryCompare<GetType, InnerType>(src, size, val_, op_type_, res);
-    }
-
-    void
-    HandleValidData(const bool* valid,
-                    size_t size,
-                    TargetBitmapView res,
-                    TargetBitmapView valid_res) {
-        if (valid != nullptr) {
-            for (int i = 0; i < size; ++i) {
-                if (!valid[i]) {
-                    res[i] = valid_res[i] = false;
-                }
-            }
-        }
     }
 
     proto::plan::OpType op_type_;
@@ -708,12 +694,12 @@ class ShreddingArrayBsonExecutor {
 
     void
     operator()(const std::string_view* src,
-               const bool* valid,
+               ValidityView valid,
                size_t size,
                TargetBitmapView res,
                TargetBitmapView valid_res) {
         for (size_t i = 0; i < size; ++i) {
-            if (valid != nullptr && !valid[i]) {
+            if (valid && !valid[i]) {
                 res[i] = valid_res[i] = false;
                 continue;
             }

--- a/internal/core/src/exec/operator/groupby/SearchGroupByOperator.h
+++ b/internal/core/src/exec/operator/groupby/SearchGroupByOperator.h
@@ -179,14 +179,14 @@ class SealedDataGetter : public DataGetter<OutputType> {
 
     mutable std::unordered_map<
         int64_t,
-        PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>>
+        PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>>
         str_pw_map;
 
     PinWrapper<const index::IndexBase*> index_ptr_;
     // Getting str_view from segment is cpu-costly, this map is to cache this view for performance
     mutable std::unordered_map<
         int64_t,
-        PinWrapper<std::pair<std::vector<milvus::Json>, FixedVector<bool>>>>
+        PinWrapper<std::pair<std::vector<milvus::Json>, ValidityView>>>
         json_pw_map;
 
  public:
@@ -230,7 +230,7 @@ class SealedDataGetter : public DataGetter<OutputType> {
                 }
                 auto& pw = str_pw_map[chunk_id];
                 auto& [str_chunk_view, valid_data] = pw.get();
-                if (!valid_data.empty() && !valid_data[inner_offset]) {
+                if (valid_data && !valid_data[inner_offset]) {
                     return std::nullopt;
                 }
                 std::string_view str_val_view = str_chunk_view[inner_offset];
@@ -243,7 +243,7 @@ class SealedDataGetter : public DataGetter<OutputType> {
                 }
                 auto& pw = json_pw_map[chunk_id];
                 auto& [json_chunk_view, valid_data] = pw.get();
-                if (!valid_data.empty() && !valid_data[inner_offset]) {
+                if (valid_data && !valid_data[inner_offset]) {
                     return std::nullopt;
                 }
                 auto& json_val = json_chunk_view[inner_offset];
@@ -258,7 +258,7 @@ class SealedDataGetter : public DataGetter<OutputType> {
                 auto pw = segment_.chunk_data<InnerRawType>(
                     op_ctx_, field_id_, chunk_id);
                 auto& span = pw.get();
-                if (span.valid_data() && !span.valid_data()[inner_offset]) {
+                if (!span.is_valid(inner_offset)) {
                     return std::nullopt;
                 }
                 auto raw = span.operator[](inner_offset);

--- a/internal/core/src/index/SkipIndex.cpp
+++ b/internal/core/src/index/SkipIndex.cpp
@@ -65,7 +65,7 @@ FieldChunkMetricsTranslator::get_cells(
             auto span = chunk->Span();
 
             const void* chunk_data = span.data();
-            const bool* valid_data = span.valid_data();
+            const auto validity = span.validity();
             int64_t count = span.row_count();
 
             auto chunk_metrics = std::make_unique<FieldChunkMetrics>();
@@ -76,7 +76,7 @@ FieldChunkMetricsTranslator::get_cells(
                         const int8_t* typedData =
                             static_cast<const int8_t*>(chunk_data);
                         auto info = ProcessFieldMetrics<int8_t>(
-                            typedData, valid_data, count);
+                            typedData, validity, count);
                         chunk_metrics->min_ = Metrics(info.min_);
                         chunk_metrics->max_ = Metrics(info.max_);
                         chunk_metrics->null_count_ = info.null_count_;
@@ -86,7 +86,7 @@ FieldChunkMetricsTranslator::get_cells(
                         const int16_t* typedData =
                             static_cast<const int16_t*>(chunk_data);
                         auto info = ProcessFieldMetrics<int16_t>(
-                            typedData, valid_data, count);
+                            typedData, validity, count);
                         chunk_metrics->min_ = Metrics(info.min_);
                         chunk_metrics->max_ = Metrics(info.max_);
                         chunk_metrics->null_count_ = info.null_count_;
@@ -96,7 +96,7 @@ FieldChunkMetricsTranslator::get_cells(
                         const int32_t* typedData =
                             static_cast<const int32_t*>(chunk_data);
                         auto info = ProcessFieldMetrics<int32_t>(
-                            typedData, valid_data, count);
+                            typedData, validity, count);
                         chunk_metrics->min_ = Metrics(info.min_);
                         chunk_metrics->max_ = Metrics(info.max_);
                         chunk_metrics->null_count_ = info.null_count_;
@@ -106,7 +106,7 @@ FieldChunkMetricsTranslator::get_cells(
                         const int64_t* typedData =
                             static_cast<const int64_t*>(chunk_data);
                         auto info = ProcessFieldMetrics<int64_t>(
-                            typedData, valid_data, count);
+                            typedData, validity, count);
                         chunk_metrics->min_ = Metrics(info.min_);
                         chunk_metrics->max_ = Metrics(info.max_);
                         chunk_metrics->null_count_ = info.null_count_;
@@ -116,7 +116,7 @@ FieldChunkMetricsTranslator::get_cells(
                         const float* typedData =
                             static_cast<const float*>(chunk_data);
                         auto info = ProcessFieldMetrics<float>(
-                            typedData, valid_data, count);
+                            typedData, validity, count);
                         chunk_metrics->min_ = Metrics(info.min_);
                         chunk_metrics->max_ = Metrics(info.max_);
                         chunk_metrics->null_count_ = info.null_count_;
@@ -126,7 +126,7 @@ FieldChunkMetricsTranslator::get_cells(
                         const double* typedData =
                             static_cast<const double*>(chunk_data);
                         auto info = ProcessFieldMetrics<double>(
-                            typedData, valid_data, count);
+                            typedData, validity, count);
                         chunk_metrics->min_ = Metrics(info.min_);
                         chunk_metrics->max_ = Metrics(info.max_);
                         chunk_metrics->null_count_ = info.null_count_;

--- a/internal/core/src/index/SkipIndex.h
+++ b/internal/core/src/index/SkipIndex.h
@@ -166,7 +166,7 @@ class FieldChunkMetricsTranslator
 
     template <typename T>
     metricInfo<T>
-    ProcessFieldMetrics(const T* data, const bool* valid_data, int64_t count) {
+    ProcessFieldMetrics(const T* data, ValidityView validity, int64_t count) {
         //double check to avoid crash
         if (data == nullptr || count == 0) {
             return {T(), T()};
@@ -174,7 +174,7 @@ class FieldChunkMetricsTranslator
         // find first not null value
         int64_t start = 0;
         for (int64_t i = start; i < count; i++) {
-            if (valid_data != nullptr && !valid_data[i]) {
+            if (validity && !validity[i]) {
                 start++;
                 continue;
             }
@@ -188,7 +188,7 @@ class FieldChunkMetricsTranslator
         int64_t null_count = start;
         for (int64_t i = start; i < count; i++) {
             T value = data[i];
-            if (valid_data != nullptr && !valid_data[i]) {
+            if (validity && !validity[i]) {
                 null_count++;
                 continue;
             }

--- a/internal/core/src/index/json_stats/JsonKeyStats.h
+++ b/internal/core/src/index/json_stats/JsonKeyStats.h
@@ -207,20 +207,8 @@ class JsonKeyStats : public ScalarIndex<std::string> {
 
         for (size_t i = 0; i < num_data_chunk; i++) {
             auto chunk_size = column->chunk_row_nums(i);
-            const bool* valid_data;
-            if (GetShreddingJsonType(path) == JSONType::STRING ||
-                GetShreddingJsonType(path) == JSONType::ARRAY) {
-                auto pw = column->StringViews(op_ctx, i);
-                valid_data = pw.get().second.data();
-                ApplyOnlyValidData(
-                    valid_data, valid_res + processed_size, chunk_size);
-            } else {
-                auto pw = column->Span(op_ctx, i);
-                auto chunk = pw.get();
-                valid_data = chunk.valid_data();
-                ApplyOnlyValidData(
-                    valid_data, valid_res + processed_size, chunk_size);
-            }
+            column->ApplyValidDataInChunk(
+                op_ctx, i, 0, chunk_size, valid_res + processed_size);
             processed_size += chunk_size;
         }
         AssertInfo(processed_size == valid_res.size(),
@@ -262,7 +250,7 @@ class JsonKeyStats : public ScalarIndex<std::string> {
                     auto [data_vec, valid_data] = pw.get();
 
                     func(data_vec.data(),
-                         valid_data.data(),
+                         valid_data,
                          chunk_size,
                          res + processed_size,
                          valid_res + processed_size,
@@ -271,31 +259,22 @@ class JsonKeyStats : public ScalarIndex<std::string> {
                     auto pw = column->Span(op_ctx, i);
                     auto chunk = pw.get();
                     const T* data = static_cast<const T*>(chunk.data());
-                    const bool* valid_data = chunk.valid_data();
+                    const auto validity = chunk.validity();
                     func(data,
-                         valid_data,
+                         validity,
                          chunk_size,
                          res + processed_size,
                          valid_res + processed_size,
                          values...);
                 }
             } else {
-                const bool* valid_data;
-                if constexpr (std::is_same_v<T, std::string_view>) {
-                    auto pw = column->StringViews(op_ctx, i);
-                    valid_data = pw.get().second.data();
-                    ApplyValidData(valid_data,
-                                   res + processed_size,
-                                   valid_res + processed_size,
-                                   chunk_size);
-                } else {
-                    auto pw = column->Span(op_ctx, i);
+                if (column->IsNullable()) {
+                    auto pw = column->GetChunk(op_ctx, i);
                     auto chunk = pw.get();
-                    valid_data = chunk.valid_data();
-                    ApplyValidData(valid_data,
-                                   res + processed_size,
-                                   valid_res + processed_size,
-                                   chunk_size);
+                    chunk->ApplyValidityMask(
+                        0, chunk_size, res + processed_size);
+                    chunk->ApplyValidityMask(
+                        0, chunk_size, valid_res + processed_size);
                 }
             }
 
@@ -579,33 +558,6 @@ class JsonKeyStats : public ScalarIndex<std::string> {
     void
     LoadShreddingData(const std::vector<std::string>& index_files,
                       const std::string& warmup_policy = "");
-
-    void
-    ApplyValidData(const bool* valid_data,
-                   TargetBitmapView res,
-                   TargetBitmapView valid_res,
-                   const int size) {
-        if (valid_data != nullptr) {
-            for (int i = 0; i < size; i++) {
-                if (!valid_data[i]) {
-                    res[i] = valid_res[i] = false;
-                }
-            }
-        }
-    }
-
-    void
-    ApplyOnlyValidData(const bool* valid_data,
-                       TargetBitmapView valid_res,
-                       const int size) {
-        if (valid_data != nullptr) {
-            for (int i = 0; i < size; i++) {
-                if (!valid_data[i]) {
-                    valid_res[i] = false;
-                }
-            }
-        }
-    }
 
     void
     GetColumnSchemaFromParquet(int64_t column_group_id,

--- a/internal/core/src/mmap/ChunkedColumn.h
+++ b/internal/core/src/mmap/ChunkedColumn.h
@@ -256,7 +256,7 @@ class ChunkedColumnBase : public ChunkedColumnInterface {
                   "BulkVectorValueAt only supported for ChunkedColumn");
     }
 
-    PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
     StringViews(milvus::OpContext* op_ctx,
                 int64_t chunk_id,
                 std::optional<std::pair<int64_t, int64_t>> offset_len =
@@ -265,7 +265,7 @@ class ChunkedColumnBase : public ChunkedColumnInterface {
                   "StringViews only supported for VariableColumn");
     }
 
-    PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
     ArrayViews(
         milvus::OpContext* op_ctx,
         int64_t chunk_id,
@@ -274,7 +274,7 @@ class ChunkedColumnBase : public ChunkedColumnInterface {
                   "ArrayViews only supported for ArrayChunkedColumn");
     }
 
-    PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
     VectorArrayViews(
         milvus::OpContext* op_ctx,
         int64_t chunk_id,
@@ -511,7 +511,7 @@ class ChunkedVariableColumn : public ChunkedColumnBase {
         : ChunkedColumnBase(std::move(slot), field_meta) {
     }
 
-    PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
     StringViews(milvus::OpContext* op_ctx,
                 int64_t chunk_id,
                 std::optional<std::pair<int64_t, int64_t>> offset_len =
@@ -519,7 +519,7 @@ class ChunkedVariableColumn : public ChunkedColumnBase {
         auto ca = SemiInlineGet(slot_->PinCells(op_ctx, {chunk_id}));
         auto chunk = ca->get_cell_of(chunk_id);
         return PinWrapper<
-            std::pair<std::vector<std::string_view>, FixedVector<bool>>>(
+            std::pair<std::vector<std::string_view>, ValidityView>>(
             ca, static_cast<StringChunk*>(chunk)->StringViews(offset_len));
     }
 
@@ -641,7 +641,7 @@ class ChunkedArrayColumn : public ChunkedColumnBase {
         }
     }
 
-    PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
     ArrayViews(milvus::OpContext* op_ctx,
                int64_t chunk_id,
                std::optional<std::pair<int64_t, int64_t>> offset_len =
@@ -649,7 +649,7 @@ class ChunkedArrayColumn : public ChunkedColumnBase {
         auto ca = SemiInlineGet(
             slot_->PinCells(op_ctx, {static_cast<cid_t>(chunk_id)}));
         auto chunk = ca->get_cell_of(chunk_id);
-        return PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>(
+        return PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>(
             ca, static_cast<ArrayChunk*>(chunk)->Views(offset_len));
     }
 
@@ -690,7 +690,7 @@ class ChunkedVectorArrayColumn : public ChunkedColumnBase {
         }
     }
 
-    PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
     VectorArrayViews(milvus::OpContext* op_ctx,
                      int64_t chunk_id,
                      std::optional<std::pair<int64_t, int64_t>> offset_len =
@@ -699,7 +699,7 @@ class ChunkedVectorArrayColumn : public ChunkedColumnBase {
             slot_->PinCells(op_ctx, {static_cast<cid_t>(chunk_id)}));
         auto chunk = ca->get_cell_of(chunk_id);
         return PinWrapper<
-            std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>(
+            std::pair<std::vector<VectorArrayView>, ValidityView>>(
             ca, static_cast<VectorArrayChunk*>(chunk)->Views(offset_len));
     }
 

--- a/internal/core/src/mmap/ChunkedColumnGroup.h
+++ b/internal/core/src/mmap/ChunkedColumnGroup.h
@@ -284,7 +284,7 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
             chunk_wrapper, static_cast<FixedWidthChunk*>(chunk.get())->Span());
     }
 
-    PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
     StringViews(milvus::OpContext* op_ctx,
                 int64_t chunk_id,
                 std::optional<std::pair<int64_t, int64_t>> offset_len =
@@ -297,12 +297,12 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
         auto chunk_wrapper = group_->GetGroupChunk(op_ctx, chunk_id);
         auto chunk = chunk_wrapper.get()->GetChunk(field_id_);
         return PinWrapper<
-            std::pair<std::vector<std::string_view>, FixedVector<bool>>>(
+            std::pair<std::vector<std::string_view>, ValidityView>>(
             chunk_wrapper,
             static_cast<StringChunk*>(chunk.get())->StringViews(offset_len));
     }
 
-    PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
     ArrayViews(milvus::OpContext* op_ctx,
                int64_t chunk_id,
                std::optional<std::pair<int64_t, int64_t>> offset_len =
@@ -314,12 +314,12 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
         }
         auto chunk_wrapper = group_->GetGroupChunk(op_ctx, chunk_id);
         auto chunk = chunk_wrapper.get()->GetChunk(field_id_);
-        return PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>(
+        return PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>(
             chunk_wrapper,
             static_cast<ArrayChunk*>(chunk.get())->Views(offset_len));
     }
 
-    PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
     VectorArrayViews(milvus::OpContext* op_ctx,
                      int64_t chunk_id,
                      std::optional<std::pair<int64_t, int64_t>> offset_len =
@@ -332,7 +332,7 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
         auto chunk_wrapper = group_->GetGroupChunk(op_ctx, chunk_id);
         auto chunk = chunk_wrapper.get()->GetChunk(field_id_);
         return PinWrapper<
-            std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>(
+            std::pair<std::vector<VectorArrayView>, ValidityView>>(
             chunk_wrapper,
             static_cast<VectorArrayChunk*>(chunk.get())->Views(offset_len));
     }

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -83,20 +83,18 @@ class ChunkedColumnInterface {
     PrefetchChunks(milvus::OpContext* op_ctx,
                    const std::vector<int64_t>& chunk_ids) const = 0;
 
-    virtual PinWrapper<
-        std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    virtual PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
     StringViews(milvus::OpContext* op_ctx,
                 int64_t chunk_id,
                 std::optional<std::pair<int64_t, int64_t>> offset_len =
                     std::nullopt) const = 0;
 
-    virtual PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    virtual PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
     ArrayViews(milvus::OpContext* op_ctx,
                int64_t chunk_id,
                std::optional<std::pair<int64_t, int64_t>> offset_len) const = 0;
 
-    virtual PinWrapper<
-        std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+    virtual PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
     VectorArrayViews(
         milvus::OpContext* op_ctx,
         int64_t chunk_id,
@@ -151,20 +149,7 @@ class ChunkedColumnInterface {
                    offset,
                    size,
                    chunk->RowNums());
-        auto& valid_data = chunk->Valid();
-        AssertInfo(
-            offset + size <= static_cast<int64_t>(valid_data.size()),
-            "Valid-data range out of valid-data bounds, offset: {}, size: {}, "
-            "valid-data size: {}",
-            offset,
-            size,
-            valid_data.size());
-        auto valid_data_ptr = valid_data.data() + offset;
-        for (int64_t i = 0; i < size; ++i) {
-            if (!valid_data_ptr[i]) {
-                valid_result[i] = false;
-            }
-        }
+        chunk->ApplyValidityMask(offset, size, valid_result);
     }
 
     // Get number of rows before a specific chunk

--- a/internal/core/src/query/ScalarIndex.h
+++ b/internal/core/src/query/ScalarIndex.h
@@ -25,7 +25,17 @@ template <typename T>
 inline index::ScalarIndexPtr<T>
 generate_scalar_index(Span<T> data) {
     auto indexing = std::make_unique<index::ScalarIndexSort<T>>();
-    indexing->Build(data.row_count(), data.data(), data.valid_data());
+    const auto validity = data.validity();
+    FixedVector<bool> materialized_validity;
+    const bool* valid_data = validity.expanded_data();
+    if (validity && valid_data == nullptr) {
+        materialized_validity.reserve(data.row_count());
+        for (int64_t i = 0; i < data.row_count(); ++i) {
+            materialized_validity.emplace_back(validity[i]);
+        }
+        valid_data = materialized_validity.data();
+    }
+    indexing->Build(data.row_count(), data.data(), valid_data);
     return indexing;
 }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -708,7 +708,7 @@ ChunkedSegmentSealedImpl::chunk_data_impl(milvus::OpContext* op_ctx,
               "chunk_data_impl only used for chunk column field ");
 }
 
-PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
 ChunkedSegmentSealedImpl::chunk_array_view_impl(
     milvus::OpContext* op_ctx,
     FieldId field_id,
@@ -724,7 +724,7 @@ ChunkedSegmentSealedImpl::chunk_array_view_impl(
               "chunk_array_view_impl only used for chunk column field ");
 }
 
-PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
 ChunkedSegmentSealedImpl::chunk_vector_array_view_impl(
     milvus::OpContext* op_ctx,
     FieldId field_id,
@@ -740,7 +740,7 @@ ChunkedSegmentSealedImpl::chunk_vector_array_view_impl(
               "chunk_vector_array_view_impl only used for chunk column field ");
 }
 
-PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
 ChunkedSegmentSealedImpl::chunk_string_view_impl(
     milvus::OpContext* op_ctx,
     FieldId field_id,
@@ -3112,7 +3112,7 @@ ChunkedSegmentSealedImpl::LoadGeometryCache(
 
             // Add each string view to the geometry cache
             for (size_t i = 0; i < string_views.size(); ++i) {
-                if (valid_data.empty() || valid_data[i]) {
+                if (!valid_data || valid_data[i]) {
                     // Valid geometry data
                     const auto& wkb_data = string_views[i];
                     geometry_cache.AppendData(

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -360,21 +360,21 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                     FieldId field_id,
                     int64_t chunk_id) const override;
 
-    PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
     chunk_string_view_impl(
         milvus::OpContext* op_ctx,
         FieldId field_id,
         int64_t chunk_id,
         std::optional<std::pair<int64_t, int64_t>> offset_len) const override;
 
-    PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
     chunk_array_view_impl(
         milvus::OpContext* op_ctx,
         FieldId field_id,
         int64_t chunk_id,
         std::optional<std::pair<int64_t, int64_t>> offset_len) const override;
 
-    PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
     chunk_vector_array_view_impl(
         milvus::OpContext* op_ctx,
         FieldId field_id,

--- a/internal/core/src/segcore/SegmentChunkReader.cpp
+++ b/internal/core/src/segcore/SegmentChunkReader.cpp
@@ -81,7 +81,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor(
     auto pw = segment_->chunk_data<T>(op_ctx_, field_id, current_chunk_id);
     auto chunk_info = pw.get();
     auto chunk_data = chunk_info.data();
-    auto chunk_valid_data = chunk_info.valid_data();
+    auto chunk_validity = chunk_info.validity();
     auto current_chunk_size = segment_->chunk_size(field_id, current_chunk_id);
     return [=,
             this,
@@ -99,11 +99,11 @@ SegmentChunkReader::GetMultipleChunkDataAccessor(
             // the old chunk will be unpinned, pw will now pin the new chunk.
             pw = segment_->chunk_data<T>(op_ctx_, field_id, current_chunk_id);
             chunk_data = pw.get().data();
-            chunk_valid_data = pw.get().valid_data();
+            chunk_validity = pw.get().validity();
             current_chunk_size =
                 segment_->chunk_size(field_id, current_chunk_id);
         }
-        if (chunk_valid_data && !chunk_valid_data[current_chunk_pos]) {
+        if (chunk_validity && !chunk_validity[current_chunk_pos]) {
             current_chunk_pos++;
             return std::nullopt;
         }
@@ -153,14 +153,14 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
             op_ctx_, field_id, current_chunk_id);
         auto chunk_info = pw.get();
         auto chunk_data = chunk_info.data();
-        auto chunk_valid_data = chunk_info.valid_data();
+        auto chunk_validity = chunk_info.validity();
         auto current_chunk_size =
             segment_->chunk_size(field_id, current_chunk_id);
         return [pw = std::move(pw),
                 this,
                 field_id,
                 chunk_data,
-                chunk_valid_data,
+                chunk_validity,
                 current_chunk_size,
                 num_chunks,
                 // pw = std::move(pw),
@@ -177,11 +177,11 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
                 pw = segment_->chunk_data<std::string>(
                     op_ctx_, field_id, current_chunk_id);
                 chunk_data = pw.get().data();
-                chunk_valid_data = pw.get().valid_data();
+                chunk_validity = pw.get().validity();
                 current_chunk_size =
                     segment_->chunk_size(field_id, current_chunk_id);
             }
-            if (chunk_valid_data && !chunk_valid_data[current_chunk_pos]) {
+            if (chunk_validity && !chunk_validity[current_chunk_pos]) {
                 current_chunk_pos++;
                 return std::nullopt;
             }
@@ -213,8 +213,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
             }
             auto& chunk_data = pw.get().first;
             auto& chunk_valid_data = pw.get().second;
-            if (current_chunk_pos < chunk_valid_data.size() &&
-                !chunk_valid_data[current_chunk_pos]) {
+            if (chunk_valid_data && !chunk_valid_data[current_chunk_pos]) {
                 current_chunk_pos++;
                 return std::nullopt;
             }
@@ -294,8 +293,8 @@ SegmentChunkReader::GetChunkDataAccessor(FieldId field_id,
     return [pw = std::move(pw)](int i) mutable -> const data_access_type {
         auto chunk_info = pw.get();
         auto chunk_data = chunk_info.data();
-        auto chunk_valid_data = chunk_info.valid_data();
-        if (chunk_valid_data && !chunk_valid_data[i]) {
+        auto chunk_validity = chunk_info.validity();
+        if (chunk_validity && !chunk_validity[i]) {
             return std::nullopt;
         }
         return chunk_data[i];
@@ -336,8 +335,8 @@ SegmentChunkReader::GetChunkDataAccessor<std::string>(
             segment_->chunk_data<std::string>(op_ctx_, field_id, chunk_id);
         return [pw = std::move(pw)](int i) mutable -> const data_access_type {
             auto chunk_data = pw.get().data();
-            auto chunk_valid_data = pw.get().valid_data();
-            if (chunk_valid_data && !chunk_valid_data[i]) {
+            auto chunk_validity = pw.get().validity();
+            if (chunk_validity && !chunk_validity[i]) {
                 return std::nullopt;
             }
             return data_access_type(std::string_view(chunk_data[i]));
@@ -348,7 +347,7 @@ SegmentChunkReader::GetChunkDataAccessor<std::string>(
         return [pw = std::move(pw)](int i) mutable -> const data_access_type {
             auto& chunk_data = pw.get().first;
             auto& chunk_valid_data = pw.get().second;
-            if (i < chunk_valid_data.size() && !chunk_valid_data[i]) {
+            if (chunk_valid_data && !chunk_valid_data[i]) {
                 return std::nullopt;
             }
             return data_access_type(chunk_data[i]);

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -1140,7 +1140,7 @@ SegmentGrowingImpl::ApplyFieldValidData(milvus::OpContext* op_ctx,
     }
 }
 
-PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
 SegmentGrowingImpl::chunk_string_view_impl(
     milvus::OpContext* op_ctx,
     FieldId field_id,
@@ -1150,7 +1150,7 @@ SegmentGrowingImpl::chunk_string_view_impl(
               "chunk string view impl not implement for growing segment");
 }
 
-PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
 SegmentGrowingImpl::chunk_array_view_impl(
     milvus::OpContext* op_ctx,
     FieldId field_id,
@@ -1160,7 +1160,7 @@ SegmentGrowingImpl::chunk_array_view_impl(
               "chunk array view impl not implement for growing segment");
 }
 
-PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
 SegmentGrowingImpl::chunk_vector_array_view_impl(
     milvus::OpContext* op_ctx,
     FieldId field_id,

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -579,21 +579,21 @@ class SegmentGrowingImpl : public SegmentGrowing {
                     FieldId field_id,
                     int64_t chunk_id) const override;
 
-    PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
     chunk_string_view_impl(
         milvus::OpContext* op_ctx,
         FieldId field_id,
         int64_t chunk_id,
         std::optional<std::pair<int64_t, int64_t>> offset_len) const override;
 
-    PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
     chunk_array_view_impl(
         milvus::OpContext* op_ctx,
         FieldId field_id,
         int64_t chunk_id,
         std::optional<std::pair<int64_t, int64_t>> offset_len) const override;
 
-    PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
     chunk_vector_array_view_impl(
         milvus::OpContext* op_ctx,
         FieldId field_id,

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -292,7 +292,7 @@ class SegmentInternalInterface : public SegmentInterface {
     }
 
     template <typename ViewType>
-    PinWrapper<std::pair<std::vector<ViewType>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<ViewType>, ValidityView>>
     chunk_view(milvus::OpContext* op_ctx,
                FieldId field_id,
                int64_t chunk_id,
@@ -316,14 +316,13 @@ class SegmentInternalInterface : public SegmentInterface {
             for (const auto& str_view : string_views) {
                 res.emplace_back(Json(str_view));
             }
-            return PinWrapper<
-                std::pair<std::vector<ViewType>, FixedVector<bool>>>(
+            return PinWrapper<std::pair<std::vector<ViewType>, ValidityView>>(
                 pw, {std::move(res), std::move(valid_data)});
         }
     }
 
     template <typename ViewType>
-    PinWrapper<std::pair<std::vector<ViewType>, FixedVector<bool>>>
+    PinWrapper<std::pair<std::vector<ViewType>, ValidityView>>
     get_batch_views(milvus::OpContext* op_ctx,
                     FieldId field_id,
                     int64_t chunk_id,
@@ -588,23 +587,21 @@ class SegmentInternalInterface : public SegmentInterface {
                     int64_t chunk_id) const = 0;
 
     // internal API: return chunk string views in vector
-    virtual PinWrapper<
-        std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    virtual PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
     chunk_string_view_impl(
         milvus::OpContext* op_ctx,
         FieldId field_id,
         int64_t chunk_id,
         std::optional<std::pair<int64_t, int64_t>> offset_len) const = 0;
 
-    virtual PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    virtual PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
     chunk_array_view_impl(
         milvus::OpContext* op_ctx,
         FieldId field_id,
         int64_t chunk_id,
         std::optional<std::pair<int64_t, int64_t>> offset_len) const = 0;
 
-    virtual PinWrapper<
-        std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+    virtual PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
     chunk_vector_array_view_impl(
         milvus::OpContext* op_ctx,
         FieldId field_id,

--- a/internal/core/src/segcore/storagev1translator/DefaultValueChunkTranslatorTest.cpp
+++ b/internal/core/src/segcore/storagev1translator/DefaultValueChunkTranslatorTest.cpp
@@ -284,8 +284,8 @@ TEST_P(DefaultValueChunkTranslatorTest, TestStringWithoutDefaultValue) {
 
     EXPECT_GT(views.size(), 0);
     // All should be marked as invalid (null)
-    for (const auto& v : valid) {
-        EXPECT_FALSE(v);
+    for (size_t i = 0; i < views.size(); ++i) {
+        EXPECT_FALSE(valid[i]);
     }
 }
 
@@ -962,7 +962,7 @@ TEST_P(DefaultValueChunkTranslatorTest,
         total_rows += views.size();
 
         // All values should be null (invalid)
-        for (size_t i = 0; i < valid.size(); ++i) {
+        for (size_t i = 0; i < views.size(); ++i) {
             EXPECT_FALSE(valid[i])
                 << "Expected null at cell " << cid << " row " << i;
         }

--- a/internal/core/unittest/test_json_stats/test_json_key_stats.cpp
+++ b/internal/core/unittest/test_json_stats/test_json_key_stats.cpp
@@ -278,7 +278,7 @@ TEST_P(JsonKeyStatsTest, TestExecutorForShreddingData) {
     TargetBitmapView valid_res_view(valid_res);
 
     auto func = [](const int64_t* data,
-                   const bool* valid_data,
+                   ValidityView valid_data,
                    const int size,
                    TargetBitmapView res,
                    TargetBitmapView valid_res) {
@@ -302,6 +302,20 @@ TEST_P(JsonKeyStatsTest, TestExecutorForShreddingData) {
     } else {
         EXPECT_EQ(res.count(), 800);
     }
+
+    TargetBitmap skipped_res(size_, true);
+    TargetBitmap skipped_valid_res(size_, true);
+    processed_size = index_->ExecutorForShreddingData<int64_t>(
+        nullptr,
+        field_name,
+        func,
+        [](const SkipIndex&, std::string, int) { return true; },
+        TargetBitmapView(skipped_res),
+        TargetBitmapView(skipped_valid_res));
+    EXPECT_EQ(processed_size, size_);
+    const auto expected_valid_count = nullable_ ? 400 : 800;
+    EXPECT_EQ(skipped_res.count(), expected_valid_count);
+    EXPECT_EQ(skipped_valid_res.count(), expected_valid_count);
 }
 
 TEST_P(JsonKeyStatsTest, TestGetShreddingFields) {

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -599,51 +599,42 @@ TEST(Sealed, LoadFieldData) {
     auto valid7 = dataset.get_col_valid(int64_nullable_id);
     auto valid8 = dataset.get_col_valid(double_nullable_id);
     auto valid9 = dataset.get_col_valid(str_nullable_id);
-    ASSERT_EQ(chunk_span1.get().valid_data(), nullptr);
-    ASSERT_EQ(chunk_span2.get().valid_data(), nullptr);
-    ASSERT_EQ(chunk_span3.get().second.size(), 0);
+    ASSERT_FALSE(chunk_span1.get().validity());
+    ASSERT_FALSE(chunk_span2.get().validity());
+    ASSERT_FALSE(chunk_span3.get().second);
     for (int i = 0; i < N; ++i) {
-        if (chunk_span1.get().valid_data() == nullptr ||
-            chunk_span1.get().valid_data()[i]) {
+        if (chunk_span1.get().is_valid(i)) {
             ASSERT_EQ(chunk_span1.get().data()[i], ref1[i]);
         }
-        if (chunk_span2.get().valid_data() == nullptr ||
-            chunk_span2.get().valid_data()[i]) {
+        if (chunk_span2.get().is_valid(i)) {
             ASSERT_EQ(chunk_span2.get().data()[i], ref2[i]);
         }
-        if (chunk_span3.get().second.size() == 0 ||
-            chunk_span3.get().second[i]) {
+        if (!chunk_span3.get().second || chunk_span3.get().second[i]) {
             ASSERT_EQ(chunk_span3.get().first[i], ref3[i]);
         }
-        if (chunk_span4.get().valid_data() == nullptr ||
-            chunk_span4.get().valid_data()[i]) {
+        if (chunk_span4.get().is_valid(i)) {
             ASSERT_EQ(chunk_span4.get().data()[i], ref4[i]);
         }
-        if (chunk_span5.get().valid_data() == nullptr ||
-            chunk_span5.get().valid_data()[i]) {
+        if (chunk_span5.get().is_valid(i)) {
             ASSERT_EQ(chunk_span5.get().data()[i], ref5[i]);
         }
-        if (chunk_span6.get().valid_data() == nullptr ||
-            chunk_span6.get().valid_data()[i]) {
+        if (chunk_span6.get().is_valid(i)) {
             ASSERT_EQ(chunk_span6.get().data()[i], ref6[i]);
         }
-        if (chunk_span7.get().valid_data() == nullptr ||
-            chunk_span7.get().valid_data()[i]) {
+        if (chunk_span7.get().is_valid(i)) {
             ASSERT_EQ(chunk_span7.get().data()[i], ref7[i]);
         }
-        if (chunk_span8.get().valid_data() == nullptr ||
-            chunk_span8.get().valid_data()[i]) {
+        if (chunk_span8.get().is_valid(i)) {
             ASSERT_EQ(chunk_span8.get().data()[i], ref8[i]);
         }
-        if (chunk_span9.get().second.size() == 0 ||
-            chunk_span9.get().second[i]) {
+        if (!chunk_span9.get().second || chunk_span9.get().second[i]) {
             ASSERT_EQ(chunk_span9.get().first[i], ref9[i]);
         }
-        ASSERT_EQ(chunk_span4.get().valid_data()[i], valid4[i]);
-        ASSERT_EQ(chunk_span5.get().valid_data()[i], valid5[i]);
-        ASSERT_EQ(chunk_span6.get().valid_data()[i], valid6[i]);
-        ASSERT_EQ(chunk_span7.get().valid_data()[i], valid7[i]);
-        ASSERT_EQ(chunk_span8.get().valid_data()[i], valid8[i]);
+        ASSERT_EQ(chunk_span4.get().is_valid(i), valid4[i]);
+        ASSERT_EQ(chunk_span5.get().is_valid(i), valid5[i]);
+        ASSERT_EQ(chunk_span6.get().is_valid(i), valid6[i]);
+        ASSERT_EQ(chunk_span7.get().is_valid(i), valid7[i]);
+        ASSERT_EQ(chunk_span8.get().is_valid(i), valid8[i]);
         ASSERT_EQ(chunk_span9.get().second[i], valid9[i]);
     }
 
@@ -721,7 +712,7 @@ TEST(Sealed, ClearData) {
     auto ref1 = dataset.get_col<int64_t>(counter_id);
     auto ref2 = dataset.get_col<double>(double_id);
     auto ref3 = dataset.get_col(str_id)->scalars().string_data().data();
-    ASSERT_EQ(chunk_span3.get().second.size(), 0);
+    ASSERT_FALSE(chunk_span3.get().second);
     for (int i = 0; i < N; ++i) {
         ASSERT_EQ(chunk_span1.get()[i], ref1[i]);
         ASSERT_EQ(chunk_span2.get()[i], ref2[i]);
@@ -808,7 +799,7 @@ TEST(Sealed, LoadFieldDataMmap) {
     auto ref1 = dataset.get_col<int64_t>(counter_id);
     auto ref2 = dataset.get_col<double>(double_id);
     auto ref3 = dataset.get_col(str_id)->scalars().string_data().data();
-    ASSERT_EQ(chunk_span3.get().second.size(), 0);
+    ASSERT_FALSE(chunk_span3.get().second);
     for (int i = 0; i < N; ++i) {
         ASSERT_EQ(chunk_span1.get()[i], ref1[i]);
         ASSERT_EQ(chunk_span2.get()[i], ref2[i]);


### PR DESCRIPTION
pr: #52354
issue: #52355

- Keep nullable chunk validity packed in the backing mmap or buffer for point checks, filtering, rank, and fixed-width Span access.
- Add a non-owning `ValidityView` for packed and expanded validity.
- Remove the fixed-width chunk-level expanded validity cache; materialize only at legacy scalar-index boundaries.
- Adapt the 2.6 expression, SkipIndex, JSON stats, mmap column, and segcore paths.
- Document the offset contract for expanded and packed `ValidityView` accessors.

## Test
- `clang-format --style=file --dry-run --Werror internal/core/src/common/ValidityView.h`
- `git diff --check`
- `make verifiers` (blocked locally during third-party setup: installed Conan is 2.x, while branch 2.6 requires Conan 1.x)