### PR TITLE
enhance: optimize computeRecall using hash set instead of nested loop

### DIFF
--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1641,18 +1641,22 @@ func translatePkOutputFields(schema *schemapb.CollectionSchema) ([]string, []int
 }
 
 func recallCal[T string | int64](results []T, gts []T) float32 {
+	if len(results) == 0 {
+		return 0
+	}
+
+	gtSet := make(map[T]struct{}, len(gts))
+	for _, gt := range gts {
+		gtSet[gt] = struct{}{}
+	}
+
 	hit := 0
-	total := 0
 	for _, r := range results {
-		total++
-		for _, gt := range gts {
-			if r == gt {
-				hit++
-				break
-			}
+		if _, ok := gtSet[r]; ok {
+			hit++
 		}
 	}
-	return float32(hit) / float32(total)
+	return float32(hit) / float32(len(results))
 }
 
 func computeRecall(results *schemapb.SearchResultData, gts *schemapb.SearchResultData) error {


### PR DESCRIPTION
Replaces the nested loop in `recallCal` with a hash set, reducing complexity from O(n*m) to O(n+m). For topk=100000 this cuts ~3.08s down to ~18.5ms.

issue: #52764

Signed-off-by: chasingegg