### PR TITLE
test: fix external table drop-function e2e to use drop_function_field

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_external_table.py
+++ b/tests/python_client/milvus_client/test_milvus_client_external_table.py
@@ -2957,7 +2957,7 @@ class TestMilvusClientExternalTableAddField(ExternalTableTestBase):
     def test_milvus_client_external_table_drop_function_rejected(self, minio_env, external_prefix):
         """
         target: test external table drop function rejected
-        method: call drop_collection_function on an external collection
+        method: call drop_function_field on an external collection
         expected: function schema mutation is rejected for external collections
         """
         client = self._client()
@@ -2967,7 +2967,7 @@ class TestMilvusClientExternalTableAddField(ExternalTableTestBase):
             ct.err_code: 1100,
             ct.err_msg: "alter collection schema operation is not supported for external collection",
         }
-        self.drop_collection_function(
+        self.drop_function_field(
             client,
             coll,
             "bm25_func",


### PR DESCRIPTION
## What type of PR is this?
- [x] test

## What this PR does / why we need it
Fixes `test_milvus_client_external_table_drop_function_rejected`, which asserted the old external-collection rejection message. The `DropCollectionFunction` RPC is deprecated and the proxy now rejects it earlier (impl.go:1409) with a different message, before the external-collection schema check runs, so the test failed on message comparison.

Switch the test from `drop_collection_function` to `drop_function_field`, which routes through `AlterCollectionSchema` and still exercises the external-collection schema protection, producing the expected `alter collection schema operation is not supported for external collection` rejection.

## Which issues does this PR resolve?
Fixes #52646

## Test evidence
- Reproduced the failure against master + pymilvus 3.1.0rc80, then verified the fixed test passes:
  `pytest milvus_client/test_milvus_client_external_table.py -k test_milvus_client_external_table_drop_function_rejected` → 1 passed