### PR TITLE
fix: recover streaming query nodes synchronously on replica update

### DIFF
--- a/internal/querycoordv2/job/job_update.go
+++ b/internal/querycoordv2/job/job_update.go
@@ -22,10 +22,12 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus/internal/coordinator/snmanager"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
 	"github.com/milvus-io/milvus/internal/querycoordv2/observers"
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
 	"github.com/milvus-io/milvus/internal/util/proxyutil"
+	"github.com/milvus-io/milvus/internal/util/streamingutil"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/proxypb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
@@ -183,6 +185,21 @@ func (job *UpdateLoadConfigJob) Execute() error {
 
 	// 6. recover node distribution among replicas
 	utils.RecoverReplicaOfCollection(job.ctx, job.meta, job.collectionID)
+	if streamingutil.IsStreamingServiceEnabled() {
+		// Recover streaming query nodes in the same pass. Without this, newly spawned
+		// replicas only get their streaming query nodes from the replica observer's
+		// node-changed/timeout loop, which can stall channel delegator setup for up to
+		// queryCoord.checkNodeInReplicaInterval (default 60s) after a scale-up.
+		if err := job.meta.RecoverSQNodesInCollections(
+			job.ctx,
+			[]int64{job.collectionID},
+			snmanager.StaticStreamingNodeManager.GetStreamingQueryNodeIDsByResourceGroup(),
+		); err != nil {
+			mlog.Warn(job.ctx, "failed to recover streaming query nodes after replica update",
+				mlog.FieldCollectionID(job.collectionID),
+				mlog.Err(err))
+		}
+	}
 
 	// 7. update replica number in meta
 	err = job.meta.UpdateReplicaNumber(job.ctx, job.collectionID, job.newReplicaNumber, job.userSpecifiedReplicaMode)

--- a/internal/querycoordv2/job/job_update_test.go
+++ b/internal/querycoordv2/job/job_update_test.go
@@ -1,0 +1,171 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package job
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/rgpb"
+	"github.com/milvus-io/milvus/internal/coordinator/snmanager"
+	"github.com/milvus-io/milvus/internal/metastore/mocks"
+	"github.com/milvus-io/milvus/internal/mocks/streamingcoord/server/mock_balancer"
+	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
+	"github.com/milvus-io/milvus/internal/querycoordv2/observers"
+	"github.com/milvus-io/milvus/internal/querycoordv2/session"
+	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer"
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/balance"
+	"github.com/milvus-io/milvus/internal/util/proxyutil"
+	"github.com/milvus-io/milvus/internal/util/streamingutil"
+	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+type UpdateLoadConfigJobSuite struct {
+	suite.Suite
+}
+
+func (suite *UpdateLoadConfigJobSuite) SetupSuite() {
+	paramtable.Init()
+	// The update-target loop is not under test; keep it quiet.
+	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.UpdateNextTargetInterval.Key, "3600")
+}
+
+// TestScaleUpRecoversSQNodesSynchronously verifies that UpdateLoadConfigJob
+// assigns streaming query nodes to newly spawned replicas before returning,
+// instead of leaving them to the replica observer's node-changed/timeout loop
+// (queryCoord.checkNodeInReplicaInterval, default 60s). Without the synchronous
+// recovery, channel delegators on the new replicas cannot be set up for up to
+// a minute after a scale-up.
+func (suite *UpdateLoadConfigJobSuite) TestScaleUpRecoversSQNodesSynchronously() {
+	streamingutil.SetStreamingServiceEnabled()
+	defer os.Unsetenv(streamingutil.MilvusStreamingServiceEnabled)
+
+	// Register two RG-labeled streaming nodes via the streaming node manager.
+	snmanager.ResetStreamingNodeManager()
+	b := mock_balancer.NewMockBalancer(suite.T())
+	b.EXPECT().WatchChannelAssignments(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, cb balancer.WatchChannelAssignmentsCallback) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}).Maybe()
+	streamingNodes := map[int64]*types.StreamingNodeInfoWithResourceGroup{
+		101: {StreamingNodeInfo: types.StreamingNodeInfo{ServerID: 101, Address: "localhost:101"}, ResourceGroup: "rg1"},
+		102: {StreamingNodeInfo: types.StreamingNodeInfo{ServerID: 102, Address: "localhost:102"}, ResourceGroup: "rg2"},
+	}
+	b.EXPECT().GetAllStreamingNodes(mock.Anything).Return(streamingNodes, nil).Maybe()
+	b.EXPECT().GetAvailableStreamingNodes(mock.Anything).Return(streamingNodes, nil).Maybe()
+	balance.Register(b)
+
+	ctx := context.Background()
+	collectionID := int64(1000)
+
+	catalog := mocks.NewQueryCoordCatalog(suite.T())
+	catalog.EXPECT().SaveCollection(mock.Anything, mock.Anything).Return(nil).Maybe()
+	// SaveReplica flattens its variadic replicas argument, so register one
+	// expectation per possible call arity (single or batched replica saves).
+	catalog.EXPECT().SaveReplica(mock.Anything, mock.Anything).Return(nil).Maybe()
+	catalog.EXPECT().SaveReplica(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	catalog.EXPECT().SaveReplica(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	catalog.EXPECT().SaveResourceGroup(mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	nodeMgr := session.NewNodeManager()
+	for _, id := range []int64{1, 2} {
+		nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   id,
+			Address:  "localhost",
+			Hostname: "localhost",
+		}))
+	}
+	nextID := int64(200)
+	m := meta.NewMeta(func() (int64, error) {
+		id := nextID
+		nextID++
+		return id, nil
+	}, catalog, nodeMgr)
+
+	// Two resource groups requesting one query node each; HandleNodeUp fills them.
+	rgCfg := func() *rgpb.ResourceGroupConfig {
+		return &rgpb.ResourceGroupConfig{
+			Requests: &rgpb.ResourceGroupLimit{NodeNum: 1},
+			Limits:   &rgpb.ResourceGroupLimit{NodeNum: 1},
+		}
+	}
+	for _, rgName := range []string{"rg1", "rg2"} {
+		_, err := m.AddResourceGroup(ctx, rgName, rgCfg())
+		suite.NoError(err)
+	}
+	m.HandleNodeUp(ctx, 1)
+	m.HandleNodeUp(ctx, 2)
+	for _, rgName := range []string{"rg1", "rg2"} {
+		nodes, err := m.GetNodes(ctx, rgName)
+		suite.NoError(err)
+		suite.Len(nodes, 1, "each resource group should hold exactly one query node")
+	}
+
+	// Collection loaded with one replica in rg1 (the pre-scale-up state).
+	err := m.PutCollection(ctx, utils.CreateTestCollection(collectionID, 1))
+	suite.NoError(err)
+	_, err = m.Spawn(ctx, collectionID, map[string]int{"rg1": 1}, nil, commonpb.LoadPriority_LOW)
+	suite.NoError(err)
+	utils.RecoverReplicaOfCollection(ctx, m, collectionID)
+
+	// The target observer's dependencies are mocked out; it only needs to answer
+	// the job's UpdateNextTarget call at the end of Execute.
+	targetMgr := meta.NewMockTargetManager(suite.T())
+	targetMgr.EXPECT().GetDmChannelsByCollection(mock.Anything, mock.Anything, mock.Anything).Return(map[string]*meta.DmChannel{}).Maybe()
+	targetMgr.EXPECT().IsNextTargetExist(mock.Anything, mock.Anything).Return(false).Maybe()
+	targetMgr.EXPECT().UpdateCollectionNextTarget(mock.Anything, mock.Anything).Return(nil).Maybe()
+	targetMgr.EXPECT().IsCurrentTargetExist(mock.Anything, mock.Anything, mock.Anything).Return(true).Maybe()
+	targetMgr.EXPECT().GetCollectionTargetVersion(mock.Anything, mock.Anything, mock.Anything).Return(int64(0)).Maybe()
+	targetObserver := observers.NewTargetObserver(m, targetMgr, meta.NewDistributionManager(nodeMgr), meta.NewMockBroker(suite.T()), session.NewMockCluster(suite.T()), nodeMgr)
+	targetObserver.Start()
+	defer targetObserver.Stop()
+
+	// Scale up 1 -> 2 across rg1/rg2, mirroring the control-plane flow
+	// (needWaitRGReady=true, i.e. freshly scaled-out query nodes).
+	req := &querypb.UpdateLoadConfigRequest{
+		Base:           &commonpb.MsgBase{MsgID: 1},
+		CollectionIDs:  []int64{collectionID},
+		ReplicaNumber:  2,
+		ResourceGroups: []string{"rg1", "rg2"},
+	}
+	j := NewUpdateLoadConfigJob(ctx, req, m, targetMgr, targetObserver, nil, proxyutil.NewMockProxyClientManager(suite.T()), false, true)
+	suite.NoError(j.Execute())
+
+	replicas := m.GetByCollection(ctx, collectionID)
+	suite.Len(replicas, 2)
+	byRG := lo.GroupBy(replicas, func(r *meta.Replica) string { return r.GetResourceGroup() })
+	for rgName, expectedSQNode := range map[string]int64{"rg1": 101, "rg2": 102} {
+		suite.Require().Len(byRG[rgName], 1)
+		replica := byRG[rgName][0]
+		suite.NotEmpty(replica.GetRWNodes(), "replica in %s should have query nodes assigned", rgName)
+		suite.Contains(replica.GetRWSQNodes(), expectedSQNode,
+			"replica in %s should have its streaming query node assigned synchronously after scale-up", rgName)
+	}
+}
+
+func TestUpdateLoadConfigJob(t *testing.T) {
+	suite.Run(t, new(UpdateLoadConfigJobSuite))
+}


