### PR TITLE
enhance: make tombstone sweeper non-blocking and concurrency-safe

### DIFF
--- a/internal/metastore/kv/datacoord/kv_catalog.go
+++ b/internal/metastore/kv/datacoord/kv_catalog.go
@@ -936,12 +936,12 @@ func (kc *Catalog) GcConfirm(ctx context.Context, collectionID, partitionID type
 	if partitionID != common.AllPartitionsID {
 		prefix = buildPartitionPrefix(collectionID, partitionID)
 	}
-	keys, values, err := kc.MetaKv.LoadWithPrefix(ctx, prefix)
+	exists, err := kc.MetaKv.HasPrefix(ctx, prefix)
 	if err != nil {
 		// error case can be regarded as not finished.
 		return false
 	}
-	return len(keys) == 0 && len(values) == 0
+	return !exists
 }
 
 func (kc *Catalog) ListCompactionTask(ctx context.Context) ([]*datapb.CompactionTask, error) {

--- a/internal/metastore/kv/datacoord/kv_catalog_test.go
+++ b/internal/metastore/kv/datacoord/kv_catalog_test.go
@@ -1425,17 +1425,25 @@ func TestCatalog_GcConfirm(t *testing.T) {
 	txn := mocks.NewMetaKv(t)
 	kc.MetaKv = txn
 
-	txn.On("LoadWithPrefix",
+	txn.On("HasPrefix",
 		mock.Anything,
 		mock.AnythingOfType("string")).
-		Return(nil, nil, errors.New("error mock LoadWithPrefix")).
+		Return(false, errors.New("error mock HasPrefix")).
 		Once()
 	assert.False(t, kc.GcConfirm(context.TODO(), 100, 10000))
 
-	txn.On("LoadWithPrefix",
+	txn.On("HasPrefix",
 		mock.Anything,
 		mock.AnythingOfType("string")).
-		Return(nil, nil, nil)
+		Return(true, nil).
+		Once()
+	assert.False(t, kc.GcConfirm(context.TODO(), 100, 10000))
+
+	txn.On("HasPrefix",
+		mock.Anything,
+		mock.AnythingOfType("string")).
+		Return(false, nil).
+		Once()
 	assert.True(t, kc.GcConfirm(context.TODO(), 100, 10000))
 }
 

--- a/internal/rootcoord/tombstone/scheduler.go
+++ b/internal/rootcoord/tombstone/scheduler.go
@@ -18,6 +18,7 @@ package tombstone
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -30,10 +31,8 @@ import (
 // Once the tombstone is safe to be removed, it will be removed by the background goroutine.
 func NewTombstoneSweeper() TombstoneSweeper {
 	ts := &tombstoneSweeperImpl{
-		notifier:   syncutil.NewAsyncTaskNotifier[struct{}](),
-		incoming:   make(chan Tombstone),
-		tombstones: make(map[string]Tombstone),
-		interval:   5 * time.Minute,
+		notifier: syncutil.NewAsyncTaskNotifier[struct{}](),
+		interval: 5 * time.Minute,
 	}
 	ts.SetLogger(mlog.With(mlog.FieldModule(typeutil.RootCoordRole), mlog.FieldComponent("tombstone_sweeper")))
 	go ts.background()
@@ -44,18 +43,31 @@ func NewTombstoneSweeper() TombstoneSweeper {
 type tombstoneSweeperImpl struct {
 	mlog.Binder
 
-	notifier   *syncutil.AsyncTaskNotifier[struct{}]
-	incoming   chan Tombstone
-	tombstones map[string]Tombstone
+	notifier *syncutil.AsyncTaskNotifier[struct{}]
+
+	// tombstones is written by DropCollection/DropPartition callbacks and
+	// iterated by the background GC concurrently. The entry wrapper gives
+	// CompareAndDelete a comparable generation token, so a concurrent
+	// re-registration with the same ID cannot be deleted by an older sweep.
+	tombstones sync.Map // map[string]*tombstoneEntry
 	interval   time.Duration
 	// TODO: add metrics for the tombstone sweeper.
 }
 
-// AddTombstone adds a tombstone to the sweeper.
+type tombstoneEntry struct {
+	tombstone Tombstone
+}
+
+// AddTombstone adds a tombstone to the sweeper without waiting for the
+// background GC, which may be performing slow external calls.
 func (s *tombstoneSweeperImpl) AddTombstone(tombstone Tombstone) {
-	select {
-	case <-s.notifier.Context().Done():
-	case s.incoming <- tombstone:
+	if s.notifier.Context().Err() != nil {
+		return
+	}
+
+	_, loaded := s.tombstones.Swap(tombstone.ID(), &tombstoneEntry{tombstone: tombstone})
+	if !loaded {
+		s.Logger().Info(context.TODO(), "tombstone added", mlog.String("tombstone", tombstone.ID()))
 	}
 }
 
@@ -71,11 +83,6 @@ func (s *tombstoneSweeperImpl) background() {
 
 	for {
 		select {
-		case tombstone := <-s.incoming:
-			if _, ok := s.tombstones[tombstone.ID()]; !ok {
-				s.tombstones[tombstone.ID()] = tombstone
-				s.Logger().Info(context.TODO(), "tombstone added", mlog.String("tombstone", tombstone.ID()))
-			}
 		case <-ticker.C:
 			s.triggerGCTombstone(s.notifier.Context())
 		case <-s.notifier.Context().Done():
@@ -86,30 +93,32 @@ func (s *tombstoneSweeperImpl) background() {
 
 // triggerGCTombstone triggers the garbage collection of the tombstones.
 func (s *tombstoneSweeperImpl) triggerGCTombstone(ctx context.Context) {
-	if len(s.tombstones) == 0 {
-		return
-	}
-	for _, tombstone := range s.tombstones {
+	s.tombstones.Range(func(key, value any) bool {
 		if ctx.Err() != nil {
 			// The tombstone sweeper is closing, stop it.
-			return
+			return false
 		}
-		tombstoneID := tombstone.ID()
+
+		tombstoneID := key.(string)
+		entry := value.(*tombstoneEntry)
+		tombstone := entry.tombstone
 		confirmed, err := tombstone.ConfirmCanBeRemoved(ctx)
 		if err != nil {
 			s.Logger().Warn(ctx, "fail to confirm if tombstone can be removed", mlog.String("tombstone", tombstoneID), mlog.Err(err))
-			continue
+			return true
 		}
 		if !confirmed {
-			continue
+			return true
 		}
 		if err := tombstone.Remove(ctx); err != nil {
 			s.Logger().Warn(ctx, "fail to remove tombstone", mlog.String("tombstone", tombstoneID), mlog.Err(err))
-			continue
+			return true
 		}
-		delete(s.tombstones, tombstoneID)
-		s.Logger().Info(ctx, "tombstone removed", mlog.String("tombstone", tombstoneID))
-	}
+		if s.tombstones.CompareAndDelete(tombstoneID, entry) {
+			s.Logger().Info(ctx, "tombstone removed", mlog.String("tombstone", tombstoneID))
+		}
+		return true
+	})
 }
 
 // Close closes the tombstone sweeper.

--- a/internal/rootcoord/tombstone/scheduler_test.go
+++ b/internal/rootcoord/tombstone/scheduler_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
 	"github.com/milvus-io/milvus/pkg/v3/util/syncutil"
@@ -34,10 +35,8 @@ func TestTombstoneSweeper_AddTombstone(t *testing.T) {
 	sweeper.Close()
 
 	sweeperImpl := &tombstoneSweeperImpl{
-		notifier:   syncutil.NewAsyncTaskNotifier[struct{}](),
-		incoming:   make(chan Tombstone),
-		tombstones: make(map[string]Tombstone),
-		interval:   1 * time.Millisecond,
+		notifier: syncutil.NewAsyncTaskNotifier[struct{}](),
+		interval: 1 * time.Millisecond,
 	}
 	go sweeperImpl.background()
 
@@ -63,7 +62,97 @@ func TestTombstoneSweeper_AddTombstone(t *testing.T) {
 	}, 100*time.Millisecond, 10*time.Millisecond)
 
 	sweeperImpl.Close()
-	assert.Len(t, sweeperImpl.tombstones, 0)
+	assert.Equal(t, 0, countTombstones(sweeperImpl))
+}
+
+func TestTombstoneSweeper_AddDoesNotBlockDuringGC(t *testing.T) {
+	sweeper := &tombstoneSweeperImpl{
+		notifier: syncutil.NewAsyncTaskNotifier[struct{}](),
+	}
+	defer sweeper.notifier.Cancel()
+
+	confirmStarted := make(chan struct{})
+	confirmRelease := make(chan struct{})
+	blocking := &funcTombstone{
+		id: "blocking",
+		confirm: func(ctx context.Context) (bool, error) {
+			close(confirmStarted)
+			select {
+			case <-ctx.Done():
+				return false, ctx.Err()
+			case <-confirmRelease:
+				return false, nil
+			}
+		},
+	}
+	sweeper.AddTombstone(blocking)
+
+	gcDone := make(chan struct{})
+	go func() {
+		defer close(gcDone)
+		sweeper.triggerGCTombstone(context.Background())
+	}()
+
+	select {
+	case <-confirmStarted:
+	case <-time.After(time.Second):
+		t.Fatal("GC did not start")
+	}
+
+	addDone := make(chan struct{})
+	go func() {
+		defer close(addDone)
+		sweeper.AddTombstone(&funcTombstone{id: "concurrent"})
+	}()
+
+	select {
+	case <-addDone:
+	case <-time.After(time.Second):
+		t.Fatal("AddTombstone blocked while GC was running")
+	}
+
+	close(confirmRelease)
+	select {
+	case <-gcDone:
+	case <-time.After(time.Second):
+		t.Fatal("GC did not finish")
+	}
+	require.Equal(t, 2, countTombstones(sweeper))
+}
+
+func TestTombstoneSweeper_ConcurrentReplacementIsNotDeleted(t *testing.T) {
+	sweeper := &tombstoneSweeperImpl{
+		notifier: syncutil.NewAsyncTaskNotifier[struct{}](),
+	}
+	defer sweeper.notifier.Cancel()
+
+	replacement := &funcTombstone{id: "same"}
+	original := &funcTombstone{
+		id: "same",
+		confirm: func(context.Context) (bool, error) {
+			return true, nil
+		},
+		remove: func(context.Context) error {
+			sweeper.AddTombstone(replacement)
+			return nil
+		},
+	}
+	sweeper.AddTombstone(original)
+
+	sweeper.triggerGCTombstone(context.Background())
+
+	value, ok := sweeper.tombstones.Load("same")
+	require.True(t, ok)
+	assert.Same(t, replacement, value.(*tombstoneEntry).tombstone)
+}
+
+func countTombstones(sweeper *tombstoneSweeperImpl) int {
+	count := 0
+	sweeper.tombstones.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	return count
 }
 
 type testTombstoneImpl struct {
@@ -90,4 +179,28 @@ func (t *testTombstoneImpl) Remove(ctx context.Context) error {
 	}
 	t.removed.Store(true)
 	return nil
+}
+
+type funcTombstone struct {
+	id      string
+	confirm func(context.Context) (bool, error)
+	remove  func(context.Context) error
+}
+
+func (t *funcTombstone) ID() string {
+	return t.id
+}
+
+func (t *funcTombstone) ConfirmCanBeRemoved(ctx context.Context) (bool, error) {
+	if t.confirm == nil {
+		return false, nil
+	}
+	return t.confirm(ctx)
+}
+
+func (t *funcTombstone) Remove(ctx context.Context) error {
+	if t.remove == nil {
+		return nil
+	}
+	return t.remove(ctx)
 }


### PR DESCRIPTION
## Summary

- Make `AddTombstone` non-blocking by registering the tombstone directly in a `sync.Map` instead of sending it over a channel, so it no longer blocks while the background GC is performing slow external calls (`ConfirmCanBeRemoved` / `Remove`).
- Make `Remove` concurrency-safe via `CompareAndDelete` on the entry pointer, so a concurrent re-registration with the same ID is not deleted by an older sweep.
- Switch `GcConfirm` from `LoadWithPrefix` to `HasPrefix` to avoid loading all keys/values just to check for existence.

## Test plan

- Added unit tests: `TestTombstoneSweeper_AddDoesNotBlockDuringGC`, `TestTombstoneSweeper_ConcurrentReplacementIsNotDeleted`.
- Updated `TestCatalog_GcConfirm` for `HasPrefix`.
- `go test -tags dynamic,test -gcflags="all=-N -l" ./internal/rootcoord/tombstone/...` passes.

Made with [Cursor](https://cursor.com)

issue: #52660