### PR TITLE
fix: [3.0] MinHash validation on all DDL paths and external-collection function validation

### DIFF
--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -3463,6 +3463,31 @@ func TestValidateFunctionInputField(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("Valid MinHash function input - varchar", func(t *testing.T) {
+		function := &schemapb.FunctionSchema{
+			Type: schemapb.FunctionType_MinHash,
+		}
+		fields := []*schemapb.FieldSchema{
+			{DataType: schemapb.DataType_VarChar},
+		}
+		err := validator.CheckFunctionInputField(function, fields)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Invalid MinHash function input - TEXT rejected", func(t *testing.T) {
+		// align with ValidateMinHashFunction's VarChar-only input contract:
+		// admitting TEXT here let the direct RootCoord path (which skipped that
+		// check) create schemas the runner-side validator rejects
+		function := &schemapb.FunctionSchema{
+			Type: schemapb.FunctionType_MinHash,
+		}
+		fields := []*schemapb.FieldSchema{
+			{DataType: schemapb.DataType_Text},
+		}
+		err := validator.CheckFunctionInputField(function, fields)
+		assert.Error(t, err)
+	})
+
 	t.Run("Invalid BM25 function input - multiple fields", func(t *testing.T) {
 		function := &schemapb.FunctionSchema{
 			Type: schemapb.FunctionType_BM25,

--- a/internal/rootcoord/create_collection_task.go
+++ b/internal/rootcoord/create_collection_task.go
@@ -29,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer"
+	"github.com/milvus-io/milvus/internal/util/function/validator"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -555,6 +556,13 @@ func (t *createCollectionTask) prepareMilvusTableSnapshotSchema(ctx context.Cont
 	if err := assignFunctionIDsFromFieldNames(schema); err != nil {
 		return merr.Wrap(err, "align milvus-table function field IDs")
 	}
+	// Newly aligned milvus-table schemas set preserveFieldID below and would
+	// bypass the direct-path ValidateFunction in prepareSchema, so run the
+	// non-runtime function validation here; DDL replay never reaches this
+	// point (it returns early above) and keeps its historical schema unjudged.
+	if err := validator.ValidateFunction(schema, "", true); err != nil {
+		return err
+	}
 	t.preserveFieldID = true
 	t.Req.Properties = upsertCreateCollectionProperty(t.Req.GetProperties(), util.PreserveFieldIdsKey, "true")
 
@@ -702,6 +710,18 @@ func (t *createCollectionTask) prepareSchema(ctx context.Context) error {
 		}
 	} else {
 		if err := t.assignFieldAndFunctionID(t.body.CollectionSchema); err != nil {
+			return err
+		}
+		// Function schema validation for requests entering RootCoord directly —
+		// the proxy validates before forwarding, but nothing else on this path
+		// does. Runs only for newly created schemas: preserveFieldID restores an
+		// existing collection (snapshot/replication), whose historical schema
+		// must not be re-judged by current-version rules. External collections
+		// are validated too — the one resolution-sensitive rule (nullable
+		// input) exempts externally-mapped fields at the rule level, so the
+		// structural checks (e.g. the MinHash dim/num_hashes relation) stay
+		// authoritative on this path for the RESOLVED schema as well.
+		if err := validator.ValidateFunction(t.body.CollectionSchema, "", true); err != nil {
 			return err
 		}
 	}

--- a/internal/rootcoord/create_collection_task_test.go
+++ b/internal/rootcoord/create_collection_task_test.go
@@ -1753,6 +1753,10 @@ func TestPrepareMilvusTableSnapshotSchemaAlignsTargetFunctionOutputs(t *testing.
 				Schema: &schemapb.CollectionSchema{
 					Fields: []*schemapb.FieldSchema{
 						{FieldID: 101, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+						{FieldID: 103, Name: "text", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{
+							{Key: common.MaxLengthKey, Value: "128"},
+							{Key: common.EnableAnalyzerKey, Value: "true"},
+						}},
 						{
 							FieldID:  105,
 							Name:     "vec",
@@ -1767,12 +1771,19 @@ func TestPrepareMilvusTableSnapshotSchemaAlignsTargetFunctionOutputs(t *testing.
 		}, nil).Build()
 	defer mockReadMetadata.UnPatch()
 
+	// The target function must also satisfy the non-runtime function
+	// validation that now runs on newly aligned milvus-table schemas: a
+	// typed BM25 over a VarChar input, no params.
 	schema := &schemapb.CollectionSchema{
 		Name:           "target",
 		ExternalSource: "minio://localhost:9000/bucket/snapshots/100/metadata/200.json",
 		ExternalSpec:   `{"format":"milvus-table","extfs":{"access_key_id":"AK","access_key_value":"SK"}}`,
 		Fields: []*schemapb.FieldSchema{
 			{FieldID: 0, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, ExternalField: "pk"},
+			{FieldID: 0, Name: "doc", DataType: schemapb.DataType_VarChar, ExternalField: "text", TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.MaxLengthKey, Value: "128"},
+				{Key: common.EnableAnalyzerKey, Value: "true"},
+			}},
 			{
 				FieldID:       0,
 				Name:          "embedding",
@@ -1787,7 +1798,8 @@ func TestPrepareMilvusTableSnapshotSchemaAlignsTargetFunctionOutputs(t *testing.
 		Functions: []*schemapb.FunctionSchema{
 			{
 				Name:             "bm25",
-				InputFieldNames:  []string{"id"},
+				Type:             schemapb.FunctionType_BM25,
+				InputFieldNames:  []string{"doc"},
 				OutputFieldNames: []string{"sparse"},
 			},
 		},
@@ -1809,12 +1821,74 @@ func TestPrepareMilvusTableSnapshotSchemaAlignsTargetFunctionOutputs(t *testing.
 
 	assert.True(t, task.preserveFieldID)
 	assert.Equal(t, int64(101), schema.GetFields()[0].GetFieldID())
-	assert.Equal(t, int64(105), schema.GetFields()[1].GetFieldID())
-	assert.Equal(t, int64(106), schema.GetFields()[2].GetFieldID())
+	assert.Equal(t, int64(103), schema.GetFields()[1].GetFieldID())
+	assert.Equal(t, int64(105), schema.GetFields()[2].GetFieldID())
+	assert.Equal(t, int64(106), schema.GetFields()[3].GetFieldID())
 	require.Len(t, schema.GetFunctions(), 1)
 	assert.Equal(t, int64(StartOfUserFunctionID), schema.GetFunctions()[0].GetId())
-	assert.Equal(t, []int64{101}, schema.GetFunctions()[0].GetInputFieldIds())
+	assert.Equal(t, []int64{103}, schema.GetFunctions()[0].GetInputFieldIds())
 	assert.Equal(t, []int64{106}, schema.GetFunctions()[0].GetOutputFieldIds())
+}
+
+// The newly aligned milvus-table schema is a NEW schema that merely reuses
+// source field IDs, so it must pass the same non-runtime function validation
+// as any direct-path create; before this call a structurally impossible
+// function persisted through the milvus-table path (preserveFieldID bypassed
+// the prepareSchema validation).
+func TestPrepareMilvusTableSnapshotSchemaRejectsInvalidFunction(t *testing.T) {
+	mockReadMetadata := mockey.Mock(packed.ReadMilvusTableSnapshotMetadata).
+		Return(&datapb.SnapshotMetadata{
+			Collection: &datapb.CollectionDescription{
+				Schema: &schemapb.CollectionSchema{
+					Fields: []*schemapb.FieldSchema{
+						{FieldID: 101, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+						{FieldID: 103, Name: "text", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{
+							{Key: common.MaxLengthKey, Value: "128"},
+						}},
+					},
+				},
+			},
+		}, nil).Build()
+	defer mockReadMetadata.UnPatch()
+
+	// (2^59+1)*32 wraps around int64 to 32; the division-based check must
+	// reject it on the milvus-table path too.
+	schema := &schemapb.CollectionSchema{
+		Name:           "target",
+		ExternalSource: "minio://localhost:9000/bucket/snapshots/100/metadata/200.json",
+		ExternalSpec:   `{"format":"milvus-table","extfs":{"access_key_id":"AK","access_key_value":"SK"}}`,
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 0, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, ExternalField: "pk"},
+			{FieldID: 0, Name: "doc", DataType: schemapb.DataType_VarChar, ExternalField: "text", TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.MaxLengthKey, Value: "128"},
+			}},
+			{FieldID: 0, Name: "hash", DataType: schemapb.DataType_BinaryVector, IsFunctionOutput: true, TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.DimKey, Value: "32"},
+			}},
+		},
+		Functions: []*schemapb.FunctionSchema{
+			{
+				Name: "minhash", Type: schemapb.FunctionType_MinHash,
+				InputFieldNames: []string{"doc"}, OutputFieldNames: []string{"hash"},
+				Params: []*commonpb.KeyValuePair{{Key: "num_hashes", Value: "576460752303423489"}},
+			},
+		},
+	}
+	task := &createCollectionTask{
+		Req: &milvuspb.CreateCollectionRequest{
+			CollectionName: "target",
+			Properties: []*commonpb.KeyValuePair{
+				{Key: util.PreserveFieldIdsKey, Value: "false"},
+			},
+		},
+		body: &message.CreateCollectionRequest{
+			CollectionSchema: schema,
+		},
+	}
+
+	err := task.prepareMilvusTableSnapshotSchema(context.Background())
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	assert.ErrorContains(t, err, "does not match expected dim")
 }
 
 func TestPrepareMilvusTableSnapshotSchemaMapsSourceFunctionOutputAsDataField(t *testing.T) {
@@ -3005,4 +3079,125 @@ func Test_appendConsistecyLevel(t *testing.T) {
 	consistencyLevel, properties := mustConsumeConsistencyLevel(task.Req.Properties)
 	assert.Equal(t, commonpb.ConsistencyLevel_Session, consistencyLevel)
 	assert.Len(t, properties, 0)
+}
+
+// The direct RootCoord path never went through validator.ValidateFunction:
+// prepareSchema only validated fields and assigned IDs, so a client hitting
+// RootCoord directly could persist a MinHash schema the proxy path rejects.
+// prepareSchema is the real create path — these cases must fail there, not
+// only in the validator helper.
+func Test_createCollectionTask_prepareSchema_validatesFunctions(t *testing.T) {
+	buildTask := func(numHashes string) createCollectionTask {
+		collectionName := funcutil.GenRandomStr()
+		schema := &schemapb.CollectionSchema{
+			Name: collectionName,
+			Fields: []*schemapb.FieldSchema{
+				{Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{Name: "text", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "128"},
+				}},
+				{Name: "hash", DataType: schemapb.DataType_BinaryVector, IsFunctionOutput: true, TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "32"},
+				}},
+			},
+			Functions: []*schemapb.FunctionSchema{{
+				Name: "minhash", Type: schemapb.FunctionType_MinHash,
+				InputFieldNames: []string{"text"}, OutputFieldNames: []string{"hash"},
+				Params: []*commonpb.KeyValuePair{{Key: "num_hashes", Value: numHashes}},
+			}},
+		}
+		return createCollectionTask{
+			Req: &milvuspb.CreateCollectionRequest{
+				Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
+				CollectionName: collectionName,
+			},
+			body: &message.CreateCollectionRequest{
+				CollectionSchema: schema,
+			},
+		}
+	}
+
+	t.Run("overflowing num_hashes rejected", func(t *testing.T) {
+		// (2^59+1)*32 wraps around int64 to 32; a multiply-based check passes
+		// and the runner then attempts an impossibly large permutation alloc.
+		task := buildTask("576460752303423489")
+		err := task.prepareSchema(context.TODO())
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.ErrorContains(t, err, "does not match expected dim")
+	})
+
+	t.Run("valid minhash accepted", func(t *testing.T) {
+		task := buildTask("1")
+		err := task.prepareSchema(context.TODO())
+		assert.NoError(t, err)
+	})
+}
+
+// External collections go through the direct-path function validation like any
+// other schema; only the one resolution-sensitive rule (nullable input) exempts
+// externally-mapped fields at the rule level, because their nullability is
+// inferred from the external source (a nullable TextEmbedding input resolved
+// from parquet, as the go-sdk e2e creates) rather than declared by the user.
+// Structural checks — e.g. the MinHash dim/num_hashes relation — stay
+// authoritative for external schemas too.
+func Test_createCollectionTask_prepareSchema_validatesExternalFunctions(t *testing.T) {
+	buildTask := func(schema *schemapb.CollectionSchema) createCollectionTask {
+		return createCollectionTask{
+			Req: &milvuspb.CreateCollectionRequest{
+				Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
+				CollectionName: schema.GetName(),
+			},
+			body: &message.CreateCollectionRequest{
+				CollectionSchema: schema,
+			},
+		}
+	}
+
+	t.Run("nullable externally-mapped input accepted", func(t *testing.T) {
+		task := buildTask(&schemapb.CollectionSchema{
+			Name: funcutil.GenRandomStr(),
+			Fields: []*schemapb.FieldSchema{
+				{Name: "pk", DataType: schemapb.DataType_Int64, ExternalField: "pk"},
+				{Name: "doc", DataType: schemapb.DataType_VarChar, Nullable: true, ExternalField: "doc", TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "1024"},
+				}},
+				{Name: "dense", DataType: schemapb.DataType_FloatVector, IsFunctionOutput: true, TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "8"},
+				}},
+			},
+			Functions: []*schemapb.FunctionSchema{{
+				Name: "tei_fn", Type: schemapb.FunctionType_TextEmbedding,
+				InputFieldNames: []string{"doc"}, OutputFieldNames: []string{"dense"},
+				Params: []*commonpb.KeyValuePair{{Key: "provider", Value: "TEI"}},
+			}},
+		})
+		err := task.prepareSchema(context.TODO())
+		assert.NoError(t, err)
+	})
+
+	t.Run("overflowing minhash num_hashes rejected on external too", func(t *testing.T) {
+		// (2^59+1)*32 wraps around int64 to 32; before the rule-level exemption
+		// the whole ValidateFunction call was skipped for external schemas, so
+		// this impossible MinHash persisted through the direct RootCoord path.
+		task := buildTask(&schemapb.CollectionSchema{
+			Name: funcutil.GenRandomStr(),
+			Fields: []*schemapb.FieldSchema{
+				{Name: "pk", DataType: schemapb.DataType_Int64, ExternalField: "pk"},
+				{Name: "text", DataType: schemapb.DataType_VarChar, ExternalField: "text", TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "128"},
+				}},
+				{Name: "hash", DataType: schemapb.DataType_BinaryVector, IsFunctionOutput: true, TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "32"},
+				}},
+			},
+			Functions: []*schemapb.FunctionSchema{{
+				Name: "minhash", Type: schemapb.FunctionType_MinHash,
+				InputFieldNames: []string{"text"}, OutputFieldNames: []string{"hash"},
+				Params: []*commonpb.KeyValuePair{{Key: "num_hashes", Value: "576460752303423489"}},
+			}},
+		})
+		err := task.prepareSchema(context.TODO())
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.ErrorContains(t, err, "does not match expected dim")
+	})
 }

