### PR TITLE
enhance: optimize import task lookup by job

### DIFF
--- a/internal/datacoord/import_checker.go
+++ b/internal/datacoord/import_checker.go
@@ -228,7 +228,7 @@ func (c *importChecker) getLackFilesForPreImports(job ImportJob) []*internalpb.I
 	lacks := lo.KeyBy(job.GetFiles(), func(file *internalpb.ImportFile) int64 {
 		return file.GetId()
 	})
-	exists := c.importMeta.GetTaskBy(c.ctx, WithType(PreImportTaskType), WithJob(job.GetJobID()))
+	exists := c.importMeta.GetTaskByJob(c.ctx, job.GetJobID(), WithType(PreImportTaskType))
 	for _, task := range exists {
 		for _, file := range task.GetFileStats() {
 			delete(lacks, file.GetImportFile().GetId())
@@ -238,14 +238,14 @@ func (c *importChecker) getLackFilesForPreImports(job ImportJob) []*internalpb.I
 }
 
 func (c *importChecker) getLackFilesForImports(job ImportJob) []*datapb.ImportFileStats {
-	preimports := c.importMeta.GetTaskBy(c.ctx, WithType(PreImportTaskType), WithJob(job.GetJobID()))
+	preimports := c.importMeta.GetTaskByJob(c.ctx, job.GetJobID(), WithType(PreImportTaskType))
 	lacks := make(map[int64]*datapb.ImportFileStats, 0)
 	for _, t := range preimports {
 		for _, stat := range t.GetFileStats() {
 			lacks[stat.GetImportFile().GetId()] = stat
 		}
 	}
-	exists := c.importMeta.GetTaskBy(c.ctx, WithType(ImportTaskType), WithJob(job.GetJobID()))
+	exists := c.importMeta.GetTaskByJob(c.ctx, job.GetJobID(), WithType(ImportTaskType))
 	for _, task := range exists {
 		for _, file := range task.GetFileStats() {
 			delete(lacks, file.GetImportFile().GetId())
@@ -289,7 +289,7 @@ func (c *importChecker) checkPendingJob(job ImportJob) {
 func (c *importChecker) checkPreImportingJob(job ImportJob) {
 	log := mlog.With(mlog.FieldJobID(job.GetJobID()))
 
-	preimports := c.importMeta.GetTaskBy(c.ctx, WithType(PreImportTaskType), WithJob(job.GetJobID()))
+	preimports := c.importMeta.GetTaskByJob(c.ctx, job.GetJobID(), WithType(PreImportTaskType))
 	totalRows := int64(0)
 	for _, t := range preimports {
 		if t.GetState() != datapb.ImportTaskStateV2_Completed {
@@ -360,7 +360,7 @@ func (c *importChecker) checkPreImportingJob(job ImportJob) {
 
 func (c *importChecker) checkImportingJob(job ImportJob) {
 	log := mlog.With(mlog.FieldJobID(job.GetJobID()))
-	tasks := c.importMeta.GetTaskBy(c.ctx, WithType(ImportTaskType), WithJob(job.GetJobID()), WithRequestSource())
+	tasks := c.importMeta.GetTaskByJob(c.ctx, job.GetJobID(), WithType(ImportTaskType), WithRequestSource())
 	for _, t := range tasks {
 		if t.GetState() != datapb.ImportTaskStateV2_Completed {
 			return
@@ -401,7 +401,7 @@ func (c *importChecker) checkSortingJob(job ImportJob) {
 		taskCnt = 0
 		doneCnt = 0
 	)
-	tasks := c.importMeta.GetTaskBy(c.ctx, WithType(ImportTaskType), WithJob(job.GetJobID()))
+	tasks := c.importMeta.GetTaskByJob(c.ctx, job.GetJobID(), WithType(ImportTaskType))
 	for _, task := range tasks {
 		originSegmentIDs := task.(*importTask).GetSegmentIDs()
 		sortSegmentIDs := task.(*importTask).GetSortedSegmentIDs()
@@ -451,7 +451,7 @@ func (c *importChecker) checkSortingJob(job ImportJob) {
 
 func (c *importChecker) checkIndexBuildingJob(job ImportJob) {
 	log := mlog.With(mlog.FieldJobID(job.GetJobID()))
-	tasks := c.importMeta.GetTaskBy(c.ctx, WithType(ImportTaskType), WithJob(job.GetJobID()))
+	tasks := c.importMeta.GetTaskByJob(c.ctx, job.GetJobID(), WithType(ImportTaskType))
 	originSegmentIDs := lo.FlatMap(tasks, func(t ImportTask, _ int) []int64 {
 		return t.(*importTask).GetSegmentIDs()
 	})
@@ -545,7 +545,7 @@ func (c *importChecker) checkFailedJob(job ImportJob) {
 }
 
 func (c *importChecker) tryFailingTasks(job ImportJob) {
-	tasks := c.importMeta.GetTaskBy(c.ctx, WithJob(job.GetJobID()), WithStates(datapb.ImportTaskStateV2_Pending,
+	tasks := c.importMeta.GetTaskByJob(c.ctx, job.GetJobID(), WithStates(datapb.ImportTaskStateV2_Pending,
 		datapb.ImportTaskStateV2_InProgress, datapb.ImportTaskStateV2_Completed, datapb.ImportTaskStateV2_Retry))
 	if len(tasks) == 0 {
 		return
@@ -616,7 +616,7 @@ func (c *importChecker) checkGC(job ImportJob) {
 		GCRetention := Params.DataCoordCfg.ImportTaskRetention.GetAsDuration(time.Second)
 		log.Info(c.ctx, "job has reached the GC retention",
 			mlog.Time("cleanupTime", cleanupTime), mlog.Duration("GCRetention", GCRetention))
-		tasks := c.importMeta.GetTaskBy(c.ctx, WithJob(job.GetJobID()))
+		tasks := c.importMeta.GetTaskByJob(c.ctx, job.GetJobID())
 		shouldRemoveJob := true
 		for _, task := range tasks {
 			if job.GetState() == internalpb.ImportJobState_Failed && task.GetType() == ImportTaskType {

--- a/internal/datacoord/import_checker_test.go
+++ b/internal/datacoord/import_checker_test.go
@@ -183,11 +183,11 @@ func (s *ImportCheckerSuite) TestCheckJob() {
 	catalog.EXPECT().SavePreImportTask(mock.Anything, mock.Anything).Return(nil)
 
 	s.checker.checkPendingJob(job)
-	preimportTasks := s.importMeta.GetTaskBy(context.TODO(), WithJob(job.GetJobID()), WithType(PreImportTaskType))
+	preimportTasks := s.importMeta.GetTaskByJob(context.TODO(), job.GetJobID(), WithType(PreImportTaskType))
 	s.Equal(2, len(preimportTasks))
 	s.Equal(internalpb.ImportJobState_PreImporting, s.importMeta.GetJob(context.TODO(), job.GetJobID()).GetState())
 	s.checker.checkPendingJob(job) // no lack
-	preimportTasks = s.importMeta.GetTaskBy(context.TODO(), WithJob(job.GetJobID()), WithType(PreImportTaskType))
+	preimportTasks = s.importMeta.GetTaskByJob(context.TODO(), job.GetJobID(), WithType(PreImportTaskType))
 	s.Equal(2, len(preimportTasks))
 	s.Equal(internalpb.ImportJobState_PreImporting, s.importMeta.GetJob(context.TODO(), job.GetJobID()).GetState())
 
@@ -205,11 +205,11 @@ func (s *ImportCheckerSuite) TestCheckJob() {
 	}
 
 	s.checker.checkPreImportingJob(job)
-	importTasks := s.importMeta.GetTaskBy(context.TODO(), WithJob(job.GetJobID()), WithType(ImportTaskType))
+	importTasks := s.importMeta.GetTaskByJob(context.TODO(), job.GetJobID(), WithType(ImportTaskType))
 	s.Equal(1, len(importTasks))
 	s.Equal(internalpb.ImportJobState_Importing, s.importMeta.GetJob(context.TODO(), job.GetJobID()).GetState())
 	s.checker.checkPreImportingJob(job) // no lack
-	importTasks = s.importMeta.GetTaskBy(context.TODO(), WithJob(job.GetJobID()), WithType(ImportTaskType))
+	importTasks = s.importMeta.GetTaskByJob(context.TODO(), job.GetJobID(), WithType(ImportTaskType))
 	s.Equal(1, len(importTasks))
 	s.Equal(internalpb.ImportJobState_Importing, s.importMeta.GetJob(context.TODO(), job.GetJobID()).GetState())
 
@@ -313,14 +313,14 @@ func (s *ImportCheckerSuite) TestCheckJob_Failed() {
 	catalog.EXPECT().SavePreImportTask(mock.Anything, mock.Anything).Return(mockErr)
 
 	s.checker.checkPendingJob(job)
-	preimportTasks := s.importMeta.GetTaskBy(context.TODO(), WithJob(job.GetJobID()), WithType(PreImportTaskType))
+	preimportTasks := s.importMeta.GetTaskByJob(context.TODO(), job.GetJobID(), WithType(PreImportTaskType))
 	s.Equal(0, len(preimportTasks))
 	s.Equal(internalpb.ImportJobState_Pending, s.importMeta.GetJob(context.TODO(), job.GetJobID()).GetState())
 
 	alloc.ExpectedCalls = nil
 	alloc.EXPECT().AllocN(mock.Anything).Return(0, 0, mockErr)
 	s.checker.checkPendingJob(job)
-	preimportTasks = s.importMeta.GetTaskBy(context.TODO(), WithJob(job.GetJobID()), WithType(PreImportTaskType))
+	preimportTasks = s.importMeta.GetTaskByJob(context.TODO(), job.GetJobID(), WithType(PreImportTaskType))
 	s.Equal(0, len(preimportTasks))
 	s.Equal(internalpb.ImportJobState_Pending, s.importMeta.GetJob(context.TODO(), job.GetJobID()).GetState())
 
@@ -330,7 +330,7 @@ func (s *ImportCheckerSuite) TestCheckJob_Failed() {
 	catalog.EXPECT().SaveImportJob(mock.Anything, mock.Anything).Return(nil)
 	catalog.EXPECT().SavePreImportTask(mock.Anything, mock.Anything).Return(nil)
 	s.checker.checkPendingJob(job)
-	preimportTasks = s.importMeta.GetTaskBy(context.TODO(), WithJob(job.GetJobID()), WithType(PreImportTaskType))
+	preimportTasks = s.importMeta.GetTaskByJob(context.TODO(), job.GetJobID(), WithType(PreImportTaskType))
 	s.Equal(2, len(preimportTasks))
 	s.Equal(internalpb.ImportJobState_PreImporting, s.importMeta.GetJob(context.TODO(), job.GetJobID()).GetState())
 
@@ -350,7 +350,7 @@ func (s *ImportCheckerSuite) TestCheckJob_Failed() {
 	catalog.EXPECT().SaveImportTask(mock.Anything, mock.Anything).Return(mockErr)
 	catalog.EXPECT().SaveImportJob(mock.Anything, mock.Anything).Return(nil)
 	s.checker.checkPreImportingJob(job)
-	importTasks := s.importMeta.GetTaskBy(context.TODO(), WithJob(job.GetJobID()), WithType(ImportTaskType))
+	importTasks := s.importMeta.GetTaskByJob(context.TODO(), job.GetJobID(), WithType(ImportTaskType))
 	s.Equal(0, len(importTasks))
 	s.Equal(internalpb.ImportJobState_Failed, s.importMeta.GetJob(context.TODO(), job.GetJobID()).GetState())
 
@@ -358,7 +358,7 @@ func (s *ImportCheckerSuite) TestCheckJob_Failed() {
 	alloc.EXPECT().AllocN(mock.Anything).Return(0, 0, mockErr)
 	s.manuallyUpdateJob(job.GetJobID(), UpdateJobState(internalpb.ImportJobState_PreImporting))
 	s.checker.checkPreImportingJob(job)
-	importTasks = s.importMeta.GetTaskBy(context.TODO(), WithJob(job.GetJobID()), WithType(ImportTaskType))
+	importTasks = s.importMeta.GetTaskByJob(context.TODO(), job.GetJobID(), WithType(ImportTaskType))
 	s.Equal(0, len(importTasks))
 	s.Equal(internalpb.ImportJobState_PreImporting, s.importMeta.GetJob(context.TODO(), job.GetJobID()).GetState())
 
@@ -368,7 +368,7 @@ func (s *ImportCheckerSuite) TestCheckJob_Failed() {
 	alloc.ExpectedCalls = nil
 	alloc.EXPECT().AllocN(mock.Anything).Return(0, 0, nil)
 	s.checker.checkPreImportingJob(job)
-	importTasks = s.importMeta.GetTaskBy(context.TODO(), WithJob(job.GetJobID()), WithType(ImportTaskType))
+	importTasks = s.importMeta.GetTaskByJob(context.TODO(), job.GetJobID(), WithType(ImportTaskType))
 	s.Equal(1, len(importTasks))
 	s.Equal(internalpb.ImportJobState_Importing, s.importMeta.GetJob(context.TODO(), job.GetJobID()).GetState())
 }
@@ -413,19 +413,19 @@ func (s *ImportCheckerSuite) TestCheckFailure() {
 	s.NoError(err)
 
 	s.checker.checkFailedJob(s.importMeta.GetJob(context.TODO(), s.jobID))
-	tasks := s.importMeta.GetTaskBy(context.TODO(), WithJob(s.jobID), WithStates(datapb.ImportTaskStateV2_Failed))
+	tasks := s.importMeta.GetTaskByJob(context.TODO(), s.jobID, WithStates(datapb.ImportTaskStateV2_Failed))
 	s.Equal(1, len(tasks))
 
 	catalog.ExpectedCalls = nil
 	catalog.EXPECT().SaveImportTask(mock.Anything, mock.Anything).Return(errors.New("mock error"))
 	s.checker.checkFailedJob(s.importMeta.GetJob(context.TODO(), s.jobID))
-	tasks = s.importMeta.GetTaskBy(context.TODO(), WithJob(s.jobID), WithStates(datapb.ImportTaskStateV2_Failed))
+	tasks = s.importMeta.GetTaskByJob(context.TODO(), s.jobID, WithStates(datapb.ImportTaskStateV2_Failed))
 	s.Equal(1, len(tasks))
 
 	catalog.ExpectedCalls = nil
 	catalog.EXPECT().SaveImportTask(mock.Anything, mock.Anything).Return(nil)
 	s.checker.checkFailedJob(s.importMeta.GetJob(context.TODO(), s.jobID))
-	tasks = s.importMeta.GetTaskBy(context.TODO(), WithJob(s.jobID), WithStates(datapb.ImportTaskStateV2_Failed))
+	tasks = s.importMeta.GetTaskByJob(context.TODO(), s.jobID, WithStates(datapb.ImportTaskStateV2_Failed))
 	s.Equal(1, len(tasks))
 }
 
@@ -452,7 +452,7 @@ func (s *ImportCheckerSuite) TestCheckGC() {
 
 	// not failed or completed
 	s.checker.checkGC(s.importMeta.GetJob(context.TODO(), s.jobID))
-	s.Equal(1, len(s.importMeta.GetTaskBy(context.TODO(), WithJob(s.jobID))))
+	s.Equal(1, len(s.importMeta.GetTaskByJob(context.TODO(), s.jobID)))
 	s.Equal(1, len(s.importMeta.GetJobBy(context.TODO())))
 	catalog.EXPECT().SaveImportJob(mock.Anything, mock.Anything).Return(nil)
 	err = s.importMeta.UpdateJob(context.TODO(), s.jobID, UpdateJobState(internalpb.ImportJobState_Failed))
@@ -460,7 +460,7 @@ func (s *ImportCheckerSuite) TestCheckGC() {
 
 	// not reach cleanup ts
 	s.checker.checkGC(s.importMeta.GetJob(context.TODO(), s.jobID))
-	s.Equal(1, len(s.importMeta.GetTaskBy(context.TODO(), WithJob(s.jobID))))
+	s.Equal(1, len(s.importMeta.GetTaskByJob(context.TODO(), s.jobID)))
 	s.Equal(1, len(s.importMeta.GetJobBy(context.TODO())))
 	GCRetention := Params.DataCoordCfg.ImportTaskRetention.GetAsDuration(time.Second)
 	job := s.importMeta.GetJob(context.TODO(), s.jobID)
@@ -470,21 +470,21 @@ func (s *ImportCheckerSuite) TestCheckGC() {
 
 	// origin segment not dropped
 	s.checker.checkGC(s.importMeta.GetJob(context.TODO(), s.jobID))
-	s.Equal(1, len(s.importMeta.GetTaskBy(context.TODO(), WithJob(s.jobID))))
+	s.Equal(1, len(s.importMeta.GetTaskByJob(context.TODO(), s.jobID)))
 	s.Equal(1, len(s.importMeta.GetJobBy(context.TODO())))
 	err = s.importMeta.UpdateTask(context.TODO(), task.GetTaskID(), UpdateSegmentIDs([]int64{}))
 	s.NoError(err)
 
 	// stats segment not dropped
 	s.checker.checkGC(s.importMeta.GetJob(context.TODO(), s.jobID))
-	s.Equal(1, len(s.importMeta.GetTaskBy(context.TODO(), WithJob(s.jobID))))
+	s.Equal(1, len(s.importMeta.GetTaskByJob(context.TODO(), s.jobID)))
 	s.Equal(1, len(s.importMeta.GetJobBy(context.TODO())))
 	err = s.importMeta.UpdateTask(context.TODO(), task.GetTaskID(), UpdateStatsSegmentIDs([]int64{}))
 	s.NoError(err)
 
 	// task is not dropped
 	s.checker.checkGC(s.importMeta.GetJob(context.TODO(), s.jobID))
-	s.Equal(1, len(s.importMeta.GetTaskBy(context.TODO(), WithJob(s.jobID))))
+	s.Equal(1, len(s.importMeta.GetTaskByJob(context.TODO(), s.jobID)))
 	s.Equal(1, len(s.importMeta.GetJobBy(context.TODO())))
 	err = s.importMeta.UpdateTask(context.TODO(), task.GetTaskID(), UpdateNodeID(NullNodeID))
 	s.NoError(err)
@@ -492,7 +492,7 @@ func (s *ImportCheckerSuite) TestCheckGC() {
 	// remove task failed
 	catalog.EXPECT().DropImportTask(mock.Anything, mock.Anything).Return(mockErr)
 	s.checker.checkGC(s.importMeta.GetJob(context.TODO(), s.jobID))
-	s.Equal(1, len(s.importMeta.GetTaskBy(context.TODO(), WithJob(s.jobID))))
+	s.Equal(1, len(s.importMeta.GetTaskByJob(context.TODO(), s.jobID)))
 	s.Equal(1, len(s.importMeta.GetJobBy(context.TODO())))
 
 	// remove job failed
@@ -500,14 +500,14 @@ func (s *ImportCheckerSuite) TestCheckGC() {
 	catalog.EXPECT().DropImportTask(mock.Anything, mock.Anything).Return(nil)
 	catalog.EXPECT().DropImportJob(mock.Anything, mock.Anything).Return(mockErr)
 	s.checker.checkGC(s.importMeta.GetJob(context.TODO(), s.jobID))
-	s.Equal(0, len(s.importMeta.GetTaskBy(context.TODO(), WithJob(s.jobID))))
+	s.Equal(0, len(s.importMeta.GetTaskByJob(context.TODO(), s.jobID)))
 	s.Equal(1, len(s.importMeta.GetJobBy(context.TODO())))
 
 	// normal case
 	catalog.ExpectedCalls = nil
 	catalog.EXPECT().DropImportJob(mock.Anything, mock.Anything).Return(nil)
 	s.checker.checkGC(s.importMeta.GetJob(context.TODO(), s.jobID))
-	s.Equal(0, len(s.importMeta.GetTaskBy(context.TODO(), WithJob(s.jobID))))
+	s.Equal(0, len(s.importMeta.GetTaskByJob(context.TODO(), s.jobID)))
 	s.Equal(0, len(s.importMeta.GetJobBy(context.TODO())))
 }
 
@@ -777,7 +777,7 @@ func (s *ImportCheckerSuite) TestStateMachineProgressesWhileGCRollbackParked() {
 	s.NoError(s.importMeta.AddTask(context.TODO(), task))
 
 	s.Eventually(func() bool {
-		tasks := s.importMeta.GetTaskBy(context.TODO(), WithJob(jobB.GetJobID()))
+		tasks := s.importMeta.GetTaskByJob(context.TODO(), jobB.GetJobID())
 		return len(tasks) == 1 && tasks[0].GetState() == datapb.ImportTaskStateV2_Failed
 	}, 10*time.Second, 20*time.Millisecond)
 }
@@ -979,7 +979,7 @@ func TestImportCheckerCompaction(t *testing.T) {
 	catalog.EXPECT().SaveImportJob(mock.Anything, mock.Anything).Return(nil).Once()
 	assert.Eventually(t, func() bool {
 		job := importMeta.GetJob(context.TODO(), jobID)
-		preimportTasks := importMeta.GetTaskBy(context.TODO(), WithJob(job.GetJobID()), WithType(PreImportTaskType))
+		preimportTasks := importMeta.GetTaskByJob(context.TODO(), job.GetJobID(), WithType(PreImportTaskType))
 		taskLen := len(preimportTasks)
 		mlog.Info(context.TODO(), "job pre-importing", mlog.Any("taskLen", taskLen), mlog.Any("jobState", job.GetState()))
 		return taskLen == 2 && job.GetState() == internalpb.ImportJobState_PreImporting
@@ -990,7 +990,7 @@ func TestImportCheckerCompaction(t *testing.T) {
 	catalog.EXPECT().SaveImportTask(mock.Anything, mock.Anything).Return(nil).Once()
 	catalog.EXPECT().SavePreImportTask(mock.Anything, mock.Anything).Return(nil).Twice()
 	catalog.EXPECT().SaveImportJob(mock.Anything, mock.Anything).Return(nil).Once()
-	preimportTasks := importMeta.GetTaskBy(context.TODO(), WithJob(job.GetJobID()), WithType(PreImportTaskType))
+	preimportTasks := importMeta.GetTaskByJob(context.TODO(), job.GetJobID(), WithType(PreImportTaskType))
 	fileStats := []*datapb.ImportFileStats{
 		{
 			TotalRows: 100,
@@ -1003,7 +1003,7 @@ func TestImportCheckerCompaction(t *testing.T) {
 	}
 	assert.Eventually(t, func() bool {
 		job := importMeta.GetJob(context.TODO(), jobID)
-		importTasks := importMeta.GetTaskBy(context.TODO(), WithJob(job.GetJobID()), WithType(ImportTaskType))
+		importTasks := importMeta.GetTaskByJob(context.TODO(), job.GetJobID(), WithType(ImportTaskType))
 		return len(importTasks) == 1 && job.GetState() == internalpb.ImportJobState_Importing
 	}, 2*time.Second, 100*time.Millisecond)
 	mlog.Info(context.TODO(), "job importing")
@@ -1016,7 +1016,7 @@ func TestImportCheckerCompaction(t *testing.T) {
 	catalog.EXPECT().SaveChannelCheckpoint(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 	catalog.EXPECT().SaveImportJob(mock.Anything, mock.Anything).Return(nil).Once()
 	catalog.EXPECT().SaveImportTask(mock.Anything, mock.Anything).Return(nil).Once()
-	importTasks := importMeta.GetTaskBy(context.TODO(), WithJob(job.GetJobID()), WithType(ImportTaskType))
+	importTasks := importMeta.GetTaskByJob(context.TODO(), job.GetJobID(), WithType(ImportTaskType))
 	targetSegmentIDs := make([]int64, 0)
 	for _, it := range importTasks {
 		segment := &SegmentInfo{
@@ -1206,7 +1206,7 @@ func (s *ImportCheckerSuite) TestCheckPreImporting_EmptyImport_AutoCommitFalse()
 	s.Equal(internalpb.ImportJobState_PreImporting, s.importMeta.GetJob(context.TODO(), s.jobID).GetState())
 
 	// Mark all pre-import tasks completed with totalRows == 0 (empty import).
-	preimportTasks := s.importMeta.GetTaskBy(context.TODO(), WithJob(s.jobID), WithType(PreImportTaskType))
+	preimportTasks := s.importMeta.GetTaskByJob(context.TODO(), s.jobID, WithType(PreImportTaskType))
 	for _, t := range preimportTasks {
 		err := s.importMeta.UpdateTask(context.TODO(), t.GetTaskID(),
 			UpdateState(datapb.ImportTaskStateV2_Completed),
@@ -1240,7 +1240,7 @@ func (s *ImportCheckerSuite) TestCheckPreImporting_EmptyImport_AutoCommitTrue() 
 	s.Equal(internalpb.ImportJobState_PreImporting, s.importMeta.GetJob(context.TODO(), s.jobID).GetState())
 
 	// Mark all pre-import tasks completed with totalRows == 0 (empty import).
-	preimportTasks := s.importMeta.GetTaskBy(context.TODO(), WithJob(s.jobID), WithType(PreImportTaskType))
+	preimportTasks := s.importMeta.GetTaskByJob(context.TODO(), s.jobID, WithType(PreImportTaskType))
 	for _, t := range preimportTasks {
 		err := s.importMeta.UpdateTask(context.TODO(), t.GetTaskID(),
 			UpdateState(datapb.ImportTaskStateV2_Completed),

--- a/internal/datacoord/import_inspector.go
+++ b/internal/datacoord/import_inspector.go
@@ -82,41 +82,46 @@ func (s *importInspector) Close() {
 }
 
 func (s *importInspector) reloadFromMeta() {
-	jobs := s.importMeta.GetJobBy(s.ctx)
-	sort.Slice(jobs, func(i, j int) bool {
-		return jobs[i].GetJobID() < jobs[j].GetJobID()
-	})
-	for _, job := range jobs {
-		tasks := s.importMeta.GetTaskBy(s.ctx, WithJob(job.GetJobID()))
-		for _, task := range tasks {
-			if task.GetState() == datapb.ImportTaskStateV2_InProgress {
-				s.scheduler.Enqueue(task)
-			}
+	tasks := s.importMeta.GetTaskBy(s.ctx, WithStates(datapb.ImportTaskStateV2_InProgress))
+	sortImportTasks(tasks)
+	for _, task := range tasks {
+		if s.importMeta.GetJob(s.ctx, task.GetJobID()) != nil {
+			s.scheduler.Enqueue(task)
 		}
 	}
 }
 
 func (s *importInspector) inspect() {
-	jobs := s.importMeta.GetJobBy(s.ctx)
-	sort.Slice(jobs, func(i, j int) bool {
-		return jobs[i].GetJobID() < jobs[j].GetJobID()
-	})
-	for _, job := range jobs {
-		tasks := s.importMeta.GetTaskBy(s.ctx, WithJob(job.GetJobID()))
-		for _, task := range tasks {
-			switch task.GetState() {
-			case datapb.ImportTaskStateV2_Pending:
-				switch task.GetType() {
-				case PreImportTaskType:
-					s.processPendingPreImport(task)
-				case ImportTaskType:
-					s.processPendingImport(task)
-				}
-			case datapb.ImportTaskStateV2_Failed:
-				s.processFailed(task)
+	tasks := s.importMeta.GetTaskBy(s.ctx, WithStates(
+		datapb.ImportTaskStateV2_Pending,
+		datapb.ImportTaskStateV2_Failed,
+	))
+	sortImportTasks(tasks)
+	for _, task := range tasks {
+		if s.importMeta.GetJob(s.ctx, task.GetJobID()) == nil {
+			continue
+		}
+		switch task.GetState() {
+		case datapb.ImportTaskStateV2_Pending:
+			switch task.GetType() {
+			case PreImportTaskType:
+				s.processPendingPreImport(task)
+			case ImportTaskType:
+				s.processPendingImport(task)
 			}
+		case datapb.ImportTaskStateV2_Failed:
+			s.processFailed(task)
 		}
 	}
+}
+
+func sortImportTasks(tasks []ImportTask) {
+	sort.Slice(tasks, func(i, j int) bool {
+		if tasks[i].GetJobID() == tasks[j].GetJobID() {
+			return tasks[i].GetTaskID() < tasks[j].GetTaskID()
+		}
+		return tasks[i].GetJobID() < tasks[j].GetJobID()
+	})
 }
 
 func (s *importInspector) processPendingPreImport(task ImportTask) {

--- a/internal/datacoord/import_inspector_test.go
+++ b/internal/datacoord/import_inspector_test.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
@@ -329,6 +330,64 @@ func (s *ImportInspectorSuite) TestReloadFromMeta() {
 	// Mock scheduler expectations
 	s.inspector.scheduler.(*task2.MockGlobalScheduler).EXPECT().Enqueue(mock.Anything).Times(2)
 	s.inspector.reloadFromMeta()
+}
+
+func (s *ImportInspectorSuite) TestIgnoreOrphanTasks() {
+	newTask := func(taskID int64, state datapb.ImportTaskStateV2, segmentIDs ...int64) ImportTask {
+		task := &importTask{
+			importMeta: s.importMeta,
+			tr:         timerecord.NewTimeRecorder("import task"),
+		}
+		task.task.Store(&datapb.ImportTaskV2{
+			JobID:        100,
+			TaskID:       taskID,
+			CollectionID: s.collectionID,
+			State:        state,
+			SegmentIDs:   segmentIDs,
+		})
+		return task
+	}
+
+	s.catalog.EXPECT().SaveImportTask(mock.Anything, mock.Anything).Return(nil).Times(3)
+	s.NoError(s.importMeta.AddTask(context.TODO(), newTask(1, datapb.ImportTaskStateV2_InProgress)))
+	s.NoError(s.importMeta.AddTask(context.TODO(), newTask(2, datapb.ImportTaskStateV2_Pending)))
+	s.NoError(s.importMeta.AddTask(context.TODO(), newTask(3, datapb.ImportTaskStateV2_Failed, 10)))
+
+	s.catalog.EXPECT().AddSegment(mock.Anything, mock.Anything).Return(nil)
+	s.NoError(s.meta.AddSegment(context.TODO(), &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:          10,
+			State:       commonpb.SegmentState_Importing,
+			IsImporting: true,
+		},
+	}))
+
+	// Orphan tasks are skipped just as they were when the inspector iterated jobs first.
+	s.inspector.reloadFromMeta()
+	s.inspector.inspect()
+	s.Equal(commonpb.SegmentState_Importing, s.meta.GetSegment(context.TODO(), 10).GetState())
+}
+
+func (s *ImportInspectorSuite) TestSortImportTasks() {
+	newTask := func(jobID, taskID int64) ImportTask {
+		task := &importTask{}
+		task.task.Store(&datapb.ImportTaskV2{JobID: jobID, TaskID: taskID})
+		return task
+	}
+	tasks := []ImportTask{
+		newTask(2, 4),
+		newTask(1, 3),
+		newTask(2, 2),
+		newTask(1, 1),
+	}
+
+	sortImportTasks(tasks)
+	s.Equal([]int64{1, 1, 2, 2}, lo.Map(tasks, func(task ImportTask, _ int) int64 {
+		return task.GetJobID()
+	}))
+	s.Equal([]int64{1, 3, 2, 4}, lo.Map(tasks, func(task ImportTask, _ int) int64 {
+		return task.GetTaskID()
+	}))
 }
 
 func TestImportInspector(t *testing.T) {

--- a/internal/datacoord/import_meta.go
+++ b/internal/datacoord/import_meta.go
@@ -47,19 +47,22 @@ type ImportMeta interface {
 	UpdateTask(ctx context.Context, taskID int64, actions ...UpdateAction) error
 	GetTask(ctx context.Context, taskID int64) ImportTask
 	GetTaskBy(ctx context.Context, filters ...ImportTaskFilter) []ImportTask
+	GetTaskByJob(ctx context.Context, jobID int64, filters ...ImportTaskFilter) []ImportTask
 	RemoveTask(ctx context.Context, taskID int64) error
 	TaskStatsJSON(ctx context.Context) string
 }
 
 type importTasks struct {
-	tasks     map[int64]ImportTask
-	taskStats *expirable.LRU[int64, ImportTask]
+	tasks          map[int64]ImportTask
+	taskIDsByJobID map[int64]map[int64]struct{}
+	taskStats      *expirable.LRU[int64, ImportTask]
 }
 
 func newImportTasks() *importTasks {
 	return &importTasks{
-		tasks:     make(map[int64]ImportTask),
-		taskStats: expirable.NewLRU[UniqueID, ImportTask](512, nil, time.Minute*30),
+		tasks:          make(map[int64]ImportTask),
+		taskIDsByJobID: make(map[int64]map[int64]struct{}),
+		taskStats:      expirable.NewLRU[UniqueID, ImportTask](512, nil, time.Minute*30),
 	}
 }
 
@@ -72,20 +75,49 @@ func (t *importTasks) get(taskID int64) ImportTask {
 }
 
 func (t *importTasks) add(task ImportTask) {
-	t.tasks[task.GetTaskID()] = task
-	t.taskStats.Add(task.GetTaskID(), task)
+	taskID := task.GetTaskID()
+	jobID := task.GetJobID()
+	if oldTask, ok := t.tasks[taskID]; ok && oldTask.GetJobID() != jobID {
+		t.removeFromJob(oldTask.GetJobID(), taskID)
+	}
+	t.tasks[taskID] = task
+	if _, ok := t.taskIDsByJobID[jobID]; !ok {
+		t.taskIDsByJobID[jobID] = make(map[int64]struct{})
+	}
+	t.taskIDsByJobID[jobID][taskID] = struct{}{}
+	t.taskStats.Add(taskID, task)
 }
 
 func (t *importTasks) remove(taskID int64) {
 	task, ok := t.tasks[taskID]
 	if ok {
 		delete(t.tasks, taskID)
+		t.removeFromJob(task.GetJobID(), taskID)
 		t.taskStats.Add(task.GetTaskID(), task)
+	}
+}
+
+func (t *importTasks) removeFromJob(jobID, taskID int64) {
+	taskIDs := t.taskIDsByJobID[jobID]
+	delete(taskIDs, taskID)
+	if len(taskIDs) == 0 {
+		delete(t.taskIDsByJobID, jobID)
 	}
 }
 
 func (t *importTasks) listTasks() []ImportTask {
 	return maps.Values(t.tasks)
+}
+
+func (t *importTasks) listTasksByJob(jobID int64) []ImportTask {
+	taskIDs := t.taskIDsByJobID[jobID]
+	tasks := make([]ImportTask, 0, len(taskIDs))
+	for taskID := range taskIDs {
+		if task, ok := t.tasks[taskID]; ok {
+			tasks = append(tasks, task)
+		}
+	}
+	return tasks
 }
 
 func (t *importTasks) listTaskStats() []ImportTask {
@@ -294,9 +326,19 @@ func (m *importMeta) GetTask(ctx context.Context, taskID int64) ImportTask {
 func (m *importMeta) GetTaskBy(ctx context.Context, filters ...ImportTaskFilter) []ImportTask {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+	return filterImportTasks(m.tasks.listTasks(), filters...)
+}
+
+func (m *importMeta) GetTaskByJob(ctx context.Context, jobID int64, filters ...ImportTaskFilter) []ImportTask {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return filterImportTasks(m.tasks.listTasksByJob(jobID), filters...)
+}
+
+func filterImportTasks(tasks []ImportTask, filters ...ImportTaskFilter) []ImportTask {
 	ret := make([]ImportTask, 0)
 OUTER:
-	for _, task := range m.tasks.listTasks() {
+	for _, task := range tasks {
 		for _, f := range filters {
 			if !f(task) {
 				continue OUTER

--- a/internal/datacoord/import_meta_test.go
+++ b/internal/datacoord/import_meta_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/errors"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
@@ -55,6 +56,8 @@ func TestImportMeta_Restore(t *testing.T) {
 	tasks = im.GetTaskBy(ctx, WithType(ImportTaskType))
 	assert.Equal(t, 1, len(tasks))
 	assert.Equal(t, int64(2), tasks[0].GetTaskID())
+	tasks = im.GetTaskByJob(ctx, 0)
+	assert.Equal(t, 2, len(tasks))
 
 	// new meta failed
 	mockErr := errors.New("mock error")
@@ -228,8 +231,12 @@ func TestImportMeta_ImportTask(t *testing.T) {
 	err = im.AddTask(context.TODO(), task2)
 	assert.NoError(t, err)
 
-	tasks := im.GetTaskBy(context.TODO(), WithJob(task1.GetJobID()))
+	tasks := im.GetTaskByJob(context.TODO(), task1.GetJobID())
 	assert.Equal(t, 2, len(tasks))
+	tasks = im.GetTaskByJob(context.TODO(), task1.GetJobID(), WithStates(datapb.ImportTaskStateV2_Completed))
+	assert.Equal(t, 1, len(tasks))
+	assert.Equal(t, task2.GetTaskID(), tasks[0].GetTaskID())
+	assert.Empty(t, im.GetTaskByJob(context.TODO(), 100))
 	tasks = im.GetTaskBy(context.TODO(), WithType(ImportTaskType), WithStates(datapb.ImportTaskStateV2_Completed))
 	assert.Equal(t, 1, len(tasks))
 	assert.Equal(t, task2.GetTaskID(), tasks[0].GetTaskID())
@@ -256,10 +263,96 @@ func TestImportMeta_ImportTask(t *testing.T) {
 	assert.NoError(t, err)
 	tasks = im.GetTaskBy(context.TODO())
 	assert.Equal(t, 1, len(tasks))
+	assert.Equal(t, 1, len(im.GetTaskByJob(context.TODO(), task1.GetJobID())))
 	err = im.RemoveTask(context.TODO(), 10)
 	assert.NoError(t, err)
 	tasks = im.GetTaskBy(context.TODO())
 	assert.Equal(t, 1, len(tasks))
+}
+
+func TestImportTasksByJobIndex(t *testing.T) {
+	tasks := newImportTasks()
+	newTask := func(jobID, taskID int64) ImportTask {
+		task := &importTask{}
+		task.task.Store(&datapb.ImportTaskV2{JobID: jobID, TaskID: taskID})
+		return task
+	}
+
+	tasks.add(newTask(10, 1))
+	tasks.add(newTask(10, 2))
+	tasks.add(newTask(20, 3))
+	assert.ElementsMatch(t, []int64{1, 2}, lo.Map(tasks.listTasksByJob(10), func(task ImportTask, _ int) int64 {
+		return task.GetTaskID()
+	}))
+	assert.ElementsMatch(t, []int64{3}, lo.Map(tasks.listTasksByJob(20), func(task ImportTask, _ int) int64 {
+		return task.GetTaskID()
+	}))
+
+	// Re-adding an existing task ID under a different job keeps both indexes consistent.
+	tasks.add(newTask(20, 1))
+	assert.ElementsMatch(t, []int64{2}, lo.Map(tasks.listTasksByJob(10), func(task ImportTask, _ int) int64 {
+		return task.GetTaskID()
+	}))
+	assert.ElementsMatch(t, []int64{1, 3}, lo.Map(tasks.listTasksByJob(20), func(task ImportTask, _ int) int64 {
+		return task.GetTaskID()
+	}))
+
+	tasks.remove(1)
+	assert.ElementsMatch(t, []int64{3}, lo.Map(tasks.listTasksByJob(20), func(task ImportTask, _ int) int64 {
+		return task.GetTaskID()
+	}))
+	tasks.remove(3)
+	assert.Empty(t, tasks.listTasksByJob(20))
+	assert.NotContains(t, tasks.taskIDsByJobID, int64(20))
+
+	// Moving the only task of a job removes the old empty index bucket.
+	tasks.add(newTask(30, 4))
+	tasks.add(newTask(40, 4))
+	assert.Empty(t, tasks.listTasksByJob(30))
+	assert.NotContains(t, tasks.taskIDsByJobID, int64(30))
+	assert.ElementsMatch(t, []int64{4}, lo.Map(tasks.listTasksByJob(40), func(task ImportTask, _ int) int64 {
+		return task.GetTaskID()
+	}))
+}
+
+func BenchmarkImportTaskLookupByJob(b *testing.B) {
+	for _, jobCount := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("jobs_%d", jobCount), func(b *testing.B) {
+			tasks := newImportTasks()
+			for jobID := range jobCount {
+				for taskOffset := range 2 {
+					task := &importTask{}
+					task.task.Store(&datapb.ImportTaskV2{
+						JobID:  int64(jobID),
+						TaskID: int64(jobID*2 + taskOffset),
+					})
+					tasks.add(task)
+				}
+			}
+			targetJobID := int64(jobCount - 1)
+
+			b.Run("full_scan", func(b *testing.B) {
+				b.ReportAllocs()
+				for range b.N {
+					result := filterImportTasks(tasks.listTasks(), func(task ImportTask) bool {
+						return task.GetJobID() == targetJobID
+					})
+					if len(result) != 2 {
+						b.Fatalf("expected 2 tasks, got %d", len(result))
+					}
+				}
+			})
+			b.Run("job_index", func(b *testing.B) {
+				b.ReportAllocs()
+				for range b.N {
+					result := filterImportTasks(tasks.listTasksByJob(targetJobID))
+					if len(result) != 2 {
+						b.Fatalf("expected 2 tasks, got %d", len(result))
+					}
+				}
+			})
+		})
+	}
 }
 
 func TestImportMeta_Task_Failed(t *testing.T) {

--- a/internal/datacoord/import_task.go
+++ b/internal/datacoord/import_task.go
@@ -46,12 +46,6 @@ func WithType(taskType TaskType) ImportTaskFilter {
 	}
 }
 
-func WithJob(jobID int64) ImportTaskFilter {
-	return func(task ImportTask) bool {
-		return task.GetJobID() == jobID
-	}
-}
-
 func WithStates(states ...datapb.ImportTaskStateV2) ImportTaskFilter {
 	return func(task ImportTask) bool {
 		for _, state := range states {

--- a/internal/datacoord/import_util.go
+++ b/internal/datacoord/import_util.go
@@ -447,7 +447,7 @@ func CheckDiskQuota(ctx context.Context, job ImportJob, meta *meta, importMeta I
 	quotaInfo := meta.GetQuotaInfo()
 	totalUsage, collectionsUsage := quotaInfo.TotalBinlogSize, quotaInfo.CollectionBinlogSize
 
-	tasks := importMeta.GetTaskBy(ctx, WithJob(job.GetJobID()), WithType(PreImportTaskType))
+	tasks := importMeta.GetTaskByJob(ctx, job.GetJobID(), WithType(PreImportTaskType))
 	files := make([]*datapb.ImportFileStats, 0)
 	for _, task := range tasks {
 		files = append(files, task.GetFileStats()...)
@@ -481,7 +481,7 @@ func CheckDiskQuota(ctx context.Context, job ImportJob, meta *meta, importMeta I
 }
 
 func getPendingProgress(ctx context.Context, jobID int64, importMeta ImportMeta) float32 {
-	tasks := importMeta.GetTaskBy(context.TODO(), WithJob(jobID), WithType(PreImportTaskType))
+	tasks := importMeta.GetTaskByJob(context.TODO(), jobID, WithType(PreImportTaskType))
 	preImportingFiles := lo.SumBy(tasks, func(task ImportTask) int {
 		return len(task.GetFileStats())
 	})
@@ -493,7 +493,7 @@ func getPendingProgress(ctx context.Context, jobID int64, importMeta ImportMeta)
 }
 
 func getPreImportingProgress(ctx context.Context, jobID int64, importMeta ImportMeta) float32 {
-	tasks := importMeta.GetTaskBy(ctx, WithJob(jobID), WithType(PreImportTaskType))
+	tasks := importMeta.GetTaskByJob(ctx, jobID, WithType(PreImportTaskType))
 	completedTasks := lo.Filter(tasks, func(task ImportTask, _ int) bool {
 		return task.GetState() == datapb.ImportTaskStateV2_Completed
 	})
@@ -504,7 +504,7 @@ func getPreImportingProgress(ctx context.Context, jobID int64, importMeta Import
 }
 
 func getImportRowsInfo(ctx context.Context, jobID int64, importMeta ImportMeta, meta *meta) (importedRows, totalRows int64) {
-	tasks := importMeta.GetTaskBy(ctx, WithJob(jobID), WithType(ImportTaskType))
+	tasks := importMeta.GetTaskByJob(ctx, jobID, WithType(ImportTaskType))
 	segmentIDs := make([]int64, 0)
 	for _, task := range tasks {
 		totalRows += lo.SumBy(task.GetFileStats(), func(file *datapb.ImportFileStats) int64 {
@@ -528,7 +528,7 @@ func getStatsProgress(ctx context.Context, jobID int64, importMeta ImportMeta, m
 	if !enableSortCompaction() {
 		return 1
 	}
-	tasks := importMeta.GetTaskBy(ctx, WithJob(jobID), WithType(ImportTaskType))
+	tasks := importMeta.GetTaskByJob(ctx, jobID, WithType(ImportTaskType))
 	targetSegmentIDs := lo.FlatMap(tasks, func(t ImportTask, _ int) []int64 {
 		return t.(*importTask).GetSortedSegmentIDs()
 	})
@@ -550,7 +550,7 @@ func getIndexBuildingProgress(ctx context.Context, jobID int64, importMeta Impor
 	if !Params.DataCoordCfg.WaitForIndex.GetAsBool() {
 		return 1
 	}
-	tasks := importMeta.GetTaskBy(ctx, WithJob(jobID), WithType(ImportTaskType))
+	tasks := importMeta.GetTaskByJob(ctx, jobID, WithType(ImportTaskType))
 	originSegmentIDs := lo.FlatMap(tasks, func(t ImportTask, _ int) []int64 {
 		return t.(*importTask).GetSegmentIDs()
 	})
@@ -633,7 +633,7 @@ func GetJobProgress(ctx context.Context, jobID int64,
 
 func GetTaskProgresses(ctx context.Context, jobID int64, importMeta ImportMeta, meta *meta) []*internalpb.ImportTaskProgress {
 	progresses := make([]*internalpb.ImportTaskProgress, 0)
-	tasks := importMeta.GetTaskBy(ctx, WithJob(jobID), WithType(ImportTaskType))
+	tasks := importMeta.GetTaskByJob(ctx, jobID, WithType(ImportTaskType))
 	for _, task := range tasks {
 		totalRows := lo.SumBy(task.GetFileStats(), func(file *datapb.ImportFileStats) int64 {
 			return file.GetTotalRows()

--- a/internal/datacoord/mock_import_meta.go
+++ b/internal/datacoord/mock_import_meta.go
@@ -400,6 +400,70 @@ func (_c *MockImportMeta_GetTaskBy_Call) RunAndReturn(run func(context.Context, 
 	return _c
 }
 
+// GetTaskByJob provides a mock function with given fields: ctx, jobID, filters
+func (_m *MockImportMeta) GetTaskByJob(ctx context.Context, jobID int64, filters ...ImportTaskFilter) []ImportTask {
+	_va := make([]interface{}, len(filters))
+	for _i := range filters {
+		_va[_i] = filters[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, jobID)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTaskByJob")
+	}
+
+	var r0 []ImportTask
+	if rf, ok := ret.Get(0).(func(context.Context, int64, ...ImportTaskFilter) []ImportTask); ok {
+		r0 = rf(ctx, jobID, filters...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]ImportTask)
+		}
+	}
+
+	return r0
+}
+
+// MockImportMeta_GetTaskByJob_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTaskByJob'
+type MockImportMeta_GetTaskByJob_Call struct {
+	*mock.Call
+}
+
+// GetTaskByJob is a helper method to define mock.On call
+//   - ctx context.Context
+//   - jobID int64
+//   - filters ...ImportTaskFilter
+func (_e *MockImportMeta_Expecter) GetTaskByJob(ctx interface{}, jobID interface{}, filters ...interface{}) *MockImportMeta_GetTaskByJob_Call {
+	return &MockImportMeta_GetTaskByJob_Call{Call: _e.mock.On("GetTaskByJob",
+		append([]interface{}{ctx, jobID}, filters...)...)}
+}
+
+func (_c *MockImportMeta_GetTaskByJob_Call) Run(run func(ctx context.Context, jobID int64, filters ...ImportTaskFilter)) *MockImportMeta_GetTaskByJob_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]ImportTaskFilter, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(ImportTaskFilter)
+			}
+		}
+		run(args[0].(context.Context), args[1].(int64), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockImportMeta_GetTaskByJob_Call) Return(_a0 []ImportTask) *MockImportMeta_GetTaskByJob_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockImportMeta_GetTaskByJob_Call) RunAndReturn(run func(context.Context, int64, ...ImportTaskFilter) []ImportTask) *MockImportMeta_GetTaskByJob_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // HandleCommitVchannel provides a mock function with given fields: ctx, jobID, vchannel, callback
 func (_m *MockImportMeta) HandleCommitVchannel(ctx context.Context, jobID int64, vchannel string, callback func() error) error {
 	ret := _m.Called(ctx, jobID, vchannel, callback)
@@ -718,7 +782,8 @@ func (_c *MockImportMeta_UpdateTask_Call) RunAndReturn(run func(context.Context,
 func NewMockImportMeta(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockImportMeta {
+},
+) *MockImportMeta {
 	mock := &MockImportMeta{}
 	mock.Mock.Test(t)
 

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -3221,7 +3221,7 @@ func (s *Server) HandleCommitVchannel(ctx context.Context, req *datapb.HandleCom
 // the given import job that are assigned to the given vchannel.
 // This must be called BEFORE acquiring importMeta's mutex (i.e., before HandleCommitVchannel).
 func (s *Server) getImportSegmentIDsByVchannel(ctx context.Context, jobID int64, vchannel string) []int64 {
-	tasks := s.importMeta.GetTaskBy(ctx, WithJob(jobID), WithType(ImportTaskType))
+	tasks := s.importMeta.GetTaskByJob(ctx, jobID, WithType(ImportTaskType))
 	var segIDs []int64
 	for _, task := range tasks {
 		it, ok := task.(*importTask)


### PR DESCRIPTION
## Summary

Fixes #52867

Optimize DataCoord import task lookup for clusters with many import jobs and retained tasks.

- Maintain a `jobID -> taskIDs` secondary index alongside import task metadata.
- Add `GetTaskByJob` for indexed job-scoped queries and remove the scan-based `WithJob` filter.
- Scan actionable task states once per Import Inspector cycle instead of scanning all tasks for every job.
- Preserve job/task processing order and skip orphan tasks whose job metadata is absent.
- Keep the secondary index consistent during restoration, replacement, and removal.

## Performance

Local benchmark with 10,000 jobs and two tasks per job:

```text
full_scan    ~990 us/op    327728 B/op
job_index    ~0.25 us/op       80 B/op
```

The indexed lookup remains effectively constant as unrelated task count grows.

## Test Plan

- [x] Import-related DataCoord unit tests
- [x] Secondary-index replacement and removal regression tests
- [x] Inspector orphan-task and deterministic-order regression tests
- [x] `make build-go`
- [x] `make static-check` (core, pkg, client, and go_client e2e: 0 issues)
- [x] `git diff --check` and gofumpt

## Local Test Note

A full `internal/datacoord` package run also reaches a pre-existing, unrelated failure in `TestCompactionTriggerManagerSuite/TestGetExpectedSegmentSize/all_DISKANN` (expected 200 MiB, actual 100 MiB). The failure reproduces when run in isolation without this change.