### PR TITLE
fix: present declared defaults for absent fields in the StorageV2/V3 record reader

### DIFF
--- a/internal/datanode/compactor/bump_schema_version_compactor_test.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor_test.go
@@ -1477,3 +1477,34 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionInputSchemaByF
 	s.ErrorContains(err, "references by_field lang of type")
 	s.ErrorContains(err, "only VarChar is allowed")
 }
+
+// TestNewCompactionSegmentRecordReaderWithFieldsThreadsPresentFields pins that on
+// the manifest path the compactor hands its already-computed existingFields to the
+// reader via WithPresentFields, so the reader does not re-open the manifest with a
+// second GetManifestFieldIDs (the P5 perf fix).
+func TestNewCompactionSegmentRecordReaderWithFieldsThreadsPresentFields(t *testing.T) {
+	seg := &datapb.CompactionSegmentBinlogs{Manifest: "manifest-json"}
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64},
+	}}
+	existing := map[int64]struct{}{100: {}}
+
+	mockEnc := mockey.Mock(hookutil.IsClusterEncryptionEnabled).Return(false).Build()
+	defer mockEnc.UnPatch()
+	mockFieldIDs := mockey.Mock(packed.GetManifestFieldIDs).To(
+		func(string, *indexpb.StorageConfig) (map[int64]struct{}, error) {
+			t.Fatal("reader must not re-derive present fields; the compactor already passed existingFields")
+			return nil, nil
+		}).Build()
+	defer mockFieldIDs.UnPatch()
+	mockReader := mockey.Mock(storage.NewRecordReaderFromManifest).Return(nil, nil).Build()
+	defer mockReader.UnPatch()
+
+	_, got, err := newCompactionSegmentRecordReaderWithFields(context.Background(), seg, schema,
+		&indexpb.StorageConfig{RootPath: "root"}, existing,
+		storage.WithVersion(storage.StorageV3),
+		storage.WithStorageConfig(&indexpb.StorageConfig{RootPath: "root"}),
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, existing, got)
+}

--- a/internal/datanode/compactor/compactor_common.go
+++ b/internal/datanode/compactor/compactor_common.go
@@ -304,7 +304,11 @@ func newCompactionSegmentRecordReaderWithFields(ctx context.Context, segment *da
 	readSchema := compactionReadSchema(schema, existingFields)
 
 	if segment.GetManifest() != "" {
-		reader, err := storage.NewManifestRecordReader(ctx, segment.GetManifest(), readSchema, opts...)
+		// existingFields is already the manifest's physically-present field set
+		// (compactionSegmentStorageFields called GetManifestFieldIDs on the same
+		// manifest); hand it over so the reader does not re-open the manifest.
+		reader, err := storage.NewManifestRecordReader(ctx, segment.GetManifest(), readSchema,
+			append(opts, storage.WithPresentFields(existingFields))...)
 		return reader, existingFields, err
 	}
 

--- a/internal/storage/record_reader.go
+++ b/internal/storage/record_reader.go
@@ -490,3 +490,107 @@ func (crr *CompositeBinlogRecordReader) releaseCurrent() {
 		crr.current = nil
 	}
 }
+
+// NewAbsentFieldFillRecordReader completes a partial record to full read-schema
+// width the way V1's CompositeBinlogRecordReader does: every read-schema field NOT
+// physically present (FieldID not in presentFields) is filled via
+// GenerateEmptyArrayFromSchema -- its declared default when it has one, else null,
+// erroring on a non-nullable absent field. Present columns pass through from inner.
+// This gives the packed StorageV3 manifest reader the same default-for-absent
+// semantic the V1 binlog reader already applies, so it stops presenting declared
+// defaults as NULL (issue #52771). presentFields is the physically-present field
+// set -- self-sourced from the manifest, or supplied by a caller that already
+// computed it (compaction via WithPresentFields). Returns inner unchanged when
+// nothing is absent.
+func NewAbsentFieldFillRecordReader(inner RecordReader, neededSchema *schemapb.CollectionSchema, presentFields map[FieldID]struct{}) RecordReader {
+	fill := make([]*schemapb.FieldSchema, 0)
+	for _, f := range typeutil.GetAllFieldSchemas(neededSchema) {
+		if _, present := presentFields[f.GetFieldID()]; present {
+			continue
+		}
+		fill = append(fill, f)
+	}
+	if len(fill) == 0 {
+		return inner
+	}
+	return &absentFieldFillRecordReader{inner: inner, fill: fill}
+}
+
+type absentFieldFillRecordReader struct {
+	inner RecordReader
+	fill  []*schemapb.FieldSchema
+	cur   *absentFilledRecord
+}
+
+var _ RecordReader = (*absentFieldFillRecordReader)(nil)
+
+func (r *absentFieldFillRecordReader) Next() (Record, error) {
+	r.releaseCur()
+	base, err := r.inner.Next()
+	if err != nil {
+		return nil, err
+	}
+	computed := make(map[FieldID]arrow.Array, len(r.fill))
+	for _, f := range r.fill {
+		arr, genErr := GenerateEmptyArrayFromSchema(f, base.Len())
+		if genErr != nil {
+			for _, a := range computed {
+				a.Release()
+			}
+			return nil, genErr
+		}
+		computed[f.GetFieldID()] = arr
+	}
+	base.Retain()
+	r.cur = &absentFilledRecord{base: base, computed: computed}
+	return r.cur, nil
+}
+
+func (r *absentFieldFillRecordReader) releaseCur() {
+	if r.cur == nil {
+		return
+	}
+	r.cur.Release()
+	r.cur = nil
+}
+
+func (r *absentFieldFillRecordReader) Close() error {
+	r.releaseCur()
+	if r.inner == nil {
+		return nil
+	}
+	return r.inner.Close()
+}
+
+// absentFilledRecord overlays filled columns onto base (the present columns). It
+// owns a retained ref on base plus the filled arrays; Release drops both, so the
+// wrapping reader frees them by releasing this record on its next Next/Close.
+type absentFilledRecord struct {
+	base     Record
+	computed map[FieldID]arrow.Array
+}
+
+var _ Record = (*absentFilledRecord)(nil)
+
+func (r *absentFilledRecord) Column(i FieldID) arrow.Array {
+	if col, ok := r.computed[i]; ok {
+		return col
+	}
+	return r.base.Column(i)
+}
+
+func (r *absentFilledRecord) Len() int { return r.base.Len() }
+
+func (r *absentFilledRecord) Retain() {
+	r.base.Retain()
+	for _, col := range r.computed {
+		col.Retain()
+	}
+}
+
+func (r *absentFilledRecord) Release() {
+	r.base.Release()
+	for _, col := range r.computed {
+		col.Release()
+	}
+}

