### PR TITLE
test: tolerate reranker score drift in model-rerank ground truth comparison

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search.py
@@ -6367,6 +6367,30 @@ class TestMilvusClientSearchModelRerank(TestMilvusClientV2Base):
 
             log.info(f"{'-' * 58} | {'-' * 58}")
 
+    def assert_rerank_order_matches_ground_truth(self, actual_rerank_results, gt, gt_scores, rtol=1e-2, atol=1e-6):
+        """
+        Compare Milvus's rerank order against the ground truth order, tolerating
+        reorderings between documents whose ground truth scores are within the
+        reranker service's own run-to-run reproducibility. Repeated calls to the
+        same reranker service can return scores that drift by up to ~5e-3
+        relative between calls, which is enough to flip the order of
+        neighbouring candidates without indicating a real Milvus defect.
+
+        Documents whose ground truth scores differ by more than the tolerance
+        must still keep their relative order; only near-tied documents may swap.
+        """
+        assert set(actual_rerank_results) == set(gt), \
+            f"Rerank result set differs from ground truth: {actual_rerank_results} vs {gt}"
+        actual_rank = {doc: idx for idx, doc in enumerate(actual_rerank_results)}
+        for i in range(len(gt)):
+            for j in range(i + 1, len(gt)):
+                tolerance = atol + rtol * max(abs(gt_scores[i]), abs(gt_scores[j]))
+                if gt_scores[i] - gt_scores[j] > tolerance:
+                    assert actual_rank[gt[i]] < actual_rank[gt[j]], \
+                        (f"Rerank order violated beyond score tolerance: expected "
+                         f"'{gt[i]}' (score {gt_scores[i]}) before '{gt[j]}' "
+                         f"(score {gt_scores[j]}), tolerance {tolerance}")
+
     def compare_milvus_rerank_with_origin_rerank(self, query_texts, rerank_results, results_without_rerank,
                                                  enable_truncate=False,
                                                  provider_type=None,
@@ -6443,8 +6467,10 @@ class TestMilvusClientSearchModelRerank(TestMilvusClientV2Base):
             self.display_side_by_side_comparison(query_text, actual_rerank_results, gt, doc_to_original,
                                                milvus_scores=distances, gt_scores=gt_scores)
 
-            # Use strict comparison since scores are now normalized to f32 precision
-            assert gt == actual_rerank_results, "Rerank result is different from ground truth rerank result"
+            # Tolerate reordering only between documents whose ground truth scores
+            # are within the reranker service's own run-to-run reproducibility;
+            # order between documents with a clear score gap must still match.
+            self.assert_rerank_order_matches_ground_truth(actual_rerank_results, gt, gt_scores)
 
     @pytest.mark.parametrize("ranker_model", [
         pytest.param("tei", marks=pytest.mark.tags(CaseLabel.L1)),


### PR DESCRIPTION
Motivation:
TestMilvusClientSearchModelRerank compares Milvus's rerank order against
a "ground truth" order the test computes by independently calling the
same external reranker service (TEI/vLLM), using strict list equality.
The reranker service performs batched GPU inference, which is not
bit-reproducible across calls: repeated requests for the same input can
return scores that drift by up to ~5e-3 relative. When two neighbouring
candidates' true scores are only a few 1e-5 apart, the Milvus-side call
and the test's own ground-truth call can rank them differently even
though both correctly reflect the (slightly different) scores each call
received. The strict equality assertion then fails, even though there is
no product bug -- both orderings are individually correct for the scores
they were given, and score comparisons this close are dominated by the
reranker service's own reproducibility, not by Milvus.

Approach:
Add assert_rerank_order_matches_ground_truth, which checks that Milvus's
result set matches the ground truth set, and that ordering is preserved
only for document pairs whose ground truth scores differ by more than a
tolerance (atol=1e-6, rtol=1e-2 of the larger score). Pairs within
tolerance may appear in either order; pairs with a clear score gap must
still keep their relative order, so a genuine ordering defect is still
caught. This replaces the previous exact `gt == actual_rerank_results`
assertion used by test_milvus_client_single_vector_search_with_model_rerank
and test_milvus_client_hybrid_vector_search_with_model_rerank.

Validation:
This test suite requires a live Milvus deployment plus a reachable
TEI/vLLM reranker endpoint, neither of which is available in this
environment, so the parametrized pytest case itself was not executed
here. Instead:
- `python3 -m py_compile tests/python_client/milvus_client/test_milvus_client_search.py`
  passes.
- `ruff check --config tests/ruff.toml tests/python_client/milvus_client/test_milvus_client_search.py`
  reports no issues.
- The new comparison logic was validated offline against the exact
  numbers reported in the issue (a standalone script reproducing
  assert_rerank_order_matches_ground_truth's logic): fed the reported
  5-document score table, it confirmed the old strict assertion fails on
  that data (reproducing the reported flake) while the new tolerant
  assertion passes on the same data; it also confirmed the new assertion
  still fails when a document pair with a clear (non-drift-sized) score
  gap is reordered, and still fails on a result-set mismatch, so it is
  not a rubber-stamp comparison.
- This does not prove the fix resolves the flake against a live TEI
  service; it demonstrates the new tolerance logic behaves correctly on
  the reported failure data and still catches real ordering violations.

Report: https://github.com/milvus-io/milvus/issues/52737

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

Fixes #52737