### PR TITLE
test: re-level import_2pc REST tests L0->L2 (tag audit)

### DIFF
--- a/tests/restful_client_v2/testcases/test_import_2pc_operation.py
+++ b/tests/restful_client_v2/testcases/test_import_2pc_operation.py
@@ -22,7 +22,6 @@ from utils.utils import gen_collection_name
 IMPORT_2PC_TIMEOUT = 360
 
 
-@pytest.mark.tags(CaseLabel.L0)
 class TestImport2PCRestOperation(TestBase):
     def _kubectl_get_release_pods(self, release_name, namespace="chaos-testing"):
         if not shutil.which("kubectl"):
@@ -2411,7 +2410,7 @@ class TestImport2PCRestOperation(TestBase):
                 if os.path.exists(file_path):
                     os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_list_empty_collection_filter_returns_no_records(self):
         """
         target: REST import list empty collectionName filter
@@ -2426,7 +2425,7 @@ class TestImport2PCRestOperation(TestBase):
         records = list_rsp.get("data", {}).get("records", [])
         assert records == [], list_rsp
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_list_rejects_numeric_collection_name(self):
         """
         target: REST import list collectionName type validation
@@ -2548,7 +2547,7 @@ class TestImport2PCRestOperation(TestBase):
             ("files", "array", "list", "type", "string"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_string_options_value(self):
         """
         target: import create options type validation
@@ -2567,7 +2566,7 @@ class TestImport2PCRestOperation(TestBase):
             ("options", "object", "map", "type", "string"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_numeric_partition_name(self):
         """
         target: import create partitionName type validation
@@ -2587,7 +2586,7 @@ class TestImport2PCRestOperation(TestBase):
             ("partition", "string", "type", "number"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_numeric_file_path(self):
         """
         target: import create file path type validation
@@ -2606,7 +2605,7 @@ class TestImport2PCRestOperation(TestBase):
             ("files", "string", "type", "number"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_flat_files_list(self):
         """
         target: import create files nested shape validation
@@ -2625,7 +2624,7 @@ class TestImport2PCRestOperation(TestBase):
             ("files", "array", "list", "type", "string"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_empty_file_group(self):
         """
         target: import create empty file group validation
@@ -2644,7 +2643,7 @@ class TestImport2PCRestOperation(TestBase):
             ("files", "file", "empty"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_numeric_timeout_option(self):
         """
         target: import create timeout option type validation
@@ -2671,7 +2670,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_read_job_endpoints_reject_boolean_job_id(self):
         """
         target: import read job endpoint jobId type validation
@@ -2689,7 +2688,7 @@ class TestImport2PCRestOperation(TestBase):
             ("job", "id", "type", "bool"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_write_job_endpoints_reject_boolean_job_id(self):
         """
         target: import write job endpoint jobId type validation
@@ -2707,7 +2706,7 @@ class TestImport2PCRestOperation(TestBase):
             ("job", "id", "type", "bool"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_null_collection_name(self):
         """
         target: import create collectionName null validation
@@ -2723,7 +2722,7 @@ class TestImport2PCRestOperation(TestBase):
             ("collection", "name", "string", "null"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_null_files(self):
         """
         target: import create files null validation
@@ -2742,7 +2741,7 @@ class TestImport2PCRestOperation(TestBase):
             ("files", "array", "list", "null"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_array_partition_name(self):
         """
         target: import create partitionName array validation
@@ -2762,7 +2761,7 @@ class TestImport2PCRestOperation(TestBase):
             ("partition", "string", "array", "type"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_read_job_endpoints_reject_array_job_id(self):
         """
         target: import read job endpoint jobId array validation
@@ -2780,7 +2779,7 @@ class TestImport2PCRestOperation(TestBase):
             ("job", "id", "array", "type", "unmarshal", "parse"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_write_job_endpoints_reject_array_job_id(self):
         """
         target: import write job endpoint jobId array validation
@@ -2820,7 +2819,7 @@ class TestImport2PCRestOperation(TestBase):
                 ("job", "id", "object", "type", "unmarshal", "parse"),
             )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_array_collection_name(self):
         """
         target: import create collectionName array validation
@@ -2836,7 +2835,7 @@ class TestImport2PCRestOperation(TestBase):
             ("collection", "name", "array", "type", "unmarshal", "string"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_object_collection_name(self):
         """
         target: import create collectionName object validation
@@ -2852,7 +2851,7 @@ class TestImport2PCRestOperation(TestBase):
             ("collection", "name", "object", "type", "unmarshal", "string"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_object_files_value(self):
         """
         target: import create files object validation
@@ -2871,7 +2870,7 @@ class TestImport2PCRestOperation(TestBase):
             ("files", "object", "array", "list", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_object_file_path(self):
         """
         target: import create nested file path object validation
@@ -2890,7 +2889,7 @@ class TestImport2PCRestOperation(TestBase):
             ("files", "path", "object", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_array_options_value(self):
         """
         target: import create options array validation
@@ -2909,7 +2908,7 @@ class TestImport2PCRestOperation(TestBase):
             ("options", "array", "object", "map", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_numeric_options_value(self):
         """
         target: import create options numeric validation
@@ -2928,7 +2927,7 @@ class TestImport2PCRestOperation(TestBase):
             ("options", "number", "object", "map", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_boolean_auto_commit_option(self):
         """
         target: import create auto_commit option value type validation
@@ -2947,7 +2946,7 @@ class TestImport2PCRestOperation(TestBase):
             ("auto_commit", "bool", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_null_auto_commit_option(self):
         """
         target: import create auto_commit option null validation
@@ -2975,7 +2974,7 @@ class TestImport2PCRestOperation(TestBase):
         ), rsp
         assert "jobId" not in str(rsp), rsp
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_array_auto_commit_option(self):
         """
         target: import create auto_commit option array validation
@@ -2994,7 +2993,7 @@ class TestImport2PCRestOperation(TestBase):
             ("auto_commit", "array", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_boolean_backup_option(self):
         """
         target: import create backup option value type validation
@@ -3014,7 +3013,7 @@ class TestImport2PCRestOperation(TestBase):
             ("backup", "bool", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_boolean_l0_import_option(self):
         """
         target: import create l0_import option value type validation
@@ -3033,7 +3032,7 @@ class TestImport2PCRestOperation(TestBase):
             ("l0_import", "bool", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_boolean_skip_disk_quota_check_option(self):
         """
         target: import create skip_disk_quota_check option value type validation
@@ -3052,7 +3051,7 @@ class TestImport2PCRestOperation(TestBase):
             ("skip_disk_quota_check", "bool", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_array_backup_option(self):
         """
         target: import create backup option array validation
@@ -3072,7 +3071,7 @@ class TestImport2PCRestOperation(TestBase):
             ("backup", "array", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_object_backup_option(self):
         """
         target: import create backup option object validation
@@ -3092,7 +3091,7 @@ class TestImport2PCRestOperation(TestBase):
             ("backup", "object", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_array_l0_import_option(self):
         """
         target: import create l0_import option array validation
@@ -3111,7 +3110,7 @@ class TestImport2PCRestOperation(TestBase):
             ("l0_import", "array", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_object_l0_import_option(self):
         """
         target: import create l0_import option object validation
@@ -3130,7 +3129,7 @@ class TestImport2PCRestOperation(TestBase):
             ("l0_import", "object", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_array_skip_disk_quota_check_option(self):
         """
         target: import create skip_disk_quota_check option array validation
@@ -3149,7 +3148,7 @@ class TestImport2PCRestOperation(TestBase):
             ("skip_disk_quota_check", "array", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_object_skip_disk_quota_check_option(self):
         """
         target: import create skip_disk_quota_check option object validation
@@ -3168,7 +3167,7 @@ class TestImport2PCRestOperation(TestBase):
             ("skip_disk_quota_check", "object", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_numeric_storage_version_option(self):
         """
         target: import create storage_version option value type validation
@@ -3188,7 +3187,7 @@ class TestImport2PCRestOperation(TestBase):
             ("storage_version", "number", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_array_start_ts_option(self):
         """
         target: import create start_ts option value type validation
@@ -3208,7 +3207,7 @@ class TestImport2PCRestOperation(TestBase):
             ("start_ts", "array", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_object_end_ts_option(self):
         """
         target: import create end_ts option value type validation
@@ -3228,7 +3227,7 @@ class TestImport2PCRestOperation(TestBase):
             ("end_ts", "object", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_boolean_sep_option(self):
         """
         target: import create CSV sep option value type validation
@@ -3247,7 +3246,7 @@ class TestImport2PCRestOperation(TestBase):
             ("sep", "bool", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_array_nullkey_option(self):
         """
         target: import create CSV nullkey option value type validation
@@ -3266,7 +3265,7 @@ class TestImport2PCRestOperation(TestBase):
             ("nullkey", "array", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_object_ezk_option(self):
         """
         target: import create ezk option value type validation
@@ -3286,7 +3285,7 @@ class TestImport2PCRestOperation(TestBase):
             ("ezk", "object", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_invalid_timeout_option(self):
         """
         target: import create timeout option validation
@@ -3550,7 +3549,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_completed_job_observability_fields_are_reported(self):
         """
         target: completed import job REST observability
@@ -3609,7 +3608,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_completed_import_survives_release_and_reload(self):
         """
         target: completed import visibility after reload/target refresh
@@ -3673,7 +3672,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_db_name_body_and_header_route_same_job_deterministically(self):
         """
         target: import REST database routing
@@ -4016,6 +4015,7 @@ class TestImport2PCRestOperation(TestBase):
                 if os.path.exists(file_path):
                     os.remove(file_path)
 
+    @pytest.mark.tags(CaseLabel.L0)
     def test_import_2pc_default_auto_commit_completed_and_visible(self):
         """
         target: default import compatibility
@@ -4065,7 +4065,7 @@ class TestImport2PCRestOperation(TestBase):
             ("auto_commit", "true", "false"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_auto_commit_uppercase_false_stops_at_uncommitted(self):
         """
         target: auto_commit option contract
@@ -4111,7 +4111,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_empty_parquet_auto_commit_completes_with_zero_rows(self):
         """
         target: empty import file lifecycle
@@ -4220,7 +4220,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_manual_multi_file_import_accumulates_rows(self):
         """
         target: multi-file import request
@@ -4336,7 +4336,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_jsonl_file_manual_import_preserves_rows(self):
         """
         target: JSONL file import with 2PC
@@ -4393,7 +4393,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_csv_file_with_custom_separator_manual_import_preserves_rows(self):
         """
         target: CSV file import with custom separator and 2PC
@@ -4453,7 +4453,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_csv_nullkey_manual_import_preserves_nulls(self):
         """
         target: CSV nullkey import with 2PC
@@ -4534,7 +4534,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_numpy_field_per_file_manual_import_preserves_rows(self):
         """
         target: NumPy field-per-file import with 2PC
@@ -4591,7 +4591,7 @@ class TestImport2PCRestOperation(TestBase):
         finally:
             shutil.rmtree(local_dir, ignore_errors=True)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_invalid_file_suffix_fails_with_reason_and_no_visible_rows(self):
         """
         target: invalid import file suffix handling
@@ -4635,7 +4635,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_csv_invalid_separator_rejected_with_reason_and_no_visible_rows(self):
         """
         target: invalid CSV separator validation
@@ -4678,7 +4678,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_mixed_file_formats_across_file_groups_commits_all_rows(self):
         """
         target: mixed import file format support
@@ -4730,7 +4730,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_backup_invalid_storage_version_fails_with_reason_and_no_visible_rows(self):
         """
         target: backup import storage_version parse contract
@@ -4776,7 +4776,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_backup_storage_version_supported_values_reach_reader_validation(self):
         """
         target: backup import storage_version supported string values
@@ -4840,7 +4840,7 @@ class TestImport2PCRestOperation(TestBase):
                 if os.path.exists(file_path):
                     os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_backup_reversed_time_range_fails_with_reason_and_no_visible_rows(self):
         """
         target: backup import start_ts/end_ts guardrail
@@ -4893,7 +4893,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_backup_camelcase_time_range_alias_fails_with_reason_and_no_visible_rows(self):
         """
         target: backup import startTs/endTs alias guardrail
@@ -4946,7 +4946,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_backup_invalid_start_ts_fails_with_reason_and_no_visible_rows(self):
         """
         target: backup import start_ts parse guardrail
@@ -4998,7 +4998,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_backup_invalid_end_ts_fails_with_reason_and_no_visible_rows(self):
         """
         target: backup import end_ts parse guardrail
@@ -5074,7 +5074,7 @@ class TestImport2PCRestOperation(TestBase):
         self.collection_client.refresh_load(collection_name)
         assert self._query_count(collection_name) == 0
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_skip_disk_quota_check_is_ignored_for_regular_import(self):
         """
         target: skip_disk_quota_check regular import contract
@@ -5295,6 +5295,7 @@ class TestImport2PCRestOperation(TestBase):
             "committed import segments with normal segments"
         )
     )
+    @pytest.mark.tags(CaseLabel.L0)
     def test_import_2pc_manual_compaction_after_commit_preserves_rows(self):
         """
         target: manual compaction after committed import rows
@@ -5841,7 +5842,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_flat_scann_manual_import_searches_after_commit(self):
         """
         target: FLAT and SCANN index import
@@ -6081,7 +6082,7 @@ class TestImport2PCRestOperation(TestBase):
                 if os.path.exists(file_path):
                     os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_sparse_struct_parquet_manual_import_searches_after_commit(self):
         """
         target: SparseFloatVector parquet struct encoding with manual 2PC
@@ -6135,7 +6136,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_bm25_function_input_only_manual_import_searches_after_commit(self):
         """
         target: BM25 function output generation with manual 2PC import
@@ -6207,7 +6208,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_bm25_function_output_field_rejected_and_no_visible_rows(self):
         """
         target: BM25 function output field guardrail with manual 2PC import
@@ -6260,7 +6261,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_scalar_indexes_manual_import_filters_after_commit(self):
         """
         target: scalar indexes with manual 2PC import
@@ -6333,7 +6334,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_half_vector_types_manual_import_searches_after_commit(self):
         """
         target: Float16Vector and BFloat16Vector import with 2PC
@@ -6400,7 +6401,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_int8_vector_manual_import_searches_after_commit(self):
         """
         target: Int8Vector import with 2PC
@@ -6460,7 +6461,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_array_of_vector_manual_import_searches_after_commit(self):
         """
         target: ArrayOfVector import with 2PC
@@ -6528,7 +6529,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_geometry_timestamptz_manual_import_filters_after_commit(self):
         """
         target: Geometry and Timestamptz import with 2PC
@@ -7175,7 +7176,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_partition_key_collection_rejects_explicit_partition_name(self):
         """
         target: explicit partitionName guardrail on partition-key collection import
@@ -7270,7 +7271,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_clustering_key_collection_manual_import_survives_clustering_compaction(self):
         """
         target: clustering-key collection import and clustering compaction with manual 2PC
@@ -7546,7 +7547,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_binary_vector_byte_length_mismatch_fails_with_reason_and_no_visible_rows(self):
         """
         target: BinaryVector byte-length validation for manual import
@@ -7654,7 +7655,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_varchar_overflow_fails_with_reason_and_no_visible_rows(self):
         """
         target: varchar max_length validation for manual import
@@ -7767,7 +7768,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_field_type_mismatch_fails_with_reason_and_no_visible_rows(self):
         """
         target: field type validation for manual import
@@ -7890,7 +7891,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_vector_nan_inf_fails_with_reason_and_no_visible_rows(self):
         """
         target: FloatVector finite-value validation for manual import
@@ -8151,7 +8152,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_flush_during_uncommitted_keeps_import_invisible(self):
         """
         target: manual flush while import is Uncommitted
@@ -8260,7 +8261,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_delete_after_commit_removes_import_rows(self):
         """
         target: delete timestamp after import commit timestamp
@@ -8314,7 +8315,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_mixed_delete_across_commit_boundary(self):
         """
         target: mixed delete timestamps around import commit timestamp
@@ -8387,7 +8388,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_auto_id_scalar_delete_respects_commit_timestamp(self):
         """
         target: auto_id collection delete timestamp boundary with scalar filter
@@ -8518,7 +8519,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_abort_is_idempotent_for_failed_job(self):
         """
         target: abort retry idempotency for terminal failed import job
@@ -8736,7 +8737,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_abort_rejects_completed_job(self):
         """
         target: abort terminal committed import job


### PR DESCRIPTION
## Goal

The whole `TestImport2PCRestOperation` class (144 tests in `tests/restful_client_v2/testcases/test_import_2pc_operation.py`) ran at L0 — every PR gate executed all 144, each doing a real file import (expensive). Per the tag audit (each test body read and classified), this re-levels:

- **Keep 62 core tests at L0** (PR gate): REST contract smoke, jobId type contract, list isolation, missing-required-fields, max-file-count limit, fundamental 2PC lifecycle semantics (uncommitted-invisible, commit->visible+idempotent, abort->failed, delete-before-commit no-op, commit-timestamp semantics), multi-DB isolation, consistency levels, one representative per index family (HNSW/IVF_FLAT/DISKANN/binary/sparse) and per data-type family, and the env-gated CDC/restart tests (they skip in a normal PR gate via `_require_cdc_rest_env` / `_skip_if_release_has_no_component`, so L0 is free there and keeps any CDC/chaos gating intact).
- **Move 81 extended/redundant tests to L2** (nightly): single-field `create_rejects_*` validation variants, file-format/index/data-type matrix variants beyond the representative, backup option validation, state-machine edge cases.
- The RBAC-tagged `user_without_import_privilege` test stays RBAC (not part of the L0/L1 gate).
- Remove the redundant class-level `@pytest.mark.tags(CaseLabel.L0)` marker.

## Impact

| | before | after |
|---|--------|-------|
| PR gate (L0 L1) collected | 144 | **62** |
| Nightly (L0 L1 L2) | 144 | 143 (RBAC test excluded, runs in RBAC suites) |

Zero tests deleted; all moved scenarios still run in nightly. No consolidation into parametrized tests in this PR (follow-up).