### PR TITLE
fix: reject read tasks in querynode scheduler under memory pressure

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -669,6 +669,9 @@ queryNode:
     # Max read concurrency must greater than or equal to 1, and less than or equal to hardware.GetCPUNum * 100.
     # (0, 100]
     maxReadConcurrentRatio: 1
+    memProtection:
+      enabled: false # When true, new search/query tasks are rejected with a retriable error while process memory usage is above memProtection.waterLevel, instead of queueing toward OOM.
+      waterLevel: 0.9 # Fraction (0, 1] of total memory (container-limit aware) above which read tasks are rejected; values outside the range disable the protection.
     cpuRatio: 10 # ratio used to estimate read task cpu usage.
     maxTimestampLag: 86400
     scheduleReadPolicy:

--- a/internal/util/searchutil/scheduler/concurrent_safe_scheduler.go
+++ b/internal/util/searchutil/scheduler/concurrent_safe_scheduler.go
@@ -67,6 +67,8 @@ type scheduler struct {
 	execChan    chan Task
 	pool        *conc.Pool[any]
 	gpuPool     *conc.Pool[any]
+	// memProtector rejects new read tasks while process memory sits above the configured water level.
+	memProtector memProtector
 
 	// wg is the waitgroup for internal worker goroutine
 	wg sync.WaitGroup
@@ -235,6 +237,14 @@ func (s *scheduler) handleAddTaskRequest(req addTaskReq, maxWaitTaskNum int64, n
 			int32(maxWaitTaskNum),
 			fmt.Sprintf("limit by %s", paramtable.Get().QueryNodeCfg.MaxUnsolvedQueueSize.Key),
 		)
+		req.err <- err
+	} else if s.memProtector.shouldReject(now) {
+		waterLevel := paramtable.Get().QueryNodeCfg.SchedulerMemProtectionWaterLevel
+		err := merr.WrapErrTooManyRequests(
+			int32(waterLevel.GetAsFloat()*100),
+			fmt.Sprintf("read task rejected under memory pressure, limit by %s", waterLevel.Key),
+		)
+		mlog.RatedWarn(context.TODO(), 1, "scheduler memory protection rejected read task", mlog.Err(err))
 		req.err <- err
 	} else {
 		// Push the task into the policy to schedule and update the counter of the ready queue.

--- a/internal/util/searchutil/scheduler/memory_protection.go
+++ b/internal/util/searchutil/scheduler/memory_protection.go
@@ -1,0 +1,59 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scheduler
+
+import (
+	"time"
+
+	"go.uber.org/atomic"
+
+	"github.com/milvus-io/milvus/pkg/v3/util/hardware"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+// Package-level indirections so unit tests can stub hardware readings.
+var (
+	getUsedMemory  = hardware.GetUsedMemoryCount
+	getTotalMemory = hardware.GetMemoryCount
+)
+
+// memProtectionRefreshInterval bounds how often admission re-reads process memory.
+const memProtectionRefreshInterval = 100 * time.Millisecond
+
+// memProtector caches memory readings so per-task admission stays syscall-free.
+type memProtector struct {
+	lastRefresh atomic.Int64
+	rejecting   atomic.Bool
+}
+
+// shouldReject reports whether new read tasks must be rejected due to memory pressure.
+func (p *memProtector) shouldReject(now time.Time) bool {
+	cfg := &paramtable.Get().QueryNodeCfg
+	if !cfg.SchedulerMemProtectionEnabled.GetAsBool() {
+		return false
+	}
+	waterLevel := cfg.SchedulerMemProtectionWaterLevel.GetAsFloat()
+	if waterLevel <= 0 || waterLevel > 1 {
+		return false
+	}
+	last := p.lastRefresh.Load()
+	if now.UnixNano()-last >= int64(memProtectionRefreshInterval) && p.lastRefresh.CompareAndSwap(last, now.UnixNano()) {
+		total := getTotalMemory()
+		p.rejecting.Store(total > 0 && float64(getUsedMemory()) >= waterLevel*float64(total))
+	}
+	return p.rejecting.Load()
+}

--- a/internal/util/searchutil/scheduler/memory_protection_test.go
+++ b/internal/util/searchutil/scheduler/memory_protection_test.go
@@ -1,0 +1,117 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+func stubMemory(t *testing.T, used, total uint64) {
+	oldUsed, oldTotal := getUsedMemory, getTotalMemory
+	getUsedMemory = func() uint64 { return used }
+	getTotalMemory = func() uint64 { return total }
+	t.Cleanup(func() {
+		getUsedMemory, getTotalMemory = oldUsed, oldTotal
+	})
+}
+
+func setMemProtection(t *testing.T, enabled, waterLevel string) {
+	pt := paramtable.Get()
+	pt.Save(pt.QueryNodeCfg.SchedulerMemProtectionEnabled.Key, enabled)
+	pt.Save(pt.QueryNodeCfg.SchedulerMemProtectionWaterLevel.Key, waterLevel)
+	t.Cleanup(func() {
+		pt.Reset(pt.QueryNodeCfg.SchedulerMemProtectionEnabled.Key)
+		pt.Reset(pt.QueryNodeCfg.SchedulerMemProtectionWaterLevel.Key)
+	})
+}
+
+func TestMemProtectorDisabledByDefault(t *testing.T) {
+	paramtable.Init()
+	stubMemory(t, 100, 100)
+	p := &memProtector{}
+	assert.False(t, p.shouldReject(time.Now()))
+}
+
+func TestMemProtectorRejectsAboveWaterLevel(t *testing.T) {
+	paramtable.Init()
+	setMemProtection(t, "true", "0.9")
+	stubMemory(t, 95, 100)
+	p := &memProtector{}
+	assert.True(t, p.shouldReject(time.Now()))
+}
+
+func TestMemProtectorAllowsBelowWaterLevel(t *testing.T) {
+	paramtable.Init()
+	setMemProtection(t, "true", "0.9")
+	stubMemory(t, 50, 100)
+	p := &memProtector{}
+	assert.False(t, p.shouldReject(time.Now()))
+}
+
+func TestMemProtectorInvalidWaterLevelDisables(t *testing.T) {
+	paramtable.Init()
+	stubMemory(t, 100, 100)
+	for _, level := range []string{"0", "-0.5", "1.5"} {
+		setMemProtection(t, "true", level)
+		p := &memProtector{}
+		assert.False(t, p.shouldReject(time.Now()), "waterLevel=%s", level)
+	}
+}
+
+func TestMemProtectorCachesBetweenRefreshes(t *testing.T) {
+	paramtable.Init()
+	setMemProtection(t, "true", "0.9")
+	stubMemory(t, 95, 100)
+	p := &memProtector{}
+	t0 := time.Now()
+	assert.True(t, p.shouldReject(t0))
+
+	// A reading change within the refresh interval must not flip the cached verdict.
+	getUsedMemory = func() uint64 { return 10 }
+	assert.True(t, p.shouldReject(t0))
+
+	// After the interval elapses the verdict refreshes from the new reading.
+	assert.False(t, p.shouldReject(t0.Add(2*memProtectionRefreshInterval)))
+}
+
+func TestSchedulerRejectsTaskUnderMemoryPressure(t *testing.T) {
+	paramtable.Init()
+	setMemProtection(t, "true", "0.9")
+	stubMemory(t, 95, 100)
+
+	scheduler := newScheduler(newFIFOPolicy())
+	scheduler.Start()
+	defer scheduler.Stop()
+
+	task := newMockTask(mockTaskConfig{
+		nq:          1,
+		executeCost: time.Millisecond,
+		execution: func(ctx context.Context) error {
+			return nil
+		},
+	})
+	err := scheduler.Add(task)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, merr.ErrServiceTooManyRequests)
+}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3961,16 +3961,18 @@ type queryNodeConfig struct {
 	ReadAheadPolicy     ParamItem `refreshable:"false"`
 	ChunkCacheWarmingUp ParamItem `refreshable:"true"`
 
-	MaxUnsolvedQueueSize         ParamItem `refreshable:"true"`
-	MaxReadConcurrency           ParamItem `refreshable:"true"`
-	MaxGpuReadConcurrency        ParamItem `refreshable:"false"`
-	MaxGroupNQ                   ParamItem `refreshable:"true"`
-	NQMergeRatio                 ParamItem `refreshable:"true"`
-	MaxDeadlineMergeGap          ParamItem `refreshable:"true"`
-	TopKMergeRatio               ParamItem `refreshable:"true"`
-	CPURatio                     ParamItem `refreshable:"true"`
-	GracefulStopTimeout          ParamItem `refreshable:"false"`
-	StandaloneMigrateDataTimeout ParamItem `refreshable:"false"`
+	MaxUnsolvedQueueSize             ParamItem `refreshable:"true"`
+	MaxReadConcurrency               ParamItem `refreshable:"true"`
+	SchedulerMemProtectionEnabled    ParamItem `refreshable:"true"`
+	SchedulerMemProtectionWaterLevel ParamItem `refreshable:"true"`
+	MaxGpuReadConcurrency            ParamItem `refreshable:"false"`
+	MaxGroupNQ                       ParamItem `refreshable:"true"`
+	NQMergeRatio                     ParamItem `refreshable:"true"`
+	MaxDeadlineMergeGap              ParamItem `refreshable:"true"`
+	TopKMergeRatio                   ParamItem `refreshable:"true"`
+	CPURatio                         ParamItem `refreshable:"true"`
+	GracefulStopTimeout              ParamItem `refreshable:"false"`
+	StandaloneMigrateDataTimeout     ParamItem `refreshable:"false"`
 
 	EnableResultZeroCopy ParamItem `refreshable:"true"`
 
@@ -4935,6 +4937,24 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 		Export:       true,
 	}
 	p.MaxUnsolvedQueueSize.Init(base.mgr)
+
+	p.SchedulerMemProtectionEnabled = ParamItem{
+		Key:          "queryNode.scheduler.memProtection.enabled",
+		Version:      "2.6.14",
+		DefaultValue: "false",
+		Doc:          "When true, new search/query tasks are rejected with a retriable error while process memory usage is above memProtection.waterLevel, instead of queueing toward OOM.",
+		Export:       true,
+	}
+	p.SchedulerMemProtectionEnabled.Init(base.mgr)
+
+	p.SchedulerMemProtectionWaterLevel = ParamItem{
+		Key:          "queryNode.scheduler.memProtection.waterLevel",
+		Version:      "2.6.14",
+		DefaultValue: "0.9",
+		Doc:          "Fraction (0, 1] of total memory (container-limit aware) above which read tasks are rejected; values outside the range disable the protection.",
+		Export:       true,
+	}
+	p.SchedulerMemProtectionWaterLevel.Init(base.mgr)
 
 	p.MaxGroupNQ = ParamItem{
 		Key:          "queryNode.grouping.maxNQ",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -642,6 +642,8 @@ func TestComponentParam(t *testing.T) {
 
 		assert.Equal(t, int32(1024), Params.MaxUnsolvedQueueSize.GetAsInt32())
 		assert.Equal(t, "1024", Params.MaxUnsolvedQueueSize.DefaultValue)
+		assert.False(t, Params.SchedulerMemProtectionEnabled.GetAsBool())
+		assert.Equal(t, 0.9, Params.SchedulerMemProtectionWaterLevel.GetAsFloat())
 		assert.Equal(t, int64(64), Params.MaxGroupNQ.GetAsInt64())
 		assert.Equal(t, 16.0, Params.NQMergeRatio.GetAsFloat())
 		assert.Equal(t, 20.0, Params.TopKMergeRatio.GetAsFloat())


### PR DESCRIPTION
issue: #52847

The read scheduler admits search/query tasks purely by queue count
(`queryNode.scheduler.unsolvedQueueSize`). Under concurrent DQL on
memory-constrained deployments — worst on standalone, where every role
shares one process RSS — queued and running tasks accumulate holding
query vectors and result buffers until the kernel OOM-kills the
process. QueryNode memory watermarks currently throttle DML only; the
adaptive read protections were removed in #35935, leaving no memory
feedback on the read path (see also #44417).

This PR adds an opt-in, node-local memory protection to the read
scheduler: when process memory usage exceeds
`queryNode.scheduler.memProtection.waterLevel` (default 0.9; the
protection is disabled by default via `memProtection.enabled=false`),
new search/query tasks are rejected with a retriable TooManyRequests
error instead of queueing toward OOM. Memory readings are cached
(100ms) so per-task admission stays syscall-free.

Changes:
- `pkg/util/paramtable`: new refreshable params
  `queryNode.scheduler.memProtection.enabled` / `.waterLevel` + default
  assertions
- `internal/util/searchutil/scheduler`: `memProtector` (cached
  process-memory check, test-stubbable) wired into
  `handleAddTaskRequest`, rejecting with the same retriable error
  family as the existing queue-count rejection
- `configs/milvus.yaml`: regenerated via `gen-yaml`

Verified: new unit tests cover enable/disable, waterLevel bounds,
reading-cache behavior, and end-to-end `scheduler.Add` rejection; the
full scheduler package suite passes with the repo-standard test flags.
