### PR TITLE
test: invalidate stale ci-passed before CI completes

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -137,14 +137,8 @@ misc:
             - or:
                 - 'status-failure=Code Checker AMD64 Ubuntu 22.04'
                 - 'status-failure=ci-v2/code-check'
-  - when_master_build_ut_cov_gate_failure: &WHEN_MASTER_BUILD_UT_COV_GATE_FAILURE
-      and:
-        - -status-success=ci-v2/build-ut-cov
-        - status-failure=ci-v2/build-ut-cov
-  - when_master_go_unit_build_ut_cov_gate_failure: &WHEN_MASTER_GO_UNIT_BUILD_UT_COV_GATE_FAILURE
-      and:
-        - -status-success=ci-v2/build-ut-cov
-        - status-failure=ci-v2/build-ut-cov
+  - when_master_build_ut_cov_gate_not_success: &WHEN_MASTER_BUILD_UT_COV_GATE_NOT_SUCCESS
+      -status-success=ci-v2/build-ut-cov
 
   # Branch configurations
   - branch: &BRANCHES
@@ -379,8 +373,8 @@ pull_request_rules:
           - ci-passed
 
   # ==========================================================================
-  # CI FAILURE HANDLING
-  # Remove ci-passed labels when tests fail
+  # CI-PASSED INVALIDATION
+  # Remove stale ci-passed labels while required checks are pending, missing, or failed
   # ==========================================================================
 
   - name: Remove ci-passed when E2E test not success for tests changed
@@ -413,143 +407,113 @@ pull_request_rules:
           - ci-passed
 
   # ==========================================================================
-  # CONSOLIDATED MIGRATION FAILURE HANDLING
-  # Handle failure scenarios during CI system migration with optimized rules
+  # SOURCE CODE CI-PASSED INVALIDATION
+  # Keep the required-check matrix aligned with the corresponding pass rules
+  # Do not require status-failure: a new head SHA starts with missing/pending
+  # statuses and must invalidate the PR-scoped label immediately.
   # ==========================================================================
 
-  - name: Remove ci-passed when any CI system fails during master build-ut-cov migration
+  - name: Remove stale ci-passed when required CI is not successful on master
     conditions:
       - *MASTER_BRANCH
       - label!=manual-pass
+      - label=ci-passed
       - *source_code_files
       - or:
-        # build-ut-cov replaces the legacy build/ut/code-check group on master.
-        - and:
-            - *only_go_unittest_files
-            - *WHEN_MASTER_GO_UNIT_BUILD_UT_COV_GATE_FAILURE
-        - and:
-            - *morethan_go_unittest_files
-            - *WHEN_MASTER_BUILD_UT_COV_GATE_FAILURE
-        # E2E tests: remove only when E2E is required by the matching pass rule.
+        # build-ut-cov is required for every source-code pass path.
+        - *WHEN_MASTER_BUILD_UT_COV_GATE_NOT_SUCCESS
+        # Go SDK and E2E are required only for regular source-code changes.
         - and:
             - -title~=\[skip e2e\]
             - *morethan_go_unittest_files
             - not:
                 or:
-                  - status-success = cpu-e2e
-                  - status-success = ci-v2/e2e-default
-            - or:
-                - status-failure = cpu-e2e
-                - status-failure = ci-v2/e2e-default
-        # E2E tests: required case - remove if no success AND has failure (when not skipped)
+                  - status-success=go-sdk
+                  - status-success=milvus-sdk-go
+                  - status-success=ci-v2/go-sdk
         - and:
-          - -title~=\[skip e2e\]
-          - files~=^(?!(.*_test\.go|.*\.md|\.github\/mergify\.yml)).*$
-          - not:
-              or:
-                - status-success = cpu-e2e
-                - status-success = ci-v2/e2e-default
-          - or:
-              - status-failure = cpu-e2e
-              - status-failure = ci-v2/e2e-default
+            - -title~=\[skip e2e\]
+            - *morethan_go_unittest_files
+            - not:
+                or:
+                  - status-success=cpu-e2e
+                  - status-success=ci-v2/e2e-default
     actions:
       label:
         remove:
           - ci-passed
 
-  - name: Remove ci-passed when any CI system fails during migration on 2.* branch
+  - name: Remove stale ci-passed when required CI is not successful on 2.* branch
     conditions:
       - *2X_BRANCH
       - label!=manual-pass
+      - label=ci-passed
       - *source_code_files
-      # Comprehensive failure logic: remove ci-passed when any required system fails
       - or:
-        # Build systems: remove if no success AND has failure
+        # Build, Go UT, and code check are required for every source-code pass path.
+        - not:
+            or:
+              - status-success=Build and test AMD64 Ubuntu 22.04
+              - status-success=ci-v2/build
+        - not:
+            or:
+              - status-success=go-unit-test
+              - status-success=UT for Go
+              - status-success=ci-v2/ut-go
+        - not:
+            or:
+              - status-success=Code Checker AMD64 Ubuntu 22.04
+              - status-success=ci-v2/code-check
+        # Cpp UT and integration are not required for Go-unit-test-only changes.
         - and:
