### PR TITLE
fix: [2.6] preserve vector iterator chunk index after empty chunks

### DIFF
--- a/internal/core/src/common/QueryResult.h
+++ b/internal/core/src/common/QueryResult.h
@@ -187,12 +187,15 @@ struct VectorIterator {
     void
     seal() {
         sealed = true;
-        int idx = 0;
-        for (auto& iter : iterators_) {
+        // idx must track the iterator's physical position. A bitset can make
+        // one chunk empty, but Next() still uses this index to refill from
+        // iterators_.
+        for (int idx = 0; idx < static_cast<int>(iterators_.size()); ++idx) {
+            auto& iter = iterators_[idx];
             if (iter->HasNext()) {
                 auto origin_pair = iter->Next();
                 auto off_dis_pair =
-                    std::make_shared<OffsetDisPair>(origin_pair, idx++);
+                    std::make_shared<OffsetDisPair>(origin_pair, idx);
                 heap_.push(off_dis_pair);
             }
         }

--- a/internal/core/src/common/QueryResultTest.cpp
+++ b/internal/core/src/common/QueryResultTest.cpp
@@ -1,0 +1,78 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/QueryResult.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace milvus {
+namespace {
+
+class FixedKnowhereIterator : public knowhere::IndexNode::iterator {
+ public:
+    explicit FixedKnowhereIterator(
+        std::vector<std::pair<int64_t, float>> results)
+        : results_(std::move(results)) {
+    }
+
+    std::pair<int64_t, float>
+    Next() override {
+        return results_.at(position_++);
+    }
+
+    bool
+    HasNext() override {
+        return position_ < results_.size();
+    }
+
+ private:
+    std::vector<std::pair<int64_t, float>> results_;
+    size_t position_{0};
+};
+
+TEST(QueryResultTest, ChunkMergeIteratorKeepsIndexAfterEmptyChunk) {
+    std::vector<knowhere::IndexNode::IteratorPtr> chunk_iterators{
+        std::make_shared<FixedKnowhereIterator>(
+            std::vector<std::pair<int64_t, float>>{}),
+        std::make_shared<FixedKnowhereIterator>(
+            std::vector<std::pair<int64_t, float>>{{10, 1.0F}, {11, 3.0F}}),
+        std::make_shared<FixedKnowhereIterator>(
+            std::vector<std::pair<int64_t, float>>{{20, 2.0F}, {21, 4.0F}}),
+    };
+
+    SearchResult search_result;
+    search_result.AssembleChunkVectorIterators(
+        1, 3, {}, chunk_iterators, nullptr);
+
+    auto iterator = search_result.vector_iterators_->at(0);
+    std::vector<std::pair<int64_t, float>> actual;
+    while (iterator->HasNext()) {
+        actual.push_back(iterator->Next().value());
+    }
+
+    const std::vector<std::pair<int64_t, float>> expected{
+        {10, 1.0F}, {20, 2.0F}, {11, 3.0F}, {21, 4.0F}};
+    EXPECT_EQ(actual, expected);
+}
+
+}  // namespace
+}  // namespace milvus

--- a/internal/core/unittest/test_group_by.cpp
+++ b/internal/core/unittest/test_group_by.cpp
@@ -17,6 +17,7 @@
 #include "segcore/plan_c.h"
 #include "segcore/segment_c.h"
 #include "test_utils/DataGen.h"
+#include "test_utils/SegcoreConfigUtils.h"
 #include "test_utils/c_api_test_utils.h"
 #include "test_utils/storage_test_utils.h"
 #include "test_utils/cachinglayer_test_utils.h"
@@ -692,6 +693,104 @@ TEST(GroupBY, GrowingRawData) {
             idx++;
         }
     }
+}
+
+TEST(GroupBY, GrowingRawDataDeleteReinsertWithEmptyLeadingChunk) {
+    constexpr int64_t chunk_rows = 2;
+    constexpr int64_t dim = 4;
+    constexpr int64_t topk = 2;
+    constexpr int64_t group_size = 2;
+
+    auto schema = std::make_shared<Schema>();
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto group_fid = schema->AddDebugField("group", DataType::BOOL);
+    auto vec_fid = schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, dim, knowhere::metric::L2);
+    schema->set_primary_field_id(pk_fid);
+
+    auto& config = SegcoreConfig::default_config();
+    ScopedSegcoreConfigRestore config_restore(config);
+    config.set_chunk_rows(chunk_rows);
+    config.set_enable_interim_segment_index(false);
+    auto segment = CreateGrowingSegment(schema, nullptr, 1, config);
+    auto* growing = dynamic_cast<SegmentGrowingImpl*>(segment.get());
+    ASSERT_NE(growing, nullptr);
+
+    auto insert = [&](GeneratedData& data) {
+        const auto rows = data.raw_->num_rows();
+        const auto offset = growing->PreInsert(rows);
+        growing->Insert(offset,
+                        rows,
+                        data.row_ids_.data(),
+                        data.timestamps_.data(),
+                        data.raw_);
+        return offset;
+    };
+
+    // The first physical chunk contains the versions that will be deleted.
+    auto old_data = DataGen(schema, chunk_rows, 42, 0, 1, 10, 1, false, false);
+    ASSERT_EQ(insert(old_data), 0);
+
+    auto old_pks = old_data.get_col<int64_t>(pk_fid);
+    auto delete_pks = GenPKs(old_pks.begin(), old_pks.end());
+    auto delete_tss = GenTss(chunk_rows, 2);
+    ASSERT_TRUE(
+        growing->Delete(chunk_rows, delete_pks.get(), delete_tss.data()).ok());
+
+    // The two following chunks contain live replacements and additional rows.
+    auto live_data =
+        DataGen(schema, 2 * chunk_rows, 42, 4, 1, 10, 1, false, false);
+    for (auto& row_id : live_data.row_ids_) {
+        row_id += chunk_rows;
+    }
+    ASSERT_EQ(insert(live_data), chunk_rows);
+
+    const auto* vec_data = growing->get_insert_record().get_data_base(vec_fid);
+    ASSERT_NE(vec_data, nullptr);
+    ASSERT_EQ(vec_data->get_size_per_chunk(), chunk_rows);
+    ASSERT_EQ(vec_data->num_chunk(), 3);
+
+    BitsetType delete_mask(3 * chunk_rows, false);
+    auto delete_view = delete_mask.view();
+    growing->mask_with_delete(delete_view, 3 * chunk_rows, MAX_TIMESTAMP);
+    ASSERT_EQ(delete_mask.count(), chunk_rows);
+    for (int64_t i = 0; i < 3 * chunk_rows; ++i) {
+        EXPECT_EQ(delete_mask[i], i < chunk_rows);
+    }
+
+    ScopedSchemaHandle handle(*schema);
+    auto plan_blob = handle.ParseGroupBySearch("",
+                                               "vec",
+                                               topk,
+                                               "L2",
+                                               "{}",
+                                               group_fid.get(),
+                                               group_size,
+                                               "",
+                                               proto::schema::DataType::None,
+                                               true);
+    auto plan =
+        CreateSearchPlanByExpr(schema, plan_blob.data(), plan_blob.size());
+
+    auto live_vectors = live_data.get_col<float>(vec_fid);
+    auto raw_ph = CreatePlaceholderGroupFromBlob(1, dim, live_vectors.data());
+    auto ph = ParsePlaceholderGroup(plan.get(), raw_ph.SerializeAsString());
+    auto result = growing->Search(plan.get(), ph.get(), MAX_TIMESTAMP);
+
+    CheckGroupBySearchResult(*result, topk, 1, true);
+    ASSERT_EQ(result->seg_offsets_.size(), 2 * topk);
+    auto offsets = result->seg_offsets_;
+    std::sort(offsets.begin(), offsets.end());
+    EXPECT_EQ(offsets, (std::vector<int64_t>{2, 3, 4, 5}));
+
+    std::unordered_map<bool, int> group_counts;
+    for (const auto& value : result->group_by_values_.value()) {
+        ASSERT_TRUE(value.has_value());
+        ASSERT_TRUE(std::holds_alternative<bool>(value.value()));
+        ++group_counts[std::get<bool>(value.value())];
+    }
+    EXPECT_EQ(group_counts[false], group_size);
+    EXPECT_EQ(group_counts[true], group_size);
 }
 
 TEST(GroupBY, GrowingIndex) {


### PR DESCRIPTION
issue: #52605
pr: #51017

`VectorIterator::seal()` assigns the iterator index used later by `Next()` to refill a chunk. In 2.6, that index is incremented only when `HasNext()` is true. If a delete bitset makes a leading physical chunk empty, the following non-empty chunks are stamped with compacted indices rather than their positions in `iterators_`.

For example, with `[empty, live, live]`, the two live chunks are incorrectly stamped `0` and `1` although their actual positions are `1` and `2`. When `Next()` consumes their first candidates, it refills `iterators_[0]` or `iterators_[1]` instead of the originating chunk. The later chunk therefore contributes only its first candidate and its remaining candidates are silently dropped.

This matches #52605: GroupBy is the path that uses vector iterators; delete/reinsert without compaction can leave a leading chunk entirely tombstoned; compaction removes those tombstones and restores the physical chunk layout. Dense and sparse search share this chunk-merge code.

master fixed the same chunk-index bug in #51017. Its full change also adapts segcore to a newer Knowhere error-code iterator API, which is not applicable to 2.6. This PR only backports the physical-index fix.

Adds a deterministic `[empty, live, live]` merge test and a growing delete/reinsert GroupBy regression test that asserts the expected four live offsets. `QueryResultTest.* + GroupBY.*` passes (7 tests); clang-format 12 and `git diff --check` pass.