### PR TITLE
fix: validate functions for external collections on the direct RootCoord path

### DIFF
--- a/internal/rootcoord/create_collection_task.go
+++ b/internal/rootcoord/create_collection_task.go
@@ -550,6 +550,13 @@ func (t *createCollectionTask) prepareMilvusTableSnapshotSchema(ctx context.Cont
 	if err := assignFunctionIDsFromFieldNames(schema); err != nil {
 		return merr.Wrap(err, "align milvus-table function field IDs")
 	}
+	// Newly aligned milvus-table schemas set preserveFieldID below and would
+	// bypass the direct-path ValidateFunction in prepareSchema, so run the
+	// non-runtime function validation here; DDL replay never reaches this
+	// point (it returns early above) and keeps its historical schema unjudged.
+	if err := validator.ValidateFunction(schema, "", true); err != nil {
+		return err
+	}
 	t.preserveFieldID = true
 	t.Req.Properties = upsertCreateCollectionProperty(t.Req.GetProperties(), util.PreserveFieldIdsKey, "true")
 
@@ -704,14 +711,12 @@ func (t *createCollectionTask) prepareSchema(ctx context.Context) error {
 		// does. Runs only for newly created schemas: preserveFieldID restores an
 		// existing collection (snapshot/replication), whose historical schema
 		// must not be re-judged by current-version rules. External collections
-		// are exempt too: this schema is the RESOLVED one, not what the user
-		// submitted — e.g. nullability is inferred from the external source, so
-		// judging it by user-schema rules rejects legal external tables (the
-		// proxy already validated the user-submitted form).
-		if !typeutil.IsExternalCollection(t.body.CollectionSchema) {
-			if err := validator.ValidateFunction(t.body.CollectionSchema, "", true); err != nil {
-				return err
-			}
+		// are validated too — the one resolution-sensitive rule (nullable
+		// input) exempts externally-mapped fields at the rule level, so the
+		// structural checks (e.g. the MinHash dim/num_hashes relation) stay
+		// authoritative on this path for the RESOLVED schema as well.
+		if err := validator.ValidateFunction(t.body.CollectionSchema, "", true); err != nil {
+			return err
 		}
 	}
 	if err := typeutil.ValidateExternalCollectionResolvedSchema(t.body.CollectionSchema); err != nil {

--- a/internal/rootcoord/create_collection_task_test.go
+++ b/internal/rootcoord/create_collection_task_test.go
@@ -1830,6 +1830,10 @@ func TestPrepareMilvusTableSnapshotSchemaAlignsTargetFunctionOutputs(t *testing.
 				Schema: &schemapb.CollectionSchema{
 					Fields: []*schemapb.FieldSchema{
 						{FieldID: 101, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+						{FieldID: 103, Name: "text", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{
+							{Key: common.MaxLengthKey, Value: "128"},
+							{Key: common.EnableAnalyzerKey, Value: "true"},
+						}},
 						{
 							FieldID:  105,
 							Name:     "vec",
@@ -1844,12 +1848,19 @@ func TestPrepareMilvusTableSnapshotSchemaAlignsTargetFunctionOutputs(t *testing.
 		}, nil).Build()
 	defer mockReadMetadata.UnPatch()
 
+	// The target function must also satisfy the non-runtime function
+	// validation that now runs on newly aligned milvus-table schemas: a
+	// typed BM25 over a VarChar input, no params.
 	schema := &schemapb.CollectionSchema{
 		Name:           "target",
 		ExternalSource: "minio://localhost:9000/bucket/snapshots/100/metadata/200.json",
 		ExternalSpec:   `{"format":"milvus-table","extfs":{"access_key_id":"AK","access_key_value":"SK"}}`,
 		Fields: []*schemapb.FieldSchema{
 			{FieldID: 0, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, ExternalField: "pk"},
+			{FieldID: 0, Name: "doc", DataType: schemapb.DataType_VarChar, ExternalField: "text", TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.MaxLengthKey, Value: "128"},
+				{Key: common.EnableAnalyzerKey, Value: "true"},
+			}},
 			{
 				FieldID:       0,
 				Name:          "embedding",
@@ -1864,7 +1875,8 @@ func TestPrepareMilvusTableSnapshotSchemaAlignsTargetFunctionOutputs(t *testing.
 		Functions: []*schemapb.FunctionSchema{
 			{
 				Name:             "bm25",
-				InputFieldNames:  []string{"id"},
+				Type:             schemapb.FunctionType_BM25,
+				InputFieldNames:  []string{"doc"},
 				OutputFieldNames: []string{"sparse"},
 			},
 		},
@@ -1886,12 +1898,74 @@ func TestPrepareMilvusTableSnapshotSchemaAlignsTargetFunctionOutputs(t *testing.
 
 	assert.True(t, task.preserveFieldID)
 	assert.Equal(t, int64(101), schema.GetFields()[0].GetFieldID())
-	assert.Equal(t, int64(105), schema.GetFields()[1].GetFieldID())
-	assert.Equal(t, int64(106), schema.GetFields()[2].GetFieldID())
+	assert.Equal(t, int64(103), schema.GetFields()[1].GetFieldID())
+	assert.Equal(t, int64(105), schema.GetFields()[2].GetFieldID())
+	assert.Equal(t, int64(106), schema.GetFields()[3].GetFieldID())
 	require.Len(t, schema.GetFunctions(), 1)
 	assert.Equal(t, int64(StartOfUserFunctionID), schema.GetFunctions()[0].GetId())
-	assert.Equal(t, []int64{101}, schema.GetFunctions()[0].GetInputFieldIds())
+	assert.Equal(t, []int64{103}, schema.GetFunctions()[0].GetInputFieldIds())
 	assert.Equal(t, []int64{106}, schema.GetFunctions()[0].GetOutputFieldIds())
+}
+
+// The newly aligned milvus-table schema is a NEW schema that merely reuses
+// source field IDs, so it must pass the same non-runtime function validation
+// as any direct-path create; before this call a structurally impossible
+// function persisted through the milvus-table path (preserveFieldID bypassed
+// the prepareSchema validation).
+func TestPrepareMilvusTableSnapshotSchemaRejectsInvalidFunction(t *testing.T) {
+	mockReadMetadata := mockey.Mock(packed.ReadMilvusTableSnapshotMetadata).
+		Return(&datapb.SnapshotMetadata{
+			Collection: &datapb.CollectionDescription{
+				Schema: &schemapb.CollectionSchema{
+					Fields: []*schemapb.FieldSchema{
+						{FieldID: 101, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+						{FieldID: 103, Name: "text", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{
+							{Key: common.MaxLengthKey, Value: "128"},
+						}},
+					},
+				},
+			},
+		}, nil).Build()
+	defer mockReadMetadata.UnPatch()
+
+	// (2^59+1)*32 wraps around int64 to 32; the division-based check must
+	// reject it on the milvus-table path too.
+	schema := &schemapb.CollectionSchema{
+		Name:           "target",
+		ExternalSource: "minio://localhost:9000/bucket/snapshots/100/metadata/200.json",
+		ExternalSpec:   `{"format":"milvus-table","extfs":{"access_key_id":"AK","access_key_value":"SK"}}`,
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 0, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, ExternalField: "pk"},
+			{FieldID: 0, Name: "doc", DataType: schemapb.DataType_VarChar, ExternalField: "text", TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.MaxLengthKey, Value: "128"},
+			}},
+			{FieldID: 0, Name: "hash", DataType: schemapb.DataType_BinaryVector, IsFunctionOutput: true, TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.DimKey, Value: "32"},
+			}},
+		},
+		Functions: []*schemapb.FunctionSchema{
+			{
+				Name: "minhash", Type: schemapb.FunctionType_MinHash,
+				InputFieldNames: []string{"doc"}, OutputFieldNames: []string{"hash"},
+				Params: []*commonpb.KeyValuePair{{Key: "num_hashes", Value: "576460752303423489"}},
+			},
+		},
+	}
+	task := &createCollectionTask{
+		Req: &milvuspb.CreateCollectionRequest{
+			CollectionName: "target",
+			Properties: []*commonpb.KeyValuePair{
+				{Key: util.PreserveFieldIdsKey, Value: "false"},
+			},
+		},
+		body: &message.CreateCollectionRequest{
+			CollectionSchema: schema,
+		},
+	}
+
+	err := task.prepareMilvusTableSnapshotSchema(context.Background())
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	assert.ErrorContains(t, err, "does not match expected dim")
 }
 
 func TestPrepareMilvusTableSnapshotSchemaMapsSourceFunctionOutputAsDataField(t *testing.T) {
@@ -3128,38 +3202,71 @@ func Test_createCollectionTask_prepareSchema_validatesFunctions(t *testing.T) {
 	})
 }
 
-// External collections are exempt from the direct-path function validation:
-// prepareSchema sees the RESOLVED schema (e.g. nullability inferred from the
-// external source), not the user-submitted one the proxy validated — judging
-// it by user-schema rules rejects legal external tables (a nullable
-// TextEmbedding input resolved from parquet, as the go-sdk e2e creates).
-func Test_createCollectionTask_prepareSchema_skipsFunctionValidationForExternal(t *testing.T) {
-	collectionName := funcutil.GenRandomStr()
-	schema := &schemapb.CollectionSchema{
-		Name: collectionName,
-		Fields: []*schemapb.FieldSchema{
-			{Name: "pk", DataType: schemapb.DataType_Int64, ExternalField: "pk"},
-			{Name: "doc", DataType: schemapb.DataType_VarChar, Nullable: true, ExternalField: "doc", TypeParams: []*commonpb.KeyValuePair{
-				{Key: common.MaxLengthKey, Value: "1024"},
-			}},
-			{Name: "dense", DataType: schemapb.DataType_FloatVector, IsFunctionOutput: true, TypeParams: []*commonpb.KeyValuePair{
-				{Key: common.DimKey, Value: "8"},
-			}},
-		},
-		Functions: []*schemapb.FunctionSchema{{
-			Name: "tei_fn", Type: schemapb.FunctionType_TextEmbedding,
-			InputFieldNames: []string{"doc"}, OutputFieldNames: []string{"dense"},
-		}},
+// External collections go through the direct-path function validation like any
+// other schema; only the one resolution-sensitive rule (nullable input) exempts
+// externally-mapped fields at the rule level, because their nullability is
+// inferred from the external source (a nullable TextEmbedding input resolved
+// from parquet, as the go-sdk e2e creates) rather than declared by the user.
+// Structural checks — e.g. the MinHash dim/num_hashes relation — stay
+// authoritative for external schemas too.
+func Test_createCollectionTask_prepareSchema_validatesExternalFunctions(t *testing.T) {
+	buildTask := func(schema *schemapb.CollectionSchema) createCollectionTask {
+		return createCollectionTask{
+			Req: &milvuspb.CreateCollectionRequest{
+				Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
+				CollectionName: schema.GetName(),
+			},
+			body: &message.CreateCollectionRequest{
+				CollectionSchema: schema,
+			},
+		}
 	}
-	task := createCollectionTask{
-		Req: &milvuspb.CreateCollectionRequest{
-			Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
-			CollectionName: collectionName,
-		},
-		body: &message.CreateCollectionRequest{
-			CollectionSchema: schema,
-		},
-	}
-	err := task.prepareSchema(context.TODO())
-	assert.NoError(t, err)
+
+	t.Run("nullable externally-mapped input accepted", func(t *testing.T) {
+		task := buildTask(&schemapb.CollectionSchema{
+			Name: funcutil.GenRandomStr(),
+			Fields: []*schemapb.FieldSchema{
+				{Name: "pk", DataType: schemapb.DataType_Int64, ExternalField: "pk"},
+				{Name: "doc", DataType: schemapb.DataType_VarChar, Nullable: true, ExternalField: "doc", TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "1024"},
+				}},
+				{Name: "dense", DataType: schemapb.DataType_FloatVector, IsFunctionOutput: true, TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "8"},
+				}},
+			},
+			Functions: []*schemapb.FunctionSchema{{
+				Name: "tei_fn", Type: schemapb.FunctionType_TextEmbedding,
+				InputFieldNames: []string{"doc"}, OutputFieldNames: []string{"dense"},
+				Params: []*commonpb.KeyValuePair{{Key: "provider", Value: "TEI"}},
+			}},
+		})
+		err := task.prepareSchema(context.TODO())
+		assert.NoError(t, err)
+	})
+
+	t.Run("overflowing minhash num_hashes rejected on external too", func(t *testing.T) {
+		// (2^59+1)*32 wraps around int64 to 32; before the rule-level exemption
+		// the whole ValidateFunction call was skipped for external schemas, so
+		// this impossible MinHash persisted through the direct RootCoord path.
+		task := buildTask(&schemapb.CollectionSchema{
+			Name: funcutil.GenRandomStr(),
+			Fields: []*schemapb.FieldSchema{
+				{Name: "pk", DataType: schemapb.DataType_Int64, ExternalField: "pk"},
+				{Name: "text", DataType: schemapb.DataType_VarChar, ExternalField: "text", TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "128"},
+				}},
+				{Name: "hash", DataType: schemapb.DataType_BinaryVector, IsFunctionOutput: true, TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "32"},
+				}},
+			},
+			Functions: []*schemapb.FunctionSchema{{
+				Name: "minhash", Type: schemapb.FunctionType_MinHash,
+				InputFieldNames: []string{"text"}, OutputFieldNames: []string{"hash"},
+				Params: []*commonpb.KeyValuePair{{Key: "num_hashes", Value: "576460752303423489"}},
+			}},
+		})
+		err := task.prepareSchema(context.TODO())
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.ErrorContains(t, err, "does not match expected dim")
+	})
 }