--- a/internal/util/function/embedding/function_executor.go
+++ b/internal/util/function/embedding/function_executor.go
@@ -28,7 +28,6 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
-	"github.com/milvus-io/milvus/internal/util/function"
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
@@ -81,15 +80,10 @@ func validateFunction(schema *schemapb.CollectionSchema, fSchema *schemapb.Funct
 		return err
 	}
 
-	// BM25 or minhash function returns nil from createFunction
+	// BM25 and MinHash return nil from createFunction: neither needs a model
+	// runtime check. MinHash parameter validation is pure schema checking and
+	// runs unconditionally in validator.ValidateFunction instead.
 	if f == nil {
-		if fSchema.GetType() == schemapb.FunctionType_MinHash {
-			err := function.ValidateMinHashFunction(schema, fSchema)
-			if err != nil {
-				return err
-			}
-		}
-		// bm25 or minhash validate pass
 		return nil
 	}
 

--- a/internal/util/function/embedding/text_embedding_function.go
+++ b/internal/util/function/embedding/text_embedding_function.go
@@ -73,7 +73,12 @@ func TextEmbeddingInputsCheck(name string, fields []*schemapb.FieldSchema) error
 		return merr.WrapErrParameterInvalidMsg("TextEmbedding function input field must be a VARCHAR/TEXT field") //nolint:staticcheck // starts with proper noun
 	}
 
