### PR TITLE
enhance: collect cached filesystem metrics on scrape

### DIFF
--- a/cmd/roles/roles.go
+++ b/cmd/roles/roles.go
@@ -32,12 +32,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/samber/lo"
+	"golang.org/x/time/rate"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/cmd/components"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/http"
 	"github.com/milvus-io/milvus/internal/http/healthz"
+	"github.com/milvus-io/milvus/internal/storagev2"
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	kvfactory "github.com/milvus-io/milvus/internal/util/dependency/kv"
 	"github.com/milvus-io/milvus/internal/util/fileresource"
@@ -69,6 +71,28 @@ func init() {
 	metrics.Register(Registry.GoRegistry)
 	metrics.RegisterMetaMetrics(Registry.GoRegistry)
 	metrics.RegisterMsgStreamMetrics(Registry.GoRegistry)
+	metrics.SetFilesystemMetricsCollectFn(func() []metrics.FilesystemMetrics {
+		entries, err := storagev2.ListFilesystemMetrics()
+		if err != nil {
+			mlog.RatedWarn(context.TODO(), rate.Every(time.Minute), "failed to list filesystem metrics", mlog.Err(err))
+			return nil
+		}
+		metricsList := make([]metrics.FilesystemMetrics, 0, len(entries))
+		for _, entry := range entries {
+			metricsList = append(metricsList, metrics.FilesystemMetrics{
+				DisplayKey:              entry.DisplayKey,
+				ReadCount:               entry.ReadCount,
+				WriteCount:              entry.WriteCount,
+				ReadBytes:               entry.ReadBytes,
+				WriteBytes:              entry.WriteBytes,
+				GetFileInfoCount:        entry.GetFileInfoCount,
+				FailedCount:             entry.FailedCount,
+				MultiPartUploadCreated:  entry.MultiPartUploadCreated,
+				MultiPartUploadFinished: entry.MultiPartUploadFinished,
+			})
+		}
+		return metricsList
+	})
 	metrics.RegisterStorageMetrics(Registry.GoRegistry)
 }
 

--- a/cmd/roles/roles_test.go
+++ b/cmd/roles/roles_test.go
@@ -23,8 +23,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/milvus-io/milvus/internal/storagev2"
 	"github.com/milvus-io/milvus/internal/util/fileresource"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -51,6 +54,44 @@ func TestRoles(t *testing.T) {
 	_, err = os.Stat(localPath)
 	assert.Error(t, err)
 	assert.Equal(t, true, os.IsNotExist(err))
+}
+
+func TestFilesystemMetricsRegisteredWithRolesRegistry(t *testing.T) {
+	dir := t.TempDir()
+	_, err := storagev2.GetFilesystemMetricsWithConfig(&indexpb.StorageConfig{
+		StorageType: "local",
+		RootPath:    dir,
+	})
+	require.NoError(t, err)
+
+	gathered, err := Registry.GoRegistry.Gather()
+	require.NoError(t, err)
+
+	missingFamilies := map[string]struct{}{
+		"milvus_storage_filesystem_read_count":                 {},
+		"milvus_storage_filesystem_write_count":                {},
+		"milvus_storage_filesystem_read_bytes":                 {},
+		"milvus_storage_filesystem_write_bytes":                {},
+		"milvus_storage_filesystem_get_file_info_count":        {},
+		"milvus_storage_filesystem_failed_count":               {},
+		"milvus_storage_filesystem_multi_part_upload_created":  {},
+		"milvus_storage_filesystem_multi_part_upload_finished": {},
+	}
+	expectedDisplayKeyPrefix := "file://" + dir + "#fs:"
+	for _, family := range gathered {
+		if _, ok := missingFamilies[family.GetName()]; !ok {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == "fs" && strings.HasPrefix(label.GetValue(), expectedDisplayKeyPrefix) {
+					delete(missingFamilies, family.GetName())
+					break
+				}
+			}
+		}
+	}
+	require.Empty(t, missingFamilies)
 }
 
 func TestResolveFileResourceMode(t *testing.T) {

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION 3ae6ac4)
+set( milvus-storage_VERSION ced9c9a)
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION ced9c9a)
+set( milvus-storage_VERSION 3ae6ac4)
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")

--- a/internal/datanode/compactor/executor.go
+++ b/internal/datanode/compactor/executor.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/samber/lo"
 
-	"github.com/milvus-io/milvus/internal/storagev2"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
@@ -157,12 +156,6 @@ func (e *executor) completeTask(planID int64, result *datapb.CompactionPlanResul
 		e.mu.Unlock()
 
 		task.compactor.Complete()
-
-		// Publish filesystem metrics after compaction task completion
-		storageConfig := task.compactor.GetStorageConfig()
-		if _, err := storagev2.PublishFilesystemMetricsWithConfig(storageConfig); err != nil {
-			mlog.Warn(context.TODO(), "failed to publish filesystem metrics", mlog.Err(err))
-		}
 		return
 	}
 

