### PR TITLE
test: bump CI Helm values target index versions to 11/4

### DIFF
--- a/tests/_helm/values/e2e-amd/distributed-pulsar
+++ b/tests/_helm/values/e2e-amd/distributed-pulsar
@@ -85,6 +85,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-amd/distributed-pulsar
+++ b/tests/_helm/values/e2e-amd/distributed-pulsar
@@ -87,7 +87,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 4
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-amd/distributed-woodpecker-service-boundary
+++ b/tests/_helm/values/e2e-amd/distributed-woodpecker-service-boundary
@@ -93,7 +93,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 4
+      targetScalarIndexVersion: 5
       enableCompaction: true
       compaction:
         enableAutoCompaction: false

--- a/tests/_helm/values/e2e-amd/distributed-woodpecker-service-boundary
+++ b/tests/_helm/values/e2e-amd/distributed-woodpecker-service-boundary
@@ -91,6 +91,9 @@ extraConfigFiles:
       segment:
         insertBufSize: 1048576
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 4
       enableCompaction: true
       compaction:
         enableAutoCompaction: false

--- a/tests/_helm/values/e2e-amd/standalone
+++ b/tests/_helm/values/e2e-amd/standalone
@@ -46,7 +46,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 4
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-amd/standalone
+++ b/tests/_helm/values/e2e-amd/standalone
@@ -44,6 +44,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-amd/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e-amd/standalone-kafka-mmap
@@ -42,7 +42,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 4
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-amd/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e-amd/standalone-kafka-mmap
@@ -40,6 +40,9 @@ extraConfigFiles:
         # enable storage v3
         useLoonFFI: true
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-amd/standalone-wp-embed
+++ b/tests/_helm/values/e2e-amd/standalone-wp-embed
@@ -46,7 +46,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 4
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-amd/standalone-wp-embed
+++ b/tests/_helm/values/e2e-amd/standalone-wp-embed
@@ -44,6 +44,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-arm/distributed-pulsar
+++ b/tests/_helm/values/e2e-arm/distributed-pulsar
@@ -74,7 +74,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 4
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-arm/distributed-pulsar
+++ b/tests/_helm/values/e2e-arm/distributed-pulsar
@@ -72,6 +72,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-arm/distributed-woodpecker-service-boundary
+++ b/tests/_helm/values/e2e-arm/distributed-woodpecker-service-boundary
@@ -80,7 +80,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 4
+      targetScalarIndexVersion: 5
       enableCompaction: true
       compaction:
         enableAutoCompaction: false

--- a/tests/_helm/values/e2e-arm/distributed-woodpecker-service-boundary
+++ b/tests/_helm/values/e2e-arm/distributed-woodpecker-service-boundary
@@ -1,0 +1,169 @@
+nodeSelector:
+  jenkins-e2e-arm: "true"
+cluster:
+  enabled: true
+woodpecker:
+  enabled: true
+  image:
+    repository: harbor.milvus.io/woodpecker/woodpecker
+    tag: v0.1.37
+    pullPolicy: Always
+streaming:
+  enabled: true
+  woodpecker:
+    embedded: false
+proxy:
+  replicas: 2
+  resources:
+    limits:
+      cpu: "1"
+      memory: 4Gi
+    requests:
+      cpu: "0.3"
+      memory: 256Mi
+dataNode:
+  replicas: 2
+  resources:
+    limits:
+      cpu: "2"
+      memory: 8Gi
+    requests:
+      cpu: "0.5"
+      memory: 500Mi
+indexNode:
+  enabled: false
+queryNode:
+  replicas: 2
+  disk:
+    enabled: true
+  resources:
+    limits:
+      cpu: "1"
+      memory: 4Gi
+    requests:
+      cpu: "0.5"
+      memory: 512Mi
+streamingNode:
+  replicas: 2
+  resources:
+    limits:
+      cpu: "2"
+      memory: 8Gi
+    requests:
+      cpu: "0.5"
+      memory: 512Mi
+mixCoordinator:
+  resources:
+    limits:
+      cpu: "1"
+      memory: 4Gi
+    requests:
+      cpu: "0.2"
+      memory: 256Mi
+service:
+  type: ClusterIP
+log:
+  level: debug
+extraConfigFiles:
+  user.yaml: |+
+    common:
+      bloomFilterApplyBatchSize: 511
+      storage:
+        enablev2: true
+        # enable storage v3
+        useLoonFFI: true
+    dataNode:
+      storage:
+        format: vortex
+      segment:
+        insertBufSize: 1048576
+    dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 4
+      enableCompaction: true
+      compaction:
+        enableAutoCompaction: false
+        storageVersion:
+          enabled: true
+        storageFormat:
+          enabled: true
+        bumpSchemaVersion:
+          enabled: true
+      segment:
+        maxSize: 64
+        sealProportion: 0.05
+        sealProportionJitter: 0
+      gc:
+        interval: 1800
+        missingTolerance: 1800
+        dropTolerance: 1800
+    queryNode:
+      segcore:
+        exprEvalBatchSize: 511
+        storageV2:
+          cellTargetSizeBytes: 1048576
+      mmap:
+        vectorField: true
+        vectorIndex: true
+        scalarField: true
+        scalarIndex: true
+        growingMmapEnabled: true
+    queryCoord:
+      checkNodeInReplicaInterval: 3
+    quotaAndLimits:
+      flushRate:
+        collection:
+          max: 4
+metrics:
+  serviceMonitor:
+    enabled: true
+# dependencies
+etcd:
+  nodeSelector:
+    jenkins-e2e-arm: "true"
+  metrics:
+    enabled: true
+    podMonitor:
+      enabled: true
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: "0.2"
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 4Gi
+  tolerations:
+  - effect: NoSchedule
+    key: jenkins-e2e-arm
+    operator: Exists
+minio:
+  nodeSelector:
+    jenkins-e2e-arm: "true"
+  mode: standalone
+  resources:
+    requests:
+      cpu: "0.2"
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 4Gi
+  tolerations:
+  - effect: NoSchedule
+    key: jenkins-e2e-arm
+    operator: Exists
+kafka:
+  enabled: false
+pulsarv3:
+  enabled: false
+# others
+image:
+  all:
+    pullPolicy: Always
+    repository: harbor.milvus.io/milvus/milvus
+    tag: nightly-20240821-ed4eaff
+tolerations:
+- effect: NoSchedule
+  key: jenkins-e2e-arm
+  operator: Exists

