### PR TITLE
test: e2e for schema-bump backfill over added-field function input and TEXT LOB

### DIFF
--- a/tests/python_client/base/client_v2_base.py
+++ b/tests/python_client/base/client_v2_base.py
@@ -876,6 +876,31 @@ class TestMilvusClientV2Base(Base):
             time.sleep(2)
         return False
 
+    def wait_for_schema_version_consistency(self, client, collection_name, timeout=None):
+        """Wait until every eligible sealed segment catches up with the latest collection
+        schema version, i.e. all pending schema-bump backfill is done. Polls the
+        schema_version_consistent_segments / schema_version_total_segments stats emitted
+        by DataCoord through get_collection_stats (present only after a schema-changing
+        DDL; growing and L0 segments are excluded server-side, so flush data that must
+        be counted). Two consecutive consistent polls absorb the DDL -> DataCoord
+        propagation window.
+        """
+        timeout = TIMEOUT if timeout is None else timeout
+        start_time = time.time()
+        streak = 0
+        while start_time + timeout > time.time():
+            stats, _ = self.get_collection_stats(client, collection_name)
+            consistent = stats.get("schema_version_consistent_segments")
+            total = stats.get("schema_version_total_segments")
+            if consistent is not None and total is not None and int(total) > 0 and int(consistent) == int(total):
+                streak += 1
+                if streak >= 2:
+                    return True
+            else:
+                streak = 0
+            time.sleep(2)
+        return False
+
     @trace()
     def create_alias(self, client, collection_name, alias, timeout=None, check_task=None, check_items=None, **kwargs):
         timeout = TIMEOUT if timeout is None else timeout

--- a/tests/python_client/milvus_client/test_add_function_field_feature.py
+++ b/tests/python_client/milvus_client/test_add_function_field_feature.py
@@ -3390,7 +3390,7 @@ class TestMilvusClientAddFunctionFieldFeature(TestMilvusClientV2Base):
             check_items={
                 ct.err_code: 1100,
                 ct.err_msg: (
-                    "minhash function output field 'mh' dim 256 does not match expected dim 512 "
+                    "minhash function output field 'mh' dim 256 does not match expected dim "
                     "(numHashes 16 * one minhash signature size of 32bit): invalid parameter"
                 ),
             },
@@ -3807,4 +3807,134 @@ class TestMilvusClientAddFunctionFieldFeature(TestMilvusClientV2Base):
 
         self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_add_bm25_function_field_on_backfilled_varchar_input(self):
