### PR TITLE
[3.0] fix: align unrepresentable JSON number semantics

### DIFF
--- a/internal/core/src/common/Consts.h
+++ b/internal/core/src/common/Consts.h
@@ -64,8 +64,9 @@ const char HINTS[] = "hints";
 const char JSON_KEY_INDEX_LOG_ROOT_PATH[] = "json_key_index_log";
 const char NGRAM_LOG_ROOT_PATH[] = "ngram_log";
 constexpr const char* JSON_STATS_ROOT_PATH = "json_stats";
-// Version 3: metadata moved to separate meta.json file (instead of parquet metadata)
-constexpr const char* JSON_STATS_DATA_FORMAT_VERSION = "3";
+// Version 4: shared BSON may contain undefined sentinels for numeric values
+// rejected by simdjson. Exact-version loading protects older readers.
+constexpr const char* JSON_STATS_DATA_FORMAT_VERSION = "4";
 constexpr const char* JSON_STATS_SHARED_INDEX_PATH = "shared_key_index";
 constexpr const char* JSON_STATS_SHREDDING_DATA_PATH = "shredding_data";
 constexpr const char* JSON_STATS_META_FILE_NAME = "meta.json";

--- a/internal/core/src/common/JsonCastFunction.cpp
+++ b/internal/core/src/common/JsonCastFunction.cpp
@@ -2,7 +2,6 @@
 
 #include <simdjson.h>
 #include <cstdint>
