### PR TITLE
fix: [3.0] stop AlterWAL from resetting the replicate checkpoint message ID

### DIFF
--- a/internal/streamingnode/server/wal/adaptor/opener.go
+++ b/internal/streamingnode/server/wal/adaptor/opener.go
@@ -473,10 +473,11 @@ func (o *openerAdaptorImpl) handleAlterWALAdvanceCheckpointsStage(ctx context.Co
 	// Update pchannel checkpoint: reset alterWALState and set position to new WAL initial position
 	finalCheckpoint := snapshot.Checkpoint.Clone()
 	finalCheckpoint.AlterWalState = nil
+	// Only the local checkpoint moves to the new backend. The replicate checkpoint
+	// holds the position this cluster has reached in the SOURCE cluster's WAL, so a
+	// local backend migration must leave it alone: the two message IDs belong to
+	// different clusters and therefore to different ID spaces.
 	finalCheckpoint.MessageID = msgadaptor.MustGetMessageIDFromMQWrapperID(newWALInitialMsgID)
-	if finalCheckpoint.ReplicateCheckpoint != nil {
-		finalCheckpoint.ReplicateCheckpoint.MessageID = finalCheckpoint.MessageID
-	}
 
 	// Persist final checkpoint to catalog
 	if err := catalog.SaveConsumeCheckpoint(ctx, opt.Channel.Name, finalCheckpoint.IntoProto()); err != nil {

--- a/internal/streamingnode/server/wal/adaptor/opener_test.go
+++ b/internal/streamingnode/server/wal/adaptor/opener_test.go
@@ -259,3 +259,67 @@ func TestHandleAlterWALFlushingStagePassesRateLimitComponent(t *testing.T) {
 	assert.Same(t, snapshot, capturedParam.RecoverySnapshot)
 	assert.Equal(t, streamingpb.AlterWALStage_ADVANCE_CHECKPOINT, snapshot.Checkpoint.AlterWalState.Stage)
 }
+
+func TestHandleAlterWALAdvanceCheckpointsStageKeepsReplicateCheckpoint(t *testing.T) {
+	channel := types.PChannelInfo{
+		Name:       "alter-wal-replicate-checkpoint-test",
+		Term:       1,
+		AccessMode: types.AccessModeRW,
+	}
+	// The position this cluster has reached in the source cluster's WAL. The source
+	// cluster runs a different backend than the one this cluster migrates to.
+	sourceMessageID := rmq.NewRmqID(42)
+
+	var persisted *streamingpb.WALCheckpoint
+	catalog := mock_metastore.NewMockStreamingNodeCataLog(t)
+	catalog.EXPECT().ListVChannel(mock.Anything, channel.Name).Return(nil, nil)
+	catalog.EXPECT().
+		SaveConsumeCheckpoint(mock.Anything, channel.Name, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ string, checkpoint *streamingpb.WALCheckpoint) error {
+			persisted = checkpoint
+			return nil
+		})
+	resource.InitForTest(t, resource.OptStreamingNodeCatalog(catalog))
+
+	previousDefaultWALName := message.GetDefaultWALName()
+	defer message.RegisterDefaultWALName(previousDefaultWALName)
+
+	snapshot := &recovery.RecoverySnapshot{
+		Checkpoint: &recovery.WALCheckpoint{
+			MessageID: rmq.NewRmqID(1),
+			TimeTick:  100,
+			AlterWalState: &streamingpb.AlterWALState{
+				TargetWalName: commonpb.WALName_Kafka,
+				TimeTick:      100,
+				Stage:         streamingpb.AlterWALStage_ADVANCE_CHECKPOINT,
+			},
+			ReplicateCheckpoint: &utility.ReplicateCheckpoint{
+				ClusterID: "source-cluster",
+				PChannel:  "source-pchannel",
+				MessageID: sourceMessageID,
+				TimeTick:  50,
+			},
+		},
+	}
+
+	err := (&openerAdaptorImpl{}).handleAlterWALAdvanceCheckpointsStage(
+		context.Background(),
+		&wal.OpenOption{Channel: channel},
+		snapshot,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+
+	// The local checkpoint moves to the initial position of the new backend.
+	assert.Equal(t, commonpb.WALName_Kafka, persisted.GetMessageId().GetWALName())
+
+	// The replicate checkpoint still points at the source cluster, whose WAL the
+	// local migration did not touch.
+	replicateCheckpoint := persisted.GetReplicateCheckpoint()
+	require.NotNil(t, replicateCheckpoint)
+	assert.Equal(t, "source-cluster", replicateCheckpoint.GetClusterId())
+	assert.Equal(t, "source-pchannel", replicateCheckpoint.GetPchannel())
+	assert.Equal(t, uint64(50), replicateCheckpoint.GetTimeTick())
+	assert.Equal(t, sourceMessageID.IntoProto().GetWALName(), replicateCheckpoint.GetMessageId().GetWALName())
+	assert.Equal(t, sourceMessageID.Marshal(), replicateCheckpoint.GetMessageId().GetId())
+}


### PR DESCRIPTION
issue: #52945
pr: #52946

Cherry-pick of #52946 to the 3.0 branch. The change applies cleanly; the code on 3.0 was identical to master.

## What problem does this PR solve?

When an `AlterWAL` operation completed, `handleAlterWALAdvanceCheckpointsStage` rewrote the pchannel checkpoint to the initial position of the new WAL backend and then stamped that same position into the replicate checkpoint. The two message IDs do not live in the same ID space: `ReplicateCheckpoint` holds the last confirmed position this cluster has reached in the **source** cluster's WAL, written from the replicate header of an incoming replicated message and read back by the CDC channel replicator to decide where to resume subscribing.

A local WAL backend migration says nothing about the source cluster, and the two clusters may run different WAL backends. Overwriting the field left the replicate checkpoint pointing at a local position, so resuming replication either failed to unmarshal the id under the source backend, or silently resumed from an unrelated position and lost or duplicated replicated data.

## What is changed and how does it work?

- `AlterWAL` now only moves the local pchannel checkpoint and leaves the replicate checkpoint untouched.
- Added `TestHandleAlterWALAdvanceCheckpointsStageKeepsReplicateCheckpoint`, which fails on the previous behaviour and passes with this change.