+            - *morethan_go_unittest_files
             - not:
                 or:
-                  - status-success = Build and test AMD64 Ubuntu 22.04
-                  - status-success = ci-v2/build
-            - or:
-                - status-failure = Build and test AMD64 Ubuntu 22.04
-                - status-failure = ci-v2/build
-        # Go unit tests: remove if no success AND has failure
+                  - status-success=cpp-unit-test
+                  - status-success=UT for Cpp
+                  - status-success=ci-v2/ut-cpp
         - and:
+            - *morethan_go_unittest_files
             - not:
                 or:
-                  - status-success = UT for Go
-                  - status-success = ci-v2/ut-go
-            - or:
-                - status-failure = UT for Go
-                - status-failure = ci-v2/ut-go
-        # Integration tests: remove if no success AND has failure
+                  - status-success=integration-test
+                  - status-success=Integration Test
+                  - status-success=ci-v2/integration-test
+        # E2E is required only for regular source-code changes.
         - and:
+            - -title~=\[skip e2e\]
+            - *morethan_go_unittest_files
             - not:
                 or:
-                  - status-success = Integration Test
-                  - status-success = ci-v2/integration-test
-            - or:
-                - status-failure = Integration Test
-                - status-failure = ci-v2/integration-test
-        # Cpp unit tests: remove if no success AND has failure (only when cpp files changed)
-        - and:
-          - *morethan_go_unittest_files
-          - not:
-              or:
-                - status-success = cpp-unit-test
-                - status-success = ci-v2/ut-cpp
-          - or:
-              - status-failure = cpp-unit-test
-              - status-failure = ci-v2/ut-cpp
-        # Code checker Ubuntu: remove if no success AND has failure
-        - and:
-            - not:
-                or:
-                  - status-success = Code Checker AMD64 Ubuntu 22.04
-                  - status-success = ci-v2/code-check
-            - or:
-                - status-failure = Code Checker AMD64 Ubuntu 22.04
-                - status-failure = ci-v2/code-check
-        # E2E tests: regular case - remove if no success AND has failure
-        - and:
-            - not:
-                or:
-                  - status-success = cpu-e2e
-                  - status-success = ci-v2/e2e-default
-            - or:
-                - status-failure = cpu-e2e
-                - status-failure = ci-v2/e2e-default
-        # E2E tests: required case - remove if no success AND has failure (when not skipped)
-        - and:
-          - -title~=\[skip e2e\]
-          - files~=^(?!(.*_test\.go|.*\.md|\.github\/mergify\.yml)).*$
-          - not:
-              or:
-                - status-success = cpu-e2e
-                - status-success = ci-v2/e2e-default
-          - or:
-              - status-failure = cpu-e2e
-              - status-failure = ci-v2/e2e-default
+                  - status-success=cpu-e2e
+                  - status-success=ci-v2/e2e-default
     actions:
       label:
         remove:
           - ci-passed
 
-  - name: Remove ci-passed when any CI fails on 3.0 branch
+  - name: Remove stale ci-passed when required CI is not successful on 3.0 branch
     conditions:
       - *3X_BRANCH
       - label!=manual-pass
+      - label=ci-passed
       - *source_code_files
       - or:
-          - and:
-              - -status-success = ci-v2/build-ut-cov
-              - status-failure = ci-v2/build-ut-cov
-          - and:
-              - -status-success = ci-v2/e2e-amd
-              - status-failure = ci-v2/e2e-amd
-          - and:
-              - -status-success = ci-v2/go-sdk
-              - status-failure = ci-v2/go-sdk
+        # build-ut-cov is required for every source-code pass path.
+        - -status-success=ci-v2/build-ut-cov
+        # Go SDK and E2E are required only for regular source-code changes.
+        - and:
+            - -title~=\[skip e2e\]
+            - *morethan_go_unittest_files
+            - not:
+                or:
+                  - status-success=go-sdk
+                  - status-success=milvus-sdk-go
+                  - status-success=ci-v2/go-sdk
+        - and:
+            - -title~=\[skip e2e\]
+            - *morethan_go_unittest_files
+            - -status-success=ci-v2/e2e-amd
     actions:
       label:
         remove:


### PR DESCRIPTION
## What this changes

Restore the original ci-passed invalidation behavior for source-code PRs on master, 2.x, and 3.0:

- remove stale ci-passed while any required CI status is missing, pending, or failed
- keep manual-pass exempt from automatic removal
- align required checks with the existing pass rules for regular, Go-unit-test-only, and [skip e2e] changes
- avoid add/remove label fights for checks that are intentionally skipped

## Why

During the CI-v2 migration, the removal rules were changed to require an explicit CI failure. A new head SHA starts with missing or pending statuses, so the ci-passed label from the previous SHA could remain until the Jenkins fallback pipeline started. PR #52642 exposed this: its new commit retained ci-passed for about 69 minutes and was merged before the fallback removed the stale label.

## Validation

- parsed .github/mergify.yml with Ruby YAML aliases enabled
- verified all three source invalidation rules retain manual-pass and ci-passed guards
- verified active source invalidation rules do not require status-failure
- git diff --check