### PR TITLE
enhance: Nominate zhuwenxing, foxspy, chyezh and weiliu1031 as maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -8,3 +8,7 @@ maintainers:
   - tedxu
   - liliu-z
   - zhengbuqian
+  - zhuwenxing
+  - foxspy
+  - chyezh
+  - weiliu1031

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,4 +9,6 @@ aliases:
     - zhengbuqian
     - chyezh
     - weiliu1031
+    - zhuwenxing
+    - foxspy
 


### PR DESCRIPTION
## Summary

Nominate zhuwenxing, foxspy, chyezh and weiliu1031 as Milvus maintainers.

## Changes

- Add zhuwenxing, foxspy, chyezh and weiliu1031 to MAINTAINERS.
- Add zhuwenxing and foxspy to the maintainers alias in OWNERS_ALIASES.