### PR TITLE
fix: [3.0] run MinHash schema validation on all DDL paths and reject TEXT input

### DIFF
--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -3362,6 +3362,31 @@ func TestValidateFunctionInputField(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("Valid MinHash function input - varchar", func(t *testing.T) {
+		function := &schemapb.FunctionSchema{
+			Type: schemapb.FunctionType_MinHash,
+		}
+		fields := []*schemapb.FieldSchema{
+			{DataType: schemapb.DataType_VarChar},
+		}
+		err := validator.CheckFunctionInputField(function, fields)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Invalid MinHash function input - TEXT rejected", func(t *testing.T) {
+		// align with ValidateMinHashFunction's VarChar-only input contract:
+		// admitting TEXT here let the direct RootCoord path (which skipped that
+		// check) create schemas the runner-side validator rejects
+		function := &schemapb.FunctionSchema{
+			Type: schemapb.FunctionType_MinHash,
+		}
+		fields := []*schemapb.FieldSchema{
+			{DataType: schemapb.DataType_Text},
+		}
+		err := validator.CheckFunctionInputField(function, fields)
+		assert.Error(t, err)
+	})
+
 	t.Run("Invalid BM25 function input - multiple fields", func(t *testing.T) {
 		function := &schemapb.FunctionSchema{
 			Type: schemapb.FunctionType_BM25,

--- a/internal/rootcoord/create_collection_task.go
+++ b/internal/rootcoord/create_collection_task.go
@@ -29,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer"
+	"github.com/milvus-io/milvus/internal/util/function/validator"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -703,6 +704,20 @@ func (t *createCollectionTask) prepareSchema(ctx context.Context) error {
 	} else {
 		if err := t.assignFieldAndFunctionID(t.body.CollectionSchema); err != nil {
 			return err
+		}
+		// Function schema validation for requests entering RootCoord directly —
+		// the proxy validates before forwarding, but nothing else on this path
+		// does. Runs only for newly created schemas: preserveFieldID restores an
+		// existing collection (snapshot/replication), whose historical schema
+		// must not be re-judged by current-version rules. External collections
+		// are exempt too: this schema is the RESOLVED one, not what the user
+		// submitted — e.g. nullability is inferred from the external source, so
+		// judging it by user-schema rules rejects legal external tables (the
+		// proxy already validated the user-submitted form).
+		if !typeutil.IsExternalCollection(t.body.CollectionSchema) {
+			if err := validator.ValidateFunction(t.body.CollectionSchema, "", true); err != nil {
+				return err
+			}
 		}
 	}
 	if err := typeutil.ValidateExternalCollectionResolvedSchema(t.body.CollectionSchema); err != nil {

--- a/internal/rootcoord/create_collection_task_test.go
+++ b/internal/rootcoord/create_collection_task_test.go
@@ -3006,3 +3006,91 @@ func Test_appendConsistecyLevel(t *testing.T) {
 	assert.Equal(t, commonpb.ConsistencyLevel_Session, consistencyLevel)
 	assert.Len(t, properties, 0)
 }
+
+// The direct RootCoord path never went through validator.ValidateFunction:
+// prepareSchema only validated fields and assigned IDs, so a client hitting
+// RootCoord directly could persist a MinHash schema the proxy path rejects.
+// prepareSchema is the real create path — these cases must fail there, not
+// only in the validator helper.
+func Test_createCollectionTask_prepareSchema_validatesFunctions(t *testing.T) {
+	buildTask := func(numHashes string) createCollectionTask {
+		collectionName := funcutil.GenRandomStr()
+		schema := &schemapb.CollectionSchema{
+			Name: collectionName,
+			Fields: []*schemapb.FieldSchema{
+				{Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{Name: "text", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "128"},
+				}},
+				{Name: "hash", DataType: schemapb.DataType_BinaryVector, IsFunctionOutput: true, TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "32"},
+				}},
+			},
+			Functions: []*schemapb.FunctionSchema{{
+				Name: "minhash", Type: schemapb.FunctionType_MinHash,
+				InputFieldNames: []string{"text"}, OutputFieldNames: []string{"hash"},
+				Params: []*commonpb.KeyValuePair{{Key: "num_hashes", Value: numHashes}},
+			}},
+		}
+		return createCollectionTask{
+			Req: &milvuspb.CreateCollectionRequest{
+				Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
+				CollectionName: collectionName,
+			},
+			body: &message.CreateCollectionRequest{
+				CollectionSchema: schema,
+			},
+		}
+	}
+
+	t.Run("overflowing num_hashes rejected", func(t *testing.T) {
+		// (2^59+1)*32 wraps around int64 to 32; a multiply-based check passes
+		// and the runner then attempts an impossibly large permutation alloc.
+		task := buildTask("576460752303423489")
+		err := task.prepareSchema(context.TODO())
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.ErrorContains(t, err, "does not match expected dim")
+	})
+
+	t.Run("valid minhash accepted", func(t *testing.T) {
+		task := buildTask("1")
+		err := task.prepareSchema(context.TODO())
+		assert.NoError(t, err)
+	})
+}
+
+// External collections are exempt from the direct-path function validation:
+// prepareSchema sees the RESOLVED schema (e.g. nullability inferred from the
+// external source), not the user-submitted one the proxy validated — judging
+// it by user-schema rules rejects legal external tables (a nullable
+// TextEmbedding input resolved from parquet, as the go-sdk e2e creates).
+func Test_createCollectionTask_prepareSchema_skipsFunctionValidationForExternal(t *testing.T) {
+	collectionName := funcutil.GenRandomStr()
+	schema := &schemapb.CollectionSchema{
+		Name: collectionName,
+		Fields: []*schemapb.FieldSchema{
+			{Name: "pk", DataType: schemapb.DataType_Int64, ExternalField: "pk"},
+			{Name: "doc", DataType: schemapb.DataType_VarChar, Nullable: true, ExternalField: "doc", TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.MaxLengthKey, Value: "1024"},
+			}},
+			{Name: "dense", DataType: schemapb.DataType_FloatVector, IsFunctionOutput: true, TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.DimKey, Value: "8"},
+			}},
+		},
+		Functions: []*schemapb.FunctionSchema{{
+			Name: "tei_fn", Type: schemapb.FunctionType_TextEmbedding,
+			InputFieldNames: []string{"doc"}, OutputFieldNames: []string{"dense"},
+		}},
+	}
+	task := createCollectionTask{
+		Req: &milvuspb.CreateCollectionRequest{
+			Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
+			CollectionName: collectionName,
+		},
+		body: &message.CreateCollectionRequest{
+			CollectionSchema: schema,
+		},
+	}
+	err := task.prepareSchema(context.TODO())
+	assert.NoError(t, err)
+}

