### PR TITLE
enhance: optimize inverted index null expr by caching bitmap directly

### DIFF
--- a/internal/core/src/index/BitmapIndex.cpp
+++ b/internal/core/src/index/BitmapIndex.cpp
@@ -639,16 +639,17 @@ BitmapIndex<T>::LoadWithoutAssemble(const BinarySet& binary_set,
                                            index_meta_buffer->size);
     auto index_length = index_meta.first;
     total_num_rows_ = index_meta.second;
-    valid_bitset_ =
-        TargetBitmap(total_num_rows_, is_nested_index_ || !schema_.nullable());
-    bool rebuild_validity_from_postings =
-        schema_.nullable() && !is_nested_index_;
 
     auto valid_bitset_buffer = binary_set.GetByName(BITMAP_INDEX_VALID_BITSET);
+    bool rebuild_validity_from_postings = false;
     if (valid_bitset_buffer != nullptr) {
         DeserializeValidBitsetData(valid_bitset_buffer->data.get(),
                                    valid_bitset_buffer->size);
-        rebuild_validity_from_postings = false;
+    } else {
+        valid_bitset_ = TargetBitmap(total_num_rows_,
+                                     is_nested_index_ || !schema_.nullable());
+        rebuild_validity_from_postings =
+            schema_.nullable() && !is_nested_index_;
     }
 
     auto index_data_buffer = binary_set.GetByName(BITMAP_INDEX_DATA);
@@ -817,8 +818,7 @@ BitmapIndex<T>::IsNull() {
     tracer::AutoSpan span("BitmapIndex::IsNull", tracer::GetRootSpan());
 
     AssertInfo(is_built_, "index has not been built");
-    TargetBitmap res(total_num_rows_, true);
-    res &= valid_bitset_;
+    auto res = valid_bitset_.clone();
     res.flip();
     return res;
 }
@@ -829,9 +829,7 @@ BitmapIndex<T>::IsNotNull() {
     tracer::AutoSpan span("BitmapIndex::IsNotNull", tracer::GetRootSpan());
 
     AssertInfo(is_built_, "index has not been built");
-    TargetBitmap res(total_num_rows_, true);
-    res &= valid_bitset_;
-    return res;
+    return valid_bitset_.clone();
 }
 
 template <typename T>
@@ -1453,19 +1451,20 @@ BitmapIndex<T>::LoadEntries(storage::IndexEntryReader& reader,
     total_num_rows_ = reader.GetMeta<size_t>(BITMAP_INDEX_NUM_ROWS);
     is_nested_index_ =
         reader.GetMeta<bool>(BITMAP_INDEX_IS_NESTED_META, is_nested_index_);
-    valid_bitset_ =
-        TargetBitmap(total_num_rows_, is_nested_index_ || !schema_.nullable());
-    bool rebuild_validity_from_postings =
-        schema_.nullable() && !is_nested_index_;
 
     auto entry_names = reader.GetEntryNames();
+    bool rebuild_validity_from_postings = false;
     if (std::find(entry_names.begin(),
                   entry_names.end(),
                   BITMAP_INDEX_VALID_BITSET) != entry_names.end()) {
         auto valid_bitset_entry = reader.ReadEntry(BITMAP_INDEX_VALID_BITSET);
         DeserializeValidBitsetData(valid_bitset_entry.data.data(),
                                    valid_bitset_entry.data.size());
-        rebuild_validity_from_postings = false;
+    } else {
+        valid_bitset_ = TargetBitmap(total_num_rows_,
+                                     is_nested_index_ || !schema_.nullable());
+        rebuild_validity_from_postings =
+            schema_.nullable() && !is_nested_index_;
     }
 
     ChooseIndexLoadMode(index_length);

--- a/internal/core/src/index/InvertedIndexArrayTest.cpp
+++ b/internal/core/src/index/InvertedIndexArrayTest.cpp
@@ -359,7 +359,13 @@ class NullableInt64ArrayInvertedIndex
  public:
     void
     SetNullOffsets(std::vector<size_t> offsets) {
+        schema_.set_nullable(true);
         null_offset_ = std::move(offsets);
+        if (is_nested_index_) {
+            validity_mode_ = ValidityMode::ImplicitAllValid;
+            return;
+        }
+        validity_mode_ = ValidityMode::NullOffsets;
     }
 };
 

