### PR TITLE
enhance: [3.0] move nullable vector mapping into index layer

### DIFF
--- a/internal/core/src/common/GrowingOffsetMapping.cpp
+++ b/internal/core/src/common/GrowingOffsetMapping.cpp
@@ -190,55 +190,6 @@ GrowingOffsetMapping::GetTotalCount() const {
     return LoadCounts().total;
 }
 
-OffsetMapping::BitsetTransformStatus
-GrowingOffsetMapping::TransformBitset(const BitsetView& bitset,
-                                      TargetBitmap& result) const {
-    const auto counts = LoadCounts();
-    result.clear();
-    if (counts.total == 0) {
-        return BitsetTransformStatus::NoFilter;
-    }
-
-    // An empty BitsetView means "no filter", NOT "zero rows", and both all()
-    // and none() are vacuously true on it -- so it has to be classified before
-    // either of them is consulted. SealedOffsetMapping gets this from
-    // ShouldSkipBitsetTransform; #51953 open-coded the growing path and dropped
-    // the check, which turned an unfiltered growing search into AllFiltered,
-    // i.e. an empty result. Both call sites also guard on !bitset.empty(), but
-    // the classification belongs here so a third caller cannot reintroduce it.
-    if (bitset.empty()) {
-        return BitsetTransformStatus::NoFilter;
-    }
-    if (bitset.all()) {
-        return BitsetTransformStatus::AllFiltered;
-    }
-
-    // #51953: materialize the no-filter case instead of returning NoFilter.
-    // The bitmap is sized to valid_count from the SAME counts snapshot that
-    // total_count came from, so callers get one consistent view instead of
-    // pairing a NoFilter status with a separately (racily) read GetValidCount().
-    if (static_cast<int64_t>(bitset.size()) >= counts.total && bitset.none()) {
-        result.resize(counts.valid, false);
-        return BitsetTransformStatus::Transformed;
-    }
-
-    result.resize(counts.valid, true);
-    const auto bitset_size = static_cast<int64_t>(bitset.size());
-    for (int64_t physical_idx = 0; physical_idx < counts.valid;
-         ++physical_idx) {
-        const int64_t logical_offset = p2l_.Get(physical_idx);
-        // p2l is strictly increasing, so once a row sits past the end of the
-        // bitset every later row does too. Those stay set (= filtered out),
-        // which is exactly how rows appended after the bitset was built are
-        // excluded.
-        if (logical_offset >= bitset_size) {
-            break;
-        }
-        result[physical_idx] = bitset.test(logical_offset);
-    }
-    return BitsetTransformStatus::Transformed;
-}
-
 int64_t
 GrowingOffsetMapping::ValidCountBelow(int64_t logical_bound) const {
     const auto counts = LoadCounts();
@@ -306,31 +257,22 @@ GrowingOffsetMapping::GallopLowerBound(int64_t logical_target,
     return lo;
 }
 
-void
-GrowingOffsetMapping::TransformOffsets(std::vector<int64_t>& offsets) const {
+OffsetMappingIdView
+GrowingOffsetMapping::GetPhysicalToLogicalIds(int64_t physical_offset,
+                                              int64_t count) const {
     const auto counts = LoadCounts();
-    if (counts.total == 0) {
-        return;
+    if (counts.total == 0 || count <= 0) {
+        return {};
     }
-    for (auto& offset : offsets) {
-        if (offset >= 0) {
-            offset = GetLogicalOffsetInternal(offset, counts.valid);
-        }
-    }
-}
-
-void
-GrowingOffsetMapping::TransformLogicalOffsets(
-    std::vector<int64_t>& offsets) const {
-    const auto counts = LoadCounts();
-    if (counts.total == 0) {
-        return;
-    }
-    for (auto& offset : offsets) {
-        if (offset >= 0) {
-            offset = GetPhysicalOffsetInternal(offset, counts);
-        }
-    }
+    AssertInfo(physical_offset >= 0,
+               "physical offset {} is negative",
+               physical_offset);
+    AssertInfo(physical_offset < counts.valid,
+               "physical offset {} exceeds valid count {}",
+               physical_offset,
+               counts.valid);
+    const auto available = counts.valid - physical_offset;
+    return p2l_.View(physical_offset, std::min(count, available));
 }
 
 void

--- a/internal/core/src/common/GrowingOffsetMapping.h
+++ b/internal/core/src/common/GrowingOffsetMapping.h
@@ -16,12 +16,14 @@
 
 #pragma once
 
+#include <algorithm>
 #include <atomic>
 #include <cstdint>
 #include <limits>
 #include <mutex>
 #include <vector>
 
+#include "common/EasyAssert.h"
 #include "common/OffsetMapping.h"
 
 namespace milvus {
@@ -55,13 +57,14 @@ namespace milvus {
 // payload). The logical -> physical direction is a binary search over that
 // array -- it is strictly increasing -- so point lookups cost
 // O(log valid_count). Those sit on result-bounded paths (fetching the rows a
-// query returns); the loops a search actually scans with (TransformBitset,
-// ValidCountBelow, TransformOffsets) read physical -> logical directly and
-// never search. An all-valid mapping (no nulls yet) short-circuits point
-// lookups to the identity, and batch conversions gallop from a cursor on
-// ascending inputs, so a full-range pass (flush, chunk views) costs O(N)
-// rather than N binary searches. The old per-lookup shared_lock RMW -- a
-// contention point across reader threads -- is gone either way.
+// query returns). Search scan paths use ValidCountBelow for the visible
+// physical bound and GetPhysicalToLogicalIds for contiguous p2l windows; they
+// read physical -> logical directly and never search. An all-valid mapping
+// (no nulls yet) short-circuits point lookups to the identity, and batch
+// conversions gallop from a cursor on ascending inputs, so a full-range pass
+// (flush, chunk views) costs O(N) rather than N binary searches. The old
+// per-lookup shared_lock RMW -- a contention point across reader threads -- is
+// gone either way.
 class GrowingOffsetMapping final : public OffsetMapping {
  public:
     // Append `count` rows. start_logical / start_physical default to the
@@ -104,15 +107,9 @@ class GrowingOffsetMapping final : public OffsetMapping {
     int64_t
     GetTotalCount() const override;
 
-    BitsetTransformStatus
-    TransformBitset(const BitsetView& bitset,
-                    TargetBitmap& result) const override;
-
-    void
-    TransformOffsets(std::vector<int64_t>& offsets) const override;
-
-    void
-    TransformLogicalOffsets(std::vector<int64_t>& offsets) const override;
+    OffsetMappingIdView
+    GetPhysicalToLogicalIds(int64_t physical_offset,
+                            int64_t count) const override;
 
     void
     FilterValidLogicalOffsets(
@@ -191,6 +188,23 @@ class GrowingOffsetMapping final : public OffsetMapping {
             const int chunk = ChunkOf(index);
             return chunks_[chunk].load(
                 std::memory_order_relaxed)[PosOf(index, chunk)];
+        }
+
+        OffsetMappingIdView
+        View(int64_t index, int64_t count) const {
+            if (count <= 0) {
+                return {};
+            }
+            AssertInfo(
+                index >= 0, "offset mapping index {} is negative", index);
+            const int chunk = ChunkOf(index);
+            auto* data = chunks_[chunk].load(std::memory_order_relaxed);
+            AssertInfo(data != nullptr,
+                       "growing offset mapping chunk {} is not allocated",
+                       chunk);
+            const auto pos = PosOf(index, chunk);
+            const auto chunk_size = kFirstChunk << chunk;
+            return {data + pos, std::min<int64_t>(count, chunk_size - pos)};
         }
 
      private:

--- a/internal/core/src/common/GrowingOffsetMappingTest.cpp
+++ b/internal/core/src/common/GrowingOffsetMappingTest.cpp
@@ -382,74 +382,36 @@ TEST(GrowingOffsetMapping, AppendGrowsAcrossChunkBoundaries) {
     }
 }
 
-// ---------- TransformBitset ----------
+TEST(GrowingOffsetMapping,
+     PhysicalToLogicalIdViewStopsAtInternalChunkBoundary) {
+    constexpr int64_t kRows = 1700;
 
-// A bitset is built from the logical rows a query can see. Rows appended after
-// it must stay filtered out -- that is what stops a concurrent insert from
-// occupying top-k slots. p2l is increasing, so the scan stops at the first such
-// row; everything above it keeps the "filtered" default.
-TEST(GrowingOffsetMapping, TransformBitsetExcludesRowsAppendedAfterTheBitset) {
     GrowingOffsetMapping mapping;
-    auto v = ToBoolBytes(MakeValid({1, 0, 1, 1, 1, 1}));
-    mapping.Append(reinterpret_cast<const bool*>(v.data()), 6, 0, 0);
-    ASSERT_EQ(mapping.GetValidCount(), 5);
+    std::vector<int64_t> expected_p2l;
+    std::vector<uint8_t> valid(kRows);
+    for (int64_t i = 0; i < kRows; ++i) {
+        const bool is_valid = i % 7 != 3;
+        valid[i] = is_valid ? 1 : 0;
+        if (is_valid) {
+            expected_p2l.push_back(i);
+        }
+    }
+    ASSERT_GT(expected_p2l.size(), 1124);
+    mapping.Append(reinterpret_cast<const bool*>(valid.data()), kRows, 0, 0);
 
-    // The query saw 4 logical rows, none of them filtered.
-    BitsetType logical_bitset(4);
-    TargetBitmap physical;
-    const auto status =
-        mapping.TransformBitset(BitsetView(logical_bitset), physical);
+    auto tail = mapping.GetPhysicalToLogicalIds(1000, 100);
+    ASSERT_NE(tail.data, nullptr);
+    ASSERT_EQ(tail.count, 24);
+    for (int64_t i = 0; i < tail.count; ++i) {
+        EXPECT_EQ(tail.data[i], expected_p2l[1000 + i]) << "i=" << i;
+    }
 
-    ASSERT_EQ(status, OffsetMapping::BitsetTransformStatus::Transformed);
-    ASSERT_EQ(physical.size(), 5);
-    // logical 0,2,3 -> physical 0,1,2 : visible.
-    EXPECT_FALSE(physical[0]);
-    EXPECT_FALSE(physical[1]);
-    EXPECT_FALSE(physical[2]);
-    // logical 4,5 -> physical 3,4 : past the query's view, still filtered.
-    EXPECT_TRUE(physical[3]);
-    EXPECT_TRUE(physical[4]);
-}
-
-TEST(GrowingOffsetMapping, TransformBitsetMaterializesTheNoFilterCase) {
-    GrowingOffsetMapping mapping;
-    auto v = ToBoolBytes(MakeValid({1, 0, 1, 1}));
-    mapping.Append(reinterpret_cast<const bool*>(v.data()), 4, 0, 0);
-
-    BitsetType logical_bitset(4);  // covers every row, nothing filtered
-    TargetBitmap physical;
-    const auto status =
-        mapping.TransformBitset(BitsetView(logical_bitset), physical);
-
-    ASSERT_EQ(status, OffsetMapping::BitsetTransformStatus::Transformed);
-    ASSERT_EQ(physical.size(), 3);
-    EXPECT_TRUE(physical.none());
-}
-
-// An empty BitsetView is how "no filter at all" reaches the search kernels
-// (VectorSearchNode's all-rows-visible fast path). Both all() and none() are
-// vacuously true on it, so classifying it last -- as #51953 did after
-// open-coding this function -- reports AllFiltered and turns an unfiltered
-// growing search into an empty result. SealedOffsetMapping has always answered
-// NoFilter here via ShouldSkipBitsetTransform; the two must agree.
-TEST(GrowingOffsetMapping, TransformBitsetTreatsEmptyBitsetAsNoFilter) {
-    GrowingOffsetMapping mapping;
-    auto v = ToBoolBytes(MakeValid({1, 0, 1}));
-    mapping.Append(reinterpret_cast<const bool*>(v.data()), 3, 0, 0);
-    ASSERT_TRUE(mapping.IsEnabled());
-
-    TargetBitmap physical;
-    EXPECT_EQ(mapping.TransformBitset(BitsetView{}, physical),
-              OffsetMapping::BitsetTransformStatus::NoFilter);
-    EXPECT_TRUE(physical.empty());
-}
-
-TEST(GrowingOffsetMapping, TransformBitsetOnDisabledMappingIsNoFilter) {
-    GrowingOffsetMapping mapping;
-    BitsetType logical_bitset(4);
-    TargetBitmap physical;
-    EXPECT_EQ(mapping.TransformBitset(BitsetView(logical_bitset), physical),
-              OffsetMapping::BitsetTransformStatus::NoFilter);
+    auto next = mapping.GetPhysicalToLogicalIds(1024, 100);
+    ASSERT_NE(next.data, nullptr);
+    ASSERT_EQ(next.count, 100);
+    for (int64_t i = 0; i < next.count; ++i) {
+        EXPECT_EQ(next.data[i], expected_p2l[1024 + i]) << "i=" << i;
+    }
 }
 
 // ---------- concurrency ----------

--- a/internal/core/src/common/OffsetMapping.cpp
+++ b/internal/core/src/common/OffsetMapping.cpp
@@ -17,155 +17,12 @@
 #include "common/OffsetMapping.h"
 
 #include <algorithm>
-#include <cerrno>
-#include <cstring>
-#include <filesystem>
-#include <limits>
-
-#include <fcntl.h>
-#include <sys/mman.h>
-#include <unistd.h>
 
 namespace milvus {
-
-namespace {
-
-class FileDescriptorGuard {
- public:
-    explicit FileDescriptorGuard(int fd) : fd_(fd) {
-    }
-
-    ~FileDescriptorGuard() {
-        if (fd_ >= 0) {
-            close(fd_);
-        }
-    }
-
-    int
-    Get() const {
-        return fd_;
-    }
-
- private:
-    int fd_;
-};
-
-}  // namespace
-
-OffsetMappingArray::~OffsetMappingArray() {
-    Clear();
-}
-
-void
-OffsetMappingArray::Resize(size_t size,
-                           int32_t value,
-                           bool enable_mmap,
-                           std::string filepath) {
-    Clear();
-    if (size == 0) {
-        return;
-    }
-
-    if (enable_mmap) {
-        AssertInfo(!filepath.empty(), "offset mapping mmap filepath is empty");
-        AssertInfo(size <= std::numeric_limits<size_t>::max() / sizeof(int32_t),
-                   "offset mapping mmap buffer is too large");
-
-        const auto mmap_size = sizeof(int32_t) * size;
-        std::filesystem::create_directories(
-            std::filesystem::path(filepath).parent_path());
-
-        const int fd = open(filepath.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0600);
-        if (fd < 0) {
-            ThrowInfo(MmapError,
-                      "failed to create offset mapping mmap file {}: {}",
-                      filepath,
-                      std::strerror(errno));
-        }
-        FileDescriptorGuard fd_guard(fd);
-
-        if (ftruncate(fd_guard.Get(), mmap_size) != 0) {
-            const auto err = errno;
-            unlink(filepath.c_str());
-            ThrowInfo(MmapError,
-                      "failed to resize offset mapping mmap file {} to {} "
-                      "bytes: {}",
-                      filepath,
-                      mmap_size,
-                      std::strerror(err));
-        }
-
-        auto* data = mmap(nullptr,
-                          mmap_size,
-                          PROT_READ | PROT_WRITE,
-                          MAP_SHARED,
-                          fd_guard.Get(),
-                          0);
-        if (data == MAP_FAILED) {
-            const auto err = errno;
-            unlink(filepath.c_str());
-            ThrowInfo(MmapError,
-                      "failed to mmap offset mapping file {}: {}",
-                      filepath,
-                      std::strerror(err));
-        }
-
-        mmap_data_ = static_cast<int32_t*>(data);
-        mmap_size_ = mmap_size;
-        mmap_filepath_ = std::move(filepath);
-        size_ = size;
-        std::fill_n(mmap_data_, size_, value);
-        return;
-    }
-
-    vec_.assign(size, value);
-    size_ = size;
-}
-
-void
-OffsetMappingArray::Clear() {
-    if (mmap_data_ != nullptr) {
-        munmap(mmap_data_, mmap_size_);
-    }
-    if (!mmap_filepath_.empty()) {
-        unlink(mmap_filepath_.c_str());
-    }
-    size_ = 0;
-    vec_.clear();
-    mmap_data_ = nullptr;
-    mmap_size_ = 0;
-    mmap_filepath_.clear();
-}
 
 bool
 OffsetMapping::IsValid(int64_t logical_offset) const {
     return GetPhysicalOffset(logical_offset) >= 0;
-}
-
-bool
-OffsetMapping::ShouldSkipBitsetTransform(const BitsetView& bitset,
-                                         int64_t total_count,
-                                         TargetBitmap& result,
-                                         BitsetTransformStatus& status) {
-    result.clear();
-    if (bitset.empty()) {
-        status = BitsetTransformStatus::NoFilter;
-        return true;
-    }
-    if (bitset.all()) {
-        status = BitsetTransformStatus::AllFiltered;
-        return true;
-    }
-    if (static_cast<int64_t>(bitset.size()) >= total_count && bitset.none()) {
-        status = BitsetTransformStatus::NoFilter;
-        return true;
-    }
-    return false;
-}
-
-bool
-OffsetMapping::IsMmap() const {
-    return false;
 }
 
 int64_t
@@ -199,23 +56,12 @@ NoOpOffsetMapping::GetTotalCount() const {
     return 0;
 }
 
-OffsetMapping::BitsetTransformStatus
-NoOpOffsetMapping::TransformBitset(const BitsetView& bitset,
-                                   TargetBitmap& result) const {
-    (void)bitset;
-    result.clear();
-    return BitsetTransformStatus::NoFilter;
-}
-
-void
-NoOpOffsetMapping::TransformOffsets(std::vector<int64_t>& offsets) const {
-    (void)offsets;
-}
-
-void
-NoOpOffsetMapping::TransformLogicalOffsets(
-    std::vector<int64_t>& offsets) const {
-    (void)offsets;
+OffsetMappingIdView
+NoOpOffsetMapping::GetPhysicalToLogicalIds(int64_t physical_offset,
+                                           int64_t count) const {
+    (void)physical_offset;
+    (void)count;
+    return {};
 }
 
 void

--- a/internal/core/src/common/OffsetMapping.h
+++ b/internal/core/src/common/OffsetMapping.h
@@ -18,20 +18,18 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <string>
 #include <vector>
-
-#include "common/BitsetView.h"
-#include "common/Types.h"
 
 namespace milvus {
 
-struct OffsetMappingBuildOptions {
-    // i2o: index/internal id -> original/logical offset.
-    bool enable_mmap_i2o_map{false};
-    // o2i: original/logical offset -> index/internal id.
-    bool enable_mmap_o2i_map{false};
-    std::string mmap_dir_path;
+struct OffsetMappingIdView {
+    const int32_t* data = nullptr;
+    int64_t count = 0;
+
+    bool
+    empty() const {
+        return data == nullptr || count == 0;
+    }
 };
 
 // Bidirectional offset mapping for nullable vector storage.
@@ -54,12 +52,6 @@ struct OffsetMappingBuildOptions {
 // error.
 class OffsetMapping {
  public:
-    enum class BitsetTransformStatus {
-        NoFilter,
-        AllFiltered,
-        Transformed,
-    };
-
     OffsetMapping() = default;
     virtual ~OffsetMapping() = default;
 
@@ -96,23 +88,12 @@ class OffsetMapping {
     virtual bool
     IsEnabled() const = 0;
 
-    // Whether either direction is backed by mmap storage. Non-sealed
-    // implementations use the default false capability.
-    virtual bool
-    IsMmap() const;
-
     // Get total logical count (including nulls).
     virtual int64_t
     GetTotalCount() const = 0;
 
-    virtual BitsetTransformStatus
-    TransformBitset(const BitsetView& bitset, TargetBitmap& result) const = 0;
-
-    virtual void
-    TransformOffsets(std::vector<int64_t>& offsets) const = 0;
-
-    virtual void
-    TransformLogicalOffsets(std::vector<int64_t>& offsets) const = 0;
+    virtual OffsetMappingIdView
+    GetPhysicalToLogicalIds(int64_t physical_offset, int64_t count) const = 0;
 
     virtual void
     FilterValidLogicalOffsets(const int64_t* logical_offsets,
@@ -125,60 +106,6 @@ class OffsetMapping {
     // two answers disagree.
     virtual bool
     IsValid(int64_t logical_offset) const;
-
- protected:
-    // Shared TransformBitset fast paths: an empty / all-set / all-clear input
-    // bitset needs no per-row conversion. Returns true when `status` has been
-    // filled in and the caller should return it as-is.
-    static bool
-    ShouldSkipBitsetTransform(const BitsetView& bitset,
-                              int64_t total_count,
-                              TargetBitmap& result,
-                              BitsetTransformStatus& status);
-};
-
-// Storage used by sealed mappings. Each direction can independently use a
-// heap vector or a file-backed mmap region.
-class OffsetMappingArray {
- public:
-    OffsetMappingArray() = default;
-    ~OffsetMappingArray();
-    OffsetMappingArray(const OffsetMappingArray&) = delete;
-    OffsetMappingArray&
-    operator=(const OffsetMappingArray&) = delete;
-
-    void
-    Resize(size_t size, int32_t value, bool enable_mmap, std::string filepath);
-
-    void
-    Clear();
-
-    size_t
-    size() const {
-        return size_;
-    }
-
-    bool
-    IsMmap() const {
-        return mmap_data_ != nullptr;
-    }
-
-    int32_t&
-    operator[](size_t index) {
-        return IsMmap() ? mmap_data_[index] : vec_[index];
-    }
-
-    const int32_t&
-    operator[](size_t index) const {
-        return IsMmap() ? mmap_data_[index] : vec_[index];
-    }
-
- private:
-    size_t size_{0};
-    std::vector<int32_t> vec_;
-    int32_t* mmap_data_{nullptr};
-    size_t mmap_size_{0};
-    std::string mmap_filepath_;
 };
 
 // The "no mapping" implementation, for fields that are not nullable.
@@ -212,15 +139,9 @@ class NoOpOffsetMapping final : public OffsetMapping {
     int64_t
     GetTotalCount() const override;
 
-    BitsetTransformStatus
-    TransformBitset(const BitsetView& bitset,
-                    TargetBitmap& result) const override;
-
-    void
-    TransformOffsets(std::vector<int64_t>& offsets) const override;
-
-    void
-    TransformLogicalOffsets(std::vector<int64_t>& offsets) const override;
+    OffsetMappingIdView
+    GetPhysicalToLogicalIds(int64_t physical_offset,
+                            int64_t count) const override;
 
     void
     FilterValidLogicalOffsets(

--- a/internal/core/src/common/OffsetMappingTest.cpp
+++ b/internal/core/src/common/OffsetMappingTest.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
@@ -24,7 +25,6 @@
 #include "common/OffsetMapping.h"
 #include "common/SealedOffsetMapping.h"
 #include "index/VectorIndexValidDataUtils.h"
-#include "storage/MmapChunkManager.h"
 
 namespace milvus {
 
@@ -54,23 +54,6 @@ MakeMmapRoot(const std::string& test_name) {
            ("milvus_offset_mapping_" + test_name + "_" +
             std::to_string(
                 std::chrono::steady_clock::now().time_since_epoch().count()));
-}
-
-storage::MmapChunkManagerPtr
-MakeMmapChunkManager(const std::filesystem::path& mmap_root) {
-    return std::make_shared<storage::MmapChunkManager>(
-        mmap_root.string(), 64 * 1024 * 1024, 4 * 1024);
-}
-
-OffsetMappingBuildOptions
-MmapOptions(const std::filesystem::path& mmap_dir,
-            bool enable_i2o = true,
-            bool enable_o2i = true) {
-    OffsetMappingBuildOptions options;
-    options.enable_mmap_i2o_map = enable_i2o;
-    options.enable_mmap_o2i_map = enable_o2i;
-    options.mmap_dir_path = mmap_dir.string();
-    return options;
 }
 
 std::vector<std::filesystem::path>
@@ -125,42 +108,19 @@ ExpectMappingValues(const SealedOffsetMapping& mapping,
         EXPECT_EQ(mapping.GetLogicalOffset(i), expected_p2l[i])
             << "physical offset: " << i;
     }
+    if (!expected_p2l.empty()) {
+        auto ids = mapping.GetPhysicalToLogicalIds(0, expected_p2l.size());
+        ASSERT_FALSE(ids.empty());
+        ASSERT_EQ(ids.count, expected_p2l.size());
+        for (size_t i = 0; i < expected_p2l.size(); ++i) {
+            EXPECT_EQ(ids.data[i], expected_p2l[i])
+                << "physical offset in p2l view: " << i;
+        }
+    }
 }
 
 void
-ExpectStorageMode(const SealedOffsetMapping& mapping,
-                  bool i2o_mmap,
-                  bool o2i_mmap,
-                  bool i2o_map,
-                  bool o2i_map) {
-    EXPECT_EQ(mapping.IsI2OMmap(), i2o_mmap);
-    EXPECT_EQ(mapping.IsO2IMmap(), o2i_mmap);
-    EXPECT_EQ(mapping.IsMmap(), i2o_mmap || o2i_mmap);
-    EXPECT_EQ(mapping.IsI2OUsingMap(), i2o_map);
-    EXPECT_EQ(mapping.IsO2IUsingMap(), o2i_map);
-    EXPECT_EQ(mapping.IsUsingMap(), i2o_map || o2i_map);
-}
-
-void
-ExpectTransformOperations(const SealedOffsetMapping& mapping) {
-    TargetBitmap bitset(5, false);
-    bitset.set(2);
-    TargetBitmap transformed;
-    EXPECT_EQ(mapping.TransformBitset(bitset, transformed),
-              OffsetMapping::BitsetTransformStatus::Transformed);
-    ASSERT_EQ(transformed.size(), 3);
-    EXPECT_FALSE(transformed[0]);
-    EXPECT_TRUE(transformed[1]);
-    EXPECT_FALSE(transformed[2]);
-
-    std::vector<int64_t> physical_offsets{0, 1, 2, -1};
-    mapping.TransformOffsets(physical_offsets);
-    EXPECT_EQ(physical_offsets, (std::vector<int64_t>{0, 2, 3, -1}));
-
-    std::vector<int64_t> logical_offsets{0, 1, 3, 4};
-    mapping.TransformLogicalOffsets(logical_offsets);
-    EXPECT_EQ(logical_offsets, (std::vector<int64_t>{0, -1, 2, -1}));
-
+ExpectFilterValidLogicalOffsets(const SealedOffsetMapping& mapping) {
     const int64_t input_offsets[] = {0, 1, 2, 4};
     bool input_valid_data[4] = {};
     std::vector<int64_t> filtered_offsets;
@@ -252,6 +212,19 @@ class TestVectorIndex : public index::VectorIndex {
         (void)dataset;
         return nullptr;
     }
+
+    knowhere::IdMap&
+    GetIdMap() override {
+        return id_map_;
+    }
+
+    const knowhere::IdMap&
+    GetIdMap() const override {
+        return id_map_;
+    }
+
+ private:
+    knowhere::IdMap id_map_;
 };
 }  // namespace
 
@@ -274,58 +247,12 @@ TEST(OffsetMapping, BuildBasicVecMode) {
     const std::vector<int64_t> expected_l2p{0, -1, 1, 2, -1};
     const std::vector<int64_t> expected_p2l{0, 2, 3};
 
-    {
-        SealedOffsetMapping mapping;
-        mapping.Build(reinterpret_cast<const bool*>(valid.data()), 5);
-        ExpectMappingValues(mapping, expected_l2p, expected_p2l);
-        ExpectStorageMode(mapping, false, false, false, false);
-    }
-
-    {
-        const auto mmap_root = MakeMmapRoot("basic_both");
-        auto mmap_dir = mmap_root;
-        SealedOffsetMapping mapping;
-        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
-                      5,
-                      MmapOptions(mmap_dir));
-        ExpectMappingValues(mapping, expected_l2p, expected_p2l);
-        ExpectStorageMode(mapping, true, true, false, false);
-        ExpectMmapBlockFiles(mmap_root,
-                             {3 * sizeof(int32_t), 5 * sizeof(int32_t)});
-    }
+    SealedOffsetMapping mapping;
+    mapping.Build(reinterpret_cast<const bool*>(valid.data()), 5);
+    ExpectMappingValues(mapping, expected_l2p, expected_p2l);
 }
 
-TEST(OffsetMapping, BuildBasicVecModeMapsDirectionsIndependently) {
-    auto valid = ToBoolBytes(MakeValid({1, 0, 1, 1, 0}));
-    const std::vector<int64_t> expected_l2p{0, -1, 1, 2, -1};
-    const std::vector<int64_t> expected_p2l{0, 2, 3};
-
-    {
-        const auto mmap_root = MakeMmapRoot("basic_i2o");
-        auto mmap_dir = mmap_root;
-        SealedOffsetMapping mapping;
-        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
-                      5,
-                      MmapOptions(mmap_dir, true, false));
-        ExpectMappingValues(mapping, expected_l2p, expected_p2l);
-        ExpectStorageMode(mapping, true, false, false, false);
-        ExpectMmapBlockFiles(mmap_root, {3 * sizeof(int32_t)});
-    }
-
-    {
-        const auto mmap_root = MakeMmapRoot("basic_o2i");
-        auto mmap_dir = mmap_root;
-        SealedOffsetMapping mapping;
-        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
-                      5,
-                      MmapOptions(mmap_dir, false, true));
-        ExpectMappingValues(mapping, expected_l2p, expected_p2l);
-        ExpectStorageMode(mapping, false, true, false, false);
-        ExpectMmapBlockFiles(mmap_root, {5 * sizeof(int32_t)});
-    }
-}
-
-TEST(OffsetMapping, BuildMapModeOnSparse) {
+TEST(OffsetMapping, BuildSparseUsesContiguousStorage) {
     std::vector<uint8_t> valid(100, 0);
     valid[5] = 1;
     valid[50] = 1;
@@ -334,74 +261,18 @@ TEST(OffsetMapping, BuildMapModeOnSparse) {
     expected_l2p[50] = 1;
     const std::vector<int64_t> expected_p2l{5, 50};
 
-    {
-        SealedOffsetMapping mapping;
-        mapping.Build(reinterpret_cast<const bool*>(valid.data()), 100);
-        ExpectMappingValues(mapping, expected_l2p, expected_p2l);
-        ExpectStorageMode(mapping, false, false, true, true);
-    }
-
-    {
-        const auto mmap_root = MakeMmapRoot("sparse_both");
-        auto mmap_dir = mmap_root;
-        SealedOffsetMapping mapping;
-        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
-                      100,
-                      MmapOptions(mmap_dir));
-        ExpectMappingValues(mapping, expected_l2p, expected_p2l);
-        ExpectStorageMode(mapping, true, true, false, false);
-        ExpectMmapBlockFiles(mmap_root,
-                             {2 * sizeof(int32_t), 100 * sizeof(int32_t)});
-    }
-
-    {
-        const auto mmap_root = MakeMmapRoot("sparse_i2o");
-        auto mmap_dir = mmap_root;
-        SealedOffsetMapping mapping;
-        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
-                      100,
-                      MmapOptions(mmap_dir, true, false));
-        ExpectMappingValues(mapping, expected_l2p, expected_p2l);
-        ExpectStorageMode(mapping, true, false, false, true);
-        ExpectMmapBlockFiles(mmap_root, {2 * sizeof(int32_t)});
-    }
-
-    {
-        const auto mmap_root = MakeMmapRoot("sparse_o2i");
-        auto mmap_dir = mmap_root;
-        SealedOffsetMapping mapping;
-        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
-                      100,
-                      MmapOptions(mmap_dir, false, true));
-        ExpectMappingValues(mapping, expected_l2p, expected_p2l);
-        ExpectStorageMode(mapping, false, true, true, false);
-        ExpectMmapBlockFiles(mmap_root, {100 * sizeof(int32_t)});
-    }
+    SealedOffsetMapping mapping;
+    mapping.Build(reinterpret_cast<const bool*>(valid.data()), 100);
+    ExpectMappingValues(mapping, expected_l2p, expected_p2l);
 }
 
 TEST(OffsetMapping, BuildAllValid) {
     std::vector<uint8_t> valid(4, 1);
     const std::vector<int64_t> expected{0, 1, 2, 3};
 
-    {
-        SealedOffsetMapping mapping;
-        mapping.Build(reinterpret_cast<const bool*>(valid.data()), 4);
-        ExpectMappingValues(mapping, expected, expected);
-        ExpectStorageMode(mapping, false, false, false, false);
-    }
-
-    {
-        const auto mmap_root = MakeMmapRoot("all_valid");
-        auto mmap_dir = mmap_root;
-        SealedOffsetMapping mapping;
-        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
-                      4,
-                      MmapOptions(mmap_dir));
-        ExpectMappingValues(mapping, expected, expected);
-        ExpectStorageMode(mapping, true, true, false, false);
-        ExpectMmapBlockFiles(mmap_root,
-                             {4 * sizeof(int32_t), 4 * sizeof(int32_t)});
-    }
+    SealedOffsetMapping mapping;
+    mapping.Build(reinterpret_cast<const bool*>(valid.data()), 4);
+    ExpectMappingValues(mapping, expected, expected);
 }
 
 TEST(OffsetMapping, BuildAllNull) {
@@ -409,46 +280,18 @@ TEST(OffsetMapping, BuildAllNull) {
     const std::vector<int64_t> expected_l2p(4, -1);
     const std::vector<int64_t> expected_p2l;
 
-    {
-        SealedOffsetMapping mapping;
-        mapping.Build(reinterpret_cast<const bool*>(valid.data()), 4);
-        ExpectMappingValues(mapping, expected_l2p, expected_p2l);
-        ExpectStorageMode(mapping, false, false, true, true);
-        EXPECT_EQ(mapping.GetLogicalOffset(0), -1);
-    }
-
-    {
-        const auto mmap_root = MakeMmapRoot("all_null");
-        auto mmap_dir = mmap_root;
-        SealedOffsetMapping mapping;
-        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
-                      4,
-                      MmapOptions(mmap_dir));
-        ExpectMappingValues(mapping, expected_l2p, expected_p2l);
-        ExpectStorageMode(mapping, false, true, false, false);
-        EXPECT_EQ(mapping.GetLogicalOffset(0), -1);
-        ExpectMmapBlockFiles(mmap_root, {4 * sizeof(int32_t)});
-    }
+    SealedOffsetMapping mapping;
+    mapping.Build(reinterpret_cast<const bool*>(valid.data()), 4);
+    ExpectMappingValues(mapping, expected_l2p, expected_p2l);
+    EXPECT_EQ(mapping.GetLogicalOffset(0), -1);
 }
 
 TEST(OffsetMapping, TransformOperationsMatchBuildMode) {
     auto valid = ToBoolBytes(MakeValid({1, 0, 1, 1, 0}));
 
-    {
-        SealedOffsetMapping mapping;
-        mapping.Build(reinterpret_cast<const bool*>(valid.data()), 5);
-        ExpectTransformOperations(mapping);
-    }
-
-    {
-        const auto mmap_root = MakeMmapRoot("transform");
-        auto mmap_dir = mmap_root;
-        SealedOffsetMapping mapping;
-        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
-                      5,
-                      MmapOptions(mmap_dir));
-        ExpectTransformOperations(mapping);
-    }
+    SealedOffsetMapping mapping;
+    mapping.Build(reinterpret_cast<const bool*>(valid.data()), 5);
+    ExpectFilterValidLogicalOffsets(mapping);
 }
 
 TEST(OffsetMapping, BuildNoopOnNullOrZero) {
@@ -461,208 +304,145 @@ TEST(OffsetMapping, BuildNoopOnNullOrZero) {
         mapping.Build(reinterpret_cast<const bool*>(valid.data()), 0);
         EXPECT_FALSE(mapping.IsEnabled());
     }
-
-    {
-        const auto mmap_root = MakeMmapRoot("noop");
-        auto mmap_dir = mmap_root;
-        SealedOffsetMapping mapping;
-        auto valid = ToBoolBytes(MakeValid({1, 0, 1, 1, 0}));
-
-        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
-                      5,
-                      MmapOptions(mmap_dir));
-        EXPECT_TRUE(mapping.IsEnabled());
-        EXPECT_TRUE(mapping.IsMmap());
-
-        mapping.Build(nullptr, 100, MmapOptions(mmap_dir));
-        EXPECT_FALSE(mapping.IsEnabled());
-        EXPECT_FALSE(mapping.IsMmap());
-        EXPECT_FALSE(mapping.IsUsingMap());
-        EXPECT_EQ(mapping.GetPhysicalOffset(3), 3);
-
-        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
-                      0,
-                      MmapOptions(mmap_dir));
-        EXPECT_FALSE(mapping.IsEnabled());
-        EXPECT_FALSE(mapping.IsMmap());
-        EXPECT_FALSE(mapping.IsUsingMap());
-    }
 }
 
 TEST(OffsetMapping, BuildTwiceResetsState) {
     auto v1 = ToBoolBytes(MakeValid({1, 1, 0, 0, 1}));
     auto v2 = ToBoolBytes(MakeValid({1, 0, 0}));
 
-    {
-        SealedOffsetMapping mapping;
-        mapping.Build(reinterpret_cast<const bool*>(v1.data()), 5);
-        EXPECT_EQ(mapping.GetValidCount(), 3);
-        EXPECT_EQ(mapping.GetTotalCount(), 5);
+    SealedOffsetMapping mapping;
+    mapping.Build(reinterpret_cast<const bool*>(v1.data()), 5);
+    EXPECT_EQ(mapping.GetValidCount(), 3);
+    EXPECT_EQ(mapping.GetTotalCount(), 5);
 
-        mapping.Build(reinterpret_cast<const bool*>(v2.data()), 3);
-        EXPECT_EQ(mapping.GetValidCount(), 1);
-        EXPECT_EQ(mapping.GetTotalCount(), 3);
-        EXPECT_EQ(mapping.GetPhysicalOffset(0), 0);
-        EXPECT_EQ(mapping.GetPhysicalOffset(1), -1);
-        EXPECT_EQ(mapping.GetPhysicalOffset(2), -1);
-        EXPECT_FALSE(mapping.IsMmap());
-    }
-
-    {
-        const auto mmap_root = MakeMmapRoot("build_twice");
-        auto mmap_dir = mmap_root;
-        SealedOffsetMapping mapping;
-        mapping.Build(
-            reinterpret_cast<const bool*>(v1.data()), 5, MmapOptions(mmap_dir));
-        EXPECT_TRUE(mapping.IsMmap());
-
-        mapping.Build(reinterpret_cast<const bool*>(v2.data()), 3);
-        EXPECT_EQ(mapping.GetValidCount(), 1);
-        EXPECT_EQ(mapping.GetTotalCount(), 3);
-        EXPECT_EQ(mapping.GetPhysicalOffset(0), 0);
-        EXPECT_EQ(mapping.GetPhysicalOffset(1), -1);
-        EXPECT_EQ(mapping.GetPhysicalOffset(2), -1);
-        EXPECT_FALSE(mapping.IsMmap());
-    }
+    mapping.Build(reinterpret_cast<const bool*>(v2.data()), 3);
+    EXPECT_EQ(mapping.GetValidCount(), 1);
+    EXPECT_EQ(mapping.GetTotalCount(), 3);
+    EXPECT_EQ(mapping.GetPhysicalOffset(0), 0);
+    EXPECT_EQ(mapping.GetPhysicalOffset(1), -1);
+    EXPECT_EQ(mapping.GetPhysicalOffset(2), -1);
 }
 
-TEST(OffsetMapping, MmapOptionsUseOnlyIdMappingConfigKeys) {
+TEST(IdMapValidDataHelpers, ConfigureMmapUsesOnlyIdMappingConfigKeys) {
+    const std::vector<uint8_t> bitmap{0b00001101};
     Config config;
     config[index::ENABLE_MMAP] = true;
 
-    auto options = index::GetOffsetMappingMmapOptions(config);
-    EXPECT_FALSE(options.enable_mmap_i2o_map);
-    EXPECT_FALSE(options.enable_mmap_o2i_map);
-
-    config[index::ENABLE_MMAP_I2O_MAP] = true;
-    config[index::ENABLE_MMAP_O2I_MAP] = false;
-
-    options = index::GetOffsetMappingMmapOptions(config);
-    EXPECT_TRUE(options.enable_mmap_i2o_map);
-    EXPECT_FALSE(options.enable_mmap_o2i_map);
-
-    config[index::ENABLE_MMAP_I2O_MAP] = "false";
-    config[index::ENABLE_MMAP_O2I_MAP] = "true";
-
-    options = index::GetOffsetMappingMmapOptions(config);
-    EXPECT_FALSE(options.enable_mmap_i2o_map);
-    EXPECT_TRUE(options.enable_mmap_o2i_map);
-}
-
-TEST(OffsetMapping, OffsetMappingMmapDirUsesDedicatedIndexSubdirectory) {
-    const auto local_index_prefix = (std::filesystem::temp_directory_path() /
-                                     "milvus_local_chunk/index_files/1_2_3_4")
-                                        .string();
-    const auto mmap_dir = index::GetOffsetMappingMmapDir(local_index_prefix);
-
-    EXPECT_EQ(mmap_dir,
-              (std::filesystem::path(local_index_prefix) /
-               index::OFFSET_MAPPING_MMAP_DIR)
-                  .string());
-    EXPECT_EQ(std::filesystem::path(mmap_dir).parent_path(),
-              std::filesystem::path(local_index_prefix));
-}
-
-TEST(OffsetMapping, FileBackedMmapDoesNotResetMmapChunkManagerAccounting) {
-    const auto manager_root = MakeMmapRoot("accounting_manager");
-    auto mmap_chunk_manager = MakeMmapChunkManager(manager_root);
-    auto descriptor = mmap_chunk_manager->Register();
-    mmap_chunk_manager->Allocate(descriptor, sizeof(int32_t));
-    const auto allocated_size = mmap_chunk_manager->GetDiskAllocSize();
-    ASSERT_GT(allocated_size, 0);
-
-    auto valid = ToBoolBytes(MakeValid({1, 0, 1, 1, 0}));
-    const auto mmap_root = MakeMmapRoot("accounting_mapping");
-    auto mmap_dir = mmap_root;
     {
-        SealedOffsetMapping mapping;
-        mapping.Build(reinterpret_cast<const bool*>(valid.data()),
-                      5,
-                      MmapOptions(mmap_dir));
-        EXPECT_TRUE(mapping.IsMmap());
-        ExpectMmapBlockFiles(mmap_root,
-                             {3 * sizeof(int32_t), 5 * sizeof(int32_t)});
-        EXPECT_EQ(mmap_chunk_manager->GetDiskAllocSize(), allocated_size);
+        const auto mmap_root = MakeMmapRoot("mmap_disabled");
+        knowhere::IdMap id_map;
+        id_map.SetType(knowhere::IdMap::Type::SEALED);
+        index::ConfigureIdMapMmap(id_map, config, mmap_root.string());
+        id_map.AddFromData(
+            knowhere::IdMapData::FromValidBitmap(bitmap.data(), 5));
+        id_map.FinalizeVectorIds();
+        EXPECT_TRUE(MmapBlockFiles(mmap_root / index::ID_MAP_MMAP_DIR).empty());
     }
 
-    EXPECT_EQ(mmap_chunk_manager->GetDiskAllocSize(), allocated_size);
+    {
+        const auto mmap_root = MakeMmapRoot("mmap_i2o");
+        knowhere::IdMap id_map;
+        Config i2o_config = config;
+        i2o_config[index::ENABLE_MMAP_I2O_MAP] = true;
+        i2o_config[index::ENABLE_MMAP_O2I_MAP] = false;
+        index::ConfigureIdMapMmap(id_map, i2o_config, mmap_root.string());
+        id_map.AddFromData(
+            knowhere::IdMapData::FromValidBitmap(bitmap.data(), 5));
+        id_map.FinalizeVectorIds();
+        ExpectMmapBlockFiles(mmap_root / index::ID_MAP_MMAP_DIR,
+                             {3 * sizeof(int32_t)});
+    }
+
+    {
+        const auto mmap_root = MakeMmapRoot("mmap_o2i");
+        knowhere::IdMap id_map;
+        Config o2i_config = config;
+        o2i_config[index::ENABLE_MMAP_I2O_MAP] = "false";
+        o2i_config[index::ENABLE_MMAP_O2I_MAP] = "true";
+        index::ConfigureIdMapMmap(id_map, o2i_config, mmap_root.string());
+        id_map.AddFromData(
+            knowhere::IdMapData::FromValidBitmap(bitmap.data(), 5));
+        id_map.FinalizeVectorIds();
+        ExpectMmapBlockFiles(mmap_root / index::ID_MAP_MMAP_DIR,
+                             {5 * sizeof(int32_t)});
+    }
 }
 
-TEST(OffsetMapping, NeedOffsetMappingMmapMatchesDirectionSizes) {
-    OffsetMappingBuildOptions options;
-    EXPECT_FALSE(index::NeedOffsetMappingMmap(options, 10, 5));
-
-    options.enable_mmap_i2o_map = true;
-    EXPECT_TRUE(index::NeedOffsetMappingMmap(options, 10, 5));
-    EXPECT_FALSE(index::NeedOffsetMappingMmap(options, 10, 0));
-
-    options.enable_mmap_i2o_map = false;
-    options.enable_mmap_o2i_map = true;
-    EXPECT_TRUE(index::NeedOffsetMappingMmap(options, 10, 0));
-    EXPECT_FALSE(index::NeedOffsetMappingMmap(options, 0, 0));
-}
-
-TEST(OffsetMapping, ValidDataHelpersPreserveMappingValuesWithMmapOptions) {
+TEST(IdMapValidDataHelpers, ValidDataHelpersPreserveSnapshotValues) {
     const std::vector<uint8_t> bitmap{0b00001101};
-    const std::vector<int64_t> expected_l2p{0, -1, 1, 2, -1};
-    const std::vector<int64_t> expected_p2l{0, 2, 3};
+    const std::vector<int32_t> expected_in_to_out{0, 2, 3};
 
     {
         TestVectorIndex vector_index;
-        index::BuildValidDataFromBitmap(&vector_index, 5, bitmap.data());
-        const auto* mapping = dynamic_cast<const SealedOffsetMapping*>(
-            &vector_index.GetOffsetMapping());
-        ASSERT_NE(mapping, nullptr);
-        ExpectMappingValues(*mapping, expected_l2p, expected_p2l);
-        ExpectStorageMode(*mapping, false, false, false, false);
+        vector_index.SetIdMapType(knowhere::IdMap::Type::SEALED);
+        vector_index.GetIdMap().AddFromData(
+            knowhere::IdMapData::FromValidBitmap(bitmap.data(), 5));
+        vector_index.GetIdMap().FinalizeVectorIds();
+        const auto& id_map = vector_index.GetIdMap();
+        ASSERT_EQ(id_map.OutCount(), 5);
+        ASSERT_EQ(id_map.InToOutIds().size(), expected_in_to_out.size());
+        for (size_t i = 0; i < expected_in_to_out.size(); ++i) {
+            EXPECT_EQ(id_map.InToOutIds()[i], expected_in_to_out[i]);
+        }
     }
 
     {
         const auto mmap_root = MakeMmapRoot("bitmap_helper");
-        auto mmap_dir = mmap_root;
         TestVectorIndex vector_index;
-        index::BuildValidDataFromBitmap(
-            &vector_index, 5, bitmap.data(), MmapOptions(mmap_dir));
-        const auto* mapping = dynamic_cast<const SealedOffsetMapping*>(
-            &vector_index.GetOffsetMapping());
-        ASSERT_NE(mapping, nullptr);
-        ExpectMappingValues(*mapping, expected_l2p, expected_p2l);
-        ExpectStorageMode(*mapping, true, true, false, false);
+        vector_index.SetIdMapType(knowhere::IdMap::Type::SEALED);
+        vector_index.GetIdMap().ConfigureMmap(
+            knowhere::IdMapMmapOptions{true, true, mmap_root.string()});
+        vector_index.GetIdMap().AddFromData(
+            knowhere::IdMapData::FromValidBitmap(bitmap.data(), 5));
+        vector_index.GetIdMap().FinalizeVectorIds();
+        const auto& id_map = vector_index.GetIdMap();
+        ASSERT_EQ(id_map.OutCount(), 5);
+        ASSERT_EQ(id_map.InToOutIds().size(), expected_in_to_out.size());
+        for (size_t i = 0; i < expected_in_to_out.size(); ++i) {
+            EXPECT_EQ(id_map.InToOutIds()[i], expected_in_to_out[i]);
+        }
+        ExpectMmapBlockFiles(mmap_root,
+                             {3 * sizeof(int32_t), 5 * sizeof(int32_t)});
     }
 }
 
-TEST(OffsetMapping, LoadValidDataFromBinarySetUsesProvidedMmapOptions) {
-    SealedOffsetMapping source_mapping;
-    auto valid = ToBoolBytes(MakeValid({1, 0, 1, 1, 0}));
-    source_mapping.Build(reinterpret_cast<const bool*>(valid.data()), 5);
+TEST(IdMapValidDataHelpers, LoadIdMapDataFromBinarySetRestoresIdMapData) {
+    const std::array<bool, 5> valid{{true, false, true, true, false}};
+    knowhere::IdMap source_id_map;
+    source_id_map.SetType(knowhere::IdMap::Type::SEALED);
+    source_id_map.AddFromData(
+        knowhere::IdMapData::FromValidData(valid.data(), valid.size()));
 
     BinarySet binary_set;
-    index::AppendValidDataToBinarySet(source_mapping, binary_set);
+    index::AppendValidDataToBinarySet(source_id_map, binary_set);
 
     {
         TestVectorIndex vector_index;
-        ASSERT_TRUE(
-            index::LoadValidDataFromBinarySet(binary_set, &vector_index));
-        const auto* mapping = dynamic_cast<const SealedOffsetMapping*>(
-            &vector_index.GetOffsetMapping());
-        ASSERT_NE(mapping, nullptr);
-        EXPECT_FALSE(mapping->IsMmap());
-        EXPECT_EQ(mapping->GetPhysicalOffset(3), 2);
-        EXPECT_EQ(mapping->GetLogicalOffset(2), 3);
+        ASSERT_TRUE(index::RestoreIdMapFromBinarySet(binary_set,
+                                                     vector_index.GetIdMap())
+                        .has_valid_data);
+        vector_index.GetIdMap().FinalizeVectorIds();
+        const auto& id_map = vector_index.GetIdMap();
+        ASSERT_EQ(id_map.OutCount(), 5);
+        ASSERT_EQ(id_map.InToOutIds().size(), 3);
+        EXPECT_EQ(id_map.MapInToOut(2), 3);
     }
 
     {
         const auto mmap_root = MakeMmapRoot("binary_set_helper");
-        auto mmap_dir = mmap_root;
         TestVectorIndex vector_index;
-        ASSERT_TRUE(index::LoadValidDataFromBinarySet(
-            binary_set, &vector_index, MmapOptions(mmap_dir)));
-        const auto* mapping = dynamic_cast<const SealedOffsetMapping*>(
-            &vector_index.GetOffsetMapping());
-        ASSERT_NE(mapping, nullptr);
-        EXPECT_TRUE(mapping->IsMmap());
-        EXPECT_EQ(mapping->GetPhysicalOffset(3), 2);
-        EXPECT_EQ(mapping->GetLogicalOffset(2), 3);
+        vector_index.SetIdMapType(knowhere::IdMap::Type::SEALED);
+        vector_index.GetIdMap().ConfigureMmap(
+            knowhere::IdMapMmapOptions{true, true, mmap_root.string()});
+        ASSERT_TRUE(index::RestoreIdMapFromBinarySet(binary_set,
+                                                     vector_index.GetIdMap())
+                        .has_valid_data);
+        vector_index.GetIdMap().FinalizeVectorIds();
+        const auto& id_map = vector_index.GetIdMap();
+        ASSERT_EQ(id_map.InToOutIds().size(), 3);
+        EXPECT_EQ(id_map.MapInToOut(2), 3);
+        ExpectMmapBlockFiles(mmap_root,
+                             {3 * sizeof(int32_t), 5 * sizeof(int32_t)});
     }
 }
 
@@ -725,18 +505,6 @@ TEST(OffsetMapping, IsValidMatchesPhysicalOffsetSign) {
         EXPECT_TRUE(mapping.IsValid(2));
         EXPECT_FALSE(mapping.IsValid(3));
     }
-
-    {
-        const auto mmap_root = MakeMmapRoot("is_valid");
-        auto mmap_dir = mmap_root;
-        SealedOffsetMapping mapping;
-        mapping.Build(
-            reinterpret_cast<const bool*>(v.data()), 4, MmapOptions(mmap_dir));
-        EXPECT_TRUE(mapping.IsValid(0));
-        EXPECT_FALSE(mapping.IsValid(1));
-        EXPECT_TRUE(mapping.IsValid(2));
-        EXPECT_FALSE(mapping.IsValid(3));
-    }
 }
 
 // ---------- Out-of-bounds queries ----------
@@ -747,16 +515,6 @@ TEST(OffsetMapping, OutOfBoundsReturnsMinusOne) {
     {
         SealedOffsetMapping mapping;
         mapping.Build(reinterpret_cast<const bool*>(v.data()), 3);
-        EXPECT_EQ(mapping.GetPhysicalOffset(99), -1);
-        EXPECT_EQ(mapping.GetLogicalOffset(99), -1);
-    }
-
-    {
-        const auto mmap_root = MakeMmapRoot("out_of_bounds");
-        auto mmap_dir = mmap_root;
-        SealedOffsetMapping mapping;
-        mapping.Build(
-            reinterpret_cast<const bool*>(v.data()), 3, MmapOptions(mmap_dir));
         EXPECT_EQ(mapping.GetPhysicalOffset(99), -1);
         EXPECT_EQ(mapping.GetLogicalOffset(99), -1);
     }

--- a/internal/core/src/common/QueryResult.h
+++ b/internal/core/src/common/QueryResult.h
@@ -31,7 +31,6 @@
 #include "common/EasyAssert.h"
 #include "common/FieldMeta.h"
 #include "common/ArrayOffsets.h"
-#include "common/OffsetMapping.h"
 #include "common/Types.h"
 #include "pb/schema.pb.h"
 #include "knowhere/index/index_node.h"
@@ -163,13 +162,8 @@ class VectorIterator {
 // returning results in distance-sorted order.
 class ChunkMergeIterator : public VectorIterator {
  public:
-    // Pass nullptr for VECTOR_ARRAY element-level search: the iterator
-    // returns element IDs, which will be processed by IArrayOffsets.
-    ChunkMergeIterator(int chunk_count,
-                       const milvus::OffsetMapping* offset_mapping,
-                       bool larger_is_closer = false)
-        : offset_mapping_(offset_mapping),
-          heap_(OffsetDisPairComparator(larger_is_closer)) {
+    ChunkMergeIterator(int chunk_count, bool larger_is_closer = false)
+        : heap_(OffsetDisPairComparator(larger_is_closer)) {
         iterators_.reserve(chunk_count);
     }
 
@@ -197,11 +191,7 @@ class ChunkMergeIterator : public VectorIterator {
                     origin_pair.value(), top->GetIteratorIdx());
                 heap_.push(off_dis_pair);
             }
-            auto result = top->GetOffDis();
-            if (offset_mapping_ != nullptr) {
-                result.first = offset_mapping_->GetLogicalOffset(result.first);
-            }
-            return result;
+            return top->GetOffDis();
         }
         return std::nullopt;
     }
@@ -249,7 +239,6 @@ class ChunkMergeIterator : public VectorIterator {
                         OffsetDisPairComparator>
         heap_;
     bool sealed = false;
-    const milvus::OffsetMapping* offset_mapping_ = nullptr;
     //currently, ChunkMergeIterator is guaranteed to be used serially without concurrent problem, in the future
     //we may need to add mutex to protect the variable sealed
 };
@@ -274,7 +263,6 @@ struct SearchResult {
         int64_t nq,
         int chunk_count,
         const std::vector<knowhere::IndexNode::IteratorPtr>& kw_iterators,
-        const milvus::OffsetMapping* offset_mapping,
         bool larger_is_closer = false) {
         AssertInfo(kw_iterators.size() == nq * chunk_count,
                    "kw_iterators count:{} is not equal to nq*chunk_count:{}, "
@@ -287,7 +275,7 @@ struct SearchResult {
             vec_iter_idx = vec_iter_idx % nq;
             if (vector_iterators.size() < nq) {
                 auto chunk_merge_iter = std::make_shared<ChunkMergeIterator>(
-                    chunk_count, offset_mapping, larger_is_closer);
+                    chunk_count, larger_is_closer);
                 vector_iterators.emplace_back(chunk_merge_iter);
             }
             const auto& kw_iterator = kw_iterators[i];

--- a/internal/core/src/common/Schema.cpp
+++ b/internal/core/src/common/Schema.cpp
@@ -234,7 +234,9 @@ Schema::ParseFrom(const milvus::proto::schema::CollectionSchema& schema_proto) {
     for (const milvus::proto::schema::StructArrayFieldSchema& child :
          schema_proto.struct_array_fields()) {
         for (const auto& sub_field : child.fields()) {
-            process_field(sub_field);
+            auto field = sub_field;
+            field.set_nullable(field.nullable() || child.nullable());
+            process_field(field);
         }
     }
 

--- a/internal/core/src/common/SchemaTest.cpp
+++ b/internal/core/src/common/SchemaTest.cpp
@@ -654,6 +654,43 @@ TEST_F(SchemaTest,
               columns->end());
 }
 
+TEST_F(SchemaTest, NullableStructArrayMakesSubFieldsEffectivelyNullable) {
+    milvus::proto::schema::CollectionSchema schema_proto;
+
+    auto* pk_field = schema_proto.add_fields();
+    pk_field->set_fieldid(100);
+    pk_field->set_name("pk");
+    pk_field->set_data_type(milvus::proto::schema::DataType::Int64);
+    pk_field->set_is_primary_key(true);
+
+    auto* struct_array = schema_proto.add_struct_array_fields();
+    struct_array->set_fieldid(200);
+    struct_array->set_name("events");
+    struct_array->set_nullable(true);
+
+    auto* vector = struct_array->add_fields();
+    vector->set_fieldid(201);
+    vector->set_name("events[embedding]");
+    vector->set_data_type(milvus::proto::schema::DataType::ArrayOfVector);
+    vector->set_element_type(milvus::proto::schema::DataType::FloatVector);
+    auto* dim = vector->add_type_params();
+    dim->set_key("dim");
+    dim->set_value("8");
+
+    auto* tag = struct_array->add_fields();
+    tag->set_fieldid(202);
+    tag->set_name("events[tag]");
+    tag->set_data_type(milvus::proto::schema::DataType::Array);
+    tag->set_element_type(milvus::proto::schema::DataType::VarChar);
+
+    auto schema = Schema::ParseFrom(schema_proto);
+
+    EXPECT_TRUE(schema->operator[](FieldId(201)).is_nullable());
+    EXPECT_TRUE(schema->operator[](FieldId(202)).is_nullable());
+    EXPECT_FALSE(vector->nullable());
+    EXPECT_FALSE(tag->nullable());
+}
+
 TEST_F(SchemaTest, MilvusTableRealPKLoadsSourceTimestampColumn) {
     milvus::proto::schema::CollectionSchema schema_proto;
     schema_proto.set_external_source(

--- a/internal/core/src/common/SealedOffsetMapping.cpp
+++ b/internal/core/src/common/SealedOffsetMapping.cpp
@@ -17,27 +17,13 @@
 #include "common/SealedOffsetMapping.h"
 
 #include <algorithm>
-#include <filesystem>
-#include <limits>
+
+#include "common/EasyAssert.h"
 
 namespace milvus {
 
-namespace {
-
-constexpr const char* O2I_MMAP_FILE = "o2i";
-constexpr const char* I2O_MMAP_FILE = "i2o";
-
-std::string
-GetMmapFilePath(const std::string& mmap_dir_path, const char* filename) {
-    return (std::filesystem::path(mmap_dir_path) / filename).string();
-}
-
-}  // namespace
-
 void
-SealedOffsetMapping::Build(const bool* valid_data,
-                           int64_t total_count,
-                           const OffsetMappingBuildOptions& options) {
+SealedOffsetMapping::Build(const bool* valid_data, int64_t total_count) {
     constexpr int64_t start_logical = 0;
     constexpr int64_t start_physical = 0;
 
@@ -45,14 +31,10 @@ SealedOffsetMapping::Build(const bool* valid_data,
     // disabled empty mapping, as the header contract states, instead of
     // silently retaining the previous build.
     enabled_ = false;
-    use_i2o_map_ = false;
-    use_o2i_map_ = false;
     total_count_ = 0;
     valid_count_ = 0;
-    l2p_vec_.Clear();
-    p2l_vec_.Clear();
-    l2p_map_.clear();
-    p2l_map_.clear();
+    l2p_vec_.clear();
+    p2l_vec_.clear();
 
     if (total_count == 0 || valid_data == nullptr) {
         return;
@@ -68,53 +50,17 @@ SealedOffsetMapping::Build(const bool* valid_data,
         }
     }
 
-    const bool use_sparse_mapping = valid_count * 10 < total_count;
-    use_i2o_map_ = !options.enable_mmap_i2o_map && use_sparse_mapping;
-    use_o2i_map_ = !options.enable_mmap_o2i_map && use_sparse_mapping;
-
     const int64_t required_size = start_logical + total_count;
     const int64_t required_p2l_size = start_physical + valid_count;
 
-    const bool need_o2i_mmap =
-        !use_o2i_map_ && options.enable_mmap_o2i_map && required_size > 0;
-    const bool need_i2o_mmap =
-        !use_i2o_map_ && options.enable_mmap_i2o_map && required_p2l_size > 0;
-    if (need_i2o_mmap || need_o2i_mmap) {
-        AssertInfo(!options.mmap_dir_path.empty(),
-                   "offset mapping mmap dir path is empty");
-    }
-
-    if (!use_o2i_map_) {
-        l2p_vec_.Resize(required_size,
-                        -1,
-                        options.enable_mmap_o2i_map,
-                        need_o2i_mmap ? GetMmapFilePath(options.mmap_dir_path,
-                                                        O2I_MMAP_FILE)
-                                      : "");
-    }
-
-    if (!use_i2o_map_) {
-        p2l_vec_.Resize(required_p2l_size,
-                        -1,
-                        options.enable_mmap_i2o_map,
-                        need_i2o_mmap ? GetMmapFilePath(options.mmap_dir_path,
-                                                        I2O_MMAP_FILE)
-                                      : "");
-    }
+    l2p_vec_.assign(static_cast<size_t>(required_size), -1);
+    p2l_vec_.assign(static_cast<size_t>(required_p2l_size), -1);
 
     int64_t physical_idx = start_physical;
     for (int64_t i = 0; i < total_count; ++i) {
         if (valid_data[i]) {
-            if (use_o2i_map_) {
-                l2p_map_[start_logical + i] = physical_idx;
-            } else {
-                l2p_vec_[start_logical + i] = physical_idx;
-            }
-            if (use_i2o_map_) {
-                p2l_map_[physical_idx] = start_logical + i;
-            } else {
-                p2l_vec_[physical_idx] = start_logical + i;
-            }
+            l2p_vec_[start_logical + i] = physical_idx;
+            p2l_vec_[physical_idx] = start_logical + i;
             ++physical_idx;
         }
     }
@@ -135,10 +81,6 @@ SealedOffsetMapping::GetPhysicalOffsetInternal(int64_t logical_offset) const {
     if (logical_offset < 0 || logical_offset >= total_count_) {
         return -1;
     }
-    if (use_o2i_map_) {
-        auto it = l2p_map_.find(static_cast<int32_t>(logical_offset));
-        return it == l2p_map_.end() ? -1 : it->second;
-    }
     return logical_offset < static_cast<int64_t>(l2p_vec_.size())
                ? l2p_vec_[logical_offset]
                : -1;
@@ -156,10 +98,6 @@ SealedOffsetMapping::GetLogicalOffsetInternal(int64_t physical_offset) const {
     }
     if (physical_offset < 0 || physical_offset >= valid_count_) {
         return -1;
-    }
-    if (use_i2o_map_) {
-        auto it = p2l_map_.find(static_cast<int32_t>(physical_offset));
-        return it == p2l_map_.end() ? -1 : it->second;
     }
     return physical_offset < static_cast<int64_t>(p2l_vec_.size())
                ? p2l_vec_[physical_offset]
@@ -183,20 +121,12 @@ SealedOffsetMapping::ValidCountBelow(int64_t logical_bound) const {
         return valid_count_;
     }
     // physical -> logical is built in ascending logical order, so it is
-    // strictly increasing and binary-searchable in either representation.
+    // strictly increasing and binary-searchable.
     int64_t lo = 0;
     int64_t hi = valid_count_;
     while (lo < hi) {
         const int64_t mid = lo + (hi - lo) / 2;
-        int64_t logical;
-        if (use_i2o_map_) {
-            auto it = p2l_map_.find(static_cast<int32_t>(mid));
-            logical = (it == p2l_map_.end())
-                          ? std::numeric_limits<int64_t>::max()
-                          : static_cast<int64_t>(it->second);
-        } else {
-            logical = p2l_vec_[mid];
-        }
+        const int64_t logical = p2l_vec_[mid];
         if (logical < logical_bound) {
             lo = mid + 1;
         } else {
@@ -211,74 +141,26 @@ SealedOffsetMapping::IsEnabled() const {
     return enabled_;
 }
 
-bool
-SealedOffsetMapping::IsMmap() const {
-    return l2p_vec_.IsMmap() || p2l_vec_.IsMmap();
-}
-
 int64_t
 SealedOffsetMapping::GetTotalCount() const {
     return total_count_;
 }
 
-OffsetMapping::BitsetTransformStatus
-SealedOffsetMapping::TransformBitset(const BitsetView& bitset,
-                                     TargetBitmap& result) const {
-    if (!enabled_) {
-        result.clear();
-        return BitsetTransformStatus::NoFilter;
+OffsetMappingIdView
+SealedOffsetMapping::GetPhysicalToLogicalIds(int64_t physical_offset,
+                                             int64_t count) const {
+    if (!enabled_ || count <= 0) {
+        return {};
     }
-    BitsetTransformStatus status;
-    if (ShouldSkipBitsetTransform(bitset, total_count_, result, status)) {
-        return status;
-    }
-
-    result.resize(valid_count_, true);
-    if (use_i2o_map_) {
-        for (int64_t physical_idx = 0; physical_idx < valid_count_;
-             ++physical_idx) {
-            auto it = p2l_map_.find(static_cast<int32_t>(physical_idx));
-            if (it != p2l_map_.end() &&
-                it->second < static_cast<int64_t>(bitset.size())) {
-                result[physical_idx] = bitset.test(it->second);
-            }
-        }
-    } else {
-        for (int64_t physical_idx = 0; physical_idx < valid_count_;
-             ++physical_idx) {
-            auto logical_idx = p2l_vec_[physical_idx];
-            if (logical_idx >= 0 &&
-                logical_idx < static_cast<int64_t>(bitset.size())) {
-                result[physical_idx] = bitset.test(logical_idx);
-            }
-        }
-    }
-    return BitsetTransformStatus::Transformed;
-}
-
-void
-SealedOffsetMapping::TransformOffsets(std::vector<int64_t>& offsets) const {
-    if (!enabled_) {
-        return;
-    }
-    for (auto& offset : offsets) {
-        if (offset >= 0) {
-            offset = GetLogicalOffsetInternal(offset);
-        }
-    }
-}
-
-void
-SealedOffsetMapping::TransformLogicalOffsets(
-    std::vector<int64_t>& offsets) const {
-    if (!enabled_) {
-        return;
-    }
-    for (auto& offset : offsets) {
-        if (offset >= 0) {
-            offset = GetPhysicalOffsetInternal(offset);
-        }
-    }
+    AssertInfo(physical_offset >= 0,
+               "physical offset {} is negative",
+               physical_offset);
+    AssertInfo(physical_offset <= valid_count_ - count,
+               "physical id range [{}, {}) exceeds valid count {}",
+               physical_offset,
+               physical_offset + count,
+               valid_count_);
+    return {p2l_vec_.data() + static_cast<size_t>(physical_offset), count};
 }
 
 void

--- a/internal/core/src/common/SealedOffsetMapping.h
+++ b/internal/core/src/common/SealedOffsetMapping.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <cstdint>
-#include <unordered_map>
 #include <vector>
 
 #include "common/OffsetMapping.h"
@@ -27,19 +26,13 @@ namespace milvus {
 // Offset mapping for sealed storage: built once from a complete valid_data
 // array, then immutable. Because nothing mutates after Build(), every read is
 // lock-free.
-//
-// Each direction independently chooses one representation in Build():
-//   - contiguous int32 storage, heap-backed or file-backed mmap
-//   - hash map when valid rows are sparse and mmap was not requested
 class SealedOffsetMapping final : public OffsetMapping {
  public:
     // Build the mapping from a complete valid_data array. Resets any state
     // from a previous Build(). A null pointer or zero count leaves the mapping
     // disabled.
     void
-    Build(const bool* valid_data,
-          int64_t total_count,
-          const OffsetMappingBuildOptions& options = {});
+    Build(const bool* valid_data, int64_t total_count);
 
     int64_t
     GetPhysicalOffset(int64_t logical_offset) const override;
@@ -58,21 +51,12 @@ class SealedOffsetMapping final : public OffsetMapping {
     bool
     IsEnabled() const override;
 
-    bool
-    IsMmap() const override;
-
     int64_t
     GetTotalCount() const override;
 
-    BitsetTransformStatus
-    TransformBitset(const BitsetView& bitset,
-                    TargetBitmap& result) const override;
-
-    void
-    TransformOffsets(std::vector<int64_t>& offsets) const override;
-
-    void
-    TransformLogicalOffsets(std::vector<int64_t>& offsets) const override;
+    OffsetMappingIdView
+    GetPhysicalToLogicalIds(int64_t physical_offset,
+                            int64_t count) const override;
 
     void
     FilterValidLogicalOffsets(
@@ -80,31 +64,6 @@ class SealedOffsetMapping final : public OffsetMapping {
         int64_t count,
         bool* valid_data,
         std::vector<int64_t>& physical_offsets) const override;
-
-    bool
-    IsUsingMap() const {
-        return IsI2OUsingMap() || IsO2IUsingMap();
-    }
-
-    bool
-    IsI2OUsingMap() const {
-        return use_i2o_map_;
-    }
-
-    bool
-    IsO2IUsingMap() const {
-        return use_o2i_map_;
-    }
-
-    bool
-    IsI2OMmap() const {
-        return p2l_vec_.IsMmap();
-    }
-
-    bool
-    IsO2IMmap() const {
-        return l2p_vec_.IsMmap();
-    }
 
  private:
     int64_t
@@ -114,15 +73,9 @@ class SealedOffsetMapping final : public OffsetMapping {
     GetLogicalOffsetInternal(int64_t physical_offset) const;
 
     bool enabled_{false};
-    bool use_i2o_map_{false};
-    bool use_o2i_map_{false};
-    // Sealed vec mode storage (uses int32_t to save memory)
-    OffsetMappingArray l2p_vec_;  // o2i: logical/original -> physical/index
-    OffsetMappingArray p2l_vec_;  // i2o: physical/index -> logical/original
-
-    // Sealed map mode storage (for sparse valid data)
-    std::unordered_map<int32_t, int32_t> l2p_map_;  // logical -> physical
-    std::unordered_map<int32_t, int32_t> p2l_map_;  // physical -> logical
+    // Sealed mapping uses int32_t to save memory.
+    std::vector<int32_t> l2p_vec_;  // logical/original -> physical/index
+    std::vector<int32_t> p2l_vec_;  // physical/index -> logical/original
 
     int64_t valid_count_{0};
     int64_t total_count_{0};  // total logical count (including nulls)

--- a/internal/core/src/common/SealedOffsetMappingTest.cpp
+++ b/internal/core/src/common/SealedOffsetMappingTest.cpp
@@ -58,7 +58,7 @@ TEST(SealedOffsetMapping, BuildBasicVecMode) {
     EXPECT_EQ(mapping.GetLogicalOffset(2), 3);
 }
 
-TEST(SealedOffsetMapping, BuildMapModeOnSparse) {
+TEST(SealedOffsetMapping, BuildSparseUsesContiguousStorage) {
     SealedOffsetMapping mapping;
     std::vector<uint8_t> valid(100, 0);
     valid[5] = 1;
@@ -184,9 +184,8 @@ TEST(SealedOffsetMapping, ValidCountBelowConvertsLogicalBound) {
     EXPECT_EQ(mapping.ValidCountBelow(100), 4);
 }
 
-// Sparse input takes the map-mode binary search instead of lower_bound over a
-// contiguous array; both branches must agree.
-TEST(SealedOffsetMapping, ValidCountBelowInMapMode) {
+// Sparse input still uses the same contiguous physical->logical storage.
+TEST(SealedOffsetMapping, ValidCountBelowOnSparseMapping) {
     SealedOffsetMapping mapping;
     std::vector<uint8_t> valid(100, 0);
     valid[5] = 1;

--- a/internal/core/src/common/VectorArrayStorageV2Test.cpp
+++ b/internal/core/src/common/VectorArrayStorageV2Test.cpp
@@ -62,6 +62,7 @@
 #include "knowhere/comp/index_param.h"
 #include "knowhere/config.h"
 #include "knowhere/dataset.h"
+#include "knowhere/index/emb_list_strategy.h"
 #include "knowhere/version.h"
 #include "milvus-storage/common/config.h"
 #include "milvus-storage/filesystem/fs.h"
@@ -598,7 +599,7 @@ TEST_F(TestVectorArrayStorageV2, BuildEncodedEmbListHNSWIndexWithMmap) {
         create_index_info.metric_type = knowhere::metric::MAX_SIM_COSINE;
         create_index_info.index_type = knowhere::IndexEnum::INDEX_HNSW;
         create_index_info.index_engine_version =
-            knowhere::Version::GetCurrentVersion().VersionNumber();
+            knowhere::kEmbListMetaV2MinVersion;
 
         auto emb_list_hnsw_index =
             milvus::index::IndexFactory::GetInstance().CreateIndex(

--- a/internal/core/src/exec/operator/Utils.h
+++ b/internal/core/src/exec/operator/Utils.h
@@ -126,20 +126,8 @@ PrepareVectorIteratorsFromIndex(const SearchInfo& search_info,
             if (iterators_val.has_value()) {
                 bool larger_is_closer =
                     PositivelyRelated(search_info.metric_type_);
-                // Element-level search skips row-level mapping (element IDs
-                // are not row-aligned); see ChunkMergeIterator ctor.
-                const auto& offset_mapping = index.GetOffsetMapping();
-                const milvus::OffsetMapping* iter_offset_mapping =
-                    (search_info.array_offsets_ != nullptr ||
-                     !offset_mapping.IsEnabled())
-                        ? nullptr
-                        : &offset_mapping;
                 search_result.AssembleChunkVectorIterators(
-                    nq,
-                    1,
-                    iterators_val.value(),
-                    iter_offset_mapping,
-                    larger_is_closer);
+                    nq, 1, iterators_val.value(), larger_is_closer);
             } else {
                 std::string operator_type = "";
                 if (search_info.has_group_by()) {

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -184,7 +184,7 @@ SaturatingMul(uint64_t lhs, uint64_t rhs) {
 }
 
 uint64_t
-OffsetMappingMmapDiskCost(const Config& config, int64_t num_rows) {
+IdMapMmapDiskCost(const Config& config, int64_t num_rows) {
     if (num_rows <= 0) {
         return 0;
     }
@@ -670,12 +670,11 @@ IndexFactory::VecIndexLoadResource(
         request.max_memory_cost = 2 * res.memoryCost;
     }
     if (knowhere::UseDiskLoad(index_type, index_version)) {
-        const auto offset_mapping_disk_cost =
-            OffsetMappingMmapDiskCost(config, num_rows);
+        const auto id_map_disk_cost = IdMapMmapDiskCost(config, num_rows);
         request.final_disk_cost =
-            SaturatingAdd(request.final_disk_cost, offset_mapping_disk_cost);
+            SaturatingAdd(request.final_disk_cost, id_map_disk_cost);
         request.max_disk_cost =
-            SaturatingAdd(request.max_disk_cost, offset_mapping_disk_cost);
+            SaturatingAdd(request.max_disk_cost, id_map_disk_cost);
     }
     return request;
 }

--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -30,7 +30,6 @@
 
 #include "common/Consts.h"
 #include "common/FastMem.h"
-#include "common/OffsetMapping.h"
 #include "common/QueryInfo.h"
 #include "common/QueryResult.h"
 #include "common/RangeSearchHelper.h"
@@ -69,13 +68,6 @@ namespace milvus::index {
 namespace {
 
 constexpr const char* EMPTY_EMB_LIST_OFFSET_KEY = "empty_emb_list_offsets";
-
-struct DiskValidData {
-    bool found = false;
-    size_t total_count = 0;
-    size_t valid_count = 0;
-    std::vector<uint8_t> bitmap;
-};
 
 struct EmptyEmbListState {
     int64_t dim = 0;
@@ -139,7 +131,7 @@ WriteDiskEmptyEmbListOffsets(const LocalChunkManagerPtr& local_chunk_manager,
         local_chunk_manager->CreateFile(empty_offsets_path);
     }
 
-    auto count = ToValidDataCount(offsets.size());
+    auto count = static_cast<uint64_t>(offsets.size());
     int64_t write_pos = 0;
     local_chunk_manager->Write(
         empty_offsets_path, write_pos, &dim, sizeof(int64_t));
@@ -194,6 +186,8 @@ size_t
 GetEmbListNumOffsets(const DatasetPtr& dataset,
                      const size_t* offsets,
                      size_t total_vectors) {
+    AssertInfo(total_vectors > 0,
+               "embedding list offset count requires non-empty vectors");
     auto num_queries = dataset->Get<int64_t>(knowhere::meta::NQ);
     AssertInfo(num_queries > 0, "embedding list build query count is missing");
     AssertInfo(offsets[num_queries] == total_vectors,
@@ -206,10 +200,10 @@ GetEmbListNumOffsets(const DatasetPtr& dataset,
 }
 
 template <typename LocalChunkManagerPtr>
-DiskValidData
+OwnedValidData
 ReadDiskValidData(const LocalChunkManagerPtr& local_chunk_manager,
                   const std::string& valid_data_path) {
-    DiskValidData valid_data;
+    OwnedValidData valid_data;
     if (!local_chunk_manager->Exist(valid_data_path)) {
         return valid_data;
     }
@@ -221,8 +215,8 @@ ReadDiskValidData(const LocalChunkManagerPtr& local_chunk_manager,
     uint64_t wire_count = 0;
     local_chunk_manager->Read(
         valid_data_path, 0, &wire_count, sizeof(uint64_t));
-    valid_data.total_count = FromValidDataCount(wire_count);
-    valid_data.bitmap.resize(GetValidDataBitmapSize(valid_data.total_count));
+    valid_data.count = FromValidDataCount(wire_count);
+    valid_data.bitmap.resize(GetValidDataBitmapSize(valid_data.count));
     AssertInfo(file_size >= sizeof(uint64_t) + valid_data.bitmap.size(),
                "nullable vector disk valid_data bitmap file is too small");
     if (!valid_data.bitmap.empty()) {
@@ -231,19 +225,47 @@ ReadDiskValidData(const LocalChunkManagerPtr& local_chunk_manager,
                                   valid_data.bitmap.data(),
                                   valid_data.bitmap.size());
     }
-    valid_data.valid_count =
-        CountValidDataBitmap(valid_data.total_count, valid_data.bitmap.data());
     return valid_data;
+}
+
+template <typename LocalChunkManagerPtr>
+size_t
+ReadDiskRawDataRows(const LocalChunkManagerPtr& local_chunk_manager,
+                    const std::string& raw_data_path) {
+    AssertInfo(local_chunk_manager->Exist(raw_data_path),
+               "disk raw data file not found: {}",
+               raw_data_path);
+    AssertInfo(local_chunk_manager->Size(raw_data_path) >= sizeof(uint32_t),
+               "disk raw data file is too small");
+
+    uint32_t rows = 0;
+    local_chunk_manager->Read(raw_data_path, 0, &rows, sizeof(rows));
+    return static_cast<size_t>(rows);
+}
+
+void
+ApplyDiskAnnBuildThreadConfig(const IndexType& index_type,
+                              knowhere::Json& build_config) {
+    if (index_type != knowhere::IndexEnum::INDEX_DISKANN) {
+        return;
+    }
+
+    auto num_threads = GetValueFromConfig<std::string>(
+        build_config, DISK_ANN_BUILD_THREAD_NUM);
+    AssertInfo(num_threads.has_value(),
+               "param {} is empty",
+               DISK_ANN_BUILD_THREAD_NUM);
+    build_config[DISK_ANN_THREADS_NUM] = std::atoi(num_threads.value().c_str());
 }
 
 template <typename LocalChunkManagerPtr>
 void
 WriteDiskValidData(const LocalChunkManagerPtr& local_chunk_manager,
                    const std::string& valid_data_path,
-                   const OffsetMapping& offset_mapping) {
-    auto total_count = static_cast<size_t>(offset_mapping.GetTotalCount());
-    auto wire_count = ToValidDataCount(total_count);
-    auto packed_data = PackValidDataBitmap(offset_mapping);
+                   const knowhere::IdMap& id_map) {
+    auto total_count = static_cast<size_t>(id_map.ValidBitmap().size());
+    auto wire_count = static_cast<uint64_t>(total_count);
+    auto packed_data = PackValidDataBitmap(id_map);
     if (!local_chunk_manager->Exist(valid_data_path)) {
         local_chunk_manager->CreateFile(valid_data_path);
     }
@@ -342,9 +364,12 @@ VectorDiskAnnIndex<T>::Load(milvus::tracer::TraceContext ctx,
     auto valid_data_path = local_index_path_prefix + "/" + VALID_DATA_KEY;
     auto disk_valid_data =
         ReadDiskValidData(local_chunk_manager, valid_data_path);
-    bool all_null_nullable = disk_valid_data.found &&
-                             disk_valid_data.total_count > 0 &&
-                             disk_valid_data.valid_count == 0;
+    const auto restored_id_map =
+        RestoreIdMapFromValidData(index_.GetIdMap(),
+                                  disk_valid_data.View(),
+                                  &load_config,
+                                  local_index_path_prefix);
+    bool all_null_nullable = restored_id_map.IsAllNullNullable();
     auto empty_emb_list_state = ReadDiskEmptyEmbListOffsets(
         local_chunk_manager,
         local_index_path_prefix + "/" + EMPTY_EMB_LIST_OFFSET_KEY);
@@ -373,15 +398,12 @@ VectorDiskAnnIndex<T>::Load(milvus::tracer::TraceContext ctx,
         SetDim(empty_emb_list_state->dim);
         empty_emb_list_offsets_ = std::move(empty_emb_list_state->offsets);
     }
-
-    if (disk_valid_data.found) {
-        auto offset_mapping_options = GetOffsetMappingMmapOptions(load_config);
-        offset_mapping_options.mmap_dir_path =
-            GetOffsetMappingMmapDir(local_index_path_prefix);
-        BuildValidDataFromBitmap(this,
-                                 disk_valid_data.total_count,
-                                 disk_valid_data.bitmap.data(),
-                                 offset_mapping_options);
+    if (restored_id_map.has_valid_data) {
+        if (all_null_nullable || empty_emb_list_state.has_value()) {
+            FinalizeRestoredIdMap(index_.Node(),
+                                  ErrorCode::UnexpectedError,
+                                  "disk metadata-only load");
+        }
     }
 }
 
@@ -389,8 +411,8 @@ template <typename T>
 IndexStatsPtr
 VectorDiskAnnIndex<T>::Upload(const Config& config) {
     BinarySet ret;
-    const auto& offset_mapping = GetOffsetMapping();
-    if (!IsAllNullNullable(offset_mapping) && !IsEmptyEmbListIndex()) {
+    const auto& id_map = GetIdMap();
+    if (!IsAllNullNullable(id_map) && !IsEmptyEmbListIndex()) {
         auto stat = index_.Serialize(ret);
         if (stat != knowhere::Status::success) {
             ThrowInfo(ErrorCode::UnexpectedError,
@@ -438,17 +460,50 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
     auto local_data_path =
         file_manager_->CacheRawDataToDisk<T>(config_with_emb_list);
     build_config[DISK_ANN_RAW_DATA_PATH] = local_data_path;
+    const auto raw_data_rows =
+        ReadDiskRawDataRows(local_chunk_manager, local_data_path);
 
     auto disk_valid_data =
         ReadDiskValidData(local_chunk_manager, valid_data_path);
-    if (disk_valid_data.found) {
-        BuildValidDataFromBitmap(
-            this, disk_valid_data.total_count, disk_valid_data.bitmap.data());
-        if (disk_valid_data.valid_count == 0) {
-            auto dim = GetValueFromConfig<int64_t>(build_config, DIM_KEY);
-            if (dim.has_value()) {
-                SetDim(dim.value());
-            }
+    auto dim = GetValueFromConfig<int64_t>(build_config, DIM_KEY);
+    auto id_map_dataset =
+        GenIdMapDatasetFromValidData(index_.GetIdMap(),
+                                     static_cast<int64_t>(raw_data_rows),
+                                     dim.value_or(0),
+                                     disk_valid_data.View(),
+                                     build_config,
+                                     local_index_path_prefix);
+    auto build_metadata_id_map = [&](const DatasetPtr& dataset,
+                                     const char* context) {
+        auto stat = index_.Build(dataset, build_config);
+        if (stat != knowhere::Status::success) {
+            ThrowInfo(ErrorCode::IndexBuildError,
+                      "failed to build {}, {}",
+                      context,
+                      KnowhereStatusString(stat));
+        }
+    };
+    auto write_empty_emb_list_metadata = [&](std::vector<size_t> offsets) {
+        empty_emb_list_offsets_ = std::move(offsets);
+        auto empty_offsets_path =
+            local_index_path_prefix + "/" + EMPTY_EMB_LIST_OFFSET_KEY;
+        WriteDiskEmptyEmbListOffsets(local_chunk_manager,
+                                     empty_offsets_path,
+                                     GetDim(),
+                                     empty_emb_list_offsets_);
+        file_manager_->AddFile(empty_offsets_path);
+    };
+    const auto disk_valid_data_all_null =
+        disk_valid_data.found &&
+        std::none_of(disk_valid_data.bitmap.begin(),
+                     disk_valid_data.bitmap.end(),
+                     [](uint8_t byte) { return byte != 0; });
+
+    if (id_map_dataset != nullptr) {
+        if (!is_embedding_list && raw_data_rows == 0) {
+            SetDim(ResolveDatasetOrConfigDim(
+                id_map_dataset, build_config, "build all-null disk index"));
+            build_metadata_id_map(id_map_dataset, "all-null disk id map");
             file_manager_->AddFile(valid_data_path);
             file_manager_->RemoveRawDataFiles();
             LOG_INFO("build all-null nullable disk index done, build_id: {}",
@@ -462,28 +517,38 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
         auto offsets =
             ReadDiskEmbListOffsets(local_chunk_manager, offsets_path);
         if (!offsets.has_value()) {
+            if (id_map_dataset != nullptr && raw_data_rows == 0 &&
+                disk_valid_data_all_null) {
+                SetDim(ResolveDatasetOrConfigDim(
+                    id_map_dataset,
+                    build_config,
+                    "build all-null emb-list disk index"));
+                write_empty_emb_list_metadata({0});
+                build_metadata_id_map(id_map_dataset,
+                                      "all-null emb-list disk id map");
+                file_manager_->AddFile(valid_data_path);
+                file_manager_->RemoveRawDataFiles();
+                LOG_INFO(
+                    "build all-null emb_list disk index done, build_id: {}",
+                    config.value("build_id", "unknown"));
+                return;
+            }
             ThrowInfo(ErrorCode::UnexpectedError,
                       fmt::format("Embedding list offsets file not found: {}",
                                   offsets_path));
         }
         if (offsets->back() == 0) {
-            auto dim = GetValueFromConfig<int64_t>(build_config, DIM_KEY);
             AssertInfo(dim.has_value() && dim.value() > 0,
                        "dim is missing when build empty emb_list disk index");
             SetDim(dim.value());
 
-            auto empty_offsets_path =
-                local_index_path_prefix + "/" + EMPTY_EMB_LIST_OFFSET_KEY;
-            WriteDiskEmptyEmbListOffsets(local_chunk_manager,
-                                         empty_offsets_path,
-                                         GetDim(),
-                                         offsets.value());
-            file_manager_->AddFile(empty_offsets_path);
-            if (local_chunk_manager->Exist(valid_data_path)) {
+            write_empty_emb_list_metadata(std::move(offsets.value()));
+            if (id_map_dataset != nullptr) {
+                build_metadata_id_map(id_map_dataset,
+                                      "empty emb-list disk id map");
                 file_manager_->AddFile(valid_data_path);
             }
             file_manager_->RemoveRawDataFiles();
-            empty_emb_list_offsets_ = std::move(offsets.value());
             LOG_INFO("build all-empty emb_list disk index done, build_id: {}",
                      config.value("build_id", "unknown"));
             return;
@@ -492,16 +557,7 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
     }
 
     build_config[DISK_ANN_PREFIX_PATH] = local_index_path_prefix;
-
-    if (GetIndexType() == knowhere::IndexEnum::INDEX_DISKANN) {
-        auto num_threads = GetValueFromConfig<std::string>(
-            build_config, DISK_ANN_BUILD_THREAD_NUM);
-        AssertInfo(num_threads.has_value(),
-                   "param {} is empty",
-                   DISK_ANN_BUILD_THREAD_NUM);
-        build_config[DISK_ANN_THREADS_NUM] =
-            std::atoi(num_threads.value().c_str());
-    }
+    ApplyDiskAnnBuildThreadConfig(GetIndexType(), build_config);
 
     auto opt_fields = GetValueFromConfig<OptFieldT>(config, VEC_OPT_FIELDS);
     auto is_partition_key_isolation =
@@ -517,7 +573,7 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
 
     build_config.erase(INSERT_FILES_KEY);
     build_config.erase(VEC_OPT_FIELDS);
-    auto stat = index_.Build({}, build_config);
+    auto stat = index_.Build(id_map_dataset, build_config);
     if (stat != knowhere::Status::success)
         ThrowInfo(ErrorCode::IndexBuildError,
                   "failed to build disk index, {}",
@@ -558,53 +614,41 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
         file_manager_->AcquireLocalDirWriteLease(local_index_path_prefix);
     build_config[DISK_ANN_PREFIX_PATH] = local_index_path_prefix;
 
-    const auto& offset_mapping = GetOffsetMapping();
-    if (HasValidData() && GetValidCount() == 0 &&
-        offset_mapping.GetTotalCount() > 0) {
+    if (dataset != nullptr && dataset->HasIdMapData() &&
+        !index_.GetIdMap().IsEnabled()) {
+        index_.GetIdMap().SetType(knowhere::IdMap::Type::SEALED);
+    }
+    ConfigureIdMapMmapForDataset(
+        index_.GetIdMap(), dataset, build_config, local_index_path_prefix);
+    const auto id_map_only_build =
+        GetIdMapOnlyBuildPlan(dataset, is_embedding_list);
+    if (id_map_only_build.enabled) {
+        SetDim(ResolveDatasetOrConfigDim(
+            dataset, build_config, "build metadata-only disk index"));
+        if (id_map_only_build.empty_embedding_list) {
+            empty_emb_list_offsets_ = {0};
+            auto empty_offsets_path =
+                local_index_path_prefix + "/" + EMPTY_EMB_LIST_OFFSET_KEY;
+            WriteDiskEmptyEmbListOffsets(local_chunk_manager,
+                                         empty_offsets_path,
+                                         GetDim(),
+                                         empty_emb_list_offsets_);
+            file_manager_->AddFile(empty_offsets_path);
+        }
+        auto stat = index_.Build(dataset, build_config);
+        if (stat != knowhere::Status::success) {
+            ThrowInfo(ErrorCode::IndexBuildError,
+                      "failed to build metadata-only disk id map, {}",
+                      KnowhereStatusString(stat));
+        }
         auto valid_data_path = local_index_path_prefix + "/" + VALID_DATA_KEY;
-        WriteDiskValidData(
-            local_chunk_manager, valid_data_path, offset_mapping);
+        WriteDiskValidData(local_chunk_manager, valid_data_path, GetIdMap());
         file_manager_->AddFile(valid_data_path);
-        auto dim = GetValueFromConfig<int64_t>(build_config, DIM_KEY);
-        if (dim.has_value()) {
-            SetDim(dim.value());
-        }
         file_manager_->RemoveRawDataFiles();
         return;
     }
 
-    if (is_embedding_list && milvus::GetDatasetRows(dataset) == 0) {
-        auto offsets =
-            dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
-        if (offsets == nullptr) {
-            ThrowInfo(ErrorCode::UnexpectedError,
-                      "Embedding list offsets is empty when build index");
-        }
-        auto num_offsets = GetEmbListNumOffsets(dataset, offsets, 0);
-        auto empty_offsets =
-            std::vector<size_t>(offsets, offsets + num_offsets);
-        auto empty_offsets_path =
-            local_index_path_prefix + "/" + EMPTY_EMB_LIST_OFFSET_KEY;
-        WriteDiskEmptyEmbListOffsets(local_chunk_manager,
-                                     empty_offsets_path,
-                                     dataset->GetDim(),
-                                     empty_offsets);
-        file_manager_->AddFile(empty_offsets_path);
-        SetDim(dataset->GetDim());
-        empty_emb_list_offsets_ = std::move(empty_offsets);
-        file_manager_->RemoveRawDataFiles();
-        return;
-    }
-
-    if (GetIndexType() == knowhere::IndexEnum::INDEX_DISKANN) {
-        auto num_threads = GetValueFromConfig<std::string>(
-            build_config, DISK_ANN_BUILD_THREAD_NUM);
-        AssertInfo(num_threads.has_value(),
-                   "param {} is empty",
-                   DISK_ANN_BUILD_THREAD_NUM);
-        build_config[DISK_ANN_THREADS_NUM] =
-            std::atoi(num_threads.value().c_str());
-    }
+    ApplyDiskAnnBuildThreadConfig(GetIndexType(), build_config);
     if (!local_chunk_manager->Exist(local_data_path)) {
         local_chunk_manager->CreateFile(local_data_path);
     }
@@ -656,7 +700,7 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
         build_config[EMB_LIST_OFFSETS_PATH] = offsets_path;
     }
 
-    auto stat = index_.Build({}, build_config);
+    auto stat = index_.Build(dataset, build_config);
     if (stat != knowhere::Status::success)
         ThrowInfo(ErrorCode::IndexBuildError,
                   "failed to build index, {}",
@@ -664,8 +708,7 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
 
     if (HasValidData()) {
         auto valid_data_path = local_index_path_prefix + "/" + VALID_DATA_KEY;
-        WriteDiskValidData(
-            local_chunk_manager, valid_data_path, offset_mapping);
+        WriteDiskValidData(local_chunk_manager, valid_data_path, GetIdMap());
         file_manager_->AddFile(valid_data_path);
     }
 
@@ -689,8 +732,8 @@ VectorDiskAnnIndex<T>::Query(const DatasetPtr dataset,
 
     knowhere::Json search_config = PrepareSearchParams(search_info);
 
-    const auto& offset_mapping = GetOffsetMapping();
-    if (IsAllNullNullable(offset_mapping) || IsEmptyEmbListIndex()) {
+    const auto& id_map = GetIdMap();
+    if (IsAllNullNullable(id_map) || IsEmptyEmbListIndex()) {
         auto offsets =
             dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
         auto num_queries = dataset->GetRows();
@@ -801,8 +844,8 @@ VectorDiskAnnIndex<T>::VectorIterators(const DatasetPtr dataset,
         return iterators;
     };
 
-    const auto& offset_mapping = GetOffsetMapping();
-    if (IsAllNullNullable(offset_mapping) || IsEmptyEmbListIndex()) {
+    const auto& id_map = GetIdMap();
+    if (IsAllNullNullable(id_map) || IsEmptyEmbListIndex()) {
         auto offsets =
             dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
         auto num_queries = dataset->GetRows();
@@ -827,8 +870,8 @@ VectorDiskAnnIndex<T>::VectorIterators(const DatasetPtr dataset,
 template <typename T>
 const bool
 VectorDiskAnnIndex<T>::HasRawData() const {
-    const auto& offset_mapping = GetOffsetMapping();
-    if (IsAllNullNullable(offset_mapping) || IsEmptyEmbListIndex()) {
+    const auto& id_map = GetIdMap();
+    if (IsAllNullNullable(id_map) || IsEmptyEmbListIndex()) {
         return true;
     }
     return index_.HasRawData(GetMetricType());
@@ -837,8 +880,8 @@ VectorDiskAnnIndex<T>::HasRawData() const {
 template <typename T>
 bool
 VectorDiskAnnIndex<T>::IsIndexRefineEnabled() const {
-    const auto& offset_mapping = GetOffsetMapping();
-    if (IsAllNullNullable(offset_mapping) || IsEmptyEmbListIndex()) {
+    const auto& id_map = GetIdMap();
+    if (IsAllNullNullable(id_map) || IsEmptyEmbListIndex()) {
         return false;
     }
     return index_.IsIndexRefineEnabled();
@@ -856,6 +899,13 @@ VectorDiskAnnIndex<T>::GetVector(const DatasetPtr dataset) const {
     // if dataset is empty, return empty vector
     if (dataset->GetRows() == 0) {
         return {};
+    }
+
+    const auto& id_map = GetIdMap();
+    if (IsAllNullNullable(id_map)) {
+        ThrowInfo(ErrorCode::UnexpectedError,
+                  "failed to get vector, nullable vector index contains no "
+                  "valid vectors");
     }
 
     auto res = index_.GetVectorByIds(dataset);
@@ -880,12 +930,7 @@ VectorDiskAnnIndex<T>::GetEmbListByIds(const DatasetPtr dataset,
         auto rows = dataset->GetRows();
         auto emb_list_count =
             static_cast<int64_t>(empty_emb_list_offsets_.size()) - 1;
-        for (int64_t i = 0; i < rows; ++i) {
-            AssertInfo(ids[i] >= 0 && ids[i] < emb_list_count,
-                       "emb list id {} out of range {}",
-                       ids[i],
-                       emb_list_count);
-        }
+        CheckEmptyEmbListIds(ids, rows, emb_list_count);
         return {{}, std::vector<size_t>(rows + 1, 0)};
     }
 

--- a/internal/core/src/index/VectorDiskIndex.h
+++ b/internal/core/src/index/VectorDiskIndex.h
@@ -52,8 +52,7 @@ class VectorDiskAnnIndex : public VectorIndex {
 
     int64_t
     Count() override {
-        const auto& offset_mapping = GetOffsetMapping();
-        if (offset_mapping.IsEnabled() && offset_mapping.GetValidCount() == 0) {
+        if (HasValidData() && GetValidCount() == 0) {
             return 0;
         }
         if (IsEmptyEmbListIndex()) {
@@ -118,6 +117,21 @@ class VectorDiskAnnIndex : public VectorIndex {
                     const knowhere::Json& json,
                     const BitsetView& bitset,
                     milvus::OpContext* op_context = nullptr) const override;
+
+    knowhere::IdMap&
+    GetIdMap() override {
+        return index_.GetIdMap();
+    }
+
+    const knowhere::IdMap&
+    GetIdMap() const override {
+        return index_.GetIdMap();
+    }
+
+    void
+    SetIdMapType(knowhere::IdMap::Type type) override {
+        index_.SetIdMapType(type);
+    }
 
  private:
     bool

--- a/internal/core/src/index/VectorIndex.h
+++ b/internal/core/src/index/VectorIndex.h
@@ -26,13 +26,11 @@
 
 #include "Utils.h"
 #include "knowhere/comp/index_param.h"
+#include "knowhere/id_map.h"
 #include "knowhere/index/index_factory.h"
 #include "index/Index.h"
 #include "common/Types.h"
 #include "common/BitsetView.h"
-#include "common/OffsetMapping.h"
-#include "common/GrowingOffsetMapping.h"
-#include "common/SealedOffsetMapping.h"
 #include "common/QueryResult.h"
 #include "common/QueryInfo.h"
 #include "common/OpContext.h"
@@ -49,9 +47,7 @@ class VectorIndex : public IndexBase {
  public:
     explicit VectorIndex(const IndexType& index_type,
                          const MetricType& metric_type)
-        : IndexBase(index_type),
-          offset_mapping_(std::make_unique<milvus::GrowingOffsetMapping>()),
-          metric_type_(metric_type) {
+        : IndexBase(index_type), metric_type_(metric_type) {
     }
 
  public:
@@ -91,6 +87,17 @@ class VectorIndex : public IndexBase {
 
     virtual bool
     IsIndexRefineEnabled() const = 0;
+
+    virtual knowhere::IdMap&
+    GetIdMap() = 0;
+
+    virtual const knowhere::IdMap&
+    GetIdMap() const = 0;
+
+    virtual void
+    SetIdMapType(knowhere::IdMap::Type type) {
+        GetIdMap().SetType(type);
+    }
 
     virtual knowhere::expected<knowhere::DataSetPtr>
     CalcDistByIDs(const knowhere::DataSetPtr query_dataset,
@@ -189,58 +196,56 @@ class VectorIndex : public IndexBase {
         return search_cfg;
     }
 
-    void
-    UpdateValidData(const bool* valid_data, int64_t count) {
-        auto* growing_mapping =
-            dynamic_cast<milvus::GrowingOffsetMapping*>(offset_mapping_.get());
-        AssertInfo(growing_mapping != nullptr,
-                   "cannot update growing valid data from sealed mapping");
-        growing_mapping->Append(valid_data, count);
-    }
-
-    void
-    BuildValidData(const bool* valid_data,
-                   int64_t total_count,
-                   const milvus::OffsetMappingBuildOptions& options = {}) {
-        auto sealed_mapping = std::make_unique<milvus::SealedOffsetMapping>();
-        sealed_mapping->Build(valid_data, total_count, options);
-        offset_mapping_ = std::move(sealed_mapping);
-    }
-
+    // Indexed nullable mapping is owned by Knowhere IdMap. Milvus only exposes
+    // logical-row helpers here; raw column physical mapping stays in OffsetMapping.
     bool
     IsRowValid(int64_t logical_offset) const {
-        if (!offset_mapping_->IsEnabled()) {
+        const auto& id_map = GetIdMap();
+        if (id_map.ValidBitmap().empty()) {
             return true;
         }
-        return offset_mapping_->IsValid(logical_offset);
+        return id_map.IsValidOutId(logical_offset);
     }
 
     bool
     HasValidData() const {
-        return offset_mapping_->IsEnabled();
+        return !GetIdMap().ValidBitmap().empty();
     }
 
     int64_t
     GetValidCount() const {
-        return offset_mapping_->GetValidCount();
-    }
-
-    int64_t
-    GetPhysicalOffset(int64_t logical_offset) const {
-        return offset_mapping_->GetPhysicalOffset(logical_offset);
-    }
-
-    int64_t
-    GetLogicalOffset(int64_t physical_offset) const {
-        return offset_mapping_->GetLogicalOffset(physical_offset);
-    }
-
-    const milvus::OffsetMapping&
-    GetOffsetMapping() const {
-        return *offset_mapping_;
+        return static_cast<int64_t>(GetIdMap().InCount());
     }
 
  protected:
+    void
+    CheckEmptyEmbListIds(const int64_t* ids,
+                         int64_t rows,
+                         int64_t fallback_list_count) const {
+        AssertInfo(rows >= 0, "emb list ids row count is negative");
+        if (rows == 0) {
+            return;
+        }
+        AssertInfo(ids != nullptr, "emb list ids are null");
+
+        const auto& id_map = GetIdMap();
+        const bool has_valid_data = !id_map.ValidBitmap().empty();
+        const auto logical_count = has_valid_data
+                                       ? static_cast<int64_t>(id_map.OutCount())
+                                       : fallback_list_count;
+        for (int64_t i = 0; i < rows; ++i) {
+            const auto id = ids[i];
+            AssertInfo(id >= 0 && id < logical_count,
+                       "emb list id {} out of range {}",
+                       id,
+                       logical_count);
+            if (has_valid_data) {
+                AssertInfo(
+                    id_map.IsValidOutId(id), "emb list id {} is null", id);
+            }
+        }
+    }
+
     template <typename T>
     static std::vector<uint8_t>
     DecodeVectorByIdsResult(const knowhere::DataSetPtr& result) {
@@ -274,8 +279,6 @@ class VectorIndex : public IndexBase {
         std::vector<size_t> offsets(offsets_ptr, offsets_ptr + num_el_ids + 1);
         return {std::move(raw_data), std::move(offsets)};
     }
-
-    std::unique_ptr<milvus::OffsetMapping> offset_mapping_;
 
  private:
     MetricType metric_type_;

--- a/internal/core/src/index/VectorIndexValidDataUtils.h
+++ b/internal/core/src/index/VectorIndexValidDataUtils.h
@@ -28,10 +28,12 @@
 
 #include "common/EasyAssert.h"
 #include "common/FastMem.h"
-#include "common/OffsetMapping.h"
+#include "common/Utils.h"
 #include "index/Meta.h"
 #include "index/Utils.h"
 #include "index/VectorIndex.h"
+#include "knowhere/id_map.h"
+#include "knowhere/index/index_node.h"
 
 namespace milvus::index {
 
@@ -94,19 +96,9 @@ ContainsOnlyValidData(const BinarySet& binary_set) {
     return true;
 }
 
-inline bool
-IsAllNullNullable(const OffsetMapping& offset_mapping) {
-    return offset_mapping.IsEnabled() && offset_mapping.GetValidCount() == 0;
-}
-
 inline size_t
 GetValidDataBitmapSize(size_t count) {
     return (count + 7) / 8;
-}
-
-inline uint64_t
-ToValidDataCount(size_t count) {
-    return static_cast<uint64_t>(count);
 }
 
 inline size_t
@@ -116,82 +108,198 @@ FromValidDataCount(uint64_t count) {
     return static_cast<size_t>(count);
 }
 
-inline size_t
-CountValidDataBitmap(size_t count, const uint8_t* bitmap) {
-    size_t valid_count = 0;
-    for (size_t i = 0; i < count; ++i) {
-        if ((bitmap[i / 8] >> (i % 8)) & 1) {
-            ++valid_count;
-        }
-    }
-    return valid_count;
-}
-
-inline constexpr const char* OFFSET_MAPPING_MMAP_DIR = "id_mapping_mmap";
-
-inline std::string
-GetOffsetMappingMmapDir(const std::string& local_index_path_prefix) {
-    return (std::filesystem::path(local_index_path_prefix) /
-            OFFSET_MAPPING_MMAP_DIR)
-        .string();
-}
-
 inline bool
-NeedOffsetMappingMmap(const OffsetMappingBuildOptions& options,
-                      size_t total_count,
-                      size_t valid_count) {
-    return (options.enable_mmap_o2i_map && total_count > 0) ||
-           (options.enable_mmap_i2o_map && valid_count > 0);
+IsAllNullNullable(const knowhere::IdMap& id_map) {
+    return !id_map.ValidBitmap().empty() && id_map.InCount() == 0;
 }
 
-inline OffsetMappingBuildOptions
-GetOffsetMappingMmapOptions(const Config& config) {
-    OffsetMappingBuildOptions options;
-    options.enable_mmap_i2o_map =
+struct ValidDataView {
+    bool found = false;
+    size_t count = 0;
+    const uint8_t* bitmap = nullptr;
+};
+
+struct OwnedValidData {
+    bool found = false;
+    size_t count = 0;
+    std::vector<uint8_t> bitmap;
+
+    ValidDataView
+    View() const {
+        return {found, count, bitmap.data()};
+    }
+};
+
+inline knowhere::IdMapData
+MakeIdMapData(const ValidDataView& valid_data) {
+    AssertInfo(valid_data.found, "nullable vector valid_data is empty");
+    return knowhere::IdMapData::FromValidBitmap(valid_data.bitmap,
+                                                valid_data.count);
+}
+
+struct RestoredIdMap {
+    bool has_valid_data = false;
+    bool all_null_nullable = false;
+
+    bool
+    IsAllNullNullable() const {
+        return has_valid_data && all_null_nullable;
+    }
+};
+
+inline DatasetPtr
+GenIdMapDataset(int64_t rows,
+                int64_t dim,
+                const knowhere::IdMapData& id_map_data,
+                bool is_sparse = false) {
+    auto dataset = GenDataset(rows, dim, nullptr);
+    dataset->SetIdMapData(id_map_data);
+    if (is_sparse) {
+        dataset->SetIsSparse(true);
+    }
+    return dataset;
+}
+
+inline DatasetPtr
+GenIdMapDataset(int64_t rows,
+                int64_t dim,
+                const ValidDataView& valid_data,
+                bool is_sparse = false) {
+    auto id_map_data = MakeIdMapData(valid_data);
+    return GenIdMapDataset(rows, dim, id_map_data, is_sparse);
+}
+
+struct IdMapOnlyBuildPlan {
+    bool enabled = false;
+    bool empty_embedding_list = false;
+};
+
+inline IdMapOnlyBuildPlan
+GetIdMapOnlyBuildPlan(const DatasetPtr& dataset, bool is_embedding_list) {
+    AssertInfo(dataset != nullptr, "dataset is null");
+    if (milvus::GetDatasetRows(dataset) != 0) {
+        return {};
+    }
+    if (is_embedding_list) {
+        AssertInfo(dataset->HasIdMapData(),
+                   "empty embedding list dataset must provide id map data");
+        return {true, true};
+    }
+    return {dataset->HasIdMapData(), false};
+}
+
+inline int64_t
+ResolveDatasetOrConfigDim(const DatasetPtr& dataset,
+                          const Config& config,
+                          const char* context) {
+    auto dim = dataset == nullptr ? 0 : dataset->GetDim();
+    if (dim > 0) {
+        return dim;
+    }
+    auto config_dim = GetValueFromConfig<int64_t>(config, DIM_KEY);
+    AssertInfo(config_dim.has_value() && config_dim.value() > 0,
+               "dim is missing when {}",
+               context);
+    return config_dim.value();
+}
+
+inline constexpr const char* ID_MAP_MMAP_DIR = "id_mapping_mmap";
+
+inline void
+ConfigureIdMapMmap(knowhere::IdMap& id_map,
+                   const Config& config,
+                   const std::string& local_index_path_prefix) {
+    knowhere::IdMapMmapOptions options;
+    options.enable_in_to_out_ids =
         GetValueFromConfig<bool>(config, ENABLE_MMAP_I2O_MAP).value_or(false);
-    options.enable_mmap_o2i_map =
+    options.enable_out_to_in_ids =
         GetValueFromConfig<bool>(config, ENABLE_MMAP_O2I_MAP).value_or(false);
-    return options;
+    options.mmap_dir_path =
+        (std::filesystem::path(local_index_path_prefix) / ID_MAP_MMAP_DIR)
+            .string();
+    if (options.enable_in_to_out_ids || options.enable_out_to_in_ids) {
+        if (!id_map.IsEnabled()) {
+            id_map.SetType(knowhere::IdMap::Type::SEALED);
+        }
+        AssertInfo(id_map.type() == knowhere::IdMap::Type::SEALED,
+                   "nullable vector id map mmap requires sealed storage");
+        // Mmap applies only to derived dense id arrays. The validity bitmap
+        // stays heap-backed and is consumed once by AddFromData.
+        id_map.ConfigureMmap(std::move(options));
+    }
+}
+
+inline void
+ConfigureIdMapMmapForDataset(knowhere::IdMap& id_map,
+                             const DatasetPtr& dataset,
+                             const Config& config,
+                             const std::string& local_index_path_prefix) {
+    if (dataset == nullptr || !dataset->HasIdMapData()) {
+        return;
+    }
+    ConfigureIdMapMmap(id_map, config, local_index_path_prefix);
+}
+
+inline DatasetPtr
+GenIdMapDatasetFromValidData(knowhere::IdMap& id_map,
+                             int64_t rows,
+                             int64_t dim,
+                             const ValidDataView& valid_data,
+                             const Config& config,
+                             const std::string& local_index_path_prefix,
+                             bool is_sparse = false) {
+    if (!valid_data.found) {
+        return nullptr;
+    }
+    if (!id_map.IsEnabled()) {
+        id_map.SetType(knowhere::IdMap::Type::SEALED);
+    }
+    AssertInfo(id_map.type() == knowhere::IdMap::Type::SEALED,
+               "nullable sealed vector index requires sealed id map storage");
+    ConfigureIdMapMmap(id_map, config, local_index_path_prefix);
+    return GenIdMapDataset(rows, dim, valid_data, is_sparse);
+}
+
+inline void
+FinalizeRestoredIdMap(knowhere::IndexNode* index_node,
+                      ErrorCode error_code,
+                      const std::string& context) {
+    AssertInfo(index_node != nullptr, "index node is null");
+    auto stat = index_node->FinalizeIdMap();
+    if (stat != knowhere::Status::success) {
+        ThrowInfo(error_code,
+                  "failed to finalize id map for {}, {}",
+                  context,
+                  KnowhereStatusString(stat));
+    }
 }
 
 inline std::vector<uint8_t>
-PackValidDataBitmap(const OffsetMapping& offset_mapping) {
-    auto count = static_cast<size_t>(offset_mapping.GetTotalCount());
-    std::vector<uint8_t> data(GetValidDataBitmapSize(count), 0);
-    for (size_t i = 0; i < count; ++i) {
-        if (offset_mapping.IsValid(i)) {
-            data[i / 8] |= (1 << (i % 8));
-        }
+PackValidDataBitmap(const knowhere::IdMap& id_map) {
+    const auto& valid_bitmap = id_map.ValidBitmap();
+    if (valid_bitmap.empty()) {
+        return {};
     }
+    const auto bytes = GetValidDataBitmapSize(valid_bitmap.size());
+    std::vector<uint8_t> data(bytes, 0);
+    milvus::fastmem::FastMemcpy(data.data(), valid_bitmap.data(), bytes);
     return data;
 }
 
 inline void
-BuildValidDataFromBitmap(VectorIndex* vector_index,
-                         size_t count,
-                         const uint8_t* bitmap,
-                         const OffsetMappingBuildOptions& options = {}) {
-    std::unique_ptr<bool[]> valid_data(new bool[count]);
-    for (size_t i = 0; i < count; ++i) {
-        valid_data[i] = (bitmap[i / 8] >> (i % 8)) & 1;
-    }
-    vector_index->BuildValidData(valid_data.get(), count, options);
-}
-
-inline void
-AppendValidDataToBinarySet(const OffsetMapping& offset_mapping,
+AppendValidDataToBinarySet(const knowhere::IdMap& id_map,
                            BinarySet& binary_set) {
-    if (!offset_mapping.IsEnabled()) {
+    if (id_map.ValidBitmap().empty()) {
         return;
     }
 
-    auto count = static_cast<size_t>(offset_mapping.GetTotalCount());
-    auto wire_count = ToValidDataCount(count);
+    auto count = static_cast<size_t>(id_map.ValidBitmap().size());
+    auto wire_count = static_cast<uint64_t>(count);
     std::shared_ptr<uint8_t[]> count_buf(new uint8_t[sizeof(uint64_t)]);
     milvus::fastmem::FastMemcpy(count_buf.get(), &wire_count, sizeof(uint64_t));
     binary_set.Append(VALID_DATA_COUNT_KEY, count_buf, sizeof(uint64_t));
 
-    auto packed_data = PackValidDataBitmap(offset_mapping);
+    auto packed_data = PackValidDataBitmap(id_map);
     std::shared_ptr<uint8_t[]> data(new uint8_t[packed_data.size()]);
     if (!packed_data.empty()) {
         milvus::fastmem::FastMemcpy(
@@ -200,33 +308,82 @@ AppendValidDataToBinarySet(const OffsetMapping& offset_mapping,
     binary_set.Append(VALID_DATA_KEY, data, packed_data.size());
 }
 
-inline bool
-LoadValidDataFromBinarySet(const BinarySet& binary_set,
-                           VectorIndex* vector_index,
-                           const OffsetMappingBuildOptions& options = {}) {
+inline ValidDataView
+LoadValidDataViewFromPayload(const uint8_t* count_data,
+                             int64_t count_size,
+                             const uint8_t* bitmap_data,
+                             int64_t bitmap_size) {
+    AssertInfo(count_data != nullptr &&
+                   count_size == static_cast<int64_t>(sizeof(uint64_t)),
+               "nullable vector index valid_data count file is invalid");
+    uint64_t wire_count = 0;
+    milvus::fastmem::FastMemcpy(&wire_count, count_data, sizeof(uint64_t));
+    auto count = FromValidDataCount(wire_count);
+
+    const auto expected_bitmap_size =
+        static_cast<int64_t>(GetValidDataBitmapSize(count));
+    AssertInfo((bitmap_data != nullptr || expected_bitmap_size == 0) &&
+                   bitmap_size >= expected_bitmap_size,
+               "nullable vector index valid_data bitmap file is invalid");
+    return {true, count, bitmap_data};
+}
+
+inline RestoredIdMap
+RestoreIdMapFromValidData(knowhere::IdMap& id_map,
+                          const ValidDataView& valid_data,
+                          const Config* mmap_config = nullptr,
+                          const std::string& mmap_path_prefix = {}) {
+    if (!valid_data.found) {
+        return {};
+    }
+    if (!id_map.IsEnabled()) {
+        id_map.SetType(knowhere::IdMap::Type::SEALED);
+    }
+    AssertInfo(id_map.type() == knowhere::IdMap::Type::SEALED,
+               "nullable sealed vector index requires sealed id map storage");
+    if (mmap_config != nullptr) {
+        ConfigureIdMapMmap(id_map, *mmap_config, mmap_path_prefix);
+    }
+    id_map.AddFromData(MakeIdMapData(valid_data));
+    return {true, IsAllNullNullable(id_map)};
+}
+
+inline RestoredIdMap
+RestoreIdMapFromValidDataPayload(knowhere::IdMap& id_map,
+                                 const uint8_t* count_data,
+                                 int64_t count_size,
+                                 const uint8_t* bitmap_data,
+                                 int64_t bitmap_size,
+                                 const Config* mmap_config = nullptr,
+                                 const std::string& mmap_path_prefix = {}) {
+    return RestoreIdMapFromValidData(
+        id_map,
+        LoadValidDataViewFromPayload(
+            count_data, count_size, bitmap_data, bitmap_size),
+        mmap_config,
+        mmap_path_prefix);
+}
+
+inline RestoredIdMap
+RestoreIdMapFromBinarySet(const BinarySet& binary_set,
+                          knowhere::IdMap& id_map) {
     bool has_count = binary_set.Contains(VALID_DATA_COUNT_KEY);
     bool has_data = binary_set.Contains(VALID_DATA_KEY);
     if (!has_count && !has_data) {
-        return false;
+        return {};
     }
     AssertInfo(has_count && has_data,
                "nullable vector index valid_data files are incomplete");
 
     auto count_ptr = binary_set.GetByName(VALID_DATA_COUNT_KEY);
-    AssertInfo(count_ptr != nullptr && count_ptr->size == sizeof(uint64_t),
-               "nullable vector index valid_data count file is invalid");
-    uint64_t wire_count = 0;
-    milvus::fastmem::FastMemcpy(
-        &wire_count, count_ptr->data.get(), sizeof(uint64_t));
-    auto count = FromValidDataCount(wire_count);
-
     auto data_ptr = binary_set.GetByName(VALID_DATA_KEY);
-    AssertInfo(
-        data_ptr != nullptr && data_ptr->size >= GetValidDataBitmapSize(count),
-        "nullable vector index valid_data bitmap file is invalid");
-    BuildValidDataFromBitmap(
-        vector_index, count, data_ptr->data.get(), options);
-    return true;
+    AssertInfo(count_ptr != nullptr && data_ptr != nullptr,
+               "nullable vector index valid_data files are incomplete");
+    return RestoreIdMapFromValidDataPayload(id_map,
+                                            count_ptr->data.get(),
+                                            count_ptr->size,
+                                            data_ptr->data.get(),
+                                            data_ptr->size);
 }
 
 }  // namespace milvus::index

--- a/internal/core/src/index/VectorMemIndex.cpp
+++ b/internal/core/src/index/VectorMemIndex.cpp
@@ -45,7 +45,6 @@
 #include "common/FieldData.h"
 #include "common/FieldDataInterface.h"
 #include "common/File.h"
-#include "common/OffsetMapping.h"
 #include "common/QueryInfo.h"
 #include "common/QueryResult.h"
 #include "common/RangeSearchHelper.h"
@@ -142,7 +141,7 @@ AppendEmptyEmbListOffsetsToBinarySet(int64_t dim,
         return;
     }
 
-    auto count = ToValidDataCount(offsets.size());
+    auto count = static_cast<uint64_t>(offsets.size());
     auto bytes =
         sizeof(int64_t) + sizeof(uint64_t) + offsets.size() * sizeof(size_t);
     std::shared_ptr<uint8_t[]> data(new uint8_t[bytes]);
@@ -246,8 +245,8 @@ VectorMemIndex<T>::VectorIterators(const milvus::DatasetPtr dataset,
         return iterators;
     };
 
-    const auto& offset_mapping = GetOffsetMapping();
-    if (IsAllNullNullable(offset_mapping)) {
+    const auto& id_map = GetIdMap();
+    if (IsAllNullNullable(id_map)) {
         auto offsets =
             dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
         auto num_queries = dataset->GetRows();
@@ -304,8 +303,8 @@ template <typename T>
 BinarySet
 VectorMemIndex<T>::Serialize(const Config& config) {
     knowhere::BinarySet ret;
-    const auto& offset_mapping = GetOffsetMapping();
-    bool all_null_nullable = IsAllNullNullable(offset_mapping);
+    const auto& id_map = GetIdMap();
+    bool all_null_nullable = IsAllNullNullable(id_map);
     if (IsEmptyEmbListIndex()) {
         AppendEmptyEmbListOffsetsToBinarySet(
             GetDim(), empty_emb_list_offsets_, ret);
@@ -317,7 +316,7 @@ VectorMemIndex<T>::Serialize(const Config& config) {
                       KnowhereStatusString(stat));
     }
 
-    AppendValidDataToBinarySet(offset_mapping, ret);
+    AppendValidDataToBinarySet(id_map, ret);
     Disassemble(ret);
 
     return ret;
@@ -327,14 +326,25 @@ template <typename T>
 void
 VectorMemIndex<T>::LoadWithoutAssemble(const BinarySet& binary_set,
                                        const Config& config) {
+    const auto restored_id_map =
+        RestoreIdMapFromBinarySet(binary_set, index_.GetIdMap());
     auto empty_emb_list_state =
         LoadEmptyEmbListOffsetsFromBinarySet(binary_set);
     if (empty_emb_list_state.has_value()) {
         SetDim(empty_emb_list_state->dim);
         empty_emb_list_offsets_ = std::move(empty_emb_list_state->offsets);
+        if (restored_id_map.has_valid_data) {
+            FinalizeRestoredIdMap(index_.Node(),
+                                  ErrorCode::UnexpectedError,
+                                  "empty emb-list load");
+        }
     } else if (ContainsOnlyValidData(binary_set)) {
         if (config.contains(DIM_KEY)) {
             SetDim(GetDimFromConfig(config));
+        }
+        if (restored_id_map.has_valid_data) {
+            FinalizeRestoredIdMap(
+                index_.Node(), ErrorCode::UnexpectedError, "all-null load");
         }
     } else {
         auto stat = index_.Deserialize(binary_set, config);
@@ -342,10 +352,9 @@ VectorMemIndex<T>::LoadWithoutAssemble(const BinarySet& binary_set,
             ThrowInfo(ErrorCode::UnexpectedError,
                       "failed to Deserialize index: {}",
                       KnowhereStatusString(stat));
-        SetDim(index_.Dim());
+        auto dim = index_.Dim();
+        SetDim(dim > 0 ? dim : GetDim());
     }
-
-    LoadValidDataFromBinarySet(binary_set, this);
 }
 
 template <typename T>
@@ -491,7 +500,16 @@ VectorMemIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
     knowhere::Json index_config;
     index_config.update(config);
 
+    if (dataset != nullptr && dataset->HasIdMapData() &&
+        !index_.GetIdMap().IsEnabled()) {
+        index_.GetIdMap().SetType(knowhere::IdMap::Type::SEALED);
+    }
     SetDim(dataset->GetDim());
+    const auto id_map_only_build =
+        GetIdMapOnlyBuildPlan(dataset, elem_type_ != DataType::NONE);
+    if (id_map_only_build.empty_embedding_list) {
+        empty_emb_list_offsets_ = {0};
+    }
 
     knowhere::TimeRecorder rc("BuildWithoutIds", 1);
     LOG_INFO("start build memory index with KNOWHERE, build_id: {}",
@@ -504,7 +522,11 @@ VectorMemIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
     rc.ElapseFromBegin("Done");
     LOG_INFO("build memory index with KNOWHERE done, build_id: {}",
              config.value("build_id", "unknown"));
-    SetDim(index_.Dim());
+    if (id_map_only_build.enabled) {
+        return;
+    }
+    auto dim = index_.Dim();
+    SetDim(dim > 0 ? dim : dataset->GetDim());
 }
 
 template <typename T>
@@ -557,6 +579,20 @@ VectorMemIndex<T>::Build(const Config& config) {
             chunk_offset += rows;
         }
     }
+    auto make_dataset = [&](int64_t rows,
+                            int64_t dim,
+                            const void* tensor,
+                            bool is_sparse = false) {
+        auto dataset = GenDataset(rows, dim, tensor);
+        if (is_sparse) {
+            dataset->SetIsSparse(true);
+        }
+        if (nullable) {
+            dataset->SetIdMapData(knowhere::IdMapData::FromValidData(
+                valid_data.get(), static_cast<size_t>(total_num_rows)));
+        }
+        return dataset;
+    };
 
     if (!IndexIsSparse(GetIndexType())) {
         int64_t dim = 0;
@@ -572,8 +608,8 @@ VectorMemIndex<T>::Build(const Config& config) {
             }
         }
         if (nullable && total_valid_rows == 0) {
-            SetDim(dim);
-            BuildValidData(valid_data.get(), total_num_rows);
+            auto dataset = make_dataset(0, dim, nullptr);
+            BuildWithDataset(dataset, build_config);
             return;
         }
         auto buf = std::shared_ptr<uint8_t[]>(new uint8_t[total_size]);
@@ -633,12 +669,14 @@ VectorMemIndex<T>::Build(const Config& config) {
                 data.reset();
             }
 
-            total_valid_rows = lim_offset;
-            if (lim_offset == 0) {
-                SetDim(dim);
-                empty_emb_list_offsets_ = std::move(offsets);
+            const auto total_vectors = static_cast<int64_t>(lim_offset);
+            if (total_vectors == 0) {
                 if (nullable) {
-                    BuildValidData(valid_data.get(), total_num_rows);
+                    auto dataset = make_dataset(0, dim, nullptr);
+                    BuildWithDataset(dataset, build_config);
+                } else {
+                    empty_emb_list_offsets_ = std::move(offsets);
+                    SetDim(dim);
                 }
                 return;
             }
@@ -646,7 +684,10 @@ VectorMemIndex<T>::Build(const Config& config) {
 
         field_datas.clear();
 
-        auto dataset = GenDataset(total_valid_rows, dim, buf.get());
+        auto rows = elem_type_ == DataType::NONE
+                        ? total_valid_rows
+                        : static_cast<int64_t>(lim_offset);
+        auto dataset = make_dataset(rows, dim, buf.get());
         if (!scalar_info.empty()) {
             dataset->Set(knowhere::meta::SCALAR_INFO, std::move(scalar_info));
         }
@@ -655,9 +696,6 @@ VectorMemIndex<T>::Build(const Config& config) {
                          const_cast<const size_t*>(offsets.data()));
         }
         BuildWithDataset(dataset, build_config);
-        if (nullable) {
-            BuildValidData(valid_data.get(), total_num_rows);
-        }
     } else {
         // sparse
         int64_t dim = 0;
@@ -669,8 +707,8 @@ VectorMemIndex<T>::Build(const Config& config) {
                     ->Dim());
         }
         if (nullable && total_valid_rows == 0) {
-            SetDim(dim);
-            BuildValidData(valid_data.get(), total_num_rows);
+            auto dataset = make_dataset(0, dim, nullptr, true);
+            BuildWithDataset(dataset, build_config);
             return;
         }
         std::vector<knowhere::sparse::SparseRow<SparseValueType>> vec(
@@ -690,15 +728,11 @@ VectorMemIndex<T>::Build(const Config& config) {
             }
             offset += field_data->get_valid_rows();
         }
-        auto dataset = GenDataset(total_valid_rows, dim, vec.data());
-        dataset->SetIsSparse(true);
+        auto dataset = make_dataset(total_valid_rows, dim, vec.data(), true);
         if (!scalar_info.empty()) {
             dataset->Set(knowhere::meta::SCALAR_INFO, std::move(scalar_info));
         }
         BuildWithDataset(dataset, build_config);
-        if (nullable) {
-            BuildValidData(valid_data.get(), total_num_rows);
-        }
     }
 }
 
@@ -731,8 +765,8 @@ VectorMemIndex<T>::Query(const DatasetPtr dataset,
     auto num_vectors = dataset->GetRows();
     knowhere::Json search_conf = PrepareSearchParams(search_info);
     auto topk = search_info.topk_;
-    const auto& offset_mapping = GetOffsetMapping();
-    if (IsAllNullNullable(offset_mapping) || IsEmptyEmbListIndex()) {
+    const auto& id_map = GetIdMap();
+    if (IsAllNullNullable(id_map) || IsEmptyEmbListIndex()) {
         auto offsets =
             dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
         auto num_queries = dataset->GetRows();
@@ -823,8 +857,8 @@ VectorMemIndex<T>::Query(const DatasetPtr dataset,
 template <typename T>
 const bool
 VectorMemIndex<T>::HasRawData() const {
-    const auto& offset_mapping = GetOffsetMapping();
-    if (IsAllNullNullable(offset_mapping) || IsEmptyEmbListIndex()) {
+    const auto& id_map = GetIdMap();
+    if (IsAllNullNullable(id_map) || IsEmptyEmbListIndex()) {
         return true;
     }
     return index_.HasRawData(GetMetricType());
@@ -833,8 +867,8 @@ VectorMemIndex<T>::HasRawData() const {
 template <typename T>
 bool
 VectorMemIndex<T>::IsIndexRefineEnabled() const {
-    const auto& offset_mapping = GetOffsetMapping();
-    if (IsAllNullNullable(offset_mapping) || IsEmptyEmbListIndex()) {
+    const auto& id_map = GetIdMap();
+    if (IsAllNullNullable(id_map) || IsEmptyEmbListIndex()) {
         return false;
     }
     return index_.IsIndexRefineEnabled();
@@ -852,6 +886,13 @@ VectorMemIndex<T>::GetVector(const DatasetPtr dataset) const {
     // if dataset is empty, return empty vector
     if (dataset->GetRows() == 0) {
         return {};
+    }
+
+    const auto& id_map = GetIdMap();
+    if (IsAllNullNullable(id_map)) {
+        ThrowInfo(ErrorCode::UnexpectedError,
+                  "failed to get vector, nullable vector index contains no "
+                  "valid vectors");
     }
 
     auto res = index_.GetVectorByIds(dataset);
@@ -875,12 +916,7 @@ VectorMemIndex<T>::GetEmbListByIds(const DatasetPtr dataset,
         auto rows = dataset->GetRows();
         auto emb_list_count =
             static_cast<int64_t>(empty_emb_list_offsets_.size()) - 1;
-        for (int64_t i = 0; i < rows; ++i) {
-            AssertInfo(ids[i] >= 0 && ids[i] < emb_list_count,
-                       "emb list id {} out of range {}",
-                       ids[i],
-                       emb_list_count);
-        }
+        CheckEmptyEmbListIds(ids, rows, emb_list_count);
         return {{}, std::vector<size_t>(rows + 1, 0)};
     }
 
@@ -898,6 +934,13 @@ std::unique_ptr<const knowhere::sparse::SparseRow<SparseValueType>[]>
 VectorMemIndex<T>::GetSparseVector(const DatasetPtr dataset) const {
     if (dataset->GetRows() == 0) {
         return nullptr;
+    }
+
+    const auto& id_map = GetIdMap();
+    if (IsAllNullNullable(id_map)) {
+        ThrowInfo(ErrorCode::UnexpectedError,
+                  "failed to get vector, nullable vector index contains no "
+                  "valid vectors");
     }
 
     auto res = index_.GetVectorByIds(dataset);
@@ -1132,6 +1175,25 @@ VectorMemIndex<T>::LoadFromFile(const Config& config) {
                 embedding_list_raw_index_path.value();
         }
     }
+    auto restore_id_map = [&]() -> RestoredIdMap {
+        if (!valid_data_count_codec && !valid_data_codec) {
+            return {};
+        }
+        AssertInfo(valid_data_count_codec && valid_data_codec,
+                   "nullable vector index valid_data files are incomplete");
+        return RestoreIdMapFromValidDataPayload(
+            index_.GetIdMap(),
+            valid_data_count_codec->PayloadData(),
+            valid_data_count_codec->PayloadSize(),
+            valid_data_codec->PayloadData(),
+            valid_data_codec->PayloadSize(),
+            &conf,
+            std::filesystem::path(local_filepath.value())
+                .parent_path()
+                .string());
+    };
+    const auto restored_id_map = restore_id_map();
+
     auto start_deserialize = std::chrono::system_clock::now();
     std::chrono::duration<double> deserialize_duration{};
     if (wrote_index_data) {
@@ -1152,6 +1214,11 @@ VectorMemIndex<T>::LoadFromFile(const Config& config) {
             static_cast<size_t>(empty_emb_list_offsets_codec->PayloadSize()));
         this->SetDim(empty_emb_list_state.dim);
         empty_emb_list_offsets_ = std::move(empty_emb_list_state.offsets);
+        if (restored_id_map.has_valid_data) {
+            FinalizeRestoredIdMap(index_.Node(),
+                                  ErrorCode::UnexpectedError,
+                                  "empty emb-list mmap load");
+        }
     } else {
         LOG_INFO("load all-null nullable vector index valid data only...");
         AssertInfo(valid_data_count_codec && valid_data_codec,
@@ -1159,25 +1226,16 @@ VectorMemIndex<T>::LoadFromFile(const Config& config) {
         if (conf.contains(DIM_KEY)) {
             this->SetDim(GetDimFromConfig(conf));
         }
+        if (restored_id_map.has_valid_data) {
+            FinalizeRestoredIdMap(index_.Node(),
+                                  ErrorCode::UnexpectedError,
+                                  "all-null mmap load");
+        }
     }
     milvus::monitor::internal_storage_deserialize_duration.Observe(
         std::chrono::duration_cast<std::chrono::milliseconds>(
             deserialize_duration)
             .count());
-
-    // Restore valid_data for nullable vector support
-    if (valid_data_count_codec && valid_data_codec) {
-        size_t count;
-        milvus::fastmem::FastMemcpy(
-            &count, valid_data_count_codec->PayloadData(), sizeof(size_t));
-
-        std::unique_ptr<bool[]> valid_data(new bool[count]);
-        auto bitmap = valid_data_codec->PayloadData();
-        for (size_t i = 0; i < count; ++i) {
-            valid_data[i] = (bitmap[i / 8] >> (i % 8)) & 1;
-        }
-        BuildValidData(valid_data.get(), count);
-    }
 
     this->mmap_file_raii_ =
         std::make_unique<MmapFileRAII>(local_filepath.value());

--- a/internal/core/src/index/VectorMemIndex.h
+++ b/internal/core/src/index/VectorMemIndex.h
@@ -84,8 +84,7 @@ class VectorMemIndex : public VectorIndex {
 
     int64_t
     Count() override {
-        const auto& offset_mapping = GetOffsetMapping();
-        if (offset_mapping.IsEnabled() && offset_mapping.GetValidCount() == 0) {
+        if (HasValidData() && GetValidCount() == 0) {
             return 0;
         }
         if (IsEmptyEmbListIndex()) {
@@ -133,6 +132,21 @@ class VectorMemIndex : public VectorIndex {
                   size_t labels_len,
                   bool is_cosine,
                   milvus::OpContext* op_context = nullptr) const override;
+
+    knowhere::IdMap&
+    GetIdMap() override {
+        return index_.GetIdMap();
+    }
+
+    const knowhere::IdMap&
+    GetIdMap() const override {
+        return index_.GetIdMap();
+    }
+
+    void
+    SetIdMapType(knowhere::IdMap::Type type) override {
+        index_.SetIdMapType(type);
+    }
 
  protected:
     virtual void

--- a/internal/core/src/indexbuilder/VecIndexCreator.cpp
+++ b/internal/core/src/indexbuilder/VecIndexCreator.cpp
@@ -17,6 +17,7 @@
 #include "index/Utils.h"
 #include "index/VectorIndex.h"
 #include "indexbuilder/VecIndexCreator.h"
+#include "knowhere/dataset.h"
 #include "nlohmann/json.hpp"
 #include "storage/Types.h"
 
@@ -70,17 +71,9 @@ void
 VecIndexCreator::Build(const milvus::DatasetPtr& dataset,
                        const bool* valid_data,
                        const int64_t valid_data_len) {
-    if (valid_data && valid_data_len > 0) {
-        auto vec_index = dynamic_cast<index::VectorIndex*>(index_.get());
-        AssertInfo(vec_index != nullptr, "failed to cast index to VectorIndex");
-        if (dataset->GetRows() == 0) {
-            vec_index->SetDim(dataset->GetDim());
-            vec_index->BuildValidData(valid_data, valid_data_len);
-            return;
-        }
-        index_->BuildWithDataset(dataset, config_);
-        vec_index->BuildValidData(valid_data, valid_data_len);
-        return;
+    if (valid_data_len > 0) {
+        dataset->SetIdMapData(knowhere::IdMapData::FromValidData(
+            valid_data, static_cast<size_t>(valid_data_len)));
     }
     index_->BuildWithDataset(dataset, config_);
 }

--- a/internal/core/src/mmap/ChunkedColumn.h
+++ b/internal/core/src/mmap/ChunkedColumn.h
@@ -754,6 +754,13 @@ class ChunkedVectorArrayColumn : public ChunkedColumnBase {
         return PinWrapper<const size_t*>(
             std::move(ca), static_cast<VectorArrayChunk*>(chunk)->Offsets());
     }
+
+ protected:
+    void
+    BuildValidArrayOffsetsInChunks(
+        const std::vector<PinWrapper<Chunk*>>& chunk_pws) override {
+        BuildVectorArrayValidOffsets(chunk_pws);
+    }
 };
 
 inline std::shared_ptr<ChunkedColumnInterface>

--- a/internal/core/src/mmap/ChunkedColumnGroup.h
+++ b/internal/core/src/mmap/ChunkedColumnGroup.h
@@ -768,6 +768,16 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
             });
     }
 
+ protected:
+    void
+    BuildValidArrayOffsetsInChunks(
+        const std::vector<PinWrapper<Chunk*>>& chunk_pws) override {
+        if (!IsChunkedVectorArrayColumnDataType(data_type_)) {
+            return;
+        }
+        BuildVectorArrayValidOffsets(chunk_pws);
+    }
+
  private:
     // Resolve, for each requested offset, the chunk that owns it and invoke
     // fn(chunk, offset_in_chunk, i), preserving the original row order.

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -17,6 +17,7 @@
 
 #include <atomic>
 #include <mutex>
+#include <vector>
 
 #include "cachinglayer/CacheSlot.h"
 #include "common/Chunk.h"
@@ -214,9 +215,21 @@ class ChunkedColumnInterface {
         return offset_mapping_;
     }
 
+    const std::vector<size_t>&
+    GetValidArrayOffsetsInChunk(int64_t chunk_id) const {
+        AssertInfo(!valid_array_offsets_per_chunk_.empty(),
+                   "Valid array offsets are not built for nullable column");
+        AssertInfo(chunk_id >= 0 &&
+                       chunk_id < static_cast<int64_t>(
+                                      valid_array_offsets_per_chunk_.size()),
+                   "Chunk id {} out of range, valid array offset chunks {}",
+                   chunk_id,
+                   valid_array_offsets_per_chunk_.size());
+        return valid_array_offsets_per_chunk_[chunk_id];
+    }
+
     virtual void
-    BuildValidRowIds(milvus::OpContext* op_ctx,
-                     const OffsetMappingBuildOptions& options = {}) {
+    BuildValidRowIds(milvus::OpContext* op_ctx) {
         if (!IsNullable()) {
             return;
         }
@@ -247,6 +260,7 @@ class ChunkedColumnInterface {
             valid_count_per_chunk_[i] = valid_count;
             logical_offset += rows;
         }
+        BuildValidArrayOffsetsInChunks(chunk_pws);
 
         num_valid_rows_until_chunk_.clear();
         num_valid_rows_until_chunk_.reserve(total_chunks + 1);
@@ -255,16 +269,15 @@ class ChunkedColumnInterface {
             num_valid_rows_until_chunk_.push_back(
                 num_valid_rows_until_chunk_.back() + valid_count_per_chunk_[i]);
         }
-        BuildOffsetMapping(options);
+        BuildOffsetMapping();
         valid_row_ids_built_.store(true, std::memory_order_release);
     }
 
     // Build offset mapping from valid_data
     void
-    BuildOffsetMapping(const OffsetMappingBuildOptions& options = {}) {
+    BuildOffsetMapping() {
         if (!valid_data_.empty()) {
-            offset_mapping_.Build(
-                valid_data_.data(), valid_data_.size(), options);
+            offset_mapping_.Build(valid_data_.data(), valid_data_.size());
         }
     }
 
@@ -378,9 +391,38 @@ class ChunkedColumnInterface {
     FixedVector<bool> valid_data_;
     std::vector<int64_t> valid_count_per_chunk_;
     std::vector<int64_t> num_valid_rows_until_chunk_;
+    std::vector<std::vector<size_t>> valid_array_offsets_per_chunk_;
     SealedOffsetMapping offset_mapping_;
     std::atomic<bool> valid_row_ids_built_{false};
     std::mutex offset_mapping_build_mutex_;
+
+    virtual void
+    BuildValidArrayOffsetsInChunks(
+        const std::vector<PinWrapper<Chunk*>>& chunk_pws) {
+    }
+
+    void
+    BuildVectorArrayValidOffsets(
+        const std::vector<PinWrapper<Chunk*>>& chunk_pws) {
+        valid_array_offsets_per_chunk_.assign(chunk_pws.size(), {});
+        for (size_t i = 0; i < chunk_pws.size(); ++i) {
+            auto chunk = static_cast<VectorArrayChunk*>(chunk_pws[i].get());
+            auto logical_offsets = chunk->Offsets();
+            auto& valid_offsets = valid_array_offsets_per_chunk_[i];
+            valid_offsets.reserve(valid_count_per_chunk_[i] + 1);
+            valid_offsets.push_back(0);
+
+            size_t total = 0;
+            const auto rows = chunk->RowNums();
+            for (int64_t j = 0; j < rows; ++j) {
+                if (!chunk->isValid(j)) {
+                    continue;
+                }
+                total += logical_offsets[j + 1] - logical_offsets[j];
+                valid_offsets.push_back(total);
+            }
+        }
+    }
 
     std::pair<std::vector<milvus::cachinglayer::cid_t>, std::vector<int64_t>>
     ToChunkIdAndOffset(const int64_t* offsets, int64_t count) const {

--- a/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
@@ -17,9 +17,7 @@
 #include <gtest/gtest.h>
 
 #include <array>
-#include <chrono>
 #include <cstring>
-#include <filesystem>
 #include <iterator>
 #include <memory>
 #include <set>
@@ -42,14 +40,6 @@ constexpr int64_t kTestFieldId = 1;
 constexpr int64_t kVectorArrayFieldId = 2;
 constexpr int64_t kVectorArrayRows = 4;
 constexpr int64_t kVectorArrayDim = 2;
-
-std::filesystem::path
-MakeMmapRoot(const std::string& test_name) {
-    return std::filesystem::temp_directory_path() /
-           ("milvus_chunked_column_" + test_name + "_" +
-            std::to_string(
-                std::chrono::steady_clock::now().time_since_epoch().count()));
-}
 
 struct ColumnFixture {
     std::shared_ptr<ChunkedColumnInterface> column;
@@ -369,44 +359,32 @@ TYPED_TEST(ChunkedColumnInterfaceTest, BuildValidRowIdsBuildsFullMapping) {
                      {true, true, true, true}},
                     true};
 
-    auto run_case = [&](bool enable_mmap) {
-        auto fx = TypeParam::Create(spec);
-        EXPECT_TRUE(fx.fetched->empty());
+    auto fx = TypeParam::Create(spec);
+    EXPECT_TRUE(fx.fetched->empty());
 
-        OffsetMappingBuildOptions options;
-        options.enable_mmap_i2o_map = enable_mmap;
-        options.enable_mmap_o2i_map = enable_mmap;
-        if (enable_mmap) {
-            options.mmap_dir_path = MakeMmapRoot("valid_row_ids").string();
-        }
-        fx.column->BuildValidRowIds(nullptr, options);
-        EXPECT_EQ(fx.fetched->size(), 3u);
-        EXPECT_EQ(fx.fetched->count(0), 1u);
-        EXPECT_EQ(fx.fetched->count(1), 1u);
-        EXPECT_EQ(fx.fetched->count(2), 1u);
+    fx.column->BuildValidRowIds(nullptr);
+    EXPECT_EQ(fx.fetched->size(), 3u);
+    EXPECT_EQ(fx.fetched->count(0), 1u);
+    EXPECT_EQ(fx.fetched->count(1), 1u);
+    EXPECT_EQ(fx.fetched->count(2), 1u);
 
-        EXPECT_EQ(fx.column->GetValidCountInChunk(0), 3);
-        EXPECT_EQ(fx.column->GetValidCountInChunk(1), 0);
-        EXPECT_EQ(fx.column->GetValidCountInChunk(2), 4);
+    EXPECT_EQ(fx.column->GetValidCountInChunk(0), 3);
+    EXPECT_EQ(fx.column->GetValidCountInChunk(1), 0);
+    EXPECT_EQ(fx.column->GetValidCountInChunk(2), 4);
 
-        const auto& m = fx.column->GetOffsetMapping();
-        EXPECT_TRUE(m.IsEnabled());
-        EXPECT_EQ(m.IsMmap(), enable_mmap);
-        EXPECT_EQ(m.GetTotalCount(), 12);
-        EXPECT_EQ(m.GetValidCount(), 7);
-        EXPECT_EQ(m.GetPhysicalOffset(0), 0);
-        EXPECT_EQ(m.GetPhysicalOffset(2), 1);
-        EXPECT_EQ(m.GetPhysicalOffset(3), 2);
-        EXPECT_EQ(m.GetPhysicalOffset(1), -1);
-        EXPECT_EQ(m.GetPhysicalOffset(4), -1);
-        EXPECT_EQ(m.GetPhysicalOffset(8), 3);
-        EXPECT_EQ(m.GetPhysicalOffset(9), 4);
-        EXPECT_EQ(m.GetPhysicalOffset(10), 5);
-        EXPECT_EQ(m.GetPhysicalOffset(11), 6);
-    };
-
-    run_case(false);
-    run_case(true);
+    const auto& m = fx.column->GetOffsetMapping();
+    EXPECT_TRUE(m.IsEnabled());
+    EXPECT_EQ(m.GetTotalCount(), 12);
+    EXPECT_EQ(m.GetValidCount(), 7);
+    EXPECT_EQ(m.GetPhysicalOffset(0), 0);
+    EXPECT_EQ(m.GetPhysicalOffset(2), 1);
+    EXPECT_EQ(m.GetPhysicalOffset(3), 2);
+    EXPECT_EQ(m.GetPhysicalOffset(1), -1);
+    EXPECT_EQ(m.GetPhysicalOffset(4), -1);
+    EXPECT_EQ(m.GetPhysicalOffset(8), 3);
+    EXPECT_EQ(m.GetPhysicalOffset(9), 4);
+    EXPECT_EQ(m.GetPhysicalOffset(10), 5);
+    EXPECT_EQ(m.GetPhysicalOffset(11), 6);
 }
 
 TYPED_TEST(ChunkedColumnInterfaceTest, CellsLoadedDoesNotFetchCells) {

--- a/internal/core/src/query/CachedSearchIterator.cpp
+++ b/internal/core/src/query/CachedSearchIterator.cpp
@@ -29,6 +29,7 @@
 #include "nlohmann/json.hpp"
 #include "query/CachedSearchIterator.h"
 #include "query/SearchBruteForce.h"
+#include "query/Utils.h"
 #include "query/helper.h"
 #include "segcore/ConcurrentVector.h"
 
@@ -77,6 +78,28 @@ CachedSearchIterator::CachedSearchIterator(
 }
 
 void
+CachedSearchIterator::AppendChunkIterators(
+    const dataset::SearchDataset& query_ds,
+    const SearchInfo& search_info,
+    const std::map<std::string, std::string>& index_info,
+    const dataset::RawDataset& raw_data,
+    const BitsetView& bitset,
+    const milvus::DataType& data_type) {
+    auto expected_iterators = GetBruteForceSearchIterators(
+        query_ds, raw_data, search_info, index_info, bitset, data_type);
+    if (expected_iterators.has_value()) {
+        auto& chunk_iterators = expected_iterators.value();
+        iterators_.insert(iterators_.end(),
+                          std::make_move_iterator(chunk_iterators.begin()),
+                          std::make_move_iterator(chunk_iterators.end()));
+        ++num_chunks_;
+        return;
+    }
+    ThrowInfo(ErrorCode::UnexpectedError,
+              "Failed to create iterators from index");
+}
+
+void
 CachedSearchIterator::InitializeChunkedIterators(
     const dataset::SearchDataset& query_ds,
     const SearchInfo& search_info,
@@ -86,23 +109,18 @@ CachedSearchIterator::InitializeChunkedIterators(
     const GetChunkDataFunc& get_chunk_data) {
     int64_t offset = 0;
     chunked_heaps_.resize(nq_);
-    for (int64_t chunk_id = 0; chunk_id < num_chunks_; ++chunk_id) {
-        auto [chunk_data, chunk_size] = get_chunk_data(chunk_id);
-        auto sub_data = query::dataset::RawDataset{
-            offset, query_ds.dim, chunk_size, chunk_data};
-
-        auto expected_iterators = GetBruteForceSearchIterators(
-            query_ds, sub_data, search_info, index_info, bitset, data_type);
-        if (expected_iterators.has_value()) {
-            auto& chunk_iterators = expected_iterators.value();
-            iterators_.insert(iterators_.end(),
-                              std::make_move_iterator(chunk_iterators.begin()),
-                              std::make_move_iterator(chunk_iterators.end()));
-        } else {
-            ThrowInfo(ErrorCode::UnexpectedError,
-                      "Failed to create iterators from index");
-        }
-        offset += chunk_size;
+    const auto source_chunks = num_chunks_;
+    num_chunks_ = 0;
+    for (int64_t chunk_id = 0; chunk_id < static_cast<int64_t>(source_chunks);
+         ++chunk_id) {
+        auto chunk = get_chunk_data(chunk_id, offset);
+        AppendChunkIterators(query_ds,
+                             search_info,
+                             index_info,
+                             chunk.raw_data,
+                             chunk.bitset,
+                             data_type);
+        offset += chunk.raw_data.num_raw_data;
     }
 }
 
@@ -127,7 +145,7 @@ CachedSearchIterator::CachedSearchIterator(
     }
 
     const int64_t vec_size_per_chunk = vec_data->get_size_per_chunk();
-    num_chunks_ = upper_div(row_count, vec_size_per_chunk);
+    const int64_t source_chunks = upper_div(row_count, vec_size_per_chunk);
     nq_ = query_ds.num_queries;
     Init(search_info);
 
@@ -139,52 +157,79 @@ CachedSearchIterator::CachedSearchIterator(
     // it here).
     const bool is_element_level = search_info.array_offsets_ != nullptr;
     if (is_element_level) {
-        chunk_buffers_.reserve(num_chunks_);
+        chunk_buffers_.reserve(source_chunks);
     }
 
-    iterators_.reserve(nq_ * num_chunks_);
-    InitializeChunkedIterators(
-        query_ds,
-        search_info,
-        index_info,
-        bitset,
-        data_type,
-        [this,
-         &vec_data,
-         &chunks,
-         vec_size_per_chunk,
-         row_count,
-         is_element_level](int64_t chunk_id) {
-            // Read through the caller's snapshot, not the live container: the
-            // generation behind `chunks` is pinned and cannot be reclaimed
-            // under us. There is no PinWrapper here (unlike the sealed path)
-            // because the snapshot itself is the pin, and the caller holds it
-            // for at least as long as this iterator lives.
-            const void* chunk_data = vec_data->get_chunk_data(chunks, chunk_id);
-            int64_t chunk_size = std::min(
-                vec_size_per_chunk, row_count - chunk_id * vec_size_per_chunk);
-            if (!is_element_level) {
-                return std::make_pair(chunk_data, chunk_size);
-            }
+    iterators_.reserve(nq_ * source_chunks);
+    chunked_heaps_.resize(nq_);
+    num_chunks_ = 0;
+    const auto& offset_mapping = vec_data->get_offset_mapping();
+    const bool has_offset_mapping = offset_mapping.IsEnabled() &&
+                                    !is_element_level &&
+                                    data_type != DataType::VECTOR_ARRAY;
+    int64_t element_offset = 0;
 
-            auto va_ptr = reinterpret_cast<const VectorArray*>(chunk_data);
-            int64_t total_bytes = 0;
-            int64_t total_elements = 0;
-            for (int64_t i = 0; i < chunk_size; ++i) {
-                total_bytes += va_ptr[i].byte_size();
-                total_elements += va_ptr[i].length();
+    for (int64_t chunk_id = 0; chunk_id < source_chunks; ++chunk_id) {
+        // Read through the caller's snapshot, not the live container: the
+        // generation behind `chunks` is pinned and cannot be reclaimed under
+        // us. There is no PinWrapper here (unlike the sealed path) because the
+        // snapshot itself is the pin, and the caller holds it for at least as
+        // long as this iterator lives.
+        const void* chunk_data = vec_data->get_chunk_data(chunks, chunk_id);
+        const int64_t row_begin = chunk_id * vec_size_per_chunk;
+        const int64_t row_end =
+            std::min(row_count, (chunk_id + 1) * vec_size_per_chunk);
+        auto range_begin = row_begin;
+        while (range_begin < row_end) {
+            int64_t chunk_size = row_end - range_begin;
+            const void* range_data = chunk_data;
+            OffsetMappingIdView id_view;
+            if (has_offset_mapping) {
+                id_view = offset_mapping.GetPhysicalToLogicalIds(range_begin,
+                                                                 chunk_size);
+                AssertInfo(!id_view.empty(),
+                           "empty id map view for non-empty BF iterator range");
+                chunk_size = id_view.count;
+                range_data = AdvanceVectorDataPointer(chunk_data,
+                                                      data_type,
+                                                      query_ds.dim,
+                                                      range_begin - row_begin);
             }
-            auto buf = std::make_unique<uint8_t[]>(total_bytes);
-            auto* ptr = buf.get();
-            for (int64_t i = 0; i < chunk_size; ++i) {
-                milvus::fastmem::FastMemcpy(
-                    ptr, va_ptr[i].data(), va_ptr[i].byte_size());
-                ptr += va_ptr[i].byte_size();
+            auto chunk_bitset = AttachOffsetMappingIds(bitset, id_view);
+
+            dataset::RawDataset raw_data;
+            if (!is_element_level) {
+                raw_data = {range_begin, query_ds.dim, chunk_size, range_data};
+            } else {
+                auto va_ptr = reinterpret_cast<const VectorArray*>(range_data);
+                int64_t total_bytes = 0;
+                int64_t total_elements = 0;
+                for (int64_t i = 0; i < chunk_size; ++i) {
+                    total_bytes += va_ptr[i].byte_size();
+                    total_elements += va_ptr[i].length();
+                }
+                auto buf = std::make_unique<uint8_t[]>(total_bytes);
+                auto* ptr = buf.get();
+                for (int64_t i = 0; i < chunk_size; ++i) {
+                    milvus::fastmem::FastMemcpy(
+                        ptr, va_ptr[i].data(), va_ptr[i].byte_size());
+                    ptr += va_ptr[i].byte_size();
+                }
+                const void* flat_data = buf.get();
+                chunk_buffers_.emplace_back(std::move(buf));
+                raw_data = {
+                    element_offset, query_ds.dim, total_elements, flat_data};
+                element_offset += total_elements;
             }
-            const void* flat_data = buf.get();
-            chunk_buffers_.emplace_back(std::move(buf));
-            return std::make_pair(flat_data, total_elements);
-        });
+            AppendChunkIterators(query_ds,
+                                 search_info,
+                                 index_info,
+                                 raw_data,
+                                 chunk_bitset,
+                                 data_type);
+            range_begin += chunk_size;
+        }
+    }
 }
 
 // For sealed segment with chunked data, BF
@@ -213,14 +258,18 @@ CachedSearchIterator::CachedSearchIterator(
         index_info,
         bitset,
         data_type,
-        [this, column, &search_info](int64_t chunk_id) {
+        [this, column, &query_ds, &search_info, &bitset](
+            int64_t chunk_id, int64_t physical_begin) {
             auto pw = column->DataOfChunk(nullptr, chunk_id)
                           .transform<const void*>([](const auto& x) {
                               return static_cast<const void*>(x);
                           });
             int64_t chunk_size = column->chunk_row_nums(chunk_id);
             const auto& offset_mapping = column->GetOffsetMapping();
-            if (offset_mapping.IsEnabled()) {
+            const bool has_offset_mapping =
+                offset_mapping.IsEnabled() &&
+                search_info.array_offsets_ == nullptr;
+            if (has_offset_mapping) {
                 chunk_size = column->GetValidCountInChunk(chunk_id);
             }
             // For element-level search on vector array field, chunk_size
@@ -233,7 +282,16 @@ CachedSearchIterator::CachedSearchIterator(
             // pw guarantees chunk_data is kept alive.
             auto chunk_data = pw.get();
             pin_wrappers_.emplace_back(std::move(pw));
-            return std::make_pair(chunk_data, chunk_size);
+            BitsetView chunk_bitset = bitset;
+            if (has_offset_mapping) {
+                chunk_bitset = AttachOffsetMappingIds(
+                    bitset,
+                    offset_mapping.GetPhysicalToLogicalIds(physical_begin,
+                                                           chunk_size));
+            }
+            return ChunkSearchData{
+                {physical_begin, query_ds.dim, chunk_size, chunk_data},
+                chunk_bitset};
         });
 }
 

--- a/internal/core/src/query/CachedSearchIterator.h
+++ b/internal/core/src/query/CachedSearchIterator.h
@@ -97,8 +97,11 @@ class CachedSearchIterator {
     using DisIdPair = std::pair<float, int64_t>;
     using IterIdx = size_t;
     using IterIdDisIdPair = std::pair<IterIdx, DisIdPair>;
-    using GetChunkDataFunc =
-        std::function<std::pair<const void*, int64_t>(int64_t)>;
+    struct ChunkSearchData {
+        dataset::RawDataset raw_data;
+        BitsetView bitset;
+    };
+    using GetChunkDataFunc = std::function<ChunkSearchData(int64_t, int64_t)>;
 
     // used only for sealed segment with chunked data
     std::vector<milvus::cachinglayer::PinWrapper<const void*>> pin_wrappers_;
@@ -191,6 +194,14 @@ class CachedSearchIterator {
 
     void
     Init(const SearchInfo& search_info);
+
+    void
+    AppendChunkIterators(const dataset::SearchDataset& dataset,
+                         const SearchInfo& search_info,
+                         const std::map<std::string, std::string>& index_info,
+                         const dataset::RawDataset& raw_data,
+                         const BitsetView& bitset,
+                         const milvus::DataType& data_type);
 
     // must call get_chunk_data from chunk 0 to chunk num_chunks_ - 1 in order.
     void

--- a/internal/core/src/query/CachedSearchIteratorTest.cpp
+++ b/internal/core/src/query/CachedSearchIteratorTest.cpp
@@ -854,8 +854,9 @@ TEST(CachedSearchIteratorNullableTest, ChunkedColumnWithPartialNulls) {
     // Build query from first valid vector
     std::vector<float> query_data(base_data.begin(), base_data.begin() + dim);
 
-    // Create an all-zero bitset (no filtering) for the physical data range
-    TargetBitmap search_bitset(total_valid, false);
+    // Search bitsets stay in logical row space; CachedSearchIterator attaches
+    // the chunk-local physical->logical window before entering Knowhere BF.
+    TargetBitmap search_bitset(chunk_rows * num_chunks, false);
     BitsetView search_bitview(search_bitset);
 
     dataset::SearchDataset search_dataset{
@@ -875,8 +876,6 @@ TEST(CachedSearchIteratorNullableTest, ChunkedColumnWithPartialNulls) {
     iter_v2_info.batch_size = batch_size;
     search_info.iterator_v2_info_ = iter_v2_info;
 
-    // Create CachedSearchIterator - this tests Fix 1:
-    // The lambda should use valid_count_per_chunk[chunk_id] as chunk_size
     CachedSearchIterator iter(column.get(),
                               search_dataset,
                               search_info,
@@ -890,8 +889,7 @@ TEST(CachedSearchIteratorNullableTest, ChunkedColumnWithPartialNulls) {
     ASSERT_EQ(result.seg_offsets_.size(), batch_size);
     ASSERT_EQ(result.distances_.size(), batch_size);
 
-    // All returned offsets should be physical offsets in [0, total_valid)
-    // (TransformOffset is NOT called here - that's the caller's job)
+    // Knowhere BF returns logical offsets through the BitsetView out-id window.
     int valid_count = 0;
     for (auto& offset : result.seg_offsets_) {
         if (offset == INVALID_SEG_OFFSET) {
@@ -899,9 +897,8 @@ TEST(CachedSearchIteratorNullableTest, ChunkedColumnWithPartialNulls) {
         }
         valid_count++;
         ASSERT_GE(offset, 0);
-        ASSERT_LT(offset, total_valid)
-            << "Physical offset " << offset << " exceeds valid count "
-            << total_valid;
+        ASSERT_LT(offset, chunk_rows * num_chunks);
+        ASSERT_EQ(offset % 2, 0) << "logical offset should be a valid row";
     }
     ASSERT_GT(valid_count, 0);
 }

--- a/internal/core/src/query/SearchBruteForceSparseTest.cpp
+++ b/internal/core/src/query/SearchBruteForceSparseTest.cpp
@@ -13,6 +13,7 @@
 #include <nlohmann/json.hpp>
 #include <stdint.h>
 #include <algorithm>
+#include <array>
 #include <functional>
 #include <limits>
 #include <map>
@@ -30,6 +31,7 @@
 #include "common/protobuf_utils.h"
 #include "filemanager/InputStream.h"
 #include "gtest/gtest.h"
+#include "knowhere/array_store.h"
 #include "knowhere/comp/index_param.h"
 #include "knowhere/config.h"
 #include "knowhere/index/index_node.h"
@@ -203,6 +205,79 @@ TEST_F(TestSparseFloatSearchBruteForce, NotSupported) {
 TEST_F(TestSparseFloatSearchBruteForce, IP) {
     Run(100, 10, 5, "IP");
     Run(100, 10, 5, "ip");
+}
+
+TEST(SparseFloatBruteForce, UsesOutIdsForBitsetAndResultIds) {
+    using SparseRow = knowhere::sparse::SparseRow<milvus::SparseValueType>;
+
+    std::vector<SparseRow> base;
+    base.emplace_back(
+        std::vector<std::pair<knowhere::sparse::table_t, float>>{{1, 1.0F}});
+    base.emplace_back(
+        std::vector<std::pair<knowhere::sparse::table_t, float>>{{1, 1.0F}});
+    std::vector<SparseRow> query;
+    query.emplace_back(
+        std::vector<std::pair<knowhere::sparse::table_t, float>>{{1, 1.0F}});
+
+    constexpr int64_t nq = 1;
+    constexpr int64_t topk = 1;
+    constexpr int64_t dim = 8;
+    dataset::SearchDataset query_dataset{
+        knowhere::metric::IP, nq, topk, -1, dim, query.data()};
+    query::dataset::RawDataset raw_dataset{
+        1, dim, static_cast<int64_t>(base.size()), base.data()};
+
+    SearchInfo search_info;
+    search_info.topk_ = topk;
+    search_info.metric_type_ = knowhere::metric::IP;
+
+    BitsetType logical_filter;
+    logical_filter.resize(6);
+    logical_filter.set(1);
+    BitsetView bitset_view(logical_filter);
+    std::array<int32_t, 3> out_id_values{0, 1, 5};
+    knowhere::IdArray out_ids(out_id_values.data(), out_id_values.size());
+    bitset_view.set_id_offset(1);
+    bitset_view.set_out_ids(out_ids, out_ids.size());
+
+    std::map<std::string, std::string> index_info;
+    auto result = BruteForceSearch(query_dataset,
+                                   raw_dataset,
+                                   search_info,
+                                   index_info,
+                                   bitset_view,
+                                   DataType::VECTOR_SPARSE_U32_F32,
+                                   DataType::NONE,
+                                   nullptr);
+    ASSERT_EQ(result.mutable_offsets().size(), topk);
+    EXPECT_EQ(result.mutable_offsets()[0], 5);
+
+    search_info.search_params_[RADIUS] = 0.5F;
+    search_info.search_params_[RANGE_FILTER] = 1.5F;
+    auto range_result = BruteForceSearch(query_dataset,
+                                         raw_dataset,
+                                         search_info,
+                                         index_info,
+                                         bitset_view,
+                                         DataType::VECTOR_SPARSE_U32_F32,
+                                         DataType::NONE,
+                                         nullptr);
+    ASSERT_EQ(range_result.mutable_offsets().size(), topk);
+    EXPECT_EQ(range_result.mutable_offsets()[0], 5);
+
+    auto iterator_result = PackBruteForceSearchIteratorsIntoSubResult(
+        query_dataset,
+        raw_dataset,
+        search_info,
+        index_info,
+        bitset_view,
+        DataType::VECTOR_SPARSE_U32_F32);
+    auto iterators = iterator_result.chunk_iterators();
+    ASSERT_EQ(iterators.size(), nq);
+    ASSERT_TRUE(iterators[0]->HasNext().value());
+    auto first = iterators[0]->Next().value();
+    EXPECT_EQ(first.first, 5);
+    EXPECT_FLOAT_EQ(first.second, 1.0F);
 }
 
 // Behavioral regression for #51366: a segment that predates a BM25 field added

--- a/internal/core/src/query/SearchOnGrowing.cpp
+++ b/internal/core/src/query/SearchOnGrowing.cpp
@@ -290,19 +290,7 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
         const auto has_offset_mapping =
             offset_mapping.IsEnabled() && !is_element_level_search;
 
-        TargetBitmap transformed_bitset;
         BitsetView search_bitset = bitset;
-        if (has_offset_mapping && !bitset.empty()) {
-            auto status =
-                offset_mapping.TransformBitset(bitset, transformed_bitset);
-            if (status == OffsetMapping::BitsetTransformStatus::AllFiltered) {
-                FillEmptySearchResult(search_result, num_queries, info.topk_);
-                return;
-            }
-            if (status == OffsetMapping::BitsetTransformStatus::NoFilter) {
-                search_bitset = BitsetView{};
-            }
-        }
 
         // An empty BitsetView means "no filter", NOT "zero rows": its size() is
         // 0 and clamping to it would zero the bound and make the search return
@@ -340,11 +328,6 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
             FillEmptySearchResult(search_result, num_queries, info.topk_);
             return;
         }
-        if (has_offset_mapping && !bitset.empty() &&
-            !transformed_bitset.empty()) {
-            search_bitset =
-                search_result.PinBitset(std::move(transformed_bitset));
-        }
 
         // Element-level search (embedding-search-embedding): knowhere sees
         // a scalar vector type and the per-chunk size must be measured in
@@ -374,8 +357,8 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                                              search_bitset,
                                              iter_data_type);
             cached_iter.NextBatch(info, search_result);
-            FinalizeVectorSearchOffsets(
-                search_result, offset_mapping, info.array_offsets_.get());
+            FinalizeVectorSearchOffsets(search_result,
+                                        info.array_offsets_.get());
             // The iterator is consumed and destroyed above, so nothing borrows
             // the chunks past this point today. Pin the generation anyway: the
             // brute-force branch below has to, and a future change that lets
@@ -392,6 +375,7 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
         // begin_id must be the cumulative element count (not row offset),
         // because ArrayOffsets maps global element IDs to row IDs.
         int64_t cumulative_element_offset = 0;
+        int bf_chunk_count = 0;
 
         std::vector<size_t> offsets;
         for (int chunk_id = current_chunk_id; chunk_id < max_chunk;
@@ -401,103 +385,117 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
             auto row_begin = chunk_id * vec_size_per_chunk;
             auto row_end =
                 std::min(active_count, (chunk_id + 1) * vec_size_per_chunk);
-            auto size_per_chunk = row_end - row_begin;
-
-            query::dataset::RawDataset sub_data;
-            std::unique_ptr<uint8_t[]> buf = nullptr;
-            if (data_type != DataType::VECTOR_ARRAY) {
-                sub_data = query::dataset::RawDataset{
-                    row_begin, dim, size_per_chunk, chunk_data};
-            } else {
-                // TODO(SpadeA): For VectorArray(Embedding List), data is
-                // discreted stored in FixedVector which means we will copy the
-                // data to a contiguous memory buffer. This is inefficient and
-                // will be optimized in the future.
-                auto vec_ptr = reinterpret_cast<const VectorArray*>(chunk_data);
-                auto size = 0;
-                for (int i = 0; i < size_per_chunk; ++i) {
-                    size += vec_ptr[i].byte_size();
+            auto range_begin = row_begin;
+            while (range_begin < row_end) {
+                auto size_per_chunk = row_end - range_begin;
+                const void* range_data = chunk_data;
+                OffsetMappingIdView id_view;
+                if (has_offset_mapping) {
+                    id_view = offset_mapping.GetPhysicalToLogicalIds(
+                        range_begin, size_per_chunk);
+                    AssertInfo(!id_view.empty(),
+                               "empty id map view for non-empty BF range");
+                    size_per_chunk = id_view.count;
+                    range_data = AdvanceVectorDataPointer(
+                        chunk_data, data_type, dim, range_begin - row_begin);
                 }
+                auto chunk_bitset =
+                    AttachOffsetMappingIds(search_bitset, id_view);
 
-                buf = std::make_unique<uint8_t[]>(size);
-
-                if (is_element_level_search) {
-                    auto count = 0;
-                    auto ptr = buf.get();
-                    for (int i = 0; i < size_per_chunk; ++i) {
-                        milvus::fastmem::FastMemcpy(
-                            ptr, vec_ptr[i].data(), vec_ptr[i].byte_size());
-                        ptr += vec_ptr[i].byte_size();
-                        count += vec_ptr[i].length();
-                    }
+                query::dataset::RawDataset sub_data;
+                std::unique_ptr<uint8_t[]> buf = nullptr;
+                if (data_type != DataType::VECTOR_ARRAY) {
                     sub_data = query::dataset::RawDataset{
-                        cumulative_element_offset, dim, count, buf.get()};
-                    cumulative_element_offset += count;
+                        range_begin, dim, size_per_chunk, range_data};
                 } else {
-                    offsets.clear();
-                    offsets.reserve(size_per_chunk + 1);
-                    offsets.push_back(0);
-
-                    auto offset = 0;
-                    auto ptr = buf.get();
+                    // TODO(SpadeA): For VectorArray(Embedding List), data is
+                    // discreted stored in FixedVector which means we will copy the
+                    // data to a contiguous memory buffer. This is inefficient and
+                    // will be optimized in the future.
+                    auto vec_ptr =
+                        reinterpret_cast<const VectorArray*>(range_data);
+                    auto size = 0;
                     for (int i = 0; i < size_per_chunk; ++i) {
-                        milvus::fastmem::FastMemcpy(
-                            ptr, vec_ptr[i].data(), vec_ptr[i].byte_size());
-                        ptr += vec_ptr[i].byte_size();
-
-                        offset += vec_ptr[i].length();
-                        offsets.push_back(offset);
+                        size += vec_ptr[i].byte_size();
                     }
-                    sub_data = query::dataset::RawDataset{row_begin,
-                                                          dim,
-                                                          size_per_chunk,
-                                                          buf.get(),
-                                                          offsets.data()};
+
+                    buf = std::make_unique<uint8_t[]>(size);
+
+                    if (is_element_level_search) {
+                        auto count = 0;
+                        auto ptr = buf.get();
+                        for (int i = 0; i < size_per_chunk; ++i) {
+                            milvus::fastmem::FastMemcpy(
+                                ptr, vec_ptr[i].data(), vec_ptr[i].byte_size());
+                            ptr += vec_ptr[i].byte_size();
+                            count += vec_ptr[i].length();
+                        }
+                        sub_data = query::dataset::RawDataset{
+                            cumulative_element_offset, dim, count, buf.get()};
+                        cumulative_element_offset += count;
+                    } else {
+                        offsets.clear();
+                        offsets.reserve(size_per_chunk + 1);
+                        offsets.push_back(0);
+
+                        auto offset = 0;
+                        auto ptr = buf.get();
+                        for (int i = 0; i < size_per_chunk; ++i) {
+                            milvus::fastmem::FastMemcpy(
+                                ptr, vec_ptr[i].data(), vec_ptr[i].byte_size());
+                            ptr += vec_ptr[i].byte_size();
+
+                            offset += vec_ptr[i].length();
+                            offsets.push_back(offset);
+                        }
+                        sub_data = query::dataset::RawDataset{range_begin,
+                                                              dim,
+                                                              size_per_chunk,
+                                                              buf.get(),
+                                                              offsets.data()};
+                    }
                 }
-            }
 
-            if (use_vector_iterator) {
-                AssertInfo(iter_data_type != DataType::VECTOR_ARRAY,
-                           "vector array(embedding list) is not supported for "
-                           "vector iterator");
+                if (use_vector_iterator) {
+                    AssertInfo(
+                        iter_data_type != DataType::VECTOR_ARRAY,
+                        "vector array(embedding list) is not supported for "
+                        "vector iterator");
 
-                if (buf != nullptr) {
-                    search_result.chunk_buffers_.emplace_back(std::move(buf));
+                    if (buf != nullptr) {
+                        search_result.chunk_buffers_.emplace_back(
+                            std::move(buf));
+                    }
+
+                    auto sub_qr = PackBruteForceSearchIteratorsIntoSubResult(
+                        search_dataset,
+                        sub_data,
+                        info,
+                        index_info,
+                        chunk_bitset,
+                        iter_data_type);
+                    final_qr.merge(sub_qr);
+                } else {
+                    auto sub_qr = BruteForceSearch(search_dataset,
+                                                   sub_data,
+                                                   info,
+                                                   index_info,
+                                                   chunk_bitset,
+                                                   iter_data_type,
+                                                   element_type,
+                                                   op_context);
+                    final_qr.merge(sub_qr);
                 }
-
-                auto sub_qr =
-                    PackBruteForceSearchIteratorsIntoSubResult(search_dataset,
-                                                               sub_data,
-                                                               info,
-                                                               index_info,
-                                                               search_bitset,
-                                                               iter_data_type);
-                final_qr.merge(sub_qr);
-            } else {
-                auto sub_qr = BruteForceSearch(search_dataset,
-                                               sub_data,
-                                               info,
-                                               index_info,
-                                               search_bitset,
-                                               iter_data_type,
-                                               element_type,
-                                               op_context);
-                final_qr.merge(sub_qr);
+                range_begin += size_per_chunk;
+                ++bf_chunk_count;
             }
         }
         if (use_vector_iterator) {
             bool larger_is_closer = PositivelyRelated(info.metric_type_);
-            // Element-level search skips row-level mapping (element IDs are
-            // not row-aligned); see ChunkMergeIterator ctor.
-            const milvus::OffsetMapping* iter_offset_mapping =
-                (is_element_level_search || !has_offset_mapping)
-                    ? nullptr
-                    : &offset_mapping;
             search_result.AssembleChunkVectorIterators(
                 num_queries,
-                max_chunk,
+                bf_chunk_count,
                 final_qr.chunk_iterators(),
-                iter_offset_mapping,
                 larger_is_closer);
             // Knowhere's brute-force iterators retain raw pointers into the
             // chunk storage and are consumed after SearchOnGrowing returns.
@@ -517,9 +515,6 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                 search_result.element_indices_ = std::move(elem_indicies);
                 search_result.element_level_ = true;
             } else {
-                if (has_offset_mapping) {
-                    offset_mapping.TransformOffsets(final_qr.mutable_offsets());
-                }
                 search_result.seg_offsets_ =
                     std::move(final_qr.mutable_offsets());
             }

--- a/internal/core/src/query/SearchOnIndex.cpp
+++ b/internal/core/src/query/SearchOnIndex.cpp
@@ -20,7 +20,6 @@
 #include "CachedSearchIterator.h"
 #include "Utils.h"
 #include "common/Consts.h"
-#include "common/OffsetMapping.h"
 #include "common/QueryInfo.h"
 #include "common/QueryResult.h"
 #include "common/Types.h"
@@ -45,10 +44,7 @@ SearchOnIndex(const dataset::SearchDataset& search_dataset,
         knowhere::GenDataSet(num_queries, dim, search_dataset.query_data);
     dataset->SetIsSparse(is_sparse);
 
-    const auto& offset_mapping = indexing.GetOffsetMapping();
-    TargetBitmap transformed_bitset;
     BitsetView search_bitset = bitset;
-    const auto has_offset_mapping = offset_mapping.IsEnabled();
     const auto active_count = search_conf.active_count_;
 
     // A growing interim index can advance after the plan freezes its visible
@@ -57,15 +53,9 @@ SearchOnIndex(const dataset::SearchDataset& search_dataset,
     // rows appended after active_count can occupy the ANN top-k before Reduce
     // gets a chance to validate their offsets.
     //
-    // Keep the bound in the index's physical space for nullable vectors.  The
-    // pinned bitmap is shared by Query, iterator and iterator-v2 paths below;
-    // Knowhere filters every id >= bitmap.size(), which also covers rows added
-    // after this bitmap is constructed.
-    int64_t physical_active_count = active_count;
-    if (active_count >= 0 && has_offset_mapping) {
-        physical_active_count = offset_mapping.ValidCountBelow(active_count);
-    }
-    if (active_count >= 0 && physical_active_count == 0) {
+    // Indexed nullable mapping lives inside Knowhere IdMap, so the visible
+    // prefix stays in logical row space.
+    if (active_count >= 0 && active_count == 0) {
         FillEmptySearchResult(search_result, num_queries, search_conf.topk_);
         return;
     }
@@ -75,39 +65,8 @@ SearchOnIndex(const dataset::SearchDataset& search_dataset,
         search_bitset = search_result.PinBitset(std::move(visible_prefix));
     };
 
-    if (has_offset_mapping) {
-        if (active_count < 0 && offset_mapping.GetValidCount() == 0) {
-            // All vectors are null, return empty result
-            FillEmptySearchResult(
-                search_result, num_queries, search_conf.topk_);
-            return;
-        }
-        if (!bitset.empty()) {
-            auto status =
-                offset_mapping.TransformBitset(bitset, transformed_bitset);
-            if (status == OffsetMapping::BitsetTransformStatus::AllFiltered) {
-                FillEmptySearchResult(
-                    search_result, num_queries, search_conf.topk_);
-                return;
-            }
-            if (status == OffsetMapping::BitsetTransformStatus::NoFilter) {
-                if (active_count >= 0) {
-                    pin_visible_prefix(physical_active_count);
-                } else {
-                    search_bitset = BitsetView{};
-                }
-            } else {
-                if (active_count >= 0) {
-                    transformed_bitset.resize(physical_active_count);
-                }
-                search_bitset =
-                    search_result.PinBitset(std::move(transformed_bitset));
-            }
-        } else if (active_count >= 0) {
-            pin_visible_prefix(physical_active_count);
-        }
-    } else if (active_count >= 0 && bitset.empty()) {
-        pin_visible_prefix(physical_active_count);
+    if (active_count >= 0 && bitset.empty()) {
+        pin_visible_prefix(active_count);
     } else if (active_count >= 0) {
         // The plan layer sizes the filter bitmap to the same frozen
         // active_count it stamps into SearchInfo (both come from one
@@ -140,17 +99,11 @@ SearchOnIndex(const dataset::SearchDataset& search_dataset,
         auto iter = CachedSearchIterator(
             indexing, dataset, search_conf, search_bitset, op_context);
         iter.NextBatch(search_conf, search_result);
-        if (has_offset_mapping) {
-            offset_mapping.TransformOffsets(search_result.seg_offsets_);
-        }
         return;
     }
 
     indexing.Query(
         dataset, search_conf, search_bitset, op_context, search_result);
-    if (has_offset_mapping) {
-        offset_mapping.TransformOffsets(search_result.seg_offsets_);
-    }
 }
 
 }  // namespace milvus::query

--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -92,38 +92,16 @@ SearchOnSealedIndex(const Schema& schema,
     auto vec_index =
         dynamic_cast<index::VectorIndex*>(accessor->get_cell_of(0));
 
-    const auto& offset_mapping = vec_index->GetOffsetMapping();
     const bool is_element_level_search = search_info.array_offsets_ != nullptr;
     search_result.element_level_ = is_element_level_search;
-    TargetBitmap transformed_bitset;
     BitsetView search_bitset = bitset;
-    const auto has_offset_mapping =
-        offset_mapping.IsEnabled() && !is_element_level_search;
-    if (has_offset_mapping) {
-        if (offset_mapping.GetValidCount() == 0) {
-            FillEmptySearchResult(search_result, num_queries, topK);
-            return;
-        }
-        if (!bitset.empty()) {
-            auto status =
-                offset_mapping.TransformBitset(bitset, transformed_bitset);
-            if (status == OffsetMapping::BitsetTransformStatus::AllFiltered) {
-                FillEmptySearchResult(search_result, num_queries, topK);
-                return;
-            }
-            search_bitset =
-                status == OffsetMapping::BitsetTransformStatus::NoFilter
-                    ? BitsetView{}
-                    : search_result.PinBitset(std::move(transformed_bitset));
-        }
-    }
 
     if (search_info.iterator_v2_info_.has_value()) {
         CachedSearchIterator cached_iter(
             *vec_index, dataset, search_info, search_bitset, op_context);
         cached_iter.NextBatch(search_info, search_result);
-        FinalizeVectorSearchOffsets(
-            search_result, offset_mapping, search_info.array_offsets_.get());
+        FinalizeVectorSearchOffsets(search_result,
+                                    search_info.array_offsets_.get());
         return;
     }
 
@@ -150,7 +128,6 @@ SearchOnSealedIndex(const Schema& schema,
     }
     FinalizeVectorSearchOffsets(
         search_result,
-        offset_mapping,
         use_iterator ? nullptr : search_info.array_offsets_.get());
     if (use_iterator) {
         search_result.resource_pins_.emplace_back(std::move(accessor));
@@ -190,26 +167,19 @@ SearchOnSealedColumn(const Schema& schema,
 
     CheckBruteForceSearchParam(field, search_info);
 
-    // Nullable plain-vector chunks compact away NULL rows and therefore need
-    // physical/logical row mapping. VECTOR_ARRAY raw chunks keep one list
-    // offset per logical row; NULL and empty rows are represented by
-    // zero-length lists, so row mapping must not be built or applied here.
+    const bool is_element_level_search = data_type == DataType::VECTOR_ARRAY &&
+                                         search_info.array_offsets_ != nullptr;
+    // Nullable vector chunks scan compacted physical rows. Row-level searches
+    // need p2l ids; element-level VECTOR_ARRAY searches map element ids later.
     const bool needs_offset_mapping =
-        column->IsNullable() && data_type != DataType::VECTOR_ARRAY;
+        column->IsNullable() && !is_element_level_search;
     if (needs_offset_mapping) {
         column->BuildValidRowIds(op_context);
     }
 
     // Check for nullable vector field with all null values - must be done before creating iterators
     const auto& offset_mapping = column->GetOffsetMapping();
-    // Element-level VECTOR_ARRAY search has already expanded the row bitset
-    // to element IDs. OffsetMapping is row-level, so only use it for row-level
-    // vector searches.
-    bool is_element_level_search =
-        field.get_data_type() == DataType::VECTOR_ARRAY &&
-        search_info.array_offsets_ != nullptr;
     result.element_level_ = is_element_level_search;
-    TargetBitmap transformed_bitset;
     BitsetView search_bitview = bitview;
     const auto has_offset_mapping =
         needs_offset_mapping && offset_mapping.IsEnabled();
@@ -218,18 +188,6 @@ SearchOnSealedColumn(const Schema& schema,
             // All vectors are null, return empty result
             FillEmptySearchResult(result, num_queries, search_info.topk_);
             return;
-        }
-        if (!bitview.empty()) {
-            auto status =
-                offset_mapping.TransformBitset(bitview, transformed_bitset);
-            if (status == OffsetMapping::BitsetTransformStatus::AllFiltered) {
-                FillEmptySearchResult(result, num_queries, search_info.topk_);
-                return;
-            }
-            search_bitview =
-                status == OffsetMapping::BitsetTransformStatus::NoFilter
-                    ? BitsetView{}
-                    : result.PinBitset(std::move(transformed_bitset));
         }
     }
 
@@ -256,8 +214,7 @@ SearchOnSealedColumn(const Schema& schema,
                                          search_bitview,
                                          data_type);
         cached_iter.NextBatch(search_info, result);
-        FinalizeVectorSearchOffsets(
-            result, offset_mapping, search_info.array_offsets_.get());
+        FinalizeVectorSearchOffsets(result, search_info.array_offsets_.get());
         return;
     }
 
@@ -270,7 +227,7 @@ SearchOnSealedColumn(const Schema& schema,
                              search_info.metric_type_,
                              search_info.round_decimal_);
 
-    auto offset = 0;
+    int64_t offset = 0;
     auto vector_chunks = column->GetAllChunks(op_context);
     for (int i = 0; i < num_chunk; ++i) {
         const auto& pw = vector_chunks[i];
@@ -289,6 +246,13 @@ SearchOnSealedColumn(const Schema& schema,
 
         auto raw_dataset =
             query::dataset::RawDataset{offset, dim, chunk_size, vec_data};
+        auto chunk_bitview = search_bitview;
+        OffsetMappingIdView id_view;
+        if (has_offset_mapping) {
+            id_view =
+                offset_mapping.GetPhysicalToLogicalIds(offset, chunk_size);
+            chunk_bitview = AttachOffsetMappingIds(search_bitview, id_view);
+        }
 
         PinWrapper<const size_t*> offsets_pw;
         if (data_type == DataType::VECTOR_ARRAY) {
@@ -296,8 +260,13 @@ SearchOnSealedColumn(const Schema& schema,
                 query_offsets != nullptr,
                 "query_offsets is nullptr, but data_type is vector array");
 
-            offsets_pw = column->VectorArrayOffsets(op_context, i);
-            raw_dataset.raw_data_offsets = offsets_pw.get();
+            if (has_offset_mapping) {
+                raw_dataset.raw_data_offsets =
+                    column->GetValidArrayOffsetsInChunk(i).data();
+            } else {
+                offsets_pw = column->VectorArrayOffsets(op_context, i);
+                raw_dataset.raw_data_offsets = offsets_pw.get();
+            }
             if (raw_dataset.raw_data_offsets[chunk_size] == 0) {
                 offset += chunk_size;
                 continue;
@@ -313,7 +282,7 @@ SearchOnSealedColumn(const Schema& schema,
                                                            raw_dataset,
                                                            search_info,
                                                            index_info,
-                                                           search_bitview,
+                                                           chunk_bitview,
                                                            data_type);
             final_qr.merge(sub_qr);
         } else {
@@ -321,7 +290,7 @@ SearchOnSealedColumn(const Schema& schema,
                                            raw_dataset,
                                            search_info,
                                            index_info,
-                                           search_bitview,
+                                           chunk_bitview,
                                            data_type,
                                            element_type,
                                            op_context);
@@ -331,16 +300,9 @@ SearchOnSealedColumn(const Schema& schema,
     }
     if (use_vector_iterator) {
         bool larger_is_closer = PositivelyRelated(search_info.metric_type_);
-        // Element-level search skips row-level mapping (element IDs are
-        // not row-aligned); see ChunkMergeIterator ctor.
-        const milvus::OffsetMapping* iter_offset_mapping =
-            (search_info.array_offsets_ != nullptr || !has_offset_mapping)
-                ? nullptr
-                : &offset_mapping;
         result.AssembleChunkVectorIterators(num_queries,
                                             num_chunk,
                                             final_qr.chunk_iterators(),
-                                            iter_offset_mapping,
                                             larger_is_closer);
     } else {
         // See FinalizeVectorSearchOffsets for the rationale: element-level
@@ -353,9 +315,6 @@ SearchOnSealedColumn(const Schema& schema,
             result.element_indices_ = std::move(elem_indicies);
             result.element_level_ = true;
         } else {
-            if (has_offset_mapping) {
-                offset_mapping.TransformOffsets(final_qr.mutable_offsets());
-            }
             result.seg_offsets_ = std::move(final_qr.mutable_offsets());
         }
         result.distances_ = std::move(final_qr.mutable_distances());

--- a/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
+++ b/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
@@ -28,6 +28,8 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <numeric>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -48,6 +50,7 @@
 #include "segcore/SegmentGrowing.h"
 #include "segcore/SegmentGrowingImpl.h"
 #include "segcore/SealedIndexingRecord.h"
+#include "segcore/Utils.h"
 #include "test_utils/DataGen.h"
 #include "test_utils/SegcoreConfigUtils.h"
 #include "test_utils/cachinglayer_test_utils.h"
@@ -107,8 +110,9 @@ MakeGroupBySearchInfo(FieldId vector_field,
 
 void
 AssertVectorIteratorUsableAfterSearchReturns(SearchResult& search_result,
-                                             int64_t max_results) {
-    ASSERT_EQ(search_result.pinned_bitsets_.size(), 1);
+                                             int64_t max_results,
+                                             size_t expected_pinned_bitsets) {
+    ASSERT_EQ(search_result.pinned_bitsets_.size(), expected_pinned_bitsets);
     ASSERT_TRUE(search_result.vector_iterators_.has_value());
     ASSERT_FALSE(search_result.vector_iterators_->empty());
 
@@ -157,35 +161,66 @@ BuildNullableFloatVectorColumn(const FieldMeta& field_meta,
                                int64_t dim,
                                const bool* valid_data,
                                const std::vector<float>& vectors,
-                               std::vector<std::vector<char>>& chunk_buffers) {
+                               std::vector<std::vector<char>>& chunk_buffers,
+                               std::vector<int64_t> rows_per_chunk = {}) {
     std::vector<std::unique_ptr<Chunk>> chunks;
-    std::vector<int64_t> num_rows_per_chunk;
-    num_rows_per_chunk.push_back(total_count);
-
-    auto null_bitmap_bytes = (total_count + 7) / 8;
-    auto vector_data_bytes = vectors.size() * sizeof(float);
-    auto buffer_size = null_bitmap_bytes + vector_data_bytes;
-    chunk_buffers.emplace_back(buffer_size, 0);
-    char* buffer = chunk_buffers.back().data();
-
-    for (int64_t i = 0; i < total_count; ++i) {
-        if (valid_data[i]) {
-            buffer[i >> 3] |= 1U << (i & 0x07);
-        }
+    if (rows_per_chunk.empty()) {
+        rows_per_chunk.push_back(total_count);
     }
-    std::memcpy(buffer + null_bitmap_bytes, vectors.data(), vector_data_bytes);
 
-    auto chunk_mmap_guard = std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
-    chunks.emplace_back(std::make_unique<FixedWidthChunk>(total_count,
-                                                          dim,
-                                                          buffer,
-                                                          buffer_size,
-                                                          sizeof(float),
-                                                          true,
-                                                          chunk_mmap_guard));
+    int64_t logical_begin = 0;
+    int64_t physical_begin = 0;
+    for (auto chunk_rows : rows_per_chunk) {
+        int64_t chunk_valid_count = 0;
+        for (int64_t i = 0; i < chunk_rows; ++i) {
+            if (valid_data[logical_begin + i]) {
+                ++chunk_valid_count;
+            }
+        }
+
+        auto null_bitmap_bytes = (chunk_rows + 7) / 8;
+        auto vector_data_bytes =
+            static_cast<size_t>(chunk_valid_count * dim) * sizeof(float);
+        auto buffer_size = null_bitmap_bytes + vector_data_bytes;
+        chunk_buffers.emplace_back(buffer_size, 0);
+        char* buffer = chunk_buffers.back().data();
+
+        int64_t chunk_physical = 0;
+        for (int64_t i = 0; i < chunk_rows; ++i) {
+            if (!valid_data[logical_begin + i]) {
+                continue;
+            }
+            buffer[i >> 3] |= 1U << (i & 0x07);
+            const auto* src =
+                vectors.data() +
+                static_cast<size_t>((physical_begin + chunk_physical) * dim);
+            auto* dst =
+                buffer + null_bitmap_bytes +
+                static_cast<size_t>(chunk_physical * dim) * sizeof(float);
+            std::memcpy(dst, src, static_cast<size_t>(dim) * sizeof(float));
+            ++chunk_physical;
+        }
+
+        auto chunk_mmap_guard =
+            std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
+        chunks.emplace_back(
+            std::make_unique<FixedWidthChunk>(chunk_rows,
+                                              dim,
+                                              buffer,
+                                              buffer_size,
+                                              sizeof(float),
+                                              true,
+                                              chunk_mmap_guard));
+        logical_begin += chunk_rows;
+        physical_begin += chunk_valid_count;
+    }
+    AssertInfo(logical_begin == total_count,
+               "nullable test chunk rows do not match total rows");
+    AssertInfo(physical_begin * dim == static_cast<int64_t>(vectors.size()),
+               "nullable test compact vectors do not match valid rows");
 
     auto translator = std::make_unique<TestChunkTranslator>(
-        num_rows_per_chunk, "", std::move(chunks));
+        rows_per_chunk, "", std::move(chunks));
     auto slot =
         cachinglayer::Manager::GetInstance().CreateCacheSlot<milvus::Chunk>(
             std::move(translator), nullptr);
@@ -216,14 +251,212 @@ BuildNullableVectorIndex(int64_t total_count,
 
     auto build_dataset =
         knowhere::GenDataSet(vectors.size() / dim, dim, vectors.data());
+    build_dataset->SetIdMapData(
+        knowhere::IdMapData::FromValidData(valid_data, total_count));
     auto build_conf = knowhere::Json{
         {knowhere::meta::METRIC_TYPE, knowhere::metric::COSINE},
         {knowhere::meta::DIM, std::to_string(dim)},
         {knowhere::indexparam::NLIST, "128"},
     };
     index_base->BuildWithDataset(build_dataset, build_conf);
-    vector_index->BuildValidData(valid_data, total_count);
     return index_base;
+}
+
+struct NullableRawVectorFixture {
+    SchemaPtr schema;
+    FieldId vector_field;
+    FieldId pk_field;
+    int64_t total_count = 0;
+    int64_t valid_count = 0;
+    int64_t filtered_logical = 0;
+    int64_t target_logical = 0;
+    std::unique_ptr<bool[]> valid_data;
+    std::vector<float> compact_vectors;
+    std::vector<float> query;
+};
+
+NullableRawVectorFixture
+MakeNullableRawVectorFixture(int64_t total_count = 1400,
+                             int64_t filtered_logical = 1100,
+                             int64_t target_logical = 1200) {
+    NullableRawVectorFixture fixture;
+    fixture.schema = std::make_shared<Schema>();
+    fixture.vector_field = fixture.schema->AddDebugField(
+        "vector", DataType::VECTOR_FLOAT, kDim, knowhere::metric::L2, true);
+    fixture.pk_field = fixture.schema->AddDebugField("pk", DataType::INT64);
+    fixture.schema->set_primary_field_id(fixture.pk_field);
+    fixture.total_count = total_count;
+    fixture.filtered_logical = filtered_logical;
+    fixture.target_logical = target_logical;
+    fixture.valid_data = std::make_unique<bool[]>(total_count);
+    fixture.query.assign(kDim, 0.0F);
+
+    for (int64_t logical = 0; logical < total_count; ++logical) {
+        const bool valid =
+            (logical == filtered_logical || logical == target_logical)
+                ? true
+                : logical % 17 != 5;
+        fixture.valid_data[logical] = valid;
+        if (!valid) {
+            continue;
+        }
+        ++fixture.valid_count;
+        for (int64_t dim = 0; dim < kDim; ++dim) {
+            float value = 1000.0F + static_cast<float>(logical + dim);
+            if (logical == filtered_logical || logical == target_logical) {
+                value = 0.0F;
+            }
+            fixture.compact_vectors.push_back(value);
+        }
+    }
+    return fixture;
+}
+
+std::unique_ptr<InsertRecordProto>
+MakeNullableRawVectorInsertData(const NullableRawVectorFixture& fixture) {
+    std::vector<int64_t> pks(fixture.total_count);
+    std::iota(pks.begin(), pks.end(), 0);
+
+    auto insert_data = std::make_unique<InsertRecordProto>();
+    auto pk_array =
+        segcore::CreateDataArrayFrom(pks.data(),
+                                     nullptr,
+                                     fixture.total_count,
+                                     (*fixture.schema)[fixture.pk_field]);
+    auto vector_array = segcore::CreateVectorDataArrayFrom(
+        fixture.compact_vectors.data(),
+        fixture.valid_data.get(),
+        fixture.total_count,
+        fixture.valid_count,
+        (*fixture.schema)[fixture.vector_field]);
+    insert_data->mutable_fields_data()->AddAllocated(pk_array.release());
+    insert_data->mutable_fields_data()->AddAllocated(vector_array.release());
+    insert_data->set_num_rows(fixture.total_count);
+    return insert_data;
+}
+
+std::unique_ptr<segcore::SegmentGrowing>
+MakeGrowingNullableRawVectorSegment(const NullableRawVectorFixture& fixture) {
+    auto& config = segcore::SegcoreConfig::default_config();
+    segcore::ScopedSegcoreConfigRestore config_restore(config);
+    config.set_chunk_rows(2048);
+    config.set_enable_interim_segment_index(false);
+
+    auto segment = segcore::CreateGrowingSegment(
+        fixture.schema, empty_index_meta, 0, config);
+    auto insert_data = MakeNullableRawVectorInsertData(fixture);
+    std::vector<idx_t> row_ids(fixture.total_count);
+    std::vector<Timestamp> timestamps(fixture.total_count, 100);
+    std::iota(row_ids.begin(), row_ids.end(), 0);
+    auto offset = segment->PreInsert(fixture.total_count);
+    segment->Insert(offset,
+                    fixture.total_count,
+                    row_ids.data(),
+                    timestamps.data(),
+                    insert_data.get());
+    return segment;
+}
+
+SearchInfo
+MakeNullableRawVectorSearchInfo(FieldId vector_field,
+                                int64_t topk,
+                                std::optional<float> radius = std::nullopt,
+                                bool iterator_v2 = false) {
+    SearchInfo search_info;
+    search_info.field_id_ = vector_field;
+    search_info.topk_ = topk;
+    search_info.round_decimal_ = -1;
+    search_info.metric_type_ = knowhere::metric::L2;
+    search_info.search_params_ = knowhere::Json{
+        {knowhere::indexparam::NPROBE, "1"},
+    };
+    if (radius.has_value()) {
+        search_info.search_params_[knowhere::meta::RADIUS] = radius.value();
+    }
+    if (iterator_v2) {
+        SearchIteratorV2Info iterator_info;
+        iterator_info.batch_size = topk;
+        search_info.iterator_v2_info_ = iterator_info;
+    }
+    return search_info;
+}
+
+BitsetView
+MakeSingleFilteredBitset(TargetBitmap& bitmap, int64_t filtered_logical) {
+    bitmap.set(filtered_logical);
+    return BitsetView(bitmap);
+}
+
+void
+ExpectTargetReturnedAndFilteredSkipped(const SearchResult& result,
+                                       int64_t target_logical,
+                                       int64_t filtered_logical) {
+    ASSERT_FALSE(result.seg_offsets_.empty());
+    EXPECT_EQ(result.seg_offsets_[0], target_logical);
+    EXPECT_EQ(std::find(result.seg_offsets_.begin(),
+                        result.seg_offsets_.end(),
+                        filtered_logical),
+              result.seg_offsets_.end())
+        << "filtered logical id must not be returned";
+}
+
+SearchResult
+SearchGrowingNullableRawBruteForce(const NullableRawVectorFixture& fixture,
+                                   SearchInfo search_info) {
+    auto segment = MakeGrowingNullableRawVectorSegment(fixture);
+    auto* growing_segment =
+        dynamic_cast<segcore::SegmentGrowingImpl*>(segment.get());
+    AssertInfo(growing_segment != nullptr, "failed to create growing segment");
+
+    search_info.active_count_ = fixture.total_count;
+    TargetBitmap filter(fixture.total_count, false);
+    auto bitset = MakeSingleFilteredBitset(filter, fixture.filtered_logical);
+
+    SearchResult result;
+    SearchOnGrowing(*growing_segment,
+                    search_info,
+                    fixture.query.data(),
+                    nullptr,
+                    1,
+                    MAX_TIMESTAMP,
+                    bitset,
+                    nullptr,
+                    result);
+    return result;
+}
+
+SearchResult
+SearchSealedNullableRawBruteForce(const NullableRawVectorFixture& fixture,
+                                  const SearchInfo& search_info,
+                                  std::vector<int64_t> rows_per_chunk = {}) {
+    std::vector<std::vector<char>> chunk_buffers;
+    auto column =
+        BuildNullableFloatVectorColumn((*fixture.schema)[fixture.vector_field],
+                                       fixture.total_count,
+                                       kDim,
+                                       fixture.valid_data.get(),
+                                       fixture.compact_vectors,
+                                       chunk_buffers,
+                                       std::move(rows_per_chunk));
+    AssertInfo(column->GetOffsetMapping().IsEnabled(),
+               "sealed nullable column must build an offset mapping");
+
+    TargetBitmap filter(fixture.total_count, false);
+    auto bitset = MakeSingleFilteredBitset(filter, fixture.filtered_logical);
+
+    SearchResult result;
+    SearchOnSealedColumn(*fixture.schema,
+                         column.get(),
+                         search_info,
+                         std::map<std::string, std::string>{},
+                         fixture.query.data(),
+                         nullptr,
+                         1,
+                         fixture.total_count,
+                         bitset,
+                         nullptr,
+                         result);
+    return result;
 }
 
 }  // namespace
@@ -246,7 +479,9 @@ TEST(SearchOnSealedIndexBitsetLifetime,
         BuildNullableVectorIndex(total_count, kDim, valid_data.get(), vectors);
     auto* vector_index = dynamic_cast<index::VectorIndex*>(index_base.get());
     ASSERT_NE(vector_index, nullptr);
-    ASSERT_TRUE(vector_index->GetOffsetMapping().IsEnabled());
+    ASSERT_TRUE(vector_index->HasValidData());
+    ASSERT_EQ(vector_index->GetIdMap().OutCount(), total_count);
+    ASSERT_EQ(vector_index->GetValidCount(), valid_count);
 
     auto indexing_entry = MakeSealedIndexingEntry(
         knowhere::metric::COSINE,
@@ -271,7 +506,9 @@ TEST(SearchOnSealedIndexBitsetLifetime,
                         nullptr,
                         search_result);
 
-    AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count);
+    // Indexed nullable search now passes the caller's logical bitset directly
+    // to Knowhere; there is no Milvus-side transformed bitset to pin.
+    AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count, 0);
 }
 
 TEST(SearchOnSealedIndexCachePinLifetime,
@@ -292,7 +529,9 @@ TEST(SearchOnSealedIndexCachePinLifetime,
         BuildNullableVectorIndex(total_count, kDim, valid_data.get(), vectors);
     auto* vector_index = dynamic_cast<index::VectorIndex*>(index_base.get());
     ASSERT_NE(vector_index, nullptr);
-    ASSERT_TRUE(vector_index->GetOffsetMapping().IsEnabled());
+    ASSERT_TRUE(vector_index->HasValidData());
+    ASSERT_EQ(vector_index->GetIdMap().OutCount(), total_count);
+    ASSERT_EQ(vector_index->GetValidCount(), valid_count);
 
     auto cache_index = CreateTestCacheIndex(
         "nullable-vector-index-pin-lifetime", std::move(index_base));
@@ -394,8 +633,9 @@ TEST(SearchOnSealedIndexNullableNoFilter,
         BuildNullableVectorIndex(total_count, kDim, valid_data.get(), vectors);
     auto* vector_index = dynamic_cast<index::VectorIndex*>(index_base.get());
     ASSERT_NE(vector_index, nullptr);
-    ASSERT_TRUE(vector_index->GetOffsetMapping().IsEnabled());
-    ASSERT_EQ(vector_index->GetOffsetMapping().GetValidCount(), valid_count);
+    ASSERT_TRUE(vector_index->HasValidData());
+    ASSERT_EQ(vector_index->GetIdMap().OutCount(), total_count);
+    ASSERT_EQ(vector_index->GetValidCount(), valid_count);
 
     auto indexing_entry = MakeSealedIndexingEntry(
         knowhere::metric::COSINE,
@@ -538,7 +778,7 @@ TEST(SearchOnGrowingBitsetLifetime,
                     search_result);
 
     ASSERT_EQ(search_result.resource_pins_.size(), 1);
-    AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count);
+    AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count, 0);
     search_result.vector_iterators_.reset();
 
     // The storage reference outlives SearchOnGrowing and is released wherever
@@ -623,6 +863,142 @@ TEST(SearchOnGrowingBitsetLifetime, NullableGrowingEmptyBitsetMeansNoFilter) {
         [](int64_t offset) { return offset != INVALID_SEG_OFFSET; });
     EXPECT_GT(matched, 0)
         << "an empty bitset must not be read as zero visible rows";
+}
+
+TEST(SearchOnGrowingNullableRawBruteForce,
+     KnnUsesLogicalBitsetAndResultIdsAcrossIdMapChunks) {
+    auto fixture = MakeNullableRawVectorFixture();
+    auto search_info = MakeNullableRawVectorSearchInfo(fixture.vector_field, 1);
+    auto result = SearchGrowingNullableRawBruteForce(fixture, search_info);
+
+    ASSERT_EQ(result.seg_offsets_.size(), 1);
+    ExpectTargetReturnedAndFilteredSkipped(
+        result, fixture.target_logical, fixture.filtered_logical);
+}
+
+TEST(SearchOnGrowingNullableRawBruteForce,
+     RangeSearchUsesLogicalBitsetAndResultIdsAcrossIdMapChunks) {
+    auto fixture = MakeNullableRawVectorFixture();
+    auto search_info =
+        MakeNullableRawVectorSearchInfo(fixture.vector_field, 2, 0.01F);
+    auto result = SearchGrowingNullableRawBruteForce(fixture, search_info);
+
+    ASSERT_EQ(result.seg_offsets_.size(), 2);
+    ExpectTargetReturnedAndFilteredSkipped(
+        result, fixture.target_logical, fixture.filtered_logical);
+}
+
+TEST(SearchOnGrowingNullableRawBruteForce,
+     IteratorUsesLogicalBitsetAndResultIdsAcrossIdMapChunks) {
+    auto fixture = MakeNullableRawVectorFixture();
+    auto search_info = MakeNullableRawVectorSearchInfo(
+        fixture.vector_field, 1, std::nullopt, true);
+    auto result = SearchGrowingNullableRawBruteForce(fixture, search_info);
+
+    ASSERT_EQ(result.seg_offsets_.size(), 1);
+    ExpectTargetReturnedAndFilteredSkipped(
+        result, fixture.target_logical, fixture.filtered_logical);
+}
+
+TEST(SearchOnGrowingNullableRawBruteForce,
+     VectorArrayRowSearchReturnsLogicalIds) {
+    constexpr int64_t dim = 2;
+    constexpr int64_t row_count = 4;
+
+    auto schema = std::make_shared<Schema>();
+    auto pk_field = schema->AddDebugField("pk", DataType::INT64);
+    auto vector_field =
+        schema->AddDebugVectorArrayField("emb",
+                                         DataType::VECTOR_FLOAT,
+                                         dim,
+                                         knowhere::metric::MAX_SIM_COSINE,
+                                         true);
+    schema->set_primary_field_id(pk_field);
+
+    auto& config = segcore::SegcoreConfig::default_config();
+    segcore::ScopedSegcoreConfigRestore config_restore(config);
+    config.set_chunk_rows(1024);
+    config.set_enable_interim_segment_index(false);
+
+    auto segment =
+        segcore::CreateGrowingSegment(schema, empty_index_meta, 0, config);
+
+    auto insert_data = std::make_unique<InsertRecordProto>();
+    insert_data->set_num_rows(row_count);
+
+    auto pk_data = insert_data->add_fields_data();
+    pk_data->set_field_id(pk_field.get());
+    pk_data->set_type(proto::schema::DataType::Int64);
+    for (int64_t pk = 0; pk < row_count; ++pk) {
+        pk_data->mutable_scalars()->mutable_long_data()->add_data(pk);
+    }
+
+    auto array_data = insert_data->add_fields_data();
+    array_data->set_field_id(vector_field.get());
+    array_data->set_type(proto::schema::DataType::ArrayOfVector);
+    array_data->add_valid_data(false);
+    array_data->add_valid_data(true);
+    array_data->add_valid_data(true);
+    array_data->add_valid_data(true);
+    array_data->mutable_vectors()->set_dim(dim);
+    auto vector_array = array_data->mutable_vectors()->mutable_vector_array();
+    vector_array->set_dim(dim);
+    vector_array->set_element_type(proto::schema::DataType::FloatVector);
+
+    auto empty_row = vector_array->add_data();
+    empty_row->set_dim(dim);
+    empty_row->mutable_float_vector();
+
+    auto target_row = vector_array->add_data();
+    target_row->set_dim(dim);
+    target_row->mutable_float_vector()->add_data(1.0F);
+    target_row->mutable_float_vector()->add_data(0.0F);
+
+    auto control_row = vector_array->add_data();
+    control_row->set_dim(dim);
+    control_row->mutable_float_vector()->add_data(0.0F);
+    control_row->mutable_float_vector()->add_data(1.0F);
+
+    std::vector<idx_t> row_ids(row_count);
+    std::iota(row_ids.begin(), row_ids.end(), 0);
+    std::vector<Timestamp> timestamps(row_count, 100);
+    auto reserved_offset = segment->PreInsert(row_count);
+    segment->Insert(reserved_offset,
+                    row_count,
+                    row_ids.data(),
+                    timestamps.data(),
+                    insert_data.get());
+
+    auto* growing_segment =
+        dynamic_cast<segcore::SegmentGrowingImpl*>(segment.get());
+    ASSERT_NE(growing_segment, nullptr);
+
+    SearchInfo search_info;
+    search_info.field_id_ = vector_field;
+    search_info.topk_ = 2;
+    search_info.round_decimal_ = -1;
+    search_info.metric_type_ = knowhere::metric::MAX_SIM_COSINE;
+    search_info.search_params_ = knowhere::Json{
+        {knowhere::meta::METRIC_TYPE, knowhere::metric::MAX_SIM_COSINE}};
+    search_info.active_count_ = row_count;
+
+    std::vector<float> query{1.0F, 0.0F};
+    std::vector<size_t> query_offsets{0, 1};
+
+    SearchResult result;
+    SearchOnGrowing(*growing_segment,
+                    search_info,
+                    query.data(),
+                    query_offsets.data(),
+                    1,
+                    MAX_TIMESTAMP,
+                    BitsetView{},
+                    nullptr,
+                    result);
+
+    ASSERT_EQ(result.seg_offsets_.size(), 2);
+    EXPECT_EQ(result.seg_offsets_[0], 2);
+    EXPECT_EQ(result.seg_offsets_[1], 3);
 }
 
 void
@@ -916,6 +1292,79 @@ TEST(SearchOnGrowingBitsetLifetime,
     AssertGrowingIndexEmptyBitsetHonorsPlannedPrefix(false);
 }
 
+TEST(SearchOnSealedColumnNullableRawBruteForce,
+     KnnUsesLogicalBitsetAndResultIds) {
+    auto fixture = MakeNullableRawVectorFixture();
+    auto search_info = MakeNullableRawVectorSearchInfo(fixture.vector_field, 1);
+    auto result = SearchSealedNullableRawBruteForce(fixture, search_info);
+
+    ASSERT_EQ(result.seg_offsets_.size(), 1);
+    ExpectTargetReturnedAndFilteredSkipped(
+        result, fixture.target_logical, fixture.filtered_logical);
+}
+
+TEST(SearchOnSealedColumnNullableRawBruteForce,
+     KnnUsesLogicalBitsetAndResultIdsAcrossPhysicalChunks) {
+    auto fixture = MakeNullableRawVectorFixture();
+    auto search_info = MakeNullableRawVectorSearchInfo(fixture.vector_field, 1);
+    auto result =
+        SearchSealedNullableRawBruteForce(fixture, search_info, {700, 700});
+
+    ASSERT_EQ(result.seg_offsets_.size(), 1);
+    ExpectTargetReturnedAndFilteredSkipped(
+        result, fixture.target_logical, fixture.filtered_logical);
+}
+
+TEST(SearchOnSealedColumnNullableRawBruteForce,
+     RangeSearchUsesLogicalBitsetAndResultIds) {
+    auto fixture = MakeNullableRawVectorFixture();
+    auto search_info =
+        MakeNullableRawVectorSearchInfo(fixture.vector_field, 2, 0.01F);
+    auto result = SearchSealedNullableRawBruteForce(fixture, search_info);
+
+    ASSERT_EQ(result.seg_offsets_.size(), 2);
+    ExpectTargetReturnedAndFilteredSkipped(
+        result, fixture.target_logical, fixture.filtered_logical);
+}
+
+TEST(SearchOnSealedColumnNullableRawBruteForce,
+     RangeSearchUsesLogicalBitsetAndResultIdsAcrossPhysicalChunks) {
+    auto fixture = MakeNullableRawVectorFixture();
+    auto search_info =
+        MakeNullableRawVectorSearchInfo(fixture.vector_field, 2, 0.01F);
+    auto result =
+        SearchSealedNullableRawBruteForce(fixture, search_info, {700, 700});
+
+    ASSERT_EQ(result.seg_offsets_.size(), 2);
+    ExpectTargetReturnedAndFilteredSkipped(
+        result, fixture.target_logical, fixture.filtered_logical);
+}
+
+TEST(SearchOnSealedColumnNullableRawBruteForce,
+     IteratorUsesLogicalBitsetAndResultIds) {
+    auto fixture = MakeNullableRawVectorFixture();
+    auto search_info = MakeNullableRawVectorSearchInfo(
+        fixture.vector_field, 1, std::nullopt, true);
+    auto result = SearchSealedNullableRawBruteForce(fixture, search_info);
+
+    ASSERT_EQ(result.seg_offsets_.size(), 1);
+    ExpectTargetReturnedAndFilteredSkipped(
+        result, fixture.target_logical, fixture.filtered_logical);
+}
+
+TEST(SearchOnSealedColumnNullableRawBruteForce,
+     IteratorUsesLogicalBitsetAndResultIdsAcrossPhysicalChunks) {
+    auto fixture = MakeNullableRawVectorFixture();
+    auto search_info = MakeNullableRawVectorSearchInfo(
+        fixture.vector_field, 1, std::nullopt, true);
+    auto result =
+        SearchSealedNullableRawBruteForce(fixture, search_info, {700, 700});
+
+    ASSERT_EQ(result.seg_offsets_.size(), 1);
+    ExpectTargetReturnedAndFilteredSkipped(
+        result, fixture.target_logical, fixture.filtered_logical);
+}
+
 TEST(SearchOnSealedColumnBitsetLifetime,
      GroupByIteratorMustNotKeepDanglingTransformedBitset) {
     constexpr int64_t total_count = 512;
@@ -959,7 +1408,7 @@ TEST(SearchOnSealedColumnBitsetLifetime,
                          nullptr,
                          search_result);
 
-    AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count);
+    AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count, 0);
 }
 
 }  // namespace milvus::query

--- a/internal/core/src/query/Utils.h
+++ b/internal/core/src/query/Utils.h
@@ -24,6 +24,7 @@
 #include "common/QueryResult.h"
 #include "common/Types.h"
 #include "common/Utils.h"
+#include "knowhere/array_store.h"
 
 namespace milvus::query {
 inline void
@@ -35,11 +36,41 @@ FillEmptySearchResult(SearchResult& result, int64_t num_queries, int64_t topk) {
     result.unity_topK_ = topk;
 }
 
-// Map logical element IDs returned by knowhere to (doc_id, elem_idx) pairs
-// via ArrayOffsets. Caller must ensure the input `element_ids` are already
-// in logical space (i.e. apply OffsetMapping::TransformOffsets first when
-// offset_mapping is enabled), since ArrayOffsets::ElementIDToRowID is keyed
-// on logical element IDs.
+inline BitsetView
+AttachOffsetMappingIds(const BitsetView& bitset,
+                       const OffsetMappingIdView& ids) {
+    auto mapped = bitset;
+    if (!ids.empty()) {
+        // BF scans local physical ids. The mapping view is already clipped to
+        // one contiguous p2l window, so the backend can use ids directly.
+        knowhere::IdArray out_ids(ids.data, static_cast<size_t>(ids.count));
+        mapped.set_id_offset(0);
+        mapped.set_out_ids(out_ids, out_ids.size());
+        mapped.set_vector_count(static_cast<size_t>(ids.count));
+    }
+    return mapped;
+}
+
+inline const void*
+AdvanceVectorDataPointer(const void* data,
+                         DataType data_type,
+                         int64_t dim,
+                         int64_t rows) {
+    if (rows == 0) {
+        return data;
+    }
+    if (data_type == DataType::VECTOR_SPARSE_U32_F32) {
+        return static_cast<const knowhere::sparse::SparseRow<SparseValueType>*>(
+                   data) +
+               rows;
+    }
+    return static_cast<const uint8_t*>(data) +
+           rows * static_cast<int64_t>(GetDataTypeSize(data_type, dim));
+}
+
+// Map VECTOR_ARRAY element IDs returned by Knowhere to (doc_id, elem_idx)
+// pairs via ArrayOffsets. This is element-space only; row-level nullable
+// mapping is handled before or inside Knowhere search.
 inline std::pair<std::vector<int64_t>, std::vector<int32_t>>
 ApplyElementIDMapping(const std::vector<int64_t>& element_ids,
                       const milvus::IArrayOffsets& array_offsets) {
@@ -61,24 +92,11 @@ ApplyElementIDMapping(const std::vector<int64_t>& element_ids,
     return std::make_pair(std::move(doc_offsets), std::move(element_indices));
 }
 
-// Map knowhere's raw offsets back to logical space. The two inputs are
-// mutually exclusive:
-//
-// - array_offsets != nullptr (VECTOR_ARRAY element-level search):
-//   knowhere returns physical element IDs. ArrayOffsets is built by
-//   walking every row in the segment and advancing the row counter on
-//   every row (including empty/null rows, which occupy a zero-length
-//   element range), so ElementIDToRowID produces (logical_row_id,
-//   elem_idx) directly. No OffsetMapping pass is needed.
-//
-// - array_offsets == nullptr (plain vector field): when OffsetMapping is
-//   enabled, the index/chunk was built over valid rows only, so
-//   knowhere's physical row IDs must be remapped to logical via
-//   OffsetMapping. When OffsetMapping is disabled, TransformOffsets is a
-//   no-op.
+// Convert VECTOR_ARRAY element IDs to (row_id, elem_idx). Row-level vector
+// search already receives logical IDs from Knowhere: indexed paths use IdMap,
+// raw BF paths pass physical->logical IDs through BitsetView.
 inline void
 FinalizeVectorSearchOffsets(SearchResult& result,
-                            const milvus::OffsetMapping& offset_mapping,
                             const milvus::IArrayOffsets* array_offsets) {
     if (array_offsets != nullptr) {
         auto [doc_offsets, elem_indices] =
@@ -86,10 +104,6 @@ FinalizeVectorSearchOffsets(SearchResult& result,
         result.seg_offsets_ = std::move(doc_offsets);
         result.element_indices_ = std::move(elem_indices);
         result.element_level_ = true;
-    } else {
-        if (offset_mapping.IsEnabled()) {
-            offset_mapping.TransformOffsets(result.seg_offsets_);
-        }
     }
 }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedBinlogIndexTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedBinlogIndexTest.cpp
@@ -387,6 +387,10 @@ class BinlogIndexTest : public ::testing::TestWithParam<Param> {
         } else {
             throw std::runtime_error("not implemented");
         }
+        if (nullable) {
+            raw_dataset->SetIdMapData(knowhere::IdMapData::FromValidBitmap(
+                valid_data.data(), data_n));
+        }
     }
 
  public:
@@ -986,17 +990,6 @@ TEST_P(BinlogIndexTest, AccuracyWithLoadFieldData) {
                 vec_indexing_for_serde->Load(binary_set, load_conf);
             }
 
-            if (nullable) {
-                auto vec_indexing =
-                    dynamic_cast<milvus::index::VectorIndex*>(indexing.get());
-                ASSERT_NE(vec_indexing, nullptr);
-                std::unique_ptr<bool[]> valid_data_bool(new bool[data_n]);
-                for (int64_t i = 0; i < data_n; ++i) {
-                    valid_data_bool[i] = (valid_data[i >> 3] >> (i & 0x07)) & 1;
-                }
-                vec_indexing->UpdateValidData(valid_data_bool.get(), data_n);
-            }
-
             LoadIndexInfo load_info;
             load_info.field_id = vec_field_id.get();
             load_info.index_params = GenIndexParams(indexing.get());
@@ -1269,17 +1262,6 @@ TEST_P(BinlogIndexTest, AccuracyWithMapFieldData) {
                 vec_indexing_for_serde->Load(binary_set, load_conf);
             }
 
-            if (nullable) {
-                auto vec_indexing =
-                    dynamic_cast<milvus::index::VectorIndex*>(indexing.get());
-                ASSERT_NE(vec_indexing, nullptr);
-                std::unique_ptr<bool[]> valid_data_bool(new bool[data_n]);
-                for (int64_t i = 0; i < data_n; ++i) {
-                    valid_data_bool[i] = (valid_data[i >> 3] >> (i & 0x07)) & 1;
-                }
-                vec_indexing->UpdateValidData(valid_data_bool.get(), data_n);
-            }
-
             LoadIndexInfo load_info;
             load_info.field_id = vec_field_id.get();
             load_info.index_params = GenIndexParams(indexing.get());
@@ -1414,17 +1396,6 @@ TEST_P(BinlogIndexTest, DisableInterimIndex) {
                 {knowhere::meta::METRIC_TYPE, metric_type}};
             auto binary_set = indexing->Serialize(load_conf);
             vec_indexing_for_serde->Load(binary_set, load_conf);
-        }
-
-        if (nullable) {
-            auto vec_indexing =
-                dynamic_cast<milvus::index::VectorIndex*>(indexing.get());
-            ASSERT_NE(vec_indexing, nullptr);
-            std::unique_ptr<bool[]> valid_data_bool(new bool[data_n]);
-            for (int64_t i = 0; i < data_n; ++i) {
-                valid_data_bool[i] = (valid_data[i >> 3] >> (i & 0x07)) & 1;
-            }
-            vec_indexing->UpdateValidData(valid_data_bool.get(), data_n);
         }
 
         LoadIndexInfo load_info;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -3758,8 +3758,13 @@ ChunkedSegmentSealedImpl::FilterVectorValidOffsetsFromIndex(
                "nullable vector index does not contain valid data");
 
     result.valid_data = std::make_unique<bool[]>(count);
-    vec_index->GetOffsetMapping().FilterValidLogicalOffsets(
-        seg_offsets, count, result.valid_data.get(), result.valid_offsets);
+    result.valid_offsets.reserve(count);
+    for (int64_t i = 0; i < count; ++i) {
+        result.valid_data[i] = vec_index->IsRowValid(seg_offsets[i]);
+        if (result.valid_data[i]) {
+            result.valid_offsets.push_back(seg_offsets[i]);
+        }
+    }
     result.valid_count = result.valid_offsets.size();
     return result;
 }
@@ -3916,9 +3921,8 @@ ChunkedSegmentSealedImpl::get_emb_list(milvus::OpContext* op_ctx,
         return data_array;
     }
 
-    // Build el_ids dataset from valid_offsets. For nullable VECTOR_ARRAY, the
-    // index offset mapping maps logical row offsets to compact physical
-    // embedding-list ids.
+    // Knowhere IdMap maps nullable list ids internally, so ids stay logical at
+    // the Milvus/VectorIndex boundary.
     auto ids_ds = GenIdsDataset(valid_count, valid_offsets);
 
     auto [raw_data, offsets] = vec_index->GetEmbListByIds(ids_ds, metric_type);
@@ -6415,20 +6419,8 @@ ChunkedSegmentSealedImpl::CalcDistByIDs(
     if (vec_index == nullptr) {
         return false;
     }
-    // Callers pass logical offsets (already translated from physical by
-    // SearchOnIndex). When the index carries an offset_mapping (nullable
-    // vector), the underlying knowhere index operates on physical offsets,
-    // so translate logical -> physical before the call.
-    const auto& offset_mapping = vec_index->GetOffsetMapping();
-    std::vector<int64_t> physical_offsets;
-    const int64_t* labels = seg_offsets;
-    if (offset_mapping.IsEnabled()) {
-        physical_offsets.assign(seg_offsets, seg_offsets + count);
-        offset_mapping.TransformLogicalOffsets(physical_offsets);
-        labels = physical_offsets.data();
-    }
     auto res = vec_index->CalcDistByIDs(
-        query_dataset, BitsetView(), labels, count, is_cosine, op_ctx);
+        query_dataset, BitsetView(), seg_offsets, count, is_cosine, op_ctx);
     if (!res.has_value()) {
         return false;
     }

--- a/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
@@ -126,6 +126,96 @@ MakeSearchResult(std::vector<int64_t> offsets) {
     return result;
 }
 
+struct NullableVectorArrayRow {
+    bool valid = true;
+    std::vector<float> values;
+};
+
+std::vector<char>
+BuildNullableVectorArrayChunkBuffer(
+    int64_t dim, const std::vector<NullableVectorArrayRow>& rows) {
+    const auto row_count = static_cast<int64_t>(rows.size());
+    const auto bitmap_bytes = (row_count + 7) / 8;
+    const auto header_bytes = sizeof(uint32_t) * (row_count * 2 + 1);
+    const auto payload_offset =
+        static_cast<uint32_t>(bitmap_bytes + header_bytes);
+    const auto vector_bytes = static_cast<uint32_t>(dim * sizeof(float));
+
+    size_t payload_values = 0;
+    for (const auto& row : rows) {
+        AssertInfo(row.valid || row.values.empty(),
+                   "null vector-array row must not carry payload");
+        AssertInfo(row.values.size() % dim == 0,
+                   "vector-array row payload is not aligned to dim");
+        payload_values += row.values.size();
+    }
+
+    std::vector<char> buffer(bitmap_bytes + header_bytes +
+                                 payload_values * sizeof(float) +
+                                 MMAP_ARRAY_PADDING,
+                             0);
+    std::vector<uint32_t> header(static_cast<size_t>(row_count * 2 + 1));
+
+    auto payload_cursor = payload_offset;
+    auto* payload = buffer.data() + payload_offset;
+    for (int64_t i = 0; i < row_count; ++i) {
+        const auto& row = rows[i];
+        if (row.valid) {
+            buffer[i >> 3] |= 1U << (i & 0x07);
+        }
+        header[i * 2] = payload_cursor;
+        header[i * 2 + 1] = static_cast<uint32_t>(row.values.size() / dim);
+        if (!row.values.empty()) {
+            const auto payload_bytes = row.values.size() * sizeof(float);
+            memcpy(payload, row.values.data(), payload_bytes);
+            payload += payload_bytes;
+            payload_cursor +=
+                static_cast<uint32_t>(row.values.size() / dim) * vector_bytes;
+        }
+    }
+    header[row_count * 2] = payload_cursor;
+    memcpy(buffer.data() + bitmap_bytes,
+           header.data(),
+           header.size() * sizeof(uint32_t));
+    return buffer;
+}
+
+std::shared_ptr<ChunkedColumnInterface>
+BuildNullableVectorArrayColumn(
+    const FieldMeta& field_meta,
+    int64_t dim,
+    const std::vector<std::vector<NullableVectorArrayRow>>& chunk_rows,
+    std::vector<std::vector<char>>& buffers) {
+    std::vector<std::unique_ptr<Chunk>> chunks;
+    std::vector<int64_t> rows_per_chunk;
+    chunks.reserve(chunk_rows.size());
+    rows_per_chunk.reserve(chunk_rows.size());
+    buffers.reserve(chunk_rows.size());
+
+    for (const auto& rows : chunk_rows) {
+        buffers.emplace_back(BuildNullableVectorArrayChunkBuffer(dim, rows));
+        rows_per_chunk.push_back(static_cast<int64_t>(rows.size()));
+        auto chunk_mmap_guard =
+            std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
+        chunks.emplace_back(std::make_unique<VectorArrayChunk>(
+            dim,
+            static_cast<int32_t>(rows.size()),
+            buffers.back().data(),
+            buffers.back().size(),
+            field_meta.get_element_type(),
+            chunk_mmap_guard,
+            true));
+    }
+
+    auto translator = std::make_unique<TestChunkTranslator>(
+        rows_per_chunk, "", std::move(chunks));
+    auto slot =
+        cachinglayer::Manager::GetInstance().CreateCacheSlot<milvus::Chunk>(
+            std::move(translator), nullptr);
+    return MakeChunkedColumnBase(
+        DataType::VECTOR_ARRAY, std::move(slot), field_meta);
+}
+
 segcore::SegmentSealedUPtr
 CreateColdVectorOutputSegment(const SchemaPtr& schema,
                               const FieldId& vector_field_id,
@@ -567,7 +657,6 @@ TEST(test_chunk_segment,
      SearchOnSealedColumnNullableVectorArrayUsesLogicalRowOffsets) {
     constexpr int64_t dim = 2;
     constexpr int64_t row_count = 6;
-    constexpr int64_t vector_count = 3;
 
     auto schema = std::make_shared<Schema>();
     auto vec_id =
@@ -578,58 +667,16 @@ TEST(test_chunk_segment,
                                          true);
     auto field_meta = schema->operator[](vec_id);
 
-    const auto bitmap_bytes = (row_count + 7) / 8;
-    const auto header_bytes = sizeof(uint32_t) * (row_count * 2 + 1);
-    const auto payload_offset =
-        static_cast<uint32_t>(bitmap_bytes + header_bytes);
-    const auto vector_bytes = static_cast<uint32_t>(dim * sizeof(float));
-    const std::array<float, vector_count * dim> payload{
-        1.0F, 0.0F, 0.0F, 1.0F, -1.0F, 0.0F};
-    std::vector<char> buffer(bitmap_bytes + header_bytes +
-                                 payload.size() * sizeof(float) +
-                                 MMAP_ARRAY_PADDING,
-                             0);
-
-    // Logical rows: [NULL, [], [A], [B], [], [C]].
-    buffer[0] = 0b00111110;
-    const std::array<uint32_t, row_count * 2 + 1> header{
-        payload_offset,
-        0,
-        payload_offset,
-        0,
-        payload_offset,
-        1,
-        payload_offset + vector_bytes,
-        1,
-        payload_offset + 2 * vector_bytes,
-        0,
-        payload_offset + 2 * vector_bytes,
-        1,
-        payload_offset + 3 * vector_bytes};
-    memcpy(buffer.data() + bitmap_bytes,
-           header.data(),
-           header.size() * sizeof(uint32_t));
-    memcpy(buffer.data() + payload_offset,
-           payload.data(),
-           payload.size() * sizeof(float));
-
-    std::vector<std::unique_ptr<Chunk>> chunks;
-    auto chunk_mmap_guard = std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
-    chunks.emplace_back(
-        std::make_unique<VectorArrayChunk>(dim,
-                                           row_count,
-                                           buffer.data(),
-                                           buffer.size(),
-                                           DataType::VECTOR_FLOAT,
-                                           chunk_mmap_guard,
-                                           true));
-    auto translator = std::make_unique<TestChunkTranslator>(
-        std::vector<int64_t>{row_count}, "", std::move(chunks));
-    auto slot =
-        cachinglayer::Manager::GetInstance().CreateCacheSlot<milvus::Chunk>(
-            std::move(translator), nullptr);
-    auto column = MakeChunkedColumnBase(
-        DataType::VECTOR_ARRAY, std::move(slot), field_meta);
+    std::vector<std::vector<char>> buffers;
+    auto column = BuildNullableVectorArrayColumn(field_meta,
+                                                 dim,
+                                                 {{{false, {}},
+                                                   {true, {}},
+                                                   {true, {1.0F, 0.0F}},
+                                                   {true, {0.0F, 1.0F}},
+                                                   {true, {}},
+                                                   {true, {-1.0F, 0.0F}}}},
+                                                 buffers);
     ASSERT_FALSE(column->GetOffsetMapping().IsEnabled());
     auto offsets_pw = column->VectorArrayOffsets(nullptr, 0);
     const std::array<size_t, row_count + 1> expected_offsets{
@@ -686,7 +733,95 @@ TEST(test_chunk_segment,
     EXPECT_EQ(filtered_result.seg_offsets_[2], INVALID_SEG_OFFSET);
     EXPECT_FLOAT_EQ(filtered_result.distances_[0], 1.0F);
     EXPECT_FLOAT_EQ(filtered_result.distances_[1], -1.0F);
-    EXPECT_FALSE(column->GetOffsetMapping().IsEnabled());
+    EXPECT_TRUE(column->GetOffsetMapping().IsEnabled());
+    EXPECT_EQ(column->GetOffsetMapping().GetValidCount(), 5);
+    const std::array<size_t, 6> expected_valid_offsets{0, 0, 1, 2, 2, 3};
+    const auto& valid_offsets = column->GetValidArrayOffsetsInChunk(0);
+    ASSERT_EQ(valid_offsets.size(), expected_valid_offsets.size());
+    for (size_t i = 0; i < expected_valid_offsets.size(); ++i) {
+        EXPECT_EQ(valid_offsets[i], expected_valid_offsets[i]);
+    }
+}
+
+TEST(test_chunk_segment,
+     SearchOnSealedColumnNullableVectorArrayUsesCachedChunkOffsets) {
+    constexpr int64_t dim = 2;
+    constexpr int64_t row_count = 7;
+
+    auto schema = std::make_shared<Schema>();
+    auto vec_id =
+        schema->AddDebugVectorArrayField("profile[embedding]",
+                                         DataType::VECTOR_FLOAT,
+                                         dim,
+                                         knowhere::metric::MAX_SIM_COSINE,
+                                         true);
+    auto field_meta = schema->operator[](vec_id);
+
+    std::vector<std::vector<char>> buffers;
+    auto column = BuildNullableVectorArrayColumn(
+        field_meta,
+        dim,
+        {{{false, {}}, {true, {}}, {true, {1.0F, 0.0F}}},
+         {{false, {}},
+          {true, {0.0F, 1.0F}},
+          {true, {}},
+          {true, {-1.0F, 0.0F}}}},
+        buffers);
+
+    SearchInfo search_info;
+    search_info.search_params_ = knowhere::Json{
+        {knowhere::meta::METRIC_TYPE, knowhere::metric::MAX_SIM_COSINE}};
+    search_info.field_id_ = vec_id;
+    search_info.metric_type_ = knowhere::metric::MAX_SIM_COSINE;
+    search_info.topk_ = 3;
+
+    const std::array<float, dim> query{1.0F, 0.0F};
+    const std::array<size_t, 2> query_offsets{0, 1};
+    const std::map<std::string, std::string> index_info;
+    milvus::OpContext op_context;
+
+    auto run_search = [&](const BitsetView& bitset) {
+        SearchResult result;
+        query::SearchOnSealedColumn(*schema,
+                                    column.get(),
+                                    search_info,
+                                    index_info,
+                                    query.data(),
+                                    query_offsets.data(),
+                                    1,
+                                    row_count,
+                                    bitset,
+                                    &op_context,
+                                    result);
+        return result;
+    };
+
+    auto result = run_search(BitsetView{});
+    ASSERT_EQ(result.seg_offsets_.size(), 3);
+    EXPECT_EQ(result.seg_offsets_[0], 2);
+    EXPECT_EQ(result.seg_offsets_[1], 4);
+    EXPECT_EQ(result.seg_offsets_[2], 6);
+
+    std::array<uint8_t, 1> filtered_bits{1U << 4};
+    auto filtered_result =
+        run_search(BitsetView(filtered_bits.data(), row_count));
+    ASSERT_EQ(filtered_result.seg_offsets_.size(), 3);
+    EXPECT_EQ(filtered_result.seg_offsets_[0], 2);
+    EXPECT_EQ(filtered_result.seg_offsets_[1], 6);
+    EXPECT_EQ(filtered_result.seg_offsets_[2], INVALID_SEG_OFFSET);
+
+    const std::array<size_t, 3> chunk0_offsets{0, 0, 1};
+    const std::array<size_t, 4> chunk1_offsets{0, 1, 1, 2};
+    const auto& valid_offsets0 = column->GetValidArrayOffsetsInChunk(0);
+    const auto& valid_offsets1 = column->GetValidArrayOffsetsInChunk(1);
+    ASSERT_EQ(valid_offsets0.size(), chunk0_offsets.size());
+    ASSERT_EQ(valid_offsets1.size(), chunk1_offsets.size());
+    for (size_t i = 0; i < chunk0_offsets.size(); ++i) {
+        EXPECT_EQ(valid_offsets0[i], chunk0_offsets[i]);
+    }
+    for (size_t i = 0; i < chunk1_offsets.size(); ++i) {
+        EXPECT_EQ(valid_offsets1[i], chunk1_offsets[i]);
+    }
 }
 
 // Test search on nullable vector field with all null vectors
@@ -906,8 +1041,8 @@ TEST(test_chunk_segment, TestSearchIteratorOnSealedWithAllNullVectors) {
 // This test verifies:
 // 1. CachedSearchIterator uses valid_count_per_chunk (not total row count)
 //    as chunk_size, preventing out-of-bounds reads
-// 2. TransformOffset is applied after NextBatch, converting physical offsets
-//    (valid-only) back to logical offsets (including nulls)
+// 2. Knowhere BF receives each chunk's physical->logical id window and returns
+//    logical offsets directly.
 TEST(test_chunk_segment, TestSearchIteratorOnSealedWithPartialNullVectors) {
     int dim = 16;
     int chunk_num = 2;
@@ -1020,9 +1155,6 @@ TEST(test_chunk_segment, TestSearchIteratorOnSealedWithPartialNullVectors) {
     SearchResult search_result;
     milvus::OpContext op_context;
 
-    // This exercises both fixes:
-    // Fix 1: CachedSearchIterator uses valid_count_per_chunk as chunk_size
-    // Fix 2: TransformOffset converts physical -> logical offsets
     query::SearchOnSealedColumn(*schema,
                                 column.get(),
                                 search_info,

--- a/internal/core/src/segcore/ConcurrentVector.h
+++ b/internal/core/src/segcore/ConcurrentVector.h
@@ -335,6 +335,11 @@ class VectorBase {
         return FixedVector<bool>{};
     }
 
+    virtual void
+    bulk_is_valid_range(int64_t start, int64_t count, bool* out) const {
+        std::fill_n(out, count, true);
+    }
+
     // Non-nullable fields have no mapping at all; hand back the shared no-op
     // so callers never have to branch on a null pointer.
     virtual const OffsetMapping&
@@ -682,6 +687,17 @@ class ConcurrentVectorImpl : public VectorBase {
             return valid_data_ptr_->get_data();
         }
         return FixedVector<bool>{};
+    }
+
+    void
+    bulk_is_valid_range(int64_t start,
+                        int64_t count,
+                        bool* out) const override {
+        if (valid_data_ptr_ != nullptr) {
+            valid_data_ptr_->bulk_is_valid_range(start, count, out);
+            return;
+        }
+        std::fill_n(out, count, true);
     }
 
  private:

--- a/internal/core/src/segcore/FieldIndexing.cpp
+++ b/internal/core/src/segcore/FieldIndexing.cpp
@@ -35,6 +35,7 @@
 #include "index/RTreeIndex.h"
 #include "index/ScalarIndexSort.h"
 #include "index/StringIndexMarisa.h"
+#include "index/VectorIndexValidDataUtils.h"
 #include "index/VectorMemIndex.h"
 #include "knowhere/comp/index_param.h"
 #include "knowhere/dataset.h"
@@ -53,6 +54,71 @@
 
 namespace milvus::segcore {
 using std::unique_ptr;
+
+namespace {
+
+struct NullableAppendInfo {
+    std::unique_ptr<bool[]> batch_valid_data;
+    int64_t logical_begin = 0;
+    int64_t logical_count = 0;
+    int64_t valid_before_new = 0;
+    int64_t add_count = 0;
+
+    bool
+    HasLogicalRange() const {
+        return logical_count > 0;
+    }
+
+    bool
+    HasPayload() const {
+        return add_count > 0;
+    }
+
+    const bool*
+    ValidDataForNewRange(int64_t reserved_offset) const {
+        return batch_valid_data.get() + (logical_begin - reserved_offset);
+    }
+};
+
+NullableAppendInfo
+PrepareNullableAppendInfo(const VectorBase* field_raw_data,
+                          int64_t reserved_offset,
+                          int64_t size,
+                          int64_t indexed_logical_count) {
+    AssertInfo(size >= 0, "nullable index append size is negative");
+    const auto logical_end = reserved_offset + size;
+    if (size == 0 || indexed_logical_count >= logical_end) {
+        NullableAppendInfo info;
+        info.logical_begin = logical_end;
+        return info;
+    }
+    AssertInfo(indexed_logical_count >= reserved_offset,
+               "nullable index id map lags behind append batch, indexed "
+               "logical count: {}, reserved offset: {}",
+               indexed_logical_count,
+               reserved_offset);
+
+    NullableAppendInfo info;
+    info.logical_begin = indexed_logical_count;
+    info.logical_count = logical_end - indexed_logical_count;
+    info.batch_valid_data = std::make_unique<bool[]>(static_cast<size_t>(size));
+    field_raw_data->bulk_is_valid_range(
+        reserved_offset, size, info.batch_valid_data.get());
+
+    for (int64_t i = 0; i < size; ++i) {
+        if (!info.batch_valid_data[i]) {
+            continue;
+        }
+        if (reserved_offset + i < info.logical_begin) {
+            ++info.valid_before_new;
+        } else {
+            ++info.add_count;
+        }
+    }
+    return info;
+}
+
+}  // namespace
 
 void
 IndexingRecord::AppendingIndex(int64_t reserved_offset,
@@ -166,6 +232,7 @@ VectorFieldIndexing::VectorFieldIndexing(const FieldMeta& field_meta,
     : FieldIndexing(field_meta, segcore_config),
       built_(false),
       sync_with_index_(false),
+      index_unavailable_(false),
       config_(std::make_unique<VecIndexConfig>(
           segment_max_row_count,
           field_index_meta,
@@ -189,7 +256,7 @@ VectorFieldIndexing::recreate_index(DataType data_type,
             reinterpret_cast<const ConcurrentVector<FloatVector>*>(
                 field_raw_data);
         AssertInfo(concurrent_fp32_vec != nullptr,
-                   "Fail to generate a cocurrent vector when recreate_index in "
+                   "Fail to generate a concurrent vector when create_index in "
                    "growing segment.");
         knowhere::ViewDataOp view_data = [field_raw_data_ptr =
                                               concurrent_fp32_vec](size_t id) {
@@ -206,7 +273,7 @@ VectorFieldIndexing::recreate_index(DataType data_type,
             reinterpret_cast<const ConcurrentVector<Float16Vector>*>(
                 field_raw_data);
         AssertInfo(concurrent_fp16_vec != nullptr,
-                   "Fail to generate a cocurrent vector when    recreate_index "
+                   "Fail to generate a concurrent vector when create_index "
                    "in growing segment.");
         knowhere::ViewDataOp view_data = [field_raw_data_ptr =
                                               concurrent_fp16_vec](size_t id) {
@@ -223,7 +290,7 @@ VectorFieldIndexing::recreate_index(DataType data_type,
             reinterpret_cast<const ConcurrentVector<BFloat16Vector>*>(
                 field_raw_data);
         AssertInfo(concurrent_bf16_vec != nullptr,
-                   "Fail to generate a cocurrent vector when    recreate_index "
+                   "Fail to generate a concurrent vector when create_index "
                    "in growing segment.");
         knowhere::ViewDataOp view_data = [field_raw_data_ptr =
                                               concurrent_bf16_vec](size_t id) {
@@ -236,6 +303,18 @@ VectorFieldIndexing::recreate_index(DataType data_type,
             knowhere::Version::GetCurrentVersion().VersionNumber(),
             view_data);
     }
+    built_.store(false);
+    sync_with_index_.store(false);
+    index_cur_.store(0);
+    index_unavailable_.store(false);
+}
+
+void
+VectorFieldIndexing::DisableIndexAfterBuildFailure() {
+    built_.store(false);
+    sync_with_index_.store(false);
+    index_cur_.store(0);
+    index_unavailable_.store(true);
 }
 
 // for sparse float vector:
@@ -273,6 +352,9 @@ VectorFieldIndexing::AppendSegmentIndexSparse(int64_t reserved_offset,
     using value_type = knowhere::sparse::SparseRow<SparseValueType>;
     AssertInfo(get_data_type() == DataType::VECTOR_SPARSE_U32_F32,
                "Data type of vector field is not VECTOR_SPARSE_U32_F32");
+    if (index_unavailable_.load()) {
+        return;
+    }
 
     auto conf = get_build_params(get_data_type());
     auto field_source =
@@ -287,7 +369,6 @@ VectorFieldIndexing::AppendSegmentIndexSparse(int64_t reserved_offset,
     auto size_per_chunk = field_raw_data->get_size_per_chunk();
     auto build_threshold = get_build_threshold();
     bool is_mapping_storage = field_raw_data->is_mapping_storage();
-    auto valid_data = field_raw_data->get_valid_data();
 
     if (!built_) {
         const void* data_ptr = nullptr;
@@ -324,19 +405,27 @@ VectorFieldIndexing::AppendSegmentIndexSparse(int64_t reserved_offset,
 
         auto dataset = knowhere::GenDataSet(build_threshold, dim, data_ptr);
         dataset->SetIsSparse(true);
+        std::unique_ptr<bool[]> id_map_valid_data;
+        if (is_mapping_storage) {
+            auto logical_offset =
+                field_raw_data->get_logical_offset(build_threshold - 1);
+            auto update_count = logical_offset + 1;
+            index_->SetIdMapType(knowhere::IdMap::Type::GROWING);
+            // IdMapData only keeps a view of valid_data; keep this buffer
+            // alive until the synchronous Build call consumes the dataset.
+            id_map_valid_data = std::make_unique<bool[]>(update_count);
+            field_raw_data->bulk_is_valid_range(
+                0, update_count, id_map_valid_data.get());
+            dataset->SetIdMapData(knowhere::IdMapData::FromValidData(
+                id_map_valid_data.get(), static_cast<size_t>(update_count)));
+        }
         try {
             index_->BuildWithDataset(dataset, conf);
-            if (is_mapping_storage) {
-                auto logical_offset =
-                    field_raw_data->get_logical_offset(build_threshold - 1);
-                auto update_count = logical_offset + 1;
-                index_->UpdateValidData(valid_data.data(), update_count);
-            }
             built_ = true;
             index_cur_.fetch_add(build_threshold);
         } catch (SegcoreError& error) {
             LOG_ERROR("growing sparse index build error: {}", error.what());
-            recreate_index(get_data_type(), field_raw_data);
+            DisableIndexAfterBuildFailure();
             return;
         }
     }
@@ -344,7 +433,7 @@ VectorFieldIndexing::AppendSegmentIndexSparse(int64_t reserved_offset,
     // Append rest data when index has been built
     int64_t add_count = 0;
     int64_t total_count = 0;
-    if (valid_data.empty()) {
+    if (!is_mapping_storage) {
         // Non-nullable case: add all rows
         add_count = reserved_offset + size - index_cur_.load();
         total_count = size;
@@ -361,56 +450,37 @@ VectorFieldIndexing::AppendSegmentIndexSparse(int64_t reserved_offset,
             sync_with_index_.store(true);
         } catch (SegcoreError& error) {
             LOG_ERROR("growing sparse index add error: {}", error.what());
-            // Known design defect: after a raw-data-owning interim index has
-            // synchronized, its source chunks may have been reclaimed and
-            // field_raw_data is no longer a complete recovery source. This
-            // catch is reachable when AddWithDataset fails, but recreating the
-            // index here is not a valid recovery path and must not exist under
-            // single-owner semantics. The failure should instead be propagated
-            // and the segment marked unrecoverable.
-            recreate_index(get_data_type(), field_raw_data);
+            throw;
         }
     } else {
-        // Nullable case: only add valid rows (matching dense vector approach)
-        auto index_total_count = index_->GetOffsetMapping().GetTotalCount();
-        auto add_valid_data_count = reserved_offset + size - index_total_count;
-        for (auto i = reserved_offset; i < reserved_offset + size; i++) {
-            if (valid_data[i]) {
-                total_count++;
-                if (i >= index_total_count) {
-                    add_count++;
-                }
-            }
-        }
-        if (add_count <= 0 && add_valid_data_count <= 0) {
+        auto append_info = PrepareNullableAppendInfo(
+            field_raw_data,
+            reserved_offset,
+            size,
+            static_cast<int64_t>(index_->GetIdMap().OutCount()));
+        if (!append_info.HasLogicalRange()) {
             sync_with_index_.store(true);
             return;
         }
-        if (add_count > 0) {
-            auto data_ptr = source + (total_count - add_count);
-            auto dataset = knowhere::GenDataSet(add_count, dim, data_ptr);
-            dataset->SetIsSparse(true);
-            try {
-                index_->AddWithDataset(dataset, conf);
-            } catch (SegcoreError& error) {
-                LOG_ERROR("growing sparse index add error: {}", error.what());
-                // Known design defect: after a raw-data-owning interim index
-                // has synchronized, its source chunks may have been reclaimed
-                // and field_raw_data is no longer a complete recovery source.
-                // This catch is reachable when AddWithDataset fails, but
-                // recreating the index here is not a valid recovery path and
-                // must not exist under single-owner semantics. The failure
-                // should instead be propagated and the segment marked
-                // unrecoverable.
-                recreate_index(get_data_type(), field_raw_data);
-            }
+        auto dataset =
+            append_info.HasPayload()
+                ? knowhere::GenDataSet(append_info.add_count,
+                                       dim,
+                                       source + append_info.valid_before_new)
+                : knowhere::GenDataSet(0, dim, nullptr);
+        dataset->SetIsSparse(true);
+        index_->SetIdMapType(knowhere::IdMap::Type::GROWING);
+        dataset->SetIdMapData(knowhere::IdMapData::FromValidData(
+            append_info.ValidDataForNewRange(reserved_offset),
+            static_cast<size_t>(append_info.logical_count)));
+        try {
+            index_->AddWithDataset(dataset, conf);
+            index_cur_.fetch_add(append_info.add_count);
+            sync_with_index_.store(true);
+        } catch (SegcoreError& error) {
+            LOG_ERROR("growing sparse index add error: {}", error.what());
+            throw;
         }
-        if (add_valid_data_count > 0) {
-            index_->UpdateValidData(valid_data.data() + index_total_count,
-                                    add_valid_data_count);
-        }
-        index_cur_.fetch_add(add_count);
-        sync_with_index_.store(true);
     }
 }
 
@@ -424,12 +494,15 @@ VectorFieldIndexing::AppendSegmentIndexDense(int64_t reserved_offset,
                    get_data_type() == DataType::VECTOR_BFLOAT16,
                "Data type of vector field is not in (VECTOR_FLOAT, "
                "VECTOR_FLOAT16,VECTOR_BFLOAT16)");
+    if (index_unavailable_.load()) {
+        return;
+    }
+
     auto dim = get_dim();
     auto conf = get_build_params(get_data_type());
     auto size_per_chunk = field_raw_data->get_size_per_chunk();
     auto build_threshold = get_build_threshold();
     bool is_mapping_storage = field_raw_data->is_mapping_storage();
-    auto valid_data = field_raw_data->get_valid_data();
 
     AssertInfo(ConcurrentDenseVectorCheck(field_raw_data, get_data_type()),
                "vec_base can't cast to ConcurrentVector type");
@@ -477,26 +550,34 @@ VectorFieldIndexing::AppendSegmentIndexDense(int64_t reserved_offset,
         }
 
         auto dataset = knowhere::GenDataSet(build_threshold, dim, data_ptr);
+        std::unique_ptr<bool[]> id_map_valid_data;
+        if (is_mapping_storage) {
+            auto logical_offset =
+                field_raw_data->get_logical_offset(build_threshold - 1);
+            auto update_count = logical_offset + 1;
+            index_->SetIdMapType(knowhere::IdMap::Type::GROWING);
+            // IdMapData only keeps a view of valid_data; keep this buffer
+            // alive until the synchronous Build call consumes the dataset.
+            id_map_valid_data = std::make_unique<bool[]>(update_count);
+            field_raw_data->bulk_is_valid_range(
+                0, update_count, id_map_valid_data.get());
+            dataset->SetIdMapData(knowhere::IdMapData::FromValidData(
+                id_map_valid_data.get(), static_cast<size_t>(update_count)));
+        }
         try {
             index_->BuildWithDataset(dataset, conf);
-            if (is_mapping_storage) {
-                auto logical_offset =
-                    field_raw_data->get_logical_offset(build_threshold - 1);
-                auto update_count = logical_offset + 1;
-                index_->UpdateValidData(valid_data.data(), update_count);
-            }
             built_ = true;
             index_cur_.fetch_add(build_threshold);
         } catch (SegcoreError& error) {
             LOG_ERROR("growing index build error: {}", error.what());
-            recreate_index(get_data_type(), field_raw_data);
+            DisableIndexAfterBuildFailure();
             return;
         }
     }
     //append rest data when index has built
     int64_t add_count = 0;
     int64_t total_count = 0;
-    if (valid_data.empty()) {
+    if (!is_mapping_storage) {
         add_count = reserved_offset + size - index_cur_.load();
         total_count = size;
         if (add_count <= 0) {
@@ -512,58 +593,36 @@ VectorFieldIndexing::AppendSegmentIndexDense(int64_t reserved_offset,
             sync_with_index_.store(true);
         } catch (SegcoreError& error) {
             LOG_ERROR("growing index add error: {}", error.what());
-            // Known design defect: after a raw-data-owning interim index has
-            // synchronized, its source chunks may have been reclaimed and
-            // field_raw_data is no longer a complete recovery source. This
-            // catch is reachable when AddWithDataset fails, but recreating the
-            // index here is not a valid recovery path and must not exist under
-            // single-owner semantics. The failure should instead be propagated
-            // and the segment marked unrecoverable.
-            recreate_index(get_data_type(), field_raw_data);
+            throw;
         }
     } else {
-        // Nullable dense vectors: data_source (proto) contains valid vectors compactly
-        auto index_total_count = index_->GetOffsetMapping().GetTotalCount();
-        auto add_valid_data_count = reserved_offset + size - index_total_count;
-        // Count valid vectors in this batch range
-        for (auto i = reserved_offset; i < reserved_offset + size; i++) {
-            if (valid_data[i]) {
-                total_count++;
-                if (i >= index_total_count) {
-                    add_count++;
-                }
-            }
-        }
-        if (add_count <= 0 && add_valid_data_count <= 0) {
+        auto append_info = PrepareNullableAppendInfo(
+            field_raw_data,
+            reserved_offset,
+            size,
+            static_cast<int64_t>(index_->GetIdMap().OutCount()));
+        if (!append_info.HasLogicalRange()) {
             sync_with_index_.store(true);
             return;
         }
-        if (add_count > 0) {
-            // data_source contains valid vectors compactly, skip already indexed ones
-            auto data_ptr = static_cast<const char*>(data_source) +
-                            (total_count - add_count) * vec_length;
-            auto dataset = knowhere::GenDataSet(add_count, dim, data_ptr);
-            try {
-                index_->AddWithDataset(dataset, conf);
-            } catch (SegcoreError& error) {
-                LOG_ERROR("growing index add error: {}", error.what());
-                // Known design defect: after a raw-data-owning interim index
-                // has synchronized, its source chunks may have been reclaimed
-                // and field_raw_data is no longer a complete recovery source.
-                // This catch is reachable when AddWithDataset fails, but
-                // recreating the index here is not a valid recovery path and
-                // must not exist under single-owner semantics. The failure
-                // should instead be propagated and the segment marked
-                // unrecoverable.
-                recreate_index(get_data_type(), field_raw_data);
-            }
+        auto data_ptr = append_info.HasPayload()
+                            ? static_cast<const char*>(data_source) +
+                                  append_info.valid_before_new * vec_length
+                            : nullptr;
+        auto dataset =
+            knowhere::GenDataSet(append_info.add_count, dim, data_ptr);
+        index_->SetIdMapType(knowhere::IdMap::Type::GROWING);
+        dataset->SetIdMapData(knowhere::IdMapData::FromValidData(
+            append_info.ValidDataForNewRange(reserved_offset),
+            static_cast<size_t>(append_info.logical_count)));
+        try {
+            index_->AddWithDataset(dataset, conf);
+            index_cur_.fetch_add(append_info.add_count);
+            sync_with_index_.store(true);
+        } catch (SegcoreError& error) {
+            LOG_ERROR("growing index add error: {}", error.what());
+            throw;
         }
-        if (add_valid_data_count > 0) {
-            index_->UpdateValidData(valid_data.data() + index_total_count,
-                                    add_valid_data_count);
-        }
-        index_cur_.fetch_add(add_count);
-        sync_with_index_.store(true);
     }
 }
 
@@ -587,12 +646,12 @@ VectorFieldIndexing::get_search_params(const SearchInfo& searchInfo) const {
 
 bool
 VectorFieldIndexing::sync_data_with_index() const {
-    return sync_with_index_.load();
+    return !index_unavailable_.load() && sync_with_index_.load();
 }
 
 bool
 VectorFieldIndexing::has_raw_data() const {
-    return index_->HasRawData();
+    return !index_unavailable_.load() && index_->HasRawData();
 }
 
 template <typename T>

--- a/internal/core/src/segcore/FieldIndexing.h
+++ b/internal/core/src/segcore/FieldIndexing.h
@@ -349,6 +349,10 @@ class VectorFieldIndexing : public FieldIndexing {
  private:
     void
     recreate_index(DataType data_type, const VectorBase* field_raw_data);
+
+    void
+    DisableIndexAfterBuildFailure();
+
     // current number of rows in index.
     std::atomic<idx_t> index_cur_ = 0;
     // whether the growing index has been built.
@@ -356,6 +360,9 @@ class VectorFieldIndexing : public FieldIndexing {
     // whether all insertd data has been added to growing index and can be
     // searched.
     std::atomic<bool> sync_with_index_;
+    // whether growing index build has failed and future appends should keep
+    // using brute force over raw chunks.
+    std::atomic<bool> index_unavailable_;
     std::unique_ptr<VecIndexConfig> config_;
     std::unique_ptr<index::VectorIndex> index_;
     tbb::concurrent_vector<std::unique_ptr<index::VectorIndex>> data_;

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -3312,11 +3312,13 @@ SegmentGrowingImpl::FilterVectorValidOffsets(milvus::OpContext* op_ctx,
 
         if (vec_index != nullptr && vec_index->HasValidData()) {
             result.valid_data = std::make_unique<bool[]>(count);
-            vec_index->GetOffsetMapping().FilterValidLogicalOffsets(
-                seg_offsets,
-                count,
-                result.valid_data.get(),
-                result.valid_offsets);
+            result.valid_offsets.reserve(count);
+            for (int64_t i = 0; i < count; ++i) {
+                result.valid_data[i] = vec_index->IsRowValid(seg_offsets[i]);
+                if (result.valid_data[i]) {
+                    result.valid_offsets.push_back(seg_offsets[i]);
+                }
+            }
             result.valid_count = result.valid_offsets.size();
         }
     } else {
@@ -3343,6 +3345,11 @@ SegmentGrowingImpl::FilterVectorValidOffsets(milvus::OpContext* op_ctx,
                     result.valid_offsets.reserve(count);
                     valid_data_ptr->bulk_is_valid(
                         seg_offsets, count, result.valid_data.get());
+                    for (int64_t i = 0; i < count; ++i) {
+                        if (result.valid_data[i]) {
+                            result.valid_offsets.push_back(seg_offsets[i]);
+                        }
+                    }
                 }
                 result.valid_count = result.valid_offsets.size();
             }

--- a/internal/core/src/segcore/SegmentGrowingIndexTest.cpp
+++ b/internal/core/src/segcore/SegmentGrowingIndexTest.cpp
@@ -12,6 +12,7 @@
 #include <folly/FBVector.h>
 #include <gtest/gtest.h>
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <map>
@@ -636,6 +637,68 @@ TEST_P(GrowingIndexTest, AddWithoutBuildPool) {
     } else {
         throw std::invalid_argument("Unsupported data type");
     }
+}
+
+TEST(GrowingIndexNullableVectorTest, AddAllNullTailAdvancesIdMapLogicalCount) {
+    constexpr int64_t dim = 2;
+
+    auto build_config =
+        knowhere::Json{{knowhere::meta::METRIC_TYPE, knowhere::metric::L2},
+                       {knowhere::meta::DIM, std::to_string(dim)},
+                       {knowhere::indexparam::NLIST, "1"}};
+
+    milvus::index::VectorMemIndex<float> index(
+        DataType::NONE,
+        knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC,
+        knowhere::metric::L2,
+        knowhere::Version::GetCurrentVersion().VersionNumber(),
+        false,
+        milvus::storage::FileManagerContext());
+    index.SetIdMapType(knowhere::IdMap::Type::GROWING);
+
+    std::array<float, 4> initial_data = {0.0F, 0.0F, 2.0F, 0.0F};
+    std::array<bool, 3> initial_valid = {true, false, true};
+    auto initial_dataset = knowhere::GenDataSet(2, dim, initial_data.data());
+    initial_dataset->SetIdMapData(knowhere::IdMapData::FromValidData(
+        initial_valid.data(), initial_valid.size()));
+    index.BuildWithDataset(initial_dataset, build_config);
+
+    const auto* id_map = &index.GetIdMap();
+    ASSERT_EQ(id_map->OutCount(), 3);
+    ASSERT_EQ(id_map->InToOutIds().size(), 2);
+    EXPECT_EQ(id_map->MapInToOut(0), 0);
+    EXPECT_EQ(id_map->MapInToOut(1), 2);
+
+    std::array<bool, 2> all_null_tail = {false, false};
+    auto all_null_dataset = knowhere::GenDataSet(0, dim, nullptr);
+    all_null_dataset->SetIdMapData(knowhere::IdMapData::FromValidData(
+        all_null_tail.data(), all_null_tail.size()));
+    index.AddWithDataset(all_null_dataset, build_config);
+
+    id_map = &index.GetIdMap();
+    ASSERT_EQ(id_map->OutCount(), 5);
+    ASSERT_EQ(id_map->InToOutIds().size(), 2);
+    EXPECT_FALSE(index.IsRowValid(3));
+    EXPECT_FALSE(index.IsRowValid(4));
+
+    std::array<float, 4> appended_data = {5.0F, 0.0F, 7.0F, 0.0F};
+    std::array<bool, 3> appended_valid = {true, false, true};
+    auto appended_dataset = knowhere::GenDataSet(2, dim, appended_data.data());
+    appended_dataset->SetIdMapData(knowhere::IdMapData::FromValidData(
+        appended_valid.data(), appended_valid.size()));
+    index.AddWithDataset(appended_dataset, build_config);
+
+    id_map = &index.GetIdMap();
+    ASSERT_EQ(id_map->OutCount(), 8);
+    ASSERT_EQ(id_map->InToOutIds().size(), 4);
+    EXPECT_EQ(id_map->MapInToOut(0), 0);
+    EXPECT_EQ(id_map->MapInToOut(1), 2);
+    EXPECT_EQ(id_map->MapInToOut(2), 5);
+    EXPECT_EQ(id_map->MapInToOut(3), 7);
+    EXPECT_TRUE(index.IsRowValid(5));
+    EXPECT_FALSE(index.IsRowValid(6));
+    EXPECT_TRUE(index.IsRowValid(7));
+    EXPECT_EQ(index.Count(), 4);
 }
 
 TEST(GrowingIndexNullableVectorTest,

--- a/internal/core/src/segcore/UtilsTest.cpp
+++ b/internal/core/src/segcore/UtilsTest.cpp
@@ -23,10 +23,7 @@
 #include <vector>
 
 #include "common/EasyAssert.h"
-#include "common/GrowingOffsetMapping.h"
-#include "common/OffsetMapping.h"
 #include "common/OpContext.h"
-#include "common/SealedOffsetMapping.h"
 #include "common/Schema.h"
 #include "common/Types.h"
 #include "common/protobuf_utils.h"
@@ -385,93 +382,6 @@ TEST(Util_Segcore, BitsetViewAllNone) {
             }
         }
     }
-}
-
-TEST(Util_Segcore, TransformBitsetAllFilteredAndNoFilterFastPaths) {
-    using namespace milvus;
-
-    constexpr size_t kRows = 130;  // not a multiple of 8 or 64
-    std::vector<bool> valid_flags(kRows, true);
-    std::unique_ptr<bool[]> valid_data(new bool[kRows]);
-    std::copy(valid_flags.begin(), valid_flags.end(), valid_data.get());
-
-    SealedOffsetMapping mapping;
-    mapping.Build(valid_data.get(), kRows);
-
-    const size_t n_bytes = (kRows + 7) / 8;
-    std::vector<uint8_t> ones(n_bytes, 0xFF);
-    ones.back() = static_cast<uint8_t>((1U << (kRows & 7)) - 1U);
-    TargetBitmap physical_bitset;
-    auto status = mapping.TransformBitset(BitsetView(ones.data(), kRows),
-                                          physical_bitset);
-    EXPECT_EQ(status, OffsetMapping::BitsetTransformStatus::AllFiltered);
-
-    std::vector<uint8_t> zeros(n_bytes, 0x00);
-    status = mapping.TransformBitset(BitsetView(zeros.data(), kRows),
-                                     physical_bitset);
-    EXPECT_EQ(status, OffsetMapping::BitsetTransformStatus::NoFilter);
-}
-
-TEST(Util_Segcore, TransformBitsetMasksNullableVectorRowsOutsideLogicalView) {
-    using namespace milvus;
-
-    std::array<bool, 3> valid_data = {true, true, true};
-    GrowingOffsetMapping mapping;
-    mapping.Append(valid_data.data(), valid_data.size(), 0, 0);
-
-    // Growing search passes a logical bitset sized by the query timestamp's
-    // active row count. Rows beyond that logical view are not visible yet and
-    // must be masked in the transformed physical bitset.
-    BitsetType logical_bitset(2);
-    BitsetView logical_view(logical_bitset);
-
-    TargetBitmap physical_bitset;
-    auto status = mapping.TransformBitset(logical_view, physical_bitset);
-
-    EXPECT_EQ(status, OffsetMapping::BitsetTransformStatus::Transformed);
-    ASSERT_EQ(physical_bitset.size(), 3);
-    EXPECT_FALSE(physical_bitset[0]);
-    EXPECT_FALSE(physical_bitset[1]);
-    EXPECT_TRUE(physical_bitset[2]);
-}
-
-TEST(Util_Segcore, GrowingTransformBitsetMaterializesNoFilterSnapshot) {
-    using namespace milvus;
-
-    std::array<bool, 5> valid_data = {true, true, false, true, true};
-    GrowingOffsetMapping mapping;
-    mapping.Append(valid_data.data(), valid_data.size(), 0, 0);
-
-    BitsetType logical_bitset(valid_data.size());
-    BitsetView logical_view(logical_bitset);
-
-    TargetBitmap physical_bitset;
-    auto status = mapping.TransformBitset(logical_view, physical_bitset);
-
-    EXPECT_EQ(status, OffsetMapping::BitsetTransformStatus::Transformed);
-    ASSERT_EQ(physical_bitset.size(), 4);
-    EXPECT_TRUE(physical_bitset.none());
-
-    std::array<bool, 2> later_valid_data = {true, true};
-    mapping.Append(later_valid_data.data(), later_valid_data.size(), 5, 4);
-    EXPECT_EQ(mapping.GetValidCount(), 6);
-    EXPECT_EQ(physical_bitset.size(), 4);
-    EXPECT_TRUE(physical_bitset.none());
-}
-
-TEST(Util_Segcore, TransformBitsetKeepsEmptyViewAsAllVisibleFastPath) {
-    using namespace milvus;
-
-    std::array<bool, 3> valid_data = {true, true, true};
-    SealedOffsetMapping mapping;
-    mapping.Build(valid_data.data(), valid_data.size());
-
-    BitsetView all_visible;
-    TargetBitmap physical_bitset;
-    auto status = mapping.TransformBitset(all_visible, physical_bitset);
-
-    EXPECT_EQ(status, OffsetMapping::BitsetTransformStatus::NoFilter);
-    EXPECT_TRUE(physical_bitset.empty());
 }
 
 TEST(Util_Segcore, MergeDataArrayWithNullableVectorArrayUsesLogicalOffsets) {

--- a/internal/core/src/segcore/storagev1translator/InterimSealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/InterimSealedIndexTranslator.cpp
@@ -15,6 +15,7 @@
 #include "index/Index.h"
 #include "index/Utils.h"
 #include "index/VectorIndex.h"
+#include "index/VectorIndexValidDataUtils.h"
 #include "index/VectorMemIndex.h"
 #include "knowhere/dataset.h"
 #include "knowhere/expected.h"
@@ -125,6 +126,10 @@ InterimSealedIndexTranslator::get_cells(
     }
     const auto& offset_mapping = vec_data_->GetOffsetMapping();
     bool nullable = offset_mapping.IsEnabled();
+    const FixedVector<bool>* valid_data = nullptr;
+    if (nullable) {
+        valid_data = &vec_data_->GetValidData();
+    }
 
     if (!is_sparse_) {
         auto rows_until_chunk = std::make_shared<std::vector<int64_t>>();
@@ -195,11 +200,17 @@ InterimSealedIndexTranslator::get_cells(
 
     int64_t total_valid_count =
         nullable ? offset_mapping.GetValidCount() : vec_data_->NumRows();
+    if (nullable) {
+        vec_index->SetIdMapType(knowhere::IdMap::Type::GROWING);
+    }
 
     if (total_valid_count == 0) {
         if (nullable) {
-            const auto& valid_data = vec_data_->GetValidData();
-            vec_index->BuildValidData(valid_data.data(), valid_data.size());
+            auto dataset = knowhere::GenDataSet(0, dim_, nullptr);
+            dataset->SetIsSparse(is_sparse_);
+            dataset->SetIdMapData(knowhere::IdMapData::FromValidData(
+                valid_data->data(), valid_data->size()));
+            vec_index->BuildWithDataset(dataset, build_config_);
         }
         std::vector<std::pair<cid_t, std::unique_ptr<milvus::index::IndexBase>>>
             result;
@@ -212,10 +223,20 @@ InterimSealedIndexTranslator::get_cells(
         auto pw = vec_data_->GetChunk(ctx, i);
         auto chunk = pw.get();
 
-        int64_t actual_row_count = nullable ? vec_data_->GetValidCountInChunk(i)
-                                            : vec_data_->chunk_row_nums(i);
+        const int64_t logical_begin = vec_data_->GetNumRowsUntilChunk(i);
+        const int64_t logical_rows = vec_data_->chunk_row_nums(i);
+        int64_t actual_row_count =
+            nullable ? vec_data_->GetValidCountInChunk(i) : logical_rows;
 
         if (actual_row_count == 0) {
+            if (nullable && !first_build) {
+                auto dataset = knowhere::GenDataSet(0, dim_, nullptr);
+                dataset->SetIsSparse(is_sparse_);
+                dataset->SetIdMapData(knowhere::IdMapData::FromValidData(
+                    valid_data->data() + logical_begin,
+                    static_cast<size_t>(logical_rows)));
+                vec_index->AddWithDataset(dataset, build_config_);
+            }
             continue;
         }
 
@@ -225,17 +246,23 @@ InterimSealedIndexTranslator::get_cells(
         dataset->SetIsSparse(is_sparse_);
 
         if (first_build) {
+            if (nullable) {
+                const auto logical_prefix = logical_begin + logical_rows;
+                dataset->SetIdMapData(knowhere::IdMapData::FromValidData(
+                    valid_data->data(), static_cast<size_t>(logical_prefix)));
+            }
             vec_index->BuildWithDataset(dataset, build_config_);
             first_build = false;
         } else {
+            if (nullable) {
+                dataset->SetIdMapData(knowhere::IdMapData::FromValidData(
+                    valid_data->data() + logical_begin,
+                    static_cast<size_t>(logical_rows)));
+            }
             vec_index->AddWithDataset(dataset, build_config_);
         }
     }
 
-    if (nullable) {
-        const auto& valid_data = vec_data_->GetValidData();
-        vec_index->BuildValidData(valid_data.data(), valid_data.size());
-    }
     std::vector<std::pair<cid_t, std::unique_ptr<milvus::index::IndexBase>>>
         result;
     result.emplace_back(std::make_pair(0, std::move(vec_index)));

--- a/internal/core/src/storage/DiskFileManagerTest.cpp
+++ b/internal/core/src/storage/DiskFileManagerTest.cpp
@@ -125,8 +125,8 @@ GeneratedIndexIdentifierPrefixForTest(const IndexMeta& index_meta) {
 }
 
 std::vector<std::string>
-CollectOffsetMappingMmapFiles(const std::string& root_path,
-                              const IndexMeta& index_meta) {
+CollectIdMapMmapFiles(const std::string& root_path,
+                      const IndexMeta& index_meta) {
     std::vector<std::string> files;
     boost::filesystem::path root(root_path);
     if (!boost::filesystem::exists(root)) {
@@ -146,11 +146,33 @@ CollectOffsetMappingMmapFiles(const std::string& root_path,
             continue;
         }
         if (path.parent_path().filename().string() ==
-            milvus::index::OFFSET_MAPPING_MMAP_DIR) {
+            milvus::index::ID_MAP_MMAP_DIR) {
             files.emplace_back(path.string());
         }
     }
     std::sort(files.begin(), files.end());
+    return files;
+}
+
+bool
+HasIdMapMmapFilePrefix(const std::vector<std::string>& files,
+                       const std::string& prefix) {
+    const auto prefix_with_generation = prefix + ".";
+    return std::any_of(files.begin(), files.end(), [&](const auto& file) {
+        return boost::filesystem::path(file).filename().string().rfind(
+                   prefix_with_generation, 0) == 0;
+    });
+}
+
+std::vector<std::string>
+NewFilesAfter(const std::vector<std::string>& before,
+              const std::vector<std::string>& after) {
+    std::vector<std::string> files;
+    for (const auto& file : after) {
+        if (!std::binary_search(before.begin(), before.end(), file)) {
+            files.emplace_back(file);
+        }
+    }
     return files;
 }
 
@@ -877,7 +899,7 @@ TEST_F(DiskAnnFileManagerTest, LoadStreamIndexCachesOnlyValidDataSidecar) {
 
     auto valid_data_path =
         local_index_prefix + "/" + milvus::index::VALID_DATA_KEY;
-    auto wire_count = milvus::index::ToValidDataCount(total_count);
+    auto wire_count = static_cast<uint64_t>(total_count);
     auto bitmap_size = milvus::index::GetValidDataBitmapSize(total_count);
     std::vector<uint8_t> valid_data(sizeof(uint64_t) + bitmap_size, 0);
     std::memcpy(valid_data.data(), &wire_count, sizeof(uint64_t));
@@ -930,15 +952,15 @@ TEST_F(DiskAnnFileManagerTest, LoadStreamIndexCachesOnlyValidDataSidecar) {
     std::memcpy(&cached_wire_count, cached_valid_data.data(), sizeof(uint64_t));
     ASSERT_EQ(milvus::index::FromValidDataCount(cached_wire_count),
               total_count);
-    milvus::index::BuildValidDataFromBitmap(
-        &loaded_index,
-        total_count,
-        cached_valid_data.data() + sizeof(uint64_t));
+    loaded_index.SetIdMapType(knowhere::IdMap::Type::SEALED);
+    loaded_index.GetIdMap().AddFromData(knowhere::IdMapData::FromValidBitmap(
+        cached_valid_data.data() + sizeof(uint64_t), total_count));
+    loaded_index.GetIdMap().FinalizeVectorIds();
     loaded_index.SetDim(128);
 
-    ASSERT_TRUE(loaded_index.GetOffsetMapping().IsEnabled());
-    EXPECT_EQ(loaded_index.GetOffsetMapping().GetTotalCount(), total_count);
-    EXPECT_EQ(loaded_index.GetOffsetMapping().GetValidCount(), valid_count);
+    ASSERT_TRUE(loaded_index.HasValidData());
+    EXPECT_EQ(loaded_index.GetIdMap().OutCount(), total_count);
+    EXPECT_EQ(loaded_index.GetValidCount(), valid_count);
     EXPECT_EQ(loaded_index.GetDim(), 128);
 
     local_chunk_manager->Remove(valid_data_path);
@@ -1677,13 +1699,11 @@ TEST_F(DiskAnnFileManagerTest, BuildAllNullNullableDiskVectorIndexFromDataset) {
 
     std::unique_ptr<bool[]> valid_data(new bool[num_rows]);
     std::fill_n(valid_data.get(), num_rows, false);
-    index.UpdateValidData(valid_data.get(), num_rows);
-    ASSERT_TRUE(index.GetOffsetMapping().IsEnabled());
-    ASSERT_EQ(index.GetOffsetMapping().GetTotalCount(), num_rows);
-    ASSERT_EQ(index.GetOffsetMapping().GetValidCount(), 0);
 
     std::vector<float> vec_data(dim, 0.0f);
     auto dataset = knowhere::GenDataSet(0, dim, vec_data.data());
+    dataset->SetIdMapData(
+        knowhere::IdMapData::FromValidData(valid_data.get(), num_rows));
 
     milvus::Config config;
     config[DIM_KEY] = dim;
@@ -1691,15 +1711,130 @@ TEST_F(DiskAnnFileManagerTest, BuildAllNullNullableDiskVectorIndexFromDataset) {
 
     index.BuildWithDataset(dataset, config);
 
-    ASSERT_TRUE(index.GetOffsetMapping().IsEnabled());
-    EXPECT_EQ(index.GetOffsetMapping().GetTotalCount(), num_rows);
-    EXPECT_EQ(index.GetOffsetMapping().GetValidCount(), 0);
+    ASSERT_TRUE(index.HasValidData());
+    EXPECT_EQ(index.GetIdMap().OutCount(), num_rows);
+    EXPECT_EQ(index.GetValidCount(), 0);
     EXPECT_EQ(index.GetDim(), dim);
 
     auto stats = index.Upload(config);
     auto files = stats->GetIndexFiles();
     ASSERT_EQ(files.size(), 1);
     EXPECT_NE(files[0].find(milvus::index::VALID_DATA_KEY), std::string::npos);
+
+    for (const auto& file : files) {
+        cm_->Remove(file);
+    }
+}
+
+TEST_F(DiskAnnFileManagerTest,
+       BuildNullableDiskVectorIndexCreatesIdMapMmapFilesInCompatibleDir) {
+    const int64_t collection_id = 1;
+    const int64_t partition_id = 2;
+    const int64_t segment_id = 3003;
+    const int64_t field_id = 100;
+    const int64_t dim = 128;
+    const int64_t num_rows = 1000;
+
+    FieldDataMeta field_data_meta = {
+        collection_id, partition_id, segment_id, field_id};
+    field_data_meta.field_schema.set_nullable(true);
+
+    IndexMeta index_meta = {segment_id,
+                            field_id,
+                            1001,
+                            1,
+                            "test",
+                            "vec_field",
+                            DataType::VECTOR_FLOAT,
+                            dim};
+    storage::FileManagerContext file_manager_context(
+        field_data_meta, index_meta, cm_, fs_);
+    milvus::index::VectorDiskAnnIndex<float> index(
+        DataType::NONE,
+        knowhere::IndexEnum::INDEX_DISKANN,
+        knowhere::metric::L2,
+        knowhere::Version::GetCurrentVersion().VersionNumber(),
+        file_manager_context);
+
+    std::unique_ptr<bool[]> valid_data(new bool[num_rows]);
+    int64_t valid_count = 0;
+    for (int64_t i = 0; i < num_rows; ++i) {
+        valid_data[i] = (i % 10 != 0);
+        if (valid_data[i]) {
+            ++valid_count;
+        }
+    }
+
+    std::vector<float> vec_data(static_cast<size_t>(valid_count * dim));
+    for (size_t i = 0; i < vec_data.size(); ++i) {
+        vec_data[i] = static_cast<float>(i % 100);
+    }
+    auto dataset = knowhere::GenDataSet(valid_count, dim, vec_data.data());
+    dataset->SetIdMapData(
+        knowhere::IdMapData::FromValidData(valid_data.get(), num_rows));
+
+    milvus::Config config;
+    config[DIM_KEY] = dim;
+    config[milvus::index::DISK_ANN_MAX_DEGREE] = std::to_string(24);
+    config[milvus::index::DISK_ANN_SEARCH_LIST_SIZE] = std::to_string(56);
+    config[milvus::index::DISK_ANN_PQ_CODE_BUDGET] = std::to_string(0.001);
+    config[milvus::index::DISK_ANN_BUILD_DRAM_BUDGET] = std::to_string(2);
+    config[milvus::index::DISK_ANN_BUILD_THREAD_NUM] = "1";
+    config[milvus::index::ENABLE_MMAP_I2O_MAP] = true;
+    config[milvus::index::ENABLE_MMAP_O2I_MAP] = true;
+
+    auto local_chunk_manager =
+        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+    const auto mmap_files_before_build =
+        CollectIdMapMmapFiles(local_chunk_manager->GetRootPath(), index_meta)
+            .size();
+
+    index.BuildWithDataset(dataset, config);
+
+    ASSERT_TRUE(index.HasValidData());
+    EXPECT_EQ(index.GetIdMap().OutCount(), num_rows);
+    EXPECT_EQ(index.GetValidCount(), valid_count);
+
+    const auto mmap_files_after_build =
+        CollectIdMapMmapFiles(local_chunk_manager->GetRootPath(), index_meta);
+    EXPECT_GT(mmap_files_after_build.size(), mmap_files_before_build);
+    EXPECT_TRUE(
+        HasIdMapMmapFilePrefix(mmap_files_after_build, "in_to_out_ids"));
+    EXPECT_TRUE(
+        HasIdMapMmapFilePrefix(mmap_files_after_build, "out_to_in_ids"));
+
+    auto stats = index.Upload(config);
+    auto files = stats->GetIndexFiles();
+    ASSERT_GT(files.size(), 1);
+
+    milvus::Config load_config;
+    load_config[DIM_KEY] = dim;
+    load_config[milvus::index::DISK_ANN_LOAD_THREAD_NUM] = "1";
+    load_config["index_files"] = files;
+    load_config[milvus::index::ENABLE_MMAP_I2O_MAP] = true;
+    load_config[milvus::index::ENABLE_MMAP_O2I_MAP] = true;
+
+    const auto mmap_files_before_load =
+        CollectIdMapMmapFiles(local_chunk_manager->GetRootPath(), index_meta);
+
+    milvus::index::VectorDiskAnnIndex<float> loaded_index(
+        DataType::NONE,
+        knowhere::IndexEnum::INDEX_DISKANN,
+        knowhere::metric::L2,
+        knowhere::Version::GetCurrentVersion().VersionNumber(),
+        file_manager_context);
+
+    loaded_index.Load(milvus::tracer::TraceContext{}, load_config);
+    ASSERT_TRUE(loaded_index.HasValidData());
+    EXPECT_EQ(loaded_index.GetIdMap().OutCount(), num_rows);
+    EXPECT_EQ(loaded_index.GetValidCount(), valid_count);
+
+    const auto mmap_files_after_load =
+        CollectIdMapMmapFiles(local_chunk_manager->GetRootPath(), index_meta);
+    const auto loaded_mmap_files =
+        NewFilesAfter(mmap_files_before_load, mmap_files_after_load);
+    EXPECT_TRUE(HasIdMapMmapFilePrefix(loaded_mmap_files, "in_to_out_ids"));
+    EXPECT_TRUE(HasIdMapMmapFilePrefix(loaded_mmap_files, "out_to_in_ids"));
 
     for (const auto& file : files) {
         cm_->Remove(file);
@@ -1740,10 +1875,11 @@ TEST_F(DiskAnnFileManagerTest, LoadAllNullNullableDiskVectorIndexFromDataset) {
 
         std::unique_ptr<bool[]> valid_data(new bool[num_rows]);
         std::fill_n(valid_data.get(), num_rows, false);
-        index.UpdateValidData(valid_data.get(), num_rows);
 
         std::vector<float> vec_data(dim, 0.0f);
         auto dataset = knowhere::GenDataSet(0, dim, vec_data.data());
+        dataset->SetIdMapData(
+            knowhere::IdMapData::FromValidData(valid_data.get(), num_rows));
 
         milvus::Config config;
         config[DIM_KEY] = dim;
@@ -1765,8 +1901,7 @@ TEST_F(DiskAnnFileManagerTest, LoadAllNullNullableDiskVectorIndexFromDataset) {
     auto local_chunk_manager =
         LocalChunkManagerSingleton::GetInstance().GetChunkManager();
     const auto mmap_file_count_before_load =
-        CollectOffsetMappingMmapFiles(local_chunk_manager->GetRootPath(),
-                                      index_meta)
+        CollectIdMapMmapFiles(local_chunk_manager->GetRootPath(), index_meta)
             .size();
 
     {
@@ -1782,21 +1917,20 @@ TEST_F(DiskAnnFileManagerTest, LoadAllNullNullableDiskVectorIndexFromDataset) {
 
         loaded_index.Load(milvus::tracer::TraceContext{},
                           generic_mmap_load_config);
-        ASSERT_TRUE(loaded_index.GetOffsetMapping().IsEnabled());
-        EXPECT_FALSE(loaded_index.GetOffsetMapping().IsMmap());
-        EXPECT_EQ(loaded_index.GetOffsetMapping().GetTotalCount(), num_rows);
-        EXPECT_EQ(loaded_index.GetOffsetMapping().GetValidCount(), 0);
+        ASSERT_TRUE(loaded_index.HasValidData());
+        EXPECT_EQ(loaded_index.GetIdMap().OutCount(), num_rows);
+        EXPECT_EQ(loaded_index.GetValidCount(), 0);
         EXPECT_EQ(loaded_index.GetDim(), dim);
     }
 
-    EXPECT_EQ(CollectOffsetMappingMmapFiles(local_chunk_manager->GetRootPath(),
-                                            index_meta)
-                  .size(),
-              mmap_file_count_before_load);
+    EXPECT_EQ(
+        CollectIdMapMmapFiles(local_chunk_manager->GetRootPath(), index_meta)
+            .size(),
+        mmap_file_count_before_load);
 
-    auto offset_mapping_mmap_load_config = load_config;
-    offset_mapping_mmap_load_config[milvus::index::ENABLE_MMAP_I2O_MAP] = true;
-    offset_mapping_mmap_load_config[milvus::index::ENABLE_MMAP_O2I_MAP] = true;
+    auto id_map_mmap_load_config = load_config;
+    id_map_mmap_load_config[milvus::index::ENABLE_MMAP_I2O_MAP] = true;
+    id_map_mmap_load_config[milvus::index::ENABLE_MMAP_O2I_MAP] = true;
 
     milvus::index::VectorDiskAnnIndex<float> loaded_index(
         DataType::NONE,
@@ -1805,130 +1939,15 @@ TEST_F(DiskAnnFileManagerTest, LoadAllNullNullableDiskVectorIndexFromDataset) {
         knowhere::Version::GetCurrentVersion().VersionNumber(),
         file_manager_context);
 
-    loaded_index.Load(milvus::tracer::TraceContext{},
-                      offset_mapping_mmap_load_config);
-    const auto& offset_mapping = loaded_index.GetOffsetMapping();
-    ASSERT_TRUE(offset_mapping.IsEnabled());
-    EXPECT_TRUE(offset_mapping.IsMmap());
-    EXPECT_EQ(offset_mapping.GetTotalCount(), num_rows);
-    EXPECT_EQ(offset_mapping.GetValidCount(), 0);
+    loaded_index.Load(milvus::tracer::TraceContext{}, id_map_mmap_load_config);
+    ASSERT_TRUE(loaded_index.HasValidData());
+    EXPECT_EQ(loaded_index.GetIdMap().OutCount(), num_rows);
+    EXPECT_EQ(loaded_index.GetValidCount(), 0);
     EXPECT_EQ(loaded_index.GetDim(), dim);
-
-    const auto* sealed_mapping =
-        dynamic_cast<const SealedOffsetMapping*>(&offset_mapping);
-    ASSERT_NE(sealed_mapping, nullptr);
-    EXPECT_FALSE(sealed_mapping->IsI2OMmap());
-    EXPECT_TRUE(sealed_mapping->IsO2IMmap());
-    EXPECT_EQ(CollectOffsetMappingMmapFiles(local_chunk_manager->GetRootPath(),
-                                            index_meta)
-                  .size(),
-              mmap_file_count_before_load + 1);
-
-    for (const auto& file : files) {
-        cm_->Remove(file);
-    }
-}
-
-TEST_F(DiskAnnFileManagerTest, BuildAllValidEmptyEmbListDiskIndexFromDataset) {
-    const int64_t collection_id = 1;
-    const int64_t partition_id = 2;
-    const int64_t segment_id = 3003;
-    const int64_t field_id = 100;
-    const int64_t dim = 128;
-    const int64_t num_queries = 3;
-
-    FieldDataMeta field_data_meta = {
-        collection_id, partition_id, segment_id, field_id};
-
-    IndexMeta index_meta = {segment_id,
-                            field_id,
-                            1000,
-                            1,
-                            "test",
-                            "vector_array_field",
-                            DataType::VECTOR_ARRAY,
-                            dim};
-    storage::FileManagerContext file_manager_context(
-        field_data_meta, index_meta, cm_, fs_);
-    milvus::index::VectorDiskAnnIndex<float> index(
-        DataType::VECTOR_FLOAT,
-        knowhere::IndexEnum::INDEX_DISKANN,
-        knowhere::metric::L2,
-        knowhere::Version::GetCurrentVersion().VersionNumber(),
-        file_manager_context);
-
-    std::vector<float> vec_data(dim, 0.0f);
-    auto dataset = knowhere::GenDataSet(0, dim, vec_data.data());
-    std::vector<size_t> offsets(num_queries + 1, 0);
-    dataset->Set(knowhere::meta::EMB_LIST_OFFSET,
-                 const_cast<const size_t*>(offsets.data()));
-    dataset->Set(knowhere::meta::NQ, num_queries);
-    ASSERT_EQ(dataset->GetRows(), 0);
-    ASSERT_EQ(dataset->Get<int64_t>(knowhere::meta::NQ), num_queries);
-    ASSERT_EQ(dataset->Get<const size_t*>(
-                  knowhere::meta::EMB_LIST_OFFSET)[num_queries],
-              0);
-
-    milvus::Config config;
-    config[DIM_KEY] = dim;
-    config[milvus::index::DISK_ANN_BUILD_THREAD_NUM] = "1";
-
-    index.BuildWithDataset(dataset, config);
-
-    EXPECT_EQ(index.Count(), 0);
-    EXPECT_TRUE(index.HasRawData());
-    EXPECT_EQ(index.GetDim(), dim);
-
-    SearchInfo search_info;
-    search_info.metric_type_ = knowhere::metric::L2;
-    search_info.topk_ = 2;
-
-    SearchResult search_result;
-    index.Query(
-        dataset, search_info, milvus::BitsetView{}, nullptr, search_result);
-    EXPECT_EQ(search_result.total_nq_, num_queries);
-    EXPECT_EQ(search_result.unity_topK_, search_info.topk_);
-    ASSERT_EQ(search_result.seg_offsets_.size(),
-              num_queries * search_info.topk_);
-    ASSERT_EQ(search_result.distances_.size(), num_queries * search_info.topk_);
-    for (auto offset : search_result.seg_offsets_) {
-        EXPECT_EQ(offset, INVALID_SEG_OFFSET);
-    }
-
-    auto stats = index.Upload(config);
-    auto files = stats->GetIndexFiles();
-    ASSERT_EQ(files.size(), 1);
-    EXPECT_NE(files[0].find("empty_emb_list_offsets"), std::string::npos);
-
-    milvus::index::VectorDiskAnnIndex<float> loaded_index(
-        DataType::VECTOR_FLOAT,
-        knowhere::IndexEnum::INDEX_DISKANN,
-        knowhere::metric::L2,
-        knowhere::Version::GetCurrentVersion().VersionNumber(),
-        file_manager_context);
-
-    milvus::Config load_config;
-    load_config[DIM_KEY] = dim;
-    load_config[milvus::index::DISK_ANN_LOAD_THREAD_NUM] = "1";
-    load_config["index_files"] = files;
-
-    loaded_index.Load(milvus::tracer::TraceContext{}, load_config);
-    EXPECT_EQ(loaded_index.Count(), 0);
-    EXPECT_TRUE(loaded_index.HasRawData());
-    EXPECT_EQ(loaded_index.GetDim(), dim);
-
-    SearchResult loaded_search_result;
-    loaded_index.Query(dataset,
-                       search_info,
-                       milvus::BitsetView{},
-                       nullptr,
-                       loaded_search_result);
-    EXPECT_EQ(loaded_search_result.total_nq_, num_queries);
-    ASSERT_EQ(loaded_search_result.seg_offsets_.size(),
-              num_queries * search_info.topk_);
-    for (auto offset : loaded_search_result.seg_offsets_) {
-        EXPECT_EQ(offset, INVALID_SEG_OFFSET);
-    }
+    EXPECT_EQ(
+        CollectIdMapMmapFiles(local_chunk_manager->GetRootPath(), index_meta)
+            .size(),
+        mmap_file_count_before_load);
 
     for (const auto& file : files) {
         cm_->Remove(file);

--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -14,9 +14,7 @@
 # Update KNOWHERE_VERSION for the first occurrence
 milvus_add_pkg_config("knowhere")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-# Pins the short zilliztech/knowhere#1761 commit without nullable ID mapping.
-# It retains the COSINE/IP CalcDistByIDs fix for fully cached DiskANN vectors.
-set( KNOWHERE_VERSION 6a3b7df1 )
+set( KNOWHERE_VERSION d85f7080 )
 set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
 
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")

--- a/internal/core/unittest/test_element_filter.cpp
+++ b/internal/core/unittest/test_element_filter.cpp
@@ -3980,12 +3980,6 @@ LoadNullableElementFlatIndex(SegmentSealed* segment,
                                    flat_data.data(),
                                    knowhere::IndexEnum::INDEX_FAISS_IDMAP);
 
-    std::unique_ptr<bool[]> valid_rows(new bool[kNullableElemN]);
-    for (int row = 0; row < kNullableElemN; ++row) {
-        valid_rows[row] = true;
-    }
-    indexing->BuildValidData(valid_rows.get(), kNullableElemN);
-
     LoadIndexInfo load_index_info;
     load_index_info.field_id = vec_fid.get();
     load_index_info.index_params = GenIndexParams(indexing.get());
@@ -4006,12 +4000,6 @@ LoadNullableElementFlatIndexWithValidRows(SegmentSealed* segment,
                                    kNullableElemDim,
                                    flat_data.data(),
                                    knowhere::IndexEnum::INDEX_FAISS_IDMAP);
-
-    std::unique_ptr<bool[]> valid_data(new bool[valid_rows.size()]);
-    for (size_t row = 0; row < valid_rows.size(); ++row) {
-        valid_data[row] = valid_rows[row];
-    }
-    indexing->BuildValidData(valid_data.get(), valid_rows.size());
 
     LoadIndexInfo load_index_info;
     load_index_info.field_id = vec_fid.get();

--- a/internal/core/unittest/test_index_wrapper.cpp
+++ b/internal/core/unittest/test_index_wrapper.cpp
@@ -301,16 +301,28 @@ TEST(VectorMemIndexTest, LoadMmapSlicedValidData) {
         true,
         file_manager_context);
 
-    auto dataset = knowhere::GenDataSet(kRows, kDim, data.data());
-    index.BuildWithDataset(dataset, config);
-
     std::unique_ptr<bool[]> valid_data(new bool[kRows]);
     int64_t valid_count = 0;
     for (int64_t i = 0; i < kRows; ++i) {
         valid_data[i] = i % 3 != 0;
         valid_count += valid_data[i] ? 1 : 0;
     }
-    index.BuildValidData(valid_data.get(), kRows);
+
+    std::vector<float> compact_data;
+    compact_data.reserve(valid_count * kDim);
+    for (int64_t i = 0; i < kRows; ++i) {
+        if (!valid_data[i]) {
+            continue;
+        }
+        compact_data.insert(compact_data.end(),
+                            data.begin() + i * kDim,
+                            data.begin() + (i + 1) * kDim);
+    }
+
+    auto dataset = knowhere::GenDataSet(valid_count, kDim, compact_data.data());
+    dataset->SetIdMapData(
+        knowhere::IdMapData::FromValidData(valid_data.get(), kRows));
+    index.BuildWithDataset(dataset, config);
 
     auto stats = index.Upload();
     auto index_files = stats->GetIndexFiles();
@@ -346,7 +358,8 @@ TEST(VectorMemIndexTest, LoadMmapSlicedValidData) {
 
     loaded_index.Load(milvus::tracer::TraceContext{}, load_config);
 
-    ASSERT_EQ(loaded_index.Count(), kRows);
+    ASSERT_EQ(loaded_index.Count(), valid_count);
+    ASSERT_EQ(loaded_index.GetIdMap().OutCount(), kRows);
     EXPECT_EQ(loaded_index.GetValidCount(), valid_count);
     for (int64_t i = 0; i < kRows; ++i) {
         EXPECT_EQ(loaded_index.IsRowValid(i), valid_data[i]) << i;

--- a/internal/core/unittest/test_indexing.cpp
+++ b/internal/core/unittest/test_indexing.cpp
@@ -15,6 +15,7 @@
 #include <nlohmann/json_fwd.hpp>
 #include <string.h>
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <initializer_list>
 #include <iostream>
@@ -841,6 +842,63 @@ TEST_P(IndexTest, GetVector_EmptySparseVector) {
             ASSERT_EQ(row[j].val, vec[id][j].val);
         }
     }
+}
+
+TEST(Indexing, HnswEmbListEmptyNullableUsesLogicalIds) {
+    constexpr int64_t dim = DIM;
+    auto metric_type = knowhere::metric::MAX_SIM;
+
+    milvus::index::CreateIndexInfo create_index_info;
+    create_index_info.index_type = knowhere::IndexEnum::INDEX_HNSW;
+    create_index_info.metric_type = metric_type;
+    create_index_info.field_type = DataType::VECTOR_ARRAY;
+    create_index_info.index_engine_version =
+        knowhere::Version::GetCurrentVersion().VersionNumber();
+
+    auto storage_config = get_default_local_storage_config();
+    auto chunk_manager = storage::CreateChunkManager(storage_config);
+    auto fs = milvus::storage::InitArrowFileSystem(storage_config);
+    auto field_data_meta = milvus::segcore::gen_field_meta(
+        1, 2, 3, 100, DataType::VECTOR_ARRAY, DataType::VECTOR_FLOAT, true);
+    milvus::storage::IndexMeta index_meta{3, 100, 1000, 1};
+    index_meta.field_type = DataType::VECTOR_ARRAY;
+    index_meta.dim = dim;
+    milvus::storage::FileManagerContext file_manager_context(
+        field_data_meta, index_meta, chunk_manager, fs);
+
+    auto index = milvus::index::IndexFactory::GetInstance().CreateIndex(
+        create_index_info, file_manager_context);
+    auto vec_index = dynamic_cast<milvus::index::VectorIndex*>(index.get());
+    ASSERT_NE(vec_index, nullptr);
+
+    std::array<bool, 3> valid_data{{true, false, true}};
+    auto dataset = knowhere::GenDataSet(0, dim, nullptr);
+    dataset->SetIdMapData(knowhere::IdMapData::FromValidData(
+        valid_data.data(), valid_data.size()));
+
+    Config build_conf;
+    build_conf[milvus::index::INDEX_TYPE] = knowhere::IndexEnum::INDEX_HNSW;
+    build_conf[knowhere::meta::METRIC_TYPE] = metric_type;
+    build_conf[knowhere::indexparam::M] = "16";
+    build_conf[knowhere::indexparam::EF] = "10";
+    build_conf[DIM_KEY] = dim;
+
+    ASSERT_NO_THROW(index->BuildWithDataset(dataset, build_conf));
+    EXPECT_TRUE(vec_index->HasValidData());
+    EXPECT_EQ(vec_index->GetValidCount(), 2);
+    EXPECT_EQ(vec_index->GetIdMap().OutCount(), 3);
+    EXPECT_EQ(vec_index->Count(), 0);
+
+    std::vector<int64_t> logical_ids = {0, 2};
+    auto ids_ds = GenIdsDataset(logical_ids.size(), logical_ids.data());
+    auto [raw_data, emb_offsets] =
+        vec_index->GetEmbListByIds(ids_ds, metric_type);
+    EXPECT_TRUE(raw_data.empty());
+    EXPECT_EQ(emb_offsets, std::vector<size_t>({0, 0, 0}));
+
+    std::vector<int64_t> null_ids = {1};
+    auto null_ids_ds = GenIdsDataset(null_ids.size(), null_ids.data());
+    EXPECT_ANY_THROW(vec_index->GetEmbListByIds(null_ids_ds, metric_type));
 }
 
 TEST(Indexing, HnswEmbListBuildAllNullNullableFromBinlog) {

--- a/internal/core/unittest/test_loading.cpp
+++ b/internal/core/unittest/test_loading.cpp
@@ -358,10 +358,10 @@ TEST(IndexLoadTest, LoadResourceRequestCacheIsOptional) {
 }
 
 #ifdef BUILD_DISK_ANN
-TEST(IndexLoadTest, DiskAnnOffsetMappingMmapEstimateChargesDiskCost) {
+TEST(IndexLoadTest, DiskAnnIdMapMmapEstimateChargesDiskCost) {
     constexpr uint64_t kIndexSize = 1024UL * 1024 * 1024;
     constexpr int64_t kNumRows = 1025;
-    constexpr uint64_t kOffsetMappingMmapBytes =
+    constexpr uint64_t kIdMapMmapBytes =
         static_cast<uint64_t>(kNumRows) * sizeof(int32_t);
 
     auto make_load_info = [] {
@@ -398,20 +398,16 @@ TEST(IndexLoadTest, DiskAnnOffsetMappingMmapEstimateChargesDiskCost) {
     auto i2o_info = make_load_info();
     i2o_info.index_params[milvus::index::ENABLE_MMAP_I2O_MAP] = "true";
     auto i2o = EstimateLoadIndexResource(&i2o_info);
-    ASSERT_EQ(i2o.final_disk_cost,
-              baseline.final_disk_cost + kOffsetMappingMmapBytes);
-    ASSERT_EQ(i2o.max_disk_cost,
-              baseline.max_disk_cost + kOffsetMappingMmapBytes);
+    ASSERT_EQ(i2o.final_disk_cost, baseline.final_disk_cost + kIdMapMmapBytes);
+    ASSERT_EQ(i2o.max_disk_cost, baseline.max_disk_cost + kIdMapMmapBytes);
     ASSERT_EQ(i2o.final_memory_cost, baseline.final_memory_cost);
     ASSERT_EQ(i2o.max_memory_cost, baseline.max_memory_cost);
 
     auto o2i_info = make_load_info();
     o2i_info.index_params[milvus::index::ENABLE_MMAP_O2I_MAP] = "true";
     auto o2i = EstimateLoadIndexResource(&o2i_info);
-    ASSERT_EQ(o2i.final_disk_cost,
-              baseline.final_disk_cost + kOffsetMappingMmapBytes);
-    ASSERT_EQ(o2i.max_disk_cost,
-              baseline.max_disk_cost + kOffsetMappingMmapBytes);
+    ASSERT_EQ(o2i.final_disk_cost, baseline.final_disk_cost + kIdMapMmapBytes);
+    ASSERT_EQ(o2i.max_disk_cost, baseline.max_disk_cost + kIdMapMmapBytes);
     ASSERT_EQ(o2i.final_memory_cost, baseline.final_memory_cost);
     ASSERT_EQ(o2i.max_memory_cost, baseline.max_memory_cost);
 
@@ -419,10 +415,8 @@ TEST(IndexLoadTest, DiskAnnOffsetMappingMmapEstimateChargesDiskCost) {
     both_info.index_params[milvus::index::ENABLE_MMAP_I2O_MAP] = "true";
     both_info.index_params[milvus::index::ENABLE_MMAP_O2I_MAP] = "true";
     auto both = EstimateLoadIndexResource(&both_info);
-    ASSERT_EQ(both.final_disk_cost,
-              baseline.final_disk_cost + kOffsetMappingMmapBytes);
-    ASSERT_EQ(both.max_disk_cost,
-              baseline.max_disk_cost + kOffsetMappingMmapBytes);
+    ASSERT_EQ(both.final_disk_cost, baseline.final_disk_cost + kIdMapMmapBytes);
+    ASSERT_EQ(both.max_disk_cost, baseline.max_disk_cost + kIdMapMmapBytes);
     ASSERT_EQ(both.final_memory_cost, baseline.final_memory_cost);
     ASSERT_EQ(both.max_memory_cost, baseline.max_memory_cost);
 }

--- a/internal/datacoord/task_index.go
+++ b/internal/datacoord/task_index.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -60,6 +61,25 @@ type indexBuildTask struct {
 var _ globalTask.Task = (*indexBuildTask)(nil)
 
 var errVectorArrayFieldBinlogNotFound = errors.New("vector array field binlog not found")
+
+func fieldSchemaForIndexBuild(schema *schemapb.CollectionSchema, field *schemapb.FieldSchema) *schemapb.FieldSchema {
+	if field == nil || field.GetNullable() {
+		return field
+	}
+	for _, structField := range schema.GetStructArrayFields() {
+		if !structField.GetNullable() {
+			continue
+		}
+		for _, subField := range structField.GetFields() {
+			if subField.GetFieldID() == field.GetFieldID() {
+				buildField := proto.Clone(field).(*schemapb.FieldSchema)
+				buildField.Nullable = true
+				return buildField
+			}
+		}
+	}
+	return field
+}
 
 func newIndexBuildTask(segIndex *model.SegmentIndex,
 	taskSlot int64,
@@ -495,6 +515,7 @@ func (it *indexBuildTask) prepareJobRequest(ctx context.Context, segment *Segmen
 	if field == nil {
 		return nil, merr.WrapErrFieldNotFound(fieldID)
 	}
+	buildField := fieldSchemaForIndexBuild(schema, field)
 
 	// Extract dim only for vector types to avoid unnecessary warnings
 	dim := -1
@@ -550,7 +571,7 @@ func (it *indexBuildTask) prepareJobRequest(ctx context.Context, segment *Segmen
 		Dim:                       int64(dim),
 		DataIds:                   binlogIDs,
 		OptionalScalarFields:      optionalFields,
-		Field:                     field,
+		Field:                     buildField,
 		PartitionKeyIsolation:     partitionKeyIsolation,
 		StorageVersion:            segment.GetStorageVersion(),
 		TaskSlot:                  it.taskSlot,

--- a/internal/datacoord/task_index_test.go
+++ b/internal/datacoord/task_index_test.go
@@ -17,6 +17,7 @@
 package datacoord
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -645,6 +646,68 @@ func (s *indexTaskSuite) TestEstimateVectorArrayElementCountForIndexBuild_Manife
 	s.NoError(err)
 	s.True(estimate.manifestBacked)
 	s.False(estimate.emptyOnStaleSchema)
+}
+
+func (s *indexTaskSuite) TestPrepareJobRequestUsesNullableStructArrayParentForSubField() {
+	const dim = 128
+
+	catalog := catalogmocks.NewDataCoordCatalog(s.T())
+	mt := &meta{
+		indexMeta: createIndexMetaWithSegment(catalog, s.collID, s.partID, s.segID, s.indexID, s.fieldID, s.taskID),
+	}
+	segIndex, ok := mt.indexMeta.segmentBuildInfo.Get(s.taskID)
+	s.True(ok)
+
+	childField := &schemapb.FieldSchema{
+		Name:        "events[embedding]",
+		FieldID:     s.fieldID,
+		DataType:    schemapb.DataType_ArrayOfVector,
+		ElementType: schemapb.DataType_FloatVector,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: common.DimKey, Value: fmt.Sprintf("%d", dim)},
+		},
+	}
+	schema := &schemapb.CollectionSchema{
+		StructArrayFields: []*schemapb.StructArrayFieldSchema{
+			{
+				Name:     "events",
+				FieldID:  100,
+				Nullable: true,
+				Fields:   []*schemapb.FieldSchema{childField},
+			},
+		},
+	}
+
+	handler := NewNMockHandler(s.T())
+	handler.EXPECT().GetCollection(mock.Anything, s.collID).Return(&collectionInfo{
+		ID:         s.collID,
+		Schema:     schema,
+		Partitions: []int64{s.partID},
+	}, nil)
+	cm := mocks.NewChunkManager(s.T())
+	cm.EXPECT().RootPath().Return("root")
+
+	it := newIndexBuildTask(segIndex, 1, mt, handler, cm, newIndexEngineVersionManager())
+	req, err := it.prepareJobRequest(
+		context.Background(),
+		&SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+			ID:           s.segID,
+			CollectionID: s.collID,
+			PartitionID:  s.partID,
+			NumOfRows:    4,
+		}},
+		segIndex,
+		[]*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: "HNSW"},
+			{Key: common.MetricTypeKey, Value: "MAX_SIM_COSINE"},
+		},
+		"HNSW",
+	)
+
+	s.NoError(err)
+	s.True(req.GetField().GetNullable())
+	s.False(childField.GetNullable())
+	s.NotSame(childField, req.GetField())
 }
 
 func (s *indexTaskSuite) TestQueryTaskOnWorker() {


### PR DESCRIPTION
Backport of #50524 (enhance: move nullable vector mapping into index layer) to the 3.0 branch.

pr: #50524

## Summary
- Move nullable vector id mapping into the vector index/Knowhere boundary. Milvus now passes logical row/list ids and logical bitsets to vector APIs, and indexed paths return logical ids directly.
- Pass nullable valid-data metadata to Knowhere as `IdMapData` during vector index build/load/add. Knowhere owns the compact internal id map, including mmap-backed dense id arrays for sealed indexes.
- Keep Milvus `OffsetMapping` only for compact raw/growing brute-force views.
- Depend on zilliztech/knowhere#1673 which provides dataset-carried `IdMapData`, snapshot-backed `IdMap`, mmap-backed sealed id arrays, and brute-force out-id mapping.

## Commits
- `ae44cab01e` enhance: move nullable vector mapping into index layer

## Validation
- `make build-cpp-with-unittest jobs=16` passed (`BUILD_EXIT=0`)
- Targeted gtests passed: `TestVectorArrayStorageV2.BuildEmbListHNSWIndexWithMmap`, `TestVectorArrayStorageV2.BuildEncodedEmbListHNSWIndexWithMmap`, `SearchOnSealedIndexBitsetLifetime.GroupByIteratorMustNotKeepDanglingTransformedBitset`, `Growing.NullableVectorInsertBuildsMonotonicOffsetMapping`