### PR TITLE
[2.6] fix: align unrepresentable JSON number semantics

### DIFF
--- a/internal/core/src/common/Consts.h
+++ b/internal/core/src/common/Consts.h
@@ -56,8 +56,9 @@ const char HINTS[] = "hints";
 const char JSON_KEY_INDEX_LOG_ROOT_PATH[] = "json_key_index_log";
 const char NGRAM_LOG_ROOT_PATH[] = "ngram_log";
 constexpr const char* JSON_STATS_ROOT_PATH = "json_stats";
-// Version 3: metadata moved to separate meta.json file (instead of parquet metadata)
-constexpr const char* JSON_STATS_DATA_FORMAT_VERSION = "3";
+// Version 4: shared BSON may contain undefined sentinels for numeric values
+// rejected by simdjson. Exact-version loading protects older readers.
+constexpr const char* JSON_STATS_DATA_FORMAT_VERSION = "4";
 constexpr const char* JSON_STATS_SHARED_INDEX_PATH = "shared_key_index";
 constexpr const char* JSON_STATS_SHREDDING_DATA_PATH = "shredding_data";
 constexpr const char* JSON_STATS_META_FILE_NAME = "meta.json";

--- a/internal/core/src/common/JsonCastFunction.cpp
+++ b/internal/core/src/common/JsonCastFunction.cpp
@@ -1,4 +1,7 @@
 #include "common/JsonCastFunction.h"
+
+#include <simdjson.h>
+#include <cstdint>
 #include <string>
 #include "common/EasyAssert.h"
 
