### PR TITLE
enhance: [2.6] refine segment loading resource control

### DIFF
--- a/internal/core/src/common/Chunk.h
+++ b/internal/core/src/common/Chunk.h
@@ -100,10 +100,18 @@ class Chunk {
 
     cachinglayer::ResourceUsage
     CellByteSize() const {
+        if (cell_size_override_.has_value()) {
+            return cell_size_override_.value();
+        }
         if (chunk_mmap_guard_ && chunk_mmap_guard_->is_file_backed()) {
             return cachinglayer::ResourceUsage(0, static_cast<int64_t>(size_));
         }
         return cachinglayer::ResourceUsage(static_cast<int64_t>(size_), 0);
+    }
+
+    void
+    SetCellSize(cachinglayer::ResourceUsage cell_size) {
+        cell_size_override_ = cell_size;
     }
 
     int64_t
@@ -251,6 +259,7 @@ class Chunk {
     bool nullable_;
 
     std::shared_ptr<ChunkMmapGuard> chunk_mmap_guard_{nullptr};
+    std::optional<cachinglayer::ResourceUsage> cell_size_override_;
     mutable std::once_flag valid_rank_blocks_once_;
     mutable std::vector<int64_t> valid_rank_blocks_;
 };

--- a/internal/core/src/common/Utils.h
+++ b/internal/core/src/common/Utils.h
@@ -20,9 +20,11 @@
 #include <cstring>
 #include <cmath>
 #include <filesystem>
+#include <limits>
 #include <memory>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <vector>
 
 #include "common/Consts.h"
@@ -159,6 +161,60 @@ upper_div(int64_t value, int64_t align) {
     Assert(align > 0);
     auto groups = value / align + (value % align != 0);
     return groups;
+}
+
+template <typename T,
+          std::enable_if_t<std::is_integral_v<T> &&
+                               !std::is_same_v<std::remove_cv_t<T>, bool>,
+                           int> = 0>
+constexpr T
+SaturatingAdd(T lhs, T rhs) noexcept {
+    if constexpr (std::is_unsigned_v<T>) {
+        return rhs > std::numeric_limits<T>::max() - lhs
+                   ? std::numeric_limits<T>::max()
+                   : lhs + rhs;
+    } else {
+        if (rhs > 0 && lhs > std::numeric_limits<T>::max() - rhs) {
+            return std::numeric_limits<T>::max();
+        }
+        if (rhs < 0 && lhs < std::numeric_limits<T>::min() - rhs) {
+            return std::numeric_limits<T>::min();
+        }
+        return lhs + rhs;
+    }
+}
+
+template <typename T,
+          std::enable_if_t<std::is_integral_v<T> &&
+                               !std::is_same_v<std::remove_cv_t<T>, bool>,
+                           int> = 0>
+constexpr T
+SaturatingMultiply(T lhs, T rhs) noexcept {
+    if constexpr (std::is_unsigned_v<T>) {
+        return lhs != 0 && rhs > std::numeric_limits<T>::max() / lhs
+                   ? std::numeric_limits<T>::max()
+                   : lhs * rhs;
+    } else {
+        if (lhs == 0 || rhs == 0) {
+            return 0;
+        }
+        if (lhs > 0) {
+            if (rhs > 0 && lhs > std::numeric_limits<T>::max() / rhs) {
+                return std::numeric_limits<T>::max();
+            }
+            if (rhs < 0 && rhs < std::numeric_limits<T>::min() / lhs) {
+                return std::numeric_limits<T>::min();
+            }
+        } else {
+            if (rhs > 0 && lhs < std::numeric_limits<T>::min() / rhs) {
+                return std::numeric_limits<T>::min();
+            }
+            if (rhs < 0 && lhs < std::numeric_limits<T>::max() / rhs) {
+                return std::numeric_limits<T>::max();
+            }
+        }
+        return lhs * rhs;
+    }
 }
 
 inline bool

--- a/internal/core/src/common/UtilsTest.cpp
+++ b/internal/core/src/common/UtilsTest.cpp
@@ -11,6 +11,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
+#include <limits>
 #include <string>
 
 #include "common/Utils.h"
@@ -30,6 +32,33 @@ TEST(Util_Common, GetCommonPrefix) {
     str2 = "";
     common_prefix = milvus::GetCommonPrefix(str1, str2);
     EXPECT_STREQ(common_prefix.c_str(), "");
+}
+
+TEST(Util_Common, SaturatingArithmetic) {
+    constexpr auto uint64_max = std::numeric_limits<uint64_t>::max();
+
+    EXPECT_EQ(milvus::SaturatingAdd<uint64_t>(1, 2), 3);
+    EXPECT_EQ(milvus::SaturatingAdd<uint64_t>(uint64_max - 1, 1), uint64_max);
+    EXPECT_EQ(milvus::SaturatingAdd<uint64_t>(uint64_max, 1), uint64_max);
+
+    EXPECT_EQ(milvus::SaturatingMultiply<uint64_t>(2, 3), 6);
+    EXPECT_EQ(milvus::SaturatingMultiply<uint64_t>(0, uint64_max), 0);
+    EXPECT_EQ(milvus::SaturatingMultiply<uint64_t>(uint64_max / 2, 2),
+              uint64_max - 1);
+    EXPECT_EQ(milvus::SaturatingMultiply<uint64_t>(uint64_max / 2 + 1, 2),
+              uint64_max);
+
+    constexpr auto int32_max = std::numeric_limits<int32_t>::max();
+    constexpr auto int32_min = std::numeric_limits<int32_t>::min();
+    EXPECT_EQ(milvus::SaturatingAdd<int32_t>(int32_max, 1), int32_max);
+    EXPECT_EQ(milvus::SaturatingAdd<int32_t>(int32_min, -1), int32_min);
+    EXPECT_EQ(milvus::SaturatingMultiply<int32_t>(int32_max, 2), int32_max);
+    EXPECT_EQ(milvus::SaturatingMultiply<int32_t>(int32_min, 2), int32_min);
+    EXPECT_EQ(milvus::SaturatingMultiply<int32_t>(int32_min, -1), int32_max);
+
+    constexpr auto uint8_max = std::numeric_limits<uint8_t>::max();
+    EXPECT_EQ(milvus::SaturatingAdd<uint8_t>(uint8_max, 1), uint8_max);
+    EXPECT_EQ(milvus::SaturatingMultiply<uint8_t>(uint8_max, 2), uint8_max);
 }
 
 TEST(SimilarityCorelation, Naive) {

--- a/internal/core/src/index/BitmapIndex.cpp
+++ b/internal/core/src/index/BitmapIndex.cpp
@@ -16,6 +16,9 @@
 
 #include <algorithm>
 #include <boost/algorithm/string.hpp>
+#include <cstring>
+#include <filesystem>
+#include <folly/ScopeGuard.h>
 #include <optional>
 #include <sys/errno.h>
 #include <unistd.h>
@@ -1446,30 +1449,74 @@ BitmapIndex<T>::LoadEntries(storage::IndexEntryReader& reader,
         rebuild_validity_from_postings = false;
     }
 
-    auto data_entry = reader.ReadEntry(BITMAP_INDEX_DATA);
-
     ChooseIndexLoadMode(index_length);
+
+    auto priority = GetValueFromConfig<milvus::proto::common::LoadPriority>(
+                        config, milvus::LOAD_PRIORITY)
+                        .value_or(milvus::proto::common::LoadPriority::HIGH);
 
     if (config.contains(MMAP_FILE_PATH) &&
         build_mode_ == BitmapIndexBuildMode::ROARING) {
         auto mmap_filepath =
             GetValueFromConfig<std::string>(config, MMAP_FILE_PATH);
-        auto priority =
-            GetValueFromConfig<milvus::proto::common::LoadPriority>(
-                config, milvus::LOAD_PRIORITY)
-                .value_or(milvus::proto::common::LoadPriority::HIGH);
         AssertInfo(mmap_filepath.has_value(),
                    "mmap filepath is empty when load index");
+
+        auto parent =
+            std::filesystem::path(mmap_filepath.value()).parent_path();
+        if (!parent.empty()) {
+            std::filesystem::create_directories(parent);
+        }
+        auto tmp_path = mmap_filepath.value() + ".tmp_load";
+        auto tmp_path_guard =
+            folly::makeGuard([&tmp_path]() { unlink(tmp_path.c_str()); });
+        {
+            auto file_writer = storage::FileWriter(
+                tmp_path, storage::io::GetPriorityFromLoadPriority(priority));
+            reader.ReadEntryStream(BITMAP_INDEX_DATA,
+                                   [&](const uint8_t* data, size_t len) {
+                                       file_writer.Write(data, len);
+                                   });
+            file_writer.Finish();
+        }
+        auto tmp_size = std::filesystem::file_size(tmp_path);
+        auto tmp_file = File::Open(tmp_path, O_RDONLY);
+        auto* tmp_map = mmap(nullptr,
+                             tmp_size,
+                             PROT_READ,
+                             MAP_PRIVATE,
+                             tmp_file.Descriptor(),
+                             0);
+        AssertInfo(tmp_map != MAP_FAILED,
+                   "failed to mmap bitmap temp file: {}",
+                   strerror(errno));
+        tmp_file.Close();
+        auto tmp_map_guard = folly::makeGuard(
+            [tmp_map, tmp_size]() { munmap(tmp_map, tmp_size); });
+
         MMapIndexData(mmap_filepath.value(),
-                      data_entry.data.data(),
-                      data_entry.data.size(),
+                      static_cast<const uint8_t*>(tmp_map),
+                      tmp_size,
                       index_length,
                       priority,
                       rebuild_validity_from_postings);
     } else {
-        DeserializeIndexData(data_entry.data.data(),
-                             index_length,
-                             rebuild_validity_from_postings);
+        auto data_size = reader.GetEntrySize(BITMAP_INDEX_DATA);
+        std::vector<uint8_t> data(data_size);
+        size_t written = 0;
+        reader.ReadEntryStream(
+            BITMAP_INDEX_DATA, [&](const uint8_t* slice, size_t len) {
+                AssertInfo(len <= data_size - written,
+                           "bitmap index stream exceeds expected size");
+                std::memcpy(data.data() + written, slice, len);
+                written += len;
+            });
+        AssertInfo(written == data_size,
+                   "bitmap index stream size mismatch: got {}, expected {}",
+                   written,
+                   data_size);
+        DeserializeIndexData(
+            data.data(), index_length, rebuild_validity_from_postings);
     }
 
     if (enable_offset_cache.has_value() && enable_offset_cache.value()) {

--- a/internal/core/src/index/HybridScalarIndexTest.cpp
+++ b/internal/core/src/index/HybridScalarIndexTest.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 #include <functional>
 #include <boost/filesystem.hpp>
+#include <map>
 #include <unordered_set>
 #include <memory>
 
@@ -109,6 +110,8 @@ class HybridIndexTestV1 : public testing::Test {
             collection_id, partition_id, segment_id, field_id, field_schema};
         auto index_meta = storage::IndexMeta{
             segment_id, field_id, index_build_id, index_version};
+        field_meta_ = field_meta;
+        index_meta_ = index_meta;
 
         std::vector<T> data_gen;
         data_gen = GenerateData<T>(nb_, cardinality_);
@@ -181,6 +184,7 @@ class HybridIndexTestV1 : public testing::Test {
             ASSERT_GT(memSize, 0);
             ASSERT_GT(serializedSize, 0);
             index_files = create_index_result->GetIndexFiles();
+            index_files_ = index_files;
         }
 
         index::CreateIndexInfo index_info{};
@@ -512,6 +516,9 @@ class HybridIndexTestV1 : public testing::Test {
     boost::container::vector<T> data_;
     std::shared_ptr<storage::ChunkManager> chunk_manager_;
     milvus_storage::ArrowFileSystemPtr fs_;
+    storage::FieldDataMeta field_meta_;
+    storage::IndexMeta index_meta_;
+    std::vector<std::string> index_files_;
     bool nullable_;
     FixedVector<bool> valid_data_;
     int index_build_id_;
@@ -526,6 +533,33 @@ TYPED_TEST_SUITE_P(HybridIndexTestV1);
 TYPED_TEST_P(HybridIndexTestV1, CountFuncTest) {
     auto count = this->index_->Count();
     EXPECT_EQ(count, this->nb_);
+}
+
+TYPED_TEST_P(HybridIndexTestV1, ResourceEstimateUsesInternalIndexType) {
+    constexpr uint64_t kIndexSize = 1024;
+    const std::map<std::string, std::string> index_params{
+        {milvus::index::INDEX_TYPE, milvus::index::HYBRID_INDEX_TYPE},
+        {milvus::index::SCALAR_INDEX_ENGINE_VERSION, "3"}};
+    storage::FileManagerContext ctx(
+        this->field_meta_, this->index_meta_, this->chunk_manager_, this->fs_);
+    ctx.set_for_loading_index(true);
+
+    const auto request =
+        index::IndexFactory::GetInstance().ScalarIndexLoadResource(
+            this->type_,
+            0,
+            kIndexSize,
+            index_params,
+            false,
+            this->nb_,
+            this->index_files_,
+            ctx);
+
+    EXPECT_EQ(request.final_memory_cost, kIndexSize);
+    EXPECT_EQ(request.final_disk_cost, 0);
+    EXPECT_EQ(request.max_memory_cost, 2 * kIndexSize);
+    EXPECT_EQ(request.max_disk_cost, 0);
+    EXPECT_FALSE(request.has_raw_data);
 }
 
 TYPED_TEST_P(HybridIndexTestV1, INFuncTest) {
@@ -557,6 +591,7 @@ using BitmapType =
 
 REGISTER_TYPED_TEST_SUITE_P(HybridIndexTestV1,
                             CountFuncTest,
+                            ResourceEstimateUsesInternalIndexType,
                             INFuncTest,
                             IsNullFuncTest,
                             IsNotNullFuncTest,

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -50,6 +50,7 @@
 #include "pb/schema.pb.h"
 #include "storage/IndexEntryReader.h"
 #include "storage/MemFileManagerImpl.h"
+#include "storage/ThreadPools.h"
 
 namespace milvus::index {
 namespace {
@@ -107,6 +108,15 @@ GetFileName(const std::string& path) {
     return pos == std::string::npos ? path : path.substr(pos + 1);
 }
 
+proto::common::LoadPriority
+ResolveLoadPriority(const std::map<std::string, std::string>& index_params) {
+    // Missing or unrecognized values use the higher-concurrency pool so the
+    // loading-memory estimate remains conservative.
+    const auto it = index_params.find(LOAD_PRIORITY);
+    return it == index_params.end() ? proto::common::LoadPriority::HIGH
+                                    : PriorityForLoad(it->second);
+}
+
 IndexType
 HybridInternalIndexTypeToIndexType(ScalarIndexType type) {
     switch (type) {
@@ -126,13 +136,13 @@ HybridInternalIndexTypeToIndexType(ScalarIndexType type) {
 std::optional<ScalarIndexType>
 ResolveHybridInternalIndexType(
     const std::vector<std::string>& index_files,
-    const storage::FileManagerContext& file_manager_context) {
+    const storage::FileManagerContext& file_manager_context,
+    proto::common::LoadPriority load_priority) {
     if (index_files.empty() || !file_manager_context.Valid()) {
         return std::nullopt;
     }
 
     storage::MemFileManagerImpl file_manager(file_manager_context);
-    const auto load_priority = proto::common::LoadPriority::HIGH;
     auto type_file =
         std::find_if(index_files.begin(), index_files.end(), [](const auto& f) {
             return GetFileName(f) == INDEX_TYPE;
@@ -156,7 +166,11 @@ ResolveHybridInternalIndexType(
         AssertInfo(input != nullptr,
                    "failed to open packed hybrid index file: {}",
                    index_files.front());
-        auto reader = storage::IndexEntryReader::Open(input, input->Size());
+        auto reader =
+            storage::IndexEntryReader::Open(input,
+                                            input->Size(),
+                                            /*collection_id=*/0,
+                                            PriorityForLoad(load_priority));
         AssertInfo(reader != nullptr,
                    "failed to create reader for packed hybrid index file");
         if (reader->HasMeta(INDEX_TYPE)) {
@@ -504,6 +518,7 @@ IndexFactory::ScalarIndexLoadResource(
     const auto scalar_version =
         GetValueFromConfig<int32_t>(config, SCALAR_INDEX_ENGINE_VERSION)
             .value_or(1);
+    const auto load_priority = ResolveLoadPriority(index_params);
 
     knowhere::expected<knowhere::Resource> resource;
 
@@ -513,7 +528,7 @@ IndexFactory::ScalarIndexLoadResource(
     if (index_type == milvus::index::ASCENDING_SORT) {
         if (scalar_version >= 3) {
             const auto stream_memory_overhead = ScalarIndexStreamMemoryOverhead(
-                index_size_in_bytes, scalar_version);
+                index_size_in_bytes, scalar_version, load_priority);
             const auto legacy_aux_bytes = SortLegacyAuxBytes(num_rows);
             if (mmap_enable) {
                 request.final_memory_cost = legacy_aux_bytes;
@@ -541,7 +556,7 @@ IndexFactory::ScalarIndexLoadResource(
                index_type == milvus::index::MARISA_TRIE_UPPER) {
         if (scalar_version >= 3) {
             const auto stream_memory_overhead = ScalarIndexStreamMemoryOverhead(
-                index_size_in_bytes, scalar_version);
+                index_size_in_bytes, scalar_version, load_priority);
             if (mmap_enable) {
                 const auto legacy_csr_resident_bytes =
                     MarisaLegacyCsrBytes(num_rows, 2);
@@ -578,9 +593,10 @@ IndexFactory::ScalarIndexLoadResource(
                index_type == milvus::index::NGRAM_INDEX_TYPE) {
         const auto validity_bitmap_bytes = ValidityBitmapBytes(num_rows);
         const auto stream_memory_overhead =
-            scalar_version >= 3 ? ScalarIndexStreamMemoryOverhead(
-                                      index_size_in_bytes, scalar_version)
-                                : index_size_in_bytes;
+            scalar_version >= 3
+                ? ScalarIndexStreamMemoryOverhead(
+                      index_size_in_bytes, scalar_version, load_priority)
+                : index_size_in_bytes;
         if (mmap_enable) {
             request.final_memory_cost = validity_bitmap_bytes;
             request.final_disk_cost = index_size_in_bytes;
@@ -605,8 +621,11 @@ IndexFactory::ScalarIndexLoadResource(
     } else if (index_type == milvus::index::BITMAP_INDEX_TYPE) {
         if (scalar_version >= 3) {
             const auto stream_memory_overhead = ScalarIndexStreamMemoryOverhead(
-                index_size_in_bytes, scalar_version);
+                index_size_in_bytes, scalar_version, load_priority);
             if (mmap_enable) {
+                // TODO: Once bitmap cardinality is exposed to admission
+                // estimation, account for the BITSET load mode's per-value
+                // resident bitsets here.
                 const auto resident_bytes = BitsetBytes(num_rows);
                 const auto frozen_buffer_bytes =
                     BitmapMmapFrozenBufferBytes(num_rows, index_size_in_bytes);
@@ -680,8 +699,9 @@ IndexFactory::ScalarIndexLoadResource(
     }
 
     try {
-        const auto internal_index_type =
-            ResolveHybridInternalIndexType(index_files, file_manager_context);
+        const auto load_priority = ResolveLoadPriority(index_params);
+        const auto internal_index_type = ResolveHybridInternalIndexType(
+            index_files, file_manager_context, load_priority);
         if (internal_index_type.has_value()) {
             const auto resolved_index_type =
                 HybridInternalIndexTypeToIndexType(internal_index_type.value());

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -15,14 +15,19 @@
 // limitations under the License.
 
 #include "index/IndexFactory.h"
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
 #include <cstdlib>
 #include <limits>
 #include <memory>
 #include <string>
+#include "common/Consts.h"
 #include "common/EasyAssert.h"
 #include "common/FieldDataInterface.h"
 #include "common/JsonCastType.h"
 #include "common/Types.h"
+#include "common/Utils.h"
 #include "index/Index.h"
 #include "index/JsonFlatIndex.h"
 #include "index/VectorMemIndex.h"
@@ -43,26 +48,132 @@
 #include "knowhere/comp/knowhere_check.h"
 #include "log/Log.h"
 #include "pb/schema.pb.h"
+#include "storage/IndexEntryReader.h"
+#include "storage/MemFileManagerImpl.h"
 
 namespace milvus::index {
+namespace {
+
+uint64_t
+BitsetBytes(int64_t num_rows) {
+    if (num_rows <= 0) {
+        return 0;
+    }
+    return (static_cast<uint64_t>(num_rows) + 7) / 8;
+}
+
+uint64_t
+AlignUp(uint64_t size, uint64_t alignment) {
+    if (alignment == 0 || size == 0) {
+        return size;
+    }
+    if (size > std::numeric_limits<uint64_t>::max() - (alignment - 1)) {
+        return std::numeric_limits<uint64_t>::max();
+    }
+    return ((size + alignment - 1) / alignment) * alignment;
+}
+
+uint64_t
+BitmapMmapFrozenBufferBytes(int64_t num_rows, uint64_t index_size_in_bytes) {
+    constexpr uint64_t kBitmapFrozenAlignment = 32;
+    return std::max(AlignUp(BitsetBytes(num_rows), kBitmapFrozenAlignment),
+                    index_size_in_bytes);
+}
+
+uint64_t
+SortLegacyAuxBytes(int64_t num_rows) {
+    if (num_rows <= 0) {
+        return 0;
+    }
+    const auto rows = static_cast<uint64_t>(num_rows);
+    return SaturatingAdd(SaturatingMultiply(rows, sizeof(int32_t)),
+                         BitsetBytes(num_rows));
+}
+
+uint64_t
+MarisaLegacyCsrBytes(int64_t num_rows, uint64_t arrays_per_row) {
+    if (num_rows <= 0) {
+        return 0;
+    }
+    const auto rows = static_cast<uint64_t>(num_rows);
+    return SaturatingMultiply(
+        SaturatingAdd(SaturatingMultiply(arrays_per_row, rows), uint64_t{1}),
+        sizeof(uint32_t));
+}
+
+std::string
+GetFileName(const std::string& path) {
+    const auto pos = path.find_last_of('/');
+    return pos == std::string::npos ? path : path.substr(pos + 1);
+}
+
+IndexType
+HybridInternalIndexTypeToIndexType(ScalarIndexType type) {
+    switch (type) {
+        case ScalarIndexType::BITMAP:
+            return BITMAP_INDEX_TYPE;
+        case ScalarIndexType::STLSORT:
+            return ASCENDING_SORT;
+        case ScalarIndexType::MARISA:
+            return MARISA_TRIE;
+        case ScalarIndexType::INVERTED:
+            return INVERTED_INDEX_TYPE;
+        default:
+            return "";
+    }
+}
+
+std::optional<ScalarIndexType>
+ResolveHybridInternalIndexType(
+    const std::vector<std::string>& index_files,
+    const storage::FileManagerContext& file_manager_context) {
+    if (index_files.empty() || !file_manager_context.Valid()) {
+        return std::nullopt;
+    }
+
+    storage::MemFileManagerImpl file_manager(file_manager_context);
+    const auto load_priority = proto::common::LoadPriority::HIGH;
+    auto type_file =
+        std::find_if(index_files.begin(), index_files.end(), [](const auto& f) {
+            return GetFileName(f) == INDEX_TYPE;
+        });
+    if (type_file != index_files.end()) {
+        auto index_datas = file_manager.LoadIndexToMemory(
+            std::vector<std::string>{*type_file}, load_priority);
+        BinarySet binary_set;
+        AssembleIndexDatas(index_datas, binary_set);
+        auto type_buffer = binary_set.GetByName(INDEX_TYPE);
+        AssertInfo(
+            type_buffer != nullptr && type_buffer->size >= sizeof(uint8_t),
+            "index type file not found in hybrid index binary set");
+        uint8_t type = 0;
+        std::memcpy(&type, type_buffer->data.get(), sizeof(type));
+        return static_cast<ScalarIndexType>(type);
+    }
+
+    if (index_files.size() == 1 && file_manager_context.fs != nullptr) {
+        auto input = file_manager.OpenInputStream(index_files.front());
+        AssertInfo(input != nullptr,
+                   "failed to open packed hybrid index file: {}",
+                   index_files.front());
+        auto reader = storage::IndexEntryReader::Open(input, input->Size());
+        AssertInfo(reader != nullptr,
+                   "failed to create reader for packed hybrid index file");
+        if (reader->HasMeta(INDEX_TYPE)) {
+            return static_cast<ScalarIndexType>(
+                reader->GetMeta<uint8_t>(INDEX_TYPE));
+        }
+    }
+    return std::nullopt;
+}
+
+}  // namespace
 
 namespace {
 
 uint64_t
 ValidityBitmapBytes(int64_t num_rows) {
-    if (num_rows <= 0) {
-        return 0;
-    }
-    auto rows = static_cast<uint64_t>(num_rows);
-    return ((rows - 1) / 64 + 1) * sizeof(uint64_t);
-}
-
-uint64_t
-SaturatingAdd(uint64_t lhs, uint64_t rhs) {
-    if (lhs > std::numeric_limits<uint64_t>::max() - rhs) {
-        return std::numeric_limits<uint64_t>::max();
-    }
-    return lhs + rhs;
+    return AlignUp(BitsetBytes(num_rows), sizeof(uint64_t));
 }
 
 }  // namespace
@@ -159,6 +270,38 @@ IndexFactory::IndexLoadResource(
                                        mmap_enable,
                                        num_rows);
     }
+}
+
+LoadResourceRequest
+IndexFactory::IndexLoadResource(
+    DataType field_type,
+    DataType element_type,
+    IndexVersion index_version,
+    uint64_t index_size_in_bytes,
+    const std::map<std::string, std::string>& index_params,
+    bool mmap_enable,
+    int64_t num_rows,
+    int64_t dim,
+    const std::vector<std::string>& index_files,
+    const storage::FileManagerContext& file_manager_context) {
+    if (milvus::IsVectorDataType(field_type)) {
+        return VecIndexLoadResource(field_type,
+                                    element_type,
+                                    index_version,
+                                    index_size_in_bytes,
+                                    index_params,
+                                    mmap_enable,
+                                    num_rows,
+                                    dim);
+    }
+    return ScalarIndexLoadResource(field_type,
+                                   index_version,
+                                   index_size_in_bytes,
+                                   index_params,
+                                   mmap_enable,
+                                   num_rows,
+                                   index_files,
+                                   file_manager_context);
 }
 
 LoadResourceRequest
@@ -358,6 +501,9 @@ IndexFactory::ScalarIndexLoadResource(
     auto index_type_it = index_params.find("index_type");
     AssertInfo(index_type_it != index_params.end(), "index type is empty");
     const std::string& index_type = index_type_it->second;
+    const auto scalar_version =
+        GetValueFromConfig<int32_t>(config, SCALAR_INDEX_ENGINE_VERSION)
+            .value_or(1);
 
     knowhere::expected<knowhere::Resource> resource;
 
@@ -365,38 +511,89 @@ IndexFactory::ScalarIndexLoadResource(
     request.has_raw_data = false;
 
     if (index_type == milvus::index::ASCENDING_SORT) {
-        request.final_memory_cost = index_size_in_bytes;
-        request.final_disk_cost = 0;
-        request.max_memory_cost = 2 * index_size_in_bytes;
-        request.max_disk_cost = 0;
-        request.has_raw_data = true;
-    } else if (index_type == milvus::index::MARISA_TRIE ||
-               index_type == milvus::index::MARISA_TRIE_UPPER) {
-        if (mmap_enable) {
-            request.final_memory_cost = 0;
-            request.final_disk_cost = index_size_in_bytes;
-            request.max_memory_cost = index_size_in_bytes;
-            request.max_disk_cost = index_size_in_bytes;
+        if (scalar_version >= 3) {
+            const auto stream_memory_overhead = ScalarIndexStreamMemoryOverhead(
+                index_size_in_bytes, scalar_version);
+            const auto legacy_aux_bytes = SortLegacyAuxBytes(num_rows);
+            if (mmap_enable) {
+                request.final_memory_cost = legacy_aux_bytes;
+                request.final_disk_cost = index_size_in_bytes;
+                request.max_memory_cost =
+                    SaturatingAdd(legacy_aux_bytes, stream_memory_overhead);
+                request.max_disk_cost = index_size_in_bytes;
+            } else {
+                request.final_memory_cost =
+                    SaturatingAdd(index_size_in_bytes, legacy_aux_bytes);
+                request.final_disk_cost = 0;
+                request.max_memory_cost = SaturatingAdd(
+                    request.final_memory_cost, stream_memory_overhead);
+                request.max_disk_cost = 0;
+            }
         } else {
             request.final_memory_cost = index_size_in_bytes;
             request.final_disk_cost = 0;
-            request.max_memory_cost = 2 * index_size_in_bytes;
-            request.max_disk_cost = index_size_in_bytes;
+            request.max_memory_cost =
+                SaturatingMultiply(uint64_t{2}, index_size_in_bytes);
+            request.max_disk_cost = 0;
+        }
+        request.has_raw_data = true;
+    } else if (index_type == milvus::index::MARISA_TRIE ||
+               index_type == milvus::index::MARISA_TRIE_UPPER) {
+        if (scalar_version >= 3) {
+            const auto stream_memory_overhead = ScalarIndexStreamMemoryOverhead(
+                index_size_in_bytes, scalar_version);
+            if (mmap_enable) {
+                const auto legacy_csr_resident_bytes =
+                    MarisaLegacyCsrBytes(num_rows, 2);
+                const auto legacy_csr_peak_bytes =
+                    MarisaLegacyCsrBytes(num_rows, 3);
+                request.final_memory_cost = legacy_csr_resident_bytes;
+                request.final_disk_cost = index_size_in_bytes;
+                request.max_memory_cost = SaturatingAdd(legacy_csr_peak_bytes,
+                                                        stream_memory_overhead);
+                request.max_disk_cost = index_size_in_bytes;
+            } else {
+                request.final_memory_cost = index_size_in_bytes;
+                request.final_disk_cost = 0;
+                request.max_memory_cost =
+                    SaturatingAdd(index_size_in_bytes, stream_memory_overhead);
+                request.max_disk_cost = index_size_in_bytes;
+            }
+        } else {
+            if (mmap_enable) {
+                request.final_memory_cost = 0;
+                request.final_disk_cost = index_size_in_bytes;
+                request.max_memory_cost = index_size_in_bytes;
+                request.max_disk_cost = index_size_in_bytes;
+            } else {
+                request.final_memory_cost = index_size_in_bytes;
+                request.final_disk_cost = 0;
+                request.max_memory_cost =
+                    SaturatingMultiply(uint64_t{2}, index_size_in_bytes);
+                request.max_disk_cost = index_size_in_bytes;
+            }
         }
         request.has_raw_data = true;
     } else if (index_type == milvus::index::INVERTED_INDEX_TYPE ||
                index_type == milvus::index::NGRAM_INDEX_TYPE) {
-        auto validity_bitmap_bytes = ValidityBitmapBytes(num_rows);
+        const auto validity_bitmap_bytes = ValidityBitmapBytes(num_rows);
+        const auto stream_memory_overhead =
+            scalar_version >= 3 ? ScalarIndexStreamMemoryOverhead(
+                                      index_size_in_bytes, scalar_version)
+                                : index_size_in_bytes;
         if (mmap_enable) {
             request.final_memory_cost = validity_bitmap_bytes;
             request.final_disk_cost = index_size_in_bytes;
+            request.max_memory_cost =
+                SaturatingAdd(stream_memory_overhead, validity_bitmap_bytes);
         } else {
-            request.final_memory_cost =
+            const auto resident_bytes =
                 SaturatingAdd(index_size_in_bytes, validity_bitmap_bytes);
+            request.final_memory_cost = resident_bytes;
             request.final_disk_cost = 0;
+            request.max_memory_cost =
+                std::max(resident_bytes, stream_memory_overhead);
         }
-        request.max_memory_cost =
-            SaturatingAdd(index_size_in_bytes, validity_bitmap_bytes);
         request.max_disk_cost = index_size_in_bytes;
         request.has_raw_data = false;
     } else if (index_type == milvus::index::RTREE_INDEX_TYPE) {
@@ -406,16 +603,41 @@ IndexFactory::ScalarIndexLoadResource(
         request.max_disk_cost = index_size_in_bytes;
         request.has_raw_data = false;
     } else if (index_type == milvus::index::BITMAP_INDEX_TYPE) {
-        if (mmap_enable) {
-            request.final_memory_cost = 0;
-            request.final_disk_cost = index_size_in_bytes;
-            request.max_memory_cost = index_size_in_bytes;
-            request.max_disk_cost = index_size_in_bytes;
+        if (scalar_version >= 3) {
+            const auto stream_memory_overhead = ScalarIndexStreamMemoryOverhead(
+                index_size_in_bytes, scalar_version);
+            if (mmap_enable) {
+                const auto resident_bytes = BitsetBytes(num_rows);
+                const auto frozen_buffer_bytes =
+                    BitmapMmapFrozenBufferBytes(num_rows, index_size_in_bytes);
+                request.final_memory_cost = resident_bytes;
+                request.final_disk_cost = index_size_in_bytes;
+                request.max_memory_cost = SaturatingAdd(
+                    SaturatingAdd(resident_bytes, stream_memory_overhead),
+                    frozen_buffer_bytes);
+                request.max_disk_cost =
+                    SaturatingMultiply(uint64_t{2}, index_size_in_bytes);
+            } else {
+                request.final_memory_cost = index_size_in_bytes;
+                request.final_disk_cost = 0;
+                request.max_memory_cost = std::max(
+                    SaturatingMultiply(uint64_t{2}, index_size_in_bytes),
+                    SaturatingAdd(index_size_in_bytes, stream_memory_overhead));
+                request.max_disk_cost = 0;
+            }
         } else {
-            request.final_memory_cost = index_size_in_bytes;
-            request.final_disk_cost = 0;
-            request.max_memory_cost = 2 * index_size_in_bytes;
-            request.max_disk_cost = 0;
+            if (mmap_enable) {
+                request.final_memory_cost = 0;
+                request.final_disk_cost = index_size_in_bytes;
+                request.max_memory_cost = index_size_in_bytes;
+                request.max_disk_cost = index_size_in_bytes;
+            } else {
+                request.final_memory_cost = index_size_in_bytes;
+                request.final_disk_cost = 0;
+                request.max_memory_cost =
+                    SaturatingMultiply(uint64_t{2}, index_size_in_bytes);
+                request.max_disk_cost = 0;
+            }
         }
 
         request.has_raw_data = false;
@@ -434,6 +656,63 @@ IndexFactory::ScalarIndexLoadResource(
     request.has_raw_data =
         CanUseIndexRawDataForField(field_type, request.has_raw_data);
     return request;
+}
+
+LoadResourceRequest
+IndexFactory::ScalarIndexLoadResource(
+    DataType field_type,
+    IndexVersion index_version,
+    uint64_t index_size_in_bytes,
+    const std::map<std::string, std::string>& index_params,
+    bool mmap_enable,
+    int64_t num_rows,
+    const std::vector<std::string>& index_files,
+    const storage::FileManagerContext& file_manager_context) {
+    const auto index_type_it = index_params.find(INDEX_TYPE);
+    AssertInfo(index_type_it != index_params.end(), "index type is empty");
+    if (index_type_it->second != HYBRID_INDEX_TYPE) {
+        return ScalarIndexLoadResource(field_type,
+                                       index_version,
+                                       index_size_in_bytes,
+                                       index_params,
+                                       mmap_enable,
+                                       num_rows);
+    }
+
+    try {
+        const auto internal_index_type =
+            ResolveHybridInternalIndexType(index_files, file_manager_context);
+        if (internal_index_type.has_value()) {
+            const auto resolved_index_type =
+                HybridInternalIndexTypeToIndexType(internal_index_type.value());
+            if (!resolved_index_type.empty()) {
+                auto resolved_params = index_params;
+                resolved_params[INDEX_TYPE] = resolved_index_type;
+                LOG_INFO(
+                    "estimate hybrid scalar index load resource by internal "
+                    "index type: {}",
+                    resolved_index_type);
+                return ScalarIndexLoadResource(field_type,
+                                               index_version,
+                                               index_size_in_bytes,
+                                               resolved_params,
+                                               mmap_enable,
+                                               num_rows);
+            }
+        }
+    } catch (const std::exception& e) {
+        LOG_WARN(
+            "failed to resolve hybrid scalar internal index type, fallback "
+            "to hybrid estimate: {}",
+            e.what());
+    }
+
+    return ScalarIndexLoadResource(field_type,
+                                   index_version,
+                                   index_size_in_bytes,
+                                   index_params,
+                                   mmap_enable,
+                                   num_rows);
 }
 
 IndexBasePtr

--- a/internal/core/src/index/IndexFactory.h
+++ b/internal/core/src/index/IndexFactory.h
@@ -17,7 +17,9 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
+#include <vector>
 #include <mutex>
 #include <shared_mutex>
 
@@ -57,6 +59,10 @@ class IndexFactory {
     static bool
     CanUseIndexRawDataForField(DataType field_type, bool has_raw_data);
 
+    // Metadata-only estimator for callers that do not own an index-file
+    // context, notably the Go/CGo segment-loader admission path. This overload
+    // performs no index-file I/O, so a HYBRID index uses the conservative
+    // HYBRID fallback because its selected internal index type is unavailable.
     LoadResourceRequest
     IndexLoadResource(DataType field_type,
                       DataType element_type,
@@ -66,6 +72,22 @@ class IndexFactory {
                       bool mmap_enable,
                       int64_t num_rows,
                       int64_t dim);
+
+    // Context-aware estimator used by SealedIndexTranslator. The file context
+    // lets a HYBRID index resolve its persisted internal index type before
+    // estimating; vector and non-HYBRID scalar indexes share the metadata-only
+    // estimation logic above.
+    LoadResourceRequest
+    IndexLoadResource(DataType field_type,
+                      DataType element_type,
+                      IndexVersion index_version,
+                      uint64_t index_size_in_bytes,
+                      const std::map<std::string, std::string>& index_params,
+                      bool mmap_enable,
+                      int64_t num_rows,
+                      int64_t dim,
+                      const std::vector<std::string>& index_files,
+                      const storage::FileManagerContext& file_manager_context);
 
     LoadResourceRequest
     VecIndexLoadResource(DataType field_type,
@@ -77,6 +99,7 @@ class IndexFactory {
                          int64_t num_rows,
                          int64_t dim);
 
+    // Shared metadata-only scalar estimator.
     LoadResourceRequest
     ScalarIndexLoadResource(
         DataType field_type,
@@ -85,6 +108,18 @@ class IndexFactory {
         const std::map<std::string, std::string>& index_params,
         bool mmap_enable,
         int64_t num_rows);
+
+    // HYBRID-aware scalar estimator backing the context-aware entry point.
+    LoadResourceRequest
+    ScalarIndexLoadResource(
+        DataType field_type,
+        IndexVersion index_version,
+        uint64_t index_size_in_bytes,
+        const std::map<std::string, std::string>& index_params,
+        bool mmap_enable,
+        int64_t num_rows,
+        const std::vector<std::string>& index_files,
+        const storage::FileManagerContext& file_manager_context);
 
     IndexBasePtr
     CreateIndex(const CreateIndexInfo& create_index_info,

--- a/internal/core/src/index/Meta.h
+++ b/internal/core/src/index/Meta.h
@@ -31,6 +31,8 @@ constexpr const char* MATCH_VALUE = "match_value";
 // below configurations will be persistent, do not edit them.
 constexpr const char* MARISA_TRIE_INDEX = "marisa_trie_index";
 constexpr const char* MARISA_STR_IDS = "marisa_trie_str_ids";
+constexpr const char* MARISA_CSR_INDEX = "marisa_csr_index";
+constexpr const char* MARISA_CSR_OFFSETS = "marisa_csr_offsets";
 
 // below meta key of store bitmap indexes
 constexpr const char* BITMAP_INDEX_DATA = "bitmap_index_data";

--- a/internal/core/src/index/ScalarIndex.cpp
+++ b/internal/core/src/index/ScalarIndex.cpp
@@ -33,6 +33,7 @@
 #include "storage/FileManager.h"
 #include "storage/IndexEntryReader.h"
 #include "storage/IndexEntryWriter.h"
+#include "storage/ThreadPools.h"
 #include "storage/Util.h"
 
 namespace milvus::index {
@@ -249,9 +250,12 @@ ScalarIndex<T>::LoadUnified(const Config& config) {
 
     auto collection_id =
         GetValueFromConfig<int64_t>(config, COLLECTION_ID).value_or(0);
+    const auto load_priority =
+        GetValueFromConfig<proto::common::LoadPriority>(config, LOAD_PRIORITY)
+            .value_or(proto::common::LoadPriority::HIGH);
 
-    auto reader =
-        storage::IndexEntryReader::Open(input, file_size, collection_id);
+    auto reader = storage::IndexEntryReader::Open(
+        input, file_size, collection_id, PriorityForLoad(load_priority));
     AssertInfo(reader != nullptr, "failed to create IndexEntryReader");
 
     LoadEntries(*reader, config);

--- a/internal/core/src/index/ScalarIndexSort.cpp
+++ b/internal/core/src/index/ScalarIndexSort.cpp
@@ -16,12 +16,12 @@
 
 #include <errno.h>
 #include <fcntl.h>
-#include <stdio.h>
 #include <string.h>
 #include <algorithm>
 #include <cstdint>
 #include <exception>
 #include <filesystem>
+#include <limits>
 #include <map>
 #include <memory>
 #include <optional>
@@ -62,7 +62,8 @@ const std::string STLSORT_INDEX_FILE_NAME = "stlsort-index";
 
 constexpr size_t ALIGNMENT = 32;  // 32-byte alignment
 
-const uint64_t MMAP_INDEX_PADDING = 1;
+// mmap rejects a zero-length mapping; all-null indexes need one backing byte.
+constexpr size_t MIN_MMAP_FILE_SIZE = 1;
 
 template <typename T>
 ScalarIndexSort<T>::ScalarIndexSort(
@@ -119,6 +120,8 @@ ScalarIndexSort<T>::Build(size_t n, const T* values, const bool* valid_data) {
     for (size_t i = 0; i < data_.size(); ++i) {
         idx_to_offsets_[data_[i].idx_] = i;
     }
+    idx_to_offsets_ptr_ = idx_to_offsets_.data();
+    idx_to_offsets_size_ = idx_to_offsets_.size();
     is_built_ = true;
 
     setup_data_pointers();
@@ -163,6 +166,8 @@ ScalarIndexSort<T>::BuildWithFieldData(
         }
         idx_to_offsets_[data_[i].idx_] = i;
     }
+    idx_to_offsets_ptr_ = idx_to_offsets_.data();
+    idx_to_offsets_size_ = idx_to_offsets_.size();
     is_built_ = true;
 
     setup_data_pointers();
@@ -228,8 +233,10 @@ ScalarIndexSort<T>::SetupMmapFromData(
                          : MMAP_PATH_FOR_TEST;
     std::filesystem::create_directories(
         std::filesystem::path(mmap_filepath_).parent_path());
+    auto mmap_file_raii = std::make_unique<MmapFileRAII>(mmap_filepath_);
 
     auto aligned_size = ((size + ALIGNMENT - 1) / ALIGNMENT) * ALIGNMENT;
+    auto mmap_size = std::max(aligned_size, MIN_MMAP_FILE_SIZE);
 
     // Write data to file with alignment padding
     {
@@ -241,31 +248,31 @@ ScalarIndexSort<T>::SetupMmapFromData(
             std::vector<uint8_t> padding(aligned_size - size, 0);
             file_writer.Write(padding.data(), padding.size());
         }
-        // Write extra padding for safety
-        std::vector<uint8_t> padding(MMAP_INDEX_PADDING, 0);
-        file_writer.Write(padding.data(), padding.size());
+        // Keep the mmap length non-zero when the index contains no valid
+        // values.
+        if (aligned_size == 0) {
+            const uint8_t empty_index_placeholder = 0;
+            file_writer.Write(&empty_index_placeholder,
+                              sizeof(empty_index_placeholder));
+        }
         file_writer.Finish();
     }
 
     // mmap the file
     auto file = File::Open(mmap_filepath_, O_RDONLY);
-    mmap_data_ = static_cast<char*>(mmap(NULL,
-                                         aligned_size + MMAP_INDEX_PADDING,
-                                         PROT_READ,
-                                         MAP_PRIVATE,
-                                         file.Descriptor(),
-                                         0));
+    mmap_data_ = static_cast<char*>(
+        mmap(NULL, mmap_size, PROT_READ, MAP_PRIVATE, file.Descriptor(), 0));
 
     if (mmap_data_ == MAP_FAILED) {
         file.Close();
-        remove(mmap_filepath_.c_str());
         ThrowInfo(
             ErrorCode::UnexpectedError, "failed to mmap: {}", strerror(errno));
     }
 
-    mmap_size_ = aligned_size + MMAP_INDEX_PADDING;
+    mmap_size_ = mmap_size;
     data_size_ = size;
     file.Close();
+    this->mmap_file_raii_ = std::move(mmap_file_raii);
 }
 
 template <typename T>
@@ -313,6 +320,8 @@ ScalarIndexSort<T>::LoadWithoutAssemble(const BinarySet& index_binary,
         idx_to_offsets_[item.idx_] = i;
         valid_bitset_.set(item.idx_);
     }
+    idx_to_offsets_ptr_ = idx_to_offsets_.data();
+    idx_to_offsets_size_ = idx_to_offsets_.size();
 
     is_built_ = true;
     ComputeByteSize();
@@ -530,13 +539,13 @@ ScalarIndexSort<T>::Range(const T& lower_bound_value,
 template <typename T>
 std::optional<T>
 ScalarIndexSort<T>::Reverse_Lookup(size_t idx) const {
-    AssertInfo(idx < idx_to_offsets_.size(), "out of range of total count");
+    AssertInfo(idx < idx_to_offsets_size_, "out of range of total count");
     AssertInfo(is_built_, "index has not been built");
 
     if (!valid_bitset_[idx]) {
         return std::nullopt;
     }
-    auto offset = idx_to_offsets_[idx];
+    auto offset = idx_to_offsets_ptr_[idx];
     return operator[](offset).a_;
 }
 
@@ -593,6 +602,12 @@ ScalarIndexSort<T>::WriteEntries(storage::IndexEntryWriter* writer) {
 
     writer->WriteEntry(
         "index_data", data_.data(), data_.size() * sizeof(IndexStructure<T>));
+    writer->WriteEntry("idx_to_offsets",
+                       idx_to_offsets_.data(),
+                       idx_to_offsets_.size() * sizeof(int32_t));
+    writer->WriteEntry("valid_bitset",
+                       reinterpret_cast<const uint8_t*>(valid_bitset_.data()),
+                       valid_bitset_.size_in_bytes());
 }
 
 template <typename T>
@@ -604,32 +619,212 @@ ScalarIndexSort<T>::LoadEntries(storage::IndexEntryReader& reader,
     auto is_nested = reader.GetMeta<bool>("is_nested");
     AssertInfo(!is_nested, "nested scalar sort index is not supported in 2.6");
 
-    auto data_entry = reader.ReadEntry("index_data");
-
     is_mmap_ = GetValueFromConfig<bool>(config, ENABLE_MMAP).value_or(true);
+    auto load_priority =
+        GetValueFromConfig<milvus::proto::common::LoadPriority>(
+            config, milvus::LOAD_PRIORITY)
+            .value_or(milvus::proto::common::LoadPriority::HIGH);
+
+    AssertInfo(index_size <= std::numeric_limits<size_t>::max() /
+                                 sizeof(IndexStructure<T>),
+               "scalar sort index data size overflow: {} entries",
+               index_size);
+    const auto expected_data_size = index_size * sizeof(IndexStructure<T>);
+    AssertInfo(reader.GetEntrySize("index_data") == expected_data_size,
+               "invalid scalar sort index data size: expected {}, got {}",
+               expected_data_size,
+               reader.GetEntrySize("index_data"));
 
     if (is_mmap_) {
-        auto load_priority =
-            GetValueFromConfig<milvus::proto::common::LoadPriority>(
-                config, milvus::LOAD_PRIORITY)
-                .value_or(milvus::proto::common::LoadPriority::HIGH);
-        SetupMmapFromData(
-            data_entry.data.data(), data_entry.data.size(), load_priority);
+        mmap_filepath_ = disk_file_manager_ != nullptr
+                             ? disk_file_manager_->GetLocalIndexObjectPrefix() +
+                                   STLSORT_INDEX_FILE_NAME
+                             : MMAP_PATH_FOR_TEST;
+        std::filesystem::create_directories(
+            std::filesystem::path(mmap_filepath_).parent_path());
+        auto mmap_file_raii = std::make_unique<MmapFileRAII>(mmap_filepath_);
+
+        size_t written = 0;
+        AssertInfo(expected_data_size <=
+                       std::numeric_limits<size_t>::max() - (ALIGNMENT - 1),
+                   "scalar sort mmap size overflow: {}",
+                   expected_data_size);
+        auto aligned_size =
+            ((expected_data_size + ALIGNMENT - 1) / ALIGNMENT) * ALIGNMENT;
+        auto mmap_size = std::max(aligned_size, MIN_MMAP_FILE_SIZE);
+        {
+            auto file_writer = storage::FileWriter(
+                mmap_filepath_,
+                storage::io::GetPriorityFromLoadPriority(load_priority));
+            reader.ReadEntryStream(
+                "index_data", [&](const uint8_t* data, size_t len) {
+                    AssertInfo(
+                        len <= expected_data_size - written,
+                        "scalar sort index stream exceeds expected size");
+                    file_writer.Write(data, len);
+                    written += len;
+                });
+            AssertInfo(written == expected_data_size,
+                       "scalar sort index stream size mismatch: got {}, "
+                       "expected {}",
+                       written,
+                       expected_data_size);
+            if (aligned_size > expected_data_size) {
+                std::vector<uint8_t> padding(aligned_size - expected_data_size,
+                                             0);
+                file_writer.Write(padding.data(), padding.size());
+            }
+            // Keep the mmap length non-zero when the index contains no valid
+            // values.
+            if (aligned_size == 0) {
+                const uint8_t empty_index_placeholder = 0;
+                file_writer.Write(&empty_index_placeholder,
+                                  sizeof(empty_index_placeholder));
+            }
+            file_writer.Finish();
+        }
+
+        data_size_ = expected_data_size;
+        mmap_size_ = mmap_size;
+        auto file = File::Open(mmap_filepath_, O_RDONLY);
+        mmap_data_ = static_cast<char*>(mmap(
+            nullptr, mmap_size_, PROT_READ, MAP_PRIVATE, file.Descriptor(), 0));
+        if (mmap_data_ == MAP_FAILED) {
+            file.Close();
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      "failed to mmap scalar sort index: {}",
+                      strerror(errno));
+        }
+        file.Close();
+        this->mmap_file_raii_ = std::move(mmap_file_raii);
     } else {
         data_.resize(index_size);
-        std::memcpy(
-            data_.data(), data_entry.data.data(), data_entry.data.size());
+        size_t written = 0;
+        reader.ReadEntryStream(
+            "index_data", [&](const uint8_t* data, size_t len) {
+                AssertInfo(len <= expected_data_size - written,
+                           "scalar sort index stream exceeds expected size");
+                std::memcpy(reinterpret_cast<uint8_t*>(data_.data()) + written,
+                            data,
+                            len);
+                written += len;
+            });
+        AssertInfo(written == expected_data_size,
+                   "scalar sort index stream size mismatch: got {}, expected "
+                   "{}",
+                   written,
+                   expected_data_size);
     }
 
     setup_data_pointers();
 
-    idx_to_offsets_.resize(total_num_rows_);
-    valid_bitset_ = TargetBitmap(total_num_rows_, false);
+    const auto has_offsets = reader.HasEntry("idx_to_offsets");
+    const auto has_validity = reader.HasEntry("valid_bitset");
 
-    for (size_t i = 0; i < Size(); ++i) {
-        const auto& item = operator[](i);
-        idx_to_offsets_[item.idx_] = i;
-        valid_bitset_.set(item.idx_);
+    if (has_offsets && has_validity) {
+        AssertInfo(total_num_rows_ <=
+                       std::numeric_limits<size_t>::max() / sizeof(int32_t),
+                   "scalar sort offset size overflow for {} rows",
+                   total_num_rows_);
+        const auto offsets_size = total_num_rows_ * sizeof(int32_t);
+        AssertInfo(reader.GetEntrySize("idx_to_offsets") == offsets_size,
+                   "invalid idx_to_offsets size: expected {}, got {}",
+                   offsets_size,
+                   reader.GetEntrySize("idx_to_offsets"));
+
+        valid_bitset_ = TargetBitmap(total_num_rows_, false);
+        const auto validity_size = valid_bitset_.size_in_bytes();
+        AssertInfo(reader.GetEntrySize("valid_bitset") >= validity_size,
+                   "invalid valid_bitset size: expected at least {}, got {}",
+                   validity_size,
+                   reader.GetEntrySize("valid_bitset"));
+        auto validity_entry = reader.ReadEntry("valid_bitset");
+        std::memcpy(reinterpret_cast<uint8_t*>(valid_bitset_.data()),
+                    validity_entry.data.data(),
+                    validity_size);
+
+        if (is_mmap_) {
+            mmap_meta_filepath_ = mmap_filepath_ + "-meta";
+            auto mmap_meta_file_raii =
+                std::make_unique<MmapFileRAII>(mmap_meta_filepath_);
+            {
+                auto file_writer = storage::FileWriter(
+                    mmap_meta_filepath_,
+                    storage::io::GetPriorityFromLoadPriority(load_priority));
+                size_t written = 0;
+                reader.ReadEntryStream(
+                    "idx_to_offsets", [&](const uint8_t* data, size_t len) {
+                        AssertInfo(len <= offsets_size - written,
+                                   "idx_to_offsets stream exceeds expected "
+                                   "size");
+                        file_writer.Write(data, len);
+                        written += len;
+                    });
+                AssertInfo(written == offsets_size,
+                           "idx_to_offsets stream size mismatch: got {}, "
+                           "expected {}",
+                           written,
+                           offsets_size);
+                file_writer.Finish();
+            }
+
+            mmap_meta_size_ = offsets_size;
+            auto file = File::Open(mmap_meta_filepath_, O_RDONLY);
+            mmap_meta_data_ = static_cast<char*>(mmap(nullptr,
+                                                      mmap_meta_size_,
+                                                      PROT_READ,
+                                                      MAP_PRIVATE,
+                                                      file.Descriptor(),
+                                                      0));
+            if (mmap_meta_data_ == MAP_FAILED) {
+                file.Close();
+                ThrowInfo(ErrorCode::UnexpectedError,
+                          "failed to mmap scalar sort offsets: {}",
+                          strerror(errno));
+            }
+            file.Close();
+            mmap_meta_file_raii_ = std::move(mmap_meta_file_raii);
+            idx_to_offsets_ptr_ =
+                reinterpret_cast<const int32_t*>(mmap_meta_data_);
+            idx_to_offsets_size_ = total_num_rows_;
+        } else {
+            idx_to_offsets_.resize(total_num_rows_);
+            size_t written = 0;
+            reader.ReadEntryStream(
+                "idx_to_offsets", [&](const uint8_t* data, size_t len) {
+                    AssertInfo(len <= offsets_size - written,
+                               "idx_to_offsets stream exceeds expected size");
+                    std::memcpy(
+                        reinterpret_cast<uint8_t*>(idx_to_offsets_.data()) +
+                            written,
+                        data,
+                        len);
+                    written += len;
+                });
+            AssertInfo(written == offsets_size,
+                       "idx_to_offsets stream size mismatch: got {}, expected "
+                       "{}",
+                       written,
+                       offsets_size);
+            idx_to_offsets_ptr_ = idx_to_offsets_.data();
+            idx_to_offsets_size_ = idx_to_offsets_.size();
+        }
+    } else {
+        // Backward compatibility for V3 indexes written before side entries
+        // were persisted.
+        idx_to_offsets_.resize(total_num_rows_);
+        valid_bitset_ = TargetBitmap(total_num_rows_, false);
+        for (size_t i = 0; i < Size(); ++i) {
+            const auto& item = operator[](i);
+            AssertInfo(item.idx_ >= 0 &&
+                           static_cast<size_t>(item.idx_) < total_num_rows_,
+                       "invalid scalar sort row id: {}",
+                       item.idx_);
+            idx_to_offsets_[item.idx_] = i;
+            valid_bitset_.set(item.idx_);
+        }
+        idx_to_offsets_ptr_ = idx_to_offsets_.data();
+        idx_to_offsets_size_ = idx_to_offsets_.size();
     }
 
     is_built_ = true;

--- a/internal/core/src/index/ScalarIndexSort.h
+++ b/internal/core/src/index/ScalarIndexSort.h
@@ -19,7 +19,6 @@
 #include <assert.h>
 #include <stdint.h>
 #include <sys/mman.h>
-#include <unistd.h>
 #include <chrono>
 #include <cstddef>
 #include <iterator>
@@ -62,7 +61,9 @@ class ScalarIndexSort : public ScalarIndex<T> {
     ~ScalarIndexSort() {
         if (is_mmap_ && mmap_data_ != nullptr && mmap_data_ != MAP_FAILED) {
             munmap(mmap_data_, mmap_size_);
-            unlink(mmap_filepath_.c_str());
+        }
+        if (mmap_meta_data_ != nullptr && mmap_meta_data_ != MAP_FAILED) {
+            munmap(mmap_meta_data_, mmap_meta_size_);
         }
     }
 
@@ -135,8 +136,12 @@ class ScalarIndexSort : public ScalarIndex<T> {
         ScalarIndex<T>::ComputeByteSize();
         int64_t total = this->cached_byte_size_;
 
-        // idx_to_offsets_: vector<int32_t>
-        total += idx_to_offsets_.capacity() * sizeof(int32_t);
+        // idx_to_offsets_: vector (memory load) or mmap region (mmap load)
+        if (mmap_meta_data_ != nullptr) {
+            total += mmap_meta_size_;
+        } else {
+            total += idx_to_offsets_.capacity() * sizeof(int32_t);
+        }
 
         // valid_bitset_: TargetBitmap
         total += valid_bitset_.size_in_bytes();
@@ -242,7 +247,11 @@ class ScalarIndexSort : public ScalarIndex<T> {
 
     bool is_built_ = false;
     Config config_;
-    std::vector<int32_t> idx_to_offsets_;  // used to retrieve.
+    // Maps row id to the sorted index offset. Build and memory-load paths own
+    // the vector; mmap-load points the read accessor into mmap_meta_data_.
+    std::vector<int32_t> idx_to_offsets_;
+    const int32_t* idx_to_offsets_ptr_ = nullptr;
+    size_t idx_to_offsets_size_ = 0;
     std::shared_ptr<storage::DiskFileManagerImpl> disk_file_manager_;
     size_t total_num_rows_{0};
     // generate valid_bitset_ to speed up NotIn and IsNull and IsNotNull operate
@@ -259,6 +268,12 @@ class ScalarIndexSort : public ScalarIndex<T> {
     // Note: it should not be used directly for accessing data. Use data_ptr_ instead.
     char* mmap_data_ = nullptr;
     std::string mmap_filepath_;
+
+    // mmap backing for the persisted idx_to_offsets V3 side entry.
+    char* mmap_meta_data_ = nullptr;
+    int64_t mmap_meta_size_ = 0;
+    std::string mmap_meta_filepath_;
+    std::unique_ptr<MmapFileRAII> mmap_meta_file_raii_;
 
     mutable const IndexStructure<T>* data_ptr_ = nullptr;
     mutable const IndexStructure<T>* end_ptr_ = nullptr;

--- a/internal/core/src/index/ScalarIndexSortTest.cpp
+++ b/internal/core/src/index/ScalarIndexSortTest.cpp
@@ -1,11 +1,15 @@
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
+#include <filesystem>
 #include <functional>
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_set>
 #include <vector>
 #include "bitset/bitset.h"
 #include "common/Tracer.h"
@@ -18,6 +22,9 @@
 #include "pb/common.pb.h"
 #include "storage/ChunkManager.h"
 #include "storage/FileManager.h"
+#include "storage/IndexEntryDirectStreamWriter.h"
+#include "storage/IndexEntryReader.h"
+#include "storage/IndexEntryWriter.h"
 #include "storage/ThreadPools.h"
 #include "storage/Types.h"
 #include "storage/Util.h"
@@ -26,6 +33,145 @@
 #include "test_utils/storage_test_utils.h"
 using namespace milvus;
 using namespace milvus::index;
+
+namespace {
+
+class RecordingIndexEntryWriter : public storage::IndexEntryWriter {
+ public:
+    void
+    WriteEntry(const std::string& name, const void*, size_t size) override {
+        names_.insert(name);
+        total_bytes_ += size;
+    }
+
+    void
+    WriteEntry(const std::string& name, int, size_t size) override {
+        names_.insert(name);
+        total_bytes_ += size;
+    }
+
+    void
+    Finish() override {
+    }
+
+    size_t
+    GetTotalBytesWritten() const override {
+        return total_bytes_;
+    }
+
+    bool
+    HasEntry(const std::string& name) const {
+        return names_.count(name) != 0;
+    }
+
+ private:
+    std::unordered_set<std::string> names_;
+    size_t total_bytes_{0};
+};
+
+class MemoryOutputStream : public OutputStream {
+ public:
+    explicit MemoryOutputStream(std::shared_ptr<std::vector<uint8_t>> data)
+        : data_(std::move(data)) {
+    }
+
+    size_t
+    Tell() const override {
+        return data_->size();
+    }
+
+    size_t
+    Write(const void* data, size_t size) override {
+        const auto* bytes = static_cast<const uint8_t*>(data);
+        data_->insert(data_->end(), bytes, bytes + size);
+        return size;
+    }
+
+    size_t
+    Write(int, size_t) override {
+        return 0;
+    }
+
+    void
+    Close() override {
+    }
+
+ private:
+    std::shared_ptr<std::vector<uint8_t>> data_;
+};
+
+class FailingMemoryInputStream : public InputStream {
+ public:
+    FailingMemoryInputStream(std::shared_ptr<const std::vector<uint8_t>> data,
+                             size_t failing_offset)
+        : data_(std::move(data)), failing_offset_(failing_offset) {
+    }
+
+    size_t
+    Size() const override {
+        return data_->size();
+    }
+
+    bool
+    Seek(int64_t offset) override {
+        if (offset < 0 || static_cast<size_t>(offset) > data_->size()) {
+            return false;
+        }
+        position_ = static_cast<size_t>(offset);
+        return true;
+    }
+
+    size_t
+    Tell() const override {
+        return position_;
+    }
+
+    bool
+    Eof() const override {
+        return position_ == data_->size();
+    }
+
+    size_t
+    Read(void* data, size_t size) override {
+        auto bytes_read = ReadAt(data, position_, size);
+        position_ += bytes_read;
+        return bytes_read;
+    }
+
+    size_t
+    ReadAt(void* data, size_t offset, size_t size) override {
+        if (offset == failing_offset_ || offset >= data_->size()) {
+            return 0;
+        }
+        auto bytes_read = std::min(size, data_->size() - offset);
+        std::memcpy(data, data_->data() + offset, bytes_read);
+        return bytes_read;
+    }
+
+    size_t
+    Read(int, size_t) override {
+        return 0;
+    }
+
+ private:
+    std::shared_ptr<const std::vector<uint8_t>> data_;
+    size_t failing_offset_;
+    size_t position_{0};
+};
+
+std::shared_ptr<std::vector<uint8_t>>
+BuildPackedScalarSortIndex(const std::vector<int64_t>& values) {
+    auto packed_data = std::make_shared<std::vector<uint8_t>>();
+    ScalarIndexSort<int64_t> source;
+    source.Build(values.size(), values.data());
+    auto output = std::make_shared<MemoryOutputStream>(packed_data);
+    storage::IndexEntryDirectStreamWriter writer(output);
+    source.WriteEntries(&writer);
+    writer.Finish();
+    return packed_data;
+}
+
+}  // namespace
 
 static storage::FileManagerContext
 CreateScalarSortTestFileManagerContext() {
@@ -152,4 +298,106 @@ TEST(StlSortIndexTest, TestIn) {
 
     test_stlsort_for_range(
         data, DataType::INT64, true, exec_expr, expected_result);
+}
+
+TEST(StlSortIndexTest, V3PersistsDirectLoadMetadata) {
+    const std::vector<int64_t> data = {10, 2, 6, 5, 9, 3, 7, 8, 4, 1};
+    auto index = std::make_shared<index::ScalarIndexSort<int64_t>>();
+    index->Build(data.size(), data.data());
+    RecordingIndexEntryWriter writer;
+
+    index->WriteEntries(&writer);
+
+    EXPECT_TRUE(writer.HasEntry("index_data"));
+    EXPECT_TRUE(writer.HasEntry("idx_to_offsets"));
+    EXPECT_TRUE(writer.HasEntry("valid_bitset"));
+}
+
+TEST(StlSortIndexTest, MmapFileOnlyPadsEmptyIndex) {
+    constexpr size_t kAlignment = 32;
+    constexpr const char* kMmapPath = "/tmp/milvus/mmap_test";
+    Config config;
+    config[milvus::index::ENABLE_MMAP] = true;
+    config[milvus::LOAD_PRIORITY] = milvus::proto::common::LoadPriority::HIGH;
+
+    const std::vector<int64_t> values = {10, 2, 6, 5};
+    BinarySet non_empty_binary;
+    {
+        auto index = std::make_shared<index::ScalarIndexSort<int64_t>>();
+        index->Build(values.size(), values.data());
+        non_empty_binary = index->Serialize({});
+    }
+    {
+        auto index = std::make_shared<index::ScalarIndexSort<int64_t>>();
+        index->Load(non_empty_binary, config);
+        const auto data_size = non_empty_binary.GetByName("index_data")->size;
+        const auto aligned_size =
+            ((data_size + kAlignment - 1) / kAlignment) * kAlignment;
+        EXPECT_EQ(std::filesystem::file_size(kMmapPath), aligned_size);
+    }
+
+    const bool all_null[] = {false, false, false, false};
+    BinarySet empty_binary;
+    {
+        auto index = std::make_shared<index::ScalarIndexSort<int64_t>>();
+        index->Build(values.size(), values.data(), all_null);
+        empty_binary = index->Serialize({});
+    }
+    {
+        auto index = std::make_shared<index::ScalarIndexSort<int64_t>>();
+        index->Load(empty_binary, config);
+        EXPECT_EQ(std::filesystem::file_size(kMmapPath), 1);
+    }
+}
+
+TEST(StlSortIndexTest, MmapLoadRemovesBackingFileOnStreamFailure) {
+    constexpr const char* kMmapPath = "/tmp/milvus/mmap_test";
+    std::filesystem::remove(kMmapPath);
+
+    const std::vector<int64_t> values = {10, 2, 6, 5};
+    auto packed_data = BuildPackedScalarSortIndex(values);
+
+    auto input = std::make_shared<FailingMemoryInputStream>(
+        packed_data, storage::MILVUS_V3_MAGIC_SIZE);
+    auto reader = storage::IndexEntryReader::Open(input, packed_data->size());
+
+    Config config;
+    config[milvus::index::ENABLE_MMAP] = true;
+    config[milvus::LOAD_PRIORITY] = milvus::proto::common::LoadPriority::HIGH;
+    {
+        ScalarIndexSort<int64_t> index;
+        EXPECT_THROW(index.LoadEntries(*reader, config), SegcoreError);
+    }
+
+    EXPECT_FALSE(std::filesystem::exists(kMmapPath));
+    std::filesystem::remove(kMmapPath);
+}
+
+TEST(StlSortIndexTest, MmapLoadRemovesMetaFileOnStreamFailure) {
+    constexpr const char* kMmapPath = "/tmp/milvus/mmap_test";
+    const auto mmap_meta_path = std::string(kMmapPath) + "-meta";
+    std::filesystem::remove(kMmapPath);
+    std::filesystem::remove(mmap_meta_path);
+
+    const std::vector<int64_t> values = {10, 2, 6, 5};
+    auto packed_data = BuildPackedScalarSortIndex(values);
+    const auto offsets_entry_offset =
+        storage::MILVUS_V3_MAGIC_SIZE +
+        values.size() * sizeof(IndexStructure<int64_t>);
+    auto input = std::make_shared<FailingMemoryInputStream>(
+        packed_data, offsets_entry_offset);
+    auto reader = storage::IndexEntryReader::Open(input, packed_data->size());
+
+    Config config;
+    config[milvus::index::ENABLE_MMAP] = true;
+    config[milvus::LOAD_PRIORITY] = milvus::proto::common::LoadPriority::HIGH;
+    {
+        ScalarIndexSort<int64_t> index;
+        EXPECT_THROW(index.LoadEntries(*reader, config), SegcoreError);
+    }
+
+    EXPECT_FALSE(std::filesystem::exists(kMmapPath));
+    EXPECT_FALSE(std::filesystem::exists(mmap_meta_path));
+    std::filesystem::remove(kMmapPath);
+    std::filesystem::remove(mmap_meta_path);
 }

--- a/internal/core/src/index/SkipIndex.h
+++ b/internal/core/src/index/SkipIndex.h
@@ -95,8 +95,8 @@ class FieldChunkMetricsTranslator
     }
     std::pair<milvus::cachinglayer::ResourceUsage,
               milvus::cachinglayer::ResourceUsage>
-    estimated_byte_size_of_cell(
-        milvus::cachinglayer::cid_t cid) const override {
+    estimated_loading_usage(
+        const std::vector<milvus::cachinglayer::cid_t>&) const override {
         // TODO(tiered storage 1): provide a better estimation.
         return {{0, 0}, {0, 0}};
     }

--- a/internal/core/src/index/StringIndexMarisa.cpp
+++ b/internal/core/src/index/StringIndexMarisa.cpp
@@ -25,6 +25,7 @@
 #include <exception>
 #include <filesystem>
 #include <iosfwd>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <system_error>
@@ -63,6 +64,25 @@
 
 namespace milvus::index {
 
+namespace {
+
+constexpr uint32_t MARISA_CSR_FORMAT_VERSION = 1;
+constexpr const char* MARISA_CSR_FORMAT_VERSION_META =
+    "marisa_csr_format_version";
+
+void
+ValidateMarisaEntryElementSize(const char* entry_name,
+                               size_t bytes,
+                               size_t element_size) {
+    AssertInfo(bytes % element_size == 0,
+               "invalid {} size: expected multiple of {}, got {}",
+               entry_name,
+               element_size,
+               bytes);
+}
+
+}  // namespace
+
 StringIndexMarisa::StringIndexMarisa(
     const storage::FileManagerContext& file_manager_context)
     : StringIndex(MARISA_TRIE) {
@@ -85,17 +105,18 @@ StringIndexMarisa::ComputeByteSize() {
     // Size of the trie structure (marisa trie uses io_size() for serialized/memory size)
     total += trie_.io_size();
 
-    // str_ids_: vector<int64_t>
-    total += str_ids_.capacity() * sizeof(int64_t);
-
-    // str_ids_to_offsets_: map<size_t, vector<size_t>>
-    for (const auto& [key, vec] : str_ids_to_offsets_) {
-        total += sizeof(size_t);                   // key
-        total += vec.capacity() * sizeof(size_t);  // vector capacity
-        total += sizeof(std::vector<size_t>);      // vector object overhead
+    if (str_ids_mmap_data_ != nullptr && str_ids_mmap_data_ != MAP_FAILED) {
+        total += str_ids_mmap_size_;
+    } else {
+        total += str_ids_.capacity() * sizeof(int64_t);
     }
-    // Map node overhead (rough estimate: ~40 bytes per node for std::map)
-    total += str_ids_to_offsets_.size() * 40;
+
+    if (csr_mmap_data_ != nullptr && csr_mmap_data_ != MAP_FAILED) {
+        total += csr_mmap_size_;
+    } else {
+        total += csr_index_.capacity() * sizeof(uint32_t);
+        total += csr_offsets_.capacity() * sizeof(uint32_t);
+    }
 
     cached_byte_size_ = total;
 }
@@ -109,13 +130,17 @@ StringIndexMarisa::CalculateTotalSize() const {
     // which approximates the memory usage
     size += trie_.io_size();
 
-    // Size of str_ids_ vector (main data structure)
-    size += str_ids_.size() * sizeof(int64_t);
+    if (str_ids_mmap_data_ != nullptr && str_ids_mmap_data_ != MAP_FAILED) {
+        size += str_ids_mmap_size_;
+    } else {
+        size += str_ids_.size() * sizeof(int64_t);
+    }
 
-    // Size of str_ids_to_offsets_ map data
-    for (const auto& [key, vec] : str_ids_to_offsets_) {
-        size += sizeof(size_t);               // key
-        size += vec.size() * sizeof(size_t);  // vector data
+    if (csr_mmap_data_ != nullptr && csr_mmap_data_ != MAP_FAILED) {
+        size += csr_mmap_size_;
+    } else {
+        size += csr_index_.size() * sizeof(uint32_t);
+        size += csr_offsets_.size() * sizeof(uint32_t);
     }
 
     return size;
@@ -123,7 +148,7 @@ StringIndexMarisa::CalculateTotalSize() const {
 
 bool
 valid_str_id(size_t str_id) {
-    return str_id >= 0 && str_id != MARISA_INVALID_KEY_ID;
+    return str_id != MARISA_NULL_KEY_ID && str_id != MARISA_INVALID_KEY_ID;
 }
 
 void
@@ -175,7 +200,8 @@ StringIndexMarisa::BuildWithFieldData(
         }
     }
 
-    // fill str_ids_to_offsets_
+    str_ids_ptr_ = str_ids_.data();
+    str_ids_size_ = str_ids_.size();
     fill_offsets();
 
     built_ = true;
@@ -203,6 +229,8 @@ StringIndexMarisa::Build(size_t n,
 
     trie_.build(keyset, MARISA_LABEL_ORDER);
     fill_str_ids(n, values, valid_data);
+    str_ids_ptr_ = str_ids_.data();
+    str_ids_size_ = str_ids_.size();
     fill_offsets();
 
     built_ = true;
@@ -228,7 +256,7 @@ StringIndexMarisa::Serialize(const Config& config) {
     close(fd);
     remove(file.c_str());
 
-    auto str_ids_len = str_ids_.size() * sizeof(size_t);
+    auto str_ids_len = str_ids_.size() * sizeof(int64_t);
     std::shared_ptr<uint8_t[]> str_ids(new uint8_t[str_ids_len]);
     memcpy(str_ids.get(), str_ids_.data(), str_ids_len);
 
@@ -274,8 +302,9 @@ StringIndexMarisa::LoadWithoutAssemble(const BinarySet& set,
     }
 
     if (config.contains(MMAP_FILE_PATH)) {
+        auto trie_file_raii = std::make_unique<MmapFileRAII>(file_name);
         trie_.mmap(file_name.c_str());
-        mmap_file_raii_ = std::make_unique<MmapFileRAII>(file_name);
+        mmap_file_raii_ = std::move(trie_file_raii);
     } else {
         auto file = File::Open(file_name, O_RDONLY);
         trie_.read(file.Descriptor());
@@ -288,8 +317,12 @@ StringIndexMarisa::LoadWithoutAssemble(const BinarySet& set,
 
     auto str_ids = set.GetByName(MARISA_STR_IDS);
     auto str_ids_len = str_ids->size;
-    str_ids_.resize(str_ids_len / sizeof(size_t), MARISA_NULL_KEY_ID);
+    ValidateMarisaEntryElementSize(
+        MARISA_STR_IDS, str_ids_len, sizeof(int64_t));
+    str_ids_.resize(str_ids_len / sizeof(int64_t), MARISA_NULL_KEY_ID);
     memcpy(str_ids_.data(), str_ids->data.get(), str_ids_len);
+    str_ids_ptr_ = str_ids_.data();
+    str_ids_size_ = str_ids_.size();
 
     fill_offsets();
     built_ = true;
@@ -326,13 +359,15 @@ StringIndexMarisa::Load(milvus::tracer::TraceContext ctx,
 const TargetBitmap
 StringIndexMarisa::In(size_t n, const std::string* values) {
     tracer::AutoSpan span("StringIndexMarisa::In", tracer::GetRootSpan());
-    TargetBitmap bitset(str_ids_.size());
+    TargetBitmap bitset(str_ids_size_);
     for (size_t i = 0; i < n; i++) {
         const auto& str = values[i];
         auto str_id = lookup(str);
         if (valid_str_id(str_id)) {
-            auto& offsets = str_ids_to_offsets_[str_id];
-            for (auto offset : offsets) {
+            for (size_t j = csr_index_ptr_[str_id];
+                 j < csr_index_ptr_[str_id + 1];
+                 ++j) {
+                auto offset = csr_offsets_ptr_[j];
                 bitset[offset] = true;
             }
         }
@@ -343,13 +378,15 @@ StringIndexMarisa::In(size_t n, const std::string* values) {
 const TargetBitmap
 StringIndexMarisa::NotIn(size_t n, const std::string* values) {
     tracer::AutoSpan span("StringIndexMarisa::NotIn", tracer::GetRootSpan());
-    TargetBitmap bitset(str_ids_.size(), true);
+    TargetBitmap bitset(str_ids_size_, true);
     for (size_t i = 0; i < n; i++) {
         const auto& str = values[i];
         auto str_id = lookup(str);
         if (valid_str_id(str_id)) {
-            auto& offsets = str_ids_to_offsets_[str_id];
-            for (auto offset : offsets) {
+            for (size_t j = csr_index_ptr_[str_id];
+                 j < csr_index_ptr_[str_id + 1];
+                 ++j) {
+                auto offset = csr_offsets_ptr_[j];
                 bitset[offset] = false;
             }
         }
@@ -362,7 +399,7 @@ StringIndexMarisa::NotIn(size_t n, const std::string* values) {
 const TargetBitmap
 StringIndexMarisa::IsNull() {
     tracer::AutoSpan span("StringIndexMarisa::IsNull", tracer::GetRootSpan());
-    TargetBitmap bitset(str_ids_.size());
+    TargetBitmap bitset(str_ids_size_);
     SetNull(bitset);
     return bitset;
 }
@@ -371,7 +408,7 @@ void
 StringIndexMarisa::SetNull(TargetBitmap& bitset) {
     tracer::AutoSpan span("StringIndexMarisa::SetNull", tracer::GetRootSpan());
     for (size_t i = 0; i < bitset.size(); i++) {
-        if (str_ids_[i] == MARISA_NULL_KEY_ID) {
+        if (str_ids_ptr_[i] == MARISA_NULL_KEY_ID) {
             bitset.set(i);
         }
     }
@@ -382,7 +419,7 @@ StringIndexMarisa::ResetNull(TargetBitmap& bitset) {
     tracer::AutoSpan span("StringIndexMarisa::ResetNull",
                           tracer::GetRootSpan());
     for (size_t i = 0; i < bitset.size(); i++) {
-        if (str_ids_[i] == MARISA_NULL_KEY_ID) {
+        if (str_ids_ptr_[i] == MARISA_NULL_KEY_ID) {
             bitset.reset(i);
         }
     }
@@ -392,9 +429,9 @@ TargetBitmap
 StringIndexMarisa::IsNotNull() {
     tracer::AutoSpan span("StringIndexMarisa::IsNotNull",
                           tracer::GetRootSpan());
-    TargetBitmap bitset(str_ids_.size());
+    TargetBitmap bitset(str_ids_size_);
     for (size_t i = 0; i < bitset.size(); i++) {
-        if (str_ids_[i] != MARISA_NULL_KEY_ID) {
+        if (str_ids_ptr_[i] != MARISA_NULL_KEY_ID) {
             bitset.set(i);
         }
     }
@@ -513,8 +550,9 @@ StringIndexMarisa::Range(const std::string& value, OpType op) {
     }
 
     for (const auto str_id : ids) {
-        auto& offsets = str_ids_to_offsets_[str_id];
-        for (auto offset : offsets) {
+        for (size_t j = csr_index_ptr_[str_id]; j < csr_index_ptr_[str_id + 1];
+             ++j) {
+            auto offset = csr_offsets_ptr_[j];
             bitset[offset] = true;
         }
     }
@@ -567,8 +605,9 @@ StringIndexMarisa::Range(const std::string& lower_bound_value,
         }
     }
     for (const auto str_id : ids) {
-        auto& offsets = str_ids_to_offsets_[str_id];
-        for (auto offset : offsets) {
+        for (size_t j = csr_index_ptr_[str_id]; j < csr_index_ptr_[str_id + 1];
+             ++j) {
+            auto offset = csr_offsets_ptr_[j];
             bitset[offset] = true;
         }
     }
@@ -580,11 +619,12 @@ const TargetBitmap
 StringIndexMarisa::PrefixMatch(std::string_view prefix) {
     tracer::AutoSpan span("StringIndexMarisa::PrefixMatch",
                           tracer::GetRootSpan());
-    TargetBitmap bitset(str_ids_.size());
+    TargetBitmap bitset(str_ids_size_);
     auto matched = prefix_match(prefix);
     for (const auto str_id : matched) {
-        auto& offsets = str_ids_to_offsets_[str_id];
-        for (auto offset : offsets) {
+        for (size_t j = csr_index_ptr_[str_id]; j < csr_index_ptr_[str_id + 1];
+             ++j) {
+            auto offset = csr_offsets_ptr_[j];
             bitset[offset] = true;
         }
     }
@@ -607,7 +647,7 @@ StringIndexMarisa::PatternMatch(const std::string& pattern,
                   static_cast<int>(op));
     }
 
-    TargetBitmap bitset(str_ids_.size());
+    TargetBitmap bitset(str_ids_size_);
 
     auto match_value = [&pattern, op](const std::string& value) {
         switch (op) {
@@ -625,20 +665,30 @@ StringIndexMarisa::PatternMatch(const std::string& pattern,
 
     if (op == proto::plan::OpType::Match) {
         RegexMatcher matcher(translate_pattern_match_to_regex(pattern));
-        for (const auto& [str_id, offsets] : str_ids_to_offsets_) {
-            auto val = Reverse_Lookup(offsets[0]);
+        for (size_t str_id = 0; str_id < csr_num_keys_; ++str_id) {
+            auto begin = csr_index_ptr_[str_id];
+            auto end = csr_index_ptr_[str_id + 1];
+            if (begin == end) {
+                continue;
+            }
+            auto val = Reverse_Lookup(csr_offsets_ptr_[begin]);
             if (val.has_value() && matcher(val.value())) {
-                for (auto offset : offsets) {
-                    bitset[offset] = true;
+                for (size_t j = begin; j < end; ++j) {
+                    bitset[csr_offsets_ptr_[j]] = true;
                 }
             }
         }
     } else {
-        for (const auto& [str_id, offsets] : str_ids_to_offsets_) {
-            auto val = Reverse_Lookup(offsets[0]);
+        for (size_t str_id = 0; str_id < csr_num_keys_; ++str_id) {
+            auto begin = csr_index_ptr_[str_id];
+            auto end = csr_index_ptr_[str_id + 1];
+            if (begin == end) {
+                continue;
+            }
+            auto val = Reverse_Lookup(csr_offsets_ptr_[begin]);
             if (val.has_value() && match_value(val.value())) {
-                for (auto offset : offsets) {
-                    bitset[offset] = true;
+                for (size_t j = begin; j < end; ++j) {
+                    bitset[csr_offsets_ptr_[j]] = true;
                 }
             }
         }
@@ -664,13 +714,41 @@ StringIndexMarisa::fill_str_ids(size_t n,
 
 void
 StringIndexMarisa::fill_offsets() {
-    for (size_t offset = 0; offset < str_ids_.size(); offset++) {
-        auto str_id = str_ids_[offset];
-        if (str_ids_to_offsets_.find(str_id) == str_ids_to_offsets_.end()) {
-            str_ids_to_offsets_[str_id] = std::vector<size_t>{};
+    csr_num_keys_ = trie_.num_keys();
+    AssertInfo(str_ids_size_ <= std::numeric_limits<uint32_t>::max(),
+               "segment row count {} exceeds uint32_t capacity for CSR",
+               str_ids_size_);
+    AssertInfo(csr_num_keys_ < std::numeric_limits<uint32_t>::max(),
+               "trie key count {} exceeds uint32_t capacity for CSR",
+               csr_num_keys_);
+
+    csr_index_.assign(csr_num_keys_ + 1, 0);
+    for (size_t offset = 0; offset < str_ids_size_; ++offset) {
+        auto str_id = str_ids_ptr_[offset];
+        if (valid_str_id(str_id)) {
+            AssertInfo(str_id < csr_num_keys_,
+                       "marisa key id {} exceeds trie key count {}",
+                       str_id,
+                       csr_num_keys_);
+            ++csr_index_[str_id + 1];
         }
-        str_ids_to_offsets_[str_id].push_back(offset);
     }
+    for (size_t i = 1; i <= csr_num_keys_; ++i) {
+        csr_index_[i] += csr_index_[i - 1];
+    }
+
+    csr_offsets_.resize(csr_index_[csr_num_keys_]);
+    std::vector<uint32_t> write_pos(csr_index_.begin(),
+                                    csr_index_.begin() + csr_num_keys_);
+    for (size_t offset = 0; offset < str_ids_size_; ++offset) {
+        auto str_id = str_ids_ptr_[offset];
+        if (valid_str_id(str_id)) {
+            csr_offsets_[write_pos[str_id]++] = static_cast<uint32_t>(offset);
+        }
+    }
+
+    csr_index_ptr_ = csr_index_.data();
+    csr_offsets_ptr_ = csr_offsets_.data();
 }
 
 size_t
@@ -701,12 +779,12 @@ std::optional<std::string>
 StringIndexMarisa::Reverse_Lookup(size_t offset) const {
     tracer::AutoSpan span("StringIndexMarisa::Reverse_Lookup",
                           tracer::GetRootSpan());
-    AssertInfo(offset < str_ids_.size(), "out of range of total count");
+    AssertInfo(offset < str_ids_size_, "out of range of total count");
     marisa::Agent agent;
-    if (str_ids_[offset] < 0) {
+    if (str_ids_ptr_[offset] < 0) {
         return std::nullopt;
     }
-    agent.set_query(str_ids_[offset]);
+    agent.set_query(str_ids_ptr_[offset]);
     trie_.reverse_lookup(agent);
     return std::string(agent.key().ptr(), agent.key().length());
 }
@@ -757,15 +835,22 @@ StringIndexMarisa::WriteEntries(storage::IndexEntryWriter* writer) {
     writer->WriteEntry(MARISA_TRIE_INDEX, fd, size);
 
     // Write str_ids
-    auto str_ids_len = str_ids_.size() * sizeof(size_t);
+    auto str_ids_len = str_ids_.size() * sizeof(int64_t);
     writer->WriteEntry(MARISA_STR_IDS, str_ids_.data(), str_ids_len);
+
+    writer->WriteEntry(MARISA_CSR_INDEX,
+                       csr_index_.data(),
+                       csr_index_.size() * sizeof(uint32_t));
+    writer->WriteEntry(MARISA_CSR_OFFSETS,
+                       csr_offsets_.data(),
+                       csr_offsets_.size() * sizeof(uint32_t));
+    writer->PutMeta(MARISA_CSR_FORMAT_VERSION_META, MARISA_CSR_FORMAT_VERSION);
+    writer->PutMeta("csr_num_keys", csr_num_keys_);
 }
 
 void
 StringIndexMarisa::LoadEntries(storage::IndexEntryReader& reader,
                                const Config& config) {
-    auto trie_entry = reader.ReadEntry(MARISA_TRIE_INDEX);
-
     auto local_cm =
         storage::LocalChunkManagerSingleton::GetInstance().GetChunkManager();
     std::string tmp_dir =
@@ -785,33 +870,243 @@ StringIndexMarisa::LoadEntries(storage::IndexEntryReader& reader,
             config, milvus::LOAD_PRIORITY)
             .value_or(milvus::proto::common::LoadPriority::HIGH);
 
+    // Marisa consumes a file descriptor/path, so stream the trie entry to its
+    // final temporary file instead of materializing the whole entry first.
     {
         auto file_writer = storage::FileWriter(
             file_name, storage::io::GetPriorityFromLoadPriority(load_priority));
-        file_writer.Write(trie_entry.data.data(), trie_entry.data.size());
+        reader.ReadEntryStream(MARISA_TRIE_INDEX,
+                               [&](const uint8_t* data, size_t len) {
+                                   file_writer.Write(data, len);
+                               });
         file_writer.Finish();
     }
 
-    if (config.contains(MMAP_FILE_PATH)) {
+    const auto mmap_enabled = config.contains(MMAP_FILE_PATH);
+    if (mmap_enabled) {
+        auto trie_file_raii = std::make_unique<MmapFileRAII>(file_name);
         trie_.mmap(file_name.c_str());
-        mmap_file_raii_ = std::make_unique<MmapFileRAII>(file_name);
+        mmap_file_raii_ = std::move(trie_file_raii);
     } else {
         auto file = File::Open(file_name, O_RDONLY);
         trie_.read(file.Descriptor());
         mmap_file_raii_ = nullptr;
     }
 
-    if (!config.contains(MMAP_FILE_PATH)) {
+    if (!mmap_enabled) {
         unlink(file_name.c_str());
     }
 
-    auto str_ids_entry = reader.ReadEntry(MARISA_STR_IDS);
+    const auto str_ids_bytes = reader.GetEntrySize(MARISA_STR_IDS);
+    ValidateMarisaEntryElementSize(
+        MARISA_STR_IDS, str_ids_bytes, sizeof(int64_t));
+    if (mmap_enabled) {
+        auto str_ids_path = file_name + ".str_ids";
+        {
+            auto file_writer = storage::FileWriter(
+                str_ids_path,
+                storage::io::GetPriorityFromLoadPriority(load_priority));
+            size_t written = 0;
+            reader.ReadEntryStream(
+                MARISA_STR_IDS, [&](const uint8_t* data, size_t len) {
+                    AssertInfo(len <= str_ids_bytes - written,
+                               "marisa str_ids stream exceeds expected size");
+                    file_writer.Write(data, len);
+                    written += len;
+                });
+            AssertInfo(written == str_ids_bytes,
+                       "marisa str_ids stream size mismatch: got {}, expected "
+                       "{}",
+                       written,
+                       str_ids_bytes);
+            file_writer.Finish();
+        }
 
-    auto str_ids_len = str_ids_entry.data.size();
-    str_ids_.resize(str_ids_len / sizeof(size_t), MARISA_NULL_KEY_ID);
-    memcpy(str_ids_.data(), str_ids_entry.data.data(), str_ids_len);
+        auto str_ids_file_raii = std::make_unique<MmapFileRAII>(str_ids_path);
+        auto file = File::Open(str_ids_path, O_RDONLY);
+        auto* mapped = mmap(nullptr,
+                            str_ids_bytes,
+                            PROT_READ,
+                            MAP_PRIVATE,
+                            file.Descriptor(),
+                            0);
+        if (mapped == MAP_FAILED) {
+            file.Close();
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      "failed to mmap marisa str_ids: {}",
+                      strerror(errno));
+        }
+        file.Close();
+        str_ids_mmap_data_ = static_cast<char*>(mapped);
+        str_ids_mmap_size_ = str_ids_bytes;
+        str_ids_mmap_raii_ = std::move(str_ids_file_raii);
+        str_ids_ptr_ = reinterpret_cast<const int64_t*>(str_ids_mmap_data_);
+        str_ids_size_ = str_ids_bytes / sizeof(int64_t);
+    } else {
+        str_ids_.resize(str_ids_bytes / sizeof(int64_t), MARISA_NULL_KEY_ID);
+        size_t written = 0;
+        reader.ReadEntryStream(
+            MARISA_STR_IDS, [&](const uint8_t* data, size_t len) {
+                AssertInfo(len <= str_ids_bytes - written,
+                           "marisa str_ids stream exceeds expected size");
+                std::memcpy(
+                    reinterpret_cast<uint8_t*>(str_ids_.data()) + written,
+                    data,
+                    len);
+                written += len;
+            });
+        AssertInfo(written == str_ids_bytes,
+                   "marisa str_ids stream size mismatch: got {}, expected {}",
+                   written,
+                   str_ids_bytes);
+        str_ids_ptr_ = str_ids_.data();
+        str_ids_size_ = str_ids_.size();
+    }
 
-    fill_offsets();
+    const auto has_csr_index = reader.HasEntry(MARISA_CSR_INDEX);
+    const auto has_csr_offsets = reader.HasEntry(MARISA_CSR_OFFSETS);
+    const auto has_csr_num_keys = reader.HasMeta("csr_num_keys");
+    const auto has_csr_version = reader.HasMeta(MARISA_CSR_FORMAT_VERSION_META);
+    const auto has_any_csr =
+        has_csr_index || has_csr_offsets || has_csr_num_keys || has_csr_version;
+
+    if (has_any_csr) {
+        AssertInfo(has_csr_index && has_csr_offsets && has_csr_num_keys &&
+                       has_csr_version,
+                   "incomplete marisa CSR side entries: index {}, offsets {}, "
+                   "num_keys {}, version {}",
+                   has_csr_index,
+                   has_csr_offsets,
+                   has_csr_num_keys,
+                   has_csr_version);
+        const auto version =
+            reader.GetMeta<uint32_t>(MARISA_CSR_FORMAT_VERSION_META);
+        AssertInfo(version == MARISA_CSR_FORMAT_VERSION,
+                   "unsupported marisa CSR format version: expected {}, got "
+                   "{}",
+                   MARISA_CSR_FORMAT_VERSION,
+                   version);
+        csr_num_keys_ = reader.GetMeta<size_t>("csr_num_keys");
+        AssertInfo(csr_num_keys_ == trie_.num_keys(),
+                   "invalid marisa CSR key count: expected {}, got {}",
+                   trie_.num_keys(),
+                   csr_num_keys_);
+        AssertInfo(
+            csr_num_keys_ <=
+                std::numeric_limits<size_t>::max() / sizeof(uint32_t) - 1,
+            "marisa CSR key count {} is too large",
+            csr_num_keys_);
+        AssertInfo(str_ids_size_ <= std::numeric_limits<uint32_t>::max(),
+                   "segment row count {} exceeds uint32_t capacity for CSR",
+                   str_ids_size_);
+
+        const auto index_bytes = reader.GetEntrySize(MARISA_CSR_INDEX);
+        const auto offsets_bytes = reader.GetEntrySize(MARISA_CSR_OFFSETS);
+        ValidateMarisaEntryElementSize(
+            MARISA_CSR_INDEX, index_bytes, sizeof(uint32_t));
+        ValidateMarisaEntryElementSize(
+            MARISA_CSR_OFFSETS, offsets_bytes, sizeof(uint32_t));
+        AssertInfo(index_bytes == (csr_num_keys_ + 1) * sizeof(uint32_t),
+                   "invalid marisa CSR index size: expected {}, got {}",
+                   (csr_num_keys_ + 1) * sizeof(uint32_t),
+                   index_bytes);
+
+        if (mmap_enabled) {
+            auto csr_path = file_name + ".csr";
+            {
+                auto file_writer = storage::FileWriter(
+                    csr_path,
+                    storage::io::GetPriorityFromLoadPriority(load_priority));
+                size_t written = 0;
+                reader.ReadEntryStream(
+                    MARISA_CSR_INDEX, [&](const uint8_t* data, size_t len) {
+                        AssertInfo(len <= index_bytes + offsets_bytes - written,
+                                   "marisa CSR stream exceeds expected size");
+                        file_writer.Write(data, len);
+                        written += len;
+                    });
+                reader.ReadEntryStream(
+                    MARISA_CSR_OFFSETS, [&](const uint8_t* data, size_t len) {
+                        AssertInfo(len <= index_bytes + offsets_bytes - written,
+                                   "marisa CSR stream exceeds expected size");
+                        file_writer.Write(data, len);
+                        written += len;
+                    });
+                AssertInfo(written == index_bytes + offsets_bytes,
+                           "marisa CSR stream size mismatch: got {}, expected "
+                           "{}",
+                           written,
+                           index_bytes + offsets_bytes);
+                file_writer.Finish();
+            }
+
+            auto csr_file_raii = std::make_unique<MmapFileRAII>(csr_path);
+            csr_mmap_size_ = index_bytes + offsets_bytes;
+            auto file = File::Open(csr_path, O_RDONLY);
+            auto* mapped = mmap(nullptr,
+                                csr_mmap_size_,
+                                PROT_READ,
+                                MAP_PRIVATE,
+                                file.Descriptor(),
+                                0);
+            if (mapped == MAP_FAILED) {
+                file.Close();
+                ThrowInfo(ErrorCode::UnexpectedError,
+                          "failed to mmap marisa CSR: {}",
+                          strerror(errno));
+            }
+            file.Close();
+            csr_mmap_data_ = static_cast<char*>(mapped);
+            csr_mmap_raii_ = std::move(csr_file_raii);
+            csr_index_ptr_ = reinterpret_cast<const uint32_t*>(csr_mmap_data_);
+            csr_offsets_ptr_ =
+                reinterpret_cast<const uint32_t*>(csr_mmap_data_ + index_bytes);
+        } else {
+            csr_index_.resize(index_bytes / sizeof(uint32_t));
+            size_t written = 0;
+            reader.ReadEntryStream(
+                MARISA_CSR_INDEX, [&](const uint8_t* data, size_t len) {
+                    AssertInfo(len <= index_bytes - written,
+                               "marisa CSR index stream exceeds expected size");
+                    std::memcpy(
+                        reinterpret_cast<uint8_t*>(csr_index_.data()) + written,
+                        data,
+                        len);
+                    written += len;
+                });
+            AssertInfo(written == index_bytes,
+                       "marisa CSR index stream size mismatch: got {}, "
+                       "expected {}",
+                       written,
+                       index_bytes);
+
+            csr_offsets_.resize(offsets_bytes / sizeof(uint32_t));
+            written = 0;
+            reader.ReadEntryStream(
+                MARISA_CSR_OFFSETS, [&](const uint8_t* data, size_t len) {
+                    AssertInfo(
+                        len <= offsets_bytes - written,
+                        "marisa CSR offsets stream exceeds expected size");
+                    std::memcpy(
+                        reinterpret_cast<uint8_t*>(csr_offsets_.data()) +
+                            written,
+                        data,
+                        len);
+                    written += len;
+                });
+            AssertInfo(written == offsets_bytes,
+                       "marisa CSR offsets stream size mismatch: got {}, "
+                       "expected {}",
+                       written,
+                       offsets_bytes);
+            csr_index_ptr_ = csr_index_.data();
+            csr_offsets_ptr_ = csr_offsets_.data();
+        }
+    } else {
+        // Backward compatibility for V3 files written before CSR side entries.
+        fill_offsets();
+    }
+
     built_ = true;
     total_size_ = CalculateTotalSize();
     ComputeByteSize();

--- a/internal/core/src/index/StringIndexMarisa.h
+++ b/internal/core/src/index/StringIndexMarisa.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <marisa.h>
+#include <sys/mman.h>
 #include "index/StringIndex.h"
 #include <string>
 #include <vector>
@@ -31,6 +32,15 @@ class StringIndexMarisa : public StringIndex {
     explicit StringIndexMarisa(
         const storage::FileManagerContext& file_manager_context =
             storage::FileManagerContext());
+
+    ~StringIndexMarisa() override {
+        if (str_ids_mmap_data_ != nullptr && str_ids_mmap_data_ != MAP_FAILED) {
+            munmap(str_ids_mmap_data_, str_ids_mmap_size_);
+        }
+        if (csr_mmap_data_ != nullptr && csr_mmap_data_ != MAP_FAILED) {
+            munmap(csr_mmap_data_, csr_mmap_size_);
+        }
+    }
 
     int64_t
     Size() override;
@@ -49,7 +59,7 @@ class StringIndexMarisa : public StringIndex {
 
     int64_t
     Count() override {
-        return str_ids_.size();
+        return str_ids_size_;
     }
 
     ScalarIndexType
@@ -156,8 +166,25 @@ class StringIndexMarisa : public StringIndex {
  private:
     Config config_;
     marisa::Trie trie_;
-    std::vector<int64_t> str_ids_;  // used to retrieve.
-    std::map<size_t, std::vector<size_t>> str_ids_to_offsets_;
+
+    // Maps row offset to trie key id. Memory loads own the vector; mmap loads
+    // point the accessor into the streamed side-entry file.
+    std::vector<int64_t> str_ids_;
+    const int64_t* str_ids_ptr_ = nullptr;
+    size_t str_ids_size_ = 0;
+    char* str_ids_mmap_data_ = nullptr;
+    int64_t str_ids_mmap_size_ = 0;
+    std::unique_ptr<MmapFileRAII> str_ids_mmap_raii_;
+
+    // CSR mapping from trie key id to row offsets.
+    std::vector<uint32_t> csr_index_;
+    std::vector<uint32_t> csr_offsets_;
+    const uint32_t* csr_index_ptr_ = nullptr;
+    const uint32_t* csr_offsets_ptr_ = nullptr;
+    size_t csr_num_keys_ = 0;
+    char* csr_mmap_data_ = nullptr;
+    int64_t csr_mmap_size_ = 0;
+    std::unique_ptr<MmapFileRAII> csr_mmap_raii_;
     bool built_ = false;
     int64_t total_size_ = 0;  // Cached total size to avoid runtime calculation
 };

--- a/internal/core/src/index/StringIndexSort.cpp
+++ b/internal/core/src/index/StringIndexSort.cpp
@@ -56,6 +56,21 @@
 
 namespace milvus::index {
 
+namespace {
+
+void
+SetIdxToOffset(std::vector<int32_t>& idx_to_offsets,
+               uint32_t row_id,
+               uint32_t unique_idx) {
+    AssertInfo(static_cast<size_t>(row_id) < idx_to_offsets.size(),
+               "row_id {} exceeds idx_to_offsets size {}",
+               row_id,
+               idx_to_offsets.size());
+    idx_to_offsets[row_id] = unique_idx;
+}
+
+}  // namespace
+
 StringIndexSortImpl::ParsedData
 StringIndexSortImpl::ParseBinaryData(const uint8_t* data, size_t data_size) {
     ParsedData result;
@@ -127,7 +142,11 @@ StringIndexSort::StringIndexSort(
     }
 }
 
-StringIndexSort::~StringIndexSort() = default;
+StringIndexSort::~StringIndexSort() {
+    if (mmap_meta_data_ != nullptr && mmap_meta_data_ != MAP_FAILED) {
+        munmap(mmap_meta_data_, mmap_meta_size_);
+    }
+}
 
 int64_t
 StringIndexSort::Count() {
@@ -156,6 +175,8 @@ StringIndexSort::Build(size_t n,
     // Let MemoryImpl handle the building process
     memory_impl->BuildFromRawData(
         n, values, valid_data, valid_bitset_, idx_to_offsets_);
+    idx_to_offsets_ptr_ = idx_to_offsets_.data();
+    idx_to_offsets_size_ = idx_to_offsets_.size();
 
     is_built_ = true;
     total_size_ = CalculateTotalSize();
@@ -202,6 +223,8 @@ StringIndexSort::BuildWithFieldData(
     static_cast<StringIndexSortMemoryImpl*>(impl_.get())
         ->BuildFromFieldData(
             field_datas, total_num_rows_, valid_bitset_, idx_to_offsets_);
+    idx_to_offsets_ptr_ = idx_to_offsets_.data();
+    idx_to_offsets_size_ = idx_to_offsets_.size();
 
     is_built_ = true;
     total_size_ = CalculateTotalSize();
@@ -347,8 +370,10 @@ StringIndexSort::LoadWithoutAssemble(const BinarySet& binary_set,
         auto mmap_path =
             GetValueFromConfig<std::string>(config, MMAP_FILE_PATH).value();
         mmap_impl->SetMmapFilePath(mmap_path);
+        auto mmap_file_raii = std::make_unique<MmapFileRAII>(mmap_path);
         mmap_impl->LoadFromBinary(
             binary_set, total_num_rows_, valid_bitset_, idx_to_offsets_);
+        mmap_file_raii_ = std::move(mmap_file_raii);
         impl_ = std::move(mmap_impl);
     } else {
         LOG_INFO("StringIndexSort: loading with memory strategy");
@@ -356,6 +381,8 @@ StringIndexSort::LoadWithoutAssemble(const BinarySet& binary_set,
         impl_->LoadFromBinary(
             binary_set, total_num_rows_, valid_bitset_, idx_to_offsets_);
     }
+    idx_to_offsets_ptr_ = idx_to_offsets_.data();
+    idx_to_offsets_size_ = idx_to_offsets_.size();
 
     is_built_ = true;
     total_size_ = CalculateTotalSize();
@@ -437,8 +464,11 @@ StringIndexSort::PatternMatch(const std::string& pattern,
 std::optional<std::string>
 StringIndexSort::Reverse_Lookup(size_t offset) const {
     assert(impl_ != nullptr);
-    return impl_->Reverse_Lookup(
-        offset, total_num_rows_, valid_bitset_, idx_to_offsets_);
+    return impl_->Reverse_Lookup(offset,
+                                 total_num_rows_,
+                                 valid_bitset_,
+                                 idx_to_offsets_ptr_,
+                                 idx_to_offsets_size_);
 }
 
 int64_t
@@ -452,7 +482,7 @@ StringIndexSort::CalculateTotalSize() const {
 
     size += impl_->Size();
     // Add common structures (always present)
-    size += idx_to_offsets_.size() * sizeof(int32_t);
+    size += idx_to_offsets_size_ * sizeof(int32_t);
     size += valid_bitset_.size() / 8;
 
     // Add object overhead
@@ -466,9 +496,11 @@ StringIndexSort::ComputeByteSize() {
     StringIndex::ComputeByteSize();
     int64_t total = cached_byte_size_;
 
-    // Common structures (always in memory)
-    // idx_to_offsets_: vector<int32_t>
-    total += idx_to_offsets_.capacity() * sizeof(int32_t);
+    if (mmap_meta_data_ != nullptr) {
+        total += mmap_meta_size_;
+    } else {
+        total += idx_to_offsets_.capacity() * sizeof(int32_t);
+    }
 
     // valid_bitset_: TargetBitmap
     total += valid_bitset_.size_in_bytes();
@@ -509,6 +541,9 @@ StringIndexSort::WriteEntries(storage::IndexEntryWriter* writer) {
     writer->WriteEntry("index_data", data_buffer.data(), total_size);
     writer->WriteEntry(
         "valid_bitset", valid_bitset_data.data(), valid_bitset_size);
+    writer->WriteEntry("idx_to_offsets",
+                       idx_to_offsets_.data(),
+                       idx_to_offsets_.size() * sizeof(int32_t));
 }
 
 void
@@ -528,9 +563,10 @@ StringIndexSort::LoadEntries(storage::IndexEntryReader& reader,
     auto is_nested = reader.GetMeta<bool>("is_nested");
     AssertInfo(!is_nested, "nested string sort index is not supported in 2.6");
 
-    idx_to_offsets_.resize(total_num_rows_);
-
     auto valid_bitset_entry = reader.ReadEntry("valid_bitset");
+    AssertInfo(total_num_rows_ <= std::numeric_limits<size_t>::max() - 7,
+               "string sort validity size overflow for {} rows",
+               total_num_rows_);
     auto expected_valid_bitset_size = (total_num_rows_ + 7) / 8;
     AssertInfo(valid_bitset_entry.data.size() >= expected_valid_bitset_size,
                "invalid valid_bitset size: expected at least {}, got {}",
@@ -544,7 +580,23 @@ StringIndexSort::LoadEntries(storage::IndexEntryReader& reader,
         }
     }
 
-    auto index_data_entry = reader.ReadEntry("index_data");
+    auto load_priority =
+        GetValueFromConfig<milvus::proto::common::LoadPriority>(
+            config, milvus::LOAD_PRIORITY)
+            .value_or(milvus::proto::common::LoadPriority::HIGH);
+    const auto data_size = reader.GetEntrySize("index_data");
+    const auto has_offsets = reader.HasEntry("idx_to_offsets");
+    AssertInfo(
+        total_num_rows_ <= std::numeric_limits<size_t>::max() / sizeof(int32_t),
+        "string sort offset size overflow for {} rows",
+        total_num_rows_);
+    const auto offsets_size = total_num_rows_ * sizeof(int32_t);
+    if (has_offsets) {
+        AssertInfo(reader.GetEntrySize("idx_to_offsets") == offsets_size,
+                   "invalid idx_to_offsets size: expected {}, got {}",
+                   offsets_size,
+                   reader.GetEntrySize("idx_to_offsets"));
+    }
 
     if (config.contains(MMAP_FILE_PATH)) {
         LOG_INFO("StringIndexSort::LoadEntries: loading with mmap strategy");
@@ -552,20 +604,150 @@ StringIndexSort::LoadEntries(storage::IndexEntryReader& reader,
         auto mmap_path =
             GetValueFromConfig<std::string>(config, MMAP_FILE_PATH).value();
         mmap_impl->SetMmapFilePath(mmap_path);
-        mmap_impl->LoadFromData(index_data_entry.data.data(),
-                                index_data_entry.data.size(),
+        auto mmap_file_raii = std::make_unique<MmapFileRAII>(mmap_path);
+        std::unique_ptr<MmapFileRAII> mmap_meta_file_raii;
+
+        auto parent = std::filesystem::path(mmap_path).parent_path();
+        if (!parent.empty()) {
+            std::filesystem::create_directories(parent);
+        }
+        AssertInfo(
+            data_size <= std::numeric_limits<size_t>::max() - (ALIGNMENT - 1),
+            "string sort mmap size overflow: {}",
+            data_size);
+        auto aligned_size =
+            ((data_size + ALIGNMENT - 1) / ALIGNMENT) * ALIGNMENT;
+        {
+            auto file_writer = storage::FileWriter(
+                mmap_path,
+                storage::io::GetPriorityFromLoadPriority(load_priority));
+            size_t written = 0;
+            reader.ReadEntryStream(
+                "index_data", [&](const uint8_t* data, size_t len) {
+                    AssertInfo(len <= data_size - written,
+                               "string sort stream exceeds expected size");
+                    file_writer.Write(data, len);
+                    written += len;
+                });
+            AssertInfo(written == data_size,
+                       "string sort stream size mismatch: got {}, expected {}",
+                       written,
+                       data_size);
+            if (aligned_size > data_size) {
+                std::vector<uint8_t> padding(aligned_size - data_size, 0);
+                file_writer.Write(padding.data(), padding.size());
+            }
+            const uint8_t mmap_padding = 0;
+            file_writer.Write(&mmap_padding, MMAP_INDEX_PADDING);
+            file_writer.Finish();
+        }
+
+        if (has_offsets) {
+            mmap_meta_filepath_ = mmap_path + "-meta";
+            mmap_meta_file_raii =
+                std::make_unique<MmapFileRAII>(mmap_meta_filepath_);
+            {
+                auto file_writer = storage::FileWriter(
+                    mmap_meta_filepath_,
+                    storage::io::GetPriorityFromLoadPriority(load_priority));
+                size_t written = 0;
+                reader.ReadEntryStream(
+                    "idx_to_offsets", [&](const uint8_t* data, size_t len) {
+                        AssertInfo(len <= offsets_size - written,
+                                   "string sort offsets stream exceeds "
+                                   "expected size");
+                        file_writer.Write(data, len);
+                        written += len;
+                    });
+                AssertInfo(written == offsets_size,
+                           "string sort offsets stream size mismatch: got {}, "
+                           "expected {}",
+                           written,
+                           offsets_size);
+                file_writer.Finish();
+            }
+
+            mmap_meta_size_ = offsets_size;
+            auto file = File::Open(mmap_meta_filepath_, O_RDONLY);
+            mmap_meta_data_ = static_cast<char*>(mmap(nullptr,
+                                                      mmap_meta_size_,
+                                                      PROT_READ,
+                                                      MAP_PRIVATE,
+                                                      file.Descriptor(),
+                                                      0));
+            if (mmap_meta_data_ == MAP_FAILED) {
+                file.Close();
+                ThrowInfo(ErrorCode::UnexpectedError,
+                          "failed to mmap string sort offsets: {}",
+                          strerror(errno));
+            }
+            file.Close();
+            idx_to_offsets_ptr_ =
+                reinterpret_cast<const int32_t*>(mmap_meta_data_);
+            idx_to_offsets_size_ = total_num_rows_;
+        } else {
+            idx_to_offsets_.resize(total_num_rows_);
+        }
+
+        mmap_impl->LoadFromFile(data_size,
                                 total_num_rows_,
                                 valid_bitset_,
-                                idx_to_offsets_);
+                                idx_to_offsets_,
+                                has_offsets);
+        if (!has_offsets) {
+            idx_to_offsets_ptr_ = idx_to_offsets_.data();
+            idx_to_offsets_size_ = idx_to_offsets_.size();
+        }
+        mmap_file_raii_ = std::move(mmap_file_raii);
+        mmap_meta_file_raii_ = std::move(mmap_meta_file_raii);
         impl_ = std::move(mmap_impl);
     } else {
         LOG_INFO("StringIndexSort::LoadEntries: loading with memory strategy");
-        impl_ = std::make_unique<StringIndexSortMemoryImpl>();
-        impl_->LoadFromData(index_data_entry.data.data(),
-                            index_data_entry.data.size(),
-                            total_num_rows_,
-                            valid_bitset_,
-                            idx_to_offsets_);
+        idx_to_offsets_.resize(total_num_rows_);
+        if (has_offsets) {
+            size_t written = 0;
+            reader.ReadEntryStream(
+                "idx_to_offsets", [&](const uint8_t* data, size_t len) {
+                    AssertInfo(len <= offsets_size - written,
+                               "string sort offsets stream exceeds expected "
+                               "size");
+                    std::memcpy(
+                        reinterpret_cast<uint8_t*>(idx_to_offsets_.data()) +
+                            written,
+                        data,
+                        len);
+                    written += len;
+                });
+            AssertInfo(written == offsets_size,
+                       "string sort offsets stream size mismatch: got {}, "
+                       "expected {}",
+                       written,
+                       offsets_size);
+        }
+
+        std::vector<uint8_t> data(data_size);
+        size_t written = 0;
+        reader.ReadEntryStream(
+            "index_data", [&](const uint8_t* slice, size_t len) {
+                AssertInfo(len <= data_size - written,
+                           "string sort stream exceeds expected size");
+                std::memcpy(data.data() + written, slice, len);
+                written += len;
+            });
+        AssertInfo(written == data_size,
+                   "string sort stream size mismatch: got {}, expected {}",
+                   written,
+                   data_size);
+
+        auto buffer_impl = std::make_unique<StringIndexSortMmapImpl>();
+        buffer_impl->LoadFromBuffer(std::move(data),
+                                    total_num_rows_,
+                                    valid_bitset_,
+                                    idx_to_offsets_,
+                                    has_offsets);
+        idx_to_offsets_ptr_ = idx_to_offsets_.data();
+        idx_to_offsets_size_ = idx_to_offsets_.size();
+        impl_ = std::move(buffer_impl);
     }
 
     is_built_ = true;
@@ -804,14 +986,7 @@ StringIndexSortMemoryImpl::LoadFromData(const uint8_t* data,
             posting_list.push_back(row_id);
 
             // Map each row_id to its unique value index
-            if (static_cast<size_t>(row_id) >= idx_to_offsets.size()) {
-                ThrowInfo(
-                    milvus::ErrorCode::UnexpectedError,
-                    fmt::format("row_id {} exceeds idx_to_offsets size {}",
-                                row_id,
-                                idx_to_offsets.size()));
-            }
-            idx_to_offsets[row_id] = unique_idx;
+            SetIdxToOffset(idx_to_offsets, row_id, unique_idx);
         }
 
         unique_values_.push_back(std::move(value));
@@ -1092,16 +1267,16 @@ StringIndexSortMemoryImpl::PatternMatch(const std::string& pattern,
 }
 
 std::optional<std::string>
-StringIndexSortMemoryImpl::Reverse_Lookup(
-    size_t offset,
-    size_t total_num_rows,
-    const TargetBitmap& valid_bitset,
-    const std::vector<int32_t>& idx_to_offsets) const {
+StringIndexSortMemoryImpl::Reverse_Lookup(size_t offset,
+                                          size_t total_num_rows,
+                                          const TargetBitmap& valid_bitset,
+                                          const int32_t* idx_to_offsets,
+                                          size_t idx_to_offsets_size) const {
     if (offset >= total_num_rows || !valid_bitset[offset]) {
         return std::nullopt;
     }
 
-    if (offset < idx_to_offsets.size()) {
+    if (offset < idx_to_offsets_size) {
         size_t unique_idx = idx_to_offsets[offset];
         if (unique_idx < unique_values_.size()) {
             return unique_values_[unique_idx];
@@ -1159,11 +1334,8 @@ StringIndexSortMemoryImpl::ByteSize() const {
 }
 
 StringIndexSortMmapImpl::~StringIndexSortMmapImpl() {
-    if (mmap_data_ != nullptr && mmap_data_ != MAP_FAILED) {
+    if (mmap_data_ != nullptr && mmap_data_ != MAP_FAILED && mmap_size_ > 0) {
         munmap(mmap_data_, mmap_size_);
-        if (!mmap_filepath_.empty()) {
-            unlink(mmap_filepath_.c_str());
-        }
     }
 }
 
@@ -1188,9 +1360,15 @@ StringIndexSortMmapImpl::LoadFromData(const uint8_t* data,
                                       std::vector<int32_t>& idx_to_offsets) {
     AssertInfo(!mmap_filepath_.empty(), "mmap filepath is not set");
 
-    std::filesystem::create_directories(
-        std::filesystem::path(mmap_filepath_).parent_path());
+    auto parent = std::filesystem::path(mmap_filepath_).parent_path();
+    if (!parent.empty()) {
+        std::filesystem::create_directories(parent);
+    }
 
+    AssertInfo(
+        data_size <= std::numeric_limits<size_t>::max() - (ALIGNMENT - 1),
+        "string sort mmap size overflow: {}",
+        data_size);
     auto aligned_size = ((data_size + ALIGNMENT - 1) / ALIGNMENT) * ALIGNMENT;
     {
         auto file_writer = storage::FileWriter(mmap_filepath_);
@@ -1205,6 +1383,72 @@ StringIndexSortMmapImpl::LoadFromData(const uint8_t* data,
         file_writer.Write(padding.data(), padding.size());
         file_writer.Finish();
     }
+
+    MmapAndParse(
+        data_size, total_num_rows, valid_bitset, idx_to_offsets, false);
+}
+
+void
+StringIndexSortMmapImpl::LoadFromFile(size_t data_size,
+                                      size_t total_num_rows,
+                                      TargetBitmap& valid_bitset,
+                                      std::vector<int32_t>& idx_to_offsets,
+                                      bool skip_idx_to_offsets) {
+    AssertInfo(!mmap_filepath_.empty(), "mmap filepath is not set");
+    MmapAndParse(data_size,
+                 total_num_rows,
+                 valid_bitset,
+                 idx_to_offsets,
+                 skip_idx_to_offsets);
+}
+
+void
+StringIndexSortMmapImpl::LoadFromBuffer(std::vector<uint8_t>&& buffer,
+                                        size_t total_num_rows,
+                                        TargetBitmap& valid_bitset,
+                                        std::vector<int32_t>& idx_to_offsets,
+                                        bool skip_idx_to_offsets) {
+    (void)total_num_rows;
+    (void)valid_bitset;
+    owned_data_ = std::move(buffer);
+    data_size_ = owned_data_.size();
+    mmap_data_ = reinterpret_cast<char*>(owned_data_.data());
+    mmap_size_ = 0;
+
+    auto parsed = ParseBinaryData(reinterpret_cast<const uint8_t*>(mmap_data_),
+                                  data_size_);
+    unique_count_ = parsed.unique_count;
+    string_offsets_ = parsed.string_offsets;
+    string_data_start_ = parsed.string_data_start;
+    post_list_offsets_ = parsed.post_list_offsets;
+    post_list_data_start_ = parsed.post_list_data_start;
+
+    if (!skip_idx_to_offsets) {
+        std::fill(idx_to_offsets.begin(), idx_to_offsets.end(), -1);
+        for (uint32_t unique_idx = 0; unique_idx < unique_count_;
+             ++unique_idx) {
+            auto entry = GetEntry(unique_idx);
+            entry.for_each_row_id(
+                [&idx_to_offsets, unique_idx](uint32_t row_id) {
+                    SetIdxToOffset(idx_to_offsets, row_id, unique_idx);
+                });
+        }
+    }
+}
+
+void
+StringIndexSortMmapImpl::MmapAndParse(size_t data_size,
+                                      size_t total_num_rows,
+                                      TargetBitmap& valid_bitset,
+                                      std::vector<int32_t>& idx_to_offsets,
+                                      bool skip_idx_to_offsets) {
+    (void)total_num_rows;
+    (void)valid_bitset;
+    AssertInfo(
+        data_size <= std::numeric_limits<size_t>::max() - (ALIGNMENT - 1),
+        "string sort mmap size overflow: {}",
+        data_size);
+    auto aligned_size = ((data_size + ALIGNMENT - 1) / ALIGNMENT) * ALIGNMENT;
 
     auto fd = open(mmap_filepath_.c_str(), O_RDONLY);
     if (fd == -1) {
@@ -1230,16 +1474,16 @@ StringIndexSortMmapImpl::LoadFromData(const uint8_t* data,
     post_list_offsets_ = parsed.post_list_offsets;
     post_list_data_start_ = parsed.post_list_data_start;
 
-    // Initialize idx_to_offsets
-    std::fill(idx_to_offsets.begin(), idx_to_offsets.end(), -1);
-    // Rebuild idx_to_offsets by iterating through entries
-    for (uint32_t unique_idx = 0; unique_idx < unique_count_; ++unique_idx) {
-        MmapEntry entry = GetEntry(unique_idx);
-
-        // Map each row_id in posting list to this unique index
-        entry.for_each_row_id([&idx_to_offsets, unique_idx](uint32_t row_id) {
-            idx_to_offsets[row_id] = unique_idx;
-        });
+    if (!skip_idx_to_offsets) {
+        std::fill(idx_to_offsets.begin(), idx_to_offsets.end(), -1);
+        for (uint32_t unique_idx = 0; unique_idx < unique_count_;
+             ++unique_idx) {
+            auto entry = GetEntry(unique_idx);
+            entry.for_each_row_id(
+                [&idx_to_offsets, unique_idx](uint32_t row_id) {
+                    SetIdxToOffset(idx_to_offsets, row_id, unique_idx);
+                });
+        }
     }
 }
 
@@ -1523,16 +1767,16 @@ StringIndexSortMmapImpl::PatternMatch(const std::string& pattern,
 }
 
 std::optional<std::string>
-StringIndexSortMmapImpl::Reverse_Lookup(
-    size_t offset,
-    size_t total_num_rows,
-    const TargetBitmap& valid_bitset,
-    const std::vector<int32_t>& idx_to_offsets) const {
+StringIndexSortMmapImpl::Reverse_Lookup(size_t offset,
+                                        size_t total_num_rows,
+                                        const TargetBitmap& valid_bitset,
+                                        const int32_t* idx_to_offsets,
+                                        size_t idx_to_offsets_size) const {
     if (offset >= total_num_rows || !valid_bitset[offset]) {
         return std::nullopt;
     }
 
-    if (offset < idx_to_offsets.size()) {
+    if (offset < idx_to_offsets_size) {
         int32_t unique_idx = idx_to_offsets[offset];
         if (unique_idx >= 0 &&
             static_cast<size_t>(unique_idx) < unique_count_) {
@@ -1548,13 +1792,12 @@ StringIndexSortMmapImpl::Reverse_Lookup(
 
 int64_t
 StringIndexSortMmapImpl::Size() {
-    return mmap_size_;
+    return mmap_size_ > 0 ? mmap_size_ : data_size_;
 }
 
 int64_t
 StringIndexSortMmapImpl::ByteSize() const {
-    // mmap size (O(n) - the mapped index data)
-    return mmap_size_;
+    return mmap_size_ > 0 ? mmap_size_ : data_size_;
 }
 
 }  // namespace milvus::index

--- a/internal/core/src/index/StringIndexSort.h
+++ b/internal/core/src/index/StringIndexSort.h
@@ -160,10 +160,18 @@ class StringIndexSort : public StringIndex {
     size_t total_num_rows_{0};
     TargetBitmap valid_bitset_;
     std::vector<int32_t> idx_to_offsets_;
+    const int32_t* idx_to_offsets_ptr_ = nullptr;
+    size_t idx_to_offsets_size_ = 0;
     std::chrono::time_point<std::chrono::system_clock> index_build_begin_;
 
     int64_t total_size_{0};
     std::unique_ptr<StringIndexSortImpl> impl_;
+
+    // mmap backing for the persisted idx_to_offsets V3 side entry.
+    char* mmap_meta_data_ = nullptr;
+    int64_t mmap_meta_size_ = 0;
+    std::string mmap_meta_filepath_;
+    std::unique_ptr<MmapFileRAII> mmap_meta_file_raii_;
 };
 
 // Abstract interface for implementations
@@ -233,7 +241,8 @@ class StringIndexSortImpl {
     Reverse_Lookup(size_t offset,
                    size_t total_num_rows,
                    const TargetBitmap& valid_bitset,
-                   const std::vector<int32_t>& idx_to_offsets) const = 0;
+                   const int32_t* idx_to_offsets,
+                   size_t idx_to_offsets_size) const = 0;
 
     virtual int64_t
     Size() = 0;
@@ -322,7 +331,8 @@ class StringIndexSortMemoryImpl : public StringIndexSortImpl {
     Reverse_Lookup(size_t offset,
                    size_t total_num_rows,
                    const TargetBitmap& valid_bitset,
-                   const std::vector<int32_t>& idx_to_offsets) const override;
+                   const int32_t* idx_to_offsets,
+                   size_t idx_to_offsets_size) const override;
 
     int64_t
     Size() override;
@@ -420,6 +430,20 @@ class StringIndexSortMmapImpl : public StringIndexSortImpl {
                  std::vector<int32_t>& idx_to_offsets) override;
 
     void
+    LoadFromFile(size_t data_size,
+                 size_t total_num_rows,
+                 TargetBitmap& valid_bitset,
+                 std::vector<int32_t>& idx_to_offsets,
+                 bool skip_idx_to_offsets = false);
+
+    void
+    LoadFromBuffer(std::vector<uint8_t>&& buffer,
+                   size_t total_num_rows,
+                   TargetBitmap& valid_bitset,
+                   std::vector<int32_t>& idx_to_offsets,
+                   bool skip_idx_to_offsets = false);
+
+    void
     SetMmapFilePath(const std::string& filepath) {
         mmap_filepath_ = filepath;
     }
@@ -461,7 +485,8 @@ class StringIndexSortMmapImpl : public StringIndexSortImpl {
     Reverse_Lookup(size_t offset,
                    size_t total_num_rows,
                    const TargetBitmap& valid_bitset,
-                   const std::vector<int32_t>& idx_to_offsets) const override;
+                   const int32_t* idx_to_offsets,
+                   size_t idx_to_offsets_size) const override;
 
     int64_t
     Size() override;
@@ -470,6 +495,13 @@ class StringIndexSortMmapImpl : public StringIndexSortImpl {
     ByteSize() const override;
 
  private:
+    void
+    MmapAndParse(size_t data_size,
+                 size_t total_num_rows,
+                 TargetBitmap& valid_bitset,
+                 std::vector<int32_t>& idx_to_offsets,
+                 bool skip_idx_to_offsets = false);
+
     // Binary search for a value
     size_t
     FindValueIndex(const std::string& value) const;
@@ -504,6 +536,7 @@ class StringIndexSortMmapImpl : public StringIndexSortImpl {
     size_t mmap_size_ = 0;
     size_t data_size_ = 0;  // Actual data size without padding
     std::string mmap_filepath_;
+    std::vector<uint8_t> owned_data_;
     size_t unique_count_ = 0;
 
     // Pointers to different sections in mmap'd data

--- a/internal/core/src/index/StringIndexSortTest.cpp
+++ b/internal/core/src/index/StringIndexSortTest.cpp
@@ -1,9 +1,18 @@
 #include <gtest/gtest.h>
+#include <arrow/io/memory.h>
 #include <boost/filesystem.hpp>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <vector>
 
 #include "index/StringIndexSort.h"
 #include "index/IndexFactory.h"
 #include "pb/plan.pb.h"
+#include "storage/IndexEntryDirectStreamWriter.h"
+#include "storage/IndexEntryReader.h"
+#include "storage/RemoteInputStream.h"
+#include "storage/RemoteOutputStream.h"
 #include "test_utils/Constants.h"
 #include "test_utils/indexbuilder_test_utils.h"
 
@@ -424,6 +433,48 @@ TEST_F(StringIndexSortTest, LoadWithoutAssembleMmap) {
 
     // Clean up
     std::remove((TestLocalPath + "test_load_without_assemble.idx").c_str());
+}
+
+TEST_F(StringIndexSortTest, MmapLoadRemovesFilesOnParseFailure) {
+    const auto mmap_path = TestLocalPath + "string-sort-raii-test";
+    const auto mmap_meta_path = mmap_path + "-meta";
+    std::filesystem::remove(mmap_path);
+    std::filesystem::remove(mmap_meta_path);
+
+    auto arrow_output = arrow::io::BufferOutputStream::Create().ValueOrDie();
+    std::shared_ptr<arrow::io::OutputStream> arrow_output_base = arrow_output;
+    auto output = std::make_shared<storage::RemoteOutputStream>(
+        std::move(arrow_output_base));
+    storage::IndexEntryDirectStreamWriter writer(output);
+    writer.PutMeta("version", StringIndexSort::SERIALIZATION_VERSION);
+    writer.PutMeta("num_rows", size_t{1});
+    writer.PutMeta("is_nested", false);
+    const uint64_t invalid_index_data = 0;
+    const uint8_t valid_bitset = 1;
+    const int32_t idx_to_offset = 0;
+    writer.WriteEntry(
+        "index_data", &invalid_index_data, sizeof(invalid_index_data));
+    writer.WriteEntry("valid_bitset", &valid_bitset, sizeof(valid_bitset));
+    writer.WriteEntry("idx_to_offsets", &idx_to_offset, sizeof(idx_to_offset));
+    writer.Finish();
+    auto packed_data = arrow_output->Finish().ValueOrDie();
+
+    auto arrow_input = std::make_shared<arrow::io::BufferReader>(packed_data);
+    std::shared_ptr<arrow::io::RandomAccessFile> random_access_input =
+        arrow_input;
+    auto input = std::make_shared<storage::RemoteInputStream>(
+        std::move(random_access_input));
+    auto reader = storage::IndexEntryReader::Open(input, packed_data->size());
+
+    Config config;
+    config[MMAP_FILE_PATH] = mmap_path;
+    StringIndexSort index;
+    EXPECT_THROW(index.LoadEntries(*reader, config), SegcoreError);
+
+    EXPECT_FALSE(std::filesystem::exists(mmap_path));
+    EXPECT_FALSE(std::filesystem::exists(mmap_meta_path));
+    std::filesystem::remove(mmap_path);
+    std::filesystem::remove(mmap_meta_path);
 }
 }  // namespace index
 }  // namespace milvus

--- a/internal/core/src/index/TextMatchIndexTest.cpp
+++ b/internal/core/src/index/TextMatchIndexTest.cpp
@@ -446,13 +446,14 @@ TEST(TextMatch, TranslatorResourceAccountsForValidityBitmap) {
             101,
             "{}",
             index_size,
+            2,
             static_cast<int64_t>(texts.size()),
             ""};
         storagev1translator::TextMatchIndexTranslator translator(
             load_info, ctx, config);
 
         auto [estimated_loaded, estimated_total_loading] =
-            translator.estimated_byte_size_of_cell(0);
+            translator.estimated_loading_usage({0});
         if (mmap_enabled) {
             EXPECT_EQ(estimated_loaded.memory_bytes, bitmap_bytes);
             EXPECT_EQ(estimated_loaded.file_bytes, index_size);
@@ -463,7 +464,7 @@ TEST(TextMatch, TranslatorResourceAccountsForValidityBitmap) {
             EXPECT_EQ(estimated_loaded.memory_bytes, index_size + bitmap_bytes);
             EXPECT_EQ(estimated_loaded.file_bytes, 0);
             EXPECT_EQ(estimated_total_loading.memory_bytes,
-                      index_size + bitmap_bytes);
+                      2 * index_size + bitmap_bytes);
             EXPECT_EQ(estimated_total_loading.file_bytes, index_size);
         }
 

--- a/internal/core/src/index/Utils.cpp
+++ b/internal/core/src/index/Utils.cpp
@@ -28,6 +28,7 @@
 #include <google/protobuf/text_format.h>
 
 #include "common/EasyAssert.h"
+#include "common/Consts.h"
 #include "common/Exception.h"
 #include "common/File.h"
 #include "common/FieldData.h"
@@ -38,10 +39,37 @@
 #include "index/Utils.h"
 #include "index/Meta.h"
 #include "storage/IndexData.h"
+#include "storage/PluginLoader.h"
+#include "storage/ThreadPools.h"
 #include "storage/Util.h"
 #include "knowhere/comp/index_param.h"
 
 namespace milvus::index {
+
+uint64_t
+ScalarIndexStreamMemoryOverhead(uint64_t index_size_in_bytes,
+                                int32_t scalar_version,
+                                proto::common::LoadPriority load_priority) {
+    if (index_size_in_bytes == 0) {
+        return 0;
+    }
+    if (scalar_version < 3) {
+        return index_size_in_bytes;
+    }
+
+    // Without persisted slice metadata an encrypted slice has no trustworthy
+    // ciphertext bound. Keep the existing whole-index estimate whenever a
+    // cipher plugin is active.
+    if (storage::PluginLoader::GetInstance().getCipherPlugin() != nullptr) {
+        return index_size_in_bytes;
+    }
+
+    auto& pool = ThreadPools::GetThreadPool(PriorityForLoad(load_priority));
+    const auto worker_count = std::max<size_t>(1, pool.GetMaxThreadNum());
+    const auto pool_download_peak = SaturatingMultiply(
+        worker_count, static_cast<uint64_t>(DEFAULT_INDEX_FILE_SLICE_SIZE));
+    return std::min(index_size_in_bytes, pool_download_peak);
+}
 
 size_t
 get_file_size(int fd) {

--- a/internal/core/src/index/Utils.h
+++ b/internal/core/src/index/Utils.h
@@ -191,8 +191,7 @@ ParseConfigFromIndexParams(
 uint64_t
 ScalarIndexStreamMemoryOverhead(uint64_t index_size_in_bytes,
                                 int32_t scalar_version,
-                                proto::common::LoadPriority load_priority =
-                                    proto::common::LoadPriority::HIGH);
+                                proto::common::LoadPriority load_priority);
 
 struct IndexDataCodec {
     std::list<std::unique_ptr<storage::DataCodec>> codecs_{};

--- a/internal/core/src/index/Utils.h
+++ b/internal/core/src/index/Utils.h
@@ -38,6 +38,7 @@
 #include "storage/Types.h"
 #include "storage/DataCodec.h"
 #include "log/Log.h"
+#include "pb/common.pb.h"
 
 namespace milvus::index {
 
@@ -186,6 +187,12 @@ GetIndexMetaFromConfig(const Config& config);
 Config
 ParseConfigFromIndexParams(
     const std::map<std::string, std::string>& index_params);
+
+uint64_t
+ScalarIndexStreamMemoryOverhead(uint64_t index_size_in_bytes,
+                                int32_t scalar_version,
+                                proto::common::LoadPriority load_priority =
+                                    proto::common::LoadPriority::HIGH);
 
 struct IndexDataCodec {
     std::list<std::unique_ptr<storage::DataCodec>> codecs_{};

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1959,6 +1959,7 @@ ChunkedSegmentSealedImpl::LoadTextIndex(
         info_proto->fieldid(),
         field_meta.get_analyzer_params(),
         info_proto->index_size(),
+        info_proto->current_scalar_index_version(),
         num_rows,
         info_proto->warmup_policy()};
 

--- a/internal/core/src/segcore/LoadCancellationTest.cpp
+++ b/internal/core/src/segcore/LoadCancellationTest.cpp
@@ -285,7 +285,8 @@ class SlowChunkTranslator : public cachinglayer::Translator<milvus::Chunk> {
         return uid;
     }
     std::pair<cachinglayer::ResourceUsage, cachinglayer::ResourceUsage>
-    estimated_byte_size_of_cell(cachinglayer::cid_t) const override {
+    estimated_loading_usage(
+        const std::vector<cachinglayer::cid_t>&) const override {
         return {{0, 0}, {0, 0}};
     }
     int64_t

--- a/internal/core/src/segcore/MemoryPlannerTest.cpp
+++ b/internal/core/src/segcore/MemoryPlannerTest.cpp
@@ -13,10 +13,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <future>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -182,6 +184,11 @@ TEST(ParallelDegreeSplitStrategy, ContinuousExceedingAvgSize) {
 
 // ---- LoadCellBatchAsync tests ----
 
+TEST(LoadCellBatchAsync, Uses16MiBDefaultBatchTarget) {
+    constexpr int64_t MB = 1 << 20;
+    EXPECT_EQ(kDefaultFieldDataLoadBatchTargetBytes, 16 * MB);
+}
+
 namespace {
 
 // Helper: create a BatchReaderFactory that returns empty Arrow tables.
@@ -203,22 +210,80 @@ MakeMockReaderFactory() {
     };
 }
 
+CellFinalizeFunc
+MakeMockCellFinalizer() {
+    return
+        [](const std::vector<std::shared_ptr<arrow::Table>>& /*tables*/,
+           int64_t /*cid*/) { return std::make_unique<milvus::GroupChunk>(); };
+}
+
+LoadedCellBatch
+CollectLoadedCells(std::vector<CellLoadFuture>& futures) {
+    LoadedCellBatch loaded_cells;
+    for (auto& future : futures) {
+        auto batch = future.get();
+        for (auto& loaded_cell : batch) {
+            loaded_cells.push_back(std::move(loaded_cell));
+        }
+    }
+    return loaded_cells;
+}
+
 // Helper to run LoadCellBatchAsync and return future count (= batch count).
 size_t
 RunAndCountBatches(std::vector<CellSpec> cell_specs, int64_t memory_limit) {
-    auto channel = std::make_shared<CellReaderChannel>(64);
     auto futures = LoadCellBatchAsync(nullptr,
                                       std::move(cell_specs),
                                       MakeMockReaderFactory(),
-                                      channel,
-                                      memory_limit);
-    for (auto& f : futures) {
-        f.get();
-    }
+                                      memory_limit,
+                                      milvus::proto::common::LoadPriority::HIGH,
+                                      MakeMockCellFinalizer());
+    CollectLoadedCells(futures);
     return futures.size();
 }
 
 }  // namespace
+
+TEST(LoadCellBatchAsync, ReaderLimitFollowsEachBatchMemory) {
+    constexpr int64_t MB = 1 << 20;
+    constexpr int64_t kBatchTarget = 16 * MB;
+    std::vector<CellSpec> specs = {
+        {0, 0, 0, 1, 3 * MB},
+        {1, 0, 1, 1, 5 * MB},
+        {2, 1, 0, 1, 32 * MB},
+    };
+
+    std::atomic<int64_t> small_batch_reader_limit{-1};
+    std::atomic<int64_t> oversized_batch_reader_limit{-1};
+    auto delegate = MakeMockReaderFactory();
+    BatchReaderFactory reader_factory = [delegate = std::move(delegate),
+                                         &small_batch_reader_limit,
+                                         &oversized_batch_reader_limit](
+                                            size_t batch_key,
+                                            int64_t rg_offset,
+                                            int64_t total_rg_count,
+                                            int64_t reader_memory_limit) {
+        if (batch_key == 0) {
+            small_batch_reader_limit.store(reader_memory_limit);
+        } else if (batch_key == 1) {
+            oversized_batch_reader_limit.store(reader_memory_limit);
+        }
+        return delegate(
+            batch_key, rg_offset, total_rg_count, reader_memory_limit);
+    };
+
+    auto futures = LoadCellBatchAsync(nullptr,
+                                      std::move(specs),
+                                      std::move(reader_factory),
+                                      kBatchTarget,
+                                      milvus::proto::common::LoadPriority::HIGH,
+                                      MakeMockCellFinalizer());
+    CollectLoadedCells(futures);
+
+    ASSERT_EQ(futures.size(), 2);
+    EXPECT_EQ(small_batch_reader_limit.load(), 8 * MB);
+    EXPECT_EQ(oversized_batch_reader_limit.load(), kBatchTarget);
+}
 
 TEST(LoadCellBatchAsync, MemoryBasedSplit) {
     // 10 cells x 64MB each, limit=128MB -> 5 batches (2 cells each)
@@ -306,13 +371,102 @@ TEST(LoadCellBatchAsync, ContiguityBreak) {
 }
 
 TEST(LoadCellBatchAsync, EmptyCells) {
-    auto channel = std::make_shared<CellReaderChannel>(64);
-    auto futures = LoadCellBatchAsync(
-        nullptr, {}, MakeMockReaderFactory(), channel, 128 << 20);
+    auto futures = LoadCellBatchAsync(nullptr,
+                                      {},
+                                      MakeMockReaderFactory(),
+                                      128 << 20,
+                                      milvus::proto::common::LoadPriority::HIGH,
+                                      MakeMockCellFinalizer());
     EXPECT_EQ(futures.size(), 0);
 }
 
-TEST(LoadCellBatchAsync, CancellationStopsMidBatchPush) {
+TEST(LoadCellBatchAsync, FinalizesCellsBeforeFutureCompletion) {
+    constexpr int64_t MB = 1 << 20;
+    std::vector<CellSpec> specs = {
+        {0, 0, 0, 1, 8 * MB},
+        {1, 0, 1, 1, 8 * MB},
+    };
+
+    std::atomic<int> finalized{0};
+    auto futures = LoadCellBatchAsync(
+        nullptr,
+        std::move(specs),
+        MakeMockReaderFactory(),
+        32 * MB,
+        milvus::proto::common::LoadPriority::HIGH,
+        [&finalized](const std::vector<std::shared_ptr<arrow::Table>>& tables,
+                     int64_t /*cid*/) {
+            EXPECT_EQ(tables.size(), 1);
+            finalized.fetch_add(1);
+            return std::make_unique<milvus::GroupChunk>();
+        });
+
+    auto loaded_cells = CollectLoadedCells(futures);
+    ASSERT_EQ(loaded_cells.size(), 2);
+    EXPECT_EQ(finalized.load(), 2);
+    EXPECT_NE(loaded_cells[0].chunk, nullptr);
+    EXPECT_NE(loaded_cells[1].chunk, nullptr);
+}
+
+TEST(LoadCellBatchAsync, CompletedBatchDoesNotRequireResultConsumer) {
+    std::vector<CellSpec> specs = {
+        {0, 0, 0, 1, 1},
+        {1, 0, 1, 1, 1},
+    };
+
+    auto futures = LoadCellBatchAsync(nullptr,
+                                      std::move(specs),
+                                      MakeMockReaderFactory(),
+                                      2,
+                                      milvus::proto::common::LoadPriority::HIGH,
+                                      MakeMockCellFinalizer());
+    ASSERT_EQ(futures.size(), 1);
+    EXPECT_EQ(futures[0].wait_for(std::chrono::milliseconds(100)),
+              std::future_status::ready);
+    EXPECT_EQ(futures[0].get().size(), 2);
+}
+
+TEST(LoadCellBatchAsync, ReleasesArrowTablesBeforeFutureCompletion) {
+    std::weak_ptr<arrow::Table> loaded_table;
+    BatchReaderFactory factory = [&loaded_table](
+                                     size_t, int64_t, int64_t, int64_t)
+        -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
+        auto schema = arrow::schema({arrow::field("x", arrow::int64())});
+        auto table = arrow::Table::MakeEmpty(schema).ValueOrDie();
+        loaded_table = table;
+        return std::vector<std::shared_ptr<arrow::Table>>{std::move(table)};
+    };
+
+    auto futures = LoadCellBatchAsync(nullptr,
+                                      {{0, 0, 0, 1, 1}},
+                                      std::move(factory),
+                                      1,
+                                      milvus::proto::common::LoadPriority::HIGH,
+                                      MakeMockCellFinalizer());
+
+    ASSERT_EQ(futures.size(), 1);
+    auto loaded_cells = futures[0].get();
+    ASSERT_EQ(loaded_cells.size(), 1);
+    EXPECT_TRUE(loaded_table.expired());
+}
+
+TEST(LoadCellBatchAsync, FinalizerFailurePropagatesThroughFuture) {
+    auto futures =
+        LoadCellBatchAsync(nullptr,
+                           {{0, 0, 0, 1, 1}},
+                           MakeMockReaderFactory(),
+                           1,
+                           milvus::proto::common::LoadPriority::HIGH,
+                           [](const std::vector<std::shared_ptr<arrow::Table>>&,
+                              int64_t) -> std::unique_ptr<milvus::GroupChunk> {
+                               throw std::runtime_error("finalize failed");
+                           });
+
+    ASSERT_EQ(futures.size(), 1);
+    EXPECT_THROW(futures[0].get(), std::runtime_error);
+}
+
+TEST(LoadCellBatchAsync, CancellationStopsMidBatchFinalize) {
     constexpr int64_t MB = 1 << 20;
     std::vector<CellSpec> specs = {
         {0, 0, 0, 1, 8 * MB},
@@ -323,24 +477,22 @@ TEST(LoadCellBatchAsync, CancellationStopsMidBatchPush) {
 
     folly::CancellationSource source;
     milvus::OpContext op_ctx(source.getToken());
-    auto channel = std::make_shared<CellReaderChannel>(1);
+    std::atomic<size_t> finalized{0};
     auto futures = LoadCellBatchAsync(
-        &op_ctx, specs, MakeMockReaderFactory(), channel, 128 * MB);
+        &op_ctx,
+        specs,
+        MakeMockReaderFactory(),
+        128 * MB,
+        milvus::proto::common::LoadPriority::HIGH,
+        [&source, &finalized](const std::vector<std::shared_ptr<arrow::Table>>&,
+                              int64_t) {
+            if (finalized.fetch_add(1) == 0) {
+                source.requestCancellation();
+            }
+            return std::make_unique<milvus::GroupChunk>();
+        });
 
     ASSERT_EQ(futures.size(), 1);
-
-    std::shared_ptr<CellLoadResult> cell_data;
-    ASSERT_TRUE(channel->pop(cell_data));
-    ASSERT_NE(cell_data, nullptr);
-    EXPECT_EQ(cell_data->cid, 0);
-
-    source.requestCancellation();
-
-    size_t received = 1;
-    while (channel->pop(cell_data)) {
-        ASSERT_NE(cell_data, nullptr);
-        ++received;
-    }
 
     try {
         futures[0].get();
@@ -348,5 +500,5 @@ TEST(LoadCellBatchAsync, CancellationStopsMidBatchPush) {
     } catch (const milvus::SegcoreError& e) {
         EXPECT_EQ(e.get_error_code(), milvus::ErrorCode::FollyCancel);
     }
-    EXPECT_LT(received, specs.size());
+    EXPECT_LT(finalized.load(), specs.size());
 }

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -16,8 +16,8 @@
 #include "segcore/memory_planner.h"
 
 #include <algorithm>
-#include <atomic>
 #include <cstddef>
+#include <exception>
 #include <future>
 #include <memory>
 #include <numeric>
@@ -250,15 +250,14 @@ LoadWithStrategy(const std::vector<std::string>& remote_files,
     }
 }
 
-std::vector<std::future<void>>
+std::vector<CellLoadFuture>
 LoadCellBatchAsync(milvus::OpContext* op_ctx,
                    std::vector<CellSpec> cell_specs,
                    BatchReaderFactory reader_factory,
-                   std::shared_ptr<CellReaderChannel>& channel,
                    int64_t memory_limit,
-                   milvus::proto::common::LoadPriority priority) {
+                   milvus::proto::common::LoadPriority priority,
+                   CellFinalizeFunc finalize_cell) {
     if (cell_specs.empty()) {
-        channel->close();
         return {};
     }
 
@@ -329,76 +328,85 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
         memory_limit >> 20);
 
     if (batches.empty()) {
-        channel->close();
         return {};
     }
 
     auto& pool = ThreadPools::GetThreadPool(milvus::PriorityForLoad(priority));
-    auto remaining = std::make_shared<std::atomic<size_t>>(batches.size());
-    auto reader_memory_limit =
-        std::max<int64_t>(memory_limit / static_cast<int64_t>(batches.size()),
-                          FILE_SLICE_SIZE.load());
     auto shared_factory =
         std::make_shared<BatchReaderFactory>(std::move(reader_factory));
+    auto shared_finalizer =
+        std::make_shared<CellFinalizeFunc>(std::move(finalize_cell));
+    AssertInfo(static_cast<bool>(*shared_finalizer),
+               "[StorageV2] LoadCellBatchAsync requires a cell finalizer");
 
-    std::vector<std::future<void>> futures;
+    std::vector<CellLoadFuture> futures;
     futures.reserve(batches.size());
 
+    auto append_failed_future = [&futures](std::exception_ptr error) {
+        std::promise<LoadedCellBatch> promise;
+        futures.emplace_back(promise.get_future());
+        promise.set_exception(std::move(error));
+    };
+
     for (auto& batch : batches) {
-        futures.emplace_back(pool.Submit([batch = std::move(batch),
-                                          shared_factory,
-                                          reader_memory_limit,
-                                          channel,
-                                          remaining,
-                                          op_ctx]() {
-            auto task_guard = folly::makeGuard([&channel, &remaining]() {
-                if (remaining->fetch_sub(1) == 1) {
-                    channel->close();
-                }
-            });
-            CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
-
-            auto tables_result = (*shared_factory)(batch.file_idx,
-                                                   batch.rg_offset,
-                                                   batch.rg_count,
-                                                   reader_memory_limit);
-            AssertInfo(tables_result.ok(),
-                       "[StorageV2] Failed to read batch: " +
-                           tables_result.status().ToString());
-            auto all_tables = std::move(tables_result).ValueOrDie();
-            AssertInfo(all_tables.size() == static_cast<size_t>(batch.rg_count),
-                       "reader returns less tables than expected, batch rg "
-                       "count: {}, result size: {}",
-                       batch.rg_count,
-                       all_tables.size());
-            CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
-
-            int64_t table_offset = 0;
-            for (const auto& cell : batch.cells) {
+        const auto reader_memory_limit =
+            std::max<int64_t>(1, std::min(batch.batch_memory, memory_limit));
+        try {
+            futures.emplace_back(pool.Submit([batch = std::move(batch),
+                                              shared_factory,
+                                              reader_memory_limit,
+                                              shared_finalizer,
+                                              op_ctx]() mutable {
                 CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
-                auto cell_result = std::make_shared<CellLoadResult>();
-                cell_result->cid = cell.cid;
-                cell_result->tables.reserve(cell.rg_count);
-                for (int64_t i = 0; i < cell.rg_count; ++i) {
-                    cell_result->tables.push_back(
-                        std::move(all_tables[table_offset + i]));
+
+                auto tables_result = (*shared_factory)(batch.file_idx,
+                                                       batch.rg_offset,
+                                                       batch.rg_count,
+                                                       reader_memory_limit);
+                AssertInfo(tables_result.ok(),
+                           "[StorageV2] Failed to read batch: " +
+                               tables_result.status().ToString());
+                auto all_tables = std::move(tables_result).ValueOrDie();
+                AssertInfo(
+                    all_tables.size() == static_cast<size_t>(batch.rg_count),
+                    "reader returns less tables than expected, batch rg "
+                    "count: {}, result size: {}",
+                    batch.rg_count,
+                    all_tables.size());
+                CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
+
+                int64_t table_offset = 0;
+                LoadedCellBatch loaded_cells;
+                loaded_cells.reserve(batch.cells.size());
+                for (const auto& cell : batch.cells) {
+                    CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
+                    std::vector<std::shared_ptr<arrow::Table>> cell_tables;
+                    cell_tables.reserve(cell.rg_count);
+                    for (int64_t i = 0; i < cell.rg_count; ++i) {
+                        cell_tables.push_back(
+                            std::move(all_tables[table_offset + i]));
+                    }
+                    table_offset += cell.rg_count;
+                    auto chunk = (*shared_finalizer)(cell_tables, cell.cid);
+                    cell_tables.clear();
+                    CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
+                    loaded_cells.push_back({cell.cid, std::move(chunk)});
                 }
-                table_offset += cell.rg_count;
-                channel->push(std::move(cell_result));
-            }
-        }));
+                return loaded_cells;
+            }));
+        } catch (...) {
+            append_failed_future(std::current_exception());
+        }
     }
 
     return futures;
 }
 
 size_t
-GetCellReaderChannelCapacity(
-    milvus::proto::common::LoadPriority load_priority) {
+GetCellBatchConcurrency(milvus::proto::common::LoadPriority load_priority) {
     auto& pool =
         ThreadPools::GetThreadPool(milvus::PriorityForLoad(load_priority));
-    return std::max<size_t>(1,
-                            static_cast<size_t>(pool.GetMaxThreadNum() * 1.5));
+    return std::max<size_t>(1, pool.GetMaxThreadNum());
 }
 
 BatchReaderFactory

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -392,6 +392,15 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
     return futures;
 }
 
+size_t
+GetCellReaderChannelCapacity(
+    milvus::proto::common::LoadPriority load_priority) {
+    auto& pool =
+        ThreadPools::GetThreadPool(milvus::PriorityForLoad(load_priority));
+    return std::max<size_t>(1,
+                            static_cast<size_t>(pool.GetMaxThreadNum() * 1.5));
+}
+
 BatchReaderFactory
 MakeFileReaderFactory(std::vector<std::string> remote_files,
                       milvus_storage::ArrowFileSystemPtr fs) {

--- a/internal/core/src/segcore/memory_planner.h
+++ b/internal/core/src/segcore/memory_planner.h
@@ -120,6 +120,9 @@ struct CellLoadResult {
 
 using CellReaderChannel = milvus::Channel<std::shared_ptr<CellLoadResult>>;
 
+size_t
+GetCellReaderChannelCapacity(milvus::proto::common::LoadPriority load_priority);
+
 // Creates a batch reader for a range of contiguous row groups.
 // Returns all row groups as a vector of tables in one call.
 // batch_key: grouping key (file_idx for files, 0 for single reader)

--- a/internal/core/src/segcore/memory_planner.h
+++ b/internal/core/src/segcore/memory_planner.h
@@ -28,6 +28,7 @@
 
 #include "common/Channel.h"
 #include "common/FieldData.h"
+#include "common/GroupChunk.h"
 #include "common/OpContext.h"
 #include "milvus-storage/common/metadata.h"
 #include "milvus-storage/filesystem/fs.h"
@@ -103,6 +104,9 @@ LoadWithStrategy(const std::vector<std::string>& remote_files,
 
 // ---- Cell-batch loading ----
 
+constexpr int64_t kDefaultFieldDataLoadBatchTargetBytes =
+    DEFAULT_FIELD_MAX_MEMORY_LIMIT / 8;
+
 // A cell specification: identifies a cell's location within a specific file.
 struct CellSpec {
     int64_t cid;              // cell id
@@ -112,16 +116,13 @@ struct CellSpec {
     int64_t memory_size = 0;  // estimated Arrow memory in bytes; 0 = unknown
 };
 
-// Result of loading a single cell: cid + the arrow tables read.
-struct CellLoadResult {
+struct LoadedCell {
     int64_t cid;
-    std::vector<std::shared_ptr<arrow::Table>> tables;
+    std::unique_ptr<milvus::GroupChunk> chunk;
 };
 
-using CellReaderChannel = milvus::Channel<std::shared_ptr<CellLoadResult>>;
-
-size_t
-GetCellReaderChannelCapacity(milvus::proto::common::LoadPriority load_priority);
+using LoadedCellBatch = std::vector<LoadedCell>;
+using CellLoadFuture = std::future<LoadedCellBatch>;
 
 // Creates a batch reader for a range of contiguous row groups.
 // Returns all row groups as a vector of tables in one call.
@@ -136,28 +137,34 @@ using BatchReaderFactory =
         int64_t total_rg_count,
         int64_t reader_memory_limit)>;
 
+using CellFinalizeFunc = std::function<std::unique_ptr<milvus::GroupChunk>(
+    const std::vector<std::shared_ptr<arrow::Table>>& tables, int64_t cid)>;
+
 /**
  * Load cells in batches using a pluggable reader factory. Cells are sorted by
  * (file_idx, local_rg_offset) and grouped into IO-merged batches.
- * Each completed cell is pushed to the channel immediately, enabling
- * streaming consumption without accumulating all ArrowTables.
+ * Each load-pool worker reads and finalizes its batch before returning the
+ * completed cells in the batch future. This bounds concurrent batch data by
+ * the load-pool worker count without a separate result queue.
  *
  * @param op_ctx operation context for cancellation
  * @param cell_specs cell specifications (sorted internally)
  * @param reader_factory factory that reads all row groups for a batch
- * @param channel channel to receive loaded cell data; closed when all done
- * @param memory_limit total memory limit for readers
+ * @param memory_limit target memory size for each batch
  * @param priority load priority
- * @return vector of futures for the batch loading tasks
+ * @param finalize_cell converts a cell's Arrow tables into its final chunk
+ * @return futures containing finalized cells for each batch
  */
-std::vector<std::future<void>>
+std::vector<CellLoadFuture>
 LoadCellBatchAsync(milvus::OpContext* op_ctx,
                    std::vector<CellSpec> cell_specs,
                    BatchReaderFactory reader_factory,
-                   std::shared_ptr<CellReaderChannel>& channel,
                    int64_t memory_limit,
-                   milvus::proto::common::LoadPriority priority =
-                       milvus::proto::common::LoadPriority::HIGH);
+                   milvus::proto::common::LoadPriority priority,
+                   CellFinalizeFunc finalize_cell);
+
+size_t
+GetCellBatchConcurrency(milvus::proto::common::LoadPriority load_priority);
 
 /**
  * Creates a BatchReaderFactory that reads from Parquet files via FileRowGroupReader.

--- a/internal/core/src/segcore/segcore_init_c.cpp
+++ b/internal/core/src/segcore/segcore_init_c.cpp
@@ -259,42 +259,46 @@ ConfigureTieredStorage(const CacheWarmupPolicy scalarFieldCacheWarmupPolicy,
                        const float max_disk_usage_percentage,
                        const char* disk_path,
                        const int64_t loading_timeout_ms,
-                       const int64_t warmup_loading_timeout_ms) {
+                       const int64_t warmup_loading_timeout_ms,
+                       const double max_loading_memory_ratio) {
     std::string disk_path_str(disk_path);
-    milvus::cachinglayer::Manager::ConfigureTieredStorage(
-        {scalarFieldCacheWarmupPolicy,
-         vectorFieldCacheWarmupPolicy,
-         scalarIndexCacheWarmupPolicy,
-         vectorIndexCacheWarmupPolicy},
-        {memory_low_watermark_bytes,
-         memory_high_watermark_bytes,
-         memory_max_bytes,
-         disk_low_watermark_bytes,
-         disk_high_watermark_bytes,
-         disk_max_bytes},
-        storage_usage_tracking_enabled,
-        eviction_enabled,
-        {cache_touch_window_ms,
-         background_eviction_enabled,
-         eviction_interval_ms,
-         cache_cell_unaccessed_survival_time,
-         overloaded_memory_threshold_percentage,
-         max_disk_usage_percentage,
-         std::move(disk_path_str),
-         loading_resource_factor},
-        std::chrono::milliseconds(loading_timeout_ms),
-        std::chrono::milliseconds(warmup_loading_timeout_ms));
+    milvus::cachinglayer::TieredStorageOptions options;
+    options.warmup_policies = {scalarFieldCacheWarmupPolicy,
+                               vectorFieldCacheWarmupPolicy,
+                               scalarIndexCacheWarmupPolicy,
+                               vectorIndexCacheWarmupPolicy};
+    options.cache_limit = {memory_low_watermark_bytes,
+                           memory_high_watermark_bytes,
+                           memory_max_bytes,
+                           disk_low_watermark_bytes,
+                           disk_high_watermark_bytes,
+                           disk_max_bytes};
+    options.storage_usage_tracking_enabled = storage_usage_tracking_enabled;
+    options.eviction_enabled = eviction_enabled;
+    options.eviction_config = {cache_touch_window_ms,
+                               background_eviction_enabled,
+                               eviction_interval_ms,
+                               cache_cell_unaccessed_survival_time,
+                               overloaded_memory_threshold_percentage,
+                               max_disk_usage_percentage,
+                               std::move(disk_path_str),
+                               loading_resource_factor};
+    options.loading_timeout = std::chrono::milliseconds(loading_timeout_ms);
+    options.warmup_loading_timeout =
+        std::chrono::milliseconds(warmup_loading_timeout_ms);
+    options.max_loading_mem_ratio = max_loading_memory_ratio;
+    milvus::cachinglayer::Manager::ConfigureTieredStorage(options);
 }
 
 extern "C" void
-UpdateTieredStorageConfig(
-    const int64_t loading_timeout_ms,
-    const int64_t warmup_loading_timeout_ms,
-    const bool storage_usage_tracking_enabled,
-    const CacheWarmupPolicy scalarFieldCacheWarmupPolicy,
-    const CacheWarmupPolicy vectorFieldCacheWarmupPolicy,
-    const CacheWarmupPolicy scalarIndexCacheWarmupPolicy,
-    const CacheWarmupPolicy vectorIndexCacheWarmupPolicy) {
+UpdateTieredStorageConfig(const int64_t loading_timeout_ms,
+                          const int64_t warmup_loading_timeout_ms,
+                          const bool storage_usage_tracking_enabled,
+                          const CacheWarmupPolicy scalarFieldCacheWarmupPolicy,
+                          const CacheWarmupPolicy vectorFieldCacheWarmupPolicy,
+                          const CacheWarmupPolicy scalarIndexCacheWarmupPolicy,
+                          const CacheWarmupPolicy vectorIndexCacheWarmupPolicy,
+                          const double max_loading_memory_ratio) {
     milvus::cachinglayer::Manager::UpdateConfig(
         std::chrono::milliseconds(loading_timeout_ms),
         std::chrono::milliseconds(warmup_loading_timeout_ms),
@@ -302,7 +306,8 @@ UpdateTieredStorageConfig(
         {scalarFieldCacheWarmupPolicy,
          vectorFieldCacheWarmupPolicy,
          scalarIndexCacheWarmupPolicy,
-         vectorIndexCacheWarmupPolicy});
+         vectorIndexCacheWarmupPolicy},
+        max_loading_memory_ratio);
 }
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/segcore_init_c.h
+++ b/internal/core/src/segcore/segcore_init_c.h
@@ -135,7 +135,8 @@ ConfigureTieredStorage(
     const float max_disk_usage_percentage,
     const char* disk_path,
     const int64_t loading_timeout_ms,
-    const int64_t warmup_loading_timeout_ms);
+    const int64_t warmup_loading_timeout_ms,
+    const double max_loading_memory_ratio);
 
 void
 UpdateTieredStorageConfig(const int64_t loading_timeout_ms,
@@ -144,7 +145,8 @@ UpdateTieredStorageConfig(const int64_t loading_timeout_ms,
                           const CacheWarmupPolicy scalarFieldCacheWarmupPolicy,
                           const CacheWarmupPolicy vectorFieldCacheWarmupPolicy,
                           const CacheWarmupPolicy scalarIndexCacheWarmupPolicy,
-                          const CacheWarmupPolicy vectorIndexCacheWarmupPolicy);
+                          const CacheWarmupPolicy vectorIndexCacheWarmupPolicy,
+                          const double max_loading_memory_ratio);
 
 #ifdef __cplusplus
 }

--- a/internal/core/src/segcore/storagev1translator/ChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/ChunkTranslator.cpp
@@ -133,18 +133,26 @@ ChunkTranslator::cell_id_of(milvus::cachinglayer::uid_t uid) const {
 
 std::pair<milvus::cachinglayer::ResourceUsage,
           milvus::cachinglayer::ResourceUsage>
-ChunkTranslator::estimated_byte_size_of_cell(
-    milvus::cachinglayer::cid_t cid) const {
-    AssertInfo(cid < file_infos_.size(), "cid out of range");
+ChunkTranslator::estimated_loading_usage(
+    const std::vector<milvus::cachinglayer::cid_t>& cids) const {
+    milvus::cachinglayer::ResourceUsage loaded_usage;
+    milvus::cachinglayer::ResourceUsage loading_usage;
+    for (const auto cid : cids) {
+        AssertInfo(cid < file_infos_.size(), "cid out of range");
 
-    int64_t memory_size = file_infos_[cid].memory_size;
-    if (use_mmap_) {
-        // For mmap, the memory is counted as disk usage
-        return {{0, memory_size}, {memory_size * 2, memory_size * 2}};
-    } else {
-        // For non-mmap, the memory is counted as memory usage
-        return {{memory_size, 0}, {memory_size * 2, 0}};
+        const auto memory_size = file_infos_[cid].memory_size;
+        if (use_mmap_) {
+            // For mmap, the memory is counted as disk usage.
+            loaded_usage.file_bytes += memory_size;
+            loading_usage.memory_bytes += memory_size * 2;
+            loading_usage.file_bytes += memory_size * 2;
+        } else {
+            // For non-mmap, the memory is counted as memory usage.
+            loaded_usage.memory_bytes += memory_size;
+            loading_usage.memory_bytes += memory_size * 2;
+        }
     }
+    return {loaded_usage, loading_usage};
 }
 
 const std::string&

--- a/internal/core/src/segcore/storagev1translator/ChunkTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/ChunkTranslator.h
@@ -74,7 +74,8 @@ class ChunkTranslator : public milvus::cachinglayer::Translator<milvus::Chunk> {
     cell_id_of(milvus::cachinglayer::uid_t uid) const override;
     std::pair<milvus::cachinglayer::ResourceUsage,
               milvus::cachinglayer::ResourceUsage>
-    estimated_byte_size_of_cell(milvus::cachinglayer::cid_t cid) const override;
+    estimated_loading_usage(
+        const std::vector<milvus::cachinglayer::cid_t>& cids) const override;
     const std::string&
     key() const override;
     std::vector<

--- a/internal/core/src/segcore/storagev1translator/DefaultValueChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/DefaultValueChunkTranslator.cpp
@@ -18,6 +18,25 @@
 #include "storage/Util.h"
 
 namespace milvus::segcore::storagev1translator {
+namespace {
+
+milvus::cachinglayer::ResourceUsage
+BufferResourceUsage(const milvus::ChunkBuffer& buffer) {
+    const auto size = static_cast<int64_t>(buffer.size);
+    if (buffer.guard && buffer.guard->is_file_backed()) {
+        return {0, size};
+    }
+    return {size, 0};
+}
+
+void
+AddUsage(milvus::cachinglayer::ResourceUsage& total,
+         const milvus::cachinglayer::ResourceUsage& usage) {
+    total.memory_bytes = SaturatingAdd(total.memory_bytes, usage.memory_bytes);
+    total.file_bytes = SaturatingAdd(total.file_bytes, usage.file_bytes);
+}
+
+}  // namespace
 
 DefaultValueChunkTranslator::DefaultValueChunkTranslator(
     int64_t segment_id,
@@ -189,20 +208,30 @@ DefaultValueChunkTranslator::value_size() const {
 
 std::pair<milvus::cachinglayer::ResourceUsage,
           milvus::cachinglayer::ResourceUsage>
-DefaultValueChunkTranslator::estimated_byte_size_of_cell(
-    milvus::cachinglayer::cid_t cid) const {
-    // TODO: actually only the first cell is used, other cells share the same buffer,
-    // but for now we estimate the same size for all cells
-    auto value_size = this->value_size();
-    auto rows_begin = meta_.num_rows_until_chunk_[cid];
-    auto rows_end = meta_.num_rows_until_chunk_[cid + 1];
-    auto rows = rows_end - rows_begin;
-    auto cell_bytes = value_size * rows;
-    if (use_mmap_) {
-        return {{0, cell_bytes}, {0, cell_bytes}};
-    } else {
-        return {{cell_bytes, 0}, {cell_bytes, 0}};
+DefaultValueChunkTranslator::estimated_loading_usage(
+    const std::vector<milvus::cachinglayer::cid_t>& cids) const {
+    if (cids.empty()) {
+        return {};
     }
+
+    for (const auto cid : cids) {
+        AssertInfo(cid + 1 < meta_.num_rows_until_chunk_.size(),
+                   "cid out of range");
+    }
+
+    // Both buffers are built with the translator and remain alive regardless
+    // of which cell is requested. Cells are non-evictable, so the first loaded
+    // cell can own each backing buffer's cache charge for the slot lifetime.
+    milvus::cachinglayer::ResourceUsage usage;
+    if (primary_buffer_.has_value() &&
+        !primary_buffer_accounted_.load(std::memory_order_acquire)) {
+        AddUsage(usage, BufferResourceUsage(primary_buffer_.value()));
+    }
+    if (tail_buffer_.has_value() &&
+        !tail_buffer_accounted_.load(std::memory_order_acquire)) {
+        AddUsage(usage, BufferResourceUsage(tail_buffer_.value()));
+    }
+    return {usage, usage};
 }
 
 const std::string&
@@ -293,7 +322,27 @@ DefaultValueChunkTranslator::get_cells(
                     field_meta_, primary_buffer_.value(), 0);
             }
         }
+        // Every view defaults to zero charge. One stable, non-evictable owner
+        // below reports the shared backing buffer's actual resource usage.
+        chunk->SetCellSize({});
         res.emplace_back(cid, std::move(chunk));
+    }
+
+    if (res.empty()) {
+        return res;
+    }
+
+    milvus::cachinglayer::ResourceUsage owned_usage;
+    if (primary_buffer_.has_value() &&
+        !primary_buffer_accounted_.exchange(true, std::memory_order_acq_rel)) {
+        AddUsage(owned_usage, BufferResourceUsage(primary_buffer_.value()));
+    }
+    if (tail_buffer_.has_value() &&
+        !tail_buffer_accounted_.exchange(true, std::memory_order_acq_rel)) {
+        AddUsage(owned_usage, BufferResourceUsage(tail_buffer_.value()));
+    }
+    if (owned_usage.AnyGTZero()) {
+        res.front().second->SetCellSize(owned_usage);
     }
 
     return res;

--- a/internal/core/src/segcore/storagev1translator/DefaultValueChunkTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/DefaultValueChunkTranslator.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <string>
 #include <vector>
 #include <optional>
@@ -45,7 +46,8 @@ class DefaultValueChunkTranslator
     cell_id_of(milvus::cachinglayer::uid_t uid) const override;
     std::pair<milvus::cachinglayer::ResourceUsage,
               milvus::cachinglayer::ResourceUsage>
-    estimated_byte_size_of_cell(milvus::cachinglayer::cid_t cid) const override;
+    estimated_loading_usage(
+        const std::vector<milvus::cachinglayer::cid_t>& cids) const override;
     const std::string&
     key() const override;
     std::vector<
@@ -84,10 +86,12 @@ class DefaultValueChunkTranslator
 
     // Shared chunk buffer for primary cells (all have primary_cell_rows_).
     std::optional<milvus::ChunkBuffer> primary_buffer_;
+    mutable std::atomic<bool> primary_buffer_accounted_{false};
 
     // Separate buffer for tail cell if it has different row count.
     // Only used for variable-length types where buffer layout depends on row count.
     std::optional<milvus::ChunkBuffer> tail_buffer_;
+    mutable std::atomic<bool> tail_buffer_accounted_{false};
     int64_t tail_cell_rows_{0};
 
     // Whether this field type can share buffers across cells with different

--- a/internal/core/src/segcore/storagev1translator/DefaultValueChunkTranslatorTest.cpp
+++ b/internal/core/src/segcore/storagev1translator/DefaultValueChunkTranslatorTest.cpp
@@ -13,7 +13,11 @@
 #include <fmt/core.h>
 #include <filesystem>
 #include <memory>
+#include <numeric>
 #include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include "common/Chunk.h"
 #include "common/FieldMeta.h"
@@ -83,8 +87,8 @@ TEST_P(DefaultValueChunkTranslatorTest, TestInt64WithDefaultValue) {
         EXPECT_EQ(translator->cell_id_of(i), i);
     }
 
-    // Test estimated_byte_size_of_cell
-    auto [usage, peak_usage] = translator->estimated_byte_size_of_cell(0);
+    // Test estimated_loading_usage
+    auto [usage, peak_usage] = translator->estimated_loading_usage({0});
     if (use_mmap) {
         EXPECT_GT(usage.file_bytes, 0);
     } else {
@@ -542,7 +546,7 @@ TEST_P(DefaultValueChunkTranslatorTest, TestZeroRows) {
     EXPECT_EQ(translator->num_cells(), 0);
 }
 
-// Test estimated_byte_size_of_cell for different cell indices
+// Test estimated_loading_usage for different cell indices
 TEST_P(DefaultValueChunkTranslatorTest, TestEstimatedByteSizeMultipleCells) {
     bool use_mmap = GetParam();
     int64_t row_count = 5000000;  // Ensure multiple cells
@@ -563,8 +567,7 @@ TEST_P(DefaultValueChunkTranslatorTest, TestEstimatedByteSizeMultipleCells) {
     size_t num_cells = translator->num_cells();
     if (num_cells > 1) {
         for (size_t i = 0; i < num_cells; ++i) {
-            auto [usage, peak_usage] =
-                translator->estimated_byte_size_of_cell(i);
+            auto [usage, peak_usage] = translator->estimated_loading_usage({i});
             if (use_mmap) {
                 EXPECT_GT(usage.file_bytes, 0);
             } else {
@@ -572,6 +575,65 @@ TEST_P(DefaultValueChunkTranslatorTest, TestEstimatedByteSizeMultipleCells) {
             }
         }
     }
+}
+
+TEST_P(DefaultValueChunkTranslatorTest, AccountsSharedBuffersOnce) {
+    const bool use_mmap = GetParam();
+    const std::string default_string = "shared_default_value";
+    const int64_t rows_per_cell =
+        DefaultValueChunkTranslator::kTargetCellBytes /
+        (default_string.size() + 1);
+    const int64_t row_count = rows_per_cell * 3 + rows_per_cell / 2;
+
+    DefaultValueType value_field;
+    value_field.set_string_data(default_string);
+    FieldMeta field_meta(FieldName("shared_buffer_accounting"),
+                         FieldId(1102),
+                         DataType::STRING,
+                         false,
+                         value_field);
+    FieldDataInfo field_data_info(1102, row_count, getMmapDirPath());
+    auto translator = std::make_unique<DefaultValueChunkTranslator>(
+        segment_id_, field_meta, field_data_info, use_mmap, true);
+
+    std::vector<cachinglayer::cid_t> cids(translator->num_cells());
+    std::iota(cids.begin(), cids.end(), 0);
+    const auto tail_cid = cids.back();
+    const auto [estimated, estimated_peak] =
+        translator->estimated_loading_usage({tail_cid});
+    auto cells = translator->get_cells(nullptr, {tail_cid});
+    cids.pop_back();
+    auto remaining_cells = translator->get_cells(nullptr, cids);
+    for (auto& cell : remaining_cells) {
+        cells.emplace_back(std::move(cell));
+    }
+
+    int64_t unique_buffer_bytes = 0;
+    int64_t charged_memory_bytes = 0;
+    int64_t charged_file_bytes = 0;
+    std::unordered_set<const char*> seen_buffers;
+    for (const auto& [cid, chunk] : cells) {
+        if (seen_buffers.insert(chunk->RawData()).second) {
+            unique_buffer_bytes += chunk->Size();
+        }
+        const auto charged = chunk->CellByteSize();
+        charged_memory_bytes += charged.memory_bytes;
+        charged_file_bytes += charged.file_bytes;
+    }
+    ASSERT_EQ(seen_buffers.size(), 2);
+
+    if (use_mmap) {
+        EXPECT_EQ(estimated,
+                  (cachinglayer::ResourceUsage{0, unique_buffer_bytes}));
+        EXPECT_EQ(charged_memory_bytes, 0);
+        EXPECT_EQ(charged_file_bytes, unique_buffer_bytes);
+    } else {
+        EXPECT_EQ(estimated,
+                  (cachinglayer::ResourceUsage{unique_buffer_bytes, 0}));
+        EXPECT_EQ(charged_memory_bytes, unique_buffer_bytes);
+        EXPECT_EQ(charged_file_bytes, 0);
+    }
+    EXPECT_EQ(estimated_peak, estimated);
 }
 
 // Parameterized test with both mmap modes

--- a/internal/core/src/segcore/storagev1translator/InterimSealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/InterimSealedIndexTranslator.cpp
@@ -72,8 +72,11 @@ InterimSealedIndexTranslator::cell_id_of(
 
 std::pair<milvus::cachinglayer::ResourceUsage,
           milvus::cachinglayer::ResourceUsage>
-InterimSealedIndexTranslator::estimated_byte_size_of_cell(
-    milvus::cachinglayer::cid_t cid) const {
+InterimSealedIndexTranslator::estimated_loading_usage(
+    const std::vector<milvus::cachinglayer::cid_t>& cids) const {
+    if (cids.empty()) {
+        return {};
+    }
     int64_t size = vec_data_->DataByteSize();
     int64_t row_count = vec_data_->NumRows();
     // TODO: hack, move these estimate logic to knowhere

--- a/internal/core/src/segcore/storagev1translator/InterimSealedIndexTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/InterimSealedIndexTranslator.h
@@ -38,7 +38,8 @@ class InterimSealedIndexTranslator
     cell_id_of(milvus::cachinglayer::uid_t uid) const override;
     std::pair<milvus::cachinglayer::ResourceUsage,
               milvus::cachinglayer::ResourceUsage>
-    estimated_byte_size_of_cell(milvus::cachinglayer::cid_t cid) const override;
+    estimated_loading_usage(
+        const std::vector<milvus::cachinglayer::cid_t>& cids) const override;
     const std::string&
     key() const override;
     std::vector<std::pair<milvus::cachinglayer::cid_t,

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
@@ -44,6 +44,7 @@ SealedIndexTranslator::SealedIndexTranslator(
                         std::to_string(load_index_info->field_id),
                         load_index_info->num_rows,
                         load_index_info->dim,
+                        load_index_info->index_files,
                         load_index_info->warmup_policy}),
       meta_(
           load_index_info->enable_mmap
@@ -73,6 +74,25 @@ SealedIndexTranslator::SealedIndexTranslator(
                 index_info_.index_type, knowhere::feature::LAZY_LOAD))) {
 }
 
+const LoadResourceRequest&
+SealedIndexTranslator::EstimateLoadResource() const {
+    std::call_once(load_resource_request_once_, [this]() {
+        load_resource_request_ =
+            milvus::index::IndexFactory::GetInstance().IndexLoadResource(
+                index_load_info_.field_type,
+                index_load_info_.element_type,
+                index_load_info_.index_engine_version,
+                index_load_info_.index_size,
+                index_load_info_.index_params,
+                index_load_info_.enable_mmap,
+                index_load_info_.num_rows,
+                index_load_info_.dim,
+                index_load_info_.index_files,
+                file_manager_context_);
+    });
+    return load_resource_request_;
+}
+
 size_t
 SealedIndexTranslator::num_cells() const {
     return 1;
@@ -90,21 +110,30 @@ SealedIndexTranslator::estimated_loading_usage(
     if (cids.empty()) {
         return {};
     }
-    LoadResourceRequest request =
-        milvus::index::IndexFactory::GetInstance().IndexLoadResource(
-            index_load_info_.field_type,
-            index_load_info_.element_type,
-            index_load_info_.index_engine_version,
-            index_load_info_.index_size,
-            index_load_info_.index_params,
-            index_load_info_.enable_mmap,
-            index_load_info_.num_rows,
-            index_load_info_.dim);
+    const auto& load_resource_request = EstimateLoadResource();
     // this is an estimation, error could be up to 20%.
-    return {milvus::cachinglayer::ResourceUsage(request.final_memory_cost,
-                                                request.final_disk_cost),
-            milvus::cachinglayer::ResourceUsage(request.max_memory_cost,
-                                                request.max_disk_cost * 2)};
+    const auto final_usage = milvus::cachinglayer::ResourceUsage(
+        load_resource_request.final_memory_cost,
+        load_resource_request.final_disk_cost);
+    const auto peak_usage = milvus::cachinglayer::ResourceUsage(
+        load_resource_request.max_memory_cost,
+        load_resource_request.max_disk_cost);
+    LOG_INFO(
+        "estimated index loading usage: index_id={}, segment_id={}, "
+        "field_id={}, index_type={}, index_size={}, mmap={}, "
+        "final_memory_bytes={}, final_disk_bytes={}, "
+        "peak_memory_bytes={}, peak_disk_bytes={}",
+        index_load_info_.index_id,
+        index_load_info_.segment_id,
+        index_load_info_.field_id,
+        index_info_.index_type,
+        index_load_info_.index_size,
+        index_load_info_.enable_mmap,
+        final_usage.memory_bytes,
+        final_usage.file_bytes,
+        peak_usage.memory_bytes,
+        peak_usage.file_bytes);
+    return {final_usage, peak_usage};
 }
 
 const std::string&
@@ -117,22 +146,14 @@ std::vector<std::pair<milvus::cachinglayer::cid_t,
 SealedIndexTranslator::get_cells(milvus::OpContext* ctx,
                                  const std::vector<cid_t>& cids) {
     int64_t segment_id = std::stoll(index_load_info_.segment_id);
+    const auto& load_resource_request = EstimateLoadResource();
 
     std::unique_ptr<milvus::index::IndexBase> index =
         milvus::index::IndexFactory::GetInstance().CreateIndex(
             index_info_, file_manager_context_);
-    LoadResourceRequest request =
-        milvus::index::IndexFactory::GetInstance().IndexLoadResource(
-            index_load_info_.field_type,
-            index_load_info_.element_type,
-            index_load_info_.index_engine_version,
-            index_load_info_.index_size,
-            index_load_info_.index_params,
-            index_load_info_.enable_mmap,
-            index_load_info_.num_rows,
-            index_load_info_.dim);
     index->SetCellSize(milvus::cachinglayer::ResourceUsage(
-        request.final_memory_cost, request.final_disk_cost));
+        load_resource_request.final_memory_cost,
+        load_resource_request.final_disk_cost));
     if (index_load_info_.enable_mmap && index->IsMmapSupported()) {
         AssertInfo(!index_load_info_.mmap_dir_path.empty(),
                    "mmap directory path is empty");

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
@@ -85,8 +85,11 @@ SealedIndexTranslator::cell_id_of(milvus::cachinglayer::uid_t uid) const {
 
 std::pair<milvus::cachinglayer::ResourceUsage,
           milvus::cachinglayer::ResourceUsage>
-SealedIndexTranslator::estimated_byte_size_of_cell(
-    milvus::cachinglayer::cid_t cid) const {
+SealedIndexTranslator::estimated_loading_usage(
+    const std::vector<milvus::cachinglayer::cid_t>& cids) const {
+    if (cids.empty()) {
+        return {};
+    }
     LoadResourceRequest request =
         milvus::index::IndexFactory::GetInstance().IndexLoadResource(
             index_load_info_.field_type,

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.h
@@ -32,7 +32,8 @@ class SealedIndexTranslator
     cell_id_of(milvus::cachinglayer::uid_t uid) const override;
     std::pair<milvus::cachinglayer::ResourceUsage,
               milvus::cachinglayer::ResourceUsage>
-    estimated_byte_size_of_cell(milvus::cachinglayer::cid_t cid) const override;
+    estimated_loading_usage(
+        const std::vector<milvus::cachinglayer::cid_t>& cids) const override;
     const std::string&
     key() const override;
     std::vector<std::pair<milvus::cachinglayer::cid_t,

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.h
@@ -10,7 +10,9 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include <cstdint>
+#include <mutex>
 #include "cachinglayer/Translator.h"
+#include "common/resource_c.h"
 #include "index/Index.h"
 #include "segcore/ChunkedSegmentSealedImpl.h"
 
@@ -58,6 +60,9 @@ class SealedIndexTranslator
     }
 
  private:
+    const LoadResourceRequest&
+    EstimateLoadResource() const;
+
     struct IndexLoadInfo {
         bool enable_mmap;
         std::string mmap_dir_path;
@@ -71,6 +76,7 @@ class SealedIndexTranslator
         std::string field_id;
         int64_t num_rows;
         int64_t dim;
+        std::vector<std::string> index_files;
         std::string
             warmup_policy;  // "disable" or "sync", empty means use global config
     };
@@ -81,6 +87,10 @@ class SealedIndexTranslator
     Config config_;
     std::string index_key_;
     IndexLoadInfo index_load_info_;
+    // Resolve HYBRID metadata only when loading is first attempted, then reuse
+    // the same request for reservation and cell accounting.
+    mutable std::once_flag load_resource_request_once_;
+    mutable LoadResourceRequest load_resource_request_{};
     milvus::cachinglayer::Meta meta_;
 };
 }  // namespace milvus::segcore::storagev1translator

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslatorTest.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslatorTest.cpp
@@ -1,0 +1,114 @@
+// Copyright (C) 2019-2026 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <string>
+
+#include "common/Consts.h"
+#include "index/IndexInfo.h"
+#include "index/Meta.h"
+#include "segcore/Types.h"
+#include "segcore/storagev1translator/SealedIndexTranslator.h"
+#include "storage/ThreadPools.h"
+
+namespace milvus::segcore::storagev1translator {
+namespace {
+
+LoadIndexInfo
+MakeScalarLoadInfo(const IndexType& index_type,
+                   int64_t index_size,
+                   bool enable_mmap) {
+    LoadIndexInfo info{};
+    info.segment_id = 1;
+    info.field_id = 2;
+    info.index_id = 3;
+    info.field_type = DataType::INT64;
+    info.element_type = DataType::NONE;
+    info.enable_mmap = enable_mmap;
+    info.index_engine_version = 0;
+    info.index_size = index_size;
+    info.num_rows = 1'000'000;
+    info.index_params = {{index::INDEX_TYPE, index_type},
+                         {index::SCALAR_INDEX_ENGINE_VERSION, "3"}};
+    info.schema.set_nullable(false);
+    info.warmup_policy = "disable";
+    return info;
+}
+
+index::CreateIndexInfo
+MakeScalarIndexInfo(const IndexType& index_type) {
+    index::CreateIndexInfo info{};
+    info.field_type = DataType::INT64;
+    info.index_type = index_type;
+    info.scalar_index_engine_version = 3;
+    return info;
+}
+
+TEST(SealedIndexTranslatorTest, UsesFactoryPeakDiskWithoutDoublingIt) {
+    constexpr int64_t kIndexSize = 64 * 1024 * 1024;
+    auto load_info =
+        MakeScalarLoadInfo(index::RTREE_INDEX_TYPE, kIndexSize, true);
+    SealedIndexTranslator translator(
+        MakeScalarIndexInfo(index::RTREE_INDEX_TYPE),
+        &load_info,
+        tracer::TraceContext{},
+        storage::FileManagerContext{},
+        Config{});
+
+    const auto [final_usage, peak_usage] =
+        translator.estimated_loading_usage({0});
+
+    EXPECT_EQ(final_usage.file_bytes, kIndexSize);
+    EXPECT_EQ(peak_usage.file_bytes, kIndexSize);
+}
+
+TEST(SealedIndexTranslatorTest, CachesLoadEstimateAfterFirstUse) {
+    constexpr int64_t kIndexSize = 256 * 1024 * 1024;
+    auto& pool = ThreadPools::GetThreadPool(ThreadPoolPriority::HIGH);
+    const auto original_worker_count = pool.GetMaxThreadNum();
+    struct PoolSizeGuard {
+        ThreadPool& pool;
+        size_t original_size;
+        ~PoolSizeGuard() {
+            pool.Resize(static_cast<int>(original_size));
+        }
+    } guard{pool, original_worker_count};
+
+    pool.Resize(1);
+    auto load_info =
+        MakeScalarLoadInfo(index::ASCENDING_SORT, kIndexSize, true);
+    SealedIndexTranslator translator(MakeScalarIndexInfo(index::ASCENDING_SORT),
+                                     &load_info,
+                                     tracer::TraceContext{},
+                                     storage::FileManagerContext{},
+                                     Config{});
+
+    const auto first_peak =
+        translator.estimated_loading_usage({0}).second.memory_bytes;
+    pool.Resize(2);
+    const auto second_peak =
+        translator.estimated_loading_usage({0}).second.memory_bytes;
+
+    const auto legacy_aux_bytes =
+        load_info.num_rows * sizeof(int32_t) + (load_info.num_rows + 7) / 8;
+    EXPECT_EQ(first_peak, legacy_aux_bytes + DEFAULT_INDEX_FILE_SLICE_SIZE);
+    EXPECT_EQ(second_peak, first_peak);
+}
+
+}  // namespace
+}  // namespace milvus::segcore::storagev1translator

--- a/internal/core/src/segcore/storagev1translator/TextMatchIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/TextMatchIndexTranslator.cpp
@@ -16,11 +16,13 @@
 
 #include "segcore/storagev1translator/TextMatchIndexTranslator.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <utility>
 
 #include "cachinglayer/CacheSlot.h"
-#include "segcore/Utils.h"
+#include "common/Utils.h"
+#include "index/Utils.h"
 #include "segcore/Utils.h"
 #include "monitor/Monitor.h"
 #include "common/ScopedTimer.h"
@@ -79,16 +81,33 @@ TextMatchIndexTranslator::estimated_loading_usage(
         return {};
     }
     // ignore the cid checking, because there is only one cell
-    auto bitmap_bytes = EstimateValidityBitmapBytes(load_info_.num_rows);
+    const auto index_size = std::max<int64_t>(load_info_.index_size, 0);
+    const auto bitmap_bytes = EstimateValidityBitmapBytes(load_info_.num_rows);
+    const auto load_priority =
+        milvus::index::GetValueFromConfig<milvus::proto::common::LoadPriority>(
+            config_, LOAD_PRIORITY)
+            .value_or(milvus::proto::common::LoadPriority::HIGH);
+    const auto stream_memory_peak =
+        static_cast<int64_t>(milvus::index::ScalarIndexStreamMemoryOverhead(
+            static_cast<uint64_t>(index_size),
+            load_info_.scalar_index_version,
+            load_priority));
+    const auto stream_peak_with_bitmap =
+        SaturatingAdd(stream_memory_peak, bitmap_bytes);
     if (load_info_.enable_mmap) {
-        return {{bitmap_bytes, load_info_.index_size},
-                {load_info_.index_size + bitmap_bytes, load_info_.index_size}};
+        return {{bitmap_bytes, index_size},
+                {stream_peak_with_bitmap, index_size}};
     } else {
-        // The reason the maximum disk usage is not zero is that the text match index
-        // is first written to the disk, then loaded into memory. Only after that are
-        // the disk files deleted.
-        return {{load_info_.index_size + bitmap_bytes, 0},
-                {load_info_.index_size + bitmap_bytes, load_info_.index_size}};
+        // Tantivy first materializes the index on disk, then copies each file
+        // through a temporary buffer into RamDirectory. The largest file can
+        // approach the whole index size, and the disk files are removed only
+        // after the in-memory index has been opened.
+        const auto loaded_memory = SaturatingAdd(index_size, bitmap_bytes);
+        const auto ram_directory_peak = SaturatingAdd(
+            SaturatingMultiply(int64_t{2}, index_size), bitmap_bytes);
+        return {{loaded_memory, 0},
+                {std::max(ram_directory_peak, stream_peak_with_bitmap),
+                 index_size}};
     }
 }
 

--- a/internal/core/src/segcore/storagev1translator/TextMatchIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/TextMatchIndexTranslator.cpp
@@ -73,8 +73,11 @@ TextMatchIndexTranslator::cell_id_of(milvus::cachinglayer::uid_t) const {
 
 std::pair<milvus::cachinglayer::ResourceUsage,
           milvus::cachinglayer::ResourceUsage>
-TextMatchIndexTranslator::estimated_byte_size_of_cell(
-    milvus::cachinglayer::cid_t) const {
+TextMatchIndexTranslator::estimated_loading_usage(
+    const std::vector<milvus::cachinglayer::cid_t>& cids) const {
+    if (cids.empty()) {
+        return {};
+    }
     // ignore the cid checking, because there is only one cell
     auto bitmap_bytes = EstimateValidityBitmapBytes(load_info_.num_rows);
     if (load_info_.enable_mmap) {

--- a/internal/core/src/segcore/storagev1translator/TextMatchIndexTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/TextMatchIndexTranslator.h
@@ -29,6 +29,7 @@ struct TextMatchIndexLoadInfo {
     int64_t field_id;
     std::string analyzer_params;
     int64_t index_size;
+    int32_t scalar_index_version;
     int64_t num_rows;
     std::string
         warmup_policy;  // "disable" or "sync", empty means use global config

--- a/internal/core/src/segcore/storagev1translator/TextMatchIndexTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/TextMatchIndexTranslator.h
@@ -55,7 +55,8 @@ class TextMatchIndexTranslator
 
     std::pair<milvus::cachinglayer::ResourceUsage,
               milvus::cachinglayer::ResourceUsage>
-    estimated_byte_size_of_cell(milvus::cachinglayer::cid_t cid) const override;
+    estimated_loading_usage(
+        const std::vector<milvus::cachinglayer::cid_t>& cids) const override;
 
     int64_t
     cells_storage_bytes(

--- a/internal/core/src/segcore/storagev1translator/TextMatchIndexTranslatorTest.cpp
+++ b/internal/core/src/segcore/storagev1translator/TextMatchIndexTranslatorTest.cpp
@@ -46,7 +46,7 @@ TEST(TextMatchIndexTranslatorTest,
     constexpr int64_t kIndexSize = std::numeric_limits<int64_t>::max() / 4;
     constexpr int64_t kNumRows = 512 * 1024;
     constexpr int64_t kValidityBitmapBytes = kNumRows / 8;
-    constexpr auto kLoadPriority = proto::common::LoadPriority::HIGH;
+    constexpr auto kLoadPriority = proto::common::LoadPriority::LOW;
 
     TextMatchIndexLoadInfo load_info{
         true, 1, 2, "{}", kIndexSize, 3, kNumRows, "disable"};

--- a/internal/core/src/segcore/storagev1translator/TextMatchIndexTranslatorTest.cpp
+++ b/internal/core/src/segcore/storagev1translator/TextMatchIndexTranslatorTest.cpp
@@ -1,0 +1,78 @@
+// Copyright (C) 2019-2025 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <utility>
+
+#include "common/Consts.h"
+#include "common/Utils.h"
+#include "index/Meta.h"
+#include "segcore/storagev1translator/TextMatchIndexTranslator.h"
+#include "storage/ThreadPools.h"
+
+namespace milvus::segcore::storagev1translator {
+namespace {
+
+TEST(TextMatchIndexTranslatorTest, NonMmapAccountsForRamDirectoryCopyPeak) {
+    constexpr int64_t kIndexSize = 64 * 1024 * 1024;
+    TextMatchIndexLoadInfo load_info{
+        false, 1, 2, "{}", kIndexSize, 3, 0, "disable"};
+    TextMatchIndexTranslator translator(
+        std::move(load_info), storage::FileManagerContext{}, Config{});
+
+    const auto [final_usage, peak_usage] =
+        translator.estimated_loading_usage({0});
+
+    EXPECT_EQ(final_usage.memory_bytes, kIndexSize);
+    EXPECT_EQ(final_usage.file_bytes, 0);
+    EXPECT_EQ(peak_usage.memory_bytes, 2 * kIndexSize);
+    EXPECT_EQ(peak_usage.file_bytes, kIndexSize);
+}
+
+TEST(TextMatchIndexTranslatorTest,
+     MmapV3UsesPoolBoundedStreamAndValidityBitmap) {
+    constexpr int64_t kIndexSize = std::numeric_limits<int64_t>::max() / 4;
+    constexpr int64_t kNumRows = 512 * 1024;
+    constexpr int64_t kValidityBitmapBytes = kNumRows / 8;
+    constexpr auto kLoadPriority = proto::common::LoadPriority::HIGH;
+
+    TextMatchIndexLoadInfo load_info{
+        true, 1, 2, "{}", kIndexSize, 3, kNumRows, "disable"};
+    Config config;
+    config[LOAD_PRIORITY] = kLoadPriority;
+    TextMatchIndexTranslator translator(
+        std::move(load_info), storage::FileManagerContext{}, config);
+
+    const auto worker_count = std::max<size_t>(
+        1,
+        ThreadPools::GetThreadPool(PriorityForLoad(kLoadPriority))
+            .GetMaxThreadNum());
+    const auto stream_peak =
+        std::min<int64_t>(kIndexSize,
+                          SaturatingMultiply(static_cast<int64_t>(worker_count),
+                                             DEFAULT_INDEX_FILE_SLICE_SIZE));
+    const auto expected_peak = SaturatingAdd(stream_peak, kValidityBitmapBytes);
+
+    const auto [final_usage, peak_usage] =
+        translator.estimated_loading_usage({0});
+
+    EXPECT_EQ(final_usage.memory_bytes, kValidityBitmapBytes);
+    EXPECT_EQ(final_usage.file_bytes, kIndexSize);
+    EXPECT_EQ(peak_usage.memory_bytes, expected_peak);
+    EXPECT_EQ(peak_usage.file_bytes, kIndexSize);
+}
+
+}  // namespace
+}  // namespace milvus::segcore::storagev1translator

--- a/internal/core/src/segcore/storagev1translator/V1SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/V1SealedIndexTranslator.cpp
@@ -59,8 +59,8 @@ V1SealedIndexTranslator::cell_id_of(milvus::cachinglayer::uid_t uid) const {
 
 std::pair<milvus::cachinglayer::ResourceUsage,
           milvus::cachinglayer::ResourceUsage>
-V1SealedIndexTranslator::estimated_byte_size_of_cell(
-    milvus::cachinglayer::cid_t cid) const {
+V1SealedIndexTranslator::estimated_loading_usage(
+    const std::vector<milvus::cachinglayer::cid_t>&) const {
     return {{0, 0}, {0, 0}};
 }
 

--- a/internal/core/src/segcore/storagev1translator/V1SealedIndexTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/V1SealedIndexTranslator.h
@@ -31,7 +31,8 @@ class V1SealedIndexTranslator : public Translator<milvus::index::IndexBase> {
     cell_id_of(milvus::cachinglayer::uid_t uid) const override;
     std::pair<milvus::cachinglayer::ResourceUsage,
               milvus::cachinglayer::ResourceUsage>
-    estimated_byte_size_of_cell(milvus::cachinglayer::cid_t cid) const override;
+    estimated_loading_usage(
+        const std::vector<milvus::cachinglayer::cid_t>& cids) const override;
     const std::string&
     key() const override;
     std::vector<std::pair<milvus::cachinglayer::cid_t,

--- a/internal/core/src/segcore/storagev2translator/GroupCTMeta.h
+++ b/internal/core/src/segcore/storagev2translator/GroupCTMeta.h
@@ -19,11 +19,11 @@
 #include <cassert>
 #include <cstdint>
 #include <functional>
-#include <numeric>
 #include <utility>
 #include <vector>
 
 #include "cachinglayer/Translator.h"
+#include "common/Utils.h"
 
 namespace milvus::segcore::storagev2translator {
 
@@ -39,40 +39,36 @@ inline std::pair<milvus::cachinglayer::ResourceUsage,
 EstimateGroupChunkLoadingUsage(
     const std::vector<int64_t>& cell_sizes,
     const std::vector<milvus::cachinglayer::cid_t>& cids,
+    int64_t max_cell_size,
     bool use_mmap,
-    size_t queue_capacity) {
+    size_t worker_count,
+    int64_t batch_target_bytes) {
     if (cids.empty()) {
         return {};
     }
 
-    std::vector<int64_t> requested_sizes;
-    requested_sizes.reserve(cids.size());
+    int64_t loaded_size = 0;
     for (const auto cid : cids) {
         assert(cid < cell_sizes.size());
-        requested_sizes.push_back(cell_sizes[cid]);
+        loaded_size = SaturatingAdd(loaded_size, cell_sizes[cid]);
     }
 
-    const auto loaded_size =
-        std::accumulate(requested_sizes.begin(), requested_sizes.end(), 0LL);
-    // All requested cells remain loaded. Use the bounded result channel as the
-    // pipeline's temporary-loading concurrency limit, and choose the largest
-    // cells for a conservative peak estimate.
-    const auto concurrent_cells =
-        std::min(requested_sizes.size(), std::max<size_t>(queue_capacity, 1));
-    std::partial_sort(requested_sizes.begin(),
-                      requested_sizes.begin() + concurrent_cells,
-                      requested_sizes.end(),
-                      std::greater<int64_t>());
+    // All requested cells remain loaded. A load-pool worker owns at most one
+    // batch at a time, including both Arrow reads and finalization. A batch is
+    // bounded by the target size unless it contains one oversized cell.
+    const auto concurrent_batches =
+        std::min(cids.size(), std::max<size_t>(worker_count, 1));
+    const auto max_batch_size =
+        std::max({batch_target_bytes, max_cell_size, int64_t{1}});
     const auto temporary_size =
-        std::accumulate(requested_sizes.begin(),
-                        requested_sizes.begin() + concurrent_cells,
-                        0LL);
+        std::min(loaded_size,
+                 SaturatingMultiply(max_batch_size,
+                                    static_cast<int64_t>(concurrent_batches)));
 
     if (use_mmap) {
-        return {{0, loaded_size},
-                {2 * temporary_size, loaded_size + temporary_size}};
+        return {{0, loaded_size}, {temporary_size, loaded_size}};
     }
-    return {{loaded_size, 0}, {loaded_size + temporary_size, 0}};
+    return {{loaded_size, 0}, {SaturatingAdd(loaded_size, temporary_size), 0}};
 }
 
 struct GroupCTMeta : public milvus::cachinglayer::Meta {
@@ -81,6 +77,7 @@ struct GroupCTMeta : public milvus::cachinglayer::Meta {
     std::vector<int64_t> num_rows_until_chunk_;
     // memory size for each group chunk(cache cell)
     std::vector<int64_t> chunk_memory_size_;
+    int64_t max_chunk_memory_size_{0};
     size_t num_fields_;
     // total number of row groups
     size_t total_row_groups_;

--- a/internal/core/src/segcore/storagev2translator/GroupCTMeta.h
+++ b/internal/core/src/segcore/storagev2translator/GroupCTMeta.h
@@ -15,6 +15,14 @@
 // limitations under the License.
 #pragma once
 
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <functional>
+#include <numeric>
+#include <utility>
+#include <vector>
+
 #include "cachinglayer/Translator.h"
 
 namespace milvus::segcore::storagev2translator {
@@ -25,6 +33,47 @@ namespace milvus::segcore::storagev2translator {
 constexpr size_t kRowGroupsPerCell = 4;
 static_assert(kRowGroupsPerCell > 0,
               "kRowGroupsPerCell must be greater than 0");
+
+inline std::pair<milvus::cachinglayer::ResourceUsage,
+                 milvus::cachinglayer::ResourceUsage>
+EstimateGroupChunkLoadingUsage(
+    const std::vector<int64_t>& cell_sizes,
+    const std::vector<milvus::cachinglayer::cid_t>& cids,
+    bool use_mmap,
+    size_t queue_capacity) {
+    if (cids.empty()) {
+        return {};
+    }
+
+    std::vector<int64_t> requested_sizes;
+    requested_sizes.reserve(cids.size());
+    for (const auto cid : cids) {
+        assert(cid < cell_sizes.size());
+        requested_sizes.push_back(cell_sizes[cid]);
+    }
+
+    const auto loaded_size =
+        std::accumulate(requested_sizes.begin(), requested_sizes.end(), 0LL);
+    // All requested cells remain loaded. Use the bounded result channel as the
+    // pipeline's temporary-loading concurrency limit, and choose the largest
+    // cells for a conservative peak estimate.
+    const auto concurrent_cells =
+        std::min(requested_sizes.size(), std::max<size_t>(queue_capacity, 1));
+    std::partial_sort(requested_sizes.begin(),
+                      requested_sizes.begin() + concurrent_cells,
+                      requested_sizes.end(),
+                      std::greater<int64_t>());
+    const auto temporary_size =
+        std::accumulate(requested_sizes.begin(),
+                        requested_sizes.begin() + concurrent_cells,
+                        0LL);
+
+    if (use_mmap) {
+        return {{0, loaded_size},
+                {2 * temporary_size, loaded_size + temporary_size}};
+    }
+    return {{loaded_size, 0}, {loaded_size + temporary_size, 0}};
+}
 
 struct GroupCTMeta : public milvus::cachinglayer::Meta {
     // num_rows_until_chunk_[i] = total rows(prefix sum) in cells [0, i-1]

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -46,7 +46,6 @@
 #include "segcore/memory_planner.h"
 #include "segcore/storagev2translator/GroupCTMeta.h"
 #include "storage/KeyRetriever.h"
-#include "storage/ThreadPools.h"
 #include "storage/Util.h"
 
 namespace milvus::segcore::storagev2translator {
@@ -234,19 +233,13 @@ GroupChunkTranslator::cell_id_of(milvus::cachinglayer::uid_t uid) const {
 
 std::pair<milvus::cachinglayer::ResourceUsage,
           milvus::cachinglayer::ResourceUsage>
-GroupChunkTranslator::estimated_byte_size_of_cell(
-    milvus::cachinglayer::cid_t cid) const {
-    assert(cid < meta_.chunk_memory_size_.size());
-    auto cell_sz = meta_.chunk_memory_size_[cid];
-
-    if (use_mmap_) {
-        // why double the disk size for loading?
-        // during file writing, the temporary size could be larger than the final size
-        // so we need to reserve more space for the disk size.
-        return {{0, cell_sz}, {2 * cell_sz, 2 * cell_sz}};
-    } else {
-        return {{cell_sz, 0}, {2 * cell_sz, 0}};
-    }
+GroupChunkTranslator::estimated_loading_usage(
+    const std::vector<milvus::cachinglayer::cid_t>& cids) const {
+    return EstimateGroupChunkLoadingUsage(
+        meta_.chunk_memory_size_,
+        cids,
+        use_mmap_,
+        GetCellReaderChannelCapacity(load_priority_));
 }
 
 const std::string&
@@ -334,10 +327,8 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
     }
 
     // Submit cell-batch loading tasks
-    auto& pool = milvus::ThreadPools::GetThreadPool(
-        milvus::PriorityForLoad(load_priority_));
     auto channel = std::make_shared<milvus::segcore::CellReaderChannel>(
-        static_cast<size_t>(pool.GetMaxThreadNum() * 1.5));
+        GetCellReaderChannelCapacity(load_priority_));
     auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
                   .GetArrowFileSystem();
 

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -30,7 +30,6 @@
 #include "cachinglayer/Utils.h"
 #include "common/Chunk.h"
 #include "common/ChunkWriter.h"
-#include "common/Common.h"
 #include "common/Consts.h"
 #include "common/EasyAssert.h"
 #include "common/FieldMeta.h"
@@ -198,6 +197,8 @@ GroupChunkTranslator::GroupChunkTranslator(
         }
         meta_.num_rows_until_chunk_.push_back(cumulative_rows);
         meta_.chunk_memory_size_.push_back(cell_size);
+        meta_.max_chunk_memory_size_ =
+            std::max(meta_.max_chunk_memory_size_, cell_size);
     }
 
     AssertInfo(
@@ -238,8 +239,10 @@ GroupChunkTranslator::estimated_loading_usage(
     return EstimateGroupChunkLoadingUsage(
         meta_.chunk_memory_size_,
         cids,
+        meta_.max_chunk_memory_size_,
         use_mmap_,
-        GetCellReaderChannelCapacity(load_priority_));
+        GetCellBatchConcurrency(load_priority_),
+        kDefaultFieldDataLoadBatchTargetBytes);
 }
 
 const std::string&
@@ -326,70 +329,50 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
                               meta_.chunk_memory_size_[cid]});
     }
 
-    // Submit cell-batch loading tasks
-    auto channel = std::make_shared<milvus::segcore::CellReaderChannel>(
-        GetCellReaderChannelCapacity(load_priority_));
+    // Submit cell-batch loading tasks. The same load-pool worker reads and
+    // finalizes every cell in its batch.
     auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
                   .GetArrowFileSystem();
 
     auto factory = milvus::segcore::MakeFileReaderFactory(insert_files_, fs);
-    auto load_futures =
-        milvus::segcore::LoadCellBatchAsync(ctx,
-                                            std::move(cell_specs),
-                                            std::move(factory),
-                                            channel,
-                                            DEFAULT_FIELD_MAX_MEMORY_LIMIT,
-                                            load_priority_);
-
-    LOG_INFO(
-        "[StorageV2] translator {} submits {} batch tasks for column group {}",
-        key_,
-        load_futures.size(),
-        column_group_info_.field_id);
-
-    // Pop loop — convert each cell immediately, no ArrowTable accumulation
+    auto finalize_cell =
+        [this](const std::vector<std::shared_ptr<arrow::Table>>& tables,
+               int64_t cid) {
+            return load_group_chunk(
+                tables, static_cast<milvus::cachinglayer::cid_t>(cid));
+        };
     std::unordered_map<cachinglayer::cid_t, std::unique_ptr<milvus::GroupChunk>>
         completed_cells;
     completed_cells.reserve(cids.size());
 
-    try {
-        std::shared_ptr<milvus::segcore::CellLoadResult> cell_data;
-        while (channel->pop(cell_data)) {
-            CheckCancellation(
-                ctx, segment_id_, "GroupChunkTranslator::get_cells()");
-            completed_cells[cell_data->cid] =
-                load_group_chunk(cell_data->tables, cell_data->cid);
-        }
-    } catch (...) {
-        // Drain the channel to unblock producers that may be stuck on push()
-        // to a full bounded channel. Without draining, producers block forever
-        // and their task_guard (which calls channel->close()) never executes.
-        std::shared_ptr<milvus::segcore::CellLoadResult> discard;
-        try {
-            while (channel->pop(discard)) {
-            }
-        } catch (...) {
-            LOG_WARN("drain channel exception swallowed");
-        }
-        try {
-            storage::WaitAllFutures(load_futures);
-        } catch (const std::exception& e) {
-            LOG_WARN(
-                "[StorageV2] translator {} cleanup ignored background load "
-                "exception after cancellation: {}",
-                key_,
-                e.what());
-        } catch (...) {
-            LOG_WARN(
-                "[StorageV2] translator {} cleanup ignored unknown background "
-                "load exception after cancellation",
-                key_);
-        }
-        throw;
-    }
+    auto load_futures = milvus::segcore::LoadCellBatchAsync(
+        ctx,
+        std::move(cell_specs),
+        std::move(factory),
+        kDefaultFieldDataLoadBatchTargetBytes,
+        load_priority_,
+        std::move(finalize_cell));
 
-    // access underlying future to get exception if any
-    storage::WaitAllFutures(load_futures);
+    storage::ProcessFuturesInOrder(
+        load_futures, [&](milvus::segcore::LoadedCellBatch loaded_cells) {
+            for (auto& loaded_cell : loaded_cells) {
+                CheckCancellation(
+                    ctx, segment_id_, "GroupChunkTranslator::get_cells()");
+                AssertInfo(loaded_cell.chunk != nullptr,
+                           "[StorageV2] translator {} cell {} is not "
+                           "finalized by batch task",
+                           key_,
+                           loaded_cell.cid);
+                completed_cells[loaded_cell.cid] = std::move(loaded_cell.chunk);
+            }
+        });
+
+    LOG_INFO(
+        "[StorageV2] translator {} completed {} batch tasks for column group "
+        "{}",
+        key_,
+        load_futures.size(),
+        column_group_info_.field_id);
 
     for (auto cid : cids) {
         auto it = completed_cells.find(cid);

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.h
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.h
@@ -57,7 +57,8 @@ class GroupChunkTranslator
 
     std::pair<milvus::cachinglayer::ResourceUsage,
               milvus::cachinglayer::ResourceUsage>
-    estimated_byte_size_of_cell(milvus::cachinglayer::cid_t cid) const override;
+    estimated_loading_usage(
+        const std::vector<milvus::cachinglayer::cid_t>& cids) const override;
 
     const std::string&
     key() const override;

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslatorTest.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslatorTest.cpp
@@ -98,6 +98,36 @@ class GroupChunkTranslatorTest : public ::testing::TestWithParam<bool> {
     int64_t segment_id_ = 0;
 };
 
+TEST(GroupChunkLoadingUsageTest, LimitsTemporaryUsageByQueueCapacity) {
+    const std::vector<int64_t> cell_sizes = {10, 20, 30, 40};
+    const std::vector<cachinglayer::cid_t> cids = {0, 1, 2, 3};
+
+    const auto [loaded, loading] = EstimateGroupChunkLoadingUsage(
+        cell_sizes, cids, /*use_mmap=*/false, /*queue_capacity=*/2);
+
+    EXPECT_EQ(loaded, (cachinglayer::ResourceUsage{100, 0}));
+    EXPECT_EQ(loading, (cachinglayer::ResourceUsage{170, 0}));
+}
+
+TEST(GroupChunkLoadingUsageTest, AccountsForMmapTemporaryUsage) {
+    const std::vector<int64_t> cell_sizes = {10, 20, 30, 40};
+    const std::vector<cachinglayer::cid_t> cids = {0, 1, 2, 3};
+
+    const auto [loaded, loading] = EstimateGroupChunkLoadingUsage(
+        cell_sizes, cids, /*use_mmap=*/true, /*queue_capacity=*/2);
+
+    EXPECT_EQ(loaded, (cachinglayer::ResourceUsage{0, 100}));
+    EXPECT_EQ(loading, (cachinglayer::ResourceUsage{140, 170}));
+}
+
+TEST(GroupChunkLoadingUsageTest, EmptyBatchUsesNoResources) {
+    const auto [loaded, loading] = EstimateGroupChunkLoadingUsage(
+        {10, 20}, {}, /*use_mmap=*/false, /*queue_capacity=*/2);
+
+    EXPECT_EQ(loaded, cachinglayer::ResourceUsage{});
+    EXPECT_EQ(loading, cachinglayer::ResourceUsage{});
+}
+
 TEST_P(GroupChunkTranslatorTest, TestWithMmap) {
     auto temp_dir =
         std::filesystem::path(TestLocalPath) / "gctt_test_with_mmap";
@@ -156,7 +186,7 @@ TEST_P(GroupChunkTranslatorTest, TestWithMmap) {
             expected_size += static_cast<int64_t>(
                 row_group_metadata_vector.Get(row_group_idx).memory_size());
         }
-        auto usage = translator->estimated_byte_size_of_cell(i).first;
+        auto usage = translator->estimated_loading_usage({i}).first;
         if (use_mmap) {
             EXPECT_EQ(usage.file_bytes, expected_size);
         } else {
@@ -361,7 +391,7 @@ TEST_P(GroupChunkTranslatorTest, TestMultipleFiles) {
     }
 
     for (size_t cid = 0; cid < translator->num_cells(); ++cid) {
-        auto usage = translator->estimated_byte_size_of_cell(cid).first;
+        auto usage = translator->estimated_loading_usage({cid}).first;
 
         // Calculate expected size by summing all row groups in this cell
         auto [rg_start, rg_end] = static_cast<GroupCTMeta*>(translator->meta())

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslatorTest.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslatorTest.cpp
@@ -98,31 +98,62 @@ class GroupChunkTranslatorTest : public ::testing::TestWithParam<bool> {
     int64_t segment_id_ = 0;
 };
 
-TEST(GroupChunkLoadingUsageTest, LimitsTemporaryUsageByQueueCapacity) {
+TEST(GroupChunkLoadingUsageTest, LimitsTemporaryUsageByWorkerBatches) {
     const std::vector<int64_t> cell_sizes = {10, 20, 30, 40};
     const std::vector<cachinglayer::cid_t> cids = {0, 1, 2, 3};
 
-    const auto [loaded, loading] = EstimateGroupChunkLoadingUsage(
-        cell_sizes, cids, /*use_mmap=*/false, /*queue_capacity=*/2);
+    const auto [loaded, loading] =
+        EstimateGroupChunkLoadingUsage(cell_sizes,
+                                       cids,
+                                       /*max_cell_size=*/40,
+                                       /*use_mmap=*/false,
+                                       /*worker_count=*/2,
+                                       /*batch_target_bytes=*/25);
 
     EXPECT_EQ(loaded, (cachinglayer::ResourceUsage{100, 0}));
-    EXPECT_EQ(loading, (cachinglayer::ResourceUsage{170, 0}));
+    EXPECT_EQ(loading, (cachinglayer::ResourceUsage{180, 0}));
 }
 
 TEST(GroupChunkLoadingUsageTest, AccountsForMmapTemporaryUsage) {
     const std::vector<int64_t> cell_sizes = {10, 20, 30, 40};
     const std::vector<cachinglayer::cid_t> cids = {0, 1, 2, 3};
 
-    const auto [loaded, loading] = EstimateGroupChunkLoadingUsage(
-        cell_sizes, cids, /*use_mmap=*/true, /*queue_capacity=*/2);
+    const auto [loaded, loading] =
+        EstimateGroupChunkLoadingUsage(cell_sizes,
+                                       cids,
+                                       /*max_cell_size=*/40,
+                                       /*use_mmap=*/true,
+                                       /*worker_count=*/2,
+                                       /*batch_target_bytes=*/25);
 
     EXPECT_EQ(loaded, (cachinglayer::ResourceUsage{0, 100}));
-    EXPECT_EQ(loading, (cachinglayer::ResourceUsage{140, 170}));
+    EXPECT_EQ(loading, (cachinglayer::ResourceUsage{80, 100}));
+}
+
+TEST(GroupChunkLoadingUsageTest, AccountsForOversizedCells) {
+    const std::vector<int64_t> cell_sizes = {10, 60, 80};
+    const std::vector<cachinglayer::cid_t> cids = {0, 1, 2};
+
+    const auto [loaded, loading] =
+        EstimateGroupChunkLoadingUsage(cell_sizes,
+                                       cids,
+                                       /*max_cell_size=*/80,
+                                       /*use_mmap=*/true,
+                                       /*worker_count=*/2,
+                                       /*batch_target_bytes=*/25);
+
+    EXPECT_EQ(loaded, (cachinglayer::ResourceUsage{0, 150}));
+    EXPECT_EQ(loading, (cachinglayer::ResourceUsage{150, 150}));
 }
 
 TEST(GroupChunkLoadingUsageTest, EmptyBatchUsesNoResources) {
-    const auto [loaded, loading] = EstimateGroupChunkLoadingUsage(
-        {10, 20}, {}, /*use_mmap=*/false, /*queue_capacity=*/2);
+    const auto [loaded, loading] =
+        EstimateGroupChunkLoadingUsage({10, 20},
+                                       {},
+                                       /*max_cell_size=*/20,
+                                       /*use_mmap=*/false,
+                                       /*worker_count=*/2,
+                                       /*batch_target_bytes=*/25);
 
     EXPECT_EQ(loaded, cachinglayer::ResourceUsage{});
     EXPECT_EQ(loading, cachinglayer::ResourceUsage{});

--- a/internal/core/src/segcore/storagev2translator/JsonStatsTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/JsonStatsTranslator.cpp
@@ -59,8 +59,11 @@ JsonStatsTranslator::cell_id_of(milvus::cachinglayer::uid_t) const {
 
 std::pair<milvus::cachinglayer::ResourceUsage,
           milvus::cachinglayer::ResourceUsage>
-JsonStatsTranslator::estimated_byte_size_of_cell(
-    milvus::cachinglayer::cid_t) const {
+JsonStatsTranslator::estimated_loading_usage(
+    const std::vector<milvus::cachinglayer::cid_t>& cids) const {
+    if (cids.empty()) {
+        return {};
+    }
     if (load_info_.enable_mmap) {
         return {{0, load_info_.stats_size},
                 {load_info_.stats_size, load_info_.stats_size}};

--- a/internal/core/src/segcore/storagev2translator/JsonStatsTranslator.h
+++ b/internal/core/src/segcore/storagev2translator/JsonStatsTranslator.h
@@ -55,7 +55,8 @@ class JsonStatsTranslator
 
     std::pair<milvus::cachinglayer::ResourceUsage,
               milvus::cachinglayer::ResourceUsage>
-    estimated_byte_size_of_cell(milvus::cachinglayer::cid_t cid) const override;
+    estimated_loading_usage(
+        const std::vector<milvus::cachinglayer::cid_t>& cids) const override;
 
     const std::string&
     key() const override;

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -19,7 +19,6 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <exception>
 #include <filesystem>
 #include <memory>
 #include <set>
@@ -144,6 +143,8 @@ ManifestGroupTranslator::ManifestGroupTranslator(
         }
         meta_.num_rows_until_chunk_.push_back(cumulative_rows);
         meta_.chunk_memory_size_.push_back(cell_size);
+        meta_.max_chunk_memory_size_ =
+            std::max(meta_.max_chunk_memory_size_, cell_size);
     }
 
     LOG_INFO(
@@ -172,8 +173,10 @@ ManifestGroupTranslator::estimated_loading_usage(
     return EstimateGroupChunkLoadingUsage(
         meta_.chunk_memory_size_,
         cids,
+        meta_.max_chunk_memory_size_,
         use_mmap_,
-        GetCellReaderChannelCapacity(load_priority_));
+        GetCellBatchConcurrency(load_priority_),
+        kDefaultFieldDataLoadBatchTargetBytes);
 }
 
 const std::string&
@@ -219,68 +222,48 @@ ManifestGroupTranslator::get_cells(
     // Create factory using ChunkReader — reads a batch of row groups at once
     auto factory = milvus::segcore::MakeChunkReaderFactory(chunk_reader_);
 
-    // Submit cell-batch loading tasks
-    auto channel = std::make_shared<milvus::segcore::CellReaderChannel>(
-        GetCellReaderChannelCapacity(load_priority_));
-
-    auto load_futures =
-        milvus::segcore::LoadCellBatchAsync(ctx,
-                                            std::move(cell_specs),
-                                            std::move(factory),
-                                            channel,
-                                            DEFAULT_FIELD_MAX_MEMORY_LIMIT,
-                                            load_priority_);
-
-    LOG_INFO(
-        "[StorageV2] translator {} submits {} batch tasks for manifest column "
-        "group {}",
-        key_,
-        load_futures.size(),
-        column_group_index_);
-
-    // Pop loop — convert each cell immediately, no ArrowTable accumulation
+    // Submit cell-batch loading tasks. The same load-pool worker reads and
+    // finalizes every cell in its batch.
+    auto finalize_cell =
+        [this](const std::vector<std::shared_ptr<arrow::Table>>& tables,
+               int64_t cid) {
+            return load_group_chunk(
+                tables, static_cast<milvus::cachinglayer::cid_t>(cid));
+        };
     std::unordered_map<milvus::cachinglayer::cid_t,
                        std::unique_ptr<milvus::GroupChunk>>
         completed_cells;
     completed_cells.reserve(cids.size());
 
-    try {
-        std::shared_ptr<milvus::segcore::CellLoadResult> cell_data;
-        while (channel->pop(cell_data)) {
-            CheckCancellation(
-                ctx, segment_id_, "ManifestGroupTranslator::get_cells()");
-            completed_cells[cell_data->cid] =
-                load_group_chunk(cell_data->tables, cell_data->cid);
-        }
-    } catch (...) {
-        // Drain the channel to unblock producers that may be stuck on push()
-        // to a full bounded channel. Without draining, producers block forever
-        // and their task_guard (which calls channel->close()) never executes.
-        std::shared_ptr<milvus::segcore::CellLoadResult> discard;
-        try {
-            while (channel->pop(discard)) {
-            }
-        } catch (...) {
-            LOG_WARN("drain channel exception swallowed");
-        }
-        try {
-            storage::WaitAllFutures(load_futures);
-        } catch (const std::exception& e) {
-            LOG_WARN(
-                "[StorageV2] translator {} cleanup ignored background load "
-                "exception after cancellation: {}",
-                key_,
-                e.what());
-        } catch (...) {
-            LOG_WARN(
-                "[StorageV2] translator {} cleanup ignored unknown background "
-                "load exception after cancellation",
-                key_);
-        }
-        throw;
-    }
+    auto load_futures = milvus::segcore::LoadCellBatchAsync(
+        ctx,
+        std::move(cell_specs),
+        std::move(factory),
+        kDefaultFieldDataLoadBatchTargetBytes,
+        load_priority_,
+        std::move(finalize_cell));
 
-    storage::WaitAllFutures(load_futures);
+    storage::ProcessFuturesInOrder(
+        load_futures, [&](milvus::segcore::LoadedCellBatch loaded_cells) {
+            for (auto& loaded_cell : loaded_cells) {
+                CheckCancellation(
+                    ctx, segment_id_, "ManifestGroupTranslator::get_cells()");
+                AssertInfo(loaded_cell.chunk != nullptr,
+                           "[StorageV2] translator {} cell {} is not "
+                           "finalized by batch task",
+                           key_,
+                           loaded_cell.cid);
+                completed_cells[loaded_cell.cid] = std::move(loaded_cell.chunk);
+            }
+        });
+
+    LOG_INFO(
+        "[StorageV2] translator {} completed {} batch tasks for manifest "
+        "column "
+        "group {}",
+        key_,
+        load_futures.size(),
+        column_group_index_);
 
     for (auto cid : cids) {
         auto it = completed_cells.find(cid);

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -46,7 +46,6 @@
 #include "segcore/memory_planner.h"
 #include "segcore/storagev2translator/GroupCTMeta.h"
 #include "storage/KeyRetriever.h"
-#include "storage/ThreadPools.h"
 #include "storage/Util.h"
 
 namespace milvus::segcore::storagev2translator {
@@ -168,19 +167,13 @@ ManifestGroupTranslator::cell_id_of(milvus::cachinglayer::uid_t uid) const {
 
 std::pair<milvus::cachinglayer::ResourceUsage,
           milvus::cachinglayer::ResourceUsage>
-ManifestGroupTranslator::estimated_byte_size_of_cell(
-    milvus::cachinglayer::cid_t cid) const {
-    assert(cid < meta_.chunk_memory_size_.size());
-    auto cell_sz = meta_.chunk_memory_size_[cid];
-
-    if (use_mmap_) {
-        // why double the disk size for loading?
-        // during file writing, the temporary size could be larger than the final size
-        // so we need to reserve more space for the disk size.
-        return {{0, cell_sz}, {2 * cell_sz, 2 * cell_sz}};
-    } else {
-        return {{cell_sz, 0}, {2 * cell_sz, 0}};
-    }
+ManifestGroupTranslator::estimated_loading_usage(
+    const std::vector<milvus::cachinglayer::cid_t>& cids) const {
+    return EstimateGroupChunkLoadingUsage(
+        meta_.chunk_memory_size_,
+        cids,
+        use_mmap_,
+        GetCellReaderChannelCapacity(load_priority_));
 }
 
 const std::string&
@@ -227,10 +220,8 @@ ManifestGroupTranslator::get_cells(
     auto factory = milvus::segcore::MakeChunkReaderFactory(chunk_reader_);
 
     // Submit cell-batch loading tasks
-    auto& pool = milvus::ThreadPools::GetThreadPool(
-        milvus::PriorityForLoad(load_priority_));
     auto channel = std::make_shared<milvus::segcore::CellReaderChannel>(
-        static_cast<size_t>(pool.GetMaxThreadNum() * 1.5));
+        GetCellReaderChannelCapacity(load_priority_));
 
     auto load_futures =
         milvus::segcore::LoadCellBatchAsync(ctx,

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.h
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.h
@@ -106,7 +106,8 @@ class ManifestGroupTranslator
      */
     std::pair<milvus::cachinglayer::ResourceUsage,
               milvus::cachinglayer::ResourceUsage>
-    estimated_byte_size_of_cell(milvus::cachinglayer::cid_t cid) const override;
+    estimated_loading_usage(
+        const std::vector<milvus::cachinglayer::cid_t>& cids) const override;
 
     /**
      * @brief Get the cache key for this translator

--- a/internal/core/src/storage/DiskFileManagerTest.cpp
+++ b/internal/core/src/storage/DiskFileManagerTest.cpp
@@ -14,6 +14,7 @@
 #include <boost/filesystem/path.hpp>
 #include <cxxabi.h>
 #include <fcntl.h>
+#include <folly/ScopeGuard.h>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 #include <stdlib.h>
@@ -90,6 +91,93 @@ using namespace std;
 using namespace milvus;
 using namespace milvus::storage;
 using namespace knowhere;
+
+namespace {
+
+std::string
+GetLocalStorageV2Path(const storage::FileManagerContext& context,
+                      const std::string& remote_path) {
+    return boost::filesystem::path(remote_path)
+        .lexically_relative(context.chunkManagerPtr->GetRootPath())
+        .string();
+}
+
+void
+ExpectMatchingRows(const TargetBitmap& bitmap,
+                   size_t row_count,
+                   std::initializer_list<size_t> matching_rows) {
+    std::vector<bool> expected(row_count, false);
+    for (auto row : matching_rows) {
+        ASSERT_LT(row, row_count);
+        expected[row] = true;
+    }
+
+    ASSERT_EQ(bitmap.size(), row_count);
+    EXPECT_EQ(bitmap.count(), matching_rows.size());
+    for (size_t row = 0; row < row_count; ++row) {
+        EXPECT_EQ(bitmap[row], expected[row]) << "offset " << row;
+    }
+}
+
+void
+VerifyStringSortPatternMatches(milvus::index::StringIndexSort& index,
+                               size_t row_count) {
+    using milvus::proto::plan::OpType;
+
+    ExpectMatchingRows(
+        index.PatternMatch("app%ion", OpType::Match), row_count, {1, 7});
+    ExpectMatchingRows(
+        index.PatternMatch("%ana%", OpType::Match), row_count, {3});
+    ExpectMatchingRows(
+        index.PatternMatch("a\\%b", OpType::Match), row_count, {8});
+    ExpectMatchingRows(index.PatternMatch("app", OpType::PrefixMatch),
+                       row_count,
+                       {0, 1, 2, 7});
+    ExpectMatchingRows(
+        index.PatternMatch("ion", OpType::PostfixMatch), row_count, {1, 7});
+    ExpectMatchingRows(
+        index.PatternMatch("cat", OpType::InnerMatch), row_count, {1, 5, 7});
+}
+
+void
+RunStringSortV3PatternMatchRoundtrip(const storage::FileManagerContext& context,
+                                     milvus::Config load_config) {
+    const std::vector<std::string> values = {
+        "apple",
+        "application",
+        "apply",
+        "banana",
+        "band",
+        "category",
+        "dog",
+        "application",
+        "a%b",
+        "application",
+    };
+    const bool valid_data[] = {
+        true, true, true, true, true, true, true, true, true, false};
+
+    milvus::index::StringIndexSort build_index(context);
+    build_index.Build(values.size(), values.data(), valid_data);
+
+    auto stats = build_index.UploadUnified({});
+    ASSERT_NE(stats, nullptr);
+    auto files = stats->GetIndexFiles();
+    ASSERT_EQ(files.size(), 1);
+    auto local_index_path = GetLocalStorageV2Path(context, files.front());
+    auto cleanup_index_file = folly::makeGuard(
+        [path = local_index_path]() { (void)unlink(path.c_str()); });
+
+    load_config[milvus::index::INDEX_FILES] =
+        std::vector<std::string>{files.front()};
+    milvus::index::StringIndexSort load_index(context);
+    load_index.LoadUnified(load_config);
+
+    ASSERT_EQ(load_index.Count(), static_cast<int64_t>(values.size()));
+    VerifyStringSortPatternMatches(load_index, values.size());
+}
+
+}  // namespace
 
 class DiskAnnFileManagerTest : public testing::Test {
  public:
@@ -1369,6 +1457,9 @@ TEST_F(DiskAnnFileManagerTest, StringIndexSortV3Roundtrip) {
     ASSERT_NE(stats, nullptr);
     auto files = stats->GetIndexFiles();
     ASSERT_EQ(files.size(), 1);
+    auto local_index_path = GetLocalStorageV2Path(context, files.front());
+    auto cleanup_index_file = folly::makeGuard(
+        [path = local_index_path]() { (void)unlink(path.c_str()); });
 
     milvus::index::StringIndexSort load_index(context);
     milvus::Config load_config;
@@ -1394,6 +1485,33 @@ TEST_F(DiskAnnFileManagerTest, StringIndexSortV3Roundtrip) {
         ASSERT_TRUE(val.has_value());
         EXPECT_EQ(val.value(), "str_000");
     }
+}
+
+TEST_F(DiskAnnFileManagerTest, StringIndexSortV3PatternMatchMemoryRoundtrip) {
+    FieldDataMeta field_data_meta = {1, 2, 3, 100};
+    IndexMeta index_meta = {3, 100, 1001, 1, "index"};
+    storage::FileManagerContext context(field_data_meta, index_meta, cm_, fs_);
+
+    milvus::Config load_config;
+    load_config[milvus::index::ENABLE_MMAP] = false;
+    load_config[milvus::LOAD_PRIORITY] =
+        milvus::proto::common::LoadPriority::HIGH;
+    RunStringSortV3PatternMatchRoundtrip(context, std::move(load_config));
+}
+
+TEST_F(DiskAnnFileManagerTest,
+       StringIndexSortV3PatternMatchMmapLowPriorityRoundtrip) {
+    FieldDataMeta field_data_meta = {1, 2, 3, 100};
+    IndexMeta index_meta = {3, 100, 1002, 1, "index"};
+    storage::FileManagerContext context(field_data_meta, index_meta, cm_, fs_);
+
+    milvus::Config load_config;
+    load_config[milvus::index::ENABLE_MMAP] = true;
+    load_config[milvus::index::MMAP_FILE_PATH] =
+        TestLocalPath + "string_sort_v3_pattern_match_low_mmap.idx";
+    load_config[milvus::LOAD_PRIORITY] =
+        milvus::proto::common::LoadPriority::LOW;
+    RunStringSortV3PatternMatchRoundtrip(context, std::move(load_config));
 }
 
 TEST_F(DiskAnnFileManagerTest, CacheRawDataToDiskValidDataFile) {

--- a/internal/core/src/storage/FileWriter.cpp
+++ b/internal/core/src/storage/FileWriter.cpp
@@ -14,12 +14,90 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <utility>
+#include <errno.h>
 #include <cstdlib>
+#include <utility>
+
+#include "folly/ScopeGuard.h"
 #include "folly/futures/Future.h"
 #include "storage/FileWriter.h"
 
 namespace milvus::storage {
+namespace {
+
+bool
+PWriteAll(int fd, const void* data, size_t nbyte, size_t file_offset) {
+    const char* src = static_cast<const char*>(data);
+    size_t left = nbyte;
+
+    while (left != 0) {
+        ssize_t done = pwrite(fd, src, left, file_offset);
+        if (done < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return false;
+        }
+        if (done == 0) {
+            errno = EIO;
+            return false;
+        }
+        left -= done;
+        file_offset += done;
+        src += done;
+    }
+
+    return true;
+}
+
+void
+PositionedWriteWithRateLimit(int fd,
+                             const std::string& filename,
+                             io::WriteRateLimiter& rate_limiter,
+                             io::Priority priority,
+                             size_t alignment_bytes,
+                             const void* data,
+                             size_t nbyte,
+                             size_t file_offset) {
+    size_t bytes_to_write = nbyte;
+    int32_t empty_loops = 0;
+    int64_t total_wait_us = 0;
+    while (bytes_to_write != 0) {
+        auto allowed_bytes =
+            rate_limiter.Acquire(bytes_to_write, alignment_bytes, priority);
+        if (allowed_bytes == 0) {
+            ++empty_loops;
+            if (empty_loops > FileWriter::MAX_EMPTY_LOOPS ||
+                total_wait_us > FileWriter::MAX_WAIT_US) {
+                allowed_bytes = bytes_to_write;
+                empty_loops = 0;
+                total_wait_us = 0;
+            } else {
+                int64_t wait_us = (1 << (empty_loops / 10)) *
+                                  rate_limiter.GetRateLimitPeriod();
+                std::this_thread::sleep_for(std::chrono::microseconds(wait_us));
+                total_wait_us += wait_us;
+                continue;
+            }
+        }
+        if (!PWriteAll(fd, data, allowed_bytes, file_offset)) {
+            ThrowInfo(ErrorCode::FileWriteFailed,
+                      "Failed to write to file: {}, error: {}",
+                      filename,
+                      strerror(errno));
+        }
+        file_offset += allowed_bytes;
+        bytes_to_write -= allowed_bytes;
+        data = static_cast<const char*>(data) + allowed_bytes;
+    }
+}
+
+size_t
+RoundUpToAlignment(size_t size) {
+    return (size + FileWriter::ALIGNMENT_MASK) & ~FileWriter::ALIGNMENT_MASK;
+}
+
+}  // namespace
 
 FileWriter::FileWriter(std::string filename, io::Priority priority)
     : filename_(std::move(filename)),
@@ -98,61 +176,26 @@ bool
 FileWriter::PositionedWrite(const void* data,
                             size_t nbyte,
                             size_t file_offset) {
-    const char* src = static_cast<const char*>(data);
-    size_t left = nbyte;
-
-    while (left != 0) {
-        ssize_t done = pwrite(fd_, src, left, file_offset);
-        if (done < 0) {
-            if (errno == EINTR) {
-                continue;
-            }
-            return false;
-        }
-        left -= done;
-        file_offset += done;
-        src += done;
-    }
-
-    return true;
+    return PWriteAll(fd_, data, nbyte, file_offset);
 }
 
 void
 FileWriter::PositionedWriteWithCheck(const void* data,
                                      size_t nbyte,
                                      size_t file_offset) {
-    size_t bytes_to_write = nbyte;
-    int32_t empty_loops = 0;
-    int64_t total_wait_us = 0;
     size_t alignment_bytes = use_direct_io_ ? ALIGNMENT_BYTES : 1;
-    while (bytes_to_write != 0) {
-        auto allowed_bytes =
-            rate_limiter_.Acquire(bytes_to_write, alignment_bytes, priority_);
-        if (allowed_bytes == 0) {
-            ++empty_loops;
-            // if the empty loops is too large or the total wait time is too long, we should write the data directly
-            if (empty_loops > MAX_EMPTY_LOOPS || total_wait_us > MAX_WAIT_US) {
-                allowed_bytes = bytes_to_write;
-                empty_loops = 0;
-                total_wait_us = 0;
-            } else {
-                int64_t wait_us = (1 << (empty_loops / 10)) *
-                                  rate_limiter_.GetRateLimitPeriod();
-                std::this_thread::sleep_for(std::chrono::microseconds(wait_us));
-                total_wait_us += wait_us;
-                continue;
-            }
-        }
-        if (!PositionedWrite(data, allowed_bytes, file_offset)) {
-            Cleanup();
-            ThrowInfo(ErrorCode::FileWriteFailed,
-                      "Failed to write to file: {}, error: {}",
-                      filename_,
-                      strerror(errno));
-        }
-        file_offset += allowed_bytes;
-        bytes_to_write -= allowed_bytes;
-        data = static_cast<const char*>(data) + allowed_bytes;
+    try {
+        PositionedWriteWithRateLimit(fd_,
+                                     filename_,
+                                     rate_limiter_,
+                                     priority_,
+                                     alignment_bytes,
+                                     data,
+                                     nbyte,
+                                     file_offset);
+    } catch (...) {
+        Cleanup();
+        throw;
     }
 }
 
@@ -324,6 +367,164 @@ FileWriter::Finish() {
     Cleanup();
 
     // return the file size
+    return file_size_;
+}
+
+PositionedFileWriter::PositionedFileWriter(std::string filename,
+                                           size_t file_size,
+                                           io::Priority priority)
+    : filename_(std::move(filename)),
+      file_size_(file_size),
+      mode_(priority == io::Priority::HIGH ? FileWriter::WriteMode::BUFFERED
+                                           : FileWriter::GetMode()),
+      use_direct_io_(mode_ == FileWriter::WriteMode::DIRECT),
+      priority_(priority),
+      rate_limiter_(io::WriteRateLimiter::GetInstance()) {
+    auto open_flags = O_CREAT | O_RDWR | O_TRUNC;
+    if (use_direct_io_) {
+#ifndef __APPLE__
+        open_flags |= O_DIRECT;
+#endif
+    }
+
+    fd_ = open(filename_.c_str(), open_flags, S_IRUSR | S_IWUSR);
+    if (fd_ == -1) {
+        ThrowInfo(ErrorCode::FileCreateFailed,
+                  "Failed to open file: {}, error: {}",
+                  filename_,
+                  strerror(errno));
+    }
+
+#ifdef __APPLE__
+    if (use_direct_io_) {
+        auto ret = fcntl(fd_, F_NOCACHE, 1);
+        if (ret == -1) {
+            Cleanup();
+            ThrowInfo(ErrorCode::FileCreateFailed,
+                      "Failed to set F_NOCACHE on file: {}, error: {}",
+                      filename_,
+                      strerror(errno));
+        }
+    }
+#endif
+}
+
+PositionedFileWriter::~PositionedFileWriter() {
+    Cleanup();
+}
+
+void
+PositionedFileWriter::Cleanup() noexcept {
+    if (fd_ != -1) {
+        close(fd_);
+        fd_ = -1;
+    }
+}
+
+void
+PositionedFileWriter::WriteBufferedAt(size_t file_offset,
+                                      const void* data,
+                                      size_t size) {
+    PositionedWriteWithRateLimit(
+        fd_, filename_, rate_limiter_, priority_, 1, data, size, file_offset);
+}
+
+void
+PositionedFileWriter::WriteDirectAlignedAt(size_t file_offset,
+                                           const void* data,
+                                           size_t size) {
+    AssertInfo((file_offset & FileWriter::ALIGNMENT_MASK) == 0,
+               "Direct positioned write offset must be {}-byte aligned, got {}",
+               FileWriter::ALIGNMENT_BYTES,
+               file_offset);
+
+    auto end_offset = file_offset + size;
+    bool is_tail = end_offset == file_size_;
+    bool aligned_size = (size & FileWriter::ALIGNMENT_MASK) == 0;
+    AssertInfo(aligned_size || is_tail,
+               "Direct positioned write size must be {}-byte aligned unless "
+               "it is the file tail: offset {}, size {}, file size {}",
+               FileWriter::ALIGNMENT_BYTES,
+               file_offset,
+               size,
+               file_size_);
+
+    auto write_size = aligned_size ? size : RoundUpToAlignment(size);
+    bool aligned_data =
+        (reinterpret_cast<uintptr_t>(data) & FileWriter::ALIGNMENT_MASK) == 0;
+    if (aligned_data && write_size == size) {
+        PositionedWriteWithRateLimit(fd_,
+                                     filename_,
+                                     rate_limiter_,
+                                     priority_,
+                                     FileWriter::ALIGNMENT_BYTES,
+                                     data,
+                                     size,
+                                     file_offset);
+        return;
+    }
+
+    void* aligned_data_ptr =
+        aligned_alloc(FileWriter::ALIGNMENT_BYTES, write_size);
+    AssertInfo(aligned_data_ptr != nullptr,
+               "Failed to allocate aligned write buffer of size {}",
+               write_size);
+    auto free_aligned_data =
+        folly::makeGuard([aligned_data_ptr]() { free(aligned_data_ptr); });
+
+    memcpy(aligned_data_ptr, data, size);
+    if (write_size > size) {
+        memset(
+            static_cast<char*>(aligned_data_ptr) + size, 0, write_size - size);
+    }
+    PositionedWriteWithRateLimit(fd_,
+                                 filename_,
+                                 rate_limiter_,
+                                 priority_,
+                                 FileWriter::ALIGNMENT_BYTES,
+                                 aligned_data_ptr,
+                                 write_size,
+                                 file_offset);
+}
+
+void
+PositionedFileWriter::WriteAt(size_t file_offset,
+                              const void* data,
+                              size_t size) {
+    AssertInfo(!finished_, "Cannot write after Finish() has been called");
+    AssertInfo(fd_ != -1, "File is not open: {}", filename_);
+    if (size == 0) {
+        return;
+    }
+    AssertInfo(
+        data != nullptr, "Cannot write null data to file: {}", filename_);
+    AssertInfo(file_offset <= file_size_ && size <= file_size_ - file_offset,
+               "Positioned write exceeds file size: offset {}, size {}, file "
+               "size {}",
+               file_offset,
+               size,
+               file_size_);
+
+    if (use_direct_io_) {
+        WriteDirectAlignedAt(file_offset, data, size);
+    } else {
+        WriteBufferedAt(file_offset, data, size);
+    }
+}
+
+size_t
+PositionedFileWriter::Finish() {
+    AssertInfo(!finished_, "Finish() has already been called");
+    finished_ = true;
+
+    if (fd_ != -1 && ftruncate(fd_, file_size_) != 0) {
+        Cleanup();
+        ThrowInfo(ErrorCode::FileWriteFailed,
+                  "Failed to truncate file: {}, error: {}",
+                  filename_,
+                  strerror(errno));
+    }
+    Cleanup();
     return file_size_;
 }
 

--- a/internal/core/src/storage/FileWriter.h
+++ b/internal/core/src/storage/FileWriter.h
@@ -293,6 +293,45 @@ class FileWriter {
     io::WriteRateLimiter& rate_limiter_;
 };
 
+class PositionedFileWriter {
+ public:
+    explicit PositionedFileWriter(std::string filename,
+                                  size_t file_size,
+                                  io::Priority priority = io::Priority::MIDDLE);
+
+    ~PositionedFileWriter();
+
+    PositionedFileWriter(const PositionedFileWriter&) = delete;
+    PositionedFileWriter&
+    operator=(const PositionedFileWriter&) = delete;
+
+    void
+    WriteAt(size_t file_offset, const void* data, size_t size);
+
+    size_t
+    Finish();
+
+ private:
+    void
+    WriteBufferedAt(size_t file_offset, const void* data, size_t size);
+
+    void
+    WriteDirectAlignedAt(size_t file_offset, const void* data, size_t size);
+
+    void
+    Cleanup() noexcept;
+
+    int fd_{-1};
+    std::string filename_{""};
+    size_t file_size_{0};
+    FileWriter::WriteMode mode_{FileWriter::WriteMode::BUFFERED};
+    bool use_direct_io_{false};
+    bool finished_{false};
+
+    io::Priority priority_;
+    io::WriteRateLimiter& rate_limiter_;
+};
+
 class FileWriteWorkerPool {
  public:
     FileWriteWorkerPool() = default;

--- a/internal/core/src/storage/FileWriterTest.cpp
+++ b/internal/core/src/storage/FileWriterTest.cpp
@@ -376,6 +376,139 @@ TEST_F(FileWriterTest, ExistingFileWithDirectIO) {
     EXPECT_EQ(content, new_data);
 }
 
+TEST_F(FileWriterTest, PositionedWriterBufferedWritesOutOfOrder) {
+    FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
+
+    std::string filename =
+        (test_dir_ / "positioned_buffered_out_of_order.txt").string();
+    std::vector<char> data(kBufferSize * 3 + 17);
+    std::generate(data.begin(), data.end(), std::rand);
+
+    {
+        PositionedFileWriter writer(filename, data.size());
+        writer.WriteAt(kBufferSize * 2, data.data() + kBufferSize * 2, 17);
+        writer.WriteAt(0, data.data(), kBufferSize);
+        writer.WriteAt(kBufferSize, data.data() + kBufferSize, kBufferSize);
+        writer.WriteAt(kBufferSize * 2 + 17,
+                       data.data() + kBufferSize * 2 + 17,
+                       kBufferSize);
+        writer.Finish();
+    }
+
+    std::ifstream file(filename, std::ios::binary);
+    std::vector<char> read_data((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
+    EXPECT_EQ(read_data, data);
+}
+
+TEST_F(FileWriterTest, PositionedWriterDirectIOHandlesUnalignedInputAndTail) {
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(kBufferSize);
+
+    std::string filename =
+        (test_dir_ / "positioned_direct_unaligned_tail.txt").string();
+    std::vector<char> storage(kBufferSize * 2 + 18);
+    std::generate(storage.begin(), storage.end(), std::rand);
+    auto* data = storage.data() + 1;
+    const size_t data_size = kBufferSize * 2 + 17;
+
+    {
+        PositionedFileWriter writer(filename, data_size);
+        writer.WriteAt(kBufferSize, data + kBufferSize, kBufferSize);
+        writer.WriteAt(0, data, kBufferSize);
+        writer.WriteAt(kBufferSize * 2, data + kBufferSize * 2, 17);
+        writer.Finish();
+    }
+
+    std::ifstream file(filename, std::ios::binary);
+    std::vector<char> read_data((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
+    ASSERT_EQ(read_data.size(), data_size);
+    EXPECT_EQ(read_data, std::vector<char>(data, data + data_size));
+}
+
+TEST_F(FileWriterTest, PositionedWriterDirectIORejectsUnalignedOffset) {
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(kBufferSize);
+
+    std::string filename =
+        (test_dir_ / "positioned_direct_unaligned_offset.txt").string();
+    std::vector<char> data(kBufferSize);
+
+    PositionedFileWriter writer(filename, data.size() * 2);
+    EXPECT_THROW(writer.WriteAt(1, data.data(), data.size()),
+                 std::runtime_error);
+}
+
+TEST_F(FileWriterTest, PositionedWriterDirectIORejectsMiddleUnalignedWrite) {
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(kBufferSize);
+
+    std::string filename =
+        (test_dir_ / "positioned_direct_middle_tail.txt").string();
+    std::vector<char> data(kBufferSize * 2 + 17);
+
+    PositionedFileWriter writer(filename, data.size());
+    EXPECT_THROW(writer.WriteAt(kBufferSize, data.data(), 17),
+                 std::runtime_error);
+}
+
+TEST_F(FileWriterTest, PositionedWriterKeepsFileOpenAfterWriteAtError) {
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(kBufferSize);
+
+    std::string filename =
+        (test_dir_ / "positioned_direct_error_recovery.txt").string();
+    std::vector<char> data(kBufferSize * 2);
+    std::generate(data.begin(), data.end(), std::rand);
+
+    {
+        PositionedFileWriter writer(filename, data.size());
+        EXPECT_THROW(writer.WriteAt(kBufferSize, data.data(), 17),
+                     std::runtime_error);
+        writer.WriteAt(0, data.data(), kBufferSize);
+        writer.WriteAt(kBufferSize, data.data() + kBufferSize, kBufferSize);
+        writer.Finish();
+    }
+
+    std::ifstream file(filename, std::ios::binary);
+    std::vector<char> read_data((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
+    ASSERT_EQ(read_data.size(), data.size());
+    EXPECT_EQ(read_data, data);
+}
+
+TEST_F(FileWriterTest, PositionedWriterDirectIOSupportsConcurrentWrites) {
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(kBufferSize);
+
+    std::string filename =
+        (test_dir_ / "positioned_direct_concurrent.txt").string();
+    std::vector<char> data(kBufferSize * 8);
+    std::generate(data.begin(), data.end(), std::rand);
+
+    {
+        PositionedFileWriter writer(filename, data.size());
+        std::vector<std::thread> threads;
+        for (size_t i = 0; i < 8; ++i) {
+            threads.emplace_back([&, i]() {
+                writer.WriteAt(i * kBufferSize,
+                               data.data() + i * kBufferSize,
+                               kBufferSize);
+            });
+        }
+        for (auto& thread : threads) {
+            thread.join();
+        }
+        writer.Finish();
+    }
+
+    std::ifstream file(filename, std::ios::binary);
+    std::vector<char> read_data((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
+    EXPECT_EQ(read_data, data);
+}
+
 // Test rate limiter basic behavior: alignment and refill period
 TEST_F(FileWriterTest, RateLimiterAlignmentAndPeriods) {
     using milvus::storage::io::Priority;

--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -16,10 +16,7 @@
 
 #include "storage/IndexEntryReader.h"
 
-#include <fcntl.h>
-#include <unistd.h>
 #include <algorithm>
-#include <cerrno>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -89,6 +86,19 @@ EntryDownloadRangeCount(uint64_t size) {
         return 0;
     }
     return static_cast<size_t>((size - 1) / kEntryDownloadRangeSize + 1);
+}
+
+io::Priority
+WriterPriority(ThreadPoolPriority priority) {
+    switch (priority) {
+        case ThreadPoolPriority::HIGH:
+            return io::Priority::HIGH;
+        case ThreadPoolPriority::MIDDLE:
+            return io::Priority::MIDDLE;
+        case ThreadPoolPriority::LOW:
+            return io::Priority::LOW;
+    }
+    return io::Priority::MIDDLE;
 }
 
 void
@@ -386,8 +396,12 @@ IndexEntryReader::ReadFooterAndDirectory() {
         edek_ = dir_json["__edek__"].get<std::string>();
         ez_id_ = std::stoll(dir_json["__ez_id__"].get<std::string>());
         slice_size_ = dir_json["slice_size"].get<size_t>();
-        AssertInfo(slice_size_ > 0,
-                   "Encrypted entry slice_size must be positive");
+        AssertInfo(
+            slice_size_ != 0 && slice_size_ % FileWriter::ALIGNMENT_BYTES == 0,
+            "Encrypted V3 index slice size must be a positive multiple "
+            "of {} bytes, got {}",
+            FileWriter::ALIGNMENT_BYTES,
+            slice_size_);
 
         for (const auto& entry : dir_json["entries"]) {
             EntryMeta meta;
@@ -608,30 +622,19 @@ IndexEntryReader::EntryDownloadState
 IndexEntryReader::PrepareEntryDownload(const std::string& name,
                                        const std::string& local_path,
                                        const EntryMeta& meta) {
-    int fd = ::open(local_path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);
-    AssertInfo(fd != -1, "Failed to create file: {}", local_path);
-
     EntryDownloadState state;
     state.name = name;
-    state.fd = fd;
-
-    try {
-        if (meta.encrypted) {
-            state.expected_crc = meta.enc.crc32;
-            state.range_crcs.resize(meta.enc.slices.size());
-            auto trc_ret = ::ftruncate(fd, meta.enc.original_size);
-            AssertInfo(trc_ret == 0,
-                       "Failed to ftruncate file {}: {}",
-                       local_path,
-                       strerror(errno));
-        } else {
-            state.expected_crc = meta.plain.crc32;
-            size_t num_ranges = EntryDownloadRangeCount(meta.plain.size);
-            state.range_crcs.resize(num_ranges);
-        }
-    } catch (...) {
-        ::close(fd);
-        throw;
+    if (meta.encrypted) {
+        state.expected_crc = meta.enc.crc32;
+        state.range_crcs.resize(meta.enc.slices.size());
+        state.writer = std::make_unique<PositionedFileWriter>(
+            local_path, meta.enc.original_size, WriterPriority(priority_));
+    } else {
+        state.expected_crc = meta.plain.crc32;
+        size_t num_ranges = EntryDownloadRangeCount(meta.plain.size);
+        state.range_crcs.resize(num_ranges);
+        state.writer = std::make_unique<PositionedFileWriter>(
+            local_path, meta.plain.size, WriterPriority(priority_));
     }
 
     return state;
@@ -643,6 +646,7 @@ IndexEntryReader::SubmitEntryDownloadTasks(
     EntryDownloadState& state,
     std::vector<std::future<void>>& futures) {
     auto& pool = ThreadPools::GetThreadPool(priority_);
+    auto* writer = state.writer.get();
     futures.reserve(futures.size() + (meta.encrypted ? meta.enc.slices.size()
                                                      : EntryDownloadRangeCount(
                                                            meta.plain.size)));
@@ -669,7 +673,7 @@ IndexEntryReader::SubmitEntryDownloadTasks(
                                            collection_id,
                                            edek,
                                            slice,
-                                           fd = state.fd,
+                                           writer,
                                            this_output_offset,
                                            plain_len,
                                            i,
@@ -688,10 +692,7 @@ IndexEntryReader::SubmitEntryDownloadTasks(
                            "Decrypted size mismatch: expected {}, got {}",
                            plain_len,
                            plain.size());
-                auto written = ::pwrite(
-                    fd, plain.data(), plain.size(), this_output_offset);
-                AssertInfo(written == static_cast<ssize_t>(plain.size()),
-                           "Failed to pwrite");
+                writer->WriteAt(this_output_offset, plain.data(), plain.size());
                 state.range_crcs[i] = {
                     Crc32cValue(reinterpret_cast<const uint8_t*>(plain.data()),
                                 plain.size()),
@@ -715,7 +716,7 @@ IndexEntryReader::SubmitEntryDownloadTasks(
             futures.push_back(pool.Submit([input,
                                            this_src_offset,
                                            len,
-                                           fd = state.fd,
+                                           writer,
                                            this_file_offset,
                                            this_range_idx,
                                            &state]() {
@@ -723,9 +724,7 @@ IndexEntryReader::SubmitEntryDownloadTasks(
                 size_t n = input->ReadAt(
                     buf.data(), MILVUS_V3_MAGIC_SIZE + this_src_offset, len);
                 AssertInfo(n == len, "Failed to read data for file");
-                auto written = ::pwrite(fd, buf.data(), len, this_file_offset);
-                AssertInfo(written == static_cast<ssize_t>(len),
-                           "Failed to pwrite");
+                writer->WriteAt(this_file_offset, buf.data(), len);
                 state.range_crcs[this_range_idx] = {
                     Crc32cValue(buf.data(), len), len};
             }));
@@ -754,8 +753,8 @@ IndexEntryReader::FinalizeEntryDownload(EntryDownloadState& state) {
                Crc32cToHex(state.expected_crc),
                Crc32cToHex(combined_crc));
 
-    ::close(state.fd);
-    state.fd = -1;
+    state.writer->Finish();
+    state.writer.reset();
 }
 
 void
@@ -778,10 +777,7 @@ IndexEntryReader::ReadEntryToFile(const std::string& name,
         FinalizeEntryDownload(state);
     } catch (...) {
         WaitForAllFutures(futures);
-        if (state.fd != -1) {
-            ::close(state.fd);
-            state.fd = -1;
-        }
+        state.writer.reset();
         throw;
     }
 }
@@ -797,13 +793,9 @@ IndexEntryReader::ReadEntriesToFiles(
     std::vector<EntryDownloadState> states;
     states.reserve(name_path_pairs.size());
 
-    // Helper to close all open fds in states
-    auto close_all_fds = [&states]() {
+    auto reset_all_writers = [&states]() {
         for (auto& s : states) {
-            if (s.fd != -1) {
-                ::close(s.fd);
-                s.fd = -1;
-            }
+            s.writer.reset();
         }
     };
 
@@ -830,13 +822,13 @@ IndexEntryReader::ReadEntriesToFiles(
         // Wait for ALL tasks to complete
         RethrowIfError(WaitForAllFutures(all_futures));
 
-        // Verify CRCs and close all file descriptors
+        // Verify CRCs and finish all writers
         for (auto& state : states) {
             FinalizeEntryDownload(state);
         }
     } catch (...) {
         WaitForAllFutures(all_futures);
-        close_all_fds();
+        reset_all_writers();
         throw;
     }
 }

--- a/internal/core/src/storage/IndexEntryReader.h
+++ b/internal/core/src/storage/IndexEntryReader.h
@@ -28,6 +28,7 @@
 #include "common/EasyAssert.h"
 #include "filemanager/InputStream.h"
 #include "nlohmann/json.hpp"
+#include "storage/FileWriter.h"
 #include "storage/IndexEntryWriter.h"
 #include "storage/ThreadPools.h"
 #include "storage/plugin/PluginInterface.h"
@@ -171,12 +172,12 @@ class IndexEntryReader {
 
     struct EntryDownloadState {
         std::string name;
-        int fd;
+        std::unique_ptr<PositionedFileWriter> writer;
         uint32_t expected_crc;
         std::vector<RangeCrc> range_crcs;
     };
 
-    // Prepare download state for an entry (open file, allocate CRC vector)
+    // Prepare download state for an entry (open writer, allocate CRC vector)
     EntryDownloadState
     PrepareEntryDownload(const std::string& name,
                          const std::string& local_path,
@@ -188,7 +189,7 @@ class IndexEntryReader {
                              EntryDownloadState& state,
                              std::vector<std::future<void>>& futures);
 
-    // Verify CRC and close file descriptor
+    // Verify CRC and finish the writer
     void
     FinalizeEntryDownload(EntryDownloadState& state);
 

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -35,8 +35,10 @@
 #include "common/Common.h"
 #include "common/EasyAssert.h"
 #include "filemanager/InputStream.h"
+#include "folly/ScopeGuard.h"
 #include "test_utils/Constants.h"
 #include "milvus-storage/filesystem/fs.h"
+#include "storage/FileWriter.h"
 #include "storage/IndexEntryDirectStreamWriter.h"
 #include "storage/IndexEntryEncryptedLocalWriter.h"
 #include "storage/IndexEntryReader.h"
@@ -528,6 +530,57 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryToFile) {
     ::unlink(local_file.c_str());
 }
 
+TEST_F(IndexEntryWriterV3Test, ReadEntryToFileUsesWriterPriority) {
+    const std::string file_path = kV3FilePath + "_tofile_writer_priority";
+    const size_t entry_size = 4 * 1024;
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("file_entry", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(
+        input, file_size, 0, milvus::ThreadPoolPriority::LOW);
+
+    auto old_mode = FileWriter::GetMode();
+    auto& limiter = io::WriteRateLimiter::GetInstance();
+    auto restore_config = folly::makeGuard([old_mode, &limiter]() {
+        FileWriter::SetMode(old_mode);
+        limiter.Configure(/*refill_period_us=*/100000,
+                          /*avg_bps=*/8192 * 10,
+                          /*max_burst_bps=*/8192 * 40,
+                          /*high=*/-1,
+                          /*middle=*/-1,
+                          /*low=*/-1);
+    });
+
+    FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
+    limiter.Configure(/*refill_period_us=*/5000000,
+                      /*avg_bps=*/820,
+                      /*max_burst_bps=*/820,
+                      /*high=*/-1,
+                      /*middle=*/-1,
+                      /*low=*/1);
+    limiter.Reset();
+
+    std::string local_file = GetRootPath() + "/read_entry_writer_priority.bin";
+    reader->ReadEntryToFile("file_entry", local_file);
+
+    auto remaining_credit = limiter.Acquire(entry_size, 1, io::Priority::LOW);
+    EXPECT_LT(remaining_credit, entry_size);
+
+    std::ifstream ifs(local_file, std::ios::binary | std::ios::ate);
+    ASSERT_TRUE(ifs.is_open());
+    ASSERT_EQ(static_cast<size_t>(ifs.tellg()), entry_size);
+
+    ::unlink(local_file.c_str());
+}
+
 TEST_F(IndexEntryWriterV3Test, ReadEntriesToFiles) {
     const std::string file_path = kV3FilePath + "_tofiles";
     const size_t size_a = 256 * 1024;
@@ -768,9 +821,9 @@ TEST_F(IndexEntryWriterV3Test, ReadEntriesToFilesMultiRangeParallel) {
     const std::string file_path = kV3FilePath + "_multirange";
 
     // Each entry > 16MB to require multiple ranges
-    const size_t size_a = 35 * 1024 * 1024;  // 35 MB = 3 ranges
-    const size_t size_b = 50 * 1024 * 1024;  // 50 MB = 4 ranges
-    const size_t size_c = 20 * 1024 * 1024;  // 20 MB = 2 ranges
+    const size_t size_a = 35 * 1024 * 1024 + 17;    // 3 ranges
+    const size_t size_b = 50 * 1024 * 1024 + 123;   // 4 ranges
+    const size_t size_c = 20 * 1024 * 1024 + 2047;  // 2 ranges
     // Total: 9 parallel range tasks across 3 entries
 
     auto data_a = GeneratePattern(size_a);
@@ -788,7 +841,13 @@ TEST_F(IndexEntryWriterV3Test, ReadEntriesToFilesMultiRangeParallel) {
 
     auto input = CreateInputStream(file_path);
     int64_t file_size = GetFileSize(file_path);
-    auto reader = IndexEntryReader::Open(input, file_size);
+    auto reader = IndexEntryReader::Open(
+        input, file_size, 0, milvus::ThreadPoolPriority::LOW);
+
+    auto old_mode = FileWriter::GetMode();
+    auto restore_mode =
+        folly::makeGuard([old_mode]() { FileWriter::SetMode(old_mode); });
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
 
     std::string file_a = GetRootPath() + "/multirange_a.bin";
     std::string file_b = GetRootPath() + "/multirange_b.bin";
@@ -1005,12 +1064,34 @@ class IndexEntryEncryptedV3Test : public IndexEntryWriterV3Test {
     std::shared_ptr<MockCipherPlugin> mock_cipher_;
 };
 
+TEST_F(IndexEntryEncryptedV3Test, RejectsUnalignedSliceSize) {
+    const std::string file_path = kV3FilePath + "_enc_unaligned_slice_size";
+    constexpr size_t slice_size = 512;
+    auto data = GeneratePattern(1024);
+
+    {
+        IndexEntryEncryptedLocalWriter writer(file_path,
+                                              fs_,
+                                              mock_cipher_,
+                                              /*ez_id=*/1,
+                                              /*collection_id=*/100,
+                                              GetRootPath(),
+                                              slice_size);
+        writer.WriteEntry("enc_entry", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    auto file_size = GetFileSize(file_path);
+    EXPECT_THROW(IndexEntryReader::Open(input, file_size, 100),
+                 milvus::SegcoreError);
+}
+
 TEST_F(IndexEntryEncryptedV3Test, EncryptedSmallEntryRoundtrip) {
     const std::string file_path = kV3FilePath + "_enc_small";
-    const size_t entry_size = 1024;
+    constexpr size_t slice_size = FileWriter::ALIGNMENT_BYTES;
+    const size_t entry_size = 2 * slice_size;
     auto data = GeneratePattern(entry_size);
-
-    const size_t slice_size = 1024;
 
     {
         // Note: remote_path should be relative to fs root
@@ -1066,8 +1147,8 @@ TEST_F(IndexEntryEncryptedV3Test, EncryptedWriterCreatesMissingTempDir) {
 TEST_F(IndexEntryEncryptedV3Test, EncryptedMultiSliceEntry) {
     // Entry larger than slice_size, requiring multiple slices
     const std::string file_path = kV3FilePath + "_enc_multislice";
-    const size_t slice_size = 1024;
-    const size_t entry_size = 5 * slice_size + 100;
+    constexpr size_t slice_size = FileWriter::ALIGNMENT_BYTES;
+    const size_t entry_size = 5 * slice_size + 100;  // 6 slices
     auto data = GeneratePattern(entry_size);
 
     {
@@ -1092,11 +1173,11 @@ TEST_F(IndexEntryEncryptedV3Test, EncryptedMultiSliceEntry) {
 TEST_F(IndexEntryEncryptedV3Test, EncryptedMultipleEntriesMultiSlice) {
     // Multiple entries, each requiring multiple slices
     const std::string file_path = kV3FilePath + "_enc_multi_multi";
-    const size_t slice_size = 1024;
+    constexpr size_t slice_size = FileWriter::ALIGNMENT_BYTES;
 
-    const size_t size_a = 3 * slice_size + 500;
-    const size_t size_b = 2 * slice_size + 100;
-    const size_t size_c = 5 * slice_size;
+    const size_t size_a = 3 * slice_size + 500;  // 4 slices
+    const size_t size_b = 2 * slice_size + 100;  // 3 slices
+    const size_t size_c = 5 * slice_size;        // 5 slices
 
     auto data_a = GeneratePattern(size_a);
     auto data_b = GeneratePattern(size_b);
@@ -1128,7 +1209,7 @@ TEST_F(IndexEntryEncryptedV3Test, EncryptedMultipleEntriesMultiSlice) {
 TEST_F(IndexEntryEncryptedV3Test, EncryptedLargeMetaMultiSlice) {
     // Large meta entry requiring multiple slices
     const std::string file_path = kV3FilePath + "_enc_largemeta";
-    const size_t slice_size = 1024;
+    constexpr size_t slice_size = FileWriter::ALIGNMENT_BYTES;
 
     auto data = GeneratePattern(256);
 
@@ -1162,8 +1243,8 @@ TEST_F(IndexEntryEncryptedV3Test, EncryptedLargeMetaMultiSlice) {
 TEST_F(IndexEntryEncryptedV3Test, EncryptedFdEntryMultiSlice) {
     // Test fd-based entry with multiple slices
     const std::string file_path = kV3FilePath + "_enc_fd";
-    const size_t slice_size = 1024;
-    const size_t entry_size = 4 * slice_size + 200;
+    constexpr size_t slice_size = FileWriter::ALIGNMENT_BYTES;
+    const size_t entry_size = 4 * slice_size + 200;  // 5 slices
     auto data = GeneratePattern(entry_size);
 
     // Write source file
@@ -1204,7 +1285,7 @@ TEST_F(IndexEntryEncryptedV3Test, EncryptedFdEntryMultiSlice) {
 TEST_F(IndexEntryEncryptedV3Test,
        EncryptedDirectoryValidationAcceptsValidDirectory) {
     const std::string file_path = kV3FilePath + "_dir_valid";
-    const size_t slice_size = 1024;
+    constexpr size_t slice_size = FileWriter::ALIGNMENT_BYTES;
     const size_t entry_size = 2 * slice_size + 100;  // 3 slices
     auto data = GeneratePattern(entry_size);
 
@@ -1233,7 +1314,7 @@ TEST_F(IndexEntryEncryptedV3Test,
 TEST_F(IndexEntryEncryptedV3Test,
        EncryptedDirectoryValidationRejectsSliceOffsetPastDataRegion) {
     const std::string file_path = kV3FilePath + "_dir_bad_slice_offset";
-    constexpr size_t slice_size = 1024;
+    constexpr size_t slice_size = FileWriter::ALIGNMENT_BYTES;
     auto data = GeneratePattern(2 * slice_size + 100);
 
     {
@@ -1272,7 +1353,7 @@ TEST_F(IndexEntryEncryptedV3Test,
 TEST_F(IndexEntryEncryptedV3Test,
        EncryptedDirectoryValidationRejectsSliceSizePastDataRegion) {
     const std::string file_path = kV3FilePath + "_dir_bad_slice_size";
-    constexpr size_t slice_size = 1024;
+    constexpr size_t slice_size = FileWriter::ALIGNMENT_BYTES;
     auto data = GeneratePattern(2 * slice_size + 100);
 
     {
@@ -1311,7 +1392,7 @@ TEST_F(IndexEntryEncryptedV3Test,
 TEST_F(IndexEntryEncryptedV3Test,
        EncryptedDirectoryValidationRejectsOutOfRangeSlice) {
     const std::string file_path = kV3FilePath + "_dir_out_of_range";
-    const size_t slice_size = 1024;
+    constexpr size_t slice_size = FileWriter::ALIGNMENT_BYTES;
     const size_t entry_size = 2 * slice_size + 100;  // 3 slices
     auto data = GeneratePattern(entry_size);
 
@@ -1353,7 +1434,7 @@ TEST_F(IndexEntryEncryptedV3Test,
 TEST_F(IndexEntryEncryptedV3Test,
        EncryptedDirectoryValidationRejectsIncompleteCoverage) {
     const std::string file_path = kV3FilePath + "_dir_incomplete";
-    const size_t slice_size = 1024;
+    constexpr size_t slice_size = FileWriter::ALIGNMENT_BYTES;
     const size_t entry_size = 2 * slice_size + 100;  // 3 slices
     auto data = GeneratePattern(entry_size);
 

--- a/internal/core/src/storage/ThreadPool.cpp
+++ b/internal/core/src/storage/ThreadPool.cpp
@@ -15,6 +15,9 @@
 // limitations under the License.
 
 #include "ThreadPool.h"
+
+#include <algorithm>
+
 #include "log/Log.h"
 
 namespace milvus {
@@ -66,9 +69,7 @@ void
 ThreadPool::Init() {
     std::lock_guard<std::mutex> lock(mutex_);
     for (int i = 0; i < min_threads_size_; i++) {
-        std::thread t(&ThreadPool::Worker, this);
-        assert(threads_.find(t.get_id()) == threads_.end());
-        threads_[t.get_id()] = std::move(t);
+        threads_.emplace_back(&ThreadPool::Worker, this);
         current_threads_size_++;
     }
 }
@@ -82,8 +83,8 @@ ThreadPool::ShutDown() {
     }
     condition_lock_.notify_all();
     for (auto& thread : threads_) {
-        if (thread.second.joinable()) {
-            thread.second.join();
+        if (thread.joinable()) {
+            thread.join();
         }
     }
     LOG_INFO("Finish shutting down {}", name_);
@@ -95,10 +96,13 @@ ThreadPool::FinishThreads() {
         std::thread::id id;
         auto dequeue = need_finish_threads_.dequeue(id);
         if (dequeue) {
-            auto iter = threads_.find(id);
+            auto iter = std::find_if(
+                threads_.begin(), threads_.end(), [id](const std::thread& t) {
+                    return t.get_id() == id;
+                });
             assert(iter != threads_.end());
-            if (iter->second.joinable()) {
-                iter->second.join();
+            if (iter->joinable()) {
+                iter->join();
             }
             threads_.erase(iter);
         }

--- a/internal/core/src/storage/ThreadPool.h
+++ b/internal/core/src/storage/ThreadPool.h
@@ -16,15 +16,21 @@
 
 #pragma once
 
+#include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <cmath>
+#include <condition_variable>
 #include <functional>
 #include <future>
-#include <mutex>
+#include <list>
 #include <memory>
+#include <mutex>
 #include <queue>
+#include <string>
 #include <thread>
-#include <vector>
 #include <utility>
-#include <cassert>
+#include <vector>
 
 #include <prometheus/counter.h>
 #include <prometheus/gauge.h>
@@ -123,15 +129,10 @@ class ThreadPool {
 
         std::function<void()> wrap_func = [task_ptr]() { (*task_ptr)(); };
 
-        work_queue_.enqueue(wrap_func);
-        if (metric_submitted_) {
-            metric_submitted_->Increment();
-        }
-        if (metric_queue_depth_) {
-            metric_queue_depth_->Set(work_queue_.size());
-        }
+        auto future = task_ptr->get_future();
 
-        std::lock_guard<std::mutex> lock(mutex_);
+        std::unique_lock<std::mutex> lock(mutex_);
+        work_queue_.enqueue(std::move(wrap_func));
 
         if (idle_threads_size_ > 0) {
             condition_lock_.notify_one();
@@ -140,9 +141,10 @@ class ThreadPool {
             current_threads_size_ < max_threads_size_.load()) {
             // Dynamic increase thread number
             try {
-                std::thread t(&ThreadPool::Worker, this);
-                assert(threads_.find(t.get_id()) == threads_.end());
-                threads_[t.get_id()] = std::move(t);
+                if (worker_spawn_hook_for_test_) {
+                    worker_spawn_hook_for_test_();
+                }
+                threads_.emplace_back(&ThreadPool::Worker, this);
                 current_threads_size_++;
             } catch (const std::exception& e) {
                 LOG_WARN(
@@ -151,8 +153,24 @@ class ThreadPool {
                 LOG_WARN("Failed to expand thread pool {}", name_);
             }
         }
+        lock.unlock();
 
-        return task_ptr->get_future();
+        try {
+            if (metric_submitted_) {
+                metric_submitted_->Increment();
+            }
+            if (metric_queue_depth_) {
+                metric_queue_depth_->Set(work_queue_.size());
+            }
+        } catch (const std::exception& e) {
+            LOG_WARN("Failed to update thread pool {} submit metrics: {}",
+                     name_,
+                     e.what());
+        } catch (...) {
+            LOG_WARN("Failed to update thread pool {} submit metrics", name_);
+        }
+
+        return future;
     }
 
     void
@@ -212,7 +230,7 @@ class ThreadPool {
     bool shutdown_;
     static constexpr size_t WAIT_SECONDS = 2;
     SafeQueue<std::function<void()>> work_queue_;
-    std::unordered_map<std::thread::id, std::thread> threads_;
+    std::list<std::thread> threads_;
     SafeQueue<std::thread::id> need_finish_threads_;
     std::mutex mutex_;
     std::condition_variable condition_lock_;
@@ -225,6 +243,12 @@ class ThreadPool {
     prometheus::Gauge* metric_queue_depth_{nullptr};
     prometheus::Counter* metric_submitted_{nullptr};
     prometheus::Counter* metric_completed_{nullptr};
+
+ private:
+    friend class ThreadPoolTest_WorkerSpawnFailureDoesNotFailQueuedTask_Test;
+
+    // Deterministic test seam for worker-spawn failure coverage.
+    std::function<void()> worker_spawn_hook_for_test_;
 };
 
 }  // namespace milvus

--- a/internal/core/src/storage/ThreadPoolTest.cpp
+++ b/internal/core/src/storage/ThreadPoolTest.cpp
@@ -14,6 +14,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <system_error>
+
 #include <gtest/gtest.h>
 
 #include "storage/ThreadPool.h"
@@ -134,6 +139,39 @@ TEST_F(ThreadPoolTest, DynamicMaxThreadsSizeUpdate) {
     SetThreadPoolMaxThreadsSize(8);
     pool.Resize(20);
     EXPECT_EQ(pool.GetMaxThreadNum(), 8);
+}
+
+TEST_F(ThreadPoolTest, WorkerSpawnFailureDoesNotFailQueuedTask) {
+    ThreadPool pool(1.0, "test_pool");
+
+    std::promise<void> blocker_started;
+    std::promise<void> unblock_worker;
+    auto unblock_future = unblock_worker.get_future().share();
+    auto blocker = pool.Submit([&blocker_started, unblock_future]() {
+        blocker_started.set_value();
+        unblock_future.wait();
+    });
+    ASSERT_EQ(blocker_started.get_future().wait_for(std::chrono::seconds(2)),
+              std::future_status::ready);
+
+    pool.worker_spawn_hook_for_test_ = []() {
+        throw std::system_error(
+            std::make_error_code(std::errc::resource_unavailable_try_again));
+    };
+
+    std::atomic<int> task_runs{0};
+    std::future<void> task_future;
+    EXPECT_NO_THROW(
+        task_future = pool.Submit([&task_runs]() { task_runs.fetch_add(1); }));
+
+    unblock_worker.set_value();
+    blocker.get();
+
+    ASSERT_TRUE(task_future.valid());
+    ASSERT_EQ(task_future.wait_for(std::chrono::seconds(2)),
+              std::future_status::ready);
+    task_future.get();
+    EXPECT_EQ(task_runs.load(), 1);
 }
 
 }  // namespace milvus

--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update KNOWHERE_VERSION for the first occurrence
 milvus_add_pkg_config("knowhere")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( KNOWHERE_VERSION v2.6.19 )
+set( KNOWHERE_VERSION v2.6.20 )
 set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
 
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")

--- a/internal/core/thirdparty/milvus-common/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-common/CMakeLists.txt
@@ -13,7 +13,7 @@
 
 milvus_add_pkg_config("milvus-common")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( MILVUS-COMMON-VERSION c4ea184 )
+set( MILVUS-COMMON-VERSION 54cb8fe )
 set( GIT_REPOSITORY "https://github.com/zilliztech/milvus-common.git")
 
 message(STATUS "milvus-common repo: ${GIT_REPOSITORY}")

--- a/internal/core/unittest/test_loading.cpp
+++ b/internal/core/unittest/test_loading.cpp
@@ -31,6 +31,26 @@
 using Param =
     std::pair<std::map<std::string, std::string>, LoadResourceRequest>;
 
+class ThreadPoolMaxSizeGuard {
+ public:
+    ThreadPoolMaxSizeGuard(milvus::ThreadPool& pool, int max_threads)
+        : pool_(pool), original_max_threads_(pool.GetMaxThreadNum()) {
+        pool_.Resize(max_threads);
+    }
+
+    ~ThreadPoolMaxSizeGuard() {
+        pool_.Resize(static_cast<int>(original_max_threads_));
+    }
+
+    ThreadPoolMaxSizeGuard(const ThreadPoolMaxSizeGuard&) = delete;
+    ThreadPoolMaxSizeGuard&
+    operator=(const ThreadPoolMaxSizeGuard&) = delete;
+
+ private:
+    milvus::ThreadPool& pool_;
+    const size_t original_max_threads_;
+};
+
 class IndexLoadTest : public ::testing::TestWithParam<Param> {
  protected:
     void
@@ -404,6 +424,45 @@ TEST(IndexLoadTest, ScalarV3SortUsesStreamConcurrencyBound) {
                                                         0,
                                                         0);
     EXPECT_EQ(small_mmap_request.max_memory_cost, kSmallIndexSize);
+}
+
+TEST(IndexLoadTest, ScalarV3EstimateUsesConfiguredLoadPriority) {
+    auto& high_pool =
+        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH);
+    auto& low_pool =
+        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
+    ThreadPoolMaxSizeGuard high_pool_guard(high_pool, 2);
+    ThreadPoolMaxSizeGuard low_pool_guard(low_pool, 1);
+
+    constexpr uint64_t kIndexSize = 1024UL * 1024 * 1024;
+    const auto high_stream_overhead = 2UL * DEFAULT_INDEX_FILE_SLICE_SIZE;
+    const auto low_stream_overhead = DEFAULT_INDEX_FILE_SLICE_SIZE;
+
+    auto estimate_mmap_peak = [](const std::string& index_type,
+                                 const char* load_priority) {
+        std::map<std::string, std::string> index_params{
+            {milvus::index::INDEX_TYPE, index_type},
+            {milvus::index::SCALAR_INDEX_ENGINE_VERSION, "3"}};
+        if (load_priority != nullptr) {
+            index_params[milvus::LOAD_PRIORITY] = load_priority;
+        }
+        return milvus::index::IndexFactory::GetInstance()
+            .ScalarIndexLoadResource(
+                milvus::DataType::VARCHAR, 0, kIndexSize, index_params, true, 0)
+            .max_memory_cost;
+    };
+
+    for (const auto* index_type : {milvus::index::ASCENDING_SORT,
+                                   milvus::index::MARISA_TRIE,
+                                   milvus::index::INVERTED_INDEX_TYPE,
+                                   milvus::index::NGRAM_INDEX_TYPE}) {
+        EXPECT_EQ(estimate_mmap_peak(index_type, "LOW"), low_stream_overhead)
+            << index_type;
+    }
+    EXPECT_EQ(estimate_mmap_peak(milvus::index::BITMAP_INDEX_TYPE, "LOW"),
+              kIndexSize + low_stream_overhead);
+    EXPECT_EQ(estimate_mmap_peak(milvus::index::ASCENDING_SORT, nullptr),
+              high_stream_overhead);
 }
 
 TEST(IndexLoadTest, ScalarV2SortRetainsWholeEntryBound) {

--- a/internal/core/unittest/test_loading.cpp
+++ b/internal/core/unittest/test_loading.cpp
@@ -19,10 +19,14 @@
 #include <vector>
 #include <map>
 
+#include "common/Consts.h"
 #include "segcore/Types.h"
+#include "index/IndexFactory.h"
+#include "index/Meta.h"
 #include "knowhere/version.h"
 #include "knowhere/comp/index_param.h"
 #include "segcore/load_index_c.h"
+#include "storage/ThreadPools.h"
 
 using Param =
     std::pair<std::map<std::string, std::string>, LoadResourceRequest>;
@@ -314,6 +318,132 @@ TEST_P(IndexLoadTest, ResourceEstimate) {
     ASSERT_EQ(request.final_disk_cost, expected.final_disk_cost);
     ASSERT_EQ(request.max_memory_cost, expected.max_memory_cost);
     ASSERT_EQ(request.max_disk_cost, expected.max_disk_cost);
+}
+
+TEST(IndexLoadTest, ScalarV3MmapTantivyUsesDownloadConcurrencyBound) {
+    constexpr uint64_t kIndexSize = 1024UL * 1024 * 1024;
+    constexpr int64_t kNumRows = 64UL * 1024 * 1024;
+    constexpr uint64_t kValidityBitmapBytes = kNumRows / 8;
+    const auto worker_count = std::max<size_t>(
+        1,
+        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH)
+            .GetMaxThreadNum());
+    const auto expected_download_peak = std::min<uint64_t>(
+        kIndexSize, worker_count * DEFAULT_INDEX_FILE_SLICE_SIZE);
+
+    for (const auto* index_type : {milvus::index::INVERTED_INDEX_TYPE,
+                                   milvus::index::NGRAM_INDEX_TYPE}) {
+        std::map<std::string, std::string> index_params{
+            {milvus::index::INDEX_TYPE, index_type},
+            {milvus::index::SCALAR_INDEX_ENGINE_VERSION, "3"}};
+        milvus::segcore::LoadIndexInfo load_index_info{};
+        load_index_info.field_type = milvus::DataType::VARCHAR;
+        load_index_info.element_type = milvus::DataType::NONE;
+        load_index_info.enable_mmap = true;
+        load_index_info.index_params = index_params;
+        load_index_info.index_size = kIndexSize;
+        load_index_info.num_rows = kNumRows;
+        load_index_info.schema.set_nullable(false);
+
+        auto request = EstimateLoadIndexResource(&load_index_info);
+
+        EXPECT_EQ(request.max_memory_cost,
+                  expected_download_peak + kValidityBitmapBytes);
+        EXPECT_EQ(request.max_disk_cost, kIndexSize);
+        EXPECT_EQ(request.final_memory_cost, kValidityBitmapBytes);
+        EXPECT_EQ(request.final_disk_cost, kIndexSize);
+    }
+}
+
+TEST(IndexLoadTest, ScalarV3SortUsesStreamConcurrencyBound) {
+    constexpr uint64_t kIndexSize = 1024UL * 1024 * 1024;
+    constexpr uint64_t kSmallIndexSize = DEFAULT_INDEX_FILE_SLICE_SIZE / 2;
+    const auto worker_count = std::max<size_t>(
+        1,
+        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH)
+            .GetMaxThreadNum());
+    const auto stream_overhead = std::min<uint64_t>(
+        kIndexSize, worker_count * DEFAULT_INDEX_FILE_SLICE_SIZE);
+    std::map<std::string, std::string> index_params{
+        {milvus::index::INDEX_TYPE, milvus::index::ASCENDING_SORT},
+        {milvus::index::SCALAR_INDEX_ENGINE_VERSION, "3"}};
+
+    auto& factory = milvus::index::IndexFactory::GetInstance();
+    auto memory_request = factory.IndexLoadResource(milvus::DataType::INT64,
+                                                    milvus::DataType::NONE,
+                                                    0,
+                                                    kIndexSize,
+                                                    index_params,
+                                                    false,
+                                                    0,
+                                                    0);
+    EXPECT_EQ(memory_request.final_memory_cost, kIndexSize);
+    EXPECT_EQ(memory_request.final_disk_cost, 0);
+    EXPECT_EQ(memory_request.max_memory_cost, kIndexSize + stream_overhead);
+    EXPECT_EQ(memory_request.max_disk_cost, 0);
+
+    auto mmap_request = factory.IndexLoadResource(milvus::DataType::INT64,
+                                                  milvus::DataType::NONE,
+                                                  0,
+                                                  kIndexSize,
+                                                  index_params,
+                                                  true,
+                                                  0,
+                                                  0);
+    EXPECT_EQ(mmap_request.final_memory_cost, 0);
+    EXPECT_EQ(mmap_request.final_disk_cost, kIndexSize);
+    EXPECT_EQ(mmap_request.max_memory_cost, stream_overhead);
+    EXPECT_EQ(mmap_request.max_disk_cost, kIndexSize);
+
+    auto small_mmap_request = factory.IndexLoadResource(milvus::DataType::INT64,
+                                                        milvus::DataType::NONE,
+                                                        0,
+                                                        kSmallIndexSize,
+                                                        index_params,
+                                                        true,
+                                                        0,
+                                                        0);
+    EXPECT_EQ(small_mmap_request.max_memory_cost, kSmallIndexSize);
+}
+
+TEST(IndexLoadTest, ScalarV2SortRetainsWholeEntryBound) {
+    constexpr uint64_t kIndexSize = 1024UL * 1024 * 1024;
+    std::map<std::string, std::string> index_params{
+        {milvus::index::INDEX_TYPE, milvus::index::ASCENDING_SORT},
+        {milvus::index::SCALAR_INDEX_ENGINE_VERSION, "2"}};
+
+    auto request = milvus::index::IndexFactory::GetInstance().IndexLoadResource(
+        milvus::DataType::INT64,
+        milvus::DataType::NONE,
+        0,
+        kIndexSize,
+        index_params,
+        false,
+        0,
+        0);
+
+    EXPECT_EQ(request.final_memory_cost, kIndexSize);
+    EXPECT_EQ(request.max_memory_cost, 2 * kIndexSize);
+}
+
+TEST(IndexLoadTest, ScalarV3MmapRTreeRetainsWholeIndexLoadingEstimate) {
+    constexpr uint64_t kIndexSize = 1024UL * 1024 * 1024;
+    std::map<std::string, std::string> index_params{
+        {milvus::index::INDEX_TYPE, milvus::index::RTREE_INDEX_TYPE},
+        {milvus::index::SCALAR_INDEX_ENGINE_VERSION, "3"}};
+
+    auto request = milvus::index::IndexFactory::GetInstance().IndexLoadResource(
+        milvus::DataType::GEOMETRY,
+        milvus::DataType::NONE,
+        0,
+        kIndexSize,
+        index_params,
+        true,
+        10'000'000,
+        0);
+
+    EXPECT_EQ(request.max_memory_cost, kIndexSize);
+    EXPECT_EQ(request.final_disk_cost, kIndexSize);
 }
 
 // Test that warmup policy is kept in index_params and passed to Knowhere

--- a/internal/core/unittest/test_utils/cachinglayer_test_utils.h
+++ b/internal/core/unittest/test_utils/cachinglayer_test_utils.h
@@ -73,7 +73,7 @@ class TestChunkTranslator : public Translator<milvus::Chunk> {
     }
 
     std::pair<ResourceUsage, ResourceUsage>
-    estimated_byte_size_of_cell(cid_t cid) const override {
+    estimated_loading_usage(const std::vector<cid_t>&) const override {
         return {{0, 0}, {0, 0}};
     }
 
@@ -149,7 +149,7 @@ class TestGroupChunkTranslator : public Translator<milvus::GroupChunk> {
     }
 
     std::pair<ResourceUsage, ResourceUsage>
-    estimated_byte_size_of_cell(cid_t cid) const override {
+    estimated_loading_usage(const std::vector<cid_t>&) const override {
         return {{0, 0}, {0, 0}};
     }
 
@@ -214,7 +214,7 @@ class TestIndexTranslator : public Translator<milvus::index::IndexBase> {
     }
 
     std::pair<ResourceUsage, ResourceUsage>
-    estimated_byte_size_of_cell(cid_t cid) const override {
+    estimated_loading_usage(const std::vector<cid_t>&) const override {
         return {{0, 0}, {0, 0}};
     }
 

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -377,6 +377,7 @@ func InitTieredStorage(params *paramtable.ComponentParam) error {
 	loadingResourceFactor := C.float(params.QueryNodeCfg.TieredLoadingResourceFactor.GetAsFloat())
 	loadingTimeoutMs := C.int64_t(params.QueryNodeCfg.TieredLoadingTimeoutMs.GetAsInt64())
 	warmupLoadingTimeoutMs := C.int64_t(params.QueryNodeCfg.TieredWarmupLoadingTimeoutMs.GetAsInt64())
+	maxLoadingMemoryRatio := C.double(params.QueryNodeCfg.TieredMaxLoadingMemoryRatio.GetAsFloat())
 	overloadedMemoryThresholdPercentage := C.float(memoryMaxRatio)
 	maxDiskUsagePercentage := C.float(diskMaxRatio)
 	diskPath := C.CString(params.LocalStorageCfg.Path.GetValue())
@@ -392,7 +393,7 @@ func InitTieredStorage(params *paramtable.ComponentParam) error {
 		evictionEnabled, cacheTouchWindowMs,
 		backgroundEvictionEnabled, evictionIntervalMs, cacheCellUnaccessedSurvivalTime,
 		overloadedMemoryThresholdPercentage, loadingResourceFactor, maxDiskUsagePercentage, diskPath,
-		loadingTimeoutMs, warmupLoadingTimeoutMs)
+		loadingTimeoutMs, warmupLoadingTimeoutMs, maxLoadingMemoryRatio)
 
 	tieredEvictableMemoryCacheRatio := params.QueryNodeCfg.TieredEvictableMemoryCacheRatio.GetAsFloat()
 	tieredEvictableDiskCacheRatio := params.QueryNodeCfg.TieredEvictableDiskCacheRatio.GetAsFloat()
@@ -436,6 +437,7 @@ func UpdateTieredStorageConfig(params *paramtable.ComponentParam) error {
 	loadingTimeoutMs := C.int64_t(params.QueryNodeCfg.TieredLoadingTimeoutMs.GetAsInt64())
 	warmupLoadingTimeoutMs := C.int64_t(params.QueryNodeCfg.TieredWarmupLoadingTimeoutMs.GetAsInt64())
 	storageUsageTrackingEnabled := C.bool(params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool())
+	maxLoadingMemoryRatio := C.double(params.QueryNodeCfg.TieredMaxLoadingMemoryRatio.GetAsFloat())
 
 	C.UpdateTieredStorageConfig(
 		loadingTimeoutMs,
@@ -444,7 +446,8 @@ func UpdateTieredStorageConfig(params *paramtable.ComponentParam) error {
 		scalarFieldCacheWarmupPolicy,
 		vectorFieldCacheWarmupPolicy,
 		scalarIndexCacheWarmupPolicy,
-		vectorIndexCacheWarmupPolicy)
+		vectorIndexCacheWarmupPolicy,
+		maxLoadingMemoryRatio)
 
 	return nil
 }
@@ -681,6 +684,7 @@ func SetupCoreConfigChangelCallback() {
 		paramtable.Get().QueryNodeCfg.TieredWarmupVectorField.RegisterCallback(updateTieredStorageConfigCallback)
 		paramtable.Get().QueryNodeCfg.TieredWarmupScalarIndex.RegisterCallback(updateTieredStorageConfigCallback)
 		paramtable.Get().QueryNodeCfg.TieredWarmupVectorIndex.RegisterCallback(updateTieredStorageConfigCallback)
+		paramtable.Get().QueryNodeCfg.TieredMaxLoadingMemoryRatio.RegisterCallback(updateTieredStorageConfigCallback)
 	})
 }
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3485,6 +3485,7 @@ type queryNodeConfig struct {
 	TieredEvictionIntervalMs        ParamItem `refreshable:"false"`
 	CacheCellUnaccessedSurvivalTime ParamItem `refreshable:"false"`
 	TieredLoadingResourceFactor     ParamItem `refreshable:"false"`
+	TieredMaxLoadingMemoryRatio     ParamItem `refreshable:"true"`
 	TieredLoadingTimeoutMs          ParamItem `refreshable:"true"`
 	TieredWarmupLoadingTimeoutMs    ParamItem `refreshable:"true"`
 	StorageUsageTrackingEnabled     ParamItem `refreshable:"true"`
@@ -3959,6 +3960,22 @@ If set to 0, time based eviction is disabled.`,
 		Export: false,
 	}
 	p.TieredLoadingResourceFactor.Init(base.mgr)
+
+	p.TieredMaxLoadingMemoryRatio = ParamItem{
+		Key:          "queryNode.segcore.tieredStorage.maxLoadingMemoryRatio",
+		Version:      "2.6.23",
+		DefaultValue: "1.0",
+		Formatter: func(v string) string {
+			ratio := getAsFloat(v)
+			if ratio <= 0 || ratio > 1 {
+				return "1.0"
+			}
+			return fmt.Sprintf("%f", ratio)
+		},
+		Doc:    "Maximum ratio of effective memory that may be used by concurrent caching-layer loading. Valid range: (0.0, 1.0].",
+		Export: false,
+	}
+	p.TieredMaxLoadingMemoryRatio.Init(base.mgr)
 
 	p.TieredLoadingTimeoutMs = ParamItem{
 		Key:          "queryNode.segcore.tieredStorage.loadingTimeoutMs",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -17,6 +17,7 @@
 package paramtable
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -980,4 +981,27 @@ func TestQueryCoordForceLoadPriority(t *testing.T) {
 			assert.Equal(t, tc.expected, standardized)
 		}
 	})
+}
+
+func TestQueryNodeMaxLoadingMemoryRatio(t *testing.T) {
+	Init()
+	params := Get()
+	item := &params.QueryNodeCfg.TieredMaxLoadingMemoryRatio
+	defer params.Reset(item.Key)
+
+	assert.Equal(t, "queryNode.segcore.tieredStorage.maxLoadingMemoryRatio", item.Key)
+	assert.False(t, item.Forbidden)
+	field, ok := reflect.TypeOf(&params.QueryNodeCfg).Elem().FieldByName("TieredMaxLoadingMemoryRatio")
+	assert.True(t, ok)
+	assert.Equal(t, "true", field.Tag.Get("refreshable"))
+	assert.InDelta(t, 1.0, item.GetAsFloat(), 0.0001)
+
+	params.Save(item.Key, "0.25")
+	assert.InDelta(t, 0.25, item.GetAsFloat(), 0.0001)
+
+	params.Save(item.Key, "0")
+	assert.InDelta(t, 1.0, item.GetAsFloat(), 0.0001)
+
+	params.Save(item.Key, "1.1")
+	assert.InDelta(t, 1.0, item.GetAsFloat(), 0.0001)
 }


### PR DESCRIPTION
issue: #52669
pr: #50267
pr: #50478

## What changed

### Caching-layer and column loading

- Pin `milvus-common` to [zilliztech/milvus-common#121](https://github.com/zilliztech/milvus-common/pull/121).
- Adopt the batch-level `estimated_loading_usage(cids)` contract across caching-layer translators.
- Run each contiguous field-data batch's Arrow read and per-cell finalization on the same HIGH/LOW load-pool worker. Release Arrow tables before the batch future completes; no separate result queue is used.
- Bound column-group temporary memory by the selected cells and active load-pool workers: at most `min(selected size, concurrency × max(16 MiB, largest cell))`.
- Make thread-pool submission exception-safe when dynamic worker creation or metric updates fail.

### Index I/O and loading estimates

- Backport `PositionedFileWriter` and use it for `IndexEntryReader` positioned writes, including buffered/direct-I/O handling and writer priority. Validate encrypted V3 `slice_size` as a positive 4 KiB multiple.
- Add ordered `ReadEntryStream` loading and stream V3 payloads for scalar sort, string sort, Marisa, and bitmap indexes instead of materializing whole entries. Plain V3 stream memory is bounded by 16 MiB slices and load-pool concurrency; legacy and encrypted paths keep conservative whole-entry estimates.
- Refine scalar-index resident and peak estimates for sort auxiliary data, Marisa CSR data, Tantivy row/path offsets, bitmap buffers, and the persisted internal type of HYBRID indexes. Log the resulting index loading estimate at info level.
- Refine TextMatch estimates:
  - non-mmap keeps the index resident in memory and accounts for the temporary disk-to-`RamDirectory` copy with a `2 × index size` memory peak;
  - mmap keeps the index on disk, retains nullable row offsets in memory, and uses the larger of the pool-bounded V3 stream peak and the row-offset construction peak.