### PR TITLE
fix: ignore topology changes that predate a replication task

### DIFF
--- a/internal/cdc/replication/replicatemanager/channel_replicator.go
+++ b/internal/cdc/replication/replicatemanager/channel_replicator.go
@@ -180,6 +180,17 @@ func (r *channelReplicator) startConsumeLoop() {
 			logger.Info(context.TODO(), "consume loop stopped")
 			return
 		case msg := <-r.msgChan:
+			// A topology change older than this task describes a past state, not an
+			// instruction. Forwarding it would make the secondary act on it — a
+			// configuration that no longer lists the secondary turns it back into a
+			// standalone primary — so it is dropped instead of replicated.
+			if msg.MessageType() == message.MessageTypeAlterReplicateConfig &&
+				util.IsStaleTopologyChange(msg, r.channel.Value) {
+				logger.Info(context.TODO(), "skip replicating topology change older than this replication task",
+					mlog.FieldMessage(msg),
+					mlog.Uint64("initializedTimeTick", r.channel.Value.GetInitializedCheckpoint().GetTimeTick()))
+				continue
+			}
 			err := r.streamClient.Replicate(msg)
 			if err != nil {
 				if !errors.Is(err, replicatestream.ErrReplicateIgnored) {

--- a/internal/cdc/replication/replicatemanager/channel_replicator_test.go
+++ b/internal/cdc/replication/replicatemanager/channel_replicator_test.go
@@ -181,3 +181,83 @@ func TestChannelReplicatorInitMetricFromInitializedCheckpoint(t *testing.T) {
 	got := testutil.ToFloat64(metrics.CDCLastReplicatedTimeTick.WithLabelValues(source, target))
 	assert.InDelta(t, tsoutil.PhysicalTimeSeconds(checkpoint), got, 1)
 }
+
+// TestChannelReplicatorConsumeLoopSkipsStaleTopologyChange covers the case where
+// the replicator resumes from a checkpoint that predates its own creation — the
+// position a `restore secondary` leaves on the target. The replay then walks
+// over a topology change that removed this edge before it was re-created. That
+// message must neither be forwarded to the secondary, where a configuration
+// without the secondary turns it back into a standalone primary, nor end the
+// consume loop.
+func TestChannelReplicatorConsumeLoopSkipsStaleTopologyChange(t *testing.T) {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.ClusterPrefix.Key, "current-cluster")
+	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.ClusterPrefix.Key)
+
+	source, target := "TestStale-source", "TestStale-target"
+	// The task was created by the configuration appended at time tick 100.
+	replicateInfo := &streamingpb.ReplicatePChannelMeta{
+		SourceChannelName: source,
+		TargetChannelName: target,
+		TargetCluster:     &commonpb.MilvusCluster{ClusterId: "removed-target-cluster"},
+		InitializedCheckpoint: &commonpb.ReplicateCheckpoint{
+			ClusterId: "current-cluster",
+			Pchannel:  source,
+			TimeTick:  100,
+		},
+	}
+
+	// A detach broadcast from before the task existed.
+	staleMsg := message.NewAlterReplicateConfigMessageBuilderV2().
+		WithHeader(&message.AlterReplicateConfigMessageHeader{
+			ReplicateConfiguration: &commonpb.ReplicateConfiguration{
+				Clusters: []*commonpb.MilvusCluster{
+					{
+						ClusterId:       "current-cluster",
+						ConnectionParam: &commonpb.ConnectionParam{Uri: "localhost:19530"},
+						Pchannels:       []string{source},
+					},
+				},
+			},
+		}).
+		WithBody(&message.AlterReplicateConfigMessageBody{}).
+		WithAllVChannel().
+		MustBuildMutable().
+		WithLastConfirmedUseMessageID().
+		WithTimeTick(50).
+		IntoImmutableMessage(pulsar2.NewPulsarID(pulsar.EarliestMessageID()))
+
+	rs := replicatestream.NewMockReplicateStreamClient(t)
+	// No Replicate and no BlockUntilFinish expectation: the message is dropped
+	// before either is reached, and the mock fails the test on any other call.
+
+	replicator := &channelReplicator{
+		channel: &meta.ReplicateChannel{
+			Key:         "stale-key",
+			ModRevision: 1,
+			Value:       replicateInfo,
+		},
+		streamClient:  rs,
+		msgChan:       make(adaptor.ChanMessageHandler),
+		asyncNotifier: syncutil.NewAsyncTaskNotifier[struct{}](),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		replicator.startConsumeLoop()
+		close(done)
+	}()
+	replicator.msgChan <- staleMsg
+
+	// The loop must still be running: give it a moment, then stop it ourselves.
+	select {
+	case <-done:
+		t.Fatal("consume loop stopped on a topology change that predates the task")
+	case <-time.After(200 * time.Millisecond):
+	}
+	replicator.asyncNotifier.Cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("consume loop did not stop after cancel")
+	}
+}

