### PR TITLE
test: fix flaky InvertedIndex.HasLackBinlogRows

### DIFF
--- a/internal/core/src/index/InvertedIndexTest.cpp
+++ b/internal/core/src/index/InvertedIndexTest.cpp
@@ -169,6 +169,8 @@ test_run() {
             default_value->set_float_data(20);
         } else if constexpr (std::is_same_v<double, T>) {
             default_value->set_double_data(20);
+        } else if constexpr (std::is_same_v<bool, T>) {
+            default_value->set_bool_data(true);
         }
     }
 


### PR DESCRIPTION
## Problem

`InvertedIndex.HasLackBinlogRows` (C++ UT) failed in branch CI `build-ut-ciloop` with:

```
InvertedIndexTest.cpp:312: Failure
Expected equality of these values:
  bitset[i]          Which is: 0
  s.find(20) != s.end()   Which is: true
```

## Root cause

The test's `test_run` template declares a default value for the `has_default_value_` case, but its type dispatch only sets `int8/16/32/64/float/double` and never sets `bool_data`. For the bool instantiation the "lack binlog rows" are therefore filled with the protobuf default `false` (via `CacheRawDataAndFillMissing` -> `FillFieldData`).

The `In`/`NotIn` assertions compare against `s.find(20)`, which for `T=bool` degrades to `s.find(true)` (int 20 -> bool true). So the expected value is "true is in the query set" while the actual filled default is `false`. The test only fails when the first 10 random bool values (`rand() % 2 == 0`) are all the same — roughly 0.2% of runs — which is why it is intermittent.

## Repro

Deterministically reproduced by seeding `rand()` so the first 10 bool values are all `true`: `InvertedIndexTest.cpp:312` failed 3/3 runs with the exact CI signature above.

## Fix

Set the bool default value explicitly so the filled value matches the assertion:

```cpp
} else if constexpr (std::is_same_v<bool, T>) {
    default_value->set_bool_data(true);
}
```

## Verification

- `InvertedIndex.HasLackBinlogRows` `--gtest_repeat=20`: 20/20 PASS
- `InvertedIndex.*` suite: 4/4 PASS

Signed-off-by: Li Liu <li.liu@zilliz.com>