### PR TITLE
fix: clang-format HybridScalarIndex.cpp to unblock Code-Check

### DIFF
--- a/internal/core/src/index/HybridScalarIndex.cpp
+++ b/internal/core/src/index/HybridScalarIndex.cpp
@@ -69,7 +69,8 @@ ParsePhysicalTypeFromPackedFileName(const std::string& filename) {
     const std::string suffix = "_index.v3";
     if (filename.size() < prefix.size() + suffix.size() ||
         filename.compare(0, prefix.size(), prefix) != 0 ||
-        filename.compare(filename.size() - suffix.size(), suffix.size(), suffix) != 0) {
+        filename.compare(
+            filename.size() - suffix.size(), suffix.size(), suffix) != 0) {
         return std::nullopt;
     }
     auto type_str = filename.substr(


### PR DESCRIPTION
issue: #52693

`ci-v2/build-ut-cov` is red on every open PR, including PRs that touch no C++:

```
check_result:  M internal/core/src/index/HybridScalarIndex.cpp
The cpp files are not formatted, please use internal/core/run_clang_format.sh
make: *** [Makefile:167: cppcheck] Error 1
```

`ParsePhysicalTypeFromPackedFileName` kept one `filename.compare(...)` call over the column limit; it came in with #52642 (`d513b678c0`). Confirmed the same failure on #52684, #52685, #52687, #52688 and #52691, so nothing can reach `ci-passed` until this lands.

## Test

Output of the repo's own formatter, no manual edits:

```
$ CLANG_FORMAT=clang-format-15 internal/core/run_clang_format.sh internal/core
start formating
license adder: 402 file(s) skiped
$ git status --porcelain
 M internal/core/src/index/HybridScalarIndex.cpp
```

Re-running the script after the commit reports no further changes. Formatting only — no behavior change.

Note: the same check also reports a second failing stage, `UT-CPP-Cov`, with `ERROR: exact PR base commit is unavailable: missing`. That looks like a coverage-diff infrastructure issue rather than a code one and is not addressed here.