--- a/internal/datanode/compactor/executor_test.go
+++ b/internal/datanode/compactor/executor_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
-	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
@@ -207,7 +206,6 @@ func TestCompactionExecutor(t *testing.T) {
 		mockC.EXPECT().GetSlotUsage().Return(int64(8)).Times(2)
 		mockC.EXPECT().Compact().Return(result, nil)
 		mockC.EXPECT().Complete().Return()
-		mockC.EXPECT().GetStorageConfig().Return(nil)
 
 		succeed, err := ex.Enqueue(mockC)
 		assert.True(t, succeed)
@@ -236,7 +234,6 @@ func TestCompactionExecutor(t *testing.T) {
 		mockC.EXPECT().GetSlotUsage().Return(int64(8)).Times(2)
 		mockC.EXPECT().Compact().Return(nil, errors.New("compaction failed"))
 		mockC.EXPECT().Complete().Return()
-		mockC.EXPECT().GetStorageConfig().Return(nil)
 
 		succeed, err := ex.Enqueue(mockC)
 		assert.True(t, succeed)
@@ -424,7 +421,6 @@ func TestCompactionExecutor(t *testing.T) {
 		mockC.EXPECT().GetPlanID().Return(planID)
 		mockC.EXPECT().GetSlotUsage().Return(slotUsage).Times(2)
 		mockC.EXPECT().Complete().Return()
-		mockC.EXPECT().GetStorageConfig().Return(nil)
 
 		ex.Enqueue(mockC)
 		assert.Equal(t, slotUsage, ex.Slots())
@@ -449,7 +445,6 @@ func TestCompactionExecutor(t *testing.T) {
 		mockC := NewMockCompactor(t)
 		mockC.EXPECT().GetSlotUsage().Return(int64(10))
 		mockC.EXPECT().Complete().Return()
-		mockC.EXPECT().GetStorageConfig().Return(nil)
 
 		ex.tasks[1] = &taskState{
 			compactor: mockC,
@@ -473,14 +468,11 @@ func TestCompactionExecutor(t *testing.T) {
 		}
 		ex.usingSlots = slotUsage
 
-		callbackSlots := make(chan int64, 2)
+		callbackSlots := make(chan int64, 1)
 		mockC.EXPECT().GetSlotUsage().Return(slotUsage)
 		mockC.EXPECT().Complete().Run(func() {
 			callbackSlots <- ex.Slots()
 		}).Return()
-		mockC.EXPECT().GetStorageConfig().Run(func() {
-			callbackSlots <- ex.Slots()
-		}).Return(nil)
 
 		done := make(chan struct{})
 		go func() {
@@ -494,7 +486,6 @@ func TestCompactionExecutor(t *testing.T) {
 			t.Fatal("completeTask blocked while invoking compactor callbacks")
 		}
 
-		require.Equal(t, int64(0), <-callbackSlots)
 		require.Equal(t, int64(0), <-callbackSlots)
 		assert.Equal(t, int64(0), ex.Slots())
 	})
@@ -510,7 +501,6 @@ func TestCompactionExecutor(t *testing.T) {
 		mockC.EXPECT().GetChannelName().Return("ch1")
 		mockC.EXPECT().Complete().Return()
 		mockC.EXPECT().GetCompactionType().Return(datapb.CompactionType_MixCompaction)
-		mockC.EXPECT().GetStorageConfig().Return(nil)
 
 		ex.Enqueue(mockC)
 		ex.mu.RLock()
@@ -544,7 +534,7 @@ func TestCompactionExecutor(t *testing.T) {
 		assert.Equal(t, datapb.CompactionTaskState_executing, results[0].State)
 	})
 
-	t.Run("Test_Multiple_ExecuteTask_WithMetrics", func(t *testing.T) {
+	t.Run("Test_Multiple_ExecuteTask", func(t *testing.T) {
 		ex := NewExecutor()
 
 		planIDs := []int64{1, 2, 3}
@@ -556,7 +546,6 @@ func TestCompactionExecutor(t *testing.T) {
 			mockC.EXPECT().GetChannelName().Return("ch1")
 			mockC.EXPECT().GetSlotUsage().Return(int64(4)).Times(2)
 			mockC.EXPECT().Complete().Return()
-			mockC.EXPECT().GetStorageConfig().Return(nil)
 
 			result := &datapb.CompactionPlanResult{
 				PlanID: planID,
@@ -589,36 +578,5 @@ func TestCompactionExecutor(t *testing.T) {
 		for _, result := range results {
 			assert.Equal(t, datapb.CompactionTaskState_completed, result.State)
 		}
-	})
-
-	t.Run("Test_CompleteTask_WithStorageConfig", func(t *testing.T) {
-		ex := NewExecutor()
-		mockC := NewMockCompactor(t)
-
-		planID := int64(1)
-		storageConfig := &indexpb.StorageConfig{
-			StorageType: "minio",
-			Address:     "localhost:9000",
-			BucketName:  "test-bucket",
-		}
-
-		mockC.EXPECT().GetPlanID().Return(planID)
-		mockC.EXPECT().GetSlotUsage().Return(int64(8)).Times(2)
-		mockC.EXPECT().Complete().Return()
-		mockC.EXPECT().GetStorageConfig().Return(storageConfig)
-
-		ex.Enqueue(mockC)
-		assert.Equal(t, int64(8), ex.Slots())
-
-		result := &datapb.CompactionPlanResult{PlanID: planID}
-		ex.completeTask(planID, result)
-
-		assert.Equal(t, int64(0), ex.Slots())
-
-		ex.mu.RLock()
-		task := ex.tasks[planID]
-		ex.mu.RUnlock()
-		assert.Equal(t, datapb.CompactionTaskState_completed, task.state)
-		assert.Equal(t, result, task.result)
 	})
 }

--- a/internal/datanode/index/scheduler.go
+++ b/internal/datanode/index/scheduler.go
@@ -27,7 +27,6 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/milvus-io/milvus/internal/datanode/taskcost"
-	"github.com/milvus-io/milvus/internal/storagev2"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
@@ -286,13 +285,6 @@ func (sched *TaskScheduler) processTask(t Task) {
 	} else {
 		t.SetState(indexpb.JobState_JobStateFinished, "")
 		mlog.Debug(t.Ctx(), "process task completed", mlog.String("task", t.Name()))
-	}
-
-	// Publish filesystem metrics after index task completion
-	if indexTask != nil {
-		if indexTask.req != nil && indexTask.req.GetStorageConfig() != nil {
-			storagev2.PublishFilesystemMetricsWithConfig(indexTask.req.GetStorageConfig())
-		}
 	}
 }
 

--- a/internal/datanode/services_test.go
+++ b/internal/datanode/services_test.go
@@ -238,7 +238,6 @@ func (s *DataNodeServicesSuite) TestGetCompactionState() {
 			PlanID: 1,
 			State:  datapb.CompactionTaskState_completed,
 		}, nil)
-		mockC.EXPECT().GetStorageConfig().Return(s.storageConfig)
 		s.node.compactionExecutor.Enqueue(mockC)
 
 		mockC2 := compactor.NewMockCompactor(s.T())
@@ -252,7 +251,6 @@ func (s *DataNodeServicesSuite) TestGetCompactionState() {
 			PlanID: 2,
 			State:  datapb.CompactionTaskState_failed,
 		}, nil)
-		mockC2.EXPECT().GetStorageConfig().Return(s.storageConfig)
 		s.node.compactionExecutor.Enqueue(mockC2)
 
 		s.Eventually(func() bool {

--- a/internal/flushcommon/syncmgr/task.go
+++ b/internal/flushcommon/syncmgr/task.go
@@ -31,7 +31,6 @@ import (
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagecommon"
-	"github.com/milvus-io/milvus/internal/storagev2"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -226,9 +225,6 @@ func (t *SyncTask) Run(ctx context.Context) (err error) {
 		metrics.DataNodeAutoFlushBufferCount.WithLabelValues(paramtable.GetStringNodeID(), metrics.SuccessLabel, t.level.String()).Inc()
 	}
 	metrics.DataNodeFlushBufferCount.WithLabelValues(paramtable.GetStringNodeID(), metrics.SuccessLabel, t.level.String()).Inc()
-
-	// Publish filesystem metrics after sync task completion
-	storagev2.PublishFilesystemMetricsWithConfig(t.storageConfig)
 
 	return nil
 }

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -38,7 +38,6 @@ import (
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
 	"github.com/milvus-io/milvus/internal/querynodev2/tasks"
 	"github.com/milvus-io/milvus/internal/storage"
-	"github.com/milvus-io/milvus/internal/storagev2"
 	"github.com/milvus-io/milvus/internal/streamingnode/client/handler"
 	"github.com/milvus-io/milvus/internal/streamingnode/client/handler/registry"
 	"github.com/milvus-io/milvus/internal/util/analyzer"
@@ -593,10 +592,6 @@ func (node *QueryNode) LoadSegments(ctx context.Context, req *querypb.LoadSegmen
 
 	log.Info(ctx, "load segments done...",
 		mlog.Int64s("segments", lo.Map(loaded, func(s segments.Segment, _ int) int64 { return s.ID() })))
-
-	// Publish filesystem metrics after load task completion
-	// Use default filesystem (empty path) for load tasks
-	storagev2.PublishDefaultFilesystemMetrics()
 
 	return merr.Success(), nil
 }

--- a/internal/storagev2/filesystem_metrics.go
+++ b/internal/storagev2/filesystem_metrics.go
@@ -27,18 +27,14 @@ package storagev2
 import "C"
 
 import (
-	"context"
 	"strconv"
 	"unsafe"
 
-	"github.com/milvus-io/milvus/pkg/v3/metrics"
-	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
-	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
-// FilesystemMetrics holds the 8 filesystem metrics retrieved from the default filesystem
+// FilesystemMetrics holds a filesystem metrics snapshot.
 type FilesystemMetrics struct {
 	ReadCount               int64
 	WriteCount              int64
@@ -48,6 +44,12 @@ type FilesystemMetrics struct {
 	FailedCount             int64
 	MultiPartUploadCreated  int64
 	MultiPartUploadFinished int64
+}
+
+// FilesystemMetricsEntry identifies one cached filesystem and its metrics.
+type FilesystemMetricsEntry struct {
+	DisplayKey string
+	FilesystemMetrics
 }
 
 // getMetricsFromHandle retrieves metrics from a filesystem handle
@@ -72,6 +74,35 @@ func getMetricsFromHandle(cFilesystem C.FileSystemHandle) (*FilesystemMetrics, e
 
 	C.loon_filesystem_destroy(cFilesystem)
 	return fsMetrics, nil
+}
+
+// ListFilesystemMetrics returns metrics for every filesystem currently held by the cache.
+func ListFilesystemMetrics() ([]FilesystemMetricsEntry, error) {
+	var cMetricsList C.LoonFilesystemMetricsList
+	result := C.loon_filesystem_list_metrics(&cMetricsList)
+	if err := HandleLoonFFIResult(result); err != nil {
+		return nil, merr.Wrap(err, "failed to list filesystem metrics")
+	}
+	defer C.loon_filesystem_free_metrics_list(&cMetricsList)
+
+	entries := unsafe.Slice(cMetricsList.entries, int(cMetricsList.count))
+	metricsList := make([]FilesystemMetricsEntry, 0, len(entries))
+	for _, entry := range entries {
+		metricsList = append(metricsList, FilesystemMetricsEntry{
+			DisplayKey: C.GoString(entry.display_key),
+			FilesystemMetrics: FilesystemMetrics{
+				ReadCount:               int64(entry.metrics.read_count),
+				WriteCount:              int64(entry.metrics.write_count),
+				ReadBytes:               int64(entry.metrics.read_bytes),
+				WriteBytes:              int64(entry.metrics.write_bytes),
+				GetFileInfoCount:        int64(entry.metrics.get_file_info_count),
+				FailedCount:             int64(entry.metrics.failed_count),
+				MultiPartUploadCreated:  int64(entry.metrics.multi_part_upload_created),
+				MultiPartUploadFinished: int64(entry.metrics.multi_part_upload_finished),
+			},
+		})
+	}
+	return metricsList, nil
 }
 
 // Property keys exported by milvus-storage/ffi_c.h.
@@ -245,87 +276,4 @@ func HandleLoonFFIResult(ffiResult C.LoonFFIResult) error {
 		return merr.WrapErrStorageMsg("loon FFI error (code %d): %s", errCode, errStr)
 	}
 	return nil
-}
-
-// GetFilesystemKeyFromStorageConfig extracts filesystem cache key from StorageConfig.
-func GetFilesystemKeyFromStorageConfig(storageConfig *indexpb.StorageConfig) string {
-	if storageConfig == nil {
-		return ""
-	}
-
-	storageType := storageConfig.GetStorageType()
-	if storageType == "local" {
-		return storageConfig.GetRootPath()
-	}
-
-	address := storageConfig.GetAddress()
-	bucketName := storageConfig.GetBucketName()
-	if address == "" || bucketName == "" {
-		return ""
-	}
-	return address + "/" + bucketName
-}
-
-// PublishDefaultFilesystemMetrics retrieves and publishes metrics from the default filesystem.
-func PublishDefaultFilesystemMetrics() (*FilesystemMetrics, error) {
-	params := paramtable.Get()
-	var storageConfig *indexpb.StorageConfig
-
-	if params.CommonCfg.StorageType.GetValue() == "local" {
-		storageConfig = &indexpb.StorageConfig{
-			RootPath:    params.LocalStorageCfg.Path.GetValue(),
-			StorageType: params.CommonCfg.StorageType.GetValue(),
-			// External collections may reference an s3:// source even when the
-			// primary storage is local, so the connection cap still applies.
-			MaxConnections: uint32(params.MinioCfg.MaxConnections.GetAsInt()),
-		}
-	} else {
-		storageConfig = &indexpb.StorageConfig{
-			Address:           params.MinioCfg.Address.GetValue(),
-			AccessKeyID:       params.MinioCfg.AccessKeyID.GetValue(),
-			SecretAccessKey:   params.MinioCfg.SecretAccessKey.GetValue(),
-			UseSSL:            params.MinioCfg.UseSSL.GetAsBool(),
-			SslCACert:         params.MinioCfg.SslCACert.GetValue(),
-			BucketName:        params.MinioCfg.BucketName.GetValue(),
-			RootPath:          params.MinioCfg.RootPath.GetValue(),
-			UseIAM:            params.MinioCfg.UseIAM.GetAsBool(),
-			IAMEndpoint:       params.MinioCfg.IAMEndpoint.GetValue(),
-			StorageType:       params.CommonCfg.StorageType.GetValue(),
-			Region:            params.MinioCfg.Region.GetValue(),
-			UseVirtualHost:    params.MinioCfg.UseVirtualHost.GetAsBool(),
-			CloudProvider:     params.MinioCfg.CloudProvider.GetValue(),
-			RequestTimeoutMs:  params.MinioCfg.RequestTimeoutMs.GetAsInt64(),
-			MaxConnections:    uint32(params.MinioCfg.MaxConnections.GetAsInt()),
-			GcpCredentialJSON: params.MinioCfg.GcpCredentialJSON.GetValue(),
-			SslTlsMinVersion:  params.MinioCfg.SslTLSMinVersion.GetValue(),
-			UseCrc32CChecksum: params.MinioCfg.UseCRC32C.GetAsBool(),
-		}
-	}
-	return PublishFilesystemMetricsWithConfig(storageConfig)
-}
-
-// PublishFilesystemMetricsWithConfig retrieves and publishes filesystem metrics using storage config.
-func PublishFilesystemMetricsWithConfig(storageConfig *indexpb.StorageConfig) (*FilesystemMetrics, error) {
-	metricSnapshot, err := GetFilesystemMetricsWithConfig(storageConfig)
-	if err != nil {
-		mlog.Warn(context.TODO(), "failed to get filesystem metrics with config", mlog.Err(err))
-		return nil, err
-	}
-
-	fsKey := GetFilesystemKeyFromStorageConfig(storageConfig)
-	if fsKey == "" {
-		fsKey = "default"
-	}
-	metrics.PublishFilesystemMetrics(
-		fsKey,
-		metricSnapshot.ReadCount,
-		metricSnapshot.WriteCount,
-		metricSnapshot.ReadBytes,
-		metricSnapshot.WriteBytes,
-		metricSnapshot.GetFileInfoCount,
-		metricSnapshot.FailedCount,
-		metricSnapshot.MultiPartUploadCreated,
-		metricSnapshot.MultiPartUploadFinished,
-	)
-	return metricSnapshot, nil
 }

--- a/internal/storagev2/filesystem_metrics_test.go
+++ b/internal/storagev2/filesystem_metrics_test.go
@@ -17,181 +17,24 @@
 package storagev2
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/milvus-io/milvus/internal/util/initcore"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
-	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
-func TestGetFilesystemKeyFromStorageConfig(t *testing.T) {
-	tests := []struct {
-		name          string
-		storageConfig *indexpb.StorageConfig
-		expected      string
-	}{
-		{
-			name:          "nil storage config",
-			storageConfig: nil,
-			expected:      "",
-		},
-		{
-			name: "local storage with root path",
-			storageConfig: &indexpb.StorageConfig{
-				StorageType: "local",
-				RootPath:    "/var/lib/milvus/data",
-			},
-			expected: "/var/lib/milvus/data",
-		},
-		{
-			name: "local storage with empty root path",
-			storageConfig: &indexpb.StorageConfig{
-				StorageType: "local",
-				RootPath:    "",
-			},
-			expected: "",
-		},
-		{
-			name: "minio storage valid address and bucket",
-			storageConfig: &indexpb.StorageConfig{
-				StorageType: "minio",
-				Address:     "localhost:9000",
-				BucketName:  "test-bucket",
-			},
-			expected: "localhost:9000/test-bucket",
-		},
-		{
-			name: "minio storage empty address",
-			storageConfig: &indexpb.StorageConfig{
-				StorageType: "minio",
-				Address:     "",
-				BucketName:  "test-bucket",
-			},
-			expected: "",
-		},
-		{
-			name: "minio storage empty bucket name",
-			storageConfig: &indexpb.StorageConfig{
-				StorageType: "minio",
-				Address:     "localhost:9000",
-				BucketName:  "",
-			},
-			expected: "",
-		},
-		{
-			name: "minio storage both empty",
-			storageConfig: &indexpb.StorageConfig{
-				StorageType: "minio",
-				Address:     "",
-				BucketName:  "",
-			},
-			expected: "",
-		},
-		{
-			name: "S3 endpoint format",
-			storageConfig: &indexpb.StorageConfig{
-				StorageType: "s3",
-				Address:     "s3.amazonaws.com",
-				BucketName:  "my-bucket",
-			},
-			expected: "s3.amazonaws.com/my-bucket",
-		},
-		{
-			name: "minio with IP address",
-			storageConfig: &indexpb.StorageConfig{
-				StorageType: "minio",
-				Address:     "192.168.1.100:9000",
-				BucketName:  "data-bucket",
-			},
-			expected: "192.168.1.100:9000/data-bucket",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := GetFilesystemKeyFromStorageConfig(tt.storageConfig)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestGetFilesystemKeyFromStorageConfigWithOtherFields(t *testing.T) {
-	// Test that other fields in StorageConfig don't affect the result for object storage
-	storageConfig := &indexpb.StorageConfig{
-		Address:           "localhost:9000",
-		BucketName:        "test-bucket",
-		AccessKeyID:       "access-key",
-		SecretAccessKey:   "secret-key",
-		UseSSL:            true,
-		RootPath:          "/root/path",
-		UseIAM:            false,
-		IAMEndpoint:       "iam-endpoint",
-		StorageType:       "s3",
-		UseVirtualHost:    true,
-		Region:            "us-east-1",
-		CloudProvider:     "aws",
-		RequestTimeoutMs:  30000,
-		SslCACert:         "cert",
-		GcpCredentialJSON: "json",
-		MaxConnections:    10,
-	}
-
-	result := GetFilesystemKeyFromStorageConfig(storageConfig)
-	assert.Equal(t, "localhost:9000/test-bucket", result)
-
-	// Test that other fields don't affect the result for local storage
-	localConfig := &indexpb.StorageConfig{
-		Address:           "localhost:9000", // Should be ignored for local
-		BucketName:        "test-bucket",    // Should be ignored for local
-		AccessKeyID:       "access-key",
-		SecretAccessKey:   "secret-key",
-		UseSSL:            true,
-		RootPath:          "/var/lib/milvus/data",
-		UseIAM:            false,
-		IAMEndpoint:       "iam-endpoint",
-		StorageType:       "local",
-		UseVirtualHost:    true,
-		Region:            "us-east-1",
-		CloudProvider:     "aws",
-		RequestTimeoutMs:  30000,
-		SslCACert:         "cert",
-		GcpCredentialJSON: "json",
-		MaxConnections:    10,
-	}
-
-	result = GetFilesystemKeyFromStorageConfig(localConfig)
-	assert.Equal(t, "/var/lib/milvus/data", result)
-}
-
-// TestGetFilesystemMetricsWithConfig tests GetFilesystemMetricsWithConfig with local storage
 func TestGetFilesystemMetricsWithConfig(t *testing.T) {
 	dir := t.TempDir()
-	pt := paramtable.Get()
-	pt.Save(pt.CommonCfg.StorageType.Key, "local")
-	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
-
-	t.Cleanup(func() {
-		pt.Reset(pt.CommonCfg.StorageType.Key)
-		pt.Reset(pt.LocalStorageCfg.Path.Key)
-	})
-
-	err := initcore.InitLocalArrowFileSystem(dir)
-	require.NoError(t, err, "Failed to initialize local arrow filesystem")
-
 	localConfig := &indexpb.StorageConfig{
 		StorageType: "local",
 		RootPath:    dir,
 	}
 	metrics, err := GetFilesystemMetricsWithConfig(localConfig)
-	if err != nil {
-		t.Skipf("Skipping CGO test: %v", err)
-		return
-	}
-
-	require.NotNil(t, metrics, "Metrics should not be nil")
+	require.NoError(t, err)
+	require.NotNil(t, metrics)
 	assert.GreaterOrEqual(t, metrics.ReadCount, int64(0))
 	assert.GreaterOrEqual(t, metrics.WriteCount, int64(0))
 	assert.GreaterOrEqual(t, metrics.ReadBytes, int64(0))
@@ -217,172 +60,60 @@ func TestGetFilesystemMetricsWithConfig(t *testing.T) {
 	}
 }
 
-// TestPublishFilesystemMetricsWithLocalConfig tests PublishFilesystemMetricsWithConfig
-func TestPublishFilesystemMetricsWithLocalConfig(t *testing.T) {
-	dir := t.TempDir()
-	pt := paramtable.Get()
-	pt.Save(pt.CommonCfg.StorageType.Key, "local")
-	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
-
-	t.Cleanup(func() {
-		pt.Reset(pt.CommonCfg.StorageType.Key)
-		pt.Reset(pt.LocalStorageCfg.Path.Key)
-	})
-
-	err := initcore.InitLocalArrowFileSystem(dir)
-	require.NoError(t, err, "Failed to initialize local arrow filesystem")
-
-	localConfig := &indexpb.StorageConfig{
-		StorageType: "local",
-		RootPath:    dir,
-	}
-	metrics, err := PublishFilesystemMetricsWithConfig(localConfig)
-	if err != nil {
-		t.Skipf("Skipping CGO test: %v", err)
-		return
+func TestListFilesystemMetrics(t *testing.T) {
+	metricsBefore, err := ListFilesystemMetrics()
+	require.NoError(t, err)
+	existingDisplayKeys := make(map[string]struct{}, len(metricsBefore))
+	for _, fsMetrics := range metricsBefore {
+		existingDisplayKeys[fsMetrics.DisplayKey] = struct{}{}
 	}
 
-	require.NotNil(t, metrics, "Metrics should not be nil")
-	assert.GreaterOrEqual(t, metrics.ReadCount, int64(0))
-	assert.GreaterOrEqual(t, metrics.WriteCount, int64(0))
-	assert.GreaterOrEqual(t, metrics.ReadBytes, int64(0))
-	assert.GreaterOrEqual(t, metrics.WriteBytes, int64(0))
-	assert.GreaterOrEqual(t, metrics.GetFileInfoCount, int64(0))
-	assert.GreaterOrEqual(t, metrics.FailedCount, int64(0))
-	assert.GreaterOrEqual(t, metrics.MultiPartUploadCreated, int64(0))
-	assert.GreaterOrEqual(t, metrics.MultiPartUploadFinished, int64(0))
-}
-
-// TestPublishFilesystemMetricsWithConfig tests PublishFilesystemMetricsWithConfig function
-func TestPublishFilesystemMetricsWithConfig(t *testing.T) {
-	// Set up local storage for testing
-	dir := t.TempDir()
-	pt := paramtable.Get()
-	pt.Save(pt.CommonCfg.StorageType.Key, "local")
-	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
-
-	t.Cleanup(func() {
-		pt.Reset(pt.CommonCfg.StorageType.Key)
-		pt.Reset(pt.LocalStorageCfg.Path.Key)
-	})
-
-	// Initialize local arrow filesystem
-	err := initcore.InitLocalArrowFileSystem(dir)
-	require.NoError(t, err, "Failed to initialize local arrow filesystem")
-
-	// Test with local storage config
-	localConfig := &indexpb.StorageConfig{
-		StorageType: "local",
-		RootPath:    dir,
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	expectedDisplayPrefixes := map[string]struct{}{
+		"file://" + dirA + "#fs:": {},
+		"file://" + dirB + "#fs:": {},
+	}
+	for _, dir := range []string{dirA, dirB} {
+		_, err := GetFilesystemMetricsWithConfig(&indexpb.StorageConfig{
+			StorageType: "local",
+			RootPath:    dir,
+		})
+		require.NoError(t, err)
 	}
 
-	metrics, err := PublishFilesystemMetricsWithConfig(localConfig)
-	assert.NoError(t, err)
+	metricsList, err := ListFilesystemMetrics()
+	require.NoError(t, err)
 
-	// Verify metrics struct is not nil
-	require.NotNil(t, metrics, "Metrics should not be nil")
-
-	// Verify all 8 metrics fields are present
-	assert.GreaterOrEqual(t, metrics.ReadCount, int64(0))
-	assert.GreaterOrEqual(t, metrics.WriteCount, int64(0))
-	assert.GreaterOrEqual(t, metrics.ReadBytes, int64(0))
-	assert.GreaterOrEqual(t, metrics.WriteBytes, int64(0))
-	assert.GreaterOrEqual(t, metrics.GetFileInfoCount, int64(0))
-	assert.GreaterOrEqual(t, metrics.FailedCount, int64(0))
-	assert.GreaterOrEqual(t, metrics.MultiPartUploadCreated, int64(0))
-	assert.GreaterOrEqual(t, metrics.MultiPartUploadFinished, int64(0))
+	newFilesystemCount := 0
+	for _, fsMetrics := range metricsList {
+		if _, ok := existingDisplayKeys[fsMetrics.DisplayKey]; ok {
+			continue
+		}
+		newFilesystemCount++
+		matched := false
+		for prefix := range expectedDisplayPrefixes {
+			if strings.HasPrefix(fsMetrics.DisplayKey, prefix) {
+				delete(expectedDisplayPrefixes, prefix)
+				matched = true
+				break
+			}
+		}
+		assert.True(t, matched, fsMetrics.DisplayKey)
+		assert.GreaterOrEqual(t, fsMetrics.ReadCount, int64(0))
+		assert.GreaterOrEqual(t, fsMetrics.WriteCount, int64(0))
+		assert.GreaterOrEqual(t, fsMetrics.ReadBytes, int64(0))
+		assert.GreaterOrEqual(t, fsMetrics.WriteBytes, int64(0))
+		assert.GreaterOrEqual(t, fsMetrics.GetFileInfoCount, int64(0))
+		assert.GreaterOrEqual(t, fsMetrics.FailedCount, int64(0))
+		assert.GreaterOrEqual(t, fsMetrics.MultiPartUploadCreated, int64(0))
+		assert.GreaterOrEqual(t, fsMetrics.MultiPartUploadFinished, int64(0))
+	}
+	require.Equal(t, 2, newFilesystemCount)
+	require.Empty(t, expectedDisplayPrefixes)
 }
 
-// TestPublishDefaultFilesystemMetrics tests PublishDefaultFilesystemMetrics function
-func TestPublishDefaultFilesystemMetrics(t *testing.T) {
-	// Set up local storage for testing
-	dir := t.TempDir()
-	pt := paramtable.Get()
-	pt.Save(pt.CommonCfg.StorageType.Key, "local")
-	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
-
-	t.Cleanup(func() {
-		pt.Reset(pt.CommonCfg.StorageType.Key)
-		pt.Reset(pt.LocalStorageCfg.Path.Key)
-	})
-
-	// Initialize local arrow filesystem
-	err := initcore.InitLocalArrowFileSystem(dir)
-	require.NoError(t, err, "Failed to initialize local arrow filesystem")
-
-	// Test PublishDefaultFilesystemMetrics
-	metrics, err := PublishDefaultFilesystemMetrics()
-	assert.NoError(t, err)
-	assert.NotNil(t, metrics, "Metrics should not be nil")
-}
-
-// TestNilConfig tests error handling for nil config
 func TestNilConfig(t *testing.T) {
 	_, err := GetFilesystemMetricsWithConfig(nil)
 	assert.Error(t, err)
-
-	_, err = PublishFilesystemMetricsWithConfig(nil)
-	assert.Error(t, err)
-}
-
-// TestGetFilesystemKeyFromStorageConfigEdgeCases tests edge cases for key generation
-func TestGetFilesystemKeyFromStorageConfigEdgeCases(t *testing.T) {
-	tests := []struct {
-		name          string
-		storageConfig *indexpb.StorageConfig
-		expected      string
-	}{
-		{
-			name: "empty storage type defaults to object storage logic",
-			storageConfig: &indexpb.StorageConfig{
-				StorageType: "",
-				Address:     "localhost:9000",
-				BucketName:  "bucket",
-			},
-			expected: "localhost:9000/bucket",
-		},
-		{
-			name: "unknown storage type uses object storage logic",
-			storageConfig: &indexpb.StorageConfig{
-				StorageType: "unknown",
-				Address:     "localhost:9000",
-				BucketName:  "bucket",
-			},
-			expected: "localhost:9000/bucket",
-		},
-		{
-			name: "azure storage type",
-			storageConfig: &indexpb.StorageConfig{
-				StorageType: "azure",
-				Address:     "account.blob.core.windows.net",
-				BucketName:  "container",
-			},
-			expected: "account.blob.core.windows.net/container",
-		},
-		{
-			name: "gcp storage type",
-			storageConfig: &indexpb.StorageConfig{
-				StorageType: "gcp",
-				Address:     "storage.googleapis.com",
-				BucketName:  "my-gcp-bucket",
-			},
-			expected: "storage.googleapis.com/my-gcp-bucket",
-		},
-		{
-			name: "address with special characters",
-			storageConfig: &indexpb.StorageConfig{
-				StorageType: "minio",
-				Address:     "minio-service.namespace.svc.cluster.local:9000",
-				BucketName:  "bucket-name-with-dashes",
-			},
-			expected: "minio-service.namespace.svc.cluster.local:9000/bucket-name-with-dashes",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := GetFilesystemKeyFromStorageConfig(tt.storageConfig)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
 }

--- a/pkg/metrics/persistent_store_metrics.go
+++ b/pkg/metrics/persistent_store_metrics.go
@@ -17,6 +17,8 @@
 package metrics
 
 import (
+	"sync"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -57,87 +59,189 @@ var (
 			Help:      "count of persistent data operation",
 		}, []string{persistentDataOpType, statusLabelName})
 
-	// Filesystem metrics (default filesystem only) - common across all nodes
+	// Deprecated: filesystem metrics are collected from the filesystem cache at scrape time. Remove in v4.
 	FilesystemReadCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: milvusNamespace,
 			Subsystem: "storage",
 			Name:      "filesystem_read_count",
 			Help:      "number of filesystem read operations",
-		}, []string{
-			filesystemKeyLabelName,
-		})
+		}, []string{filesystemKeyLabelName})
 
+	// Deprecated: filesystem metrics are collected from the filesystem cache at scrape time. Remove in v4.
 	FilesystemWriteCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: milvusNamespace,
 			Subsystem: "storage",
 			Name:      "filesystem_write_count",
 			Help:      "number of filesystem write operations",
-		}, []string{
-			filesystemKeyLabelName,
-		})
+		}, []string{filesystemKeyLabelName})
 
+	// Deprecated: filesystem metrics are collected from the filesystem cache at scrape time. Remove in v4.
 	FilesystemReadBytes = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: milvusNamespace,
 			Subsystem: "storage",
 			Name:      "filesystem_read_bytes",
 			Help:      "total bytes read from filesystem",
-		}, []string{
-			filesystemKeyLabelName,
-		})
+		}, []string{filesystemKeyLabelName})
 
+	// Deprecated: filesystem metrics are collected from the filesystem cache at scrape time. Remove in v4.
 	FilesystemWriteBytes = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: milvusNamespace,
 			Subsystem: "storage",
 			Name:      "filesystem_write_bytes",
 			Help:      "total bytes written to filesystem",
-		}, []string{
-			filesystemKeyLabelName,
-		})
+		}, []string{filesystemKeyLabelName})
 
+	// Deprecated: filesystem metrics are collected from the filesystem cache at scrape time. Remove in v4.
 	FilesystemGetFileInfoCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: milvusNamespace,
 			Subsystem: "storage",
 			Name:      "filesystem_get_file_info_count",
 			Help:      "number of get file info operations",
-		}, []string{
-			filesystemKeyLabelName,
-		})
+		}, []string{filesystemKeyLabelName})
 
