### PR TITLE
enhance: enable CMake unity build and reduce hot-header includes

### DIFF
--- a/internal/core/CMakeLists.txt
+++ b/internal/core/CMakeLists.txt
@@ -50,14 +50,6 @@ else ()
     message(FATAL_ERROR "Unsupported platform!" )
 endif ()
 
-# Use -g1 (minimal debug info) for Release to speed up compile & link;
-# full -g for Debug/RelWithDebInfo where detailed debugging matters.
-if (CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g1")
-else ()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
-endif ()
-
 # Use pipes between compiler stages instead of temp files (faster I/O)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pipe")
@@ -114,15 +106,6 @@ set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
 
 # **************************** Project ****************************
 project( milvus VERSION "${MILVUS_VERSION}" )
-
-# Unity (jumbo) build: merge multiple .cpp files per target into fewer
-# translation units, dramatically reducing redundant header parsing.
-if ( MILVUS_UNITY_BUILD )
-    set( CMAKE_UNITY_BUILD ON )
-    # ~8 sources per unity chunk is a good balance between speed and memory.
-    set( CMAKE_UNITY_BUILD_BATCH_SIZE 8 )
-    message( STATUS "Unity build enabled (batch size ${CMAKE_UNITY_BUILD_BATCH_SIZE})" )
-endif ()
 
 set( CMAKE_CXX_STANDARD 20 )
 set( CMAKE_CXX_STANDARD_REQUIRED on )
@@ -204,6 +187,61 @@ include( CTest )
 include( BuildUtils )
 include( DefineOptions )
 using_ccache_if_defined(MILVUS_USE_CCACHE)
+
+# Use -g1 (minimal debug info) for Release to speed up compile & link;
+# full -g for Debug/RelWithDebInfo where detailed debugging matters.
+# MILVUS_DEV_DEBUG_INFO=line-tables is an opt-in mode mapping to clang's
+# -gline-tables-only (GCC's -g1): stack traces + file:line only, no
+# variable-level DWARF. The default remains "full"; pass line-tables only when
+# faster/smaller developer builds do not need variable inspection. Defined via
+# define_option_string in DefineOptions.cmake so the configure summary reports
+# it and the allowed values are enumerated.
+if (MILVUS_DEV_DEBUG_INFO STREQUAL "line-tables")
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        set(MILVUS_DEV_DEBUG_FLAG "-gline-tables-only")
+    else ()
+        set(MILVUS_DEV_DEBUG_FLAG "-g1")
+    endif ()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MILVUS_DEV_DEBUG_FLAG}")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${MILVUS_DEV_DEBUG_FLAG}")
+    # CMake emits the per-config flags (CMAKE_CXX_FLAGS_DEBUG /
+    # CMAKE_CXX_FLAGS_RELWITHDEBINFO, both "-g" by default) AFTER the general
+    # CMAKE_CXX_FLAGS, and the last -g option wins, which would silently
+    # override the line-tables flag above. Re-apply it in the per-config flags
+    # so line-tables stays effective in Debug/RelWithDebInfo.
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${MILVUS_DEV_DEBUG_FLAG}")
+    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} ${MILVUS_DEV_DEBUG_FLAG}")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} ${MILVUS_DEV_DEBUG_FLAG}")
+    set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} ${MILVUS_DEV_DEBUG_FLAG}")
+elseif (CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g1")
+else ()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+endif ()
+
+# Unity (jumbo) build: merge multiple .cpp files per target into fewer
+# translation units, dramatically reducing redundant header parsing.
+# Defined after include(DefineOptions) so MILVUS_UNITY_BUILD is defined on a
+# fresh configure. The CMake option defaults to OFF to preserve per-source
+# compile_commands.json for clangd/clang-tidy; scripts/core_build.sh opts in
+# for its normal development path.
+if ( MILVUS_UNITY_BUILD )
+    set( CMAKE_UNITY_BUILD ON )
+    # ~8 sources per unity chunk is a good balance between speed and memory.
+    set( CMAKE_UNITY_BUILD_BATCH_SIZE 8 )
+    message( STATUS "Unity build enabled (batch size ${CMAKE_UNITY_BUILD_BATCH_SIZE})" )
+    if ( CMAKE_EXPORT_COMPILE_COMMANDS )
+        # CMAKE_EXPORT_COMPILE_COMMANDS does not work well with unity builds:
+        # the generated compile_commands.json only lists the jumbo
+        # Unity/unity_*.cxx entries, not the real per-source entries, so
+        # clangd / YouCompleteMe / run_clang_tidy.py cannot resolve individual
+        # sources against this database. Configure with
+        # -DMILVUS_UNITY_BUILD=OFF for IDE tooling and clang-tidy.
+        message( STATUS "Note: unity build is ON; compile_commands.json will only contain "
+                        "unity batch entries. Use -DMILVUS_UNITY_BUILD=OFF for clangd / "
+                        "clang-tidy / other per-source tooling." )
+    endif ()
+endif ()
 
 include( ExternalProject )
 include( GNUInstallDirs )

--- a/internal/core/benchmark/CMakeLists.txt
+++ b/internal/core/benchmark/CMakeLists.txt
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Benchmarks stay out of the unity build (see unittest/CMakeLists.txt).
+set(CMAKE_UNITY_BUILD OFF)
+
 add_executable(fastmem_benchmark FastMemBenchmark.cpp)
 target_include_directories(fastmem_benchmark PRIVATE ${CMAKE_HOME_DIRECTORY}/src)
 target_link_libraries(fastmem_benchmark PRIVATE benchmark::benchmark)

--- a/internal/core/cmake/DefineOptions.cmake
+++ b/internal/core/cmake/DefineOptions.cmake
@@ -63,6 +63,12 @@ define_option(MILVUS_USE_PCH "Use precompiled headers to speed up compilation" O
 
 define_option(MILVUS_UNITY_BUILD "Use CMake unity (jumbo) build to speed up compilation" OFF)
 
+define_option_string(MILVUS_DEV_DEBUG_INFO
+        "Debug info level: full | line-tables (line-tables = -gline-tables-only/-g1)"
+        "full"
+        "full"
+        "line-tables")
+
 define_option(MILVUS_VERBOSE_THIRDPARTY_BUILD
         "Show output from ExternalProjects rather than just logging to files" ON)
 

--- a/internal/core/src/bitset/detail/platform/dynamic.cpp
+++ b/internal/core/src/bitset/detail/platform/dynamic.cpp
@@ -23,17 +23,12 @@
 #include "x86/avx2.h"
 #include "x86/avx512.h"
 #include "x86/instruction_set.h"
-
-using namespace milvus::bitset::detail::x86;
 #endif
 
 #if defined(__aarch64__)
 #include "arm/instruction_set.h"
 #include "arm/neon.h"
 #include "arm/sve.h"
-
-using namespace milvus::bitset::detail::arm;
-
 #endif
 
 #include "vectorized_ref.h"
@@ -482,6 +477,14 @@ static void
 init_dynamic_hook() {
     using namespace milvus::bitset;
     using namespace milvus::bitset::detail;
+
+#if defined(__x86_64__)
+    using namespace milvus::bitset::detail::x86;
+#endif
+
+#if defined(__aarch64__)
+    using namespace milvus::bitset::detail::arm;
+#endif
 
 #if defined(__x86_64__)
     // AVX512 ?

--- a/internal/core/src/clustering/analyze_c.cpp
+++ b/internal/core/src/clustering/analyze_c.cpp
@@ -34,10 +34,9 @@
 #include "storage/loon_ffi/util.h"
 #include "type_c.h"
 
-using namespace milvus;
-
 milvus::storage::StorageConfig
 get_storage_config(const milvus::proto::clustering::StorageConfig& config) {
+    using namespace milvus;
     auto storage_config = milvus::storage::StorageConfig();
     storage_config.address = config.address();
     storage_config.bucket_name = config.bucket_name();
@@ -66,6 +65,7 @@ Analyze(CAnalyze* res_analyze,
         const uint8_t* serialized_analyze_info,
         const uint64_t len,
         const CPluginContext* plugin_context) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     try {
@@ -171,6 +171,7 @@ Analyze(CAnalyze* res_analyze,
 
 CStatus
 DeleteAnalyze(CAnalyze analyze) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     auto status = CStatus();
@@ -194,6 +195,7 @@ GetAnalyzeResultMeta(CAnalyze analyze,
                      int64_t* centroid_file_size,
                      void* id_mapping_paths,
                      int64_t* id_mapping_sizes) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     auto status = CStatus();

--- a/internal/core/src/common/FieldDataInterface.h
+++ b/internal/core/src/common/FieldDataInterface.h
@@ -28,9 +28,10 @@
 
 #include "log/Log.h"
 #include "Types.h"
-#include "arrow/api.h"
+#include "arrow/array/array_base.h"
 #include "arrow/array/array_binary.h"
 #include "arrow/chunked_array.h"
+#include "arrow/type.h"
 #include "common/FieldMeta.h"
 #include "common/Utils.h"
 #include "common/VectorTrait.h"

--- a/internal/core/src/common/binary_set_c.h
+++ b/internal/core/src/common/binary_set_c.h
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/internal/core/src/exec/Driver.cpp
+++ b/internal/core/src/exec/Driver.cpp
@@ -539,3 +539,5 @@ LocalPlanner::Plan(
 
 }  // namespace exec
 }  // namespace milvus
+
+#undef CALL_OPERATOR

--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
@@ -3117,3 +3117,7 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImpl<int64_t>(
 
 }  //namespace exec
 }  // namespace milvus
+
+#undef BinaryArithRangeJSONCompare
+#undef BinaryArithRangeJONCompareArrayLength
+#undef BinaryArithRangeArrayCompare

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
@@ -808,3 +808,7 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
 
 }  //namespace exec
 }  // namespace milvus
+
+#undef GEOMETRY_EXECUTE_SUB_BATCH_WITH_COMPARISON
+#undef GEOMETRY_EXECUTE_SUB_BATCH_WITH_COMPARISON_DISTANCE
+#undef GEOMETRY_EXECUTE_SUB_BATCH_UNARY

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -2528,3 +2528,5 @@ PhyUnaryRangeFilterExpr::PrefetchRawData() {
 
 }  // namespace exec
 }  // namespace milvus
+
+#undef UnaryRangeJSONCompare

--- a/internal/core/src/index/CMakeLists.txt
+++ b/internal/core/src/index/CMakeLists.txt
@@ -14,3 +14,11 @@ add_library(milvus_index OBJECT ${SOURCE_FILES})
 # libsais (PUBLIC) propagates its include dir so the vendored FM-index sources
 # under fmindex/ can #include "libsais.h"; milvus_core links the objects (below).
 target_link_libraries(milvus_index PUBLIC milvus_conan_deps libsais)
+
+# Unity-build escape hatch: VectorDiskIndex.cpp and VectorMemIndex.cpp both
+# declare the same helpers in an anonymous namespace (EmptyEmbListState,
+# EMPTY_EMB_LIST_OFFSET_KEY); merging them collides. Exclude VectorDiskIndex.cpp
+# via the flag-neutral SKIP_UNITY_BUILD_INCLUSION source property.
+set_source_files_properties(
+    ${CMAKE_CURRENT_SOURCE_DIR}/VectorDiskIndex.cpp
+    PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE)

--- a/internal/core/src/index/IndexStructure.h
+++ b/internal/core/src/index/IndexStructure.h
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
+
 namespace milvus::index {
 template <typename T>
 struct IndexStructure {

--- a/internal/core/src/indexbuilder/index_c.cpp
+++ b/internal/core/src/indexbuilder/index_c.cpp
@@ -56,12 +56,12 @@
 #include "storage/loon_ffi/util.h"
 #include "storage/plugin/PluginInterface.h"
 
-using namespace milvus;
 CStatus
 CreateIndexForUT(enum CDataType dtype,
                  const char* serialized_type_params,
                  const char* serialized_index_params,
                  CIndex* res_index) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     auto status = CStatus();
@@ -113,6 +113,7 @@ CreateIndexForUT(enum CDataType dtype,
 
 milvus::storage::StorageConfig
 get_storage_config(const milvus::proto::indexcgo::StorageConfig& config) {
+    using namespace milvus;
     auto storage_config = milvus::storage::StorageConfig();
     storage_config.address = std::string(config.address());
     storage_config.bucket_name = std::string(config.bucket_name());
@@ -139,6 +140,7 @@ get_storage_config(const milvus::proto::indexcgo::StorageConfig& config) {
 milvus::OptFieldT
 get_opt_field(const ::google::protobuf::RepeatedPtrField<
               milvus::proto::indexcgo::OptionalFieldInfo>& field_infos) {
+    using namespace milvus;
     milvus::OptFieldT opt_fields_map;
     for (const auto& field_info : field_infos) {
         auto field_id = field_info.fieldid();
@@ -165,6 +167,7 @@ get_opt_field(const ::google::protobuf::RepeatedPtrField<
 milvus::SegmentInsertFiles
 get_segment_insert_files(
     const milvus::proto::indexcgo::SegmentInsertFiles& segment_insert_files) {
+    using namespace milvus;
     milvus::SegmentInsertFiles files;
     for (const auto& column_group_files :
          segment_insert_files.field_insert_files()) {
@@ -182,6 +185,7 @@ milvus::storage::StorageColumnMapping
 get_storage_column_mapping(
     const milvus::proto::schema::FieldSchema& field_schema,
     bool is_milvus_table) {
+    using namespace milvus;
     auto physical_mapping =
         milvus::ResolvePhysicalColumnMapping(is_milvus_table, field_schema);
     milvus::storage::StorageColumnMapping mapping;
@@ -195,6 +199,7 @@ milvus::storage::StorageColumnMapping
 get_storage_column_mapping(
     const milvus::proto::indexcgo::OptionalFieldInfo& field_info,
     bool is_milvus_table) {
+    using namespace milvus;
     milvus::storage::StorageColumnMapping mapping;
     mapping.schema_column_name = field_info.field_name();
     mapping.storage_column_name = std::to_string(field_info.fieldid());
@@ -207,6 +212,7 @@ configure_manifest_file_manager_context(
     milvus::storage::FileManagerContext& file_manager_context,
     const milvus::proto::indexcgo::BuildIndexInfo& build_index_info,
     const milvus::storage::StorageConfig& storage_config) {
+    using namespace milvus;
     if (build_index_info.manifest().empty()) {
         return;
     }
@@ -244,6 +250,7 @@ configure_manifest_file_manager_context(
 
 milvus::Config
 get_config(std::unique_ptr<milvus::proto::indexcgo::BuildIndexInfo>& info) {
+    using namespace milvus;
     milvus::Config config;
     for (auto i = 0; i < info->index_params().size(); ++i) {
         const auto& param = info->index_params(i);
@@ -288,6 +295,7 @@ CStatus
 CreateIndex(CIndex* res_index,
             const uint8_t* serialized_build_index_info,
             const uint64_t len) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     try {
@@ -404,6 +412,7 @@ CStatus
 BuildJsonKeyIndex(ProtoLayoutInterface result,
                   const uint8_t* serialized_build_index_info,
                   const uint64_t len) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     try {
@@ -507,6 +516,7 @@ CStatus
 BuildTextIndex(ProtoLayoutInterface result,
                const uint8_t* serialized_build_index_info,
                const uint64_t len) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     try {
@@ -608,6 +618,7 @@ BuildTextIndex(ProtoLayoutInterface result,
 
 CStatus
 DeleteIndex(CIndex index) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     auto status = CStatus();
@@ -629,6 +640,7 @@ CStatus
 BuildFloatVecIndex(CIndex index,
                    int64_t float_value_num,
                    const float* vectors) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     auto status = CStatus();
@@ -658,6 +670,7 @@ BuildFloatVecIndexWithValidData(CIndex index,
                                 const float* vectors,
                                 const bool* valid_data,
                                 int64_t valid_data_len) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     auto status = CStatus();
@@ -685,6 +698,7 @@ CStatus
 BuildFloat16VecIndex(CIndex index,
                      int64_t float16_value_num,
                      const uint8_t* vectors) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     auto status = CStatus();
@@ -715,6 +729,7 @@ BuildFloat16VecIndexWithValidData(CIndex index,
                                   const uint8_t* vectors,
                                   const bool* valid_data,
                                   int64_t valid_data_len) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     auto status = CStatus();
@@ -743,6 +758,7 @@ CStatus
 BuildBFloat16VecIndex(CIndex index,
                       int64_t bfloat16_value_num,
                       const uint8_t* vectors) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     auto status = CStatus();
@@ -773,6 +789,7 @@ BuildBFloat16VecIndexWithValidData(CIndex index,
                                    const uint8_t* vectors,
                                    const bool* valid_data,
                                    int64_t valid_data_len) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     auto status = CStatus();
@@ -799,6 +816,7 @@ BuildBFloat16VecIndexWithValidData(CIndex index,
 
 CStatus
 BuildBinaryVecIndex(CIndex index, int64_t data_size, const uint8_t* vectors) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     auto status = CStatus();
@@ -829,6 +847,7 @@ BuildBinaryVecIndexWithValidData(CIndex index,
                                  const uint8_t* vectors,
                                  const bool* valid_data,
                                  int64_t valid_data_len) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     auto status = CStatus();
@@ -858,6 +877,7 @@ BuildSparseFloatVecIndex(CIndex index,
                          int64_t row_num,
                          int64_t dim,
                          const uint8_t* vectors) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     auto status = CStatus();
@@ -888,6 +908,7 @@ BuildSparseFloatVecIndexWithValidData(CIndex index,
                                       const uint8_t* vectors,
                                       const bool* valid_data,
                                       int64_t valid_data_len) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     auto status = CStatus();
@@ -913,6 +934,7 @@ BuildSparseFloatVecIndexWithValidData(CIndex index,
 
 CStatus
 BuildInt8VecIndex(CIndex index, int64_t int8_value_num, const int8_t* vectors) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     auto status = CStatus();
@@ -942,6 +964,7 @@ BuildInt8VecIndexWithValidData(CIndex index,
                                const int8_t* vectors,
                                const bool* valid_data,
                                int64_t valid_data_len) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     auto status = CStatus();
@@ -972,6 +995,7 @@ BuildInt8VecIndexWithValidData(CIndex index,
 // TODO: optimize here if necessary.
 CStatus
 BuildScalarIndex(CIndex c_index, int64_t size, const void* field_data) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     auto status = CStatus();
@@ -996,6 +1020,7 @@ BuildScalarIndex(CIndex c_index, int64_t size, const void* field_data) {
 
 CStatus
 SerializeIndexToBinarySet(CIndex index, CBinarySet* c_binary_set) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     auto status = CStatus();
@@ -1019,6 +1044,7 @@ SerializeIndexToBinarySet(CIndex index, CBinarySet* c_binary_set) {
 
 CStatus
 LoadIndexFromBinarySet(CIndex index, CBinarySet c_binary_set) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     auto status = CStatus();
@@ -1041,6 +1067,7 @@ LoadIndexFromBinarySet(CIndex index, CBinarySet c_binary_set) {
 
 CStatus
 CleanLocalData(CIndex index) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     auto status = CStatus();
@@ -1063,6 +1090,7 @@ CleanLocalData(CIndex index) {
 
 CStatus
 SerializeIndexAndUpLoad(CIndex index, ProtoLayoutInterface result) {
+    using namespace milvus;
     SCOPE_CGO_CALL_METRIC();
 
     auto status = CStatus();

--- a/internal/core/src/indexbuilder/types.h
+++ b/internal/core/src/indexbuilder/types.h
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
 #include <map>
 #include <stdint.h>
 #include <string>

--- a/internal/core/src/pb/CMakeLists.txt
+++ b/internal/core/src/pb/CMakeLists.txt
@@ -14,3 +14,8 @@ find_package(Protobuf REQUIRED)
 add_source_at_current_directory_recursively()
 add_library(milvus_pb OBJECT ${SOURCE_FILES})
 target_link_libraries(milvus_pb PUBLIC milvus_conan_deps)
+
+# Protobuf-generated .pb.cc files declare non-static globals (schemas[],
+# file_default_instances[], _static_init2_*) that collide when CMake Unity Build
+# merges several of them into one jumbo TU. Keep generated code out of batches.
+set_target_properties(milvus_pb PROPERTIES UNITY_BUILD OFF)

--- a/internal/core/src/segcore/load_field_data_c.h
+++ b/internal/core/src/segcore/load_field_data_c.h
@@ -15,6 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
 #include <stdint.h>
 #include <stdbool.h>
 

--- a/internal/core/src/segcore/load_index_c.h
+++ b/internal/core/src/segcore/load_index_c.h
@@ -9,6 +9,8 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#pragma once
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/internal/core/src/segcore/metrics_c.h
+++ b/internal/core/src/segcore/metrics_c.h
@@ -9,6 +9,8 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#pragma once
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/internal/core/src/segcore/storagev1translator/InterimSealedIndexTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/InterimSealedIndexTranslator.h
@@ -9,6 +9,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#pragma once
 #include <cstdint>
 #include "cachinglayer/Translator.h"
 #include "common/Types.h"

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.h
@@ -9,6 +9,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#pragma once
 #include <cstdint>
 #include <optional>
 

--- a/internal/core/src/segcore/vector_index_c.h
+++ b/internal/core/src/segcore/vector_index_c.h
@@ -9,6 +9,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#pragma once
 #include <stdint.h>
 #ifdef __cplusplus
 extern "C" {

--- a/internal/core/src/storage/CMakeLists.txt
+++ b/internal/core/src/storage/CMakeLists.txt
@@ -40,3 +40,15 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/plugin)
 
 add_library(milvus_storage OBJECT ${SOURCE_FILES})
 target_link_libraries(milvus_storage PUBLIC milvus_conan_deps)
+
+# Unity-build escape hatches: cloud-provider credential files carry identical
+# file-scope constants (STS_* log tags / expiration grace periods) copied from
+# AWS SDK samples. Merging them into one jumbo TU triggers redefinitions, so
+# exclude them from unity batches via the flag-neutral SKIP_UNITY_BUILD_INCLUSION
+# source property (no compile-flag change in any build type).
+set_source_files_properties(
+    ${CMAKE_CURRENT_SOURCE_DIR}/tencent/TencentCloudCredentialsProvider.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tencent/TencentCloudSTSClient.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/huawei/HuaweiCloudCredentialsProvider.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/huawei/HuaweiCloudSTSClient.cpp
+    PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE)

--- a/internal/core/src/storage/KeyRetriever.h
+++ b/internal/core/src/storage/KeyRetriever.h
@@ -9,6 +9,8 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#pragma once
+
 #include "common/type_c.h"
 #include "parquet/encryption/encryption.h"
 #include "parquet/properties.h"

--- a/internal/core/src/storage/huawei/HuaweiCloudCredentialsProvider.h
+++ b/internal/core/src/storage/huawei/HuaweiCloudCredentialsProvider.h
@@ -9,6 +9,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#pragma once
 #include <atomic>
 #include <chrono>
 #include <aws/core/auth/AWSCredentialsProvider.h>

--- a/internal/core/thirdparty/CMakeLists.txt
+++ b/internal/core/thirdparty/CMakeLists.txt
@@ -14,6 +14,12 @@
 # Thirdpart cxx and c flags
 append_flags(CMAKE_CXX_FLAGS FLAGS "-O3 -fPIC -Wno-error -fopenmp -Wno-macro-redefined")
 
+# Unity build is scoped to Milvus' own src (set in the parent CMakeLists.txt).
+# Third-party sub-builds (knowhere/faiss, rocksdb, rdkafka, ...) are excluded:
+# merging their TUs triggers file-scope symbol collisions (e.g. faiss::SL,
+# faiss::roundup) and these trees are rarely recompiled during the dev loop.
+set(CMAKE_UNITY_BUILD OFF)
+
 if (NOT KNOWHERE_VERBOSE_THIRDPARTY_BUILD)
     set(EP_LOG_OPTIONS LOG_CONFIGURE 1 LOG_BUILD 1 LOG_INSTALL 1 LOG_DOWNLOAD 1)
 else ()

--- a/internal/core/unittest/CMakeLists.txt
+++ b/internal/core/unittest/CMakeLists.txt
@@ -9,6 +9,13 @@
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 # or implied. See the License for the specific language governing permissions and limitations under the License
 
+# Unit tests stay out of the unity build: all_tests GLOB_RECURSEs hundreds of
+# *Test.cpp files that declare identical file-scope names (e.g.
+# `constexpr int64_t nb = 100;` in ScalarIndexTest.cpp / StringIndexSortTest.cpp
+# / StringIndexTest.cpp / ScalarIndexCreatorTest.cpp), which collide when
+# merged into one jumbo TU.
+set(CMAKE_UNITY_BUILD OFF)
+
 include_directories(${CMAKE_HOME_DIRECTORY}/src)
 include_directories(${CMAKE_HOME_DIRECTORY}/src/thirdparty)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})

--- a/scripts/core_build.sh
+++ b/scripts/core_build.sh
@@ -109,7 +109,10 @@ fi
 : "${ENABLE_GCP_NATIVE:="OFF"}"
 # Build acceleration options (override via env vars)
 : "${USE_PCH:="ON"}"
-: "${USE_UNITY_BUILD:="OFF"}"
+: "${USE_UNITY_BUILD:="ON"}"
+# Debug info level: "full" or "line-tables". line-tables is opt-in and maps to
+# -gline-tables-only/-g1 (stack traces + file:line, no variable-level DWARF).
+: "${DEV_DEBUG_INFO:="full"}"
 
 while getopts "p:t:s:n:a:y:x:f:S:ulcgbZh" arg; do
   case $arg in
@@ -255,7 +258,8 @@ ${CMAKE_EXTRA_ARGS} \
 -DENABLE_GCP_NATIVE=${ENABLE_GCP_NATIVE} \
 -DENABLE_AZURE_FS=${ENABLE_AZURE_FS} \
 -DMILVUS_USE_PCH=${USE_PCH} \
--DMILVUS_UNITY_BUILD=${USE_UNITY_BUILD} "
+-DMILVUS_UNITY_BUILD=${USE_UNITY_BUILD} \
+-DMILVUS_DEV_DEBUG_INFO=${DEV_DEBUG_INFO} "
 # Azure build variables removed as we now use Arrow with Azure support directly
 CMAKE_CMD=${CMAKE_CMD}"${CPP_SRC_DIR}"
 


### PR DESCRIPTION
## Reason

  Rebuilding the Milvus C++ core is a significant part of the local development
  loop. Many production sources include substantially the same header closures,
  so a normal build reparses those headers once per source file.

  Unity build reduces that redundancy by compiling several Milvus-owned sources
  in one translation unit and amortizing their shared includes. This change also
  adds an opt-in line-tables debug mode and narrows one direct Arrow header
  dependency.

  This change intentionally does not include extern-template work; that requires
  separate investigation and measurements.

  ## What changed

  ### Unity-build policy

  The unity-build policy is deliberately split between the normal build script
  and direct CMake configuration:

  - `scripts/core_build.sh` defaults `USE_UNITY_BUILD` to `ON`.
  - The script explicitly passes that value to CMake as
    `MILVUS_UNITY_BUILD`, so the normal development build path uses unity build.
  - The standalone CMake option `MILVUS_UNITY_BUILD` defaults to `OFF`.
  - Keeping direct CMake configuration non-unity by default preserves per-source
    `compile_commands.json` entries for clangd, YouCompleteMe, and per-source
    clang-tidy.
  - Direct CMake users can explicitly enable unity build with:

    ```bash
    -DMILVUS_UNITY_BUILD=ON

  - CMAKE_UNITY_BUILD_BATCH_SIZE is set to 8.
  - With unity explicitly enabled, this revision generates 38 unity batch
    files covering 223 Milvus-owned source includes across the production
    src targets.

  The following sources and targets are deliberately kept out of unity batches:

  - Generated protobuf sources in src/pb, because generated .pb.cc files
    contain colliding file-scope/generated symbols.

  - Unit tests and benchmarks, because test sources commonly define identical
    file-scope constants and helpers.

  - In-tree third-party build directories, so Milvus' unity setting does not
    alter knowhere/faiss, rocksdb, rdkafka, and other dependency trees.

  - VectorDiskIndex.cpp, which declares helpers colliding with those in
    VectorMemIndex.cpp.

  - Tencent/Huawei credential-provider sources containing duplicated STS_*
    file-scope names.

  These exclusions use CMake's UNITY_BUILD OFF or
  SKIP_UNITY_BUILD_INCLUSION properties; no compiler optimization flags are
  changed to escape a unity batch.

  ### Unity-build hygiene

  Unity build merges several source files into one translation unit, so
  file-local macros and namespace lookup state can otherwise leak into later
  sources in the same batch.

  This change cleans up the known cases:

  - File-local helper macros are explicitly undefined with #undef before the
    end of their source files.

  - File-scope using namespace directives in unity-participating sources were
    removed or moved into function scope.

  - This prevents macro definitions and namespace lookup changes from affecting
    unrelated source files included later in the same unity batch.

  Developers adding production sources should continue to avoid:

  - unguarded file-scope macros;
  - duplicated file-scope or anonymous-namespace symbols;
  - unnecessary file-scope using namespace directives.

  A source that cannot safely participate in a unity batch can be excluded with:

  set_source_files_properties(<source>
      PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE)

  ### Opt-in line-tables debug information

  Added MILVUS_DEV_DEBUG_INFO with these supported values:

  - full
  - line-tables

  The default remains full, so this does not change existing CI or developer
  debug-information behavior.

  With line-tables:

  - Clang uses -gline-tables-only.
  - GCC uses -g1.
  - The flag is re-applied after CMake's per-configuration
    Debug/RelWithDebInfo -g flags so the requested line-tables mode remains
    effective.

  scripts/core_build.sh forwards DEV_DEBUG_INFO to CMake as
  MILVUS_DEV_DEBUG_INFO. For example:

  DEV_DEBUG_INFO=line-tables ./scripts/core_build.sh ...

  This mode remains opt-in and is useful when stack traces and file/line
  information are sufficient and variable-level DWARF is not required.

  ### Reduce direct Arrow includes

  FieldDataInterface.h no longer includes the broad arrow/api.h. It now
  includes the concrete Arrow headers needed by that file:

  - arrow/array/array_base.h
  - arrow/array/array_binary.h
  - arrow/chunked_array.h
  - arrow/type.h

  This is an include-hygiene cleanup; no runtime behavior change is intended.

  ### Add missing include guards

  Added #pragma once to 11 headers that could be indirectly included more
  than once once sources were merged into unity batches:

  - src/common/binary_set_c.h
  - src/index/IndexStructure.h
  - src/indexbuilder/types.h
  - src/segcore/load_field_data_c.h
  - src/segcore/load_index_c.h
  - src/segcore/metrics_c.h
  - src/segcore/storagev1translator/InterimSealedIndexTranslator.h
  - src/segcore/storagev1translator/SealedIndexTranslator.h
  - src/segcore/vector_index_c.h
  - src/storage/KeyRetriever.h
  - src/storage/huawei/HuaweiCloudCredentialsProvider.h

  ## Migration notes

  - A fresh bare CMake configure selects MILVUS_UNITY_BUILD=OFF.
  - Existing CMake build directories retain whatever MILVUS_UNITY_BUILD value
    is already cached.

  - The normal scripts/core_build.sh path defaults USE_UNITY_BUILD to ON
    and passes -DMILVUS_UNITY_BUILD=${USE_UNITY_BUILD} explicitly on every
    configure.

  - Therefore:
      - direct CMake defaults to non-unity;
      - scripts/core_build.sh defaults to unity;
      - existing build directories continue using their cached value unless the
        script or an explicit -D argument overrides it.

  To enable unity build through direct CMake configuration:

  -DMILVUS_UNITY_BUILD=ON

  When unity build is enabled, CMake's compile_commands.json contains unity
  batch entries rather than one entry per original source file. For clangd,
  YouCompleteMe, or per-source clang-tidy, use a separate non-unity
  configuration:

  -DMILVUS_UNITY_BUILD=OFF

  ## Benchmark evidence

  No cold-build, incremental-rebuild, binary-size, or runtime-performance
  improvement is claimed in this PR body without a corresponding paired
  measurement.

  For reviewers evaluating the build-time effect, the useful measurements are:

  1. Full build with MILVUS_UNITY_BUILD=OFF versus ON.
  2. Incremental rebuild after touching one .cpp.
  3. Incremental rebuild after touching a shared header.
  4. MILVUS_DEV_DEBUG_INFO=full versus line-tables.
  5. Binary/object sizes.
  6. A representative runtime performance comparison, since unity builds can
     expose latent translation-unit-boundary issues even though this change does
     not intentionally alter runtime code.

  ## Validation

  - A fresh bare CMake configure selects MILVUS_UNITY_BUILD=OFF and produces
    per-source compile commands.

  - A configure with unity explicitly enabled, including the normal
    scripts/core_build.sh path, generated 38 unity batches and 223
    unity-included Milvus-owned sources.

  - Modified production sources were compiled successfully in both non-unity and
    unity configurations.

  - Verified that GCC Debug with MILVUS_DEV_DEBUG_INFO=line-tables emits both
    CMake's default -g and the later -g1, so line-tables wins.

## Conclusions

1. **The cold/full build of Milvus-owned C++ code became significantly faster.**
   - Parent commit + Unity OFF: `17:43.52`
   - Current commit + Unity ON: `7:22.50`
   - Speedup: approximately `2.40x`
   - Time saved: approximately `10m21s`
   - Wall-time reduction: approximately `58.4%`

2. **The measured cold-build benefit mainly comes from Unity Build rather than the other include changes in this PR.**
   - Parent + Unity OFF: `17:43.52`
   - Current + Unity OFF: `17:54.76`
   - The difference is only `11.24s`, or about `1.1%`, which is effectively unchanged in this benchmark.

3. **A single `.cpp` incremental rebuild became noticeably slower.**
   - Parent + Unity OFF: `39.18s`
   - Current + Unity ON: `2:25.59`
   - This is about `3.72x` slower and adds `1:46.41`.
   - Reason: after changing `Driver.cpp`, Unity Build must rebuild the entire `unity_0` batch containing that source.
