### PR TITLE
enhance: [3.0] stop copying both vectors out of StringChunk::ViewsByOffsets

### DIFF
--- a/internal/core/src/common/Chunk.cpp
+++ b/internal/core/src/common/Chunk.cpp
@@ -62,7 +62,7 @@ StringChunk::ViewsByOffsets(const FixedVector<int32_t>& offsets) {
         ret.emplace_back(data_ + start, offsets_[idx + 1] - start);
         valid_res.emplace_back(isValid(idx));
     }
-    return {ret, valid_res};
+    return {std::move(ret), std::move(valid_res)};
 }
 
 }  // namespace milvus


### PR DESCRIPTION
pr: #52827

Backport of #52827 to 3.0.

`StringChunk::ViewsByOffsets()` returned two lvalues, copying both the `std::vector<std::string_view>` and expanded validity vector on every offsets-based string predicate evaluation. This moves both results into the returned pair.

The surrounding 3.0 ownership path already contains the fixes from #52354, so this branch needs only the missing `ViewsByOffsets()` move.
