### PR TITLE
fix: [cp3.0]translate x-amz-* headers to x-goog-* in GCS OAuth transport

### DIFF
--- a/internal/storage/minio_object_storage.go
+++ b/internal/storage/minio_object_storage.go
@@ -33,6 +33,8 @@ const minioSingleCopyObjectMaxSize = 5 * 1024 * 1024 * 1024
 
 type MinioObjectStorage struct {
 	*minio.Client
+
+	cloudProvider string
 }
 
 type ObjectReader struct {
@@ -52,7 +54,7 @@ func newMinioObjectStorageWithConfig(ctx context.Context, c *objectstorage.Confi
 	if err != nil {
 		return nil, err
 	}
-	return &MinioObjectStorage{minIOClient}, nil
+	return &MinioObjectStorage{Client: minIOClient, cloudProvider: c.CloudProvider}, nil
 }
 
 func (minioObjectStorage *MinioObjectStorage) GetObject(ctx context.Context, bucketName, objectName string, offset int64, size int64) (FileReader, error) {
@@ -136,7 +138,10 @@ func (minioObjectStorage *MinioObjectStorage) CopyObjectCrossBucket(ctx context.
 	if err != nil {
 		return mapObjectStorageError(srcObjectName, err)
 	}
-	if srcInfo.Size <= minioSingleCopyObjectMaxSize {
+	// GCS's XML API has no multipart copy: x-amz-copy-source-range (emitted by
+	// ComposeObject) has no x-goog-* equivalent. Its whole-object copy has no
+	// 5GiB cap though, so GCP always takes the single-copy path.
+	if srcInfo.Size <= minioSingleCopyObjectMaxSize || minioObjectStorage.cloudProvider == objectstorage.CloudProviderGCP {
 		_, err = minioObjectStorage.CopyObject(ctx, dstOpts, srcOpts)
 		return mapObjectStorageError(srcObjectName, err)
 	}

--- a/internal/storage/minio_object_storage_test.go
+++ b/internal/storage/minio_object_storage_test.go
@@ -157,6 +157,41 @@ func TestMinioObjectStorageCopyObjectCrossBucketUsesComposeForLargeObject(t *tes
 	assert.Equal(t, "dst-object", gotDst.Object)
 }
 
+func TestMinioObjectStorageCopyObjectCrossBucketGCPUsesSingleCopyForLargeObject(t *testing.T) {
+	var gotDst minio.CopyDestOptions
+	var gotSrc minio.CopySrcOptions
+	copyCalled := false
+	composeCalled := false
+	mockStat := mockey.Mock((*minio.Client).StatObject).Return(
+		minio.ObjectInfo{Size: minioSingleCopyObjectMaxSize + 1}, nil).Build()
+	defer mockStat.UnPatch()
+	mockCopy := mockey.Mock((*minio.Client).CopyObject).To(
+		func(_ *minio.Client, _ context.Context, dst minio.CopyDestOptions, src minio.CopySrcOptions) (minio.UploadInfo, error) {
+			copyCalled = true
+			gotDst = dst
+			gotSrc = src
+			return minio.UploadInfo{}, nil
+		}).Build()
+	defer mockCopy.UnPatch()
+	mockCompose := mockey.Mock((*minio.Client).ComposeObject).To(
+		func(_ *minio.Client, _ context.Context, _ minio.CopyDestOptions, _ ...minio.CopySrcOptions) (minio.UploadInfo, error) {
+			composeCalled = true
+			return minio.UploadInfo{}, nil
+		}).Build()
+	defer mockCompose.UnPatch()
+
+	objectStorage := &MinioObjectStorage{Client: &minio.Client{}, cloudProvider: objectstorage.CloudProviderGCP}
+	err := objectStorage.CopyObjectCrossBucket(context.Background(), "src-bucket", "src-object", "dst-bucket", "dst-object")
+	require.NoError(t, err)
+
+	assert.True(t, copyCalled)
+	assert.False(t, composeCalled)
+	assert.Equal(t, "src-bucket", gotSrc.Bucket)
+	assert.Equal(t, "src-object", gotSrc.Object)
+	assert.Equal(t, "dst-bucket", gotDst.Bucket)
+	assert.Equal(t, "dst-object", gotDst.Object)
+}
+
 func TestMinioObjectStorage(t *testing.T) {
 	ctx := context.Background()
 	config := objectstorage.Config{

--- a/internal/storage/remote_chunk_manager.go
+++ b/internal/storage/remote_chunk_manager.go
@@ -102,7 +102,7 @@ func NewRemoteChunkManager(ctx context.Context, c *objectstorage.Config) (*Remot
 // NewRemoteChunkManagerForTesting is used for testing.
 func NewRemoteChunkManagerForTesting(c *minio.Client, bucket string, rootPath string) *RemoteChunkManager {
 	mcm := &RemoteChunkManager{
-		client:            &MinioObjectStorage{c},
+		client:            &MinioObjectStorage{Client: c},
 		bucketName:        bucket,
 		rootPath:          rootPath,
 		readRetryAttempts: 10,

--- a/pkg/objectstorage/gcp/gcp.go
+++ b/pkg/objectstorage/gcp/gcp.go
@@ -38,8 +38,25 @@ func NewWrapHTTPTransport(secure bool) (*WrapHTTPTransport, error) {
 	}, nil
 }
 
+const (
+	xAmzPrefix  = "X-Amz-"
+	xGoogPrefix = "X-Goog-"
+)
+
 // RoundTrip wraps original http.RoundTripper by Adding a Bearer token acquired from tokenSrc
 func (t *WrapHTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// GCS's XML API only honors x-amz-* headers when the request is signed with
+	// HMAC keys. With OAuth 2.0 (Bearer token) authentication they must be sent
+	// as their x-goog-* counterparts — e.g. minio's CopyObject sends
+	// x-amz-copy-source, which GCS rejects with "Invalid argument" under Bearer
+	// auth unless it is translated to x-goog-copy-source.
+	for k, v := range req.Header {
+		if strings.HasPrefix(k, xAmzPrefix) {
+			req.Header[xGoogPrefix+strings.TrimPrefix(k, xAmzPrefix)] = v
+			delete(req.Header, k)
+		}
+	}
+
 	// here Valid() means the token won't be expired in 10 sec
 	// so the http client timeout shouldn't be longer, or we need to change the default `expiryDelta` time
 	currentToken := t.currentToken.Load()

--- a/pkg/objectstorage/gcp/gcp_test.go
+++ b/pkg/objectstorage/gcp/gcp_test.go
@@ -99,4 +99,20 @@ func TestGCPWrappedHTTPTransport_RoundTrip(t *testing.T) {
 		_, err = ts.RoundTrip(req)
 		assert.Error(t, err)
 	})
+
+	t.Run("x-amz headers translated to x-goog", func(t *testing.T) {
+		ts.backend = &mockTransport{}
+		req, err := http.NewRequest("PUT", "http://example.com/dst", nil)
+		assert.NoError(t, err)
+		req.Header.Set("X-Amz-Copy-Source", "bucket/src")
+		req.Header.Set("X-Amz-Metadata-Directive", "COPY")
+		req.Header.Set("X-Other-Header", "untouched")
+		_, err = ts.RoundTrip(req)
+		assert.NoError(t, err)
+		assert.Equal(t, "bucket/src", req.Header.Get("X-Goog-Copy-Source"))
+		assert.Equal(t, "COPY", req.Header.Get("X-Goog-Metadata-Directive"))
+		assert.Empty(t, req.Header.Get("X-Amz-Copy-Source"))
+		assert.Empty(t, req.Header.Get("X-Amz-Metadata-Directive"))
+		assert.Equal(t, "untouched", req.Header.Get("X-Other-Header"))
+	})
 }


### PR DESCRIPTION
Cherry-pick from master (PR still open)

pr: #52748
issue: #52746

## Summary

Cherry-picked from master PR #52748 (open - preemptive backport).

With `cloudProvider=gcp` and IAM/OAuth credentials, `WrapHTTPTransport` only swapped the Authorization header for a Bearer token. minio-go's `CopyObject` sends `x-amz-copy-source`, which GCS's XML API does not honor under OAuth 2.0 authentication, so every server-side copy (e.g. Storage V3 snapshot restore CopySegment tasks) failed with `Invalid argument`.

Two changes:

- Translate all `x-amz-*` headers to their `x-goog-*` counterparts in the transport, the same approach milvus-backup's `gcpTransport` has used in production against real GCS IAM.
- `MinioObjectStorage.CopyObjectCrossBucket` no longer routes >5GiB objects through `ComposeObject` when the provider is GCP: GCS's XML API has no multipart copy (`x-amz-copy-source-range` has no `x-goog-*` equivalent), while its whole-object copy has no 5GiB cap, so GCP always takes the single-copy path.

**Note**: Original PR is still open (under review). This CP PR should be updated if the original PR changes.

## Verification

- [x] File count matches original PR (5 files)
- [x] Changed lines identical to master PR (byte-for-byte diff empty on all 5 files)
- [x] No conflict markers
- [x] `go test -tags dynamic,test -gcflags="all=-N -l" ./pkg/objectstorage/gcp/...` green on this branch (new `x-amz_headers_translated_to_x-goog` case ran)
- [ ] internal/storage tests (blocked locally: milvus_core C++ build not present on dev machine; CI covers)
- [ ] make static-check (skipped by cherry-pick workflow)