### PR TITLE
feat(datacoord): add generic bounded retry and failure surfacing for compaction tasks

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -820,6 +820,7 @@ dataCoord:
     rpcTimeout: 10
     maxParallelTaskNum: -1 # Deprecated, see datanode.slot.slotCap
     dropTolerance: 3600 # Compaction task will be cleaned after finish longer than this time(in seconds)
+    maxRetryTimes: 3 # Max number of times a compaction task retries a retryable failure before it is marked failed permanently.
     gcInterval: 1800 # The time interval in seconds for compaction gc
     scheduleInterval: 500 # The time interval in milliseconds for scheduling compaction tasks. If the configuration setting is below 100ms, it will be adjusted upwards to 100ms
     mix:

--- a/docs/design-docs/design_docs/20260821-compaction-bounded-retry-and-failure-surfacing.md
+++ b/docs/design-docs/design_docs/20260821-compaction-bounded-retry-and-failure-surfacing.md
@@ -110,6 +110,36 @@ Exposed through the existing `GetMetrics` debug-request mechanism via a new
 `metricsinfo.CompactionTaskFailureKey` (`"compaction_task_failures"`), registered in
 `server.go` next to the existing `compaction_tasks` key — no new RPC.
 
+### 2.4 Fixes from code review
+
+Two issues surfaced in review, both addressed:
+
+- **`RecordTerminalFailure` recorded a blank `EndTime` (Medium).** `updateAndSaveTaskMeta`
+  only stamps `EndTime` when the task's state was *already* terminal before that save —
+  but the save that transitions a task *into* `failed`/`timeout` (via `classifyFailure`,
+  or the timeout branches in `QueryTaskOnWorker`) runs while the prior state was still
+  `executing`/`pipelining`. The stamp only lands on the *next* save after that (`Clean()`'s
+  `failed/timeout -> cleaned` transition), which runs later and asynchronously — after
+  `RecordTerminalFailure`'s snapshot is already taken. So every history entry's `EndTime`
+  was silently empty. Fixed by backfilling `EndTime` with the current time in
+  `RecordTerminalFailure` whenever it's still zero (on a clone, not mutating the caller's
+  task). The original regression test couldn't catch this because it hand-set `EndTime` on
+  the test fixture; `TestRecordTerminalFailureBackfillsEndTime` was added to drive the real
+  zero-`EndTime` path, plus `TestRecordTerminalFailurePreservesExistingEndTime` to confirm
+  the backfill doesn't clobber a task that legitimately already has one.
+- **`DataCoordCompactionTaskNum` mixes gauge and counter semantics (Low).**
+  `pending`/`executing` are true gauges (paired Inc/Dec); `done`/`failed`/`timeout` only
+  ever increase, which is counter behavior sharing a `GaugeVec` — meaning the count
+  resets to 0 on every DataCoord restart with no record that a restart happened, and
+  `rate()`/`increase()` (the standard way to watch for "failures spiking") isn't designed
+  for that. Two fixes were on the table: split the terminal-outcome labels into a proper
+  `CounterVec` (correct, but a new public metric name existing dashboards would need to
+  adopt), or clarify the Help text so the mixed semantics are at least visible to a reader
+  (fully backward compatible, doesn't fix the `rate()` problem). Went with the minimal
+  fix for this PR — `DataCoordCompactionTaskNum`'s Help text now explicitly states which
+  labels are live counts and which are cumulative-since-restart. The `CounterVec` split
+  remains a valid follow-up if the restart-reset behavior needs to be queryable correctly.
+
 ## 3. Config
 
 `dataCoord.compaction.maxRetryTimes` (`DataCoordCfg.CompactionMaxRetryTimes`,
@@ -129,21 +159,34 @@ literal as the shared budget for all task types using `classifyFailure`.
   real catalog-backed meta, not just a mock).
 - `compaction_task_meta_test.go`: failure history — empty state, recording, and the core
   regression case (`TestFailureHistorySurvivesTaskMetaDrop`) proving a failure reason
-  remains queryable after the normal task meta is dropped.
+  remains queryable after the normal task meta is dropped. Plus (§2.4)
+  `TestRecordTerminalFailureBackfillsEndTime` and
+  `TestRecordTerminalFailurePreservesExistingEndTime` for the `EndTime` backfill.
 - `compaction_inspector_test.go`: `checkCompaction()` no longer folds failed/timeout into
-  `done`, and failure history is populated before cleanup.
+  `done`, and failure history is populated before cleanup. `SetupTest()` also stubs
+  `MockCompactionMeta.GetCompactionTaskMeta()` (`.Maybe()`, returning a real
+  `compactionTaskMeta`) since `checkCompaction()` now calls it for every finished task —
+  see §5, this was the one gap hand-review missed and CI caught.
 
 ## 5. Verification note
 
-This environment could not run `go test` for `internal/datacoord` — the C++ core
-(`milvus_core.pc`) has not been built here, which blocks *any* Go test in that package
-tree independent of this change. The pure-Go pieces (`pkg/util/paramtable`,
-`pkg/metrics`, `pkg/util/metricsinfo`) were confirmed to `go build` cleanly. The
-`internal/datacoord` changes were verified by hand: every new getter/wrapper/mock call
-site was checked against its actual generated signature (`datapb.CompactionTask`
-getters, `merr.Wrap*` signatures, `MockCompactionMeta`/`MockCluster`/`DataCoordCatalog`
-mock signatures), but this is not a substitute for `go build`/`go test` — run those
-before merging.
+The dev environment used to write this PR could not run `go test` for
+`internal/datacoord` — the C++ core (`milvus_core.pc`) was never built there, which
+blocks *any* Go test in that package tree independent of this change. The pure-Go
+pieces (`pkg/util/paramtable`, `pkg/metrics`, `pkg/util/metricsinfo`) were confirmed to
+`go build` cleanly there; the `internal/datacoord` changes were instead verified by
+hand — every new getter/wrapper/mock call site checked against its actual generated
+signature.
+
+That hand-review had exactly one gap, and CI (which does have the core built) caught
+it: `checkCompaction()`'s new `c.meta.GetCompactionTaskMeta().RecordTerminalFailure(...)`
+call is a dependency none of the five pre-existing `TestCompactionPlanHandlerSuite`
+tests that reach a terminal task state had stubbed on `MockCompactionMeta` — hand-review
+only added the stub to the *new* test, not to the shared `SetupTest()` every other test
+in the suite also runs through. Fixed once, in `SetupTest()` (§4). All five failures
+traced back to this single root cause; everything else in the diff passed CI as
+hand-verified. Lesson for next time: a new call added to a widely-shared code path needs
+its mock stub added at the suite's shared setup, not just the test that motivated it.
 
 ## 6. Out of scope / follow-ups
 

--- a/docs/design-docs/design_docs/20260821-compaction-bounded-retry-and-failure-surfacing.md
+++ b/docs/design-docs/design_docs/20260821-compaction-bounded-retry-and-failure-surfacing.md
@@ -1,0 +1,166 @@
+# DataCoord compaction: generic bounded retry and failure surfacing
+
+- Status: Implemented (this PR) — scoped to retry generalization, metrics, and failure
+  history. Segment-level cross-task cooldown (issue proposal #2) is explicitly deferred;
+  see [6. Out of scope](#6-out-of-scope--follow-ups).
+- Date: 2026-08-21
+- Scope: `internal/datacoord/compaction_task_retry.go` (new),
+  `internal/datacoord/compaction_task_mix.go`,
+  `internal/datacoord/compaction_task_bump_schema_version.go`,
+  `internal/datacoord/compaction_task_l0.go`,
+  `internal/datacoord/compaction_task_meta.go`,
+  `internal/datacoord/compaction_inspector.go`,
+  `internal/datacoord/server.go`,
+  `pkg/metrics/metrics.go`,
+  `pkg/util/metricsinfo/metric_request.go`,
+  `pkg/util/paramtable/component_param.go`
+- Related: #52708
+
+## 1. Problem
+
+DataCoord compaction has four task types (`mixCompactionTask`, `bumpSchemaVersionTask`,
+`l0CompactionTask`, `clusteringCompactionTask`). Only `clusteringCompactionTask` implements
+bounded retry (`merr.IsRetryableErr(err) && RetryTimes < 3`); the other three transition
+straight to `failed` on the first error, with no distinction between a transient failure
+(worth retrying) and a deterministic one.
+
+Separately, failure visibility is poor:
+- `fail_reason` is persisted on the task, but `compactionInspector.cleanCompactionTaskMeta`
+  deletes the whole task record (including the reason) once it has been `cleaned` for
+  longer than `CompactionDropToleranceInSeconds` — so the reason does not survive
+  diagnosis after the fact.
+- `metrics.DataCoordCompactionTaskNum` only has `pending`/`executing`/`done` labels;
+  `checkCompaction()` incremented `done` for every finished task regardless of state, so a
+  compaction that fails every time looks identical to a healthy one on a dashboard.
+- `GetCompactionState`'s `FailedPlanNo` is scoped by `triggerID`, which only a manual
+  compaction caller ever queries back — background triggers (bump/sort/clustering
+  auto-triggers) generate their own internal trigger IDs nobody polls, so this RPC is
+  structurally blind to background failures.
+
+Full analysis: #52708.
+
+## 2. Design
+
+### 2.1 Shared retry classification
+
+`classifyFailure()` (new file, `compaction_task_retry.go`) generalizes clustering's
+existing pattern into one function every task type calls:
+
+```go
+func classifyFailure(ctx context.Context, label string, taskProto *datapb.CompactionTask,
+    err error, updateAndSaveTaskMeta func(opts ...compactionTaskOpt) error) bool
+```
+
+A retryable error (`merr.IsRetryableErr`) under the configured budget
+(`dataCoord.compaction.maxRetryTimes`, default `3`) increments `retry_times` and leaves
+state untouched, so the task is reattempted on its own next scheduling cycle. Anything
+else — non-retryable, or retryable but out of budget — transitions the task to `failed`
+with `fail_reason` set.
+
+Wired into every call site that was previously an *unconditional* `setState(failed)` in
+`compaction_task_mix.go`, `compaction_task_bump_schema_version.go`, and
+`compaction_task_l0.go`.
+
+**Deliberately not touched**, to avoid changing behavior for cases this PR did not
+analyze deeply enough to be confident about:
+- Node-connectivity retry loops (`setState(pipelining), setNodeID(NullNodeID)` on
+  `CreateCompaction`/`QueryCompaction` RPC failure) — already an existing, working,
+  unbounded retry; out of scope here.
+- The opaque "compaction failed in datanode" branches — `CompactionPlanResult` carries no
+  error detail from the DataNode side today (only a state enum), so there is nothing to
+  classify without fabricating an error.
+- One `saveSegmentMeta` failure path per task type (mix/bump/L0) that today only
+  terminates on `merr.ErrIllegalCompactionPlan` and otherwise implicitly retries forever
+  via a bare `return` (next poll re-tries `QueryCompaction` → `saveSegmentMeta`).
+  `merr.IsRetryableErr` defaults to `false` for any error that isn't an explicit merr
+  sentinel (e.g. a raw KV/etcd error), so routing this specific path through
+  `classifyFailure` unmodified would flip "retry forever on a transient storage error"
+  into "fail permanently on the first transient storage error" — a regression, not an
+  improvement. Left as-is; revisiting it needs an audit of what errors
+  `CompleteCompactionMutation`'s catalog writes actually raise.
+
+`clusteringCompactionTask` itself is untouched: it already has working retry coverage,
+and rewriting it risked scope creep. One latent gap was found during review — in
+`QueryTaskOnWorker`, an explicit `setState(failed)` call at the segment-validation
+failure site leaves `err` still holding the original error for the deferred
+`t.retryOnError(err)` to see, so a "retryable" classification there only bumps
+`retry_times` on a task whose state was already forced to `failed` two lines above,
+i.e. it doesn't actually retry. Documented as a known follow-up, not fixed here.
+
+### 2.2 Metrics
+
+Added `Failed`/`Timeout` labels to `pkg/metrics/metrics.go`. `checkCompaction()`
+(`compaction_inspector.go`) now switches on the task's terminal state instead of always
+incrementing `done`. This changes the *meaning* of the existing `done` label (it no
+longer double-counts failures) without adding a new label name — treated as compatible
+per this repo's metric-compatibility convention (label-set stable, `done` becomes
+strictly more accurate). Failure/timeout finishes also log at `Warn` instead of `Info`.
+
+### 2.3 Terminal failure history
+
+`compactionTaskMeta` gets a second bounded LRU, `failureHistory` (256 entries, 24h TTL —
+deliberately longer than the existing `taskStats` LRU's 15 minutes, since this exists
+specifically to outlive `cleanCompactionTaskMeta`'s deletion of the task's own record),
+with `RecordTerminalFailure()` / `FailureHistoryJSON()`. Recorded in `checkCompaction()`
+at the same point the metric label is chosen — the one place every task type's terminal
+transition (classified retry-exhaustion, opaque DataNode failure, or timeout) is
+observed uniformly, regardless of which internal path produced it.
+
+Exposed through the existing `GetMetrics` debug-request mechanism via a new
+`metricsinfo.CompactionTaskFailureKey` (`"compaction_task_failures"`), registered in
+`server.go` next to the existing `compaction_tasks` key — no new RPC.
+
+## 3. Config
+
+`dataCoord.compaction.maxRetryTimes` (`DataCoordCfg.CompactionMaxRetryTimes`,
+refreshable, default `3`) — replaces clustering's previously-hardcoded `maxRetryTimes: 3`
+literal as the shared budget for all task types using `classifyFailure`.
+(`clusteringCompactionTask`'s own hardcoded constant is untouched per §2.1.)
+
+## 4. Testing
+
+- `compaction_task_retry_test.go` (new): `classifyFailure` in isolation — retry-under-budget,
+  retry-at-budget terminates, non-retryable terminates immediately, budget is configurable,
+  a raw (non-merr) error is treated as non-retryable.
+- `compaction_task_mix_test.go`, `compaction_task_bump_schema_version_test.go`,
+  `compaction_task_l0_test.go`: end-to-end wiring tests through each type's real
+  `QueryTaskOnWorker`/`CreateTaskOnWorker`/`updateAndSaveTaskMeta`, proving retry_times
+  persists through each type's actual save path (bump/L0 additionally exercised against a
+  real catalog-backed meta, not just a mock).
+- `compaction_task_meta_test.go`: failure history — empty state, recording, and the core
+  regression case (`TestFailureHistorySurvivesTaskMetaDrop`) proving a failure reason
+  remains queryable after the normal task meta is dropped.
+- `compaction_inspector_test.go`: `checkCompaction()` no longer folds failed/timeout into
+  `done`, and failure history is populated before cleanup.
+
+## 5. Verification note
+
+This environment could not run `go test` for `internal/datacoord` — the C++ core
+(`milvus_core.pc`) has not been built here, which blocks *any* Go test in that package
+tree independent of this change. The pure-Go pieces (`pkg/util/paramtable`,
+`pkg/metrics`, `pkg/util/metricsinfo`) were confirmed to `go build` cleanly. The
+`internal/datacoord` changes were verified by hand: every new getter/wrapper/mock call
+site was checked against its actual generated signature (`datapb.CompactionTask`
+getters, `merr.Wrap*` signatures, `MockCompactionMeta`/`MockCluster`/`DataCoordCatalog`
+mock signatures), but this is not a substitute for `go build`/`go test` — run those
+before merging.
+
+## 6. Out of scope / follow-ups
+
+**Cross-task cooldown (issue proposal #2).** `retry_times` is scoped to one
+`CompactionTask` instance; every trigger cycle allocates a fresh `PlanID` and a new task
+struct (see `compaction_trigger_v2.go`), so `retry_times` cannot express "this segment
+has failed compaction repeatedly across many trigger cycles." Stopping a trigger policy
+from re-selecting a segment that keeps failing needs new state that outlives a task
+instance, keyed by segment. Two shapes were considered and neither was implemented here:
+a field on `SegmentInfo`/its proto (persists across restarts, small diff, but a proto
+change and a per-policy selection-filter change across five policy files), or a separate
+keyed store in `compactionTaskMeta` (more isolated, more plumbing). Needs a decision
+before implementation.
+
+**Clustering's `retryOnError` bug** (§2.1) — not fixed, to keep this change's blast
+radius to the three previously-unprotected task types.
+
+**`saveSegmentMeta`'s implicit-infinite-retry paths** (§2.1) — left as pre-existing
+behavior; would need auditing what errors the underlying catalog/KV writes actually
+raise before converting safely.

--- a/internal/datacoord/compaction_inspector.go
+++ b/internal/datacoord/compaction_inspector.go
@@ -643,18 +643,34 @@ func (c *compactionInspector) checkCompaction() error {
 	c.executingGuard.Lock()
 	for _, t := range finishedTasks {
 		delete(c.executingTasks, t.GetTaskProto().GetPlanID())
-		mlog.Info(context.TODO(), "compaction task finished",
+		state := t.GetTaskProto().GetState()
+		terminal := state == datapb.CompactionTaskState_failed || state == datapb.CompactionTaskState_timeout
+		logFields := []mlog.Field{
 			mlog.Int64("planID", t.GetTaskProto().GetPlanID()),
 			mlog.String("type", t.GetTaskProto().GetType().String()),
-			mlog.String("state", t.GetTaskProto().GetState().String()),
+			mlog.String("state", state.String()),
 			mlog.String("channel", t.GetTaskProto().GetChannel()),
 			mlog.String("label", t.GetLabel()),
 			mlog.FieldNodeID(t.GetTaskProto().GetNodeID()),
 			mlog.Int64s("inputSegments", t.GetTaskProto().GetInputSegments()),
 			mlog.String("reason", t.GetTaskProto().GetFailReason()),
-		)
+		}
+		if terminal {
+			mlog.Warn(context.TODO(), "compaction task finished with a failure or timeout", logFields...)
+			c.meta.GetCompactionTaskMeta().RecordTerminalFailure(t.GetTaskProto())
+		} else {
+			mlog.Info(context.TODO(), "compaction task finished", logFields...)
+		}
+
 		metrics.DataCoordCompactionTaskNum.WithLabelValues(fmt.Sprintf("%d", t.GetTaskProto().GetNodeID()), t.GetTaskProto().GetType().String(), metrics.Executing).Dec()
-		metrics.DataCoordCompactionTaskNum.WithLabelValues(fmt.Sprintf("%d", t.GetTaskProto().GetNodeID()), t.GetTaskProto().GetType().String(), metrics.Done).Inc()
+		switch state {
+		case datapb.CompactionTaskState_failed:
+			metrics.DataCoordCompactionTaskNum.WithLabelValues(fmt.Sprintf("%d", t.GetTaskProto().GetNodeID()), t.GetTaskProto().GetType().String(), metrics.Failed).Inc()
+		case datapb.CompactionTaskState_timeout:
+			metrics.DataCoordCompactionTaskNum.WithLabelValues(fmt.Sprintf("%d", t.GetTaskProto().GetNodeID()), t.GetTaskProto().GetType().String(), metrics.Timeout).Inc()
+		default:
+			metrics.DataCoordCompactionTaskNum.WithLabelValues(fmt.Sprintf("%d", t.GetTaskProto().GetNodeID()), t.GetTaskProto().GetType().String(), metrics.Done).Inc()
+		}
 	}
 	c.executingGuard.Unlock()
 

--- a/internal/datacoord/compaction_inspector_test.go
+++ b/internal/datacoord/compaction_inspector_test.go
@@ -61,6 +61,9 @@ type CompactionPlanHandlerSuite struct {
 func (s *CompactionPlanHandlerSuite) SetupTest() {
 	s.mockMeta = NewMockCompactionMeta(s.T())
 	s.mockMeta.EXPECT().SaveCompactionTask(mock.Anything, mock.Anything).Return(nil).Maybe()
+	// checkCompaction() records terminal failures/timeouts via GetCompactionTaskMeta();
+	// any test whose tasks reach a failed/timeout state exercises this call.
+	s.mockMeta.EXPECT().GetCompactionTaskMeta().Return(newTestCompactionTaskMeta(s.T())).Maybe()
 	mockAlloc := allocator.NewMockAllocator(s.T())
 	mockAlloc.EXPECT().AllocTimestamp(mock.Anything).Return(uint64(1000), nil).Maybe()
 	s.mockAlloc = mockAlloc

--- a/internal/datacoord/compaction_inspector_test.go
+++ b/internal/datacoord/compaction_inspector_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/magiconair/properties/assert"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -34,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus/internal/datacoord/task"
 	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/metastore/kv/datacoord"
+	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	taskcommon "github.com/milvus-io/milvus/pkg/v3/taskcommon"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
@@ -730,6 +732,54 @@ func (s *CompactionPlanHandlerSuite) TestCheckCompaction() {
 
 	t = s.handler.getCompactionTask(6)
 	s.Equal(datapb.CompactionTaskState_executing, t.GetTaskProto().GetState())
+}
+
+// TestCheckCompactionMetricsAndFailureHistory verifies checkCompaction no longer folds
+// failed and timed-out tasks into the "done" metric label, and that a terminal task's
+// FailReason is captured into the failure history before its regular meta is cleaned up.
+func (s *CompactionPlanHandlerSuite) TestCheckCompactionMetricsAndFailureHistory() {
+	s.SetupTest()
+
+	catalog := &datacoord.Catalog{MetaKv: NewMetaMemoryKV()}
+	compactionTaskMeta, err := newCompactionTaskMeta(context.TODO(), catalog)
+	s.NoError(err)
+	s.handler.meta = &meta{compactionTaskMeta: compactionTaskMeta}
+
+	failedTask := newMixCompactionTask(&datapb.CompactionTask{
+		PlanID:     10,
+		Type:       datapb.CompactionType_MixCompaction,
+		Channel:    "ch-1",
+		State:      datapb.CompactionTaskState_failed,
+		FailReason: "segment integrity check failed",
+		NodeID:     111,
+		StartTime:  time.Now().Unix(),
+	}, s.mockAlloc, s.handler.meta, newMockVersionManager())
+
+	timeoutTask := newMixCompactionTask(&datapb.CompactionTask{
+		PlanID:    11,
+		Type:      datapb.CompactionType_MixCompaction,
+		Channel:   "ch-1",
+		State:     datapb.CompactionTaskState_timeout,
+		NodeID:    111,
+		StartTime: time.Now().Unix(),
+	}, s.mockAlloc, s.handler.meta, newMockVersionManager())
+
+	s.handler.executingTasks[10] = failedTask
+	s.handler.executingTasks[11] = timeoutTask
+
+	labelValues := func(status string) float64 {
+		return testutil.ToFloat64(metrics.DataCoordCompactionTaskNum.WithLabelValues("111", datapb.CompactionType_MixCompaction.String(), status))
+	}
+	failedBefore, timeoutBefore, doneBefore := labelValues(metrics.Failed), labelValues(metrics.Timeout), labelValues(metrics.Done)
+
+	s.NoError(s.handler.checkCompaction())
+
+	s.Equal(failedBefore+1, labelValues(metrics.Failed))
+	s.Equal(timeoutBefore+1, labelValues(metrics.Timeout))
+	// Neither the failure nor the timeout should also be counted into "done".
+	s.Equal(doneBefore, labelValues(metrics.Done))
+
+	s.Contains(s.handler.meta.GetCompactionTaskMeta().FailureHistoryJSON(), "segment integrity check failed")
 }
 
 func (s *CompactionPlanHandlerSuite) TestCompactionGC() {

--- a/internal/datacoord/compaction_task_bump_schema_version.go
+++ b/internal/datacoord/compaction_task_bump_schema_version.go
@@ -220,10 +220,7 @@ func (t *bumpSchemaVersionTask) CreateTaskOnWorker(nodeID int64, cluster session
 	plan, err := t.BuildCompactionRequest()
 	if err != nil {
 		log.Warn(context.TODO(), "bumpSchemaVersionTask failed to build compaction request", mlog.Err(err))
-		err = t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed), setFailReason(err.Error()))
-		if err != nil {
-			log.Warn(context.TODO(), "bumpSchemaVersionTask failed to updateAndSaveTaskMeta", mlog.Err(err))
-		}
+		classifyFailure(context.TODO(), "bumpSchemaVersionTask", t.GetTaskProto(), err, t.updateAndSaveTaskMeta)
 		return
 	}
 
@@ -269,26 +266,19 @@ func (t *bumpSchemaVersionTask) QueryTaskOnWorker(cluster session.Cluster) {
 	case datapb.CompactionTaskState_completed:
 		if len(result.GetSegments()) == 0 {
 			log.Warn(context.TODO(), "bumpSchemaVersionTask illegal compaction results: no segments returned")
-			if err := t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed),
-				setFailReason("illegal compaction results: no segments returned")); err != nil {
-				log.Warn(context.TODO(), "bumpSchemaVersionTask failed to setState failed", mlog.Err(err))
-			}
+			classifyFailure(context.TODO(), "bumpSchemaVersionTask", t.GetTaskProto(),
+				merr.WrapErrIllegalCompactionPlan("illegal compaction results: no segments returned"), t.updateAndSaveTaskMeta)
 			return
 		}
 		err = t.meta.ValidateSegmentStateBeforeCompleteCompactionMutation(t.GetTaskProto())
 		if err != nil {
-			if saveErr := t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed), setFailReason(err.Error())); saveErr != nil {
-				log.Warn(context.TODO(), "bumpSchemaVersionTask failed to setState failed", mlog.Err(saveErr))
-			}
+			classifyFailure(context.TODO(), "bumpSchemaVersionTask", t.GetTaskProto(), err, t.updateAndSaveTaskMeta)
 			return
 		}
 		if err := t.saveSegmentMeta(result); err != nil {
 			log.Warn(context.TODO(), "bumpSchemaVersionTask failed to save segment meta", mlog.Err(err))
 			if errors.Is(err, merr.ErrIllegalCompactionPlan) {
-				if saveErr := t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed),
-					setFailReason(err.Error())); saveErr != nil {
-					log.Warn(context.TODO(), "bumpSchemaVersionTask failed to setState failed", mlog.Err(saveErr))
-				}
+				classifyFailure(context.TODO(), "bumpSchemaVersionTask", t.GetTaskProto(), err, t.updateAndSaveTaskMeta)
 			}
 			return
 		}

--- a/internal/datacoord/compaction_task_bump_schema_version_test.go
+++ b/internal/datacoord/compaction_task_bump_schema_version_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	taskcommon "github.com/milvus-io/milvus/pkg/v3/taskcommon"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 func TestBumpSchemaVersionCompactionTaskSuite(t *testing.T) {
@@ -283,6 +284,50 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestBuildCompactionRequestSegment
 	s.Error(err)
 	s.Nil(plan)
 	s.Contains(err.Error(), "segment not found")
+}
+
+// TestCreateTaskOnWorkerSegmentNotFoundDoesNotRetry confirms a non-retryable build failure
+// (segment not found is a deterministic condition, not a transient one) still fails on the
+// first attempt without consuming any retry budget, matching pre-fix behavior.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestCreateTaskOnWorkerSegmentNotFoundDoesNotRetry() {
+	task := s.generateBasicTask()
+	cluster := session.NewMockCluster(s.T())
+	task.CreateTaskOnWorker(1, cluster)
+
+	s.Equal(datapb.CompactionTaskState_failed, task.GetTaskProto().GetState())
+	s.Equal(int32(0), task.GetTaskProto().GetRetryTimes())
+	s.NotEmpty(task.GetTaskProto().GetFailReason())
+}
+
+// TestClassifyFailureRetriesThenTerminates exercises classifyFailure against a real,
+// catalog-backed bumpSchemaVersionTask.updateAndSaveTaskMeta (not a mock), proving retry_times
+// and the terminal failed transition both actually persist through this task type's save path.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestClassifyFailureRetriesThenTerminates() {
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.CompactionMaxRetryTimes.Key, "2")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.CompactionMaxRetryTimes.Key)
+
+	task := s.generateBasicTask()
+	task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing)))
+
+	// Attempt 1: retryable, under budget (0 < 2) -> retries, state untouched.
+	retried := classifyFailure(context.TODO(), "bumpSchemaVersionTask", task.GetTaskProto(),
+		merr.WrapErrServiceUnavailable("transient"), task.updateAndSaveTaskMeta)
+	s.True(retried)
+	s.Equal(int32(1), task.GetTaskProto().GetRetryTimes())
+	s.Equal(datapb.CompactionTaskState_executing, task.GetTaskProto().GetState())
+
+	// Attempt 2: retryable, under budget (1 < 2) -> retries again.
+	retried = classifyFailure(context.TODO(), "bumpSchemaVersionTask", task.GetTaskProto(),
+		merr.WrapErrServiceUnavailable("transient"), task.updateAndSaveTaskMeta)
+	s.True(retried)
+	s.Equal(int32(2), task.GetTaskProto().GetRetryTimes())
+
+	// Attempt 3: retry_times(2) is no longer < max(2) -> terminates.
+	retried = classifyFailure(context.TODO(), "bumpSchemaVersionTask", task.GetTaskProto(),
+		merr.WrapErrServiceUnavailable("transient"), task.updateAndSaveTaskMeta)
+	s.False(retried)
+	s.Equal(datapb.CompactionTaskState_failed, task.GetTaskProto().GetState())
+	s.NotEmpty(task.GetTaskProto().GetFailReason())
 }
 
 func (s *BumpSchemaVersionCompactionTaskSuite) TestCreateTaskOnWorker() {

--- a/internal/datacoord/compaction_task_l0.go
+++ b/internal/datacoord/compaction_task_l0.go
@@ -89,10 +89,7 @@ func (t *l0CompactionTask) CreateTaskOnWorker(nodeID int64, cluster session.Clus
 	plan, err := t.BuildCompactionRequest()
 	if err != nil {
 		log.Warn(context.TODO(), "l0CompactionTask failed to build compaction request", mlog.Err(err))
-		err = t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed), setFailReason(err.Error()))
-		if err != nil {
-			log.Warn(context.TODO(), "l0CompactionTask failed to updateAndSaveTaskMeta", mlog.Err(err))
-		}
+		classifyFailure(context.TODO(), "l0CompactionTask", t.GetTaskProto(), err, t.updateAndSaveTaskMeta)
 		return
 	}
 
