### PR TITLE
fix: return the replicate configuration of an unconfigured cluster instead of blocking

### DIFF
--- a/internal/distributed/streaming/replicate_service.go
+++ b/internal/distributed/streaming/replicate_service.go
@@ -120,6 +120,9 @@ func (s replicateService) overwriteReplicateMessage(ctx context.Context, msg mes
 	if err != nil {
 		return nil, err
 	}
+	if cfg == nil {
+		return nil, status.NewReplicateViolation("cluster has no replicate configuration, cannot receive replicate message")
+	}
 
 	// Get target vchannel on current cluster that should be written to
 	currentCluster := cfg.GetCluster(s.clusterID)

--- a/internal/streamingcoord/client/assignment/assignment_test.go
+++ b/internal/streamingcoord/client/assignment/assignment_test.go
@@ -378,21 +378,59 @@ func TestWatcher_GetLatestReplicateConfiguration(t *testing.T) {
 		assert.NoError(t, <-errCh)
 	})
 
-	t.Run("blocks_when_version_set_but_config_nil", func(t *testing.T) {
+	t.Run("returns_nil_when_version_set_but_config_nil", func(t *testing.T) {
+		// A cluster that has never been given a replicate configuration reports a
+		// nil config in its assignment. That is an answer, not a missing update:
+		// the call must return promptly with a nil helper instead of blocking
+		// until the deadline.
 		w := newWatcher()
 
-		// Update with valid version but nil config
 		w.Update(types.VersionedStreamingNodeAssignments{
 			Version:               typeutil.VersionInt64Pair{Global: 1, Local: 1},
 			Assignments:           map[int64]types.StreamingNodeAssignment{},
 			ReplicateConfigHelper: nil,
 		})
 
-		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		_, err := w.GetLatestReplicateConfiguration(ctx)
-		assert.ErrorIs(t, err, context.DeadlineExceeded)
+		config, err := w.GetLatestReplicateConfiguration(ctx)
+		assert.NoError(t, err)
+		assert.Nil(t, config)
+		// The nil helper stays usable for the read accessors.
+		assert.Nil(t, config.GetReplicateConfiguration())
+		assert.Nil(t, config.GetCluster("any"))
+	})
+
+	t.Run("blocks_until_first_assignment_arrives", func(t *testing.T) {
+		// With no assignment received at all the call still blocks: that is a
+		// genuine "not known yet", unlike a received-but-nil configuration.
+		w := newWatcher()
+
+		resultCh := make(chan error, 1)
+		go func() {
+			_, err := w.GetLatestReplicateConfiguration(context.Background())
+			resultCh <- err
+		}()
+
+		select {
+		case <-resultCh:
+			t.Fatal("GetLatestReplicateConfiguration should block before the first assignment")
+		case <-time.After(50 * time.Millisecond):
+		}
+
+		w.Update(types.VersionedStreamingNodeAssignments{
+			Version:               typeutil.VersionInt64Pair{Global: 1, Local: 1},
+			Assignments:           map[int64]types.StreamingNodeAssignment{},
+			ReplicateConfigHelper: nil,
+		})
+
+		select {
+		case err := <-resultCh:
+			assert.NoError(t, err)
+		case <-time.After(time.Second):
+			t.Fatal("GetLatestReplicateConfiguration should have returned")
+		}
 	})
 
 	t.Run("returns_error_on_context_cancel", func(t *testing.T) {

--- a/internal/streamingcoord/client/assignment/watcher.go
+++ b/internal/streamingcoord/client/assignment/watcher.go
@@ -57,10 +57,15 @@ func (w *watcher) GetLatestDiscover(ctx context.Context) (*types.VersionedStream
 	return &last, nil
 }
 
+// GetLatestReplicateConfiguration returns the replicate configuration of the
+// latest assignment. It waits until an assignment has been received, and only
+// for that: a nil ConfigHelper is a valid answer meaning "this cluster has no
+// replication configured", which is the steady state of every cluster that has
+// never been given one. Waiting for a non-nil helper would block forever there
+// and surface as DEADLINE_EXCEEDED, indistinguishable from an unhealthy cluster.
 func (w *watcher) GetLatestReplicateConfiguration(ctx context.Context) (*replicateutil.ConfigHelper, error) {
 	w.cond.L.Lock()
-	for (w.lastVersionedAssignment.Version.Global == -1 && w.lastVersionedAssignment.Version.Local == -1) ||
-		w.lastVersionedAssignment.ReplicateConfigHelper == nil {
+	for w.lastVersionedAssignment.Version.Global == -1 && w.lastVersionedAssignment.Version.Local == -1 {
 		if err := w.cond.Wait(ctx); err != nil {
 			return nil, err
 		}

--- a/pkg/util/replicateutil/config_helper.go
+++ b/pkg/util/replicateutil/config_helper.go
@@ -128,6 +128,10 @@ type ConfigHelper struct {
 
 // GetReplicateConfiguration returns the replicate configuration of the graph.
 func (g *ConfigHelper) GetReplicateConfiguration() *commonpb.ReplicateConfiguration {
+	if g == nil {
+		// A nil helper is how "no replication configured" is represented.
+		return nil
+	}
 	return g.cfg
 }
 
@@ -145,6 +149,9 @@ func (g *ConfigHelper) IsJoinReplication() bool {
 
 // GetCluster returns the cluster from the graph.
 func (g *ConfigHelper) GetCluster(clusterID string) *MilvusCluster {
+	if g == nil {
+		return nil
+	}
 	return g.vs[clusterID]
 }
 


### PR DESCRIPTION
issue: #52686

## Problem

`GetReplicateConfiguration` never returns on a cluster that has never been given a
replicate configuration — it blocks until the caller's deadline and surfaces as
`DEADLINE_EXCEEDED`, which reads as an unhealthy cluster. Every freshly installed
cluster is in that state, so reading the topology before configuring replication
appears to fail.

A cluster with no replication has no configuration to report, and that is nil all the
way down: the balancer pushes a nil `ReplicateConfiguration` when `cm.replicateConfig`
is nil, `NewConfigHelper` maps a nil config to a nil helper, and the watcher's wait
condition treated that nil helper as "no assignment received yet":

```go
for (…Version.Global == -1 && …Version.Local == -1) ||
    w.lastVersionedAssignment.ReplicateConfigHelper == nil {
```

The second term can never be satisfied there. The sibling accessors on the same watcher,
`GetLatestStreamingVersion` and `GetLatestDiscover`, wait only on the version.

Sending an empty configuration from the balancer instead is not viable: `NewConfigHelper`
rejects a configuration with no clusters (`primary count is not 1`), so
`MustNewConfigHelper` would panic in every client. A nil helper *is* the representation
of "no replication configured".

#47517 made this deterministic rather than intermittent: the public API now always takes
the fresh-read path, which builds a throwaway watcher and waits for one assignment push,
so a genuinely fresh cluster fails every time while a previously-configured one still
answers from its long-lived watcher.

## Change

- `watcher.GetLatestReplicateConfiguration` waits only until an assignment has been
  received, and returns the possibly-nil helper.
- `ConfigHelper.GetReplicateConfiguration` and `GetCluster` are nil-receiver safe, so
  callers can use the result directly.
- `overwriteReplicateMessage` rejects a replicate message explicitly when the cluster has
  no configuration — previously unreachable, because the lookup blocked first.

## Tests

- `blocks_when_version_set_but_config_nil` asserted the old behaviour (deadline). It is
  replaced by `returns_nil_when_version_set_but_config_nil`, which asserts a prompt nil
  result and that the read accessors stay usable on it.
- New `blocks_until_first_assignment_arrives` keeps the genuine "not known yet" case
  covered: with no assignment at all the call still blocks, and returns once one arrives.
- `TestWatcher_GetLatestReplicateConfiguration` and `TestGetReplicateConfiguration_FreshRead`
  pass in full.
