### PR TITLE
enhance: include field name and actual type in expression type-mismatch errors

### DIFF
--- a/internal/parser/planparserv2/fill_expression_value.go
+++ b/internal/parser/planparserv2/fill_expression_value.go
@@ -271,7 +271,7 @@ func FillBinaryArithOpEvalRangeExpressionValue(expr *planpb.BinaryArithOpEvalRan
 		}
 
 		if err = checkValidModArith(expr.GetArithOp(), expr.GetColumnInfo().GetDataType(), expr.GetColumnInfo().GetElementType(),
-			rDataType, schemapb.DataType_None); err != nil {
+			rDataType, schemapb.DataType_None, "", ""); err != nil {
 			return err
 		}
 

--- a/internal/parser/planparserv2/parser_visitor.go
+++ b/internal/parser/planparserv2/parser_visitor.go
@@ -52,6 +52,20 @@ func NewParserVisitor(schema *typeutil.SchemaHelper, args *ParserVisitorArgs) *P
 	return &ParserVisitor{schema: schema, args: args}
 }
 
+// fieldName resolves the field name for a column expression through the
+// schema, or returns an empty string for constants and computed expressions.
+func (v *ParserVisitor) fieldName(expr *ExprWithType) string {
+	info := toColumnInfo(expr)
+	if info == nil {
+		return ""
+	}
+	field, err := v.schema.GetFieldFromID(info.GetFieldId())
+	if err != nil {
+		return ""
+	}
+	return field.GetName()
+}
+
 // VisitParens unpack the parentheses.
 func (v *ParserVisitor) VisitParens(ctx *parser.ParensContext) interface{} {
 	return ctx.Expr().Accept(v)
@@ -482,7 +496,7 @@ func (v *ParserVisitor) VisitMulDivMod(ctx *parser.MulDivModContext) interface{}
 			return merr.WrapErrParameterInvalidMsg("'%s' %s", arithNameMap[ctx.GetOp().GetTokenType()], err.Error())
 		}
 
