### PR TITLE
fix: [poc_2.6.17] let a replicate configuration read from the cluster be written back

### DIFF
--- a/internal/streamingcoord/server/service/assignment.go
+++ b/internal/streamingcoord/server/service/assignment.go
@@ -79,6 +79,14 @@ func (s *assignmentServiceImpl) UpdateReplicateConfiguration(ctx context.Context
 		return s.handleForcePromote(ctx, config)
 	}
 
+	// Connection tokens are redacted whenever the configuration is read, so a
+	// caller that read it back cannot resend them. Take the stored ones before
+	// anything compares or validates this configuration.
+	config, err := s.fillRedactedConnectionTokens(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+
 	// check if the configuration is same.
 	// so even if current cluster is not primary, we can still make a idempotent success result.
 	if _, err := s.validateReplicateConfiguration(ctx, config); err != nil {
@@ -117,6 +125,22 @@ func (s *assignmentServiceImpl) UpdateReplicateConfiguration(ctx context.Context
 		return nil, err
 	}
 	return &streamingpb.UpdateReplicateConfigurationResponse{}, nil
+}
+
+// fillRedactedConnectionTokens replaces the redacted connection tokens of an
+// incoming configuration with the ones already stored for the same clusters.
+// Without it a configuration that was read back can never be written again: the
+// read redacts the tokens and the validator rejects the change.
+func (s *assignmentServiceImpl) fillRedactedConnectionTokens(ctx context.Context, config *commonpb.ReplicateConfiguration) (*commonpb.ReplicateConfiguration, error) {
+	balancer, err := balance.GetWithContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	latestAssignment, err := balancer.GetLatestChannelAssignment()
+	if err != nil {
+		return nil, err
+	}
+	return replicateutil.FillRedactedConnectionTokens(config, latestAssignment.ReplicateConfiguration), nil
 }
 
 // waitUntilPrimaryChangeOrConfigurationSame waits until the primary changes or the configuration is same.

--- a/pkg/util/replicateutil/sanitize.go
+++ b/pkg/util/replicateutil/sanitize.go
@@ -41,3 +41,46 @@ func SanitizeReplicateConfiguration(config *commonpb.ReplicateConfiguration) *co
 
 	return sanitized
 }
+
+// FillRedactedConnectionTokens returns a copy of incoming in which a cluster
+// with an empty connection token takes the token stored for the same cluster in
+// current.
+//
+// SanitizeReplicateConfiguration clears connection tokens on every read, so a
+// caller that reads the configuration, edits the topology and writes it back
+// cannot send a token it was never given. The validator requires connection
+// parameters to be unchanged, so without this the read-modify-write round trip
+// is always rejected with "connection_param.token cannot be changed", and
+// simply accepting the empty token would store it and erase the credential CDC
+// uses to reach the peer.
+//
+// A non-empty incoming token is left untouched, so an actual attempt to change
+// a token is still rejected by the validator.
+func FillRedactedConnectionTokens(incoming, current *commonpb.ReplicateConfiguration) *commonpb.ReplicateConfiguration {
+	if incoming == nil || current == nil {
+		return incoming
+	}
+
+	stored := make(map[string]string, len(current.GetClusters()))
+	for _, cluster := range current.GetClusters() {
+		if token := cluster.GetConnectionParam().GetToken(); token != "" {
+			stored[cluster.GetClusterId()] = token
+		}
+	}
+	if len(stored) == 0 {
+		return incoming
+	}
+
+	filled := proto.Clone(incoming).(*commonpb.ReplicateConfiguration)
+	for _, cluster := range filled.GetClusters() {
+		// A nil ConnectionParam is left alone: its uri is empty too, and that
+		// mismatch is reported on its own.
+		if cluster.GetConnectionParam() == nil || cluster.GetConnectionParam().GetToken() != "" {
+			continue
+		}
+		if token, ok := stored[cluster.GetClusterId()]; ok {
+			cluster.ConnectionParam.Token = token
+		}
+	}
+	return filled
+}

--- a/pkg/util/replicateutil/sanitize_test.go
+++ b/pkg/util/replicateutil/sanitize_test.go
@@ -158,3 +158,100 @@ func TestSanitizeReplicateConfiguration_PreservesClusterIDs(t *testing.T) {
 	assert.Equal(t, "token-a", config.Clusters[0].ConnectionParam.Token)
 	assert.Equal(t, "token-b", config.Clusters[1].ConnectionParam.Token)
 }