@@ -105,10 +102,7 @@ func (t *l0CompactionTask) CreateTaskOnWorker(nodeID int64, cluster session.Clus
 		// Save segment meta with empty output segments (marks L0 input segments as dropped)
 		if err = t.saveSegmentMeta([]*datapb.CompactionSegment{}); err != nil {
 			log.Warn(context.TODO(), "l0CompactionTask fast finish failed to save segment meta", mlog.Err(err))
-			err = t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed), setFailReason(err.Error()))
-			if err != nil {
-				log.Warn(context.TODO(), "l0CompactionTask failed to updateAndSaveTaskMeta", mlog.Err(err))
-			}
+			classifyFailure(context.TODO(), "l0CompactionTask", t.GetTaskProto(), err, t.updateAndSaveTaskMeta)
 			return
 		}
 
@@ -162,7 +156,7 @@ func (t *l0CompactionTask) QueryTaskOnWorker(cluster session.Cluster) {
 	case datapb.CompactionTaskState_completed:
 		err = t.meta.ValidateSegmentStateBeforeCompleteCompactionMutation(t.GetTaskProto())
 		if err != nil {
-			t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed), setFailReason(err.Error()))
+			classifyFailure(context.TODO(), "l0CompactionTask", t.GetTaskProto(), err, t.updateAndSaveTaskMeta)
 			return
 		}
 

