### PR TITLE
fix: do not wait indexes outside import job schema snapshot (#52154)

### DIFF
--- a/internal/datacoord/import_checker.go
+++ b/internal/datacoord/import_checker.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/broker"
+	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster"
 	"github.com/milvus-io/milvus/internal/util/importutilv2"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
@@ -36,6 +37,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 type ImportChecker interface {
@@ -60,14 +62,23 @@ type importCheckerHooks struct {
 	isReplicatingCluster func(ctx context.Context) (bool, error)
 }
 
+// scopedIndexCreator lets the import checker drive index creation for a segment
+// with an era attestation (fields whose data the import itself materialized),
+// routed onto the inspector's single creation goroutine. Implemented by
+// indexInspector — the sole owner of the creation mechanics.
+type scopedIndexCreator interface {
+	enqueueScopedCreation(segmentID int64, attestedFields typeutil.Set[int64])
+}
+
 type importChecker struct {
-	ctx        context.Context
-	meta       *meta
-	broker     broker.Broker
-	alloc      allocator.Allocator
-	importMeta ImportMeta
-	ci         CompactionInspector
-	handler    Handler
+	ctx          context.Context
+	meta         *meta
+	broker       broker.Broker
+	alloc        allocator.Allocator
+	importMeta   ImportMeta
+	ci           CompactionInspector
+	handler      Handler
+	indexCreator scopedIndexCreator
 
 	hooks importCheckerHooks
 
@@ -82,18 +93,20 @@ func NewImportChecker(ctx context.Context,
 	importMeta ImportMeta,
 	ci CompactionInspector,
 	handler Handler,
+	indexCreator scopedIndexCreator,
 	hooks importCheckerHooks,
 ) ImportChecker {
 	return &importChecker{
-		ctx:        ctx,
-		meta:       meta,
-		broker:     broker,
-		alloc:      alloc,
-		importMeta: importMeta,
-		ci:         ci,
-		handler:    handler,
-		hooks:      hooks,
-		closeChan:  make(chan struct{}),
+		ctx:          ctx,
+		meta:         meta,
+		broker:       broker,
+		alloc:        alloc,
+		importMeta:   importMeta,
+		ci:           ci,
+		handler:      handler,
+		indexCreator: indexCreator,
+		hooks:        hooks,
+		closeChan:    make(chan struct{}),
 	}
 }
 
@@ -464,17 +477,21 @@ func (c *importChecker) checkIndexBuildingJob(job ImportJob) {
 		targetSegmentIDs = originSegmentIDs
 	}
 
-	healthySegments := c.meta.GetSegments(targetSegmentIDs, isSegmentHealthy)
-	unindexed := c.meta.indexMeta.GetUnindexedSegments(job.GetCollectionID(), healthySegments)
-	if Params.DataCoordCfg.WaitForIndex.GetAsBool() && len(unindexed) > 0 && !importutilv2.IsL0Import(job.GetOptions()) {
-		for _, segmentID := range unindexed {
-			select {
-			case getBuildIndexChSingleton() <- segmentID: // accelerate index building:
-			default:
-			}
+	if Params.DataCoordCfg.WaitForIndex.GetAsBool() && !importutilv2.IsL0Import(job.GetOptions()) {
+		snapshotFields := importJobSnapshotFields(job)
+		healthySegments := c.meta.GetSegments(targetSegmentIDs, isSegmentHealthy)
+		unindexed := c.meta.indexMeta.GetUnindexedSegments(job.GetCollectionID(), healthySegments)
+		kept, needsCreation, excluded := filterUnindexedBySnapshotSchema(snapshotFields, job.GetCollectionID(), c.meta.indexMeta, unindexed)
+		if len(kept) > 0 {
+			c.ensureImportSegmentIndexes(job, snapshotFields, needsCreation)
+			log.Debug(c.ctx, "waiting for import segments building index...", mlog.Int64s("unindexed", kept))
+			return
 		}
-		log.Debug(c.ctx, "waiting for import segments building index...", mlog.Int64s("unindexed", unindexed))
-		return
+		if len(excluded) > 0 {
+			log.Info(c.ctx, "import job proceeds without waiting for indexes on fields outside its schema snapshot; they build after commit via schema-bump backfill",
+				mlog.Int64s("excludedIndexIDs", lo.Map(excluded, func(index *model.Index, _ int) int64 { return index.IndexID })),
+				mlog.Int64s("excludedFieldIDs", lo.Map(excluded, func(index *model.Index, _ int) int64 { return index.FieldID })))
+		}
 	}
 	buildIndexDuration := job.GetTR().RecordSpan()
 	metrics.ImportJobLatency.WithLabelValues(metrics.ImportStageBuildIndex).Observe(float64(buildIndexDuration.Milliseconds()))
@@ -492,6 +509,52 @@ func (c *importChecker) checkIndexBuildingJob(job ImportJob) {
 	LogResultSegmentsInfo(job.GetJobID(), c.meta, targetSegmentIDs)
 	log.Info(c.ctx, "import job indexes built, transitioned to Uncommitted",
 		mlog.Bool("autoCommit", job.GetAutoCommit()))
+}
+
+// ensureImportSegmentIndexes drives index creation for segments whose snapshot-scoped
+// index has no SegmentIndex row yet (needsCreation), routing by whether the inspector's
+// own periodic scan can handle it:
+//   - common path — the inspector will build the index on its next scan; just send the
+//     cheap acceleration nudge (bare segment ID), no clones, no attestation.
+//   - wedge path — the segment's schema version lags the collection's while the
+//     collection has functions, so the inspector whole-segment-defers it and the lag
+//     cannot heal before commit (sort is one-shot, schema-bump skips is_importing
+//     segments). Route an attested request onto the inspector's single creation
+//     goroutine, marking the job's snapshot fields as materialized.
+//
+// The wedge test needs the CURRENT collection schema version (not the job snapshot's).
+// It is read once per call from the local meta cache (non-blocking): an unresolved
+// collection only skips the wedge optimization for this tick (the segment falls to the
+// nudge and retries next tick once the cache warms), so it must not block the shared
+// state-machine loop with a rootcoord lazy-load.
+func (c *importChecker) ensureImportSegmentIndexes(job ImportJob, snapshotFields typeutil.Set[int64], needsCreation []int64) {
+	if len(needsCreation) == 0 {
+		return
+	}
+	hasFunctions, collectionVersion := false, int32(0)
+	if collection := c.meta.GetCollection(job.GetCollectionID()); collection != nil && collection.Schema != nil {
+		hasFunctions = len(collection.Schema.GetFunctions()) > 0
+		collectionVersion = collection.Schema.GetVersion()
+	} else {
+		mlog.Warn(c.ctx, "cannot resolve collection schema from cache, skip wedge index routing this tick",
+			mlog.FieldJobID(job.GetJobID()), mlog.FieldCollectionID(job.GetCollectionID()),
+			mlog.Int64s("segments", needsCreation))
+	}
+	for _, segmentID := range needsCreation {
+		if c.indexCreator != nil && hasFunctions {
+			// GetSegment is a light read (no index clones); reached only for
+			// function-bearing collections, and only these segments enqueue.
+			if segment := c.meta.GetSegment(c.ctx, segmentID); segment != nil &&
+				segment.GetSchemaVersion() < collectionVersion {
+				c.indexCreator.enqueueScopedCreation(segmentID, snapshotFields)
+				continue
+			}
+		}
+		select {
+		case getBuildIndexChSingleton() <- segmentID: // accelerate index building
+		default:
+		}
+	}
 }
 
 // checkUncommittedJob handles jobs in the Uncommitted state.

--- a/internal/datacoord/import_checker_test.go
+++ b/internal/datacoord/import_checker_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	broker2 "github.com/milvus-io/milvus/internal/datacoord/broker"
 	"github.com/milvus-io/milvus/internal/metastore/mocks"
+	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
@@ -42,7 +43,20 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/timerecord"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
+
+// fakeScopedIndexCreator records the checker's scoped-creation enqueues.
+type fakeScopedIndexCreator struct {
+	scopedCalls map[int64]typeutil.Set[int64] // segmentID -> attested fields of last enqueue
+}
+
+func (f *fakeScopedIndexCreator) enqueueScopedCreation(segmentID int64, attestedFields typeutil.Set[int64]) {
+	if f.scopedCalls == nil {
+		f.scopedCalls = make(map[int64]typeutil.Set[int64])
+	}
+	f.scopedCalls[segmentID] = attestedFields
+}
 
 type ImportCheckerSuite struct {
 	suite.Suite
@@ -51,6 +65,7 @@ type ImportCheckerSuite struct {
 	importMeta ImportMeta
 	checker    *importChecker
 	alloc      *allocator.MockAllocator
+	creator    *fakeScopedIndexCreator
 }
 
 func (s *ImportCheckerSuite) SetupTest() {
@@ -91,7 +106,9 @@ func (s *ImportCheckerSuite) SetupTest() {
 		}, nil
 	}).Maybe()
 
-	checker := NewImportChecker(context.TODO(), meta, broker, s.alloc, importMeta, ci, handler, importCheckerHooks{}).(*importChecker)
+	s.creator = &fakeScopedIndexCreator{}
+	checker := NewImportChecker(context.TODO(), meta, broker, s.alloc, importMeta, ci, handler,
+		s.creator, importCheckerHooks{}).(*importChecker)
 	s.checker = checker
 
 	job := &importJob{
@@ -288,6 +305,112 @@ func (s *ImportCheckerSuite) TestCheckJob() {
 		}
 	}
 	s.Equal(internalpb.ImportJobState_Uncommitted, s.importMeta.GetJob(context.TODO(), job.GetJobID()).GetState())
+}
+
+// TestCheckIndexBuildingJobSnapshotScope: an index bound to a field absent from the
+// job's schema snapshot (e.g. created by a concurrent add_function_field) must not
+// block the IndexBuilding -> Uncommitted transition; it cannot build before commit (#52154).
+func (s *ImportCheckerSuite) TestCheckIndexBuildingJobSnapshotScope() {
+	const (
+		segmentID     = int64(700)
+		sortedSegID   = int64(701)
+		snapshotIndex = int64(10)
+		boundIndex    = int64(11)
+	)
+	catalog := s.importMeta.(*importMeta).catalog.(*mocks.DataCoordCatalog)
+	catalog.EXPECT().SaveImportTask(mock.Anything, mock.Anything).Return(nil)
+	catalog.EXPECT().AddSegment(mock.Anything, mock.Anything).Return(nil)
+
+	// The collection (in the local meta cache) has a function and its schema version
+	// (2) is ahead of the import segment's (1): the inspector would whole-segment-defer,
+	// so the checker must route an attested scoped-creation request.
+	s.checker.meta.AddCollection(&collectionInfo{
+		ID: 1,
+		Schema: &schemapb.CollectionSchema{
+			Version: 2,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector},
+			},
+			Functions: []*schemapb.FunctionSchema{{Name: "bm25", OutputFieldIds: []int64{101}}},
+		},
+	})
+
+	taskProto := &datapb.ImportTaskV2{
+		JobID:            s.jobID,
+		TaskID:           7,
+		State:            datapb.ImportTaskStateV2_Completed,
+		SegmentIDs:       []int64{segmentID},
+		SortedSegmentIDs: []int64{sortedSegID},
+	}
+	task := &importTask{tr: timerecord.NewTimeRecorder("import task")}
+	task.task.Store(taskProto)
+	s.NoError(s.importMeta.AddTask(context.TODO(), task))
+
+	s.NoError(s.checker.meta.AddSegment(context.Background(), &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            sortedSegID,
+			CollectionID:  1,
+			State:         commonpb.SegmentState_Flushed,
+			IsImporting:   true,
+			InsertChannel: "ch0",
+			IsSorted:      true,
+			SchemaVersion: 1,
+		},
+	}))
+
+	// The snapshot field (100) index has NO segment-index row yet (the inspector
+	// version-gate defers it); the bound index on post-snapshot field (101) is
+	// out of the snapshot entirely.
+	indexMeta := s.checker.meta.indexMeta
+	indexMeta.indexes[1] = map[UniqueID]*model.Index{
+		snapshotIndex: {CollectionID: 1, IndexID: snapshotIndex, FieldID: 100},
+		boundIndex:    {CollectionID: 1, IndexID: boundIndex, FieldID: 101},
+	}
+
+	s.manuallyUpdateJob(s.jobID, UpdateJobState(internalpb.ImportJobState_IndexBuilding))
+
+	// Snapshot-scoped index has no row -> needsCreation -> keep waiting, and the checker
+	// must route an attested scoped-creation request for exactly the snapshot fields.
+	s.checker.checkIndexBuildingJob(s.importMeta.GetJob(context.TODO(), s.jobID))
+	s.Equal(internalpb.ImportJobState_IndexBuilding, s.importMeta.GetJob(context.TODO(), s.jobID).GetState())
+	attested, ok := s.creator.scopedCalls[sortedSegID]
+	s.True(ok, "checker must hand the era attestation to the index creator")
+	s.True(attested.Contain(int64(100)))
+	s.False(attested.Contain(int64(101)))
+
+	// Snapshot-scoped index finished -> the missing bound index alone must not block commit.
+	segmentIndexes := typeutil.NewConcurrentMap[UniqueID, *model.SegmentIndex]()
+	segmentIndexes.Insert(snapshotIndex, &model.SegmentIndex{SegmentID: sortedSegID, IndexID: snapshotIndex, IndexState: commonpb.IndexState_Finished})
+	indexMeta.segmentIndexes.Insert(sortedSegID, segmentIndexes)
+	s.checker.checkIndexBuildingJob(s.importMeta.GetJob(context.TODO(), s.jobID))
+	s.Equal(internalpb.ImportJobState_Uncommitted, s.importMeta.GetJob(context.TODO(), s.jobID).GetState())
+}
+
+// TestEnsureImportSegmentIndexesCommonPath: a resolved, function-less collection is
+// not a wedge, so the checker must not drive scoped creation — the inspector's own scan
+// builds the index; the cheap nudge is used instead.
+func (s *ImportCheckerSuite) TestEnsureImportSegmentIndexesCommonPath() {
+	s.checker.meta.AddCollection(&collectionInfo{
+		ID: 1,
+		Schema: &schemapb.CollectionSchema{
+			Version: 2,
+			Fields:  []*schemapb.FieldSchema{{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true}},
+		},
+	})
+	job := s.importMeta.GetJob(context.TODO(), s.jobID)
+	s.checker.ensureImportSegmentIndexes(job, importJobSnapshotFields(job), []int64{12345})
+	s.Empty(s.creator.scopedCalls, "function-less collection -> no scoped enqueue")
+}
+
+// TestEnsureImportSegmentIndexesUnresolvedSchema: when the collection cannot be resolved
+// from the local meta cache, the wedge routing is skipped for this tick (segments fall to
+// the nudge and retry next tick) rather than blocking; no scoped creation is driven.
+func (s *ImportCheckerSuite) TestEnsureImportSegmentIndexesUnresolvedSchema() {
+	// meta has no collection for this job -> meta.GetCollection returns nil.
+	job := s.importMeta.GetJob(context.TODO(), s.jobID)
+	s.checker.ensureImportSegmentIndexes(job, importJobSnapshotFields(job), []int64{12345})
+	s.Empty(s.creator.scopedCalls, "unresolved schema -> no scoped enqueue, falls to nudge")
 }
 
 func (s *ImportCheckerSuite) manuallyUpdateJob(jobID int64, actions ...UpdateJobAction) {
@@ -878,7 +1001,7 @@ func TestImportCheckerCompaction(t *testing.T) {
 	cim := NewMockCompactionInspector(t)
 	handler := NewNMockHandler(t)
 
-	checker := NewImportChecker(context.TODO(), meta, broker, alloc, importMeta, cim, handler, importCheckerHooks{}).(*importChecker)
+	checker := NewImportChecker(context.TODO(), meta, broker, alloc, importMeta, cim, handler, nil, importCheckerHooks{}).(*importChecker)
 
 	job := &importJob{
 		ImportJob: &datapb.ImportJob{

--- a/internal/datacoord/import_util.go
+++ b/internal/datacoord/import_util.go
@@ -30,8 +30,10 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
+	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/importutilv2"
 	"github.com/milvus-io/milvus/pkg/v3/common"
@@ -545,6 +547,69 @@ func getStatsProgress(ctx context.Context, jobID int64, importMeta ImportMeta, m
 	return float32(doneCnt) / float32(len(targetSegmentIDs))
 }
 
+// importJobSnapshotFields returns the field IDs of the job's schema snapshot
+// (struct sub-fields included), or nil when the job carries no snapshot.
+func importJobSnapshotFields(job ImportJob) typeutil.Set[int64] {
+	schema := job.GetSchema()
+	if schema == nil {
+		return nil
+	}
+	return typeutil.NewSet(lo.Map(typeutil.GetAllFieldSchemas(schema), func(field *schemapb.FieldSchema, _ int) int64 {
+		return field.GetFieldID()
+	})...)
+}
+
+// filterUnindexedBySnapshotSchema narrows the import's index wait to the job's own
+// schema snapshot. An index on a field absent from the snapshot is one the job never
+// wrote (e.g. added by a concurrent DDL); it can only build after commit + schema-bump
+// backfill (StorageV3 segments), so waiting on it deadlocks the job (#52154). Returns:
+//   - kept: segments still to wait on — a snapshot-scoped index is not yet Finished;
+//   - needsCreation: segments whose snapshot-scoped index has no SegmentIndex row yet,
+//     i.e. creation must be driven (a segment whose row exists but is still building is
+//     kept-but-not-needsCreation, so the checker does not re-drive an in-flight build);
+//   - excluded: the out-of-snapshot indexes dropped from the wait, for the caller to log.
+//
+// snapshotFields is passed in (computed once by the caller) to avoid recomputing it.
+func filterUnindexedBySnapshotSchema(snapshotFields typeutil.Set[int64], collectionID int64, indexMeta *indexMeta, unindexed []int64) ([]int64, []int64, []*model.Index) {
+	if len(unindexed) == 0 {
+		return unindexed, nil, nil
+	}
+	if snapshotFields == nil {
+		// No snapshot to scope by: preserve the drive-all-unindexed behavior.
+		return unindexed, unindexed, nil
+	}
+	snapshotIndexes, excluded := lo.FilterReject(indexMeta.GetIndexesForCollection(collectionID, ""), func(index *model.Index, _ int) bool {
+		return snapshotFields.Contain(index.FieldID)
+	})
+	if len(snapshotIndexes) == 0 {
+		return nil, nil, excluded
+	}
+	// Single batch read of state-only objects; avoids per-segment locking and
+	// SegmentIndex deep clones (IndexFileKeys) on the checker hot path.
+	states := indexMeta.getSegmentsIndexStates(collectionID, unindexed)
+	kept := make([]int64, 0, len(unindexed))
+	needsCreation := make([]int64, 0, len(unindexed))
+	for _, segmentID := range unindexed {
+		segmentStates := states[segmentID]
+		keep, create := false, false
+		for _, index := range snapshotIndexes {
+			state, ok := segmentStates[index.IndexID]
+			if !ok {
+				create, keep = true, true // no row yet -> drive creation, and wait
+			} else if state.GetState() != commonpb.IndexState_Finished {
+				keep = true // row exists but building -> wait, do not re-drive
+			}
+		}
+		if keep {
+			kept = append(kept, segmentID)
+		}
+		if create {
+			needsCreation = append(needsCreation, segmentID)
+		}
+	}
+	return kept, needsCreation, excluded
+}
+
 func getIndexBuildingProgress(ctx context.Context, jobID int64, importMeta ImportMeta, meta *meta) float32 {
 	job := importMeta.GetJob(ctx, jobID)
 	if !Params.DataCoordCfg.WaitForIndex.GetAsBool() {
@@ -564,7 +629,8 @@ func getIndexBuildingProgress(ctx context.Context, jobID int64, importMeta Impor
 		targetSegmentIDs = originSegmentIDs
 	}
 	unindexed := meta.indexMeta.GetUnindexedSegments(job.GetCollectionID(), targetSegmentIDs)
-	return float32(len(targetSegmentIDs)-len(unindexed)) / float32(len(targetSegmentIDs))
+	kept, _, _ := filterUnindexedBySnapshotSchema(importJobSnapshotFields(job), job.GetCollectionID(), meta.indexMeta, unindexed)
+	return float32(len(targetSegmentIDs)-len(kept)) / float32(len(targetSegmentIDs))
 }
 
 // GetJobProgress calculates the importing job progress.

--- a/internal/datacoord/import_util_test.go
+++ b/internal/datacoord/import_util_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/milvus-io/milvus/internal/datacoord/session"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/internal/metastore/mocks"
+	"github.com/milvus-io/milvus/internal/metastore/model"
 	mocks2 "github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/importutilv2"
@@ -48,6 +49,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/timerecord"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 func TestImportUtil_NewPreImportTasks(t *testing.T) {
@@ -1360,4 +1362,68 @@ func TestImportUtil_ValidateMaxImportJobExceed(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "The number of jobs has reached the limit")
 	})
+}
+
+func TestFilterUnindexedBySnapshotSchema(t *testing.T) {
+	const (
+		collectionID  = int64(1)
+		snapshotField = int64(100)
+		addedField    = int64(101)
+		snapshotIndex = int64(10)
+		boundIndex    = int64(11)
+	)
+	newJob := func(schema *schemapb.CollectionSchema) ImportJob {
+		return &importJob{ImportJob: &datapb.ImportJob{
+			JobID:        1,
+			CollectionID: collectionID,
+			Schema:       schema,
+		}}
+	}
+	snapshot := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: snapshotField, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+		},
+	}
+	im := &indexMeta{
+		indexes: map[UniqueID]map[UniqueID]*model.Index{
+			collectionID: {
+				snapshotIndex: {CollectionID: collectionID, IndexID: snapshotIndex, FieldID: snapshotField},
+				boundIndex:    {CollectionID: collectionID, IndexID: boundIndex, FieldID: addedField},
+			},
+		},
+		segmentIndexes: typeutil.NewConcurrentMap[UniqueID, *typeutil.ConcurrentMap[UniqueID, *model.SegmentIndex]](),
+	}
+	insertSegmentIndex := func(segmentID, indexID int64, state commonpb.IndexState) {
+		segmentIndexes, _ := im.segmentIndexes.GetOrInsert(segmentID, typeutil.NewConcurrentMap[UniqueID, *model.SegmentIndex]())
+		segmentIndexes.Insert(indexID, &model.SegmentIndex{SegmentID: segmentID, IndexID: indexID, IndexState: state})
+	}
+	// segment 1: snapshot-scoped index finished, bound index absent -> released.
+	insertSegmentIndex(1, snapshotIndex, commonpb.IndexState_Finished)
+	// segment 2: snapshot-scoped index still building (row exists) -> kept, but NOT
+	// needsCreation (the build is already in flight; do not re-drive it).
+	insertSegmentIndex(2, snapshotIndex, commonpb.IndexState_InProgress)
+	// segment 3: no segment index row at all -> kept AND needsCreation.
+
+	snapshotFields := importJobSnapshotFields(newJob(snapshot))
+	unindexed := []int64{1, 2, 3}
+	kept, needsCreation, excluded := filterUnindexedBySnapshotSchema(snapshotFields, collectionID, im, unindexed)
+	assert.ElementsMatch(t, []int64{2, 3}, kept)
+	assert.ElementsMatch(t, []int64{3}, needsCreation, "only the row-missing segment needs creation")
+	assert.Len(t, excluded, 1)
+	assert.Equal(t, boundIndex, excluded[0].IndexID)
+
+	// nil snapshot preserves the drive-all behavior: kept == needsCreation == unindexed.
+	kept, needsCreation, excluded = filterUnindexedBySnapshotSchema(nil, collectionID, im, unindexed)
+	assert.ElementsMatch(t, unindexed, kept)
+	assert.ElementsMatch(t, unindexed, needsCreation)
+	assert.Nil(t, excluded)
+
+	// every index out of snapshot scope -> nothing to wait for, nothing to create.
+	foreignSnapshot := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{{FieldID: 102, Name: "other", DataType: schemapb.DataType_Int64}},
+	}
+	kept, needsCreation, excluded = filterUnindexedBySnapshotSchema(importJobSnapshotFields(newJob(foreignSnapshot)), collectionID, im, unindexed)
+	assert.Empty(t, kept)
+	assert.Empty(t, needsCreation)
+	assert.Len(t, excluded, 2)
 }

