### PR TITLE
enhance: Parallelize search output field materialization

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -8869,44 +8869,17 @@ ChunkedSegmentSealedImpl::FillTargetEntry(const query::Plan* plan,
     bool used_take = TryTakeForSearch(
         plan, results.seg_offsets_.data(), size, results, op_ctx);
 
-    std::unique_ptr<DataArray> field_data;
-    // Per-call OpContext keeps storage_usage scoped to this segment;
-    // sharing op_ctx across segments would double-count bytes. See
-    // SegmentInternalInterface::FillPrimaryKeys for the same pattern.
-    milvus::OpContext local_ctx;
-    if (op_ctx != nullptr) {
-        local_ctx.cancellation_token = op_ctx->cancellation_token;
-        local_ctx.runtime_load_priority = op_ctx->runtime_load_priority;
-    }
+    std::vector<FieldId> fields_to_fetch;
+    fields_to_fetch.reserve(plan->target_entries_.size());
     for (auto field_id : plan->target_entries_) {
         // Skip fields already filled by take
         if (used_take && results.output_fields_data_.count(field_id) > 0) {
             continue;
         }
-        segcore::CheckCancellation(
-            op_ctx, get_segment_id(), field_id.get(), "FillTargetEntry");
-        auto& field_meta = plan->schema_->operator[](field_id);
-        if (plan->schema_->get_dynamic_field_id().has_value() &&
-            plan->schema_->get_dynamic_field_id().value() == field_id &&
-            !plan->target_dynamic_fields_.empty()) {
-            auto& target_dynamic_fields = plan->target_dynamic_fields_;
-            field_data = bulk_subscript(&local_ctx,
-                                        field_id,
-                                        results.seg_offsets_.data(),
-                                        size,
-                                        target_dynamic_fields);
-        } else if (!is_field_exist(field_id)) {
-            field_data = bulk_subscript_not_exist_field(field_meta, size);
-        } else {
-            field_data = bulk_subscript(
-                &local_ctx, field_id, results.seg_offsets_.data(), size);
-        }
-        results.output_fields_data_[field_id] = std::move(field_data);
+        fields_to_fetch.push_back(field_id);
     }
-    results.search_storage_cost_.scanned_remote_bytes +=
-        local_ctx.storage_usage.scanned_cold_bytes.load();
-    results.search_storage_cost_.scanned_total_bytes +=
-        local_ctx.storage_usage.scanned_total_bytes.load();
+
+    FillSearchResultOutputFields(plan, fields_to_fetch, results, op_ctx);
 }
 
 // ---- Shared helpers for TryTakeForRetrieve / TryTakeForSearch ----

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -11,15 +11,20 @@
 
 #include "SegmentInterface.h"
 
+#include <folly/CancellationToken.h>
 #include <folly/ExceptionWrapper.h>
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
+#include <future>
 #include <limits>
 #include <map>
+#include <memory>
 #include <ratio>
 #include <type_traits>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include "ChunkedSegmentSealedImpl.h"
 #include "NamedType/named_type_impl.hpp"
@@ -47,6 +52,8 @@
 #include "query/PlanImpl.h"
 #include "query/PlanNode.h"
 #include "segcore/ConcurrentVector.h"
