### PR TITLE
fix: drop proxy collection metrics by partial match instead of enumerating labels

### DIFF
--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -690,7 +690,7 @@ func (t *searchTask) initAdvancedSearchRequest(ctx context.Context) error {
 			return err
 		}
 		if typeutil.IsFieldSparseFloatVector(t.schema.CollectionSchema, internalSubReq.FieldId) {
-			metrics.ProxySearchSparseNumNonZeros.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), t.collectionName, metrics.HybridSearchLabel, strconv.FormatInt(internalSubReq.FieldId, 10)).Observe(float64(typeutil.EstimateSparseVectorNNZFromPlaceholderGroup(internalSubReq.PlaceholderGroup, int(internalSubReq.GetNq()))))
+			metrics.ProxySearchSparseNumNonZeros.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), t.request.GetDbName(), t.collectionName, metrics.HybridSearchLabel, strconv.FormatInt(internalSubReq.FieldId, 10)).Observe(float64(typeutil.EstimateSparseVectorNNZFromPlaceholderGroup(internalSubReq.PlaceholderGroup, int(internalSubReq.GetNq()))))
 		}
 		internalSubReq.PlaceholderGroup = convertedPlaceholder
 		t.SubReqs[index] = internalSubReq
@@ -1043,7 +1043,7 @@ func (t *searchTask) initSearchRequest(ctx context.Context) error {
 	}
 	t.PkFilter = checkSegmentFilter(plan)
 	if typeutil.IsFieldSparseFloatVector(t.schema.CollectionSchema, t.FieldId) {
-		metrics.ProxySearchSparseNumNonZeros.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), t.collectionName, metrics.SearchLabel, strconv.FormatInt(t.FieldId, 10)).Observe(float64(typeutil.EstimateSparseVectorNNZFromPlaceholderGroup(t.request.GetPlaceholderGroup(), int(t.request.GetNq()))))
+		metrics.ProxySearchSparseNumNonZeros.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), t.request.GetDbName(), t.collectionName, metrics.SearchLabel, strconv.FormatInt(t.FieldId, 10)).Observe(float64(typeutil.EstimateSparseVectorNNZFromPlaceholderGroup(t.request.GetPlaceholderGroup(), int(t.request.GetNq()))))
 	}
 	// Convert placeholder group vector type if needed (e.g., fp32 -> fp16/bf16)
 	var placeholderType commonpb.PlaceholderType

--- a/internal/util/function/embedding/function_executor.go
+++ b/internal/util/function/embedding/function_executor.go
@@ -54,6 +54,9 @@ type Runner interface {
 
 type FunctionExecutor struct {
 	runners map[int64]Runner
+	// dbName labels the function latency metric so a dropped collection can be
+	// cleaned per (db, collection); collection names are only unique per db.
+	dbName string
 }
 
 func createFunction(coll *schemapb.CollectionSchema, schema *schemapb.FunctionSchema, extraInfo *models.ModelExtraInfo) (Runner, error) {
@@ -118,6 +121,9 @@ func NewFunctionExecutor(schema *schemapb.CollectionSchema, functions []*schemap
 	executor := &FunctionExecutor{
 		runners: make(map[int64]Runner),
 	}
+	if extraInfo != nil {
+		executor.dbName = extraInfo.DBName
+	}
 	if functions == nil {
 		functions = schema.Functions
 	}
@@ -152,7 +158,7 @@ func (executor *FunctionExecutor) processSingleFunction(ctx context.Context, run
 		return nil, err
 	}
 
-	metrics.ProxyFunctionlatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), runner.GetCollectionName(), runner.GetFunctionTypeName(), runner.GetFunctionProvider(), runner.GetFunctionName()).Observe(float64(tr.RecordSpan().Milliseconds()))
+	metrics.ProxyFunctionlatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), executor.dbName, runner.GetCollectionName(), runner.GetFunctionTypeName(), runner.GetFunctionProvider(), runner.GetFunctionName()).Observe(float64(tr.RecordSpan().Milliseconds()))
 	tr.CtxElapse(ctx, "function ProcessInsert done")
 	return outputs, nil
 }
