### PR TITLE
test: stop pinning the knowhere codec list in test_sparse_index_rejects_invalid_codec

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_sparse_inverted_index.py
+++ b/tests/python_client/milvus_client/test_milvus_client_sparse_inverted_index.py
@@ -1124,7 +1124,10 @@ class TestSparseInvertedIndexV3Negative(_SparseInvertedIndexV3Base):
             "bad_codec",
             "IP",
             {"inverted_index_algo": "DAAT_MAXSCORE", "inverted_index_codec": "invalid_codec"},
-            "inverted_index_codec invalid_codec not found or not supported, supported: [block_streamvbyte block_maskedvbyte]: invalid parameter",
+            # The trailing ", supported: [...]" list is generated from the knowhere
+            # codec registry and grows with every knowhere upgrade, so only assert the
+            # version-independent rejection prefix here.
+            "inverted_index_codec invalid_codec not found or not supported",
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- team2-testfix:52645 -->
fix: #52645

## What

Test-only change. `test_sparse_index_rejects_invalid_codec` asserted the full server error message, including the `supported: [...]` list that knowhere generates. That list legitimately grows when knowhere is upgraded (it gained `block_adaptive`), so the assertion breaks on a correct server. The expectation is narrowed to the part that does not drift:

```
"inverted_index_codec invalid_codec not found or not supported"
```

The check is a substring match (`assert error_dict[err_msg] in res.message`), so the shortened expectation still verifies that the invalid codec is rejected, and the error-code assertion (1100) is unchanged. Sibling negative cases in the same file (`inverted_index_algo`, `quant_type`) already use this short-prefix form; this makes the codec case consistent with them. No product code is touched.

## Why this is not a server bug

- `grep -rn "block_streamvbyte\|block_maskedvbyte\|block_adaptive"` over the repository matches only this test file. The parameter name and the `supported: [...]` list come from the knowhere binary; Milvus passes the parameters through `ValidateIndexParams` (cgo).
- The error code is 1100 on both sides and the rejection path executes correctly — only the set of supported codecs grew.
- There is no upstream fix to backport: the hardcoded string was introduced in `0bbe4d02a8` (#50775) and has not been touched since.
- No cross-repo change is involved: pymilvus only relays the server's error message; the proto is unchanged.

## Evidence

The single failing case was run against one running Milvus instance, alternating unpatched/patched twice each (`milvus_client/test_milvus_client_sparse_inverted_index.py::TestSparseInvertedIndexV3Negative::test_sparse_index_rejects_invalid_codec`):

| run | unpatched | patched |
|---|---|---|
| 1 | fails with the reported assertion | passes |
| 2 | fails with the reported assertion | passes |

---
_Automated draft from the team2 pipeline. Not auto-merged; please review._
