### PR TITLE
fix: keep owned copy of JSON default value and stop strlen on non-NUL-terminated views

### DIFF
--- a/internal/core/src/common/FieldDataInterface.h
+++ b/internal/core/src/common/FieldDataInterface.h
@@ -809,7 +809,9 @@ class FieldDataJsonImpl : public FieldDataImpl<Json, true> {
                        "json type default_value shall be bytes data");
 
             auto data = default_value->bytes_data();
-            Json default_json = Json(simdjson::padded_string(data));
+            auto buffer = std::make_shared<simdjson::padded_string>(data);
+            Json default_json(buffer->data(), buffer->size());
+            shared_json_buffers_.emplace_back(std::move(buffer));
             std::fill(data_.data() + length_,
                       data_.data() + length_ + element_count,
                       default_json);
@@ -872,6 +874,14 @@ class FieldDataJsonImpl : public FieldDataImpl<Json, true> {
         }
         length_ += json.size();
     }
+
+ private:
+    // Buffers backing the non-owning Json views of rows filled from a
+    // default value. One buffer is appended per FillFieldData(default_value,
+    // ...) call and kept alive for the FieldData lifetime, so all rows
+    // filled by a call share a single copy instead of allocating one per
+    // row.
+    std::vector<std::shared_ptr<simdjson::padded_string>> shared_json_buffers_;
 };
 
 class FieldDataArrayImpl : public FieldDataImpl<Array, true> {

--- a/internal/core/src/common/FieldDataInterface.h
+++ b/internal/core/src/common/FieldDataInterface.h
@@ -809,7 +809,7 @@ class FieldDataJsonImpl : public FieldDataImpl<Json, true> {
                        "json type default_value shall be bytes data");
 
             auto data = default_value->bytes_data();
-            Json default_json = Json(data.data(), data.size());
+            Json default_json = Json(simdjson::padded_string(data));
             std::fill(data_.data() + length_,
                       data_.data() + length_ + element_count,
                       default_json);

--- a/internal/core/src/index/json_stats/JsonKeyStats.cpp
+++ b/internal/core/src/index/json_stats/JsonKeyStats.cpp
@@ -330,7 +330,7 @@ JsonKeyStats::TraverseJsonForStats(const char* json,
 
 void
 JsonKeyStats::CollectSingleJsonStatsInfo(
-    const char* json_str, std::map<JsonKey, KeyStatsInfo>& infos) {
+    std::string_view json_str, std::map<JsonKey, KeyStatsInfo>& infos) {
     jsmn_parser parser;
     jsmn_init(&parser);
 
@@ -339,8 +339,11 @@ JsonKeyStats::CollectSingleJsonStatsInfo(
     std::vector<jsmntok_t> tokens(token_capacity);
 
     while (1) {
-        int r = jsmn_parse(
-            &parser, json_str, strlen(json_str), tokens.data(), token_capacity);
+        int r = jsmn_parse(&parser,
+                           json_str.data(),
+                           json_str.size(),
+                           tokens.data(),
+                           token_capacity);
         if (r < 0) {
             if (r == JSMN_ERROR_NOMEM) {
                 // Reallocate tokens array if not enough space
@@ -364,7 +367,7 @@ JsonKeyStats::CollectSingleJsonStatsInfo(
 
     int index = 0;
     std::vector<std::string> paths;
-    TraverseJsonForStats(json_str, tokens.data(), index, paths, infos);
+    TraverseJsonForStats(json_str.data(), tokens.data(), index, paths, infos);
 }
 
 std::map<JsonKey, KeyStatsInfo>
@@ -378,9 +381,8 @@ JsonKeyStats::CollectKeyInfo(const std::vector<FieldDataPtr>& field_datas,
             if ((nullable || data->IsNullable()) && !data->is_valid(i)) {
                 continue;
             }
-            auto json_str = static_cast<const milvus::Json*>(data->RawValue(i))
-                                ->data()
-                                .data();
+            auto json_str =
+                static_cast<const milvus::Json*>(data->RawValue(i))->data();
             CollectSingleJsonStatsInfo(json_str, infos);
         }
         num_rows += n;
@@ -612,7 +614,7 @@ JsonKeyStats::BuildKeyStatsForNullRow() {
 }
 
 void
-JsonKeyStats::BuildKeyStatsForRow(const char* json_str, uint32_t row_id) {
+JsonKeyStats::BuildKeyStatsForRow(std::string_view json_str, uint32_t row_id) {
     LOG_TRACE("build key stats for row {} with json {} for segment {}",
               row_id,
               json_str,
@@ -625,8 +627,11 @@ JsonKeyStats::BuildKeyStatsForRow(const char* json_str, uint32_t row_id) {
     std::vector<jsmntok_t> tokens(token_capacity);
 
     while (1) {
-        int r = jsmn_parse(
-            &parser, json_str, strlen(json_str), tokens.data(), token_capacity);
+        int r = jsmn_parse(&parser,
+                           json_str.data(),
+                           json_str.size(),
+                           tokens.data(),
+                           token_capacity);
         if (r < 0) {
             if (r == JSMN_ERROR_NOMEM) {
                 // Reallocate tokens array if not enough space
@@ -651,7 +656,8 @@ JsonKeyStats::BuildKeyStatsForRow(const char* json_str, uint32_t row_id) {
     int index = 0;
     std::vector<std::string> paths;
     std::map<JsonKey, std::string> values;
-    TraverseJsonForBuildStats(json_str, tokens.data(), index, paths, values);
+    TraverseJsonForBuildStats(
+        json_str.data(), tokens.data(), index, paths, values);
     DomNode root;
     std::set<JsonKey> hit_keys;
     for (const auto& [key, value] : values) {
@@ -716,13 +722,11 @@ JsonKeyStats::BuildKeyStats(const std::vector<FieldDataPtr>& field_datas,
                 BuildKeyStatsForNullRow();
             } else {
                 auto json_str =
-                    static_cast<const milvus::Json*>(data->RawValue(i))
-                        ->data()
-                        .data();
+                    static_cast<const milvus::Json*>(data->RawValue(i))->data();
 
                 // some situations, such as empty json string,
                 // should be handled as null row
-                if (strlen(json_str) == 0) {
+                if (json_str.empty()) {
                     BuildKeyStatsForNullRow();
                 } else {
                     BuildKeyStatsForRow(json_str, row_id);

--- a/internal/core/src/index/json_stats/JsonKeyStats.h
+++ b/internal/core/src/index/json_stats/JsonKeyStats.h
@@ -427,7 +427,7 @@ class JsonKeyStats : public ScalarIndex<std::string> {
 
  private:
     void
-    CollectSingleJsonStatsInfo(const char* json_str,
+    CollectSingleJsonStatsInfo(std::string_view json_str,
                                std::map<JsonKey, KeyStatsInfo>& infos);
 
     std::string
@@ -476,7 +476,7 @@ class JsonKeyStats : public ScalarIndex<std::string> {
     BuildKeyStats(const std::vector<FieldDataPtr>& field_datas, bool nullable);
 
     void
-    BuildKeyStatsForRow(const char* json_str, uint32_t row_id);
+    BuildKeyStatsForRow(std::string_view json_str, uint32_t row_id);
 
     void
     BuildKeyStatsForNullRow();

--- a/internal/core/unittest/test_json_stats/test_traverse_json_for_build_stats.cpp
+++ b/internal/core/unittest/test_json_stats/test_traverse_json_for_build_stats.cpp
@@ -208,17 +208,6 @@ TEST(JsonFieldDataTest, FillFieldDataWithDefaultValueOwnsData) {
         milvus::DataType::JSON, milvus::DataType::NONE, false, 1, 5);
     field_data->FillFieldData(milvus::DefaultValueType{default_value}, 5);
 
-    // All filled rows must share a single owned copy: identical backing
-    // pointer, so a fill of N rows performs exactly one data copy.
-    const char* shared_ptr =
-        static_cast<const milvus::Json*>(field_data->RawValue(0))
-            ->data()
-            .data();
-    for (int i = 1; i < 5; i++) {
-        auto* json = static_cast<const milvus::Json*>(field_data->RawValue(i));
-        EXPECT_EQ(json->data().data(), shared_ptr);
-    }
-
     ClobberStackAndHeap(default_json);
 
     for (int i = 0; i < 5; i++) {

--- a/internal/core/unittest/test_json_stats/test_traverse_json_for_build_stats.cpp
+++ b/internal/core/unittest/test_json_stats/test_traverse_json_for_build_stats.cpp
@@ -201,7 +201,7 @@ TEST(JsonFieldDataTest, FillFieldDataWithDefaultValueOwnsData) {
     // FillFieldData, leaving every filled row dangling.
     std::string default_json =
         R"({"default_key": 12345, "another_key": "value"})";
-    proto::schema::ValueField default_value;
+    milvus::proto::schema::ValueField default_value;
     default_value.set_bytes_data(default_json);
 
     auto field_data = milvus::storage::CreateFieldData(

--- a/internal/core/unittest/test_json_stats/test_traverse_json_for_build_stats.cpp
+++ b/internal/core/unittest/test_json_stats/test_traverse_json_for_build_stats.cpp
@@ -205,7 +205,7 @@ TEST(JsonFieldDataTest, FillFieldDataWithDefaultValueOwnsData) {
     default_value.set_bytes_data(default_json);
 
     auto field_data = milvus::storage::CreateFieldData(
-        milvus::DataType::JSON, milvus::DataType::NONE, false, 1, 5);
+        milvus::DataType::JSON, milvus::DataType::NONE, true, 1, 5);
     field_data->FillFieldData(milvus::DefaultValueType{default_value}, 5);
 
     ClobberStackAndHeap(default_json);

--- a/internal/core/unittest/test_json_stats/test_traverse_json_for_build_stats.cpp
+++ b/internal/core/unittest/test_json_stats/test_traverse_json_for_build_stats.cpp
@@ -22,6 +22,7 @@
 #include "gtest/gtest.h"
 #include "index/json_stats/JsonKeyStats.h"
 #include "index/json_stats/utils.h"
+#include "pb/schema.pb.h"
 #include "storage/FileManager.h"
 #include "storage/Types.h"
 #include "storage/Util.h"

--- a/internal/core/unittest/test_json_stats/test_traverse_json_for_build_stats.cpp
+++ b/internal/core/unittest/test_json_stats/test_traverse_json_for_build_stats.cpp
@@ -11,9 +11,12 @@
 #include <cstring>
 #include <map>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
+#include "common/FieldDataInterface.h"
+#include "common/Json.h"
 #include "common/jsmn.h"
 #include "common/protobuf_utils.h"
 #include "gtest/gtest.h"
@@ -47,7 +50,7 @@ class CollectSingleJsonStatsInfoAccessor {
  public:
     static void
     Call(JsonKeyStats& s,
-         const char* json,
+         std::string_view json,
          std::map<JsonKey, milvus::index::KeyStatsInfo>& infos) {
         s.CollectSingleJsonStatsInfo(json, infos);
     }
@@ -146,4 +149,69 @@ TEST(CollectSingleJsonStatsInfoTest, EmptyJsonStringThrows) {
     std::map<JsonKey, milvus::index::KeyStatsInfo> infos;
     EXPECT_NO_THROW(
         { CollectSingleJsonStatsInfoAccessor::Call(stats, json, infos); });
+}
+
+TEST(CollectSingleJsonStatsInfoTest, ParsesJsonWithoutNulTerminator) {
+    // The JSON views stored in field data are string_views that are not
+    // guaranteed to be NUL-terminated. The parse must rely on the view
+    // length instead of strlen, otherwise trailing bytes leak into jsmn.
+    std::string json = R"({"a": 1, "b": "x"})";
+    std::string buffer = json;
+    buffer.append(64, '\xAB');
+
+    milvus::storage::FieldDataMeta field_meta{1, 2, 3, 100, {}};
+    milvus::storage::IndexMeta index_meta{3, 100, 1, 1};
+    milvus::storage::StorageConfig storage_config;
+    storage_config.storage_type = "local";
+    storage_config.root_path = TestLocalPath;
+    auto cm = milvus::storage::CreateChunkManager(storage_config);
+    auto fs = milvus::storage::InitArrowFileSystem(storage_config);
+    milvus::storage::FileManagerContext ctx(field_meta, index_meta, cm, fs);
+    JsonKeyStats stats(ctx, true);
+
+    std::map<JsonKey, milvus::index::KeyStatsInfo> infos;
+    EXPECT_NO_THROW(CollectSingleJsonStatsInfoAccessor::Call(
+        stats, std::string_view(buffer.data(), json.size()), infos));
+    EXPECT_NE(infos.find(JsonKey{"/a", JSONType::INT64}), infos.end());
+    EXPECT_NE(infos.find(JsonKey{"/b", JSONType::STRING}), infos.end());
+}
+
+namespace {
+
+// Overwrite the stack and recycle same-sized heap allocations so that a
+// Json view danging into a destroyed local shows up as corrupted content.
+__attribute__((noinline)) void
+ClobberStackAndHeap(const std::string& value) {
+    volatile uint8_t stack_buf[4096];
+    for (size_t i = 0; i < sizeof(stack_buf); i++) {
+        stack_buf[i] = 0xAB;
+    }
+    for (int i = 0; i < 64; i++) {
+        std::string chunk(value.size(), '\xAB');
+        (void)chunk;
+    }
+}
+
+}  // namespace
+
+TEST(JsonFieldDataTest, FillFieldDataWithDefaultValueOwnsData) {
+    // Regression test for #52843: the default value used to be stored as a
+    // non-owning Json view onto a local std::string that dies with
+    // FillFieldData, leaving every filled row dangling.
+    std::string default_json =
+        R"({"default_key": 12345, "another_key": "value"})";
+    proto::schema::ValueField default_value;
+    default_value.set_bytes_data(default_json);
+
+    auto field_data = milvus::storage::CreateFieldData(
+        milvus::DataType::JSON, milvus::DataType::NONE, false, 1, 5);
+    field_data->FillFieldData(milvus::DefaultValueType{default_value}, 5);
+
+    ClobberStackAndHeap(default_json);
+
+    for (int i = 0; i < 5; i++) {
+        auto* json = static_cast<const milvus::Json*>(field_data->RawValue(i));
+        EXPECT_EQ(std::string_view(json->data()),
+                  std::string_view(default_json));
+    }
 }

--- a/internal/core/unittest/test_json_stats/test_traverse_json_for_build_stats.cpp
+++ b/internal/core/unittest/test_json_stats/test_traverse_json_for_build_stats.cpp
@@ -208,6 +208,17 @@ TEST(JsonFieldDataTest, FillFieldDataWithDefaultValueOwnsData) {
         milvus::DataType::JSON, milvus::DataType::NONE, false, 1, 5);
     field_data->FillFieldData(milvus::DefaultValueType{default_value}, 5);
 
+    // All filled rows must share a single owned copy: identical backing
+    // pointer, so a fill of N rows performs exactly one data copy.
+    const char* shared_ptr =
+        static_cast<const milvus::Json*>(field_data->RawValue(0))
+            ->data()
+            .data();
+    for (int i = 1; i < 5; i++) {
+        auto* json = static_cast<const milvus::Json*>(field_data->RawValue(i));
+        EXPECT_EQ(json->data().data(), shared_ptr);
+    }
+
     ClobberStackAndHeap(default_json);
 
     for (int i = 0; i < 5; i++) {


### PR DESCRIPTION
issue: #52843

## What changed

Fix the ASan stack-buffer-overflow crash when building JSON key stats for segments missing binlogs of a newly added JSON field with a default value.

- `FieldDataJsonImpl::FillFieldData(default_value, ...)` stored the default value as a non-owning `Json` view onto a local `std::string`, leaving every filled row dangling once the function returned. Make an owning copy via `simdjson::padded_string` (same pattern as the arrow BinaryArray path).
- `JsonKeyStats` parsed row JSON with `strlen` on `string_view`s that are not NUL-terminated, which is UB and turned the dangling pointer into the observed crash. Parse with the view length instead (`CollectSingleJsonStatsInfo`, `BuildKeyStatsForRow`, `BuildKeyStats`).

## Validation

- Added `CollectSingleJsonStatsInfoTest.ParsesJsonWithoutNulTerminator`: parses a JSON view followed by non-NUL garbage — fails deterministically with the old `strlen`-based parsing.
- Added `JsonFieldDataTest.FillFieldDataWithDefaultValueOwnsData`: fills 5 rows with a default value, clobbers stack/heap, and verifies the stored values survive — guards the dangling-view fix (fully effective under ASan nightly).

Unit tests pending CI (internal/core/unittest/test_json_stats).