### PR TITLE
fix: [2.6] synchronize Sonic JIT registration with Go plugin loading (#51931)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,12 @@ PWD 	  := $(shell pwd)
 GOPATH	:= $(shell $(GO) env GOPATH)
 SHELL 	:= /bin/bash
 OBJPREFIX := "github.com/milvus-io/milvus/cmd/milvus"
-MILVUS_GO_BUILD_TAGS := "dynamic,sonic,with_jemalloc"
+# Temporary synchronization workaround for the race between Go plugin loading
+# and github.com/bytedance/sonic/loader registering JIT moduledata. All Go
+# plugins loaded by Milvus must use the same tag and linker flag.
+SONIC_PLUGIN_SYNC_TAG := bytedance_tango
+SONIC_PLUGIN_SYNC_LDFLAG := -checklinkname=0
+MILVUS_GO_BUILD_TAGS := dynamic,sonic,with_jemalloc,$(SONIC_PLUGIN_SYNC_TAG)
 
 INSTALL_PATH := $(PWD)/bin
 LIBRARY_PATH := $(PWD)/lib
@@ -112,14 +117,14 @@ build-go:
 	@echo "Building Milvus ..."
 	@source $(PWD)/scripts/setenv.sh && \
 		mkdir -p $(INSTALL_PATH) && go env -w CGO_ENABLED="1" && \
-		$(GOEXPERIMENT_FLAG) CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" GO111MODULE=on $(GO) build -pgo=$(PGO_PATH)/default.pgo -ldflags="-r $${RPATH} -X '$(OBJPREFIX).BuildTags=$(BUILD_TAGS)' -X '$(OBJPREFIX).BuildTime=$(BUILD_TIME)' -X '$(OBJPREFIX).GitCommit=$(GIT_COMMIT)' -X '$(OBJPREFIX).GoVersion=$(GO_VERSION)' -X '$(OBJPREFIX).MilvusVersion=$(MILVUS_VERSION)'" \
-		-tags $(MILVUS_GO_BUILD_TAGS) -o $(INSTALL_PATH)/milvus $(PWD)/cmd/main.go 1>/dev/null
+		$(GOEXPERIMENT_FLAG) CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" GO111MODULE=on $(GO) build -pgo=$(PGO_PATH)/default.pgo -ldflags="$(SONIC_PLUGIN_SYNC_LDFLAG) -r $${RPATH} -X '$(OBJPREFIX).BuildTags=$(BUILD_TAGS)' -X '$(OBJPREFIX).BuildTime=$(BUILD_TIME)' -X '$(OBJPREFIX).GitCommit=$(GIT_COMMIT)' -X '$(OBJPREFIX).GoVersion=$(GO_VERSION)' -X '$(OBJPREFIX).MilvusVersion=$(MILVUS_VERSION)'" \
+		-tags "$(MILVUS_GO_BUILD_TAGS)" -o $(INSTALL_PATH)/milvus $(PWD)/cmd/main.go 1>/dev/null
 
 milvus-gpu: build-cpp-gpu print-gpu-build-info
 	@echo "Building Milvus-gpu ..."
 	@source $(PWD)/scripts/setenv.sh && \
 		mkdir -p $(INSTALL_PATH) && go env -w CGO_ENABLED="1" && \
-		CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" GO111MODULE=on $(GO) build -pgo=$(PGO_PATH)/default.pgo -ldflags="-r $${RPATH} -X '$(OBJPREFIX).BuildTags=$(BUILD_TAGS_GPU)' -X '$(OBJPREFIX).BuildTime=$(BUILD_TIME)' -X '$(OBJPREFIX).GitCommit=$(GIT_COMMIT)' -X '$(OBJPREFIX).GoVersion=$(GO_VERSION)' -X '$(OBJPREFIX).MilvusVersion=$(MILVUS_VERSION)'" \
+		CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" GO111MODULE=on $(GO) build -pgo=$(PGO_PATH)/default.pgo -ldflags="$(SONIC_PLUGIN_SYNC_LDFLAG) -r $${RPATH} -X '$(OBJPREFIX).BuildTags=$(BUILD_TAGS_GPU)' -X '$(OBJPREFIX).BuildTime=$(BUILD_TIME)' -X '$(OBJPREFIX).GitCommit=$(GIT_COMMIT)' -X '$(OBJPREFIX).GoVersion=$(GO_VERSION)' -X '$(OBJPREFIX).MilvusVersion=$(MILVUS_VERSION)'" \
 		-tags "$(MILVUS_GO_BUILD_TAGS),cuda" -o $(INSTALL_PATH)/milvus $(PWD)/cmd/main.go 1>/dev/null
 
 get-build-deps:

--- a/internal/util/hookutil/plugin.go
+++ b/internal/util/hookutil/plugin.go
@@ -13,8 +13,9 @@ import (
 var pluginMutex sync.Mutex
 
 // LoadPlugin opens a Go plugin at the given path, looks up the named symbol,
-// and type-asserts it to T. All calls are serialized with a mutex because
-// Go's plugin.Open() is not safe for concurrent use (causes "empty pluginpath" panic).
+// and type-asserts it to T. The mutex serializes Milvus plugin loads, while
+// production builds also use Sonic's bytedance_tango synchronization to keep
+// concurrent JIT module registration out of plugin.Open's critical section.
 func LoadPlugin[T any](path string, symbol string) (T, error) {
 	var zero T
 	if path == "" {


### PR DESCRIPTION
Cherry-pick from master
pr: #51931
Enable Sonic's bytedance_tango build path for the Milvus CPU and GPU executables. This makes Sonic runtime module registration use the same plugin.pluginsMu critical section as plugin.Open.

Add -checklinkname=0 because Go 1.26 otherwise rejects Sonic loader's linkname reference to the private plugin.pluginsMu symbol.

issue: #51930

Tested:
- built a focused host and plugin with Tango synchronization enabled
- passed 50 concurrent Sonic JIT and plugin.Open stress runs
- passed hookutil tests with the required dynamic,test flags
- verified CPU and GPU Makefile command expansion

---------