### PR TITLE
fix: collect input field names from all FunctionScore functions [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/internal/util/function/chain/rerank_builder.go
+++ b/internal/util/function/chain/rerank_builder.go
@@ -748,8 +748,21 @@ func GetInputFieldNamesFromFuncScore(funcScore *schemapb.FunctionScore) []string
 	if funcScore == nil || len(funcScore.Functions) == 0 {
 		return nil
 	}
-	funcSchema := funcScore.Functions[0]
-	return funcSchema.GetInputFieldNames()
+	seen := make(map[string]struct{})
+	var names []string
+	for _, f := range funcScore.Functions {
+		for _, name := range f.GetInputFieldNames() {
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			seen[name] = struct{}{}
+			names = append(names, name)
+		}
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	return names
 }
 
 // GetInputFieldIDsFromSchema resolves input field IDs from the collection schema using the function score's input field names.

--- a/internal/util/function/chain/rerank_builder_test.go
+++ b/internal/util/function/chain/rerank_builder_test.go
@@ -2355,6 +2355,17 @@ func (s *RerankBuilderTestSuite) TestGetInputFieldNamesFromFuncScore_EmptyFuncti
 }
 
 // =============================================================================
+
+func (s *RerankBuilderTestSuite) TestGetInputFieldNamesFromFuncScore_MultipleFunctions() {
+	funcScore := &schemapb.FunctionScore{
+		Functions: []*schemapb.FunctionSchema{
+			{Type: schemapb.FunctionType_Rerank}, // boost, no input fields
+			{Type: schemapb.FunctionType_Rerank, InputFieldNames: []string{"jd"}},
+		},
+	}
+	names := GetInputFieldNamesFromFuncScore(funcScore)
+	s.Equal([]string{"jd"}, names)
+}
 // GetInputFieldIDsFromSchema Tests
 // =============================================================================
 


### PR DESCRIPTION
#### What type of PR is this?
bug-fix

#### What this PR does / why we need it:

`GetInputFieldNamesFromFuncScore` only read the input fields of `Functions[0]`. When a `FunctionScore` combines a boost reranker (which carries no input fields) with a decay reranker, and the boost entry comes first (`[boost, decay]`), the decay input field name is never collected. The field is then not requested for fetching during search execution, and the map_op fails with `column not found`.

With `[decay, boost]` the same functions work because the decay entry happens to be first. The behavior must not depend on function order.

#### Which issue(s) this PR fixes:
Fixes #52960

#### Verification:
- The function now iterates over **all** functions and collects input field names, deduplicating them.
- Added `TestGetInputFieldNamesFromFuncScore_MultipleFunctions` covering boost-first + decay input field, plus regression coverage for the existing single-function cases.

#### Special notes for your reviewer:
This mirrors how `FunctionConfigUtils` handles `schemaProperties`/input fields for functions — every function contributes its inputs, not just the first. The existing tests (`WithFields`, `NoFields`, `Nil`, `EmptyFunctions`) continue to pass.

Signed-off-by: waterWang <waterWang@users.noreply.github.com>