### PR TITLE
test: [3.0] cherry-pick #52674 #52628 #52616

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_external_table.py
+++ b/tests/python_client/milvus_client/test_milvus_client_external_table.py
@@ -2957,7 +2957,7 @@ class TestMilvusClientExternalTableAddField(ExternalTableTestBase):
     def test_milvus_client_external_table_drop_function_rejected(self, minio_env, external_prefix):
         """
         target: test external table drop function rejected
-        method: call drop_collection_function on an external collection
+        method: call drop_function_field on an external collection
         expected: function schema mutation is rejected for external collections
         """
         client = self._client()
@@ -2967,7 +2967,7 @@ class TestMilvusClientExternalTableAddField(ExternalTableTestBase):
             ct.err_code: 1100,
             ct.err_msg: "DropCollectionFunction RPC is no longer supported; drop a function via drop_function_field",
         }
-        self.drop_collection_function(
+        self.drop_function_field(
             client,
             coll,
             "bm25_func",

--- a/tests/python_client/milvus_client/test_milvus_client_query.py
+++ b/tests/python_client/milvus_client/test_milvus_client_query.py
@@ -2106,7 +2106,7 @@ class TestMilvusClientQueryValid(TestMilvusClientV2Base):
                 "listFlt": [m * 1.0 for m in range(i, i + limit)],
                 "listBool": [bool(i % 2)],
                 "listList": [[i, str(i + 1)], [i * 1.0, i + 1]],
-                "listMix": [i, i * 1.1, str(i), bool(i % 2), [i, str(i)]],
+                "listMix": [i, i + 0.5, str(i), bool(i % 2), [i, str(i)]],
             }
         self.insert(client, collection_name, rows)
         # 3. create index and load
@@ -2175,7 +2175,7 @@ class TestMilvusClientQueryValid(TestMilvusClientV2Base):
                 "listFlt": [m * 1.0 for m in range(i, i + limit)],
                 "listBool": [bool(i % 2)],
                 "listList": [[i, str(i + 1)], [i * 1.0, i + 1]],
-                "listMix": [i, i * 1.1, str(i), bool(i % 2), [i, str(i)]],
+                "listMix": [i, i + 0.5, str(i), bool(i % 2), [i, str(i)]],
             }
         self.insert(client, collection_name, rows)
         # 3. create index and load
@@ -2475,7 +2475,7 @@ class TestMilvusClientQueryValid(TestMilvusClientV2Base):
         flt_data = [[m * 1.0 for m in range(i, i + limit)] for i in range(default_nb)]
         bool_data = [[bool(i % 2)] for i in range(default_nb)]
         list_data = [[[i, str(i + 1)], [i * 1.0, i + 1]] for i in range(default_nb)]
-        mix_data = [[i, i * 1.1, str(i), bool(i % 2), [i, str(i)]] for i in range(default_nb)]
+        mix_data = [[i, i + 0.5, str(i), bool(i % 2), [i, str(i)]] for i in range(default_nb)]
 
         for i in range(default_nb):
             rows[i][ct.default_json_field_name] = {

--- a/tests/restful_client_v2/testcases/test_external_collection_operations.py
+++ b/tests/restful_client_v2/testcases/test_external_collection_operations.py
@@ -1569,9 +1569,19 @@ class TestRestExternalCollection(TestBase):
         second_rsp = self._refresh_external_collection(payload)
         if second_rsp.get("code") == 0:
             second_job_id = _assert_refresh_response(second_rsp)
-            assert second_job_id == first_job_id, (
-                f"duplicate refresh returned a different job id: first={first_job_id}, second={second_job_id}"
-            )
+            if second_job_id != first_job_id:
+                # On fast machines the first refresh job can reach a terminal state
+                # before the second request's duplicate check runs, in which case the
+                # server legitimately allocates a fresh job id. Only fail when the first
+                # job is still active yet a different job id was returned.
+                first_job_rsp = self._describe_external_collection_job(first_job_id)
+                first_state = first_job_rsp.get("data", {}).get("state")
+                assert first_state in TERMINAL_JOB_STATES, (
+                    f"duplicate refresh returned a different job id while the first job is still active: "
+                    f"first={first_job_id} (state={first_state}), second={second_job_id}"
+                )
+                _, second_finished = self._wait_refresh_completed(second_job_id)
+                assert second_finished
         else:
             _assert_error_response(second_rsp)
             message = second_rsp["message"].lower()


### PR DESCRIPTION
Cherry-pick of the following PRs to the 3.0 branch:

related pr: #52674 test: fix external table drop-function e2e to use drop_function_field
- #52628 test: accept new refresh job when the first job is already terminal
- #52616 test: avoid float-int collision in json_contains_any test data