### PR TITLE
enhance: optimize computeRecall using hash set instead of nested loop

### DIFF
--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1572,18 +1572,22 @@ func translatePkOutputFields(schema *schemapb.CollectionSchema) ([]string, []int
 }
 
 func recallCal[T string | int64](results []T, gts []T) float32 {
+	if len(results) == 0 {
+		return 0
+	}
+
+	gtSet := make(map[T]struct{}, len(gts))
+	for _, gt := range gts {
+		gtSet[gt] = struct{}{}
+	}
+
 	hit := 0
-	total := 0
 	for _, r := range results {
-		total++
-		for _, gt := range gts {
-			if r == gt {
-				hit++
-				break
-			}
+		if _, ok := gtSet[r]; ok {
+			hit++
 		}
 	}
-	return float32(hit) / float32(total)
+	return float32(hit) / float32(len(results))
 }
 
 func computeRecall(results *schemapb.SearchResultData, gts *schemapb.SearchResultData) error {


### PR DESCRIPTION
## What this PR does

`recallCal` in `internal/proxy/util.go` uses a nested loop to compute recall, which is O(n*m). When topk is large (e.g. 100000), this results in 10^10 comparisons and takes several seconds per query.

This PR replaces the nested loop with a hash set, reducing the complexity to O(n+m).

## Benchmark (topk = 100000)

| Implementation | Complexity | Time |
| --- | --- | --- |
| nested loop (before) | O(n*m) = 10^10 | ~3.08s |
| hash set (after) | O(n+m) | ~18.5ms |

~166x faster.

issue: #52764
pr: #52762 

Signed-off-by: chasingegg