### PR DESCRIPTION
## Summary

issue: #52860

In streaming-architecture clusters, `UpdateLoadConfigJob` (replica scale up/down, RG transfer) recovers query nodes synchronously (step 6, `RecoverReplicaOfCollection`) but leaves **streaming query node** assignment to `ReplicaObserver.scheduleStreamingQN`, which waits on the SN node-changed listener with a `queryCoord.checkNodeInReplicaInterval` timeout (default 60s).

In the common scale-up sequence the streaming nodes register **before** the new replicas are spawned (pods come up first, then the load config is updated), so the node-changed event is consumed while the replicas don't exist yet, and the loop then sleeps the full timeout. Result: newly spawned replicas sit with `rwNodes` set but `rwSQNodes` empty for up to 60s, no channel delegator can be set up, and `/management/replica/loadconfig/compliance` reports `not serviceable: no leader for channel` until the timeout fires.

Measured on a 2 -> 4 scale-up of a 32M-vector (~98GiB) collection: 53s of the 185s total was this dead wait (`reassign replica` at T+0, `new replica recovery streaming query node found` at T+60.000s exactly); only then did channel/segment tasks start.

## Fix

Call `RecoverSQNodesInCollections` synchronously from `UpdateLoadConfigJob.Execute` right after `RecoverReplicaOfCollection`, guarded by `streamingutil.IsStreamingServiceEnabled()` — mirroring the established pattern in `SpawnReplicasWithReplicaConfig` / `SpawnReplicasWithRG` (utils/meta.go), which already do exactly this for the initial-load path. The observer loop remains as the safety net for streaming-node-side changes (SN crash, independent SN scaling).

Failure semantics: on error (e.g. etcd save failure) the job logs and continues; the observer loop converges within one interval, identical to pre-change behavior. The recovery is a diff-based no-op (in-memory scan, etcd write only on change) for converged replicas, so transfer-only and scale-down updates are unaffected.

## Test

New `job_update_test.go`: runs a 1 -> 2 scale-up through `UpdateLoadConfigJob.Execute` with two RG-labeled streaming nodes registered and asserts both replicas hold their SQ nodes immediately after `Execute` returns — no observer involved. Fails without the fix (`rwSQNodes` empty), passes with it.

```
go test -tags "dynamic test" -gcflags="all=-N -l" -count=1 ./internal/querycoordv2/job/...
ok  github.com/milvus-io/milvus/internal/querycoordv2/job  5.601s
```

## Notes

- The e2e latency claim (removing the ~53s stall) is derived from tracing the timeout path in production logs; a re-run of the scale-up benchmark with this patch is planned as follow-up validation.
- `utils`/`meta` package tests were not run locally (they require an etcd instance not available in the dev environment; failures reproduce identically on clean master).