### PR TITLE
enhance: chunk oversized WAL payloads at the storage layer, drop proxy size-based packing

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -190,6 +190,10 @@ woodpecker:
   meta:
     type: etcd # The Type of the metadata provider. currently only support etcd.
     prefix: woodpecker # The Prefix of the metadata provider, prepended with etcd.rootPath. default is woodpecker. Only takes effect on an etcd with no pre-existing woodpecker metadata under the legacy root 'woodpecker/' prefix; if legacy metadata is detected, the legacy prefix is reused for backward compatibility.
+  # The target maximum size of each Woodpecker WAL record produced by Milvus. Unit: Byte.
+  # Woodpecker does not enforce a corresponding single-entry hard limit. Milvus uses this value as the WAL-layer chunk threshold and splits larger payloads into multiple records.
+  # Values below 256 KiB are clamped to 256 KiB. Invalid or out-of-range values fall back to the default 10 MiB limit.
+  maxMessageSize: 10485760
   client:
     segmentAppend:
       queueSize: 10000 # The size of the queue for pending messages to be sent of each log.
@@ -281,9 +285,13 @@ pulsar:
   port: 6650 # Port of Pulsar service.
   webport: 80 # Web port of of Pulsar service. If you connect direcly without proxy, should use 8080.
   # The maximum size of each message in Pulsar. Unit: Byte.
-  # By default, Pulsar can transmit at most 2MB of data in a single message. When the size of inserted data is greater than this value, proxy fragments the data into multiple messages to ensure that they can be transmitted correctly.
-  # If the corresponding parameter in Pulsar remains unchanged, increasing this configuration will cause Milvus to fail, and reducing it produces no advantage.
+  # By default, Pulsar can transmit at most 2MB of data in a single message. When streaming.splitChunkSN is enabled, the StreamingNode WAL layer splits larger payloads into multiple records that fit this limit.
+  # Values below 256 KiB are clamped to 256 KiB. The Pulsar broker/proxy limit must be no smaller than this effective value; otherwise Pulsar can still reject records that Milvus considers valid. Invalid or out-of-range values fall back to the default 2 MiB limit.
   maxMessageSize: 2097152
+  # The headroom reserved out of the active WAL backend's message-size limit (pulsar.maxMessageSize, kafka.producer.message.max.bytes, or woodpecker.maxMessageSize) for message overhead outside the plaintext body. Unit: Byte.
+  # A produced record carries a streaming message header, properties added before WAL append, cipher metadata/expansion, and broker message metadata on top of the body, so the producer budgets only the active WAL backend's own message-size limit minus this value for the body itself.
+  # Must be a 32-bit integer of at least 1024 bytes and smaller than the active WAL backend's message-size limit: a smaller reserve cannot absorb one record's envelope, so a full-budget chunk would still be rejected by the backend. Invalid or out-of-range values fall back to the default reserve size.
+  messageReserveSize: 65536
   # Pulsar can be provisioned for specific tenants with appropriate capacity allocated to the tenant.
   # To share a Pulsar instance among multiple Milvus instances, you can change this to an Pulsar tenant rather than the default one for each Milvus instance before you start them. However, if you do not want Pulsar multi-tenancy, you are advised to change msgChannel.chanNamePrefix.cluster to the different value.
   tenant: public
@@ -316,7 +324,7 @@ pulsar:
 #   producer:
 #     message:
 #       max:
-#         bytes: 10485760 # Maximum size of a Kafka producer message in bytes. Requires a restart to take effect.
+#         bytes: 10485760 # Maximum size of a Kafka producer message in bytes. Values below 256 KiB are clamped to 256 KiB; invalid or out-of-range values fall back to the default 10 MiB. Kafka broker/topic limits must support the configured value. Requires a restart to take effect.
 #   readTimeout: 10
 #   queuedmaxkbytes: 100000
 
@@ -379,6 +387,10 @@ rootCoord:
 
 # Related configuration of proxy, used to validate client requests and reduce the returned results.
 proxy:
+  # Whether Proxy keeps the legacy row-based size packing before sending messages to StreamingNode.
+  # Keep this enabled until chunk writing is enabled and observed on every StreamingNode that can own a pchannel.
+  # For migration, enable streaming.splitChunkSN first, then disable proxy.splitChunk. Both parameters support live refresh.
+  splitChunk: true
   timeTickInterval: 200 # The interval at which proxy synchronizes the time tick, unit: ms.
   healthCheckTimeout: 3000 # ms, the interval that to do component healthy check
   msgStream:
@@ -1267,7 +1279,19 @@ quotaAndLimits:
     complexDeleteLimitEnable: false # whether complex delete check forward data by limiter
     maxCollectionNum: 65536
     maxCollectionNumPerDB: 65536 # Maximum number of collections per database.
-    maxInsertSize: -1 # maximum size of a single insert request, in bytes, -1 means no limit
+    # maximum protobuf size of the Proxy-side materialized insert message, in bytes,
+    # for both insert and upsert; -1 means no limit. The check runs after Proxy field
+    # materialization, including generated fields, row IDs, timestamps, namespace data,
+    # and partial-upsert query reconstruction. It does not include later streaming-message
+    # properties, encryption expansion, StreamingNode-generated function fields, or the
+    # broker envelope.
+    maxInsertSize: 67108864
+    # maximum protobuf size of each Proxy-side materialized delete message, in bytes,
+    # for both delete and upsert tombstones; -1 means no limit. The check runs after
+    # primary keys and timestamps are materialized and routed to a vchannel. It does
+    # not include later streaming-message properties, encryption expansion, chunk
+    # markers, or the broker envelope.
+    maxDeleteSize: 16777216
     maxResourceGroupNumOfQueryNode: 1024 # maximum number of resource groups of query nodes
     maxGroupSize: 10 # maximum size for one single group when doing search group by
   ddl:
@@ -1476,6 +1500,10 @@ streamingNode:
 
 # Any configuration related to the streaming service.
 streaming:
+  # Whether StreamingNode splits oversized logical messages into physical WAL records.
+  # Enable this on every StreamingNode and confirm the live update before disabling proxy.splitChunk.
+  # Once chunk records have been written, do not roll StreamingNode back to a version that cannot reassemble them. Both parameters support live refresh.
+  splitChunkSN: false
   walBalancer:
     # The interval of balance task trigger at background, 1 min by default.
     # It's ok to set it into duration string, such as 30s or 1m30s, see time.ParseDuration

--- a/docs/design-docs/design_docs/20260822-wal-payload-chunking.md
+++ b/docs/design-docs/design_docs/20260822-wal-payload-chunking.md
@@ -1,0 +1,429 @@
+# WAL payload chunking: oversized records split at the storage layer
+
+- Status: Implementing (this PR)
+- Date: 2026-08-22
+- Scope: `pkg/streaming/util/message/{builder,chunk}.go`, `pkg/util/fastpb/insert_request_*.go`, `internal/streamingnode/server/wal/adaptor/{wal_adaptor,scanner_adaptor}.go`, `internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go`, `internal/streamingnode/server/service/handler/producer/produce_server.go`, `internal/proxy/{task_insert_streaming,task_delete,task_upsert_streaming}.go`, `internal/proxy/channelmgr/msg_pack.go`, `pkg/util/paramtable/{component_param,service_param}.go`
+- Related: #52474 (woodpecker.maxMessageSize); supersedes the size-packing half and reuses the direct-encoding half of the `insert-repack-view-encoder` line of work
+
+## 1. Problem
+
+Pulsar and Kafka enforce hard caps on a single record: Pulsar rejects above
+`pulsar.maxMessageSize` (default 2 MiB, and the broker's own cap applies
+regardless), and Kafka above `message.max.bytes`. Woodpecker has no equivalent
+single-entry hard cap; this PR adds `woodpecker.maxMessageSize` as a Milvus WAL
+chunk threshold so Woodpecker records use the same bounded granularity. When a
+record crosses an enforced backend cap, the failure surfaces as an append error that
+`appendOneWithRetry` classifies as recoverable — an infinite backoff loop.
+Nothing between the producer and the broker can shrink the message, so **one
+oversized insert permanently stalls the pchannel's write path**.
+
+The proxy's row packing targets the Pulsar-shaped threshold, but it budgets
+entity bytes only: the final materialized record adds the streaming header,
+properties, and cipher expansion on top, and only the partial-update-CAS path
+re-validates and re-splits the built message. A normal insert whose final
+envelope crosses the backend limit — envelope growth, cipher expansion, or any
+drift between the Milvus config and the broker's — reaches the WAL as one
+oversized record.
+
+## 2. Design
+
+**P1 — Chunk at the storage layer, below the interceptor chain.** The payload
+is an opaque byte blob there: no protobuf is unmarshaled or re-marshaled. The
+exact bytes the backend would have stored are sliced in place. Every
+interceptor (txn, timetick, fencing) and every consumer above the WAL sees
+complete messages only — chunking is invisible to them.
+
+**P2 — The reader reassembles before any interpretation.** The scanner
+adaptor feeds every incoming message through a `ChunkAssembler` at the head of
+`handleUpstream`, before filtering, reordering, or the txn buffer. A chunk is
+never a valid message body, so nothing downstream ever parses one.
+
+**P3 — Chunks are self-describing; the log needs no contiguity.** Every
+chunk carries the original message's time tick (unique per message on a
+pchannel) plus its index/total markers, so packs may interleave freely with
+any other traffic in the log — the consumer pairs chunks by time tick, not
+by adjacency. No write-side coordination is added on a path where master
+runs appends fully concurrently.
+
+**P4 — The successful first-chunk attempt's message ID is the logical message
+ID.** The append caller is acked with the ID returned by the successful append
+of chunk 0. A backend may persist an earlier attempt and still return an error,
+so the reader replaces a payload-identical duplicate slot with the later log
+observation. The reassembled message therefore carries the same successful
+chunk-0 ID whether it comes from WAB tailing or durable catch-up.
+`LastConfirmedMessageID` remains conservative: it is derived from the logical
+ID after every chunk of the run has already been persisted.
+
+### 2.1 Chunk format
+
+```
+payload (bytes)  ──slice──▶  [ c0 | c1 | ... | cN-1 ]   each ≤ limit - reserve
+chunk record     =  payload slice + FULL clone of the original properties
+                    + _ci (0-based index) + _ct (total count)
+reassembled      =  concat(slices), properties of c0 minus _ci/_ct, ID of c0
+```
+
+Every chunk carries the complete property set, not a skeleton: backends and
+walimpls-level delivery filters make per-record decisions from properties, so
+each chunk must be delivered exactly where the whole message would have been.
+The reserve (`pulsar.messageReserveSize`, default 64 KiB) absorbs the
+per-record envelope — properties clone, cipher metadata/expansion, broker
+metadata — so a chunk record never crosses the backend cap. The *effective*
+reserve is clamped to at least 1 KiB: a smaller value cannot cover any
+envelope, so a full-budget chunk would still be rejected and retried forever —
+the very stall this design removes. A configured reserve below the minimum, or
+one that does not fit under the active limit, falls back to the 64 KiB default.
+Every bounded WAL message-size configuration is itself clamped to at least
+256 KiB, so the default reserve always fits. External Pulsar broker/proxy and
+Kafka broker/topic caps must be no smaller than the corresponding effective
+Milvus limit; clamping Milvus configuration cannot raise an external cap.
+
+`_ci`/`_ct` are reserved: chunks are created below the interceptor chain and the
+markers are stripped again on reassembly, so a message arriving at the produce
+API can never legitimately carry them. `ProduceServer.validateMessage` rejects
+one that does. Without that check a foreign record would be read back as a
+corrupted chunk run and fail-stop the pchannel (§2.3), turning a bad input into
+a channel-wide outage.
+
+`SplitIntoChunks` returns the message unchanged when the payload fits or the
+budget is zero (for an unbounded backend such as RocksMQ); `IsChunkedPayload`
+recognizes a record carrying either reserved marker, and the assembler then
+requires the `_ci`/`_ct` pair to be valid.
+
+### 2.2 Write path
+
+Two independent, live-refreshable switches control the write path:
+
+- `proxy.splitChunk` defaults to `true`. While true, Proxy retains the
+  legacy row-based size packing path; while false, it builds one logical
+  message per channel/partition.
+- `streaming.splitChunkSN` defaults to `false`. While false, StreamingNode calls
+  `appendOneWithRetry` without creating physical chunks; while true, it computes
+  the backend payload budget and runs
+  `SplitIntoChunks(msg, chunkPayloadSize())` → `appendOneWithRetry` per chunk →
+  return chunk 0's ID.
+
+Records that fit, and backends without a per-record cap, still use the
+single-record path. Separating the switches gives the rollout a safe bridge
+state: enable SN chunking everywhere while Proxy packing remains enabled, then
+disable Proxy packing. There is no assignment watch or global StreamingVersion
+dependency in the append path.
+
+There is no lock anywhere on this path: master runs
+appends fully concurrently and that property is preserved for all traffic,
+oversized included. A run that fails unrecoverably midway leaves the caller
+un-acked with a partial run in the log; the reader never assembles it and the
+scanner keeps it incomplete, while the client's retry writes a fresh run under
+a newly assigned time tick.
+
+`chunkPayloadSize()` = `WALMaxMessageSize(backend) - reserve`, served from a
+1-second cache because `GetAsInt` on refreshable items is not per-append hot
+path work. A downward live config refresh takes effect within that window.
+
+`WALMaxMessageSize` is the single place a WAL name maps to its chunking limit:
+Pulsar and Kafka return their effective configured per-record limits, while
+Woodpecker returns the Milvus-configured `woodpecker.maxMessageSize` threshold.
+All three configuration items clamp numeric values below 256 KiB to 256 KiB;
+malformed or out-of-range values use their shipped backend default. **Anything else,
+including RocksMQ, returns 0**, which disables chunking entirely: RocksMQ's
+page size is not a per-entry cap, and its pre-chunking behavior (store the
+oversized record as-is) is preserved.
+
+### 2.3 Read path
+
+`ChunkAssembler.Push(msg)` at the head of `handleUpstream`, pairing chunks
+into per-time-tick runs (packs may interleave; §3):
+
+| Input | State | Result |
+|---|---|---|
+| ordinary non-chunk message | state untouched | process normally |
+| TimeTick T | discard incomplete runs at or below T | process normally |
+| first chunk of an unseen time tick | open a run | swallow |
+| chunk filling a missing slot of its run | buffer at its index | swallow; if all `_ct` slots filled → emit reassembled message |
+| chunk duplicating an already-filled slot payload byte-for-byte | redelivery (persisted-but-unacked retry rewrites it under a new message ID) | replace the slot with the later observation, then swallow |
+| malformed markers, same slot with different bytes, or total mismatch inside one time tick | corruption | fail the scanner; the flusher marks the current WAL unavailable, so recovery cannot advance its checkpoint and new writes are rejected |
+| middle chunk of an unknown time tick | nothing joinable | swallow |
+
+There is no count/byte limit and no silent eviction. The number of concurrently
+open runs does not prove that the oldest writer is dead; rejecting or evicting
+it can make a successfully persisted WAL impossible to replay or silently lose
+a message whose writer later persists the remaining chunks and is acknowledged.
+The next TimeTick is a safe cleanup barrier: after observing T, no live writer
+can still append chunks for a run whose time tick is at or below T. The
+assembler discards those proven-orphan runs while retaining newer runs.
+
+An interrupted run never completes on its own. It remains local until a
+TimeTick proves it orphaned (or the scanner closes); the producer was never
+successfully acknowledged, and a client retry uses a new timetick. Durable WAL
+records pass through one assembler before legacy-v0 conversion and all later
+filter/reorder/transaction handling. Tailing reads use the write-ahead buffer's
+already-logical messages. A corrupt run is propagated through the producer
+loop and fail-stops the scanner, so recovery cannot move its checkpoint past
+incomplete acknowledged data.
+
+### 2.4 Proxy side: size-based packing retained as the compatibility mode
+
+While `proxy.splitChunk=true`, Proxy keeps its existing size-driven packing.
+Once that switch is disabled (after `streaming.splitChunkSN=true` is active on
+every possible SN owner), Proxy uses the logical-message path:
+
+- **Insert**: one message per (channel, partition) group. Existing
+  `InsertRequestViewEncoder` borrows the source columns and ordered row offsets,
+  computes the exact wire size, and writes the selection directly into the
+  final protobuf payload through `WithBodyEncoder`. It does not materialize
+  destination `FieldsData`, row-ID, or timestamp slices. The normal builder
+  still owns header creation, optional encryption, and the final payload.
+  There are no entity-size estimates, envelope re-validation, or single-row
+  rejection: chunking slices bytes without row semantics, so even one row can
+  ride through up to the logical-message bound in §2.5.
+- **Delete**: one tombstone batch per hashed channel, bounded by the 16 MiB
+  logical-message limit in §2.5. This also eliminates a latent master bug where
+  a first PK already over the old backend-derived packing limit produced an
+  empty first `DeleteMsg` that was still allocated an ID and appended.
+- **Partial-update CAS** survives everything by construction: it is written
+  into the encoder's fresh `InsertRequest` template before exact-size planning,
+  then `MarkPartialUpdateCASForBodyEncoder` adds the message-property marker.
+  Both ride along — body verbatim through slicing/reassembly, properties via
+  the full per-chunk clone (§2.1).
+- The proxy→SN transport is not the bottleneck: the streaming gRPC channel
+  pins all four message-size caps at 256 MB (`streamingNode.grpc.*`,
+  `configs/milvus.yaml`), far above any realistic record.
+
+The accepted price is memory granularity: while assembling an N-byte logical
+message, one scanner temporarily retains about N bytes across the physical
+chunk payloads and allocates another contiguous N-byte reassembly buffer. Peak
+assembly memory is therefore about 2N per scanner, before any additional
+downstream protobuf decoding, and multiple scanners on the same pchannel can
+multiply that transient cost. After reassembly returns, the chunk references
+become reclaimable and the contiguous N-byte message remains as one unit for
+the flusher or txn buffer. Re-*splitting* it would reintroduce size-based
+packing somewhere; deliberately NOT done. Re-*bounding* it is a different
+question, answered next.
+
+### 2.5 Bound Proxy-materialized logical writes
+
+Removing size-based packing removes the backend-record bottleneck, but it also
+makes one logical insert the unit retained by the StreamingNode and each
+scanner. Chunking temporarily retains about N bytes of chunks and allocates an
+additional contiguous N-byte reassembly buffer per scanner. The Segment seal
+threshold is not a hard message-size constraint: every growing segment may
+accept the indivisible allocation that first takes it over the threshold and
+then seal. The upstream bound is therefore a resource guard, not a derivation
+from Segment capacity.
+
+`quotaAndLimits.limits.maxInsertSize` changes its default from `-1` (no limit)
+to 64 MiB. `insertTask.PreExecute` checks at the end of all Proxy-side insert
+transformations. `upsertTask.insertPreExecute` checks after partial-upsert query
+results have reconstructed the complete insert row; CAS retries call the same
+method after every reconstruction. Both measure `InsertMsg.Size()`, the
+protobuf size of the materialized `InsertRequest`. An oversized write returns
+the deterministic `InputError` `ErrParameterTooLarge` (code 1102) before
+`Execute` can append it to the WAL, although field generation, query work, and
+ID allocation have already occurred.
+
+The 64 MiB default deliberately leaves headroom below the shipped 128 MiB
+Proxy ingress limit and 256 MiB Proxy-to-StreamingNode limit for RPC wrappers,
+message properties, and later growth. It is a conservative operational margin,
+not an end-to-end proof of the final transport size.
+
+This is intentionally not the exact final WAL-record size. It excludes later
+per-channel/partition message properties, partial-update CAS metadata,
+encryption expansion, StreamingNode-generated BM25/MinHash fields, segment
+assignment, chunk markers, and broker envelope. WAL-layer chunking remains
+responsible for the backend's physical record limit. The Proxy limit applies
+to the whole materialized request before channel/partition fanout, and `-1`
+still disables it.
+
+`quotaAndLimits.limits.maxDeleteSize` independently defaults to 16 MiB. After
+primary keys and timestamps have been materialized and routed,
+`repackDeleteMsgByHash` measures the protobuf body of every per-vchannel
+`DeleteMsg`; this shared path covers both normal Delete and the tombstone side
+of Upsert. The largest body must fit the limit, so multiple vchannels may
+collectively exceed 16 MiB while no individual logical WAL message does. The
+same deterministic `InputError`/`ErrParameterTooLarge` behavior applies, and
+`-1` disables the limit. Like `maxInsertSize`, it measures plaintext application
+data rather than streaming properties, encryption expansion, chunk metadata,
+or the broker envelope.
+
+## 3. Concurrency & ordering
+
+- **The timetick watermark is enforced by the ack machinery, not by write
+  adjacency.** A TimeTick(ts=T) record asserts that every record carrying
+  ts ≤ T is already durable; reorder-buffer release, checkpoint advance,
+  txn commit visibility, and crash recovery all consume that assertion.
+  The interceptor acknowledges a message only when its append has fully
+  returned — for a chunked insert, when the WHOLE pack is persisted — and
+  the sync operator publishes `ts = lastAllAcknowledgedTimestamp()`, the
+  consecutive acknowledged prefix (its own comment: "some message sent
+  operation is blocked, new TT cannot be pushed forward"). So TimeTick(T)
+  can never enter the log while any ts ≤ T message is still mid-pack,
+  regardless of how records interleave. No write-side lock is needed to
+  protect it; this is why the design needs none.
+- Consequently packs interleave freely with other traffic in the log, and
+  the consumer pairs chunks by time tick + index/total markers instead of
+  by position (§2.3). Within one run the chunks are still sent
+  sequentially by a single goroutine, so backend per-producer FIFO keeps
+  their relative order — though even that is only an optimization, not a
+  correctness requirement of the assembler.
+- Chunk appends complete before the logical ID is returned upward, so the
+  timetick interceptor's `LastConfirmedMessageID` never advances past
+  un-persisted chunks — it under-reports at worst, by the tail chunks of
+  the last run, until the next timetick confirms them.
+- The assembler is scanner-local and single-goroutine (upstream delivery is
+  serialized per scanner); its keyed state machine needs no locking.
+
+## 4. Activation switches
+
+Chunk records are readable only by StreamingNodes carrying this change.
+Instead of deriving that fact from the cumulative StreamingVersion ladder, two
+explicit switches independently control the producing roles:
+
+| `proxy.splitChunk` | `streaming.splitChunkSN` | Write behavior | Rollout state |
+|---|---|---|---|
+| `true` | `false` | Proxy row-packs; SN writes each packed message as one WAL record | Safe initial/default state |
+| `true` | `true` | Proxy still row-packs; SN additionally enforces the physical WAL record limit | Safe bridge state |
+| `false` | `true` | Proxy sends logical messages; SN creates bounded physical WAL records | Safe target state |
+| `false` | `false` | Neither role splits an oversized logical message | **Unsafe:** a backend-size rejection can retry forever |
+
+The reader always runs `ChunkAssembler`, independently of both switches.
+Turning `streaming.splitChunkSN` off stops creation of new chunks but must not
+make historical chunk records unreadable. Both parameters support live refresh.
+A config update may therefore change subsequent writes without restarting the
+role, which makes ordering mandatory: first set `streaming.splitChunkSN=true`
+and confirm that every possible pchannel owner has observed it; only then set
+`proxy.splitChunk=false`. Propagation may temporarily mix old and new values
+within one role, but each intermediate state is safe in that order.
+
+This is an operational compatibility boundary, not an automatic capability
+barrier. Before any Proxy observes `proxy.splitChunk=false`, every StreamingNode
+that can own a pchannel must be upgraded and must have observed
+`streaming.splitChunkSN=true`. The cumulative global streaming version and
+StreamingCoord assignment metadata are unchanged.
+
+## 5. Alternatives rejected
+
+- **Permanently keeping proxy-side size splitting (status quo ante).** Splits are visible
+  above the WAL: multiple messages per user insert complicate txn/timetick
+  semantics, replication, and every interceptor — and the packing itself was
+  the cost center (entity-size estimates that still missed the envelope,
+  re-marshaling per split, a single-row rejection wall). This PR removes the
+  need for those splits after activation, but keeps the old path behind
+  `proxy.splitChunk=true` as the rolling-upgrade compatibility mode.
+- **Splitting inside the SN interceptor chain.** Each interceptor would
+  observe partial messages, and the split would have to be undone before the
+  chain's bookkeeping (timetick, txn state machine) anyway.
+- **A synthetic transaction wrapping the chunks.** A ghost begin/commit pair
+  around every chunked insert adds txn-state machinery and extra records to
+  solve a pure transport problem.
+- **Marker records (begin/end) instead of property markers.** Doubles the
+  record count for a run; `_ci`/`_ct` on each record carry the same
+  information.
+- **Raising the backend limits.** Not always available: the Pulsar broker's
+  `maxMessageSize` is a broker-side cap an operator may not control.
+- **Splitting single-message size at the proxy**: re-splitting reintroduces
+  size-driven packing and multiple messages per user write; rejected in favor
+  of passing client batches through whole (§2.4). Note this rejects *splitting*,
+  not *bounding* — see §2.5 for the bound that is required.
+- **Persisting a per-channel or global chunk capability bit.** The bit would have to be
+  committed before the first chunk but remain consistent with a failed append,
+  ownership changes, and recovery. An explicit deployment switch keeps the
+  cumulative StreamingVersion state machine untouched.
+
+## 6. Accepted gaps
+
+| # | Gap | Trigger | Impact | Why accepted |
+|---|---|---|---|---|
+| 1 | In-place downgrade after activation | A StreamingNode is replaced by a binary without chunk support after `streaming.splitChunkSN=true` has written chunks | That owner cannot reassemble historical chunk records | Turning SN chunking off only stops new chunks; making old WAL history safe for an old binary requires a drain/watermark protocol |
+| 2 | Unbounded per-scanner assembly memory | Many chunk runs interleave, a very large logical message reaches the WAL, or many scanners consume one pchannel | Each scanner retains every incomplete run and allocates a contiguous reassembly buffer; memory is multiplied by scanner count | A reader-side hard limit could reject a durable WAL layout that the writer already acknowledged. The 64 MiB Proxy materialized-message default bounds the normal insert path and leaves headroom for later RPC envelopes; disabling it or later StreamingNode expansion accepts this resource risk |
+
+## 7. Rollout & rollback
+
+This is an additive WAL property encoding (`_ci`/`_ct`) with no protobuf schema
+change. New StreamingNodes can read old complete records and new chunk records;
+old StreamingNodes cannot interpret chunk records. New configs
+(`proxy.splitChunk`, `streaming.splitChunkSN`,
+`woodpecker.maxMessageSize`, and `pulsar.messageReserveSize`) use safe shipped
+defaults. Numeric Pulsar, Kafka, and Woodpecker message-size values below
+256 KiB are clamped to 256 KiB; parse errors use the backend default. A reserve
+that is too small or does not fit under the active limit falls back rather than
+producing a budget with no envelope headroom (§2.1).
+
+The intended live-write rollout order is:
+
+1. Deploy binaries containing chunk read/write support with the shipped
+   defaults: `proxy.splitChunk=true` and
+   `streaming.splitChunkSN=false`. Proxy continues legacy row packing and no SN
+   creates chunk records. This state is safe while binaries roll in any order.
+2. Set `streaming.splitChunkSN=true`. Wait until every StreamingNode that can
+   own a pchannel has upgraded and observed the new value. Proxy remains on
+   `proxy.splitChunk=true`, so traffic remains safe while SN configuration
+   propagation is mixed.
+3. Set `proxy.splitChunk=false` only after step 2 is confirmed. Mixed
+   Proxies are safe in this phase: Proxies still observing `true` keep sending
+   packed messages, while those observing `false` send logical messages to SNs
+   that all chunk oversized WAL payloads.
+
+The two switches remove any dependency on Deployment restart order for the
+initial binary rollout, including Helm's unordered Deployments. They do not
+provide an automatic capability barrier: an operator or rollout controller must
+confirm step 2 before step 3. Disabling Proxy packing while any possible SN
+owner is legacy or still observes `streaming.splitChunkSN=false` is unsupported
+because a large logical record can take the unsplit backend path.
+
+To return to the compatibility write mode while retaining the new binaries,
+reverse the transition safely: first set `proxy.splitChunk=true` and confirm all
+Proxies observe it, then set `streaming.splitChunkSN=false`. This only controls
+new writes.
+Downgrading or reintroducing a legacy StreamingNode after chunks have been
+written remains unsupported because historical WAL may already contain chunks;
+that requires a separate drain/watermark protocol.
+
+## 8. Testing
+
+- `pkg/streaming/util/message/chunk_test.go` (runs with `-tags dynamic,test`):
+  round-trip split→assemble (properties, payload, first-chunk ID), exact
+  boundary fit, empty payload, non-positive chunk size, assembler
+  reassemble / pass-through / retain-incomplete-across-interleaving; 1,025
+  interleaved live runs are retained without a reader-only rejection bound; a
+  duplicate chunk-0 retry uses the later successful observation's ID and
+  properties; malformed/corrupt markers fail the scanner explicitly, declared
+  totals do not preallocate slots, and TimeTick
+  barriers discard only proven-orphan runs.
+- `internal/proxy/task_insert_streaming_test.go` (new): `proxy.splitChunk`
+  selects Proxy-packed messages while true and one logical message while false;
+  row-selection parity, CAS metadata preservation, and empty selection cover
+  the SN-owned path.
+- `pkg/util/fastpb/insert_request_*_test.go`: differential wire parity against
+  the official protobuf encoder covers scalar, document, nested, dense,
+  nullable, sparse, and ArrayOfVector selections; descriptor tripwires force
+  explicit review when the hand-written codec's protobuf contracts change.
+- `pkg/streaming/util/message/{builder,partial_update_cas}_test.go`: direct body
+  encoders are consumed synchronously, cannot be combined with `WithBody`, and
+  preserve CAS metadata through optional encryption.
+- `internal/proxy/task_upsert_test.go`: CAS inserts retain Proxy envelope-aware
+  splitting while `proxy.splitChunk=true` and become one logical message while
+  false; malformed source columns fail alignment checks before direct encoding.
+- `internal/proxy/task_insert_test.go`: the materialized-message bound of §2.5
+  runs after insert field processing, and an upsert fixture containing
+  query-reconstructed fields is measured through `insertPreExecute`; `-1`
+  still disables it.
+- `internal/proxy/routing_table_hash_test.go`: the per-vchannel materialized
+  Delete bound accepts its exact boundary, rejects the next byte with
+  `ErrParameterTooLarge`, and `-1` still disables it.
+- `pkg/util/paramtable/service_param_test.go`: known bounded backends clamp
+  message-size limits below 256 KiB, malformed values use backend defaults,
+  and an invalid reserve still leaves a positive payload budget; defensive
+  direct-helper coverage also verifies the per-record envelope minimum (§2.1).
+- `internal/streamingnode/server/service/handler/producer/produce_server_test.go`:
+  a message carrying the reserved `_ci`/`_ct` markers is rejected at ingress.
+- `internal/streamingnode/server/wal/adaptor/{wal_adaptor_trace,wal_adaptor_fence}_test.go`:
+  SN chunking creates and reassembles physical records while the switch is
+  true; while false, the same oversized logical input follows the legacy single
+  record path through the interceptor chain.
+- Segment stats tests verify that every growing segment accepts the one
+  indivisible allocation that crosses its soft target, rejects later
+  allocations, seals an over-target segment immediately after recovery, and
+  recovers a dropped capacity notification through the periodic scan.
+- `pkg/util/paramtable/component_param_test.go` verifies that
+  `proxy.splitChunk` defaults to true,
+  `streaming.splitChunkSN` defaults to false, and both values can be refreshed.

--- a/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
@@ -594,7 +594,11 @@ TEST(test_chunk_segment,
     auto old_offsets = segment->GetArrayOffsets(old_label);
     ASSERT_NE(old_offsets, nullptr);
     ASSERT_EQ(old_offsets.get(), segment->GetArrayOffsets(old_score).get());
-    ASSERT_EQ(old_offsets->GetTotalElementCount(), row_count * array_len);
+    // DataGen marks alternating rows valid for nullable scalar fields, starting
+    // with row 0. Sealed binlog serialization drops payloads from null rows, so
+    // only the three valid rows contribute elements to the shared offsets.
+    constexpr int64_t valid_row_count = (row_count + 1) / 2;
+    ASSERT_EQ(old_offsets->GetTotalElementCount(), valid_row_count * array_len);
 
     auto new_schema = std::make_shared<Schema>();
     new_schema->set_schema_version(2);

--- a/internal/mocks/streamingnode/server/mock_wal/mock_WAL.go
+++ b/internal/mocks/streamingnode/server/mock_wal/mock_WAL.go
@@ -122,12 +122,12 @@ func (_c *MockWAL_AppendAsync_Call) RunAndReturn(run func(context.Context, messa
 	return _c
 }
 
-// Available provides a mock function with no fields
-func (_m *MockWAL) Available() <-chan struct{} {
+// Unavailable provides a mock function with no fields
+func (_m *MockWAL) Unavailable() <-chan struct{} {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for Available")
+		panic("no return value specified for Unavailable")
 	}
 
 	var r0 <-chan struct{}
@@ -142,29 +142,29 @@ func (_m *MockWAL) Available() <-chan struct{} {
 	return r0
 }
 
-// MockWAL_Available_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Available'
-type MockWAL_Available_Call struct {
+// MockWAL_Unavailable_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Unavailable'
+type MockWAL_Unavailable_Call struct {
 	*mock.Call
 }
 
-// Available is a helper method to define mock.On call
-func (_e *MockWAL_Expecter) Available() *MockWAL_Available_Call {
-	return &MockWAL_Available_Call{Call: _e.mock.On("Available")}
+// Unavailable is a helper method to define mock.On call
+func (_e *MockWAL_Expecter) Unavailable() *MockWAL_Unavailable_Call {
+	return &MockWAL_Unavailable_Call{Call: _e.mock.On("Unavailable")}
 }
 
-func (_c *MockWAL_Available_Call) Run(run func()) *MockWAL_Available_Call {
+func (_c *MockWAL_Unavailable_Call) Run(run func()) *MockWAL_Unavailable_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockWAL_Available_Call) Return(_a0 <-chan struct{}) *MockWAL_Available_Call {
+func (_c *MockWAL_Unavailable_Call) Return(_a0 <-chan struct{}) *MockWAL_Unavailable_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockWAL_Available_Call) RunAndReturn(run func() <-chan struct{}) *MockWAL_Available_Call {
+func (_c *MockWAL_Unavailable_Call) RunAndReturn(run func() <-chan struct{}) *MockWAL_Unavailable_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -674,7 +674,8 @@ func (_c *MockWAL_WALName_Call) RunAndReturn(run func() message.WALName) *MockWA
 func NewMockWAL(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockWAL {
+},
+) *MockWAL {
 	mock := &MockWAL{}
 	mock.Mock.Test(t)
 

--- a/internal/proxy/channelmgr/msg_pack_test.go
+++ b/internal/proxy/channelmgr/msg_pack_test.go
@@ -18,6 +18,7 @@ package channelmgr
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -32,50 +33,58 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
+const minWALMessageSizeForTest = 256 * 1024
+
 func TestGenInsertMsgsByPartitionRejectsSingleOversizedRow(t *testing.T) {
-	assert.NoError(t, paramtable.Get().Save(paramtable.Get().PulsarCfg.MaxMessageSize.Key, "64"))
-	defer paramtable.Get().Reset(paramtable.Get().PulsarCfg.MaxMessageSize.Key)
+	params := paramtable.Get()
+	assert.NoError(t, params.Save(params.PulsarCfg.MaxMessageSize.Key, strconv.Itoa(minWALMessageSizeForTest)))
+	t.Cleanup(func() { assert.NoError(t, params.Reset(params.PulsarCfg.MaxMessageSize.Key)) })
 
 	t.Run("only row", func(t *testing.T) {
-		insertMsg := newVarCharInsertMsgForPackTest(strings.Repeat("x", 1024))
+		insertMsg := newVarCharInsertMsgForPackTest(strings.Repeat("x", minWALMessageSizeForTest+1024))
 		msgs, err := GenInsertMsgsByPartition(context.Background(), 0, 1, "test_partition", []int{0}, "test_channel", insertMsg, message.WALNamePulsar)
 		assert.Nil(t, msgs)
-		assert.ErrorIs(t, err, merr.ErrParameterTooLarge)
-		assert.Contains(t, err.Error(), "single row at offset 0")
-		assert.False(t, merr.Status(err).GetRetriable())
+		if assert.ErrorIs(t, err, merr.ErrParameterTooLarge) {
+			assert.Contains(t, err.Error(), "single row at offset 0")
+			assert.False(t, merr.Status(err).GetRetriable())
+		}
 	})
 
 	t.Run("row at limit", func(t *testing.T) {
-		insertMsg := newVarCharInsertMsgForPackTest(strings.Repeat("x", 64))
+		insertMsg := newVarCharInsertMsgForPackTest(strings.Repeat("x", minWALMessageSizeForTest))
 		msgs, err := GenInsertMsgsByPartition(context.Background(), 0, 1, "test_partition", []int{0}, "test_channel", insertMsg, message.WALNamePulsar)
 		assert.Nil(t, msgs)
 		assert.ErrorIs(t, err, merr.ErrParameterTooLarge)
 	})
 
 	t.Run("later row", func(t *testing.T) {
-		insertMsg := newVarCharInsertMsgForPackTest("small", strings.Repeat("x", 1024))
+		insertMsg := newVarCharInsertMsgForPackTest("small", strings.Repeat("x", minWALMessageSizeForTest+1024))
 		msgs, err := GenInsertMsgsByPartition(context.Background(), 0, 1, "test_partition", []int{0, 1}, "test_channel", insertMsg, message.WALNamePulsar)
 		assert.Nil(t, msgs)
-		assert.ErrorIs(t, err, merr.ErrParameterTooLarge)
-		assert.Contains(t, err.Error(), "single row at offset 1")
+		if assert.ErrorIs(t, err, merr.ErrParameterTooLarge) {
+			assert.Contains(t, err.Error(), "single row at offset 1")
+		}
 	})
 }
 
 func TestGenInsertMsgsByPartitionUsesWALSpecificSingleRowLimit(t *testing.T) {
-	assert.NoError(t, paramtable.Get().Save(paramtable.Get().PulsarCfg.MaxMessageSize.Key, "64"))
-	defer paramtable.Get().Reset(paramtable.Get().PulsarCfg.MaxMessageSize.Key)
-	assert.NoError(t, paramtable.Get().Save(paramtable.Get().KafkaCfg.ProducerMessageMaxBytes.Key, "2048"))
-	defer paramtable.Get().Reset(paramtable.Get().KafkaCfg.ProducerMessageMaxBytes.Key)
+	params := paramtable.Get()
+	assert.NoError(t, params.Save(params.PulsarCfg.MaxMessageSize.Key, strconv.Itoa(minWALMessageSizeForTest)))
+	assert.NoError(t, params.Save(params.KafkaCfg.ProducerMessageMaxBytes.Key, strconv.Itoa(2*minWALMessageSizeForTest)))
+	t.Cleanup(func() {
+		assert.NoError(t, params.Reset(params.KafkaCfg.ProducerMessageMaxBytes.Key))
+		assert.NoError(t, params.Reset(params.PulsarCfg.MaxMessageSize.Key))
+	})
 
 	t.Run("kafka allows row above pulsar split threshold", func(t *testing.T) {
-		insertMsg := newVarCharInsertMsgForPackTest(strings.Repeat("x", 1024))
+		insertMsg := newVarCharInsertMsgForPackTest(strings.Repeat("x", minWALMessageSizeForTest+minWALMessageSizeForTest/2))
 		msgs, err := GenInsertMsgsByPartition(context.Background(), 0, 1, "test_partition", []int{0}, "test_channel", insertMsg, message.WALNameKafka)
 		assert.NoError(t, err)
 		assert.Len(t, msgs, 1)
 	})
 
 	t.Run("kafka rejects row at its own limit", func(t *testing.T) {
-		insertMsg := newVarCharInsertMsgForPackTest(strings.Repeat("x", 2048))
+		insertMsg := newVarCharInsertMsgForPackTest(strings.Repeat("x", 2*minWALMessageSizeForTest))
 		msgs, err := GenInsertMsgsByPartition(context.Background(), 0, 1, "test_partition", []int{0}, "test_channel", insertMsg, message.WALNameKafka)
 		assert.Nil(t, msgs)
 		assert.ErrorIs(t, err, merr.ErrParameterTooLarge)
@@ -83,7 +92,7 @@ func TestGenInsertMsgsByPartitionUsesWALSpecificSingleRowLimit(t *testing.T) {
 
 	for _, walName := range []message.WALName{message.WALNameRocksmq, message.WALNameWoodpecker} {
 		t.Run(walName.String()+" has no single row limit", func(t *testing.T) {
-			insertMsg := newVarCharInsertMsgForPackTest(strings.Repeat("x", 1024))
+			insertMsg := newVarCharInsertMsgForPackTest(strings.Repeat("x", minWALMessageSizeForTest+minWALMessageSizeForTest/2))
 			msgs, err := GenInsertMsgsByPartition(context.Background(), 0, 1, "test_partition", []int{0}, "test_channel", insertMsg, walName)
 			assert.NoError(t, err)
 			assert.Len(t, msgs, 1)
@@ -92,10 +101,14 @@ func TestGenInsertMsgsByPartitionUsesWALSpecificSingleRowLimit(t *testing.T) {
 }
 
 func TestGenInsertMsgsByPartitionSplitsMultipleRows(t *testing.T) {
-	assert.NoError(t, paramtable.Get().Save(paramtable.Get().PulsarCfg.MaxMessageSize.Key, "512"))
-	defer paramtable.Get().Reset(paramtable.Get().PulsarCfg.MaxMessageSize.Key)
+	params := paramtable.Get()
+	assert.NoError(t, params.Save(params.PulsarCfg.MaxMessageSize.Key, strconv.Itoa(minWALMessageSizeForTest)))
+	t.Cleanup(func() { assert.NoError(t, params.Reset(params.PulsarCfg.MaxMessageSize.Key)) })
 
-	insertMsg := newVarCharInsertMsgForPackTest(strings.Repeat("x", 300), strings.Repeat("y", 300))
+	insertMsg := newVarCharInsertMsgForPackTest(
+		strings.Repeat("x", 160*1024),
+		strings.Repeat("y", 160*1024),
+	)
 	msgs, err := GenInsertMsgsByPartition(context.Background(), 0, 1, "test_partition", []int{0, 1}, "test_channel", insertMsg, message.WALNamePulsar)
 	assert.NoError(t, err)
 	assert.Len(t, msgs, 2)

--- a/internal/proxy/routing_table_hash_test.go
+++ b/internal/proxy/routing_table_hash_test.go
@@ -18,14 +18,18 @@ package proxy
 
 import (
 	"context"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	pkgtypeutil "github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -134,6 +138,91 @@ func TestRepackDeleteMsgByHashReturnsRoutingErrorWithoutChannels(t *testing.T) {
 	assert.ErrorIs(t, err, common.ErrRoutingTableNoValues)
 	assert.Nil(t, got)
 	assert.Zero(t, rows)
+}
+
+func TestRepackDeleteMsgByHashHonorsMaxDeleteSize(t *testing.T) {
+	paramtable.Init()
+	primaryKeys := &schemapb.IDs{
+		IdField: &schemapb.IDs_IntId{
+			IntId: &schemapb.LongArray{Data: []int64{1}},
+		},
+	}
+	repack := func() (map[uint32][]*msgstream.DeleteMsg, int64, error) {
+		return repackDeleteMsgByHash(
+			context.Background(),
+			primaryKeys,
+			[]string{"vchan-0"},
+			allocator.NewLocalAllocator(100, 200),
+			1000,
+			1,
+			"collection",
+			2,
+			"partition",
+			"default",
+			nil,
+			nil,
+		)
+	}
+
+	require.NoError(t, Params.Save(Params.QuotaConfig.MaxDeleteSize.Key, "-1"))
+	t.Cleanup(func() {
+		Params.Reset(Params.QuotaConfig.MaxDeleteSize.Key)
+	})
+	result, rows, err := repack()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rows)
+	require.Len(t, result, 1)
+	var materializedSize int
+	for _, msgs := range result {
+		require.Len(t, msgs, 1)
+		materializedSize = msgs[0].Size()
+	}
+	require.Positive(t, materializedSize)
+
+	require.NoError(t, Params.Save(Params.QuotaConfig.MaxDeleteSize.Key, strconv.Itoa(materializedSize)))
+	_, _, err = repack()
+	require.NoError(t, err, "the exact maxDeleteSize boundary must be accepted")
+
+	require.NoError(t, Params.Save(Params.QuotaConfig.MaxDeleteSize.Key, strconv.Itoa(materializedSize-1)))
+	result, rows, err = repack()
+	require.ErrorIs(t, err, merr.ErrParameterTooLarge)
+	assert.Equal(t, merr.InputError, merr.GetErrorType(err))
+	assert.Nil(t, result)
+	assert.Zero(t, rows)
+}
+
+func TestRepackDeleteMsgByHashSwitchesChunkOwner(t *testing.T) {
+	paramtable.Init()
+	oldMaxMessageSize := Params.PulsarCfg.MaxMessageSize.SwapTempValue("512")
+	oldMaxDeleteSize := Params.QuotaConfig.MaxDeleteSize.SwapTempValue("-1")
+	oldSplitChunkProxy := Params.ProxyCfg.SplitChunkProxy.SwapTempValue("true")
+	t.Cleanup(func() {
+		Params.PulsarCfg.MaxMessageSize.SwapTempValue(oldMaxMessageSize)
+		Params.QuotaConfig.MaxDeleteSize.SwapTempValue(oldMaxDeleteSize)
+		Params.ProxyCfg.SplitChunkProxy.SwapTempValue(oldSplitChunkProxy)
+	})
+
+	primaryKeys := &schemapb.IDs{
+		IdField: &schemapb.IDs_StrId{
+			StrId: &schemapb.StringArray{Data: []string{strings.Repeat("a", 300), strings.Repeat("b", 300)}},
+		},
+	}
+	repack := func() map[uint32][]*msgstream.DeleteMsg {
+		result, rows, err := repackDeleteMsgByHash(
+			context.Background(), primaryKeys, []string{"vchan-0"}, allocator.NewLocalAllocator(100, 200),
+			1000, 1, "collection", 2, "partition", "default", nil, nil,
+		)
+		require.NoError(t, err)
+		require.Equal(t, int64(2), rows)
+		return result
+	}
+
+	result := repack()
+	require.Len(t, result[0], 2)
+
+	Params.ProxyCfg.SplitChunkProxy.SwapTempValue("false")
+	result = repack()
+	require.Len(t, result[0], 1)
 }
 
 func expectedInt64ModuloHashes(t *testing.T, keys []int64, targetCount int) []uint32 {

--- a/internal/proxy/task_delete.go
+++ b/internal/proxy/task_delete.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"strconv"
 	"time"
@@ -147,6 +148,20 @@ func (dt *deleteTask) PostExecute(ctx context.Context) error {
 	return nil
 }
 
+// checkMaxDeleteSize rejects a materialized per-vchannel delete message whose
+// protobuf body exceeds quotaAndLimits.limits.maxDeleteSize.
+func checkMaxDeleteSize(ctx context.Context, size int) error {
+	maxDeleteSize := Params.QuotaConfig.MaxDeleteSize.GetAsInt()
+	if maxDeleteSize == -1 || size <= maxDeleteSize {
+		return nil
+	}
+	mlog.Warn(ctx, "materialized delete message exceeds maxDeleteSize",
+		mlog.Int("message size", size),
+		mlog.Int("maxDeleteSize", maxDeleteSize))
+	return merr.WrapErrAsInputError(merr.WrapErrParameterTooLarge(
+		fmt.Sprintf("delete materialized message size %d exceeds maxDeleteSize %d", size, maxDeleteSize)))
+}
+
 func repackDeleteMsgByHash(
 	ctx context.Context,
 	primaryKeys *schemapb.IDs,
@@ -161,7 +176,8 @@ func repackDeleteMsgByHash(
 	namespace *string,
 	schema *schemapb.CollectionSchema,
 ) (map[uint32][]*msgstream.DeleteMsg, int64, error) {
-	maxSize := Params.PulsarCfg.MaxMessageSize.GetAsInt()
+	splitChunkProxy := Params.ProxyCfg.SplitChunkProxy.GetAsBool()
+	maxWALMessageSize := Params.PulsarCfg.MaxMessageSize.GetAsInt()
 	var hashValues []uint32
 	// Delete tombstones are PK+timestamp based. Namespace can narrow routing,
 	// but it is not part of the tombstone identity; PKs must stay unique across
@@ -182,9 +198,11 @@ func repackDeleteMsgByHash(
 			return nil, 0, err
 		}
 	}
-	// repack delete msg by dmChannel
+	// Repack delete messages by dmChannel. Proxy keeps the legacy size packing
+	// while splitChunkProxy is enabled; once disabled, one logical tombstone
+	// body is built per hashed channel so StreamingNode can own physical chunking.
 	result := make(map[uint32][]*msgstream.DeleteMsg)
-	lastMessageSize := map[uint32]int{}
+	lastMessageSize := make(map[uint32]int)
 
 	numRows := int64(0)
 	numMessage := 0
@@ -225,16 +243,23 @@ func repackDeleteMsgByHash(
 		}
 		curMsg := msgs[len(msgs)-1]
 		size, id := typeutil.GetId(primaryKeys, index)
-		if lastMessageSize[key]+16+size > maxSize {
-			curMsg = createMessage(key, vchannel)
-			result[key] = append(result[key], curMsg)
+		rowSize := 16 + size
+		if splitChunkProxy {
+			if maxWALMessageSize > 0 && rowSize >= maxWALMessageSize {
+				return nil, 0, merr.WrapErrAsInputError(merr.WrapErrParameterTooLarge(
+					fmt.Sprintf("single delete primary key at offset %d is too large to fit in one WAL message", index)))
+			}
+			if maxWALMessageSize > 0 && curMsg.NumRows > 0 && lastMessageSize[key]+rowSize > maxWALMessageSize {
+				curMsg = createMessage(key, vchannel)
+				result[key] = append(result[key], curMsg)
+			}
 		}
 		curMsg.HashValues = append(curMsg.HashValues, hashValues[index])
 		curMsg.Timestamps = append(curMsg.Timestamps, ts)
 
 		typeutil.AppendID(curMsg.PrimaryKeys, id)
-		lastMessageSize[key] += 16 + size
 		curMsg.NumRows++
+		lastMessageSize[key] += rowSize
 		numRows++
 	}
 
@@ -245,11 +270,16 @@ func repackDeleteMsgByHash(
 	}
 
 	cnt := int64(0)
+	maxMessageSize := 0
 	for _, msgs := range result {
 		for _, msg := range msgs {
 			msg.Base.MsgID = start + cnt
+			maxMessageSize = max(maxMessageSize, msg.Size())
 			cnt++
 		}
+	}
+	if err := checkMaxDeleteSize(ctx, maxMessageSize); err != nil {
+		return nil, 0, err
 	}
 	return result, numRows, nil
 }

--- a/internal/proxy/task_insert.go
+++ b/internal/proxy/task_insert.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"go.opentelemetry.io/otel"
@@ -101,6 +102,25 @@ func (it *insertTask) OnEnqueue() error {
 	return nil
 }
 
+// checkMaxInsertSize rejects a materialized insert message whose protobuf body
+// exceeds quotaAndLimits.limits.maxInsertSize.
+//
+// Both insert and upsert call this after Proxy-side field materialization so
+// generated fields, row IDs, timestamps, and partial-upsert query results are
+// included in the measured size.
+func checkMaxInsertSize(ctx context.Context, op string, size int) error {
+	maxInsertSize := Params.QuotaConfig.MaxInsertSize.GetAsInt()
+	if maxInsertSize == -1 || size <= maxInsertSize {
+		return nil
+	}
+	mlog.Warn(ctx, "materialized insert message exceeds maxInsertSize",
+		mlog.String("op", op),
+		mlog.Int("message size", size),
+		mlog.Int("maxInsertSize", maxInsertSize))
+	return merr.WrapErrAsInputError(merr.WrapErrParameterTooLarge(
+		fmt.Sprintf("%s materialized message size %d exceeds maxInsertSize %d", op, size, maxInsertSize)))
+}
+
 func (it *insertTask) PreExecute(ctx context.Context) error {
 	ctx, sp := otel.Tracer(typeutil.ProxyRole).Start(ctx, "Proxy-Insert-PreExecute")
 	defer sp.End()
@@ -121,13 +141,6 @@ func (it *insertTask) PreExecute(ctx context.Context) error {
 	if err := validateCollectionName(collectionName); err != nil {
 		log.Warn(ctx, "valid collection name failed", mlog.String("collectionName", collectionName), mlog.Err(err))
 		return err
-	}
-
-	maxInsertSize := Params.QuotaConfig.MaxInsertSize.GetAsInt()
-	if maxInsertSize != -1 && it.insertMsg.Size() > maxInsertSize {
-		log.Warn(ctx, "insert request size exceeds maxInsertSize",
-			mlog.Int("request size", it.insertMsg.Size()), mlog.Int("maxInsertSize", maxInsertSize))
-		return merr.WrapErrAsInputError(merr.WrapErrParameterTooLarge("insert request size exceeds maxInsertSize"))
 	}
 
 	collID, err := it.getMetaCache().GetCollectionID(context.Background(), it.insertMsg.GetDbName(), collectionName)
@@ -294,6 +307,10 @@ func (it *insertTask) PreExecute(ctx context.Context) error {
 	if err := fieldvalidator.NewValidateUtil(fieldvalidator.WithNANCheck(), fieldvalidator.WithOverflowCheck(), fieldvalidator.WithMaxLenCheck(), fieldvalidator.WithMaxCapCheck()).
 		Validate(it.insertMsg.GetFieldsData(), schema.SchemaHelper, it.insertMsg.NRows()); err != nil {
 		return merr.WrapErrAsInputError(err)
+	}
+
+	if err := checkMaxInsertSize(ctx, "insert", it.insertMsg.Size()); err != nil {
+		return err
 	}
 
 	log.Debug(ctx, "Proxy Insert PreExecute done")

--- a/internal/proxy/task_insert_streaming.go
+++ b/internal/proxy/task_insert_streaming.go
@@ -6,7 +6,9 @@ import (
 
 	"go.opentelemetry.io/otel"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/proxy/channelmgr"
@@ -16,6 +18,8 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/commonpbutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/fastpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/timerecord"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -99,8 +103,6 @@ func repackInsertDataForStreamingService(
 	partialUpdateCASGroups map[string]*messagespb.PartialUpdateCAS,
 ) ([]message.MutableMessage, error) {
 	messages := make([]message.MutableMessage, 0)
-	walName := channelmgr.GetActiveWALName()
-
 	channel2RowOffsets, err := assignChannelsByPK(result.IDs, channelNames, insertMsg)
 	if err != nil {
 		return nil, err
@@ -128,7 +130,6 @@ func repackInsertDataForStreamingService(
 			ez,
 			schemaVersion,
 			partialUpdateCAS,
-			walName,
 		)
 		if err != nil {
 			return nil, err
@@ -151,7 +152,6 @@ func repackInsertDataWithPartitionKeyForStreamingService(
 	partialUpdateCASGroups map[string]*messagespb.PartialUpdateCAS,
 ) ([]message.MutableMessage, error) {
 	messages := make([]message.MutableMessage, 0)
-	walName := channelmgr.GetActiveWALName()
 
 	var channel2RowOffsets map[string][]int
 	var err error
@@ -218,7 +218,6 @@ func repackInsertDataWithPartitionKeyForStreamingService(
 				ez,
 				schemaVersion,
 				partialUpdateCAS,
-				walName,
 			)
 			if err != nil {
 				return nil, err
@@ -247,6 +246,122 @@ func getPartialUpdateCASForStreamingService(
 }
 
 func repackInsertDataByPartitionForStreamingService(
+	ctx context.Context,
+	partitionID int64,
+	partitionName string,
+	rowOffsets []int,
+	channel string,
+	insertMsg *msgstream.InsertMsg,
+	ez *message.CipherConfig,
+	schemaVersion int32,
+	partialUpdateCAS *messagespb.PartialUpdateCAS,
+) ([]message.MutableMessage, error) {
+	if Params.ProxyCfg.SplitChunkProxy.GetAsBool() {
+		return repackInsertDataAtProxyForStreamingService(
+			ctx,
+			partitionID,
+			partitionName,
+			rowOffsets,
+			channel,
+			insertMsg,
+			ez,
+			schemaVersion,
+			partialUpdateCAS,
+			channelmgr.GetActiveWALName(),
+		)
+	}
+	return buildSingleInsertMessageForStreamingService(
+		partitionID,
+		partitionName,
+		rowOffsets,
+		channel,
+		insertMsg,
+		ez,
+		schemaVersion,
+		partialUpdateCAS,
+	)
+}
+
+// buildSingleInsertMessageForStreamingService builds exactly one logical V1
+// insert message per (channel, partition) group. The view encoder writes the
+// selected rows directly into the final protobuf payload without materializing
+// copied RowIDs, Timestamps, or FieldsData columns in Proxy.
+func buildSingleInsertMessageForStreamingService(
+	partitionID int64,
+	partitionName string,
+	rowOffsets []int,
+	channel string,
+	insertMsg *msgstream.InsertMsg,
+	ez *message.CipherConfig,
+	schemaVersion int32,
+	partialUpdateCAS *messagespb.PartialUpdateCAS,
+) ([]message.MutableMessage, error) {
+	if len(rowOffsets) == 0 {
+		return nil, nil
+	}
+	if err := insertMsg.CheckAligned(); err != nil {
+		return nil, err
+	}
+
+	template := &msgpb.InsertRequest{
+		Base: commonpbutil.NewMsgBase(
+			commonpbutil.WithMsgType(commonpb.MsgType_Insert),
+			commonpbutil.WithTimeStamp(insertMsg.BeginTimestamp),
+			commonpbutil.WithSourceID(insertMsg.GetBase().GetSourceID()),
+		),
+		DbID:           insertMsg.GetDbID(),
+		CollectionID:   insertMsg.GetCollectionID(),
+		PartitionID:    partitionID,
+		DbName:         insertMsg.GetDbName(),
+		CollectionName: insertMsg.GetCollectionName(),
+		PartitionName:  partitionName,
+		SegmentID:      0, // segment id is assigned at StreamingNode.
+		ShardName:      channel,
+		NumRows:        uint64(len(rowOffsets)),
+		Version:        msgpb.InsertDataVersion_ColumnBased,
+		Namespace:      insertMsg.Namespace,
+	}
+	if partialUpdateCAS != nil {
+		// CAS lives in Base.Properties and must be present before the encoder
+		// computes the exact body size.
+		if err := message.EncodePartialUpdateCASIntoInsertTemplate(partialUpdateCAS, template); err != nil {
+			return nil, err
+		}
+	}
+
+	encoder, err := fastpb.NewInsertRequestViewEncoder(template, insertMsg.InsertRequest, rowOffsets)
+	if err != nil {
+		return nil, err
+	}
+	builder := message.NewInsertMessageBuilderV1().
+		WithVChannel(channel).
+		WithHeader(&message.InsertMessageHeader{
+			CollectionId: insertMsg.GetCollectionID(),
+			Partitions: []*message.PartitionSegmentAssignment{
+				{
+					PartitionId: partitionID,
+					Rows:        uint64(len(rowOffsets)),
+					BinarySize:  0, // StreamingNode uses the encoded message size when absent.
+				},
+			},
+			SchemaVersion: &schemaVersion,
+		}).
+		WithBodyEncoder(encoder)
+	if partialUpdateCAS != nil {
+		if err := builder.MarkPartialUpdateCASForBodyEncoder(); err != nil {
+			return nil, err
+		}
+	}
+	msg, err := builder.
+		WithCipher(ez).
+		BuildMutable()
+	if err != nil {
+		return nil, err
+	}
+	return []message.MutableMessage{msg}, nil
+}
+
+func repackInsertDataAtProxyForStreamingService(
 	ctx context.Context,
 	partitionID int64,
 	partitionName string,
@@ -313,8 +428,9 @@ func repackInsertDataByPartitionForStreamingService(
 		}
 
 		// Entity-size packing does not include the streaming header or CAS
-		// metadata. Validate the fully built message and split the original row
-		// offsets again when that final envelope crosses the transport limit.
+		// metadata. Validate the fully built partial-update message and split the
+		// original row offsets again when that final envelope crosses the legacy
+		// Proxy transport limit.
 		if partialUpdateCAS == nil || msg.EstimateSize() <= maxMessageSize {
 			messages = append(messages, msg)
 			continue
@@ -324,11 +440,10 @@ func repackInsertDataByPartitionForStreamingService(
 		}
 
 		middle := len(pack.rowOffsets) / 2
-		split := []pendingInsertPack{
+		pending = append([]pendingInsertPack{
 			{rowOffsets: pack.rowOffsets[:middle]},
 			{rowOffsets: pack.rowOffsets[middle:]},
-		}
-		pending = append(split, pending...)
+		}, pending...)
 	}
 	return messages, nil
 }
@@ -350,7 +465,7 @@ func buildInsertMessageForStreamingService(
 				{
 					PartitionId: partitionID,
 					Rows:        insertRequest.GetNumRows(),
-					BinarySize:  0, // TODO: current not used, message estimate size is used.
+					BinarySize:  0, // StreamingNode uses the encoded message size when absent.
 				},
 			},
 			SchemaVersion: &schemaVersion,

--- a/internal/proxy/task_insert_streaming_test.go
+++ b/internal/proxy/task_insert_streaming_test.go
@@ -1,0 +1,296 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package proxy
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
+	streamingmessage "github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+)
+
+// newInt64VarCharInsertMsgForRepackTest builds a column-based source request
+// whose per-row values are positionally distinct.
+func newInt64VarCharInsertMsgForRepackTest(collectionID int64, rows ...string) *msgstream.InsertMsg {
+	namespace := "test-namespace"
+	rowIDs := make([]int64, len(rows))
+	timestamps := make([]uint64, len(rows))
+	longValues := make([]int64, len(rows))
+	hashValues := make([]uint32, len(rows))
+	for i := range rows {
+		rowIDs[i] = int64(i + 1)
+		timestamps[i] = uint64(10 + i)
+		longValues[i] = int64(100 + i)
+		hashValues[i] = uint32(i)
+	}
+
+	return &msgstream.InsertMsg{
+		BaseMsg: msgstream.BaseMsg{
+			Ctx:            context.Background(),
+			BeginTimestamp: uint64(99),
+			EndTimestamp:   uint64(99),
+			HashValues:     hashValues,
+		},
+		InsertRequest: &msgpb.InsertRequest{
+			Base: &commonpb.MsgBase{
+				MsgType:  commonpb.MsgType_Insert,
+				SourceID: 42,
+			},
+			DbID:           8,
+			CollectionID:   collectionID,
+			DbName:         "db",
+			CollectionName: "collection",
+			PartitionName:  "source-partition",
+			NumRows:        uint64(len(rows)),
+			RowIDs:         rowIDs,
+			Timestamps:     timestamps,
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Int64,
+					FieldId:   100,
+					FieldName: "pk",
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_LongData{
+								LongData: &schemapb.LongArray{Data: longValues},
+							},
+						},
+					},
+				},
+				{
+					Type:      schemapb.DataType_VarChar,
+					FieldId:   101,
+					FieldName: "large_text",
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_StringData{
+								StringData: &schemapb.StringArray{Data: rows},
+							},
+						},
+					},
+				},
+			},
+			Version:   msgpb.InsertDataVersion_ColumnBased,
+			Namespace: &namespace,
+		},
+	}
+}
+
+func TestRepackInsertDataByPartitionForStreamingServiceSelectsRows(t *testing.T) {
+	oldSplitChunkProxy := Params.ProxyCfg.SplitChunkProxy.SwapTempValue("false")
+	t.Cleanup(func() { Params.ProxyCfg.SplitChunkProxy.SwapTempValue(oldSplitChunkProxy) })
+	source := newInt64VarCharInsertMsgForRepackTest(100, "a", "bb", "ccc", "dddd")
+	selection := []int{1, 3}
+
+	msgs, err := repackInsertDataByPartitionForStreamingService(
+		context.Background(),
+		200,
+		"target-partition",
+		selection,
+		"vchannel-1",
+		source,
+		nil,
+		7,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+
+	insert := streamingmessage.MustAsMutableInsertMessageV1(msgs[0])
+	header := insert.Header()
+	assert.Equal(t, int64(100), header.GetCollectionId())
+	assert.Equal(t, int32(7), header.GetSchemaVersion())
+	require.Len(t, header.GetPartitions(), 1)
+	assert.Equal(t, int64(200), header.GetPartitions()[0].GetPartitionId())
+	assert.Equal(t, uint64(len(selection)), header.GetPartitions()[0].GetRows())
+
+	body := insert.MustBody()
+	assert.Equal(t, uint64(len(selection)), body.GetNumRows())
+	assert.Equal(t, int64(200), body.GetPartitionID())
+	assert.Equal(t, "target-partition", body.GetPartitionName())
+	assert.Equal(t, "vchannel-1", body.GetShardName())
+	assert.Equal(t, "db", body.GetDbName())
+	assert.Equal(t, int64(8), body.GetDbID())
+	assert.Equal(t, "collection", body.GetCollectionName())
+	assert.Equal(t, "test-namespace", body.GetNamespace())
+	assert.Equal(t, uint64(99), body.GetBase().GetTimestamp())
+	assert.Equal(t, int64(42), body.GetBase().GetSourceID())
+	// The body must carry exactly the selected source rows.
+	assert.Equal(t, []int64{2, 4}, body.GetRowIDs())
+	assert.Equal(t, []uint64{11, 13}, body.GetTimestamps())
+	assert.Equal(t, []int64{101, 103}, body.GetFieldsData()[0].GetScalars().GetLongData().GetData())
+	assert.Equal(t, []string{"bb", "dddd"}, body.GetFieldsData()[1].GetScalars().GetStringData().GetData())
+
+	// Repacking must not mutate or compact the source request.
+	assert.Equal(t, []int64{1, 2, 3, 4}, source.GetRowIDs())
+	assert.Equal(t, []string{"a", "bb", "ccc", "dddd"}, source.GetFieldsData()[1].GetScalars().GetStringData().GetData())
+}
+
+func TestRepackInsertDataByPartitionForStreamingServiceCarriesPartialUpdateCASInBody(t *testing.T) {
+	oldSplitChunkProxy := Params.ProxyCfg.SplitChunkProxy.SwapTempValue("false")
+	t.Cleanup(func() { Params.ProxyCfg.SplitChunkProxy.SwapTempValue(oldSplitChunkProxy) })
+	source := newInt64VarCharInsertMsgForRepackTest(100, "a", "bb")
+	sourceBefore := proto.Clone(source.InsertRequest).(*msgpb.InsertRequest)
+	meta := &messagespb.PartialUpdateCAS{
+		ReadTs:               100,
+		ObservedPchannelTerm: 1,
+	}
+
+	msgs, err := repackInsertDataByPartitionForStreamingService(
+		context.Background(),
+		200,
+		"target-partition",
+		[]int{0, 1},
+		"vchannel-1",
+		source,
+		nil,
+		7,
+		meta,
+	)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	require.True(t, streamingmessage.HasPartialUpdateCAS(msgs[0]))
+	extracted, err := streamingmessage.ExtractPartialUpdateCAS(msgs[0])
+	require.NoError(t, err)
+	require.True(t, proto.Equal(meta, extracted))
+
+	bodyProperties := streamingmessage.MustAsMutableInsertMessageV1(msgs[0]).MustBody().GetBase().GetProperties()
+	require.NotEmpty(t, bodyProperties)
+	require.True(t, proto.Equal(sourceBefore, source.InsertRequest))
+
+	// BuildMutable consumes the borrowed source view synchronously: mutating the
+	// source after the build must not change the already-built payload.
+	source.RowIDs[0] = 999
+	source.Timestamps[0] = 999
+	source.FieldsData[0].GetScalars().GetLongData().Data[0] = 999
+	source.FieldsData[1].GetScalars().GetStringData().Data[0] = "mutated"
+	body := streamingmessage.MustAsMutableInsertMessageV1(msgs[0]).MustBody()
+	assert.Equal(t, []int64{1, 2}, body.GetRowIDs())
+	assert.Equal(t, []uint64{10, 11}, body.GetTimestamps())
+	assert.Equal(t, []int64{100, 101}, body.GetFieldsData()[0].GetScalars().GetLongData().GetData())
+	assert.Equal(t, []string{"a", "bb"}, body.GetFieldsData()[1].GetScalars().GetStringData().GetData())
+}
+
+func TestRepackInsertDataByPartitionForStreamingServiceSelectsCompactNullableVector(t *testing.T) {
+	oldSplitChunkProxy := Params.ProxyCfg.SplitChunkProxy.SwapTempValue("false")
+	t.Cleanup(func() { Params.ProxyCfg.SplitChunkProxy.SwapTempValue(oldSplitChunkProxy) })
+	source := newInt64VarCharInsertMsgForRepackTest(100, "a", "b", "c", "d")
+	source.FieldsData = []*schemapb.FieldData{
+		{
+			Type:    schemapb.DataType_FloatVector,
+			FieldId: 102,
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim:       2,
+					ValidData: []bool{true, false, true, false},
+					Data: &schemapb.VectorField_FloatVector{
+						FloatVector: &schemapb.FloatArray{Data: []float32{1, 2, 3, 4}},
+					},
+				},
+			},
+		},
+	}
+
+	msgs, err := repackInsertDataByPartitionForStreamingService(
+		context.Background(),
+		200,
+		"target-partition",
+		[]int{1, 2},
+		"vchannel-1",
+		source,
+		nil,
+		7,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+
+	field := streamingmessage.MustAsMutableInsertMessageV1(msgs[0]).MustBody().GetFieldsData()[0]
+	assert.Equal(t, []bool{false, true}, field.GetVectors().GetValidData())
+	assert.Equal(t, []float32{3, 4}, field.GetVectors().GetFloatVector().GetData())
+}
+
+func TestRepackInsertDataByPartitionForStreamingServiceRejectsInvalidSelection(t *testing.T) {
+	oldSplitChunkProxy := Params.ProxyCfg.SplitChunkProxy.SwapTempValue("false")
+	t.Cleanup(func() { Params.ProxyCfg.SplitChunkProxy.SwapTempValue(oldSplitChunkProxy) })
+	source := newInt64VarCharInsertMsgForRepackTest(100, "a", "b", "c", "d")
+
+	for name, selection := range map[string][]int{
+		"negative":     {-1},
+		"out of range": {4},
+		"duplicate":    {1, 1},
+		"descending":   {2, 1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			msgs, err := repackInsertDataByPartitionForStreamingService(
+				context.Background(), 200, "target-partition", selection, "vchannel-1", source, nil, 7, nil,
+			)
+			require.Error(t, err)
+			require.Empty(t, msgs)
+		})
+	}
+}
+
+func TestRepackInsertDataByPartitionForStreamingServiceEmptySelection(t *testing.T) {
+	oldSplitChunkProxy := Params.ProxyCfg.SplitChunkProxy.SwapTempValue("false")
+	t.Cleanup(func() { Params.ProxyCfg.SplitChunkProxy.SwapTempValue(oldSplitChunkProxy) })
+	source := newInt64VarCharInsertMsgForRepackTest(100, "a")
+
+	msgs, err := repackInsertDataByPartitionForStreamingService(
+		context.Background(),
+		200,
+		"target-partition",
+		nil,
+		"vchannel-1",
+		source,
+		nil,
+		7,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Empty(t, msgs)
+}
+
+func TestRepackInsertDataByPartitionForStreamingServiceSwitchesChunkOwner(t *testing.T) {
+	oldMaxMessageSize := Params.PulsarCfg.MaxMessageSize.SwapTempValue("512")
+	t.Cleanup(func() { Params.PulsarCfg.MaxMessageSize.SwapTempValue(oldMaxMessageSize) })
+	source := newInt64VarCharInsertMsgForRepackTest(100, strings.Repeat("a", 300), strings.Repeat("b", 300))
+
+	oldSplitChunkProxy := Params.ProxyCfg.SplitChunkProxy.SwapTempValue("true")
+	t.Cleanup(func() { Params.ProxyCfg.SplitChunkProxy.SwapTempValue(oldSplitChunkProxy) })
+	msgs, err := repackInsertDataByPartitionForStreamingService(
+		context.Background(), 200, "target-partition", []int{0, 1}, "vchannel-1", source, nil, 7, nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+
+	Params.ProxyCfg.SplitChunkProxy.SwapTempValue("false")
+	msgs, err = repackInsertDataByPartitionForStreamingService(
+		context.Background(), 200, "target-partition", []int{0, 1}, "vchannel-1", source, nil, 7, nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+}

--- a/internal/proxy/task_insert_test.go
+++ b/internal/proxy/task_insert_test.go
@@ -2,10 +2,14 @@ package proxy
 
 import (
 	"context"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -19,6 +23,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/v3/proto/rootcoordpb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/testutils"
@@ -53,6 +58,10 @@ func TestRepackInsertDataForStreamingServicePreservesExplicitZeroSchemaVersion(t
 			},
 			RowIDs:     []int64{1},
 			Timestamps: []uint64{1},
+			// The proxy always produces column-based inserts (impl.go). Without
+			// it, NRows() reads the empty row-based RowData and the alignment
+			// check rejects the fixture.
+			Version: msgpb.InsertDataVersion_ColumnBased,
 		},
 	}
 	result := &milvuspb.MutationResult{
@@ -383,22 +392,146 @@ func TestInsertTask(t *testing.T) {
 }
 
 func TestMaxInsertSize(t *testing.T) {
-	t.Run("test MaxInsertSize", func(t *testing.T) {
-		paramtable.Init()
-		Params.Save(Params.QuotaConfig.MaxInsertSize.Key, "1")
-		defer Params.Reset(Params.QuotaConfig.MaxInsertSize.Key)
-		it := insertTask{
-			ctx: context.Background(),
-			insertMsg: &msgstream.InsertMsg{
-				InsertRequest: &msgpb.InsertRequest{
-					DbName:         "hooooooo",
-					CollectionName: "fooooo",
+	newIDAllocator := func(t *testing.T) *allocator.IDAllocator {
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		rc := mocks.NewMockRootCoordClient(t)
+		rc.EXPECT().AllocID(mock.Anything, mock.Anything).Return(&rootcoordpb.AllocIDResponse{
+			Status: merr.Status(nil),
+			ID:     1000,
+			Count:  10,
+		}, nil)
+		idAllocator, err := allocator.NewIDAllocator(ctx, rc, 0)
+		require.NoError(t, err)
+		require.NoError(t, idAllocator.Start())
+		t.Cleanup(idAllocator.Close)
+		return idAllocator
+	}
+	newPrimaryFieldData := func() *schemapb.FieldData {
+		return &schemapb.FieldData{
+			FieldName: "id",
+			FieldId:   100,
+			Type:      schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{1}},
+					},
 				},
 			},
 		}
+	}
+	newValueFieldData := func() *schemapb.FieldData {
+		return &schemapb.FieldData{
+			FieldName: "value",
+			FieldId:   101,
+			Type:      schemapb.DataType_VarChar,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_StringData{
+						StringData: &schemapb.StringArray{Data: []string{strings.Repeat("x", 512)}},
+					},
+				},
+			},
+		}
+	}
+	const (
+		dbName         = "test_db"
+		collectionName = "test_max_insert_size"
+	)
+	collectionSchema := &schemapb.CollectionSchema{
+		Name: collectionName,
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{
+				FieldID:  101,
+				Name:     "value",
+				DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "1024"},
+				},
+			},
+		},
+	}
+	schema := mustNewSchemaInfo(collectionSchema)
+
+	t.Run("insert checks the materialized message", func(t *testing.T) {
+		paramtable.Init()
+		cache := NewMockCache(t)
+		cache.On("GetCollectionID", mock.Anything, dbName, collectionName).Return(UniqueID(100), nil)
+		cache.On("GetCollectionInfo", mock.Anything, dbName, collectionName, UniqueID(100)).Return(&collectionInfo{Schema: schema}, nil)
+		cache.On("GetCollectionSchema", mock.Anything, dbName, collectionName).Return(schema, nil)
+		it := insertTask{
+			baseTask: baseTask{metaCache: cache},
+			ctx:      context.Background(),
+			insertMsg: &msgstream.InsertMsg{
+				InsertRequest: &msgpb.InsertRequest{
+					Base:           commonpbutil.NewMsgBase(commonpbutil.WithMsgType(commonpb.MsgType_Insert)),
+					DbName:         dbName,
+					CollectionName: collectionName,
+					PartitionName:  Params.CommonCfg.DefaultPartitionName.GetValue(),
+					FieldsData:     []*schemapb.FieldData{newPrimaryFieldData(), newValueFieldData()},
+					NumRows:        1,
+					Version:        msgpb.InsertDataVersion_ColumnBased,
+				},
+			},
+			idAllocator: newIDAllocator(t),
+		}
+		require.NoError(t, validateAndNormalizeFieldDataValidData(it.insertMsg.GetFieldsData()))
+		incomingSize := it.insertMsg.Size()
+		Params.Save(Params.QuotaConfig.MaxInsertSize.Key, strconv.Itoa(incomingSize))
+		defer Params.Reset(Params.QuotaConfig.MaxInsertSize.Key)
+
 		err := it.PreExecute(context.Background())
-		assert.Error(t, err)
-		assert.ErrorIs(t, err, merr.ErrParameterTooLarge)
+		require.ErrorIs(t, err, merr.ErrParameterTooLarge)
+		require.Greater(t, it.insertMsg.Size(), incomingSize)
+	})
+
+	t.Run("upsert checks the materialized insert message", func(t *testing.T) {
+		paramtable.Init()
+		ut := upsertTask{
+			ctx:         context.Background(),
+			idAllocator: newIDAllocator(t),
+			schema:      schema,
+			result:      &milvuspb.MutationResult{},
+			req: &milvuspb.UpsertRequest{
+				DbName:         dbName,
+				CollectionName: collectionName,
+				FieldsData:     []*schemapb.FieldData{newPrimaryFieldData()},
+				NumRows:        1,
+				PartialUpdate:  true,
+			},
+			upsertMsg: &msgstream.UpsertMsg{
+				InsertMsg: &msgstream.InsertMsg{
+					InsertRequest: &msgpb.InsertRequest{
+						Base:           commonpbutil.NewMsgBase(commonpbutil.WithMsgType(commonpb.MsgType_Insert)),
+						DbName:         dbName,
+						CollectionName: collectionName,
+						PartitionName:  Params.CommonCfg.DefaultPartitionName.GetValue(),
+						// queryPreExecute has already reconstructed the complete row
+						// before insertPreExecute is called.
+						FieldsData: []*schemapb.FieldData{newPrimaryFieldData(), newValueFieldData()},
+						NumRows:    1,
+						Version:    msgpb.InsertDataVersion_ColumnBased,
+					},
+				},
+			},
+		}
+		materializationInputSize := ut.upsertMsg.InsertMsg.Size()
+		require.Less(t, proto.Size(ut.req), materializationInputSize)
+		Params.Save(Params.QuotaConfig.MaxInsertSize.Key, strconv.Itoa(materializationInputSize))
+		defer Params.Reset(Params.QuotaConfig.MaxInsertSize.Key)
+
+		err := ut.insertPreExecute(context.Background())
+		require.ErrorIs(t, err, merr.ErrParameterTooLarge)
+		require.Greater(t, ut.upsertMsg.InsertMsg.Size(), materializationInputSize)
+	})
+
+	t.Run("-1 still disables the limit", func(t *testing.T) {
+		paramtable.Init()
+		Params.Save(Params.QuotaConfig.MaxInsertSize.Key, "-1")
+		defer Params.Reset(Params.QuotaConfig.MaxInsertSize.Key)
+		assert.NoError(t, checkMaxInsertSize(context.Background(), "insert", 1<<30))
 	})
 }
 

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -1515,6 +1515,10 @@ func (it *upsertTask) insertPreExecute(ctx context.Context) error {
 		return err
 	}
 
+	if err := checkMaxInsertSize(ctx, "upsert", it.upsertMsg.InsertMsg.Size()); err != nil {
+		return err
+	}
+
 	log.Debug(ctx, "Proxy Upsert insertPreExecute done")
 
 	return nil

--- a/internal/proxy/task_upsert_streaming.go
+++ b/internal/proxy/task_upsert_streaming.go
@@ -322,15 +322,17 @@ func (ut *upsertTask) attachPartialUpdateCAS(messages []message.MutableMessage) 
 		if !message.HasPartialUpdateCAS(msg) {
 			return merr.WrapErrServiceInternalMsg("partial update insert is missing CAS metadata for vchannel %s", vchannel)
 		}
-		maxMessageSize := Params.PulsarCfg.MaxMessageSize.GetAsInt()
-		messageSize := msg.EstimateSize()
-		if messageSize > maxMessageSize {
-			return merr.WrapErrServiceInternalMsg(
-				"partial update insert packer emitted oversized message for vchannel %s: size=%d, max=%d",
-				vchannel,
-				messageSize,
-				maxMessageSize,
-			)
+		if Params.ProxyCfg.SplitChunkProxy.GetAsBool() {
+			maxMessageSize := Params.PulsarCfg.MaxMessageSize.GetAsInt()
+			messageSize := msg.EstimateSize()
+			if messageSize > maxMessageSize {
+				return merr.WrapErrServiceInternalMsg(
+					"partial update insert packer emitted oversized message for vchannel %s: size=%d, max=%d",
+					vchannel,
+					messageSize,
+					maxMessageSize,
+				)
+			}
 		}
 		attached[vchannel] = struct{}{}
 	}

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/bytedance/mockey"
@@ -1131,7 +1130,9 @@ func TestRepackInsertDataForStreamingServiceCASMetadata(t *testing.T) {
 	require.ErrorIs(t, err, merr.ErrServiceInternal)
 }
 
-func TestRepackInsertDataForStreamingServiceSplitsOversizedCASMessage(t *testing.T) {
+func TestRepackInsertDataForStreamingServiceProducesSingleMessageWithCASMetadata(t *testing.T) {
+	oldSplitChunkProxy := Params.ProxyCfg.SplitChunkProxy.SwapTempValue("false")
+	t.Cleanup(func() { Params.ProxyCfg.SplitChunkProxy.SwapTempValue(oldSplitChunkProxy) })
 	mockCache := &MetaCache{}
 	partitionPatch := mockey.Mock((*MetaCache).GetPartitionID).Return(int64(200), nil).Build()
 	defer partitionPatch.UnPatch()
@@ -1146,6 +1147,45 @@ func TestRepackInsertDataForStreamingServiceSplitsOversizedCASMessage(t *testing
 		},
 	}
 
+	msgs, err := repackInsertDataForStreamingService(
+		context.Background(),
+		mockCache,
+		[]string{vchannel},
+		task.upsertMsg.InsertMsg,
+		task.result,
+		nil,
+		1,
+		groups,
+	)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	require.True(t, streamingmessage.HasPartialUpdateCAS(msgs[0]))
+	meta, err := streamingmessage.ExtractPartialUpdateCAS(msgs[0])
+	require.NoError(t, err)
+	require.True(t, proto.Equal(groups[vchannel], meta))
+
+	insert := streamingmessage.MustAsMutableInsertMessageV1(msgs[0])
+	require.Equal(t, uint64(len(pks)), insert.Header().GetPartitions()[0].GetRows())
+	require.Equal(t, []int64{101, 102}, insert.MustBody().GetRowIDs())
+}
+
+func TestRepackInsertDataForStreamingServiceSwitchesCASChunkOwner(t *testing.T) {
+	mockCache := &MetaCache{}
+	partitionPatch := mockey.Mock((*MetaCache).GetPartitionID).Return(int64(200), nil).Build()
+	defer partitionPatch.UnPatch()
+
+	pks := []int64{10, 20}
+	task := partialUpdateCASRealPackTestTask(t, pks, pks, nil)
+	vchannel := partialUpdateCASTestVChannels[0]
+	groups := map[string]*messagespb.PartialUpdateCAS{
+		vchannel: {
+			ReadTs:               100,
+			ObservedPchannelTerm: 1,
+		},
+	}
+
+	oldSplitChunkProxy := Params.ProxyCfg.SplitChunkProxy.SwapTempValue("false")
+	t.Cleanup(func() { Params.ProxyCfg.SplitChunkProxy.SwapTempValue(oldSplitChunkProxy) })
 	unsplit, err := repackInsertDataForStreamingService(
 		context.Background(),
 		mockCache,
@@ -1158,11 +1198,12 @@ func TestRepackInsertDataForStreamingServiceSplitsOversizedCASMessage(t *testing
 	)
 	require.NoError(t, err)
 	require.Len(t, unsplit, 1)
-	maxMessageSize := unsplit[0].EstimateSize() - 1
-	require.NoError(t, Params.Save(Params.PulsarCfg.MaxMessageSize.Key, strconv.Itoa(maxMessageSize)))
-	t.Cleanup(func() { Params.Reset(Params.PulsarCfg.MaxMessageSize.Key) })
 
-	msgs, err := repackInsertDataForStreamingService(
+	oldMaxMessageSize := Params.PulsarCfg.MaxMessageSize.SwapTempValue(strconv.Itoa(unsplit[0].EstimateSize() - 1))
+	t.Cleanup(func() { Params.PulsarCfg.MaxMessageSize.SwapTempValue(oldMaxMessageSize) })
+
+	Params.ProxyCfg.SplitChunkProxy.SwapTempValue("true")
+	proxySplit, err := repackInsertDataForStreamingService(
 		context.Background(),
 		mockCache,
 		[]string{vchannel},
@@ -1173,36 +1214,14 @@ func TestRepackInsertDataForStreamingServiceSplitsOversizedCASMessage(t *testing
 		groups,
 	)
 	require.NoError(t, err)
-	require.Len(t, msgs, 2)
-
-	rowIDs := make([]int64, 0, len(pks))
-	for _, msg := range msgs {
-		require.LessOrEqual(t, msg.EstimateSize(), maxMessageSize)
+	require.Len(t, proxySplit, 2)
+	for _, msg := range proxySplit {
+		require.LessOrEqual(t, msg.EstimateSize(), unsplit[0].EstimateSize()-1)
 		require.True(t, streamingmessage.HasPartialUpdateCAS(msg))
-		meta, err := streamingmessage.ExtractPartialUpdateCAS(msg)
-		require.NoError(t, err)
-		require.True(t, proto.Equal(groups[vchannel], meta))
-		body := streamingmessage.MustAsMutableInsertMessageV1(msg).MustBody()
-		rowIDs = append(rowIDs, body.GetRowIDs()...)
-	}
-	require.Equal(t, []int64{101, 102}, rowIDs)
-}
-
-func TestRepackInsertDataForStreamingServiceRejectsOversizedSingleRow(t *testing.T) {
-	mockCache := &MetaCache{}
-	partitionPatch := mockey.Mock((*MetaCache).GetPartitionID).Return(int64(200), nil).Build()
-	defer partitionPatch.UnPatch()
-
-	task := partialUpdateCASRealPackTestTask(t, []int64{10}, []int64{10}, nil)
-	vchannel := partialUpdateCASTestVChannels[0]
-	groups := map[string]*messagespb.PartialUpdateCAS{
-		vchannel: {
-			ReadTs:               100,
-			ObservedPchannelTerm: 1,
-		},
 	}
 
-	baseline, err := repackInsertDataForStreamingService(
+	Params.ProxyCfg.SplitChunkProxy.SwapTempValue("false")
+	snSplit, err := repackInsertDataForStreamingService(
 		context.Background(),
 		mockCache,
 		[]string{vchannel},
@@ -1213,25 +1232,15 @@ func TestRepackInsertDataForStreamingServiceRejectsOversizedSingleRow(t *testing
 		groups,
 	)
 	require.NoError(t, err)
-	require.Len(t, baseline, 1)
-	require.NoError(t, Params.Save(Params.PulsarCfg.MaxMessageSize.Key, strconv.Itoa(baseline[0].EstimateSize()-1)))
-	t.Cleanup(func() { Params.Reset(Params.PulsarCfg.MaxMessageSize.Key) })
-
-	_, err = repackInsertDataForStreamingService(
-		context.Background(),
-		mockCache,
-		[]string{vchannel},
-		task.upsertMsg.InsertMsg,
-		task.result,
-		nil,
-		1,
-		groups,
-	)
-	require.ErrorIs(t, err, merr.ErrParameterTooLarge)
+	require.Len(t, snSplit, 1)
 }
 
-func TestRepackInsertDataByPartitionForStreamingServicePropagatesPackingError(t *testing.T) {
+func TestRepackInsertDataByPartitionForStreamingServiceRejectsMisalignedSource(t *testing.T) {
+	oldSplitChunkProxy := Params.ProxyCfg.SplitChunkProxy.SwapTempValue("false")
+	t.Cleanup(func() { Params.ProxyCfg.SplitChunkProxy.SwapTempValue(oldSplitChunkProxy) })
 	task := partialUpdateCASRealPackTestTask(t, []int64{10}, []int64{10}, nil)
+	// A source column shorter than NumRows is a proxy-internal contract
+	// violation and must fail before materialization.
 	task.upsertMsg.InsertMsg.FieldsData = []*schemapb.FieldData{
 		{
 			Type: schemapb.DataType_VarChar,
@@ -1255,89 +1264,8 @@ func TestRepackInsertDataByPartitionForStreamingServicePropagatesPackingError(t 
 		nil,
 		1,
 		nil,
-		streamingmessage.WALNamePulsar,
 	)
-	require.ErrorIs(t, err, merr.ErrParameterInvalid)
-}
-
-func TestRepackInsertDataByPartitionForStreamingServicePreservesEntityPackingOrder(t *testing.T) {
-	pks := []int64{10, 20}
-	task := partialUpdateCASRealPackTestTask(t, pks, pks, nil)
-	task.upsertMsg.InsertMsg.HashValues = []uint32{0, 0}
-	task.upsertMsg.InsertMsg.FieldsData = []*schemapb.FieldData{
-		{
-			FieldId: 100,
-			Type:    schemapb.DataType_VarChar,
-			Field: &schemapb.FieldData_Scalars{
-				Scalars: &schemapb.ScalarField{
-					Data: &schemapb.ScalarField_StringData{
-						StringData: &schemapb.StringArray{Data: []string{
-							strings.Repeat("a", 4096),
-							strings.Repeat("b", 4096),
-						}},
-					},
-				},
-			},
-		},
-	}
-	meta := &messagespb.PartialUpdateCAS{
-		ReadTs:               100,
-		ObservedPchannelTerm: 1,
-	}
-
-	baseline, err := repackInsertDataByPartitionForStreamingService(
-		context.Background(),
-		200,
-		"_default",
-		[]int{0},
-		partialUpdateCASTestVChannels[0],
-		task.upsertMsg.InsertMsg,
-		nil,
-		1,
-		meta,
-		streamingmessage.WALNamePulsar,
-	)
-	require.NoError(t, err)
-	require.Len(t, baseline, 1)
-	maxMessageSize := baseline[0].EstimateSize()
-	require.NoError(t, Params.Save(Params.PulsarCfg.MaxMessageSize.Key, strconv.Itoa(maxMessageSize)))
-	t.Cleanup(func() { Params.Reset(Params.PulsarCfg.MaxMessageSize.Key) })
-
-	entityPacked, err := channelmgr.GenInsertMsgsByPartition(
-		context.Background(),
-		0,
-		200,
-		"_default",
-		[]int{0, 1},
-		partialUpdateCASTestVChannels[0],
-		task.upsertMsg.InsertMsg,
-		streamingmessage.WALNamePulsar,
-	)
-	require.NoError(t, err)
-	require.Len(t, entityPacked, 2)
-
-	msgs, err := repackInsertDataByPartitionForStreamingService(
-		context.Background(),
-		200,
-		"_default",
-		[]int{0, 1},
-		partialUpdateCASTestVChannels[0],
-		task.upsertMsg.InsertMsg,
-		nil,
-		1,
-		meta,
-		streamingmessage.WALNamePulsar,
-	)
-	require.NoError(t, err)
-	require.Len(t, msgs, 2)
-
-	rowIDs := make([]int64, 0, len(pks))
-	for _, msg := range msgs {
-		require.LessOrEqual(t, msg.EstimateSize(), maxMessageSize)
-		body := streamingmessage.MustAsMutableInsertMessageV1(msg).MustBody()
-		rowIDs = append(rowIDs, body.GetRowIDs()...)
-	}
-	require.Equal(t, []int64{101, 102}, rowIDs)
+	require.ErrorIs(t, err, merr.ErrDataIntegrity)
 }
 
 func TestRepackInsertDataWithPartitionKeyForStreamingServiceCASMetadata(t *testing.T) {
@@ -1427,7 +1355,9 @@ func TestRepackInsertDataWithPartitionKeyForStreamingServiceCASMetadata(t *testi
 	require.ErrorIs(t, err, merr.ErrServiceInternal)
 }
 
-func TestRepackInsertDataWithPartitionKeyForStreamingServiceSplitsOversizedCASMessage(t *testing.T) {
+func TestRepackInsertDataWithPartitionKeyForStreamingServiceProducesSingleMessageWithCASMetadata(t *testing.T) {
+	oldSplitChunkProxy := Params.ProxyCfg.SplitChunkProxy.SwapTempValue("false")
+	t.Cleanup(func() { Params.ProxyCfg.SplitChunkProxy.SwapTempValue(oldSplitChunkProxy) })
 	mockCache := NewMockCache(t)
 	mockCache.EXPECT().
 		GetPartitions(mock.Anything, mock.Anything, mock.Anything).
@@ -1449,24 +1379,6 @@ func TestRepackInsertDataWithPartitionKeyForStreamingServiceSplitsOversizedCASMe
 		},
 	}
 
-	unsplit, err := repackInsertDataWithPartitionKeyForStreamingService(
-		context.Background(),
-		mockCache,
-		[]string{vchannel},
-		task.upsertMsg.InsertMsg,
-		task.result,
-		task.partitionKeys,
-		nil,
-		task.schema.CollectionSchema,
-		1,
-		groups,
-	)
-	require.NoError(t, err)
-	require.Len(t, unsplit, 1)
-	maxMessageSize := unsplit[0].EstimateSize() - 1
-	require.NoError(t, Params.Save(Params.PulsarCfg.MaxMessageSize.Key, strconv.Itoa(maxMessageSize)))
-	t.Cleanup(func() { Params.Reset(Params.PulsarCfg.MaxMessageSize.Key) })
-
 	msgs, err := repackInsertDataWithPartitionKeyForStreamingService(
 		context.Background(),
 		mockCache,
@@ -1480,19 +1392,15 @@ func TestRepackInsertDataWithPartitionKeyForStreamingServiceSplitsOversizedCASMe
 		groups,
 	)
 	require.NoError(t, err)
-	require.Len(t, msgs, 2)
+	require.Len(t, msgs, 1)
+	require.True(t, streamingmessage.HasPartialUpdateCAS(msgs[0]))
+	meta, err := streamingmessage.ExtractPartialUpdateCAS(msgs[0])
+	require.NoError(t, err)
+	require.True(t, proto.Equal(groups[vchannel], meta))
 
-	rowIDs := make([]int64, 0, len(pks))
-	for _, msg := range msgs {
-		require.LessOrEqual(t, msg.EstimateSize(), maxMessageSize)
-		require.True(t, streamingmessage.HasPartialUpdateCAS(msg))
-		meta, err := streamingmessage.ExtractPartialUpdateCAS(msg)
-		require.NoError(t, err)
-		require.True(t, proto.Equal(groups[vchannel], meta))
-		body := streamingmessage.MustAsMutableInsertMessageV1(msg).MustBody()
-		rowIDs = append(rowIDs, body.GetRowIDs()...)
-	}
-	require.Equal(t, []int64{101, 102}, rowIDs)
+	insert := streamingmessage.MustAsMutableInsertMessageV1(msgs[0])
+	require.Equal(t, uint64(len(pks)), insert.Header().GetPartitions()[0].GetRows())
+	require.Equal(t, []int64{101, 102}, insert.MustBody().GetRowIDs())
 }
 
 func TestInsertTaskExecuteSelectsPartitionRouting(t *testing.T) {
@@ -2303,23 +2211,6 @@ func TestAttachPartialUpdateCASAcceptsEveryBuilderMarkedInsertChunk(t *testing.T
 		require.NoError(t, err)
 		require.NotNil(t, meta)
 	}
-}
-
-func TestAttachPartialUpdateCASRejectsOversizedInvariant(t *testing.T) {
-	task, _, _ := partialUpdateCASTestTask(t, true, []int64{10}, []int64{10}, nil)
-	setPartialUpdateCASTestChannels(task, partialUpdateCASTestVChannels[:1])
-	fakeWAL := newPartialUpdateCASTestWAL(t, 9)
-	oldWAL := streaming.WAL()
-	streaming.SetWALForTest(fakeWAL)
-	defer streaming.SetWALForTest(oldWAL)
-	preparePartialUpdateCASTestGroups(t, task)
-	insertMsgs, _ := buildPartialUpdateCASTestMessages(t, task.collectionID, partialUpdateCASTestVChannels[:1], []int64{10}, nil, task.partialUpdateCASGroups)
-
-	require.NoError(t, Params.Save(Params.PulsarCfg.MaxMessageSize.Key, strconv.Itoa(insertMsgs[0].EstimateSize()-1)))
-	defer Params.Reset(Params.PulsarCfg.MaxMessageSize.Key)
-
-	err := task.attachPartialUpdateCAS(insertMsgs)
-	require.ErrorIs(t, err, merr.ErrServiceInternal)
 }
 
 func TestRetrieveByPKs_Success(t *testing.T) {

--- a/internal/proxy/telemetry_command_reply_test.go
+++ b/internal/proxy/telemetry_command_reply_test.go
@@ -32,7 +32,16 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
+
+func disableTelemetryAuthorization(t *testing.T) {
+	t.Helper()
+	require.NoError(t, paramtable.Get().Save(Params.CommonCfg.AuthorizationEnabled.Key, "false"))
+	t.Cleanup(func() {
+		require.NoError(t, paramtable.Get().Reset(Params.CommonCfg.AuthorizationEnabled.Key))
+	})
+}
 
 // telemetryRespWithReply builds the shape the server actually returns: replies are JSON
 // encoded into ClientInfo.Reserved["command_replies"], not a dedicated proto field.
@@ -200,6 +209,7 @@ func TestCommandReplyPayload(t *testing.T) {
 }
 
 func TestGetTelemetryCommandReplyHandler(t *testing.T) {
+	disableTelemetryAuthorization(t)
 	gin.SetMode(gin.TestMode)
 
 	newCtx := func(url string, commandID string) (*httptest.ResponseRecorder, *gin.Context) {
@@ -354,6 +364,7 @@ func TestGetTelemetryCommandReplyHandler(t *testing.T) {
 // sync.Map handed back one arbitrary client's answer as though it were the cluster's --
 // non-deterministically, and with no hint that more existed.
 func TestBroadcastCommandReturnsEveryReply(t *testing.T) {
+	disableTelemetryAuthorization(t)
 	gin.SetMode(gin.TestMode)
 
 	mixCoord := mocks.NewMockMixCoordClient(t)
@@ -400,6 +411,7 @@ func TestBroadcastCommandReturnsEveryReply(t *testing.T) {
 // client keeps the singular convenience fields, so the shared response shape did not become
 // harder to read for the endpoints that can only ever have one answer.
 func TestTargetedLookupStillReturnsOneReply(t *testing.T) {
+	disableTelemetryAuthorization(t)
 	gin.SetMode(gin.TestMode)
 
 	mixCoord := mocks.NewMockMixCoordClient(t)

--- a/internal/streamingnode/client/handler/handler_client_impl.go
+++ b/internal/streamingnode/client/handler/handler_client_impl.go
@@ -28,7 +28,6 @@ import (
 
 var (
 	errWaitNextBackoff                   = errors.New("wait for next backoff")
-	_                  producer.Producer = wal.WAL(nil)
 	_                  consumer.Consumer = wal.Scanner(nil)
 )
 

--- a/internal/streamingnode/client/handler/registry/wal_manager.go
+++ b/internal/streamingnode/client/handler/registry/wal_manager.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 
+	"github.com/milvus-io/milvus/internal/streamingnode/client/handler/producer"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
@@ -13,6 +14,8 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/syncutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
+
+var _ producer.Producer = localWAL{}
 
 var (
 	registry                   = syncutil.NewFuture[WALManager]()
@@ -67,6 +70,13 @@ type localWAL struct {
 
 func (l localWAL) isLocal() localTrait {
 	return localTrait{}
+}
+
+// Available preserves the client Producer contract for the local fast path.
+// The legacy method name is misleading: like Unavailable, the returned channel
+// closes when the underlying WAL becomes unavailable.
+func (l localWAL) Available() <-chan struct{} {
+	return l.Unavailable()
 }
 
 // Append writes a record to the log.

--- a/internal/streamingnode/client/handler/registry/wal_manager_test.go
+++ b/internal/streamingnode/client/handler/registry/wal_manager_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus/internal/mocks/streamingnode/server/mock_wal"
+	"github.com/milvus-io/milvus/internal/streamingnode/client/handler/producer"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
@@ -17,7 +18,8 @@ import (
 )
 
 type mockWALManager struct {
-	t *testing.T
+	t           *testing.T
+	unavailable <-chan struct{}
 }
 
 func (m *mockWALManager) Metrics() (*types.StreamingNodeMetrics, error) {
@@ -29,6 +31,7 @@ func (m *mockWALManager) GetAvailableWAL(channel types.PChannelInfo) (wal.WAL, e
 	l.EXPECT().Append(mock.Anything, mock.Anything).Return(&types.AppendResult{}, nil)
 	l.EXPECT().AppendAsync(mock.Anything, mock.Anything, mock.Anything).Return()
 	l.EXPECT().Read(mock.Anything, mock.Anything).Return(mock_wal.NewMockScanner(m.t), nil)
+	l.EXPECT().Unavailable().Return(m.unavailable)
 	return l, nil
 }
 
@@ -36,13 +39,18 @@ func TestGetLocalAvailableWAL(t *testing.T) {
 	paramtable.Init()
 	paramtable.SetLocalComponentEnabled(typeutil.StreamingNodeRole)
 
-	manager := &mockWALManager{t: t}
+	unavailable := make(chan struct{})
+	manager := &mockWALManager{t: t, unavailable: unavailable}
 	RegisterLocalWALManager(manager)
 
 	walInstance, err := GetLocalAvailableWAL(types.PChannelInfo{})
 	assert.NoError(t, err)
 	assert.NotNil(t, walInstance)
 	assert.True(t, IsLocal(walInstance))
+	localProducer, ok := any(walInstance).(producer.Producer)
+	if assert.True(t, ok) {
+		assert.Equal(t, (<-chan struct{})(unavailable), localProducer.Available())
+	}
 
 	msg, _ := message.NewTimeTickMessageBuilderV1().
 		WithAllVChannel().

--- a/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
@@ -40,6 +40,7 @@ type RecoverWALFlusherParam struct {
 	RecoverySnapshot   *recovery.RecoverySnapshot
 	RecoveryStorage    recovery.RecoveryStorage
 	RateLimitComponent *rate.WALRateLimitComponent
+	OnFatal            func(error)
 }
 
 // RecoverWALFlusher recovers the wal flusher.
@@ -54,6 +55,7 @@ func RecoverWALFlusher(param *RecoverWALFlusherParam) *WALFlusherImpl {
 		emptyTimeTickCounter: metrics.WALFlusherEmptyTimeTickFilteredTotal.WithLabelValues(paramtable.GetStringNodeID(), param.ChannelInfo.Name),
 		rateLimitComponent:   param.RateLimitComponent,
 		RecoveryStorage:      param.RecoveryStorage,
+		onFatal:              param.OnFatal,
 	}
 	go flusher.Execute(param.RecoverySnapshot)
 	return flusher
@@ -69,6 +71,7 @@ type WALFlusherImpl struct {
 	emptyTimeTickCounter prometheus.Counter
 	rateLimitComponent   *rate.WALRateLimitComponent
 	recovery.RecoveryStorage
+	onFatal func(error)
 }
 
 // Execute starts the wal flusher.
@@ -79,7 +82,7 @@ func (impl *WALFlusherImpl) Execute(recoverSnapshot *recovery.RecoverySnapshot) 
 			impl.logger.Info(context.TODO(), "wal flusher stop")
 			return
 		}
-		if !errors.Is(err, context.Canceled) {
+		if impl.notifier.Context().Err() == nil {
 			impl.logger.DPanic(context.TODO(), "wal flusher stop to executing with unexpected error", mlog.Err(err))
 			return
 		}
@@ -94,20 +97,20 @@ func (impl *WALFlusherImpl) Execute(recoverSnapshot *recovery.RecoverySnapshot) 
 	impl.logger.Info(context.TODO(), "wal flusher start to recovery...")
 	l, err := impl.wal.GetWithContext(impl.notifier.Context())
 	if err != nil {
-		return errors.Wrap(err, "when get wal from future")
+		return impl.notifyFatal(errors.Wrap(err, "when get wal from future"))
 	}
 	impl.logger.Info(context.TODO(), "wal ready for flusher recovery")
 
 	var checkpoint message.MessageID
 	impl.flusherComponents, checkpoint, err = impl.buildFlusherComponents(impl.notifier.Context(), l, recoverSnapshot)
 	if err != nil {
-		return errors.Wrap(err, "when build flusher components")
+		return impl.notifyFatal(errors.Wrap(err, "when build flusher components"))
 	}
 	defer impl.flusherComponents.Close()
 
 	scanner, err := impl.generateScanner(impl.notifier.Context(), impl.wal.Get(), checkpoint)
 	if err != nil {
-		return errors.Wrap(err, "when generate scanner")
+		return impl.notifyFatal(errors.Wrap(err, "when generate scanner"))
 	}
 	defer scanner.Close()
 
@@ -122,22 +125,34 @@ func (impl *WALFlusherImpl) Execute(recoverSnapshot *recovery.RecoverySnapshot) 
 			return nil
 		case msg, ok := <-scanner.Chan():
 			if !ok {
-				impl.logger.Warn(context.TODO(), "wal flusher is closing for closed scanner channel, which is unexpected at graceful way")
-				return nil
+				if err := scanner.Error(); err != nil {
+					return impl.notifyFatal(errors.Wrap(err, "wal flusher scanner stopped"))
+				}
+				if impl.notifier.Context().Err() != nil {
+					return nil
+				}
+				return impl.notifyFatal(errors.New("wal flusher scanner stopped unexpectedly"))
 			}
 			impl.metrics.ObserveMetrics(msg.TimeTick())
 			if err := impl.dispatch(msg); err != nil {
-				if errors.IsAny(err, context.Canceled, context.DeadlineExceeded) {
+				if errors.IsAny(err, context.Canceled, context.DeadlineExceeded) && impl.notifier.Context().Err() != nil {
 					return nil
 				}
 				impl.logger.Error(impl.notifier.Context(), "wal flusher dispatch failed with unexpected error",
 					mlog.FieldVChannel(msg.VChannel()),
 					mlog.String("messageType", msg.MessageType().String()),
 					mlog.Err(err))
-				return err
+				return impl.notifyFatal(err)
 			}
 		}
 	}
+}
+
+func (impl *WALFlusherImpl) notifyFatal(err error) error {
+	if err != nil && impl.notifier.Context().Err() == nil && impl.onFatal != nil {
+		impl.onFatal(err)
+	}
+	return err
 }
 
 // Close closes the wal flusher and release all related resources for it.

--- a/internal/streamingnode/server/flusher/flusherimpl/wal_flusher_test.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/wal_flusher_test.go
@@ -527,8 +527,9 @@ func TestWALFlusher_ExecuteReturnsObserveMessageError(t *testing.T) {
 	mockWBMgr := writebuffer.NewMockBufferManager(t)
 	mockWBMgr.EXPECT().FlushChannel(mock.Anything, vchannel, timeTick).Return(nil).Once()
 
+	observeErr := errors.New("observe failed")
 	rs := mock_recovery.NewMockRecoveryStorage(t)
-	rs.EXPECT().ObserveMessage(mock.Anything, immutableMsg).Return(errors.New("observe failed")).Once()
+	rs.EXPECT().ObserveMessage(mock.Anything, immutableMsg).Return(observeErr).Once()
 
 	l := mock_wal.NewMockWAL(t)
 	pchannel := types.PChannelInfo{Name: "pchannel"}
@@ -553,6 +554,7 @@ func TestWALFlusher_ExecuteReturnsObserveMessageError(t *testing.T) {
 
 	rateLimitComponent := rate.NewWALRateLimitComponent(pchannel)
 	defer rateLimitComponent.Close()
+	fatalErrCh := make(chan error, 2)
 	flusher := &WALFlusherImpl{
 		notifier:             syncutil.NewAsyncTaskNotifier[struct{}](),
 		wal:                  syncutil.NewFuture[wal.WAL](),
@@ -561,6 +563,9 @@ func TestWALFlusher_ExecuteReturnsObserveMessageError(t *testing.T) {
 		RecoveryStorage:      rs,
 		rateLimitComponent:   rateLimitComponent,
 		emptyTimeTickCounter: metrics.WALFlusherEmptyTimeTickFilteredTotal.WithLabelValues(paramtable.GetStringNodeID(), pchannel.Name),
+		onFatal: func(err error) {
+			fatalErrCh <- err
+		},
 	}
 	flusher.wal.Set(l)
 
@@ -570,7 +575,83 @@ func TestWALFlusher_ExecuteReturnsObserveMessageError(t *testing.T) {
 			TimeTick: 0,
 		},
 	})
-	require.ErrorContains(t, err, "observe failed")
+	require.ErrorIs(t, err, observeErr)
+	select {
+	case fatalErr := <-fatalErrCh:
+		require.ErrorIs(t, fatalErr, observeErr)
+	default:
+		t.Fatal("fatal flusher error was not reported")
+	}
+	select {
+	case fatalErr := <-fatalErrCh:
+		t.Fatalf("fatal flusher error was reported more than once: %v", fatalErr)
+	default:
+	}
+}
+
+func TestWALFlusher_ExecuteReturnsScannerError(t *testing.T) {
+	streamingutil.SetStreamingServiceEnabled()
+	defer streamingutil.UnsetStreamingServiceEnabled()
+
+	scannerErr := errors.New("corrupted wal record")
+	messageCh := make(chan message.ImmutableMessage)
+	close(messageCh)
+
+	scanner := mock_wal.NewMockScanner(t)
+	scanner.EXPECT().Chan().Return(messageCh).Once()
+	scanner.EXPECT().Error().Return(scannerErr).Once()
+	scanner.EXPECT().Close().Return(scannerErr).Once()
+
+	pchannel := types.PChannelInfo{Name: "pchannel"}
+	l := mock_wal.NewMockWAL(t)
+	l.EXPECT().WALName().Return(message.WALNameRocksmq).Once()
+	l.EXPECT().Read(mock.Anything, mock.Anything).Return(scanner, nil).Once()
+
+	mixcoord := mocks.NewMockMixCoordClient(t)
+	fMixcoord := syncutil.NewFuture[internaltypes.MixCoordClient]()
+	fMixcoord.Set(mixcoord)
+	resource.InitForTest(
+		t,
+		resource.OptMixCoordClient(fMixcoord),
+		resource.OptChunkManager(mock_storage.NewMockChunkManager(t)),
+	)
+
+	rs := mock_recovery.NewMockRecoveryStorage(t)
+	rateLimitComponent := rate.NewWALRateLimitComponent(pchannel)
+	defer rateLimitComponent.Close()
+	fatalErrCh := make(chan error, 2)
+	flusher := &WALFlusherImpl{
+		notifier:             syncutil.NewAsyncTaskNotifier[struct{}](),
+		wal:                  syncutil.NewFuture[wal.WAL](),
+		logger:               mlog.With(mlog.FieldComponent("test-flusher")),
+		metrics:              newFlusherMetrics(pchannel),
+		RecoveryStorage:      rs,
+		rateLimitComponent:   rateLimitComponent,
+		emptyTimeTickCounter: metrics.WALFlusherEmptyTimeTickFilteredTotal.WithLabelValues(paramtable.GetStringNodeID(), pchannel.Name),
+		onFatal: func(err error) {
+			fatalErrCh <- err
+		},
+	}
+	flusher.wal.Set(l)
+
+	err := flusher.Execute(&recovery.RecoverySnapshot{
+		VChannels: map[string]*streamingpb.VChannelMeta{},
+		Checkpoint: &recovery.WALCheckpoint{
+			TimeTick: 0,
+		},
+	})
+	require.ErrorIs(t, err, scannerErr)
+	select {
+	case fatalErr := <-fatalErrCh:
+		require.ErrorIs(t, fatalErr, scannerErr)
+	default:
+		t.Fatal("scanner error was not reported as fatal")
+	}
+	select {
+	case fatalErr := <-fatalErrCh:
+		t.Fatalf("scanner error was reported more than once: %v", fatalErr)
+	default:
+	}
 }
 
 func TestDispatch_CommitImportMessage_FlushUnexpectedErrorPanics(t *testing.T) {

--- a/internal/streamingnode/server/service/handler/producer/produce_server.go
+++ b/internal/streamingnode/server/service/handler/producer/produce_server.go
@@ -101,15 +101,15 @@ func (p *ProduceServer) sendLoop() (err error) {
 		}
 		p.logger.Info(context.TODO(), "send arm of stream closed")
 	}()
-	available := p.wal.Available()
+	unavailable := p.wal.Unavailable()
 	var appendWGDoneChan <-chan struct{}
 
 	for {
 		select {
-		case <-available:
+		case <-unavailable:
 			// If the wal is not available any more, we should stop sending message, and close the server.
 			// appendWGDoneChan make a graceful shutdown for those case.
-			available = nil
+			unavailable = nil
 			appendWGDoneChan = p.getWaitAppendChan()
 		case <-appendWGDoneChan:
 			// All pending append request has been finished, we can close the streaming server now.
@@ -217,6 +217,16 @@ func (p *ProduceServer) validateMessage(msg message.MutableMessage) error {
 	// validate the msg.
 	if !msg.MessageType().Valid() {
 		return status.NewInvalidArgument("unsupported message type")
+	}
+	// Chunk markers are produced below this layer, by the WAL adaptor, and are
+	// stripped again on reassembly -- a message arriving here can never
+	// legitimately carry them. Reject instead of appending: a foreign record
+	// carrying `_ci`/`_ct` is read back as a corrupted chunk run, which fails
+	// the scanner and takes the whole pchannel down. Turning a bad input into a
+	// channel-wide outage is not an acceptable trade, so the check belongs at
+	// ingress.
+	if message.IsChunkedPayload(msg) {
+		return status.NewInvalidArgument("message properties must not carry the reserved WAL chunk markers")
 	}
 	return nil
 }

--- a/internal/streamingnode/server/service/handler/producer/produce_server_test.go
+++ b/internal/streamingnode/server/service/handler/producer/produce_server_test.go
@@ -100,7 +100,7 @@ func TestProduceSendArm(t *testing.T) {
 	})
 
 	wal := mock_wal.NewMockWAL(t)
-	wal.EXPECT().Available().Return(make(<-chan struct{}))
+	wal.EXPECT().Unavailable().Return(make(<-chan struct{}))
 
 	p := &ProduceServer{
 		wal: wal,
@@ -324,7 +324,7 @@ func TestProduceServerSendLoop_RateLimitMessage(t *testing.T) {
 	})
 
 	wal := mock_wal.NewMockWAL(t)
-	wal.EXPECT().Available().Return(make(<-chan struct{}))
+	wal.EXPECT().Unavailable().Return(make(<-chan struct{}))
 
 	p := &ProduceServer{
 		wal: wal,
@@ -370,7 +370,7 @@ func TestProduceServerSendLoop_RateLimitMessageError(t *testing.T) {
 	})
 
 	wal := mock_wal.NewMockWAL(t)
-	wal.EXPECT().Available().Return(make(<-chan struct{}))
+	wal.EXPECT().Unavailable().Return(make(<-chan struct{}))
 
 	p := &ProduceServer{
 		wal: wal,
@@ -415,7 +415,7 @@ func TestProduceServerSendLoop_WALUnavailable(t *testing.T) {
 
 	availableCh := make(chan struct{})
 	wal := mock_wal.NewMockWAL(t)
-	wal.EXPECT().Available().Return(availableCh)
+	wal.EXPECT().Unavailable().Return(availableCh)
 
 	p := &ProduceServer{
 		wal: wal,
@@ -954,7 +954,7 @@ func TestProduceServerExecute(t *testing.T) {
 		Name: "test",
 		Term: 1,
 	})
-	l.EXPECT().Available().Return(make(<-chan struct{}))
+	l.EXPECT().Unavailable().Return(make(<-chan struct{}))
 	l.EXPECT().Register(mock.Anything).Return().Maybe()
 	l.EXPECT().Unregister(mock.Anything).Return().Maybe()
 	l.EXPECT().IsAvailable().Return(true)
@@ -1012,4 +1012,24 @@ func TestProduceServerExecute(t *testing.T) {
 
 	// Should have sent at least 2 messages: produce response + close response
 	assert.GreaterOrEqual(t, sendCallCount.Load(), int32(2))
+}
+
+func TestProduceServerValidateMessageRejectsChunkMarkers(t *testing.T) {
+	p := &ProduceServer{}
+
+	// An ordinary message produced by a client is accepted.
+	assert.NoError(t, p.validateMessage(message.CreateTestEmptyInsertMesage(1, nil)))
+
+	// Chunk markers are added below this layer and stripped on reassembly, so a
+	// message carrying them at ingress is foreign. Appending it would be read
+	// back as a corrupted chunk run and fail-stop the whole pchannel.
+	for _, props := range []map[string]string{
+		{"_ci": "0"},
+		{"_ct": "2"},
+		{"_ci": "0", "_ct": "2"},
+		{"_ci": "not-a-number", "_ct": "2"},
+	} {
+		err := p.validateMessage(message.CreateTestEmptyInsertMesage(1, props))
+		assert.Error(t, err, "properties: %v", props)
+	}
 }

--- a/internal/streamingnode/server/wal/adaptor/old_version_message_test.go
+++ b/internal/streamingnode/server/wal/adaptor/old_version_message_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -215,4 +216,80 @@ func TestNewOldVersionImmutableMessage(t *testing.T) {
 	ImportMsgV1, err := message.AsImmutableImportMessageV1(msg)
 	assert.NoError(t, err)
 	assert.NotNil(t, ImportMsgV1)
+}
+
+func TestCatchupScannerAssemblesOldVersionBeforeConversion(t *testing.T) {
+	resource.InitForTest(t)
+
+	tt := uint64(10086)
+	insert := &msgpb.InsertRequest{
+		Base: &commonpb.MsgBase{
+			MsgType:   commonpb.MsgType_Insert,
+			Timestamp: tt,
+		},
+		Timestamps:   []uint64{tt},
+		CollectionID: 1,
+		PartitionID:  2,
+		NumRows:      1,
+		SegmentID:    100,
+		ShardName:    "test-v0",
+	}
+	payload, err := proto.Marshal(insert)
+	require.NoError(t, err)
+
+	logical := message.NewMutableMessageBeforeAppend(payload, map[string]string{
+		"_v": message.VersionOld.String(),
+	}).WithTimeTick(tt)
+	chunks := message.SplitIntoChunks(logical, len(payload)/2)
+	require.Greater(t, len(chunks), 1)
+
+	physical := make([]message.ImmutableMessage, 0, len(chunks))
+	for i, chunk := range chunks {
+		physical = append(physical, chunk.IntoImmutableMessage(walimplstest.NewTestMessageID(int64(i+1))))
+	}
+
+	captured := runTraceTestCatchupScanner(t, physical...)
+	require.Len(t, captured, 1)
+	assert.False(t, message.IsChunkedPayload(captured[0]))
+	converted, err := message.AsImmutableInsertMessageV1(captured[0])
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), converted.Header().CollectionId)
+	assert.Equal(t, uint64(1), converted.Header().Partitions[0].Rows)
+}
+
+func TestCatchupScannerUsesConvertedOldTimeTickAsChunkBarrier(t *testing.T) {
+	resource.InitForTest(t)
+
+	insert := &msgpb.InsertRequest{
+		Base:         &commonpb.MsgBase{MsgType: commonpb.MsgType_Insert, Timestamp: 100},
+		Timestamps:   []uint64{100},
+		CollectionID: 1,
+		PartitionID:  2,
+		NumRows:      1,
+		SegmentID:    100,
+		ShardName:    "test-v0",
+	}
+	payload, err := proto.Marshal(insert)
+	require.NoError(t, err)
+	chunks := message.SplitIntoChunks(
+		message.NewMutableMessageBeforeAppend(payload, map[string]string{"_v": message.VersionOld.String()}).WithTimeTick(100),
+		(len(payload)+1)/2,
+	)
+	require.Len(t, chunks, 2)
+
+	timeTickPayload, err := proto.Marshal(&msgpb.DeleteRequest{
+		Base: &commonpb.MsgBase{MsgType: commonpb.MsgType_TimeTick, Timestamp: 150},
+	})
+	require.NoError(t, err)
+	timeTick := message.NewMutableMessageBeforeAppend(timeTickPayload, map[string]string{
+		"_v": message.VersionOld.String(),
+	}).WithTimeTick(150)
+
+	captured := runTraceTestCatchupScanner(t,
+		chunks[0].IntoImmutableMessage(walimplstest.NewTestMessageID(1)),
+		timeTick.IntoImmutableMessage(walimplstest.NewTestMessageID(2)),
+		chunks[1].IntoImmutableMessage(walimplstest.NewTestMessageID(3)),
+	)
+	require.Len(t, captured, 1, "the stale tail must not complete after the TimeTick barrier")
+	assert.Equal(t, message.MessageTypeTimeTick, captured[0].MessageType())
 }

--- a/internal/streamingnode/server/wal/adaptor/opener.go
+++ b/internal/streamingnode/server/wal/adaptor/opener.go
@@ -256,6 +256,7 @@ func (o *openerAdaptorImpl) openRWWAL(ctx context.Context, l walimpls.WALImpls, 
 			ChannelInfo:        l.Channel(),
 			RecoverySnapshot:   snapshot,
 			RateLimitComponent: roWAL.WALRateLimitComponent,
+			OnFatal:            roWAL.markUnavailable,
 		})
 		resources.flusher = flusher
 	}
@@ -329,6 +330,7 @@ func (o *openerAdaptorImpl) handleAlterWALFlushingStage(ctx context.Context, opt
 			ChannelInfo:        roWAL.Channel(),
 			RecoverySnapshot:   snapshot,
 			RateLimitComponent: roWAL.WALRateLimitComponent,
+			OnFatal:            roWAL.markUnavailable,
 		})
 		resources.flusher = flusher
 	}
@@ -343,8 +345,12 @@ func (o *openerAdaptorImpl) handleAlterWALFlushingStage(ctx context.Context, opt
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
-	const defaultWALSwitchFlushTimeout = 1 * time.Minute
-
+	// There is deliberately no internal wall-clock deadline on this wait. It
+	// ends when the target checkpoint is reached, the recovered WAL becomes
+	// unavailable, or the caller's Open context is canceled. The caller owns
+	// the overall assignment/open deadline, while a backlog that is still
+	// draining must be allowed to keep making progress within that lifetime.
+	//
 	// Periodically check flush progress until target time tick is reached
 	var flusherCP *utility.WALCheckpoint
 	for flusherCP == nil || flusherCP.TimeTick < targetTimeTick {
@@ -369,11 +375,8 @@ func (o *openerAdaptorImpl) handleAlterWALFlushingStage(ctx context.Context, opt
 				mlog.Uint64("currentTS", flusherCP.TimeTick),
 				mlog.Uint64("targetTS", targetTimeTick),
 				mlog.Uint64("remainingTS", remaining))
-		case <-time.After(defaultWALSwitchFlushTimeout):
-			mlog.Warn(ctx, "timeout waiting for flush completion",
-				mlog.String("channel", opt.Channel.Name),
-				mlog.Duration("timeout", defaultWALSwitchFlushTimeout))
-			return status.NewInner("timeout waiting for flush completion during WAL switch")
+		case <-roWAL.Unavailable():
+			return status.NewInner("wal became unavailable while waiting for flush completion during WAL switch")
 		case <-ctx.Done():
 			mlog.Warn(ctx, "context canceled while waiting for flush completion", mlog.String("channel", opt.Channel.Name), mlog.Err(ctx.Err()))
 			return errors.Wrap(ctx.Err(), "context canceled during WAL switch flush waiting")

--- a/internal/streamingnode/server/wal/adaptor/opener_test.go
+++ b/internal/streamingnode/server/wal/adaptor/opener_test.go
@@ -257,6 +257,7 @@ func TestHandleAlterWALFlushingStagePassesRateLimitComponent(t *testing.T) {
 	assert.Same(t, rs, capturedParam.RecoveryStorage)
 	assert.Equal(t, channel, capturedParam.ChannelInfo)
 	assert.Same(t, snapshot, capturedParam.RecoverySnapshot)
+	require.NotNil(t, capturedParam.OnFatal)
 	assert.Equal(t, streamingpb.AlterWALStage_ADVANCE_CHECKPOINT, snapshot.Checkpoint.AlterWalState.Stage)
 }
 
@@ -322,4 +323,73 @@ func TestHandleAlterWALAdvanceCheckpointsStageKeepsReplicateCheckpoint(t *testin
 	assert.Equal(t, uint64(50), replicateCheckpoint.GetTimeTick())
 	assert.Equal(t, sourceMessageID.IntoProto().GetWALName(), replicateCheckpoint.GetMessageId().GetWALName())
 	assert.Equal(t, sourceMessageID.Marshal(), replicateCheckpoint.GetMessageId().GetId())
+}
+
+func TestHandleAlterWALFlushingStageReturnsWhenFlusherFails(t *testing.T) {
+	channel := types.PChannelInfo{
+		Name:       "alter-wal-flusher-failure-test",
+		Term:       1,
+		AccessMode: types.AccessModeRW,
+	}
+	resource.InitForTest(t)
+
+	roWAL := adaptImplsToROWAL(&firstTimeTickWALImpls{
+		channel: channel,
+		appendFunc: func(context.Context, message.MutableMessage) (message.MessageID, error) {
+			return rmq.NewRmqID(1), nil
+		},
+	}, func() {})
+
+	rs := mock_recovery.NewMockRecoveryStorage(t)
+	rs.EXPECT().Close().Return()
+	snapshot := &recovery.RecoverySnapshot{
+		Checkpoint: &recovery.WALCheckpoint{
+			MessageID: rmq.NewRmqID(1),
+			TimeTick:  10,
+			AlterWalState: &streamingpb.AlterWALState{
+				TargetWalName: commonpb.WALName_Test,
+				TimeTick:      100,
+				Stage:         streamingpb.AlterWALStage_FLUSHING,
+			},
+		},
+		AlterWALInfo: &recovery.AlterWALInfo{
+			FoundAlterWALMsg: true,
+			TargetWALName:    commonpb.WALName_Test,
+			AlterWALTs:       100,
+		},
+	}
+
+	mockRecoverFlusher := mockey.Mock(flusherimpl.RecoverWALFlusher).
+		To(func(param *flusherimpl.RecoverWALFlusherParam) *flusherimpl.WALFlusherImpl {
+			require.NotNil(t, param.OnFatal)
+			param.OnFatal(errors.New("flusher failed"))
+			return &flusherimpl.WALFlusherImpl{}
+		}).
+		Build()
+	defer mockRecoverFlusher.UnPatch()
+
+	mockFlusherClose := mockey.Mock((*flusherimpl.WALFlusherImpl).Close).
+		To(func(*flusherimpl.WALFlusherImpl) {
+			rs.Close()
+		}).
+		Build()
+	defer mockFlusherClose.UnPatch()
+
+	resources := &walOpenResources{
+		roWAL:           roWAL,
+		param:           &interceptors.InterceptorBuildParam{},
+		recoveryStorage: rs,
+	}
+	defer resources.Close()
+
+	err := (&openerAdaptorImpl{}).handleAlterWALFlushingStage(
+		context.Background(),
+		&wal.OpenOption{Channel: channel},
+		roWAL,
+		rs,
+		resources,
+		snapshot,
+	)
+	require.ErrorContains(t, err, "wal became unavailable")
+	assert.Equal(t, streamingpb.AlterWALStage_FLUSHING, snapshot.Checkpoint.AlterWalState.Stage)
 }

--- a/internal/streamingnode/server/wal/adaptor/ro_wal_adaptor.go
+++ b/internal/streamingnode/server/wal/adaptor/ro_wal_adaptor.go
@@ -136,9 +136,16 @@ func (w *roWALAdaptorImpl) IsAvailable() bool {
 	return w.availableCtx.Err() == nil
 }
 
-// Available returns a channel that will be closed when the wal is shut down.
-func (w *roWALAdaptorImpl) Available() <-chan struct{} {
+// Unavailable returns a channel that is closed when the WAL becomes unavailable.
+func (w *roWALAdaptorImpl) Unavailable() <-chan struct{} {
 	return w.availableCtx.Done()
+}
+
+// markUnavailable rejects new operations without closing the WAL from the
+// failing background task. The owner remains responsible for closing it.
+func (w *roWALAdaptorImpl) markUnavailable(err error) {
+	w.Logger().Error(context.TODO(), "wal is unavailable because a background task failed", mlog.Err(err))
+	w.availableCancel()
 }
 
 // Close overrides Scanner Close function.

--- a/internal/streamingnode/server/wal/adaptor/scanner_adaptor.go
+++ b/internal/streamingnode/server/wal/adaptor/scanner_adaptor.go
@@ -167,34 +167,48 @@ func (s *scannerAdaptorImpl) clear() {
 }
 
 func (s *scannerAdaptorImpl) execute() {
+	var finalErr error
 	defer func() {
 		s.readOption.MesasgeHandler.Close()
-		s.Finish(nil)
+		s.Finish(finalErr)
 		s.logger.Info(context.TODO(), "scanner is closed")
 	}()
 	s.logger.Info(context.TODO(), "scanner start background task")
 
 	msgChan := make(chan message.ImmutableMessage)
 
-	ch := make(chan struct{})
-	defer func() { <-ch }()
+	producerErrCh := make(chan error, 1)
 	// TODO: optimize the extra goroutine here after msgstream is removed.
 	go func() {
-		defer close(ch)
 		err := s.produceEventLoop(msgChan)
-		if errors.Is(err, context.Canceled) {
-			s.logger.Info(context.TODO(), "the produce event loop of scanner is closed")
-			return
-		}
-		s.logger.Warn(context.TODO(), "the produce event loop of scanner is closed with unexpected error", mlog.Err(err))
+		producerErrCh <- err
+		// Wake a consumer blocked in its handler. execute reconciles the two
+		// loop results below and preserves a non-cancellation producer error.
+		s.Cancel()
 	}()
 
-	err := s.consumeEventLoop(msgChan)
-	if errors.Is(err, context.Canceled) {
-		s.logger.Info(context.TODO(), "the consuming event loop of scanner is closed")
-		return
+	consumeErr := s.consumeEventLoop(msgChan)
+	s.Cancel()
+	producerErr := <-producerErrCh
+
+	if errors.Is(producerErr, context.Canceled) {
+		s.logger.Info(context.TODO(), "the produce event loop of scanner is closed")
+	} else if producerErr != nil {
+		s.logger.Warn(context.TODO(), "the produce event loop of scanner is closed with unexpected error", mlog.Err(producerErr))
 	}
-	s.logger.Warn(context.TODO(), "the consuming event loop of scanner is closed with unexpected error", mlog.Err(err))
+	if errors.Is(consumeErr, context.Canceled) {
+		s.logger.Info(context.TODO(), "the consuming event loop of scanner is closed")
+	} else if consumeErr != nil {
+		s.logger.Warn(context.TODO(), "the consuming event loop of scanner is closed with unexpected error", mlog.Err(consumeErr))
+	}
+
+	// A consumer-side processing failure wins if both loops fail. Otherwise a
+	// fatal durable-reader/assembly error must be visible from Scanner.Error().
+	if consumeErr != nil && !errors.Is(consumeErr, context.Canceled) {
+		finalErr = consumeErr
+	} else if producerErr != nil && !errors.Is(producerErr, context.Canceled) {
+		finalErr = producerErr
+	}
 }
 
 // produceEventLoop produces the message from the wal and write ahead buffer.
@@ -265,7 +279,9 @@ func (s *scannerAdaptorImpl) consumeEventLoop(msgChan <-chan message.ImmutableMe
 			s.metrics.UpdatePendingQueueSize(s.pendingQueue.Bytes())
 		}
 		if handleResult.Incoming != nil {
-			s.handleUpstream(handleResult.Incoming)
+			if err := s.handleUpstream(handleResult.Incoming); err != nil {
+				return err
+			}
 		}
 	}
 }
@@ -335,11 +351,11 @@ func (c *slowdownCheckerImpl) SlowdownStartupHWM() int64 {
 }
 
 // handleUpstream handles the incoming message from the upstream.
-func (s *scannerAdaptorImpl) handleUpstream(msg message.ImmutableMessage) {
+func (s *scannerAdaptorImpl) handleUpstream(msg message.ImmutableMessage) error {
 	// Filtering the message if needed.
 	// System message should never be filtered.
 	if s.filterFunc != nil && !s.filterFunc(msg) {
-		return
+		return nil
 	}
 
 	// Track read rate for rate limiting control.
@@ -381,14 +397,14 @@ func (s *scannerAdaptorImpl) handleUpstream(msg message.ImmutableMessage) {
 			s.pendingQueue.Add([]message.ImmutableMessage{msg})
 		}
 		s.metrics.UpdatePendingQueueSize(s.pendingQueue.Bytes())
-		return
+		return nil
 	}
 
 	// Filtering the vchannel
 	// If the message is not belong to any vchannel, it should be broadcasted to all vchannels.
 	// Otherwise, it should be filtered by vchannel.
 	if msg.VChannel() != "" && s.readOption.VChannel != "" && s.readOption.VChannel != msg.VChannel() {
-		return
+		return nil
 	}
 	// otherwise add message into reorder buffer directly.
 	if err := s.reorderBuffer.Push(msg); err != nil {
@@ -403,4 +419,5 @@ func (s *scannerAdaptorImpl) handleUpstream(msg message.ImmutableMessage) {
 	// Observe the filtered message.
 	s.metrics.UpdateTimeTickBufSize(s.reorderBuffer.Bytes())
 	s.metrics.ObservePassedMessage(isTailing, msg.MessageType(), msg.EstimateSize())
+	return nil
 }

--- a/internal/streamingnode/server/wal/adaptor/scanner_adaptor_test.go
+++ b/internal/streamingnode/server/wal/adaptor/scanner_adaptor_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
 	"github.com/milvus-io/milvus/internal/mocks/streamingnode/server/wal/interceptors/mock_wab"
@@ -24,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/helper"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/impls/walimplstest"
 	"github.com/milvus-io/milvus/pkg/v3/util/lifetime"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
@@ -70,6 +72,63 @@ func TestScannerAdaptorReadError(t *testing.T) {
 	<-s.Chan()
 	<-s.Done()
 	assert.NoError(t, s.Error())
+}
+
+func TestScannerAdaptorStopsOnCorruptedChunk(t *testing.T) {
+	resource.InitForTest(t)
+
+	corrupted := message.NewMutableMessageBeforeAppend([]byte("broken"), map[string]string{
+		"_t":  "x",
+		"_tt": "!",
+		"_ci": "0",
+		"_ct": "2",
+		"_v":  message.VersionV1.String(),
+	}).IntoImmutableMessage(walimplstest.NewTestMessageID(1))
+	upstream := make(chan message.ImmutableMessage, 1)
+	upstream <- corrupted
+
+	innerScanner := mock_walimpls.NewMockScannerImpls(t)
+	innerScanner.EXPECT().Chan().Return(upstream)
+	innerScanner.EXPECT().Close().Return(nil).Once()
+
+	l := mock_walimpls.NewMockWALImpls(t)
+	l.EXPECT().Channel().Return(types.PChannelInfo{})
+	l.EXPECT().Read(mock.Anything, mock.Anything).Return(innerScanner, nil).Once()
+
+	s := newScannerAdaptor("corrupted-chunk", l, wal.ReadOption{
+		DeliverPolicy: options.DeliverPolicyAll(),
+	}, metricsutil.NewScanMetrics(types.PChannelInfo{}).NewScannerMetrics(), func() {}, true)
+
+	select {
+	case <-s.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("scanner did not stop after corrupted chunk")
+	}
+	require.ErrorIs(t, s.Error(), message.ErrCorruptedChunk)
+	_, ok := <-s.Chan()
+	assert.False(t, ok)
+	require.ErrorIs(t, s.Close(), message.ErrCorruptedChunk)
+}
+
+func TestCatchupScannerDeliversOnlyReassembledLogicalMessages(t *testing.T) {
+	resource.InitForTest(t)
+
+	messageID := walimplstest.NewTestMessageID(1)
+	logical := message.CreateTestEmptyInsertMesage(1, nil).
+		WithTimeTick(100).
+		WithLastConfirmed(messageID)
+	payload := logical.IntoMessageProto().GetPayload()
+	chunks := message.SplitIntoChunks(logical, (len(payload)+1)/2)
+	require.Len(t, chunks, 2)
+
+	physical := make([]message.ImmutableMessage, 0, len(chunks))
+	for i, chunk := range chunks {
+		physical = append(physical, chunk.IntoImmutableMessage(walimplstest.NewTestMessageID(int64(i+1))))
+	}
+	captured := runTraceTestCatchupScanner(t, physical...)
+	require.Len(t, captured, 1)
+	assert.Equal(t, payload, captured[0].IntoImmutableMessageProto().GetPayload())
+	assert.False(t, message.IsChunkedPayload(captured[0]))
 }
 
 func TestPauseConsumption(t *testing.T) {

--- a/internal/streamingnode/server/wal/adaptor/scanner_switchable.go
+++ b/internal/streamingnode/server/wal/adaptor/scanner_switchable.go
@@ -113,6 +113,7 @@ type catchupScanner struct {
 	deliverPolicy                  options.DeliverPolicy
 	exclusiveStartTimeTick         uint64 // scanner should filter out the message that less than or equal to this time tick.
 	oldVersionLastConfirmedTracker *oldVersionLastConfirmedTracker
+	chunkAssembler                 message.ChunkAssembler
 }
 
 func (s *catchupScanner) Do(ctx context.Context) (switchableScanner, error) {
@@ -127,6 +128,9 @@ func (s *catchupScanner) Do(ctx context.Context) (switchableScanner, error) {
 		}
 		switchedScanner, err := s.consumeWithScanner(ctx, scanner)
 		if err != nil {
+			if errors.Is(err, message.ErrCorruptedChunk) {
+				return nil, err
+			}
 			s.logger.Warn(ctx, "scanner consuming was interrpurted with error, start a backoff", mlog.Err(err))
 			continue
 		}
@@ -143,6 +147,21 @@ func (s *catchupScanner) consumeWithScanner(ctx context.Context, scanner walimpl
 		case msg, ok := <-scanner.Chan():
 			if !ok {
 				return nil, scanner.Error()
+			}
+
+			// The underlying durable WAL exposes physical records. Reassemble all
+			// chunk versions here so every later stage sees exactly one complete
+			// logical message. In particular, v0 conversion parses the body and
+			// must never observe an individual payload slice.
+			assembled, handled, err := s.chunkAssembler.Push(msg)
+			if err != nil {
+				return nil, err
+			}
+			if handled {
+				if assembled == nil {
+					continue
+				}
+				msg = assembled
 			}
 
 			if msg.Version() == message.VersionOld {
@@ -168,6 +187,11 @@ func (s *catchupScanner) consumeWithScanner(ctx context.Context, scanner walimpl
 				}
 				if err != nil {
 					panic("unrechable: unexpected error found: " + err.Error())
+				}
+				if msg.MessageType() == message.MessageTypeTimeTick {
+					// A raw v0 TimeTick has no message-type property, so Push cannot
+					// recognize it as a cleanup barrier until conversion completes.
+					s.chunkAssembler.AdvanceTimeTick(msg.TimeTick())
 				}
 			}
 

--- a/internal/streamingnode/server/wal/adaptor/wal_adaptor.go
+++ b/internal/streamingnode/server/wal/adaptor/wal_adaptor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls"
 	"github.com/milvus-io/milvus/pkg/v3/util/conc"
 	"github.com/milvus-io/milvus/pkg/v3/util/contextutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -103,6 +104,8 @@ type walAdaptorImpl struct {
 	writeMetrics           *metricsutil.WriteMetrics
 	isFenced               *atomic.Bool
 	appendRateCounter      *utility.AverageRateCounter // tracks append rate (bytes/sec)
+	chunkPayloadSizeValue  atomic.Int64                // cached payload budget per chunked WAL record; 0 until first computed.
+	chunkPayloadSizeAt     atomic.Int64                // unixnano of the last chunk-payload-size recompute.
 }
 
 // Metrics returns the metrics of the wal.
@@ -219,7 +222,7 @@ func (w *walAdaptorImpl) Append(ctx context.Context, msg message.MutableMessage)
 			}
 
 			metricsGuard.StartWALImplAppend()
-			msgID, err := w.retryAppendWhenRecoverableError(ctx, msg)
+			msgID, err := w.appendWithOptionalChunking(ctx, msg)
 			metricsGuard.FinishWALImplAppend()
 			if err != nil {
 				return msgID, err
@@ -283,8 +286,94 @@ func (w *walAdaptorImpl) Read(ctx context.Context, opts wal.ReadOption) (wal.Sca
 	return w.roWALAdaptorImpl.Read(ctx, opts)
 }
 
-// retryAppendWhenRecoverableError retries the append operation when recoverable error occurs.
-func (w *walAdaptorImpl) retryAppendWhenRecoverableError(ctx context.Context, msg message.MutableMessage) (message.MessageID, error) {
+// appendWithOptionalChunking appends a logical message, splitting it into WAL
+// records only when streaming.splitChunkSN is enabled. During a rolling
+// upgrade, proxy.splitChunk stays enabled until every StreamingNode has been
+// upgraded and observed streaming.splitChunkSN=true.
+//
+// The timetick durability barrier does not depend on record adjacency: a
+// TimeTick(T) message is only published after every message with ts <= T has
+// been fully appended and acknowledged (the ack manager advances its
+// watermark over the consecutive acknowledged prefix, and a chunked message
+// acknowledges exactly once -- when its whole run is persisted), so no
+// downstream component can ever observe a half-written pack.
+func (w *walAdaptorImpl) appendWithOptionalChunking(ctx context.Context, msg message.MutableMessage) (message.MessageID, error) {
+	if !paramtable.Get().StreamingCfg.SplitChunkSN.GetAsBool() {
+		return w.appendOneWithRetry(ctx, msg)
+	}
+
+	chunkPayloadSize := w.chunkPayloadSize()
+	if chunkPayloadSize <= 0 || len(msg.IntoMessageProto().GetPayload()) <= chunkPayloadSize {
+		return w.appendOneWithRetry(ctx, msg)
+	}
+
+	// Split into chunks when the payload exceeds the backend's per-message
+	// limit, so the backend never sees an oversized record. Backends without
+	// a per-record cap (RocksMQ) get a zero budget and keep the pre-chunking
+	// single-record behavior. The successful append attempt of the first chunk
+	// supplies the logical message ID returned to the caller. On durable replay,
+	// the assembler keeps the later payload-identical retry observation, so its
+	// reassembled ID matches the acknowledged one.
+	chunks := message.SplitIntoChunks(msg, chunkPayloadSize)
+
+	var firstID message.MessageID
+	for i, chunk := range chunks {
+		msgID, err := w.appendOneWithRetry(ctx, chunk)
+		if err != nil {
+			return nil, err
+		}
+		if i == 0 {
+			firstID = msgID
+		}
+	}
+	return firstID, nil
+}
+
+// chunkPayloadSizeRefresh bounds how stale the cached chunk-payload budget may
+// be. The underlying config items (pulsar.maxMessageSize,
+// pulsar.messageReserveSize) are refreshable; a live DOWNWARD refresh takes
+// effect for chunking within this window. Note a message already stuck in
+// appendOneWithRetry's infinite retry loop never re-reads config regardless --
+// that exposure is pre-existing, and the cache only widens it by this window
+// for newly arriving appends.
+const chunkPayloadSizeRefresh = time.Second
+
+// chunkPayloadSize reports the payload-size budget per WAL record: the active
+// backend's enforced limit, or Woodpecker's configured Milvus chunk threshold,
+// minus reserve headroom for properties, cipher metadata, and the backend
+// envelope. A zero value disables chunking because no limit/threshold is
+// configured (RocksMQ or an unrecognized WAL); bounded WAL configuration is
+// normalized to at least 256 KiB before reaching this path.
+//
+// Served from a cache refreshed at most once per chunkPayloadSizeRefresh:
+// GetConfig traverses two concurrent lookup structures plus source resolution,
+// which is not per-append work the hot path should pay.
+func (w *walAdaptorImpl) chunkPayloadSize() int {
+	now := time.Now().UnixNano()
+	last := w.chunkPayloadSizeAt.Load()
+	if last != 0 && now-last < int64(chunkPayloadSizeRefresh) {
+		return int(w.chunkPayloadSizeValue.Load())
+	}
+	size := w.computeChunkPayloadSize()
+	w.chunkPayloadSizeValue.Store(int64(size))
+	w.chunkPayloadSizeAt.Store(now)
+	return size
+}
+
+func (w *walAdaptorImpl) computeChunkPayloadSize() int {
+	walName := w.rwWALImpls.WALName()
+	params := paramtable.Get()
+	maxMessageSize := params.WALMaxMessageSize(walName.String())
+	_, reserve := params.PulsarCfg.GetMessageSizeLimitsFor(maxMessageSize)
+	if maxMessageSize <= 0 || reserve < 0 || reserve >= maxMessageSize {
+		return 0
+	}
+	return maxMessageSize - reserve
+}
+
+// appendOneWithRetry appends a single message, retrying until it succeeds or
+// an unrecoverable error occurs.
+func (w *walAdaptorImpl) appendOneWithRetry(ctx context.Context, msg message.MutableMessage) (message.MessageID, error) {
 	backoff := backoff.NewExponentialBackOff()
 	backoff.InitialInterval = 10 * time.Millisecond
 	backoff.MaxInterval = 5 * time.Second

--- a/internal/streamingnode/server/wal/adaptor/wal_adaptor_fence_test.go
+++ b/internal/streamingnode/server/wal/adaptor/wal_adaptor_fence_test.go
@@ -2,6 +2,7 @@ package adaptor
 
 import (
 	"context"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -124,6 +125,54 @@ func TestAppendWaitingBehindAlterWALIsFenced(t *testing.T) {
 	defer mu.Unlock()
 	assert.Equal(t, []message.MessageType{message.MessageTypeAlterWAL}, appendedTypes)
 }
+
+func TestOversizedAppendWithSNChunkingDisabledUsesLegacySingleRecordPath(t *testing.T) {
+	var persisted atomic.Int32
+	walImpls := &chunkRetryTestWALImpls{firstTimeTickWALImpls: newFirstTimeTickWALImpls(
+		func(ctx context.Context, _ message.MutableMessage) (message.MessageID, error) {
+			persisted.Add(1)
+			return finishFenceTestAppend(ctx, 1), nil
+		},
+	)}
+	observer := &countingAppendInterceptor{}
+	w := newFenceTestWAL(t, walImpls, observer)
+
+	const chunkBudget = 2048
+	params := paramtable.Get()
+	oldSplitChunkSN := params.StreamingCfg.SplitChunkSN.SwapTempValue("false")
+	t.Cleanup(func() { params.StreamingCfg.SplitChunkSN.SwapTempValue(oldSplitChunkSN) })
+	maxMessageSizeKey := params.PulsarCfg.MaxMessageSize.Key
+	reserveSizeKey := params.PulsarCfg.MessageReserveSize.Key
+	require.NoError(t, params.Save(maxMessageSizeKey, strconv.Itoa(testMinWALMessageSize)))
+	require.NoError(t, params.Save(reserveSizeKey, strconv.Itoa(testMinWALMessageSize-chunkBudget)))
+	t.Cleanup(func() {
+		assert.NoError(t, params.Reset(reserveSizeKey))
+		assert.NoError(t, params.Reset(maxMessageSizeKey))
+	})
+
+	msg := newOversizedTestInsertMessage(t, chunkBudget).
+		WithTimeTick(100).
+		WithLastConfirmedUseMessageID()
+	_, err := w.Append(context.Background(), msg)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), observer.calls.Load())
+	assert.Equal(t, int32(1), persisted.Load())
+}
+
+type countingAppendInterceptor struct {
+	calls atomic.Int32
+}
+
+func (i *countingAppendInterceptor) DoAppend(
+	ctx context.Context,
+	msg message.MutableMessage,
+	append interceptors.Append,
+) (message.MessageID, error) {
+	i.calls.Add(1)
+	return append(ctx, msg)
+}
+
+func (i *countingAppendInterceptor) Close() {}
 
 type fenceTestGateInterceptor struct {
 	insertEntered chan struct{}

--- a/internal/streamingnode/server/wal/adaptor/wal_adaptor_trace_test.go
+++ b/internal/streamingnode/server/wal/adaptor/wal_adaptor_trace_test.go
@@ -2,9 +2,12 @@ package adaptor
 
 import (
 	"context"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
@@ -12,6 +15,9 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/resource"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/metricsutil"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/utility"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -19,9 +25,225 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/helper"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/impls/walimplstest"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
-func TestRetryAppendOverwritesTraceContextWithAppendImplSpan(t *testing.T) {
+type chunkRetryTestWALImpls struct {
+	*firstTimeTickWALImpls
+}
+
+const testMinWALMessageSize = 256 * 1024
+
+func (w *chunkRetryTestWALImpls) WALName() message.WALName {
+	return message.WALNamePulsar
+}
+
+// newOversizedTestInsertMessage builds an insert message whose marshaled body
+// is guaranteed to exceed budget bytes, so the chunking path is entered for a
+// realistic (non-degenerate) backend limit.
+func newOversizedTestInsertMessage(t *testing.T, budget int) message.MutableMessage {
+	msg, err := message.NewInsertMessageBuilderV1().
+		WithHeader(&message.InsertMessageHeader{
+			CollectionId: 1,
+			Partitions: []*message.PartitionSegmentAssignment{
+				{PartitionId: 2, Rows: 1000, BinarySize: 1024 * 1024},
+			},
+		}).
+		WithBody(&msgpb.InsertRequest{
+			Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_Insert, MsgID: 1},
+			CollectionName: strings.Repeat("x", budget*2),
+		}).
+		WithVChannel("v1").
+		BuildMutable()
+	require.NoError(t, err)
+	return msg
+}
+
+func TestAppendWithOptionalChunkingUsesSuccessfulHeadIDOnDurableAssembly(t *testing.T) {
+	resource.InitForTest(t)
+	params := paramtable.Get()
+	oldSplitChunkSN := params.StreamingCfg.SplitChunkSN.SwapTempValue("true")
+	t.Cleanup(func() { params.StreamingCfg.SplitChunkSN.SwapTempValue(oldSplitChunkSN) })
+	maxMessageSizeKey := params.PulsarCfg.MaxMessageSize.Key
+	reserveSizeKey := params.PulsarCfg.MessageReserveSize.Key
+	// The smallest budget a valid configuration can express: keep the WAL
+	// message-size limit at its supported minimum and reserve all but one byte.
+	require.NoError(t, params.Save(maxMessageSizeKey, strconv.Itoa(testMinWALMessageSize)))
+	require.NoError(t, params.Save(reserveSizeKey, strconv.Itoa(testMinWALMessageSize-1)))
+	t.Cleanup(func() {
+		assert.NoError(t, params.Reset(reserveSizeKey))
+		assert.NoError(t, params.Reset(maxMessageSizeKey))
+	})
+
+	var persisted []message.ImmutableMessage
+	var nextID int64
+	headAttempts := 0
+	inner := newFirstTimeTickWALImpls(func(_ context.Context, msg message.MutableMessage) (message.MessageID, error) {
+		id := walimplstest.NewTestMessageID(nextID)
+		nextID++
+		// Snapshot the record before returning the result: the first head attempt
+		// models a broker-persisted record whose acknowledgement was lost.
+		persisted = append(persisted, msg.IntoImmutableMessage(id))
+		if message.ChunkIndex(msg) == 0 {
+			headAttempts++
+			if headAttempts == 1 {
+				return nil, errors.New("head persisted but acknowledgement lost")
+			}
+		}
+		return id, nil
+	})
+	walImpls := &chunkRetryTestWALImpls{firstTimeTickWALImpls: inner}
+	roWAL := adaptImplsToROWAL(walImpls, func() {})
+	defer roWAL.Close()
+	writeMetrics := metricsutil.NewWriteMetrics(walImpls.Channel(), walImpls.WALName())
+	defer writeMetrics.Close()
+	w := &walAdaptorImpl{
+		roWALAdaptorImpl: roWAL,
+		rwWALImpls:       walImpls,
+		writeMetrics:     writeMetrics,
+	}
+
+	msg := message.CreateTestEmptyInsertMesage(1, nil).
+		WithTimeTick(100).
+		WithLastConfirmedUseMessageID()
+	require.Greater(t, len(msg.IntoMessageProto().GetPayload()), 1)
+
+	acknowledgedID, err := w.appendWithOptionalChunking(context.Background(), msg)
+	require.NoError(t, err)
+	require.Equal(t, 2, headAttempts)
+	require.Greater(t, len(persisted), 2)
+	require.True(t, walimplstest.NewTestMessageID(0).EQ(persisted[0].MessageID()))
+	require.True(t, walimplstest.NewTestMessageID(1).EQ(persisted[1].MessageID()))
+	require.True(t, walimplstest.NewTestMessageID(1).EQ(acknowledgedID))
+
+	var assembler message.ChunkAssembler
+	var assembled message.ImmutableMessage
+	for _, physical := range persisted {
+		candidate, handled, err := assembler.Push(physical)
+		require.NoError(t, err)
+		require.True(t, handled)
+		if candidate != nil {
+			require.Nil(t, assembled)
+			assembled = candidate
+		}
+	}
+	require.NotNil(t, assembled)
+	assert.True(t, acknowledgedID.EQ(assembled.MessageID()))
+	assert.Equal(t, msg.IntoMessageProto().GetPayload(), assembled.IntoImmutableMessageProto().GetPayload())
+}
+
+func TestAppendWithOptionalChunkingDisabledUsesSingleRecord(t *testing.T) {
+	resource.InitForTest(t)
+
+	// A budget both messages below can be compared against: the oversized
+	// insert must exceed it while an ordinary time tick stays well under.
+	const chunkBudget = 2048
+	params := paramtable.Get()
+	oldSplitChunkSN := params.StreamingCfg.SplitChunkSN.SwapTempValue("false")
+	t.Cleanup(func() { params.StreamingCfg.SplitChunkSN.SwapTempValue(oldSplitChunkSN) })
+	maxMessageSizeKey := params.PulsarCfg.MaxMessageSize.Key
+	reserveSizeKey := params.PulsarCfg.MessageReserveSize.Key
+	require.NoError(t, params.Save(maxMessageSizeKey, strconv.Itoa(testMinWALMessageSize)))
+	require.NoError(t, params.Save(reserveSizeKey, strconv.Itoa(testMinWALMessageSize-chunkBudget)))
+	t.Cleanup(func() {
+		assert.NoError(t, params.Reset(reserveSizeKey))
+		assert.NoError(t, params.Reset(maxMessageSizeKey))
+	})
+
+	var persisted []message.MutableMessage
+	inner := newFirstTimeTickWALImpls(func(_ context.Context, msg message.MutableMessage) (message.MessageID, error) {
+		persisted = append(persisted, msg)
+		return walimplstest.NewTestMessageID(int64(len(persisted))), nil
+	})
+	w := &walAdaptorImpl{
+		rwWALImpls: &chunkRetryTestWALImpls{firstTimeTickWALImpls: inner},
+	}
+	msg := newOversizedTestInsertMessage(t, chunkBudget).
+		WithTimeTick(100).
+		WithLastConfirmedUseMessageID()
+	require.Greater(t, len(msg.IntoMessageProto().GetPayload()), chunkBudget)
+
+	_, err := w.appendWithOptionalChunking(context.Background(), msg)
+	require.NoError(t, err)
+	require.Len(t, persisted, 1)
+	assert.False(t, message.IsChunkedPayload(persisted[0]))
+}
+
+func TestAppendWithOptionalChunkingObservesSplitChunkSNHotUpdate(t *testing.T) {
+	resource.InitForTest(t)
+
+	const chunkBudget = 2048
+	params := paramtable.Get()
+	oldSplitChunkSN := params.StreamingCfg.SplitChunkSN.SwapTempValue("false")
+	t.Cleanup(func() { params.StreamingCfg.SplitChunkSN.SwapTempValue(oldSplitChunkSN) })
+	maxMessageSizeKey := params.PulsarCfg.MaxMessageSize.Key
+	reserveSizeKey := params.PulsarCfg.MessageReserveSize.Key
+	require.NoError(t, params.Save(maxMessageSizeKey, strconv.Itoa(testMinWALMessageSize)))
+	require.NoError(t, params.Save(reserveSizeKey, strconv.Itoa(testMinWALMessageSize-chunkBudget)))
+	t.Cleanup(func() {
+		assert.NoError(t, params.Reset(reserveSizeKey))
+		assert.NoError(t, params.Reset(maxMessageSizeKey))
+	})
+
+	var persisted []message.MutableMessage
+	inner := newFirstTimeTickWALImpls(func(_ context.Context, msg message.MutableMessage) (message.MessageID, error) {
+		persisted = append(persisted, msg)
+		return walimplstest.NewTestMessageID(int64(len(persisted))), nil
+	})
+	w := &walAdaptorImpl{
+		rwWALImpls: &chunkRetryTestWALImpls{firstTimeTickWALImpls: inner},
+	}
+
+	appendWithSwitch := func(timeTick uint64, enabled bool) []message.MutableMessage {
+		params.StreamingCfg.SplitChunkSN.SwapTempValue(strconv.FormatBool(enabled))
+		start := len(persisted)
+		msg := newOversizedTestInsertMessage(t, chunkBudget).
+			WithTimeTick(timeTick).
+			WithLastConfirmedUseMessageID()
+		_, err := w.appendWithOptionalChunking(context.Background(), msg)
+		require.NoError(t, err)
+		return persisted[start:]
+	}
+
+	disabled := appendWithSwitch(100, false)
+	require.Len(t, disabled, 1)
+	assert.False(t, message.IsChunkedPayload(disabled[0]))
+
+	enabled := appendWithSwitch(200, true)
+	require.Greater(t, len(enabled), 1)
+	for _, physical := range enabled {
+		assert.True(t, message.IsChunkedPayload(physical))
+	}
+
+	disabledAgain := appendWithSwitch(300, false)
+	require.Len(t, disabledAgain, 1)
+	assert.False(t, message.IsChunkedPayload(disabledAgain[0]))
+}
+
+func TestAppendWithOptionalChunkingDoesNotChunkWithoutRecordLimit(t *testing.T) {
+	resource.InitForTest(t)
+	params := paramtable.Get()
+	oldSplitChunkSN := params.StreamingCfg.SplitChunkSN.SwapTempValue("true")
+	t.Cleanup(func() { params.StreamingCfg.SplitChunkSN.SwapTempValue(oldSplitChunkSN) })
+
+	var persisted []message.MutableMessage
+	w := &walAdaptorImpl{
+		rwWALImpls: newFirstTimeTickWALImpls(func(_ context.Context, msg message.MutableMessage) (message.MessageID, error) {
+			persisted = append(persisted, msg)
+			return walimplstest.NewTestMessageID(1), nil
+		}),
+	}
+	msg := message.CreateTestEmptyInsertMesage(1, nil).
+		WithTimeTick(100).
+		WithLastConfirmedUseMessageID()
+
+	_, err := w.appendWithOptionalChunking(context.Background(), msg)
+	require.NoError(t, err)
+	require.Len(t, persisted, 1)
+	assert.False(t, message.IsChunkedPayload(persisted[0]))
+}
+
+func TestAppendWithOptionalChunkingOverwritesTraceContextWithAppendImplSpan(t *testing.T) {
 	exporter := tracetest.NewInMemoryExporter()
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSyncer(exporter),
@@ -45,7 +267,7 @@ func TestRetryAppendOverwritesTraceContextWithAppendImplSpan(t *testing.T) {
 		}),
 	}
 
-	_, err := w.retryAppendWhenRecoverableError(sourceCtx, msg)
+	_, err := w.appendWithOptionalChunking(sourceCtx, msg)
 	require.NoError(t, err)
 
 	spans := exporter.GetSpans()
@@ -67,7 +289,7 @@ func TestRetryAppendOverwritesTraceContextWithAppendImplSpan(t *testing.T) {
 	assert.Equal(t, appendImpl.SpanContext.SpanID(), msgSC.SpanID())
 }
 
-func TestRetryAppendSkipsTraceForTimeTickMessage(t *testing.T) {
+func TestAppendWithOptionalChunkingSkipsTraceForTimeTickMessage(t *testing.T) {
 	exporter := tracetest.NewInMemoryExporter()
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSyncer(exporter),
@@ -93,7 +315,7 @@ func TestRetryAppendSkipsTraceForTimeTickMessage(t *testing.T) {
 		}),
 	}
 
-	_, err := w.retryAppendWhenRecoverableError(sourceCtx, msg)
+	_, err := w.appendWithOptionalChunking(sourceCtx, msg)
 	require.NoError(t, err)
 
 	for _, s := range exporter.GetSpans() {

--- a/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor.go
@@ -222,8 +222,8 @@ func (impl *shardInterceptor) handleInsertMessage(ctx context.Context, msg messa
 			// we just redo it to refresh a new latest timetick.
 			return nil, redo.ErrRedo
 		}
-		if errors.IsAny(err, shards.ErrTooLargeInsert, shards.ErrPartitionNotFound, shards.ErrCollectionNotFound) {
-			// Message is too large, so retry operation is unrecoverable, can't be retry at client side.
+		if errors.IsAny(err, shards.ErrPartitionNotFound, shards.ErrCollectionNotFound) {
+			// The target metadata no longer exists, so retrying cannot recover the operation.
 			impl.shardManager.Logger().Warn(ctx, "unrecoverable insert operation", mlog.Object("message", msg), mlog.Err(err))
 			return nil, status.NewUnrecoverableError("fail to assign segment, %s", err.Error())
 		}

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/partition_manager.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/partition_manager.go
@@ -199,9 +199,8 @@ func (m *partitionManager) assignSegment(req *AssignSegmentRequest) (*AssignSegm
 		if err == nil {
 			return result, nil
 		}
-		if errors.IsAny(err, ErrTooLargeInsert, ErrTimeTickTooOld) {
+		if errors.Is(err, ErrTimeTickTooOld) {
 			// Return error directly.
-			// If the insert message is too large to hold by single segment, it can not be inserted anymore.
 			lastErr = err
 		}
 	}

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/partition_manager_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/partition_manager_test.go
@@ -56,7 +56,7 @@ func TestPartitionManager(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	w := mock_wal.NewMockWAL(t)
-	w.EXPECT().Available().RunAndReturn(func() <-chan struct{} {
+	w.EXPECT().Unavailable().RunAndReturn(func() <-chan struct{} {
 		return make(chan struct{})
 	}).Maybe()
 	f := syncutil.NewFuture[wal.WAL]()
@@ -141,8 +141,22 @@ func TestPartitionManager(t *testing.T) {
 		},
 	}
 
-	result, _ = m.AssignSegment(req)
+	result, err = m.AssignSegment(req)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
 	result.Ack()
+
+	// Each existing segment accepts the allocation that crosses its soft
+	// assignment target, then rejects later allocations.
+	result, err = m.AssignSegment(req)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	result.Ack()
+	result, err = m.AssignSegment(req)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	result.Ack()
+
 	_, err = m.AssignSegment(req)
 	assert.ErrorIs(t, err, ErrWaitForNewSegment)
 

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/segment_alloc_worker.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/segment_alloc_worker.go
@@ -80,7 +80,7 @@ func (w *segmentAllocWorker) do() {
 		case <-w.ctx.Done():
 			w.Logger().Info(w.ctx, "segment allocation canceled", mlog.Err(w.ctx.Err()))
 			return
-		case <-w.wal.Available():
+		case <-w.wal.Unavailable():
 			// wal is unavailable, stop the worker.
 			w.Logger().Warn(w.ctx, "wal is unavailable, stop alloc new segment")
 			return

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/segment_flush_worker.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/segment_flush_worker.go
@@ -88,7 +88,7 @@ func (w *segmentFlushWorker) do() {
 		case <-w.ctx.Done():
 			w.Logger().Info(w.ctx, "flush segment canceled", mlog.Err(w.ctx.Err()))
 			return
-		case <-w.wal.Available():
+		case <-w.wal.Unavailable():
 			// wal is unavailable, stop the worker.
 			w.Logger().Warn(w.ctx, "wal is unavailable, stop flush segment")
 			return
@@ -106,7 +106,7 @@ func (w *segmentFlushWorker) waitForTxnManagerRecoverDone() error {
 	case <-w.ctx.Done():
 		w.Logger().Info(w.ctx, "flush segment canceled", mlog.Err(w.ctx.Err()))
 		return w.ctx.Err()
-	case <-w.wal.Available():
+	case <-w.wal.Unavailable():
 		return status.NewOnShutdownError("wal is unavailable")
 	}
 }

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/segment_manager.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/segment_manager.go
@@ -149,11 +149,15 @@ func (s *segmentAllocManager) AllocRows(req *AssignSegmentRequest) (*AssignSegme
 		return nil, ErrNotGrowing
 	}
 
+	// Hold an acknowledge before allocation because a successful allocation can
+	// immediately trigger a capacity seal. The flush worker must wait until the
+	// corresponding insert has been appended to the WAL.
+	s.ackSem.Inc()
 	err := resource.Resource().SegmentStatsManager().AllocRows(s.GetSegmentID(), req.ModifiedMetrics, req.RuntimeFlushSize)
 	if err != nil {
+		s.ackSem.Dec()
 		return nil, err
 	}
-	s.ackSem.Inc()
 
 	// register the txn session cleanup to the segment.
 	if req.TxnSession != nil {

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/segment_manager_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/segment_manager_test.go
@@ -2,14 +2,17 @@ package shards
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus/internal/mocks/streamingnode/server/wal/interceptors/shard/mock_utils"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/resource"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/policy"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/stats"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/utils"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/impls/rmq"
@@ -74,18 +77,7 @@ func TestSegmentAllocManager(t *testing.T) {
 		TimeTick: 120,
 		ModifiedMetrics: stats.ModifiedMetrics{
 			Rows:       100,
-			BinarySize: 120,
-		},
-	})
-	assert.Error(t, err)
-	assert.ErrorIs(t, err, ErrTooLargeInsert)
-	assert.Nil(t, result)
-
-	result, err = m.AllocRows(&AssignSegmentRequest{
-		TimeTick: 120,
-		ModifiedMetrics: stats.ModifiedMetrics{
-			Rows:       100,
-			BinarySize: 50,
+			BinarySize: 30,
 		},
 	})
 	assert.NoError(t, err)
@@ -99,17 +91,6 @@ func TestSegmentAllocManager(t *testing.T) {
 		TimeTick: 120,
 		ModifiedMetrics: stats.ModifiedMetrics{
 			Rows:       100,
-			BinarySize: 70,
-		},
-	})
-	assert.Error(t, err)
-	assert.ErrorIs(t, err, ErrNotEnoughSpace)
-	assert.Nil(t, result)
-
-	result, err = m.AllocRows(&AssignSegmentRequest{
-		TimeTick: 120,
-		ModifiedMetrics: stats.ModifiedMetrics{
-			Rows:       100,
 			BinarySize: 50,
 		},
 		TxnSession: &mockedSession{},
@@ -118,6 +99,33 @@ func TestSegmentAllocManager(t *testing.T) {
 	assert.NotNil(t, result)
 	assert.Equal(t, m.TxnSem(), int32(1))
 	assert.Equal(t, m.AckSem(), int32(2))
+
+	result, err = m.AllocRows(&AssignSegmentRequest{
+		TimeTick: 120,
+		ModifiedMetrics: stats.ModifiedMetrics{
+			Rows:       100,
+			BinarySize: 30,
+		},
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, m.TxnSem(), int32(1))
+	assert.Equal(t, m.AckSem(), int32(3))
+	stat := resource.Resource().SegmentStatsManager().GetStatsOfSegment(3)
+	assert.Equal(t, stats.ModifiedMetrics{Rows: 300, BinarySize: 110}, stat.Modified)
+	assert.True(t, stat.ShouldBeSealed())
+
+	result, err = m.AllocRows(&AssignSegmentRequest{
+		TimeTick: 120,
+		ModifiedMetrics: stats.ModifiedMetrics{
+			Rows:       1,
+			BinarySize: 1,
+		},
+	})
+	assert.ErrorIs(t, err, ErrNotEnoughSpace)
+	assert.Nil(t, result)
+	assert.Equal(t, m.TxnSem(), int32(1))
+	assert.Equal(t, m.AckSem(), int32(3))
 
 	assert.Panics(t, func() {
 		m.GetFlushedStat()
@@ -140,6 +148,57 @@ func TestSegmentAllocManager(t *testing.T) {
 	})
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrNotGrowing)
+}
+
+func TestSegmentAllocManagerAcceptsOversizedFirstAllocation(t *testing.T) {
+	paramtable.Init()
+	resource.InitForTest(t)
+	channel := types.PChannelInfo{
+		Name: "test_channel_oversized",
+		Term: 1,
+	}
+
+	sealObserved := make(chan int32, 1)
+	var m *segmentAllocManager
+	o := mock_utils.NewMockSealOperator(t)
+	o.EXPECT().Channel().Return(channel)
+	o.EXPECT().AsyncFlushSegment(mock.Anything).Run(func(utils.SealSegmentSignal) {
+		sealObserved <- m.AckSem()
+	}).Return().Once()
+	resource.Resource().SegmentStatsManager().RegisterSealOperator(o, nil, nil)
+
+	m = newTestSegmentAllocManager(channel, &message.CreateSegmentMessageHeader{
+		CollectionId:   1,
+		PartitionId:    2,
+		SegmentId:      3,
+		MaxSegmentSize: 100,
+		StorageVersion: 2,
+	}, 110)
+
+	result, err := m.AllocRows(&AssignSegmentRequest{
+		TimeTick: 120,
+		ModifiedMetrics: stats.ModifiedMetrics{
+			Rows:       100,
+			BinarySize: 120,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, int64(3), result.SegmentID)
+	assert.Equal(t, int32(1), m.AckSem())
+	stat := resource.Resource().SegmentStatsManager().GetStatsOfSegment(3)
+	assert.Equal(t, stats.ModifiedMetrics{Rows: 100, BinarySize: 120}, stat.Modified)
+	assert.True(t, stat.ShouldBeSealed())
+
+	select {
+	case ackSem := <-sealObserved:
+		assert.Equal(t, int32(1), ackSem, "capacity seal must wait for the oversized insert acknowledgement")
+	case <-time.After(10 * time.Second):
+		t.Fatal("capacity seal was not triggered")
+	}
+
+	result.Ack()
+	assert.Zero(t, m.AckSem())
 }
 
 type mockedSession struct{}

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/segment_workers_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/segment_workers_test.go
@@ -59,7 +59,7 @@ func TestSegmentFlushWorker_RetryAfterAppendFailure(t *testing.T) {
 	defer cancel()
 
 	mockWAL := mock_wal.NewMockWAL(t)
-	mockWAL.EXPECT().Available().RunAndReturn(func() <-chan struct{} {
+	mockWAL.EXPECT().Unavailable().RunAndReturn(func() <-chan struct{} {
 		return make(chan struct{})
 	}).Maybe()
 
@@ -127,7 +127,7 @@ func TestSegmentAllocWorker_RetryAfterAppendFailure(t *testing.T) {
 	defer cancel()
 
 	mockWAL := mock_wal.NewMockWAL(t)
-	mockWAL.EXPECT().Available().RunAndReturn(func() <-chan struct{} {
+	mockWAL.EXPECT().Unavailable().RunAndReturn(func() <-chan struct{} {
 		return make(chan struct{})
 	}).Maybe()
 
@@ -231,7 +231,7 @@ func TestSegmentFlushWorker_DoOnceCheckIfReady(t *testing.T) {
 	ctx := context.Background()
 
 	mockWAL := mock_wal.NewMockWAL(t)
-	mockWAL.EXPECT().Available().RunAndReturn(func() <-chan struct{} {
+	mockWAL.EXPECT().Unavailable().RunAndReturn(func() <-chan struct{} {
 		return make(chan struct{})
 	}).Maybe()
 
@@ -338,7 +338,7 @@ func TestSegmentFlushWorker_WaitForTxnManagerRecoverDone(t *testing.T) {
 	t.Run("txn manager ready", func(t *testing.T) {
 		ctx := context.Background()
 		mockWAL := mock_wal.NewMockWAL(t)
-		mockWAL.EXPECT().Available().RunAndReturn(func() <-chan struct{} {
+		mockWAL.EXPECT().Unavailable().RunAndReturn(func() <-chan struct{} {
 			return make(chan struct{})
 		}).Maybe()
 
@@ -358,7 +358,7 @@ func TestSegmentFlushWorker_WaitForTxnManagerRecoverDone(t *testing.T) {
 		cancel() // Cancel immediately
 
 		mockWAL := mock_wal.NewMockWAL(t)
-		mockWAL.EXPECT().Available().RunAndReturn(func() <-chan struct{} {
+		mockWAL.EXPECT().Unavailable().RunAndReturn(func() <-chan struct{} {
 			return make(chan struct{})
 		}).Maybe()
 
@@ -384,7 +384,7 @@ func TestSegmentFlushWorker_WaitForTxnManagerRecoverDone(t *testing.T) {
 		unavailableCh := make(chan struct{})
 		close(unavailableCh)
 		mockWAL := mock_wal.NewMockWAL(t)
-		mockWAL.EXPECT().Available().RunAndReturn(func() <-chan struct{} {
+		mockWAL.EXPECT().Unavailable().RunAndReturn(func() <-chan struct{} {
 			return unavailableCh
 		}).Maybe()
 
@@ -414,7 +414,7 @@ func TestSegmentAllocWorker_DoLoop(t *testing.T) {
 		defer cancel()
 
 		mockWAL := mock_wal.NewMockWAL(t)
-		mockWAL.EXPECT().Available().RunAndReturn(func() <-chan struct{} {
+		mockWAL.EXPECT().Unavailable().RunAndReturn(func() <-chan struct{} {
 			return make(chan struct{})
 		}).Maybe()
 		mockWAL.EXPECT().Append(mock.Anything, mock.Anything).RunAndReturn(
@@ -453,7 +453,7 @@ func TestSegmentAllocWorker_DoLoop(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 
 		mockWAL := mock_wal.NewMockWAL(t)
-		mockWAL.EXPECT().Available().RunAndReturn(func() <-chan struct{} {
+		mockWAL.EXPECT().Unavailable().RunAndReturn(func() <-chan struct{} {
 			return make(chan struct{})
 		}).Maybe()
 		mockWAL.EXPECT().Append(mock.Anything, mock.Anything).RunAndReturn(
@@ -515,7 +515,7 @@ func TestSegmentFlushWorker_DoLoop(t *testing.T) {
 		defer cancel()
 
 		mockWAL := mock_wal.NewMockWAL(t)
-		mockWAL.EXPECT().Available().RunAndReturn(func() <-chan struct{} {
+		mockWAL.EXPECT().Unavailable().RunAndReturn(func() <-chan struct{} {
 			return make(chan struct{})
 		}).Maybe()
 		mockWAL.EXPECT().Append(mock.Anything, mock.Anything).RunAndReturn(
@@ -750,7 +750,7 @@ func TestSegmentAllocWorker_UnrecoverableError(t *testing.T) {
 	defer cancel()
 
 	mockWAL := mock_wal.NewMockWAL(t)
-	mockWAL.EXPECT().Available().RunAndReturn(func() <-chan struct{} {
+	mockWAL.EXPECT().Unavailable().RunAndReturn(func() <-chan struct{} {
 		return make(chan struct{})
 	}).Maybe()
 	mockWAL.EXPECT().Append(mock.Anything, mock.Anything).RunAndReturn(
@@ -808,7 +808,7 @@ func TestSegmentFlushWorker_UnrecoverableError(t *testing.T) {
 	defer cancel()
 
 	mockWAL := mock_wal.NewMockWAL(t)
-	mockWAL.EXPECT().Available().RunAndReturn(func() <-chan struct{} {
+	mockWAL.EXPECT().Unavailable().RunAndReturn(func() <-chan struct{} {
 		return make(chan struct{})
 	}).Maybe()
 	mockWAL.EXPECT().Append(mock.Anything, mock.Anything).RunAndReturn(
@@ -850,7 +850,7 @@ func TestSegmentAllocWorker_WALUnavailable(t *testing.T) {
 
 	unavailableCh := make(chan struct{})
 	mockWAL := mock_wal.NewMockWAL(t)
-	mockWAL.EXPECT().Available().RunAndReturn(func() <-chan struct{} {
+	mockWAL.EXPECT().Unavailable().RunAndReturn(func() <-chan struct{} {
 		return unavailableCh
 	}).Maybe()
 	mockWAL.EXPECT().Append(mock.Anything, mock.Anything).RunAndReturn(
@@ -909,7 +909,7 @@ func TestSegmentFlushWorker_ContextCanceledDuringRetry(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	mockWAL := mock_wal.NewMockWAL(t)
-	mockWAL.EXPECT().Available().RunAndReturn(func() <-chan struct{} {
+	mockWAL.EXPECT().Unavailable().RunAndReturn(func() <-chan struct{} {
 		return make(chan struct{})
 	}).Maybe()
 	mockWAL.EXPECT().Append(mock.Anything, mock.Anything).RunAndReturn(
@@ -970,7 +970,7 @@ func TestSegmentFlushWorker_TxnManagerRecoverFailed(t *testing.T) {
 
 	unavailableCh := make(chan struct{})
 	mockWAL := mock_wal.NewMockWAL(t)
-	mockWAL.EXPECT().Available().RunAndReturn(func() <-chan struct{} {
+	mockWAL.EXPECT().Unavailable().RunAndReturn(func() <-chan struct{} {
 		return unavailableCh
 	}).Maybe()
 
@@ -1025,7 +1025,7 @@ func TestSegmentFlushWorker_WALUnavailableDuringRetry(t *testing.T) {
 
 	unavailableCh := make(chan struct{})
 	mockWAL := mock_wal.NewMockWAL(t)
-	mockWAL.EXPECT().Available().RunAndReturn(func() <-chan struct{} {
+	mockWAL.EXPECT().Unavailable().RunAndReturn(func() <-chan struct{} {
 		return unavailableCh
 	}).Maybe()
 	mockWAL.EXPECT().Append(mock.Anything, mock.Anything).RunAndReturn(

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager.go
@@ -46,7 +46,6 @@ var (
 	ErrWaitForNewSegment = errors.New("wait for new segment")
 	ErrNotGrowing        = errors.New("segment is not growing")
 	ErrNotEnoughSpace    = stats.ErrNotEnoughSpace
-	ErrTooLargeInsert    = stats.ErrTooLargeInsert
 )
 
 // ShardManagerRecoverParam is the parameter for recovering the segment assignment manager.

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager_test.go
@@ -41,7 +41,7 @@ func TestShardManager(t *testing.T) {
 		Term: 1,
 	}
 	w := mock_wal.NewMockWAL(t)
-	w.EXPECT().Available().RunAndReturn(func() <-chan struct{} {
+	w.EXPECT().Unavailable().RunAndReturn(func() <-chan struct{} {
 		return make(chan struct{})
 	}).Maybe()
 	w.EXPECT().Append(mock.Anything, mock.Anything).Return(&types.AppendResult{
@@ -311,7 +311,7 @@ func TestShardManagerAssignSegmentTextUsesV3CreateSegmentWhenStorageV3Enabled(t 
 	}
 	appendCh := make(chan *message.CreateSegmentMessageHeader, 1)
 	w := mock_wal.NewMockWAL(t)
-	w.EXPECT().Available().RunAndReturn(func() <-chan struct{} {
+	w.EXPECT().Unavailable().RunAndReturn(func() <-chan struct{} {
 		return make(chan struct{})
 	}).Maybe()
 	w.EXPECT().Append(mock.Anything, mock.Anything).RunAndReturn(
@@ -389,7 +389,7 @@ func TestShardManagerSchemaVersionCheck(t *testing.T) {
 		Term: 1,
 	}
 	w := mock_wal.NewMockWAL(t)
-	w.EXPECT().Available().RunAndReturn(func() <-chan struct{} {
+	w.EXPECT().Unavailable().RunAndReturn(func() <-chan struct{} {
 		return make(chan struct{})
 	}).Maybe()
 	w.EXPECT().Append(mock.Anything, mock.Anything).Return(&types.AppendResult{
@@ -747,7 +747,7 @@ func newShardManagerWithGrowingSegment(t *testing.T, collID, partID, segID int64
 	t.Helper()
 	channel := types.PChannelInfo{Name: "test_alter_channel", Term: 1}
 	w := mock_wal.NewMockWAL(t)
-	w.EXPECT().Available().RunAndReturn(func() <-chan struct{} {
+	w.EXPECT().Unavailable().RunAndReturn(func() <-chan struct{} {
 		return make(chan struct{})
 	}).Maybe()
 	w.EXPECT().Append(mock.Anything, mock.Anything).Return(&types.AppendResult{

--- a/internal/streamingnode/server/wal/interceptors/shard/stats/stats_manager.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/stats/stats_manager.go
@@ -24,10 +24,7 @@ type (
 	SealOperator         = utils.SealOperator
 )
 
-var (
-	ErrNotEnoughSpace = errors.New("not enough space")
-	ErrTooLargeInsert = errors.New("insert too large")
-)
+var ErrNotEnoughSpace = errors.New("not enough space")
 
 // StatsManager is the manager of stats.
 // It manages the insert stats of all segments, used to check if a segment has enough space to insert or should be sealed.
@@ -98,6 +95,10 @@ func NewStatsManager() *StatsManager {
 // It will perform an atomic operation to register the seal operator and segments into the manager.
 func (m *StatsManager) RegisterSealOperator(sealOperator SealOperator, belongs []SegmentBelongs, stats []*SegmentStats) {
 	m.registerSealOperator(sealOperator, belongs, stats)
+	// ReachLimit is runtime-only. Seal recovered segments that have already
+	// crossed their persisted soft assignment target without waiting for
+	// another allocation or a periodic policy check.
+	m.worker.notifyToSealSegmentWithCapacityPolicy()
 	m.notifyIfTotalGrowingBytesOverHWM()
 }
 
@@ -202,7 +203,9 @@ func (m *StatsManager) registerNewGrowingSegment(belongs SegmentBelongs, stats *
 }
 
 // AllocRows alloc number of rows on current segment.
-// AllocRows will check if the segment has enough space to insert.
+// AllocRows treats the segment limits as soft sealing targets: every segment
+// may accept one allocation that crosses a target and is sealed afterwards;
+// later allocations are rejected so the caller can move to another segment.
 // Must be called after RegisterGrowingSegment and before UnregisterGrowingSegment.
 func (m *StatsManager) AllocRows(segmentID int64, insert ModifiedMetrics, runtimeFlushSize ...uint64) error {
 	if insert.Rows == 0 || insert.BinarySize == 0 {
@@ -260,9 +263,6 @@ func (m *StatsManager) allocRows(segmentID int64, insert ModifiedMetrics, runtim
 
 		m.metricHelper.ObservePChannelBytesUpdate(info.PChannel, m.pchannelStats[info.PChannel])
 		return stat.ShouldBeSealed(), nil
-	}
-	if stat.IsEmpty() {
-		return false, ErrTooLargeInsert
 	}
 	return stat.ShouldBeSealed(), ErrNotEnoughSpace
 }
@@ -461,6 +461,23 @@ func (m *StatsManager) selectSegmentsWithTimePolicy() map[int64]policy.SealPolic
 		}
 	}
 	return sealSegmentIDs
+}
+
+// selectSegmentsWithCapacityPolicy selects growing segments that have crossed
+// their soft assignment target. The comparison is recoverable from persisted
+// stats, so this is also the fallback when the best-effort capacity notifier is
+// dropped.
+func (m *StatsManager) selectSegmentsWithCapacityPolicy() []int64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	segmentIDs := make([]int64, 0)
+	for segmentID, stat := range m.segmentStats {
+		if stat.ShouldBeSealed() {
+			segmentIDs = append(segmentIDs, segmentID)
+		}
+	}
+	return segmentIDs
 }
 
 // selectSegmentsWithBlockingL0Policy selects the earliest L1 growing segment per vchannel

--- a/internal/streamingnode/server/wal/interceptors/shard/stats/stats_manager_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/stats/stats_manager_test.go
@@ -2,6 +2,7 @@ package stats
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 	"sync"
 	"testing"
@@ -90,30 +91,41 @@ func TestStatsManager(t *testing.T) {
 	assert.Equal(t, uint64(150), stat.Modified.BinarySize)
 
 	err = m.AllocRows(5, ModifiedMetrics{Rows: 250, BinarySize: 250})
-	assert.ErrorIs(t, err, ErrNotEnoughSpace)
+	assert.NoError(t, err)
 
 	err = m.AllocRows(6, ModifiedMetrics{Rows: 150, BinarySize: 150})
 	assert.NoError(t, err)
 
 	assert.Equal(t, uint64(250), m.vchannelStats["vchannel3"].Insert.BinarySize)
-	assert.Equal(t, uint64(100), m.vchannelStats["vchannel2"].Insert.BinarySize)
+	assert.Equal(t, uint64(350), m.vchannelStats["vchannel2"].Insert.BinarySize)
 	assert.Equal(t, uint64(250), m.vchannelStats["vchannel"].Insert.BinarySize)
 
-	assert.Equal(t, uint64(350), m.pchannelStats["pchannel"].Insert.BinarySize)
+	assert.Equal(t, uint64(600), m.pchannelStats["pchannel"].Insert.BinarySize)
 	assert.Equal(t, uint64(250), m.pchannelStats["pchannel2"].Insert.BinarySize)
 
 	m.UpdateOnSync(3, SyncOperationMetrics{BinLogCounterIncr: 100})
 	m.UpdateOnSync(1000, SyncOperationMetrics{BinLogCounterIncr: 100})
 
 	err = m.AllocRows(3, ModifiedMetrics{Rows: 400, BinarySize: 400})
+	assert.NoError(t, err)
+	stat = m.GetStatsOfSegment(3)
+	assert.Equal(t, ModifiedMetrics{Rows: 550, BinarySize: 550}, stat.Modified)
+	assert.True(t, stat.ShouldBeSealed())
+	err = m.AllocRows(3, ModifiedMetrics{Rows: 1, BinarySize: 1})
 	assert.ErrorIs(t, err, ErrNotEnoughSpace)
 	err = m.AllocRows(5, ModifiedMetrics{Rows: 250, BinarySize: 250})
 	assert.ErrorIs(t, err, ErrNotEnoughSpace)
 	err = m.AllocRows(6, ModifiedMetrics{Rows: 400, BinarySize: 400})
-	assert.ErrorIs(t, err, ErrNotEnoughSpace)
+	assert.NoError(t, err)
+	stat = m.GetStatsOfSegment(6)
+	assert.Equal(t, ModifiedMetrics{Rows: 650, BinarySize: 650}, stat.Modified)
+	assert.True(t, stat.ShouldBeSealed())
 
 	err = m.AllocRows(7, ModifiedMetrics{Rows: 400, BinarySize: 400})
-	assert.ErrorIs(t, err, ErrTooLargeInsert)
+	assert.NoError(t, err)
+	stat = m.GetStatsOfSegment(7)
+	assert.Equal(t, ModifiedMetrics{Rows: 400, BinarySize: 400}, stat.Modified)
+	assert.True(t, stat.ShouldBeSealed())
 
 	assert.Panics(t, func() {
 		// alloc rows on a sealed segment should panic
@@ -147,6 +159,90 @@ func TestStatsManager(t *testing.T) {
 	assert.Empty(t, m.pchannelStats)
 	assert.Empty(t, m.segmentIndex)
 	assert.Empty(t, m.sealOperators)
+}
+
+func TestRegisterSealOperatorImmediatelySealsRecoveredOverTargetSegment(t *testing.T) {
+	paramtable.Init()
+	m := NewStatsManager()
+
+	sealed := make(chan utils.SealSegmentSignal, 1)
+	sealOperator := mock_utils.NewMockSealOperator(t)
+	sealOperator.EXPECT().Channel().Return(types.PChannelInfo{Name: "pchannel"})
+	sealOperator.EXPECT().AsyncFlushSegment(mock.MatchedBy(func(signal utils.SealSegmentSignal) bool {
+		return signal.SegmentBelongs.SegmentID == 10 && signal.SealPolicy.Policy == policy.PolicyNameCapacity
+	})).Run(func(signal utils.SealSegmentSignal) {
+		select {
+		case sealed <- signal:
+		default:
+		}
+	}).Maybe()
+
+	recovered := createSegmentStats(101, 401, 400)
+	recovered.MaxRows = 100
+	assert.False(t, recovered.ReachLimit)
+	m.RegisterSealOperator(sealOperator, []SegmentBelongs{{
+		PChannel:     "pchannel",
+		VChannel:     "vchannel",
+		CollectionID: 1,
+		PartitionID:  2,
+		SegmentID:    10,
+	}}, []*SegmentStats{recovered})
+
+	select {
+	case signal := <-sealed:
+		assert.Equal(t, int64(10), signal.SegmentBelongs.SegmentID)
+	case <-time.After(time.Second):
+		t.Fatal("recovered over-target segment was not sealed during registration")
+	}
+	m.UnregisterSealOperator(sealOperator)
+}
+
+func TestCapacityScanRecoversDroppedSealNotification(t *testing.T) {
+	stat := createSegmentStats(110, 410, 400)
+	belongs := SegmentBelongs{
+		PChannel:     "pchannel",
+		VChannel:     "vchannel",
+		CollectionID: 1,
+		PartitionID:  2,
+		SegmentID:    11,
+	}
+	m := &StatsManager{
+		segmentStats:  map[int64]*SegmentStats{11: stat},
+		segmentIndex:  map[int64]SegmentBelongs{11: belongs},
+		sealOperators: make(map[string]SealOperator),
+	}
+	worker := &sealWorker{
+		statsManager: m,
+		sealNotifier: make(chan sealSegmentIDWithPolicy, 1),
+	}
+	m.worker = worker
+
+	sealed := make(chan utils.SealSegmentSignal, 1)
+	sealOperator := mock_utils.NewMockSealOperator(t)
+	sealOperator.EXPECT().AsyncFlushSegment(mock.MatchedBy(func(signal utils.SealSegmentSignal) bool {
+		return signal.SegmentBelongs.SegmentID == 11 && signal.SealPolicy.Policy == policy.PolicyNameCapacity
+	})).Run(func(signal utils.SealSegmentSignal) {
+		sealed <- signal
+	}).Once()
+	m.sealOperators[belongs.PChannel] = sealOperator
+
+	// Saturate the best-effort notifier so the capacity hint is dropped.
+	worker.sealNotifier <- sealSegmentIDWithPolicy{segmentID: 999, sealPolicy: policy.PolicyCapacity()}
+	worker.NotifySealSegment(11, policy.PolicyCapacity())
+	select {
+	case signal := <-sealed:
+		t.Fatalf("capacity seal unexpectedly bypassed the saturated notifier for segment %d", signal.SegmentBelongs.SegmentID)
+	default:
+	}
+
+	// This is the same scan invoked by the worker timer.
+	worker.notifyToSealSegmentWithCapacityPolicy()
+	select {
+	case signal := <-sealed:
+		assert.Equal(t, int64(11), signal.SegmentBelongs.SegmentID)
+	case <-time.After(time.Second):
+		t.Fatal("periodic capacity scan did not recover the dropped notification")
+	}
 }
 
 func TestStatsManagerRuntimeFlushSizeForMemoryPressure(t *testing.T) {
@@ -621,6 +717,7 @@ func createSegmentStats(row uint64, binarySize uint64, maxBinarSize uint64) *Seg
 			Rows:       row,
 			BinarySize: binarySize,
 		},
+		MaxRows:          math.MaxUint64,
 		MaxBinarySize:    maxBinarSize,
 		CreateTime:       time.Now(),
 		LastModifiedTime: time.Now(),

--- a/internal/streamingnode/server/wal/interceptors/shard/stats/stats_seal_worker.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/stats/stats_seal_worker.go
@@ -38,9 +38,9 @@ type sealWorker struct {
 
 // NotifySealSegment is used to notify the seal worker to seal the segment.
 func (m *sealWorker) NotifySealSegment(segmentID int64, sealPolicy policy.SealPolicy) {
-	// Keep notification bounded and non-blocking. Capacity and binlog policies
-	// are retriggered by later allocation or sync events, with time policies as
-	// a backstop for inactive segments.
+	// Keep notification bounded and non-blocking. Capacity is also scanned
+	// periodically, so dropping this low-latency hint cannot strand a segment
+	// above its soft assignment target.
 	select {
 	case m.sealNotifier <- sealSegmentIDWithPolicy{segmentID: segmentID, sealPolicy: sealPolicy}:
 	default:
@@ -83,6 +83,7 @@ func (m *sealWorker) loop() {
 			m.asyncMustSealSegment(targetSegment.segmentID, targetSegment.sealPolicy)
 		case <-timer.C:
 			m.statsManager.updateConfig()
+			m.notifyToSealSegmentWithCapacityPolicy()
 			m.notifyToSealSegmentWithTimePolicy()
 			m.notifyToSealSegmentWithBlockingL0Policy()
 		case policy := <-memoryNotifier:
@@ -91,6 +92,19 @@ func (m *sealWorker) loop() {
 		case totalBytes := <-m.growingBytesNotifier.Chan():
 			m.statsManager.updateConfig()
 			m.notifyToSealSegmentUntilLessThanLWM(policy.PolicyGrowingSegmentBytesHWM(totalBytes))
+		}
+	}
+}
+
+// notifyToSealSegmentWithCapacityPolicy notifies to seal segments that have
+// crossed their soft assignment target. It is called immediately after
+// recovery registration and periodically as a fallback for dropped hints.
+func (m *sealWorker) notifyToSealSegmentWithCapacityPolicy() {
+	segmentIDs := m.statsManager.selectSegmentsWithCapacityPolicy()
+	if len(segmentIDs) != 0 {
+		m.Logger().Info(context.TODO(), "notify to seal segments with capacity policy", mlog.Int("segmentNum", len(segmentIDs)))
+		for _, segmentID := range segmentIDs {
+			m.asyncMustSealSegment(segmentID, policy.PolicyCapacity())
 		}
 	}
 }

--- a/internal/streamingnode/server/wal/interceptors/shard/utils/stats.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/utils/stats.go
@@ -42,14 +42,14 @@ func (s *SegmentBelongs) PartitionUniqueKey() PartitionUniqueKey {
 type SegmentStats struct {
 	Modified              ModifiedMetrics
 	RuntimeFlushSize      uint64    // runtime-only size used by StreamingNode flush HWM/LWM decisions; not persisted into recovery meta.
-	MaxRows               uint64    // MaxRows of current segment should be assigned, it's a fixed value when segment is transfer int growing.
-	MaxBinarySize         uint64    // MaxBinarySize of current segment should be assigned, it's a fixed value when segment is transfer int growing.
+	MaxRows               uint64    // MaxRows is the soft assignment target of the segment and is fixed when the segment becomes growing.
+	MaxBinarySize         uint64    // MaxBinarySize is the soft assignment target of the segment and is fixed when the segment becomes growing.
 	CreateTime            time.Time // created timestamp of this segment, it's a fixed value when segment is created, not a tso.
 	LastModifiedTime      time.Time // LastWriteTime is the last write time of this segment, it's not a tso, just a local time.
 	CreateSegmentTimeTick uint64
 	BinLogCounter         uint64 // BinLogCounter is the counter of binlog (equal to the binlog file count of primary key), it's an async stat not real time.
 	BinLogFileCounter     uint64 // BinLogFileCounter is the counter of binlog files, it's an async stat not real time.
-	ReachLimit            bool   // ReachLimit is a flag to indicate the segment reach the limit once.
+	ReachLimit            bool   // ReachLimit means this segment has accepted its one allocation that crossed the soft assignment target.
 	Level                 datapb.SegmentLevel
 }
 
@@ -105,17 +105,27 @@ func NewProtoFromSegmentStat(stat *SegmentStats) *streamingpb.SegmentAssignmentS
 // AllocRows alloc space of rows on current segment.
 // Return true if the segment is assigned.
 func (s *SegmentStats) AllocRows(m ModifiedMetrics) bool {
-	if m.BinarySize > s.BinaryCanBeAssign() || m.Rows > s.RowsCanBeAssign() {
-		if s.Modified.BinarySize > 0 {
-			// if the binary size is not empty, it means the segment cannot hold more data, mark it as reach limit.
-			s.ReachLimit = true
-		}
+	// Every segment may accept exactly one allocation that crosses its soft
+	// assignment target. Once that crossing allocation has been accepted, all
+	// later allocations must move to another segment.
+	if s.ReachLimit || s.isOverAssignmentTarget() {
+		s.ReachLimit = true
 		return false
+	}
+
+	if m.BinarySize > s.BinaryCanBeAssign() || m.Rows > s.RowsCanBeAssign() {
+		// The target is a sealing threshold, not a hard admission limit. Accept
+		// the indivisible allocation that crosses it and seal afterwards.
+		s.ReachLimit = true
 	}
 
 	s.Modified.Collect(m)
 	s.LastModifiedTime = time.Now()
 	return true
+}
+
+func (s *SegmentStats) isOverAssignmentTarget() bool {
+	return s.Modified.BinarySize > s.MaxBinarySize || s.Modified.Rows > s.MaxRows
 }
 
 // AllocRuntimeFlushSize records runtime-only size growth for flush HWM/LWM decisions.
@@ -137,17 +147,20 @@ func (s *SegmentStats) FlushSize() uint64 {
 
 // BinaryCanBeAssign returns the capacity of binary size can be inserted.
 func (s *SegmentStats) BinaryCanBeAssign() uint64 {
-	return s.MaxBinarySize - s.Modified.BinarySize
+	return SaturatingSubUint64(s.MaxBinarySize, s.Modified.BinarySize)
 }
 
 // RowsCanBeAssign returns the capacity of rows can be inserted.
 func (s *SegmentStats) RowsCanBeAssign() uint64 {
-	return s.MaxRows - s.Modified.Rows
+	return SaturatingSubUint64(s.MaxRows, s.Modified.Rows)
 }
 
 // ShouldBeSealed returns if the segment should be sealed.
 func (s *SegmentStats) ShouldBeSealed() bool {
-	return s.ReachLimit
+	// ReachLimit is runtime-only, so it is lost when SegmentStats is rebuilt
+	// from the persisted assignment stat. Recover the same sealing decision
+	// from the persisted modified metrics and assignment targets.
+	return s.ReachLimit || s.isOverAssignmentTarget()
 }
 
 // IsEmpty returns if the segment is empty.

--- a/internal/streamingnode/server/wal/interceptors/shard/utils/stats_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/utils/stats_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -77,6 +78,18 @@ func TestNewSegmentStatFromProtoPreservesCreateSegmentTimeTick(t *testing.T) {
 	assert.Equal(t, uint64(10086), roundTrip.GetCreateSegmentTimeTick())
 }
 
+func TestRecoveredOverTargetSegmentShouldBeSealed(t *testing.T) {
+	stat := NewSegmentStatFromProto(&streamingpb.SegmentAssignmentStat{
+		MaxRows:            100,
+		MaxBinarySize:      400,
+		ModifiedRows:       101,
+		ModifiedBinarySize: 401,
+	})
+
+	assert.False(t, stat.ReachLimit)
+	assert.True(t, stat.ShouldBeSealed())
+}
+
 func TestSegmentStats(t *testing.T) {
 	now := time.Now()
 	stat := &SegmentStats{
@@ -84,6 +97,7 @@ func TestSegmentStats(t *testing.T) {
 			Rows:       100,
 			BinarySize: 200,
 		},
+		MaxRows:           math.MaxUint64,
 		MaxBinarySize:     400,
 		CreateTime:        now,
 		LastModifiedTime:  now,
@@ -108,11 +122,16 @@ func TestSegmentStats(t *testing.T) {
 		BinarySize: 100,
 	}
 	inserted = stat.AllocRows(insert1)
-	assert.False(t, inserted)
-	assert.Equal(t, stat.Modified.Rows, uint64(160))
-	assert.Equal(t, stat.Modified.BinarySize, uint64(320))
+	assert.True(t, inserted)
+	assert.Equal(t, stat.Modified.Rows, uint64(260))
+	assert.Equal(t, stat.Modified.BinarySize, uint64(420))
 	assert.False(t, stat.IsEmpty())
 	assert.True(t, stat.ShouldBeSealed())
+
+	modifiedAfterCrossing := stat.Modified
+	inserted = stat.AllocRows(ModifiedMetrics{Rows: 1, BinarySize: 1})
+	assert.False(t, inserted)
+	assert.Equal(t, modifiedAfterCrossing, stat.Modified)
 
 	stat.UpdateOnSync(SyncOperationMetrics{
 		BinLogCounterIncr:     4,
@@ -135,19 +154,70 @@ func TestIsZero(t *testing.T) {
 	assert.False(t, nonZeroInsert.IsZero())
 }
 
-func TestOversizeAlloc(t *testing.T) {
+func TestOversizeFirstAllocIsAcceptedAndSealed(t *testing.T) {
 	now := time.Now()
 	stat := &SegmentStats{
 		Modified:         ModifiedMetrics{},
+		MaxRows:          100,
 		MaxBinarySize:    400,
 		CreateTime:       now,
 		LastModifiedTime: now,
 	}
-	// Try to alloc a oversized insert metrics.
+	// An oversized first logical batch is accepted because the segment limit is
+	// a sealing threshold, then the segment is sealed immediately.
 	inserted := stat.AllocRows(ModifiedMetrics{
+		Rows:       1,
 		BinarySize: 401,
 	})
+	assert.True(t, inserted)
+	assert.Equal(t, ModifiedMetrics{Rows: 1, BinarySize: 401}, stat.Modified)
+	assert.False(t, stat.IsEmpty())
+	assert.True(t, stat.ShouldBeSealed())
+	assert.Zero(t, stat.BinaryCanBeAssign())
+
+	modifiedAfterCrossing := stat.Modified
+	inserted = stat.AllocRows(ModifiedMetrics{Rows: 1, BinarySize: 1})
 	assert.False(t, inserted)
-	assert.True(t, stat.IsEmpty())
+	assert.Equal(t, modifiedAfterCrossing, stat.Modified)
+
+	rowLimitedStat := &SegmentStats{
+		MaxRows:       1,
+		MaxBinarySize: 400,
+	}
+	inserted = rowLimitedStat.AllocRows(ModifiedMetrics{
+		Rows:       2,
+		BinarySize: 1,
+	})
+	assert.True(t, inserted)
+	assert.True(t, rowLimitedStat.ShouldBeSealed())
+	assert.Zero(t, rowLimitedStat.RowsCanBeAssign())
+
+	modifiedAfterRowCrossing := rowLimitedStat.Modified
+	inserted = rowLimitedStat.AllocRows(ModifiedMetrics{Rows: 1, BinarySize: 1})
+	assert.False(t, inserted)
+	assert.Equal(t, modifiedAfterRowCrossing, rowLimitedStat.Modified)
+}
+
+func TestSegmentStatsExactLimitDoesNotSealBeforeFirstCrossingAllocation(t *testing.T) {
+	stat := &SegmentStats{
+		MaxRows:       2,
+		MaxBinarySize: 400,
+	}
+
+	inserted := stat.AllocRows(ModifiedMetrics{Rows: 2, BinarySize: 400})
+	assert.True(t, inserted)
+	assert.Equal(t, ModifiedMetrics{Rows: 2, BinarySize: 400}, stat.Modified)
 	assert.False(t, stat.ShouldBeSealed())
+	assert.Zero(t, stat.RowsCanBeAssign())
+	assert.Zero(t, stat.BinaryCanBeAssign())
+
+	inserted = stat.AllocRows(ModifiedMetrics{Rows: 1, BinarySize: 1})
+	assert.True(t, inserted)
+	assert.Equal(t, ModifiedMetrics{Rows: 3, BinarySize: 401}, stat.Modified)
+	assert.True(t, stat.ShouldBeSealed())
+
+	modifiedAfterCrossing := stat.Modified
+	inserted = stat.AllocRows(ModifiedMetrics{Rows: 1, BinarySize: 1})
+	assert.False(t, inserted)
+	assert.Equal(t, modifiedAfterCrossing, stat.Modified)
 }

--- a/internal/streamingnode/server/wal/wal.go
+++ b/internal/streamingnode/server/wal/wal.go
@@ -58,8 +58,8 @@ type ROWAL interface {
 	// Read returns a scanner for reading records from the wal.
 	Read(ctx context.Context, deliverPolicy ReadOption) (Scanner, error)
 
-	// Available return a channel that will be closed when the wal is available.
-	Available() <-chan struct{}
+	// Unavailable returns a channel that is closed when the WAL becomes unavailable.
+	Unavailable() <-chan struct{}
 
 	// IsAvailable returns if the wal is available.
 	IsAvailable() bool

--- a/pkg/mq/msgstream/mqwrapper/kafka/kafka_client.go
+++ b/pkg/mq/msgstream/mqwrapper/kafka/kafka_client.go
@@ -183,13 +183,15 @@ func (kc *kafkaClient) getKafkaProducer() (*kafka.Producer, error) {
 
 func (kc *kafkaClient) newProducerConfig() *kafka.ConfigMap {
 	newConf := cloneKafkaConfig(kc.basicConfig)
-	newConf.SetKey("message.max.bytes", paramtable.Get().KafkaCfg.ProducerMessageMaxBytes.GetAsInt())
 	newConf.SetKey("compression.codec", "zstd")
 	// we want to ensure tt send out as soon as possible
 	newConf.SetKey("linger.ms", 2)
 
 	// special producer config
 	kc.specialExtraConfig(newConf, kc.producerConfig)
+	// producerConfig contains the raw kafka.producer.message.max.bytes entry.
+	// Apply the normalized ParamItem last so it remains authoritative.
+	newConf.SetKey("message.max.bytes", paramtable.Get().KafkaCfg.ProducerMessageMaxBytes.GetAsInt())
 
 	return newConf
 }

--- a/pkg/mq/msgstream/mqwrapper/kafka/kafka_client_test.go
+++ b/pkg/mq/msgstream/mqwrapper/kafka/kafka_client_test.go
@@ -375,16 +375,17 @@ func createKafkaClient(t *testing.T) *kafkaClient {
 	return kc
 }
 
-func TestNewProducerConfigUsesConfiguredMessageMaxBytes(t *testing.T) {
-	config := &paramtable.Get().KafkaCfg
-	oldValue := config.ProducerMessageMaxBytes.SwapTempValue("4096")
-	defer config.ProducerMessageMaxBytes.SwapTempValue(oldValue)
+func TestNewProducerConfigClampsConfiguredMessageMaxBytes(t *testing.T) {
+	params := paramtable.Get()
+	config := &params.KafkaCfg
+	assert.NoError(t, params.Save(config.ProducerMessageMaxBytes.Key, "4096"))
+	t.Cleanup(func() { assert.NoError(t, params.Reset(config.ProducerMessageMaxBytes.Key)) })
 
 	kc := NewKafkaClientInstance(getKafkaBrokerList())
 	producerConfig := kc.newProducerConfig()
 	value, err := producerConfig.Get("message.max.bytes", nil)
 	assert.NoError(t, err)
-	assert.Equal(t, 4096, value)
+	assert.Equal(t, 256*1024, value)
 }
 
 func createConsumer(t *testing.T,

--- a/pkg/mq/msgstream/msgstream_util.go
+++ b/pkg/mq/msgstream/msgstream_util.go
@@ -116,6 +116,10 @@ func KafkaHealthCheck(clusterStatus *pcommon.MQClusterStatus) {
 	for k, v := range pConfig {
 		config.SetKey(k, v)
 	}
+	// ProducerExtraConfig includes the raw message.max.bytes value. Keep the
+	// normalized ParamItem authoritative here as well, so an undersized raw
+	// value cannot prevent the health-check producer from being created.
+	config.SetKey("message.max.bytes", paramtable.Get().KafkaCfg.ProducerMessageMaxBytes.GetAsInt())
 	producer, err := kafka.NewProducer(&config)
 	if err != nil {
 		clusterStatus.Reason = fmt.Sprintf("failed to create Kafka producer: %v", err)

--- a/pkg/streaming/util/message/builder.go
+++ b/pkg/streaming/util/message/builder.go
@@ -124,10 +124,21 @@ func newMutableMessageBuilder[H proto.Message, B proto.Message]() *mutableMesasg
 	}
 }
 
+// BodyEncoder encodes a body of type B directly into a caller-provided buffer.
+// EncodedSize must return the exact number of bytes MarshalTo writes. BodyType
+// is a compile-time type marker; builders consume the encoder synchronously and
+// retain only the encoded payload.
+type BodyEncoder[B proto.Message] interface {
+	EncodedSize() (int, error)
+	MarshalTo([]byte) (int, error)
+	BodyType() B
+}
+
 // mutableMesasgeBuilder is the builder for message.
 type mutableMesasgeBuilder[H proto.Message, B proto.Message] struct {
 	header       H
 	body         B
+	bodyEncoder  BodyEncoder[B]
 	properties   propertiesImpl
 	cipherConfig *CipherConfig
 	allVChannel  bool
@@ -158,6 +169,13 @@ func (b *mutableMesasgeBuilder[H, B]) WithUnreplicable() *mutableMesasgeBuilder[
 // WithBody creates a new builder with message body.
 func (b *mutableMesasgeBuilder[H, B]) WithBody(body B) *mutableMesasgeBuilder[H, B] {
 	b.body = body
+	return b
+}
+
+// WithBodyEncoder creates a new builder with a body encoder that writes the
+// encoded body directly into the message payload during Build.
+func (b *mutableMesasgeBuilder[H, B]) WithBodyEncoder(bodyEncoder BodyEncoder[B]) *mutableMesasgeBuilder[H, B] {
+	b.bodyEncoder = bodyEncoder
 	return b
 }
 
@@ -336,8 +354,13 @@ func (b *mutableMesasgeBuilder[H, B]) build() (*messageImpl, error) {
 	if reflect.ValueOf(b.header).IsNil() {
 		panic("message builder not ready for header field")
 	}
-	if reflect.ValueOf(b.body).IsNil() {
+	bodySet := !reflect.ValueOf(b.body).IsNil()
+	bodyEncoderSet := !isNilBodyEncoder(b.bodyEncoder)
+	if !bodySet && !bodyEncoderSet {
 		panic("message builder not ready for body field")
+	}
+	if bodySet && bodyEncoderSet {
+		panic("message builder must set exactly one of body or body encoder")
 	}
 
 	// setup header.
@@ -347,9 +370,17 @@ func (b *mutableMesasgeBuilder[H, B]) build() (*messageImpl, error) {
 	}
 	b.properties.Set(messageHeader, sp)
 
-	payload, err := proto.Marshal(b.body)
+	var payload []byte
+	if bodyEncoderSet {
+		payload, err = marshalBodyEncoder(b.bodyEncoder)
+	} else {
+		payload, err = proto.Marshal(b.body)
+		if err != nil {
+			err = errors.Wrap(err, "failed to marshal body")
+		}
+	}
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal body")
+		return nil, err
 	}
 	if b.cipherConfig != nil {
 		messageType := MustGetMessageTypeWithVersion[H, B]()
@@ -381,6 +412,40 @@ func (b *mutableMesasgeBuilder[H, B]) build() (*messageImpl, error) {
 		payload:    payload,
 		properties: b.properties,
 	}, nil
+}
+
+func isNilBodyEncoder[B proto.Message](bodyEncoder BodyEncoder[B]) bool {
+	if bodyEncoder == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(bodyEncoder)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func marshalBodyEncoder[B proto.Message](bodyEncoder BodyEncoder[B]) ([]byte, error) {
+	size, err := bodyEncoder.EncodedSize()
+	if err != nil {
+		return nil, merr.Wrap(err, "failed to get encoded body size")
+	}
+	if size < 0 {
+		return nil, merr.WrapErrServiceInternalMsg("body encoder returned negative encoded size %d", size)
+	}
+
+	payload := make([]byte, size)
+	written, err := bodyEncoder.MarshalTo(payload)
+	if err != nil {
+		return nil, merr.Wrap(err, "failed to marshal body")
+	}
+	if written != size {
+		return nil, merr.WrapErrServiceInternalMsg("body encoder wrote %d bytes, expected %d", written, size)
+	}
+	return payload, nil
 }
 
 // NewImmutableTxnMessageBuilder creates a new txn builder.

--- a/pkg/streaming/util/message/builder_test.go
+++ b/pkg/streaming/util/message/builder_test.go
@@ -7,12 +7,31 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/impls/walimplstest"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
+
+type testBodyEncoder struct {
+	encodedSize func() (int, error)
+	marshalTo   func([]byte) (int, error)
+}
+
+func (e *testBodyEncoder) EncodedSize() (int, error) {
+	return e.encodedSize()
+}
+
+func (e *testBodyEncoder) MarshalTo(dst []byte) (int, error) {
+	return e.marshalTo(dst)
+}
+
+func (e *testBodyEncoder) BodyType() *msgpb.InsertRequest {
+	return nil
+}
 
 func TestMutableBuilder(t *testing.T) {
 	b := message.NewTimeTickMessageBuilderV1().
@@ -36,6 +55,120 @@ func TestMutableBuilder(t *testing.T) {
 
 	assert.Panics(t, func() {
 		message.NewCreateCollectionMessageBuilderV1().WithNotPersisted()
+	})
+}
+
+func TestMutableBuilderWithBodyEncoder(t *testing.T) {
+	body := &msgpb.InsertRequest{
+		ShardName: "v1",
+		RowIDs:    []int64{1, 2, 3},
+	}
+	expectedPayload, err := proto.Marshal(body)
+	require.NoError(t, err)
+
+	encodedSizeCalls := 0
+	marshalToCalls := 0
+	encoder := &testBodyEncoder{
+		encodedSize: func() (int, error) {
+			encodedSizeCalls++
+			return len(expectedPayload), nil
+		},
+		marshalTo: func(dst []byte) (int, error) {
+			marshalToCalls++
+			assert.Len(t, dst, len(expectedPayload))
+			assert.Equal(t, len(expectedPayload), cap(dst))
+			return copy(dst, expectedPayload), nil
+		},
+	}
+
+	msg, err := message.NewInsertMessageBuilderV1().
+		WithHeader(&message.InsertMessageHeader{}).
+		WithBodyEncoder(encoder).
+		WithVChannel("v1").
+		BuildMutable()
+	require.NoError(t, err)
+	assert.Equal(t, expectedPayload, msg.Payload())
+	assert.Equal(t, len(expectedPayload), cap(msg.Payload()))
+	assert.Equal(t, 1, encodedSizeCalls)
+	assert.Equal(t, 1, marshalToCalls)
+
+	insertMsg, err := message.AsMutableInsertMessageV1(msg)
+	require.NoError(t, err)
+	actualBody, err := insertMsg.Body()
+	require.NoError(t, err)
+	assert.True(t, proto.Equal(body, actualBody))
+}
+
+func TestMutableBuilderBodyEncoderValidation(t *testing.T) {
+	build := func(encoder message.BodyEncoder[*msgpb.InsertRequest]) (message.MutableMessage, error) {
+		return message.NewInsertMessageBuilderV1().
+			WithHeader(&message.InsertMessageHeader{}).
+			WithBodyEncoder(encoder).
+			WithVChannel("v1").
+			BuildMutable()
+	}
+
+	t.Run("encoded size error", func(t *testing.T) {
+		expectedErr := merr.WrapErrServiceInternalMsg("encoded size failed")
+		_, err := build(&testBodyEncoder{
+			encodedSize: func() (int, error) { return 0, expectedErr },
+			marshalTo:   func([]byte) (int, error) { panic("unexpected MarshalTo call") },
+		})
+		require.ErrorIs(t, err, expectedErr)
+		assert.ErrorContains(t, err, "failed to get encoded body size")
+	})
+
+	t.Run("negative encoded size", func(t *testing.T) {
+		_, err := build(&testBodyEncoder{
+			encodedSize: func() (int, error) { return -1, nil },
+			marshalTo:   func([]byte) (int, error) { panic("unexpected MarshalTo call") },
+		})
+		require.ErrorIs(t, err, merr.ErrServiceInternal)
+		assert.ErrorContains(t, err, "negative encoded size")
+	})
+
+	t.Run("marshal error", func(t *testing.T) {
+		expectedErr := merr.WrapErrServiceInternalMsg("marshal failed")
+		_, err := build(&testBodyEncoder{
+			encodedSize: func() (int, error) { return 1, nil },
+			marshalTo:   func([]byte) (int, error) { return 0, expectedErr },
+		})
+		require.ErrorIs(t, err, expectedErr)
+		assert.ErrorContains(t, err, "failed to marshal body")
+	})
+
+	t.Run("written size mismatch", func(t *testing.T) {
+		_, err := build(&testBodyEncoder{
+			encodedSize: func() (int, error) { return 2, nil },
+			marshalTo:   func(dst []byte) (int, error) { return copy(dst, []byte{1}), nil },
+		})
+		require.ErrorIs(t, err, merr.ErrServiceInternal)
+		assert.ErrorContains(t, err, "wrote 1 bytes, expected 2")
+	})
+}
+
+func TestMutableBuilderBodyAndEncoderAreMutuallyExclusive(t *testing.T) {
+	encoder := &testBodyEncoder{
+		encodedSize: func() (int, error) { return 0, nil },
+		marshalTo:   func([]byte) (int, error) { return 0, nil },
+	}
+
+	assert.PanicsWithValue(t, "message builder must set exactly one of body or body encoder", func() {
+		message.NewInsertMessageBuilderV1().
+			WithHeader(&message.InsertMessageHeader{}).
+			WithBody(&msgpb.InsertRequest{}).
+			WithBodyEncoder(encoder).
+			WithVChannel("v1").
+			BuildMutable()
+	})
+
+	var nilEncoder *testBodyEncoder
+	assert.PanicsWithValue(t, "message builder not ready for body field", func() {
+		message.NewInsertMessageBuilderV1().
+			WithHeader(&message.InsertMessageHeader{}).
+			WithBodyEncoder(nilEncoder).
+			WithVChannel("v1").
+			BuildMutable()
 	})
 }
 

--- a/pkg/streaming/util/message/chunk.go
+++ b/pkg/streaming/util/message/chunk.go
@@ -1,0 +1,259 @@
+package message
+
+import (
+	"bytes"
+	"strconv"
+
+	"github.com/cockroachdb/errors"
+)
+
+// ErrCorruptedChunk indicates that a physical WAL record cannot belong to a
+// trustworthy chunk run.
+var ErrCorruptedChunk = errors.New("corrupted WAL payload chunk")
+
+// SplitIntoChunks splits a message whose serialized payload exceeds the WAL
+// backend's per-message limit into chunk messages, each carrying a slice of
+// the original (possibly ciphered) payload bytes plus the original properties
+// and a chunk index/total marker. Readers reassemble them via AssembleChunks.
+//
+// This lives at the storage layer: the payload is treated as an opaque byte
+// blob, so no protobuf is unmarshaled or re-marshaled -- the exact bytes the
+// backend would have stored are sliced in place. The returned chunks keep the
+// original message type and properties (a chunk is not itself a valid message
+// body), so readers must reassemble before parsing. Chunks of one message are
+// appended in index order, but concurrent writers may interleave their runs.
+//
+// If the payload already fits, the returned slice contains msg unchanged.
+func SplitIntoChunks(msg MutableMessage, chunkSize int) []MutableMessage {
+	pb := msg.IntoMessageProto()
+	payload := pb.Payload
+	if chunkSize <= 0 || len(payload) <= chunkSize {
+		return []MutableMessage{msg}
+	}
+
+	total := (len(payload) + chunkSize - 1) / chunkSize
+	chunks := make([]MutableMessage, 0, total)
+	for i := 0; i < total; i++ {
+		start := i * chunkSize
+		end := start + chunkSize
+		if end > len(payload) {
+			end = len(payload)
+		}
+		chunkProps := make(map[string]string, len(pb.Properties)+2)
+		for k, v := range pb.Properties {
+			chunkProps[k] = v
+		}
+		chunkProps[messageChunkIndex] = strconv.Itoa(i)
+		chunkProps[messageChunkTotal] = strconv.Itoa(total)
+		chunks = append(chunks, NewMutableMessageBeforeAppend(payload[start:end], chunkProps))
+	}
+	return chunks
+}
+
+// IsChunkedPayload reports whether the message carries either reserved chunk
+// marker. ChunkAssembler validates that both markers form a valid pair.
+func IsChunkedPayload(msg BasicMessage) bool {
+	return msg.Properties().Exist(messageChunkIndex) || msg.Properties().Exist(messageChunkTotal)
+}
+
+// ChunkIndex returns the 0-based chunk index of a chunked payload message.
+// It returns 0 for a non-chunked message.
+func ChunkIndex(msg BasicMessage) int {
+	v, ok := msg.Properties().Get(messageChunkIndex)
+	if !ok {
+		return 0
+	}
+	i, _ := strconv.Atoi(v)
+	return i
+}
+
+// ChunkTotal returns the total chunk count of a chunked payload message.
+// It returns 0 for a non-chunked message.
+func ChunkTotal(msg BasicMessage) int {
+	v, ok := msg.Properties().Get(messageChunkTotal)
+	if !ok {
+		return 0
+	}
+	i, _ := strconv.Atoi(v)
+	return i
+}
+
+// AssembleChunks reassembles an index-ordered set of payload chunks
+// (produced by SplitIntoChunks) back into a single immutable message carrying
+// the concatenated payload, the properties of the first chunk (with the chunk
+// markers removed), and the first chunk's message ID -- which is the logical
+// message ID returned to the append caller.
+func AssembleChunks(chunks []ImmutableMessage) ImmutableMessage {
+	first := chunks[0]
+
+	totalLen := 0
+	for _, c := range chunks {
+		totalLen += len(c.IntoImmutableMessageProto().GetPayload())
+	}
+	payload := make([]byte, 0, totalLen)
+	for _, c := range chunks {
+		payload = append(payload, c.IntoImmutableMessageProto().GetPayload()...)
+	}
+
+	props := first.IntoImmutableMessageProto().GetProperties()
+	assembledProps := make(map[string]string, len(props))
+	for k, v := range props {
+		assembledProps[k] = v
+	}
+	delete(assembledProps, messageChunkIndex)
+	delete(assembledProps, messageChunkTotal)
+
+	return NewImmutableMesasge(first.MessageID(), payload, assembledProps)
+}
+
+// ChunkAssembler reassembles chunked payloads split by SplitIntoChunks back
+// into complete messages. It is stateful and must be fed messages in WAL order
+// via Push. Its zero value is ready to use.
+//
+// Chunks of one original message are correlated by their time tick -- unique
+// per message on a pchannel and cloned onto every chunk -- so packs may
+// interleave with other traffic in the log: no write-side coordination is
+// required. Incomplete runs are not evicted based only on the number of
+// concurrent runs: a run may still belong to a live writer, and dropping it
+// would silently lose an acknowledged message when its remaining chunks arrive.
+// A TimeTick is a safe barrier, however, so runs at or before it are discarded.
+type ChunkAssembler struct {
+	runs map[uint64]*chunkRun // keyed by the original message's time tick.
+}
+
+type chunkRun struct {
+	total int
+	slots map[int]ImmutableMessage // indexed sparsely so a corrupt `_ct` cannot force a large allocation.
+}
+
+// Push feeds one message (a chunk or a complete message) to the assembler.
+// It returns:
+//   - (assembled, true, nil) once the final missing chunk of a pack arrived and
+//     the full message was reconstructed;
+//   - (nil, true, nil) while chunks are being buffered (the caller must swallow
+//     the message);
+//   - (nil, false, nil) when msg is not a chunk (the caller processes it normally);
+//   - a non-nil error when the chunk markers or an existing run are corrupted.
+//
+// A pack assembles from exactly `_ct` distinct indices under one time tick.
+// A backend may persist a record and still surface its send as an error, so
+// the producer's retry redelivers an identical record under a new message ID;
+// such payload-identical duplicates are swallowed. The same index redelivered
+// with different bytes, or a total mismatch inside one time tick, means the
+// log does not carry what this assembler can trust: the caller must stop the
+// scanner instead of advancing a checkpoint past it.
+func (a *ChunkAssembler) Push(msg ImmutableMessage) (ImmutableMessage, bool, error) {
+	idx, total, tt, chunked, err := parseChunkMetadata(msg)
+	if !chunked {
+		if msg.MessageType() == MessageTypeTimeTick {
+			a.discardRunsAtOrBefore(msg.TimeTick())
+		}
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, true, err
+	}
+	if a.runs == nil {
+		a.runs = make(map[uint64]*chunkRun)
+	}
+
+	run := a.runs[tt]
+	if run == nil {
+		if idx != 0 {
+			// A middle chunk whose head never arrived: nothing joinable.
+			return nil, true, nil
+		}
+		run = &chunkRun{total: total, slots: make(map[int]ImmutableMessage)}
+		a.runs[tt] = run
+	} else if run.total != total {
+		a.deleteRun(tt)
+		return nil, true, errors.Wrapf(ErrCorruptedChunk,
+			"time tick %d changed total from %d to %d", tt, run.total, total)
+	} else if previous, ok := run.slots[idx]; ok {
+		if !sameChunkBytes(previous, msg) {
+			a.deleteRun(tt)
+			return nil, true, errors.Wrapf(ErrCorruptedChunk,
+				"time tick %d index %d was rewritten with different payload bytes", tt, idx)
+		}
+		// Byte-identical: a persisted-but-unacked chunk rewritten by the
+		// producer's retry. Keep the later observation: chunks are appended
+		// sequentially within one run, so the last rewrite before the next
+		// chunk carries the message ID and properties of the successful append.
+		run.slots[idx] = msg
+		return nil, true, nil
+	}
+
+	run.slots[idx] = msg
+	if len(run.slots) < total {
+		return nil, true, nil
+	}
+	chunks := make([]ImmutableMessage, total)
+	for i := 0; i < total; i++ {
+		chunks[i] = run.slots[i]
+	}
+	assembled := AssembleChunks(chunks)
+	a.deleteRun(tt)
+	return assembled, true, nil
+}
+
+func parseChunkMetadata(msg BasicMessage) (idx int, total int, tt uint64, chunked bool, err error) {
+	idxValue, hasIndex := msg.Properties().Get(messageChunkIndex)
+	totalValue, hasTotal := msg.Properties().Get(messageChunkTotal)
+	if !hasIndex && !hasTotal {
+		return 0, 0, 0, false, nil
+	}
+	if !hasIndex || !hasTotal {
+		return 0, 0, 0, true, errors.Wrapf(ErrCorruptedChunk,
+			"chunk markers must appear together: index=%q total=%q", idxValue, totalValue)
+	}
+	idx, idxErr := parseCanonicalNonNegativeInt(idxValue)
+	total, totalErr := parseCanonicalNonNegativeInt(totalValue)
+	if idxErr != nil || totalErr != nil || total < 2 || idx < 0 || idx >= total {
+		return 0, 0, 0, true, errors.Wrapf(ErrCorruptedChunk,
+			"invalid chunk markers: index=%q total=%q", idxValue, totalValue)
+	}
+
+	ttValue, hasTimeTick := msg.Properties().Get(messageTimeTick)
+	parsedTimeTick, ttErr := DecodeUint64(ttValue)
+	if !hasTimeTick || ttErr != nil || EncodeUint64(parsedTimeTick) != ttValue {
+		return 0, 0, 0, true, errors.Wrapf(ErrCorruptedChunk,
+			"chunk time tick is missing or invalid: %q", ttValue)
+	}
+	return idx, total, parsedTimeTick, true, nil
+}
+
+func parseCanonicalNonNegativeInt(value string) (int, error) {
+	parsed, err := strconv.ParseUint(value, 10, strconv.IntSize)
+	if err != nil || strconv.FormatUint(parsed, 10) != value {
+		return 0, ErrCorruptedChunk
+	}
+	return int(parsed), nil
+}
+
+func (a *ChunkAssembler) discardRunsAtOrBefore(timeTick uint64) {
+	for runTimeTick := range a.runs {
+		if runTimeTick <= timeTick {
+			a.deleteRun(runTimeTick)
+		}
+	}
+}
+
+// AdvanceTimeTick discards incomplete runs that can no longer complete before
+// the observed logical TimeTick barrier. It is needed when a legacy TimeTick's
+// message type becomes visible only after v0 conversion.
+func (a *ChunkAssembler) AdvanceTimeTick(timeTick uint64) {
+	a.discardRunsAtOrBefore(timeTick)
+}
+
+func (a *ChunkAssembler) deleteRun(tt uint64) {
+	delete(a.runs, tt)
+}
+
+// sameChunkBytes reports whether two observations of one chunk position carry
+// identical payload bytes. A retry keeps the payload but may change its message
+// ID and attempt-specific properties such as trace context. Time tick, index,
+// and total already identify the slot, so payload equality identifies a safe
+// rewrite and Push keeps the later complete observation.
+func sameChunkBytes(a, b ImmutableMessage) bool {
+	return bytes.Equal(a.IntoImmutableMessageProto().GetPayload(), b.IntoImmutableMessageProto().GetPayload())
+}

--- a/pkg/streaming/util/message/chunk_test.go
+++ b/pkg/streaming/util/message/chunk_test.go
@@ -1,0 +1,577 @@
+package message
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func requireChunkPush(t *testing.T, assembler *ChunkAssembler, msg ImmutableMessage) (ImmutableMessage, bool) {
+	t.Helper()
+	assembled, handled, err := assembler.Push(msg)
+	require.NoError(t, err)
+	return assembled, handled
+}
+
+func TestSplitIntoChunksFitsInOne(t *testing.T) {
+	payload := []byte("hello world")
+	msg := NewMutableMessageBeforeAppend(payload, map[string]string{"_t": "x", "_v": "1"})
+
+	chunks := SplitIntoChunks(msg, 100)
+	require.Len(t, chunks, 1)
+	assert.Same(t, msg, chunks[0])
+}
+
+func TestSplitIntoChunksRoundTrip(t *testing.T) {
+	payload := make([]byte, 1000)
+	for i := range payload {
+		payload[i] = byte(i % 251)
+	}
+	props := map[string]string{
+		"_t":  "insert",
+		"_v":  "1",
+		"_tt": "123",
+		"_tx": "whatever",
+	}
+	msg := NewMutableMessageBeforeAppend(payload, props)
+
+	chunks := SplitIntoChunks(msg, 300)
+	// ceil(1000/300) = 4 chunks: 300+300+300+100.
+	require.Len(t, chunks, 4)
+
+	// Every chunk carries the original properties plus index/total markers.
+	for i, c := range chunks {
+		assert.True(t, IsChunkedPayload(c))
+		assert.Equal(t, i, ChunkIndex(c))
+		assert.Equal(t, 4, ChunkTotal(c))
+	}
+
+	// Round-trip the chunks through immutable messages (as the read side sees
+	// them from the backend), then reassemble.
+	immutables := make([]ImmutableMessage, len(chunks))
+	for i, c := range chunks {
+		immutables[i] = c.IntoImmutableMessage(testMessageID(strconv.Itoa(i)))
+	}
+
+	assembled := AssembleChunks(immutables)
+
+	// The reassembled payload must be byte-identical to the original.
+	assert.Equal(t, payload, assembled.IntoImmutableMessageProto().GetPayload())
+
+	// The logical message ID is the first chunk's ID.
+	assert.True(t, testMessageID("0").EQ(assembled.MessageID()))
+
+	// The chunk markers are removed and the original properties preserved.
+	assert.False(t, IsChunkedPayload(assembled))
+	rawProps := assembled.IntoImmutableMessageProto().GetProperties()
+	assert.Equal(t, "123", rawProps["_tt"])
+	assert.Equal(t, "whatever", rawProps["_tx"])
+	assert.NotContains(t, rawProps, "_ci")
+	assert.NotContains(t, rawProps, "_ct")
+}
+
+func TestSplitIntoChunksDisabledOnNonPositiveChunkSize(t *testing.T) {
+	payload := make([]byte, 100)
+	msg := NewMutableMessageBeforeAppend(payload, map[string]string{"_t": "x", "_tt": "100"})
+
+	chunks := SplitIntoChunks(msg, 0)
+	require.Len(t, chunks, 1)
+	assert.Same(t, msg, chunks[0])
+}
+
+func TestSplitIntoChunksExactBoundary(t *testing.T) {
+	// payload exactly a multiple of chunkSize must split into exactly that many
+	// chunks, with no empty trailing chunk.
+	payload := make([]byte, 600)
+	for i := range payload {
+		payload[i] = byte(i % 251)
+	}
+	msg := NewMutableMessageBeforeAppend(payload, map[string]string{"_t": "x", "_tt": "100"})
+
+	chunks := SplitIntoChunks(msg, 300)
+	require.Len(t, chunks, 2)
+	for _, c := range chunks {
+		assert.Equal(t, 2, ChunkTotal(c))
+	}
+}
+
+func TestSplitIntoChunksEmptyPayload(t *testing.T) {
+	msg := NewMutableMessageBeforeAppend([]byte{}, map[string]string{"_t": "x", "_tt": "100"})
+	chunks := SplitIntoChunks(msg, 300)
+	require.Len(t, chunks, 1)
+	assert.Same(t, msg, chunks[0])
+}
+
+func TestChunkAssemblerReassembles(t *testing.T) {
+	payload := make([]byte, 1000)
+	for i := range payload {
+		payload[i] = byte(i % 251)
+	}
+	msg := NewMutableMessageBeforeAppend(payload, map[string]string{"_t": "x", "_tt": "100"})
+	chunks := SplitIntoChunks(msg, 300) // 4 chunks
+
+	var a ChunkAssembler
+	for i, c := range chunks {
+		assembled, handled := requireChunkPush(t, &a, c.IntoImmutableMessage(testMessageID(strconv.Itoa(i))))
+		require.True(t, handled)
+		if i < 3 {
+			assert.Nil(t, assembled, "intermediate chunks must be buffered, not assembled")
+		} else {
+			require.NotNil(t, assembled)
+			assert.Equal(t, payload, assembled.IntoImmutableMessageProto().GetPayload())
+			assert.True(t, testMessageID("0").EQ(assembled.MessageID()))
+		}
+	}
+}
+
+func TestChunkAssemblerPassesThroughNonChunk(t *testing.T) {
+	var a ChunkAssembler
+	other := NewMutableMessageBeforeAppend([]byte("plain"), map[string]string{"_t": "x", "_tt": "100"}).
+		IntoImmutableMessage(testMessageID("7"))
+	assembled, handled := requireChunkPush(t, &a, other)
+	assert.False(t, handled, "a non-chunk message must not be swallowed")
+	assert.Nil(t, assembled)
+}
+
+func TestChunkAssemblerRejectsMalformedMarkers(t *testing.T) {
+	tests := []struct {
+		name       string
+		indexValue *string
+		totalValue *string
+	}{
+		{name: "missing index", totalValue: stringPtr("2")},
+		{name: "missing total", indexValue: stringPtr("0")},
+		{name: "non numeric index", indexValue: stringPtr("x"), totalValue: stringPtr("2")},
+		{name: "signed index", indexValue: stringPtr("+1"), totalValue: stringPtr("2")},
+		{name: "negative index", indexValue: stringPtr("-1"), totalValue: stringPtr("2")},
+		{name: "leading zero", indexValue: stringPtr("00"), totalValue: stringPtr("2")},
+		{name: "overflow", indexValue: stringPtr("0"), totalValue: stringPtr("999999999999999999999999")},
+		{name: "single chunk total", indexValue: stringPtr("0"), totalValue: stringPtr("1")},
+		{name: "index out of range", indexValue: stringPtr("2"), totalValue: stringPtr("2")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			properties := map[string]string{messageTypeKey: "x", messageTimeTick: "100"}
+			if test.indexValue != nil {
+				properties[messageChunkIndex] = *test.indexValue
+			}
+			if test.totalValue != nil {
+				properties[messageChunkTotal] = *test.totalValue
+			}
+			msg := NewMutableMessageBeforeAppend([]byte("x"), properties).
+				IntoImmutableMessage(testMessageID("malformed"))
+
+			var assembler ChunkAssembler
+			assembled, handled, err := assembler.Push(msg)
+			assert.True(t, handled)
+			assert.Nil(t, assembled)
+			require.ErrorIs(t, err, ErrCorruptedChunk)
+		})
+	}
+}
+
+func TestChunkAssemblerRejectsMalformedTimeTick(t *testing.T) {
+	tests := []struct {
+		name          string
+		timeTickValue *string
+	}{
+		{name: "missing"},
+		{name: "empty", timeTickValue: stringPtr("")},
+		{name: "non numeric", timeTickValue: stringPtr("!")},
+		{name: "signed", timeTickValue: stringPtr("+1")},
+		{name: "leading zero", timeTickValue: stringPtr("01")},
+		{name: "uppercase", timeTickValue: stringPtr("A")},
+		{name: "overflow", timeTickValue: stringPtr("zzzzzzzzzzzzzzzzzzzzzzzz")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			properties := map[string]string{
+				messageTypeKey:    "x",
+				messageChunkIndex: "0",
+				messageChunkTotal: "2",
+			}
+			if test.timeTickValue != nil {
+				properties[messageTimeTick] = *test.timeTickValue
+			}
+			msg := NewMutableMessageBeforeAppend([]byte("x"), properties).
+				IntoImmutableMessage(testMessageID("malformed-timetick"))
+
+			var assembler ChunkAssembler
+			assembled, handled, err := assembler.Push(msg)
+			assert.True(t, handled)
+			assert.Nil(t, assembled)
+			require.ErrorIs(t, err, ErrCorruptedChunk)
+		})
+	}
+}
+
+func TestChunkAssemblerUsesSparseSlotsAndDiscardsOrphansAtTimeTick(t *testing.T) {
+	oldHead := NewMutableMessageBeforeAppend([]byte("old"), map[string]string{
+		messageTypeKey:    "x",
+		messageTimeTick:   "100",
+		messageChunkIndex: "0",
+		messageChunkTotal: "1000000000",
+	}).IntoImmutableMessage(testMessageID("old-head"))
+
+	future := SplitIntoChunks(NewMutableMessageBeforeAppend(
+		[]byte{0xAA, 0xBB},
+		map[string]string{messageTypeKey: "x", messageTimeTick: "200"},
+	), 1)
+
+	var assembler ChunkAssembler
+	requireChunkPush(t, &assembler, oldHead)
+	requireChunkPush(t, &assembler, future[0].IntoImmutableMessage(testMessageID("future-head")))
+	oldTimeTick := oldHead.TimeTick()
+	futureTimeTick := future[0].TimeTick()
+	require.Len(t, assembler.runs[oldTimeTick].slots, 1, "declared total must not preallocate slots")
+
+	timeTick := NewMutableMessageBeforeAppend(nil, map[string]string{
+		messageTypeKey:  MessageTypeTimeTick.marshal(),
+		messageTimeTick: "150",
+	}).IntoImmutableMessage(testMessageID("timetick"))
+	assembled, handled := requireChunkPush(t, &assembler, timeTick)
+	assert.False(t, handled)
+	assert.Nil(t, assembled)
+	assert.NotContains(t, assembler.runs, oldTimeTick)
+	assert.Contains(t, assembler.runs, futureTimeTick, "a run newer than the TimeTick remains live")
+
+	assembled, handled = requireChunkPush(t, &assembler, future[1].IntoImmutableMessage(testMessageID("future-tail")))
+	assert.True(t, handled)
+	require.NotNil(t, assembled)
+	assert.Equal(t, []byte{0xAA, 0xBB}, assembled.Payload())
+	assert.Empty(t, assembler.runs)
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+func TestChunkAssemblerPassesThroughNonChunkDuringIncompleteRun(t *testing.T) {
+	payload := make([]byte, 1000)
+	msg := NewMutableMessageBeforeAppend(payload, map[string]string{"_t": "x", "_tt": "100"})
+	chunks := SplitIntoChunks(msg, 300) // 4 chunks, only feed 2
+
+	var a ChunkAssembler
+	requireChunkPush(t, &a, chunks[0].IntoImmutableMessage(testMessageID("0")))
+	requireChunkPush(t, &a, chunks[1].IntoImmutableMessage(testMessageID("1")))
+
+	// Unrelated traffic may interleave with a live run. It passes through while
+	// the buffered chunks remain available for their eventual tail.
+	other := NewMutableMessageBeforeAppend([]byte("other"), map[string]string{"_t": "x", "_tt": "100"}).
+		IntoImmutableMessage(testMessageID("2"))
+	assembled, handled := requireChunkPush(t, &a, other)
+	assert.False(t, handled)
+	assert.Nil(t, assembled)
+
+	assembled, handled = requireChunkPush(t, &a, chunks[2].IntoImmutableMessage(testMessageID("3")))
+	require.True(t, handled)
+	require.Nil(t, assembled)
+	assembled, handled = requireChunkPush(t, &a, chunks[3].IntoImmutableMessage(testMessageID("4")))
+	require.True(t, handled)
+	require.NotNil(t, assembled)
+	assert.Equal(t, payload, assembled.IntoImmutableMessageProto().GetPayload())
+}
+
+func TestChunkAssemblerAssemblesInterleavedPacksIndependently(t *testing.T) {
+	// Pairing is keyed by time tick, not by log adjacency: two packs whose
+	// chunks interleave in the stream must each assemble from their own slots.
+	payloadA := bytes.Repeat([]byte{0xAA}, 1200) // 4 chunks
+	payloadB := bytes.Repeat([]byte{0xBB}, 900)  // 3 chunks
+	msgA := NewMutableMessageBeforeAppend(payloadA, map[string]string{"_t": "x", "_tt": "100"})
+	msgB := NewMutableMessageBeforeAppend(payloadB, map[string]string{"_t": "x", "_tt": "200"})
+	chunksA := SplitIntoChunks(msgA, 300)
+	chunksB := SplitIntoChunks(msgB, 300)
+
+	var a ChunkAssembler
+	requireChunkPush(t, &a, chunksA[0].IntoImmutableMessage(testMessageID("0")))
+	requireChunkPush(t, &a, chunksB[0].IntoImmutableMessage(testMessageID("1")))
+	requireChunkPush(t, &a, chunksA[1].IntoImmutableMessage(testMessageID("2")))
+	requireChunkPush(t, &a, chunksB[1].IntoImmutableMessage(testMessageID("3")))
+
+	assembledB, handled := requireChunkPush(t, &a, chunksB[2].IntoImmutableMessage(testMessageID("4")))
+	require.True(t, handled)
+	require.NotNil(t, assembledB)
+	assert.Equal(t, payloadB, assembledB.IntoImmutableMessageProto().GetPayload())
+	assert.True(t, testMessageID("1").EQ(assembledB.MessageID()))
+
+	assembledA, handled := requireChunkPush(t, &a, chunksA[2].IntoImmutableMessage(testMessageID("5")))
+	assert.Nil(t, assembledA)
+	require.True(t, handled)
+	assembledA, handled = requireChunkPush(t, &a, chunksA[3].IntoImmutableMessage(testMessageID("6")))
+	require.True(t, handled)
+	require.NotNil(t, assembledA)
+	assert.Equal(t, payloadA, assembledA.IntoImmutableMessageProto().GetPayload())
+	assert.True(t, testMessageID("0").EQ(assembledA.MessageID()))
+}
+
+func TestChunkAssemblerDoesNotRejectManyInterleavedRuns(t *testing.T) {
+	const runCount = 1025
+	allChunks := make([][]MutableMessage, runCount)
+	for i := range allChunks {
+		msg := NewMutableMessageBeforeAppend(
+			[]byte{byte(i), byte(i + 1)},
+			map[string]string{"_t": "x", "_tt": strconv.Itoa(100 + i)},
+		)
+		allChunks[i] = SplitIntoChunks(msg, 1)
+		require.Len(t, allChunks[i], 2)
+	}
+
+	var a ChunkAssembler
+	for i, chunks := range allChunks {
+		assembled, handled := requireChunkPush(t, &a, chunks[0].IntoImmutableMessage(testMessageID("head-"+strconv.Itoa(i))))
+		require.True(t, handled)
+		require.Nil(t, assembled)
+	}
+
+	for i, chunks := range allChunks {
+		assembled, handled := requireChunkPush(t, &a, chunks[1].IntoImmutableMessage(testMessageID("tail-"+strconv.Itoa(i))))
+		require.True(t, handled)
+		require.NotNil(t, assembled, "live run %d was discarded", i)
+		assert.Equal(t, []byte{byte(i), byte(i + 1)}, assembled.IntoImmutableMessageProto().GetPayload())
+		assert.True(t, testMessageID("head-"+strconv.Itoa(i)).EQ(assembled.MessageID()))
+	}
+}
+
+func TestChunkAssemblerSwallowsRedeliveredMiddleChunk(t *testing.T) {
+	payload := make([]byte, 900)
+	for i := range payload {
+		payload[i] = byte(i % 253)
+	}
+	msg := NewMutableMessageBeforeAppend(payload, map[string]string{"_t": "x", "_tt": "100"})
+	chunks := SplitIntoChunks(msg, 300) // 3 chunks
+
+	var a ChunkAssembler
+	requireChunkPush(t, &a, chunks[0].IntoImmutableMessage(testMessageID("0")))
+	requireChunkPush(t, &a, chunks[1].IntoImmutableMessage(testMessageID("1")))
+
+	// The backend persisted chunk 1 but its send surfaced as an error, so the
+	// producer rewrote it under a new message ID. The duplicate must be
+	// swallowed without corrupting the run.
+	dup, handled := requireChunkPush(t, &a, chunks[1].IntoImmutableMessage(testMessageID("9")))
+	require.True(t, handled)
+	assert.Nil(t, dup)
+
+	assembled, handled := requireChunkPush(t, &a, chunks[2].IntoImmutableMessage(testMessageID("2")))
+	require.True(t, handled)
+	require.NotNil(t, assembled)
+	assert.Equal(t, payload, assembled.IntoImmutableMessageProto().GetPayload())
+}
+
+func TestChunkAssemblerDuplicateHeadUsesLatestObservation(t *testing.T) {
+	msg := NewMutableMessageBeforeAppend(
+		[]byte{0xAA, 0xBB},
+		map[string]string{"_t": "x", "_tt": "100"},
+	)
+	chunks := SplitIntoChunks(msg, 1)
+	require.Len(t, chunks, 2)
+
+	headProto := chunks[0].IntoMessageProto()
+	newHead := func(id, traceContext string) ImmutableMessage {
+		props := make(map[string]string, len(headProto.GetProperties()))
+		for key, value := range headProto.GetProperties() {
+			props[key] = value
+		}
+		props[messageTraceContext] = traceContext
+		return NewMutableMessageBeforeAppend(headProto.GetPayload(), props).
+			IntoImmutableMessage(testMessageID(id))
+	}
+
+	var a ChunkAssembler
+	assembled, handled := requireChunkPush(t, &a, newHead("persisted-before-error", "first-attempt"))
+	require.True(t, handled)
+	require.Nil(t, assembled)
+	assembled, handled = requireChunkPush(t, &a, newHead("successful-retry", "successful-attempt"))
+	require.True(t, handled)
+	require.Nil(t, assembled)
+	assembled, handled = requireChunkPush(t, &a, chunks[1].IntoImmutableMessage(testMessageID("tail")))
+	require.True(t, handled)
+	require.NotNil(t, assembled)
+	assert.True(t, testMessageID("successful-retry").EQ(assembled.MessageID()))
+	assert.Equal(t, "successful-attempt", assembled.IntoImmutableMessageProto().GetProperties()[messageTraceContext])
+}
+
+func TestChunkAssemblerRejectsNonDuplicateRegression(t *testing.T) {
+	payloadA := bytes.Repeat([]byte{0xAA}, 900)
+	payloadB := bytes.Repeat([]byte{0xBB}, 900)
+	msgA := NewMutableMessageBeforeAppend(payloadA, map[string]string{"_t": "x", "_tt": "100"})
+	msgB := NewMutableMessageBeforeAppend(payloadB, map[string]string{"_t": "x", "_tt": "100"})
+	chunksA := SplitIntoChunks(msgA, 300)
+	chunksB := SplitIntoChunks(msgB, 300)
+
+	var a ChunkAssembler
+	requireChunkPush(t, &a, chunksA[0].IntoImmutableMessage(testMessageID("0")))
+	requireChunkPush(t, &a, chunksA[1].IntoImmutableMessage(testMessageID("1")))
+
+	// Same index, same total, different bytes: not a redelivery but a broken
+	// log. The scanner must stop rather than advance past the logical message.
+	interloper, handled, err := a.Push(chunksB[1].IntoImmutableMessage(testMessageID("8")))
+	require.True(t, handled)
+	assert.Nil(t, interloper)
+	require.ErrorIs(t, err, ErrCorruptedChunk)
+
+	// The corrupt run was removed before the error was returned.
+	tail, handled := requireChunkPush(t, &a, chunksA[2].IntoImmutableMessage(testMessageID("2")))
+	require.True(t, handled)
+	assert.Nil(t, tail, "stale tail of a discarded run must not complete it")
+
+	// The next fresh run assembles normally.
+	requireChunkPush(t, &a, chunksB[0].IntoImmutableMessage(testMessageID("3")))
+	requireChunkPush(t, &a, chunksB[1].IntoImmutableMessage(testMessageID("4")))
+	assembled, handled := requireChunkPush(t, &a, chunksB[2].IntoImmutableMessage(testMessageID("5")))
+	require.True(t, handled)
+	require.NotNil(t, assembled)
+	assert.Equal(t, payloadB, assembled.IntoImmutableMessageProto().GetPayload())
+}
+
+func TestChunkAssemblerRejectsTotalMismatch(t *testing.T) {
+	msg := NewMutableMessageBeforeAppend(
+		bytes.Repeat([]byte{0xAA}, 900),
+		map[string]string{messageTypeKey: "x", messageTimeTick: "100"},
+	)
+	chunks := SplitIntoChunks(msg, 300)
+
+	var assembler ChunkAssembler
+	requireChunkPush(t, &assembler, chunks[0].IntoImmutableMessage(testMessageID("head")))
+	mismatched := chunks[1].IntoMessageProto()
+	mismatched.Properties[messageChunkTotal] = "4"
+	assembled, handled, err := assembler.Push(
+		NewMutableMessageBeforeAppend(mismatched.Payload, mismatched.Properties).
+			IntoImmutableMessage(testMessageID("mismatch")),
+	)
+	assert.True(t, handled)
+	assert.Nil(t, assembled)
+	require.ErrorIs(t, err, ErrCorruptedChunk)
+}
+
+func TestChunkAssemblerSwallowsOrphanMiddleChunk(t *testing.T) {
+	payload := make([]byte, 600)
+	msg := NewMutableMessageBeforeAppend(payload, map[string]string{"_t": "x", "_tt": "100"})
+	chunks := SplitIntoChunks(msg, 300)
+
+	var a ChunkAssembler
+	// A middle chunk whose run head was never delivered must not be buffered:
+	// without its head there is no complete logical-message identity to retain.
+	orphan, handled := requireChunkPush(t, &a, chunks[1].IntoImmutableMessage(testMessageID("7")))
+	require.True(t, handled)
+	assert.Nil(t, orphan)
+
+	// And it leaves nothing behind for the next run.
+	requireChunkPush(t, &a, chunks[0].IntoImmutableMessage(testMessageID("0")))
+	assembled, handled := requireChunkPush(t, &a, chunks[1].IntoImmutableMessage(testMessageID("1")))
+	require.True(t, handled)
+	require.NotNil(t, assembled)
+	assert.Equal(t, payload, assembled.IntoImmutableMessageProto().GetPayload())
+}
+
+// TestChunkAssemblerEndToEndDeliveryStream simulates a realistic delivery
+// stream as the read side sees it from a backend: several oversized messages,
+// retry redeliveries injected right after their originals, and unrelated
+// complete messages flowing between packs. Every pack must assemble exactly
+// once, byte-identical, and every unrelated message must pass through untouched.
+func TestChunkAssemblerEndToEndDeliveryStream(t *testing.T) {
+	const packs = 6
+	chunkSize := 256
+
+	// Build the logical messages and their splits.
+	type pack struct {
+		payload []byte
+		chunks  []MutableMessage
+	}
+	packsData := make([]pack, packs)
+	for k := 0; k < packs; k++ {
+		size := chunkSize*(k%3+2) - k*7 // varying sizes, always >= 2 chunks
+		payload := make([]byte, size)
+		for i := range payload {
+			payload[i] = byte(i*31 + k*7)
+		}
+		msg := NewMutableMessageBeforeAppend(payload, map[string]string{"_t": "insert", "_tt": strconv.Itoa(100 + k), "_k": strconv.Itoa(k)})
+		chunks := SplitIntoChunks(msg, chunkSize)
+		require.GreaterOrEqual(t, len(chunks), 2)
+		packsData[k] = pack{payload: payload, chunks: chunks}
+	}
+
+	nextID := 0
+	newID := func() string { nextID++; return strconv.Itoa(nextID) }
+
+	// Produce the delivery sequence exactly as the log would hold it.
+	var stream []ImmutableMessage
+	var wantPassthrough []ImmutableMessage
+	for k := 0; k < packs; k++ {
+		for ci, c := range packsData[k].chunks {
+			stream = append(stream, c.IntoImmutableMessage(testMessageID(newID())))
+			if ci%2 == 1 { // persisted-but-unacked rewrite of the same record
+				stream = append(stream, c.IntoImmutableMessage(testMessageID(newID())))
+			}
+		}
+		if k != packs-1 { // unrelated traffic between packs
+			m := NewMutableMessageBeforeAppend([]byte{byte(k)}, map[string]string{"_t": "delete", "_tt": "200"})
+			imm := m.IntoImmutableMessage(testMessageID(newID()))
+			stream = append(stream, imm)
+			wantPassthrough = append(wantPassthrough, imm)
+		}
+	}
+
+	// Drive the assembler.
+	var a ChunkAssembler
+	var gotPacks [][]byte
+	var gotPassthrough []ImmutableMessage
+	for _, m := range stream {
+		assembled, handled := requireChunkPush(t, &a, m)
+		if !handled {
+			// Not a chunk: the caller processes it normally.
+			gotPassthrough = append(gotPassthrough, m)
+			continue
+		}
+		if assembled != nil {
+			gotPacks = append(gotPacks, assembled.IntoImmutableMessageProto().GetPayload())
+		}
+	}
+
+	// Every pack came out exactly once, byte-identical, in order.
+	require.Len(t, gotPacks, packs)
+	for k := range packsData {
+		assert.Equal(t, packsData[k].payload, gotPacks[k], "pack %d corrupted", k)
+	}
+	// Every unrelated message passed through exactly once.
+	require.Len(t, gotPassthrough, len(wantPassthrough))
+	for i := range wantPassthrough {
+		assert.True(t, wantPassthrough[i].MessageID().EQ(gotPassthrough[i].MessageID()))
+	}
+	// Nothing left buffered.
+	_, handled := requireChunkPush(t, &a, NewMutableMessageBeforeAppend([]byte("x"), map[string]string{"_t": "insert", "_tt": "300"}).IntoImmutableMessage(testMessageID(newID())))
+	assert.False(t, handled, "trailing non-chunk must process normally")
+}
+
+// TestChunkAssemblerSwallowsLateDuplicateAfterCompletion covers a defensive
+// case: a redelivered copy arriving after its run already completed (e.g. a
+// scanner racing ahead across a checkpoint). It must neither resurrect the
+// old run nor pollute the next one.
+func TestChunkAssemblerSwallowsLateDuplicateAfterCompletion(t *testing.T) {
+	payload := make([]byte, 900)
+	msg := NewMutableMessageBeforeAppend(payload, map[string]string{"_t": "x", "_tt": "100"})
+	chunks := SplitIntoChunks(msg, 300)
+
+	var a ChunkAssembler
+	requireChunkPush(t, &a, chunks[0].IntoImmutableMessage(testMessageID("0")))
+	requireChunkPush(t, &a, chunks[1].IntoImmutableMessage(testMessageID("1")))
+	assembled, handled := requireChunkPush(t, &a, chunks[2].IntoImmutableMessage(testMessageID("2")))
+	require.True(t, handled)
+	require.NotNil(t, assembled)
+
+	late, handled := requireChunkPush(t, &a, chunks[1].IntoImmutableMessage(testMessageID("9")))
+	require.True(t, handled)
+	assert.Nil(t, late)
+
+	// The next run is unaffected.
+	requireChunkPush(t, &a, chunks[0].IntoImmutableMessage(testMessageID("3")))
+	requireChunkPush(t, &a, chunks[1].IntoImmutableMessage(testMessageID("4")))
+	second, handled := requireChunkPush(t, &a, chunks[2].IntoImmutableMessage(testMessageID("5")))
+	require.True(t, handled)
+	require.NotNil(t, second)
+	assert.Equal(t, payload, second.IntoImmutableMessageProto().GetPayload())
+}

--- a/pkg/streaming/util/message/partial_update_cas.go
+++ b/pkg/streaming/util/message/partial_update_cas.go
@@ -33,6 +33,41 @@ func (b *mutableMesasgeBuilder[H, B]) AddPartialUpdateCAS(meta *messagespb.Parti
 	return nil
 }
 
+// EncodePartialUpdateCASIntoInsertTemplate validates meta and stores it into
+// the template InsertRequest a body encoder serializes from, so the encoded
+// body carries the same Base.Properties entry AddPartialUpdateCAS writes into
+// a materialized body. The template must be prepared before the encoder plans
+// its sizes; pair it with MarkPartialUpdateCASForBodyEncoder on each builder
+// producing a message from that template.
+func EncodePartialUpdateCASIntoInsertTemplate(meta *messagespb.PartialUpdateCAS, template *InsertRequest) error {
+	encoded, err := encodePartialUpdateCAS(meta)
+	if err != nil {
+		return err
+	}
+	if template == nil {
+		return merr.WrapErrServiceInternalMsg("partial update CAS metadata requires an insert template")
+	}
+	setPartialUpdateCASInsertBody(template, encoded)
+	return nil
+}
+
+// MarkPartialUpdateCASForBodyEncoder marks an insert builder whose
+// encoder-produced body already carries CAS metadata written by
+// EncodePartialUpdateCASIntoInsertTemplate. It is the counterpart of the
+// marking half of AddPartialUpdateCAS when no materialized body is attached to
+// the builder.
+func (b *mutableMesasgeBuilder[H, B]) MarkPartialUpdateCASForBodyEncoder() error {
+	messageType := MustGetMessageTypeWithVersion[H, B]()
+	if messageType.MessageType != MessageTypeInsert {
+		return merr.WrapErrServiceInternalMsg("partial update CAS metadata requires an insert message builder")
+	}
+	if isNilBodyEncoder(b.bodyEncoder) {
+		return merr.WrapErrServiceInternalMsg("partial update CAS marker requires a body encoder")
+	}
+	b.properties.Set(messagePartialUpdateCAS, "")
+	return nil
+}
+
 // MarkPartialUpdateCASCommit marks a locally-created CommitTxn so the WAL can
 // serialize its CAS admission without exposing the proof metadata in headers.
 func MarkPartialUpdateCASCommit(msg MutableMessage) error {

--- a/pkg/streaming/util/message/partial_update_cas_test.go
+++ b/pkg/streaming/util/message/partial_update_cas_test.go
@@ -79,6 +79,45 @@ func TestPartialUpdateCASBuilderEncryptsMetadataWithBody(t *testing.T) {
 	require.True(t, proto.Equal(meta, got))
 }
 
+func TestPartialUpdateCASBodyEncoderEncryptsMetadataWithBody(t *testing.T) {
+	oldCipher := cipher
+	cipher = partialUpdateCASTestCipher{}
+	t.Cleanup(func() { cipher = oldCipher })
+
+	meta := validPartialUpdateCAS()
+	template := &msgpb.InsertRequest{Base: &commonpb.MsgBase{}}
+	// CAS must be part of the template before the encoder plans its exact size.
+	require.NoError(t, EncodePartialUpdateCASIntoInsertTemplate(meta, template))
+	encodedBody, err := proto.Marshal(template)
+	require.NoError(t, err)
+	encoder := &partialUpdateCASTestBodyEncoder{payload: encodedBody}
+
+	builder := NewInsertMessageBuilderV1().
+		WithVChannel("v1").
+		WithHeader(&InsertMessageHeader{CollectionId: 10}).
+		WithBodyEncoder(encoder)
+	require.NoError(t, builder.MarkPartialUpdateCASForBodyEncoder())
+	msg, err := builder.
+		WithCipher(&CipherConfig{EzID: 1, CollectionID: 10}).
+		BuildMutable()
+	require.NoError(t, err)
+	require.Equal(t, 1, encoder.encodedSizeCalls)
+	require.Equal(t, 1, encoder.marshalToCalls)
+
+	marker, ok := msg.Properties().Get(messagePartialUpdateCAS)
+	require.True(t, ok)
+	require.Empty(t, marker)
+	rawPayload := msg.IntoMessageProto().GetPayload()
+	require.NotEqual(t, encodedBody, rawPayload)
+	encodedMeta := template.GetBase().GetProperties()[messagePartialUpdateCAS]
+	require.NotEmpty(t, encodedMeta)
+	require.False(t, bytes.Contains(rawPayload, []byte(encodedMeta)))
+
+	got, err := ExtractPartialUpdateCAS(msg)
+	require.NoError(t, err)
+	require.True(t, proto.Equal(meta, got))
+}
+
 func TestMarkPartialUpdateCASCommit(t *testing.T) {
 	commit := NewCommitTxnMessageBuilderV2().
 		WithVChannel("v1").
@@ -111,6 +150,25 @@ func TestPartialUpdateCASDefensiveErrors(t *testing.T) {
 			WithHeader(&CommitTxnMessageHeader{}).
 			WithBody(&CommitTxnMessageBody{})
 		require.Error(t, builder.AddPartialUpdateCAS(validPartialUpdateCAS()))
+	})
+
+	t.Run("nil body encoder template", func(t *testing.T) {
+		require.Error(t, EncodePartialUpdateCASIntoInsertTemplate(validPartialUpdateCAS(), nil))
+	})
+
+	t.Run("body encoder marker without encoder", func(t *testing.T) {
+		builder := NewInsertMessageBuilderV1().
+			WithVChannel("v1").
+			WithHeader(&InsertMessageHeader{CollectionId: 10})
+		require.Error(t, builder.MarkPartialUpdateCASForBodyEncoder())
+	})
+
+	t.Run("body encoder marker on non insert", func(t *testing.T) {
+		builder := NewDeleteMessageBuilderV1().
+			WithVChannel("v1").
+			WithHeader(&DeleteMessageHeader{}).
+			WithBodyEncoder(partialUpdateCASTestDeleteBodyEncoder{})
+		require.Error(t, builder.MarkPartialUpdateCASForBodyEncoder())
 	})
 
 	t.Run("commit without property setter", func(t *testing.T) {
@@ -305,4 +363,38 @@ func partialUpdateCASTestXOR(input []byte) []byte {
 		output[i] = value ^ 0xff
 	}
 	return output
+}
+
+type partialUpdateCASTestBodyEncoder struct {
+	payload          []byte
+	encodedSizeCalls int
+	marshalToCalls   int
+}
+
+func (e *partialUpdateCASTestBodyEncoder) EncodedSize() (int, error) {
+	e.encodedSizeCalls++
+	return len(e.payload), nil
+}
+
+func (e *partialUpdateCASTestBodyEncoder) MarshalTo(dst []byte) (int, error) {
+	e.marshalToCalls++
+	return copy(dst, e.payload), nil
+}
+
+func (e *partialUpdateCASTestBodyEncoder) BodyType() *msgpb.InsertRequest {
+	return nil
+}
+
+type partialUpdateCASTestDeleteBodyEncoder struct{}
+
+func (partialUpdateCASTestDeleteBodyEncoder) EncodedSize() (int, error) {
+	return 0, nil
+}
+
+func (partialUpdateCASTestDeleteBodyEncoder) MarshalTo([]byte) (int, error) {
+	return 0, nil
+}
+
+func (partialUpdateCASTestDeleteBodyEncoder) BodyType() *msgpb.DeleteRequest {
+	return nil
 }

--- a/pkg/streaming/util/message/properties.go
+++ b/pkg/streaming/util/message/properties.go
@@ -20,6 +20,8 @@ const (
 	messageUnreplicable                     = "_ur"  // mark the message as unsafe to replicate.
 	messageTraceContext                     = "_tc"  // Trace context subset header.
 	messagePartialUpdateCAS                 = "_puc" // partial update CAS transaction marker.
+	messageChunkIndex                       = "_ci"  // payload chunk index (0-based) of a chunked WAL record.
+	messageChunkTotal                       = "_ct"  // total chunk count of a chunked WAL record.
 )
 
 var (

--- a/pkg/streaming/walimpls/helper/scanner_helper.go
+++ b/pkg/streaming/walimpls/helper/scanner_helper.go
@@ -40,9 +40,14 @@ func (s *ScannerHelper) Done() <-chan struct{} {
 	return s.notifier.FinishChan()
 }
 
+// Cancel asks the scanner task to stop without waiting for it to finish.
+func (s *ScannerHelper) Cancel() {
+	s.notifier.Cancel()
+}
+
 // Close closes the scanner, block until the Finish is called.
 func (s *ScannerHelper) Close() error {
-	s.notifier.Cancel()
+	s.Cancel()
 	return s.notifier.BlockAndGetResult()
 }
 

--- a/pkg/streaming/walimpls/impls/kafka/builder.go
+++ b/pkg/streaming/walimpls/impls/kafka/builder.go
@@ -40,13 +40,16 @@ func (b *builderImpl) getProducerConfig() kafka.ConfigMap {
 	config := &paramtable.Get().KafkaCfg
 	producerConfig := getBasicConfig(config)
 
-	producerConfig.SetKey("message.max.bytes", config.ProducerMessageMaxBytes.GetAsInt())
 	producerConfig.SetKey("compression.codec", "zstd")
 	// we want to ensure tt send out as soon as possible
 	producerConfig.SetKey("linger.ms", 5)
 	for k, v := range config.ProducerExtraConfig.GetValue() {
 		producerConfig.SetKey(k, v)
 	}
+	// ProducerExtraConfig includes the raw kafka.producer.message.max.bytes
+	// entry. Apply the normalized ParamItem last so a value below the supported
+	// WAL minimum cannot overwrite the clamped producer limit.
+	producerConfig.SetKey("message.max.bytes", config.ProducerMessageMaxBytes.GetAsInt())
 	return producerConfig
 }
 

--- a/pkg/streaming/walimpls/impls/kafka/kafka_test.go
+++ b/pkg/streaming/walimpls/impls/kafka/kafka_test.go
@@ -61,13 +61,14 @@ func TestGetBasicConfig(t *testing.T) {
 	assert.NotNil(t, basicConfig["security.protocol"])
 }
 
-func TestGetProducerConfigUsesConfiguredMessageMaxBytes(t *testing.T) {
-	config := &paramtable.Get().KafkaCfg
-	oldValue := config.ProducerMessageMaxBytes.SwapTempValue("4096")
-	defer config.ProducerMessageMaxBytes.SwapTempValue(oldValue)
+func TestGetProducerConfigClampsConfiguredMessageMaxBytes(t *testing.T) {
+	params := paramtable.Get()
+	config := &params.KafkaCfg
+	assert.NoError(t, params.Save(config.ProducerMessageMaxBytes.Key, "4096"))
+	t.Cleanup(func() { assert.NoError(t, params.Reset(config.ProducerMessageMaxBytes.Key)) })
 
 	producerConfig := (&builderImpl{}).getProducerConfig()
 	value, err := producerConfig.Get("message.max.bytes", nil)
 	assert.NoError(t, err)
-	assert.Equal(t, 4096, value)
+	assert.Equal(t, 256*1024, value)
 }

--- a/pkg/streaming/walimpls/impls/pulsar/wal.go
+++ b/pkg/streaming/walimpls/impls/pulsar/wal.go
@@ -86,18 +86,31 @@ func (w *walImpl) Append(ctx context.Context, msg message.MutableMessage) (messa
 		return nil, errors.Wrap(err, "get producer from future")
 	}
 	pb := msg.IntoMessageProto()
+	recordSize := estimatePulsarRecordSize(pb.Payload, pb.Properties)
 	id, err := p.Send(ctx, &pulsar.ProducerMessage{
 		Payload:    pb.Payload,
 		Properties: pb.Properties,
 	})
 	// Observe the append traffic even if the message is not sent successfully.
 	// Because if the write is failed, the message may be already written to the pulsar topic.
-	w.backlogClearHelper.ObserveAppend(msg.EstimateSize())
+	w.backlogClearHelper.ObserveAppend(recordSize)
 	if err != nil {
 		w.Log().RatedWarn(ctx, rate.Limit(1), "send message to pulsar failed", mlog.Err(err))
 		return nil, err
 	}
 	return pulsarID{id}, nil
+}
+
+// estimatePulsarRecordSize counts the bytes handed to Pulsar for one physical
+// record. MutableMessage.EstimateSize intentionally reports plaintext logical
+// size for encrypted messages; using it here would therefore count the full
+// logical payload once for every encrypted WAL chunk.
+func estimatePulsarRecordSize(payload []byte, properties map[string]string) int {
+	size := len(payload)
+	for key, value := range properties {
+		size += len(key) + len(value)
+	}
+	return size
 }
 
 func (w *walImpl) Read(ctx context.Context, opt walimpls.ReadOption) (s walimpls.ScannerImpls, err error) {

--- a/pkg/streaming/walimpls/impls/pulsar/wal_test.go
+++ b/pkg/streaming/walimpls/impls/pulsar/wal_test.go
@@ -1,0 +1,138 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pulsar
+
+import (
+	"bytes"
+	"context"
+	"math"
+	"sync"
+	"testing"
+
+	"github.com/apache/pulsar-client-go/pulsar"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/helper"
+	"github.com/milvus-io/milvus/pkg/v3/util/syncutil"
+)
+
+func TestEstimatePulsarRecordSize(t *testing.T) {
+	tests := []struct {
+		name       string
+		payload    []byte
+		properties map[string]string
+		expected   int
+	}{
+		{name: "empty"},
+		{name: "payload only", payload: []byte("payload"), expected: len("payload")},
+		{
+			name:       "properties only",
+			properties: map[string]string{"": "", "键": "值"},
+			expected:   len("键") + len("值"),
+		},
+		{
+			name:       "payload and properties",
+			payload:    []byte("payload"),
+			properties: map[string]string{"key": "value", "longer-key": "v"},
+			expected:   len("payload") + len("key") + len("value") + len("longer-key") + len("v"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, estimatePulsarRecordSize(test.payload, test.properties))
+		})
+	}
+}
+
+func TestEstimatePulsarRecordSizeForEncryptedChunks(t *testing.T) {
+	const (
+		logicalPlaintextSize = 64 << 10
+		chunkSize            = 2 << 10
+	)
+	cipherHeader, err := message.EncodeProto(&messagespb.CipherHeader{
+		EzId:         1,
+		CollectionId: 2,
+		SafeKey:      []byte("safe-key"),
+		PayloadBytes: logicalPlaintextSize,
+	})
+	require.NoError(t, err)
+
+	ciphertext := bytes.Repeat([]byte{0xab}, logicalPlaintextSize)
+	original := message.NewMutableMessageBeforeAppend(ciphertext, map[string]string{
+		"_ch": cipherHeader,
+		"_vc": "by-dev-rootcoord-dml_0v0",
+	})
+	chunks := message.SplitIntoChunks(original, chunkSize)
+	require.Len(t, chunks, logicalPlaintextSize/chunkSize)
+
+	producer := &recordingPulsarProducer{}
+	producerFuture := syncutil.NewFuture[pulsar.Producer]()
+	producerFuture.Set(producer)
+	backlogHelper := &backlogClearHelper{
+		cond:      syncutil.NewContextCond(&sync.Mutex{}),
+		threshold: math.MaxInt64,
+	}
+	w := &walImpl{
+		WALHelper: helper.NewWALHelper(&walimpls.OpenOption{
+			Channel: types.PChannelInfo{
+				Name:       "test-channel",
+				Term:       1,
+				AccessMode: types.AccessModeRW,
+			},
+		}),
+		p:                  producerFuture,
+		backlogClearHelper: backlogHelper,
+	}
+
+	physicalSize := 0
+	logicalEstimate := 0
+	payloadSize := 0
+	propertiesSize := 0
+	for _, chunk := range chunks {
+		pb := chunk.IntoMessageProto()
+		physicalSize += estimatePulsarRecordSize(pb.Payload, pb.Properties)
+		logicalEstimate += chunk.EstimateSize()
+		payloadSize += len(pb.Payload)
+		for key, value := range pb.Properties {
+			propertiesSize += len(key) + len(value)
+		}
+		_, err := w.Append(context.Background(), chunk)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, len(ciphertext), payloadSize)
+	assert.Equal(t, payloadSize+propertiesSize, physicalSize)
+	assert.Greater(t, logicalEstimate, physicalSize)
+	assert.Equal(t, int64(physicalSize), backlogHelper.written)
+	assert.Len(t, producer.messages, len(chunks))
+}
+
+type recordingPulsarProducer struct {
+	pulsar.Producer
+	messages []*pulsar.ProducerMessage
+}
+
+func (p *recordingPulsarProducer) Send(_ context.Context, msg *pulsar.ProducerMessage) (pulsar.MessageID, error) {
+	p.messages = append(p.messages, msg)
+	return pulsar.EarliestMessageID(), nil
+}

--- a/pkg/util/fastpb/insert_request_cell.go
+++ b/pkg/util/fastpb/insert_request_cell.go
@@ -1,0 +1,404 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fastpb
+
+import (
+	"math"
+
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+)
+
+// An ArrayArray element is a whole schemapb.ScalarField rather than a row
+// slice, so the row-selection encoders in insert_request_view.go do not apply
+// to it. Before this file it was the only insert payload still measured and
+// written by the protobuf reflection encoder. Here it is measured and written
+// arithmetically instead.
+//
+// The split is deliberate:
+//
+//	classifyScalarCell -- O(1), looks at the oneof only
+//	scalarCellPayload  -- O(elements), pure arithmetic, no reflection
+//	appendScalarCell   -- the bytes, byte-identical to proto.Marshal
+//
+// Sizing runs classify+payload and stores the payload in cursor scratch;
+// MarshalTo runs classify again and replays the stored payload, so the
+// O(elements) pass happens exactly once per cell.
+//
+// Note this is exact, not an estimate. A cheap over-approximation was
+// considered and rejected: bounding a packed int64 array at 10 bytes per
+// element is O(1) but roughly 10x the real size for small values, which would
+// cut the rows per message by the same factor. SizeVarint is a bit-length
+// operation -- computing the true size costs little more than bounding it, and
+// keeps the splitter's limit exact so no headroom is needed to absorb sizing
+// error.
+//
+// Cells the fast path does not cover -- an unknown oneof, a nested ArrayData,
+// or any cell carrying unknown fields -- report ok=false from classify and go
+// back through the protobuf runtime for both sizing and writing. Dropping
+// unknown fields on only one of those sides would make the length prefix disagree
+// with the bytes written, which corrupts the message rather than merely losing
+// data.
+
+type scalarCellKind uint8
+
+const (
+	// scalarCellUnsupported marks a cell the arithmetic path must not encode.
+	scalarCellUnsupported scalarCellKind = iota
+	// scalarCellEmpty is a ScalarField with no oneof set.
+	scalarCellEmpty
+	// scalarCellPacked covers repeated numeric arrays, which proto3 encodes as
+	// one packed length-delimited payload under field 1 of the array message.
+	// An empty array omits field 1 entirely.
+	scalarCellPacked
+	// scalarCellRepeated covers repeated string/bytes arrays, where every
+	// element carries its own tag and length prefix under field 1.
+	scalarCellRepeated
+)
+
+// scalarCellPlan is a cell's classification plus the one size that cannot be
+// derived from its type alone.
+type scalarCellPlan struct {
+	kind scalarCellKind
+	// oneofNumber is the ScalarField field number holding the array message.
+	oneofNumber protowire.Number
+	// payload is the packed byte count for scalarCellPacked, or the summed
+	// element wire size for scalarCellRepeated.
+	payload int
+}
+
+// classifyScalarCell inspects only the oneof and reports whether the
+// arithmetic path can reproduce this cell. Both the sizing pass and MarshalTo
+// call it and must agree on every cell, so it derives its verdict from the
+// cell alone -- the borrowed source is immutable for the cursor's lifetime.
+func classifyScalarCell(cell *schemapb.ScalarField) (scalarCellPlan, bool) {
+	if cell == nil {
+		return scalarCellPlan{kind: scalarCellEmpty}, true
+	}
+	// ValidData (field 17) has no producer anywhere in this repo yet, but proto
+	// reflection recognizes it now, so GetUnknown() no longer catches it: a cell
+	// carrying it would silently lose that data through the arithmetic path,
+	// which only writes the oneof value. Fall back to the protobuf path, which
+	// writes every recognized field, until this one earns explicit handling.
+	if len(cell.GetValidData()) != 0 {
+		return scalarCellPlan{}, false
+	}
+	if len(cell.ProtoReflect().GetUnknown()) != 0 {
+		return scalarCellPlan{}, false
+	}
+
+	switch value := cell.Data.(type) {
+	case nil:
+		return scalarCellPlan{kind: scalarCellEmpty}, true
+	case *schemapb.ScalarField_BoolData:
+		return packedCellPlan(1, value.BoolData)
+	case *schemapb.ScalarField_IntData:
+		return packedCellPlan(2, value.IntData)
+	case *schemapb.ScalarField_LongData:
+		return packedCellPlan(3, value.LongData)
+	case *schemapb.ScalarField_FloatData:
+		return packedCellPlan(4, value.FloatData)
+	case *schemapb.ScalarField_DoubleData:
+		return packedCellPlan(5, value.DoubleData)
+	case *schemapb.ScalarField_StringData:
+		return repeatedCellPlan(6, value.StringData)
+	case *schemapb.ScalarField_BytesData:
+		return repeatedCellPlan(7, value.BytesData)
+	case *schemapb.ScalarField_JsonData:
+		return repeatedCellPlan(9, value.JsonData)
+	case *schemapb.ScalarField_GeometryData:
+		return repeatedCellPlan(10, value.GeometryData)
+	case *schemapb.ScalarField_TimestamptzData:
+		return packedCellPlan(11, value.TimestamptzData)
+	case *schemapb.ScalarField_GeometryWktData:
+		return repeatedCellPlan(12, value.GeometryWktData)
+	case *schemapb.ScalarField_MolData:
+		return repeatedCellPlan(13, value.MolData)
+	case *schemapb.ScalarField_MolSmilesData:
+		return repeatedCellPlan(14, value.MolSmilesData)
+	case *schemapb.ScalarField_DateData:
+		return packedCellPlan(15, value.DateData)
+	case *schemapb.ScalarField_TimeData:
+		return packedCellPlan(16, value.TimeData)
+	default:
+		// A nested ArrayData, or an oneof added after this code was written.
+		return scalarCellPlan{}, false
+	}
+}
+
+// packedCellPlan rejects a set-but-nil oneof wrapper. proto.Marshal still emits
+// the empty array message for one, and the arithmetic path agrees, but the
+// row-selection encoders treat it as a malformed source, so keep the two paths
+// consistent by refusing it here too.
+func packedCellPlan(oneofNumber protowire.Number, array proto.Message) (scalarCellPlan, bool) {
+	if !scalarCellNestedArraySupported(array) {
+		return scalarCellPlan{}, false
+	}
+	return scalarCellPlan{kind: scalarCellPacked, oneofNumber: oneofNumber}, true
+}
+
+func repeatedCellPlan(oneofNumber protowire.Number, array proto.Message) (scalarCellPlan, bool) {
+	if !scalarCellNestedArraySupported(array) {
+		return scalarCellPlan{}, false
+	}
+	return scalarCellPlan{kind: scalarCellRepeated, oneofNumber: oneofNumber}, true
+}
+
+// scalarCellNestedArraySupported rejects both malformed set-but-nil oneofs and
+// nested messages carrying fields this arithmetic encoder does not know about.
+// The protobuf fallback preserves those unknown bytes verbatim.
+func scalarCellNestedArraySupported(array proto.Message) bool {
+	return !isNilProto(array) && len(array.ProtoReflect().GetUnknown()) == 0
+}
+
+// scalarCellPayload computes the cell's inner payload size arithmetically. The
+// caller must have classified the cell first; an unsupported cell returns 0.
+func scalarCellPayload(cell *schemapb.ScalarField, plan scalarCellPlan) int {
+	if plan.kind != scalarCellPacked && plan.kind != scalarCellRepeated {
+		return 0
+	}
+	switch value := cell.Data.(type) {
+	case *schemapb.ScalarField_BoolData:
+		// Every bool is a single-byte varint.
+		return len(value.BoolData.GetData())
+	case *schemapb.ScalarField_IntData:
+		return int32VarintPayload(value.IntData.GetData())
+	case *schemapb.ScalarField_LongData:
+		return int64VarintPayload(value.LongData.GetData())
+	case *schemapb.ScalarField_FloatData:
+		return 4 * len(value.FloatData.GetData())
+	case *schemapb.ScalarField_DoubleData:
+		return 8 * len(value.DoubleData.GetData())
+	case *schemapb.ScalarField_StringData:
+		return stringElementsPayload(value.StringData.GetData())
+	case *schemapb.ScalarField_BytesData:
+		return bytesElementsPayload(value.BytesData.GetData())
+	case *schemapb.ScalarField_JsonData:
+		return bytesElementsPayload(value.JsonData.GetData())
+	case *schemapb.ScalarField_GeometryData:
+		return bytesElementsPayload(value.GeometryData.GetData())
+	case *schemapb.ScalarField_TimestamptzData:
+		return int64VarintPayload(value.TimestamptzData.GetData())
+	case *schemapb.ScalarField_GeometryWktData:
+		return stringElementsPayload(value.GeometryWktData.GetData())
+	case *schemapb.ScalarField_MolData:
+		return bytesElementsPayload(value.MolData.GetData())
+	case *schemapb.ScalarField_MolSmilesData:
+		return stringElementsPayload(value.MolSmilesData.GetData())
+	case *schemapb.ScalarField_DateData:
+		return int32VarintPayload(value.DateData.GetData())
+	case *schemapb.ScalarField_TimeData:
+		return int64VarintPayload(value.TimeData.GetData())
+	default:
+		return 0
+	}
+}
+
+// arrayMessageSize is the wire size of the array message itself (LongArray,
+// StringArray, ...) sitting inside the ScalarField oneof.
+func (p scalarCellPlan) arrayMessageSize() int {
+	switch p.kind {
+	case scalarCellPacked:
+		if p.payload == 0 {
+			// proto3 omits an empty packed field, leaving an empty message.
+			return 0
+		}
+		return protowire.SizeTag(1) + protowire.SizeBytes(p.payload)
+	case scalarCellRepeated:
+		return p.payload
+	default:
+		return 0
+	}
+}
+
+// scalarCellSize is the cell's full wire size, i.e. what proto.Size returns for
+// the same ScalarField.
+func (p scalarCellPlan) scalarCellSize() int {
+	if p.kind == scalarCellEmpty || p.kind == scalarCellUnsupported {
+		return 0
+	}
+	return protowire.SizeTag(p.oneofNumber) + protowire.SizeBytes(p.arrayMessageSize())
+}
+
+// appendScalarCell writes the ScalarField body -- without the caller's own tag
+// and length prefix -- reproducing proto.Marshal byte for byte. plan must carry
+// the payload measured from this same, unmodified cell.
+func appendScalarCell(w *insertViewWriter, cell *schemapb.ScalarField, plan scalarCellPlan) error {
+	switch plan.kind {
+	case scalarCellEmpty:
+		return nil
+	case scalarCellPacked, scalarCellRepeated:
+	default:
+		return insertViewInternal("array cell is not encodable by the arithmetic path")
+	}
+
+	return w.message(plan.oneofNumber, plan.arrayMessageSize(), func() error {
+		switch value := cell.Data.(type) {
+		case *schemapb.ScalarField_BoolData:
+			return appendPackedCell(w, plan, func(out []byte) []byte {
+				for _, item := range value.BoolData.GetData() {
+					if item {
+						out = append(out, 1)
+					} else {
+						out = append(out, 0)
+					}
+				}
+				return out
+			})
+		case *schemapb.ScalarField_IntData:
+			return appendPackedInt32Cell(w, plan, value.IntData.GetData())
+		case *schemapb.ScalarField_LongData:
+			return appendPackedInt64Cell(w, plan, value.LongData.GetData())
+		case *schemapb.ScalarField_FloatData:
+			return appendPackedCell(w, plan, func(out []byte) []byte {
+				for _, item := range value.FloatData.GetData() {
+					out = protowire.AppendFixed32(out, math.Float32bits(item))
+				}
+				return out
+			})
+		case *schemapb.ScalarField_DoubleData:
+			return appendPackedCell(w, plan, func(out []byte) []byte {
+				for _, item := range value.DoubleData.GetData() {
+					out = protowire.AppendFixed64(out, math.Float64bits(item))
+				}
+				return out
+			})
+		case *schemapb.ScalarField_StringData:
+			return appendStringCell(w, value.StringData.GetData())
+		case *schemapb.ScalarField_BytesData:
+			return appendBytesCell(w, value.BytesData.GetData())
+		case *schemapb.ScalarField_JsonData:
+			return appendBytesCell(w, value.JsonData.GetData())
+		case *schemapb.ScalarField_GeometryData:
+			return appendBytesCell(w, value.GeometryData.GetData())
+		case *schemapb.ScalarField_TimestamptzData:
+			return appendPackedInt64Cell(w, plan, value.TimestamptzData.GetData())
+		case *schemapb.ScalarField_GeometryWktData:
+			return appendStringCell(w, value.GeometryWktData.GetData())
+		case *schemapb.ScalarField_MolData:
+			return appendBytesCell(w, value.MolData.GetData())
+		case *schemapb.ScalarField_MolSmilesData:
+			return appendStringCell(w, value.MolSmilesData.GetData())
+		case *schemapb.ScalarField_DateData:
+			return appendPackedInt32Cell(w, plan, value.DateData.GetData())
+		case *schemapb.ScalarField_TimeData:
+			return appendPackedInt64Cell(w, plan, value.TimeData.GetData())
+		default:
+			return insertViewInternal("array cell oneof %T changed after planning", value)
+		}
+	})
+}
+
+// appendPackedCell writes the packed payload under field 1. appendValues is
+// charged once against the payload size measured during sizing, so it never
+// recomputes a per-value size the way w.varint would.
+func appendPackedCell(w *insertViewWriter, plan scalarCellPlan, appendValues func([]byte) []byte) error {
+	if plan.payload == 0 {
+		return nil
+	}
+	return w.message(1, plan.payload, func() error {
+		w.appendBulk(plan.payload, appendValues)
+		return w.err
+	})
+}
+
+func appendPackedInt32Cell(w *insertViewWriter, plan scalarCellPlan, values []int32) error {
+	return appendPackedCell(w, plan, func(out []byte) []byte {
+		for _, item := range values {
+			out = protowire.AppendVarint(out, uint64(item))
+		}
+		return out
+	})
+}
+
+func appendPackedInt64Cell(w *insertViewWriter, plan scalarCellPlan, values []int64) error {
+	return appendPackedCell(w, plan, func(out []byte) []byte {
+		for _, item := range values {
+			out = protowire.AppendVarint(out, uint64(item))
+		}
+		return out
+	})
+}
+
+// appendStringCell does not rescan UTF-8, matching how the row-selection
+// encoders treat top-level proto3 strings: trusted internal input. proto.Marshal,
+// which used to write these cells, did validate and fail on invalid UTF-8, so an
+// array cell is now accepted where it previously errored -- the same treatment a
+// top-level varchar already got. Validation belongs at the ingest boundary, not
+// in the encoder.
+func appendStringCell(w *insertViewWriter, values []string) error {
+	for _, item := range values {
+		w.stringBytes(1, item)
+	}
+	return w.err
+}
+
+func appendBytesCell(w *insertViewWriter, values [][]byte) error {
+	for _, item := range values {
+		w.bytes(1, item)
+	}
+	return w.err
+}
+
+const scalarCellProtoFallbackPayload = -1
+
+// scalarCellWirePlan is the sizing side's entry point. It returns the exact
+// wire size of one ArrayArray element plus the payload token MarshalTo replays.
+// Non-negative tokens are arithmetic payload sizes; -1 selects protobuf's
+// cached-size fallback so unknown fields remain byte-preserving.
+func scalarCellWirePlan(cell *schemapb.ScalarField) (int, int) {
+	plan, ok := classifyScalarCell(cell)
+	if !ok {
+		return nullableProtoSize(cell, false), scalarCellProtoFallbackPayload
+	}
+	plan.payload = scalarCellPayload(cell, plan)
+	return plan.scalarCellSize(), plan.payload
+}
+
+func int32VarintPayload(values []int32) int {
+	payload := 0
+	for _, item := range values {
+		payload += protowire.SizeVarint(uint64(item))
+	}
+	return payload
+}
+
+func int64VarintPayload(values []int64) int {
+	payload := 0
+	for _, item := range values {
+		payload += protowire.SizeVarint(uint64(item))
+	}
+	return payload
+}
+
+func stringElementsPayload(values []string) int {
+	payload := 0
+	for _, item := range values {
+		payload += protowire.SizeTag(1) + protowire.SizeBytes(len(item))
+	}
+	return payload
+}
+
+func bytesElementsPayload(values [][]byte) int {
+	payload := 0
+	for _, item := range values {
+		payload += protowire.SizeTag(1) + protowire.SizeBytes(len(item))
+	}
+	return payload
+}

--- a/pkg/util/fastpb/insert_request_cell_test.go
+++ b/pkg/util/fastpb/insert_request_cell_test.go
@@ -1,0 +1,417 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fastpb
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+)
+
+// encodeCell runs the arithmetic path end to end and returns the bytes it
+// produces, mirroring how appendArrayArray drives it: classify, measure, then
+// replay the measured payload through the writer.
+func encodeCell(t *testing.T, cell *schemapb.ScalarField) ([]byte, bool) {
+	t.Helper()
+	plan, ok := classifyScalarCell(cell)
+	if !ok {
+		return nil, false
+	}
+	plan.payload = scalarCellPayload(cell, plan)
+
+	size := plan.scalarCellSize()
+	w := newInsertViewMarshalWriter(make([]byte, 0, size), nil)
+	require.NoError(t, appendScalarCell(w, cell, plan))
+	require.NoError(t, w.err)
+	require.Equal(t, size, w.n, "scalarCellSize disagrees with the bytes written")
+	return w.out, true
+}
+
+// assertCellMatchesProto is the core contract: for every cell the arithmetic
+// path claims, its size must equal proto.Size and its bytes must equal
+// proto.Marshal. A mismatch in size corrupts the enclosing length prefix, so
+// this is checked separately from the bytes.
+func assertCellMatchesProto(t *testing.T, cell *schemapb.ScalarField) {
+	t.Helper()
+	got, ok := encodeCell(t, cell)
+	if !ok {
+		t.Skip("cell is not on the arithmetic path")
+	}
+
+	want, err := proto.Marshal(cell)
+	require.NoError(t, err)
+	assert.Equal(t, len(want), len(got), "size mismatch: proto=%d arithmetic=%d", len(want), len(got))
+	assert.Equal(t, want, got, "bytes differ from proto.Marshal")
+
+	// Decoding what we wrote must also reproduce the original message. Equal
+	// byte length with different content would otherwise slip through if both
+	// assertions above were ever relaxed.
+	var round schemapb.ScalarField
+	require.NoError(t, proto.Unmarshal(got, &round))
+	assert.True(t, proto.Equal(cell, &round), "round trip differs: want=%v got=%v", cell, &round)
+}
+
+func TestScalarCell_AllOneofs(t *testing.T) {
+	cells := map[string]*schemapb.ScalarField{
+		"bool": {Data: &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{Data: []bool{true, false, true}}}},
+		"int": {Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{
+			// Negative int32 is sign-extended to a 10-byte varint.
+			Data: []int32{0, 1, -1, math.MaxInt32, math.MinInt32, 127, 128},
+		}}},
+		"long": {Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{
+			Data: []int64{0, 1, -1, math.MaxInt64, math.MinInt64, 127, 128, 16383, 16384},
+		}}},
+		"float": {Data: &schemapb.ScalarField_FloatData{FloatData: &schemapb.FloatArray{
+			Data: []float32{0, -0, 1.5, float32(math.Inf(1)), float32(math.Inf(-1))},
+		}}},
+		"double": {Data: &schemapb.ScalarField_DoubleData{DoubleData: &schemapb.DoubleArray{
+			Data: []float64{0, -0, 1.5, math.Inf(1), math.Inf(-1)},
+		}}},
+		"string": {Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{
+			Data: []string{"", "a", "utf8 ✓ 中文", string(make([]byte, 300))},
+		}}},
+		"bytes": {Data: &schemapb.ScalarField_BytesData{BytesData: &schemapb.BytesArray{
+			Data: [][]byte{nil, {}, {0x00}, make([]byte, 300)},
+		}}},
+		"json": {Data: &schemapb.ScalarField_JsonData{JsonData: &schemapb.JSONArray{
+			Data: [][]byte{[]byte(`{"a":1}`), {}},
+		}}},
+		"geometry": {Data: &schemapb.ScalarField_GeometryData{GeometryData: &schemapb.GeometryArray{
+			Data: [][]byte{{0x01, 0x02}},
+		}}},
+		"timestamptz": {Data: &schemapb.ScalarField_TimestamptzData{TimestamptzData: &schemapb.TimestamptzArray{
+			Data: []int64{0, -1, math.MaxInt64},
+		}}},
+		"geometry_wkt": {Data: &schemapb.ScalarField_GeometryWktData{GeometryWktData: &schemapb.GeometryWktArray{
+			Data: []string{"POINT(1 2)", ""},
+		}}},
+		"mol": {Data: &schemapb.ScalarField_MolData{MolData: &schemapb.MolArray{Data: [][]byte{{0xff}}}}},
+		"mol_smiles": {Data: &schemapb.ScalarField_MolSmilesData{MolSmilesData: &schemapb.MolSmilesArray{
+			Data: []string{"CCO"},
+		}}},
+		"date": {Data: &schemapb.ScalarField_DateData{DateData: &schemapb.DateArray{
+			Data: []int32{0, -1, math.MaxInt32},
+		}}},
+		"time": {Data: &schemapb.ScalarField_TimeData{TimeData: &schemapb.TimeArray{
+			Data: []int64{0, -1, math.MaxInt64},
+		}}},
+	}
+
+	for name, cell := range cells {
+		t.Run(name, func(t *testing.T) {
+			assertCellMatchesProto(t, cell)
+		})
+	}
+}
+
+// TestScalarCell_EmptyArrays pins the proto3 rule the arithmetic path has to
+// reproduce by hand: an empty packed field is omitted entirely, leaving an
+// empty array message, while the oneof itself is still written.
+func TestScalarCell_EmptyArrays(t *testing.T) {
+	cells := map[string]*schemapb.ScalarField{
+		"empty bool":   {Data: &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{}}},
+		"empty long":   {Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{}}},
+		"empty float":  {Data: &schemapb.ScalarField_FloatData{FloatData: &schemapb.FloatArray{}}},
+		"empty string": {Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{}}},
+		"empty bytes":  {Data: &schemapb.ScalarField_BytesData{BytesData: &schemapb.BytesArray{}}},
+		"one empty string": {Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{
+			Data: []string{""},
+		}}},
+		"one empty bytes": {Data: &schemapb.ScalarField_BytesData{BytesData: &schemapb.BytesArray{
+			Data: [][]byte{{}},
+		}}},
+	}
+
+	for name, cell := range cells {
+		t.Run(name, func(t *testing.T) {
+			assertCellMatchesProto(t, cell)
+		})
+	}
+}
+
+func TestScalarCell_NilAndEmptyCell(t *testing.T) {
+	t.Run("nil cell", func(t *testing.T) {
+		plan, ok := classifyScalarCell(nil)
+		require.True(t, ok)
+		assert.Equal(t, scalarCellEmpty, plan.kind)
+		assert.Equal(t, 0, plan.scalarCellSize())
+	})
+
+	t.Run("no oneof set", func(t *testing.T) {
+		cell := &schemapb.ScalarField{}
+		assertCellMatchesProto(t, cell)
+		plan, ok := classifyScalarCell(cell)
+		require.True(t, ok)
+		assert.Equal(t, scalarCellEmpty, plan.kind)
+	})
+}
+
+// TestScalarCell_FallbackCases covers every input the arithmetic path must
+// refuse. Refusing is the safe outcome: the caller keeps using proto.Marshal
+// on both the sizing and the writing side, so the two stay consistent.
+func TestScalarCell_FallbackCases(t *testing.T) {
+	t.Run("unknown fields", func(t *testing.T) {
+		cell := &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+			LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}},
+		}}
+		unknown := protowire.AppendTag(nil, 999, protowire.VarintType)
+		unknown = protowire.AppendVarint(unknown, 7)
+		cell.ProtoReflect().SetUnknown(protoreflect.RawFields(unknown))
+
+		_, ok := classifyScalarCell(cell)
+		assert.False(t, ok, "a cell with unknown fields must not take the arithmetic path")
+	})
+
+	t.Run("packed nested unknown fields", func(t *testing.T) {
+		array := &schemapb.LongArray{Data: []int64{1, 2, 3}}
+		unknown := protowire.AppendTag(nil, 999, protowire.VarintType)
+		unknown = protowire.AppendVarint(unknown, 11)
+		array.ProtoReflect().SetUnknown(protoreflect.RawFields(unknown))
+		cell := &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: array}}
+
+		_, ok := classifyScalarCell(cell)
+		assert.False(t, ok, "a packed nested message with unknown fields must use protobuf")
+	})
+
+	t.Run("repeated nested unknown fields", func(t *testing.T) {
+		array := &schemapb.StringArray{Data: []string{"a", "b"}}
+		unknown := protowire.AppendTag(nil, 998, protowire.BytesType)
+		unknown = protowire.AppendBytes(unknown, []byte("future"))
+		array.ProtoReflect().SetUnknown(protoreflect.RawFields(unknown))
+		cell := &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: array}}
+
+		_, ok := classifyScalarCell(cell)
+		assert.False(t, ok, "a repeated nested message with unknown fields must use protobuf")
+	})
+
+	t.Run("nested array", func(t *testing.T) {
+		cell := &schemapb.ScalarField{Data: &schemapb.ScalarField_ArrayData{
+			ArrayData: &schemapb.ArrayArray{Data: []*schemapb.ScalarField{{}}},
+		}}
+		_, ok := classifyScalarCell(cell)
+		assert.False(t, ok, "nested ArrayData must not take the arithmetic path")
+	})
+
+	t.Run("set but nil array", func(t *testing.T) {
+		cell := &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: nil}}
+		_, ok := classifyScalarCell(cell)
+		assert.False(t, ok, "a set-but-nil oneof wrapper must not take the arithmetic path")
+	})
+}
+
+func TestAppendArrayCell_ReplaysPayloadToken(t *testing.T) {
+	unknown := protowire.AppendTag(nil, 999, protowire.VarintType)
+	unknown = protowire.AppendVarint(unknown, 7)
+	fallbackArray := &schemapb.StringArray{Data: []string{"future"}}
+	fallbackArray.ProtoReflect().SetUnknown(protoreflect.RawFields(unknown))
+
+	for _, tc := range []struct {
+		name  string
+		cell  *schemapb.ScalarField
+		token int
+	}{
+		{
+			name: "arithmetic",
+			cell: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+				LongData: &schemapb.LongArray{Data: []int64{1, 128, -1}},
+			}},
+		},
+		{
+			name: "protobuf fallback",
+			cell: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{
+				StringData: fallbackArray,
+			}},
+			token: scalarCellProtoFallbackPayload,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.token != scalarCellProtoFallbackPayload {
+				plan, ok := classifyScalarCell(tc.cell)
+				require.True(t, ok)
+				tc.token = scalarCellPayload(tc.cell, plan)
+			}
+			want, err := proto.Marshal(&schemapb.ArrayArray{Data: []*schemapb.ScalarField{tc.cell}})
+			require.NoError(t, err)
+
+			w := newInsertViewMarshalWriter(make([]byte, 0, len(want)), nil)
+			require.NoError(t, appendArrayCell(w, tc.cell, tc.token))
+			require.NoError(t, w.err)
+			assert.Equal(t, 0, w.planIndex)
+			assert.Equal(t, want, w.out)
+		})
+	}
+}
+
+// TestScalarCell_InvalidUTF8 pins that an array cell now passes invalid UTF-8
+// through instead of failing. proto.Marshal, the encoder this path replaced,
+// rejects it; the arithmetic encoder treats proto3 strings as trusted internal
+// input, which is what the top-level varchar path already did. The bytes it
+// writes are exactly what proto.Marshal would have produced had it not refused.
+func TestScalarCell_InvalidUTF8(t *testing.T) {
+	for name, invalid := range map[string]string{
+		"bare continuation": string([]byte{0xff, 0xfe}),
+		"truncated":         string([]byte{0xe4, 0xb8}),
+		"surrogate":         string([]byte{0xed, 0xa0, 0x80}),
+		"overlong nul":      string([]byte{0xc0, 0x80}),
+	} {
+		t.Run(name, func(t *testing.T) {
+			cell := &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{
+				StringData: &schemapb.StringArray{Data: []string{invalid}},
+			}}
+
+			_, err := proto.Marshal(cell)
+			require.Error(t, err, "proto.Marshal is expected to reject invalid UTF-8")
+
+			got, ok := encodeCell(t, cell)
+			require.True(t, ok)
+
+			// proto.Unmarshal validates UTF-8 too, so compare against the wire
+			// bytes the official encoder would have emitted:
+			// ScalarField.string_data (6) -> StringArray.data (1) -> raw string.
+			inner := protowire.AppendTag(nil, 1, protowire.BytesType)
+			inner = protowire.AppendString(inner, invalid)
+			want := protowire.AppendTag(nil, 6, protowire.BytesType)
+			want = protowire.AppendBytes(want, inner)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+// TestScalarCell_ValidUTF8Boundaries guards the check above against being
+// tightened by accident: these are all legal and must still encode.
+func TestScalarCell_ValidUTF8Boundaries(t *testing.T) {
+	cell := &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{
+		StringData: &schemapb.StringArray{Data: []string{
+			"",
+			"\x00",
+			"\x7f",
+			"\u0080",
+			"߿",
+			"ࠀ",
+			"￿",
+			"\U0001f600",
+		}},
+	}}
+	assertCellMatchesProto(t, cell)
+}
+
+// TestScalarCell_RandomizedAgainstProto is the broad net: random shapes and
+// values across every supported oneof, each compared byte for byte against the
+// official encoder.
+func TestScalarCell_RandomizedAgainstProto(t *testing.T) {
+	rng := rand.New(rand.NewSource(20260810))
+
+	randInt64 := func() int64 {
+		// Cover every varint width, including the 10-byte negative case.
+		switch rng.Intn(5) {
+		case 0:
+			return 0
+		case 1:
+			return int64(rng.Intn(128))
+		case 2:
+			return int64(rng.Intn(1 << 20))
+		case 3:
+			return -int64(rng.Intn(1 << 20))
+		default:
+			return rng.Int63()
+		}
+	}
+	randBytes := func() []byte {
+		b := make([]byte, rng.Intn(40))
+		rng.Read(b)
+		return b
+	}
+	// proto.Marshal rejects invalid UTF-8 in a string field, so the differential
+	// comparison has to feed it valid text. The arithmetic path's behavior on
+	// invalid UTF-8 is pinned separately in TestScalarCell_InvalidUTF8.
+	randString := func() string {
+		runes := make([]rune, rng.Intn(20))
+		for j := range runes {
+			runes[j] = rune(rng.Intn(0x2FFF-0x20) + 0x20)
+		}
+		return string(runes)
+	}
+
+	for i := 0; i < 2000; i++ {
+		n := rng.Intn(12)
+		var cell *schemapb.ScalarField
+		switch rng.Intn(8) {
+		case 0:
+			data := make([]bool, n)
+			for j := range data {
+				data[j] = rng.Intn(2) == 1
+			}
+			cell = &schemapb.ScalarField{Data: &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{Data: data}}}
+		case 1:
+			data := make([]int32, n)
+			for j := range data {
+				data[j] = int32(randInt64())
+			}
+			cell = &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: data}}}
+		case 2:
+			data := make([]int64, n)
+			for j := range data {
+				data[j] = randInt64()
+			}
+			cell = &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: data}}}
+		case 3:
+			data := make([]float32, n)
+			for j := range data {
+				data[j] = rng.Float32()
+			}
+			cell = &schemapb.ScalarField{Data: &schemapb.ScalarField_FloatData{FloatData: &schemapb.FloatArray{Data: data}}}
+		case 4:
+			data := make([]float64, n)
+			for j := range data {
+				data[j] = rng.Float64()
+			}
+			cell = &schemapb.ScalarField{Data: &schemapb.ScalarField_DoubleData{DoubleData: &schemapb.DoubleArray{Data: data}}}
+		case 5:
+			data := make([]string, n)
+			for j := range data {
+				data[j] = randString()
+			}
+			cell = &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: data}}}
+		case 6:
+			data := make([][]byte, n)
+			for j := range data {
+				data[j] = randBytes()
+			}
+			cell = &schemapb.ScalarField{Data: &schemapb.ScalarField_BytesData{BytesData: &schemapb.BytesArray{Data: data}}}
+		default:
+			data := make([][]byte, n)
+			for j := range data {
+				data[j] = randBytes()
+			}
+			cell = &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{JsonData: &schemapb.JSONArray{Data: data}}}
+		}
+
+		got, ok := encodeCell(t, cell)
+		require.True(t, ok)
+		want, err := proto.Marshal(cell)
+		require.NoError(t, err)
+		require.Equal(t, want, got, "iteration %d: cell=%v", i, cell)
+	}
+}

--- a/pkg/util/fastpb/insert_request_parity_test.go
+++ b/pkg/util/fastpb/insert_request_parity_test.go
@@ -1,0 +1,416 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fastpb
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"math/rand"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+)
+
+// TestInsertRequestViewParity holds every message the cursor produces to the
+// encoding it replaces: decoding it must yield exactly the message that
+// materializing the same rows through AppendFieldData and marshaling it would
+// have produced. It runs the whole corpus of field shapes against several
+// message budgets, so the split boundaries move around and each shape is
+// checked at more than one selection.
+//
+// The two encodings are wire-equivalent, not byte-identical, and the difference
+// is the order fields go out in. Inside a FieldData this encoder writes strictly
+// by field number -- type, field_name, the scalars/vectors oneof, field_id --
+// while Go's marshaler emits a oneof payload after the plain fields that follow
+// it by number, so it writes field_id before the oneof. Both decode to the same
+// InsertRequest, which is the contract a consumer depends on. Do not tighten
+// this to bytes.Equal without reordering the encoder to match.
+//
+// The digest is logged, not asserted. It is there to compare two builds by
+// hand; a golden value would have to be regenerated for changes that are not
+// regressions, such as a new field in the corpus.
+//
+// The corpus deliberately avoids invalid UTF-8, which is the one intentional
+// behavior change: proto.Marshal errors on it, so there would be no oracle to
+// compare against.
+func TestInsertRequestViewParity(t *testing.T) {
+	template := insertViewTemplate()
+	digest := sha256.New()
+	totalMessages := 0
+	totalBytes := 0
+
+	for _, tc := range parityCorpus() {
+		t.Run(tc.name, func(t *testing.T) {
+			// Several budgets so message boundaries land in different
+			// places; 0 means unbounded, which yields a single message.
+			for _, budget := range []int{0, 512, 4 << 10, 64 << 10} {
+				rows := make([]int, int(tc.source.GetNumRows()))
+				for i := range rows {
+					rows[i] = i
+				}
+
+				cursor, err := NewInsertRequestViewCursor(tc.source)
+				require.NoError(t, err)
+				for start := 0; start < len(rows); {
+					encoder, consumed, err := cursor.NextEncoder(template, rows[start:], budget)
+					require.NoError(t, err)
+					size, err := encoder.EncodedSize()
+					require.NoError(t, err)
+					payload := make([]byte, size)
+					written, err := encoder.MarshalTo(payload)
+					require.NoError(t, err)
+					require.Equal(t, size, written)
+
+					var decoded msgpb.InsertRequest
+					require.NoError(t, proto.Unmarshal(payload, &decoded))
+					require.Equal(t, uint64(consumed), decoded.GetNumRows())
+
+					selection := rows[start : start+consumed]
+					expected := materializeWithAppendFieldData(template, tc.source, selection)
+					require.True(t, proto.Equal(expected, &decoded),
+						"encoding drifted from the materialized oracle: budget=%d selection=%v",
+						budget, selection)
+					require.Equal(t, proto.Size(expected), size,
+						"encoded size drifted: budget=%d selection=%v", budget, selection)
+
+					digest.Write(payload)
+					totalMessages++
+					totalBytes += size
+					start += consumed
+				}
+			}
+		})
+	}
+
+	t.Logf("PARITY messages=%d bytes=%d sha256=%s",
+		totalMessages, totalBytes, hex.EncodeToString(digest.Sum(nil)))
+}
+
+type parityCase struct {
+	name   string
+	source *msgpb.InsertRequest
+}
+
+func parityCorpus() []parityCase {
+	rng := rand.New(rand.NewSource(4242))
+	const rowCount = 400
+
+	rowIDs := make([]int64, rowCount)
+	timestamps := make([]uint64, rowCount)
+	for row := range rowIDs {
+		rowIDs[row] = int64(row) * 7
+		timestamps[row] = uint64(row) * 13
+	}
+	base := func(fields ...*schemapb.FieldData) *msgpb.InsertRequest {
+		return &msgpb.InsertRequest{
+			NumRows:    rowCount,
+			RowIDs:     rowIDs,
+			Timestamps: timestamps,
+			FieldsData: fields,
+		}
+	}
+
+	// Array cells with varied element counts and value magnitudes, so the
+	// packed payload hits every varint width including the 10-byte negative.
+	arrayCells := make([]*schemapb.ScalarField, rowCount)
+	stringCells := make([]*schemapb.ScalarField, rowCount)
+	emptyishCells := make([]*schemapb.ScalarField, rowCount)
+	nestedArrayCells := make([]*schemapb.ScalarField, rowCount)
+	for row := range arrayCells {
+		n := rng.Intn(16)
+		values := make([]int64, n)
+		for i := range values {
+			switch rng.Intn(4) {
+			case 0:
+				values[i] = 0
+			case 1:
+				values[i] = int64(rng.Intn(1 << 14))
+			case 2:
+				values[i] = -int64(rng.Intn(1 << 14))
+			default:
+				values[i] = rng.Int63()
+			}
+		}
+		arrayCells[row] = &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+			LongData: &schemapb.LongArray{Data: values},
+		}}
+
+		texts := make([]string, rng.Intn(5))
+		for i := range texts {
+			texts[i] = "cell-" + strconv.Itoa(row) + "-" + strconv.Itoa(i)
+		}
+		stringCells[row] = &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{
+			StringData: &schemapb.StringArray{Data: texts},
+		}}
+
+		// Mix in the empty-array and no-oneof shapes, whose proto3 encoding
+		// the arithmetic path has to reproduce by hand.
+		switch row % 3 {
+		case 0:
+			emptyishCells[row] = &schemapb.ScalarField{}
+		case 1:
+			emptyishCells[row] = &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+				LongData: &schemapb.LongArray{},
+			}}
+		default:
+			emptyishCells[row] = &schemapb.ScalarField{Data: &schemapb.ScalarField_BoolData{
+				BoolData: &schemapb.BoolArray{Data: []bool{row%2 == 0}},
+			}}
+		}
+
+		// Recursive ARRAY support landed after the original encoder branch.
+		// Nested cells deliberately take the protobuf fallback path, which must
+		// still preserve the complete cell while selecting outer rows.
+		nestedArrayCells[row] = &schemapb.ScalarField{Data: &schemapb.ScalarField_ArrayData{
+			ArrayData: &schemapb.ArrayArray{
+				ElementType: schemapb.DataType_Array,
+				Data: []*schemapb.ScalarField{
+					{Data: &schemapb.ScalarField_ArrayData{ArrayData: &schemapb.ArrayArray{
+						ElementType: schemapb.DataType_Int64,
+						Data: []*schemapb.ScalarField{{Data: &schemapb.ScalarField_LongData{
+							LongData: &schemapb.LongArray{Data: []int64{int64(row), int64(-row)}},
+						}}},
+					}}},
+				},
+			},
+		}}
+	}
+
+	longs := make([]int64, rowCount)
+	texts := make([]string, rowCount)
+	blobs := make([][]byte, rowCount)
+	floats := make([]float32, 0, rowCount*4)
+	sparse := make([][]byte, rowCount)
+	valid := make([]bool, rowCount)
+	for row := range longs {
+		longs[row] = rng.Int63() * int64(1-2*(row%2))
+		texts[row] = "row-" + strconv.Itoa(row)
+		blobs[row] = []byte{byte(row), byte(row >> 8)}
+		floats = append(floats, float32(row), 1.5, -2.25, 0)
+		entry := make([]byte, 8*(1+row%3))
+		for i := 0; i < len(entry); i += 8 {
+			entry[i] = byte(i / 8)
+		}
+		sparse[row] = entry
+		valid[row] = row%4 != 0
+	}
+
+	nullableVector := &schemapb.FieldData{
+		Type: schemapb.DataType_FloatVector, FieldId: 400, FieldName: "nullable_vec",
+		ValidData: valid,
+		Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+			Dim: 2,
+			Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{
+				Data: func() []float32 {
+					out := make([]float32, 0, rowCount*2)
+					for row := 0; row < rowCount; row++ {
+						if valid[row] {
+							out = append(out, float32(row), float32(-row))
+						}
+					}
+					return out
+				}(),
+			}},
+		}},
+	}
+	dynamicJSON := scalarField(202, schemapb.DataType_JSON, &schemapb.ScalarField_JsonData{
+		JsonData: &schemapb.JSONArray{Data: blobs},
+	})
+	dynamicJSON.FieldName = "$meta"
+	dynamicJSON.IsDynamic = true
+
+	return []parityCase{
+		{name: "array_int64", source: base(
+			scalarField(100, schemapb.DataType_Array, &schemapb.ScalarField_ArrayData{
+				ArrayData: &schemapb.ArrayArray{Data: arrayCells, ElementType: schemapb.DataType_Int64},
+			}))},
+		{name: "array_varchar", source: base(
+			scalarField(101, schemapb.DataType_Array, &schemapb.ScalarField_ArrayData{
+				ArrayData: &schemapb.ArrayArray{Data: stringCells, ElementType: schemapb.DataType_VarChar},
+			}))},
+		{name: "array_empty_shapes", source: base(
+			scalarField(102, schemapb.DataType_Array, &schemapb.ScalarField_ArrayData{
+				ArrayData: &schemapb.ArrayArray{Data: emptyishCells, ElementType: schemapb.DataType_Bool},
+			}))},
+		{name: "recursively_nested_array", source: base(
+			scalarField(103, schemapb.DataType_Array, &schemapb.ScalarField_ArrayData{
+				ArrayData: &schemapb.ArrayArray{Data: nestedArrayCells, ElementType: schemapb.DataType_Array},
+			}))},
+		{name: "mixed_columns", source: base(
+			scalarField(200, schemapb.DataType_Int64, &schemapb.ScalarField_LongData{
+				LongData: &schemapb.LongArray{Data: longs},
+			}),
+			scalarField(201, schemapb.DataType_VarChar, &schemapb.ScalarField_StringData{
+				StringData: &schemapb.StringArray{Data: texts},
+			}),
+			dynamicJSON,
+			scalarField(203, schemapb.DataType_Array, &schemapb.ScalarField_ArrayData{
+				ArrayData: &schemapb.ArrayArray{Data: arrayCells, ElementType: schemapb.DataType_Int64},
+			}),
+			&schemapb.FieldData{
+				Type: schemapb.DataType_FloatVector, FieldId: 204, FieldName: "vec",
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  4,
+					Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: floats}},
+				}},
+			},
+		)},
+		{name: "array_every_element_type", source: base(arrayFieldsForEveryElementType(rowCount)...)},
+		{name: "sparse_and_nullable_vector", source: base(
+			&schemapb.FieldData{
+				Type: schemapb.DataType_SparseFloatVector, FieldId: 300, FieldName: "sparse",
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Data: &schemapb.VectorField_SparseFloatVector{
+						SparseFloatVector: &schemapb.SparseFloatArray{Contents: sparse},
+					},
+				}},
+			},
+			nullableVector,
+		)},
+	}
+}
+
+// arrayFieldsForEveryElementType builds one array column per supported cell
+// type. The cell-level differential test covers each type against
+// proto.Marshal directly, but only these exercise the full path -- sizing,
+// the enclosing ArrayArray length prefix, and message splitting -- for every
+// element type rather than just the int64 and string ones used elsewhere.
+func arrayFieldsForEveryElementType(rowCount int) []*schemapb.FieldData {
+	cell := func(row int, kind int) *schemapb.ScalarField {
+		// Vary element count per row, including 0, so empty packed payloads
+		// and empty repeated lists both appear.
+		n := row % 4
+		switch kind {
+		case 0:
+			d := make([]bool, n)
+			for i := range d {
+				d[i] = (row+i)%2 == 0
+			}
+			return &schemapb.ScalarField{Data: &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{Data: d}}}
+		case 1:
+			d := make([]int32, n)
+			for i := range d {
+				d[i] = int32(row*3+i) * int32(1-2*(i%2)) // mix signs: negatives are 10-byte varints
+			}
+			return &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: d}}}
+		case 2:
+			d := make([]int64, n)
+			for i := range d {
+				d[i] = int64(row*7+i) * int64(1-2*(i%2))
+			}
+			return &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: d}}}
+		case 3:
+			d := make([]float32, n)
+			for i := range d {
+				d[i] = float32(row) + float32(i)/4
+			}
+			return &schemapb.ScalarField{Data: &schemapb.ScalarField_FloatData{FloatData: &schemapb.FloatArray{Data: d}}}
+		case 4:
+			d := make([]float64, n)
+			for i := range d {
+				d[i] = float64(row) - float64(i)/8
+			}
+			return &schemapb.ScalarField{Data: &schemapb.ScalarField_DoubleData{DoubleData: &schemapb.DoubleArray{Data: d}}}
+		case 5:
+			d := make([]string, n)
+			for i := range d {
+				d[i] = "s" + strconv.Itoa(row) + "_" + strconv.Itoa(i)
+			}
+			return &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: d}}}
+		case 6:
+			d := make([][]byte, n)
+			for i := range d {
+				d[i] = []byte{byte(row), byte(i)}
+			}
+			return &schemapb.ScalarField{Data: &schemapb.ScalarField_BytesData{BytesData: &schemapb.BytesArray{Data: d}}}
+		case 7:
+			d := make([][]byte, n)
+			for i := range d {
+				d[i] = []byte(`{"r":` + strconv.Itoa(row) + `}`)
+			}
+			return &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{JsonData: &schemapb.JSONArray{Data: d}}}
+		case 8:
+			d := make([][]byte, n)
+			for i := range d {
+				d[i] = []byte{0x01, byte(row), byte(i)}
+			}
+			return &schemapb.ScalarField{Data: &schemapb.ScalarField_GeometryData{GeometryData: &schemapb.GeometryArray{Data: d}}}
+		case 9:
+			d := make([]int64, n)
+			for i := range d {
+				d[i] = int64(row)*1_000_000 + int64(i)
+			}
+			return &schemapb.ScalarField{Data: &schemapb.ScalarField_TimestamptzData{TimestamptzData: &schemapb.TimestamptzArray{Data: d}}}
+		case 10:
+			d := make([]string, n)
+			for i := range d {
+				d[i] = "POINT(" + strconv.Itoa(row) + " " + strconv.Itoa(i) + ")"
+			}
+			return &schemapb.ScalarField{Data: &schemapb.ScalarField_GeometryWktData{GeometryWktData: &schemapb.GeometryWktArray{Data: d}}}
+		case 11:
+			d := make([][]byte, n)
+			for i := range d {
+				d[i] = []byte{0xde, byte(row), byte(i)}
+			}
+			return &schemapb.ScalarField{Data: &schemapb.ScalarField_MolData{MolData: &schemapb.MolArray{Data: d}}}
+		case 12:
+			d := make([]string, n)
+			for i := range d {
+				d[i] = "CC" + strconv.Itoa(row%9) + "O"
+			}
+			return &schemapb.ScalarField{Data: &schemapb.ScalarField_MolSmilesData{MolSmilesData: &schemapb.MolSmilesArray{Data: d}}}
+		case 13:
+			d := make([]int32, n)
+			for i := range d {
+				d[i] = int32(row*17 + i)
+			}
+			return &schemapb.ScalarField{Data: &schemapb.ScalarField_DateData{DateData: &schemapb.DateArray{Data: d}}}
+		default:
+			d := make([]int64, n)
+			for i := range d {
+				d[i] = int64(row*31+i) * int64(1-2*(i%2))
+			}
+			return &schemapb.ScalarField{Data: &schemapb.ScalarField_TimeData{TimeData: &schemapb.TimeArray{Data: d}}}
+		}
+	}
+
+	elementTypes := []schemapb.DataType{
+		schemapb.DataType_Bool, schemapb.DataType_Int32, schemapb.DataType_Int64,
+		schemapb.DataType_Float, schemapb.DataType_Double, schemapb.DataType_VarChar,
+		schemapb.DataType_String, schemapb.DataType_JSON, schemapb.DataType_Geometry,
+		schemapb.DataType_Timestamptz, schemapb.DataType_Geometry, schemapb.DataType_Mol,
+		schemapb.DataType_Mol, schemapb.DataType_Date, schemapb.DataType_Time,
+	}
+
+	fields := make([]*schemapb.FieldData, 0, len(elementTypes))
+	for kind, elementType := range elementTypes {
+		cells := make([]*schemapb.ScalarField, rowCount)
+		for row := range cells {
+			cells[row] = cell(row, kind)
+		}
+		fields = append(fields, scalarField(int64(500+kind), schemapb.DataType_Array,
+			&schemapb.ScalarField_ArrayData{ArrayData: &schemapb.ArrayArray{
+				Data: cells, ElementType: elementType,
+			}}))
+	}
+	return fields
+}

--- a/pkg/util/fastpb/insert_request_plan.go
+++ b/pkg/util/fastpb/insert_request_plan.go
@@ -1,0 +1,1926 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fastpb
+
+import (
+	"math"
+
+	"google.golang.org/protobuf/encoding/protowire"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+)
+
+type insertFieldPlanClass uint8
+
+const (
+	insertFieldPlanNone insertFieldPlanClass = iota
+	insertFieldPlanScalar
+	insertFieldPlanVector
+)
+
+type insertFieldValuePlan uint8
+
+const (
+	insertFieldValueNone insertFieldValuePlan = iota
+	insertFieldValueScalarEmpty
+	insertFieldValueScalarPacked
+	insertFieldValueScalarRepeated
+	insertFieldValueScalarArray
+	insertFieldValueVectorEmpty
+	insertFieldValueVectorDenseBytes
+	insertFieldValueVectorFloat
+	insertFieldValueVectorSparse
+	insertFieldValueVectorArray
+)
+
+// insertFieldSizeState keeps aggregate protobuf payload sizes and the ordinal
+// of an ARRAY/ArrayOfVector field in the request-level row-major token arena.
+// It never owns row data. Aggregate sizes are flattened into the replay plan;
+// nested-cell tokens remain cursor scratch borrowed during MarshalTo.
+type insertFieldSizeState struct {
+	field            *schemapb.FieldData
+	class            insertFieldPlanClass
+	valuePlan        insertFieldValuePlan
+	valueFieldNumber protowire.Number
+	metadataSize     int
+	payloadSize      int
+	wireSize         int
+	previewWireSize  int
+	selectedRows     int
+	sparseDim        int64
+	stride           int
+	payloadStride    int
+	compactVector    bool
+	arrayOrdinal     int
+	validData        []bool
+}
+
+// insertFieldValidData resolves the row-validity mask with the same precedence
+// typeutil.GetFieldDataValidData uses: the legacy FieldData location first,
+// else the field-specific ScalarField/VectorField location #52203 moved it to.
+func insertFieldValidData(field *schemapb.FieldData) []bool {
+	if legacy := field.GetValidData(); len(legacy) > 0 {
+		return legacy
+	}
+	if scalars := field.GetScalars(); scalars != nil {
+		return scalars.GetValidData()
+	}
+	return field.GetVectors().GetValidData()
+}
+
+type insertFieldRowDelta struct {
+	payloadSize      int
+	selectedRows     int
+	sparseDim        int64
+	arrayCellPayload int
+}
+
+type insertFieldComputedSize struct {
+	fieldSize    int
+	nestedSize   int
+	payloadSize  int
+	selectedRows int
+	sparseDim    int
+}
+
+type vectorArrayCellPlanKind uint8
+
+const (
+	vectorArrayCellPlanEmpty vectorArrayCellPlanKind = iota
+	vectorArrayCellPlanFloat
+	vectorArrayCellProtoFallback = -1
+)
+
+type vectorArrayCellPlan struct {
+	kind           vectorArrayCellPlanKind
+	payloadSize    int
+	floatArraySize int
+	cellSize       int
+}
+
+type insertRequestSizeState struct {
+	template                 *msgpb.InsertRequest
+	source                   *msgpb.InsertRequest
+	fixedSize                int
+	rowCount                 int
+	timestampPayload         int
+	timestampWireSize        int
+	previewTimestampWireSize int
+	rowIDPayload             int
+	rowIDWireSize            int
+	previewRowIDWireSize     int
+	numRowsWireSize          int
+	previewNumRowsWireSize   int
+	encodedSize              int
+	fields                   []insertFieldSizeState
+	rowDeltas                []insertFieldRowDelta
+	aggregateDeltas          []insertFieldRowDelta
+	aggregateCheckpoint      []insertFieldRowDelta
+	arrayCellPayloads        []int
+	arrayFieldCount          int
+}
+
+func (s *insertRequestSizeState) reset(template, source *msgpb.InsertRequest, selectedRowCapacity int) error {
+	if template == nil {
+		return insertViewInternal("nil output template")
+	}
+	if source == nil {
+		return insertViewInternal("nil source request")
+	}
+	if len(source.GetRowData()) != 0 {
+		return insertViewInternal("row-based InsertRequest is not supported")
+	}
+
+	fixedSize, err := insertRequestFixedSize(template)
+	if err != nil {
+		return err
+	}
+	arrayCellPayloads := s.arrayCellPayloads[:0]
+	s.arrayFieldCount = 0
+	fieldCount := len(source.GetFieldsData())
+	if cap(s.fields) < fieldCount {
+		s.fields = make([]insertFieldSizeState, fieldCount)
+	} else {
+		s.fields = s.fields[:fieldCount]
+	}
+	if cap(s.rowDeltas) < fieldCount {
+		s.rowDeltas = make([]insertFieldRowDelta, fieldCount)
+	} else {
+		s.rowDeltas = s.rowDeltas[:fieldCount]
+		clear(s.rowDeltas)
+	}
+	if cap(s.aggregateDeltas) < fieldCount {
+		s.aggregateDeltas = make([]insertFieldRowDelta, fieldCount)
+		s.aggregateCheckpoint = make([]insertFieldRowDelta, fieldCount)
+	} else {
+		s.aggregateDeltas = s.aggregateDeltas[:fieldCount]
+		s.aggregateCheckpoint = s.aggregateCheckpoint[:fieldCount]
+		clear(s.aggregateDeltas)
+		clear(s.aggregateCheckpoint)
+	}
+	for i, field := range source.GetFieldsData() {
+		if err := s.fields[i].reset(field); err != nil {
+			return err
+		}
+		if s.fields[i].valuePlan == insertFieldValueScalarArray || s.fields[i].valuePlan == insertFieldValueVectorArray {
+			s.fields[i].arrayOrdinal = s.arrayFieldCount
+			s.arrayFieldCount++
+		}
+	}
+	if s.arrayFieldCount > 0 {
+		expectedPayloads, err := checkedProduct(selectedRowCapacity, s.arrayFieldCount, "nested cell payload scratch")
+		if err != nil {
+			return err
+		}
+		const maxPreallocatedCellPayloads = 1 << 20
+		if expectedPayloads <= maxPreallocatedCellPayloads && cap(arrayCellPayloads) < expectedPayloads {
+			arrayCellPayloads = make([]int, 0, expectedPayloads)
+		}
+	}
+
+	s.template = template
+	s.source = source
+	s.fixedSize = fixedSize
+	s.rowCount = 0
+	s.timestampPayload = 0
+	s.timestampWireSize = 0
+	s.previewTimestampWireSize = 0
+	s.rowIDPayload = 0
+	s.rowIDWireSize = 0
+	s.previewRowIDWireSize = 0
+	s.numRowsWireSize = 0
+	s.previewNumRowsWireSize = 0
+	s.encodedSize = fixedSize
+	s.arrayCellPayloads = arrayCellPayloads
+	return nil
+}
+
+func (s *insertRequestSizeState) previewRow(row int, fieldDataIndices []int64) (int, error) {
+	if err := s.validateRow(row); err != nil {
+		return 0, err
+	}
+	if len(fieldDataIndices) != len(s.fields) {
+		return 0, insertViewInternal("field data index count %d does not match FieldsData count %d", len(fieldDataIndices), len(s.fields))
+	}
+
+	clear(s.rowDeltas)
+	for i := range s.fields {
+		dataIndex := fieldDataIndices[i]
+		if dataIndex < 0 || uint64(dataIndex) > uint64(math.MaxInt) {
+			return 0, insertViewInternal("field data index %d for field %d is invalid", dataIndex, i)
+		}
+		if err := s.fields[i].previewRow(row, int(dataIndex), &s.rowDeltas[i]); err != nil {
+			return 0, err
+		}
+	}
+	return s.previewSize(row, s.rowDeltas)
+}
+
+func (s *insertRequestSizeState) previewCachedRow(row int, deltas []insertFieldRowDelta) (int, error) {
+	if err := s.validateRow(row); err != nil {
+		return 0, err
+	}
+	if len(deltas) != len(s.fields) {
+		return 0, insertViewInternal("cached row delta count %d does not match FieldsData count %d", len(deltas), len(s.fields))
+	}
+	copy(s.rowDeltas, deltas)
+	return s.previewSize(row, s.rowDeltas)
+}
+
+func (s *insertRequestSizeState) validateRow(row int) error {
+	if row < 0 {
+		return insertViewInternal("row offset is negative: %d", row)
+	}
+	if row >= len(s.source.GetRowIDs()) {
+		return insertViewInternal("row offset %d exceeds RowIDs length %d", row, len(s.source.GetRowIDs()))
+	}
+	if row >= len(s.source.GetTimestamps()) {
+		return insertViewInternal("row offset %d exceeds Timestamps length %d", row, len(s.source.GetTimestamps()))
+	}
+	if s.source.GetNumRows() != 0 && uint64(row) >= s.source.GetNumRows() {
+		return insertViewInternal("row offset %d exceeds source NumRows %d", row, s.source.GetNumRows())
+	}
+	return nil
+}
+
+// aggregateSimpleRows commits a simple prefix using either a fixed-width upper
+// bound or exact block sizing for variable-width payloads. The remaining
+// boundary rows still use exact incremental sizing.
+func (s *insertRequestSizeState) aggregateSimpleRows(rows []int, previous, sizeLimit int) (int, error) {
+	boundedVariableWidth := false
+	for i := range s.fields {
+		field := &s.fields[i]
+		if sizeLimit > 0 && (field.valuePlan == insertFieldValueScalarRepeated ||
+			field.valuePlan == insertFieldValueVectorSparse) {
+			boundedVariableWidth = true
+		}
+		if field.class == insertFieldPlanNone {
+			continue
+		}
+		if field.class == insertFieldPlanScalar &&
+			(field.valuePlan == insertFieldValueScalarEmpty || field.valuePlan == insertFieldValueScalarPacked ||
+				field.valuePlan == insertFieldValueScalarRepeated) {
+			continue
+		}
+		if field.class == insertFieldPlanVector && !field.compactVector &&
+			(field.valuePlan == insertFieldValueVectorEmpty || field.valuePlan == insertFieldValueVectorDenseBytes ||
+				field.valuePlan == insertFieldValueVectorFloat || field.valuePlan == insertFieldValueVectorSparse) {
+			continue
+		}
+		return 0, nil
+	}
+
+	prefixCount := len(rows)
+	preparedVariableWidth := false
+	preparedTimestampPayload := 0
+	preparedRowIDPayload := 0
+	if sizeLimit > 0 {
+		if boundedVariableWidth {
+			var err error
+			prefixCount, preparedTimestampPayload, preparedRowIDPayload, err = s.boundedVariableSimplePrefix(rows, previous, sizeLimit)
+			if err != nil {
+				return 0, err
+			}
+			preparedVariableWidth = true
+		} else {
+			low, high := 0, len(rows)
+			for low < high {
+				middle := low + (high-low+1)/2
+				upperBound, err := s.simpleRowsUpperBound(middle)
+				if err != nil {
+					return 0, err
+				}
+				if upperBound < sizeLimit {
+					low = middle
+				} else {
+					high = middle - 1
+				}
+			}
+			prefixCount = low
+		}
+	}
+	if prefixCount == 0 {
+		return 0, nil
+	}
+	selected := rows[:prefixCount]
+
+	for i, row := range selected {
+		if row < 0 {
+			return 0, insertViewInternal("row offset at selection index %d is negative: %d", i, row)
+		}
+		if row <= previous {
+			return 0, insertViewInternal("cursor row offsets must be globally increasing: rows[%d]=%d after %d", i, row, previous)
+		}
+		if err := s.validateRow(row); err != nil {
+			return 0, err
+		}
+		previous = row
+	}
+
+	rowCount := len(selected)
+	if _, err := checkedProduct(rowCount, 10, "timestamp payload upper bound"); err != nil {
+		return 0, err
+	}
+	timestampPayload := preparedTimestampPayload
+	rowIDPayload := preparedRowIDPayload
+	if !preparedVariableWidth {
+		for _, row := range selected {
+			timestampPayload += protowire.SizeVarint(s.source.GetTimestamps()[row])
+			rowIDPayload += protowire.SizeVarint(uint64(s.source.GetRowIDs()[row]))
+		}
+	}
+
+	total := s.fixedSize
+	timestampWireSize, err := insertBytesFieldSize(10, timestampPayload)
+	if err != nil {
+		return 0, err
+	}
+	total, err = checkedAddSize(total, timestampWireSize, "insert request size")
+	if err != nil {
+		return 0, err
+	}
+	rowIDWireSize, err := insertBytesFieldSize(11, rowIDPayload)
+	if err != nil {
+		return 0, err
+	}
+	total, err = checkedAddSize(total, rowIDWireSize, "insert request size")
+	if err != nil {
+		return 0, err
+	}
+
+	for i := range s.fields {
+		field := &s.fields[i]
+		payloadSize, selectedRows, sparseDim := 0, 0, int64(0)
+		if preparedVariableWidth {
+			payloadSize = s.aggregateDeltas[i].payloadSize
+			selectedRows = s.aggregateDeltas[i].selectedRows
+			sparseDim = s.aggregateDeltas[i].sparseDim
+		} else {
+			var err error
+			payloadSize, selectedRows, sparseDim, err = field.aggregateSimplePayload(selected)
+			if err != nil {
+				return 0, err
+			}
+		}
+		field.payloadSize = payloadSize
+		field.selectedRows = selectedRows
+		field.sparseDim = sparseDim
+		computed, err := field.computedSize(nil, rowCount)
+		if err != nil {
+			return 0, err
+		}
+		fieldWireSize, err := insertBytesFieldSize(13, computed.fieldSize)
+		if err != nil {
+			return 0, err
+		}
+		field.wireSize = fieldWireSize
+		field.previewWireSize = fieldWireSize
+		total, err = checkedAddSize(total, fieldWireSize, "insert request size")
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	numRowsWireSize := insertProto3VarintFieldSize(14, uint64(rowCount))
+	total, err = checkedAddSize(total, numRowsWireSize, "insert request size")
+	if err != nil {
+		return 0, err
+	}
+
+	s.rowCount = rowCount
+	s.timestampPayload = timestampPayload
+	s.timestampWireSize = timestampWireSize
+	s.previewTimestampWireSize = timestampWireSize
+	s.rowIDPayload = rowIDPayload
+	s.rowIDWireSize = rowIDWireSize
+	s.previewRowIDWireSize = rowIDWireSize
+	s.numRowsWireSize = numRowsWireSize
+	s.previewNumRowsWireSize = numRowsWireSize
+	s.encodedSize = total
+	return prefixCount, nil
+}
+
+// boundedVariableSimplePrefix finds the exact bounded prefix in a single
+// forward pass. It checks size once per block and only replays the block that
+// crosses the limit, so repeated scalar and sparse multi-packet splitting is
+// O(N) instead of rescanning every remaining suffix.
+func (s *insertRequestSizeState) boundedVariableSimplePrefix(rows []int, previous, sizeLimit int) (int, int, int, error) {
+	const blockRows = 64
+	clear(s.aggregateDeltas)
+	timestampPayload := 0
+	rowIDPayload := 0
+
+	for blockStart := 0; blockStart < len(rows); blockStart += blockRows {
+		blockEnd := min(blockStart+blockRows, len(rows))
+		copy(s.aggregateCheckpoint, s.aggregateDeltas)
+		checkpointTimestampPayload := timestampPayload
+		checkpointRowIDPayload := rowIDPayload
+		checkpointPrevious := previous
+
+		for rowIndex := blockStart; rowIndex < blockEnd; rowIndex++ {
+			var err error
+			timestampPayload, rowIDPayload, previous, err = s.accumulateSimpleRow(
+				rows[rowIndex], rowIndex, previous, timestampPayload, rowIDPayload, s.aggregateDeltas,
+			)
+			if err != nil {
+				return 0, 0, 0, err
+			}
+		}
+		encodedSize, err := s.simpleAggregateSize(blockEnd, timestampPayload, rowIDPayload, s.aggregateDeltas)
+		if err != nil {
+			return 0, 0, 0, err
+		}
+		if encodedSize < sizeLimit {
+			continue
+		}
+
+		copy(s.aggregateDeltas, s.aggregateCheckpoint)
+		timestampPayload = checkpointTimestampPayload
+		rowIDPayload = checkpointRowIDPayload
+		previous = checkpointPrevious
+		for rowIndex := blockStart; rowIndex < blockEnd; rowIndex++ {
+			copy(s.aggregateCheckpoint, s.aggregateDeltas)
+			checkpointTimestampPayload = timestampPayload
+			checkpointRowIDPayload = rowIDPayload
+			timestampPayload, rowIDPayload, previous, err = s.accumulateSimpleRow(
+				rows[rowIndex], rowIndex, previous, timestampPayload, rowIDPayload, s.aggregateDeltas,
+			)
+			if err != nil {
+				return 0, 0, 0, err
+			}
+			encodedSize, err = s.simpleAggregateSize(rowIndex+1, timestampPayload, rowIDPayload, s.aggregateDeltas)
+			if err != nil {
+				return 0, 0, 0, err
+			}
+			if encodedSize >= sizeLimit {
+				if rowIndex == 0 {
+					return 1, timestampPayload, rowIDPayload, nil
+				}
+				copy(s.aggregateDeltas, s.aggregateCheckpoint)
+				return rowIndex, checkpointTimestampPayload, checkpointRowIDPayload, nil
+			}
+		}
+	}
+	return len(rows), timestampPayload, rowIDPayload, nil
+}
+
+func (s *insertRequestSizeState) accumulateSimpleRow(
+	row, selectionIndex, previous, timestampPayload, rowIDPayload int,
+	deltas []insertFieldRowDelta,
+) (int, int, int, error) {
+	if row < 0 {
+		return 0, 0, previous, insertViewInternal("row offset at selection index %d is negative: %d", selectionIndex, row)
+	}
+	if row <= previous {
+		return 0, 0, previous, insertViewInternal("cursor row offsets must be globally increasing: rows[%d]=%d after %d", selectionIndex, row, previous)
+	}
+	if err := s.validateRow(row); err != nil {
+		return 0, 0, previous, err
+	}
+
+	var err error
+	timestampPayload, err = checkedAddSize(timestampPayload, protowire.SizeVarint(s.source.GetTimestamps()[row]), "timestamp payload")
+	if err != nil {
+		return 0, 0, previous, err
+	}
+	rowIDPayload, err = checkedAddSize(rowIDPayload, protowire.SizeVarint(uint64(s.source.GetRowIDs()[row])), "row ID payload")
+	if err != nil {
+		return 0, 0, previous, err
+	}
+
+	clear(s.rowDeltas)
+	for i := range s.fields {
+		if err := s.fields[i].previewRow(row, row, &s.rowDeltas[i]); err != nil {
+			return 0, 0, previous, err
+		}
+		deltas[i].payloadSize, err = checkedAddSize(deltas[i].payloadSize, s.rowDeltas[i].payloadSize, "simple field payload")
+		if err != nil {
+			return 0, 0, previous, err
+		}
+		deltas[i].selectedRows, err = checkedAddSize(deltas[i].selectedRows, s.rowDeltas[i].selectedRows, "simple field selected rows")
+		if err != nil {
+			return 0, 0, previous, err
+		}
+		if s.rowDeltas[i].sparseDim > deltas[i].sparseDim {
+			deltas[i].sparseDim = s.rowDeltas[i].sparseDim
+		}
+	}
+	return timestampPayload, rowIDPayload, row, nil
+}
+
+func (s *insertRequestSizeState) simpleAggregateSize(
+	rowCount, timestampPayload, rowIDPayload int,
+	deltas []insertFieldRowDelta,
+) (int, error) {
+	total := s.fixedSize
+	for _, wireSize := range []uint64{
+		directBytesFieldSize(10, uint64(timestampPayload)),
+		directBytesFieldSize(11, uint64(rowIDPayload)),
+	} {
+		if wireSize > uint64(math.MaxInt) {
+			return 0, insertViewInternal("insert request packed column exceeds addressable memory")
+		}
+		var err error
+		total, err = checkedAddSize(total, int(wireSize), "insert request size")
+		if err != nil {
+			return 0, err
+		}
+	}
+	for i := range s.fields {
+		wireSize, direct, err := s.fields[i].directWireSize(&deltas[i], rowCount)
+		if err != nil {
+			return 0, err
+		}
+		if !direct {
+			return 0, insertViewInternal("field %q (%d) lost simple direct sizing", s.fields[i].field.GetFieldName(), s.fields[i].field.GetFieldId())
+		}
+		total, err = checkedAddSize(total, wireSize, "insert request size")
+		if err != nil {
+			return 0, err
+		}
+	}
+	numRowsWireSize := directProto3VarintFieldSize(14, uint64(rowCount))
+	if numRowsWireSize > uint64(math.MaxInt) {
+		return 0, insertViewInternal("NumRows field exceeds addressable memory")
+	}
+	return checkedAddSize(total, int(numRowsWireSize), "insert request size")
+}
+
+func (s *insertRequestSizeState) simpleRowsUpperBound(rowCount int) (int, error) {
+	packedPayload, err := checkedProduct(rowCount, 10, "packed request column upper bound")
+	if err != nil {
+		return 0, err
+	}
+	total := s.fixedSize
+	for _, number := range []protowire.Number{10, 11} {
+		wireSize, err := insertBytesFieldSize(number, packedPayload)
+		if err != nil {
+			return 0, err
+		}
+		total, err = checkedAddSize(total, wireSize, "insert request size upper bound")
+		if err != nil {
+			return 0, err
+		}
+	}
+	for i := range s.fields {
+		field := &s.fields[i]
+		maxPayload, selectedRows, sparseDim, err := field.simplePayloadUpperBound(rowCount)
+		if err != nil {
+			return 0, err
+		}
+		computed, err := field.computedSize(&insertFieldRowDelta{payloadSize: maxPayload, selectedRows: selectedRows, sparseDim: sparseDim}, rowCount)
+		if err != nil {
+			return 0, err
+		}
+		wireSize, err := insertBytesFieldSize(13, computed.fieldSize)
+		if err != nil {
+			return 0, err
+		}
+		total, err = checkedAddSize(total, wireSize, "insert request size upper bound")
+		if err != nil {
+			return 0, err
+		}
+	}
+	return checkedAddSize(total, insertProto3VarintFieldSize(14, uint64(rowCount)), "insert request size upper bound")
+}
+
+func (s *insertRequestSizeState) previewSize(row int, deltas []insertFieldRowDelta) (int, error) {
+	newRowCount := s.rowCount + 1
+	timestampPayload, err := checkedAddSize(s.timestampPayload, protowire.SizeVarint(s.source.GetTimestamps()[row]), "timestamp payload")
+	if err != nil {
+		return 0, err
+	}
+	rowIDPayload, err := checkedAddSize(s.rowIDPayload, protowire.SizeVarint(uint64(s.source.GetRowIDs()[row])), "row ID payload")
+	if err != nil {
+		return 0, err
+	}
+
+	timestampWireSize, err := insertBytesFieldSize(10, timestampPayload)
+	if err != nil {
+		return 0, err
+	}
+	if timestampWireSize < s.timestampWireSize {
+		return 0, insertViewInternal("timestamp wire size shrank from %d to %d", s.timestampWireSize, timestampWireSize)
+	}
+	wireDelta := uint64(timestampWireSize - s.timestampWireSize)
+	rowIDWireSize, err := insertBytesFieldSize(11, rowIDPayload)
+	if err != nil {
+		return 0, err
+	}
+	if rowIDWireSize < s.rowIDWireSize {
+		return 0, insertViewInternal("row ID wire size shrank from %d to %d", s.rowIDWireSize, rowIDWireSize)
+	}
+	wireDelta += uint64(rowIDWireSize - s.rowIDWireSize)
+
+	for i := range s.fields {
+		fieldWireSize, direct, err := s.fields[i].directWireSize(&deltas[i], newRowCount)
+		if err != nil {
+			return 0, err
+		}
+		if !direct {
+			computed, err := s.fields[i].computedSize(&deltas[i], newRowCount)
+			if err != nil {
+				return 0, err
+			}
+			fieldWireSize, err = insertBytesFieldSize(13, computed.fieldSize)
+			if err != nil {
+				return 0, err
+			}
+		}
+		s.fields[i].previewWireSize = fieldWireSize
+		if fieldWireSize < s.fields[i].wireSize {
+			return 0, insertViewInternal("field %d wire size shrank from %d to %d", i, s.fields[i].wireSize, fieldWireSize)
+		}
+		fieldDelta := uint64(fieldWireSize - s.fields[i].wireSize)
+		if wireDelta > math.MaxUint64-fieldDelta {
+			return 0, insertViewInternal("insert request wire-size delta exceeds addressable memory")
+		}
+		wireDelta += fieldDelta
+	}
+
+	numRowsWireSize := insertProto3VarintFieldSize(14, uint64(newRowCount))
+	if numRowsWireSize < s.numRowsWireSize {
+		return 0, insertViewInternal("NumRows wire size shrank from %d to %d", s.numRowsWireSize, numRowsWireSize)
+	}
+	numRowsDelta := uint64(numRowsWireSize - s.numRowsWireSize)
+	if wireDelta > math.MaxUint64-numRowsDelta || wireDelta+numRowsDelta > uint64(math.MaxInt-s.encodedSize) {
+		return 0, insertViewInternal("insert request size exceeds addressable memory")
+	}
+	total := s.encodedSize + int(wireDelta+numRowsDelta)
+	s.previewTimestampWireSize = timestampWireSize
+	s.previewRowIDWireSize = rowIDWireSize
+	s.previewNumRowsWireSize = numRowsWireSize
+	return total, nil
+}
+
+func (s *insertRequestSizeState) commitRow(row, encodedSize int) {
+	s.rowCount++
+	s.timestampPayload += protowire.SizeVarint(s.source.GetTimestamps()[row])
+	s.timestampWireSize = s.previewTimestampWireSize
+	s.rowIDPayload += protowire.SizeVarint(uint64(s.source.GetRowIDs()[row]))
+	s.rowIDWireSize = s.previewRowIDWireSize
+	s.numRowsWireSize = s.previewNumRowsWireSize
+	for i := range s.fields {
+		s.fields[i].commit(s.rowDeltas[i], s.fields[i].previewWireSize)
+		if s.fields[i].arrayOrdinal >= 0 {
+			s.arrayCellPayloads = append(s.arrayCellPayloads, s.rowDeltas[i].arrayCellPayload)
+		}
+	}
+	s.encodedSize = encodedSize
+}
+
+func (s *insertRequestSizeState) buildPlan(plan []int) ([]int, int, error) {
+	if s.rowCount == 0 {
+		return nil, 0, insertViewInternal("cannot finalize an empty insert request view")
+	}
+	expectedArrayCellPayloads, err := checkedProduct(s.rowCount, s.arrayFieldCount, "array cell payload plan")
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(s.arrayCellPayloads) != expectedArrayCellPayloads {
+		return nil, 0, insertViewInternal("array cell payload plan has %d entries, expected %d", len(s.arrayCellPayloads), expectedArrayCellPayloads)
+	}
+	plan = prepareSizePlan(plan, len(s.fields))
+	plan = append(plan, s.timestampPayload, s.rowIDPayload)
+
+	total := s.fixedSize
+	timestampSize, err := insertBytesFieldSize(10, s.timestampPayload)
+	if err != nil {
+		return nil, 0, err
+	}
+	total, err = checkedAddSize(total, timestampSize, "insert request size")
+	if err != nil {
+		return nil, 0, err
+	}
+	rowIDSize, err := insertBytesFieldSize(11, s.rowIDPayload)
+	if err != nil {
+		return nil, 0, err
+	}
+	total, err = checkedAddSize(total, rowIDSize, "insert request size")
+	if err != nil {
+		return nil, 0, err
+	}
+
+	for i := range s.fields {
+		computed, err := s.fields[i].computedSize(nil, s.rowCount)
+		if err != nil {
+			return nil, 0, err
+		}
+		plan = s.fields[i].appendPlan(plan, computed, s.rowCount)
+		fieldWireSize, err := insertBytesFieldSize(13, computed.fieldSize)
+		if err != nil {
+			return nil, 0, err
+		}
+		total, err = checkedAddSize(total, fieldWireSize, "insert request size")
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+	total, err = checkedAddSize(total, insertProto3VarintFieldSize(14, uint64(s.rowCount)), "insert request size")
+	if err != nil {
+		return nil, 0, err
+	}
+	if total != s.encodedSize {
+		return nil, 0, insertViewInternal("incremental encoded size changed during finalization: previewed %d, finalized %d", s.encodedSize, total)
+	}
+	return plan, total, nil
+}
+
+func (s *insertFieldSizeState) reset(field *schemapb.FieldData) error {
+	*s = insertFieldSizeState{
+		field:        field,
+		arrayOrdinal: -1,
+	}
+	if field == nil {
+		return insertViewInternal("source FieldsData contains nil field")
+	}
+	if field.GetStructArrays() != nil {
+		return insertViewInternal("source field %q (%d) still contains StructArrays; proxy must flatten struct fields before repacking", field.GetFieldName(), field.GetFieldId())
+	}
+
+	metadataSize, err := insertFieldMetadataSize(field)
+	if err != nil {
+		return err
+	}
+	s.metadataSize = metadataSize
+	s.validData = insertFieldValidData(field)
+	switch value := field.Field.(type) {
+	case nil:
+		s.class = insertFieldPlanNone
+		return nil
+	case *schemapb.FieldData_Scalars:
+		if value.Scalars == nil {
+			return insertViewInternal("scalar field %q (%d) has a nil ScalarField", field.GetFieldName(), field.GetFieldId())
+		}
+		s.class = insertFieldPlanScalar
+		return s.resetScalar(value.Scalars)
+	case *schemapb.FieldData_Vectors:
+		if value.Vectors == nil {
+			return insertViewInternal("vector field %q (%d) has a nil VectorField", field.GetFieldName(), field.GetFieldId())
+		}
+		s.class = insertFieldPlanVector
+		if err := s.resetVector(value.Vectors); err != nil {
+			return err
+		}
+		s.compactVector = len(s.validData) > 0 && (s.valuePlan == insertFieldValueVectorDenseBytes ||
+			s.valuePlan == insertFieldValueVectorFloat || s.valuePlan == insertFieldValueVectorSparse)
+		return nil
+	case *schemapb.FieldData_StructArrays:
+		return insertViewInternal("source field %q (%d) still contains StructArrays; proxy must flatten struct fields before repacking", field.GetFieldName(), field.GetFieldId())
+	default:
+		return insertViewInternal("source field %q (%d) has unsupported FieldData oneof %T", field.GetFieldName(), field.GetFieldId(), value)
+	}
+}
+
+func (s *insertFieldSizeState) resetScalar(scalar *schemapb.ScalarField) error {
+	switch value := scalar.Data.(type) {
+	case nil:
+		s.valuePlan = insertFieldValueScalarEmpty
+	case *schemapb.ScalarField_BoolData:
+		if value.BoolData == nil {
+			return insertViewInternal("nil bool scalar array")
+		}
+		s.valuePlan, s.valueFieldNumber = insertFieldValueScalarPacked, 1
+	case *schemapb.ScalarField_IntData:
+		if value.IntData == nil {
+			return insertViewInternal("nil int scalar array")
+		}
+		s.valuePlan, s.valueFieldNumber = insertFieldValueScalarPacked, 2
+	case *schemapb.ScalarField_LongData:
+		if value.LongData == nil {
+			return insertViewInternal("nil long scalar array")
+		}
+		s.valuePlan, s.valueFieldNumber = insertFieldValueScalarPacked, 3
+	case *schemapb.ScalarField_FloatData:
+		if value.FloatData == nil {
+			return insertViewInternal("nil float scalar array")
+		}
+		s.valuePlan, s.valueFieldNumber = insertFieldValueScalarPacked, 4
+	case *schemapb.ScalarField_DoubleData:
+		if value.DoubleData == nil {
+			return insertViewInternal("nil double scalar array")
+		}
+		s.valuePlan, s.valueFieldNumber = insertFieldValueScalarPacked, 5
+	case *schemapb.ScalarField_StringData:
+		if value.StringData == nil {
+			return insertViewInternal("nil string scalar array")
+		}
+		s.valuePlan, s.valueFieldNumber = insertFieldValueScalarRepeated, 6
+	case *schemapb.ScalarField_BytesData:
+		if value.BytesData == nil {
+			return insertViewInternal("nil bytes scalar array")
+		}
+		s.valuePlan, s.valueFieldNumber = insertFieldValueScalarRepeated, 7
+	case *schemapb.ScalarField_ArrayData:
+		if value.ArrayData == nil {
+			return insertViewInternal("nil array scalar payload")
+		}
+		s.valuePlan, s.valueFieldNumber = insertFieldValueScalarArray, 8
+		s.payloadSize = insertProto3VarintFieldSize(2, uint64(value.ArrayData.GetElementType()))
+	case *schemapb.ScalarField_JsonData:
+		if value.JsonData == nil {
+			return insertViewInternal("nil JSON scalar array")
+		}
+		s.valuePlan, s.valueFieldNumber = insertFieldValueScalarRepeated, 9
+	case *schemapb.ScalarField_GeometryData:
+		if value.GeometryData == nil {
+			return insertViewInternal("nil geometry scalar array")
+		}
+		s.valuePlan, s.valueFieldNumber = insertFieldValueScalarRepeated, 10
+	case *schemapb.ScalarField_TimestamptzData:
+		if value.TimestamptzData == nil {
+			return insertViewInternal("nil timestamptz scalar array")
+		}
+		s.valuePlan, s.valueFieldNumber = insertFieldValueScalarPacked, 11
+	case *schemapb.ScalarField_GeometryWktData:
+		if value.GeometryWktData == nil {
+			return insertViewInternal("nil geometry WKT scalar array")
+		}
+		s.valuePlan, s.valueFieldNumber = insertFieldValueScalarRepeated, 12
+	case *schemapb.ScalarField_MolData:
+		if value.MolData == nil {
+			return insertViewInternal("nil molecular scalar array")
+		}
+		s.valuePlan, s.valueFieldNumber = insertFieldValueScalarRepeated, 13
+	case *schemapb.ScalarField_MolSmilesData:
+		if value.MolSmilesData == nil {
+			return insertViewInternal("nil molecular SMILES scalar array")
+		}
+		s.valuePlan, s.valueFieldNumber = insertFieldValueScalarRepeated, 14
+	case *schemapb.ScalarField_DateData:
+		if value.DateData == nil {
+			return insertViewInternal("nil date scalar array")
+		}
+		s.valuePlan, s.valueFieldNumber = insertFieldValueScalarPacked, 15
+	case *schemapb.ScalarField_TimeData:
+		if value.TimeData == nil {
+			return insertViewInternal("nil time scalar array")
+		}
+		s.valuePlan, s.valueFieldNumber = insertFieldValueScalarPacked, 16
+	default:
+		return insertViewInternal("unsupported ScalarField oneof %T", value)
+	}
+	return nil
+}
+
+func (s *insertFieldSizeState) resetVector(vector *schemapb.VectorField) error {
+	switch value := vector.Data.(type) {
+	case nil:
+		s.valuePlan = insertFieldValueVectorEmpty
+	case *schemapb.VectorField_BinaryVector:
+		stride, err := denseVectorStride(vector.GetDim(), 8, "binary vector")
+		if err != nil {
+			return err
+		}
+		s.valuePlan, s.valueFieldNumber, s.stride, s.payloadStride = insertFieldValueVectorDenseBytes, 3, stride, stride
+	case *schemapb.VectorField_FloatVector:
+		if value.FloatVector == nil {
+			return insertViewInternal("field %q (%d) has a nil float vector payload", s.field.GetFieldName(), s.field.GetFieldId())
+		}
+		stride, err := nonNegativeDim(vector.GetDim(), "float vector")
+		if err != nil {
+			return err
+		}
+		payloadStride, err := checkedProduct(stride, 4, "float vector row payload")
+		if err != nil {
+			return err
+		}
+		s.valuePlan, s.valueFieldNumber, s.stride, s.payloadStride = insertFieldValueVectorFloat, 2, stride, payloadStride
+	case *schemapb.VectorField_Float16Vector:
+		stride, err := denseVectorStride(vector.GetDim(), 2, "float16 vector")
+		if err != nil {
+			return err
+		}
+		s.valuePlan, s.valueFieldNumber, s.stride, s.payloadStride = insertFieldValueVectorDenseBytes, 4, stride, stride
+	case *schemapb.VectorField_Bfloat16Vector:
+		stride, err := denseVectorStride(vector.GetDim(), 2, "bfloat16 vector")
+		if err != nil {
+			return err
+		}
+		s.valuePlan, s.valueFieldNumber, s.stride, s.payloadStride = insertFieldValueVectorDenseBytes, 5, stride, stride
+	case *schemapb.VectorField_SparseFloatVector:
+		if value.SparseFloatVector == nil {
+			return insertViewInternal("field %q (%d) has a nil sparse vector payload", s.field.GetFieldName(), s.field.GetFieldId())
+		}
+		s.valuePlan, s.valueFieldNumber = insertFieldValueVectorSparse, 6
+	case *schemapb.VectorField_Int8Vector:
+		stride, err := denseVectorStride(vector.GetDim(), 1, "int8 vector")
+		if err != nil {
+			return err
+		}
+		s.valuePlan, s.valueFieldNumber, s.stride, s.payloadStride = insertFieldValueVectorDenseBytes, 7, stride, stride
+	case *schemapb.VectorField_VectorArray:
+		if value.VectorArray == nil {
+			return insertViewInternal("nil ArrayOfVector payload")
+		}
+		s.valuePlan, s.valueFieldNumber = insertFieldValueVectorArray, 8
+		s.payloadSize = insertProto3VarintFieldSize(1, uint64(value.VectorArray.GetDim())) +
+			insertProto3VarintFieldSize(3, uint64(value.VectorArray.GetElementType()))
+	default:
+		return insertViewInternal("field %q (%d) has unsupported VectorField oneof %T", s.field.GetFieldName(), s.field.GetFieldId(), value)
+	}
+	return nil
+}
+
+func (s *insertFieldSizeState) previewRow(row, dataIndex int, delta *insertFieldRowDelta) error {
+	*delta = insertFieldRowDelta{}
+	valid := s.validData
+	if len(valid) > 0 && row >= len(valid) {
+		return insertViewInternal("row offset %d exceeds ValidData length %d for field %q (%d)", row, len(valid), s.field.GetFieldName(), s.field.GetFieldId())
+	}
+
+	switch value := s.field.Field.(type) {
+	case nil:
+		return nil
+	case *schemapb.FieldData_Scalars:
+		return s.previewScalarRow(value.Scalars, row, delta)
+	case *schemapb.FieldData_Vectors:
+		if s.compactVector && !valid[row] {
+			return nil
+		}
+		return s.previewVectorRow(value.Vectors, row, dataIndex, delta)
+	default:
+		return insertViewInternal("source field %q (%d) has unsupported FieldData oneof %T", s.field.GetFieldName(), s.field.GetFieldId(), value)
+	}
+}
+
+func (s *insertFieldSizeState) previewScalarRow(scalar *schemapb.ScalarField, row int, delta *insertFieldRowDelta) error {
+	switch value := scalar.Data.(type) {
+	case nil:
+		return nil
+	case *schemapb.ScalarField_BoolData:
+		if row >= len(value.BoolData.GetData()) {
+			return insertViewInternal("row offset %d exceeds bool scalar length %d", row, len(value.BoolData.GetData()))
+		}
+		delta.payloadSize = 1
+	case *schemapb.ScalarField_IntData:
+		if row >= len(value.IntData.GetData()) {
+			return insertViewInternal("row offset %d exceeds int scalar length %d", row, len(value.IntData.GetData()))
+		}
+		delta.payloadSize = protowire.SizeVarint(uint64(value.IntData.GetData()[row]))
+	case *schemapb.ScalarField_LongData:
+		if row >= len(value.LongData.GetData()) {
+			return insertViewInternal("row offset %d exceeds long scalar length %d", row, len(value.LongData.GetData()))
+		}
+		delta.payloadSize = protowire.SizeVarint(uint64(value.LongData.GetData()[row]))
+	case *schemapb.ScalarField_FloatData:
+		if row >= len(value.FloatData.GetData()) {
+			return insertViewInternal("row offset %d exceeds float scalar length %d", row, len(value.FloatData.GetData()))
+		}
+		delta.payloadSize = 4
+	case *schemapb.ScalarField_DoubleData:
+		if row >= len(value.DoubleData.GetData()) {
+			return insertViewInternal("row offset %d exceeds double scalar length %d", row, len(value.DoubleData.GetData()))
+		}
+		delta.payloadSize = 8
+	case *schemapb.ScalarField_StringData:
+		return previewStringRow(value.StringData.GetData(), row, 1, "string scalar", delta)
+	case *schemapb.ScalarField_BytesData:
+		return previewBytesRow(value.BytesData.GetData(), row, 1, "bytes scalar", delta)
+	case *schemapb.ScalarField_ArrayData:
+		if row >= len(value.ArrayData.GetData()) {
+			return insertViewInternal("row offset %d exceeds array scalar length %d", row, len(value.ArrayData.GetData()))
+		}
+		itemSize, cellPayload := scalarCellWirePlan(value.ArrayData.GetData()[row])
+		wireSize, err := insertBytesFieldSize(1, itemSize)
+		if err != nil {
+			return err
+		}
+		delta.payloadSize = wireSize
+		delta.arrayCellPayload = cellPayload
+	case *schemapb.ScalarField_JsonData:
+		return previewBytesRow(value.JsonData.GetData(), row, 1, "JSON scalar", delta)
+	case *schemapb.ScalarField_GeometryData:
+		return previewBytesRow(value.GeometryData.GetData(), row, 1, "geometry scalar", delta)
+	case *schemapb.ScalarField_TimestamptzData:
+		return previewInt64Row(value.TimestamptzData.GetData(), row, "timestamptz scalar", delta)
+	case *schemapb.ScalarField_GeometryWktData:
+		return previewStringRow(value.GeometryWktData.GetData(), row, 1, "geometry WKT scalar", delta)
+	case *schemapb.ScalarField_MolData:
+		return previewBytesRow(value.MolData.GetData(), row, 1, "molecular scalar", delta)
+	case *schemapb.ScalarField_MolSmilesData:
+		return previewStringRow(value.MolSmilesData.GetData(), row, 1, "molecular SMILES scalar", delta)
+	case *schemapb.ScalarField_DateData:
+		if row >= len(value.DateData.GetData()) {
+			return insertViewInternal("row offset %d exceeds date scalar length %d", row, len(value.DateData.GetData()))
+		}
+		delta.payloadSize = protowire.SizeVarint(uint64(value.DateData.GetData()[row]))
+	case *schemapb.ScalarField_TimeData:
+		return previewInt64Row(value.TimeData.GetData(), row, "time scalar", delta)
+	default:
+		return insertViewInternal("unsupported ScalarField oneof %T", value)
+	}
+	return nil
+}
+
+func (s *insertFieldSizeState) packedScalarPayloadUpperBound(rowCount int) (int, error) {
+	width := 0
+	switch s.valuePlan {
+	case insertFieldValueNone, insertFieldValueScalarEmpty:
+	case insertFieldValueScalarPacked:
+		switch s.valueFieldNumber {
+		case 1:
+			width = 1
+		case 4:
+			width = 4
+		case 5:
+			width = 8
+		case 2, 3, 11, 15, 16:
+			width = 10
+		default:
+			return 0, insertViewInternal("unexpected packed scalar field number %d", s.valueFieldNumber)
+		}
+	default:
+		return 0, insertViewInternal("unexpected packed scalar size plan %d", s.valuePlan)
+	}
+	return checkedProduct(rowCount, width, "packed scalar payload upper bound")
+}
+
+func (s *insertFieldSizeState) simplePayloadUpperBound(rowCount int) (int, int, int64, error) {
+	switch s.class {
+	case insertFieldPlanNone:
+		return 0, 0, 0, nil
+	case insertFieldPlanScalar:
+		switch s.valuePlan {
+		case insertFieldValueScalarEmpty, insertFieldValueScalarPacked:
+			payloadSize, err := s.packedScalarPayloadUpperBound(rowCount)
+			return payloadSize, 0, 0, err
+		}
+	case insertFieldPlanVector:
+		switch s.valuePlan {
+		case insertFieldValueVectorEmpty:
+			return 0, 0, 0, nil
+		case insertFieldValueVectorDenseBytes, insertFieldValueVectorFloat:
+			payloadSize, err := checkedProduct(rowCount, s.payloadStride, "dense vector payload upper bound")
+			return payloadSize, rowCount, 0, err
+		}
+	}
+	return 0, 0, 0, insertViewInternal("field %q (%d) is not eligible for simple aggregate sizing", s.field.GetFieldName(), s.field.GetFieldId())
+}
+
+func (s *insertFieldSizeState) aggregateSimplePayload(rows []int) (int, int, int64, error) {
+	if err := s.validateSelectedValidData(rows); err != nil {
+		return 0, 0, 0, err
+	}
+	switch s.class {
+	case insertFieldPlanNone:
+		return 0, 0, 0, nil
+	case insertFieldPlanScalar:
+		switch s.valuePlan {
+		case insertFieldValueScalarEmpty, insertFieldValueScalarPacked:
+			payloadSize, err := s.aggregatePackedScalarPayload(rows)
+			return payloadSize, 0, 0, err
+		case insertFieldValueScalarRepeated:
+			payloadSize, err := s.aggregateRepeatedScalarPayload(rows)
+			return payloadSize, 0, 0, err
+		}
+	case insertFieldPlanVector:
+		switch s.valuePlan {
+		case insertFieldValueVectorEmpty:
+			return 0, 0, 0, nil
+		case insertFieldValueVectorDenseBytes, insertFieldValueVectorFloat:
+			if err := s.validateDenseVectorRows(rows); err != nil {
+				return 0, 0, 0, err
+			}
+			payloadSize, err := checkedProduct(len(rows), s.payloadStride, "dense vector selected payload")
+			return payloadSize, len(rows), 0, err
+		case insertFieldValueVectorSparse:
+			values := s.field.GetVectors().GetSparseFloatVector().GetContents()
+			payloadSize := uint64(0)
+			maxDim := int64(0)
+			for _, row := range rows {
+				if row < 0 || row >= len(values) {
+					return 0, 0, 0, insertViewInternal("sparse vector row %d exceeds payload rows %d for field %q (%d)", row, len(values), s.field.GetFieldName(), s.field.GetFieldId())
+				}
+				rowDim, err := sparseRowDim(values[row])
+				if err != nil {
+					return 0, 0, 0, err
+				}
+				wireSize := directBytesFieldSize(1, uint64(len(values[row])))
+				if payloadSize > math.MaxUint64-wireSize {
+					return 0, 0, 0, insertViewInternal("sparse vector selected payload exceeds addressable memory")
+				}
+				payloadSize += wireSize
+				if rowDim > maxDim {
+					maxDim = rowDim
+				}
+			}
+			if payloadSize > uint64(math.MaxInt) {
+				return 0, 0, 0, insertViewInternal("sparse vector selected payload exceeds addressable memory")
+			}
+			return int(payloadSize), len(rows), maxDim, nil
+		}
+	}
+	return 0, 0, 0, insertViewInternal("field %q (%d) is not eligible for simple aggregate sizing", s.field.GetFieldName(), s.field.GetFieldId())
+}
+
+func (s *insertFieldSizeState) validateSelectedValidData(rows []int) error {
+	valid := s.validData
+	if len(valid) == 0 {
+		return nil
+	}
+	for _, row := range rows {
+		if row < 0 || row >= len(valid) {
+			return insertViewInternal("row offset %d exceeds ValidData length %d for field %q (%d)", row, len(valid), s.field.GetFieldName(), s.field.GetFieldId())
+		}
+	}
+	return nil
+}
+
+func (s *insertFieldSizeState) validateDenseVectorRows(rows []int) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	lastRow := rows[len(rows)-1]
+	vector := s.field.GetVectors()
+	switch value := vector.Data.(type) {
+	case *schemapb.VectorField_BinaryVector:
+		_, _, err := vectorBounds(lastRow, s.stride, len(value.BinaryVector), s.field, "binary vector")
+		return err
+	case *schemapb.VectorField_FloatVector:
+		_, _, err := vectorBounds(lastRow, s.stride, len(value.FloatVector.GetData()), s.field, "float vector")
+		return err
+	case *schemapb.VectorField_Float16Vector:
+		_, _, err := vectorBounds(lastRow, s.stride, len(value.Float16Vector), s.field, "float16 vector")
+		return err
+	case *schemapb.VectorField_Bfloat16Vector:
+		_, _, err := vectorBounds(lastRow, s.stride, len(value.Bfloat16Vector), s.field, "bfloat16 vector")
+		return err
+	case *schemapb.VectorField_Int8Vector:
+		_, _, err := vectorBounds(lastRow, s.stride, len(value.Int8Vector), s.field, "int8 vector")
+		return err
+	default:
+		return insertViewInternal("field %q (%d) has unexpected simple vector payload %T", s.field.GetFieldName(), s.field.GetFieldId(), value)
+	}
+}
+
+func (s *insertFieldSizeState) aggregateRepeatedScalarPayload(rows []int) (int, error) {
+	payloadSize, _, err := s.repeatedScalarWireStats(rows)
+	return payloadSize, err
+}
+
+func (s *insertFieldSizeState) repeatedScalarWireStats(rows []int) (int, int, error) {
+	valid := s.validData
+	for _, row := range rows {
+		if len(valid) > 0 && (row < 0 || row >= len(valid)) {
+			return 0, 0, insertViewInternal("row offset %d exceeds ValidData length %d for field %q (%d)", row, len(valid), s.field.GetFieldName(), s.field.GetFieldId())
+		}
+	}
+	scalar := s.field.GetScalars()
+	switch value := scalar.Data.(type) {
+	case *schemapb.ScalarField_StringData:
+		return repeatedStringWireStats(value.StringData.GetData(), rows, "string scalar")
+	case *schemapb.ScalarField_BytesData:
+		return repeatedBytesWireStats(value.BytesData.GetData(), rows, "bytes scalar")
+	case *schemapb.ScalarField_JsonData:
+		return repeatedBytesWireStats(value.JsonData.GetData(), rows, "JSON scalar")
+	case *schemapb.ScalarField_GeometryData:
+		return repeatedBytesWireStats(value.GeometryData.GetData(), rows, "geometry scalar")
+	case *schemapb.ScalarField_GeometryWktData:
+		return repeatedStringWireStats(value.GeometryWktData.GetData(), rows, "geometry WKT scalar")
+	case *schemapb.ScalarField_MolData:
+		return repeatedBytesWireStats(value.MolData.GetData(), rows, "molecular scalar")
+	case *schemapb.ScalarField_MolSmilesData:
+		return repeatedStringWireStats(value.MolSmilesData.GetData(), rows, "molecular SMILES scalar")
+	default:
+		return 0, 0, insertViewInternal("unexpected repeated ScalarField oneof %T", value)
+	}
+}
+
+func repeatedStringWireStats(values []string, rows []int, label string) (int, int, error) {
+	payloadSize := uint64(0)
+	maxWireSize := uint64(0)
+	for _, row := range rows {
+		if row < 0 || row >= len(values) {
+			return 0, 0, insertViewInternal("row offset %d exceeds %s length %d", row, label, len(values))
+		}
+		wireSize := directBytesFieldSize(1, uint64(len(values[row])))
+		if payloadSize > math.MaxUint64-wireSize {
+			return 0, 0, insertViewInternal("%s payload exceeds addressable memory", label)
+		}
+		payloadSize += wireSize
+		if wireSize > maxWireSize {
+			maxWireSize = wireSize
+		}
+	}
+	if payloadSize > uint64(math.MaxInt) || maxWireSize > uint64(math.MaxInt) {
+		return 0, 0, insertViewInternal("%s payload exceeds addressable memory", label)
+	}
+	return int(payloadSize), int(maxWireSize), nil
+}
+
+func repeatedBytesWireStats(values [][]byte, rows []int, label string) (int, int, error) {
+	payloadSize := uint64(0)
+	maxWireSize := uint64(0)
+	for _, row := range rows {
+		if row < 0 || row >= len(values) {
+			return 0, 0, insertViewInternal("row offset %d exceeds %s length %d", row, label, len(values))
+		}
+		wireSize := directBytesFieldSize(1, uint64(len(values[row])))
+		if payloadSize > math.MaxUint64-wireSize {
+			return 0, 0, insertViewInternal("%s payload exceeds addressable memory", label)
+		}
+		payloadSize += wireSize
+		if wireSize > maxWireSize {
+			maxWireSize = wireSize
+		}
+	}
+	if payloadSize > uint64(math.MaxInt) || maxWireSize > uint64(math.MaxInt) {
+		return 0, 0, insertViewInternal("%s payload exceeds addressable memory", label)
+	}
+	return int(payloadSize), int(maxWireSize), nil
+}
+
+func (s *insertFieldSizeState) aggregatePackedScalarPayload(rows []int) (int, error) {
+	if _, err := s.packedScalarPayloadUpperBound(len(rows)); err != nil {
+		return 0, err
+	}
+	valid := s.validData
+	if len(valid) > 0 && len(rows) > 0 && rows[len(rows)-1] >= len(valid) {
+		for _, row := range rows {
+			if row >= len(valid) {
+				return 0, insertViewInternal("row offset %d exceeds ValidData length %d for field %q (%d)", row, len(valid), s.field.GetFieldName(), s.field.GetFieldId())
+			}
+		}
+	}
+
+	if s.class == insertFieldPlanNone || s.valuePlan == insertFieldValueScalarEmpty {
+		return 0, nil
+	}
+	scalar := s.field.GetScalars()
+	switch value := scalar.Data.(type) {
+	case *schemapb.ScalarField_BoolData:
+		values := value.BoolData.GetData()
+		if err := validateSelectedRows(rows, len(values), "bool scalar"); err != nil {
+			return 0, err
+		}
+		return len(rows), nil
+	case *schemapb.ScalarField_IntData:
+		values := value.IntData.GetData()
+		if err := validateSelectedRows(rows, len(values), "int scalar"); err != nil {
+			return 0, err
+		}
+		size := 0
+		for _, row := range rows {
+			size += protowire.SizeVarint(uint64(values[row]))
+		}
+		return size, nil
+	case *schemapb.ScalarField_LongData:
+		values := value.LongData.GetData()
+		if err := validateSelectedRows(rows, len(values), "long scalar"); err != nil {
+			return 0, err
+		}
+		size := 0
+		for _, row := range rows {
+			size += protowire.SizeVarint(uint64(values[row]))
+		}
+		return size, nil
+	case *schemapb.ScalarField_FloatData:
+		values := value.FloatData.GetData()
+		if err := validateSelectedRows(rows, len(values), "float scalar"); err != nil {
+			return 0, err
+		}
+		return checkedProduct(len(rows), 4, "float scalar payload")
+	case *schemapb.ScalarField_DoubleData:
+		values := value.DoubleData.GetData()
+		if err := validateSelectedRows(rows, len(values), "double scalar"); err != nil {
+			return 0, err
+		}
+		return checkedProduct(len(rows), 8, "double scalar payload")
+	case *schemapb.ScalarField_TimestamptzData:
+		return aggregateSelectedInt64(value.TimestamptzData.GetData(), rows, "timestamptz scalar")
+	case *schemapb.ScalarField_DateData:
+		values := value.DateData.GetData()
+		if err := validateSelectedRows(rows, len(values), "date scalar"); err != nil {
+			return 0, err
+		}
+		size := 0
+		for _, row := range rows {
+			size += protowire.SizeVarint(uint64(values[row]))
+		}
+		return size, nil
+	case *schemapb.ScalarField_TimeData:
+		return aggregateSelectedInt64(value.TimeData.GetData(), rows, "time scalar")
+	default:
+		return 0, insertViewInternal("unexpected packed ScalarField oneof %T", value)
+	}
+}
+
+func (s *insertFieldSizeState) previewVectorRow(vector *schemapb.VectorField, row, dataIndex int, delta *insertFieldRowDelta) error {
+	switch value := vector.Data.(type) {
+	case nil:
+		return nil
+	case *schemapb.VectorField_BinaryVector:
+		if _, _, err := vectorBounds(dataIndex, s.stride, len(value.BinaryVector), s.field, "binary vector"); err != nil {
+			return err
+		}
+		delta.payloadSize, delta.selectedRows = s.stride, 1
+	case *schemapb.VectorField_FloatVector:
+		if _, _, err := vectorBounds(dataIndex, s.stride, len(value.FloatVector.GetData()), s.field, "float vector"); err != nil {
+			return err
+		}
+		delta.payloadSize, delta.selectedRows = s.payloadStride, 1
+	case *schemapb.VectorField_Float16Vector:
+		if _, _, err := vectorBounds(dataIndex, s.stride, len(value.Float16Vector), s.field, "float16 vector"); err != nil {
+			return err
+		}
+		delta.payloadSize, delta.selectedRows = s.stride, 1
+	case *schemapb.VectorField_Bfloat16Vector:
+		if _, _, err := vectorBounds(dataIndex, s.stride, len(value.Bfloat16Vector), s.field, "bfloat16 vector"); err != nil {
+			return err
+		}
+		delta.payloadSize, delta.selectedRows = s.stride, 1
+	case *schemapb.VectorField_SparseFloatVector:
+		if dataIndex < 0 || dataIndex >= len(value.SparseFloatVector.GetContents()) {
+			return insertViewInternal("compact sparse vector index %d exceeds payload rows %d for field %q (%d)", dataIndex, len(value.SparseFloatVector.GetContents()), s.field.GetFieldName(), s.field.GetFieldId())
+		}
+		contents := value.SparseFloatVector.GetContents()[dataIndex]
+		rowDim, err := sparseRowDim(contents)
+		if err != nil {
+			return err
+		}
+		wireSize, err := insertBytesFieldSize(1, len(contents))
+		if err != nil {
+			return err
+		}
+		delta.payloadSize, delta.selectedRows, delta.sparseDim = wireSize, 1, rowDim
+	case *schemapb.VectorField_Int8Vector:
+		if _, _, err := vectorBounds(dataIndex, s.stride, len(value.Int8Vector), s.field, "int8 vector"); err != nil {
+			return err
+		}
+		delta.payloadSize, delta.selectedRows = s.stride, 1
+	case *schemapb.VectorField_VectorArray:
+		if row >= len(value.VectorArray.GetData()) {
+			return insertViewInternal("row offset %d exceeds ArrayOfVector length %d", row, len(value.VectorArray.GetData()))
+		}
+		itemSize, cellPayload, err := vectorArrayCellWirePlan(value.VectorArray.GetData()[row])
+		if err != nil {
+			return err
+		}
+		wireSize, err := insertBytesFieldSize(2, itemSize)
+		if err != nil {
+			return err
+		}
+		delta.payloadSize = wireSize
+		delta.arrayCellPayload = cellPayload
+	default:
+		return insertViewInternal("field %q (%d) has unsupported VectorField oneof %T", s.field.GetFieldName(), s.field.GetFieldId(), value)
+	}
+	return nil
+}
+
+func vectorArrayCellWirePlan(cell *schemapb.VectorField) (int, int, error) {
+	plan, ok, err := classifyVectorArrayCell(cell)
+	if err != nil {
+		return 0, 0, err
+	}
+	if ok {
+		return plan.cellSize, plan.payloadSize, nil
+	}
+	return nullableProtoSize(cell, false), vectorArrayCellProtoFallback, nil
+}
+
+func classifyVectorArrayCell(cell *schemapb.VectorField) (vectorArrayCellPlan, bool, error) {
+	if isNilProto(cell) {
+		return vectorArrayCellPlan{}, true, nil
+	}
+	// ValidData (field 9) has no producer anywhere in this repo yet, but proto
+	// reflection recognizes it now, so GetUnknown() no longer catches it: a cell
+	// carrying it would silently lose that data through the arithmetic path.
+	// Fall back to the protobuf path until this one earns explicit handling.
+	if len(cell.GetValidData()) != 0 {
+		return vectorArrayCellPlan{}, false, nil
+	}
+	if len(cell.ProtoReflect().GetUnknown()) != 0 {
+		return vectorArrayCellPlan{}, false, nil
+	}
+	plan := vectorArrayCellPlan{
+		kind:     vectorArrayCellPlanEmpty,
+		cellSize: insertProto3VarintFieldSize(1, uint64(cell.GetDim())),
+	}
+	switch value := cell.Data.(type) {
+	case nil:
+		return plan, true, nil
+	case *schemapb.VectorField_FloatVector:
+		if value.FloatVector == nil || len(value.FloatVector.ProtoReflect().GetUnknown()) != 0 {
+			return vectorArrayCellPlan{}, false, nil
+		}
+		payloadSize, err := checkedProduct(len(value.FloatVector.GetData()), 4, "ArrayOfVector float cell payload")
+		if err != nil {
+			return vectorArrayCellPlan{}, false, err
+		}
+		floatArraySize := 0
+		if payloadSize > 0 {
+			floatArraySize, err = insertBytesFieldSize(1, payloadSize)
+			if err != nil {
+				return vectorArrayCellPlan{}, false, err
+			}
+		}
+		floatWireSize, err := insertBytesFieldSize(2, floatArraySize)
+		if err != nil {
+			return vectorArrayCellPlan{}, false, err
+		}
+		cellSize, err := checkedAddSize(plan.cellSize, floatWireSize, "ArrayOfVector cell size")
+		if err != nil {
+			return vectorArrayCellPlan{}, false, err
+		}
+		plan.kind = vectorArrayCellPlanFloat
+		plan.payloadSize = payloadSize
+		plan.floatArraySize = floatArraySize
+		plan.cellSize = cellSize
+		return plan, true, nil
+	default:
+		return vectorArrayCellPlan{}, false, nil
+	}
+}
+
+func (s *insertFieldSizeState) computedSize(delta *insertFieldRowDelta, rowCount int) (insertFieldComputedSize, error) {
+	payloadSize := s.payloadSize
+	selectedRows := s.selectedRows
+	sparseDim := s.sparseDim
+	if delta != nil {
+		var err error
+		payloadSize, err = checkedAddSize(payloadSize, delta.payloadSize, "field payload size")
+		if err != nil {
+			return insertFieldComputedSize{}, err
+		}
+		selectedRows, err = checkedAddSize(selectedRows, delta.selectedRows, "selected vector row count")
+		if err != nil {
+			return insertFieldComputedSize{}, err
+		}
+		if delta.sparseDim > sparseDim {
+			sparseDim = delta.sparseDim
+		}
+	}
+
+	computed := insertFieldComputedSize{
+		payloadSize:  payloadSize,
+		selectedRows: selectedRows,
+	}
+	if sparseDim < 0 || uint64(sparseDim) > uint64(math.MaxInt) {
+		return insertFieldComputedSize{}, insertViewInternal("selected sparse vector dimension %d exceeds addressable memory", sparseDim)
+	}
+	computed.sparseDim = int(sparseDim)
+
+	fieldSize := s.metadataSize
+	switch s.class {
+	case insertFieldPlanNone:
+	case insertFieldPlanScalar:
+		scalarSize, err := s.scalarSize(payloadSize, rowCount)
+		if err != nil {
+			return insertFieldComputedSize{}, err
+		}
+		if len(s.validData) > 0 && rowCount > 0 {
+			validWireSize, err := insertBytesFieldSize(17, rowCount)
+			if err != nil {
+				return insertFieldComputedSize{}, err
+			}
+			scalarSize, err = checkedAddSize(scalarSize, validWireSize, "ScalarField size")
+			if err != nil {
+				return insertFieldComputedSize{}, err
+			}
+		}
+		computed.nestedSize = scalarSize
+		scalarWireSize, err := insertBytesFieldSize(3, scalarSize)
+		if err != nil {
+			return insertFieldComputedSize{}, err
+		}
+		fieldSize, err = checkedAddSize(fieldSize, scalarWireSize, "FieldData size")
+		if err != nil {
+			return insertFieldComputedSize{}, err
+		}
+	case insertFieldPlanVector:
+		vectorSize, err := s.vectorSize(payloadSize, selectedRows, sparseDim)
+		if err != nil {
+			return insertFieldComputedSize{}, err
+		}
+		if len(s.validData) > 0 && rowCount > 0 {
+			validWireSize, err := insertBytesFieldSize(9, rowCount)
+			if err != nil {
+				return insertFieldComputedSize{}, err
+			}
+			vectorSize, err = checkedAddSize(vectorSize, validWireSize, "VectorField size")
+			if err != nil {
+				return insertFieldComputedSize{}, err
+			}
+		}
+		computed.nestedSize = vectorSize
+		vectorWireSize, err := insertBytesFieldSize(4, vectorSize)
+		if err != nil {
+			return insertFieldComputedSize{}, err
+		}
+		fieldSize, err = checkedAddSize(fieldSize, vectorWireSize, "FieldData size")
+		if err != nil {
+			return insertFieldComputedSize{}, err
+		}
+	}
+	computed.fieldSize = fieldSize
+	return computed, nil
+}
+
+// directWireSize mirrors computedSize for the arithmetic-only field plans, but
+// keeps the hot split loop in uint64 and validates overflow once at the edge.
+func (s *insertFieldSizeState) directWireSize(delta *insertFieldRowDelta, rowCount int) (int, bool, error) {
+	payloadSize := uint64(s.payloadSize)
+	selectedRows := uint64(s.selectedRows)
+	sparseDim := s.sparseDim
+	if delta != nil {
+		payloadSize += uint64(delta.payloadSize)
+		selectedRows += uint64(delta.selectedRows)
+		if delta.sparseDim > sparseDim {
+			sparseDim = delta.sparseDim
+		}
+	}
+	if payloadSize > uint64(math.MaxInt) || selectedRows > uint64(math.MaxInt) {
+		return 0, true, insertViewInternal("direct field size exceeds addressable memory")
+	}
+
+	fieldSize := uint64(s.metadataSize)
+	switch s.class {
+	case insertFieldPlanNone:
+	case insertFieldPlanScalar:
+		scalarSize := uint64(0)
+		switch s.valuePlan {
+		case insertFieldValueScalarEmpty:
+		case insertFieldValueScalarPacked:
+			arraySize := uint64(0)
+			if rowCount > 0 {
+				arraySize = directBytesFieldSize(1, payloadSize)
+			}
+			scalarSize = directBytesFieldSize(s.valueFieldNumber, arraySize)
+		case insertFieldValueScalarRepeated:
+			scalarSize = directBytesFieldSize(s.valueFieldNumber, payloadSize)
+		default:
+			return 0, false, nil
+		}
+		if len(s.validData) > 0 && rowCount > 0 {
+			scalarSize += directBytesFieldSize(17, uint64(rowCount))
+		}
+		fieldSize += directBytesFieldSize(3, scalarSize)
+	case insertFieldPlanVector:
+		vector := s.field.GetVectors()
+		outerDim := vector.GetDim()
+		if s.valuePlan == insertFieldValueVectorSparse && selectedRows > 0 {
+			outerDim = vector.GetSparseFloatVector().GetDim()
+		}
+		vectorSize := directProto3VarintFieldSize(1, uint64(outerDim))
+		switch s.valuePlan {
+		case insertFieldValueVectorEmpty:
+		case insertFieldValueVectorDenseBytes:
+			if selectedRows > 0 {
+				vectorSize += directBytesFieldSize(s.valueFieldNumber, payloadSize)
+			}
+		case insertFieldValueVectorFloat:
+			if selectedRows > 0 {
+				floatArraySize := uint64(0)
+				if payloadSize > 0 {
+					floatArraySize = directBytesFieldSize(1, payloadSize)
+				}
+				vectorSize += directBytesFieldSize(2, floatArraySize)
+			}
+		case insertFieldValueVectorSparse:
+			if selectedRows > 0 {
+				if sparseDim < 0 {
+					return 0, true, insertViewInternal("selected sparse vector dimension %d is negative", sparseDim)
+				}
+				sparseSize := payloadSize + directProto3VarintFieldSize(2, uint64(sparseDim))
+				vectorSize += directBytesFieldSize(6, sparseSize)
+			}
+		case insertFieldValueVectorArray:
+			vectorSize += directBytesFieldSize(8, payloadSize)
+		default:
+			return 0, false, nil
+		}
+		if len(s.validData) > 0 && rowCount > 0 {
+			vectorSize += directBytesFieldSize(9, uint64(rowCount))
+		}
+		fieldSize += directBytesFieldSize(4, vectorSize)
+	default:
+		return 0, false, nil
+	}
+	fieldWireSize := directBytesFieldSize(13, fieldSize)
+	if fieldWireSize > uint64(math.MaxInt) {
+		return 0, true, insertViewInternal("direct FieldData wire size exceeds addressable memory")
+	}
+	return int(fieldWireSize), true, nil
+}
+
+func directProto3VarintFieldSize(number protowire.Number, value uint64) uint64 {
+	if value == 0 {
+		return 0
+	}
+	return uint64(protowire.SizeTag(number) + protowire.SizeVarint(value))
+}
+
+func directBytesFieldSize(number protowire.Number, payloadSize uint64) uint64 {
+	return uint64(protowire.SizeTag(number)+protowire.SizeVarint(payloadSize)) + payloadSize
+}
+
+func (s *insertFieldSizeState) scalarSize(payloadSize, rowCount int) (int, error) {
+	switch s.valuePlan {
+	case insertFieldValueScalarEmpty:
+		return 0, nil
+	case insertFieldValueScalarPacked:
+		arraySize := 0
+		if rowCount > 0 {
+			var err error
+			arraySize, err = insertBytesFieldSize(1, payloadSize)
+			if err != nil {
+				return 0, err
+			}
+		}
+		return insertBytesFieldSize(s.valueFieldNumber, arraySize)
+	case insertFieldValueScalarRepeated, insertFieldValueScalarArray:
+		return insertBytesFieldSize(s.valueFieldNumber, payloadSize)
+	default:
+		return 0, insertViewInternal("unexpected scalar size plan %d", s.valuePlan)
+	}
+}
+
+func (s *insertFieldSizeState) vectorSize(payloadSize, selectedRows int, sparseDim int64) (int, error) {
+	vector := s.field.GetVectors()
+	outerDim := vector.GetDim()
+	if s.valuePlan == insertFieldValueVectorSparse && selectedRows > 0 {
+		outerDim = vector.GetSparseFloatVector().GetDim()
+	}
+	size := insertProto3VarintFieldSize(1, uint64(outerDim))
+
+	switch s.valuePlan {
+	case insertFieldValueVectorEmpty:
+		return size, nil
+	case insertFieldValueVectorDenseBytes:
+		if selectedRows == 0 {
+			return size, nil
+		}
+		wireSize, err := insertBytesFieldSize(s.valueFieldNumber, payloadSize)
+		if err != nil {
+			return 0, err
+		}
+		return checkedAddSize(size, wireSize, "VectorField size")
+	case insertFieldValueVectorFloat:
+		if selectedRows == 0 {
+			return size, nil
+		}
+		floatArraySize := 0
+		if payloadSize > 0 {
+			var err error
+			floatArraySize, err = insertBytesFieldSize(1, payloadSize)
+			if err != nil {
+				return 0, err
+			}
+		}
+		wireSize, err := insertBytesFieldSize(2, floatArraySize)
+		if err != nil {
+			return 0, err
+		}
+		return checkedAddSize(size, wireSize, "VectorField size")
+	case insertFieldValueVectorSparse:
+		if selectedRows == 0 {
+			return size, nil
+		}
+		sparseSize := payloadSize
+		sparseSize, err := checkedAddSize(sparseSize, insertProto3VarintFieldSize(2, uint64(sparseDim)), "sparse vector size")
+		if err != nil {
+			return 0, err
+		}
+		wireSize, err := insertBytesFieldSize(6, sparseSize)
+		if err != nil {
+			return 0, err
+		}
+		return checkedAddSize(size, wireSize, "VectorField size")
+	case insertFieldValueVectorArray:
+		wireSize, err := insertBytesFieldSize(8, payloadSize)
+		if err != nil {
+			return 0, err
+		}
+		return checkedAddSize(size, wireSize, "VectorField size")
+	default:
+		return 0, insertViewInternal("unexpected vector size plan %d", s.valuePlan)
+	}
+}
+
+func (s *insertFieldSizeState) appendPlan(plan []int, computed insertFieldComputedSize, rowCount int) []int {
+	plan = append(plan, computed.fieldSize)
+	switch s.class {
+	case insertFieldPlanScalar:
+		plan = append(plan, computed.nestedSize)
+		if s.valuePlan != insertFieldValueScalarEmpty {
+			plan = append(plan, computed.payloadSize)
+		}
+	case insertFieldPlanVector:
+		plan = append(plan, computed.nestedSize)
+		switch s.valuePlan {
+		case insertFieldValueVectorDenseBytes, insertFieldValueVectorFloat:
+			plan = append(plan, computed.selectedRows)
+		case insertFieldValueVectorSparse:
+			plan = append(plan, computed.selectedRows, computed.payloadSize, computed.sparseDim)
+		case insertFieldValueVectorArray:
+			plan = append(plan, computed.payloadSize)
+		}
+	}
+	// Validity now lives inside the nested ScalarField/VectorField message
+	// (#52203), so the slot only exists when the writer enters that message.
+	if (s.class == insertFieldPlanScalar || s.class == insertFieldPlanVector) && len(s.validData) > 0 && rowCount > 0 {
+		plan = append(plan, rowCount)
+	}
+	return plan
+}
+
+func (s *insertFieldSizeState) commit(delta insertFieldRowDelta, wireSize int) {
+	s.payloadSize += delta.payloadSize
+	s.wireSize = wireSize
+	s.selectedRows += delta.selectedRows
+	if delta.sparseDim > s.sparseDim {
+		s.sparseDim = delta.sparseDim
+	}
+}
+
+func insertRequestFixedSize(template *msgpb.InsertRequest) (int, error) {
+	size := 0
+	if template.GetBase() != nil {
+		baseSize := nullableProtoSize(template.GetBase(), false)
+		wireSize, err := insertBytesFieldSize(1, baseSize)
+		if err != nil {
+			return 0, err
+		}
+		size = wireSize
+	}
+	var err error
+	for _, field := range []struct {
+		number protowire.Number
+		value  string
+		force  bool
+	}{
+		{2, template.GetShardName(), false},
+		{3, template.GetDbName(), false},
+		{4, template.GetCollectionName(), false},
+		{5, template.GetPartitionName(), false},
+	} {
+		wireSize, wireErr := insertStringFieldSize(field.number, field.value, field.force)
+		if wireErr != nil {
+			return 0, wireErr
+		}
+		size, err = checkedAddSize(size, wireSize, "insert request metadata size")
+		if err != nil {
+			return 0, err
+		}
+	}
+	for _, field := range []struct {
+		number protowire.Number
+		value  uint64
+	}{
+		{6, uint64(template.GetDbID())},
+		{7, uint64(template.GetCollectionID())},
+		{8, uint64(template.GetPartitionID())},
+		{9, uint64(template.GetSegmentID())},
+		{15, uint64(template.GetVersion())},
+	} {
+		size, err = checkedAddSize(size, insertProto3VarintFieldSize(field.number, field.value), "insert request metadata size")
+		if err != nil {
+			return 0, err
+		}
+	}
+	if template.Namespace != nil {
+		wireSize, wireErr := insertStringFieldSize(16, *template.Namespace, true)
+		if wireErr != nil {
+			return 0, wireErr
+		}
+		size, err = checkedAddSize(size, wireSize, "insert request metadata size")
+		if err != nil {
+			return 0, err
+		}
+	}
+	return checkedAddSize(size, len(template.ProtoReflect().GetUnknown()), "insert request metadata size")
+}
+
+func insertFieldMetadataSize(field *schemapb.FieldData) (int, error) {
+	size := insertProto3VarintFieldSize(1, uint64(field.GetType()))
+	nameSize, err := insertStringFieldSize(2, field.GetFieldName(), false)
+	if err != nil {
+		return 0, err
+	}
+	size, err = checkedAddSize(size, nameSize, "FieldData metadata size")
+	if err != nil {
+		return 0, err
+	}
+	size, err = checkedAddSize(size, insertProto3VarintFieldSize(5, uint64(field.GetFieldId())), "FieldData metadata size")
+	if err != nil {
+		return 0, err
+	}
+	if field.GetIsDynamic() {
+		size, err = checkedAddSize(size, protowire.SizeTag(6)+1, "FieldData metadata size")
+		if err != nil {
+			return 0, err
+		}
+	}
+	return size, nil
+}
+
+func previewStringRow(values []string, row int, fieldNumber protowire.Number, label string, delta *insertFieldRowDelta) error {
+	if row >= len(values) {
+		return insertViewInternal("row offset %d exceeds %s length %d", row, label, len(values))
+	}
+	wireSize, err := insertBytesFieldSize(fieldNumber, len(values[row]))
+	if err != nil {
+		return err
+	}
+	delta.payloadSize = wireSize
+	return nil
+}
+
+func previewBytesRow(values [][]byte, row int, fieldNumber protowire.Number, label string, delta *insertFieldRowDelta) error {
+	if row >= len(values) {
+		return insertViewInternal("row offset %d exceeds %s length %d", row, label, len(values))
+	}
+	wireSize, err := insertBytesFieldSize(fieldNumber, len(values[row]))
+	if err != nil {
+		return err
+	}
+	delta.payloadSize = wireSize
+	return nil
+}
+
+func previewInt64Row(values []int64, row int, label string, delta *insertFieldRowDelta) error {
+	if row >= len(values) {
+		return insertViewInternal("row offset %d exceeds %s length %d", row, label, len(values))
+	}
+	delta.payloadSize = protowire.SizeVarint(uint64(values[row]))
+	return nil
+}
+
+func validateSelectedRows(rows []int, valueCount int, label string) error {
+	if len(rows) == 0 || rows[len(rows)-1] < valueCount {
+		return nil
+	}
+	for _, row := range rows {
+		if row >= valueCount {
+			return insertViewInternal("row offset %d exceeds %s length %d", row, label, valueCount)
+		}
+	}
+	return nil
+}
+
+func aggregateSelectedInt64(values []int64, rows []int, label string) (int, error) {
+	if err := validateSelectedRows(rows, len(values), label); err != nil {
+		return 0, err
+	}
+	size := 0
+	for _, row := range rows {
+		size += protowire.SizeVarint(uint64(values[row]))
+	}
+	return size, nil
+}
+
+func insertProto3VarintFieldSize(number protowire.Number, value uint64) int {
+	if value == 0 {
+		return 0
+	}
+	return protowire.SizeTag(number) + protowire.SizeVarint(value)
+}
+
+func insertStringFieldSize(number protowire.Number, value string, force bool) (int, error) {
+	if !force && value == "" {
+		return 0, nil
+	}
+	return insertBytesFieldSize(number, len(value))
+}
+
+func insertBytesFieldSize(number protowire.Number, payloadSize int) (int, error) {
+	if payloadSize < 0 {
+		return 0, insertViewInternal("negative protobuf payload size %d", payloadSize)
+	}
+	prefixSize, err := checkedAddSize(protowire.SizeTag(number), protowire.SizeVarint(uint64(payloadSize)), "protobuf length prefix")
+	if err != nil {
+		return 0, err
+	}
+	return checkedAddSize(prefixSize, payloadSize, "protobuf bytes field")
+}
+
+// checkedAddSize is the single largest flat cost on the O(rows x fields) sizing
+// path (~12% of a wide-table encode). It does not inline: splitting the error
+// construction into a //go:noinline helper brings it to cost 81 against a
+// budget of 80, and rewriting the overflow test to use wraparound makes it
+// worse (84). Getting under the budget needs the label parameter gone, which
+// costs the diagnostics on every call site, so it is left alone until the
+// sizing loop itself is restructured.
+func checkedAddSize(a, b int, label string) (int, error) {
+	if a < 0 || b < 0 || a > math.MaxInt-b {
+		return 0, insertViewInternal("%s exceeds addressable memory", label)
+	}
+	return a + b, nil
+}

--- a/pkg/util/fastpb/insert_request_view.go
+++ b/pkg/util/fastpb/insert_request_view.go
@@ -1,0 +1,1407 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fastpb
+
+import (
+	"encoding/binary"
+	"math"
+	"reflect"
+
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+// InsertRequestViewEncoder serializes a row selection from Source directly into
+// the protobuf wire representation of a msgpb.InsertRequest. It deliberately
+// does not materialize destination RowIDs, Timestamps, or FieldData columns.
+//
+// Template supplies the output message metadata (base, collection, partition,
+// segment, shard, version, and namespace). Its row-bearing fields are ignored.
+// Source supplies RowIDs, Timestamps, and FieldsData. Rows is borrowed rather
+// than copied and must be strictly increasing.
+//
+// For a cursor-owned encoder, Template and Rows must remain immutable until its
+// single MarshalTo call returns, while Source and every object reachable from
+// it must remain immutable for the cursor's entire lifetime. A standalone
+// encoder may be marshaled repeatedly, so all of its borrowed inputs must stay
+// immutable for the encoder's entire lifetime. This is the same ownership rule
+// as an Arrow array view: the encoder owns only the view, not the referenced
+// data. Direct proto3 strings are a trusted internal input; the encoder
+// deliberately does not rescan UTF-8 payloads.
+type InsertRequestViewEncoder struct {
+	template              *msgpb.InsertRequest
+	source                *msgpb.InsertRequest
+	rows                  []int
+	firstFieldDataIndices []int64
+	sizePlan              []int
+	fieldSizeStates       []insertFieldSizeState
+	arrayCellPayloads     []int
+	arrayFieldCount       int
+	size                  int
+	owner                 *InsertRequestViewCursor
+	consumed              bool
+}
+
+// BodyType binds this encoder to InsertRequest message builders at compile
+// time. The returned value is a type marker and is never inspected at runtime.
+func (*InsertRequestViewEncoder) BodyType() *msgpb.InsertRequest {
+	return nil
+}
+
+// InsertRequestViewCursor binds compact nullable-vector prefix state and
+// reusable encoding scratch to one source request. Source and every object
+// reachable from it must remain immutable from cursor creation until the cursor
+// is discarded. Successive calls to NextEncoder must use globally increasing
+// row selections. The returned encoder borrows the cursor scratch until
+// MarshalTo returns, so callers must consume it synchronously before requesting
+// the next view.
+type InsertRequestViewCursor struct {
+	source                       *msgpb.InsertRequest
+	scanRow                      int
+	lastSelectedRow              int
+	fieldDataIndices             []int64
+	nextFieldDataIndices         []int64
+	rowFieldDataIndices          []int64
+	encoderFirstFieldDataIndices []int64
+	pendingFieldDataIndices      []int64
+	pendingFieldDeltas           []insertFieldRowDelta
+	pendingRow                   int
+	sizeState                    insertRequestSizeState
+	sizePlan                     []int
+	activeEncoder                *InsertRequestViewEncoder
+}
+
+// NewInsertRequestViewCursor creates a source-bound cursor for a sequential
+// message splitter.
+func NewInsertRequestViewCursor(source *msgpb.InsertRequest) (*InsertRequestViewCursor, error) {
+	if source == nil {
+		return nil, insertViewInternal("nil source request")
+	}
+	if len(source.GetRowData()) != 0 {
+		return nil, insertViewInternal("row-based InsertRequest is not supported")
+	}
+	return &InsertRequestViewCursor{
+		source:                       source,
+		lastSelectedRow:              -1,
+		fieldDataIndices:             make([]int64, len(source.GetFieldsData())),
+		nextFieldDataIndices:         make([]int64, len(source.GetFieldsData())),
+		rowFieldDataIndices:          make([]int64, len(source.GetFieldsData())),
+		encoderFirstFieldDataIndices: make([]int64, len(source.GetFieldsData())),
+		pendingFieldDataIndices:      make([]int64, len(source.GetFieldsData())),
+		pendingFieldDeltas:           make([]insertFieldRowDelta, len(source.GetFieldsData())),
+		pendingRow:                   -1,
+	}, nil
+}
+
+// newEncoder creates an unbounded borrowed view for package tests. Production
+// splitters must pass an explicit size limit through NextEncoder.
+func (c *InsertRequestViewCursor) newEncoder(template *msgpb.InsertRequest, rows []int) (*InsertRequestViewEncoder, error) {
+	encoder, consumed, err := c.NextEncoder(template, rows, 0)
+	if err != nil {
+		return nil, err
+	}
+	if consumed != len(rows) {
+		return nil, insertViewInternal("unbounded encoder consumed %d of %d rows", consumed, len(rows))
+	}
+	return encoder, nil
+}
+
+// NextEncoder returns an encoder over the largest non-empty prefix of rows
+// whose exact plaintext protobuf body size is below sizeLimit. A single row is
+// always returned even when it reaches or exceeds the limit, matching the
+// existing insert split behavior. A non-positive limit disables splitting.
+//
+// The exact sizing pass and MarshalTo share a replay plan plus row-major ARRAY
+// scratch. Callers must synchronously marshal the returned encoder before
+// requesting the next one.
+func (c *InsertRequestViewCursor) NextEncoder(template *msgpb.InsertRequest, rows []int, sizeLimit int) (*InsertRequestViewEncoder, int, error) {
+	if c == nil || c.source == nil {
+		return nil, 0, insertViewInternal("nil insert request view cursor")
+	}
+	if c.activeEncoder != nil {
+		return nil, 0, insertViewInternal("previous cursor encoder has not been marshaled")
+	}
+	if len(rows) == 0 {
+		return nil, 0, insertViewInternal("row selection is empty")
+	}
+	fieldCount := len(c.source.GetFieldsData())
+	if len(c.fieldDataIndices) != fieldCount || len(c.nextFieldDataIndices) != fieldCount ||
+		len(c.rowFieldDataIndices) != fieldCount || len(c.encoderFirstFieldDataIndices) != fieldCount ||
+		len(c.pendingFieldDataIndices) != fieldCount || len(c.pendingFieldDeltas) != fieldCount {
+		return nil, 0, insertViewInternal("source FieldsData count changed while cursor was in use")
+	}
+	if err := c.sizeState.reset(template, c.source, len(rows)); err != nil {
+		return nil, 0, err
+	}
+
+	copy(c.nextFieldDataIndices, c.fieldDataIndices)
+	planScanRow := c.scanRow
+	previous := c.lastSelectedRow
+	consumed := 0
+	aggregatedRows, err := c.sizeState.aggregateSimpleRows(rows, previous, sizeLimit)
+	if err != nil {
+		return nil, 0, err
+	}
+	if aggregatedRows < 0 || aggregatedRows > len(rows) {
+		return nil, 0, insertViewInternal("aggregated row count %d is out of range for %d selected rows", aggregatedRows, len(rows))
+	}
+	if aggregatedRows > 0 {
+		aggregated := rows[:aggregatedRows]
+		firstRow := aggregated[0]
+		lastRow := aggregated[len(aggregated)-1]
+		for fieldIndex := range c.sizeState.fields {
+			c.encoderFirstFieldDataIndices[fieldIndex] = int64(firstRow)
+			c.nextFieldDataIndices[fieldIndex] = int64(lastRow + 1)
+		}
+		c.pendingRow = -1
+		planScanRow = lastRow + 1
+		previous = lastRow
+		consumed = aggregatedRows
+	}
+	for i := aggregatedRows; i < len(rows); i++ {
+		row := rows[i]
+		if row < 0 {
+			return nil, 0, insertViewInternal("row offset at selection index %d is negative: %d", i, row)
+		}
+		if row <= previous {
+			return nil, 0, insertViewInternal("cursor row offsets must be globally increasing: rows[%d]=%d after %d", i, row, previous)
+		}
+		usePending := i == 0 && row == c.pendingRow
+		var encodedSize int
+		var err error
+		if usePending {
+			copy(c.rowFieldDataIndices, c.pendingFieldDataIndices)
+			encodedSize, err = c.sizeState.previewCachedRow(row, c.pendingFieldDeltas)
+		} else {
+			if i == 0 {
+				c.pendingRow = -1
+			}
+			if err := c.resolveRowFieldDataIndices(planScanRow, row); err != nil {
+				return nil, 0, err
+			}
+			encodedSize, err = c.sizeState.previewRow(row, c.rowFieldDataIndices)
+		}
+		if err != nil {
+			return nil, 0, err
+		}
+		if consumed > 0 && sizeLimit > 0 && encodedSize >= sizeLimit {
+			c.pendingRow = row
+			copy(c.pendingFieldDataIndices, c.rowFieldDataIndices)
+			copy(c.pendingFieldDeltas, c.sizeState.rowDeltas)
+			break
+		}
+		if consumed == 0 {
+			copy(c.encoderFirstFieldDataIndices, c.rowFieldDataIndices)
+		}
+		c.sizeState.commitRow(row, encodedSize)
+		if usePending {
+			c.pendingRow = -1
+		}
+		for fieldIndex := range c.sizeState.fields {
+			if c.sizeState.fields[fieldIndex].compactVector {
+				nextIndex := c.rowFieldDataIndices[fieldIndex]
+				if c.sizeState.fields[fieldIndex].validData[row] {
+					nextIndex++
+				}
+				c.nextFieldDataIndices[fieldIndex] = nextIndex
+			} else {
+				c.nextFieldDataIndices[fieldIndex] = int64(row + 1)
+			}
+		}
+		planScanRow = row + 1
+		previous = row
+		consumed++
+	}
+	if consumed == 0 {
+		return nil, 0, insertViewInternal("exact insert splitter produced an empty selection")
+	}
+
+	sizePlan, encodedSize, err := c.sizeState.buildPlan(c.sizePlan[:0])
+	if err != nil {
+		return nil, 0, err
+	}
+	encoder := &InsertRequestViewEncoder{
+		template:              template,
+		source:                c.source,
+		rows:                  rows[:consumed],
+		firstFieldDataIndices: c.encoderFirstFieldDataIndices,
+		sizePlan:              sizePlan,
+		fieldSizeStates:       c.sizeState.fields,
+		arrayCellPayloads:     c.sizeState.arrayCellPayloads,
+		arrayFieldCount:       c.sizeState.arrayFieldCount,
+		size:                  encodedSize,
+	}
+
+	c.fieldDataIndices, c.nextFieldDataIndices = c.nextFieldDataIndices, c.fieldDataIndices
+	c.scanRow = planScanRow
+	c.lastSelectedRow = rows[consumed-1]
+	c.sizePlan = sizePlan
+	encoder.owner = c
+	c.activeEncoder = encoder
+	return encoder, consumed, nil
+}
+
+func (c *InsertRequestViewCursor) resolveRowFieldDataIndices(scanRow, row int) error {
+	if scanRow < 0 || scanRow > row {
+		return insertViewInternal("invalid compact-vector scan range [%d:%d]", scanRow, row)
+	}
+	for fieldIndex := range c.sizeState.fields {
+		state := &c.sizeState.fields[fieldIndex]
+		if !state.compactVector {
+			c.rowFieldDataIndices[fieldIndex] = int64(row)
+			continue
+		}
+		valid := state.validData
+		if row >= len(valid) {
+			return insertViewInternal("row offset %d exceeds ValidData length %d for field %q (%d)", row, len(valid), state.field.GetFieldName(), state.field.GetFieldId())
+		}
+		if scanRow > len(valid) {
+			return insertViewInternal("compact-vector scan row %d exceeds ValidData length %d for field %q (%d)", scanRow, len(valid), state.field.GetFieldName(), state.field.GetFieldId())
+		}
+		dataIndex := c.nextFieldDataIndices[fieldIndex]
+		for _, isValid := range valid[scanRow:row] {
+			if isValid {
+				dataIndex++
+			}
+		}
+		c.rowFieldDataIndices[fieldIndex] = dataIndex
+	}
+	return nil
+}
+
+// NewInsertRequestViewEncoder creates a borrowed row-selection view over source.
+// Invalid offsets and malformed source column shapes are Milvus-internal
+// contract violations, so they intentionally use ErrServiceInternal rather
+// than an input-error code.
+func NewInsertRequestViewEncoder(template, source *msgpb.InsertRequest, rows []int) (*InsertRequestViewEncoder, error) {
+	cursor, err := NewInsertRequestViewCursor(source)
+	if err != nil {
+		return nil, err
+	}
+	encoder, consumed, err := cursor.NextEncoder(template, rows, 0)
+	if err != nil {
+		return nil, err
+	}
+	if consumed != len(rows) {
+		return nil, insertViewInternal("unbounded encoder consumed %d of %d rows", consumed, len(rows))
+	}
+	// Standalone encoders own their scratch through the slices above and may be
+	// marshaled more than once. Cursor encoders remain single-use so their
+	// scratch can be safely recycled by the next exact split.
+	encoder.owner = nil
+	cursor.activeEncoder = nil
+	return encoder, nil
+}
+
+// EncodedSize returns the exact number of bytes MarshalTo writes.
+func (e *InsertRequestViewEncoder) EncodedSize() (int, error) {
+	if e == nil {
+		return 0, insertViewInternal("nil encoder")
+	}
+	if err := e.checkCursorOwnership(); err != nil {
+		return 0, err
+	}
+	return e.size, nil
+}
+
+// MarshalTo writes the selected request into dst without constructing target
+// protobuf columns. dst may be larger than EncodedSize; only its prefix is used.
+func (e *InsertRequestViewEncoder) MarshalTo(dst []byte) (int, error) {
+	if e == nil {
+		return 0, insertViewInternal("nil encoder")
+	}
+	if err := e.checkCursorOwnership(); err != nil {
+		return 0, err
+	}
+	if len(dst) < e.size {
+		return 0, insertViewInternal("destination buffer has %d bytes, need %d", len(dst), e.size)
+	}
+
+	w := newInsertViewMarshalWriter(dst[:0:e.size], &e.sizePlan)
+	if err := e.appendRequest(w); err != nil {
+		return 0, err
+	}
+	if w.err != nil {
+		return 0, w.err
+	}
+	if w.planIndex != len(e.sizePlan) {
+		return 0, insertViewInternal("encoded size plan changed while borrowed data was in use: consumed %d entries, expected %d", w.planIndex, len(e.sizePlan))
+	}
+	if w.n != e.size || len(w.out) != e.size {
+		return 0, insertViewInternal("encoded size changed while borrowed data was in use: expected %d, wrote %d", e.size, w.n)
+	}
+	if e.size > 0 && &w.out[0] != &dst[0] {
+		return 0, insertViewInternal("encoder exceeded the caller-provided destination buffer")
+	}
+	if e.owner != nil {
+		e.consumed = true
+		e.owner.activeEncoder = nil
+	}
+	return e.size, nil
+}
+
+func (e *InsertRequestViewEncoder) checkCursorOwnership() error {
+	if e.owner == nil {
+		return nil
+	}
+	if e.consumed {
+		return insertViewInternal("encoder has already been marshaled")
+	}
+	// Pointer identity also rejects value-copied encoders. Without it, a stale
+	// copy could release scratch that a newer encoder currently borrows.
+	if e.owner.activeEncoder != e {
+		return insertViewInternal("encoder is no longer active for its cursor")
+	}
+	return nil
+}
+
+func (e *InsertRequestViewEncoder) appendRequest(w *insertViewWriter) error {
+	t := e.template
+	if t.GetBase() != nil {
+		if err := w.protoMessage(1, t.GetBase(), "insert base"); err != nil {
+			return err
+		}
+	}
+	if err := w.proto3String(2, t.GetShardName(), "shard name"); err != nil {
+		return err
+	}
+	if err := w.proto3String(3, t.GetDbName(), "database name"); err != nil {
+		return err
+	}
+	if err := w.proto3String(4, t.GetCollectionName(), "collection name"); err != nil {
+		return err
+	}
+	if err := w.proto3String(5, t.GetPartitionName(), "partition name"); err != nil {
+		return err
+	}
+	w.proto3Varint(6, uint64(t.GetDbID()))
+	w.proto3Varint(7, uint64(t.GetCollectionID()))
+	w.proto3Varint(8, uint64(t.GetPartitionID()))
+	w.proto3Varint(9, uint64(t.GetSegmentID()))
+
+	if err := e.appendSelectedUint64(w, 10, e.source.GetTimestamps()); err != nil {
+		return err
+	}
+	if err := e.appendSelectedInt64(w, 11, e.source.GetRowIDs()); err != nil {
+		return err
+	}
+
+	for i, field := range e.source.GetFieldsData() {
+		if field == nil {
+			return insertViewInternal("source FieldsData[%d] is nil", i)
+		}
+		if field.GetStructArrays() != nil {
+			return insertViewInternal("source field %q (%d) still contains StructArrays; proxy must flatten struct fields before repacking", field.GetFieldName(), field.GetFieldId())
+		}
+		fieldSize, err := w.plannedInt()
+		if err != nil {
+			return err
+		}
+		if err := w.message(13, fieldSize, func() error {
+			return e.appendFieldData(w, i, field)
+		}); err != nil {
+			return err
+		}
+	}
+
+	w.proto3Varint(14, uint64(len(e.rows)))
+	w.proto3Varint(15, uint64(t.GetVersion()))
+	if t.Namespace != nil {
+		if err := w.string(16, *t.Namespace, true, "namespace"); err != nil {
+			return err
+		}
+	}
+
+	// A shallow-copy-and-overwrite implementation would retain template unknown
+	// fields. Preserve them here as well so future metadata remains wire-safe.
+	w.raw(t.ProtoReflect().GetUnknown())
+	return w.err
+}
+
+func (e *InsertRequestViewEncoder) appendSelectedUint64(w *insertViewWriter, fieldNumber protowire.Number, values []uint64) error {
+	if len(e.rows) == 0 {
+		return nil
+	}
+	payloadSize, err := w.plannedInt()
+	if err != nil {
+		return err
+	}
+	return w.message(fieldNumber, payloadSize, func() error {
+		for _, row := range e.rows {
+			w.varint(values[row])
+		}
+		return w.err
+	})
+}
+
+func (e *InsertRequestViewEncoder) appendSelectedInt64(w *insertViewWriter, fieldNumber protowire.Number, values []int64) error {
+	if len(e.rows) == 0 {
+		return nil
+	}
+	payloadSize, err := w.plannedInt()
+	if err != nil {
+		return err
+	}
+	return w.message(fieldNumber, payloadSize, func() error {
+		for _, row := range e.rows {
+			w.varint(uint64(values[row]))
+		}
+		return w.err
+	})
+}
+
+func (e *InsertRequestViewEncoder) appendFieldData(w *insertViewWriter, fieldIndex int, field *schemapb.FieldData) error {
+	w.proto3Varint(1, uint64(field.GetType()))
+	if err := w.proto3String(2, field.GetFieldName(), "field name"); err != nil {
+		return err
+	}
+
+	switch value := field.Field.(type) {
+	case nil:
+		// Match AppendFieldData: metadata survives even if the source has no
+		// scalar/vector payload.
+	case *schemapb.FieldData_Scalars:
+		if value.Scalars == nil {
+			return insertViewInternal("scalar field %q (%d) has a nil ScalarField", field.GetFieldName(), field.GetFieldId())
+		}
+		scalarSize, err := w.plannedInt()
+		if err != nil {
+			return err
+		}
+		if err := w.message(3, scalarSize, func() error {
+			return e.appendScalarField(w, fieldIndex, value.Scalars)
+		}); err != nil {
+			return err
+		}
+	case *schemapb.FieldData_Vectors:
+		if value.Vectors == nil {
+			return insertViewInternal("vector field %q (%d) has a nil VectorField", field.GetFieldName(), field.GetFieldId())
+		}
+		vectorSize, err := w.plannedInt()
+		if err != nil {
+			return err
+		}
+		if err := w.message(4, vectorSize, func() error {
+			return e.appendVectorField(w, fieldIndex, field, value.Vectors)
+		}); err != nil {
+			return err
+		}
+	case *schemapb.FieldData_StructArrays:
+		return insertViewInternal("source field %q (%d) still contains StructArrays; proxy must flatten struct fields before repacking", field.GetFieldName(), field.GetFieldId())
+	default:
+		return insertViewInternal("source field %q (%d) has unsupported FieldData oneof %T", field.GetFieldName(), field.GetFieldId(), value)
+	}
+
+	w.proto3Varint(5, uint64(field.GetFieldId()))
+	if field.GetIsDynamic() {
+		w.varintField(6, 1)
+	}
+	return w.err
+}
+
+// appendFieldValidData writes the row-selected validity mask into the nested
+// ScalarField (field 17) / VectorField (field 9) message, the field-specific
+// location #52203 moved it to. It must run after every oneof value write so
+// the planned-slot consumption order matches appendPlan.
+func (e *InsertRequestViewEncoder) appendFieldValidData(w *insertViewWriter, fieldIndex int, fieldNumber protowire.Number) error {
+	if fieldIndex < 0 || fieldIndex >= len(e.fieldSizeStates) {
+		return insertViewInternal("validity payload field index %d is out of range", fieldIndex)
+	}
+	valid := e.fieldSizeStates[fieldIndex].validData
+	if len(valid) == 0 || len(e.rows) == 0 {
+		return w.err
+	}
+	validSize, err := w.plannedInt()
+	if err != nil {
+		return err
+	}
+	return w.message(fieldNumber, validSize, func() error {
+		for _, row := range e.rows {
+			if valid[row] {
+				w.varint(1)
+			} else {
+				w.varint(0)
+			}
+		}
+		return w.err
+	})
+}
+
+func (e *InsertRequestViewEncoder) appendScalarField(w *insertViewWriter, fieldIndex int, field *schemapb.ScalarField) error {
+	var err error
+	switch value := field.Data.(type) {
+	case nil:
+	case *schemapb.ScalarField_BoolData:
+		err = e.appendBoolArray(w, 1, value.BoolData)
+	case *schemapb.ScalarField_IntData:
+		err = e.appendInt32Array(w, 2, value.IntData, "int scalar")
+	case *schemapb.ScalarField_LongData:
+		err = e.appendInt64Array(w, 3, value.LongData, "long scalar")
+	case *schemapb.ScalarField_FloatData:
+		err = e.appendFloat32Array(w, 4, value.FloatData)
+	case *schemapb.ScalarField_DoubleData:
+		err = e.appendFloat64Array(w, 5, value.DoubleData)
+	case *schemapb.ScalarField_StringData:
+		err = e.appendStringArray(w, 6, value.StringData, "string scalar")
+	// These cold oneofs are declared by the current schema but are not handled
+	// by the old row-at-a-time AppendFieldData oracle. Encoding them here is a
+	// forward-safe row selection; the differential test covers the old oracle's
+	// real support set separately.
+	case *schemapb.ScalarField_BytesData:
+		err = e.appendBytesArray(w, 7, value.BytesData, "bytes scalar")
+	case *schemapb.ScalarField_ArrayData:
+		err = e.appendArrayArray(w, fieldIndex, 8, value.ArrayData)
+	case *schemapb.ScalarField_JsonData:
+		err = e.appendRawBytesRows(w, 9, value.JsonData.GetData(), "JSON scalar", value.JsonData == nil)
+	case *schemapb.ScalarField_GeometryData:
+		err = e.appendRawBytesRows(w, 10, value.GeometryData.GetData(), "geometry scalar", value.GeometryData == nil)
+	case *schemapb.ScalarField_TimestamptzData:
+		err = e.appendInt64Values(w, 11, value.TimestamptzData.GetData(), "timestamptz scalar", value.TimestamptzData == nil)
+	case *schemapb.ScalarField_GeometryWktData:
+		err = e.appendStringValues(w, 12, value.GeometryWktData.GetData(), "geometry WKT scalar", value.GeometryWktData == nil)
+	case *schemapb.ScalarField_MolData:
+		err = e.appendRawBytesRows(w, 13, value.MolData.GetData(), "molecular scalar", value.MolData == nil)
+	case *schemapb.ScalarField_MolSmilesData:
+		err = e.appendStringValues(w, 14, value.MolSmilesData.GetData(), "molecular SMILES scalar", value.MolSmilesData == nil)
+	case *schemapb.ScalarField_DateData:
+		err = e.appendInt32Values(w, 15, value.DateData.GetData(), "date scalar", value.DateData == nil)
+	case *schemapb.ScalarField_TimeData:
+		err = e.appendInt64Values(w, 16, value.TimeData.GetData(), "time scalar", value.TimeData == nil)
+	default:
+		return insertViewInternal("unsupported ScalarField oneof %T", value)
+	}
+	if err != nil {
+		return err
+	}
+	return e.appendFieldValidData(w, fieldIndex, 17)
+}
+
+func (e *InsertRequestViewEncoder) appendBoolArray(w *insertViewWriter, fieldNumber protowire.Number, values *schemapb.BoolArray) error {
+	if values == nil {
+		return insertViewInternal("nil bool scalar array")
+	}
+	payloadSize, err := w.plannedInt()
+	if err != nil {
+		return err
+	}
+	arraySize := 0
+	if payloadSize > 0 {
+		arraySize = protowire.SizeTag(1) + protowire.SizeBytes(payloadSize)
+	}
+	return w.message(fieldNumber, arraySize, func() error {
+		if payloadSize == 0 {
+			return nil
+		}
+		return w.message(1, payloadSize, func() error {
+			for _, row := range e.rows {
+				if values.GetData()[row] {
+					w.varint(1)
+				} else {
+					w.varint(0)
+				}
+			}
+			return w.err
+		})
+	})
+}
+
+func (e *InsertRequestViewEncoder) appendInt32Array(w *insertViewWriter, fieldNumber protowire.Number, values *schemapb.IntArray, label string) error {
+	if values == nil {
+		return insertViewInternal("nil %s array", label)
+	}
+	return e.appendInt32Values(w, fieldNumber, values.GetData(), label, false)
+}
+
+func (e *InsertRequestViewEncoder) appendInt64Array(w *insertViewWriter, fieldNumber protowire.Number, values *schemapb.LongArray, label string) error {
+	if values == nil {
+		return insertViewInternal("nil %s array", label)
+	}
+	return e.appendInt64Values(w, fieldNumber, values.GetData(), label, false)
+}
+
+func (e *InsertRequestViewEncoder) appendInt32Values(w *insertViewWriter, fieldNumber protowire.Number, values []int32, label string, nilArray bool) error {
+	if nilArray {
+		return insertViewInternal("nil %s array", label)
+	}
+	payloadSize, err := w.plannedInt()
+	if err != nil {
+		return err
+	}
+	arraySize := 0
+	if len(e.rows) > 0 {
+		arraySize = protowire.SizeTag(1) + protowire.SizeBytes(payloadSize)
+	}
+	return w.message(fieldNumber, arraySize, func() error {
+		if len(e.rows) == 0 {
+			return nil
+		}
+		return w.message(1, payloadSize, func() error {
+			for _, row := range e.rows {
+				w.varint(uint64(values[row]))
+			}
+			return w.err
+		})
+	})
+}
+
+func (e *InsertRequestViewEncoder) appendInt64Values(w *insertViewWriter, fieldNumber protowire.Number, values []int64, label string, nilArray bool) error {
+	if nilArray {
+		return insertViewInternal("nil %s array", label)
+	}
+	payloadSize, err := w.plannedInt()
+	if err != nil {
+		return err
+	}
+	arraySize := 0
+	if len(e.rows) > 0 {
+		arraySize = protowire.SizeTag(1) + protowire.SizeBytes(payloadSize)
+	}
+	return w.message(fieldNumber, arraySize, func() error {
+		if len(e.rows) == 0 {
+			return nil
+		}
+		return w.message(1, payloadSize, func() error {
+			for _, row := range e.rows {
+				w.varint(uint64(values[row]))
+			}
+			return w.err
+		})
+	})
+}
+
+func (e *InsertRequestViewEncoder) appendFloat32Array(w *insertViewWriter, fieldNumber protowire.Number, values *schemapb.FloatArray) error {
+	if values == nil {
+		return insertViewInternal("nil float scalar array")
+	}
+	payloadSize, err := w.plannedInt()
+	if err != nil {
+		return err
+	}
+	arraySize := 0
+	if payloadSize > 0 {
+		arraySize = protowire.SizeTag(1) + protowire.SizeBytes(payloadSize)
+	}
+	return w.message(fieldNumber, arraySize, func() error {
+		if payloadSize == 0 {
+			return nil
+		}
+		return w.message(1, payloadSize, func() error {
+			for _, row := range e.rows {
+				w.fixed32(math.Float32bits(values.GetData()[row]))
+			}
+			return w.err
+		})
+	})
+}
+
+func (e *InsertRequestViewEncoder) appendFloat64Array(w *insertViewWriter, fieldNumber protowire.Number, values *schemapb.DoubleArray) error {
+	if values == nil {
+		return insertViewInternal("nil double scalar array")
+	}
+	payloadSize, err := w.plannedInt()
+	if err != nil {
+		return err
+	}
+	arraySize := 0
+	if payloadSize > 0 {
+		arraySize = protowire.SizeTag(1) + protowire.SizeBytes(payloadSize)
+	}
+	return w.message(fieldNumber, arraySize, func() error {
+		if payloadSize == 0 {
+			return nil
+		}
+		return w.message(1, payloadSize, func() error {
+			for _, row := range e.rows {
+				w.fixed64(math.Float64bits(values.GetData()[row]))
+			}
+			return w.err
+		})
+	})
+}
+
+func (e *InsertRequestViewEncoder) appendStringArray(w *insertViewWriter, fieldNumber protowire.Number, values *schemapb.StringArray, label string) error {
+	if values == nil {
+		return insertViewInternal("nil %s array", label)
+	}
+	return e.appendStringValues(w, fieldNumber, values.GetData(), label, false)
+}
+
+func (e *InsertRequestViewEncoder) appendStringValues(w *insertViewWriter, fieldNumber protowire.Number, values []string, label string, nilArray bool) error {
+	if nilArray {
+		return insertViewInternal("nil %s array", label)
+	}
+	arraySize, err := w.plannedInt()
+	if err != nil {
+		return err
+	}
+	return w.message(fieldNumber, arraySize, func() error {
+		for _, row := range e.rows {
+			w.stringBytes(1, values[row])
+		}
+		return w.err
+	})
+}
+
+func (e *InsertRequestViewEncoder) appendBytesArray(w *insertViewWriter, fieldNumber protowire.Number, values *schemapb.BytesArray, label string) error {
+	if values == nil {
+		return insertViewInternal("nil %s array", label)
+	}
+	return e.appendRawBytesRows(w, fieldNumber, values.GetData(), label, false)
+}
+
+func (e *InsertRequestViewEncoder) appendRawBytesRows(w *insertViewWriter, fieldNumber protowire.Number, values [][]byte, label string, nilArray bool) error {
+	if nilArray {
+		return insertViewInternal("nil %s array", label)
+	}
+	arraySize, err := w.plannedInt()
+	if err != nil {
+		return err
+	}
+	return w.message(fieldNumber, arraySize, func() error {
+		for _, row := range e.rows {
+			w.bytes(1, values[row])
+		}
+		return w.err
+	})
+}
+
+func (e *InsertRequestViewEncoder) appendArrayArray(w *insertViewWriter, fieldIndex int, fieldNumber protowire.Number, values *schemapb.ArrayArray) error {
+	if values == nil {
+		return insertViewInternal("nil array scalar payload")
+	}
+	if fieldIndex < 0 || fieldIndex >= len(e.fieldSizeStates) {
+		return insertViewInternal("array cell payload field index %d is out of range", fieldIndex)
+	}
+	arrayOrdinal := e.fieldSizeStates[fieldIndex].arrayOrdinal
+	if arrayOrdinal < 0 || arrayOrdinal >= e.arrayFieldCount {
+		return insertViewInternal("array field %d has invalid payload ordinal %d of %d", fieldIndex, arrayOrdinal, e.arrayFieldCount)
+	}
+	expectedPayloads, err := checkedProduct(len(e.rows), e.arrayFieldCount, "array cell payload plan")
+	if err != nil {
+		return err
+	}
+	if len(e.arrayCellPayloads) != expectedPayloads {
+		return insertViewInternal("array cell payload plan has %d entries, expected %d", len(e.arrayCellPayloads), expectedPayloads)
+	}
+	arraySize, err := w.plannedInt()
+	if err != nil {
+		return err
+	}
+	return w.message(fieldNumber, arraySize, func() error {
+		for i, row := range e.rows {
+			payload := e.arrayCellPayloads[i*e.arrayFieldCount+arrayOrdinal]
+			if err := appendArrayCell(w, values.GetData()[row], payload); err != nil {
+				return err
+			}
+		}
+		w.proto3Varint(2, uint64(values.GetElementType()))
+		return w.err
+	})
+}
+
+// appendArrayCell writes one ArrayArray element. The sizing pass stores one
+// payload token per selected cell in cursor scratch: a non-negative arithmetic
+// payload size or scalarCellProtoFallbackPayload. Replaying that token removes
+// the second O(elements) sizing traversal while the writer's byte-count checks
+// detect borrowed-data mutation.
+func appendArrayCell(w *insertViewWriter, cell *schemapb.ScalarField, payload int) error {
+	plan, ok := classifyScalarCell(cell)
+	if payload == scalarCellProtoFallbackPayload {
+		if ok {
+			return insertViewInternal("array cell classification changed after planning: expected protobuf fallback")
+		}
+		return w.protoMessage(1, cell, "array scalar row")
+	}
+	if payload < 0 {
+		return insertViewInternal("array cell plan contains invalid payload size %d", payload)
+	}
+	if !ok {
+		return insertViewInternal("array cell classification changed after planning: expected arithmetic path")
+	}
+	plan.payload = payload
+	return w.message(1, plan.scalarCellSize(), func() error {
+		return appendScalarCell(w, cell, plan)
+	})
+}
+
+func (e *InsertRequestViewEncoder) appendVectorField(w *insertViewWriter, fieldIndex int, field *schemapb.FieldData, vector *schemapb.VectorField) error {
+	var err error
+	switch value := vector.Data.(type) {
+	case nil:
+		w.proto3Varint(1, uint64(vector.GetDim()))
+		err = w.err
+	case *schemapb.VectorField_BinaryVector:
+		err = e.appendDenseBytesVector(w, fieldIndex, field, vector.GetDim(), 3, value.BinaryVector, 8, "binary vector")
+	case *schemapb.VectorField_FloatVector:
+		err = e.appendFloatVector(w, fieldIndex, field, vector.GetDim(), value.FloatVector)
+	case *schemapb.VectorField_Float16Vector:
+		err = e.appendDenseBytesVector(w, fieldIndex, field, vector.GetDim(), 4, value.Float16Vector, 2, "float16 vector")
+	case *schemapb.VectorField_Bfloat16Vector:
+		err = e.appendDenseBytesVector(w, fieldIndex, field, vector.GetDim(), 5, value.Bfloat16Vector, 2, "bfloat16 vector")
+	case *schemapb.VectorField_SparseFloatVector:
+		err = e.appendSparseVector(w, fieldIndex, field, vector, value.SparseFloatVector)
+	case *schemapb.VectorField_Int8Vector:
+		err = e.appendDenseBytesVector(w, fieldIndex, field, vector.GetDim(), 7, value.Int8Vector, 1, "int8 vector")
+	case *schemapb.VectorField_VectorArray:
+		err = e.appendVectorArray(w, fieldIndex, vector, value.VectorArray)
+	default:
+		return insertViewInternal("field %q (%d) has unsupported VectorField oneof %T", field.GetFieldName(), field.GetFieldId(), value)
+	}
+	if err != nil {
+		return err
+	}
+	return e.appendFieldValidData(w, fieldIndex, 9)
+}
+
+// appendDenseBytesVector handles byte-backed dense vectors. unit denotes bytes
+// per dimension, except binary vectors where unit=8 means dimensions per byte.
+func (e *InsertRequestViewEncoder) appendDenseBytesVector(w *insertViewWriter, fieldIndex int, field *schemapb.FieldData, dim int64, fieldNumber protowire.Number, data []byte, unit int, label string) error {
+	stride, err := denseVectorStride(dim, unit, label)
+	if err != nil {
+		return err
+	}
+	selected, err := w.plannedInt()
+	if err != nil {
+		return err
+	}
+	w.proto3Varint(1, uint64(dim))
+	if selected == 0 {
+		return w.err
+	}
+	payloadSize, err := checkedProduct(selected, stride, label+" payload")
+	if err != nil {
+		return err
+	}
+	return w.message(fieldNumber, payloadSize, func() error {
+		_, err := e.countSelectedVectorRows(fieldIndex, field, func(dataIndex int) error {
+			start, end, err := vectorBounds(dataIndex, stride, len(data), field, label)
+			if err != nil {
+				return err
+			}
+			w.raw(data[start:end])
+			return w.err
+		})
+		return err
+	})
+}
+
+func (e *InsertRequestViewEncoder) appendFloatVector(w *insertViewWriter, fieldIndex int, field *schemapb.FieldData, dim int64, values *schemapb.FloatArray) error {
+	if values == nil {
+		return insertViewInternal("field %q (%d) has a nil float vector payload", field.GetFieldName(), field.GetFieldId())
+	}
+	stride, err := nonNegativeDim(dim, "float vector")
+	if err != nil {
+		return err
+	}
+	selected, err := w.plannedInt()
+	if err != nil {
+		return err
+	}
+	w.proto3Varint(1, uint64(dim))
+	if selected == 0 {
+		return w.err
+	}
+	elementCount, err := checkedProduct(selected, stride, "float vector element count")
+	if err != nil {
+		return err
+	}
+	payloadSize, err := checkedProduct(elementCount, 4, "float vector payload")
+	if err != nil {
+		return err
+	}
+	floatArraySize := 0
+	if payloadSize > 0 {
+		floatArraySize = protowire.SizeTag(1) + protowire.SizeBytes(payloadSize)
+	}
+	return w.message(2, floatArraySize, func() error {
+		if payloadSize == 0 {
+			return nil
+		}
+		return w.message(1, payloadSize, func() error {
+			_, err := e.countSelectedVectorRows(fieldIndex, field, func(dataIndex int) error {
+				start, end, err := vectorBounds(dataIndex, stride, len(values.GetData()), field, "float vector")
+				if err != nil {
+					return err
+				}
+				w.raw(f32ReadOnlyBytes(values.GetData()[start:end]))
+				return w.err
+			})
+			return err
+		})
+	})
+}
+
+func (e *InsertRequestViewEncoder) appendSparseVector(w *insertViewWriter, fieldIndex int, field *schemapb.FieldData, vector *schemapb.VectorField, values *schemapb.SparseFloatArray) error {
+	if values == nil {
+		return insertViewInternal("field %q (%d) has a nil sparse vector payload", field.GetFieldName(), field.GetFieldId())
+	}
+	selected, err := w.plannedInt()
+	if err != nil {
+		return err
+	}
+	sparseSize, err := w.plannedInt()
+	if err != nil {
+		return err
+	}
+	selectedDimSize, err := w.plannedInt()
+	if err != nil {
+		return err
+	}
+	selectedDim := int64(selectedDimSize)
+
+	outerDim := vector.GetDim()
+	if selected > 0 {
+		// This intentionally matches AppendFieldData's sparse-vector behavior:
+		// once data is present, VectorField.Dim comes from SparseFloatArray.Dim.
+		outerDim = values.GetDim()
+	}
+	w.proto3Varint(1, uint64(outerDim))
+	if selected == 0 {
+		return w.err
+	}
+	if selectedDim != 0 {
+		sparseSize += protowire.SizeTag(2) + protowire.SizeVarint(uint64(selectedDim))
+	}
+	return w.message(6, sparseSize, func() error {
+		_, err := e.countSelectedVectorRows(fieldIndex, field, func(dataIndex int) error {
+			w.bytes(1, values.GetContents()[dataIndex])
+			return w.err
+		})
+		if err != nil {
+			return err
+		}
+		w.proto3Varint(2, uint64(selectedDim))
+		return w.err
+	})
+}
+
+func (e *InsertRequestViewEncoder) appendVectorArray(w *insertViewWriter, fieldIndex int, vector *schemapb.VectorField, values *schemapb.VectorArray) error {
+	if values == nil {
+		return insertViewInternal("nil ArrayOfVector payload")
+	}
+	if fieldIndex < 0 || fieldIndex >= len(e.fieldSizeStates) {
+		return insertViewInternal("ArrayOfVector cell payload field index %d is out of range", fieldIndex)
+	}
+	arrayOrdinal := e.fieldSizeStates[fieldIndex].arrayOrdinal
+	if arrayOrdinal < 0 || arrayOrdinal >= e.arrayFieldCount {
+		return insertViewInternal("ArrayOfVector field %d has invalid payload ordinal %d of %d", fieldIndex, arrayOrdinal, e.arrayFieldCount)
+	}
+	expectedPayloads, err := checkedProduct(len(e.rows), e.arrayFieldCount, "nested cell payload plan")
+	if err != nil {
+		return err
+	}
+	if len(e.arrayCellPayloads) != expectedPayloads {
+		return insertViewInternal("nested cell payload plan has %d entries, expected %d", len(e.arrayCellPayloads), expectedPayloads)
+	}
+	w.proto3Varint(1, uint64(vector.GetDim()))
+	arraySize, err := w.plannedInt()
+	if err != nil {
+		return err
+	}
+	return w.message(8, arraySize, func() error {
+		w.proto3Varint(1, uint64(values.GetDim()))
+		for i, row := range e.rows {
+			payload := e.arrayCellPayloads[i*e.arrayFieldCount+arrayOrdinal]
+			if err := appendVectorArrayCell(w, values.GetData()[row], payload); err != nil {
+				return err
+			}
+		}
+		w.proto3Varint(3, uint64(values.GetElementType()))
+		return w.err
+	})
+}
+
+func appendVectorArrayCell(w *insertViewWriter, cell *schemapb.VectorField, payload int) error {
+	plan, ok, err := classifyVectorArrayCell(cell)
+	if err != nil {
+		return err
+	}
+	if payload == vectorArrayCellProtoFallback {
+		if ok {
+			return insertViewInternal("ArrayOfVector cell classification changed after planning: expected protobuf fallback")
+		}
+		return w.protoMessage(2, cell, "ArrayOfVector row")
+	}
+	if payload < 0 {
+		return insertViewInternal("ArrayOfVector cell plan contains invalid payload size %d", payload)
+	}
+	if !ok {
+		return insertViewInternal("ArrayOfVector cell classification changed after planning: expected arithmetic path")
+	}
+	if payload != plan.payloadSize {
+		return insertViewInternal("ArrayOfVector cell payload changed after planning: expected %d, got %d", payload, plan.payloadSize)
+	}
+	return w.message(2, plan.cellSize, func() error {
+		if isNilProto(cell) {
+			return nil
+		}
+		w.proto3Varint(1, uint64(cell.GetDim()))
+		if plan.kind != vectorArrayCellPlanFloat {
+			return w.err
+		}
+		values := cell.GetFloatVector().GetData()
+		return w.message(2, plan.floatArraySize, func() error {
+			if payload == 0 {
+				return nil
+			}
+			return w.message(1, payload, func() error {
+				w.raw(f32ReadOnlyBytes(values))
+				return w.err
+			})
+		})
+	})
+}
+
+// countSelectedVectorRows converts logical row offsets into physical compact
+// vector indices. Nullable scalar columns and ArrayOfVector remain dense; this
+// helper is used only for the regular vector oneofs whose null payload is
+// compacted according to ValidData.
+func (e *InsertRequestViewEncoder) countSelectedVectorRows(fieldIndex int, field *schemapb.FieldData, visit func(dataIndex int) error) (int, error) {
+	valid := insertFieldValidData(field)
+	if len(valid) == 0 {
+		for _, row := range e.rows {
+			if err := visit(row); err != nil {
+				return 0, err
+			}
+		}
+		return len(e.rows), nil
+	}
+
+	dataIndex := 0
+	scanRow := 0
+	if len(e.rows) > 0 && len(e.firstFieldDataIndices) == len(e.source.GetFieldsData()) {
+		if fieldIndex < 0 || fieldIndex >= len(e.firstFieldDataIndices) {
+			return 0, insertViewInternal("field index %d is outside the borrowed source request", fieldIndex)
+		}
+		dataIndex = int(e.firstFieldDataIndices[fieldIndex])
+		scanRow = e.rows[0]
+	}
+	selected := 0
+	for _, row := range e.rows {
+		if row >= len(valid) {
+			return 0, insertViewInternal("row offset %d exceeds ValidData length %d for field %q (%d)", row, len(valid), field.GetFieldName(), field.GetFieldId())
+		}
+		for scanRow < row {
+			if valid[scanRow] {
+				dataIndex++
+			}
+			scanRow++
+		}
+		if valid[row] {
+			if err := visit(dataIndex); err != nil {
+				return 0, err
+			}
+			selected++
+			dataIndex++
+		}
+		scanRow = row + 1
+	}
+	return selected, nil
+}
+
+func denseVectorStride(dim int64, unit int, label string) (int, error) {
+	d, err := nonNegativeDim(dim, label)
+	if err != nil {
+		return 0, err
+	}
+	if unit == 8 {
+		if d%8 != 0 {
+			return 0, insertViewInternal("%s dimension %d is not divisible by 8", label, dim)
+		}
+		return d / 8, nil
+	}
+	return checkedProduct(d, unit, label+" row width")
+}
+
+func nonNegativeDim(dim int64, label string) (int, error) {
+	if dim < 0 || uint64(dim) > uint64(math.MaxInt) {
+		return 0, insertViewInternal("%s has invalid dimension %d", label, dim)
+	}
+	return int(dim), nil
+}
+
+func vectorBounds(dataIndex, stride, dataLength int, field *schemapb.FieldData, label string) (int, int, error) {
+	if dataIndex < 0 {
+		return 0, 0, insertViewInternal("negative compact %s index %d for field %q (%d)", label, dataIndex, field.GetFieldName(), field.GetFieldId())
+	}
+	if stride == 0 {
+		return 0, 0, nil
+	}
+	if dataIndex > dataLength/stride {
+		return 0, 0, insertViewInternal("compact %s index %d exceeds payload length %d for field %q (%d)", label, dataIndex, dataLength, field.GetFieldName(), field.GetFieldId())
+	}
+	start := dataIndex * stride
+	if start > dataLength-stride {
+		return 0, 0, insertViewInternal("compact %s row %d needs [%d:%d], payload length is %d for field %q (%d)", label, dataIndex, start, start+stride, dataLength, field.GetFieldName(), field.GetFieldId())
+	}
+	return start, start + stride, nil
+}
+
+func sparseRowDim(row []byte) (int64, error) {
+	if len(row) == 0 {
+		return 0, nil
+	}
+	if len(row)%8 != 0 {
+		return 0, insertViewInternal("sparse row length %d is not a multiple of 8", len(row))
+	}
+	lastIndex := binary.LittleEndian.Uint32(row[len(row)-8:])
+	return int64(lastIndex) + 1, nil
+}
+
+func checkedProduct(a, b int, label string) (int, error) {
+	if a < 0 || b < 0 || (a != 0 && b > math.MaxInt/a) {
+		return 0, insertViewInternal("%s exceeds addressable memory", label)
+	}
+	return a * b, nil
+}
+
+func prepareSizePlan(plan []int, fieldCount int) []int {
+	capacity, err := checkedProduct(fieldCount, 6, "encoded size plan capacity")
+	if err != nil || capacity > math.MaxInt-8 {
+		return plan[:0]
+	}
+	capacity += 8
+	if cap(plan) < capacity {
+		return make([]int, 0, capacity)
+	}
+	return plan[:0]
+}
+
+func nullableProtoSize(message proto.Message, useCachedSize bool) int {
+	if isNilProto(message) {
+		return 0
+	}
+	return nestedMessageMarshalOptions(useCachedSize).Size(message)
+}
+
+func nestedMessageMarshalOptions(useCachedSize bool) proto.MarshalOptions {
+	return proto.MarshalOptions{
+		AllowPartial:  true,
+		UseCachedSize: useCachedSize,
+	}
+}
+
+func isNilProto(message proto.Message) bool {
+	if message == nil {
+		return true
+	}
+	switch message := message.(type) {
+	case *schemapb.ScalarField:
+		return message == nil
+	case *schemapb.VectorField:
+		return message == nil
+	}
+	value := reflect.ValueOf(message)
+	return value.Kind() == reflect.Ptr && value.IsNil()
+}
+
+func insertViewInternal(format string, args ...any) error {
+	return merr.WrapErrServiceInternalMsg("insert request view: "+format, args...)
+}
+
+type insertViewWriter struct {
+	out       []byte
+	n         int
+	err       error
+	sizePlan  *[]int
+	planIndex int
+}
+
+func newInsertViewMarshalWriter(dst []byte, sizePlan *[]int) *insertViewWriter {
+	return &insertViewWriter{out: dst, sizePlan: sizePlan}
+}
+
+// plannedInt replays aggregate sizes produced by the incremental exact splitter
+// in the same pre-order used by MarshalTo.
+func (w *insertViewWriter) plannedInt() (int, error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+	if w.sizePlan == nil {
+		return 0, insertViewInternal("missing encoded size plan")
+	}
+	if w.planIndex >= len(*w.sizePlan) {
+		return 0, insertViewInternal("encoded size plan exhausted at entry %d", w.planIndex)
+	}
+	size := (*w.sizePlan)[w.planIndex]
+	w.planIndex++
+	return size, nil
+}
+
+// appendBulk writes a run of values whose combined size is already known,
+// charging the writer once instead of per value. The per-value helpers below
+// each recompute the value's size to advance w.n; for a packed array that size
+// was already computed during sizing, so replaying it here would double the
+// varint work on the hot path. appendValues must append exactly size bytes --
+// verified rather than trusted, since a mismatch would silently desynchronize
+// the length prefix from the payload.
+func (w *insertViewWriter) appendBulk(size int, appendValues func([]byte) []byte) {
+	if w.err != nil {
+		return
+	}
+	start := len(w.out)
+	w.out = appendValues(w.out)
+	if actual := len(w.out) - start; actual != size {
+		w.err = insertViewInternal("bulk append wrote %d bytes, expected %d", actual, size)
+		return
+	}
+	w.add(size)
+}
+
+func (w *insertViewWriter) add(n int) {
+	if w.err != nil {
+		return
+	}
+	if n < 0 || w.n > math.MaxInt-n {
+		w.err = insertViewInternal("protobuf size exceeds addressable memory")
+		return
+	}
+	w.n += n
+}
+
+func (w *insertViewWriter) tag(number protowire.Number, typ protowire.Type) {
+	if w.err != nil {
+		return
+	}
+	w.add(protowire.SizeTag(number))
+	w.out = protowire.AppendTag(w.out, number, typ)
+}
+
+func (w *insertViewWriter) varint(value uint64) {
+	if w.err != nil {
+		return
+	}
+	w.add(protowire.SizeVarint(value))
+	w.out = protowire.AppendVarint(w.out, value)
+}
+
+func (w *insertViewWriter) fixed32(value uint32) {
+	if w.err != nil {
+		return
+	}
+	w.add(4)
+	w.out = protowire.AppendFixed32(w.out, value)
+}
+
+func (w *insertViewWriter) fixed64(value uint64) {
+	if w.err != nil {
+		return
+	}
+	w.add(8)
+	w.out = protowire.AppendFixed64(w.out, value)
+}
+
+func (w *insertViewWriter) raw(value []byte) {
+	if w.err != nil {
+		return
+	}
+	w.add(len(value))
+	w.out = append(w.out, value...)
+}
+
+func (w *insertViewWriter) varintField(number protowire.Number, value uint64) {
+	w.tag(number, protowire.VarintType)
+	w.varint(value)
+}
+
+func (w *insertViewWriter) proto3Varint(number protowire.Number, value uint64) {
+	if value != 0 {
+		w.varintField(number, value)
+	}
+}
+
+func (w *insertViewWriter) proto3String(number protowire.Number, value, label string) error {
+	return w.string(number, value, false, label)
+}
+
+func (w *insertViewWriter) string(number protowire.Number, value string, force bool, label string) error {
+	if !force && value == "" {
+		return nil
+	}
+	w.stringBytes(number, value)
+	return w.err
+}
+
+func (w *insertViewWriter) stringBytes(number protowire.Number, value string) {
+	w.tag(number, protowire.BytesType)
+	w.varint(uint64(len(value)))
+	if w.err != nil {
+		return
+	}
+	w.add(len(value))
+	w.out = append(w.out, value...)
+}
+
+func (w *insertViewWriter) bytes(number protowire.Number, value []byte) {
+	w.tag(number, protowire.BytesType)
+	w.varint(uint64(len(value)))
+	w.raw(value)
+}
+
+func (w *insertViewWriter) message(number protowire.Number, size int, appendBody func() error) error {
+	if size < 0 {
+		return insertViewInternal("negative nested protobuf size %d", size)
+	}
+	w.tag(number, protowire.BytesType)
+	w.varint(uint64(size))
+	if w.err != nil {
+		return w.err
+	}
+	start := w.n
+	if err := appendBody(); err != nil {
+		return err
+	}
+	if w.err != nil {
+		return w.err
+	}
+	if actual := w.n - start; actual != size {
+		return insertViewInternal("nested protobuf size changed while borrowed data was in use: expected %d, wrote %d", size, actual)
+	}
+	return nil
+}
+
+func (w *insertViewWriter) protoMessage(number protowire.Number, message proto.Message, label string) error {
+	if isNilProto(message) {
+		return w.message(number, 0, func() error { return nil })
+	}
+	// The size pass seeds protobuf's per-message size cache. Reuse it through
+	// protobuf's public API during MarshalTo; with the current generated runtime,
+	// this avoids recursively traversing every ARRAY/ArrayOfVector row again.
+	options := nestedMessageMarshalOptions(true)
+	size := options.Size(message)
+	return w.message(number, size, func() error {
+		if size == 0 {
+			return nil
+		}
+		startLen := len(w.out)
+		out, err := options.MarshalAppend(w.out, message)
+		if err != nil {
+			return merr.WrapErrServiceInternalErr(err, "failed to marshal %s", label)
+		}
+		actual := len(out) - startLen
+		w.out = out
+		w.add(actual)
+		if actual != size {
+			return insertViewInternal("%s size changed while borrowed data was in use: expected %d, wrote %d", label, size, actual)
+		}
+		return w.err
+	})
+}

--- a/pkg/util/fastpb/insert_request_view_bench_test.go
+++ b/pkg/util/fastpb/insert_request_view_bench_test.go
@@ -1,0 +1,732 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fastpb
+
+import (
+	"encoding/binary"
+	"strconv"
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	msgpb "github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	schemapb "github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+var insertRequestViewBenchmarkSink []byte
+
+// BenchmarkInsertRequestViewDataTypes10K compares the master materialize +
+// proto.Marshal path with the borrowed view encoder over representative scalar,
+// document, nested, dense, nullable, sparse, and ArrayOfVector payloads.
+func BenchmarkInsertRequestViewDataTypes10K(b *testing.B) {
+	const (
+		rowCount  = 10_000
+		vectorDim = 768
+	)
+	rows, rowIDs, timestamps := benchmarkInsertRows(rowCount)
+
+	bools := make([]bool, rowCount)
+	int32s := make([]int32, rowCount)
+	int64s := make([]int64, rowCount)
+	doubles := make([]float64, rowCount)
+	varchars := make([]string, rowCount)
+	jsonRows := make([][]byte, rowCount)
+	arrayRows := make([]*schemapb.ScalarField, rowCount)
+	sparseRows := make([][]byte, rowCount)
+	arrayOfVectorRows := make([]*schemapb.VectorField, rowCount)
+	valid := make([]bool, rowCount)
+
+	document := strings.Repeat("Milvus vector database payload. ", 32)
+	floatVectors := make([]float32, rowCount*vectorDim)
+	nullableFloatVectors := make([]float32, 0, rowCount*vectorDim/2)
+	binaryVectors := make([]byte, rowCount*vectorDim/8)
+	float16Vectors := make([]byte, rowCount*vectorDim*2)
+	bfloat16Vectors := make([]byte, rowCount*vectorDim*2)
+	int8Vectors := make([]byte, rowCount*vectorDim)
+
+	for row := 0; row < rowCount; row++ {
+		bools[row] = row%2 == 0
+		int32s[row] = int32(row * 17)
+		int64s[row] = int64(row * 17)
+		doubles[row] = float64(row) + 0.25
+		varchars[row] = document + strconv.Itoa(row)
+		jsonRows[row] = []byte(`{"row":` + strconv.Itoa(row) + `,"payload":"` + document + `"}`)
+
+		arrayValues := make([]int64, 64)
+		for element := range arrayValues {
+			arrayValues[element] = int64(row*64 + element)
+		}
+		arrayRows[row] = &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+			LongData: &schemapb.LongArray{Data: arrayValues},
+		}}
+
+		sparseRows[row] = benchmarkSparseRow(32)
+		arrayOfVectorValues := make([]float32, 128)
+		for column := range arrayOfVectorValues {
+			arrayOfVectorValues[column] = float32(row + column)
+		}
+		arrayOfVectorRows[row] = &schemapb.VectorField{
+			Dim: 128,
+			Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{
+				Data: arrayOfVectorValues,
+			}},
+		}
+
+		valid[row] = row%2 == 0
+		for column := 0; column < vectorDim; column++ {
+			value := byte(row + column)
+			floatVectors[row*vectorDim+column] = float32(row + column)
+			int8Vectors[row*vectorDim+column] = value
+			float16Vectors[(row*vectorDim+column)*2] = value
+			bfloat16Vectors[(row*vectorDim+column)*2] = value
+			if valid[row] {
+				nullableFloatVectors = append(nullableFloatVectors, float32(row+column))
+			}
+		}
+		for column := 0; column < vectorDim/8; column++ {
+			binaryVectors[row*vectorDim/8+column] = byte(row + column)
+		}
+	}
+
+	request := func(field *schemapb.FieldData) *msgpb.InsertRequest {
+		return &msgpb.InsertRequest{
+			NumRows: rowCount, RowIDs: rowIDs, Timestamps: timestamps,
+			FieldsData: []*schemapb.FieldData{field},
+		}
+	}
+	cases := []struct {
+		name   string
+		source *msgpb.InsertRequest
+	}{
+		{"rowid_timestamp_only", &msgpb.InsertRequest{NumRows: rowCount, RowIDs: rowIDs, Timestamps: timestamps}},
+		{"bool", request(scalarField(100, schemapb.DataType_Bool, &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{Data: bools}}))},
+		{"int32", request(scalarField(100, schemapb.DataType_Int32, &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: int32s}}))},
+		{"int64", request(scalarField(100, schemapb.DataType_Int64, &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: int64s}}))},
+		{"double", request(scalarField(100, schemapb.DataType_Double, &schemapb.ScalarField_DoubleData{DoubleData: &schemapb.DoubleArray{Data: doubles}}))},
+		{"varchar_1kib", request(scalarField(100, schemapb.DataType_VarChar, &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: varchars}}))},
+		{"json_1kib", request(scalarField(100, schemapb.DataType_JSON, &schemapb.ScalarField_JsonData{JsonData: &schemapb.JSONArray{Data: jsonRows}}))},
+		{"array_64_int64", request(scalarField(100, schemapb.DataType_Array, &schemapb.ScalarField_ArrayData{ArrayData: &schemapb.ArrayArray{Data: arrayRows, ElementType: schemapb.DataType_Int64}}))},
+		{"binary_vector_768", request(vectorField(100, schemapb.DataType_BinaryVector, vectorDim, &schemapb.VectorField_BinaryVector{BinaryVector: binaryVectors}, nil))},
+		{"float_vector_768", request(vectorField(100, schemapb.DataType_FloatVector, vectorDim, &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: floatVectors}}, nil))},
+		{"nullable_float_vector_768_50pct", request(vectorField(100, schemapb.DataType_FloatVector, vectorDim, &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: nullableFloatVectors}}, valid))},
+		{"float16_vector_768", request(vectorField(100, schemapb.DataType_Float16Vector, vectorDim, &schemapb.VectorField_Float16Vector{Float16Vector: float16Vectors}, nil))},
+		{"bfloat16_vector_768", request(vectorField(100, schemapb.DataType_BFloat16Vector, vectorDim, &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: bfloat16Vectors}, nil))},
+		{"int8_vector_768", request(vectorField(100, schemapb.DataType_Int8Vector, vectorDim, &schemapb.VectorField_Int8Vector{Int8Vector: int8Vectors}, nil))},
+		{"sparse_vector_32nnz", request(vectorField(100, schemapb.DataType_SparseFloatVector, 4096, &schemapb.VectorField_SparseFloatVector{SparseFloatVector: &schemapb.SparseFloatArray{Dim: 4096, Contents: sparseRows}}, nil))},
+		{"array_of_vector_float_128", request(vectorField(100, schemapb.DataType_ArrayOfVector, 128, &schemapb.VectorField_VectorArray{VectorArray: &schemapb.VectorArray{Dim: 128, ElementType: schemapb.DataType_FloatVector, Data: arrayOfVectorRows}}, nil))},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			benchmarkInsertRequestMasterVsView(b, tc.source, rows)
+		})
+	}
+}
+
+func vectorField(id int64, dataType schemapb.DataType, dim int64, data any, valid []bool) *schemapb.FieldData {
+	vector := &schemapb.VectorField{Dim: dim}
+	switch value := data.(type) {
+	case *schemapb.VectorField_BinaryVector:
+		vector.Data = value
+	case *schemapb.VectorField_FloatVector:
+		vector.Data = value
+	case *schemapb.VectorField_Float16Vector:
+		vector.Data = value
+	case *schemapb.VectorField_Bfloat16Vector:
+		vector.Data = value
+	case *schemapb.VectorField_SparseFloatVector:
+		vector.Data = value
+	case *schemapb.VectorField_Int8Vector:
+		vector.Data = value
+	case *schemapb.VectorField_VectorArray:
+		vector.Data = value
+	default:
+		panic("unsupported vector benchmark data")
+	}
+	return &schemapb.FieldData{
+		Type: dataType, FieldName: "vector", FieldId: id, ValidData: valid,
+		Field: &schemapb.FieldData_Vectors{Vectors: vector},
+	}
+}
+
+func benchmarkSparseRow(nonZero int) []byte {
+	row := make([]byte, nonZero*8)
+	for i := 0; i < nonZero; i++ {
+		binary.LittleEndian.PutUint32(row[i*8:], uint32(i*128))
+		binary.LittleEndian.PutUint32(row[i*8+4:], 0x3f800000)
+	}
+	return row
+}
+
+func benchmarkInsertRequestMasterVsView(b *testing.B, source *msgpb.InsertRequest, rows []int) {
+	b.Helper()
+	template := insertViewTemplate()
+	encoder, err := NewInsertRequestViewEncoder(template, source, rows)
+	if err != nil {
+		b.Fatal(err)
+	}
+	payloadSize, err := encoder.EncodedSize()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("master_materialize_then_proto_marshal", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(payloadSize))
+		for i := 0; i < b.N; i++ {
+			materialized := materializeWithAppendFieldData(template, source, rows)
+			payload, err := proto.Marshal(materialized)
+			if err != nil {
+				b.Fatal(err)
+			}
+			insertRequestViewBenchmarkSink = payload
+		}
+	})
+
+	b.Run("local_view_to_final_payload", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(payloadSize))
+		for i := 0; i < b.N; i++ {
+			view, err := NewInsertRequestViewEncoder(template, source, rows)
+			if err != nil {
+				b.Fatal(err)
+			}
+			size, err := view.EncodedSize()
+			if err != nil {
+				b.Fatal(err)
+			}
+			payload := make([]byte, size)
+			if _, err := view.MarshalTo(payload); err != nil {
+				b.Fatal(err)
+			}
+			insertRequestViewBenchmarkSink = payload
+		}
+	})
+
+	b.Run("master_estimate_split_materialize_marshal", func(b *testing.B) {
+		b.ReportAllocs()
+		var bytesPerIteration int64
+		var messagesPerIteration int
+		for i := 0; i < b.N; i++ {
+			encodedBytes, messages, err := benchmarkMasterSplitAndMarshal(template, source, rows, 2<<20)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if i == 0 {
+				bytesPerIteration = encodedBytes
+				messagesPerIteration = messages
+			}
+		}
+		b.SetBytes(bytesPerIteration)
+		b.ReportMetric(float64(messagesPerIteration), "messages/op")
+	})
+
+	b.Run("local_exact_split_view", func(b *testing.B) {
+		b.ReportAllocs()
+		var bytesPerIteration int64
+		var messagesPerIteration int
+		for i := 0; i < b.N; i++ {
+			encodedBytes, messages, err := benchmarkViewSplitAndMarshal(template, source, rows, (2<<20)-(4<<10))
+			if err != nil {
+				b.Fatal(err)
+			}
+			if i == 0 {
+				bytesPerIteration = encodedBytes
+				messagesPerIteration = messages
+			}
+		}
+		b.SetBytes(bytesPerIteration)
+		b.ReportMetric(float64(messagesPerIteration), "messages/op")
+	})
+}
+
+func benchmarkMasterSplitAndMarshal(template, source *msgpb.InsertRequest, rows []int, bodyBudget int) (int64, int, error) {
+	fields := source.GetFieldsData()
+	idxComputer := typeutil.NewFieldDataIdxComputer(fields)
+	requestSize := 0
+	var encodedBytes int64
+	messages := 0
+	newRequest := func() *msgpb.InsertRequest {
+		request := proto.Clone(template).(*msgpb.InsertRequest)
+		request.Timestamps = nil
+		request.RowIDs = nil
+		request.RowData = nil
+		request.FieldsData = make([]*schemapb.FieldData, len(fields))
+		request.NumRows = 0
+		return request
+	}
+	request := newRequest()
+	flush := func() error {
+		payload, err := proto.Marshal(request)
+		if err != nil {
+			return err
+		}
+		insertRequestViewBenchmarkSink = payload
+		encodedBytes += int64(len(payload))
+		messages++
+		return nil
+	}
+
+	for _, row := range rows {
+		fieldIndices := idxComputer.Compute(int64(row))
+		rowSize, err := typeutil.EstimateEntitySize(fields, row, fieldIndices...)
+		if err != nil {
+			return 0, 0, err
+		}
+		if request.GetNumRows() > 0 && requestSize+rowSize >= bodyBudget {
+			if err := flush(); err != nil {
+				return 0, 0, err
+			}
+			request = newRequest()
+			requestSize = 0
+		}
+		typeutil.AppendFieldData(request.FieldsData, fields, int64(row), fieldIndices...)
+		request.Timestamps = append(request.Timestamps, source.GetTimestamps()[row])
+		request.RowIDs = append(request.RowIDs, source.GetRowIDs()[row])
+		request.NumRows++
+		requestSize += rowSize
+	}
+	if request.GetNumRows() > 0 {
+		if err := flush(); err != nil {
+			return 0, 0, err
+		}
+	}
+	return encodedBytes, messages, nil
+}
+
+func benchmarkViewSplitAndMarshal(template, source *msgpb.InsertRequest, rows []int, bodyBudget int) (int64, int, error) {
+	cursor, err := NewInsertRequestViewCursor(source)
+	if err != nil {
+		return 0, 0, err
+	}
+	var encodedBytes int64
+	messages := 0
+	for start := 0; start < len(rows); {
+		encoder, consumed, err := cursor.NextEncoder(template, rows[start:], bodyBudget)
+		if err != nil {
+			return 0, 0, err
+		}
+		size, err := encoder.EncodedSize()
+		if err != nil {
+			return 0, 0, err
+		}
+		payload := make([]byte, size)
+		if _, err := encoder.MarshalTo(payload); err != nil {
+			return 0, 0, err
+		}
+		insertRequestViewBenchmarkSink = payload
+		encodedBytes += int64(size)
+		messages++
+		start += consumed
+	}
+	return encodedBytes, messages, nil
+}
+
+// BenchmarkInsertRequestViewEncoder10Kx768 measures the allocation difference
+// this view is designed to remove: materializing a 10k-row destination float
+// vector before protobuf marshal versus gathering directly into the final wire
+// payload.
+func BenchmarkInsertRequestViewEncoder10Kx768(b *testing.B) {
+	const (
+		rowCount = 10_000
+		dim      = 768
+	)
+	rows := make([]int, rowCount)
+	rowIDs := make([]int64, rowCount)
+	timestamps := make([]uint64, rowCount)
+	vectors := make([]float32, rowCount*dim)
+	for row := 0; row < rowCount; row++ {
+		rows[row] = row
+		rowIDs[row] = int64(row)
+		timestamps[row] = uint64(row)
+		for column := 0; column < dim; column++ {
+			vectors[row*dim+column] = float32(row + column)
+		}
+	}
+	source := &msgpb.InsertRequest{
+		NumRows:    rowCount,
+		RowIDs:     rowIDs,
+		Timestamps: timestamps,
+		FieldsData: []*schemapb.FieldData{{
+			Type:      schemapb.DataType_FloatVector,
+			FieldName: "embedding",
+			FieldId:   100,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim: dim,
+				Data: &schemapb.VectorField_FloatVector{
+					FloatVector: &schemapb.FloatArray{Data: vectors},
+				},
+			}},
+		}},
+	}
+	benchmarkInsertRequestViewEncoder(b, source, rows)
+}
+
+// BenchmarkInsertRequestViewEncoder10KVarChar1KiB covers a document-style
+// trusted string payload.
+func BenchmarkInsertRequestViewEncoder10KVarChar1KiB(b *testing.B) {
+	const rowCount = 10_000
+	rows, rowIDs, timestamps := benchmarkInsertRows(rowCount)
+	document := strings.Repeat("Milvus 向量数据库 document payload. ", 26)
+	texts := make([]string, rowCount)
+	for row := range texts {
+		texts[row] = document + strconv.Itoa(row)
+	}
+	source := &msgpb.InsertRequest{
+		NumRows:    rowCount,
+		RowIDs:     rowIDs,
+		Timestamps: timestamps,
+		FieldsData: []*schemapb.FieldData{
+			scalarField(100, schemapb.DataType_VarChar, &schemapb.ScalarField_StringData{
+				StringData: &schemapb.StringArray{Data: texts},
+			}),
+		},
+	}
+	benchmarkInsertRequestViewEncoder(b, source, rows)
+}
+
+// BenchmarkInsertRequestViewEncoder10KArray64Int64 covers nested protobuf rows,
+// whose sizes must be measured once and reused while writing the final payload.
+func BenchmarkInsertRequestViewEncoder10KArray64Int64(b *testing.B) {
+	const (
+		rowCount    = 10_000
+		elementsPer = 64
+	)
+	rows, rowIDs, timestamps := benchmarkInsertRows(rowCount)
+	arrayRows := make([]*schemapb.ScalarField, rowCount)
+	for row := range arrayRows {
+		values := make([]int64, elementsPer)
+		for element := range values {
+			values[element] = int64(row*elementsPer + element)
+		}
+		arrayRows[row] = &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+			LongData: &schemapb.LongArray{Data: values},
+		}}
+	}
+	source := &msgpb.InsertRequest{
+		NumRows:    rowCount,
+		RowIDs:     rowIDs,
+		Timestamps: timestamps,
+		FieldsData: []*schemapb.FieldData{
+			scalarField(100, schemapb.DataType_Array, &schemapb.ScalarField_ArrayData{
+				ArrayData: &schemapb.ArrayArray{
+					Data:        arrayRows,
+					ElementType: schemapb.DataType_Int64,
+				},
+			}),
+		},
+	}
+	benchmarkInsertRequestViewEncoder(b, source, rows)
+}
+
+func BenchmarkInsertRequestViewExactSplit10K(b *testing.B) {
+	const (
+		rowCount    = 10_000
+		elementsPer = 64
+		bodyBudget  = 64 << 10
+	)
+	template := insertViewTemplate()
+	rows, rowIDs, timestamps := benchmarkInsertRows(rowCount)
+	document := strings.Repeat("Milvus exact split document payload. ", 26)
+	texts := make([]string, rowCount)
+	sparseRows := make([][]byte, rowCount)
+	arrayRows := make([]*schemapb.ScalarField, rowCount)
+	vectorRows := make([]*schemapb.VectorField, rowCount)
+	for row := 0; row < rowCount; row++ {
+		texts[row] = document + strconv.Itoa(row)
+		sparseRows[row] = make([]byte, 128*8)
+		for element := 0; element < 128; element++ {
+			offset := element * 8
+			binary.LittleEndian.PutUint32(sparseRows[row][offset:], uint32(element*2+row%2))
+			binary.LittleEndian.PutUint32(sparseRows[row][offset+4:], 0x3f800000)
+		}
+		values := make([]int64, elementsPer)
+		for element := range values {
+			values[element] = int64(row*elementsPer + element)
+		}
+		arrayRows[row] = &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+			LongData: &schemapb.LongArray{Data: values},
+		}}
+		vectorRows[row] = &schemapb.VectorField{
+			Dim: 4,
+			Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{
+				Data: []float32{float32(row), 1, 2, 3},
+			}},
+		}
+	}
+
+	cases := []struct {
+		name   string
+		source *msgpb.InsertRequest
+	}{
+		{name: "varchar_1kib", source: &msgpb.InsertRequest{
+			NumRows:    rowCount,
+			RowIDs:     rowIDs,
+			Timestamps: timestamps,
+			FieldsData: []*schemapb.FieldData{
+				scalarField(100, schemapb.DataType_VarChar, &schemapb.ScalarField_StringData{
+					StringData: &schemapb.StringArray{Data: texts},
+				}),
+			},
+		}},
+		{name: "sparse_1kib", source: &msgpb.InsertRequest{
+			NumRows:    rowCount,
+			RowIDs:     rowIDs,
+			Timestamps: timestamps,
+			FieldsData: []*schemapb.FieldData{{
+				Type: schemapb.DataType_SparseFloatVector, FieldId: 100, FieldName: "sparse",
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Data: &schemapb.VectorField_SparseFloatVector{SparseFloatVector: &schemapb.SparseFloatArray{Contents: sparseRows}},
+				}},
+			}},
+		}},
+		{name: "array_and_array_of_vector", source: &msgpb.InsertRequest{
+			NumRows:    rowCount,
+			RowIDs:     rowIDs,
+			Timestamps: timestamps,
+			FieldsData: []*schemapb.FieldData{
+				scalarField(100, schemapb.DataType_Array, &schemapb.ScalarField_ArrayData{
+					ArrayData: &schemapb.ArrayArray{Data: arrayRows, ElementType: schemapb.DataType_Int64},
+				}),
+				{
+					Type: schemapb.DataType_ArrayOfVector, FieldId: 101, FieldName: "vectors",
+					Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+						Dim: 4,
+						Data: &schemapb.VectorField_VectorArray{VectorArray: &schemapb.VectorArray{
+							Dim: 4, ElementType: schemapb.DataType_FloatVector, Data: vectorRows,
+						}},
+					}},
+				},
+			},
+		}},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			var bytesPerIteration int64
+			for i := 0; i < b.N; i++ {
+				cursor, err := NewInsertRequestViewCursor(tc.source)
+				if err != nil {
+					b.Fatal(err)
+				}
+				var encodedBytes int64
+				for start := 0; start < len(rows); {
+					encoder, consumed, err := cursor.NextEncoder(template, rows[start:], bodyBudget)
+					if err != nil {
+						b.Fatal(err)
+					}
+					size, err := encoder.EncodedSize()
+					if err != nil {
+						b.Fatal(err)
+					}
+					payload := make([]byte, size)
+					if _, err := encoder.MarshalTo(payload); err != nil {
+						b.Fatal(err)
+					}
+					encodedBytes += int64(size)
+					insertRequestViewBenchmarkSink = payload
+					start += consumed
+				}
+				if i == 0 {
+					bytesPerIteration = encodedBytes
+				}
+			}
+			b.SetBytes(bytesPerIteration)
+		})
+	}
+}
+
+func benchmarkInsertRows(rowCount int) ([]int, []int64, []uint64) {
+	rows := make([]int, rowCount)
+	rowIDs := make([]int64, rowCount)
+	timestamps := make([]uint64, rowCount)
+	for row := range rows {
+		rows[row] = row
+		rowIDs[row] = int64(row)
+		timestamps[row] = uint64(row)
+	}
+	return rows, rowIDs, timestamps
+}
+
+func benchmarkInsertRequestViewEncoder(b *testing.B, source *msgpb.InsertRequest, rows []int) {
+	b.Helper()
+	template := insertViewTemplate()
+	encoder, err := NewInsertRequestViewEncoder(template, source, rows)
+	if err != nil {
+		b.Fatal(err)
+	}
+	payloadSize, err := encoder.EncodedSize()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("materialized_append_then_proto_marshal", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(payloadSize))
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			materialized := materializeWithAppendFieldData(template, source, rows)
+			payload, err := proto.Marshal(materialized)
+			if err != nil {
+				b.Fatal(err)
+			}
+			insertRequestViewBenchmarkSink = payload
+		}
+	})
+
+	b.Run("preallocated_materialize_then_proto_marshal", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(payloadSize))
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			materialized := materializePreallocatedForBenchmark(template, source, rows)
+			payload, err := proto.Marshal(materialized)
+			if err != nil {
+				b.Fatal(err)
+			}
+			insertRequestViewBenchmarkSink = payload
+		}
+	})
+
+	b.Run("view_encode_to_final_payload", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(payloadSize))
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			view, err := NewInsertRequestViewEncoder(template, source, rows)
+			if err != nil {
+				b.Fatal(err)
+			}
+			size, err := view.EncodedSize()
+			if err != nil {
+				b.Fatal(err)
+			}
+			payload := make([]byte, size)
+			if _, err := view.MarshalTo(payload); err != nil {
+				b.Fatal(err)
+			}
+			insertRequestViewBenchmarkSink = payload
+		}
+	})
+}
+
+func materializePreallocatedForBenchmark(template, source *msgpb.InsertRequest, rows []int) *msgpb.InsertRequest {
+	request := proto.Clone(template).(*msgpb.InsertRequest)
+	request.Timestamps = make([]uint64, 0, len(rows))
+	request.RowIDs = make([]int64, 0, len(rows))
+	request.RowData = nil
+	request.FieldsData = typeutil.PrepareResultFieldData(source.GetFieldsData(), int64(len(rows)))
+	request.NumRows = uint64(len(rows))
+
+	idxComputer := typeutil.NewFieldDataIdxComputer(source.GetFieldsData())
+	for _, row := range rows {
+		fieldIndices := idxComputer.Compute(int64(row))
+		typeutil.AppendFieldData(request.FieldsData, source.GetFieldsData(), int64(row), fieldIndices...)
+		request.Timestamps = append(request.Timestamps, source.GetTimestamps()[row])
+		request.RowIDs = append(request.RowIDs, source.GetRowIDs()[row])
+	}
+	return request
+}
+
+// BenchmarkInsertRequestViewWideTable stresses the sizing loop rather than
+// payload volume. previewSize walks every field for every row, so its
+// O(rows x fields) cost is invisible in the single-field benchmarks above --
+// there, row-major and field-major traversal touch memory in the same order.
+// A wide table separates the two: 128 narrow columns mean each row's sizing
+// pass jumps across 128 slices.
+//
+// The array columns are the only ones whose per-row size is not O(1), so this
+// is also where an estimated (rather than measured) array size would have to
+// pay off if it pays off anywhere.
+func BenchmarkInsertRequestViewWideTable(b *testing.B) {
+	const (
+		rowCount    = 2_000
+		scalarCount = 96
+		arrayCount  = 32
+		elementsPer = 8
+		bodyBudget  = 256 << 10
+	)
+	template := insertViewTemplate()
+	rows, rowIDs, timestamps := benchmarkInsertRows(rowCount)
+
+	fields := make([]*schemapb.FieldData, 0, scalarCount+arrayCount)
+	for field := 0; field < scalarCount; field++ {
+		values := make([]int64, rowCount)
+		for row := range values {
+			values[row] = int64(row + field)
+		}
+		fields = append(fields, scalarField(int64(100+field), schemapb.DataType_Int64,
+			&schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: values}}))
+	}
+	for field := 0; field < arrayCount; field++ {
+		cells := make([]*schemapb.ScalarField, rowCount)
+		for row := range cells {
+			values := make([]int64, elementsPer)
+			for element := range values {
+				values[element] = int64(row*elementsPer + element)
+			}
+			cells[row] = &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+				LongData: &schemapb.LongArray{Data: values},
+			}}
+		}
+		fields = append(fields, scalarField(int64(1000+field), schemapb.DataType_Array,
+			&schemapb.ScalarField_ArrayData{ArrayData: &schemapb.ArrayArray{
+				Data: cells, ElementType: schemapb.DataType_Int64,
+			}}))
+	}
+
+	source := &msgpb.InsertRequest{
+		NumRows:    rowCount,
+		RowIDs:     rowIDs,
+		Timestamps: timestamps,
+		FieldsData: fields,
+	}
+
+	b.ReportAllocs()
+	var bytesPerIteration int64
+	for i := 0; i < b.N; i++ {
+		cursor, err := NewInsertRequestViewCursor(source)
+		if err != nil {
+			b.Fatal(err)
+		}
+		var encodedBytes int64
+		for start := 0; start < len(rows); {
+			encoder, consumed, err := cursor.NextEncoder(template, rows[start:], bodyBudget)
+			if err != nil {
+				b.Fatal(err)
+			}
+			size, err := encoder.EncodedSize()
+			if err != nil {
+				b.Fatal(err)
+			}
+			payload := make([]byte, size)
+			if _, err := encoder.MarshalTo(payload); err != nil {
+				b.Fatal(err)
+			}
+			encodedBytes += int64(size)
+			insertRequestViewBenchmarkSink = payload
+			start += consumed
+		}
+		if i == 0 {
+			bytesPerIteration = encodedBytes
+		}
+	}
+	b.SetBytes(bytesPerIteration)
+}

--- a/pkg/util/fastpb/insert_request_view_test.go
+++ b/pkg/util/fastpb/insert_request_view_test.go
@@ -1,0 +1,1363 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fastpb
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"math/rand"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+
+	commonpb "github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	msgpb "github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	schemapb "github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+func TestInsertRequestViewEncoder_DifferentialAllRepackTypes(t *testing.T) {
+	template := insertViewTemplate()
+	// The encoder owns the row-bearing fields, even if a caller accidentally
+	// leaves stale values in the metadata template.
+	template.Timestamps = []uint64{999}
+	template.RowIDs = []int64{999}
+	template.FieldsData = []*schemapb.FieldData{{FieldId: 999}}
+	template.NumRows = 999
+	template.ProtoReflect().SetUnknown(protowire.AppendVarint(protowire.AppendTag(nil, 99, protowire.VarintType), 7))
+
+	source := insertViewAllRepackTypesSource()
+	for _, rows := range [][]int{
+		{0},
+		{0, 2, 4},
+		{1, 4}, // all-null selection for compact vector fields
+		{0, 1, 2, 3, 4},
+	} {
+		t.Run(rowsName(rows), func(t *testing.T) {
+			assertViewMatchesMaterialized(t, template, source, rows)
+		})
+	}
+}
+
+func TestInsertRequestViewEncoder_DifferentialRandomSelections(t *testing.T) {
+	r := rand.New(rand.NewSource(0x52269))
+	template := insertViewTemplate()
+	for iteration := 0; iteration < 500; iteration++ {
+		rowCount := 1 + r.Intn(32)
+		source := randomInsertViewSource(r, rowCount)
+		rows := make([]int, 0, rowCount)
+		for row := 0; row < rowCount; row++ {
+			if r.Intn(3) != 0 {
+				rows = append(rows, row)
+			}
+		}
+		if len(rows) == 0 {
+			rows = append(rows, r.Intn(rowCount))
+		}
+		assertViewMatchesMaterialized(t, template, source, rows)
+	}
+}
+
+func TestInsertRequestViewCursor_AggregatesPackedScalarsExactly(t *testing.T) {
+	allTypes := insertViewAllRepackTypesSource()
+	source := &msgpb.InsertRequest{
+		NumRows:    allTypes.GetNumRows(),
+		RowIDs:     allTypes.GetRowIDs(),
+		Timestamps: allTypes.GetTimestamps(),
+		FieldsData: []*schemapb.FieldData{
+			allTypes.GetFieldsData()[0], // bool, including ValidData
+			allTypes.GetFieldsData()[1], // int32 varints
+			allTypes.GetFieldsData()[2], // int64 varints
+			allTypes.GetFieldsData()[3], // fixed32
+			allTypes.GetFieldsData()[4], // fixed64
+			allTypes.GetFieldsData()[8], // timestamptz varints
+		},
+	}
+	rows := []int{0, 1, 2, 3, 4}
+	template := insertViewTemplate()
+	expected := materializeWithAppendFieldData(template, source, rows)
+
+	cursor, err := NewInsertRequestViewCursor(source)
+	require.NoError(t, err)
+	encoder, consumed, err := cursor.NextEncoder(template, rows, 1<<20)
+	require.NoError(t, err)
+	require.Equal(t, len(rows), consumed)
+
+	size, err := encoder.EncodedSize()
+	require.NoError(t, err)
+	actualBytes := make([]byte, size)
+	_, err = encoder.MarshalTo(actualBytes)
+	require.NoError(t, err)
+	require.Equal(t, proto.Size(expected), size)
+
+	actual := &msgpb.InsertRequest{}
+	require.NoError(t, proto.Unmarshal(actualBytes, actual))
+	assert.True(t, proto.Equal(expected, actual))
+}
+
+func TestInsertRequestViewCursor_AggregatesSimpleVectorsExactly(t *testing.T) {
+	const (
+		rowCount = 64
+		dim      = 16
+	)
+	rows, rowIDs, timestamps := benchmarkInsertRows(rowCount)
+	floatValues := make([]float32, rowCount*dim)
+	byteValues := make([]byte, rowCount*dim)
+	binaryValues := make([]byte, rowCount*dim/8)
+	for i := range floatValues {
+		floatValues[i] = float32(i)
+	}
+	for i := range byteValues {
+		byteValues[i] = byte(i)
+	}
+	for i := range binaryValues {
+		binaryValues[i] = byte(i)
+	}
+
+	wideBytes := make([]byte, rowCount*dim*2)
+	fields := map[string]*schemapb.FieldData{
+		"binary":   vectorField(1, schemapb.DataType_BinaryVector, dim, &schemapb.VectorField_BinaryVector{BinaryVector: binaryValues}, nil),
+		"float":    vectorField(1, schemapb.DataType_FloatVector, dim, &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: floatValues}}, nil),
+		"float16":  vectorField(1, schemapb.DataType_Float16Vector, dim, &schemapb.VectorField_Float16Vector{Float16Vector: wideBytes}, nil),
+		"bfloat16": vectorField(1, schemapb.DataType_BFloat16Vector, dim, &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: wideBytes}, nil),
+		"int8":     vectorField(1, schemapb.DataType_Int8Vector, dim, &schemapb.VectorField_Int8Vector{Int8Vector: byteValues}, nil),
+	}
+
+	for name, field := range fields {
+		t.Run(name, func(t *testing.T) {
+			source := &msgpb.InsertRequest{NumRows: rowCount, RowIDs: rowIDs, Timestamps: timestamps, FieldsData: []*schemapb.FieldData{field}}
+			limit := proto.Size(materializeWithAppendFieldData(insertViewTemplate(), source, rows[:17]))
+			assertCursorExactSplits(t, insertViewTemplate(), source, rows, limit)
+		})
+	}
+}
+
+func TestInsertRequestViewCursor_AggregatesSparseVectorExactly(t *testing.T) {
+	const rowCount = 64
+	rows, rowIDs, timestamps := benchmarkInsertRows(rowCount)
+	contents := make([][]byte, rowCount)
+	for row := range contents {
+		contents[row] = sparseTestRow(uint32(row + 1))
+	}
+	source := &msgpb.InsertRequest{
+		NumRows: rowCount, RowIDs: rowIDs, Timestamps: timestamps,
+		FieldsData: []*schemapb.FieldData{vectorField(1, schemapb.DataType_SparseFloatVector, 1024,
+			&schemapb.VectorField_SparseFloatVector{SparseFloatVector: &schemapb.SparseFloatArray{Dim: 1024, Contents: contents}}, nil)},
+	}
+	limit := proto.Size(materializeWithAppendFieldData(insertViewTemplate(), source, rows[:17]))
+	assertCursorExactSplits(t, insertViewTemplate(), source, rows, limit)
+}
+
+// boundedVariableSimplePrefix sizes one 64-row block at a time and replays only
+// the block that crosses the limit, so the seam between two blocks is where a
+// checkpoint/rollback mistake would show up: a prefix that ends exactly on the
+// block edge, the first row of the following block, and a split that happens
+// several blocks in. A budget equal to the size of prefix+1 rows must roll that
+// row over (the limit is exclusive); one more byte of budget must take it.
+func assertBoundedPrefixBlockSeams(t *testing.T, source *msgpb.InsertRequest, rows []int, prefixes []int) {
+	t.Helper()
+	template := insertViewTemplate()
+	sizeAt := func(prefix int) int {
+		return proto.Size(materializeWithAppendFieldData(template, source, rows[:prefix]))
+	}
+	consumedWithLimit := func(limit int) int {
+		cursor, err := NewInsertRequestViewCursor(source)
+		require.NoError(t, err)
+		_, consumed, err := cursor.NextEncoder(template, rows, limit)
+		require.NoError(t, err)
+		return consumed
+	}
+	for _, prefix := range prefixes {
+		require.Less(t, prefix+1, len(rows))
+		t.Run("prefix"+strconv.Itoa(prefix), func(t *testing.T) {
+			limit := sizeAt(prefix + 1)
+			assert.Equal(t, prefix, consumedWithLimit(limit), "equal-size prefix must roll over")
+			assertCursorExactSplits(t, template, source, rows, limit)
+
+			assert.Equal(t, prefix+1, consumedWithLimit(limit+1), "one more byte must take one more row")
+			assertCursorExactSplits(t, template, source, rows, limit+1)
+		})
+	}
+}
+
+func TestInsertRequestViewCursor_RepeatedScalarPrefixBlockSeams(t *testing.T) {
+	const rowCount = 200
+	rows, rowIDs, timestamps := benchmarkInsertRows(rowCount)
+	stringsData := make([]string, rowCount)
+	jsonData := make([][]byte, rowCount)
+	for row := 0; row < rowCount; row++ {
+		stringsData[row] = strings.Repeat("s", row%131)
+		jsonData[row] = []byte(`{"row":` + strconv.Itoa(row) + `,"payload":"` + strings.Repeat("j", row%257) + `"}`)
+	}
+	source := &msgpb.InsertRequest{
+		NumRows: rowCount, RowIDs: rowIDs, Timestamps: timestamps,
+		FieldsData: []*schemapb.FieldData{
+			scalarField(1, schemapb.DataType_VarChar,
+				&schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: stringsData}}),
+			scalarField(2, schemapb.DataType_JSON,
+				&schemapb.ScalarField_JsonData{JsonData: &schemapb.JSONArray{Data: jsonData}}),
+		},
+	}
+	assertBoundedPrefixBlockSeams(t, source, rows, []int{1, 62, 63, 64, 65, 66, 127, 128, 129, 130})
+}
+
+func TestInsertRequestViewCursor_SparsePrefixBlockSeams(t *testing.T) {
+	const rowCount = 200
+	rows, rowIDs, timestamps := benchmarkInsertRows(rowCount)
+	contents := make([][]byte, rowCount)
+	for row := range contents {
+		// The sparse index grows with the row, so the selection's max dimension
+		// keeps moving and has to be rolled back with the rest of the block.
+		contents[row] = sparseTestRow(uint32(row + 1))
+	}
+	source := &msgpb.InsertRequest{
+		NumRows: rowCount, RowIDs: rowIDs, Timestamps: timestamps,
+		FieldsData: []*schemapb.FieldData{vectorField(1, schemapb.DataType_SparseFloatVector, int64(rowCount+1),
+			&schemapb.VectorField_SparseFloatVector{SparseFloatVector: &schemapb.SparseFloatArray{
+				Dim: int64(rowCount + 1), Contents: contents,
+			}}, nil)},
+	}
+	assertBoundedPrefixBlockSeams(t, source, rows, []int{1, 63, 64, 65, 126, 127, 128, 129})
+}
+
+func TestInsertRequestViewCursor_AggregatesRepeatedScalarsExactly(t *testing.T) {
+	const rowCount = 64
+	rows, rowIDs, timestamps := benchmarkInsertRows(rowCount)
+	stringsData := make([]string, rowCount)
+	jsonData := make([][]byte, rowCount)
+	valid := make([]bool, rowCount)
+	for row := 0; row < rowCount; row++ {
+		stringsData[row] = strings.Repeat("s", row%131)
+		jsonData[row] = []byte(`{"row":` + strconv.Itoa(row) + `,"payload":"` + strings.Repeat("j", row%257) + `"}`)
+		valid[row] = row%3 != 0
+	}
+	jsonField := scalarField(2, schemapb.DataType_JSON,
+		&schemapb.ScalarField_JsonData{JsonData: &schemapb.JSONArray{Data: jsonData}})
+	jsonField.ValidData = valid
+	source := &msgpb.InsertRequest{
+		NumRows: rowCount, RowIDs: rowIDs, Timestamps: timestamps,
+		FieldsData: []*schemapb.FieldData{
+			scalarField(1, schemapb.DataType_VarChar,
+				&schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: stringsData}}),
+			jsonField,
+		},
+	}
+	limit := proto.Size(materializeWithAppendFieldData(insertViewTemplate(), source, rows[:17]))
+	assertCursorExactSplits(t, insertViewTemplate(), source, rows, limit)
+}
+
+func TestInsertRequestViewEncoder_VectorArrayCellPlans(t *testing.T) {
+	unknown := protowire.AppendVarint(protowire.AppendTag(nil, 99, protowire.VarintType), 7)
+	fallback := &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: []float32{3, 4}}}}
+	fallback.ProtoReflect().SetUnknown(unknown)
+	cells := []*schemapb.VectorField{
+		{Dim: 2, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: []float32{1, 2}}}},
+		fallback,
+		nil,
+		{Dim: 2},
+	}
+	source := &msgpb.InsertRequest{
+		NumRows: 4, RowIDs: []int64{1, 2, 3, 4}, Timestamps: []uint64{10, 20, 30, 40},
+		FieldsData: []*schemapb.FieldData{vectorField(1, schemapb.DataType_ArrayOfVector, 2,
+			&schemapb.VectorField_VectorArray{VectorArray: &schemapb.VectorArray{Dim: 2, ElementType: schemapb.DataType_FloatVector, Data: cells}}, nil)},
+	}
+	assertViewMatchesMaterialized(t, insertViewTemplate(), source, []int{0, 1, 2, 3})
+}
+
+func TestInsertRequestViewEncoder_DifferentialNilRepeatedMessages(t *testing.T) {
+	template := insertViewTemplate()
+	source := insertViewAllRepackTypesSource()
+	source.GetFieldsData()[6].GetScalars().GetArrayData().Data[2] = nil
+	source.GetFieldsData()[17].GetVectors().GetVectorArray().Data[2] = nil
+	assertViewMatchesMaterialized(t, template, source, []int{2})
+}
+
+func TestInsertRequestViewEncoder_ArrayNestedUnknownFields(t *testing.T) {
+	packedUnknown := protowire.AppendTag(nil, 999, protowire.VarintType)
+	packedUnknown = protowire.AppendVarint(packedUnknown, 17)
+	packed := &schemapb.LongArray{Data: []int64{1, 128, -1}}
+	packed.ProtoReflect().SetUnknown(packedUnknown)
+
+	repeatedUnknown := protowire.AppendTag(nil, 998, protowire.BytesType)
+	repeatedUnknown = protowire.AppendBytes(repeatedUnknown, []byte("future-string-array-field"))
+	repeated := &schemapb.StringArray{Data: []string{"a", "b"}}
+	repeated.ProtoReflect().SetUnknown(repeatedUnknown)
+
+	source := &msgpb.InsertRequest{
+		NumRows:    2,
+		RowIDs:     []int64{1, 2},
+		Timestamps: []uint64{10, 20},
+		FieldsData: []*schemapb.FieldData{
+			scalarField(1, schemapb.DataType_Array, &schemapb.ScalarField_ArrayData{ArrayData: &schemapb.ArrayArray{
+				ElementType: schemapb.DataType_Int64,
+				Data: []*schemapb.ScalarField{
+					{Data: &schemapb.ScalarField_LongData{LongData: packed}},
+					{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{2}}}},
+				},
+			}}),
+			scalarField(2, schemapb.DataType_Array, &schemapb.ScalarField_ArrayData{ArrayData: &schemapb.ArrayArray{
+				ElementType: schemapb.DataType_VarChar,
+				Data: []*schemapb.ScalarField{
+					{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"known"}}}},
+					{Data: &schemapb.ScalarField_StringData{StringData: repeated}},
+				},
+			}}),
+		},
+	}
+
+	rows := []int{0, 1}
+	expected := materializeWithAppendFieldData(insertViewTemplate(), source, rows)
+
+	encoder, err := NewInsertRequestViewEncoder(insertViewTemplate(), source, rows)
+	require.NoError(t, err)
+	size, err := encoder.EncodedSize()
+	require.NoError(t, err)
+	actualBytes := make([]byte, size)
+	_, err = encoder.MarshalTo(actualBytes)
+	require.NoError(t, err)
+	assert.Equal(t, proto.Size(expected), len(actualBytes))
+	replayedBytes := make([]byte, size)
+	_, err = encoder.MarshalTo(replayedBytes)
+	require.NoError(t, err)
+	assert.Equal(t, actualBytes, replayedBytes)
+
+	decoded := &msgpb.InsertRequest{}
+	require.NoError(t, proto.Unmarshal(actualBytes, decoded))
+	assert.True(t, proto.Equal(expected, decoded))
+	assert.True(t, bytes.Equal(packedUnknown, decoded.GetFieldsData()[0].GetScalars().GetArrayData().GetData()[0].GetLongData().ProtoReflect().GetUnknown()))
+	assert.True(t, bytes.Equal(repeatedUnknown, decoded.GetFieldsData()[1].GetScalars().GetArrayData().GetData()[1].GetStringData().ProtoReflect().GetUnknown()))
+}
+
+// TestInsertRequestViewEncoder_ArrayCellValidDataFallback pins the fix for a
+// real proto change, not a synthetic one: schemapb.ScalarField and
+// schemapb.VectorField each gained a ValidData field (element-level nullability
+// within one cell) that has no producer anywhere in this repo yet. Because
+// proto reflection recognizes it, GetUnknown() no longer catches it -- the
+// arithmetic cell path only writes the oneof value, so a cell carrying it would
+// silently lose that data. classifyScalarCell / classifyVectorArrayCell must
+// treat a non-empty ValidData the same as an unrecognized field: fall back to
+// the protobuf path, which serializes every field it does not know to drop.
+func TestInsertRequestViewEncoder_ArrayCellValidDataFallback(t *testing.T) {
+	scalarCell := &schemapb.ScalarField{
+		Data:      &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2}}},
+		ValidData: []bool{true, false},
+	}
+	vectorCell := &schemapb.VectorField{
+		Dim:       2,
+		Data:      &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: []float32{1, 2}}},
+		ValidData: []bool{true},
+	}
+
+	source := &msgpb.InsertRequest{
+		NumRows:    1,
+		RowIDs:     []int64{1},
+		Timestamps: []uint64{10},
+		FieldsData: []*schemapb.FieldData{
+			scalarField(1, schemapb.DataType_Array, &schemapb.ScalarField_ArrayData{ArrayData: &schemapb.ArrayArray{
+				ElementType: schemapb.DataType_Int64,
+				Data:        []*schemapb.ScalarField{scalarCell},
+			}}),
+			vectorField(2, schemapb.DataType_ArrayOfVector, 2,
+				&schemapb.VectorField_VectorArray{VectorArray: &schemapb.VectorArray{
+					Dim: 2, ElementType: schemapb.DataType_FloatVector,
+					Data: []*schemapb.VectorField{vectorCell},
+				}}, nil),
+		},
+	}
+
+	rows := []int{0}
+	expected := materializeWithAppendFieldData(insertViewTemplate(), source, rows)
+
+	encoder, err := NewInsertRequestViewEncoder(insertViewTemplate(), source, rows)
+	require.NoError(t, err)
+	size, err := encoder.EncodedSize()
+	require.NoError(t, err)
+	actualBytes := make([]byte, size)
+	_, err = encoder.MarshalTo(actualBytes)
+	require.NoError(t, err)
+	assert.Equal(t, proto.Size(expected), len(actualBytes))
+
+	decoded := &msgpb.InsertRequest{}
+	require.NoError(t, proto.Unmarshal(actualBytes, decoded))
+	assert.True(t, proto.Equal(expected, decoded))
+	assert.Equal(t, []bool{true, false},
+		decoded.GetFieldsData()[0].GetScalars().GetArrayData().GetData()[0].GetValidData(),
+		"ScalarField.ValidData must survive the cell, not be silently dropped")
+	assert.Equal(t, []bool{true},
+		decoded.GetFieldsData()[1].GetVectors().GetVectorArray().GetData()[0].GetValidData(),
+		"VectorField.ValidData must survive the cell, not be silently dropped")
+}
+
+// TestInsertRequestViewEncoder_TopLevelFieldSpecificValidData covers the
+// field-specific ScalarField.ValidData (field 17) / VectorField.ValidData
+// (field 9) location that #52203 moved top-level row nullability to, with the
+// legacy FieldData.ValidData left empty. The encoder must resolve validity
+// with the same precedence as typeutil.GetFieldDataValidData and re-emit it at
+// the field-specific location the AppendFieldData oracle now writes,
+// row-selected like every other column. The vector payload is compacted: only
+// non-null rows carry vector data.
+func TestInsertRequestViewEncoder_TopLevelFieldSpecificValidData(t *testing.T) {
+	source := &msgpb.InsertRequest{
+		NumRows:    3,
+		RowIDs:     []int64{1, 2, 3},
+		Timestamps: []uint64{10, 20, 30},
+		FieldsData: []*schemapb.FieldData{
+			scalarField(1, schemapb.DataType_Int64, &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}}}),
+			vectorField(2, schemapb.DataType_FloatVector, 2,
+				&schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: []float32{1, 2, 5, 6}}}, nil),
+		},
+	}
+	source.FieldsData[0].GetScalars().ValidData = []bool{true, false, true}
+	// Compacted vector payload: rows 0 and 2 are valid and own the two vectors.
+	source.FieldsData[1].GetVectors().ValidData = []bool{true, false, true}
+
+	rows := []int{0, 1, 2}
+	expected := materializeWithAppendFieldData(insertViewTemplate(), source, rows)
+
+	encoder, err := NewInsertRequestViewEncoder(insertViewTemplate(), source, rows)
+	require.NoError(t, err)
+	size, err := encoder.EncodedSize()
+	require.NoError(t, err)
+	actualBytes := make([]byte, size)
+	_, err = encoder.MarshalTo(actualBytes)
+	require.NoError(t, err)
+	assert.Equal(t, proto.Size(expected), len(actualBytes))
+
+	decoded := &msgpb.InsertRequest{}
+	require.NoError(t, proto.Unmarshal(actualBytes, decoded))
+	assert.True(t, proto.Equal(expected, decoded))
+	assert.Empty(t, decoded.GetFieldsData()[0].GetValidData(),
+		"legacy FieldData.ValidData must stay empty; validity lives at the field-specific location")
+	assert.Equal(t, []bool{true, false, true},
+		decoded.GetFieldsData()[0].GetScalars().GetValidData(),
+		"ScalarField.ValidData must survive at the field-specific location")
+	assert.Equal(t, []bool{true, false, true},
+		decoded.GetFieldsData()[1].GetVectors().GetValidData(),
+		"VectorField.ValidData must survive at the field-specific location")
+
+	// Row selection with nulls: keep rows 1 (null) and 2 (valid).
+	subRows := []int{1, 2}
+	subExpected := materializeWithAppendFieldData(insertViewTemplate(), source, subRows)
+	subDecoded := encodeAndDecodeInsertView(t, insertViewTemplate(), source, subRows)
+	assert.True(t, proto.Equal(subExpected, subDecoded))
+	assert.Equal(t, []bool{false, true}, subDecoded.GetFieldsData()[1].GetVectors().GetValidData())
+}
+
+func TestInsertRequestViewEncoder_ExtendedScalarOneofs(t *testing.T) {
+	// Bytes/Mol/MolSmiles/Date/Time are current ScalarField oneofs, but the old
+	// AppendFieldData repack helper does not handle them. Keep this explicit
+	// expected-object test separate from the old-path differential oracle above.
+	rows := []int{0, 2, 3}
+	source := &msgpb.InsertRequest{
+		NumRows:    4,
+		RowIDs:     []int64{1, 2, 3, 4},
+		Timestamps: []uint64{11, 12, 13, 14},
+		FieldsData: []*schemapb.FieldData{
+			scalarField(100, schemapb.DataType_None, &schemapb.ScalarField_BytesData{BytesData: &schemapb.BytesArray{Data: [][]byte{{1}, {}, {3, 3}, {4}}}}),
+			scalarField(101, schemapb.DataType_None, &schemapb.ScalarField_MolData{MolData: &schemapb.MolArray{Data: [][]byte{{10}, {20}, {30}, {40}}}}),
+			scalarField(102, schemapb.DataType_Text, &schemapb.ScalarField_MolSmilesData{MolSmilesData: &schemapb.MolSmilesArray{Data: []string{"C", "CC", "CCC", ""}}}),
+			scalarField(103, schemapb.DataType_Date, &schemapb.ScalarField_DateData{DateData: &schemapb.DateArray{Data: []int32{-1, 0, 1, math.MaxInt32}}}),
+			scalarField(104, schemapb.DataType_Time, &schemapb.ScalarField_TimeData{TimeData: &schemapb.TimeArray{Data: []int64{-1, 0, 1, math.MaxInt64}}}),
+		},
+	}
+
+	expected := materializeExtendedScalars(insertViewTemplate(), source, rows)
+	got := encodeAndDecodeInsertView(t, insertViewTemplate(), source, rows)
+	require.True(t, proto.Equal(expected, got), "extended scalar selection mismatch\nexpected: %v\nactual:   %v", expected, got)
+
+	packedSource := &msgpb.InsertRequest{
+		NumRows:    source.GetNumRows(),
+		RowIDs:     source.GetRowIDs(),
+		Timestamps: source.GetTimestamps(),
+		FieldsData: source.GetFieldsData()[3:],
+	}
+	packedExpected := materializeExtendedScalars(insertViewTemplate(), packedSource, rows)
+	packedGot := encodeAndDecodeInsertView(t, insertViewTemplate(), packedSource, rows)
+	require.True(t, proto.Equal(packedExpected, packedGot), "packed date/time selection mismatch\nexpected: %v\nactual:   %v", packedExpected, packedGot)
+}
+
+func TestInsertRequestViewCursor_SequentialViews(t *testing.T) {
+	template := insertViewTemplate()
+	source := insertViewAllRepackTypesSource()
+	cursor, err := NewInsertRequestViewCursor(source)
+	require.NoError(t, err)
+
+	for _, rows := range [][]int{{0, 2}, {3, 4}} {
+		encoder, err := cursor.newEncoder(template, rows)
+		require.NoError(t, err)
+		size, err := encoder.EncodedSize()
+		require.NoError(t, err)
+		payload := make([]byte, size)
+		_, err = encoder.MarshalTo(payload)
+		require.NoError(t, err)
+		got := &msgpb.InsertRequest{}
+		require.NoError(t, proto.Unmarshal(payload, got))
+		expected := materializeWithAppendFieldData(template, source, rows)
+		require.True(t, proto.Equal(expected, got))
+	}
+
+	_, err = cursor.newEncoder(template, []int{4})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, merr.ErrServiceInternal)
+
+	_, err = NewInsertRequestViewCursor(nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, merr.ErrServiceInternal)
+
+	t.Run("requires synchronous consumption", func(t *testing.T) {
+		cursor, err := NewInsertRequestViewCursor(source)
+		require.NoError(t, err)
+		encoder, err := cursor.newEncoder(template, []int{0})
+		require.NoError(t, err)
+		_, err = cursor.newEncoder(template, []int{2})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrServiceInternal)
+
+		size, err := encoder.EncodedSize()
+		require.NoError(t, err)
+		_, err = encoder.MarshalTo(make([]byte, size))
+		require.NoError(t, err)
+		_, err = cursor.newEncoder(template, []int{2})
+		require.NoError(t, err)
+	})
+
+	t.Run("first view starts after row zero", func(t *testing.T) {
+		cursor, err := NewInsertRequestViewCursor(source)
+		require.NoError(t, err)
+		for _, rows := range [][]int{{2}, {4}} {
+			encoder, err := cursor.newEncoder(template, rows)
+			require.NoError(t, err)
+			size, err := encoder.EncodedSize()
+			require.NoError(t, err)
+			payload := make([]byte, size)
+			_, err = encoder.MarshalTo(payload)
+			require.NoError(t, err)
+
+			got := &msgpb.InsertRequest{}
+			require.NoError(t, proto.Unmarshal(payload, got))
+			expected := materializeWithAppendFieldData(template, source, rows)
+			require.True(t, proto.Equal(expected, got))
+		}
+	})
+
+	t.Run("consumed encoder cannot release a newer encoder", func(t *testing.T) {
+		cursor, err := NewInsertRequestViewCursor(source)
+		require.NoError(t, err)
+
+		first, err := cursor.newEncoder(template, []int{0})
+		require.NoError(t, err)
+		firstSize, err := first.EncodedSize()
+		require.NoError(t, err)
+		firstCopy := *first
+		_, err = first.MarshalTo(make([]byte, firstSize))
+		require.NoError(t, err)
+
+		second, err := cursor.newEncoder(template, []int{2})
+		require.NoError(t, err)
+		_, err = firstCopy.MarshalTo(make([]byte, firstSize))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrServiceInternal)
+
+		_, err = cursor.newEncoder(template, []int{3})
+		require.Error(t, err, "the consumed encoder must not release the newer encoder's scratch")
+		assert.ErrorIs(t, err, merr.ErrServiceInternal)
+
+		secondSize, err := second.EncodedSize()
+		require.NoError(t, err)
+		_, err = second.MarshalTo(make([]byte, secondSize))
+		require.NoError(t, err)
+		_, err = cursor.newEncoder(template, []int{3})
+		require.NoError(t, err)
+	})
+
+	t.Run("failed encoder creation does not advance compact prefix", func(t *testing.T) {
+		cursor, err := NewInsertRequestViewCursor(source)
+		require.NoError(t, err)
+
+		_, err = cursor.newEncoder(nil, []int{2})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrServiceInternal)
+
+		var encoder *InsertRequestViewEncoder
+		require.NotPanics(t, func() {
+			encoder, err = cursor.newEncoder(template, []int{0})
+		})
+		require.NoError(t, err)
+		size, err := encoder.EncodedSize()
+		require.NoError(t, err)
+		payload := make([]byte, size)
+		_, err = encoder.MarshalTo(payload)
+		require.NoError(t, err)
+
+		got := &msgpb.InsertRequest{}
+		require.NoError(t, proto.Unmarshal(payload, got))
+		expected := materializeWithAppendFieldData(template, source, []int{0})
+		require.True(t, proto.Equal(expected, got))
+	})
+}
+
+func TestInsertRequestViewCursor_AggregateRejectsShortValidData(t *testing.T) {
+	rows := []int{0, 1}
+	for _, tc := range []struct {
+		name  string
+		field *schemapb.FieldData
+	}{
+		{
+			name: "payload-less field",
+			field: &schemapb.FieldData{
+				Type: schemapb.DataType_Bool, FieldName: "empty", FieldId: 100,
+				ValidData: []bool{true},
+			},
+		},
+		{
+			name: "empty vector",
+			field: &schemapb.FieldData{
+				Type: schemapb.DataType_FloatVector, FieldName: "empty-vector", FieldId: 101,
+				ValidData: []bool{true},
+				Field:     &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 4}},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := &msgpb.InsertRequest{
+				NumRows: 2, RowIDs: []int64{1, 2}, Timestamps: []uint64{10, 20},
+				FieldsData: []*schemapb.FieldData{tc.field},
+			}
+			cursor, err := NewInsertRequestViewCursor(source)
+			require.NoError(t, err)
+			require.NotPanics(t, func() {
+				_, _, err = cursor.NextEncoder(insertViewTemplate(), rows, 1<<20)
+			})
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrServiceInternal)
+		})
+	}
+}
+
+func TestInsertRequestViewCursor_ExactPrefixSizing(t *testing.T) {
+	const rowCount = 129
+	rowIDs := make([]int64, rowCount)
+	timestamps := make([]uint64, rowCount)
+	longs := make([]int64, rowCount)
+	stringsData := make([]string, rowCount)
+	for row := 0; row < rowCount; row++ {
+		rowIDs[row] = int64(row)
+		timestamps[row] = uint64(row)
+		longs[row] = int64(row)
+	}
+	for row, value := range []uint64{0, 127, 128, 16_383, 16_384} {
+		rowIDs[row] = int64(value)
+		timestamps[row] = value
+		longs[row] = int64(value)
+	}
+	stringsData[1] = strings.Repeat("a", 127)
+	stringsData[2] = strings.Repeat("b", 128)
+	stringsData[3] = strings.Repeat("c", 16_383)
+	stringsData[4] = strings.Repeat("d", 16_384)
+	source := &msgpb.InsertRequest{
+		NumRows:    rowCount,
+		RowIDs:     rowIDs,
+		Timestamps: timestamps,
+		FieldsData: []*schemapb.FieldData{
+			scalarField(1, schemapb.DataType_Int64, &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: longs}}),
+			scalarField(2, schemapb.DataType_VarChar, &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: stringsData}}),
+		},
+	}
+	template := insertViewTemplate()
+	rows := make([]int, rowCount)
+	for row := range rows {
+		rows[row] = row
+	}
+
+	for _, prefix := range []int{1, 2, 3, 4, 5, 126, 127, 128, 129} {
+		cursor, err := NewInsertRequestViewCursor(source)
+		require.NoError(t, err)
+		encoder, consumed, err := cursor.NextEncoder(template, rows[:prefix], 0)
+		require.NoError(t, err)
+		assert.Equal(t, prefix, consumed)
+		expected := materializeWithAppendFieldData(template, source, rows[:prefix])
+		size, err := encoder.EncodedSize()
+		require.NoError(t, err)
+		assert.Equal(t, proto.Size(expected), size, "prefix=%d", prefix)
+		payload := make([]byte, size)
+		written, err := encoder.MarshalTo(payload)
+		require.NoError(t, err)
+		assert.Equal(t, size, written)
+	}
+}
+
+func TestInsertRequestViewCursor_ExactSplitPendingRow(t *testing.T) {
+	unknown := protowire.AppendTag(nil, 999, protowire.VarintType)
+	unknown = protowire.AppendVarint(unknown, 17)
+	fallbackArray := &schemapb.LongArray{Data: []int64{1, 128, -1}}
+	fallbackArray.ProtoReflect().SetUnknown(unknown)
+
+	for _, tc := range []struct {
+		name string
+		cell *schemapb.ScalarField
+	}{
+		{
+			name: "arithmetic payload token",
+			cell: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+				LongData: &schemapb.LongArray{Data: []int64{1, 128, -1}},
+			}},
+		},
+		{
+			name: "protobuf fallback token",
+			cell: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+				LongData: fallbackArray,
+			}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			template := insertViewTemplate()
+			source := insertViewAllRepackTypesSource()
+			// Row 2 is the first rejected/pending row below. Its ARRAY token must
+			// survive into the next view without re-sizing the cell. Keep
+			// ArrayOfVector nil to retain zero-length nested-message coverage.
+			source.GetFieldsData()[6].GetScalars().GetArrayData().Data[2] = tc.cell
+			source.GetFieldsData()[17].GetVectors().GetVectorArray().Data[2] = nil
+			oracleSource := proto.Clone(source).(*msgpb.InsertRequest)
+			rows := []int{0, 1, 2, 3, 4}
+			limit := proto.Size(materializeWithAppendFieldData(template, oracleSource, rows[:3]))
+
+			cursor, err := NewInsertRequestViewCursor(source)
+			require.NoError(t, err)
+			start := 0
+			var selections [][]int
+			for start < len(rows) {
+				encoder, consumed, err := cursor.NextEncoder(template, rows[start:], limit)
+				require.NoError(t, err)
+				selection := rows[start : start+consumed]
+				selections = append(selections, append([]int(nil), selection...))
+
+				size, err := encoder.EncodedSize()
+				require.NoError(t, err)
+				payload := make([]byte, size)
+				_, err = encoder.MarshalTo(payload)
+				require.NoError(t, err)
+				got := &msgpb.InsertRequest{}
+				require.NoError(t, proto.Unmarshal(payload, got))
+				expected := materializeWithAppendFieldData(template, oracleSource, selection)
+				require.True(t, proto.Equal(expected, got), "selection=%v", selection)
+				start += consumed
+			}
+			assert.Equal(t, []int{0, 1}, selections[0], "candidate equal to the limit must roll over")
+			assert.Equal(t, rows, flattenRowSelections(selections))
+		})
+	}
+}
+
+func TestInsertRequestViewCursor_SingleOversizedPendingRow(t *testing.T) {
+	values := []string{"small", strings.Repeat("x", 4096), "small"}
+	source := &msgpb.InsertRequest{
+		NumRows:    3,
+		RowIDs:     []int64{1, 2, 3},
+		Timestamps: []uint64{1, 2, 3},
+		FieldsData: []*schemapb.FieldData{
+			scalarField(1, schemapb.DataType_VarChar, &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: values}}),
+		},
+	}
+	template := insertViewTemplate()
+	rows := []int{0, 1, 2}
+	smallSize := proto.Size(materializeWithAppendFieldData(template, source, rows[:1]))
+	hugeSize := proto.Size(materializeWithAppendFieldData(template, source, rows[1:2]))
+	limit := smallSize + 32
+	require.Less(t, limit, hugeSize)
+
+	cursor, err := NewInsertRequestViewCursor(source)
+	require.NoError(t, err)
+	start := 0
+	var selections [][]int
+	var sizes []int
+	for start < len(rows) {
+		encoder, consumed, err := cursor.NextEncoder(template, rows[start:], limit)
+		require.NoError(t, err)
+		selection := rows[start : start+consumed]
+		selections = append(selections, append([]int(nil), selection...))
+		size, err := encoder.EncodedSize()
+		require.NoError(t, err)
+		sizes = append(sizes, size)
+		_, err = encoder.MarshalTo(make([]byte, size))
+		require.NoError(t, err)
+		start += consumed
+	}
+	assert.Equal(t, [][]int{{0}, {1}, {2}}, selections)
+	assert.Less(t, sizes[0], limit)
+	assert.Greater(t, sizes[1], limit)
+	assert.Less(t, sizes[2], limit)
+}
+
+func TestInsertRequestViewCursor_DifferentialRandomExactSplits(t *testing.T) {
+	r := rand.New(rand.NewSource(0x52269_51))
+	template := insertViewTemplate()
+	for iteration := 0; iteration < 100; iteration++ {
+		rowCount := 2 + r.Intn(31)
+		source := randomInsertViewSource(r, rowCount)
+		rows := make([]int, 0, rowCount)
+		for row := 0; row < rowCount; row++ {
+			if r.Intn(4) != 0 {
+				rows = append(rows, row)
+			}
+		}
+		if len(rows) == 0 {
+			rows = append(rows, r.Intn(rowCount))
+		}
+		oracleSource := proto.Clone(source).(*msgpb.InsertRequest)
+		fullSize := proto.Size(materializeWithAppendFieldData(template, oracleSource, rows))
+		limit := 1 + r.Intn(fullSize)
+
+		cursor, err := NewInsertRequestViewCursor(source)
+		require.NoError(t, err)
+		start := 0
+		for start < len(rows) {
+			encoder, consumed, err := cursor.NextEncoder(template, rows[start:], limit)
+			require.NoError(t, err)
+			selection := rows[start : start+consumed]
+			size, err := encoder.EncodedSize()
+			require.NoError(t, err)
+			if consumed > 1 {
+				assert.Less(t, size, limit)
+			}
+			payload := make([]byte, size)
+			_, err = encoder.MarshalTo(payload)
+			require.NoError(t, err)
+			got := &msgpb.InsertRequest{}
+			require.NoError(t, proto.Unmarshal(payload, got))
+			expected := materializeWithAppendFieldData(template, oracleSource, selection)
+			require.True(t, proto.Equal(expected, got), "iteration=%d selection=%v limit=%d", iteration, selection, limit)
+			if next := start + consumed; next < len(rows) {
+				candidate := append(append([]int(nil), selection...), rows[next])
+				candidateSize := proto.Size(materializeWithAppendFieldData(template, oracleSource, candidate))
+				require.GreaterOrEqual(t, candidateSize, limit,
+					"iteration=%d selection=%v next=%d limit=%d", iteration, selection, rows[next], limit)
+			}
+			start += consumed
+		}
+	}
+}
+
+func TestInsertRequestViewEncoder_AllNullHighDimVectorDoesNotMaterialize(t *testing.T) {
+	const (
+		rowCount = 10_000
+		dim      = 32_768
+	)
+	rows := make([]int, rowCount)
+	rowIDs := make([]int64, rowCount)
+	timestamps := make([]uint64, rowCount)
+	valid := make([]bool, rowCount)
+	for row := range rows {
+		rows[row] = row
+		rowIDs[row] = int64(row)
+	}
+	source := &msgpb.InsertRequest{
+		NumRows:    rowCount,
+		RowIDs:     rowIDs,
+		Timestamps: timestamps,
+		FieldsData: []*schemapb.FieldData{{
+			Type:      schemapb.DataType_FloatVector,
+			FieldName: "embedding",
+			FieldId:   100,
+			ValidData: valid,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim: dim,
+				Data: &schemapb.VectorField_FloatVector{
+					FloatVector: &schemapb.FloatArray{},
+				},
+			}},
+		}},
+	}
+
+	encoder, err := NewInsertRequestViewEncoder(insertViewTemplate(), source, rows)
+	require.NoError(t, err)
+	size, err := encoder.EncodedSize()
+	require.NoError(t, err)
+	assert.Less(t, size, 1<<20, "all-null vector payload must not scale with dim*rowCount")
+
+	decoded := encodeAndDecodeInsertView(t, insertViewTemplate(), source, rows)
+	require.Len(t, decoded.GetFieldsData()[0].GetVectors().GetValidData(), rowCount)
+	assert.Nil(t, decoded.GetFieldsData()[0].GetVectors().GetFloatVector())
+}
+
+func TestInsertRequestViewEncoder_InternalContractErrors(t *testing.T) {
+	validSource := &msgpb.InsertRequest{
+		NumRows:    2,
+		RowIDs:     []int64{1, 2},
+		Timestamps: []uint64{10, 20},
+		FieldsData: []*schemapb.FieldData{
+			scalarField(1, schemapb.DataType_Int64, &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2}}}),
+		},
+	}
+
+	cases := []struct {
+		name     string
+		template *msgpb.InsertRequest
+		source   *msgpb.InsertRequest
+		rows     []int
+	}{
+		{name: "nil template", source: validSource, rows: []int{0}},
+		{name: "nil source", template: insertViewTemplate(), rows: []int{0}},
+		{name: "empty selection", template: insertViewTemplate(), source: validSource},
+		{name: "negative row", template: insertViewTemplate(), source: validSource, rows: []int{-1}},
+		{name: "duplicate row", template: insertViewTemplate(), source: validSource, rows: []int{0, 0}},
+		{name: "descending rows", template: insertViewTemplate(), source: validSource, rows: []int{1, 0}},
+		{name: "row ID out of range", template: insertViewTemplate(), source: validSource, rows: []int{2}},
+		{name: "row based source", template: insertViewTemplate(), source: &msgpb.InsertRequest{RowData: []*commonpb.Blob{{Value: []byte{1}}}}, rows: nil},
+		{name: "struct arrays", template: insertViewTemplate(), source: &msgpb.InsertRequest{
+			NumRows: 1, RowIDs: []int64{1}, Timestamps: []uint64{1},
+			FieldsData: []*schemapb.FieldData{{FieldId: 1, Field: &schemapb.FieldData_StructArrays{StructArrays: &schemapb.StructArrayField{}}}},
+		}, rows: []int{0}},
+		{name: "short scalar", template: insertViewTemplate(), source: &msgpb.InsertRequest{
+			NumRows: 2, RowIDs: []int64{1, 2}, Timestamps: []uint64{1, 2},
+			FieldsData: []*schemapb.FieldData{scalarField(1, schemapb.DataType_Int64, &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1}}})},
+		}, rows: []int{1}},
+		{name: "short repeated scalar", template: insertViewTemplate(), source: &msgpb.InsertRequest{
+			NumRows: 2, RowIDs: []int64{1, 2}, Timestamps: []uint64{1, 2},
+			FieldsData: []*schemapb.FieldData{scalarField(1, schemapb.DataType_JSON, &schemapb.ScalarField_JsonData{JsonData: &schemapb.JSONArray{Data: [][]byte{[]byte(`{}`)}}})},
+		}, rows: []int{1}},
+		{name: "short compact vector", template: insertViewTemplate(), source: &msgpb.InsertRequest{
+			NumRows: 2, RowIDs: []int64{1, 2}, Timestamps: []uint64{1, 2},
+			FieldsData: []*schemapb.FieldData{{
+				Type: schemapb.DataType_FloatVector, FieldId: 1, ValidData: []bool{true, true},
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: []float32{1, 2}}}}},
+			}},
+		}, rows: []int{1}},
+		{name: "bad binary dim", template: insertViewTemplate(), source: &msgpb.InsertRequest{
+			NumRows: 1, RowIDs: []int64{1}, Timestamps: []uint64{1},
+			FieldsData: []*schemapb.FieldData{{
+				Type: schemapb.DataType_BinaryVector, FieldId: 1,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 7, Data: &schemapb.VectorField_BinaryVector{BinaryVector: []byte{1}}}},
+			}},
+		}, rows: []int{0}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewInsertRequestViewEncoder(tc.template, tc.source, tc.rows)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrServiceInternal)
+		})
+	}
+}
+
+func TestInsertRequestViewEncoder_MarshalContract(t *testing.T) {
+	source := insertViewAllRepackTypesSource()
+	encoder, err := NewInsertRequestViewEncoder(insertViewTemplate(), source, []int{0, 2})
+	require.NoError(t, err)
+	size, err := encoder.EncodedSize()
+	require.NoError(t, err)
+	first := make([]byte, size)
+	_, err = encoder.MarshalTo(first)
+	require.NoError(t, err)
+	second := make([]byte, size)
+	_, err = encoder.MarshalTo(second)
+	require.NoError(t, err)
+	assert.Equal(t, first, second, "standalone ARRAY size plans must be replayable")
+
+	_, err = encoder.MarshalTo(make([]byte, size-1))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, merr.ErrServiceInternal)
+
+	// Borrowed inputs must remain immutable for the standalone encoder's entire
+	// lifetime. This particular size-changing contract violation is detected and
+	// returned as a typed internal error instead of silently returning a payload
+	// outside the caller's buffer; cached-size mutation behavior is otherwise
+	// intentionally undefined by protobuf.
+	source.FieldsData[5].GetScalars().GetStringData().Data[0] = "a much longer value"
+	_, err = encoder.MarshalTo(make([]byte, size))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, merr.ErrServiceInternal)
+}
+
+func TestNestedMessageMarshalOptionsCachedSizeContract(t *testing.T) {
+	sizeOptions := nestedMessageMarshalOptions(false)
+	cachedOptions := nestedMessageMarshalOptions(true)
+
+	assert.True(t, sizeOptions.AllowPartial)
+	assert.True(t, cachedOptions.UseCachedSize)
+	cachedOptions.UseCachedSize = false
+	assert.Equal(t, sizeOptions, cachedOptions,
+		"cached marshal options must differ from sizing only by UseCachedSize")
+}
+
+func TestInsertRequestViewEncoder_InvalidUTF8(t *testing.T) {
+	invalid := string([]byte{0xff})
+	baseSource := func(field *schemapb.FieldData) *msgpb.InsertRequest {
+		return &msgpb.InsertRequest{
+			NumRows:    1,
+			RowIDs:     []int64{1},
+			Timestamps: []uint64{10},
+			FieldsData: []*schemapb.FieldData{field},
+		}
+	}
+
+	t.Run("top-level varchar is treated as trusted", func(t *testing.T) {
+		source := baseSource(scalarField(1, schemapb.DataType_VarChar, &schemapb.ScalarField_StringData{
+			StringData: &schemapb.StringArray{Data: []string{invalid}},
+		}))
+		encoder, err := NewInsertRequestViewEncoder(insertViewTemplate(), source, []int{0})
+		require.NoError(t, err)
+		size, err := encoder.EncodedSize()
+		require.NoError(t, err)
+		payload := make([]byte, size)
+		written, err := encoder.MarshalTo(payload)
+		require.NoError(t, err)
+		assert.Equal(t, size, written)
+		assert.True(t, bytes.Contains(payload, []byte{0xff}))
+	})
+
+	// An array cell used to be written by proto.Marshal, which validates UTF-8
+	// and fails. The arithmetic encoder that replaced it treats proto3 strings
+	// as trusted internal input, so nested strings now behave like the
+	// top-level varchar above: passed through untouched.
+	t.Run("nested array string is treated as trusted", func(t *testing.T) {
+		source := baseSource(scalarField(1, schemapb.DataType_Array, &schemapb.ScalarField_ArrayData{
+			ArrayData: &schemapb.ArrayArray{
+				Data: []*schemapb.ScalarField{{Data: &schemapb.ScalarField_StringData{
+					StringData: &schemapb.StringArray{Data: []string{invalid}},
+				}}},
+				ElementType: schemapb.DataType_VarChar,
+			},
+		}))
+		encoder, err := NewInsertRequestViewEncoder(insertViewTemplate(), source, []int{0})
+		require.NoError(t, err)
+		size, err := encoder.EncodedSize()
+		require.NoError(t, err)
+		payload := make([]byte, size)
+		written, err := encoder.MarshalTo(payload)
+		require.NoError(t, err)
+		assert.Equal(t, size, written)
+		assert.True(t, bytes.Contains(payload, []byte{0xff}))
+	})
+}
+
+func assertViewMatchesMaterialized(t *testing.T, template, source *msgpb.InsertRequest, rows []int) {
+	t.Helper()
+	expected := materializeWithAppendFieldData(template, source, rows)
+	got := encodeAndDecodeInsertView(t, template, source, rows)
+	require.True(t, proto.Equal(expected, got), "view encoding mismatch\nrows:     %v\nexpected: %v\nactual:   %v", rows, expected, got)
+	assert.Equal(t, proto.Size(expected), proto.Size(got))
+}
+
+func assertCursorExactSplits(t *testing.T, template, source *msgpb.InsertRequest, rows []int, limit int) {
+	t.Helper()
+	oracleSource := proto.Clone(source).(*msgpb.InsertRequest)
+	cursor, err := NewInsertRequestViewCursor(source)
+	require.NoError(t, err)
+	for start := 0; start < len(rows); {
+		encoder, consumed, err := cursor.NextEncoder(template, rows[start:], limit)
+		require.NoError(t, err)
+		selection := rows[start : start+consumed]
+		size, err := encoder.EncodedSize()
+		require.NoError(t, err)
+		if consumed > 1 {
+			require.Less(t, size, limit)
+		}
+		payload := make([]byte, size)
+		_, err = encoder.MarshalTo(payload)
+		require.NoError(t, err)
+		actual := &msgpb.InsertRequest{}
+		require.NoError(t, proto.Unmarshal(payload, actual))
+		expected := materializeWithAppendFieldData(template, oracleSource, selection)
+		require.True(t, proto.Equal(expected, actual), "selection=%v", selection)
+		if next := start + consumed; next < len(rows) {
+			candidate := append(append([]int(nil), selection...), rows[next])
+			candidateSize := proto.Size(materializeWithAppendFieldData(template, oracleSource, candidate))
+			require.GreaterOrEqual(t, candidateSize, limit, "selection=%v next=%d", selection, rows[next])
+		}
+		start += consumed
+	}
+}
+
+func encodeAndDecodeInsertView(t *testing.T, template, source *msgpb.InsertRequest, rows []int) *msgpb.InsertRequest {
+	t.Helper()
+	encoder, err := NewInsertRequestViewEncoder(template, source, rows)
+	require.NoError(t, err)
+	size, err := encoder.EncodedSize()
+	require.NoError(t, err)
+	dst := make([]byte, size+8)
+	for i := size; i < len(dst); i++ {
+		dst[i] = 0xA5
+	}
+	n, err := encoder.MarshalTo(dst)
+	require.NoError(t, err)
+	require.Equal(t, size, n)
+	for i := size; i < len(dst); i++ {
+		assert.Equal(t, byte(0xA5), dst[i], "MarshalTo wrote past EncodedSize")
+	}
+	got := &msgpb.InsertRequest{}
+	require.NoError(t, proto.Unmarshal(dst[:n], got))
+	return got
+}
+
+func materializeWithAppendFieldData(template, source *msgpb.InsertRequest, rows []int) *msgpb.InsertRequest {
+	expected := proto.Clone(template).(*msgpb.InsertRequest)
+	expected.Timestamps = make([]uint64, 0, len(rows))
+	expected.RowIDs = make([]int64, 0, len(rows))
+	expected.RowData = nil
+	expected.FieldsData = make([]*schemapb.FieldData, len(source.GetFieldsData()))
+	expected.NumRows = uint64(len(rows))
+
+	idxComputer := typeutil.NewFieldDataIdxComputer(source.GetFieldsData())
+	for _, row := range rows {
+		fieldIndices := idxComputer.Compute(int64(row))
+		typeutil.AppendFieldData(expected.FieldsData, source.GetFieldsData(), int64(row), fieldIndices...)
+		expected.Timestamps = append(expected.Timestamps, source.GetTimestamps()[row])
+		expected.RowIDs = append(expected.RowIDs, source.GetRowIDs()[row])
+	}
+	return expected
+}
+
+func materializeExtendedScalars(template, source *msgpb.InsertRequest, rows []int) *msgpb.InsertRequest {
+	expected := proto.Clone(template).(*msgpb.InsertRequest)
+	expected.Timestamps = make([]uint64, 0, len(rows))
+	expected.RowIDs = make([]int64, 0, len(rows))
+	expected.RowData = nil
+	expected.FieldsData = make([]*schemapb.FieldData, 0, len(source.GetFieldsData()))
+	expected.NumRows = uint64(len(rows))
+	for _, row := range rows {
+		expected.Timestamps = append(expected.Timestamps, source.GetTimestamps()[row])
+		expected.RowIDs = append(expected.RowIDs, source.GetRowIDs()[row])
+	}
+	for _, sourceField := range source.GetFieldsData() {
+		field := &schemapb.FieldData{
+			Type: sourceField.GetType(), FieldName: sourceField.GetFieldName(), FieldId: sourceField.GetFieldId(), IsDynamic: sourceField.GetIsDynamic(),
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{}},
+		}
+		for _, row := range rows {
+			if len(sourceField.GetValidData()) > 0 {
+				field.ValidData = append(field.ValidData, sourceField.GetValidData()[row])
+			}
+		}
+		switch value := sourceField.GetScalars().Data.(type) {
+		case *schemapb.ScalarField_BytesData:
+			selected := &schemapb.BytesArray{}
+			for _, row := range rows {
+				selected.Data = append(selected.Data, value.BytesData.GetData()[row])
+			}
+			field.GetScalars().Data = &schemapb.ScalarField_BytesData{BytesData: selected}
+		case *schemapb.ScalarField_MolData:
+			selected := &schemapb.MolArray{}
+			for _, row := range rows {
+				selected.Data = append(selected.Data, value.MolData.GetData()[row])
+			}
+			field.GetScalars().Data = &schemapb.ScalarField_MolData{MolData: selected}
+		case *schemapb.ScalarField_MolSmilesData:
+			selected := &schemapb.MolSmilesArray{}
+			for _, row := range rows {
+				selected.Data = append(selected.Data, value.MolSmilesData.GetData()[row])
+			}
+			field.GetScalars().Data = &schemapb.ScalarField_MolSmilesData{MolSmilesData: selected}
+		case *schemapb.ScalarField_DateData:
+			selected := &schemapb.DateArray{}
+			for _, row := range rows {
+				selected.Data = append(selected.Data, value.DateData.GetData()[row])
+			}
+			field.GetScalars().Data = &schemapb.ScalarField_DateData{DateData: selected}
+		case *schemapb.ScalarField_TimeData:
+			selected := &schemapb.TimeArray{}
+			for _, row := range rows {
+				selected.Data = append(selected.Data, value.TimeData.GetData()[row])
+			}
+			field.GetScalars().Data = &schemapb.ScalarField_TimeData{TimeData: selected}
+		default:
+			panic("unexpected extended scalar")
+		}
+		expected.FieldsData = append(expected.FieldsData, field)
+	}
+	return expected
+}
+
+func insertViewTemplate() *msgpb.InsertRequest {
+	namespace := "tenant-a"
+	return &msgpb.InsertRequest{
+		Base: &commonpb.MsgBase{
+			MsgType:   commonpb.MsgType_Insert,
+			MsgID:     100,
+			Timestamp: 200,
+			SourceID:  300,
+		},
+		ShardName:      "by-dev-rootcoord-dml_0_123v0",
+		DbName:         "db",
+		CollectionName: "collection",
+		PartitionName:  "partition",
+		DbID:           10,
+		CollectionID:   20,
+		PartitionID:    30,
+		SegmentID:      40,
+		Version:        msgpb.InsertDataVersion_ColumnBased,
+		Namespace:      &namespace,
+	}
+}
+
+func insertViewAllRepackTypesSource() *msgpb.InsertRequest {
+	const rows = 5
+	valid := []bool{true, false, true, true, false}
+	arrayRows := make([]*schemapb.ScalarField, rows)
+	vectorArrayRows := make([]*schemapb.VectorField, rows)
+	for row := 0; row < rows; row++ {
+		arrayRows[row] = &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{int64(row), int64(row + 10)}}}}
+		vectorData := []float32{float32(row), float32(row) + 0.5}
+		if !valid[row] {
+			vectorData = nil // ArrayOfVector keeps a placeholder for null rows.
+		}
+		vectorArrayRows[row] = &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: vectorData}}}
+	}
+
+	return &msgpb.InsertRequest{
+		NumRows:    rows,
+		RowIDs:     []int64{-1, 0, 1, 2, math.MaxInt64},
+		Timestamps: []uint64{0, 1, 127, 128, math.MaxUint64},
+		FieldsData: []*schemapb.FieldData{
+			{Type: schemapb.DataType_Bool, FieldName: "bool", FieldId: 1, ValidData: valid, Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{Data: []bool{true, false, true, false, true}}}}}},
+			scalarField(2, schemapb.DataType_Int32, &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{-1, 0, 1, 128, math.MaxInt32}}}),
+			scalarField(3, schemapb.DataType_Int64, &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{-1, 0, 1, 128, math.MaxInt64}}}),
+			scalarField(4, schemapb.DataType_Float, &schemapb.ScalarField_FloatData{FloatData: &schemapb.FloatArray{Data: []float32{-1.5, 0, 1.5, float32(math.Inf(1)), float32(math.NaN())}}}),
+			scalarField(5, schemapb.DataType_Double, &schemapb.ScalarField_DoubleData{DoubleData: &schemapb.DoubleArray{Data: []float64{-1.5, 0, 1.5, math.Inf(-1), math.NaN()}}}),
+			scalarField(6, schemapb.DataType_VarChar, &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"", "ascii", "向量", "x", "last"}}}),
+			scalarField(7, schemapb.DataType_Array, &schemapb.ScalarField_ArrayData{ArrayData: &schemapb.ArrayArray{Data: arrayRows, ElementType: schemapb.DataType_Int64}}),
+			scalarField(8, schemapb.DataType_JSON, &schemapb.ScalarField_JsonData{JsonData: &schemapb.JSONArray{Data: [][]byte{[]byte(`{}`), []byte(`null`), []byte(`{"a":2}`), {}, []byte(`[]`)}}}),
+			scalarField(9, schemapb.DataType_Timestamptz, &schemapb.ScalarField_TimestamptzData{TimestamptzData: &schemapb.TimestamptzArray{Data: []int64{-1, 0, 1, 2, 3}}}),
+			scalarField(10, schemapb.DataType_Geometry, &schemapb.ScalarField_GeometryData{GeometryData: &schemapb.GeometryArray{Data: [][]byte{{1}, {2}, {3}, {}, {5}}}}),
+			scalarField(11, schemapb.DataType_VarChar, &schemapb.ScalarField_GeometryWktData{GeometryWktData: &schemapb.GeometryWktArray{Data: []string{"POINT(0 0)", "", "POINT(2 2)", "POINT(3 3)", "POINT(4 4)"}}}),
+			{Type: schemapb.DataType_BinaryVector, FieldName: "binary", FieldId: 12, Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 16, Data: &schemapb.VectorField_BinaryVector{BinaryVector: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}}}}},
+			{Type: schemapb.DataType_FloatVector, FieldName: "float-vector", FieldId: 13, ValidData: valid, Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: []float32{10, 11, 20, 21, 30, 31}}}}}},
+			{Type: schemapb.DataType_Float16Vector, FieldName: "float16", FieldId: 14, ValidData: valid, Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_Float16Vector{Float16Vector: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}}}}},
+			{Type: schemapb.DataType_BFloat16Vector, FieldName: "bfloat16", FieldId: 15, ValidData: valid, Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: []byte{12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}}}}},
+			{Type: schemapb.DataType_SparseFloatVector, FieldName: "sparse", FieldId: 16, ValidData: valid, Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 99, Data: &schemapb.VectorField_SparseFloatVector{SparseFloatVector: &schemapb.SparseFloatArray{Dim: 100, Contents: [][]byte{sparseTestRow(1), sparseTestRow(9), sparseTestRow(4)}}}}}},
+			{Type: schemapb.DataType_Int8Vector, FieldName: "int8", FieldId: 17, ValidData: valid, Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_Int8Vector{Int8Vector: []byte{1, 2, 3, 4, 5, 6}}}}},
+			{Type: schemapb.DataType_ArrayOfVector, FieldName: "array-of-vector", FieldId: 18, ValidData: valid, Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_VectorArray{VectorArray: &schemapb.VectorArray{Dim: 2, ElementType: schemapb.DataType_FloatVector, Data: vectorArrayRows}}}}},
+		},
+	}
+}
+
+func randomInsertViewSource(r *rand.Rand, rows int) *msgpb.InsertRequest {
+	valid := make([]bool, rows)
+	floatData := make([]float32, 0, rows*4)
+	binaryData := make([]byte, 0, rows*2)
+	sparseData := make([][]byte, 0, rows)
+	for row := 0; row < rows; row++ {
+		valid[row] = r.Intn(3) != 0
+		if valid[row] {
+			for i := 0; i < 4; i++ {
+				floatData = append(floatData, r.Float32())
+			}
+			binaryData = append(binaryData, byte(r.Uint32()), byte(r.Uint32()))
+			sparseData = append(sparseData, sparseTestRow(uint32(r.Intn(256))))
+		}
+	}
+	rowIDs := make([]int64, rows)
+	timestamps := make([]uint64, rows)
+	ints := make([]int64, rows)
+	strings := make([]string, rows)
+	vectorArrayRows := make([]*schemapb.VectorField, rows)
+	for row := 0; row < rows; row++ {
+		rowIDs[row] = int64(r.Uint64())
+		timestamps[row] = r.Uint64()
+		ints[row] = int64(r.Uint64())
+		strings[row] = rowsName([]int{row, r.Intn(1000)})
+		vectorArrayRows[row] = &schemapb.VectorField{Dim: 1, Data: &schemapb.VectorField_Int8Vector{Int8Vector: []byte{byte(r.Uint32())}}}
+	}
+	return &msgpb.InsertRequest{
+		NumRows: uint64(rows), RowIDs: rowIDs, Timestamps: timestamps,
+		FieldsData: []*schemapb.FieldData{
+			scalarField(1, schemapb.DataType_Int64, &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: ints}}),
+			scalarField(2, schemapb.DataType_VarChar, &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: strings}}),
+			{Type: schemapb.DataType_FloatVector, FieldId: 3, ValidData: valid, Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 4, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: floatData}}}}},
+			{Type: schemapb.DataType_BinaryVector, FieldId: 4, ValidData: valid, Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 16, Data: &schemapb.VectorField_BinaryVector{BinaryVector: binaryData}}}},
+			{Type: schemapb.DataType_SparseFloatVector, FieldId: 5, ValidData: valid, Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Data: &schemapb.VectorField_SparseFloatVector{SparseFloatVector: &schemapb.SparseFloatArray{Dim: 256, Contents: sparseData}}}}},
+			{Type: schemapb.DataType_ArrayOfVector, FieldId: 6, Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 1, Data: &schemapb.VectorField_VectorArray{VectorArray: &schemapb.VectorArray{Dim: 1, ElementType: schemapb.DataType_Int8Vector, Data: vectorArrayRows}}}}},
+		},
+	}
+}
+
+func scalarField(id int64, dataType schemapb.DataType, data any) *schemapb.FieldData {
+	scalar := &schemapb.ScalarField{}
+	switch value := data.(type) {
+	case *schemapb.ScalarField_BoolData:
+		scalar.Data = value
+	case *schemapb.ScalarField_IntData:
+		scalar.Data = value
+	case *schemapb.ScalarField_LongData:
+		scalar.Data = value
+	case *schemapb.ScalarField_FloatData:
+		scalar.Data = value
+	case *schemapb.ScalarField_DoubleData:
+		scalar.Data = value
+	case *schemapb.ScalarField_StringData:
+		scalar.Data = value
+	case *schemapb.ScalarField_BytesData:
+		scalar.Data = value
+	case *schemapb.ScalarField_ArrayData:
+		scalar.Data = value
+	case *schemapb.ScalarField_JsonData:
+		scalar.Data = value
+	case *schemapb.ScalarField_GeometryData:
+		scalar.Data = value
+	case *schemapb.ScalarField_TimestamptzData:
+		scalar.Data = value
+	case *schemapb.ScalarField_GeometryWktData:
+		scalar.Data = value
+	case *schemapb.ScalarField_MolData:
+		scalar.Data = value
+	case *schemapb.ScalarField_MolSmilesData:
+		scalar.Data = value
+	case *schemapb.ScalarField_DateData:
+		scalar.Data = value
+	case *schemapb.ScalarField_TimeData:
+		scalar.Data = value
+	default:
+		panic("unsupported scalar test data")
+	}
+	return &schemapb.FieldData{
+		Type: dataType, FieldName: rowsName([]int{int(id)}), FieldId: id,
+		Field: &schemapb.FieldData_Scalars{Scalars: scalar},
+	}
+}
+
+func sparseTestRow(index uint32) []byte {
+	row := make([]byte, 8)
+	binary.LittleEndian.PutUint32(row, index)
+	binary.LittleEndian.PutUint32(row[4:], math.Float32bits(float32(index)+0.5))
+	return row
+}
+
+func rowsName(rows []int) string {
+	if len(rows) == 0 {
+		return "empty"
+	}
+	result := "rows"
+	for _, row := range rows {
+		result += "_" + string(rune('a'+row%26))
+	}
+	return result
+}
+
+func flattenRowSelections(selections [][]int) []int {
+	var rows []int
+	for _, selection := range selections {
+		rows = append(rows, selection...)
+	}
+	return rows
+}

--- a/pkg/util/fastpb/proto_contract_test.go
+++ b/pkg/util/fastpb/proto_contract_test.go
@@ -1,43 +1,72 @@
 package fastpb
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	milvuspb "github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	msgpb "github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	schemapb "github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 )
 
-// fieldNumbers returns the sorted set of field numbers declared on m's
-// descriptor, INCLUDING oneof members and proto3-optional fields (the
-// descriptor enumerates them, unlike struct-tag scraping).
-func fieldNumbers(m proto.Message) []int {
+func fieldDescriptorContract(m proto.Message) string {
 	fds := m.ProtoReflect().Descriptor().Fields()
-	out := make([]int, 0, fds.Len())
-	for i := 0; i < fds.Len(); i++ {
-		out = append(out, int(fds.Get(i).Number()))
+	type contract struct {
+		number protoreflect.FieldNumber
+		text   string
 	}
-	sort.Ints(out)
-	return out
+	contracts := make([]contract, 0, fds.Len())
+	for i := 0; i < fds.Len(); i++ {
+		fd := fds.Get(i)
+		typeName := "-"
+		if fd.Message() != nil {
+			typeName = string(fd.Message().FullName())
+		} else if fd.Enum() != nil {
+			typeName = string(fd.Enum().FullName())
+		}
+		oneofName := "-"
+		oneofSynthetic := false
+		if oneof := fd.ContainingOneof(); oneof != nil {
+			oneofName = string(oneof.FullName())
+			oneofSynthetic = oneof.IsSynthetic()
+		}
+		contracts = append(contracts, contract{
+			number: fd.Number(),
+			text: fmt.Sprintf("%s#%d/%s/%s/packed=%t/type=%s/oneof=%s/synthetic=%t/presence=%t",
+				fd.Name(), fd.Number(), fd.Kind(), fd.Cardinality(), fd.IsPacked(), typeName, oneofName, oneofSynthetic, fd.HasPresence()),
+		})
+	}
+	sort.Slice(contracts, func(i, j int) bool {
+		return contracts[i].number < contracts[j].number
+	})
+	parts := make([]string, len(contracts))
+	for i, contract := range contracts {
+		parts[i] = contract.text
+	}
+	return strings.Join(parts, ";")
 }
 
-// TestProtoContract_FieldSetsPinned is a tripwire. fastpb hand-writes wire
-// decoders for the message types below; each decoder switches on hard-coded
-// field numbers. The golden field set for every such type is pinned here, so
-// ANY edit to these protos (a new field, a removed field, a renumber) flips
-// this test red and blocks CI.
+// TestProtoContract_FieldDescriptorsPinned is a tripwire. fastpb hand-writes
+// wire codecs for the message types below; each codec depends on exact field
+// names, numbers, kinds, cardinality, packed representation, message/enum type,
+// presence, and oneof membership. A stable digest of that complete normalized
+// descriptor tuple is pinned for every type.
 //
-// When it fails, do NOT just bump the golden set. First go read the matching
-// hand-decoder in pkg/util/fastpb and decide what the proto change requires:
+// When it fails, do NOT just bump the digest. First go read the matching
+// hand-written codec in pkg/util/fastpb and decide what the proto change requires:
 //
-//   - A new plain (non-oneof) scalar/message field is correct-by-construction:
-//     unknown field numbers fold into the official codec via the decoder's
-//     `default -> rest -> protoMerge` fallback. You may still want to hand-decode
-//     it if it lands on a hot path, but correctness is already preserved.
+//   - A new plain (non-oneof) scalar/message field may be correct-by-construction
+//     for a decoder that folds unknown fields through `rest -> protoMerge`.
+//     Encoders do not have that fallback: decide whether the field belongs to
+//     output metadata, selected row data, or must be rejected explicitly.
 //
 //   - A NEW oneof VARIANT is the dangerous case. It also falls through to the
 //     deferred protoMerge, but that breaks oneof last-wins ordering relative to
@@ -45,47 +74,112 @@ func fieldNumbers(m proto.Message) []int {
 //     fielddata.go). New oneof variants on FieldData / ScalarField / VectorField
 //     / IDs MUST be handled in-pass, not left to the fallback.
 //
-//   - Changing the wire type or meaning of an EXISTING hand-decoded number
+//   - Changing the wire type or meaning of an EXISTING hard-coded number
 //     silently corrupts the fast path — the hard-coded case still fires.
 //
-// Only after the decoder is correct should you update the golden set below.
-func TestProtoContract_FieldSetsPinned(t *testing.T) {
+// Only after every affected codec is correct should you update the digest.
+func TestProtoContract_FieldDescriptorsPinned(t *testing.T) {
 	cases := []struct {
 		name string
 		msg  proto.Message
-		want []int
+		want string
 	}{
 		// top-level fast-pathed types (TryUnmarshal dispatch)
-		{"internalpb.RetrieveResults", &internalpb.RetrieveResults{}, []int{1, 2, 3, 4, 5, 6, 7, 8, 13, 14, 15, 16, 17, 18, 19}},
-		{"milvuspb.InsertRequest", &milvuspb.InsertRequest{}, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}},
-		{"milvuspb.UpsertRequest", &milvuspb.UpsertRequest{}, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}},
-		{"schemapb.SearchResultData", &schemapb.SearchResultData{}, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17, 18, 19}},
+		{"internalpb.RetrieveResults", &internalpb.RetrieveResults{}, "2b1e7ae8a633e6145c1f352e2653f28d561d144629be05fc7b18ccf7022518a6"},
+		{"milvuspb.InsertRequest", &milvuspb.InsertRequest{}, "a334da7b112573d379549d8c81c1afcf0a8526488947c4868b6ff4d9413b29a7"},
+		{"milvuspb.UpsertRequest", &milvuspb.UpsertRequest{}, "a0fc2a36ce1d4f67f0d73a4c7faabbf0d7c76b522ce8acc851c149f311c78d50"},
+		{"msgpb.InsertRequest", &msgpb.InsertRequest{}, "c98eeac7deeace0770cdafbb910aec8fb2a1de9e152f99821bb260afdd19c44d"},
+		{"schemapb.SearchResultData", &schemapb.SearchResultData{}, "f17c51046b4baf17f67a48938a244aaa0a5ca50fbfe649fd0e88e03af8c53ecd"},
 		// nested hand-decoded types (oneof-bearing — highest divergence risk)
-		{"schemapb.FieldData", &schemapb.FieldData{}, []int{1, 2, 3, 4, 5, 6, 7, 8}},
-		{"schemapb.ScalarField", &schemapb.ScalarField{}, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17}},
-		{"schemapb.VectorField", &schemapb.VectorField{}, []int{1, 2, 3, 4, 5, 6, 7, 8, 9}},
-		{"schemapb.IDs", &schemapb.IDs{}, []int{1, 2, 3}},
+		{"schemapb.FieldData", &schemapb.FieldData{}, "dde2cc5e2e91394c5f3c2099f2529b7ef2e6f6707744c98a73bd4b86505cc081"},
+		{"schemapb.ScalarField", &schemapb.ScalarField{}, "4e8d38191186856584bf0b02593b8d6f513b775845b1c1cebddeb98cff11ffda"},
+		{"schemapb.VectorField", &schemapb.VectorField{}, "157f02036ff1af36827de849900cb9a0430e99258acded8e11a589b227df0411"},
+		{"schemapb.IDs", &schemapb.IDs{}, "350a0a056fcd16e1aa576276108dcfac0ff2dd368d51bb49a7c9e05b67e00a6c"},
 		// leaf arrays with their own hand-written field switches (no unknown-field
 		// fallback in some — a new field here would mis-parse)
-		{"schemapb.SparseFloatArray", &schemapb.SparseFloatArray{}, []int{1, 2}},
-		{"schemapb.FloatArray", &schemapb.FloatArray{}, []int{1}},
-		{"schemapb.LongArray", &schemapb.LongArray{}, []int{1}},
-		{"schemapb.IntArray", &schemapb.IntArray{}, []int{1}},
-		{"schemapb.BoolArray", &schemapb.BoolArray{}, []int{1}},
-		{"schemapb.DoubleArray", &schemapb.DoubleArray{}, []int{1}},
-		{"schemapb.BytesArray", &schemapb.BytesArray{}, []int{1}},
-		{"schemapb.UUIDArray", &schemapb.UUIDArray{}, []int{1}},
-		{"schemapb.JSONArray", &schemapb.JSONArray{}, []int{1}},
-		{"schemapb.UUIDArray", &schemapb.UUIDArray{}, []int{1}},
-		{"schemapb.StringArray", &schemapb.StringArray{}, []int{1}},
+		{"schemapb.SparseFloatArray", &schemapb.SparseFloatArray{}, "7f2a00a40e7a3e7664403c3d08d7753e1d3044ff074db735a6b20dc98737b813"},
+		{"schemapb.FloatArray", &schemapb.FloatArray{}, "7338e15ebca10fe312d1e9820dc09fdc49fec68905b162966271e9f58313efde"},
+		{"schemapb.LongArray", &schemapb.LongArray{}, "3aea90038f9e62d79ad96e6524f939d9130a06539ce54c78eda45a11e3028291"},
+		{"schemapb.IntArray", &schemapb.IntArray{}, "7c1ee638141b8de8c9d740fcb70bbc7c76d38817cb6d5380b3e8f7690f2f8370"},
+		{"schemapb.BoolArray", &schemapb.BoolArray{}, "e03d41a1a7eb0a5d1d17a7455df71cca7474e4b0d55eac0df979d9cfabeca0c7"},
+		{"schemapb.DoubleArray", &schemapb.DoubleArray{}, "65647c549e381e12de24c66049c31f9fefce216e0af82457829bd8e7a6fdee9d"},
+		{"schemapb.BytesArray", &schemapb.BytesArray{}, "bbc4d3675300c40250e658c62d35489560260a781142b03d330e5bf6618baeab"},
+		{"schemapb.ArrayArray", &schemapb.ArrayArray{}, "03f99b445863ce638c0132bbfdfd15db193f9adefca807e5ba710129f1ce9d64"},
+		{"schemapb.JSONArray", &schemapb.JSONArray{}, "bbc4d3675300c40250e658c62d35489560260a781142b03d330e5bf6618baeab"},
+		{"schemapb.UUIDArray", &schemapb.UUIDArray{}, "bbc4d3675300c40250e658c62d35489560260a781142b03d330e5bf6618baeab"},
+		{"schemapb.GeometryArray", &schemapb.GeometryArray{}, "bbc4d3675300c40250e658c62d35489560260a781142b03d330e5bf6618baeab"},
+		{"schemapb.TimestamptzArray", &schemapb.TimestamptzArray{}, "3aea90038f9e62d79ad96e6524f939d9130a06539ce54c78eda45a11e3028291"},
+		{"schemapb.GeometryWktArray", &schemapb.GeometryWktArray{}, "80b5e36020cb25d39d76417531402eaba350456c82050dfa96654473dc59f298"},
+		{"schemapb.MolArray", &schemapb.MolArray{}, "bbc4d3675300c40250e658c62d35489560260a781142b03d330e5bf6618baeab"},
+		{"schemapb.MolSmilesArray", &schemapb.MolSmilesArray{}, "80b5e36020cb25d39d76417531402eaba350456c82050dfa96654473dc59f298"},
+		{"schemapb.DateArray", &schemapb.DateArray{}, "7c1ee638141b8de8c9d740fcb70bbc7c76d38817cb6d5380b3e8f7690f2f8370"},
+		{"schemapb.TimeArray", &schemapb.TimeArray{}, "3aea90038f9e62d79ad96e6524f939d9130a06539ce54c78eda45a11e3028291"},
+		{"schemapb.StringArray", &schemapb.StringArray{}, "80b5e36020cb25d39d76417531402eaba350456c82050dfa96654473dc59f298"},
+		{"schemapb.VectorArray", &schemapb.VectorArray{}, "4a2324ee4ff40a0723da8b011125c7762e2739c3de63e4dde7e6025faa532e17"},
 	}
 	for _, c := range cases {
-		got := fieldNumbers(c.msg)
+		contract := fieldDescriptorContract(c.msg)
+		got := fmt.Sprintf("%x", sha256.Sum256([]byte(contract)))
 		assert.Equalf(t, c.want, got,
-			"%s proto field set changed (want %v, got %v).\n"+
-				"This type is hand-decoded in pkg/util/fastpb. Read the decoder and the\n"+
-				"guidance on TestProtoContract_FieldSetsPinned BEFORE updating this golden set —\n"+
-				"a new oneof variant in particular must be handled in-pass, not by the protoMerge fallback.",
-			c.name, c.want, got)
+			"%s proto field descriptor changed (want digest %s, got %s).\n"+
+				"Normalized descriptor: %s\n"+
+				"This type has a hand-written codec in pkg/util/fastpb. Read the codec and the\n"+
+				"guidance on TestProtoContract_FieldDescriptorsPinned BEFORE updating this digest —\n"+
+				"a new oneof variant in particular requires explicit handling.",
+			c.name, c.want, got, contract)
+	}
+}
+
+// TestInsertRequestViewEncoder_FieldNumbersCovered makes the encoder's field
+// ownership explicit. The descriptor digest above catches every proto change,
+// but this independent allowlist prevents a future contributor from merely
+// updating that digest after adding a field that appendRequest does not emit.
+//
+// row_data is the only intentional omission: the Proxy uses the column-based
+// representation and materializeWithAppendFieldData drops this compatibility
+// field as well. Every other known field is emitted from either the metadata
+// template or the selected row view.
+func TestInsertRequestViewEncoder_FieldNumbersCovered(t *testing.T) {
+	type fieldContract struct {
+		name    protoreflect.Name
+		emitted bool
+	}
+	contracts := map[protoreflect.FieldNumber]fieldContract{
+		1:  {name: "base", emitted: true},
+		2:  {name: "shardName", emitted: true},
+		3:  {name: "db_name", emitted: true},
+		4:  {name: "collection_name", emitted: true},
+		5:  {name: "partition_name", emitted: true},
+		6:  {name: "dbID", emitted: true},
+		7:  {name: "collectionID", emitted: true},
+		8:  {name: "partitionID", emitted: true},
+		9:  {name: "segmentID", emitted: true},
+		10: {name: "timestamps", emitted: true},
+		11: {name: "rowIDs", emitted: true},
+		12: {name: "row_data", emitted: false},
+		13: {name: "fields_data", emitted: true},
+		14: {name: "num_rows", emitted: true},
+		15: {name: "version", emitted: true},
+		16: {name: "namespace", emitted: true},
+	}
+
+	fields := (&msgpb.InsertRequest{}).ProtoReflect().Descriptor().Fields()
+	assert.Equal(t, len(contracts), fields.Len(),
+		"msgpb.InsertRequest gained or lost a field; classify it in the view encoder contract")
+	for i := 0; i < fields.Len(); i++ {
+		field := fields.Get(i)
+		contract, ok := contracts[field.Number()]
+		if !assert.Truef(t, ok,
+			"msgpb.InsertRequest field %s (#%d) is not classified by InsertRequestViewEncoder",
+			field.FullName(), field.Number()) {
+			continue
+		}
+		assert.Equalf(t, contract.name, field.Name(),
+			"msgpb.InsertRequest field #%d changed identity; audit InsertRequestViewEncoder before updating the contract",
+			field.Number())
+		if !contract.emitted {
+			assert.Equal(t, protoreflect.FieldNumber(12), field.Number(),
+				"only the legacy row_data field may be intentionally omitted")
+		}
 	}
 }

--- a/pkg/util/fastpb/unsafeopt.go
+++ b/pkg/util/fastpb/unsafeopt.go
@@ -8,11 +8,10 @@ import (
 // validUTF8 reports whether v is valid UTF-8 (matches proto3 string validation).
 func validUTF8(v []byte) bool { return utf8.Valid(v) }
 
-// This file isolates the only unsafe in the package. Both helpers are
-// little-endian (x86/arm64) and produce freshly-allocated, self-owned memory —
-// they do NOT alias the source buffer, so they are safe regardless of the
-// source buffer's lifetime (gRPC-pooled or owned). A separate zero-copy
-// aliasing variant (for the owned sliced_blob path) can be added later.
+// This file isolates the only unsafe in the package. The conversion helpers are
+// little-endian (x86/arm64). bytesToF32/bytesToF64 produce freshly-allocated,
+// self-owned memory; f32ReadOnlyBytes is explicitly a borrowed read-only view
+// used only while synchronously copying into a final protobuf payload.
 
 // bytesToF32 returns a new []float32 holding the little-endian float32s in v
 // via a single memcpy (len(v) must be a multiple of 4).
@@ -34,6 +33,17 @@ func bytesToF64(v []byte) []float64 {
 		copy(unsafe.Slice((*byte)(unsafe.Pointer(&out[0])), n*8), v)
 	}
 	return out
+}
+
+// f32ReadOnlyBytes returns a byte view over v without allocating. The returned
+// slice aliases v and must never be mutated or retained beyond the synchronous
+// encode that requested it. Float protobuf wire values are little-endian, which
+// matches every architecture Milvus currently supports (x86-64 and arm64).
+func f32ReadOnlyBytes(v []float32) []byte {
+	if len(v) == 0 {
+		return nil
+	}
+	return unsafe.Slice((*byte)(unsafe.Pointer(&v[0])), len(v)*4)
 }
 
 // strings copies the string elements out of one StringArray submessage into

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2351,6 +2351,9 @@ type proxyConfig struct {
 	// Alias  string
 	SoPath ParamItem `refreshable:"false"`
 
+	// WAL payload chunking rollout switch.
+	SplitChunkProxy ParamItem `refreshable:"true"`
+
 	TimeTickInterval               ParamItem `refreshable:"false"`
 	HealthCheckTimeout             ParamItem `refreshable:"true"`
 	MsgStreamTimeTickBufSize       ParamItem `refreshable:"true"`
@@ -2420,6 +2423,17 @@ type proxyConfig struct {
 }
 
 func (p *proxyConfig) init(base *BaseTable) {
+	p.SplitChunkProxy = ParamItem{
+		Key:          "proxy.splitChunk",
+		Version:      "3.0.2",
+		DefaultValue: "true",
+		Doc: `Whether Proxy keeps the legacy row-based size packing before sending messages to StreamingNode.
+Keep this enabled until chunk writing is enabled and observed on every StreamingNode that can own a pchannel.
+For migration, enable streaming.splitChunkSN first, then disable proxy.splitChunk. Both parameters support live refresh.`,
+		Export: true,
+	}
+	p.SplitChunkProxy.Init(base.mgr)
+
 	p.TimeTickInterval = ParamItem{
 		Key:          "proxy.timeTickInterval",
 		Version:      "2.2.0",
@@ -8222,6 +8236,9 @@ writeRetryInitialInterval, otherwise the effective cap is raised to twice the in
 }
 
 type streamingConfig struct {
+	// WAL payload chunking rollout switch.
+	SplitChunkSN ParamItem `refreshable:"true"`
+
 	// primary resource group
 	PrimaryResourceGroup ParamItem `refreshable:"true"`
 
@@ -8320,6 +8337,17 @@ type streamingConfig struct {
 }
 
 func (p *streamingConfig) init(base *BaseTable) {
+	p.SplitChunkSN = ParamItem{
+		Key:          "streaming.splitChunkSN",
+		Version:      "3.0.2",
+		DefaultValue: "false",
+		Doc: `Whether StreamingNode splits oversized logical messages into physical WAL records.
+Enable this on every StreamingNode and confirm the live update before disabling proxy.splitChunk.
+Once chunk records have been written, do not roll StreamingNode back to a version that cannot reassemble them. Both parameters support live refresh.`,
+		Export: true,
+	}
+	p.SplitChunkSN.Init(base.mgr)
+
 	// primary resource group
 	p.PrimaryResourceGroup = ParamItem{
 		Key:     "streaming.primaryResourceGroup",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -421,6 +421,13 @@ func TestComponentParam(t *testing.T) {
 	t.Run("test proxyConfig", func(t *testing.T) {
 		Params := &params.ProxyCfg
 
+		assert.Equal(t, "proxy.splitChunk", Params.SplitChunkProxy.Key)
+		assert.True(t, Params.SplitChunkProxy.GetAsBool())
+		params.Save(Params.SplitChunkProxy.Key, "false")
+		assert.False(t, Params.SplitChunkProxy.GetAsBool())
+		params.Reset(Params.SplitChunkProxy.Key)
+		assert.True(t, Params.SplitChunkProxy.GetAsBool())
+
 		t.Logf("TimeTickInterval: %v", &Params.TimeTickInterval)
 
 		t.Logf("healthCheckTimeout: %v", &Params.HealthCheckTimeout)
@@ -1028,6 +1035,12 @@ func TestComponentParam(t *testing.T) {
 	})
 
 	t.Run("test streamingConfig", func(t *testing.T) {
+		assert.Equal(t, "streaming.splitChunkSN", params.StreamingCfg.SplitChunkSN.Key)
+		assert.False(t, params.StreamingCfg.SplitChunkSN.GetAsBool())
+		params.Save(params.StreamingCfg.SplitChunkSN.Key, "true")
+		assert.True(t, params.StreamingCfg.SplitChunkSN.GetAsBool())
+		params.Reset(params.StreamingCfg.SplitChunkSN.Key)
+		assert.False(t, params.StreamingCfg.SplitChunkSN.GetAsBool())
 		assert.Equal(t, false, params.StreamingCfg.WALScannerPauseConsumption.GetAsBool())
 		assert.Equal(t, 1*time.Minute, params.StreamingCfg.WALBalancerTriggerInterval.GetAsDurationByParse())
 		assert.Equal(t, 10*time.Millisecond, params.StreamingCfg.WALBalancerBackoffInitialInterval.GetAsDurationByParse())

--- a/pkg/util/paramtable/quota_param.go
+++ b/pkg/util/paramtable/quota_param.go
@@ -129,6 +129,7 @@ type quotaConfig struct {
 	LargeMaxQueryResultWindow      ParamItem `refreshable:"true"`
 	MaxOutputSize                  ParamItem `refreshable:"true"`
 	MaxInsertSize                  ParamItem `refreshable:"true"`
+	MaxDeleteSize                  ParamItem `refreshable:"true"`
 	MaxResourceGroupNumOfQueryNode ParamItem `refreshable:"true"`
 	MaxGroupSize                   ParamItem `refreshable:"true"`
 
@@ -1502,11 +1503,29 @@ Check https://milvus.io/docs/limitations.md for more details.`,
 	p.MaxInsertSize = ParamItem{
 		Key:          "quotaAndLimits.limits.maxInsertSize",
 		Version:      "2.4.1",
-		DefaultValue: "-1", // -1 means no limit, the unit is byte
-		Doc:          `maximum size of a single insert request, in bytes, -1 means no limit`,
-		Export:       true,
+		DefaultValue: "67108864", // 64 MiB, the unit is byte
+		Doc: `maximum protobuf size of the Proxy-side materialized insert message, in bytes,
+for both insert and upsert; -1 means no limit. The check runs after Proxy field
+materialization, including generated fields, row IDs, timestamps, namespace data,
+and partial-upsert query reconstruction. It does not include later streaming-message
+properties, encryption expansion, StreamingNode-generated function fields, or the
+broker envelope.`,
+		Export: true,
 	}
 	p.MaxInsertSize.Init(base.mgr)
+
+	p.MaxDeleteSize = ParamItem{
+		Key:          "quotaAndLimits.limits.maxDeleteSize",
+		Version:      "3.0.2",
+		DefaultValue: "16777216", // 16 MiB, the unit is byte
+		Doc: `maximum protobuf size of each Proxy-side materialized delete message, in bytes,
+for both delete and upsert tombstones; -1 means no limit. The check runs after
+primary keys and timestamps are materialized and routed to a vchannel. It does
+not include later streaming-message properties, encryption expansion, chunk
+markers, or the broker envelope.`,
+		Export: true,
+	}
+	p.MaxDeleteSize.Init(base.mgr)
 
 	p.MaxResourceGroupNumOfQueryNode = ParamItem{
 		Key:          "quotaAndLimits.limits.maxResourceGroupNumOfQueryNode",

--- a/pkg/util/paramtable/quota_param_test.go
+++ b/pkg/util/paramtable/quota_param_test.go
@@ -183,9 +183,19 @@ func TestQuotaParam(t *testing.T) {
 		params.Save(params.QuotaConfig.MaxResourceGroupNumOfQueryNode.Key, "512")
 		assert.Equal(t, 512, params.QuotaConfig.MaxResourceGroupNumOfQueryNode.GetAsInt())
 
-		assert.Equal(t, -1, qc.MaxInsertSize.GetAsInt())
+		assert.Equal(t, 64*1024*1024, qc.MaxInsertSize.GetAsInt())
 		baseParams.Save(params.QuotaConfig.MaxInsertSize.Key, "1024")
 		assert.Equal(t, 1024, qc.MaxInsertSize.GetAsInt())
+		baseParams.Save(params.QuotaConfig.MaxInsertSize.Key, "-1")
+		assert.Equal(t, -1, qc.MaxInsertSize.GetAsInt())
+		baseParams.Reset(params.QuotaConfig.MaxInsertSize.Key)
+
+		assert.Equal(t, 16*1024*1024, qc.MaxDeleteSize.GetAsInt())
+		baseParams.Save(params.QuotaConfig.MaxDeleteSize.Key, "1024")
+		assert.Equal(t, 1024, qc.MaxDeleteSize.GetAsInt())
+		baseParams.Save(params.QuotaConfig.MaxDeleteSize.Key, "-1")
+		assert.Equal(t, -1, qc.MaxDeleteSize.GetAsInt())
+		baseParams.Reset(params.QuotaConfig.MaxDeleteSize.Key)
 	})
 
 	t.Run("test limit writing", func(t *testing.T) {

--- a/pkg/util/paramtable/service_param.go
+++ b/pkg/util/paramtable/service_param.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/time/rate"
+
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/util"
@@ -39,8 +41,53 @@ const (
 	KafkaProducerConfigPrefix = "kafka.producer."
 	KafkaConsumerConfigPrefix = "kafka.consumer."
 
+	// minWALMessageSize is the smallest supported per-record WAL message-size
+	// limit. Smaller limits do not leave enough useful payload capacity after
+	// reserving the streaming headers, properties, encryption expansion, and
+	// broker envelope, so bounded WAL backends clamp their configured limit to
+	// 256 KiB.
+	minWALMessageSize = 256 * 1024
+
+	// defaultPulsarMessageReserveSize is the headroom kept outside the plaintext
+	// message body for the streaming message header, cipher metadata/expansion,
+	// properties added before WAL append, and Pulsar message metadata. Sized
+	// generously (64 KiB): the WAL-impl payload chunker slices bodies into
+	// records of at most (limit - reserve) bytes, and this reserve must absorb
+	// the per-record properties clone plus the backend envelope of every chunk.
+	defaultPulsarMessageReserveSize = 64 * 1024
+
+	// minPulsarMessageReserveSize is the smallest headroom that can plausibly
+	// absorb one record's envelope. A reserve below this would let a full chunk
+	// plus its properties clone,
+	// streaming header, cipher metadata, and broker metadata cross the backend
+	// cap, and the rejected record would retry forever: exactly the stall the
+	// chunker exists to remove. The effective reserve is therefore clamped
+	// rather than trusted.
+	minPulsarMessageReserveSize = 1024
+
 	defaultLocalStoragePath = "/var/lib/milvus/data"
 )
+
+func walMessageSizeFormatter(key string, defaultSize int) func(string) string {
+	return func(value string) string {
+		messageSize, err := strconv.ParseInt(value, 10, 32)
+		if err != nil {
+			mlog.Warn(context.TODO(), "WAL message size must be a 32-bit integer, using default",
+				mlog.String("key", key),
+				mlog.String("configured", value),
+				mlog.Int("default", defaultSize))
+			return strconv.Itoa(defaultSize)
+		}
+		if messageSize < minWALMessageSize {
+			mlog.Warn(context.TODO(), "WAL message size is below the supported minimum, clamping",
+				mlog.String("key", key),
+				mlog.Int64("configured", messageSize),
+				mlog.Int("minimum", minWALMessageSize))
+			return strconv.Itoa(minWALMessageSize)
+		}
+		return value
+	}
+}
 
 // ServiceParam is used to quickly and easily access all basic service configurations.
 type ServiceParam struct {
@@ -73,6 +120,27 @@ func (p *ServiceParam) init(bt *BaseTable) {
 
 func (p *ServiceParam) RocksmqEnable() bool {
 	return p.RocksmqCfg.Path.GetValue() != ""
+}
+
+// WALMaxMessageSize reports the effective per-record limit used by WAL
+// chunking. Pulsar, Kafka, and Woodpecker configuration is normalized to at
+// least 256 KiB by the corresponding ParamItem formatter. External Pulsar
+// broker/proxy and Kafka broker/topic limits must support the same limit
+// because local normalization cannot raise their caps. RocksMQ has neither a
+// hard per-entry cap nor a configured chunk threshold (and neither do
+// unrecognized names), so 0 is returned there. This is the single place a WAL
+// name maps to its chunking limit.
+func (p *ServiceParam) WALMaxMessageSize(walName string) int {
+	switch walName {
+	case "kafka":
+		return p.KafkaCfg.ProducerMessageMaxBytes.GetAsInt()
+	case "woodpecker":
+		return p.WoodpeckerCfg.MaxMessageSize.GetAsInt()
+	case "pulsar":
+		return p.PulsarCfg.MaxMessageSize.GetAsInt()
+	default:
+		return 0
+	}
 }
 
 func (p *ServiceParam) PulsarEnable() bool {
@@ -726,6 +794,11 @@ type WoodpeckerConfig struct {
 	MetaType   ParamItem `refreshable:"false"`
 	MetaPrefix ParamItem `refreshable:"false"`
 
+	// MaxMessageSize is Milvus' target upper bound for one Woodpecker WAL
+	// record. Woodpecker does not enforce a corresponding single-entry hard
+	// limit; the WAL layer uses this value as its chunk threshold (#52474).
+	MaxMessageSize ParamItem `refreshable:"true"`
+
 	// client
 	AppendQueueSize           ParamItem `refreshable:"true"`
 	AppendMaxRetries          ParamItem `refreshable:"true"`
@@ -793,6 +866,18 @@ func (p *WoodpeckerConfig) Init(base *BaseTable) {
 		Export:       true,
 	}
 	p.MetaPrefix.Init(base.mgr)
+
+	p.MaxMessageSize = ParamItem{
+		Key:          "woodpecker.maxMessageSize",
+		Version:      "3.0.2",
+		DefaultValue: strconv.Itoa(10 * 1024 * 1024),
+		Doc: `The target maximum size of each Woodpecker WAL record produced by Milvus. Unit: Byte.
+Woodpecker does not enforce a corresponding single-entry hard limit. Milvus uses this value as the WAL-layer chunk threshold and splits larger payloads into multiple records.
+Values below 256 KiB are clamped to 256 KiB. Invalid or out-of-range values fall back to the default 10 MiB limit.`,
+		Export:    true,
+		Formatter: walMessageSizeFormatter("woodpecker.maxMessageSize", 10*1024*1024),
+	}
+	p.MaxMessageSize.Init(base.mgr)
 
 	p.AppendQueueSize = ParamItem{
 		Key:          "woodpecker.client.segmentAppend.queueSize",
@@ -1144,11 +1229,12 @@ Valid values: [auto, enable, disable]`,
 // /////////////////////////////////////////////////////////////////////////////
 // --- pulsar ---
 type PulsarConfig struct {
-	Address        ParamItem `refreshable:"false"`
-	Port           ParamItem `refreshable:"false"`
-	WebAddress     ParamItem `refreshable:"false"`
-	WebPort        ParamItem `refreshable:"false"`
-	MaxMessageSize ParamItem `refreshable:"true"`
+	Address            ParamItem `refreshable:"false"`
+	Port               ParamItem `refreshable:"false"`
+	WebAddress         ParamItem `refreshable:"false"`
+	WebPort            ParamItem `refreshable:"false"`
+	MaxMessageSize     ParamItem `refreshable:"true"`
+	MessageReserveSize ParamItem `refreshable:"true"`
 
 	// support auth
 	AuthPlugin ParamItem `refreshable:"false"`
@@ -1165,6 +1251,48 @@ type PulsarConfig struct {
 	EnableClientMetrics ParamItem `refreshable:"false"`
 
 	BacklogAutoClearBytes ParamItem `refreshable:"false"`
+}
+
+// GetMessageSizeLimitsFor generalizes the plaintext-body budget to an
+// arbitrary WAL backend's broker limit -- not necessarily Pulsar's own. The
+// reserve amount (streaming message header, properties added before WAL
+// append, cipher metadata/expansion, and broker message metadata) covers the
+// same envelope regardless of which backend produced maxMessageSize, so it is
+// still read from pulsar.messageReserveSize; that config item is not
+// Pulsar-specific in what it represents, only in where it is set.
+func (p *PulsarConfig) GetMessageSizeLimitsFor(maxMessageSize int) (int, int) {
+	return maxMessageSize, normalizePulsarMessageReserve(maxMessageSize, p.MessageReserveSize.GetAsInt())
+}
+
+func normalizePulsarMessageReserve(maxMessageSize, messageReserveSize int) int {
+	if maxMessageSize <= 0 {
+		return 0
+	}
+	if messageReserveSize >= minPulsarMessageReserveSize && messageReserveSize < maxMessageSize {
+		return messageReserveSize
+	}
+	// Bounded WAL configuration is normalized to at least 256 KiB before it
+	// reaches this helper, so the default reserve always fits in production.
+	// Keep the smaller-limit branches defensive for direct callers and
+	// rate-limit the persistent misconfiguration warning globally by call site.
+	//
+	// Prefer the generous default; fall back to the minimum envelope headroom
+	// when a direct caller supplies a smaller limit. Zero is used only when that
+	// limit is too small to reserve anything at all, which disables chunking
+	// rather than emitting records that are guaranteed to be rejected.
+	fallback := 0
+	switch {
+	case defaultPulsarMessageReserveSize < maxMessageSize:
+		fallback = defaultPulsarMessageReserveSize
+	case minPulsarMessageReserveSize < maxMessageSize:
+		fallback = minPulsarMessageReserveSize
+	}
+	mlog.RatedWarn(context.TODO(), rate.Limit(1.0/60.0),
+		"pulsar.messageReserveSize does not fit under the active WAL message size limit, falling back",
+		mlog.Int("configuredReserve", messageReserveSize),
+		mlog.Int("maxMessageSize", maxMessageSize),
+		mlog.Int("effectiveReserve", fallback))
+	return fallback
 }
 
 func (p *PulsarConfig) Init(base *BaseTable) {
@@ -1230,11 +1358,34 @@ Default value applies when Pulsar is running on the same network with Milvus.`,
 		Version:      "2.0.0",
 		DefaultValue: "2097152",
 		Doc: `The maximum size of each message in Pulsar. Unit: Byte.
-By default, Pulsar can transmit at most 2MB of data in a single message. When the size of inserted data is greater than this value, proxy fragments the data into multiple messages to ensure that they can be transmitted correctly.
-If the corresponding parameter in Pulsar remains unchanged, increasing this configuration will cause Milvus to fail, and reducing it produces no advantage.`,
-		Export: true,
+By default, Pulsar can transmit at most 2MB of data in a single message. When streaming.splitChunkSN is enabled, the StreamingNode WAL layer splits larger payloads into multiple records that fit this limit.
+Values below 256 KiB are clamped to 256 KiB. The Pulsar broker/proxy limit must be no smaller than this effective value; otherwise Pulsar can still reject records that Milvus considers valid. Invalid or out-of-range values fall back to the default 2 MiB limit.`,
+		Export:    true,
+		Formatter: walMessageSizeFormatter("pulsar.maxMessageSize", 2*1024*1024),
 	}
 	p.MaxMessageSize.Init(base.mgr)
+
+	p.MessageReserveSize = ParamItem{
+		Key:          "pulsar.messageReserveSize",
+		Version:      "3.0.2",
+		DefaultValue: strconv.Itoa(defaultPulsarMessageReserveSize),
+		Doc: `The headroom reserved out of the active WAL backend's message-size limit (pulsar.maxMessageSize, kafka.producer.message.max.bytes, or woodpecker.maxMessageSize) for message overhead outside the plaintext body. Unit: Byte.
+A produced record carries a streaming message header, properties added before WAL append, cipher metadata/expansion, and broker message metadata on top of the body, so the producer budgets only the active WAL backend's own message-size limit minus this value for the body itself.
+Must be a 32-bit integer of at least 1024 bytes and smaller than the active WAL backend's message-size limit: a smaller reserve cannot absorb one record's envelope, so a full-budget chunk would still be rejected by the backend. Invalid or out-of-range values fall back to the default reserve size.`,
+		Export: true,
+		Formatter: func(value string) string {
+			reserveSize, err := strconv.ParseInt(value, 10, 32)
+			if err != nil || reserveSize < minPulsarMessageReserveSize {
+				mlog.Warn(context.TODO(), "pulsar.messageReserveSize must be a 32-bit integer of at least the minimum envelope headroom, using default",
+					mlog.String("configured", value),
+					mlog.Int("minimum", minPulsarMessageReserveSize),
+					mlog.Int("default", defaultPulsarMessageReserveSize))
+				return strconv.Itoa(defaultPulsarMessageReserveSize)
+			}
+			return value
+		},
+	}
+	p.MessageReserveSize.Init(base.mgr)
 
 	p.Tenant = ParamItem{
 		Key:          "pulsar.tenant",
@@ -1421,9 +1572,10 @@ func (k *KafkaConfig) Init(base *BaseTable) {
 		Key:          KafkaProducerConfigPrefix + "message.max.bytes",
 		DefaultValue: strconv.Itoa(10 * 1024 * 1024),
 		Version:      "3.0.0",
-		Doc:          "Maximum size of a Kafka producer message in bytes. Requires a restart to take effect.",
+		Doc:          "Maximum size of a Kafka producer message in bytes. Values below 256 KiB are clamped to 256 KiB; invalid or out-of-range values fall back to the default 10 MiB. Kafka broker/topic limits must support the configured value. Requires a restart to take effect.",
 		Export:       true,
 		Immutable:    true,
+		Formatter:    walMessageSizeFormatter(KafkaProducerConfigPrefix+"message.max.bytes", 10*1024*1024),
 	}
 	k.ProducerMessageMaxBytes.Init(base.mgr)
 

--- a/pkg/util/paramtable/service_param_test.go
+++ b/pkg/util/paramtable/service_param_test.go
@@ -17,6 +17,7 @@
 package paramtable
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -425,4 +426,122 @@ func TestRuntimConfig(t *testing.T) {
 
 	SetLocalComponentEnabled(typeutil.QueryCoordRole)
 	assert.True(t, IsLocalComponentEnabled(typeutil.QueryCoordRole))
+}
+
+func TestNormalizePulsarMessageReserve(t *testing.T) {
+	const maxMessageSize = 2 * 1024 * 1024
+
+	t.Run("configured reserve is honored", func(t *testing.T) {
+		assert.Equal(t, 128*1024, normalizePulsarMessageReserve(maxMessageSize, 128*1024))
+		assert.Equal(t, minPulsarMessageReserveSize, normalizePulsarMessageReserve(maxMessageSize, minPulsarMessageReserveSize))
+	})
+
+	t.Run("reserve below the envelope minimum falls back", func(t *testing.T) {
+		// A reserve this small cannot absorb one record's envelope, so a
+		// full-budget chunk would still be rejected by the backend and retried
+		// forever. The ParamItem formatter prevents these values in production;
+		// keep the helper defensive for direct callers.
+		for _, reserve := range []int{0, 1, minPulsarMessageReserveSize - 1, -1} {
+			assert.Equal(t, defaultPulsarMessageReserveSize, normalizePulsarMessageReserve(maxMessageSize, reserve),
+				"reserve=%d", reserve)
+		}
+	})
+
+	t.Run("reserve not fitting under the active limit falls back", func(t *testing.T) {
+		// The default no longer fits, but the minimum still does.
+		assert.Equal(t, minPulsarMessageReserveSize, normalizePulsarMessageReserve(32*1024, 32*1024))
+		// These values are below the supported WAL message-size minimum and are
+		// unreachable through normalized configuration. Keep zero as a safe
+		// defensive result for direct callers.
+		assert.Equal(t, 0, normalizePulsarMessageReserve(512, 0))
+		assert.Equal(t, 0, normalizePulsarMessageReserve(0, 1024))
+	})
+
+	t.Run("every effective reserve leaves a usable budget", func(t *testing.T) {
+		for _, maxSize := range []int{512, 1024, 1025, 32 * 1024, 64 * 1024, 10 * 1024 * 1024} {
+			for _, reserve := range []int{0, 1, 1024, 64 * 1024, 1 << 30} {
+				effective := normalizePulsarMessageReserve(maxSize, reserve)
+				if effective == 0 {
+					// Defensive direct-helper outcome. Normalized bounded WAL
+					// configuration cannot supply a limit this small.
+					continue
+				}
+				assert.GreaterOrEqual(t, effective, minPulsarMessageReserveSize,
+					"maxSize=%d reserve=%d", maxSize, reserve)
+				assert.Less(t, effective, maxSize, "maxSize=%d reserve=%d", maxSize, reserve)
+			}
+		}
+	})
+}
+
+func TestWALMessageSizeMinimum(t *testing.T) {
+	bt := NewBaseTable(SkipRemote(true))
+	params := &ServiceParam{}
+	params.init(bt)
+
+	tests := []struct {
+		name        string
+		walName     string
+		item        *ParamItem
+		defaultSize int
+	}{
+		{
+			name:        "pulsar",
+			walName:     "pulsar",
+			item:        &params.PulsarCfg.MaxMessageSize,
+			defaultSize: 2 * 1024 * 1024,
+		},
+		{
+			name:        "kafka",
+			walName:     "kafka",
+			item:        &params.KafkaCfg.ProducerMessageMaxBytes,
+			defaultSize: 10 * 1024 * 1024,
+		},
+		{
+			name:        "woodpecker",
+			walName:     "woodpecker",
+			item:        &params.WoodpeckerCfg.MaxMessageSize,
+			defaultSize: 10 * 1024 * 1024,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for _, tc := range []struct {
+				configured string
+				expected   int
+			}{
+				{configured: "-1", expected: minWALMessageSize},
+				{configured: "0", expected: minWALMessageSize},
+				{configured: strconv.Itoa(minWALMessageSize - 1), expected: minWALMessageSize},
+				{configured: strconv.Itoa(minWALMessageSize), expected: minWALMessageSize},
+				{configured: strconv.Itoa(minWALMessageSize + 1), expected: minWALMessageSize + 1},
+				{configured: "invalid", expected: test.defaultSize},
+				{configured: "2147483648", expected: test.defaultSize},
+			} {
+				assert.NoError(t, bt.Save(test.item.Key, tc.configured))
+				assert.Equal(t, tc.expected, test.item.GetAsInt(), "configured=%s", tc.configured)
+				assert.Equal(t, tc.expected, params.WALMaxMessageSize(test.walName), "configured=%s", tc.configured)
+			}
+			assert.NoError(t, bt.Reset(test.item.Key))
+		})
+	}
+
+	assert.Zero(t, params.WALMaxMessageSize("rocksmq"))
+	assert.Zero(t, params.WALMaxMessageSize("unknown"))
+
+	t.Run("clamped limit and invalid reserve leave a usable budget", func(t *testing.T) {
+		assert.NoError(t, bt.Save(params.PulsarCfg.MessageReserveSize.Key, "0"))
+		t.Cleanup(func() { assert.NoError(t, bt.Reset(params.PulsarCfg.MessageReserveSize.Key)) })
+
+		for _, test := range tests {
+			assert.NoError(t, bt.Save(test.item.Key, "1"))
+			maxMessageSize := params.WALMaxMessageSize(test.walName)
+			_, reserve := params.PulsarCfg.GetMessageSizeLimitsFor(maxMessageSize)
+			assert.Equal(t, minWALMessageSize, maxMessageSize, test.name)
+			assert.Equal(t, defaultPulsarMessageReserveSize, reserve, test.name)
+			assert.Positive(t, maxMessageSize-reserve, test.name)
+			assert.NoError(t, bt.Reset(test.item.Key))
+		}
+	})
 }


### PR DESCRIPTION
## Problem

Every WAL backend enforces a hard cap on one physical record. Proxy row packing budgets entity data but cannot precisely account for the streaming header, properties, encryption expansion, and broker envelope. When the final record crosses the backend cap, the backend rejects it and the existing retry loop can stall the pchannel indefinitely.

Related issue: #52474

## Solution

**Split oversized payloads in the StreamingNode WAL adaptor**, below interceptors and above the backend:

- When `streaming.splitChunkSN=true`, the adaptor slices the final opaque payload against the backend message limit minus an effective reserve. Chunk records clone the logical properties and carry reserved `_ci` / `_ct` markers.
- The durable scanner reassembles physical chunks before v0 conversion, filtering, reordering, transaction handling, flush, or CDC consumption. Malformed metadata returns `ErrCorruptedChunk` and fail-stops the scanner instead of panicking or silently losing acknowledged data.
- The backend message-size limit is normalized to at least 256 KiB. Invalid or undersized `pulsar.messageReserveSize` values fall back to safe positive headroom, so a full-budget chunk cannot recreate the permanent message-too-large retry.
- RocksMQ and other backends without a bounded record size retain the legacy single-record path.

**Keep Proxy and StreamingNode ownership independently switchable:**

- `proxy.splitChunk=true` by default: keep the legacy row-based Proxy packer.
- `streaming.splitChunkSN=false` by default: do not write physical WAL chunks.
- Target state: enable SN chunking first, confirm it on every potential pchannel owner, and only then disable Proxy packing.
- When `proxy.splitChunk=false`, Insert and Upsert use `InsertRequestViewEncoder` to encode selected rows directly into the final protobuf payload without first materializing copied `FieldsData`, `RowIDs`, and `Timestamps` slices. Delete produces one logical message per hashed vchannel.

The safe rollout is `(proxy=true, SN=false) -> (true, true) -> (false, true)`. Rollback reverses the transition: restore Proxy packing everywhere before disabling SN chunk creation. Old binaries cannot read already-persisted chunk records, so downgrade across chunk-bearing WAL history remains an operator constraint.

Segment assignment is treated as a soft sealing target: an indivisible allocation may cross the target once and the segment is then sealed. Independent Proxy resource limits still bound a fully materialized logical write.

Design doc: `docs/design-docs/design_docs/20260822-wal-payload-chunking.md`

## Notable behavior changes

- Oversized WAL records no longer enter the backend message-too-large retry loop when SN chunking is enabled; they are stored as physical chunk records and exposed to consumers as one logical message.
- **`quotaAndLimits.limits.maxInsertSize` now defaults to 64 MiB instead of `-1`**, applies to Insert and Upsert, and is checked after Proxy-side materialization. A larger write is rejected with `ErrParameterTooLarge`. Set it to `-1` to disable the limit.
- **`quotaAndLimits.limits.maxDeleteSize` is new and defaults to 16 MiB.** The check is performed on each materialized per-vchannel delete message. With the default `proxy.splitChunk=true`, legacy WAL-size packing keeps messages below this limit in normal configurations; the limit becomes behaviorally relevant after `proxy.splitChunk=false`, when one logical delete message is built per hashed vchannel. Operators should size it before completing that migration step. Set it to `-1` to disable the limit.
- New rollout configs: `proxy.splitChunk=true` and `streaming.splitChunkSN=false`; both are refreshable.
- New WAL sizing configs/semantics: `woodpecker.maxMessageSize` defaults to 10 MiB, `pulsar.messageReserveSize` defaults to 64 KiB, and bounded WAL message sizes are normalized to at least 256 KiB.
- Produce requests carrying the reserved `_ci` / `_ct` properties are rejected as invalid arguments.
- A reassembled logical message remains one flusher/transaction-buffer unit, so its payload is contiguous in StreamingNode memory.

## Test plan

- [x] Chunk boundary, round-trip, interleaving, corruption, duplicate, and TimeTick cleanup tests
- [x] Durable scanner reassembly before legacy v0 conversion
- [x] SN switch and live-refresh tests, including the legacy single-record path
- [x] Proxy switch tests for Insert, Upsert/partial-update CAS, and Delete
- [x] FastEncoder parity against protobuf materialization across scalar, vector, nullable, nested array, dynamic JSON, and arbitrary row-selection cases
- [x] FastEncoder descriptor digest and explicit `msgpb.InsertRequest` field-number ownership checks
- [x] Insert/Upsert 64 MiB and Delete 16 MiB resource-limit tests
- [x] WAL reserve normalization and 256 KiB minimum tests
- [x] Reserved marker ingress rejection and scanner fail-stop tests
- [x] Focused Go formatting and package tests
- [ ] Full CI build and integration suites