--- a/internal/storage/record_reader_test.go
+++ b/internal/storage/record_reader_test.go
@@ -141,3 +141,218 @@ func TestCompositeBinlogRecordReaderOwnsCurrentRecord(t *testing.T) {
 		allocator.AssertSize(t, 0)
 	})
 }
+
+func TestAbsentFieldFillReaderFillsDefaultAndNull(t *testing.T) {
+	// inner returns ONLY the present field (id); the two added fields are absent.
+	const idField, defField, nullField = FieldID(100), FieldID(101), FieldID(102)
+	idb := array.NewInt64Builder(memory.DefaultAllocator)
+	defer idb.Release()
+	idb.AppendValues([]int64{1, 2, 3}, nil)
+	idArr := idb.NewArray()
+	defer idArr.Release()
+	inner := &compositeRecord{index: map[FieldID]int16{idField: 0}, recs: []arrow.Array{idArr}}
+
+	readSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: idField, Name: "id", DataType: schemapb.DataType_Int64},
+		{FieldID: defField, Name: "added_def", DataType: schemapb.DataType_Int64, Nullable: true, DefaultValue: &schemapb.ValueField{Data: &schemapb.ValueField_LongData{LongData: 42}}},
+		{FieldID: nullField, Name: "added_nulldef", DataType: schemapb.DataType_Int64, Nullable: true},
+	}}
+	present := map[FieldID]struct{}{idField: {}}
+
+	rr := NewAbsentFieldFillRecordReader(&sliceRecordReader{recs: []Record{inner}}, readSchema, present)
+	defer rr.Close()
+	rec, err := rr.Next()
+	require.NoError(t, err)
+
+	def := rec.Column(defField).(*array.Int64)
+	require.Equal(t, 0, def.NullN())
+	require.Equal(t, []int64{42, 42, 42}, []int64{def.Value(0), def.Value(1), def.Value(2)}) // default materialized
+	require.Equal(t, 3, rec.Column(nullField).(*array.Int64).NullN())                        // no default -> null
+	require.Equal(t, int64(2), rec.Column(idField).(*array.Int64).Value(1))                  // present passthrough
+}
+
+func TestAbsentFieldFillReaderRejectsNonNullableAbsent(t *testing.T) {
+	const idField, badField = FieldID(100), FieldID(101)
+	idb := array.NewInt64Builder(memory.DefaultAllocator)
+	defer idb.Release()
+	idb.AppendValues([]int64{1}, nil)
+	idArr := idb.NewArray()
+	defer idArr.Release()
+	inner := &compositeRecord{index: map[FieldID]int16{idField: 0}, recs: []arrow.Array{idArr}}
+	readSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: idField, Name: "id", DataType: schemapb.DataType_Int64},
+		{FieldID: badField, Name: "bad", DataType: schemapb.DataType_Int64, Nullable: false}, // non-nullable, absent
+	}}
+	rr := NewAbsentFieldFillRecordReader(&sliceRecordReader{recs: []Record{inner}}, readSchema, map[FieldID]struct{}{idField: {}})
+	defer rr.Close()
+	_, err := rr.Next()
+	require.Error(t, err)
+}
+
+// countedRecord wraps a Record and tracks its net Retain/Release balance so a test
+// can assert the wrapper neither over-releases (missing Retain -> live < 0) nor
+// leaks (stray Retain -> live > 0) a borrowed base. It still forwards to the
+// embedded Record, so arrow's own buffer refcount stays consistent. This is needed
+// because CheckedAllocator only sees NET bytes: a mis-timed / negative-refcount
+// release is byte-balanced (the buffer is still freed exactly once) and slips past
+// AssertSize.
+type countedRecord struct {
+	Record
+	live int
+}
+
+func (r *countedRecord) Retain() {
+	r.live++
+	r.Record.Retain()
+}
+
+func (r *countedRecord) Release() {
+	r.live--
+	r.Record.Release()
+}
+
+// borrowingRecordReader models the real borrowed-record contract: it owns the
+// records handed to it and releases the previously returned one on the next
+// Next()/Close(), the way a packed/binlog reader frees or reuses its buffer when
+// advanced. A wrapper that keeps a returned record past an advance must therefore
+// Retain it; otherwise the inner release below drops it under the wrapper.
+type borrowingRecordReader struct {
+	recs []Record
+	pos  int
+	held Record
+}
+
+func (r *borrowingRecordReader) Next() (Record, error) {
+	if r.held != nil {
+		r.held.Release()
+		r.held = nil
+	}
+	if r.pos >= len(r.recs) {
+		return nil, io.EOF
+	}
+	r.held = r.recs[r.pos]
+	r.pos++
+	return r.held, nil
+}
+
+func (r *borrowingRecordReader) Close() error {
+	if r.held != nil {
+		r.held.Release()
+		r.held = nil
+	}
+	return nil
+}
+
+// TestAbsentFieldFillReaderBaseRefcountBalanced drives the wrapper across TWO
+// borrowed base records + EOF + Close with a CheckedAllocator behind base and an
+// inner that releases each base when advanced (the borrowed contract). The wrapper
+// must Retain base when it stores it and Release it on the next advance/Close;
+// without that, the inner's release drops base under the wrapper (double free).
+func TestAbsentFieldFillReaderBaseRefcountBalanced(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	newBase := func(vals []int64) *countedRecord {
+		b := array.NewInt64Builder(alloc)
+		b.AppendValues(vals, nil)
+		arr := b.NewArray()
+		b.Release()
+		return &countedRecord{Record: &compositeRecord{index: map[FieldID]int16{100: 0}, recs: []arrow.Array{arr}}, live: 1}
+	}
+	// the inner owns both bases and releases them as it is advanced/closed.
+	base1, base2 := newBase([]int64{1, 2}), newBase([]int64{3, 4, 5})
+	inner := &borrowingRecordReader{recs: []Record{base1, base2}}
+
+	readSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64},
+		{FieldID: 101, Name: "added", DataType: schemapb.DataType_Int64, Nullable: true},
+	}}
+	rr := NewAbsentFieldFillRecordReader(inner, readSchema, map[FieldID]struct{}{100: {}})
+
+	_, err := rr.Next()
+	require.NoError(t, err)
+	_, err = rr.Next() // wrapper releases its ref on base1, inner releases its own
+	require.NoError(t, err)
+	_, err = rr.Next() // EOF; same for base2
+	require.ErrorIs(t, err, io.EOF)
+	require.NoError(t, rr.Close())
+
+	require.Zero(t, base1.live, "base1 wrapper Retain/Release must balance (negative = missing Retain)")
+	require.Zero(t, base2.live, "base2 wrapper Retain/Release must balance (negative = missing Retain)")
+	alloc.AssertSize(t, 0)
+}
+
+// TestAbsentFieldFillReaderErrorPathDoesNotRetainBase pins that base.Retain runs
+// only AFTER the fill loop succeeds: when a later absent field fails to generate,
+// Next returns the error without retaining base, so the inner's own release on
+// Close frees base exactly once — a base retained on the error path would leak.
+func TestAbsentFieldFillReaderErrorPathDoesNotRetainBase(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	b := array.NewInt64Builder(alloc)
+	b.AppendValues([]int64{1}, nil)
+	arr := b.NewArray()
+	b.Release()
+	base := &countedRecord{Record: &compositeRecord{index: map[FieldID]int16{100: 0}, recs: []arrow.Array{arr}}, live: 1}
+	inner := &borrowingRecordReader{recs: []Record{base}}
+
+	// GetAllFieldSchemas preserves Fields order: 101 (nullable, fills) then 102
+	// (non-nullable, GenerateEmptyArrayFromSchema errors) — the failure is mid-loop.
+	readSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64},
+		{FieldID: 101, Name: "ok", DataType: schemapb.DataType_Int64, Nullable: true},
+		{FieldID: 102, Name: "bad", DataType: schemapb.DataType_Int64, Nullable: false},
+	}}
+	rr := NewAbsentFieldFillRecordReader(inner, readSchema, map[FieldID]struct{}{100: {}})
+	_, err := rr.Next()
+	require.Error(t, err)
+	require.NoError(t, rr.Close())
+
+	require.Zero(t, base.live, "error path must not retain base (positive = leaked Retain)")
+	alloc.AssertSize(t, 0)
+}
+
+// TestAbsentFieldFillReaderFillsStructChildren pins that struct array fields are
+// covered: their first-level child columns are flattened by GetAllFieldSchemas, so
+// an absent whole struct has each child filled (null here, no default) rather than
+// left missing.
+func TestAbsentFieldFillReaderFillsStructChildren(t *testing.T) {
+	idb := array.NewInt64Builder(memory.DefaultAllocator)
+	defer idb.Release()
+	idb.AppendValues([]int64{1, 2}, nil)
+	idArr := idb.NewArray()
+	defer idArr.Release()
+	base := &compositeRecord{index: map[FieldID]int16{100: 0}, recs: []arrow.Array{idArr}}
+
+	readSchema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64}},
+		StructArrayFields: []*schemapb.StructArrayFieldSchema{
+			{FieldID: 200, Name: "st", Fields: []*schemapb.FieldSchema{
+				{FieldID: 201, Name: "st[a]", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Int64, Nullable: true},
+				{FieldID: 202, Name: "st[b]", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_VarChar, Nullable: true},
+			}},
+		},
+	}
+	// present = only the top-level id; the whole struct (children 201,202) is absent.
+	rr := NewAbsentFieldFillRecordReader(&sliceRecordReader{recs: []Record{base}}, readSchema, map[FieldID]struct{}{100: {}})
+	defer rr.Close()
+	rec, err := rr.Next()
+	require.NoError(t, err)
+
+	require.Equal(t, 2, rec.Column(201).Len())
+	require.Equal(t, 2, rec.Column(201).NullN())
+	require.Equal(t, 2, rec.Column(202).Len())
+	require.Equal(t, 2, rec.Column(202).NullN())
+	require.Equal(t, int64(2), rec.Column(100).(*array.Int64).Value(1)) // present passthrough
+}
+
+// TestAbsentFieldFillReaderReturnsInnerWhenAllPresent pins the short-circuit: when
+// every read-schema field is present there is nothing to fill, so inner is returned
+// unwrapped (no per-record overlay allocation).
+func TestAbsentFieldFillReaderReturnsInnerWhenAllPresent(t *testing.T) {
+	inner := &sliceRecordReader{recs: []Record{&compositeRecord{index: map[FieldID]int16{100: 0}}}}
+	readSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64},
+	}}
+	rr := NewAbsentFieldFillRecordReader(inner, readSchema, map[FieldID]struct{}{100: {}})
+	_, wrapped := rr.(*absentFieldFillRecordReader)
+	require.False(t, wrapped, "nothing absent -> inner must be returned unwrapped")
+	require.Same(t, inner, rr)
+}

