### PR TITLE
fix: [3.0] tolerate legacy STLSORT physical files under HYBRID nested index metadata

### DIFF
--- a/internal/core/src/index/BitmapIndexArrayTest.cpp
+++ b/internal/core/src/index/BitmapIndexArrayTest.cpp
@@ -34,6 +34,7 @@
 #include "common/protobuf_utils.h"
 #include "gtest/gtest.h"
 #include "index/BitmapIndex.h"
+#include "index/HybridScalarIndex.h"
 #include "index/Index.h"
 #include "index/IndexFactory.h"
 #include "index/IndexInfo.h"
@@ -51,6 +52,8 @@
 #include "storage/ChunkManager.h"
 #include "storage/EntryStreamUtils.h"
 #include "storage/FileManager.h"
+#include "storage/IndexEntryReader.h"
+#include "storage/IndexEntryWriter.h"
 #include "storage/InsertData.h"
 #include "storage/PayloadReader.h"
 #include "storage/PluginLoader.h"
@@ -1551,4 +1554,212 @@ TEST(ArrayOffsetsSealedTest, BuildAllZerosEmptyArraysAndBalancedResource) {
         ASSERT_EQ(tmp->GetRowCount(), 500);
         ASSERT_EQ(tmp->GetTotalElementCount(), 0);
     }