+        """
+        target: verify BM25 add_function_field whose input VARCHAR was itself added after
+                sealed data neither crashes datanode nor corrupts data (issue #52159)
+        method: seal rows without the varchar; add_collection_field(varchar+analyzer);
+                gate the bump on schema-version consistency stats; verify null backfill
+                through output_fields; insert valued rows; add a BM25 function using the
+                added varchar as input; gate again; verify search hits and per-row values
+        expected: both bumps reach consistent==total; old rows read back null; BM25 hits
+                  only valued rows; every row value byte-exact; total count intact
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        n_old, n_new = 50, 20
+
+        schema = client.create_schema(enable_dynamic_field=False, auto_id=False)
+        schema.add_field("id", DataType.INT64, is_primary=True)
+        schema.add_field("vec", DataType.FLOAT_VECTOR, dim=4)
+        schema.add_field("code", DataType.INT64)
+        index_params = client.prepare_index_params()
+        index_params.add_index(field_name="vec", index_type="AUTOINDEX", metric_type="L2")
+        client.create_collection(
+            collection_name=collection_name,
+            schema=schema,
+            index_params=index_params,
+            consistency_level="Strong",
+        )
+
+        # Feature-carrying sibling columns: every row's code/vec derive from its pk so the
+        # final read-back can prove the bumps corrupted nothing besides adding fields.
+        expected_code = {i: 1000 + i for i in range(n_old)}
+        expected_vec = {i: [float(i), 0.0, 0.0, 0.0] for i in range(n_old)}
+        client.insert(
+            collection_name,
+            [{"id": i, "vec": expected_vec[i], "code": expected_code[i]} for i in range(n_old)],
+        )
+        client.flush(collection_name)
+        assert self.wait_for_index_ready(client, collection_name, index_name="vec", timeout=120)
+        client.load_collection(collection_name)
+        schema_version_initial = client.describe_collection(collection_name)["schema_version"]
+
+        # Step 1: the future BM25 input field does not exist yet — add it now.
+        client.add_collection_field(
+            collection_name,
+            field_name="doc_text",
+            data_type=DataType.VARCHAR,
+            max_length=512,
+            nullable=True,
+            enable_analyzer=True,
+            analyzer_params={"tokenizer": "standard"},
+        )
+        schema_version_after_add_field = client.describe_collection(collection_name)["schema_version"]
+        assert schema_version_after_add_field > schema_version_initial
+        assert self.wait_for_schema_version_consistency(client, collection_name), (
+            "add-field schema bump did not reach segment consistency"
+        )
+
+        # Step 2: value-level oracle — every sealed row reads back null for the added field.
+        old_rows = client.query(collection_name, filter=f"id < {n_old}", output_fields=["id", "doc_text"], limit=n_old)
+        assert len(old_rows) == n_old
+        assert all(row["doc_text"] is None for row in old_rows)
+
+        expected_text = {100 + i: f"docmarker row{100 + i} milvus backfilled input" for i in range(n_new)}
+        expected_code.update({pk: 2000 + pk for pk in expected_text})
+        expected_vec.update({pk: [0.0, float(pk), 0.0, 0.0] for pk in expected_text})
+        client.insert(
+            collection_name,
+            [
+                {"id": pk, "vec": expected_vec[pk], "code": expected_code[pk], "doc_text": text}
+                for pk, text in expected_text.items()
+            ],
+        )
+        client.flush(collection_name)
+
+        # Step 3: BM25 whose input is the ADDED field — the function backfill must
+        # materialize over segments where the input itself was backfilled null.
+        sparse_field = FieldSchema(name="sparse", dtype=DataType.SPARSE_FLOAT_VECTOR)
+        bm25_function = Function(
+            name="bm25_fn",
+            function_type=FunctionType.BM25,
+            input_field_names=["doc_text"],
+            output_field_names=["sparse"],
+        )
+        bound_index_params = client.prepare_index_params()
+        bound_index_params.add_index(field_name="sparse", index_type="SPARSE_INVERTED_INDEX", metric_type="BM25")
+        client.add_function_field(collection_name, sparse_field, bm25_function, index_params=bound_index_params)
+
+        schema_version_after_add_function = client.describe_collection(collection_name)["schema_version"]
+        assert schema_version_after_add_function > schema_version_after_add_field
+        assert self.wait_for_schema_version_consistency(client, collection_name), (
+            "function-field schema bump did not reach segment consistency"
+        )
+        assert self.wait_for_index_ready(client, collection_name, index_name="sparse", timeout=180)
+        self.release_collection(client, collection_name)
+        client.load_collection(collection_name)
+
+        search_res = self.wait_for_search_hit(
+            client,
+            collection_name,
+            data=["docmarker row105"],
+            anns_field="sparse",
+            expected_id=105,
+            label="BM25 on backfilled varchar input",
+            search_params={"metric_type": "BM25"},
+            output_fields=["id"],
+            limit=10,
+        )
+        hit_ids = [hit["id"] for hit in search_res[0]]
+        assert all(pk >= 100 for pk in hit_ids), f"null-input rows must not match: {hit_ids}"
+
+        # Step 4: value-level integrity — the added column reads back null for old rows and
+        # byte-exact for new rows, and the sibling columns still match what was inserted.
+        all_rows = client.query(
+            collection_name,
+            filter="id >= 0",
+            output_fields=["id", "doc_text", "code", "vec"],
+            limit=n_old + n_new,
+        )
+        assert len(all_rows) == n_old + n_new
+        for row in all_rows:
+            pk = row["id"]
+            assert row["doc_text"] == expected_text.get(pk), f"id={pk} doc_text mismatch"
+            assert row["code"] == expected_code[pk], f"id={pk} sibling code corrupted"
+            assert len(row["vec"]) == 4 and all(abs(a - b) < 1e-6 for a, b in zip(row["vec"], expected_vec[pk])), (
+                f"id={pk} sibling vec corrupted"
+            )
+
         self.drop_collection(client, collection_name)

--- a/tests/python_client/milvus_client/test_milvus_client_text_lob.py
+++ b/tests/python_client/milvus_client/test_milvus_client_text_lob.py
@@ -12,7 +12,7 @@ from base.client_v2_base import TestMilvusClientV2Base
 from common import common_func as cf
 from common import common_type as ct
 from common.common_type import CaseLabel, CheckTasks
-from pymilvus import AnnSearchRequest, DataType, Function, FunctionType, WeightedRanker
+from pymilvus import AnnSearchRequest, DataType, FieldSchema, Function, FunctionType, WeightedRanker
 from pymilvus.client.types import LoadState
 from utils.util_log import test_log as log
 
@@ -2073,6 +2073,137 @@ class TestMilvusClientTextLOBIndependent(TestMilvusClientV2Base):
         rows_by_id = query_by_ids(self, client, collection_name, survivor_ids, [CONTENT_FIELD])
         assert_rows_payload(rows_by_id, expected, [CONTENT_FIELD])
         assert query_by_ids(self, client, collection_name, deleted, [CONTENT_FIELD]) == {}
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_text_lob_add_function_field_bump_preserves_lob(self):
+        """
+        target: verify the add_function_field schema bump over sealed TEXT LOB data
+                preserves every payload byte-exact (issue #52159 family)
+        method: seal mixed external/inline/empty/null TEXT rows plus a varchar tag; add
+                a BM25 function on the tag; gate the bump on schema-version consistency
+                stats; compare every TEXT payload through output_fields; search via the
+                new sparse field; keep writing after the bump
+        expected: bump reaches consistent==total; all TEXT payloads byte-exact afterwards;
+                  BM25 hits the tagged row; post-bump writes stay correct; count intact
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        tag_field = "tag"
+        sparse_field_name = "tag_sparse"
+        external_size = int_env("MILVUS_TEXT_INLINE_THRESHOLD", 65536) + 1
+
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name=ID_FIELD, datatype=DataType.INT64, is_primary=True)
+        schema.add_field(field_name=VECTOR_FIELD, datatype=DataType.FLOAT_VECTOR, dim=DIM)
+        schema.add_field(
+            field_name=CONTENT_FIELD,
+            datatype=DataType.TEXT,
+            nullable=True,
+            enable_analyzer=True,
+            analyzer_params=STANDARD_ANALYZER,
+        )
+        schema.add_field(
+            field_name=tag_field,
+            datatype=DataType.VARCHAR,
+            max_length=256,
+            nullable=True,
+            enable_analyzer=True,
+            analyzer_params=STANDARD_ANALYZER,
+        )
+        index_params = client.prepare_index_params()
+        index_params.add_index(field_name=VECTOR_FIELD, index_type="FLAT", metric_type="COSINE")
+        self.create_collection(client, collection_name, schema=schema, consistency_level="Strong", load=False)
+        self.create_index(client, collection_name, index_params=index_params)
+
+        contents = {
+            1900: make_text(external_size, "bump-lob-a"),
+            1901: make_text(external_size + 4096, "bump-lob-b"),
+            1902: make_text(2048, "bump-inline-a"),
+            1903: "",
+            1904: None,
+        }
+        rows = [
+            {ID_FIELD: pk, VECTOR_FIELD: vector_for_pk(pk), CONTENT_FIELD: content, tag_field: f"tagmark row{pk}"}
+            for pk, content in contents.items()
+        ]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+        self.load_collection(client, collection_name)
+        expected = {pk: {CONTENT_FIELD: payload_meta(content)} for pk, content in contents.items()}
+        expected_tag = {pk: f"tagmark row{pk}" for pk in contents}
+        desc, _ = self.describe_collection(client, collection_name)
+        schema_version_initial = desc["schema_version"]
+
+        bm25_function = Function(
+            name="tag_bm25",
+            function_type=FunctionType.BM25,
+            input_field_names=[tag_field],
+            output_field_names=[sparse_field_name],
+        )
+        bound_index_params = client.prepare_index_params()
+        bound_index_params.add_index(
+            field_name=sparse_field_name, index_type="SPARSE_INVERTED_INDEX", metric_type="BM25"
+        )
+        client.add_function_field(
+            collection_name,
+            FieldSchema(name=sparse_field_name, dtype=DataType.SPARSE_FLOAT_VECTOR),
+            bm25_function,
+            index_params=bound_index_params,
+        )
+
+        desc, _ = self.describe_collection(client, collection_name)
+        assert desc["schema_version"] > schema_version_initial
+        assert self.wait_for_schema_version_consistency(client, collection_name), (
+            "schema bump did not reach segment consistency after add_function_field"
+        )
+        assert self.wait_for_index_ready(client, collection_name, index_name=sparse_field_name, timeout=180)
+        self.release_collection(client, collection_name)
+        self.load_collection(client, collection_name)
+
+        rows_by_id = query_by_ids(
+            self, client, collection_name, contents.keys(), [CONTENT_FIELD, tag_field, VECTOR_FIELD]
+        )
+        assert_rows_payload(rows_by_id, expected, [CONTENT_FIELD])
+        for pk, row in rows_by_id.items():
+            assert row[tag_field] == expected_tag[pk], f"id={pk} sibling tag corrupted"
+            expected_vector = vector_for_pk(pk)
+            assert len(row[VECTOR_FIELD]) == DIM and all(
+                abs(a - b) < 1e-6 for a, b in zip(row[VECTOR_FIELD], expected_vector)
+            ), f"id={pk} sibling vector corrupted"
+
+        search_res, _ = self.search(
+            client,
+            collection_name,
+            data=["row1901"],
+            anns_field=sparse_field_name,
+            search_params={"metric_type": "BM25", "params": {}},
+            limit=5,
+            output_fields=[ID_FIELD],
+            consistency_level="Strong",
+        )
+        assert 1901 in [result_id(hit) for hit in search_res[0]]
+
+        post_pk = 1910
+        post_content = make_text(external_size, "bump-post")
+        self.insert(
+            client,
+            collection_name,
+            [
+                {
+                    ID_FIELD: post_pk,
+                    VECTOR_FIELD: vector_for_pk(post_pk),
+                    CONTENT_FIELD: post_content,
+                    tag_field: f"tagmark row{post_pk}",
+                }
+            ],
+        )
+        self.flush(client, collection_name)
+        rows_by_id = query_by_ids(self, client, collection_name, [post_pk], [CONTENT_FIELD, tag_field])
+        assert_rows_payload(rows_by_id, {post_pk: {CONTENT_FIELD: payload_meta(post_content)}}, [CONTENT_FIELD])
+        assert rows_by_id[post_pk][tag_field] == f"tagmark row{post_pk}"
+        assert_count(self, client, collection_name, len(contents) + 1)
+
+        self.drop_collection(client, collection_name)
 
 
 class TestMilvusClientTextLOBNegative(TestMilvusClientV2Base):


