### PR TITLE
enhance: update Knowhere to 59c51f0a

### DIFF
--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update KNOWHERE_VERSION for the first occurrence
 milvus_add_pkg_config("knowhere")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( KNOWHERE_VERSION d7cfd888 )
+set( KNOWHERE_VERSION 59c51f0a )
 set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
 
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array.py
@@ -199,16 +199,12 @@ for _index_type in ["HNSW_SQ", "HNSW_PQ", "HNSW_PRQ", "IVF_FLAT", "IVF_FLAT_CC"]
             "emb_list_rerank": True,
         },
     }
-EMB_LIST_MUVERA_LEMUR_INDEX_TYPES = ["HNSW", "HNSW_SQ", "HNSW_PQ", "HNSW_PRQ", "IVF_FLAT", "IVF_FLAT_CC"]
-EMB_LIST_STRATEGY_INDEX_CASES = (
-    [pytest.param("tokenann", "HNSW", id="tokenann-hnsw")]
-    + [
-        pytest.param(strategy, index_type, id=f"{strategy}-{index_type.lower()}")
-        for strategy in ["muvera", "lemur"]
-        for index_type in EMB_LIST_MUVERA_LEMUR_INDEX_TYPES
-    ]
-    + [pytest.param("tokenann", "DISKANN", id="tokenann-diskann")]
-)
+# Muvera and Lemur require EMB_LIST_META V2 (index engine version >= 11),
+# while Milvus currently resolves new vector indexes to version 10.
+EMB_LIST_STRATEGY_INDEX_CASES = [
+    pytest.param("tokenann", "HNSW", id="tokenann-hnsw"),
+    pytest.param("tokenann", "DISKANN", id="tokenann-diskann"),
+]
 EMB_LIST_UNSUPPORTED_STRATEGY_INDEX_CASES = [
     pytest.param("muvera", "DISKANN", id="muvera-diskann"),
     pytest.param("lemur", "DISKANN", id="lemur-diskann"),


### PR DESCRIPTION
## What

- Update Knowhere from `d7cfd888` to commit `59c51f0a`.
- Pick up zilliztech/knowhere#1788, which moves the embedding-list V2 minimum version from 10 to 11.
- Pick up zilliztech/knowhere#1790, which fixes growable sparse-index handling for `block_max_maxscore` and `block_max_wand`.
- Pick up zilliztech/knowhere#1789, which updates Cardinal v2 to `v3.0.6` and includes zilliztech/cardinal#917.
- Pick up zilliztech/knowhere#1787, which bounds `AioContextPool` waits and fails fast when no AIO context can be allocated.
- Remove the Muvera/Lemur EBL cases that require index engine version 11 from the default E2E parametrization; keep the TokenANN cases supported by Milvus' current version 10.

## Why

Knowhere PR #1788 raises `kEmbListMetaV2MinVersion` to 11. Milvus currently resolves new vector indexes to version 10, so Muvera and Lemur enter an unsupported legacy serialization path and their 12 E2E cases time out during index creation.

Following the existing test-side compatibility pattern used for version-gated index features, this PR trims only those unsupported parameter combinations instead of changing runtime or Helm configuration. TokenANN coverage remains enabled.

## Validation

- No local build or test was run, as requested; validation is delegated to Milvus PR CI.
- `git diff --check upstream/master..HEAD`
- Verified that `59c51f0a2f0b3908b68c0a6a3d693a8633422c79` is the merge commit of Knowhere PR #1787 and directly follows the previous pin.
