### PR TITLE
enhance: name field and type in arith type-mismatch errors

### DIFF
--- a/internal/parser/planparserv2/fill_expression_value.go
+++ b/internal/parser/planparserv2/fill_expression_value.go
@@ -270,8 +270,11 @@ func FillBinaryArithOpEvalRangeExpressionValue(expr *planpb.BinaryArithOpEvalRan
 			lDataType = expr.GetColumnInfo().GetElementType()
 		}
 
+		// No SchemaHelper is available at template-fill time (only field IDs, not
+		// names, survive into the plan by this point), so the field name is
+		// omitted here; checkValidModArith falls back to a type-only message.
 		if err = checkValidModArith(expr.GetArithOp(), expr.GetColumnInfo().GetDataType(), expr.GetColumnInfo().GetElementType(),
-			rDataType, schemapb.DataType_None); err != nil {
+			rDataType, schemapb.DataType_None, "", ""); err != nil {
 			return err
 		}
 

--- a/internal/parser/planparserv2/parser_visitor.go
+++ b/internal/parser/planparserv2/parser_visitor.go
@@ -482,7 +482,8 @@ func (v *ParserVisitor) VisitMulDivMod(ctx *parser.MulDivModContext) interface{}
 			return merr.WrapErrParameterInvalidMsg("'%s' %s", arithNameMap[ctx.GetOp().GetTokenType()], err.Error())
 		}
 
