### PR TITLE
fix: [2.6] scale thread pool when queued work exceeds idle threads

### DIFF
--- a/internal/core/src/storage/ThreadPool.h
+++ b/internal/core/src/storage/ThreadPool.h
@@ -135,12 +135,21 @@ class ThreadPool {
 
         if (idle_threads_size_ > 0) {
             condition_lock_.notify_one();
-        } else if (current_threads_size_ < max_threads_size_.load()) {
+        }
+        if (work_queue_.size() > static_cast<size_t>(idle_threads_size_) &&
+            current_threads_size_ < max_threads_size_.load()) {
             // Dynamic increase thread number
-            std::thread t(&ThreadPool::Worker, this);
-            assert(threads_.find(t.get_id()) == threads_.end());
-            threads_[t.get_id()] = std::move(t);
-            current_threads_size_++;
+            try {
+                std::thread t(&ThreadPool::Worker, this);
+                assert(threads_.find(t.get_id()) == threads_.end());
+                threads_[t.get_id()] = std::move(t);
+                current_threads_size_++;
+            } catch (const std::exception& e) {
+                LOG_WARN(
+                    "Failed to expand thread pool {}: {}", name_, e.what());
+            } catch (...) {
+                LOG_WARN("Failed to expand thread pool {}", name_);
+            }
         }
 
         return task_ptr->get_future();


### PR DESCRIPTION
issue: #52715
pr: #50267

Handle idle-worker notification and pool expansion as independent decisions. Expand the pool only when queued demand exceeds currently idle capacity:
if (idle_threads_size_ > 0) {
    condition_lock_.notify_one();
}

if (work_queue_.size() > static_cast<size_t>(idle_threads_size_) &&
    current_threads_size_ < max_threads_size_.load()) {
    // Create a new worker.
}
This avoids unnecessary worker creation when idle workers are sufficient while allowing the pool to scale during task bursts.
