### PR TITLE
fix: [3.0] validate compaction fallback parents (#52741)

### DIFF
--- a/internal/datacoord/handler.go
+++ b/internal/datacoord/handler.go
@@ -225,7 +225,8 @@ func (h *ServerHandler) GetQueryVChanPositions(channel RWChannel, partitionIDs .
 		return indexed.Contain(segID) || ((validSegmentInfos[segID].GetIsSorted() || validSegmentInfos[segID].GetIsSortedByNamespace()) && validSegmentInfos[segID].GetNumOfRows() < Params.DataCoordCfg.MinSegmentNumRowsToEnableIndex.GetAsInt64())
 	}
 
-	flushedIDs, droppedIDs = retrieveSegment(validSegmentInfos, flushedIDs, droppedIDs, segmentIndexed)
+	fallbackParentReady := func(segID UniqueID) bool { return indexed.Contain(segID) }
+	flushedIDs, droppedIDs = retrieveSegment(validSegmentInfos, flushedIDs, droppedIDs, segmentIndexed, fallbackParentReady)
 
 	seekPosition := h.GetChannelSeekPosition(channel, partitionIDs...)
 	// if no l0 segment exist, use checkpoint as delete checkpoint
@@ -248,85 +249,234 @@ func (h *ServerHandler) GetQueryVChanPositions(channel RWChannel, partitionIDs .
 
 func retrieveSegment(validSegmentInfos map[int64]*SegmentInfo,
 	flushedIDs, droppedIDs typeutil.UniqueSet,
-	segmentIndexed func(segID UniqueID) bool,
+	segmentIndexed, fallbackParentReady func(segID UniqueID) bool,
 ) (typeutil.UniqueSet, typeutil.UniqueSet) {
-	newFlushedIDs := make(typeutil.UniqueSet)
+	// A recovered view may contain both compactTo segments and still-live
+	// compactFrom segments when an ordered compaction metadata update is
+	// interrupted. CompactTo segments are published before any compactFrom
+	// segment is retired, so normalize the immutable input frontier as follows:
+	//   - all direct parents present: retirement has not started and the output
+	//     set may be incomplete; keep the parents and remove the child;
+	//   - only some direct parents present: retirement has started, which proves
+	//     the output set was fully published; keep the child and remove the
+	//     remaining parents.
+	// Each child can be evaluated independently. M:N outputs share the same
+	// CompactionFrom set, so they make the same decision against this snapshot.
+	initialFlushedIDs := typeutil.NewUniqueSet(flushedIDs.Collect()...)
+	removeFromView := make(typeutil.UniqueSet)
+	for id := range initialFlushedIDs {
+		segment := validSegmentInfos[id]
+		if segment == nil || len(segment.GetCompactionFrom()) == 0 {
+			continue
+		}
 
-	isConditionMet := func(condition func(seg *SegmentInfo) bool, ids ...UniqueID) bool {
+		presentParents := make(typeutil.UniqueSet)
+		for _, parentID := range segment.GetCompactionFrom() {
+			if initialFlushedIDs.Contain(parentID) {
+				presentParents.Insert(parentID)
+			}
+		}
+
+		switch len(presentParents) {
+		case len(segment.GetCompactionFrom()):
+			removeFromView.Insert(id)
+		case 0:
+		default:
+			removeFromView.Insert(presentParents.Collect()...)
+		}
+	}
+	initialFlushedIDs.Remove(removeFromView.Collect()...)
+	flushedIDs = initialFlushedIDs
+
+	allParentsReady := func(ids ...UniqueID) bool {
 		for _, id := range ids {
-			if seg, ok := validSegmentInfos[id]; !ok || seg == nil || !condition(seg) {
+			seg, ok := validSegmentInfos[id]
+			if !ok || seg == nil || seg.GetIsInvisible() || !fallbackParentReady(id) {
 				return false
 			}
 		}
 		return true
 	}
 
-	isValid := func(ids ...UniqueID) bool {
-		return isConditionMet(func(seg *SegmentInfo) bool {
-			return true
-		}, ids...)
-	}
-
-	isVisible := func(ids ...UniqueID) bool {
-		return isConditionMet(func(seg *SegmentInfo) bool {
-			return !seg.GetIsInvisible()
-		}, ids...)
-	}
-
-	compactionFromExistWithCache := func(segID UniqueID) bool {
-		var compactionFromExist func(segID UniqueID) bool
-		compactionFromExistMap := make(map[UniqueID]bool)
-
-		compactionFromExist = func(segID UniqueID) bool {
-			if exist, ok := compactionFromExistMap[segID]; ok {
-				return exist
-			}
-			compactionFrom := validSegmentInfos[segID].GetCompactionFrom()
-			if len(compactionFrom) == 0 || !isValid(compactionFrom...) {
-				compactionFromExistMap[segID] = false
-				return false
-			}
-			for _, fromID := range compactionFrom {
-				if flushedIDs.Contain(fromID) || newFlushedIDs.Contain(fromID) {
-					compactionFromExistMap[segID] = true
-					return true
-				}
-				if compactionFromExist(fromID) {
-					compactionFromExistMap[segID] = true
-					return true
-				}
-			}
-			compactionFromExistMap[segID] = false
-			return false
+	// Select the initial fallbacks in one pass. Every expansion, including the
+	// ones added later to resolve overlap, must use a complete ready parent set.
+	expanded := make(typeutil.UniqueSet)
+	for id := range flushedIDs {
+		segment := validSegmentInfos[id]
+		compactionFrom := segment.GetCompactionFrom()
+		if len(compactionFrom) == 0 || segmentIndexed(id) || !allParentsReady(compactionFrom...) {
+			continue
 		}
-		return compactionFromExist(segID)
+		expanded.Insert(id)
 	}
 
-	retrieve := func() bool {
-		continueRetrieve := false
+	buildCandidates := func() (typeutil.UniqueSet, map[UniqueID]typeutil.UniqueSet) {
+		candidates := make(typeutil.UniqueSet)
+		fallbackOwners := make(map[UniqueID]typeutil.UniqueSet)
+		type candidateVisit struct {
+			id     UniqueID
+			rootID UniqueID
+		}
+		var visited map[candidateVisit]struct{}
+		var emit func(id, rootID UniqueID, fromFallback bool)
+		emit = func(id, rootID UniqueID, fromFallback bool) {
+			segment, ok := validSegmentInfos[id]
+			if ok && segment != nil && expanded.Contain(id) {
+				if visited == nil {
+					visited = make(map[candidateVisit]struct{})
+				}
+				visit := candidateVisit{id: id, rootID: rootID}
+				if _, ok := visited[visit]; ok {
+					return
+				}
+				visited[visit] = struct{}{}
+
+				for _, parentID := range segment.GetCompactionFrom() {
+					emit(parentID, rootID, true)
+				}
+				return
+			}
+
+			candidates.Insert(id)
+			if fromFallback {
+				if fallbackOwners[id] == nil {
+					fallbackOwners[id] = make(typeutil.UniqueSet)
+				}
+				fallbackOwners[id].Insert(rootID)
+			}
+		}
 		for id := range flushedIDs {
-			compactionFrom := validSegmentInfos[id].GetCompactionFrom()
-			if len(compactionFrom) == 0 {
-				newFlushedIDs.Insert(id)
-			} else if !compactionFromExistWithCache(id) && (segmentIndexed(id) || !isVisible(compactionFrom...)) {
-				newFlushedIDs.Insert(id)
-			} else {
-				for _, fromID := range compactionFrom {
-					newFlushedIDs.Insert(fromID)
-					continueRetrieve = true
-					droppedIDs.Remove(fromID)
+			emit(id, id, false)
+		}
+		return candidates, fallbackOwners
+	}
+
+	type ancestorCoverage int
+	const (
+		noAncestorCoverage ancestorCoverage = iota
+		partialAncestorCoverage
+		completeAncestorCoverage
+	)
+
+	type coverageResult struct {
+		coverage ancestorCoverage
+		owners   typeutil.UniqueSet
+	}
+	newCoverageChecker := func(candidates typeutil.UniqueSet, fallbackOwners map[UniqueID]typeutil.UniqueSet) func(UniqueID) coverageResult {
+		coverageCache := make(map[UniqueID]coverageResult)
+		trackOwners := fallbackOwners != nil
+		var coverage func(UniqueID) coverageResult
+		coverage = func(id UniqueID) coverageResult {
+			if cached, ok := coverageCache[id]; ok {
+				return cached
+			}
+
+			segment, ok := validSegmentInfos[id]
+			if !ok || segment == nil || len(segment.GetCompactionFrom()) == 0 {
+				return coverageResult{coverage: noAncestorCoverage}
+			}
+
+			result := coverageResult{}
+			if trackOwners {
+				result.owners = make(typeutil.UniqueSet)
+			}
+			anyCovered := false
+			allCovered := true
+			for _, parentID := range segment.GetCompactionFrom() {
+				parentResult := coverageResult{coverage: noAncestorCoverage}
+				if candidates.Contain(parentID) {
+					parentResult.coverage = completeAncestorCoverage
+					if trackOwners {
+						parentResult.owners = fallbackOwners[parentID]
+					}
+				} else {
+					parentResult = coverage(parentID)
+				}
+				anyCovered = anyCovered || parentResult.coverage != noAncestorCoverage
+				allCovered = allCovered && parentResult.coverage == completeAncestorCoverage
+				if trackOwners {
+					for ownerID := range parentResult.owners {
+						result.owners.Insert(ownerID)
+					}
 				}
 			}
+
+			switch {
+			case allCovered:
+				result.coverage = completeAncestorCoverage
+			case anyCovered:
+				result.coverage = partialAncestorCoverage
+			default:
+				result.coverage = noAncestorCoverage
+			}
+			coverageCache[id] = result
+			return result
 		}
-		return continueRetrieve
+		return coverage
 	}
 
-	for retrieve() {
-		flushedIDs = newFlushedIDs
-		newFlushedIDs = make(typeutil.UniqueSet)
+	// Close partial overlaps created by M:N compactions. Expand the descendant
+	// when all of its direct parents are ready; otherwise cancel the root
+	// fallback that introduced the overlapping ancestors and keep its child.
+	var candidates typeutil.UniqueSet
+	blockedRoots := make(typeutil.UniqueSet)
+	for {
+		var fallbackOwners map[UniqueID]typeutil.UniqueSet
+		candidates, fallbackOwners = buildCandidates()
+		coverage := newCoverageChecker(candidates, fallbackOwners)
+		toExpand := make(typeutil.UniqueSet)
+		toCancel := make(typeutil.UniqueSet)
+		hasPartialCoverage := false
+		for id := range candidates {
+			result := coverage(id)
+			if result.coverage != partialAncestorCoverage {
+				continue
+			}
+			hasPartialCoverage = true
+			segment := validSegmentInfos[id]
+			if segment != nil && len(segment.GetCompactionFrom()) > 0 && !blockedRoots.Contain(id) && allParentsReady(segment.GetCompactionFrom()...) {
+				toExpand.Insert(id)
+			} else {
+				toCancel.Insert(result.owners.Collect()...)
+			}
+		}
+		if !hasPartialCoverage {
+			break
+		}
+
+		changed := false
+		for id := range toExpand {
+			if !toCancel.Contain(id) {
+				expanded.Insert(id)
+				changed = true
+			}
+		}
+		for id := range toCancel {
+			expanded.Remove(id)
+			blockedRoots.Insert(id)
+			changed = true
+		}
+		if !changed {
+			// The original leaf frontier is the safe fallback for malformed
+			// metadata that cannot attribute a partial overlap to an expansion.
+			candidates = typeutil.NewUniqueSet(flushedIDs.Collect()...)
+			break
+		}
 	}
 
-	return newFlushedIDs, droppedIDs
+	// Deduplicate against the immutable candidate frontier. An ancestor may be
+	// selected by another branch of an M:N compaction, so walk the complete
+	// ancestry here, but never introduce additional segments during this phase.
+	coverage := newCoverageChecker(candidates, nil)
+	finalFrontier := make(typeutil.UniqueSet)
+	for id := range candidates {
+		if coverage(id).coverage != completeAncestorCoverage {
+			finalFrontier.Insert(id)
+		}
+	}
+	droppedIDs.Remove(finalFrontier.Collect()...)
+
+	return finalFrontier, droppedIDs
 }
 
 func (h *ServerHandler) GetCurrentSegmentsView(ctx context.Context, channel RWChannel, partitionIDs ...UniqueID) *SegmentsView {
@@ -373,9 +523,8 @@ func (h *ServerHandler) GetCurrentSegmentsView(ctx context.Context, channel RWCh
 		}
 	}
 
-	flushedIDs, droppedIDs = retrieveSegment(validSegmentInfos, flushedIDs, droppedIDs, func(segID UniqueID) bool {
-		return true
-	})
+	alwaysReady := func(UniqueID) bool { return true }
+	flushedIDs, droppedIDs = retrieveSegment(validSegmentInfos, flushedIDs, droppedIDs, alwaysReady, alwaysReady)
 
 	mlog.Info(ctx, "GetCurrentSegmentsView",
 		mlog.FieldCollectionID(channel.GetCollectionID()),

--- a/internal/datacoord/handler_test.go
+++ b/internal/datacoord/handler_test.go
@@ -28,7 +28,233 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
+
+func TestRetrieveSegment(t *testing.T) {
+	segment := func(id int64, state commonpb.SegmentState, parents ...int64) *SegmentInfo {
+		return NewSegmentInfo(&datapb.SegmentInfo{
+			ID:             id,
+			State:          state,
+			CompactionFrom: parents,
+		})
+	}
+
+	t.Run("all direct parents indexed", func(t *testing.T) {
+		segments := map[int64]*SegmentInfo{
+			1: segment(1, commonpb.SegmentState_Dropped),
+			2: segment(2, commonpb.SegmentState_Dropped),
+			3: segment(3, commonpb.SegmentState_Flushed, 1, 2),
+		}
+		indexed := typeutil.NewUniqueSet(1, 2)
+		flushed, dropped := retrieveSegment(
+			segments,
+			typeutil.NewUniqueSet(3),
+			typeutil.NewUniqueSet(1, 2),
+			func(segmentID UniqueID) bool { return indexed.Contain(segmentID) },
+			func(segmentID UniqueID) bool { return indexed.Contain(segmentID) },
+		)
+
+		assert.ElementsMatch(t, []int64{1, 2}, flushed.Collect())
+		assert.Empty(t, dropped.Collect())
+	})
+
+	t.Run("one direct parent unindexed", func(t *testing.T) {
+		segments := map[int64]*SegmentInfo{
+			1: segment(1, commonpb.SegmentState_Dropped),
+			2: segment(2, commonpb.SegmentState_Dropped),
+			3: segment(3, commonpb.SegmentState_Flushed, 1, 2),
+		}
+		indexed := typeutil.NewUniqueSet(1)
+		flushed, dropped := retrieveSegment(
+			segments,
+			typeutil.NewUniqueSet(3),
+			typeutil.NewUniqueSet(1, 2),
+			func(segmentID UniqueID) bool { return indexed.Contain(segmentID) },
+			func(segmentID UniqueID) bool { return indexed.Contain(segmentID) },
+		)
+
+		assert.Equal(t, []int64{3}, flushed.Collect())
+		assert.ElementsMatch(t, []int64{1, 2}, dropped.Collect())
+	})
+
+	t.Run("does not walk to indexed grandparent", func(t *testing.T) {
+		segments := map[int64]*SegmentInfo{
+			1: segment(1, commonpb.SegmentState_Dropped),
+			2: segment(2, commonpb.SegmentState_Dropped, 1),
+			3: segment(3, commonpb.SegmentState_Flushed, 2),
+		}
+		indexed := typeutil.NewUniqueSet(1)
+		flushed, dropped := retrieveSegment(
+			segments,
+			typeutil.NewUniqueSet(3),
+			typeutil.NewUniqueSet(1, 2),
+			func(segmentID UniqueID) bool { return indexed.Contain(segmentID) },
+			func(segmentID UniqueID) bool { return indexed.Contain(segmentID) },
+		)
+
+		assert.Equal(t, []int64{3}, flushed.Collect())
+		assert.ElementsMatch(t, []int64{1, 2}, dropped.Collect())
+	})
+
+	t.Run("indexed child wins", func(t *testing.T) {
+		segments := map[int64]*SegmentInfo{
+			1: segment(1, commonpb.SegmentState_Dropped),
+			2: segment(2, commonpb.SegmentState_Flushed, 1),
+		}
+		indexed := typeutil.NewUniqueSet(1, 2)
+		flushed, dropped := retrieveSegment(
+			segments,
+			typeutil.NewUniqueSet(2),
+			typeutil.NewUniqueSet(1),
+			func(segmentID UniqueID) bool { return indexed.Contain(segmentID) },
+			func(segmentID UniqueID) bool { return indexed.Contain(segmentID) },
+		)
+
+		assert.Equal(t, []int64{2}, flushed.Collect())
+		assert.Equal(t, []int64{1}, dropped.Collect())
+	})
+
+	t.Run("keeps compactFrom before retirement starts", func(t *testing.T) {
+		segments := map[int64]*SegmentInfo{
+			1: segment(1, commonpb.SegmentState_Flushed),
+			2: segment(2, commonpb.SegmentState_Flushed),
+			3: segment(3, commonpb.SegmentState_Flushed, 1, 2),
+			4: segment(4, commonpb.SegmentState_Flushed, 1, 2),
+		}
+		flushed, dropped := retrieveSegment(
+			segments,
+			typeutil.NewUniqueSet(1, 2, 3, 4),
+			make(typeutil.UniqueSet),
+			func(UniqueID) bool { return true },
+			func(UniqueID) bool { return true },
+		)
+
+		assert.ElementsMatch(t, []int64{1, 2}, flushed.Collect())
+		assert.Empty(t, dropped.Collect())
+	})
+
+	t.Run("keeps compactTo after retirement starts", func(t *testing.T) {
+		segments := map[int64]*SegmentInfo{
+			1: segment(1, commonpb.SegmentState_Flushed),
+			2: segment(2, commonpb.SegmentState_Dropped),
+			3: segment(3, commonpb.SegmentState_Flushed, 1, 2),
+			4: segment(4, commonpb.SegmentState_Flushed, 1, 2),
+		}
+		flushed, dropped := retrieveSegment(
+			segments,
+			typeutil.NewUniqueSet(1, 3, 4),
+			typeutil.NewUniqueSet(2),
+			func(UniqueID) bool { return true },
+			func(UniqueID) bool { return true },
+		)
+
+		assert.ElementsMatch(t, []int64{3, 4}, flushed.Collect())
+		assert.Equal(t, []int64{2}, dropped.Collect())
+	})
+
+	t.Run("deduplicates candidates from an immutable snapshot", func(t *testing.T) {
+		segments := map[int64]*SegmentInfo{
+			1: segment(1, commonpb.SegmentState_Flushed),
+			2: segment(2, commonpb.SegmentState_Flushed),
+			3: segment(3, commonpb.SegmentState_Flushed, 1, 2),
+			4: segment(4, commonpb.SegmentState_Flushed, 3),
+		}
+		flushed, _ := retrieveSegment(
+			segments,
+			typeutil.NewUniqueSet(1, 2, 3, 4),
+			make(typeutil.UniqueSet),
+			func(UniqueID) bool { return true },
+			func(UniqueID) bool { return true },
+		)
+
+		assert.ElementsMatch(t, []int64{1, 2}, flushed.Collect())
+	})
+
+	t.Run("deduplicates selected ancestors across multiple generations", func(t *testing.T) {
+		segments := map[int64]*SegmentInfo{
+			1: segment(1, commonpb.SegmentState_Dropped),
+			2: segment(2, commonpb.SegmentState_Dropped),
+			3: segment(3, commonpb.SegmentState_Dropped, 1, 2),
+			4: segment(4, commonpb.SegmentState_Flushed, 1, 2),
+			5: segment(5, commonpb.SegmentState_Flushed, 3),
+		}
+		// Segment 5 remains serviceable while segment 4 falls back to 1 and 2.
+		// Recursive deduplication must remove 5 without selecting unready 3.
+		indexed := typeutil.NewUniqueSet(1, 2, 5)
+		flushed, dropped := retrieveSegment(
+			segments,
+			typeutil.NewUniqueSet(4, 5),
+			typeutil.NewUniqueSet(1, 2, 3),
+			func(segmentID UniqueID) bool { return indexed.Contain(segmentID) },
+			func(segmentID UniqueID) bool { return indexed.Contain(segmentID) },
+		)
+
+		assert.ElementsMatch(t, []int64{1, 2}, flushed.Collect())
+		assert.Equal(t, []int64{3}, dropped.Collect())
+	})
+
+	t.Run("keeps child when fallback parent is not explicitly ready", func(t *testing.T) {
+		segments := map[int64]*SegmentInfo{
+			1: segment(1, commonpb.SegmentState_Dropped),
+			2: segment(2, commonpb.SegmentState_Flushed, 1),
+		}
+		flushed, dropped := retrieveSegment(
+			segments,
+			typeutil.NewUniqueSet(2),
+			typeutil.NewUniqueSet(1),
+			func(segmentID UniqueID) bool { return segmentID == 1 },
+			func(UniqueID) bool { return false },
+		)
+
+		assert.Equal(t, []int64{2}, flushed.Collect())
+		assert.Equal(t, []int64{1}, dropped.Collect())
+	})
+
+	t.Run("cancels fallback on partial ancestor coverage", func(t *testing.T) {
+		segments := map[int64]*SegmentInfo{
+			1: segment(1, commonpb.SegmentState_Dropped),
+			2: segment(2, commonpb.SegmentState_Dropped),
+			3: segment(3, commonpb.SegmentState_Dropped, 1, 2),
+			4: segment(4, commonpb.SegmentState_Flushed, 1, 2),
+			5: segment(5, commonpb.SegmentState_Dropped),
+			6: segment(6, commonpb.SegmentState_Flushed, 3, 5),
+		}
+		indexed := typeutil.NewUniqueSet(1, 2, 6)
+		flushed, dropped := retrieveSegment(
+			segments,
+			typeutil.NewUniqueSet(4, 6),
+			typeutil.NewUniqueSet(1, 2, 3, 5),
+			func(segmentID UniqueID) bool { return indexed.Contain(segmentID) },
+			func(segmentID UniqueID) bool { return indexed.Contain(segmentID) },
+		)
+
+		assert.ElementsMatch(t, []int64{4, 6}, flushed.Collect())
+		assert.ElementsMatch(t, []int64{1, 2, 3, 5}, dropped.Collect())
+	})
+
+	t.Run("expands partial coverage through ready parents", func(t *testing.T) {
+		segments := map[int64]*SegmentInfo{
+			1: segment(1, commonpb.SegmentState_Dropped),
+			2: segment(2, commonpb.SegmentState_Dropped),
+			3: segment(3, commonpb.SegmentState_Dropped, 1, 2),
+			4: segment(4, commonpb.SegmentState_Flushed, 1, 2),
+			5: segment(5, commonpb.SegmentState_Dropped),
+			6: segment(6, commonpb.SegmentState_Flushed, 3, 5),
+		}
+		indexed := typeutil.NewUniqueSet(1, 2, 3, 5, 6)
+		flushed, dropped := retrieveSegment(
+			segments,
+			typeutil.NewUniqueSet(4, 6),
+			typeutil.NewUniqueSet(1, 2, 3, 5),
+			func(segmentID UniqueID) bool { return indexed.Contain(segmentID) },
+			func(segmentID UniqueID) bool { return indexed.Contain(segmentID) },
+		)
+
+		assert.ElementsMatch(t, []int64{1, 2, 5}, flushed.Collect())
+		assert.Equal(t, []int64{3}, dropped.Collect())
+	})
+}
 
 func TestGetQueryVChanPositionsRetrieveM2N(t *testing.T) {
 	svr := newTestServer(t)
@@ -595,8 +821,9 @@ func TestGetQueryVChanPositions_Retrieve_unIndexed(t *testing.T) {
 		//        \         /     \        /                              |
 		//         \       /       \      /                               |
 		//           [16u]          [17u]       [18u](unsorted)     [20u](sorted)      [21i](unsorted)
-		// all leaf nodes are [1,2,3,4,5,6,7], but because segment3 has been gced, the leaf node becomes [7,8,9,10,4,5,6]
-		// should be returned: flushed: [7, 8, 9, 10, 4, 5, 6, 20, 21], growing: [18]
+		// Segments 7-15 are not valid fallbacks for the current frontier, so keep
+		// their children 16 and 17. The independent leaves 20 and 21 are unchanged.
+		// Expected: flushed [16, 17, 20, 21], growing [18].
 		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 		schema := newTestSchema()
@@ -971,9 +1198,9 @@ func TestGetQueryVChanPositions_Retrieve_unIndexed(t *testing.T) {
 		assert.NoError(t, err)
 
 		vchan := svr.handler.GetQueryVChanPositions(&channelMeta{Name: "ch1", CollectionID: 0})
-		assert.ElementsMatch(t, []int64{7, 8, 9, 10, 4, 5, 6, 20, 21}, vchan.FlushedSegmentIds)
+		assert.ElementsMatch(t, []int64{16, 17, 20, 21}, vchan.FlushedSegmentIds)
 		assert.ElementsMatch(t, []int64{18}, vchan.UnflushedSegmentIds)
-		assert.ElementsMatch(t, []int64{1, 2, 19}, vchan.DroppedSegmentIds)
+		assert.ElementsMatch(t, []int64{1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 19}, vchan.DroppedSegmentIds)
 	})
 
 	t.Run("compaction iterate", func(t *testing.T) {

--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -1776,9 +1776,9 @@ func TestGetRecoveryInfo(t *testing.T) {
 		assert.EqualValues(t, commonpb.ErrorCode_Success, resp.GetStatus().GetErrorCode())
 		assert.NotNil(t, resp.GetChannels()[0].SeekPosition)
 		assert.NotEqual(t, 0, resp.GetChannels()[0].GetSeekPosition().GetTimestamp())
-		assert.Len(t, resp.GetChannels()[0].GetDroppedSegmentIds(), 0)
+		assert.ElementsMatch(t, []UniqueID{9, 10, 11, 12}, resp.GetChannels()[0].GetDroppedSegmentIds())
 		assert.ElementsMatch(t, []UniqueID{}, resp.GetChannels()[0].GetUnflushedSegmentIds())
-		// assert.ElementsMatch(t, []UniqueID{9, 10, 12}, resp.GetChannels()[0].GetFlushedSegmentIds())
+		assert.ElementsMatch(t, []UniqueID{13}, resp.GetChannels()[0].GetFlushedSegmentIds())
 	})
 
 	t.Run("with closed server", func(t *testing.T) {

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -1687,9 +1687,9 @@ func TestGetRecoveryInfoV2(t *testing.T) {
 		assert.EqualValues(t, commonpb.ErrorCode_Success, resp.GetStatus().GetErrorCode())
 		assert.NotNil(t, resp.GetChannels()[0].SeekPosition)
 		assert.NotEqual(t, 0, resp.GetChannels()[0].GetSeekPosition().GetTimestamp())
-		assert.Len(t, resp.GetChannels()[0].GetDroppedSegmentIds(), 0)
+		assert.ElementsMatch(t, []UniqueID{9, 10, 11, 12}, resp.GetChannels()[0].GetDroppedSegmentIds())
 		// assert.ElementsMatch(t, []UniqueID{}, resp.GetChannels()[0].GetUnflushedSegmentIds())
-		// assert.ElementsMatch(t, []UniqueID{9, 10, 12}, resp.GetChannels()[0].GetFlushedSegmentIds())
+		assert.ElementsMatch(t, []UniqueID{13}, resp.GetChannels()[0].GetFlushedSegmentIds())
 	})
 
 	t.Run("with closed server", func(t *testing.T) {


### PR DESCRIPTION
issue: #52431
pr: #52741

## Summary
- Normalize an interrupted compaction view before index fallback. If every direct compactFrom remains in the view, retain compactFrom because compactTo may be incomplete; once any compactFrom has retired, retain compactTo because outputs are published first.
- Replace a child only when its complete direct parent set is ready for the current schema.
- Resolve M:N overlap by expanding through ready parents; if that is impossible, cancel the conflicting fallback and keep the child.

## Verification
- Includes the same focused DataCoord regression cases as the master PR; CP CI is pending for the current commit.
- An earlier master revision completed a local-only 10-minute randomized stress test with 180,663 iterations, 100 initial segments, and 100 compactions per iteration. The temporary stress test is not included in either PR.