### PR TITLE
fix: prevent sonic JIT racing plugin loading

### DIFF
--- a/cmd/roles/roles.go
+++ b/cmd/roles/roles.go
@@ -41,6 +41,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	kvfactory "github.com/milvus-io/milvus/internal/util/dependency/kv"
 	"github.com/milvus-io/milvus/internal/util/fileresource"
+	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/internal/util/initcore"
 	internalmetrics "github.com/milvus-io/milvus/internal/util/metrics"
 	"github.com/milvus-io/milvus/internal/util/pathutil"
@@ -548,6 +549,13 @@ func (mr *MilvusRoles) Run() {
 		return
 	}
 	mlog.Info(context.TODO(), "All components are ready", mlog.Strings("roles", lo.Keys(componentMap)))
+
+	// All components have started. Every plugin load this process can perform is
+	// now done (the hook plugin is loaded eagerly by the proxy during creation;
+	// the cipher plugin is forced to completion here), so permanently disable the
+	// sonic JSON gate: plugin.Open can no longer run and sonic JIT registration
+	// cannot race with it, and the JSON hot path costs nothing from now on.
+	hookutil.FinishPluginLoading()
 
 	http.RegisterStopComponent(func(role string) error {
 		if len(role) == 0 || componentMap[role] == nil {

--- a/internal/json/gate.go
+++ b/internal/json/gate.go
@@ -1,0 +1,121 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package json
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// sonic JIT-compiles a dedicated decoder/encoder for every type on first use.
+// The compilation appends a synthetic runtime.moduledata whose pluginpath is
+// empty. If that append overlaps with plugin.Open's lastmoduleinit section, the
+// Go runtime may treat sonic's synthetic module as the newly loaded plugin and
+// terminate the process with "runtime: plugin has empty pluginpath".
+//
+// To prevent the race, every sonic entry point takes the reader side of this
+// gate, while plugin.Open is executed inside the exclusive (writer) side.
+//
+// The reader fast path is lock-free: a single atomic increment plus a recheck of
+// writeHeld. It only falls back to the mutex-protected slow path when a plugin
+// load is actually in progress (a one-shot startup event), so the JSON hot path
+// never touches a contended mutex.
+//
+// The reader side is implemented as a counter instead of sync.RWMutex so that a
+// reader can safely re-enter (e.g. a custom MarshalJSON that calls json.Marshal
+// again) without deadlocking against a pending writer.
+var (
+	// gateMu serializes the writer side and the slow (blocking) reader path.
+	gateMu sync.Mutex
+	// gateCond notifies waiters when the writer side is released or readers drain.
+	gateCond = sync.NewCond(&gateMu)
+	// writeHeld reports whether plugin loading (the exclusive side) is active.
+	writeHeld atomic.Bool
+	// reading counts in-flight sonic calls.
+	reading atomic.Int64
+	// gateDisabled is set once every plugin load in the process has finished.
+	// After that plugin.Open never runs again, so sonic JIT registration can no
+	// longer race with it and the reader fast path costs nothing.
+	gateDisabled atomic.Bool
+)
+
+func acquireRead() {
+	// Steady state: the gate is disabled after all plugin loading finished and
+	// costs nothing beyond a single atomic load.
+	if gateDisabled.Load() {
+		return
+	}
+	// Fast path: no plugin load active, a single atomic increment suffices.
+	if !writeHeld.Load() {
+		reading.Add(1)
+		if !writeHeld.Load() {
+			return
+		}
+		// A plugin load started right after our check; undo and take the slow path.
+		releaseRead()
+	}
+	// Slow path: wait until the exclusive side is released.
+	gateMu.Lock()
+	for writeHeld.Load() {
+		gateCond.Wait()
+	}
+	reading.Add(1)
+	gateMu.Unlock()
+}
+
+func releaseRead() {
+	if reading.Add(-1) == 0 && writeHeld.Load() {
+		// The writer may be waiting for the last in-flight reader to finish.
+		gateMu.Lock()
+		gateCond.Broadcast()
+		gateMu.Unlock()
+	}
+}
+
+// BlockForPluginLoad acquires the exclusive side of the gate. It returns once
+// no sonic call is in flight and blocks any new sonic call from starting until
+// UnblockForPluginLoad is called. plugin.Open must be wrapped with it so that
+// sonic JIT module registration never runs concurrently with plugin loading.
+func BlockForPluginLoad() {
+	// Re-arm the gate in case it was disabled; a plugin load always needs the
+	// reader side to block again.
+	gateDisabled.Store(false)
+	gateMu.Lock()
+	writeHeld.Store(true)
+	for reading.Load() > 0 {
+		gateCond.Wait()
+	}
+	gateMu.Unlock()
+}
+
+// UnblockForPluginLoad releases the exclusive side of the gate acquired by
+// BlockForPluginLoad.
+func UnblockForPluginLoad() {
+	gateMu.Lock()
+	writeHeld.Store(false)
+	gateCond.Broadcast()
+	gateMu.Unlock()
+}
+
+// DisableGate permanently disables the reader side of the gate. It must only be
+// called once every plugin loading in the process has finished; after that
+// point plugin.Open never runs again, so sonic JIT registration can no longer
+// race with it, and the reader fast path costs nothing beyond a single atomic
+// load. A later BlockForPluginLoad re-arms the gate.
+func DisableGate() {
+	gateDisabled.Store(true)
+}

--- a/internal/json/gate_bench_test.go
+++ b/internal/json/gate_bench_test.go
@@ -1,0 +1,208 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package json
+
+import (
+	"bytes"
+	"testing"
+)
+
+type benchObj struct {
+	A string    `json:"a"`
+	B int       `json:"b"`
+	C float64   `json:"c"`
+	D []int     `json:"d"`
+	E *benchObj `json:"e,omitempty"`
+}
+
+var benchPayload = []byte(`{"a":"hello","b":42,"c":3.14,"d":[1,2,3,4,5]}`)
+
+// baseline marshal bypasses the gate by calling sonic directly.
+func baselineMarshal(v any) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// baseline unmarshal bypasses the gate by calling sonic directly.
+func baselineUnmarshal(b []byte, v any) error {
+	return json.Unmarshal(b, v)
+}
+
+func BenchmarkMarshal_Small_Gated(b *testing.B) {
+	o := benchObj{A: "hello", B: 42, C: 3.14, D: []int{1, 2, 3, 4, 5}}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := Marshal(&o); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMarshal_Small_Baseline(b *testing.B) {
+	o := benchObj{A: "hello", B: 42, C: 3.14, D: []int{1, 2, 3, 4, 5}}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := baselineMarshal(&o); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_Small_Gated(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var o benchObj
+		if err := Unmarshal(benchPayload, &o); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_Small_Baseline(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var o benchObj
+		if err := baselineUnmarshal(benchPayload, &o); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkNewDecoderDecode_Gated(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		d := NewDecoder(bytes.NewReader(benchPayload))
+		var o benchObj
+		if err := d.Decode(&o); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkNewDecoderDecode_Baseline(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		d := json.NewDecoder(bytes.NewReader(benchPayload))
+		var o benchObj
+		if err := d.Decode(&o); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMarshal_Small_Parallel_Gated(b *testing.B) {
+	o := benchObj{A: "hello", B: 42, C: 3.14, D: []int{1, 2, 3, 4, 5}}
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, err := Marshal(&o); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkMarshal_Small_Parallel_Baseline(b *testing.B) {
+	o := benchObj{A: "hello", B: 42, C: 3.14, D: []int{1, 2, 3, 4, 5}}
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, err := baselineMarshal(&o); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkMarshal_Small_Parallel_GateDisabled is the steady state after all
+// plugin loading finished: the gate costs nothing beyond one atomic load.
+func BenchmarkMarshal_Small_Parallel_GateDisabled(b *testing.B) {
+	DisableGate()
+	defer func() { gateDisabled.Store(false) }()
+	o := benchObj{A: "hello", B: 42, C: 3.14, D: []int{1, 2, 3, 4, 5}}
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, err := Marshal(&o); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkMarshal_Large_Gated(b *testing.B) {
+	big := benchBig(2048)
+	b.SetBytes(int64(len(big)))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := Marshal(&big); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMarshal_Large_Baseline(b *testing.B) {
+	big := benchBig(2048)
+	b.SetBytes(int64(len(big)))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := baselineMarshal(&big); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMarshal_Large_Parallel_Gated(b *testing.B) {
+	big := benchBig(2048)
+	b.SetBytes(int64(len(big)))
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, err := Marshal(&big); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkMarshal_Large_Parallel_Baseline(b *testing.B) {
+	big := benchBig(2048)
+	b.SetBytes(int64(len(big)))
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, err := baselineMarshal(&big); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func benchBig(n int) map[string]any {
+	m := make(map[string]any, n)
+	for i := 0; i < n; i++ {
+		m[benchKey(i)] = benchVal(i)
+	}
+	return m
+}
+
+func benchKey(i int) string {
+	return "key_" + string(rune('a'+i%26)) + string(rune('0'+i%10))
+}
+
+func benchVal(i int) any {
+	return map[string]any{"id": i, "name": "item", "score": float64(i) / 100}
+}

--- a/internal/json/gate_test.go
+++ b/internal/json/gate_test.go
@@ -1,0 +1,238 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package json
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSonicAPIs(t *testing.T) {
+	type nested struct {
+		V int `json:"v"`
+	}
+	type obj struct {
+		A string  `json:"a"`
+		B int     `json:"b"`
+		N *nested `json:"n,omitempty"`
+	}
+
+	o := obj{A: "x", B: 1, N: &nested{V: 2}}
+	data, err := Marshal(o)
+	require.NoError(t, err)
+
+	var got obj
+	require.NoError(t, Unmarshal(data, &got))
+	assert.Equal(t, o, got)
+
+	indented, err := MarshalIndent(o, "", "  ")
+	require.NoError(t, err)
+	assert.Contains(t, string(indented), "\n")
+
+	require.True(t, Valid(data))
+	require.False(t, Valid([]byte("{not json")))
+}
+
+func TestDecoderEncoder(t *testing.T) {
+	type obj struct {
+		A string  `json:"a"`
+		B int     `json:"b"`
+		C float64 `json:"c"`
+	}
+
+	input := `{"a":"x","b":1,"c":2.5}`
+
+	dec := NewDecoder(bytes.NewBufferString(input))
+	dec.UseNumber()
+	var got obj
+	require.NoError(t, dec.Decode(&got))
+	assert.Equal(t, obj{A: "x", B: 1, C: 2.5}, got)
+
+	var buf bytes.Buffer
+	enc := NewEncoder(&buf)
+	require.NoError(t, enc.Encode(obj{A: "y", B: 2, C: 3.5}))
+	var decoded obj
+	require.NoError(t, Unmarshal(buf.Bytes(), &decoded))
+	assert.Equal(t, obj{A: "y", B: 2, C: 3.5}, decoded)
+}
+
+func TestBlockForPluginLoad_WaitsForInflightReader(t *testing.T) {
+	acquireRead()
+
+	blocked := make(chan struct{})
+	go func() {
+		BlockForPluginLoad()
+		close(blocked)
+	}()
+
+	select {
+	case <-blocked:
+		t.Fatal("BlockForPluginLoad returned while a reader was still in flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseRead()
+	select {
+	case <-blocked:
+	case <-time.After(time.Second):
+		t.Fatal("BlockForPluginLoad did not return after the reader released")
+	}
+
+	UnblockForPluginLoad()
+}
+
+func TestBlockForPluginLoad_BlocksNewReaders(t *testing.T) {
+	BlockForPluginLoad()
+
+	readerDone := make(chan struct{})
+	go func() {
+		acquireRead()
+		releaseRead()
+		close(readerDone)
+	}()
+
+	select {
+	case <-readerDone:
+		t.Fatal("reader acquired while plugin load was holding the exclusive side")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	UnblockForPluginLoad()
+	select {
+	case <-readerDone:
+	case <-time.After(time.Second):
+		t.Fatal("reader did not proceed after the plugin load released")
+	}
+}
+
+func TestConcurrentReadersAllowed(t *testing.T) {
+	BlockForPluginLoad()
+	UnblockForPluginLoad()
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 100; j++ {
+				b, err := Marshal(map[string]int{"k": j})
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				if err := Unmarshal(b, new(map[string]int)); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+}
+
+// TestGateWriterTogglesWithReaders stresses the handshake between concurrent
+// readers and repeatedly toggling writers. It guards against deadlocks and
+// missed wakeups (a reader's fast-path undo racing a writer's drain).
+func TestGateWriterTogglesWithReaders(t *testing.T) {
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 2000; j++ {
+				acquireRead()
+				b, err := json.Marshal(map[string]int{"k": j})
+				if err != nil {
+					t.Error(err)
+					releaseRead()
+					return
+				}
+				if err := json.Unmarshal(b, new(map[string]int)); err != nil {
+					t.Error(err)
+					releaseRead()
+					return
+				}
+				releaseRead()
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		for j := 0; j < 500; j++ {
+			BlockForPluginLoad()
+			UnblockForPluginLoad()
+		}
+	}()
+
+	close(start)
+	wg.Wait()
+}
+
+// TestDisableGateSkipsFastPath verifies that once the gate is disabled a reader
+// ignores the writer side entirely (steady state: zero blocking).
+func TestDisableGateSkipsFastPath(t *testing.T) {
+	DisableGate()
+	defer func() { gateDisabled.Store(false) }()
+
+	// Simulate a writer holding the exclusive side.
+	gateMu.Lock()
+	writeHeld.Store(true)
+	gateMu.Unlock()
+
+	acquireRead() // must return immediately even though a writer is active
+
+	gateMu.Lock()
+	writeHeld.Store(false)
+	gateMu.Unlock()
+
+	assert.Equal(t, int64(0), reading.Load(), "disabled gate must not touch the reader counter")
+}
+
+// TestBlockForPluginLoadRearmsAfterDisable verifies that a plugin load after
+// DisableGate re-arms the gate so readers block again.
+func TestBlockForPluginLoadRearmsAfterDisable(t *testing.T) {
+	DisableGate()
+	BlockForPluginLoad() // re-arms
+	defer UnblockForPluginLoad()
+
+	readerDone := make(chan struct{})
+	go func() {
+		acquireRead()
+		releaseRead()
+		close(readerDone)
+	}()
+
+	select {
+	case <-readerDone:
+		t.Fatal("reader acquired while a re-armed plugin load was holding the exclusive side")
+	case <-time.After(50 * time.Millisecond):
+	}
+}

--- a/internal/json/sonic.go
+++ b/internal/json/sonic.go
@@ -18,29 +18,126 @@ package json
 
 import (
 	gojson "encoding/json"
+	"io"
 
 	"github.com/bytedance/sonic"
 )
 
-var (
-	json = sonic.ConfigStd
-	// Marshal is exported from bytedance/sonic package.
-	Marshal = json.Marshal
-	// Unmarshal is exported from bytedance/sonic package.
-	Unmarshal = json.Unmarshal
-	// MarshalIndent is exported from bytedance/sonic package.
-	MarshalIndent = json.MarshalIndent
-	// NewDecoder is exported from bytedance/sonic package.
-	NewDecoder = json.NewDecoder
-	// NewEncoder is exported from bytedance/sonic package.
-	NewEncoder = json.NewEncoder
-	// Valid is exported from bytedance/sonic package.
-	Valid = json.Valid
-)
+var json = sonic.ConfigStd
+
+// sonic JIT-compiles a dedicated decoder/encoder for every type on first use.
+// The compilation registers a synthetic runtime module concurrently with
+// plugin.Open and can crash the process (see gate.go). Every entry point below
+// therefore takes the reader side of the gate, so JIT registration never
+// overlaps with plugin loading.
+
+// Marshal returns the JSON encoding bytes of v.
+func Marshal(v any) ([]byte, error) {
+	acquireRead()
+	defer releaseRead()
+	return json.Marshal(v)
+}
+
+// MarshalIndent returns the JSON encoding bytes of v with prefix and indent.
+func MarshalIndent(v any, prefix, indent string) ([]byte, error) {
+	acquireRead()
+	defer releaseRead()
+	return json.MarshalIndent(v, prefix, indent)
+}
+
+// Unmarshal parses the JSON-encoded data and stores the result in the value
+// pointed to by v.
+func Unmarshal(data []byte, v any) error {
+	acquireRead()
+	defer releaseRead()
+	return json.Unmarshal(data, v)
+}
+
+// Valid reports whether data is a valid JSON encoding.
+func Valid(data []byte) bool {
+	acquireRead()
+	defer releaseRead()
+	return json.Valid(data)
+}
+
+// NewDecoder returns a decoder that reads from r. The returned Decoder holds
+// the reader side of the gate for the whole decode operation.
+func NewDecoder(r io.Reader) *Decoder {
+	acquireRead()
+	defer releaseRead()
+	return &Decoder{decoder: json.NewDecoder(r)}
+}
+
+// NewEncoder returns an encoder that writes to w. The returned Encoder holds
+// the reader side of the gate for the whole encode operation.
+func NewEncoder(w io.Writer) *Encoder {
+	acquireRead()
+	defer releaseRead()
+	return &Encoder{encoder: json.NewEncoder(w)}
+}
+
+// Decoder reads and decodes JSON values from an input stream.
+type Decoder struct {
+	decoder sonic.Decoder
+}
+
+// Decode reads the next JSON-encoded value from its input and stores it in the
+// value pointed to by v.
+func (d *Decoder) Decode(v any) error {
+	acquireRead()
+	defer releaseRead()
+	return d.decoder.Decode(v)
+}
+
+// Buffered returns a reader of the data remaining in the Decoder's buffer.
+func (d *Decoder) Buffered() io.Reader {
+	return d.decoder.Buffered()
+}
+
+// DisallowUnknownFields causes the Decoder to return an error when the
+// destination is a struct and the input contains object keys which do not match
+// any non-ignored, exported fields in the destination.
+func (d *Decoder) DisallowUnknownFields() {
+	d.decoder.DisallowUnknownFields()
+}
+
+// More reports whether there is another element in the current array or object
+// being parsed.
+func (d *Decoder) More() bool {
+	return d.decoder.More()
+}
+
+// UseNumber causes the Decoder to unmarshal a number into an interface{} as a
+// Number instead of as a float64.
+func (d *Decoder) UseNumber() {
+	d.decoder.UseNumber()
+}
+
+// Encoder writes JSON values to an output stream.
+type Encoder struct {
+	encoder sonic.Encoder
+}
+
+// Encode writes the JSON encoding of v to the stream, followed by a newline.
+func (e *Encoder) Encode(v any) error {
+	acquireRead()
+	defer releaseRead()
+	return e.encoder.Encode(v)
+}
+
+// SetEscapeHTML specifies whether problematic HTML characters should be
+// escaped inside JSON quoted strings.
+func (e *Encoder) SetEscapeHTML(on bool) {
+	e.encoder.SetEscapeHTML(on)
+}
+
+// SetIndent instructs the encoder to format each subsequent encoded value.
+func (e *Encoder) SetIndent(prefix, indent string) {
+	e.encoder.SetIndent(prefix, indent)
+}
 
 type (
 	Delim      = gojson.Delim
-	Decoder    = gojson.Decoder
 	Number     = gojson.Number
 	RawMessage = gojson.RawMessage
 )

--- a/internal/util/hookutil/plugin.go
+++ b/internal/util/hookutil/plugin.go
@@ -5,15 +5,33 @@ import (
 	"plugin"
 	"sync"
 
+	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 var pluginMutex sync.Mutex
 
+// FinishPluginLoading completes every plugin load this process can still
+// perform and then permanently disables the sonic JSON gate. It must be called
+// after all components have started, at the point where plugin.Open can no
+// longer run. This is the process-level lifecycle guarantee that replaces any
+// runtime counting: the hook plugin is loaded eagerly by the proxy during
+// creation (internal/proxy/proxy.go), and the cipher plugin is forced to
+// completion here (a no-op when not configured). After it returns, sonic JIT
+// module registration can no longer race with plugin loading, so the JSON hot
+// path costs nothing.
+func FinishPluginLoading() {
+	InitOnceCipher()
+	json.DisableGate()
+}
+
 // LoadPlugin opens a Go plugin at the given path, looks up the named symbol,
 // and type-asserts it to T. All calls are serialized with a mutex because
-// Go's plugin.Open() is not safe for concurrent use (causes "empty pluginpath" panic).
+// Go's plugin.Open() is not safe for concurrent use. The plugin opening is
+// additionally guarded by the json gate's exclusive side so that sonic JIT
+// module registration never races with plugin loading (which can crash the
+// process with "runtime: plugin has empty pluginpath").
 func LoadPlugin[T any](path string, symbol string) (T, error) {
 	var zero T
 	if path == "" {
@@ -24,6 +42,9 @@ func LoadPlugin[T any](path string, symbol string) (T, error) {
 
 	pluginMutex.Lock()
 	defer pluginMutex.Unlock()
+
+	json.BlockForPluginLoad()
+	defer json.UnblockForPluginLoad()
 
 	p, err := plugin.Open(path)
 	if err != nil {

--- a/internal/util/hookutil/plugin_test.go
+++ b/internal/util/hookutil/plugin_test.go
@@ -19,3 +19,11 @@ func TestLoadPlugin_NonExistentFile(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "fail to open plugin")
 }
+
+func TestFinishPluginLoading(t *testing.T) {
+	// FinishPluginLoading must not panic with unconfigured plugin paths, and
+	// must be safe to call more than once (InitOnceCipher is a sync.Once and
+	// json.DisableGate is idempotent).
+	FinishPluginLoading()
+	FinishPluginLoading()
+}


### PR DESCRIPTION
issue: #51930

Sonic JIT-compiles a decoder/encoder for every type on first use and registers a synthetic runtime.moduledata whose pluginpath is empty, without holding the plugin package pluginsMu. When that overlaps plugin.Open lastmoduleinit, the runtime may treat sonic synthetic module as the newly loaded plugin and die with an unrecoverable "runtime: plugin has empty pluginpath".

Serializing plugin.Open with a mutex alone does not help: sonic JIT can fire from any goroutine at any time, so a concurrent first use of a type can still race the plugin-open window.

Introduce a process-wide reader-writer gate in internal/json. Every sonic entry point (Marshal, Unmarshal, Valid, NewDecoder, NewEncoder) takes the reader side; plugin.Open in hookutil.LoadPlugin runs inside the exclusive side. The reader fast path is a lock-free atomic counter and only blocks while a plugin is actually being opened, which happens once per process during startup. After all components have started, roles.Run calls hookutil.FinishPluginLoading, which forces the cipher plugin init to complete and permanently disables the gate, so the JSON hot path costs nothing in steady state. The hook plugin remains proxy-only and loads eagerly at proxy creation.