### PR TITLE
fix: compile nested-array mmap path on macOS

### DIFF
--- a/internal/core/src/segcore/ConcurrentVector.cpp
+++ b/internal/core/src/segcore/ConcurrentVector.cpp
@@ -254,7 +254,8 @@ ConcurrentVector<ArrayValue>::set_mmap_proto_rows(
     while (source_offset < rows.size()) {
         const auto chunk_id = current_offset / size_per_chunk_;
         const auto chunk_offset = current_offset % size_per_chunk_;
-        const auto remaining_in_chunk = size_per_chunk_ - chunk_offset;
+        const auto remaining_in_chunk =
+            static_cast<ssize_t>(size_per_chunk_ - chunk_offset);
         const auto remaining_rows =
             static_cast<ssize_t>(rows.size() - source_offset);
         const auto copy_count = std::min(remaining_in_chunk, remaining_rows);


### PR DESCRIPTION
issue: #52797

## What this PR does

#51794 (recursively nested Array fields) calls `std::min` with mixed `int64_t` and `ssize_t` operands in `ConcurrentVector<ArrayValue>::set_mmap_proto_rows`. On Linux both typedefs resolve to `long`, so template argument deduction succeeds; on macOS `int64_t` is `long long` while `ssize_t` is `long`, so `std::min` fails to deduce a common type and `milvus_segcore` no longer compiles on macOS (broken since 2026-08-20).

This PR normalizes `remaining_in_chunk` to `ssize_t` so both operands share a type. Both types are signed 64-bit and the value cannot exceed `size_per_chunk_`, so the cast preserves the value.

## Verification

- Full `make` on macOS (arm64, Apple clang): passes with 0 errors; `ConcurrentVector.cpp.o` compiles cleanly.
- Root cause reproduced with a minimal reproducer against the pre-fix code (libc++: `deduced conflicting types for parameter '_Tp' ('int64_t' (aka 'long long') vs. 'ssize_t' (aka 'long'))`); fixed version compiles and runs.
- clang-format 15: no diff.

Related: pr #51794 (introduced the regression).
