### PR TITLE
fix: add configurable single-message size limit for Woodpecker WAL

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -196,6 +196,7 @@ woodpecker:
       maxRetries: 3 # Maximum number of retries for segment append operations.
       maxBatchEntries: 1000 # Client-side group commit: max consecutive appends coalesced into one AddEntries request. Opportunistic (only batches already-queued ops, adds no latency at low load). Set to 1 to disable batching.
       maxBatchBytes: 2000000 # Max total payload (bytes) of a coalesced batch, default 2MB. A batch closes once it reaches maxBatchEntries or its payload reaches maxBatchBytes; the first entry is always taken, so a batch may exceed the byte cap by one entry. Set to 0 to remove the byte limit (bounded by maxBatchEntries only). Ignored when maxBatchEntries <= 1.
+      maxSingleMessageSize: 10485760 # Maximum size of a single WAL entry in bytes, default 10MB. A row whose encoded size exceeds this limit is rejected on the client before it is queued for append, instead of being retried indefinitely against the WAL backend.
     segmentRollingPolicy:
       maxSize: 256M # Maximum size of a segment.
       maxInterval: 10m # Maximum interval between two segments, default is 10 minutes.

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -196,7 +196,7 @@ woodpecker:
       maxRetries: 3 # Maximum number of retries for segment append operations.
       maxBatchEntries: 1000 # Client-side group commit: max consecutive appends coalesced into one AddEntries request. Opportunistic (only batches already-queued ops, adds no latency at low load). Set to 1 to disable batching.
       maxBatchBytes: 2000000 # Max total payload (bytes) of a coalesced batch, default 2MB. A batch closes once it reaches maxBatchEntries or its payload reaches maxBatchBytes; the first entry is always taken, so a batch may exceed the byte cap by one entry. Set to 0 to remove the byte limit (bounded by maxBatchEntries only). Ignored when maxBatchEntries <= 1.
-      maxSingleMessageSize: 10485760 # Maximum size of a single WAL entry in bytes, default 10MB. A row whose encoded size exceeds this limit is rejected on the client before it is queued for append, instead of being retried indefinitely against the WAL backend.
+      maxSingleMessageSize: 10485760 # Maximum size of a single WAL entry in bytes, default 10MB. A row whose encoded size exceeds this limit is rejected on the client before it is queued for append, instead of being retried indefinitely against the WAL backend. Unlike other segmentAppend settings, this is a Milvus-side check only (Woodpecker itself has no per-entry size limit); it is re-read on every check, so it takes effect without a restart.
     segmentRollingPolicy:
       maxSize: 256M # Maximum size of a segment.
       maxInterval: 10m # Maximum interval between two segments, default is 10 minutes.