+#include "storage/ThreadPools.h"
+#include "storage/Util.h"
 
 namespace milvus::segcore {
 
@@ -55,6 +62,17 @@ SegmentInternalInterface::GetGeometryCache(FieldId field_id) const {
     return milvus::exec::SimpleGeometryCacheManager::Instance().GetCache(
         segment_instance_uid(), get_segment_id(), field_id);
 }
+
+namespace {
+
+struct FetchedOutputField {
+    FieldId field_id;
+    std::unique_ptr<DataArray> field_data;
+    int64_t scanned_remote_bytes;
+    int64_t scanned_total_bytes;
+};
+
+}  // namespace
 
 void
 SegmentInternalInterface::FillPrimaryKeys(const query::Plan* plan,
@@ -97,6 +115,80 @@ SegmentInternalInterface::FillPrimaryKeys(const query::Plan* plan,
 }
 
 void
+SegmentInternalInterface::FillSearchResultOutputFields(
+    const query::Plan* plan,
+    const std::vector<FieldId>& field_ids,
+    SearchResult& results,
+    milvus::OpContext* op_ctx) const {
+    if (field_ids.empty()) {
+        return;
+    }
+
+    const auto size = results.seg_offsets_.size();
+    auto fetch_one = [this, plan, &results, size, op_ctx](FieldId field_id) {
+        milvus::OpContext field_ctx;
+        if (op_ctx != nullptr) {
+            field_ctx.cancellation_token = op_ctx->cancellation_token;
+            field_ctx.runtime_load_priority = op_ctx->runtime_load_priority;
+            field_ctx.coload_fields = op_ctx->coload_fields;
+            field_ctx.pinned_segment_state = op_ctx->pinned_segment_state;
+            field_ctx.pinned_state_owner = op_ctx->pinned_state_owner;
+            field_ctx.trace_context = op_ctx->trace_context;
+            field_ctx.trace_span = op_ctx->trace_span;
+        }
+        segcore::CheckCancellation(
+            &field_ctx, get_segment_id(), field_id.get(), "FillTargetEntry");
+        auto& field_meta = plan->schema_->operator[](field_id);
+        std::unique_ptr<DataArray> field_data;
+        if (plan->schema_->get_dynamic_field_id().has_value() &&
+            plan->schema_->get_dynamic_field_id().value() == field_id &&
+            !plan->target_dynamic_fields_.empty()) {
+            field_data = bulk_subscript(&field_ctx,
+                                        field_id,
+                                        results.seg_offsets_.data(),
+                                        size,
+                                        plan->target_dynamic_fields_);
+        } else if (!is_field_exist(field_id)) {
+            field_data = bulk_subscript_not_exist_field(field_meta, size);
+        } else {
+            field_data = bulk_subscript(
+                &field_ctx, field_id, results.seg_offsets_.data(), size);
+        }
+        return FetchedOutputField{
+            field_id,
+            std::move(field_data),
+            field_ctx.storage_usage.scanned_cold_bytes.load(),
+            field_ctx.storage_usage.scanned_total_bytes.load()};
+    };
+
+    // Multi-segment parents run on the search executor. Use MIDDLE for field
+    // tasks so parents and children never wait on the same pool.
+    std::vector<std::future<FetchedOutputField>> futures;
+    futures.reserve(field_ids.size());
+    auto& pool = ThreadPools::GetThreadPool(ThreadPoolPriority::MIDDLE);
+    try {
+        for (auto field_id : field_ids) {
+            futures.emplace_back(pool.Submit(
+                [fetch_one, field_id] { return fetch_one(field_id); }));
+        }
+    } catch (...) {
+        storage::DrainFutures(futures);
+        throw;
+    }
+
+    auto fetched_fields = storage::WaitAllFutures(std::move(futures));
+
+    for (auto& fetched : fetched_fields) {
+        results.output_fields_data_[fetched.field_id] =
+            std::move(fetched.field_data);
+        results.search_storage_cost_.scanned_remote_bytes +=
+            fetched.scanned_remote_bytes;
+        results.search_storage_cost_.scanned_total_bytes +=
+            fetched.scanned_total_bytes;
+    }
+}
+
+void
 SegmentInternalInterface::FillTargetEntry(const query::Plan* plan,
                                           SearchResult& results,
                                           milvus::OpContext* op_ctx) const {
@@ -106,40 +198,7 @@ SegmentInternalInterface::FillTargetEntry(const query::Plan* plan,
     AssertInfo(results.seg_offsets_.size() == size,
                "Size of result distances is not equal to size of ids");
 
-    std::unique_ptr<DataArray> field_data;
-    // See FillPrimaryKeys: per-call OpContext so storage_usage stays scoped
-    // to this segment's fills.
-    milvus::OpContext local_ctx;
-    if (op_ctx != nullptr) {
-        local_ctx.cancellation_token = op_ctx->cancellation_token;
-        local_ctx.runtime_load_priority = op_ctx->runtime_load_priority;
-    }
-    // fill other entries except primary key by result_offset
-    for (auto field_id : plan->target_entries_) {
-        segcore::CheckCancellation(
-            op_ctx, get_segment_id(), field_id.get(), "FillTargetEntry");
-        auto& field_meta = plan->schema_->operator[](field_id);
-        if (plan->schema_->get_dynamic_field_id().has_value() &&
-            plan->schema_->get_dynamic_field_id().value() == field_id &&
-            !plan->target_dynamic_fields_.empty()) {
-            auto& target_dynamic_fields = plan->target_dynamic_fields_;
-            field_data = bulk_subscript(&local_ctx,
-                                        field_id,
-                                        results.seg_offsets_.data(),
-                                        size,
-                                        target_dynamic_fields);
-        } else if (!is_field_exist(field_id)) {
-            field_data = bulk_subscript_not_exist_field(field_meta, size);
-        } else {
-            field_data = bulk_subscript(
-                &local_ctx, field_id, results.seg_offsets_.data(), size);
-        }
-        results.output_fields_data_[field_id] = std::move(field_data);
-    }
-    results.search_storage_cost_.scanned_remote_bytes +=
-        local_ctx.storage_usage.scanned_cold_bytes.load();
-    results.search_storage_cost_.scanned_total_bytes +=
-        local_ctx.storage_usage.scanned_total_bytes.load();
+    FillSearchResultOutputFields(plan, plan->target_entries_, results, op_ctx);
 }
 
 std::unique_ptr<SearchResult>

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -803,6 +803,15 @@ class SegmentInternalInterface : public SegmentInterface {
                                    int64_t count) const;
 
  protected:
+    // Fetch independent search output fields concurrently, then publish them
+    // to SearchResult on the caller thread. Futures are drained before return,
+    // and each fetch has its own OpContext for race-free storage accounting.
+    void
+    FillSearchResultOutputFields(const query::Plan* plan,
+                                 const std::vector<FieldId>& field_ids,
+                                 SearchResult& results,
+                                 milvus::OpContext* op_ctx) const;
+
     // todo: use an Unified struct for all type in growing/seal segment to store data and valid_data.
     // internal API: return chunk_data in span
     virtual PinWrapper<SpanBase>

--- a/internal/core/src/segcore/search_result_export_c.cpp
+++ b/internal/core/src/segcore/search_result_export_c.cpp
@@ -26,6 +26,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "common/EasyAssert.h"
@@ -34,6 +35,7 @@
 #include "log/Log.h"
 #include "common/QueryResult.h"
 #include "common/Types.h"
+#include "futures/Executor.h"
 #include "futures/Future.h"
 #include "monitor/Monitor.h"
 #include "monitor/scope_metric.h"
@@ -43,11 +45,23 @@
 #include "segcore/SegmentReadLease.h"
 #include "segcore/Utils.h"
 #include "segcore/reduce/Reduce.h"
-#include "storage/ThreadPools.h"
 
 using SearchResult = milvus::SearchResult;
 
 namespace {
+
+template <typename F>
+std::future<void>
+SubmitSearchExecutorTask(F&& task) {
+    auto packaged_task =
+        std::make_shared<std::packaged_task<void()>>(std::forward<F>(task));
+    auto future = packaged_task->get_future();
+    milvus::futures::getSearchCPUExecutor()->add(
+        [packaged_task = std::move(packaged_task)]() mutable {
+            (*packaged_task)();
+        });
+    return future;
+}
 
 // GroupByArrowInfo describes one $group_by_<fieldID> Arrow column to emit.
 // Element type is derived from the plan's search_info_, falling back to
@@ -947,8 +961,6 @@ MaterializeOrderedFields(
     };
 
     if (segment_fields.size() > 1) {
-        auto& pool = milvus::ThreadPools::GetThreadPool(
-            milvus::ThreadPoolPriority::MIDDLE);
         std::vector<std::future<void>> futures;
         futures.reserve(segment_fields.size());
         auto futures_guard = folly::makeGuard([&futures]() {
@@ -963,9 +975,10 @@ MaterializeOrderedFields(
         });
         for (auto& entry : segment_fields) {
             auto* materialized = &entry.second;
-            futures.emplace_back(pool.Submit([&materialize_one, materialized] {
-                materialize_one(*materialized);
-            }));
+            futures.emplace_back(
+                SubmitSearchExecutorTask([&materialize_one, materialized] {
+                    materialize_one(*materialized);
+                }));
         }
         for (auto& future : futures) {
             future.get();

--- a/internal/core/src/segcore/search_result_export_c.h
+++ b/internal/core/src/segcore/search_result_export_c.h
@@ -51,8 +51,9 @@ ExportSearchResultAsArrowRecordBatch(CSearchResult c_search_result,
 //   result_seg_offsets[i] = seg_offset within that segment
 // The output proto FieldsData is assembled in the order of these arrays.
 //
-// Internally: groups by segment, calls FillTargetEntry per segment,
-// then uses MergeDataArray to produce the correctly-ordered output.
+// Internally: groups by segment, calls FillTargetEntry per segment (which
+// fetches independent target fields concurrently), then uses MergeDataArray
+// to produce the correctly-ordered output.
 // Writes a serialized SearchResultData proto into out_result. Caller owns
 // out_result->proto_blob and must free it after use when proto_size > 0.
 CStatus

--- a/internal/core/src/segcore/search_result_export_c_test.cpp
+++ b/internal/core/src/segcore/search_result_export_c_test.cpp
@@ -1604,6 +1604,81 @@ TEST(SearchResultExport,
     free(const_cast<char*>(status.error_msg));
 }
 
+TEST(SearchResultExport, FillOutputFieldsOrdered_MultipleSegments) {
+    using namespace milvus;
+    using namespace milvus::segcore;
+
+    auto schema = std::make_shared<Schema>();
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_fid);
+    auto output_fid = schema->AddDebugField("output_i32", DataType::INT32);
+    auto vec_fid = schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+
+    constexpr int64_t row_count = 4;
+    auto raw_data = DataGen(schema, row_count, /*seed=*/1);
+    auto segment_a = CreateSealedWithFieldDataLoaded(schema, raw_data);
+    auto segment_b = CreateSealedWithFieldDataLoaded(schema, raw_data);
+
+    auto plan_bytes = BuildSimpleVectorSearchPlan(vec_fid, /*topk=*/2);
+    auto plan = milvus::query::CreateSearchPlanByExpr(
+        schema, plan_bytes.data(), plan_bytes.size());
+    plan->target_entries_ = {pk_fid, output_fid};
+
+    SearchResult sr_a;
+    SearchResult sr_b;
+    AttachSealedRequestLease(sr_a, segment_a.get());
+    AttachSealedRequestLease(sr_b, segment_b.get());
+    std::vector<CSearchResult> c_results = {
+        reinterpret_cast<CSearchResult>(&sr_a),
+        reinterpret_cast<CSearchResult>(&sr_b)};
+
+    int32_t seg_indices[] = {0, 1, 0, 1};
+    int64_t seg_offsets[] = {0, 1, 2, 3};
+    CProto c_proto{};
+    auto status =
+        FillOutputFieldsOrdered(c_results.data(),
+                                c_results.size(),
+                                reinterpret_cast<CSearchPlan>(plan.get()),
+                                seg_indices,
+                                seg_offsets,
+                                /*total_rows=*/4,
+                                &c_proto,
+                                nullptr);
+    ASSERT_EQ(status.error_code, 0) << status.error_msg;
+    ASSERT_GT(c_proto.proto_size, 0);
+
+    milvus::proto::schema::SearchResultData result_data;
+    ASSERT_TRUE(
+        result_data.ParseFromArray(c_proto.proto_blob, c_proto.proto_size));
+    ASSERT_EQ(result_data.fields_data_size(), 2);
+    EXPECT_EQ(result_data.fields_data(0).field_id(), pk_fid.get());
+    EXPECT_EQ(result_data.fields_data(1).field_id(), output_fid.get());
+
+    const auto pk = raw_data.get_col<int64_t>(pk_fid);
+    const std::vector<int64_t> expected_pk = {pk[0], pk[1], pk[2], pk[3]};
+    const auto& actual_pk =
+        result_data.fields_data(0).scalars().long_data().data();
+    ASSERT_EQ(actual_pk.size(), expected_pk.size());
+    for (size_t i = 0; i < expected_pk.size(); ++i) {
+        EXPECT_EQ(actual_pk.Get(i), expected_pk[i]);
+    }
+
+    const auto output = raw_data.get_col<int32_t>(output_fid);
+    const std::vector<int32_t> expected_output = {
+        output[0], output[1], output[2], output[3]};
+    const auto& actual_output =
+        result_data.fields_data(1).scalars().int_data().data();
+    ASSERT_EQ(actual_output.size(), expected_output.size());
+    for (size_t i = 0; i < expected_output.size(); ++i) {
+        EXPECT_EQ(actual_output.Get(i), expected_output[i])
+            << "position=" << i << ", segment=" << seg_indices[i]
+            << ", offset=" << seg_offsets[i];
+    }
+
+    free(const_cast<void*>(c_proto.proto_blob));
+}
+
 TEST(SearchResultExport, HasTargetEntries) {
     using namespace milvus;
 


### PR DESCRIPTION
## Summary

- run multi-segment ordered field materialization on the search executor
- fetch independent output fields concurrently on the middle-priority pool with per-field operation contexts
- publish fetched fields and storage accounting after all tasks finish
- add ordered multi-segment regression coverage

issue: #52833

## Test Plan

- [x] `make build-cpp-with-unittest SKIP_3RDPARTY=1`
- [x] `cmake_build/unittest/all_tests --gtest_filter=SearchResultExport.FillOutputFieldsOrdered_*`
- [x] repeated the related tests 20 times
- [x] `make cppcheck` with clang-format 15