### PR TITLE
enhance: group segment load assignments by rwnodes

### DIFF
--- a/internal/querycoordv2/checkers/segment_checker.go
+++ b/internal/querycoordv2/checkers/segment_checker.go
@@ -19,6 +19,8 @@ package checkers
 import (
 	"context"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/samber/lo"
@@ -499,8 +501,17 @@ func (c *SegmentChecker) createSegmentLoadTasks(ctx context.Context, segments []
 		return s.GetInsertChannel()
 	})
 
-	plans := make([]assign.SegmentAssignPlan, 0)
-	for shard, segments := range shardSegments {
+	type segmentAssignGroup struct {
+		rwNodes  []int64
+		segments []*datapb.SegmentInfo
+	}
+
+	groupKeys := make([]string, 0)
+	segmentGroups := make(map[string]*segmentAssignGroup)
+	shards := lo.Keys(shardSegments)
+	sort.Strings(shards)
+	for _, shard := range shards {
+		segments := shardSegments[shard]
 		// if channel is not subscribed yet, skip load segments
 		leader := c.dist.ChannelDistManager.GetShardLeader(shard, replica)
 		if leader == nil {
@@ -513,13 +524,27 @@ func (c *SegmentChecker) createSegmentLoadTasks(ctx context.Context, segments []
 		if len(rwNodes) == 0 {
 			rwNodes = replica.GetRWNodes()
 		}
+		rwNodes = sortedNodes(rwNodes)
+		key := segmentAssignGroupKey(rwNodes)
+		if _, ok := segmentGroups[key]; !ok {
+			groupKeys = append(groupKeys, key)
+			segmentGroups[key] = &segmentAssignGroup{
+				rwNodes: rwNodes,
+			}
+		}
+		segmentGroups[key].segments = append(segmentGroups[key].segments, segments...)
+	}
 
-		segmentInfos := lo.Map(segments, func(s *datapb.SegmentInfo, _ int) *meta.Segment {
+	sort.Strings(groupKeys)
+	plans := make([]assign.SegmentAssignPlan, 0)
+	for _, key := range groupKeys {
+		group := segmentGroups[key]
+		segmentInfos := lo.Map(group.segments, func(s *datapb.SegmentInfo, _ int) *meta.Segment {
 			return &meta.Segment{
 				SegmentInfo: s,
 			}
 		})
-		shardPlans := c.assignPolicy.AssignSegment(ctx, replica.GetCollectionID(), segmentInfos, rwNodes, true)
+		shardPlans := c.assignPolicy.AssignSegment(ctx, replica.GetCollectionID(), segmentInfos, group.rwNodes, true)
 		for i := range shardPlans {
 			shardPlans[i].Replica = replica
 			shardPlans[i].LoadPriority = priorityMap[shardPlans[i].Segment.GetID()]
@@ -535,6 +560,23 @@ func (c *SegmentChecker) createSegmentLoadTasks(ctx context.Context, segments []
 	// either backoff/a retry cap on repeated DeadlineExceeded rebuilds, or a
 	// no-progress timeout instead of a flat per-task wall-clock budget.
 	return balance.CreateSegmentTasksFromPlans(ctx, c.ID(), Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond), plans)
+}
+
+func sortedNodes(nodes []int64) []int64 {
+	sorted := make([]int64, len(nodes))
+	copy(sorted, nodes)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i] < sorted[j]
+	})
+	return sorted
+}
+
+func segmentAssignGroupKey(nodes []int64) string {
+	parts := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		parts = append(parts, strconv.FormatInt(node, 10))
+	}
+	return strings.Join(parts, ",")
 }
 
 func (c *SegmentChecker) createSegmentReopenTasks(ctx context.Context, segments []*meta.Segment, replica *meta.Replica) []task.Task {

--- a/internal/querycoordv2/checkers/segment_checker_test.go
+++ b/internal/querycoordv2/checkers/segment_checker_test.go
@@ -256,6 +256,148 @@ func (suite *SegmentCheckerTestSuite) TestLoadSegmentsGroupByRWNodes() {
 	suite.Len(assignedNodes, len(nodes))
 }
 
+func (suite *SegmentCheckerTestSuite) TestLoadSegmentsKeepDifferentRWNodeGroupsSeparate() {
+	ctx := context.Background()
+	checker := suite.checker
+	collectionID := int64(1)
+	replicaID := int64(1)
+	nodes := []int64{1, 2, 3, 4}
+	shardRWNodes := map[string][]int64{
+		"channel1": {1, 2},
+		"channel2": {2, 1},
+		"channel3": {3, 4},
+		"channel4": {4, 3},
+	}
+
+	checker.meta.PutCollection(ctx, utils.CreateTestCollection(collectionID, 1))
+	checker.meta.PutPartition(ctx, utils.CreateTestPartition(collectionID, 1))
+	replica := meta.NewReplica(
+		&querypb.Replica{
+			ID:           replicaID,
+			CollectionID: collectionID,
+			Nodes:        nodes,
+			ChannelNodeInfos: map[string]*querypb.ChannelNodeInfo{
+				"channel1": {RwNodes: shardRWNodes["channel1"]},
+				"channel2": {RwNodes: shardRWNodes["channel2"]},
+				"channel3": {RwNodes: shardRWNodes["channel3"]},
+				"channel4": {RwNodes: shardRWNodes["channel4"]},
+			},
+		},
+	)
+	checker.meta.Put(ctx, replica)
+
+	for _, node := range nodes {
+		suite.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   node,
+			Address:  "localhost",
+			Hostname: "localhost",
+		}))
+		checker.meta.HandleNodeUp(ctx, node)
+	}
+
+	shards := lo.Keys(shardRWNodes)
+	sort.Strings(shards)
+	segments := make([]*datapb.SegmentInfo, 0, len(shards))
+	loadPriorities := make([]commonpb.LoadPriority, 0, len(shards))
+	for i, shard := range shards {
+		segment := &datapb.SegmentInfo{
+			ID:            int64(i + 1),
+			CollectionID:  collectionID,
+			PartitionID:   1,
+			InsertChannel: shard,
+			NumOfRows:     100,
+		}
+		segments = append(segments, segment)
+		loadPriorities = append(loadPriorities, commonpb.LoadPriority_HIGH)
+		checker.dist.ChannelDistManager.Update(int64(i+1), &meta.DmChannel{
+			VchannelInfo: &datapb.VchannelInfo{
+				CollectionID: collectionID,
+				ChannelName:  shard,
+			},
+			Node:    int64(i + 1),
+			Version: 1,
+			View:    &meta.LeaderView{ID: int64(i + 1), CollectionID: collectionID, Channel: shard, Version: 1, Status: &querypb.LeaderViewStatus{Serviceable: true}},
+		})
+	}
+
+	tasks := checker.createSegmentLoadTasks(ctx, segments, loadPriorities, replica)
+	suite.Len(tasks, len(segments))
+
+	assignedNodes := make(map[int64]struct{})
+	for _, t := range tasks {
+		suite.Require().Len(t.Actions(), 1)
+		action, ok := t.Actions()[0].(*task.SegmentAction)
+		suite.Require().True(ok)
+		suite.Equal(task.ActionTypeGrow, action.Type())
+		suite.Contains(shardRWNodes[action.GetShard()], action.Node())
+		assignedNodes[action.Node()] = struct{}{}
+	}
+	suite.Len(assignedNodes, len(nodes))
+}
+
+func (suite *SegmentCheckerTestSuite) TestLoadSegmentsFallbackToReplicaRWNodes() {
+	ctx := context.Background()
+	checker := suite.checker
+	collectionID := int64(1)
+	replicaID := int64(1)
+	nodes := []int64{1, 2, 3, 4}
+
+	checker.meta.PutCollection(ctx, utils.CreateTestCollection(collectionID, 1))
+	checker.meta.PutPartition(ctx, utils.CreateTestPartition(collectionID, 1))
+	replica := meta.NewReplica(
+		&querypb.Replica{
+			ID:           replicaID,
+			CollectionID: collectionID,
+			Nodes:        nodes,
+			ChannelNodeInfos: map[string]*querypb.ChannelNodeInfo{
+				"channel1": {RwNodes: []int64{1, 2}},
+			},
+		},
+	)
+	checker.meta.Put(ctx, replica)
+
+	for _, node := range nodes {
+		nodeInfo := session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   node,
+			Address:  "localhost",
+			Hostname: "localhost",
+		})
+		if node <= 2 {
+			nodeInfo.UpdateStats(session.WithSegmentCnt(10))
+		}
+		suite.nodeMgr.Add(nodeInfo)
+		checker.meta.HandleNodeUp(ctx, node)
+	}
+
+	segments := []*datapb.SegmentInfo{
+		{
+			ID:            1,
+			CollectionID:  collectionID,
+			PartitionID:   1,
+			InsertChannel: "channel-without-rw-nodes",
+			NumOfRows:     100,
+		},
+	}
+	checker.dist.ChannelDistManager.Update(1, &meta.DmChannel{
+		VchannelInfo: &datapb.VchannelInfo{
+			CollectionID: collectionID,
+			ChannelName:  "channel-without-rw-nodes",
+		},
+		Node:    1,
+		Version: 1,
+		View:    &meta.LeaderView{ID: 1, CollectionID: collectionID, Channel: "channel-without-rw-nodes", Version: 1, Status: &querypb.LeaderViewStatus{Serviceable: true}},
+	})
+
+	tasks := checker.createSegmentLoadTasks(ctx, segments, []commonpb.LoadPriority{commonpb.LoadPriority_HIGH}, replica)
+	suite.Len(tasks, 1)
+	suite.Require().Len(tasks[0].Actions(), 1)
+	action, ok := tasks[0].Actions()[0].(*task.SegmentAction)
+	suite.Require().True(ok)
+	suite.Equal(task.ActionTypeGrow, action.Type())
+	suite.EqualValues(1, action.GetSegmentID())
+	suite.EqualValues(3, action.Node())
+}
+
 func (suite *SegmentCheckerTestSuite) TestSkipLoadSegments() {
 	ctx := context.Background()
 	checker := suite.checker

--- a/internal/querycoordv2/checkers/segment_checker_test.go
+++ b/internal/querycoordv2/checkers/segment_checker_test.go
@@ -185,6 +185,77 @@ func (suite *SegmentCheckerTestSuite) TestLoadSegments() {
 	suite.Len(addedTasks, 1)
 }
 
+func (suite *SegmentCheckerTestSuite) TestLoadSegmentsGroupByRWNodes() {
+	ctx := context.Background()
+	checker := suite.checker
+	collectionID := int64(1)
+	replicaID := int64(1)
+	nodes := []int64{1, 2, 3, 4}
+	shards := []string{"channel1", "channel2", "channel3", "channel4"}
+
+	checker.meta.PutCollection(ctx, utils.CreateTestCollection(collectionID, 1))
+	checker.meta.PutPartition(ctx, utils.CreateTestPartition(collectionID, 1))
+	replica := meta.NewReplica(
+		&querypb.Replica{
+			ID:           replicaID,
+			CollectionID: collectionID,
+			Nodes:        nodes,
+			ChannelNodeInfos: map[string]*querypb.ChannelNodeInfo{
+				"channel1": {RwNodes: []int64{1, 2, 3, 4}},
+				"channel2": {RwNodes: []int64{4, 3, 2, 1}},
+				"channel3": {RwNodes: []int64{1, 2, 3, 4}},
+				"channel4": {RwNodes: []int64{4, 3, 2, 1}},
+			},
+		},
+	)
+	checker.meta.Put(ctx, replica)
+
+	for _, node := range nodes {
+		suite.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   node,
+			Address:  "localhost",
+			Hostname: "localhost",
+		}))
+		checker.meta.HandleNodeUp(ctx, node)
+	}
+
+	segments := make([]*datapb.SegmentInfo, 0, len(shards))
+	loadPriorities := make([]commonpb.LoadPriority, 0, len(shards))
+	for i, shard := range shards {
+		segment := &datapb.SegmentInfo{
+			ID:            int64(i + 1),
+			CollectionID:  collectionID,
+			PartitionID:   1,
+			InsertChannel: shard,
+			NumOfRows:     100,
+		}
+		segments = append(segments, segment)
+		loadPriorities = append(loadPriorities, commonpb.LoadPriority_HIGH)
+		checker.dist.ChannelDistManager.Update(int64(i+1), &meta.DmChannel{
+			VchannelInfo: &datapb.VchannelInfo{
+				CollectionID: collectionID,
+				ChannelName:  shard,
+			},
+			Node:    int64(i + 1),
+			Version: 1,
+			View:    &meta.LeaderView{ID: int64(i + 1), CollectionID: collectionID, Channel: shard, Version: 1, Status: &querypb.LeaderViewStatus{Serviceable: true}},
+		})
+	}
+
+	tasks := checker.createSegmentLoadTasks(ctx, segments, loadPriorities, replica)
+	suite.Len(tasks, len(segments))
+
+	assignedNodes := make(map[int64]struct{})
+	for _, t := range tasks {
+		suite.Require().Len(t.Actions(), 1)
+		action, ok := t.Actions()[0].(*task.SegmentAction)
+		suite.Require().True(ok)
+		suite.Equal(task.ActionTypeGrow, action.Type())
+		assignedNodes[action.Node()] = struct{}{}
+	}
+	suite.Len(assignedNodes, len(nodes))
+}
+
 func (suite *SegmentCheckerTestSuite) TestSkipLoadSegments() {
 	ctx := context.Background()
 	checker := suite.checker


### PR DESCRIPTION
issue: #52874

## What was changed

Group shards with identical RW node sets and assign their segments in one
batch instead of assigning each shard independently.

## Why

When the number of RW nodes exceeds the number of segments in one shard,
per-shard round-robin assignment repeatedly selects the first nodes in the
sorted candidate list. Multiple small shards can therefore produce an
uneven segment distribution.

Combining segments from shards with identical candidate node sets allows
round-robin assignment to distribute them across all eligible nodes.

## Test Plan
```
go test -tags dynamic,test -gcflags="all=-N -l" -count=1 \
    ./internal/querycoordv2/checkers \
    -run 'TestSegmentCheckerSuite/TestLoadSegmentsGroupByRWNodes'
```    