### PR TITLE
fix: [2.6] initialize IndexMeta members

### DIFF
--- a/internal/core/src/storage/Types.h
+++ b/internal/core/src/storage/Types.h
@@ -75,15 +75,15 @@ enum CodecType {
 
 // index meta information corresponding to index file data
 struct IndexMeta {
-    int64_t segment_id;
-    int64_t field_id;
-    int64_t build_id;
-    int64_t index_version;
+    int64_t segment_id{0};
+    int64_t field_id{0};
+    int64_t build_id{0};
+    int64_t index_version{0};
     std::string key;
     std::string field_name;
-    DataType field_type;
-    int64_t dim;
-    bool index_non_encoding;
+    DataType field_type{DataType::NONE};
+    int64_t dim{0};
+    bool index_non_encoding{false};
 };
 
 struct StorageConfig {

--- a/internal/core/src/storage/TypesTest.cpp
+++ b/internal/core/src/storage/TypesTest.cpp
@@ -1,0 +1,39 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "storage/Types.h"
+
+namespace milvus::storage {
+namespace {
+
+TEST(StorageTypesTest, DefaultIndexMetaHasSafeValues) {
+    IndexMeta index_meta;
+
+    EXPECT_EQ(index_meta.segment_id, 0);
+    EXPECT_EQ(index_meta.field_id, 0);
+    EXPECT_EQ(index_meta.build_id, 0);
+    EXPECT_EQ(index_meta.index_version, 0);
+    EXPECT_TRUE(index_meta.key.empty());
+    EXPECT_TRUE(index_meta.field_name.empty());
+    EXPECT_EQ(index_meta.field_type, DataType::NONE);
+    EXPECT_EQ(index_meta.dim, 0);
+    EXPECT_FALSE(index_meta.index_non_encoding);
+}
+
+}  // namespace
+}  // namespace milvus::storage


### PR DESCRIPTION
pr: #52743
issue: #52480

- Backport deterministic IndexMeta member initialization.
- Adapt runtime regression coverage to the branch C++17 toolchain.