### PR TITLE
enhance: [3.0] support weights for RRF reranking (#52818)

### DIFF
--- a/client/entity/function.go
+++ b/client/entity/function.go
@@ -78,7 +78,10 @@ func (f *Function) WithType(funcType FunctionType) *Function {
 
 func (f *Function) WithParam(key string, value any) *Function {
 	// Handle slices by converting to JSON format
-	if reflect.TypeOf(value).Kind() == reflect.Slice {
+	valueType := reflect.TypeOf(value)
+	if valueType == nil {
+		f.Params[key] = "null"
+	} else if valueType.Kind() == reflect.Slice {
 		if jsonBytes, err := json.Marshal(value); err == nil {
 			f.Params[key] = string(jsonBytes)
 		} else {

--- a/client/entity/function_test.go
+++ b/client/entity/function_test.go
@@ -64,6 +64,10 @@ func TestFunctionWithParamSliceHandling(t *testing.T) {
 	f = NewFunction().WithParam("empty_slice_key", []string{})
 	assert.Equal(t, "[]", f.Params["empty_slice_key"])
 
+	// Test nil without panicking
+	f = NewFunction().WithParam("nil_key", nil)
+	assert.Equal(t, "null", f.Params["nil_key"])
+
 	// Test the JSON marshal error fallback path
 	type unmarshalableType struct {
 		Channel chan int

--- a/client/milvusclient/reranker.go
+++ b/client/milvusclient/reranker.go
@@ -21,7 +21,8 @@ type Reranker interface {
 }
 
 type rrfReranker struct {
-	K float64 `json:"k,omitempty"`
+	K       float64 `json:"k,omitempty"`
+	weights *[]float64
 }
 
 func (r *rrfReranker) WithK(k float64) *rrfReranker {
@@ -29,8 +30,28 @@ func (r *rrfReranker) WithK(k float64) *rrfReranker {
 	return r
 }
 
+// WithWeights sets optional reciprocal-rank coefficients in ANN request order.
+// The server requires a non-empty slice, one value in [0, 1] per ANN request;
+// nil and empty slices are serialized so the server can reject them.
+func (r *rrfReranker) WithWeights(weights []float64) *rrfReranker {
+	var copied []float64
+	if weights != nil {
+		copied = make([]float64, len(weights))
+		copy(copied, weights)
+	}
+	r.weights = &copied
+	return r
+}
+
 func (r *rrfReranker) GetParams() []*commonpb.KeyValuePair {
-	bs, _ := json.Marshal(r)
+	params := struct {
+		K       float64    `json:"k,omitempty"`
+		Weights *[]float64 `json:"weights,omitempty"`
+	}{
+		K:       r.K,
+		Weights: r.weights,
+	}
+	bs, _ := json.Marshal(params)
 
 	return []*commonpb.KeyValuePair{
 		{Key: rerankType, Value: rrfRerankType},

--- a/client/milvusclient/reranker_test.go
+++ b/client/milvusclient/reranker_test.go
@@ -44,6 +44,18 @@ func TestReranker(t *testing.T) {
 		params = rr.GetParams()
 		assert.True(t, checkParam(params, rerankType, rrfRerankType))
 		assert.True(t, checkParam(params, rerankParams, `{"k":50}`))
+
+		rr.WithWeights([]float64{0.8, 0.2})
+		params = rr.GetParams()
+		assert.True(t, checkParam(params, rerankParams, `{"k":50,"weights":[0.8,0.2]}`))
+
+		emptyWeights := NewRRFReranker().WithWeights([]float64{})
+		params = emptyWeights.GetParams()
+		assert.True(t, checkParam(params, rerankParams, `{"k":60,"weights":[]}`))
+
+		nullWeights := NewRRFReranker().WithWeights(nil)
+		params = nullWeights.GetParams()
+		assert.True(t, checkParam(params, rerankParams, `{"k":60,"weights":null}`))
 	})
 
 	t.Run("weightedReranker", func(t *testing.T) {

--- a/docs/design-docs/design_docs/20260824-weighted-rrf-reranking.md
+++ b/docs/design-docs/design_docs/20260824-weighted-rrf-reranking.md
@@ -1,0 +1,220 @@
+# MEP: Weighted Reciprocal Rank Fusion Reranking
+
+- **Created:** 2026-08-24
+- **Author(s):** @AmSmart
+- **Status:** Draft
+- **Component:** Proxy
+- **Related Issues:** #52817
+- **Released:** TBD
+
+## Summary
+
+Extend the existing Reciprocal Rank Fusion (RRF) reranker with an optional
+`weights` parameter. Each weight applies to the hybrid-search ANN request at
+the same position. When weights are supplied, Milvus computes:
+
+```text
+score(d) = sum_i(weights[i] / (k + rank_i(d)))
+```
+
+Ranks are one-based. When `weights` is omitted, Milvus retains the existing
+RRF formula and scores exactly:
+
+```text
+score(d) = sum_i(1 / (k + rank_i(d)))
+```
+
+## Motivation
+
+Milvus currently provides two server-side fusion choices with different
+semantics:
+
+- RRF combines rank positions but gives every retrieval path equal influence.
+- The weighted reranker gives paths different influence but combines
+  normalized or direction-adjusted retrieval scores.
+
+Dense, sparse, BM25, and other retrieval paths often have different measured
+quality, while their raw scores are not necessarily comparable. Users who
+want both rank-only fusion and different path importance must currently issue
+separate searches and fuse the results in application code. That loses the
+single-request execution model and duplicates candidate-fusion logic outside
+Milvus.
+
+Weighted RRF fills this gap without introducing score normalization or
+metric-specific behavior.
+
+## Public Interfaces
+
+The existing RRF reranker accepts an optional `weights` array in its function
+parameters:
+
+```python
+ranker = Function(
+    name="weighted_rrf",
+    input_field_names=[],
+    function_type=FunctionType.RERANK,
+    params={
+        "reranker": "rrf",
+        "k": 60,
+        "weights": [0.7, 0.3],
+    },
+)
+```
+
+The legacy hybrid-search rank parameters accept the same option:
+
+```json
+{
+  "strategy": "rrf",
+  "params": {
+    "k": 60,
+    "weights": [0.7, 0.3]
+  }
+}
+```
+
+The weight at index `i` applies to ANN request `i`. The validation contract is:
+
+- `weights` is optional.
+- When supplied, it must be a non-empty JSON array of numbers.
+- Each value must be in the inclusive range `[0, 1]`.
+- The array length must equal the number of ANN search requests.
+- Values are not normalized and do not need to sum to one.
+
+The generic reranker parameter fields already carry JSON-encoded arrays, so
+this change does not require a protobuf or REST schema change. The Go client
+RRF helper adds an optional `WithWeights` convenience method. Convenience APIs
+in other SDK repositories can be added independently.
+
+## Design Details
+
+### Parameter conversion and validation
+
+Both public reranker paths converge in the Proxy function-chain builder:
+
+- FunctionScore requests already expose function parameters as key/value
+  pairs.
+- Legacy rank parameters are converted to the same FunctionSchema shape. The
+  conversion will forward `weights` for RRF in addition to the existing `k`
+  parameter.
+
+The RRF builder parses `k` as it does today, parses optional weights, and
+validates the weight count against the ordered search-metric list. That list is
+built in the same order as the hybrid-search sub-requests, preserving the
+public positional mapping.
+
+An omitted `weights` parameter remains distinguishable from an explicitly
+empty or null value. Omission selects classic RRF. Empty, null, malformed,
+out-of-range, or length-mismatched values return a parameter error before the
+merge executes.
+
+### Merge execution
+
+The existing MergeOp already stores per-input weights for weighted score
+fusion. RRF reuses that configuration field without enabling score
+normalization or metric conversion.
+
+For every query chunk, the RRF collector iterates each input list in request
+order. Rank resets for each input and is `row index + 1`. The contribution is:
+
+```text
+path_weight / (k + rank)
+```
+
+When optional weights are absent, `path_weight` is exactly `1`. This preserves
+both ordering and the exposed float scores produced by existing RRF requests;
+it does not substitute `1 / number_of_paths`.
+
+Documents missing from a path receive no contribution from that path. A
+zero-weight path contributes zero while its candidates remain part of the
+merged candidate union, consistent with the existing merge operator model.
+All-zero weights are permitted and produce deterministic tie ordering by the
+existing primary-key tie breaker.
+
+The execution layer also checks that configured weights match the actual input
+count and contain only finite values in `[0, 1]`. This is defense in depth for
+programmatic MergeOp construction and internal contract violations;
+user-facing validation remains in the builder.
+
+### Scoring and ordering
+
+RRF remains metric-agnostic. Original similarity or distance scores are not
+read, and score normalization is not applied. Fused scores remain descending:
+larger values rank first. Existing primary-key tie breaking, grouping,
+rounding, limiting, and output selection remain unchanged.
+
+## Compatibility, Deprecation, and Migration Plan
+
+This change is backward-compatible:
+
+- Existing RRF requests without `weights` produce the same ordering and scores.
+- Existing `k` defaults and validation remain unchanged.
+- The existing weighted score reranker is unchanged.
+- No wire fields, persisted metadata, storage formats, or configuration values
+  change.
+- Mixed-version clients can send classic RRF as before. Servers predating this
+  enhancement silently ignore unknown RRF function parameters, while their
+  legacy converter drops RRF weights, so clients must version-gate weighted
+  RRF rather than assume an older server will reject it.
+- Requests with invalid reranker parameters now return a parameter error even
+  when every sub-search returns empty results (previously they succeeded with
+  empty results). Validation is now independent of result content.
+
+No migration or deprecation is required. Omitting the parameter restores
+classic RRF. Rolling back to an older server also silently restores classic
+RRF even if a client continues to send weights.
+
+## Test Plan
+
+Unit tests will cover:
+
+- omitted weights preserve classic RRF scores;
+- all-one weights are equivalent to omitted weights;
+- unequal weights change exact scores and ordering according to the formula;
+- zero and one are accepted weight boundaries;
+- weights are not required to sum to one;
+- malformed, null, empty, negative, greater-than-one, and length-mismatched
+  weights are rejected;
+- FunctionScore and legacy rank parameters produce the same MergeOp
+  configuration;
+- execution-time input-count mismatch returns an internal contract error;
+- Go client RRF parameters serialize optional weights correctly.
+
+Query-level tests will verify that hybrid search accepts valid RRF weights and
+rejects invalid or mismatched weights through both the public Function API and
+the legacy typed RRF helper.
+
+## Rejected Alternatives
+
+### Use the existing weighted score reranker
+
+The weighted reranker combines retrieval scores after normalization or metric
+direction handling. That is different from rank-only fusion and can remain
+sensitive to score distributions. It does not satisfy the requested semantics.
+
+### Perform weighted RRF in application code
+
+Application-side fusion requires separate result handling, transfers more
+candidates to the client, and prevents Milvus from applying the final fusion,
+limit, grouping, and requery pipeline in one request.
+
+### Add a separate `weighted_rrf` reranker name
+
+Weighted RRF differs from RRF by one optional coefficient per input. Extending
+the existing RRF parameters keeps classic RRF as the default, avoids another
+top-level strategy, and matches the existing parameterized `k` design.
+
+### Normalize weights automatically
+
+Scaling every weight by the same positive constant does not change result
+ordering, but it does change exposed fused scores. Implicit normalization would
+make the requested coefficients less transparent. Milvus therefore uses the
+provided values directly.
+
+## References
+
+- Issue #52817: Support per-path weights in RRF reranking
+- Issue #52319: FunctionChain roadmap
+- Issue #46565: FunctionChain umbrella
+- Cormack, Clarke, and Buettcher, "Reciprocal Rank Fusion Outperforms Condorcet
+  and Individual Rank Learning Methods," SIGIR 2009

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -3739,7 +3739,10 @@ func genFunctionSchema(ctx context.Context, function *FunctionSchema) (*schemapb
 	description := function.Description
 	params := []*commonpb.KeyValuePair{}
 	for key, value := range function.Params {
-		if reflect.TypeOf(value).Kind() == reflect.Slice || reflect.TypeOf(value).Kind() == reflect.Map {
+		valueType := reflect.TypeOf(value)
+		if valueType == nil {
+			params = append(params, &commonpb.KeyValuePair{Key: key, Value: "null"})
+		} else if valueType.Kind() == reflect.Slice || valueType.Kind() == reflect.Map {
 			bs, err := json.Marshal(value)
 			if err != nil {
 				return nil, merr.WrapErrParameterInvalidMsg("Marshal function params fail, please check it!")

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -3593,11 +3594,16 @@ func TestGenFunctionSchem(t *testing.T) {
 				"test2": map[string]interface{}{
 					"test3": "test4",
 				},
-				"test3": []int{1, 2, 3},
+				"test3":   []int{1, 2, 3},
+				"test4":   nil,
+				"weights": []float64{0.7, 0.3},
 			},
 		}
-		_, err := genFunctionSchema(context.Background(), funcSchema)
+		result, err := genFunctionSchema(context.Background(), funcSchema)
 		assert.NoError(t, err)
+		params := funcutil.KeyValuePair2Map(result.GetParams())
+		assert.Equal(t, "null", params["test4"])
+		assert.Equal(t, "[0.7,0.3]", params["weights"])
 	}
 }
 

--- a/internal/proxy/search_pipeline.go
+++ b/internal/proxy/search_pipeline.go
@@ -1110,6 +1110,35 @@ func (op *rerankOperator) run(ctx context.Context, span trace.Span, inputs ...an
 			}
 		}
 	}
+	// Build search params and validate the rerank chain before the empty-result
+	// fast path so invalid reranker configurations never return success.
+	var searchParams *chain.SearchParams
+	if op.groupByFieldName != "" && op.groupSize > 0 {
+		scorer := chain.GroupScorer(op.groupScorerStr)
+		searchParams = chain.NewSearchParamsWithGroupingAndScorer(
+			op.nq, op.topK, op.offset, op.roundDecimal,
+			op.groupByFieldName, op.groupSize, scorer)
+	} else {
+		searchParams = chain.NewSearchParams(op.nq, op.topK, op.offset, op.roundDecimal)
+	}
+	if op.rerankMeta == nil {
+		for _, df := range dataframes {
+			df.Release()
+		}
+		return nil, merr.WrapErrFunctionFailedMsg("rerank operator: rerankMeta is nil, cannot build rerank chain")
+	}
+	searchParams.ModelExtraInfo = &models.ModelExtraInfo{
+		ClusterID: paramtable.Get().CommonCfg.ClusterPrefix.GetValue(),
+		DBName:    op.dbName,
+	}
+	fc, err := buildChainFromMeta(op.rerankMeta, op.collSchema, inputMetrics, searchParams, alloc)
+	if err != nil {
+		for _, df := range dataframes {
+			df.Release()
+		}
+		return nil, err
+	}
+
 	if allEmpty {
 		var elementIndices *schemapb.LongArray
 		for _, df := range dataframes {
@@ -1134,35 +1163,6 @@ func (op *rerankOperator) run(ctx context.Context, span trace.Span, inputs ...an
 				ElementIndices: elementIndices,
 			},
 		}}, nil
-	}
-
-	// Build search params
-	var searchParams *chain.SearchParams
-	if op.groupByFieldName != "" && op.groupSize > 0 {
-		scorer := chain.GroupScorer(op.groupScorerStr)
-		searchParams = chain.NewSearchParamsWithGroupingAndScorer(
-			op.nq, op.topK, op.offset, op.roundDecimal,
-			op.groupByFieldName, op.groupSize, scorer)
-	} else {
-		searchParams = chain.NewSearchParams(op.nq, op.topK, op.offset, op.roundDecimal)
-	}
-	// Build chain
-	if op.rerankMeta == nil {
-		for _, df := range dataframes {
-			df.Release()
-		}
-		return nil, merr.WrapErrFunctionFailedMsg("rerank operator: rerankMeta is nil, cannot build rerank chain")
-	}
-	searchParams.ModelExtraInfo = &models.ModelExtraInfo{
-		ClusterID: paramtable.Get().CommonCfg.ClusterPrefix.GetValue(),
-		DBName:    op.dbName,
-	}
-	fc, err := buildChainFromMeta(op.rerankMeta, op.collSchema, inputMetrics, searchParams, alloc)
-	if err != nil {
-		for _, df := range dataframes {
-			df.Release()
-		}
-		return nil, err
 	}
 
 	// Execute chain. Liveness pruning removes scalar inputs after their last use;

--- a/internal/proxy/search_pipeline_test.go
+++ b/internal/proxy/search_pipeline_test.go
@@ -300,6 +300,99 @@ func (s *SearchPipelineSuite) TestRerankOp() {
 	s.NoError(err)
 }
 
+func (s *SearchPipelineSuite) TestRerankOpValidatesAllEmptyResults() {
+	const (
+		nq   = int64(1)
+		topK = int64(10)
+	)
+
+	emptyResults := []*milvuspb.SearchResults{
+		{
+			Status: merr.Success(),
+			Results: &schemapb.SearchResultData{
+				NumQueries: nq,
+				TopK:       topK,
+				Topks:      []int64{0},
+				Ids:        &schemapb.IDs{},
+			},
+		},
+		{
+			Status: merr.Success(),
+			Results: &schemapb.SearchResultData{
+				NumQueries: nq,
+				TopK:       topK,
+				Topks:      []int64{0},
+				Ids:        &schemapb.IDs{},
+			},
+		},
+	}
+	metrics := []string{"IP", "COSINE"}
+
+	functionRRF := func(weights string) rerankMeta {
+		return &funcScoreRerankMeta{
+			funcScore: &schemapb.FunctionScore{
+				Functions: []*schemapb.FunctionSchema{
+					{
+						Type: schemapb.FunctionType_Rerank,
+						Params: []*commonpb.KeyValuePair{
+							{Key: "reranker", Value: "rrf"},
+							{Key: "weights", Value: weights},
+						},
+					},
+				},
+			},
+		}
+	}
+	legacyRRF := func(params string) rerankMeta {
+		return &legacyRerankMeta{
+			legacyParams: []*commonpb.KeyValuePair{
+				{Key: "strategy", Value: "rrf"},
+				{Key: "params", Value: params},
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		meta    rerankMeta
+		wantErr string
+	}{
+		{name: "function malformed weights", meta: functionRRF("not-json"), wantErr: "failed to parse weights"},
+		{name: "function null weights", meta: functionRRF("null"), wantErr: "non-empty array"},
+		{name: "function empty weights", meta: functionRRF("[]"), wantErr: "non-empty array"},
+		{name: "function out-of-range weights", meta: functionRRF("[-0.1, 0.2]"), wantErr: "range [0, 1]"},
+		{name: "function mismatched weights", meta: functionRRF("[0.8]"), wantErr: "length of weights param mismatch"},
+		{name: "legacy mismatched weights", meta: legacyRRF(`{"weights":[0.8]}`), wantErr: "length of weights param mismatch"},
+		{name: "function valid weights", meta: functionRRF("[0.8, 0.2]")},
+		{name: "legacy omitted weights", meta: legacyRRF(`{"k":60}`)},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			op := rerankOperator{
+				nq:           nq,
+				topK:         topK,
+				roundDecimal: -1,
+				rerankMeta:   test.meta,
+			}
+
+			outputs, err := op.run(context.Background(), s.span, emptyResults, metrics)
+			if test.wantErr != "" {
+				s.ErrorIs(err, merr.ErrParameterInvalid)
+				s.ErrorContains(err, test.wantErr)
+				s.Nil(outputs)
+				return
+			}
+
+			s.Require().NoError(err)
+			s.Require().Len(outputs, 1)
+			result := outputs[0].(*milvuspb.SearchResults).GetResults()
+			s.Equal([]int64{0}, result.GetTopks())
+			s.Empty(result.GetScores())
+		})
+	}
+}
+
 func (s *SearchPipelineSuite) TestRerankOpWithFunctionChainMeta() {
 	schema := &schemapb.CollectionSchema{
 		Name: "test",

--- a/internal/util/function/chain/operator_merge.go
+++ b/internal/util/function/chain/operator_merge.go
@@ -60,10 +60,11 @@ func init() {
 }
 
 type mergeSpec struct {
-	strategy  MergeStrategy
-	rrfK      float64
-	weights   []float64
-	normalize bool
+	strategy   MergeStrategy
+	rrfK       float64
+	weights    []float64
+	weightsSet bool
+	normalize  bool
 }
 
 // NewMergeOpFromReprWithContext creates a MergeOp from its declarative
@@ -86,6 +87,14 @@ func NewMergeOpFromReprWithContext(repr *OperatorRepr, buildCtx types.FunctionBu
 	switch spec.strategy {
 	case MergeStrategyRRF:
 		opts = append(opts, WithRRFK(spec.rrfK))
+		if spec.weightsSet {
+			if len(spec.weights) != len(metricTypes) {
+				return nil, merr.WrapErrParameterInvalidMsg(
+					"merge_op: weights count %d does not match search input count %d",
+					len(spec.weights), len(metricTypes))
+			}
+			opts = append(opts, WithWeights(spec.weights))
+		}
 	case MergeStrategyWeighted:
 		if len(spec.weights) != len(metricTypes) {
 			return nil, merr.WrapErrParameterInvalidMsg(
@@ -135,6 +144,7 @@ func parseMergeSpec(repr *OperatorRepr) (*mergeSpec, error) {
 	switch strategy {
 	case MergeStrategyRRF:
 		allowed[MergeParamK] = struct{}{}
+		allowed[MergeParamWeights] = struct{}{}
 	case MergeStrategyWeighted:
 		allowed[MergeParamWeights] = struct{}{}
 		allowed[MergeParamNormScore] = struct{}{}
@@ -160,18 +170,17 @@ func parseMergeSpec(repr *OperatorRepr) (*mergeSpec, error) {
 		if !isFiniteFloat64(spec.rrfK) || spec.rrfK <= 0 || spec.rrfK >= 16384 {
 			return nil, merr.WrapErrParameterInvalidMsg("merge_op: k must be finite and in range (0, 16384)")
 		}
+		_, spec.weightsSet = repr.Params[MergeParamWeights]
+		if spec.weightsSet {
+			spec.weights, err = parseMergeWeights(reader)
+			if err != nil {
+				return nil, err
+			}
+		}
 	case MergeStrategyWeighted:
-		spec.weights, err = reader.Float64Slice(MergeParamWeights, true)
+		spec.weights, err = parseMergeWeights(reader)
 		if err != nil {
 			return nil, err
-		}
-		if len(spec.weights) == 0 {
-			return nil, merr.WrapErrParameterInvalidMsg("merge_op: weights must not be empty")
-		}
-		for i, weight := range spec.weights {
-			if !isFiniteFloat64(weight) || weight < 0 || weight > 1 {
-				return nil, merr.WrapErrParameterInvalidMsg("merge_op: weights[%d] must be finite and in range [0, 1]", i)
-			}
 		}
 		spec.normalize, err = reader.Bool(MergeParamNormScore, false, false)
 		if err != nil {
@@ -184,6 +193,22 @@ func parseMergeSpec(repr *OperatorRepr) (*mergeSpec, error) {
 		}
 	}
 	return spec, nil
+}
+
+func parseMergeWeights(reader types.ParamReader) ([]float64, error) {
+	weights, err := reader.Float64Slice(MergeParamWeights, true)
+	if err != nil {
+		return nil, err
+	}
+	if len(weights) == 0 {
+		return nil, merr.WrapErrParameterInvalidMsg("merge_op: weights must not be empty")
+	}
+	for i, weight := range weights {
+		if !isFiniteFloat64(weight) || weight < 0 || weight > 1 {
+			return nil, merr.WrapErrParameterInvalidMsg("merge_op: weights[%d] must be finite and in range [0, 1]", i)
+		}
+	}
+	return weights, nil
 }
 
 func isFiniteFloat64(value float64) bool {
@@ -206,7 +231,8 @@ func isFiniteFloat64(value float64) bool {
 type MergeOp struct {
 	BaseOp
 	strategy       MergeStrategy
-	weights        []float64       // for weighted strategy
+	weights        []float64       // for weighted strategy and optional RRF path weights
+	weightsSet     bool            // distinguishes omitted RRF weights from an explicit empty value
 	rrfK           float64         // for rrf strategy, default 60
 	sortDescending bool            // pre-computed: true means larger score = better match
 	scoreNormFuncs []normalizeFunc // pre-computed per-input normalization; nil entry = no-op
@@ -218,6 +244,7 @@ type MergeOp struct {
 // on MergeOp, then discarded.
 type mergeConfig struct {
 	weights         []float64
+	weightsSet      bool
 	rrfK            float64
 	metricTypes     []string
 	normalize       bool
@@ -228,10 +255,11 @@ type mergeConfig struct {
 // MergeOption is a functional option for MergeOp.
 type MergeOption func(*mergeConfig)
 
-// WithWeights sets the weights for weighted merge strategy.
+// WithWeights sets the per-input weights for weighted or RRF merge strategy.
 func WithWeights(weights []float64) MergeOption {
 	return func(cfg *mergeConfig) {
 		cfg.weights = append([]float64(nil), weights...)
+		cfg.weightsSet = true
 	}
 }
 
@@ -303,6 +331,7 @@ func NewMergeOp(strategy MergeStrategy, opts ...MergeOption) *MergeOp {
 		},
 		strategy:       strategy,
 		weights:        append([]float64(nil), cfg.weights...),
+		weightsSet:     cfg.weightsSet,
 		rrfK:           cfg.rrfK,
 		sortDescending: sortDesc,
 		scoreNormFuncs: normFuncs,
@@ -395,10 +424,16 @@ func (op *MergeOp) validateInputs(ctx *types.FuncContext, inputs []*DataFrame) (
 		return nil, merr.WrapErrServiceInternalMsg("merge_op: scoreNormFuncs count %d != inputs count %d", len(op.scoreNormFuncs), len(inputs))
 	}
 
-	// Validate weights for weighted strategy
-	if op.strategy == MergeStrategyWeighted {
+	// Weighted score fusion always requires weights. RRF validates them only
+	// when the optional weights setting was explicitly supplied.
+	if op.strategy == MergeStrategyWeighted || (op.strategy == MergeStrategyRRF && op.weightsSet) {
 		if len(op.weights) != len(inputs) {
 			return nil, merr.WrapErrServiceInternalMsg("merge_op: weights count %d != inputs count %d", len(op.weights), len(inputs))
+		}
+		for index, weight := range op.weights {
+			if math.IsNaN(weight) || math.IsInf(weight, 0) || weight < 0 || weight > 1 {
+				return nil, merr.WrapErrServiceInternalMsg("merge_op: weight[%d] must be finite and in range [0, 1]", index)
+			}
 		}
 	}
 
@@ -630,6 +665,11 @@ func (op *MergeOp) collectRRFScores(inputs []*DataFrame, chunkIdx int, layout *m
 
 	for inputIdx, df := range inputs {
 		idCol := df.Column(types.IDFieldName)
+		pathWeight := 1.0
+		if op.weightsSet {
+			pathWeight = op.weights[inputIdx]
+		}
+
 		idChunk := idCol.Chunk(chunkIdx)
 		var elementChunk arrow.Array
 		if layout.hasElement {
@@ -638,8 +678,9 @@ func (op *MergeOp) collectRRFScores(inputs []*DataFrame, chunkIdx int, layout *m
 		for rowIdx := 0; rowIdx < idChunk.Len(); rowIdx++ {
 			key := readCandidateKey(idChunk, elementChunk, rowIdx)
 
-			// RRF score: 1 / (k + rank), rank is 1-based
-			rrfScore := float32(1.0 / (op.rrfK + float64(rowIdx+1)))
+			// Weighted RRF score: pathWeight / (k + rank), rank is 1-based.
+			// pathWeight defaults to 1 to preserve classic RRF scores.
+			rrfScore := float32(pathWeight / (op.rrfK + float64(rowIdx+1)))
 
 			if existingScore, exists := candidateScores[key]; exists {
 				candidateScores[key] = existingScore + rrfScore

--- a/internal/util/function/chain/operator_merge_test.go
+++ b/internal/util/function/chain/operator_merge_test.go
@@ -541,6 +541,11 @@ func (s *MergeHelperTestSuite) TestWithRRFKOption() {
 	s.InDelta(30.0, op.rrfK, 1e-9)
 }
 
+func (s *MergeHelperTestSuite) TestWithRRFWeightsOption() {
+	op := NewMergeOp(MergeStrategyRRF, WithWeights([]float64{0.8, 0.2}))
+	s.Equal([]float64{0.8, 0.2}, op.weights)
+}
+
 func (s *MergeHelperTestSuite) TestWithMetricTypesOption() {
 	op := NewMergeOp(MergeStrategyRRF, WithMetricTypes([]string{"COSINE", "L2"}))
 	// Mixed metrics → sortDescending=true, scoreNormFuncs populated for direction conversion
@@ -1179,6 +1184,131 @@ func (s *MergeHelperTestSuite) TestSingleInputRRFIgnoresOriginalScores() {
 
 	scores := result.Column(types.ScoreFieldName).Chunk(0).(*array.Float32)
 	s.InDelta(1.0/(60+1), float64(scores.Value(0)), 1e-6) // RRF score, not original
+}
+
+func (s *MergeHelperTestSuite) TestWeightedRRFProducesExpectedScoresAndOrder() {
+	df1 := s.createDF([]int64{1, 2, 3}, []float32{0.1, 0.2, 0.3}, []int64{3})
+	df2 := s.createDF([]int64{3, 2, 4}, []float32{0.9, 0.8, 0.7}, []int64{3})
+	defer df1.Release()
+	defer df2.Release()
+
+	op := NewMergeOp(MergeStrategyRRF, WithRRFK(1), WithWeights([]float64{0.7, 0.2}))
+	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
+
+	result, err := op.ExecuteMulti(ctx, []*DataFrame{df1, df2})
+	s.Require().NoError(err)
+	defer result.Release()
+
+	ids := result.Column(types.IDFieldName).Chunk(0).(*array.Int64)
+	scores := result.Column(types.ScoreFieldName).Chunk(0).(*array.Float32)
+	expectedIDs := []int64{1, 2, 3, 4}
+	expectedScores := []float64{0.35, 0.3, 0.275, 0.05}
+	for i := range expectedIDs {
+		s.Equal(expectedIDs[i], ids.Value(i))
+		s.InDelta(expectedScores[i], float64(scores.Value(i)), 1e-6)
+	}
+}
+
+func (s *MergeHelperTestSuite) TestAllOneRRFWeightsPreserveClassicScores() {
+	df1 := s.createDF([]int64{1, 2, 3}, []float32{0.1, 0.2, 0.3}, []int64{3})
+	df2 := s.createDF([]int64{3, 2, 4}, []float32{0.9, 0.8, 0.7}, []int64{3})
+	defer df1.Release()
+	defer df2.Release()
+
+	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
+	classic, err := NewMergeOp(MergeStrategyRRF).ExecuteMulti(ctx, []*DataFrame{df1, df2})
+	s.Require().NoError(err)
+	defer classic.Release()
+	weighted, err := NewMergeOp(MergeStrategyRRF, WithWeights([]float64{1, 1})).ExecuteMulti(ctx, []*DataFrame{df1, df2})
+	s.Require().NoError(err)
+	defer weighted.Release()
+
+	classicIDs := classic.Column(types.IDFieldName).Chunk(0).(*array.Int64)
+	weightedIDs := weighted.Column(types.IDFieldName).Chunk(0).(*array.Int64)
+	classicScores := classic.Column(types.ScoreFieldName).Chunk(0).(*array.Float32)
+	weightedScores := weighted.Column(types.ScoreFieldName).Chunk(0).(*array.Float32)
+	s.Equal(classicIDs.Len(), weightedIDs.Len())
+	for i := 0; i < classicIDs.Len(); i++ {
+		s.Equal(classicIDs.Value(i), weightedIDs.Value(i))
+		s.Equal(classicScores.Value(i), weightedScores.Value(i))
+	}
+}
+
+func (s *MergeHelperTestSuite) TestWeightedRRFInputCountMismatch() {
+	df1 := s.createDF([]int64{1}, []float32{0.1}, []int64{1})
+	df2 := s.createDF([]int64{2}, []float32{0.2}, []int64{1})
+	defer df1.Release()
+	defer df2.Release()
+
+	op := NewMergeOp(MergeStrategyRRF, WithWeights([]float64{1}))
+	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
+	_, err := op.ExecuteMulti(ctx, []*DataFrame{df1, df2})
+	s.Error(err)
+	s.Contains(err.Error(), "weights count 1 != inputs count 2")
+}
+
+func (s *MergeHelperTestSuite) TestWeightedStrategyRequiresWeights() {
+	df := s.createDF([]int64{1}, []float32{0.1}, []int64{1})
+	defer df.Release()
+
+	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
+	for _, op := range []*MergeOp{
+		NewMergeOp(MergeStrategyWeighted),
+		NewMergeOp(MergeStrategyWeighted, WithWeights(nil)),
+		NewMergeOp(MergeStrategyWeighted, WithWeights([]float64{})),
+	} {
+		_, err := op.ExecuteMulti(ctx, []*DataFrame{df})
+		s.Error(err)
+		s.Contains(err.Error(), "weights count 0 != inputs count 1")
+	}
+}
+
+func (s *MergeHelperTestSuite) TestRRFExplicitEmptyWeightsRejected() {
+	df := s.createDF([]int64{1}, []float32{0.1}, []int64{1})
+	defer df.Release()
+
+	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
+	for _, op := range []*MergeOp{
+		NewMergeOp(MergeStrategyRRF, WithWeights(nil)),
+		NewMergeOp(MergeStrategyRRF, WithWeights([]float64{})),
+	} {
+		_, err := op.ExecuteMulti(ctx, []*DataFrame{df})
+		s.Error(err)
+		s.Contains(err.Error(), "weights count 0 != inputs count 1")
+	}
+}
+
+func (s *MergeHelperTestSuite) TestAllZeroRRFWeightsKeepCandidateUnion() {
+	df1 := s.createDF([]int64{3, 1}, []float32{0.2, 0.1}, []int64{2})
+	df2 := s.createDF([]int64{2, 1}, []float32{0.4, 0.3}, []int64{2})
+	defer df1.Release()
+	defer df2.Release()
+
+	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
+	result, err := NewMergeOp(MergeStrategyRRF, WithWeights([]float64{0, 0})).ExecuteMulti(ctx, []*DataFrame{df1, df2})
+	s.Require().NoError(err)
+	defer result.Release()
+
+	ids := result.Column(types.IDFieldName).Chunk(0).(*array.Int64)
+	scores := result.Column(types.ScoreFieldName).Chunk(0).(*array.Float32)
+	s.Equal([]int64{1, 2, 3}, []int64{ids.Value(0), ids.Value(1), ids.Value(2)})
+	for index := 0; index < scores.Len(); index++ {
+		s.Zero(scores.Value(index))
+	}
+}
+
+func (s *MergeHelperTestSuite) TestMergeRejectsInvalidConfiguredWeights() {
+	df := s.createDF([]int64{1}, []float32{0.1}, []int64{1})
+	defer df.Release()
+
+	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
+	for _, strategy := range []MergeStrategy{MergeStrategyRRF, MergeStrategyWeighted} {
+		for _, weight := range []float64{math.NaN(), math.Inf(1), -0.1, 1.1} {
+			_, err := NewMergeOp(strategy, WithWeights([]float64{weight})).ExecuteMulti(ctx, []*DataFrame{df})
+			s.Require().Error(err)
+			s.Contains(err.Error(), "must be finite and in range [0, 1]")
+		}
+	}
 }
 
 func (s *MergeHelperTestSuite) TestSingleInputWeightedScoreNotFloat32() {
@@ -2411,7 +2541,24 @@ func TestNewMergeOpFromReprWithContext(t *testing.T) {
 			sortDescending: true,
 			verify: func(t *testing.T, op *MergeOp) {
 				assert.Equal(t, float64(60), op.rrfK)
+				assert.False(t, op.weightsSet)
+				assert.Empty(t, op.weights)
 				assert.Empty(t, op.scoreNormFuncs)
+			},
+		},
+		{
+			name: "rrf weighted typed params",
+			repr: mergeRepr("rrf", map[string]*schemapb.FunctionParamValue{
+				MergeParamK:       intParam(30),
+				MergeParamWeights: arrayParam(doubleParam(0.8), doubleParam(0.2)),
+			}),
+			metrics:        []string{"COSINE", "IP"},
+			strategy:       MergeStrategyRRF,
+			sortDescending: true,
+			verify: func(t *testing.T, op *MergeOp) {
+				assert.Equal(t, float64(30), op.rrfK)
+				assert.True(t, op.weightsSet)
+				assert.Equal(t, []float64{0.8, 0.2}, op.weights)
 			},
 		},
 		{
@@ -2489,7 +2636,10 @@ func TestMergeReprRejectsInvalidPublicConfiguration(t *testing.T) {
 		{"outputs", &OperatorRepr{Type: types.OpTypeMerge, Outputs: []string{"$score"}}},
 		{"missing strategy", &OperatorRepr{Type: types.OpTypeMerge}},
 		{"unsupported strategy", mergeRepr("median", nil)},
-		{"rrf incompatible weights", mergeRepr("rrf", map[string]*schemapb.FunctionParamValue{MergeParamWeights: arrayParam(doubleParam(1))})},
+		{"rrf empty weights", mergeRepr("rrf", map[string]*schemapb.FunctionParamValue{MergeParamWeights: arrayParam()})},
+		{"rrf bad weight", mergeRepr("rrf", map[string]*schemapb.FunctionParamValue{MergeParamWeights: arrayParam(doubleParam(math.NaN()))})},
+		{"rrf wrong weights type", mergeRepr("rrf", map[string]*schemapb.FunctionParamValue{MergeParamWeights: stringParam("[1]")})},
+		{"rrf weights count mismatch", mergeRepr("rrf", map[string]*schemapb.FunctionParamValue{MergeParamWeights: arrayParam(doubleParam(0.8), doubleParam(0.2))})},
 		{"rrf wrong k type", mergeRepr("rrf", map[string]*schemapb.FunctionParamValue{MergeParamK: stringParam("60")})},
 		{"rrf non finite k", mergeRepr("rrf", map[string]*schemapb.FunctionParamValue{MergeParamK: doubleParam(math.Inf(1))})},
 		{"rrf zero k", mergeRepr("rrf", map[string]*schemapb.FunctionParamValue{MergeParamK: intParam(0)})},

--- a/internal/util/function/chain/rerank_builder.go
+++ b/internal/util/function/chain/rerank_builder.go
@@ -210,14 +210,13 @@ func convertLegacyParams(rankParams []*commonpb.KeyValuePair) (*schemapb.Functio
 				return nil, merr.WrapErrParameterInvalidMsg("the type of rank param k should be float")
 			}
 		}
+		if err := appendLegacyWeightsParam(fSchema, params); err != nil {
+			return nil, err
+		}
 	case "weighted":
 		fSchema.Params = append(fSchema.Params, &commonpb.KeyValuePair{Key: rerankerKey, Value: WeightedRerankerName})
-		if v, ok := params[weightsKey]; ok {
-			if d, err := json.Marshal(v); err != nil {
-				return nil, merr.WrapErrParameterInvalidMsg("the weights param should be an array")
-			} else {
-				fSchema.Params = append(fSchema.Params, &commonpb.KeyValuePair{Key: weightsKey, Value: string(d)})
-			}
+		if err := appendLegacyWeightsParam(fSchema, params); err != nil {
+			return nil, err
 		}
 		if normScore, ok := params[normScoreKey]; ok {
 			switch ns := normScore.(type) {
@@ -238,6 +237,17 @@ func convertLegacyParams(rankParams []*commonpb.KeyValuePair) (*schemapb.Functio
 	}
 
 	return fSchema, nil
+}
+
+func appendLegacyWeightsParam(funcSchema *schemapb.FunctionSchema, params map[string]interface{}) error {
+	if value, ok := params[weightsKey]; ok {
+		data, err := json.Marshal(value)
+		if err != nil {
+			return merr.WrapErrParameterInvalidMsg("the weights param should be an array")
+		}
+		funcSchema.Params = append(funcSchema.Params, &commonpb.KeyValuePair{Key: weightsKey, Value: string(data)})
+	}
+	return nil
 }
 
 // buildRerankChainInternal builds a FuncChain from FunctionSchema.
@@ -359,11 +369,21 @@ func buildRRFChain(fc *FuncChain, funcSchema *schemapb.FunctionSchema, searchMet
 	if err != nil {
 		return err
 	}
+	weights, weightsSet, err := parseRRFWeights(funcSchema)
+	if err != nil {
+		return err
+	}
+	if weightsSet && len(weights) != len(searchMetrics) {
+		return merr.WrapErrParameterInvalidMsg("the length of weights param mismatch with ann search requests: got %d, want %d", len(weights), len(searchMetrics))
+	}
 
 	// RRF scores are computed purely from rank position, not from original scores,
 	// so metricTypes and normalize are not needed.
-	fc.Merge(MergeStrategyRRF,
-		WithRRFK(rrfK))
+	options := []MergeOption{WithRRFK(rrfK)}
+	if weightsSet {
+		options = append(options, WithWeights(weights))
+	}
+	fc.Merge(MergeStrategyRRF, options...)
 
 	return nil
 }
@@ -382,6 +402,22 @@ func parseRRFK(funcSchema *schemapb.FunctionSchema) (float64, error) {
 		}
 	}
 	return defaultRRFK, nil
+}
+
+func parseRRFWeights(funcSchema *schemapb.FunctionSchema) ([]float64, bool, error) {
+	for _, param := range funcSchema.Params {
+		if strings.ToLower(param.Key) == weightsKey {
+			weights, err := parseRRFWeightArray(param.Value)
+			if err != nil {
+				return nil, false, err
+			}
+			if len(weights) == 0 {
+				return nil, false, merr.WrapErrParameterInvalidMsg("rerank_builder: rrf weights parameter must be a non-empty array")
+			}
+			return weights, true, nil
+		}
+	}
+	return nil, false, nil
 }
 
 // =============================================================================
@@ -419,14 +455,9 @@ func parseWeightedParams(funcSchema *schemapb.FunctionSchema) ([]float64, bool, 
 	for _, param := range funcSchema.Params {
 		switch strings.ToLower(param.Key) {
 		case weightsKey:
-			var ws []float64
-			if err := json.Unmarshal([]byte(param.Value), &ws); err != nil {
-				return nil, false, merr.WrapErrParameterInvalidMsg("failed to parse weights: %v", err)
-			}
-			for _, w := range ws {
-				if w < 0 || w > 1 {
-					return nil, false, merr.WrapErrParameterInvalidMsg("rank param weight should be in range [0, 1]")
-				}
+			ws, err := parseWeights(param.Value)
+			if err != nil {
+				return nil, false, err
 			}
 			weights = ws
 		case normScoreKey:
@@ -439,6 +470,43 @@ func parseWeightedParams(funcSchema *schemapb.FunctionSchema) ([]float64, bool, 
 	}
 
 	return weights, normalize, nil
+}
+
+func parseWeights(value string) ([]float64, error) {
+	var weights []float64
+	if err := json.Unmarshal([]byte(value), &weights); err != nil {
+		return nil, merr.WrapErrParameterInvalidMsg("failed to parse weights: %v", err)
+	}
+	for _, weight := range weights {
+		if weight < 0 || weight > 1 {
+			return nil, merr.WrapErrParameterInvalidMsg("rank param weight should be in range [0, 1]")
+		}
+	}
+	return weights, nil
+}
+
+// parseRRFWeightArray preserves the existing weighted-score parser while
+// enforcing that every optional RRF weight is an actual JSON number. In
+// particular, encoding/json otherwise decodes a null array element as zero.
+func parseRRFWeightArray(value string) ([]float64, error) {
+	var rawWeights []json.RawMessage
+	if err := json.Unmarshal([]byte(value), &rawWeights); err != nil {
+		return nil, merr.WrapErrParameterInvalidMsg("failed to parse weights: %v", err)
+	}
+	weights := make([]float64, len(rawWeights))
+	for index, rawWeight := range rawWeights {
+		if string(rawWeight) == "null" {
+			return nil, merr.WrapErrParameterInvalidMsg("failed to parse weights: weight at index %d must be a number", index)
+		}
+		if err := json.Unmarshal(rawWeight, &weights[index]); err != nil {
+			return nil, merr.WrapErrParameterInvalidMsg("failed to parse weights: weight at index %d must be a number", index)
+		}
+		weight := weights[index]
+		if weight < 0 || weight > 1 {
+			return nil, merr.WrapErrParameterInvalidMsg("rank param weight should be in range [0, 1]")
+		}
+	}
+	return weights, nil
 }
 
 // =============================================================================

--- a/internal/util/function/chain/rerank_builder_test.go
+++ b/internal/util/function/chain/rerank_builder_test.go
@@ -148,6 +148,34 @@ func (s *RerankBuilderTestSuite) TestBuildRRFChain() {
 	s.Equal("Merge", fc.operators[0].Name())
 	s.Equal("Sort", fc.operators[1].Name())
 	s.Equal("Limit", fc.operators[2].Name())
+	s.Nil(fc.operators[0].(*MergeOp).weights)
+}
+
+func (s *RerankBuilderTestSuite) TestBuildRRFChainWithWeights() {
+	collSchema := s.createCollectionSchema()
+	searchParams := s.createSearchParams()
+	searchMetrics := []string{"COSINE", "IP"}
+
+	funcScoreSchema := &schemapb.FunctionScore{
+		Functions: []*schemapb.FunctionSchema{
+			{
+				Type: schemapb.FunctionType_Rerank,
+				Params: []*commonpb.KeyValuePair{
+					{Key: "reranker", Value: "rrf"},
+					{Key: "k", Value: "30"},
+					{Key: "weights", Value: "[0.8, 0.2]"},
+				},
+			},
+		},
+	}
+
+	fc, err := BuildRerankChain(collSchema, funcScoreSchema, searchMetrics, searchParams, s.pool)
+	s.Require().NoError(err)
+
+	mergeOp := fc.operators[0].(*MergeOp)
+	s.Equal(MergeStrategyRRF, mergeOp.strategy)
+	s.Equal(30.0, mergeOp.rrfK)
+	s.Equal([]float64{0.8, 0.2}, mergeOp.weights)
 }
 
 func (s *RerankBuilderTestSuite) TestBuildRRFChainDefaultK() {
@@ -232,6 +260,66 @@ func (s *RerankBuilderTestSuite) TestBuildRRFChainKNotANumber() {
 	_, err := BuildRerankChain(collSchema, funcScoreSchema, searchMetrics, searchParams, s.pool)
 	s.Error(err)
 	s.Contains(err.Error(), "is not a number")
+}
+
+func (s *RerankBuilderTestSuite) TestBuildRRFChainWeightsValidation() {
+	collSchema := s.createCollectionSchema()
+	searchParams := s.createSearchParams()
+	searchMetrics := []string{"COSINE", "IP"}
+
+	tests := []struct {
+		name          string
+		weights       string
+		expectedError string
+	}{
+		{name: "malformed", weights: "not-json", expectedError: "failed to parse weights"},
+		{name: "not numeric", weights: `["0.8", 0.2]`, expectedError: "failed to parse weights"},
+		{name: "null element", weights: "[null, 0.2]", expectedError: "failed to parse weights"},
+		{name: "null", weights: "null", expectedError: "non-empty array"},
+		{name: "empty", weights: "[]", expectedError: "non-empty array"},
+		{name: "negative", weights: "[-0.1, 0.2]", expectedError: "range [0, 1]"},
+		{name: "greater than one", weights: "[0.8, 1.1]", expectedError: "range [0, 1]"},
+		{name: "count mismatch", weights: "[0.8]", expectedError: "length of weights param mismatch"},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			funcScoreSchema := &schemapb.FunctionScore{
+				Functions: []*schemapb.FunctionSchema{
+					{
+						Type: schemapb.FunctionType_Rerank,
+						Params: []*commonpb.KeyValuePair{
+							{Key: "reranker", Value: "rrf"},
+							{Key: "weights", Value: test.weights},
+						},
+					},
+				},
+			}
+
+			_, err := BuildRerankChain(collSchema, funcScoreSchema, searchMetrics, searchParams, s.pool)
+			s.Error(err)
+			s.Contains(err.Error(), test.expectedError)
+		})
+	}
+}
+
+func (s *RerankBuilderTestSuite) TestBuildRRFChainWeightsBoundaries() {
+	collSchema := s.createCollectionSchema()
+	funcScoreSchema := &schemapb.FunctionScore{
+		Functions: []*schemapb.FunctionSchema{
+			{
+				Type: schemapb.FunctionType_Rerank,
+				Params: []*commonpb.KeyValuePair{
+					{Key: "reranker", Value: "rrf"},
+					{Key: "weights", Value: "[0, 1]"},
+				},
+			},
+		},
+	}
+
+	fc, err := BuildRerankChain(collSchema, funcScoreSchema, []string{"COSINE", "IP"}, s.createSearchParams(), s.pool)
+	s.Require().NoError(err)
+	s.Equal([]float64{0, 1}, fc.operators[0].(*MergeOp).weights)
 }
 
 // =============================================================================
@@ -530,11 +618,11 @@ func (s *RerankBuilderTestSuite) TestBuildDecayChainWithScoreMode() {
 func (s *RerankBuilderTestSuite) TestBuildLegacyRRF() {
 	collSchema := s.createCollectionSchema()
 	searchParams := s.createSearchParams()
-	searchMetrics := []string{"COSINE"}
+	searchMetrics := []string{"COSINE", "IP"}
 
 	rankParams := []*commonpb.KeyValuePair{
 		{Key: "strategy", Value: "rrf"},
-		{Key: "params", Value: `{"k": 60}`},
+		{Key: "params", Value: `{"k": 60, "weights": [0.8, 0.2]}`},
 	}
 
 	fc, err := BuildRerankChainWithLegacy(collSchema, rankParams, searchMetrics, searchParams, s.pool)
@@ -544,6 +632,38 @@ func (s *RerankBuilderTestSuite) TestBuildLegacyRRF() {
 	mergeOp := fc.operators[0].(*MergeOp)
 	s.Equal(MergeStrategyRRF, mergeOp.strategy)
 	s.Equal(60.0, mergeOp.rrfK)
+	s.Equal([]float64{0.8, 0.2}, mergeOp.weights)
+}
+
+func (s *RerankBuilderTestSuite) TestRRFPublicPathsBuildEquivalentMergeOps() {
+	collSchema := s.createCollectionSchema()
+	searchParams := s.createSearchParams()
+	searchMetrics := []string{"COSINE", "IP"}
+
+	funcScore := &schemapb.FunctionScore{Functions: []*schemapb.FunctionSchema{{
+		Type: schemapb.FunctionType_Rerank,
+		Params: []*commonpb.KeyValuePair{
+			{Key: "reranker", Value: "rrf"},
+			{Key: "k", Value: "30"},
+			{Key: "weights", Value: "[0.7, 0.2]"},
+		},
+	}}}
+	legacyParams := []*commonpb.KeyValuePair{
+		{Key: "strategy", Value: "rrf"},
+		{Key: "params", Value: `{"k": 30, "weights": [0.7, 0.2]}`},
+	}
+
+	functionChain, err := BuildRerankChain(collSchema, funcScore, searchMetrics, searchParams, s.pool)
+	s.Require().NoError(err)
+	legacyChain, err := BuildRerankChainWithLegacy(collSchema, legacyParams, searchMetrics, searchParams, s.pool)
+	s.Require().NoError(err)
+
+	functionMerge := functionChain.operators[0].(*MergeOp)
+	legacyMerge := legacyChain.operators[0].(*MergeOp)
+	s.Equal(functionMerge.strategy, legacyMerge.strategy)
+	s.Equal(functionMerge.rrfK, legacyMerge.rrfK)
+	s.Equal(functionMerge.weights, legacyMerge.weights)
+	s.Equal(functionMerge.weightsSet, legacyMerge.weightsSet)
 }
 
 func (s *RerankBuilderTestSuite) TestBuildLegacyWeighted() {

--- a/tests/go_client/testcases/hybrid_search_test.go
+++ b/tests/go_client/testcases/hybrid_search_test.go
@@ -277,6 +277,7 @@ func TestHybridSearchMultiVectorsDefault(t *testing.T) {
 		// search with different reranker
 		for _, reranker := range []client.Reranker{
 			client.NewRRFReranker(),
+			client.NewRRFReranker().WithWeights([]float64{0.2, 0.3}),
 			client.NewWeightedReranker([]float64{0.8, 0.2}),
 			client.NewWeightedReranker([]float64{0.0, 0.2}),
 			client.NewWeightedReranker([]float64{0.4, 1.0}),
@@ -334,6 +335,18 @@ func TestHybridSearchInvalidParams(t *testing.T) {
 	} {
 		_, errReranker := mc.HybridSearch(ctx, client.NewHybridSearchOption(schema.CollectionName, common.DefaultLimit, annReq1, annReq2).WithReranker(invalidRanker))
 		common.CheckErr(t, errReranker, false, "rank param weight should be in range [0, 1]",
+			"the length of weights param mismatch with ann search requests")
+	}
+
+	// hybrid search with invalid weighted RRF params
+	for _, invalidRanker := range []client.Reranker{
+		client.NewRRFReranker().WithWeights([]float64{}),
+		client.NewRRFReranker().WithWeights(nil),
+		client.NewRRFReranker().WithWeights([]float64{-0.1, 0.2}),
+		client.NewRRFReranker().WithWeights([]float64{0.8}),
+	} {
+		_, errReranker := mc.HybridSearch(ctx, client.NewHybridSearchOption(schema.CollectionName, common.DefaultLimit, annReq1, annReq2).WithReranker(invalidRanker))
+		common.CheckErr(t, errReranker, false, "non-empty array", "rank param weight should be in range [0, 1]",
 			"the length of weights param mismatch with ann search requests")
 	}
 

--- a/tests/go_client/testcases/reranker_function_test.go
+++ b/tests/go_client/testcases/reranker_function_test.go
@@ -339,13 +339,17 @@ func TestRerankFunctionRRF(t *testing.T) {
 	queryVec2 := hp.GenSearchVectors(common.DefaultNq, common.DefaultDim, entity.FieldTypeFloat16Vector)
 
 	testCases := []struct {
-		name string
-		k    int
+		name    string
+		k       int
+		weights []float64
 	}{
-		{"default_k", 60},
-		{"small_k", 10},
-		{"large_k", 100},
-		{"very_large_k", 1000},
+		{name: "default_k", k: 60},
+		{name: "small_k", k: 10},
+		{name: "large_k", k: 100},
+		{name: "very_large_k", k: 1000},
+		{name: "weighted_rrf", k: 60, weights: []float64{0.8, 0.2}},
+		{name: "weights_not_normalized", k: 60, weights: []float64{0.2, 0.3}},
+		{name: "all_zero_weights", k: 60, weights: []float64{0, 0}},
 	}
 
 	for _, tc := range testCases {
@@ -356,6 +360,9 @@ func TestRerankFunctionRRF(t *testing.T) {
 				WithInputFields().
 				WithParam("reranker", "rrf").
 				WithParam("k", tc.k)
+			if tc.weights != nil {
+				rrfReranker.WithParam("weights", tc.weights)
+			}
 
 			annReq1 := client.NewAnnRequest(common.DefaultFloatVecFieldName, common.DefaultLimit, queryVec1...)
 			annReq2 := client.NewAnnRequest(common.DefaultFloat16VecFieldName, common.DefaultLimit, queryVec2...)
@@ -366,6 +373,14 @@ func TestRerankFunctionRRF(t *testing.T) {
 
 			common.CheckErr(t, err, true)
 			validateRerankFunctionResults(t, results, common.DefaultLimit)
+			if tc.name == "all_zero_weights" {
+				for _, result := range results {
+					require.Positive(t, result.ResultCount)
+					for _, score := range result.Scores {
+						require.Zero(t, score)
+					}
+				}
+			}
 		})
 	}
 }
@@ -628,6 +643,48 @@ func TestRerankFunctionRRFNegative(t *testing.T) {
 				WithInputFields().
 				WithParam("reranker", "rrf").
 				WithParam("k", tc.k)
+
+			_, err := mc.HybridSearch(ctx, client.NewHybridSearchOption(
+				schema.CollectionName, common.DefaultLimit, annReq1, annReq2,
+			).WithFunctionRerankers(rrfReranker))
+
+			common.CheckErr(t, err, false, tc.expectedError)
+		})
+	}
+}
+
+func TestRerankFunctionRRFWeightsNegative(t *testing.T) {
+	t.Parallel()
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	_, schema := createRerankFunctionTestCollection(ctx, t, mc, false)
+
+	queryVec1 := hp.GenSearchVectors(1, common.DefaultDim, entity.FieldTypeFloatVector)
+	queryVec2 := hp.GenSearchVectors(1, common.DefaultDim, entity.FieldTypeFloat16Vector)
+	annReq1 := client.NewAnnRequest(common.DefaultFloatVecFieldName, common.DefaultLimit, queryVec1...)
+	annReq2 := client.NewAnnRequest(common.DefaultFloat16VecFieldName, common.DefaultLimit, queryVec2...)
+
+	testCases := []struct {
+		name          string
+		weights       interface{}
+		expectedError string
+	}{
+		{name: "empty", weights: []float64{}, expectedError: "non-empty array"},
+		{name: "null", weights: nil, expectedError: "non-empty array"},
+		{name: "negative", weights: []float64{-0.1, 0.2}, expectedError: "range [0, 1]"},
+		{name: "greater_than_one", weights: []float64{0.8, 1.1}, expectedError: "range [0, 1]"},
+		{name: "count_mismatch", weights: []float64{0.8}, expectedError: "length of weights param mismatch"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rrfReranker := entity.NewFunction().
+				WithName("test_rrf_weights_negative_"+tc.name).
+				WithType(entity.FunctionTypeRerank).
+				WithInputFields().
+				WithParam("reranker", "rrf").
+				WithParam("weights", tc.weights)
 
 			_, err := mc.HybridSearch(ctx, client.NewHybridSearchOption(
 				schema.CollectionName, common.DefaultLimit, annReq1, annReq2,


### PR DESCRIPTION
issue: #52817
pr: #52818
design doc: docs/design-docs/design_docs/20260824-weighted-rrf-reranking.md

## What changed

Backport weighted RRF support to 3.0.

- Accept optional per-ANN-request weights through FunctionScore, REST, and legacy hybrid-search rank parameters.
- Apply weight[i] / (k + rank) without normalization while preserving classic RRF when weights are omitted.
- Add the Go client WithWeights helper.
- Validate malformed, null, empty, non-finite, out-of-range, and request-count-mismatched weights before the empty-result fast path.

## Backport notes

- Clean cherry-pick of the master squash commit dac586c8 onto 3.0 at 5444bf19, after #52891 landed.
- No conflict resolution or branch-specific code edits were needed.
- The complete sequence of added and removed lines matches the master source patch.
- Replaces the closed backport #52909, which was prepared before #52891 reached 3.0.

## Validation

- make fmt
- Go client: go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./entity ./milvusclient
- FunctionChain: go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/util/function/chain
- Proxy empty-result validation regression test
- REST FunctionSchema conversion tests
- golangci-lint on all touched root, client, and tests/go_client packages: 0 issues
- git diff --check
- Full make static-check reaches an unrelated pre-existing 3.0 module error: cmd/tools/migration is missing a go.sum entry for github.com/prometheus/client_golang. No migration or module files are changed here.
- Live-server Go E2E was not run locally; CI should run the integrated suites.