@@ -214,7 +220,7 @@ func (executor *FunctionExecutor) processSingleSearch(ctx context.Context, runne
 	if err != nil {
 		return nil, err
 	}
-	metrics.ProxyFunctionlatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), runner.GetCollectionName(), runner.GetFunctionTypeName(), runner.GetFunctionProvider(), runner.GetFunctionName()).Observe(float64(tr.RecordSpan().Milliseconds()))
+	metrics.ProxyFunctionlatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), executor.dbName, runner.GetCollectionName(), runner.GetFunctionTypeName(), runner.GetFunctionProvider(), runner.GetFunctionName()).Observe(float64(tr.RecordSpan().Milliseconds()))
 	tr.CtxElapse(ctx, "function ProcessSearch done")
 	return proto.Marshal(res)
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -171,7 +171,6 @@ const (
 	// model function/UDF labels
 	functionTypeName = "function_type_name"
 	functionProvider = "function_provider"
-	functionName     = "function_name"
 
 	// entities label
 	LoadedLabel         = "loaded"

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -17,10 +17,16 @@
 package metrics
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -260,50 +266,48 @@ func observeQueryNodeCollection(nodeID, collectionID string) {
 	QueryNodeGlobalRefineCount.WithLabelValues(nodeID, collectionID).Add(1)
 }
 
+// proxyCollectionCollectors mirrors the production cleanup list, so a metric
+// added there is automatically observed and asserted on here.
 func proxyCollectionCollectors() []prometheus.Collector {
-	return []prometheus.Collector{
-		ProxyReceivedNQ,
-		ProxySearchVectors,
-		ProxyInsertVectors,
-		ProxyUpsertVectors,
-		ProxyDeleteVectors,
-		ProxySQLatency,
-		ProxyCollectionSQLatency,
-		ProxyMutationLatency,
-		ProxyCollectionMutationLatency,
-		ProxyFunctionCall,
-		ProxyReceiveBytes,
-		ProxyRetrySearchCount,
-		ProxyRetrySearchResultInsufficientCount,
-		ProxyRecallSearchCount,
-		ProxySearchSparseNumNonZeros,
-		ProxyFunctionlatency,
-		ProxyScannedRemoteMB,
-		ProxyScannedTotalMB,
+	scoped := proxyCollectionScopedMetrics()
+	collectors := make([]prometheus.Collector, 0, len(scoped))
+	for _, m := range scoped {
+		collectors = append(collectors, m.(prometheus.Collector))
 	}
+	return collectors
 }
 
+// observeProxyCollection touches every (metric, label value) combination the
+// proxy emits for a collection. Observing a single combination per metric is
+// not enough: cleanup used to enumerate label values with Delete() and passed
+// such a test while leaking every value the test did not happen to pick.
 func observeProxyCollection(nodeID, db, collection string) {
-	ProxyReceivedNQ.WithLabelValues(nodeID, SearchLabel, db, collection).Add(1)
+	for _, queryType := range []string{SearchLabel, HybridSearchLabel, QueryLabel, UpsertQueryLabel} {
+		ProxyReceivedNQ.WithLabelValues(nodeID, queryType, db, collection).Add(1)
+		ProxySQLatency.WithLabelValues(nodeID, queryType, db, collection).Observe(1)
+		ProxyCollectionSQLatency.WithLabelValues(nodeID, queryType, db, collection).Observe(1)
+		ProxyRetrySearchCount.WithLabelValues(nodeID, queryType, db, collection).Add(1)
+		ProxyRetrySearchResultInsufficientCount.WithLabelValues(nodeID, queryType, db, collection).Add(1)
+		ProxyRecallSearchCount.WithLabelValues(nodeID, queryType, db, collection).Add(1)
+		ProxySearchSparseNumNonZeros.WithLabelValues(nodeID, db, collection, queryType, "1").Observe(1)
+	}
+	for _, msgType := range []string{InsertLabel, DeleteLabel, UpsertLabel, SearchLabel, HybridSearchLabel, QueryLabel} {
+		ProxyMutationLatency.WithLabelValues(nodeID, msgType, db, collection).Observe(1)
+		ProxyCollectionMutationLatency.WithLabelValues(nodeID, msgType, db, collection).Observe(1)
+		ProxyReceiveBytes.WithLabelValues(nodeID, msgType, db, collection).Add(1)
+		ProxyScannedRemoteMB.WithLabelValues(nodeID, msgType, db, collection).Add(1)
+		ProxyScannedTotalMB.WithLabelValues(nodeID, msgType, db, collection).Add(1)
+	}
 	ProxySearchVectors.WithLabelValues(nodeID, db, collection).Add(1)
 	ProxyInsertVectors.WithLabelValues(nodeID, db, collection).Add(1)
 	ProxyUpsertVectors.WithLabelValues(nodeID, db, collection).Add(1)
 	ProxyDeleteVectors.WithLabelValues(nodeID, db, collection).Add(1)
-	ProxySQLatency.WithLabelValues(nodeID, SearchLabel, db, collection).Observe(1)
-	ProxyCollectionSQLatency.WithLabelValues(nodeID, SearchLabel, db, collection).Observe(1)
-	ProxyMutationLatency.WithLabelValues(nodeID, DeleteLabel, db, collection).Observe(1)
-	ProxyCollectionMutationLatency.WithLabelValues(nodeID, DeleteLabel, db, collection).Observe(1)
 	ProxyFunctionCall.WithLabelValues(nodeID, "x", SuccessLabel, CauseNA, db, collection).Add(1)
-	ProxyReceiveBytes.WithLabelValues(nodeID, DeleteLabel, db, collection).Add(1)
-	ProxyRetrySearchCount.WithLabelValues(nodeID, SearchLabel, db, collection).Add(1)
-	ProxyRetrySearchResultInsufficientCount.WithLabelValues(nodeID, SearchLabel, db, collection).Add(1)
-	ProxyRecallSearchCount.WithLabelValues(nodeID, SearchLabel, db, collection).Add(1)
-	ProxySearchSparseNumNonZeros.WithLabelValues(nodeID, collection, SearchLabel, "1").Observe(1)
-	ProxyFunctionlatency.WithLabelValues(nodeID, collection, "x", "x", "x").Observe(1)
-	ProxyScannedRemoteMB.WithLabelValues(nodeID, DeleteLabel, db, collection).Add(1)
-	ProxyScannedTotalMB.WithLabelValues(nodeID, DeleteLabel, db, collection).Add(1)
+	ProxyFunctionlatency.WithLabelValues(nodeID, db, collection, "x", "x", "x").Observe(1)
 }
 
+// leftoverCollectionSeries returns the distinct metric names that still hold a
+// series carrying label=value.
 func leftoverCollectionSeries(t *testing.T, collectors []prometheus.Collector, label, value string) []string {
 	t.Helper()
 	r := prometheus.NewRegistry()
@@ -312,14 +316,19 @@ func leftoverCollectionSeries(t *testing.T, collectors []prometheus.Collector, l
 	}
 	mfs, err := r.Gather()
 	assert.NoError(t, err)
+	seen := make(map[string]struct{})
 	var names []string
 	for _, mf := range mfs {
 		for _, m := range mf.GetMetric() {
 			for _, lp := range m.GetLabel() {
-				if lp.GetName() == label && lp.GetValue() == value {
-					names = append(names, mf.GetName())
-					break
+				if lp.GetName() != label || lp.GetValue() != value {
+					continue
 				}
+				if _, ok := seen[mf.GetName()]; !ok {
+					seen[mf.GetName()] = struct{}{}
+					names = append(names, mf.GetName())
+				}
+				break
 			}
 		}
 	}
@@ -358,7 +367,8 @@ func TestCleanupProxyCollectionMetricsDropsEveryCollectionSeries(t *testing.T) {
 	observeProxyCollection("7", db, other)
 
 	before := leftoverCollectionSeries(t, proxyCollectionCollectors(), collectionName, coll)
-	assert.NotEmpty(t, before)
+	assert.Len(t, before, len(proxyCollectionScopedMetrics()),
+		"observeProxyCollection must observe every metric in proxyCollectionScopedMetrics")
 
 	CleanupProxyCollectionMetrics(nodeID, db, coll)
 
@@ -366,4 +376,200 @@ func TestCleanupProxyCollectionMetricsDropsEveryCollectionSeries(t *testing.T) {
 	assert.NotEmpty(t, leftoverCollectionSeries(t, proxyCollectionCollectors(), collectionName, other))
 
 	CleanupProxyCollectionMetrics(nodeID, db, other)
+}
+
+func TestCleanupProxyDBMetricsDropsEveryCollectionSeries(t *testing.T) {
+	nodeID := int64(7)
+	db := "metric_db_cleanup_db"
+	otherDB := "metric_db_cleanup_other_db"
+
+	observeProxyCollection("7", db, "coll_a")
+	observeProxyCollection("7", db, "coll_b")
+	observeProxyCollection("7", otherDB, "coll_a")
+
+	before := leftoverCollectionSeries(t, proxyCollectionCollectors(), databaseLabelName, db)
+	assert.Len(t, before, len(proxyCollectionScopedMetrics()))
+
+	CleanupProxyDBMetrics(nodeID, db)
+
+	assert.Empty(t, leftoverCollectionSeries(t, proxyCollectionCollectors(), databaseLabelName, db))
+	assert.NotEmpty(t, leftoverCollectionSeries(t, proxyCollectionCollectors(), databaseLabelName, otherDB))
+
+	CleanupProxyDBMetrics(nodeID, otherDB)
+}
+
+// TestCollectionScopedMetricsAreComplete parses the metric declarations and
+// fails when a collection labeled metric is not wired into the matching drop
+// cleanup, which is how these series leaked in the first place.
+func TestCollectionScopedMetricsAreComplete(t *testing.T) {
+	t.Run("proxy", func(t *testing.T) {
+		assertCleanupCoversLabels(t, "proxy_metrics.go", "proxyCollectionScopedMetrics",
+			map[string]string{
+				// ProxyReportValue is db-scoped only (no collection_name label), so it
+				// cannot join proxyCollectionScopedMetrics(): CleanupProxyCollectionMetrics
+				// passes collection_name too and would then match nothing for it. It is
+				// cleaned separately in CleanupProxyDBMetrics.
+				"ProxyReportValue": "db-scoped only, cleaned in CleanupProxyDBMetrics",
+			},
+			"databaseLabelName", "collectionName")
+	})
+	t.Run("querynode", func(t *testing.T) {
+		assertCleanupCoversLabels(t, "querynode_metrics.go", "CleanupQueryNodeCollectionMetrics",
+			nil, "collectionIDLabelName")
+	})
+}
+
+// assertCleanupCoversLabels asserts every prometheus vec declared in file whose
+// variable label set overlaps requiredLabels is cleaned up by the named
+// function:
+//   - a vec carrying all required labels must be referenced by funcName;
+//   - a vec carrying only some of them (e.g. collection_name without db_name)
+//     is flagged as a gap unless it is allow-listed in allowList.
+//
+// Labels are matched by the identifier used in the declaration (for example
+// "collectionName"), not by the string it expands to; string-literal label
+// elements are resolved through the label-name constants in metrics.go. Scope is
+// the single named file -- a vec declared in another file of the package is
+// invisible to this guard.
+func assertCleanupCoversLabels(t *testing.T, file, funcName string, allowList map[string]string, requiredLabels ...string) {
+	t.Helper()
+	labelIdentByValue := labelIdentifiers(t)
+
+	parsed, err := parser.ParseFile(token.NewFileSet(), file, nil, 0)
+	require.NoError(t, err)
+
+	referenced := make(map[string]struct{})
+	var declared []string
+	var partial []string
+
+	ast.Inspect(parsed, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.FuncDecl:
+			if node.Name.Name != funcName {
+				return true
+			}
+			ast.Inspect(node.Body, func(inner ast.Node) bool {
+				if ident, ok := inner.(*ast.Ident); ok {
+					referenced[ident.Name] = struct{}{}
+				}
+				return true
+			})
+		case *ast.ValueSpec:
+			if len(node.Names) != 1 || len(node.Values) != 1 {
+				return true
+			}
+			labels, ok := vecVariableLabels(node.Values[0], labelIdentByValue)
+			if !ok {
+				return true
+			}
+			hasAny, hasAll := false, true
+			for _, required := range requiredLabels {
+				_, has := labels[required]
+				hasAny = hasAny || has
+				hasAll = hasAll && has
+			}
+			if !hasAny {
+				return true
+			}
+			name := node.Names[0].Name
+			if hasAll {
+				declared = append(declared, name)
+				return true
+			}
+			if _, allowed := allowList[name]; !allowed {
+				partial = append(partial, name)
+			}
+		}
+		return true
+	})
+
+	require.NotEmpty(t, declared, "no metric declaration matched %v in %s", requiredLabels, file)
+	for _, name := range declared {
+		_, ok := referenced[name]
+		assert.True(t, ok, "%s is labeled with %v but is never cleaned up in %s", name, requiredLabels, funcName)
+	}
+	for _, name := range partial {
+		assert.Failf(t, "metric carries only some required labels", "%s is labeled with only some of %v but is not cleaned up in %s", name, requiredLabels, funcName)
+	}
+}
+
+// labelIdentifiers parses the label-name constants declared in metrics.go and
+// returns a map from a constant's string value to its identifier (for example
+// "collection_name" -> "collectionName"), so a vec whose labels are written as
+// string literals resolves to the same identifiers the guard matches against.
+func labelIdentifiers(t *testing.T) map[string]string {
+	t.Helper()
+	parsed, err := parser.ParseFile(token.NewFileSet(), "metrics.go", nil, 0)
+	require.NoError(t, err)
+
+	result := make(map[string]string)
+	ast.Inspect(parsed, func(n ast.Node) bool {
+		decl, ok := n.(*ast.GenDecl)
+		if !ok || decl.Tok != token.CONST {
+			return true
+		}
+		for _, spec := range decl.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range vs.Names {
+				if i >= len(vs.Values) {
+					continue
+				}
+				lit, ok := vs.Values[i].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				if val, err := strconv.Unquote(lit.Value); err == nil {
+					result[val] = name.Name
+				}
+			}
+		}
+		return true
+	})
+	return result
+}
+
+// vecVariableLabels returns the variable label names of a
+// `prometheus.NewXxxVec(opts, []string{...})` expression. Identifiers are kept
+// as-is; string literals are resolved to their identifier via labelIdentByValue.
+func vecVariableLabels(expr ast.Expr, labelIdentByValue map[string]string) (map[string]struct{}, bool) {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok || len(call.Args) == 0 {
+		return nil, false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || !strings.HasSuffix(sel.Sel.Name, "Vec") {
+		return nil, false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok || pkg.Name != "prometheus" {
+		return nil, false
+	}
+	lit, ok := call.Args[len(call.Args)-1].(*ast.CompositeLit)
+	if !ok {
+		return nil, false
+	}
+	if _, ok := lit.Type.(*ast.ArrayType); !ok {
+		return nil, false
+	}
+	labels := make(map[string]struct{}, len(lit.Elts))
+	for _, elt := range lit.Elts {
+		switch e := elt.(type) {
+		case *ast.Ident:
+			labels[e.Name] = struct{}{}
+		case *ast.BasicLit:
+			if e.Kind == token.STRING {
+				if val, err := strconv.Unquote(e.Value); err == nil {
+					if ident, ok := labelIdentByValue[val]; ok {
+						labels[ident] = struct{}{}
+					} else {
+						labels[val] = struct{}{}
+					}
+				}
+			}
+		}
+	}
+	return labels, true
 }

--- a/pkg/metrics/proxy_metrics.go
+++ b/pkg/metrics/proxy_metrics.go
@@ -438,7 +438,7 @@ var (
 			Name:      "search_sparse_num_non_zeros",
 			Help:      "the number of non-zeros in each sparse search task",
 			Buckets:   buckets,
-		}, []string{nodeIDLabelName, collectionName, queryTypeLabelName, fieldIDLabelName})
+		}, []string{nodeIDLabelName, databaseLabelName, collectionName, queryTypeLabelName, fieldIDLabelName})
 
 	// ProxyQueueTaskNum records task number of queue in Proxy.
 	ProxyQueueTaskNum = prometheus.NewGaugeVec(
@@ -465,7 +465,7 @@ var (
 			Name:      "function_udf_call_latency",
 			Help:      "latency of function call",
 			Buckets:   buckets,
-		}, []string{nodeIDLabelName, collectionName, functionTypeName, functionProvider, functionName})
+		}, []string{nodeIDLabelName, databaseLabelName, collectionName, functionTypeName, functionProvider, functionLabelName})
 
 	ProxyScannedRemoteMB = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -557,230 +557,67 @@ func RegisterProxy(registry *prometheus.Registry) {
 	RegisterLoggingMetrics(registry)
 }
 