--- a/internal/storage/rw.go
+++ b/internal/storage/rw.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 
 	"github.com/samber/lo"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
@@ -77,6 +78,7 @@ type rwOptions struct {
 	textRefsAsBinary    bool                      // TEXT columns already contain encoded LOB refs and should be copied as-is
 	externalReader      packed.ExternalReaderContext
 	writerFormat        string
+	presentFields       map[FieldID]struct{} // reader: caller-known physically-present field IDs, skips a manifest re-read
 }
 
 func (o *rwOptions) validate() error {
@@ -182,6 +184,15 @@ func WithNeededFields(neededFields typeutil.Set[int64]) RwOption {
 func WithExternalReaderContext(externalReader packed.ExternalReaderContext) RwOption {
 	return func(options *rwOptions) {
 		options.externalReader = externalReader
+	}
+}
+
+// WithPresentFields lets a caller that already knows a segment's physically-present
+// field IDs hand them to NewManifestRecordReader, so it skips re-deriving them via
+// packed.GetManifestFieldIDs (a redundant manifest open on the compaction path).
+func WithPresentFields(present map[FieldID]struct{}) RwOption {
+	return func(options *rwOptions) {
+		options.presentFields = present
 	}
 }
 
@@ -349,8 +360,24 @@ func NewBinlogRecordReader(ctx context.Context, binlogs []*datapb.FieldBinlog, s
 				paths[j] = append(paths[j], logPath)
 			}
 		}
-		// FIXME: add needed fields support
-		rr = newIterativePackedRecordReader(paths, schema, rwOptions.bufferSize, rwOptions.storageConfig, pluginContext, rwOptions.externalReader)
+		// StorageV2/V3 binlog: present declared defaults for absent fields like V1,
+		// sourcing physical presence from FieldBinlog.ChildFields (set by the
+		// flush/compaction writers, reliable for those segments). Import-reconstructed
+		// binlogs carry no ChildFields (FieldID is a column-group ID), so presence is
+		// not derivable there; pass the full schema through unchanged (the engine
+		// null-fills absent columns). Default-fill for the import path is a documented
+		// follow-up (issue #52771).
+		present, reliable := binlogFieldIDSet(binlogs)
+		if reliable {
+			readSchema, ferr := filterSchemaToPresentFields(schema, present)
+			if ferr != nil {
+				return nil, ferr
+			}
+			rr = newIterativePackedRecordReader(paths, readSchema, rwOptions.bufferSize, rwOptions.storageConfig, pluginContext, rwOptions.externalReader)
+			rr = NewAbsentFieldFillRecordReader(rr, schema, present)
+		} else {
+			rr = newIterativePackedRecordReader(paths, schema, rwOptions.bufferSize, rwOptions.storageConfig, pluginContext, rwOptions.externalReader)
+		}
 	default:
 		return nil, merr.WrapErrServiceInternalMsg("unsupported storage version %d", rwOptions.version)
 	}