--- a/internal/core/src/index/InvertedIndexArrayTest.cpp
+++ b/internal/core/src/index/InvertedIndexArrayTest.cpp
@@ -362,10 +362,10 @@ class NullableInt64ArrayInvertedIndex
         schema_.set_nullable(true);
         null_offset_ = std::move(offsets);
         if (is_nested_index_) {
-            validity_mode_ = ValidityMode::ImplicitAllValid;
+            validity_mode_ = milvus::index::ValidityMode::ImplicitAllValid;
             return;
         }
-        validity_mode_ = ValidityMode::NullOffsets;
+        validity_mode_ = milvus::index::ValidityMode::NullOffsets;
     }
 };
 

--- a/internal/core/src/index/InvertedIndexTantivy.cpp
+++ b/internal/core/src/index/InvertedIndexTantivy.cpp
@@ -104,6 +104,9 @@ InvertedIndexTantivy<T>::InvertedIndexTantivy(
       inverted_index_single_segment_(inverted_index_single_segment),
       user_specified_doc_id_(user_specified_doc_id),
       is_nested_index_(is_nested_index) {
+    validity_mode_ = !is_nested_index_ && schema_.nullable()
+                         ? ValidityMode::NullOffsets
+                         : ValidityMode::ImplicitAllValid;
     this->file_manager_ = std::make_shared<MemFileManager>(ctx);
     disk_file_manager_ = std::make_shared<DiskFileManager>(ctx);
     // push init wrapper to load process
@@ -132,6 +135,41 @@ template <typename T>
 void
 InvertedIndexTantivy<T>::finish() {
     wrapper_->finish();
+}
+
+template <typename T>
+void
+InvertedIndexTantivy<T>::LoadNullOffsets(const uint8_t* data, size_t size) {
+    const auto offset_count = size / sizeof(size_t);
+    null_offset_.resize(offset_count);
+    milvus::fastmem::FastMemcpy(
+        null_offset_.data(), data, offset_count * sizeof(size_t));
+    validity_mode_ = ValidityMode::NullOffsets;
+}
+
+template <typename T>
+void
+InvertedIndexTantivy<T>::FinalizeLoadedValidity() {
+    AssertInfo(!is_growing_,
+               "loaded inverted index must not be a growing index");
+
+    if (!schema_.nullable() || is_nested_index_) {
+        validity_mode_ = ValidityMode::ImplicitAllValid;
+        std::vector<size_t>().swap(null_offset_);
+        return;
+    }
+
+    const auto count = static_cast<size_t>(Count());
+    valid_bitset_ = TargetBitmap(count, true);
+    for (auto offset : null_offset_) {
+        AssertInfo(offset < count,
+                   "inverted index null offset {} out of range {}",
+                   offset,
+                   count);
+        valid_bitset_.reset(offset);
+    }
+    validity_mode_ = ValidityMode::ValidBitmap;
+    std::vector<size_t>().swap(null_offset_);
 }
 
 template <typename T>
@@ -244,6 +282,7 @@ InvertedIndexTantivy<T>::Load(milvus::tracer::TraceContext ctx,
         GetValueFromConfig<bool>(config, ENABLE_MMAP).value_or(true);
     wrapper_ = std::make_shared<TantivyIndexWrapper>(
         prefix.c_str(), load_in_mmap, milvus::index::SetBitsetSealed);
+    FinalizeLoadedValidity();
 
     if (!load_in_mmap) {
         // the index is loaded in ram, so we can remove files in advance
@@ -257,8 +296,7 @@ void
 InvertedIndexTantivy<T>::LoadIndexMetas(
     const std::vector<std::string>& index_files, const Config& config) {
     auto fill_null_offsets = [&](const uint8_t* data, int64_t size) {
-        null_offset_.resize((size_t)size / sizeof(size_t));
-        milvus::fastmem::FastMemcpy(null_offset_.data(), data, (size_t)size);
+        LoadNullOffsets(data, static_cast<size_t>(size));
     };
     auto null_offset_file_itr = std::find_if(
         index_files.begin(), index_files.end(), [&](const std::string& file) {
@@ -349,15 +387,31 @@ const TargetBitmap
 InvertedIndexTantivy<T>::IsNull() {
     tracer::AutoSpan span("InvertedIndexTantivy::IsNull",
                           tracer::GetRootSpan());
-    int64_t count = Count();
-    TargetBitmap bitset(count);
-
-    // For nested index, null rows don't have elements in the index,
-    // so all elements in the index are valid (none are null).
-    // null_offset_ stores row offsets, not element offsets.
-    if (is_nested_index_) {
-        return bitset;  // All false - no element is null
+    const auto count = static_cast<size_t>(Count());
+    if (validity_mode_ == ValidityMode::ValidBitmap) {
+        AssertInfo(null_offset_.empty(),
+                   "bitmap-backed inverted index must not retain null "
+                   "offsets");
+        AssertInfo(valid_bitset_.size() == count,
+                   "inverted index validity bitmap size mismatch, expect {}, "
+                   "got {}",
+                   count,
+                   valid_bitset_.size());
+        auto bitset = valid_bitset_.clone();
+        bitset.flip();
+        return bitset;
     }
+
+    TargetBitmap bitset(count, false);
+    if (validity_mode_ == ValidityMode::ImplicitAllValid) {
+        return bitset;
+    }
+
+    AssertInfo(validity_mode_ == ValidityMode::NullOffsets,
+               "unexpected inverted index validity mode {}",
+               static_cast<int>(validity_mode_));
+    AssertInfo(!is_nested_index_,
+               "nested inverted index must use implicit validity");
 
     auto fill_bitset = [this, count, &bitset]() {
         auto end =
@@ -382,15 +436,29 @@ TargetBitmap
 InvertedIndexTantivy<T>::IsNotNull() {
     tracer::AutoSpan span("InvertedIndexTantivy::IsNotNull",
                           tracer::GetRootSpan());
-    int64_t count = Count();
-    TargetBitmap bitset(count, true);
-
-    // For nested index, null rows don't have elements in the index,
-    // so all elements in the index are valid.
-    // null_offset_ stores row offsets, not element offsets.
-    if (is_nested_index_) {
-        return bitset;  // All true - all elements are valid
+    const auto count = static_cast<size_t>(Count());
+    if (validity_mode_ == ValidityMode::ValidBitmap) {
+        AssertInfo(null_offset_.empty(),
+                   "bitmap-backed inverted index must not retain null "
+                   "offsets");
+        AssertInfo(valid_bitset_.size() == count,
+                   "inverted index validity bitmap size mismatch, expect {}, "
+                   "got {}",
+                   count,
+                   valid_bitset_.size());
+        return valid_bitset_.clone();
     }
+
+    TargetBitmap bitset(count, true);
+    if (validity_mode_ == ValidityMode::ImplicitAllValid) {
+        return bitset;
+    }
+
+    AssertInfo(validity_mode_ == ValidityMode::NullOffsets,
+               "unexpected inverted index validity mode {}",
+               static_cast<int>(validity_mode_));
+    AssertInfo(!is_nested_index_,
+               "nested inverted index must use implicit validity");
 
     auto fill_bitset = [this, count, &bitset]() {
         auto end =
@@ -439,13 +507,36 @@ template <typename T>
 const TargetBitmap
 InvertedIndexTantivy<T>::NotIn(size_t n, const T* values) {
     tracer::AutoSpan span("InvertedIndexTantivy::NotIn", tracer::GetRootSpan());
-    int64_t count = Count();
+    const auto count = static_cast<size_t>(Count());
     TargetBitmap bitset(count);
     wrapper_->terms_query(values, n, &bitset);
     // The expression is "not" in, so we flip the bit.
     bitset.flip();
 
-    auto fill_bitset = [this, count, &bitset]() {
+    if (validity_mode_ == ValidityMode::ImplicitAllValid) {
+        return bitset;
+    }
+
+    if (validity_mode_ == ValidityMode::ValidBitmap) {
+        AssertInfo(null_offset_.empty(),
+                   "bitmap-backed inverted index must not retain null "
+                   "offsets");
+        AssertInfo(valid_bitset_.size() == count,
+                   "inverted index validity bitmap size mismatch, expect {}, "
+                   "got {}",
+                   count,
+                   valid_bitset_.size());
+        bitset &= valid_bitset_;
+        return bitset;
+    }
+
+    AssertInfo(validity_mode_ == ValidityMode::NullOffsets,
+               "unexpected inverted index validity mode {}",
+               static_cast<int>(validity_mode_));
+    AssertInfo(!is_nested_index_,
+               "nested inverted index must use implicit validity");
+
+    auto exclude_nulls = [this, count, &bitset]() {
         auto end =
             std::lower_bound(null_offset_.begin(), null_offset_.end(), count);
         for (auto iter = null_offset_.begin(); iter != end; ++iter) {
@@ -455,9 +546,9 @@ InvertedIndexTantivy<T>::NotIn(size_t n, const T* values) {
 
     if (is_growing_) {
         std::shared_lock<folly::SharedMutex> lock(mutex_);
-        fill_bitset();
+        exclude_nulls();
     } else {
-        fill_bitset();
+        exclude_nulls();
     }
 
     return bitset;
@@ -645,6 +736,9 @@ template <typename T>
 void
 InvertedIndexTantivy<T>::BuildWithFieldData(
     const std::vector<std::shared_ptr<FieldDataBase>>& field_datas) {
+    validity_mode_ = !is_nested_index_ && schema_.nullable()
+                         ? ValidityMode::NullOffsets
+                         : ValidityMode::ImplicitAllValid;
     if (schema_.nullable()) {
         int64_t total = 0;
         for (const auto& data : field_datas) {
@@ -940,16 +1034,14 @@ InvertedIndexTantivy<T>::LoadEntries(storage::IndexEntryReader& reader,
 
     if (has_null) {
         auto null_entry = reader.ReadEntry(INDEX_NULL_OFFSET_FILE_NAME);
-        null_offset_.resize(null_entry.data.size() / sizeof(size_t));
-        milvus::fastmem::FastMemcpy(null_offset_.data(),
-                                    null_entry.data.data(),
-                                    null_entry.data.size());
+        LoadNullOffsets(null_entry.data.data(), null_entry.data.size());
     }
 
     auto load_in_mmap =
         GetValueFromConfig<bool>(config, ENABLE_MMAP).value_or(true);
     wrapper_ = std::make_shared<TantivyIndexWrapper>(
         path_.c_str(), load_in_mmap, milvus::index::SetBitsetSealed);
+    FinalizeLoadedValidity();
 
     if (!load_in_mmap) {
         disk_file_manager_->RemoveIndexFiles();

--- a/internal/core/src/index/InvertedIndexTantivy.h
+++ b/internal/core/src/index/InvertedIndexTantivy.h
@@ -89,6 +89,16 @@ get_tantivy_data_type(proto::schema::DataType data_type) {
 using TantivyIndexWrapper = milvus::tantivy::TantivyIndexWrapper;
 using RustArrayWrapper = milvus::tantivy::RustArrayWrapper;
 
+enum class ValidityMode {
+    // Non-nullable indexes and nested indexes need no row-validity storage at
+    // query time.
+    ImplicitAllValid,
+    // Used by growing indexes and build-side sealed indexes.
+    NullOffsets,
+    // Used after loading a nullable, non-nested sealed index.
+    ValidBitmap,
+};
+
 template <typename T>
 class InvertedIndexTantivy : public ScalarIndex<T> {
  public:
@@ -229,7 +239,9 @@ class InvertedIndexTantivy : public ScalarIndex<T> {
         // Tantivy index size
         total += wrapper_->index_size_bytes();
 
-        // null_offset_: vector<size_t>
+        // Loaded nullable sealed validity bitmap and null offsets used while
+        // building or growing the index.
+        total += valid_bitset_.size_in_bytes();
         total += null_offset_.capacity() * sizeof(size_t);
 
         this->cached_byte_size_ = total;
@@ -318,6 +330,9 @@ class InvertedIndexTantivy : public ScalarIndex<T> {
     void
     set_is_growing(bool is_growing) {
         is_growing_ = is_growing;
+        if (is_growing) {
+            validity_mode_ = ValidityMode::NullOffsets;
+        }
     }
 
     void
@@ -366,6 +381,14 @@ class InvertedIndexTantivy : public ScalarIndex<T> {
     virtual nlohmann::json
     BuildTantivyMeta(const std::vector<std::string>& file_names, bool has_null);
 
+    // Load the existing persisted null-offset format. After the Tantivy reader
+    // is ready, FinalizeLoadedValidity converts it to the runtime bitmap.
+    void
+    LoadNullOffsets(const uint8_t* data, size_t size);
+
+    void
+    FinalizeLoadedValidity();
+
  protected:
     std::shared_ptr<TantivyIndexWrapper> wrapper_;
     TantivyDataType d_type_;
@@ -382,8 +405,11 @@ class InvertedIndexTantivy : public ScalarIndex<T> {
     DiskFileManagerPtr disk_file_manager_;
 
     folly::SharedMutexWritePriority mutex_{};
-    // all data need to be built to align the offset
-    // so need to store null_offset_ in inverted index additionally
+    // Runtime validity representation is explicit because build-side sealed
+    // indexes and growing indexes both keep the persisted null-offset format,
+    // while loaded nullable sealed indexes use a bitmap.
+    ValidityMode validity_mode_{ValidityMode::ImplicitAllValid};
+    TargetBitmap valid_bitset_{};
     std::vector<size_t> null_offset_{};
 
     // `inverted_index_single_segment_` is used to control whether to build tantivy index with single segment.

--- a/internal/core/src/index/JsonFlatIndex.h
+++ b/internal/core/src/index/JsonFlatIndex.h
@@ -800,6 +800,10 @@ JsonFlatIndexQueryExecutor<T>::JsonFlatIndexQueryExecutor(
     json_path_ = json_path;
     use_comparable_value_mask_ = use_comparable_value_mask;
     this->wrapper_ = json_flat_index.wrapper_;
-    this->null_offset_ = json_flat_index.null_offset_;
+    if (!use_comparable_value_mask_) {
+        this->null_offset_ = json_flat_index.null_offset_;
+        this->valid_bitset_ = json_flat_index.valid_bitset_.clone();
+        this->validity_mode_ = json_flat_index.validity_mode_;
+    }
 }
 }  // namespace milvus::index

--- a/internal/core/src/index/NgramInvertedIndex.cpp
+++ b/internal/core/src/index/NgramInvertedIndex.cpp
@@ -85,6 +85,8 @@ NgramInvertedIndex::NgramInvertedIndex(const storage::FileManagerContext& ctx,
                                        const NgramParams& params)
     : min_gram_(params.min_gram), max_gram_(params.max_gram) {
     schema_ = ctx.fieldDataMeta.field_schema;
+    validity_mode_ = schema_.nullable() ? ValidityMode::NullOffsets
+                                        : ValidityMode::ImplicitAllValid;
     field_id_ = ctx.fieldDataMeta.field_id;
     file_manager_ = std::make_shared<MemFileManager>(ctx);
     disk_file_manager_ = std::make_shared<DiskFileManager>(ctx);
@@ -312,11 +314,14 @@ NgramInvertedIndex::Load(milvus::tracer::TraceContext ctx,
         GetValueFromConfig<bool>(config, ENABLE_MMAP).value_or(true);
     wrapper_ = std::make_shared<TantivyIndexWrapper>(
         path_.c_str(), load_in_mmap, milvus::index::SetBitsetSealed);
+    FinalizeLoadedValidity();
 
     if (!load_in_mmap) {
         // the index is loaded in ram, so we can remove files in advance
         disk_file_manager_->RemoveNgramIndexFiles();
     }
+
+    ComputeByteSize();
 
     LOG_INFO(
         "load ngram index done for field id:{} with dir:{}", field_id_, path_);

--- a/internal/core/src/index/TextMatchIndex.cpp
+++ b/internal/core/src/index/TextMatchIndex.cpp
@@ -84,6 +84,8 @@ TextMatchIndex::TextMatchIndex(const storage::FileManagerContext& ctx,
     : commit_interval_in_ms_(std::numeric_limits<int64_t>::max()),
       last_commit_time_(stdclock::now()) {
     schema_ = ctx.fieldDataMeta.field_schema;
+    validity_mode_ = schema_.nullable() ? ValidityMode::NullOffsets
+                                        : ValidityMode::ImplicitAllValid;
     this->file_manager_ = std::make_shared<MemFileManager>(ctx);
     disk_file_manager_ = std::make_shared<DiskFileManager>(ctx);
     is_index_file_ = false;
@@ -107,6 +109,8 @@ TextMatchIndex::TextMatchIndex(const storage::FileManagerContext& ctx)
     : commit_interval_in_ms_(std::numeric_limits<int64_t>::max()),
       last_commit_time_(stdclock::now()) {
     schema_ = ctx.fieldDataMeta.field_schema;
+    validity_mode_ = schema_.nullable() ? ValidityMode::NullOffsets
+                                        : ValidityMode::ImplicitAllValid;
     this->file_manager_ = std::make_shared<MemFileManager>(ctx);
     disk_file_manager_ = std::make_shared<DiskFileManager>(ctx);
     is_index_file_ = false;
@@ -231,10 +235,8 @@ TextMatchIndex::Load(const Config& config) {
         // clear index_datas to free memory early
         index_datas.clear();
         auto index_valid_data = binary_set.GetByName("index_null_offset");
-        null_offset_.resize((size_t)index_valid_data->size / sizeof(size_t));
-        milvus::fastmem::FastMemcpy(null_offset_.data(),
-                                    index_valid_data->data.get(),
-                                    (size_t)index_valid_data->size);
+        LoadNullOffsets(index_valid_data->data.get(),
+                        static_cast<size_t>(index_valid_data->size));
     }
     disk_file_manager_->CacheTextLogToDisk(files_value, load_priority);
     AssertInfo(
@@ -245,11 +247,14 @@ TextMatchIndex::Load(const Config& config) {
 
     wrapper_ = std::make_shared<TantivyIndexWrapper>(
         prefix.c_str(), load_in_mmap, milvus::index::SetBitsetSealed);
+    FinalizeLoadedValidity();
 
     if (!load_in_mmap) {
         // the index is loaded in ram, so we can remove files in advance
         disk_file_manager_->RemoveTextLogFiles();
     }
+
+    ComputeByteSize();
 }
 
 // Add text for sealed segment
@@ -267,6 +272,7 @@ TextMatchIndex::AddTextSealed(const std::string& text,
 // Add null for sealed segment
 void
 TextMatchIndex::AddNullSealed(int64_t offset) {
+    validity_mode_ = ValidityMode::NullOffsets;
     null_offset_.push_back(offset);
     // still need to add null to make offset is correct
     static const std::string empty;
@@ -300,6 +306,7 @@ TextMatchIndex::BuildIndexFromFieldData(
     const std::vector<FieldDataPtr>& field_datas, bool nullable) {
     int64_t offset = 0;
     if (nullable) {
+        validity_mode_ = ValidityMode::NullOffsets;
         int64_t total = 0;
         for (const auto& data : field_datas) {
             total += data->get_null_count();


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/52879