### PR TITLE
fix: [3.0] reconcile physical fields during schema bump (#52159)

### DIFF
--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -2117,16 +2117,23 @@ func (suite *MetaBasicSuite) TestCompleteBumpSchemaVersionCompactionMutation() {
 		suite.EqualValues(5, got.GetInsertBinlogCount())
 	})
 
-	suite.Run("in-place result merges column groups into Binlogs", func() {
+	suite.Run("in-place result atomically merges ordinary and function-output column groups", func() {
 		// The compactor ships only the groups this run wrote, so the receiver
-		// must upsert them: assigning the array would drop the segment's other
-		// column groups. Replaying the same result must not duplicate them.
+		// must upsert them: the live Binlogs keeps the complete column set and
+		// a not-yet-restarted QueryNode estimate stays correct. Replaying the
+		// result must neither duplicate the new groups nor re-apply the
+		// manifest-gated statistics delta.
 		currentManifest := packed.MarshalManifestPath("/data/segments/1", 10)
 		resultManifest := packed.MarshalManifestPath("/data/segments/1", 12)
 		segs := makeSegments(1, commonpb.SegmentState_Flushed)
 		old := segs.GetSegment(1)
 		old.StorageVersion = storage.StorageV3
 		old.ManifestPath = currentManifest
+		old.Stats = &datapb.Statistics{
+			InsertBinlogSize:  1024,
+			InsertBinlogCount: 1,
+			NullCounts:        map[int64]int64{100: 0},
+		}
 		old.Binlogs = []*datapb.FieldBinlog{
 			{FieldID: 0, ChildFields: []int64{0, 1, 100}, Binlogs: []*datapb.Binlog{{LogID: 10000}}},
 		}
@@ -2139,7 +2146,12 @@ func (suite *MetaBasicSuite) TestCompleteBumpSchemaVersionCompactionMutation() {
 			Type:          datapb.CompactionType_BumpSchemaVersionCompaction,
 			Schema:        &schemapb.CollectionSchema{Version: 3},
 		}
-		newGroup := &datapb.FieldBinlog{
+		ordinaryGroup := &datapb.FieldBinlog{
+			FieldID:     101,
+			ChildFields: []int64{101},
+			Binlogs:     []*datapb.Binlog{{LogID: 10001, EntriesNum: 5, MemorySize: 256}},
+		}
+		functionOutputGroup := &datapb.FieldBinlog{
 			FieldID:     102,
 			ChildFields: []int64{102},
 			Binlogs:     []*datapb.Binlog{{LogID: 10002, EntriesNum: 5, MemorySize: 512}},
@@ -2149,19 +2161,24 @@ func (suite *MetaBasicSuite) TestCompleteBumpSchemaVersionCompactionMutation() {
 				{
 					SegmentID:      1,
 					NumOfRows:      5,
-					InsertLogs:     []*datapb.FieldBinlog{newGroup},
+					InsertLogs:     []*datapb.FieldBinlog{ordinaryGroup, functionOutputGroup},
 					Manifest:       resultManifest,
 					BaseManifest:   currentManifest,
 					StorageVersion: storage.StorageV3,
-					Stats:          &datapb.Statistics{InsertBinlogSize: 1},
+					Stats: &datapb.Statistics{
+						InsertBinlogSize:  768,
+						InsertBinlogCount: 2,
+						NullCounts:        map[int64]int64{101: 5, 102: 0},
+					},
 				},
 			},
 		}
 		infos, _, err := m.completeBumpSchemaVersionCompactionMutation(task, result)
 		suite.NoError(err)
 		suite.Require().Len(infos, 1)
-		// Pre-existing group survives, the materialized group is present.
-		suite.ElementsMatch([]int64{0, 102},
+		// The pre-existing group survives and both newly appended groups are
+		// visible through the same adopted manifest.
+		suite.ElementsMatch([]int64{0, 101, 102},
 			lo.Map(infos[0].GetBinlogs(), func(fb *datapb.FieldBinlog, _ int) int64 { return fb.GetFieldID() }))
 		for _, fb := range infos[0].GetBinlogs() {
 			if fb.GetFieldID() == 0 {
@@ -2169,23 +2186,31 @@ func (suite *MetaBasicSuite) TestCompleteBumpSchemaVersionCompactionMutation() {
 					"no child collision, so the pre-existing group keeps its fields")
 			}
 		}
+		firstStats := infos[0].GetStats()
+		suite.EqualValues(1792, firstStats.GetInsertBinlogSize())
+		suite.EqualValues(3, firstStats.GetInsertBinlogCount())
+		suite.Equal(map[int64]int64{100: 0, 101: 5, 102: 0}, firstStats.GetNullCounts())
 
 		// Replay: the segment now sits at resultManifest, so this is the
-		// idempotent-adoption branch. The merge must not duplicate the group.
+		// idempotent-adoption branch. The merge must not duplicate either new
+		// group, and the manifest-gated increment must not be accumulated twice.
 		replayed, _, err := m.completeBumpSchemaVersionCompactionMutation(task, result)
 		suite.NoError(err)
 		suite.Require().Len(replayed, 1)
-		suite.Require().Len(replayed[0].GetBinlogs(), 2)
-		suite.ElementsMatch([]int64{0, 102},
+		suite.Require().Len(replayed[0].GetBinlogs(), 3)
+		suite.ElementsMatch([]int64{0, 101, 102},
 			lo.Map(replayed[0].GetBinlogs(), func(fb *datapb.FieldBinlog, _ int) int64 { return fb.GetFieldID() }))
+		replayedStats := replayed[0].GetStats()
+		suite.EqualValues(1792, replayedStats.GetInsertBinlogSize())
+		suite.EqualValues(3, replayedStats.GetInsertBinlogCount())
+		suite.Equal(map[int64]int64{100: 0, 101: 5, 102: 0}, replayedStats.GetNullCounts())
 	})
 
-	suite.Run("materialized column group is visible to the index-eligibility gate", func() {
-		// Regression pin: compaction_task_bump_schema_version enqueues the
-		// segment for index building right after this mutation, so the
-		// materialized column group must land in SegmentInfo.Binlogs — a
-		// function-output field with no data there gets no index. StorageV2/V3
-		// column groups report their real field IDs through ChildFields.
+	suite.Run("materialized column group is visible on the live segment", func() {
+		// Regression pin: the merged column group keeps the live Binlogs
+		// complete (pre-restart QueryNode estimation reads it), while index
+		// eligibility is gated by the schema-version advance — the inspector
+		// does not read Binlogs and the build worker reads the manifest.
 		currentManifest := packed.MarshalManifestPath("/data/segments/1", 10)
 		resultManifest := packed.MarshalManifestPath("/data/segments/1", 12)
 		segs := makeSegments(1, commonpb.SegmentState_Flushed)
@@ -2220,14 +2245,35 @@ func (suite *MetaBasicSuite) TestCompleteBumpSchemaVersionCompactionMutation() {
 		_, _, err := m.completeBumpSchemaVersionCompactionMutation(task, result)
 		suite.NoError(err)
 
+		updated := m.segments.GetSegment(1)
 		fields := make(map[int64]struct{})
-		for _, binlog := range m.segments.GetSegment(1).GetBinlogs() {
+		for _, binlog := range updated.GetBinlogs() {
 			for _, childFieldID := range binlog.GetChildFields() {
 				fields[childFieldID] = struct{}{}
 			}
 		}
-		suite.Contains(fields, int64(102), "materialized function-output field must have data")
-		suite.Contains(fields, int64(100), "pre-existing fields must keep their data")
+		suite.Contains(fields, int64(102), "materialized function-output field must be visible on live Binlogs")
+		suite.Contains(fields, int64(100), "pre-existing fields keep their data")
+
+		handler := NewNMockHandler(suite.T())
+		handler.EXPECT().GetCollection(mock.Anything, updated.GetCollectionID()).Return(&collectionInfo{
+			ID: updated.GetCollectionID(),
+			Schema: &schemapb.CollectionSchema{
+				Version: 3,
+				Fields: []*schemapb.FieldSchema{
+					{FieldID: 102, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector},
+				},
+				Functions: []*schemapb.FunctionSchema{
+					{OutputFieldIds: []int64{102}},
+				},
+			},
+		}, nil).Once()
+		inspector := &indexInspector{handler: handler}
+		suite.True(inspector.canCreateIndexForSegment(context.Background(), updated, &model.Index{
+			CollectionID: updated.GetCollectionID(),
+			FieldID:      102,
+			IndexID:      1,
+		}), "materialized function-output field must be index-eligible")
 	})
 
 	suite.Run("in-place result with stale base manifest is rejected", func() {

--- a/internal/datanode/compactor/bump_schema_version_compactor.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor.go
@@ -42,7 +42,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
-	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -63,6 +62,25 @@ type bumpSchemaVersionCompactionTask struct {
 	lobContext *compaction.LOBCompactionContext
 }
 
+// schemaBumpPhysicalDiff describes the difference between the target schema and
+// the columns physically present in the source manifest. existingFields always
+// comes from the manifest; target-schema membership must never be used as a
+// substitute for physical presence.
+type schemaBumpPhysicalDiff struct {
+	existingFields       map[int64]struct{}
+	droppedFieldIDs      []int64
+	absentOrdinaryFields []*schemapb.FieldSchema
+	missingOutputFields  []*schemapb.FieldSchema
+	missingFunctions     []*schemapb.FunctionSchema
+}
+
+func (d *schemaBumpPhysicalDiff) appendedFields() []*schemapb.FieldSchema {
+	fields := make([]*schemapb.FieldSchema, 0, len(d.absentOrdinaryFields)+len(d.missingOutputFields))
+	fields = append(fields, d.absentOrdinaryFields...)
+	fields = append(fields, d.missingOutputFields...)
+	return fields
+}
+
 func (t *bumpSchemaVersionCompactionTask) Compact() (*datapb.CompactionPlanResult, error) {
 	if !funcutil.CheckCtxValid(t.ctx) {
 		return nil, t.ctx.Err()
@@ -80,7 +98,7 @@ func (t *bumpSchemaVersionCompactionTask) Compact() (*datapb.CompactionPlanResul
 		mlog.FieldCollectionID(t.GetCollection()),
 	)
 
-	missingFunctions, droppedFieldIDs, existingFields, err := t.schemaBumpDecision()
+	diff, err := t.schemaBumpDecision()
 	if err != nil {
 		log.Warn(ctx, "failed to decide schema bump action", mlog.Err(err))
 		return nil, err
@@ -89,17 +107,22 @@ func (t *bumpSchemaVersionCompactionTask) Compact() (*datapb.CompactionPlanResul
 	log.Info(ctx, "schema bump compact start",
 		mlog.FieldSegmentID(t.plan.GetSegmentBinlogs()[0].GetSegmentID()),
 		mlog.Int32("collectionSchemaVersion", t.plan.GetSchema().GetVersion()),
-		mlog.Int("missingFunctionCount", len(missingFunctions)),
-		mlog.Int64s("droppedFieldIDs", droppedFieldIDs),
+		mlog.Int("missingFunctionCount", len(diff.missingFunctions)),
+		mlog.Int("absentOrdinaryFieldCount", len(diff.absentOrdinaryFields)),
+		mlog.Int("missingOutputFieldCount", len(diff.missingOutputFields)),
+		mlog.Int64s("droppedFieldIDs", diff.droppedFieldIDs),
 	)
 
 	var result *datapb.CompactionPlanResult
-	if len(missingFunctions) == 0 && len(droppedFieldIDs) == 0 {
+	// Dropped physical fields always require a replacement rewrite. Zero-row
+	// segments still route to additive reconciliation, which rejects them as a
+	// data-integrity error rather than writing an empty materialized record.
+	if len(diff.droppedFieldIDs) > 0 {
+		result, err = t.runFullSchemaRewrite(diff.existingFields)
+	} else if len(diff.absentOrdinaryFields) == 0 && len(diff.missingOutputFields) == 0 {
 		result = t.runSchemaVersionBumpOnly()
-	} else if len(droppedFieldIDs) > 0 {
-		result, err = t.runFullSchemaRewrite(existingFields)
 	} else {
-		result, err = t.runMissingFunctionMaterialization(ctx, missingFunctions, droppedFieldIDs, existingFields)
+		result, err = t.runAdditivePhysicalReconciliation(ctx, diff)
 	}
 	if err != nil {
 		log.Warn(ctx, "schema bump compact failed", mlog.Err(err), mlog.Duration("compact cost", time.Since(compactStart)))
@@ -145,29 +168,20 @@ func (t *bumpSchemaVersionCompactionTask) missingFunctionInputSchema(missingFunc
 		fields = append(fields, field)
 		fieldIDs = append(fieldIDs, fieldID)
 	}
+	// Inputs were validated by schemaBumpDecision (missingFunctionMaterializations);
+	// this only assembles the read schema.
 	for _, functionSchema := range missingFunctions {
-		if err := validateSupportedMissingFunctionMaterialization(functionSchema); err != nil {
-			return nil, nil, err
-		}
 		for _, inputFieldID := range functionSchema.GetInputFieldIds() {
 			inputField := typeutil.GetField(schema, inputFieldID)
 			if inputField == nil {
-				return nil, nil, merr.WrapErrParameterInvalidMsg("input field not found in schema")
-			}
-			if err := validateMaterializationInputField(functionSchema, inputField); err != nil {
-				return nil, nil, err
+				return nil, nil, merr.WrapErrDataIntegrityMsg(
+					"function %s input field %d not found in persisted schema",
+					functionSchema.GetName(), inputFieldID)
 			}
 			addInputField(inputField)
 
-			additionalFields, err := additionalFunctionInputFields(schema, functionSchema, inputField)
-			if err != nil {
+			if err := addBM25MultiAnalyzerInputFields(schema, functionSchema, inputField, addInputField); err != nil {
 				return nil, nil, err
-			}
-			for _, additionalField := range additionalFields {
-				if err := validateMaterializationInputField(functionSchema, additionalField); err != nil {
-					return nil, nil, err
-				}
-				addInputField(additionalField)
 			}
 		}
 	}
@@ -180,13 +194,23 @@ func (t *bumpSchemaVersionCompactionTask) missingFunctionInputSchema(missingFunc
 	}, fieldIDs, nil
 }
 
-func additionalFunctionInputFields(schema *schemapb.CollectionSchema, functionSchema *schemapb.FunctionSchema, inputField *schemapb.FieldSchema) ([]*schemapb.FieldSchema, error) {
-	switch functionSchema.GetType() {
-	case schemapb.FunctionType_BM25:
-		return bm25AdditionalInputFields(schema, functionSchema, inputField)
-	default:
-		return nil, nil
+// addBM25MultiAnalyzerInputFields adds the by_field analyzer-selector column of
+// a BM25 multi-analyzer input to the physical read schema; the selector is the
+// runner's per-row analyzer name, not a function text input, so it is resolved
+// and VarChar-validated in bm25AdditionalInputFields instead of the generic
+// input validator. No-op for other function types.
+func addBM25MultiAnalyzerInputFields(schema *schemapb.CollectionSchema, functionSchema *schemapb.FunctionSchema, inputField *schemapb.FieldSchema, addInputField func(*schemapb.FieldSchema)) error {
+	if functionSchema.GetType() != schemapb.FunctionType_BM25 {
+		return nil
 	}
+	byFields, err := bm25AdditionalInputFields(schema, functionSchema, inputField)
+	if err != nil {
+		return err
+	}
+	for _, byField := range byFields {
+		addInputField(byField)
+	}
+	return nil
 }
 
 func bm25AdditionalInputFields(schema *schemapb.CollectionSchema, functionSchema *schemapb.FunctionSchema, inputField *schemapb.FieldSchema) ([]*schemapb.FieldSchema, error) {
@@ -220,65 +244,49 @@ func bm25AdditionalInputFields(schema *schemapb.CollectionSchema, functionSchema
 	return []*schemapb.FieldSchema{byField}, nil
 }
 
-func (t *bumpSchemaVersionCompactionTask) missingFunctionOutputFields(missingFunctions []*schemapb.FunctionSchema, existingFields map[int64]struct{}) ([]*schemapb.FieldSchema, []int64, error) {
-	schema := t.plan.GetSchema()
-	var fields []*schemapb.FieldSchema
-	var fieldIDs []int64
-	for _, functionSchema := range missingFunctions {
-		if err := validateSupportedMissingFunctionMaterialization(functionSchema); err != nil {
-			return nil, nil, err
-		}
-		for _, outputIndex := range functionOutputIndexesToMaterialize(functionSchema, existingFields) {
-			outputFieldID := functionSchema.GetOutputFieldIds()[outputIndex]
-			outputField := typeutil.GetField(schema, outputFieldID)
-			if outputField == nil {
-				return nil, nil, merr.WrapErrParameterInvalidMsg("output field not found in schema")
-			}
-			if err := validateMaterializationOutputField(functionSchema, outputField); err != nil {
-				return nil, nil, err
-			}
-			fields = append(fields, outputField)
-			fieldIDs = append(fieldIDs, outputFieldID)
-		}
-	}
-	if len(fields) == 0 {
-		return nil, nil, merr.WrapErrParameterInvalidMsg("no missing function output fields")
-	}
-	return fields, fieldIDs, nil
-}
-
 func validateSupportedMissingFunctionMaterialization(functionSchema *schemapb.FunctionSchema) error {
 	switch functionSchema.GetType() {
 	case schemapb.FunctionType_BM25:
 		if len(functionSchema.GetInputFieldIds()) == 0 {
-			return merr.WrapErrParameterInvalidMsg("bm25 function should have input fields")
+			return merr.WrapErrDataIntegrityMsg("persisted bm25 function %s has no input fields", functionSchema.GetName())
 		}
 		if len(functionSchema.GetOutputFieldIds()) == 0 {
-			return merr.WrapErrParameterInvalidMsg("bm25 function should have output fields")
+			return merr.WrapErrDataIntegrityMsg("persisted bm25 function %s has no output fields", functionSchema.GetName())
 		}
 		return nil
 	case schemapb.FunctionType_MinHash:
 		if len(functionSchema.GetInputFieldIds()) == 0 {
-			return merr.WrapErrParameterInvalidMsg("minhash function should have input fields")
+			return merr.WrapErrDataIntegrityMsg("persisted minhash function %s has no input fields", functionSchema.GetName())
 		}
 		if len(functionSchema.GetOutputFieldIds()) == 0 {
-			return merr.WrapErrParameterInvalidMsg("minhash function should have output fields")
+			return merr.WrapErrDataIntegrityMsg("persisted minhash function %s has no output fields", functionSchema.GetName())
 		}
 		return nil
 	default:
-		return merr.WrapErrParameterInvalidMsg("unsupported function type")
+		return merr.WrapErrDataIntegrityMsg(
+			"persisted function %s has unsupported materialization type %s",
+			functionSchema.GetName(), functionSchema.GetType())
 	}
 }
 
+// validateMaterializationInputField enforces the schema-bump runtime contract on
+// persisted function inputs. It is narrower than the collection-creation
+// validator: a sealed StorageV3 Text column is read back as encoded LOB
+// references, which stringInputsFromRecord cannot consume without LOB decoding,
+// so only VarChar is an acceptable persisted input here.
 func validateMaterializationInputField(functionSchema *schemapb.FunctionSchema, field *schemapb.FieldSchema) error {
 	switch functionSchema.GetType() {
 	case schemapb.FunctionType_BM25:
-		if field.GetDataType() != schemapb.DataType_VarChar && field.GetDataType() != schemapb.DataType_Text {
-			return merr.WrapErrParameterInvalidMsg("input field data type must be varchar or text for bm25 materialization")
+		if field.GetDataType() != schemapb.DataType_VarChar {
+			return merr.WrapErrDataIntegrityMsg(
+				"persisted bm25 input field %d must be VarChar for schema-bump materialization (Text would require LOB decoding), got %s",
+				field.GetFieldID(), field.GetDataType())
 		}
 	case schemapb.FunctionType_MinHash:
-		if field.GetDataType() != schemapb.DataType_VarChar && field.GetDataType() != schemapb.DataType_Text {
-			return merr.WrapErrParameterInvalidMsg("input field data type must be varchar or text for minhash materialization")
+		if field.GetDataType() != schemapb.DataType_VarChar {
+			return merr.WrapErrDataIntegrityMsg(
+				"persisted minhash input field %d must be VarChar for schema-bump materialization (Text would require LOB decoding), got %s",
+				field.GetFieldID(), field.GetDataType())
 		}
 	}
 	return nil
@@ -288,24 +296,18 @@ func validateMaterializationOutputField(functionSchema *schemapb.FunctionSchema,
 	switch functionSchema.GetType() {
 	case schemapb.FunctionType_BM25:
 		if field.GetDataType() != schemapb.DataType_SparseFloatVector {
-			return merr.WrapErrParameterInvalidMsg("output field data type must be sparse float vector for bm25 materialization")
+			return merr.WrapErrDataIntegrityMsg(
+				"persisted bm25 output field %d must be SparseFloatVector, got %s",
+				field.GetFieldID(), field.GetDataType())
 		}
 	case schemapb.FunctionType_MinHash:
 		if field.GetDataType() != schemapb.DataType_BinaryVector {
-			return merr.WrapErrParameterInvalidMsg("output field data type must be binary vector for minhash materialization")
+			return merr.WrapErrDataIntegrityMsg(
+				"persisted minhash output field %d must be BinaryVector, got %s",
+				field.GetFieldID(), field.GetDataType())
 		}
 	}
 	return nil
-}
-
-func partialMaterializerExistingFields(schema *schemapb.CollectionSchema, missingFunctions []*schemapb.FunctionSchema, existingFields map[int64]struct{}) map[int64]struct{} {
-	fields := collectionSchemaFields(schema)
-	for _, functionSchema := range missingFunctions {
-		for _, outputIndex := range functionOutputIndexesToMaterialize(functionSchema, existingFields) {
-			delete(fields, functionSchema.GetOutputFieldIds()[outputIndex])
-		}
-	}
-	return fields
 }
 
 func (t *bumpSchemaVersionCompactionTask) openRecordReader(segment *datapb.CompactionSegmentBinlogs, schema *schemapb.CollectionSchema) (storage.RecordReader, map[int64]struct{}, error) {
@@ -321,13 +323,210 @@ func (t *bumpSchemaVersionCompactionTask) openRecordReader(segment *datapb.Compa
 	return reader, existingFields, err
 }
 
-func (t *bumpSchemaVersionCompactionTask) schemaBumpDecision() ([]*schemapb.FunctionSchema, []int64, map[int64]struct{}, error) {
+// schemaBumpDecision diffs the target schema against the manifest-backed
+// physical field set and classifies every gap the bump has to close.
+func (t *bumpSchemaVersionCompactionTask) schemaBumpDecision() (*schemaBumpPhysicalDiff, error) {
 	segment := t.plan.GetSegmentBinlogs()[0]
 	existingFields, err := compactionSegmentStorageFields(segment, t.compactionParams.StorageConfig)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
-	return missingSchemaFunctions(t.plan.GetSchema(), existingFields), droppedSchemaFieldIDs(t.plan.GetSchema(), existingFields), existingFields, nil
+	schema := t.plan.GetSchema()
+
+	functionOutputFields, err := declaredFunctionOutputFields(schema)
+	if err != nil {
+		return nil, err
+	}
+	missingFunctions, missingOutputFields, err := missingFunctionMaterializations(schema, existingFields)
+	if err != nil {
+		return nil, err
+	}
+
+	return &schemaBumpPhysicalDiff{
+		existingFields:       existingFields,
+		droppedFieldIDs:      droppedSchemaFieldIDs(schema, existingFields),
+		absentOrdinaryFields: absentOrdinarySchemaFields(schema, existingFields, functionOutputFields),
+		missingOutputFields:  missingOutputFields,
+		missingFunctions:     missingFunctions,
+	}, nil
+}
+
+// declaredFunctionOutputFields returns the field IDs declared as outputs by the
+// schema's functions. A field marked IsFunctionOutput that no function declares
+// is persisted-schema corruption: fail instead of silently backfilling a
+// non-nullable vector as an ordinary field.
+func declaredFunctionOutputFields(schema *schemapb.CollectionSchema) (map[int64]struct{}, error) {
+	declared := make(map[int64]struct{})
+	for _, functionSchema := range schema.GetFunctions() {
+		for _, outputFieldID := range functionSchema.GetOutputFieldIds() {
+			declared[outputFieldID] = struct{}{}
+		}
+	}
+	for _, field := range typeutil.GetAllFieldSchemas(schema) {
+		if field.GetIsFunctionOutput() {
+			if _, hasProducer := declared[field.GetFieldID()]; !hasProducer {
+				return nil, merr.WrapErrDataIntegrityMsg(
+					"function output field %d has no producing function", field.GetFieldID())
+			}
+		}
+	}
+	return declared, nil
+}
+
+// missingFunctionMaterializations derives, from the manifest-backed
+// existingFields, the functions whose outputs must be materialized by this bump
+// together with those output fields. Missing functions are defined by their
+// physically absent outputs, so both results are non-empty or both empty by
+// construction. The materialization contract is enforced here, upfront for
+// every route: supported function type, all-or-none output presence, output
+// field types, and input fields that exist and satisfy the schema-bump input
+// contract.
+func missingFunctionMaterializations(schema *schemapb.CollectionSchema, existingFields map[int64]struct{}) ([]*schemapb.FunctionSchema, []*schemapb.FieldSchema, error) {
+	var missingFunctions []*schemapb.FunctionSchema
+	var missingOutputFields []*schemapb.FieldSchema
+	for _, functionSchema := range schema.GetFunctions() {
+		outputFieldIDs := functionSchema.GetOutputFieldIds()
+		// A persisted function with no output fields is schema corruption (DDL
+		// rejects it); reject before the all-present early-continue treats the
+		// empty set as "nothing missing" and silently drops it.
+		if len(outputFieldIDs) == 0 {
+			return nil, nil, merr.WrapErrDataIntegrityMsg("persisted function %s has no output fields", functionSchema.GetName())
+		}
+		presentCount := 0
+		for _, outputFieldID := range outputFieldIDs {
+			if _, present := existingFields[outputFieldID]; present {
+				presentCount++
+			}
+		}
+		if presentCount == len(outputFieldIDs) {
+			continue
+		}
+		if err := validateSupportedMissingFunctionMaterialization(functionSchema); err != nil {
+			return nil, nil, err
+		}
+		if presentCount != 0 {
+			return nil, nil, merr.WrapErrDataIntegrityMsg(
+				"function %s has partially materialized output fields: %d of %d are physically present",
+				functionSchema.GetName(), presentCount, len(outputFieldIDs))
+		}
+		for _, outputFieldID := range outputFieldIDs {
+			outputField := typeutil.GetField(schema, outputFieldID)
+			if outputField == nil {
+				return nil, nil, merr.WrapErrDataIntegrityMsg(
+					"function %s output field %d not found in persisted schema",
+					functionSchema.GetName(), outputFieldID)
+			}
+			if err := validateMaterializationOutputField(functionSchema, outputField); err != nil {
+				return nil, nil, err
+			}
+			missingOutputFields = append(missingOutputFields, outputField)
+		}
+		if err := validateFunctionInputFields(schema, functionSchema); err != nil {
+			return nil, nil, err
+		}
+		missingFunctions = append(missingFunctions, functionSchema)
+	}
+	return missingFunctions, missingOutputFields, nil
+}
+
+// validateFunctionInputFields checks that every declared input of a
+// to-be-materialized function exists in the persisted schema and satisfies the
+// schema-bump materialization input contract.
+func validateFunctionInputFields(schema *schemapb.CollectionSchema, functionSchema *schemapb.FunctionSchema) error {
+	for _, inputFieldID := range functionSchema.GetInputFieldIds() {
+		inputField := typeutil.GetField(schema, inputFieldID)
+		if inputField == nil {
+			return merr.WrapErrDataIntegrityMsg(
+				"function %s input field %d not found in persisted schema",
+				functionSchema.GetName(), inputFieldID)
+		}
+		if err := validateMaterializationInputField(functionSchema, inputField); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// absentOrdinarySchemaFields returns the non-system, non-function-output schema
+// fields that are physically absent from the manifest.
+func absentOrdinarySchemaFields(schema *schemapb.CollectionSchema, existingFields, functionOutputFields map[int64]struct{}) []*schemapb.FieldSchema {
+	absent := make([]*schemapb.FieldSchema, 0)
+	for _, field := range typeutil.GetAllFieldSchemas(schema) {
+		fieldID := field.GetFieldID()
+		if common.IsSystemField(fieldID) {
+			continue
+		}
+		if _, isFunctionOutput := functionOutputFields[fieldID]; isFunctionOutput {
+			continue
+		}
+		if _, present := existingFields[fieldID]; !present {
+			absent = append(absent, field)
+		}
+	}
+	return absent
+}
+
+func (t *bumpSchemaVersionCompactionTask) additiveReadSchema(diff *schemaBumpPhysicalDiff) (*schemapb.CollectionSchema, []int64, error) {
+	inputSchema, logicalInputFieldIDs, err := t.missingFunctionInputSchema(diff.missingFunctions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	readFields := make([]*schemapb.FieldSchema, 0, len(inputSchema.GetFields())+1)
+	seen := make(map[int64]struct{}, len(inputSchema.GetFields())+1)
+	// Appends a field once (dedup by ID); absent fields stay in the read schema
+	// for the reader to fill per its contract.
+	addReadField := func(field *schemapb.FieldSchema) {
+		if field == nil {
+			return
+		}
+		fieldID := field.GetFieldID()
+		if _, ok := seen[fieldID]; ok {
+			return
+		}
+		seen[fieldID] = struct{}{}
+		readFields = append(readFields, field)
+	}
+	// Every additive pass reads one stable system column so batches retain row
+	// cardinality even when all logical function inputs are newly added fields.
+	anchor := typeutil.GetField(t.plan.GetSchema(), common.RowIDField)
+	if _, ok := diff.existingFields[common.RowIDField]; !ok || anchor == nil {
+		anchor = nil
+		if _, ok := diff.existingFields[common.TimeStampField]; ok {
+			anchor = typeutil.GetField(t.plan.GetSchema(), common.TimeStampField)
+		}
+	}
+	if anchor == nil {
+		return nil, nil, merr.WrapErrDataIntegrityMsg(
+			"schema bump additive reconciliation requires a physical RowID or Timestamp anchor")
+	}
+	// Anchor was selected from existingFields above, so it is physically present.
+	addReadField(anchor)
+	for _, field := range inputSchema.GetFields() {
+		addReadField(field)
+	}
+	for _, structField := range inputSchema.GetStructArrayFields() {
+		for _, field := range structField.GetFields() {
+			addReadField(field)
+		}
+	}
+
+	// Absent ordinary fields (including absent function inputs) enter the read
+	// schema so the reader fills them per its contract; the writer then takes
+	// the appended columns straight from the read record, and functions see
+	// target-schema values for their inputs.
+	for _, field := range diff.absentOrdinaryFields {
+		addReadField(field)
+	}
+
+	schema := t.plan.GetSchema()
+	return &schemapb.CollectionSchema{
+		Name:               schema.GetName(),
+		Description:        schema.GetDescription(),
+		Fields:             readFields,
+		EnableDynamicField: schema.GetEnableDynamicField(),
+		Properties:         schema.GetProperties(),
+	}, logicalInputFieldIDs, nil
 }
 
 func (t *bumpSchemaVersionCompactionTask) fullRewriteSegmentID() (int64, error) {
@@ -338,35 +537,35 @@ func (t *bumpSchemaVersionCompactionTask) fullRewriteSegmentID() (int64, error) 
 	return idRange.GetBegin(), nil
 }
 
-func selectFullRewriteRecord(record storage.Record, pkField *schemapb.FieldSchema, entityFilter compaction.EntityFilter, ttlFieldID int64, useTTLField bool, ttlValues []int64) (*recordSelection, []int64, error) {
+func selectFullRewriteRecord(record storage.Record, pkField *schemapb.FieldSchema, entityFilter compaction.EntityFilter, ttlFieldID int64, useTTLField bool) (*recordSelection, error) {
 	pkArray := record.Column(pkField.GetFieldID())
 	var pkAt func(int) any
 	switch pkField.GetDataType() {
 	case schemapb.DataType_Int64:
 		int64Array, ok := pkArray.(*array.Int64)
 		if !ok {
-			return nil, nil, merr.WrapErrServiceInternal("int64 primary key field not found in full schema rewrite record")
+			return nil, merr.WrapErrServiceInternal("int64 primary key field not found in full schema rewrite record")
 		}
 		pkAt = func(i int) any { return int64Array.Value(i) }
 	case schemapb.DataType_VarChar:
 		stringArray, ok := pkArray.(*array.String)
 		if !ok {
-			return nil, nil, merr.WrapErrServiceInternal("varchar primary key field not found in full schema rewrite record")
+			return nil, merr.WrapErrServiceInternal("varchar primary key field not found in full schema rewrite record")
 		}
 		pkAt = func(i int) any { return stringArray.Value(i) }
 	default:
-		return nil, nil, merr.WrapErrServiceInternal("invalid primary key data type for full schema rewrite")
+		return nil, merr.WrapErrServiceInternal("invalid primary key data type for full schema rewrite")
 	}
 
 	timestampArray, ok := record.Column(common.TimeStampField).(*array.Int64)
 	if !ok {
-		return nil, nil, merr.WrapErrServiceInternal("timestamp field not found in full schema rewrite record")
+		return nil, merr.WrapErrServiceInternal("timestamp field not found in full schema rewrite record")
 	}
 	var ttlArray *array.Int64
 	if useTTLField {
 		ttlArray, ok = record.Column(ttlFieldID).(*array.Int64)
 		if !ok {
-			return nil, nil, merr.WrapErrServiceInternal("TTL field not found in full schema rewrite record")
+			return nil, merr.WrapErrServiceInternal("TTL field not found in full schema rewrite record")
 		}
 	}
 
@@ -388,9 +587,6 @@ func selectFullRewriteRecord(record storage.Record, pkField *schemapb.FieldSchem
 			continue
 		}
 
-		if useTTLField && expireTs > 0 {
-			ttlValues = append(ttlValues, expireTs)
-		}
 		if sliceStart == -1 {
 			sliceStart = i
 		}
@@ -400,9 +596,9 @@ func selectFullRewriteRecord(record storage.Record, pkField *schemapb.FieldSchem
 		selection.length += record.Len() - sliceStart
 	}
 	if filteredRows == 0 {
-		return nil, ttlValues, nil
+		return nil, nil
 	}
-	return selection, ttlValues, nil
+	return selection, nil
 }
 
 func (t *bumpSchemaVersionCompactionTask) runSchemaVersionBumpOnly() *datapb.CompactionPlanResult {
@@ -454,6 +650,9 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 	}
 	entityFilter := compaction.NewEntityFilter(delta, t.plan.GetCollectionTtl(), t.currentTime, segment.GetCommitTimestamp())
 	ttlFieldID := getTTLFieldID(t.plan.GetSchema())
+	_, ttlFieldPhysicallyPresent := existingFields[ttlFieldID]
+	sourceHasTTLField := ttlFieldID >= common.StartOfUserFieldID && ttlFieldPhysicallyPresent
+	preMaterializeFilter := len(delta) > 0 || t.plan.GetCollectionTtl() > 0 || sourceHasTTLField
 	reader, _, err := newCompactionSegmentRecordReaderWithFields(t.ctx, segment, t.plan.GetSchema(), t.compactionParams.StorageConfig, existingFields,
 		storage.WithCollectionID(collectionID),
 		storage.WithVersion(segment.GetStorageVersion()),
@@ -524,11 +723,9 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 			return nil, err
 		}
 
-		sourceHasTTLField := ttlFieldID >= common.StartOfUserFieldID && record.Column(ttlFieldID) != nil
-		preMaterializeFilter := len(delta) > 0 || t.plan.GetCollectionTtl() > 0 || sourceHasTTLField
 		var selection *recordSelection
 		if preMaterializeFilter {
-			selection, _, err = selectFullRewriteRecord(record, pkField, entityFilter, ttlFieldID, sourceHasTTLField, nil)
+			selection, err = selectFullRewriteRecord(record, pkField, entityFilter, ttlFieldID, sourceHasTTLField)
 			if err != nil {
 				return nil, err
 			}
@@ -716,7 +913,7 @@ func (t *bumpSchemaVersionCompactionTask) applyLOBCompaction(ctx context.Context
 func appendBM25StatsFromArrowArray(stats *storage.BM25Stats, arr arrow.Array) (int, error) {
 	binaryArray, ok := arr.(*array.Binary)
 	if !ok {
-		return 0, merr.WrapErrParameterInvalidMsg("bm25 output field must be arrow binary array, got %T", arr)
+		return 0, merr.WrapErrFunctionFailedMsg("bm25 output field must be arrow binary array, got %T", arr)
 	}
 	memorySize := 0
 	for i := 0; i < binaryArray.Len(); i++ {
@@ -756,6 +953,34 @@ type bumpSchemaVersionBatchWriter interface {
 	GetWrittenUncompressed() uint64
 	AsNewColumnGroups()
 	Close() (packed.WriterOutput, error)
+	Abort()
+}
+
+type bumpSchemaVersionWriterLease struct {
+	writer    bumpSchemaVersionBatchWriter
+	exhausted bool
+}
+
+func (l *bumpSchemaVersionWriterLease) Close() (packed.WriterOutput, error) {
+	if l.exhausted {
+		return nil, merr.WrapErrServiceInternalMsg("schema bump writer lease already consumed")
+	}
+	out, err := l.writer.Close()
+	if err != nil {
+		// Keep the lease unconsumed so the deferred Cleanup aborts the writer;
+		// do not rely on the underlying Close to release native resources.
+		return nil, err
+	}
+	l.exhausted = true
+	return out, nil
+}
+
+func (l *bumpSchemaVersionWriterLease) Cleanup() {
+	if l == nil || l.exhausted {
+		return
+	}
+	l.exhausted = true
+	l.writer.Abort()
 }
 
 type bumpSchemaVersionWriterResult struct {
@@ -785,14 +1010,14 @@ func (t *bumpSchemaVersionCompactionTask) setupWriter(outputFields []*schemapb.F
 
 	basePath, existingVersion, err := packed.UnmarshalManifestPath(segment.GetManifest())
 	if err != nil {
-		return nil, merr.WrapErrDataIntegrityMsg("failed to parse existing manifest for schema bump: %s", err.Error())
+		return nil, merr.WrapErrDataIntegrity(err, "failed to parse existing manifest for schema bump")
 	}
 	writerResult, err := t.newV3WriterResult(outputSchema, newColumnGroups, segment, collectionID, basePath, existingVersion)
 	if err != nil {
 		return nil, err
 	}
 	writerResult.writer.AsNewColumnGroups()
-	mlog.Info(t.ctx, "[schema-bump-partial-writer] writer setup",
+	mlog.Info(t.ctx, "schema bump partial writer setup",
 		mlog.Int64("baseVersion", existingVersion),
 		mlog.String("basePath", basePath),
 		mlog.Int("outputFieldCount", len(outputFields)),
@@ -803,7 +1028,7 @@ func (t *bumpSchemaVersionCompactionTask) setupWriter(outputFields []*schemapb.F
 
 func (t *bumpSchemaVersionCompactionTask) newV3WriterResult(schema *schemapb.CollectionSchema, columnGroups []storagecommon.ColumnGroup, segment *datapb.CompactionSegmentBinlogs, collectionID int64, basePath string, baseVersion int64) (*bumpSchemaVersionWriterResult, error) {
 	if segment.GetStorageVersion() < storage.StorageV3 || segment.GetManifest() == "" {
-		return nil, merr.WrapErrParameterInvalidMsg("schema bump compaction requires a StorageV3 segment with manifest")
+		return nil, merr.WrapErrServiceInternalMsg("schema bump compaction requires a StorageV3 segment with manifest")
 	}
 
 	pluginContext, err := hookutil.GetCPluginContext(t.plan.GetPluginContext(), collectionID)
@@ -814,11 +1039,16 @@ func (t *bumpSchemaVersionCompactionTask) newV3WriterResult(schema *schemapb.Col
 	writerFormat := paramtable.Get().DataNodeCfg.StorageFormat.GetValue()
 	columnGroups = storagecommon.FillColumnGroupFormats(columnGroups, writerFormat)
 	schemaBasedFormats := storagecommon.ColumnGroupFormats(columnGroups, writerFormat)
-	writer, err := storage.NewPartialPackedRecordBatchWriter(basePath, schema, int64(t.compactionParams.BinLogMaxSize), packed.DefaultMultiPartUploadSize, columnGroups, t.compactionParams.StorageConfig, pluginContext, writerFormat, schemaBasedFormats)
+	var writer bumpSchemaVersionBatchWriter
+	if schemaContainsTextField(schema) {
+		writer, err = storage.NewPartialPackedRecordBatchWriterWithTextRefsAsBinary(basePath, schema, int64(t.compactionParams.BinLogMaxSize), packed.DefaultMultiPartUploadSize, columnGroups, t.compactionParams.StorageConfig, pluginContext, writerFormat, schemaBasedFormats)
+	} else {
+		writer, err = storage.NewPartialPackedRecordBatchWriter(basePath, schema, int64(t.compactionParams.BinLogMaxSize), packed.DefaultMultiPartUploadSize, columnGroups, t.compactionParams.StorageConfig, pluginContext, writerFormat, schemaBasedFormats)
+	}
 	if err != nil {
 		return nil, err
 	}
-	mlog.Info(t.ctx, "[schema-bump-partial-writer] partial manifest writer created",
+	mlog.Info(t.ctx, "schema bump partial manifest writer created",
 		mlog.Int64("baseVersion", baseVersion),
 		mlog.Int("schemaFieldCount", len(schema.GetFields())),
 		mlog.Int("columnGroupCount", len(columnGroups)),
@@ -831,6 +1061,15 @@ func (t *bumpSchemaVersionCompactionTask) newV3WriterResult(schema *schemapb.Col
 		basePath:       basePath,
 		baseVersion:    baseVersion,
 	}, nil
+}
+
+func schemaContainsTextField(schema *schemapb.CollectionSchema) bool {
+	for _, field := range typeutil.GetAllFieldSchemas(schema) {
+		if field.GetDataType() == schemapb.DataType_Text {
+			return true
+		}
+	}
+	return false
 }
 
 func (t *bumpSchemaVersionCompactionTask) updateStats(stats *storage.BM25Stats, outputFieldID int64, writerResult *bumpSchemaVersionWriterResult) error {
@@ -874,7 +1113,7 @@ func (t *bumpSchemaVersionCompactionTask) addV3Stats(prefix string, fieldID int6
 // DataCoord — including index building.
 // This result is therefore load-bearing: dropping it silently makes the
 // materialized field permanently un-indexable.
-func (t *bumpSchemaVersionCompactionTask) buildNewInsertLogsV3(writerResult *bumpSchemaVersionWriterResult, sparseFieldMemorySizes map[int64]int, totalRows int64) ([]*datapb.FieldBinlog, error) {
+func (t *bumpSchemaVersionCompactionTask) buildNewInsertLogsV3(writerResult *bumpSchemaVersionWriterResult, fieldMemorySizes map[int64]int, totalRows int64) ([]*datapb.FieldBinlog, error) {
 	logIDStart, _, err := t.logIDAlloc.Alloc(uint32(len(writerResult.columnGroups)))
 	if err != nil {
 		return nil, err
@@ -888,7 +1127,7 @@ func (t *bumpSchemaVersionCompactionTask) buildNewInsertLogsV3(writerResult *bum
 			Format:      columnGroup.Format,
 			Binlogs: []*datapb.Binlog{
 				{
-					MemorySize: int64(sparseFieldMemorySizes[fieldID]),
+					MemorySize: int64(fieldMemorySizes[fieldID]),
 					EntriesNum: totalRows,
 					LogID:      logIDStart + int64(i),
 				},
@@ -899,58 +1138,14 @@ func (t *bumpSchemaVersionCompactionTask) buildNewInsertLogsV3(writerResult *bum
 	return storage.SortFieldBinlogs(newInsertLogs), nil
 }
 
-func (t *bumpSchemaVersionCompactionTask) preserveDeltaLogsV3(segment *datapb.CompactionSegmentBinlogs, manifestPath string) (string, error) {
-	deltaPaths, err := packed.GetDeltaLogPathsFromManifest(segment.GetManifest(), t.compactionParams.StorageConfig)
-	if err != nil {
-		return "", merr.Wrap(err, "failed to read V3 delta logs from existing manifest")
-	}
-	if len(deltaPaths) == 0 {
-		return manifestPath, nil
-	}
-
-	deltaSummaries := make([]*datapb.Binlog, 0, len(deltaPaths))
-	for _, fieldBinlog := range segment.GetDeltalogs() {
-		deltaSummaries = append(deltaSummaries, fieldBinlog.GetBinlogs()...)
-	}
-	if len(deltaSummaries) != len(deltaPaths) {
-		return "", merr.WrapErrServiceInternalMsg("V3 delta manifest path count %d does not match segment delta summary count %d", len(deltaPaths), len(deltaSummaries))
-	}
-
-	basePath, _, err := packed.UnmarshalManifestPath(manifestPath)
-	if err != nil {
-		return "", merr.WrapErrDataIntegrityMsg("failed to parse new V3 manifest for delta preservation: %s", err.Error())
-	}
-
-	deltaEntries := make([]packed.DeltaLogEntry, 0, len(deltaPaths))
-	for i, deltaPath := range deltaPaths {
-		newDeltaPath := metautil.BuildDeltaLogPathV3(basePath, deltaSummaries[i].GetLogID())
-		if newDeltaPath != deltaPath {
-			if err := t.chunkManager.Copy(t.ctx, deltaPath, newDeltaPath); err != nil {
-				return "", merr.Wrap(err, "failed to copy V3 delta log for schema bump full rewrite")
-			}
-		}
-		deltaEntries = append(deltaEntries, packed.DeltaLogEntry{
-			Path:       newDeltaPath,
-			NumEntries: deltaSummaries[i].GetEntriesNum(),
-		})
-	}
-	newManifest, err := packed.AddDeltaLogsToManifest(manifestPath, t.compactionParams.StorageConfig, deltaEntries)
-	if err != nil {
-		return "", merr.Wrap(err, "failed to preserve V3 delta logs in full rewrite manifest")
-	}
-	return newManifest, nil
-}
-
-func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx context.Context, missingFunctions []*schemapb.FunctionSchema, droppedFieldIDs []int64, existingFields map[int64]struct{}) (*datapb.CompactionPlanResult, error) {
-	// Materialization reports a Statistics INCREMENT, which is only valid
-	// because this path adds columns and never removes them. Dropped fields
-	// must go to runFullSchemaRewrite, which ships an absolute Stats. The
-	// dispatch in Compact already guarantees this; assert it so a future edit
-	// cannot silently produce an over-estimating increment.
-	if len(droppedFieldIDs) > 0 {
+func (t *bumpSchemaVersionCompactionTask) runAdditivePhysicalReconciliation(ctx context.Context, diff *schemaBumpPhysicalDiff) (*datapb.CompactionPlanResult, error) {
+	// Additive reconciliation reports a Statistics INCREMENT, which is only
+	// valid because this path appends columns and never removes them. Dropped
+	// fields must go to runFullSchemaRewrite, which ships absolute statistics.
+	if len(diff.droppedFieldIDs) > 0 {
 		return nil, merr.WrapErrServiceInternalMsg(
-			"schema bump materialization cannot run with dropped fields, planID = %d, droppedFieldIDs = %v",
-			t.GetPlanID(), droppedFieldIDs)
+			"schema bump additive reconciliation cannot run with dropped fields, planID = %d, droppedFieldIDs = %v",
+			t.GetPlanID(), diff.droppedFieldIDs)
 	}
 
 	segment := t.plan.GetSegmentBinlogs()[0]
@@ -958,13 +1153,17 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 	partitionID := segment.GetPartitionID()
 	segmentID := segment.GetSegmentID()
 
-	inputSchema, inputFieldIDs, err := t.missingFunctionInputSchema(missingFunctions)
+	inputSchema, inputFieldIDs, err := t.additiveReadSchema(diff)
 	if err != nil {
 		return nil, err
 	}
-	outputFields, outputFieldIDs, err := t.missingFunctionOutputFields(missingFunctions, existingFields)
-	if err != nil {
-		return nil, err
+	outputFields := diff.appendedFields()
+	if len(outputFields) == 0 {
+		return nil, merr.WrapErrServiceInternalMsg("schema bump additive reconciliation has no fields to append")
+	}
+	outputFieldIDs := make([]int64, 0, len(outputFields))
+	for _, field := range outputFields {
+		outputFieldIDs = append(outputFieldIDs, field.GetFieldID())
 	}
 
 	log := mlog.With(
@@ -988,13 +1187,13 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 	if err != nil {
 		return nil, err
 	}
+	writerLease := &bumpSchemaVersionWriterLease{writer: writerResult.writer}
+	defer writerLease.Cleanup()
 
 	log.Info(ctx, "schema bump writer setup",
 		mlog.Int64("effectiveStorageVersion", writerResult.storageVersion),
 		mlog.Int64("clusterStorageVersion", t.compactionParams.StorageVersion),
 		mlog.Bool("segmentHasManifest", segment.GetManifest() != ""),
-		mlog.Int64s("inputFieldIDs", inputFieldIDs),
-		mlog.Int64s("outputFieldIDs", outputFieldIDs),
 	)
 	_, span := otel.Tracer(typeutil.DataNodeRole).Start(ctx, "BumpSchemaVersionCompact.batchProcess")
 	statsByField := make(map[int64]*storage.BM25Stats)
@@ -1005,8 +1204,7 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 			statsByField[outputFieldID] = storage.NewBM25Stats()
 		}
 	}
-	existingFields = partialMaterializerExistingFields(t.plan.GetSchema(), missingFunctions, existingFields)
-	materializer, err := NewRecordMaterializer(t.plan.GetSchema(), missingFunctions, existingFields)
+	materializer, err := NewRecordMaterializer(t.plan.GetSchema(), diff.missingFunctions, diff.existingFields)
 	if err != nil {
 		span.End()
 		return nil, err
@@ -1043,7 +1241,10 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 			if outputCol == nil {
 				cleanupMaterializedRecord(wrapped)
 				span.End()
-				return nil, merr.WrapErrServiceInternalMsg("output field %d not found in materialized record", outputFieldID)
+				if outputField.GetIsFunctionOutput() {
+					return nil, merr.WrapErrFunctionFailedMsg("function output field %d not found in materialized record", outputFieldID)
+				}
+				return nil, merr.WrapErrServiceInternalMsg("ordinary output field %d not found in materialized record", outputFieldID)
 			}
 			batchMemSize := arrowArrayMemorySize(outputCol)
 			if stats, ok := statsByField[outputFieldID]; ok {
@@ -1066,16 +1267,22 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 			return nil, err
 		}
 		writeDuration += time.Since(writeStart)
-		log.Info(ctx, "[schema-bump-partial-writer] record batch written",
-			mlog.Int("rows", wrapped.Len()),
-			mlog.Int64("totalRowsBeforeBatch", totalRows),
-			mlog.Int("outputFieldCount", len(outputFields)),
-		)
 
 		totalRows += int64(wrapped.Len())
 		cleanupMaterializedRecord(wrapped)
 	}
 	span.End()
+	if totalRows != t.plan.GetTotalRows() {
+		return nil, merr.WrapErrDataIntegrityMsg(
+			"schema bump additive reconciliation read %d rows, expected %d",
+			totalRows, t.plan.GetTotalRows())
+	}
+	// A zero-row materialized write would manufacture physical completeness for
+	// an empty segment; fail and let the deferred lease Abort the writer.
+	if totalRows == 0 {
+		return nil, merr.WrapErrDataIntegrityMsg(
+			"schema bump additive reconciliation observed zero rows for segment %d, refusing to write an empty materialized record", segmentID)
+	}
 
 	_, span2 := otel.Tracer(typeutil.DataNodeRole).Start(ctx, "BumpSchemaVersionCompact.updateStats")
 	for outputFieldID, stats := range statsByField {
@@ -1090,7 +1297,7 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 	span2.End()
 
 	log.Info(ctx, "schema bump bm25 stats written",
-		mlog.Int("bm25StatsFieldCount", len(outputFieldIDs)),
+		mlog.Int("bm25StatsFieldCount", len(statsByField)),
 		mlog.Int64("storageVersion", writerResult.storageVersion),
 		mlog.Int("v3StatsCount", len(writerResult.v3Stats)),
 	)
@@ -1100,12 +1307,12 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 		return nil, err
 	}
 
-	writerOutput, err := writerResult.writer.Close()
-	if err != nil {
-		return nil, err
-	}
+	writerOutput, err := writerLease.Close()
 	if writerOutput != nil {
 		defer writerOutput.Destroy()
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	manifestPath, err := packed.CommitManifestUpdates(
@@ -1120,7 +1327,7 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 	if err != nil {
 		return nil, merr.Wrap(err, "failed to commit schema bump V3 manifest")
 	}
-	log.Info(ctx, "[schema-bump-partial-writer] writer output and bm25 stats committed",
+	log.Info(ctx, "schema bump writer output and bm25 stats committed",
 		mlog.String("manifestPath", manifestPath),
 		mlog.Int64("totalRows", totalRows),
 		mlog.Int("newInsertLogsCount", len(newInsertLogs)),
@@ -1155,7 +1362,7 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 		},
 		Type: t.plan.GetType(),
 	}
-	log.Info(ctx, "[schema-bump-partial-writer] compaction completed",
+	log.Info(ctx, "schema bump additive reconciliation completed",
 		mlog.Int64("numOfRows", totalRows),
 		mlog.Int("newInsertLogsCount", len(newInsertLogs)),
 		mlog.String("manifestPath", manifestPath),

--- a/internal/datanode/compactor/bump_schema_version_compactor_test.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor_test.go
@@ -18,6 +18,7 @@ package compactor
 
 import (
 	"context"
+	sio "io"
 	"math"
 	"path"
 	"strings"
@@ -27,6 +28,7 @@ import (
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/bytedance/mockey"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -83,6 +85,33 @@ type fakeBinlogRecordWriter struct {
 	statsBlobSize    int64
 	schema           *schemapb.CollectionSchema
 	writtenTimestamp []int64
+}
+
+type cleanupTrackingBatchWriter struct {
+	closeCount int
+	abortCount int
+	writeRows  []int
+	closeErr   error
+}
+
+type emptyRecordReader struct{}
+
+func (*emptyRecordReader) Next() (storage.Record, error) { return nil, sio.EOF }
+func (*emptyRecordReader) Close() error                  { return nil }
+
+func (w *cleanupTrackingBatchWriter) Write(record storage.Record) error {
+	w.writeRows = append(w.writeRows, record.Len())
+	return nil
+}
+
+func (w *cleanupTrackingBatchWriter) GetWrittenUncompressed() uint64 {
+	return 0
+}
+func (w *cleanupTrackingBatchWriter) AsNewColumnGroups() {}
+func (w *cleanupTrackingBatchWriter) Abort()             { w.abortCount++ }
+func (w *cleanupTrackingBatchWriter) Close() (packed.WriterOutput, error) {
+	w.closeCount++
+	return nil, w.closeErr
 }
 
 func (w *fakeBinlogRecordWriter) Write(r storage.Record) error {
@@ -496,6 +525,383 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionSu
 	}
 }
 
+func (s *BumpSchemaVersionCompactionTaskSuite) TestAdditiveReconciliationPersistsOrdinaryNullableField() {
+	const ordinaryFieldID = int64(103)
+	s.task.plan.Schema.Functions = nil
+	s.task.plan.Schema.Fields = s.task.plan.Schema.Fields[:4]
+	s.task.plan.Schema.Fields = append(s.task.plan.Schema.Fields, &schemapb.FieldSchema{
+		FieldID:  ordinaryFieldID,
+		Name:     "added_nullable",
+		DataType: schemapb.DataType_Int64,
+		Nullable: true,
+	})
+	s.prepareBumpSchemaVersionCompaction()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	segment := result.GetSegments()[0]
+	s.EqualValues(3, segment.GetNumOfRows())
+	s.NotEqual(segment.GetBaseManifest(), segment.GetManifest())
+	s.Require().Len(segment.GetInsertLogs(), 1)
+	s.EqualValues(ordinaryFieldID, segment.GetInsertLogs()[0].GetFieldID())
+	s.EqualValues(3, segment.GetInsertLogs()[0].GetBinlogs()[0].GetEntriesNum())
+	s.EqualValues(3, segment.GetStats().GetNullCounts()[ordinaryFieldID])
+
+	fields, err := packed.GetManifestFieldIDs(segment.GetManifest(), s.task.compactionParams.StorageConfig)
+	s.Require().NoError(err)
+	s.Contains(fields, ordinaryFieldID)
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestAdditiveReconciliationPersistsOrdinaryDefaultField() {
+	const ordinaryFieldID = int64(103)
+	s.task.plan.Schema.Functions = nil
+	s.task.plan.Schema.Fields = s.task.plan.Schema.Fields[:4]
+	s.task.plan.Schema.Fields = append(s.task.plan.Schema.Fields, &schemapb.FieldSchema{
+		FieldID:  ordinaryFieldID,
+		Name:     "added_default",
+		DataType: schemapb.DataType_Int64,
+		Nullable: true,
+		DefaultValue: &schemapb.ValueField{Data: &schemapb.ValueField_LongData{
+			LongData: 42,
+		}},
+	})
+	s.prepareBumpSchemaVersionCompaction()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	segment := result.GetSegments()[0]
+	s.Require().Len(segment.GetInsertLogs(), 1)
+	s.EqualValues(ordinaryFieldID, segment.GetInsertLogs()[0].GetFieldID())
+	// #52781/#52807 (merged): the reader default-fills absent default-valued fields,
+	// so the added column materializes its declared default (42), not NULL.
+	s.EqualValues(0, segment.GetStats().GetNullCounts()[ordinaryFieldID])
+
+	reader, err := storage.NewManifestRecordReader(context.Background(), segment.GetManifest(), &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{typeutil.GetField(s.task.plan.GetSchema(), ordinaryFieldID)},
+	}, storage.WithCollectionID(1), storage.WithVersion(storage.StorageV3), storage.WithStorageConfig(s.task.compactionParams.StorageConfig))
+	s.Require().NoError(err)
+	defer reader.Close()
+	record, err := reader.Next()
+	s.Require().NoError(err)
+	column, ok := record.Column(ordinaryFieldID).(*array.Int64)
+	s.Require().True(ok)
+	s.Equal(3, column.Len())
+	for i := 0; i < column.Len(); i++ {
+		s.False(column.IsNull(i))
+		s.EqualValues(42, column.Value(i))
+	}
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestAdditiveReconciliationPersistsTTLDefaultWithoutFiltering() {
+	const ttlFieldID = int64(103)
+	expireAt := s.task.currentTime.Add(-time.Hour).UnixMicro()
+	s.task.plan.Schema.Functions = nil
+	s.task.plan.Schema.Fields = s.task.plan.Schema.Fields[:4]
+	s.task.plan.Schema.Fields = append(s.task.plan.Schema.Fields, &schemapb.FieldSchema{
+		FieldID:  ttlFieldID,
+		Name:     "expire_at",
+		DataType: schemapb.DataType_Timestamptz,
+		Nullable: true,
+		DefaultValue: &schemapb.ValueField{Data: &schemapb.ValueField_TimestamptzData{
+			TimestamptzData: expireAt,
+		}},
+	})
+	s.task.plan.Schema.Properties = append(s.task.plan.Schema.Properties, &commonpb.KeyValuePair{
+		Key: common.CollectionTTLFieldKey, Value: "expire_at",
+	})
+	s.prepareBumpSchemaVersionCompaction()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	segment := result.GetSegments()[0]
+	s.EqualValues(3, segment.GetNumOfRows(), "an added TTL field must not filter rows during additive reconciliation")
+	// #52781/#52807 (merged): the reader default-fills the added TTL field with its
+	// declared default; additive reconciliation must NOT apply TTL filtering, so
+	// all rows survive even though that default is already expired.
+	s.EqualValues(0, segment.GetStats().GetNullCounts()[ttlFieldID])
+
+	reader, err := storage.NewManifestRecordReader(context.Background(), segment.GetManifest(), &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{typeutil.GetField(s.task.plan.GetSchema(), ttlFieldID)},
+	}, storage.WithCollectionID(1), storage.WithVersion(storage.StorageV3), storage.WithStorageConfig(s.task.compactionParams.StorageConfig))
+	s.Require().NoError(err)
+	defer reader.Close()
+	record, err := reader.Next()
+	s.Require().NoError(err)
+	column := record.Column(ttlFieldID).(*array.Int64)
+	for i := 0; i < column.Len(); i++ {
+		s.False(column.IsNull(i))
+		s.EqualValues(expireAt, column.Value(i))
+	}
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestAdditiveReconciliationPersistsNullableTTLWithoutFiltering() {
+	const ttlFieldID = int64(103)
+	s.task.plan.Schema.Functions = nil
+	s.task.plan.Schema.Fields = s.task.plan.Schema.Fields[:4]
+	s.task.plan.Schema.Fields = append(s.task.plan.Schema.Fields, &schemapb.FieldSchema{
+		FieldID: ttlFieldID, Name: "expire_at", DataType: schemapb.DataType_Timestamptz, Nullable: true,
+	})
+	s.task.plan.Schema.Properties = append(s.task.plan.Schema.Properties, &commonpb.KeyValuePair{
+		Key: common.CollectionTTLFieldKey, Value: "expire_at",
+	})
+	s.prepareBumpSchemaVersionCompaction()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	segment := result.GetSegments()[0]
+	s.EqualValues(3, segment.GetNumOfRows(), "an added nullable TTL field must not filter rows during additive reconciliation")
+	s.EqualValues(3, segment.GetStats().GetNullCounts()[ttlFieldID])
+
+	reader, err := storage.NewManifestRecordReader(context.Background(), segment.GetManifest(), &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{typeutil.GetField(s.task.plan.GetSchema(), ttlFieldID)},
+	}, storage.WithCollectionID(1), storage.WithVersion(storage.StorageV3), storage.WithStorageConfig(s.task.compactionParams.StorageConfig))
+	s.Require().NoError(err)
+	defer reader.Close()
+	record, err := reader.Next()
+	s.Require().NoError(err)
+	column := record.Column(ttlFieldID).(*array.Int64)
+	s.Equal(3, column.Len())
+	s.Equal(3, column.NullN())
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestAdditiveReconciliationPersistsNullableStructChildren() {
+	const structFieldID = int64(200)
+	children := []*schemapb.FieldSchema{
+		{
+			FieldID:     201,
+			Name:        "profile[tags]",
+			DataType:    schemapb.DataType_Array,
+			ElementType: schemapb.DataType_VarChar,
+			Nullable:    true,
+			TypeParams: []*commonpb.KeyValuePair{{
+				Key: common.MaxCapacityKey, Value: "16",
+			}},
+		},
+		{
+			FieldID:     202,
+			Name:        "profile[scores]",
+			DataType:    schemapb.DataType_Array,
+			ElementType: schemapb.DataType_Int64,
+			Nullable:    true,
+			TypeParams: []*commonpb.KeyValuePair{{
+				Key: common.MaxCapacityKey, Value: "16",
+			}},
+		},
+	}
+	s.task.plan.Schema.Functions = nil
+	s.task.plan.Schema.Fields = s.task.plan.Schema.Fields[:4]
+	s.task.plan.Schema.StructArrayFields = []*schemapb.StructArrayFieldSchema{{
+		FieldID:  structFieldID,
+		Name:     "profile",
+		Fields:   children,
+		Nullable: true,
+	}}
+	s.prepareBumpSchemaVersionCompaction()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	segment := result.GetSegments()[0]
+	s.EqualValues(3, segment.GetNumOfRows())
+	s.Require().Len(segment.GetInsertLogs(), 2)
+	s.ElementsMatch([]int64{201, 202}, lo.Map(segment.GetInsertLogs(), func(fb *datapb.FieldBinlog, _ int) int64 {
+		return fb.GetFieldID()
+	}))
+
+	manifestFields, err := packed.GetManifestFieldIDs(segment.GetManifest(), s.task.compactionParams.StorageConfig)
+	s.Require().NoError(err)
+	s.NotContains(manifestFields, structFieldID)
+	for _, child := range children {
+		s.Contains(manifestFields, child.GetFieldID())
+		s.EqualValues(3, segment.GetStats().GetNullCounts()[child.GetFieldID()])
+	}
+
+	readSchema := &schemapb.CollectionSchema{StructArrayFields: s.task.plan.Schema.GetStructArrayFields()}
+	reader, err := storage.NewManifestRecordReader(context.Background(), segment.GetManifest(), readSchema,
+		storage.WithCollectionID(1),
+		storage.WithVersion(storage.StorageV3),
+		storage.WithStorageConfig(s.task.compactionParams.StorageConfig),
+	)
+	s.Require().NoError(err)
+	defer reader.Close()
+	record, err := reader.Next()
+	s.Require().NoError(err)
+	for _, child := range children {
+		column := record.Column(child.GetFieldID())
+		s.Require().NotNil(column)
+		s.Equal(3, column.Len())
+		s.Equal(3, column.NullN())
+	}
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestAdditiveReconciliationPrefillsMissingFunctionInput() {
+	const addedInputFieldID = int64(103)
+	outputField := typeutil.GetField(s.task.plan.GetSchema(), 102)
+	s.task.plan.Schema.Fields = []*schemapb.FieldSchema{
+		s.task.plan.Schema.Fields[0],
+		s.task.plan.Schema.Fields[1],
+		s.task.plan.Schema.Fields[2],
+		s.task.plan.Schema.Fields[3],
+		{
+			FieldID:  addedInputFieldID,
+			Name:     "added_input",
+			DataType: schemapb.DataType_VarChar,
+			Nullable: true,
+			TypeParams: []*commonpb.KeyValuePair{{
+				Key: common.MaxLengthKey, Value: "128",
+			}},
+		},
+		outputField,
+	}
+	s.task.plan.Schema.Functions[0].InputFieldIds = []int64{addedInputFieldID}
+	s.task.plan.Schema.Functions[0].InputFieldNames = []string{"added_input"}
+	s.prepareBumpSchemaVersionCompaction()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	segment := result.GetSegments()[0]
+	s.Require().Len(segment.GetInsertLogs(), 2)
+	s.ElementsMatch([]int64{102, addedInputFieldID}, lo.Map(segment.GetInsertLogs(), func(fb *datapb.FieldBinlog, _ int) int64 {
+		return fb.GetFieldID()
+	}))
+	s.EqualValues(3, segment.GetStats().GetNullCounts()[addedInputFieldID])
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestAdditiveReconciliationPrefillsMissingMultiAnalyzerByField() {
+	const byFieldID = int64(103)
+	textField := typeutil.GetField(s.task.plan.GetSchema(), 101)
+	textField.TypeParams = append(textField.GetTypeParams(),
+		&commonpb.KeyValuePair{Key: common.EnableAnalyzerKey, Value: "true"},
+		&commonpb.KeyValuePair{Key: "multi_analyzer_params", Value: `{"by_field":"lang","analyzers":{"default":{"type":"standard"}}}`},
+	)
+	s.task.plan.Schema.Fields = append(s.task.plan.Schema.Fields, &schemapb.FieldSchema{
+		FieldID: byFieldID, Name: "lang", DataType: schemapb.DataType_VarChar, Nullable: true,
+		TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "32"}},
+	})
+	s.prepareBumpSchemaVersionCompaction()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	segment := result.GetSegments()[0]
+	s.ElementsMatch([]int64{102, byFieldID}, lo.Map(segment.GetInsertLogs(), func(fb *datapb.FieldBinlog, _ int) int64 {
+		return fb.GetFieldID()
+	}))
+	s.EqualValues(3, segment.GetStats().GetNullCounts()[byFieldID])
+	s.EqualValues(3, segment.GetNumOfRows())
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestAdditiveReconciliationSkipsPresentFunctionOutput() {
+	const ordinaryFieldID = int64(103)
+	s.task.plan.Schema.Fields = append(s.task.plan.Schema.Fields, &schemapb.FieldSchema{
+		FieldID: ordinaryFieldID, Name: "added", DataType: schemapb.DataType_Int64, Nullable: true,
+	})
+	physicalFields := append(schemaBumpBaseFields(), typeutil.GetField(s.task.plan.GetSchema(), 102))
+	s.initSegBufferForSchemaBumpWithFields(100, physicalFields, func(_ int, value map[int64]interface{}) {
+		value[102] = typeutil.CreateAndSortSparseFloatRow(map[uint32]float32{1: 1})
+	})
+	s.finishBumpSchemaVersionSegment()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	segment := result.GetSegments()[0]
+	s.Require().Len(segment.GetInsertLogs(), 1)
+	s.EqualValues(ordinaryFieldID, segment.GetInsertLogs()[0].GetFieldID())
+	s.EqualValues(3, segment.GetStats().GetNullCounts()[ordinaryFieldID])
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestAdditiveReconciliationPersistsNullableTextAsBinary() {
+	const textFieldID = int64(103)
+	s.task.plan.Schema.Functions = nil
+	s.task.plan.Schema.Fields = s.task.plan.Schema.Fields[:4]
+	s.task.plan.Schema.Fields = append(s.task.plan.Schema.Fields, &schemapb.FieldSchema{
+		FieldID:  textFieldID,
+		Name:     "added_text",
+		DataType: schemapb.DataType_Text,
+		Nullable: true,
+		TypeParams: []*commonpb.KeyValuePair{{
+			Key: common.MaxLengthKey, Value: "65535",
+		}},
+	})
+	s.prepareBumpSchemaVersionCompaction()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	segment := result.GetSegments()[0]
+	s.Require().Len(segment.GetInsertLogs(), 1)
+	s.EqualValues(textFieldID, segment.GetInsertLogs()[0].GetFieldID())
+	s.EqualValues(3, segment.GetStats().GetNullCounts()[textFieldID])
+	s.Empty(segment.GetTextStatsLogs())
+
+	readSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		typeutil.GetField(s.task.plan.GetSchema(), textFieldID),
+	}}
+	reader, err := storage.NewManifestRecordReader(context.Background(), segment.GetManifest(), readSchema,
+		storage.WithCollectionID(1),
+		storage.WithVersion(storage.StorageV3),
+		storage.WithStorageConfig(s.task.compactionParams.StorageConfig),
+	)
+	s.Require().NoError(err)
+	defer reader.Close()
+	record, err := reader.Next()
+	s.Require().NoError(err)
+	textColumn, ok := record.Column(textFieldID).(*array.Binary)
+	s.Require().True(ok)
+	s.Equal(3, textColumn.Len())
+	s.Equal(3, textColumn.NullN())
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestAdditiveReconciliationRejectsRowCountMismatch() {
+	const ordinaryFieldID = int64(103)
+	s.task.plan.Schema.Functions = nil
+	s.task.plan.Schema.Fields = s.task.plan.Schema.Fields[:4]
+	s.task.plan.Schema.Fields = append(s.task.plan.Schema.Fields, &schemapb.FieldSchema{
+		FieldID:  ordinaryFieldID,
+		Name:     "added_nullable",
+		DataType: schemapb.DataType_Int64,
+		Nullable: true,
+	})
+	s.prepareBumpSchemaVersionCompaction()
+	s.task.plan.TotalRows = 4
+
+	_, err := s.task.Compact()
+	s.Require().Error(err)
+	s.ErrorIs(err, merr.ErrDataIntegrity)
+	s.ErrorContains(err, "read 3 rows, expected 4")
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestAdditiveReconciliationAbortsWriterOnRowCountMismatch() {
+	const ordinaryFieldID = int64(103)
+	s.task.plan.Schema.Functions = nil
+	s.task.plan.Schema.Fields = s.task.plan.Schema.Fields[:4]
+	s.task.plan.Schema.Fields = append(s.task.plan.Schema.Fields, &schemapb.FieldSchema{
+		FieldID:  ordinaryFieldID,
+		Name:     "added_nullable",
+		DataType: schemapb.DataType_Int64,
+		Nullable: true,
+	})
+	s.prepareBumpSchemaVersionCompaction()
+	s.task.plan.TotalRows = 4
+
+	writer := &cleanupTrackingBatchWriter{}
+	writerPatch := mockey.Mock((*bumpSchemaVersionCompactionTask).setupWriter).Return(
+		&bumpSchemaVersionWriterResult{
+			writer: writer,
+			columnGroups: []storagecommon.ColumnGroup{{
+				GroupID: ordinaryFieldID,
+				Columns: []int{0},
+				Fields:  []int64{ordinaryFieldID},
+			}},
+			storageVersion: storage.StorageV3,
+		}, nil,
+	).Build()
+	defer writerPatch.UnPatch()
+
+	_, err := s.task.Compact()
+	s.Require().Error(err)
+	s.ErrorIs(err, merr.ErrDataIntegrity)
+	s.Equal(1, writer.abortCount)
+	s.Zero(writer.closeCount)
+}
+
 // buildTextLOBTask builds a minimal schema-bump task whose schema optionally has a
 // DataType_Text field (the LOB-carrying input of a BM25 function). Only plan +
 // compactionParams are needed to exercise the LOB wiring (the cgo manifest helpers
@@ -887,6 +1293,57 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteFillsMissingNullab
 	s.True(found, "missing nullable TEXT field must be backfilled into the rewritten segment")
 }
 
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteMaterializesAbsentTTLDefaultWithoutSourceProbe() {
+	const ttlFieldID = int64(104)
+	expireAt := s.task.currentTime.Add(-time.Hour).UnixMicro()
+	s.task.plan.Schema.Fields = append(s.task.plan.Schema.Fields, &schemapb.FieldSchema{
+		FieldID:  ttlFieldID,
+		Name:     "expire_at",
+		DataType: schemapb.DataType_Timestamptz,
+		Nullable: true,
+		DefaultValue: &schemapb.ValueField{Data: &schemapb.ValueField_TimestamptzData{
+			TimestamptzData: expireAt,
+		}},
+	})
+	s.task.plan.Schema.Properties = append(s.task.plan.Schema.Properties, &commonpb.KeyValuePair{
+		Key: common.CollectionTTLFieldKey, Value: "expire_at",
+	})
+	params, err := compaction.GenerateJSONParams(s.task.plan.GetSchema())
+	s.Require().NoError(err)
+	s.task.plan.JsonParams = params
+
+	// Field 103 exists only in the source, so the schema bump takes the full
+	// rewrite path while the target TTL field is still absent from that source.
+	s.prepareBumpSchemaVersionCompactionWithDroppedField()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	segment := result.GetSegments()[0]
+	s.EqualValues(3, segment.GetNumOfRows())
+
+	readSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		typeutil.GetField(s.task.plan.GetSchema(), ttlFieldID),
+	}}
+	reader, err := storage.NewManifestRecordReader(context.Background(), segment.GetManifest(), readSchema,
+		storage.WithCollectionID(1),
+		storage.WithVersion(storage.StorageV3),
+		storage.WithStorageConfig(s.task.compactionParams.StorageConfig),
+	)
+	s.Require().NoError(err)
+	defer reader.Close()
+	record, err := reader.Next()
+	s.Require().NoError(err)
+	ttlColumn, ok := record.Column(ttlFieldID).(*array.Int64)
+	s.Require().True(ok)
+	s.Equal(3, ttlColumn.Len())
+	// #52781/#52807 (merged): the added TTL field materializes its declared default;
+	// the bump does not retroactively expire existing rows, so all three survive.
+	for i := 0; i < ttlColumn.Len(); i++ {
+		s.False(ttlColumn.IsNull(i))
+		s.EqualValues(expireAt, ttlColumn.Value(i))
+	}
+}
+
 // TestFullRewriteMergesLOBRefsBeforeBuildingTextIndex guards the ordering fixed for
 // liliu-z's review. createTextIndex reads the TEXT column through the output segment's
 // manifest, so applyLOBCompaction -- which merges the carried source LOB file references
@@ -948,12 +1405,11 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestSelectFullRewriteRecordDropsD
 	deleteTs := tsoutil.ComposeTSByTime(currentTime.Add(time.Second))
 	entityFilter := compaction.NewEntityFilter(map[any]typeutil.Timestamp{int64(2): deleteTs}, int64(time.Minute), currentTime, 0)
 
-	selection, ttlValues, err := selectFullRewriteRecord(record, pkField, entityFilter, 102, true, nil)
+	selection, err := selectFullRewriteRecord(record, pkField, entityFilter, 102, true)
 	s.Require().NoError(err)
 	s.Require().NotNil(selection)
 	s.Equal(2, selection.Len())
 	s.Equal([]rowRange{{start: 0, end: 1}, {start: 4, end: 5}}, selection.ranges)
-	s.Equal([]int64{keptTTLField, keptTTLField}, ttlValues)
 	s.Equal(1, entityFilter.GetDeletedCount())
 	s.Equal(2, entityFilter.GetExpiredCount())
 }
@@ -989,6 +1445,121 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestSchemaVersionBumpOnlyPreserve
 	s.Equal(expirQuantiles, segment.GetExpirQuantiles())
 }
 
+func (s *BumpSchemaVersionCompactionTaskSuite) TestEmptySegmentWithMissingFieldUsesAdditiveReconciliation() {
+	s.setupTest()
+	s.task.plan.TotalRows = 0
+	existingFields := map[int64]struct{}{
+		common.RowIDField:     {},
+		common.TimeStampField: {},
+		100:                   {},
+		101:                   {},
+	}
+	manifestPatch := mockey.Mock(packed.GetManifestFieldIDs).Return(existingFields, nil).Build()
+	defer manifestPatch.UnPatch()
+
+	additiveCalled := false
+	additivePatch := mockey.Mock((*bumpSchemaVersionCompactionTask).runAdditivePhysicalReconciliation).To(
+		func(_ *bumpSchemaVersionCompactionTask, _ context.Context, diff *schemaBumpPhysicalDiff) (*datapb.CompactionPlanResult, error) {
+			additiveCalled = true
+			s.Equal([]int64{102}, lo.Map(diff.missingOutputFields, func(field *schemapb.FieldSchema, _ int) int64 {
+				return field.GetFieldID()
+			}))
+			return &datapb.CompactionPlanResult{State: datapb.CompactionTaskState_completed}, nil
+		},
+	).Build()
+	defer additivePatch.UnPatch()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.True(additiveCalled)
+	s.Equal(datapb.CompactionTaskState_completed, result.GetState())
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestEmptySegmentWithDroppedFieldStillRoutesFullRewrite() {
+	s.setupTest()
+	s.task.plan.TotalRows = 0
+	const droppedFieldID = int64(103)
+	existingFields := map[int64]struct{}{
+		common.RowIDField:     {},
+		common.TimeStampField: {},
+		100:                   {},
+		101:                   {},
+		102:                   {},
+		droppedFieldID:        {},
+	}
+	manifestPatch := mockey.Mock(packed.GetManifestFieldIDs).Return(existingFields, nil).Build()
+	defer manifestPatch.UnPatch()
+
+	fullRewriteCalled := false
+	rewritePatch := mockey.Mock((*bumpSchemaVersionCompactionTask).runFullSchemaRewrite).To(
+		func(_ *bumpSchemaVersionCompactionTask, got map[int64]struct{}) (*datapb.CompactionPlanResult, error) {
+			fullRewriteCalled = true
+			s.Contains(got, droppedFieldID)
+			return &datapb.CompactionPlanResult{State: datapb.CompactionTaskState_completed}, nil
+		},
+	).Build()
+	defer rewritePatch.UnPatch()
+
+	_, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.True(fullRewriteCalled)
+}
+
+// A zero-row additive reconciliation must not fabricate physical completeness
+// by writing an empty materialized record: it fails as a data-integrity error
+// and the writer lease aborts the partial writer.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestEmptyAdditiveReconciliationFailsAndAbortsWriter() {
+	const ordinaryFieldID = int64(103)
+	s.task.plan.TotalRows = 0
+	s.task.plan.Schema.Functions = nil
+	s.task.plan.Schema.Fields = append(s.task.plan.Schema.Fields[:4], &schemapb.FieldSchema{
+		FieldID:  ordinaryFieldID,
+		Name:     "added_nullable",
+		DataType: schemapb.DataType_Int64,
+		Nullable: true,
+	})
+	segment := s.task.plan.GetSegmentBinlogs()[0]
+	segment.StorageVersion = storage.StorageV3
+	segment.Manifest = packed.MarshalManifestPath("/data/segments/1", 10)
+
+	diff := &schemaBumpPhysicalDiff{
+		existingFields: map[int64]struct{}{
+			common.RowIDField:     {},
+			common.TimeStampField: {},
+			100:                   {},
+			101:                   {},
+		},
+		absentOrdinaryFields: []*schemapb.FieldSchema{typeutil.GetField(s.task.plan.GetSchema(), ordinaryFieldID)},
+	}
+	reader := &emptyRecordReader{}
+	readerPatch := mockey.Mock((*bumpSchemaVersionCompactionTask).openRecordReader).Return(reader, diff.existingFields, nil).Build()
+	defer readerPatch.UnPatch()
+
+	writer := &cleanupTrackingBatchWriter{}
+	writerPatch := mockey.Mock((*bumpSchemaVersionCompactionTask).setupWriter).Return(
+		&bumpSchemaVersionWriterResult{
+			writer: writer,
+			columnGroups: []storagecommon.ColumnGroup{{
+				GroupID: ordinaryFieldID,
+				Columns: []int{0},
+				Fields:  []int64{ordinaryFieldID},
+			}},
+			storageVersion: storage.StorageV3,
+			basePath:       "/data/segments/1",
+			baseVersion:    10,
+		}, nil,
+	).Build()
+	defer writerPatch.UnPatch()
+
+	_, err := s.task.runAdditivePhysicalReconciliation(context.Background(), diff)
+	s.Require().Error(err)
+	s.ErrorIs(err, merr.ErrDataIntegrity)
+	s.ErrorContains(err, "observed zero rows")
+	s.Empty(writer.writeRows)
+	s.Zero(writer.closeCount)
+	s.Equal(1, writer.abortCount)
+}
+
 func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteRequiresPreallocatedSegmentID() {
 	s.task.plan.PreAllocatedSegmentIDs = nil
 	_, err := s.task.fullRewriteSegmentID()
@@ -1007,25 +1578,11 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestAppendBM25StatsFromArrowArray
 	s.ErrorContains(err, "arrow binary array")
 }
 
-func (s *BumpSchemaVersionCompactionTaskSuite) TestPreserveDeltaLogsV3CountMismatch() {
-	patch := mockey.Mock(packed.GetDeltaLogPathsFromManifest).Return([]string{"delta-1", "delta-2"}, nil).Build()
-	defer patch.UnPatch()
-
-	manifestPath, err := s.task.preserveDeltaLogsV3(&datapb.CompactionSegmentBinlogs{
-		Manifest: "old-manifest",
-		Deltalogs: []*datapb.FieldBinlog{
-			{Binlogs: []*datapb.Binlog{{LogID: 1, EntriesNum: 10}}},
-		},
-	}, packed.MarshalManifestPath("/data/segments/1", 10))
-
-	s.Empty(manifestPath)
-	s.ErrorContains(err, "V3 delta manifest path count 2 does not match segment delta summary count 1")
-}
-
 func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionWithoutFunctions() {
 	s.prepareBumpSchemaVersionCompaction()
 
 	s.task.plan.Schema.Functions = []*schemapb.FunctionSchema{}
+	s.task.plan.Schema.Fields = s.task.plan.Schema.Fields[:4]
 	result, err := s.task.Compact()
 	s.NoError(err)
 	s.NotNil(result)
@@ -1044,24 +1601,46 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionIn
 	}}
 
 	_, err := s.task.Compact()
-	s.Error(err)
-	s.Contains(err.Error(), "input field data type must be varchar")
+	s.Require().Error(err)
+	s.ErrorIs(err, merr.ErrDataIntegrity)
+	s.ErrorContains(err, "must be VarChar for schema-bump materialization")
+}
+
+// Schema-bump materialization reads persisted inputs, and a sealed StorageV3
+// Text column comes back as encoded LOB references that the runner cannot
+// decode, so the compaction-side contract admits only VarChar inputs even
+// though collection-creation validation admits Text.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestValidateMaterializationInputFieldRejectsTextInput() {
+	textField := &schemapb.FieldSchema{FieldID: 101, Name: "content", DataType: schemapb.DataType_Text}
+	for _, functionType := range []schemapb.FunctionType{schemapb.FunctionType_BM25, schemapb.FunctionType_MinHash} {
+		err := validateMaterializationInputField(&schemapb.FunctionSchema{Name: "f", Type: functionType}, textField)
+		s.Require().Error(err, functionType.String())
+		s.ErrorIs(err, merr.ErrDataIntegrity)
+		s.ErrorContains(err, "must be VarChar for schema-bump materialization")
+	}
 }
 
 func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionInvalidOutputField() {
 	s.prepareBumpSchemaVersionCompaction()
 
-	// Test with wrong output field type (VarChar instead of SparseFloatVector)
+	// Test with a missing output whose persisted field has the wrong type.
 	s.task.plan.Schema.Functions = []*schemapb.FunctionSchema{{
 		Name:           "BM25",
 		Type:           schemapb.FunctionType_BM25,
 		InputFieldIds:  []int64{101},
-		OutputFieldIds: []int64{101, 102},
+		OutputFieldIds: []int64{104},
 	}}
+	// The fixture's field 102 is no longer produced by any function; unmark it
+	// so this test exercises output-type validation, not orphan detection.
+	typeutil.GetField(s.task.plan.GetSchema(), 102).IsFunctionOutput = false
+	s.task.plan.Schema.Fields = append(s.task.plan.Schema.Fields, &schemapb.FieldSchema{
+		FieldID: 104, Name: "bad_output", DataType: schemapb.DataType_VarChar, IsFunctionOutput: true,
+	})
 
 	_, err := s.task.Compact()
-	s.Error(err)
-	s.Contains(err.Error(), "output field data type must be sparse float vector")
+	s.Require().Error(err)
+	s.ErrorIs(err, merr.ErrDataIntegrity)
+	s.ErrorContains(err, "must be SparseFloatVector")
 }
 
 func (s *BumpSchemaVersionCompactionTaskSuite) TestValidateSupportedMissingFunctionMaterializationAllowsMultipleInputFields() {
@@ -1121,8 +1700,9 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionMi
 	}}
 
 	_, err := s.task.Compact()
-	s.Error(err)
-	s.Contains(err.Error(), "output field not found in schema")
+	s.Require().Error(err)
+	s.ErrorIs(err, merr.ErrDataIntegrity)
+	s.ErrorContains(err, "output field 114 not found in persisted schema")
 }
 
 func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionInputFieldNotFound() {
@@ -1137,8 +1717,9 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionIn
 	}}
 
 	_, err := s.task.Compact()
-	s.Error(err)
-	s.Contains(err.Error(), "input field not found in schema")
+	s.Require().Error(err)
+	s.ErrorIs(err, merr.ErrDataIntegrity)
+	s.ErrorContains(err, "input field 999 not found in persisted schema")
 }
 
 func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionOutputFieldNotFound() {
@@ -1151,10 +1732,14 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionOu
 		InputFieldIds:  []int64{101},
 		OutputFieldIds: []int64{999}, // Non-existent field ID
 	}}
+	// Field 102 is no longer produced by any function; unmark it so this test
+	// exercises the output-not-found path, not orphan detection.
+	typeutil.GetField(s.task.plan.GetSchema(), 102).IsFunctionOutput = false
 
 	_, err := s.task.Compact()
-	s.Error(err)
-	s.Contains(err.Error(), "output field not found in schema")
+	s.Require().Error(err)
+	s.ErrorIs(err, merr.ErrDataIntegrity)
+	s.ErrorContains(err, "output field 999 not found in persisted schema")
 }
 
 func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionUnsupportedFunctionType() {
@@ -1169,8 +1754,9 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionUn
 	}}
 
 	_, err := s.task.Compact()
-	s.Error(err)
-	s.Contains(err.Error(), "unsupported function type")
+	s.Require().Error(err)
+	s.ErrorIs(err, merr.ErrDataIntegrity)
+	s.ErrorContains(err, "unsupported materialization type")
 }
 
 func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionEmptySegmentBinlogs() {
@@ -1309,6 +1895,130 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestBuildNewInsertLogsV3ReturnsOn
 	s.EqualValues(1000, newInsert[0].GetBinlogs()[0].GetEntriesNum())
 }
 
+func (s *BumpSchemaVersionCompactionTaskSuite) TestSchemaBumpPhysicalDiffIncludesOrdinaryAndFunctionOutputFields() {
+	s.setupTest()
+	const ordinaryFieldID = int64(103)
+	s.task.plan.Schema.Fields = append(s.task.plan.Schema.Fields, &schemapb.FieldSchema{
+		FieldID:  ordinaryFieldID,
+		Name:     "added",
+		DataType: schemapb.DataType_Int64,
+		Nullable: true,
+	})
+	existingFields := map[int64]struct{}{
+		common.RowIDField:     {},
+		common.TimeStampField: {},
+		100:                   {},
+		101:                   {},
+	}
+	manifestPatch := mockey.Mock(packed.GetManifestFieldIDs).Return(existingFields, nil).Build()
+	defer manifestPatch.UnPatch()
+
+	diff, err := s.task.schemaBumpDecision()
+	s.Require().NoError(err)
+	s.Empty(diff.droppedFieldIDs)
+	s.Require().Len(diff.absentOrdinaryFields, 1)
+	s.EqualValues(ordinaryFieldID, diff.absentOrdinaryFields[0].GetFieldID())
+	s.Require().Len(diff.missingOutputFields, 1)
+	s.EqualValues(102, diff.missingOutputFields[0].GetFieldID())
+	s.Require().Len(diff.missingFunctions, 1)
+	s.Equal(existingFields, diff.existingFields)
+
+	appended := diff.appendedFields()
+	s.Require().Len(appended, 2)
+	s.EqualValues(ordinaryFieldID, appended[0].GetFieldID())
+	s.EqualValues(102, appended[1].GetFieldID())
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestSchemaBumpPhysicalDiffSkipsPresentOutputWhenOrdinaryFieldIsAbsent() {
+	s.setupTest()
+	const ordinaryFieldID = int64(103)
+	s.task.plan.Schema.Fields = append(s.task.plan.Schema.Fields, &schemapb.FieldSchema{
+		FieldID: ordinaryFieldID, Name: "added", DataType: schemapb.DataType_Int64, Nullable: true,
+	})
+	existingFields := map[int64]struct{}{
+		common.RowIDField: {}, common.TimeStampField: {}, 100: {}, 101: {}, 102: {},
+	}
+	manifestPatch := mockey.Mock(packed.GetManifestFieldIDs).Return(existingFields, nil).Build()
+	defer manifestPatch.UnPatch()
+
+	diff, err := s.task.schemaBumpDecision()
+	s.Require().NoError(err)
+	s.Require().Len(diff.absentOrdinaryFields, 1)
+	s.EqualValues(ordinaryFieldID, diff.absentOrdinaryFields[0].GetFieldID())
+	s.Empty(diff.missingOutputFields)
+	s.Empty(diff.missingFunctions)
+	s.Equal([]int64{ordinaryFieldID}, lo.Map(diff.appendedFields(), func(field *schemapb.FieldSchema, _ int) int64 {
+		return field.GetFieldID()
+	}))
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestAdditiveReadSchemaAnchorPlusReaderFilledAbsents() {
+	s.setupTest()
+	var absentInput *schemapb.FieldSchema
+	for _, field := range s.task.plan.GetSchema().GetFields() {
+		if field.GetFieldID() == 101 {
+			absentInput = field
+		}
+	}
+	s.Require().NotNil(absentInput)
+	diff := &schemaBumpPhysicalDiff{
+		existingFields: map[int64]struct{}{
+			common.RowIDField:     {},
+			common.TimeStampField: {},
+			100:                   {},
+			// Function input 101 is intentionally absent.
+		},
+		missingFunctions:     s.task.plan.GetSchema().GetFunctions(),
+		absentOrdinaryFields: []*schemapb.FieldSchema{absentInput},
+	}
+
+	readSchema, logicalInputFieldIDs, err := s.task.additiveReadSchema(diff)
+	s.Require().NoError(err)
+	s.Equal([]int64{101}, logicalInputFieldIDs)
+	// The physical anchor is read as-is; the absent ordinary input stays in the
+	// read schema so the reader fills it (default/null) for function execution.
+	s.ElementsMatch([]int64{common.RowIDField, 101}, lo.Map(readSchema.GetFields(), func(field *schemapb.FieldSchema, _ int) int64 {
+		return field.GetFieldID()
+	}))
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestAdditiveReadSchemaRejectsMissingSystemAnchor() {
+	s.setupTest()
+	_, _, err := s.task.additiveReadSchema(&schemaBumpPhysicalDiff{
+		existingFields: map[int64]struct{}{100: {}},
+	})
+	s.Require().Error(err)
+	s.ErrorIs(err, merr.ErrDataIntegrity)
+	s.ErrorContains(err, "physical RowID or Timestamp anchor")
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestSchemaContainsTextField() {
+	s.False(schemaContainsTextField(&schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, DataType: schemapb.DataType_Int64},
+	}}))
+	s.True(schemaContainsTextField(&schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 101, DataType: schemapb.DataType_Text},
+	}}))
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestSchemaBumpPhysicalDiffRejectsOrphanFunctionOutput() {
+	s.setupTest()
+	s.task.plan.Schema.Functions = nil
+	existingFields := map[int64]struct{}{
+		common.RowIDField:     {},
+		common.TimeStampField: {},
+		100:                   {},
+		101:                   {},
+	}
+	manifestPatch := mockey.Mock(packed.GetManifestFieldIDs).Return(existingFields, nil).Build()
+	defer manifestPatch.UnPatch()
+
+	_, err := s.task.schemaBumpDecision()
+	s.Require().Error(err)
+	s.ErrorIs(err, merr.ErrDataIntegrity)
+	s.ErrorContains(err, "has no producing function")
+}
+
 // TestMaterializationStatsDeltaIgnoresPlanArrays is the regression test for
 // issue #51729: the increment must be identical whether or not the plan
 // carries the input segment's FieldBinlog arrays. After #50410 a recovered
@@ -1333,7 +2043,7 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestMaterializationStatsDeltaIgno
 	s.EqualValues(0, got.GetDeltaBinlogSize())
 }
 
-func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionOutputFieldsSelectsAllOutputsOnPartialState() {
+func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionMaterializationsRejectsPartialState() {
 	s.setupTest()
 	schema := schemaBumpMultiOutputBM25Schema()
 	s.task.plan.Schema = schema
@@ -1345,29 +2055,10 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionOutputFieldsSe
 		102:                   {},
 	}
 
-	outputFields, outputFieldIDs, err := s.task.missingFunctionOutputFields(schema.GetFunctions(), existingFields)
-	s.NoError(err)
-
-	s.Equal([]int64{102, 103}, outputFieldIDs)
-	s.Require().Len(outputFields, 2)
-	s.Equal(int64(102), outputFields[0].GetFieldID())
-	s.Equal(int64(103), outputFields[1].GetFieldID())
-}
-
-func (s *BumpSchemaVersionCompactionTaskSuite) TestPartialMaterializerExistingFieldsTreatsAllFunctionOutputsAsMissing() {
-	schema := schemaBumpMultiOutputBM25Schema()
-	existingFields := map[int64]struct{}{
-		common.RowIDField:     {},
-		common.TimeStampField: {},
-		100:                   {},
-		101:                   {},
-		102:                   {},
-	}
-
-	materializerFields := partialMaterializerExistingFields(schema, schema.GetFunctions(), existingFields)
-
-	s.NotContains(materializerFields, int64(102))
-	s.NotContains(materializerFields, int64(103))
+	_, _, err := missingFunctionMaterializations(schema, existingFields)
+	s.Require().Error(err)
+	s.ErrorIs(err, merr.ErrDataIntegrity)
+	s.ErrorContains(err, "partially materialized output fields")
 }
 
 // Existing BM25 fixtures expose one output; these tests need a partial multi-output state.
@@ -1419,11 +2110,9 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestGetStorageConfig() {
 func (s *BumpSchemaVersionCompactionTaskSuite) TestMaterializationRejectsDroppedFields() {
 	s.setupTest()
 
-	_, err := s.task.runMissingFunctionMaterialization(
+	_, err := s.task.runAdditivePhysicalReconciliation(
 		context.Background(),
-		nil,
-		[]int64{101},
-		map[int64]struct{}{},
+		&schemaBumpPhysicalDiff{droppedFieldIDs: []int64{101}},
 	)
 	s.Error(err)
 	s.ErrorIs(err, merr.ErrServiceInternal)
@@ -1507,4 +2196,29 @@ func TestNewCompactionSegmentRecordReaderWithFieldsThreadsPresentFields(t *testi
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, existing, got)
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionInputSchemaIncludesMultiAnalyzerByField() {
+	functionSchema := &schemapb.FunctionSchema{
+		Name: "BM25", Type: schemapb.FunctionType_BM25,
+		InputFieldIds: []int64{101}, OutputFieldIds: []int64{102},
+	}
+	s.task.plan.Schema = &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.EnableAnalyzerKey, Value: "true"},
+				{Key: "multi_analyzer_params", Value: `{"by_field":"lang"}`},
+			}},
+			{FieldID: 102, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector},
+			{FieldID: 103, Name: "lang", DataType: schemapb.DataType_VarChar, Nullable: true},
+		},
+		Functions: []*schemapb.FunctionSchema{functionSchema},
+	}
+
+	inputSchema, fieldIDs, err := s.task.missingFunctionInputSchema([]*schemapb.FunctionSchema{functionSchema})
+	s.Require().NoError(err)
+	s.Equal([]int64{101, 103}, fieldIDs)
+	s.Equal([]int64{101, 103}, lo.Map(inputSchema.GetFields(), func(field *schemapb.FieldSchema, _ int) int64 {
+		return field.GetFieldID()
+	}))
 }

--- a/internal/datanode/compactor/bump_schema_version_ut_test.go
+++ b/internal/datanode/compactor/bump_schema_version_ut_test.go
@@ -1,0 +1,2550 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compactor
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	sio "io"
+	"math"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/bytedance/mockey"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/allocator"
+	"github.com/milvus-io/milvus/internal/compaction"
+	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
+	"github.com/milvus-io/milvus/internal/mocks/flushcommon/mock_util"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagecommon"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/internal/util/function"
+	"github.com/milvus-io/milvus/internal/util/hookutil"
+	"github.com/milvus-io/milvus/internal/util/initcore"
+	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+// ============================================================================
+// Fixture: real StorageV3 source segments, deltalogs, golden helpers
+// ============================================================================
+// ---------------------------------------------------------------------------
+// Environment
+// ---------------------------------------------------------------------------
+
+// setupBumpUTEnv points storage at a per-test local temp dir, mirroring the
+// existing suite fixture (see BumpSchemaVersionCompactionTaskSuite.SetupTest).
+func setupBumpUTEnv(t *testing.T) {
+	paramtable.Get().Save("common.storage.enablev2", "true")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.StorageType.Key, "local")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "false")
+	paramtable.Get().Save(paramtable.Get().LocalStorageCfg.Path.Key, t.TempDir())
+	initcore.InitStorageV2FileSystem(paramtable.Get())
+	t.Cleanup(func() {
+		paramtable.Get().Reset(paramtable.Get().CommonCfg.StorageType.Key)
+		paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
+		paramtable.Get().Reset(paramtable.Get().LocalStorageCfg.Path.Key)
+		paramtable.Get().Reset("common.storage.enablev2")
+		initcore.CleanArrowFileSystem()
+	})
+}
+
+// ---------------------------------------------------------------------------
+// F1: fixture builder
+// ---------------------------------------------------------------------------
+
+const (
+	bumpFxPKField   = int64(100)
+	bumpFxTextField = int64(101)
+)
+
+type fixtureRow struct {
+	pk     any
+	ts     uint64
+	values map[int64]any // by source field ID, excludes system fields
+	kept   bool          // expected to survive full-rewrite filtering
+}
+
+type fixtureSpec struct {
+	rows             int
+	varCharPK        bool
+	noSourceText     bool                    // exclude the base text field from the physically written source
+	extraFields      []*schemapb.FieldSchema // physically written source fields beyond the base set
+	fill             func(i int, ts uint64, v map[int64]any)
+	rowTs            func(i int) uint64
+	targetAdded      []*schemapb.FieldSchema
+	targetDropped    []int64 // source field IDs removed from the target schema
+	functions        []*schemapb.FunctionSchema
+	collectionTTL    time.Duration
+	ttlProperty      string
+	deletedPKs       map[any]uint64 // pk -> delete ts, written as a real V3 deltalog
+	commitTs         uint64
+	fillTextAnalyzer bool  // decorate the base text field with multi_analyzer_params (by_field=lang)
+	textLOBFieldID   int64 // >0: write this source TEXT field through the LOB-aware writer
+}
+
+type fixtureOpt func(*fixtureSpec)
+
+func withRows(n int) fixtureOpt { return func(s *fixtureSpec) { s.rows = n } }
+
+func withVarCharPK() fixtureOpt { return func(s *fixtureSpec) { s.varCharPK = true } }
+
+func withoutSourceText() fixtureOpt { return func(s *fixtureSpec) { s.noSourceText = true } }
+
+func withSourceFields(fs ...*schemapb.FieldSchema) fixtureOpt {
+	return func(s *fixtureSpec) { s.extraFields = append(s.extraFields, fs...) }
+}
+
+func withFillValue(f func(i int, ts uint64, v map[int64]any)) fixtureOpt {
+	return func(s *fixtureSpec) { s.fill = f }
+}
+
+func withRowTs(f func(i int) uint64) fixtureOpt { return func(s *fixtureSpec) { s.rowTs = f } }
+
+func withTargetAddedField(fs ...*schemapb.FieldSchema) fixtureOpt {
+	return func(s *fixtureSpec) { s.targetAdded = append(s.targetAdded, fs...) }
+}
+
+func withTargetDroppedField(ids ...int64) fixtureOpt {
+	return func(s *fixtureSpec) { s.targetDropped = append(s.targetDropped, ids...) }
+}
+
+func withTargetFunctions(fns ...*schemapb.FunctionSchema) fixtureOpt {
+	return func(s *fixtureSpec) { s.functions = append(s.functions, fns...) }
+}
+
+func withCollectionTTL(d time.Duration) fixtureOpt {
+	return func(s *fixtureSpec) { s.collectionTTL = d }
+}
+
+func withTTLProperty(fieldName string) fixtureOpt {
+	return func(s *fixtureSpec) { s.ttlProperty = fieldName }
+}
+
+func withDeletedPKs(pks map[any]uint64) fixtureOpt {
+	return func(s *fixtureSpec) { s.deletedPKs = pks }
+}
+
+func withCommitTs(ts uint64) fixtureOpt { return func(s *fixtureSpec) { s.commitTs = ts } }
+
+func withTextLOBSource(fieldID int64) fixtureOpt {
+	return func(s *fixtureSpec) { s.textLOBFieldID = fieldID }
+}
+
+type bumpFixture struct {
+	t            *testing.T
+	task         *bumpSchemaVersionCompactionTask
+	segment      *datapb.CompactionSegmentBinlogs
+	sourceSchema *schemapb.CollectionSchema
+	targetSchema *schemapb.CollectionSchema
+	rows         []fixtureRow
+	cfg          *indexpb.StorageConfig
+	// manifest as written by the fixture, before Compact runs (source of truth
+	// for verifySourceIntact).
+	sourceManifest string
+}
+
+func bumpFxBaseFields(varCharPK bool) []*schemapb.FieldSchema {
+	pk := &schemapb.FieldSchema{FieldID: bumpFxPKField, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true}
+	if varCharPK {
+		pk = &schemapb.FieldSchema{
+			FieldID: bumpFxPKField, Name: "pk", DataType: schemapb.DataType_VarChar, IsPrimaryKey: true,
+			TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "64"}},
+		}
+	}
+	return []*schemapb.FieldSchema{
+		{FieldID: common.RowIDField, Name: "row_id", DataType: schemapb.DataType_Int64},
+		{FieldID: common.TimeStampField, Name: "Timestamp", DataType: schemapb.DataType_Int64},
+		pk,
+		{
+			FieldID: bumpFxTextField, Name: "text", DataType: schemapb.DataType_VarChar,
+			TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "2048"}},
+		},
+	}
+}
+
+// deterministic value formulas — golden rows are derived, never random.
+func bumpFxPK(varCharPK bool, i int) any {
+	if varCharPK {
+		return fmt.Sprintf("pk-%06d", i)
+	}
+	return int64(i)
+}
+
+func bumpFxVarchar(fieldID int64, i int) string { return fmt.Sprintf("v-%d-%d", fieldID, i) }
+
+func bumpFxTS(i int) uint64 {
+	return tsoutil.ComposeTSByTime(getMilvusBirthday().Add(time.Duration(i) * time.Second))
+}
+
+// buildBumpFixture writes a real StorageV3 source segment (and optional real
+// deltalogs) and returns a ready-to-Compact task plus the golden row set.
+func buildBumpFixture(t *testing.T, opts ...fixtureOpt) *bumpFixture {
+	spec := &fixtureSpec{rows: 3, rowTs: bumpFxTS}
+	for _, opt := range opts {
+		opt(spec)
+	}
+
+	baseFields := bumpFxBaseFields(spec.varCharPK)
+	if spec.noSourceText {
+		baseFields = baseFields[:3] // row_id, timestamp, pk
+	}
+	sourceFields := append(baseFields, spec.extraFields...)
+	if spec.fillTextAnalyzer {
+		for _, f := range sourceFields {
+			if f.GetFieldID() == bumpFxTextField {
+				f.TypeParams = append(f.TypeParams,
+					&commonpb.KeyValuePair{Key: common.EnableAnalyzerKey, Value: "true"},
+					&commonpb.KeyValuePair{Key: "multi_analyzer_params", Value: `{"by_field":"lang","analyzers":{"default":{"type":"standard"},"english":{"type":"english"}}}`},
+				)
+			}
+		}
+	}
+	sourceSchema := &schemapb.CollectionSchema{Fields: sourceFields}
+
+	// Target schema: source logical fields minus dropped, plus added, plus functions.
+	dropped := make(map[int64]struct{}, len(spec.targetDropped))
+	for _, id := range spec.targetDropped {
+		dropped[id] = struct{}{}
+	}
+	targetFields := make([]*schemapb.FieldSchema, 0, len(sourceFields)+len(spec.targetAdded))
+	for _, f := range sourceFields {
+		if _, ok := dropped[f.GetFieldID()]; ok {
+			continue
+		}
+		targetFields = append(targetFields, f)
+	}
+	targetFields = append(targetFields, spec.targetAdded...)
+	targetSchema := &schemapb.CollectionSchema{
+		Name:      "bump_ut",
+		Fields:    targetFields,
+		Functions: spec.functions,
+	}
+	if spec.ttlProperty != "" {
+		targetSchema.Properties = append(targetSchema.Properties, &commonpb.KeyValuePair{
+			Key: common.CollectionTTLFieldKey, Value: spec.ttlProperty,
+		})
+	}
+
+	// Write the source segment through the real V3 writer.
+	binlogIO := mock_util.NewMockBinlogIO(t)
+	binlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
+	segIDAlloc := allocator.NewLocalAllocator(100, math.MaxInt64)
+	logIDAlloc := allocator.NewLocalAllocator(9530, 19530)
+	compAlloc := NewCompactionAllocator(segIDAlloc, logIDAlloc)
+	params := compaction.GenParams()
+	params.StorageVersion = storage.StorageV3
+
+	fixtureWriterOpts := []storage.RwOption{
+		storage.WithStorageConfig(params.StorageConfig),
+		storage.WithVersion(storage.StorageV3),
+	}
+	if spec.textLOBFieldID > 0 {
+		lobBasePath := path.Join(params.StorageConfig.GetRootPath(),
+			common.SegmentInsertLogPath, metautil.JoinIDPath(CollectionID, PartitionID))
+		fixtureWriterOpts = append(fixtureWriterOpts, storage.WithTextColumnConfigs([]packed.TextColumnConfig{{
+			FieldID:             spec.textLOBFieldID,
+			LobBasePath:         lobBasePath,
+			InlineThreshold:     params.TextInlineThreshold,
+			MaxLobFileBytes:     params.TextMaxLobFileBytes,
+			FlushThresholdBytes: params.TextFlushThresholdBytes,
+		}}))
+	}
+	writer, err := NewMultiSegmentWriter(context.Background(), binlogIO, compAlloc,
+		64*1024*1024, sourceSchema, params, int64(spec.rows)+1000, PartitionID, CollectionID,
+		"bump_ut_channel", compactionBatchSize, fixtureWriterOpts...)
+	require.NoError(t, err)
+
+	rows := make([]fixtureRow, 0, spec.rows)
+	for i := 0; i < spec.rows; i++ {
+		ts := spec.rowTs(i)
+		pk := bumpFxPK(spec.varCharPK, i)
+		values := map[int64]any{
+			common.RowIDField:     int64(i),
+			common.TimeStampField: int64(ts),
+			bumpFxPKField:         pk,
+		}
+		if !spec.noSourceText {
+			values[bumpFxTextField] = bumpFxVarchar(bumpFxTextField, i)
+		}
+		if spec.fill != nil {
+			spec.fill(i, ts, values)
+		}
+		var pkValue storage.PrimaryKey
+		if spec.varCharPK {
+			pkValue = storage.NewVarCharPrimaryKey(pk.(string))
+		} else {
+			pkValue = storage.NewInt64PrimaryKey(pk.(int64))
+		}
+		require.NoError(t, writer.WriteValue(&storage.Value{PK: pkValue, Timestamp: int64(ts), Value: values}))
+		golden := make(map[int64]any, len(values))
+		for k, v := range values {
+			if k == common.RowIDField || k == common.TimeStampField {
+				continue
+			}
+			golden[k] = v
+		}
+		rows = append(rows, fixtureRow{pk: pk, ts: ts, values: golden, kept: true})
+	}
+	require.NoError(t, writer.Close())
+	segments := writer.GetCompactionSegments()
+	require.Len(t, segments, 1)
+	written := segments[0]
+
+	segment := &datapb.CompactionSegmentBinlogs{
+		CollectionID:    CollectionID,
+		PartitionID:     PartitionID,
+		SegmentID:       written.GetSegmentID(),
+		FieldBinlogs:    written.GetInsertLogs(),
+		InsertChannel:   "bump_ut_channel",
+		StorageVersion:  written.GetStorageVersion(),
+		Manifest:        written.GetManifest(),
+		CommitTimestamp: spec.commitTs,
+	}
+
+	// Real V3 deltalog: production recipe from BulkPackWriterV3.writeDelta.
+	if len(spec.deletedPKs) > 0 {
+		segment.Deltalogs = writeFixtureDeltalog(t, spec, segment, params.StorageConfig)
+	}
+
+	jsonParams, err := compaction.GenerateJSONParams(targetSchema)
+	require.NoError(t, err)
+	plan := &datapb.CompactionPlan{
+		PlanID:                 999,
+		Type:                   datapb.CompactionType_BumpSchemaVersionCompaction,
+		SegmentBinlogs:         []*datapb.CompactionSegmentBinlogs{segment},
+		Schema:                 targetSchema,
+		TotalRows:              int64(spec.rows),
+		PreAllocatedSegmentIDs: &datapb.IDRange{Begin: 19531, End: math.MaxInt64},
+		PreAllocatedLogIDs:     &datapb.IDRange{Begin: 20000, End: 30000},
+		MaxSize:                64 * 1024 * 1024,
+		JsonParams:             jsonParams,
+		CollectionTtl:          int64(spec.collectionTTL),
+		Channel:                "bump_ut_channel",
+	}
+
+	cm, err := storage.NewChunkManagerFactoryWithParam(paramtable.Get()).NewPersistentStorageChunkManager(context.Background())
+	require.NoError(t, err)
+	task := NewBumpSchemaVersionCompactionTask(context.Background(), cm, plan, params)
+
+	fix := &bumpFixture{
+		t:              t,
+		task:           task,
+		segment:        segment,
+		sourceSchema:   sourceSchema,
+		targetSchema:   targetSchema,
+		rows:           rows,
+		cfg:            params.StorageConfig,
+		sourceManifest: segment.GetManifest(),
+	}
+	fix.computeKept(spec)
+	return fix
+}
+
+// writeFixtureDeltalog writes a real V3 delta file and commits it to the source
+// manifest, mirroring syncmgr.BulkPackWriterV3.writeDelta.
+func writeFixtureDeltalog(t *testing.T, spec *fixtureSpec, segment *datapb.CompactionSegmentBinlogs, cfg *indexpb.StorageConfig) []*datapb.FieldBinlog {
+	const deltaLogID = int64(777001)
+	pks := make([]storage.PrimaryKey, 0, len(spec.deletedPKs))
+	tss := make([]uint64, 0, len(spec.deletedPKs))
+	for pk, ts := range spec.deletedPKs {
+		if spec.varCharPK {
+			pks = append(pks, storage.NewVarCharPrimaryKey(pk.(string)))
+		} else {
+			pks = append(pks, storage.NewInt64PrimaryKey(pk.(int64)))
+		}
+		tss = append(tss, ts)
+	}
+	pkType := schemapb.DataType_Int64
+	if spec.varCharPK {
+		pkType = schemapb.DataType_VarChar
+	}
+	basePath, _, err := packed.UnmarshalManifestPath(segment.GetManifest())
+	require.NoError(t, err)
+	deltaPath := metautil.BuildDeltaLogPathV3(basePath, deltaLogID)
+
+	writer, err := storage.NewDeltalogWriter(context.Background(), segment.GetCollectionID(),
+		segment.GetPartitionID(), segment.GetSegmentID(), deltaLogID, pkType, deltaPath,
+		storage.WithVersion(storage.StorageV2),
+		storage.WithStorageConfig(cfg),
+	)
+	require.NoError(t, err)
+	record, tsFrom, tsTo, err := storage.BuildDeleteRecord(pks, tss)
+	require.NoError(t, err)
+	defer record.Release()
+	require.NoError(t, writer.Write(record))
+	require.NoError(t, writer.Close())
+
+	newManifest, err := packed.AddDeltaLogsToManifest(segment.GetManifest(), cfg,
+		[]packed.DeltaLogEntry{{Path: deltaPath, NumEntries: int64(len(pks))}})
+	require.NoError(t, err)
+	segment.Manifest = newManifest
+
+	return []*datapb.FieldBinlog{{Binlogs: []*datapb.Binlog{{
+		LogID:         deltaLogID,
+		EntriesNum:    int64(len(pks)),
+		TimestampFrom: tsFrom,
+		TimestampTo:   tsTo,
+	}}}}
+}
+
+// computeKept replicates EntityFilterImpl's rules exactly (delete / collection
+// TTL / TTL field) so golden expectations are derived, not asserted ad hoc.
+func (f *bumpFixture) computeKept(spec *fixtureSpec) {
+	ttlFieldID := int64(-1)
+	if spec.ttlProperty != "" {
+		for _, field := range f.targetSchema.GetFields() {
+			if field.GetName() == spec.ttlProperty && field.GetDataType() == schemapb.DataType_Timestamptz {
+				ttlFieldID = field.GetFieldID()
+			}
+		}
+	}
+	now := time.Now()
+	for i := range f.rows {
+		row := &f.rows[i]
+		effective := row.ts
+		if spec.commitTs > effective {
+			effective = spec.commitTs
+		}
+		if deleteTs, ok := spec.deletedPKs[row.pk]; ok && effective < deleteTs {
+			row.kept = false
+			continue
+		}
+		if spec.collectionTTL > 0 {
+			entityTime, _ := tsoutil.ParseTS(effective)
+			if now.UnixMilli()-entityTime.UnixMilli() >= spec.collectionTTL.Milliseconds() {
+				row.kept = false
+				continue
+			}
+		}
+		if ttlFieldID >= common.StartOfUserFieldID {
+			if v, ok := row.values[ttlFieldID]; ok && v != nil {
+				if expireMicros, ok := v.(int64); ok && expireMicros >= 0 && now.UnixMicro() >= expireMicros {
+					row.kept = false
+				}
+			}
+		}
+	}
+}
+
+func (f *bumpFixture) keptRows() []fixtureRow {
+	kept := make([]fixtureRow, 0, len(f.rows))
+	for _, r := range f.rows {
+		if r.kept {
+			kept = append(kept, r)
+		}
+	}
+	return kept
+}
+
+// ---------------------------------------------------------------------------
+// F2: golden verifier
+// ---------------------------------------------------------------------------
+
+// readAllColumns reads every row of readSchema's fields from the manifest into
+// per-field value slices (nil entry = NULL) and returns the row count.
+func readAllColumns(t *testing.T, cfg *indexpb.StorageConfig, manifest string, readSchema *schemapb.CollectionSchema) (map[int64][]any, int) {
+	reader, err := storage.NewManifestRecordReader(context.Background(), manifest, readSchema,
+		storage.WithCollectionID(CollectionID),
+		storage.WithVersion(storage.StorageV3),
+		storage.WithStorageConfig(cfg),
+	)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	out := make(map[int64][]any)
+	total := 0
+	batches := 0
+	for {
+		rec, err := reader.Next()
+		if err == sio.EOF {
+			break
+		}
+		require.NoError(t, err)
+		batches++
+		total += rec.Len()
+		for _, field := range readSchema.GetFields() {
+			col := rec.Column(field.GetFieldID())
+			require.NotNil(t, col, "field %d missing from record", field.GetFieldID())
+			out[field.GetFieldID()] = appendArrowValues(t, out[field.GetFieldID()], col)
+		}
+	}
+	t.Logf("readAllColumns: manifest rows=%d batches=%d", total, batches)
+	return out, total
+}
+
+func appendArrowValues(t *testing.T, dst []any, col arrow.Array) []any {
+	for i := 0; i < col.Len(); i++ {
+		if col.IsNull(i) {
+			dst = append(dst, nil)
+			continue
+		}
+		switch arr := col.(type) {
+		case *array.Int64:
+			dst = append(dst, arr.Value(i))
+		case *array.Int32:
+			dst = append(dst, int64(arr.Value(i)))
+		case *array.String:
+			// String.Value aliases the reader's arrow buffer without copying;
+			// clone it so the value survives the reader's Close (buffer free).
+			dst = append(dst, strings.Clone(arr.Value(i)))
+		case *array.Binary:
+			dst = append(dst, append([]byte(nil), arr.Value(i)...))
+		case *array.FixedSizeBinary:
+			dst = append(dst, append([]byte(nil), arr.Value(i)...))
+		case *array.Float32:
+			dst = append(dst, arr.Value(i))
+		case *array.Float64:
+			dst = append(dst, arr.Value(i))
+		case *array.Boolean:
+			dst = append(dst, arr.Value(i))
+		default:
+			t.Fatalf("appendArrowValues: unsupported arrow type %T", col)
+		}
+	}
+	return dst
+}
+
+// verifySegmentData asserts every column of every row (value + null bitmap +
+// row order) matches wantRows for all non-system fields in readSchema.
+func verifySegmentData(t *testing.T, cfg *indexpb.StorageConfig, manifest string, readSchema *schemapb.CollectionSchema, wantRows []fixtureRow) {
+	got, total := readAllColumns(t, cfg, manifest, readSchema)
+	require.Equal(t, len(wantRows), total, "row count mismatch")
+	for _, field := range readSchema.GetFields() {
+		fieldID := field.GetFieldID()
+		if common.IsSystemField(fieldID) {
+			continue
+		}
+		colValues := got[fieldID]
+		require.Len(t, colValues, len(wantRows), "field %d column length", fieldID)
+		for i, want := range wantRows {
+			assertGoldenValue(t, fieldID, i, want.values[fieldID], colValues[i])
+		}
+	}
+}
+
+func assertGoldenValue(t *testing.T, fieldID int64, row int, want, got any) {
+	if want == nil {
+		require.Nil(t, got, "field %d row %d: expected NULL", fieldID, row)
+		return
+	}
+	switch w := want.(type) {
+	case int64:
+		require.Equal(t, w, got, "field %d row %d", fieldID, row)
+	case int:
+		require.EqualValues(t, w, got, "field %d row %d", fieldID, row)
+	case string:
+		require.Equal(t, w, got, "field %d row %d", fieldID, row)
+	case []byte:
+		require.Equal(t, w, got, "field %d row %d", fieldID, row)
+	default:
+		require.Equal(t, want, got, "field %d row %d", fieldID, row)
+	}
+}
+
+// verifyManifestFields asserts physical field membership of a manifest.
+func verifyManifestFields(t *testing.T, cfg *indexpb.StorageConfig, manifest string, want []int64, absent []int64) {
+	fields, err := packed.GetManifestFieldIDs(manifest, cfg)
+	require.NoError(t, err)
+	for _, id := range want {
+		require.Contains(t, fields, id, "manifest must contain field %d", id)
+	}
+	for _, id := range absent {
+		require.NotContains(t, fields, id, "manifest must not contain field %d", id)
+	}
+}
+
+// verifySourceIntact asserts a failed compaction left the source segment
+// untouched: same manifest pointer, source data still fully readable.
+func verifySourceIntact(t *testing.T, f *bumpFixture) {
+	require.Equal(t, f.sourceManifest, f.segment.GetManifest(), "source manifest pointer must not advance")
+	readSchema := &schemapb.CollectionSchema{Fields: physicalReadFields(f.sourceSchema)}
+	_, total := readAllColumns(t, f.cfg, f.sourceManifest, readSchema)
+	require.Equal(t, len(f.rows), total, "source rows must stay readable after failure")
+}
+
+// physicalReadFields drops system fields (readers require user fields only in
+// some verification paths; keeping pk+data fields is sufficient for goldens).
+func physicalReadFields(schema *schemapb.CollectionSchema) []*schemapb.FieldSchema {
+	fields := make([]*schemapb.FieldSchema, 0, len(schema.GetFields()))
+	for _, f := range schema.GetFields() {
+		if common.IsSystemField(f.GetFieldID()) {
+			continue
+		}
+		fields = append(fields, f)
+	}
+	return fields
+}
+
+// timestampReadSchema reads only the system timestamp column.
+func timestampReadSchema() *schemapb.CollectionSchema {
+	return &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: common.TimeStampField, Name: "Timestamp", DataType: schemapb.DataType_Int64},
+	}}
+}
+
+// runCompact runs the task and returns the single result segment.
+func runCompact(t *testing.T, f *bumpFixture) *datapb.CompactionSegment {
+	result, err := f.task.Compact()
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, datapb.CompactionTaskState_completed, result.GetState())
+	require.Len(t, result.GetSegments(), 1)
+	return result.GetSegments()[0]
+}
+
+func fieldIDsOf(schema *schemapb.CollectionSchema) []int64 {
+	ids := make([]int64, 0, len(schema.GetFields()))
+	for _, f := range typeutil.GetAllFieldSchemas(schema) {
+		ids = append(ids, f.GetFieldID())
+	}
+	return ids
+}
+
+// ---------------------------------------------------------------------------
+// golden transforms & case helpers
+// ---------------------------------------------------------------------------
+
+// bumpFxPad fattens varchar payloads so large fixtures span multiple reader
+// batches / row groups.
+var bumpFxPad = func() string {
+	b := make([]byte, 1024)
+	for i := range b {
+		b[i] = 'x'
+	}
+	return string(b)
+}()
+
+// goldenWithAdded returns a copy of rows with fieldID set per-row via valueAt.
+func goldenWithAdded(rows []fixtureRow, fieldID int64, valueAt func(i int) any) []fixtureRow {
+	out := make([]fixtureRow, len(rows))
+	copy(out, rows)
+	for i := range out {
+		values := make(map[int64]any, len(out[i].values)+1)
+		for k, v := range out[i].values {
+			values[k] = v
+		}
+		values[fieldID] = valueAt(i)
+		out[i].values = values
+	}
+	return out
+}
+
+// dropField returns a copy of rows with fieldID removed from every row.
+func dropField(rows []fixtureRow, fieldID int64) []fixtureRow {
+	out := make([]fixtureRow, len(rows))
+	copy(out, rows)
+	for i := range out {
+		values := make(map[int64]any, len(out[i].values))
+		for k, v := range out[i].values {
+			if k == fieldID {
+				continue
+			}
+			values[k] = v
+		}
+		out[i].values = values
+	}
+	return out
+}
+
+// withBM25Target adds the standard missing-BM25 target: sparse output 102
+// produced from the base text input 101.
+func withBM25Target() fixtureOpt {
+	return func(s *fixtureSpec) {
+		s.targetAdded = append(s.targetAdded, &schemapb.FieldSchema{
+			FieldID: 102, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true,
+		})
+		s.functions = append(s.functions, &schemapb.FunctionSchema{
+			Name: "bm25", Id: 100, Type: schemapb.FunctionType_BM25,
+			InputFieldNames: []string{"text"}, InputFieldIds: []int64{bumpFxTextField},
+			OutputFieldNames: []string{"sparse"}, OutputFieldIds: []int64{102},
+		})
+	}
+}
+
+// withMultiAnalyzerBM25Target is withBM25Target plus multi_analyzer_params on
+// the text input (by_field = lang, field 115).
+func withMultiAnalyzerBM25Target() fixtureOpt {
+	return func(s *fixtureSpec) {
+		withBM25Target()(s)
+		s.fillTextAnalyzer = true
+	}
+}
+
+// requireSparseRows verifies the materialized sparse column. When expected is
+// non-nil it byte-compares every row — the content<->row alignment oracle that
+// non-emptiness cannot provide (review W1: rotation/misalignment corruption is
+// invisible to NotNil and to constant NULL/default columns).
+func requireSparseRows(t *testing.T, fix *bumpFixture, manifest string, fieldID int64, wantRows int, expected [][]byte) {
+	got, total := readAllColumns(t, fix.cfg, manifest, &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{{FieldID: fieldID, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector}},
+	})
+	require.Equal(t, wantRows, total)
+	for i, v := range got[fieldID] {
+		require.NotNil(t, v, "sparse row %d must be materialized", i)
+		if expected != nil {
+			require.Equal(t, expected[i], v, "sparse content<->row alignment at %d", i)
+		}
+	}
+}
+
+// expectedBM25SparseRows derives the expected sparse bytes per row by running
+// the REAL BM25 runner over the deterministic golden inputs. Runner mirroring
+// is acceptable for this oracle: it targets row<->content alignment, not
+// analyzer semantics.
+func expectedBM25SparseRows(t *testing.T, schema *schemapb.CollectionSchema, fn *schemapb.FunctionSchema, inputs ...any) [][]byte {
+	runner, err := function.NewFunctionRunner(schema, fn)
+	require.NoError(t, err)
+	defer runner.Close()
+	outputs, err := runner.BatchRun(inputs...)
+	require.NoError(t, err)
+	require.Len(t, outputs, 1)
+	sparse, ok := outputs[0].(*schemapb.SparseFloatArray)
+	require.True(t, ok, "BM25 runner must return SparseFloatArray, got %T", outputs[0])
+	return sparse.GetContents()
+}
+
+// verifySystemColumns reads the row_id and timestamp system columns back from
+// the written files and compares them row by row — verifySegmentData skips
+// system fields, so passthrough/normalization contracts need this explicit
+// oracle.
+func verifySystemColumns(t *testing.T, fix *bumpFixture, manifest string, wantRowID, wantTs func(i int) int64) {
+	got, total := readAllColumns(t, fix.cfg, manifest, &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: common.RowIDField, Name: "row_id", DataType: schemapb.DataType_Int64},
+		{FieldID: common.TimeStampField, Name: "ts", DataType: schemapb.DataType_Int64},
+	}})
+	require.Positive(t, total)
+	for i := 0; i < total; i++ {
+		if wantRowID != nil {
+			require.Equal(t, wantRowID(i), got[common.RowIDField][i], "row_id at %d", i)
+		}
+		if wantTs != nil {
+			require.Equal(t, wantTs(i), got[common.TimeStampField][i], "ts at %d", i)
+		}
+	}
+}
+
+// listSegmentDataFiles snapshots the segment's _data parquet files (relative
+// path -> size:sha256): the on-disk column-group CONTENT ledger for
+// exact-append/idempotency assertions — content-hashed so a same-size in-place
+// tamper is visible, which set-semantics manifest checks cannot express.
+func listSegmentDataFiles(t *testing.T, fix *bumpFixture) map[string]string {
+	return snapshotFilesByHash(t, fix, "/_data/", "")
+}
+
+// listLobFiles snapshots every .vx LOB blob (relative path -> size:sha256).
+func listLobFiles(t *testing.T, fix *bumpFixture) map[string]string {
+	return snapshotFilesByHash(t, fix, "", ".vx")
+}
+
+func snapshotFilesByHash(t *testing.T, fix *bumpFixture, contains, suffix string) map[string]string {
+	root := fix.cfg.GetRootPath()
+	paths := make(map[string]string) // rel -> abs, collected first; reads happen after the walk
+	require.NoError(t, filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		if contains != "" && !strings.Contains(p, contains) {
+			return nil
+		}
+		if suffix != "" && !strings.HasSuffix(p, suffix) {
+			return nil
+		}
+		rel, rerr := filepath.Rel(root, p)
+		require.NoError(t, rerr)
+		paths[rel] = p
+		return nil
+	}))
+	files := make(map[string]string, len(paths))
+	for rel, abs := range paths {
+		content, err := os.ReadFile(abs)
+		require.NoError(t, err)
+		files[rel] = fmt.Sprintf("%d:%x", len(content), sha256.Sum256(content))
+	}
+	return files
+}
+
+// requireBM25StatsBlob locates the committed bm25 stats blob under the segment
+// base path and asserts it deserializes into non-empty BM25 stats.
+func requireBM25StatsBlob(t *testing.T, fix *bumpFixture, fieldID int64, wantRows int) *storage.BM25Stats {
+	needle := fmt.Sprintf("_stats/bm25.%d/", fieldID)
+	cm, err := storage.NewChunkManagerFactoryWithParam(paramtable.Get()).NewPersistentStorageChunkManager(context.Background())
+	require.NoError(t, err)
+	var paths []string
+	require.NoError(t, cm.WalkWithPrefix(context.Background(), cm.RootPath(), true, func(obj *storage.ChunkObjectInfo) bool {
+		if strings.Contains(obj.FilePath, needle) {
+			paths = append(paths, obj.FilePath)
+		}
+		return true
+	}))
+	require.NotEmpty(t, paths, "bm25 stats blob must be committed (needle %s)", needle)
+	blob, err := cm.Read(context.Background(), paths[0])
+	require.NoError(t, err)
+	stats := storage.NewBM25Stats()
+	require.NoError(t, stats.Deserialize(blob))
+	require.EqualValues(t, wantRows, stats.NumRow())
+	return stats
+}
+
+func mustBasePath(t *testing.T, manifest string) string {
+	basePath, _, err := packed.UnmarshalManifestPath(manifest)
+	require.NoError(t, err)
+	return basePath
+}
+
+// ============================================================================
+// Data goldens: bump-only / additive / full-rewrite (B/A/F series)
+// ============================================================================
+// [B1][S0] bump-only: nothing absent, nothing dropped — the result must echo
+// the plan segment verbatim (pure metadata bump, zero data churn).
+func TestBumpUTBumpOnlyEchoesSource(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := buildBumpFixture(t)
+
+	seg := runCompact(t, fix)
+	require.Equal(t, fix.segment.GetSegmentID(), seg.GetSegmentID())
+	require.EqualValues(t, len(fix.rows), seg.GetNumOfRows())
+	require.Equal(t, fix.segment.GetManifest(), seg.GetManifest())
+	require.Equal(t, fix.segment.GetManifest(), seg.GetBaseManifest())
+	require.Equal(t, fix.segment.GetFieldBinlogs(), seg.GetInsertLogs())
+	require.Nil(t, seg.GetStats())
+
+	// Source data still fully readable and golden.
+	verifySegmentData(t, fix.cfg, seg.GetManifest(),
+		&schemapb.CollectionSchema{Fields: physicalReadFields(fix.sourceSchema)}, fix.rows)
+}
+
+// [A1][S0] additive: +nullable int64 — every historical row gets NULL, the new
+// column joins the manifest, existing columns stay golden, and the result is an
+// in-place increment (BaseManifest == source manifest).
+func TestBumpUTAdditiveNullableColumn(t *testing.T) {
+	setupBumpUTEnv(t)
+	const addedID = int64(103)
+	fix := buildBumpFixture(t, withTargetAddedField(&schemapb.FieldSchema{
+		FieldID: addedID, Name: "added_nullable", DataType: schemapb.DataType_Int64, Nullable: true,
+	}))
+
+	seg := runCompact(t, fix)
+	require.Equal(t, fix.segment.GetSegmentID(), seg.GetSegmentID(), "additive is in-place")
+	require.EqualValues(t, len(fix.rows), seg.GetNumOfRows())
+	// [A21] CAS adoption prerequisites.
+	require.Equal(t, fix.sourceManifest, seg.GetBaseManifest())
+	require.NotEqual(t, fix.sourceManifest, seg.GetManifest(), "manifest must advance")
+
+	// Golden: old columns unchanged, new column all NULL.
+	want := make([]fixtureRow, len(fix.rows))
+	copy(want, fix.rows)
+	for i := range want {
+		values := make(map[int64]any, len(want[i].values)+1)
+		for k, v := range want[i].values {
+			values[k] = v
+		}
+		values[addedID] = nil
+		want[i].values = values
+	}
+	readSchema := &schemapb.CollectionSchema{Fields: append(physicalReadFields(fix.sourceSchema),
+		fix.targetSchema.GetFields()[len(fix.targetSchema.GetFields())-1])}
+	verifySegmentData(t, fix.cfg, seg.GetManifest(), readSchema, want)
+	verifyManifestFields(t, fix.cfg, seg.GetManifest(), []int64{addedID}, nil)
+
+	// Increment stats describe only the new column group.
+	require.NotNil(t, seg.GetStats())
+	require.EqualValues(t, 1, seg.GetStats().GetInsertBinlogCount())
+	require.EqualValues(t, len(fix.rows), seg.GetStats().GetNullCounts()[addedID])
+	// The new column group's insert-log summary must carry the exact row count.
+	require.Len(t, seg.GetInsertLogs(), 1)
+	require.EqualValues(t, len(fix.rows), seg.GetInsertLogs()[0].GetBinlogs()[0].GetEntriesNum())
+
+	// [TS1][S0] additive must not touch system columns: both pass through.
+	verifySystemColumns(t, fix, seg.GetManifest(),
+		func(i int) int64 { return int64(i) },
+		func(i int) int64 { return int64(fix.rows[i].ts) })
+}
+
+// [F1][S0] full rewrite, pure drop: no filtering configured — all rows survive,
+// all remaining columns stay golden, dropped column leaves the manifest.
+func TestBumpUTFullRewritePureDrop(t *testing.T) {
+	setupBumpUTEnv(t)
+	const droppedID = int64(102)
+	fix := buildBumpFixture(t,
+		withSourceFields(&schemapb.FieldSchema{FieldID: droppedID, Name: "dropped", DataType: schemapb.DataType_Int64}),
+		withFillValue(func(i int, ts uint64, v map[int64]any) { v[droppedID] = int64(i * 10) }),
+		withTargetDroppedField(droppedID),
+	)
+
+	seg := runCompact(t, fix)
+	require.NotEqual(t, fix.segment.GetSegmentID(), seg.GetSegmentID(), "full rewrite is a replacement")
+	require.EqualValues(t, len(fix.rows), seg.GetNumOfRows())
+	require.NotEmpty(t, seg.GetManifest())
+
+	// Golden on the target schema: dropped column absent, others intact.
+	want := make([]fixtureRow, len(fix.rows))
+	copy(want, fix.rows)
+	for i := range want {
+		values := make(map[int64]any, len(want[i].values))
+		for k, v := range want[i].values {
+			if k == droppedID {
+				continue
+			}
+			values[k] = v
+		}
+		want[i].values = values
+	}
+	verifySegmentData(t, fix.cfg, seg.GetManifest(),
+		&schemapb.CollectionSchema{Fields: physicalReadFields(fix.targetSchema)}, want)
+	verifyManifestFields(t, fix.cfg, seg.GetManifest(), []int64{bumpFxPKField, bumpFxTextField}, []int64{droppedID})
+
+	// [TS2/W2][S0] commitTs==0 full rewrite: BOTH system columns pass through
+	// untouched (verifySegmentData skips system fields).
+	verifySystemColumns(t, fix, seg.GetManifest(),
+		func(i int) int64 { return int64(i) },
+		func(i int) int64 { return int64(fix.rows[i].ts) })
+}
+
+// ---------------------------------------------------------------------------
+// bump-only
+// ---------------------------------------------------------------------------
+
+// [B2][S0] bump-only with delta summaries: passthrough must carry Deltalogs.
+func TestBumpUTBumpOnlyCarriesDeltalogs(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := buildBumpFixture(t, withRows(4), withDeletedPKs(map[any]uint64{int64(1): bumpFxTS(1) + 1}))
+
+	seg := runCompact(t, fix)
+	require.Equal(t, fix.segment.GetSegmentID(), seg.GetSegmentID())
+	require.Equal(t, fix.segment.GetDeltalogs(), seg.GetDeltalogs())
+	require.Equal(t, fix.segment.GetManifest(), seg.GetManifest())
+	// bump-only must NOT apply the delete: all 4 physical rows stay readable.
+	verifySegmentData(t, fix.cfg, seg.GetManifest(),
+		&schemapb.CollectionSchema{Fields: physicalReadFields(fix.sourceSchema)}, fix.rows)
+}
+
+// [B3][S3] function outputs physically present: routes bump-only, no rewrite.
+func TestBumpUTBumpOnlyWhenFunctionOutputsPresent(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := buildBumpFixture(t,
+		withSourceFields(&schemapb.FieldSchema{
+			FieldID: 102, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true,
+		}),
+		withFillValue(func(i int, ts uint64, v map[int64]any) {
+			v[102] = typeutil.CreateAndSortSparseFloatRow(map[uint32]float32{uint32(i + 1): 1.0})
+		}),
+		withTargetFunctions(&schemapb.FunctionSchema{
+			Name: "bm25", Id: 100, Type: schemapb.FunctionType_BM25,
+			InputFieldNames: []string{"text"}, InputFieldIds: []int64{bumpFxTextField},
+			OutputFieldNames: []string{"sparse"}, OutputFieldIds: []int64{102},
+		}),
+	)
+
+	seg := runCompact(t, fix)
+	require.Equal(t, fix.segment.GetSegmentID(), seg.GetSegmentID())
+	require.Equal(t, fix.segment.GetManifest(), seg.GetManifest(), "no rewrite may happen")
+}
+
+// ---------------------------------------------------------------------------
+// additive
+// ---------------------------------------------------------------------------
+
+// [A2][S0] +default column: backfilled as NULL — the reader layer null-fills
+// absent fields and default materialization is deferred; the declared default
+// must not leak into historical rows.
+func TestBumpUTAdditiveDefaultColumn(t *testing.T) {
+	setupBumpUTEnv(t)
+	const addedID = int64(103)
+	fix := buildBumpFixture(t, withTargetAddedField(&schemapb.FieldSchema{
+		FieldID: addedID, Name: "added_default", DataType: schemapb.DataType_Int64, Nullable: true,
+		DefaultValue: &schemapb.ValueField{Data: &schemapb.ValueField_LongData{LongData: 42}},
+	}))
+
+	seg := runCompact(t, fix)
+	// #52781/#52807 (merged): the packed reader default-fills absent default-valued
+	// fields, so the added column materializes its declared default (42), not NULL.
+	want := goldenWithAdded(fix.rows, addedID, func(int) any { return int64(42) })
+	readSchema := &schemapb.CollectionSchema{Fields: append(physicalReadFields(fix.sourceSchema),
+		typeutil.GetField(fix.targetSchema, addedID))}
+	verifySegmentData(t, fix.cfg, seg.GetManifest(), readSchema, want)
+	require.EqualValues(t, 0, seg.GetStats().GetNullCounts()[addedID])
+}
+
+// [A3][S0] mixed additions: nullable + default + nullable-TEXT(binary NULL) in
+// one pass; the nullable and TEXT columns land as NULL, the default column
+// materializes its declared default (#52781/#52807), old columns stay golden.
+func TestBumpUTAdditiveMixedColumns(t *testing.T) {
+	setupBumpUTEnv(t)
+	const nullID, defID, textID = int64(103), int64(104), int64(105)
+	fix := buildBumpFixture(t,
+		withTargetAddedField(
+			&schemapb.FieldSchema{FieldID: nullID, Name: "n1", DataType: schemapb.DataType_Int64, Nullable: true},
+			&schemapb.FieldSchema{
+				FieldID: defID, Name: "d1", DataType: schemapb.DataType_Int64, Nullable: true,
+				DefaultValue: &schemapb.ValueField{Data: &schemapb.ValueField_LongData{LongData: 7}},
+			},
+			&schemapb.FieldSchema{
+				FieldID: textID, Name: "t1", DataType: schemapb.DataType_Text, Nullable: true,
+				TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "65535"}},
+			},
+		))
+
+	seg := runCompact(t, fix)
+	want := goldenWithAdded(fix.rows, nullID, func(int) any { return nil })
+	want = goldenWithAdded(want, defID, func(int) any { return int64(7) })
+	want = goldenWithAdded(want, textID, func(int) any { return nil })
+	readSchema := &schemapb.CollectionSchema{Fields: append(physicalReadFields(fix.sourceSchema),
+		typeutil.GetField(fix.targetSchema, nullID),
+		typeutil.GetField(fix.targetSchema, defID),
+		typeutil.GetField(fix.targetSchema, textID))}
+	verifySegmentData(t, fix.cfg, seg.GetManifest(), readSchema, want)
+	verifyManifestFields(t, fix.cfg, seg.GetManifest(), []int64{nullID, defID, textID}, nil)
+	require.EqualValues(t, 3, seg.GetStats().GetInsertBinlogCount())
+}
+
+// [A4][S0] BM25 materialization: sparse output present for every row and the
+// bm25 stats blob is committed and deserializable.
+func TestBumpUTAdditiveBM25Materialization(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := buildBumpFixture(t, withBM25Target())
+
+	seg := runCompact(t, fix)
+	require.EqualValues(t, len(fix.rows), seg.GetNumOfRows())
+	texts := make([]any, 0, 1)
+	rows := make([]string, len(fix.rows))
+	for i := range fix.rows {
+		rows[i] = bumpFxVarchar(bumpFxTextField, i)
+	}
+	texts = append(texts, rows)
+	expected := expectedBM25SparseRows(t, fix.targetSchema, fix.targetSchema.GetFunctions()[0], texts...)
+	requireSparseRows(t, fix, seg.GetManifest(), 102, len(fix.rows), expected)
+	// [ST1][S1] the committed stats ledger must equal the accumulation of
+	// exactly the written rows — deserializable+non-empty cannot see
+	// over/under-counting.
+	expectedStats := storage.NewBM25Stats()
+	expectedStats.AppendBytes(expected...)
+	require.Equal(t, expectedStats, requireBM25StatsBlob(t, fix, 102, len(fix.rows)))
+}
+
+// expectedMinHashRows derives the expected binary-vector bytes per row by
+// running the REAL MinHash runner over the deterministic golden inputs — same
+// oracle rationale as expectedBM25SparseRows: row<->content alignment, not
+// hash semantics.
+func expectedMinHashRows(t *testing.T, schema *schemapb.CollectionSchema, fn *schemapb.FunctionSchema, texts []string) [][]byte {
+	runner, err := function.NewFunctionRunner(schema, fn)
+	require.NoError(t, err)
+	defer runner.Close()
+	outputs, err := runner.BatchRun(texts)
+	require.NoError(t, err)
+	require.Len(t, outputs, 1)
+	fieldData, ok := outputs[0].(*schemapb.FieldData)
+	require.True(t, ok, "MinHash runner must return FieldData, got %T", outputs[0])
+	flat := fieldData.GetVectors().GetBinaryVector()
+	rowBytes := int(fieldData.GetVectors().GetDim()) / 8
+	require.Positive(t, rowBytes)
+	require.Len(t, flat, rowBytes*len(texts))
+	rows := make([][]byte, len(texts))
+	for i := range rows {
+		rows[i] = flat[i*rowBytes : (i+1)*rowBytes]
+	}
+	return rows
+}
+
+// [A5][S0] MinHash materialization: binary-vector output for every row, each
+// row byte-equal to the real runner's output for ITS OWN text (row<->content
+// alignment — Len/NotNil alone cannot see rotation, review Round-3).
+func TestBumpUTAdditiveMinHashMaterialization(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := buildBumpFixture(t,
+		withTargetAddedField(&schemapb.FieldSchema{
+			FieldID: 102, Name: "minhash", DataType: schemapb.DataType_BinaryVector, IsFunctionOutput: true,
+			TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "32"}},
+		}),
+		withTargetFunctions(&schemapb.FunctionSchema{
+			Name: "minhash_func", Id: 1000, Type: schemapb.FunctionType_MinHash,
+			InputFieldNames: []string{"text"}, InputFieldIds: []int64{bumpFxTextField},
+			OutputFieldNames: []string{"minhash"}, OutputFieldIds: []int64{102},
+		}),
+	)
+
+	seg := runCompact(t, fix)
+	got, total := readAllColumns(t, fix.cfg, seg.GetManifest(), &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{typeutil.GetField(fix.targetSchema, 102)},
+	})
+	require.Equal(t, len(fix.rows), total)
+	texts := make([]string, len(fix.rows))
+	for i := range fix.rows {
+		texts[i] = bumpFxVarchar(bumpFxTextField, i)
+	}
+	expected := expectedMinHashRows(t, fix.targetSchema, fix.targetSchema.GetFunctions()[0], texts)
+	for i, v := range got[102] {
+		require.NotNil(t, v, "minhash row %d", i)
+		require.Len(t, v.([]byte), 32/8, "minhash row %d dim", i)
+		require.Equal(t, expected[i], v.([]byte), "minhash content<->row alignment at %d", i)
+	}
+}
+
+// [A6][S0] BM25 multi-analyzer by_field: materialization succeeds with the
+// per-row analyzer selector physically read from the segment.
+func TestBumpUTAdditiveBM25MultiAnalyzer(t *testing.T) {
+	setupBumpUTEnv(t)
+	const langID = int64(115)
+	fix := buildBumpFixture(t,
+		withSourceFields(&schemapb.FieldSchema{
+			FieldID: langID, Name: "lang", DataType: schemapb.DataType_VarChar,
+			TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "16"}},
+		}),
+		withFillValue(func(i int, ts uint64, v map[int64]any) {
+			if i%2 == 0 {
+				v[langID] = "default"
+			} else {
+				v[langID] = "english"
+			}
+		}),
+		withMultiAnalyzerBM25Target(),
+	)
+
+	seg := runCompact(t, fix)
+	requireSparseRows(t, fix, seg.GetManifest(), 102, len(fix.rows), nil) // multi-analyzer needs the lang input; alignment oracle lives in A4/F21
+}
+
+// [A7][S0] multi-batch additive: new column stays row-aligned with the anchor
+// across reader batches (pk-value cross-check).
+func TestBumpUTAdditiveMultiBatchAlignment(t *testing.T) {
+	setupBumpUTEnv(t)
+	const rows = 50_000
+	const addedID = int64(103)
+	fix := buildBumpFixture(t, withRows(rows),
+		withFillValue(func(i int, ts uint64, v map[int64]any) {
+			v[bumpFxTextField] = fmt.Sprintf("%s-%s", bumpFxVarchar(bumpFxTextField, i), bumpFxPad)
+		}),
+		withTargetAddedField(&schemapb.FieldSchema{
+			FieldID: addedID, Name: "added", DataType: schemapb.DataType_Int64, Nullable: true,
+		}))
+
+	seg := runCompact(t, fix)
+	require.EqualValues(t, rows, seg.GetNumOfRows())
+
+	readSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		typeutil.GetField(fix.targetSchema, bumpFxPKField),
+		typeutil.GetField(fix.targetSchema, addedID),
+	}}
+	got, total := readAllColumns(t, fix.cfg, seg.GetManifest(), readSchema)
+	require.Equal(t, rows, total)
+	for i := 0; i < rows; i += 997 { // stride sampling incl. batch boundaries
+		require.Equal(t, int64(i), got[bumpFxPKField][i], "pk alignment at %d", i)
+		require.Nil(t, got[addedID][i], "added col at %d", i)
+	}
+	require.EqualValues(t, rows, seg.GetStats().GetNullCounts()[addedID])
+}
+
+// [A11][S0] #52159 shape: the BM25 input field itself was added after sealing
+// (physically absent). Input is synthesized, output materialized, no crash.
+func TestBumpUTAdditiveFunctionInputAddedAfterSeal(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := buildBumpFixture(t,
+		withoutSourceText(),
+		withTargetAddedField(&schemapb.FieldSchema{
+			FieldID: bumpFxTextField, Name: "text", DataType: schemapb.DataType_VarChar, Nullable: true,
+			TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "2048"}},
+		}),
+		withBM25Target(),
+	)
+
+	seg := runCompact(t, fix)
+	require.EqualValues(t, len(fix.rows), seg.GetNumOfRows())
+	// Both the synthesized input column and the function output must land.
+	// Empty synthesized text yields empty embeddings, so cells may legally read
+	// back NULL — row cardinality is the invariant here.
+	verifyManifestFields(t, fix.cfg, seg.GetManifest(), []int64{bumpFxTextField, 102}, nil)
+	_, total := readAllColumns(t, fix.cfg, seg.GetManifest(), &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{typeutil.GetField(fix.targetSchema, 102)},
+	})
+	require.Equal(t, len(fix.rows), total)
+}
+
+// ---------------------------------------------------------------------------
+// full rewrite
+// ---------------------------------------------------------------------------
+
+// [F2][S0] real deltalog: deleted rows are physically dropped, survivors stay
+// golden in every column, NumOfRows is exact.
+func TestBumpUTFullRewriteAppliesRealDelta(t *testing.T) {
+	setupBumpUTEnv(t)
+	const droppedID = int64(103)
+	// pk 5 is an upsert-shaped boundary: delete ts == row ts. Per the delete
+	// contract (entity_filter.go: "Strict < is preserved so upserts keep the
+	// inserted row") it must SURVIVE — this expectation is spec-derived, and
+	// guards the < vs <= boundary independently of the implementation.
+	fix := buildBumpFixture(t, withRows(6),
+		withSourceFields(&schemapb.FieldSchema{FieldID: droppedID, Name: "dropped", DataType: schemapb.DataType_Int64}),
+		withFillValue(func(i int, ts uint64, v map[int64]any) { v[droppedID] = int64(i) }),
+		withTargetDroppedField(droppedID),
+		withDeletedPKs(map[any]uint64{int64(1): bumpFxTS(1) + 1, int64(4): bumpFxTS(4) + 1, int64(5): bumpFxTS(5)}),
+	)
+	require.Len(t, fix.keptRows(), 4, "fixture golden: rows 1,4 deleted; upsert-boundary row 5 kept")
+
+	seg := runCompact(t, fix)
+	require.EqualValues(t, 4, seg.GetNumOfRows())
+	verifySegmentData(t, fix.cfg, seg.GetManifest(),
+		&schemapb.CollectionSchema{Fields: physicalReadFields(fix.targetSchema)}, dropField(fix.keptRows(), droppedID))
+}
+
+// [F3][S0] collection TTL: expired rows dropped, fresh rows kept and golden.
+func TestBumpUTFullRewriteCollectionTTL(t *testing.T) {
+	setupBumpUTEnv(t)
+	const droppedID = int64(103)
+	nowTS := tsoutil.ComposeTSByTime(time.Now())
+	fix := buildBumpFixture(t, withRows(6),
+		withRowTs(func(i int) uint64 {
+			if i < 2 {
+				return bumpFxTS(i) // 2021 -> expired under 1h TTL
+			}
+			return nowTS + uint64(i)
+		}),
+		withSourceFields(&schemapb.FieldSchema{FieldID: droppedID, Name: "dropped", DataType: schemapb.DataType_Int64}),
+		withFillValue(func(i int, ts uint64, v map[int64]any) { v[droppedID] = int64(i) }),
+		withTargetDroppedField(droppedID),
+		withCollectionTTL(time.Hour),
+	)
+	require.Len(t, fix.keptRows(), 4)
+
+	seg := runCompact(t, fix)
+	require.EqualValues(t, 4, seg.GetNumOfRows())
+	verifySegmentData(t, fix.cfg, seg.GetManifest(),
+		&schemapb.CollectionSchema{Fields: physicalReadFields(fix.targetSchema)}, dropField(fix.keptRows(), droppedID))
+}
+
+// [F4][S0] entity-TTL column: expired-by-value rows dropped, NULL-TTL rows kept.
+func TestBumpUTFullRewriteEntityTTLColumn(t *testing.T) {
+	setupBumpUTEnv(t)
+	const droppedID, ttlID = int64(103), int64(104)
+	past := time.Now().Add(-time.Hour).UnixMicro()
+	future := time.Now().Add(24 * time.Hour).UnixMicro()
+	fix := buildBumpFixture(t, withRows(6),
+		withSourceFields(
+			&schemapb.FieldSchema{FieldID: droppedID, Name: "dropped", DataType: schemapb.DataType_Int64},
+			&schemapb.FieldSchema{FieldID: ttlID, Name: "expire_at", DataType: schemapb.DataType_Timestamptz, Nullable: true},
+		),
+		withFillValue(func(i int, ts uint64, v map[int64]any) {
+			v[droppedID] = int64(i)
+			switch i % 3 {
+			case 0:
+				v[ttlID] = past // expired
+			case 1:
+				v[ttlID] = future // kept
+			default:
+				v[ttlID] = nil // NULL ttl -> kept
+			}
+		}),
+		withTargetDroppedField(droppedID),
+		withTTLProperty("expire_at"),
+	)
+	require.Len(t, fix.keptRows(), 4)
+
+	seg := runCompact(t, fix)
+	require.EqualValues(t, 4, seg.GetNumOfRows())
+	verifySegmentData(t, fix.cfg, seg.GetManifest(),
+		&schemapb.CollectionSchema{Fields: physicalReadFields(fix.targetSchema)}, dropField(fix.keptRows(), droppedID))
+}
+
+// [F5][S0] delete + collection TTL + entity TTL combined, disjoint causes.
+func TestBumpUTFullRewriteMixedFilters(t *testing.T) {
+	setupBumpUTEnv(t)
+	const droppedID, ttlID = int64(103), int64(104)
+	nowTS := tsoutil.ComposeTSByTime(time.Now())
+	past := time.Now().Add(-time.Hour).UnixMicro()
+	future := time.Now().Add(24 * time.Hour).UnixMicro()
+	fix := buildBumpFixture(t, withRows(6),
+		withRowTs(func(i int) uint64 {
+			if i == 1 {
+				return bumpFxTS(i) // collection-TTL victim
+			}
+			return nowTS + uint64(i)
+		}),
+		withSourceFields(
+			&schemapb.FieldSchema{FieldID: droppedID, Name: "dropped", DataType: schemapb.DataType_Int64},
+			&schemapb.FieldSchema{FieldID: ttlID, Name: "expire_at", DataType: schemapb.DataType_Timestamptz, Nullable: true},
+		),
+		withFillValue(func(i int, ts uint64, v map[int64]any) {
+			v[droppedID] = int64(i)
+			if i == 2 {
+				v[ttlID] = past // entity-TTL victim
+			} else {
+				v[ttlID] = future
+			}
+		}),
+		withTargetDroppedField(droppedID),
+		withTTLProperty("expire_at"),
+		withCollectionTTL(time.Hour),
+		withDeletedPKs(map[any]uint64{int64(0): nowTS + 100}), // delete victim
+	)
+	require.Len(t, fix.keptRows(), 3)
+
+	seg := runCompact(t, fix)
+	require.EqualValues(t, 3, seg.GetNumOfRows())
+	verifySegmentData(t, fix.cfg, seg.GetManifest(),
+		&schemapb.CollectionSchema{Fields: physicalReadFields(fix.targetSchema)}, dropField(fix.keptRows(), droppedID))
+}
+
+// [F6][S0] deletes spanning reader-batch boundaries, including a fully deleted
+// prefix run — the compacted output must stay row-aligned in every column.
+func TestBumpUTFullRewriteCrossBatchDeletes(t *testing.T) {
+	setupBumpUTEnv(t)
+	const rows = 30_000
+	const droppedID = int64(103)
+	deleted := map[any]uint64{}
+	for i := 0; i < 512; i++ { // fully deleted prefix run
+		deleted[int64(i)] = bumpFxTS(i) + 1
+	}
+	for i := 511; i < rows; i += 1013 { // scattered mid/batch-edge deletes
+		deleted[int64(i)] = bumpFxTS(i) + 1
+	}
+	fix := buildBumpFixture(t, withRows(rows),
+		withSourceFields(&schemapb.FieldSchema{FieldID: droppedID, Name: "dropped", DataType: schemapb.DataType_Int64}),
+		withFillValue(func(i int, ts uint64, v map[int64]any) {
+			v[droppedID] = int64(i)
+			v[bumpFxTextField] = fmt.Sprintf("%s-%s", bumpFxVarchar(bumpFxTextField, i), bumpFxPad)
+		}),
+		withTargetDroppedField(droppedID),
+		withDeletedPKs(deleted),
+	)
+	kept := fix.keptRows()
+	require.Equal(t, rows-len(deleted), len(kept))
+
+	seg := runCompact(t, fix)
+	require.EqualValues(t, len(kept), seg.GetNumOfRows())
+	got, total := readAllColumns(t, fix.cfg, seg.GetManifest(), &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{typeutil.GetField(fix.targetSchema, bumpFxPKField)},
+	})
+	require.Equal(t, len(kept), total)
+	for i, want := range kept {
+		require.Equal(t, want.pk, got[bumpFxPKField][i], "pk order at %d", i)
+	}
+}
+
+// [F7][S0] filter armed but zero rows match: the zero-copy fast path must still
+// produce a golden replacement.
+func TestBumpUTFullRewriteFilterZeroHits(t *testing.T) {
+	setupBumpUTEnv(t)
+	const droppedID = int64(103)
+	nowTS := tsoutil.ComposeTSByTime(time.Now())
+	fix := buildBumpFixture(t, withRows(4),
+		withRowTs(func(i int) uint64 { return nowTS + uint64(i) }),
+		withSourceFields(&schemapb.FieldSchema{FieldID: droppedID, Name: "dropped", DataType: schemapb.DataType_Int64}),
+		withFillValue(func(i int, ts uint64, v map[int64]any) { v[droppedID] = int64(i) }),
+		withTargetDroppedField(droppedID),
+		withCollectionTTL(time.Hour),
+	)
+	require.Len(t, fix.keptRows(), 4)
+
+	seg := runCompact(t, fix)
+	require.EqualValues(t, 4, seg.GetNumOfRows())
+	verifySegmentData(t, fix.cfg, seg.GetManifest(),
+		&schemapb.CollectionSchema{Fields: physicalReadFields(fix.targetSchema)}, dropField(fix.keptRows(), droppedID))
+}
+
+// [F8][S1] everything deleted: the rewrite legally produces an empty result
+// (0 rows, empty manifest) and never builds a text index.
+func TestBumpUTFullRewriteAllRowsDeleted(t *testing.T) {
+	setupBumpUTEnv(t)
+	const droppedID = int64(103)
+	nowTS := tsoutil.ComposeTSByTime(time.Now())
+	fix := buildBumpFixture(t, withRows(3),
+		withSourceFields(&schemapb.FieldSchema{FieldID: droppedID, Name: "dropped", DataType: schemapb.DataType_Int64}),
+		withFillValue(func(i int, ts uint64, v map[int64]any) { v[droppedID] = int64(i) }),
+		withTargetDroppedField(droppedID),
+		withDeletedPKs(map[any]uint64{int64(0): nowTS, int64(1): nowTS, int64(2): nowTS}),
+	)
+	require.Empty(t, fix.keptRows())
+
+	textIndexCalls := 0
+	patch := mockey.Mock(createTextIndex).To(func(_ context.Context, _ storage.ChunkManager, _ *datapb.CompactionPlan, _ compaction.Params,
+		_ int64, _ int64, _ int64, _ int64, _ int64, _ *datapb.CompactionSegment,
+	) (map[int64]*datapb.TextIndexStats, error) {
+		textIndexCalls++
+		return nil, nil
+	}).Build()
+	defer patch.UnPatch()
+
+	seg := runCompact(t, fix)
+	require.EqualValues(t, 0, seg.GetNumOfRows())
+	require.Empty(t, seg.GetManifest())
+	require.Zero(t, textIndexCalls, "text index must not run for an empty rewrite")
+}
+
+// [F9][S0] VarChar primary key with deletes.
+func TestBumpUTFullRewriteVarCharPK(t *testing.T) {
+	setupBumpUTEnv(t)
+	const droppedID = int64(103)
+	fix := buildBumpFixture(t, withRows(5), withVarCharPK(),
+		withSourceFields(&schemapb.FieldSchema{FieldID: droppedID, Name: "dropped", DataType: schemapb.DataType_Int64}),
+		withFillValue(func(i int, ts uint64, v map[int64]any) { v[droppedID] = int64(i) }),
+		withTargetDroppedField(droppedID),
+		withDeletedPKs(map[any]uint64{"pk-000002": bumpFxTS(2) + 1}),
+	)
+	require.Len(t, fix.keptRows(), 4)
+
+	seg := runCompact(t, fix)
+	require.EqualValues(t, 4, seg.GetNumOfRows())
+	verifySegmentData(t, fix.cfg, seg.GetManifest(),
+		&schemapb.CollectionSchema{Fields: physicalReadFields(fix.targetSchema)}, dropField(fix.keptRows(), droppedID))
+}
+
+// [F11][S0] commit-timestamp normalization across all rows: the output ts
+// column must read back as commitTs everywhere.
+func TestBumpUTFullRewriteCommitTsNormalization(t *testing.T) {
+	setupBumpUTEnv(t)
+	const droppedID = int64(103)
+	commitTs := tsoutil.ComposeTSByTime(time.Now())
+	fix := buildBumpFixture(t, withRows(5),
+		withSourceFields(&schemapb.FieldSchema{FieldID: droppedID, Name: "dropped", DataType: schemapb.DataType_Int64}),
+		withFillValue(func(i int, ts uint64, v map[int64]any) { v[droppedID] = int64(i) }),
+		withTargetDroppedField(droppedID),
+		withCommitTs(commitTs),
+	)
+
+	seg := runCompact(t, fix)
+	require.EqualValues(t, 5, seg.GetNumOfRows())
+	got, total := readAllColumns(t, fix.cfg, seg.GetManifest(), timestampReadSchema())
+	require.Equal(t, 5, total)
+	for i, v := range got[common.TimeStampField] {
+		require.Equal(t, int64(commitTs), v, "row %d ts must be normalized to commitTs", i)
+	}
+	// [TS3][S0] commitTs must ONLY rewrite ts: row_id still passes through.
+	verifySystemColumns(t, fix, seg.GetManifest(),
+		func(i int) int64 { return int64(i) }, nil)
+}
+
+// [F12][S1] ExpirQuantiles passthrough: the result must carry exactly what the
+// writer returned (writer-owned metadata, no bump-side recomputation).
+func TestBumpUTFullRewriteQuantilesPassthrough(t *testing.T) {
+	setupBumpUTEnv(t)
+	const droppedID = int64(103)
+	fix := buildBumpFixture(t,
+		withSourceFields(&schemapb.FieldSchema{FieldID: droppedID, Name: "dropped", DataType: schemapb.DataType_Int64}),
+		withFillValue(func(i int, ts uint64, v map[int64]any) { v[droppedID] = int64(i) }),
+		withTargetDroppedField(droppedID),
+	)
+
+	writer := &fakeBinlogRecordWriter{
+		fieldBinlogs: map[storage.FieldID]*datapb.FieldBinlog{
+			bumpFxPKField: {FieldID: bumpFxPKField, Binlogs: []*datapb.Binlog{{LogID: 1, EntriesNum: 3}}},
+		},
+		manifest:       packed.MarshalManifestPath(mustBasePath(t, fix.sourceManifest)+"-out", 1),
+		expirQuantiles: []int64{11, 22, 33},
+		schema:         fix.targetSchema,
+	}
+	patch := mockey.Mock(storage.NewBinlogRecordWriter).Return(writer, nil).Build()
+	defer patch.UnPatch()
+
+	seg := runCompact(t, fix)
+	require.Equal(t, []int64{11, 22, 33}, seg.GetExpirQuantiles())
+}
+
+// [F21][S0] dropped field + missing function output combined: full rewrite
+// materializes the function output while dropping the column.
+func TestBumpUTFullRewriteMaterializesFunctionOutput(t *testing.T) {
+	setupBumpUTEnv(t)
+	const droppedID = int64(103)
+	fix := buildBumpFixture(t,
+		withSourceFields(&schemapb.FieldSchema{FieldID: droppedID, Name: "dropped", DataType: schemapb.DataType_Int64}),
+		withFillValue(func(i int, ts uint64, v map[int64]any) { v[droppedID] = int64(i) }),
+		withTargetDroppedField(droppedID),
+		withBM25Target(),
+	)
+
+	seg := runCompact(t, fix)
+	require.EqualValues(t, len(fix.rows), seg.GetNumOfRows())
+	verifyManifestFields(t, fix.cfg, seg.GetManifest(), []int64{102}, []int64{droppedID})
+	f21Texts := make([]string, len(fix.rows))
+	for i := range fix.rows {
+		f21Texts[i] = bumpFxVarchar(bumpFxTextField, i)
+	}
+	f21Expected := expectedBM25SparseRows(t, fix.targetSchema, fix.targetSchema.GetFunctions()[0], f21Texts)
+	requireSparseRows(t, fix, seg.GetManifest(), 102, len(fix.rows), f21Expected)
+}
+
+// ---------------------------------------------------------------------------
+// P1 regression: materialization slice budget (buqian review, PR #52484)
+// ---------------------------------------------------------------------------
+
+// [P1][S2][characterization] The no-fix decision for the additive batch
+// amplification review (PR #52484, buqian) rests on two implicit
+// storage-layer contracts, pinned here:
+//  1. the V3 manifest reader delivers exactly ONE row group per Next()
+//     (milvus-storage file_reader.cpp ReadNextRowGroup/SliceRowGroupFromTable;
+//     buffer_size only controls prefetch), and
+//  2. writer row groups cap at ~1MB uncompressed (DEFAULT_MAX_ROW_GROUP_SIZE),
+//
+// so a batch carries at most ~1MB/row-width rows and materialization amplifies
+// a bounded row count (~1MB x materializedWidth/rowWidth per batch).
+// If this test fails, the reader's batching contract changed and the
+// amplification risk must be re-assessed.
+func TestBumpUTReaderDeliversPerRowGroupBatches(t *testing.T) {
+	setupBumpUTEnv(t)
+	const rows = 30000
+	fix := buildBumpFixture(t, withRows(rows))
+
+	count := func(bufSize int64, fields []*schemapb.FieldSchema) (batches, maxBatchRows, total int) {
+		opts := []storage.RwOption{
+			storage.WithCollectionID(CollectionID),
+			storage.WithVersion(storage.StorageV3),
+			storage.WithStorageConfig(fix.cfg),
+		}
+		if bufSize > 0 {
+			opts = append(opts, storage.WithBufferSize(bufSize))
+		}
+		reader, _, err := newCompactionSegmentRecordReader(context.Background(),
+			fix.segment, &schemapb.CollectionSchema{Fields: fields}, fix.cfg, opts...)
+		require.NoError(t, err)
+		defer reader.Close()
+		for {
+			rec, err := reader.Next()
+			if err == sio.EOF {
+				break
+			}
+			require.NoError(t, err)
+			batches++
+			maxBatchRows = max(maxBatchRows, rec.Len())
+			total += rec.Len()
+		}
+		return
+	}
+
+	full := physicalReadFields(fix.sourceSchema)
+	// The production additive anchor is the RowID SYSTEM column (field 0) —
+	// physicalReadFields strips system fields, so build it explicitly; the
+	// narrow user column (pk) is kept as a third projection for contrast.
+	rowIDOnly := []*schemapb.FieldSchema{{FieldID: common.RowIDField, Name: "row_id", DataType: schemapb.DataType_Int64}}
+	pkOnly := full[:1]
+
+	refBatches, refMax, refTotal := count(0, full)
+	require.Equal(t, rows, refTotal)
+	require.Greater(t, refBatches, 1, "a multi-row-group segment must yield multiple batches")
+	require.Less(t, refMax, rows, "one batch must never carry the whole segment")
+	// Absolute amplitude bound: fixture rows are ~139B, so a 1MB row group
+	// holds ~7.5k rows; 16384 gives ~2x headroom while still failing loudly if
+	// the storage layer ever grows DEFAULT_MAX_ROW_GROUP_SIZE — which would
+	// silently re-open the amplification vector this test guards against.
+	require.LessOrEqual(t, refMax, 16384, "row-group quantum grew: re-assess the amplification risk")
+
+	// Delivery granularity must be invariant to both the buffer size and the
+	// read projection: always one row group per batch.
+	for _, tc := range []struct {
+		name    string
+		bufSize int64
+		fields  []*schemapb.FieldSchema
+	}{
+		{"full-projection small buffer", 8 * 1024, full},
+		{"rowid-anchor default buffer", 0, rowIDOnly},
+		{"rowid-anchor small buffer", 8 * 1024, rowIDOnly},
+		{"pk-only small buffer", 8 * 1024, pkOnly},
+	} {
+		batches, maxRows, total := count(tc.bufSize, tc.fields)
+		require.Equal(t, refBatches, batches, tc.name)
+		require.Equal(t, refMax, maxRows, tc.name)
+		require.Equal(t, rows, total, tc.name)
+	}
+}
+
+// ============================================================================
+// Fault injection: error class + cleanup + source-intact (A/F fault series)
+// ============================================================================
+// Every fault case follows the same triple assertion: (1) the injected failure
+// surfaces as an error of the right class, (2) partial writers are cleaned up,
+// (3) the source segment stays fully intact (no dirty adoption input).
+
+var errBumpUTInjected = errors.New("bump-ut injected failure")
+
+// faultBatchWriter is a bumpSchemaVersionBatchWriter with injectable failures.
+type faultBatchWriter struct {
+	writeErr error
+	closeErr error
+	writes   int
+	closes   int
+	aborts   int
+}
+
+func (w *faultBatchWriter) Write(storage.Record) error {
+	w.writes++
+	return w.writeErr
+}
+func (w *faultBatchWriter) GetWrittenUncompressed() uint64 { return 0 }
+func (w *faultBatchWriter) AsNewColumnGroups()             {}
+func (w *faultBatchWriter) Abort()                         { w.aborts++ }
+func (w *faultBatchWriter) Close() (packed.WriterOutput, error) {
+	w.closes++
+	if w.closeErr != nil {
+		return nil, w.closeErr
+	}
+	return nil, nil
+}
+
+func faultWriterResult(w *faultBatchWriter, fix *bumpFixture) *bumpSchemaVersionWriterResult {
+	const addedID = int64(103)
+	basePath := mustBasePath(fix.t, fix.sourceManifest)
+	return &bumpSchemaVersionWriterResult{
+		writer: w,
+		columnGroups: []storagecommon.ColumnGroup{{
+			GroupID: addedID, Columns: []int{0}, Fields: []int64{addedID},
+		}},
+		storageVersion: storage.StorageV3,
+		basePath:       basePath,
+		baseVersion:    1,
+	}
+}
+
+func additiveFixture(t *testing.T) *bumpFixture {
+	return buildBumpFixture(t, withTargetAddedField(&schemapb.FieldSchema{
+		FieldID: 103, Name: "added", DataType: schemapb.DataType_Int64, Nullable: true,
+	}))
+}
+
+func fullRewriteFixture(t *testing.T) *bumpFixture {
+	return buildBumpFixture(t,
+		withSourceFields(&schemapb.FieldSchema{FieldID: 103, Name: "dropped", DataType: schemapb.DataType_Int64}),
+		withFillValue(func(i int, ts uint64, v map[int64]any) { v[103] = int64(i) }),
+		withTargetDroppedField(103),
+	)
+}
+
+// [A12][S1] additive writer.Write fails mid-flight: the lease must Abort the
+// writer, never Close it, and the source segment must stay untouched.
+func TestBumpUTFaultAdditiveWriteError(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := additiveFixture(t)
+	fw := &faultBatchWriter{writeErr: errBumpUTInjected}
+	patch := mockey.Mock((*bumpSchemaVersionCompactionTask).setupWriter).
+		Return(faultWriterResult(fw, fix), nil).Build()
+	defer patch.UnPatch()
+
+	_, err := fix.task.Compact()
+	require.ErrorIs(t, err, errBumpUTInjected)
+	require.Equal(t, 1, fw.aborts)
+	require.Zero(t, fw.closes)
+	verifySourceIntact(t, fix)
+}
+
+// [A13][S1] additive writer.Close fails: error surfaces, the lease stays
+// unconsumed, and the deferred Cleanup Aborts the writer.
+func TestBumpUTFaultAdditiveCloseError(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := additiveFixture(t)
+	fw := &faultBatchWriter{closeErr: errBumpUTInjected}
+	patch := mockey.Mock((*bumpSchemaVersionCompactionTask).setupWriter).
+		Return(faultWriterResult(fw, fix), nil).Build()
+	defer patch.UnPatch()
+
+	_, err := fix.task.Compact()
+	require.ErrorIs(t, err, errBumpUTInjected)
+	require.Equal(t, 1, fw.closes)
+	require.Equal(t, 1, fw.aborts, "Close failure keeps the lease unconsumed; Cleanup must Abort")
+	verifySourceIntact(t, fix)
+}
+
+// [A14][S1] manifest commit fails: writer output is still destroyed and the
+// source manifest pointer never advances.
+func TestBumpUTFaultAdditiveCommitError(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := additiveFixture(t)
+	fw := &faultBatchWriter{}
+	writerPatch := mockey.Mock((*bumpSchemaVersionCompactionTask).setupWriter).
+		Return(faultWriterResult(fw, fix), nil).Build()
+	defer writerPatch.UnPatch()
+	commitPatch := mockey.Mock(packed.CommitManifestUpdates).
+		Return("", errBumpUTInjected).Build()
+	defer commitPatch.UnPatch()
+
+	_, err := fix.task.Compact()
+	require.ErrorIs(t, err, errBumpUTInjected)
+	require.Equal(t, 1, fw.closes, "writer must be closed before commit")
+	verifySourceIntact(t, fix)
+}
+
+// [A15][S3] corrupt manifest string reaching setupWriter: DataIntegrity, not a
+// crash. Driven through runAdditivePhysicalReconciliation directly because the
+// decision step would reject the manifest earlier on the full Compact path.
+func TestBumpUTFaultAdditiveBadManifest(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := additiveFixture(t)
+	fix.segment.Manifest = "not-a-manifest"
+	diff := &schemaBumpPhysicalDiff{
+		existingFields: map[int64]struct{}{
+			common.RowIDField: {}, common.TimeStampField: {}, bumpFxPKField: {}, bumpFxTextField: {},
+		},
+		absentOrdinaryFields: []*schemapb.FieldSchema{typeutil.GetField(fix.targetSchema, 103)},
+	}
+	readerPatch := mockey.Mock((*bumpSchemaVersionCompactionTask).openRecordReader).
+		Return(&emptyRecordReader{}, diff.existingFields, nil).Build()
+	defer readerPatch.UnPatch()
+
+	_, err := fix.task.runAdditivePhysicalReconciliation(context.Background(), diff)
+	require.Error(t, err)
+	require.ErrorIs(t, err, merr.ErrDataIntegrity)
+	require.ErrorContains(t, err, "failed to parse existing manifest")
+}
+
+// [A16][S1] V3 stats blob write fails (BM25 path): error propagates, source intact.
+func TestBumpUTFaultAdditiveStatsWriteError(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := buildBumpFixture(t, withBM25Target())
+	patch := mockey.Mock(packed.WriteFile).Return(errBumpUTInjected).Build()
+	defer patch.UnPatch()
+
+	_, err := fix.task.Compact()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to write V3 stats")
+	verifySourceIntact(t, fix)
+}
+
+// [A19][S1] segment reader cannot open: warn branch + propagation.
+func TestBumpUTFaultAdditiveReaderOpenError(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := additiveFixture(t)
+	patch := mockey.Mock(storage.NewManifestRecordReader).
+		Return(nil, errBumpUTInjected).Build()
+
+	_, err := fix.task.Compact()
+	patch.UnPatch() // verification below needs the real reader
+	require.ErrorIs(t, err, errBumpUTInjected)
+	verifySourceIntact(t, fix)
+}
+
+// [A20][S1] plugin-context resolution fails during writer setup.
+func TestBumpUTFaultAdditivePluginContextError(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := additiveFixture(t)
+	patch := mockey.Mock(hookutil.GetCPluginContext).
+		Return((*indexcgopb.StoragePluginContext)(nil), errBumpUTInjected).Build()
+	defer patch.UnPatch()
+
+	_, err := fix.task.Compact()
+	require.ErrorIs(t, err, errBumpUTInjected)
+	verifySourceIntact(t, fix)
+}
+
+// faultRecordReader fails immediately on Next.
+type faultRecordReader struct{ err error }
+
+func (r *faultRecordReader) Next() (storage.Record, error) { return nil, r.err }
+func (r *faultRecordReader) Close() error                  { return nil }
+
+// [F14][S1] full-rewrite reader fails: error propagates, source intact.
+func TestBumpUTFaultFullRewriteReaderError(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := fullRewriteFixture(t)
+	patch := mockey.Mock(newCompactionSegmentRecordReaderWithFields).
+		Return(&faultRecordReader{err: errBumpUTInjected}, nil, nil).Build()
+	defer patch.UnPatch()
+
+	_, err := fix.task.Compact()
+	require.ErrorIs(t, err, errBumpUTInjected)
+	verifySourceIntact(t, fix)
+}
+
+// faultBinlogWriter is a storage.BinlogRecordWriter with injectable failures.
+type faultBinlogWriter struct {
+	writeErr error
+	closeErr error
+	statsLog *datapb.FieldBinlog
+	manifest string
+	schema   *schemapb.CollectionSchema
+	rows     int64
+}
+
+func (w *faultBinlogWriter) Write(r storage.Record) error {
+	if w.writeErr != nil {
+		return w.writeErr
+	}
+	w.rows += int64(r.Len())
+	return nil
+}
+func (w *faultBinlogWriter) Close() error { return w.closeErr }
+func (w *faultBinlogWriter) GetLogs() (map[storage.FieldID]*datapb.FieldBinlog, *datapb.FieldBinlog, map[storage.FieldID]*datapb.FieldBinlog, string, []int64) {
+	return map[storage.FieldID]*datapb.FieldBinlog{}, w.statsLog, nil, w.manifest, nil
+}
+func (w *faultBinlogWriter) GetRowNum() int64                   { return w.rows }
+func (w *faultBinlogWriter) GetStatsBlobSize() int64            { return 0 }
+func (w *faultBinlogWriter) FlushChunk() error                  { return nil }
+func (w *faultBinlogWriter) GetBufferUncompressed() uint64      { return 0 }
+func (w *faultBinlogWriter) GetWrittenUncompressed() uint64     { return 0 }
+func (w *faultBinlogWriter) Schema() *schemapb.CollectionSchema { return w.schema }
+
+// [F15][S2] full-rewrite writer.Write fails: clean error, no panic, no leak of
+// the wrapped record path.
+func TestBumpUTFaultFullRewriteWriteError(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := fullRewriteFixture(t)
+	fw := &faultBinlogWriter{writeErr: errBumpUTInjected, schema: fix.targetSchema}
+	patch := mockey.Mock(storage.NewBinlogRecordWriter).Return(fw, nil).Build()
+	defer patch.UnPatch()
+
+	_, err := fix.task.Compact()
+	require.ErrorIs(t, err, errBumpUTInjected)
+	verifySourceIntact(t, fix)
+}
+
+// [F16][S1] full-rewrite writer.Close fails.
+func TestBumpUTFaultFullRewriteCloseError(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := fullRewriteFixture(t)
+	fw := &faultBinlogWriter{closeErr: errBumpUTInjected, schema: fix.targetSchema}
+	patch := mockey.Mock(storage.NewBinlogRecordWriter).Return(fw, nil).Build()
+	defer patch.UnPatch()
+
+	_, err := fix.task.Compact()
+	require.ErrorIs(t, err, errBumpUTInjected)
+	verifySourceIntact(t, fix)
+}
+
+// [F17][S1] committing writer stats to the manifest fails.
+func TestBumpUTFaultFullRewriteAddStatsError(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := fullRewriteFixture(t)
+	fw := &faultBinlogWriter{
+		schema:   fix.targetSchema,
+		manifest: packed.MarshalManifestPath(mustBasePath(t, fix.sourceManifest)+"-out", 1),
+		statsLog: &datapb.FieldBinlog{FieldID: bumpFxPKField, Binlogs: []*datapb.Binlog{{LogID: 1, MemorySize: 8}}},
+	}
+	writerPatch := mockey.Mock(storage.NewBinlogRecordWriter).Return(fw, nil).Build()
+	defer writerPatch.UnPatch()
+	statsPatch := mockey.Mock(packed.AddStatsToManifest).Return("", errBumpUTInjected).Build()
+	defer statsPatch.UnPatch()
+
+	_, err := fix.task.Compact()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to add writer stats")
+	verifySourceIntact(t, fix)
+}
+
+// [F18][S1] LOB reference merge fails (TEXT schema, REUSE_ALL context).
+func TestBumpUTFaultFullRewriteLOBMergeError(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := buildBumpFixture(t,
+		withSourceFields(&schemapb.FieldSchema{FieldID: 103, Name: "dropped", DataType: schemapb.DataType_Int64}),
+		withFillValue(func(i int, ts uint64, v map[int64]any) { v[103] = int64(i) }),
+		withTargetDroppedField(103),
+		withTargetAddedField(&schemapb.FieldSchema{
+			FieldID: 105, Name: "note", DataType: schemapb.DataType_Text, Nullable: true,
+			TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "65535"}},
+		}),
+	)
+	patch := mockey.Mock(compaction.ApplyLobCompactionToManifests).
+		Return(map[int64]string(nil), errBumpUTInjected).Build()
+	defer patch.UnPatch()
+
+	_, err := fix.task.Compact()
+	require.ErrorIs(t, err, errBumpUTInjected)
+	verifySourceIntact(t, fix)
+}
+
+// [F19][S1] text index build fails after data is written: error propagates,
+// no partial adoption input is produced.
+func TestBumpUTFaultFullRewriteTextIndexError(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := fullRewriteFixture(t)
+	patch := mockey.Mock(createTextIndex).To(func(_ context.Context, _ storage.ChunkManager, _ *datapb.CompactionPlan, _ compaction.Params,
+		_ int64, _ int64, _ int64, _ int64, _ int64, _ *datapb.CompactionSegment,
+	) (map[int64]*datapb.TextIndexStats, error) {
+		return nil, errBumpUTInjected
+	}).Build()
+	defer patch.UnPatch()
+
+	_, err := fix.task.Compact()
+	require.ErrorIs(t, err, errBumpUTInjected)
+	verifySourceIntact(t, fix)
+}
+
+var _ storage.BinlogRecordWriter = (*faultBinlogWriter)(nil)
+
+var _ = indexpb.StorageConfig{} // keep import for future fault cases
+
+// [F22][S3] target schema without a primary key: full rewrite fails upfront.
+func TestBumpUTFaultFullRewriteNoPrimaryKey(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := fullRewriteFixture(t)
+	for _, f := range fix.targetSchema.GetFields() {
+		f.IsPrimaryKey = false
+	}
+	_, err := fix.task.Compact()
+	require.Error(t, err)
+}
+
+// [F23][S1] delta composition fails: full rewrite aborts before writing.
+func TestBumpUTFaultFullRewriteComposeDeltaError(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := fullRewriteFixture(t)
+	patch := mockey.Mock(compaction.ComposeDeleteFromDeltalogs).
+		Return(map[any]typeutil.Timestamp(nil), errBumpUTInjected).Build()
+	defer patch.UnPatch()
+
+	_, err := fix.task.Compact()
+	require.ErrorIs(t, err, errBumpUTInjected)
+	verifySourceIntact(t, fix)
+}
+
+// [F24][S1] LOB collection from the source manifest fails during init.
+func TestBumpUTFaultFullRewriteCollectLobError(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := buildBumpFixture(t,
+		withSourceFields(&schemapb.FieldSchema{FieldID: 103, Name: "dropped", DataType: schemapb.DataType_Int64}),
+		withFillValue(func(i int, ts uint64, v map[int64]any) { v[103] = int64(i) }),
+		withTargetDroppedField(103),
+		withTargetAddedField(&schemapb.FieldSchema{
+			FieldID: 105, Name: "note", DataType: schemapb.DataType_Text, Nullable: true,
+			TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "65535"}},
+		}),
+	)
+	patch := mockey.Mock(compaction.CollectLobFilesFromManifests).
+		Return(map[int64][]packed.LobFileInfo(nil), errBumpUTInjected).Build()
+	defer patch.UnPatch()
+
+	_, err := fix.task.Compact()
+	require.ErrorIs(t, err, errBumpUTInjected)
+	verifySourceIntact(t, fix)
+}
+
+// [F25][S1] writer reports rows but no manifest: internal error, not adoption.
+func TestBumpUTFaultFullRewriteEmptyManifestWithRows(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := fullRewriteFixture(t)
+	fw := &faultBinlogWriter{schema: fix.targetSchema}
+	patch := mockey.Mock(storage.NewBinlogRecordWriter).Return(fw, nil).Build()
+	defer patch.UnPatch()
+
+	_, err := fix.task.Compact()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "produced empty manifest")
+}
+
+// [F26][S1] insert-log compression fails after a successful write.
+func TestBumpUTFaultFullRewriteCompressError(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := fullRewriteFixture(t)
+	patch := mockey.Mock(binlog.CompressFieldBinlogs).Return(errBumpUTInjected).Build()
+	defer patch.UnPatch()
+
+	_, err := fix.task.Compact()
+	require.ErrorIs(t, err, errBumpUTInjected)
+	verifySourceIntact(t, fix)
+}
+
+// [F27][S1] committing text-index stats to the manifest fails.
+func TestBumpUTFaultFullRewriteTextStatsCommitError(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := fullRewriteFixture(t)
+	textPatch := mockey.Mock(createTextIndex).To(func(_ context.Context, _ storage.ChunkManager, _ *datapb.CompactionPlan, _ compaction.Params,
+		_ int64, _ int64, _ int64, _ int64, _ int64, _ *datapb.CompactionSegment,
+	) (map[int64]*datapb.TextIndexStats, error) {
+		return map[int64]*datapb.TextIndexStats{bumpFxTextField: {LogSize: 1}}, nil
+	}).Build()
+	defer textPatch.UnPatch()
+	statsPatch := mockey.Mock(packed.AddStatsToManifest).Return("", errBumpUTInjected).Build()
+	defer statsPatch.UnPatch()
+
+	_, err := fix.task.Compact()
+	require.ErrorIs(t, err, errBumpUTInjected)
+	verifySourceIntact(t, fix)
+}
+
+// [F28][S2] commit-ts wrapper + write failure: the wrapped record release path
+// must not panic or double-release.
+func TestBumpUTFaultFullRewriteWriteErrorWithCommitTs(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := buildBumpFixture(t,
+		withSourceFields(&schemapb.FieldSchema{FieldID: 103, Name: "dropped", DataType: schemapb.DataType_Int64}),
+		withFillValue(func(i int, ts uint64, v map[int64]any) { v[103] = int64(i) }),
+		withTargetDroppedField(103),
+		withCommitTs(tsoutil.ComposeTSByTime(getMilvusBirthday().Add(time.Hour))),
+	)
+	fw := &faultBinlogWriter{writeErr: errBumpUTInjected, schema: fix.targetSchema}
+	patch := mockey.Mock(storage.NewBinlogRecordWriter).Return(fw, nil).Build()
+	defer patch.UnPatch()
+
+	_, err := fix.task.Compact()
+	require.ErrorIs(t, err, errBumpUTInjected)
+	verifySourceIntact(t, fix)
+}
+
+// [F29][S1] writer construction fails.
+func TestBumpUTFaultFullRewriteWriterCtorError(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := fullRewriteFixture(t)
+	patch := mockey.Mock(storage.NewBinlogRecordWriter).
+		Return(nil, errBumpUTInjected).Build()
+	defer patch.UnPatch()
+
+	_, err := fix.task.Compact()
+	require.ErrorIs(t, err, errBumpUTInjected)
+	verifySourceIntact(t, fix)
+}
+
+// [A22][S1] BM25 stats serialization fails after batches were written.
+func TestBumpUTFaultAdditiveStatsSerializeError(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := buildBumpFixture(t, withBM25Target())
+	patch := mockey.Mock((*storage.BM25Stats).Serialize).
+		Return(nil, errBumpUTInjected).Build()
+	defer patch.UnPatch()
+
+	_, err := fix.task.Compact()
+	require.ErrorIs(t, err, errBumpUTInjected)
+	verifySourceIntact(t, fix)
+}
+
+// [A23][S1] log-ID exhaustion during V3 stats commit.
+func TestBumpUTFaultAdditiveStatsAllocExhausted(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := buildBumpFixture(t, withBM25Target())
+	fix.task.logIDAlloc = allocator.NewLocalAllocator(5, 5)
+
+	_, err := fix.task.Compact()
+	require.Error(t, err)
+	verifySourceIntact(t, fix)
+}
+
+// [U9][S3] additive reconciliation on a partially materialized function: the
+// materializer's own integrity guard fires (defense behind decision).
+func TestBumpUTFaultAdditivePartialFunctionState(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := buildBumpFixture(t, withBM25Target())
+	diff := &schemaBumpPhysicalDiff{
+		existingFields: map[int64]struct{}{
+			common.RowIDField: {}, common.TimeStampField: {}, bumpFxPKField: {}, bumpFxTextField: {},
+			102: {}, // pretend one output is already physically present
+		},
+		missingFunctions:    fix.targetSchema.GetFunctions(),
+		missingOutputFields: []*schemapb.FieldSchema{typeutil.GetField(fix.targetSchema, 102)},
+	}
+	// make the function multi-output so presence is partial
+	fix.targetSchema.GetFunctions()[0].OutputFieldIds = []int64{102, 106}
+
+	_, err := fix.task.runAdditivePhysicalReconciliation(context.Background(), diff)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "partially materialized")
+}
+
+// bumpFxLobText builds a deterministic ~70KB TEXT row that exceeds the LOB
+// inline threshold (65536), forcing a real .vx LOB file.
+func bumpFxLobText(i int) string {
+	return fmt.Sprintf("lob-%04d|", i) + strings.Repeat(fmt.Sprintf("x%03d ", i), 14000)
+}
+
+// readTextRefs reads a TEXT column back as raw LOB reference bytes, keyed by pk.
+func readTextRefs(t *testing.T, fix *bumpFixture, manifest string, textID int64) map[int64][]byte {
+	got, total := readAllColumns(t, fix.cfg, manifest, &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		typeutil.GetField(fix.sourceSchema, bumpFxPKField),
+		{FieldID: textID, Name: "big_text", DataType: schemapb.DataType_Text},
+	}})
+	refs := make(map[int64][]byte, total)
+	for i := 0; i < total; i++ {
+		pk := got[bumpFxPKField][i].(int64)
+		rb, ok := got[textID][i].([]byte)
+		require.True(t, ok, "text ref must read back as bytes for pk %d", pk)
+		require.NotEmpty(t, rb, "text ref empty for pk %d", pk)
+		refs[pk] = rb
+	}
+	return refs
+}
+
+// [LOB1][S0] additive keeps TEXT LOB data dereferenceable: every row's LOB
+// reference bytes survive the bump unchanged AND the referenced .vx blob file
+// stays byte-identical — together this proves content round-trip without
+// depending on the ref encoding.
+func TestBumpUTAdditiveTextLOBRoundTrip(t *testing.T) {
+	setupBumpUTEnv(t)
+	const textID = int64(105)
+	fix := buildBumpFixture(t, withRows(6),
+		withSourceFields(&schemapb.FieldSchema{FieldID: textID, Name: "big_text", DataType: schemapb.DataType_Text}),
+		withFillValue(func(i int, ts uint64, v map[int64]any) { v[textID] = bumpFxLobText(i) }),
+		withTextLOBSource(textID),
+		withTargetAddedField(&schemapb.FieldSchema{FieldID: 106, Name: "added", DataType: schemapb.DataType_Int64, Nullable: true}),
+	)
+	srcRefs := readTextRefs(t, fix, fix.sourceManifest, textID)
+	preLob := listLobFiles(t, fix)
+	require.NotEmpty(t, preLob, "fixture must produce a real LOB file")
+
+	seg := runCompact(t, fix)
+
+	require.Equal(t, srcRefs, readTextRefs(t, fix, seg.GetManifest(), textID),
+		"additive must not touch LOB references")
+	require.Equal(t, preLob, listLobFiles(t, fix), "LOB blob files must stay byte-identical")
+}
+
+// [LOB2][S0] full rewrite with deletes: every KEPT row's LOB reference must
+// survive byte-identically (a dangling reference is silent data loss under
+// REUSE_ALL), and the LOB blob files stay intact.
+func TestBumpUTFullRewriteTextLOBKeptRowsSurvive(t *testing.T) {
+	setupBumpUTEnv(t)
+	const textID = int64(105)
+	const droppedID = int64(107)
+	const rows = 9
+	deleted := map[any]uint64{}
+	for i := 0; i < rows; i += 3 {
+		deleted[int64(i)] = bumpFxTS(i) + 1
+	}
+	fix := buildBumpFixture(t, withRows(rows),
+		withSourceFields(
+			&schemapb.FieldSchema{FieldID: textID, Name: "big_text", DataType: schemapb.DataType_Text},
+			&schemapb.FieldSchema{FieldID: droppedID, Name: "dropped", DataType: schemapb.DataType_Int64},
+		),
+		withFillValue(func(i int, ts uint64, v map[int64]any) {
+			v[textID] = bumpFxLobText(i)
+			v[droppedID] = int64(i)
+		}),
+		withTextLOBSource(textID),
+		withTargetDroppedField(droppedID),
+		withDeletedPKs(deleted),
+	)
+	kept := fix.keptRows()
+	require.NotEmpty(t, kept)
+	srcRefs := readTextRefs(t, fix, fix.sourceManifest, textID)
+	preLob := listLobFiles(t, fix)
+	require.NotEmpty(t, preLob)
+
+	seg := runCompact(t, fix)
+	require.EqualValues(t, len(kept), seg.GetNumOfRows())
+
+	postRefs := readTextRefs(t, fix, seg.GetManifest(), textID)
+	require.Len(t, postRefs, len(kept))
+	for _, r := range kept {
+		pk := r.pk.(int64)
+		require.Equal(t, srcRefs[pk], postRefs[pk], "kept row %d must keep a live LOB reference", pk)
+	}
+	require.Equal(t, preLob, listLobFiles(t, fix), "LOB blob files must stay byte-identical")
+}
+
+// [ST2][S1] full rewrite with deletes + BM25 materialization: the committed
+// stats ledger must accumulate ONLY the surviving rows — filtered rows leaking
+// into stats is invisible to every other oracle in the suite.
+func TestBumpUTFullRewriteBM25StatsGoldenUnderDeletes(t *testing.T) {
+	setupBumpUTEnv(t)
+	const rows = 40
+	const droppedID = int64(103)
+	deleted := map[any]uint64{}
+	for i := 0; i < rows; i += 3 {
+		deleted[int64(i)] = bumpFxTS(i) + 1
+	}
+	fix := buildBumpFixture(t, withRows(rows),
+		withSourceFields(&schemapb.FieldSchema{FieldID: droppedID, Name: "dropped", DataType: schemapb.DataType_Int64}),
+		withFillValue(func(i int, ts uint64, v map[int64]any) { v[droppedID] = int64(i) }),
+		withTargetDroppedField(droppedID),
+		withBM25Target(),
+		withDeletedPKs(deleted),
+	)
+	kept := fix.keptRows()
+	require.NotEmpty(t, kept)
+
+	seg := runCompact(t, fix)
+	require.EqualValues(t, len(kept), seg.GetNumOfRows())
+
+	keptTexts := make([]string, len(kept))
+	for i, r := range kept {
+		keptTexts[i] = r.values[bumpFxTextField].(string)
+	}
+	expected := expectedBM25SparseRows(t, fix.targetSchema, fix.targetSchema.GetFunctions()[0], keptTexts)
+	requireSparseRows(t, fix, seg.GetManifest(), 102, len(kept), expected)
+	expectedStats := storage.NewBM25Stats()
+	expectedStats.AppendBytes(expected...)
+	require.Equal(t, expectedStats, requireBM25StatsBlob(t, fix, 102, len(kept)))
+}
+
+// [MF1][S1] additive appends EXACTLY one data file and every pre-existing file
+// stays byte-identical — the on-disk exact ledger that set-semantics manifest
+// checks cannot express (duplicated column groups would be invisible there).
+func TestBumpUTAdditiveDataFileLedgerExactAppend(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := buildBumpFixture(t, withRows(20), withTargetAddedField(&schemapb.FieldSchema{
+		FieldID: 103, Name: "added", DataType: schemapb.DataType_Int64, Nullable: true,
+	}))
+	pre := listSegmentDataFiles(t, fix)
+	require.NotEmpty(t, pre)
+
+	seg := runCompact(t, fix)
+	require.NotEmpty(t, seg.GetManifest())
+
+	post := listSegmentDataFiles(t, fix)
+	for f, size := range pre {
+		require.Contains(t, post, f, "pre-existing data file must survive: %s", f)
+		require.Equal(t, size, post[f], "pre-existing data file mutated: %s", f)
+	}
+	require.Len(t, post, len(pre)+1, "additive must append exactly one column-group file")
+}
+
+// [MF2][S1] re-running the bump on an already-reconciled segment (the
+// real-world retry vector) must route bump-only: the same manifest comes back
+// and not a single data file is written — duplicate column groups from retries
+// are exactly what the set-semantics manifest check cannot see.
+func TestBumpUTIdempotentRerunAppendsNothing(t *testing.T) {
+	setupBumpUTEnv(t)
+	fix := buildBumpFixture(t, withRows(20), withTargetAddedField(&schemapb.FieldSchema{
+		FieldID: 103, Name: "added", DataType: schemapb.DataType_Int64, Nullable: true,
+	}))
+	first := runCompact(t, fix)
+	mid := listSegmentDataFiles(t, fix)
+
+	segment2 := proto.Clone(fix.segment).(*datapb.CompactionSegmentBinlogs)
+	segment2.Manifest = first.GetManifest()
+	segment2.FieldBinlogs = first.GetInsertLogs()
+	plan2 := proto.Clone(fix.task.plan).(*datapb.CompactionPlan)
+	plan2.SegmentBinlogs = []*datapb.CompactionSegmentBinlogs{segment2}
+	cmgr, err := storage.NewChunkManagerFactoryWithParam(paramtable.Get()).NewPersistentStorageChunkManager(context.Background())
+	require.NoError(t, err)
+	task2 := NewBumpSchemaVersionCompactionTask(context.Background(), cmgr, plan2, fix.task.compactionParams)
+
+	result2, err := task2.Compact()
+	require.NoError(t, err)
+	seg2 := result2.GetSegments()[0]
+	require.Equal(t, first.GetManifest(), seg2.GetManifest(), "re-run must be a pure metadata bump")
+	require.Equal(t, mid, listSegmentDataFiles(t, fix), "re-run must not write any data file")
+}
+
+// ============================================================================
+// Unit guards: decision/validation/writer helpers (D series)
+// ============================================================================
+// [D1][S3] preCompact guards: canceled context and malformed plans fail fast.
+func TestBumpUTUnitPreCompactGuards(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	task := &bumpSchemaVersionCompactionTask{ctx: ctx, plan: &datapb.CompactionPlan{
+		SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{{StorageVersion: storage.StorageV3, Manifest: "m"}},
+	}}
+	require.ErrorIs(t, task.preCompact(), context.Canceled)
+
+	task = &bumpSchemaVersionCompactionTask{ctx: context.Background(), plan: &datapb.CompactionPlan{}}
+	err := task.preCompact()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "must have exactly one segment")
+}
+
+// [D2-D5][S3] unsupported/empty function declarations are DataIntegrity errors.
+func TestBumpUTUnitValidateSupportedFunctionEmptySets(t *testing.T) {
+	cases := []struct {
+		name string
+		fn   *schemapb.FunctionSchema
+		want string
+	}{
+		{"bm25-no-input", &schemapb.FunctionSchema{Name: "f", Type: schemapb.FunctionType_BM25, OutputFieldIds: []int64{2}}, "no input fields"},
+		{"bm25-no-output", &schemapb.FunctionSchema{Name: "f", Type: schemapb.FunctionType_BM25, InputFieldIds: []int64{1}}, "no output fields"},
+		{"minhash-no-input", &schemapb.FunctionSchema{Name: "f", Type: schemapb.FunctionType_MinHash, OutputFieldIds: []int64{2}}, "no input fields"},
+		{"minhash-no-output", &schemapb.FunctionSchema{Name: "f", Type: schemapb.FunctionType_MinHash, InputFieldIds: []int64{1}}, "no output fields"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSupportedMissingFunctionMaterialization(tc.fn)
+			require.ErrorIs(t, err, merr.ErrDataIntegrity)
+			require.ErrorContains(t, err, tc.want)
+		})
+	}
+}
+
+// [D6][S3] minhash output must be BinaryVector.
+func TestBumpUTUnitMinHashOutputTypeRejected(t *testing.T) {
+	err := validateMaterializationOutputField(
+		&schemapb.FunctionSchema{Name: "f", Type: schemapb.FunctionType_MinHash},
+		&schemapb.FieldSchema{FieldID: 2, DataType: schemapb.DataType_FloatVector},
+	)
+	require.ErrorIs(t, err, merr.ErrDataIntegrity)
+	require.ErrorContains(t, err, "must be BinaryVector")
+}
+
+func bm25FieldWithAnalyzerParams(params string) *schemapb.FieldSchema {
+	return &schemapb.FieldSchema{
+		FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: common.EnableAnalyzerKey, Value: "true"},
+			{Key: "multi_analyzer_params", Value: params},
+		},
+	}
+}
+
+// [D7-D10][S3] by_field resolution failures are DataIntegrity errors.
+func TestBumpUTUnitBM25ByFieldErrors(t *testing.T) {
+	fn := &schemapb.FunctionSchema{Name: "f", Type: schemapb.FunctionType_BM25}
+	schemaWith := func(extra ...*schemapb.FieldSchema) *schemapb.CollectionSchema {
+		return &schemapb.CollectionSchema{Fields: append([]*schemapb.FieldSchema{{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64}}, extra...)}
+	}
+
+	_, err := bm25AdditionalInputFields(schemaWith(), fn, bm25FieldWithAnalyzerParams("{bad json"))
+	require.ErrorIs(t, err, merr.ErrDataIntegrity)
+	require.ErrorContains(t, err, "failed to parse multi_analyzer_params")
+
+	_, err = bm25AdditionalInputFields(schemaWith(), fn, bm25FieldWithAnalyzerParams(`{"analyzers":{}}`))
+	require.ErrorIs(t, err, merr.ErrDataIntegrity)
+	require.ErrorContains(t, err, "missing required 'by_field'")
+
+	_, err = bm25AdditionalInputFields(schemaWith(), fn, bm25FieldWithAnalyzerParams(`{"by_field":"lang"}`))
+	require.ErrorIs(t, err, merr.ErrDataIntegrity)
+	require.ErrorContains(t, err, "references missing input field")
+
+	langInt := &schemapb.FieldSchema{FieldID: 115, Name: "lang", DataType: schemapb.DataType_Int64}
+	_, err = bm25AdditionalInputFields(schemaWith(langInt), fn, bm25FieldWithAnalyzerParams(`{"by_field":"lang"}`))
+	require.ErrorIs(t, err, merr.ErrDataIntegrity)
+	require.ErrorContains(t, err, "only VarChar is allowed")
+}
+
+func bumpUTStringArray(values []string) arrow.Array {
+	b := array.NewStringBuilder(memory.DefaultAllocator)
+	defer b.Release()
+	for _, v := range values {
+		b.Append(v)
+	}
+	return b.NewArray()
+}
+
+func bumpUTInt64ArrayWithNull(values []int64, nullAt map[int]bool) arrow.Array {
+	b := array.NewInt64Builder(memory.DefaultAllocator)
+	defer b.Release()
+	for i, v := range values {
+		if nullAt[i] {
+			b.AppendNull()
+		} else {
+			b.Append(v)
+		}
+	}
+	return b.NewArray()
+}
+
+// [D11][S2] selectFullRewriteRecord type guards + VarChar PK + NULL-TTL rows.
+func TestBumpUTUnitSelectFullRewriteRecord(t *testing.T) {
+	intPK := &schemapb.FieldSchema{FieldID: 100, DataType: schemapb.DataType_Int64, IsPrimaryKey: true}
+	strPK := &schemapb.FieldSchema{FieldID: 100, DataType: schemapb.DataType_VarChar, IsPrimaryKey: true}
+	filter := compaction.NewEntityFilter(nil, 0, getMilvusBirthday(), 0)
+
+	ints := newInt64Array(t, []int64{1, 2})
+	defer ints.Release()
+	strs := bumpUTStringArray([]string{"a", "b"})
+	defer strs.Release()
+
+	// pk column type mismatches per PK type, plus unsupported PK type.
+	rec := &materializerTestRecord{columns: map[storage.FieldID]arrow.Array{100: strs, common.TimeStampField: ints}, len: 2}
+	_, err := selectFullRewriteRecord(rec, intPK, filter, -1, false)
+	require.ErrorContains(t, err, "int64 primary key field not found")
+
+	rec = &materializerTestRecord{columns: map[storage.FieldID]arrow.Array{100: ints, common.TimeStampField: ints}, len: 2}
+	_, err = selectFullRewriteRecord(rec, strPK, filter, -1, false)
+	require.ErrorContains(t, err, "varchar primary key field not found")
+
+	doublePK := &schemapb.FieldSchema{FieldID: 100, DataType: schemapb.DataType_Double, IsPrimaryKey: true}
+	_, err = selectFullRewriteRecord(rec, doublePK, filter, -1, false)
+	require.ErrorContains(t, err, "invalid primary key data type")
+
+	// timestamp column type mismatch.
+	rec = &materializerTestRecord{columns: map[storage.FieldID]arrow.Array{100: ints, common.TimeStampField: strs}, len: 2}
+	_, err = selectFullRewriteRecord(rec, intPK, filter, -1, false)
+	require.ErrorContains(t, err, "timestamp field not found")
+
+	// ttl column type mismatch.
+	rec = &materializerTestRecord{columns: map[storage.FieldID]arrow.Array{100: ints, common.TimeStampField: ints, 104: strs}, len: 2}
+	_, err = selectFullRewriteRecord(rec, intPK, filter, 104, true)
+	require.ErrorContains(t, err, "TTL field not found")
+
+	// VarChar PK happy path with a delete; NULL-TTL rows are never
+	// ttl-field-filtered (expireTs sentinel -1).
+	deleteTs := tsoutil.ComposeTSByTime(getMilvusBirthday().Add(time.Hour))
+	strFilter := compaction.NewEntityFilter(map[any]typeutil.Timestamp{"a": deleteTs}, 0, getMilvusBirthday(), 0)
+	ttl := bumpUTInt64ArrayWithNull([]int64{0, 0}, map[int]bool{0: true, 1: true})
+	defer ttl.Release()
+	rec = &materializerTestRecord{columns: map[storage.FieldID]arrow.Array{100: strs, common.TimeStampField: ints, 104: ttl}, len: 2}
+	selection, err := selectFullRewriteRecord(rec, strPK, strFilter, 104, true)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, 1, selection.Len(), "row a deleted, row b kept; NULL ttl never filters")
+}
+
+// [D12][S1] writer lease: double Close rejected, Cleanup after Close is a no-op.
+func TestBumpUTUnitWriterLeaseLifecycle(t *testing.T) {
+	w := &cleanupTrackingBatchWriter{}
+	lease := &bumpSchemaVersionWriterLease{writer: w}
+	_, err := lease.Close()
+	require.NoError(t, err)
+	_, err = lease.Close()
+	require.ErrorContains(t, err, "already consumed")
+	lease.Cleanup()
+	require.Zero(t, w.abortCount, "Cleanup after Close must not Abort")
+	require.Equal(t, 1, w.closeCount)
+
+	var nilLease *bumpSchemaVersionWriterLease
+	nilLease.Cleanup() // must not panic
+}
+
+// [P3-buqian] A failed Close must NOT consume the lease, so the deferred Cleanup
+// still aborts the writer — native release must not rely on the underlying Close
+// self-freeing on error.
+func TestBumpUTUnitWriterLeaseAbortsOnCloseError(t *testing.T) {
+	w := &cleanupTrackingBatchWriter{closeErr: errBumpUTInjected}
+	lease := &bumpSchemaVersionWriterLease{writer: w}
+	_, err := lease.Close()
+	require.ErrorIs(t, err, errBumpUTInjected)
+	require.Equal(t, 1, w.closeCount)
+	lease.Cleanup()
+	require.Equal(t, 1, w.abortCount, "Close failure must leave the lease unconsumed so Cleanup aborts")
+}
+
+// [P3-buqian] A persisted function with no output fields is schema corruption and
+// must fail loud in both the additive decision and the materializer selection,
+// not be silently dropped by the all-present early return (0 == 0).
+func TestBumpUTUnitZeroOutputFunctionRejected(t *testing.T) {
+	zeroOut := &schemapb.FunctionSchema{Name: "f", Type: schemapb.FunctionType_BM25, InputFieldIds: []int64{101}}
+
+	_, _, err := missingFunctionMaterializations(
+		&schemapb.CollectionSchema{Functions: []*schemapb.FunctionSchema{zeroOut}}, map[int64]struct{}{})
+	require.ErrorIs(t, err, merr.ErrDataIntegrity)
+	require.ErrorContains(t, err, "no output fields")
+
+	_, err = functionOutputIndexesToMaterialize(zeroOut, map[int64]struct{}{})
+	require.ErrorIs(t, err, merr.ErrDataIntegrity)
+	require.ErrorContains(t, err, "no output fields")
+}
+
+// [D13][S1] BM25 stats accumulation skips NULL cells.
+func TestBumpUTUnitAppendBM25StatsSkipsNulls(t *testing.T) {
+	row := typeutil.CreateAndSortSparseFloatRow(map[uint32]float32{1: 0.5, 7: 1.5})
+	b := array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
+	defer b.Release()
+	b.Append(row)
+	b.AppendNull()
+	b.Append(row)
+	arr := b.NewArray()
+	defer arr.Release()
+
+	stats := storage.NewBM25Stats()
+	size, err := appendBM25StatsFromArrowArray(stats, arr)
+	require.NoError(t, err)
+	require.Equal(t, 2*len(row), size, "null cell contributes no bytes")
+	require.EqualValues(t, 2, stats.NumRow())
+}
+
+// [D14][S3] tiny accessors' nil/empty guards.
+func TestBumpUTUnitSmallGuards(t *testing.T) {
+	require.Zero(t, arrowArrayMemorySize(nil))
+	task := &bumpSchemaVersionCompactionTask{plan: &datapb.CompactionPlan{}}
+	require.Zero(t, task.GetCollection())
+}
+
+// [D15][S1] insert-log construction fails cleanly when log IDs are exhausted.
+func TestBumpUTUnitBuildNewInsertLogsAllocExhausted(t *testing.T) {
+	task := &bumpSchemaVersionCompactionTask{logIDAlloc: allocator.NewLocalAllocator(5, 5)}
+	_, err := task.buildNewInsertLogsV3(&bumpSchemaVersionWriterResult{
+		columnGroups: []storagecommon.ColumnGroup{{GroupID: 103, Columns: []int{0}, Fields: []int64{103}}},
+	}, map[int64]int{}, 3)
+	require.Error(t, err)
+}
+
+// [D16][S0] read-schema input dedup: shared and repeated input IDs collapse.
+func TestBumpUTUnitMissingFunctionInputDedup(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			{FieldID: 102, Name: "s1", DataType: schemapb.DataType_SparseFloatVector},
+			{FieldID: 103, Name: "s2", DataType: schemapb.DataType_SparseFloatVector},
+		},
+	}
+	task := &bumpSchemaVersionCompactionTask{plan: &datapb.CompactionPlan{Schema: schema}}
+	missing := []*schemapb.FunctionSchema{
+		{Name: "f1", Type: schemapb.FunctionType_BM25, InputFieldIds: []int64{101, 101}, OutputFieldIds: []int64{102}},
+		{Name: "f2", Type: schemapb.FunctionType_BM25, InputFieldIds: []int64{101}, OutputFieldIds: []int64{103}},
+	}
+	inputSchema, inputIDs, err := task.missingFunctionInputSchema(missing)
+	require.NoError(t, err)
+	require.Equal(t, []int64{101}, inputIDs)
+	require.Len(t, inputSchema.GetFields(), 1)
+}
+
+// [D17][S3] read-schema builder's own not-found guard (defense in depth behind
+// the decision-time validation).
+func TestBumpUTUnitMissingFunctionInputNotFound(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+	}}
+	task := &bumpSchemaVersionCompactionTask{plan: &datapb.CompactionPlan{Schema: schema}}
+	_, _, err := task.missingFunctionInputSchema([]*schemapb.FunctionSchema{{
+		Name: "f", Type: schemapb.FunctionType_BM25, InputFieldIds: []int64{999}, OutputFieldIds: []int64{102},
+	}})
+	require.ErrorIs(t, err, merr.ErrDataIntegrity)
+	require.ErrorContains(t, err, "input field 999 not found")
+}
+
+// [A9/A10][S3] additiveReadSchema anchor selection: Timestamp fallback when
+// RowID is physically absent; hard error when both anchors are absent.
+func TestBumpUTUnitAdditiveReadSchemaAnchors(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: common.RowIDField, Name: "row_id", DataType: schemapb.DataType_Int64},
+		{FieldID: common.TimeStampField, Name: "ts", DataType: schemapb.DataType_Int64},
+		{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+	}}
+	task := &bumpSchemaVersionCompactionTask{plan: &datapb.CompactionPlan{Schema: schema}}
+
+	// RowID absent -> Timestamp anchor.
+	diff := &schemaBumpPhysicalDiff{existingFields: map[int64]struct{}{common.TimeStampField: {}, 100: {}}}
+	readSchema, _, err := task.additiveReadSchema(diff)
+	require.NoError(t, err)
+	require.Len(t, readSchema.GetFields(), 1)
+	require.EqualValues(t, common.TimeStampField, readSchema.GetFields()[0].GetFieldID())
+
+	// both anchors absent -> DataIntegrity.
+	diff = &schemaBumpPhysicalDiff{existingFields: map[int64]struct{}{100: {}}}
+	_, _, err = task.additiveReadSchema(diff)
+	require.ErrorIs(t, err, merr.ErrDataIntegrity)
+	require.ErrorContains(t, err, "RowID or Timestamp anchor")
+}
+
+// [U3][S3] additive reconciliation with nothing to append is an internal error.
+func TestBumpUTUnitAdditiveNoOutputFields(t *testing.T) {
+	task := &bumpSchemaVersionCompactionTask{
+		ctx: context.Background(),
+		plan: &datapb.CompactionPlan{
+			SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{{SegmentID: 1}},
+			Schema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+				{FieldID: common.RowIDField, Name: "row_id", DataType: schemapb.DataType_Int64},
+			}},
+		},
+	}
+	diff := &schemaBumpPhysicalDiff{existingFields: map[int64]struct{}{common.RowIDField: {}}}
+	_, err := task.runAdditivePhysicalReconciliation(context.Background(), diff)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "no fields to append")
+}
+
+// [U5][S3] newV3WriterResult rejects non-V3 segments (defense behind preCompact).
+func TestBumpUTUnitNewV3WriterRejectsNonV3(t *testing.T) {
+	task := &bumpSchemaVersionCompactionTask{plan: &datapb.CompactionPlan{}}
+	_, err := task.newV3WriterResult(&schemapb.CollectionSchema{}, nil,
+		&datapb.CompactionSegmentBinlogs{StorageVersion: storage.StorageV2}, 1, "", 0)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "requires a StorageV3 segment")
+}

