### PR TITLE
fix: prevent ID exhaustion in large backup restores

### DIFF
--- a/internal/datacoord/import_util.go
+++ b/internal/datacoord/import_util.go
@@ -346,16 +346,19 @@ func AssembleImportRequest(task ImportTask, job ImportJob, meta *meta, alloc all
 		return stat.GetTotalRows()
 	})
 
-	// Pre-allocate IDs for autoIDs and logIDs.
+	// Pre-allocate IDs for output logIDs and row IDs on legacy or missing-system-field paths.
 	fieldsNum := len(job.GetSchema().GetFields()) + 2 // userFields + tsField + rowIDField
 	binlogNum := fieldsNum + 2                        // binlogs + statslog + BM25Statslog
 	expansionFactor := paramtable.Get().DataCoordCfg.ImportPreAllocIDExpansionFactor.GetAsInt64()
-	preAllocIDNum := (totalRows + 1) * int64(binlogNum) * expansionFactor
+	preAllocIDNum, preAllocIDNumCapped, err := calculatePreAllocIDNum(totalRows, int64(binlogNum), expansionFactor)
+	if err != nil {
+		return nil, err
+	}
 
 	idBegin, idEnd, err := common.AllocAutoID(func(n uint32) (int64, int64, error) {
 		ids, ide, e := alloc.AllocN(int64(n))
 		return ids, ide, e
-	}, uint32(preAllocIDNum), Params.CommonCfg.ClusterID.GetAsUint64())
+	}, preAllocIDNum, Params.CommonCfg.ClusterID.GetAsUint64())
 	if err != nil {
 		return nil, err
 	}
