### PR TITLE
fix: implement CopyObjectCrossBucket on canceledObjectStorage test double

### DIFF
--- a/internal/storage/remote_chunk_manager_test.go
+++ b/internal/storage/remote_chunk_manager_test.go
@@ -1352,7 +1352,7 @@ func (*canceledObjectStorage) RemoveObject(context.Context, string, string) erro
 	return nil
 }
 
-func (*canceledObjectStorage) CopyObject(context.Context, string, string, string) error {
+func (*canceledObjectStorage) CopyObjectCrossBucket(context.Context, string, string, string, string) error {
 	return nil
 }
 


### PR DESCRIPTION
issue: #52922

#50978 renamed `ObjectStorage.CopyObject` to `CopyObjectCrossBucket(ctx, srcBucket, srcObjectName, dstBucket, dstObjectName)` while #51860 was in flight adding the `canceledObjectStorage` test double against the old signature. The two crossed on merge, so `internal/storage` no longer typechecks with test files on master and **every PR's Code Check (static-check) currently fails** with:

```
internal/storage/remote_chunk_manager_test.go:1309:16: cannot use &canceledObjectStorage{…} as ObjectStorage value in assignment: *canceledObjectStorage does not implement ObjectStorage (missing method CopyObjectCrossBucket) (typecheck)
```

One-line fix: rename the double's now-dead `CopyObject` method to the interface's `CopyObjectCrossBucket` signature (it keeps returning `nil`; the double only injects Get/Put errors for the cancellation-metrics tests).

Verified in the CI builder image: `internal/storage` typechecks and `TestRemoteChunkManagerCanceledMetrics` / `TestToMilvusIoError` pass; full `make static-check` is green across core/pkg/client/e2e groups with this change applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)