### PR TITLE
test: [cp3.0] bump CI Helm values target index versions to 11/4

### DIFF
--- a/tests/_helm/values/e2e-amd/distributed-pulsar
+++ b/tests/_helm/values/e2e-amd/distributed-pulsar
@@ -85,9 +85,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
-      targetVecIndexVersion: 10
+      targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-amd/distributed-woodpecker-service-boundary
+++ b/tests/_helm/values/e2e-amd/distributed-woodpecker-service-boundary
@@ -91,9 +91,9 @@ extraConfigFiles:
       segment:
         insertBufSize: 1048576
     dataCoord:
-      targetVecIndexVersion: 10
+      targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       enableCompaction: true
       compaction:
         enableAutoCompaction: false

--- a/tests/_helm/values/e2e-amd/standalone
+++ b/tests/_helm/values/e2e-amd/standalone
@@ -44,9 +44,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
-      targetVecIndexVersion: 10
+      targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-amd/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e-amd/standalone-kafka-mmap
@@ -40,9 +40,9 @@ extraConfigFiles:
         # enable storage v3
         useLoonFFI: true
     dataCoord:
-      targetVecIndexVersion: 10
+      targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-amd/standalone-wp-embed
+++ b/tests/_helm/values/e2e-amd/standalone-wp-embed
@@ -44,9 +44,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
-      targetVecIndexVersion: 10
+      targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-arm/distributed-pulsar
+++ b/tests/_helm/values/e2e-arm/distributed-pulsar
@@ -72,9 +72,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
-      targetVecIndexVersion: 10
+      targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-arm/distributed-woodpecker-service-boundary
+++ b/tests/_helm/values/e2e-arm/distributed-woodpecker-service-boundary
@@ -78,9 +78,9 @@ extraConfigFiles:
       segment:
         insertBufSize: 1048576
     dataCoord:
-      targetVecIndexVersion: 10
+      targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       enableCompaction: true
       compaction:
         enableAutoCompaction: false

--- a/tests/_helm/values/e2e-arm/standalone
+++ b/tests/_helm/values/e2e-arm/standalone
@@ -31,9 +31,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
-      targetVecIndexVersion: 10
+      targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-arm/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e-arm/standalone-kafka-mmap
@@ -27,9 +27,9 @@ extraConfigFiles:
         # enable storage v3
         useLoonFFI: true
     dataCoord:
-      targetVecIndexVersion: 10
+      targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-arm/standalone-wp-embed
+++ b/tests/_helm/values/e2e-arm/standalone-wp-embed
@@ -31,9 +31,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
-      targetVecIndexVersion: 10
+      targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e/distributed-pulsar
+++ b/tests/_helm/values/e2e/distributed-pulsar
@@ -85,9 +85,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
-      targetVecIndexVersion: 10
+      targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e/standalone
+++ b/tests/_helm/values/e2e/standalone
@@ -44,9 +44,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
-      targetVecIndexVersion: 10
+      targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e/standalone-kafka-mmap
@@ -40,9 +40,9 @@ extraConfigFiles:
         # enable storage v3
         useLoonFFI: true
     dataCoord:
-      targetVecIndexVersion: 10
+      targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-kafka
+++ b/tests/_helm/values/nightly/distributed-kafka
@@ -86,9 +86,9 @@ extraConfigFiles:
         # enable storage v3
         useLoonFFI: true
     dataCoord:
-      targetVecIndexVersion: 10
+      targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-pulsar-mmap
+++ b/tests/_helm/values/nightly/distributed-pulsar-mmap
@@ -87,9 +87,9 @@ extraConfigFiles:
         # enable storage v3
         useLoonFFI: true
     dataCoord:
-      targetVecIndexVersion: 10
+      targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-woodpecker
+++ b/tests/_helm/values/nightly/distributed-woodpecker
@@ -92,9 +92,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
-      targetVecIndexVersion: 10
+      targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         storageVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-woodpecker-service
+++ b/tests/_helm/values/nightly/distributed-woodpecker-service
@@ -98,9 +98,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
-      targetVecIndexVersion: 10
+      targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         storageVersion:
           enabled: true

--- a/tests/_helm/values/nightly/standalone-authentication-mmap
+++ b/tests/_helm/values/nightly/standalone-authentication-mmap
@@ -37,9 +37,9 @@ log:
 extraConfigFiles:
   user.yaml: |+
     dataCoord:
-      targetVecIndexVersion: 10
+      targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true


### PR DESCRIPTION
Cherry-pick of #52799 to 3.0.

Bump target index versions in CI Helm values.

- targetVecIndexVersion: 10 -> 11
- targetScalarIndexVersion: 3 -> 4
- forceRebuildScalarSegmentIndex: true (unchanged)