### PR TITLE
fix: prevent SIGILL from cross-microarchitecture Conan cache reuse

### DIFF
--- a/scripts/3rdparty_build.sh
+++ b/scripts/3rdparty_build.sh
@@ -206,6 +206,100 @@ def post_build(conanfile, **kwargs):
     _saved_env.clear()
 HOOK_EOF
 
+# ---------------------------------------------------------------------------
+# Build-host fingerprint validation
+# ---------------------------------------------------------------------------
+# Prevents cross-microarchitecture cache pollution that causes SIGILL.
+#
+# Background: the Conan local cache (and ccache) may contain binaries that
+# were compiled on a host with a newer instruction set (e.g. AMD Zen4/c8a
+# with AVX-512).  When those cached artifacts are reused on a host with an
+# older ISA (e.g. AMD Zen3/c6a, no AVX-512), any code path that executes
+# the newer instructions crashes with SIGILL at run time.
+#
+# This check writes a fingerprint of the current build host into the Conan
+# cache directory.  On every build, the stored fingerprint is compared to
+# the current host; on mismatch, the Conan package cache and ccache are
+# cleared before any dependency resolution happens, forcing a clean
+# rebuild that is safe for the current CPU.
+# ---------------------------------------------------------------------------
+function milvus_host_fingerprint() {
+    local os arch cpu_model has_avx512 has_avx2
+    os="$(uname -s)"
+    arch="$(uname -m)"
+
+    if [[ "$os" == "Darwin" ]]; then
+        cpu_model="$(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo 'unknown')"
+        has_avx512="n/a"
+        has_avx2="n/a"
+    elif [[ "$os" == "Linux" && -r /proc/cpuinfo ]]; then
+        cpu_model="$(grep -m1 'model name' /proc/cpuinfo | cut -d: -f2- | xargs)"
+        [[ -z "$cpu_model" ]] && cpu_model="unknown"
+        if grep -qm1 'avx512f' /proc/cpuinfo; then has_avx512="yes"; else has_avx512="no"; fi
+        if grep -qm1 'avx2'    /proc/cpuinfo; then has_avx2="yes";    else has_avx2="no";    fi
+    else
+        cpu_model="unknown"
+        has_avx512="n/a"
+        has_avx2="n/a"
+    fi
+
+    echo "${os}|${arch}|${cpu_model}|avx512=${has_avx512}|avx2=${has_avx2}"
+}
+
+function milvus_host_fingerprint_check() {
+    local conan_home tag_file current_fp cached_fp
+
+    conan_home="${CONAN_HOME_DIR:-$HOME/.conan2}"
+    tag_file="${conan_home}/.milvus_build_host_tag"
+    current_fp="$(milvus_host_fingerprint)"
+
+    if [[ ! -f "$tag_file" ]]; then
+        # First run on this cache volume: we have no record of which host
+        # populated the existing cache.  The cache may contain binaries from
+        # a previous (possibly different) CPU.  Clear it to guarantee a
+        # safe rebuild, then stamp the current host.
+        echo "============================================================"
+        echo "[milvus-ci] No host tag found on this Conan cache."
+        echo "[milvus-ci] Existing cache is untrusted (may contain binaries"
+        echo "[milvus-ci] compiled on a different CPU architecture)."
+        echo "[milvus-ci] Clearing Conan package cache and ccache..."
+        echo "============================================================"
+
+        rm -rf "${conan_home}/p" 2>/dev/null || true
+        if command -v ccache &>/dev/null; then
+            ccache --clear 2>/dev/null || true
+        fi
+    else
+        cached_fp="$(cat "$tag_file" 2>/dev/null || true)"
+        if [[ -n "$cached_fp" && "$cached_fp" != "$current_fp" ]]; then
+            echo "============================================================"
+            echo "[milvus-ci] WARNING: Conan cache host mismatch detected"
+            echo "[milvus-ci]   cached host : ${cached_fp}"
+            echo "[milvus-ci]   current host: ${current_fp}"
+            echo "[milvus-ci] The local cache was populated on a different CPU."
+            echo "[milvus-ci] Reusing it risks SIGILL from newer instructions."
+            echo "[milvus-ci] Clearing Conan package cache and ccache..."
+            echo "============================================================"
+
+            # Remove Conan package binaries (keeps profiles, remotes, hooks)
+            rm -rf "${conan_home}/p" 2>/dev/null || true
+
+            # Clear ccache if present
+            if command -v ccache &>/dev/null; then
+                ccache --clear 2>/dev/null || true
+            fi
+        fi
+    fi
+
+    # Always (re)write the tag with the current host fingerprint.
+    mkdir -p "$conan_home"
+    echo "$current_fp" > "$tag_file"
+    echo "[milvus-ci] Build host fingerprint: ${current_fp}"
+}
+
+# Run validation before any dependency resolution.
+milvus_host_fingerprint_check
+
 unameOut="$(uname -s)"
 case "${unameOut}" in
   Darwin*)


