### PR TITLE
fix: [poc_2.6.17] skip the "default" tlsMinVersion sentinel in the storage FFI properties

### DIFF
--- a/internal/storagev2/packed/ffi_common.go
+++ b/internal/storagev2/packed/ffi_common.go
@@ -144,10 +144,10 @@ func MakePropertiesFromStorageConfig(storageConfig *indexpb.StorageConfig, extra
 	keys = append(keys, PropertyFSRequestTimeoutMS)
 	values = append(values, strconv.FormatInt(storageConfig.GetRequestTimeoutMs(), 10))
 
-	// Add TLS min version
-	if storageConfig.GetSslTlsMinVersion() != "" {
+	// Add TLS min version (skip "default" — consistent with C++ layer filtering)
+	if v := storageConfig.GetSslTlsMinVersion(); v != "" && v != "default" {
 		keys = append(keys, PropertyFSTLSMinVersion)
-		values = append(values, storageConfig.GetSslTlsMinVersion())
+		values = append(values, v)
 	}
 
 	// Add CRC32C checksum


### PR DESCRIPTION
issue: #52730
pr: #52731
related pr: #48476

Same one-line fix as #52731 (branch `2.6`), applied to `poc_2.6.17`, which carries the same unfiltered code.

`minio.ssl.tlsMinVersion` defaults to the sentinel string `"default"`, documented as "the SDK/runtime default is used". The CGO path maps `"default"`/`""` to `""` via `tlsMinVersionForStorage()` (#48028 / #48119), but the FFI path (`common.storage.useLoonFFI=true`) forwarded the literal `"default"` to milvus-storage, whose property validator accepts only `""`, `1.0`, `1.1`, `1.2`, `1.3`. The property set is rejected, the packed writer retries forever and no write ever lands. master and 3.0 already filter the sentinel (#48476); this is that same code.

Verified on a bare-metal standalone build of this exact branch (kafka, RESTful v2, insert + flush + query), `common.storage.useLoonFFI=true`, `minio.ssl.tlsMinVersion` left at its default:

| | before | after |
|---|---|---|
| `"default" ... is not in allowed set` | 9 | 0 |
| `pack_writer_v2` retry failures | 9 | 0 |
| flush | never completes | completes |

Unit tests of the affected package pass before and after the change (the existing cases do not cover this path).