+	// Deprecated: filesystem metrics are collected from the filesystem cache at scrape time. Remove in v4.
 	FilesystemFailedCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: milvusNamespace,
 			Subsystem: "storage",
 			Name:      "filesystem_failed_count",
 			Help:      "number of failed filesystem operations",
-		}, []string{
-			filesystemKeyLabelName,
-		})
+		}, []string{filesystemKeyLabelName})
 
+	// Deprecated: filesystem metrics are collected from the filesystem cache at scrape time. Remove in v4.
 	FilesystemMultiPartUploadCreated = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: milvusNamespace,
 			Subsystem: "storage",
 			Name:      "filesystem_multi_part_upload_created",
 			Help:      "number of multi-part uploads created",
-		}, []string{
-			filesystemKeyLabelName,
-		})
+		}, []string{filesystemKeyLabelName})
 
+	// Deprecated: filesystem metrics are collected from the filesystem cache at scrape time. Remove in v4.
 	FilesystemMultiPartUploadFinished = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: milvusNamespace,
 			Subsystem: "storage",
 			Name:      "filesystem_multi_part_upload_finished",
 			Help:      "number of multi-part uploads finished",
-		}, []string{
-			filesystemKeyLabelName,
-		})
+		}, []string{filesystemKeyLabelName})
+
+	filesystemMetricVecs = []*prometheus.GaugeVec{
+		FilesystemReadCount,
+		FilesystemWriteCount,
+		FilesystemReadBytes,
+		FilesystemWriteBytes,
+		FilesystemGetFileInfoCount,
+		FilesystemFailedCount,
+		FilesystemMultiPartUploadCreated,
+		FilesystemMultiPartUploadFinished,
+	}
 )