### PR DESCRIPTION
## Problem

  C++ unit tests (UT-CPP-Cov) and integration tests intermittently crash with `SIGILL (Signal 4, illegal instruction)` across all test shards, producing 0 test results. The
  crash stack consistently points to OpenBLAS Zen-specific kernels:


  sgemm_incopy_ZEN        ← crash point (OpenBLAS Zen kernel)
  ↑ sgemm_tn
  ↑ sgemm_ / cblas_sgemm
  ↑ faiss knn_jaccard / LemurEmbListStrategy::ComputeMaxSimLabels
  ↑ knowhere IndexBinaryIVF::Train / IndexFlat::search


  Example: PR #52897, Jenkins build #27784 — all 5 shards (heavy + shard0-3) crashed with SIGILL, integration test datanode processes repeatedly exited with `signal:
  illegal instruction (core dumped)`.

  ## Root Cause

  The Jenkins CI cluster previously ran a mix of c6a (AMD EPYC Milan / Zen 3, no AVX-512) and c8a (AMD EPYC Genoa / Zen 4, AVX-512 capable) instances. Conan caches and
  ccache are stored on shared EBS volumes and allocated to jobs from a pool:

  1. A job scheduled to a **c8a** node compiled dependencies (OpenBLAS, etc.) with Zen 4-level instructions (AVX-512)
  2. Those binaries persisted on the EBS cache volume
  3. Later, a job scheduled to a **c6a** node was allocated the same EBS volume
  4. Conan resolved dependencies from the local cache (`Already installed!`) — reusing the c8a-compiled binary
  5. At runtime, when the test exercised `sgemm_incopy_ZEN`, the CPU encountered an unsupported instruction → SIGILL

  The c8a instances have since been removed from the cluster, but **polluted binaries remain on some EBS cache volumes**, causing intermittent failures depending on which
  volume a job happens to be allocated.

  ## Solution

  Add a build-host fingerprint validation to `scripts/3rdparty_build.sh` that runs before any dependency resolution:

  1. **Compute fingerprint** of the current build host: `OS | arch | CPU model | AVX-512 capability | AVX-2 capability` (read from `/proc/cpuinfo`)
  2. **Compare** with the fingerprint stored in the Conan cache directory (`.milvus_build_host_tag`)
  3. **Auto-clear** Conan package cache and ccache when:
     - The tag file does not exist (first run — existing cache is untrusted, may contain binaries from an unknown host)
     - The tag file exists but the fingerprint differs (cache was populated on a different CPU architecture)
  4. **Proceed normally** when fingerprints match (same CPU type — cache is safe to reuse)

  This makes the script self-healing: no manual EBS cleanup required. Each EBS volume will automatically clear its cache on the first run after this patch lands, then
  rebuild all dependencies locally on the current (c6a) hardware.

  ## Behavior Matrix

  | Scenario | Tag file | Action | Result |
  |---|---|---|---|
  | EBS has c8a-era cache, no tag | missing | Clear cache + write tag | Safe rebuild on c6a ✅ |
  | EBS already clean, no tag | missing | Clear (no-op) + write tag | Normal build ✅ |
  | Same CPU type, subsequent run | match | Use cache | Fast build ✅ |
  | Future: new CPU type joins cluster | mismatch | Clear cache + update tag | Safe rebuild ✅ |

  ## One-time Cost

  Each EBS cache volume will trigger one full dependency rebuild (~30-50 min extra) on the first CI run after this patch merges. Subsequent runs on the same volume type
  will resume normal cache hit rates.

  ## Verification

  - [x] Shell syntax check passes (`bash -n`)
  - [x] Fingerprint generation tested on x86_64 Linux
  - [x] Mismatch detection logic validated (c8a-style tag vs c6a host → triggers clear)
  - [ ] Full CI run on a previously-failing PR confirms SIGILL no longer occurs

  issue: #52897