### PR TITLE
fix: [hotfix-2.5.13] upgrade librdkafka to 2.6.1 for SASL/SCRAM against Kafka 4.x

### DIFF
--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -40,7 +40,7 @@ class MilvusConan(ConanFile):
         "folly/2023.10.30.08@milvus/dev#81d7729cd4013a1b708af3340a3b04d9",
         "google-cloud-cpp/2.5.0@milvus/2.4#c5591ab30b26b53ea6068af6f07128d3",
         "opentelemetry-cpp/1.8.1.1@milvus/2.4#7345034855d593047826b0c74d9a0ced",
-        "librdkafka/1.9.1#e24dcbb0a1684dcf5a56d8d0692ceef3",
+        "librdkafka/2.6.1#5b0ecc7c75e262b3e22d652018bedb93",
         "abseil/20230125.3#dad7cc4c83bbd44c1f1cc9cc4d97ac88",
         "roaring/3.0.0#25a703f80eda0764a31ef939229e202d",
         "grpc/1.50.1@milvus/dev#75103960d1cac300cf425ccfccceac08",

--- a/pkg/mq/msgstream/mqwrapper/kafka/kafka_consumer_test.go
+++ b/pkg/mq/msgstream/mqwrapper/kafka/kafka_consumer_test.go
@@ -162,9 +162,15 @@ func TestKafkaConsumer_GetLatestMsgID(t *testing.T) {
 	assert.NoError(t, err)
 	defer consumer.Close()
 
+	// GetLatestMsgID queries the watermark offsets without allowing topic
+	// auto-creation, so the topic must exist before the first call. The
+	// mock cluster bundled with older librdkafka (<= 1.9.x, Metadata API
+	// v2) created it implicitly; newer versions follow the request flag.
+	createTopic(t, topic)
+
 	latestMsgID, err := consumer.GetLatestMsgID()
-	assert.Equal(t, int64(0), latestMsgID.(*kafkaID).messageID)
 	assert.NoError(t, err)
+	assert.Equal(t, int64(0), latestMsgID.(*kafkaID).messageID)
 
 	data1 := []int{111, 222, 333}
 	data2 := []string{"111", "222", "333"}
@@ -246,6 +252,16 @@ func testKafkaConsumerProduceData(t *testing.T, topic string, data []int, arr []
 	producer.(*kafkaProducer).p.Flush(500)
 }
 
+// createTopic makes sure topic exists on the broker by issuing a metadata
+// request from a producer, which allows automatic topic creation by default.
+func createTopic(t *testing.T, topic string) {
+	p, err := kafka.NewProducer(&kafka.ConfigMap{"bootstrap.servers": getKafkaBrokerList()})
+	assert.NoError(t, err)
+	defer p.Close()
+	_, err = p.GetMetadata(&topic, false, 10000)
+	assert.NoError(t, err)
+}
+
 func createConfig(groupID string) *kafka.ConfigMap {
 	kafkaAddress := getKafkaBrokerList()
 	return &kafka.ConfigMap{
@@ -259,6 +275,10 @@ func TestKafkaConsumer_CheckPreTopicValid(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	groupID := fmt.Sprintf("test-groupid-%d", rand.Int())
 	topic := fmt.Sprintf("test-topicName-%d", rand.Int())
+
+	// CheckTopicValid reports an error for a topic that does not exist on
+	// the broker, so make sure it exists first.
+	createTopic(t, topic)
 
 	config := createConfig(groupID)
 	consumer, err := newKafkaConsumer(config, 16, topic, groupID, mqcommon.SubscriptionPositionEarliest)


### PR DESCRIPTION
issue: #52601
pr: #52602 (master), #52666 (2.6)

Milvus cannot authenticate to an Apache Kafka 4.x broker when the listener
uses SASL with SCRAM-SHA-256. Every attempt fails with "invalid credentials"
while the Java client authenticates with the same user and password, and the
same Milvus build works against Kafka 3.9.1.

librdkafka appended the client nonce to the server-sent nonce a second time
when building the SCRAM client-final-message (present since v0.0.99). Kafka
4.x restored the strict nonce comparison required by RFC 5802, so brokers on
the 4.x line reject the proof. Fixed upstream in librdkafka 2.6.1
(confluentinc/librdkafka#4895). 2.6.0 still fails, so 2.6.1 is the lowest
usable version.

No Go changes are needed: Milvus builds with -tags dynamic, so
confluent-kafka-go links whatever librdkafka the build provides and only
requires a minimum of 1.9.0.

The conan 1.x recipe is published to default-conan-local as librdkafka/2.6.1
(milvus-io/conanfiles#180, recipe revision 5b0ecc7c75e262b3e22d652018bedb93),
so this pins that revision.