+// partialMatchDeleter is implemented by every prometheus *Vec type; it lets the
+// cleanup helpers below drop series without enumerating the remaining labels.
+type partialMatchDeleter interface {
+	DeletePartialMatch(labels prometheus.Labels) int
+}
+
+// proxyCollectionScopedMetrics lists every proxy metric that carries both a
+// db_name and a collection_name label, so a dropped database or collection can
+// be cleaned from one place.
+//
+// Cleanup deliberately goes through DeletePartialMatch on (node_id, db_name[,
+// collection_name]) instead of Delete() with a fully specified label set:
+// enumerating the msg_type/query_type values a metric may hold silently leaks
+// series as soon as a new value is emitted (hybrid search and upsert used to
+// leak this way). Keep this list in sync when adding a collection labeled proxy
+// metric -- TestCollectionScopedMetricsAreComplete guards it.
+func proxyCollectionScopedMetrics() []partialMatchDeleter {
+	return []partialMatchDeleter{
+		ProxySearchVectors,
+		ProxyInsertVectors,
+		ProxyUpsertVectors,
+		ProxyDeleteVectors,
+		ProxySQLatency,
+		ProxyCollectionSQLatency,
+		ProxyMutationLatency,
+		ProxyCollectionMutationLatency,
+		ProxyFunctionCall,
+		ProxyFunctionlatency,
+		ProxyReceivedNQ,
+		ProxyReceiveBytes,
+		ProxyRetrySearchCount,
+		ProxyRetrySearchResultInsufficientCount,
+		ProxyRecallSearchCount,
+		ProxySearchSparseNumNonZeros,
+		ProxyScannedRemoteMB,
+		ProxyScannedTotalMB,
+	}
+}
+
 func CleanupProxyDBMetrics(nodeID int64, dbName string) {
-	ProxySearchVectors.DeletePartialMatch(prometheus.Labels{
+	labels := prometheus.Labels{
 		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
 		databaseLabelName: dbName,
-	})
-	ProxyInsertVectors.DeletePartialMatch(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		databaseLabelName: dbName,
-	})
-	ProxyUpsertVectors.DeletePartialMatch(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		databaseLabelName: dbName,
-	})
-	ProxyDeleteVectors.DeletePartialMatch(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		databaseLabelName: dbName,
-	})
-	ProxySQLatency.DeletePartialMatch(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		databaseLabelName: dbName,
-	})
-	ProxyMutationLatency.DeletePartialMatch(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		databaseLabelName: dbName,
-	})
-	ProxyFunctionCall.DeletePartialMatch(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		databaseLabelName: dbName,
-	})
+	}
+	for _, m := range proxyCollectionScopedMetrics() {
+		m.DeletePartialMatch(labels)
+	}
+	// ProxyReportValue is the only proxy metric carrying db_name without a
+	// collection_name label, so it cannot join proxyCollectionScopedMetrics():
+	// CleanupProxyCollectionMetrics passes collection_name too and would then
+	// match nothing for it. Delete it here, db-scoped only.
+	ProxyReportValue.DeletePartialMatch(labels)
 }
 
 func CleanupProxyCollectionMetrics(nodeID int64, dbName string, collection string) {
-	ProxySearchVectors.DeletePartialMatch(prometheus.Labels{
+	labels := prometheus.Labels{
 		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
 		databaseLabelName: dbName,
 		collectionName:    collection,
-	})
-	ProxyInsertVectors.DeletePartialMatch(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		databaseLabelName: dbName,
-		collectionName:    collection,
-	})
-	ProxyUpsertVectors.DeletePartialMatch(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		databaseLabelName: dbName,
-		collectionName:    collection,
-	})
-	ProxyDeleteVectors.DeletePartialMatch(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		databaseLabelName: dbName,
-		collectionName:    collection,
-	})
-	ProxySQLatency.DeletePartialMatch(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		databaseLabelName: dbName,
-		collectionName:    collection,
-	})
-	ProxyMutationLatency.DeletePartialMatch(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		databaseLabelName: dbName,
-		collectionName:    collection,
-	})
-	ProxyFunctionCall.DeletePartialMatch(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		databaseLabelName: dbName,
-		collectionName:    collection,
-	})
-
-	ProxyCollectionSQLatency.Delete(prometheus.Labels{
-		nodeIDLabelName:    strconv.FormatInt(nodeID, 10),
-		queryTypeLabelName: SearchLabel,
-		databaseLabelName:  dbName,
-		collectionName:     collection,
-	})
-	ProxyCollectionSQLatency.Delete(prometheus.Labels{
-		nodeIDLabelName:    strconv.FormatInt(nodeID, 10),
-		queryTypeLabelName: QueryLabel,
-		databaseLabelName:  dbName,
-		collectionName:     collection,
-	})
-	ProxyCollectionSQLatency.Delete(prometheus.Labels{
-		nodeIDLabelName:    strconv.FormatInt(nodeID, 10),
-		queryTypeLabelName: UpsertQueryLabel,
-		databaseLabelName:  dbName,
-		collectionName:     collection,
-	})
-	ProxyCollectionMutationLatency.Delete(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		msgTypeLabelName:  InsertLabel,
-		databaseLabelName: dbName,
-		collectionName:    collection,
-	})
-	ProxyCollectionMutationLatency.Delete(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		msgTypeLabelName:  DeleteLabel,
-		databaseLabelName: dbName,
-		collectionName:    collection,
-	})
-	ProxyReceivedNQ.Delete(prometheus.Labels{
-		nodeIDLabelName:    strconv.FormatInt(nodeID, 10),
-		queryTypeLabelName: SearchLabel,
-		databaseLabelName:  dbName,
-		collectionName:     collection,
-	})
-	ProxyReceivedNQ.Delete(prometheus.Labels{
-		nodeIDLabelName:    strconv.FormatInt(nodeID, 10),
-		queryTypeLabelName: QueryLabel,
-		databaseLabelName:  dbName,
-		collectionName:     collection,
-	})
-	ProxyReceiveBytes.Delete(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		msgTypeLabelName:  SearchLabel,
-		databaseLabelName: dbName,
-		collectionName:    collection,
-	})
-	ProxyReceiveBytes.Delete(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		msgTypeLabelName:  QueryLabel,
-		databaseLabelName: dbName,
-		collectionName:    collection,
-	})
-	ProxyReceiveBytes.Delete(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		msgTypeLabelName:  InsertLabel,
-		databaseLabelName: dbName,
-		collectionName:    collection,
-	})
-	ProxyReceiveBytes.Delete(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		msgTypeLabelName:  DeleteLabel,
-		databaseLabelName: dbName,
-		collectionName:    collection,
-	})
-	ProxyReceiveBytes.Delete(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		msgTypeLabelName:  UpsertLabel,
-		databaseLabelName: dbName,
-		collectionName:    collection,
-	})
-	ProxyRetrySearchCount.Delete(prometheus.Labels{
-		nodeIDLabelName:    strconv.FormatInt(nodeID, 10),
-		queryTypeLabelName: SearchLabel,
-		databaseLabelName:  dbName,
-		collectionName:     collection,
-	})
-	ProxyRetrySearchCount.Delete(prometheus.Labels{
-		nodeIDLabelName:    strconv.FormatInt(nodeID, 10),
-		queryTypeLabelName: HybridSearchLabel,
-		databaseLabelName:  dbName,
-		collectionName:     collection,
-	})
-	ProxyRetrySearchResultInsufficientCount.Delete(prometheus.Labels{
-		nodeIDLabelName:    strconv.FormatInt(nodeID, 10),
-		queryTypeLabelName: SearchLabel,
-		databaseLabelName:  dbName,
-		collectionName:     collection,
-	})
-	ProxyRetrySearchResultInsufficientCount.Delete(prometheus.Labels{
-		nodeIDLabelName:    strconv.FormatInt(nodeID, 10),
-		queryTypeLabelName: HybridSearchLabel,
-		databaseLabelName:  dbName,
-		collectionName:     collection,
-	})
-	ProxyRecallSearchCount.Delete(prometheus.Labels{
-		nodeIDLabelName:    strconv.FormatInt(nodeID, 10),
-		queryTypeLabelName: SearchLabel,
-		databaseLabelName:  dbName,
-		collectionName:     collection,
-	})
-	ProxyScannedRemoteMB.Delete(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		msgTypeLabelName:  SearchLabel,
-		databaseLabelName: dbName,
-		collectionName:    collection,
-	})
-	ProxyScannedRemoteMB.Delete(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		msgTypeLabelName:  QueryLabel,
-		databaseLabelName: dbName,
-		collectionName:    collection,
-	})
-	ProxyScannedRemoteMB.Delete(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		msgTypeLabelName:  UpsertLabel,
-		databaseLabelName: dbName,
-		collectionName:    collection,
-	})
-	ProxyScannedRemoteMB.Delete(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		msgTypeLabelName:  DeleteLabel,
-		databaseLabelName: dbName,
-		collectionName:    collection,
-	})
-	ProxyScannedTotalMB.Delete(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		msgTypeLabelName:  SearchLabel,
-		databaseLabelName: dbName,
-		collectionName:    collection,
-	})
-	ProxyScannedTotalMB.Delete(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		msgTypeLabelName:  QueryLabel,
-		databaseLabelName: dbName,
-		collectionName:    collection,
-	})
-	ProxyScannedTotalMB.Delete(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		msgTypeLabelName:  UpsertLabel,
-		databaseLabelName: dbName,
-		collectionName:    collection,
-	})
-	ProxyScannedTotalMB.Delete(prometheus.Labels{
-		nodeIDLabelName:   strconv.FormatInt(nodeID, 10),
-		msgTypeLabelName:  DeleteLabel,
-		databaseLabelName: dbName,
-		collectionName:    collection,
-	})
-	ProxySearchSparseNumNonZeros.DeletePartialMatch(prometheus.Labels{
-		nodeIDLabelName: strconv.FormatInt(nodeID, 10),
-		collectionName:  collection,
-	})
-	ProxyFunctionlatency.DeletePartialMatch(prometheus.Labels{
-		nodeIDLabelName: strconv.FormatInt(nodeID, 10),
-		collectionName:  collection,
-	})
+	}
+	for _, m := range proxyCollectionScopedMetrics() {
+		m.DeletePartialMatch(labels)
+	}
 }