--- a/internal/datanode/compactor/clustering_compactor_test.go
+++ b/internal/datanode/compactor/clustering_compactor_test.go
@@ -389,14 +389,14 @@ func (s *ClusteringCompactionTaskSuite) TestScalarCompactionNormalByMemoryLimit(
 
 func (s *ClusteringCompactionTaskSuite) prepareCompactionWithBM25FunctionTask() {
 	s.SetupTest()
-	s.prepareCompactionWithBM25OutputTask(10240, false)
+	s.prepareCompactionWithBM25OutputTask(10240)
 }
 
 func (s *ClusteringCompactionTaskSuite) prepareCompactionWithMissingBM25OutputTask(rowNum int) {
-	s.prepareCompactionWithBM25OutputTask(rowNum, true)
+	s.prepareCompactionWithBM25OutputTask(rowNum, 102)
 }
 
-func (s *ClusteringCompactionTaskSuite) prepareCompactionWithBM25OutputTask(rowNum int, removeBM25Output bool) {
+func (s *ClusteringCompactionTaskSuite) prepareCompactionWithBM25OutputTask(rowNum int, removeFieldIDs ...int64) {
 	schema := genCollectionSchemaWithBM25()
 	segmentID := int64(1001)
 	segWriter, err := NewSegmentWriter(schema, int64(rowNum), compactionBatchSize, segmentID, PartitionID, CollectionID, []int64{102})
@@ -415,8 +415,8 @@ func (s *ClusteringCompactionTaskSuite) prepareCompactionWithBM25OutputTask(rowN
 
 	kvs, fBinlogs, err := serializeWrite(context.TODO(), s.mockAlloc, segWriter)
 	s.Require().NoError(err)
-	if removeBM25Output {
-		removeFieldBinlogForTest(kvs, fBinlogs, 102)
+	for _, fieldID := range removeFieldIDs {
+		removeFieldBinlogForTest(kvs, fBinlogs, fieldID)
 	}
 	s.mockBinlogIO.EXPECT().Download(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, paths []string) ([][]byte, error) {
 		return downloadValuesForPathsForTest(kvs, paths)
@@ -512,6 +512,22 @@ func (s *ClusteringCompactionTaskSuite) TestScalarClusteringMaterializesMissingB
 	for _, segment := range result.GetSegments() {
 		bm25Rows += fieldBinlogEntriesForTest(segment.GetBm25Logs(), 102)
 	}
+	s.EqualValues(3, bm25Rows)
+}
+
+func (s *ClusteringCompactionTaskSuite) TestScalarClusteringPrefillsMissingBM25InputBeforeOutput() {
+	s.prepareCompactionWithBM25OutputTask(3, 101, 102)
+	typeutil.GetField(s.task.plan.GetSchema(), 101).Nullable = true
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+	var inputRows, bm25Rows int64
+	for _, segment := range result.GetSegments() {
+		inputRows += fieldBinlogEntriesForTest(segment.GetInsertLogs(), 101)
+		bm25Rows += fieldBinlogEntriesForTest(segment.GetBm25Logs(), 102)
+	}
+	s.EqualValues(3, inputRows)
 	s.EqualValues(3, bm25Rows)
 }
 
@@ -632,9 +648,10 @@ func genCollectionSchemaWithBM25() *schemapb.CollectionSchema {
 				},
 			},
 			{
-				FieldID:  102,
-				Name:     "sparse",
-				DataType: schemapb.DataType_SparseFloatVector,
+				FieldID:          102,
+				Name:             "sparse",
+				DataType:         schemapb.DataType_SparseFloatVector,
+				IsFunctionOutput: true,
 			},
 		},
 		Functions: []*schemapb.FunctionSchema{{

--- a/internal/datanode/compactor/compactor_common.go
+++ b/internal/datanode/compactor/compactor_common.go
@@ -264,19 +264,6 @@ func collectionSchemaFields(schema *schemapb.CollectionSchema) map[int64]struct{
 	return fields
 }
 
-func missingSchemaFunctions(schema *schemapb.CollectionSchema, existingFields map[int64]struct{}) []*schemapb.FunctionSchema {
-	var missing []*schemapb.FunctionSchema
-	for _, functionSchema := range schema.GetFunctions() {
-		for _, outputFieldID := range functionSchema.GetOutputFieldIds() {
-			if _, ok := existingFields[outputFieldID]; !ok {
-				missing = append(missing, functionSchema)
-				break
-			}
-		}
-	}
-	return missing
-}
-
 func droppedSchemaFieldIDs(schema *schemapb.CollectionSchema, existingFields map[int64]struct{}) []int64 {
 	targetFields := collectionSchemaFields(schema)
 	dropped := make([]int64, 0)
@@ -358,9 +345,16 @@ func compactionReadSchema(schema *schemapb.CollectionSchema, existingFields map[
 	return readSchema
 }
 
+// compactionFieldReadable keeps a field in the read schema when it is
+// physically present, or when the reader layer can synthesize it (absent
+// ordinary fields are reader-filled with default/null). Only function outputs
+// missing from storage are excluded: storage cannot synthesize them and the
+// RecordMaterializer computes them instead.
 func compactionFieldReadable(field *schemapb.FieldSchema, existingFields map[int64]struct{}) bool {
-	_, ok := existingFields[field.GetFieldID()]
-	return ok
+	if _, ok := existingFields[field.GetFieldID()]; ok {
+		return true
+	}
+	return !field.GetIsFunctionOutput()
 }
 
 func filterCompactionFieldBinlogs(fieldBinlogs []*datapb.FieldBinlog, readFields map[int64]struct{}) []*datapb.FieldBinlog {

--- a/internal/datanode/compactor/compactor_common_test.go
+++ b/internal/datanode/compactor/compactor_common_test.go
@@ -38,11 +38,16 @@ func TestFilterCompactionFieldBinlogsKeepsChildFieldMatch(t *testing.T) {
 	require.Equal(t, []int64{102, 103}, filtered[0].GetChildFields())
 }
 
-func TestCompactionReadSchemaFiltersMissingScalarAndStructChildren(t *testing.T) {
+func TestCompactionReadSchemaKeepsAbsentOrdinaryDropsMissingFunctionOutputs(t *testing.T) {
+	// Absent ordinary fields (scalars and struct children) stay in the read
+	// schema — the reader layer fills them. Only function outputs missing from
+	// storage are dropped: they are computed by the RecordMaterializer.
 	schema := &schemapb.CollectionSchema{
 		Fields: []*schemapb.FieldSchema{
 			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64},
 			{FieldID: 101, Name: "missing", DataType: schemapb.DataType_Int64},
+			{FieldID: 102, Name: "sparse_missing", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
+			{FieldID: 103, Name: "sparse_present", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
 		},
 		StructArrayFields: []*schemapb.StructArrayFieldSchema{
 			{
@@ -63,33 +68,32 @@ func TestCompactionReadSchemaFiltersMissingScalarAndStructChildren(t *testing.T)
 		},
 	}
 
-	readSchema := compactionReadSchema(schema, map[int64]struct{}{100: {}, 201: {}})
+	fieldIDs := func(fields []*schemapb.FieldSchema) []int64 {
+		ids := make([]int64, 0, len(fields))
+		for _, field := range fields {
+			ids = append(ids, field.GetFieldID())
+		}
+		return ids
+	}
+
+	readSchema := compactionReadSchema(schema, map[int64]struct{}{100: {}, 201: {}, 103: {}})
 	require.NotNil(t, readSchema)
-	require.Len(t, readSchema.GetFields(), 1)
-	require.EqualValues(t, 100, readSchema.GetFields()[0].GetFieldID())
-	require.Len(t, readSchema.GetStructArrayFields(), 1)
-	require.EqualValues(t, 200, readSchema.GetStructArrayFields()[0].GetFieldID())
-	require.Len(t, readSchema.GetStructArrayFields()[0].GetFields(), 1)
-	require.EqualValues(t, 201, readSchema.GetStructArrayFields()[0].GetFields()[0].GetFieldID())
+	require.ElementsMatch(t, []int64{100, 101, 103}, fieldIDs(readSchema.GetFields()))
+	require.Len(t, readSchema.GetStructArrayFields(), 2)
+	require.ElementsMatch(t, []int64{201, 202}, fieldIDs(readSchema.GetStructArrayFields()[0].GetFields()))
+	require.ElementsMatch(t, []int64{301}, fieldIDs(readSchema.GetStructArrayFields()[1].GetFields()))
 }
 
 func TestCompactionReadSchemaNilSchema(t *testing.T) {
 	require.Nil(t, compactionReadSchema(nil, map[int64]struct{}{}))
 }
 
-func TestMissingSchemaFunctionsAndDroppedFields(t *testing.T) {
-	functionSchema := &schemapb.FunctionSchema{
-		Name:           "bm25",
-		Type:           schemapb.FunctionType_BM25,
-		InputFieldIds:  []int64{100},
-		OutputFieldIds: []int64{101},
-	}
+func TestDroppedSchemaFieldIDs(t *testing.T) {
 	schema := &schemapb.CollectionSchema{
 		Fields: []*schemapb.FieldSchema{
 			{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar},
 			{FieldID: 101, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector},
 		},
-		Functions: []*schemapb.FunctionSchema{functionSchema},
 	}
 	droppedUserField := int64(common.StartOfUserFieldID + 1000)
 	systemField := int64(common.StartOfUserFieldID - 1)
@@ -98,10 +102,6 @@ func TestMissingSchemaFunctionsAndDroppedFields(t *testing.T) {
 		droppedUserField: {},
 		systemField:      {},
 	}
-
-	missingFunctions := missingSchemaFunctions(schema, existingFields)
-	require.Len(t, missingFunctions, 1)
-	require.Equal(t, functionSchema.GetName(), missingFunctions[0].GetName())
 
 	dropped := droppedSchemaFieldIDs(schema, existingFields)
 	require.Equal(t, []int64{droppedUserField}, dropped)

--- a/internal/datanode/compactor/mix_compactor_test.go
+++ b/internal/datanode/compactor/mix_compactor_test.go
@@ -150,6 +150,45 @@ func TestMixCompactionMaterializesMissingBM25OutputNoDelete(t *testing.T) {
 	s.EqualValues(3, fieldBinlogEntriesForTest(segment.GetBm25Logs(), 102))
 }
 
+func TestMixCompactionPrefillsMissingBM25InputBeforeOutput(t *testing.T) {
+	s := newMixCompactionStorageV1SuiteForDirectTest(t)
+	s.SetupBM25()
+	inputField := typeutil.GetField(s.task.plan.GetSchema(), 101)
+	inputField.Nullable = true
+
+	segments := []int64{5, 6, 7}
+	alloc := allocator.NewLocalAllocator(7777777, math.MaxInt64)
+	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil)
+	s.task.plan.SegmentBinlogs = make([]*datapb.CompactionSegmentBinlogs, 0, len(segments))
+	for _, segID := range segments {
+		s.initSegBufferWithBM25(segID)
+		kvs, fBinlogs, err := serializeWrite(context.TODO(), alloc, s.segWriter)
+		s.Require().NoError(err)
+		removeFieldBinlogForTest(kvs, fBinlogs, 101)
+		removeFieldBinlogForTest(kvs, fBinlogs, 102)
+
+		s.mockBinlogIO.EXPECT().Download(mock.Anything, mock.MatchedBy(func(keys []string) bool {
+			left, right := lo.Difference(keys, lo.Keys(kvs))
+			return len(left) == 0 && len(right) == 0
+		})).RunAndReturn(func(ctx context.Context, keys []string) ([][]byte, error) {
+			return downloadValuesForPathsForTest(kvs, keys)
+		}).Once()
+		s.task.plan.SegmentBinlogs = append(s.task.plan.SegmentBinlogs, &datapb.CompactionSegmentBinlogs{
+			CollectionID: 1,
+			SegmentID:    segID,
+			FieldBinlogs: lo.Values(fBinlogs),
+		})
+	}
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+	segment := result.GetSegments()[0]
+	s.EqualValues(3, segment.GetNumOfRows())
+	s.EqualValues(3, fieldBinlogEntriesForTest(segment.GetInsertLogs(), 101))
+	s.EqualValues(3, fieldBinlogEntriesForTest(segment.GetBm25Logs(), 102))
+}
+
 func TestMixCompactionMaterializesMissingFieldWithDeleteFilter(t *testing.T) {
 	s := newMixCompactionStorageV1SuiteForDirectTest(t)
 
@@ -305,6 +344,43 @@ func TestMixCompactionMergeSortMaterializesMissingBM25Output(t *testing.T) {
 	segment := result.GetSegments()[0]
 	s.EqualValues(3, segment.GetNumOfRows())
 	s.True(segment.GetIsSorted())
+	s.EqualValues(3, fieldBinlogEntriesForTest(segment.GetBm25Logs(), 102))
+}
+
+func TestMixCompactionMergeSortPrefillsMissingBM25InputBeforeOutput(t *testing.T) {
+	s := newMixCompactionStorageV1SuiteForDirectTest(t)
+	mergeSortKey := paramtable.Get().DataNodeCfg.UseMergeSort.Key
+	paramtable.Get().Save(mergeSortKey, "true")
+	t.Cleanup(func() { paramtable.Get().Reset(mergeSortKey) })
+	s.SetupBM25()
+	typeutil.GetField(s.task.plan.GetSchema(), 101).Nullable = true
+
+	segments := []int64{5, 6, 7}
+	alloc := allocator.NewLocalAllocator(7777777, math.MaxInt64)
+	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil)
+	s.task.plan.SegmentBinlogs = make([]*datapb.CompactionSegmentBinlogs, 0, len(segments))
+	for _, segID := range segments {
+		s.initSegBufferWithBM25(segID)
+		kvs, fBinlogs, err := serializeWrite(context.TODO(), alloc, s.segWriter)
+		s.Require().NoError(err)
+		removeFieldBinlogForTest(kvs, fBinlogs, 101)
+		removeFieldBinlogForTest(kvs, fBinlogs, 102)
+		s.mockBinlogIO.EXPECT().Download(mock.Anything, mock.MatchedBy(func(keys []string) bool {
+			left, right := lo.Difference(keys, lo.Keys(kvs))
+			return len(left) == 0 && len(right) == 0
+		})).RunAndReturn(func(ctx context.Context, keys []string) ([][]byte, error) {
+			return downloadValuesForPathsForTest(kvs, keys)
+		}).Once()
+		s.task.plan.SegmentBinlogs = append(s.task.plan.SegmentBinlogs, &datapb.CompactionSegmentBinlogs{
+			CollectionID: 1, SegmentID: segID, FieldBinlogs: lo.Values(fBinlogs), IsSorted: true,
+		})
+	}
+	s.task.compactionParams = compaction.GenParams()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	segment := result.GetSegments()[0]
+	s.EqualValues(3, fieldBinlogEntriesForTest(segment.GetInsertLogs(), 101))
 	s.EqualValues(3, fieldBinlogEntriesForTest(segment.GetBm25Logs(), 102))
 }
 

--- a/internal/datanode/compactor/record_materializer.go
+++ b/internal/datanode/compactor/record_materializer.go
@@ -26,7 +26,6 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/function"
-	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -54,17 +53,23 @@ func (s *recordSelection) Len() int {
 }
 
 type RecordMaterializer struct {
-	materializers  []FunctionMaterializer
-	missingFields  []*schemapb.FieldSchema
-	schema         *schemapb.CollectionSchema
-	existingFields map[int64]struct{}
+	materializers []FunctionMaterializer
+	schema        *schemapb.CollectionSchema
+	// pendingOutputs are the function-output fields this materializer computes:
+	// the only schema fields absent from the records it wraps. Absent ordinary
+	// fields are already reader-filled (default/null) per the reader contract.
+	pendingOutputs map[int64]struct{}
 }
 
 func NewRecordMaterializer(schema *schemapb.CollectionSchema, functions []*schemapb.FunctionSchema, existingFields map[int64]struct{}) (*RecordMaterializer, error) {
-	materializer := &RecordMaterializer{schema: schema, existingFields: existingFields}
+	materializer := &RecordMaterializer{schema: schema}
 	materializedFields := make(map[int64]struct{})
 	for _, functionSchema := range functions {
-		outputIndexes := functionOutputIndexesToMaterialize(functionSchema, existingFields)
+		outputIndexes, err := functionOutputIndexesToMaterialize(functionSchema, existingFields)
+		if err != nil {
+			materializer.Close()
+			return nil, err
+		}
 		if len(outputIndexes) == 0 {
 			continue
 		}
@@ -89,7 +94,7 @@ func NewRecordMaterializer(schema *schemapb.CollectionSchema, functions []*schem
 		}
 		materializer.materializers = append(materializer.materializers, functionMaterializer)
 	}
-	materializer.missingFields = missingNonMaterializedSchemaFields(schema, existingFields, materializedFields)
+	materializer.pendingOutputs = materializedFields
 	return materializer, nil
 }
 
@@ -97,16 +102,19 @@ func (m *RecordMaterializer) Wrap(rec storage.Record) (storage.Record, error) {
 	return m.WrapWithSelection(rec, nil)
 }
 
-// WrapWithSelection wraps rec — optionally filtered to selection — filling absent
-// function outputs and missing schema fields. rec stays borrowed from its reader
-// and is valid until the reader's next Next/Close; the caller must clean up only
-// the derived arrays owned by the returned record (cleanupMaterializedRecord),
-// never the input record itself. Callers that keep the returned record across a
-// reader advance must Retain/Release it explicitly (see storage.Sort).
+// WrapWithSelection wraps rec — optionally filtered to selection — filling
+// absent function outputs. Ordinary fields, including reader-filled defaults
+// and nulls for fields absent from storage, arrive complete on rec per the
+// reader contract, so functions read their inputs from it directly. rec stays
+// borrowed from its reader and is valid until the reader's next Next/Close;
+// the caller must clean up only the derived arrays owned by the returned
+// record (cleanupMaterializedRecord), never the input record itself. Callers
+// that keep the returned record across a reader advance must Retain/Release
+// it explicitly (see storage.Sort).
 func (m *RecordMaterializer) WrapWithSelection(rec storage.Record, selection *recordSelection) (storage.Record, error) {
 	base := rec
 	if selection != nil {
-		selected, err := newSelectedRecord(rec, m.schema, m.existingFields, selection)
+		selected, err := newSelectedRecord(rec, m.schema, m.pendingOutputs, selection)
 		if err != nil {
 			return nil, err
 		}
@@ -116,35 +124,22 @@ func (m *RecordMaterializer) WrapWithSelection(rec storage.Record, selection *re
 		return base, nil
 	}
 
-	computed := make(map[int64]arrow.Array)
+	functionOutputs := make(map[int64]arrow.Array)
 	for _, materializer := range m.materializers {
 		arrays, err := materializer.Materialize(base)
 		if err != nil {
-			releaseArrowArrays(computed)
+			releaseArrowArrays(functionOutputs)
 			cleanupMaterializedRecord(base)
 			return nil, err
 		}
 		for fieldID, arr := range arrays {
-			computed[fieldID] = arr
+			functionOutputs[fieldID] = arr
 		}
 	}
-	for _, field := range m.missingFields {
-		fieldID := field.GetFieldID()
-		if _, ok := computed[fieldID]; ok {
-			continue
-		}
-		arr, err := storage.GenerateEmptyArrayFromSchema(field, base.Len())
-		if err != nil {
-			releaseArrowArrays(computed)
-			cleanupMaterializedRecord(base)
-			return nil, err
-		}
-		computed[fieldID] = arr
-	}
-	if len(computed) == 0 {
+	if len(functionOutputs) == 0 {
 		return base, nil
 	}
-	return &materializedRecord{base: base, computed: computed}, nil
+	return &materializedRecord{base: base, computed: functionOutputs}, nil
 }
 
 func (m *RecordMaterializer) Close() {
@@ -157,7 +152,7 @@ func (m *RecordMaterializer) Close() {
 }
 
 func (m *RecordMaterializer) hasMaterialization() bool {
-	return m != nil && (len(m.materializers) > 0 || len(m.missingFields) > 0)
+	return m != nil && len(m.materializers) > 0
 }
 
 type materializedRecord struct {
@@ -209,17 +204,19 @@ type selectedRecord struct {
 
 var _ storage.Record = (*selectedRecord)(nil)
 
-// newSelectedRecord eagerly slices every schema field physically present in
-// base down to the selection ranges. The column set must be fixed for the
-// record's lifetime: a column created lazily after a wrapper Retain-snapshot
-// (e.g. timestampOverwriteRecord) would escape the snapshot and be released
-// once more than it was retained. Presence is decided by existingFields, never
-// by probing base.Column: V2/V3 records panic on Column for absent fields.
-func newSelectedRecord(base storage.Record, schema *schemapb.CollectionSchema, existingFields map[int64]struct{}, selection *recordSelection) (*selectedRecord, error) {
+// newSelectedRecord eagerly slices every readSchema field of base down to the
+// selection ranges. The column set must be fixed for the record's lifetime: a
+// column created lazily after a wrapper Retain-snapshot (e.g.
+// timestampOverwriteRecord) would escape the snapshot and be released once
+// more than it was retained. Per the reader contract base is readSchema-wide
+// (absent ordinary fields arrive reader-filled), so the only schema fields to
+// skip are the function outputs this materializer has yet to compute —
+// declared by pendingOutputs, never decided by probing base.Column.
+func newSelectedRecord(base storage.Record, schema *schemapb.CollectionSchema, pendingOutputs map[int64]struct{}, selection *recordSelection) (*selectedRecord, error) {
 	columns := make(map[int64]arrow.Array)
 	for _, field := range typeutil.GetAllFieldSchemas(schema) {
 		fieldID := field.GetFieldID()
-		if _, ok := existingFields[fieldID]; !ok {
+		if _, pending := pendingOutputs[fieldID]; pending {
 			continue
 		}
 		col, err := buildSelectedColumn(base, field, selection)
@@ -246,10 +243,8 @@ func buildSelectedColumn(base storage.Record, field *schemapb.FieldSchema, selec
 	}
 	built := builder.Build()
 	defer built.Release()
+	// built holds exactly this field (single-field builder), so Column never returns nil.
 	col := built.Column(field.GetFieldID())
-	if col == nil {
-		return nil, merr.WrapErrServiceInternalMsg("selected record field %d not found", field.GetFieldID())
-	}
 	col.Retain()
 	return col, nil
 }
@@ -549,38 +544,32 @@ func (m *minHashFunctionMaterializer) Close() {
 	}
 }
 
-func functionOutputIndexesToMaterialize(functionSchema *schemapb.FunctionSchema, existingFields map[int64]struct{}) []int {
+func functionOutputIndexesToMaterialize(functionSchema *schemapb.FunctionSchema, existingFields map[int64]struct{}) ([]int, error) {
 	outputFieldIDs := functionSchema.GetOutputFieldIds()
+	// A persisted function with no output fields is schema corruption; reject
+	// before the all-present early-return treats the empty set as "nothing to
+	// materialize" and silently drops it.
+	if len(outputFieldIDs) == 0 {
+		return nil, merr.WrapErrDataIntegrityMsg("persisted function %s has no output fields", functionSchema.GetName())
+	}
 	indexes := make([]int, 0, len(outputFieldIDs))
-	hasMissingOutput := false
+	presentCount := 0
 	for idx, outputFieldID := range outputFieldIDs {
 		indexes = append(indexes, idx)
-		if _, ok := existingFields[outputFieldID]; !ok {
-			hasMissingOutput = true
+		if _, ok := existingFields[outputFieldID]; ok {
+			presentCount++
 		}
 	}
-	if !hasMissingOutput {
-		return nil
+	if presentCount == len(outputFieldIDs) {
+		return nil, nil
 	}
-	return indexes
-}
-
-func missingNonMaterializedSchemaFields(schema *schemapb.CollectionSchema, existingFields map[int64]struct{}, materializedFields map[int64]struct{}) []*schemapb.FieldSchema {
-	missing := make([]*schemapb.FieldSchema, 0)
-	for _, field := range typeutil.GetAllFieldSchemas(schema) {
-		fieldID := field.GetFieldID()
-		if common.IsSystemField(fieldID) {
-			continue
-		}
-		if _, ok := existingFields[fieldID]; ok {
-			continue
-		}
-		if _, ok := materializedFields[fieldID]; ok {
-			continue
-		}
-		missing = append(missing, field)
+	if presentCount != 0 {
+		return nil, merr.WrapErrDataIntegrityMsg(
+			"function %s has partially materialized output fields: %d of %d are physically present",
+			functionSchema.GetName(), presentCount, len(outputFieldIDs),
+		)
 	}
-	return missing
+	return indexes, nil
 }
 
 func stringInputsFromRecord(rec storage.Record, fieldID int64) ([]string, error) {

--- a/internal/datanode/compactor/record_materializer_test.go
+++ b/internal/datanode/compactor/record_materializer_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/function"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -81,6 +82,33 @@ func (m selectedColumnMaterializer) Materialize(rec storage.Record) (map[int64]a
 
 func (m selectedColumnMaterializer) Close() {}
 
+type inputViewMaterializer struct {
+	inputFieldID  int64
+	hiddenFieldID int64
+	outputFieldID int64
+	output        arrow.Array
+	view          storage.Record
+	input         arrow.Array
+	hidden        arrow.Array
+}
+
+func (m *inputViewMaterializer) Materialize(rec storage.Record) (map[int64]arrow.Array, error) {
+	m.view = rec
+	m.input = rec.Column(m.inputFieldID)
+	if m.input == nil {
+		return nil, merr.WrapErrFunctionFailedMsg("input field %d not found", m.inputFieldID)
+	}
+	if m.hiddenFieldID != 0 {
+		m.hidden = rec.Column(m.hiddenFieldID)
+	}
+	if m.output == nil {
+		return nil, nil
+	}
+	return map[int64]arrow.Array{m.outputFieldID: m.output}, nil
+}
+
+func (m *inputViewMaterializer) Close() {}
+
 type materializerTestFunctionRunner struct {
 	schema       *schemapb.FunctionSchema
 	inputFields  []*schemapb.FieldSchema
@@ -129,7 +157,11 @@ func TestRecordMaterializerWrapNoOpWhenAllFieldsExist(t *testing.T) {
 	require.Same(t, record, wrapped)
 }
 
-func TestRecordMaterializerWrapFillsNullableMissingFields(t *testing.T) {
+func TestRecordMaterializerWrapLeavesAbsentOrdinaryToReader(t *testing.T) {
+	// Contract pin: absent ordinary fields are reader-filled before records
+	// reach the materializer, so with no functions to run Wrap must hand the
+	// record back untouched even when the schema lists fields the record does
+	// not carry.
 	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
 		{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar},
 		{FieldID: 101, Name: "added", DataType: schemapb.DataType_Int64, Nullable: true},
@@ -141,38 +173,7 @@ func TestRecordMaterializerWrapFillsNullableMissingFields(t *testing.T) {
 	record := &materializerTestRecord{len: 3}
 	wrapped, err := materializer.Wrap(record)
 	require.NoError(t, err)
-	require.NotSame(t, record, wrapped)
-
-	column := wrapped.Column(101)
-	require.NotNil(t, column)
-	require.Equal(t, 3, column.Len())
-	require.Equal(t, 3, column.NullN())
-	cleanupMaterializedRecord(wrapped)
-	require.Equal(t, 0, record.releaseCount)
-}
-
-func TestRecordMaterializerWrapFillsNullableMissingTextFieldAsBinary(t *testing.T) {
-	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
-		{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64},
-		{FieldID: 101, Name: "added_text", DataType: schemapb.DataType_Text, Nullable: true},
-	}}
-	materializer, err := NewRecordMaterializer(schema, nil, map[int64]struct{}{100: {}})
-	require.NoError(t, err)
-	defer materializer.Close()
-
-	pk := newInt64Array(t, []int64{1, 2, 3})
-	defer pk.Release()
-	record := &materializerTestRecord{len: 3, columns: map[storage.FieldID]arrow.Array{100: pk}}
-	wrapped, err := materializer.Wrap(record)
-	require.NoError(t, err)
-	require.NotSame(t, record, wrapped)
-
-	column := wrapped.Column(101)
-	require.NotNil(t, column)
-	require.IsType(t, &array.Binary{}, column)
-	require.Equal(t, 3, column.Len())
-	require.Equal(t, 3, column.NullN())
-	cleanupMaterializedRecord(wrapped)
+	require.Same(t, record, wrapped)
 	require.Equal(t, 0, record.releaseCount)
 }
 
@@ -187,7 +188,12 @@ func TestRecordMaterializerWrapWithSelectionMaterializesKeptRowsOnly(t *testing.
 
 	input := newStringArray(t, []string{"drop-0", "keep-1", "drop-2", "keep-3"})
 	defer input.Release()
-	record := &materializerTestRecord{len: 4, columns: map[storage.FieldID]arrow.Array{100: input}}
+	// The reader contract delivers records readSchema-wide: the absent-ordinary
+	// field arrives reader-filled (all-null here).
+	added, err := storage.GenerateEmptyArrayFromSchema(schema.GetFields()[1], 4)
+	require.NoError(t, err)
+	defer added.Release()
+	record := &materializerTestRecord{len: 4, columns: map[storage.FieldID]arrow.Array{100: input, 101: added}}
 	selection := &recordSelection{ranges: []rowRange{{start: 1, end: 2}, {start: 3, end: 4}}, length: 2}
 
 	wrapped, err := materializer.WrapWithSelection(record, selection)
@@ -210,9 +216,8 @@ func TestRecordMaterializerWrapWithSelectionReturnsColumnBuildError(t *testing.T
 		{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar},
 	}}
 	materializer := &RecordMaterializer{
-		schema:         schema,
-		existingFields: map[int64]struct{}{100: {}},
-		materializers:  []FunctionMaterializer{selectedColumnMaterializer{fieldID: 100}},
+		schema:        schema,
+		materializers: []FunctionMaterializer{selectedColumnMaterializer{fieldID: 100}},
 	}
 
 	input := newInt64Array(t, []int64{1, 2})
@@ -237,7 +242,10 @@ func TestRecordMaterializerSelectionColumnsFixedBeforeTimestampOverwrite(t *test
 
 	input := newStringArray(t, []string{"drop-0", "keep-1", "drop-2", "keep-3"})
 	defer input.Release()
-	record := &materializerTestRecord{len: 4, columns: map[storage.FieldID]arrow.Array{100: input}}
+	added, err := storage.GenerateEmptyArrayFromSchema(schema.GetFields()[1], 4)
+	require.NoError(t, err)
+	defer added.Release()
+	record := &materializerTestRecord{len: 4, columns: map[storage.FieldID]arrow.Array{100: input, 101: added}}
 	selection := &recordSelection{ranges: []rowRange{{start: 1, end: 2}, {start: 3, end: 4}}, length: 2}
 
 	wrapped, err := materializer.WrapWithSelection(record, selection)
@@ -246,8 +254,8 @@ func TestRecordMaterializerSelectionColumnsFixedBeforeTimestampOverwrite(t *test
 	// commit-ts wrapper snapshots refcounts via Retain; a writer only pulls
 	// columns afterwards. Every column must exist before the snapshot, or the
 	// late-created ones escape it and get released more than they were retained.
-	selected := wrapped.(*materializedRecord).base.(*selectedRecord)
-	require.Len(t, selected.columns, 1)
+	selected := wrapped.(*selectedRecord)
+	require.Len(t, selected.columns, 2)
 
 	out := overwriteRecordTimestamps(wrapped, 12345)
 	require.NotSame(t, wrapped, out)
@@ -280,8 +288,12 @@ func TestRecordMaterializerSelectionColumnLifecycleExact(t *testing.T) {
 		builder.AppendValues([]string{"drop-0", "keep-1", "drop-2", "keep-3"}, nil)
 		input := builder.NewStringArray()
 		defer input.Release()
+		// Reader contract: the absent-ordinary field arrives reader-filled.
+		added, err := storage.GenerateEmptyArrayFromSchema(schema.GetFields()[1], 4)
+		require.NoError(t, err)
+		defer added.Release()
 
-		record := &materializerTestRecord{len: 4, columns: map[storage.FieldID]arrow.Array{100: input}}
+		record := &materializerTestRecord{len: 4, columns: map[storage.FieldID]arrow.Array{100: input, 101: added}}
 		selection := &recordSelection{ranges: []rowRange{{start: 1, end: 2}, {start: 3, end: 4}}, length: 2}
 
 		wrapped, err := materializer.WrapWithSelection(record, selection)
@@ -368,20 +380,92 @@ func TestRecordMaterializerWrapSkipsMissingSystemFields(t *testing.T) {
 	require.Same(t, record, wrapped)
 }
 
-func TestRecordMaterializerWrapFailsForMissingNonNullableField(t *testing.T) {
-	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
-		{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar},
-		{FieldID: 101, Name: "required", DataType: schemapb.DataType_Int64},
-	}}
-	materializer, err := NewRecordMaterializer(schema, nil, map[int64]struct{}{100: {}})
-	require.NoError(t, err)
-	defer materializer.Close()
+func TestRecordMaterializerFunctionsShareOrdinaryInputView(t *testing.T) {
+	ordinaryField := &schemapb.FieldSchema{
+		FieldID: 101, Name: "added_input", DataType: schemapb.DataType_VarChar,
+		Nullable: true,
+	}
+	output := newInt64Array(t, []int64{10, 20})
+	first := &inputViewMaterializer{
+		inputFieldID:  ordinaryField.GetFieldID(),
+		outputFieldID: 102,
+		output:        output,
+	}
+	second := &inputViewMaterializer{
+		inputFieldID:  ordinaryField.GetFieldID(),
+		hiddenFieldID: first.outputFieldID,
+	}
+	materializer := &RecordMaterializer{
+		materializers: []FunctionMaterializer{first, second},
+	}
 
-	record := &materializerTestRecord{len: 3}
-	_, err = materializer.Wrap(record)
-	require.Error(t, err)
-	require.ErrorContains(t, err, "missing field data required")
-	require.Equal(t, 0, record.releaseCount)
+	// Per the reader contract the absent-ordinary input arrives on the base
+	// record null-filled; functions read it from there.
+	input, err := storage.GenerateEmptyArrayFromSchema(ordinaryField, 2)
+	require.NoError(t, err)
+	defer input.Release()
+	record := &materializerTestRecord{len: 2, columns: map[storage.FieldID]arrow.Array{ordinaryField.GetFieldID(): input}}
+	wrapped, err := materializer.Wrap(record)
+	require.NoError(t, err)
+	defer cleanupMaterializedRecord(wrapped)
+
+	require.Same(t, storage.Record(record), first.view, "functions read inputs straight from the base record")
+	require.Same(t, first.view, second.view)
+	require.Nil(t, second.hidden, "one function must not observe another function's new output")
+	for _, in := range []arrow.Array{first.input, second.input} {
+		column := in.(*array.String)
+		require.Equal(t, 2, column.Len())
+		require.Equal(t, 2, column.NullN(), "null-filled absent input stays null")
+	}
+	require.Nil(t, first.view.Column(first.outputFieldID), "the function input view must remain output-free")
+	require.Same(t, output, wrapped.Column(first.outputFieldID))
+}
+
+func TestRecordMaterializerFunctionOutputLifecycleExact(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	original := memory.DefaultAllocator
+	memory.DefaultAllocator = alloc
+	defer func() { memory.DefaultAllocator = original }()
+
+	func() {
+		builder := array.NewInt64Builder(alloc)
+		builder.AppendValues([]int64{10, 20}, nil)
+		output := builder.NewArray()
+		builder.Release()
+
+		ordinaryField := &schemapb.FieldSchema{
+			FieldID: 101, Name: "added_input", DataType: schemapb.DataType_VarChar,
+			Nullable: true,
+		}
+		functionMaterializer := &inputViewMaterializer{
+			inputFieldID:  ordinaryField.GetFieldID(),
+			outputFieldID: 102,
+			output:        output,
+		}
+		materializer := &RecordMaterializer{
+			materializers: []FunctionMaterializer{functionMaterializer},
+		}
+		// Reader-null-filled ordinary input lives on the base record.
+		input, err := storage.GenerateEmptyArrayFromSchema(ordinaryField, 2)
+		require.NoError(t, err)
+		defer input.Release()
+		record := &materializerTestRecord{len: 2, columns: map[storage.FieldID]arrow.Array{ordinaryField.GetFieldID(): input}}
+
+		wrapped, err := materializer.Wrap(record)
+		require.NoError(t, err)
+		wrapped.Retain()
+		cleanupMaterializedRecord(wrapped)
+
+		// The retained view must keep the output layer alive after the reader's
+		// original derived references have been cleaned up; the ordinary input
+		// stays readable through the base record.
+		require.True(t, wrapped.Column(ordinaryField.GetFieldID()).(*array.String).IsNull(0))
+		require.Equal(t, int64(10), wrapped.Column(functionMaterializer.outputFieldID).(*array.Int64).Value(0))
+		wrapped.Release()
+		require.Equal(t, record.retainCount, record.releaseCount)
+	}()
+
+	alloc.AssertSize(t, 0)
 }
 
 func TestBM25FunctionMaterializerMaterializesSparseOutput(t *testing.T) {
@@ -541,10 +625,32 @@ func TestBM25FunctionMaterializerRejectsBadRunnerOutput(t *testing.T) {
 	})
 }
 
-func TestFunctionOutputIndexesToMaterializePartialStateReturnsAllOutputs(t *testing.T) {
-	functionSchema := &schemapb.FunctionSchema{OutputFieldIds: []int64{101, 102}}
-	require.Nil(t, functionOutputIndexesToMaterialize(functionSchema, map[int64]struct{}{101: {}, 102: {}}))
-	require.Equal(t, []int{0, 1}, functionOutputIndexesToMaterialize(functionSchema, map[int64]struct{}{101: {}}))
+func TestFunctionOutputIndexesToMaterialize(t *testing.T) {
+	functionSchema := &schemapb.FunctionSchema{Name: "multi_output", OutputFieldIds: []int64{101, 102}}
+
+	indexes, err := functionOutputIndexesToMaterialize(functionSchema, map[int64]struct{}{101: {}, 102: {}})
+	require.NoError(t, err)
+	require.Nil(t, indexes)
+
+	indexes, err = functionOutputIndexesToMaterialize(functionSchema, nil)
+	require.NoError(t, err)
+	require.Equal(t, []int{0, 1}, indexes)
+
+	indexes, err = functionOutputIndexesToMaterialize(functionSchema, map[int64]struct{}{101: {}})
+	require.Nil(t, indexes)
+	require.ErrorIs(t, err, merr.ErrDataIntegrity)
+	require.ErrorContains(t, err, "partially materialized output fields")
+}
+
+func TestNewRecordMaterializerRejectsPartiallyPresentFunctionOutputs(t *testing.T) {
+	functionSchema := &schemapb.FunctionSchema{Name: "multi_output", OutputFieldIds: []int64{101, 102}}
+	materializer, err := NewRecordMaterializer(
+		&schemapb.CollectionSchema{},
+		[]*schemapb.FunctionSchema{functionSchema},
+		map[int64]struct{}{101: {}},
+	)
+	require.Nil(t, materializer)
+	require.ErrorIs(t, err, merr.ErrDataIntegrity)
 }
 
 func TestMaterializedRecordReaderReleasesPreviousRecordOnNextAndClose(t *testing.T) {
@@ -578,13 +684,29 @@ func TestMaterializedRecordReaderReleasesPreviousRecordOnNextAndClose(t *testing
 // the retained composite stays readable after the reader releases its own base
 // reference and the wrapper cleans its derived arrays, and every reference
 // balances to zero at the end.
+// freshOutputMaterializer emits a newly-allocated output column per call, so the
+// materialized record's function output is what makes Wrap return a
+// materializedRecord and no arrow array is shared between successive records.
+type freshOutputMaterializer struct {
+	t             *testing.T
+	outputFieldID int64
+}
+
+func (m freshOutputMaterializer) Materialize(storage.Record) (map[int64]arrow.Array, error) {
+	return map[int64]arrow.Array{m.outputFieldID: newInt64Array(m.t, []int64{7})}, nil
+}
+
+func (m freshOutputMaterializer) Close() {}
+
 func TestMaterializedRecordReaderRetainedRecordSurvivesAdvance(t *testing.T) {
-	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
-		{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar},
-		{FieldID: 101, Name: "added", DataType: schemapb.DataType_Int64, Nullable: true},
-	}}
-	materializer, err := NewRecordMaterializer(schema, nil, map[int64]struct{}{100: {}})
-	require.NoError(t, err)
+	// Absent ordinary fields are reader-filled now, so the materializer only
+	// produces function outputs. Use a function output (field 101) as the
+	// materialized column to verify a retained wrapped record survives the
+	// reader advancing (its base ref is kept until the retained record is
+	// released).
+	materializer := &RecordMaterializer{
+		materializers: []FunctionMaterializer{freshOutputMaterializer{t: t, outputFieldID: 101}},
+	}
 
 	first := &materializerTestRecord{len: 1}
 	second := &materializerTestRecord{len: 1}

--- a/internal/datanode/compactor/record_materializer_ut_test.go
+++ b/internal/datanode/compactor/record_materializer_ut_test.go
@@ -1,0 +1,764 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compactor
+
+import (
+	"context"
+	"fmt"
+	sio "io"
+	"math"
+	"testing"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/bytedance/mockey"
+	"github.com/cockroachdb/errors"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/allocator"
+	"github.com/milvus-io/milvus/internal/compaction"
+	"github.com/milvus-io/milvus/internal/mocks"
+	"github.com/milvus-io/milvus/internal/mocks/flushcommon/mock_util"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/function"
+	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
+)
+
+// ============================================================================
+// Unit layer: ctor guards, runner errors, bad outputs, lifecycle (U series)
+// ============================================================================
+// fakeFunctionRunner is a controllable function.FunctionRunner for exercising
+// materializer constructor guards and bad-output handling without cgo runners.
+type fakeFunctionRunner struct {
+	schema     *schemapb.FunctionSchema
+	inputs     []*schemapb.FieldSchema
+	outputs    []any
+	runErr     error
+	closeCount int
+}
+
+func (r *fakeFunctionRunner) BatchRun(...any) ([]any, error) {
+	if r.runErr != nil {
+		return nil, r.runErr
+	}
+	return r.outputs, nil
+}
+func (r *fakeFunctionRunner) GetSchema() *schemapb.FunctionSchema      { return r.schema }
+func (r *fakeFunctionRunner) GetOutputFields() []*schemapb.FieldSchema { return nil }
+func (r *fakeFunctionRunner) GetInputFields() []*schemapb.FieldSchema  { return r.inputs }
+func (r *fakeFunctionRunner) Close()                                   { r.closeCount++ }
+
+var _ function.FunctionRunner = (*fakeFunctionRunner)(nil)
+
+func rmSchemaBM25() *schemapb.CollectionSchema {
+	return &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+		{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+		{FieldID: 102, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
+	}}
+}
+
+func rmSchemaMinHash() *schemapb.CollectionSchema {
+	return &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+		{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+		{
+			FieldID: 102, Name: "mh", DataType: schemapb.DataType_BinaryVector, IsFunctionOutput: true,
+			TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "32"}},
+		},
+	}}
+}
+
+// ---------------------------------------------------------------------------
+// U2: function-materializer constructor guards (table-driven, fake runner)
+// ---------------------------------------------------------------------------
+
+// [U2][S3] every schema-integrity guard in the BM25/MinHash materializer
+// constructors fires with the right message.
+func TestRMFunctionMaterializerCtorGuards(t *testing.T) {
+	varcharIn := &schemapb.FieldSchema{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar}
+	int64In := &schemapb.FieldSchema{FieldID: 101, Name: "text", DataType: schemapb.DataType_Int64}
+	ghostIn := &schemapb.FieldSchema{FieldID: 999, Name: "ghost", DataType: schemapb.DataType_VarChar}
+
+	cases := []struct {
+		name    string
+		fnType  schemapb.FunctionType
+		schema  *schemapb.CollectionSchema
+		mutate  func(r *fakeFunctionRunner, s *schemapb.CollectionSchema)
+		wantErr string
+	}{
+		{"bm25-no-inputs", schemapb.FunctionType_BM25, rmSchemaBM25(), func(r *fakeFunctionRunner, _ *schemapb.CollectionSchema) {
+			r.inputs = nil
+		}, "should have input fields"},
+		{"bm25-input-not-in-schema", schemapb.FunctionType_BM25, rmSchemaBM25(), func(r *fakeFunctionRunner, _ *schemapb.CollectionSchema) {
+			r.inputs = []*schemapb.FieldSchema{ghostIn}
+		}, "input field not found in schema"},
+		{"bm25-input-wrong-type", schemapb.FunctionType_BM25, rmSchemaBM25(), func(r *fakeFunctionRunner, s *schemapb.CollectionSchema) {
+			s.Fields[1].DataType = schemapb.DataType_Int64
+			r.inputs = []*schemapb.FieldSchema{int64In}
+		}, "must be varchar or text"},
+		{"bm25-no-outputs", schemapb.FunctionType_BM25, rmSchemaBM25(), func(r *fakeFunctionRunner, _ *schemapb.CollectionSchema) {
+			r.schema.OutputFieldIds = nil
+		}, "should have output fields"},
+		{"bm25-output-not-in-schema", schemapb.FunctionType_BM25, rmSchemaBM25(), func(r *fakeFunctionRunner, _ *schemapb.CollectionSchema) {
+			r.schema.OutputFieldIds = []int64{888}
+		}, "output field not found in schema"},
+		{"bm25-output-wrong-type", schemapb.FunctionType_BM25, rmSchemaBM25(), func(_ *fakeFunctionRunner, s *schemapb.CollectionSchema) {
+			s.Fields[2].DataType = schemapb.DataType_FloatVector
+		}, "must be sparse float vector"},
+		{"bm25-output-nullable", schemapb.FunctionType_BM25, rmSchemaBM25(), func(_ *fakeFunctionRunner, s *schemapb.CollectionSchema) {
+			s.Fields[2].Nullable = true
+		}, "cannot be nullable"},
+		{"minhash-no-inputs", schemapb.FunctionType_MinHash, rmSchemaMinHash(), func(r *fakeFunctionRunner, _ *schemapb.CollectionSchema) {
+			r.inputs = nil
+		}, "should have input fields"},
+		{"minhash-input-not-in-schema", schemapb.FunctionType_MinHash, rmSchemaMinHash(), func(r *fakeFunctionRunner, _ *schemapb.CollectionSchema) {
+			r.inputs = []*schemapb.FieldSchema{ghostIn}
+		}, "input field not found in schema"},
+		{"minhash-input-wrong-type", schemapb.FunctionType_MinHash, rmSchemaMinHash(), func(r *fakeFunctionRunner, s *schemapb.CollectionSchema) {
+			s.Fields[1].DataType = schemapb.DataType_Int64
+			r.inputs = []*schemapb.FieldSchema{int64In}
+		}, "must be varchar or text"},
+		{"minhash-no-outputs", schemapb.FunctionType_MinHash, rmSchemaMinHash(), func(r *fakeFunctionRunner, _ *schemapb.CollectionSchema) {
+			r.schema.OutputFieldIds = nil
+		}, "should have output fields"},
+		{"minhash-output-not-in-schema", schemapb.FunctionType_MinHash, rmSchemaMinHash(), func(r *fakeFunctionRunner, _ *schemapb.CollectionSchema) {
+			r.schema.OutputFieldIds = []int64{888}
+		}, "output field not found in schema"},
+		{"minhash-output-wrong-type", schemapb.FunctionType_MinHash, rmSchemaMinHash(), func(_ *fakeFunctionRunner, s *schemapb.CollectionSchema) {
+			s.Fields[2].DataType = schemapb.DataType_SparseFloatVector
+			s.Fields[2].TypeParams = nil
+		}, "must be binary vector"},
+		{"minhash-output-nullable", schemapb.FunctionType_MinHash, rmSchemaMinHash(), func(_ *fakeFunctionRunner, s *schemapb.CollectionSchema) {
+			s.Fields[2].Nullable = true
+		}, "cannot be nullable"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &fakeFunctionRunner{
+				schema: &schemapb.FunctionSchema{
+					Name: "f", Type: tc.fnType,
+					InputFieldIds: []int64{101}, OutputFieldIds: []int64{102},
+				},
+				inputs: []*schemapb.FieldSchema{varcharIn},
+			}
+			tc.mutate(runner, tc.schema)
+			_, err := newFunctionMaterializer(tc.schema, runner, []int{0}, true)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// U3: NewRecordMaterializer error chain
+// ---------------------------------------------------------------------------
+
+// [U3][S3] runner construction failures propagate and never leak an already
+// constructed runner.
+func TestRMNewRecordMaterializerRunnerErrors(t *testing.T) {
+	schema := rmSchemaBM25()
+	fn := &schemapb.FunctionSchema{
+		Name: "f", Type: schemapb.FunctionType_BM25,
+		InputFieldIds: []int64{101}, OutputFieldIds: []int64{102},
+	}
+	existing := map[int64]struct{}{100: {}, 101: {}}
+
+	// runner factory error
+	errPatch := mockey.Mock(function.NewFunctionRunner).
+		Return(nil, errors.New("rm-ut runner factory failed")).Build()
+	_, err := NewRecordMaterializer(schema, []*schemapb.FunctionSchema{fn}, existing)
+	errPatch.UnPatch()
+	require.ErrorContains(t, err, "runner factory failed")
+
+	// nil runner without error
+	nilPatch := mockey.Mock(function.NewFunctionRunner).
+		Return(nil, nil).Build()
+	_, err = NewRecordMaterializer(schema, []*schemapb.FunctionSchema{fn}, existing)
+	nilPatch.UnPatch()
+	require.ErrorContains(t, err, "failed to set up function runner")
+
+	// materializer construction fails after a live runner: the runner must be closed.
+	runner := &fakeFunctionRunner{
+		schema: &schemapb.FunctionSchema{Name: "f", Type: schemapb.FunctionType_Unknown},
+	}
+	livePatch := mockey.Mock(function.NewFunctionRunner).
+		Return(runner, nil).Build()
+	_, err = NewRecordMaterializer(schema, []*schemapb.FunctionSchema{fn}, existing)
+	livePatch.UnPatch()
+	require.ErrorContains(t, err, "unsupported function type")
+	require.Equal(t, 1, runner.closeCount, "runner must be closed when materializer setup fails")
+}
+
+// ---------------------------------------------------------------------------
+// U4: bad runner outputs at Materialize time
+// ---------------------------------------------------------------------------
+
+func rmVarcharRecord(t *testing.T, values []string) *materializerTestRecord {
+	arr := bumpUTStringArray(values)
+	t.Cleanup(arr.Release)
+	return &materializerTestRecord{len: len(values), columns: map[storage.FieldID]arrow.Array{101: arr}}
+}
+
+// [U4][S3] minhash materializer rejects malformed runner outputs instead of
+// writing garbage.
+func TestRMMinHashMaterializeBadOutputs(t *testing.T) {
+	newMH := func(outputs []any, runErr error) FunctionMaterializer {
+		runner := &fakeFunctionRunner{
+			schema: &schemapb.FunctionSchema{
+				Name: "f", Type: schemapb.FunctionType_MinHash,
+				InputFieldIds: []int64{101}, OutputFieldIds: []int64{102},
+			},
+			inputs:  []*schemapb.FieldSchema{{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar}},
+			outputs: outputs,
+			runErr:  runErr,
+		}
+		m, err := newFunctionMaterializer(rmSchemaMinHash(), runner, []int{0}, true)
+		require.NoError(t, err)
+		return m
+	}
+	rec := rmVarcharRecord(t, []string{"a", "b"})
+
+	_, err := newMH(nil, errors.New("rm-ut run failed")).Materialize(rec)
+	require.ErrorContains(t, err, "run failed")
+
+	_, err = newMH([]any{}, nil).Materialize(rec)
+	require.ErrorContains(t, err, "expects 1 outputs, got 0")
+
+	_, err = newMH([]any{"not-field-data"}, nil).Materialize(rec)
+	require.ErrorContains(t, err, "expected FieldData")
+
+	_, err = newMH([]any{&schemapb.FieldData{}}, nil).Materialize(rec)
+	require.ErrorContains(t, err, "expected binary vector field data")
+
+	short := &schemapb.FieldData{Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+		Dim: 32, Data: &schemapb.VectorField_BinaryVector{BinaryVector: make([]byte, 4)}, // 1 row, record has 2
+	}}}
+	_, err = newMH([]any{short}, nil).Materialize(rec)
+	require.ErrorContains(t, err, "row count mismatch")
+}
+
+// [U4b][S3] bm25 materializer rejects wrong output arity and type.
+func TestRMBM25MaterializeBadOutputs(t *testing.T) {
+	newBM := func(outputs []any) FunctionMaterializer {
+		runner := &fakeFunctionRunner{
+			schema: &schemapb.FunctionSchema{
+				Name: "f", Type: schemapb.FunctionType_BM25,
+				InputFieldIds: []int64{101}, OutputFieldIds: []int64{102},
+			},
+			inputs:  []*schemapb.FieldSchema{{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar}},
+			outputs: outputs,
+		}
+		m, err := newFunctionMaterializer(rmSchemaBM25(), runner, []int{0}, true)
+		require.NoError(t, err)
+		return m
+	}
+	rec := rmVarcharRecord(t, []string{"a", "b"})
+
+	_, err := newBM([]any{}).Materialize(rec)
+	require.ErrorContains(t, err, "expects 1 outputs, got 0")
+
+	_, err = newBM([]any{"nope"}).Materialize(rec)
+	require.ErrorContains(t, err, "expected SparseFloatArray")
+}
+
+// ---------------------------------------------------------------------------
+// U5/U6: synthesis failure release + reader wrap failure
+// ---------------------------------------------------------------------------
+
+// failingFunctionMaterializer forces a Wrap-time error for failure-path tests.
+type failingFunctionMaterializer struct{}
+
+func (failingFunctionMaterializer) Materialize(storage.Record) (map[int64]arrow.Array, error) {
+	return nil, merr.WrapErrServiceInternalMsg("injected materialize failure")
+}
+
+func (failingFunctionMaterializer) Close() {}
+
+// [U6][S1] materializedRecordReader propagates Wrap failures, cleans the
+// previous record, and leaves the base record reader-owned.
+func TestRMMaterializedReaderWrapFailure(t *testing.T) {
+	materializer := &RecordMaterializer{materializers: []FunctionMaterializer{failingFunctionMaterializer{}}}
+
+	ints := newInt64Array(t, []int64{1, 2})
+	defer ints.Release()
+	base := &materializerTestRecord{len: 2, columns: map[storage.FieldID]arrow.Array{100: ints}}
+	reader := newMaterializedRecordReader(&stubRecordReader{records: []storage.Record{base}}, materializer)
+
+	_, err := reader.Next()
+	require.Error(t, err)
+	require.Zero(t, base.releaseCount, "base record stays owned by its reader")
+	require.NoError(t, reader.Close())
+}
+
+// stubRecordReader hands out a fixed record sequence.
+type stubRecordReader struct {
+	records []storage.Record
+	pos     int
+}
+
+func (r *stubRecordReader) Next() (storage.Record, error) {
+	if r.pos >= len(r.records) {
+		return nil, errStubEOF
+	}
+	rec := r.records[r.pos]
+	r.pos++
+	return rec, nil
+}
+func (r *stubRecordReader) Close() error { return nil }
+
+var errStubEOF = errors.New("stub EOF")
+
+// ---------------------------------------------------------------------------
+// U7: small guards
+// ---------------------------------------------------------------------------
+
+// [U7][S3] tiny guards: nil selection length, nil materializer close,
+// mismatched selection column build.
+func TestRMSmallGuards(t *testing.T) {
+	var nilSelection *recordSelection
+	require.Zero(t, nilSelection.Len())
+
+	var nilMaterializer *RecordMaterializer
+	nilMaterializer.Close() // must not panic
+
+	// buildSelectedColumn: schema/builder mismatch surfaces as an error, not a
+	// silent wrong column (field absent from the built record).
+	ints := newInt64Array(t, []int64{1, 2})
+	defer ints.Release()
+	rec := &materializerTestRecord{len: 2, columns: map[storage.FieldID]arrow.Array{100: ints}}
+	_, err := buildSelectedColumn(rec, &schemapb.FieldSchema{FieldID: 100, Name: "pk", DataType: schemapb.DataType_VarChar},
+		&recordSelection{ranges: []rowRange{{start: 0, end: 1}}, length: 1})
+	require.Error(t, err)
+}
+
+// ============================================================================
+// Consumer goldens: sort / merge-sort / mix / clustering / invariance (C series)
+// ============================================================================
+// Consumer-level golden tests: RecordMaterializer runs inside every compaction
+// task, so each consumer's usage pattern (sort's retained reader records,
+// merge-sort's K concurrent readers, mix's Wrap + commit-ts overwrite chain)
+// must be verified against per-row data, not just metadata counts. These tests
+// drive the real Compact() of each consumer over V1/V2 binlog segments whose
+// materialized columns (added default + BM25 output) are absent from storage.
+
+const (
+	rmcPKField     = int64(100)
+	rmcTextField   = int64(101)
+	rmcSparseField = int64(102)
+	rmcAddedField  = int64(103)
+	rmcAddedValue  = int64(777)
+)
+
+func rmcSourceSchema() *schemapb.CollectionSchema {
+	return &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: common.RowIDField, Name: "row_id", DataType: schemapb.DataType_Int64},
+		{FieldID: common.TimeStampField, Name: "Timestamp", DataType: schemapb.DataType_Int64},
+		{FieldID: rmcPKField, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+		{
+			FieldID: rmcTextField, Name: "text", DataType: schemapb.DataType_VarChar,
+			TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "256"}},
+		},
+	}}
+}
+
+func rmcTargetSchema() *schemapb.CollectionSchema {
+	schema := rmcSourceSchema()
+	schema.Fields = append(schema.Fields,
+		&schemapb.FieldSchema{
+			FieldID: rmcAddedField, Name: "added_default", DataType: schemapb.DataType_Int64, Nullable: true,
+			DefaultValue: &schemapb.ValueField{Data: &schemapb.ValueField_LongData{LongData: rmcAddedValue}},
+		},
+		&schemapb.FieldSchema{
+			FieldID: rmcSparseField, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true,
+		},
+	)
+	schema.Functions = []*schemapb.FunctionSchema{{
+		Name: "bm25", Id: 100, Type: schemapb.FunctionType_BM25,
+		InputFieldNames: []string{"text"}, InputFieldIds: []int64{rmcTextField},
+		OutputFieldNames: []string{"sparse"}, OutputFieldIds: []int64{rmcSparseField},
+	}}
+	return schema
+}
+
+func rmcText(segID int64, i int) string { return fmt.Sprintf("seg%d word%d common", segID, i) }
+
+// rmcWriteSourceSegment writes rows through the real V1 segment writer using
+// the SOURCE schema (added + sparse fields physically absent) and returns the
+// serialized blobs. Rows are written in ascending pk order so segments qualify
+// as sorted inputs for the merge-sort path.
+func rmcWriteSourceSegment(t *testing.T, segID int64, rows int, logIDStart int64) (map[string][]byte, []*datapb.FieldBinlog) {
+	writer, err := NewSegmentWriter(rmcSourceSchema(), int64(rows), compactionBatchSize, segID, PartitionID, CollectionID, nil)
+	require.NoError(t, err)
+	for i := 0; i < rows; i++ {
+		pk := segID*100000 + int64(i)
+		ts := tsoutil.ComposeTSByTime(getMilvusBirthday().Add(0))
+		err := writer.Write(&storage.Value{
+			PK:        storage.NewInt64PrimaryKey(pk),
+			Timestamp: int64(ts),
+			Value: map[int64]interface{}{
+				common.RowIDField:     pk,
+				common.TimeStampField: int64(ts),
+				rmcPKField:            pk,
+				rmcTextField:          rmcText(segID, i),
+			},
+		})
+		require.NoError(t, err)
+	}
+	writer.FlushAndIsFull()
+	alloc := allocator.NewLocalAllocator(logIDStart, math.MaxInt64)
+	kvs, fBinlogs, err := serializeWrite(context.TODO(), alloc, writer)
+	require.NoError(t, err)
+	return kvs, lo.Values(fBinlogs)
+}
+
+// rmcBinlogIO wires Download over the source blobs; compaction outputs are
+// written by the V2 storage writer straight to the local root path, so reading
+// them back goes through the filesystem (rmcReadOutputValues), not Upload.
+func rmcBinlogIO(t *testing.T, sources map[string][]byte) *mock_util.MockBinlogIO {
+	binlogIO := mock_util.NewMockBinlogIO(t)
+	binlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
+	binlogIO.EXPECT().Download(mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, paths []string) ([][]byte, error) {
+			out := make([][]byte, 0, len(paths))
+			for _, p := range paths {
+				data, ok := sources[p]
+				require.True(t, ok, "unknown binlog path %s", p)
+				out = append(out, data)
+			}
+			return out, nil
+		}).Maybe()
+	return binlogIO
+}
+
+// rmcReadOutputColumns reads every result segment back through the package's
+// own segment reader (same storage stack that wrote it) and accumulates the
+// requested columns row-by-row in output order.
+func rmcReadOutputColumns(t *testing.T, cfg *indexpb.StorageConfig, schema *schemapb.CollectionSchema, segments []*datapb.CompactionSegment) (map[int64][]any, int) {
+	readSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: common.RowIDField, Name: "row_id", DataType: schemapb.DataType_Int64},
+		{FieldID: common.TimeStampField, Name: "Timestamp", DataType: schemapb.DataType_Int64},
+	}}
+	for _, f := range schema.GetFields() {
+		if !common.IsSystemField(f.GetFieldID()) {
+			readSchema.Fields = append(readSchema.Fields, f)
+		}
+	}
+	out := make(map[int64][]any)
+	total := 0
+	for _, seg := range segments {
+		segBinlogs := &datapb.CompactionSegmentBinlogs{
+			SegmentID:      seg.GetSegmentID(),
+			CollectionID:   CollectionID,
+			PartitionID:    PartitionID,
+			FieldBinlogs:   seg.GetInsertLogs(),
+			StorageVersion: storage.StorageV2,
+		}
+		reader, _, err := newCompactionSegmentRecordReader(context.Background(), segBinlogs, readSchema, cfg,
+			storage.WithCollectionID(CollectionID),
+			storage.WithVersion(storage.StorageV2),
+			storage.WithStorageConfig(cfg),
+		)
+		require.NoError(t, err)
+		for {
+			rec, err := reader.Next()
+			if err == sio.EOF {
+				break
+			}
+			require.NoError(t, err)
+			total += rec.Len()
+			for _, field := range readSchema.GetFields() {
+				col := rec.Column(field.GetFieldID())
+				require.NotNil(t, col, "output field %d missing", field.GetFieldID())
+				out[field.GetFieldID()] = appendArrowValues(t, out[field.GetFieldID()], col)
+			}
+		}
+		require.NoError(t, reader.Close())
+	}
+	return out, total
+}
+
+// rmcAssertGolden checks every output row against the deterministic source
+// formulas: original columns intact, added column = declared default, sparse
+// output present and non-empty. Returns sparse bytes keyed by pk.
+func rmcAssertGolden(t *testing.T, cols map[int64][]any, total, wantRows int) map[int64][]byte {
+	require.Equal(t, wantRows, total)
+	sparseByPK := make(map[int64][]byte, total)
+	for i := 0; i < total; i++ {
+		pk := cols[rmcPKField][i].(int64)
+		segID, row := pk/100000, int(pk%100000)
+		require.Equal(t, rmcText(segID, row), cols[rmcTextField][i], "text intact for pk %d", pk)
+		require.Equal(t, rmcAddedValue, cols[rmcAddedField][i], "default materialized for pk %d", pk)
+		sparse, ok := cols[rmcSparseField][i].([]byte)
+		require.True(t, ok, "sparse output missing for pk %d", pk)
+		require.NotEmpty(t, sparse, "sparse output empty for pk %d", pk)
+		sparseByPK[pk] = sparse
+	}
+	// W1 oracle: recompute the expected sparse bytes from the deterministic
+	// text formula through a real BM25 runner and byte-compare per row —
+	// non-emptiness cannot see rotation/misalignment corruption.
+	pks := make([]int64, 0, total)
+	texts := make([]string, 0, total)
+	for i := 0; i < total; i++ {
+		pk := cols[rmcPKField][i].(int64)
+		pks = append(pks, pk)
+		texts = append(texts, rmcText(pk/100000, int(pk%100000)))
+	}
+	schema := rmcTargetSchema()
+	expected := expectedBM25SparseRows(t, schema, schema.GetFunctions()[0], texts)
+	for i, pk := range pks {
+		require.Equal(t, expected[i], sparseByPK[pk], "sparse content<->row alignment for pk %d", pk)
+	}
+	return sparseByPK
+}
+
+func rmcPKsSorted(cols map[int64][]any, total int) bool {
+	for i := 1; i < total; i++ {
+		if cols[rmcPKField][i-1].(int64) > cols[rmcPKField][i].(int64) {
+			return false
+		}
+	}
+	return true
+}
+
+func rmcSortPlan(schema *schemapb.CollectionSchema, segments []*datapb.CompactionSegmentBinlogs, totalRows int64, compactionType datapb.CompactionType) *datapb.CompactionPlan {
+	jsonParams, err := compaction.GenerateJSONParams(schema)
+	if err != nil {
+		panic(err)
+	}
+	return &datapb.CompactionPlan{
+		PlanID:                 999,
+		Type:                   compactionType,
+		SegmentBinlogs:         segments,
+		Schema:                 schema,
+		TotalRows:              totalRows,
+		PreAllocatedSegmentIDs: &datapb.IDRange{Begin: 19531, End: math.MaxInt64},
+		PreAllocatedLogIDs:     &datapb.IDRange{Begin: 50000, End: math.MaxInt64},
+		MaxSize:                64 * 1024 * 1024,
+		JsonParams:             jsonParams,
+		Channel:                "rmc_channel",
+	}
+}
+
+// [C1][S0] sort consumer: materialized columns survive the sort pipeline
+// (reader-wrapper + storage.Sort record retention) row-for-row, and the output
+// order is by pk.
+func TestRMConsumerSortGolden(t *testing.T) {
+	setupBumpUTEnv(t)
+	const rows = 120
+	kvs, fBinlogs := rmcWriteSourceSegment(t, 5, rows, 40000)
+	binlogIO := rmcBinlogIO(t, kvs)
+
+	plan := rmcSortPlan(rmcTargetSchema(), []*datapb.CompactionSegmentBinlogs{{
+		SegmentID: 5, CollectionID: CollectionID, PartitionID: PartitionID, FieldBinlogs: fBinlogs,
+	}}, rows, datapb.CompactionType_SortCompaction)
+
+	params := compaction.GenParams()
+	task := NewSortCompactionTask(context.Background(), mocks.NewChunkManager(t), plan, params, []int64{rmcPKField})
+	task.binlogIO = binlogIO
+
+	result, err := task.Compact()
+	require.NoError(t, err)
+	require.Equal(t, datapb.CompactionTaskState_completed, result.GetState())
+	require.Len(t, result.GetSegments(), 1)
+	require.True(t, result.GetSegments()[0].GetIsSorted())
+
+	cols, total := rmcReadOutputColumns(t, params.StorageConfig, rmcTargetSchema(), result.GetSegments())
+	rmcAssertGolden(t, cols, total, rows)
+	require.True(t, rmcPKsSorted(cols, total), "sort output must be pk-ordered")
+}
+
+// [C2][S0] merge-sort consumer: three sorted segments, each with its own
+// materializer instance, merge into one globally ordered golden output with no
+// cross-segment value bleed.
+func TestRMConsumerMergeSortGolden(t *testing.T) {
+	setupBumpUTEnv(t)
+	const perSeg = 50
+	segIDs := []int64{5, 6, 7}
+	sources := make(map[string][]byte)
+	segments := make([]*datapb.CompactionSegmentBinlogs, 0, len(segIDs))
+	for idx, segID := range segIDs {
+		kvs, fBinlogs := rmcWriteSourceSegment(t, segID, perSeg, 40000+int64(idx)*1000)
+		for k, v := range kvs {
+			sources[k] = v
+		}
+		segments = append(segments, &datapb.CompactionSegmentBinlogs{
+			SegmentID: segID, CollectionID: CollectionID, PartitionID: PartitionID,
+			FieldBinlogs: fBinlogs, IsSorted: true,
+		})
+	}
+	binlogIO := rmcBinlogIO(t, sources)
+
+	plan := rmcSortPlan(rmcTargetSchema(), segments, int64(perSeg*len(segIDs)), datapb.CompactionType_MixCompaction)
+	params := compaction.GenParams()
+	params.UseMergeSort = true
+	params.MaxSegmentMergeSort = 8
+	task := NewMixCompactionTask(context.Background(), binlogIO, mocks.NewChunkManager(t), plan, params, []int64{rmcPKField})
+
+	result, err := task.Compact()
+	require.NoError(t, err)
+	require.Equal(t, datapb.CompactionTaskState_completed, result.GetState())
+
+	cols, total := rmcReadOutputColumns(t, params.StorageConfig, rmcTargetSchema(), result.GetSegments())
+	rmcAssertGolden(t, cols, total, perSeg*len(segIDs))
+	require.True(t, rmcPKsSorted(cols, total), "merge-sort output must be globally pk-ordered")
+
+	// [TS4][S0] merge-sort must carry the row_id system column through: every
+	// row keeps a unique row_id (no zeroed/duplicated system column).
+	rowIDs := make(map[int64]struct{}, total)
+	for i := 0; i < total; i++ {
+		id := cols[common.RowIDField][i].(int64)
+		_, dup := rowIDs[id]
+		require.False(t, dup, "duplicate row_id %d at row %d", id, i)
+		rowIDs[id] = struct{}{}
+	}
+}
+
+// [C3][S0] mix consumer: unsorted merge with a per-segment commit timestamp —
+// materialization and the ts-overwrite chain must compose, and rows from the
+// commit-ts segment must read back with the normalized timestamp.
+func TestRMConsumerMixCommitTsGolden(t *testing.T) {
+	setupBumpUTEnv(t)
+	const perSeg = 40
+	commitTs := tsoutil.ComposeTSByTime(getMilvusBirthday().Add(24 * 3600 * 1e9))
+	kvsA, fBinlogsA := rmcWriteSourceSegment(t, 5, perSeg, 40000)
+	kvsB, fBinlogsB := rmcWriteSourceSegment(t, 6, perSeg, 41000)
+	sources := make(map[string][]byte)
+	for k, v := range kvsA {
+		sources[k] = v
+	}
+	for k, v := range kvsB {
+		sources[k] = v
+	}
+	binlogIO := rmcBinlogIO(t, sources)
+
+	plan := rmcSortPlan(rmcTargetSchema(), []*datapb.CompactionSegmentBinlogs{
+		{SegmentID: 5, CollectionID: CollectionID, PartitionID: PartitionID, FieldBinlogs: fBinlogsA},
+		{SegmentID: 6, CollectionID: CollectionID, PartitionID: PartitionID, FieldBinlogs: fBinlogsB, CommitTimestamp: commitTs},
+	}, int64(perSeg*2), datapb.CompactionType_MixCompaction)
+
+	params := compaction.GenParams()
+	task := NewMixCompactionTask(context.Background(), binlogIO, mocks.NewChunkManager(t), plan, params, []int64{rmcPKField})
+
+	result, err := task.Compact()
+	require.NoError(t, err)
+	require.Equal(t, datapb.CompactionTaskState_completed, result.GetState())
+
+	cols, total := rmcReadOutputColumns(t, params.StorageConfig, rmcTargetSchema(), result.GetSegments())
+	rmcAssertGolden(t, cols, total, perSeg*2)
+	for i := 0; i < total; i++ {
+		pk := cols[rmcPKField][i].(int64)
+		ts := cols[common.TimeStampField][i].(int64)
+		if pk >= 600000 { // rows of segment 6 carry the normalized commit ts
+			require.Equal(t, int64(commitTs), ts, "commit-ts normalization for pk %d", pk)
+		} else {
+			rawTs := int64(tsoutil.ComposeTSByTime(getMilvusBirthday()))
+			require.Equal(t, rawTs, ts, "segment 5 keeps raw ts for pk %d", pk)
+		}
+	}
+}
+
+// [C5][S0] cross-consumer invariance: the same source rows materialized through
+// sort and through mix must yield identical added-column values and identical
+// BM25 sparse bytes per pk — the materializer's semantics must not depend on
+// its consumer.
+func TestRMConsumerCrossConsumerInvariance(t *testing.T) {
+	const rows = 60
+
+	runSort := func(t *testing.T) map[int64][]byte {
+		setupBumpUTEnv(t)
+		kvs, fBinlogs := rmcWriteSourceSegment(t, 5, rows, 40000)
+		binlogIO := rmcBinlogIO(t, kvs)
+		plan := rmcSortPlan(rmcTargetSchema(), []*datapb.CompactionSegmentBinlogs{{
+			SegmentID: 5, CollectionID: CollectionID, PartitionID: PartitionID, FieldBinlogs: fBinlogs,
+		}}, rows, datapb.CompactionType_SortCompaction)
+		params := compaction.GenParams()
+		task := NewSortCompactionTask(context.Background(), mocks.NewChunkManager(t), plan, params, []int64{rmcPKField})
+		task.binlogIO = binlogIO
+		result, err := task.Compact()
+		require.NoError(t, err)
+		cols, total := rmcReadOutputColumns(t, params.StorageConfig, rmcTargetSchema(), result.GetSegments())
+		return rmcAssertGolden(t, cols, total, rows)
+	}
+	runMix := func(t *testing.T) map[int64][]byte {
+		setupBumpUTEnv(t)
+		kvs, fBinlogs := rmcWriteSourceSegment(t, 5, rows, 40000)
+		binlogIO := rmcBinlogIO(t, kvs)
+		plan := rmcSortPlan(rmcTargetSchema(), []*datapb.CompactionSegmentBinlogs{{
+			SegmentID: 5, CollectionID: CollectionID, PartitionID: PartitionID, FieldBinlogs: fBinlogs,
+		}}, rows, datapb.CompactionType_MixCompaction)
+		params := compaction.GenParams()
+		task := NewMixCompactionTask(context.Background(), binlogIO, mocks.NewChunkManager(t), plan, params, []int64{rmcPKField})
+		result, err := task.Compact()
+		require.NoError(t, err)
+		cols, total := rmcReadOutputColumns(t, params.StorageConfig, rmcTargetSchema(), result.GetSegments())
+		return rmcAssertGolden(t, cols, total, rows)
+	}
+
+	sortSparse := runSort(t)
+	mixSparse := runMix(t)
+	require.Equal(t, len(sortSparse), len(mixSparse))
+	for pk, sparse := range sortSparse {
+		require.Equal(t, sparse, mixSparse[pk], "sparse bytes must be consumer-independent for pk %d", pk)
+	}
+}
+
+// [C4][S0] clustering consumer: buckets re-partition rows after
+// materialization; every output bucket's rows keep golden sparse outputs and
+// the input pk set is preserved exactly.
+func TestRMConsumerClusteringGolden(t *testing.T) {
+	s := &ClusteringCompactionTaskSuite{}
+	s.SetT(t)
+	s.SetupSuite()
+	s.SetupTest()
+	t.Cleanup(s.TearDownTest)
+
+	const rows = 30
+	s.prepareCompactionWithMissingBM25OutputTask(rows)
+
+	result, err := s.task.Compact()
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	cols, total := rmcReadOutputColumns(t, s.task.compactionParams.StorageConfig, s.task.plan.GetSchema(), result.GetSegments())
+	require.Equal(t, rows, total)
+	seenPKs := make(map[int64]struct{}, rows)
+	texts := make([]string, total)
+	for i := 0; i < total; i++ {
+		pk := cols[100][i].(int64)
+		seenPKs[pk] = struct{}{}
+		texts[i] = cols[101][i].(string)
+	}
+	require.Len(t, seenPKs, rows, "clustering must preserve the exact pk set")
+	// W1 oracle: each sparse row must equal the BM25 output of ITS OWN row's
+	// text — alignment is asserted independently of the bucket order.
+	schema := s.task.plan.GetSchema()
+	expected := expectedBM25SparseRows(t, schema, schema.GetFunctions()[0], texts)
+	for i := 0; i < total; i++ {
+		pk := cols[100][i].(int64)
+		sparse, ok := cols[102][i].([]byte)
+		require.True(t, ok, "sparse missing for pk %d", pk)
+		require.Equal(t, expected[i], sparse, "sparse content<->row alignment for pk %d", pk)
+	}
+}

--- a/internal/datanode/compactor/sort_compaction_test.go
+++ b/internal/datanode/compactor/sort_compaction_test.go
@@ -251,7 +251,7 @@ func (s *SortCompactionTaskSuite) TestSortCompactionBasic() {
 
 func (s *SortCompactionTaskSuite) TestSortCompactionWithBM25() {
 	s.setupBM25Test()
-	s.prepareSortCompactionWithBM25Task(false)
+	s.prepareSortCompactionWithBM25Task()
 
 	result, err := s.task.Compact()
 	s.NoError(err)
@@ -271,7 +271,7 @@ func (s *SortCompactionTaskSuite) TestSortCompactionWithBM25() {
 
 func (s *SortCompactionTaskSuite) TestSortCompactionMaterializesMissingBM25OutputFromOldSegment() {
 	s.setupBM25Test()
-	s.prepareSortCompactionWithBM25Task(true)
+	s.prepareSortCompactionWithBM25Task(102)
 
 	result, err := s.task.Compact()
 	s.NoError(err)
@@ -281,6 +281,18 @@ func (s *SortCompactionTaskSuite) TestSortCompactionMaterializesMissingBM25Outpu
 	s.EqualValues(1, segment.GetNumOfRows())
 	s.True(segment.GetIsSorted())
 	s.EqualValues(1, fieldBinlogEntriesForTest(segment.GetBm25Logs(), 102))
+}
+
+func (s *SortCompactionTaskSuite) TestSortCompactionPrefillsMissingBM25InputBeforeOutput() {
+	s.setupBM25Test()
+	typeutil.GetField(s.task.plan.GetSchema(), 101).Nullable = true
+	s.prepareSortCompactionWithBM25Task(101, 102)
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+	s.EqualValues(1, fieldBinlogEntriesForTest(result.GetSegments()[0].GetInsertLogs(), 101))
+	s.EqualValues(1, fieldBinlogEntriesForTest(result.GetSegments()[0].GetBm25Logs(), 102))
 }
 
 func (s *SortCompactionTaskSuite) TestSortCompactionMaterializesNullableAddedFieldFromOldSegment() {
@@ -353,7 +365,7 @@ func (s *SortCompactionTaskSuite) setupBM25Test() {
 	s.task.binlogIO = s.mockBinlogIO
 }
 
-func (s *SortCompactionTaskSuite) prepareSortCompactionWithBM25Task(removeBM25Output bool) {
+func (s *SortCompactionTaskSuite) prepareSortCompactionWithBM25Task(removeFieldIDs ...int64) {
 	segmentID := int64(1001)
 	alloc := allocator.NewLocalAllocator(100, math.MaxInt64)
 	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil)
@@ -361,8 +373,8 @@ func (s *SortCompactionTaskSuite) prepareSortCompactionWithBM25Task(removeBM25Ou
 	s.initSegBufferWithBM25(segmentID)
 	kvs, fBinlogs, err := serializeWrite(context.TODO(), alloc, s.segWriter)
 	s.Require().NoError(err)
-	if removeBM25Output {
-		removeFieldBinlogForTest(kvs, fBinlogs, 102)
+	for _, fieldID := range removeFieldIDs {
+		removeFieldBinlogForTest(kvs, fBinlogs, fieldID)
 	}
 
 	s.mockBinlogIO.EXPECT().Download(mock.Anything, mock.MatchedBy(func(keys []string) bool {

--- a/internal/storage/binlog_record_writer_v3_test.go
+++ b/internal/storage/binlog_record_writer_v3_test.go
@@ -233,6 +233,42 @@ func TestPackedManifestRecordWriter_TextRefsUseBinarySchema(t *testing.T) {
 	require.Equal(t, arrow.BINARY, gotSchema.Field(2).Type.ID())
 }
 
+func TestPartialPackedRecordBatchWriter_TextRefsUseBinarySchema(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 101, DataType: schemapb.DataType_Text, Name: "doc", Nullable: true},
+	}}
+	columnGroups := []storagecommon.ColumnGroup{
+		{GroupID: 101, Columns: []int{0}, Fields: []int64{101}},
+	}
+	cfg := &indexpb.StorageConfig{StorageType: "local", RootPath: t.TempDir()}
+
+	var gotSchema *arrow.Schema
+	patch := mockey.Mock(packed.NewFFIPackedWriter).To(
+		func(_ string, schema *arrow.Schema, _ []storagecommon.ColumnGroup,
+			_ *indexpb.StorageConfig, _ *indexcgopb.StoragePluginContext,
+			_ ...map[string]string,
+		) (*packed.FFIPackedWriter, error) {
+			gotSchema = schema
+			return &packed.FFIPackedWriter{}, nil
+		}).Build()
+	defer patch.UnPatch()
+
+	_, err := NewPartialPackedRecordBatchWriter(
+		t.TempDir(), schema, 0, 0, columnGroups, cfg, nil, "vortex", nil,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires TEXT-aware writer")
+	require.Nil(t, gotSchema)
+
+	w, err := NewPartialPackedRecordBatchWriterWithTextRefsAsBinary(
+		t.TempDir(), schema, 0, 0, columnGroups, cfg, nil, "vortex", nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, w)
+	require.NotNil(t, gotSchema)
+	require.Equal(t, arrow.BINARY, gotSchema.Field(0).Type.ID())
+}
+
 func TestPackedManifestRecordWriter_UsesExplicitWriterFormat(t *testing.T) {
 	params := paramtable.Get()
 	require.NoError(t, params.Save(params.DataNodeCfg.StorageFormat.Key, "vortex"))

--- a/internal/storage/record_writer.go
+++ b/internal/storage/record_writer.go
@@ -36,6 +36,29 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
+// toWriterRecord returns r as an arrow.Record projected onto the writer's own
+// schema, plus a release func the caller must defer. The fast path (returning
+// the backing arrow record untouched) is taken only when r is a
+// simpleArrowRecord whose schema already equals the writer's; otherwise the
+// writer's columns are selected by field ID, narrowing an over-wide record
+// (e.g. the additive schema-bump reader record carrying a row-anchor column in
+// addition to the appended field) to exactly the writer's column set. Passing
+// such an over-wide record straight to the FFI writer misaligns column count
+// against the writer's manifest and crashes loon_writer_write.
+func toWriterRecord(r Record, schema *schemapb.CollectionSchema, arrowSchema *arrow.Schema) (arrow.Record, func()) {
+	if sar, ok := r.(*simpleArrowRecord); ok && sar.r.Schema().Equal(arrowSchema) {
+		return sar.r, func() {}
+	}
+	// Include struct sub-fields, matching the writer's arrow schema layout.
+	allFields := typeutil.GetAllFieldSchemas(schema)
+	arrays := make([]arrow.Array, len(allFields))
+	for i, field := range allFields {
+		arrays[i] = r.Column(field.GetFieldID())
+	}
+	rec := array.NewRecord(arrowSchema, arrays, int64(r.Len()))
+	return rec, rec.Release
+}
+
 var _ RecordWriter = (*packedRecordWriter)(nil)
 
 type packedRecordWriter struct {
@@ -195,20 +218,8 @@ type packedRecordBatchWriter struct {
 }
 
 func (pw *packedRecordBatchWriter) Write(r Record) error {
-	var rec arrow.Record
-	sar, ok := r.(*simpleArrowRecord)
-	if !ok {
-		// Get all fields including struct sub-fields
-		allFields := typeutil.GetAllFieldSchemas(pw.schema)
-		arrays := make([]arrow.Array, len(allFields))
-		for i, field := range allFields {
-			arrays[i] = r.Column(field.FieldID)
-		}
-		rec = array.NewRecord(pw.arrowSchema, arrays, int64(r.Len()))
-		defer rec.Release()
-	} else {
-		rec = sar.r
-	}
+	rec, release := toWriterRecord(r, pw.schema, pw.arrowSchema)
+	defer release()
 	pw.rowNum += int64(r.Len())
 	for col, arr := range rec.Columns() {
 		size := calculateActualDataSize(arr)
@@ -271,6 +282,19 @@ func (pw *packedRecordBatchWriter) Close() (packed.WriterOutput, error) {
 	return out, nil
 }
 
+// Abort releases the underlying FFI writer without producing column groups for
+// CommitManifestUpdates. It prevents metadata publication only: files already
+// flushed before the abort stay on storage as unreferenced objects, and GC
+// skips files under a registered V3 segment prefix, so their reclamation
+// depends on the manifest-aware orphan cleanup tracked by #51649.
+func (pw *packedRecordBatchWriter) Abort() {
+	if pw.writer == nil {
+		return
+	}
+	pw.writer.Destroy()
+	pw.writer = nil
+}
+
 func (pw *packedRecordBatchWriter) AsNewColumnGroups() {
 	if pw.writer != nil {
 		pw.writer.AsNewColumnGroups()
@@ -303,6 +327,25 @@ func NewPartialPackedRecordBatchWriter(
 	schemaBasedFormats []string,
 ) (*packedRecordBatchWriter, error) {
 	return newPackedRecordBatchWriter(basePath, schema, bufferSize, multiPartUploadSize, columnGroups, storageConfig, storagePluginContext, false, false, writerFormat, schemaBasedFormats)
+}
+
+// NewPartialPackedRecordBatchWriterWithTextRefsAsBinary creates a partial
+// column-group writer whose TEXT columns use the binary LOB-reference Arrow
+// representation. Schema-bump reconciliation uses this for newly added,
+// nullable TEXT columns, whose historical values are materialized as binary
+// NULLs without rewriting any existing LOB data.
+func NewPartialPackedRecordBatchWriterWithTextRefsAsBinary(
+	basePath string,
+	schema *schemapb.CollectionSchema,
+	bufferSize int64,
+	multiPartUploadSize int64,
+	columnGroups []storagecommon.ColumnGroup,
+	storageConfig *indexpb.StorageConfig,
+	storagePluginContext *indexcgopb.StoragePluginContext,
+	writerFormat string,
+	schemaBasedFormats []string,
+) (*packedRecordBatchWriter, error) {
+	return newPackedRecordBatchWriter(basePath, schema, bufferSize, multiPartUploadSize, columnGroups, storageConfig, storagePluginContext, false, true, writerFormat, schemaBasedFormats)
 }
 
 func validatePackedRecordBatchWriterSchema(schema *schemapb.CollectionSchema) error {

--- a/internal/storage/record_writer_test.go
+++ b/internal/storage/record_writer_test.go
@@ -1,0 +1,99 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+)
+
+// TestToWriterRecordProjectsOverWideRecord pins the schema-bump additive
+// regression: the reader hands the writer a record carrying the row anchor in
+// addition to the appended field, while the writer's schema is only the
+// appended field. toWriterRecord must narrow the record to the writer's column
+// set instead of passing the over-wide record straight to the FFI writer
+// (which crashed loon_writer_write on the column-count mismatch).
+func TestToWriterRecordProjectsOverWideRecord(t *testing.T) {
+	// Writer schema: only the appended field 103.
+	writerSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 103, Name: "added", DataType: schemapb.DataType_VarChar},
+	}}
+	writerArrow, err := ConvertToArrowSchema(writerSchema, false)
+	require.NoError(t, err)
+
+	// Over-wide reader record: anchor field 0 (int64) + appended field 103.
+	anchorB := array.NewInt64Builder(memory.DefaultAllocator)
+	anchorB.AppendValues([]int64{10, 11, 12}, nil)
+	anchor := anchorB.NewArray()
+	anchorB.Release()
+	defer anchor.Release()
+
+	addedB := array.NewStringBuilder(memory.DefaultAllocator)
+	addedB.AppendValues([]string{"a", "b", "c"}, nil)
+	added := addedB.NewArray()
+	addedB.Release()
+	defer added.Release()
+
+	wideArrow := arrow.NewSchema([]arrow.Field{
+		{Name: "0", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "103", Type: arrow.BinaryTypes.String},
+	}, nil)
+	wideRec := array.NewRecord(wideArrow, []arrow.Array{anchor, added}, 3)
+	defer wideRec.Release()
+	overWide := NewSimpleArrowRecord(wideRec, map[FieldID]int{0: 0, 103: 1})
+
+	rec, release := toWriterRecord(overWide, writerSchema, writerArrow)
+	defer release()
+
+	require.EqualValues(t, 1, rec.NumCols(), "record must be narrowed to the writer's single column")
+	require.Equal(t, "added", rec.Schema().Field(0).Name)
+	col, ok := rec.Column(0).(*array.String)
+	require.True(t, ok)
+	require.Equal(t, 3, col.Len())
+	require.Equal(t, []string{"a", "b", "c"}, []string{col.Value(0), col.Value(1), col.Value(2)})
+}
+
+// TestToWriterRecordFastPathOnMatchingSchema verifies the optimization is kept:
+// a simpleArrowRecord whose schema already equals the writer's is returned
+// as-is with a no-op release.
+func TestToWriterRecordFastPathOnMatchingSchema(t *testing.T) {
+	writerSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 103, Name: "added", DataType: schemapb.DataType_VarChar},
+	}}
+	writerArrow, err := ConvertToArrowSchema(writerSchema, false)
+	require.NoError(t, err)
+
+	b := array.NewStringBuilder(memory.DefaultAllocator)
+	b.AppendValues([]string{"x", "y"}, nil)
+	col := b.NewArray()
+	b.Release()
+	defer col.Release()
+	matchRec := array.NewRecord(writerArrow, []arrow.Array{col}, 2)
+	defer matchRec.Release()
+	sar := NewSimpleArrowRecord(matchRec, map[FieldID]int{103: 0})
+
+	rec, release := toWriterRecord(sar, writerSchema, writerArrow)
+	defer release()
+
+	require.Same(t, matchRec, rec, "matching schema must take the fast path and return the backing record")
+}

--- a/internal/storage/rw_test.go
+++ b/internal/storage/rw_test.go
@@ -203,6 +203,30 @@ func (s *PackedBinlogRecordSuite) TestPackedBinlogRecordIntegration() {
 	s.Equal(err, io.EOF)
 	err = r.Close()
 	s.NoError(err)
+
+	// Fill contract on the packed (StorageV2) path: schema fields absent from the
+	// written files are backfilled by the reader (#52781/#52807) — a plain nullable
+	// field comes back all-null, a field with a declared default comes back default-filled.
+	extSchema := typeutil.Clone(s.schema)
+	extSchema.Fields = append(extSchema.Fields,
+		&schemapb.FieldSchema{FieldID: 200, Name: "added_nullable", DataType: schemapb.DataType_Int64, Nullable: true},
+		&schemapb.FieldSchema{
+			FieldID: 201, Name: "added_default", DataType: schemapb.DataType_Int64, Nullable: true,
+			DefaultValue: &schemapb.ValueField{Data: &schemapb.ValueField_LongData{LongData: 42}},
+		},
+	)
+	fr, err := NewBinlogRecordReader(s.ctx, binlogs, extSchema, rOption...)
+	s.NoError(err)
+	defer fr.Close()
+	frec, err := fr.Next()
+	s.NoError(err)
+	s.Positive(frec.Len())
+	s.Equal(frec.Len(), frec.Column(200).NullN(), "absent nullable column arrives all-null")
+	s.Equal(0, frec.Column(201).NullN(), "absent default-carrying column arrives default-filled (#52781/#52807)")
+	col201 := frec.Column(201).(*array.Int64)
+	for i := 0; i < col201.Len(); i++ {
+		s.EqualValues(42, col201.Value(i))
+	}
 }
 
 // TestManifestReadFillsAbsentDefaultField is the StorageV3/manifest analog: an

--- a/internal/storagev2/packed/manifest_commit_test.go
+++ b/internal/storagev2/packed/manifest_commit_test.go
@@ -252,6 +252,38 @@ func TestCommitManifestUpdates_AddNewColumnGroups(t *testing.T) {
 	require.Equal(t, int64(1), version)
 }
 
+func TestCommitManifestUpdates_AddEmptyColumnGroup(t *testing.T) {
+	cfg := manifestTestStorageConfig(t)
+	basePath := "files/commit_empty_cg/seg1"
+
+	schema := arrow.NewSchema([]arrow.Field{{
+		Name:     "101",
+		Type:     arrow.PrimitiveTypes.Int64,
+		Nullable: true,
+		Metadata: arrow.NewMetadata([]string{ArrowFieldIdMetadataKey}, []string{"101"}),
+	}}, nil)
+	columnGroups := []storagecommon.ColumnGroup{{Columns: []int{0}, Fields: []int64{101}, GroupID: 101}}
+
+	w, err := NewFFIPackedWriter(basePath, schema, columnGroups, cfg, nil)
+	require.NoError(t, err)
+	w.AsNewColumnGroups()
+	b := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+	defer b.Release()
+	rec := b.NewRecord()
+	defer rec.Release()
+	require.NoError(t, w.WriteRecordBatch(rec))
+
+	out, err := w.Close()
+	require.NoError(t, err)
+	defer out.Destroy()
+	manifest, err := CommitManifestUpdates(basePath, ManifestEarliest, cfg, &ManifestUpdates{NewFiles: out})
+	require.NoError(t, err)
+
+	fields, err := GetManifestFieldIDs(manifest, cfg)
+	require.NoError(t, err)
+	require.Contains(t, fields, int64(101))
+}
+
 // TestColumnGroups_DestroyIdempotent verifies that calling Destroy on a
 // ColumnGroups handle multiple times (and on a nil receiver) is safe.
 func TestColumnGroups_DestroyIdempotent(t *testing.T) {

--- a/internal/storagev2/packed/packed_writer_ffi.go
+++ b/internal/storagev2/packed/packed_writer_ffi.go
@@ -187,11 +187,14 @@ func (pw *FFIPackedWriter) AsNewColumnGroups() *FFIPackedWriter {
 	return pw
 }
 
-// Destroy releases writer resources without committing pending output.
+// Destroy releases writer resources without committing pending output. It
+// also marks the writer closed, so a later Close reports the misuse instead
+// of handing a null handle to the FFI as an "invalid arguments" error.
 func (pw *FFIPackedWriter) Destroy() {
 	if pw == nil {
 		return
 	}
+	pw.closed = true
 	if pw.cWriterHandle != 0 {
 		C.loon_writer_destroy(pw.cWriterHandle)
 		pw.cWriterHandle = 0
@@ -277,16 +280,7 @@ func (pw *FFIPackedWriter) Close() (WriterOutput, error) {
 		return nil, merr.WrapErrServiceInternalMsg("FFIPackedWriter already closed")
 	}
 	pw.closed = true
-	defer func() {
-		if pw.cWriterHandle != 0 {
-			C.loon_writer_destroy(pw.cWriterHandle)
-			pw.cWriterHandle = 0
-		}
-		if pw.cProperties != nil {
-			C.loon_properties_free(pw.cProperties)
-			pw.cProperties = nil
-		}
-	}()
+	defer pw.Destroy()
 	var cColumnGroups *C.LoonColumnGroups
 	result := C.loon_writer_close(pw.cWriterHandle, nil, nil, 0, &cColumnGroups)
 	if err := HandleLoonFFIResult(result); err != nil {


### PR DESCRIPTION
[3.0] cherry-pick of #52484.

Use manifest field IDs as the physical source of truth, prefill ordinary fields before function materialization, and publish additive columns through one replay-safe manifest adoption. Fill absent ordinary fields as null in the go layer instead of default-materializing them, and restore the live Binlogs merge on in-place adoption. Assemble the additive read schema through the reader's fill-absent contract, gating only the row-count anchor on physical presence.

issue: #52159
pr: #52484