### PR TITLE
fix: [2.6] preserve the validity bitmap for nullable GEOMETRY in insert binlogs (#52813)

### DIFF
--- a/internal/core/src/storage/DataCodecTest.cpp
+++ b/internal/core/src/storage/DataCodecTest.cpp
@@ -533,17 +533,96 @@ TEST(storage, InsertDataGeometryNullable) {
     auto new_payload = new_insert_data->GetFieldData();
     ASSERT_EQ(new_payload->get_data_type(), storage::DataType::GEOMETRY);
     ASSERT_EQ(new_payload->get_num_rows(), data.size());
-    // Note: current geometry serialization path writes empty string for null
-    // rows and loses Arrow null-bitmap, so null_count()==0 after round-trip.
 
-    // Expected data: original rows preserved (bitmap ignored by codec)
+    // Null rows must come back as nulls, exactly like every other nullable
+    // variable-length type in this file (see InsertDataStringNullable): the
+    // serializer has to hand the payload writer a negative length for a null
+    // row so Arrow records a 0 bit in the validity bitmap.
+    FixedVector<std::string> expected = {str1, str2, "", "", str5};
     FixedVector<std::string> new_data(data.size());
     for (int i = 0; i < data.size(); ++i) {
         new_data[i] =
             *static_cast<const std::string*>(new_payload->RawValue(i));
-        ASSERT_EQ(new_payload->DataSize(i), data[i].size());
+        ASSERT_EQ(new_payload->DataSize(i), expected[i].size());
     }
-    ASSERT_EQ(data, new_data);
+    ASSERT_EQ(expected, new_data);
+    ASSERT_EQ(new_payload->get_null_count(), 2);
+    EXPECT_TRUE(new_payload->is_valid(0));
+    EXPECT_TRUE(new_payload->is_valid(1));
+    EXPECT_FALSE(new_payload->is_valid(2));
+    EXPECT_FALSE(new_payload->is_valid(3));
+    EXPECT_TRUE(new_payload->is_valid(4));
+    ASSERT_EQ(*new_payload->ValidData(), *valid_data);
+}
+
+// Same round-trip, but with a row count that neither fills nor aligns to a
+// validity-bitmap byte: 13 rows spans two bytes with a partial second one, and
+// the nulls straddle the byte boundary (rows 7 and 8). A serializer that gets
+// the per-row validity lookup right for the first byte but drops or misindexes
+// it afterwards passes the 5-row case above and fails here.
+TEST(storage, InsertDataGeometryNullableAcrossValidityByteBoundary) {
+    auto ctx = GEOS_init_r();
+    constexpr int kRows = 13;
+    FixedVector<std::string> data(kRows);
+    for (int i = 0; i < kRows; ++i) {
+        std::string wkt =
+            "POINT (" + std::to_string(i) + ".0 " + std::to_string(i) + ".0)";
+        data[i] = Geometry(ctx, wkt.c_str()).to_wkb_string();
+    }
+    GEOS_finish_r(ctx);
+
+    // Nulls at rows 3, 7, 8, 12 -- bit i of byte i/8, LSB first, unused
+    // trailing bits set (the convention the other tests in this file use).
+    // byte0 rows 0-7 : 0b01110111 = 0x77   (rows 3, 7 null)
+    // byte1 rows 8-12: 0b11101110 = 0xEE   (rows 8, 12 null)
+    uint8_t valid_data_storage[2] = {0x77, 0xEE};
+    const std::vector<bool> expect_valid = {true,
+                                            true,
+                                            true,
+                                            false,
+                                            true,
+                                            true,
+                                            true,
+                                            false,
+                                            false,
+                                            true,
+                                            true,
+                                            true,
+                                            false};
+
+    auto field_data = milvus::storage::CreateFieldData(
+        storage::DataType::GEOMETRY, storage::DataType::NONE, true);
+    field_data->FillFieldData(data.data(), valid_data_storage, kRows, 0);
+
+    auto payload_reader =
+        std::make_shared<milvus::storage::PayloadReader>(field_data);
+    storage::InsertData insert_data(payload_reader);
+    storage::FieldDataMeta field_data_meta{100, 101, 102, 103};
+    insert_data.SetFieldDataMeta(field_data_meta);
+    insert_data.SetTimestamps(0, 100);
+
+    auto serialized_bytes = insert_data.Serialize(storage::StorageType::Remote);
+    std::shared_ptr<uint8_t[]> serialized_data_ptr(serialized_bytes.data(),
+                                                   [&](uint8_t*) {});
+    auto new_insert_data = storage::DeserializeFileData(
+        serialized_data_ptr, serialized_bytes.size());
+
+    auto new_payload = new_insert_data->GetFieldData();
+    ASSERT_EQ(new_payload->get_data_type(), storage::DataType::GEOMETRY);
+    ASSERT_EQ(new_payload->get_num_rows(), kRows);
+    ASSERT_EQ(new_payload->get_null_count(), 4);
+    for (int i = 0; i < kRows; ++i) {
+        EXPECT_EQ(new_payload->is_valid(i), expect_valid[i])
+            << "validity mismatch at row " << i;
+        const auto& wkb =
+            *static_cast<const std::string*>(new_payload->RawValue(i));
+        if (expect_valid[i]) {
+            EXPECT_EQ(wkb, data[i]) << "payload mismatch at row " << i;
+        } else {
+            EXPECT_EQ(new_payload->DataSize(i), 0)
+                << "null row " << i << " should carry no payload";
+        }
+    }
 }
 TEST(storage, InsertDataString) {
     FixedVector<std::string> data = {

--- a/internal/core/src/storage/Event.cpp
+++ b/internal/core/src/storage/Event.cpp
@@ -326,9 +326,15 @@ BaseEventData::Serialize() {
                      ++offset) {
                     auto geo_ptr = static_cast<const std::string*>(
                         field_data->RawValue(offset));
+                    // A negative length is the only way a null reaches Arrow
+                    // (AddOneBinaryToArrowBuilder appends a null iff
+                    // length < 0), so a null row must not be handed its raw
+                    // size -- same as the STRING/ARRAY/JSON branches above.
+                    auto size =
+                        field_data->is_valid(offset) ? geo_ptr->size() : -1;
                     payload_writer->add_one_binary_payload(
                         reinterpret_cast<const uint8_t*>(geo_ptr->data()),
-                        geo_ptr->size());
+                        size);
                 }
                 break;
             }


### PR DESCRIPTION
Cherry-pick from master
pr: #52813
issue: #52812

`BaseEventData::Serialize()` consults `field_data->is_valid(offset)` for every nullable
variable-length type — except `GEOMETRY`, which always passed `geo_ptr->size()`. A negative
length is the *only* signal that reaches Arrow as a null (`AddOneBinaryToArrowBuilder`
appends a null iff `data == nullptr || length < 0`), so every GEOMETRY row was appended as
non-null: the round-tripped payload came back with an all-valid bitmap, and null rows still
carried whatever WKB the `FieldData` held for them.

The fix is the one-line alignment with the three neighbouring STRING/ARRAY/JSON branches.
See #52813 for the full scope discussion — in short, **production insert binlogs are not
affected** (they are written by the Go DataNode, whose `AddOneGeometryToPayload` already
handles `isValid`); `InsertData::Serialize` has no production caller, so this fixes a latent
defect plus the fidelity of the C++ nullable-GEOMETRY test fixtures that go through it.

## Why this branch needs it

Verified against `upstream/2.6` before cherry-picking, not assumed from master:

- The `case DataType::GEOMETRY` branch in `Event.cpp` is byte-identical to master's
  pre-fix code.
- `AddOneBinaryToArrowBuilder` on 2.6 has the same `length < 0 → AppendNull` contract the
  fix relies on.
- The Go writer on 2.6 (`AddOneGeometryToPayload(data, isValid)`) already handles nulls,
  so the "production binlogs unaffected" scoping holds here too.
- `TEST(storage, InsertDataGeometryNullable)` on 2.6 still carried the
  "bitmap ignored by codec" comment codifying the broken behavior.

The cherry-pick applied cleanly with no conflicts; the diff is identical to master's.

## Verification on this branch

Full `make build-cpp-with-unittest` in a clean `upstream/2.6` worktree, then
`storage.*` + every `Geometry` / `GIS` / `RTree` suite: **394 tests, 0 failures**
(2.6 carries fewer GIS suites than master, hence the smaller count).

Red/green on this branch: with `upstream/2.6`'s `Event.cpp` restored, `InsertDataGeometryNullable`
fails (null row still reports `DataSize 21`) and `InsertDataGeometryNullableAcrossValidityByteBoundary`
fails (`get_null_count() == 0` instead of `4`), while the non-nullable control `InsertDataGeometry`
passes; with the fix, all three pass. `clang-format-15` clean on both files.


Note for anyone reproducing locally: 2.6 requires Conan 1.x (`CONAN_CMD=conan-1 make ...`).
