### PR TITLE
fix: preserve the validity bitmap for nullable GEOMETRY in insert binlogs

### DIFF
--- a/internal/core/src/storage/DataCodecTest.cpp
+++ b/internal/core/src/storage/DataCodecTest.cpp
@@ -1166,17 +1166,96 @@ TEST(storage, InsertDataGeometryNullable) {
     auto new_payload = new_insert_data->GetFieldData();
     ASSERT_EQ(new_payload->get_data_type(), storage::DataType::GEOMETRY);
     ASSERT_EQ(new_payload->get_num_rows(), data.size());
-    // Note: current geometry serialization path writes empty string for null
-    // rows and loses Arrow null-bitmap, so null_count()==0 after round-trip.
 
-    // Expected data: original rows preserved (bitmap ignored by codec)
+    // Null rows must come back as nulls, exactly like every other nullable
+    // variable-length type in this file (see InsertDataStringNullable): the
+    // serializer has to hand the payload writer a negative length for a null
+    // row so Arrow records a 0 bit in the validity bitmap.
+    FixedVector<std::string> expected = {str1, str2, "", "", str5};
     FixedVector<std::string> new_data(data.size());
     for (int i = 0; i < data.size(); ++i) {
         new_data[i] =
             *static_cast<const std::string*>(new_payload->RawValue(i));
-        ASSERT_EQ(new_payload->DataSize(i), data[i].size());
+        ASSERT_EQ(new_payload->DataSize(i), expected[i].size());
     }
-    ASSERT_EQ(data, new_data);
+    ASSERT_EQ(expected, new_data);
+    ASSERT_EQ(new_payload->get_null_count(), 2);
+    EXPECT_TRUE(new_payload->is_valid(0));
+    EXPECT_TRUE(new_payload->is_valid(1));
+    EXPECT_FALSE(new_payload->is_valid(2));
+    EXPECT_FALSE(new_payload->is_valid(3));
+    EXPECT_TRUE(new_payload->is_valid(4));
+    ASSERT_EQ(*new_payload->ValidData(), *valid_data);
+}
+
+// Same round-trip, but with a row count that neither fills nor aligns to a
+// validity-bitmap byte: 13 rows spans two bytes with a partial second one, and
+// the nulls straddle the byte boundary (rows 7 and 8). A serializer that gets
+// the per-row validity lookup right for the first byte but drops or misindexes
+// it afterwards passes the 5-row case above and fails here.
+TEST(storage, InsertDataGeometryNullableAcrossValidityByteBoundary) {
+    auto ctx = GEOS_init_r();
+    constexpr int kRows = 13;
+    FixedVector<std::string> data(kRows);
+    for (int i = 0; i < kRows; ++i) {
+        std::string wkt =
+            "POINT (" + std::to_string(i) + ".0 " + std::to_string(i) + ".0)";
+        data[i] = Geometry(ctx, wkt.c_str()).to_wkb_string();
+    }
+    GEOS_finish_r(ctx);
+
+    // Nulls at rows 3, 7, 8, 12 -- bit i of byte i/8, LSB first, unused
+    // trailing bits set (the convention the other tests in this file use).
+    // byte0 rows 0-7 : 0b01110111 = 0x77   (rows 3, 7 null)
+    // byte1 rows 8-12: 0b11101110 = 0xEE   (rows 8, 12 null)
+    uint8_t valid_data_storage[2] = {0x77, 0xEE};
+    const std::vector<bool> expect_valid = {true,
+                                            true,
+                                            true,
+                                            false,
+                                            true,
+                                            true,
+                                            true,
+                                            false,
+                                            false,
+                                            true,
+                                            true,
+                                            true,
+                                            false};
+
+    auto field_data = milvus::storage::CreateFieldData(
+        storage::DataType::GEOMETRY, storage::DataType::NONE, true);
+    field_data->FillFieldData(data.data(), valid_data_storage, kRows, 0);
+
+    auto payload_reader =
+        std::make_shared<milvus::storage::PayloadReader>(field_data);
+    storage::InsertData insert_data(payload_reader);
+    storage::FieldDataMeta field_data_meta{100, 101, 102, 103};
+    insert_data.SetFieldDataMeta(field_data_meta);
+    insert_data.SetTimestamps(0, 100);
+
+    auto serialized_bytes = insert_data.Serialize(storage::StorageType::Remote);
+    std::shared_ptr<uint8_t[]> serialized_data_ptr(serialized_bytes.data(),
+                                                   [&](uint8_t*) {});
+    auto new_insert_data = storage::DeserializeFileData(
+        serialized_data_ptr, serialized_bytes.size());
+
+    auto new_payload = new_insert_data->GetFieldData();
+    ASSERT_EQ(new_payload->get_data_type(), storage::DataType::GEOMETRY);
+    ASSERT_EQ(new_payload->get_num_rows(), kRows);
+    ASSERT_EQ(new_payload->get_null_count(), 4);
+    for (int i = 0; i < kRows; ++i) {
+        EXPECT_EQ(new_payload->is_valid(i), expect_valid[i])
+            << "validity mismatch at row " << i;
+        const auto& wkb =
+            *static_cast<const std::string*>(new_payload->RawValue(i));
+        if (expect_valid[i]) {
+            EXPECT_EQ(wkb, data[i]) << "payload mismatch at row " << i;
+        } else {
+            EXPECT_EQ(new_payload->DataSize(i), 0)
+                << "null row " << i << " should carry no payload";
+        }
+    }
 }
 TEST(storage, InsertDataString) {
     FixedVector<std::string> data = {

--- a/internal/core/src/storage/Event.cpp
+++ b/internal/core/src/storage/Event.cpp
@@ -372,9 +372,15 @@ BaseEventData::Serialize() {
                      ++offset) {
                     auto geo_ptr = static_cast<const std::string*>(
                         field_data->RawValue(offset));
+                    // A negative length is the only way a null reaches Arrow
+                    // (AddOneBinaryToArrowBuilder appends a null iff
+                    // length < 0), so a null row must not be handed its raw
+                    // size -- same as the STRING/ARRAY/JSON branches above.
+                    auto size =
+                        field_data->is_valid(offset) ? geo_ptr->size() : -1;
                     payload_writer->add_one_binary_payload(
                         reinterpret_cast<const uint8_t*>(geo_ptr->data()),
-                        geo_ptr->size());
+                        size);
                 }
                 break;
             }