@@ -360,7 +387,7 @@ func NewBinlogRecordReader(ctx context.Context, binlogs []*datapb.FieldBinlog, s
 	return rr, nil
 }
 
-func NewManifestRecordReader(ctx context.Context, manifestPath string, schema *schemapb.CollectionSchema, option ...RwOption) (rr RecordReader, err error) {
+func NewManifestRecordReader(ctx context.Context, manifestPath string, neededSchema *schemapb.CollectionSchema, option ...RwOption) (rr RecordReader, err error) {
 	rwOptions := DefaultReaderOptions()
 	for _, opt := range option {
 		opt(rwOptions)
@@ -375,7 +402,7 @@ func NewManifestRecordReader(ctx context.Context, manifestPath string, schema *s
 		if rwOptions.pluginContext != nil {
 			pluginContext = rwOptions.pluginContext
 		} else {
-			ez := hookutil.GetEzByCollProperties(schema.GetProperties(), rwOptions.collectionID)
+			ez := hookutil.GetEzByCollProperties(neededSchema.GetProperties(), rwOptions.collectionID)
 			if ez != nil {
 				unsafe := hookutil.GetCipher().GetUnsafeKey(ez.EzID, ez.CollectionID)
 				if len(unsafe) > 0 {
@@ -388,8 +415,91 @@ func NewManifestRecordReader(ctx context.Context, manifestPath string, schema *s
 			}
 		}
 	}
-	return NewRecordReaderFromManifest(manifestPath, schema, rwOptions.bufferSize,
-		rwOptions.storageConfig, pluginContext, option...)
+	// External-source reads (e.g. parquet) are not milvus manifests carrying
+	// default-aware internal field IDs and are out of scope for #52771; keep the
+	// original pass-through. An internal manifest reads only its physically-present
+	// columns, then fills every absent read-schema field with its schema default
+	// (or null) so declared defaults are not presented as NULL, matching V1.
+	if rwOptions.externalReader.Source != "" {
+		return NewRecordReaderFromManifest(manifestPath, neededSchema, rwOptions.bufferSize,
+			rwOptions.storageConfig, pluginContext, option...)
+	}
+	present := rwOptions.presentFields
+	if present == nil {
+		present, err = packed.GetManifestFieldIDs(manifestPath, rwOptions.storageConfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+	presentSchema, err := filterSchemaToPresentFields(neededSchema, present)
+	if err != nil {
+		return nil, err
+	}
+	inner, err := NewRecordReaderFromManifest(manifestPath, presentSchema,
+		rwOptions.bufferSize, rwOptions.storageConfig, pluginContext, option...)
+	if err != nil {
+		return nil, err
+	}
+	return NewAbsentFieldFillRecordReader(inner, neededSchema, present), nil
+}
+
+// filterSchemaToPresentFields returns a copy of schema keeping only the fields
+// (and struct sub-fields) whose FieldID is physically present, so the packed
+// reader is asked to read only stored columns; absent fields are then filled by
+// NewAbsentFieldFillRecordReader rather than null-synthesized by the engine.
+// A struct array field is physically all-or-nothing (add/drop/update act on the
+// whole struct), so it is kept whole or dropped whole; a partially-present struct
+// is a data-integrity violation that must never occur and is surfaced as an error.
+func filterSchemaToPresentFields(schema *schemapb.CollectionSchema, present map[FieldID]struct{}) (*schemapb.CollectionSchema, error) {
+	out := proto.Clone(schema).(*schemapb.CollectionSchema)
+	fields := out.Fields[:0]
+	for _, f := range out.Fields {
+		if _, ok := present[f.GetFieldID()]; ok {
+			fields = append(fields, f)
+		}
+	}
+	out.Fields = fields
+	structs := out.StructArrayFields[:0]
+	for _, st := range out.StructArrayFields {
+		presentChildren := 0
+		for _, f := range st.GetFields() {
+			if _, ok := present[f.GetFieldID()]; ok {
+				presentChildren++
+			}
+		}
+		switch presentChildren {
+		case 0:
+			// whole struct absent: drop it here, the wrapper fills its children.
+		case len(st.GetFields()):
+			structs = append(structs, st)
+		default:
+			return nil, merr.WrapErrServiceInternalMsg(
+				"struct array field %q partially present (%d of %d children): a struct array is physically all-or-nothing",
+				st.GetName(), presentChildren, len(st.GetFields()))
+		}
+	}
+	out.StructArrayFields = structs
+	return out, nil
+}
+
+// binlogFieldIDSet returns the physically-present field IDs of a StorageV2/V3
+// binlog segment, taken from each FieldBinlog's ChildFields (the column group's
+// member field IDs, written by the flush/compaction writers). Presence is reliable
+// ONLY when every FieldBinlog carries ChildFields; import-reconstructed binlogs key
+// FieldID by column-group ID and set no ChildFields, so presence is not derivable —
+// the second return value is then false and the caller must read unfiltered.
+func binlogFieldIDSet(binlogs []*datapb.FieldBinlog) (map[FieldID]struct{}, bool) {
+	present := make(map[FieldID]struct{}, len(binlogs))
+	for _, fb := range binlogs {
+		children := fb.GetChildFields()
+		if len(children) == 0 {
+			return nil, false
+		}
+		for _, child := range children {
+			present[child] = struct{}{}
+		}
+	}
+	return present, true
 }
 
 func NewBinlogRecordWriter(ctx context.Context, collectionID, partitionID, segmentID UniqueID,

--- a/internal/storage/rw_test.go
+++ b/internal/storage/rw_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -202,6 +203,198 @@ func (s *PackedBinlogRecordSuite) TestPackedBinlogRecordIntegration() {
 	s.Equal(err, io.EOF)
 	err = r.Close()
 	s.NoError(err)
+}
+
+// TestManifestReadFillsAbsentDefaultField is the StorageV3/manifest analog: an
+// internal manifest read must present the default of a field that has no column
+// in the manifest, not NULL (#52771).
+func (s *PackedBinlogRecordSuite) TestManifestReadFillsAbsentDefaultField() {
+	dir := s.T().TempDir()
+	paramtable.Get().Save(paramtable.Get().CommonCfg.StorageType.Key, "local")
+	paramtable.Get().Save(paramtable.Get().LocalStorageCfg.Path.Key, dir)
+	defer func() {
+		paramtable.Get().Reset(paramtable.Get().CommonCfg.StorageType.Key)
+		paramtable.Get().Reset(paramtable.Get().LocalStorageCfg.Path.Key)
+	}()
+	storageConfig := &indexpb.StorageConfig{RootPath: dir, StorageType: "local"}
+	columnGroups := []storagecommon.ColumnGroup{
+		{GroupID: 0, Columns: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, Fields: []int64{0, 1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 101}},
+	}
+	w, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.maxRowNum,
+		WithVersion(StorageV3), WithColumnGroups(columnGroups), WithStorageConfig(storageConfig),
+		WithUploader(func(ctx context.Context, kvs map[string][]byte) error { return nil }))
+	s.NoError(err)
+	blobs, err := generateTestData(10)
+	s.NoError(err)
+	deser, err := NewBinlogDeserializeReader(generateTestSchema(), MakeBlobsReader(blobs), false)
+	s.NoError(err)
+	for i := 0; i < 10; i++ {
+		v, err := deser.NextValue()
+		s.NoError(err)
+		rec, err := ValueSerializer([]*Value{*v}, s.schema)
+		s.NoError(err)
+		s.NoError(w.Write(rec))
+	}
+	deser.Close()
+	s.NoError(w.Close())
+	_, _, _, manifestPath, _ := w.GetLogs()
+	s.NotEmpty(manifestPath)
+
+	const absentFieldID = int64(200)
+	readSchema := &schemapb.CollectionSchema{
+		Name: s.schema.GetName(),
+		Fields: append(append([]*schemapb.FieldSchema{}, s.schema.GetFields()...),
+			&schemapb.FieldSchema{
+				FieldID: absentFieldID, Name: "added_def", DataType: schemapb.DataType_Int64,
+				Nullable: true, DefaultValue: &schemapb.ValueField{Data: &schemapb.ValueField_LongData{LongData: 7}},
+			}),
+	}
+	r, err := NewManifestRecordReader(s.ctx, manifestPath, readSchema, WithVersion(StorageV3), WithStorageConfig(storageConfig))
+	s.NoError(err)
+	defer r.Close()
+	total := 0
+	for {
+		rec, err := r.Next()
+		if err == io.EOF {
+			break
+		}
+		s.NoError(err)
+		added := rec.Column(absentFieldID).(*array.Int64)
+		s.Equal(0, added.NullN(), "absent default field must not be null")
+		for j := 0; j < added.Len(); j++ {
+			s.Equal(int64(7), added.Value(j))
+		}
+		s.NotNil(rec.Column(int64(13)))
+		total += rec.Len()
+	}
+	s.Equal(10, total)
+}
+
+// writeV2Segment writes a 10-row StorageV2 packed segment and returns its
+// FieldBinlogs (which the V2 writer populates with ChildFields).
+func (s *PackedBinlogRecordSuite) writeV2Segment(storageConfig *indexpb.StorageConfig, columnGroups []storagecommon.ColumnGroup) []*datapb.FieldBinlog {
+	w, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.maxRowNum,
+		WithVersion(StorageV2), WithColumnGroups(columnGroups), WithStorageConfig(storageConfig),
+		WithUploader(func(ctx context.Context, kvs map[string][]byte) error { return nil }))
+	s.NoError(err)
+	blobs, err := generateTestData(10)
+	s.NoError(err)
+	deser, err := NewBinlogDeserializeReader(generateTestSchema(), MakeBlobsReader(blobs), false)
+	s.NoError(err)
+	for i := 0; i < 10; i++ {
+		v, err := deser.NextValue()
+		s.NoError(err)
+		rec, err := ValueSerializer([]*Value{*v}, s.schema)
+		s.NoError(err)
+		s.NoError(w.Write(rec))
+	}
+	deser.Close()
+	s.NoError(w.Close())
+	fieldBinlogs, _, _, _, _ := w.GetLogs()
+	return SortFieldBinlogs(fieldBinlogs)
+}
+
+func newAbsentDefaultReadSchema(base *schemapb.CollectionSchema, absentFieldID int64) *schemapb.CollectionSchema {
+	return &schemapb.CollectionSchema{
+		Name: base.GetName(),
+		Fields: append(append([]*schemapb.FieldSchema{}, base.GetFields()...),
+			&schemapb.FieldSchema{
+				FieldID: absentFieldID, Name: "added_def", DataType: schemapb.DataType_Int64,
+				Nullable: true, DefaultValue: &schemapb.ValueField{Data: &schemapb.ValueField_LongData{LongData: 7}},
+			}),
+	}
+}
+
+// TestBinlogReadFillsAbsentDefaultFieldV2 is the StorageV2/binlog analog of the
+// manifest test: a packed binlog read must present the default of an added field
+// that has no column in the segment, sourcing physical presence from the
+// FieldBinlog ChildFields written by the V2 writer.
+func (s *PackedBinlogRecordSuite) TestBinlogReadFillsAbsentDefaultFieldV2() {
+	dir := s.T().TempDir()
+	paramtable.Get().Save(paramtable.Get().CommonCfg.StorageType.Key, "local")
+	paramtable.Get().Save(paramtable.Get().LocalStorageCfg.Path.Key, dir)
+	defer func() {
+		paramtable.Get().Reset(paramtable.Get().CommonCfg.StorageType.Key)
+		paramtable.Get().Reset(paramtable.Get().LocalStorageCfg.Path.Key)
+	}()
+	storageConfig := &indexpb.StorageConfig{RootPath: dir, StorageType: "local"}
+	columnGroups := []storagecommon.ColumnGroup{
+		{GroupID: 0, Columns: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, Fields: []int64{0, 1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 101}},
+		{GroupID: 102, Columns: []int{13}, Fields: []int64{102}},
+		{GroupID: 103, Columns: []int{14}, Fields: []int64{103}},
+		{GroupID: 104, Columns: []int{15}, Fields: []int64{104}},
+		{GroupID: 105, Columns: []int{16}, Fields: []int64{105}},
+		{GroupID: 106, Columns: []int{17}, Fields: []int64{106}},
+	}
+	binlogs := s.writeV2Segment(storageConfig, columnGroups)
+	s.NotEmpty(binlogs[0].GetChildFields(), "V2 writer must populate ChildFields for presence to be derivable")
+
+	const absentFieldID = int64(200)
+	readSchema := newAbsentDefaultReadSchema(s.schema, absentFieldID)
+	r, err := NewBinlogRecordReader(s.ctx, binlogs, readSchema, WithVersion(StorageV2), WithStorageConfig(storageConfig))
+	s.NoError(err)
+	defer r.Close()
+	total := 0
+	for {
+		rec, err := r.Next()
+		if err == io.EOF {
+			break
+		}
+		s.NoError(err)
+		added := rec.Column(absentFieldID).(*array.Int64)
+		s.Equal(0, added.NullN(), "absent default field must not be null")
+		for j := 0; j < added.Len(); j++ {
+			s.Equal(int64(7), added.Value(j))
+		}
+		total += added.Len()
+	}
+	s.Equal(10, total)
+}
+
+// TestBinlogReadNoChildFieldsFallsBackUnfiltered pins the import-restore safety net:
+// binlogs without ChildFields (FieldID keyed by column-group ID, the shape import
+// reconstructs) are not filterable, so the reader passes the full schema through
+// unchanged — no PK strip / no crash — instead of default-filling.
+func (s *PackedBinlogRecordSuite) TestBinlogReadNoChildFieldsFallsBackUnfiltered() {
+	dir := s.T().TempDir()
+	paramtable.Get().Save(paramtable.Get().CommonCfg.StorageType.Key, "local")
+	paramtable.Get().Save(paramtable.Get().LocalStorageCfg.Path.Key, dir)
+	defer func() {
+		paramtable.Get().Reset(paramtable.Get().CommonCfg.StorageType.Key)
+		paramtable.Get().Reset(paramtable.Get().LocalStorageCfg.Path.Key)
+	}()
+	storageConfig := &indexpb.StorageConfig{RootPath: dir, StorageType: "local"}
+	columnGroups := []storagecommon.ColumnGroup{
+		{GroupID: 0, Columns: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, Fields: []int64{0, 1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 101}},
+		{GroupID: 102, Columns: []int{13}, Fields: []int64{102}},
+		{GroupID: 103, Columns: []int{14}, Fields: []int64{103}},
+		{GroupID: 104, Columns: []int{15}, Fields: []int64{104}},
+		{GroupID: 105, Columns: []int{16}, Fields: []int64{105}},
+		{GroupID: 106, Columns: []int{17}, Fields: []int64{106}},
+	}
+	binlogs := s.writeV2Segment(storageConfig, columnGroups)
+	for _, fb := range binlogs { // simulate import-reconstructed binlogs: drop ChildFields
+		fb.ChildFields = nil
+	}
+
+	const absentFieldID = int64(200)
+	readSchema := newAbsentDefaultReadSchema(s.schema, absentFieldID)
+	r, err := NewBinlogRecordReader(s.ctx, binlogs, readSchema, WithVersion(StorageV2), WithStorageConfig(storageConfig))
+	s.NoError(err) // must not strip the PK / fail — regression guard for the import break
+	defer r.Close()
+	total := 0
+	for {
+		rec, err := r.Next()
+		if err == io.EOF {
+			break
+		}
+		s.NoError(err)
+		added := rec.Column(absentFieldID).(*array.Int64)
+		s.Equal(added.Len(), added.NullN(), "no-ChildFields fallback must not default-fill")
+		s.NotNil(rec.Column(int64(13))) // present column still reads back
+		total += rec.Len()
+	}
+	s.Equal(10, total)
 }
 
 func (s *PackedBinlogRecordSuite) TestGenerateBM25Stats() {
@@ -788,4 +981,82 @@ func TestRwOptionValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFilterSchemaToPresentFieldsStructAllOrNothing(t *testing.T) {
+	// One ordinary field plus a struct array whose two children are the physical
+	// (first-level) columns of the struct. A struct array is added/dropped whole,
+	// so its children are physically all-or-nothing.
+	newSchema := func() *schemapb.CollectionSchema {
+		return &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64},
+			},
+			StructArrayFields: []*schemapb.StructArrayFieldSchema{
+				{FieldID: 200, Name: "st", Fields: []*schemapb.FieldSchema{
+					{FieldID: 201, Name: "st[a]", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Int64},
+					{FieldID: 202, Name: "st[b]", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_VarChar},
+				}},
+			},
+		}
+	}
+
+	t.Run("struct fully present is kept whole", func(t *testing.T) {
+		out, err := filterSchemaToPresentFields(newSchema(), map[FieldID]struct{}{100: {}, 201: {}, 202: {}})
+		require.NoError(t, err)
+		require.Len(t, out.GetStructArrayFields(), 1)
+		require.Len(t, out.GetStructArrayFields()[0].GetFields(), 2)
+	})
+
+	t.Run("struct fully absent is dropped whole", func(t *testing.T) {
+		out, err := filterSchemaToPresentFields(newSchema(), map[FieldID]struct{}{100: {}})
+		require.NoError(t, err)
+		require.Empty(t, out.GetStructArrayFields())
+		require.Len(t, out.GetFields(), 1)
+	})
+
+	t.Run("struct partially present is a data-integrity error", func(t *testing.T) {
+		_, err := filterSchemaToPresentFields(newSchema(), map[FieldID]struct{}{100: {}, 201: {}})
+		require.Error(t, err)
+	})
+}
+
+func TestFilterSchemaToPresentFieldsDropsAbsentTopLevelAndKeepsAttrs(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Name:               "coll",
+		EnableDynamicField: true,
+		Functions:          []*schemapb.FunctionSchema{{Name: "fn", Id: 7}},
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "absent", DataType: schemapb.DataType_Int64, Nullable: true},
+		},
+	}
+	out, err := filterSchemaToPresentFields(schema, map[FieldID]struct{}{100: {}})
+	require.NoError(t, err)
+	require.Len(t, out.GetFields(), 1) // absent top-level 101 dropped
+	require.Equal(t, int64(100), out.GetFields()[0].GetFieldID())
+	// non-field schema attributes survive the proto.Clone-based filter
+	require.Equal(t, "coll", out.GetName())
+	require.True(t, out.GetEnableDynamicField())
+	require.Len(t, out.GetFunctions(), 1)
+}
+
+func TestBinlogFieldIDSet(t *testing.T) {
+	// flush/compaction binlogs carry ChildFields (the group's member field IDs) -> reliable.
+	withChildren := []*datapb.FieldBinlog{
+		{FieldID: 0, ChildFields: []int64{0, 1, 100}},
+		{FieldID: 101, ChildFields: []int64{101}},
+	}
+	present, reliable := binlogFieldIDSet(withChildren)
+	require.True(t, reliable)
+	require.Equal(t, map[FieldID]struct{}{0: {}, 1: {}, 100: {}, 101: {}}, present)
+
+	// import-reconstructed binlogs key FieldID by column-group ID with no ChildFields
+	// -> presence is not derivable -> unreliable (caller must read unfiltered).
+	noChildren := []*datapb.FieldBinlog{
+		{FieldID: 0, ChildFields: []int64{0, 1, 100}},
+		{FieldID: 101}, // no ChildFields
+	}
+	_, reliable = binlogFieldIDSet(noChildren)
+	require.False(t, reliable)
 }

