### PR TITLE
fix: prevent import id pre-allocation overflow

### DIFF
--- a/internal/datacoord/import_util.go
+++ b/internal/datacoord/import_util.go
@@ -340,7 +340,7 @@ func AssembleImportRequest(task ImportTask, job ImportJob, meta *meta, alloc all
 	fieldsNum := len(job.GetSchema().GetFields()) + 2 // userFields + tsField + rowIDField
 	binlogNum := fieldsNum + 2                        // binlogs + statslog + BM25Statslog
 	expansionFactor := paramtable.Get().DataCoordCfg.ImportPreAllocIDExpansionFactor.GetAsInt64()
-	preAllocIDNum, err := calculatePreAllocIDNum(totalRows, int64(binlogNum), expansionFactor)
+	preAllocIDNum, preAllocIDNumCapped, err := calculatePreAllocIDNum(totalRows, int64(binlogNum), expansionFactor)
 	if err != nil {
 		return nil, err
 	}
@@ -357,6 +357,7 @@ func AssembleImportRequest(task ImportTask, job ImportJob, meta *meta, alloc all
 		mlog.Int64("totalRows", totalRows),
 		mlog.Int("fieldsNum", fieldsNum),
 		mlog.Uint32("preAllocIDNum", preAllocIDNum),
+		mlog.Bool("preAllocIDNumCapped", preAllocIDNumCapped),
 		mlog.Int64("idBegin", idBegin),
 		mlog.Int64("idEnd", idEnd),
 		mlog.Uint64("ts", ts))...,
@@ -393,14 +394,14 @@ func AssembleImportRequest(task ImportTask, job ImportJob, meta *meta, alloc all
 	return req, nil
 }
 
-func calculatePreAllocIDNum(totalRows, binlogNum, expansionFactor int64) (uint32, error) {
+func calculatePreAllocIDNum(totalRows, binlogNum, expansionFactor int64) (uint32, bool, error) {
 	if totalRows < 0 {
-		return 0, merr.WrapErrServiceInternalMsg(
+		return 0, false, merr.WrapErrServiceInternalMsg(
 			"import total rows must not be negative: %d", totalRows,
 		)
 	}
 	if expansionFactor <= 0 {
-		return 0, merr.WrapErrParameterInvalidMsg(
+		return 0, false, merr.WrapErrParameterInvalidMsg(
 			"import pre-allocate ID expansion factor must be positive: %d",
 			expansionFactor,
 		)
@@ -411,7 +412,7 @@ func calculatePreAllocIDNum(totalRows, binlogNum, expansionFactor int64) (uint32
 	preAllocIDNum.Mul(preAllocIDNum, big.NewInt(binlogNum))
 	maxBatchSize := new(big.Int).SetUint64(uint64(math.MaxUint32))
 	if preAllocIDNum.Cmp(maxBatchSize) > 0 {
-		return 0, merr.WrapErrParameterInvalidMsg(
+		return 0, false, merr.WrapErrParameterInvalidMsg(
 			"too large to allocate IDs: required %s, max %d",
 			preAllocIDNum.String(), uint64(math.MaxUint32),
 		)
@@ -420,9 +421,9 @@ func calculatePreAllocIDNum(totalRows, binlogNum, expansionFactor int64) (uint32
 	preAllocIDNum.Mul(preAllocIDNum, big.NewInt(expansionFactor))
 	if preAllocIDNum.Cmp(maxBatchSize) > 0 {
 		// AllocIDRequest.Count is uint32; saturate instead of wrapping to a smaller range.
-		return math.MaxUint32, nil
+		return math.MaxUint32, true, nil
 	}
-	return uint32(preAllocIDNum.Uint64()), nil
+	return uint32(preAllocIDNum.Uint64()), false, nil
 }
 
 func RegroupImportFiles(job ImportJob, files []*datapb.ImportFileStats, segmentMaxSize int) [][]*datapb.ImportFileStats {

--- a/internal/datacoord/import_util.go
+++ b/internal/datacoord/import_util.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"math/big"
 	"path"
 	"sort"
 	"sync"
@@ -339,12 +340,15 @@ func AssembleImportRequest(task ImportTask, job ImportJob, meta *meta, alloc all
 	fieldsNum := len(job.GetSchema().GetFields()) + 2 // userFields + tsField + rowIDField
 	binlogNum := fieldsNum + 2                        // binlogs + statslog + BM25Statslog
 	expansionFactor := paramtable.Get().DataCoordCfg.ImportPreAllocIDExpansionFactor.GetAsInt64()
-	preAllocIDNum := (totalRows + 1) * int64(binlogNum) * expansionFactor
+	preAllocIDNum, preAllocIDNumRequested, err := calculatePreAllocIDNum(totalRows, int64(binlogNum), expansionFactor)
+	if err != nil {
+		return nil, err
+	}
 
 	idBegin, idEnd, err := common.AllocAutoID(func(n uint32) (int64, int64, error) {
 		ids, ide, e := alloc.AllocN(int64(n))
 		return ids, ide, e
-	}, uint32(preAllocIDNum), Params.CommonCfg.ClusterID.GetAsUint64())
+	}, preAllocIDNum, Params.CommonCfg.ClusterID.GetAsUint64())
 	if err != nil {
 		return nil, err
 	}
@@ -352,6 +356,8 @@ func AssembleImportRequest(task ImportTask, job ImportJob, meta *meta, alloc all
 	mlog.Info(context.TODO(), "pre-allocate ids and ts for import task", WrapTaskLog(task,
 		mlog.Int64("totalRows", totalRows),
 		mlog.Int("fieldsNum", fieldsNum),
+		mlog.Uint32("preAllocIDNum", preAllocIDNum),
+		mlog.String("preAllocIDNumRequested", preAllocIDNumRequested),
 		mlog.Int64("idBegin", idBegin),
 		mlog.Int64("idEnd", idEnd),
 		mlog.Uint64("ts", ts))...,
@@ -386,6 +392,27 @@ func AssembleImportRequest(task ImportTask, job ImportJob, meta *meta, alloc all
 	}
 	WrapPluginContext(task.GetCollectionID(), job.GetSchema().GetProperties(), req)
 	return req, nil
+}
+
+func calculatePreAllocIDNum(totalRows, binlogNum, expansionFactor int64) (uint32, string, error) {
+	if totalRows < 0 || binlogNum <= 0 || expansionFactor <= 0 {
+		return 0, "", merr.WrapErrServiceInternalMsg(
+			"invalid import ID pre-allocation parameters, totalRows=%d, binlogNum=%d, expansionFactor=%d",
+			totalRows, binlogNum, expansionFactor,
+		)
+	}
+
+	preAllocIDNum := big.NewInt(totalRows)
+	preAllocIDNum.Add(preAllocIDNum, big.NewInt(1))
+	preAllocIDNum.Mul(preAllocIDNum, big.NewInt(binlogNum))
+	preAllocIDNum.Mul(preAllocIDNum, big.NewInt(expansionFactor))
+	requested := preAllocIDNum.String()
+
+	if preAllocIDNum.Cmp(new(big.Int).SetUint64(uint64(math.MaxUint32))) > 0 {
+		// AllocIDRequest.Count is uint32; saturate instead of wrapping to a smaller range.
+		return math.MaxUint32, requested, nil
+	}
+	return uint32(preAllocIDNum.Uint64()), requested, nil
 }
 
 func RegroupImportFiles(job ImportJob, files []*datapb.ImportFileStats, segmentMaxSize int) [][]*datapb.ImportFileStats {

--- a/internal/datacoord/import_util.go
+++ b/internal/datacoord/import_util.go
@@ -340,7 +340,7 @@ func AssembleImportRequest(task ImportTask, job ImportJob, meta *meta, alloc all
 	fieldsNum := len(job.GetSchema().GetFields()) + 2 // userFields + tsField + rowIDField
 	binlogNum := fieldsNum + 2                        // binlogs + statslog + BM25Statslog
 	expansionFactor := paramtable.Get().DataCoordCfg.ImportPreAllocIDExpansionFactor.GetAsInt64()
-	preAllocIDNum, preAllocIDNumRequested, err := calculatePreAllocIDNum(totalRows, int64(binlogNum), expansionFactor)
+	preAllocIDNum, err := calculatePreAllocIDNum(totalRows, int64(binlogNum), expansionFactor)
 	if err != nil {
 		return nil, err
 	}
@@ -357,7 +357,6 @@ func AssembleImportRequest(task ImportTask, job ImportJob, meta *meta, alloc all
 		mlog.Int64("totalRows", totalRows),
 		mlog.Int("fieldsNum", fieldsNum),
 		mlog.Uint32("preAllocIDNum", preAllocIDNum),
-		mlog.String("preAllocIDNumRequested", preAllocIDNumRequested),
 		mlog.Int64("idBegin", idBegin),
 		mlog.Int64("idEnd", idEnd),
 		mlog.Uint64("ts", ts))...,
@@ -394,25 +393,36 @@ func AssembleImportRequest(task ImportTask, job ImportJob, meta *meta, alloc all
 	return req, nil
 }
 
-func calculatePreAllocIDNum(totalRows, binlogNum, expansionFactor int64) (uint32, string, error) {
-	if totalRows < 0 || binlogNum <= 0 || expansionFactor <= 0 {
-		return 0, "", merr.WrapErrServiceInternalMsg(
-			"invalid import ID pre-allocation parameters, totalRows=%d, binlogNum=%d, expansionFactor=%d",
-			totalRows, binlogNum, expansionFactor,
+func calculatePreAllocIDNum(totalRows, binlogNum, expansionFactor int64) (uint32, error) {
+	if totalRows < 0 {
+		return 0, merr.WrapErrServiceInternalMsg(
+			"import total rows must not be negative: %d", totalRows,
+		)
+	}
+	if expansionFactor <= 0 {
+		return 0, merr.WrapErrParameterInvalidMsg(
+			"import pre-allocate ID expansion factor must be positive: %d",
+			expansionFactor,
 		)
 	}
 
 	preAllocIDNum := big.NewInt(totalRows)
 	preAllocIDNum.Add(preAllocIDNum, big.NewInt(1))
 	preAllocIDNum.Mul(preAllocIDNum, big.NewInt(binlogNum))
-	preAllocIDNum.Mul(preAllocIDNum, big.NewInt(expansionFactor))
-	requested := preAllocIDNum.String()
-
-	if preAllocIDNum.Cmp(new(big.Int).SetUint64(uint64(math.MaxUint32))) > 0 {
-		// AllocIDRequest.Count is uint32; saturate instead of wrapping to a smaller range.
-		return math.MaxUint32, requested, nil
+	maxBatchSize := new(big.Int).SetUint64(uint64(math.MaxUint32))
+	if preAllocIDNum.Cmp(maxBatchSize) > 0 {
+		return 0, merr.WrapErrParameterInvalidMsg(
+			"too large to allocate IDs: required %s, max %d",
+			preAllocIDNum.String(), uint64(math.MaxUint32),
+		)
 	}
-	return uint32(preAllocIDNum.Uint64()), requested, nil
+
+	preAllocIDNum.Mul(preAllocIDNum, big.NewInt(expansionFactor))
+	if preAllocIDNum.Cmp(maxBatchSize) > 0 {
+		// AllocIDRequest.Count is uint32; saturate instead of wrapping to a smaller range.
+		return math.MaxUint32, nil
+	}
+	return uint32(preAllocIDNum.Uint64()), nil
 }
 
 func RegroupImportFiles(job ImportJob, files []*datapb.ImportFileStats, segmentMaxSize int) [][]*datapb.ImportFileStats {

--- a/internal/datacoord/import_util_test.go
+++ b/internal/datacoord/import_util_test.go
@@ -59,6 +59,7 @@ func TestCalculatePreAllocIDNum(t *testing.T) {
 		binlogNum        int64
 		expansion        int64
 		expectedNum      uint32
+		expectedCapped   bool
 		expectedError    error
 		errorContains    string
 		errorNotContains string
@@ -71,11 +72,12 @@ func TestCalculatePreAllocIDNum(t *testing.T) {
 			expectedNum: 11110,
 		},
 		{
-			name:        "expanded IDs exceed single batch",
-			totalRows:   78201209,
-			binlogNum:   11,
-			expansion:   10,
-			expectedNum: math.MaxUint32,
+			name:           "expanded IDs exceed single batch",
+			totalRows:      78201209,
+			binlogNum:      11,
+			expansion:      10,
+			expectedNum:    math.MaxUint32,
+			expectedCapped: true,
 		},
 		{
 			name:             "minimum required IDs exceed single batch",
@@ -113,7 +115,7 @@ func TestCalculatePreAllocIDNum(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			num, err := calculatePreAllocIDNum(test.totalRows, test.binlogNum, test.expansion)
+			num, capped, err := calculatePreAllocIDNum(test.totalRows, test.binlogNum, test.expansion)
 			if test.expectedError != nil {
 				require.ErrorIs(t, err, test.expectedError)
 				assert.ErrorContains(t, err, test.errorContains)
@@ -124,6 +126,7 @@ func TestCalculatePreAllocIDNum(t *testing.T) {
 			}
 			assert.NoError(t, err)
 			assert.Equal(t, test.expectedNum, num)
+			assert.Equal(t, test.expectedCapped, capped)
 		})
 	}
 }

--- a/internal/datacoord/import_util_test.go
+++ b/internal/datacoord/import_util_test.go
@@ -19,6 +19,7 @@ package datacoord
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/rand"
 	"path"
 	"strings"
@@ -49,6 +50,78 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/timerecord"
 )
+
+func TestCalculatePreAllocIDNum(t *testing.T) {
+	tests := []struct {
+		name          string
+		totalRows     int64
+		binlogNum     int64
+		expansion     int64
+		expectedNum   uint32
+		expectedReq   string
+		expectedError bool
+	}{
+		{
+			name:        "normal",
+			totalRows:   100,
+			binlogNum:   11,
+			expansion:   10,
+			expectedNum: 11110,
+			expectedReq: "11110",
+		},
+		{
+			name:        "reported overflow case",
+			totalRows:   78201209,
+			binlogNum:   11,
+			expansion:   10,
+			expectedNum: math.MaxUint32,
+			expectedReq: "8602133100",
+		},
+		{
+			name:        "int64 rows cannot overflow calculation",
+			totalRows:   math.MaxInt64,
+			binlogNum:   11,
+			expansion:   10,
+			expectedNum: math.MaxUint32,
+			expectedReq: "1014570924054025338880",
+		},
+		{
+			name:          "negative rows",
+			totalRows:     -1,
+			binlogNum:     11,
+			expansion:     10,
+			expectedError: true,
+		},
+		{
+			name:          "non-positive binlog count",
+			totalRows:     100,
+			binlogNum:     0,
+			expansion:     10,
+			expectedError: true,
+		},
+		{
+			name:          "non-positive expansion",
+			totalRows:     100,
+			binlogNum:     11,
+			expansion:     0,
+			expectedError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			num, requested, err := calculatePreAllocIDNum(test.totalRows, test.binlogNum, test.expansion)
+			if test.expectedError {
+				assert.Error(t, err)
+				assert.True(t, errors.Is(err, merr.ErrServiceInternal))
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedNum, num)
+			assert.Equal(t, test.expectedReq, requested)
+		})
+	}
+}
 
 func TestImportUtil_NewPreImportTasks(t *testing.T) {
 	fileGroups := [][]*internalpb.ImportFile{

--- a/internal/datacoord/import_util_test.go
+++ b/internal/datacoord/import_util_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
@@ -53,13 +54,14 @@ import (
 
 func TestCalculatePreAllocIDNum(t *testing.T) {
 	tests := []struct {
-		name          string
-		totalRows     int64
-		binlogNum     int64
-		expansion     int64
-		expectedNum   uint32
-		expectedReq   string
-		expectedError bool
+		name             string
+		totalRows        int64
+		binlogNum        int64
+		expansion        int64
+		expectedNum      uint32
+		expectedError    error
+		errorContains    string
+		errorNotContains string
 	}{
 		{
 			name:        "normal",
@@ -67,58 +69,61 @@ func TestCalculatePreAllocIDNum(t *testing.T) {
 			binlogNum:   11,
 			expansion:   10,
 			expectedNum: 11110,
-			expectedReq: "11110",
 		},
 		{
-			name:        "reported overflow case",
+			name:        "expanded IDs exceed single batch",
 			totalRows:   78201209,
 			binlogNum:   11,
 			expansion:   10,
 			expectedNum: math.MaxUint32,
-			expectedReq: "8602133100",
 		},
 		{
-			name:        "int64 rows cannot overflow calculation",
-			totalRows:   math.MaxInt64,
-			binlogNum:   11,
-			expansion:   10,
-			expectedNum: math.MaxUint32,
-			expectedReq: "1014570924054025338880",
+			name:             "minimum required IDs exceed single batch",
+			totalRows:        math.MaxUint32 / 11,
+			binlogNum:        11,
+			expansion:        1,
+			expectedError:    merr.ErrParameterInvalid,
+			errorContains:    "required 4294967303, max 4294967295",
+			errorNotContains: "try reducing",
+		},
+		{
+			name:             "int64 rows cannot overflow calculation",
+			totalRows:        math.MaxInt64,
+			binlogNum:        11,
+			expansion:        10,
+			expectedError:    merr.ErrParameterInvalid,
+			errorContains:    "required 101457092405402533888, max 4294967295",
+			errorNotContains: "try reducing",
 		},
 		{
 			name:          "negative rows",
 			totalRows:     -1,
 			binlogNum:     11,
 			expansion:     10,
-			expectedError: true,
-		},
-		{
-			name:          "non-positive binlog count",
-			totalRows:     100,
-			binlogNum:     0,
-			expansion:     10,
-			expectedError: true,
+			expectedError: merr.ErrServiceInternal,
 		},
 		{
 			name:          "non-positive expansion",
 			totalRows:     100,
 			binlogNum:     11,
 			expansion:     0,
-			expectedError: true,
+			expectedError: merr.ErrParameterInvalid,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			num, requested, err := calculatePreAllocIDNum(test.totalRows, test.binlogNum, test.expansion)
-			if test.expectedError {
-				assert.Error(t, err)
-				assert.True(t, errors.Is(err, merr.ErrServiceInternal))
+			num, err := calculatePreAllocIDNum(test.totalRows, test.binlogNum, test.expansion)
+			if test.expectedError != nil {
+				require.ErrorIs(t, err, test.expectedError)
+				assert.ErrorContains(t, err, test.errorContains)
+				if test.errorNotContains != "" {
+					assert.NotContains(t, err.Error(), test.errorNotContains)
+				}
 				return
 			}
 			assert.NoError(t, err)
 			assert.Equal(t, test.expectedNum, num)
-			assert.Equal(t, test.expectedReq, requested)
 		})
 	}
 }


### PR DESCRIPTION
issue: #52632

## What was changed

- Calculate import ID pre-allocation count using big integers.
- Cap the allocator request count at `math.MaxUint32` instead of allowing uint32 wraparound.
- Add unit tests for normal, overflow, and invalid parameter cases.

## Why

Large import/restore jobs can request more IDs than `AllocIDRequest.Count` can represent. The previous conversion to `uint32` could wrap to a smaller value, causing insufficient ID pre-allocation.

## Test

```text
go test -tags dynamic,test -gcflags="all=-N -l" -count=1
./internal/datacoord
-run '^TestCalculatePreAllocIDNum$'
```