### PR TITLE
enhance: [cp2.6] Return trace ID in REST responses (#49968)

### DIFF
--- a/internal/distributed/proxy/httpserver/constant.go
+++ b/internal/distributed/proxy/httpserver/constant.go
@@ -130,6 +130,7 @@ const (
 	HTTPHeaderAllowInt64     = "Accept-Type-Allow-Int64"
 	HTTPHeaderDBName         = "DB-Name"
 	HTTPHeaderRequestTimeout = "Request-Timeout"
+	HTTPHeaderMilvusTraceID  = "X-Milvus-Trace-Id"
 	HTTPReturnCode           = "code"
 	HTTPReturnMessage        = "message"
 	HTTPReturnData           = "data"

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -31,7 +31,6 @@ import (
 	validator "github.com/go-playground/validator/v10"
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -372,14 +371,9 @@ func wrapperPost(newReq newReqFunc, v2 handlerFuncV2) gin.HandlerFunc {
 				collectionName = getter.GetCollectionName()
 			}
 		}
-		innerCtx := gCtx.Request.Context()
-		ctx, span := otel.Tracer(typeutil.ProxyRole).Start(innerCtx, gCtx.Request.URL.Path)
-		defer span.End()
+		ctx := gCtx.Request.Context()
 		username, _ := gCtx.Get(ContextUsername)
 		ctx = proxy.NewContextWithMetadata(ctx, username.(string), dbName)
-		traceID := span.SpanContext().TraceID().String()
-		ctx = log.WithTraceID(ctx, traceID)
-		gCtx.Set("traceID", traceID)
 		log.Ctx(ctx).Debug("high level restful api, read parameters from request body, then start to handle.",
 			zap.Any("url", gCtx.Request.URL.Path))
 

--- a/internal/distributed/proxy/httpserver/timeout_middleware.go
+++ b/internal/distributed/proxy/httpserver/timeout_middleware.go
@@ -304,6 +304,9 @@ func timeoutMiddleware(handler gin.HandlerFunc) gin.HandlerFunc {
 			bufPool.Put(buffer)
 
 			realWriter.Header().Set("Content-Type", "application/json; charset=utf-8")
+			if traceID, ok := getTraceID(gCtx); ok {
+				setTraceIDHeaderTo(realWriter.Header(), traceID)
+			}
 			realWriter.WriteHeader(http.StatusRequestTimeout)
 			body, _ := json.Marshal(gin.H{HTTPReturnCode: merr.TimeoutCode, HTTPReturnMessage: "request timeout"})
 			realWriter.Write(body)

--- a/internal/distributed/proxy/httpserver/traceid_test.go
+++ b/internal/distributed/proxy/httpserver/traceid_test.go
@@ -1,0 +1,380 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+const testTraceID = "0123456789abcdef0123456789abcdef"
+
+var traceIDPattern = regexp.MustCompile(`^[0-9a-f]{32}$`)
+
+func withTestTracerProvider(t *testing.T, opts ...sdktrace.TracerProviderOption) {
+	t.Helper()
+	oldProvider := otel.GetTracerProvider()
+	tp := sdktrace.NewTracerProvider(opts...)
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		require.NoError(t, tp.Shutdown(context.Background()))
+		otel.SetTracerProvider(oldProvider)
+	})
+}
+
+func withTraceContextPropagator(t *testing.T) {
+	t.Helper()
+	oldPropagator := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() {
+		otel.SetTextMapPropagator(oldPropagator)
+	})
+}
+
+func newTraceIDTestContext() (*gin.Context, *httptest.ResponseRecorder) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/traceid", nil)
+	c.Set("traceID", testTraceID)
+	return c, w
+}
+
+func assertTraceIDHeader(t *testing.T, headers http.Header, expected string) {
+	t.Helper()
+	assert.Equal(t, expected, headers.Get(HTTPHeaderMilvusTraceID))
+}
+
+func assertValidTraceIDHeader(t *testing.T, headers http.Header) string {
+	t.Helper()
+	traceID := headers.Get(HTTPHeaderMilvusTraceID)
+	require.Regexp(t, traceIDPattern, traceID)
+	assertTraceIDHeader(t, headers, traceID)
+	return traceID
+}
+
+func TestHTTPReturnWritesTraceIDHeader(t *testing.T) {
+	tests := []struct {
+		name  string
+		write func(*gin.Context)
+	}{
+		{
+			name: "json",
+			write: func(c *gin.Context) {
+				HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil)})
+			},
+		},
+		{
+			name: "stream",
+			write: func(c *gin.Context) {
+				HTTPReturnStream(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil)})
+			},
+		},
+		{
+			name: "abort",
+			write: func(c *gin.Context) {
+				HTTPAbortReturn(c, http.StatusUnauthorized, gin.H{
+					HTTPReturnCode:    merr.Code(merr.ErrNeedAuthenticate),
+					HTTPReturnMessage: merr.ErrNeedAuthenticate.Error(),
+				})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c, w := newTraceIDTestContext()
+
+			test.write(c)
+
+			assertTraceIDHeader(t, w.Header(), testTraceID)
+		})
+	}
+}
+
+func TestHTTPReturnSkipsTraceIDHeaderWhenMissing(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/traceid", nil)
+
+	HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil)})
+
+	assert.Empty(t, w.Header().Get(HTTPHeaderMilvusTraceID))
+}
+
+func TestTraceIDHandlerFuncCreatesRequestTraceID(t *testing.T) {
+	withTestTracerProvider(t)
+	app := gin.New()
+	app.Use(TraceIDHandlerFunc)
+
+	var ctxTraceID string
+	app.POST("/v2/vectordb/entities/search", func(c *gin.Context) {
+		spanCtx := oteltrace.SpanFromContext(c.Request.Context()).SpanContext()
+		require.True(t, spanCtx.TraceID().IsValid())
+		ctxTraceID = spanCtx.TraceID().String()
+
+		traceID, ok := c.Get("traceID")
+		require.True(t, ok)
+		assert.Equal(t, ctxTraceID, traceID)
+
+		HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil)})
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v2/vectordb/entities/search", nil)
+	app.ServeHTTP(w, req)
+
+	returnedTraceID := assertValidTraceIDHeader(t, w.Header())
+	assert.Equal(t, ctxTraceID, returnedTraceID)
+}
+
+func TestTraceIDHandlerFuncContinuesIncomingTrace(t *testing.T) {
+	withTestTracerProvider(t)
+	withTraceContextPropagator(t)
+
+	parentTraceID, err := oteltrace.TraceIDFromHex("11111111111111111111111111111111")
+	require.NoError(t, err)
+	parentSpanID, err := oteltrace.SpanIDFromHex("2222222222222222")
+	require.NoError(t, err)
+	parentSpan := oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+		TraceID:    parentTraceID,
+		SpanID:     parentSpanID,
+		TraceFlags: oteltrace.FlagsSampled,
+		Remote:     true,
+	})
+
+	app := gin.New()
+	app.Use(TraceIDHandlerFunc)
+	app.POST("/v2/vectordb/entities/search", func(c *gin.Context) {
+		spanCtx := oteltrace.SpanFromContext(c.Request.Context()).SpanContext()
+		assert.Equal(t, parentTraceID, spanCtx.TraceID())
+		assert.NotEqual(t, parentSpanID, spanCtx.SpanID())
+		HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil)})
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v2/vectordb/entities/search", nil)
+	otel.GetTextMapPropagator().Inject(
+		oteltrace.ContextWithRemoteSpanContext(context.Background(), parentSpan),
+		propagation.HeaderCarrier(req.Header),
+	)
+	app.ServeHTTP(w, req)
+
+	assertTraceIDHeader(t, w.Header(), parentTraceID.String())
+}
+
+func TestTraceIDHandlerFuncCoversV1AndV2RestRoutes(t *testing.T) {
+	withTestTracerProvider(t)
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{
+			name:   "v1",
+			method: http.MethodGet,
+			path:   "/v1/vector/collections",
+		},
+		{
+			name:   "v2",
+			method: http.MethodPost,
+			path:   "/v2/vectordb/collections/list",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			app := gin.New()
+			app.Use(TraceIDHandlerFunc)
+			app.Handle(test.method, test.path, func(c *gin.Context) {
+				HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil)})
+			})
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(test.method, test.path, nil)
+			app.ServeHTTP(w, req)
+
+			assertValidTraceIDHeader(t, w.Header())
+		})
+	}
+}
+
+func TestTraceIDHandlerFuncCreatesTraceIDWhenUnsampled(t *testing.T) {
+	withTestTracerProvider(t, sdktrace.WithSampler(sdktrace.NeverSample()))
+	app := gin.New()
+	app.Use(TraceIDHandlerFunc)
+
+	var sampled bool
+	app.POST("/v2/vectordb/entities/search", func(c *gin.Context) {
+		spanCtx := oteltrace.SpanFromContext(c.Request.Context()).SpanContext()
+		require.True(t, spanCtx.TraceID().IsValid())
+		sampled = spanCtx.IsSampled()
+
+		HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil)})
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v2/vectordb/entities/search", nil)
+	app.ServeHTTP(w, req)
+
+	assert.False(t, sampled)
+	assertValidTraceIDHeader(t, w.Header())
+}
+
+func TestTraceIDHandlerFuncReturnsUniqueTraceID(t *testing.T) {
+	withTestTracerProvider(t)
+	app := gin.New()
+	app.Use(TraceIDHandlerFunc)
+	app.POST("/v2/vectordb/entities/search", func(c *gin.Context) {
+		HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil)})
+	})
+
+	seen := make(map[string]struct{})
+	for i := 0; i < 20; i++ {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/v2/vectordb/entities/search", nil)
+		app.ServeHTTP(w, req)
+
+		traceID := assertValidTraceIDHeader(t, w.Header())
+		require.NotContains(t, seen, traceID)
+		seen[traceID] = struct{}{}
+	}
+}
+
+func TestTraceIDHandlerFuncCoversEarlyAbort(t *testing.T) {
+	withTestTracerProvider(t)
+	app := gin.New()
+	app.Use(TraceIDHandlerFunc)
+	app.GET("/auth", func(c *gin.Context) {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+			HTTPReturnCode:    merr.Code(merr.ErrNeedAuthenticate),
+			HTTPReturnMessage: merr.ErrNeedAuthenticate.Error(),
+		})
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/auth", nil)
+	app.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assertValidTraceIDHeader(t, w.Header())
+}
+
+func TestWrapperPostBadJSONReturnsTraceIDHeader(t *testing.T) {
+	withTestTracerProvider(t)
+	app := gin.New()
+	app.Use(TraceIDHandlerFunc)
+	app.POST("/v2/vectordb/entities/search", wrapperPost(func() any { return &DefaultReq{} },
+		func(ctx context.Context, c *gin.Context, req any, dbName string) (interface{}, error) {
+			return nil, nil
+		}))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v2/vectordb/entities/search", strings.NewReader(`{"dbName"}`))
+	app.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assertValidTraceIDHeader(t, w.Header())
+}
+
+func TestWrapperPostKeepsRequestTraceID(t *testing.T) {
+	withTestTracerProvider(t)
+	app := gin.New()
+	app.Use(TraceIDHandlerFunc)
+	app.Use(func(c *gin.Context) {
+		c.Set(ContextUsername, "")
+		c.Next()
+	})
+
+	var handlerTraceID string
+	app.POST("/v2/vectordb/entities/search", wrapperPost(func() any { return &DefaultReq{} },
+		func(ctx context.Context, c *gin.Context, req any, dbName string) (interface{}, error) {
+			handlerTraceID = oteltrace.SpanFromContext(ctx).SpanContext().TraceID().String()
+			HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil)})
+			return nil, nil
+		}))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v2/vectordb/entities/search", strings.NewReader(`{}`))
+	app.ServeHTTP(w, req)
+
+	returnedTraceID := assertValidTraceIDHeader(t, w.Header())
+	assert.Equal(t, handlerTraceID, returnedTraceID)
+}
+
+func TestWrapperPostUsesRequestSpan(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	withTestTracerProvider(t, sdktrace.WithSpanProcessor(recorder))
+
+	app := gin.New()
+	app.Use(TraceIDHandlerFunc)
+	app.Use(func(c *gin.Context) {
+		c.Set(ContextUsername, "")
+		c.Next()
+	})
+	app.POST("/v2/vectordb/entities/search", wrapperPost(func() any { return &DefaultReq{} },
+		func(ctx context.Context, c *gin.Context, req any, dbName string) (interface{}, error) {
+			HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil)})
+			return nil, nil
+		}))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v2/vectordb/entities/search", strings.NewReader(`{}`))
+	app.ServeHTTP(w, req)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "/v2/vectordb/entities/search", spans[0].Name())
+}
+
+func TestTimeoutMiddlewareReturnsTraceIDHeader(t *testing.T) {
+	withTestTracerProvider(t)
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key, "10")
+	t.Cleanup(func() {
+		paramtable.Get().Reset(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key)
+	})
+
+	app := gin.New()
+	app.Use(TraceIDHandlerFunc)
+	app.POST("/timeout", timeoutMiddleware(func(c *gin.Context) {
+		time.Sleep(50 * time.Millisecond)
+	}))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/timeout", nil)
+	app.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusRequestTimeout, w.Code)
+	assertValidTraceIDHeader(t, w.Header())
+}

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -22,6 +22,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math"
+	"net/http"
 	"reflect"
 	"strconv"
 	"strings"
