### PR TITLE
fix: keep telemetry commands idempotent at cursor

### DIFF
--- a/client/milvusclient/telemetry.go
+++ b/client/milvusclient/telemetry.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"os"
 	"sort"
 	"strconv"
@@ -37,6 +38,11 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/client/v3/common"
 	"github.com/milvus-io/milvus/client/v3/internal/merr"
+)
+
+const (
+	telemetryHistoryRetention    = time.Hour
+	maxTelemetryHistorySnapshots = 3600
 )
 
 // TelemetryConfig holds configurable settings for client telemetry
@@ -1112,8 +1118,21 @@ func (m *ClientTelemetryManager) collectMetrics() []*OperationMetrics {
 	return result
 }
 
-// handleCommand handles a single command
-func (m *ClientTelemetryManager) handleCommand(cmd *ClientCommand) *CommandReply {
+// handleCommand handles a single command. Command handlers are extensible user callbacks
+// invoked by the background heartbeat goroutine, so a panic must not take down either that
+// goroutine or the caller's whole process. Convert it into the same failed reply used for an
+// ordinary handler error and let later commands and heartbeats continue.
+func (m *ClientTelemetryManager) handleCommand(cmd *ClientCommand) (reply *CommandReply) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			reply = &CommandReply{
+				CommandId:    cmd.CommandId,
+				Success:      false,
+				ErrorMessage: "command handler panicked: " + panicValueString(recovered),
+			}
+		}
+	}()
+
 	m.commandHandlersMu.RLock()
 	handler, ok := m.commandHandlers[cmd.CommandType]
 	m.commandHandlersMu.RUnlock()
@@ -1127,6 +1146,17 @@ func (m *ClientTelemetryManager) handleCommand(cmd *ClientCommand) *CommandReply
 	}
 
 	return handler(cmd)
+}
+
+func panicValueString(value any) (result string) {
+	// A panic value can implement Stringer/Error with another panicking method. Keep a safe
+	// type-only fallback so formatting a malicious callback failure cannot escape the boundary.
+	result = fmt.Sprintf("%T", value)
+	defer func() {
+		_ = recover()
+	}()
+	result = fmt.Sprint(value)
+	return result
 }
 
 // RegisterCommandHandler registers a handler for a command type
@@ -1319,11 +1349,22 @@ func (m *ClientTelemetryManager) createSnapshot() {
 		Metrics:   metrics,
 	}
 
-	// Add to snapshot list (keep only the most recent 120 = 1 hour at 30s intervals)
+	// Retain one hour by timestamp instead of assuming a fixed heartbeat interval. The
+	// interval is dynamically configurable, so a fixed snapshot count silently changes the
+	// amount of queryable history. Keep a hard cap as a final memory bound for sub-second
+	// heartbeat configurations.
 	m.snapshotsMu.Lock()
 	m.snapshots = append(m.snapshots, snapshot)
-	if len(m.snapshots) > 120 {
-		m.snapshots = m.snapshots[len(m.snapshots)-120:]
+	cutoff := now - telemetryHistoryRetention.Milliseconds()
+	retained := m.snapshots[:0]
+	for _, existing := range m.snapshots {
+		if existing.EndTime >= cutoff {
+			retained = append(retained, existing)
+		}
+	}
+	m.snapshots = retained
+	if len(m.snapshots) > maxTelemetryHistorySnapshots {
+		m.snapshots = m.snapshots[len(m.snapshots)-maxTelemetryHistorySnapshots:]
 	}
 	m.snapshotsMu.Unlock()
 }