### PR DESCRIPTION
### What problem
master e2e never covers two schema-bump additive intersections: (1) an `add_function_field` whose input VARCHAR was itself added via `add_collection_field` after the data was sealed (the exact crash shape of issue #52159); (2) an `add_function_field` bump triggered while the collection already holds a TEXT LOB column. Today `test_add_function_field_feature.py` uses only create-time VARCHAR inputs (no `add_collection_field`), and `test_milvus_client_text_lob.py` has no `add_function_field` at all — the two concerns never meet.

### What this does
Add two pymilvus e2e cases into the existing files (reusing their helpers, no new file):
- `test_add_bm25_function_field_on_backfilled_varchar_input`: seal rows without the varchar, `add_collection_field(VARCHAR)`, then `add_function_field` BM25 whose input is that added field. Asserts: old rows read back null; sibling columns (code/vec) are byte-exact per row against the inserted values; schema_version increments across both bumps; null-input rows are never matched by BM25.
- `test_text_lob_add_function_field_bump_preserves_lob`: sealed TEXT LOB rows in four states (external/inline/empty/null) plus an `add_function_field` BM25 bump. Asserts: every `content` payload is preserved byte-exact; sibling columns (tag/vector) stay intact per row; a post-bump insert is still exact.

Add base helper `wait_for_schema_version_consistency`: gate bump completion on the DataCoord-emitted `schema_version_consistent_segments == schema_version_total_segments` stats (via `get_collection_stats`) instead of a fixed sleep; combined with a `describe_collection` schema_version increment assertion so the gate cannot pass on the pre-bump state.

### Dependency / notes
- Depends on the master fix landing first: `pr: #52484` (issue #52159). Until it merges, `test_add_bm25_function_field_on_backfilled_varchar_input` reproduces a `panic: no such field` on the datanode (exactly the regression this test guards), so CI is expected RED — this is intended.
- Validated locally with a with-fix / without-fix two-arm comparison: the without-fix binary reproduces the panic (RED), the with-fix binary passes both tests (GREEN). External LOB goes through the `.vx` ref and the bump uses REUSE_ALL (LOB path unchanged), both confirmed against on-disk storage.
- Requires `dataCoord.compaction.bumpSchemaVersion.enabled: true` (already set in the three e2e helm values).
- Related enhancement tracking: #51649.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Also folds in a one-line repair of a stale L2 assertion (issue: #52878): #52219 intentionally dropped the computed expected dim from the minhash dim-mismatch message (overflow-safe division check), so the assertion no longer expects the literal `512`.