--- a/internal/datacoord/index_inspector.go
+++ b/internal/datacoord/index_inspector.go
@@ -33,12 +33,23 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
+// scopedCreateRequest carries an era-attested index-creation request from the
+// import checker to the inspector's single creation goroutine (see
+// enqueueScopedCreation).
+type scopedCreateRequest struct {
+	segmentID      int64
+	attestedFields typeutil.Set[int64]
+}
+
 type indexInspector struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 
 	notifyIndexChan chan int64
+	// scopedCreateCh funnels the import checker's attested creation requests onto
+	// the same goroutine as the periodic scan, so all creation stays single-owner.
+	scopedCreateCh chan scopedCreateRequest
 
 	meta                      *meta
 	scheduler                 task.GlobalScheduler
@@ -64,11 +75,23 @@ func newIndexInspector(
 		cancel:                    cancel,
 		meta:                      meta,
 		notifyIndexChan:           notifyIndexChan,
+		scopedCreateCh:            make(chan scopedCreateRequest, 256),
 		scheduler:                 scheduler,
 		allocator:                 allocator,
 		handler:                   handler,
 		storageCli:                storageCli,
 		indexEngineVersionManager: indexEngineVersionManager,
+	}
+}
+
+// enqueueScopedCreation asks the inspector to create the segment's still-missing
+// indexes, attesting attestedFields as materialized so the schema-version deferral
+// does not apply to them. Non-blocking: a full buffer drops the request and the
+// import checker re-enqueues on its next tick.
+func (i *indexInspector) enqueueScopedCreation(segmentID int64, attestedFields typeutil.Set[int64]) {
+	select {
+	case i.scopedCreateCh <- scopedCreateRequest{segmentID: segmentID, attestedFields: attestedFields}:
+	default:
 	}
 }
 