--- a/internal/datacoord/compaction_task_l0_test.go
+++ b/internal/datacoord/compaction_task_l0_test.go
@@ -407,6 +407,39 @@ func (s *L0CompactionTaskSuite) TestPorcessStateTrans() {
 		t.QueryTaskOnWorker(cluster)
 		s.Equal(datapb.CompactionTaskState_completed, t.GetTaskProto().GetState())
 	})
+	s.Run("test executing with result completed retryable validation error retries", func() {
+		paramtable.Get().Save(paramtable.Get().DataCoordCfg.CompactionMaxRetryTimes.Key, "3")
+		defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.CompactionMaxRetryTimes.Key)
+
+		s.mockMeta.EXPECT().SaveCompactionTask(mock.Anything, mock.Anything).Return(nil)
+		t := s.generateTestL0Task(datapb.CompactionTaskState_executing)
+		t.updateAndSaveTaskMeta(setNodeID(100))
+
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryCompaction(t.GetTaskProto().NodeID, mock.Anything).
+			Return(&datapb.CompactionPlanResult{
+				PlanID: t.GetTaskProto().GetPlanID(),
+				State:  datapb.CompactionTaskState_completed,
+			}, nil)
+		s.mockMeta.EXPECT().ValidateSegmentStateBeforeCompleteCompactionMutation(mock.Anything).
+			Return(merr.WrapErrServiceUnavailable("transient"))
+
+		t.QueryTaskOnWorker(cluster)
+		s.Equal(datapb.CompactionTaskState_executing, t.GetTaskProto().GetState())
+		s.Equal(int32(1), t.GetTaskProto().GetRetryTimes())
+
+		t.QueryTaskOnWorker(cluster)
+		s.Equal(int32(2), t.GetTaskProto().GetRetryTimes())
+
+		t.QueryTaskOnWorker(cluster)
+		s.Equal(int32(3), t.GetTaskProto().GetRetryTimes())
+		s.Equal(datapb.CompactionTaskState_executing, t.GetTaskProto().GetState())
+
+		// 4th failure exceeds the budget (3 < 3 is false) and terminates the task.
+		t.QueryTaskOnWorker(cluster)
+		s.Equal(datapb.CompactionTaskState_failed, t.GetTaskProto().GetState())
+		s.NotEmpty(t.GetTaskProto().GetFailReason())
+	})
 	s.Run("test executing with result completed save segment meta failed", func() {
 		s.mockMeta.EXPECT().SaveCompactionTask(mock.Anything, mock.Anything).Return(nil)
 		t := s.generateTestL0Task(datapb.CompactionTaskState_executing)

--- a/internal/datacoord/compaction_task_meta.go
+++ b/internal/datacoord/compaction_task_meta.go
@@ -56,6 +56,16 @@ func newCompactionTaskStats(task *datapb.CompactionTask) *metricsinfo.Compaction
 	}
 }
 