+}
+
+// ============================================================================
+// Regression for struct-array sub-field HYBRID scalar index load failure
+// (segcoreCode=2001, "Meta key not found: index_type").
+//
+// In 3.0.0, IndexFactory::CreateNestedIndex routed HYBRID through the default
+// STLSORT factory, so a HYBRID collection index on a struct-array sub-field
+// (e.g. items[items[category]], element VarChar) produced a standalone
+// milvus_packed_stlsort_index.v3 whose meta lacks the hybrid index_type key.
+// The load path trusted metadata HYBRID, built a HybridScalarIndex, and its
+// LoadEntries unconditionally read the index_type meta -> assert -> 2001.
+//
+// The fix makes HybridScalarIndex::LoadEntries tolerant: when index_type is
+// absent it infers the physical index type from the file's meta keys and
+// dispatches to the existing internal index loader.
+// ============================================================================
+
+TEST(BitmapIndexArrayNestedTest,
+     LegacyStandaloneStlsortLoadsUnderHybridMetadata) {
+    proto::schema::FieldSchema field_schema;
+    field_schema.set_name("struct_field[sub]");
+    field_schema.set_data_type(proto::schema::DataType::Array);
+    field_schema.set_element_type(proto::schema::DataType::VarChar);
+    field_schema.set_nullable(false);
+
+    auto field_meta = storage::FieldDataMeta{1, 2, 3, 101, field_schema};
+    auto index_meta = storage::IndexMeta{3, 101, 3130, 3130};
+
+    auto root_path =
+        fmt::format("{}/legacy_stlsort_under_hybrid", TestLocalPath);
+    boost::filesystem::remove_all(root_path);
+    storage::StorageConfig storage_config;
+    storage_config.storage_type = "local";
+    storage_config.root_path = root_path;
+    auto chunk_manager = storage::CreateChunkManager(storage_config);
+    auto fs = storage::InitArrowFileSystem(storage_config);
+    storage::FileManagerContext ctx(field_meta, index_meta, chunk_manager, fs);
+
+    // Build a standalone STLSORT (StringIndexSort) through the nested index
+    // factory exactly as 3.0.0 did for struct-array sub-fields: the default
+    // (non-BITMAP/INVERTED/HYBRID) routing in CreateNestedIndex produces a
+    // StringIndexSort whose packed file carries no hybrid index_type meta.
+    index::CreateIndexInfo build_info{};
+    build_info.index_type = milvus::index::ASCENDING_SORT;
+    build_info.field_type = DataType::ARRAY;
+    build_info.field_name = "struct_field[sub]";
+
+    auto stlsort =
+        index::IndexFactory::GetInstance().CreateIndex(build_info, ctx);
+    ASSERT_TRUE(stlsort->IsNestedIndex());
+    ASSERT_NE(dynamic_cast<index::StringIndexSort*>(stlsort.get()), nullptr);
+
+    // Element-indexed data: row0 {alpha,beta}, row1 {}, row2 {}, row3
+    // {beta,gamma} -> flattened elements alpha,beta,beta,gamma (4 elements).
+    std::vector<ScalarFieldProto> scalar_arrays(4);
+    scalar_arrays[0].mutable_string_data()->add_data("alpha");
+    scalar_arrays[0].mutable_string_data()->add_data("beta");
+    scalar_arrays[3].mutable_string_data()->add_data("beta");
+    scalar_arrays[3].mutable_string_data()->add_data("gamma");
+    std::vector<milvus::Array> array_data;
+    array_data.reserve(scalar_arrays.size());
+    for (const auto& scalar_array : scalar_arrays) {
+        array_data.emplace_back(scalar_array);
+    }
+    auto field_data =
+        storage::CreateFieldData(DataType::ARRAY, DataType::NONE, false);
+    field_data->FillFieldData(array_data.data(), array_data.size());
+
+    auto stlsort_index = dynamic_cast<index::StringIndexSort*>(stlsort.get());
+    stlsort_index->BuildWithFieldData(std::vector<FieldDataPtr>{field_data});
+    ASSERT_EQ(stlsort_index->Count(), 4);
+
+    // Upload produces the legacy milvus_packed_stlsort_index.v3 file.
+    auto create_index_result = stlsort_index->UploadUnified({});
+    ASSERT_EQ(create_index_result->GetIndexFiles().size(), 1);
+    auto index_files = create_index_result->GetIndexFiles();
+
+    // The file meta must genuinely lack the hybrid index_type key so this test
+    // exercises the inference branch (not the HasMeta branch).
+    {
+        storage::MemFileManagerImpl fm(ctx);
+        auto input = fm.OpenInputStream(index_files[0]);
+        ASSERT_NE(input, nullptr);
+        auto reader = storage::IndexEntryReader::Open(input, input->Size());
+        ASSERT_NE(reader, nullptr);
+        EXPECT_FALSE(reader->HasMeta(INDEX_TYPE));
+        EXPECT_TRUE(reader->HasMeta("version"));
+        EXPECT_TRUE(reader->HasMeta("num_rows"));
+    }
+
+    // Now load that STLSORT file through the HYBRID (nested) index path.
+    index::CreateIndexInfo load_info{};
+    load_info.index_type = milvus::index::HYBRID_INDEX_TYPE;
+    load_info.field_type = DataType::ARRAY;
+    load_info.field_name = "struct_field[sub]";
+    load_info.tantivy_index_version = 7;
+
+    Config config;
+    config["index_files"] = index_files;
+    config[milvus::LOAD_PRIORITY] = milvus::proto::common::LoadPriority::HIGH;
+    config[milvus::index::SCALAR_INDEX_ENGINE_VERSION] = 3;
+
+    ctx.set_for_loading_index(true);
+    auto hybrid =
+        index::IndexFactory::GetInstance().CreateIndex(load_info, ctx);
+    ASSERT_TRUE(hybrid->IsNestedIndex());
+    ASSERT_EQ(hybrid->Type(), milvus::index::HYBRID_INDEX_TYPE);
+
+    auto hybrid_index =
+        dynamic_cast<index::HybridScalarIndex<std::string>*>(hybrid.get());
+    ASSERT_NE(hybrid_index, nullptr);
+
+    // Before the fix this threw "Meta key not found: index_type"; now the
+    // physical type is inferred from the file meta and the load succeeds.
+    hybrid->LoadUnified(config);
+    EXPECT_EQ(hybrid_index->internal_index_type_, ScalarIndexType::STLSORT);
+    EXPECT_EQ(hybrid->Count(), 4);
+
+    // Element-indexed queries delegate to the inferred STLSORT internal index.
+    // Flattened valid elements: e0=alpha, e1=beta, e2=beta, e3=gamma.
+    std::string beta = "beta";
+    auto in_result = hybrid_index->In(1, &beta);
+    ASSERT_EQ(in_result.size(), 4);
+    EXPECT_FALSE(in_result[0]);
+    EXPECT_TRUE(in_result[1]);
+    EXPECT_TRUE(in_result[2]);
+    EXPECT_FALSE(in_result[3]);
+
+    boost::filesystem::remove_all(root_path);
+}
+
+TEST(BitmapIndexArrayNestedTest,
+     HybridFileWithIndexTypeMetaStillLoadsViaMetaBranch) {
+    proto::schema::FieldSchema field_schema;
+    field_schema.set_name("struct_field[sub]");
+    field_schema.set_data_type(proto::schema::DataType::Array);
+    field_schema.set_element_type(proto::schema::DataType::VarChar);
+    field_schema.set_nullable(false);
+
+    auto field_meta = storage::FieldDataMeta{1, 2, 3, 101, field_schema};
+    auto index_meta = storage::IndexMeta{3, 101, 3131, 3131};
+
+    auto root_path =
+        fmt::format("{}/hybrid_with_index_type_meta", TestLocalPath);
+    boost::filesystem::remove_all(root_path);
+    storage::StorageConfig storage_config;
+    storage_config.storage_type = "local";
+    storage_config.root_path = root_path;
+    auto chunk_manager = storage::CreateChunkManager(storage_config);
+    auto fs = storage::InitArrowFileSystem(storage_config);
+    storage::FileManagerContext ctx(field_meta, index_meta, chunk_manager, fs);
+
+    // Build a proper STLSORT-backed hybrid packed file exactly as
+    // HybridScalarIndex::WriteEntries does (internal entries + index_type meta).
+    auto stlsort = std::make_unique<index::StringIndexSort>(ctx, true);
+
+    std::vector<ScalarFieldProto> scalar_arrays(3);
+    scalar_arrays[0].mutable_string_data()->add_data("x");
+    scalar_arrays[1].mutable_string_data()->add_data("y");
+    scalar_arrays[2].mutable_string_data()->add_data("x");
+    std::vector<milvus::Array> array_data;
+    array_data.reserve(scalar_arrays.size());
+    for (const auto& scalar_array : scalar_arrays) {
+        array_data.emplace_back(scalar_array);
+    }
+    auto field_data =
+        storage::CreateFieldData(DataType::ARRAY, DataType::NONE, false);
+    field_data->FillFieldData(array_data.data(), array_data.size());
+    stlsort->BuildWithFieldData(std::vector<FieldDataPtr>{field_data});
+    ASSERT_EQ(stlsort->Count(), 3);
+
+    auto file_manager = std::make_shared<storage::MemFileManagerImpl>(ctx);
+    auto writer = file_manager->CreateIndexEntryWriterUnified(
+        "milvus_packed_hybrid_index.v3");
+    stlsort->WriteEntries(writer.get());
+    writer->PutMeta(INDEX_TYPE, static_cast<uint8_t>(ScalarIndexType::STLSORT));
+    writer->Finish();
+
+    std::vector<std::string> index_files{
+        file_manager->GetRemoteIndexObjectPrefix() +
+        "/milvus_packed_hybrid_index.v3"};
+
+    index::CreateIndexInfo load_info{};
+    load_info.index_type = milvus::index::HYBRID_INDEX_TYPE;
+    load_info.field_type = DataType::ARRAY;
+    load_info.field_name = "struct_field[sub]";
+    load_info.tantivy_index_version = 7;
+
+    Config config;
+    config["index_files"] = index_files;
+    config[milvus::LOAD_PRIORITY] = milvus::proto::common::LoadPriority::HIGH;
+    config[milvus::index::SCALAR_INDEX_ENGINE_VERSION] = 3;
+
+    ctx.set_for_loading_index(true);
+    auto hybrid =
+        index::IndexFactory::GetInstance().CreateIndex(load_info, ctx);
+    auto hybrid_index =
+        dynamic_cast<index::HybridScalarIndex<std::string>*>(hybrid.get());
+    ASSERT_NE(hybrid_index, nullptr);
+
+    hybrid->LoadUnified(config);
+    // The index_type meta exists, so the HasMeta branch decides the physical
+    // type (STLSORT), not the inference fallback.
+    EXPECT_EQ(hybrid_index->internal_index_type_, ScalarIndexType::STLSORT);
+    EXPECT_EQ(hybrid->Count(), 3);
+
+    boost::filesystem::remove_all(root_path);
 }

