### PR TITLE
fix: the analyze task could not be rescheduled due to datanode restart

### DIFF
--- a/internal/datacoord/task_analyze.go
+++ b/internal/datacoord/task_analyze.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
 
@@ -33,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/workerpb"
 	"github.com/milvus-io/milvus/pkg/v3/taskcommon"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -305,7 +307,7 @@ func (at *analyzeTask) tryDropTaskOnWorker(cluster session.Cluster) error {
 		mlog.FieldNodeID(at.NodeID),
 	)
 
-	if err := cluster.DropAnalyze(at.NodeID, at.GetTaskID()); err != nil {
+	if err := cluster.DropAnalyze(at.NodeID, at.GetTaskID()); err != nil && !errors.Is(err, merr.ErrNodeNotFound) {
 		log.Warn(context.TODO(), "failed to drop analyze task on worker", mlog.Err(err))
 		return err
 	}

--- a/internal/datacoord/task_analyze_test.go
+++ b/internal/datacoord/task_analyze_test.go
@@ -469,6 +469,10 @@ func (s *analyzeTaskSuite) TestQueryTaskOnWorker() {
 		cluster.EXPECT().QueryAnalyze(mock.Anything, mock.Anything).Return(nil, fmt.Errorf("mock error"))
 		cluster.EXPECT().DropAnalyze(mock.Anything, mock.Anything).Return(nil)
 
+		catalog := catalogmocks.NewDataCoordCatalog(s.T())
+		catalog.EXPECT().SaveAnalyzeTask(mock.Anything, mock.Anything).Return(nil)
+		s.mt.analyzeMeta.catalog = catalog
+
 		at.QueryTaskOnWorker(cluster)
 		s.Equal(indexpb.JobState_JobStateInit, at.GetState())
 	})
@@ -478,8 +482,35 @@ func (s *analyzeTaskSuite) TestQueryTaskOnWorker() {
 		cluster.EXPECT().QueryAnalyze(mock.Anything, mock.Anything).Return(nil, merr.ErrNodeNotFound)
 		cluster.EXPECT().DropAnalyze(mock.Anything, mock.Anything).Return(nil)
 
+		catalog := catalogmocks.NewDataCoordCatalog(s.T())
+		catalog.EXPECT().SaveAnalyzeTask(mock.Anything, mock.Anything).Return(nil)
+		s.mt.analyzeMeta.catalog = catalog
+
 		at.QueryTaskOnWorker(cluster)
 		s.Equal(indexpb.JobState_JobStateInit, at.GetState())
+	})
+
+	s.Run("node gone resets task for reschedule", func() {
+		// The assigned node has disappeared, so both QueryAnalyze and the
+		// follow-up DropAnalyze return ErrNodeNotFound. The task must still be
+		// reset to Init so the scheduler can re-dispatch it to a healthy node,
+		// otherwise it stays stuck in InProgress forever (see index/stats tasks).
+		freshTask := newAnalyzeTask(&indexpb.AnalyzeTask{
+			TaskID: s.taskID,
+			NodeID: 1,
+			State:  indexpb.JobState_JobStateInProgress,
+		}, s.mt)
+
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryAnalyze(mock.Anything, mock.Anything).Return(nil, merr.ErrNodeNotFound)
+		cluster.EXPECT().DropAnalyze(mock.Anything, mock.Anything).Return(merr.ErrNodeNotFound)
+
+		catalog := catalogmocks.NewDataCoordCatalog(s.T())
+		catalog.EXPECT().SaveAnalyzeTask(mock.Anything, mock.Anything).Return(nil)
+		s.mt.analyzeMeta.catalog = catalog
+
+		freshTask.QueryTaskOnWorker(cluster)
+		s.Equal(indexpb.JobState_JobStateInit, freshTask.GetState())
 	})
 
 	s.Run("task finished", func() {


### PR DESCRIPTION
Related to #52962

After restarting the datanode, the analyze task cannot be dropped because it cannot find the original datanode. This prevents the analyze task from being rescheduled.
Furthermore, this deadlocked analyze task also prevents the generation of new analyze tasks for that collection.