--- a/internal/storage/serde_events_test.go
+++ b/internal/storage/serde_events_test.go
@@ -760,6 +760,11 @@ func TestNewManifestRecordReaderBranches(t *testing.T) {
 	mockEncryption := mockey.Mock(hookutil.IsClusterEncryptionEnabled).Return(true).Build()
 	defer mockEncryption.UnPatch()
 
+	// The reader self-sources physical field IDs from the manifest; stub it so the
+	// mocked inner reader (fake manifest path) is reached.
+	mockFieldIDs := mockey.Mock(packed.GetManifestFieldIDs).Return(map[int64]struct{}{100: {}}, nil).Build()
+	defer mockFieldIDs.UnPatch()
+
 	var capturedPluginContext *indexcgopb.StoragePluginContext
 	mockReader := mockey.Mock(NewRecordReaderFromManifest).To(
 		func(manifest string,
@@ -803,6 +808,70 @@ func TestNewManifestRecordReaderBranches(t *testing.T) {
 	// the plugin context contract carries the key base64-encoded, matching
 	// NewBinlogRecordReader/NewBinlogRecordWriter and hookutil.GetCPluginContext
 	require.Equal(t, base64.StdEncoding.EncodeToString([]byte("unsafe-key")), capturedPluginContext.GetEncryptionKey())
+}
+
+// TestNewManifestRecordReaderPresentFieldsSkipManifestRead pins the P5 perf path:
+// when the caller already knows the segment's physically-present field IDs and
+// supplies them via WithPresentFields, the reader must NOT re-derive them with a
+// second GetManifestFieldIDs manifest open.
+func TestNewManifestRecordReaderPresentFieldsSkipManifestRead(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64},
+		},
+	}
+	mockEnc := mockey.Mock(hookutil.IsClusterEncryptionEnabled).Return(false).Build()
+	defer mockEnc.UnPatch()
+	mockFieldIDs := mockey.Mock(packed.GetManifestFieldIDs).To(
+		func(string, *indexpb.StorageConfig) (map[int64]struct{}, error) {
+			t.Fatal("GetManifestFieldIDs must not be called when present fields are supplied")
+			return nil, nil
+		}).Build()
+	defer mockFieldIDs.UnPatch()
+	mockReader := mockey.Mock(NewRecordReaderFromManifest).Return(fakeManifestRecordReader{}, nil).Build()
+	defer mockReader.UnPatch()
+
+	reader, err := NewManifestRecordReader(context.Background(), "manifest-json", schema,
+		WithVersion(StorageV3),
+		WithStorageConfig(&indexpb.StorageConfig{RootPath: "root"}),
+		WithPresentFields(map[FieldID]struct{}{100: {}}),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, reader)
+}
+
+// TestNewManifestRecordReaderPartialStructErrors pins that the struct-array
+// all-or-nothing check in filterSchemaToPresentFields surfaces through the reader:
+// a physically-present set that covers only SOME children of a struct array is a
+// data-integrity violation, so NewManifestRecordReader must return an error and
+// never open the manifest.
+func TestNewManifestRecordReaderPartialStructErrors(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64}},
+		StructArrayFields: []*schemapb.StructArrayFieldSchema{
+			{FieldID: 200, Name: "st", Fields: []*schemapb.FieldSchema{
+				{FieldID: 201, Name: "st[a]", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Int64, Nullable: true},
+				{FieldID: 202, Name: "st[b]", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_VarChar, Nullable: true},
+			}},
+		},
+	}
+	mockEnc := mockey.Mock(hookutil.IsClusterEncryptionEnabled).Return(false).Build()
+	defer mockEnc.UnPatch()
+	// present covers only ONE of the struct's two children -> partial struct.
+	mockFieldIDs := mockey.Mock(packed.GetManifestFieldIDs).Return(map[int64]struct{}{100: {}, 201: {}}, nil).Build()
+	defer mockFieldIDs.UnPatch()
+	mockReader := mockey.Mock(NewRecordReaderFromManifest).To(
+		func(string, *schemapb.CollectionSchema, int64, *indexpb.StorageConfig, *indexcgopb.StoragePluginContext, ...RwOption) (RecordReader, error) {
+			t.Fatal("must not open the manifest when the present set is a partial struct")
+			return nil, nil
+		}).Build()
+	defer mockReader.UnPatch()
+
+	_, err := NewManifestRecordReader(context.Background(), "manifest-json", schema,
+		WithVersion(StorageV3),
+		WithStorageConfig(&indexpb.StorageConfig{RootPath: "root"}),
+	)
+	require.Error(t, err)
 }
 
 func TestBinlogSerializeWriter(t *testing.T) {


### PR DESCRIPTION
The packed StorageV2/V3 record readers returned NULL for a read-schema field physically absent from a segment even when the field declares a `default_value`, while the V1 binlog reader and segcore synthesize the default. This makes the packed readers default-aware, matching V1: they read only physically-present columns and fill every absent read-schema field via `GenerateEmptyArrayFromSchema` (its declared default, else null). Physical presence is the reader's own truth:

- **StorageV3 manifest reader** — from `packed.GetManifestFieldIDs`, or a caller-supplied present set (compaction passes its already-computed `existingFields` via `WithPresentFields` to avoid a redundant manifest open).
- **StorageV2/V3 binlog reader** — from `FieldBinlog.ChildFields` (the column group's member field IDs, written by the flush/compaction writers).

**Struct array fields** are physically all-or-nothing (add/drop/update act on the whole struct): a struct is kept whole or dropped whole, and a partially-present struct is surfaced as a data-integrity error rather than read partial.

**Import-restore** reads reconstruct FieldBinlogs from object-storage directory names (`FieldID` is a column-group ID, no `ChildFields`), so physical presence is not derivable there; those reads pass the full schema through unchanged (the engine null-fills absent columns) — no crash, no PK strip. Import-restore default-fill is a tracked follow-up on #52771 (it needs presence from the packed files' arrow schema, or an extended import contract).

**Scope / current effect (honest):** this is the reader-contract prerequisite for #52484. Today the fill is inert on the compaction path — `compactionReadSchema` reduces the read schema to `existingFields`, and the `RecordMaterializer` still fills ordinary-field defaults — so the new reader path is currently exercised by the tests in this PR, not by a live compaction. It goes live once #52484 removes the RM's ordinary-field fill and makes `base` read-schema-wide; **#52781 must merge before #52484** to avoid a window where neither fills (the #52771 NULL). This PR does not, by itself, change compaction output on master.

**Behavior change:** an absent non-nullable read-schema field now errors instead of being silently null-filled, matching the V1 reader. External-source reads pass through unchanged.

**Follow-ups:** import-restore default-fill (above); de-dupe the absent-fill overlay record shared with the compactor's `RecordMaterializer` (`absentFilledRecord` vs `materializedRecord`).

issue: #52771

🤖 Generated with [Claude Code](https://claude.com/claude-code)