### PR TITLE
enhance: [3.0] update Knowhere to 59c51f0a

### DIFF
--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update KNOWHERE_VERSION for the first occurrence
 milvus_add_pkg_config("knowhere")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( KNOWHERE_VERSION c424ba0 )
+set( KNOWHERE_VERSION 59c51f0a )
 set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
 
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")


### PR DESCRIPTION
Source master PR: #52820 (pending merge).

This is the `3.0` companion of #52820. The release `pr:` metadata is intentionally deferred until the source PR is merged into `master`.

## What

- Update Knowhere from `c424ba0` to commit `59c51f0a`.
- Pick up zilliztech/knowhere#1790, which fixes growable sparse-index handling for `block_max_maxscore` and `block_max_wand`.
- Pick up zilliztech/knowhere#1789, which updates Cardinal v2 to `v3.0.6` and includes zilliztech/cardinal#917.
- Pick up zilliztech/knowhere#1787, which bounds `AioContextPool` waits and fails fast when no AIO context can be allocated.

## Why

The latest `3.0` base already pins Knowhere `c424ba0`, which contains zilliztech/knowhere#1788 and raises `kEmbListMetaV2MinVersion` to 11. Milvus PR #52800 is also merged into `3.0` and updates the CI target vector index version to 11, so the complete Muvera/Lemur EBL test matrix remains enabled without any test or Helm changes in this PR.

`59c51f0a` is a descendant of `c424ba0` and adds the three Knowhere fixes listed above.

## Validation

- No local build or test was run, as requested; validation is delegated to Milvus PR CI.
- `git diff --check upstream/3.0...HEAD`
- Verified with the Knowhere commit graph that `59c51f0a` is three commits ahead of `c424ba0` with no divergence.
