### PR TITLE
fix: [poc_2.6.17] stop CDC acting on stale topology changes; answer topology queries on unconfigured clusters

### DIFF
--- a/internal/cdc/replication/replicatemanager/channel_replicator.go
+++ b/internal/cdc/replication/replicatemanager/channel_replicator.go
@@ -76,6 +76,7 @@ func NewChannelReplicator(channel *meta.ReplicateChannel) Replicator {
 }
 
 func (r *channelReplicator) StartReplication() {
+	r.initLastReplicatedTimeTickMetric()
 	logger := log.With(zap.String("key", r.channel.Key), zap.Int64("modRevision", r.channel.ModRevision))
 	logger.Info("start replicate channel")
 	go func() {
@@ -109,6 +110,21 @@ func (r *channelReplicator) StartReplication() {
 	}()
 }
 
+// initLastReplicatedTimeTickMetric seeds the lag series synchronously, before
+// any network dependency, so that the series exists even while init() keeps
+// failing against an unreachable target — an absent series reads as zero lag
+// on the dashboard. The initialized (creation-time) checkpoint is a
+// conservative bound: real progress is at or after it, so the seed can only
+// overstate the lag. init() overwrites it with the target-confirmed
+// checkpoint once the target is reachable.
+func (r *channelReplicator) initLastReplicatedTimeTickMetric() {
+	checkpoint := r.channel.Value.GetInitializedCheckpoint()
+	if checkpoint == nil {
+		return
+	}
+	replicatestream.InitLastReplicatedTimeTick(r.channel.Value, checkpoint.GetTimeTick())
+}
+
 func (r *channelReplicator) init() error {
 	logger := log.With(zap.String("key", r.channel.Key), zap.Int64("modRevision", r.channel.ModRevision))
 	// init target client
@@ -138,6 +154,11 @@ func (r *channelReplicator) init() error {
 		})
 		r.msgScanner = scanner
 		r.msgChan = ch
+		// Seed the last replicated time tick from the resume checkpoint so that
+		// after a CDC pod restart the lag metric reports the real backlog
+		// immediately, instead of the series being absent (which reads as 0)
+		// until the first message is replicated.
+		replicatestream.InitLastReplicatedTimeTick(r.channel.Value, cp.TimeTick)
 		logger.Info("scanner initialized", zap.Any("checkpoint", cp))
 	}
 	// init replicate stream client
@@ -182,6 +203,10 @@ func (r *channelReplicator) startConsumeLoop() {
 				if util.IsReplicationRemovedByAlterReplicateConfigMessage(msg, r.channel.Value) {
 					logger.Info("replication removed, stop consume loop")
 					r.streamClient.BlockUntilFinish()
+					// The replication is genuinely removed, delete its lag
+					// series. Deleting after BlockUntilFinish ensures no
+					// in-flight confirm re-creates the series afterwards.
+					replicatestream.DeleteLastReplicatedTimeTick(r.channel.Value)
 					return
 				}
 			}

--- a/internal/cdc/replication/replicatemanager/channel_replicator.go
+++ b/internal/cdc/replication/replicatemanager/channel_replicator.go
@@ -159,6 +159,17 @@ func (r *channelReplicator) startConsumeLoop() {
 			logger.Info("consume loop stopped")
 			return
 		case msg := <-r.msgChan:
+			// A topology change older than this task describes a past state, not an
+			// instruction. Forwarding it would make the secondary act on it — a
+			// configuration that no longer lists the secondary turns it back into a
+			// standalone primary — so it is dropped instead of replicated.
+			if msg.MessageType() == message.MessageTypeAlterReplicateConfig &&
+				util.IsStaleTopologyChange(msg, r.channel.Value) {
+				logger.Info("skip replicating topology change older than this replication task",
+					log.FieldMessage(msg),
+					zap.Uint64("initializedTimeTick", r.channel.Value.GetInitializedCheckpoint().GetTimeTick()))
+				continue
+			}
 			err := r.streamClient.Replicate(msg)
 			if err != nil {
 				if !errors.Is(err, replicatestream.ErrReplicateIgnored) {

--- a/internal/cdc/replication/replicatemanager/channel_replicator_test.go
+++ b/internal/cdc/replication/replicatemanager/channel_replicator_test.go
@@ -93,3 +93,83 @@ func TestChannelReplicator_StartReplicateChannel(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 	replicator.StopReplication()
 }
+
+// TestChannelReplicatorConsumeLoopSkipsStaleTopologyChange covers the case where
+// the replicator resumes from a checkpoint that predates its own creation — the
+// position a `restore secondary` leaves on the target. The replay then walks
+// over a topology change that removed this edge before it was re-created. That
+// message must neither be forwarded to the secondary, where a configuration
+// without the secondary turns it back into a standalone primary, nor end the
+// consume loop.
+func TestChannelReplicatorConsumeLoopSkipsStaleTopologyChange(t *testing.T) {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.ClusterPrefix.Key, "current-cluster")
+	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.ClusterPrefix.Key)
+
+	source, target := "TestStale-source", "TestStale-target"
+	// The task was created by the configuration appended at time tick 100.
+	replicateInfo := &streamingpb.ReplicatePChannelMeta{
+		SourceChannelName: source,
+		TargetChannelName: target,
+		TargetCluster:     &commonpb.MilvusCluster{ClusterId: "removed-target-cluster"},
+		InitializedCheckpoint: &commonpb.ReplicateCheckpoint{
+			ClusterId: "current-cluster",
+			Pchannel:  source,
+			TimeTick:  100,
+		},
+	}
+
+	// A detach broadcast from before the task existed.
+	staleMsg := message.NewAlterReplicateConfigMessageBuilderV2().
+		WithHeader(&message.AlterReplicateConfigMessageHeader{
+			ReplicateConfiguration: &commonpb.ReplicateConfiguration{
+				Clusters: []*commonpb.MilvusCluster{
+					{
+						ClusterId:       "current-cluster",
+						ConnectionParam: &commonpb.ConnectionParam{Uri: "localhost:19530"},
+						Pchannels:       []string{source},
+					},
+				},
+			},
+		}).
+		WithBody(&message.AlterReplicateConfigMessageBody{}).
+		WithAllVChannel().
+		MustBuildMutable().
+		WithLastConfirmedUseMessageID().
+		WithTimeTick(50).
+		IntoImmutableMessage(pulsar2.NewPulsarID(pulsar.EarliestMessageID()))
+
+	rs := replicatestream.NewMockReplicateStreamClient(t)
+	// No Replicate and no BlockUntilFinish expectation: the message is dropped
+	// before either is reached, and the mock fails the test on any other call.
+
+	replicator := &channelReplicator{
+		channel: &meta.ReplicateChannel{
+			Key:         "stale-key",
+			ModRevision: 1,
+			Value:       replicateInfo,
+		},
+		streamClient:  rs,
+		msgChan:       make(adaptor.ChanMessageHandler),
+		asyncNotifier: syncutil.NewAsyncTaskNotifier[struct{}](),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		replicator.startConsumeLoop()
+		close(done)
+	}()
+	replicator.msgChan <- staleMsg
+
+	// The loop must still be running: give it a moment, then stop it ourselves.
+	select {
+	case <-done:
+		t.Fatal("consume loop stopped on a topology change that predates the task")
+	case <-time.After(200 * time.Millisecond):
+	}
+	replicator.asyncNotifier.Cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("consume loop did not stop after cancel")
+	}
+}

