### PR TITLE
fix:[3.0] prevent crash on zero-length Arrow C Data buffers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -312,7 +312,7 @@ require (
 )
 
 replace (
-	github.com/apache/arrow/go/v17 => github.com/milvus-io/arrow/go/v17 v17.0.1
+	github.com/apache/arrow/go/v17 => github.com/milvus-io/arrow/go/v17 v17.0.2
 	github.com/bketelsen/crypt => github.com/bketelsen/crypt v0.0.4 // Fix security alert for core-os/etcd
 	github.com/expr-lang/expr => github.com/SimFG/expr v0.0.0-20250513112851-9b981e8400b9
 	github.com/go-kit/kit => github.com/go-kit/kit v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -792,8 +792,8 @@ github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/le
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26 h1:gPxPSwALAeHJSjarOs00QjVdV9QoBvc1D2ujQUr5BzU=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
-github.com/milvus-io/arrow/go/v17 v17.0.1 h1:juKuEgTNQbe8a+LuBnyt9/UkfllTwtQIB+K7PvK4+Y4=
-github.com/milvus-io/arrow/go/v17 v17.0.1/go.mod h1:jR7QHkODl15PfYyjM2nU+yTLScZ/qfj7OSUZmJ8putc=
+github.com/milvus-io/arrow/go/v17 v17.0.2 h1:vHaLmnERUWU5m6uggpqT2yoUV0gjvx2n9P1XjnPg01w=
+github.com/milvus-io/arrow/go/v17 v17.0.2/go.mod h1:jR7QHkODl15PfYyjM2nU+yTLScZ/qfj7OSUZmJ8putc=
 github.com/milvus-io/blobloom v0.0.0-20240603110411-471ae49f3b93 h1:xnIeuG1nuTEHKbbv51OwNGO82U+d6ut08ppTmZVm+VY=
 github.com/milvus-io/blobloom v0.0.0-20240603110411-471ae49f3b93/go.mod h1:mjMJ1hh1wjGVfr93QIHJ6FfDNVrA0IELv8OvMHJxHKs=
 github.com/milvus-io/cgosymbolizer v0.0.0-20260810014817-f3b338cf6824 h1:zT7BfS7IOm9LjtpePHE1lzJ3+acyv4niTtEsdmRF1c0=

--- a/internal/storage/arrow_cdata_test.go
+++ b/internal/storage/arrow_cdata_test.go
@@ -1,0 +1,93 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"runtime"
+	"testing"
+	"unsafe"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/cdata"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+)
+
+func TestIssue52233ImportAllNullStringWithSentinelValuesPointer(t *testing.T) {
+	const rowCount = 1000
+
+	builder := array.NewStringBuilder(memory.DefaultAllocator)
+	defer builder.Release()
+	builder.AppendNulls(rowCount)
+	source := builder.NewStringArray()
+	defer source.Release()
+
+	var exported cdata.CArrowArray
+	cdata.ExportArrowArray(source, &exported, nil)
+	defer cdata.ReleaseCArrowArray(&exported)
+
+	// ArrowArray is part of the stable C Data Interface ABI. Treat the buffer
+	// entries as uintptr values so the Go runtime never treats the 0x1 sentinel
+	// as a Go pointer while constructing the fixture.
+	type arrowArrayLayout struct {
+		length    int64
+		nullCount int64
+		offset    int64
+		nBuffers  int64
+		nChildren int64
+		buffers   unsafe.Pointer
+	}
+	layout := (*arrowArrayLayout)(unsafe.Pointer(&exported))
+	if layout.nBuffers != 3 {
+		t.Fatalf("C ArrowArray buffer count = %d, want 3", layout.nBuffers)
+	}
+	buffers := unsafe.Slice((*uintptr)(layout.buffers), int(layout.nBuffers))
+	buffers[2] = 1
+
+	imported, err := cdata.ImportCArrayWithType(&exported, arrow.BinaryTypes.String)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer imported.Release()
+
+	values := imported.Data().Buffers()[2]
+	if values == nil {
+		t.Fatal("values buffer is nil")
+	}
+	bytes := values.Bytes()
+	if got := len(bytes); got != 0 {
+		t.Fatalf("values buffer length = %d, want 0", got)
+	}
+	if got := imported.Len(); got != rowCount {
+		t.Fatalf("array length = %d, want %d", got, rowCount)
+	}
+	if got := imported.NullN(); got != rowCount {
+		t.Fatalf("array null count = %d, want %d", got, rowCount)
+	}
+
+	var growStack func(int) int
+	growStack = func(depth int) int {
+		var padding [1024]byte
+		padding[0] = byte(depth)
+		if depth == 0 {
+			return int(padding[0])
+		}
+		return int(padding[0]) + growStack(depth-1)
+	}
+	_ = growStack(128)
+	runtime.KeepAlive(bytes)
+}


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/52233
pr: https://github.com/milvus-io/milvus/pull/52651

Upgrade the Milvus Arrow Go fork to v17.0.2 so the C Data importer does not call unsafe.Slice for zero-length buffers.

This prevents sentinel addresses from being retained as Go pointers and avoids runtime crashes during stack growth.