### PR TITLE
enhance: Add OrcaRouter as a text embedding provider

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1638,6 +1638,10 @@ function:
         credential:  # The name in the crendential configuration item
         enable: true # Whether to enable openai model service
         url:  # Your openai embedding url, Default is the official embedding url
+      orcarouter:
+        credential:  # The name in the crendential configuration item
+        enable: true # Whether to enable OrcaRouter model service
+        url:  # Your orcarouter embedding url, Default is the official embedding url
       siliconflow:
         credential:  # The name in the crendential configuration item
         enable: true # Whether to enable siliconflow model service

--- a/internal/util/function/embedding/orcarouter_embedding_provider.go
+++ b/internal/util/function/embedding/orcarouter_embedding_provider.go
@@ -1,0 +1,133 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package embedding
+
+import (
+	"context"
+	"strings"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/credentials"
+	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/internal/util/function/models/openai"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+// OrcaRouter is an OpenAI-compatible AI gateway, so it speaks the same
+// /v1/embeddings protocol as OpenAI. The provider reuses the OpenAI client
+// and only swaps the endpoint and credential source.
+type OrcaRouterEmbeddingProvider struct {
+	fieldDim int64
+
+	client        openai.OpenAIEmbeddingInterface
+	modelName     string
+	embedDimParam int64
+	user          string
+
+	maxBatch  int
+	timeoutMs int64
+	extraInfo *models.ModelExtraInfo
+}
+
+func NewOrcaRouterEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *schemapb.FunctionSchema, params map[string]string, credentials *credentials.Credentials, extraInfo *models.ModelExtraInfo) (*OrcaRouterEmbeddingProvider, error) {
+	fieldDim, err := typeutil.GetDim(fieldSchema)
+	if err != nil {
+		return nil, err
+	}
+
+	apiKey, url, err := models.ParseAKAndURL(credentials, functionSchema.Params, params, models.OrcaRouterAKEnvStr, extraInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	if apiKey == "" {
+		return nil, merr.WrapErrParameterInvalidMsg("missing credentials config or configure the %s environment variable in the Milvus service", models.OrcaRouterAKEnvStr)
+	}
+
+	var modelName, user string
+	var dim int64
+	for _, param := range functionSchema.Params {
+		switch strings.ToLower(param.Key) {
+		case models.ModelNameParamKey:
+			modelName = param.Value
+		case models.DimParamKey:
+			dim, err = models.ParseAndCheckFieldDim(param.Value, fieldDim, fieldSchema.Name)
+			if err != nil {
+				return nil, err
+			}
+		case models.UserParamKey:
+			user = param.Value
+		default:
+		}
+	}
+
+	if url == "" {
+		url = "https://api.orcarouter.ai/v1/embeddings"
+	}
+
+	c := openai.NewOpenAIEmbeddingClient(apiKey, url)
+	timeoutMs := models.ResolveTimeoutMs(functionSchema.Params)
+
+	provider := OrcaRouterEmbeddingProvider{
+		client:        c,
+		fieldDim:      fieldDim,
+		modelName:     modelName,
+		user:          user,
+		embedDimParam: dim,
+		maxBatch:      128,
+		timeoutMs:     timeoutMs,
+		extraInfo:     extraInfo,
+	}
+	return &provider, nil
+}
+
+func (provider *OrcaRouterEmbeddingProvider) MaxBatch() int {
+	return provider.extraInfo.BatchFactor * provider.maxBatch
+}
+
+func (provider *OrcaRouterEmbeddingProvider) FieldDim() int64 {
+	return provider.fieldDim
+}
+
+func (provider *OrcaRouterEmbeddingProvider) CallEmbedding(ctx context.Context, texts []string, _ models.TextEmbeddingMode) (any, error) {
+	numRows := len(texts)
+	data := make([][]float32, 0, numRows)
+	for i := 0; i < numRows; i += provider.maxBatch {
+		end := i + provider.maxBatch
+		if end > numRows {
+			end = numRows
+		}
+		resp, err := provider.client.Embedding(provider.modelName, texts[i:end], int(provider.embedDimParam), provider.user, provider.timeoutMs)
+		if err != nil {
+			return nil, err
+		}
+		if end-i != len(resp.Data) {
+			return nil, merr.WrapErrFunctionFailedMsg("get embedding failed, the number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(resp.Data))
+		}
+		for _, item := range resp.Data {
+			if len(item.Embedding) != int(provider.fieldDim) {
+				return nil, merr.WrapErrFunctionFailedMsg("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
+					provider.fieldDim, len(item.Embedding))
+			}
+			data = append(data, item.Embedding)
+		}
+	}
+	return data, nil
+}

--- a/internal/util/function/embedding/orcarouter_embedding_provider_test.go
+++ b/internal/util/function/embedding/orcarouter_embedding_provider_test.go
@@ -1,0 +1,109 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package embedding
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/credentials"
+	"github.com/milvus-io/milvus/internal/util/function/models"
+)
+
+func TestOrcaRouterTextEmbeddingProvider(t *testing.T) {
+	suite.Run(t, new(OrcaRouterTextEmbeddingProviderSuite))
+}
+
+type OrcaRouterTextEmbeddingProviderSuite struct {
+	suite.Suite
+	schema *schemapb.CollectionSchema
+}
+
+func (s *OrcaRouterTextEmbeddingProviderSuite) SetupTest() {
+	s.schema = &schemapb.CollectionSchema{
+		Name: "test",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "int64", DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			{
+				FieldID: 102, Name: "vector", DataType: schemapb.DataType_FloatVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "dim", Value: "4"},
+				},
+			},
+		},
+	}
+}
+
+func (s *OrcaRouterTextEmbeddingProviderSuite) TestEmbedding() {
+	ts := CreateOpenAIEmbeddingServer()
+	defer ts.Close()
+
+	provider, err := NewOrcaRouterEmbeddingProvider(s.schema.Fields[2], &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_TextEmbedding,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: models.ModelNameParamKey, Value: "text-embedding-3-small"},
+			{Key: models.DimParamKey, Value: "4"},
+			{Key: models.CredentialParamKey, Value: "mock"},
+		},
+	}, map[string]string{models.URLParamKey: ts.URL}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db"})
+	s.NoError(err)
+
+	{
+		data := []string{"sentence"}
+		r, err := provider.CallEmbedding(context.Background(), data, models.InsertMode)
+		s.NoError(err)
+		ret := r.([][]float32)
+		s.Equal(1, len(ret))
+		s.Equal(4, len(ret[0]))
+		s.Equal([]float32{0.0, 1.0, 2.0, 3.0}, ret[0])
+	}
+	{
+		data := []string{"sentence 1", "sentence 2", "sentence 3"}
+		r, err := provider.CallEmbedding(context.Background(), data, models.SearchMode)
+		s.NoError(err)
+		ret := r.([][]float32)
+		s.Equal([][]float32{{0.0, 1.0, 2.0, 3.0}, {1.0, 2.0, 3.0, 4.0}, {2.0, 3.0, 4.0, 5.0}}, ret)
+	}
+}
+
+func (s *OrcaRouterTextEmbeddingProviderSuite) TestMissingCredential() {
+	_, err := NewOrcaRouterEmbeddingProvider(s.schema.Fields[2], &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_TextEmbedding,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: models.ModelNameParamKey, Value: "text-embedding-3-small"},
+			{Key: models.DimParamKey, Value: "4"},
+		},
+	}, map[string]string{}, credentials.NewCredentials(map[string]string{}), &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db"})
+	s.ErrorContains(err, "missing credentials config or configure the MILVUS_ORCAROUTER_API_KEY")
+}