--- a/internal/cdc/replication/replicatemanager/channel_replicator_test.go
+++ b/internal/cdc/replication/replicatemanager/channel_replicator_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	mock "github.com/stretchr/testify/mock"
 
@@ -32,8 +33,14 @@ import (
 	"github.com/milvus-io/milvus/internal/cdc/replication/replicatestream"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/mocks/distributed/mock_streaming"
+	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message/adaptor"
 	pulsar2 "github.com/milvus-io/milvus/pkg/v2/streaming/walimpls/impls/pulsar"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/syncutil"
+	"github.com/milvus-io/milvus/pkg/v2/util/tsoutil"
 )
 
 func newMockPulsarMessageID() *commonpb.MessageID {
@@ -92,6 +99,87 @@ func TestChannelReplicator_StartReplicateChannel(t *testing.T) {
 	replicator.StartReplication()
 	time.Sleep(200 * time.Millisecond)
 	replicator.StopReplication()
+}
+
+// TestChannelReplicatorConsumeLoopDeletesLagSeriesOnRemoval verifies the
+// in-band removal path: when the consume loop replicates an
+// AlterReplicateConfig message that removes this replication, the lag series
+// is deleted.
+func TestChannelReplicatorConsumeLoopDeletesLagSeriesOnRemoval(t *testing.T) {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.ClusterPrefix.Key, "current-cluster")
+	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.ClusterPrefix.Key)
+
+	source, target := "TestRemoval-source", "TestRemoval-target"
+	replicateInfo := &streamingpb.ReplicatePChannelMeta{
+		SourceChannelName: source,
+		TargetChannelName: target,
+		TargetCluster:     &commonpb.MilvusCluster{ClusterId: "removed-target-cluster"},
+	}
+
+	// An AlterReplicateConfig whose topology no longer contains the
+	// current->target edge, i.e. this replication is removed.
+	msg := message.NewAlterReplicateConfigMessageBuilderV2().
+		WithHeader(&message.AlterReplicateConfigMessageHeader{
+			ReplicateConfiguration: &commonpb.ReplicateConfiguration{
+				Clusters: []*commonpb.MilvusCluster{
+					{
+						ClusterId:       "current-cluster",
+						ConnectionParam: &commonpb.ConnectionParam{Uri: "localhost:19530"},
+						Pchannels:       []string{source},
+					},
+				},
+			},
+		}).
+		WithBody(&message.AlterReplicateConfigMessageBody{}).
+		WithAllVChannel().
+		MustBuildMutable().
+		WithLastConfirmedUseMessageID().
+		WithTimeTick(1).
+		IntoImmutableMessage(pulsar2.NewPulsarID(pulsar.EarliestMessageID()))
+
+	rs := replicatestream.NewMockReplicateStreamClient(t)
+	rs.EXPECT().Replicate(mock.Anything).Return(nil)
+	rs.EXPECT().BlockUntilFinish().Return()
+
+	replicator := &channelReplicator{
+		channel: &meta.ReplicateChannel{
+			Key:         "removal-key",
+			ModRevision: 1,
+			Value:       replicateInfo,
+		},
+		streamClient:  rs,
+		msgChan:       make(adaptor.ChanMessageHandler),
+		asyncNotifier: syncutil.NewAsyncTaskNotifier[struct{}](),
+	}
+	replicatestream.InitLastReplicatedTimeTick(replicateInfo, tsoutil.ComposeTSByTime(time.Now(), 0))
+
+	go func() { replicator.msgChan <- msg }()
+	replicator.startConsumeLoop()
+
+	assert.False(t, metrics.CDCLastReplicatedTimeTick.DeleteLabelValues(source, target))
+}
+
+func TestChannelReplicatorInitMetricFromInitializedCheckpoint(t *testing.T) {
+	source, target := "TestInitMetric-source", "TestInitMetric-target"
+	checkpoint := tsoutil.ComposeTSByTime(time.Now().Add(-5*time.Minute), 0)
+	defer metrics.CDCLastReplicatedTimeTick.DeleteLabelValues(source, target)
+
+	replicator := NewChannelReplicator(&meta.ReplicateChannel{
+		Value: &streamingpb.ReplicatePChannelMeta{
+			SourceChannelName: source,
+			TargetChannelName: target,
+			InitializedCheckpoint: &commonpb.ReplicateCheckpoint{
+				TimeTick: checkpoint,
+			},
+		},
+	})
+	channelReplicator, ok := replicator.(*channelReplicator)
+	assert.True(t, ok)
+
+	channelReplicator.initLastReplicatedTimeTickMetric()
+
+	got := testutil.ToFloat64(metrics.CDCLastReplicatedTimeTick.WithLabelValues(source, target))
+	assert.InDelta(t, tsoutil.PhysicalTimeSeconds(checkpoint), got, 1)
 }
 
 // TestChannelReplicatorConsumeLoopSkipsStaleTopologyChange covers the case where

--- a/internal/cdc/replication/replicatemanager/replicate_manager.go
+++ b/internal/cdc/replication/replicatemanager/replicate_manager.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/cdc/meta"
+	"github.com/milvus-io/milvus/internal/cdc/replication/replicatestream"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
@@ -76,21 +77,26 @@ func (r *replicateManager) CreateReplicator(channel *meta.ReplicateChannel) {
 func (r *replicateManager) RemoveReplicator(key string, modRevision int64) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.removeReplicatorInternal(key, modRevision)
+	channel, removed := r.removeReplicatorInternal(key, modRevision)
+	if removed && channel != nil {
+		replicatestream.DeleteLastReplicatedTimeTick(channel.Value)
+	}
 }
 