-		if err = checkValidModArith(arithExprMap[ctx.GetOp().GetTokenType()], leftExpr.dataType, getArrayElementType(leftExpr), rightExpr.dataType, getArrayElementType(rightExpr)); err != nil {
+		if err = checkValidModArith(arithExprMap[ctx.GetOp().GetTokenType()], leftExpr.dataType, getArrayElementType(leftExpr), rightExpr.dataType, getArrayElementType(rightExpr),
+			columnDisplayName(v.schema, leftExpr), columnDisplayName(v.schema, rightExpr)); err != nil {
 			return err
 		}
 
@@ -1746,7 +1747,8 @@ func (v *ParserVisitor) VisitUnary(ctx *parser.UnaryContext) interface{} {
 		if err := canArithmetic(childExpr.dataType, getArrayElementType(childExpr), minusOne.dataType, getArrayElementType(minusOne), false); err != nil {
 			return merr.WrapErrParameterInvalidMsg("'bitnot' %s", err.Error())
 		}
-		if err := checkValidModArith(planpb.ArithOpType_BitXor, childExpr.dataType, getArrayElementType(childExpr), minusOne.dataType, getArrayElementType(minusOne)); err != nil {
+		if err := checkValidModArith(planpb.ArithOpType_BitXor, childExpr.dataType, getArrayElementType(childExpr), minusOne.dataType, getArrayElementType(minusOne),
+			columnDisplayName(v.schema, childExpr), ""); err != nil {
 			return err
 		}
 		dataType, err := calcDataType(childExpr, minusOne, false)
@@ -2026,7 +2028,8 @@ func (v *ParserVisitor) visitBitwiseBinaryOp(leftCtx, rightCtx parser.IExprConte
 		if err = canArithmetic(leftExpr.dataType, getArrayElementType(leftExpr), rightExpr.dataType, getArrayElementType(rightExpr), reverse); err != nil {
 			return merr.WrapErrParameterInvalidMsg("'%s' %s", arithNameMap[tokenType], err.Error())
 		}
-		if err = checkValidModArith(arithExprMap[tokenType], leftExpr.dataType, getArrayElementType(leftExpr), rightExpr.dataType, getArrayElementType(rightExpr)); err != nil {
+		if err = checkValidModArith(arithExprMap[tokenType], leftExpr.dataType, getArrayElementType(leftExpr), rightExpr.dataType, getArrayElementType(rightExpr),
+			columnDisplayName(v.schema, leftExpr), columnDisplayName(v.schema, rightExpr)); err != nil {
 			return err
 		}
 		dataType, err = calcDataType(leftExpr, rightExpr, reverse)

--- a/internal/parser/planparserv2/plan_parser_v2_test.go
+++ b/internal/parser/planparserv2/plan_parser_v2_test.go
@@ -1758,6 +1758,33 @@ func TestExpr_BinaryArith(t *testing.T) {
 	}
 }
 
+// TestExpr_ArithTypeMismatchNamesField asserts that modulo/bitwise type
+// mismatch errors name the offending field and its actual data type, instead
+// of a generic message the caller has to guess the field from.
+func TestExpr_ArithTypeMismatchNamesField(t *testing.T) {
+	schema := newTestSchema(true)
+	helper, err := typeutil.CreateSchemaHelper(schema)
+	assert.NoError(t, err)
+
+	cases := []struct {
+		exprStr    string
+		wantSubstr string
+	}{
+		{`FloatField % 10 == 1`, "field 'FloatField' is Float"},
+		{`(FloatField & 1) == 1`, "field 'FloatField' is Float"},
+		{`(DoubleField | 2) == 3`, "field 'DoubleField' is Double"},
+		{`(FloatField ^ 4) == 0`, "field 'FloatField' is Float"},
+		{`(FloatField << 1) == 0`, "field 'FloatField' is Float"},
+		{`(DoubleField >> 1) == 0`, "field 'DoubleField' is Double"},
+		{`~FloatField == 0`, "field 'FloatField' is Float"},
+	}
+	for _, c := range cases {
+		_, err := ParseExpr(helper, c.exprStr, nil)
+		require.Error(t, err, c.exprStr)
+		assert.Contains(t, err.Error(), c.wantSubstr, c.exprStr)
+	}
+}
+
 // TestExpr_BitwiseArith asserts the generated plan structure for bitwise
 // operators, not merely that the expression parses. A bitwise op over a field
 // must fuse into a BinaryArithOpEvalRangeExpr carrying the matching ArithOpType,

--- a/internal/parser/planparserv2/utils.go
+++ b/internal/parser/planparserv2/utils.go
@@ -744,20 +744,70 @@ func hexDigit(n uint32) byte {
 	return byte(n-10) + 'a'
 }
 
-func checkValidModArith(tokenType planpb.ArithOpType, leftType, leftElementType, rightType, rightElementType schemapb.DataType) error {
+// checkValidModArith validates that both operands of a modulo/bitwise operator
+// can convert to an integer type. leftName/rightName are the schema field name
+// backing each operand when it is a direct column reference, or "" when the
+// operand is a literal or a nested expression with no single backing field;
+// the error message includes the name when known.
+func checkValidModArith(tokenType planpb.ArithOpType, leftType, leftElementType, rightType, rightElementType schemapb.DataType, leftName, rightName string) error {
 	switch tokenType {
 	case planpb.ArithOpType_Mod:
-		if !canConvertToIntegerType(leftType, leftElementType) || !canConvertToIntegerType(rightType, rightElementType) {
-			return merr.WrapErrQueryPlanMsg("modulo can only apply on integer types")
+		if !canConvertToIntegerType(leftType, leftElementType) {
+			return newArithTypeMismatchErr("modulo", leftName, leftType, leftElementType)
+		}
+		if !canConvertToIntegerType(rightType, rightElementType) {
+			return newArithTypeMismatchErr("modulo", rightName, rightType, rightElementType)
 		}
 	case planpb.ArithOpType_BitAnd, planpb.ArithOpType_BitOr, planpb.ArithOpType_BitXor,
 		planpb.ArithOpType_Shl, planpb.ArithOpType_Shr:
-		if !canConvertToIntegerType(leftType, leftElementType) || !canConvertToIntegerType(rightType, rightElementType) {
-			return merr.WrapErrQueryPlanMsg("bitwise operations can only apply on integer types")
+		if !canConvertToIntegerType(leftType, leftElementType) {
+			return newArithTypeMismatchErr("bitwise operations", leftName, leftType, leftElementType)
+		}
+		if !canConvertToIntegerType(rightType, rightElementType) {
+			return newArithTypeMismatchErr("bitwise operations", rightName, rightType, rightElementType)
 		}
 	default:
 	}
 	return nil
+}
+
+// newArithTypeMismatchErr reports the offending operand of an integer-only
+// arithmetic operator. When name is known it names the field so the caller
+// does not have to guess which side of the expression is wrong.
+func newArithTypeMismatchErr(opDesc, name string, dataType, elementType schemapb.DataType) error {
+	typeName := formatDataTypeWithElement(dataType, elementType)
+	if name == "" {
+		return merr.WrapErrQueryPlanMsg("%s can only apply on integer types, got %s", opDesc, typeName)
+	}
+	return merr.WrapErrQueryPlanMsg("%s can only apply on integer types, but field '%s' is %s", opDesc, name, typeName)
+}
+
+// formatDataTypeWithElement renders an array type as "Array[ElementType]",
+// matching getDataType's display for ExprWithType, so an array-typed field in
+// an error message reads the same way whether it started as one or not.
+func formatDataTypeWithElement(dataType, elementType schemapb.DataType) string {
+	if typeutil.IsArrayType(dataType) {
+		return fmt.Sprintf("%s[%s]", dataType, elementType)
+	}
+	return dataType.String()
+}
+
+// columnDisplayName returns the schema field name backing expr, or "" when
+// expr is not a direct column reference (a literal, or a nested expression
+// with no single backing field) or schema is unavailable.
+func columnDisplayName(schema *typeutil.SchemaHelper, expr *ExprWithType) string {
+	if schema == nil || expr == nil {
+		return ""
+	}
+	info := toColumnInfo(expr)
+	if info == nil {
+		return ""
+	}
+	field, err := schema.GetFieldFromID(info.GetFieldId())
+	if err != nil {
+		return ""
+	}
+	return field.GetName()
 }
 
 func castRangeValue(dataType schemapb.DataType, value *planpb.GenericValue) (*planpb.GenericValue, error) {

--- a/internal/parser/planparserv2/utils_test.go
+++ b/internal/parser/planparserv2/utils_test.go
@@ -1197,14 +1197,14 @@ func Test_checkValidModArith(t *testing.T) {
 	t.Run("mod with integers is valid", func(t *testing.T) {
 		err := checkValidModArith(planpb.ArithOpType_Mod,
 			schemapb.DataType_Int64, schemapb.DataType_None,
-			schemapb.DataType_Int64, schemapb.DataType_None)
+			schemapb.DataType_Int64, schemapb.DataType_None, "", "")
 		assert.NoError(t, err)
 	})
 
 	t.Run("mod with float left is invalid", func(t *testing.T) {
 		err := checkValidModArith(planpb.ArithOpType_Mod,
 			schemapb.DataType_Float, schemapb.DataType_None,
-			schemapb.DataType_Int64, schemapb.DataType_None)
+			schemapb.DataType_Int64, schemapb.DataType_None, "", "")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "modulo can only apply on integer types")
 	})
@@ -1212,7 +1212,7 @@ func Test_checkValidModArith(t *testing.T) {
 	t.Run("mod with float right is invalid", func(t *testing.T) {
 		err := checkValidModArith(planpb.ArithOpType_Mod,
 			schemapb.DataType_Int64, schemapb.DataType_None,
-			schemapb.DataType_Float, schemapb.DataType_None)
+			schemapb.DataType_Float, schemapb.DataType_None, "", "")
 		assert.Error(t, err)
 	})
 
@@ -1220,8 +1220,34 @@ func Test_checkValidModArith(t *testing.T) {
 		// Non-mod operations should not be validated by this function
 		err := checkValidModArith(planpb.ArithOpType_Add,
 			schemapb.DataType_Float, schemapb.DataType_None,
-			schemapb.DataType_Float, schemapb.DataType_None)
+			schemapb.DataType_Float, schemapb.DataType_None, "", "")
 		assert.NoError(t, err)
+	})
+
+	t.Run("mod with named float left names the field and its type", func(t *testing.T) {
+		err := checkValidModArith(planpb.ArithOpType_Mod,
+			schemapb.DataType_Double, schemapb.DataType_None,
+			schemapb.DataType_Int64, schemapb.DataType_None, "price", "qty")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "modulo can only apply on integer types")
+		assert.Contains(t, err.Error(), "field 'price' is Double")
+	})
+
+	t.Run("mod with named float right names the field and its type", func(t *testing.T) {
+		err := checkValidModArith(planpb.ArithOpType_Mod,
+			schemapb.DataType_Int64, schemapb.DataType_None,
+			schemapb.DataType_Double, schemapb.DataType_None, "qty", "price")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "field 'price' is Double")
+		assert.NotContains(t, err.Error(), "'qty'")
+	})
+
+	t.Run("mod with named integer array element field reports element type", func(t *testing.T) {
+		err := checkValidModArith(planpb.ArithOpType_Mod,
+			schemapb.DataType_Array, schemapb.DataType_Double,
+			schemapb.DataType_Int64, schemapb.DataType_None, "prices", "qty")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "field 'prices' is Array[Double]")
 	})
 }
 