@@ -363,6 +366,8 @@ func AssembleImportRequest(task ImportTask, job ImportJob, meta *meta, alloc all
 	mlog.Info(context.TODO(), "pre-allocate ids and ts for import task", WrapTaskLog(task,
 		mlog.Int64("totalRows", totalRows),
 		mlog.Int("fieldsNum", fieldsNum),
+		mlog.Uint32("preAllocIDNum", preAllocIDNum),
+		mlog.Bool("preAllocIDNumCapped", preAllocIDNumCapped),
 		mlog.Int64("idBegin", idBegin),
 		mlog.Int64("idEnd", idEnd),
 		mlog.Uint64("ts", ts))...,
@@ -414,6 +419,36 @@ func AssembleImportRequest(task ImportTask, job ImportJob, meta *meta, alloc all
 	}
 	WrapPluginContext(task.GetCollectionID(), job.GetSchema().GetProperties(), req)
 	return req, nil
+}
+
+func calculatePreAllocIDNum(totalRows, binlogNum, expansionFactor int64) (uint32, bool, error) {
+	if totalRows < 0 {
+		return 0, false, merr.WrapErrServiceInternalMsg(
+			"import total rows must not be negative: %d", totalRows,
+		)
+	}
+	if binlogNum <= 0 {
+		return 0, false, merr.WrapErrServiceInternalMsg(
+			"import binlog count must be positive: %d", binlogNum,
+		)
+	}
+	if expansionFactor <= 0 {
+		expansionFactor = 1
+	}
+
+	maxBatchSize := uint64(math.MaxUint32)
+	rows := uint64(totalRows) + 1
+	logs := uint64(binlogNum)
+	if rows > maxBatchSize/logs {
+		return math.MaxUint32, true, nil
+	}
+
+	baseIDs := rows * logs
+	if uint64(expansionFactor) > maxBatchSize/baseIDs {
+		// AllocIDRequest.Count is uint32; saturate instead of wrapping to a smaller range.
+		return math.MaxUint32, true, nil
+	}
+	return uint32(baseIDs * uint64(expansionFactor)), false, nil
 }
 
 func RegroupImportFiles(job ImportJob, files []*datapb.ImportFileStats, segmentMaxSize int) [][]*datapb.ImportFileStats {

--- a/internal/datacoord/import_util_test.go
+++ b/internal/datacoord/import_util_test.go
@@ -19,6 +19,7 @@ package datacoord
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/rand"
 	"path"
 	"strings"
@@ -50,6 +51,84 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/timerecord"
 )
+
+func TestCalculatePreAllocIDNum(t *testing.T) {
+	tests := []struct {
+		name           string
+		totalRows      int64
+		binlogNum      int64
+		expansion      int64
+		expectedNum    uint32
+		expectedCapped bool
+		expectedError  error
+	}{
+		{
+			name:        "normal",
+			totalRows:   100,
+			binlogNum:   11,
+			expansion:   10,
+			expectedNum: 11110,
+		},
+		{
+			name:           "expansion exceeds single batch",
+			totalRows:      78201209,
+			binlogNum:      11,
+			expansion:      10,
+			expectedNum:    math.MaxUint32,
+			expectedCapped: true,
+		},
+		{
+			name:           "base estimate exceeds single batch",
+			totalRows:      math.MaxUint32 / 11,
+			binlogNum:      11,
+			expansion:      1,
+			expectedNum:    math.MaxUint32,
+			expectedCapped: true,
+		},
+		{
+			name:           "int64 rows do not overflow calculation",
+			totalRows:      math.MaxInt64,
+			binlogNum:      11,
+			expansion:      10,
+			expectedNum:    math.MaxUint32,
+			expectedCapped: true,
+		},
+		{
+			name:          "negative rows",
+			totalRows:     -1,
+			binlogNum:     11,
+			expansion:     10,
+			expectedError: merr.ErrServiceInternal,
+		},
+		{
+			name:          "non-positive binlog count",
+			totalRows:     100,
+			binlogNum:     0,
+			expansion:     10,
+			expectedError: merr.ErrServiceInternal,
+		},
+		{
+			name:        "non-positive expansion uses one",
+			totalRows:   100,
+			binlogNum:   11,
+			expansion:   0,
+			expectedNum: 1111,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			num, capped, err := calculatePreAllocIDNum(test.totalRows, test.binlogNum, test.expansion)
+			if test.expectedError != nil {
+				require.ErrorIs(t, err, test.expectedError)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedNum, num)
+			assert.Equal(t, test.expectedCapped, capped)
+		})
+	}
+}
 
 func TestImportUtil_NewPreImportTasks(t *testing.T) {
 	fileGroups := [][]*internalpb.ImportFile{
@@ -229,7 +308,15 @@ func TestImportUtil_NewImportTasksWithDataTt(t *testing.T) {
 
 func TestImportUtil_AssembleRequest(t *testing.T) {
 	var job ImportJob = &importJob{
-		ImportJob: &datapb.ImportJob{JobID: 0, CollectionID: 1, PartitionIDs: []int64{2}, Vchannels: []string{"v0"}},
+		ImportJob: &datapb.ImportJob{
+			JobID:        0,
+			CollectionID: 1,
+			PartitionIDs: []int64{2},
+			Vchannels:    []string{"v0"},
+			// Seven user fields plus RowID/Timestamp produce the 11 logs per row
+			// from the restore that originally exposed the uint32 wrap.
+			Schema: &schemapb.CollectionSchema{Fields: make([]*schemapb.FieldSchema, 7)},
+		},
 	}
 	importMeta := NewMockImportMeta(t)
 	importMeta.EXPECT().GetJob(mock.Anything, mock.Anything).Return(job)
@@ -257,6 +344,7 @@ func TestImportUtil_AssembleRequest(t *testing.T) {
 		TaskID:       4,
 		CollectionID: 1,
 		SegmentIDs:   []int64{5, 6},
+		FileStats:    []*datapb.ImportFileStats{{TotalRows: 78201209}},
 	}
 	var task ImportTask = &importTask{
 		importMeta: importMeta,
@@ -278,9 +366,8 @@ func TestImportUtil_AssembleRequest(t *testing.T) {
 	catalog.EXPECT().ListExternalCollectionRefreshTasks(mock.Anything).Return(nil, nil)
 
 	alloc := allocator.NewMockAllocator(t)
-	alloc.EXPECT().AllocN(mock.Anything).RunAndReturn(func(n int64) (int64, int64, error) {
-		id := rand.Int63()
-		return id, id + n, nil
+	alloc.EXPECT().AllocN(int64(math.MaxUint32)).RunAndReturn(func(n int64) (int64, int64, error) {
+		return 1000, 1000 + n, nil
 	})
 	alloc.EXPECT().AllocTimestamp(mock.Anything).Return(800, nil)
 
@@ -304,6 +391,7 @@ func TestImportUtil_AssembleRequest(t *testing.T) {
 	assert.Equal(t, task.GetCollectionID(), importReq.GetCollectionID())
 	assert.Equal(t, job.GetPartitionIDs(), importReq.GetPartitionIDs())
 	assert.Equal(t, job.GetVchannels(), importReq.GetVchannels())
+	assert.Equal(t, int64(math.MaxUint32), importReq.GetIDRange().GetEnd()-importReq.GetIDRange().GetBegin())
 }
 
 func TestImportUtil_AssembleRequestWithDataTt(t *testing.T) {

--- a/internal/datanode/importv2/task_import.go
+++ b/internal/datanode/importv2/task_import.go
@@ -66,9 +66,9 @@ func NewImportTask(req *datapb.ImportRequest,
 	if importutilv2.IsBackup(req.GetOptions()) {
 		UnsetAutoID(req.GetSchema())
 	}
-	// Local allocator for binlog logIDs (and the legacy autoID fallback when a file
-	// carries no primary-allocated PK range). Deterministic cross-cluster autoID PKs
-	// are derived per file from ImportFile.PreAllocatedAutoIds, not from this allocator.
+	// Local allocator for binlog logIDs and for missing row IDs on legacy imports.
+	// Deterministic cross-cluster autoID PKs are derived per file from
+	// ImportFile.PreAllocatedAutoIds, not from this allocator.
 	alloc := allocator.NewLocalAllocator(req.GetIDRange().GetBegin(), req.GetIDRange().GetEnd())
 	task := &ImportTask{
 		ImportTaskV2: &datapb.ImportTaskV2{

--- a/internal/datanode/importv2/util.go
+++ b/internal/datanode/importv2/util.go
@@ -429,39 +429,45 @@ func appendSystemFieldsDataWithCursor(task *ImportTask, data *storage.InsertData
 	if err != nil {
 		return err
 	}
-	ids := make([]int64, rowNum)
-	var start int64
-	if cur != nil && cur.end > cur.begin {
-		// Deterministic path: derive PKs from the primary-allocated per-file range.
-		start, err = cur.take(rowNum)
-		if err != nil {
-			return err
-		}
-	} else {
-		// Legacy path: allocate PKs from the task's local allocator.
-		start, _, err = task.allocator.Alloc(uint32(rowNum))
-		if err != nil {
-			return err
-		}
-	}
-	for i := 0; i < rowNum; i++ {
-		ids[i] = start + int64(i)
-	}
 	pkData, ok := data.Data[pkField.GetFieldID()]
 	allowInsertAutoID, _ := common.IsAllowInsertAutoID(task.req.Schema.GetProperties()...)
-	if pkField.GetAutoID() && (!ok || pkData == nil || pkData.RowNum() == 0 || !allowInsertAutoID) {
-		switch pkField.GetDataType() {
-		case schemapb.DataType_Int64:
-			data.Data[pkField.GetFieldID()] = &storage.Int64FieldData{Data: ids}
-		case schemapb.DataType_VarChar:
-			strIDs := lo.Map(ids, func(id int64, _ int) string {
-				return strconv.FormatInt(id, 10)
-			})
-			data.Data[pkField.GetFieldID()] = &storage.StringFieldData{Data: strIDs}
+	generatePK := pkField.GetAutoID() && (!ok || pkData == nil || pkData.RowNum() == 0 || !allowInsertAutoID)
+	_, hasRowID := data.Data[common.RowIDField]
+	generateRowID := !hasRowID
+	if generatePK || generateRowID {
+		ids := make([]int64, rowNum)
+		var start int64
+		if cur != nil && cur.end > cur.begin {
+			// Deterministic path: derive PKs from the primary-allocated per-file range.
+			start, err = cur.take(rowNum)
+			if err != nil {
+				return err
+			}
+		} else {
+			// Legacy path: allocate PKs or missing RowIDs from the task's local allocator.
+			start, _, err = task.allocator.Alloc(uint32(rowNum))
+			if err != nil {
+				return err
+			}
 		}
-	}
-	if _, ok := data.Data[common.RowIDField]; !ok { // for binlog import, keep original rowID and ts
-		data.Data[common.RowIDField] = &storage.Int64FieldData{Data: ids}
+		for i := 0; i < rowNum; i++ {
+			ids[i] = start + int64(i)
+		}
+
+		if generatePK {
+			switch pkField.GetDataType() {
+			case schemapb.DataType_Int64:
+				data.Data[pkField.GetFieldID()] = &storage.Int64FieldData{Data: ids}
+			case schemapb.DataType_VarChar:
+				strIDs := lo.Map(ids, func(id int64, _ int) string {
+					return strconv.FormatInt(id, 10)
+				})
+				data.Data[pkField.GetFieldID()] = &storage.StringFieldData{Data: strIDs}
+			}
+		}
+		if generateRowID {
+			data.Data[common.RowIDField] = &storage.Int64FieldData{Data: ids}
+		}
 	}
 	if _, ok := data.Data[common.TimeStampField]; !ok {
 		tss := make([]int64, rowNum)

--- a/internal/datanode/importv2/util_test.go
+++ b/internal/datanode/importv2/util_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/importutilv2"
 	"github.com/milvus-io/milvus/internal/util/testutil"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
@@ -102,6 +103,51 @@ func Test_AppendSystemFieldsData(t *testing.T) {
 	assert.Equal(t, count, insertData.Data[common.TimeStampField].RowNum())
 }
 
+func Test_AppendSystemFieldsData_BackupKeepsIDsWithoutAllocation(t *testing.T) {
+	const count = 10
+	pkField := &schemapb.FieldSchema{
+		FieldID:      100,
+		Name:         "pk",
+		DataType:     schemapb.DataType_Int64,
+		IsPrimaryKey: true,
+		AutoID:       true,
+	}
+	vecField := &schemapb.FieldSchema{
+		FieldID: 101, Name: "vec", DataType: schemapb.DataType_FloatVector,
+		TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "4"}},
+	}
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{pkField, vecField}}
+
+	data, err := testutil.CreateInsertData(schema, count)
+	assert.NoError(t, err)
+	originalPK := &storage.Int64FieldData{Data: []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}}
+	originalRowID := &storage.Int64FieldData{Data: []int64{10, 11, 12, 13, 14, 15, 16, 17, 18, 19}}
+	originalTS := &storage.Int64FieldData{Data: []int64{20, 21, 22, 23, 24, 25, 26, 27, 28, 29}}
+	data.Data[pkField.GetFieldID()] = originalPK
+	data.Data[common.RowIDField] = originalRowID
+	data.Data[common.TimeStampField] = originalTS
+
+	// The range is deliberately smaller than rowNum. A backup batch already has
+	// PK, RowID and Timestamp, so it must not consume row IDs from the allocator.
+	task := NewImportTask(&datapb.ImportRequest{
+		Ts:      1000,
+		Schema:  schema,
+		IDRange: &datapb.IDRange{Begin: 1000, End: 1001},
+		Options: []*commonpb.KeyValuePair{{Key: importutilv2.BackupFlag, Value: "true"}},
+	}, nil, nil, nil).(*ImportTask)
+	assert.False(t, pkField.GetAutoID())
+	err = AppendSystemFieldsData(task, data, count)
+	assert.NoError(t, err)
+	assert.Same(t, originalPK, data.Data[pkField.GetFieldID()])
+	assert.Same(t, originalRowID, data.Data[common.RowIDField])
+	assert.Same(t, originalTS, data.Data[common.TimeStampField])
+
+	// The untouched range remains available for the output binlog writer's logID.
+	logID, err := task.allocator.AllocOne()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1000), logID)
+}
+
 func Test_AppendSystemFieldsData_AllowInsertAutoID_KeepUserPK(t *testing.T) {
 	const count = 10
 
@@ -148,6 +194,7 @@ func Test_AppendSystemFieldsData_AllowInsertAutoID_KeepUserPK(t *testing.T) {
 	for i := 0; i < count; i++ {
 		assert.Equal(t, userPK[i], got.Data[i])
 	}
+	assert.Equal(t, count, insertData.Data[common.RowIDField].RowNum())
 }
 
 func Test_UnsetAutoID(t *testing.T) {


### PR DESCRIPTION
## What this fixes

Large backup restores can exhaust the task-local ID range even though backup binlogs already carry their original PK, RowID, and Timestamp.

Two issues combine on this path:

- DataCoord computes `(totalRows + 1) * binlogNum * expansionFactor` and converts it to `uint32`. Large estimates wrap to a much smaller allocation.
- DataNode allocates `rowNum` IDs before checking whether PK or RowID needs generation. Backup imports keep both original fields, so those allocated IDs are discarded while the shared range cursor still advances.

For #52632, the expected count was 8,602,133,100, which wrapped to 12,198,508 and matched the exhausted range in the report.

## Changes

- Allocate per-row IDs only when an autoID PK or a missing RowID actually needs generation.
- Preserve backup PK, RowID, and Timestamp without advancing the task allocator.
- Keep the same allocator available for new insert binlog, stats log, and BM25 log IDs.
- Compute the pre-allocation bound with checked `uint64` arithmetic and saturate at `math.MaxUint32` instead of wrapping.
- Clamp a non-positive expansion-factor configuration to 1, matching per-file import reservation behavior.
- Log the final allocation and whether it was capped.

The estimate is an upper bound, not a proven minimum, so an estimate above one allocator batch is capped rather than rejecting a restore that may fit in the maximum range.

## Tests

- Reproduce the #52632 values at the final `AssembleImportRequest -> AllocN` boundary and assert a `MaxUint32` allocation.
- Cover normal, capped, `MaxInt64`, and invalid-input calculations.
- Exercise the real `backup=true` task construction path with a range smaller than `rowNum`, verify the original PK/RowID/Timestamp are preserved, and verify the first ID remains available for a writer logID.
- Keep the existing autoID cursor and user-supplied PK behavior covered.

Fixes #52632.
Supersedes #52633.