### PR TITLE
fix: replace removed MmapConfig setters in MatchExprTest

### DIFF
--- a/internal/core/src/exec/expression/MatchExprTest.cpp
+++ b/internal/core/src/exec/expression/MatchExprTest.cpp
@@ -1060,9 +1060,9 @@ TEST(MatchExprNestedArrayExpressions, MatchFamilyGrowingAndSealed) {
     {
         auto& mmap_config = storage::MmapManager::GetInstance().GetMmapConfig();
         const auto saved_growing_mmap = mmap_config.GetEnableGrowingMmap();
-        mmap_config.SetEnableGrowingMmap(true);
+        mmap_config.growing_enable_mmap = true;
         auto mmap_guard = folly::makeGuard([&mmap_config, saved_growing_mmap] {
-            mmap_config.SetEnableGrowingMmap(saved_growing_mmap);
+            mmap_config.growing_enable_mmap = saved_growing_mmap;
         });
 
         auto& config = SegcoreConfig::default_config();


### PR DESCRIPTION
## What changed

`MatchExprTest.cpp` still called `MmapConfig::SetEnableGrowingMmap`, which #52756 removed as dead code. This breaks the `ci-v2/ut-cpp` build (compile error) for every master-based PR, including Go-only PRs like #52818.

Assign the public `growing_enable_mmap` field directly, matching the pattern already used in `internal/core/src/mmap/ChunkVectorTest.cpp`.

## Validation

- The only remaining callers of the removed setters were these two lines (verified by grep across `internal/core`).
- Local ut-cpp build not run (requires full C++ dependency stack); CI will validate.