@@ -30,6 +31,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/spf13/cast"
 	"github.com/tidwall/gjson"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
@@ -57,6 +61,7 @@ func HTTPReturn(c *gin.Context, code int, result gin.H) {
 	if errorMsg, ok := result[HTTPReturnMessage]; ok {
 		c.Set(HTTPReturnMessage, errorMsg)
 	}
+	setTraceIDHeader(c)
 	c.JSON(code, result)
 }
 
@@ -67,6 +72,7 @@ func HTTPReturnStream(c *gin.Context, code int, result gin.H) {
 	if errorMsg, ok := result[HTTPReturnMessage]; ok {
 		c.Set(HTTPReturnMessage, errorMsg)
 	}
+	setTraceIDHeader(c)
 	c.Render(code, jsonRender{Data: result})
 }
 
@@ -75,7 +81,56 @@ func HTTPAbortReturn(c *gin.Context, code int, result gin.H) {
 	if errorMsg, ok := result[HTTPReturnMessage]; ok {
 		c.Set(HTTPReturnMessage, errorMsg)
 	}
+	setTraceIDHeader(c)
 	c.AbortWithStatusJSON(code, result)
+}
+
+func TraceIDHandlerFunc(c *gin.Context) {
+	ctx := otel.GetTextMapPropagator().Extract(c.Request.Context(), propagation.HeaderCarrier(c.Request.Header))
+	ctx, span := otel.Tracer(typeutil.ProxyRole).Start(ctx, c.Request.URL.Path)
+	defer span.End()
+
+	traceID := span.SpanContext().TraceID()
+	if traceID.IsValid() {
+		traceIDStr := traceID.String()
+		ctx = log.WithTraceID(ctx, traceIDStr)
+		c.Set("traceID", traceIDStr)
+		c.Request = c.Request.WithContext(ctx)
+		setTraceIDHeader(c)
+	}
+
+	c.Next()
+}
+
+func getTraceID(c *gin.Context) (string, bool) {
+	traceID, ok := c.Get("traceID")
+	if ok {
+		traceIDStr, ok := traceID.(string)
+		if ok && traceIDStr != "" {
+			return traceIDStr, true
+		}
+	}
+
+	if c.Request == nil {
+		return "", false
+	}
+	spanTraceID := oteltrace.SpanFromContext(c.Request.Context()).SpanContext().TraceID()
+	if !spanTraceID.IsValid() {
+		return "", false
+	}
+	return spanTraceID.String(), true
+}
+
+func setTraceIDHeader(c *gin.Context) {
+	traceID, ok := getTraceID(c)
+	if !ok {
+		return
+	}
+	setTraceIDHeaderTo(c.Writer.Header(), traceID)
+}
+
+func setTraceIDHeaderTo(header http.Header, traceID string) {
+	header.Set(HTTPHeaderMilvusTraceID, traceID)
 }
 
 func ParseUsernamePassword(c *gin.Context) (string, string, bool) {

--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -212,6 +212,7 @@ func (s *Server) startHTTPServer(errChan chan error) {
 	defer s.wg.Done()
 	ginHandler := gin.New()
 	ginHandler.Use(httpserver.MetricsHandlerFunc)
+	ginHandler.Use(httpserver.TraceIDHandlerFunc)
 	ginHandler.Use(accesslog.AccessLogMiddleware)
 	ginHandler.Use(httpserver.LoggerHandlerFunc(), gin.Recovery())
 	ginHandler.Use(httpserver.RequestHandlerFunc)


### PR DESCRIPTION
Cherry-pick from master
pr: #49968

issue: #49967

## What was changed

- Add `X-Milvus-Trace-Id` to REST responses for `/v1/vector/...` and `/v2/vectordb/...` routes.
- Create a REST entry trace span before access logging so response headers and REST logs use the same request trace ID.
- Keep the v2 wrapper from overwriting the entry trace ID when one already exists.
- Add timeout and early-return coverage for the trace ID header.

## Test Plan

- `gofumpt -l internal/distributed/proxy/httpserver/traceid_test.go internal/distributed/proxy/httpserver/utils.go internal/distributed/proxy/httpserver/constant.go internal/distributed/proxy/httpserver/timeout_middleware.go internal/distributed/proxy/httpserver/handler_v2.go internal/distributed/proxy/service.go`
- `git diff --check`
- `go test -count=1 -tags dynamic,test ./internal/distributed/proxy/httpserver -run "TestHTTPReturnWritesTraceIDHeader|TestHTTPReturnSkipsTraceIDHeaderWhenMissing|TestTraceIDHandlerFunc|TestWrapperPost|TestTimeoutMiddlewareReturnsTraceIDHeader" -timeout 300s`
- `make` full build passes
