### PR TITLE
fix: [3.0] update libavrocpp recipe revision

### DIFF
--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -39,7 +39,7 @@ class MilvusConan(ConanFile):
         "unordered_dense/4.4.0#6a855c992618cc4c63019109a2e47298",
         "geos/3.12.0#a923af6dc4c18f87a7dfa960118f3166",
         "icu/74.2#cd1937b9561b8950a2ae6311284c5813",
-        "libavrocpp/1.12.1.1@milvus/dev#cde7bb587a29f6f233bae7e18b71815d",
+        "libavrocpp/1.12.1.1@milvus/dev#b4854183542196740ec9a004fdfff7ec",
     )
 
     default_options = {


### PR DESCRIPTION
### What

Backport the libavrocpp recipe revision update to the 3.0 branch.

- Update libavrocpp/1.12.1.1@milvus/dev from cde7bb587a29f6f233bae7e18b71815d to b4854183542196740ec9a004fdfff7ec.
- Keep the 3.0 dependency pin aligned with the fixed Conan 2 recipe used by #52704.

### Why

The old recipe downloads Avro 1.12.1 from dlcdn.apache.org, where the archived release now returns 404. milvus-io/conanfiles#183 switched the source to archive.apache.org and published recipe revision b4854183542196740ec9a004fdfff7ec.

### Verification

- The new recipe was built from source and its test package passed in the conanfiles production publish workflow.
- git diff --check passed.
- Branch is rebased on the latest origin/3.0.

pr: #52704
Recipe fix: milvus-io/conanfiles#183