### PR TITLE
test: accept new refresh job when the first job is already terminal

### DIFF
--- a/tests/restful_client_v2/testcases/test_external_collection_operations.py
+++ b/tests/restful_client_v2/testcases/test_external_collection_operations.py
@@ -1569,9 +1569,19 @@ class TestRestExternalCollection(TestBase):
         second_rsp = self._refresh_external_collection(payload)
         if second_rsp.get("code") == 0:
             second_job_id = _assert_refresh_response(second_rsp)
-            assert second_job_id == first_job_id, (
-                f"duplicate refresh returned a different job id: first={first_job_id}, second={second_job_id}"
-            )
+            if second_job_id != first_job_id:
+                # On fast machines the first refresh job can reach a terminal state
+                # before the second request's duplicate check runs, in which case the
+                # server legitimately allocates a fresh job id. Only fail when the first
+                # job is still active yet a different job id was returned.
+                first_job_rsp = self._describe_external_collection_job(first_job_id)
+                first_state = first_job_rsp.get("data", {}).get("state")
+                assert first_state in TERMINAL_JOB_STATES, (
+                    f"duplicate refresh returned a different job id while the first job is still active: "
+                    f"first={first_job_id} (state={first_state}), second={second_job_id}"
+                )
+                _, second_finished = self._wait_refresh_completed(second_job_id)
+                assert second_finished
         else:
             _assert_error_response(second_rsp)
             message = second_rsp["message"].lower()


### PR DESCRIPTION
## Related Issue

Fixes #52593

## What type of PR is this?

- [x] test

## What this PR does

Fixes a flaky test `test_rest_external_collection_duplicate_refresh_rejected_or_reuses_job` that intermittently fails on fast machines when the first refresh job finishes before the second request arrives.

## Root cause

The test issues two back-to-back refresh requests and unconditionally asserts `second_job_id == first_job_id` when the second request returns `code=0`. But the server only treats `Init/Retry/InProgress` as active (`internal/datacoord/external_collection_refresh_meta.go` `GetActiveJobByCollectionID`); once the first job reaches a terminal state (`Finished/Failed`), the duplicate check at `internal/datacoord/services.go` finds no active job and legitimately allocates a fresh job id. On a fast machine the 20k-row refresh completes in ~0.5s, so the second request frequently lands after the first job is terminal and the assertion fails.

This is a test timing-assumption defect, not a product bug — the server result is correct.

## Changes

In `tests/restful_client_v2/testcases/test_external_collection_operations.py`, when the second refresh returns `code=0` with a different job id, query the first job's state:
- if the first job is terminal (`RefreshCompleted`/`RefreshFailed`), accept the legitimate new job and wait for it to complete;
- only fail when the first job is still active yet a different job id was returned.

## Verification

- Reproduced before the fix: a 20k-row refresh reaches `RefreshCompleted` in ~0.57s, and the following refresh returns `code=0` with a **different** job id (exactly the reported failure).
- After the fix, the forced race (wait for job1 terminal, then refresh again) is accepted correctly.
- `test_rest_external_collection_duplicate_refresh_rejected_or_reuses_job` passed 5 consecutive runs.