-func (r *replicateManager) removeReplicatorInternal(key string, modRevision int64) {
+func (r *replicateManager) removeReplicatorInternal(key string, modRevision int64) (*meta.ReplicateChannel, bool) {
 	logger := log.With(zap.String("key", key), zap.Int64("modRevision", modRevision))
 	repKey := buildReplicatorKey(key, modRevision)
 	replicator, ok := r.replicators[repKey]
 	if !ok {
 		logger.Info("replicator not found, skip remove")
-		return
+		return nil, false
 	}
+	channel := r.replicatorChannels[repKey]
 	replicator.StopReplication()
 	delete(r.replicators, repKey)
 	delete(r.replicatorChannels, repKey)
 	logger.Info("removed replicator for replicate pchannel")
+	return channel, true
 }
 
 func (r *replicateManager) RemoveOutdatedReplicators(aliveChannels []*meta.ReplicateChannel) {
@@ -104,6 +110,14 @@ func (r *replicateManager) RemoveOutdatedReplicators(aliveChannels []*meta.Repli
 	for repKey := range r.replicators {
 		if _, ok := alivesMap[repKey]; !ok {
 			channel := r.replicatorChannels[repKey]
+			if channel == nil {
+				continue
+			}
+			// No lag-series deletion here: a replicate pchannel key is only
+			// deleted after the replicator's in-band removal path
+			// (handleAlterReplicateConfigMessage) confirmed the removal and
+			// deleted the series; out-of-band key deletions are covered by
+			// the etcd DELETE event path (RemoveReplicator).
 			r.removeReplicatorInternal(channel.Key, channel.ModRevision)
 		}
 	}

--- a/internal/cdc/replication/replicatemanager/replicate_manager_test.go
+++ b/internal/cdc/replication/replicatemanager/replicate_manager_test.go
@@ -18,16 +18,45 @@ package replicatemanager
 
 import (
 	"testing"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	mock "github.com/stretchr/testify/mock"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus/internal/cdc/cluster"
 	"github.com/milvus-io/milvus/internal/cdc/meta"
+	"github.com/milvus-io/milvus/internal/cdc/replication/replicatestream"
+	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/tsoutil"
 )
+
+type testReplicator struct {
+	stopped bool
+}
+
+func (*testReplicator) StartReplication() {}
+
+func (r *testReplicator) StopReplication() {
+	r.stopped = true
+}
+
+func newTestReplicateChannel(key string, revision int64, source, target string) *meta.ReplicateChannel {
+	return &meta.ReplicateChannel{
+		Key:         key,
+		ModRevision: revision,
+		Value: &streamingpb.ReplicatePChannelMeta{
+			SourceChannelName: source,
+			TargetChannelName: target,
+			TargetCluster: &commonpb.MilvusCluster{
+				ClusterId: "test-target-cluster",
+			},
+		},
+	}
+}
 
 func TestReplicateManager_CreateReplicator(t *testing.T) {
 	paramtable.Get().Save(paramtable.Get().CommonCfg.ClusterPrefix.Key, "test-source")
@@ -90,4 +119,44 @@ func TestReplicateManager_CreateReplicator(t *testing.T) {
 	replicator1, exists := manager.replicators[buildReplicatorKey(key, 0)]
 	assert.True(t, exists)
 	assert.NotNil(t, replicator1)
+}
+
+func TestReplicateManagerRemoveReplicatorDeletesLagSeries(t *testing.T) {
+	source, target := "remove-source", "remove-target"
+	channel := newTestReplicateChannel("remove-key", 10, source, target)
+	manager := NewReplicateManager()
+	repKey := buildReplicatorKey(channel.Key, channel.ModRevision)
+	replicator := &testReplicator{}
+	manager.replicators[repKey] = replicator
+	manager.replicatorChannels[repKey] = channel
+	replicatestream.InitLastReplicatedTimeTick(
+		channel.Value,
+		tsoutil.ComposeTSByTime(time.Now(), 0),
+	)
+
+	manager.RemoveReplicator(channel.Key, channel.ModRevision)
+
+	assert.True(t, replicator.stopped)
+	assert.False(t, metrics.CDCLastReplicatedTimeTick.DeleteLabelValues(source, target))
+}
+
+func TestRemoveOutdatedReplicatorsKeepsLiveLagSeries(t *testing.T) {
+	source, target := "replace-source", "replace-target"
+	oldChannel := newTestReplicateChannel("replace-key", 10, source, target)
+	newChannel := newTestReplicateChannel("replace-key", 11, source, target)
+	manager := NewReplicateManager()
+	oldKey := buildReplicatorKey(oldChannel.Key, oldChannel.ModRevision)
+	oldReplicator := &testReplicator{}
+	manager.replicators[oldKey] = oldReplicator
+	manager.replicatorChannels[oldKey] = oldChannel
+
+	newValue := tsoutil.ComposeTSByTime(time.Now(), 0)
+	replicatestream.InitLastReplicatedTimeTick(newChannel.Value, newValue)
+	defer metrics.CDCLastReplicatedTimeTick.DeleteLabelValues(source, target)
+
+	manager.RemoveOutdatedReplicators([]*meta.ReplicateChannel{newChannel})
+
+	assert.True(t, oldReplicator.stopped)
+	got := testutil.ToFloat64(metrics.CDCLastReplicatedTimeTick.WithLabelValues(source, target))
+	assert.InDelta(t, tsoutil.PhysicalTimeSeconds(newValue), got, 1)
 }

--- a/internal/cdc/replication/replicatestream/metrics.go
+++ b/internal/cdc/replication/replicatestream/metrics.go
@@ -54,11 +54,41 @@ func NewReplicateMetrics(replicateInfo *streamingpb.ReplicatePChannelMeta) Repli
 	}
 }
 
-func (m *replicateMetrics) UpdateLastReplicatedTimeTick(ts uint64) {
+func setLastReplicatedTimeTick(source, target string, ts uint64) {
 	metrics.CDCLastReplicatedTimeTick.WithLabelValues(
+		source,
+		target,
+	).Set(tsoutil.PhysicalTimeSeconds(ts))
+}
+
+func (m *replicateMetrics) UpdateLastReplicatedTimeTick(ts uint64) {
+	setLastReplicatedTimeTick(
 		m.replicateInfo.GetSourceChannelName(),
 		m.replicateInfo.GetTargetChannelName(),
-	).Set(tsoutil.PhysicalTimeSeconds(ts))
+		ts,
+	)
+}
+
+// InitLastReplicatedTimeTick initializes the last replicated time tick gauge
+// from a known checkpoint. Callers may seed it conservatively and later
+// overwrite it with the target-confirmed position.
+func InitLastReplicatedTimeTick(info *streamingpb.ReplicatePChannelMeta, ts uint64) {
+	if info == nil || ts == 0 {
+		return
+	}
+	setLastReplicatedTimeTick(info.GetSourceChannelName(), info.GetTargetChannelName(), ts)
+}
+
+// DeleteLastReplicatedTimeTick deletes the lag series for a replication task
+// that has been genuinely removed.
+func DeleteLastReplicatedTimeTick(info *streamingpb.ReplicatePChannelMeta) {
+	if info == nil {
+		return
+	}
+	metrics.CDCLastReplicatedTimeTick.DeleteLabelValues(
+		info.GetSourceChannelName(),
+		info.GetTargetChannelName(),
+	)
 }
 
 func (m *replicateMetrics) StartReplicate(msg message.ImmutableMessage) {
@@ -134,6 +164,10 @@ func (m *replicateMetrics) OnConnect() {
 	).Inc()
 }
 
+// OnClose deletes the connection series of the target cluster.
+// CDCStreamRPCConnections is labeled by (target_cluster, status) only, so
+// this removes the series shared by every channel replicating to that
+// cluster, not just the ones owned by this stream instance.
 func (m *replicateMetrics) OnClose() {
 	metrics.CDCStreamRPCConnections.DeletePartialMatch(prometheus.Labels{
 		metrics.CDCLabelTargetCluster: m.replicateInfo.GetTargetCluster().GetClusterId(),

--- a/internal/cdc/replication/replicatestream/metrics_test.go
+++ b/internal/cdc/replication/replicatestream/metrics_test.go
@@ -1,0 +1,92 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package replicatestream
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/pkg/v2/metrics"
+	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/tsoutil"
+)
+
+func newTestReplicateInfo(source, target string) *streamingpb.ReplicatePChannelMeta {
+	return &streamingpb.ReplicatePChannelMeta{
+		SourceChannelName: source,
+		TargetChannelName: target,
+		TargetCluster: &commonpb.MilvusCluster{
+			ClusterId: "test-cluster",
+		},
+	}
+}
+
+// TestInitLastReplicatedTimeTick verifies that seeding from the resume
+// checkpoint reports the real backlog (checkpoint physical time), so a
+// restarted CDC pod does not read as 0.
+func TestInitLastReplicatedTimeTick(t *testing.T) {
+	source, target := "TestInit-source", "TestInit-target"
+	defer metrics.CDCLastReplicatedTimeTick.DeleteLabelValues(source, target)
+
+	// A checkpoint 300s in the past -> the gauge reports that physical time,
+	// which against wall-clock now is a ~300s backlog, not 0.
+	checkpoint := tsoutil.ComposeTSByTime(time.Now().Add(-300*time.Second), 0)
+	InitLastReplicatedTimeTick(newTestReplicateInfo(source, target), checkpoint)
+
+	got := testutil.ToFloat64(metrics.CDCLastReplicatedTimeTick.WithLabelValues(source, target))
+	assert.InDelta(t, tsoutil.PhysicalTimeSeconds(checkpoint), got, 1)
+	assert.InDelta(t, 300, float64(time.Now().Unix())-got, 5)
+}
+
+func TestInitLastReplicatedTimeTickIgnoresZero(t *testing.T) {
+	source, target := "TestInitZero-source", "TestInitZero-target"
+
+	InitLastReplicatedTimeTick(newTestReplicateInfo(source, target), 0)
+
+	assert.False(t, metrics.CDCLastReplicatedTimeTick.DeleteLabelValues(source, target))
+}
+
+func TestInitLastReplicatedTimeTickIgnoresNilInfo(t *testing.T) {
+	assert.NotPanics(t, func() {
+		InitLastReplicatedTimeTick(nil, tsoutil.ComposeTSByTime(time.Now(), 0))
+	})
+}
+
+func TestReplicateMetricsOnCloseKeepsLastReplicatedSeries(t *testing.T) {
+	source, target := "TestOnClose-source", "TestOnClose-target"
+
+	m := NewReplicateMetrics(newTestReplicateInfo(source, target))
+	m.UpdateLastReplicatedTimeTick(tsoutil.ComposeTSByTime(time.Now(), 0))
+
+	m.OnClose()
+
+	assert.True(t, metrics.CDCLastReplicatedTimeTick.DeleteLabelValues(source, target))
+}
+
+func TestDeleteLastReplicatedTimeTickDeletesExactSeries(t *testing.T) {
+	source, target := "TestDelete-source", "TestDelete-target"
+	info := newTestReplicateInfo(source, target)
+	InitLastReplicatedTimeTick(info, tsoutil.ComposeTSByTime(time.Now(), 0))
+
+	DeleteLastReplicatedTimeTick(info)
+
+	assert.False(t, metrics.CDCLastReplicatedTimeTick.DeleteLabelValues(source, target))
+}

--- a/internal/cdc/util/util.go
+++ b/internal/cdc/util/util.go
@@ -7,6 +7,30 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/replicateutil"
 )
 
+// IsStaleTopologyChange reports whether an AlterReplicateConfig message predates
+// the replication task it is being evaluated against.
+//
+// A replicator does not necessarily start reading at the live position: it
+// resumes from the checkpoint reported by the target cluster, which after a
+// `restore secondary` is the position the backup was taken at. Replaying from
+// there walks over every topology change made since — including ones that
+// removed this very edge before it was re-created — and those describe a past
+// state, not an instruction for the task replaying them.
+//
+// The initialized checkpoint carries the time tick of the AlterReplicateConfig
+// that created the task, so anything at or before it predates the task itself.
+// A zero value means the field is absent (task written by an older version), in
+// which case no ordering is enforced and the previous behaviour is kept.
+func IsStaleTopologyChange(msg message.ImmutableMessage, replicateInfo *streamingpb.ReplicatePChannelMeta) bool {
+	initTimeTick := replicateInfo.GetInitializedCheckpoint().GetTimeTick()
+	return initTimeTick != 0 && msg.TimeTick() <= initTimeTick
+}
+
+// IsReplicationRemovedByAlterReplicateConfigMessage reports whether the given
+// AlterReplicateConfig message removes the replication task described by
+// replicateInfo, i.e. whether its topology still carries the task's
+// `current -> target` edge. A message that predates the task is not an
+// instruction for it and never removes it.
 func IsReplicationRemovedByAlterReplicateConfigMessage(msg message.ImmutableMessage, replicateInfo *streamingpb.ReplicatePChannelMeta) (replicationRemoved bool) {
 	prcMsg := message.MustAsImmutableAlterReplicateConfigMessageV2(msg)
 	header := prcMsg.Header()
@@ -14,6 +38,10 @@ func IsReplicationRemovedByAlterReplicateConfigMessage(msg message.ImmutableMess
 	// Check ignore field - if true, this message should be ignored
 	// This is used for incomplete switchover messages that should be ignored after force promote
 	if header.Ignore {
+		return false
+	}
+
+	if IsStaleTopologyChange(msg, replicateInfo) {
 		return false
 	}
 

--- a/internal/cdc/util/util_test.go
+++ b/internal/cdc/util/util_test.go
@@ -1,0 +1,158 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/apache/pulsar-client-go/pulsar"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	pulsar2 "github.com/milvus-io/milvus/pkg/v2/streaming/walimpls/impls/pulsar"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+const (
+	testCurrentCluster = "current-cluster"
+	testTargetCluster  = "target-cluster"
+	testSourceChannel  = "current-cluster-rootcoord-dml_0"
+	testTargetChannel  = "target-cluster-rootcoord-dml_0"
+)
+
+// task builds the replication task metadata under test. initTimeTick is the
+// time tick of the AlterReplicateConfig that created it; zero means the field
+// is absent, as it is for tasks written by an older version.
+func task(initTimeTick uint64) *streamingpb.ReplicatePChannelMeta {
+	meta := &streamingpb.ReplicatePChannelMeta{
+		SourceChannelName: testSourceChannel,
+		TargetChannelName: testTargetChannel,
+		TargetCluster:     &commonpb.MilvusCluster{ClusterId: testTargetCluster},
+	}
+	if initTimeTick != 0 {
+		meta.InitializedCheckpoint = &commonpb.ReplicateCheckpoint{
+			ClusterId: testCurrentCluster,
+			Pchannel:  testSourceChannel,
+			TimeTick:  initTimeTick,
+		}
+	}
+	return meta
+}
+
+// alterMsg builds an AlterReplicateConfig message at the given time tick. When
+// withEdge is true the topology still carries current -> target; otherwise the
+// current cluster stands alone, which is what a detach broadcasts.
+func alterMsg(timeTick uint64, withEdge bool, ignore bool) message.ImmutableMessage {
+	clusters := []*commonpb.MilvusCluster{
+		{
+			ClusterId:       testCurrentCluster,
+			ConnectionParam: &commonpb.ConnectionParam{Uri: "localhost:19530"},
+			Pchannels:       []string{testSourceChannel},
+		},
+	}
+	var topology []*commonpb.CrossClusterTopology
+	if withEdge {
+		clusters = append(clusters, &commonpb.MilvusCluster{
+			ClusterId:       testTargetCluster,
+			ConnectionParam: &commonpb.ConnectionParam{Uri: "localhost:19531"},
+			Pchannels:       []string{testTargetChannel},
+		})
+		topology = []*commonpb.CrossClusterTopology{
+			{SourceClusterId: testCurrentCluster, TargetClusterId: testTargetCluster},
+		}
+	}
+
+	return message.NewAlterReplicateConfigMessageBuilderV2().
+		WithHeader(&message.AlterReplicateConfigMessageHeader{
+			ReplicateConfiguration: &commonpb.ReplicateConfiguration{
+				Clusters:             clusters,
+				CrossClusterTopology: topology,
+			},
+			Ignore: ignore,
+		}).
+		WithBody(&message.AlterReplicateConfigMessageBody{}).
+		WithAllVChannel().
+		MustBuildMutable().
+		WithLastConfirmedUseMessageID().
+		WithTimeTick(timeTick).
+		IntoImmutableMessage(pulsar2.NewPulsarID(pulsar.EarliestMessageID()))
+}
+
+func withCurrentCluster(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().CommonCfg.ClusterPrefix.Key, testCurrentCluster)
+	t.Cleanup(func() { paramtable.Get().Reset(paramtable.Get().CommonCfg.ClusterPrefix.Key) })
+}
+
+func TestIsStaleTopologyChange(t *testing.T) {
+	// The task was created by the configuration appended at time tick 100.
+	const created = uint64(100)
+
+	t.Run("older than the task is stale", func(t *testing.T) {
+		assert.True(t, IsStaleTopologyChange(alterMsg(created-1, false, false), task(created)))
+	})
+
+	t.Run("the message that created the task is stale", func(t *testing.T) {
+		// Its own creating message carries no instruction for it either.
+		assert.True(t, IsStaleTopologyChange(alterMsg(created, true, false), task(created)))
+	})
+
+	t.Run("newer than the task is current", func(t *testing.T) {
+		assert.False(t, IsStaleTopologyChange(alterMsg(created+1, false, false), task(created)))
+	})
+
+	t.Run("no initialized time tick enforces no ordering", func(t *testing.T) {
+		// Tasks written by an older version keep the previous behaviour.
+		assert.False(t, IsStaleTopologyChange(alterMsg(1, false, false), task(0)))
+	})
+}
+
+func TestIsReplicationRemovedByAlterReplicateConfigMessage(t *testing.T) {
+	withCurrentCluster(t)
+	const created = uint64(100)
+
+	t.Run("a current detach removes the replication", func(t *testing.T) {
+		assert.True(t, IsReplicationRemovedByAlterReplicateConfigMessage(
+			alterMsg(created+10, false, false), task(created)))
+	})
+
+	t.Run("a current configuration that keeps the edge does not", func(t *testing.T) {
+		assert.False(t, IsReplicationRemovedByAlterReplicateConfigMessage(
+			alterMsg(created+10, true, false), task(created)))
+	})
+
+	// The regression: replaying the WAL from a checkpoint that predates the task
+	// walks over topology changes that removed this edge before it was
+	// re-created. Acting on them makes the replicator delete itself moments
+	// after starting.
+	t.Run("a detach that predates the task does not remove it", func(t *testing.T) {
+		assert.False(t, IsReplicationRemovedByAlterReplicateConfigMessage(
+			alterMsg(created-10, false, false), task(created)))
+	})
+
+	t.Run("a detach predating a task with no initialized time tick still removes it", func(t *testing.T) {
+		assert.True(t, IsReplicationRemovedByAlterReplicateConfigMessage(
+			alterMsg(1, false, false), task(0)))
+	})
+
+	t.Run("an ignored message never removes the replication", func(t *testing.T) {
+		assert.False(t, IsReplicationRemovedByAlterReplicateConfigMessage(
+			alterMsg(created+10, false, true), task(created)))
+	})
+}

--- a/internal/distributed/streaming/replicate_service.go
+++ b/internal/distributed/streaming/replicate_service.go
@@ -120,6 +120,9 @@ func (s replicateService) overwriteReplicateMessage(ctx context.Context, msg mes
 	if err != nil {
 		return nil, err
 	}
+	if cfg == nil {
+		return nil, status.NewReplicateViolation("cluster has no replicate configuration, cannot receive replicate message")
+	}
 
 	// Get target vchannel on current cluster that should be written to
 	currentCluster := cfg.GetCluster(s.clusterID)

--- a/internal/streamingcoord/client/assignment/assignment_test.go
+++ b/internal/streamingcoord/client/assignment/assignment_test.go
@@ -378,21 +378,59 @@ func TestWatcher_GetLatestReplicateConfiguration(t *testing.T) {
 		assert.NoError(t, <-errCh)
 	})
 
-	t.Run("blocks_when_version_set_but_config_nil", func(t *testing.T) {
+	t.Run("returns_nil_when_version_set_but_config_nil", func(t *testing.T) {
+		// A cluster that has never been given a replicate configuration reports a
+		// nil config in its assignment. That is an answer, not a missing update:
+		// the call must return promptly with a nil helper instead of blocking
+		// until the deadline.
 		w := newWatcher()
 
-		// Update with valid version but nil config
 		w.Update(types.VersionedStreamingNodeAssignments{
 			Version:               typeutil.VersionInt64Pair{Global: 1, Local: 1},
 			Assignments:           map[int64]types.StreamingNodeAssignment{},
 			ReplicateConfigHelper: nil,
 		})
 
-		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		_, err := w.GetLatestReplicateConfiguration(ctx)
-		assert.ErrorIs(t, err, context.DeadlineExceeded)
+		config, err := w.GetLatestReplicateConfiguration(ctx)
+		assert.NoError(t, err)
+		assert.Nil(t, config)
+		// The nil helper stays usable for the read accessors.
+		assert.Nil(t, config.GetReplicateConfiguration())
+		assert.Nil(t, config.GetCluster("any"))
+	})
+
+	t.Run("blocks_until_first_assignment_arrives", func(t *testing.T) {
+		// With no assignment received at all the call still blocks: that is a
+		// genuine "not known yet", unlike a received-but-nil configuration.
+		w := newWatcher()
+
+		resultCh := make(chan error, 1)
+		go func() {
+			_, err := w.GetLatestReplicateConfiguration(context.Background())
+			resultCh <- err
+		}()
+
+		select {
+		case <-resultCh:
+			t.Fatal("GetLatestReplicateConfiguration should block before the first assignment")
+		case <-time.After(50 * time.Millisecond):
+		}
+
+		w.Update(types.VersionedStreamingNodeAssignments{
+			Version:               typeutil.VersionInt64Pair{Global: 1, Local: 1},
+			Assignments:           map[int64]types.StreamingNodeAssignment{},
+			ReplicateConfigHelper: nil,
+		})
+
+		select {
+		case err := <-resultCh:
+			assert.NoError(t, err)
+		case <-time.After(time.Second):
+			t.Fatal("GetLatestReplicateConfiguration should have returned")
+		}
 	})
 
 	t.Run("returns_error_on_context_cancel", func(t *testing.T) {

--- a/internal/streamingcoord/client/assignment/watcher.go
+++ b/internal/streamingcoord/client/assignment/watcher.go
@@ -57,10 +57,15 @@ func (w *watcher) GetLatestDiscover(ctx context.Context) (*types.VersionedStream
 	return &last, nil
 }
 
+// GetLatestReplicateConfiguration returns the replicate configuration of the
+// latest assignment. It waits until an assignment has been received, and only
+// for that: a nil ConfigHelper is a valid answer meaning "this cluster has no
+// replication configured", which is the steady state of every cluster that has
+// never been given one. Waiting for a non-nil helper would block forever there
+// and surface as DEADLINE_EXCEEDED, indistinguishable from an unhealthy cluster.
 func (w *watcher) GetLatestReplicateConfiguration(ctx context.Context) (*replicateutil.ConfigHelper, error) {
 	w.cond.L.Lock()
-	for (w.lastVersionedAssignment.Version.Global == -1 && w.lastVersionedAssignment.Version.Local == -1) ||
-		w.lastVersionedAssignment.ReplicateConfigHelper == nil {
+	for w.lastVersionedAssignment.Version.Global == -1 && w.lastVersionedAssignment.Version.Local == -1 {
 		if err := w.cond.Wait(ctx); err != nil {
 			return nil, err
 		}

--- a/internal/streamingcoord/server/balancer/channel/pchannel_stats.go
+++ b/internal/streamingcoord/server/balancer/channel/pchannel_stats.go
@@ -35,6 +35,21 @@ func (pm *PchannelStatsManager) WatchAtChannelCountChanged() *syncutil.Versioned
 	return pm.n.Listen(syncutil.VersionedListenAtEarliest)
 }
 
+// PChannels returns pchannels that currently have vchannels.
+func (pm *PchannelStatsManager) PChannels() []string {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	pchannels := make([]string, 0, len(pm.stats))
+	for id, stat := range pm.stats {
+		if stat.VChannelCount() == 0 {
+			continue
+		}
+		pchannels = append(pchannels, id.Name)
+	}
+	return pchannels
+}
+
 // GetPChannelStats returns the stats of the pchannel.
 func (pm *PchannelStatsManager) GetPChannelStats(channelID ChannelID) *pchannelStats {
 	pm.mu.Lock()

--- a/internal/streamingcoord/server/balancer/channel/pchannel_test.go
+++ b/internal/streamingcoord/server/balancer/channel/pchannel_test.go
@@ -67,6 +67,23 @@ func TestPChannelAvailableInReplication(t *testing.T) {
 	assert.False(t, pchannel.AvailableInReplication())
 }
 
+func TestPChannelStatsManagerPChannels(t *testing.T) {
+	ResetStaticPChannelStatsManager()
+	RecoverPChannelStatsManager([]string{
+		"by-dev-rootcoord-dml_0_100v0",
+		"by-dev-rootcoord-dml_3_101v0",
+	})
+
+	stats := StaticPChannelStatsManager.Get()
+	assert.ElementsMatch(t, []string{
+		"by-dev-rootcoord-dml_0",
+		"by-dev-rootcoord-dml_3",
+	}, stats.PChannels())
+
+	stats.RemoveVChannel("by-dev-rootcoord-dml_0_100v0")
+	assert.ElementsMatch(t, []string{"by-dev-rootcoord-dml_3"}, stats.PChannels())
+}
+
 func TestPChannel(t *testing.T) {
 	ResetStaticPChannelStatsManager()
 	RecoverPChannelStatsManager([]string{})

--- a/internal/streamingcoord/server/server.go
+++ b/internal/streamingcoord/server/server.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/balance"
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/channel"
 	_ "github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/policy" // register the balancer policy
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/broadcast"
@@ -50,8 +51,8 @@ func (s *Server) initBasicComponent(ctx context.Context) (err error) {
 	futures = append(futures, conc.Go(func() (struct{}, error) {
 		s.logger.Info("start recovery balancer...")
 		// Create a provider that reads channel names from configuration
-		// and polls for dynamic changes.
-		provider := util.NewConfigChannelProvider()
+		// and collection metadata recovered by RootCoord.
+		provider := util.NewConfigChannelProviderWithPChannelStatsManager(channel.StaticPChannelStatsManager)
 		balancer, err := balancer.RecoverBalancer(ctx, provider)
 		if err != nil {
 			provider.Close()

--- a/internal/util/streamingutil/util/config_channel_provider.go
+++ b/internal/util/streamingutil/util/config_channel_provider.go
@@ -1,7 +1,10 @@
 package util
 
 import (
+	"fmt"
 	"sort"
+	"strconv"
+	"strings"
 
 	"go.uber.org/zap"
 
@@ -21,12 +24,14 @@ type ConfigChannelProvider struct {
 	ch              chan []string
 	trigger         chan struct{}
 	handler         config.EventHandler
+	statsReady      <-chan struct{}
+	getPChannels    func() []string
 }
 
-// NewConfigChannelProvider creates a ConfigChannelProvider that reads the
-// current set of topics from configuration and watches for config changes
-// to detect any newly added topics.
-func NewConfigChannelProvider() *ConfigChannelProvider {
+// NewConfigChannelProviderWithPChannelStatsManager creates a ConfigChannelProvider
+// that reads channel names from configuration and also discovers pchannels
+// recovered from collection metadata.
+func NewConfigChannelProviderWithPChannelStatsManager[T interface{ PChannels() []string }](statsFuture *syncutil.Future[T]) *ConfigChannelProvider {
 	currentTopics := GetAllTopicsFromConfiguration()
 	initial := currentTopics.Collect()
 	sort.Strings(initial)
@@ -37,6 +42,10 @@ func NewConfigChannelProvider() *ConfigChannelProvider {
 		initialChannels: initial,
 		ch:              make(chan []string),
 		trigger:         make(chan struct{}, 1),
+	}
+	p.statsReady = statsFuture.Done()
+	p.getPChannels = func() []string {
+		return statsFuture.Get().PChannels()
 	}
 	p.handler = config.NewHandler("config_channel_provider", func(event *config.Event) {
 		// Non-blocking send to coalesce rapid config changes.
@@ -72,18 +81,32 @@ func (p *ConfigChannelProvider) Close() {
 // background is the single goroutine that processes config change triggers.
 func (p *ConfigChannelProvider) background() {
 	defer p.notifier.Finish(struct{}{})
+	statsReady := p.statsReady
 	for {
 		select {
 		case <-p.trigger:
-			p.onConfigChange()
+			p.onConfigChanged()
+		case <-statsReady:
+			statsReady = nil
+			p.onPChannelStatsReady()
 		case <-p.notifier.Context().Done():
 			return
 		}
 	}
 }
 
-func (p *ConfigChannelProvider) onConfigChange() {
-	current := GetAllTopicsFromConfiguration()
+func (p *ConfigChannelProvider) onConfigChanged() {
+	p.notifyNewChannels(GetAllTopicsFromConfiguration(), "ConfigChannelProvider detected new channels")
+}
+
+func (p *ConfigChannelProvider) onPChannelStatsReady() {
+	p.notifyNewChannels(
+		getAllTopicsFromConfigurationAndPChannels(p.getPChannels()),
+		"ConfigChannelProvider detected new channels from pchannel stats",
+	)
+}
+
+func (p *ConfigChannelProvider) notifyNewChannels(current typeutil.Set[string], logMessage string) {
 	var newChannels []string
 	current.Range(func(name string) bool {
 		if !p.known.Contain(name) {
@@ -94,11 +117,50 @@ func (p *ConfigChannelProvider) onConfigChange() {
 	})
 	if len(newChannels) > 0 {
 		sort.Strings(newChannels)
-		log.Info("ConfigChannelProvider detected new channels",
-			zap.Strings("newChannels", newChannels))
+		log.Info(logMessage, zap.Strings("newChannels", newChannels))
 		select {
 		case p.ch <- newChannels:
 		case <-p.notifier.Context().Done():
 		}
 	}
+}
+
+func getAllTopicsFromConfigurationAndPChannels(pchannels []string) typeutil.Set[string] {
+	current := GetAllTopicsFromConfiguration()
+	if paramtable.Get().CommonCfg.PreCreatedTopicEnabled.GetAsBool() {
+		for _, pchannel := range pchannels {
+			if !current.Contain(pchannel) {
+				log.Warn("skip pchannel not in pre-created topic list",
+					zap.String("pchannel", pchannel))
+			}
+		}
+		return current
+	}
+
+	prefix := paramtable.Get().CommonCfg.RootCoordDml.GetValue()
+	for _, pchannel := range pchannels {
+		if idx, ok := parseConfiguredDMLChannelIndex(pchannel, prefix); ok {
+			for i := 0; i <= idx; i++ {
+				current.Insert(fmt.Sprintf("%s_%d", prefix, i))
+			}
+			continue
+		}
+		current.Insert(pchannel)
+	}
+	return current
+}
+
+func parseConfiguredDMLChannelIndex(pchannel string, prefix string) (int, bool) {
+	suffix, ok := strings.CutPrefix(pchannel, prefix+"_")
+	if !ok || suffix == "" {
+		return 0, false
+	}
+	idx, err := strconv.Atoi(suffix)
+	if err != nil {
+		return 0, false
+	}
+	if idx < 0 || fmt.Sprintf("%s_%d", prefix, idx) != pchannel {
+		return 0, false
+	}
+	return idx, true
 }

--- a/internal/util/streamingutil/util/config_channel_provider_test.go
+++ b/internal/util/streamingutil/util/config_channel_provider_test.go
@@ -7,13 +7,15 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/syncutil"
 )
 
 func TestConfigChannelProvider_GetInitialChannels(t *testing.T) {
 	paramtable.Init()
-	provider := NewConfigChannelProvider()
+	provider := newTestConfigChannelProvider()
 	defer provider.Close()
 
 	initial := provider.GetInitialChannels()
@@ -29,7 +31,7 @@ func TestConfigChannelProvider_DetectsNewChannels(t *testing.T) {
 	paramtable.Init()
 
 	originalNum := paramtable.Get().RootCoordCfg.DmlChannelNum.GetValue()
-	provider := NewConfigChannelProvider()
+	provider := newTestConfigChannelProvider()
 	defer provider.Close()
 
 	initial := provider.GetInitialChannels()
@@ -47,11 +49,41 @@ func TestConfigChannelProvider_DetectsNewChannels(t *testing.T) {
 	}
 }
 
+func TestConfigChannelProvider_DetectsChannelsFromPChannelStats(t *testing.T) {
+	paramtable.Init()
+
+	originalNum := paramtable.Get().RootCoordCfg.DmlChannelNum.GetValue()
+	originalDML := paramtable.Get().CommonCfg.RootCoordDml.GetValue()
+	paramtable.Get().Save(paramtable.Get().RootCoordCfg.DmlChannelNum.Key, "2")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.RootCoordDml.Key, "rootcoord-dml")
+	defer paramtable.Get().Save(paramtable.Get().RootCoordCfg.DmlChannelNum.Key, originalNum)
+	defer paramtable.Get().Save(paramtable.Get().CommonCfg.RootCoordDml.Key, originalDML)
+
+	statsFuture := syncutil.NewFuture[*testPChannelStats]()
+	provider := NewConfigChannelProviderWithPChannelStatsManager(statsFuture)
+	defer provider.Close()
+
+	prefix := paramtable.Get().CommonCfg.RootCoordDml.GetValue()
+	statsFuture.Set(&testPChannelStats{
+		pchannels: []string{fmt.Sprintf("%s_3", prefix)},
+	})
+
+	select {
+	case newChannels := <-provider.NewIncomingChannels():
+		require.ElementsMatch(t, []string{
+			fmt.Sprintf("%s_2", prefix),
+			fmt.Sprintf("%s_3", prefix),
+		}, newChannels)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for pchannel stats notification")
+	}
+}
+
 func TestConfigChannelProvider_NoDuplicates(t *testing.T) {
 	paramtable.Init()
 
 	originalNum := paramtable.Get().RootCoordCfg.DmlChannelNum.GetValue()
-	provider := NewConfigChannelProvider()
+	provider := newTestConfigChannelProvider()
 	defer provider.Close()
 
 	// Trigger a config change with the same value, should not produce new channels.
@@ -67,7 +99,7 @@ func TestConfigChannelProvider_NoDuplicates(t *testing.T) {
 
 func TestConfigChannelProvider_CloseStopsWatching(t *testing.T) {
 	paramtable.Init()
-	provider := NewConfigChannelProvider()
+	provider := newTestConfigChannelProvider()
 	provider.Close()
 
 	_, ok := <-provider.NewIncomingChannels()
@@ -78,7 +110,7 @@ func TestConfigChannelProvider_CloseUnblocksInFlightSend(t *testing.T) {
 	paramtable.Init()
 
 	originalNum := paramtable.Get().RootCoordCfg.DmlChannelNum.GetValue()
-	provider := NewConfigChannelProvider()
+	provider := newTestConfigChannelProvider()
 
 	initial := provider.GetInitialChannels()
 	initialCount := len(initial)
@@ -107,4 +139,57 @@ func TestConfigChannelProvider_CloseUnblocksInFlightSend(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("Close() deadlocked while background goroutine was blocked on channel send")
 	}
+}
+
+func TestGetAllTopicsFromConfigurationAndPChannelsKeepsNonDMLChannels(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().RootCoordCfg.DmlChannelNum.Key, "1")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.RootCoordDml.Key, "rootcoord-dml")
+	defer paramtable.Get().Reset(paramtable.Get().RootCoordCfg.DmlChannelNum.Key)
+	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.RootCoordDml.Key)
+
+	channels := getAllTopicsFromConfigurationAndPChannels([]string{"custom-pchannel"})
+
+	assert.True(t, channels.Contain("custom-pchannel"))
+	assert.True(t, channels.Contain(fmt.Sprintf("%s_0", paramtable.Get().CommonCfg.RootCoordDml.GetValue())))
+}
+
+func TestGetAllTopicsFromConfigurationAndPChannelsKeepsNonCanonicalDMLNames(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().RootCoordCfg.DmlChannelNum.Key, "1")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.RootCoordDml.Key, "rootcoord-dml")
+	defer paramtable.Get().Reset(paramtable.Get().RootCoordCfg.DmlChannelNum.Key)
+	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.RootCoordDml.Key)
+
+	prefix := paramtable.Get().CommonCfg.RootCoordDml.GetValue()
+	channels := getAllTopicsFromConfigurationAndPChannels([]string{
+		fmt.Sprintf("%s_3", prefix),
+		fmt.Sprintf("%s_-1", prefix),
+		fmt.Sprintf("%s_007", prefix),
+		fmt.Sprintf("%s_+7", prefix),
+	})
+
+	assert.True(t, channels.Contain(fmt.Sprintf("%s_0", prefix)))
+	assert.True(t, channels.Contain(fmt.Sprintf("%s_1", prefix)))
+	assert.True(t, channels.Contain(fmt.Sprintf("%s_2", prefix)))
+	assert.True(t, channels.Contain(fmt.Sprintf("%s_3", prefix)))
+	assert.True(t, channels.Contain(fmt.Sprintf("%s_-1", prefix)))
+	assert.True(t, channels.Contain(fmt.Sprintf("%s_007", prefix)))
+	assert.True(t, channels.Contain(fmt.Sprintf("%s_+7", prefix)))
+	assert.False(t, channels.Contain(fmt.Sprintf("%s_4", prefix)))
+	assert.False(t, channels.Contain(fmt.Sprintf("%s_7", prefix)))
+}
+
+type testPChannelStats struct {
+	pchannels []string
+}
+
+func (s *testPChannelStats) PChannels() []string {
+	return append([]string(nil), s.pchannels...)
+}
+
+func newTestConfigChannelProvider() *ConfigChannelProvider {
+	statsFuture := syncutil.NewFuture[*testPChannelStats]()
+	statsFuture.Set(&testPChannelStats{})
+	return NewConfigChannelProviderWithPChannelStatsManager(statsFuture)
 }

--- a/pkg/util/replicateutil/config_helper.go
+++ b/pkg/util/replicateutil/config_helper.go
@@ -127,6 +127,10 @@ type ConfigHelper struct {
 
 // GetReplicateConfiguration returns the replicate configuration of the graph.
 func (g *ConfigHelper) GetReplicateConfiguration() *commonpb.ReplicateConfiguration {
+	if g == nil {
+		// A nil helper is how "no replication configured" is represented.
+		return nil
+	}
 	return g.cfg
 }
 
@@ -144,6 +148,9 @@ func (g *ConfigHelper) IsJoinReplication() bool {
 
 // GetCluster returns the cluster from the graph.
 func (g *ConfigHelper) GetCluster(clusterID string) *MilvusCluster {
+	if g == nil {
+		return nil
+	}
 	return g.vs[clusterID]
 }
 


### PR DESCRIPTION
Cherry-picks onto `poc_2.6.17` for a customer running this branch, so a single image carries
everything they need. Two fixes are open upstream against master (#52728, #52687); the other
two are already on 2.6 and are brought over because they bear on the same area.

### milvus-io/milvus#52728 — CDC stops itself on a topology change that predates the task

A replicator resumes from the checkpoint the target cluster reports, which after
`milvus-backup restore secondary` is the position the backup was taken at. Replaying from
there walks over every topology change made since — including ones that removed this edge
before it was re-created — and those were acted on as if they were current:

- the replicator deleted its own `replicating-pchannel/` key and stopped 0.2 s after
  starting;
- the same message, forwarded to the secondary, made it a standalone primary again, dropping
  its replicate checkpoint.

Nothing recovered from it: the topology query still reported the edge (only the per-pchannel
task keys were gone), and re-applying the same configuration was short-circuited as unchanged
and returned success.

`ReplicatePChannelMeta.initialized_checkpoint` already carries the time tick of the
`AlterReplicateConfig` that created the task, so a message at or before it predates the task
and cannot be an instruction for it. It is now disregarded both when deciding to remove the
task and when deciding to forward the message. A task with no initialized time tick keeps the
previous behaviour.

### milvus-io/milvus#52687 — topology query on a cluster with no replication blocks

`GetReplicateConfiguration` never returned on a cluster that had never been given a replicate
configuration — the state of every freshly installed cluster. Such a cluster reports a nil
configuration, and the watcher's wait condition treated the resulting nil helper as "no
assignment received yet", so the call ran to the caller's deadline and surfaced as
`DEADLINE_EXCEEDED`, indistinguishable from an unhealthy cluster.

Wait only until an assignment has been received and return the possibly-nil helper; make the
`ConfigHelper` read accessors nil-receiver safe; reject replicate messages explicitly on a
cluster with no configuration, which previously could not be reached because the lookup
blocked first.

### Tests

Both upstream PRs' unit tests are included. `internal/cdc/util` had no test file before:

- ordering check in both directions, including the no-initialized-time-tick case that keeps
  the old behaviour;
- a current detach still removes the replication, a detach that predates the task does not;
- the consume loop neither forwards a stale topology change nor ends on it.

### Also picked from 2.6

- **#51144 — recover pchannels from collection metadata** (`51749e6f8d`). streamingcoord
  recovery adds WAL topics missing after stats initialization by reading them back from
  RootCoord collection metadata. Directly relevant here: the customer reinstalled the
  secondary, and recovery on a rebuilt cluster is exactly this path.
- **#51365 — correct the CDC replication lag metric** (`e6b5d9308d`). The replication lag
  series was wrong, so the one signal an operator would watch to notice replication had
  stopped could not be trusted. Given the failure this branch fixes is otherwise silent, the
  metric being correct matters.

Both apply cleanly; the only conflict was two tests appended to the same file, resolved by
keeping both.

`#50849 — ignore stale replicated txn body` was checked and is already present on
`poc_2.6.17`. `#51454 — skip unreplicable replicated ddl` is on master only and depends on
message-property changes that are not on 2.6; it is left for a regular cherry-pick to 2.6
rather than being adapted here.