@@ -1240,21 +1266,21 @@ func Test_checkValidBitwiseArith(t *testing.T) {
 		t.Run(op.String()+" with integers is valid", func(t *testing.T) {
 			err := checkValidModArith(op,
 				schemapb.DataType_Int64, schemapb.DataType_None,
-				schemapb.DataType_Int64, schemapb.DataType_None)
+				schemapb.DataType_Int64, schemapb.DataType_None, "", "")
 			assert.NoError(t, err)
 		})
 
 		t.Run(op.String()+" with integer array element is valid", func(t *testing.T) {
 			err := checkValidModArith(op,
 				schemapb.DataType_Array, schemapb.DataType_Int32,
-				schemapb.DataType_Int64, schemapb.DataType_None)
+				schemapb.DataType_Int64, schemapb.DataType_None, "", "")
 			assert.NoError(t, err)
 		})
 
 		t.Run(op.String()+" with float left is invalid", func(t *testing.T) {
 			err := checkValidModArith(op,
 				schemapb.DataType_Float, schemapb.DataType_None,
-				schemapb.DataType_Int64, schemapb.DataType_None)
+				schemapb.DataType_Int64, schemapb.DataType_None, "", "")
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "bitwise operations can only apply on integer types")
 		})
@@ -1262,11 +1288,52 @@ func Test_checkValidBitwiseArith(t *testing.T) {
 		t.Run(op.String()+" with double right is invalid", func(t *testing.T) {
 			err := checkValidModArith(op,
 				schemapb.DataType_Int64, schemapb.DataType_None,
-				schemapb.DataType_Double, schemapb.DataType_None)
+				schemapb.DataType_Double, schemapb.DataType_None, "", "")
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "bitwise operations can only apply on integer types")
 		})
