### PR TITLE
enhance: extract proxy fieldvalidator package

### DIFF
--- a/internal/proxy/fieldvalidator/OWNERS
+++ b/internal/proxy/fieldvalidator/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - SpadeA-Tang
+  - xiaocai2333
+  - czs007
+  - congqixia
+
+approvers:
+  - maintainers

--- a/internal/proxy/fieldvalidator/README.md
+++ b/internal/proxy/fieldvalidator/README.md
@@ -1,0 +1,98 @@
+# FieldValidator Package
+
+The `fieldvalidator` package validates Milvus `FieldData` payloads (insert /
+upsert rows) and fills null/default values. It is a pure leaf: it imports only
+`pkg/v3` and protobuf types and has **no dependency on the proxy root package or
+any sibling proxy sub-package**.
+
+## Overview
+
+Before DML rows are packed and dispatched, the proxy must guarantee the payload
+is well-formed:
+
+- **Aligned**: every field has the same row count (`CheckAligned`).
+- **Type-correct**: each field's data matches its schema type — vector dims,
+  varchar/array length and capacity, integer overflow, NaN in float vectors,
+  JSON/timestamptz constraints, nested-array element types
+  (`ValidateUtil.Validate` with `With*Check` options).
+- **Complete**: nullable / defaultable fields are expanded so downstream
+  consumers always see dense payloads (`FillWithNullValue`,
+  `FillWithDefaultValue`).
+
+This package is the "VALIDATE" component of the proxy extraction plan (issue
+#44761); it was extracted verbatim from the proxy root package
+(`validate_util.go`).
+
+## Responsibilities
+
+1. **`ValidateUtil`** — a configurable validator built with functional options
+   (`NewValidateUtil(WithNANCheck(), WithMaxLenCheck(), WithOverflowCheck(),
+   WithMaxCapCheck())`). Its `Validate` method checks a batch of `FieldData`
+   against a `*typeutil.SchemaHelper`.
+2. **`CheckAligned`** — cheap row-count alignment guard run before the full
+   validation to avoid index-out-of-range panics.
+3. **`FillWithNullValue` / `FillWithDefaultValue`** — expand compact `ValidData`
+   payloads into dense field data, honoring nullable/defaultable schemas and
+   nested (ArrayOfVector / struct) fields.
+4. **`ValidateGeometryFieldSearchResult`** — geometry result sanity check used
+   by the search/query reduce path.
+5. **`ValidateAutoIndexMmapConfig`** — AutoIndex mmap config compatibility check.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────┐
+│               fieldvalidator                 │
+│                                              │
+│   ValidateUtil ── options ──► Validate()     │
+│        │                                     │
+│        └──► CheckAligned()                   │
+│                                              │
+│   FillWithNullValue / FillWithDefaultValue   │
+│   ValidateGeometryFieldSearchResult          │
+│   ValidateAutoIndexMmapConfig                │
+└──────────────────────────────────────────────┘
+```
+
+### Key types
+
+```go
+type ValidateUtil struct{ ... }
+
+type ValidateOption func(*ValidateUtil)
+
+func NewValidateUtil(opts ...ValidateOption) *ValidateUtil
+
+func (v *ValidateUtil) Validate(data []*schemapb.FieldData,
+    helper *typeutil.SchemaHelper, numRows uint64) error
+
+func (v *ValidateUtil) CheckAligned(data []*schemapb.FieldData,
+    schema *typeutil.SchemaHelper, numRows uint64) error
+```
+
+## Usage
+
+- **Insert / upsert tasks** call
+  `fieldvalidator.NewValidateUtil(fieldvalidator.WithNANCheck(), ...)` then
+  `Validate(...)` on the request's `FieldData`; upsert additionally uses
+  `CheckAligned` and `FillWith*` for nullable payloads.
+- **Search / query** call `fieldvalidator.ValidateGeometryFieldSearchResult` on
+  result field data in the reduce path.
+- **Index** calls `fieldvalidator.ValidateAutoIndexMmapConfig`.
+
+The package holds **no state** and reads config only through
+`paramtable.Get()` (never the proxy `Params` global), so every entry point is
+pure and unit-testable.
+
+## Testing
+
+`validate_util_test.go` is a package-local white-box suite (moved verbatim with
+the code) exercising every `check*` method, alignment, and fill path with
+`schemapb` data only — no coordinators, no mocks.
+
+## Related Components
+
+- **TASKS** (`internal/proxy/task_*.go`): the only consumers. Edges are one-way
+  (tasks → fieldvalidator).
+- **Proxy root** (`internal/proxy/`): `util.go` also calls
+  `ValidateAutoIndexMmapConfig`.

--- a/internal/proxy/fieldvalidator/validate_util.go
+++ b/internal/proxy/fieldvalidator/validate_util.go
@@ -1,4 +1,4 @@
-package proxy
+package fieldvalidator
 
 import (
 	"context"
@@ -20,40 +20,40 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
-type validateUtil struct {
+type ValidateUtil struct {
 	checkNAN      bool
 	checkMaxLen   bool
 	checkOverflow bool
 	checkMaxCap   bool
 }
 
-type validateOption func(*validateUtil)
+type ValidateOption func(*ValidateUtil)
 
-func withNANCheck() validateOption {
-	return func(v *validateUtil) {
+func WithNANCheck() ValidateOption {
+	return func(v *ValidateUtil) {
 		v.checkNAN = true
 	}
 }
 
-func withMaxLenCheck() validateOption {
-	return func(v *validateUtil) {
+func WithMaxLenCheck() ValidateOption {
+	return func(v *ValidateUtil) {
 		v.checkMaxLen = true
 	}
 }
 
-func withOverflowCheck() validateOption {
-	return func(v *validateUtil) {
+func WithOverflowCheck() ValidateOption {
+	return func(v *ValidateUtil) {
 		v.checkOverflow = true
 	}
 }
 
-func withMaxCapCheck() validateOption {
-	return func(v *validateUtil) {
+func WithMaxCapCheck() ValidateOption {
+	return func(v *ValidateUtil) {
 		v.checkMaxCap = true
 	}
 }
 
-func validateGeometryFieldSearchResult(fieldData **schemapb.FieldData) error {
+func ValidateGeometryFieldSearchResult(fieldData **schemapb.FieldData) error {
 	if *fieldData == nil || (*fieldData).GetScalars() == nil || (*fieldData).GetScalars().Data == nil {
 		return nil
 	}
@@ -99,13 +99,13 @@ func validateGeometryFieldSearchResult(fieldData **schemapb.FieldData) error {
 	return nil
 }
 
-func (v *validateUtil) apply(opts ...validateOption) {
+func (v *ValidateUtil) apply(opts ...ValidateOption) {
 	for _, opt := range opts {
 		opt(v)
 	}
 }
 
-func (v *validateUtil) Validate(data []*schemapb.FieldData, helper *typeutil.SchemaHelper, numRows uint64) error {
+func (v *ValidateUtil) Validate(data []*schemapb.FieldData, helper *typeutil.SchemaHelper, numRows uint64) error {
 	if helper == nil {
 		return merr.WrapErrServiceInternal("nil schema helper provided for Validation")
 	}
@@ -198,14 +198,14 @@ func (v *validateUtil) Validate(data []*schemapb.FieldData, helper *typeutil.Sch
 		return err
 	}
 
-	if err := v.checkAligned(data, helper, numRows); err != nil {
+	if err := v.CheckAligned(data, helper, numRows); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (v *validateUtil) checkAligned(data []*schemapb.FieldData, schema *typeutil.SchemaHelper, numRows uint64) error {
+func (v *ValidateUtil) CheckAligned(data []*schemapb.FieldData, schema *typeutil.SchemaHelper, numRows uint64) error {
 	errNumRowsMismatch := func(fieldName string, fieldNumRows uint64) error {
 		msg := fmt.Sprintf("the num_rows (%d) of field (%s) is not equal to passed num_rows (%d)", fieldNumRows, fieldName, numRows)
 		return merr.WrapErrParameterInvalid(numRows, fieldNumRows, msg)
@@ -217,7 +217,7 @@ func (v *validateUtil) checkAligned(data []*schemapb.FieldData, schema *typeutil
 	getExpectedVectorRows := func(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) uint64 {
 		validData := typeutil.GetFieldDataValidData(field)
 		if fieldSchema.GetNullable() && len(validData) > 0 {
-			return uint64(getValidNumber(validData))
+			return uint64(GetValidNumber(validData))
 		}
 		return numRows
 	}
@@ -458,7 +458,7 @@ func (v *validateUtil) checkAligned(data []*schemapb.FieldData, schema *typeutil
 //     will fill default_value when passed num_rows not equal to expected num_rows,
 //
 // after fillWithValue, only nullable field will has valid_data, the length of all data will be passed num_rows
-func (v *validateUtil) fillWithValue(data []*schemapb.FieldData, schema *typeutil.SchemaHelper, numRows int) error {
+func (v *ValidateUtil) fillWithValue(data []*schemapb.FieldData, schema *typeutil.SchemaHelper, numRows int) error {
 	for _, field := range data {
 		fieldSchema, err := schema.GetFieldFromName(field.GetFieldName())
 		if err != nil {
@@ -595,7 +595,7 @@ func FillWithNullValue(field *schemapb.FieldData, fieldSchema *schemapb.FieldSch
 }
 
 func fillVectorArrayNullValueImpl(array []*schemapb.VectorField, validData []bool, dim int64, elementType schemapb.DataType) ([]*schemapb.VectorField, error) {
-	n := getValidNumber(validData)
+	n := GetValidNumber(validData)
 	if len(array) != n {
 		return nil, merr.WrapErrParameterInvalid(n, len(array), "the length of field is wrong")
 	}
@@ -791,7 +791,7 @@ func FillWithDefaultValue(field *schemapb.FieldData, fieldSchema *schemapb.Field
 }
 
 func fillWithNullValueImpl[T any](array []T, validData []bool) ([]T, error) {
-	n := getValidNumber(validData)
+	n := GetValidNumber(validData)
 	if len(array) != n {
 		return nil, merr.WrapErrParameterInvalid(n, len(array), "the length of field is wrong")
 	}
@@ -810,7 +810,7 @@ func fillWithNullValueImpl[T any](array []T, validData []bool) ([]T, error) {
 }
 
 func fillWithDefaultValueImpl[T any](array []T, value T, validData []bool) ([]T, error) {
-	n := getValidNumber(validData)
+	n := GetValidNumber(validData)
 	if len(array) != n {
 		return nil, merr.WrapErrParameterInvalid(n, len(array), "the length of field is wrong")
 	}
@@ -830,7 +830,7 @@ func fillWithDefaultValueImpl[T any](array []T, value T, validData []bool) ([]T,
 	return res, nil
 }
 
-func getValidNumber(validData []bool) int {
+func GetValidNumber(validData []bool) int {
 	res := 0
 	for _, v := range validData {
 		if v {
@@ -840,7 +840,7 @@ func getValidNumber(validData []bool) int {
 	return res
 }
 
-func (v *validateUtil) checkFloatVectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkFloatVectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	floatArray := field.GetVectors().GetFloatVector().GetData()
 	if floatArray == nil && !fieldSchema.GetNullable() {
 		msg := fmt.Sprintf("float vector field '%v' is illegal, array type mismatch", field.GetFieldName())
@@ -854,7 +854,7 @@ func (v *validateUtil) checkFloatVectorFieldData(field *schemapb.FieldData, fiel
 	return nil
 }
 
-func (v *validateUtil) checkFloat16VectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkFloat16VectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	float16VecArray := field.GetVectors().GetFloat16Vector()
 	if float16VecArray == nil {
 		if !fieldSchema.GetNullable() {
@@ -869,7 +869,7 @@ func (v *validateUtil) checkFloat16VectorFieldData(field *schemapb.FieldData, fi
 	return nil
 }
 
-func (v *validateUtil) checkBFloat16VectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkBFloat16VectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	bfloat16VecArray := field.GetVectors().GetBfloat16Vector()
 	if bfloat16VecArray == nil {
 		if !fieldSchema.GetNullable() {
@@ -884,7 +884,7 @@ func (v *validateUtil) checkBFloat16VectorFieldData(field *schemapb.FieldData, f
 	return nil
 }
 
-func (v *validateUtil) checkBinaryVectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkBinaryVectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	bVecArray := field.GetVectors().GetBinaryVector()
 	if bVecArray == nil && !fieldSchema.GetNullable() {
 		msg := fmt.Sprintf("binary vector field '%v' is illegal, array type mismatch", field.GetFieldName())
@@ -893,7 +893,7 @@ func (v *validateUtil) checkBinaryVectorFieldData(field *schemapb.FieldData, fie
 	return nil
 }
 
-func (v *validateUtil) checkSparseFloatVectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkSparseFloatVectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	if field.GetVectors() == nil || field.GetVectors().GetSparseFloatVector() == nil {
 		if !fieldSchema.GetNullable() {
 			msg := fmt.Sprintf("sparse float vector field '%v' is illegal, array type mismatch", field.GetFieldName())
@@ -905,7 +905,7 @@ func (v *validateUtil) checkSparseFloatVectorFieldData(field *schemapb.FieldData
 	return typeutil.ValidateSparseFloatRows(sparseRows...)
 }
 
-func (v *validateUtil) checkInt8VectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkInt8VectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	int8VecArray := field.GetVectors().GetInt8Vector()
 	if int8VecArray == nil {
 		if !fieldSchema.GetNullable() {
@@ -917,7 +917,7 @@ func (v *validateUtil) checkInt8VectorFieldData(field *schemapb.FieldData, field
 	return nil
 }
 
-func (v *validateUtil) checkVarCharFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkVarCharFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	strArr := field.GetScalars().GetStringData().GetData()
 	if strArr == nil && fieldSchema.GetDefaultValue() == nil && !fieldSchema.GetNullable() {
 		msg := fmt.Sprintf("varchar field '%v' is illegal, array type mismatch", field.GetFieldName())
@@ -944,7 +944,7 @@ func (v *validateUtil) checkVarCharFieldData(field *schemapb.FieldData, fieldSch
 	return nil
 }
 
-func (v *validateUtil) checkTextFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkTextFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	strArr := field.GetScalars().GetStringData().GetData()
 	if strArr == nil && fieldSchema.GetDefaultValue() == nil && !fieldSchema.GetNullable() {
 		msg := fmt.Sprintf("text field '%v' is illegal", field.GetFieldName())
@@ -955,7 +955,7 @@ func (v *validateUtil) checkTextFieldData(field *schemapb.FieldData, fieldSchema
 	return nil
 }
 
-func (v *validateUtil) checkGeometryFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkGeometryFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	geometryArray := field.GetScalars().GetGeometryWktData().GetData()
 	validData := typeutil.GetFieldDataValidData(field)
 	wkbArray := make([][]byte, len(geometryArray))
@@ -989,7 +989,7 @@ func (v *validateUtil) checkGeometryFieldData(field *schemapb.FieldData, fieldSc
 	return nil
 }
 
-func (v *validateUtil) checkJSONFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkJSONFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	jsonArray := field.GetScalars().GetJsonData().GetData()
 	if jsonArray == nil && fieldSchema.GetDefaultValue() == nil && !fieldSchema.GetNullable() {
 		msg := fmt.Sprintf("json field '%v' is illegal, array type mismatch", field.GetFieldName())
@@ -1013,7 +1013,7 @@ func (v *validateUtil) checkJSONFieldData(field *schemapb.FieldData, fieldSchema
 	return nil
 }
 
-func (v *validateUtil) checkIntegerFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkIntegerFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	data := field.GetScalars().GetIntData().GetData()
 	if data == nil && fieldSchema.GetDefaultValue() == nil && !fieldSchema.GetNullable() {
 		msg := fmt.Sprintf("field '%v' is illegal, array type mismatch", field.GetFieldName())
@@ -1032,7 +1032,7 @@ func (v *validateUtil) checkIntegerFieldData(field *schemapb.FieldData, fieldSch
 	return nil
 }
 
-func (v *validateUtil) checkLongFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkLongFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	data := field.GetScalars().GetLongData().GetData()
 	if data == nil && fieldSchema.GetDefaultValue() == nil && !fieldSchema.GetNullable() {
 		msg := fmt.Sprintf("field '%v' is illegal, array type mismatch", field.GetFieldName())
@@ -1042,7 +1042,7 @@ func (v *validateUtil) checkLongFieldData(field *schemapb.FieldData, fieldSchema
 	return nil
 }
 
-func (v *validateUtil) checkFloatFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkFloatFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	data := field.GetScalars().GetFloatData().GetData()
 	if data == nil && fieldSchema.GetDefaultValue() == nil && !fieldSchema.GetNullable() {
 		msg := fmt.Sprintf("field '%v' is illegal, array type mismatch", field.GetFieldName())
@@ -1056,7 +1056,7 @@ func (v *validateUtil) checkFloatFieldData(field *schemapb.FieldData, fieldSchem
 	return nil
 }
 
-func (v *validateUtil) checkDoubleFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkDoubleFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	data := field.GetScalars().GetDoubleData().GetData()
 	if data == nil && fieldSchema.GetDefaultValue() == nil && !fieldSchema.GetNullable() {
 		msg := fmt.Sprintf("field '%v' is illegal, array type mismatch", field.GetFieldName())
@@ -1070,7 +1070,7 @@ func (v *validateUtil) checkDoubleFieldData(field *schemapb.FieldData, fieldSche
 	return nil
 }
 
-func (v *validateUtil) checkArrayElement(array *schemapb.ArrayArray, field *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkArrayElement(array *schemapb.ArrayArray, field *schemapb.FieldSchema) error {
 	switch field.GetElementType() {
 	case schemapb.DataType_Bool:
 		for _, row := range array.GetData() {
@@ -1191,7 +1191,7 @@ func normalizeNestedArrayElementType(
 	return nil
 }
 
-func (v *validateUtil) checkNestedArrayValue(
+func (v *ValidateUtil) checkNestedArrayValue(
 	row *schemapb.ScalarField,
 	arrayType *schemapb.TypeSchema,
 	fieldName string,
@@ -1270,7 +1270,7 @@ func (v *validateUtil) checkNestedArrayValue(
 	return v.checkArrayElement(leafArray, leafField)
 }
 
-func (v *validateUtil) checkNestedArrayFieldData(
+func (v *ValidateUtil) checkNestedArrayFieldData(
 	data *schemapb.ArrayArray,
 	fieldSchema *schemapb.FieldSchema,
 ) error {
@@ -1288,7 +1288,7 @@ func (v *validateUtil) checkNestedArrayFieldData(
 	return nil
 }
 
-func (v *validateUtil) checkArrayFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkArrayFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	data := field.GetScalars().GetArrayData()
 	if data == nil {
 		elementTypeStr := fieldSchema.GetElementType().String()
@@ -1311,7 +1311,7 @@ func (v *validateUtil) checkArrayFieldData(field *schemapb.FieldData, fieldSchem
 	return v.checkArrayElement(data, fieldSchema)
 }
 
-func (v *validateUtil) checkArrayOfVectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkArrayOfVectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	data := field.GetVectors().GetVectorArray()
 	if data == nil {
 		elementTypeStr := fieldSchema.GetElementType().String()
@@ -1457,7 +1457,7 @@ func (v *validateUtil) checkArrayOfVectorFieldData(field *schemapb.FieldData, fi
 
 // checkTimestamptzFieldData validates the input string data for a Timestamptz field,
 // converts it into UTC Unix Microseconds (int64), and replaces the data in place.
-func (v *validateUtil) checkTimestamptzFieldData(field *schemapb.FieldData, timezone string) error {
+func (v *ValidateUtil) checkTimestamptzFieldData(field *schemapb.FieldData, timezone string) error {
 	// 1. Structural Check: Data must be present and must be a string array
 	scalarField := field.GetScalars()
 	if scalarField == nil || scalarField.GetStringData() == nil {
@@ -1543,8 +1543,8 @@ func verifyOverflowByRange(arr []int32, lb int64, ub int64) error {
 	return nil
 }
 
-func newValidateUtil(opts ...validateOption) *validateUtil {
-	v := &validateUtil{
+func NewValidateUtil(opts ...ValidateOption) *ValidateUtil {
+	v := &ValidateUtil{
 		checkNAN:      true,
 		checkMaxLen:   false,
 		checkOverflow: false,

--- a/internal/proxy/fieldvalidator/validate_util_test.go
+++ b/internal/proxy/fieldvalidator/validate_util_test.go
@@ -1,4 +1,4 @@
-package proxy
+package fieldvalidator
 
 import (
 	"fmt"
@@ -19,6 +19,41 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/testutils"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
+
+func testArrayTypeSchema(element *schemapb.TypeSchema, params ...*commonpb.KeyValuePair) *schemapb.TypeSchema {
+	return &schemapb.TypeSchema{
+		Kind:       &schemapb.TypeSchema_ArrayElement{ArrayElement: element},
+		TypeParams: params,
+	}
+}
+
+func autoGenDynamicFieldData(schema *schemapb.CollectionSchema, data [][]byte) *schemapb.FieldData {
+	fd := &schemapb.FieldData{
+		FieldName: common.MetaFieldName,
+		Type:      schemapb.DataType_JSON,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_JsonData{
+					JsonData: &schemapb.JSONArray{
+						Data: data,
+					},
+				},
+			},
+		},
+		IsDynamic: true,
+	}
+	for _, f := range schema.Fields {
+		if f.GetIsDynamic() && (f.GetNullable() || f.GetDefaultValue() != nil) {
+			validData := make([]bool, len(data))
+			for i := range validData {
+				validData[i] = true
+			}
+			typeutil.SetFieldDataValidData(fd, validData)
+			break
+		}
+	}
+	return fd
+}
 
 func Test_verifyLengthPerRow(t *testing.T) {
 	maxLength := 16
@@ -42,10 +77,10 @@ func Test_verifyLengthPerRow(t *testing.T) {
 	assert.Equal(t, 1, row)
 }
 
-func Test_validateUtil_checkVarCharFieldData(t *testing.T) {
+func Test_ValidateUtil_checkVarCharFieldData(t *testing.T) {
 	t.Run("type mismatch", func(t *testing.T) {
 		f := &schemapb.FieldData{}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		assert.Error(t, v.checkVarCharFieldData(f, nil))
 	})
 
@@ -66,7 +101,7 @@ func Test_validateUtil_checkVarCharFieldData(t *testing.T) {
 			DataType: schemapb.DataType_VarChar,
 		}
 
-		v := newValidateUtil(withMaxLenCheck())
+		v := NewValidateUtil(WithMaxLenCheck())
 
 		err := v.checkVarCharFieldData(f, fs)
 		assert.Error(t, err)
@@ -95,7 +130,7 @@ func Test_validateUtil_checkVarCharFieldData(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withMaxLenCheck())
+		v := NewValidateUtil(WithMaxLenCheck())
 
 		err := v.checkVarCharFieldData(f, fs)
 		assert.Error(t, err)
@@ -124,7 +159,7 @@ func Test_validateUtil_checkVarCharFieldData(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withMaxLenCheck())
+		v := NewValidateUtil(WithMaxLenCheck())
 
 		err := v.checkVarCharFieldData(f, fs)
 		assert.NoError(t, err)
@@ -153,7 +188,7 @@ func Test_validateUtil_checkVarCharFieldData(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err := v.checkVarCharFieldData(f, fs)
 		assert.NoError(t, err)
@@ -184,17 +219,17 @@ func Test_validateUtil_checkVarCharFieldData(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withMaxLenCheck())
+		v := NewValidateUtil(WithMaxLenCheck())
 
 		err := v.checkVarCharFieldData(f, fs)
 		assert.NoError(t, err)
 	})
 }
 
-func Test_validateUtil_checkTextFieldData(t *testing.T) {
+func Test_ValidateUtil_checkTextFieldData(t *testing.T) {
 	t.Run("type mismatch", func(t *testing.T) {
 		f := &schemapb.FieldData{}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		assert.Error(t, v.checkTextFieldData(f, nil))
 	})
 
@@ -215,7 +250,7 @@ func Test_validateUtil_checkTextFieldData(t *testing.T) {
 			DataType: schemapb.DataType_Text,
 		}
 
-		v := newValidateUtil(withMaxLenCheck())
+		v := NewValidateUtil(WithMaxLenCheck())
 
 		err := v.checkTextFieldData(f, fs)
 		assert.NoError(t, err)
@@ -244,7 +279,7 @@ func Test_validateUtil_checkTextFieldData(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withMaxLenCheck())
+		v := NewValidateUtil(WithMaxLenCheck())
 
 		err := v.checkTextFieldData(f, fs)
 		assert.NoError(t, err)
@@ -273,7 +308,7 @@ func Test_validateUtil_checkTextFieldData(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withMaxLenCheck())
+		v := NewValidateUtil(WithMaxLenCheck())
 
 		err := v.checkTextFieldData(f, fs)
 		assert.NoError(t, err)
@@ -302,22 +337,22 @@ func Test_validateUtil_checkTextFieldData(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err := v.checkTextFieldData(f, fs)
 		assert.NoError(t, err)
 	})
 }
 
-func Test_validateUtil_checkBinaryVectorFieldData(t *testing.T) {
+func Test_ValidateUtil_checkBinaryVectorFieldData(t *testing.T) {
 	t.Run("not binary vector", func(t *testing.T) {
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkBinaryVectorFieldData(&schemapb.FieldData{Field: &schemapb.FieldData_Scalars{}}, nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("normal case", func(t *testing.T) {
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkBinaryVectorFieldData(&schemapb.FieldData{Field: &schemapb.FieldData_Vectors{
 			Vectors: &schemapb.VectorField{
 				Dim: 128,
@@ -345,7 +380,7 @@ func Test_validateUtil_checkBinaryVectorFieldData(t *testing.T) {
 			DataType: schemapb.DataType_BinaryVector,
 			Nullable: false,
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkBinaryVectorFieldData(data, schema)
 		assert.Error(t, err)
 	})
@@ -366,20 +401,20 @@ func Test_validateUtil_checkBinaryVectorFieldData(t *testing.T) {
 			DataType: schemapb.DataType_BinaryVector,
 			Nullable: true,
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkBinaryVectorFieldData(data, schema)
 		assert.NoError(t, err)
 	})
 }
 
-func Test_validateUtil_checkFloatVectorFieldData(t *testing.T) {
+func Test_ValidateUtil_checkFloatVectorFieldData(t *testing.T) {
 	nb := 5
 	dim := int64(8)
 	data := testutils.GenerateFloatVectors(nb, int(dim))
 	invalidData := testutils.GenerateFloatVectorsWithInvalidData(nb, int(dim))
 
 	t.Run("not float vector", func(t *testing.T) {
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkFloatVectorFieldData(&schemapb.FieldData{Field: &schemapb.FieldData_Scalars{}}, nil)
 		assert.Error(t, err)
 	})
@@ -396,7 +431,7 @@ func Test_validateUtil_checkFloatVectorFieldData(t *testing.T) {
 				},
 			},
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		v.checkNAN = false
 		err := v.checkFloatVectorFieldData(f, nil)
 		assert.NoError(t, err)
@@ -414,7 +449,7 @@ func Test_validateUtil_checkFloatVectorFieldData(t *testing.T) {
 				},
 			},
 		}
-		v := newValidateUtil(withNANCheck())
+		v := NewValidateUtil(WithNANCheck())
 		err := v.checkFloatVectorFieldData(f, nil)
 		assert.Error(t, err)
 	})
@@ -431,7 +466,7 @@ func Test_validateUtil_checkFloatVectorFieldData(t *testing.T) {
 				},
 			},
 		}
-		v := newValidateUtil(withNANCheck())
+		v := NewValidateUtil(WithNANCheck())
 		err := v.checkFloatVectorFieldData(f, nil)
 		assert.NoError(t, err)
 	})
@@ -459,7 +494,7 @@ func Test_validateUtil_checkFloatVectorFieldData(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err = v.fillWithValue(data, h, 1)
 		assert.Error(t, err)
 	})
@@ -480,7 +515,7 @@ func Test_validateUtil_checkFloatVectorFieldData(t *testing.T) {
 			DataType: schemapb.DataType_FloatVector,
 			Nullable: false,
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkFloatVectorFieldData(data, schema)
 		assert.Error(t, err)
 	})
@@ -502,20 +537,20 @@ func Test_validateUtil_checkFloatVectorFieldData(t *testing.T) {
 			Nullable: true,
 		}
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkFloatVectorFieldData(data, schema)
 		assert.NoError(t, err)
 	})
 }
 
-func Test_validateUtil_checkFloat16VectorFieldData(t *testing.T) {
+func Test_ValidateUtil_checkFloat16VectorFieldData(t *testing.T) {
 	nb := 5
 	dim := int64(8)
 	data := testutils.GenerateFloat16Vectors(nb, int(dim))
 	invalidData := testutils.GenerateFloat16VectorsWithInvalidData(nb, int(dim))
 
 	t.Run("not float16 vector", func(t *testing.T) {
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkFloat16VectorFieldData(&schemapb.FieldData{Field: &schemapb.FieldData_Scalars{}}, nil)
 		assert.Error(t, err)
 	})
@@ -531,7 +566,7 @@ func Test_validateUtil_checkFloat16VectorFieldData(t *testing.T) {
 				},
 			},
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		v.checkNAN = false
 		err := v.checkFloat16VectorFieldData(f, nil)
 		assert.NoError(t, err)
@@ -548,7 +583,7 @@ func Test_validateUtil_checkFloat16VectorFieldData(t *testing.T) {
 				},
 			},
 		}
-		v := newValidateUtil(withNANCheck())
+		v := NewValidateUtil(WithNANCheck())
 		err := v.checkFloat16VectorFieldData(f, nil)
 		assert.Error(t, err)
 	})
@@ -564,7 +599,7 @@ func Test_validateUtil_checkFloat16VectorFieldData(t *testing.T) {
 				},
 			},
 		}
-		v := newValidateUtil(withNANCheck())
+		v := NewValidateUtil(WithNANCheck())
 		err := v.checkFloat16VectorFieldData(f, nil)
 		assert.NoError(t, err)
 	})
@@ -592,7 +627,7 @@ func Test_validateUtil_checkFloat16VectorFieldData(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err = v.fillWithValue(data, h, 1)
 		assert.Error(t, err)
 	})
@@ -613,7 +648,7 @@ func Test_validateUtil_checkFloat16VectorFieldData(t *testing.T) {
 			DataType: schemapb.DataType_Float16Vector,
 			Nullable: false,
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkFloat16VectorFieldData(data, schema)
 		assert.Error(t, err)
 	})
@@ -635,20 +670,20 @@ func Test_validateUtil_checkFloat16VectorFieldData(t *testing.T) {
 			Nullable: true,
 		}
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkFloat16VectorFieldData(data, schema)
 		assert.NoError(t, err)
 	})
 }
 
-func Test_validateUtil_checkBFloat16VectorFieldData(t *testing.T) {
+func Test_ValidateUtil_checkBFloat16VectorFieldData(t *testing.T) {
 	nb := 5
 	dim := int64(8)
 	data := testutils.GenerateBFloat16Vectors(nb, int(dim))
 	invalidData := testutils.GenerateBFloat16VectorsWithInvalidData(nb, int(dim))
 
 	t.Run("not bfloat16 vector", func(t *testing.T) {
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkBFloat16VectorFieldData(&schemapb.FieldData{Field: &schemapb.FieldData_Scalars{}}, nil)
 		assert.Error(t, err)
 	})
@@ -664,7 +699,7 @@ func Test_validateUtil_checkBFloat16VectorFieldData(t *testing.T) {
 				},
 			},
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		v.checkNAN = false
 		err := v.checkBFloat16VectorFieldData(f, nil)
 		assert.NoError(t, err)
@@ -681,7 +716,7 @@ func Test_validateUtil_checkBFloat16VectorFieldData(t *testing.T) {
 				},
 			},
 		}
-		v := newValidateUtil(withNANCheck())
+		v := NewValidateUtil(WithNANCheck())
 		err := v.checkBFloat16VectorFieldData(f, nil)
 		assert.Error(t, err)
 	})
@@ -697,7 +732,7 @@ func Test_validateUtil_checkBFloat16VectorFieldData(t *testing.T) {
 				},
 			},
 		}
-		v := newValidateUtil(withNANCheck())
+		v := NewValidateUtil(WithNANCheck())
 		err := v.checkBFloat16VectorFieldData(f, nil)
 		assert.NoError(t, err)
 	})
@@ -725,7 +760,7 @@ func Test_validateUtil_checkBFloat16VectorFieldData(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err = v.fillWithValue(data, h, 1)
 		assert.Error(t, err)
 	})
@@ -746,7 +781,7 @@ func Test_validateUtil_checkBFloat16VectorFieldData(t *testing.T) {
 			DataType: schemapb.DataType_BFloat16Vector,
 			Nullable: false,
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkBFloat16VectorFieldData(data, schema)
 		assert.Error(t, err)
 	})
@@ -768,18 +803,18 @@ func Test_validateUtil_checkBFloat16VectorFieldData(t *testing.T) {
 			Nullable: true,
 		}
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkBFloat16VectorFieldData(data, schema)
 		assert.NoError(t, err)
 	})
 }
 
-func Test_validateUtil_checkSparseFloatVectorFieldData(t *testing.T) {
+func Test_ValidateUtil_checkSparseFloatVectorFieldData(t *testing.T) {
 	nb := 5
 	sparseContents, dim := testutils.GenerateSparseFloatVectorsData(nb)
 
 	t.Run("not sparse float vector", func(t *testing.T) {
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkSparseFloatVectorFieldData(&schemapb.FieldData{Field: &schemapb.FieldData_Scalars{}}, nil)
 		assert.Error(t, err)
 	})
@@ -803,7 +838,7 @@ func Test_validateUtil_checkSparseFloatVectorFieldData(t *testing.T) {
 			Name:     "vec",
 			DataType: schemapb.DataType_SparseFloatVector,
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkSparseFloatVectorFieldData(fieldData, schema)
 		assert.NoError(t, err)
 	})
@@ -824,7 +859,7 @@ func Test_validateUtil_checkSparseFloatVectorFieldData(t *testing.T) {
 			DataType: schemapb.DataType_SparseFloatVector,
 			Nullable: false,
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkSparseFloatVectorFieldData(data, schema)
 		assert.Error(t, err)
 	})
@@ -846,19 +881,19 @@ func Test_validateUtil_checkSparseFloatVectorFieldData(t *testing.T) {
 			Nullable: true,
 		}
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkSparseFloatVectorFieldData(data, schema)
 		assert.NoError(t, err)
 	})
 }
 
-func Test_validateUtil_checkInt8VectorFieldData(t *testing.T) {
+func Test_ValidateUtil_checkInt8VectorFieldData(t *testing.T) {
 	nb := 5
 	dim := int64(8)
 	data := typeutil.Int8ArrayToBytes(testutils.GenerateInt8Vectors(nb, int(dim)))
 
 	t.Run("not int8 vector", func(t *testing.T) {
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkInt8VectorFieldData(&schemapb.FieldData{Field: &schemapb.FieldData_Scalars{}}, nil)
 		assert.Error(t, err)
 	})
@@ -879,7 +914,7 @@ func Test_validateUtil_checkInt8VectorFieldData(t *testing.T) {
 			Name:     "vec",
 			DataType: schemapb.DataType_Int8Vector,
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkInt8VectorFieldData(fieldData, schema)
 		assert.NoError(t, err)
 	})
@@ -900,7 +935,7 @@ func Test_validateUtil_checkInt8VectorFieldData(t *testing.T) {
 			DataType: schemapb.DataType_Int8Vector,
 			Nullable: false,
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkInt8VectorFieldData(fieldData, schema)
 		assert.Error(t, err)
 	})
@@ -922,13 +957,13 @@ func Test_validateUtil_checkInt8VectorFieldData(t *testing.T) {
 			Nullable: true,
 		}
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkInt8VectorFieldData(fieldData, schema)
 		assert.NoError(t, err)
 	})
 }
 
-func Test_validateUtil_checkAligned(t *testing.T) {
+func Test_ValidateUtil_checkAligned(t *testing.T) {
 	t.Run("float vector column not found", func(t *testing.T) {
 		data := []*schemapb.FieldData{
 			{
@@ -941,9 +976,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -967,9 +1002,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1009,9 +1044,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 1)
+		err = v.CheckAligned(data, h, 1)
 
 		assert.Error(t, err)
 	})
@@ -1051,9 +1086,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1093,9 +1128,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1114,9 +1149,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1140,9 +1175,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1180,9 +1215,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1220,9 +1255,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1260,9 +1295,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1281,9 +1316,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1307,9 +1342,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1347,9 +1382,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1387,9 +1422,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1427,9 +1462,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 1)
+		err = v.CheckAligned(data, h, 1)
 
 		assert.Error(t, err)
 	})
@@ -1448,9 +1483,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1474,9 +1509,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1514,9 +1549,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 1)
+		err = v.CheckAligned(data, h, 1)
 
 		assert.Error(t, err)
 	})
@@ -1554,9 +1589,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1594,9 +1629,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1614,9 +1649,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1640,9 +1675,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1680,9 +1715,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 1)
+		err = v.CheckAligned(data, h, 1)
 
 		assert.Error(t, err)
 	})
@@ -1720,9 +1755,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1760,9 +1795,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1790,9 +1825,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1831,9 +1866,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1876,9 +1911,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 3)
+		err = v.CheckAligned(data, h, 3)
 
 		assert.Error(t, err)
 	})
@@ -1992,9 +2027,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 10)
+		err = v.CheckAligned(data, h, 10)
 
 		assert.NoError(t, err)
 	})
@@ -2028,9 +2063,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 3)
+		err = v.CheckAligned(data, h, 3)
 
 		assert.NoError(t, err)
 	})
@@ -2072,9 +2107,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 4)
+		err = v.CheckAligned(data, h, 4)
 
 		assert.NoError(t, err)
 	})
@@ -2116,9 +2151,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 4)
+		err = v.CheckAligned(data, h, 4)
 
 		assert.Error(t, err)
 	})
@@ -2152,9 +2187,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 3)
+		err = v.CheckAligned(data, h, 3)
 
 		assert.NoError(t, err)
 	})
@@ -2188,9 +2223,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 3)
+		err = v.CheckAligned(data, h, 3)
 
 		assert.NoError(t, err)
 	})
@@ -2224,9 +2259,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 3)
+		err = v.CheckAligned(data, h, 3)
 
 		assert.NoError(t, err)
 	})
@@ -2285,7 +2320,7 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 				h, err := typeutil.CreateSchemaHelper(schema)
 				require.NoError(t, err)
 
-				err = newValidateUtil().checkAligned(data, h, 2)
+				err = NewValidateUtil().CheckAligned(data, h, 2)
 				require.Error(t, err)
 			})
 		}
@@ -2320,9 +2355,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 3)
+		err = v.CheckAligned(data, h, 3)
 
 		assert.NoError(t, err)
 	})
@@ -2350,15 +2385,15 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 3)
+		err = v.CheckAligned(data, h, 3)
 
 		assert.NoError(t, err)
 	})
 }
 
-func Test_validateUtil_Validate(t *testing.T) {
+func Test_ValidateUtil_Validate(t *testing.T) {
 	paramtable.Init()
 
 	t.Run("nil schema", func(t *testing.T) {
@@ -2369,7 +2404,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err := v.Validate(data, nil, 100)
 
@@ -2404,7 +2439,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		err = newValidateUtil().Validate([]*schemapb.FieldData{field}, h, 2)
+		err = NewValidateUtil().Validate([]*schemapb.FieldData{field}, h, 2)
 		require.NoError(t, err)
 		assert.Nil(t, field.GetValidData())
 		assert.Equal(t, []bool{true, false}, field.GetScalars().GetValidData())
@@ -2438,7 +2473,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		err = newValidateUtil().Validate([]*schemapb.FieldData{field}, h, 2)
+		err = NewValidateUtil().Validate([]*schemapb.FieldData{field}, h, 2)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "different legacy and field-specific valid_data")
 	})
@@ -2551,7 +2586,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				err = newValidateUtil().Validate([]*schemapb.FieldData{tc.fieldData}, h, 2)
+				err = NewValidateUtil().Validate([]*schemapb.FieldData{tc.fieldData}, h, 2)
 				require.NoError(t, err)
 				assert.Equal(t, []bool{true, true}, typeutil.GetFieldDataValidData(tc.fieldData))
 			})
@@ -2590,7 +2625,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
@@ -2744,7 +2779,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withNANCheck(), withMaxLenCheck())
+		v := NewValidateUtil(WithNANCheck(), WithMaxLenCheck())
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
@@ -2898,7 +2933,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withNANCheck(), withMaxLenCheck())
+		v := NewValidateUtil(WithNANCheck(), WithMaxLenCheck())
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 		err = v.Validate(data, helper, 2)
@@ -2963,7 +2998,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 		err = v.Validate(data, helper, 2)
@@ -3001,7 +3036,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
@@ -3051,7 +3086,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withMaxCapCheck())
+		v := NewValidateUtil(WithMaxCapCheck())
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
@@ -3106,7 +3141,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withMaxCapCheck(), withMaxLenCheck())
+		v := NewValidateUtil(WithMaxCapCheck(), WithMaxLenCheck())
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
@@ -3151,7 +3186,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withMaxCapCheck())
+		v := NewValidateUtil(WithMaxCapCheck())
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
@@ -3201,7 +3236,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withMaxCapCheck())
+		v := NewValidateUtil(WithMaxCapCheck())
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
@@ -3258,7 +3293,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withMaxCapCheck())
+		v := NewValidateUtil(WithMaxCapCheck())
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 		err = v.Validate(data, helper, 1)
@@ -3313,7 +3348,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 		helper, err = typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
-		err = newValidateUtil(withMaxCapCheck()).Validate(data, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck()).Validate(data, helper, 1)
 		assert.Error(t, err)
 
 		schema = &schemapb.CollectionSchema{
@@ -3334,7 +3369,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 		helper, err = typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
-		err = newValidateUtil(withMaxCapCheck()).Validate(data, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck()).Validate(data, helper, 1)
 		assert.Error(t, err)
 
 		schema = &schemapb.CollectionSchema{
@@ -3356,7 +3391,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 		helper, err = typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
-		err = newValidateUtil(withMaxCapCheck()).Validate(data, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck()).Validate(data, helper, 1)
 		assert.Error(t, err)
 
 		data = []*schemapb.FieldData{
@@ -3407,7 +3442,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 		}
 		helper, err = typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
-		err = newValidateUtil(withMaxCapCheck()).Validate(data, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck()).Validate(data, helper, 1)
 		assert.Error(t, err)
 
 		data = []*schemapb.FieldData{
@@ -3459,7 +3494,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 		helper, err = typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
-		err = newValidateUtil(withMaxCapCheck()).Validate(data, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck()).Validate(data, helper, 1)
 		assert.Error(t, err)
 
 		data = []*schemapb.FieldData{
@@ -3511,7 +3546,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 		helper, err = typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
-		err = newValidateUtil(withMaxCapCheck()).Validate(data, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck()).Validate(data, helper, 1)
 		assert.Error(t, err)
 
 		data = []*schemapb.FieldData{
@@ -3563,7 +3598,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 		helper, err = typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
-		err = newValidateUtil(withMaxCapCheck()).Validate(data, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck()).Validate(data, helper, 1)
 		assert.Error(t, err)
 	})
 
@@ -3609,7 +3644,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 		}
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
-		err = newValidateUtil(withMaxCapCheck(), withOverflowCheck()).Validate(data, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck(), WithOverflowCheck()).Validate(data, helper, 1)
 		assert.Error(t, err)
 
 		data = []*schemapb.FieldData{
@@ -3654,7 +3689,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 		helper, err = typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
-		err = newValidateUtil(withMaxCapCheck(), withOverflowCheck()).Validate(data, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck(), WithOverflowCheck()).Validate(data, helper, 1)
 		assert.Error(t, err)
 	})
 
@@ -4073,7 +4108,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withNANCheck(), withMaxLenCheck(), withOverflowCheck(), withMaxCapCheck())
+		v := NewValidateUtil(WithNANCheck(), WithMaxLenCheck(), WithOverflowCheck(), WithMaxCapCheck())
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
@@ -4120,7 +4155,7 @@ func checkJsonfillWithValueData(values [][]byte, v []byte, length int) (bool, er
 	return true, nil
 }
 
-func Test_validateUtil_fillWithValue(t *testing.T) {
+func Test_ValidateUtil_fillWithValue(t *testing.T) {
 	t.Run("bool scalars schema not found", func(t *testing.T) {
 		data := []*schemapb.FieldData{
 			{
@@ -4133,7 +4168,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -4168,7 +4203,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4207,7 +4242,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4242,7 +4277,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4286,7 +4321,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4332,7 +4367,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4378,7 +4413,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 3)
 
@@ -4413,7 +4448,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -4457,7 +4492,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4501,7 +4536,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -4540,7 +4575,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -4564,7 +4599,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -4599,7 +4634,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4638,7 +4673,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4675,7 +4710,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4719,7 +4754,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4765,7 +4800,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4810,7 +4845,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 3)
 
@@ -4846,7 +4881,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -4891,7 +4926,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4936,7 +4971,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -4977,7 +5012,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -5000,7 +5035,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -5035,7 +5070,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5074,7 +5109,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5111,7 +5146,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5154,7 +5189,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5199,7 +5234,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5243,7 +5278,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 3)
 
@@ -5279,7 +5314,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 		assert.NoError(t, err)
@@ -5323,7 +5358,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5368,7 +5403,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -5409,7 +5444,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -5433,7 +5468,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -5468,7 +5503,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5507,7 +5542,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5544,7 +5579,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5588,7 +5623,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5634,7 +5669,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5679,7 +5714,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 3)
 
@@ -5715,7 +5750,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 		assert.NoError(t, err)
@@ -5759,7 +5794,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5804,7 +5839,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -5845,7 +5880,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -5868,7 +5903,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -5903,7 +5938,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5942,7 +5977,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5979,7 +6014,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6023,7 +6058,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6069,7 +6104,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6114,7 +6149,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 3)
 
@@ -6150,7 +6185,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 		assert.NoError(t, err)
@@ -6194,7 +6229,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6239,7 +6274,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -6279,7 +6314,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -6303,7 +6338,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -6338,7 +6373,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6377,7 +6412,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6414,7 +6449,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6458,7 +6493,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6504,7 +6539,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6550,7 +6585,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6595,7 +6630,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -6638,7 +6673,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 3)
 
@@ -6674,7 +6709,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 3)
 
@@ -6710,7 +6745,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -6732,7 +6767,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -6767,7 +6802,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6806,7 +6841,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6843,7 +6878,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6886,7 +6921,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6933,7 +6968,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6979,7 +7014,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 3)
 
@@ -7014,7 +7049,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 		assert.NoError(t, err)
@@ -7058,7 +7093,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -7102,7 +7137,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -7142,7 +7177,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -7183,7 +7218,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -7221,7 +7256,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -7267,7 +7302,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -7316,7 +7351,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -7360,7 +7395,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -7427,7 +7462,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
@@ -7480,9 +7515,9 @@ func Test_verifyOverflowByRange(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func Test_validateUtil_checkIntegerFieldData(t *testing.T) {
+func Test_ValidateUtil_checkIntegerFieldData(t *testing.T) {
 	t.Run("no check", func(t *testing.T) {
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		assert.Error(t, v.checkIntegerFieldData(&schemapb.FieldData{Field: &schemapb.FieldData_Vectors{}}, nil))
 		assert.NoError(t, v.checkIntegerFieldData(&schemapb.FieldData{Field: &schemapb.FieldData_Scalars{
 			Scalars: &schemapb.ScalarField{
@@ -7496,7 +7531,7 @@ func Test_validateUtil_checkIntegerFieldData(t *testing.T) {
 	})
 
 	t.Run("no int data but set nullable==true or set default_value", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 
 		f := &schemapb.FieldSchema{
 			DataType: schemapb.DataType_Int8,
@@ -7540,7 +7575,7 @@ func Test_validateUtil_checkIntegerFieldData(t *testing.T) {
 	})
 
 	t.Run("tiny int, type mismatch", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 
 		f := &schemapb.FieldSchema{
 			DataType: schemapb.DataType_Int8,
@@ -7558,7 +7593,7 @@ func Test_validateUtil_checkIntegerFieldData(t *testing.T) {
 	})
 
 	t.Run("tiny int, overflow", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 
 		f := &schemapb.FieldSchema{
 			DataType: schemapb.DataType_Int8,
@@ -7580,7 +7615,7 @@ func Test_validateUtil_checkIntegerFieldData(t *testing.T) {
 	})
 
 	t.Run("tiny int, normal case", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 
 		f := &schemapb.FieldSchema{
 			DataType: schemapb.DataType_Int8,
@@ -7602,7 +7637,7 @@ func Test_validateUtil_checkIntegerFieldData(t *testing.T) {
 	})
 
 	t.Run("small int, overflow", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 
 		f := &schemapb.FieldSchema{
 			DataType: schemapb.DataType_Int16,
@@ -7624,7 +7659,7 @@ func Test_validateUtil_checkIntegerFieldData(t *testing.T) {
 	})
 
 	t.Run("small int, normal case", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 
 		f := &schemapb.FieldSchema{
 			DataType: schemapb.DataType_Int16,
@@ -7646,9 +7681,9 @@ func Test_validateUtil_checkIntegerFieldData(t *testing.T) {
 	})
 }
 
-func Test_validateUtil_checkJSONData(t *testing.T) {
+func Test_ValidateUtil_checkJSONData(t *testing.T) {
 	t.Run("no json data", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 
 		f := &schemapb.FieldSchema{
 			DataType: schemapb.DataType_JSON,
@@ -7670,7 +7705,7 @@ func Test_validateUtil_checkJSONData(t *testing.T) {
 	})
 
 	t.Run("no json data but set nullable==true or set default_value", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 
 		f := &schemapb.FieldSchema{
 			DataType: schemapb.DataType_JSON,
@@ -7712,9 +7747,9 @@ func Test_validateUtil_checkJSONData(t *testing.T) {
 	})
 
 	t.Run("json string exceed max length", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck(), withMaxLenCheck())
+		v := NewValidateUtil(WithOverflowCheck(), WithMaxLenCheck())
 		jsonString := ""
-		for i := 0; i < Params.CommonCfg.JSONMaxLength.GetAsInt(); i++ {
+		for i := 0; i < paramtable.Get().CommonCfg.JSONMaxLength.GetAsInt(); i++ {
 			jsonString += fmt.Sprintf("key: %d, value: %d", i, i)
 		}
 		jsonString = "{" + jsonString + "}"
@@ -7739,9 +7774,9 @@ func Test_validateUtil_checkJSONData(t *testing.T) {
 	})
 
 	t.Run("dynamic field exceed max length", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck(), withMaxLenCheck())
+		v := NewValidateUtil(WithOverflowCheck(), WithMaxLenCheck())
 		jsonString := ""
-		for i := 0; i < Params.CommonCfg.JSONMaxLength.GetAsInt(); i++ {
+		for i := 0; i < paramtable.Get().CommonCfg.JSONMaxLength.GetAsInt(); i++ {
 			jsonString += fmt.Sprintf("key: %d, value: %d", i, i)
 		}
 		jsonString = "{" + jsonString + "}"
@@ -7767,8 +7802,8 @@ func Test_validateUtil_checkJSONData(t *testing.T) {
 	})
 }
 
-func Test_validateUtil_checkLongFieldData(t *testing.T) {
-	v := newValidateUtil()
+func Test_ValidateUtil_checkLongFieldData(t *testing.T) {
+	v := NewValidateUtil()
 	assert.Error(t, v.checkLongFieldData(&schemapb.FieldData{
 		Field: &schemapb.FieldData_Vectors{},
 	}, nil))
@@ -7785,7 +7820,7 @@ func Test_validateUtil_checkLongFieldData(t *testing.T) {
 	}, nil))
 
 	t.Run("no long data but set nullable==true or set default_value", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 
 		f := &schemapb.FieldSchema{
 			DataType: schemapb.DataType_Int64,
@@ -7828,8 +7863,8 @@ func Test_validateUtil_checkLongFieldData(t *testing.T) {
 	})
 }
 
-func Test_validateUtil_checkFloatFieldData(t *testing.T) {
-	v := newValidateUtil(withNANCheck())
+func Test_ValidateUtil_checkFloatFieldData(t *testing.T) {
+	v := NewValidateUtil(WithNANCheck())
 	assert.Error(t, v.checkFloatFieldData(&schemapb.FieldData{
 		Field: &schemapb.FieldData_Vectors{},
 	}, nil))
@@ -7857,7 +7892,7 @@ func Test_validateUtil_checkFloatFieldData(t *testing.T) {
 	}, nil))
 
 	t.Run("no float data but set nullable==true or set default_value", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 
 		f := &schemapb.FieldSchema{
 			Nullable: true,
@@ -7898,8 +7933,8 @@ func Test_validateUtil_checkFloatFieldData(t *testing.T) {
 	})
 }
 
-func Test_validateUtil_checkDoubleFieldData(t *testing.T) {
-	v := newValidateUtil(withNANCheck())
+func Test_ValidateUtil_checkDoubleFieldData(t *testing.T) {
+	v := NewValidateUtil(WithNANCheck())
 	assert.Error(t, v.checkDoubleFieldData(&schemapb.FieldData{
 		Field: &schemapb.FieldData_Vectors{},
 	}, nil))
@@ -7927,7 +7962,7 @@ func Test_validateUtil_checkDoubleFieldData(t *testing.T) {
 	}, nil))
 
 	t.Run("no float data but set nullable==true or set default_value", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 
 		f := &schemapb.FieldSchema{
 			Nullable: true,
@@ -7979,12 +8014,12 @@ func TestCheckArrayElementNilData(t *testing.T) {
 		ElementType: schemapb.DataType_Int64,
 	}
 
-	v := newValidateUtil()
+	v := NewValidateUtil()
 	err := v.checkArrayElement(data, fieldSchema)
 	assert.True(t, merr.ErrParameterInvalid.Is(err))
 }
 
-func Test_validateUtil_checkArrayOfVectorFieldData(t *testing.T) {
+func Test_ValidateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 	t.Run("nil data", func(t *testing.T) {
 		f := &schemapb.FieldData{
 			Field: &schemapb.FieldData_Vectors{
@@ -7996,7 +8031,7 @@ func Test_validateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 			ElementType: schemapb.DataType_FloatVector,
 			TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkArrayOfVectorFieldData(f, fieldSchema)
 		assert.Error(t, err)
 	})
@@ -8018,7 +8053,7 @@ func Test_validateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 			ElementType: schemapb.DataType_FloatVector,
 			TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkArrayOfVectorFieldData(f, fieldSchema)
 		assert.Error(t, err)
 	})
@@ -8048,7 +8083,7 @@ func Test_validateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 			ElementType: schemapb.DataType_FloatVector,
 			TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "3"}},
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		v.checkNAN = false
 		err := v.checkArrayOfVectorFieldData(f, fieldSchema)
 		assert.NoError(t, err)
@@ -8079,7 +8114,7 @@ func Test_validateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 			ElementType: schemapb.DataType_FloatVector,
 			TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "1"}},
 		}
-		v := newValidateUtil(withNANCheck())
+		v := NewValidateUtil(WithNANCheck())
 		err := v.checkArrayOfVectorFieldData(f, fieldSchema)
 		assert.Error(t, err)
 	})
@@ -8116,7 +8151,7 @@ func Test_validateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 			ElementType: schemapb.DataType_FloatVector,
 			TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
 		}
-		v := newValidateUtil(withNANCheck())
+		v := NewValidateUtil(WithNANCheck())
 		err := v.checkArrayOfVectorFieldData(f, fieldSchema)
 		assert.NoError(t, err)
 	})
@@ -8150,7 +8185,7 @@ func Test_validateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 				{Key: common.MaxCapacityKey, Value: "1"},
 			},
 		}
-		v := newValidateUtil(withMaxCapCheck())
+		v := NewValidateUtil(WithMaxCapCheck())
 		err := v.checkArrayOfVectorFieldData(f, fieldSchema)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "max capacity")
@@ -8182,14 +8217,14 @@ func Test_validateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 			ElementType: schemapb.DataType_FloatVector,
 			TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkArrayOfVectorFieldData(f, fieldSchema)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "divisible")
 	})
 }
 
-func Test_validateUtil_checkAligned_ArrayOfVector(t *testing.T) {
+func Test_ValidateUtil_checkAligned_ArrayOfVector(t *testing.T) {
 	t.Run("array of vector dim mismatch", func(t *testing.T) {
 		data := []*schemapb.FieldData{
 			{
@@ -8231,8 +8266,8 @@ func Test_validateUtil_checkAligned_ArrayOfVector(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
-		err = v.checkAligned(data, h, 1)
+		v := NewValidateUtil()
+		err = v.CheckAligned(data, h, 1)
 		assert.Error(t, err)
 	})
 
@@ -8277,8 +8312,8 @@ func Test_validateUtil_checkAligned_ArrayOfVector(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
-		err = v.checkAligned(data, h, 100)
+		v := NewValidateUtil()
+		err = v.CheckAligned(data, h, 100)
 		assert.Error(t, err)
 	})
 }
@@ -8464,7 +8499,7 @@ func Test_MetaNullableCompat_v25_vs_v26(t *testing.T) {
 		require.NoError(t, err)
 
 		data := []*schemapb.FieldData{sdkMetaFieldData()}
-		err = newValidateUtil().fillWithValue(data, h, numRows)
+		err = NewValidateUtil().fillWithValue(data, h, numRows)
 		assert.NoError(t, err, "2.6 schema + SDK-provided $meta should pass fillWithValue")
 	})
 
@@ -8474,7 +8509,7 @@ func Test_MetaNullableCompat_v25_vs_v26(t *testing.T) {
 		require.NoError(t, err)
 
 		data := []*schemapb.FieldData{sdkMetaFieldData()}
-		err = newValidateUtil().fillWithValue(data, h, numRows)
+		err = NewValidateUtil().fillWithValue(data, h, numRows)
 		assert.NoError(t, err, "2.5 schema + SDK-provided $meta (no ValidData) should pass fillWithValue")
 	})
 
@@ -8484,7 +8519,7 @@ func Test_MetaNullableCompat_v25_vs_v26(t *testing.T) {
 		require.NoError(t, err)
 
 		data := []*schemapb.FieldData{autoGenMetaFieldData(schema)}
-		err = newValidateUtil().fillWithValue(data, h, numRows)
+		err = NewValidateUtil().fillWithValue(data, h, numRows)
 		assert.NoError(t, err, "2.6 schema + auto-generated $meta should pass fillWithValue")
 	})
 
@@ -8496,7 +8531,7 @@ func Test_MetaNullableCompat_v25_vs_v26(t *testing.T) {
 		require.NoError(t, err)
 
 		data := []*schemapb.FieldData{autoGenMetaFieldData(schema)}
-		err = newValidateUtil().fillWithValue(data, h, numRows)
+		err = NewValidateUtil().fillWithValue(data, h, numRows)
 		assert.NoError(t, err, "2.5 schema + auto-generated $meta should pass fillWithValue")
 		// ValidData should remain empty for non-nullable field
 		assert.Empty(t, typeutil.GetFieldDataValidData(data[0]), "non-nullable $meta should not have ValidData")
@@ -8720,7 +8755,7 @@ func TestValidateNestedArrayFieldData(t *testing.T) {
 		helper, err := typeutil.CreateSchemaHelper(intSchema("3"))
 		require.NoError(t, err)
 
-		err = newValidateUtil(withMaxCapCheck()).Validate([]*schemapb.FieldData{data}, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck()).Validate([]*schemapb.FieldData{data}, helper, 1)
 		require.NoError(t, err)
 		assert.Equal(t, schemapb.DataType_Array, data.GetScalars().GetArrayData().GetElementType())
 		assert.Equal(t, schemapb.DataType_Array, data.GetScalars().GetArrayData().GetData()[0].GetArrayData().GetElementType())
@@ -8732,7 +8767,7 @@ func TestValidateNestedArrayFieldData(t *testing.T) {
 		helper, err := typeutil.CreateSchemaHelper(quadIntSchema())
 		require.NoError(t, err)
 
-		err = newValidateUtil(withMaxCapCheck()).Validate([]*schemapb.FieldData{data}, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck()).Validate([]*schemapb.FieldData{data}, helper, 1)
 		require.NoError(t, err)
 
 		root := data.GetScalars().GetArrayData()
@@ -8752,7 +8787,7 @@ func TestValidateNestedArrayFieldData(t *testing.T) {
 		helper, err := typeutil.CreateSchemaHelper(intSchema("3"))
 		require.NoError(t, err)
 
-		err = newValidateUtil(withMaxCapCheck()).Validate([]*schemapb.FieldData{data}, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck()).Validate([]*schemapb.FieldData{data}, helper, 1)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "expects Int32 element type, got Array")
 	})
@@ -8766,7 +8801,7 @@ func TestValidateNestedArrayFieldData(t *testing.T) {
 		helper, err := typeutil.CreateSchemaHelper(intSchema("3"))
 		require.NoError(t, err)
 
-		err = newValidateUtil(withMaxCapCheck()).Validate([]*schemapb.FieldData{data}, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck()).Validate([]*schemapb.FieldData{data}, helper, 1)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "undeclared null value at level 1")
 	})
@@ -8776,7 +8811,7 @@ func TestValidateNestedArrayFieldData(t *testing.T) {
 		helper, err := typeutil.CreateSchemaHelper(intSchema("2"))
 		require.NoError(t, err)
 
-		err = newValidateUtil(withMaxCapCheck()).Validate([]*schemapb.FieldData{data}, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck()).Validate([]*schemapb.FieldData{data}, helper, 1)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "max capacity")
 	})
@@ -8786,7 +8821,7 @@ func TestValidateNestedArrayFieldData(t *testing.T) {
 		helper, err := typeutil.CreateSchemaHelper(intSchema("3"))
 		require.NoError(t, err)
 
-		err = newValidateUtil(withMaxCapCheck()).Validate([]*schemapb.FieldData{data}, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck()).Validate([]*schemapb.FieldData{data}, helper, 1)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "insert data does not match")
 	})
@@ -8817,7 +8852,7 @@ func TestValidateNestedArrayFieldData(t *testing.T) {
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
-		err = newValidateUtil(withMaxCapCheck(), withMaxLenCheck()).Validate([]*schemapb.FieldData{data}, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck(), WithMaxLenCheck()).Validate([]*schemapb.FieldData{data}, helper, 1)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "max length")
 	})

--- a/internal/proxy/search_pipeline.go
+++ b/internal/proxy/search_pipeline.go
@@ -2423,7 +2423,7 @@ func isSameGroupByValue(field *schemapb.FieldData, i, j int) bool {
 //
 // Note on Float/Double NaN handling: This function does not explicitly handle NaN values
 // because Milvus rejects NaN and Infinity at insert time via proxy validation
-// (see task_insert.go withNANCheck() -> validate_util.go -> typeutil.VerifyFloat).
+// (see internal/proxy/fieldvalidator WithNANCheck -> Validate -> typeutil.VerifyFloat).
 // Therefore, NaN values cannot exist in stored data and will never reach this comparison.
 func compareFieldDataAt(field *schemapb.FieldData, i, j int, nullsFirst bool) (int, error) {
 	if cmp, handled := compareNulls(typeutil.GetFieldDataValidData(field), i, j, nullsFirst); handled {

--- a/internal/proxy/task_index.go
+++ b/internal/proxy/task_index.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/proxy/fieldvalidator"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/internal/util/vecindexmgr"
@@ -172,7 +173,7 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 		return merr.WrapErrParameterInvalidMsg("TEXT field does not support user-created scalar index")
 	}
 
-	if err := ValidateAutoIndexMmapConfig(isVecIndex, indexParamsMap); err != nil {
+	if err := fieldvalidator.ValidateAutoIndexMmapConfig(isVecIndex, indexParamsMap); err != nil {
 		return err
 	}
 

--- a/internal/proxy/task_insert.go
+++ b/internal/proxy/task_insert.go
@@ -11,6 +11,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/proxy/channelmgr"
+	"github.com/milvus-io/milvus/internal/proxy/fieldvalidator"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -290,7 +291,7 @@ func (it *insertTask) PreExecute(ctx context.Context) error {
 		}
 	}
 
-	if err := newValidateUtil(withNANCheck(), withOverflowCheck(), withMaxLenCheck(), withMaxCapCheck()).
+	if err := fieldvalidator.NewValidateUtil(fieldvalidator.WithNANCheck(), fieldvalidator.WithOverflowCheck(), fieldvalidator.WithMaxLenCheck(), fieldvalidator.WithMaxCapCheck()).
 		Validate(it.insertMsg.GetFieldsData(), schema.SchemaHelper, it.insertMsg.NRows()); err != nil {
 		return merr.WrapErrAsInputError(err)
 	}

--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -17,6 +17,7 @@ import (
 	"github.com/milvus-io/milvus/internal/parser/planparserv2"
 	"github.com/milvus-io/milvus/internal/proxy/accesslog"
 	"github.com/milvus-io/milvus/internal/proxy/channelmgr"
+	"github.com/milvus-io/milvus/internal/proxy/fieldvalidator"
 	"github.com/milvus-io/milvus/internal/proxy/shardclient"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/exprutil"
@@ -1052,7 +1053,7 @@ func (t *queryTask) PostExecute(ctx context.Context) error {
 	// Only geometry WKB→WKT conversion still needs to happen here.
 	for i, fieldData := range t.result.FieldsData {
 		if fieldData.Type == schemapb.DataType_Geometry {
-			if err := validateGeometryFieldSearchResult(&t.result.FieldsData[i]); err != nil {
+			if err := fieldvalidator.ValidateGeometryFieldSearchResult(&t.result.FieldsData[i]); err != nil {
 				log.Warn(ctx, "fail to validate geometry field search result", mlog.Err(err))
 				return err
 			}

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -21,6 +21,7 @@ import (
 	"github.com/milvus-io/milvus/internal/parser/planparserv2"
 	"github.com/milvus-io/milvus/internal/proxy/accesslog"
 	"github.com/milvus-io/milvus/internal/proxy/channelmgr"
+	"github.com/milvus-io/milvus/internal/proxy/fieldvalidator"
 	"github.com/milvus-io/milvus/internal/proxy/search_agg"
 	"github.com/milvus-io/milvus/internal/proxy/shardclient"
 	"github.com/milvus-io/milvus/internal/types"
@@ -1442,7 +1443,7 @@ func (t *searchTask) PostExecute(ctx context.Context) error {
 	fieldsData := t.result.GetResults().GetFieldsData()
 	for i, fieldData := range fieldsData {
 		if fieldData.Type == schemapb.DataType_Geometry {
-			if err := validateGeometryFieldSearchResult(&fieldsData[i]); err != nil {
+			if err := fieldvalidator.ValidateGeometryFieldSearchResult(&fieldsData[i]); err != nil {
 				log.Warn(ctx, "fail to validate geometry field search result", mlog.Err(err))
 				return err
 			}
@@ -1452,7 +1453,7 @@ func (t *searchTask) PostExecute(ctx context.Context) error {
 	// stages emit plural; runs before the legacy-wire downgrade below.
 	for i, gbv := range t.result.GetResults().GetGroupByFieldValues() {
 		if gbv != nil && gbv.GetType() == schemapb.DataType_Geometry {
-			if err := validateGeometryFieldSearchResult(&t.result.Results.GroupByFieldValues[i]); err != nil {
+			if err := fieldvalidator.ValidateGeometryFieldSearchResult(&t.result.Results.GroupByFieldValues[i]); err != nil {
 				log.Warn(ctx, "fail to validate geometry field search result", mlog.Err(err))
 				return err
 			}

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -30,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/parser/planparserv2"
 	"github.com/milvus-io/milvus/internal/proxy/channelmgr"
+	"github.com/milvus-io/milvus/internal/proxy/fieldvalidator"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/segcore"
 	"github.com/milvus-io/milvus/pkg/v3/common"
@@ -349,9 +350,9 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 						return err
 					}
 					if subFieldSchema.GetDefaultValue() != nil {
-						err = FillWithDefaultValue(subField, subFieldSchema, int(it.upsertMsg.InsertMsg.NRows()))
+						err = fieldvalidator.FillWithDefaultValue(subField, subFieldSchema, int(it.upsertMsg.InsertMsg.NRows()))
 					} else {
-						err = FillWithNullValue(subField, subFieldSchema, int(it.upsertMsg.InsertMsg.NRows()))
+						err = fieldvalidator.FillWithNullValue(subField, subFieldSchema, int(it.upsertMsg.InsertMsg.NRows()))
 					}
 					if err != nil {
 						log.Info(ctx, "unify struct field data format failed", mlog.Err(err))
@@ -388,9 +389,9 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 		if len(typeutil.GetFieldDataValidData(fieldData)) != 0 {
 			var err error
 			if fieldSchema.GetDefaultValue() != nil {
-				err = FillWithDefaultValue(fieldData, fieldSchema, int(it.upsertMsg.InsertMsg.NRows()))
+				err = fieldvalidator.FillWithDefaultValue(fieldData, fieldSchema, int(it.upsertMsg.InsertMsg.NRows()))
 			} else {
-				err = FillWithNullValue(fieldData, fieldSchema, int(it.upsertMsg.InsertMsg.NRows()))
+				err = fieldvalidator.FillWithNullValue(fieldData, fieldSchema, int(it.upsertMsg.InsertMsg.NRows()))
 			}
 			if err != nil {
 				log.Info(ctx, "unify field data format failed", mlog.Err(err))
@@ -401,7 +402,7 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 	}
 
 	// Validate field data alignment before processing to prevent index out of range panic
-	if err := newValidateUtil().checkAligned(fieldsDataToCheckAligned, it.schema.SchemaHelper, uint64(upsertIDSize)); err != nil {
+	if err := fieldvalidator.NewValidateUtil().CheckAligned(fieldsDataToCheckAligned, it.schema.SchemaHelper, uint64(upsertIDSize)); err != nil {
 		log.Warn(ctx, "check field data aligned failed", mlog.Err(err))
 		return err
 	}
@@ -676,14 +677,14 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 // ToCompressedFormatNullable converts nullable field data from full format to compressed format.
 func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 	validData := typeutil.GetFieldDataValidData(field)
-	if getValidNumber(validData) == len(validData) {
+	if fieldvalidator.GetValidNumber(validData) == len(validData) {
 		return nil
 	}
 	switch field.Field.(type) {
 	case *schemapb.FieldData_Scalars:
 		switch sd := field.GetScalars().GetData().(type) {
 		case *schemapb.ScalarField_BoolData:
-			validRowNum := getValidNumber(validData)
+			validRowNum := fieldvalidator.GetValidNumber(validData)
 			if validRowNum == 0 {
 				sd.BoolData.Data = make([]bool, 0)
 			} else {
@@ -697,7 +698,7 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 			}
 
 		case *schemapb.ScalarField_IntData:
-			validRowNum := getValidNumber(validData)
+			validRowNum := fieldvalidator.GetValidNumber(validData)
 			if validRowNum == 0 {
 				sd.IntData.Data = make([]int32, 0)
 			} else {
@@ -711,7 +712,7 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 			}
 
 		case *schemapb.ScalarField_LongData:
-			validRowNum := getValidNumber(validData)
+			validRowNum := fieldvalidator.GetValidNumber(validData)
 			if validRowNum == 0 {
 				sd.LongData.Data = make([]int64, 0)
 			} else {
@@ -725,7 +726,7 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 			}
 
 		case *schemapb.ScalarField_FloatData:
-			validRowNum := getValidNumber(validData)
+			validRowNum := fieldvalidator.GetValidNumber(validData)
 			if validRowNum == 0 {
 				sd.FloatData.Data = make([]float32, 0)
 			} else {
@@ -739,7 +740,7 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 			}
 
 		case *schemapb.ScalarField_DoubleData:
-			validRowNum := getValidNumber(validData)
+			validRowNum := fieldvalidator.GetValidNumber(validData)
 			if validRowNum == 0 {
 				sd.DoubleData.Data = make([]float64, 0)
 			} else {
@@ -753,7 +754,7 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 			}
 
 		case *schemapb.ScalarField_StringData:
-			validRowNum := getValidNumber(validData)
+			validRowNum := fieldvalidator.GetValidNumber(validData)
 			if validRowNum == 0 {
 				sd.StringData.Data = make([]string, 0)
 			} else {
@@ -767,7 +768,7 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 			}
 
 		case *schemapb.ScalarField_JsonData:
-			validRowNum := getValidNumber(validData)
+			validRowNum := fieldvalidator.GetValidNumber(validData)
 			if validRowNum == 0 {
 				sd.JsonData.Data = make([][]byte, 0)
 			} else {
@@ -781,7 +782,7 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 			}
 
 		case *schemapb.ScalarField_ArrayData:
-			validRowNum := getValidNumber(validData)
+			validRowNum := fieldvalidator.GetValidNumber(validData)
 			if validRowNum == 0 {
 				sd.ArrayData.Data = make([]*schemapb.ScalarField, 0)
 			} else {
@@ -794,7 +795,7 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 				sd.ArrayData.Data = ret
 			}
 		case *schemapb.ScalarField_TimestamptzData:
-			validRowNum := getValidNumber(validData)
+			validRowNum := fieldvalidator.GetValidNumber(validData)
 			if validRowNum == 0 {
 				sd.TimestamptzData.Data = make([]int64, 0)
 			} else {
@@ -808,7 +809,7 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 			}
 
 		case *schemapb.ScalarField_GeometryWktData:
-			validRowNum := getValidNumber(validData)
+			validRowNum := fieldvalidator.GetValidNumber(validData)
 			if validRowNum == 0 {
 				sd.GeometryWktData.Data = make([]string, 0)
 			} else {
@@ -822,7 +823,7 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 			}
 
 		case *schemapb.ScalarField_GeometryData:
-			validRowNum := getValidNumber(validData)
+			validRowNum := fieldvalidator.GetValidNumber(validData)
 			if validRowNum == 0 {
 				sd.GeometryData.Data = make([][]byte, 0)
 			} else {
@@ -1187,7 +1188,7 @@ func ToCompressedFormatNullableStructField(fieldData *schemapb.FieldData) error 
 			continue
 		}
 
-		validRows := getValidNumber(validData)
+		validRows := fieldvalidator.GetValidNumber(validData)
 		if validRows == 0 && !subFieldHasData(subField) {
 			continue
 		}
@@ -1337,7 +1338,7 @@ func validateWholeStructFieldDataForPartialUpdate(schemaHelper *typeutil.SchemaH
 			}
 			continue
 		}
-		validRows := getValidNumber(validData)
+		validRows := fieldvalidator.GetValidNumber(validData)
 		if payloadRows != validRows {
 			return merr.WrapErrParameterInvalidMsg("nullable struct sub-field '%s' payload must be compact: payload row count %d does not match valid rows %d",
 				subField.GetFieldName(), payloadRows, validRows)
@@ -1509,7 +1510,7 @@ func (it *upsertTask) insertPreExecute(ctx context.Context) error {
 		}
 	}
 
-	if err := newValidateUtil(withNANCheck(), withOverflowCheck(), withMaxLenCheck(), withMaxCapCheck()).
+	if err := fieldvalidator.NewValidateUtil(fieldvalidator.WithNANCheck(), fieldvalidator.WithOverflowCheck(), fieldvalidator.WithMaxLenCheck(), fieldvalidator.WithMaxCapCheck()).
 		Validate(it.upsertMsg.InsertMsg.GetFieldsData(), it.schema.SchemaHelper, it.upsertMsg.InsertMsg.NRows()); err != nil {
 		return err
 	}

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -39,6 +39,7 @@ import (
 	"github.com/milvus-io/milvus/internal/agg"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/internal/parser/planparserv2"
+	"github.com/milvus-io/milvus/internal/proxy/fieldvalidator"
 	"github.com/milvus-io/milvus/internal/proxy/privilege"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/function/embedding"
@@ -759,7 +760,7 @@ func ValidateField(field *schemapb.FieldSchema, schema *schemapb.CollectionSchem
 
 	// TODO should remove the index params in the field schema
 	indexParams := funcutil.KeyValuePair2Map(field.GetIndexParams())
-	if err = ValidateAutoIndexMmapConfig(isVectorType, indexParams); err != nil {
+	if err = fieldvalidator.ValidateAutoIndexMmapConfig(isVectorType, indexParams); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Related to #44761

Move validate_util.go out of the monolithic proxy package into the new leaf subpackage internal/proxy/fieldvalidator, part of the proxy component extraction.

The 1.5k-line file had no proxy-internal references - it only consumes schemapb, internal/util/nullutil and pkg/v3 - so the move is a pure symbol-for-symbol extraction with no behavior change. Export the surface tasks relied on: ValidateUtil / NewValidateUtil / ValidateOption / With*Check, ValidateGeometryFieldSearchResult, CheckAligned, GetValidNumber, and the already-exported FillWith* and ValidateAutoIndexMmapConfig.

The 8.8k-line test file moves with the code and now runs as a true package-local unit test: it builds schemapb data directly and reads config via paramtable.Get() instead of the proxy Params global. Root-package consumers (task_insert, task_upsert, task_search, task_query, task_index, util.go) call the package-qualified names.

Verification: go build ./internal/proxy/... and go vet -tags dynamic,test pass; fieldvalidator and affected consumer tests are green.