### PR TITLE
fix: [poc_2.6.17] avoid double-joining full textlog paths in datacoord GC (#50629)

### DIFF
--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -1061,18 +1061,14 @@ func getTextLogs(sinfo *SegmentInfo) map[string]struct{} {
 func getTextLogPaths(sinfo *SegmentInfo, rootPath string) map[string]struct{} {
 	textLogs := make(map[string]struct{})
 	for _, flog := range sinfo.GetTextStatsLogs() {
-		for _, file := range flog.GetFiles() {
-			if rootPath != "" {
-				file = path.Join(rootPath, common.TextIndexPath,
-					fmt.Sprintf("%d", flog.GetBuildID()),
-					fmt.Sprintf("%d", flog.GetVersion()),
-					fmt.Sprintf("%d", sinfo.GetCollectionID()),
-					fmt.Sprintf("%d", sinfo.GetPartitionID()),
-					fmt.Sprintf("%d", sinfo.GetID()),
-					fmt.Sprintf("%d", flog.GetFieldID()),
-					file,
-				)
-			}
+		files := flog.GetFiles()
+		if rootPath != "" {
+			basePath := metautil.BuildTextIndexPrefix(rootPath,
+				flog.GetBuildID(), flog.GetVersion(),
+				sinfo.GetCollectionID(), sinfo.GetPartitionID(), sinfo.GetID(), flog.GetFieldID())
+			files = metautil.BuildStatsFilePaths(basePath, files)
+		}
+		for _, file := range files {
 			textLogs[file] = struct{}{}
 		}
 	}

--- a/internal/datacoord/garbage_collector_test.go
+++ b/internal/datacoord/garbage_collector_test.go
@@ -2283,6 +2283,8 @@ func TestGarbageCollector_recycleUnusedBinlogFiles_TextAndJSONStats(t *testing.T
 		}).Build()
 	defer mockRemove.UnPatch()
 
+	segment.GetTextStatsLogs()[101].Files = []string{"gc/text_log/501/1/100/10/1003/101/text_file_keep"}
+
 	mockWalk := mockey.Mock((*storage.LocalChunkManager).WalkWithPrefix).To(
 		func(cm *storage.LocalChunkManager, ctx context.Context, prefix string, recursive bool, fn storage.ChunkObjectWalkFunc) error {
 			switch {

--- a/pkg/util/metautil/binlog.go
+++ b/pkg/util/metautil/binlog.go
@@ -114,6 +114,36 @@ func ExtractTextLogFilenames(textStatsLogs map[int64]*datapb.TextIndexStats) {
 	}
 }
 
+// BuildTextIndexPrefix returns the remote base path for text index files.
+// Format: {rootPath}/text_log/{buildID}/{version}/{collID}/{partID}/{segID}/{fieldID}
+func BuildTextIndexPrefix(rootPath string, buildID, version, collectionID, partitionID, segmentID, fieldID int64) string {
+	return path.Join(rootPath, common.TextIndexPath,
+		strconv.FormatInt(buildID, 10), strconv.FormatInt(version, 10),
+		strconv.FormatInt(collectionID, 10), strconv.FormatInt(partitionID, 10),
+		strconv.FormatInt(segmentID, 10), strconv.FormatInt(fieldID, 10))
+}
+
+// BuildStatsFilePaths normalizes stats files to full object keys.
+// TextMatch stats upload returns relative filenames; this helper also tolerates
+// already-full paths for compatibility with older/intermediate producers.
+func BuildStatsFilePaths(basePath string, files []string) []string {
+	result := make([]string, 0, len(files))
+	if basePath == "" {
+		return append(result, files...)
+	}
+
+	basePath = strings.TrimSuffix(basePath, pathSep)
+	prefix := basePath + pathSep
+	for _, file := range files {
+		if strings.HasPrefix(file, prefix) {
+			result = append(result, file)
+			continue
+		}
+		result = append(result, path.Join(basePath, strings.TrimPrefix(file, pathSep)))
+	}
+	return result
+}
+
 // BuildTextLogPaths reconstructs full paths from filenames for text index logs.
 // This function is compatible with both old version (full paths) and new version (filenames only).
 func BuildTextLogPaths(rootPath string, collectionID, partitionID, segmentID typeutil.UniqueID, textStatsLogs map[int64]*datapb.TextIndexStats) {

--- a/pkg/util/metautil/binlog_test.go
+++ b/pkg/util/metautil/binlog_test.go
@@ -195,3 +195,14 @@ func TestBuildTextLogPaths(t *testing.T) {
 		t.Errorf("BuildTextLogPaths() should keep full path unchanged, got %v", textStatsLogs[100].Files[0])
 	}
 }
+
+func TestBuildStatsFilePaths(t *testing.T) {
+	basePath := BuildTextIndexPrefix("root", 1, 2, 10, 20, 30, 100)
+	fullPath := path.Join(basePath, "file2.txt")
+
+	files := BuildStatsFilePaths(basePath, []string{"file1.txt", fullPath})
+	want := []string{path.Join(basePath, "file1.txt"), fullPath}
+	if !reflect.DeepEqual(files, want) {
+		t.Errorf("BuildStatsFilePaths() Files = %v, want %v", files, want)
+	}
+}


### PR DESCRIPTION
Cherry-pick of upstream `5759d3b5ff` (milvus-io/milvus#50629) onto `poc_2.6.17`,
unchanged apart from being applied to this branch.

### Why this branch needs it

`0231f29c2d` (#52176, 4 August) backported #50592 — which added orphan scanning
for the `text_log` and JSON auxiliary prefixes — but not #50629, which repairs
the path handling that scanning depends on. Upstream the two are fifteen hours
apart on 2.6:

```
2026-06-18 01:10   1c42283892   #50599   adds the text_log orphan scan
2026-06-18 16:42   5759d3b5ff   #50629   fixes the path double-join
```

So this branch has carried a state that existed upstream for fifteen hours, for
nineteen days. Neither official v2.6.17 nor v2.6.18 scans the `text_log` prefix
at all, and both 2.6 and master carry the fix, so the exposure is specific to
this line.

### What goes wrong without it

DataCoord loads segment metadata with `TextStatsLogs.Files` already holding
complete `text_log/...` paths. `getTextLogPaths` joins the base path onto them
again, producing a key that matches no object in storage. The checker concludes
the file is unused, and after `missingTolerance` the orphan sweep deletes it.

Reported on Zendesk #4707: a cluster upgraded on 11 August, the first orphan
scan fired 168 hours later, and `recycleUnusedBinlogFiles` deleted 8,606 live
`text_log/*` objects across 130 collections. 126 collections could not load —
`LoadSegment` returned 404 for files the metadata says exist. Only the
`text_log/` prefix was affected; `insert_log/`, `delta_log/`, `stats_log/`,
`index_files/` and `analyze_stats/` were clean.

It does not recover on its own. `needDoTextIndex` decides whether to rebuild by
looking only at whether the `TextStatsLogs` record exists, and the sweep removed
objects while leaving the records, so DataCoord believes the index is built.

### The fix

`BuildStatsFilePaths` checks whether a file already carries the base path before
joining, so a stored full path is matched as-is. A file that is genuinely
relative is still joined as before.

### Verification

Built and tested on this branch, as a before/after control rather than a
one-sided pass:

| | before (`711dd53123`) | after |
|---|---|---|
| `TestGarbageCollector_recycleUnusedBinlogFiles_TextAndJSONStats` | **FAIL** — the full-path `text_file_keep` appears in the delete list | **PASS** |
| `internal/datacoord` (`-tags dynamic,test`) | FAIL | **PASS** |
| `TestBuildStatsFilePaths` | does not compile — helper absent | **PASS** |

The failing assertion on the unfixed tree is the customer's situation in
miniature: a text log stored with its full path is classified as garbage.

### Audit of the other backports on this branch

Every upstream PR backported onto `poc_2.6.17` was checked for a follow-up fix
that was left behind: for each, later commits on 2.6 touching the same functions
and absent here. Six pairs came back; this is the only one where the follow-up
landed within a day of the change it repairs. The rest are six to thirty-six
days later and are independent improvements rather than repairs, which this
branch lacks in the same way any older build does.