+
+func TestFillRedactedConnectionTokens(t *testing.T) {
+	current := &commonpb.ReplicateConfiguration{
+		Clusters: []*commonpb.MilvusCluster{
+			{
+				ClusterId:       "cluster-1",
+				ConnectionParam: &commonpb.ConnectionParam{Uri: "localhost:19530", Token: "secret-token-1"},
+				Pchannels:       []string{"channel-1"},
+			},
+			{
+				ClusterId:       "cluster-2",
+				ConnectionParam: &commonpb.ConnectionParam{Uri: "localhost:19531", Token: "secret-token-2"},
+				Pchannels:       []string{"channel-1"},
+			},
+		},
+	}
+
+	t.Run("redacted tokens are taken from the stored configuration", func(t *testing.T) {
+		incoming := SanitizeReplicateConfiguration(current)
+		filled := FillRedactedConnectionTokens(incoming, current)
+		assert.Equal(t, "secret-token-1", filled.Clusters[0].ConnectionParam.Token)
+		assert.Equal(t, "secret-token-2", filled.Clusters[1].ConnectionParam.Token)
+		// The caller's configuration is not modified.
+		assert.Empty(t, incoming.Clusters[0].ConnectionParam.Token)
+	})
+
+	t.Run("a token the caller supplied is left alone", func(t *testing.T) {
+		incoming := SanitizeReplicateConfiguration(current)
+		incoming.Clusters[0].ConnectionParam.Token = "a-different-token"
+		filled := FillRedactedConnectionTokens(incoming, current)
+		assert.Equal(t, "a-different-token", filled.Clusters[0].ConnectionParam.Token)
+		assert.Equal(t, "secret-token-2", filled.Clusters[1].ConnectionParam.Token)
+	})
+
+	t.Run("a cluster that is not in the stored configuration is left alone", func(t *testing.T) {
+		incoming := &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{
+					ClusterId:       "cluster-3",
+					ConnectionParam: &commonpb.ConnectionParam{Uri: "localhost:19532"},
+				},
+			},
+		}
+		filled := FillRedactedConnectionTokens(incoming, current)
+		assert.Empty(t, filled.Clusters[0].ConnectionParam.Token)
+	})
+
+	t.Run("nil arguments and empty stored tokens are passed through", func(t *testing.T) {
+		assert.Nil(t, FillRedactedConnectionTokens(nil, current))
+		incoming := SanitizeReplicateConfiguration(current)
+		assert.Same(t, incoming, FillRedactedConnectionTokens(incoming, nil))
+		assert.Same(t, incoming, FillRedactedConnectionTokens(incoming, SanitizeReplicateConfiguration(current)))
+	})
+
+	t.Run("a nil connection param is left alone", func(t *testing.T) {
+		incoming := &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{{ClusterId: "cluster-1"}},
+		}
+		filled := FillRedactedConnectionTokens(incoming, current)
+		assert.Nil(t, filled.Clusters[0].ConnectionParam)
+	})
+}
+
+// A configuration that was read back from the cluster must be writable again.
+// The read redacts the connection tokens, and the validator requires connection
+// parameters to be unchanged, so the two together used to make the
+// read-modify-write round trip impossible.
+func TestValidateConfigurationReadBackFromTheCluster(t *testing.T) {
+	current := createValidValidatorConfig()
+	pchannels := []string{"channel-1", "channel-2"}
+
+	t.Run("rejected without the tokens being restored", func(t *testing.T) {
+		incoming := SanitizeReplicateConfiguration(current)
+		err := NewReplicateConfigValidator(incoming, current, "cluster-1", pchannels).Validate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "connection_param.token cannot be changed")
+	})
+
+	t.Run("accepted once the tokens are restored", func(t *testing.T) {
+		incoming := FillRedactedConnectionTokens(SanitizeReplicateConfiguration(current), current)
+		assert.NoError(t, NewReplicateConfigValidator(incoming, current, "cluster-1", pchannels).Validate())
+	})
+
+	t.Run("the topology can be edited on the round trip", func(t *testing.T) {
+		incoming := FillRedactedConnectionTokens(SanitizeReplicateConfiguration(current), current)
+		incoming.CrossClusterTopology = nil
+		assert.NoError(t, NewReplicateConfigValidator(incoming, current, "cluster-1", pchannels).Validate())
+	})
+
+	t.Run("changing a token is still rejected", func(t *testing.T) {
+		incoming := FillRedactedConnectionTokens(SanitizeReplicateConfiguration(current), current)
+		incoming.Clusters[0].ConnectionParam.Token = "a-new-token"
+		err := NewReplicateConfigValidator(incoming, current, "cluster-1", pchannels).Validate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "connection_param.token cannot be changed")
+	})
+}


### PR DESCRIPTION
issue: #52734
master: #52735

Cherry-pick of #52735 onto `poc_2.6.17`, for a customer running this branch. The
three files are identical to the master change apart from the `go-api` import
path.

`SanitizeReplicateConfiguration` clears every `ConnectionParam.Token` when the
replicate configuration is read, and `validateClusterConsistency` rejects any
change to a connection token by strict equality. A caller that reads the
configuration back, edits the topology and submits it sends the empty token it
was handed, and the update is always rejected with
`connection_param.token cannot be changed`. Unlike the `uri` check next to it,
that error does not report the current value, and the read path exists so it is
not exposed.

`UpdateReplicateConfiguration` has no topology-only form — every call resubmits
full cluster blocks — so this blocks creating, changing and removing a
replication edge for anyone who does not independently remember the token
registered at setup time. Removing an edge is included: the single-cluster
"independent" configuration carries a `connection_param` too. `force_promote` is
not affected; it returns before this validation and rebuilds the configuration
from stored state.

Relaxing the validator alone would be worse than today's behaviour. The
incoming configuration is broadcast verbatim in
`AlterReplicateConfigMessageHeader` and becomes the stored configuration, so an
accepted empty token would erase the credential CDC passes as the client
`APIKey`. This takes the stored token into the incoming configuration instead,
before anything compares, validates or broadcasts it.

### Verification on this branch

Built from this branch's content and rolled into a two-cluster CDC pair. Same
script against two images differing only by this change:

| | before | after |
|---|---|---|
| resend the configuration exactly as read | rejected | **accepted** |
| read → add the `a -> b` edge → write | rejected | **accepted** |
| change a token on purpose | rejected | rejected |

After the round trip the stored configuration in etcd still holds the original
token, and replication over the edge it created works — a 300-row insert on the
source reaches the target.

Unit tests cover the fill helper on its own (redacted tokens filled, a supplied
token left alone, unknown cluster, nil arguments, nil connection param, and that
the caller's configuration is not mutated) and the round trip through the
validator, including that the pre-fix rejection still holds without the helper
and that changing a token is still refused.