@@ -126,6 +149,16 @@ func (i *indexInspector) createIndexForSegmentLoop(ctx context.Context) {
 				mlog.Warn(ctx, "create index for segment fail, wait for retry", mlog.FieldSegmentID(segment.ID))
 				continue
 			}
+		case req := <-i.scopedCreateCh:
+			segment := i.meta.GetSegment(ctx, req.segmentID)
+			if segment == nil {
+				mlog.Warn(ctx, "segment is not exist, no need to build index", mlog.FieldSegmentID(req.segmentID))
+				continue
+			}
+			if err := i.createIndexesForSegmentWithScope(ctx, segment, req.attestedFields); err != nil {
+				mlog.Warn(ctx, "create scoped index for segment fail, wait for retry", mlog.FieldSegmentID(segment.ID))
+				continue
+			}
 		}
 	}
 }
@@ -143,6 +176,15 @@ func (i *indexInspector) getUnIndexTaskSegments(ctx context.Context) []*SegmentI
 }
 
 func (i *indexInspector) createIndexesForSegment(ctx context.Context, segment *SegmentInfo) error {
+	return i.createIndexesForSegmentWithScope(ctx, segment, nil)
+}
+
+// createIndexesForSegmentWithScope is createIndexesForSegment with an era
+// attestation: attestedFields are fields whose data the caller guarantees is
+// already materialized in this segment (e.g. an import job's schema snapshot —
+// the import wrote those fields itself), so the schema-version deferral does not
+// apply to their indexes. nil means no attestation.
+func (i *indexInspector) createIndexesForSegmentWithScope(ctx context.Context, segment *SegmentInfo, attestedFields typeutil.Set[int64]) error {
 	if enableSortCompaction() && !segment.GetIsSorted() && !segment.GetIsSortedByNamespace() && !i.isExternalCollection(segment.CollectionID) {
 		mlog.Debug(ctx, "segment is not sorted by pk, skip create indexes", mlog.FieldSegmentID(segment.GetID()))
 		return nil
@@ -159,7 +201,7 @@ func (i *indexInspector) createIndexesForSegment(ctx context.Context, segment *S
 		if _, ok := indexIDToSegIndexes[index.IndexID]; ok {
 			continue
 		}
-		if !i.canCreateIndexForSegment(ctx, segment, index) {
+		if !i.canCreateIndexForSegment(ctx, segment, index, attestedFields) {
 			continue
 		}
 		if err := i.createIndexForSegment(ctx, segment, index.IndexID); err != nil {
@@ -175,7 +217,7 @@ func (i *indexInspector) createIndexesForSegment(ctx context.Context, segment *S
 // index. The schema is resolved through the handler (lazy-loading on cache miss,
 // e.g. right after a datacoord restart); the check fails closed, deferring to
 // the next inspection round on an unresolvable or inconsistent view.
-func (i *indexInspector) canCreateIndexForSegment(ctx context.Context, segment *SegmentInfo, index *model.Index) bool {
+func (i *indexInspector) canCreateIndexForSegment(ctx context.Context, segment *SegmentInfo, index *model.Index, attestedFields typeutil.Set[int64]) bool {
 	collection, err := i.handler.GetCollection(ctx, segment.CollectionID)
 	if err != nil || collection == nil || collection.Schema == nil {
 		mlog.Warn(ctx, "cannot resolve collection schema, defer index build",
@@ -184,9 +226,11 @@ func (i *indexInspector) canCreateIndexForSegment(ctx context.Context, segment *
 	}
 	// Function outputs are materialized by schema-bump reconciliation, which
 	// advances the segment schema version. A segment behind the collection schema
-	// version may lack them, so defer the whole segment until it catches up.
+	// version may lack them, so defer the whole segment until it catches up —
+	// unless the caller attests the indexed field's data is already materialized.
 	if len(collection.Schema.GetFunctions()) > 0 &&
-		segment.GetSchemaVersion() < collection.Schema.GetVersion() {
+		segment.GetSchemaVersion() < collection.Schema.GetVersion() &&
+		!attestedFields.Contain(index.FieldID) {
 		mlog.Debug(ctx, "segment schema behind collection, function outputs may be unmaterialized, defer index build",
 			mlog.FieldSegmentID(segment.ID), mlog.FieldFieldID(index.FieldID), mlog.FieldIndexID(index.IndexID),
 			mlog.Int32("segmentSchemaVersion", segment.GetSchemaVersion()), mlog.Int32("collectionSchemaVersion", collection.Schema.GetVersion()))

--- a/internal/datacoord/index_inspector_test.go
+++ b/internal/datacoord/index_inspector_test.go
@@ -736,3 +736,47 @@ func TestIndexInspector_FunctionOutputSchemaVersionGate(t *testing.T) {
 		assert.Contains(t, m.indexMeta.GetSegmentIndexes(collID, segment.GetID()), UniqueID(14))
 	})
 }
+
+func TestCanCreateIndexForSegmentAttestedFields(t *testing.T) {
+	handler := NewNMockHandler(t)
+	handler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(&collectionInfo{
+		ID: 1,
+		Schema: &schemapb.CollectionSchema{
+			Version: 2,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector},
+			},
+			Functions: []*schemapb.FunctionSchema{{Name: "bm25", OutputFieldIds: []int64{101}}},
+		},
+	}, nil)
+	inspector := &indexInspector{handler: handler}
+	// segment schema version (1) lags the collection version (2) and the
+	// collection has functions -> version deferral engages.
+	segment := &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{ID: 10, CollectionID: 1, SchemaVersion: 1}}
+	indexOnPk := &model.Index{IndexID: 1, CollectionID: 1, FieldID: 100}
+	indexOnOutput := &model.Index{IndexID: 2, CollectionID: 1, FieldID: 101}
+
+	// no attestation: whole segment deferred.
+	assert.False(t, inspector.canCreateIndexForSegment(context.TODO(), segment, indexOnPk, nil))
+	// attested field bypasses the version deferral.
+	assert.True(t, inspector.canCreateIndexForSegment(context.TODO(), segment, indexOnPk, typeutil.NewSet[int64](100)))
+	// non-attested field stays deferred.
+	assert.False(t, inspector.canCreateIndexForSegment(context.TODO(), segment, indexOnOutput, typeutil.NewSet[int64](100)))
+	// caught-up segment needs no attestation.
+	caughtUp := &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{ID: 11, CollectionID: 1, SchemaVersion: 2}}
+	assert.True(t, inspector.canCreateIndexForSegment(context.TODO(), caughtUp, indexOnPk, nil))
+}
+
+func TestEnqueueScopedCreation(t *testing.T) {
+	i := &indexInspector{scopedCreateCh: make(chan scopedCreateRequest, 1)}
+
+	i.enqueueScopedCreation(1, typeutil.NewSet[int64](100))
+	// buffer full -> second enqueue is dropped, never blocks.
+	i.enqueueScopedCreation(2, typeutil.NewSet[int64](200))
+
+	assert.Len(t, i.scopedCreateCh, 1)
+	req := <-i.scopedCreateCh
+	assert.Equal(t, int64(1), req.segmentID)
+	assert.True(t, req.attestedFields.Contain(100))
+}

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -2411,7 +2411,7 @@ func (suite *MetaBasicSuite) TestCompleteBumpSchemaVersionCompactionMutation() {
 			CollectionID: updated.GetCollectionID(),
 			FieldID:      102,
 			IndexID:      1,
-		}), "materialized function-output field must be index-eligible")
+		}, nil), "materialized function-output field must be index-eligible")
 	})
 
 	suite.Run("in-place result with stale base manifest is rejected", func() {

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -344,7 +344,9 @@ func (s *Server) initDataCoord() error {
 
 	s.importInspector = NewImportInspector(s.ctx, s.meta, s.importMeta, s.globalScheduler)
 
-	s.importChecker = NewImportChecker(s.ctx, s.meta, s.broker, s.allocator, s.importMeta, s.compactionInspector, s.handler, importCheckerHooks{
+	// initIndexInspector (earlier in this boot sequence) has already set
+	// s.indexInspector, so inject it directly as the checker's scoped index creator.
+	s.importChecker = NewImportChecker(s.ctx, s.meta, s.broker, s.allocator, s.importMeta, s.compactionInspector, s.handler, s.indexInspector, importCheckerHooks{
 		commitImport:         s.broadcastCommitImportMessage,
 		rollbackImport:       s.broadcastRollbackImportMessage,
 		isReplicatingCluster: s.isReplicatingClusterNow,


### PR DESCRIPTION
issue: #52154

### What this fixes

An import job deadlocks when a schema-version-advancing DDL (typically `add_function_field`) lands during the import pipeline:

1. Import `IndexBuilding` waits for **all** collection indexes on the import segments (`GetUnindexedSegments`).
2. `add_function_field` materializes its bound index meta at DDL time, so the new index immediately joins the wait set.
3. That index cannot build before commit: the function-output field only materializes via schema-bump backfill, whose policy skips `is_importing` segments, and `is_importing` clears only at import commit — a deterministic three-party circular wait that wedges the job until timeout.

### How

Judge the wait against the job's own schema snapshot (`ImportJob.Schema`, captured at job creation, persisted, immutable): a new helper `filterUnindexedBySnapshotSchema` drops segments whose missing indexes are all on fields absent from the snapshot, applied at both wait sites — `checkIndexBuildingJob` (the wedge) and `getIndexBuildingProgress` (its progress view). `GetUnindexedSegments` itself is untouched.

After commit the segment becomes an ordinary stale segment: schema-bump backfill materializes the new field and advances the segment schema version, and the bound index then builds through the normal inspector path. No new convergence machinery.

### Scope notes

This breaks the cycle at its only semantically wrong edge — an import waiting on an index for a field its job never wrote. Residual hardening is tracked as follow-ups per the issue: per-field precision for the schema-version index-creation gate (#51768), and stamping import segments with the job snapshot schema version at alloc.