@@ -21,11 +24,25 @@ JsonCastFunction::FromString(const std::string& str) {
 template <>
 std::optional<double>
 JsonCastFunction::cast<double, std::string>(const std::string& t) const {
-    try {
-        return std::stod(t);
-    } catch (const std::exception&) {
+    // Parse the string as a complete JSON number document. Besides avoiding
+    // platform-dependent std::stod behavior, this accepts representable
+    // subnormals and underflow-to-zero while rejecting overflow and trailing
+    // non-whitespace content.
+    simdjson::padded_string number_token(t);
+    thread_local simdjson::ondemand::parser parser;
+    auto document = parser.iterate(number_token);
+    if (document.error() != simdjson::SUCCESS) {
         return std::nullopt;
     }
+
+    // get_number() preserves simdjson's integer-domain validation. Calling
+    // document.get_double() directly would approximate integers larger than
+    // uint64_t even though the regular raw-JSON path rejects them.
+    auto number = document.get_number();
+    if (number.error() != simdjson::SUCCESS) {
+        return std::nullopt;
+    }
+    return number.value().as_double();
 }
 
 template <>
@@ -54,30 +71,41 @@ JsonCastFunction::CastJsonValue(const JsonCastFunction& cast_function,
     AssertInfo(cast_function.match<T>(), "Type mismatch");
 
     auto json_type = json.type(pointer);
+    if (json_type.error() != simdjson::SUCCESS) {
+        return std::nullopt;
+    }
+
     std::optional<T> res;
 
     switch (json_type.value()) {
         case simdjson::ondemand::json_type::string: {
             auto json_value = json.at<std::string_view>(pointer);
+            if (json_value.error() != simdjson::SUCCESS) {
+                return std::nullopt;
+            }
             res = cast_function.cast<T, std::string>(
                 std::string(json_value.value()));
             break;
         }
 
         case simdjson::ondemand::json_type::number: {
-            if (json.get_number_type(pointer) ==
-                simdjson::ondemand::number_type::floating_point_number) {
-                auto json_value = json.at<double>(pointer);
-                res = cast_function.cast<T, double>(json_value.value());
-            } else {
-                auto json_value = json.at<int64_t>(pointer);
-                res = cast_function.cast<T, int64_t>(json_value.value());
+            // STRING_TO_DOUBLE accepts numeric JSON values as identity casts.
+            // Parse into simdjson's tagged number first so integers outside the
+            // uint64_t domain remain invalid instead of being approximated by
+            // get_double().
+            auto json_value = json.at_numeric(pointer);
+            if (json_value.error() != simdjson::SUCCESS) {
+                return std::nullopt;
             }
+            res = cast_function.cast<T, double>(json_value.value().as_double());
             break;
         }
 
         case simdjson::ondemand::json_type::boolean: {
             auto json_value = json.at<bool>(pointer);
+            if (json_value.error() != simdjson::SUCCESS) {
+                return std::nullopt;
+            }
             res = cast_function.cast<T, bool>(json_value.value());
             break;
         }

--- a/internal/core/src/common/bson_view.h
+++ b/internal/core/src/common/bson_view.h
@@ -340,6 +340,7 @@ class BsonView {
                 }
                 break;
             case bsoncxx::type::k_null:
+            case bsoncxx::type::k_undefined:
             case bsoncxx::type::k_document:
             case bsoncxx::type::k_array:
                 break;
@@ -535,6 +536,9 @@ class BsonView {
                             return ParseAsArray(ptr);
                         }
                         break;
+                    case bsoncxx::type::k_undefined:
+                    case bsoncxx::type::k_null:
+                        return std::nullopt;
                     default:
                         return std::nullopt;
                 }
@@ -557,6 +561,9 @@ class BsonView {
                     break;
                 case bsoncxx::type::k_bool:
                     ptr += 1;
+                    break;
+                case bsoncxx::type::k_undefined:
+                case bsoncxx::type::k_null:
                     break;
                 case bsoncxx::type::k_array:
                 case bsoncxx::type::k_document: {

--- a/internal/core/src/exec/expression/BinaryRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.h
@@ -93,10 +93,10 @@ struct BinaryRangeElementFunc {
     }
 };
 
-// For int64_t GetType, uses at_numeric() (get_number()) to extract any JSON
-// number in a single parse.  Branches on actual type to preserve int64
-// precision; uint64 and double values fall back to double comparison,
-// consistent with the Tantivy index and JSON-stats paths.
+// Numeric GetType uses at_numeric() (get_number()) so unrepresentable JSON
+// numbers stay UNKNOWN.  The int64_t branch preserves integer precision;
+// uint64 and double values fall back to double comparison, consistent with
+// the Tantivy index and JSON-stats paths.
 // 'cmp' must reference 'value' (int64_t or double depending on the JSON value).
 #define BinaryRangeJSONCompare(cmp)                                    \
     do {                                                               \
@@ -123,6 +123,14 @@ struct BinaryRangeElementFunc {
                                  : n.get_double();                     \
                 res[i] = (cmp);                                        \
             }                                                          \
+        } else if constexpr (std::is_same_v<GetType, double>) {        \
+            auto x = src[offset].at_numeric(pointer);                  \
+            if (x.error()) {                                           \
+                res[i] = valid_res[i] = false;                         \
+                break;                                                 \
+            }                                                          \
+            auto value = x.value().as_double();                        \
+            res[i] = (cmp);                                            \
         } else {                                                       \
             auto x = src[offset].template at<GetType>(pointer);        \
             if (x.error()) {                                           \

--- a/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
+++ b/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
@@ -666,6 +666,75 @@ TEST(JsonIndexTest, LargeInt64LiteralFallsBackToPreciseRawComparison) {
     EXPECT_TRUE(singleton[1]);
 }
 
+TEST(JsonIndexTest, UnrepresentableRawDoubleIsUnknown) {
+    ExprBatchSizeGuard batch_size_guard(2);
+    const std::vector<std::string> json_strs = {
+        R"({"a": 1e400})",
+        R"({"a": 18446744073709551616})",
+        R"({"a": 1.5})",
+        R"({"a": 7})",
+    };
+
+    auto schema = std::make_shared<Schema>();
+    auto json_fid = schema->AddDebugField("json", DataType::JSON);
+    auto segment = CreateSealedSegment(schema);
+    auto json_field =
+        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, false);
+    std::vector<milvus::Json> jsons;
+    jsons.reserve(json_strs.size());
+    for (const auto& json : json_strs) {
+        jsons.emplace_back(simdjson::padded_string(json));
+    }
+    json_field->add_json_data(jsons);
+    auto chunk_manager =
+        milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+            .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        1, 1, 1, json_fid.get(), {json_field}, chunk_manager);
+    segment->LoadFieldData(load_info);
+
+    auto evaluate = [&](const expr::TypedExprPtr& filter_expr) {
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           filter_expr);
+        return milvus::test::gen_filter_res(
+            plan.get(), segment.get(), json_strs.size(), MAX_TIMESTAMP);
+    };
+    auto expect = [](const ColumnVectorPtr& result,
+                     const std::vector<bool>& expected_result) {
+        TargetBitmapView values(result->GetRawData(), result->size());
+        TargetBitmapView validity(result->GetValidRawData(), result->size());
+        ASSERT_EQ(result->size(), expected_result.size());
+        for (size_t i = 0; i < result->size(); ++i) {
+            EXPECT_EQ(validity[i], i >= 2) << "row " << i;
+            EXPECT_EQ(values[i], expected_result[i]) << "row " << i;
+        }
+    };
+
+    proto::plan::GenericValue one_point_five;
+    one_point_five.set_float_val(1.5);
+    auto column = expr::ColumnInfo(json_fid, DataType::JSON, {"a"});
+    expect(evaluate(std::make_shared<expr::TermFilterExpr>(
+               column,
+               std::vector<proto::plan::GenericValue>{one_point_five},
+               false)),
+           {false, false, true, false});
+
+    proto::plan::GenericValue one;
+    one.set_float_val(1.0);
+    expect(evaluate(std::make_shared<expr::UnaryRangeFilterExpr>(
+               column,
+               proto::plan::OpType::GreaterThan,
+               one,
+               std::vector<proto::plan::GenericValue>())),
+           {false, false, true, true});
+
+    proto::plan::GenericValue two;
+    two.set_float_val(2.0);
+    expect(evaluate(std::make_shared<expr::BinaryRangeFilterExpr>(
+               column, one, two, true, true)),
+           {false, false, true, false});
+}
+
 class JsonIndexExistsTest : public ::testing::TestWithParam<std::string> {};
 
 INSTANTIATE_TEST_SUITE_P(JsonIndexExistsTestParams,

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include "common/ScopedTimer.h"
 #include "common/Types.h"
+#include "exec/expression/JsonNumberComparison.h"
 
 namespace milvus {
 namespace exec {

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -102,6 +102,102 @@ class ContainsAllMatcher {
     size_t num_words_{0};
 };
 
+// Match one on-demand JSON array element against mixed-type query literals.
+// Inspecting the actual JSON type first lets us consume the on-demand value
+// exactly once.  In particular, an unrepresentable number (for example
+// 1e400) only makes that element a non-match; it cannot poison a sibling JSON
+// path or abort the whole query as whole-document DOM parsing would.
+template <typename OnMatch>
+void
+VisitMatchingJsonCandidates(
+    simdjson::simdjson_result<simdjson::ondemand::value>& value,
+    const std::vector<proto::plan::GenericValue>& candidates,
+    OnMatch&& on_match) {
+    auto type = value.type();
+    if (type.error()) {
+        return;
+    }
+
+    switch (type.value()) {
+        case simdjson::ondemand::json_type::boolean: {
+            auto parsed = value.template get<bool>();
+            if (parsed.error()) {
+                return;
+            }
+            for (size_t i = 0; i < candidates.size(); ++i) {
+                if (candidates[i].val_case() ==
+                        proto::plan::GenericValue::kBoolVal &&
+                    parsed.value() == candidates[i].bool_val() && on_match(i)) {
+                    return;
+                }
+            }
+            return;
+        }
+        case simdjson::ondemand::json_type::number: {
+            auto parsed = value.get_number();
+            if (parsed.error()) {
+                return;
+            }
+            for (size_t i = 0; i < candidates.size(); ++i) {
+                if (candidates[i].val_case() !=
+                        proto::plan::GenericValue::kInt64Val &&
+                    candidates[i].val_case() !=
+                        proto::plan::GenericValue::kFloatVal) {
+                    continue;
+                }
+                auto comparison =
+                    CompareJsonNumberToBound(parsed.value(), candidates[i]);
+                if (comparison.has_value() && *comparison == 0 && on_match(i)) {
+                    return;
+                }
+            }
+            return;
+        }
+        case simdjson::ondemand::json_type::string: {
+            auto parsed = value.template get<std::string_view>();
+            if (parsed.error()) {
+                return;
+            }
+            for (size_t i = 0; i < candidates.size(); ++i) {
+                if (candidates[i].val_case() ==
+                        proto::plan::GenericValue::kStringVal &&
+                    parsed.value() == candidates[i].string_val() &&
+                    on_match(i)) {
+                    return;
+                }
+            }
+            return;
+        }
+        case simdjson::ondemand::json_type::array: {
+            // Mixed-type expressions may compare this array with more than
+            // one array literal.  An on-demand array and its elements are
+            // forward-only, so materialize only this current element into a
+            // DOM value instead of retaining ephemeral on-demand cursors.
+            auto raw = value.raw_json();
+            if (raw.error()) {
+                return;
+            }
+            simdjson::padded_string padded(raw.value());
+            thread_local simdjson::dom::parser parser;
+            auto parsed = parser.parse(padded).get_array();
+            if (parsed.error()) {
+                return;
+            }
+            for (size_t i = 0; i < candidates.size(); ++i) {
+                if (candidates[i].val_case() ==
+                        proto::plan::GenericValue::kArrayVal &&
+                    CompareTwoJsonArray(parsed, candidates[i].array_val()) &&
+                    on_match(i)) {
+                    return;
+                }
+            }
+            return;
+        }
+        default:
+            return;
+    }
+}
+
 void
 PhyJsonContainsFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
     tracer::AutoSpan span(
@@ -1405,82 +1501,20 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffType(EvalCtx& context) {
         }
         auto executor = [&](size_t i) {
             const auto& json = data[i];
-            auto doc = json.dom_doc();
+            auto doc = json.doc();
             auto array = doc.at_pointer(pointer).get_array();
             if (array.error()) {
                 return std::make_pair(false, false);
             }
             std::unordered_set<int> tmp_elements_index(elements_index);
             for (auto&& it : array) {
-                int i = -1;
-                for (auto& element : elements) {
-                    i++;
-                    switch (element.val_case()) {
-                        case proto::plan::GenericValue::kBoolVal: {
-                            auto val = it.template get<bool>();
-                            if (val.error()) {
-                                continue;
-                            }
-                            if (val.value() == element.bool_val()) {
-                                tmp_elements_index.erase(i);
-                            }
-                            break;
-                        }
-                        case proto::plan::GenericValue::kInt64Val: {
-                            auto val = it.template get<int64_t>();
-                            if (val.error()) {
-                                auto double_val = it.template get<double>();
-                                if (!double_val.error() &&
-                                    double_val.value() == element.int64_val()) {
-                                    tmp_elements_index.erase(i);
-                                }
-                                continue;
-                            }
-                            if (val.value() == element.int64_val()) {
-                                tmp_elements_index.erase(i);
-                            }
-                            break;
-                        }
-                        case proto::plan::GenericValue::kFloatVal: {
-                            auto val = it.template get<double>();
-                            if (val.error()) {
-                                continue;
-                            }
-                            if (val.value() == element.float_val()) {
-                                tmp_elements_index.erase(i);
-                            }
-                            break;
-                        }
-                        case proto::plan::GenericValue::kStringVal: {
-                            auto val = it.template get<std::string_view>();
-                            if (val.error()) {
-                                continue;
-                            }
-                            if (val.value() == element.string_val()) {
-                                tmp_elements_index.erase(i);
-                            }
-                            break;
-                        }
-                        case proto::plan::GenericValue::kArrayVal: {
-                            auto val = it.get_array();
-                            if (val.error()) {
-                                continue;
-                            }
-                            if (CompareTwoJsonArray(val, element.array_val())) {
-                                tmp_elements_index.erase(i);
-                            }
-                            break;
-                        }
-                        default:
-                            ThrowInfo(DataTypeInvalid,
-                                      "unsupported data type {}",
-                                      element.val_case());
-                    }
-                    if (tmp_elements_index.size() == 0) {
-                        return std::make_pair(true, true);
-                    }
-                }
-                if (tmp_elements_index.size() == 0) {
+                VisitMatchingJsonCandidates(
+                    it, elements, [&](size_t matched_index) {
+                        tmp_elements_index.erase(
+                            static_cast<int>(matched_index));
+                        return tmp_elements_index.empty();
+                    });
+                if (tmp_elements_index.empty()) {
                     return std::make_pair(true, true);
                 }
             }
@@ -2009,75 +2043,19 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffType(EvalCtx& context) {
         }
         auto executor = [&](const size_t i) {
             auto& json = data[i];
-            auto doc = json.dom_doc();
+            auto doc = json.doc();
             auto array = doc.at_pointer(pointer).get_array();
             if (array.error()) {
                 return std::make_pair(false, false);
             }
-            // Note: array can only be iterated once
             for (auto&& it : array) {
-                for (auto const& element : elements) {
-                    switch (element.val_case()) {
-                        case proto::plan::GenericValue::kBoolVal: {
-                            auto val = it.template get<bool>();
-                            if (val.error()) {
-                                continue;
-                            }
-                            if (val.value() == element.bool_val()) {
-                                return std::make_pair(true, true);
-                            }
-                            break;
-                        }
-                        case proto::plan::GenericValue::kInt64Val: {
-                            auto val = it.template get<int64_t>();
-                            if (val.error()) {
-                                auto double_val = it.template get<double>();
-                                if (!double_val.error() &&
-                                    double_val.value() == element.int64_val()) {
-                                    return std::make_pair(true, true);
-                                }
-                                continue;
-                            }
-                            if (val.value() == element.int64_val()) {
-                                return std::make_pair(true, true);
-                            }
-                            break;
-                        }
-                        case proto::plan::GenericValue::kFloatVal: {
-                            auto val = it.template get<double>();
-                            if (val.error()) {
-                                continue;
-                            }
-                            if (val.value() == element.float_val()) {
-                                return std::make_pair(true, true);
-                            }
-                            break;
-                        }
-                        case proto::plan::GenericValue::kStringVal: {
-                            auto val = it.template get<std::string_view>();
-                            if (val.error()) {
-                                continue;
-                            }
-                            if (val.value() == element.string_val()) {
-                                return std::make_pair(true, true);
-                            }
-                            break;
-                        }
-                        case proto::plan::GenericValue::kArrayVal: {
-                            auto val = it.get_array();
-                            if (val.error()) {
-                                continue;
-                            }
-                            if (CompareTwoJsonArray(val, element.array_val())) {
-                                return std::make_pair(true, true);
-                            }
-                            break;
-                        }
-                        default:
-                            ThrowInfo(DataTypeInvalid,
-                                      "unsupported data type {}",
-                                      element.val_case());
-                    }
+                bool matched = false;
+                VisitMatchingJsonCandidates(it, elements, [&](size_t) {
+                    matched = true;
+                    return true;
+                });
+                if (matched) {
+                    return std::make_pair(true, true);
                 }
             }
             return std::make_pair(true, false);

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -803,6 +803,13 @@ PhyTermFilterExpr::ExecTermJsonFieldInVariable(EvalCtx& context) {
                 return std::make_pair(
                     true,
                     std::floor(dval) == dval && terms->In(ValueType(dval)));
+            } else if constexpr (std::is_same_v<GetType, double>) {
+                auto x_num = data[i].at_numeric(pointer);
+                if (x_num.error()) {
+                    return std::make_pair(false, false);
+                }
+                return std::make_pair(
+                    true, terms->In(ValueType(x_num.value().as_double())));
             } else {
                 auto x = data[i].template at<GetType>(pointer);
                 if (x.error()) {

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -861,10 +861,10 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
     auto op_type = expr_->op_type_;
     auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
 
-// For int64_t GetType, uses at_numeric() (get_number()) to extract any JSON
-// number in a single parse.  Branches on actual type to preserve int64
-// precision; uint64 and double values fall back to double comparison,
-// consistent with the Tantivy index and JSON-stats paths.
+// Numeric GetType uses at_numeric() (get_number()) so unrepresentable JSON
+// numbers stay UNKNOWN.  The int64_t branch preserves integer precision;
+// uint64 and double values fall back to double comparison, consistent with
+// the Tantivy index and JSON-stats paths.
 // - 'cmp' must reference 'value' (auto-typed as int64_t or double).
 // Missing path and type mismatch are UNKNOWN/NULL under JSON 3VL semantics.
 #define UnaryRangeJSONCompare(cmp)                                     \
@@ -885,6 +885,14 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                                  : n.get_double();                     \
                 res[i] = (cmp);                                        \
             }                                                          \
+        } else if constexpr (std::is_same_v<GetType, double>) {        \
+            auto x = data[offset].at_numeric(pointer);                 \
+            if (x.error()) {                                           \
+                res[i] = valid_res[i] = false;                         \
+                break;                                                 \
+            }                                                          \
+            auto value = x.value().as_double();                        \
+            res[i] = (cmp);                                            \
         } else {                                                       \
             auto x = data[offset].template at<GetType>(pointer);       \
             if (x.error()) {                                           \

--- a/internal/core/src/index/JsonFlatIndex.cpp
+++ b/internal/core/src/index/JsonFlatIndex.cpp
@@ -35,6 +35,13 @@ JsonFlatIndex::build_index_for_json(
                 continue;
             }
             auto json = static_cast<const Json*>(data->RawValue(i));
+            // JsonFlatIndex has no per-row coverage bitmap or raw-data merge
+            // path. Keep this all-or-nothing validation until both exist:
+            // replacing an unindexable row with an empty Tantivy document
+            // would make EXISTS false and silently discard indexable sibling
+            // keys from that row.
+            // TODO: persist row coverage and merge uncovered rows from raw JSON
+            // in term/range/EXISTS executors before allowing per-row skips.
             auto exists = path_exists(json->dom_doc(), tokens);
             if (!exists || !json->exist(nested_path_)) {
                 wrapper_->add_json_array_data(nullptr, 0, offset++);

--- a/internal/core/src/index/JsonFlatIndexTest.cpp
+++ b/internal/core/src/index/JsonFlatIndexTest.cpp
@@ -119,6 +119,19 @@ BuildInMemoryJsonFlatIndex(const std::vector<std::string>& json_data) {
     return json_index;
 }
 
+TEST(JsonFlatIndexSafetyTest, RejectsUncoveredRowInsteadOfPublishingPartial) {
+    // serde_json/Tantivy cannot represent 1e400. Until JsonFlatIndex persists
+    // row coverage and query executors merge uncovered rows from raw JSON, the
+    // only safe behavior is to reject the whole build: an empty placeholder
+    // document would lose both /bad existence and the indexable /sibling key.
+    EXPECT_THROW(BuildInMemoryJsonFlatIndex({
+                     R"({"ok": 1})",
+                     R"({"bad": 1e400, "sibling": "must-not-be-lost"})",
+                     R"({"ok": 2})",
+                 }),
+                 std::exception);
+}
+
 class JsonFlatIndexTest : public ::testing::Test {
  protected:
     void

--- a/internal/core/src/index/JsonIndexBuilder.cpp
+++ b/internal/core/src/index/JsonIndexBuilder.cpp
@@ -17,6 +17,61 @@
 
 namespace milvus::index {
 
+namespace {
+
+enum class JsonPathPresence {
+    Missing,
+    Present,
+    PresentButInvalid,
+};
+
+struct JsonPathPresenceResult {
+    JsonPathPresence presence;
+    simdjson::error_code error;
+};
+
+// Probe path presence without materializing a DOM value. In particular,
+// ondemand::value::type() can identify an out-of-range JSON number as a number
+// without converting it to double; the conversion error is handled later as an
+// invalid indexed value while the path remains present for EXISTS.
+JsonPathPresenceResult
+GetJsonPathPresence(const Json& json, const std::string& nested_path) {
+    auto type = json.type(nested_path);
+    auto error = type.error();
+    if (error == simdjson::SUCCESS) {
+        return {json.exist(nested_path) ? JsonPathPresence::Present
+                                        : JsonPathPresence::Missing,
+                simdjson::SUCCESS};
+    }
+
+    // A path through a scalar, an absent object key, or an out-of-range array
+    // element is not present. Numeric parse/conversion failures still describe
+    // a present value; keep it out of the typed value index without marking the
+    // path as non-existent.
+    if (error == simdjson::NO_SUCH_FIELD ||
+        error == simdjson::INDEX_OUT_OF_BOUNDS ||
+        error == simdjson::INCORRECT_TYPE ||
+        error == simdjson::SCALAR_DOCUMENT_AS_VALUE ||
+        error == simdjson::INVALID_JSON_POINTER) {
+        return {JsonPathPresence::Missing, error};
+    }
+    if (error == simdjson::NUMBER_ERROR || error == simdjson::BIGINT_ERROR ||
+        error == simdjson::NUMBER_OUT_OF_RANGE) {
+        return {JsonPathPresence::PresentButInvalid, error};
+    }
+
+    // Preserve the previous all-or-nothing behavior for malformed JSON and
+    // invalid index paths. Treating an unclassifiable row as either present or
+    // absent would publish a semantically incomplete index.
+    AssertInfo(false,
+               "failed to inspect JSON path {}: {}",
+               nested_path,
+               simdjson::error_message(error));
+    return {JsonPathPresence::PresentButInvalid, error};  // unreachable
+}
+
+}  // namespace
+
 template <typename T>
 void
 ProcessJsonFieldData(
@@ -33,7 +88,9 @@ ProcessJsonFieldData(
     using SIMDJSON_T =
         std::conditional_t<std::is_same_v<T, std::string>, std::string_view, T>;
 
-    auto tokens = parse_json_pointer(nested_path);
+    // Preserve the previous up-front validation of the configured pointer, but
+    // do not materialize each row as a DOM document merely to test presence.
+    (void)parse_json_pointer(nested_path);
 
     bool is_array = cast_type.data_type() == JsonCastType::DataType::ARRAY;
 
@@ -49,18 +106,23 @@ ProcessJsonFieldData(
                 continue;
             }
 
-            auto exists = path_exists(json_column->dom_doc(), tokens);
-            if (!exists || !json_column->exist(nested_path)) {
+            auto presence = GetJsonPathPresence(*json_column, nested_path);
+            if (presence.presence == JsonPathPresence::Missing) {
                 error_recorder(
                     *json_column, nested_path, simdjson::NO_SUCH_FIELD);
                 non_exist_adder(offset);
                 data_adder(nullptr, 0, offset++);
                 continue;
             }
+            if (presence.presence == JsonPathPresence::PresentButInvalid) {
+                error_recorder(*json_column, nested_path, presence.error);
+                data_adder(nullptr, 0, offset++);
+                continue;
+            }
 
             values.clear();
             if (is_array) {
-                auto doc = json_column->dom_doc();
+                auto doc = json_column->doc();
                 auto array_res = doc.at_pointer(nested_path).get_array();
                 if (array_res.error() != simdjson::SUCCESS) {
                     error_recorder(
@@ -68,10 +130,16 @@ ProcessJsonFieldData(
                 } else {
                     auto array_values = array_res.value();
                     for (auto value : array_values) {
-                        auto val = value.template get<SIMDJSON_T>();
-
-                        if (val.error() == simdjson::SUCCESS) {
-                            values.push_back(static_cast<T>(val.value()));
+                        if constexpr (std::is_same_v<T, double>) {
+                            auto val = value.get_number();
+                            if (val.error() == simdjson::SUCCESS) {
+                                values.push_back(val.value().as_double());
+                            }
+                        } else {
+                            auto val = value.template get<SIMDJSON_T>();
+                            if (val.error() == simdjson::SUCCESS) {
+                                values.push_back(static_cast<T>(val.value()));
+                            }
                         }
                     }
                 }
@@ -81,6 +149,13 @@ ProcessJsonFieldData(
                         cast_function, *json_column, nested_path);
                     if (res.has_value()) {
                         values.push_back(res.value());
+                    }
+                } else if constexpr (std::is_same_v<T, double>) {
+                    auto res = json_column->at_numeric(nested_path);
+                    if (res.error() != simdjson::SUCCESS) {
+                        error_recorder(*json_column, nested_path, res.error());
+                    } else {
+                        values.push_back(res.value().as_double());
                     }
                 } else {
                     value_result<SIMDJSON_T> res =

--- a/internal/core/src/index/json_stats/JsonKeyStats.cpp
+++ b/internal/core/src/index/json_stats/JsonKeyStats.cpp
@@ -18,6 +18,8 @@
 #include <boost/uuid/uuid_io.hpp>
 
 #include <nlohmann/json.hpp>
+#include <chrono>
+#include <cctype>
 #include "index/json_stats/JsonKeyStats.h"
 #include "index/json_stats/bson_builder.h"
 #include "index/InvertedIndexUtil.h"
@@ -37,6 +39,18 @@
 
 namespace milvus::index {
 
+namespace {
+
+std::string_view
+TrimJsonToken(std::string_view token) {
+    while (!token.empty() &&
+           std::isspace(static_cast<unsigned char>(token.back()))) {
+        token.remove_suffix(1);
+    }
+    return token;
+}
+
+}  // namespace
 JsonKeyStats::JsonKeyStats(const storage::FileManagerContext& ctx,
                            bool is_load,
                            int64_t json_stats_max_shredding_columns,
@@ -131,115 +145,122 @@ JsonKeyStats::AddKeyStatsInfo(const std::vector<std::string>& paths,
     // TODO: update min and max value
 }
 
-void
-JsonKeyStats::TraverseJsonForStats(const char* json,
-                                   jsmntok* tokens,
-                                   int& index,
-                                   std::vector<std::string>& path,
-                                   std::map<JsonKey, KeyStatsInfo>& infos) {
-    jsmntok current = tokens[0];
-    AssertInfo(current.type != JSMN_UNDEFINED,
-               "current token type is undefined for json: {}.",
-               json);
-    if (current.type == JSMN_OBJECT) {
-        if (!path.empty()) {
-            AddKeyStatsInfo(path, JSONType::OBJECT, nullptr, infos);
-        }
-        int j = 1;
-        for (int i = 0; i < current.size; i++) {
-            AssertInfo(tokens[j].type == JSMN_STRING && tokens[j].size != 0,
-                       "current token type is not string for json: {} at "
-                       "type: {}, size: {}, value: {}",
-                       json,
-                       int(tokens[j].type),
-                       tokens[j].size,
-                       std::string(json + tokens[j].start,
-                                   tokens[j].end - tokens[j].start));
-            std::string key(json + tokens[j].start,
-                            tokens[j].end - tokens[j].start);
-            path.push_back(key);
-            j++;
-            int consumed = 0;
-            TraverseJsonForStats(json, tokens + j, consumed, path, infos);
-            path.pop_back();
-            j += consumed;
-        }
-        index = j;
-    } else if (current.type == JSMN_PRIMITIVE) {
-        std::string value(json + current.start, current.end - current.start);
-        auto type = getType(value);
+std::pair<JSONType, JsonStatsValue>
+JsonKeyStats::ParsePrimitiveValue(simdjson::ondemand::value value) {
+    auto type_result = value.type();
+    AssertInfo(type_result.error() == simdjson::SUCCESS,
+               "failed to read json value type: {}",
+               simdjson::error_message(type_result.error()));
 
-        if (type == JSONType::INT64) {
-            AddKeyStatsInfo(path, JSONType::INT64, nullptr, infos);
-        } else if (type == JSONType::FLOAT || type == JSONType::DOUBLE) {
-            AddKeyStatsInfo(path, JSONType::DOUBLE, nullptr, infos);
-        } else if (type == JSONType::BOOL) {
-            AddKeyStatsInfo(path, JSONType::BOOL, nullptr, infos);
-        } else if (type == JSONType::NONE) {
-            AddKeyStatsInfo(path, JSONType::NONE, nullptr, infos);
-        } else {
-            ThrowInfo(ErrorCode::UnexpectedError,
-                      "unsupported json type: {} for build json stats",
-                      type);
-        }
-        index++;
-    } else if (current.type == JSMN_ARRAY) {
-        AddKeyStatsInfo(path, JSONType::ARRAY, nullptr, infos);
-        // skip array parse
-        int count = current.size;
-        int j = 1;
-        while (count > 0) {
-            count--;
-            if (tokens[j].size != 0) {
-                count += tokens[j].size;
+    switch (type_result.value()) {
+        case simdjson::ondemand::json_type::number: {
+            auto raw = TrimJsonToken(value.raw_json_token());
+            JsonStatsValue stats_value{std::string(raw)};
+            // Use the same get_number() contract as raw JSON predicates.  In
+            // particular, get_double() alone accepts integers above uint64
+            // (for example 18446744073709551616), while get_number() rejects
+            // them; indexing such a value as a valid double would make stats
+            // disagree with the raw path.
+            auto number_result = value.get_number();
+            if (number_result.error() != simdjson::SUCCESS) {
+                stats_value.state = JsonStatsValueState::INVALID_NUMBER;
+                return {JSONType::DOUBLE, std::move(stats_value)};
             }
-            j++;
+
+            auto number = number_result.value();
+            if (number.is_int64()) {
+                return {JSONType::INT64, std::move(stats_value)};
+            }
+
+            stats_value.double_value = number.as_double();
+            return {JSONType::DOUBLE, std::move(stats_value)};
         }
-        index = j;
-    } else if (current.type == JSMN_STRING) {
-        Assert(current.size == 0);
-        AddKeyStatsInfo(path, JSONType::STRING, nullptr, infos);
-        index++;
+        case simdjson::ondemand::json_type::boolean: {
+            auto boolean = value.get_bool();
+            AssertInfo(boolean.error() == simdjson::SUCCESS,
+                       "failed to read json boolean: {}",
+                       simdjson::error_message(boolean.error()));
+            return {JSONType::BOOL,
+                    JsonStatsValue{boolean.value() ? "true" : "false"}};
+        }
+        case simdjson::ondemand::json_type::null:
+            return {JSONType::NONE, JsonStatsValue{"null"}};
+        case simdjson::ondemand::json_type::string: {
+            auto string = value.get_string();
+            AssertInfo(string.error() == simdjson::SUCCESS,
+                       "failed to read json string: {}",
+                       simdjson::error_message(string.error()));
+            return {JSONType::STRING,
+                    JsonStatsValue{std::string(string.value())}};
+        }
+        default:
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      "json value is not a primitive type");
     }
 }
 
 void
-JsonKeyStats::CollectSingleJsonStatsInfo(
-    const char* json_str, std::map<JsonKey, KeyStatsInfo>& infos) {
-    jsmn_parser parser;
-    jsmn_init(&parser);
+JsonKeyStats::TraverseJsonForStats(simdjson::ondemand::value value,
+                                   std::vector<std::string>& path,
+                                   std::map<JsonKey, KeyStatsInfo>& infos) {
+    auto type_result = value.type();
+    AssertInfo(type_result.error() == simdjson::SUCCESS,
+               "failed to read json value type: {}",
+               simdjson::error_message(type_result.error()));
 
-    int num_tokens = 0;
-    int token_capacity = 16;
-    std::vector<jsmntok_t> tokens(token_capacity);
-
-    while (1) {
-        int r = jsmn_parse(
-            &parser, json_str, strlen(json_str), tokens.data(), token_capacity);
-        if (r < 0) {
-            if (r == JSMN_ERROR_NOMEM) {
-                // Reallocate tokens array if not enough space
-                token_capacity *= 2;
-                tokens.resize(token_capacity);
-                continue;
-            } else {
-                ThrowInfo(ErrorCode::UnexpectedError,
-                          "Failed to parse Json: {}, error: {}",
-                          json_str,
-                          int(r));
-            }
+    if (type_result.value() == simdjson::ondemand::json_type::object) {
+        if (!path.empty()) {
+            AddKeyStatsInfo(path, JSONType::OBJECT, nullptr, infos);
         }
-        num_tokens = r;
-        break;
-    }
-
-    if (num_tokens == 0) {
+        auto object = value.get_object();
+        AssertInfo(object.error() == simdjson::SUCCESS,
+                   "failed to read json object: {}",
+                   simdjson::error_message(object.error()));
+        for (auto field : object.value()) {
+            auto key = field.unescaped_key();
+            AssertInfo(key.error() == simdjson::SUCCESS,
+                       "failed to read json object key: {}",
+                       simdjson::error_message(key.error()));
+            path.emplace_back(key.value());
+            auto child = field.value();
+            AssertInfo(child.error() == simdjson::SUCCESS,
+                       "failed to read json object value: {}",
+                       simdjson::error_message(child.error()));
+            TraverseJsonForStats(child.value(), path, infos);
+            path.pop_back();
+        }
         return;
     }
 
-    int index = 0;
+    if (type_result.value() == simdjson::ondemand::json_type::array) {
+        auto raw = value.raw_json();
+        AssertInfo(raw.error() == simdjson::SUCCESS,
+                   "failed to read json array: {}",
+                   simdjson::error_message(raw.error()));
+        AddKeyStatsInfo(path, JSONType::ARRAY, nullptr, infos);
+        return;
+    }
+
+    auto type = ParsePrimitiveValue(value).first;
+    AddKeyStatsInfo(path, type, nullptr, infos);
+}
+
+void
+JsonKeyStats::CollectSingleJsonStatsInfo(
+    const milvus::Json& json, std::map<JsonKey, KeyStatsInfo>& infos) {
+    if (json.data().empty()) {
+        return;
+    }
+    auto document = json.doc();
+    AssertInfo(document.error() == simdjson::SUCCESS,
+               "failed to parse json for stats: {}",
+               simdjson::error_message(document.error()));
+    auto root = document.get_value();
+    AssertInfo(root.error() == simdjson::SUCCESS,
+               "failed to read json root for stats: {}",
+               simdjson::error_message(root.error()));
     std::vector<std::string> paths;
-    TraverseJsonForStats(json_str, tokens.data(), index, paths, infos);
+    TraverseJsonForStats(root.value(), paths, infos);
 }
 
 std::map<JsonKey, KeyStatsInfo>
@@ -253,10 +274,9 @@ JsonKeyStats::CollectKeyInfo(const std::vector<FieldDataPtr>& field_datas) {
             if (check_valid && !data->is_valid(i)) {
                 continue;
             }
-            auto json_str = static_cast<const milvus::Json*>(data->RawValue(i))
-                                ->data()
-                                .data();
-            CollectSingleJsonStatsInfo(json_str, infos);
+            const auto& json =
+                *static_cast<const milvus::Json*>(data->RawValue(i));
+            CollectSingleJsonStatsInfo(json, infos);
         }
         num_rows += n;
     }
@@ -369,107 +389,63 @@ JsonKeyStats::ClassifyJsonKeyLayoutType(
 void
 JsonKeyStats::AddKeyStats(const std::vector<std::string>& path,
                           JSONType type,
-                          const std::string& value,
-                          std::map<JsonKey, std::string>& values) {
+                          JsonStatsValue value,
+                          std::map<JsonKey, JsonStatsValue>& values) {
     auto path_str = JsonPointer(path);
     auto key = JsonKey(path_str, type);
-    values[key] = value;
+    values[key] = std::move(value);
 }
 
 void
 JsonKeyStats::TraverseJsonForBuildStats(
-    const char* json,
-    jsmntok* tokens,
-    int& index,
+    simdjson::ondemand::value value,
     std::vector<std::string>& path,
-    std::map<JsonKey, std::string>& values) {
-    jsmntok current = tokens[0];
-    AssertInfo(current.type != JSMN_UNDEFINED,
-               "current token type is undefined for json: {}",
-               json);
-    if (current.type == JSMN_OBJECT) {
-        if (!path.empty() && current.size == 0) {
-            AddKeyStats(
-                path,
-                JSONType::OBJECT,
-                std::string(json + current.start, current.end - current.start),
-                values);
-            index++;
-            return;
-        }
-        int j = 1;
-        for (int i = 0; i < current.size; i++) {
-            AssertInfo(tokens[j].type == JSMN_STRING && tokens[j].size != 0,
-                       "current token type is not string for json: {} at "
-                       "type: {}, size: {}, value: {}",
-                       json,
-                       int(tokens[j].type),
-                       tokens[j].size,
-                       std::string(json + tokens[j].start,
-                                   tokens[j].end - tokens[j].start));
+    std::map<JsonKey, JsonStatsValue>& values) {
+    auto type_result = value.type();
+    AssertInfo(type_result.error() == simdjson::SUCCESS,
+               "failed to read json value type: {}",
+               simdjson::error_message(type_result.error()));
 
-            std::string key(json + tokens[j].start,
-                            tokens[j].end - tokens[j].start);
-            path.push_back(key);
-            j++;
-            int consumed = 0;
-            TraverseJsonForBuildStats(json, tokens + j, consumed, path, values);
+    if (type_result.value() == simdjson::ondemand::json_type::object) {
+        auto object = value.get_object();
+        AssertInfo(object.error() == simdjson::SUCCESS,
+                   "failed to read json object: {}",
+                   simdjson::error_message(object.error()));
+        bool empty = true;
+        for (auto field : object.value()) {
+            empty = false;
+            auto key = field.unescaped_key();
+            AssertInfo(key.error() == simdjson::SUCCESS,
+                       "failed to read json object key: {}",
+                       simdjson::error_message(key.error()));
+            path.emplace_back(key.value());
+            auto child = field.value();
+            AssertInfo(child.error() == simdjson::SUCCESS,
+                       "failed to read json object value: {}",
+                       simdjson::error_message(child.error()));
+            TraverseJsonForBuildStats(child.value(), path, values);
             path.pop_back();
-            j += consumed;
         }
-        index = j;
-    } else if (current.type == JSMN_PRIMITIVE) {
-        std::string value(json + current.start, current.end - current.start);
-        JSONType type;
-        try {
-            type = getType(value);
-        } catch (const std::exception& e) {
-            ThrowInfo(ErrorCode::UnexpectedError,
-                      "failed to get json type for value: {} with error: {}",
-                      value,
-                      e.what());
+        if (empty && !path.empty()) {
+            AddKeyStats(path, JSONType::OBJECT, JsonStatsValue{"{}"}, values);
         }
-
-        if (type == JSONType::INT64) {
-            AddKeyStats(path, JSONType::INT64, value, values);
-        } else if (type == JSONType::FLOAT || type == JSONType::DOUBLE) {
-            AddKeyStats(path, JSONType::DOUBLE, value, values);
-        } else if (type == JSONType::BOOL) {
-            AddKeyStats(path, JSONType::BOOL, value, values);
-        } else if (type == JSONType::NONE) {
-            AddKeyStats(path, JSONType::NONE, value, values);
-        } else {
-            ThrowInfo(ErrorCode::UnexpectedError,
-                      "unsupported json type: {} for build json stats",
-                      type);
-        }
-        index++;
-    } else if (current.type == JSMN_ARRAY) {
-        // Collect array as raw JSON string so it can be shredded into a dedicated column
-        AddKeyStats(
-            path,
-            JSONType::ARRAY,
-            std::string(json + current.start, current.end - current.start),
-            values);
-        // Skip array subtree
-        int count = current.size;
-        int j = 1;
-        while (count > 0) {
-            count--;
-            if (tokens[j].size != 0) {
-                count += tokens[j].size;
-            }
-            j++;
-        }
-        index = j;
-    } else if (current.type == JSMN_STRING) {
-        auto value =
-            std::string(json + current.start, current.end - current.start);
-        auto unescaped = UnescapeJsonString(value);
-        Assert(current.size == 0);
-        AddKeyStats(path, JSONType::STRING, unescaped, values);
-        index++;
+        return;
     }
+
+    if (type_result.value() == simdjson::ondemand::json_type::array) {
+        auto raw = value.raw_json();
+        AssertInfo(raw.error() == simdjson::SUCCESS,
+                   "failed to read json array: {}",
+                   simdjson::error_message(raw.error()));
+        AddKeyStats(path,
+                    JSONType::ARRAY,
+                    JsonStatsValue{std::string(raw.value())},
+                    values);
+        return;
+    }
+
+    auto [type, stats_value] = ParsePrimitiveValue(value);
+    AddKeyStats(path, type, std::move(stats_value), values);
 }
 
 void
@@ -489,65 +465,68 @@ JsonKeyStats::BuildKeyStatsForNullRow() {
 }
 
 void
-JsonKeyStats::BuildKeyStatsForRow(const char* json_str, uint32_t row_id) {
+JsonKeyStats::BuildKeyStatsForRow(const milvus::Json& json, uint32_t row_id) {
     LOG_TRACE("build key stats for row {} with json {} for segment {}",
               row_id,
-              json_str,
+              json.data(),
               segment_id_);
-    jsmn_parser parser;
-    jsmn_init(&parser);
-
-    int num_tokens = 0;
-    int token_capacity = 16;
-    std::vector<jsmntok_t> tokens(token_capacity);
-
-    while (1) {
-        int r = jsmn_parse(
-            &parser, json_str, strlen(json_str), tokens.data(), token_capacity);
-        if (r < 0) {
-            if (r == JSMN_ERROR_NOMEM) {
-                // Reallocate tokens array if not enough space
-                token_capacity *= 2;
-                tokens.resize(token_capacity);
-                continue;
-            } else {
-                ThrowInfo(ErrorCode::UnexpectedError,
-                          "Failed to parse Json: {}, error: {}",
-                          json_str,
-                          int(r));
-            }
-        }
-        num_tokens = r;
-        break;
-    }
-
-    if (num_tokens == 0) {
-        return;
-    }
-
-    int index = 0;
+    auto document = json.doc();
+    AssertInfo(document.error() == simdjson::SUCCESS,
+               "failed to parse json for stats: {}",
+               simdjson::error_message(document.error()));
+    auto root_value = document.get_value();
+    AssertInfo(root_value.error() == simdjson::SUCCESS,
+               "failed to read json root for stats: {}",
+               simdjson::error_message(root_value.error()));
     std::vector<std::string> paths;
-    std::map<JsonKey, std::string> values;
-    TraverseJsonForBuildStats(json_str, tokens.data(), index, paths, values);
+    std::map<JsonKey, JsonStatsValue> values;
+    TraverseJsonForBuildStats(root_value.value(), paths, values);
     DomNode root;
     std::set<JsonKey> hit_keys;
     for (const auto& [key, value] : values) {
         AssertInfo(key_types_.find(key) != key_types_.end(),
                    "key {} not found in key types",
                    key.key_);
-        if (key_types_[key] == JsonKeyLayoutType::SHARED) {
-            auto path_vec = ParseJsonPointerPath(key.key_);
-            BsonBuilder::AppendToDom(root, path_vec, value, key.type_);
-        } else {
-            if (key.type_ == JSONType::ARRAY) {
-                auto bson_bytes = BuildBsonArrayBytesFromJsonString(value);
+        auto path_vec = ParseJsonPointerPath(key.key_);
+        if (value.IsInvalidNumber()) {
+            BsonBuilder::AppendUndefinedToDom(root, path_vec);
+            if (key_types_[key] != JsonKeyLayoutType::SHARED) {
+                parquet_writer_->AppendNull(key.ToColumnName());
+            }
+        } else if (key.type_ == JSONType::ARRAY) {
+            auto bson_bytes =
+                BuildBsonArrayBytesFromJsonString(value.raw_value);
+            if (key_types_[key] == JsonKeyLayoutType::SHARED) {
+                BsonBuilder::AppendArrayToDom(
+                    root, path_vec, std::move(bson_bytes));
+            } else {
                 parquet_writer_->AppendValue(
                     key.ToColumnName(),
                     std::string(
                         reinterpret_cast<const char*>(bson_bytes.data()),
                         bson_bytes.size()));
+            }
+        } else if (key_types_[key] == JsonKeyLayoutType::SHARED) {
+            if (key.type_ == JSONType::DOUBLE) {
+                AssertInfo(value.double_value.has_value(),
+                           "parsed double is missing for key {}",
+                           key.key_);
+                BsonBuilder::AppendDoubleToDom(
+                    root, path_vec, value.double_value.value());
             } else {
-                parquet_writer_->AppendValue(key.ToColumnName(), value);
+                BsonBuilder::AppendToDom(
+                    root, path_vec, value.raw_value, key.type_);
+            }
+        } else {
+            if (key.type_ == JSONType::DOUBLE) {
+                AssertInfo(value.double_value.has_value(),
+                           "parsed double is missing for key {}",
+                           key.key_);
+                parquet_writer_->AppendDouble(key.ToColumnName(),
+                                              value.double_value.value());
+            } else {
+                parquet_writer_->AppendValue(key.ToColumnName(),
+                                             value.raw_value);
             }
         }
         hit_keys.insert(key);
@@ -592,17 +571,15 @@ JsonKeyStats::BuildKeyStats(const std::vector<FieldDataPtr>& field_datas) {
             if (check_valid && !data->is_valid(i)) {
                 BuildKeyStatsForNullRow();
             } else {
-                auto json_str =
-                    static_cast<const milvus::Json*>(data->RawValue(i))
-                        ->data()
-                        .data();
+                const auto& json =
+                    *static_cast<const milvus::Json*>(data->RawValue(i));
 
                 // some situations, such as empty json string,
                 // should be handled as null row
-                if (strlen(json_str) == 0) {
+                if (json.data().empty()) {
                     BuildKeyStatsForNullRow();
                 } else {
-                    BuildKeyStatsForRow(json_str, row_id);
+                    BuildKeyStatsForRow(json, row_id);
                 }
             }
             row_id++;

--- a/internal/core/src/index/json_stats/JsonKeyStats.h
+++ b/internal/core/src/index/json_stats/JsonKeyStats.h
@@ -16,16 +16,16 @@
 
 #pragma once
 
+#include <map>
+#include <optional>
+#include <string>
 // Forward declaration of test accessor in global namespace for friend declaration
 class TraverseJsonForBuildStatsAccessor;
 class CollectSingleJsonStatsInfoAccessor;
 
-#include <charconv>
-#include <string>
 #include <boost/filesystem.hpp>
 
 #include "index/InvertedIndexTantivy.h"
-#include "common/jsmn.h"
 #include "mmap/ChunkedColumnInterface.h"
 #include "arrow/api.h"
 #include "index/json_stats/utils.h"
@@ -35,7 +35,25 @@ class CollectSingleJsonStatsInfoAccessor;
 #include "common/bson_view.h"
 #include "index/SkipIndex.h"
 
+namespace milvus {
+class Json;
+}
+
 namespace milvus::index {
+
+enum class JsonStatsValueState { VALID, INVALID_NUMBER };
+
+struct JsonStatsValue {
+    std::string raw_value;
+    std::optional<double> double_value;
+    JsonStatsValueState state{JsonStatsValueState::VALID};
+
+    bool
+    IsInvalidNumber() const {
+        return state == JsonStatsValueState::INVALID_NUMBER;
+    }
+};
+
 class JsonKeyStats : public ScalarIndex<std::string> {
  public:
     explicit JsonKeyStats(
@@ -382,7 +400,7 @@ class JsonKeyStats : public ScalarIndex<std::string> {
 
  private:
     void
-    CollectSingleJsonStatsInfo(const char* json_str,
+    CollectSingleJsonStatsInfo(const milvus::Json& json,
                                std::map<JsonKey, KeyStatsInfo>& infos);
 
     std::string
@@ -398,9 +416,7 @@ class JsonKeyStats : public ScalarIndex<std::string> {
     CollectKeyInfo(const std::vector<FieldDataPtr>& field_datas);
 
     void
-    TraverseJsonForStats(const char* json,
-                         jsmntok* tokens,
-                         int& index,
+    TraverseJsonForStats(simdjson::ondemand::value value,
                          std::vector<std::string>& path,
                          std::map<JsonKey, KeyStatsInfo>& infos);
 
@@ -431,7 +447,7 @@ class JsonKeyStats : public ScalarIndex<std::string> {
     BuildKeyStats(const std::vector<FieldDataPtr>& field_datas);
 
     void
-    BuildKeyStatsForRow(const char* json_str, uint32_t row_id);
+    BuildKeyStatsForRow(const milvus::Json& json, uint32_t row_id);
 
     void
     BuildKeyStatsForNullRow();
@@ -454,125 +470,16 @@ class JsonKeyStats : public ScalarIndex<std::string> {
     void
     AddKeyStats(const std::vector<std::string>& path,
                 JSONType type,
-                const std::string& value,
-                std::map<JsonKey, std::string>& values);
+                JsonStatsValue value,
+                std::map<JsonKey, JsonStatsValue>& values);
 
     void
-    TraverseJsonForBuildStats(const char* json,
-                              jsmntok* tokens,
-                              int& index,
+    TraverseJsonForBuildStats(simdjson::ondemand::value value,
                               std::vector<std::string>& path,
-                              std::map<JsonKey, std::string>& values);
+                              std::map<JsonKey, JsonStatsValue>& values);
 
-    bool
-    IsBoolean(const std::string& str) {
-        return str == "true" || str == "false";
-    }
-
-    bool
-    IsInt8(const std::string& str) {
-        std::istringstream iss(str);
-        int8_t num;
-        iss >> num;
-
-        return !iss.fail() && iss.eof() &&
-               num >= std::numeric_limits<int8_t>::min() &&
-               num <= std::numeric_limits<int8_t>::max();
-    }
-
-    bool
-    IsInt16(const std::string& str) {
-        std::istringstream iss(str);
-        int16_t num;
-        iss >> num;
-
-        return !iss.fail() && iss.eof() &&
-               num >= std::numeric_limits<int16_t>::min() &&
-               num <= std::numeric_limits<int16_t>::max();
-    }
-
-    bool
-    IsInt32(const std::string& str) {
-        std::istringstream iss(str);
-        int64_t num;
-        iss >> num;
-
-        return !iss.fail() && iss.eof() &&
-               num >= std::numeric_limits<int32_t>::min() &&
-               num <= std::numeric_limits<int32_t>::max();
-    }
-
-    // JSON number sniffing helpers.
-    //
-    // These used to be implemented with std::stof/std::stod plus catch(...),
-    // but libstdc++ throws std::out_of_range for ANY ERANGE result of
-    // strtod/strtof, including underflow into the subnormal range (e.g.
-    // -1.48e-309, a perfectly valid double). Valid JSON numbers were then
-    // misclassified as UNKNOWN and poisoned the whole json key stats build.
-    // std::from_chars never throws and reports out-of-range values through
-    // std::errc::result_out_of_range instead.
-
-    // Strict: only a value fully representable in int64_t counts; anything
-    // else must fall through to the float/double checks.
-    bool
-    IsInt64(const std::string& str) {
-        int64_t num;
-        auto [ptr, ec] =
-            std::from_chars(str.data(), str.data() + str.size(), num);
-        return ptr == str.data() + str.size() && ec == std::errc();
-    }
-
-    // Strict: values outside float's range fall through to the DOUBLE check
-    // so they keep full double precision in the shredding column type.
-    bool
-    IsFloat(const std::string& str) {
-        float num;
-        auto [ptr, ec] =
-            std::from_chars(str.data(), str.data() + str.size(), num);
-        return ptr == str.data() + str.size() && ec == std::errc();
-    }
-
-    // Lenient on range: a well-formed JSON number whose magnitude overflows
-    // or underflows double (subnormals such as 1e-309, or 1e400) is still a
-    // valid number and must classify as DOUBLE instead of UNKNOWN.
-    bool
-    IsDouble(const std::string& str) {
-        double num;
-        auto [ptr, ec] =
-            std::from_chars(str.data(), str.data() + str.size(), num);
-        return ptr == str.data() + str.size() &&
-               (ec == std::errc() || ec == std::errc::result_out_of_range);
-    }
-
-    bool
-    IsNull(const std::string& str) {
-        return str == "null";
-    }
-
-    JSONType
-    getType(const std::string& str) {
-        if (IsBoolean(str)) {
-            return JSONType::BOOL;
-            // TODO: add int8, int16, int32 support
-            // now we only support int64 for build performance
-            // } else if (IsInt8(str)) {
-            //     return JSONType::INT8;
-            // } else if (IsInt16(str)) {
-            //     return JSONType::INT16;
-            // } else if (IsInt32(str)) {
-            //     return JSONType::INT32;
-        } else if (IsInt64(str)) {
-            return JSONType::INT64;
-        } else if (IsFloat(str)) {
-            return JSONType::FLOAT;
-        } else if (IsDouble(str)) {
-            return JSONType::DOUBLE;
-        } else if (IsNull(str)) {
-            return JSONType::NONE;
-        }
-        LOG_DEBUG("unknown json type for string: {}", str);
-        return JSONType::UNKNOWN;
-    }
+    std::pair<JSONType, JsonStatsValue>
+    ParsePrimitiveValue(simdjson::ondemand::value value);
 
     void
     LoadShreddingData(const std::vector<std::string>& index_files,
@@ -611,7 +518,6 @@ class JsonKeyStats : public ScalarIndex<std::string> {
     int64_t max_shredding_columns_;
     double shredding_ratio_threshold_;
     int64_t write_batch_size_;
-
     std::map<JsonKey, JsonKeyLayoutType> key_types_;
     std::set<JsonKey> shared_keys_;
     std::set<JsonKey> column_keys_;

--- a/internal/core/src/index/json_stats/JsonKeyStats.h
+++ b/internal/core/src/index/json_stats/JsonKeyStats.h
@@ -20,6 +20,7 @@
 class TraverseJsonForBuildStatsAccessor;
 class CollectSingleJsonStatsInfoAccessor;
 
+#include <charconv>
 #include <string>
 #include <boost/filesystem.hpp>
 
@@ -501,33 +502,46 @@ class JsonKeyStats : public ScalarIndex<std::string> {
                num <= std::numeric_limits<int32_t>::max();
     }
 
+    // JSON number sniffing helpers.
+    //
+    // These used to be implemented with std::stof/std::stod plus catch(...),
+    // but libstdc++ throws std::out_of_range for ANY ERANGE result of
+    // strtod/strtof, including underflow into the subnormal range (e.g.
+    // -1.48e-309, a perfectly valid double). Valid JSON numbers were then
+    // misclassified as UNKNOWN and poisoned the whole json key stats build.
+    // std::from_chars never throws and reports out-of-range values through
+    // std::errc::result_out_of_range instead.
+
+    // Strict: only a value fully representable in int64_t counts; anything
+    // else must fall through to the float/double checks.
     bool
     IsInt64(const std::string& str) {
-        std::istringstream iss(str);
         int64_t num;
-        iss >> num;
-
-        return !iss.fail() && iss.eof();
+        auto [ptr, ec] =
+            std::from_chars(str.data(), str.data() + str.size(), num);
+        return ptr == str.data() + str.size() && ec == std::errc();
     }
 
+    // Strict: values outside float's range fall through to the DOUBLE check
+    // so they keep full double precision in the shredding column type.
     bool
     IsFloat(const std::string& str) {
-        try {
-            float d = std::stof(str);
-            return true;
-        } catch (...) {
-            return false;
-        }
+        float num;
+        auto [ptr, ec] =
+            std::from_chars(str.data(), str.data() + str.size(), num);
+        return ptr == str.data() + str.size() && ec == std::errc();
     }
 
+    // Lenient on range: a well-formed JSON number whose magnitude overflows
+    // or underflows double (subnormals such as 1e-309, or 1e400) is still a
+    // valid number and must classify as DOUBLE instead of UNKNOWN.
     bool
     IsDouble(const std::string& str) {
-        try {
-            double d = std::stod(str);
-            return true;
-        } catch (...) {
-            return false;
-        }
+        double num;
+        auto [ptr, ec] =
+            std::from_chars(str.data(), str.data() + str.size(), num);
+        return ptr == str.data() + str.size() &&
+               (ec == std::errc() || ec == std::errc::result_out_of_range);
     }
 
     bool

--- a/internal/core/src/index/json_stats/bson_builder.cpp
+++ b/internal/core/src/index/json_stats/bson_builder.cpp
@@ -30,78 +30,208 @@ namespace {
 using bsoncxx::builder::basic::kvp;
 
 void
-AppendDomElementToBsonArray(simdjson::dom::element elem,
-                            bsoncxx::builder::basic::array& out);
+AppendJsonValueToBsonArray(simdjson::ondemand::value value,
+                           bsoncxx::builder::basic::array& out);
 
 void
-AppendDomElementToBsonDocument(simdjson::dom::element elem,
-                               std::string_view key,
-                               bsoncxx::builder::basic::document& out) {
-    using simdjson::dom::element_type;
+AppendNodeToDom(DomNode& root,
+                const std::vector<std::string>& keys,
+                DomNode value_node) {
+    DomNode* current = &root;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        const std::string& key = keys[i];
+        if (i == keys.size() - 1) {
+            current->document_children[key] = std::move(value_node);
+        } else {
+            auto& child = current->document_children[key];
+            if (child.type != DomNode::Type::DOCUMENT) {
+                child = DomNode(DomNode::Type::DOCUMENT);
+            }
+            current = &child;
+        }
+    }
+}
 
-    auto type = elem.type();
-    if (type == element_type::STRING) {
-        std::string s(std::string_view(elem.get_string()));
-        out.append(kvp(std::string(key), std::move(s)));
-    } else if (type == element_type::INT64) {
-        out.append(kvp(std::string(key), int64_t(elem.get_int64())));
-    } else if (type == element_type::UINT64) {
-        out.append(kvp(std::string(key), int64_t(elem.get_uint64())));
-    } else if (type == element_type::DOUBLE) {
-        out.append(kvp(std::string(key), elem.get_double()));
-    } else if (type == element_type::BOOL) {
-        out.append(kvp(std::string(key), bool(elem.get_bool())));
-    } else if (type == element_type::NULL_VALUE) {
-        out.append(kvp(std::string(key), bsoncxx::types::b_null{}));
-    } else if (type == element_type::OBJECT) {
-        bsoncxx::builder::basic::document sub;
-        for (auto [k, v] : elem.get_object()) {
-            AppendDomElementToBsonDocument(v, k, sub);
+double
+ParseJsonDouble(const std::string& value) {
+    simdjson::padded_string padded(value.data(), value.size());
+    simdjson::ondemand::parser parser;
+    auto document = parser.iterate(padded);
+    AssertInfo(document.error() == simdjson::SUCCESS,
+               "invalid json number {}: {}",
+               value,
+               simdjson::error_message(document.error()));
+    auto number = document.get_number();
+    AssertInfo(number.error() == simdjson::SUCCESS,
+               "invalid json number {}: {}",
+               value,
+               simdjson::error_message(number.error()));
+    return number.value().as_double();
+}
+
+void
+AppendJsonValueToBson(simdjson::ondemand::value value,
+                      std::string_view key,
+                      bsoncxx::builder::basic::document& out) {
+    auto type = value.type();
+    AssertInfo(type.error() == simdjson::SUCCESS,
+               "failed to read json array element type: {}",
+               simdjson::error_message(type.error()));
+
+    switch (type.value()) {
+        case simdjson::ondemand::json_type::string: {
+            auto string = value.get_string();
+            AssertInfo(string.error() == simdjson::SUCCESS,
+                       "failed to read json string: {}",
+                       simdjson::error_message(string.error()));
+            out.append(kvp(std::string(key), std::string(string.value())));
+            break;
         }
-        out.append(kvp(std::string(key), sub.extract()));
-    } else if (type == element_type::ARRAY) {
-        bsoncxx::builder::basic::array subarr;
-        for (simdjson::dom::element v : elem.get_array()) {
-            AppendDomElementToBsonArray(v, subarr);
+        case simdjson::ondemand::json_type::number: {
+            auto number_result = value.get_number();
+            if (number_result.error() != simdjson::SUCCESS) {
+                out.append(
+                    kvp(std::string(key), bsoncxx::types::b_undefined{}));
+                break;
+            }
+            const auto& number = number_result.value();
+            if (number.is_int64()) {
+                out.append(kvp(std::string(key), number.get_int64()));
+            } else {
+                out.append(kvp(std::string(key), number.as_double()));
+            }
+            break;
         }
-        out.append(kvp(std::string(key), subarr.extract()));
-    } else {
-        out.append(kvp(std::string(key), bsoncxx::types::b_null{}));
+        case simdjson::ondemand::json_type::boolean: {
+            auto boolean = value.get_bool();
+            AssertInfo(boolean.error() == simdjson::SUCCESS,
+                       "failed to read json boolean: {}",
+                       simdjson::error_message(boolean.error()));
+            out.append(kvp(std::string(key), boolean.value()));
+            break;
+        }
+        case simdjson::ondemand::json_type::null:
+            out.append(kvp(std::string(key), bsoncxx::types::b_null{}));
+            break;
+        case simdjson::ondemand::json_type::object: {
+            auto object = value.get_object();
+            AssertInfo(object.error() == simdjson::SUCCESS,
+                       "failed to read nested json object: {}",
+                       simdjson::error_message(object.error()));
+            bsoncxx::builder::basic::document child;
+            for (auto field : object.value()) {
+                auto field_key = field.unescaped_key();
+                AssertInfo(field_key.error() == simdjson::SUCCESS,
+                           "failed to read nested json object key: {}",
+                           simdjson::error_message(field_key.error()));
+                auto child_value = field.value();
+                AssertInfo(child_value.error() == simdjson::SUCCESS,
+                           "failed to read nested json object value: {}",
+                           simdjson::error_message(child_value.error()));
+                AppendJsonValueToBson(
+                    child_value.value(), field_key.value(), child);
+            }
+            out.append(kvp(std::string(key), child.extract()));
+            break;
+        }
+        case simdjson::ondemand::json_type::array: {
+            auto array = value.get_array();
+            AssertInfo(array.error() == simdjson::SUCCESS,
+                       "failed to read nested json array: {}",
+                       simdjson::error_message(array.error()));
+            bsoncxx::builder::basic::array child;
+            for (auto child_value : array.value()) {
+                AssertInfo(child_value.error() == simdjson::SUCCESS,
+                           "failed to read nested json array value: {}",
+                           simdjson::error_message(child_value.error()));
+                AppendJsonValueToBsonArray(child_value.value(), child);
+            }
+            out.append(kvp(std::string(key), child.extract()));
+            break;
+        }
+        default:
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      "unsupported json value type");
     }
 }
 
 void
-AppendDomElementToBsonArray(simdjson::dom::element elem,
-                            bsoncxx::builder::basic::array& out) {
-    using simdjson::dom::element_type;
+AppendJsonValueToBsonArray(simdjson::ondemand::value value,
+                           bsoncxx::builder::basic::array& out) {
+    auto type = value.type();
+    AssertInfo(type.error() == simdjson::SUCCESS,
+               "failed to read json array element type: {}",
+               simdjson::error_message(type.error()));
 
-    auto type = elem.type();
-    if (type == element_type::STRING) {
-        out.append(std::string(std::string_view(elem.get_string())));
-    } else if (type == element_type::INT64) {
-        out.append(int64_t(elem.get_int64()));
-    } else if (type == element_type::UINT64) {
-        out.append(int64_t(elem.get_uint64()));
-    } else if (type == element_type::DOUBLE) {
-        out.append(elem.get_double());
-    } else if (type == element_type::BOOL) {
-        out.append(bool(elem.get_bool()));
-    } else if (type == element_type::NULL_VALUE) {
-        out.append(bsoncxx::types::b_null{});
-    } else if (type == element_type::OBJECT) {
-        bsoncxx::builder::basic::document sub;
-        for (auto [k, v] : elem.get_object()) {
-            AppendDomElementToBsonDocument(v, k, sub);
+    switch (type.value()) {
+        case simdjson::ondemand::json_type::string: {
+            auto string = value.get_string();
+            AssertInfo(string.error() == simdjson::SUCCESS,
+                       "failed to read json string: {}",
+                       simdjson::error_message(string.error()));
+            out.append(std::string(string.value()));
+            break;
         }
-        out.append(sub.extract());
-    } else if (type == element_type::ARRAY) {
-        bsoncxx::builder::basic::array subarr;
-        for (simdjson::dom::element v : elem.get_array()) {
-            AppendDomElementToBsonArray(v, subarr);
+        case simdjson::ondemand::json_type::number: {
+            auto number = value.get_number();
+            if (number.error() != simdjson::SUCCESS) {
+                out.append(bsoncxx::types::b_undefined{});
+                break;
+            }
+            if (number.value().is_int64()) {
+                out.append(number.value().get_int64());
+            } else {
+                out.append(number.value().as_double());
+            }
+            break;
         }
-        out.append(subarr.extract());
-    } else {
-        out.append(bsoncxx::types::b_null{});
+        case simdjson::ondemand::json_type::boolean: {
+            auto boolean = value.get_bool();
+            AssertInfo(boolean.error() == simdjson::SUCCESS,
+                       "failed to read json boolean: {}",
+                       simdjson::error_message(boolean.error()));
+            out.append(boolean.value());
+            break;
+        }
+        case simdjson::ondemand::json_type::null:
+            out.append(bsoncxx::types::b_null{});
+            break;
+        case simdjson::ondemand::json_type::object: {
+            auto object = value.get_object();
+            AssertInfo(object.error() == simdjson::SUCCESS,
+                       "failed to read nested json object: {}",
+                       simdjson::error_message(object.error()));
+            bsoncxx::builder::basic::document child;
+            for (auto field : object.value()) {
+                auto field_key = field.unescaped_key();
+                auto child_value = field.value();
+                AssertInfo(field_key.error() == simdjson::SUCCESS &&
+                               child_value.error() == simdjson::SUCCESS,
+                           "failed to read nested json object");
+                AppendJsonValueToBson(
+                    child_value.value(), field_key.value(), child);
+            }
+            out.append(child.extract());
+            break;
+        }
+        case simdjson::ondemand::json_type::array: {
+            auto array = value.get_array();
+            AssertInfo(array.error() == simdjson::SUCCESS,
+                       "failed to read nested json array: {}",
+                       simdjson::error_message(array.error()));
+            bsoncxx::builder::basic::array child;
+            for (auto child_value : array.value()) {
+                AssertInfo(child_value.error() == simdjson::SUCCESS,
+                           "failed to read nested json array value: {}",
+                           simdjson::error_message(child_value.error()));
+                AppendJsonValueToBsonArray(child_value.value(), child);
+            }
+            out.append(child.extract());
+            break;
+        }
+        default:
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      "unsupported json array element type");
     }
 }
 }  // namespace
@@ -109,17 +239,23 @@ AppendDomElementToBsonArray(simdjson::dom::element elem,
 // Parse a JSON array string with simdjson and build an owning BSON array value
 bsoncxx::array::value
 BuildBsonArrayFromJsonString(const std::string& json_array) {
-    simdjson::dom::parser parser;
-    simdjson::dom::element root = parser.parse(json_array);
-    if (root.type() != simdjson::dom::element_type::ARRAY) {
-        ThrowInfo(ErrorCode::UnexpectedError,
-                  "input is not a JSON array: {}",
-                  json_array);
-    }
+    simdjson::padded_string padded(json_array.data(), json_array.size());
+    simdjson::ondemand::parser parser;
+    auto document = parser.iterate(padded);
+    AssertInfo(document.error() == simdjson::SUCCESS,
+               "failed to parse json array: {}",
+               simdjson::error_message(document.error()));
+    auto root = document.get_array();
+    AssertInfo(root.error() == simdjson::SUCCESS,
+               "input is not a json array: {}",
+               simdjson::error_message(root.error()));
 
     bsoncxx::builder::basic::array out;
-    for (simdjson::dom::element elem : root.get_array()) {
-        AppendDomElementToBsonArray(elem, out);
+    for (auto element : root.value()) {
+        AssertInfo(element.error() == simdjson::SUCCESS,
+                   "failed to read json array element: {}",
+                   simdjson::error_message(element.error()));
+        AppendJsonValueToBsonArray(element.value(), out);
     }
     return out.extract();
 }
@@ -140,25 +276,27 @@ BsonBuilder::AppendToDom(DomNode& root,
               Join(keys, "."),
               value,
               ToString(type));
-    DomNode* current = &root;
-    for (size_t i = 0; i < keys.size(); ++i) {
-        const std::string& key = keys[i];
-        if (i == keys.size() - 1) {
-            current->document_children[key] = CreateValueNode(value, type);
-        } else {
-            auto& children = current->document_children;
-            auto it = children.find(key);
-            if (it != children.end()) {
-                if (it->second.type != DomNode::Type::DOCUMENT) {
-                    it->second = DomNode(DomNode::Type::DOCUMENT);
-                }
-                current = &it->second;
-            } else {
-                children[key] = DomNode(DomNode::Type::DOCUMENT);
-                current = &children[key];
-            }
-        }
-    }
+    AppendNodeToDom(root, keys, CreateValueNode(value, type));
+}
+
+void
+BsonBuilder::AppendDoubleToDom(DomNode& root,
+                               const std::vector<std::string>& keys,
+                               double value) {
+    AppendNodeToDom(root, keys, CreateDoubleValueNode(value));
+}
+
+void
+BsonBuilder::AppendUndefinedToDom(DomNode& root,
+                                  const std::vector<std::string>& keys) {
+    AppendNodeToDom(root, keys, CreateUndefinedValueNode());
+}
+
+void
+BsonBuilder::AppendArrayToDom(DomNode& root,
+                              const std::vector<std::string>& keys,
+                              std::vector<uint8_t> array_bytes) {
+    AppendNodeToDom(root, keys, CreateArrayValueNode(std::move(array_bytes)));
 }
 
 DomNode
@@ -180,15 +318,7 @@ BsonBuilder::CreateValueNode(const std::string& value, JSONType type) {
             return DomNode(bsoncxx::types::b_int64{l});
         }
         case JSONType::DOUBLE: {
-            // strtod instead of std::stod: stod throws std::out_of_range for
-            // subnormal doubles (e.g. -1.48e-309) because they trip the ERANGE
-            // underflow flag, while strtod simply returns the denormal value.
-            char* end = nullptr;
-            double d = std::strtod(value.c_str(), &end);
-            AssertInfo(end == value.c_str() + value.size(),
-                       "invalid double value: {}",
-                       value);
-            return DomNode(bsoncxx::types::b_double{d});
+            return CreateDoubleValueNode(ParseJsonDouble(value));
         }
         case JSONType::STRING: {
             return DomNode(bsoncxx::types::b_string{value});
@@ -221,6 +351,22 @@ BsonBuilder::CreateValueNode(const std::string& value, JSONType type) {
         default:
             ThrowInfo(ErrorCode::Unsupported, "Unsupported JSON type {}", type);
     }
+}
+
+DomNode
+BsonBuilder::CreateDoubleValueNode(double value) {
+    return DomNode(bsoncxx::types::b_double{value});
+}
+
+DomNode
+BsonBuilder::CreateUndefinedValueNode() {
+    return DomNode(bsoncxx::types::b_undefined{});
+}
+
+DomNode
+BsonBuilder::CreateArrayValueNode(std::vector<uint8_t> array_bytes) {
+    bsoncxx::array::view view(array_bytes.data(), array_bytes.size());
+    return DomNode(bsoncxx::types::b_array{view});
 }
 
 void
@@ -323,6 +469,9 @@ BsonBuilder::ExtractOffsetsRecursive(
                 break;
             }
             case bsoncxx::type::k_null: {
+                break;
+            }
+            case bsoncxx::type::k_undefined: {
                 break;
             }
             default: {

--- a/internal/core/src/index/json_stats/bson_builder.cpp
+++ b/internal/core/src/index/json_stats/bson_builder.cpp
@@ -14,12 +14,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdlib>
 #include <iostream>
 #include <vector>
 #include <string>
 #include <map>
 
 #include "index/json_stats/bson_builder.h"
+#include "common/EasyAssert.h"
 
 namespace milvus::index {
 
@@ -178,7 +180,14 @@ BsonBuilder::CreateValueNode(const std::string& value, JSONType type) {
             return DomNode(bsoncxx::types::b_int64{l});
         }
         case JSONType::DOUBLE: {
-            double d = std::stod(value);
+            // strtod instead of std::stod: stod throws std::out_of_range for
+            // subnormal doubles (e.g. -1.48e-309) because they trip the ERANGE
+            // underflow flag, while strtod simply returns the denormal value.
+            char* end = nullptr;
+            double d = std::strtod(value.c_str(), &end);
+            AssertInfo(end == value.c_str() + value.size(),
+                       "invalid double value: {}",
+                       value);
             return DomNode(bsoncxx::types::b_double{d});
         }
         case JSONType::STRING: {

--- a/internal/core/src/index/json_stats/bson_builder.h
+++ b/internal/core/src/index/json_stats/bson_builder.h
@@ -61,8 +61,30 @@ class BsonBuilder {
                 const std::string& value,
                 const JSONType& type);
 
+    static void
+    AppendDoubleToDom(DomNode& root,
+                      const std::vector<std::string>& keys,
+                      double value);
+
+    static void
+    AppendUndefinedToDom(DomNode& root, const std::vector<std::string>& keys);
+
+    static void
+    AppendArrayToDom(DomNode& root,
+                     const std::vector<std::string>& keys,
+                     std::vector<uint8_t> array_bytes);
+
     static DomNode
     CreateValueNode(const std::string& value, JSONType type);
+
+    static DomNode
+    CreateDoubleValueNode(double value);
+
+    static DomNode
+    CreateUndefinedValueNode();
+
+    static DomNode
+    CreateArrayValueNode(std::vector<uint8_t> array_bytes);
 
     static void
     ConvertDomToBson(const DomNode& node,

--- a/internal/core/src/index/json_stats/parquet_writer.cpp
+++ b/internal/core/src/index/json_stats/parquet_writer.cpp
@@ -193,6 +193,26 @@ JsonStatsParquetWriter::AppendValue(const std::string& key,
 }
 
 void
+JsonStatsParquetWriter::AppendNull(const std::string& key) {
+    auto it = builders_map_.find(key);
+    AssertInfo(it != builders_map_.end(), "builder for key {} not found", key);
+    auto status = it->second->AppendNull();
+    AssertInfo(status.ok(), "failed to append null for key {}", key);
+}
+
+void
+JsonStatsParquetWriter::AppendDouble(const std::string& key, double value) {
+    auto it = builders_map_.find(key);
+    AssertInfo(it != builders_map_.end(), "builder for key {} not found", key);
+    AssertInfo(it->second->type()->id() == arrow::Type::DOUBLE,
+               "builder for key {} is not double",
+               key);
+    auto builder = std::static_pointer_cast<arrow::DoubleBuilder>(it->second);
+    auto status = builder->Append(value);
+    AssertInfo(status.ok(), "failed to append double for key {}", key);
+}
+
+void
 JsonStatsParquetWriter::AppendRow(
     const std::map<std::string, std::string>& row_data) {
     for (const auto& [key, value] : row_data) {

--- a/internal/core/src/index/json_stats/parquet_writer.h
+++ b/internal/core/src/index/json_stats/parquet_writer.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdlib>
 #include <memory>
 #include <string>
 #include <vector>
@@ -56,12 +57,25 @@ ConvertValue<int64_t>(const std::string& value) {
 template <>
 inline float
 ConvertValue<float>(const std::string& value) {
-    return std::stof(value);
+    // strtof never throws: on ERANGE (overflow / subnormal underflow) it
+    // returns the clamped value instead, unlike std::stof which throws
+    // std::out_of_range and poisoned the json stats build.
+    char* end = nullptr;
+    float v = std::strtof(value.c_str(), &end);
+    AssertInfo(end == value.c_str() + value.size(),
+               "invalid float value: {}",
+               value);
+    return v;
 }
 template <>
 inline double
 ConvertValue<double>(const std::string& value) {
-    return std::stod(value);
+    char* end = nullptr;
+    double v = std::strtod(value.c_str(), &end);
+    AssertInfo(end == value.c_str() + value.size(),
+               "invalid double value: {}",
+               value);
+    return v;
 }
 template <>
 inline bool

--- a/internal/core/src/index/json_stats/parquet_writer.h
+++ b/internal/core/src/index/json_stats/parquet_writer.h
@@ -27,12 +27,31 @@
 #include "index/json_stats/utils.h"
 #include "milvus-storage/packed/writer.h"
 #include "milvus-storage/common/config.h"
+#include "parquet/properties.h"
+#include "simdjson.h"
 
 namespace milvus::index {
 
 template <typename T>
 inline T
 ConvertValue(const std::string& value);
+
+inline double
+ParseJsonDoubleValue(const std::string& value) {
+    simdjson::padded_string padded(value.data(), value.size());
+    simdjson::ondemand::parser parser;
+    auto document = parser.iterate(padded);
+    AssertInfo(document.error() == simdjson::SUCCESS,
+               "invalid json number {}: {}",
+               value,
+               simdjson::error_message(document.error()));
+    auto number = document.get_number();
+    AssertInfo(number.error() == simdjson::SUCCESS,
+               "invalid json number {}: {}",
+               value,
+               simdjson::error_message(number.error()));
+    return number.value().as_double();
+}
 
 template <>
 inline int8_t
@@ -57,25 +76,12 @@ ConvertValue<int64_t>(const std::string& value) {
 template <>
 inline float
 ConvertValue<float>(const std::string& value) {
-    // strtof never throws: on ERANGE (overflow / subnormal underflow) it
-    // returns the clamped value instead, unlike std::stof which throws
-    // std::out_of_range and poisoned the json stats build.
-    char* end = nullptr;
-    float v = std::strtof(value.c_str(), &end);
-    AssertInfo(end == value.c_str() + value.size(),
-               "invalid float value: {}",
-               value);
-    return v;
+    return static_cast<float>(ParseJsonDoubleValue(value));
 }
 template <>
 inline double
 ConvertValue<double>(const std::string& value) {
-    char* end = nullptr;
-    double v = std::strtod(value.c_str(), &end);
-    AssertInfo(end == value.c_str() + value.size(),
-               "invalid double value: {}",
-               value);
-    return v;
+    return ParseJsonDoubleValue(value);
 }
 template <>
 inline bool
@@ -196,6 +202,12 @@ class JsonStatsParquetWriter {
 
     void
     AppendValue(const std::string& key, const std::string& value);
+
+    void
+    AppendNull(const std::string& key);
+
+    void
+    AppendDouble(const std::string& key, double value);
 
     void
     AppendRow(const std::map<std::string, std::string>& row_data);

--- a/internal/core/unittest/test_json_stats/test_bson_builder.cpp
+++ b/internal/core/unittest/test_json_stats/test_bson_builder.cpp
@@ -162,6 +162,80 @@ TEST_F(BsonBuilderTest, CreateValueNodeTest) {
                  std::runtime_error);
 }
 
+TEST_F(BsonBuilderTest, UndefinedSentinelPreservesExistsAndSibling) {
+    DomNode root(DomNode::Type::DOCUMENT);
+    BsonBuilder::AppendUndefinedToDom(root, {"bad"});
+    BsonBuilder::AppendDoubleToDom(root, {"ok"}, 1.5);
+
+    bsoncxx::builder::basic::document bson_builder;
+    BsonBuilder::ConvertDomToBson(root, bson_builder);
+    auto bson_doc = bson_builder.extract();
+    auto offsets = BsonBuilder::ExtractBsonKeyOffsets(bson_doc.view());
+    ASSERT_EQ(offsets.size(), 2);
+    EXPECT_EQ(offsets[0].first, "/bad");
+    EXPECT_EQ(offsets[1].first, "/ok");
+
+    BsonView view(bson_doc.view().data(), bson_doc.view().length());
+    EXPECT_FALSE(view.IsBsonValueEmpty(offsets[0].second));
+    EXPECT_FALSE(
+        view.ParseAsValueAtOffset<double>(offsets[0].second).has_value());
+    ASSERT_TRUE(
+        view.ParseAsValueAtOffset<double>(offsets[1].second).has_value());
+    EXPECT_DOUBLE_EQ(
+        view.ParseAsValueAtOffset<double>(offsets[1].second).value(), 1.5);
+
+    auto bad = view.FindByPath(bson_doc.view(), {"bad"});
+    ASSERT_TRUE(bad.has_value());
+    EXPECT_EQ(bad->type(), bsoncxx::type::k_undefined);
+}
+
+TEST_F(BsonBuilderTest, ArrayInvalidNumberKeepsValidElementsQueryable) {
+    const std::string json =
+        R"([1e400,7,{"bad":18446744073709551616,"ok":9},[1e400,11]])";
+
+    auto bytes = BuildBsonArrayBytesFromJsonString(json);
+    bsoncxx::array::view array(bytes.data(), bytes.size());
+    ASSERT_EQ(std::distance(array.begin(), array.end()), 4);
+
+    auto it = array.begin();
+    EXPECT_EQ(it->type(), bsoncxx::type::k_undefined);
+    ++it;
+    EXPECT_EQ(it->type(), bsoncxx::type::k_int64);
+    EXPECT_EQ(it->get_int64().value, 7);
+    ++it;
+    ASSERT_EQ(it->type(), bsoncxx::type::k_document);
+    auto object = it->get_document().value;
+    auto object_it = object.begin();
+    ASSERT_NE(object_it, object.end());
+    EXPECT_EQ(object_it->type(), bsoncxx::type::k_undefined);
+    ++object_it;
+    ASSERT_NE(object_it, object.end());
+    EXPECT_EQ(object_it->get_int64().value, 9);
+    ++it;
+    ASSERT_EQ(it->type(), bsoncxx::type::k_array);
+    auto nested = it->get_array().value;
+    auto nested_it = nested.begin();
+    EXPECT_EQ(nested_it->type(), bsoncxx::type::k_undefined);
+    ++nested_it;
+    EXPECT_EQ(nested_it->get_int64().value, 11);
+
+    // Skipping over a zero-payload undefined element must still reach later
+    // array indexes.
+    auto seven = BsonView::GetNthElementInArray<int64_t>(bytes.data(), 1);
+    ASSERT_TRUE(seven.has_value());
+    EXPECT_EQ(seven.value(), 7);
+
+    DomNode root(DomNode::Type::DOCUMENT);
+    BsonBuilder::AppendArrayToDom(root, {"array"}, std::move(bytes));
+    bsoncxx::builder::basic::document bson_builder;
+    BsonBuilder::ConvertDomToBson(root, bson_builder);
+    auto bson_doc = bson_builder.extract();
+    auto offsets = BsonBuilder::ExtractBsonKeyOffsets(bson_doc.view());
+    ASSERT_EQ(offsets.size(), 1);
+    BsonView view(bson_doc.view().data(), bson_doc.view().length());
+    EXPECT_FALSE(view.IsBsonValueEmpty(offsets[0].second));
+}
+
 TEST_F(BsonBuilderTest, AppendToDomTest) {
     BsonBuilder builder;
     DomNode root(DomNode::Type::DOCUMENT);

--- a/internal/core/unittest/test_json_stats/test_parquet_writer.cpp
+++ b/internal/core/unittest/test_json_stats/test_parquet_writer.cpp
@@ -4,7 +4,9 @@
 #include <arrow/io/interfaces.h>
 #include <arrow/io/memory.h>
 #include <arrow/result.h>
+#include <cmath>
 #include <filesystem>
+#include <limits>
 #include <map>
 #include <parquet/arrow/writer.h>
 #include <memory>
@@ -258,6 +260,35 @@ TEST_F(ParquetWriterFactoryTest, ClosePropagatesFinalCloseFailure) {
               std::string::npos);
 
     std::filesystem::remove_all(path_prefix);
+}
+
+// Regression for https://github.com/milvus-io/milvus/issues/52806
+// ConvertValue used to throw std::out_of_range on subnormal / overflowing
+// numbers because it was built on std::stof/std::stod.
+TEST(ConvertValueTest, HandlesSubnormalAndOutOfRangeNumbers) {
+    const double sub = -1.4829972460841e-309;
+    EXPECT_DOUBLE_EQ(
+        ConvertValue<double>(std::string("-1.4829972460841e-309")), sub);
+    EXPECT_DOUBLE_EQ(
+        ConvertValue<double>(std::string("-2.32430876e-316")),
+        -2.32430876e-316);
+
+    // Overflow clamps instead of throwing.
+    EXPECT_TRUE(std::isinf(ConvertValue<double>(std::string("1e400"))));
+    EXPECT_EQ(ConvertValue<double>(std::string("1e400")),
+              std::numeric_limits<double>::infinity());
+    EXPECT_TRUE(std::isinf(ConvertValue<float>(std::string("1e40"))));
+
+    // Underflow-to-zero clamps instead of throwing.
+    EXPECT_DOUBLE_EQ(ConvertValue<double>(std::string("1e-400")), 0.0);
+
+    // Normal values keep exact round-trip.
+    EXPECT_DOUBLE_EQ(ConvertValue<double>(std::string("-1.5")), -1.5);
+    EXPECT_FLOAT_EQ(ConvertValue<float>(std::string("2.5")), 2.5f);
+
+    // Malformed input still fails loudly.
+    EXPECT_ANY_THROW(ConvertValue<double>(std::string("abc")));
+    EXPECT_ANY_THROW(ConvertValue<double>(std::string("1.5xyz")));
 }
 
 }  // namespace milvus::index

--- a/internal/core/unittest/test_json_stats/test_parquet_writer.cpp
+++ b/internal/core/unittest/test_json_stats/test_parquet_writer.cpp
@@ -262,25 +262,58 @@ TEST_F(ParquetWriterFactoryTest, ClosePropagatesFinalCloseFailure) {
     std::filesystem::remove_all(path_prefix);
 }
 
-// Regression for https://github.com/milvus-io/milvus/issues/52806
-// ConvertValue used to throw std::out_of_range on subnormal / overflowing
-// numbers because it was built on std::stof/std::stod.
-TEST(ConvertValueTest, HandlesSubnormalAndOutOfRangeNumbers) {
-    const double sub = -1.4829972460841e-309;
-    EXPECT_DOUBLE_EQ(
-        ConvertValue<double>(std::string("-1.4829972460841e-309")), sub);
-    EXPECT_DOUBLE_EQ(
-        ConvertValue<double>(std::string("-2.32430876e-316")),
-        -2.32430876e-316);
+TEST_F(ParquetWriterFactoryTest, AppendsTypedNullAndParsedDoubleDirectly) {
+    auto fs = milvus::segcore::GetDefaultArrowFileSystem();
+    auto path_prefix =
+        std::filesystem::path(TestLocalPath) / "json_stats_writer_null";
+    std::filesystem::remove_all(path_prefix);
+    ASSERT_TRUE(std::filesystem::create_directories(path_prefix));
 
-    // Overflow clamps instead of throwing.
-    EXPECT_TRUE(std::isinf(ConvertValue<double>(std::string("1e400"))));
-    EXPECT_EQ(ConvertValue<double>(std::string("1e400")),
-              std::numeric_limits<double>::infinity());
+    const auto key = JsonKey("/double", JSONType::DOUBLE).ToColumnName();
+    std::map<JsonKey, JsonKeyLayoutType> column_map = {
+        {JsonKey("/double", JSONType::DOUBLE), JsonKeyLayoutType::TYPED},
+        {JsonKey("/shared", JSONType::STRING), JsonKeyLayoutType::SHARED},
+    };
+    milvus_storage::StorageConfig storage_config;
+    JsonStatsParquetWriter writer(fs, storage_config, 16 * 1024 * 1024, 1024);
+    auto context =
+        ParquetWriterFactory::CreateContext(column_map, path_prefix.string());
+    auto double_builder = std::static_pointer_cast<arrow::DoubleBuilder>(
+        context.builders_map[key]);
+    writer.Init(std::move(context));
+
+    writer.AppendNull(key);
+    writer.AppendSharedRow(nullptr, 0);
+    writer.AddCurrentRow();
+    writer.AppendDouble(key, -1.4829972460841e-309);
+    writer.AppendSharedRow(nullptr, 0);
+    writer.AddCurrentRow();
+
+    ASSERT_EQ(double_builder->length(), 2);
+    EXPECT_EQ(double_builder->null_count(), 1);
+    ASSERT_TRUE(writer.Close().ok());
+    std::filesystem::remove_all(path_prefix);
+}
+
+// Regression for https://github.com/milvus-io/milvus/issues/52806
+// Conversion uses the same simdjson get_number() contract as raw predicates.
+TEST(ConvertValueTest, MatchesSimdjsonNumberSemantics) {
+    const double sub = -1.4829972460841e-309;
+    EXPECT_DOUBLE_EQ(ConvertValue<double>(std::string("-1.4829972460841e-309")),
+                     sub);
+    EXPECT_DOUBLE_EQ(ConvertValue<double>(std::string("-2.32430876e-316")),
+                     -2.32430876e-316);
+
+    // Float narrowing still follows C++ conversion after a valid JSON double.
     EXPECT_TRUE(std::isinf(ConvertValue<float>(std::string("1e40"))));
 
     // Underflow-to-zero clamps instead of throwing.
     EXPECT_DOUBLE_EQ(ConvertValue<double>(std::string("1e-400")), 0.0);
+
+    // Values rejected by raw get_number() are rejected here too, even when a
+    // standalone double conversion could produce a rounded or infinite value.
+    EXPECT_ANY_THROW(ConvertValue<double>(std::string("1e400")));
+    EXPECT_ANY_THROW(ConvertValue<double>(std::string("18446744073709551616")));
 
     // Normal values keep exact round-trip.
     EXPECT_DOUBLE_EQ(ConvertValue<double>(std::string("-1.5")), -1.5);

--- a/internal/core/unittest/test_json_stats/test_traverse_json_for_build_stats.cpp
+++ b/internal/core/unittest/test_json_stats/test_traverse_json_for_build_stats.cpp
@@ -150,3 +150,60 @@ TEST(CollectSingleJsonStatsInfoTest, EmptyJsonStringThrows) {
     EXPECT_NO_THROW(
         { CollectSingleJsonStatsInfoAccessor::Call(stats, json, infos); });
 }
+
+// Regression for https://github.com/milvus-io/milvus/issues/52806
+// Subnormal doubles (e.g. -1.48e-309) used to be misclassified as UNKNOWN by
+// the std::stof/std::stod based sniffing and aborted the whole stats build.
+TEST(TraverseJsonForBuildStatsTest, HandlesSubnormalAndOutOfRangeNumbers) {
+    const char* json =
+        R"({"sub": -1.4829972460841e-309, "tiny": -2.32430876e-316,)"
+        R"( "huge": 1e400, "normal": 1.5})";
+
+    auto tokens = Tokenize(json);
+
+    milvus::storage::FieldDataMeta field_meta{1, 2, 3, 100, {}};
+    milvus::storage::IndexMeta index_meta{3, 100, 1, 1};
+    milvus::storage::StorageConfig storage_config;
+    storage_config.storage_type = "local";
+    storage_config.root_path = TestLocalPath;
+    auto cm = milvus::storage::CreateChunkManager(storage_config);
+    auto fs = milvus::storage::InitArrowFileSystem(storage_config);
+    milvus::storage::FileManagerContext ctx(field_meta, index_meta, cm, fs);
+    JsonKeyStats stats(ctx, true);
+
+    int index = 0;
+    std::vector<std::string> path;
+    std::map<JsonKey, std::string> values;
+    TraverseJsonForBuildStatsAccessor::Call(
+        stats, json, tokens.data(), index, path, values);
+
+    // All four values must be classified DOUBLE with raw text preserved.
+    EXPECT_EQ(values.at(JsonKey{"/sub", JSONType::DOUBLE}),
+              "-1.4829972460841e-309");
+    EXPECT_EQ(values.at(JsonKey{"/tiny", JSONType::DOUBLE}),
+              "-2.32430876e-316");
+    EXPECT_EQ(values.at(JsonKey{"/huge", JSONType::DOUBLE}), "1e400");
+    EXPECT_EQ(values.at(JsonKey{"/normal", JSONType::DOUBLE}), "1.5");
+}
+
+TEST(CollectSingleJsonStatsInfoTest, ClassifiesSubnormalNumbersAsDouble) {
+    const char* json =
+        R"({"sub": -1.4829972460841e-309, "tiny": -2.32430876e-316})";
+
+    milvus::storage::FieldDataMeta field_meta{1, 2, 3, 100, {}};
+    milvus::storage::IndexMeta index_meta{3, 100, 1, 1};
+    milvus::storage::StorageConfig storage_config;
+    storage_config.storage_type = "local";
+    storage_config.root_path = TestLocalPath;
+    auto cm = milvus::storage::CreateChunkManager(storage_config);
+    auto fs = milvus::storage::InitArrowFileSystem(storage_config);
+    milvus::storage::FileManagerContext ctx(field_meta, index_meta, cm, fs);
+    JsonKeyStats stats(ctx, true);
+
+    std::map<JsonKey, milvus::index::KeyStatsInfo> infos;
+    EXPECT_NO_THROW(
+        { CollectSingleJsonStatsInfoAccessor::Call(stats, json, infos); });
+
+    ASSERT_NE(infos.find(JsonKey{"/sub", JSONType::DOUBLE}), infos.end());
+    ASSERT_NE(infos.find(JsonKey{"/tiny", JSONType::DOUBLE}), infos.end());
+}

--- a/internal/core/unittest/test_json_stats/test_traverse_json_for_build_stats.cpp
+++ b/internal/core/unittest/test_json_stats/test_traverse_json_for_build_stats.cpp
@@ -14,8 +14,9 @@
 #include <vector>
 #include <map>
 
+#include "common/Json.h"
+#include "common/protobuf_utils.h"
 #include "index/json_stats/JsonKeyStats.h"
-#include "common/jsmn.h"
 #include "storage/ChunkManager.h"
 #include "storage/Types.h"
 #include "storage/FileManager.h"
@@ -24,6 +25,7 @@
 
 using milvus::index::JsonKey;
 using milvus::index::JsonKeyStats;
+using milvus::index::JsonStatsValue;
 using milvus::index::JSONType;
 
 // Friend accessor declared in JsonKeyStats to invoke private method for UT
@@ -32,11 +34,14 @@ class TraverseJsonForBuildStatsAccessor {
     static void
     Call(JsonKeyStats& s,
          const char* json,
-         jsmntok_t* tokens,
-         int& index,
          std::vector<std::string>& path,
-         std::map<JsonKey, std::string>& values) {
-        s.TraverseJsonForBuildStats(json, tokens, index, path, values);
+         std::map<JsonKey, JsonStatsValue>& values) {
+        milvus::Json parsed(simdjson::padded_string(json, std::strlen(json)));
+        auto document = parsed.doc();
+        ASSERT_EQ(document.error(), simdjson::SUCCESS);
+        auto root = document.get_value();
+        ASSERT_EQ(root.error(), simdjson::SUCCESS);
+        s.TraverseJsonForBuildStats(root.value(), path, values);
     }
 };
 
@@ -47,40 +52,10 @@ class CollectSingleJsonStatsInfoAccessor {
     Call(JsonKeyStats& s,
          const char* json,
          std::map<JsonKey, milvus::index::KeyStatsInfo>& infos) {
-        s.CollectSingleJsonStatsInfo(json, infos);
+        milvus::Json parsed(simdjson::padded_string(json, std::strlen(json)));
+        s.CollectSingleJsonStatsInfo(parsed, infos);
     }
 };
-
-namespace {
-
-// Helper to tokenize JSON using jsmn
-static std::vector<jsmntok_t>
-Tokenize(const char* json) {
-    jsmn_parser parser;
-    jsmn_init(&parser);
-    int token_capacity = 32;
-    std::vector<jsmntok_t> tokens(token_capacity);
-    while (true) {
-        int r = jsmn_parse(
-            &parser, json, strlen(json), tokens.data(), token_capacity);
-        if (r == JSMN_ERROR_NOMEM) {
-            token_capacity *= 2;
-            tokens.resize(token_capacity);
-            continue;
-        }
-        EXPECT_GE(r, 0) << "Failed to parse JSON with jsmn";
-        tokens.resize(r);
-        break;
-    }
-    return tokens;
-}
-
-static std::string
-Substr(const char* json, const jsmntok_t& tok) {
-    return std::string(json + tok.start, tok.end - tok.start);
-}
-
-}  // namespace
 
 TEST(TraverseJsonForBuildStatsTest,
      HandlesPrimitivesArraysNestedAndEmptyObject) {
@@ -91,8 +66,6 @@ TEST(TraverseJsonForBuildStatsTest,
         "payload":{},"public":true,"created_at":"2024-01-01T00:01:28Z",
         "msg":"line1\nline2\t\u4e2d\u6587 \/ backslash \\"}
     )";
-
-    auto tokens = Tokenize(json);
 
     // We only need an instance to access the private method we exposed.
     milvus::storage::FieldDataMeta field_meta{1, 2, 3, 100, {}};
@@ -105,11 +78,9 @@ TEST(TraverseJsonForBuildStatsTest,
     milvus::storage::FileManagerContext ctx(field_meta, index_meta, cm, fs);
     JsonKeyStats stats(ctx, true);
 
-    int index = 0;
     std::vector<std::string> path;
-    std::map<JsonKey, std::string> values;
-    TraverseJsonForBuildStatsAccessor::Call(
-        stats, json, tokens.data(), index, path, values);
+    std::map<JsonKey, JsonStatsValue> values;
+    TraverseJsonForBuildStatsAccessor::Call(stats, json, path, values);
 
     // Expect collected key-value/type pairs
     auto expect_has = [&](const std::string& key,
@@ -118,7 +89,7 @@ TEST(TraverseJsonForBuildStatsTest,
         JsonKey k{key, type};
         auto it = values.find(k);
         ASSERT_NE(it, values.end()) << "Missing key: " << key;
-        EXPECT_EQ(it->second, value_substr);
+        EXPECT_EQ(it->second.raw_value, value_substr);
     };
 
     expect_has("/id", JSONType::INT64, "34495370646");
@@ -154,12 +125,9 @@ TEST(CollectSingleJsonStatsInfoTest, EmptyJsonStringThrows) {
 // Regression for https://github.com/milvus-io/milvus/issues/52806
 // Subnormal doubles (e.g. -1.48e-309) used to be misclassified as UNKNOWN by
 // the std::stof/std::stod based sniffing and aborted the whole stats build.
-TEST(TraverseJsonForBuildStatsTest, HandlesSubnormalAndOutOfRangeNumbers) {
-    const char* json =
-        R"({"sub": -1.4829972460841e-309, "tiny": -2.32430876e-316,)"
-        R"( "huge": 1e400, "normal": 1.5})";
-
-    auto tokens = Tokenize(json);
+TEST(TraverseJsonForBuildStatsTest, MatchesSimdjsonNumberSemantics) {
+    const char* json = R"({"sub": -1.4829972460841e-309, "underflow": 1e-400,)"
+                       R"( "uint64": 18446744073709551615, "normal": 1.5})";
 
     milvus::storage::FieldDataMeta field_meta{1, 2, 3, 100, {}};
     milvus::storage::IndexMeta index_meta{3, 100, 1, 1};
@@ -171,19 +139,49 @@ TEST(TraverseJsonForBuildStatsTest, HandlesSubnormalAndOutOfRangeNumbers) {
     milvus::storage::FileManagerContext ctx(field_meta, index_meta, cm, fs);
     JsonKeyStats stats(ctx, true);
 
-    int index = 0;
     std::vector<std::string> path;
-    std::map<JsonKey, std::string> values;
-    TraverseJsonForBuildStatsAccessor::Call(
-        stats, json, tokens.data(), index, path, values);
+    std::map<JsonKey, JsonStatsValue> values;
+    TraverseJsonForBuildStatsAccessor::Call(stats, json, path, values);
 
-    // All four values must be classified DOUBLE with raw text preserved.
-    EXPECT_EQ(values.at(JsonKey{"/sub", JSONType::DOUBLE}),
+    EXPECT_EQ(values.at(JsonKey{"/sub", JSONType::DOUBLE}).raw_value,
               "-1.4829972460841e-309");
-    EXPECT_EQ(values.at(JsonKey{"/tiny", JSONType::DOUBLE}),
-              "-2.32430876e-316");
-    EXPECT_EQ(values.at(JsonKey{"/huge", JSONType::DOUBLE}), "1e400");
-    EXPECT_EQ(values.at(JsonKey{"/normal", JSONType::DOUBLE}), "1.5");
+    EXPECT_DOUBLE_EQ(
+        values.at(JsonKey{"/sub", JSONType::DOUBLE}).double_value.value(),
+        -1.4829972460841e-309);
+    EXPECT_DOUBLE_EQ(
+        values.at(JsonKey{"/underflow", JSONType::DOUBLE}).double_value.value(),
+        0.0);
+    EXPECT_DOUBLE_EQ(
+        values.at(JsonKey{"/uint64", JSONType::DOUBLE}).double_value.value(),
+        18446744073709551615.0);
+    EXPECT_DOUBLE_EQ(
+        values.at(JsonKey{"/normal", JSONType::DOUBLE}).double_value.value(),
+        1.5);
+}
+
+TEST(TraverseJsonForBuildStatsTest, InvalidNumberPreservesPathAndSibling) {
+    const char* json =
+        R"({"overflow":1e400,"bigint":18446744073709551616,"ok":7})";
+
+    milvus::storage::FieldDataMeta field_meta{1, 2, 3, 100, {}};
+    milvus::storage::IndexMeta index_meta{3, 100, 1, 1};
+    milvus::storage::StorageConfig storage_config;
+    storage_config.storage_type = "local";
+    storage_config.root_path = TestLocalPath;
+    auto cm = milvus::storage::CreateChunkManager(storage_config);
+    auto fs = milvus::storage::InitArrowFileSystem(storage_config);
+    milvus::storage::FileManagerContext ctx(field_meta, index_meta, cm, fs);
+    JsonKeyStats stats(ctx, true);
+
+    std::vector<std::string> path;
+    std::map<JsonKey, JsonStatsValue> values;
+    TraverseJsonForBuildStatsAccessor::Call(stats, json, path, values);
+
+    EXPECT_TRUE(
+        values.at(JsonKey{"/overflow", JSONType::DOUBLE}).IsInvalidNumber());
+    EXPECT_TRUE(
+        values.at(JsonKey{"/bigint", JSONType::DOUBLE}).IsInvalidNumber());
+    EXPECT_EQ(values.at(JsonKey{"/ok", JSONType::INT64}).raw_value, "7");
 }
 
 TEST(CollectSingleJsonStatsInfoTest, ClassifiesSubnormalNumbersAsDouble) {

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -174,9 +174,9 @@ func needDoJSONKeyIndex(segment *SegmentInfo, fieldIDs []UniqueID) bool {
 		if segment.GetJsonKeyStats()[fieldID] == nil {
 			return true
 		}
-		// if the data format version is less than the current version, we need to do the stats task again
-		// because the data format is updated, the old data format need to be converted to the new data format
-		if segment.GetJsonKeyStats()[fieldID].GetJsonKeyStatsDataFormat() < common.JSONStatsDataFormatVersion {
+		// Readers require an exact data-format match. Rebuild both older stats
+		// and stats produced by a newer binary after a downgrade.
+		if segment.GetJsonKeyStats()[fieldID].GetJsonKeyStatsDataFormat() != common.JSONStatsDataFormatVersion {
 			return true
 		}
 	}

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -608,7 +608,11 @@ func (st *statsTask) createJSONKeyStats(ctx context.Context,
 	if jsonKeyStatsDataFormat != common.JSONStatsDataFormatVersion {
 		log.Warn("create json key index failed dataformat invalid", zap.Int64("dataformat version", jsonKeyStatsDataFormat),
 			zap.Int64("code version", common.JSONStatsDataFormatVersion))
-		return nil
+		return merr.WrapErrServiceNotReadyMsg(
+			"json stats data format %d is incompatible with DataNode format %d",
+			jsonKeyStatsDataFormat,
+			common.JSONStatsDataFormatVersion,
+		)
 	}
 
 	fieldBinlogs := lo.GroupBy(insertBinlogs, func(binlog *datapb.FieldBinlog) int64 {

--- a/internal/datanode/index/task_stats_test.go
+++ b/internal/datanode/index/task_stats_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/workerpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
@@ -305,6 +306,29 @@ func (s *TaskStatsSuite) TestJSONKeyStatsPropagatesPluginContext() {
 		s.Require().NotNil(captured)
 		s.Equal(pluginContext, captured.GetStoragePluginContext())
 	})
+}
+
+func (s *TaskStatsSuite) TestJSONStatsDataFormatMismatchIsRetryable() {
+	st := &statsTask{req: &workerpb.CreateStatsRequest{
+		ClusterID: "cluster",
+		TaskID:    1,
+	}}
+	err := st.createJSONKeyStats(
+		context.Background(),
+		nil,
+		1,
+		2,
+		3,
+		4,
+		5,
+		common.JSONStatsDataFormatVersion+1,
+		nil,
+		256,
+		0.3,
+		81920,
+	)
+	s.ErrorIs(err, merr.ErrServiceNotReady)
+	s.True(merr.IsRetryableErr(err))
 }
 
 func genCollectionSchemaWithBM25() *schemapb.CollectionSchema {

--- a/internal/querycoordv2/checkers/index_checker.go
+++ b/internal/querycoordv2/checkers/index_checker.go
@@ -286,7 +286,7 @@ func (c *IndexChecker) checkSegmentStats(segment *meta.Segment, schema *schemapb
 			fieldID := field.GetFieldID()
 			if h.EnableJSONKeyStatsIndex() {
 				if _, ok := loadFieldMap[fieldID]; ok {
-					if info, ok := segment.JSONStatsField[fieldID]; !ok || info.GetDataFormatVersion() < common.JSONStatsDataFormatVersion {
+					if info, ok := segment.JSONStatsField[fieldID]; !ok || info.GetDataFormatVersion() != common.JSONStatsDataFormatVersion {
 						result = append(result, fieldID)
 					}
 				}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -168,8 +168,9 @@ const (
 )
 
 const (
-	// Version 3: metadata moved to separate meta.json file (instead of parquet metadata)
-	JSONStatsDataFormatVersion = 3
+	// Version 4: shared BSON may contain undefined sentinels for numeric values
+	// rejected by simdjson. Query nodes load JSON stats by exact format version.
+	JSONStatsDataFormatVersion = 4
 )
 
 // Search, Index parameter keys


### PR DESCRIPTION
Backport of #52828

Related to #52806

## Why this is a manual backport

The 2.6 JSON stats and BSON code predates the structure used by master and 3.0. This patch implements the same query semantics using the branch's existing `bsoncxx` and stats interfaces; it does not copy master-only BSON shim or typed-path helper files.

## Semantics

- representable subnormal JSON numbers remain valid finite doubles
- syntactically valid but unrepresentable numbers such as `1e400` and integers above `uint64` remain present but are invalid for numeric comparisons
- Term/Range sees no comparable value, while `exists(path)` remains true
- invalid array elements are local non-matches; later elements and sibling fields are retained
- malformed JSON remains an error

## What changed

- replace `std::stod`/string sniffing with simdjson `get_number()` in the 2.6 JSON cast, stats, path-index, and mixed JSON-contains paths
- write Arrow null for invalid typed stats values and BSON undefined for presence-preserving shared/array values
- teach the 2.6 BSON reader to skip undefined payloads safely while preserving existence
- keep JsonFlatIndex all-or-nothing until it has uncovered-row fallback
- bump JSON stats format to v4 and require exact format compatibility; DataNode returns retryable `ServiceNotReady` on mismatch

## Validation

- `git diff --check`, Go formatting, and C++ formatting checks passed
- `cd pkg && go test ./common -count=1` passed
- focused traversal, BSON undefined/array, Parquet typed-null, and flat-index safety tests were added
- full local native compilation is environment-blocked by unavailable 2.6 bsoncxx/CGo dependencies; PR CI is expected to provide the branch's supported toolchain