--- a/pkg/metrics/querynode_metrics.go
+++ b/pkg/metrics/querynode_metrics.go
@@ -1093,6 +1093,9 @@ func RegisterQueryNode(registry *prometheus.Registry) {
 	RegisterLoggingMetrics(registry)
 }
 
+// CleanupQueryNodeCollectionMetrics drops every query node series belonging to
+// collectionID. Every metric labeled with collection_id has to be listed here --
+// TestCollectionScopedMetricsAreComplete guards it.
 func CleanupQueryNodeCollectionMetrics(nodeID int64, collectionID int64) {
 	// Reuse a single labels map to avoid allocations; DeletePartialMatch does not mutate it.
 	labels := prometheus.Labels{


### PR DESCRIPTION
issue: #52690

Stacked on #52684 by @daviddallakyan2005 — that PR is the parent commit here, so this diff will collapse to a single commit once it merges. Please merge #52684 first.

`CleanupProxyCollectionMetrics` deleted most of its series with `Delete()` and a fully specified label set, so every `msg_type` / `query_type` value a metric can hold had to be enumerated by hand. Those enumerations went stale:

| metric | leaked value |
|---|---|
| `ProxyCollectionSQLatency` | hybrid_search |
| `ProxyCollectionMutationLatency` | upsert (and `insert` was enumerated but is never emitted) |
| `ProxyReceiveBytes` | hybrid_search |
| `ProxyScannedRemoteMB` | hybrid_search |
| `ProxyScannedTotalMB` | hybrid_search |

Cleanup now goes through `DeletePartialMatch` on `(node_id, db_name[, collection_name])` for every collection-scoped proxy metric. The list lives once in `proxyCollectionScopedMetrics()` and is shared by the collection and database cleanup paths, which also fixes `CleanupProxyDBMetrics` leaving 11 of 18 collection-scoped metrics behind on drop database. Net −150 lines in that file.

`search_sparse_num_non_zeros` and `function_udf_call_latency` had no `db_name` label, so cleaning them by collection name alone wipes a same-named collection in a different database. Both now carry `db_name` (`FunctionExecutor` picks it up from `extraInfo.DBName`). Neither metric is referenced by any dashboard under `deployments/`.

## Test

A guard test does not catch this class of bug by itself: observing one label combination per metric only proves the enumeration covers the value the test happened to pick. Two changes fix that:

- `observeProxyCollection` now loops over every `query_type` / `msg_type` the proxy actually emits.
- `TestCollectionScopedMetricsAreComplete` parses the metric declarations with `go/parser` and fails when a `*Vec` labeled `db_name`+`collection_name` (proxy) or `collection_id` (query node) is not referenced by the corresponding cleanup function.

Mutation-checked in both directions. Dropping `ProxyReceiveBytes` from the list:

```
ProxyReceiveBytes is labeled with [databaseLabelName collectionName] but is never cleaned up in proxyCollectionScopedMetrics
```

Dropping `QueryNodeSearchFTSNumTokens.DeletePartialMatch(labels)`:

```
QueryNodeSearchFTSNumTokens is labeled with [collectionIDLabelName] but is never cleaned up in CleanupQueryNodeCollectionMetrics
```

Before the production change, with the label values `internal/proxy/impl.go` emits:

```
LEAKED after cleanup: [milvus_proxy_collection_mutation_latency
                       milvus_proxy_collection_sq_latency
                       milvus_proxy_receive_bytes_count
                       milvus_proxy_scanned_remote_mb
                       milvus_proxy_scanned_total_mb]
```

After:

```
$ go test ./metrics/ -count=1 -timeout 300s
ok  	github.com/milvus-io/milvus/pkg/v3/metrics	1.236s
$ golangci-lint run ./metrics/...
0 issues.
```

`internal/util/function/embedding` executor tests pass, exercising the new 6-label `ProxyFunctionlatency` call. The two `internal/proxy/task_search.go` call sites type-check locally but I could not run that package's tests on macOS (no local C++ core build), so they rely on CI.
