### PR TITLE
test: [3.0] fix flaky InvertedIndex.HasLackBinlogRows (#52733)

### DIFF
--- a/internal/core/src/index/InvertedIndexTest.cpp
+++ b/internal/core/src/index/InvertedIndexTest.cpp
@@ -169,6 +169,8 @@ test_run() {
             default_value->set_float_data(20);
         } else if constexpr (std::is_same_v<double, T>) {
             default_value->set_double_data(20);
+        } else if constexpr (std::is_same_v<bool, T>) {
+            default_value->set_bool_data(true);
         }
     }
 


### PR DESCRIPTION
Cherry-pick from master
pr: #52733

## Summary

Set the bool default value explicitly in InvertedIndex.HasLackBinlogRows so the filled value and the In/NotIn expectation use the same value. This removes the random failure when the first ten generated bool values are identical.

## Backport notes

- Applied cleanly on the latest 3.0 branch with no branch-specific adaptation.
- The stable patch-id exactly matches source commit 4e4c4bb4ce6cbc1e83003ab6ca03e5860979fbd5.
- #52721 is already merged into 3.0, so it is not duplicated in this PR.

## Verification

- git diff --check — passed.
- clang-format 22.1.0 --dry-run --Werror on InvertedIndexTest.cpp — passed.
- Source PR verification: InvertedIndex.HasLackBinlogRows repeated 20 times — 20/20 passed; InvertedIndex.* — 4/4 passed.
- No local C++ test binary was available in the isolated 3.0 worktree; target-branch execution is delegated to PR CI.