--- a/internal/core/src/index/BitmapIndexArrayTest.cpp
+++ b/internal/core/src/index/BitmapIndexArrayTest.cpp
@@ -1627,10 +1627,13 @@ TEST(BitmapIndexArrayNestedTest,
     stlsort_index->BuildWithFieldData(std::vector<FieldDataPtr>{field_data});
     ASSERT_EQ(stlsort_index->Count(), 4);
 
-    // Upload produces the legacy milvus_packed_stlsort_index.v3 file.
+    // Upload produces the legacy milvus_packed_stlsort_index.v3 file; the
+    // physical type is recovered from the filename, not from meta keys.
     auto create_index_result = stlsort_index->UploadUnified({});
     ASSERT_EQ(create_index_result->GetIndexFiles().size(), 1);
     auto index_files = create_index_result->GetIndexFiles();
+    EXPECT_EQ(index_files[0].substr(index_files[0].find_last_of('/') + 1),
+              "milvus_packed_stlsort_index.v3");
 
     // The file meta must genuinely lack the hybrid index_type key so this test
     // exercises the inference branch (not the HasMeta branch).

--- a/internal/core/src/index/HybridScalarIndex.cpp
+++ b/internal/core/src/index/HybridScalarIndex.cpp
@@ -69,7 +69,8 @@ ParsePhysicalTypeFromPackedFileName(const std::string& filename) {
     const std::string suffix = "_index.v3";
     if (filename.size() < prefix.size() + suffix.size() ||
         filename.compare(0, prefix.size(), prefix) != 0 ||
-        filename.compare(filename.size() - suffix.size(), suffix.size(), suffix) != 0) {
+        filename.compare(
+            filename.size() - suffix.size(), suffix.size(), suffix) != 0) {
         return std::nullopt;
     }
     auto type_str = filename.substr(

--- a/internal/core/src/index/HybridScalarIndex.cpp
+++ b/internal/core/src/index/HybridScalarIndex.cpp
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <exception>
 #include <map>
+#include <optional>
 #include <set>
 #include <utility>
 
@@ -51,6 +52,41 @@
 
 namespace milvus {
 namespace index {
+
+namespace {
+
+// V3 packed filenames encode the physical index type (lowercased
+// ScalarIndexType, see ScalarIndex::UploadUnified): e.g.
+// "milvus_packed_stlsort_index.v3". The writer chose the name from
+// GetIndexType(), so it is an authoritative discriminator and stays correct
+// as new physical index types are added (their meta keys may reuse names like
+// "version" or "file_names", which would break meta-key-only inference).
+// Returns nullopt for the proper hybrid name ("milvus_packed_hybrid_index.v3")
+// and for unknown names, so callers fall back to the file meta.
+std::optional<ScalarIndexType>
+ParsePhysicalTypeFromPackedFileName(const std::string& filename) {
+    const std::string prefix = "milvus_packed_";
+    const std::string suffix = "_index.v3";
+    if (filename.size() < prefix.size() + suffix.size() ||
+        filename.compare(0, prefix.size(), prefix) != 0 ||
+        filename.compare(filename.size() - suffix.size(), suffix.size(), suffix) != 0) {
+        return std::nullopt;
+    }
+    auto type_str = filename.substr(
+        prefix.size(), filename.size() - prefix.size() - suffix.size());
+    if (type_str == "stlsort") {
+        return ScalarIndexType::STLSORT;
+    } else if (type_str == "inverted") {
+        return ScalarIndexType::INVERTED;
+    } else if (type_str == "bitmap") {
+        return ScalarIndexType::BITMAP;
+    } else if (type_str == "marisa") {
+        return ScalarIndexType::MARISA;
+    }
+    return std::nullopt;
+}
+
+}  // namespace
 
 template <typename T>
 HybridScalarIndex<T>::HybridScalarIndex(
@@ -445,18 +481,32 @@ HybridScalarIndex<T>::LoadEntries(storage::IndexEntryReader& reader,
     } else {
         // Legacy 3.0.0 bug (#52359/#52360): struct-array sub-field HYBRID
         // indexes were built as a standalone STLSORT (or, hypothetically, other
-        // physical) file whose meta lacks the hybrid index_type key. Infer the
-        // physical index type from the file meta so existing files load.
-        if (reader.HasMeta("version") || reader.HasMeta("index_length")) {
-            internal_index_type_ = ScalarIndexType::STLSORT;
-        } else if (reader.HasMeta("file_names")) {
-            internal_index_type_ = ScalarIndexType::INVERTED;
-        } else if (reader.HasMeta(BITMAP_INDEX_LENGTH)) {
-            internal_index_type_ = ScalarIndexType::BITMAP;
-        } else {
-            ThrowInfo(UnexpectedError,
-                      "hybrid index file has neither index_type meta nor a "
-                      "recognizable physical index meta");
+        // physical) file whose meta lacks the hybrid index_type key. Prefer the
+        // packed filename ("milvus_packed_<type>_index.v3") to recover the
+        // physical type; fall back to the file meta keys for robustness.
+        internal_index_type_ = ScalarIndexType::NONE;
+        auto index_files =
+            GetValueFromConfig<std::vector<std::string>>(config, INDEX_FILES);
+        if (index_files.has_value() && !index_files.value().empty()) {
+            auto path = index_files.value()[0];
+            auto filename = path.substr(path.find_last_of('/') + 1);
+            if (auto type = ParsePhysicalTypeFromPackedFileName(filename)) {
+                internal_index_type_ = *type;
+            }
+        }
+        if (internal_index_type_ == ScalarIndexType::NONE) {
+            if (reader.HasMeta("version") || reader.HasMeta("index_length")) {
+                internal_index_type_ = ScalarIndexType::STLSORT;
+            } else if (reader.HasMeta("file_names")) {
+                internal_index_type_ = ScalarIndexType::INVERTED;
+            } else if (reader.HasMeta(BITMAP_INDEX_LENGTH)) {
+                internal_index_type_ = ScalarIndexType::BITMAP;
+            } else {
+                ThrowInfo(UnexpectedError,
+                          "hybrid index file has neither index_type meta, a "
+                          "recognizable packed filename, nor a recognizable "
+                          "physical index meta");
+            }
         }
         LOG_WARN(
             "hybrid index missing index_type meta, inferred physical type: {}",

--- a/internal/core/src/index/HybridScalarIndex.cpp
+++ b/internal/core/src/index/HybridScalarIndex.cpp
@@ -439,8 +439,29 @@ template <typename T>
 void
 HybridScalarIndex<T>::LoadEntries(storage::IndexEntryReader& reader,
                                   const Config& config) {
-    internal_index_type_ =
-        static_cast<ScalarIndexType>(reader.GetMeta<uint8_t>("index_type"));
+    if (reader.HasMeta(INDEX_TYPE)) {
+        internal_index_type_ =
+            static_cast<ScalarIndexType>(reader.GetMeta<uint8_t>(INDEX_TYPE));
+    } else {
+        // Legacy 3.0.0 bug (#52359/#52360): struct-array sub-field HYBRID
+        // indexes were built as a standalone STLSORT (or, hypothetically, other
+        // physical) file whose meta lacks the hybrid index_type key. Infer the
+        // physical index type from the file meta so existing files load.
+        if (reader.HasMeta("version") || reader.HasMeta("index_length")) {
+            internal_index_type_ = ScalarIndexType::STLSORT;
+        } else if (reader.HasMeta("file_names")) {
+            internal_index_type_ = ScalarIndexType::INVERTED;
+        } else if (reader.HasMeta(BITMAP_INDEX_LENGTH)) {
+            internal_index_type_ = ScalarIndexType::BITMAP;
+        } else {
+            ThrowInfo(UnexpectedError,
+                      "hybrid index file has neither index_type meta nor a "
+                      "recognizable physical index meta");
+        }
+        LOG_WARN(
+            "hybrid index missing index_type meta, inferred physical type: {}",
+            ToString(internal_index_type_));
+    }
 
     LOG_INFO("LoadEntries hybrid index with internal index type: {}",
              ToString(internal_index_type_));


### PR DESCRIPTION
Cherry-pick from master
pr: #52642
issue: #52620

Struct sub-field scalar indexes use the nested index factory because their logical field type is an array. In 3.0.0, IndexFactory::CreateNestedIndex routed HYBRID through the default sort-index factory, so a HYBRID collection index on a struct-array sub-field (e.g. items[items[category]], element VarChar) produced a standalone milvus_packed_stlsort_index.v3 whose meta lacks the hybrid index_type key.

The load path is driven by collection metadata HYBRID, so it builds a HybridScalarIndex whose LoadEntries unconditionally read the index_type meta, hitting "Meta key not found: index_type" (segcoreCode=2001) and failing segment load. The build side was already fixed; existing bad files still failed to load.

Make HybridScalarIndex::LoadEntries tolerant: when the index_type meta key is absent, infer the physical index type from the file's persisted meta keys (version/index_length -> STLSORT, file_names -> INVERTED, bitmap_index_length -> BITMAP), then dispatch to the existing internal index loader. No reindexing or object-store rewrite needed.

Add regression tests: a standalone STLSORT file built via the nested index factory loads through the HYBRID path and infers STLSORT, and a proper hybrid file with the index_type meta still loads through the HasMeta branch.