--- a/internal/util/function/embedding/function_executor.go
+++ b/internal/util/function/embedding/function_executor.go
@@ -28,7 +28,6 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
-	"github.com/milvus-io/milvus/internal/util/function"
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
@@ -81,15 +80,10 @@ func validateFunction(schema *schemapb.CollectionSchema, fSchema *schemapb.Funct
 		return err
 	}
 
-	// BM25 or minhash function returns nil from createFunction
+	// BM25 and MinHash return nil from createFunction: neither needs a model
+	// runtime check. MinHash parameter validation is pure schema checking and
+	// runs unconditionally in validator.ValidateFunction instead.
 	if f == nil {
-		if fSchema.GetType() == schemapb.FunctionType_MinHash {
-			err := function.ValidateMinHashFunction(schema, fSchema)
-			if err != nil {
-				return err
-			}
-		}
-		// bm25 or minhash validate pass
 		return nil
 	}
 

--- a/internal/util/function/minhash_function.go
+++ b/internal/util/function/minhash_function.go
@@ -289,9 +289,10 @@ func ValidateMinHashFunction(collSchema *schemapb.CollectionSchema, funSchema *s
 	}
 
 	if numHashes > 0 {
-		expectedDim := int64(numHashes * 32) // binary vector, each hash is 4 bytes (32 bits), but stored as 8 bits in binary vector
-		if outputDim != expectedDim {
-			return merr.WrapErrParameterInvalidMsg("minhash function output field '%s' dim %d does not match expected dim %d (numHashes %d * one minhash signature size of 32bit)", outputFieldName, outputDim, expectedDim, numHashes)
+		// Compare via division: numHashes*32 can wrap around int64 and defeat
+		// the check. Each hash occupies 32 bits of the binary vector.
+		if outputDim%32 != 0 || outputDim/32 != int64(numHashes) {
+			return merr.WrapErrParameterInvalidMsg("minhash function output field '%s' dim %d does not match expected dim (numHashes %d * one minhash signature size of 32bit)", outputFieldName, outputDim, numHashes)
 		}
 	} else {
 		if outputDim%32 != 0 {

--- a/internal/util/function/minhash_function_test.go
+++ b/internal/util/function/minhash_function_test.go
@@ -1,0 +1,50 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package function
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+// num_hashes = 2^59+1: (2^59+1)*32 wraps around int64 to 32, so a
+// multiply-based dim check would accept it and pass the raw value to
+// initializePermutations' slice allocation on first use.
+func TestValidateMinHashFunctionRejectsNumHashesOverflowingDimCheck(t *testing.T) {
+	collSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{Name: "text", DataType: schemapb.DataType_VarChar},
+		{Name: "hash", DataType: schemapb.DataType_BinaryVector, TypeParams: []*commonpb.KeyValuePair{
+			{Key: "dim", Value: "32"},
+		}},
+	}}
+	funSchema := &schemapb.FunctionSchema{
+		Name: "minhash", Type: schemapb.FunctionType_MinHash,
+		InputFieldNames: []string{"text"}, OutputFieldNames: []string{"hash"},
+		Params: []*commonpb.KeyValuePair{{Key: NumHashesKey, Value: "576460752303423489"}},
+	}
+
+	err := ValidateMinHashFunction(collSchema, funSchema)
+	require.ErrorIs(t, err, merr.ErrParameterInvalid)
+	require.ErrorContains(t, err, "does not match expected dim")
+}

--- a/internal/util/function/validator/validator.go
+++ b/internal/util/function/validator/validator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/function"
 	"github.com/milvus-io/milvus/internal/util/function/embedding"
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
@@ -96,6 +97,20 @@ func ValidateFunction(coll *schemapb.CollectionSchema, needValidateFunctionName 
 			if usedOutputField.Contain(name) {
 				return merr.WrapErrParameterInvalidMsg("function %s input field %s is the output of another function; function cascade is not supported", function.GetName(), name)
 			}
+		}
+	}
+	// MinHash parameter validation (num_hashes vs output dim relation) is pure
+	// schema checking with no external calls; it must run even when the model
+	// runtime checks below are disabled.
+	for _, fn := range coll.GetFunctions() {
+		if fn.GetType() != schemapb.FunctionType_MinHash {
+			continue
+		}
+		if needValidateFunctionName != "" && fn.GetName() != needValidateFunctionName {
+			continue
+		}
+		if err := function.ValidateMinHashFunction(coll, fn); err != nil {
+			return err
 		}
 	}
 	if !disableRuntimeCheck {
@@ -189,8 +204,11 @@ func CheckFunctionInputField(function *schemapb.FunctionSchema, fields []*schema
 			return err
 		}
 	case schemapb.FunctionType_MinHash:
-		if len(fields) != 1 || (fields[0].DataType != schemapb.DataType_VarChar && fields[0].DataType != schemapb.DataType_Text) {
-			return merr.WrapErrParameterInvalidMsg("MinHash function input field must be a VARCHAR/TEXT field, got %d field with type %s",
+		// VarChar only: the MinHash runner has never accepted TEXT
+		// (ValidateMinHashFunction), so admitting it here produced
+		// collections whose every insert failed at the function executor.
+		if len(fields) != 1 || fields[0].DataType != schemapb.DataType_VarChar {
+			return merr.WrapErrParameterInvalidMsg("MinHash function input field must be a VARCHAR field, got %d field with type %s",
 				len(fields), fields[0].DataType.String())
 		}
 	default:

--- a/internal/util/function/validator/validator_test.go
+++ b/internal/util/function/validator/validator_test.go
@@ -1,0 +1,59 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/function"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+func minHashCollectionSchema(numHashes string) *schemapb.CollectionSchema {
+	return &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar},
+			{FieldID: 101, Name: "hash", DataType: schemapb.DataType_BinaryVector, TypeParams: []*commonpb.KeyValuePair{
+				{Key: "dim", Value: "64"},
+			}},
+		},
+		Functions: []*schemapb.FunctionSchema{{
+			Name:             "minhash",
+			Type:             schemapb.FunctionType_MinHash,
+			InputFieldNames:  []string{"text"},
+			OutputFieldNames: []string{"hash"},
+			Params:           []*commonpb.KeyValuePair{{Key: function.NumHashesKey, Value: numHashes}},
+		}},
+	}
+}
+
+// The direct RootCoord DDL path calls ValidateFunction with
+// disableRuntimeCheck=true; MinHash parameter validation is pure schema
+// checking and must still run there.
+func TestValidateFunctionChecksMinHashParamsWithRuntimeCheckDisabled(t *testing.T) {
+	err := ValidateFunction(minHashCollectionSchema("3"), "minhash", true)
+	require.ErrorIs(t, err, merr.ErrParameterInvalid)
+	require.ErrorContains(t, err, "does not match expected dim")
+}
+
+func TestValidateFunctionAcceptsValidMinHashWithRuntimeCheckDisabled(t *testing.T) {
+	require.NoError(t, ValidateFunction(minHashCollectionSchema("2"), "minhash", true))
+}


