### PR TITLE
enhance: tile the FM-index locate walk and bucket docOf

### DIFF
--- a/internal/core/thirdparty/fmindex/index/fmindex/FMIndex.h
+++ b/internal/core/thirdparty/fmindex/index/fmindex/FMIndex.h
@@ -1,6 +1,7 @@
 // Licensed to the LF AI & Data foundation under Apache-2.0.
 // Portions translated from Lance (lance_index::scalar::fmindex), Apache-2.0.
 #pragma once
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -191,6 +192,14 @@ class FMIndex {
     // LIKE '%a%' over repetitive text) makes MatchingDocs allocate GBs while
     // this stays at the caller's single bitmap. An empty pattern visits nothing
     // (as MatchingDocs).
+    //
+    // The interval is walked in TILES rather than one row at a time. Each
+    // occurrence's LF-walk is an independent chain of dependent cache misses,
+    // so walking them one by one leaves the core stalled on a single
+    // outstanding miss; advancing a tile in lock-step keeps many misses in
+    // flight at once (memory-level parallelism), the same trick CountBatch
+    // uses across patterns. The tile is fixed-size, so peak memory stays O(1)
+    // and the streaming contract above is preserved.
     template <typename Visitor>
     void
     VisitMatchingDocs(const uint8_t* pat, size_t plen, Visitor&& visit) const {
@@ -198,10 +207,74 @@ class FMIndex {
             return;
         }
         auto r = BackwardSearch(pat, plen);
-        for (size_t i = r.first; i < r.second; ++i) {
-            uint64_t pos = locateRow(i);
-            if (pos < text_len_) {  // skip the sentinel suffix
-                visit(docOf(pos));
+        if (r.first >= r.second) {
+            return;
+        }
+
+        // 128 measured best on a 96 MB corpus: 64 leaves memory-level
+        // parallelism on the table, 256 buys ~nothing more and doubles the
+        // stack frame.
+        constexpr size_t kTile = 128;
+        // Below a tile's worth of hits there are too few chains to overlap, and
+        // the per-tile bookkeeping (and its stack frame) costs more than it
+        // saves - measured as a ~40% regression on single-hit patterns, which
+        // are exactly the selective ones a filter sees most. Walk those one at
+        // a time.
+        constexpr size_t kSerialBelow = 8;
+        if (r.second - r.first <= kSerialBelow) {
+            for (size_t i = r.first; i < r.second; ++i) {
+                const uint64_t p = locateRow(i);
+                if (p < text_len_) {
+                    visit(docOf(p));
+                }
+            }
+            return;
+        }
+
+        size_t rows[kTile];
+        uint64_t steps[kTile];
+        uint64_t pos[kTile];
+        size_t pend[kTile];
+
+        for (size_t t0 = r.first; t0 < r.second; t0 += kTile) {
+            const size_t tn = std::min(kTile, r.second - t0);
+            for (size_t s = 0; s < tn; ++s) {
+                rows[s] = t0 + s;
+                steps[s] = 0;
+                pos[s] = kUnresolved;
+            }
+            // Lock-step LF-walk: every round retires the rows that landed on a
+            // sampled position and advances the rest together.
+            for (;;) {
+                size_t np = 0;
+                for (size_t s = 0; s < tn; ++s) {
+                    if (pos[s] != kUnresolved) {
+                        continue;
+                    }
+                    if (sampled_bv_.get(rows[s])) {
+                        pos[s] =
+                            sample_val(sampled_bv_.rank1(rows[s])) + steps[s];
+                        continue;
+                    }
+                    pend[np++] = s;
+                }
+                if (np == 0) {
+                    break;
+                }
+                for (size_t j = 0; j < np; ++j) {
+                    wm_.prefetch_access(rows[pend[j]]);
+                }
+                for (size_t j = 0; j < np; ++j) {
+                    const size_t s = pend[j];
+                    rows[s] = LF(rows[s]);
+                    ++steps[s];
+                    sampled_bv_.prefetch(rows[s]);
+                }
+            }
+            for (size_t s = 0; s < tn; ++s) {
+                if (pos[s] < text_len_) {  // skip the sentinel suffix
+                    visit(docOf(pos[s]));
+                }
             }
         }
     }
@@ -285,6 +358,7 @@ class FMIndex {
                sample_vals_narrow_owned_.capacity() * sizeof(uint32_t) +
                sample_vals_wide_owned_.capacity() * sizeof(uint64_t) +
                doc_bounds_owned_.capacity() * sizeof(uint64_t) +
+               doc_ckpt_.capacity() * sizeof(uint32_t) +
                id_to_byte_.capacity() * sizeof(uint8_t) +
                isa_sample_.capacity() * sizeof(uint64_t) +
                owned_blob_.capacity() * sizeof(uint8_t);
@@ -348,6 +422,12 @@ class FMIndex {
     std::vector<uint64_t>
     locateInternal(const uint8_t* pattern, size_t plen) const;
     // Document id whose internal range contains internal position p.
+    // CONTRACT: internal_pos < text_len_. Callers must reject the sentinel
+    // suffix first (`pos < text_len_`) — a position at or past text_len_ is not
+    // inside any document, and the two implementations below disagree on what
+    // to return for it (the checkpoint path clamps to the last document, the
+    // binary-search fallback runs off the end of doc_start_). Every call site
+    // already guards; this note is here so a new one does too.
     uint64_t
     docOf(uint64_t internal_pos) const;
     // Half-open SA interval of "pattern<separator>" — the occurrences of the
@@ -358,8 +438,10 @@ class FMIndex {
     std::pair<size_t, size_t>
     suffixDocInterval(const uint8_t* pattern, size_t plen) const;
     // Rebuild the (small) in-RAM-only structures derived from the serialized
-    // fields: id_to_byte_ (from byte_to_id_). Called after Build and after a
-    // load. isa_sample_ is NOT built here — see ensureIsaSample().
+    // fields: id_to_byte_ (from byte_to_id_) and doc_ckpt_ (from doc_start_).
+    // Called after Build and after a load; requires doc_start_/n_doc_bounds_/
+    // text_len_ to be set already. isa_sample_ is NOT built here — see
+    // ensureIsaSample().
     void
     buildDerived();
     // Build isa_sample_ on first use (Extract is its only consumer). Thread-safe
@@ -425,6 +507,20 @@ class FMIndex {
     std::vector<uint64_t> doc_bounds_owned_;  // Build-mode storage only
     const uint64_t* doc_start_ = nullptr;
     size_t n_doc_bounds_ = 0;
+
+    // Bucket index over doc_start_, rebuilt by buildDerived() and never
+    // serialized: doc_ckpt_[b] is the document covering internal byte
+    // b << ckpt_shift_, so docOf() starts from a lower bound instead of
+    // binary-searching. Sized by document count (~n_docs/8 entries), not by
+    // text length. Empty means "fall back to the binary search" (no documents,
+    // or more documents than a uint32_t can name).
+    std::vector<uint32_t> doc_ckpt_;
+    uint32_t ckpt_shift_ = 0;
+
+    // Sentinel for a tile slot whose LF-walk has not reached a sampled row yet.
+    // Not a representable text position (text_len_ < 2^63), so the resolved
+    // check `pos < text_len_` also rejects it.
+    static constexpr uint64_t kUnresolved = ~uint64_t{0};
 
     int32_t sep_id_ =
         1;  // dense id of the separator symbol (constant; not a byte)

--- a/internal/core/thirdparty/fmindex/index/fmindex/FMIndexInl.h
+++ b/internal/core/thirdparty/fmindex/index/fmindex/FMIndexInl.h
@@ -273,6 +273,42 @@ FMIndex::buildDerived() {
     // The separator is a fixed synthetic symbol (dense id 1), not a byte. No
     // byte_to_id_ entry equals 1, so a query byte can never step onto it.
     sep_id_ = 1;
+
+    // Bucket index for docOf. Without it docOf binary-searches doc_start_,
+    // whose every step is a cache miss once the array outgrows L2 (one million
+    // documents = 8 MB), costing ~log2(n_docs) misses per located occurrence —
+    // several times the LF-walk it follows. Here one array read lands within a
+    // bucket and the residual scan walks CONSECUTIVE doc_start_ entries, which
+    // share cache lines.
+    //
+    // The bucket width targets ~kDocsPerBucket documents, so the table holds
+    // about n_docs/kDocsPerBucket entries: its size tracks the DOCUMENT COUNT,
+    // not the text length, and stays a rounding error next to the wavelet.
+    doc_ckpt_.clear();
+    ckpt_shift_ = 0;
+    const size_t n_docs = n_doc_bounds_ ? n_doc_bounds_ - 1 : 0;
+    if (n_docs > 0 && text_len_ > 0 &&
+        n_docs <= std::numeric_limits<uint32_t>::max()) {
+        constexpr uint64_t kDocsPerBucket = 8;
+        const uint64_t target = (text_len_ / n_docs) * kDocsPerBucket + 1;
+        uint32_t sh = 6;
+        while (sh < 40 && (uint64_t{1} << sh) < target) {
+            ++sh;
+        }
+        ckpt_shift_ = sh;
+        const size_t nb = static_cast<size_t>(text_len_ >> sh) + 2;
+        doc_ckpt_.assign(nb, 0);
+        // d is monotone across buckets, so the whole table is one linear pass
+        // over doc_start_ regardless of bucket count.
+        size_t d = 0;
+        for (size_t b = 0; b < nb; ++b) {
+            const uint64_t p = static_cast<uint64_t>(b) << sh;
+            while (d + 1 < n_docs && doc_start_[d + 1] <= p) {
+                ++d;
+            }
+            doc_ckpt_[b] = static_cast<uint32_t>(d);
+        }
+    }
 }
 
 inline void
@@ -615,6 +651,21 @@ FMIndex::CountBatch(
 
 inline uint64_t
 FMIndex::docOf(uint64_t internal_pos) const {
+    const size_t n_docs = n_doc_bounds_ ? n_doc_bounds_ - 1 : 0;
+    if (!doc_ckpt_.empty() && n_docs > 0) {
+        // doc_ckpt_[b] is the document covering byte b<<ckpt_shift_, which is
+        // at or before internal_pos, so it is a lower bound for the answer;
+        // walk forward over the (few, contiguous) remaining boundaries.
+        size_t b = static_cast<size_t>(internal_pos >> ckpt_shift_);
+        if (b >= doc_ckpt_.size()) {
+            b = doc_ckpt_.size() - 1;
+        }
+        uint64_t d = doc_ckpt_[b];
+        while (d + 1 < n_docs && doc_start_[d + 1] <= internal_pos) {
+            ++d;
+        }
+        return d;
+    }
     const uint64_t* end = doc_start_ + n_doc_bounds_;
     auto it = std::upper_bound(doc_start_, end, internal_pos);
     return static_cast<uint64_t>(it - doc_start_) - 1;
@@ -1242,7 +1293,11 @@ FMIndex::parseView(const uint8_t* base, size_t size) {
                 return false;
             }
         }
-        buildDerived();  // id_to_byte_ only; isa_sample_ is lazy (Extract)
+        // id_to_byte_ + doc_ckpt_; isa_sample_ stays lazy (Extract only). Safe
+        // here: the bounds checks above already proved doc_start_ is strictly
+        // increasing and ends at text_len_, which doc_ckpt_'s single forward
+        // pass relies on.
+        buildDerived();
         return true;
     } catch (const std::bad_alloc&) {
         throw;


### PR DESCRIPTION
Fixes the two hot spots identified in #52699. Both are local to the vendored
`thirdparty/fmindex` library; no public API and no on-disk format change.

## What changed

**1. `VisitMatchingDocs`: serial walk → 128-row lock-step tiles.**

Each occurrence's LF-walk is a chain of *dependent* cache misses, so walking
them one at a time keeps exactly one miss in flight. The occurrences are
independent, and `LocateDocsBatch` already tiles LF-walks in lock-step at
*per-occurrence* granularity — the filter path just never routed through it.
The tile is fixed-size, so peak memory stays O(1) and the streaming contract
(the reason this function exists instead of `MatchingDocs`) is preserved.

Below 8 hits the tile bookkeeping costs more than it saves, so those stay
serial — without that fast path single-hit patterns regressed ~40%, and those
are exactly the selective queries a filter sees most.

**2. `docOf`: binary search → bucket index.**

`doc_start_` is 8 B/document, so past ~L2 every probe of the binary search is a
miss, once per located occurrence. `buildDerived()` now also builds a bucket
table: one array read lands in a bucket, then a short scan over *consecutive*
`doc_start_` entries. Bucket width targets ~8 documents, so the table is sized
by **document count** (~`n_docs`/8 entries), not text length — 2M documents is
about 1 MB. It is never serialized; an empty table falls back to the binary
search.

## Results

Apple Silicon, `sa_sample_rate=8`, synthetic document-scoped corpora:

| 200k docs x 500 B | baseline | this PR | |
|---|---|---|---|
| rare (occ 429) | 271 us | 169 us | **1.61x** |
| mid (occ 1967) | 1276 us | 817 us | **1.56x** |
| hot (occ 263k) | 163 ms | 100 ms | **1.63x** |

| 2M docs x 50 B | baseline | this PR | |
|---|---|---|---|
| rare (occ 354) | 477 us | 203 us | **2.35x** |
| mid (occ 1621) | 2185 us | 869 us | **2.51x** |
| hot (occ 217k) | 274 ms | 103 ms | **2.66x** |

Attributing the two independently (same measurement round):

| | 200k docs | 2M docs |
|---|---|---|
| tiling only | 1.75–1.92x | 1.74–1.88x |
| docOf bucket only | 1.07–1.16x | 1.2–1.4x |
| both | 2.04–2.16x | 2.45–2.69x |

Tiling carries most of it and is insensitive to corpus shape. The bucket's
value tracks document count: at 200k documents `doc_start_` is 1.6 MB and fits
in L2, so it buys little; at 2M documents (16 MB) it buys 1.2–1.4x. Real
segments sit at the larger end.

Constants were measured, not guessed:
- tile size: swept 16/32/64/128/256; 128 best (256 adds nothing and doubles the
  stack frame).
- serial threshold: swept occ 1..256; the tiled path is at parity through occ 8
  and already 1.20x by occ 10, so 8 is the right cut.

## Verification

- **A/B result fingerprints identical** — 2 corpus shapes x 5 query sets,
  fingerprinting occurrence counts, visit order, `(doc, offset)` pairs and the
  prefix/suffix doc APIs, cross-checking `VisitMatchingDocs` / `MatchingDocs` /
  `LocateDocs` against each other.
- **Tile-boundary sweep** — 256 configurations: occ ∈ {0,1,2,3,7,**8,9**,15,16,
  63,**64,65**,**127,128,129**,130,255,256,257,383,384,512} x docs ∈ {1,4,97} x
  `sa_sample_rate` ∈ {1,4,8,32}. Identical to baseline, and independently
  asserted (`Count` equals the constructed occurrence count; every returned
  offset lands on the needle inside its attributed document).
- **Cross-version round-trip** — old binary writes / new binary reads and the
  reverse: identical fingerprints, and the serialized bytes are identical,
  confirming the format is untouched.
- **Skewed document lengths** — one 4 MB document among 200k tiny ones, a
  bimodal mix, and an all-tiny corpus (the adaptive bucket width's worst cases):
  identical results, no regression.
- **ASan + UBSan** clean on all of the above.
- **Existing suite**: 66 tests / 424,082 checks pass, including
  `LoadViewZeroCopyMatchesInRam` and `MmapFileRoundTrip` (the mmap path is the
  third `buildDerived()` call site), `ConcurrentQueriesMatchSingleThreaded`,
  `EmptyCorpus`, `LocateDocsSingleDoc`, `EmptyDocumentAmongNonEmpty`,
  `LocateMatchesBruteForceAcrossSampleRates`, `DocMappingLocatesPkAndOffset`.

## Not yet verified

- The full `internal/core` unit-test build (`FMIndexTest.cpp`,
  `ScalarIndexCreatorTest.cpp`) has not finished on my machine yet; everything
  above was run against the library through a standalone harness. Will report
  before this merges — flagging it rather than implying it passed.
- The `n_docs > UINT32_MAX` fallback branch is unreachable in any test (it needs
  4 billion documents); it simply leaves the table empty and takes the binary
  search.
- Tile size was tuned on ~100 MB corpora; the optimum may differ at 10 GB. The
  constant is commented with that caveat.

issue: #52699