+
+// FilesystemMetrics holds the metrics for one cached filesystem.
+type FilesystemMetrics struct {
+	DisplayKey              string
+	ReadCount               int64
+	WriteCount              int64
+	ReadBytes               int64
+	WriteBytes              int64
+	GetFileInfoCount        int64
+	FailedCount             int64
+	MultiPartUploadCreated  int64
+	MultiPartUploadFinished int64
+}
+
+var (
+	filesystemMetricsCollectFn func() []FilesystemMetrics
+	filesystemMetricsMu        sync.Mutex
+
+	filesystemMetricsScrapeMu   sync.Mutex
+	filesystemMetricsStateMu    sync.Mutex
+	filesystemMetricsCacheKeys  = make(map[string]struct{})
+	filesystemMetricsLegacyKeys = make(map[string]struct{})
+)
+
+// SetFilesystemMetricsCollectFn sets the callback used to list current filesystem metrics.
+func SetFilesystemMetricsCollectFn(fn func() []FilesystemMetrics) {
+	filesystemMetricsMu.Lock()
+	defer filesystemMetricsMu.Unlock()
+	filesystemMetricsCollectFn = fn
+}
+
+type filesystemMetricsCollector struct{}
+
+func (c *filesystemMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, metric := range filesystemMetricVecs {
+		metric.Describe(ch)
+	}
+}
+
+func (c *filesystemMetricsCollector) Collect(ch chan<- prometheus.Metric) {
+	filesystemMetricsScrapeMu.Lock()
+	defer filesystemMetricsScrapeMu.Unlock()
+
+	filesystemMetricsMu.Lock()
+	fn := filesystemMetricsCollectFn
+	filesystemMetricsMu.Unlock()
+
+	var cacheMetrics []FilesystemMetrics
+	if fn != nil {
+		cacheMetrics = fn()
+	}
+
+	filesystemMetricsStateMu.Lock()
+	defer filesystemMetricsStateMu.Unlock()
+
+	for key := range filesystemMetricsCacheKeys {
+		if _, legacy := filesystemMetricsLegacyKeys[key]; legacy {
+			continue
+		}
+		for _, metric := range filesystemMetricVecs {
+			metric.DeleteLabelValues(key)
+		}
+	}
+	clear(filesystemMetricsCacheKeys)
+
+	for _, metric := range cacheMetrics {
+		if _, legacy := filesystemMetricsLegacyKeys[metric.DisplayKey]; legacy {
+			continue
+		}
+		setFilesystemMetrics(metric.DisplayKey, metric.ReadCount, metric.WriteCount, metric.ReadBytes, metric.WriteBytes,
+			metric.GetFileInfoCount, metric.FailedCount, metric.MultiPartUploadCreated, metric.MultiPartUploadFinished)
+		filesystemMetricsCacheKeys[metric.DisplayKey] = struct{}{}
+	}
+
+	for _, metric := range filesystemMetricVecs {
+		metric.Collect(ch)
+	}
+}
+
+func setFilesystemMetrics(fs string, readCount, writeCount, readBytes, writeBytes, getFileInfoCount, failedCount, multiPartUploadCreated, multiPartUploadFinished int64) {
+	FilesystemReadCount.WithLabelValues(fs).Set(float64(readCount))
+	FilesystemWriteCount.WithLabelValues(fs).Set(float64(writeCount))
+	FilesystemReadBytes.WithLabelValues(fs).Set(float64(readBytes))
+	FilesystemWriteBytes.WithLabelValues(fs).Set(float64(writeBytes))
+	FilesystemGetFileInfoCount.WithLabelValues(fs).Set(float64(getFileInfoCount))
+	FilesystemFailedCount.WithLabelValues(fs).Set(float64(failedCount))
+	FilesystemMultiPartUploadCreated.WithLabelValues(fs).Set(float64(multiPartUploadCreated))
+	FilesystemMultiPartUploadFinished.WithLabelValues(fs).Set(float64(multiPartUploadFinished))
+}
+
+// PublishFilesystemMetrics publishes filesystem metrics.
+//
+// Deprecated: filesystem metrics are collected from the filesystem cache at scrape time. Remove in v4.
+func PublishFilesystemMetrics(fs string, readCount, writeCount, readBytes, writeBytes, getFileInfoCount, failedCount, multiPartUploadCreated, multiPartUploadFinished int64) {
+	filesystemMetricsStateMu.Lock()
+	defer filesystemMetricsStateMu.Unlock()
+
+	setFilesystemMetrics(fs, readCount, writeCount, readBytes, writeBytes, getFileInfoCount, failedCount, multiPartUploadCreated, multiPartUploadFinished)
+	filesystemMetricsLegacyKeys[fs] = struct{}{}
+}
 
 // RegisterStorageMetrics registers storage metrics
 func RegisterStorageMetrics(registry *prometheus.Registry) {
@@ -145,29 +249,5 @@ func RegisterStorageMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(PersistentDataRequestLatency)
 	registry.MustRegister(PersistentDataOpCounter)
 
-	// filesystem metrics
-	registry.MustRegister(FilesystemReadCount)
-	registry.MustRegister(FilesystemWriteCount)
-	registry.MustRegister(FilesystemReadBytes)
-	registry.MustRegister(FilesystemWriteBytes)
-	registry.MustRegister(FilesystemGetFileInfoCount)
-	registry.MustRegister(FilesystemFailedCount)
-	registry.MustRegister(FilesystemMultiPartUploadCreated)
-	registry.MustRegister(FilesystemMultiPartUploadFinished)
-}
-
-// PublishFilesystemMetrics publishes filesystem metrics (common across all nodes)
-func PublishFilesystemMetrics(fs string, readCount, writeCount, readBytes, writeBytes, getFileInfoCount, failedCount, multiPartUploadCreated, multiPartUploadFinished int64) {
-	labels := prometheus.Labels{
-		filesystemKeyLabelName: fs,
-	}
-
-	FilesystemReadCount.With(labels).Set(float64(readCount))
-	FilesystemWriteCount.With(labels).Set(float64(writeCount))
-	FilesystemReadBytes.With(labels).Set(float64(readBytes))
-	FilesystemWriteBytes.With(labels).Set(float64(writeBytes))
-	FilesystemGetFileInfoCount.With(labels).Set(float64(getFileInfoCount))
-	FilesystemFailedCount.With(labels).Set(float64(failedCount))
-	FilesystemMultiPartUploadCreated.With(labels).Set(float64(multiPartUploadCreated))
-	FilesystemMultiPartUploadFinished.With(labels).Set(float64(multiPartUploadFinished))
+	registry.MustRegister(&filesystemMetricsCollector{})
 }

