### PR TITLE
fix: enforce schema version fence on backfill

### DIFF
--- a/internal/datacoord/backfill_result.go
+++ b/internal/datacoord/backfill_result.go
@@ -32,9 +32,15 @@ import (
 //
 // Reference: spark-milvus/docs/backfill-result-json-format.md
 type BackfillResult struct {
-	Success       bool                       `json:"success"`
-	CollectionID  int64                      `json:"collectionId"`
-	PartitionID   int64                      `json:"partitionId"`
+	Success      bool  `json:"success"`
+	CollectionID int64 `json:"collectionId"`
+	PartitionID  int64 `json:"partitionId"`
+	// SchemaVersion is the collection schema version the backfill job read
+	// when it snapshotted the data. Spark-milvus stamps it from the snapshot
+	// metadata; the fence in CommitBackfillResult rejects a result whose
+	// version no longer matches the collection's current version (schema
+	// changed while the job was in flight).
+	SchemaVersion int32                      `json:"schemaVersion"`
 	NewFieldNames []string                   `json:"newFieldNames"`
 	Segments      map[string]BackfillSegment `json:"segments"` // key = segmentID as decimal string
 }

--- a/internal/datacoord/services_commit_backfill.go
+++ b/internal/datacoord/services_commit_backfill.go
@@ -74,10 +74,14 @@ func (s *Server) CommitBackfillResult(ctx context.Context, req *datapb.CommitBac
 		return &datapb.CommitBackfillResultResponse{Status: merr.Status(err)}, nil
 	}
 
-	// Schema-version fence: a result computed against a schema that is no
-	// longer live (e.g. the function was dropped/changed while the Spark job
-	// was in flight) must not be committed against the current segments.
-	if err := checkBackfillSchemaVersion(result, coll); err != nil {
+	// Schema-version fence (fast-fail pre-check): a result computed against a
+	// schema that is no longer live (e.g. the function was dropped/changed
+	// while the Spark job was in flight) must not be committed against the
+	// current segments. This read happens outside the broadcast's serialization
+	// boundary, so broadcastBackfillBatch re-validates the version again while
+	// holding the resource keys — a drop/alter-function committing in the
+	// window between this check and the key acquisition is still caught.
+	if err := checkBackfillSchemaVersion(result.CollectionID, result.SchemaVersion, coll); err != nil {
 		log.Warn(ctx, "CommitBackfillResult rejected by schema version fence",
 			mlog.Err(err),
 			mlog.Int32("resultSchemaVersion", result.SchemaVersion),
@@ -105,7 +109,7 @@ func (s *Server) CommitBackfillResult(ctx context.Context, req *datapb.CommitBac
 			end = len(items)
 		}
 		batch := items[start:end]
-		if err := broadcastBackfillBatch(ctx, coll, result.CollectionID, channels, batch); err != nil {
+		if err := s.broadcastBackfillBatch(ctx, coll, result.CollectionID, result.SchemaVersion, channels, batch); err != nil {
 			log.Error(ctx, "CommitBackfillResult broadcast batch failed",
 				mlog.Err(err), mlog.Int("batchStart", start), mlog.Int("batchEnd", end))
 			lastErr = err
@@ -147,10 +151,11 @@ const maxItemsPerBroadcast = 512
 // collection's shared resource keys and issues exactly one broadcast for the
 // given items. broadcasterWithRK nils out its lock guards on the first
 // Broadcast call, so each batch needs its own broadcaster.
-func broadcastBackfillBatch(
+func (s *Server) broadcastBackfillBatch(
 	ctx context.Context,
 	coll *milvuspb.DescribeCollectionResponse,
 	collectionID int64,
+	expectedSchemaVersion int32,
 	channels []string,
 	items []*messagespb.BatchUpdateManifestItem,
 ) error {
@@ -162,6 +167,23 @@ func broadcastBackfillBatch(
 		return err
 	}
 	defer broadcaster.Close()
+
+	// Schema-version fence, enforced INSIDE the broadcast's serialization
+	// boundary: while we hold the shared collection-name resource key, no
+	// drop/alter-function (which takes the exclusive collection-name key) can
+	// commit, so the version read here cannot change before this broadcast's
+	// ack callback applies the update. The pre-broadcast check in
+	// CommitBackfillResult runs outside this boundary; re-reading here closes
+	// the window where a schema change could slip in between the two.
+	if expectedSchemaVersion != 0 {
+		freshColl, err := s.broker.DescribeCollectionInternal(ctx, collectionID)
+		if err != nil {
+			return err
+		}
+		if err := checkBackfillSchemaVersion(collectionID, expectedSchemaVersion, freshColl); err != nil {
+			return err
+		}
+	}
 
 	_, err = broadcaster.Broadcast(ctx, message.NewBatchUpdateManifestMessageBuilderV2().
 		WithHeader(&message.BatchUpdateManifestMessageHeader{
@@ -386,18 +408,18 @@ func inferKind(entry *BackfillSegment) string {
 // committed against the current segments. Results that carry no version (0 —
 // produced before Spark stamped the schema version it read) are exempt from
 // the fence for backward compatibility.
-func checkBackfillSchemaVersion(result *BackfillResult, coll *milvuspb.DescribeCollectionResponse) error {
-	if result.SchemaVersion == 0 {
+func checkBackfillSchemaVersion(collectionID int64, expectedSchemaVersion int32, coll *milvuspb.DescribeCollectionResponse) error {
+	if expectedSchemaVersion == 0 {
 		return nil
 	}
 	currentVersion := int32(0)
 	if coll.GetSchema() != nil {
 		currentVersion = coll.GetSchema().GetVersion()
 	}
-	if result.SchemaVersion != currentVersion {
+	if expectedSchemaVersion != currentVersion {
 		return merr.WrapErrCollectionSchemaMisMatch(
-			result.CollectionID,
-			"backfill result schema version "+strconv.FormatInt(int64(result.SchemaVersion), 10)+
+			collectionID,
+			"backfill result schema version "+strconv.FormatInt(int64(expectedSchemaVersion), 10)+
 				" does not match collection's current schema version "+strconv.FormatInt(int64(currentVersion), 10)+
 				"; re-run the backfill against the current schema")
 	}

--- a/internal/datacoord/services_commit_backfill.go
+++ b/internal/datacoord/services_commit_backfill.go
@@ -74,6 +74,22 @@ func (s *Server) CommitBackfillResult(ctx context.Context, req *datapb.CommitBac
 		return &datapb.CommitBackfillResultResponse{Status: merr.Status(err)}, nil
 	}
 
+	// Schema-version fence: a result computed against a schema that is no
+	// longer live (e.g. the function was dropped/changed while the Spark job
+	// was in flight) must not be committed against the current segments.
+	if err := checkBackfillSchemaVersion(result, coll); err != nil {
+		log.Warn(ctx, "CommitBackfillResult rejected by schema version fence",
+			mlog.Err(err),
+			mlog.Int32("resultSchemaVersion", result.SchemaVersion),
+			mlog.Int32("collectionSchemaVersion", coll.GetSchema().GetVersion()))
+		return &datapb.CommitBackfillResultResponse{
+			Status:          merr.Status(err),
+			TotalSegments:   total,
+			FailedSegments:  int32(len(result.Segments)),
+			SegmentStatuses: allSegmentsFailed(result, err.Error()),
+		}, nil
+	}
+
 	// Split items across multiple broadcast messages so a single
 	// BatchUpdateManifestMessageBody never exceeds the broker's message size
 	// limit (Pulsar defaults to 5MiB). Each batch acquires its own broadcaster
@@ -362,6 +378,48 @@ func inferKind(entry *BackfillSegment) string {
 		return "v2"
 	}
 	return "v3"
+}
+
+// checkBackfillSchemaVersion enforces the schema-version fence on a backfill
+// result. A result computed against a schema that is no longer live (e.g. the
+// function was dropped/changed while the Spark job was in flight) must not be
+// committed against the current segments. Results that carry no version (0 —
+// produced before Spark stamped the schema version it read) are exempt from
+// the fence for backward compatibility.
+func checkBackfillSchemaVersion(result *BackfillResult, coll *milvuspb.DescribeCollectionResponse) error {
+	if result.SchemaVersion == 0 {
+		return nil
+	}
+	currentVersion := int32(0)
+	if coll.GetSchema() != nil {
+		currentVersion = coll.GetSchema().GetVersion()
+	}
+	if result.SchemaVersion != currentVersion {
+		return merr.WrapErrCollectionSchemaMisMatch(
+			result.CollectionID,
+			"backfill result schema version "+strconv.FormatInt(int64(result.SchemaVersion), 10)+
+				" does not match collection's current schema version "+strconv.FormatInt(int64(currentVersion), 10)+
+				"; re-run the backfill against the current schema")
+	}
+	return nil
+}
+
+// allSegmentsFailed builds a per-segment failure status for every segment in
+// the result. Used when a collection-level rejection (e.g. the schema-version
+// fence) fails the whole result before any broadcast, so callers still see
+// which segments were rejected and why.
+func allSegmentsFailed(result *BackfillResult, reason string) []*datapb.CommitBackfillResultSegmentStatus {
+	statuses := make([]*datapb.CommitBackfillResultSegmentStatus, 0, len(result.Segments))
+	for segIDStr, entry := range result.Segments {
+		segID, perr := strconv.ParseInt(segIDStr, 10, 64)
+		if perr != nil {
+			segID = 0
+		}
+		statuses = append(statuses, &datapb.CommitBackfillResultSegmentStatus{
+			SegmentId: segID, Ok: false, Kind: inferKind(&entry), Reason: reason,
+		})
+	}
+	return sortStatuses(statuses)
 }
 
 func countStatuses(statuses []*datapb.CommitBackfillResultSegmentStatus) (committed, failed int32) {

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -4337,6 +4337,72 @@ func TestServer_CommitBackfillResult(t *testing.T) {
 		assert.Equal(t, int32(0), resp.GetFailedSegments())
 	})
 
+	// Schema-version fence: the pre-broadcast check passes, but the version
+	// read again under the broadcast's resource keys no longer matches (a
+	// drop/alter-function committed in the window between the two reads). The
+	// broadcast must be aborted and every segment reported failed.
+	t.Run("schema_version_changed_before_broadcast_rejected", func(t *testing.T) {
+		ctx := context.Background()
+		m, err := newMemoryMeta(t)
+		require.NoError(t, err)
+		m.AddSegment(ctx, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+			ID: 504, CollectionID: 100, State: commonpb.SegmentState_Flushed,
+			StorageVersion: storage.StorageV3,
+			ManifestPath:   packed.MarshalManifestPath("/seg/504", 1),
+		}})
+		jsonStr := `{
+          "success": true,
+          "collectionId": 100,
+          "schemaVersion": 5,
+          "segments": {
+            "504": {"version": 10, "rowCount": 1, "outputPath": "x", "manifestPaths": []}
+          }
+        }`
+		// First read (pre-broadcast) sees version 5; the second read (inside
+		// the broadcast boundary) sees version 6, as if an alter/drop-function
+		// committed between the two.
+		mockBroker := broker.NewMockBroker(t)
+		mockBroker.EXPECT().DescribeCollectionInternal(mock.Anything, mock.Anything).
+			Return(&milvuspb.DescribeCollectionResponse{
+				Status:         merr.Success(),
+				DbName:         "default",
+				CollectionName: "c",
+				Schema:         &schemapb.CollectionSchema{Version: 5},
+			}, nil).Once()
+		mockBroker.EXPECT().DescribeCollectionInternal(mock.Anything, mock.Anything).
+			Return(&milvuspb.DescribeCollectionResponse{
+				Status:         merr.Success(),
+				DbName:         "default",
+				CollectionName: "c",
+				Schema:         &schemapb.CollectionSchema{Version: 6},
+			}, nil).Once()
+		server := newServerForCommit(t, m, mockBroker, []byte(jsonStr))
+
+		wal := mock_streaming.NewMockWALAccesser(t)
+		wal.EXPECT().ControlChannel().Return("by-dev-rootcoord-dml_0").Maybe()
+		streaming.SetWALForTest(wal)
+
+		bapi := mock_broadcaster.NewMockBroadcastAPI(t)
+		bapi.EXPECT().Close().Return()
+		patch := mockey.Mock(broadcast.StartBroadcastWithResourceKeys).To(
+			func(ctx context.Context, keys ...message.ResourceKey) (broadcaster.BroadcastAPI, error) {
+				return bapi, nil
+			}).Build()
+		defer patch.UnPatch()
+
+		resp, err := server.CommitBackfillResult(ctx, &datapb.CommitBackfillResultRequest{
+			ResultPath: "s3a://bkt/result.json",
+		})
+		assert.NoError(t, err)
+		assert.Error(t, merr.Error(resp.GetStatus()))
+		assert.Equal(t, int32(1), resp.GetTotalSegments())
+		assert.Equal(t, int32(0), resp.GetCommittedSegments())
+		assert.Equal(t, int32(1), resp.GetFailedSegments())
+		require.Len(t, resp.GetSegmentStatuses(), 1)
+		assert.False(t, resp.GetSegmentStatuses()[0].GetOk())
+		assert.Contains(t, resp.GetSegmentStatuses()[0].GetReason(), "schema version")
+	})
+
 	// Schema-version fence: a result that carries no schema version (0 — legacy
 	// producer that does not stamp it) is exempt from the fence.
 	t.Run("schema_version_zero_exempt", func(t *testing.T) {

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -4230,6 +4230,174 @@ func TestServer_CommitBackfillResult(t *testing.T) {
 		assert.Error(t, merr.Error(resp.GetStatus()))
 	})
 
+	// Schema-version fence: a result computed against a schema version that no
+	// longer matches the collection's current schema version must be rejected
+	// as a whole (no broadcast), with every segment reported failed.
+	t.Run("schema_version_mismatch_rejected", func(t *testing.T) {
+		ctx := context.Background()
+		m, err := newMemoryMeta(t)
+		require.NoError(t, err)
+		m.AddSegment(ctx, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+			ID: 501, CollectionID: 100, State: commonpb.SegmentState_Flushed,
+			StorageVersion: storage.StorageV3,
+			ManifestPath:   packed.MarshalManifestPath("/seg/501", 1),
+		}})
+		// Result computed against schema version 2, collection is now at version 5.
+		jsonStr := `{
+          "success": true,
+          "collectionId": 100,
+          "schemaVersion": 2,
+          "segments": {
+            "501": {"version": 10, "rowCount": 1, "outputPath": "x", "manifestPaths": []}
+          }
+        }`
+		mockBroker := broker.NewMockBroker(t)
+		mockBroker.EXPECT().DescribeCollectionInternal(mock.Anything, mock.Anything).
+			Return(&milvuspb.DescribeCollectionResponse{
+				Status:         merr.Success(),
+				DbName:         "default",
+				CollectionName: "c",
+				Schema:         &schemapb.CollectionSchema{Version: 5},
+			}, nil).Maybe()
+		server := newServerForCommit(t, m, mockBroker, []byte(jsonStr))
+
+		wal := mock_streaming.NewMockWALAccesser(t)
+		wal.EXPECT().ControlChannel().Return("by-dev-rootcoord-dml_0").Maybe()
+		streaming.SetWALForTest(wal)
+
+		resp, err := server.CommitBackfillResult(ctx, &datapb.CommitBackfillResultRequest{
+			ResultPath: "s3a://bkt/result.json",
+		})
+		assert.NoError(t, err)
+		assert.Error(t, merr.Error(resp.GetStatus()))
+		assert.Equal(t, int32(1), resp.GetTotalSegments())
+		assert.Equal(t, int32(0), resp.GetCommittedSegments())
+		assert.Equal(t, int32(1), resp.GetFailedSegments())
+		require.Len(t, resp.GetSegmentStatuses(), 1)
+		assert.False(t, resp.GetSegmentStatuses()[0].GetOk())
+		assert.Contains(t, resp.GetSegmentStatuses()[0].GetReason(), "schema version")
+	})
+
+	// Schema-version fence: a matching version passes and reaches broadcast.
+	t.Run("schema_version_match_accepted", func(t *testing.T) {
+		ctx := context.Background()
+		m, err := newMemoryMeta(t)
+		require.NoError(t, err)
+		m.AddSegment(ctx, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+			ID: 502, CollectionID: 100, State: commonpb.SegmentState_Flushed,
+			StorageVersion: storage.StorageV3,
+			ManifestPath:   packed.MarshalManifestPath("/seg/502", 1),
+		}})
+		jsonStr := `{
+          "success": true,
+          "collectionId": 100,
+          "schemaVersion": 5,
+          "segments": {
+            "502": {"version": 10, "rowCount": 1, "outputPath": "x", "manifestPaths": []}
+          }
+        }`
+		mockBroker := broker.NewMockBroker(t)
+		mockBroker.EXPECT().DescribeCollectionInternal(mock.Anything, mock.Anything).
+			Return(&milvuspb.DescribeCollectionResponse{
+				Status:         merr.Success(),
+				DbName:         "default",
+				CollectionName: "c",
+				Schema:         &schemapb.CollectionSchema{Version: 5},
+			}, nil).Maybe()
+		server := newServerForCommit(t, m, mockBroker, []byte(jsonStr))
+
+		wal := mock_streaming.NewMockWALAccesser(t)
+		wal.EXPECT().ControlChannel().Return("by-dev-rootcoord-dml_0").Maybe()
+		streaming.SetWALForTest(wal)
+
+		bapi := mock_broadcaster.NewMockBroadcastAPI(t)
+		bapi.EXPECT().Broadcast(mock.Anything, mock.Anything).Return(&types2.BroadcastAppendResult{
+			BroadcastID: 1,
+			AppendResults: map[string]*types2.AppendResult{
+				"by-dev-rootcoord-dml_0": {
+					MessageID:              rmq.NewRmqID(1),
+					TimeTick:               tsoutil.ComposeTSByTime(time.Now()),
+					LastConfirmedMessageID: rmq.NewRmqID(1),
+				},
+			},
+		}, nil)
+		bapi.EXPECT().Close().Return()
+		patch := mockey.Mock(broadcast.StartBroadcastWithResourceKeys).To(
+			func(ctx context.Context, keys ...message.ResourceKey) (broadcaster.BroadcastAPI, error) {
+				return bapi, nil
+			}).Build()
+		defer patch.UnPatch()
+
+		resp, err := server.CommitBackfillResult(ctx, &datapb.CommitBackfillResultRequest{
+			ResultPath: "s3a://bkt/result.json",
+		})
+		assert.NoError(t, err)
+		assert.True(t, merr.Ok(resp.GetStatus()))
+		assert.Equal(t, int32(1), resp.GetCommittedSegments())
+		assert.Equal(t, int32(0), resp.GetFailedSegments())
+	})
+
+	// Schema-version fence: a result that carries no schema version (0 — legacy
+	// producer that does not stamp it) is exempt from the fence.
+	t.Run("schema_version_zero_exempt", func(t *testing.T) {
+		ctx := context.Background()
+		m, err := newMemoryMeta(t)
+		require.NoError(t, err)
+		m.AddSegment(ctx, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+			ID: 503, CollectionID: 100, State: commonpb.SegmentState_Flushed,
+			StorageVersion: storage.StorageV3,
+			ManifestPath:   packed.MarshalManifestPath("/seg/503", 1),
+		}})
+		// No schemaVersion field in JSON -> 0, which must pass even though the
+		// collection is now at version 9.
+		jsonStr := `{
+          "success": true,
+          "collectionId": 100,
+          "segments": {
+            "503": {"version": 10, "rowCount": 1, "outputPath": "x", "manifestPaths": []}
+          }
+        }`
+		mockBroker := broker.NewMockBroker(t)
+		mockBroker.EXPECT().DescribeCollectionInternal(mock.Anything, mock.Anything).
+			Return(&milvuspb.DescribeCollectionResponse{
+				Status:         merr.Success(),
+				DbName:         "default",
+				CollectionName: "c",
+				Schema:         &schemapb.CollectionSchema{Version: 9},
+			}, nil).Maybe()
+		server := newServerForCommit(t, m, mockBroker, []byte(jsonStr))
+
+		wal := mock_streaming.NewMockWALAccesser(t)
+		wal.EXPECT().ControlChannel().Return("by-dev-rootcoord-dml_0").Maybe()
+		streaming.SetWALForTest(wal)
+
+		bapi := mock_broadcaster.NewMockBroadcastAPI(t)
+		bapi.EXPECT().Broadcast(mock.Anything, mock.Anything).Return(&types2.BroadcastAppendResult{
+			BroadcastID: 1,
+			AppendResults: map[string]*types2.AppendResult{
+				"by-dev-rootcoord-dml_0": {
+					MessageID:              rmq.NewRmqID(1),
+					TimeTick:               tsoutil.ComposeTSByTime(time.Now()),
+					LastConfirmedMessageID: rmq.NewRmqID(1),
+				},
+			},
+		}, nil)
+		bapi.EXPECT().Close().Return()
+		patch := mockey.Mock(broadcast.StartBroadcastWithResourceKeys).To(
+			func(ctx context.Context, keys ...message.ResourceKey) (broadcaster.BroadcastAPI, error) {
+				return bapi, nil
+			}).Build()
+		defer patch.UnPatch()
+
+		resp, err := server.CommitBackfillResult(ctx, &datapb.CommitBackfillResultRequest{
+			ResultPath: "s3a://bkt/result.json",
+		})
+		assert.NoError(t, err)
+		assert.True(t, merr.Ok(resp.GetStatus()))
+		assert.Equal(t, int32(1), resp.GetCommittedSegments())
+		assert.Equal(t, int32(0), resp.GetFailedSegments())
+	})
+
 	t.Run("success_false_rejected", func(t *testing.T) {
 		ctx := context.Background()
 		m, err := newMemoryMeta(t)


### PR DESCRIPTION
Spark-milvus now stamps the collection schema version it read into the backfill result JSON (schemaVersion). Activate the milvus-side fence in CommitBackfillResult: parse the stamped version and reject the commit when it no longer matches the collection's current schema version, e.g. the function was dropped or changed while the Spark job was in flight.

Without this, a result computed against an older schema is still committed against the current segments, silently advancing V3 manifests / rewriting V2 column groups with stale embeddings.

Results that carry no version (0) stay exempt so older producers keep working.

issue: #51318