### PR TITLE
fix: prevent appends from landing after the AlterWAL message

### DIFF
--- a/internal/streamingnode/server/wal/adaptor/wal_adaptor.go
+++ b/internal/streamingnode/server/wal/adaptor/wal_adaptor.go
@@ -205,14 +205,36 @@ func (w *walAdaptorImpl) Append(ctx context.Context, msg message.MutableMessage)
 	ctx = utility.WithExtraAppendResult(ctx, &extraAppendResult)
 	messageID, err := w.interceptorBuildResult.Interceptor.DoAppend(ctx, msg,
 		func(ctx context.Context, msg message.MutableMessage) (message.MessageID, error) {
+			// The lock interceptor still holds its lock while this callback runs, so
+			// recheck the fence here: an append that passed the check at the entry of
+			// Append and then waited for that lock must not be persisted behind an
+			// AlterWAL message that was persisted in the meantime.
+			if w.isFenced.Load() {
+				return nil, walimpls.ErrFenced
+			}
+
 			if notPersistHint := utility.GetNotPersisted(ctx); notPersistHint != nil {
 				// do not persist the message if the hint is set.
 				return notPersistHint.MessageID, nil
 			}
+
 			metricsGuard.StartWALImplAppend()
 			msgID, err := w.retryAppendWhenRecoverableError(ctx, msg)
 			metricsGuard.FinishWALImplAppend()
-			return msgID, err
+			if err != nil {
+				return msgID, err
+			}
+
+			if msg.MessageType() == message.MessageTypeAlterWAL {
+				// AlterWAL is exclusive and pchannel-level, so the lock interceptor holds
+				// the global exclusive lock here while every other append holds the shared
+				// one. Raising the fence inside the callback therefore makes it atomic with
+				// respect to persistence: no other append can be persisting right now, and
+				// every later one sees the fence in the recheck above.
+				w.Logger().Info(ctx, "alter WAL message appended, marking WAL as fenced")
+				w.isFenced.Store(true)
+			}
+			return msgID, nil
 		})
 	metricsGuard.FinishAppend()
 	if err != nil {
@@ -227,13 +249,10 @@ func (w *walAdaptorImpl) Append(ctx context.Context, msg message.MutableMessage)
 		}
 		return nil, err
 	}
-	// Mark WAL as fenced if alter WAL message is appended successfully
-	// This prevents further append operations during WAL switch
+	// The fence itself was already raised inside the append callback.
 	if msg.MessageType() == message.MessageTypeAlterWAL {
-		w.Logger().Info(ctx, "alter WAL message appended, marking WAL as fenced")
-		w.isFenced.CompareAndSwap(false, true)
 		w.forceCancelAfterGracefulTimeout()
-		w.Logger().Info(ctx, "WAL marked as fenced for WAL switch, all append operations will be rejected")
+		w.Logger().Info(ctx, "alter WAL message appended, WAL marked as fenced, all append operations will be rejected")
 	}
 	w.appendRateCounter.Add(int64(msg.EstimateSize()))
 