+// terminalFailureHistorySize bounds the number of terminally-failed/timed-out compaction
+// tasks kept for diagnosis after their task meta has been dropped by cleanCompactionTaskMeta.
+const terminalFailureHistorySize = 256
+
+// terminalFailureHistoryTTL is deliberately longer than taskStats' TTL: taskStats is a
+// live debug snapshot of recent tasks of any outcome, while this history exists specifically
+// so a terminal failure remains queryable well after cleanCompactionTaskMeta has deleted the
+// task's own meta record (see compaction_inspector.go's CompactionDropToleranceInSeconds).
+const terminalFailureHistoryTTL = 24 * time.Hour
+
 type compactionTaskMeta struct {
 	sync.RWMutex
 	ctx     context.Context
@@ -63,6 +73,9 @@ type compactionTaskMeta struct {
 	// currently only clustering compaction task is stored in persist meta
 	compactionTasks map[int64]map[int64]*datapb.CompactionTask // triggerID -> planID
 	taskStats       *expirable.LRU[UniqueID, *metricsinfo.CompactionTask]
+	// failureHistory retains terminally-failed/timed-out tasks (keyed by planID) past the
+	// point cleanCompactionTaskMeta deletes their normal task meta, for diagnosis.
+	failureHistory *expirable.LRU[UniqueID, *metricsinfo.CompactionTask]
 }
 
 func newCompactionTaskMeta(ctx context.Context, catalog metastore.DataCoordCatalog) (*compactionTaskMeta, error) {
@@ -72,6 +85,7 @@ func newCompactionTaskMeta(ctx context.Context, catalog metastore.DataCoordCatal
 		catalog:         catalog,
 		compactionTasks: make(map[int64]map[int64]*datapb.CompactionTask, 0),
 		taskStats:       expirable.NewLRU[UniqueID, *metricsinfo.CompactionTask](512, nil, time.Minute*15),
+		failureHistory:  expirable.NewLRU[UniqueID, *metricsinfo.CompactionTask](terminalFailureHistorySize, nil, terminalFailureHistoryTTL),
 	}
 	if err := csm.reloadFromKV(); err != nil {
 		return nil, err
@@ -199,6 +213,26 @@ func (csm *compactionTaskMeta) DropCompactionTask(ctx context.Context, task *dat
 
 func (csm *compactionTaskMeta) TaskStatsJSON() string {
 	tasks := csm.taskStats.Values()
+	ret, err := json.Marshal(tasks)
+	if err != nil {
+		return ""
+	}
+	return string(ret)
+}
+
+// RecordTerminalFailure snapshots a task that just reached a terminal failed/timeout state,
+// so it stays queryable after cleanCompactionTaskMeta later deletes its regular task meta.
+// Safe to call for any task; callers are expected to only call it for failed/timeout tasks.
+func (csm *compactionTaskMeta) RecordTerminalFailure(task *datapb.CompactionTask) {
+	csm.Lock()
+	defer csm.Unlock()
+	csm.failureHistory.Add(task.GetPlanID(), newCompactionTaskStats(task))
+}
+
+// FailureHistoryJSON returns the bounded, recent history of terminally-failed/timed-out
+// compaction tasks as JSON, for diagnostic queries (see metricsinfo.CompactionTaskFailureKey).
+func (csm *compactionTaskMeta) FailureHistoryJSON() string {
+	tasks := csm.failureHistory.Values()
 	ret, err := json.Marshal(tasks)
 	if err != nil {
 		return ""

--- a/internal/datacoord/compaction_task_meta.go
+++ b/internal/datacoord/compaction_task_meta.go
@@ -223,9 +223,23 @@ func (csm *compactionTaskMeta) TaskStatsJSON() string {
 // RecordTerminalFailure snapshots a task that just reached a terminal failed/timeout state,
 // so it stays queryable after cleanCompactionTaskMeta later deletes its regular task meta.
 // Safe to call for any task; callers are expected to only call it for failed/timeout tasks.
+//
+// The task's own EndTime is usually still unset here: updateAndSaveTaskMeta only stamps
+// EndTime when the task's state was ALREADY terminal before the save, but the save that
+// transitions a task INTO failed/timeout (classifyFailure, or the timeout branches in
+// QueryTaskOnWorker) runs while the prior state was still executing/pipelining -- so the
+// stamp only lands on the next save after that (Clean()'s failed/timeout -> cleaned
+// transition), which happens later and asynchronously, after this snapshot is taken. So
+// EndTime is backfilled with the current time here whenever it is still zero, rather than
+// recording a diagnostically useless blank timestamp.
 func (csm *compactionTaskMeta) RecordTerminalFailure(task *datapb.CompactionTask) {
 	csm.Lock()
 	defer csm.Unlock()
+	if task.GetEndTime() == 0 {
+		clone := proto.Clone(task).(*datapb.CompactionTask)
+		setEndTime(time.Now().Unix())(clone)
+		task = clone
+	}
 	csm.failureHistory.Add(task.GetPlanID(), newCompactionTaskStats(task))
 }
 

--- a/internal/datacoord/compaction_task_meta_test.go
+++ b/internal/datacoord/compaction_task_meta_test.go
@@ -149,6 +149,60 @@ func (suite *CompactionTaskMetaSuite) TestFailureHistoryJSON() {
 	suite.JSONEq(string(expectedJSON), suite.meta.FailureHistoryJSON())
 }
 
+// TestRecordTerminalFailureBackfillsEndTime is the regression test for the bug where a
+// history entry silently carried no timestamp: updateAndSaveTaskMeta only stamps EndTime
+// when the task's state was ALREADY terminal before the save, but the save that transitions
+// a task INTO failed/timeout runs while EndTime is still unset -- so, unlike
+// TestFailureHistoryJSON above, this test deliberately does NOT set EndTime on the input,
+// to actually exercise the real (buggy, pre-fix) path instead of masking it.
+func (suite *CompactionTaskMetaSuite) TestRecordTerminalFailureBackfillsEndTime() {
+	failedTask := &datapb.CompactionTask{
+		PlanID:     1,
+		Type:       datapb.CompactionType_MixCompaction,
+		State:      datapb.CompactionTaskState_failed,
+		FailReason: "segment integrity check failed",
+		// EndTime deliberately left at its zero value.
+	}
+	before := time.Now()
+	suite.meta.RecordTerminalFailure(failedTask)
+	after := time.Now()
+
+	// The task passed in by the caller must not be mutated in place -- RecordTerminalFailure
+	// clones before backfilling.
+	suite.Zero(failedTask.GetEndTime())
+
+	tasks := suite.meta.failureHistory.Values()
+	suite.Require().Len(tasks, 1)
+	recorded := tasks[0]
+	suite.NotEmpty(recorded.EndTime, "EndTime must be backfilled, not left blank")
+
+	// newCompactionTaskStats renders EndTime via typeutil.TimestampToString, i.e. a
+	// second-precision formatted timestamp -- parse it back to compare against the window
+	// this call ran in, with a 1s allowance for the format's truncated precision.
+	parsed, err := time.ParseInLocation(time.DateTime, recorded.EndTime, time.Local)
+	suite.NoError(err)
+	suite.WithinRange(parsed, before.Add(-time.Second), after.Add(time.Second))
+}
+
+// TestRecordTerminalFailurePreservesExistingEndTime confirms the backfill only kicks in
+// when EndTime is actually unset -- a task that legitimately already has one (e.g. recorded
+// after Clean()'s failed -> cleaned transition already stamped it) keeps its real value.
+func (suite *CompactionTaskMetaSuite) TestRecordTerminalFailurePreservesExistingEndTime() {
+	explicitEndTime := time.Now().Add(-time.Hour).Unix()
+	failedTask := &datapb.CompactionTask{
+		PlanID:     1,
+		Type:       datapb.CompactionType_MixCompaction,
+		State:      datapb.CompactionTaskState_failed,
+		FailReason: "segment integrity check failed",
+		EndTime:    explicitEndTime,
+	}
+	suite.meta.RecordTerminalFailure(failedTask)
+
+	expectedJSON, err := json.Marshal([]*metricsinfo.CompactionTask{newCompactionTaskStats(failedTask)})
+	suite.NoError(err)
+	suite.JSONEq(string(expectedJSON), suite.meta.FailureHistoryJSON())
+}
+
 // TestFailureHistorySurvivesTaskMetaDrop is the core regression test for the issue this
 // history exists to fix: today, once a failed task's regular meta is dropped (see
 // compactionInspector.cleanCompactionTaskMeta), its FailReason is gone for good. The

--- a/internal/datacoord/compaction_task_meta_test.go
+++ b/internal/datacoord/compaction_task_meta_test.go
@@ -129,6 +129,50 @@ func (suite *CompactionTaskMetaSuite) TestTaskStatsJSON() {
 	suite.JSONEq(string(expectedJSON), actualJSON)
 }
 
+func (suite *CompactionTaskMetaSuite) TestFailureHistoryJSON() {
+	// empty history returns an empty JSON array, matching TaskStatsJSON's convention.
+	suite.Equal("[]", suite.meta.FailureHistoryJSON())
+
+	failedTask := &datapb.CompactionTask{
+		PlanID:       1,
+		CollectionID: 100,
+		Type:         datapb.CompactionType_MixCompaction,
+		State:        datapb.CompactionTaskState_failed,
+		FailReason:   "segment integrity check failed",
+		StartTime:    time.Now().Unix(),
+		EndTime:      time.Now().Add(time.Minute).Unix(),
+	}
+	suite.meta.RecordTerminalFailure(failedTask)
+
+	expectedJSON, err := json.Marshal([]*metricsinfo.CompactionTask{newCompactionTaskStats(failedTask)})
+	suite.NoError(err)
+	suite.JSONEq(string(expectedJSON), suite.meta.FailureHistoryJSON())
+}
+
+// TestFailureHistorySurvivesTaskMetaDrop is the core regression test for the issue this
+// history exists to fix: today, once a failed task's regular meta is dropped (see
+// compactionInspector.cleanCompactionTaskMeta), its FailReason is gone for good. The
+// failure history must keep it independently queryable.
+func (suite *CompactionTaskMetaSuite) TestFailureHistorySurvivesTaskMetaDrop() {
+	failedTask := &datapb.CompactionTask{
+		PlanID:       1,
+		CollectionID: 100,
+		Type:         datapb.CompactionType_BumpSchemaVersionCompaction,
+		State:        datapb.CompactionTaskState_failed,
+		FailReason:   "row count mismatch after schema bump",
+	}
+	suite.NoError(suite.meta.SaveCompactionTask(context.TODO(), failedTask))
+	suite.meta.RecordTerminalFailure(failedTask)
+
+	suite.catalog.EXPECT().DropCompactionTask(mock.Anything, mock.Anything).Return(nil)
+	suite.NoError(suite.meta.DropCompactionTask(context.TODO(), failedTask))
+
+	// The regular task meta is gone...
+	suite.Empty(suite.meta.GetCompactionTasksByTriggerID(failedTask.GetTriggerID()))
+	// ...but the failure history still has it.
+	suite.Contains(suite.meta.FailureHistoryJSON(), "row count mismatch after schema bump")
+}
+
 // TestReloadFromKV_PreAllocatedSegmentIDsCompatibility verifies that compatibility
 // logic in reloadFromKV does NOT mark Level0DeleteCompaction tasks as failed when
 // PreAllocatedSegmentIDs is nil, while still failing other unfinished tasks that

--- a/internal/datacoord/compaction_task_mix.go
+++ b/internal/datacoord/compaction_task_mix.go
@@ -84,10 +84,7 @@ func (t *mixCompactionTask) CreateTaskOnWorker(nodeID int64, cluster session.Clu
 	plan, err := t.BuildCompactionRequest()
 	if err != nil {
 		mlog.Warn(context.TODO(), "mixCompactionTask failed to build compaction request", mlog.Err(err))
-		err = t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed), setFailReason(err.Error()))
-		if err != nil {
-			mlog.Warn(context.TODO(), "mixCompactionTask failed to updateAndSaveTaskMeta", mlog.Err(err))
-		}
+		classifyFailure(context.TODO(), "mixCompactionTask", t.GetTaskProto(), err, t.updateAndSaveTaskMeta)
 		return
 	}
 
@@ -135,16 +132,13 @@ func (t *mixCompactionTask) QueryTaskOnWorker(cluster session.Cluster) {
 		}
 		err = t.meta.ValidateSegmentStateBeforeCompleteCompactionMutation(t.GetTaskProto())
 		if err != nil {
-			t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed), setFailReason(err.Error()))
+			classifyFailure(context.TODO(), "mixCompactionTask", t.GetTaskProto(), err, t.updateAndSaveTaskMeta)
 			return
 		}
 		if err := t.saveSegmentMeta(result); err != nil {
 			mlog.Warn(context.TODO(), "mixCompactionTask failed to save segment meta", mlog.Err(err))
 			if errors.Is(err, merr.ErrIllegalCompactionPlan) {
-				err = t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed))
-				if err != nil {
-					mlog.Warn(context.TODO(), "mixCompactionTask failed to setState failed", mlog.Err(err))
-				}
+				classifyFailure(context.TODO(), "mixCompactionTask", t.GetTaskProto(), err, t.updateAndSaveTaskMeta)
 			}
 			return
 		}

--- a/internal/datacoord/compaction_task_mix_test.go
+++ b/internal/datacoord/compaction_task_mix_test.go
@@ -317,3 +317,75 @@ func (s *MixCompactionTaskSuite) TestQueryTaskOnWorker() {
 
 	s.Equal(taskcommon.Retry, t1.GetTaskState())
 }
+
+// TestQueryTaskOnWorkerRetriesRetryableValidationFailure exercises the classifyFailure wiring
+// end to end: a retryable ValidateSegmentStateBeforeCompleteCompactionMutation error must be
+// retried up to DataCoordCfg.CompactionMaxRetryTimes before the task is marked failed, instead
+// of failing on the very first occurrence (the pre-fix behavior).
+func (s *MixCompactionTaskSuite) TestQueryTaskOnWorkerRetriesRetryableValidationFailure() {
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.CompactionMaxRetryTimes.Key, "3")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.CompactionMaxRetryTimes.Key)
+
+	cluster := session.NewMockCluster(s.T())
+	task := newMixCompactionTask(&datapb.CompactionTask{
+		PlanID:        1,
+		Type:          datapb.CompactionType_MixCompaction,
+		StartTime:     time.Now().Unix(),
+		Channel:       "ch-1",
+		State:         datapb.CompactionTaskState_executing,
+		NodeID:        111,
+		InputSegments: []int64{100},
+	}, nil, s.mockMeta, newMockVersionManager())
+
+	s.mockMeta.EXPECT().SaveCompactionTask(mock.Anything, mock.Anything).Return(nil)
+	cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(
+		&datapb.CompactionPlanResult{
+			PlanID:   1,
+			State:    datapb.CompactionTaskState_completed,
+			Segments: []*datapb.CompactionSegment{{SegmentID: 200}},
+		}, nil)
+	s.mockMeta.EXPECT().ValidateSegmentStateBeforeCompleteCompactionMutation(mock.Anything).
+		Return(merr.WrapErrServiceUnavailable("segment lock contention"))
+
+	// Attempts 1-3: retry_times goes 0 -> 1 -> 2 -> 3, task stays in its current state.
+	for i := int32(1); i <= 3; i++ {
+		task.QueryTaskOnWorker(cluster)
+		s.Equal(datapb.CompactionTaskState_executing, task.GetTaskProto().GetState())
+		s.Equal(i, task.GetTaskProto().GetRetryTimes())
+	}
+
+	// 4th attempt: retry_times(3) is no longer < max(3), so the task terminates.
+	task.QueryTaskOnWorker(cluster)
+	s.Equal(datapb.CompactionTaskState_failed, task.GetTaskProto().GetState())
+	s.Equal(int32(3), task.GetTaskProto().GetRetryTimes())
+	s.NotEmpty(task.GetTaskProto().GetFailReason())
+}
+
+// TestQueryTaskOnWorkerNonRetryableValidationFailsImmediately confirms a non-retryable error
+// still fails on the first occurrence, exactly like the pre-fix behavior.
+func (s *MixCompactionTaskSuite) TestQueryTaskOnWorkerNonRetryableValidationFailsImmediately() {
+	cluster := session.NewMockCluster(s.T())
+	task := newMixCompactionTask(&datapb.CompactionTask{
+		PlanID:    1,
+		Type:      datapb.CompactionType_MixCompaction,
+		StartTime: time.Now().Unix(),
+		Channel:   "ch-1",
+		State:     datapb.CompactionTaskState_executing,
+		NodeID:    111,
+	}, nil, s.mockMeta, newMockVersionManager())
+
+	s.mockMeta.EXPECT().SaveCompactionTask(mock.Anything, mock.Anything).Return(nil)
+	cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(
+		&datapb.CompactionPlanResult{
+			PlanID:   1,
+			State:    datapb.CompactionTaskState_completed,
+			Segments: []*datapb.CompactionSegment{{SegmentID: 200}},
+		}, nil).Once()
+	s.mockMeta.EXPECT().ValidateSegmentStateBeforeCompleteCompactionMutation(mock.Anything).
+		Return(merr.WrapErrIllegalCompactionPlan("segment already dropped")).Once()
+
+	task.QueryTaskOnWorker(cluster)
+
+	s.Equal(datapb.CompactionTaskState_failed, task.GetTaskProto().GetState())
+	s.Equal(int32(0), task.GetTaskProto().GetRetryTimes())
+}

