### PR TITLE
fix: [2.5] rebuild delete snapshots instead of asserting in DumpSnapshot

### DIFF
--- a/internal/core/src/segcore/DeletedRecord.h
+++ b/internal/core/src/segcore/DeletedRecord.h
@@ -235,6 +235,7 @@ class DeletedRecord {
                                              snapshots_.back().second.size());
             }
 
+            bool need_rebuild = false;
             while (total_size - dumped_entry_count_.load() >
                        DELETE_DUMP_BATCH_SIZE &&
                    it != accessor.end()) {
@@ -247,6 +248,16 @@ class DeletedRecord {
                     dump_ts = it->first;
                 }
 
+                if (it == accessor.end() || !it.good()) {
+                    // Iterator exhausted before expected: elements were
+                    // inserted before the cursor (same timestamp, smaller
+                    // row_id), which makes the existing snapshots incorrect
+                    // -- those deletes are missing from the bitmap. Discard
+                    // every snapshot and rebuild from scratch.
+                    need_rebuild = true;
+                    break;
+                }
+
                 {
                     std::unique_lock<std::shared_mutex> lock(snap_lock_);
                     if (dump_ts == last_dump_ts) {
@@ -257,7 +268,6 @@ class DeletedRecord {
                         // add new snapshot
                         snapshots_.push_back(
                             std::make_pair(dump_ts, std::move(bitmap.clone())));
-                        Assert(it != accessor.end() && it.good());
                         snap_next_pos_.push_back(*it);
                     }
                 }
@@ -273,6 +283,26 @@ class DeletedRecord {
                     snapshots_.size(),
                     segment_ ? segment_->get_segment_id() : 0);
                 last_dump_ts = dump_ts;
+            }
+
+            if (need_rebuild) {
+                {
+                    std::unique_lock<std::shared_mutex> lock(snap_lock_);
+                    auto old_size = snapshots_.size();
+                    snapshots_.clear();
+                    snap_next_pos_.clear();
+                    dumped_entry_count_.store(0);
+                    LOG_INFO(
+                        "dump delete record snapshot detected elements before "
+                        "cursor, discarded {} snapshots and rebuilding from "
+                        "scratch, total size: {} for segment: {}",
+                        old_size,
+                        total_size,
+                        segment_ ? segment_->get_segment_id() : 0);
+                }
+                // Continue the outer loop -- the next iteration rebuilds from
+                // accessor.begin() with the snapshot list empty.
+                continue;
             }
         }
     }


### PR DESCRIPTION
Backport of #48250 to `2.5`. Already on master (#48250) and 2.6 (#48302); the `2.5` branch picked up the loop bounds from that change but not the recovery, so it still asserts.

`DumpSnapshot` walks the sorted delete list from the cursor recorded with the last snapshot. Elements can be inserted before that cursor — same timestamp, smaller row_id — which exhausts the iterator earlier than the batch expects. The existing snapshots are then wrong: those deletes are missing from their bitmaps. Today the loop reaches `Assert(it != accessor.end() && it.good())` and the segcore aborts.

This detects the early exhaustion instead, discards every snapshot, resets the dumped count and continues the outer loop, which rebuilds from `accessor.begin()` with an empty snapshot list.

Not a plain cherry-pick: `2.5` renamed the constant to `DELETE_DUMP_BATCH_SIZE` and moved the counter to the atomic `dumped_entry_count_`, so all three source commits (#48250, #48302, and the 2.5.13 hotfix) conflict on this file. The logic is ported to the current `2.5` shape.

pr: #48250
issue: #48258

## Test plan
- [x] `internal/core` builds clean (638s, full C++ build)
- [x] `clang-format` reports no change to the file
- [x] the removed `Assert` has no remaining occurrence; `need_rebuild` guards both the early-exit and the rebuild path