### PR TITLE
fix: remove canceled DQL tasks from queue

### DIFF
--- a/internal/proxy/scheduler/task_scheduler.go
+++ b/internal/proxy/scheduler/task_scheduler.go
@@ -43,7 +43,6 @@ type TaskQueue interface {
 	utChan() <-chan int
 	utEmpty() bool
 	utFull() bool
-	addUnissuedTask(t taskmodel.Task) error
 	FrontUnissuedTask() taskmodel.Task
 	PopUnissuedTask() taskmodel.Task
 	AddActiveTask(t taskmodel.Task)
@@ -95,14 +94,14 @@ func (queue *BaseTaskQueue) IsFull() bool {
 	return queue.utFull()
 }
 
-func (queue *BaseTaskQueue) addUnissuedTask(t taskmodel.Task) error {
+func (queue *BaseTaskQueue) addUnissuedTask(t taskmodel.Task) (*list.Element, error) {
 	queue.utLock.Lock()
 	defer queue.utLock.Unlock()
 
 	if queue.utFull() {
-		return merr.WrapErrTooManyRequests(int32(queue.GetMaxTaskNum()))
+		return nil, merr.WrapErrTooManyRequests(int32(queue.GetMaxTaskNum()))
 	}
-	queue.unissuedTasks.PushBack(t)
+	element := queue.unissuedTasks.PushBack(t)
 	// utBufChan is an edge-triggered, capacity-1 notifier: a pending token
 	// means "the unissued list is non-empty, wake the scheduler". Concurrent
 	// sends coalesce; the scheduler drains the list on each wake.
@@ -110,7 +109,7 @@ func (queue *BaseTaskQueue) addUnissuedTask(t taskmodel.Task) error {
 	case queue.utBufChan <- 1:
 	default:
 	}
-	return nil
+	return element, nil
 }
 
 func (queue *BaseTaskQueue) FrontUnissuedTask() taskmodel.Task {
@@ -153,6 +152,18 @@ func (queue *BaseTaskQueue) popUnissuedTasks(filter func(taskmodel.Task) bool) [
 		e = next
 	}
 	return removed
+}
+
+// removeUnissuedTask removes element only if it is still waiting in this queue.
+// list.Remove is a no-op if the scheduler has already popped the element.
+func (queue *BaseTaskQueue) removeUnissuedTask(element *list.Element) {
+	if element == nil {
+		return
+	}
+
+	queue.utLock.Lock()
+	defer queue.utLock.Unlock()
+	queue.unissuedTasks.Remove(element)
 }
 
 func (queue *BaseTaskQueue) AddActiveTask(t taskmodel.Task) {
@@ -199,10 +210,10 @@ func (queue *BaseTaskQueue) getTaskByReqID(reqID taskmodel.UniqueID) taskmodel.T
 	return nil
 }
 
-func (queue *BaseTaskQueue) Enqueue(t taskmodel.Task) error {
+func (queue *BaseTaskQueue) enqueue(t taskmodel.Task) (*list.Element, error) {
 	err := t.OnEnqueue()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Fast-fail when the queue is already full, before any potentially-blocking
@@ -213,7 +224,7 @@ func (queue *BaseTaskQueue) Enqueue(t taskmodel.Task) error {
 	full := queue.utFull()
 	queue.utLock.RUnlock()
 	if full {
-		return merr.WrapErrTooManyRequests(int32(queue.GetMaxTaskNum()))
+		return nil, merr.WrapErrTooManyRequests(int32(queue.GetMaxTaskNum()))
 	}
 
 	var ts taskmodel.Timestamp
@@ -222,12 +233,12 @@ func (queue *BaseTaskQueue) Enqueue(t taskmodel.Task) error {
 		ts = tsoutil.ComposeTS(time.Now().UnixMilli(), 0)
 		id, err = t.GetMetaCache().AllocID(t.TraceCtx())
 		if err != nil {
-			return err
+			return nil, err
 		}
 	} else {
 		ts, err = queue.tsoAllocatorIns.AllocOne(t.TraceCtx())
 		if err != nil {
-			return err
+			return nil, err
 		}
 		// we always use same msg id and ts for now.
 		id = taskmodel.UniqueID(ts)
@@ -237,6 +248,11 @@ func (queue *BaseTaskQueue) Enqueue(t taskmodel.Task) error {
 
 	t.SetOnEnqueueTime()
 	return queue.addUnissuedTask(t)
+}
+
+func (queue *BaseTaskQueue) Enqueue(t taskmodel.Task) error {
+	_, err := queue.enqueue(t)
+	return err
 }
 
 func (queue *BaseTaskQueue) SetMaxTaskNum(num int64) {
@@ -426,6 +442,18 @@ func (queue *DmTaskQueue) getPChanStatsInfo() (map[taskmodel.PChan]*taskmodel.PC
 // DqTaskQueue represents queue for DQL task such as search/query
 type DqTaskQueue struct {
 	*BaseTaskQueue
+}
+
+func (queue *DqTaskQueue) Enqueue(t taskmodel.Task) error {
+	element, err := queue.BaseTaskQueue.enqueue(t)
+	if err != nil {
+		return err
+	}
+
+	t.SetOnWaitError(func() {
+		queue.removeUnissuedTask(element)
+	})
+	return nil
 }
 
 type ClearTaskQueueResult struct {

--- a/internal/proxy/scheduler/task_scheduler.go
+++ b/internal/proxy/scheduler/task_scheduler.go
@@ -450,7 +450,7 @@ func (queue *DqTaskQueue) Enqueue(t taskmodel.Task) error {
 		return err
 	}
 
-	t.SetOnWaitError(func() {
+	t.SetOnContextDone(func() {
 		queue.removeUnissuedTask(element)
 	})
 	return nil
@@ -727,6 +727,11 @@ func (sched *TaskScheduler) queryLoop() {
 					p = subTaskPool
 				}
 				p.Submit(func() (struct{}, error) {
+					// Submit may wait for a worker after the task has left the queue.
+					if err := task.TraceCtx().Err(); err != nil {
+						task.Notify(err)
+						return struct{}{}, nil
+					}
 					sched.processTask(task, sched.DqQueue)
 					return struct{}{}, nil
 				})

--- a/internal/proxy/scheduler/task_scheduler.go
+++ b/internal/proxy/scheduler/task_scheduler.go
@@ -445,7 +445,7 @@ type DqTaskQueue struct {
 }
 
 func (queue *DqTaskQueue) Enqueue(t taskmodel.Task) error {
-	element, err := queue.BaseTaskQueue.enqueue(t)
+	element, err := queue.enqueue(t)
 	if err != nil {
 		return err
 	}

--- a/internal/proxy/scheduler/task_scheduler_context_test.go
+++ b/internal/proxy/scheduler/task_scheduler_context_test.go
@@ -1,0 +1,179 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scheduler
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bytedance/mockey"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/pkg/v3/util/conc"
+)
+
+type queryLoopTestTask struct {
+	*mockDqlTask
+	subTask          bool
+	preExecute       func()
+	preExecuteCalls  atomic.Int32
+	executeCalls     atomic.Int32
+	postExecuteCalls atomic.Int32
+	notified         chan error
+}
+
+func (t *queryLoopTestTask) IsSubTask() bool {
+	return t.subTask
+}
+
+func (t *queryLoopTestTask) PreExecute(context.Context) error {
+	t.preExecuteCalls.Add(1)
+	if t.preExecute != nil {
+		t.preExecute()
+	}
+	return nil
+}
+
+func (t *queryLoopTestTask) Execute(context.Context) error {
+	t.executeCalls.Add(1)
+	return nil
+}
+
+func (t *queryLoopTestTask) PostExecute(context.Context) error {
+	t.postExecuteCalls.Add(1)
+	return nil
+}
+
+func (t *queryLoopTestTask) Notify(err error) {
+	t.mockDqlTask.Notify(err)
+	t.notified <- err
+}
+
+func TestTaskScheduler_QueryLoopContextDoneBeforeExecution(t *testing.T) {
+	for _, subTask := range []bool{false, true} {
+		poolName := "main pool"
+		if subTask {
+			poolName = "subtask pool"
+		}
+		t.Run(poolName, func(t *testing.T) {
+			for _, outcome := range []string{"canceled", "deadline exceeded", "live"} {
+				t.Run(outcome, func(t *testing.T) {
+					pools := []*conc.Pool[struct{}]{conc.NewPool[struct{}](1), conc.NewPool[struct{}](1)}
+					t.Cleanup(func() {
+						for _, pool := range pools {
+							pool.Release()
+						}
+					})
+
+					// Keep the actual pools so Waiting proves Submit is blocked before cancellation.
+					nextPool := 0
+					poolMock := mockey.MockGeneric(conc.NewPool[struct{}]).To(func(_ int, _ ...conc.PoolOption) *conc.Pool[struct{}] {
+						pool := pools[nextPool]
+						nextPool++
+						return pool
+					}).Build()
+					t.Cleanup(func() { poolMock.UnPatch() })
+
+					sched, err := NewTaskScheduler(context.Background(), newMockTsoAllocator())
+					require.NoError(t, err)
+					release := make(chan struct{})
+					var releaseOnce sync.Once
+					releaseWorker := func() { releaseOnce.Do(func() { close(release) }) }
+					t.Cleanup(func() {
+						releaseWorker()
+						sched.Close()
+					})
+					sched.wg.Add(1)
+					go sched.queryLoop()
+
+					started := make(chan struct{})
+					blockingTask := &queryLoopTestTask{
+						mockDqlTask: newDefaultMockDqlTask(),
+						subTask:     subTask,
+						preExecute: func() {
+							close(started)
+							<-release
+						},
+						notified: make(chan error, 1),
+					}
+					require.NoError(t, sched.DqQueue.Enqueue(blockingTask))
+					select {
+					case <-started:
+					case <-time.After(5 * time.Second):
+						t.Fatal("first task did not occupy the worker")
+					}
+
+					ctx, cancel := context.WithCancel(context.Background())
+					if outcome == "deadline exceeded" {
+						cancel()
+						ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+					}
+					t.Cleanup(cancel)
+					task := &queryLoopTestTask{
+						mockDqlTask: newMockDqlTask(ctx),
+						subTask:     subTask,
+						notified:    make(chan error, 1),
+					}
+					require.NoError(t, sched.DqQueue.Enqueue(task))
+
+					pool := pools[0]
+					if subTask {
+						pool = pools[1]
+					}
+					require.Eventually(t, func() bool { return pool.Waiting() == 1 }, 5*time.Second, time.Millisecond)
+					require.True(t, sched.DqQueue.utEmpty())
+
+					var expectedErr error
+					switch outcome {
+					case "canceled":
+						require.NoError(t, ctx.Err(), "cancel only after Submit starts waiting")
+						cancel()
+						expectedErr = context.Canceled
+					case "deadline exceeded":
+						<-ctx.Done()
+						expectedErr = context.DeadlineExceeded
+					}
+					if expectedErr != nil {
+						require.ErrorIs(t, task.WaitToFinish(), expectedErr)
+					}
+					releaseWorker()
+
+					select {
+					case err := <-task.notified:
+						require.ErrorIs(t, err, expectedErr)
+					case <-time.After(5 * time.Second):
+						t.Fatal("submitted task was not notified")
+					}
+					var expectedCalls int32
+					if expectedErr == nil {
+						expectedCalls = 1
+						require.NoError(t, task.WaitToFinish())
+					}
+					require.Equal(t, expectedCalls, task.preExecuteCalls.Load())
+					require.Equal(t, expectedCalls, task.executeCalls.Load())
+					require.Equal(t, expectedCalls, task.postExecuteCalls.Load())
+					require.Eventually(t, func() bool {
+						return sched.DqQueue.getTaskByReqID(task.ID()) == nil
+					}, 5*time.Second, time.Millisecond)
+				})
+			}
+		})
+	}
+}

--- a/internal/proxy/scheduler/task_scheduler_test.go
+++ b/internal/proxy/scheduler/task_scheduler_test.go
@@ -124,6 +124,38 @@ func TestBaseTaskQueue(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestDqTaskQueue_RemoveUnissuedTaskOnWaitError(t *testing.T) {
+	t.Run("remove queued task", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		queue := newDqTaskQueue(newMockTsoAllocator())
+		task := newMockDqlTask(ctx)
+
+		assert.NoError(t, queue.Enqueue(task))
+		assert.Equal(t, 1, queue.unissuedTasks.Len())
+
+		cancel()
+		assert.Error(t, task.WaitToFinish())
+		assert.True(t, queue.utEmpty())
+		assert.Nil(t, queue.getTaskByReqID(task.ID()))
+	})
+
+	t.Run("popped task is unchanged", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		queue := newDqTaskQueue(newMockTsoAllocator())
+		poppedTask := newMockDqlTask(ctx)
+		queuedTask := newDefaultMockDqlTask()
+
+		assert.NoError(t, queue.Enqueue(poppedTask))
+		assert.NoError(t, queue.Enqueue(queuedTask))
+		assert.Same(t, poppedTask, queue.PopUnissuedTask())
+
+		cancel()
+		assert.Error(t, poppedTask.WaitToFinish())
+		assert.Equal(t, 1, queue.unissuedTasks.Len())
+		assert.Same(t, queuedTask, queue.FrontUnissuedTask())
+	})
+}
+
 func TestDdTaskQueue(t *testing.T) {
 	var err error
 	var unissuedTask taskmodel.Task

--- a/internal/proxy/scheduler/task_scheduler_test.go
+++ b/internal/proxy/scheduler/task_scheduler_test.go
@@ -124,7 +124,7 @@ func TestBaseTaskQueue(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestDqTaskQueue_RemoveUnissuedTaskOnWaitError(t *testing.T) {
+func TestDqTaskQueue_RemoveUnissuedTaskOnContextDone(t *testing.T) {
 	t.Run("remove queued task", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		queue := newDqTaskQueue(newMockTsoAllocator())

--- a/internal/proxy/taskmodel/condition.go
+++ b/internal/proxy/taskmodel/condition.go
@@ -45,22 +45,18 @@ type TaskCondition struct {
 
 // WaitToFinish waits until the TaskCondition is notified or context done or canceled
 func (tc *TaskCondition) WaitToFinish() error {
-	var err error
 	select {
 	case <-tc.ctx.Done():
-		err = errors.Wrap(tc.ctx.Err(), "proxy TaskCondition context Done")
-	case err = <-tc.done:
-	}
-
-	if err != nil {
 		tc.onWaitErrorMu.RLock()
 		handler := tc.onWaitError
 		tc.onWaitErrorMu.RUnlock()
 		if handler != nil {
 			handler()
 		}
+		return errors.Wrap(tc.ctx.Err(), "proxy TaskCondition context Done")
+	case err := <-tc.done:
+		return err
 	}
-	return err
 }
 
 // Notify sends a signal into the done channel
@@ -73,7 +69,7 @@ func (tc *TaskCondition) Ctx() context.Context {
 	return tc.ctx
 }
 
-// SetOnWaitError registers a handler invoked before WaitToFinish returns an error.
+// SetOnWaitError registers a handler invoked when WaitToFinish returns because its context is done.
 func (tc *TaskCondition) SetOnWaitError(handler func()) {
 	tc.onWaitErrorMu.Lock()
 	defer tc.onWaitErrorMu.Unlock()

--- a/internal/proxy/taskmodel/condition.go
+++ b/internal/proxy/taskmodel/condition.go
@@ -18,6 +18,7 @@ package taskmodel
 
 import (
 	"context"
+	"sync"
 
 	"github.com/cockroachdb/errors"
 )
@@ -27,6 +28,7 @@ type Condition interface {
 	WaitToFinish() error
 	Notify(err error)
 	Ctx() context.Context
+	SetOnWaitError(handler func())
 }
 
 // make sure interface implementation
@@ -36,16 +38,29 @@ var _ Condition = (*TaskCondition)(nil)
 type TaskCondition struct {
 	done chan error
 	ctx  context.Context
+
+	onWaitErrorMu sync.RWMutex
+	onWaitError   func()
 }
 
 // WaitToFinish waits until the TaskCondition is notified or context done or canceled
 func (tc *TaskCondition) WaitToFinish() error {
+	var err error
 	select {
 	case <-tc.ctx.Done():
-		return errors.Wrap(tc.ctx.Err(), "proxy TaskCondition context Done")
-	case err := <-tc.done:
-		return err
+		err = errors.Wrap(tc.ctx.Err(), "proxy TaskCondition context Done")
+	case err = <-tc.done:
 	}
+
+	if err != nil {
+		tc.onWaitErrorMu.RLock()
+		handler := tc.onWaitError
+		tc.onWaitErrorMu.RUnlock()
+		if handler != nil {
+			handler()
+		}
+	}
+	return err
 }
 
 // Notify sends a signal into the done channel
@@ -56,6 +71,13 @@ func (tc *TaskCondition) Notify(err error) {
 // Ctx returns internal context
 func (tc *TaskCondition) Ctx() context.Context {
 	return tc.ctx
+}
+
+// SetOnWaitError registers a handler invoked before WaitToFinish returns an error.
+func (tc *TaskCondition) SetOnWaitError(handler func()) {
+	tc.onWaitErrorMu.Lock()
+	defer tc.onWaitErrorMu.Unlock()
+	tc.onWaitError = handler
 }
 
 // NewTaskCondition creates a TaskCondition with provided context

--- a/internal/proxy/taskmodel/condition.go
+++ b/internal/proxy/taskmodel/condition.go
@@ -18,7 +18,6 @@ package taskmodel
 
 import (
 	"context"
-	"sync"
 
 	"github.com/cockroachdb/errors"
 )
@@ -39,19 +38,15 @@ type TaskCondition struct {
 	done chan error
 	ctx  context.Context
 
-	onContextDoneMu sync.RWMutex
-	onContextDone   func()
+	onContextDone func()
 }
 
 // WaitToFinish waits until the TaskCondition is notified or context done or canceled
 func (tc *TaskCondition) WaitToFinish() error {
 	select {
 	case <-tc.ctx.Done():
-		tc.onContextDoneMu.RLock()
-		handler := tc.onContextDone
-		tc.onContextDoneMu.RUnlock()
-		if handler != nil {
-			handler()
+		if tc.onContextDone != nil {
+			tc.onContextDone()
 		}
 		return errors.Wrap(tc.ctx.Err(), "proxy TaskCondition context Done")
 	case err := <-tc.done:
@@ -70,9 +65,8 @@ func (tc *TaskCondition) Ctx() context.Context {
 }
 
 // SetOnContextDone registers a handler invoked when WaitToFinish returns because its context is done.
+// Registration must complete before WaitToFinish begins, and the handler must not change after waiting starts.
 func (tc *TaskCondition) SetOnContextDone(handler func()) {
-	tc.onContextDoneMu.Lock()
-	defer tc.onContextDoneMu.Unlock()
 	tc.onContextDone = handler
 }
 

--- a/internal/proxy/taskmodel/condition.go
+++ b/internal/proxy/taskmodel/condition.go
@@ -28,7 +28,7 @@ type Condition interface {
 	WaitToFinish() error
 	Notify(err error)
 	Ctx() context.Context
-	SetOnWaitError(handler func())
+	SetOnContextDone(handler func())
 }
 
 // make sure interface implementation
@@ -39,17 +39,17 @@ type TaskCondition struct {
 	done chan error
 	ctx  context.Context
 
-	onWaitErrorMu sync.RWMutex
-	onWaitError   func()
+	onContextDoneMu sync.RWMutex
+	onContextDone   func()
 }
 
 // WaitToFinish waits until the TaskCondition is notified or context done or canceled
 func (tc *TaskCondition) WaitToFinish() error {
 	select {
 	case <-tc.ctx.Done():
-		tc.onWaitErrorMu.RLock()
-		handler := tc.onWaitError
-		tc.onWaitErrorMu.RUnlock()
+		tc.onContextDoneMu.RLock()
+		handler := tc.onContextDone
+		tc.onContextDoneMu.RUnlock()
 		if handler != nil {
 			handler()
 		}
@@ -69,11 +69,11 @@ func (tc *TaskCondition) Ctx() context.Context {
 	return tc.ctx
 }
 
-// SetOnWaitError registers a handler invoked when WaitToFinish returns because its context is done.
-func (tc *TaskCondition) SetOnWaitError(handler func()) {
-	tc.onWaitErrorMu.Lock()
-	defer tc.onWaitErrorMu.Unlock()
-	tc.onWaitError = handler
+// SetOnContextDone registers a handler invoked when WaitToFinish returns because its context is done.
+func (tc *TaskCondition) SetOnContextDone(handler func()) {
+	tc.onContextDoneMu.Lock()
+	defer tc.onContextDoneMu.Unlock()
+	tc.onContextDone = handler
 }
 
 // NewTaskCondition creates a TaskCondition with provided context

--- a/internal/proxy/taskmodel/condition_test.go
+++ b/internal/proxy/taskmodel/condition_test.go
@@ -1,0 +1,65 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskmodel
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTaskCondition_OnWaitError(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		condition := NewTaskCondition(context.Background())
+		var calls atomic.Int32
+		condition.SetOnWaitError(func() {
+			calls.Add(1)
+		})
+
+		condition.Notify(nil)
+		assert.NoError(t, condition.WaitToFinish())
+		assert.Zero(t, calls.Load())
+	})
+
+	t.Run("task error", func(t *testing.T) {
+		condition := NewTaskCondition(context.Background())
+		var calls atomic.Int32
+		condition.SetOnWaitError(func() {
+			calls.Add(1)
+		})
+
+		condition.Notify(errors.New("task failed"))
+		assert.Error(t, condition.WaitToFinish())
+		assert.Equal(t, int32(1), calls.Load())
+	})
+
+	t.Run("context canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		condition := NewTaskCondition(ctx)
+		var calls atomic.Int32
+		condition.SetOnWaitError(func() {
+			calls.Add(1)
+		})
+
+		cancel()
+		assert.Error(t, condition.WaitToFinish())
+		assert.Equal(t, int32(1), calls.Load())
+	})
+}

--- a/internal/proxy/taskmodel/condition_test.go
+++ b/internal/proxy/taskmodel/condition_test.go
@@ -25,11 +25,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTaskCondition_OnWaitError(t *testing.T) {
+func TestTaskCondition_OnContextDone(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		condition := NewTaskCondition(context.Background())
 		var calls atomic.Int32
-		condition.SetOnWaitError(func() {
+		condition.SetOnContextDone(func() {
 			calls.Add(1)
 		})
 
@@ -41,7 +41,7 @@ func TestTaskCondition_OnWaitError(t *testing.T) {
 	t.Run("task error", func(t *testing.T) {
 		condition := NewTaskCondition(context.Background())
 		var calls atomic.Int32
-		condition.SetOnWaitError(func() {
+		condition.SetOnContextDone(func() {
 			calls.Add(1)
 		})
 
@@ -54,7 +54,7 @@ func TestTaskCondition_OnWaitError(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		condition := NewTaskCondition(ctx)
 		var calls atomic.Int32
-		condition.SetOnWaitError(func() {
+		condition.SetOnContextDone(func() {
 			calls.Add(1)
 		})
 

--- a/internal/proxy/taskmodel/condition_test.go
+++ b/internal/proxy/taskmodel/condition_test.go
@@ -47,7 +47,7 @@ func TestTaskCondition_OnWaitError(t *testing.T) {
 
 		condition.Notify(errors.New("task failed"))
 		assert.Error(t, condition.WaitToFinish())
-		assert.Equal(t, int32(1), calls.Load())
+		assert.Zero(t, calls.Load())
 	})
 
 	t.Run("context canceled", func(t *testing.T) {

--- a/internal/proxy/taskmodel/task.go
+++ b/internal/proxy/taskmodel/task.go
@@ -47,6 +47,7 @@ type Task interface {
 	PostExecute(ctx context.Context) error
 	WaitToFinish() error
 	Notify(err error)
+	SetOnWaitError(handler func())
 	CanSkipAllocTimestamp() bool
 	GetMetaCache() metacache.Cache
 	SetOnEnqueueTime()

--- a/internal/proxy/taskmodel/task.go
+++ b/internal/proxy/taskmodel/task.go
@@ -47,7 +47,7 @@ type Task interface {
 	PostExecute(ctx context.Context) error
 	WaitToFinish() error
 	Notify(err error)
-	SetOnWaitError(handler func())
+	SetOnContextDone(handler func())
 	CanSkipAllocTimestamp() bool
 	GetMetaCache() metacache.Cache
 	SetOnEnqueueTime()


### PR DESCRIPTION
Remove canceled DQL tasks from the Proxy unissued queue when the request context ends, and skip canceled or expired tasks before worker execution. The cleanup hook is registered before waiting and remains immutable afterward, so it does not require per-task synchronization.

Validation: scheduler/taskmodel suites passed with `-race -count=3`, including blocked-worker cancellation/deadline/live cases for both pools; scoped lint passed. `run_clang_format.sh` passed. Full `make lint-fix` was run but is blocked locally by incompatible native storage headers (`LoonFilesystemMetricsList`); hosted CI remains required.

issue: #52936

pr: #52939
