### PR TITLE
enhance: bump knowhere to d85f7080

### DIFF
--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -14,9 +14,9 @@
 # Update KNOWHERE_VERSION for the first occurrence
 milvus_add_pkg_config("knowhere")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-# Pins the short zilliztech/knowhere#1761 commit without nullable ID mapping.
-# It retains the COSINE/IP CalcDistByIDs fix for fully cached DiskANN vectors.
-set( KNOWHERE_VERSION 6a3b7df1 )
+# Pins zilliztech/knowhere main at #1780, which bumps the cardinal
+# references to v3.0.5 (v2) and v2.5.110 (v1).
+set( KNOWHERE_VERSION d85f7080120d2a6d627f8c8ecff62242278ff1e3 )
 set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
 
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")


### PR DESCRIPTION
Move the knowhere pin from `6a3b7df1` to main at `d85f7080` (zilliztech/knowhere#1780), which bumps the cardinal references to v3.0.5 (v2) and v2.5.110 (v1).

The stale comment above the pin is updated to describe the new one.

Heads-up for reviewers: this range also brings in zilliztech/knowhere#1673 "support nullable external id mapping", which the previous pin deliberately excluded.