--- a/internal/proxy/channelmgr/msg_pack.go
+++ b/internal/proxy/channelmgr/msg_pack.go
@@ -45,9 +45,11 @@ func getMaxSingleRowSize(walName message.WALName) (int, bool) {
 	case message.WALNameKafka:
 		limit := paramtable.Get().KafkaCfg.ProducerMessageMaxBytes.GetAsInt()
 		return limit, limit > 0
-	case message.WALNameRocksmq, message.WALNameWoodpecker:
-		// RocksMQ page size and Woodpecker batch size are not hard limits
-		// on an individual WAL entry.
+	case message.WALNameWoodpecker:
+		limit := paramtable.Get().WoodpeckerCfg.MaxMessageSize.GetAsInt()
+		return limit, limit > 0
+	case message.WALNameRocksmq:
+		// RocksMQ page size is not a hard limit on an individual WAL entry.
 		return 0, false
 	default:
 		return 0, false

--- a/internal/proxy/channelmgr/msg_pack_test.go
+++ b/internal/proxy/channelmgr/msg_pack_test.go
@@ -66,6 +66,8 @@ func TestGenInsertMsgsByPartitionUsesWALSpecificSingleRowLimit(t *testing.T) {
 	defer paramtable.Get().Reset(paramtable.Get().PulsarCfg.MaxMessageSize.Key)
 	assert.NoError(t, paramtable.Get().Save(paramtable.Get().KafkaCfg.ProducerMessageMaxBytes.Key, "2048"))
 	defer paramtable.Get().Reset(paramtable.Get().KafkaCfg.ProducerMessageMaxBytes.Key)
+	assert.NoError(t, paramtable.Get().Save(paramtable.Get().WoodpeckerCfg.MaxMessageSize.Key, "2048"))
+	defer paramtable.Get().Reset(paramtable.Get().WoodpeckerCfg.MaxMessageSize.Key)
 
 	t.Run("kafka allows row above pulsar split threshold", func(t *testing.T) {
 		insertMsg := newVarCharInsertMsgForPackTest(strings.Repeat("x", 1024))
@@ -81,14 +83,26 @@ func TestGenInsertMsgsByPartitionUsesWALSpecificSingleRowLimit(t *testing.T) {
 		assert.ErrorIs(t, err, merr.ErrParameterTooLarge)
 	})
 
-	for _, walName := range []message.WALName{message.WALNameRocksmq, message.WALNameWoodpecker} {
-		t.Run(walName.String()+" has no single row limit", func(t *testing.T) {
-			insertMsg := newVarCharInsertMsgForPackTest(strings.Repeat("x", 1024))
-			msgs, err := GenInsertMsgsByPartition(context.Background(), 0, 1, "test_partition", []int{0}, "test_channel", insertMsg, walName)
-			assert.NoError(t, err)
-			assert.Len(t, msgs, 1)
-		})
-	}
+	t.Run("woodpecker allows row above pulsar split threshold", func(t *testing.T) {
+		insertMsg := newVarCharInsertMsgForPackTest(strings.Repeat("x", 1024))
+		msgs, err := GenInsertMsgsByPartition(context.Background(), 0, 1, "test_partition", []int{0}, "test_channel", insertMsg, message.WALNameWoodpecker)
+		assert.NoError(t, err)
+		assert.Len(t, msgs, 1)
+	})
+
+	t.Run("woodpecker rejects row at its own limit", func(t *testing.T) {
+		insertMsg := newVarCharInsertMsgForPackTest(strings.Repeat("x", 2048))
+		msgs, err := GenInsertMsgsByPartition(context.Background(), 0, 1, "test_partition", []int{0}, "test_channel", insertMsg, message.WALNameWoodpecker)
+		assert.Nil(t, msgs)
+		assert.ErrorIs(t, err, merr.ErrParameterTooLarge)
+	})
+
+	t.Run("rocksmq has no single row limit", func(t *testing.T) {
+		insertMsg := newVarCharInsertMsgForPackTest(strings.Repeat("x", 1024))
+		msgs, err := GenInsertMsgsByPartition(context.Background(), 0, 1, "test_partition", []int{0}, "test_channel", insertMsg, message.WALNameRocksmq)
+		assert.NoError(t, err)
+		assert.Len(t, msgs, 1)
+	})
 }
 
 func TestGenInsertMsgsByPartitionSplitsMultipleRows(t *testing.T) {

--- a/pkg/util/paramtable/service_param.go
+++ b/pkg/util/paramtable/service_param.go
@@ -731,6 +731,7 @@ type WoodpeckerConfig struct {
 	AppendMaxRetries          ParamItem `refreshable:"true"`
 	AppendMaxBatchEntries     ParamItem `refreshable:"false"`
 	AppendMaxBatchBytes       ParamItem `refreshable:"false"`
+	MaxMessageSize            ParamItem `refreshable:"true"`
 	SegmentRollingMaxSize     ParamItem `refreshable:"true"`
 	SegmentRollingMaxTime     ParamItem `refreshable:"true"`
 	SegmentRollingMaxBlocks   ParamItem `refreshable:"true"`
@@ -829,6 +830,15 @@ func (p *WoodpeckerConfig) Init(base *BaseTable) {
 		Export:       true,
 	}
 	p.AppendMaxBatchBytes.Init(base.mgr)
+
+	p.MaxMessageSize = ParamItem{
+		Key:          "woodpecker.client.segmentAppend.maxSingleMessageSize",
+		Version:      "2.6.21",
+		DefaultValue: strconv.Itoa(10 * 1024 * 1024),
+		Doc:          "Maximum size of a single WAL entry in bytes, default 10MB. A row whose encoded size exceeds this limit is rejected on the client before it is queued for append, instead of being retried indefinitely against the WAL backend. Unlike other segmentAppend settings, this is a Milvus-side check only (Woodpecker itself has no per-entry size limit); it is re-read on every check, so it takes effect without a restart.",
+		Export:       true,
+	}
+	p.MaxMessageSize.Init(base.mgr)
 
 	p.SegmentRollingMaxSize = ParamItem{
 		Key:          "woodpecker.client.segmentRollingPolicy.maxSize",

--- a/pkg/util/paramtable/service_param_test.go
+++ b/pkg/util/paramtable/service_param_test.go
@@ -128,6 +128,7 @@ func TestServiceParam(t *testing.T) {
 		assert.Equal(t, wpCfg.AppendMaxRetries.GetAsInt(), 3)
 		assert.Equal(t, wpCfg.AppendMaxBatchEntries.GetAsInt(), 1000)
 		assert.Equal(t, wpCfg.AppendMaxBatchBytes.GetAsSize(), int64(2000000))
+		assert.Equal(t, wpCfg.MaxMessageSize.GetAsSize(), int64(10*1024*1024))
 		assert.Equal(t, wpCfg.SegmentRollingMaxSize.GetAsSize(), int64(256*1024*1024))
 		assert.Equal(t, wpCfg.SegmentRollingMaxTime.GetAsDurationByParse().Seconds(), float64(600))
 		assert.Equal(t, wpCfg.SegmentRollingMaxBlocks.GetAsInt64(), int64(1000))


### PR DESCRIPTION
PR Body:
issue: #52474

## Summary

Pulsar and Kafka both reject an oversized row on the proxy before it reaches
the WAL (`pulsar.maxMessageSize`, `kafka.producer.message.max.bytes`,
enforced in `channelmgr.getMaxSingleRowSize`). Woodpecker had no equivalent —
`getMaxSingleRowSize` explicitly returned "no limit" for it, so an oversized
row would be queued for append and retried indefinitely against the backend,
the same DML-channel-stall failure mode fixed for Pulsar/BookKeeper in #52413.

The vendored `zilliztech/woodpecker` library has no per-entry size field of
its own to enforce this (only batch-payload and gRPC transport caps, neither
of which reject a single large entry), so the guard has to live on the
Milvus side — the same way it already does for Pulsar.

## Changes

- Add `woodpecker.client.segmentAppend.maxSingleMessageSize`
  (`WoodpeckerConfig.MaxMessageSize`), default 10MiB, matching Kafka's
  default. Refreshable at runtime — it's a pure client-side check, not baked
  into an already-constructed client, so no restart is needed.
- Wire it into `channelmgr.getMaxSingleRowSize` for `WALNameWoodpecker`,
  giving it its own case instead of being grouped with RocksMQ's "no limit"
  case.
- `configs/milvus.yaml`: document the new default.
- Tests: split the old combined "rocksmq+woodpecker have no limit" test;
  Woodpecker now gets its own accept/reject-at-limit pair (mirroring the
  existing Kafka test), RocksMQ keeps its "no limit" behavior.

## Why this is safe

The check runs in `GenInsertMsgsByPartition` before any row is queued for
append, so an oversized row now fails fast with `ErrParameterTooLarge`
instead of being retried against the backend. No change to RocksMQ, and no
change to the existing cross-WAL packing threshold (`PulsarCfg.MaxMessageSize`),
which is a separate, intentionally backend-agnostic batching threshold, not
a hard per-backend limit.