--- a/internal/datacoord/compaction_task_retry.go
+++ b/internal/datacoord/compaction_task_retry.go
@@ -1,0 +1,71 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"context"
+
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+// classifyFailure decides whether a failed compaction attempt should retry in place
+// or terminate the task, generalizing the bounded-retry pattern that previously only
+// clusteringCompactionTask implemented.
+//
+// A retryable error (per merr.IsRetryableErr) under the configured retry budget
+// increments retry_times and leaves the task's state untouched, so the task is
+// reattempted the next time it is scheduled. Anything else -- a non-retryable error,
+// or a retryable one that has exhausted its budget -- transitions the task straight
+// to failed and records fail_reason.
+//
+// err must not be nil. Returns true when the task was left retryable (state unchanged),
+// false when the task was transitioned to failed.
+func classifyFailure(
+	ctx context.Context,
+	label string,
+	taskProto *datapb.CompactionTask,
+	err error,
+	updateAndSaveTaskMeta func(opts ...compactionTaskOpt) error,
+) bool {
+	maxRetryTimes := paramtable.Get().DataCoordCfg.CompactionMaxRetryTimes.GetAsInt32()
+	retryTimes := taskProto.GetRetryTimes()
+
+	if merr.IsRetryableErr(err) && retryTimes < maxRetryTimes {
+		mlog.Warn(ctx, label+" failed with a retryable error, will retry",
+			mlog.Int64("planID", taskProto.GetPlanID()),
+			mlog.Int32("retryTimes", retryTimes+1),
+			mlog.Int32("maxRetryTimes", maxRetryTimes),
+			mlog.Err(err))
+		if saveErr := updateAndSaveTaskMeta(setRetryTimes(retryTimes + 1)); saveErr != nil {
+			mlog.Warn(ctx, label+" failed to persist retry_times", mlog.Int64("planID", taskProto.GetPlanID()), mlog.Err(saveErr))
+		}
+		return true
+	}
+
+	mlog.Error(ctx, label+" failed with a non-retryable error or exhausted its retry budget, marking task failed",
+		mlog.Int64("planID", taskProto.GetPlanID()),
+		mlog.Int32("retryTimes", retryTimes),
+		mlog.Int32("maxRetryTimes", maxRetryTimes),
+		mlog.Err(err))
+	if saveErr := updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed), setFailReason(err.Error())); saveErr != nil {
+		mlog.Warn(ctx, label+" failed to persist failed state", mlog.Int64("planID", taskProto.GetPlanID()), mlog.Err(saveErr))
+	}
+	return false
+}