+
+		t.Run(op.String()+" with named float left names the field and its type", func(t *testing.T) {
+			err := checkValidModArith(op,
+				schemapb.DataType_Double, schemapb.DataType_None,
+				schemapb.DataType_Int64, schemapb.DataType_None, "price", "mask")
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "bitwise operations can only apply on integer types")
+			assert.Contains(t, err.Error(), "field 'price' is Double")
+		})
 	}
+}
+
+// Test_columnDisplayName covers columnDisplayName's fallback-to-"" cases
+// individually, since checkValidModArith call sites only exercise the two
+// most common ones (a real column, and a literal with no ColumnInfo).
+func Test_columnDisplayName(t *testing.T) {
+	schema := newTestSchemaHelper(t)
+	int64FieldID := int64(generatedFieldIDBase) + int64(schemapb.DataType_Int64)
+
+	t.Run("nil schema returns empty", func(t *testing.T) {
+		expr := toColumnExpr(&planpb.ColumnInfo{FieldId: int64FieldID, DataType: schemapb.DataType_Int64})
+		assert.Equal(t, "", columnDisplayName(nil, expr))
+	})
+
+	t.Run("nil expr returns empty", func(t *testing.T) {
+		assert.Equal(t, "", columnDisplayName(schema, nil))
+	})
+
+	t.Run("literal value expr has no backing column", func(t *testing.T) {
+		expr := toValueExpr(NewInt(1))
+		assert.Equal(t, "", columnDisplayName(schema, expr))
+	})
+
+	t.Run("unknown field id returns empty", func(t *testing.T) {
+		expr := toColumnExpr(&planpb.ColumnInfo{FieldId: -1, DataType: schemapb.DataType_Int64})
+		assert.Equal(t, "", columnDisplayName(schema, expr))
+	})
+
+	t.Run("known field id resolves its schema name", func(t *testing.T) {
+		expr := toColumnExpr(&planpb.ColumnInfo{FieldId: int64FieldID, DataType: schemapb.DataType_Int64})
+		assert.Equal(t, "Int64Field", columnDisplayName(schema, expr))
+	})
 }
 
 // Test_castRangeValue tests value casting for range operations


### PR DESCRIPTION
## Summary
- Filter expressions using modulo (`%`) or a bitwise operator (`&`, `|`, `^`, `<<`, `>>`, unary `~`) on a non-integer field only reported a generic "modulo can only apply on integer types" / "bitwise operations can only apply on integer types" message, without saying which field or type caused it.
- `checkValidModArith` now resolves the offending operand's schema field name (via `ParserVisitor.schema`) and includes it plus the actual data type in the error, e.g. `bitwise operations can only apply on integer types, but field 'price' is Double`.
- When the operand has no single backing field (a literal, or template-value filling in `fill_expression_value.go` where no `SchemaHelper` is available), the message falls back to the previous generic wording (now with the type appended) — no behavior change on that path.
- Array-typed fields render as `Array[ElementType]` (e.g. `Array[Double]`), matching the existing display convention used elsewhere in this package.

issue: #50965

## Test plan
- [x] `internal/parser/planparserv2/utils_test.go`: extended `Test_checkValidModArith` / `Test_checkValidBitwiseArith` with cases asserting the field name + type appear in the message, including an array-element case; added `Test_columnDisplayName` covering the nil-schema, nil-expr, literal, and unknown-field-id fallback paths.
- [x] `internal/parser/planparserv2/plan_parser_v2_test.go`: new `TestExpr_ArithTypeMismatchNamesField` parses real expressions end-to-end (`FloatField % 10 == 1`, `(DoubleField | 2) == 3`, `~FloatField == 0`, etc.) and asserts the field name appears in the returned error.
- [x] Full `go test ./internal/parser/planparserv2/...` passes; all newly added functions (`checkValidModArith`, `newArithTypeMismatchErr`, `formatDataTypeWithElement`, `columnDisplayName`) are at 100% statement coverage.
- [x] `golangci-lint run --config .golangci.yml ./internal/parser/planparserv2/...` reports 0 issues.
- [x] `go build ./internal/...` succeeds; `gofmt` clean.

Made with [Cursor](https://cursor.com)