### PR TITLE
enhance: [2.6] stop copying both vectors out of StringChunk::ViewsByOffsets

### DIFF
--- a/internal/core/src/common/Chunk.cpp
+++ b/internal/core/src/common/Chunk.cpp
@@ -62,7 +62,7 @@ StringChunk::ViewsByOffsets(const FixedVector<int32_t>& offsets) {
         ret.emplace_back(data_ + start, offsets_[idx + 1] - start);
         valid_res.emplace_back(isValid(idx));
     }
-    return {ret, valid_res};
+    return {std::move(ret), std::move(valid_res)};
 }
 
 }  // namespace milvus

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -490,7 +490,7 @@ class SegmentExpr : public Expr {
         auto& skip_index = segment_->GetSkipIndex();
         auto pw =
             segment_->get_views_by_offsets<T>(op_ctx_, field_id_, 0, *input);
-        auto [data_vec, valid_data] = pw.get();
+        const auto& [data_vec, valid_data] = pw.get();
         if (!skip_func || !skip_func(skip_index, field_id_, 0)) {
             func(data_vec.data(),
                  ValidityView::FromExpanded(valid_data.data()),
@@ -619,7 +619,7 @@ class SegmentExpr : public Expr {
                             field_id_,
                             chunk_id,
                             {int32_t(chunk_offset)});
-                        auto [data_vec, valid_data] = pw.get();
+                        const auto& [data_vec, valid_data] = pw.get();
                         if (!skip_func ||
                             !skip_func(skip_index, field_id_, chunk_id)) {
                             func.template operator()<FilterType::random>(
@@ -892,7 +892,7 @@ class SegmentExpr : public Expr {
                         // use valid_data to see if raw data is null
                         auto pw = segment_->get_batch_views<T>(
                             op_ctx_, field_id_, i, data_pos, size);
-                        auto [data_vec, valid_data] = pw.get();
+                        const auto& [data_vec, valid_data] = pw.get();
 
                         if constexpr (NeedSegmentOffsets) {
                             func(data_vec.data(),

--- a/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
+++ b/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
@@ -399,8 +399,19 @@ TEST(JsonIndexTest, JsonBinaryRangePathIndexMatchesRawData) {
                 evaluate(number_expr, number_index_segment.get()));
 
     exec::OffsetVector offsets = {7, 2, 4, 1, 3, 5, 6, 0, 2};
-    expect_same(evaluate(number_expr, raw_segment.get(), &offsets),
-                evaluate(number_expr, number_index_segment.get(), &offsets));
+    auto raw_offset_result = evaluate(number_expr, raw_segment.get(), &offsets);
+    auto indexed_offset_result =
+        evaluate(number_expr, number_index_segment.get(), &offsets);
+    expect_same(raw_offset_result, indexed_offset_result);
+
+    ASSERT_EQ(raw_offset_result->size(), offsets.size());
+    TargetBitmapView raw_offset_values(raw_offset_result->GetRawData(),
+                                       raw_offset_result->size());
+    TargetBitmapView raw_offset_validity(raw_offset_result->GetValidRawData(),
+                                         raw_offset_result->size());
+    ASSERT_EQ(offsets[1], offsets[8]);
+    EXPECT_EQ(raw_offset_values[1], raw_offset_values[8]);
+    EXPECT_EQ(raw_offset_validity[1], raw_offset_validity[8]);
 
     auto expect_nan_range_matches_raw = [&](bool nan_is_lower) {
         proto::plan::GenericValue nan_bound;

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -345,14 +345,16 @@ class SegmentInternalInterface : public SegmentInterface {
         } else if constexpr (std::is_same_v<ViewType, Json>) {
             auto pw =
                 chunk_string_view_impl(op_ctx, field_id, chunk_id, offset_len);
-            auto [string_views, valid_data] = pw.get();
+            auto& [string_views, valid_data] = pw.get();
             std::vector<Json> res;
             res.reserve(string_views.size());
             for (const auto& str_view : string_views) {
                 res.emplace_back(Json(str_view));
             }
+            std::pair<std::vector<ViewType>, ValidityView> content{
+                std::move(res), std::move(valid_data)};
             return PinWrapper<std::pair<std::vector<ViewType>, ValidityView>>(
-                pw, {std::move(res), std::move(valid_data)});
+                std::move(pw), std::move(content));
         }
     }
 
@@ -387,14 +389,17 @@ class SegmentInternalInterface : public SegmentInterface {
         } else if constexpr (std::is_same_v<ViewType, Json>) {
             auto pw = chunk_string_views_by_offsets(
                 op_ctx, field_id, chunk_id, offsets);
+            auto& [string_views, valid_data] = pw.get();
             std::vector<ViewType> res;
-            res.reserve(pw.get().first.size());
-            for (const auto& view : pw.get().first) {
+            res.reserve(string_views.size());
+            for (const auto& view : string_views) {
                 res.emplace_back(view);
             }
+            std::pair<std::vector<ViewType>, FixedVector<bool>> content{
+                std::move(res), std::move(valid_data)};
             return PinWrapper<
                 std::pair<std::vector<ViewType>, FixedVector<bool>>>(
-                {std::move(res), pw.get().second});
+                std::move(pw), std::move(content));
         } else if constexpr (std::is_same_v<ViewType, ArrayView>) {
             return chunk_array_views_by_offsets(
                 op_ctx, field_id, chunk_id, offsets);


### PR DESCRIPTION
pr: #52827

Backport of #52827 to 2.6.

`StringChunk::ViewsByOffsets()` now moves both result vectors instead of copying them. The follow-up also completes the older 2.6 ownership path that the original backport missed:

- expression callers bind `PinWrapper` contents by reference instead of copying them again;
- JSON adapters move validity data and retain the parent `PinWrapper`, keeping source string views pinned;
- duplicate and unsorted offsets are covered by the raw-vs-index regression test.

This brings the 2.6 data and pin-lifetime semantics in line with 3.0/master.