--- a/internal/datacoord/compaction_task_retry_test.go
+++ b/internal/datacoord/compaction_task_retry_test.go
@@ -1,0 +1,118 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+func TestClassifyFailureSuite(t *testing.T) {
+	suite.Run(t, new(ClassifyFailureSuite))
+}
+
+type ClassifyFailureSuite struct {
+	suite.Suite
+}
+
+func (s *ClassifyFailureSuite) SetupTest() {
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.CompactionMaxRetryTimes.Key, "3")
+}
+
+func (s *ClassifyFailureSuite) TearDownTest() {
+	paramtable.Get().Reset(paramtable.Get().DataCoordCfg.CompactionMaxRetryTimes.Key)
+}
+
+// recordingSave stands in for a task type's updateAndSaveTaskMeta: it applies the opts to
+// a clone, exactly like the real ShadowClone-based implementations do, and remembers how
+// many times it was invoked.
+type recordingSave struct {
+	task  *datapb.CompactionTask
+	calls int
+}
+
+func (r *recordingSave) apply(opts ...compactionTaskOpt) error {
+	r.calls++
+	clone := proto.Clone(r.task).(*datapb.CompactionTask)
+	for _, opt := range opts {
+		opt(clone)
+	}
+	r.task = clone
+	return nil
+}
+
+func (s *ClassifyFailureSuite) TestRetryableUnderBudgetRetries() {
+	rec := &recordingSave{task: &datapb.CompactionTask{PlanID: 1, RetryTimes: 0}}
+	retried := classifyFailure(context.Background(), "test", rec.task, merr.WrapErrServiceUnavailable("transient"), rec.apply)
+
+	s.True(retried)
+	s.Equal(int32(1), rec.task.GetRetryTimes())
+	s.Equal(datapb.CompactionTaskState_unknown, rec.task.GetState())
+	s.Empty(rec.task.GetFailReason())
+	s.Equal(1, rec.calls)
+}
+
+func (s *ClassifyFailureSuite) TestRetryableAtBudgetTerminates() {
+	rec := &recordingSave{task: &datapb.CompactionTask{PlanID: 1, RetryTimes: 3}}
+	retried := classifyFailure(context.Background(), "test", rec.task, merr.WrapErrServiceUnavailable("transient"), rec.apply)
+
+	s.False(retried)
+	s.Equal(datapb.CompactionTaskState_failed, rec.task.GetState())
+	s.NotEmpty(rec.task.GetFailReason())
+	// retry_times is not bumped further once the budget is exhausted.
+	s.Equal(int32(3), rec.task.GetRetryTimes())
+}
+
+func (s *ClassifyFailureSuite) TestNonRetryableTerminatesImmediately() {
+	rec := &recordingSave{task: &datapb.CompactionTask{PlanID: 1, RetryTimes: 0}}
+	retried := classifyFailure(context.Background(), "test", rec.task, merr.WrapErrIllegalCompactionPlan("bad plan"), rec.apply)
+
+	s.False(retried)
+	s.Equal(datapb.CompactionTaskState_failed, rec.task.GetState())
+	s.Contains(rec.task.GetFailReason(), "bad plan")
+	s.Equal(int32(0), rec.task.GetRetryTimes())
+}
+
+func (s *ClassifyFailureSuite) TestRetryBudgetIsConfigurable() {
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.CompactionMaxRetryTimes.Key, "1")
+	rec := &recordingSave{task: &datapb.CompactionTask{PlanID: 1, RetryTimes: 1}}
+	retried := classifyFailure(context.Background(), "test", rec.task, merr.WrapErrServiceUnavailable("transient"), rec.apply)
+
+	s.False(retried, "retry_times already at the configured max of 1, should terminate")
+	s.Equal(datapb.CompactionTaskState_failed, rec.task.GetState())
+}
+
+func (s *ClassifyFailureSuite) TestRawErrorIsTreatedAsNonRetryable() {
+	// An error that isn't a merr sentinel (e.g. a raw KV/storage error) is not classified
+	// retryable by merr.IsRetryableErr, and must not be retried indefinitely.
+	rec := &recordingSave{task: &datapb.CompactionTask{PlanID: 1, RetryTimes: 0}}
+	retried := classifyFailure(context.Background(), "test", rec.task, errPlain("boom"), rec.apply)
+
+	s.False(retried)
+	s.Equal(datapb.CompactionTaskState_failed, rec.task.GetState())
+}
+
+type errPlain string
+
+func (e errPlain) Error() string { return string(e) }

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -1155,6 +1155,11 @@ func (s *Server) registerMetricsRequest() {
 			return s.meta.compactionTaskMeta.TaskStatsJSON(), nil
 		})
 
