### PR TITLE
fix: [cp3.0] preserve commit_timestamp through clustering compaction

### DIFF
--- a/internal/datanode/compactor/clustering_compactor.go
+++ b/internal/datanode/compactor/clustering_compactor.go
@@ -497,16 +497,8 @@ func (t *clusteringCompactionTask) mapping(ctx context.Context,
 	mapStart := time.Now()
 	futures := make([]*conc.Future[any], 0, len(inputSegments))
 	for _, segment := range inputSegments {
-		segmentClone := &datapb.CompactionSegmentBinlogs{
-			SegmentID: segment.SegmentID,
-			// only FieldBinlogs and deltalogs needed
-			Deltalogs:      segment.Deltalogs,
-			FieldBinlogs:   segment.FieldBinlogs,
-			StorageVersion: segment.StorageVersion,
-			Manifest:       segment.GetManifest(),
-		}
 		future := t.mappingPool.Submit(func() (any, error) {
-			err := t.mappingSegment(ctx, segmentClone)
+			err := t.mappingSegment(ctx, segment)
 			return struct{}{}, err
 		})
 		futures = append(futures, future)
@@ -612,6 +604,7 @@ func (t *clusteringCompactionTask) mappingSegment(
 		return err
 	}
 	rr = newMaterializedRecordReader(rr, materializer)
+	rr = wrapReaderWithTimestampOverwrite(rr, segment.GetCommitTimestamp())
 	defer rr.Close()
 
 	hasTTLField := t.ttlFieldID >= common.StartOfUserFieldID
@@ -651,12 +644,6 @@ func (t *clusteringCompactionTask) mappingSegment(
 			}
 			if entityFilter.Filtered(v.PK.GetValue(), uint64(v.Timestamp), expireTs) {
 				continue
-			}
-
-			// Normalize import segment timestamps: overwrite to commit_ts
-			// so the output segment becomes a normal segment (commit_ts = 0).
-			if commitTs := segment.GetCommitTimestamp(); commitTs != 0 {
-				v.Timestamp = int64(commitTs)
 			}
 
 			clusteringKey := row[t.clusteringKeyField.FieldID]

--- a/internal/datanode/compactor/clustering_compactor_test.go
+++ b/internal/datanode/compactor/clustering_compactor_test.go
@@ -534,6 +534,32 @@ func (s *ClusteringCompactionTaskSuite) TestScalarAnalyzeSegmentFiltersDroppedOr
 	s.Equal(map[interface{}]int64{"varchar": 2}, analyzeResult)
 }
 
+// An import segment committed at birthday+2s carries a deltalog entry deleting
+// PK=100 at birthday+1s. That delete predates the commit, so it must not remove
+// the row, and every output row timestamp must be normalized to commit_ts.
+func (s *ClusteringCompactionTaskSuite) TestScalarCompactionPreservesImportCommitTimestamp() {
+	s.preparScalarCompactionNormalTask()
+	commitTs := tsoutil.ComposeTSByTime(getMilvusBirthday().Add(2 * time.Second))
+	s.plan.SegmentBinlogs[0].CommitTimestamp = commitTs
+	s.task.compactionParams = compaction.GenParams()
+
+	compactionResult, err := s.task.Compact()
+	s.Require().NoError(err)
+
+	s.EqualValues(10240, lo.SumBy(compactionResult.GetSegments(), func(seg *datapb.CompactionSegment) int64 {
+		return seg.GetNumOfRows()
+	}))
+
+	for _, seg := range compactionResult.GetSegments() {
+		for _, fieldBinlog := range seg.GetInsertLogs() {
+			for _, b := range fieldBinlog.GetBinlogs() {
+				s.EqualValues(commitTs, b.GetTimestampFrom())
+				s.EqualValues(commitTs, b.GetTimestampTo())
+			}
+		}
+	}
+}
+
 func genRow(magic int64) map[int64]interface{} {
 	ts := tsoutil.ComposeTSByTime(getMilvusBirthday())
 	return map[int64]interface{}{


### PR DESCRIPTION
Cherry-pick from master

pr: #52150
issue: #52149

## Summary

Cherry-picked from master PR #52150 (merged). Clean cherry-pick — every changed line matches the master PR diff.

## Verification

- [x] File count matches original PR
- [x] Per-file diff verified identical to master PR
- [x] No conflict markers
- [ ] make static-check (skipped by cherry-pick workflow)
