### PR TITLE
fix: keep the inclusive lower bound when OR-merging two ranges

### DIFF
--- a/internal/parser/planparserv2/rewriter/range.go
+++ b/internal/parser/planparserv2/rewriter/range.go
@@ -963,6 +963,11 @@ func (v *visitor) combineOrBinaryRanges(parts []*planpb.Expr) []*planpb.Expr {
 				mergedUpper := second.upper
 				mergedUpperInc := second.upperInc
 
+				// Lower bound: same value, prefer inclusive
+				if cmpGeneric(g.effDt, first.lower, second.lower) == 0 && second.lowerInc {
+					mergedLowerInc = true
+				}
+
 				// Upper bound: take maximum
 				cmpUppers := cmpGeneric(g.effDt, first.upper, second.upper)
 				if cmpUppers > 0 {

--- a/internal/parser/planparserv2/rewriter/range_binary_test.go
+++ b/internal/parser/planparserv2/rewriter/range_binary_test.go
@@ -194,6 +194,53 @@ func TestRewrite_BinaryRange_OR_BinaryRange_PreferInclusive(t *testing.T) {
 	require.Equal(t, int64(30), bre.GetUpperValue().GetInt64Val())
 }
 
+// Test BinaryRangeExpr OR BinaryRangeExpr - equal lower values, mixed inclusivity.
+// A union must keep the weaker (inclusive) bound regardless of operand order.
+func TestRewrite_BinaryRange_OR_BinaryRange_EqualLower_PreferInclusive(t *testing.T) {
+	helper := buildSchemaHelperForRewriteT(t)
+	// (10 < x < 30) OR (10 <= x < 20) → (10 <= x < 30)
+	expr, err := parser.ParseExpr(helper, `(Int64Field > 10 and Int64Field < 30) or (Int64Field >= 10 and Int64Field < 20)`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+	bre := expr.GetBinaryRangeExpr()
+	require.NotNil(t, bre)
+	require.Equal(t, true, bre.GetLowerInclusive(), "union must keep the inclusive lower bound")
+	require.Equal(t, false, bre.GetUpperInclusive())
+	require.Equal(t, int64(10), bre.GetLowerValue().GetInt64Val())
+	require.Equal(t, int64(30), bre.GetUpperValue().GetInt64Val())
+}
+
+// Test BinaryRangeExpr OR BinaryRangeExpr - same as above with the operands swapped.
+// Both orders must produce the same plan.
+func TestRewrite_BinaryRange_OR_BinaryRange_EqualLower_PreferInclusive_Swapped(t *testing.T) {
+	helper := buildSchemaHelperForRewriteT(t)
+	// (10 <= x < 20) OR (10 < x < 30) → (10 <= x < 30)
+	expr, err := parser.ParseExpr(helper, `(Int64Field >= 10 and Int64Field < 20) or (Int64Field > 10 and Int64Field < 30)`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+	bre := expr.GetBinaryRangeExpr()
+	require.NotNil(t, bre)
+	require.Equal(t, true, bre.GetLowerInclusive(), "union must keep the inclusive lower bound")
+	require.Equal(t, false, bre.GetUpperInclusive())
+	require.Equal(t, int64(10), bre.GetLowerValue().GetInt64Val())
+	require.Equal(t, int64(30), bre.GetUpperValue().GetInt64Val())
+}
+
+// Test BinaryRangeExpr OR BinaryRangeExpr - equal lower values on VarChar.
+func TestRewrite_BinaryRange_OR_BinaryRange_EqualLower_VarChar(t *testing.T) {
+	helper := buildSchemaHelperForRewriteT(t)
+	// ("b" < x <= "d") OR ("b" <= x <= "c") → ("b" <= x <= "d")
+	expr, err := parser.ParseExpr(helper, `(VarCharField > "b" and VarCharField <= "d") or (VarCharField >= "b" and VarCharField <= "c")`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+	bre := expr.GetBinaryRangeExpr()
+	require.NotNil(t, bre)
+	require.Equal(t, true, bre.GetLowerInclusive(), "union must keep the inclusive lower bound")
+	require.Equal(t, true, bre.GetUpperInclusive())
+	require.Equal(t, "b", bre.GetLowerValue().GetStringVal())
+	require.Equal(t, "d", bre.GetUpperValue().GetStringVal())
+}
+
 // Test with Float fields
 func TestRewrite_BinaryRange_AND_Float(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)


### PR DESCRIPTION
## Summary

`combineOrBinaryRanges` decided the merged interval's `lower_inclusive` by operand order instead of by which bound is weaker. When two OR'd intervals share the same lower value, an exclusive `>` bound could override an inclusive `>=` bound at that value, so the union silently lost the boundary row.

issue: #52852

## Root cause

Two intervals on the same column are ordered by lower value, then merged:

```go
c := cmpGeneric(g.effDt, iv1.lower, iv2.lower)
if c <= 0 {
    first, second = iv1, iv2
} else {
    first, second = iv2, iv1
}
...
mergedLowerInc := first.lowerInc     // tie broken by operand order
```

When `c == 0` the two lower values are equal, so `first` is decided by which clause the user typed first, and its inclusivity wins. A union must keep the weaker (inclusive) bound. The upper bound immediately below already implements exactly this tie-break (`cmpUppers == 0` → prefer inclusive); the symmetric lower-bound case was missing.

This is order-dependent, which makes it easy to miss: writing the inclusive clause first produces the correct plan.

```
(Int64Field > 10 and Int64Field < 30) or (Int64Field >= 10 and Int64Field < 20)
  -> lower_value:10 upper_value:30                    # lower_inclusive false — drops x == 10
(Int64Field >= 10 and Int64Field < 20) or (Int64Field > 10 and Int64Field < 30)
  -> lower_inclusive:true lower_value:10 upper_value:30
```

Affects every scalar type the rewriter handles (reproduced on Int64, VarChar and Double), and is on by default (`common.enabledOptimizeExpr`). Under `not(...)` the error inverts and returns the boundary row instead of dropping it, so a `delete` using such an expression removes the wrong set of rows.

The input intervals need not be written as ternary ranges — `combineAndRangePredicates` folds `x > 10 and x < 30` into a `BinaryRangeExpr` first, so ordinary `and`/`or` filters reach this code.

Introduced by #45526 (`e379b1f0f4`), which added `combineOrBinaryRanges`.

## Changes

- `internal/parser/planparserv2/rewriter/range.go`: prefer the inclusive lower bound when the two lower values are equal (5 lines, mirroring the upper-bound block below it).
- `internal/parser/planparserv2/rewriter/range_binary_test.go`: three regression tests.

## Test plan

New tests, written before the fix and observed failing:

- `TestRewrite_BinaryRange_OR_BinaryRange_EqualLower_PreferInclusive` — failed with `expected: true, actual: false` on `lower_inclusive`
- `TestRewrite_BinaryRange_OR_BinaryRange_EqualLower_PreferInclusive_Swapped` — passed before the fix, which is the order-dependence itself; it guards that both operand orders now agree
- `TestRewrite_BinaryRange_OR_BinaryRange_EqualLower_VarChar` — failed the same way

All three pass after the fix.

- `go test ./internal/parser/planparserv2/rewriter/` — ok
- `go test ./internal/parser/planparserv2/` — ok
- `make static-check` — 0 issues across core / pkg / client / go_client
- Negative controls confirmed unchanged: two exclusive lower bounds stay exclusive, and intervals with differing lower values are unaffected.

Note on existing coverage: `TestRewrite_BinaryRange_OR_BinaryRange_PreferInclusive` uses lower values 10 and 15, which differ, so the equal-lower branch was never exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1KL6zr8TyrvZNARTDaMxe
