### PR TITLE
enhance: stop copying both vectors out of StringChunk::ViewsByOffsets

### DIFF
--- a/internal/core/src/common/Chunk.cpp
+++ b/internal/core/src/common/Chunk.cpp
@@ -62,7 +62,7 @@ StringChunk::ViewsByOffsets(const FixedVector<int32_t>& offsets) {
         ret.emplace_back(data_ + start, offsets_[idx + 1] - start);
         valid_res.emplace_back(isValid(idx));
     }
-    return {ret, valid_res};
+    return {std::move(ret), std::move(valid_res)};
 }
 
 }  // namespace milvus


### PR DESCRIPTION
## What

`StringChunk::ViewsByOffsets()` returned `{ret, valid_res}` with both values as lvalues, so the `std::vector<std::string_view>` and expanded validity vector were copy-constructed into the returned pair. The offsets-based string predicate path paid two avoidable allocations and copies per evaluation.

The method now moves both vectors into the result, matching the sibling string/array chunk paths.

## Context

#52354 fixed the same ownership pattern in `StringChunk::StringViews()`, but the nearby `ViewsByOffsets()` path was missed. This was found while profiling a production workload with infix `LIKE` predicates.

## Backports

- #52825 for 3.0
- #52826 for 2.6