--- a/internal/streamingnode/server/wal/adaptor/wal_adaptor_fence_test.go
+++ b/internal/streamingnode/server/wal/adaptor/wal_adaptor_fence_test.go
@@ -1,0 +1,246 @@
+package adaptor
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	uberatomic "go.uber.org/atomic"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/resource"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/adaptor/rate"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors"
+	lockinterceptor "github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/lock"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/txn"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/metricsutil"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/utility"
+	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/impls/walimplstest"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+const fenceTestTimeout = 5 * time.Second
+
+func TestAppendBeforeAlterWALCompletesBeforeFence(t *testing.T) {
+	insertStarted := make(chan struct{})
+	releaseInsert := make(chan struct{})
+
+	var nextID atomic.Int64
+	var mu sync.Mutex
+	var appendedTypes []message.MessageType
+	walImpls := newFirstTimeTickWALImpls(func(ctx context.Context, msg message.MutableMessage) (message.MessageID, error) {
+		if msg.MessageType() == message.MessageTypeInsert {
+			close(insertStarted)
+			<-releaseInsert
+		}
+		mu.Lock()
+		appendedTypes = append(appendedTypes, msg.MessageType())
+		mu.Unlock()
+		return finishFenceTestAppend(ctx, nextID.Add(1)), nil
+	})
+	w := newFenceTestWAL(t, walImpls)
+
+	insertErr := make(chan error, 1)
+	go func() {
+		_, err := w.Append(context.Background(), message.CreateTestEmptyInsertMesage(1, nil))
+		insertErr <- err
+	}()
+	waitFenceTestSignal(t, insertStarted)
+
+	alterErr := make(chan error, 1)
+	go func() {
+		_, err := w.Append(context.Background(), newFenceTestAlterWALMessage())
+		alterErr <- err
+	}()
+
+	close(releaseInsert)
+	require.NoError(t, waitFenceTestError(t, insertErr))
+	require.NoError(t, waitFenceTestError(t, alterErr))
+	assert.True(t, w.isFenced.Load())
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []message.MessageType{
+		message.MessageTypeInsert,
+		message.MessageTypeAlterWAL,
+	}, appendedTypes)
+}
+
+func TestAppendWaitingBehindAlterWALIsFenced(t *testing.T) {
+	gate := &fenceTestGateInterceptor{
+		insertEntered: make(chan struct{}),
+		releaseInsert: make(chan struct{}),
+		alterAppended: make(chan struct{}),
+		releaseAlter:  make(chan struct{}),
+	}
+
+	var nextID atomic.Int64
+	var mu sync.Mutex
+	var appendedTypes []message.MessageType
+	walImpls := newFirstTimeTickWALImpls(func(ctx context.Context, msg message.MutableMessage) (message.MessageID, error) {
+		mu.Lock()
+		appendedTypes = append(appendedTypes, msg.MessageType())
+		mu.Unlock()
+		return finishFenceTestAppend(ctx, nextID.Add(1)), nil
+	})
+	w := newFenceTestWAL(t, walImpls, gate)
+
+	insertErr := make(chan error, 1)
+	go func() {
+		_, err := w.Append(context.Background(), message.CreateTestEmptyInsertMesage(1, nil))
+		insertErr <- err
+	}()
+	waitFenceTestSignal(t, gate.insertEntered)
+
+	alterErr := make(chan error, 1)
+	go func() {
+		_, err := w.Append(context.Background(), newFenceTestAlterWALMessage())
+		alterErr <- err
+	}()
+	waitFenceTestSignal(t, gate.alterAppended)
+
+	// The AlterWAL append has returned from the lock interceptor, but the outer
+	// interceptor keeps walAdaptor.Append from reaching its post-chain logic.
+	// The fence must already be visible when the waiting Insert acquires RLock.
+	close(gate.releaseInsert)
+	err := waitFenceTestError(t, insertErr)
+	require.Error(t, err)
+	assert.True(t, status.AsStreamingError(err).IsFenced())
+
+	close(gate.releaseAlter)
+	require.NoError(t, waitFenceTestError(t, alterErr))
+	assert.True(t, w.isFenced.Load())
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []message.MessageType{message.MessageTypeAlterWAL}, appendedTypes)
+}
+
+type fenceTestGateInterceptor struct {
+	insertEntered chan struct{}
+	releaseInsert chan struct{}
+	alterAppended chan struct{}
+	releaseAlter  chan struct{}
+}
+
+func (i *fenceTestGateInterceptor) DoAppend(
+	ctx context.Context,
+	msg message.MutableMessage,
+	append interceptors.Append,
+) (message.MessageID, error) {
+	switch msg.MessageType() {
+	case message.MessageTypeInsert:
+		close(i.insertEntered)
+		<-i.releaseInsert
+		return append(ctx, msg)
+	case message.MessageTypeAlterWAL:
+		messageID, err := append(ctx, msg)
+		close(i.alterAppended)
+		<-i.releaseAlter
+		return messageID, err
+	default:
+		return append(ctx, msg)
+	}
+}
+
+func (i *fenceTestGateInterceptor) Close() {}
+
+func newFenceTestWAL(
+	t *testing.T,
+	walImpls walimpls.WALImpls,
+	beforeLock ...interceptors.Interceptor,
+) *walAdaptorImpl {
+	t.Helper()
+	paramtable.Init()
+	resource.InitForTest(t)
+
+	channel := walImpls.Channel()
+	txnManager := txn.NewTxnManager(channel, nil)
+	param := &interceptors.InterceptorBuildParam{
+		ChannelInfo: channel,
+		TxnManager:  txnManager,
+	}
+	lockInterceptor := lockinterceptor.NewInterceptorBuilder().Build(param)
+	allInterceptors := append(beforeLock, lockInterceptor)
+	chainedInterceptor := interceptors.NewChainedInterceptor(allInterceptors...)
+
+	availableCtx, availableCancel := context.WithCancel(context.Background())
+	rateLimitComponent := rate.NewWALRateLimitComponent(channel)
+	roWAL := &roWALAdaptorImpl{
+		WALRateLimitComponent: rateLimitComponent,
+		lifetime:              typeutil.NewLifetime(),
+		availableCtx:          availableCtx,
+		availableCancel:       availableCancel,
+		roWALImpls:            walImpls,
+	}
+	roWAL.SetLogger(mlog.With())
+
+	writeMetrics := metricsutil.NewWriteMetrics(channel, walImpls.WALName())
+	writeMetrics.SetLogger(roWAL.Logger())
+	w := &walAdaptorImpl{
+		roWALAdaptorImpl: roWAL,
+		rwWALImpls:       walImpls,
+		interceptorBuildResult: interceptorBuildResult{
+			Interceptor:       chainedInterceptor,
+			GracefulCloseFunc: func() {},
+		},
+		writeMetrics:      writeMetrics,
+		isFenced:          uberatomic.NewBool(false),
+		appendRateCounter: utility.NewAverageRateCounter(10 * time.Second),
+	}
+
+	t.Cleanup(func() {
+		availableCancel()
+		chainedInterceptor.Close()
+		writeMetrics.Close()
+		rateLimitComponent.Close()
+		require.NoError(t, txnManager.GracefulClose(context.Background()))
+	})
+	return w
+}
+
+func newFenceTestAlterWALMessage() message.MutableMessage {
+	return message.NewAlterWALMessageBuilderV2().
+		WithHeader(&message.AlterWALMessageHeader{TargetWalName: commonpb.WALName_WoodPecker}).
+		WithBody(&message.AlterWALMessageBody{}).
+		WithAllVChannel().
+		MustBuildMutable().
+		WithTimeTick(100).
+		WithLastConfirmed(walimplstest.NewTestMessageID(0))
+}
+
+func finishFenceTestAppend(ctx context.Context, id int64) message.MessageID {
+	messageID := walimplstest.NewTestMessageID(id)
+	utility.ReplaceAppendResultTimeTick(ctx, uint64(id))
+	utility.ReplaceAppendResultLastConfirmedMessageID(ctx, messageID)
+	return messageID
+}
+
+func waitFenceTestSignal(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(fenceTestTimeout):
+		t.Fatal("timed out waiting for test signal")
+	}
+}
+
+func waitFenceTestError(t *testing.T, ch <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(fenceTestTimeout):
+		t.Fatal("timed out waiting for append result")
+		return nil
+	}
+}