--- a/internal/cdc/util/util.go
+++ b/internal/cdc/util/util.go
@@ -7,6 +7,30 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/replicateutil"
 )
 
+// IsStaleTopologyChange reports whether an AlterReplicateConfig message predates
+// the replication task it is being evaluated against.
+//
+// A replicator does not necessarily start reading at the live position: it
+// resumes from the checkpoint reported by the target cluster, which after a
+// `restore secondary` is the position the backup was taken at. Replaying from
+// there walks over every topology change made since — including ones that
+// removed this very edge before it was re-created — and those describe a past
+// state, not an instruction for the task replaying them.
+//
+// The initialized checkpoint carries the time tick of the AlterReplicateConfig
+// that created the task, so anything at or before it predates the task itself.
+// A zero value means the field is absent (task written by an older version), in
+// which case no ordering is enforced and the previous behaviour is kept.
+func IsStaleTopologyChange(msg message.ImmutableMessage, replicateInfo *streamingpb.ReplicatePChannelMeta) bool {
+	initTimeTick := replicateInfo.GetInitializedCheckpoint().GetTimeTick()
+	return initTimeTick != 0 && msg.TimeTick() <= initTimeTick
+}
+
+// IsReplicationRemovedByAlterReplicateConfigMessage reports whether the given
+// AlterReplicateConfig message removes the replication task described by
+// replicateInfo, i.e. whether its topology still carries the task's
+// `current -> target` edge. A message that predates the task is not an
+// instruction for it and never removes it.
 func IsReplicationRemovedByAlterReplicateConfigMessage(msg message.ImmutableMessage, replicateInfo *streamingpb.ReplicatePChannelMeta) (replicationRemoved bool) {
 	prcMsg := message.MustAsImmutableAlterReplicateConfigMessageV2(msg)
 	header := prcMsg.Header()
@@ -14,6 +38,10 @@ func IsReplicationRemovedByAlterReplicateConfigMessage(msg message.ImmutableMess
 	// Check ignore field - if true, this message should be ignored
 	// This is used for incomplete switchover messages that should be ignored after force promote
 	if header.Ignore {
+		return false
+	}
+
+	if IsStaleTopologyChange(msg, replicateInfo) {
 		return false
 	}
 

--- a/internal/cdc/util/util.go
+++ b/internal/cdc/util/util.go
@@ -20,7 +20,7 @@ import (
 // The initialized checkpoint carries the time tick of the AlterReplicateConfig
 // that created the task, so anything at or before it predates the task itself.
 // A zero value means the field is absent (task written by an older version), in
-// which case no ordering is enforced and the previous behaviour is kept.
+// which case no ordering is enforced and the previous behavior is kept.
 func IsStaleTopologyChange(msg message.ImmutableMessage, replicateInfo *streamingpb.ReplicatePChannelMeta) bool {
 	initTimeTick := replicateInfo.GetInitializedCheckpoint().GetTimeTick()
 	return initTimeTick != 0 && msg.TimeTick() <= initTimeTick

--- a/internal/cdc/util/util_test.go
+++ b/internal/cdc/util/util_test.go
@@ -1,0 +1,158 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/apache/pulsar-client-go/pulsar"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	pulsar2 "github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/impls/pulsar"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+const (
+	testCurrentCluster = "current-cluster"
+	testTargetCluster  = "target-cluster"
+	testSourceChannel  = "current-cluster-rootcoord-dml_0"
+	testTargetChannel  = "target-cluster-rootcoord-dml_0"
+)
+
+// task builds the replication task metadata under test. initTimeTick is the
+// time tick of the AlterReplicateConfig that created it; zero means the field
+// is absent, as it is for tasks written by an older version.
+func task(initTimeTick uint64) *streamingpb.ReplicatePChannelMeta {
+	meta := &streamingpb.ReplicatePChannelMeta{
+		SourceChannelName: testSourceChannel,
+		TargetChannelName: testTargetChannel,
+		TargetCluster:     &commonpb.MilvusCluster{ClusterId: testTargetCluster},
+	}
+	if initTimeTick != 0 {
+		meta.InitializedCheckpoint = &commonpb.ReplicateCheckpoint{
+			ClusterId: testCurrentCluster,
+			Pchannel:  testSourceChannel,
+			TimeTick:  initTimeTick,
+		}
+	}
+	return meta
+}
+
+// alterMsg builds an AlterReplicateConfig message at the given time tick. When
+// withEdge is true the topology still carries current -> target; otherwise the
+// current cluster stands alone, which is what a detach broadcasts.
+func alterMsg(timeTick uint64, withEdge bool, ignore bool) message.ImmutableMessage {
+	clusters := []*commonpb.MilvusCluster{
+		{
+			ClusterId:       testCurrentCluster,
+			ConnectionParam: &commonpb.ConnectionParam{Uri: "localhost:19530"},
+			Pchannels:       []string{testSourceChannel},
+		},
+	}
+	var topology []*commonpb.CrossClusterTopology
+	if withEdge {
+		clusters = append(clusters, &commonpb.MilvusCluster{
+			ClusterId:       testTargetCluster,
+			ConnectionParam: &commonpb.ConnectionParam{Uri: "localhost:19531"},
+			Pchannels:       []string{testTargetChannel},
+		})
+		topology = []*commonpb.CrossClusterTopology{
+			{SourceClusterId: testCurrentCluster, TargetClusterId: testTargetCluster},
+		}
+	}
+
+	return message.NewAlterReplicateConfigMessageBuilderV2().
+		WithHeader(&message.AlterReplicateConfigMessageHeader{
+			ReplicateConfiguration: &commonpb.ReplicateConfiguration{
+				Clusters:             clusters,
+				CrossClusterTopology: topology,
+			},
+			Ignore: ignore,
+		}).
+		WithBody(&message.AlterReplicateConfigMessageBody{}).
+		WithAllVChannel().
+		MustBuildMutable().
+		WithLastConfirmedUseMessageID().
+		WithTimeTick(timeTick).
+		IntoImmutableMessage(pulsar2.NewPulsarID(pulsar.EarliestMessageID()))
+}
+
+func withCurrentCluster(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().CommonCfg.ClusterPrefix.Key, testCurrentCluster)
+	t.Cleanup(func() { paramtable.Get().Reset(paramtable.Get().CommonCfg.ClusterPrefix.Key) })
+}
+
+func TestIsStaleTopologyChange(t *testing.T) {
+	// The task was created by the configuration appended at time tick 100.
+	const created = uint64(100)
+
+	t.Run("older than the task is stale", func(t *testing.T) {
+		assert.True(t, IsStaleTopologyChange(alterMsg(created-1, false, false), task(created)))
+	})
+
+	t.Run("the message that created the task is stale", func(t *testing.T) {
+		// Its own creating message carries no instruction for it either.
+		assert.True(t, IsStaleTopologyChange(alterMsg(created, true, false), task(created)))
+	})
+
+	t.Run("newer than the task is current", func(t *testing.T) {
+		assert.False(t, IsStaleTopologyChange(alterMsg(created+1, false, false), task(created)))
+	})
+
+	t.Run("no initialized time tick enforces no ordering", func(t *testing.T) {
+		// Tasks written by an older version keep the previous behavior.
+		assert.False(t, IsStaleTopologyChange(alterMsg(1, false, false), task(0)))
+	})
+}
+
+func TestIsReplicationRemovedByAlterReplicateConfigMessage(t *testing.T) {
+	withCurrentCluster(t)
+	const created = uint64(100)
+
+	t.Run("a current detach removes the replication", func(t *testing.T) {
+		assert.True(t, IsReplicationRemovedByAlterReplicateConfigMessage(
+			alterMsg(created+10, false, false), task(created)))
+	})
+
+	t.Run("a current configuration that keeps the edge does not", func(t *testing.T) {
+		assert.False(t, IsReplicationRemovedByAlterReplicateConfigMessage(
+			alterMsg(created+10, true, false), task(created)))
+	})
+
+	// The regression: replaying the WAL from a checkpoint that predates the task
+	// walks over topology changes that removed this edge before it was
+	// re-created. Acting on them makes the replicator delete itself moments
+	// after starting.
+	t.Run("a detach that predates the task does not remove it", func(t *testing.T) {
+		assert.False(t, IsReplicationRemovedByAlterReplicateConfigMessage(
+			alterMsg(created-10, false, false), task(created)))
+	})
+
+	t.Run("a detach predating a task with no initialized time tick still removes it", func(t *testing.T) {
+		assert.True(t, IsReplicationRemovedByAlterReplicateConfigMessage(
+			alterMsg(1, false, false), task(0)))
+	})
+
+	t.Run("an ignored message never removes the replication", func(t *testing.T) {
+		assert.False(t, IsReplicationRemovedByAlterReplicateConfigMessage(
+			alterMsg(created+10, false, true), task(created)))
+	})
+}


### PR DESCRIPTION
issue: #52727

## Problem

A replicator does not start reading at the live position. It resumes from the checkpoint
the target cluster reports, and after `milvus-backup restore secondary` that checkpoint is
the position the backup was taken at. The replicator therefore replays the source WAL from
far behind, walking over every topology change made since — including ones that removed this
very edge before it was re-created.

`IsReplicationRemovedByAlterReplicateConfigMessage` decides purely on the message contents,
with no ordering check, so a historical detach is executed as if it had just been issued:

- the replicator deletes its own `replicating-pchannel/` key and stops
  (`replicate_stream_client_impl.go:337-370`), and the same predicate ends the consume loop
  (`channel_replicator.go:191-199`);
- the same message is forwarded to the secondary, where `overwriteAlterReplicateConfigMessage`
  finds the secondary absent from the configuration and turns it back into a standalone
  primary.

In the field this stopped replication 0.2 s after it started, and left a state nothing
recovers from: the topology query still reports the edge, because only the per-pchannel task
keys are gone and the configuration key is untouched, and re-applying the same configuration
is short-circuited as unchanged and returns success.

Ordinary CDC catch-up never exposes this — the checkpoint stays close to the live position
and only new messages are read.

## Change

`ReplicatePChannelMeta.initialized_checkpoint` already carries the time tick of the
`AlterReplicateConfig` that created the task, so no new field or protocol change is needed.
A message at or before it predates the task and cannot be an instruction for it.

- `util.IsStaleTopologyChange` implements that comparison.
- `IsReplicationRemovedByAlterReplicateConfigMessage` returns false for such a message, so
  the replicator neither deletes its metadata nor ends its consume loop.
- The consume loop drops such a message instead of forwarding it, so the secondary cannot be
  flipped back to a standalone primary by a configuration from the past.
- A task with no initialized time tick — written by an older version — enforces no ordering
  and keeps the previous behaviour.

The pchannel-increasing path is unaffected: it deliberately sets the initialized time tick to
one below the creating message, so that message is still delivered, and it carries the edge,
which takes the existing skip path.

## Tests

`internal/cdc/util` had no test file at all. Added:

- `TestIsStaleTopologyChange` — older than the task, exactly the creating message, newer than
  the task, and the no-initialized-time-tick case.
- `TestIsReplicationRemovedByAlterReplicateConfigMessage` — a current detach still removes the
  replication; a current configuration that keeps the edge does not; **a detach that predates
  the task does not remove it** (the regression); the no-initialized-time-tick case still
  removes; an ignored message never removes.
- `TestChannelReplicatorConsumeLoopSkipsStaleTopologyChange` — a stale topology change is
  neither forwarded (the stream client mock has no `Replicate` expectation, so forwarding
  fails the test) nor ends the consume loop.

The existing `TestChannelReplicatorConsumeLoopDeletesLagSeriesOnRemoval` covers the opposite
direction and still passes: its task carries no initialized checkpoint, so the removal path
is unchanged for it.
