### PR TITLE
fix: gate nested HYBRID high-cardinality STL_SORT on scalar index version

### DIFF
--- a/internal/core/src/common/Consts.h
+++ b/internal/core/src/common/Consts.h
@@ -167,3 +167,9 @@ const std::string WARMUP_VECTOR_FIELD_KEY = "warmup.vectorField";
 constexpr int32_t kHybridIndexConfigVersion = 3;
 // The last version before hybrid index config support was added
 constexpr int32_t kLastVersionWithoutHybridIndexConfig = 2;
+// Version 4 additionally allows nested (struct sub-field) HYBRID indexes to
+// select STL_SORT for high-cardinality data instead of INVERTED. Below this
+// version, nested HYBRID indexes always keep INVERTED at high cardinality:
+// an older reader's ScalarIndexSort predates nested-index support and cannot
+// load a nested STL_SORT physical index.
+constexpr int32_t kNestedHybridStlSortMinVersion = 4;

--- a/internal/core/src/index/BitmapIndexArrayTest.cpp
+++ b/internal/core/src/index/BitmapIndexArrayTest.cpp
@@ -1808,9 +1808,10 @@ MakeStringArrayFieldData(const std::vector<ScalarFieldProto>& scalar_arrays) {
 
 // Nested (struct sub-field) HYBRID indexes flatten scalar elements, so the
 // sort index can serve high-cardinality data: STL_SORT must replace INVERTED
-// once distinct values reach the bitmap cardinality limit (default 100).
-// Regular array fields keep INVERTED because the sort index cannot handle
-// array values.
+// once distinct values reach the bitmap cardinality limit (default 100) AND
+// scalar_index_version_ >= kNestedHybridStlSortMinVersion. Regular array
+// fields keep INVERTED regardless of version because the sort index cannot
+// handle array values.
 TEST(BitmapIndexArrayNestedTest, HybridNestedHighCardinalitySelectsStlsort) {
     auto root_path =
         fmt::format("{}/hybrid_nested_high_card_stlsort", TestLocalPath);
@@ -1822,13 +1823,15 @@ TEST(BitmapIndexArrayNestedTest, HybridNestedHighCardinalitySelectsStlsort) {
         MakeStringArrayFieldData(MakeStringScalarArrays(240, 120));
 
     TestHybridScalarIndexString nested(7, ctx, true);
+    nested.scalar_index_version_ = kNestedHybridStlSortMinVersion;
     EXPECT_EQ(nested.SelectIndexBuildTypePublic(
                   std::vector<FieldDataPtr>{high_card_field_data}),
               ScalarIndexType::STLSORT);
 
     // Regular (non-nested) array fields must stay on INVERTED at high
-    // cardinality.
+    // cardinality, even at/above the nested STL_SORT version threshold.
     TestHybridScalarIndexString regular(7, ctx, false);
+    regular.scalar_index_version_ = kNestedHybridStlSortMinVersion;
     EXPECT_EQ(regular.SelectIndexBuildTypePublic(
                   std::vector<FieldDataPtr>{high_card_field_data}),
               ScalarIndexType::INVERTED);
@@ -1837,13 +1840,44 @@ TEST(BitmapIndexArrayNestedTest, HybridNestedHighCardinalitySelectsStlsort) {
     auto low_card_field_data =
         MakeStringArrayFieldData(MakeStringScalarArrays(10, 1));
     TestHybridScalarIndexString nested_low(7, ctx, true);
+    nested_low.scalar_index_version_ = kNestedHybridStlSortMinVersion;
     EXPECT_EQ(nested_low.SelectIndexBuildTypePublic(
                   std::vector<FieldDataPtr>{low_card_field_data}),
               ScalarIndexType::BITMAP);
     TestHybridScalarIndexString regular_low(7, ctx, false);
+    regular_low.scalar_index_version_ = kNestedHybridStlSortMinVersion;
     EXPECT_EQ(regular_low.SelectIndexBuildTypePublic(
                   std::vector<FieldDataPtr>{low_card_field_data}),
               ScalarIndexType::BITMAP);
+
+    boost::filesystem::remove_all(root_path);
+}
+
+// Below kNestedHybridStlSortMinVersion (e.g. the default v3 used by 3.0.x),
+// nested high-cardinality HYBRID indexes must keep selecting INVERTED so
+// that an older reader (e.g. 2.6, whose ScalarIndexSort predates nested-index
+// support) can still load the index after a rollback. Regression test for
+// https://github.com/milvus-io/milvus/issues/52893.
+TEST(BitmapIndexArrayNestedTest,
+     HybridNestedHighCardinalityBelowVersionKeepsInverted) {
+    auto root_path =
+        fmt::format("{}/hybrid_nested_high_card_legacy_version", TestLocalPath);
+    auto ctx =
+        MakeNestedCtx(root_path, proto::schema::DataType::VarChar, false, 3141);
+
+    // 120 distinct elements spread over 240 rows -> high cardinality.
+    auto high_card_field_data =
+        MakeStringArrayFieldData(MakeStringScalarArrays(240, 120));
+
+    for (int32_t version : {0, kHybridIndexConfigVersion,
+                            kNestedHybridStlSortMinVersion - 1}) {
+        TestHybridScalarIndexString nested(7, ctx, true);
+        nested.scalar_index_version_ = version;
+        EXPECT_EQ(nested.SelectIndexBuildTypePublic(
+                      std::vector<FieldDataPtr>{high_card_field_data}),
+                  ScalarIndexType::INVERTED)
+            << "scalar_index_version_=" << version;
+    }
 
     boost::filesystem::remove_all(root_path);
 }

--- a/internal/core/src/index/BitmapIndexArrayTest.cpp
+++ b/internal/core/src/index/BitmapIndexArrayTest.cpp
@@ -1869,8 +1869,8 @@ TEST(BitmapIndexArrayNestedTest,
     auto high_card_field_data =
         MakeStringArrayFieldData(MakeStringScalarArrays(240, 120));
 
-    for (int32_t version : {0, kHybridIndexConfigVersion,
-                            kNestedHybridStlSortMinVersion - 1}) {
+    for (int32_t version :
+         {0, kHybridIndexConfigVersion, kNestedHybridStlSortMinVersion - 1}) {
         TestHybridScalarIndexString nested(7, ctx, true);
         nested.scalar_index_version_ = version;
         EXPECT_EQ(nested.SelectIndexBuildTypePublic(

--- a/internal/core/src/index/HybridScalarIndex.cpp
+++ b/internal/core/src/index/HybridScalarIndex.cpp
@@ -196,12 +196,19 @@ HybridScalarIndex<T>::SelectBuildTypeForArrayType(
     }
     // For array types, always use BITMAP for low cardinality. For high
     // cardinality, nested indexes index the flattened scalar elements, so the
-    // sort index can serve them and STL_SORT replaces INVERTED; regular array
-    // fields keep INVERTED because the sort index cannot handle array values.
-    // These are hardcoded and config parameters don't apply to arrays.
+    // sort index can serve them and STL_SORT replaces INVERTED once the whole
+    // cluster is guaranteed to run scalar_index_version_ >=
+    // kNestedHybridStlSortMinVersion; below that, an older reader's
+    // ScalarIndexSort predates nested-index support and cannot load a nested
+    // STL_SORT physical index. Regular array fields keep INVERTED because the
+    // sort index cannot handle array values. These are hardcoded and config
+    // parameters don't apply to arrays.
     if (distinct_vals.size() >= bitmap_index_cardinality_limit_) {
-        internal_index_type_ = is_nested_index_ ? ScalarIndexType::STLSORT
-                                                : ScalarIndexType::INVERTED;
+        internal_index_type_ =
+            (is_nested_index_ &&
+             scalar_index_version_ >= kNestedHybridStlSortMinVersion)
+                ? ScalarIndexType::STLSORT
+                : ScalarIndexType::INVERTED;
     } else {
         internal_index_type_ = ScalarIndexType::BITMAP;
     }
@@ -301,6 +308,7 @@ HybridScalarIndex<T>::Build(const Config& config) {
     auto scalar_index_version =
         GetValueFromConfig<int32_t>(config, SCALAR_INDEX_ENGINE_VERSION)
             .value_or(kLastVersionWithoutHybridIndexConfig);
+    scalar_index_version_ = scalar_index_version;
 
     if (scalar_index_version >= kHybridIndexConfigVersion) {
         // Version 3+: Use configurable index types

--- a/internal/core/src/index/HybridScalarIndex.h
+++ b/internal/core/src/index/HybridScalarIndex.h
@@ -235,6 +235,10 @@ class HybridScalarIndex : public ScalarIndex<T> {
     int32_t bitmap_index_cardinality_limit_;
     ScalarIndexType low_cardinality_index_type_;
     ScalarIndexType high_cardinality_index_type_;
+    // Resolved scalar index engine version from the last Build() call;
+    // gates whether nested (struct sub-field) high-cardinality data may
+    // select STL_SORT (see kNestedHybridStlSortMinVersion).
+    int32_t scalar_index_version_{0};
     proto::schema::DataType field_type_;
     ScalarIndexType internal_index_type_;
     std::shared_ptr<ScalarIndex<T>> internal_index_{nullptr};

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -123,6 +123,11 @@ const (
 	// Scalar index engine version 4:
 	// - JSON path index supports STL_SORT / BITMAP / HYBRID (in addition to
 	//   the existing INVERTED / NGRAM)
+	// - Nested (struct sub-field) HYBRID indexes may select STL_SORT for
+	//   high-cardinality data (in addition to the existing INVERTED); an
+	//   older reader's ScalarIndexSort predates nested-index support and
+	//   cannot load a nested STL_SORT physical index
+	//   (see MinScalarIndexVersionForNestedHybridStlSort)
 	// - On-disk file format is unchanged from v3
 	//
 	// Scalar index engine version 5:
@@ -138,6 +143,14 @@ const (
 	// engine version that supports STL_SORT / BITMAP / HYBRID on JSON fields.
 	// Below this version, only INVERTED (and NGRAM for VARCHAR) are allowed.
 	MinScalarIndexVersionForJsonPathMultiType = int32(4) //nolint:revive // intentionally "Json" not "JSON" to match JsonCastType / JsonPathKey naming
+
+	// MinScalarIndexVersionForNestedHybridStlSort is the minimum scalar index
+	// engine version at which nested (struct sub-field) HYBRID indexes may
+	// select STL_SORT for high-cardinality data instead of INVERTED. Below
+	// this version, nested HYBRID indexes always keep INVERTED at high
+	// cardinality so that an older reader (e.g. 2.6, whose ScalarIndexSort
+	// predates nested-index support) can still load the index.
+	MinScalarIndexVersionForNestedHybridStlSort = int32(4)
 
 	// MinScalarIndexVersionForFMINDEX is the minimum scalar index engine version
 	// that recognizes FMINDEX. Creating an FMINDEX while any node still reports a


### PR DESCRIPTION

issue: #52893

HybridScalarIndex::SelectBuildTypeForArrayType unconditionally selects STL_SORT for nested (struct sub-field) high-cardinality data whenever is_nested_index_ is set, regardless of scalar_index_version. Unlike the primitive-type selection path, which already gates its choice on scalar_index_version via kHybridIndexConfigVersion, the array path never consulted the version at all.

An older reader (e.g. 2.6, whose ScalarIndexSort predates nested-index support) cannot load a nested STL_SORT physical index, so once a segment containing a nested HYBRID index gets rebuilt/compacted past the bitmap cardinality limit, the resulting index becomes unreadable after a rollback -- with no explicit action from the operator.

Add kNestedHybridStlSortMinVersion (4, matching the already-published MinScalarIndexVersionForJsonPathMultiType threshold) and thread the resolved scalar_index_version through to the array-type selector, so nested high-cardinality data only selects STL_SORT once the whole cluster is guaranteed to be on a version new enough to read it; below that it keeps the legacy INVERTED choice.