-#include <exception>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -30,11 +29,25 @@ JsonCastFunction::FromString(const std::string& str) {
 template <>
 std::optional<double>
 JsonCastFunction::cast<double, std::string>(const std::string& t) const {
-    try {
-        return std::stod(t);
-    } catch (const std::exception&) {
+    // Parse the string as a complete JSON number document. Besides avoiding
+    // platform-dependent std::stod behavior, this accepts representable
+    // subnormals and underflow-to-zero while rejecting overflow and trailing
+    // non-whitespace content.
+    simdjson::padded_string number_token(t);
+    thread_local simdjson::ondemand::parser parser;
+    auto document = parser.iterate(number_token);
+    if (document.error() != simdjson::SUCCESS) {
         return std::nullopt;
     }
+
+    // get_number() preserves simdjson's integer-domain validation. Calling
+    // document.get_double() directly would approximate integers larger than
+    // uint64_t even though the regular raw-JSON path rejects them.
+    auto number = document.get_number();
+    if (number.error() != simdjson::SUCCESS) {
+        return std::nullopt;
+    }
+    return number.value().as_double();
 }
 
 template <>
@@ -63,30 +76,41 @@ JsonCastFunction::CastJsonValue(const JsonCastFunction& cast_function,
     AssertInfo(cast_function.match<T>(), "Type mismatch");
 
     auto json_type = json.type(pointer);
+    if (json_type.error() != simdjson::SUCCESS) {
+        return std::nullopt;
+    }
+
     std::optional<T> res;
 
     switch (json_type.value()) {
         case simdjson::ondemand::json_type::string: {
             auto json_value = json.at<std::string_view>(pointer);
+            if (json_value.error() != simdjson::SUCCESS) {
+                return std::nullopt;
+            }
             res = cast_function.cast<T, std::string>(
                 std::string(json_value.value()));
             break;
         }
 
         case simdjson::ondemand::json_type::number: {
-            if (json.get_number_type(pointer) ==
-                simdjson::ondemand::number_type::floating_point_number) {
-                auto json_value = json.at<double>(pointer);
-                res = cast_function.cast<T, double>(json_value.value());
-            } else {
-                auto json_value = json.at<int64_t>(pointer);
-                res = cast_function.cast<T, int64_t>(json_value.value());
+            // STRING_TO_DOUBLE accepts numeric JSON values as identity casts.
+            // Parse into simdjson's tagged number first so integers outside the
+            // uint64_t domain remain invalid instead of being approximated by
+            // get_double().
+            auto json_value = json.at_numeric(pointer);
+            if (json_value.error() != simdjson::SUCCESS) {
+                return std::nullopt;
             }
+            res = cast_function.cast<T, double>(json_value.value().as_double());
             break;
         }
 
         case simdjson::ondemand::json_type::boolean: {
             auto json_value = json.at<bool>(pointer);
+            if (json_value.error() != simdjson::SUCCESS) {
+                return std::nullopt;
+            }
             res = cast_function.cast<T, bool>(json_value.value());
             break;
         }

--- a/internal/core/src/common/bson_shim.h
+++ b/internal/core/src/common/bson_shim.h
@@ -46,6 +46,7 @@ enum class type : uint8_t {
     k_document = 0x03,
     k_array = 0x04,
     k_binary = 0x05,
+    k_undefined = 0x06,
     k_bool = 0x08,
     k_null = 0x0A,
     k_int32 = 0x10,

--- a/internal/core/src/common/bson_view.h
+++ b/internal/core/src/common/bson_view.h
@@ -304,6 +304,7 @@ class BsonView {
                 }
                 break;
             case milvus::bson::type::k_null:
+            case milvus::bson::type::k_undefined:
             case milvus::bson::type::k_document:
             case milvus::bson::type::k_array:
                 break;
@@ -427,6 +428,9 @@ class BsonView {
                             return ParseAsArray(ptr);
                         }
                         break;
+                    case milvus::bson::type::k_undefined:
+                    case milvus::bson::type::k_null:
+                        return std::nullopt;
                     default:
                         return std::nullopt;
                 }
@@ -449,6 +453,9 @@ class BsonView {
                     break;
                 case milvus::bson::type::k_bool:
                     ptr += 1;
+                    break;
+                case milvus::bson::type::k_undefined:
+                case milvus::bson::type::k_null:
                     break;
                 case milvus::bson::type::k_array:
                 case milvus::bson::type::k_document: {

--- a/internal/core/src/exec/expression/BinaryRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.h
@@ -108,10 +108,10 @@ struct BinaryRangeElementFunc {
     }
 };
 
-// For int64_t GetType, uses at_numeric() (get_number()) to extract any JSON
-// number in a single parse.  Branches on actual type to preserve int64
-// precision; uint64 and double values fall back to double comparison,
-// consistent with the Tantivy index and JSON-stats paths.
+// For numeric GetType, uses at_numeric() (get_number()) to validate the whole
+// JSON number token before comparison.  The int64_t branch preserves integer
+// precision; the double branch rejects NUMBER_ERROR instead of approximating
+// an integer outside the uint64_t domain via Json::at<double>().
 // 'cmp' must reference 'value' (int64_t or double depending on the JSON value).
 #define BinaryRangeJSONCompare(cmp)                                    \
     do {                                                               \
@@ -138,6 +138,14 @@ struct BinaryRangeElementFunc {
                                  : n.get_double();                     \
                 res[i] = (cmp);                                        \
             }                                                          \
+        } else if constexpr (std::is_same_v<GetType, double>) {        \
+            auto x_num = src[offset].at_numeric(pointer);              \
+            if (x_num.error()) {                                       \
+                res[i] = valid_res[i] = false;                         \
+                break;                                                 \
+            }                                                          \
+            auto value = x_num.value().as_double();                    \
+            res[i] = (cmp);                                            \
         } else {                                                       \
             auto x = src[offset].template at<GetType>(pointer);        \
             if (x.error()) {                                           \

--- a/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
+++ b/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
@@ -824,6 +824,134 @@ TEST(JsonRawScanTest, EmptyInAndLargeInt64KeepThreeValuedSemantics) {
           numeric_valid);
 }
 
+TEST(JsonRawScanTest, NumberErrorIsLimitedToTheAccessedPathOrArrayElement) {
+    auto schema = std::make_shared<Schema>();
+    auto json_fid = schema->AddDebugField("json", DataType::JSON);
+    auto seg = CreateSealedSegment(schema);
+
+    const std::vector<std::string> json_strs = {
+        R"({"bad":1e400,"ok":7,"target":[1,"x",true,[1,2]]})",
+        R"({"bad":1e400,"ok":8,"target":[1e400,[3,4],[1,2],7,"x"]})",
+        R"({"bad":1e400,"ok":9,"target":[1e400,[3,4]]})",
+    };
+    auto json_field =
+        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, false);
+    std::vector<milvus::Json> jsons;
+    jsons.reserve(json_strs.size());
+    for (const auto& json : json_strs) {
+        jsons.emplace_back(simdjson::padded_string(json));
+    }
+    json_field->add_json_data(jsons);
+
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        1, 1, 1, json_fid.get(), {json_field}, cm);
+    seg->LoadFieldData(load_info);
+
+    auto evaluate = [&](const expr::TypedExprPtr& filter_expr) {
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           filter_expr);
+        return milvus::test::gen_filter_res(
+            plan.get(), seg.get(), json_strs.size(), MAX_TIMESTAMP);
+    };
+    auto check = [](const ColumnVectorPtr& result,
+                    const std::vector<bool>& expected_result,
+                    const std::vector<bool>& expected_valid) {
+        ASSERT_EQ(result->size(), expected_result.size());
+        ASSERT_EQ(result->size(), expected_valid.size());
+        TargetBitmapView result_view(result->GetRawData(), result->size());
+        TargetBitmapView valid_view(result->GetValidRawData(), result->size());
+        for (size_t i = 0; i < result->size(); ++i) {
+            EXPECT_EQ(valid_view[i], expected_valid[i]) << "row " << i;
+            EXPECT_EQ(result_view[i], expected_result[i]) << "row " << i;
+        }
+    };
+
+    proto::plan::GenericValue seven;
+    seven.set_int64_val(7);
+    proto::plan::GenericValue zero;
+    zero.set_int64_val(0);
+    proto::plan::GenericValue ten;
+    ten.set_int64_val(10);
+
+    auto bad_column = expr::ColumnInfo(json_fid, DataType::JSON, {"bad"});
+    check(
+        evaluate(std::make_shared<expr::TermFilterExpr>(
+            bad_column, std::vector<proto::plan::GenericValue>{seven}, false)),
+        {false, false, false},
+        {false, false, false});
+    check(evaluate(std::make_shared<expr::UnaryRangeFilterExpr>(
+              bad_column,
+              proto::plan::OpType::GreaterThan,
+              seven,
+              std::vector<proto::plan::GenericValue>())),
+          {false, false, false},
+          {false, false, false});
+    check(evaluate(std::make_shared<expr::BinaryRangeFilterExpr>(
+              bad_column, zero, ten, true, true)),
+          {false, false, false},
+          {false, false, false});
+    check(evaluate(std::make_shared<expr::ExistsExpr>(bad_column)),
+          {true, true, true},
+          {true, true, true});
+
+    auto ok_column = expr::ColumnInfo(json_fid, DataType::JSON, {"ok"});
+    check(evaluate(std::make_shared<expr::TermFilterExpr>(
+              ok_column, std::vector<proto::plan::GenericValue>{seven}, false)),
+          {true, false, false},
+          {true, true, true});
+    check(evaluate(std::make_shared<expr::BinaryRangeFilterExpr>(
+              ok_column, seven, ten, true, false)),
+          {true, true, true},
+          {true, true, true});
+
+    proto::plan::GenericValue missing;
+    missing.set_string_val("missing");
+    auto target_column = expr::ColumnInfo(json_fid, DataType::JSON, {"target"});
+    check(evaluate(std::make_shared<expr::JsonContainsExpr>(
+              target_column,
+              proto::plan::JSONContainsExpr_JSONOp_ContainsAny,
+              false,
+              std::vector<proto::plan::GenericValue>{seven, missing})),
+          {false, true, false},
+          {true, true, true});
+
+    proto::plan::GenericValue x;
+    x.set_string_val("x");
+    check(evaluate(std::make_shared<expr::JsonContainsExpr>(
+              target_column,
+              proto::plan::JSONContainsExpr_JSONOp_ContainsAll,
+              false,
+              std::vector<proto::plan::GenericValue>{seven, x})),
+          {false, true, false},
+          {true, true, true});
+
+    proto::plan::GenericValue array_1_2;
+    array_1_2.mutable_array_val()->add_array()->set_int64_val(1);
+    array_1_2.mutable_array_val()->add_array()->set_int64_val(2);
+    proto::plan::GenericValue array_3_4;
+    array_3_4.mutable_array_val()->add_array()->set_int64_val(3);
+    array_3_4.mutable_array_val()->add_array()->set_int64_val(4);
+    proto::plan::GenericValue array_9_9;
+    array_9_9.mutable_array_val()->add_array()->set_int64_val(9);
+    array_9_9.mutable_array_val()->add_array()->set_int64_val(9);
+    check(evaluate(std::make_shared<expr::JsonContainsExpr>(
+              target_column,
+              proto::plan::JSONContainsExpr_JSONOp_ContainsAny,
+              false,
+              std::vector<proto::plan::GenericValue>{array_9_9, array_1_2})),
+          {true, true, false},
+          {true, true, true});
+    check(evaluate(std::make_shared<expr::JsonContainsExpr>(
+              target_column,
+              proto::plan::JSONContainsExpr_JSONOp_ContainsAll,
+              false,
+              std::vector<proto::plan::GenericValue>{array_3_4, array_1_2})),
+          {false, true, false},
+          {true, true, true});
+}
+
 TEST(JsonIndexTest, TestJsonNotEqualExpr) {
     auto schema = std::make_shared<Schema>();
     schema->AddDebugField(

--- a/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
+++ b/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
@@ -367,8 +367,23 @@ TEST(JsonStatsInvalidNumberTest,
               std::vector<proto::plan::GenericValue>())),
           {false, true, false},
           {false, true, false});
+    check(compare(std::make_shared<expr::UnaryRangeFilterExpr>(
+              bad_column,
+              proto::plan::OpType::GreaterThan,
+              one_point_five,
+              std::vector<proto::plan::GenericValue>())),
+          {false, false, false},
+          {false, true, false});
     check(compare(std::make_shared<expr::BinaryRangeFilterExpr>(
               bad_column, zero, two, true, true)),
+          {false, true, false},
+          {false, true, false});
+    proto::plan::GenericValue one;
+    one.set_float_val(1.0);
+    proto::plan::GenericValue two_point_zero;
+    two_point_zero.set_float_val(2.0);
+    check(compare(std::make_shared<expr::BinaryRangeFilterExpr>(
+              bad_column, one, two_point_zero, true, true)),
           {false, true, false},
           {false, true, false});
     check(compare(std::make_shared<expr::ExistsExpr>(bad_column)),

--- a/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
+++ b/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
@@ -33,6 +33,8 @@
 #include "common/protobuf_utils.h"
 #include "exec/expression/BinaryRangeExpr.h"
 #include "exec/expression/ExprBatchTestUtils.h"
+#include "exec/expression/ExistsExpr.h"
+#include "exec/expression/JsonContainsExpr.h"
 #include "exec/expression/TermExpr.h"
 #include "exec/expression/UnaryExpr.h"
 #include "expr/ITypeExpr.h"
@@ -121,7 +123,8 @@ BuildJsonStatsIndex(const std::vector<std::string>& json_strings,
                     int64_t field_id,
                     int64_t build_id,
                     int64_t version_id,
-                    const std::vector<uint8_t>* valid_data = nullptr) {
+                    const std::vector<uint8_t>* valid_data = nullptr,
+                    int64_t json_stats_max_shredding_columns = 1024) {
     std::vector<milvus::Json> data;
     data.reserve(json_strings.size());
     for (const auto& s : json_strings) {
@@ -177,7 +180,8 @@ BuildJsonStatsIndex(const std::vector<std::string>& json_strings,
     Config build_config;
     build_config[INSERT_FILES_KEY] = std::vector<std::string>{log_path};
 
-    auto builder = std::make_shared<JsonKeyStats>(ctx, false);
+    auto builder = std::make_shared<JsonKeyStats>(
+        ctx, false, json_stats_max_shredding_columns);
     builder->Build(build_config);
 
     auto create_index_result = builder->Upload(build_config);
@@ -220,7 +224,8 @@ BuildAndLoadJsonKeyStats(const std::vector<std::string>& json_strings,
                          int64_t field_id,
                          int64_t build_id,
                          int64_t version_id,
-                         const std::vector<uint8_t>* valid_data = nullptr) {
+                         const std::vector<uint8_t>* valid_data = nullptr,
+                         int64_t json_stats_max_shredding_columns = 1024) {
     auto built_index = BuildJsonStatsIndex(json_strings,
                                            json_fid,
                                            root_path,
@@ -230,8 +235,171 @@ BuildAndLoadJsonKeyStats(const std::vector<std::string>& json_strings,
                                            field_id,
                                            build_id,
                                            version_id,
-                                           valid_data);
+                                           valid_data,
+                                           json_stats_max_shredding_columns);
     return LoadBuiltJsonStatsIndex(built_index);
+}
+
+TEST(JsonStatsInvalidNumberTest,
+     MatchesRawScanWithoutDroppingSiblingOrArrayElements) {
+    auto schema = std::make_shared<Schema>();
+    auto json_fid = schema->AddDebugField("json", DataType::JSON);
+    const std::vector<std::string> json_raw_data = {
+        R"({"bad":1e400,"ok":7,"arr":[1e400,7,8]})",
+        R"({"bad":1.5,"ok":8,"arr":[1e400]})",
+        R"({"bad":18446744073709551616,"ok":9,"arr":[7,8]})",
+    };
+
+    auto stats = BuildAndLoadJsonKeyStats(json_raw_data,
+                                          json_fid,
+                                          TestLocalPath,
+                                          1211,
+                                          2211,
+                                          3211,
+                                          json_fid.get(),
+                                          5211,
+                                          1,
+                                          nullptr);
+
+    auto shared_stats = BuildAndLoadJsonKeyStats(json_raw_data,
+                                                 json_fid,
+                                                 TestLocalPath,
+                                                 1212,
+                                                 2212,
+                                                 3212,
+                                                 json_fid.get(),
+                                                 5212,
+                                                 1,
+                                                 nullptr,
+                                                 0);
+
+    auto make_json_field = [&] {
+        auto field =
+            std::make_shared<FieldData<milvus::Json>>(DataType::JSON, false);
+        std::vector<milvus::Json> jsons;
+        jsons.reserve(json_raw_data.size());
+        for (const auto& json : json_raw_data) {
+            jsons.emplace_back(simdjson::padded_string(json));
+        }
+        field->add_json_data(jsons);
+        return field;
+    };
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto make_stats_segment = [&](const std::shared_ptr<JsonKeyStats>& index) {
+        auto segment = segcore::CreateSealedSegment(schema);
+        auto* sealed =
+            dynamic_cast<segcore::ChunkedSegmentSealedImpl*>(segment.get());
+        EXPECT_NE(sealed, nullptr);
+        sealed->SetJsonStatsForTesting(json_fid, index);
+        auto load_info = PrepareSingleFieldInsertBinlog(
+            0, 0, 0, json_fid.get(), {make_json_field()}, cm);
+        segment->LoadFieldData(load_info);
+        segment->DropFieldData(json_fid);
+        EXPECT_FALSE(segment->HasFieldData(json_fid));
+        return segment;
+    };
+    auto stats_segment = make_stats_segment(stats);
+    auto shared_stats_segment = make_stats_segment(shared_stats);
+
+    auto raw_segment = segcore::CreateSealedSegment(schema);
+    auto raw_load_info = PrepareSingleFieldInsertBinlog(
+        0, 0, 0, json_fid.get(), {make_json_field()}, cm);
+    raw_segment->LoadFieldData(raw_load_info);
+
+    auto evaluate = [&](const expr::TypedExprPtr& filter_expr,
+                        const segcore::SegmentInternalInterface* segment) {
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           filter_expr);
+        return milvus::test::gen_filter_res(
+            plan.get(), segment, json_raw_data.size(), MAX_TIMESTAMP);
+    };
+    auto expect_same = [](const ColumnVectorPtr& raw,
+                          const ColumnVectorPtr& shredded) {
+        ASSERT_EQ(raw->size(), shredded->size());
+        TargetBitmapView raw_result(raw->GetRawData(), raw->size());
+        TargetBitmapView raw_valid(raw->GetValidRawData(), raw->size());
+        TargetBitmapView shredded_result(shredded->GetRawData(),
+                                         shredded->size());
+        TargetBitmapView shredded_valid(shredded->GetValidRawData(),
+                                        shredded->size());
+        for (size_t i = 0; i < raw->size(); ++i) {
+            EXPECT_EQ(shredded_valid[i], raw_valid[i]) << "row " << i;
+            EXPECT_EQ(shredded_result[i], raw_result[i]) << "row " << i;
+        }
+    };
+    auto compare = [&](const expr::TypedExprPtr& filter_expr) {
+        auto raw = evaluate(filter_expr, raw_segment.get());
+        auto shredded = evaluate(filter_expr, stats_segment.get());
+        auto shared = evaluate(filter_expr, shared_stats_segment.get());
+        expect_same(raw, shredded);
+        expect_same(raw, shared);
+        return raw;
+    };
+    auto check = [](const ColumnVectorPtr& result,
+                    const std::vector<bool>& expected_result,
+                    const std::vector<bool>& expected_valid) {
+        TargetBitmapView result_view(result->GetRawData(), result->size());
+        TargetBitmapView valid_view(result->GetValidRawData(), result->size());
+        for (size_t i = 0; i < result->size(); ++i) {
+            EXPECT_EQ(result_view[i], expected_result[i]) << "row " << i;
+            EXPECT_EQ(valid_view[i], expected_valid[i]) << "row " << i;
+        }
+    };
+
+    proto::plan::GenericValue one_point_five;
+    one_point_five.set_float_val(1.5);
+    proto::plan::GenericValue zero;
+    zero.set_int64_val(0);
+    proto::plan::GenericValue two;
+    two.set_int64_val(2);
+    auto bad_column = expr::ColumnInfo(json_fid, DataType::JSON, {"bad"});
+    check(compare(std::make_shared<expr::TermFilterExpr>(
+              bad_column,
+              std::vector<proto::plan::GenericValue>{one_point_five},
+              false)),
+          {false, true, false},
+          {false, true, false});
+    check(compare(std::make_shared<expr::UnaryRangeFilterExpr>(
+              bad_column,
+              proto::plan::OpType::GreaterThan,
+              zero,
+              std::vector<proto::plan::GenericValue>())),
+          {false, true, false},
+          {false, true, false});
+    check(compare(std::make_shared<expr::BinaryRangeFilterExpr>(
+              bad_column, zero, two, true, true)),
+          {false, true, false},
+          {false, true, false});
+    check(compare(std::make_shared<expr::ExistsExpr>(bad_column)),
+          {true, true, true},
+          {true, true, true});
+
+    proto::plan::GenericValue seven;
+    seven.set_int64_val(7);
+    proto::plan::GenericValue eight;
+    eight.set_int64_val(8);
+    auto ok_column = expr::ColumnInfo(json_fid, DataType::JSON, {"ok"});
+    check(compare(std::make_shared<expr::TermFilterExpr>(
+              ok_column, std::vector<proto::plan::GenericValue>{seven}, false)),
+          {true, false, false},
+          {true, true, true});
+
+    auto array_column = expr::ColumnInfo(json_fid, DataType::JSON, {"arr"});
+    check(compare(std::make_shared<expr::JsonContainsExpr>(
+              array_column,
+              proto::plan::JSONContainsExpr_JSONOp_ContainsAny,
+              false,
+              std::vector<proto::plan::GenericValue>{seven})),
+          {true, false, true},
+          {true, true, true});
+    check(compare(std::make_shared<expr::JsonContainsExpr>(
+              array_column,
+              proto::plan::JSONContainsExpr_JSONOp_ContainsAll,
+              false,
+              std::vector<proto::plan::GenericValue>{seven, eight})),
+          {true, false, true},
+          {true, true, true});
 }
 
 TEST(JsonStatsSharedFallbackPruningTest,

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -124,6 +124,102 @@ class ContainsAllMatcher {
     size_t num_words_{0};
 };
 
+// Match one on-demand JSON array element against mixed-type query literals.
+// Inspecting the actual JSON type first lets us consume the on-demand value
+// exactly once.  In particular, an unrepresentable number (for example
+// 1e400) only makes that element a non-match; it cannot poison a sibling JSON
+// path or abort the whole query as whole-document DOM parsing would.
+template <typename OnMatch>
+void
+VisitMatchingJsonCandidates(
+    simdjson::simdjson_result<simdjson::ondemand::value>& value,
+    const std::vector<proto::plan::GenericValue>& candidates,
+    OnMatch&& on_match) {
+    auto type = value.type();
+    if (type.error()) {
+        return;
+    }
+
+    switch (type.value()) {
+        case simdjson::ondemand::json_type::boolean: {
+            auto parsed = value.template get<bool>();
+            if (parsed.error()) {
+                return;
+            }
+            for (size_t i = 0; i < candidates.size(); ++i) {
+                if (candidates[i].val_case() ==
+                        proto::plan::GenericValue::kBoolVal &&
+                    parsed.value() == candidates[i].bool_val() && on_match(i)) {
+                    return;
+                }
+            }
+            return;
+        }
+        case simdjson::ondemand::json_type::number: {
+            auto parsed = value.get_number();
+            if (parsed.error()) {
+                return;
+            }
+            for (size_t i = 0; i < candidates.size(); ++i) {
+                if (candidates[i].val_case() !=
+                        proto::plan::GenericValue::kInt64Val &&
+                    candidates[i].val_case() !=
+                        proto::plan::GenericValue::kFloatVal) {
+                    continue;
+                }
+                auto comparison =
+                    CompareJsonNumberToBound(parsed.value(), candidates[i]);
+                if (comparison.has_value() && *comparison == 0 && on_match(i)) {
+                    return;
+                }
+            }
+            return;
+        }
+        case simdjson::ondemand::json_type::string: {
+            auto parsed = value.template get<std::string_view>();
+            if (parsed.error()) {
+                return;
+            }
+            for (size_t i = 0; i < candidates.size(); ++i) {
+                if (candidates[i].val_case() ==
+                        proto::plan::GenericValue::kStringVal &&
+                    parsed.value() == candidates[i].string_val() &&
+                    on_match(i)) {
+                    return;
+                }
+            }
+            return;
+        }
+        case simdjson::ondemand::json_type::array: {
+            // Mixed-type expressions may compare this array with more than
+            // one array literal.  An on-demand array and its elements are
+            // forward-only, so materialize only this current element into a
+            // DOM value instead of retaining ephemeral on-demand cursors.
+            auto raw = value.raw_json();
+            if (raw.error()) {
+                return;
+            }
+            simdjson::padded_string padded(raw.value());
+            thread_local simdjson::dom::parser parser;
+            auto parsed = parser.parse(padded).get_array();
+            if (parsed.error()) {
+                return;
+            }
+            for (size_t i = 0; i < candidates.size(); ++i) {
+                if (candidates[i].val_case() ==
+                        proto::plan::GenericValue::kArrayVal &&
+                    CompareTwoJsonArray(parsed, candidates[i].array_val()) &&
+                    on_match(i)) {
+                    return;
+                }
+            }
+            return;
+        }
+        default:
+            return;
+    }
+}
+
 void
 PhyJsonContainsFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
     WaitPrefetch();
@@ -1455,82 +1551,20 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffType(EvalCtx& context) {
         }
         auto executor = [&](size_t i) {
             const auto& json = data[i];
-            auto doc = json.dom_doc();
+            auto doc = json.doc();
             auto array = doc.at_pointer(pointer).get_array();
             if (array.error()) {
                 return std::make_pair(false, false);
             }
             std::unordered_set<int> tmp_elements_index(elements_index);
             for (auto&& it : array) {
-                int i = -1;
-                for (auto& element : elements) {
-                    i++;
-                    switch (element.val_case()) {
-                        case proto::plan::GenericValue::kBoolVal: {
-                            auto val = it.template get<bool>();
-                            if (val.error()) {
-                                continue;
-                            }
-                            if (val.value() == element.bool_val()) {
-                                tmp_elements_index.erase(i);
-                            }
-                            break;
-                        }
-                        case proto::plan::GenericValue::kInt64Val: {
-                            auto val = it.template get<int64_t>();
-                            if (val.error()) {
-                                auto double_val = it.template get<double>();
-                                if (!double_val.error() &&
-                                    double_val.value() == element.int64_val()) {
-                                    tmp_elements_index.erase(i);
-                                }
-                                continue;
-                            }
-                            if (val.value() == element.int64_val()) {
-                                tmp_elements_index.erase(i);
-                            }
-                            break;
-                        }
-                        case proto::plan::GenericValue::kFloatVal: {
-                            auto val = it.template get<double>();
-                            if (val.error()) {
-                                continue;
-                            }
-                            if (val.value() == element.float_val()) {
-                                tmp_elements_index.erase(i);
-                            }
-                            break;
-                        }
-                        case proto::plan::GenericValue::kStringVal: {
-                            auto val = it.template get<std::string_view>();
-                            if (val.error()) {
-                                continue;
-                            }
-                            if (val.value() == element.string_val()) {
-                                tmp_elements_index.erase(i);
-                            }
-                            break;
-                        }
-                        case proto::plan::GenericValue::kArrayVal: {
-                            auto val = it.get_array();
-                            if (val.error()) {
-                                continue;
-                            }
-                            if (CompareTwoJsonArray(val, element.array_val())) {
-                                tmp_elements_index.erase(i);
-                            }
-                            break;
-                        }
-                        default:
-                            ThrowInfo(UnexpectedError,
-                                      "unsupported data type {}",
-                                      element.val_case());
-                    }
-                    if (tmp_elements_index.size() == 0) {
-                        return std::make_pair(true, true);
-                    }
-                }
-                if (tmp_elements_index.size() == 0) {
+                VisitMatchingJsonCandidates(
+                    it, elements, [&](size_t matched_index) {
+                        tmp_elements_index.erase(
+                            static_cast<int>(matched_index));
+                        return tmp_elements_index.empty();
+                    });
+                if (tmp_elements_index.empty()) {
                     return std::make_pair(true, true);
                 }
             }
@@ -2055,75 +2089,19 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffType(EvalCtx& context) {
         }
         auto executor = [&](const size_t i) {
             auto& json = data[i];
-            auto doc = json.dom_doc();
+            auto doc = json.doc();
             auto array = doc.at_pointer(pointer).get_array();
             if (array.error()) {
                 return std::make_pair(false, false);
             }
-            // Note: array can only be iterated once
             for (auto&& it : array) {
-                for (auto const& element : elements) {
-                    switch (element.val_case()) {
-                        case proto::plan::GenericValue::kBoolVal: {
-                            auto val = it.template get<bool>();
-                            if (val.error()) {
-                                continue;
-                            }
-                            if (val.value() == element.bool_val()) {
-                                return std::make_pair(true, true);
-                            }
-                            break;
-                        }
-                        case proto::plan::GenericValue::kInt64Val: {
-                            auto val = it.template get<int64_t>();
-                            if (val.error()) {
-                                auto double_val = it.template get<double>();
-                                if (!double_val.error() &&
-                                    double_val.value() == element.int64_val()) {
-                                    return std::make_pair(true, true);
-                                }
-                                continue;
-                            }
-                            if (val.value() == element.int64_val()) {
-                                return std::make_pair(true, true);
-                            }
-                            break;
-                        }
-                        case proto::plan::GenericValue::kFloatVal: {
-                            auto val = it.template get<double>();
-                            if (val.error()) {
-                                continue;
-                            }
-                            if (val.value() == element.float_val()) {
-                                return std::make_pair(true, true);
-                            }
-                            break;
-                        }
-                        case proto::plan::GenericValue::kStringVal: {
-                            auto val = it.template get<std::string_view>();
-                            if (val.error()) {
-                                continue;
-                            }
-                            if (val.value() == element.string_val()) {
-                                return std::make_pair(true, true);
-                            }
-                            break;
-                        }
-                        case proto::plan::GenericValue::kArrayVal: {
-                            auto val = it.get_array();
-                            if (val.error()) {
-                                continue;
-                            }
-                            if (CompareTwoJsonArray(val, element.array_val())) {
-                                return std::make_pair(true, true);
-                            }
-                            break;
-                        }
-                        default:
-                            ThrowInfo(UnexpectedError,
-                                      "unsupported data type {}",
-                                      element.val_case());
-                    }
+                bool matched = false;
+                VisitMatchingJsonCandidates(it, elements, [&](size_t) {
+                    matched = true;
+                    return true;
+                });
+                if (matched) {
+                    return std::make_pair(true, true);
                 }
             }
             return std::make_pair(true, false);

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -852,6 +852,17 @@ PhyTermFilterExpr::ExecTermJsonFieldInVariable(EvalCtx& context) {
                 return std::make_pair(
                     true,
                     std::floor(dval) == dval && terms->In(ValueType(dval)));
+            } else if constexpr (std::is_same_v<GetType, double>) {
+                // Parse the complete number token before converting it to a
+                // double. Json::at<double>() accepts integers outside the
+                // uint64_t domain by approximation, while JSON stats treats
+                // the same token as NUMBER_ERROR.
+                auto x_num = data[i].at_numeric(pointer);
+                if (x_num.error()) {
+                    return std::make_pair(false, false);
+                }
+                return std::make_pair(
+                    true, terms->In(ValueType(x_num.value().as_double())));
             } else {
                 auto x = data[i].template at<GetType>(pointer);
                 if (x.error()) {

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -879,10 +879,10 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
     auto op_type = expr_->op_type_;
     auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
 
-// For int64_t GetType, uses at_numeric() (get_number()) to extract any JSON
-// number in a single parse.  Branches on actual type to preserve int64
-// precision; uint64 and double values fall back to double comparison,
-// consistent with the Tantivy index and JSON-stats paths.
+// For numeric GetType, uses at_numeric() (get_number()) to validate the whole
+// JSON number token before comparison.  The int64_t branch preserves integer
+// precision; the double branch rejects NUMBER_ERROR instead of approximating
+// an integer outside the uint64_t domain via Json::at<double>().
 // - 'cmp' must reference 'value' (auto-typed as int64_t or double).
 // Missing path and type mismatch are UNKNOWN/NULL under JSON 3VL semantics.
 #define UnaryRangeJSONCompare(cmp)                                     \
@@ -903,6 +903,14 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                                  : n.get_double();                     \
                 res[i] = (cmp);                                        \
             }                                                          \
+        } else if constexpr (std::is_same_v<GetType, double>) {        \
+            auto x_num = data[offset].at_numeric(pointer);             \
+            if (x_num.error()) {                                       \
+                res[i] = valid_res[i] = false;                         \
+                break;                                                 \
+            }                                                          \
+            auto value = x_num.value().as_double();                    \
+            res[i] = (cmp);                                            \
         } else {                                                       \
             auto x = data[offset].template at<GetType>(pointer);       \
             if (x.error()) {                                           \

--- a/internal/core/src/index/JsonFlatIndex.cpp
+++ b/internal/core/src/index/JsonFlatIndex.cpp
@@ -42,6 +42,13 @@ JsonFlatIndex::build_index_for_json(
                 continue;
             }
             auto json = static_cast<const Json*>(data->RawValue(i));
+            // JsonFlatIndex has no per-row coverage bitmap or raw-data merge
+            // path. Keep this all-or-nothing validation until both exist:
+            // replacing an unindexable row with an empty Tantivy document
+            // would make EXISTS false and silently discard indexable sibling
+            // keys from that row.
+            // TODO: persist row coverage and merge uncovered rows from raw JSON
+            // in term/range/EXISTS executors before allowing per-row skips.
             auto exists = path_exists(json->dom_doc(), tokens);
             if (!exists || !json->exist(nested_path_)) {
                 wrapper_->add_json_array_data(nullptr, 0, offset++);

--- a/internal/core/src/index/JsonFlatIndexTest.cpp
+++ b/internal/core/src/index/JsonFlatIndexTest.cpp
@@ -137,6 +137,19 @@ BuildInMemoryJsonFlatIndex(const std::vector<std::string>& json_data) {
     return json_index;
 }
 
+TEST(JsonFlatIndexSafetyTest, RejectsUncoveredRowInsteadOfPublishingPartial) {
+    // serde_json/Tantivy cannot represent 1e400. Until JsonFlatIndex persists
+    // row coverage and query executors merge uncovered rows from raw JSON, the
+    // only safe behavior is to reject the whole build: an empty placeholder
+    // document would lose both /bad existence and the indexable /sibling key.
+    EXPECT_THROW(BuildInMemoryJsonFlatIndex({
+                     R"({"ok": 1})",
+                     R"({"bad": 1e400, "sibling": "must-not-be-lost"})",
+                     R"({"ok": 2})",
+                 }),
+                 std::exception);
+}
+
 class JsonFlatIndexTest : public ::testing::Test {
  protected:
     void

--- a/internal/core/src/index/JsonIndexBuilder.cpp
+++ b/internal/core/src/index/JsonIndexBuilder.cpp
@@ -22,11 +22,64 @@
 #include "folly/FBVector.h"
 #include "index/JsonIndexBuilder.h"
 #include "pb/schema.pb.h"
-#include "simdjson/dom/array.h"
-#include "simdjson/dom/element.h"
 #include "simdjson/error.h"
 
 namespace milvus::index {
+
+namespace {
+
+enum class JsonPathPresence {
+    Missing,
+    Present,
+    PresentButInvalid,
+};
+
+struct JsonPathPresenceResult {
+    JsonPathPresence presence;
+    simdjson::error_code error;
+};
+
+// Probe path presence without materializing a DOM value. In particular,
+// ondemand::value::type() can identify an out-of-range JSON number as a number
+// without converting it to double; the conversion error is handled later as an
+// invalid indexed value while the path remains present for EXISTS.
+JsonPathPresenceResult
+GetJsonPathPresence(const Json& json, const std::string& nested_path) {
+    auto type = json.type(nested_path);
+    auto error = type.error();
+    if (error == simdjson::SUCCESS) {
+        return {json.exist(nested_path) ? JsonPathPresence::Present
+                                        : JsonPathPresence::Missing,
+                simdjson::SUCCESS};
+    }
+
+    // A path through a scalar, an absent object key, or an out-of-range array
+    // element is not present. Numeric parse/conversion failures still describe
+    // a present value; keep it out of the typed value index without marking the
+    // path as non-existent.
+    if (error == simdjson::NO_SUCH_FIELD ||
+        error == simdjson::INDEX_OUT_OF_BOUNDS ||
+        error == simdjson::INCORRECT_TYPE ||
+        error == simdjson::SCALAR_DOCUMENT_AS_VALUE ||
+        error == simdjson::INVALID_JSON_POINTER) {
+        return {JsonPathPresence::Missing, error};
+    }
+    if (error == simdjson::NUMBER_ERROR || error == simdjson::BIGINT_ERROR ||
+        error == simdjson::NUMBER_OUT_OF_RANGE) {
+        return {JsonPathPresence::PresentButInvalid, error};
+    }
+
+    // Preserve the previous all-or-nothing behavior for malformed JSON and
+    // invalid index paths. Treating an unclassifiable row as either present or
+    // absent would publish a semantically incomplete index.
+    AssertInfo(false,
+               "failed to inspect JSON path {}: {}",
+               nested_path,
+               simdjson::error_message(error));
+    return {JsonPathPresence::PresentButInvalid, error};  // unreachable
+}
+
+}  // namespace
 
 template <typename T>
 void
@@ -44,7 +97,9 @@ ProcessJsonFieldData(
     using SIMDJSON_T =
         std::conditional_t<std::is_same_v<T, std::string>, std::string_view, T>;
 
-    auto tokens = parse_json_pointer(nested_path);
+    // Preserve the previous up-front validation of the configured pointer, but
+    // do not materialize each row as a DOM document merely to test presence.
+    (void)parse_json_pointer(nested_path);
 
     bool is_array = cast_type.data_type() == JsonCastType::DataType::ARRAY;
 
@@ -60,18 +115,23 @@ ProcessJsonFieldData(
                 continue;
             }
 
-            auto exists = path_exists(json_column->dom_doc(), tokens);
-            if (!exists || !json_column->exist(nested_path)) {
+            auto presence = GetJsonPathPresence(*json_column, nested_path);
+            if (presence.presence == JsonPathPresence::Missing) {
                 error_recorder(
                     *json_column, nested_path, simdjson::NO_SUCH_FIELD);
                 non_exist_adder(offset);
                 data_adder(nullptr, 0, offset++);
                 continue;
             }
+            if (presence.presence == JsonPathPresence::PresentButInvalid) {
+                error_recorder(*json_column, nested_path, presence.error);
+                data_adder(nullptr, 0, offset++);
+                continue;
+            }
 
             values.clear();
             if (is_array) {
-                auto doc = json_column->dom_doc();
+                auto doc = json_column->doc();
                 auto array_res = doc.at_pointer(nested_path).get_array();
                 if (array_res.error() != simdjson::SUCCESS) {
                     error_recorder(
@@ -79,10 +139,16 @@ ProcessJsonFieldData(
                 } else {
                     auto array_values = array_res.value();
                     for (auto value : array_values) {
-                        auto val = value.template get<SIMDJSON_T>();
-
-                        if (val.error() == simdjson::SUCCESS) {
-                            values.push_back(static_cast<T>(val.value()));
+                        if constexpr (std::is_same_v<T, double>) {
+                            auto val = value.get_number();
+                            if (val.error() == simdjson::SUCCESS) {
+                                values.push_back(val.value().as_double());
+                            }
+                        } else {
+                            auto val = value.template get<SIMDJSON_T>();
+                            if (val.error() == simdjson::SUCCESS) {
+                                values.push_back(static_cast<T>(val.value()));
+                            }
                         }
                     }
                 }
@@ -92,6 +158,13 @@ ProcessJsonFieldData(
                         cast_function, *json_column, nested_path);
                     if (res.has_value()) {
                         values.push_back(res.value());
+                    }
+                } else if constexpr (std::is_same_v<T, double>) {
+                    auto res = json_column->at_numeric(nested_path);
+                    if (res.error() != simdjson::SUCCESS) {
+                        error_recorder(*json_column, nested_path, res.error());
+                    } else {
+                        values.push_back(res.value().as_double());
                     }
                 } else {
                     value_result<SIMDJSON_T> res =

--- a/internal/core/src/index/JsonPathIndexTest.cpp
+++ b/internal/core/src/index/JsonPathIndexTest.cpp
@@ -19,6 +19,7 @@
 
 #include "common/FieldData.h"
 #include "common/Json.h"
+#include "common/JsonCastFunction.h"
 #include "common/JsonCastType.h"
 #include "common/Schema.h"
 #include "common/Types.h"
@@ -107,6 +108,7 @@ TEST(JsonPathIndexTest, ConvertDouble_PathNotExist) {
         R"({"b": 1})",    // path /a doesn't exist
         R"({"a": 2.0})",  // exists
         R"(100)",         // not an object, /a doesn't exist
+        R"([1, 2])",      // non-numeric array path doesn't exist
     });
     auto schema = MakeJsonSchema();
     auto result = ConvertJsonToTypedFieldData<double>(
@@ -117,15 +119,17 @@ TEST(JsonPathIndexTest, ConvertDouble_PathNotExist) {
         JsonCastFunction::FromString("unknown"));
 
     auto& fd = result.field_data;
-    EXPECT_EQ(fd->get_num_rows(), 3);
+    EXPECT_EQ(fd->get_num_rows(), 4);
     EXPECT_FALSE(fd->is_valid(0));  // path not exist
     EXPECT_TRUE(fd->is_valid(1));   // valid
     EXPECT_FALSE(fd->is_valid(2));  // path not exist
+    EXPECT_FALSE(fd->is_valid(3));  // path not exist
 
-    // non_exist_offsets should contain 0 and 2
-    ASSERT_EQ(result.non_exist_offsets.size(), 2);
+    // non_exist_offsets should contain 0, 2, and 3
+    ASSERT_EQ(result.non_exist_offsets.size(), 3);
     EXPECT_EQ(result.non_exist_offsets[0], 0);
     EXPECT_EQ(result.non_exist_offsets[1], 2);
+    EXPECT_EQ(result.non_exist_offsets[2], 3);
 }
 
 TEST(JsonPathIndexTest, ConvertDouble_PathExistsButCastFails) {
@@ -152,6 +156,90 @@ TEST(JsonPathIndexTest, ConvertDouble_PathExistsButCastFails) {
 
     // Key: non_exist_offsets should be EMPTY because path exists in all rows
     EXPECT_TRUE(result.non_exist_offsets.empty());
+}
+
+TEST(JsonPathIndexTest, ConvertDouble_NumberErrorKeepsPathPresent) {
+    auto json_fd = MakeJsonFieldData({
+        R"({"a": -1.48e-309})",             // representable subnormal
+        R"({"a": 1e-400})",                 // underflows to zero
+        R"({"a": 1e400})",                  // out of double range
+        R"({"sibling": 1e400, "a": 2.5})",  // unrelated bad number
+        R"({"a": 18446744073709551616})",   // larger than uint64_t
+        R"({"b": 1})",                      // path missing
+    });
+    auto schema = MakeJsonSchema();
+    auto result = ConvertJsonToTypedFieldData<double>(
+        {json_fd},
+        schema,
+        "/a",
+        JsonCastType::FromString("DOUBLE"),
+        JsonCastFunction::FromString("unknown"));
+
+    auto& fd = result.field_data;
+    ASSERT_EQ(fd->get_num_rows(), 6);
+    EXPECT_TRUE(fd->is_valid(0));
+    EXPECT_TRUE(fd->is_valid(1));
+    EXPECT_FALSE(fd->is_valid(2));
+    EXPECT_TRUE(fd->is_valid(3));
+    EXPECT_FALSE(fd->is_valid(4));
+    EXPECT_FALSE(fd->is_valid(5));
+
+    EXPECT_DOUBLE_EQ(*static_cast<const double*>(fd->RawValue(0)), -1.48e-309);
+    EXPECT_EQ(*static_cast<const double*>(fd->RawValue(1)), 0.0);
+    EXPECT_DOUBLE_EQ(*static_cast<const double*>(fd->RawValue(3)), 2.5);
+
+    // Numeric parse/conversion errors are invalid values, not missing paths.
+    // Only the row that truly lacks /a is excluded from EXISTS.
+    ASSERT_EQ(result.non_exist_offsets.size(), 1);
+    EXPECT_EQ(result.non_exist_offsets[0], 5);
+}
+
+TEST(JsonPathIndexTest, ConvertDouble_StringCastUsesSimdjsonNumberSemantics) {
+    auto json_fd = MakeJsonFieldData({
+        R"({"a": "-1.48e-309"})",            // representable subnormal
+        R"({"a": "1e-400"})",                // underflows to zero
+        R"({"a": "1e400"})",                 // overflows double
+        R"({"a": "1.5junk"})",               // not a complete number token
+        R"({"a": "2.5"})",                   // ordinary finite value
+        R"({"a": "18446744073709551616"})",  // larger than uint64_t
+        R"({"a": 18446744073709551616})",    // same numeric JSON value
+        R"({"b": 1})",                       // path missing
+    });
+    auto schema = MakeJsonSchema();
+    auto result = ConvertJsonToTypedFieldData<double>(
+        {json_fd},
+        schema,
+        "/a",
+        JsonCastType::FromString("DOUBLE"),
+        JsonCastFunction::FromString("STRING_TO_DOUBLE"));
+
+    auto& fd = result.field_data;
+    ASSERT_EQ(fd->get_num_rows(), 8);
+    EXPECT_TRUE(fd->is_valid(0));
+    EXPECT_TRUE(fd->is_valid(1));
+    EXPECT_FALSE(fd->is_valid(2));
+    EXPECT_FALSE(fd->is_valid(3));
+    EXPECT_TRUE(fd->is_valid(4));
+    EXPECT_FALSE(fd->is_valid(5));
+    EXPECT_FALSE(fd->is_valid(6));
+    EXPECT_FALSE(fd->is_valid(7));
+
+    EXPECT_DOUBLE_EQ(*static_cast<const double*>(fd->RawValue(0)), -1.48e-309);
+    EXPECT_EQ(*static_cast<const double*>(fd->RawValue(1)), 0.0);
+    EXPECT_DOUBLE_EQ(*static_cast<const double*>(fd->RawValue(4)), 2.5);
+
+    // Invalid numeric values still have a present /a path. Only the genuinely
+    // missing row is false for EXISTS.
+    ASSERT_EQ(result.non_exist_offsets.size(), 1);
+    EXPECT_EQ(result.non_exist_offsets[0], 7);
+
+    auto cast = JsonCastFunction::FromString("STRING_TO_DOUBLE");
+    Json out_of_range(simdjson::padded_string(std::string(R"({"a": 1e400})")));
+    EXPECT_NO_THROW({
+        auto value =
+            JsonCastFunction::CastJsonValue<double>(cast, out_of_range, "/a");
+        EXPECT_FALSE(value.has_value());
+    });
 }
 
 TEST(JsonPathIndexTest, ConvertDouble_MixedRows) {
@@ -380,6 +468,45 @@ TEST(JsonPathIndexTest, SortDouble_ComparisonUnknowns) {
 
     idx.BuildWithFieldData({json_fd});
     AssertDoubleComparisonUnknowns(idx);
+}
+
+TEST(JsonPathIndexTest, SortDouble_NumberErrorIsUnknownButExists) {
+    auto json_fd = MakeJsonFieldData({
+        R"({"a": 1.0})",
+        R"({"a": 1e400})",
+        R"({"b": 2.0})",
+        R"({"a": 3.0})",
+    });
+    auto schema = MakeJsonSchema();
+    auto ctx = MakeTestContext();
+
+    JsonScalarIndexWrapper<double, ScalarIndexSort<double>> idx(
+        JsonCastType::FromString("DOUBLE"),
+        "/a",
+        JsonCastFunction::FromString("unknown"),
+        schema,
+        ctx);
+    idx.BuildWithFieldData({json_fd});
+
+    auto valid = idx.IsNotNull();
+    ASSERT_EQ(valid.size(), 4);
+    EXPECT_TRUE(valid[0]);
+    EXPECT_FALSE(valid[1]);
+    EXPECT_FALSE(valid[2]);
+    EXPECT_TRUE(valid[3]);
+
+    auto exists = idx.Exists();
+    ASSERT_EQ(exists.size(), 4);
+    EXPECT_TRUE(exists[0]);
+    EXPECT_TRUE(exists[1]);
+    EXPECT_FALSE(exists[2]);
+    EXPECT_TRUE(exists[3]);
+
+    auto range = idx.Range(0.0, OpType::GreaterThan);
+    EXPECT_TRUE(range[0]);
+    EXPECT_FALSE(range[1]);
+    EXPECT_FALSE(range[2]);
+    EXPECT_TRUE(range[3]);
 }
 
 TEST(JsonPathIndexTest, InvertedDouble_ComparisonUnknowns) {

--- a/internal/core/src/index/json_stats/JsonKeyStats.cpp
+++ b/internal/core/src/index/json_stats/JsonKeyStats.cpp
@@ -17,6 +17,7 @@
 #include <nlohmann/json.hpp>
 #include <string.h>
 #include <chrono>
+#include <cctype>
 #include <cstdint>
 #include <exception>
 #include <filesystem>
@@ -38,7 +39,6 @@
 #include "common/GroupChunk.h"
 #include "common/Json.h"
 #include "common/Tracer.h"
-#include "common/jsmn.h"
 #include "fmt/core.h"
 #include "index/Utils.h"
 #include "index/json_stats/JsonKeyStats.h"
@@ -96,6 +96,15 @@ GetJsonStatsReadProperties() {
 std::string
 NoopParquetKeyRetriever(const std::string&) {
     return {};
+}
+
+std::string_view
+TrimJsonToken(std::string_view token) {
+    while (!token.empty() &&
+           std::isspace(static_cast<unsigned char>(token.back()))) {
+        token.remove_suffix(1);
+    }
+    return token;
 }
 
 JsonStatsParquetMetadata
@@ -256,115 +265,122 @@ JsonKeyStats::AddKeyStatsInfo(const std::vector<std::string>& paths,
     // TODO: update min and max value
 }
 
-void
-JsonKeyStats::TraverseJsonForStats(const char* json,
-                                   jsmntok* tokens,
-                                   int& index,
-                                   std::vector<std::string>& path,
-                                   std::map<JsonKey, KeyStatsInfo>& infos) {
-    jsmntok current = tokens[0];
-    AssertInfo(current.type != JSMN_UNDEFINED,
-               "current token type is undefined for json: {}.",
-               json);
-    if (current.type == JSMN_OBJECT) {
-        if (!path.empty()) {
-            AddKeyStatsInfo(path, JSONType::OBJECT, nullptr, infos);
-        }
-        int j = 1;
-        for (int i = 0; i < current.size; i++) {
-            AssertInfo(tokens[j].type == JSMN_STRING && tokens[j].size != 0,
-                       "current token type is not string for json: {} at "
-                       "type: {}, size: {}, value: {}",
-                       json,
-                       int(tokens[j].type),
-                       tokens[j].size,
-                       std::string(json + tokens[j].start,
-                                   tokens[j].end - tokens[j].start));
-            std::string key(json + tokens[j].start,
-                            tokens[j].end - tokens[j].start);
-            path.push_back(key);
-            j++;
-            int consumed = 0;
-            TraverseJsonForStats(json, tokens + j, consumed, path, infos);
-            path.pop_back();
-            j += consumed;
-        }
-        index = j;
-    } else if (current.type == JSMN_PRIMITIVE) {
-        std::string value(json + current.start, current.end - current.start);
-        auto type = getType(value);
+std::pair<JSONType, JsonStatsValue>
+JsonKeyStats::ParsePrimitiveValue(simdjson::ondemand::value value) {
+    auto type_result = value.type();
+    AssertInfo(type_result.error() == simdjson::SUCCESS,
+               "failed to read json value type: {}",
+               simdjson::error_message(type_result.error()));
 
-        if (type == JSONType::INT64) {
-            AddKeyStatsInfo(path, JSONType::INT64, nullptr, infos);
-        } else if (type == JSONType::FLOAT || type == JSONType::DOUBLE) {
-            AddKeyStatsInfo(path, JSONType::DOUBLE, nullptr, infos);
-        } else if (type == JSONType::BOOL) {
-            AddKeyStatsInfo(path, JSONType::BOOL, nullptr, infos);
-        } else if (type == JSONType::NONE) {
-            AddKeyStatsInfo(path, JSONType::NONE, nullptr, infos);
-        } else {
-            ThrowInfo(ErrorCode::UnexpectedError,
-                      "unsupported json type: {} for build json stats",
-                      type);
-        }
-        index++;
-    } else if (current.type == JSMN_ARRAY) {
-        AddKeyStatsInfo(path, JSONType::ARRAY, nullptr, infos);
-        // skip array parse
-        int count = current.size;
-        int j = 1;
-        while (count > 0) {
-            count--;
-            if (tokens[j].size != 0) {
-                count += tokens[j].size;
+    switch (type_result.value()) {
+        case simdjson::ondemand::json_type::number: {
+            auto raw = TrimJsonToken(value.raw_json_token());
+            JsonStatsValue stats_value{std::string(raw)};
+            // Use the same get_number() contract as raw JSON predicates.  In
+            // particular, get_double() alone accepts integers above uint64
+            // (for example 18446744073709551616), while get_number() rejects
+            // them; indexing such a value as a valid double would make stats
+            // disagree with the raw path.
+            auto number_result = value.get_number();
+            if (number_result.error() != simdjson::SUCCESS) {
+                stats_value.state = JsonStatsValueState::INVALID_NUMBER;
+                return {JSONType::DOUBLE, std::move(stats_value)};
             }
-            j++;
+
+            auto number = number_result.value();
+            if (number.is_int64()) {
+                return {JSONType::INT64, std::move(stats_value)};
+            }
+
+            stats_value.double_value = number.as_double();
+            return {JSONType::DOUBLE, std::move(stats_value)};
         }
-        index = j;
-    } else if (current.type == JSMN_STRING) {
-        Assert(current.size == 0);
-        AddKeyStatsInfo(path, JSONType::STRING, nullptr, infos);
-        index++;
+        case simdjson::ondemand::json_type::boolean: {
+            auto boolean = value.get_bool();
+            AssertInfo(boolean.error() == simdjson::SUCCESS,
+                       "failed to read json boolean: {}",
+                       simdjson::error_message(boolean.error()));
+            return {JSONType::BOOL,
+                    JsonStatsValue{boolean.value() ? "true" : "false"}};
+        }
+        case simdjson::ondemand::json_type::null:
+            return {JSONType::NONE, JsonStatsValue{"null"}};
+        case simdjson::ondemand::json_type::string: {
+            auto string = value.get_string();
+            AssertInfo(string.error() == simdjson::SUCCESS,
+                       "failed to read json string: {}",
+                       simdjson::error_message(string.error()));
+            return {JSONType::STRING,
+                    JsonStatsValue{std::string(string.value())}};
+        }
+        default:
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      "json value is not a primitive type");
     }
 }
 
 void
-JsonKeyStats::CollectSingleJsonStatsInfo(
-    const char* json_str, std::map<JsonKey, KeyStatsInfo>& infos) {
-    jsmn_parser parser;
-    jsmn_init(&parser);
+JsonKeyStats::TraverseJsonForStats(simdjson::ondemand::value value,
+                                   std::vector<std::string>& path,
+                                   std::map<JsonKey, KeyStatsInfo>& infos) {
+    auto type_result = value.type();
+    AssertInfo(type_result.error() == simdjson::SUCCESS,
+               "failed to read json value type: {}",
+               simdjson::error_message(type_result.error()));
 
-    int num_tokens = 0;
-    int token_capacity = 16;
-    std::vector<jsmntok_t> tokens(token_capacity);
-
-    while (1) {
-        int r = jsmn_parse(
-            &parser, json_str, strlen(json_str), tokens.data(), token_capacity);
-        if (r < 0) {
-            if (r == JSMN_ERROR_NOMEM) {
-                // Reallocate tokens array if not enough space
-                token_capacity *= 2;
-                tokens.resize(token_capacity);
-                continue;
-            } else {
-                ThrowInfo(ErrorCode::UnexpectedError,
-                          "Failed to parse Json: {}, error: {}",
-                          json_str,
-                          int(r));
-            }
+    if (type_result.value() == simdjson::ondemand::json_type::object) {
+        if (!path.empty()) {
+            AddKeyStatsInfo(path, JSONType::OBJECT, nullptr, infos);
         }
-        num_tokens = r;
-        break;
-    }
-
-    if (num_tokens == 0) {
+        auto object = value.get_object();
+        AssertInfo(object.error() == simdjson::SUCCESS,
+                   "failed to read json object: {}",
+                   simdjson::error_message(object.error()));
+        for (auto field : object.value()) {
+            auto key = field.unescaped_key();
+            AssertInfo(key.error() == simdjson::SUCCESS,
+                       "failed to read json object key: {}",
+                       simdjson::error_message(key.error()));
+            path.emplace_back(key.value());
+            auto child = field.value();
+            AssertInfo(child.error() == simdjson::SUCCESS,
+                       "failed to read json object value: {}",
+                       simdjson::error_message(child.error()));
+            TraverseJsonForStats(child.value(), path, infos);
+            path.pop_back();
+        }
         return;
     }
 
-    int index = 0;
+    if (type_result.value() == simdjson::ondemand::json_type::array) {
+        auto raw = value.raw_json();
+        AssertInfo(raw.error() == simdjson::SUCCESS,
+                   "failed to read json array: {}",
+                   simdjson::error_message(raw.error()));
+        AddKeyStatsInfo(path, JSONType::ARRAY, nullptr, infos);
+        return;
+    }
+
+    auto type = ParsePrimitiveValue(value).first;
+    AddKeyStatsInfo(path, type, nullptr, infos);
+}
+
+void
+JsonKeyStats::CollectSingleJsonStatsInfo(
+    const milvus::Json& json, std::map<JsonKey, KeyStatsInfo>& infos) {
+    if (json.data().empty()) {
+        return;
+    }
+    auto document = json.doc();
+    AssertInfo(document.error() == simdjson::SUCCESS,
+               "failed to parse json for stats: {}",
+               simdjson::error_message(document.error()));
+    auto root = document.get_value();
+    AssertInfo(root.error() == simdjson::SUCCESS,
+               "failed to read json root for stats: {}",
+               simdjson::error_message(root.error()));
     std::vector<std::string> paths;
-    TraverseJsonForStats(json_str, tokens.data(), index, paths, infos);
+    TraverseJsonForStats(root.value(), paths, infos);
 }
 
 std::map<JsonKey, KeyStatsInfo>
@@ -378,10 +394,9 @@ JsonKeyStats::CollectKeyInfo(const std::vector<FieldDataPtr>& field_datas,
             if ((nullable || data->IsNullable()) && !data->is_valid(i)) {
                 continue;
             }
-            auto json_str = static_cast<const milvus::Json*>(data->RawValue(i))
-                                ->data()
-                                .data();
-            CollectSingleJsonStatsInfo(json_str, infos);
+            const auto& json =
+                *static_cast<const milvus::Json*>(data->RawValue(i));
+            CollectSingleJsonStatsInfo(json, infos);
         }
         num_rows += n;
     }
@@ -494,107 +509,63 @@ JsonKeyStats::ClassifyJsonKeyLayoutType(
 void
 JsonKeyStats::AddKeyStats(const std::vector<std::string>& path,
                           JSONType type,
-                          const std::string& value,
-                          std::map<JsonKey, std::string>& values) {
+                          JsonStatsValue value,
+                          std::map<JsonKey, JsonStatsValue>& values) {
     auto path_str = JsonPointer(path);
     auto key = JsonKey(path_str, type);
-    values[key] = value;
+    values[key] = std::move(value);
 }
 
 void
 JsonKeyStats::TraverseJsonForBuildStats(
-    const char* json,
-    jsmntok* tokens,
-    int& index,
+    simdjson::ondemand::value value,
     std::vector<std::string>& path,
-    std::map<JsonKey, std::string>& values) {
-    jsmntok current = tokens[0];
-    AssertInfo(current.type != JSMN_UNDEFINED,
-               "current token type is undefined for json: {}",
-               json);
-    if (current.type == JSMN_OBJECT) {
-        if (!path.empty() && current.size == 0) {
-            AddKeyStats(
-                path,
-                JSONType::OBJECT,
-                std::string(json + current.start, current.end - current.start),
-                values);
-            index++;
-            return;
-        }
-        int j = 1;
-        for (int i = 0; i < current.size; i++) {
-            AssertInfo(tokens[j].type == JSMN_STRING && tokens[j].size != 0,
-                       "current token type is not string for json: {} at "
-                       "type: {}, size: {}, value: {}",
-                       json,
-                       int(tokens[j].type),
-                       tokens[j].size,
-                       std::string(json + tokens[j].start,
-                                   tokens[j].end - tokens[j].start));
+    std::map<JsonKey, JsonStatsValue>& values) {
+    auto type_result = value.type();
+    AssertInfo(type_result.error() == simdjson::SUCCESS,
+               "failed to read json value type: {}",
+               simdjson::error_message(type_result.error()));
 
-            std::string key(json + tokens[j].start,
-                            tokens[j].end - tokens[j].start);
-            path.push_back(key);
-            j++;
-            int consumed = 0;
-            TraverseJsonForBuildStats(json, tokens + j, consumed, path, values);
+    if (type_result.value() == simdjson::ondemand::json_type::object) {
+        auto object = value.get_object();
+        AssertInfo(object.error() == simdjson::SUCCESS,
+                   "failed to read json object: {}",
+                   simdjson::error_message(object.error()));
+        bool empty = true;
+        for (auto field : object.value()) {
+            empty = false;
+            auto key = field.unescaped_key();
+            AssertInfo(key.error() == simdjson::SUCCESS,
+                       "failed to read json object key: {}",
+                       simdjson::error_message(key.error()));
+            path.emplace_back(key.value());
+            auto child = field.value();
+            AssertInfo(child.error() == simdjson::SUCCESS,
+                       "failed to read json object value: {}",
+                       simdjson::error_message(child.error()));
+            TraverseJsonForBuildStats(child.value(), path, values);
             path.pop_back();
-            j += consumed;
         }
-        index = j;
-    } else if (current.type == JSMN_PRIMITIVE) {
-        std::string value(json + current.start, current.end - current.start);
-        JSONType type;
-        try {
-            type = getType(value);
-        } catch (const std::exception& e) {
-            ThrowInfo(ErrorCode::UnexpectedError,
-                      "failed to get json type for value: {} with error: {}",
-                      value,
-                      e.what());
+        if (empty && !path.empty()) {
+            AddKeyStats(path, JSONType::OBJECT, JsonStatsValue{"{}"}, values);
         }
-
-        if (type == JSONType::INT64) {
-            AddKeyStats(path, JSONType::INT64, value, values);
-        } else if (type == JSONType::FLOAT || type == JSONType::DOUBLE) {
-            AddKeyStats(path, JSONType::DOUBLE, value, values);
-        } else if (type == JSONType::BOOL) {
-            AddKeyStats(path, JSONType::BOOL, value, values);
-        } else if (type == JSONType::NONE) {
-            AddKeyStats(path, JSONType::NONE, value, values);
-        } else {
-            ThrowInfo(ErrorCode::UnexpectedError,
-                      "unsupported json type: {} for build json stats",
-                      type);
-        }
-        index++;
-    } else if (current.type == JSMN_ARRAY) {
-        // Collect array as raw JSON string so it can be shredded into a dedicated column
-        AddKeyStats(
-            path,
-            JSONType::ARRAY,
-            std::string(json + current.start, current.end - current.start),
-            values);
-        // Skip array subtree
-        int count = current.size;
-        int j = 1;
-        while (count > 0) {
-            count--;
-            if (tokens[j].size != 0) {
-                count += tokens[j].size;
-            }
-            j++;
-        }
-        index = j;
-    } else if (current.type == JSMN_STRING) {
-        auto value =
-            std::string(json + current.start, current.end - current.start);
-        auto unescaped = UnescapeJsonString(value);
-        Assert(current.size == 0);
-        AddKeyStats(path, JSONType::STRING, unescaped, values);
-        index++;
+        return;
     }
+
+    if (type_result.value() == simdjson::ondemand::json_type::array) {
+        auto raw = value.raw_json();
+        AssertInfo(raw.error() == simdjson::SUCCESS,
+                   "failed to read json array: {}",
+                   simdjson::error_message(raw.error()));
+        AddKeyStats(path,
+                    JSONType::ARRAY,
+                    JsonStatsValue{std::string(raw.value())},
+                    values);
+        return;
+    }
+
+    auto [type, stats_value] = ParsePrimitiveValue(value);
+    AddKeyStats(path, type, std::move(stats_value), values);
 }
 
 void
@@ -612,65 +583,68 @@ JsonKeyStats::BuildKeyStatsForNullRow() {
 }
 
 void
-JsonKeyStats::BuildKeyStatsForRow(const char* json_str, uint32_t row_id) {
+JsonKeyStats::BuildKeyStatsForRow(const milvus::Json& json, uint32_t row_id) {
     LOG_TRACE("build key stats for row {} with json {} for segment {}",
               row_id,
-              json_str,
+              json.data(),
               segment_id_);
-    jsmn_parser parser;
-    jsmn_init(&parser);
-
-    int num_tokens = 0;
-    int token_capacity = 16;
-    std::vector<jsmntok_t> tokens(token_capacity);
-
-    while (1) {
-        int r = jsmn_parse(
-            &parser, json_str, strlen(json_str), tokens.data(), token_capacity);
-        if (r < 0) {
-            if (r == JSMN_ERROR_NOMEM) {
-                // Reallocate tokens array if not enough space
-                token_capacity *= 2;
-                tokens.resize(token_capacity);
-                continue;
-            } else {
-                ThrowInfo(ErrorCode::UnexpectedError,
-                          "Failed to parse Json: {}, error: {}",
-                          json_str,
-                          int(r));
-            }
-        }
-        num_tokens = r;
-        break;
-    }
-
-    if (num_tokens == 0) {
-        return;
-    }
-
-    int index = 0;
+    auto document = json.doc();
+    AssertInfo(document.error() == simdjson::SUCCESS,
+               "failed to parse json for stats: {}",
+               simdjson::error_message(document.error()));
+    auto root_value = document.get_value();
+    AssertInfo(root_value.error() == simdjson::SUCCESS,
+               "failed to read json root for stats: {}",
+               simdjson::error_message(root_value.error()));
     std::vector<std::string> paths;
-    std::map<JsonKey, std::string> values;
-    TraverseJsonForBuildStats(json_str, tokens.data(), index, paths, values);
+    std::map<JsonKey, JsonStatsValue> values;
+    TraverseJsonForBuildStats(root_value.value(), paths, values);
     DomNode root;
     std::set<JsonKey> hit_keys;
     for (const auto& [key, value] : values) {
         AssertInfo(key_types_.find(key) != key_types_.end(),
                    "key {} not found in key types",
                    key.key_);
-        if (key_types_[key] == JsonKeyLayoutType::SHARED) {
-            auto path_vec = ParseJsonPointerPath(key.key_);
-            BsonBuilder::AppendToDom(root, path_vec, value, key.type_);
-        } else {
-            if (key.type_ == JSONType::ARRAY) {
-                auto bson_bytes = BuildBsonArrayBytesFromJsonString(value);
+        auto path_vec = ParseJsonPointerPath(key.key_);
+        if (value.IsInvalidNumber()) {
+            BsonBuilder::AppendUndefinedToDom(root, path_vec);
+            if (key_types_[key] != JsonKeyLayoutType::SHARED) {
+                parquet_writer_->AppendNull(key.ToColumnName());
+            }
+        } else if (key.type_ == JSONType::ARRAY) {
+            auto bson_bytes =
+                BuildBsonArrayBytesFromJsonString(value.raw_value);
+            if (key_types_[key] == JsonKeyLayoutType::SHARED) {
+                BsonBuilder::AppendArrayToDom(
+                    root, path_vec, std::move(bson_bytes));
+            } else {
                 parquet_writer_->AppendValue(
                     key.ToColumnName(),
                     std::string(
                         reinterpret_cast<const char*>(bson_bytes.data()),
                         bson_bytes.size()));
+            }
+        } else if (key_types_[key] == JsonKeyLayoutType::SHARED) {
+            if (key.type_ == JSONType::DOUBLE) {
+                AssertInfo(value.double_value.has_value(),
+                           "parsed double is missing for key {}",
+                           key.key_);
+                BsonBuilder::AppendDoubleToDom(
+                    root, path_vec, value.double_value.value());
             } else {
-                parquet_writer_->AppendValue(key.ToColumnName(), value);
+                BsonBuilder::AppendToDom(
+                    root, path_vec, value.raw_value, key.type_);
+            }
+        } else {
+            if (key.type_ == JSONType::DOUBLE) {
+                AssertInfo(value.double_value.has_value(),
+                           "parsed double is missing for key {}",
+                           key.key_);
+                parquet_writer_->AppendDouble(key.ToColumnName(),
+                                              value.double_value.value());
+            } else {
+                parquet_writer_->AppendValue(key.ToColumnName(),
+                                             value.raw_value);
             }
         }
         hit_keys.insert(key);
@@ -715,17 +689,15 @@ JsonKeyStats::BuildKeyStats(const std::vector<FieldDataPtr>& field_datas,
             if ((nullable || data->IsNullable()) && !data->is_valid(i)) {
                 BuildKeyStatsForNullRow();
             } else {
-                auto json_str =
-                    static_cast<const milvus::Json*>(data->RawValue(i))
-                        ->data()
-                        .data();
+                const auto& json =
+                    *static_cast<const milvus::Json*>(data->RawValue(i));
 
                 // some situations, such as empty json string,
                 // should be handled as null row
-                if (strlen(json_str) == 0) {
+                if (json.data().empty()) {
                     BuildKeyStatsForNullRow();
                 } else {
-                    BuildKeyStatsForRow(json_str, row_id);
+                    BuildKeyStatsForRow(json, row_id);
                 }
             }
             row_id++;

--- a/internal/core/src/index/json_stats/JsonKeyStats.h
+++ b/internal/core/src/index/json_stats/JsonKeyStats.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <charconv>
 #include <folly/ExceptionWrapper.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -515,6 +516,18 @@ class JsonKeyStats : public ScalarIndex<std::string> {
         return str == "true" || str == "false";
     }
 
+    // JSON number sniffing helpers.
+    //
+    // These used to be implemented with std::stof/std::stod plus catch(...),
+    // but libstdc++ throws std::out_of_range for ANY ERANGE result of
+    // strtod/strtof, including underflow into the subnormal range (e.g.
+    // -1.48e-309, a perfectly valid double). Valid JSON numbers were then
+    // misclassified as UNKNOWN and poisoned the whole json key stats build.
+    // std::from_chars never throws and reports out-of-range values through
+    // std::errc::result_out_of_range instead.
+
+    // Strict: only a value fully representable in int64_t counts; anything
+    // else must fall through to the float/double checks.
     bool
     IsInt8(const std::string& str) {
         std::istringstream iss(str);
@@ -550,31 +563,32 @@ class JsonKeyStats : public ScalarIndex<std::string> {
 
     bool
     IsInt64(const std::string& str) {
-        std::istringstream iss(str);
         int64_t num;
-        iss >> num;
-
-        return !iss.fail() && iss.eof();
+        auto [ptr, ec] =
+            std::from_chars(str.data(), str.data() + str.size(), num);
+        return ptr == str.data() + str.size() && ec == std::errc();
     }
 
+    // Strict: values outside float's range fall through to the DOUBLE check
+    // so they keep full double precision in the shredding column type.
     bool
     IsFloat(const std::string& str) {
-        try {
-            std::stof(str);
-            return true;
-        } catch (...) {
-            return false;
-        }
+        float num;
+        auto [ptr, ec] =
+            std::from_chars(str.data(), str.data() + str.size(), num);
+        return ptr == str.data() + str.size() && ec == std::errc();
     }
 
+    // Lenient on range: a well-formed JSON number whose magnitude overflows
+    // or underflows double (subnormals such as 1e-309, or 1e400) is still a
+    // valid number and must classify as DOUBLE instead of UNKNOWN.
     bool
     IsDouble(const std::string& str) {
-        try {
-            std::stod(str);
-            return true;
-        } catch (...) {
-            return false;
-        }
+        double num;
+        auto [ptr, ec] =
+            std::from_chars(str.data(), str.data() + str.size(), num);
+        return ptr == str.data() + str.size() &&
+               (ec == std::errc() || ec == std::errc::result_out_of_range);
     }
 
     bool

--- a/internal/core/src/index/json_stats/JsonKeyStats.h
+++ b/internal/core/src/index/json_stats/JsonKeyStats.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <charconv>
 #include <folly/ExceptionWrapper.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -49,7 +48,6 @@
 #include "common/Types.h"
 #include "common/Utils.h"
 #include "common/bson_view.h"
-#include "common/jsmn.h"
 #include "common/protobuf_utils.h"
 #include "folly/FBVector.h"
 #include "glog/logging.h"
@@ -74,7 +72,25 @@ class CollectSingleJsonStatsInfoAccessor;
 class TraverseJsonForBuildStatsAccessor;
 class JsonStatsProjectionTestAccessor;
 
+namespace milvus {
+class Json;
+}
+
 namespace milvus::index {
+
+enum class JsonStatsValueState { VALID, INVALID_NUMBER };
+
+struct JsonStatsValue {
+    std::string raw_value;
+    std::optional<double> double_value;
+    JsonStatsValueState state{JsonStatsValueState::VALID};
+
+    bool
+    IsInvalidNumber() const {
+        return state == JsonStatsValueState::INVALID_NUMBER;
+    }
+};
+
 class JsonKeyStats : public ScalarIndex<std::string> {
  public:
     explicit JsonKeyStats(
@@ -429,7 +445,7 @@ class JsonKeyStats : public ScalarIndex<std::string> {
 
  private:
     void
-    CollectSingleJsonStatsInfo(const char* json_str,
+    CollectSingleJsonStatsInfo(const milvus::Json& json,
                                std::map<JsonKey, KeyStatsInfo>& infos);
 
     std::string
@@ -445,9 +461,7 @@ class JsonKeyStats : public ScalarIndex<std::string> {
     CollectKeyInfo(const std::vector<FieldDataPtr>& field_datas, bool nullable);
 
     void
-    TraverseJsonForStats(const char* json,
-                         jsmntok* tokens,
-                         int& index,
+    TraverseJsonForStats(simdjson::ondemand::value value,
                          std::vector<std::string>& path,
                          std::map<JsonKey, KeyStatsInfo>& infos);
 
@@ -478,7 +492,7 @@ class JsonKeyStats : public ScalarIndex<std::string> {
     BuildKeyStats(const std::vector<FieldDataPtr>& field_datas, bool nullable);
 
     void
-    BuildKeyStatsForRow(const char* json_str, uint32_t row_id);
+    BuildKeyStatsForRow(const milvus::Json& json, uint32_t row_id);
 
     void
     BuildKeyStatsForNullRow();
@@ -501,125 +515,16 @@ class JsonKeyStats : public ScalarIndex<std::string> {
     void
     AddKeyStats(const std::vector<std::string>& path,
                 JSONType type,
-                const std::string& value,
-                std::map<JsonKey, std::string>& values);
+                JsonStatsValue value,
+                std::map<JsonKey, JsonStatsValue>& values);
 
     void
-    TraverseJsonForBuildStats(const char* json,
-                              jsmntok* tokens,
-                              int& index,
+    TraverseJsonForBuildStats(simdjson::ondemand::value value,
                               std::vector<std::string>& path,
-                              std::map<JsonKey, std::string>& values);
+                              std::map<JsonKey, JsonStatsValue>& values);
 
-    bool
-    IsBoolean(const std::string& str) {
-        return str == "true" || str == "false";
-    }
-
-    // JSON number sniffing helpers.
-    //
-    // These used to be implemented with std::stof/std::stod plus catch(...),
-    // but libstdc++ throws std::out_of_range for ANY ERANGE result of
-    // strtod/strtof, including underflow into the subnormal range (e.g.
-    // -1.48e-309, a perfectly valid double). Valid JSON numbers were then
-    // misclassified as UNKNOWN and poisoned the whole json key stats build.
-    // std::from_chars never throws and reports out-of-range values through
-    // std::errc::result_out_of_range instead.
-
-    // Strict: only a value fully representable in int64_t counts; anything
-    // else must fall through to the float/double checks.
-    bool
-    IsInt8(const std::string& str) {
-        std::istringstream iss(str);
-        int8_t num;
-        iss >> num;
-
-        return !iss.fail() && iss.eof() &&
-               num >= std::numeric_limits<int8_t>::min() &&
-               num <= std::numeric_limits<int8_t>::max();
-    }
-
-    bool
-    IsInt16(const std::string& str) {
-        std::istringstream iss(str);
-        int16_t num;
-        iss >> num;
-
-        return !iss.fail() && iss.eof() &&
-               num >= std::numeric_limits<int16_t>::min() &&
-               num <= std::numeric_limits<int16_t>::max();
-    }
-
-    bool
-    IsInt32(const std::string& str) {
-        std::istringstream iss(str);
-        int64_t num;
-        iss >> num;
-
-        return !iss.fail() && iss.eof() &&
-               num >= std::numeric_limits<int32_t>::min() &&
-               num <= std::numeric_limits<int32_t>::max();
-    }
-
-    bool
-    IsInt64(const std::string& str) {
-        int64_t num;
-        auto [ptr, ec] =
-            std::from_chars(str.data(), str.data() + str.size(), num);
-        return ptr == str.data() + str.size() && ec == std::errc();
-    }
-
-    // Strict: values outside float's range fall through to the DOUBLE check
-    // so they keep full double precision in the shredding column type.
-    bool
-    IsFloat(const std::string& str) {
-        float num;
-        auto [ptr, ec] =
-            std::from_chars(str.data(), str.data() + str.size(), num);
-        return ptr == str.data() + str.size() && ec == std::errc();
-    }
-
-    // Lenient on range: a well-formed JSON number whose magnitude overflows
-    // or underflows double (subnormals such as 1e-309, or 1e400) is still a
-    // valid number and must classify as DOUBLE instead of UNKNOWN.
-    bool
-    IsDouble(const std::string& str) {
-        double num;
-        auto [ptr, ec] =
-            std::from_chars(str.data(), str.data() + str.size(), num);
-        return ptr == str.data() + str.size() &&
-               (ec == std::errc() || ec == std::errc::result_out_of_range);
-    }
-
-    bool
-    IsNull(const std::string& str) {
-        return str == "null";
-    }
-
-    JSONType
-    getType(const std::string& str) {
-        if (IsBoolean(str)) {
-            return JSONType::BOOL;
-            // TODO: add int8, int16, int32 support
-            // now we only support int64 for build performance
-            // } else if (IsInt8(str)) {
-            //     return JSONType::INT8;
-            // } else if (IsInt16(str)) {
-            //     return JSONType::INT16;
-            // } else if (IsInt32(str)) {
-            //     return JSONType::INT32;
-        } else if (IsInt64(str)) {
-            return JSONType::INT64;
-        } else if (IsFloat(str)) {
-            return JSONType::FLOAT;
-        } else if (IsDouble(str)) {
-            return JSONType::DOUBLE;
-        } else if (IsNull(str)) {
-            return JSONType::NONE;
-        }
-        LOG_DEBUG("unknown json type for string: {}", str);
-        return JSONType::UNKNOWN;
-    }
+    std::pair<JSONType, JsonStatsValue>
+    ParsePrimitiveValue(simdjson::ondemand::value value);
 
     void
     LoadShreddingData(const std::vector<std::string>& index_files,
@@ -667,7 +572,6 @@ class JsonKeyStats : public ScalarIndex<std::string> {
     int64_t max_shredding_columns_;
     double shredding_ratio_threshold_;
     int64_t write_batch_size_;
-
     std::map<JsonKey, JsonKeyLayoutType> key_types_;
     std::set<JsonKey> shared_keys_;
     std::set<JsonKey> column_keys_;

--- a/internal/core/src/index/json_stats/bson_builder.cpp
+++ b/internal/core/src/index/json_stats/bson_builder.cpp
@@ -43,67 +43,141 @@ namespace milvus::index {
 
 namespace {
 
-// Append a simdjson DOM element to a libbson document/array target under the
-// given key (for arrays the key is the stringified index).
 void
-AppendJsonElementToBson(simdjson::dom::element elem,
-                        bson_t* out,
-                        const char* key,
-                        int key_len) {
-    using simdjson::dom::element_type;
+AppendNodeToDom(DomNode& root,
+                const std::vector<std::string>& keys,
+                DomNode value_node) {
+    DomNode* current = &root;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        const std::string& key = keys[i];
+        if (i == keys.size() - 1) {
+            current->document_children[key] = std::move(value_node);
+        } else {
+            auto& child = current->document_children[key];
+            if (child.type != DomNode::Type::DOCUMENT) {
+                child = DomNode(DomNode::Type::DOCUMENT);
+            }
+            current = &child;
+        }
+    }
+}
 
-    auto type = elem.type();
-    switch (type) {
-        case element_type::STRING: {
-            auto sv = std::string_view(elem.get_string());
+double
+ParseJsonDouble(const std::string& value) {
+    simdjson::padded_string padded(value.data(), value.size());
+    simdjson::ondemand::parser parser;
+    auto document = parser.iterate(padded);
+    AssertInfo(document.error() == simdjson::SUCCESS,
+               "invalid json number {}: {}",
+               value,
+               simdjson::error_message(document.error()));
+    auto number = document.get_number();
+    AssertInfo(number.error() == simdjson::SUCCESS,
+               "invalid json number {}: {}",
+               value,
+               simdjson::error_message(number.error()));
+    return number.value().as_double();
+}
+
+void
+AppendJsonValueToBson(simdjson::ondemand::value value,
+                      bson_t* out,
+                      const char* key,
+                      int key_len) {
+    auto type = value.type();
+    AssertInfo(type.error() == simdjson::SUCCESS,
+               "failed to read json array element type: {}",
+               simdjson::error_message(type.error()));
+
+    switch (type.value()) {
+        case simdjson::ondemand::json_type::string: {
+            auto string = value.get_string();
+            AssertInfo(string.error() == simdjson::SUCCESS,
+                       "failed to read json string: {}",
+                       simdjson::error_message(string.error()));
+            auto sv = string.value();
             bson_append_utf8(
                 out, key, key_len, sv.data(), static_cast<int>(sv.size()));
             break;
         }
-        case element_type::INT64:
-            bson_append_int64(out, key, key_len, int64_t(elem.get_int64()));
+        case simdjson::ondemand::json_type::number: {
+            auto number_result = value.get_number();
+            if (number_result.error() != simdjson::SUCCESS) {
+                bson_append_undefined(out, key, key_len);
+                break;
+            }
+            const auto& number = number_result.value();
+            if (number.is_int64()) {
+                bson_append_int64(out, key, key_len, number.get_int64());
+            } else {
+                bson_append_double(out, key, key_len, number.as_double());
+            }
             break;
-        case element_type::UINT64:
-            bson_append_double(out, key, key_len, double(elem.get_uint64()));
+        }
+        case simdjson::ondemand::json_type::boolean: {
+            auto boolean = value.get_bool();
+            AssertInfo(boolean.error() == simdjson::SUCCESS,
+                       "failed to read json boolean: {}",
+                       simdjson::error_message(boolean.error()));
+            bson_append_bool(out, key, key_len, boolean.value());
             break;
-        case element_type::DOUBLE:
-            bson_append_double(out, key, key_len, double(elem.get_double()));
-            break;
-        case element_type::BOOL:
-            bson_append_bool(out, key, key_len, bool(elem.get_bool()));
-            break;
-        case element_type::NULL_VALUE:
+        }
+        case simdjson::ondemand::json_type::null:
             bson_append_null(out, key, key_len);
             break;
-        case element_type::OBJECT: {
+        case simdjson::ondemand::json_type::object: {
+            auto object = value.get_object();
+            AssertInfo(object.error() == simdjson::SUCCESS,
+                       "failed to read nested json object: {}",
+                       simdjson::error_message(object.error()));
             bson_t child;
             bson_append_document_begin(out, key, key_len, &child);
-            for (auto [k, v] : elem.get_object()) {
-                AppendJsonElementToBson(
-                    v, &child, k.data(), static_cast<int>(k.size()));
+            for (auto field : object.value()) {
+                auto field_key = field.unescaped_key();
+                AssertInfo(field_key.error() == simdjson::SUCCESS,
+                           "failed to read nested json object key: {}",
+                           simdjson::error_message(field_key.error()));
+                auto child_value = field.value();
+                AssertInfo(child_value.error() == simdjson::SUCCESS,
+                           "failed to read nested json object value: {}",
+                           simdjson::error_message(child_value.error()));
+                AppendJsonValueToBson(
+                    child_value.value(),
+                    &child,
+                    field_key.value().data(),
+                    static_cast<int>(field_key.value().size()));
             }
             bson_append_document_end(out, &child);
             break;
         }
-        case element_type::ARRAY: {
+        case simdjson::ondemand::json_type::array: {
+            auto array = value.get_array();
+            AssertInfo(array.error() == simdjson::SUCCESS,
+                       "failed to read nested json array: {}",
+                       simdjson::error_message(array.error()));
             bson_t child;
             bson_append_array_begin(out, key, key_len, &child);
             uint32_t i = 0;
             char buf[16];
             const char* idx_key = nullptr;
-            for (simdjson::dom::element v : elem.get_array()) {
+            for (auto child_value : array.value()) {
+                AssertInfo(child_value.error() == simdjson::SUCCESS,
+                           "failed to read nested json array value: {}",
+                           simdjson::error_message(child_value.error()));
                 size_t klen =
                     bson_uint32_to_string(i, &idx_key, buf, sizeof(buf));
-                AppendJsonElementToBson(
-                    v, &child, idx_key, static_cast<int>(klen));
+                AppendJsonValueToBson(child_value.value(),
+                                      &child,
+                                      idx_key,
+                                      static_cast<int>(klen));
                 i++;
             }
             bson_append_array_end(out, &child);
             break;
         }
         default:
-            bson_append_null(out, key, key_len);
-            break;
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      "unsupported json array element type");
     }
 }
 
@@ -111,28 +185,31 @@ AppendJsonElementToBson(simdjson::dom::element elem,
 
 std::vector<uint8_t>
 BuildBsonArrayBytesFromJsonString(const std::string& json_array) {
-    simdjson::dom::parser parser;
-    simdjson::dom::element root = parser.parse(json_array);
-    if (root.type() != simdjson::dom::element_type::ARRAY) {
-        ThrowInfo(ErrorCode::UnexpectedError,
-                  "input is not a JSON array: {}",
-                  json_array);
-    }
+    simdjson::padded_string padded(json_array.data(), json_array.size());
+    simdjson::ondemand::parser parser;
+    auto document = parser.iterate(padded);
+    AssertInfo(document.error() == simdjson::SUCCESS,
+               "failed to parse json array: {}",
+               simdjson::error_message(document.error()));
+    auto root = document.get_array();
+    AssertInfo(root.error() == simdjson::SUCCESS,
+               "input is not a json array: {}",
+               simdjson::error_message(root.error()));
 
-    bson_t arr;
-    bson_init(&arr);
+    BsonDocument arr;
     uint32_t i = 0;
     char buf[16];
     const char* idx_key = nullptr;
-    for (simdjson::dom::element elem : root.get_array()) {
+    for (auto element : root.value()) {
+        AssertInfo(element.error() == simdjson::SUCCESS,
+                   "failed to read json array element: {}",
+                   simdjson::error_message(element.error()));
         size_t klen = bson_uint32_to_string(i, &idx_key, buf, sizeof(buf));
-        AppendJsonElementToBson(elem, &arr, idx_key, static_cast<int>(klen));
+        AppendJsonValueToBson(
+            element.value(), arr.get(), idx_key, static_cast<int>(klen));
         i++;
     }
-    std::vector<uint8_t> out(bson_get_data(&arr),
-                             bson_get_data(&arr) + arr.len);
-    bson_destroy(&arr);
-    return out;
+    return std::vector<uint8_t>(arr.data(), arr.data() + arr.length());
 }
 
 void
@@ -144,25 +221,27 @@ BsonBuilder::AppendToDom(DomNode& root,
               Join(keys, "."),
               value,
               ToString(type));
-    DomNode* current = &root;
-    for (size_t i = 0; i < keys.size(); ++i) {
-        const std::string& key = keys[i];
-        if (i == keys.size() - 1) {
-            current->document_children[key] = CreateValueNode(value, type);
-        } else {
-            auto& children = current->document_children;
-            auto it = children.find(key);
-            if (it != children.end()) {
-                if (it->second.type != DomNode::Type::DOCUMENT) {
-                    it->second = DomNode(DomNode::Type::DOCUMENT);
-                }
-                current = &it->second;
-            } else {
-                children[key] = DomNode(DomNode::Type::DOCUMENT);
-                current = &children[key];
-            }
-        }
-    }
+    AppendNodeToDom(root, keys, CreateValueNode(value, type));
+}
+
+void
+BsonBuilder::AppendDoubleToDom(DomNode& root,
+                               const std::vector<std::string>& keys,
+                               double value) {
+    AppendNodeToDom(root, keys, CreateDoubleValueNode(value));
+}
+
+void
+BsonBuilder::AppendUndefinedToDom(DomNode& root,
+                                  const std::vector<std::string>& keys) {
+    AppendNodeToDom(root, keys, CreateUndefinedValueNode());
+}
+
+void
+BsonBuilder::AppendArrayToDom(DomNode& root,
+                              const std::vector<std::string>& keys,
+                              std::vector<uint8_t> array_bytes) {
+    AppendNodeToDom(root, keys, CreateArrayValueNode(std::move(array_bytes)));
 }
 
 DomNode
@@ -192,17 +271,7 @@ BsonBuilder::CreateValueNode(const std::string& value, JSONType type) {
             return DomNode(std::move(s));
         }
         case JSONType::DOUBLE: {
-            DomScalar s;
-            s.type = JSONType::DOUBLE;
-            // strtod instead of std::stod: stod throws std::out_of_range for
-            // subnormal doubles (e.g. -1.48e-309) because they trip the ERANGE
-            // underflow flag, while strtod simply returns the denormal value.
-            char* end = nullptr;
-            s.d = std::strtod(value.c_str(), &end);
-            AssertInfo(end == value.c_str() + value.size(),
-                       "invalid double value: {}",
-                       value);
-            return DomNode(std::move(s));
+            return CreateDoubleValueNode(ParseJsonDouble(value));
         }
         case JSONType::STRING: {
             DomScalar s;
@@ -242,6 +311,29 @@ BsonBuilder::CreateValueNode(const std::string& value, JSONType type) {
     }
 }
 
+DomNode
+BsonBuilder::CreateDoubleValueNode(double value) {
+    DomScalar scalar;
+    scalar.type = JSONType::DOUBLE;
+    scalar.d = value;
+    return DomNode(std::move(scalar));
+}
+
+DomNode
+BsonBuilder::CreateUndefinedValueNode() {
+    DomScalar scalar;
+    scalar.undefined = true;
+    return DomNode(std::move(scalar));
+}
+
+DomNode
+BsonBuilder::CreateArrayValueNode(std::vector<uint8_t> array_bytes) {
+    DomScalar scalar;
+    scalar.type = JSONType::ARRAY;
+    scalar.arr_bytes = std::move(array_bytes);
+    return DomNode(std::move(scalar));
+}
+
 void
 BsonBuilder::ConvertDomToBson(const DomNode& node, bson_t* builder) {
     for (const auto& [key, child] : node.document_children) {
@@ -250,6 +342,10 @@ BsonBuilder::ConvertDomToBson(const DomNode& node, bson_t* builder) {
         switch (child.type) {
             case DomNode::Type::VALUE: {
                 const DomScalar& s = child.value.value();
+                if (s.undefined) {
+                    bson_append_undefined(builder, k, klen);
+                    break;
+                }
                 switch (s.type) {
                     case JSONType::NONE:
                         bson_append_null(builder, k, klen);
@@ -379,6 +475,9 @@ BsonBuilder::ExtractOffsetsRecursive(
                 break;
             }
             case milvus::bson::type::k_null: {
+                break;
+            }
+            case milvus::bson::type::k_undefined: {
                 break;
             }
             default: {

--- a/internal/core/src/index/json_stats/bson_builder.cpp
+++ b/internal/core/src/index/json_stats/bson_builder.cpp
@@ -19,6 +19,7 @@
 #include "common/FastMem.h"
 #include <string.h>
 #include <cstdint>
+#include <cstdlib>
 #include <exception>
 #include <map>
 #include <string>
@@ -193,7 +194,14 @@ BsonBuilder::CreateValueNode(const std::string& value, JSONType type) {
         case JSONType::DOUBLE: {
             DomScalar s;
             s.type = JSONType::DOUBLE;
-            s.d = std::stod(value);
+            // strtod instead of std::stod: stod throws std::out_of_range for
+            // subnormal doubles (e.g. -1.48e-309) because they trip the ERANGE
+            // underflow flag, while strtod simply returns the denormal value.
+            char* end = nullptr;
+            s.d = std::strtod(value.c_str(), &end);
+            AssertInfo(end == value.c_str() + value.size(),
+                       "invalid double value: {}",
+                       value);
             return DomNode(std::move(s));
         }
         case JSONType::STRING: {

--- a/internal/core/src/index/json_stats/bson_builder.h
+++ b/internal/core/src/index/json_stats/bson_builder.h
@@ -34,6 +34,7 @@ namespace milvus::index {
 // append it to a libbson document at conversion time.
 struct DomScalar {
     JSONType type{JSONType::NONE};
+    bool undefined{false};
     bool b{false};
     int32_t i32{0};
     int64_t i64{0};
@@ -101,8 +102,30 @@ class BsonBuilder {
                 const std::string& value,
                 const JSONType& type);
 
+    static void
+    AppendDoubleToDom(DomNode& root,
+                      const std::vector<std::string>& keys,
+                      double value);
+
+    static void
+    AppendUndefinedToDom(DomNode& root, const std::vector<std::string>& keys);
+
+    static void
+    AppendArrayToDom(DomNode& root,
+                     const std::vector<std::string>& keys,
+                     std::vector<uint8_t> array_bytes);
+
     static DomNode
     CreateValueNode(const std::string& value, JSONType type);
+
+    static DomNode
+    CreateDoubleValueNode(double value);
+
+    static DomNode
+    CreateUndefinedValueNode();
+
+    static DomNode
+    CreateArrayValueNode(std::vector<uint8_t> array_bytes);
 
     static void
     ConvertDomToBson(const DomNode& node, bson_t* builder);

--- a/internal/core/src/index/json_stats/parquet_writer.cpp
+++ b/internal/core/src/index/json_stats/parquet_writer.cpp
@@ -188,6 +188,26 @@ JsonStatsParquetWriter::AppendValue(const std::string& key,
 }
 
 void
+JsonStatsParquetWriter::AppendNull(const std::string& key) {
+    auto it = builders_map_.find(key);
+    AssertInfo(it != builders_map_.end(), "builder for key {} not found", key);
+    auto status = it->second->AppendNull();
+    AssertInfo(status.ok(), "failed to append null for key {}", key);
+}
+
+void
+JsonStatsParquetWriter::AppendDouble(const std::string& key, double value) {
+    auto it = builders_map_.find(key);
+    AssertInfo(it != builders_map_.end(), "builder for key {} not found", key);
+    AssertInfo(it->second->type()->id() == arrow::Type::DOUBLE,
+               "builder for key {} is not double",
+               key);
+    auto builder = std::static_pointer_cast<arrow::DoubleBuilder>(it->second);
+    auto status = builder->Append(value);
+    AssertInfo(status.ok(), "failed to append double for key {}", key);
+}
+
+void
 JsonStatsParquetWriter::AppendRow(
     const std::map<std::string, std::string>& row_data) {
     for (const auto& [key, value] : row_data) {

--- a/internal/core/src/index/json_stats/parquet_writer.h
+++ b/internal/core/src/index/json_stats/parquet_writer.h
@@ -37,12 +37,30 @@
 #include "milvus-storage/common/config.h"
 #include "milvus-storage/packed/writer.h"
 #include "parquet/properties.h"
+#include "simdjson.h"
 
 namespace milvus::index {
 
 template <typename T>
 inline T
 ConvertValue(const std::string& value);
+
+inline double
+ParseJsonDoubleValue(const std::string& value) {
+    simdjson::padded_string padded(value.data(), value.size());
+    simdjson::ondemand::parser parser;
+    auto document = parser.iterate(padded);
+    AssertInfo(document.error() == simdjson::SUCCESS,
+               "invalid json number {}: {}",
+               value,
+               simdjson::error_message(document.error()));
+    auto number = document.get_number();
+    AssertInfo(number.error() == simdjson::SUCCESS,
+               "invalid json number {}: {}",
+               value,
+               simdjson::error_message(number.error()));
+    return number.value().as_double();
+}
 
 template <>
 inline int8_t
@@ -67,25 +85,12 @@ ConvertValue<int64_t>(const std::string& value) {
 template <>
 inline float
 ConvertValue<float>(const std::string& value) {
-    // strtof never throws: on ERANGE (overflow / subnormal underflow) it
-    // returns the clamped value instead, unlike std::stof which throws
-    // std::out_of_range and poisoned the json stats build.
-    char* end = nullptr;
-    float v = std::strtof(value.c_str(), &end);
-    AssertInfo(end == value.c_str() + value.size(),
-               "invalid float value: {}",
-               value);
-    return v;
+    return static_cast<float>(ParseJsonDoubleValue(value));
 }
 template <>
 inline double
 ConvertValue<double>(const std::string& value) {
-    char* end = nullptr;
-    double v = std::strtod(value.c_str(), &end);
-    AssertInfo(end == value.c_str() + value.size(),
-               "invalid double value: {}",
-               value);
-    return v;
+    return ParseJsonDoubleValue(value);
 }
 template <>
 inline bool
@@ -205,6 +210,12 @@ class JsonStatsParquetWriter {
 
     void
     AppendValue(const std::string& key, const std::string& value);
+
+    void
+    AppendNull(const std::string& key);
+
+    void
+    AppendDouble(const std::string& key, double value);
 
     void
     AppendRow(const std::map<std::string, std::string>& row_data);

--- a/internal/core/src/index/json_stats/parquet_writer.h
+++ b/internal/core/src/index/json_stats/parquet_writer.h
@@ -18,6 +18,7 @@
 
 #include <stdint.h>
 #include <cstddef>
+#include <cstdlib>
 #include <map>
 #include <memory>
 #include <string>
@@ -66,12 +67,25 @@ ConvertValue<int64_t>(const std::string& value) {
 template <>
 inline float
 ConvertValue<float>(const std::string& value) {
-    return std::stof(value);
+    // strtof never throws: on ERANGE (overflow / subnormal underflow) it
+    // returns the clamped value instead, unlike std::stof which throws
+    // std::out_of_range and poisoned the json stats build.
+    char* end = nullptr;
+    float v = std::strtof(value.c_str(), &end);
+    AssertInfo(end == value.c_str() + value.size(),
+               "invalid float value: {}",
+               value);
+    return v;
 }
 template <>
 inline double
 ConvertValue<double>(const std::string& value) {
-    return std::stod(value);
+    char* end = nullptr;
+    double v = std::strtod(value.c_str(), &end);
+    AssertInfo(end == value.c_str() + value.size(),
+               "invalid double value: {}",
+               value);
+    return v;
 }
 template <>
 inline bool

--- a/internal/core/unittest/test_json_stats/test_bson_builder.cpp
+++ b/internal/core/unittest/test_json_stats/test_bson_builder.cpp
@@ -173,6 +173,81 @@ TEST_F(BsonBuilderTest, CreateValueNodeTest) {
                  std::runtime_error);
 }
 
+TEST_F(BsonBuilderTest, UndefinedSentinelPreservesExistsAndSibling) {
+    DomNode root(DomNode::Type::DOCUMENT);
+    BsonBuilder::AppendUndefinedToDom(root, {"bad"});
+    BsonBuilder::AppendDoubleToDom(root, {"ok"}, 1.5);
+
+    BsonDocument bson_doc;
+    BsonBuilder::ConvertDomToBson(root, bson_doc.get());
+    auto offsets =
+        BsonBuilder::ExtractBsonKeyOffsets(bson_doc.data(), bson_doc.length());
+    ASSERT_EQ(offsets.size(), 2);
+    EXPECT_EQ(offsets[0].first, "/bad");
+    EXPECT_EQ(offsets[1].first, "/ok");
+
+    BsonView view(bson_doc.data(), bson_doc.length());
+    EXPECT_FALSE(view.IsBsonValueEmpty(offsets[0].second));
+    EXPECT_FALSE(
+        view.ParseAsValueAtOffset<double>(offsets[0].second).has_value());
+    ASSERT_TRUE(
+        view.ParseAsValueAtOffset<double>(offsets[1].second).has_value());
+    EXPECT_DOUBLE_EQ(
+        view.ParseAsValueAtOffset<double>(offsets[1].second).value(), 1.5);
+
+    milvus::bson::document_view document(bson_doc.data(), bson_doc.length());
+    auto bad = view.FindByPath(document, {"bad"});
+    ASSERT_TRUE(bad.has_value());
+    EXPECT_EQ(bad->type(), milvus::bson::type::k_undefined);
+}
+
+TEST_F(BsonBuilderTest, ArrayInvalidNumberKeepsValidElementsQueryable) {
+    const std::string json =
+        R"([1e400,7,{"bad":18446744073709551616,"ok":9},[1e400,11]])";
+
+    auto bytes = BuildBsonArrayBytesFromJsonString(json);
+    milvus::bson::array_view array(bytes.data(), bytes.size());
+    ASSERT_EQ(std::distance(array.begin(), array.end()), 4);
+
+    auto it = array.begin();
+    EXPECT_EQ(it->type(), milvus::bson::type::k_undefined);
+    ++it;
+    EXPECT_EQ(it->type(), milvus::bson::type::k_int64);
+    EXPECT_EQ(it->get_int64().value, 7);
+    ++it;
+    ASSERT_EQ(it->type(), milvus::bson::type::k_document);
+    auto object = it->get_value().get_document().value;
+    auto object_it = object.begin();
+    ASSERT_NE(object_it, object.end());
+    EXPECT_EQ(object_it->type(), milvus::bson::type::k_undefined);
+    ++object_it;
+    ASSERT_NE(object_it, object.end());
+    EXPECT_EQ(object_it->get_int64().value, 9);
+    ++it;
+    ASSERT_EQ(it->type(), milvus::bson::type::k_array);
+    auto nested = it->get_value().get_array().value;
+    auto nested_it = nested.begin();
+    EXPECT_EQ(nested_it->type(), milvus::bson::type::k_undefined);
+    ++nested_it;
+    EXPECT_EQ(nested_it->get_int64().value, 11);
+
+    // Skipping over a zero-payload undefined element must still reach later
+    // array indexes.
+    auto seven = BsonView::GetNthElementInArray<int64_t>(bytes.data(), 1);
+    ASSERT_TRUE(seven.has_value());
+    EXPECT_EQ(seven.value(), 7);
+
+    DomNode root(DomNode::Type::DOCUMENT);
+    BsonBuilder::AppendArrayToDom(root, {"array"}, std::move(bytes));
+    BsonDocument bson_doc;
+    BsonBuilder::ConvertDomToBson(root, bson_doc.get());
+    auto offsets =
+        BsonBuilder::ExtractBsonKeyOffsets(bson_doc.data(), bson_doc.length());
+    ASSERT_EQ(offsets.size(), 1);
+    BsonView view(bson_doc.data(), bson_doc.length());
+    EXPECT_FALSE(view.IsBsonValueEmpty(offsets[0].second));
+}
+
 TEST_F(BsonBuilderTest, AppendToDomTest) {
     BsonBuilder builder;
     DomNode root(DomNode::Type::DOCUMENT);

--- a/internal/core/unittest/test_json_stats/test_parquet_writer.cpp
+++ b/internal/core/unittest/test_json_stats/test_parquet_writer.cpp
@@ -144,25 +144,58 @@ TEST_F(ParquetWriterFactoryTest, CloseReturnsStatusAndIsIdempotent) {
     std::filesystem::remove_all(path_prefix);
 }
 
-// Regression for https://github.com/milvus-io/milvus/issues/52806
-// ConvertValue used to throw std::out_of_range on subnormal / overflowing
-// numbers because it was built on std::stof/std::stod.
-TEST(ConvertValueTest, HandlesSubnormalAndOutOfRangeNumbers) {
-    const double sub = -1.4829972460841e-309;
-    EXPECT_DOUBLE_EQ(
-        ConvertValue<double>(std::string("-1.4829972460841e-309")), sub);
-    EXPECT_DOUBLE_EQ(
-        ConvertValue<double>(std::string("-2.32430876e-316")),
-        -2.32430876e-316);
+TEST_F(ParquetWriterFactoryTest, AppendsTypedNullAndParsedDoubleDirectly) {
+    auto fs = milvus::segcore::GetDefaultArrowFileSystem();
+    auto path_prefix =
+        std::filesystem::path(TestLocalPath) / "json_stats_writer_null";
+    std::filesystem::remove_all(path_prefix);
+    ASSERT_TRUE(std::filesystem::create_directories(path_prefix));
 
-    // Overflow clamps instead of throwing.
-    EXPECT_TRUE(std::isinf(ConvertValue<double>(std::string("1e400"))));
-    EXPECT_EQ(ConvertValue<double>(std::string("1e400")),
-              std::numeric_limits<double>::infinity());
+    const auto key = JsonKey("/double", JSONType::DOUBLE).ToColumnName();
+    std::map<JsonKey, JsonKeyLayoutType> column_map = {
+        {JsonKey("/double", JSONType::DOUBLE), JsonKeyLayoutType::TYPED},
+        {JsonKey("/shared", JSONType::STRING), JsonKeyLayoutType::SHARED},
+    };
+    milvus_storage::StorageConfig storage_config;
+    JsonStatsParquetWriter writer(fs, storage_config, 16 * 1024 * 1024, 1024);
+    auto context =
+        ParquetWriterFactory::CreateContext(column_map, path_prefix.string());
+    auto double_builder = std::static_pointer_cast<arrow::DoubleBuilder>(
+        context.builders_map[key]);
+    writer.Init(std::move(context));
+
+    writer.AppendNull(key);
+    writer.AppendSharedRow(nullptr, 0);
+    writer.AddCurrentRow();
+    writer.AppendDouble(key, -1.4829972460841e-309);
+    writer.AppendSharedRow(nullptr, 0);
+    writer.AddCurrentRow();
+
+    ASSERT_EQ(double_builder->length(), 2);
+    EXPECT_EQ(double_builder->null_count(), 1);
+    ASSERT_TRUE(writer.Close().ok());
+    std::filesystem::remove_all(path_prefix);
+}
+
+// Regression for https://github.com/milvus-io/milvus/issues/52806
+// Conversion uses the same simdjson get_number() contract as raw predicates.
+TEST(ConvertValueTest, MatchesSimdjsonNumberSemantics) {
+    const double sub = -1.4829972460841e-309;
+    EXPECT_DOUBLE_EQ(ConvertValue<double>(std::string("-1.4829972460841e-309")),
+                     sub);
+    EXPECT_DOUBLE_EQ(ConvertValue<double>(std::string("-2.32430876e-316")),
+                     -2.32430876e-316);
+
+    // Float narrowing still follows C++ conversion after a valid JSON double.
     EXPECT_TRUE(std::isinf(ConvertValue<float>(std::string("1e40"))));
 
     // Underflow-to-zero clamps instead of throwing.
     EXPECT_DOUBLE_EQ(ConvertValue<double>(std::string("1e-400")), 0.0);
+
+    // Values rejected by raw get_number() are rejected here too, even when a
+    // standalone double conversion could produce a rounded or infinite value.
+    EXPECT_ANY_THROW(ConvertValue<double>(std::string("1e400")));
+    EXPECT_ANY_THROW(ConvertValue<double>(std::string("18446744073709551616")));
 
     // Normal values keep exact round-trip.
     EXPECT_DOUBLE_EQ(ConvertValue<double>(std::string("-1.5")), -1.5);

--- a/internal/core/unittest/test_json_stats/test_parquet_writer.cpp
+++ b/internal/core/unittest/test_json_stats/test_parquet_writer.cpp
@@ -1,6 +1,8 @@
 #include <arrow/type.h>
 #include <gtest/gtest.h>
+#include <cmath>
 #include <filesystem>
+#include <limits>
 #include <map>
 #include <memory>
 #include <set>
@@ -140,6 +142,35 @@ TEST_F(ParquetWriterFactoryTest, CloseReturnsStatusAndIsIdempotent) {
     EXPECT_FALSE(writer.GetPathsToSize().empty());
 
     std::filesystem::remove_all(path_prefix);
+}
+
+// Regression for https://github.com/milvus-io/milvus/issues/52806
+// ConvertValue used to throw std::out_of_range on subnormal / overflowing
+// numbers because it was built on std::stof/std::stod.
+TEST(ConvertValueTest, HandlesSubnormalAndOutOfRangeNumbers) {
+    const double sub = -1.4829972460841e-309;
+    EXPECT_DOUBLE_EQ(
+        ConvertValue<double>(std::string("-1.4829972460841e-309")), sub);
+    EXPECT_DOUBLE_EQ(
+        ConvertValue<double>(std::string("-2.32430876e-316")),
+        -2.32430876e-316);
+
+    // Overflow clamps instead of throwing.
+    EXPECT_TRUE(std::isinf(ConvertValue<double>(std::string("1e400"))));
+    EXPECT_EQ(ConvertValue<double>(std::string("1e400")),
+              std::numeric_limits<double>::infinity());
+    EXPECT_TRUE(std::isinf(ConvertValue<float>(std::string("1e40"))));
+
+    // Underflow-to-zero clamps instead of throwing.
+    EXPECT_DOUBLE_EQ(ConvertValue<double>(std::string("1e-400")), 0.0);
+
+    // Normal values keep exact round-trip.
+    EXPECT_DOUBLE_EQ(ConvertValue<double>(std::string("-1.5")), -1.5);
+    EXPECT_FLOAT_EQ(ConvertValue<float>(std::string("2.5")), 2.5f);
+
+    // Malformed input still fails loudly.
+    EXPECT_ANY_THROW(ConvertValue<double>(std::string("abc")));
+    EXPECT_ANY_THROW(ConvertValue<double>(std::string("1.5xyz")));
 }
 
 }  // namespace milvus::index

--- a/internal/core/unittest/test_json_stats/test_traverse_json_for_build_stats.cpp
+++ b/internal/core/unittest/test_json_stats/test_traverse_json_for_build_stats.cpp
@@ -147,3 +147,60 @@ TEST(CollectSingleJsonStatsInfoTest, EmptyJsonStringThrows) {
     EXPECT_NO_THROW(
         { CollectSingleJsonStatsInfoAccessor::Call(stats, json, infos); });
 }
+
+// Regression for https://github.com/milvus-io/milvus/issues/52806
+// Subnormal doubles (e.g. -1.48e-309) used to be misclassified as UNKNOWN by
+// the std::stof/std::stod based sniffing and aborted the whole stats build.
+TEST(TraverseJsonForBuildStatsTest, HandlesSubnormalAndOutOfRangeNumbers) {
+    const char* json =
+        R"({"sub": -1.4829972460841e-309, "tiny": -2.32430876e-316,)"
+        R"( "huge": 1e400, "normal": 1.5})";
+
+    auto tokens = Tokenize(json);
+
+    milvus::storage::FieldDataMeta field_meta{1, 2, 3, 100, {}};
+    milvus::storage::IndexMeta index_meta{3, 100, 1, 1};
+    milvus::storage::StorageConfig storage_config;
+    storage_config.storage_type = "local";
+    storage_config.root_path = TestLocalPath;
+    auto cm = milvus::storage::CreateChunkManager(storage_config);
+    auto fs = milvus::storage::InitArrowFileSystem(storage_config);
+    milvus::storage::FileManagerContext ctx(field_meta, index_meta, cm, fs);
+    JsonKeyStats stats(ctx, true);
+
+    int index = 0;
+    std::vector<std::string> path;
+    std::map<JsonKey, std::string> values;
+    TraverseJsonForBuildStatsAccessor::Call(
+        stats, json, tokens.data(), index, path, values);
+
+    // All four values must be classified DOUBLE with raw text preserved.
+    EXPECT_EQ(values.at(JsonKey{"/sub", JSONType::DOUBLE}),
+              "-1.4829972460841e-309");
+    EXPECT_EQ(values.at(JsonKey{"/tiny", JSONType::DOUBLE}),
+              "-2.32430876e-316");
+    EXPECT_EQ(values.at(JsonKey{"/huge", JSONType::DOUBLE}), "1e400");
+    EXPECT_EQ(values.at(JsonKey{"/normal", JSONType::DOUBLE}), "1.5");
+}
+
+TEST(CollectSingleJsonStatsInfoTest, ClassifiesSubnormalNumbersAsDouble) {
+    const char* json =
+        R"({"sub": -1.4829972460841e-309, "tiny": -2.32430876e-316})";
+
+    milvus::storage::FieldDataMeta field_meta{1, 2, 3, 100, {}};
+    milvus::storage::IndexMeta index_meta{3, 100, 1, 1};
+    milvus::storage::StorageConfig storage_config;
+    storage_config.storage_type = "local";
+    storage_config.root_path = TestLocalPath;
+    auto cm = milvus::storage::CreateChunkManager(storage_config);
+    auto fs = milvus::storage::InitArrowFileSystem(storage_config);
+    milvus::storage::FileManagerContext ctx(field_meta, index_meta, cm, fs);
+    JsonKeyStats stats(ctx, true);
+
+    std::map<JsonKey, milvus::index::KeyStatsInfo> infos;
+    EXPECT_NO_THROW(
+        { CollectSingleJsonStatsInfoAccessor::Call(stats, json, infos); });
+
+    ASSERT_NE(infos.find(JsonKey{"/sub", JSONType::DOUBLE}), infos.end());
+    ASSERT_NE(infos.find(JsonKey{"/tiny", JSONType::DOUBLE}), infos.end());
+}

--- a/internal/core/unittest/test_json_stats/test_traverse_json_for_build_stats.cpp
+++ b/internal/core/unittest/test_json_stats/test_traverse_json_for_build_stats.cpp
@@ -14,7 +14,7 @@
 #include <utility>
 #include <vector>
 
-#include "common/jsmn.h"
+#include "common/Json.h"
 #include "common/protobuf_utils.h"
 #include "gtest/gtest.h"
 #include "index/json_stats/JsonKeyStats.h"
@@ -26,6 +26,7 @@
 
 using milvus::index::JsonKey;
 using milvus::index::JsonKeyStats;
+using milvus::index::JsonStatsValue;
 using milvus::index::JSONType;
 
 // Friend accessor declared in JsonKeyStats to invoke private method for UT
@@ -34,11 +35,14 @@ class TraverseJsonForBuildStatsAccessor {
     static void
     Call(JsonKeyStats& s,
          const char* json,
-         jsmntok_t* tokens,
-         int& index,
          std::vector<std::string>& path,
-         std::map<JsonKey, std::string>& values) {
-        s.TraverseJsonForBuildStats(json, tokens, index, path, values);
+         std::map<JsonKey, JsonStatsValue>& values) {
+        milvus::Json parsed(simdjson::padded_string(json, std::strlen(json)));
+        auto document = parsed.doc();
+        ASSERT_EQ(document.error(), simdjson::SUCCESS);
+        auto root = document.get_value();
+        ASSERT_EQ(root.error(), simdjson::SUCCESS);
+        s.TraverseJsonForBuildStats(root.value(), path, values);
     }
 };
 
@@ -49,35 +53,10 @@ class CollectSingleJsonStatsInfoAccessor {
     Call(JsonKeyStats& s,
          const char* json,
          std::map<JsonKey, milvus::index::KeyStatsInfo>& infos) {
-        s.CollectSingleJsonStatsInfo(json, infos);
+        milvus::Json parsed(simdjson::padded_string(json, std::strlen(json)));
+        s.CollectSingleJsonStatsInfo(parsed, infos);
     }
 };
-
-namespace {
-
-// Helper to tokenize JSON using jsmn
-static std::vector<jsmntok_t>
-Tokenize(const char* json) {
-    jsmn_parser parser;
-    jsmn_init(&parser);
-    int token_capacity = 32;
-    std::vector<jsmntok_t> tokens(token_capacity);
-    while (true) {
-        int r = jsmn_parse(
-            &parser, json, strlen(json), tokens.data(), token_capacity);
-        if (r == JSMN_ERROR_NOMEM) {
-            token_capacity *= 2;
-            tokens.resize(token_capacity);
-            continue;
-        }
-        EXPECT_GE(r, 0) << "Failed to parse JSON with jsmn";
-        tokens.resize(r);
-        break;
-    }
-    return tokens;
-}
-
-}  // namespace
 
 TEST(TraverseJsonForBuildStatsTest,
      HandlesPrimitivesArraysNestedAndEmptyObject) {
@@ -88,8 +67,6 @@ TEST(TraverseJsonForBuildStatsTest,
         "payload":{},"public":true,"created_at":"2024-01-01T00:01:28Z",
         "msg":"line1\nline2\t\u4e2d\u6587 \/ backslash \\"}
     )";
-
-    auto tokens = Tokenize(json);
 
     // We only need an instance to access the private method we exposed.
     milvus::storage::FieldDataMeta field_meta{1, 2, 3, 100, {}};
@@ -102,11 +79,9 @@ TEST(TraverseJsonForBuildStatsTest,
     milvus::storage::FileManagerContext ctx(field_meta, index_meta, cm, fs);
     JsonKeyStats stats(ctx, true);
 
-    int index = 0;
     std::vector<std::string> path;
-    std::map<JsonKey, std::string> values;
-    TraverseJsonForBuildStatsAccessor::Call(
-        stats, json, tokens.data(), index, path, values);
+    std::map<JsonKey, JsonStatsValue> values;
+    TraverseJsonForBuildStatsAccessor::Call(stats, json, path, values);
 
     // Expect collected key-value/type pairs
     auto expect_has = [&](const std::string& key,
@@ -115,7 +90,7 @@ TEST(TraverseJsonForBuildStatsTest,
         JsonKey k{key, type};
         auto it = values.find(k);
         ASSERT_NE(it, values.end()) << "Missing key: " << key;
-        EXPECT_EQ(it->second, value_substr);
+        EXPECT_EQ(it->second.raw_value, value_substr);
     };
 
     expect_has("/id", JSONType::INT64, "34495370646");
@@ -151,12 +126,9 @@ TEST(CollectSingleJsonStatsInfoTest, EmptyJsonStringThrows) {
 // Regression for https://github.com/milvus-io/milvus/issues/52806
 // Subnormal doubles (e.g. -1.48e-309) used to be misclassified as UNKNOWN by
 // the std::stof/std::stod based sniffing and aborted the whole stats build.
-TEST(TraverseJsonForBuildStatsTest, HandlesSubnormalAndOutOfRangeNumbers) {
-    const char* json =
-        R"({"sub": -1.4829972460841e-309, "tiny": -2.32430876e-316,)"
-        R"( "huge": 1e400, "normal": 1.5})";
-
-    auto tokens = Tokenize(json);
+TEST(TraverseJsonForBuildStatsTest, MatchesSimdjsonNumberSemantics) {
+    const char* json = R"({"sub": -1.4829972460841e-309, "underflow": 1e-400,)"
+                       R"( "uint64": 18446744073709551615, "normal": 1.5})";
 
     milvus::storage::FieldDataMeta field_meta{1, 2, 3, 100, {}};
     milvus::storage::IndexMeta index_meta{3, 100, 1, 1};
@@ -168,19 +140,49 @@ TEST(TraverseJsonForBuildStatsTest, HandlesSubnormalAndOutOfRangeNumbers) {
     milvus::storage::FileManagerContext ctx(field_meta, index_meta, cm, fs);
     JsonKeyStats stats(ctx, true);
 
-    int index = 0;
     std::vector<std::string> path;
-    std::map<JsonKey, std::string> values;
-    TraverseJsonForBuildStatsAccessor::Call(
-        stats, json, tokens.data(), index, path, values);
+    std::map<JsonKey, JsonStatsValue> values;
+    TraverseJsonForBuildStatsAccessor::Call(stats, json, path, values);
 
-    // All four values must be classified DOUBLE with raw text preserved.
-    EXPECT_EQ(values.at(JsonKey{"/sub", JSONType::DOUBLE}),
+    EXPECT_EQ(values.at(JsonKey{"/sub", JSONType::DOUBLE}).raw_value,
               "-1.4829972460841e-309");
-    EXPECT_EQ(values.at(JsonKey{"/tiny", JSONType::DOUBLE}),
-              "-2.32430876e-316");
-    EXPECT_EQ(values.at(JsonKey{"/huge", JSONType::DOUBLE}), "1e400");
-    EXPECT_EQ(values.at(JsonKey{"/normal", JSONType::DOUBLE}), "1.5");
+    EXPECT_DOUBLE_EQ(
+        values.at(JsonKey{"/sub", JSONType::DOUBLE}).double_value.value(),
+        -1.4829972460841e-309);
+    EXPECT_DOUBLE_EQ(
+        values.at(JsonKey{"/underflow", JSONType::DOUBLE}).double_value.value(),
+        0.0);
+    EXPECT_DOUBLE_EQ(
+        values.at(JsonKey{"/uint64", JSONType::DOUBLE}).double_value.value(),
+        18446744073709551615.0);
+    EXPECT_DOUBLE_EQ(
+        values.at(JsonKey{"/normal", JSONType::DOUBLE}).double_value.value(),
+        1.5);
+}
+
+TEST(TraverseJsonForBuildStatsTest, InvalidNumberPreservesPathAndSibling) {
+    const char* json =
+        R"({"overflow":1e400,"bigint":18446744073709551616,"ok":7})";
+
+    milvus::storage::FieldDataMeta field_meta{1, 2, 3, 100, {}};
+    milvus::storage::IndexMeta index_meta{3, 100, 1, 1};
+    milvus::storage::StorageConfig storage_config;
+    storage_config.storage_type = "local";
+    storage_config.root_path = TestLocalPath;
+    auto cm = milvus::storage::CreateChunkManager(storage_config);
+    auto fs = milvus::storage::InitArrowFileSystem(storage_config);
+    milvus::storage::FileManagerContext ctx(field_meta, index_meta, cm, fs);
+    JsonKeyStats stats(ctx, true);
+
+    std::vector<std::string> path;
+    std::map<JsonKey, JsonStatsValue> values;
+    TraverseJsonForBuildStatsAccessor::Call(stats, json, path, values);
+
+    EXPECT_TRUE(
+        values.at(JsonKey{"/overflow", JSONType::DOUBLE}).IsInvalidNumber());
+    EXPECT_TRUE(
+        values.at(JsonKey{"/bigint", JSONType::DOUBLE}).IsInvalidNumber());
+    EXPECT_EQ(values.at(JsonKey{"/ok", JSONType::INT64}).raw_value, "7");
 }
 
 TEST(CollectSingleJsonStatsInfoTest, ClassifiesSubnormalNumbersAsDouble) {

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -229,9 +229,9 @@ func needDoJSONKeyIndex(segment *SegmentInfo, fieldIDs []UniqueID, allowUnsorted
 		if segment.GetJsonKeyStats()[fieldID] == nil {
 			return true
 		}
-		// if the data format version is less than the current version, we need to do the stats task again
-		// because the data format is updated, the old data format need to be converted to the new data format
-		if segment.GetJsonKeyStats()[fieldID].GetJsonKeyStatsDataFormat() < common.JSONStatsDataFormatVersion {
+		// Readers require an exact data-format match. Rebuild both older stats
+		// and stats produced by a newer binary after a downgrade.
+		if segment.GetJsonKeyStats()[fieldID].GetJsonKeyStatsDataFormat() != common.JSONStatsDataFormatVersion {
 			return true
 		}
 	}

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -519,11 +519,9 @@ func (s *statsInspectorSuite) TestNeedJSONKeyIndexRequiresExactFormat() {
 	})
 
 	s.False(needDoJSONKeyIndex(segment, []UniqueID{fieldID}, true))
-	segment.JsonKeyStats[fieldID].JsonKeyStatsDataFormat =
-		common.JSONStatsDataFormatVersion - 1
+	segment.JsonKeyStats[fieldID].JsonKeyStatsDataFormat = common.JSONStatsDataFormatVersion - 1
 	s.True(needDoJSONKeyIndex(segment, []UniqueID{fieldID}, true))
-	segment.JsonKeyStats[fieldID].JsonKeyStatsDataFormat =
-		common.JSONStatsDataFormatVersion + 1
+	segment.JsonKeyStats[fieldID].JsonKeyStatsDataFormat = common.JSONStatsDataFormatVersion + 1
 	s.True(needDoJSONKeyIndex(segment, []UniqueID{fieldID}, true))
 }
 

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus/internal/metastore/mocks"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
@@ -505,6 +506,25 @@ func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskStopsAtPendingLimi
 	}
 	s.Equal(2, submitted)
 	s.Equal(2, pending)
+}
+
+func (s *statsInspectorSuite) TestNeedJSONKeyIndexRequiresExactFormat() {
+	const fieldID = int64(202)
+	segment := NewSegmentInfo(&datapb.SegmentInfo{
+		State: commonpb.SegmentState_Flushed,
+		Level: datapb.SegmentLevel_L1,
+		JsonKeyStats: map[int64]*datapb.JsonKeyStats{
+			fieldID: {JsonKeyStatsDataFormat: common.JSONStatsDataFormatVersion},
+		},
+	})
+
+	s.False(needDoJSONKeyIndex(segment, []UniqueID{fieldID}, true))
+	segment.JsonKeyStats[fieldID].JsonKeyStatsDataFormat =
+		common.JSONStatsDataFormatVersion - 1
+	s.True(needDoJSONKeyIndex(segment, []UniqueID{fieldID}, true))
+	segment.JsonKeyStats[fieldID].JsonKeyStatsDataFormat =
+		common.JSONStatsDataFormatVersion + 1
+	s.True(needDoJSONKeyIndex(segment, []UniqueID{fieldID}, true))
 }
 
 func (s *statsInspectorSuite) TestSubmitStatsTaskSkipExternalCollection() {

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -710,7 +710,11 @@ func (st *statsTask) createJSONKeyStats(ctx context.Context,
 	if jsonKeyStatsDataFormat != common.JSONStatsDataFormatVersion {
 		log.Warn(ctx, "create json key index failed dataformat invalid", mlog.Int64("dataformat version", jsonKeyStatsDataFormat),
 			mlog.Int64("code version", common.JSONStatsDataFormatVersion))
-		return nil
+		return merr.WrapErrServiceNotReadyMsg(
+			"json stats data format %d is incompatible with DataNode format %d",
+			jsonKeyStatsDataFormat,
+			common.JSONStatsDataFormatVersion,
+		)
 	}
 
 	fieldBinlogs := lo.GroupBy(insertBinlogs, func(binlog *datapb.FieldBinlog) int64 {

--- a/internal/datanode/index/task_stats_test.go
+++ b/internal/datanode/index/task_stats_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/workerpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -394,6 +395,29 @@ func (s *TaskStatsSuite) TestJSONKeyStatsPropagatesPluginContext() {
 	s.Require().NoError(err)
 	s.Require().NotNil(captured)
 	s.Equal(pluginContext, captured.GetStoragePluginContext())
+}
+
+func (s *TaskStatsSuite) TestJSONStatsDataFormatMismatchIsRetryable() {
+	st := &statsTask{req: &workerpb.CreateStatsRequest{
+		ClusterID: "cluster",
+		TaskID:    1,
+	}}
+	err := st.createJSONKeyStats(
+		context.Background(),
+		nil,
+		1,
+		2,
+		3,
+		4,
+		5,
+		common.JSONStatsDataFormatVersion+1,
+		nil,
+		256,
+		0.3,
+		81920,
+	)
+	s.ErrorIs(err, merr.ErrServiceNotReady)
+	s.True(merr.IsRetryableErr(err))
 }
 
 func genCollectionSchemaWithBM25() *schemapb.CollectionSchema {

--- a/internal/querycoordv2/checkers/index_checker.go
+++ b/internal/querycoordv2/checkers/index_checker.go
@@ -277,7 +277,7 @@ func (c *IndexChecker) checkSegmentStats(segment *meta.Segment, schema *schemapb
 			fieldID := field.GetFieldID()
 			if h.EnableJSONKeyStatsIndex() {
 				if _, ok := loadFieldMap[fieldID]; ok {
-					if info, ok := segment.JSONStatsField[fieldID]; !ok || info.GetDataFormatVersion() < common.JSONStatsDataFormatVersion {
+					if info, ok := segment.JSONStatsField[fieldID]; !ok || info.GetDataFormatVersion() != common.JSONStatsDataFormatVersion {
 						result = append(result, fieldID)
 					}
 				}

--- a/internal/querycoordv2/checkers/index_checker_test.go
+++ b/internal/querycoordv2/checkers/index_checker_test.go
@@ -182,12 +182,10 @@ func (suite *IndexCheckerSuite) TestJSONStatsRequiresExactFormat() {
 	}
 
 	suite.Empty(suite.checker.checkSegmentStats(segment, schema, []int64{fieldID}))
-	segment.JSONStatsField[fieldID].DataFormatVersion =
-		common.JSONStatsDataFormatVersion - 1
+	segment.JSONStatsField[fieldID].DataFormatVersion = common.JSONStatsDataFormatVersion - 1
 	suite.Equal([]int64{fieldID},
 		suite.checker.checkSegmentStats(segment, schema, []int64{fieldID}))
-	segment.JSONStatsField[fieldID].DataFormatVersion =
-		common.JSONStatsDataFormatVersion + 1
+	segment.JSONStatsField[fieldID].DataFormatVersion = common.JSONStatsDataFormatVersion + 1
 	suite.Equal([]int64{fieldID},
 		suite.checker.checkSegmentStats(segment, schema, []int64{fieldID}))
 }

--- a/internal/querycoordv2/checkers/index_checker_test.go
+++ b/internal/querycoordv2/checkers/index_checker_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/kv"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
@@ -164,6 +165,31 @@ func (suite *IndexCheckerSuite) TestLoadIndex() {
 	utils.RecoverAllCollection(suite.meta)
 	tasks = checker.Check(context.Background())
 	suite.Require().Len(tasks, 0)
+}
+
+func (suite *IndexCheckerSuite) TestJSONStatsRequiresExactFormat() {
+	const fieldID = int64(101)
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{{
+		FieldID:  fieldID,
+		Name:     "json",
+		DataType: schemapb.DataType_JSON,
+	}}}
+	segment := &meta.Segment{
+		SegmentInfo: &datapb.SegmentInfo{ID: 1},
+		JSONStatsField: map[int64]*querypb.JsonStatsInfo{
+			fieldID: {DataFormatVersion: common.JSONStatsDataFormatVersion},
+		},
+	}
+
+	suite.Empty(suite.checker.checkSegmentStats(segment, schema, []int64{fieldID}))
+	segment.JSONStatsField[fieldID].DataFormatVersion =
+		common.JSONStatsDataFormatVersion - 1
+	suite.Equal([]int64{fieldID},
+		suite.checker.checkSegmentStats(segment, schema, []int64{fieldID}))
+	segment.JSONStatsField[fieldID].DataFormatVersion =
+		common.JSONStatsDataFormatVersion + 1
+	suite.Equal([]int64{fieldID},
+		suite.checker.checkSegmentStats(segment, schema, []int64{fieldID}))
 }
 
 func (suite *IndexCheckerSuite) TestIndexInfoNotMatch() {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -190,8 +190,9 @@ const (
 )
 
 const (
-	// Version 3: metadata moved to separate meta.json file (instead of parquet metadata)
-	JSONStatsDataFormatVersion = 3
+	// Version 4: shared BSON may contain undefined sentinels for numeric values
+	// rejected by simdjson. Query nodes load JSON stats by exact format version.
+	JSONStatsDataFormatVersion = 4
 )
 
 // Search, Index parameter keys


### PR DESCRIPTION
Backport of #52828

Related to #52806

## What changed

- use simdjson number parsing consistently with the growing/raw JSON path
- treat a valid JSON number that cannot be represented by the target numeric type as an invalid value for comparisons, while preserving field presence for `exists`
- keep malformed JSON as an error
- write Arrow null for typed JSON stats values and BSON undefined for shared/array values that are present but numerically unrepresentable
- bump the JSON stats data format to v4 and require an exact format match before consuming stats
- add parity coverage for raw scan, typed JSON path index, shared JSON stats, arrays, sibling fields, and subnormal values

## Compatibility

This is a clean backport of the master fix. Existing JSON stats generated with the older format must be rebuilt; version mismatches are returned as retryable so mixed-version components do not silently consume incompatible stats.

## Validation

- focused raw-scan tests passed repeatedly on the master implementation
- typed-path and JSON-stats focused tests passed on the master implementation
- affected C++ translation units passed syntax compilation
- 3.0 conflict resolution passed `git diff --check`, conflict-marker checks, and `gofmt`
- focused Go execution in this worktree is environment-blocked before tests by unavailable local `milvus_core`, `rocksdb`, and `milvus-storage` packages