--- a/internal/util/function/embedding/text_embedding_function.go
+++ b/internal/util/function/embedding/text_embedding_function.go
@@ -50,6 +50,7 @@ const (
 	zillizProvider       string = "zilliz"
 	geminiProvider       string = "gemini"
 	huggingFaceProvider  string = "huggingface"
+	orcaRouterProvider   string = "orcarouter"
 )
 
 func hasEmptyString(texts []string) bool {
@@ -146,8 +147,10 @@ func NewTextEmbeddingFunction(coll *schemapb.CollectionSchema, functionSchema *s
 		embP, newProviderErr = NewGeminiEmbeddingProvider(base.outputFields[0], functionSchema, conf, credentials, extraInfo)
 	case huggingFaceProvider:
 		embP, newProviderErr = NewHuggingFaceEmbeddingProvider(base.outputFields[0], functionSchema, conf, credentials, extraInfo)
+	case orcaRouterProvider:
+		embP, newProviderErr = NewOrcaRouterEmbeddingProvider(base.outputFields[0], functionSchema, conf, credentials, extraInfo)
 	default:
-		return nil, merr.WrapErrParameterInvalidMsg("unsupported text embedding service provider: [%s] , list of supported [%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s]", base.provider, openAIProvider, azureOpenAIProvider, aliDashScopeProvider, bedrockProvider, vertexAIProvider, voyageAIProvider, cohereProvider, siliconflowProvider, teiProvider, ycProvider, zillizProvider, geminiProvider, huggingFaceProvider)
+		return nil, merr.WrapErrParameterInvalidMsg("unsupported text embedding service provider: [%s] , list of supported [%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s]", base.provider, openAIProvider, azureOpenAIProvider, aliDashScopeProvider, bedrockProvider, vertexAIProvider, voyageAIProvider, cohereProvider, siliconflowProvider, teiProvider, ycProvider, zillizProvider, geminiProvider, huggingFaceProvider, orcaRouterProvider)
 	}
 
 	if newProviderErr != nil {

--- a/internal/util/function/embedding/text_embedding_function_test.go
+++ b/internal/util/function/embedding/text_embedding_function_test.go
@@ -579,6 +579,28 @@ func (s *TextEmbeddingFunctionSuite) TestNewTextEmbeddings() {
 			InputFieldIds:    []int64{101},
 			OutputFieldIds:   []int64{102},
 			Params: []*commonpb.KeyValuePair{
+				{Key: Provider, Value: orcaRouterProvider},
+				{Key: models.ModelNameParamKey, Value: TestModel},
+				{Key: models.CredentialParamKey, Value: "mock"},
+			},
+		}
+
+		_, err := NewTextEmbeddingFunction(s.schema, fSchema, &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db"})
+		s.NoError(err)
+		fSchema.Params = []*commonpb.KeyValuePair{}
+		_, err = NewTextEmbeddingFunction(s.schema, fSchema, &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db"})
+		s.Error(err)
+	}
+
+	{
+		fSchema := &schemapb.FunctionSchema{
+			Name:             "test",
+			Type:             schemapb.FunctionType_TextEmbedding,
+			InputFieldNames:  []string{"text"},
+			OutputFieldNames: []string{"vector"},
+			InputFieldIds:    []int64{101},
+			OutputFieldIds:   []int64{102},
+			Params: []*commonpb.KeyValuePair{
 				{Key: Provider, Value: "tei"},
 				{Key: "endpoint", Value: "http://mock.com"},
 			},

--- a/internal/util/function/models/common.go
+++ b/internal/util/function/models/common.go
@@ -128,6 +128,12 @@ const (
 	SiliconflowAKEnvStr string = "MILVUS_SILICONFLOW_API_KEY"
 )
 
+// orcarouter
+
+const (
+	OrcaRouterAKEnvStr string = "MILVUS_ORCAROUTER_API_KEY"
+)
+
 // Yandex Cloud
 
 const (

--- a/pkg/util/paramtable/function_param.go
+++ b/pkg/util/paramtable/function_param.go
@@ -125,6 +125,12 @@ func (p *functionConfig) init(base *BaseTable) {
 				return "Your Hugging Face Inference Providers router URL, default is https://router.huggingface.co"
 			case "huggingface.enable":
 				return "Whether to enable Hugging Face text embedding service"
+			case "orcarouter.credential":
+				return "The name in the credential configuration item"
+			case "orcarouter.url":
+				return "Your OrcaRouter embedding url, Default is the official embedding url"
+			case "orcarouter.enable":
+				return "Whether to enable OrcaRouter model service"
 			default:
 				return ""
 			}

--- a/pkg/util/paramtable/function_param_test.go
+++ b/pkg/util/paramtable/function_param_test.go
@@ -66,6 +66,9 @@ func TestFunctionConfig(t *testing.T) {
 		"huggingface.credential",
 		"huggingface.url",
 		"huggingface.enable",
+		"orcarouter.credential",
+		"orcarouter.url",
+		"orcarouter.enable",
 	}
 	for _, key := range keys {
 		assert.True(t, cfg.TextEmbeddingProviders.GetDoc(key) != "")


### PR DESCRIPTION
Add `orcarouter` as a first-class text embedding provider for Milvus' high-performance vector database. [OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents; like OpenRouter, it exposes a provider/model namespace across many models, but also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a named provider means Milvus users can use that stack directly, instead of treating it as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint, screening every prompt/response and governing every tool call on a default-deny basis with no application code changes. The provider reuses Milvus' existing OpenAI-compatible client (`models.PostRequest`), mirroring how `siliconflow` wires in, and only swaps the endpoint and credential source (`MILVUS_ORCAROUTER_API_KEY`).

Verification:
- Provider registered in `text_embedding_function.go`, paramtable docs, `configs/milvus.yaml`; focused unit test added.
- Live-tested against the real endpoint (HTTP 200, `orcarouter/auto` → `gemini-embedding-001`, dim 3072).

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter · I'm an engineer on the OrcaRouter team.
