### PR TITLE
fix: mark AlterWAL unreplicable and ack it only after vchannels consume it

### DIFF
--- a/internal/coordinator/restful_mgr_routes.go
+++ b/internal/coordinator/restful_mgr_routes.go
@@ -1217,14 +1217,7 @@ func (s *mixCoordImpl) broadcastAlterWALMessage(ctx context.Context, targetWALNa
 	defer broadcaster.Close()
 
 	// Create AlterWAL broadcast message
-	broadcastMsg, err := message.NewAlterWALMessageBuilderV2().
-		WithHeader(&message.AlterWALMessageHeader{
-			TargetWalName: targetWALName,
-			Config:        config,
-		}).
-		WithBody(&message.AlterWALMessageBody{}).
-		WithClusterLevelBroadcast(channel.GetClusterChannels()).
-		BuildBroadcast()
+	broadcastMsg, err := newAlterWALBroadcastMessage(targetWALName, config, channel.GetClusterChannels())
 	if err != nil {
 		logger.Info(ctx, "broadcastAlterWALMessage failed to build broadcast message", mlog.Err(err))
 		return errors.Wrap(err, "failed to build broadcast message")
@@ -1242,6 +1235,32 @@ func (s *mixCoordImpl) broadcastAlterWALMessage(ctx context.Context, targetWALNa
 		mlog.Uint64("broadcastID", result.BroadcastID))
 
 	return nil
+}
+
+// newAlterWALBroadcastMessage builds the AlterWAL broadcast message.
+//
+// The message is unreplicable: the WAL backend is a per-cluster deployment choice,
+// so a local migration must not make a secondary cluster migrate as well, and the
+// secondary may not even run the target MQ.
+//
+// The broadcast acks in sync with consumption: the ack callback writes the
+// cluster-wide mq.type into etcd, so it must not run while the streaming nodes
+// have not observed the AlterWAL marker yet. Without this option the broadcast is
+// fast-acked as soon as every pchannel append succeeds.
+func newAlterWALBroadcastMessage(
+	targetWALName commonpb.WALName,
+	config map[string]string,
+	clusterChannels message.ClusterChannels,
+) (message.BroadcastMutableMessage, error) {
+	return message.NewAlterWALMessageBuilderV2().
+		WithHeader(&message.AlterWALMessageHeader{
+			TargetWalName: targetWALName,
+			Config:        config,
+		}).
+		WithBody(&message.AlterWALMessageBody{}).
+		WithUnreplicable().
+		WithClusterLevelBroadcast(clusterChannels, message.OptBuildBroadcastAckSyncUp()).
+		BuildBroadcast()
 }
 
 // HandleAlterConfig handles POST requests to alter configuration items.

--- a/internal/coordinator/restful_mgr_routes_test.go
+++ b/internal/coordinator/restful_mgr_routes_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -457,4 +459,34 @@ func TestHandleGetConfig(t *testing.T) {
 		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
 		assert.Contains(t, w.Body.String(), "Method not allowed")
 	})
+}
+
+func TestNewAlterWALBroadcastMessage(t *testing.T) {
+	clusterChannels := message.ClusterChannels{
+		Channels:       []string{"pchannel1", "pchannel2"},
+		ControlChannel: "pchannel1_vcchan",
+	}
+
+	msg, err := newAlterWALBroadcastMessage(
+		commonpb.WALName_Pulsar,
+		map[string]string{"pulsar.address": "pulsar://localhost:6650"},
+		clusterChannels,
+	)
+	require.NoError(t, err)
+
+	// A local WAL migration must not be replayed on a secondary cluster.
+	assert.True(t, msg.IsUnreplicable())
+	// The ack callback writes mq.type into etcd, so it must wait for the streaming
+	// nodes to consume the message instead of being fast-acked at append time.
+	require.NotNil(t, msg.BroadcastHeader())
+	assert.True(t, msg.BroadcastHeader().AckSyncUp)
+
+	// Both properties must survive the split into per-pchannel messages.
+	msg.WithBroadcastID(1)
+	splitMsgs := msg.SplitIntoMutableMessage()
+	require.Len(t, splitMsgs, 2)
+	for _, splitMsg := range splitMsgs {
+		assert.True(t, splitMsg.IsUnreplicable())
+		assert.True(t, splitMsg.BroadcastHeader().AckSyncUp)
+	}
 }


### PR DESCRIPTION
issue: #52948

## What problem does this PR solve?

The `AlterWAL` broadcast was built without two properties it needs.

**It was replicable.** The CDC replicate path skips a message only when it is self-controlled or explicitly unreplicable:

```go
if msg.MessageType().IsSelfControlled() || msg.IsUnreplicable() {
	return ErrReplicateIgnored
}
```

`MessageTypeAlterWAL` carries only `ExclusiveRequired` in `messageTypePropertiesMap`, so the message was forwarded to the secondary cluster, which then migrated its own WAL backend because the primary migrated. The WAL backend is a per-cluster deployment choice and the secondary may not even run the target MQ.

**It was also fast-acked.** Without `AckSyncUp`, `broadcastTask.FastAck` acks every vchannel as soon as the appends succeed, long before any streaming node reads the message out of its WAL in `recoveryStorageImpl.ObserveMessage`. Meanwhile the AlterWAL ack callback writes the cluster-wide `mq.type` into etcd. So `mq.type` flipped while no node had observed the AlterWAL marker and no channel had started its switch, and anything resolving the backend from `mq.type` (a node starting up, a restarted streaming node, `GetDefaultWALName`) picked the new backend while those channels still had checkpoints on the old one. The callback's own comment already claims it runs "when all vchannels have acknowledged", which was not true.

## What is changed and how does it work?

- Build the message with `WithUnreplicable()` and `WithClusterLevelBroadcast(..., message.OptBuildBroadcastAckSyncUp())`, moved into a small `newAlterWALBroadcastMessage` helper so the construction is testable.
- Added `TestNewAlterWALBroadcastMessage`, asserting both properties on the broadcast message and on the messages it splits into. The test fails on the previous construction and passes with this change.

Note that `OptBuildBroadcastAckSyncUp` documents its own limitation: today it only disables fast ack, and the "acked after the checkpoint of the vchannel reaches the message" semantic is still pending. This narrows the window to "every node has consumed the marker" rather than closing it at "every channel finished switching"; that remaining gap is tracked in the issue.
