### PR TITLE
fix: invalidate stale offsets for re-added struct array fields [3.0]

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -7078,6 +7078,47 @@ ChunkedSegmentSealedImpl::PrepareSchemaForReopen(const SchemaPtr& sch) {
 }
 
 void
+ChunkedSegmentSealedImpl::InvalidateStaleStructArrayOffsets(
+    const SchemaPtr& current_schema,
+    const SchemaPtr& target_schema,
+    RuntimeResourceState& runtime) {
+    if (runtime.struct_to_array_offsets.empty()) {
+        return;
+    }
+
+    // A StructArray generation survives schema evolution when at least one of
+    // its child field IDs survives under the same struct name.  This preserves
+    // offsets for ordinary schema changes while distinguishing a dropped and
+    // re-added StructArray whose name is reused with entirely new field IDs.
+    // The flattened C++ Schema does not retain the StructArray parent field ID,
+    // so child-ID continuity is the available generation marker here.
+    std::unordered_set<std::string> surviving_structs;
+    for (const auto& [field_id, target_field_meta] :
+         target_schema->get_fields()) {
+        if (!current_schema->has_field(field_id)) {
+            continue;
+        }
+
+        auto current_struct_name =
+            GetStructNameForArrayField(current_schema->operator[](field_id));
+        auto target_struct_name = GetStructNameForArrayField(target_field_meta);
+        if (current_struct_name.has_value() &&
+            current_struct_name == target_struct_name) {
+            surviving_structs.emplace(*target_struct_name);
+        }
+    }
+
+    for (auto it = runtime.struct_to_array_offsets.begin();
+         it != runtime.struct_to_array_offsets.end();) {
+        if (surviving_structs.find(it->first) == surviving_structs.end()) {
+            it = runtime.struct_to_array_offsets.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+void
 ChunkedSegmentSealedImpl::PrepareLoadDiffForReopen(
     milvus::OpContext* op_ctx,
     SegmentLoadInfo& segment_load_info,
@@ -7402,6 +7443,7 @@ ChunkedSegmentSealedImpl::ReopenSchemaLocked(milvus::OpContext* op_ctx,
         "Schema-only reopen segment {} with diff {}", id_, diff.ToString());
 
     auto next_runtime = CloneMutableRuntimeResourceState();
+    InvalidateStaleStructArrayOffsets(current_schema, sch, *next_runtime);
     auto staged = ClonePublishedState(current);
     staged->schema = sch;
     staged->load_info = std::make_shared<const SegmentLoadInfo>(new_local);
@@ -7477,6 +7519,8 @@ ChunkedSegmentSealedImpl::Reopen(
     LOG_INFO("Reopen segment {} with diff {}", id_, diff.ToString());
 
     auto next_runtime = CloneMutableRuntimeResourceState();
+    InvalidateStaleStructArrayOffsets(
+        current_schema, target_schema, *next_runtime);
     auto staged = ClonePublishedState(current);
     staged->schema = target_schema;
     staged->load_info = std::make_shared<const SegmentLoadInfo>(new_local);

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -7495,7 +7495,9 @@ ChunkedSegmentSealedImpl::Reopen(
                   new_schema->get_schema_version());
     }
 
-    auto target_schema = new_schema ? std::move(new_schema) : current_schema;
+    const bool has_schema_update = new_schema != nullptr;
+    auto target_schema =
+        has_schema_update ? std::move(new_schema) : current_schema;
 
     SegmentLoadInfo current_mutable(*current->load_info);
     SegmentLoadInfo new_local(new_load_info, target_schema);
@@ -7519,8 +7521,10 @@ ChunkedSegmentSealedImpl::Reopen(
     LOG_INFO("Reopen segment {} with diff {}", id_, diff.ToString());
 
     auto next_runtime = CloneMutableRuntimeResourceState();
-    InvalidateStaleStructArrayOffsets(
-        current_schema, target_schema, *next_runtime);
+    if (has_schema_update) {
+        InvalidateStaleStructArrayOffsets(
+            current_schema, target_schema, *next_runtime);
+    }
     auto staged = ClonePublishedState(current);
     staged->schema = target_schema;
     staged->load_info = std::make_shared<const SegmentLoadInfo>(new_local);

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -1800,6 +1800,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     IsSystemFieldReadyFromState(const PublishedSegmentState& state,
                                 const SegmentLoadInfo* load_info) const;
 
+    static void
+    InvalidateStaleStructArrayOffsets(const SchemaPtr& current_schema,
+                                      const SchemaPtr& target_schema,
+                                      RuntimeResourceState& runtime);
+
     void
     EnsureArrayOffsetsForStructField(const FieldMeta& field_meta,
                                      int64_t row_count,

--- a/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
@@ -568,6 +568,66 @@ TEST(test_chunk_segment, MissingStructArrayOffsetsReturnsEmptyForOldRows) {
     }
 }
 
+// #52877: lazy reopen may skip the drop-only schema and see the old and new
+// StructArrays as one same-name transition with disjoint child field IDs.
+TEST(test_chunk_segment,
+     ReopenInvalidatesOffsetsForReaddedStructArrayWithSameName) {
+    auto old_schema = std::make_shared<Schema>();
+    old_schema->set_schema_version(1);
+    auto pk = old_schema->AddDebugField("pk", DataType::INT64);
+    old_schema->set_primary_field_id(pk);
+    auto old_label = old_schema->AddDebugArrayField(
+        "chunks[label]", DataType::VARCHAR, true);
+    auto old_score =
+        old_schema->AddDebugArrayField("chunks[score]", DataType::INT32, true);
+
+    constexpr int64_t row_count = 5;
+    constexpr int64_t array_len = 3;
+    auto dataset = DataGen(old_schema,
+                           row_count,
+                           /*seed=*/42,
+                           /*ts_offset=*/0,
+                           /*repeat_count=*/1,
+                           array_len);
+    auto segment = CreateSealedWithFieldDataLoaded(old_schema, dataset);
+
+    auto old_offsets = segment->GetArrayOffsets(old_label);
+    ASSERT_NE(old_offsets, nullptr);
+    ASSERT_EQ(old_offsets.get(), segment->GetArrayOffsets(old_score).get());
+    ASSERT_EQ(old_offsets->GetTotalElementCount(), row_count * array_len);
+
+    auto new_schema = std::make_shared<Schema>();
+    new_schema->set_schema_version(2);
+    new_schema->AddField(
+        FieldName("pk"), pk, DataType::INT64, false, std::nullopt);
+    new_schema->set_primary_field_id(pk);
+    auto new_label = FieldId(old_score.get() + 1);
+    auto new_score = FieldId(new_label.get() + 1);
+    new_schema->AddField(FieldName("chunks[label]"),
+                         new_label,
+                         DataType::ARRAY,
+                         DataType::VARCHAR,
+                         true);
+    new_schema->AddField(FieldName("chunks[score]"),
+                         new_score,
+                         DataType::ARRAY,
+                         DataType::INT32,
+                         true);
+
+    // Model lazy reopen skipping the intermediate drop-only schema: the struct
+    // name is unchanged, while every child field ID belongs to a new generation.
+    segment->Reopen(new_schema);
+
+    auto new_offsets = segment->GetArrayOffsets(new_label);
+    ASSERT_NE(new_offsets, nullptr);
+    EXPECT_NE(new_offsets.get(), old_offsets.get());
+    EXPECT_EQ(new_offsets.get(), segment->GetArrayOffsets(new_score).get());
+    EXPECT_EQ(new_offsets->GetRowCount(), row_count);
+    EXPECT_EQ(new_offsets->GetTotalElementCount(), 0);
+    EXPECT_EQ(segment->GetArrayOffsets(old_label), nullptr);
+    EXPECT_EQ(segment->GetArrayOffsets(old_score), nullptr);
+}
+
 TEST(test_chunk_segment, SearchOnSealedColumnBruteForceUsesOriginalTopk) {
     int dim = 16;
     int chunk_num = 2;

--- a/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
@@ -583,12 +583,12 @@ TEST(test_chunk_segment,
 
     constexpr int64_t row_count = 5;
     constexpr int64_t array_len = 3;
-    auto dataset = DataGen(old_schema,
-                           row_count,
-                           /*seed=*/42,
-                           /*ts_offset=*/0,
-                           /*repeat_count=*/1,
-                           array_len);
+    auto dataset = segcore::DataGen(old_schema,
+                                    row_count,
+                                    /*seed=*/42,
+                                    /*ts_offset=*/0,
+                                    /*repeat_count=*/1,
+                                    array_len);
     auto segment = CreateSealedWithFieldDataLoaded(old_schema, dataset);
 
     auto old_offsets = segment->GetArrayOffsets(old_label);


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/52877
pr: https://github.com/milvus-io/milvus/pull/52894