### PR TITLE
enhance: [3.0] use STL_SORT for nested hybrid at high cardinality (#52819)

### DIFF
--- a/internal/core/src/index/BitmapIndexArrayTest.cpp
+++ b/internal/core/src/index/BitmapIndexArrayTest.cpp
@@ -1766,3 +1766,84 @@ TEST(BitmapIndexArrayNestedTest,
 
     boost::filesystem::remove_all(root_path);
 }
+
+namespace {
+
+// Exposes the protected array-type selection dispatcher so the
+// nested-vs-regular choice can be asserted directly.
+class TestHybridScalarIndexString
+    : public index::HybridScalarIndex<std::string> {
+ public:
+    using index::HybridScalarIndex<std::string>::HybridScalarIndex;
+    ScalarIndexType
+    SelectIndexBuildTypePublic(const std::vector<FieldDataPtr>& field_datas) {
+        return SelectIndexBuildType(field_datas);
+    }
+};
+
+std::vector<ScalarFieldProto>
+MakeStringScalarArrays(int rows, int distinct) {
+    std::vector<ScalarFieldProto> scalar_arrays(rows);
+    for (int i = 0; i < rows; ++i) {
+        scalar_arrays[i].mutable_string_data()->add_data(
+            fmt::format("value_{:04d}", i % distinct));
+    }
+    return scalar_arrays;
+}
+
+FieldDataPtr
+MakeStringArrayFieldData(const std::vector<ScalarFieldProto>& scalar_arrays) {
+    std::vector<milvus::Array> array_data;
+    array_data.reserve(scalar_arrays.size());
+    for (const auto& scalar_array : scalar_arrays) {
+        array_data.emplace_back(scalar_array);
+    }
+    auto field_data =
+        storage::CreateFieldData(DataType::ARRAY, DataType::NONE, false);
+    field_data->FillFieldData(array_data.data(), array_data.size());
+    return field_data;
+}
+
+}  // namespace
+
+// Nested (struct sub-field) HYBRID indexes flatten scalar elements, so the
+// sort index can serve high-cardinality data: STL_SORT must replace INVERTED
+// once distinct values reach the bitmap cardinality limit (default 100).
+// Regular array fields keep INVERTED because the sort index cannot handle
+// array values.
+TEST(BitmapIndexArrayNestedTest, HybridNestedHighCardinalitySelectsStlsort) {
+    auto root_path =
+        fmt::format("{}/hybrid_nested_high_card_stlsort", TestLocalPath);
+    auto ctx =
+        MakeNestedCtx(root_path, proto::schema::DataType::VarChar, false, 3140);
+
+    // 120 distinct elements spread over 240 rows -> high cardinality.
+    auto high_card_field_data =
+        MakeStringArrayFieldData(MakeStringScalarArrays(240, 120));
+
+    TestHybridScalarIndexString nested(7, ctx, true);
+    EXPECT_EQ(nested.SelectIndexBuildTypePublic(
+                  std::vector<FieldDataPtr>{high_card_field_data}),
+              ScalarIndexType::STLSORT);
+
+    // Regular (non-nested) array fields must stay on INVERTED at high
+    // cardinality.
+    TestHybridScalarIndexString regular(7, ctx, false);
+    EXPECT_EQ(regular.SelectIndexBuildTypePublic(
+                  std::vector<FieldDataPtr>{high_card_field_data}),
+              ScalarIndexType::INVERTED);
+
+    // Low cardinality keeps BITMAP for both nested and regular arrays.
+    auto low_card_field_data =
+        MakeStringArrayFieldData(MakeStringScalarArrays(10, 1));
+    TestHybridScalarIndexString nested_low(7, ctx, true);
+    EXPECT_EQ(nested_low.SelectIndexBuildTypePublic(
+                  std::vector<FieldDataPtr>{low_card_field_data}),
+              ScalarIndexType::BITMAP);
+    TestHybridScalarIndexString regular_low(7, ctx, false);
+    EXPECT_EQ(regular_low.SelectIndexBuildTypePublic(
+                  std::vector<FieldDataPtr>{low_card_field_data}),
+              ScalarIndexType::BITMAP);
+
+    boost::filesystem::remove_all(root_path);
+}

--- a/internal/core/src/index/HybridScalarIndex.cpp
+++ b/internal/core/src/index/HybridScalarIndex.cpp
@@ -194,11 +194,14 @@ HybridScalarIndex<T>::SelectBuildTypeForArrayType(
             }
         }
     }
-    // For array types, always use BITMAP for low cardinality and INVERTED for high cardinality.
-    // These are hardcoded because STL_SORT doesn't support arrays, and BITMAP is the only
-    // suitable choice for low cardinality arrays. Config parameters don't apply to arrays.
+    // For array types, always use BITMAP for low cardinality. For high
+    // cardinality, nested indexes index the flattened scalar elements, so the
+    // sort index can serve them and STL_SORT replaces INVERTED; regular array
+    // fields keep INVERTED because the sort index cannot handle array values.
+    // These are hardcoded and config parameters don't apply to arrays.
     if (distinct_vals.size() >= bitmap_index_cardinality_limit_) {
-        internal_index_type_ = ScalarIndexType::INVERTED;
+        internal_index_type_ = is_nested_index_ ? ScalarIndexType::STLSORT
+                                                : ScalarIndexType::INVERTED;
     } else {
         internal_index_type_ = ScalarIndexType::BITMAP;
     }


### PR DESCRIPTION
Cherry-pick from master
pr: #52819
Struct sub-field (nested) hybrid scalar indexes now select STL_SORT as their internal index type once distinct element values reach the bitmap cardinality limit (default 100), instead of INVERTED.

Nested indexes index the flattened scalar elements of each row, which the sort index can serve, so STL_SORT matches the default high-cardinality choice already used for primitive scalar fields. Regular (non-nested) array fields keep INVERTED because the sort index cannot handle array values; low-cardinality arrays keep BITMAP for both cases. Configurable low/high index type parameters still do not apply to array types.

---------