### PR TITLE
fix: update Knowhere for stable IndexNode ABI

### DIFF
--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update KNOWHERE_VERSION for the first occurrence
 milvus_add_pkg_config("knowhere")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( KNOWHERE_VERSION d85f7080 )
+set( KNOWHERE_VERSION d7cfd888 )
 set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
 
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")


### PR DESCRIPTION
issue: #52723
issue: #52724
issue: #52725

## What

- Update Knowhere from `d85f7080` to `d7cfd888`.
- Pick up zilliztech/knowhere#1786, which keeps `IndexNode::BuildAsync()` in the public vtable for both Cardinal and non-Cardinal builds.
- Pick up the Cardinal v1 bump to `v2.5.111`, including its nullable-index fix.

## Why

In a Cardinal-enabled Milvus build, Knowhere translation units define `KNOWHERE_WITH_CARDINAL`, while Milvus core consumers of the same public header do not. The previous conditional `BuildAsync()` declaration therefore gave the two DSOs different `IndexNode` vtable layouts.

Calls intended for `GetIdMap()` could dispatch to `Count()` instead and interpret its integer return as an `IdMap&`, causing the SIGSEGVs reported in #52723, #52724, and #52725.

Knowhere `d7cfd888` makes the public vtable independent of that feature macro.

## Validation

- No new local build or test was run for this dependency-pin-only change; validation is delegated to Milvus PR CI.
- The underlying Knowhere fix passed Knowhere CI and a prior Milvus Cardinal A/B reproduction: the affected ordinary HNSW test changed from SIGSEGV/exit 139 on the old pin to 1/1 passed with the fix.