### PR DESCRIPTION
`BaseEventData::Serialize()` consults `field_data->is_valid(offset)` for every nullable
variable-length type — except `GEOMETRY`, which always passed `geo_ptr->size()`:

```cpp
// STRING / TEXT
auto size = field_data->is_valid(offset) ? str->size() : -1;
// ARRAY
auto size = field_data->is_valid(offset) ? array_string.size() : -1;
// JSON
auto size = field_data->is_valid(offset) ? string_view.size() : -1;
// GEOMETRY  <-- always >= 0
payload_writer->add_one_binary_payload(..., geo_ptr->size());
```

A negative length is the *only* signal that reaches Arrow as a null
(`AddOneBinaryToArrowBuilder` appends a null iff `data == nullptr || length < 0`), so
every GEOMETRY row was appended as non-null: the round-tripped payload came back with an
all-valid bitmap, and null rows still carried whatever WKB the `FieldData` held for them.

The fix is the one-line alignment with the three neighbouring branches. It deliberately
keeps their `auto size = ... : -1` form (the `size_t`/`int` narrowing that form relies on
is pre-existing and identical in all four) rather than diverging on style in a bugfix.

## Scope — please read before assessing severity

**Production insert binlogs are not affected.** They are written by the Go DataNode, and
the Go writer already handles this correctly: `internal/storage/data_codec.go` passes
`isValid` into `AddOneGeometryToPayload`, which calls `builder.AppendNull()`
(`internal/storage/payload_writer.go`).

The affected C++ path has **no production caller**. I audited every construction and
call site rather than only the line I edited:

- `InsertData::Serialize` — every call site in the repository is a `*Test.cpp`.
- `PayloadWriter` is constructed only in `Event.cpp`.
- The only other consumer of `BaseEventData::Serialize` is `IndexData` via
  `EncodeAndUploadIndexSlice`, which builds its payload as `DataType::INT8` and can never
  reach the `GEOMETRY` branch.

So what this actually fixes is:

1. **A latent defect** — the moment this serializer is used for real data, or its shape is
   copied, nullable GEOMETRY silently loses null semantics.
2. **A test-fixture fidelity problem that exists today** — C++ tests that build nullable
   GEOMETRY fixtures through `InsertData::Serialize` got all-valid data back, so null
   handling in the geometry cache / RTree index / GIS expressions was never actually
   exercised at that layer. `internal/core/src/index/RTreeIndexTest.cpp` builds its
   geometry fixtures through exactly this path.

I am explicitly **not** claiming this fixes user-visible data loss.

## Test

`TEST(storage, InsertDataGeometryNullable)` codified the broken behavior as expected:

```cpp
// Note: current geometry serialization path writes empty string for null
// rows and loses Arrow null-bitmap, so null_count()==0 after round-trip.
// Expected data: original rows preserved (bitmap ignored by codec)
ASSERT_EQ(data, new_data);
```

It was also the only nullable round-trip test in that file that did not assert
`get_null_count()`. It now asserts exactly what `InsertDataStringNullable` asserts.

Adds `InsertDataGeometryNullableAcrossValidityByteBoundary`: 13 rows — neither filling nor
aligning to a bitmap byte — with nulls straddling the byte boundary (rows 7 and 8). A
regression that got the first byte right but misindexed afterwards would pass the 5-row
case and fail this one.

Red/green verified locally against `master` at `f192bafbd5`:

- **before** — both fail, for the right reason: `InsertDataGeometryNullable` reports the
  null row still carrying `DataSize 21` (its original WKB), and
  `AcrossValidityByteBoundary` reports `get_null_count() == 0` instead of `4`. The
  non-nullable control `InsertDataGeometry` passes throughout, so the failures are the
  defect and not a broken test.
- **after** — all three pass.

Regression run of `storage.*` plus every `Geometry` / `GIS` / `RTree` suite:
**417 tests, 0 failures**. `clang-format-15` clean on both files, and formatting the tree
produced no diff outside the two files this PR touches.

Built with `make build-cpp-with-unittest` in a clean worktree (full core build, exit 0) —
not a partial/borrowed-library build.

## Branches

The `GEOMETRY` branch is byte-identical on `master`, `2.6` and `3.0`, so the same fix
applies to all three. Happy to open the backports once this lands.

issue: #52812