--- a/client/milvusclient/telemetry.go
+++ b/client/milvusclient/telemetry.go
@@ -41,7 +41,10 @@ import (
 
 // TelemetryConfig holds configurable settings for client telemetry
 type TelemetryConfig struct {
-	// Enabled controls whether telemetry collection is active
+	// Enabled controls telemetry at connection startup. An initial false value is an
+	// explicit opt-out and starts no heartbeat. When an already-running client is
+	// dynamically disabled by the server, operation collection and metric payloads
+	// stop while the command heartbeat stays active for ACKs and later re-enable.
 	Enabled bool
 	// HeartbeatInterval is how often to send heartbeats to server (default: 10 seconds).
 	//
@@ -580,7 +583,8 @@ func (m *ClientTelemetryManager) Start() {
 	// Mark as ready immediately - no blocking initial heartbeat
 	m.ready.Store(true)
 
-	// Start background heartbeat loop (snapshot creation is done inside heartbeatLoop)
+	// The heartbeat is also the command control plane. Keep it running while metrics
+	// are disabled so the server receives ACKs and can later re-enable collection.
 	m.wg.Add(1)
 	go m.heartbeatLoop()
 }
@@ -717,18 +721,16 @@ func (m *ClientTelemetryManager) sendHeartbeat() {
 	enabled := m.config.Enabled
 	m.configMu.RUnlock()
 
-	if !enabled {
-		return
-	}
-
 	if m.client == nil || m.client.telemetryService == nil {
 		return
 	}
 
 	// Get metrics from the latest snapshot (P99 already calculated during snapshot creation)
 	var metrics []*commonpb.OperationMetrics
-	if latestSnapshot := m.GetLatestSnapshot(); latestSnapshot != nil {
-		metrics = m.toProtoOperationMetrics(latestSnapshot.Metrics)
+	if enabled {
+		if latestSnapshot := m.GetLatestSnapshot(); latestSnapshot != nil {
+			metrics = m.toProtoOperationMetrics(latestSnapshot.Metrics)
+		}
 	}
 
 	// Get pending command replies (snapshot only)

--- a/client/milvusclient/telemetry.go
+++ b/client/milvusclient/telemetry.go
@@ -1483,7 +1483,6 @@ type ConfigPayload struct {
 	Enabled           *bool    `json:"enabled,omitempty"`
 	HeartbeatInterval *int64   `json:"heartbeat_interval_ms,omitempty"`
 	SamplingRate      *float64 `json:"sampling_rate,omitempty"`
-	TTLSeconds        int64    `json:"ttl_seconds,omitempty"`
 }
 
 // ConfigApplyResult is what a push_config reply carries back, so the sender can tell a

--- a/client/milvusclient/telemetry.go
+++ b/client/milvusclient/telemetry.go
@@ -42,7 +42,11 @@ import (
 
 const (
 	telemetryHistoryRetention    = time.Hour
-	maxTelemetryHistorySnapshots = 3600
+	maxTelemetryHistorySnapshots = 4096
+	// Retain a small quantile sketch per operation/window for mathematically valid
+	// history percentiles. At the one-hour hard snapshot cap this stays in the same
+	// memory range as the C++ implementation while preserving sub-percentile detail.
+	telemetryHistorySamplesPerWindow = 128
 )
 
 // TelemetryConfig holds configurable settings for client telemetry
@@ -287,11 +291,20 @@ func (c *OperationMetricsCollector) Record(collection string, latencyUs int64, s
 // IMPORTANT: P99 is calculated here atomically before clearing the sample buffer
 // This prevents the race condition where sendHeartbeat could calculate P99 from a cleared buffer
 func (c *OperationMetricsCollector) GetMetrics() *Metrics {
+	metrics, _ := c.getMetricsAndHistorySamples()
+	return metrics
+}
+
+// getMetricsAndHistorySamples atomically snapshots both the public interval metrics and
+// a bounded internal latency sketch before resetting the collector. A percentile cannot
+// be combined from per-window percentiles, so history aggregation needs samples from the
+// underlying distributions rather than a weighted average of their P99 values.
+func (c *OperationMetricsCollector) getMetricsAndHistorySamples() (*Metrics, []int64) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	if c.requestCount == 0 {
-		return nil
+		return nil, nil
 	}
 
 	avgLatency := float64(c.totalLatency) / float64(c.requestCount) / 1000.0
@@ -308,6 +321,10 @@ func (c *OperationMetricsCollector) GetMetrics() *Metrics {
 		P99LatencyMs: p99Latency,
 		MaxLatencyMs: maxLatency,
 	}
+	historySamples := retainHistoryLatencySamples(
+		copyValidLatencySamples(c.latencySamples, c.totalSamples, c.bufferSize),
+		telemetryHistorySamplesPerWindow,
+	)
 
 	// Reset counters for next period
 	c.requestCount = 0
@@ -318,7 +335,7 @@ func (c *OperationMetricsCollector) GetMetrics() *Metrics {
 	c.sampleIndex = 0
 	c.totalSamples = 0
 
-	return metrics
+	return metrics, historySamples
 }
 
 // GetMetricsSnapshot returns current metrics WITHOUT resetting counters
@@ -402,6 +419,43 @@ func calculateP99FromSamples(samples []int64, totalSamples int64, bufferSize int
 	}
 
 	return float64(sorted[index])
+}
+
+func copyValidLatencySamples(samples []int64, totalSamples int64, bufferSize int) []int64 {
+	if totalSamples <= 0 || bufferSize <= 0 {
+		return nil
+	}
+	count := min(bufferSize, len(samples))
+	if totalSamples < int64(count) {
+		count = int(totalSamples)
+	}
+	result := make([]int64, count)
+	// Ring order is irrelevant because the history sketch is sorted below.
+	copy(result, samples[:count])
+	return result
+}
+
+// retainHistoryLatencySamples turns the collector's recent ring into an evenly spaced
+// quantile sketch. Including both endpoints is important for tail percentiles, while the
+// fixed cap prevents one-hour history from retaining 1000 samples for every operation in
+// every heartbeat window.
+func retainHistoryLatencySamples(samples []int64, limit int) []int64 {
+	if len(samples) == 0 || limit <= 0 {
+		return nil
+	}
+	sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
+	if len(samples) <= limit {
+		return samples
+	}
+	if limit == 1 {
+		return []int64{samples[len(samples)-1]}
+	}
+	retained := make([]int64, limit)
+	for index := range retained {
+		source := index * (len(samples) - 1) / (limit - 1)
+		retained[index] = samples[source]
+	}
+	return retained
 }
 
 // GetP99Latency calculates P99 latency from current samples (in milliseconds)
@@ -541,6 +595,11 @@ type MetricsSnapshot struct {
 	Timestamp int64               // Unix timestamp in milliseconds (start of snapshot period)
 	EndTime   int64               // Unix timestamp in milliseconds (end of snapshot period)
 	Metrics   []*OperationMetrics // Metrics for all operations
+
+	// historyLatencySamples is an internal per-operation quantile sketch in microseconds.
+	// It is deliberately absent from heartbeat/detail payloads and exists only so a history
+	// query can calculate the percentile of the combined distribution.
+	historyLatencySamples map[string][]int64
 }
 
 // NewClientTelemetryManager creates a new client telemetry manager
@@ -1096,14 +1155,23 @@ func (m *ClientTelemetryManager) updateLastCommandTimestamp(ts int64) {
 
 // collectMetrics collects all operation metrics (local types, for testing)
 func (m *ClientTelemetryManager) collectMetrics() []*OperationMetrics {
+	metrics, _ := m.collectMetricsWithHistorySamples()
+	return metrics
+}
+
+func (m *ClientTelemetryManager) collectMetricsWithHistorySamples() ([]*OperationMetrics, map[string][]int64) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	var result []*OperationMetrics
+	historySamples := make(map[string][]int64)
 	for opName, collector := range m.collectors {
-		globalMetrics := collector.GetMetrics()
+		globalMetrics, samples := collector.getMetricsAndHistorySamples()
 		if globalMetrics == nil {
 			continue
+		}
+		if len(samples) > 0 {
+			historySamples[opName] = samples
 		}
 
 		collMetrics := collector.GetCollectionMetrics()
@@ -1115,7 +1183,7 @@ func (m *ClientTelemetryManager) collectMetrics() []*OperationMetrics {
 		})
 	}
 
-	return result
+	return result, historySamples
 }
 
 // handleCommand handles a single command. Command handlers are extensible user callbacks
@@ -1323,7 +1391,7 @@ func (m *ClientTelemetryManager) createSnapshot() {
 
 	// Collect current metrics (and reset counters)
 	// P99 is calculated here, before samples are cleared
-	metrics := m.collectMetrics()
+	metrics, historySamples := m.collectMetricsWithHistorySamples()
 
 	now := time.Now().UnixMilli()
 
@@ -1344,9 +1412,10 @@ func (m *ClientTelemetryManager) createSnapshot() {
 	m.lastSnapshotEnd.Store(now)
 
 	snapshot := &MetricsSnapshot{
-		Timestamp: start, // Start of the snapshot period
-		EndTime:   now,   // End of the snapshot period
-		Metrics:   metrics,
+		Timestamp:             start, // Start of the snapshot period
+		EndTime:               now,   // End of the snapshot period
+		Metrics:               metrics,
+		historyLatencySamples: historySamples,
 	}
 
 	// Retain one hour by timestamp instead of assuming a fixed heartbeat interval. The
@@ -1941,8 +2010,7 @@ func (m *ClientTelemetryManager) handleShowLatencyHistory(cmd *ClientCommand) *C
 	}
 }
 
-// aggregateSnapshots aggregates multiple snapshots into a single response
-// Uses weighted average for latencies (weighted by request count)
+// aggregateSnapshots aggregates multiple snapshots into a single response.
 func (m *ClientTelemetryManager) aggregateSnapshots(snapshots []*MetricsSnapshot, startTime, endTime int64) *AggregatedLatencyHistoryResponse {
 	if len(snapshots) == 0 {
 		return &AggregatedLatencyHistoryResponse{
@@ -1956,13 +2024,17 @@ func (m *ClientTelemetryManager) aggregateSnapshots(snapshots []*MetricsSnapshot
 	}
 
 	// Aggregate metrics by operation
+	type weightedLatencySample struct {
+		latencyMs float64
+		weight    float64
+	}
 	type aggregator struct {
 		requestCount   int64
 		successCount   int64
 		errorCount     int64
 		weightedAvgSum float64 // sum of (avg_latency * request_count)
-		weightedP99Sum float64 // sum of (p99_latency * request_count)
 		maxLatency     float64
+		latencySamples []weightedLatencySample
 	}
 
 	aggregators := make(map[string]*aggregator)
@@ -1983,7 +2055,25 @@ func (m *ClientTelemetryManager) aggregateSnapshots(snapshots []*MetricsSnapshot
 			agg.successCount += opMetrics.Global.SuccessCount
 			agg.errorCount += opMetrics.Global.ErrorCount
 			agg.weightedAvgSum += opMetrics.Global.AvgLatencyMs * float64(opMetrics.Global.RequestCount)
-			agg.weightedP99Sum += opMetrics.Global.P99LatencyMs * float64(opMetrics.Global.RequestCount)
+			samples := snapshot.historyLatencySamples[opMetrics.Operation]
+			if len(samples) > 0 && opMetrics.Global.RequestCount > 0 {
+				weight := float64(opMetrics.Global.RequestCount) / float64(len(samples))
+				for _, latencyUs := range samples {
+					agg.latencySamples = append(agg.latencySamples, weightedLatencySample{
+						latencyMs: float64(latencyUs) / 1000.0,
+						weight:    weight,
+					})
+				}
+			} else if opMetrics.Global.RequestCount > 0 {
+				// Backward-compatible fallback for manually constructed or transferred
+				// snapshots that predate the internal sample sketch. Treat the window P99
+				// as a weighted point; unlike averaging percentiles, this at least retains
+				// percentile ordering and preserves the exact single-window result.
+				agg.latencySamples = append(agg.latencySamples, weightedLatencySample{
+					latencyMs: opMetrics.Global.P99LatencyMs,
+					weight:    float64(opMetrics.Global.RequestCount),
+				})
+			}
 			if opMetrics.Global.MaxLatencyMs > agg.maxLatency {
 				agg.maxLatency = opMetrics.Global.MaxLatencyMs
 			}
@@ -1997,7 +2087,21 @@ func (m *ClientTelemetryManager) aggregateSnapshots(snapshots []*MetricsSnapshot
 		p99Latency := 0.0
 		if agg.requestCount > 0 {
 			avgLatency = agg.weightedAvgSum / float64(agg.requestCount)
-			p99Latency = agg.weightedP99Sum / float64(agg.requestCount)
+			sort.Slice(agg.latencySamples, func(i, j int) bool {
+				return agg.latencySamples[i].latencyMs < agg.latencySamples[j].latencyMs
+			})
+			if len(agg.latencySamples) > 0 {
+				target := float64(agg.requestCount) * 0.99
+				cumulative := 0.0
+				p99Latency = agg.latencySamples[len(agg.latencySamples)-1].latencyMs
+				for _, sample := range agg.latencySamples {
+					cumulative += sample.weight
+					if cumulative > target {
+						p99Latency = sample.latencyMs
+						break
+					}
+				}
+			}
 		}
 
 		metrics[op] = &MetricsResponse{

--- a/client/milvusclient/telemetry.go
+++ b/client/milvusclient/telemetry.go
@@ -1016,12 +1016,12 @@ func (m *ClientTelemetryManager) processProtoCommands(commands []*commonpb.Clien
 		}
 	}
 
-	// Clean up old entries from executedCommands map
-	// Commands with CreateTime <= lastTS are now filtered by timestamp comparison
-	// Using <= ensures commands with same millisecond timestamp are also cleaned up
+	// Clean up entries older than the new cursor. Commands at the cursor still pass
+	// the timestamp check, so retain their IDs to keep equal-timestamp redeliveries
+	// idempotent across any number of retries.
 	m.executedCommandsMu.Lock()
 	for cmdID, ts := range m.executedCommands {
-		if ts <= lastTS {
+		if ts < maxCommandTS {
 			delete(m.executedCommands, cmdID)
 		}
 	}

--- a/client/milvusclient/telemetry_test.go
+++ b/client/milvusclient/telemetry_test.go
@@ -333,6 +333,30 @@ func TestProcessProtoCommands(t *testing.T) {
 		assert.Equal(t, 1, executions)
 	})
 
+	t.Run("custom handler panic becomes a failed reply and batch continues", func(t *testing.T) {
+		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+		executions := 0
+		manager.RegisterCommandHandler("panic", func(*ClientCommand) *CommandReply {
+			panic("boom")
+		})
+		manager.RegisterCommandHandler("success", func(cmd *ClientCommand) *CommandReply {
+			executions++
+			return &CommandReply{CommandId: cmd.CommandId, Success: true}
+		})
+
+		manager.processProtoCommands([]*commonpb.ClientCommand{
+			{CommandId: "panic-command", CommandType: "panic", CreateTime: 1000},
+			{CommandId: "next-command", CommandType: "success", CreateTime: 1000},
+		})
+
+		replies := manager.getPendingProtoRepliesSnapshot()
+		require.Len(t, replies, 2)
+		assert.False(t, replies[0].GetSuccess())
+		assert.Equal(t, "command handler panicked: boom", replies[0].GetErrorMessage())
+		assert.True(t, replies[1].GetSuccess())
+		assert.Equal(t, 1, executions)
+	})
+
 	t.Run("idempotent ack and timestamp update", func(t *testing.T) {
 		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
 
@@ -2311,7 +2335,7 @@ func TestBuildClientInfoEdgeCases(t *testing.T) {
 }
 
 func TestSnapshotTrimming(t *testing.T) {
-	t.Run("trims to 120 snapshots", func(t *testing.T) {
+	t.Run("retains more than the old 120 snapshot limit inside one hour", func(t *testing.T) {
 		manager := NewClientTelemetryManager(nil, &TelemetryConfig{
 			Enabled:           true,
 			HeartbeatInterval: time.Millisecond,
@@ -2321,13 +2345,41 @@ func TestSnapshotTrimming(t *testing.T) {
 		// Record an operation first
 		manager.RecordOperation("Test", "", time.Now(), nil)
 
-		// Manually add more than 120 snapshots
+		// A count-only cap of 120 retained just two minutes at this interval.
 		for i := 0; i < 130; i++ {
 			manager.createSnapshot()
 		}
 
 		snapshots := manager.GetMetricsSnapshots()
-		assert.Equal(t, 120, len(snapshots))
+		assert.Equal(t, 130, len(snapshots))
+	})
+
+	t.Run("drops snapshots outside the one hour retention window", func(t *testing.T) {
+		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+		now := time.Now()
+		manager.snapshots = []*MetricsSnapshot{
+			{Timestamp: now.Add(-2 * time.Hour).UnixMilli(), EndTime: now.Add(-90 * time.Minute).UnixMilli()},
+			{Timestamp: now.Add(-time.Hour).UnixMilli(), EndTime: now.Add(-59 * time.Minute).UnixMilli()},
+		}
+
+		manager.createSnapshot()
+
+		snapshots := manager.GetMetricsSnapshots()
+		require.Len(t, snapshots, 2)
+		assert.Equal(t, now.Add(-59*time.Minute).UnixMilli(), snapshots[0].EndTime)
+	})
+
+	t.Run("keeps a hard memory bound for sub-second intervals", func(t *testing.T) {
+		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+		now := time.Now().UnixMilli()
+		manager.snapshots = make([]*MetricsSnapshot, 0, maxTelemetryHistorySnapshots+1)
+		for i := 0; i < maxTelemetryHistorySnapshots; i++ {
+			manager.snapshots = append(manager.snapshots, &MetricsSnapshot{Timestamp: now, EndTime: now})
+		}
+
+		manager.createSnapshot()
+
+		assert.Len(t, manager.GetMetricsSnapshots(), maxTelemetryHistorySnapshots)
 	})
 }
 

--- a/client/milvusclient/telemetry_test.go
+++ b/client/milvusclient/telemetry_test.go
@@ -3002,6 +3002,35 @@ func TestAggregateSnapshotsEdgeCases(t *testing.T) {
 	})
 }
 
+func TestAggregateSnapshotsP99UsesCombinedLatencyDistribution(t *testing.T) {
+	manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+
+	fastStart := time.Now().Add(-time.Millisecond)
+	for i := 0; i < 100; i++ {
+		manager.RecordOperation("Search", "", fastStart, nil)
+	}
+	manager.createSnapshot()
+
+	slowStart := time.Now().Add(-100 * time.Millisecond)
+	for i := 0; i < 100; i++ {
+		manager.RecordOperation("Search", "", slowStart, nil)
+	}
+	manager.createSnapshot()
+
+	snapshots := manager.GetMetricsSnapshots()
+	require.Len(t, snapshots, 2)
+	require.NotEmpty(t, snapshots[0].historyLatencySamples["Search"])
+	require.NotEmpty(t, snapshots[1].historyLatencySamples["Search"])
+
+	result := manager.aggregateSnapshots(snapshots, snapshots[0].Timestamp, snapshots[1].EndTime)
+	search := result.Aggregated.Metrics["Search"]
+	require.NotNil(t, search)
+	assert.Equal(t, int64(200), search.RequestCount)
+	// Averaging the two per-window P99 values would report roughly 50ms. The P99 of
+	// the combined equal-sized distribution belongs to the slow window.
+	assert.Greater(t, search.P99LatencyMs, 90.0)
+}
+
 // TestCalculateP99FromSamplesBufferWrap tests the buffer wrap scenarios
 func TestCalculateP99FromSamplesBufferWrap(t *testing.T) {
 	t.Run("totalSamples greater than bufferSize copies full buffer", func(t *testing.T) {

--- a/client/milvusclient/telemetry_test.go
+++ b/client/milvusclient/telemetry_test.go
@@ -2445,7 +2445,7 @@ func TestErrorCollectorRingBuffer(t *testing.T) {
 }
 
 func TestSendHeartbeatDisabled(t *testing.T) {
-	t.Run("disabled telemetry skips heartbeat", func(t *testing.T) {
+	t.Run("disabled telemetry with no transport is safe", func(t *testing.T) {
 		manager := NewClientTelemetryManager(nil, &TelemetryConfig{
 			Enabled: false,
 		})
@@ -2461,6 +2461,160 @@ func TestSendHeartbeatDisabled(t *testing.T) {
 		// This should not panic
 		manager.sendHeartbeat()
 	})
+}
+
+func TestDisabledTelemetryKeepsControlHeartbeatForAckAndReenable(t *testing.T) {
+	lis := bufconn.Listen(bufSize)
+	service := &reconfigTelemetryServer{
+		secondEntered: make(chan struct{}),
+		releaseSecond: make(chan struct{}),
+	}
+	svr := grpc.NewServer()
+	milvuspb.RegisterClientTelemetryServiceServer(svr, service)
+	go func() { _ = svr.Serve(lis) }()
+	defer func() {
+		svr.Stop()
+		_ = lis.Close()
+	}()
+
+	conn, err := grpc.DialContext(
+		context.Background(),
+		"bufnet",
+		grpc.WithBlock(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
+	)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	client := &Client{telemetryService: milvuspb.NewClientTelemetryServiceClient(conn)}
+	optedOutConfig := DefaultTelemetryConfig()
+	optedOutConfig.Enabled = false
+	optedOutConfig.HeartbeatInterval = 5 * time.Millisecond
+	optedOut := NewClientTelemetryManager(client, optedOutConfig)
+	optedOut.Start()
+	time.Sleep(20 * time.Millisecond)
+	optedOut.Stop()
+	assert.Empty(t, service.Captures(), "an initial Enabled=false must not start the heartbeat control plane")
+
+	manager := NewClientTelemetryManager(client, DefaultTelemetryConfig())
+	manager.RecordOperation("Search", "books", time.Now().Add(-time.Millisecond), nil)
+	manager.Start()
+	require.Eventually(t, func() bool {
+		manager.configMu.RLock()
+		disabled := !manager.config.Enabled
+		manager.configMu.RUnlock()
+		return disabled && len(service.Captures()) >= 1
+	}, time.Second, time.Millisecond)
+
+	initial := service.Captures()
+	require.NotEmpty(t, initial)
+	assert.NotEmpty(t, initial[0].metrics)
+	disableHash := manager.GetConfigHash()
+	assert.NotEmpty(t, disableHash)
+	replies := manager.getPendingProtoRepliesSnapshot()
+	require.Len(t, replies, 1)
+	assert.Equal(t, "disable", replies[0].GetCommandId())
+
+	manager.snapshotsMu.RLock()
+	snapshotCount := len(manager.snapshots)
+	manager.snapshotsMu.RUnlock()
+	manager.RecordOperation("Search", "books", time.Now().Add(-time.Millisecond), nil)
+	manager.createSnapshot()
+	manager.snapshotsMu.RLock()
+	assert.Len(t, manager.snapshots, snapshotCount)
+	manager.snapshotsMu.RUnlock()
+
+	select {
+	case <-service.secondEntered:
+	case <-time.After(time.Second):
+		t.Fatal("disabled control heartbeat did not reach the server")
+	}
+	disabled := service.Captures()
+	require.GreaterOrEqual(t, len(disabled), 2)
+	assert.Empty(t, disabled[1].metrics)
+	assert.Equal(t, disableHash, disabled[1].configHash)
+	require.Equal(t, []string{"disable"}, disabled[1].replyIDs)
+	close(service.releaseSecond)
+
+	require.Eventually(t, func() bool {
+		manager.configMu.RLock()
+		enabled := manager.config.Enabled
+		manager.configMu.RUnlock()
+		return enabled && len(service.Captures()) >= 2
+	}, time.Second, time.Millisecond)
+	reenableHash := manager.GetConfigHash()
+	require.NotEmpty(t, reenableHash)
+	require.Eventually(t, func() bool {
+		return len(service.Captures()) >= 3 && len(manager.getPendingProtoRepliesSnapshot()) == 0
+	}, time.Second, time.Millisecond)
+	manager.Stop()
+	captures := service.Captures()
+	require.GreaterOrEqual(t, len(captures), 3)
+	assert.Equal(t, reenableHash, captures[2].configHash)
+	require.Equal(t, []string{"reenable"}, captures[2].replyIDs)
+	assert.Empty(t, manager.getPendingProtoRepliesSnapshot())
+}
+
+type controlHeartbeatCapture struct {
+	metrics    []*commonpb.OperationMetrics
+	replyIDs   []string
+	configHash string
+}
+
+type reconfigTelemetryServer struct {
+	milvuspb.UnimplementedClientTelemetryServiceServer
+	mu            sync.Mutex
+	captures      []controlHeartbeatCapture
+	secondEntered chan struct{}
+	releaseSecond chan struct{}
+}
+
+func (s *reconfigTelemetryServer) ClientHeartbeat(_ context.Context, request *milvuspb.ClientHeartbeatRequest) (*milvuspb.ClientHeartbeatResponse, error) {
+	s.mu.Lock()
+	replyIDs := make([]string, 0, len(request.GetCommandReplies()))
+	for _, reply := range request.GetCommandReplies() {
+		replyIDs = append(replyIDs, reply.GetCommandId())
+	}
+	s.captures = append(s.captures, controlHeartbeatCapture{
+		metrics:    request.GetMetrics(),
+		replyIDs:   replyIDs,
+		configHash: request.GetConfigHash(),
+	})
+	heartbeatNumber := len(s.captures)
+	s.mu.Unlock()
+
+	command := &commonpb.ClientCommand{
+		CommandType: "push_config",
+		Persistent:  true,
+		TargetScope: "global",
+	}
+	switch heartbeatNumber {
+	case 1:
+		command.CommandId = "disable"
+		command.Payload = []byte(`{"enabled":false,"heartbeat_interval_ms":20}`)
+		command.CreateTime = 1
+	case 2:
+		close(s.secondEntered)
+		<-s.releaseSecond
+		command.CommandId = "reenable"
+		command.Payload = []byte(`{"enabled":true}`)
+		command.CreateTime = 2
+	default:
+		return &milvuspb.ClientHeartbeatResponse{Status: &commonpb.Status{}}, nil
+	}
+	return &milvuspb.ClientHeartbeatResponse{
+		Status:   &commonpb.Status{},
+		Commands: []*commonpb.ClientCommand{command},
+	}, nil
+}
+
+func (s *reconfigTelemetryServer) Captures() []controlHeartbeatCapture {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := make([]controlHeartbeatCapture, len(s.captures))
+	copy(result, s.captures)
+	return result
 }
 
 func TestHeartbeatLoopStop(t *testing.T) {
@@ -3216,7 +3370,7 @@ func TestSendHeartbeatEdgeCases(t *testing.T) {
 		manager.sendHeartbeat()
 	})
 
-	t.Run("sendHeartbeat with telemetry disabled", func(t *testing.T) {
+	t.Run("sendHeartbeat with disabled metrics and nil client", func(t *testing.T) {
 		manager := NewClientTelemetryManager(nil, &TelemetryConfig{
 			Enabled:           false,
 			HeartbeatInterval: 30 * time.Second,
@@ -3224,7 +3378,7 @@ func TestSendHeartbeatEdgeCases(t *testing.T) {
 			ErrorMaxCount:     100,
 		})
 
-		// Should return early because enabled is false
+		// The control plane remains active, but a nil client still makes this a no-op.
 		manager.sendHeartbeat()
 	})
 

--- a/client/milvusclient/telemetry_test.go
+++ b/client/milvusclient/telemetry_test.go
@@ -313,6 +313,26 @@ func TestClientTelemetryManager(t *testing.T) {
 }
 
 func TestProcessProtoCommands(t *testing.T) {
+	t.Run("equal timestamp stays idempotent after repeated delivery", func(t *testing.T) {
+		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+		executions := 0
+		manager.RegisterCommandHandler("custom", func(cmd *ClientCommand) *CommandReply {
+			executions++
+			return &CommandReply{CommandId: cmd.CommandId, Success: true}
+		})
+		command := []*commonpb.ClientCommand{{
+			CommandId:   "same-command",
+			CommandType: "custom",
+			CreateTime:  1000,
+		}}
+
+		manager.processProtoCommands(command)
+		manager.processProtoCommands(command)
+		manager.processProtoCommands(command)
+
+		assert.Equal(t, 1, executions)
+	})
+
 	t.Run("idempotent ack and timestamp update", func(t *testing.T) {
 		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
 

--- a/docs/design-docs/design_docs/20260131-client_side_telemetry.md
+++ b/docs/design-docs/design_docs/20260131-client_side_telemetry.md
@@ -40,9 +40,10 @@ This feature addresses these gaps by implementing a comprehensive client telemet
 // TelemetryConfig holds configurable settings for client telemetry
 type TelemetryConfig struct {
     Enabled           bool          // Enable/disable telemetry collection (default: true)
-    HeartbeatInterval time.Duration // Heartbeat frequency (default: 30s)
+    HeartbeatInterval time.Duration // Heartbeat frequency (default: 10s)
     SamplingRate      float64       // Sampling rate 0.0-1.0 (default: 1.0)
     ErrorMaxCount     int           // Max errors to track (default: 100)
+    ClientID          string        // Optional stable identity across process restarts
 }
 
 // ClientConfig gains a new field
@@ -54,7 +55,7 @@ type ClientConfig struct {
 
 **Telemetry is on by default and must be turned off explicitly.** `New()` always constructs
 and starts the manager; a nil `TelemetryConfig` is replaced by `DefaultTelemetryConfig()`,
-which returns `Enabled: true` with a 30s heartbeat and 100% sampling. A caller who never
+which returns `Enabled: true` with a 10s heartbeat and 100% sampling. A caller who never
 mentions `TelemetryConfig` therefore still reports heartbeats and metrics to the server. To
 disable it:
 
@@ -64,6 +65,11 @@ client.New(ctx, &client.ClientConfig{
     TelemetryConfig: &milvusclient.TelemetryConfig{Enabled: false},
 })
 ```
+
+An initial `Enabled: false` is an explicit opt-out and starts no heartbeat worker. If an
+already-running client is disabled later by a server `push_config`, operation collection and
+metric payloads stop, but the lightweight command heartbeat remains active so the disable
+reply is acknowledged and a later re-enable can be received.
 
 ### HTTP REST APIs (Proxy)
 
@@ -133,7 +139,7 @@ privilege check on this surface.
 │  │           └────────────────────┼────────────────────┘                 │  │
 │  │                                ▼                                       │  │
 │  │                    ┌───────────────────────┐                          │  │
-│  │                    │   Heartbeat Loop      │───────── 30s interval    │  │
+│  │                    │   Heartbeat Loop      │───────── 10s default     │  │
 │  │                    │   (Background)        │                          │  │
 │  │                    └───────────┬───────────┘                          │  │
 │  └────────────────────────────────┼──────────────────────────────────────┘  │
@@ -187,9 +193,9 @@ type ClientTelemetryManager struct {
 ```
 
 **Key behaviors:**
-- Generates a client UUID on creation. It is stable for the lifetime of the `Client`, and
-  therefore across gRPC reconnects, but **not across process restarts** -- each `New()`
-  produces a fresh UUID. Servers see a restarted process as a new client.
+- Generates a client UUID on creation unless `TelemetryConfig.ClientID` pins a stable value.
+  The resolved ID is stable for the lifetime of the `Client` and across gRPC reconnects. It
+  survives a process restart only when the caller supplies `ClientID`.
 - Starts background heartbeat loop on `Start()`
 - Sends first heartbeat immediately, then every `HeartbeatInterval`
 - Uses `time.After` per iteration rather than a `time.Ticker`, so a server-pushed interval
@@ -272,6 +278,8 @@ the client and is answered with `"unknown command type: <type>"`.
 | `get_config` | Return the client's current effective config | No |
 
 `command_store.go` rejects `persistent=true` for anything other than `push_config`.
+Custom handlers execute on the heartbeat goroutine. A handler panic is recovered and turned
+into a failed command reply so it cannot terminate the process or stop later heartbeats.
 
 **Payload schemas.** `ClientCommand.payload` is raw JSON (not protobuf).
 
@@ -308,6 +316,11 @@ type LatencyHistoryPayload struct {
 
 Reply payloads are capped at 1 MB client-side; `show_errors` halves the returned count
 until it fits. `get_config` deliberately omits `Password` and `APIKey`.
+
+Latency snapshots are retained by timestamp for one hour, independent of the dynamically
+configured heartbeat interval. A 3600-snapshot hard cap is the final memory bound for
+sub-second intervals. The previous fixed 120-snapshot cap represented one hour only at the
+obsolete 30-second default and retained just 20 minutes at the current 10-second default.
 
 ### Server-Side Components
 
@@ -538,7 +551,7 @@ Client                                      Server
    │                                           │
 ```
 
-**Heartbeat interval:** 30 seconds (client default; the server can change it via
+**Heartbeat interval:** 10 seconds (client default; the server can change it via
 `push_config`).
 
 **`report_timestamp`** is accepted but ignored — the server uses its own clock for
@@ -625,6 +638,7 @@ Persistent configs are never deleted by a reply; they are removed only via
 3. **Command Processing:**
    - Server returns commands in the heartbeat response
    - Client dispatches to the registered handler for that type
+   - A custom-handler panic becomes a failed reply; later commands and heartbeats continue
    - Reply is queued and sent with the next heartbeat
    - Persistent configs are re-sent only when the client's `config_hash` disagrees
 

--- a/docs/design-docs/design_docs/20260131-client_side_telemetry.md
+++ b/docs/design-docs/design_docs/20260131-client_side_telemetry.md
@@ -318,9 +318,14 @@ Reply payloads are capped at 1 MB client-side; `show_errors` halves the returned
 until it fits. `get_config` deliberately omits `Password` and `APIKey`.
 
 Latency snapshots are retained by timestamp for one hour, independent of the dynamically
-configured heartbeat interval. A 3600-snapshot hard cap is the final memory bound for
+configured heartbeat interval. A 4096-snapshot hard cap is the final memory bound for
 sub-second intervals. The previous fixed 120-snapshot cap represented one hour only at the
 obsolete 30-second default and retained just 20 minutes at the current 10-second default.
+Each operation/window also retains an internal 128-point, evenly spaced quantile sketch
+from the collector's recent sample ring. Aggregated history merges those weighted samples
+and computes P99 from the combined distribution; averaging the P99 values of individual
+windows is mathematically invalid. The sketch is internal and is not added to heartbeat or
+detail-mode response payloads.
 
 ### Server-Side Components
 


### PR DESCRIPTION
Issue: #47281

## Summary

- retain executed command IDs at the current telemetry timestamp cursor and prevent equal-timestamp redelivery from executing twice
- keep an already-started control heartbeat alive after runtime `enabled=false`, while preserving initial `Enabled=false` as a complete user opt-out
- recover custom-handler panics (including hostile `String()` / `Error()` implementations) into failed command replies so the heartbeat stays alive
- retain at most one hour / 4096 telemetry windows and aggregate history percentiles from bounded per-window latency samples instead of averaging p99 values
- keep latency history bounded to 128 sorted quantile samples per operation/window

## Documentation

- updated the [client-side telemetry design](https://github.com/milvus-io/milvus/blob/master/docs/design-docs/design_docs/20260131-client_side_telemetry.md) with the default interval, client identity, disable semantics, panic boundary, retention limits, and percentile aggregation algorithm

## Verification

- `cd client && go test ./milvusclient -count=1`
- `cd client && go test -race ./milvusclient -run "TestAggregateSnapshotsP99UsesCombinedLatencyDistribution|TestAggregateSnapshotsEdgeCases|TestSnapshotTrimming|TestProcessProtoCommands" -count=1`
- `git diff --check`
