### PR TITLE
fix: [3.0] Streaming gRPCs bypass authentication on the external proxy port (#52608)

### DIFF
--- a/client/milvusclient/client.go
+++ b/client/milvusclient/client.go
@@ -127,6 +127,10 @@ func (c *Client) dialOptions() []grpc.DialOption {
 		c.MetadataUnaryInterceptor(),
 	))
 
+	options = append(options, grpc.WithChainStreamInterceptor(
+		c.MetadataStreamInterceptor(),
+	))
+
 	return options
 }
 

--- a/client/milvusclient/interceptors.go
+++ b/client/milvusclient/interceptors.go
@@ -42,13 +42,29 @@ const (
 	ClientRequestMsecKey string = "client-request-unixmsec"
 )
 
+// withClientMetadata applies the client's metadata enrichment (static headers,
+// connection state, and per-request extras) to an outgoing context. It is shared
+// by the unary and stream interceptors so new headers stay in sync across both.
+func (c *Client) withClientMetadata(ctx context.Context) context.Context {
+	ctx = c.metadata(ctx)
+	ctx = c.state(ctx)
+	ctx = c.extraInfo(ctx)
+	return ctx
+}
+
 func (c *Client) MetadataUnaryInterceptor() grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		ctx = c.metadata(ctx)
-		ctx = c.state(ctx)
-		ctx = c.extraInfo(ctx)
+		ctx = c.withClientMetadata(ctx)
 
 		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+func (c *Client) MetadataStreamInterceptor() grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		ctx = c.withClientMetadata(ctx)
+
+		return streamer(ctx, desc, cc, method, opts...)
 	}
 }
 

--- a/client/milvusclient/interceptors_test.go
+++ b/client/milvusclient/interceptors_test.go
@@ -23,7 +23,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 )
@@ -65,4 +67,31 @@ func TestRateLimitInterceptor(t *testing.T) {
 	err = inter(ctx1, "", nil, mockInvokerReply, nil, mockInvoker)
 	assert.NoError(t, err)
 	assert.Equal(t, uint(1), uint(mockInvokeTimes))
+}
+
+func TestMetadataStreamInterceptor(t *testing.T) {
+	c := &Client{
+		metadataHeaders: map[string]string{
+			authorizationHeader: "base64-token",
+		},
+		currentDB:  "db1",
+		identifier: "ident1",
+	}
+
+	var capturedCtx context.Context
+	mockStreamer := func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		capturedCtx = ctx
+		return nil, nil
+	}
+
+	inter := c.MetadataStreamInterceptor()
+	_, err := inter(context.Background(), &grpc.StreamDesc{}, nil, "method", mockStreamer)
+	require.NoError(t, err)
+
+	md, ok := metadata.FromOutgoingContext(capturedCtx)
+	require.True(t, ok)
+	assert.Equal(t, "base64-token", md.Get(authorizationHeader)[0])
+	assert.Equal(t, "db1", md.Get(databaseHeader)[0])
+	assert.Equal(t, "ident1", md.Get(identifierHeader)[0])
+	assert.NotEmpty(t, md.Get(ClientRequestMsecKey)[0])
 }

--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -305,6 +305,7 @@ func (s *Server) startExternalGrpc(errChan chan error) {
 	}
 
 	var unaryServerOption grpc.ServerOption
+	var streamServerOption grpc.ServerOption
 	if enableCustomInterceptor {
 		unaryServerOption = grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			streaming.ForwardLegacyProxyUnaryServerInterceptor(),
@@ -320,8 +321,16 @@ func (s *Server) startExternalGrpc(errChan chan error) {
 			proxy.TraceLogInterceptor,
 			connection.KeepActiveInterceptor,
 		))
