### PR TITLE
enhance: [2.6] support weights for RRF reranking

### DIFF
--- a/client/entity/function.go
+++ b/client/entity/function.go
@@ -77,7 +77,10 @@ func (f *Function) WithType(funcType FunctionType) *Function {
 
 func (f *Function) WithParam(key string, value any) *Function {
 	// Handle slices by converting to JSON format
-	if reflect.TypeOf(value).Kind() == reflect.Slice {
+	valueType := reflect.TypeOf(value)
+	if valueType == nil {
+		f.Params[key] = "null"
+	} else if valueType.Kind() == reflect.Slice {
 		if jsonBytes, err := json.Marshal(value); err == nil {
 			f.Params[key] = string(jsonBytes)
 		} else {

--- a/client/entity/function_test.go
+++ b/client/entity/function_test.go
@@ -64,6 +64,10 @@ func TestFunctionWithParamSliceHandling(t *testing.T) {
 	f = NewFunction().WithParam("empty_slice_key", []string{})
 	assert.Equal(t, "[]", f.Params["empty_slice_key"])
 
+	// Test nil without panicking
+	f = NewFunction().WithParam("nil_key", nil)
+	assert.Equal(t, "null", f.Params["nil_key"])
+
 	// Test the JSON marshal error fallback path
 	type unmarshalableType struct {
 		Channel chan int

--- a/client/milvusclient/reranker.go
+++ b/client/milvusclient/reranker.go
@@ -21,7 +21,8 @@ type Reranker interface {
 }
 
 type rrfReranker struct {
-	K float64 `json:"k,omitempty"`
+	K       float64 `json:"k,omitempty"`
+	weights *[]float64
 }
 
 func (r *rrfReranker) WithK(k float64) *rrfReranker {
@@ -29,8 +30,28 @@ func (r *rrfReranker) WithK(k float64) *rrfReranker {
 	return r
 }
 
+// WithWeights sets optional reciprocal-rank coefficients in ANN request order.
+// The server requires a non-empty slice, one value in [0, 1] per ANN request;
+// nil and empty slices are serialized so the server can reject them.
+func (r *rrfReranker) WithWeights(weights []float64) *rrfReranker {
+	var copied []float64
+	if weights != nil {
+		copied = make([]float64, len(weights))
+		copy(copied, weights)
+	}
+	r.weights = &copied
+	return r
+}
+
 func (r *rrfReranker) GetParams() []*commonpb.KeyValuePair {
-	bs, _ := json.Marshal(r)
+	params := struct {
+		K       float64    `json:"k,omitempty"`
+		Weights *[]float64 `json:"weights,omitempty"`
+	}{
+		K:       r.K,
+		Weights: r.weights,
+	}
+	bs, _ := json.Marshal(params)
 
 	return []*commonpb.KeyValuePair{
 		{Key: rerankType, Value: rrfRerankType},

--- a/client/milvusclient/reranker_test.go
+++ b/client/milvusclient/reranker_test.go
@@ -44,6 +44,18 @@ func TestReranker(t *testing.T) {
 		params = rr.GetParams()
 		assert.True(t, checkParam(params, rerankType, rrfRerankType))
 		assert.True(t, checkParam(params, rerankParams, `{"k":50}`))
+
+		rr.WithWeights([]float64{0.8, 0.2})
+		params = rr.GetParams()
+		assert.True(t, checkParam(params, rerankParams, `{"k":50,"weights":[0.8,0.2]}`))
+
+		emptyWeights := NewRRFReranker().WithWeights([]float64{})
+		params = emptyWeights.GetParams()
+		assert.True(t, checkParam(params, rerankParams, `{"k":60,"weights":[]}`))
+
+		nullWeights := NewRRFReranker().WithWeights(nil)
+		params = nullWeights.GetParams()
+		assert.True(t, checkParam(params, rerankParams, `{"k":60,"weights":null}`))
 	})
 
 	t.Run("weightedReranker", func(t *testing.T) {

--- a/docs/design-docs/design_docs/20260824-weighted-rrf-reranking.md
+++ b/docs/design-docs/design_docs/20260824-weighted-rrf-reranking.md
@@ -1,0 +1,220 @@
+# MEP: Weighted Reciprocal Rank Fusion Reranking
+
+- **Created:** 2026-08-24
+- **Author(s):** @AmSmart
+- **Status:** Draft
+- **Component:** Proxy
+- **Related Issues:** #52817
+- **Released:** TBD
+
+## Summary
+
+Extend the existing Reciprocal Rank Fusion (RRF) reranker with an optional
+`weights` parameter. Each weight applies to the hybrid-search ANN request at
+the same position. When weights are supplied, Milvus computes:
+
+```text
+score(d) = sum_i(weights[i] / (k + rank_i(d)))
+```
+
+Ranks are one-based. When `weights` is omitted, Milvus retains the existing
+RRF formula and scores exactly:
+
+```text
+score(d) = sum_i(1 / (k + rank_i(d)))
+```
+
+## Motivation
+
+Milvus currently provides two server-side fusion choices with different
+semantics:
+
+- RRF combines rank positions but gives every retrieval path equal influence.
+- The weighted reranker gives paths different influence but combines
+  normalized or direction-adjusted retrieval scores.
+
+Dense, sparse, BM25, and other retrieval paths often have different measured
+quality, while their raw scores are not necessarily comparable. Users who
+want both rank-only fusion and different path importance must currently issue
+separate searches and fuse the results in application code. That loses the
+single-request execution model and duplicates candidate-fusion logic outside
+Milvus.
+
+Weighted RRF fills this gap without introducing score normalization or
+metric-specific behavior.
+
+## Public Interfaces
+
+The existing RRF reranker accepts an optional `weights` array in its function
+parameters:
+
+```python
+ranker = Function(
+    name="weighted_rrf",
+    input_field_names=[],
+    function_type=FunctionType.RERANK,
+    params={
+        "reranker": "rrf",
+        "k": 60,
+        "weights": [0.7, 0.3],
+    },
+)
+```
+
+The legacy hybrid-search rank parameters accept the same option:
+
+```json
+{
+  "strategy": "rrf",
+  "params": {
+    "k": 60,
+    "weights": [0.7, 0.3]
+  }
+}
+```
+
+The weight at index `i` applies to ANN request `i`. The validation contract is:
+
+- `weights` is optional.
+- When supplied, it must be a non-empty JSON array of numbers.
+- Each value must be in the inclusive range `[0, 1]`.
+- The array length must equal the number of ANN search requests.
+- Values are not normalized and do not need to sum to one.
+
+The generic reranker parameter fields already carry JSON-encoded arrays, so
+this change does not require a protobuf or REST schema change. The Go client
+RRF helper adds an optional `WithWeights` convenience method. Convenience APIs
+in other SDK repositories can be added independently.
+
+## Design Details
+
+### Parameter conversion and validation
+
+Both public reranker paths converge in the Proxy function-chain builder:
+
+- FunctionScore requests already expose function parameters as key/value
+  pairs.
+- Legacy rank parameters are converted to the same FunctionSchema shape. The
+  conversion will forward `weights` for RRF in addition to the existing `k`
+  parameter.
+
+The RRF builder parses `k` as it does today, parses optional weights, and
+validates the weight count against the ordered search-metric list. That list is
+built in the same order as the hybrid-search sub-requests, preserving the
+public positional mapping.
+
+An omitted `weights` parameter remains distinguishable from an explicitly
+empty or null value. Omission selects classic RRF. Empty, null, malformed,
+out-of-range, or length-mismatched values return a parameter error before the
+merge executes.
+
+### Merge execution
+
+The existing MergeOp already stores per-input weights for weighted score
+fusion. RRF reuses that configuration field without enabling score
+normalization or metric conversion.
+
+For every query chunk, the RRF collector iterates each input list in request
+order. Rank resets for each input and is `row index + 1`. The contribution is:
+
+```text
+path_weight / (k + rank)
+```
+
+When optional weights are absent, `path_weight` is exactly `1`. This preserves
+both ordering and the exposed float scores produced by existing RRF requests;
+it does not substitute `1 / number_of_paths`.
+
+Documents missing from a path receive no contribution from that path. A
+zero-weight path contributes zero while its candidates remain part of the
+merged candidate union, consistent with the existing merge operator model.
+All-zero weights are permitted and produce deterministic tie ordering by the
+existing primary-key tie breaker.
+
+The execution layer also checks that configured weights match the actual input
+count and contain only finite values in `[0, 1]`. This is defense in depth for
+programmatic MergeOp construction and internal contract violations;
+user-facing validation remains in the builder.
+
+### Scoring and ordering
+
+RRF remains metric-agnostic. Original similarity or distance scores are not
+read, and score normalization is not applied. Fused scores remain descending:
+larger values rank first. Existing primary-key tie breaking, grouping,
+rounding, limiting, and output selection remain unchanged.
+
+## Compatibility, Deprecation, and Migration Plan
+
+This change is backward-compatible:
+
+- Existing RRF requests without `weights` produce the same ordering and scores.
+- Existing `k` defaults and validation remain unchanged.
+- The existing weighted score reranker is unchanged.
+- No wire fields, persisted metadata, storage formats, or configuration values
+  change.
+- Mixed-version clients can send classic RRF as before. Servers predating this
+  enhancement silently ignore unknown RRF function parameters, while their
+  legacy converter drops RRF weights, so clients must version-gate weighted
+  RRF rather than assume an older server will reject it.
+- Requests with invalid reranker parameters now return a parameter error even
+  when every sub-search returns empty results (previously they succeeded with
+  empty results). Validation is now independent of result content.
+
+No migration or deprecation is required. Omitting the parameter restores
+classic RRF. Rolling back to an older server also silently restores classic
+RRF even if a client continues to send weights.
+
+## Test Plan
+
+Unit tests will cover:
+
+- omitted weights preserve classic RRF scores;
+- all-one weights are equivalent to omitted weights;
+- unequal weights change exact scores and ordering according to the formula;
+- zero and one are accepted weight boundaries;
+- weights are not required to sum to one;
+- malformed, null, empty, negative, greater-than-one, and length-mismatched
+  weights are rejected;
+- FunctionScore and legacy rank parameters produce the same MergeOp
+  configuration;
+- execution-time input-count mismatch returns an internal contract error;
+- Go client RRF parameters serialize optional weights correctly.
+
+Query-level tests will verify that hybrid search accepts valid RRF weights and
+rejects invalid or mismatched weights through both the public Function API and
+the legacy typed RRF helper.
+
+## Rejected Alternatives
+
+### Use the existing weighted score reranker
+
+The weighted reranker combines retrieval scores after normalization or metric
+direction handling. That is different from rank-only fusion and can remain
+sensitive to score distributions. It does not satisfy the requested semantics.
+
+### Perform weighted RRF in application code
+
+Application-side fusion requires separate result handling, transfers more
+candidates to the client, and prevents Milvus from applying the final fusion,
+limit, grouping, and requery pipeline in one request.
+
+### Add a separate `weighted_rrf` reranker name
+
+Weighted RRF differs from RRF by one optional coefficient per input. Extending
+the existing RRF parameters keeps classic RRF as the default, avoids another
+top-level strategy, and matches the existing parameterized `k` design.
+
+### Normalize weights automatically
+
+Scaling every weight by the same positive constant does not change result
+ordering, but it does change exposed fused scores. Implicit normalization would
+make the requested coefficients less transparent. Milvus therefore uses the
+provided values directly.
+
+## References
+
+- Issue #52817: Support per-path weights in RRF reranking
+- Issue #52319: FunctionChain roadmap
+- Issue #46565: FunctionChain umbrella
+- Cormack, Clarke, and Buettcher, "Reciprocal Rank Fusion Outperforms Condorcet
+  and Individual Rank Learning Methods," SIGIR 2009

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -3264,7 +3264,10 @@ func genFunctionSchema(ctx context.Context, function *FunctionSchema) (*schemapb
 	description := function.Description
 	params := []*commonpb.KeyValuePair{}
 	for key, value := range function.Params {
-		if reflect.TypeOf(value).Kind() == reflect.Slice || reflect.TypeOf(value).Kind() == reflect.Map {
+		valueType := reflect.TypeOf(value)
+		if valueType == nil {
+			params = append(params, &commonpb.KeyValuePair{Key: key, Value: "null"})
+		} else if valueType.Kind() == reflect.Slice || valueType.Kind() == reflect.Map {
 			bs, err := json.Marshal(value)
 			if err != nil {
 				return nil, merr.WrapErrParameterInvalidMsg("Marshal function params fail, please check it!")

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
@@ -3323,11 +3324,16 @@ func TestGenFunctionSchem(t *testing.T) {
 				"test2": map[string]interface{}{
 					"test3": "test4",
 				},
-				"test3": []int{1, 2, 3},
+				"test3":   []int{1, 2, 3},
+				"test4":   nil,
+				"weights": []float64{0.7, 0.3},
 			},
 		}
-		_, err := genFunctionSchema(context.Background(), funcSchema)
+		result, err := genFunctionSchema(context.Background(), funcSchema)
 		assert.NoError(t, err)
+		params := funcutil.KeyValuePair2Map(result.GetParams())
+		assert.Equal(t, "null", params["test4"])
+		assert.Equal(t, "[0.7,0.3]", params["weights"])
 	}
 }
 

--- a/internal/util/function/rerank/function_score.go
+++ b/internal/util/function/rerank/function_score.go
@@ -236,6 +236,13 @@ func newFunctionScoreWithlegacy(collSchema *schemapb.CollectionSchema, rankParam
 				return nil, merr.WrapErrParameterInvalidMsg("the type of rank param k should be float")
 			}
 		}
+		if value, ok := params[WeightsParamsKey]; ok {
+			data, err := json.Marshal(value)
+			if err != nil {
+				return nil, merr.WrapErrParameterInvalidMsg("the weights param should be an array")
+			}
+			fSchema.Params = append(fSchema.Params, &commonpb.KeyValuePair{Key: WeightsParamsKey, Value: string(data)})
+		}
 	case weightedRankType:
 		fSchema.Params = append(fSchema.Params, &commonpb.KeyValuePair{Key: reranker, Value: WeightedName})
 		if v, ok := params[WeightsParamsKey]; ok {

--- a/internal/util/function/rerank/function_score_test.go
+++ b/internal/util/function/rerank/function_score_test.go
@@ -376,6 +376,19 @@ func (s *FunctionScoreSuite) TestlegacyFunction() {
 	}
 	{
 		rankParams := []*commonpb.KeyValuePair{
+			{Key: legacyRankTypeKey, Value: "rrf"},
+			{Key: legacyRankParamsKey, Value: `{"k": 30, "weights": [0.8, 0.2]}`},
+		}
+		f, err := NewFunctionScoreWithlegacy(schema, rankParams)
+		s.Require().NoError(err)
+		rrf, ok := f.reranker.(*RRFFunction[int64])
+		s.Require().True(ok)
+		s.Equal(float32(30), rrf.k)
+		s.Equal([]float64{0.8, 0.2}, rrf.weights)
+		s.True(rrf.weightsSet)
+	}
+	{
+		rankParams := []*commonpb.KeyValuePair{
 			{Key: legacyRankTypeKey, Value: "weighted"},
 			{Key: legacyRankParamsKey, Value: `{"weights": [1.0]}`},
 		}

--- a/internal/util/function/rerank/rrf_function.go
+++ b/internal/util/function/rerank/rrf_function.go
@@ -20,6 +20,7 @@ package rerank
 
 import (
 	"context"
+	"encoding/json"
 	"strconv"
 	"strings"
 
@@ -36,7 +37,9 @@ const (
 type RRFFunction[T PKType] struct {
 	RerankBase
 
-	k float32
+	k          float32
+	weights    []float64
+	weightsSet bool
 }
 
 func newRRFFunction(collSchema *schemapb.CollectionSchema, funcSchema *schemapb.FunctionSchema, pkTypeOverride ...schemapb.DataType) (Reranker, error) {
@@ -50,24 +53,63 @@ func newRRFFunction(collSchema *schemapb.CollectionSchema, funcSchema *schemapb.
 	}
 
 	k := float64(defaultRRFParamsValue)
+	var weights []float64
+	weightsSet := false
 	for _, param := range funcSchema.Params {
-		if strings.ToLower(param.Key) == RRFParamsKey {
+		switch strings.ToLower(param.Key) {
+		case RRFParamsKey:
 			if k, err = strconv.ParseFloat(param.Value, 64); err != nil {
 				return nil, merr.WrapErrParameterInvalidMsg("param k:%s is not a number", param.Value)
 			}
+		case WeightsParamsKey:
+			weights, err = parseRRFWeights(param.Value)
+			if err != nil {
+				return nil, err
+			}
+			weightsSet = true
 		}
 	}
 	if k <= 0 || k >= 16384 {
 		return nil, merr.WrapErrParameterInvalidMsg("the rank params k should be in range (0, %d)", 16384)
 	}
 	if base.pkType == schemapb.DataType_Int64 {
-		return &RRFFunction[int64]{RerankBase: *base, k: float32(k)}, nil
+		return &RRFFunction[int64]{RerankBase: *base, k: float32(k), weights: weights, weightsSet: weightsSet}, nil
 	} else {
-		return &RRFFunction[string]{RerankBase: *base, k: float32(k)}, nil
+		return &RRFFunction[string]{RerankBase: *base, k: float32(k), weights: weights, weightsSet: weightsSet}, nil
 	}
 }
 
+func parseRRFWeights(value string) ([]float64, error) {
+	var rawWeights []json.RawMessage
+	if err := json.Unmarshal([]byte(value), &rawWeights); err != nil {
+		return nil, merr.WrapErrParameterInvalidMsg("failed to parse weights: %v", err)
+	}
+	if len(rawWeights) == 0 {
+		return nil, merr.WrapErrParameterInvalidMsg("rrf weights parameter must be a non-empty array")
+	}
+
+	weights := make([]float64, len(rawWeights))
+	for index, rawWeight := range rawWeights {
+		if string(rawWeight) == "null" {
+			return nil, merr.WrapErrParameterInvalidMsg("failed to parse weights: weight at index %d must be a number", index)
+		}
+		if err := json.Unmarshal(rawWeight, &weights[index]); err != nil {
+			return nil, merr.WrapErrParameterInvalidMsg("failed to parse weights: weight at index %d must be a number", index)
+		}
+		if weights[index] < 0 || weights[index] > 1 {
+			return nil, merr.WrapErrParameterInvalidMsg("rank param weight should be in range [0, 1]")
+		}
+	}
+	return weights, nil
+}
+
 func (rrf *RRFFunction[T]) processOneSearchData(ctx context.Context, searchParams *SearchParams, cols []*columns, idGroup map[any]any) (*IDScores[T], error) {
+	if rrf.weightsSet && len(rrf.weights) != len(cols) {
+		return nil, merr.WrapErrParameterInvalidMsg(
+			"the length of weights param mismatch with ann search requests: got %d, want %d",
+			len(rrf.weights), len(cols))
+	}
+
 	rrfScores := map[T]float32{}
 	idLocations := make(map[T]IDLoc)
 	for i, col := range cols {
@@ -75,12 +117,20 @@ func (rrf *RRFFunction[T]) processOneSearchData(ctx context.Context, searchParam
 			continue
 		}
 		ids := col.ids.([]T)
+		pathWeight := 1.0
+		if rrf.weightsSet {
+			pathWeight = rrf.weights[i]
+		}
 		for idx, id := range ids {
+			rrfScore := 1 / (rrf.k + float32(idx+1))
+			if rrf.weightsSet {
+				rrfScore = float32(pathWeight / float64(rrf.k+float32(idx+1)))
+			}
 			if score, ok := rrfScores[id]; !ok {
 				idLocations[id] = IDLoc{batchIdx: i, offset: idx + int(col.nqOffset)}
-				rrfScores[id] = 1 / (rrf.k + float32(idx+1))
+				rrfScores[id] = rrfScore
 			} else {
-				rrfScores[id] = score + 1/(rrf.k+float32(idx+1))
+				rrfScores[id] = score + rrfScore
 			}
 		}
 	}

--- a/internal/util/function/rerank/rrf_function_test.go
+++ b/internal/util/function/rerank/rrf_function_test.go
@@ -86,6 +86,73 @@ func (s *RRFFunctionSuite) TestNewRRFFuction() {
 	}
 }
 
+func (s *RRFFunctionSuite) TestRRFWeightsValidation() {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr string
+	}{
+		{name: "malformed", value: "not-json", wantErr: "failed to parse weights"},
+		{name: "not numeric", value: `["0.8", 0.2]`, wantErr: "failed to parse weights"},
+		{name: "null element", value: "[null, 0.2]", wantErr: "failed to parse weights"},
+		{name: "null", value: "null", wantErr: "non-empty array"},
+		{name: "empty", value: "[]", wantErr: "non-empty array"},
+		{name: "negative", value: "[-0.1, 0.2]", wantErr: "range [0, 1]"},
+		{name: "greater than one", value: "[0.8, 1.1]", wantErr: "range [0, 1]"},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			_, err := parseRRFWeights(test.value)
+			s.ErrorContains(err, test.wantErr)
+		})
+	}
+
+	weights, err := parseRRFWeights("[0, 0.3, 1]")
+	s.NoError(err)
+	s.Equal([]float64{0, 0.3, 1}, weights)
+}
+
+func (s *RRFFunctionSuite) TestWeightedRRFProducesExpectedScoresAndOrder() {
+	cols := []*columns{
+		{size: 3, ids: []int64{1, 2, 3}},
+		{size: 3, ids: []int64{3, 2, 4}},
+	}
+	params := NewSearchParams(1, 4, 0, -1, -1, 1, false, "", []string{"COSINE", "IP"})
+	rrf := &RRFFunction[int64]{k: 1, weights: []float64{0.7, 0.2}, weightsSet: true}
+
+	result, err := rrf.processOneSearchData(context.Background(), params, cols, nil)
+	s.Require().NoError(err)
+	s.Equal([]int64{1, 2, 3, 4}, result.ids)
+	expectedScores := []float64{0.35, 0.3, 0.275, 0.05}
+	for index, expected := range expectedScores {
+		s.InDelta(expected, result.scores[index], 1e-6)
+	}
+}
+
+func (s *RRFFunctionSuite) TestRRFWeightsCompatibilityAndValidationAtExecution() {
+	cols := []*columns{
+		{size: 2, ids: []int64{3, 1}},
+		{size: 2, ids: []int64{2, 1}},
+	}
+	params := NewSearchParams(1, 4, 0, -1, -1, 1, false, "", []string{"COSINE", "IP"})
+
+	classic, err := (&RRFFunction[int64]{k: 60}).processOneSearchData(context.Background(), params, cols, nil)
+	s.Require().NoError(err)
+	allOne, err := (&RRFFunction[int64]{k: 60, weights: []float64{1, 1}, weightsSet: true}).processOneSearchData(context.Background(), params, cols, nil)
+	s.Require().NoError(err)
+	s.Equal(classic.ids, allOne.ids)
+	s.Equal(classic.scores, allOne.scores)
+
+	allZero, err := (&RRFFunction[int64]{k: 60, weights: []float64{0, 0}, weightsSet: true}).processOneSearchData(context.Background(), params, cols, nil)
+	s.Require().NoError(err)
+	s.Equal([]int64{1, 2, 3}, allZero.ids)
+	s.Equal([]float32{0, 0, 0}, allZero.scores)
+
+	_, err = (&RRFFunction[int64]{k: 60, weights: []float64{1}, weightsSet: true}).processOneSearchData(context.Background(), params, cols, nil)
+	s.ErrorContains(err, "the length of weights param mismatch with ann search requests")
+}
+
 func (s *RRFFunctionSuite) TestRRFFuctionProcess() {
 	schema := &schemapb.CollectionSchema{
 		Name: "test",

--- a/tests/go_client/testcases/hybrid_search_test.go
+++ b/tests/go_client/testcases/hybrid_search_test.go
@@ -166,6 +166,7 @@ func TestHybridSearchMultiVectorsDefault(t *testing.T) {
 		// search with different reranker
 		for _, reranker := range []client.Reranker{
 			client.NewRRFReranker(),
+			client.NewRRFReranker().WithWeights([]float64{0.2, 0.3}),
 			client.NewWeightedReranker([]float64{0.8, 0.2}),
 			client.NewWeightedReranker([]float64{0.0, 0.2}),
 			client.NewWeightedReranker([]float64{0.4, 1.0}),
@@ -223,6 +224,18 @@ func TestHybridSearchInvalidParams(t *testing.T) {
 	} {
 		_, errReranker := mc.HybridSearch(ctx, client.NewHybridSearchOption(schema.CollectionName, common.DefaultLimit, annReq1, annReq2).WithReranker(invalidRanker))
 		common.CheckErr(t, errReranker, false, "rank param weight should be in range [0, 1]",
+			"the length of weights param mismatch with ann search requests")
+	}
+
+	// hybrid search with invalid weighted RRF params
+	for _, invalidRanker := range []client.Reranker{
+		client.NewRRFReranker().WithWeights([]float64{}),
+		client.NewRRFReranker().WithWeights(nil),
+		client.NewRRFReranker().WithWeights([]float64{-0.1, 0.2}),
+		client.NewRRFReranker().WithWeights([]float64{0.8}),
+	} {
+		_, errReranker := mc.HybridSearch(ctx, client.NewHybridSearchOption(schema.CollectionName, common.DefaultLimit, annReq1, annReq2).WithReranker(invalidRanker))
+		common.CheckErr(t, errReranker, false, "non-empty array", "rank param weight should be in range [0, 1]",
 			"the length of weights param mismatch with ann search requests")
 	}
 

--- a/tests/go_client/testcases/reranker_function_test.go
+++ b/tests/go_client/testcases/reranker_function_test.go
@@ -337,13 +337,17 @@ func TestRerankFunctionRRF(t *testing.T) {
 	queryVec2 := hp.GenSearchVectors(common.DefaultNq, common.DefaultDim, entity.FieldTypeFloat16Vector)
 
 	testCases := []struct {
-		name string
-		k    int
+		name    string
+		k       int
+		weights []float64
 	}{
-		{"default_k", 60},
-		{"small_k", 10},
-		{"large_k", 100},
-		{"very_large_k", 1000},
+		{name: "default_k", k: 60},
+		{name: "small_k", k: 10},
+		{name: "large_k", k: 100},
+		{name: "very_large_k", k: 1000},
+		{name: "weighted_rrf", k: 60, weights: []float64{0.8, 0.2}},
+		{name: "weights_not_normalized", k: 60, weights: []float64{0.2, 0.3}},
+		{name: "all_zero_weights", k: 60, weights: []float64{0, 0}},
 	}
 
 	for _, tc := range testCases {
@@ -354,6 +358,9 @@ func TestRerankFunctionRRF(t *testing.T) {
 				WithInputFields().
 				WithParam("reranker", "rrf").
 				WithParam("k", tc.k)
+			if tc.weights != nil {
+				rrfReranker.WithParam("weights", tc.weights)
+			}
 
 			annReq1 := client.NewAnnRequest(common.DefaultFloatVecFieldName, common.DefaultLimit, queryVec1...)
 			annReq2 := client.NewAnnRequest(common.DefaultFloat16VecFieldName, common.DefaultLimit, queryVec2...)
@@ -364,6 +371,14 @@ func TestRerankFunctionRRF(t *testing.T) {
 
 			common.CheckErr(t, err, true)
 			validateRerankFunctionResults(t, results, common.DefaultLimit)
+			if tc.name == "all_zero_weights" {
+				for _, result := range results {
+					require.Positive(t, result.ResultCount)
+					for _, score := range result.Scores {
+						require.Zero(t, score)
+					}
+				}
+			}
 		})
 	}
 }
@@ -577,6 +592,48 @@ func TestRerankFunctionRRFNegative(t *testing.T) {
 				WithInputFields().
 				WithParam("reranker", "rrf").
 				WithParam("k", tc.k)
+
+			_, err := mc.HybridSearch(ctx, client.NewHybridSearchOption(
+				schema.CollectionName, common.DefaultLimit, annReq1, annReq2,
+			).WithFunctionRerankers(rrfReranker))
+
+			common.CheckErr(t, err, false, tc.expectedError)
+		})
+	}
+}
+
+func TestRerankFunctionRRFWeightsNegative(t *testing.T) {
+	t.Parallel()
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	_, schema := createRerankFunctionTestCollection(ctx, t, mc, false)
+
+	queryVec1 := hp.GenSearchVectors(1, common.DefaultDim, entity.FieldTypeFloatVector)
+	queryVec2 := hp.GenSearchVectors(1, common.DefaultDim, entity.FieldTypeFloat16Vector)
+	annReq1 := client.NewAnnRequest(common.DefaultFloatVecFieldName, common.DefaultLimit, queryVec1...)
+	annReq2 := client.NewAnnRequest(common.DefaultFloat16VecFieldName, common.DefaultLimit, queryVec2...)
+
+	testCases := []struct {
+		name          string
+		weights       interface{}
+		expectedError string
+	}{
+		{name: "empty", weights: []float64{}, expectedError: "non-empty array"},
+		{name: "null", weights: nil, expectedError: "non-empty array"},
+		{name: "negative", weights: []float64{-0.1, 0.2}, expectedError: "range [0, 1]"},
+		{name: "greater_than_one", weights: []float64{0.8, 1.1}, expectedError: "range [0, 1]"},
+		{name: "count_mismatch", weights: []float64{0.8}, expectedError: "length of weights param mismatch"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rrfReranker := entity.NewFunction().
+				WithName("test_rrf_weights_negative_"+tc.name).
+				WithType(entity.FunctionTypeRerank).
+				WithInputFields().
+				WithParam("reranker", "rrf").
+				WithParam("weights", tc.weights)
 
 			_, err := mc.HybridSearch(ctx, client.NewHybridSearchOption(
 				schema.CollectionName, common.DefaultLimit, annReq1, annReq2,


### PR DESCRIPTION
issue: #52817
pr: #52818
design doc: docs/design-docs/design_docs/20260824-weighted-rrf-reranking.md

## What changed

Backport #52818 to 2.6.

- Accept optional per-ANN-request `weights` for RRF through FunctionScore and legacy hybrid-search rank parameters.
- Apply `weight[i] / (k + rank)` while preserving the classic RRF path when weights are omitted.
- Add REST parameter handling and the Go client `WithWeights` helper.
- Adapt the server-side implementation to the 2.6 `internal/util/function/rerank` architecture.
- Validate malformed, null, empty, out-of-range, and request-count-mismatched weights.

## Validation

- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./entity ./milvusclient` from `client/` passes.
- `git diff --check` passes.
- Focused server tests were attempted but cannot run in this local environment because `milvus_core.pc` and `rocksdb.pc` are unavailable; Go 1.26 also cannot compile the release branch older sonic dependency. CI should run the native-backed server suites.