### PR TITLE
fix: update libavrocpp recipe revision

### DIFF
--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -39,7 +39,7 @@ class MilvusConan(ConanFile):
         "unordered_dense/4.4.0#6a855c992618cc4c63019109a2e47298",
         "geos/3.12.0#a923af6dc4c18f87a7dfa960118f3166",
         "icu/74.2#cd1937b9561b8950a2ae6311284c5813",
-        "libavrocpp/1.12.1.1@milvus/dev#cde7bb587a29f6f233bae7e18b71815d",
+        "libavrocpp/1.12.1.1@milvus/dev#b4854183542196740ec9a004fdfff7ec",
     )
 
     default_options = {


### PR DESCRIPTION
## What changed

- Update `libavrocpp/1.12.1.1@milvus/dev` to recipe revision `b4854183542196740ec9a004fdfff7ec`.

## Why

The previous recipe downloads Avro 1.12.1 from `dlcdn.apache.org`, where the pinned source has been removed. This breaks builds with a fresh Conan cache. milvus-io/conanfiles#183 switches the recipe to the permanent Apache archive URL while retaining the verified source checksum.

The new recipe revision has been built, tested, and uploaded to the production `default-conan-local2` remote by the conanfiles publish workflow.

Related: milvus-io/conanfiles#183

## Validation

- `git diff --check`
- Parsed `internal/core/conanfile.py` with Python AST
- conanfiles recipe verification and production publish succeeded: https://github.com/milvus-io/conanfiles/actions/runs/32267737247