--- a/internal/util/function/embedding/text_embedding_function.go
+++ b/internal/util/function/embedding/text_embedding_function.go
@@ -73,7 +73,10 @@ func TextEmbeddingInputsCheck(name string, fields []*schemapb.FieldSchema) error
 		return merr.WrapErrParameterInvalidMsg("TextEmbedding function input field must be a VARCHAR/TEXT field") //nolint:staticcheck // starts with proper noun
 	}
 
-	if fields[0].Nullable {
+	// An externally-mapped input's nullability is inferred from the external
+	// source during resolution, not declared by the user, so it is not judged
+	// by the user-schema rule.
+	if fields[0].Nullable && fields[0].GetExternalField() == "" {
 		return merr.WrapErrParameterInvalidMsg("function input field cannot be nullable: function %s, field %s", name, fields[0].GetName())
 	}
 	return nil


### PR DESCRIPTION
### What

Follow-up to #52219, narrowing its external-collection exemption from the path level to the rule level.

#52219 exempted external collections from the direct-path function validation wholesale: `prepareSchema` sees the RESOLVED schema, whose input nullability is inferred from the external source, so the nullable-input rule would falsely reject legal external tables (the go-sdk e2e `TestExternalTableTextEmbeddingFunction` shape). But the blanket skip also discarded every resolution-invariant structural check — a client hitting RootCoord directly could still persist an **external** MinHash schema with an overflowing `num_hashes`, the exact gap #52219 set out to close (the runner later attempts an impossibly large permutation allocation during materialization).

### How

- The only resolution-sensitive rule — the TextEmbedding nullable-input check — now passes for **externally-mapped** input fields (`GetExternalField() != ""`): their nullability is resolved from the source, not declared by the user. Non-mapped nullable inputs are still rejected, on the proxy path and the direct path alike.
- `prepareSchema` then validates external schemas unconditionally, so the structural checks (e.g. the MinHash `dim/32 == num_hashes` overflow-safe relation) stay authoritative on the direct RootCoord path for external collections too.

### Tests

- `Test_createCollectionTask_prepareSchema_validatesExternalFunctions` (repurposes the former skip test):
  - a nullable externally-mapped TextEmbedding input passes **through** validation (rule-level exemption; reverting the rule change turns this RED);
  - an external MinHash with `num_hashes = 2^59+1` is rejected (reverting the guard removal turns this RED).
- Note: the old skip-test fixture also carried an empty-params TextEmbedding function, which `CheckFunctionBasicParams` rejects — the blanket skip had been masking that too; the fixture now carries params like a real create does.
- embedding / validator / rootcoord `prepareSchema` suites green locally under `-tags dynamic,test`.

issue: #51649

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Also covered (review round 1)

- **milvus-table path**: `prepareMilvusTableSnapshotSchema` sets `preserveFieldID` for newly aligned target schemas, which routed `prepareSchema` around the direct-path validation. The same non-runtime validation now runs right after function-ID alignment there (DDL replay returns early and stays unjudged). Anti-test: `TestPrepareMilvusTableSnapshotSchemaRejectsInvalidFunction`.

### Known limitation (follow-up, pre-existing)

Nullable external embedding inputs are admitted (resolution marks externally-mapped fields nullable unconditionally since #49307), but `TextEmbeddingFunction.ProcessBulkInsert` cannot process nulls — refresh fails with a clean `merr` when actual nulls appear. Null propagation through the embedding output path is runtime feature work, tracked as a follow-up; this PR only fixes admission.
