### PR TITLE
enhance: [cp3.0] skip pinning scalar index without raw data during retrieve

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -6205,18 +6205,14 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
 
     if (!IsVectorDataType(field_meta.get_data_type())) {
         // === Scalar field ===
-        if (!use_field_data) {
+        if (!use_field_data && IndexHasRawData(field_id)) {
             // Try index first: if scalar index exists and has raw data, read from index
             PinWrapper<const index::IndexBase*> pin_scalar_index_ptr;
             auto scalar_indexes = PinIndex(op_ctx, field_id);
             if (!scalar_indexes.empty()) {
                 pin_scalar_index_ptr = std::move(scalar_indexes[0]);
-                if (IndexHasRawData(field_id)) {
-                    return ReverseDataFromIndex(pin_scalar_index_ptr.get(),
-                                                seg_offsets,
-                                                count,
-                                                field_meta);
-                }
+                return ReverseDataFromIndex(
+                    pin_scalar_index_ptr.get(), seg_offsets, count, field_meta);
             }
         }
         return get_raw_data(op_ctx, field_id, field_meta, seg_offsets, count);

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -1328,6 +1328,56 @@ TEST(Sealed, LoadScalarIndex) {
     std::cout << json.dump(1);
 }
 
+TEST(Sealed, BulkSubscriptSkipsPinIndexWhenIndexHasNoRawData) {
+    size_t N = ROW_COUNT;
+    auto schema = std::make_shared<Schema>();
+    auto counter_id = schema->AddDebugField("counter", DataType::INT64);
+    auto double_id = schema->AddDebugField("double", DataType::DOUBLE);
+    schema->set_primary_field_id(counter_id);
+
+    auto dataset = DataGen(schema, N);
+    auto double_col = dataset.get_col<double>(double_id);
+
+    auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
+
+    // Load a scalar index whose metadata reports no raw data (as INVERTED
+    // does). TestIndexTranslator records the OpContext when the index is
+    // actually materialized, so we can assert bulk_subscript never pins it.
+    auto index = GenScalarIndexing<double>(N, double_col.data());
+    milvus::OpContext* observed_ctx = nullptr;
+    LoadIndexInfo load_info;
+    load_info.field_id = double_id.get();
+    load_info.field_type = DataType::DOUBLE;
+    load_info.index_params = GenIndexParams(index.get());
+    load_info.load_resource_request.emplace();
+    load_info.load_resource_request->has_raw_data = false;
+    load_info.cache_index =
+        CreateTestCacheIndex("test", std::move(index), &observed_ctx);
+    segment->LoadIndex(load_info);
+    ASSERT_TRUE(segment->HasIndex(double_id));
+
+    std::vector<int64_t> seg_offsets(N);
+    for (int64_t i = 0; i < static_cast<int64_t>(N); i++) {
+        seg_offsets[i] = i;
+    }
+
+    milvus::OpContext op_ctx;
+    auto field_data =
+        segment->bulk_subscript(&op_ctx, double_id, seg_offsets.data(), N);
+
+    // Values must be read from the raw column, unchanged.
+    ASSERT_TRUE(field_data->has_scalars());
+    ASSERT_TRUE(field_data->scalars().has_double_data());
+    ASSERT_EQ(field_data->scalars().double_data().data_size(),
+              static_cast<int>(N));
+    for (size_t i = 0; i < N; i++) {
+        ASSERT_EQ(field_data->scalars().double_data().data(i), double_col[i]);
+    }
+    // The index carries no raw data: bulk_subscript must fall back to the raw
+    // column without pinning (and thus materializing) the index.
+    ASSERT_EQ(observed_ctx, nullptr);
+}
+
 TEST(Sealed, Delete) {
     auto dim = 4;
     auto N = 10;


### PR DESCRIPTION
Cherry-pick from master
pr: #52796

issue: #52795

## What

In `ChunkedSegmentSealedImpl::bulk_subscript` (the `DataArray` overload serving search output fields, GIS refine and rescores), check `IndexHasRawData(field_id)` **before** `PinIndex` instead of after, so scalar indexes that carry no raw data (`INVERTED` / `NGRAM` / `RTREE`) are no longer lazily materialized just to be discarded in favor of the raw column.

## Why

`PinIndex` → `PinCells` triggers lazy scalar index materialization (index file read + deserialize + in-memory build). For indexes with `has_raw_data=false` the materialized index is never used — the value is read from the raw column via `get_raw_data`. This is pure waste of CPU/IO/memory per retrieve, and it also inflated `search_storage_cost` accounting by charging the wasted materialization bytes to the query. The vector branch right below already performs this check first; this aligns the two branches.

## Test Plan

- New regression test `Sealed.BulkSubscriptSkipsPinIndexWhenIndexHasNoRawData`: loads a scalar index reporting `has_raw_data=false` and asserts `bulk_subscript` returns the raw-column values without ever pinning (materializing) the index. Verified the test **fails without the fix** and **passes with it** (on master).
- Ran on the 3.0 worktree after `make build-cpp-with-unittest`:
  `./internal/core/output/unittest/all_tests --gtest_filter='Sealed.BulkSubscriptSkipsPinIndexWhenIndexHasNoRawData:Sealed.LoadArrayFieldData:Sealed.LoadArrayFieldDataWhenIndexHasRawData'`
  → **3/3 passed**.
- `git diff --check` clean.