+		// Streaming RPCs (e.g. CreateReplicateStream, DumpMessages) bypass the
+		// unary chain, so they must be authenticated and authorized through a
+		// dedicated stream interceptor chain. Without this the external server
+		// would accept unauthenticated/unauthorized streaming calls on the
+		// client port. The order mirrors the unary chain: first authenticate
+		// (resolve the user into ctx), then enforce authorization on that user.
+		streamServerOption = newStreamInterceptorOption(getMetaCache)
 	} else {
 		unaryServerOption = grpc.EmptyServerOption{}
+		streamServerOption = grpc.EmptyServerOption{}
 	}
 
 	grpcOpts := []grpc.ServerOption{
@@ -330,6 +339,7 @@ func (s *Server) startExternalGrpc(errChan chan error) {
 		grpc.MaxRecvMsgSize(Params.ServerMaxRecvSize.GetAsInt()),
 		grpc.MaxSendMsgSize(Params.ServerMaxSendSize.GetAsInt()),
 		unaryServerOption,
+		streamServerOption,
 		grpc.StatsHandler(tracer.GetDynamicOtelGrpcServerStatsHandler()),
 		grpc.StatsHandler(metrics.NewGRPCSizeStatsHandler().
 			// both inbound and outbound
@@ -406,6 +416,23 @@ func (s *Server) startExternalGrpc(errChan chan error) {
 		return
 	}
 	mlog.Info(context.TODO(), "Proxy external grpc server exited")
+}
+
+// newStreamInterceptorOption builds the security-critical stream interceptor
+// chain for the external gRPC server: authentication, then RBAC (fail-closed).
+// It mirrors the unary chain's auth-before-RBAC ordering; streaming RPCs carry
+// no request object at the interceptor layer, so the required authorization is
+// resolved per full-method name by StreamPrivilegeInterceptor and unregistered
+// stream methods are denied by default. It is extracted so the wiring is
+// testable independently of the full Server lifecycle — a regression here would
+// silently reopen the stream auth bypass (#52387), so the chain is covered by a
+// dedicated test.
+func newStreamInterceptorOption(getMetaCache func() proxy.Cache) grpc.ServerOption {
+	return grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
+		proxy.GrpcAuthStreamInterceptor(proxy.AuthenticationInterceptorWithMetaCache(getMetaCache)),
+		proxy.PrivilegeStreamInterceptor(proxy.StreamPrivilegeInterceptor),
+		mlog.StreamServerInterceptor(typeutil.ProxyRole),
+	))
 }
 
 func (s *Server) startInternalGrpc(errChan chan error) {

--- a/internal/distributed/proxy/service_stream_test.go
+++ b/internal/distributed/proxy/service_stream_test.go
@@ -1,0 +1,101 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcproxy
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus/internal/proxy"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+const streamBufSize = 1024 * 1024
+
+// streamAuthTestServer implements the MilvusService stream endpoint needed by
+// the wiring test.
+type streamAuthTestServer struct {
+	milvuspb.UnimplementedMilvusServiceServer
+}
+
+func (s *streamAuthTestServer) DumpMessages(*milvuspb.DumpMessagesRequest, milvuspb.MilvusService_DumpMessagesServer) error {
+	return nil
+}
+
+// TestExternalStreamInterceptor_Wiring verifies that the stream interceptor
+// chain built by newStreamInterceptorOption is actually installed on the
+// external server and enforces authentication at the gRPC boundary. A
+// regression that drops this chain would silently reopen the stream auth
+// bypass (#52387).
+func TestExternalStreamInterceptor_Wiring(t *testing.T) {
+	paramtable.Init()
+	proxy.Params.Save(proxy.Params.CommonCfg.AuthorizationEnabled.Key, "true")
+	defer proxy.Params.Reset(proxy.Params.CommonCfg.AuthorizationEnabled.Key)
+
+	// A non-nil cache satisfies the auth readiness gate; the unauthenticated
+	// path below is rejected on the missing authorization header, before any
+	// credential lookup.
+	getMetaCache := func() proxy.Cache { return proxy.InitEmptyMetaCacheForTest() }
+	opt := newStreamInterceptorOption(getMetaCache)
+
+	lis := bufconn.Listen(streamBufSize)
+	srv := grpc.NewServer(opt)
+	milvuspb.RegisterMilvusServiceServer(srv, &streamAuthTestServer{})
+	t.Cleanup(srv.Stop)
+	go func() { _ = srv.Serve(lis) }()
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	client := milvuspb.NewMilvusServiceClient(conn)
+
+	t.Run("unauthenticated DumpMessages is rejected", func(t *testing.T) {
+		stream, err := client.DumpMessages(context.Background(), &milvuspb.DumpMessagesRequest{Pchannel: "ch"})
+		require.NoError(t, err)
+		_, err = stream.Recv()
+		require.Error(t, err)
+		require.Equal(t, codes.Unauthenticated, status.Code(err))
+	})
+
+	t.Run("authorization-disabled stream reaches handler", func(t *testing.T) {
+		proxy.Params.Save(proxy.Params.CommonCfg.AuthorizationEnabled.Key, "false")
+		defer proxy.Params.Reset(proxy.Params.CommonCfg.AuthorizationEnabled.Key)
+
+		// With authorization disabled both the auth and RBAC interceptors
+		// pass through, so the request must reach the handler. This guards
+		// against a chain that is too strict or mis-ordered.
+		stream, err := client.DumpMessages(context.Background(), &milvuspb.DumpMessagesRequest{Pchannel: "ch"})
+		require.NoError(t, err)
+		_, err = stream.Recv()
+		require.Equal(t, io.EOF, err)
+	})
+}

--- a/internal/proxy/authentication_interceptor.go
+++ b/internal/proxy/authentication_interceptor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -30,6 +31,34 @@ func parseMD(rawToken string) (username, password string) {
 	username = secrets[0]
 	password = secrets[1]
 	return username, password
+}
+
+// GrpcAuthStreamInterceptor is the streaming counterpart of GrpcAuthInterceptor.
+// The external gRPC server only mounts UnaryInterceptor, so streaming RPCs such as
+// CreateReplicateStream/DumpMessages would otherwise skip the authentication chain
+// entirely. This interceptor authenticates streaming calls with the same logic as
+// unary calls before the handler observes the stream, and propagates the
+// authenticated context (carrying the resolved user/token) to the handler.
+func GrpcAuthStreamInterceptor(authFunc grpc_auth.AuthFunc) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		var newCtx context.Context
+		var err error
+		if overrideSrv, ok := srv.(grpc_auth.ServiceAuthFuncOverride); ok {
+			newCtx, err = overrideSrv.AuthFuncOverride(ss.Context(), info.FullMethod)
+		} else {
+			newCtx, err = authFunc(ss.Context())
+		}
+		if err != nil {
+			hookutil.GetExtension().ReportAction(context.Background(), nil, &milvuspb.BoolResponse{
+				Status: merr.Status(err),
+			}, err, info.FullMethod, hookutil.ActionAuthorize)
+			return err
+		}
+		// Propagate the authenticated context to the handler by wrapping the ServerStream.
+		wrapped := grpc_middleware.WrapServerStream(ss)
+		wrapped.WrappedContext = newCtx
+		return handler(srv, wrapped)
+	}
 }
 
 func GrpcAuthInterceptor(authFunc grpc_auth.AuthFunc) grpc.UnaryServerInterceptor {

--- a/internal/proxy/dump_messages_authz_test.go
+++ b/internal/proxy/dump_messages_authz_test.go
@@ -1,0 +1,491 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"context"
+	"testing"
+
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus/internal/proxy/privilege"
+	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/util"
+	"github.com/milvus-io/milvus/pkg/v3/util/contextutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+func TestAuthorizeWALRead(t *testing.T) {
+	t.Run("authorization disabled allows", func(t *testing.T) {
+		Params.Save(Params.CommonCfg.AuthorizationEnabled.Key, "false")
+		defer Params.Reset(Params.CommonCfg.AuthorizationEnabled.Key)
+
+		_, err := authorizeWALRead(context.Background())
+		assert.NoError(t, err)
+	})
+
+	t.Run("authorization enabled", func(t *testing.T) {
+		Params.Save(Params.CommonCfg.AuthorizationEnabled.Key, "true")
+		defer Params.Reset(Params.CommonCfg.AuthorizationEnabled.Key)
+		defer privilege.CleanPrivilegeCache()
+		privilege.InitPrivilegeGroups()
+
+		t.Run("root is exempt", func(t *testing.T) {
+			_, err := authorizeWALRead(GetContext(context.Background(), "root:pwd"))
+			assert.NoError(t, err)
+		})
+
+		client := &MockMixCoordClientInterface{}
+		client.listPolicy = func(ctx context.Context, in *internalpb.ListPolicyRequest) (*internalpb.ListPolicyResponse, error) {
+			return &internalpb.ListPolicyResponse{
+				Status: merr.Success(),
+				UserRoles: []string{
+					funcutil.EncodeUserRoleCache("dbadmin", util.RoleAdmin),
+					funcutil.EncodeUserRoleCache("bob", "role_readonly"),
+				},
+			}, nil
+		}
+		_, err := initMetaCache(context.Background(), client)
+		require.NoError(t, err)
+
+		t.Run("admin role is allowed", func(t *testing.T) {
+			_, err := authorizeWALRead(GetContext(context.Background(), "dbadmin:pwd"))
+			assert.NoError(t, err)
+		})
+
+		t.Run("custom superuser with Global PrivilegeGroupAdmin is allowed", func(t *testing.T) {
+			superClient := &MockMixCoordClientInterface{}
+			superClient.listPolicy = func(ctx context.Context, in *internalpb.ListPolicyRequest) (*internalpb.ListPolicyResponse, error) {
+				return &internalpb.ListPolicyResponse{
+					Status: merr.Success(),
+					PolicyInfos: []string{
+						// Cluster-level PrivilegeGroupAdmin grant at db="*",
+						// the way rootcoord normalizes cluster-level grants.
+						funcutil.PolicyForPrivilege("role_super", commonpb.ObjectType_Global.String(), "*", commonpb.ObjectPrivilege_PrivilegeGroupAdmin.String(), util.AnyWord),
+					},
+					UserRoles: []string{
+						funcutil.EncodeUserRoleCache("super", "role_super"),
+					},
+				}, nil
+			}
+			_, err := initMetaCache(context.Background(), superClient)
+			require.NoError(t, err)
+
+			_, err = authorizeWALRead(GetContext(context.Background(), "super:pwd"))
+			assert.NoError(t, err)
+		})
+
+		t.Run("custom superuser with Global PrivilegeManageOwnership is allowed (v2 ClusterAdmin group materialization)", func(t *testing.T) {
+			superClient := &MockMixCoordClientInterface{}
+			superClient.listPolicy = func(ctx context.Context, in *internalpb.ListPolicyRequest) (*internalpb.ListPolicyResponse, error) {
+				return &internalpb.ListPolicyResponse{
+					Status: merr.Success(),
+					PolicyInfos: []string{
+						funcutil.PolicyForPrivilege("role_clusadmin", commonpb.ObjectType_Global.String(), "*", commonpb.ObjectPrivilege_PrivilegeManageOwnership.String(), util.AnyWord),
+					},
+					UserRoles: []string{
+						funcutil.EncodeUserRoleCache("clusadmin", "role_clusadmin"),
+					},
+				}, nil
+			}
+			_, err := initMetaCache(context.Background(), superClient)
+			require.NoError(t, err)
+
+			_, err = authorizeWALRead(GetContext(context.Background(), "clusadmin:pwd"))
+			assert.NoError(t, err)
+		})
+
+		t.Run("custom superuser with Global PrivilegeAll is allowed", func(t *testing.T) {
+			superClient := &MockMixCoordClientInterface{}
+			superClient.listPolicy = func(ctx context.Context, in *internalpb.ListPolicyRequest) (*internalpb.ListPolicyResponse, error) {
+				return &internalpb.ListPolicyResponse{
+					Status: merr.Success(),
+					PolicyInfos: []string{
+						funcutil.PolicyForPrivilege("role_all", commonpb.ObjectType_Global.String(), "*", commonpb.ObjectPrivilege_PrivilegeAll.String(), util.AnyWord),
+					},
+					UserRoles: []string{
+						funcutil.EncodeUserRoleCache("alluser", "role_all"),
+					},
+				}, nil
+			}
+			_, err := initMetaCache(context.Background(), superClient)
+			require.NoError(t, err)
+
+			_, err = authorizeWALRead(GetContext(context.Background(), "alluser:pwd"))
+			assert.NoError(t, err)
+		})
+
+		t.Run("role with only replicate-config grant is denied", func(t *testing.T) {
+			// Guardrail: replication rights (PrivilegeUpdateReplicateConfiguration)
+			// must NOT imply raw WAL dump rights. A role holding only that narrow
+			// grant can create a replicate stream but is denied DumpMessages.
+			replClient := &MockMixCoordClientInterface{}
+			replClient.listPolicy = func(ctx context.Context, in *internalpb.ListPolicyRequest) (*internalpb.ListPolicyResponse, error) {
+				return &internalpb.ListPolicyResponse{
+					Status: merr.Success(),
+					PolicyInfos: []string{
+						funcutil.PolicyForPrivilege("role_repl", commonpb.ObjectType_Global.String(), "*", commonpb.ObjectPrivilege_PrivilegeUpdateReplicateConfiguration.String(), util.AnyWord),
+					},
+					UserRoles: []string{
+						funcutil.EncodeUserRoleCache("repluser", "role_repl"),
+					},
+				}, nil
+			}
+			_, err := initMetaCache(context.Background(), replClient)
+			require.NoError(t, err)
+
+			_, err = authorizeWALRead(GetContext(context.Background(), "repluser:pwd"))
+			require.Error(t, err)
+			assert.Equal(t, codes.PermissionDenied, status.Code(err))
+		})
+
+		t.Run("non-admin role is denied", func(t *testing.T) {
+			_, err := authorizeWALRead(GetContext(context.Background(), "bob:pwd"))
+			require.Error(t, err)
+			assert.Equal(t, codes.PermissionDenied, status.Code(err))
+		})
+
+		t.Run("missing authorization is denied", func(t *testing.T) {
+			// GetAuthInfoFromContext fails with a merr error (no auth metadata),
+			// which is fail-closed rather than a PermissionDenied status.
+			_, err := authorizeWALRead(context.Background())
+			assert.Error(t, err)
+		})
+
+		t.Run("root requires admin role when bind role enabled", func(t *testing.T) {
+			Params.Save(Params.CommonCfg.RootShouldBindRole.Key, "true")
+			defer Params.Reset(Params.CommonCfg.RootShouldBindRole.Key)
+
+			rootClient := &MockMixCoordClientInterface{}
+			rootClient.listPolicy = func(ctx context.Context, in *internalpb.ListPolicyRequest) (*internalpb.ListPolicyResponse, error) {
+				return &internalpb.ListPolicyResponse{
+					Status: merr.Success(),
+					UserRoles: []string{
+						funcutil.EncodeUserRoleCache("root", util.RoleAdmin),
+						funcutil.EncodeUserRoleCache("plain", "role_readonly"),
+					},
+				}, nil
+			}
+			_, err := initMetaCache(context.Background(), rootClient)
+			require.NoError(t, err)
+
+			_, err = authorizeWALRead(GetContext(context.Background(), "root:pwd"))
+			assert.NoError(t, err)
+			_, err = authorizeWALRead(GetContext(context.Background(), "plain:pwd"))
+			require.Error(t, err)
+			assert.Equal(t, codes.PermissionDenied, status.Code(err))
+		})
+	})
+}
+
+func TestDumpMessages_UnauthorizedUserDenied(t *testing.T) {
+	Params.Save(Params.CommonCfg.AuthorizationEnabled.Key, "true")
+	defer Params.Reset(Params.CommonCfg.AuthorizationEnabled.Key)
+	defer privilege.CleanPrivilegeCache()
+
+	client := &MockMixCoordClientInterface{}
+	client.listPolicy = func(ctx context.Context, in *internalpb.ListPolicyRequest) (*internalpb.ListPolicyResponse, error) {
+		return &internalpb.ListPolicyResponse{
+			Status: merr.Success(),
+			UserRoles: []string{
+				funcutil.EncodeUserRoleCache("mockUser", "role_readonly"),
+			},
+		}, nil
+	}
+	_, err := initMetaCache(context.Background(), client)
+	require.NoError(t, err)
+
+	// The DumpMessages stream is authorized at the gRPC interceptor layer
+	// (GrpcAuthStreamInterceptor + PrivilegeStreamInterceptor), so exercise that
+	// path directly rather than the handler: an unauthorized user must be
+	// rejected before the handler observes the stream.
+	handlerCalled := false
+	interceptor := PrivilegeStreamInterceptor(StreamPrivilegeInterceptor)
+	stream := &mockDumpMessagesServer{ctx: GetContext(context.Background(), "mockUser:mockPass")}
+	err = interceptor(nil, stream, &grpc.StreamServerInfo{
+		FullMethod: milvuspb.MilvusService_DumpMessages_FullMethodName,
+	}, func(srv interface{}, ss grpc.ServerStream) error {
+		handlerCalled = true
+		return nil
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	assert.False(t, handlerCalled)
+}
+
+func TestDumpMessages_UnauthenticatedUserDenied(t *testing.T) {
+	Params.Save(Params.CommonCfg.AuthorizationEnabled.Key, "true")
+	defer Params.Reset(Params.CommonCfg.AuthorizationEnabled.Key)
+	defer privilege.CleanPrivilegeCache()
+
+	client := &MockMixCoordClientInterface{}
+	_, err := initMetaCache(context.Background(), client)
+	require.NoError(t, err)
+
+	// The DumpMessages stream is authenticated at the gRPC interceptor layer
+	// (GrpcAuthStreamInterceptor) before authorization runs, so exercise that
+	// path directly: a request without valid credentials must be rejected
+	// before the privilege interceptor or the handler runs.
+	handlerCalled := false
+	authInterceptor := GrpcAuthStreamInterceptor(AuthenticationInterceptorWithMetaCache(func() Cache { return InitEmptyMetaCacheForTest() }))
+	stream := &mockDumpMessagesServer{ctx: GetContext(context.Background(), "mockUser:wrongPass")}
+	err = authInterceptor(nil, stream, &grpc.StreamServerInfo{
+		FullMethod: milvuspb.MilvusService_DumpMessages_FullMethodName,
+	}, func(srv interface{}, ss grpc.ServerStream) error {
+		handlerCalled = true
+		return nil
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+	assert.False(t, handlerCalled)
+}
+
+// TestStreamPrivilegeInterceptor_CreateReplicateStream exercises the casbin
+// authorization path for CreateReplicateStream: a role granted the
+// cluster-level PrivilegeUpdateReplicateConfiguration at the global (db="*")
+// scope is allowed regardless of the connection namespace, matching the unary
+// interceptor's handling of cluster-level grants.
+func TestStreamPrivilegeInterceptor_CreateReplicateStream(t *testing.T) {
+	paramtable.Init()
+	Params.Save(Params.CommonCfg.AuthorizationEnabled.Key, "true")
+	defer Params.Reset(Params.CommonCfg.AuthorizationEnabled.Key)
+	defer privilege.CleanPrivilegeCache()
+
+	client := &MockMixCoordClientInterface{}
+	client.listPolicy = func(ctx context.Context, in *internalpb.ListPolicyRequest) (*internalpb.ListPolicyResponse, error) {
+		return &internalpb.ListPolicyResponse{
+			Status: merr.Success(),
+			PolicyInfos: []string{
+				// Cluster-level grant stored with db="*", the way rootcoord
+				// normalizes cluster-level privileges (see #52386 review).
+				funcutil.PolicyForPrivilege("role_replicate", commonpb.ObjectType_Global.String(), "*", commonpb.ObjectPrivilege_PrivilegeUpdateReplicateConfiguration.String(), util.AnyWord),
+			},
+			UserRoles: []string{
+				funcutil.EncodeUserRoleCache("carol", "role_replicate"),
+				funcutil.EncodeUserRoleCache("dave", "role_readonly"),
+			},
+		}, nil
+	}
+	_, err := initMetaCache(context.Background(), client)
+	require.NoError(t, err)
+
+	interceptor := PrivilegeStreamInterceptor(StreamPrivilegeInterceptor)
+
+	t.Run("role with cluster grant is allowed", func(t *testing.T) {
+		handlerCalled := false
+		stream := &mockDumpMessagesServer{ctx: GetContextWithDB(context.Background(), "carol:pwd", "some_namespace")}
+		err := interceptor(nil, stream, &grpc.StreamServerInfo{
+			FullMethod: milvuspb.MilvusService_CreateReplicateStream_FullMethodName,
+		}, func(srv interface{}, ss grpc.ServerStream) error {
+			handlerCalled = true
+			return nil
+		})
+		require.NoError(t, err)
+		assert.True(t, handlerCalled)
+	})
+
+	t.Run("role without grant is denied", func(t *testing.T) {
+		handlerCalled := false
+		stream := &mockDumpMessagesServer{ctx: GetContext(context.Background(), "dave:pwd")}
+		err := interceptor(nil, stream, &grpc.StreamServerInfo{
+			FullMethod: milvuspb.MilvusService_CreateReplicateStream_FullMethodName,
+		}, func(srv interface{}, ss grpc.ServerStream) error {
+			handlerCalled = true
+			return nil
+		})
+		require.Error(t, err)
+		assert.Equal(t, codes.PermissionDenied, status.Code(err))
+		assert.False(t, handlerCalled)
+	})
+
+	t.Run("root is exempt", func(t *testing.T) {
+		handlerCalled := false
+		stream := &mockDumpMessagesServer{ctx: GetContext(context.Background(), "root:pwd")}
+		err := interceptor(nil, stream, &grpc.StreamServerInfo{
+			FullMethod: milvuspb.MilvusService_CreateReplicateStream_FullMethodName,
+		}, func(srv interface{}, ss grpc.ServerStream) error {
+			handlerCalled = true
+			return nil
+		})
+		require.NoError(t, err)
+		assert.True(t, handlerCalled)
+	})
+}
+
+// TestStreamPrivilegeInterceptor_FailClosed covers the fail-closed default:
+// a streaming method not present in streamMethodAuthorizers is denied, while
+// the gRPC health service (used for infrastructure liveness probing) is
+// exempted.
+func TestStreamPrivilegeInterceptor_FailClosed(t *testing.T) {
+	paramtable.Init()
+	Params.Save(Params.CommonCfg.AuthorizationEnabled.Key, "true")
+	defer Params.Reset(Params.CommonCfg.AuthorizationEnabled.Key)
+
+	interceptor := PrivilegeStreamInterceptor(StreamPrivilegeInterceptor)
+
+	t.Run("unregistered stream method is denied", func(t *testing.T) {
+		handlerCalled := false
+		stream := &mockDumpMessagesServer{ctx: GetContext(context.Background(), "root:pwd")}
+		err := interceptor(nil, stream, &grpc.StreamServerInfo{
+			FullMethod: "/milvus.proto.milvus.MilvusService/FutureStreamRPC",
+		}, func(srv interface{}, ss grpc.ServerStream) error {
+			handlerCalled = true
+			return nil
+		})
+		require.Error(t, err)
+		assert.Equal(t, codes.PermissionDenied, status.Code(err))
+		assert.False(t, handlerCalled)
+	})
+
+	t.Run("health watch is exempt", func(t *testing.T) {
+		handlerCalled := false
+		stream := &mockDumpMessagesServer{ctx: context.Background()}
+		err := interceptor(nil, stream, &grpc.StreamServerInfo{
+			FullMethod: grpc_health_v1.Health_Watch_FullMethodName,
+		}, func(srv interface{}, ss grpc.ServerStream) error {
+			handlerCalled = true
+			return nil
+		})
+		require.NoError(t, err)
+		assert.True(t, handlerCalled)
+	})
+}
+
+// TestStreamHealthWatch_FullChain verifies the exemption semantics in the real
+// chain: the health service is exempt from RBAC (so an authenticated probe
+// passes) but NOT from authentication (an unauthenticated probe is rejected
+// before the exemption is reached), matching the unary health.Check behavior.
+func TestStreamHealthWatch_FullChain(t *testing.T) {
+	paramtable.Init()
+	Params.Save(Params.CommonCfg.AuthorizationEnabled.Key, "true")
+	defer Params.Reset(Params.CommonCfg.AuthorizationEnabled.Key)
+	defer privilege.CleanPrivilegeCache()
+
+	chain := grpc_middleware.ChainStreamServer(
+		GrpcAuthStreamInterceptor(AuthenticationInterceptorWithMetaCache(func() Cache { return InitEmptyMetaCacheForTest() })),
+		PrivilegeStreamInterceptor(StreamPrivilegeInterceptor),
+	)
+
+	t.Run("unauthenticated health watch is rejected", func(t *testing.T) {
+		handlerCalled := false
+		stream := &mockDumpMessagesServer{ctx: metadata.NewIncomingContext(context.Background(), metadata.MD{})}
+		err := chain(nil, stream, &grpc.StreamServerInfo{
+			FullMethod: grpc_health_v1.Health_Watch_FullMethodName,
+		}, func(srv interface{}, ss grpc.ServerStream) error {
+			handlerCalled = true
+			return nil
+		})
+		require.Error(t, err)
+		assert.Equal(t, codes.Unauthenticated, status.Code(err))
+		assert.False(t, handlerCalled)
+	})
+
+	t.Run("authenticated health watch passes the RBAC exemption", func(t *testing.T) {
+		handlerCalled := false
+		stream := &mockDumpMessagesServer{ctx: GetContext(context.Background(), "root:pwd")}
+		err := chain(nil, stream, &grpc.StreamServerInfo{
+			FullMethod: grpc_health_v1.Health_Watch_FullMethodName,
+		}, func(srv interface{}, ss grpc.ServerStream) error {
+			handlerCalled = true
+			return nil
+		})
+		require.NoError(t, err)
+		assert.True(t, handlerCalled)
+	})
+}
+
+// TestGrpcAuthStreamInterceptorChain verifies the external stream interceptor
+// chain (authentication -> authorization) propagates the context end-to-end:
+// auth runs first, authorization sees the resolved user, and the handler
+// receives the wrapped context. Authorization is disabled here so the chain
+// exercises the full pass-through path.
+func TestGrpcAuthStreamInterceptorChain(t *testing.T) {
+	Params.Save(Params.CommonCfg.AuthorizationEnabled.Key, "false")
+	defer Params.Reset(Params.CommonCfg.AuthorizationEnabled.Key)
+	_, err := initMetaCache(context.Background(), &MockMixCoordClientInterface{})
+	require.NoError(t, err)
+
+	chain := grpc_middleware.ChainStreamServer(
+		GrpcAuthStreamInterceptor(AuthenticationInterceptorWithMetaCache(func() Cache { return InitEmptyMetaCacheForTest() })),
+		PrivilegeStreamInterceptor(StreamPrivilegeInterceptor),
+	)
+	stream := &mockDumpMessagesServer{ctx: GetContext(context.Background(), "root:pwd")}
+	handlerCalled := false
+	err = chain(nil, stream, &grpc.StreamServerInfo{
+		FullMethod: milvuspb.MilvusService_DumpMessages_FullMethodName,
+	}, func(srv interface{}, ss grpc.ServerStream) error {
+		handlerCalled = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, handlerCalled)
+}
+
+// TestGrpcAuthStreamInterceptorChain_Authorized verifies the full chain with
+// authorization enabled: the handler receives a context that still carries the
+// authenticated user (incoming metadata). The mock credential store only knows
+// "mockUser:mockPass", so exercise the DumpMessages admin path by binding
+// mockUser to the admin role.
+func TestGrpcAuthStreamInterceptorChain_Authorized(t *testing.T) {
+	paramtable.Init()
+	Params.Save(Params.CommonCfg.AuthorizationEnabled.Key, "true")
+	defer Params.Reset(Params.CommonCfg.AuthorizationEnabled.Key)
+	defer privilege.CleanPrivilegeCache()
+
+	client := &MockMixCoordClientInterface{}
+	client.listPolicy = func(ctx context.Context, in *internalpb.ListPolicyRequest) (*internalpb.ListPolicyResponse, error) {
+		return &internalpb.ListPolicyResponse{
+			Status: merr.Success(),
+			UserRoles: []string{
+				funcutil.EncodeUserRoleCache("mockUser", util.RoleAdmin),
+			},
+		}, nil
+	}
+	cache, err := initMetaCache(context.Background(), client)
+	require.NoError(t, err)
+
+	chain := grpc_middleware.ChainStreamServer(
+		GrpcAuthStreamInterceptor(AuthenticationInterceptorWithMetaCache(func() Cache { return cache })),
+		PrivilegeStreamInterceptor(StreamPrivilegeInterceptor),
+	)
+	stream := &mockDumpMessagesServer{ctx: GetContext(context.Background(), "mockUser:mockPass")}
+	var handlerCtx context.Context
+	err = chain(nil, stream, &grpc.StreamServerInfo{
+		FullMethod: milvuspb.MilvusService_DumpMessages_FullMethodName,
+	}, func(srv interface{}, ss grpc.ServerStream) error {
+		handlerCtx = ss.Context()
+		return nil
+	})
+	require.NoError(t, err)
+
+	// The handler context must still carry the authenticated user so downstream
+	// checks can resolve identity from incoming metadata.
+	username, _, err := contextutil.GetAuthInfoFromContext(handlerCtx)
+	require.NoError(t, err)
+	assert.Equal(t, "mockUser", username)
+}

--- a/internal/proxy/meta_cache_testonly.go
+++ b/internal/proxy/meta_cache_testonly.go
@@ -31,6 +31,8 @@ import (
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/rootcoordpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/crypto"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -61,6 +63,31 @@ func InitEmptyMetaCacheForTest() *MetaCache {
 		panic(err)
 	}
 	mixcoord.EXPECT().ListPolicy(mock.Anything, mock.Anything, mock.Anything).Return(&internalpb.ListPolicyResponse{Status: merr.Success()}, nil)
+	credResponse := func(username, password string) *rootcoordpb.GetCredentialResponse {
+		encryptedPassword, err := crypto.PasswordEncrypt(password)
+		if err != nil {
+			panic(err)
+		}
+		return &rootcoordpb.GetCredentialResponse{
+			Status:   merr.Success(),
+			Username: username,
+			Password: encryptedPassword,
+		}
+	}
+	mixcoord.EXPECT().GetCredential(
+		mock.Anything,
+		mock.MatchedBy(func(req *rootcoordpb.GetCredentialRequest) bool {
+			return req.GetUsername() == "mockUser"
+		}),
+		mock.Anything,
+	).Return(credResponse("mockUser", "mockPass"), nil)
+	mixcoord.EXPECT().GetCredential(
+		mock.Anything,
+		mock.MatchedBy(func(req *rootcoordpb.GetCredentialRequest) bool {
+			return req.GetUsername() == "root"
+		}),
+		mock.Anything,
+	).Return(credResponse("root", "pwd"), nil)
 	privilege.InitPrivilegeCache(context.Background(), mixcoord)
 	return metaCache
 }

--- a/internal/proxy/privilege_interceptor.go
+++ b/internal/proxy/privilege_interceptor.go
@@ -6,9 +6,11 @@ import (
 	"reflect"
 	"sync"
 
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -257,4 +259,164 @@ func resolveCollectionAlias(ctx context.Context, metaCache Cache, dbName, nameOr
 		return nameOrAlias, merr.WrapErrServiceInternal("meta cache not initialized")
 	}
 	return metaCache.ResolveCollectionAlias(ctx, dbName, nameOrAlias)
+}
+
+// enforceClusterPrivilege authorizes a cluster-scoped operation via casbin
+// against a Global object at db="*" (util.AnyWord), mirroring the unary
+// PrivilegeInterceptor's handling of cluster-level grants. It is shared by all
+// stream authorizers so the enforcement contract (root exemption, GetRole +
+// RolePublic, casbin enforce with result cache, apikey masking) stays in sync
+// with the unary path. Streaming interceptors have no `req` object, so the
+// required privilege is passed explicitly.
+func enforceClusterPrivilege(ctx context.Context, objectPrivilege string) (context.Context, error) {
+	if !Params.CommonCfg.AuthorizationEnabled.GetAsBool() {
+		return ctx, nil
+	}
+	username, password, err := contextutil.GetAuthInfoFromContext(ctx)
+	if err != nil {
+		mlog.Warn(ctx, "GetAuthInfoFromContext fail for stream", mlog.Err(err))
+		return ctx, err
+	}
+	if !Params.CommonCfg.RootShouldBindRole.GetAsBool() && username == util.UserRoot {
+		return ctx, nil
+	}
+	roleNames, err := GetRole(username)
+	if err != nil {
+		mlog.Warn(ctx, "GetRole fail for stream", mlog.String("username", username), mlog.Err(err))
+		return ctx, err
+	}
+	roleNames = append(roleNames, util.RolePublic)
+	ctx = SetRBACRolesToContext(ctx, roleNames)
+
+	objectType := commonpb.ObjectType_Global.String()
+	// Cluster-level privileges are authorized globally (db = util.AnyWord),
+	// mirroring the unary interceptor's handling of cluster-level grants.
+	dbName := util.AnyWord
+	object := funcutil.PolicyForResource(dbName, objectType, util.AnyWord)
+	log := mlog.With(mlog.String("username", username), mlog.Strings("role_names", roleNames),
+		mlog.String("object_type", objectType), mlog.String("object_privilege", objectPrivilege),
+		mlog.FieldDbName(dbName))
+
+	e := privilege.GetEnforcer()
+	for _, roleName := range roleNames {
+		isPermit, cached, version := privilege.GetResultCache(roleName, object, objectPrivilege)
+		if !cached {
+			isPermit, err = e.Enforce(roleName, object, objectPrivilege)
+			if err != nil {
+				log.Warn(ctx, "fail to execute permit func for stream", mlog.Err(err))
+				return ctx, err
+			}
+			privilege.SetResultCache(roleName, object, objectPrivilege, isPermit, version)
+		}
+		if isPermit {
+			return ctx, nil
+		}
+	}
+
+	log.Info(ctx, "permission deny for stream", mlog.Strings("roles", roleNames))
+	if password == util.PasswordHolder {
+		username = "apikey user"
+	}
+	return ctx, status.Error(codes.PermissionDenied,
+		fmt.Sprintf("%s: permission deny to %s", objectPrivilege, username))
+}
+
+// authorizeWALRead gates DumpMessages, which exposes raw WAL contents for
+// CDC/data salvage. Reading raw WAL is the widest data-exposure surface on the
+// port (unfiltered, cluster-wide), so it requires a cluster-admin-level grant:
+// root, the built-in admin role, or a custom role holding Global
+// PrivilegeManageOwnership (a member of both the legacy v1 PrivilegeGroupAdmin
+// group and the modern v2 PrivilegeGroupClusterAdmin group, so both group-grant
+// styles are covered) or PrivilegeAll. A role granted only the narrow
+// PrivilegeUpdateReplicateConfiguration (replication config) is still denied,
+// so CreateReplicateStream rights do not imply WAL dump rights.
+func authorizeWALRead(ctx context.Context) (context.Context, error) {
+	return enforceClusterPrivilege(ctx, commonpb.ObjectPrivilege_PrivilegeManageOwnership.String())
+}
+
+// StreamPrivilegeFunc is the streaming counterpart of PrivilegeFunc. It
+// authorizes a streaming call using the context (which already carries the
+// authenticated user) and the full method name (which identifies the required
+// authorization via the static streamMethodAuthorizers table). Streaming
+// interceptors have no `req` object to reflect the privilege from (unlike the
+// unary PrivilegeInterceptor which resolves it via
+// funcutil.GetPrivilegeExtObj(req)), so the required authorization is declared
+// statically per full-method name.
+type StreamPrivilegeFunc func(ctx context.Context, fullMethod string) (context.Context, error)
+
+// The gRPC health stream method is exempt from RBAC authorization, but the
+// stream is STILL authenticated by GrpcAuthStreamInterceptor (matching the
+// unary health.Check path) — so when authorization is enabled, health probes
+// must carry valid credentials, and the exemption only skips the casbin check.
+// It is matched exactly so a future health service stream method cannot be
+// accidentally exempted by a prefix match.
+
+// streamMethodAuthorizers is the static authorization table for streaming RPCs
+// on the external gRPC server. It maps a streaming RPC's full method name to the
+// authorization check it requires. Streaming methods touch the WAL data plane:
+//   - CreateReplicateStream writes replicated messages into the WAL. It is
+//     authorized via casbin against the cluster-level
+//     PrivilegeUpdateReplicateConfiguration privilege (Global scope), so that a
+//     dedicated role can be granted replication rights.
+//   - DumpMessages streams raw WAL messages out for data salvage. It exposes
+//     raw, unfiltered cluster data, so it requires the cluster-admin grant
+//     (Global PrivilegeManageOwnership / PrivilegeAll / built-in admin / root)
+//     via authorizeWALRead — intentionally stricter than CreateReplicateStream,
+//     so replication rights do not imply raw WAL export rights.
+//
+// Any streaming method NOT present in this table is denied by default
+// (fail-closed) in StreamPrivilegeInterceptor, which prevents a newly-added
+// stream RPC from silently bypassing the RBAC chain.
+var streamMethodAuthorizers = map[string]func(ctx context.Context) (context.Context, error){
+	milvuspb.MilvusService_CreateReplicateStream_FullMethodName: authorizeCreateReplicateStream,
+	milvuspb.MilvusService_DumpMessages_FullMethodName:          authorizeWALRead,
+}
+
+// PrivilegeStreamInterceptor returns a new stream server interceptor that
+// performs per-stream privilege access. It mirrors UnaryServerInterceptor: it
+// wraps the authorization function into a grpc.StreamServerInterceptor,
+// propagating the authorized context to the handler via a wrapped ServerStream.
+func PrivilegeStreamInterceptor(privilegeFunc StreamPrivilegeFunc) grpc.StreamServerInterceptor {
+	privilege.InitPrivilegeGroups()
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		newCtx, err := privilegeFunc(ss.Context(), info.FullMethod)
+		if err != nil {
+			hookutil.GetExtension().ReportAction(newCtx, nil, &milvuspb.BoolResponse{
+				Status: merr.Status(err),
+			}, err, info.FullMethod, hookutil.ActionAuthorize)
+			return err
+		}
+		wrapped := grpc_middleware.WrapServerStream(ss)
+		wrapped.WrappedContext = newCtx
+		return handler(srv, wrapped)
+	}
+}
+
+// StreamPrivilegeInterceptor resolves the authorization for a streaming RPC from
+// its full method name via streamMethodAuthorizers. Unregistered methods are
+// denied (fail-closed); the health service is exempted so infrastructure
+// liveness probes keep working.
+func StreamPrivilegeInterceptor(ctx context.Context, fullMethod string) (context.Context, error) {
+	if !Params.CommonCfg.AuthorizationEnabled.GetAsBool() {
+		return ctx, nil
+	}
+	if fullMethod == grpc_health_v1.Health_Watch_FullMethodName {
+		return ctx, nil
+	}
+	authorize, ok := streamMethodAuthorizers[fullMethod]
+	if !ok {
+		// Unregistered streaming method: deny by default so no stream RPC can
+		// slip through the authorization chain unnoticed.
+		mlog.Warn(ctx, "stream method not registered for authorization check, denying", mlog.String("method", fullMethod))
+		return ctx, status.Error(codes.PermissionDenied, fmt.Sprintf("streaming method %s is not authorized", fullMethod))
+	}
+	return authorize(ctx)
+}
+
+// authorizeCreateReplicateStream authorizes CreateReplicateStream, which writes
+// replicated messages into the WAL data plane. It is a cluster-scoped operation
+// and is authorized via casbin against PrivilegeUpdateReplicateConfiguration
+// (Global scope), mirroring the unary interceptor's cluster-level handling.
+func authorizeCreateReplicateStream(ctx context.Context) (context.Context, error) {
+	return enforceClusterPrivilege(ctx, commonpb.ObjectPrivilege_PrivilegeUpdateReplicateConfiguration.String())
 }

--- a/internal/proxy/stream_method_authorizers_test.go
+++ b/internal/proxy/stream_method_authorizers_test.go
@@ -1,0 +1,63 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+)
+
+func TestStreamMethodAuthorizers_CoverAllStreams(t *testing.T) {
+	fullMethodName := func(serviceName, streamName string) string {
+		return "/" + serviceName + "/" + streamName
+	}
+
+	allowedMethods := map[string]struct{}{
+		grpc_health_v1.Health_Watch_FullMethodName: {},
+	}
+	for fullMethod := range streamMethodAuthorizers {
+		allowedMethods[fullMethod] = struct{}{}
+	}
+
+	for _, sd := range milvuspb.MilvusService_ServiceDesc.Streams {
+		method := fullMethodName(milvuspb.MilvusService_ServiceDesc.ServiceName, sd.StreamName)
+		_, ok := allowedMethods[method]
+		assert.True(t, ok, "streaming method %s on MilvusService is not registered in streamMethodAuthorizers nor exempted", method)
+	}
+
+	streamMethods := make(map[string]struct{})
+	for _, sd := range milvuspb.MilvusService_ServiceDesc.Streams {
+		streamMethods[fullMethodName(milvuspb.MilvusService_ServiceDesc.ServiceName, sd.StreamName)] = struct{}{}
+	}
+	for fullMethod := range streamMethodAuthorizers {
+		_, ok := streamMethods[fullMethod]
+		assert.True(t, ok, "streamMethodAuthorizers key %s has no corresponding stream in MilvusService", fullMethod)
+	}
+
+	var healthStreams []string
+	for _, sd := range grpc_health_v1.Health_ServiceDesc.Streams {
+		healthStreams = append(healthStreams, sd.StreamName)
+	}
+	require.Equal(t, []string{"Watch"}, healthStreams)
+	_, ok := allowedMethods[fullMethodName(grpc_health_v1.Health_ServiceDesc.ServiceName, "Watch")]
+	assert.True(t, ok, "health Watch stream is not covered by the exemption set")
+}


### PR DESCRIPTION
Cherry-pick from master
pr: https://github.com/milvus-io/milvus/pull/52608
Related to https://github.com/milvus-io/milvus/issues/52387

Release-branch adaptation:
The cherry-pick conflicted on client/milvusclient/interceptors.go and
interceptors_test.go because master carries an unrelated, already-merged
client-request-id PR that is not on 3.0. Only PR 52608's delta was kept
(withClientMetadata extraction + MetadataStreamInterceptor + its test);
the client-request-id code was dropped. The 8 remaining files are
byte-identical to the master source commit.

Local Gate A evidence:
- client/milvusclient: typecheck + full unit tests pass
- internal/proxy, internal/distributed/proxy: compile against 3.0 headers (go build)
- make fmt: pass
- make static-check: only fails on a pre-existing 3.0 go.sum issue in
  cmd/tools/migration (untouched by this cherry-pick)
- proxy runtime tests: blocked by stale local C++ artifacts — libmilvus-common.so
  has unresolved grpc symbols; reproduces on a pristine 3.0 checkout, so it is a
  local environment artifact mismatch unrelated to this cherry-pick