+	s.metricsRequest.RegisterMetricsRequest(metricsinfo.CompactionTaskFailureKey,
+		func(ctx context.Context, req *milvuspb.GetMetricsRequest, jsonReq gjson.Result) (string, error) {
+			return s.meta.compactionTaskMeta.FailureHistoryJSON(), nil
+		})
+
 	s.metricsRequest.RegisterMetricsRequest(metricsinfo.BuildIndexTaskKey,
 		func(ctx context.Context, req *milvuspb.GetMetricsRequest, jsonReq gjson.Result) (string, error) {
 			return s.meta.indexMeta.TaskStatsJSON(), nil

--- a/pkg/metrics/datacoord_metrics.go
+++ b/pkg/metrics/datacoord_metrics.go
@@ -192,7 +192,10 @@ var (
 			Namespace: milvusNamespace,
 			Subsystem: typeutil.DataCoordRole,
 			Name:      "compaction_task_num",
-			Help:      "Number of compaction tasks currently",
+			Help: "Number of compaction tasks. For status=pending/executing this is the number " +
+				"currently in that state. For status=done/failed/timeout this is a cumulative " +
+				"count of tasks that reached that terminal state since this process started " +
+				"(monotonically increasing, resets to 0 on DataCoord restart) -- not a live count.",
 		}, []string{
 			nodeIDLabelName,
 			compactionTypeLabelName,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -110,6 +110,8 @@ const (
 	Pending   = "pending"
 	Executing = "executing"
 	Done      = "done"
+	Failed    = "failed"
+	Timeout   = "timeout"
 
 	ImportStagePending      = "pending"
 	ImportStagePreImport    = "preimport"

--- a/pkg/util/metricsinfo/metric_request.go
+++ b/pkg/util/metricsinfo/metric_request.go
@@ -72,6 +72,10 @@ const (
 	// CompactionTaskKey request for get compaction tasks from the datacoord
 	CompactionTaskKey = "compaction_tasks"
 
+	// CompactionTaskFailureKey request for the bounded history of terminally-failed/timed-out
+	// compaction tasks from the datacoord, retained past normal task meta cleanup
+	CompactionTaskFailureKey = "compaction_task_failures"
+
 	// BuildIndexTaskKey request for get building index tasks from the datacoord
 	BuildIndexTaskKey = "build_index_tasks"
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5599,6 +5599,7 @@ type dataCoordConfig struct {
 	SegmentExpansionRate                       ParamItem `refreshable:"true"`
 	CompactionTimeoutInSeconds                 ParamItem `refreshable:"true"` // deprecated
 	CompactionDropToleranceInSeconds           ParamItem `refreshable:"true"`
+	CompactionMaxRetryTimes                    ParamItem `refreshable:"true"`
 	CompactionGCIntervalInSeconds              ParamItem `refreshable:"true"`
 	CompactionCheckIntervalInSeconds           ParamItem `refreshable:"false"` // deprecated
 	CompactionScheduleInterval                 ParamItem `refreshable:"false"`
@@ -6103,6 +6104,15 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 		Export:       true,
 	}
 	p.CompactionDropToleranceInSeconds.Init(base.mgr)
+
+	p.CompactionMaxRetryTimes = ParamItem{
+		Key:          "dataCoord.compaction.maxRetryTimes",
+		Version:      "2.6.11",
+		Doc:          "Max number of times a compaction task retries a retryable failure before it is marked failed permanently.",
+		DefaultValue: "3",
+		Export:       true,
+	}
+	p.CompactionMaxRetryTimes.Init(base.mgr)
 
 	p.CompactionGCIntervalInSeconds = ParamItem{
 		Key:          "dataCoord.compaction.gcInterval",


### PR DESCRIPTION

### Related Issue
Fixes #52708

---

### What this PR does / why we need it

DataCoord compaction has four task types (`mixCompactionTask`, `bumpSchemaVersionTask`, `l0CompactionTask`, `clusteringCompactionTask`). Previously, only `clusteringCompactionTask` implemented bounded retries (`merr.IsRetryableErr(err) && RetryTimes < 3`). The other three task types immediately transitioned to `failed` state on the first error, treating transient glitches (e.g. temporary network blips or busy DataNodes) the exact same as permanent failures.

Additionally, failure visibility was limited:
1. `fail_reason` on a task was erased when `cleanCompactionTaskMeta` deleted the task record after `CompactionDropToleranceInSeconds`.
2. `metrics.DataCoordCompactionTaskNum` incremented the `done` label for **every** finished task regardless of whether it succeeded, timed out, or failed.
3. `GetCompactionState`'s failure counters were scoped to manual `triggerID`s, making background compaction failures invisible to external observability tools.

This PR introduces shared bounded retry logic across `mix`, `bump_schema_version`, and `l0` compaction tasks, improves Prometheus metric accuracy, and adds long-lived failure history exposed via the `GetMetrics` endpoint.

---

### Key Changes

#### 1. Bounded Retry Classification (`compaction_task_retry.go`)
- Added `classifyFailure()` helper function:
  - Checks if an error is retryable via `merr.IsRetryableErr(err)` and whether `RetryTimes < maxRetryTimes` (default 3).
  - If retryable, increments `RetryTimes` and preserves the task state so it is re-attempted on the next scheduler tick.
  - If non-retryable or retries are exhausted, transitions the task state to `failed` and records the `fail_reason`.
- Wired `classifyFailure()` into failure paths across `compaction_task_mix.go`, `compaction_task_bump_schema_version.go`, and `compaction_task_l0.go`.

#### 2. Configuration (`component_param.go`)
- Introduced `dataCoord.compaction.maxRetryTimes` (`DataCoordCfg.CompactionMaxRetryTimes`, default `3`, refreshable) to control the retry budget across compaction tasks.

#### 3. Metrics (`metrics.go` & `compaction_inspector.go`)
- Added `Failed` and `Timeout` status labels to `metrics.DataCoordCompactionTaskNum`.
- `checkCompaction()` now inspects the terminal state of finished tasks to accurately count `done`, `failed`, and `timeout` metrics rather than folding all completed tasks into `done`.

#### 4. Diagnostic Failure History (`compaction_task_meta.go` & `server.go`)
- Added a 24-hour LRU cache (`failureHistory`, 256 entries) in `compactionTaskMeta` that records terminal task failures.
- Failure reasons survive even after `cleanCompactionTaskMeta` deletes the primary task record.
- Exposed failure history via the `GetMetrics` endpoint under the key `compaction_task_failures` (`metricsinfo.CompactionTaskFailureKey`).

---

### Out of Scope / Deferred to Follow-ups
- **Cross-Task Cooldown:** Segment-level cooldown across separate trigger cycles (which allocate fresh `PlanID`s and task structs) is explicitly deferred for a separate design discussion.
- **Clustering Task Refactoring:** `clusteringCompactionTask`'s existing retry implementation remains untouched to limit blast radius.

---

### Test Plan
- `compaction_task_retry_test.go`: Isolated unit test suite for `classifyFailure()` (retryable vs non-retryable errors, max retry limits, parameter overrides).
- `compaction_task_mix_test.go`, `compaction_task_bump_schema_version_test.go`, `compaction_task_l0_test.go`: Verified retry increments and failure transitions end-to-end through real task execution paths.
- `compaction_task_meta_test.go`: Verified `TestFailureHistorySurvivesTaskMetaDrop` to confirm failure reasons outlive task deletion.
- `compaction_inspector_test.go`: Updated metric assertion tests to ensure `done`, `failed`, and `timeout` labels are properly recorded.

---

### Does this PR introduce breaking changes?
- [ ] Yes
- [x] No

> **Note on Metrics:** The Prometheus metric `datacoord_compaction_task_num` has no change to its metric name or label keys. However, the `done` status label will now accurately exclude failed/timed-out tasks.