-		if err = checkValidModArith(arithExprMap[ctx.GetOp().GetTokenType()], leftExpr.dataType, getArrayElementType(leftExpr), rightExpr.dataType, getArrayElementType(rightExpr)); err != nil {
+		if err = checkValidModArith(arithExprMap[ctx.GetOp().GetTokenType()], leftExpr.dataType, getArrayElementType(leftExpr), rightExpr.dataType, getArrayElementType(rightExpr), v.fieldName(leftExpr), v.fieldName(rightExpr)); err != nil {
 			return err
 		}
 
@@ -1746,7 +1760,7 @@ func (v *ParserVisitor) VisitUnary(ctx *parser.UnaryContext) interface{} {
 		if err := canArithmetic(childExpr.dataType, getArrayElementType(childExpr), minusOne.dataType, getArrayElementType(minusOne), false); err != nil {
 			return merr.WrapErrParameterInvalidMsg("'bitnot' %s", err.Error())
 		}
-		if err := checkValidModArith(planpb.ArithOpType_BitXor, childExpr.dataType, getArrayElementType(childExpr), minusOne.dataType, getArrayElementType(minusOne)); err != nil {
+		if err := checkValidModArith(planpb.ArithOpType_BitXor, childExpr.dataType, getArrayElementType(childExpr), minusOne.dataType, getArrayElementType(minusOne), v.fieldName(childExpr), ""); err != nil {
 			return err
 		}
 		dataType, err := calcDataType(childExpr, minusOne, false)
@@ -2026,7 +2040,7 @@ func (v *ParserVisitor) visitBitwiseBinaryOp(leftCtx, rightCtx parser.IExprConte
 		if err = canArithmetic(leftExpr.dataType, getArrayElementType(leftExpr), rightExpr.dataType, getArrayElementType(rightExpr), reverse); err != nil {
 			return merr.WrapErrParameterInvalidMsg("'%s' %s", arithNameMap[tokenType], err.Error())
 		}
-		if err = checkValidModArith(arithExprMap[tokenType], leftExpr.dataType, getArrayElementType(leftExpr), rightExpr.dataType, getArrayElementType(rightExpr)); err != nil {
+		if err = checkValidModArith(arithExprMap[tokenType], leftExpr.dataType, getArrayElementType(leftExpr), rightExpr.dataType, getArrayElementType(rightExpr), v.fieldName(leftExpr), v.fieldName(rightExpr)); err != nil {
 			return err
 		}
 		dataType, err = calcDataType(leftExpr, rightExpr, reverse)

--- a/internal/parser/planparserv2/plan_parser_v2_test.go
+++ b/internal/parser/planparserv2/plan_parser_v2_test.go
@@ -1758,6 +1758,32 @@ func TestExpr_BinaryArith(t *testing.T) {
 	}
 }
 
+// TestExpr_ArithTypeMismatchErrors asserts that modulo / bitwise type-mismatch
+// errors name the offending field and its declared type, so a caller does not
+// have to guess which field broke the expression.
+func TestExpr_ArithTypeMismatchErrors(t *testing.T) {
+	helper := newTestSchemaHelper(t)
+	cases := []struct {
+		expr      string
+		wantMsg   string
+		wantField string
+		wantType  string
+	}{
+		{`(FloatField & 4) == 4`, "bitwise operations can only apply on integer types", "FloatField", "FLOAT"},
+		{`(DoubleField | 2) == 3`, "bitwise operations can only apply on integer types", "DoubleField", "DOUBLE"},
+		{`(FloatField << 1) == 0`, "bitwise operations can only apply on integer types", "FloatField", "FLOAT"},
+		{`~DoubleField == 0`, "bitwise operations can only apply on integer types", "DoubleField", "DOUBLE"},
+		{`FloatField % 2 == 0`, "modulo can only apply on integer types", "FloatField", "FLOAT"},
+		{`DoubleField % 2 == 0`, "modulo can only apply on integer types", "DoubleField", "DOUBLE"},
+	}
+	for _, c := range cases {
+		_, err := ParseExpr(helper, c.expr, nil)
+		require.Error(t, err, c.expr)
+		assert.Contains(t, err.Error(), c.wantMsg, c.expr)
+		assert.Contains(t, err.Error(), fmt.Sprintf("but field '%s' is %s", c.wantField, c.wantType), c.expr)
+	}
+}
+
 // TestExpr_BitwiseArith asserts the generated plan structure for bitwise
 // operators, not merely that the expression parses. A bitwise op over a field
 // must fuse into a BinaryArithOpEvalRangeExpr carrying the matching ArithOpType,

--- a/internal/parser/planparserv2/utils.go
+++ b/internal/parser/planparserv2/utils.go
@@ -262,10 +262,12 @@ func toColumnInfo(left *ExprWithType) *planpb.ColumnInfo {
 }
 
 // formatDataTypeForError renders the data type a field was declared with in
-// uppercase, keeping the element type for array fields.
+// uppercase. Array fields keep the element type and use the same
+// "Array[Element]" spelling as getDataType so error messages stay consistent
+// across the package.
 func formatDataTypeForError(dataType, elementType schemapb.DataType) string {
 	if typeutil.IsArrayType(dataType) && elementType != schemapb.DataType_None {
-		return fmt.Sprintf("ARRAY(%s)", strings.ToUpper(elementType.String()))
+		return fmt.Sprintf("%s[%s]", dataType, elementType)
 	}
 	return strings.ToUpper(dataType.String())
 }
@@ -760,14 +762,20 @@ func checkValidModArith(tokenType planpb.ArithOpType, leftType, leftElementType,
 		return nil
 	}
 
-	// Name the offending field and its declared type so the caller does not
+	// Name every offending field and its declared type so the caller does not
 	// have to guess which side of the expression broke the operator.
+	var offendingParts []string
+	if !leftValid && leftName != "" {
+		offendingParts = append(offendingParts,
+			fmt.Sprintf("field '%s' is %s", leftName, formatDataTypeForError(leftType, leftElementType)))
+	}
+	if !rightValid && rightName != "" {
+		offendingParts = append(offendingParts,
+			fmt.Sprintf("field '%s' is %s", rightName, formatDataTypeForError(rightType, rightElementType)))
+	}
 	var offending string
-	switch {
-	case !leftValid && leftName != "":
-		offending = fmt.Sprintf(", but field '%s' is %s", leftName, formatDataTypeForError(leftType, leftElementType))
-	case !rightValid && rightName != "":
-		offending = fmt.Sprintf(", but field '%s' is %s", rightName, formatDataTypeForError(rightType, rightElementType))
+	if len(offendingParts) > 0 {
+		offending = ", but " + strings.Join(offendingParts, " and ")
 	}
 
 	switch tokenType {

--- a/internal/parser/planparserv2/utils.go
+++ b/internal/parser/planparserv2/utils.go
@@ -261,6 +261,15 @@ func toColumnInfo(left *ExprWithType) *planpb.ColumnInfo {
 	return left.expr.GetColumnExpr().GetInfo()
 }
 
+// formatDataTypeForError renders the data type a field was declared with in
+// uppercase, keeping the element type for array fields.
+func formatDataTypeForError(dataType, elementType schemapb.DataType) string {
+	if typeutil.IsArrayType(dataType) && elementType != schemapb.DataType_None {
+		return fmt.Sprintf("ARRAY(%s)", strings.ToUpper(elementType.String()))
+	}
+	return strings.ToUpper(dataType.String())
+}
+
 func castValue(dataType schemapb.DataType, value *planpb.GenericValue) (*planpb.GenericValue, error) {
 	// A raw-bytes value has exactly two consumers — the bloom_match filter blob
 	// and the roaring_match bitmap blob — each validated and embedded by its own
@@ -744,17 +753,29 @@ func hexDigit(n uint32) byte {
 	return byte(n-10) + 'a'
 }
 
-func checkValidModArith(tokenType planpb.ArithOpType, leftType, leftElementType, rightType, rightElementType schemapb.DataType) error {
+func checkValidModArith(tokenType planpb.ArithOpType, leftType, leftElementType, rightType, rightElementType schemapb.DataType, leftName, rightName string) error {
+	leftValid := canConvertToIntegerType(leftType, leftElementType)
+	rightValid := canConvertToIntegerType(rightType, rightElementType)
+	if leftValid && rightValid {
+		return nil
+	}
+
+	// Name the offending field and its declared type so the caller does not
+	// have to guess which side of the expression broke the operator.
+	var offending string
+	switch {
+	case !leftValid && leftName != "":
+		offending = fmt.Sprintf(", but field '%s' is %s", leftName, formatDataTypeForError(leftType, leftElementType))
+	case !rightValid && rightName != "":
+		offending = fmt.Sprintf(", but field '%s' is %s", rightName, formatDataTypeForError(rightType, rightElementType))
+	}
+
 	switch tokenType {
 	case planpb.ArithOpType_Mod:
-		if !canConvertToIntegerType(leftType, leftElementType) || !canConvertToIntegerType(rightType, rightElementType) {
-			return merr.WrapErrQueryPlanMsg("modulo can only apply on integer types")
-		}
+		return merr.WrapErrQueryPlanMsg("modulo can only apply on integer types%s", offending)
 	case planpb.ArithOpType_BitAnd, planpb.ArithOpType_BitOr, planpb.ArithOpType_BitXor,
 		planpb.ArithOpType_Shl, planpb.ArithOpType_Shr:
-		if !canConvertToIntegerType(leftType, leftElementType) || !canConvertToIntegerType(rightType, rightElementType) {
-			return merr.WrapErrQueryPlanMsg("bitwise operations can only apply on integer types")
-		}
+		return merr.WrapErrQueryPlanMsg("bitwise operations can only apply on integer types%s", offending)
 	default:
 	}
 	return nil

--- a/internal/parser/planparserv2/utils_test.go
+++ b/internal/parser/planparserv2/utils_test.go
@@ -1227,6 +1227,21 @@ func Test_checkValidModArith(t *testing.T) {
 		assert.NotContains(t, err.Error(), "but field")
 	})
 
+	t.Run("mod with array operands reports element types", func(t *testing.T) {
+		// Array operands must render the element type using the same
+		// "Array[Element]" spelling as getDataType, and every invalid side
+		// must be named in one pass.
+		err := checkValidModArith(planpb.ArithOpType_Mod,
+			schemapb.DataType_Array, schemapb.DataType_Float,
+			schemapb.DataType_Array, schemapb.DataType_Double,
+			"floatArr", "doubleArr")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "modulo can only apply on integer types")
+		assert.Contains(t, err.Error(), "field 'floatArr' is Array[Float]")
+		assert.Contains(t, err.Error(), "field 'doubleArr' is Array[Double]")
+		assert.Contains(t, err.Error(), " and ")
+	})
+
 	t.Run("add operation is always valid", func(t *testing.T) {
 		// Non-mod operations should not be validated by this function
 		err := checkValidModArith(planpb.ArithOpType_Add,

--- a/internal/parser/planparserv2/utils_test.go
+++ b/internal/parser/planparserv2/utils_test.go
@@ -1197,30 +1197,41 @@ func Test_checkValidModArith(t *testing.T) {
 	t.Run("mod with integers is valid", func(t *testing.T) {
 		err := checkValidModArith(planpb.ArithOpType_Mod,
 			schemapb.DataType_Int64, schemapb.DataType_None,
-			schemapb.DataType_Int64, schemapb.DataType_None)
+			schemapb.DataType_Int64, schemapb.DataType_None, "", "")
 		assert.NoError(t, err)
 	})
 
 	t.Run("mod with float left is invalid", func(t *testing.T) {
 		err := checkValidModArith(planpb.ArithOpType_Mod,
 			schemapb.DataType_Float, schemapb.DataType_None,
-			schemapb.DataType_Int64, schemapb.DataType_None)
+			schemapb.DataType_Int64, schemapb.DataType_None, "price", "")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "modulo can only apply on integer types")
+		assert.Contains(t, err.Error(), "but field 'price' is FLOAT")
 	})
 
 	t.Run("mod with float right is invalid", func(t *testing.T) {
 		err := checkValidModArith(planpb.ArithOpType_Mod,
 			schemapb.DataType_Int64, schemapb.DataType_None,
-			schemapb.DataType_Float, schemapb.DataType_None)
+			schemapb.DataType_Float, schemapb.DataType_None, "", "price")
 		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "but field 'price' is FLOAT")
+	})
+
+	t.Run("mod with unnamed operands keeps the plain message", func(t *testing.T) {
+		err := checkValidModArith(planpb.ArithOpType_Mod,
+			schemapb.DataType_Float, schemapb.DataType_None,
+			schemapb.DataType_Float, schemapb.DataType_None, "", "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "modulo can only apply on integer types")
+		assert.NotContains(t, err.Error(), "but field")
 	})
 
 	t.Run("add operation is always valid", func(t *testing.T) {
 		// Non-mod operations should not be validated by this function
 		err := checkValidModArith(planpb.ArithOpType_Add,
 			schemapb.DataType_Float, schemapb.DataType_None,
-			schemapb.DataType_Float, schemapb.DataType_None)
+			schemapb.DataType_Float, schemapb.DataType_None, "", "")
 		assert.NoError(t, err)
 	})
 }
@@ -1240,31 +1251,33 @@ func Test_checkValidBitwiseArith(t *testing.T) {
 		t.Run(op.String()+" with integers is valid", func(t *testing.T) {
 			err := checkValidModArith(op,
 				schemapb.DataType_Int64, schemapb.DataType_None,
-				schemapb.DataType_Int64, schemapb.DataType_None)
+				schemapb.DataType_Int64, schemapb.DataType_None, "", "")
 			assert.NoError(t, err)
 		})
 
 		t.Run(op.String()+" with integer array element is valid", func(t *testing.T) {
 			err := checkValidModArith(op,
 				schemapb.DataType_Array, schemapb.DataType_Int32,
-				schemapb.DataType_Int64, schemapb.DataType_None)
+				schemapb.DataType_Int64, schemapb.DataType_None, "", "")
 			assert.NoError(t, err)
 		})
 
 		t.Run(op.String()+" with float left is invalid", func(t *testing.T) {
 			err := checkValidModArith(op,
 				schemapb.DataType_Float, schemapb.DataType_None,
-				schemapb.DataType_Int64, schemapb.DataType_None)
+				schemapb.DataType_Int64, schemapb.DataType_None, "price", "")
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "bitwise operations can only apply on integer types")
+			assert.Contains(t, err.Error(), "but field 'price' is FLOAT")
 		})
 
 		t.Run(op.String()+" with double right is invalid", func(t *testing.T) {
 			err := checkValidModArith(op,
 				schemapb.DataType_Int64, schemapb.DataType_None,
-				schemapb.DataType_Double, schemapb.DataType_None)
+				schemapb.DataType_Double, schemapb.DataType_None, "", "price")
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "bitwise operations can only apply on integer types")
+			assert.Contains(t, err.Error(), "but field 'price' is DOUBLE")
 		})
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #50965

Type-mismatch errors from bitwise / modulo operators only said
"bitwise operations can only apply on integer types" without naming which
field broke the expression or what type it actually has, forcing users to
guess which field caused the failure.

### What does this PR do?

- Threads the offending field name and declared type into
  `checkValidModArith` errors, e.g.:

  - before: `bitwise operations can only apply on integer types`
  - after: `bitwise operations can only apply on integer types, but field 'price' is DOUBLE`

- The field name is resolved through the schema by field ID; constants and
  computed expressions keep the original message.
- Array fields report their element type, e.g. `ARRAY(DOUBLE)`.
- The error code is unchanged.

### Tests

- Extended `Test_checkValidModArith` and `Test_checkValidBitwiseArith` to
  assert the offending field name and type.
- Added `TestExpr_ArithTypeMismatchErrors` covering bitwise (`&`, `|`, `<<`,
  `~`) and modulo (`%`) on FLOAT / DOUBLE fields at the parser level.

Signed-off-by: GerardGao <213731635+GerardGao@users.noreply.github.com>