-	if fields[0].Nullable {
+	// An externally-mapped input's nullability is source-driven, not an
+	// opt-outable user contract: parquet-style externals are force-set nullable
+	// during normalization, and a milvus-table target must mirror the source
+	// snapshot's nullability to pass identity validation. Either way the
+	// user-schema rule must not judge it.
+	if fields[0].Nullable && fields[0].GetExternalField() == "" {
 		return merr.WrapErrParameterInvalidMsg("function input field cannot be nullable: function %s, field %s", name, fields[0].GetName())
 	}
 	return nil

--- a/internal/util/function/minhash_function.go
+++ b/internal/util/function/minhash_function.go
@@ -289,9 +289,10 @@ func ValidateMinHashFunction(collSchema *schemapb.CollectionSchema, funSchema *s
 	}
 
 	if numHashes > 0 {
-		expectedDim := int64(numHashes * 32) // binary vector, each hash is 4 bytes (32 bits), but stored as 8 bits in binary vector
-		if outputDim != expectedDim {
-			return merr.WrapErrParameterInvalidMsg("minhash function output field '%s' dim %d does not match expected dim %d (numHashes %d * one minhash signature size of 32bit)", outputFieldName, outputDim, expectedDim, numHashes)
+		// Compare via division: numHashes*32 can wrap around int64 and defeat
+		// the check. Each hash occupies 32 bits of the binary vector.
+		if outputDim%32 != 0 || outputDim/32 != int64(numHashes) {
+			return merr.WrapErrParameterInvalidMsg("minhash function output field '%s' dim %d does not match expected dim (numHashes %d * one minhash signature size of 32bit)", outputFieldName, outputDim, numHashes)
 		}
 	} else {
 		if outputDim%32 != 0 {

--- a/internal/util/function/minhash_function_test.go
+++ b/internal/util/function/minhash_function_test.go
@@ -1,0 +1,50 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package function
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+// num_hashes = 2^59+1: (2^59+1)*32 wraps around int64 to 32, so a
+// multiply-based dim check would accept it and pass the raw value to
+// initializePermutations' slice allocation on first use.
+func TestValidateMinHashFunctionRejectsNumHashesOverflowingDimCheck(t *testing.T) {
+	collSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{Name: "text", DataType: schemapb.DataType_VarChar},
+		{Name: "hash", DataType: schemapb.DataType_BinaryVector, TypeParams: []*commonpb.KeyValuePair{
+			{Key: "dim", Value: "32"},
+		}},
+	}}
+	funSchema := &schemapb.FunctionSchema{
+		Name: "minhash", Type: schemapb.FunctionType_MinHash,
+		InputFieldNames: []string{"text"}, OutputFieldNames: []string{"hash"},
+		Params: []*commonpb.KeyValuePair{{Key: NumHashesKey, Value: "576460752303423489"}},
+	}
+
+	err := ValidateMinHashFunction(collSchema, funSchema)
+	require.ErrorIs(t, err, merr.ErrParameterInvalid)
+	require.ErrorContains(t, err, "does not match expected dim")
+}

--- a/internal/util/function/validator/validator.go
+++ b/internal/util/function/validator/validator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/function"
 	"github.com/milvus-io/milvus/internal/util/function/embedding"
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
@@ -34,68 +35,63 @@ func ValidateFunction(coll *schemapb.CollectionSchema, needValidateFunctionName 
 	usedOutputField := typeutil.NewSet[string]()
 	usedFunctionName := typeutil.NewSet[string]()
 
-	for _, function := range coll.GetFunctions() {
-		if err := CheckFunctionBasicParams(function); err != nil {
-			return err
-		}
+	// Targeted validation (add/alter paths pass the new function's name)
+	// grandfathers already-persisted functions: per-function rules judge only
+	// the target, because rejecting a legacy function here cannot repair it and
+	// only bricks unrelated DDL on the collection (e.g. a pre-tightening
+	// MinHash function with a TEXT input). Cross-function invariants keep
+	// seeing the full schema: every function's names are collected below, only
+	// judged functions go through validateFunctionSchema.
+	targeted := needValidateFunctionName != ""
 
+	for _, function := range coll.GetFunctions() {
 		if usedFunctionName.Contain(function.GetName()) {
 			return merr.WrapErrParameterInvalidMsg("duplicate function name: %s", function.GetName())
 		}
-
 		usedFunctionName.Insert(function.GetName())
-		inputFields := []*schemapb.FieldSchema{}
-		for _, name := range function.GetInputFieldNames() {
-			inputField, ok := nameMap[name]
-			if !ok {
-				return merr.WrapErrParameterInvalidMsg("function input field not found: %s", name)
-			}
-			inputFields = append(inputFields, inputField)
-		}
 
-		if err := CheckFunctionInputField(function, inputFields); err != nil {
-			return err
-		}
-
-		outputFields := make([]*schemapb.FieldSchema, len(function.GetOutputFieldNames()))
-		for i, name := range function.GetOutputFieldNames() {
-			outputField, ok := nameMap[name]
-			if !ok {
-				return merr.WrapErrParameterInvalidMsg("function output field not found: %s", name)
-			}
-
-			if outputField.GetIsPrimaryKey() {
-				return merr.WrapErrParameterInvalidMsg("function output field cannot be primary key: function %s, field %s", function.GetName(), outputField.GetName())
-			}
-
-			if outputField.GetIsPartitionKey() || outputField.GetIsClusteringKey() {
-				return merr.WrapErrParameterInvalidMsg("function output field cannot be partition key or clustering key: function %s, field %s", function.GetName(), outputField.GetName())
-			}
-
-			if outputField.GetNullable() {
-				return merr.WrapErrParameterInvalidMsg("function output field cannot be nullable: function %s, field %s", function.GetName(), outputField.GetName())
-			}
-
-			outputFields[i] = outputField
+		for _, name := range function.GetOutputFieldNames() {
 			if usedOutputField.Contain(name) {
 				return merr.WrapErrParameterInvalidMsg("duplicate function output field: function %s, field %s", function.GetName(), name)
 			}
 			usedOutputField.Insert(name)
 		}
 
-		if err := CheckFunctionOutputField(function, outputFields); err != nil {
+		if targeted && function.GetName() != needValidateFunctionName {
+			continue
+		}
+		if err := validateFunctionSchema(function, nameMap); err != nil {
 			return err
 		}
 	}
 	// No cascade: a function's input must not be another function's output. A field
 	// cannot be a function's own input and output (rejected above), so any input in
 	// usedOutputField belongs to a different function. Enforced here so it holds on
-	// every path (create, legacy add, alter), not only add_function_field.
+	// every path (create, legacy add, alter), not only add_function_field. On the
+	// targeted path only the target function is judged; a persisted legacy pair
+	// stays grandfathered.
 	for _, function := range coll.GetFunctions() {
+		if targeted && function.GetName() != needValidateFunctionName {
+			continue
+		}
 		for _, name := range function.GetInputFieldNames() {
 			if usedOutputField.Contain(name) {
 				return merr.WrapErrParameterInvalidMsg("function %s input field %s is the output of another function; function cascade is not supported", function.GetName(), name)
 			}
+		}
+	}
+	// MinHash parameter validation (num_hashes vs output dim relation) is pure
+	// schema checking with no external calls; it must run even when the model
+	// runtime checks below are disabled.
+	for _, fn := range coll.GetFunctions() {
+		if fn.GetType() != schemapb.FunctionType_MinHash {
+			continue
+		}
+		if needValidateFunctionName != "" && fn.GetName() != needValidateFunctionName {
+			continue
+		}
+		if err := function.ValidateMinHashFunction(coll, fn); err != nil {
+			return err
 		}
 	}
 	if !disableRuntimeCheck {
@@ -104,6 +100,46 @@ func ValidateFunction(coll *schemapb.CollectionSchema, needValidateFunctionName 
 		}
 	}
 	return nil
+}
+
+// validateFunctionSchema runs the per-function rules against one function:
+// basic params, input resolution and type rules, output resolution and
+// property rules.
+func validateFunctionSchema(function *schemapb.FunctionSchema, nameMap map[string]*schemapb.FieldSchema) error {
+	if err := CheckFunctionBasicParams(function); err != nil {
+		return err
+	}
+
+	inputFields := make([]*schemapb.FieldSchema, 0, len(function.GetInputFieldNames()))
+	for _, name := range function.GetInputFieldNames() {
+		inputField, ok := nameMap[name]
+		if !ok {
+			return merr.WrapErrParameterInvalidMsg("function input field not found: %s", name)
+		}
+		inputFields = append(inputFields, inputField)
+	}
+	if err := CheckFunctionInputField(function, inputFields); err != nil {
+		return err
+	}
+
+	outputFields := make([]*schemapb.FieldSchema, len(function.GetOutputFieldNames()))
+	for i, name := range function.GetOutputFieldNames() {
+		outputField, ok := nameMap[name]
+		if !ok {
+			return merr.WrapErrParameterInvalidMsg("function output field not found: %s", name)
+		}
+		if outputField.GetIsPrimaryKey() {
+			return merr.WrapErrParameterInvalidMsg("function output field cannot be primary key: function %s, field %s", function.GetName(), outputField.GetName())
+		}
+		if outputField.GetIsPartitionKey() || outputField.GetIsClusteringKey() {
+			return merr.WrapErrParameterInvalidMsg("function output field cannot be partition key or clustering key: function %s, field %s", function.GetName(), outputField.GetName())
+		}
+		if outputField.GetNullable() {
+			return merr.WrapErrParameterInvalidMsg("function output field cannot be nullable: function %s, field %s", function.GetName(), outputField.GetName())
+		}
+		outputFields[i] = outputField
+	}
+	return CheckFunctionOutputField(function, outputFields)
 }
 
 func NormalizeFunctionOutputFields(coll *schemapb.CollectionSchema) error {
@@ -176,9 +212,11 @@ func CheckFunctionOutputField(fSchema *schemapb.FunctionSchema, fields []*schema
 func CheckFunctionInputField(function *schemapb.FunctionSchema, fields []*schemapb.FieldSchema) error {
 	switch function.GetType() {
 	case schemapb.FunctionType_BM25:
-		if len(fields) != 1 || (fields[0].DataType != schemapb.DataType_VarChar && fields[0].DataType != schemapb.DataType_Text) {
-			return merr.WrapErrParameterInvalidMsg("BM25 function input field must be a VARCHAR/TEXT field, got %d field with type %s",
-				len(fields), fields[0].DataType.String())
+		if len(fields) != 1 {
+			return merr.WrapErrParameterInvalidMsg("BM25 function only need 1 input field, but got %d", len(fields))
+		}
+		if fields[0].DataType != schemapb.DataType_VarChar && fields[0].DataType != schemapb.DataType_Text {
+			return merr.WrapErrParameterInvalidMsg("BM25 function input field must be a VARCHAR/TEXT field, but got %s", fields[0].DataType.String())
 		}
 		h := typeutil.CreateFieldSchemaHelper(fields[0])
 		if !h.EnableAnalyzer() {
@@ -189,9 +227,16 @@ func CheckFunctionInputField(function *schemapb.FunctionSchema, fields []*schema
 			return err
 		}
 	case schemapb.FunctionType_MinHash:
-		if len(fields) != 1 || (fields[0].DataType != schemapb.DataType_VarChar && fields[0].DataType != schemapb.DataType_Text) {
-			return merr.WrapErrParameterInvalidMsg("MinHash function input field must be a VARCHAR/TEXT field, got %d field with type %s",
-				len(fields), fields[0].DataType.String())
+		if len(fields) != 1 {
+			return merr.WrapErrParameterInvalidMsg("MinHash function only need 1 input field, but got %d", len(fields))
+		}
+		// VarChar only: TEXT persists as LOB references, so every path that
+		// recomputes the output from the STORED input (add-function backfill,
+		// schema-bump materialization) reads *array.Binary refs and hard-fails
+		// without LOB decoding. Wire-path inserts would run, but the lifecycle
+		// cannot complete, so admission stays VarChar-only.
+		if fields[0].DataType != schemapb.DataType_VarChar {
+			return merr.WrapErrParameterInvalidMsg("MinHash function input field must be a VARCHAR field, but got %s", fields[0].DataType.String())
 		}
 	default:
 		return merr.WrapErrParameterInvalidMsg("check input field with unknown function type")

--- a/internal/util/function/validator/validator_test.go
+++ b/internal/util/function/validator/validator_test.go
@@ -1,0 +1,123 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/function"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+func minHashCollectionSchema(numHashes string) *schemapb.CollectionSchema {
+	return &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar},
+			{FieldID: 101, Name: "hash", DataType: schemapb.DataType_BinaryVector, TypeParams: []*commonpb.KeyValuePair{
+				{Key: "dim", Value: "64"},
+			}},
+		},
+		Functions: []*schemapb.FunctionSchema{{
+			Name:             "minhash",
+			Type:             schemapb.FunctionType_MinHash,
+			InputFieldNames:  []string{"text"},
+			OutputFieldNames: []string{"hash"},
+			Params:           []*commonpb.KeyValuePair{{Key: function.NumHashesKey, Value: numHashes}},
+		}},
+	}
+}
+
+// The direct RootCoord DDL path calls ValidateFunction with
+// disableRuntimeCheck=true; MinHash parameter validation is pure schema
+// checking and must still run there.
+func TestValidateFunctionChecksMinHashParamsWithRuntimeCheckDisabled(t *testing.T) {
+	err := ValidateFunction(minHashCollectionSchema("3"), "minhash", true)
+	require.ErrorIs(t, err, merr.ErrParameterInvalid)
+	require.ErrorContains(t, err, "does not match expected dim")
+}
+
+func TestValidateFunctionAcceptsValidMinHashWithRuntimeCheckDisabled(t *testing.T) {
+	require.NoError(t, ValidateFunction(minHashCollectionSchema("2"), "minhash", true))
+}
+
+// legacyTextMinHashSchema holds a persisted pre-tightening MinHash function
+// with a TEXT input next to a fresh, valid BM25 function named "new_bm25".
+func legacyTextMinHashSchema() *schemapb.CollectionSchema {
+	return &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "legacy_text", DataType: schemapb.DataType_Text},
+			{FieldID: 101, Name: "legacy_hash", DataType: schemapb.DataType_BinaryVector, TypeParams: []*commonpb.KeyValuePair{
+				{Key: "dim", Value: "64"},
+			}},
+			{FieldID: 102, Name: "doc", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{
+				{Key: "enable_analyzer", Value: "true"},
+			}},
+			{FieldID: 103, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector},
+		},
+		Functions: []*schemapb.FunctionSchema{
+			{
+				Name:             "legacy_minhash",
+				Type:             schemapb.FunctionType_MinHash,
+				InputFieldNames:  []string{"legacy_text"},
+				OutputFieldNames: []string{"legacy_hash"},
+				Params:           []*commonpb.KeyValuePair{{Key: function.NumHashesKey, Value: "2"}},
+			},
+			{
+				Name:             "new_bm25",
+				Type:             schemapb.FunctionType_BM25,
+				InputFieldNames:  []string{"doc"},
+				OutputFieldNames: []string{"sparse"},
+			},
+		},
+	}
+}
+
+// A legacy persisted function must not be re-judged by current-version rules
+// when an unrelated function is validated on the targeted (add/alter) path.
+func TestValidateFunctionGrandfathersLegacyFunctionsOnTargetedPath(t *testing.T) {
+	require.NoError(t, ValidateFunction(legacyTextMinHashSchema(), "new_bm25", true))
+}
+
+// The targeted path still judges the target function itself.
+func TestValidateFunctionTargetedStillJudgesTargetFunction(t *testing.T) {
+	schema := legacyTextMinHashSchema()
+	err := ValidateFunction(schema, "legacy_minhash", true)
+	require.ErrorIs(t, err, merr.ErrParameterInvalid)
+	require.ErrorContains(t, err, "must be a VARCHAR field")
+}
+
+// Full validation (create_collection, needValidateFunctionName == "") keeps
+// judging every function; nothing is grandfathered at creation.
+func TestValidateFunctionFullValidationJudgesEveryFunction(t *testing.T) {
+	err := ValidateFunction(legacyTextMinHashSchema(), "", true)
+	require.ErrorIs(t, err, merr.ErrParameterInvalid)
+	require.ErrorContains(t, err, "must be a VARCHAR field")
+}
+
+// Cross-function invariants still see the full schema on the targeted path: a
+// target function reusing a legacy function's output field is rejected.
+func TestValidateFunctionTargetedKeepsCrossFunctionInvariants(t *testing.T) {
+	schema := legacyTextMinHashSchema()
+	schema.Functions[1].OutputFieldNames = []string{"legacy_hash"}
+	err := ValidateFunction(schema, "new_bm25", true)
+	require.ErrorIs(t, err, merr.ErrParameterInvalid)
+	require.ErrorContains(t, err, "duplicate function output field")
+}

--- a/tests/python_client/milvus_client/test_add_function_field_feature.py
+++ b/tests/python_client/milvus_client/test_add_function_field_feature.py
@@ -591,7 +591,7 @@ class TestMilvusClientAddFunctionFieldFeature(TestMilvusClientV2Base):
                 ),
                 {
                     ct.err_code: 1100,
-                    ct.err_msg: "BM25 function input field must be a VARCHAR/TEXT field, got 1 field with type Int64",
+                    ct.err_msg: "BM25 function input field must be a VARCHAR/TEXT field, but got Int64",
                 },
             ),
             (
@@ -3238,7 +3238,7 @@ class TestMilvusClientAddFunctionFieldFeature(TestMilvusClientV2Base):
             check_items={
                 ct.err_code: 1100,
                 ct.err_msg: (
-                    "minhash function output field 'mh' dim 256 does not match expected dim 512 "
+                    "minhash function output field 'mh' dim 256 does not match expected dim "
                     "(numHashes 16 * one minhash signature size of 32bit): invalid parameter"
                 ),
             },


### PR DESCRIPTION
Combined [3.0] cherry-pick of #52219 and #52902 (they modify the same admission path; #52902 is the rule-level follow-up to #52219's external exemption, so they ship together).

### From #52219 — admission gaps around MinHash functions
- Hoist MinHash parameter validation into `validator.ValidateFunction` so `disableRuntimeCheck=true` paths still run it.
- Run function validation on the direct RootCoord CreateCollection path.
- Replace the overflow-bypassable dim check (`numHashes*32` wraps int64) with the division-based `outputDim%32 == 0 && outputDim/32 == numHashes`.
- Align `CheckFunctionInputField` with the runner-side VarChar-only contract for MinHash (reject TEXT input).

### From #52902 — narrow the external-collection exemption to the rule level
- The TextEmbedding nullable-input check passes for externally-mapped input fields (their nullability is resolved from the external source, not user-declared); `prepareSchema` then validates external schemas unconditionally, keeping structural checks (e.g. the MinHash dim/num_hashes relation) authoritative on the direct path.
- Covers the milvus-table path: `prepareMilvusTableSnapshotSchema` runs the same non-runtime validation right after function-ID alignment (DDL replay returns early and stays unjudged).

### Test-side note
Also updates the one L2 assertion pinning the old error message with the computed expected dim `512`, which #52219 intentionally dropped — the 3.0 mirror of the master-side #52878 repair; without it this cherry-pick would break the 3.0 nightly.

Local runs green under `-tags dynamic,test`: `internal/util/function`, `internal/util/function/validator`, rootcoord `prepareSchema`/milvus-table suites.

Note: #52902 is still in review on master; if its review changes the master patch, this cherry-pick follows.

issue: #51649
pr: #52219
pr: #52902

🤖 Generated with [Claude Code](https://claude.com/claude-code)