--- a/pkg/metrics/persistent_store_metrics_test.go
+++ b/pkg/metrics/persistent_store_metrics_test.go
@@ -17,101 +17,268 @@
 package metrics
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestPublishFilesystemMetrics(t *testing.T) {
-	// Test values
-	fsName := "test-filesystem"
-	readCount := int64(100)
-	writeCount := int64(50)
-	readBytes := int64(1024000)
-	writeBytes := int64(512000)
-	getFileInfoCount := int64(200)
-	failedCount := int64(5)
-	multiPartUploadCreated := int64(10)
-	multiPartUploadFinished := int64(8)
+func resetFilesystemMetrics() {
+	filesystemMetricsStateMu.Lock()
+	defer filesystemMetricsStateMu.Unlock()
 
-	// Call the function
-	PublishFilesystemMetrics(fsName, readCount, writeCount, readBytes, writeBytes,
-		getFileInfoCount, failedCount, multiPartUploadCreated, multiPartUploadFinished)
-
-	// Verify each metric
-	labels := prometheus.Labels{filesystemKeyLabelName: fsName}
-
-	// Check FilesystemReadCount
-	readCountMetric := FilesystemReadCount.With(labels)
-	assert.NotNil(t, readCountMetric)
-
-	// Check FilesystemWriteCount
-	writeCountMetric := FilesystemWriteCount.With(labels)
-	assert.NotNil(t, writeCountMetric)
-
-	// Check FilesystemReadBytes
-	readBytesMetric := FilesystemReadBytes.With(labels)
-	assert.NotNil(t, readBytesMetric)
-
-	// Check FilesystemWriteBytes
-	writeBytesMetric := FilesystemWriteBytes.With(labels)
-	assert.NotNil(t, writeBytesMetric)
-
-	// Check FilesystemGetFileInfoCount
-	getFileInfoMetric := FilesystemGetFileInfoCount.With(labels)
-	assert.NotNil(t, getFileInfoMetric)
-
-	// Check FilesystemFailedCount
-	failedMetric := FilesystemFailedCount.With(labels)
-	assert.NotNil(t, failedMetric)
-
-	// Check FilesystemMultiPartUploadCreated
-	multiPartCreatedMetric := FilesystemMultiPartUploadCreated.With(labels)
-	assert.NotNil(t, multiPartCreatedMetric)
-
-	// Check FilesystemMultiPartUploadFinished
-	multiPartFinishedMetric := FilesystemMultiPartUploadFinished.With(labels)
-	assert.NotNil(t, multiPartFinishedMetric)
+	FilesystemReadCount.Reset()
+	FilesystemWriteCount.Reset()
+	FilesystemReadBytes.Reset()
+	FilesystemWriteBytes.Reset()
+	FilesystemGetFileInfoCount.Reset()
+	FilesystemFailedCount.Reset()
+	FilesystemMultiPartUploadCreated.Reset()
+	FilesystemMultiPartUploadFinished.Reset()
+	clear(filesystemMetricsCacheKeys)
+	clear(filesystemMetricsLegacyKeys)
 }
 
-func TestPublishFilesystemMetricsMultipleFilesystems(t *testing.T) {
-	// Test with multiple filesystem names to ensure labels work correctly
-	fs1 := "minio"
-	fs2 := "s3"
-
-	// Publish metrics for first filesystem
-	PublishFilesystemMetrics(fs1, 100, 50, 1000, 500, 10, 1, 5, 3)
-
-	// Publish metrics for second filesystem
-	PublishFilesystemMetrics(fs2, 200, 100, 2000, 1000, 20, 2, 10, 6)
-
-	// Verify both filesystems have their own metric values
-	labels1 := prometheus.Labels{filesystemKeyLabelName: fs1}
-	labels2 := prometheus.Labels{filesystemKeyLabelName: fs2}
-
-	// Both should be non-nil and independently tracked
-	assert.NotNil(t, FilesystemReadCount.With(labels1))
-	assert.NotNil(t, FilesystemReadCount.With(labels2))
-	assert.NotNil(t, FilesystemWriteCount.With(labels1))
-	assert.NotNil(t, FilesystemWriteCount.With(labels2))
+func prepareFilesystemMetricsTest(t *testing.T) {
+	t.Helper()
+	resetFilesystemMetrics()
+	SetFilesystemMetricsCollectFn(nil)
+	t.Cleanup(func() {
+		resetFilesystemMetrics()
+		SetFilesystemMetricsCollectFn(nil)
+	})
 }
 
-func TestPublishFilesystemMetricsZeroValues(t *testing.T) {
-	// Test with zero values to ensure no issues with edge cases
-	fsName := "empty-filesystem"
+func TestPublishFilesystemMetricsCompatibility(t *testing.T) {
+	prepareFilesystemMetricsTest(t)
 
-	PublishFilesystemMetrics(fsName, 0, 0, 0, 0, 0, 0, 0, 0)
+	const filesystemKey = "legacy-filesystem"
+	PublishFilesystemMetrics(filesystemKey, 1, 2, 3, 4, 5, 6, 7, 8)
 
-	labels := prometheus.Labels{filesystemKeyLabelName: fsName}
+	registry := prometheus.NewRegistry()
+	RegisterStorageMetrics(registry)
 
-	// All metrics should still be created with zero values
-	assert.NotNil(t, FilesystemReadCount.With(labels))
-	assert.NotNil(t, FilesystemWriteCount.With(labels))
-	assert.NotNil(t, FilesystemReadBytes.With(labels))
-	assert.NotNil(t, FilesystemWriteBytes.With(labels))
-	assert.NotNil(t, FilesystemGetFileInfoCount.With(labels))
-	assert.NotNil(t, FilesystemFailedCount.With(labels))
-	assert.NotNil(t, FilesystemMultiPartUploadCreated.With(labels))
-	assert.NotNil(t, FilesystemMultiPartUploadFinished.With(labels))
+	expected := map[string]float64{
+		"milvus_storage_filesystem_read_count":                 1,
+		"milvus_storage_filesystem_write_count":                2,
+		"milvus_storage_filesystem_read_bytes":                 3,
+		"milvus_storage_filesystem_write_bytes":                4,
+		"milvus_storage_filesystem_get_file_info_count":        5,
+		"milvus_storage_filesystem_failed_count":               6,
+		"milvus_storage_filesystem_multi_part_upload_created":  7,
+		"milvus_storage_filesystem_multi_part_upload_finished": 8,
+	}
+
+	gathered, err := registry.Gather()
+	require.NoError(t, err)
+	require.Len(t, gathered, len(expected))
+	for _, family := range gathered {
+		require.Contains(t, expected, family.GetName())
+		require.Len(t, family.Metric, 1)
+		require.Equal(t, filesystemKey, family.Metric[0].Label[0].GetValue())
+		require.Equal(t, expected[family.GetName()], family.Metric[0].GetGauge().GetValue())
+	}
+}
+
+func TestFilesystemMetricsCollector(t *testing.T) {
+	prepareFilesystemMetricsTest(t)
+
+	const (
+		localKey  = "file:///tmp/a#fs:a"
+		remoteKey = "s3.example.com/bucket#fs:b"
+	)
+	metricsList := []FilesystemMetrics{
+		{
+			DisplayKey: localKey, ReadCount: 1, WriteCount: 2,
+			ReadBytes: 3, WriteBytes: 4, GetFileInfoCount: 5,
+			FailedCount: 6, MultiPartUploadCreated: 7, MultiPartUploadFinished: 8,
+		},
+		{
+			DisplayKey: remoteKey, ReadCount: 11, WriteCount: 12,
+			ReadBytes: 13, WriteBytes: 14, GetFileInfoCount: 15,
+			FailedCount: 16, MultiPartUploadCreated: 17, MultiPartUploadFinished: 18,
+		},
+	}
+	SetFilesystemMetricsCollectFn(func() []FilesystemMetrics { return metricsList })
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(&filesystemMetricsCollector{})
+
+	expected := map[string]map[string]float64{
+		"milvus_storage_filesystem_read_count":                 {localKey: 1, remoteKey: 11},
+		"milvus_storage_filesystem_write_count":                {localKey: 2, remoteKey: 12},
+		"milvus_storage_filesystem_read_bytes":                 {localKey: 3, remoteKey: 13},
+		"milvus_storage_filesystem_write_bytes":                {localKey: 4, remoteKey: 14},
+		"milvus_storage_filesystem_get_file_info_count":        {localKey: 5, remoteKey: 15},
+		"milvus_storage_filesystem_failed_count":               {localKey: 6, remoteKey: 16},
+		"milvus_storage_filesystem_multi_part_upload_created":  {localKey: 7, remoteKey: 17},
+		"milvus_storage_filesystem_multi_part_upload_finished": {localKey: 8, remoteKey: 18},
+	}
+
+	gathered, err := registry.Gather()
+	require.NoError(t, err)
+	require.Len(t, gathered, len(expected))
+	for _, family := range gathered {
+		values, ok := expected[family.GetName()]
+		require.True(t, ok, family.GetName())
+		require.Len(t, family.Metric, len(values))
+		for _, metric := range family.Metric {
+			var filesystemKey string
+			for _, label := range metric.Label {
+				if label.GetName() == filesystemKeyLabelName {
+					filesystemKey = label.GetValue()
+				}
+			}
+			require.Equal(t, values[filesystemKey], metric.GetGauge().GetValue())
+		}
+	}
+
+	metricsList = metricsList[:1]
+	gathered, err = registry.Gather()
+	require.NoError(t, err)
+	for _, family := range gathered {
+		require.Len(t, family.Metric, 1)
+		require.Equal(t, localKey, family.Metric[0].Label[0].GetValue())
+	}
+}
+
+func TestFilesystemMetricsCollectorWithoutMetrics(t *testing.T) {
+	prepareFilesystemMetricsTest(t)
+
+	tests := []struct {
+		name      string
+		collectFn func() []FilesystemMetrics
+	}{
+		{name: "nil callback"},
+		{name: "empty metrics", collectFn: func() []FilesystemMetrics { return nil }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			SetFilesystemMetricsCollectFn(test.collectFn)
+
+			registry := prometheus.NewRegistry()
+			registry.MustRegister(&filesystemMetricsCollector{})
+
+			gathered, err := registry.Gather()
+			require.NoError(t, err)
+			require.Empty(t, gathered)
+		})
+	}
+}
+
+func TestFilesystemMetricsCollectorsShareCacheOwnership(t *testing.T) {
+	prepareFilesystemMetricsTest(t)
+
+	metricsList := []FilesystemMetrics{{DisplayKey: "cache-a", ReadCount: 1}}
+	SetFilesystemMetricsCollectFn(func() []FilesystemMetrics { return metricsList })
+
+	registryA := prometheus.NewRegistry()
+	registryA.MustRegister(&filesystemMetricsCollector{})
+	registryB := prometheus.NewRegistry()
+	registryB.MustRegister(&filesystemMetricsCollector{})
+
+	_, err := registryA.Gather()
+	require.NoError(t, err)
+
+	metricsList = []FilesystemMetrics{{DisplayKey: "cache-b", ReadCount: 2}}
+	gathered, err := registryB.Gather()
+	require.NoError(t, err)
+	for _, family := range gathered {
+		require.Len(t, family.Metric, 1)
+		require.Equal(t, "cache-b", family.Metric[0].Label[0].GetValue())
+	}
+}
+
+func TestPublishFilesystemMetricsTakesOwnershipFromCache(t *testing.T) {
+	prepareFilesystemMetricsTest(t)
+
+	metricsList := []FilesystemMetrics{{DisplayKey: "shared-key", ReadCount: 1}}
+	SetFilesystemMetricsCollectFn(func() []FilesystemMetrics { return metricsList })
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(&filesystemMetricsCollector{})
+	_, err := registry.Gather()
+	require.NoError(t, err)
+
+	PublishFilesystemMetrics("shared-key", 99, 0, 0, 0, 0, 0, 0, 0)
+	metricsList = nil
+
+	gathered, err := registry.Gather()
+	require.NoError(t, err)
+	var readCount float64
+	for _, family := range gathered {
+		require.Len(t, family.Metric, 1)
+		require.Equal(t, "shared-key", family.Metric[0].Label[0].GetValue())
+		if family.GetName() == "milvus_storage_filesystem_read_count" {
+			readCount = family.Metric[0].GetGauge().GetValue()
+		}
+	}
+	require.Equal(t, float64(99), readCount)
+}
+
+func TestFilesystemMetricsCollectorConcurrentRegistrationAndGather(t *testing.T) {
+	prepareFilesystemMetricsTest(t)
+
+	callbacks := []func() []FilesystemMetrics{
+		func() []FilesystemMetrics {
+			return []FilesystemMetrics{{DisplayKey: "fs-a", ReadCount: 1}}
+		},
+		func() []FilesystemMetrics {
+			return []FilesystemMetrics{{DisplayKey: "fs-b", ReadCount: 2}}
+		},
+	}
+	SetFilesystemMetricsCollectFn(callbacks[0])
+
+	registries := []*prometheus.Registry{
+		prometheus.NewRegistry(),
+		prometheus.NewRegistry(),
+	}
+	for _, registry := range registries {
+		registry.MustRegister(&filesystemMetricsCollector{})
+	}
+
+	const iterations = 100
+	start := make(chan struct{})
+	results := make(chan struct {
+		err                error
+		familyCount        int
+		oneMetricPerFamily bool
+	}, iterations*len(registries))
+	var wg sync.WaitGroup
+	wg.Add(1 + len(registries))
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < iterations; i++ {
+			SetFilesystemMetricsCollectFn(callbacks[i%len(callbacks)])
+		}
+	}()
+	for _, registry := range registries {
+		go func() {
+			defer wg.Done()
+			<-start
+			for i := 0; i < iterations; i++ {
+				gathered, err := registry.Gather()
+				oneMetricPerFamily := true
+				for _, family := range gathered {
+					oneMetricPerFamily = oneMetricPerFamily && len(family.Metric) == 1
+				}
+				results <- struct {
+					err                error
+					familyCount        int
+					oneMetricPerFamily bool
+				}{err: err, familyCount: len(gathered), oneMetricPerFamily: oneMetricPerFamily}
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+	for result := range results {
+		require.NoError(t, result.err)
+		require.Equal(t, 8, result.familyCount)
+		require.True(t, result.oneMetricPerFamily)
+	}
 }


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/47520

Filesystem metrics were previously pushed from task-completion paths, which could miss cached filesystems and leave stale values. Collect them directly from the storage cache at scrape time instead. Update milvus-storage to use the cache-wide metrics API, expose cached snapshots through storagev2, and register a thread-safe Prometheus collector while preserving existing metric names and labels.

Remove the per-task publishing calls and old config-based helpers so compaction, index, flush, and load paths no longer manage filesystem observability.