### PR DESCRIPTION
Cherry-pick of #52219 to the 3.0 branch.

### What

Admission gaps around MinHash functions, each letting DDL persist collections that can never work:

- **`disableRuntimeCheck=true` paths skipped MinHash parameter validation.** Hoist `ValidateMinHashFunction` into `validator.ValidateFunction` so it runs regardless of the runtime-check switch; drop the now-redundant special case in the embedding executor.
- **The direct RootCoord CreateCollection path ran no function validation at all.** Run `validator.ValidateFunction(schema, "", true)` after `assignFieldAndFunctionID`, scoped to newly created schemas (the `preserveFieldID` restore path and external collections are exempt).
- **The validation itself was overflow-bypassable.** Compare via division (`outputDim%32 == 0 && outputDim/32 == numHashes`) instead of `outputDim != int64(numHashes*32)`, which wraps for large `num_hashes`.
- **`CheckFunctionInputField` admitted TEXT inputs for MinHash, contradicting the VarChar-only runner contract.** Align admission to VARCHAR-only.

### Tests

- `Test_createCollectionTask_prepareSchema_validatesFunctions`, `Test_createCollectionTask_prepareSchema_skipsFunctionValidationForExternal`
- `TestValidateMinHashFunctionRejectsNumHashesOverflowingDimCheck`, new `validator_test.go`
- `TestValidateFunctionInputField` MinHash VarChar-accepted / TEXT-rejected cases

issue: #51649
pr: #52219
