### PR TITLE
fix: [2.6] skip the "default" tlsMinVersion sentinel in the storage FFI properties

### DIFF
--- a/internal/storagev2/packed/ffi_common.go
+++ b/internal/storagev2/packed/ffi_common.go
@@ -144,10 +144,10 @@ func MakePropertiesFromStorageConfig(storageConfig *indexpb.StorageConfig, extra
 	keys = append(keys, PropertyFSRequestTimeoutMS)
 	values = append(values, strconv.FormatInt(storageConfig.GetRequestTimeoutMs(), 10))
 
-	// Add TLS min version
-	if storageConfig.GetSslTlsMinVersion() != "" {
+	// Add TLS min version (skip "default" — consistent with C++ layer filtering)
+	if v := storageConfig.GetSslTlsMinVersion(); v != "" && v != "default" {
 		keys = append(keys, PropertyFSTLSMinVersion)
-		values = append(values, storageConfig.GetSslTlsMinVersion())
+		values = append(values, v)
 	}
 
 	// Add CRC32C checksum


### PR DESCRIPTION
issue: #52730
related pr: #48476

`minio.ssl.tlsMinVersion` defaults to the sentinel string `"default"`, documented as "the SDK/runtime default is used". On this branch the two storage v3 write paths disagree about that sentinel:

- CGO path — `tlsMinVersionForStorage()` (`internal/storagev2/packed/util.go`) maps `"default"`/`""` to `""`, so the property is not passed down (#48028, backported as #48119).
- FFI path (`common.storage.useLoonFFI=true`) — `ffi_common.go` only filtered the empty string and forwarded the literal `"default"` to milvus-storage, whose property validator accepts only `""`, `1.0`, `1.1`, `1.2`, `1.3`. The whole property set is rejected, the packed writer fails and retries forever, so no write ever lands.

master and 3.0 already filter the sentinel — this patch is the same code as `ffi_common.go` on master, added there in #48476. The version on this branch came from #48332 instead and never got the filter.

Verified on a bare-metal standalone build of this line (kafka, RESTful v2, insert + flush + query), with `common.storage.useLoonFFI=true` and `minio.ssl.tlsMinVersion` left at its default:

| | before | after |
|---|---|---|
| `"default" ... is not in allowed set` | 9 | 0 |
| `pack_writer_v2` retry failures | 9 | 0 |
| flush | never completes | completes |

Setting `minio.ssl.tlsMinVersion: 1.2` explicitly was the only workaround before this patch.

Unit tests of the affected package pass before and after the change (the existing cases do not cover this path).