--- a/tests/_helm/values/e2e-arm/standalone
+++ b/tests/_helm/values/e2e-arm/standalone
@@ -33,7 +33,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 4
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-arm/standalone
+++ b/tests/_helm/values/e2e-arm/standalone
@@ -31,6 +31,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-arm/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e-arm/standalone-kafka-mmap
@@ -27,6 +27,9 @@ extraConfigFiles:
         # enable storage v3
         useLoonFFI: true
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-arm/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e-arm/standalone-kafka-mmap
@@ -29,7 +29,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 4
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-arm/standalone-wp-embed
+++ b/tests/_helm/values/e2e-arm/standalone-wp-embed
@@ -33,7 +33,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 4
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-arm/standalone-wp-embed
+++ b/tests/_helm/values/e2e-arm/standalone-wp-embed
@@ -31,6 +31,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e/distributed-pulsar
+++ b/tests/_helm/values/e2e/distributed-pulsar
@@ -85,6 +85,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e/distributed-pulsar
+++ b/tests/_helm/values/e2e/distributed-pulsar
@@ -87,7 +87,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 4
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e/standalone
+++ b/tests/_helm/values/e2e/standalone
@@ -46,7 +46,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 4
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e/standalone
+++ b/tests/_helm/values/e2e/standalone
@@ -44,6 +44,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e/standalone-kafka-mmap
@@ -42,7 +42,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 4
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e/standalone-kafka-mmap
@@ -40,6 +40,9 @@ extraConfigFiles:
         # enable storage v3
         useLoonFFI: true
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-kafka
+++ b/tests/_helm/values/nightly/distributed-kafka
@@ -88,7 +88,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 4
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-kafka
+++ b/tests/_helm/values/nightly/distributed-kafka
@@ -86,6 +86,9 @@ extraConfigFiles:
         # enable storage v3
         useLoonFFI: true
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-pulsar-mmap
+++ b/tests/_helm/values/nightly/distributed-pulsar-mmap
@@ -89,7 +89,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 4
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-pulsar-mmap
+++ b/tests/_helm/values/nightly/distributed-pulsar-mmap
@@ -87,6 +87,9 @@ extraConfigFiles:
         # enable storage v3
         useLoonFFI: true
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-woodpecker
+++ b/tests/_helm/values/nightly/distributed-woodpecker
@@ -94,7 +94,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 4
+      targetScalarIndexVersion: 5
       compaction:
         storageVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-woodpecker
+++ b/tests/_helm/values/nightly/distributed-woodpecker
@@ -92,6 +92,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 4
       compaction:
         storageVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-woodpecker-service
+++ b/tests/_helm/values/nightly/distributed-woodpecker-service
@@ -98,6 +98,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 4
       compaction:
         storageVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-woodpecker-service
+++ b/tests/_helm/values/nightly/distributed-woodpecker-service
@@ -100,7 +100,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 4
+      targetScalarIndexVersion: 5
       compaction:
         storageVersion:
           enabled: true

--- a/tests/_helm/values/nightly/standalone-authentication-mmap
+++ b/tests/_helm/values/nightly/standalone-authentication-mmap
@@ -37,6 +37,9 @@ log:
 extraConfigFiles:
   user.yaml: |+
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/nightly/standalone-authentication-mmap
+++ b/tests/_helm/values/nightly/standalone-authentication-mmap
@@ -39,7 +39,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 4
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true


### PR DESCRIPTION
Bump target index versions in CI Helm values.

- targetVecIndexVersion: 10 -> 11
- targetScalarIndexVersion: 3 -> 4
- forceRebuildScalarSegmentIndex: true (unchanged)