### PR TITLE
enhance: [3.0] sort merged rerank results without per-comparison map lookups

### DIFF
--- a/internal/util/function/chain/operator_merge.go
+++ b/internal/util/function/chain/operator_merge.go
@@ -21,7 +21,7 @@ package chain
 import (
 	"fmt"
 	"math"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/apache/arrow/go/v17/arrow"
@@ -650,36 +650,59 @@ func collectOrderedFieldNames(inputs []*DataFrame) []string {
 // sortAndExtractResults sorts IDs by score and extracts results.
 // When descending is true, larger scores sort first (higher = better match).
 // When descending is false, smaller scores sort first (lower = better match, e.g. L2).
+// scoredID carries the score and location alongside the id so that sorting does
+// not have to look them up. Sorting a slice of these with slices.SortStableFunc
+// also avoids sort.SliceStable's reflect-based swapper.
+type scoredID struct {
+	id    any
+	score float32
+	loc   idLocation
+}
+
 func sortAndExtractResults(idScores map[any]float32, idLocs map[any]idLocation, descending bool) ([]any, []float32, []idLocation) {
-	ids := make([]any, 0, len(idScores))
-	for id := range idScores {
-		ids = append(ids, id)
+	entries := make([]scoredID, 0, len(idScores))
+	for id, score := range idScores {
+		entries = append(entries, scoredID{id: id, score: score, loc: idLocs[id]})
 	}
 
-	sortIDs(ids, idScores, descending)
+	sortScoredIDs(entries, descending)
 
-	scores := make([]float32, len(ids))
-	locs := make([]idLocation, len(ids))
-	for i, id := range ids {
-		scores[i] = idScores[id]
-		locs[i] = idLocs[id]
+	ids := make([]any, len(entries))
+	scores := make([]float32, len(entries))
+	locs := make([]idLocation, len(entries))
+	for i, e := range entries {
+		ids[i] = e.id
+		scores[i] = e.score
+		locs[i] = e.loc
 	}
 
 	return ids, scores, locs
 }
 
-// sortIDs sorts IDs by score with stable tie-breaking by ID.
-func sortIDs(ids []any, idScores map[any]float32, descending bool) {
-	sort.SliceStable(ids, func(i, j int) bool {
-		scoreI := idScores[ids[i]]
-		scoreJ := idScores[ids[j]]
-		if scoreI != scoreJ {
-			if descending {
-				return scoreI > scoreJ
-			}
-			return scoreI < scoreJ
+// lessScoredID is the ordering sortIDs used to express directly, kept as a
+// predicate so the three-way comparator below is equivalent to the previous
+// sort.SliceStable call by construction -- including for scores that compare
+// unequal in both directions, such as NaN.
+func lessScoredID(a, b scoredID, descending bool) bool {
+	if a.score != b.score {
+		if descending {
+			return a.score > b.score
 		}
-		return compareIDs(ids[i], ids[j]) < 0
+		return a.score < b.score
+	}
+	return compareIDs(a.id, b.id) < 0
+}
+
+// sortScoredIDs sorts by score with stable tie-breaking by ID.
+func sortScoredIDs(entries []scoredID, descending bool) {
+	slices.SortStableFunc(entries, func(a, b scoredID) int {
+		if lessScoredID(a, b, descending) {
+			return -1
+		}
+		if lessScoredID(b, a, descending) {
+			return 1
+		}
+		return 0
 	})
 }
 

--- a/internal/util/function/chain/operator_merge_bench_test.go
+++ b/internal/util/function/chain/operator_merge_bench_test.go
@@ -1,0 +1,79 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package chain
+
+import (
+	"testing"
+
+	"github.com/apache/arrow/go/v17/arrow/memory"
+
+	"github.com/milvus-io/milvus/internal/util/function/chain/types"
+)
+
+// MergeOp is the operator every rerank chain starts with, and it was the only
+// significant one without a benchmark.
+func BenchmarkMergeOp(b *testing.B) {
+	benchCases := []struct {
+		name   string
+		nq     int
+		topK   int
+		inputs int
+	}{
+		{"RRF_nq1_topk100_2inputs", 1, 100, 2},
+		{"RRF_nq10_topk100_2inputs", 10, 100, 2},
+		{"RRF_nq10_topk1000_2inputs", 10, 1000, 2},
+		{"RRF_nq10_topk100_4inputs", 10, 100, 4},
+	}
+
+	pool := memory.NewGoAllocator()
+	for _, bc := range benchCases {
+		b.Run(bc.name, func(b *testing.B) {
+			op := NewMergeOp(MergeStrategyRRF, WithRRFK(60))
+			ctx := types.NewFuncContext(pool)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				dfs := make([]*DataFrame, bc.inputs)
+				for j := range dfs {
+					resultData := generateSearchResultData(bc.nq, bc.topK, 2)
+					df, err := FromSearchResultData(resultData, pool, fieldNamesForNumFields(2))
+					if err != nil {
+						b.Fatal(err)
+					}
+					dfs[j] = df
+				}
+				b.StartTimer()
+
+				out, err := op.ExecuteMulti(ctx, dfs)
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				b.StopTimer()
+				out.Release()
+				for _, df := range dfs {
+					df.Release()
+				}
+				b.StartTimer()
+			}
+		})
+	}
+}

--- a/internal/util/function/chain/operator_merge_sort_test.go
+++ b/internal/util/function/chain/operator_merge_sort_test.go
@@ -1,0 +1,125 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package chain
+
+import (
+	"math"
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// sortAndExtractResults used to sort a []any with sort.SliceStable, looking each
+// score up in a map inside the comparator. It now sorts a slice of structs that
+// already carry the score. This pins the resulting order against the previous
+// formulation, including the tie-break by ID and the behavior for scores that
+// compare unequal in both directions (NaN).
+func TestSortAndExtractResultsMatchesPreviousOrdering(t *testing.T) {
+	legacyOrder := func(idScores map[any]float32, descending bool) []any {
+		ids := make([]any, 0, len(idScores))
+		for id := range idScores {
+			ids = append(ids, id)
+		}
+		// Deterministic starting point: map iteration order is random, and
+		// sort.SliceStable only preserves the order of elements it considers
+		// equal, so both implementations must start from the same permutation
+		// to be comparable.
+		sort.Slice(ids, func(i, j int) bool { return compareIDs(ids[i], ids[j]) < 0 })
+		sort.SliceStable(ids, func(i, j int) bool {
+			scoreI := idScores[ids[i]]
+			scoreJ := idScores[ids[j]]
+			if scoreI != scoreJ {
+				if descending {
+					return scoreI > scoreJ
+				}
+				return scoreI < scoreJ
+			}
+			return compareIDs(ids[i], ids[j]) < 0
+		})
+		return ids
+	}
+
+	newOrder := func(idScores map[any]float32, descending bool) []any {
+		entries := make([]scoredID, 0, len(idScores))
+		for id, score := range idScores {
+			entries = append(entries, scoredID{id: id, score: score})
+		}
+		sort.Slice(entries, func(i, j int) bool { return compareIDs(entries[i].id, entries[j].id) < 0 })
+		sortScoredIDs(entries, descending)
+		ids := make([]any, len(entries))
+		for i, e := range entries {
+			ids[i] = e.id
+		}
+		return ids
+	}
+
+	cases := []struct {
+		name   string
+		scores map[any]float32
+	}{
+		{"distinct scores", map[any]float32{
+			int64(1): 0.9, int64(2): 0.5, int64(3): 0.7,
+		}},
+		{"many ties", map[any]float32{
+			int64(1): 0.5, int64(2): 0.5, int64(3): 0.5, int64(4): 0.1, int64(5): 0.5,
+		}},
+		{"string ids", map[any]float32{
+			"b": 0.5, "a": 0.5, "c": 0.9,
+		}},
+		{"nan score", map[any]float32{
+			int64(1): float32(math.NaN()), int64(2): 0.5, int64(3): 0.9,
+		}},
+	}
+
+	for _, c := range cases {
+		for _, desc := range []bool{true, false} {
+			assert.Equal(t, legacyOrder(c.scores, desc), newOrder(c.scores, desc),
+				"case=%s descending=%v", c.name, desc)
+		}
+	}
+
+	// Larger randomized case with heavy tie density.
+	r := rand.New(rand.NewSource(7))
+	big := make(map[any]float32, 500)
+	for i := 0; i < 500; i++ {
+		big[int64(i)] = float32(r.Intn(5)) / 4 // only 5 distinct scores -> many ties
+	}
+	for _, desc := range []bool{true, false} {
+		assert.Equal(t, legacyOrder(big, desc), newOrder(big, desc), "randomized descending=%v", desc)
+	}
+}
+
+// sortAndExtractResults must keep ids, scores and locs aligned.
+func TestSortAndExtractResultsKeepsTuplesAligned(t *testing.T) {
+	idScores := map[any]float32{int64(1): 0.1, int64(2): 0.9, int64(3): 0.5}
+	idLocs := map[any]idLocation{
+		int64(1): {inputIdx: 10, rowIdx: 100},
+		int64(2): {inputIdx: 20, rowIdx: 200},
+		int64(3): {inputIdx: 30, rowIdx: 300},
+	}
+
+	ids, scores, locs := sortAndExtractResults(idScores, idLocs, true)
+	assert.Equal(t, []any{int64(2), int64(3), int64(1)}, ids)
+	for i, id := range ids {
+		assert.Equal(t, idScores[id], scores[i])
+		assert.Equal(t, idLocs[id], locs[i])
+	}
+}


### PR DESCRIPTION
pr: https://github.com/milvus-io/milvus/pull/52276
https://github.com/milvus-io/milvus/issues/52275