### PR DESCRIPTION
issue: #52952

## What problem does this PR solve?

`Append` checked the fence once on entry and raised it only after `DoAppend` had returned:

```go
if w.isFenced.Load() {
	return nil, status.NewChannelFenced(w.Channel().String())
}
...
messageID, err := w.interceptorBuildResult.Interceptor.DoAppend(ctx, msg, func(...) {
	msgID, err := w.retryAppendWhenRecoverableError(ctx, msg)   // persisted here
	return msgID, err
})
...
if msg.MessageType() == message.MessageTypeAlterWAL {
	w.isFenced.CompareAndSwap(false, true)                       // fenced only here
}
```

Between those two points another append can slip past. A concurrent append passes the entry check while the WAL is not fenced yet, blocks inside the interceptor chain waiting for the lock interceptor, and once the AlterWAL message has been persisted and `DoAppend` has returned, it acquires the lock and is persisted **behind** the AlterWAL message.

That message is lost for every consumer: a reader that follows the WAL switch cuts over to the new backend at the AlterWAL marker and never delivers anything written behind it in the old WAL.

## What is changed and how does it work?

- Recheck the fence inside the persist callback, so an append that passed the entry check and then waited for the lock is rejected with `walimpls.ErrFenced` instead of being persisted.
- Raise the fence inside that same callback, right after the AlterWAL message is persisted.

The lock interceptor holds its lock around the whole inner append chain including the persist callback (`lockAppendInterceptor.DoAppend` acquires the guard and defers its release around `append(ctx, msg)`), and AlterWAL is `ExclusiveRequired` and pchannel-level, so it takes the global exclusive lock while ordinary appends take the shared one. Raising the fence inside the callback is therefore atomic with respect to persistence: no other append can be persisting at that moment, and every later one sees the fence in the recheck.

`forceCancelAfterGracefulTimeout` still runs after `DoAppend` returns, unchanged.

## Tests

`wal_adaptor_fence_test.go` covers both orders:

- `TestAppendBeforeAlterWALCompletesBeforeFence`: an append that reaches the persist callback before AlterWAL still succeeds
- `TestAppendWaitingBehindAlterWALIsFenced`: an append that is waiting while AlterWAL is persisted is rejected instead of landing behind the marker. It fails on the previous behaviour with "an error is expected but got nil".
