### PR TITLE
fix: normalize null elements in external vector rows

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1084,6 +1084,11 @@ common:
         threshold: 1024 # split by average size policy threshold(in bytes) in storage v2
     useLoonFFI: false
     enableGrowingSourceFlush: false # enable flushing growing segment payload from QueryNode growing source through StorageV3 manifest path
+    externalVector:
+      # Policy for an external nullable dense-vector row that contains both valid and NULL dimensions.
+      # error: reject the malformed row; null: treat the whole row as NULL.
+      # A row whose dimensions are all NULL is always treated as a row-level NULL.
+      partialNullPolicy: error
     iops:
       # Initial ObjectStore request rate used by the Lance AIMD limiter for External Table reads.
       # The value must be greater than 0. Values above a positive maxRate are reduced to maxRate.

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1087,7 +1087,7 @@ common:
     externalVector:
       # Policy for an external nullable dense-vector row that contains both valid and NULL dimensions.
       # error: reject the malformed row; null: treat the whole row as NULL.
-      # A row whose dimensions are all NULL is always treated as a row-level NULL.
+      # For a nullable field, a row whose dimensions are all NULL is always treated as a row-level NULL, regardless of this setting.
       partialNullPolicy: error
     iops:
       # Initial ObjectStore request rate used by the Lance AIMD limiter for External Table reads.

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1084,11 +1084,6 @@ common:
         threshold: 1024 # split by average size policy threshold(in bytes) in storage v2
     useLoonFFI: false
     enableGrowingSourceFlush: false # enable flushing growing segment payload from QueryNode growing source through StorageV3 manifest path
-    externalVector:
-      # Policy for an external nullable dense-vector row that contains both valid and NULL dimensions.
-      # error: reject the malformed row; null: treat the whole row as NULL.
-      # For a nullable field, a row whose dimensions are all NULL is always treated as a row-level NULL, regardless of this setting.
-      partialNullPolicy: error
     iops:
       # Initial ObjectStore request rate used by the Lance AIMD limiter for External Table reads.
       # The value must be greater than 0. Values above a positive maxRate are reduced to maxRate.
@@ -1098,6 +1093,11 @@ common:
       # Set to 0 to disable the rate ceiling. This is not a strict aggregate limit across all filesystem instances.
       # The default matches the milvus-storage default.
       maxRate: 5000
+    externalVector:
+      # Policy for parent-valid external dense-vector rows containing a mix of valid and null child elements.
+      # Options: error, null. error rejects the row as malformed input; null promotes the whole row to a row-level null when the field is nullable.
+      # Rows whose child elements are all null are always promoted to row-level null for nullable fields, regardless of this setting.
+      partialNullPolicy: error
   # Default value: auto
   # Valid values: [auto, avx512, avx2, avx, sse4_2]
   # This configuration is only used by querynode and indexnode, it selects CPU instruction set for Searching and Index-building.

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <atomic>
 #include <chrono>
 #include <deque>
 #include <filesystem>
@@ -26,10 +27,13 @@
 #include "arrow/array/builder_nested.h"
 #include "arrow/array/builder_primitive.h"
 #include "arrow/array/concatenate.h"
+#include "arrow/buffer.h"
 #include "arrow/buffer_builder.h"
 #include <arrow/c/bridge.h>
 #include "arrow/scalar.h"
 #include "arrow/type_fwd.h"
+#include "arrow/util/bitmap_ops.h"
+#include "arrow/util/bit_util.h"
 #include "common/type_c.h"
 #include "fmt/format.h"
 #include "index/Utils.h"
@@ -80,6 +84,24 @@
 #include "nlohmann/json.hpp"
 
 namespace milvus::storage {
+
+namespace {
+
+std::atomic<bool> external_vector_partial_null_as_row_null{false};
+
+}  // namespace
+
+void
+SetExternalVectorPartialNullAsRowNull(bool enabled) {
+    external_vector_partial_null_as_row_null.store(enabled,
+                                                   std::memory_order_relaxed);
+}
+
+bool
+GetExternalVectorPartialNullAsRowNull() {
+    return external_vector_partial_null_as_row_null.load(
+        std::memory_order_relaxed);
+}
 
 constexpr const char* TEMP = "tmp";
 
@@ -2196,6 +2218,21 @@ ValidateNoNullValuesInRange(const std::shared_ptr<arrow::Array>& values,
     }
 }
 
+int64_t
+CountValidValuesInRange(const std::shared_ptr<arrow::Array>& values,
+                        int64_t begin,
+                        int64_t end) {
+    auto length = end - begin;
+    if (values->null_count() == 0) {
+        return length;
+    }
+    auto bitmap = values->null_bitmap_data();
+    AssertInfo(bitmap != nullptr,
+               "vector child array reports nulls without a validity bitmap");
+    return arrow::internal::CountSetBits(
+        bitmap, values->offset() + begin, length);
+}
+
 bool
 IsByteVectorListInput(DataType data_type) {
     return data_type == DataType::VECTOR_BINARY ||
@@ -2333,6 +2370,75 @@ NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
             memset(dst, 0, num_rows * byte_width);
         }
 
+        // Allocate a replacement parent bitmap only if child nulls need to be
+        // promoted to row-level nulls. The common all-valid path keeps the
+        // existing zero-allocation behavior.
+        std::shared_ptr<arrow::Buffer> promoted_null_bitmap;
+        int64_t promoted_null_count = 0;
+        auto mark_row_null = [&](int64_t row) {
+            if (promoted_null_bitmap == nullptr) {
+                auto bitmap_result = arrow::AllocateEmptyBitmap(num_rows);
+                AssertInfo(bitmap_result.ok(),
+                           "Failed to allocate vector null bitmap");
+                promoted_null_bitmap = std::move(*bitmap_result);
+                auto promoted_bits = promoted_null_bitmap->mutable_data();
+                if (array->null_count() == 0) {
+                    arrow::bit_util::SetBitsTo(
+                        promoted_bits, 0, num_rows, true);
+                } else {
+                    arrow::internal::CopyBitmap(array->null_bitmap_data(),
+                                                array->offset(),
+                                                num_rows,
+                                                promoted_bits,
+                                                0);
+                }
+            }
+            arrow::bit_util::ClearBit(promoted_null_bitmap->mutable_data(),
+                                      row);
+            ++promoted_null_count;
+            // Null rows have no logical vector value. Keep their physical
+            // fixed-width slot deterministic and safe until the nullable
+            // Binary conversion drops it.
+            memset(dst + row * byte_width, 0, byte_width);
+        };
+
+        const bool coerce_partial_null =
+            GetExternalVectorPartialNullAsRowNull();
+        const bool can_promote_child_nulls =
+            field_meta.is_nullable() &&
+            IsVectorDataType(field_meta.get_data_type()) &&
+            !IsVectorArrayDataType(field_meta.get_data_type());
+        auto should_copy_row = [&](const std::shared_ptr<arrow::Array>& values,
+                                   int64_t begin,
+                                   int64_t end,
+                                   int64_t row) {
+            const auto length = end - begin;
+            const auto valid_count =
+                CountValidValuesInRange(values, begin, end);
+            if (valid_count == length) {
+                return true;
+            }
+
+            const auto null_count = length - valid_count;
+            const bool all_null = valid_count == 0;
+            if (can_promote_child_nulls && (all_null || coerce_partial_null)) {
+                mark_row_null(row);
+                return false;
+            }
+
+            ThrowInfo(ErrorCode::DataFormatBroken,
+                      "vector list contains {} null element(s){} in child "
+                      "range [{}, {}) at row {}; field nullable={}, "
+                      "partial-null policy={}",
+                      null_count,
+                      FieldErrorSuffix(field_meta),
+                      begin,
+                      end,
+                      row,
+                      field_meta.is_nullable(),
+                      coerce_partial_null ? "null" : "error");
+        };
+
         if (type_id == arrow::Type::LIST) {
             auto list_array = std::static_pointer_cast<arrow::ListArray>(array);
             auto values = list_array->values();
@@ -2364,11 +2470,13 @@ NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
                                expected_list_length,
                                actual_length,
                                i);
-                    ValidateNoNullValuesInRange(
-                        values, offset, offset + actual_length, "vector list");
-                    milvus::fastmem::FastMemcpy(dst + i * byte_width,
-                                                raw + offset * elem_byte_size,
-                                                byte_width);
+                    if (should_copy_row(
+                            values, offset, offset + actual_length, i)) {
+                        milvus::fastmem::FastMemcpy(
+                            dst + i * byte_width,
+                            raw + offset * elem_byte_size,
+                            byte_width);
+                    }
                 }
             }
         } else if (type_id == arrow::Type::FIXED_SIZE_LIST) {
@@ -2399,13 +2507,13 @@ NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
             for (int64_t i = 0; i < num_rows; i++) {
                 if (array->IsValid(i)) {
                     auto offset = fsl_array->value_offset(i);
-                    ValidateNoNullValuesInRange(values,
-                                                offset,
-                                                offset + expected_list_length,
-                                                "vector list");
-                    milvus::fastmem::FastMemcpy(dst + i * byte_width,
-                                                raw + offset * elem_byte_size,
-                                                byte_width);
+                    if (should_copy_row(
+                            values, offset, offset + expected_list_length, i)) {
+                        milvus::fastmem::FastMemcpy(
+                            dst + i * byte_width,
+                            raw + offset * elem_byte_size,
+                            byte_width);
+                    }
                 }
             }
         } else {
@@ -2417,13 +2525,16 @@ NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
 
         // Preserve null bitmap from the source array
         std::shared_ptr<arrow::Buffer> null_bitmap;
-        if (array->null_count() > 0 && array->data()->buffers[0]) {
+        if (promoted_null_bitmap != nullptr) {
+            null_bitmap = std::move(promoted_null_bitmap);
+        } else if (array->null_count() > 0 && array->data()->buffers[0]) {
             null_bitmap = array->data()->buffers[0];
         }
-        auto fsb_data = arrow::ArrayData::Make(fsb_type,
-                                               num_rows,
-                                               {null_bitmap, std::move(buffer)},
-                                               array->null_count());
+        auto fsb_data =
+            arrow::ArrayData::Make(fsb_type,
+                                   num_rows,
+                                   {null_bitmap, std::move(buffer)},
+                                   array->null_count() + promoted_null_count);
         result.push_back(
             std::make_shared<arrow::FixedSizeBinaryArray>(fsb_data));
     }

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -2523,12 +2523,22 @@ NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
                       array->type()->ToString());
         }
 
-        // Preserve null bitmap from the source array
+        // Preserve source nulls in an offset-zero bitmap. Reusing the source
+        // buffer directly is incorrect for sliced arrays because the new FSB
+        // array itself has offset zero.
         std::shared_ptr<arrow::Buffer> null_bitmap;
         if (promoted_null_bitmap != nullptr) {
             null_bitmap = std::move(promoted_null_bitmap);
-        } else if (array->null_count() > 0 && array->data()->buffers[0]) {
-            null_bitmap = array->data()->buffers[0];
+        } else if (array->null_count() > 0) {
+            auto bitmap_result = arrow::AllocateEmptyBitmap(num_rows);
+            AssertInfo(bitmap_result.ok(),
+                       "Failed to allocate vector null bitmap");
+            null_bitmap = std::move(*bitmap_result);
+            arrow::internal::CopyBitmap(array->null_bitmap_data(),
+                                        array->offset(),
+                                        num_rows,
+                                        null_bitmap->mutable_data(),
+                                        0);
         }
         auto fsb_data =
             arrow::ArrayData::Make(fsb_type,

--- a/internal/core/src/storage/Util.h
+++ b/internal/core/src/storage/Util.h
@@ -59,6 +59,15 @@
 
 namespace milvus::storage {
 
+// Controls how parent-valid external dense-vector rows with a mixture of
+// valid and null child elements are normalized. All-null child ranges are
+// always normalized to a row-level null when the field is nullable.
+void
+SetExternalVectorPartialNullAsRowNull(bool enabled);
+
+bool
+GetExternalVectorPartialNullAsRowNull();
+
 void
 ReadMediumType(BinlogReaderPtr reader);
 

--- a/internal/core/src/storage/storage_c.cpp
+++ b/internal/core/src/storage/storage_c.cpp
@@ -200,6 +200,16 @@ InitArrowReaderConfig(CArrowReaderConfig c_arrow_reader_config) {
     }
 }
 
+void
+SetExternalVectorPartialNullAsRowNull(bool enabled) {
+    milvus::storage::SetExternalVectorPartialNullAsRowNull(enabled);
+}
+
+bool
+GetExternalVectorPartialNullAsRowNull() {
+    return milvus::storage::GetExternalVectorPartialNullAsRowNull();
+}
+
 CStatus
 InitLoonReaderThreadPool(int32_t num_threads) {
     try {

--- a/internal/core/src/storage/storage_c.cpp
+++ b/internal/core/src/storage/storage_c.cpp
@@ -32,6 +32,7 @@
 #include "storage/ThreadPools.h"
 #include "storage/KeyRetriever.h"
 #include "storage/Types.h"
+#include "storage/Util.h"
 #include "storage/loon_ffi/property_singleton.h"
 #include "milvus-storage/thread_pool.h"
 

--- a/internal/core/src/storage/storage_c.h
+++ b/internal/core/src/storage/storage_c.h
@@ -19,6 +19,7 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "common/common_type_c.h"
@@ -47,6 +48,12 @@ InitDiskFileWriterConfig(CDiskWriteConfig c_disk_write_config);
 
 CStatus
 InitArrowReaderConfig(CArrowReaderConfig c_arrow_reader_config);
+
+void
+SetExternalVectorPartialNullAsRowNull(bool enabled);
+
+bool
+GetExternalVectorPartialNullAsRowNull();
 
 CStatus
 InitLoonReaderThreadPool(int32_t num_threads);

--- a/internal/core/unittest/test_arrow_canonicalize.cpp
+++ b/internal/core/unittest/test_arrow_canonicalize.cpp
@@ -634,6 +634,39 @@ TEST(NormalizeVectorArraysToFixedSizeBinary,
 }
 
 TEST(NormalizeVectorArraysToFixedSizeBinary,
+     NullableSlicedListPreservesParentNullAtLogicalOffset) {
+    ScopedExternalVectorPartialNullPolicy policy(false);
+    auto values_builder = std::make_shared<arrow::FloatBuilder>();
+    arrow::ListBuilder list_builder(arrow::default_memory_pool(),
+                                    values_builder);
+
+    ASSERT_TRUE(list_builder.Append().ok());
+    ASSERT_TRUE(values_builder->AppendValues({1.0f, 2.0f}).ok());
+    ASSERT_TRUE(list_builder.AppendNull().ok());
+    ASSERT_TRUE(list_builder.Append().ok());
+    ASSERT_TRUE(values_builder->AppendValues({3.0f, 4.0f}).ok());
+
+    std::shared_ptr<arrow::Array> input;
+    ASSERT_TRUE(list_builder.Finish(&input).ok());
+    auto sliced = input->Slice(1, 2);
+    ASSERT_EQ(sliced->offset(), 1);
+
+    auto output = NormalizeVectorArraysToFixedSizeBinaryForTest(
+        {sliced}, milvus::DataType::VECTOR_FLOAT, 2, true);
+    ASSERT_EQ(output->type_id(), arrow::Type::BINARY);
+    auto binary = std::static_pointer_cast<arrow::BinaryArray>(output);
+    ASSERT_EQ(binary->length(), 2);
+    EXPECT_TRUE(binary->IsNull(0));
+    ASSERT_TRUE(binary->IsValid(1));
+    ASSERT_EQ(binary->value_length(1), 2 * sizeof(float));
+    auto view = binary->GetView(1);
+    float actual[2];
+    std::memcpy(actual, view.data(), view.size());
+    EXPECT_FLOAT_EQ(actual[0], 3.0f);
+    EXPECT_FLOAT_EQ(actual[1], 4.0f);
+}
+
+TEST(NormalizeVectorArraysToFixedSizeBinary,
      NullableListPartialNullPolicyErrorReturnsDataFormatBroken) {
     ScopedExternalVectorPartialNullPolicy policy(false);
     arrow::FloatBuilder values_builder;
@@ -679,6 +712,43 @@ TEST(NormalizeVectorArraysToFixedSizeBinary,
 }
 
 TEST(NormalizeVectorArraysToFixedSizeBinary,
+     NullableFixedSizeListPartialNullPolicyErrorReturnsDataFormatBroken) {
+    ScopedExternalVectorPartialNullPolicy policy(false);
+    arrow::FloatBuilder values_builder;
+    ASSERT_TRUE(values_builder.Append(1.0f).ok());
+    ASSERT_TRUE(values_builder.AppendNull().ok());
+    std::shared_ptr<arrow::Array> values;
+    ASSERT_TRUE(values_builder.Finish(&values).ok());
+
+    auto input = std::make_shared<arrow::FixedSizeListArray>(
+        arrow::fixed_size_list(arrow::float32(), 2), 1, values);
+    try {
+        static_cast<void>(NormalizeVectorArraysToFixedSizeBinaryForTest(
+            {input}, milvus::DataType::VECTOR_FLOAT, 2, true));
+        FAIL() << "expected partial-null vector to be rejected";
+    } catch (const milvus::SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), milvus::DataFormatBroken);
+    }
+}
+
+TEST(NormalizeVectorArraysToFixedSizeBinary,
+     NullableFixedSizeListPartialNullPolicyNullBecomesRowNull) {
+    ScopedExternalVectorPartialNullPolicy policy(true);
+    arrow::FloatBuilder values_builder;
+    ASSERT_TRUE(values_builder.Append(1.0f).ok());
+    ASSERT_TRUE(values_builder.AppendNull().ok());
+    std::shared_ptr<arrow::Array> values;
+    ASSERT_TRUE(values_builder.Finish(&values).ok());
+
+    auto input = std::make_shared<arrow::FixedSizeListArray>(
+        arrow::fixed_size_list(arrow::float32(), 2), 1, values);
+    auto output = NormalizeVectorArraysToFixedSizeBinaryForTest(
+        {input}, milvus::DataType::VECTOR_FLOAT, 2, true);
+    ASSERT_EQ(output->type_id(), arrow::Type::BINARY);
+    EXPECT_TRUE(output->IsNull(0));
+}
+
+TEST(NormalizeVectorArraysToFixedSizeBinary,
      NonNullableListPartialNullPolicyNullStillRejects) {
     ScopedExternalVectorPartialNullPolicy policy(true);
     arrow::FloatBuilder values_builder;
@@ -693,9 +763,13 @@ TEST(NormalizeVectorArraysToFixedSizeBinary,
     ASSERT_TRUE(offsets_builder.Finish(&offsets).ok());
 
     auto input = *arrow::ListArray::FromArrays(*offsets, *values);
-    EXPECT_THROW(NormalizeVectorArraysToFixedSizeBinaryForTest(
-                     {input}, milvus::DataType::VECTOR_FLOAT, 2, false),
-                 milvus::SegcoreError);
+    try {
+        static_cast<void>(NormalizeVectorArraysToFixedSizeBinaryForTest(
+            {input}, milvus::DataType::VECTOR_FLOAT, 2, false));
+        FAIL() << "expected non-nullable partial-null vector to be rejected";
+    } catch (const milvus::SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), milvus::DataFormatBroken);
+    }
 }
 
 TEST(NormalizeVectorArraysToFixedSizeBinary, FixedSizeListDimMismatchAsserts) {

--- a/internal/core/unittest/test_arrow_canonicalize.cpp
+++ b/internal/core/unittest/test_arrow_canonicalize.cpp
@@ -293,12 +293,28 @@ std::shared_ptr<arrow::Array>
 NormalizeVectorArraysToFixedSizeBinaryForTest(
     const std::vector<std::shared_ptr<arrow::Array>>& arrays,
     milvus::DataType data_type,
-    int64_t dim) {
+    int64_t dim,
+    bool nullable = false) {
     AssertInfo(arrays.size() == 1, "test helper expects one array");
     auto field_meta = MakeExternalFieldMetaForTest(
-        data_type, dim, false, milvus::DataType::NONE);
+        data_type, dim, nullable, milvus::DataType::NONE);
     return milvus::storage::NormalizeExternalArrow(arrays.front(), field_meta);
 }
+
+class ScopedExternalVectorPartialNullPolicy {
+ public:
+    explicit ScopedExternalVectorPartialNullPolicy(bool enabled)
+        : previous_(milvus::storage::GetExternalVectorPartialNullAsRowNull()) {
+        milvus::storage::SetExternalVectorPartialNullAsRowNull(enabled);
+    }
+
+    ~ScopedExternalVectorPartialNullPolicy() {
+        milvus::storage::SetExternalVectorPartialNullAsRowNull(previous_);
+    }
+
+ private:
+    bool previous_;
+};
 
 std::shared_ptr<arrow::Array>
 MakeInt32Array(const std::vector<int32_t>& vals,
@@ -535,6 +551,151 @@ TEST(NormalizeVectorArraysToFixedSizeBinary, ListNullElementAsserts) {
     EXPECT_THROW(NormalizeVectorArraysToFixedSizeBinaryForTest(
                      {input}, milvus::DataType::VECTOR_FLOAT, 2),
                  std::exception);
+}
+
+TEST(NormalizeVectorArraysToFixedSizeBinary,
+     NullableListAllNullChildrenBecomeRowNull) {
+    ScopedExternalVectorPartialNullPolicy policy(false);
+    arrow::FloatBuilder values_builder;
+    ASSERT_TRUE(values_builder.AppendValues({1.0f, 2.0f}).ok());
+    ASSERT_TRUE(values_builder.AppendNull().ok());
+    ASSERT_TRUE(values_builder.AppendNull().ok());
+    std::shared_ptr<arrow::Array> values;
+    ASSERT_TRUE(values_builder.Finish(&values).ok());
+
+    arrow::Int32Builder offsets_builder;
+    ASSERT_TRUE(offsets_builder.AppendValues({0, 2, 4}).ok());
+    std::shared_ptr<arrow::Array> offsets;
+    ASSERT_TRUE(offsets_builder.Finish(&offsets).ok());
+
+    auto input = *arrow::ListArray::FromArrays(*offsets, *values);
+    auto output = NormalizeVectorArraysToFixedSizeBinaryForTest(
+        {input}, milvus::DataType::VECTOR_FLOAT, 2, true);
+    ASSERT_EQ(output->type_id(), arrow::Type::BINARY);
+    auto binary = std::static_pointer_cast<arrow::BinaryArray>(output);
+    ASSERT_EQ(binary->length(), 2);
+    EXPECT_TRUE(binary->IsValid(0));
+    EXPECT_TRUE(binary->IsNull(1));
+    EXPECT_EQ(binary->value_length(0), 2 * sizeof(float));
+    EXPECT_EQ(binary->value_length(1), 0);
+}
+
+TEST(NormalizeVectorArraysToFixedSizeBinary,
+     NullableFixedSizeListAllNullChildrenBecomeRowNull) {
+    ScopedExternalVectorPartialNullPolicy policy(false);
+    arrow::FloatBuilder values_builder;
+    ASSERT_TRUE(values_builder.AppendNull().ok());
+    ASSERT_TRUE(values_builder.AppendNull().ok());
+    ASSERT_TRUE(values_builder.AppendValues({3.0f, 4.0f}).ok());
+    std::shared_ptr<arrow::Array> values;
+    ASSERT_TRUE(values_builder.Finish(&values).ok());
+
+    auto input = std::make_shared<arrow::FixedSizeListArray>(
+        arrow::fixed_size_list(arrow::float32(), 2), 2, values);
+    auto output = NormalizeVectorArraysToFixedSizeBinaryForTest(
+        {input}, milvus::DataType::VECTOR_FLOAT, 2, true);
+    ASSERT_EQ(output->type_id(), arrow::Type::BINARY);
+    auto binary = std::static_pointer_cast<arrow::BinaryArray>(output);
+    ASSERT_EQ(binary->length(), 2);
+    EXPECT_TRUE(binary->IsNull(0));
+    EXPECT_TRUE(binary->IsValid(1));
+    EXPECT_EQ(binary->value_length(0), 0);
+    EXPECT_EQ(binary->value_length(1), 2 * sizeof(float));
+}
+
+TEST(NormalizeVectorArraysToFixedSizeBinary,
+     NullableListPreservesParentNullWhenPromotingAllNullChildren) {
+    ScopedExternalVectorPartialNullPolicy policy(false);
+    auto values_builder = std::make_shared<arrow::FloatBuilder>();
+    arrow::ListBuilder list_builder(arrow::default_memory_pool(),
+                                    values_builder);
+
+    ASSERT_TRUE(list_builder.Append().ok());
+    ASSERT_TRUE(values_builder->AppendValues({1.0f, 2.0f}).ok());
+    ASSERT_TRUE(list_builder.AppendNull().ok());
+    ASSERT_TRUE(list_builder.Append().ok());
+    ASSERT_TRUE(values_builder->AppendNull().ok());
+    ASSERT_TRUE(values_builder->AppendNull().ok());
+
+    std::shared_ptr<arrow::Array> input;
+    ASSERT_TRUE(list_builder.Finish(&input).ok());
+    auto output = NormalizeVectorArraysToFixedSizeBinaryForTest(
+        {input}, milvus::DataType::VECTOR_FLOAT, 2, true);
+    ASSERT_EQ(output->type_id(), arrow::Type::BINARY);
+    auto binary = std::static_pointer_cast<arrow::BinaryArray>(output);
+    ASSERT_EQ(binary->length(), 3);
+    EXPECT_EQ(binary->null_count(), 2);
+    EXPECT_TRUE(binary->IsValid(0));
+    EXPECT_TRUE(binary->IsNull(1));
+    EXPECT_TRUE(binary->IsNull(2));
+    EXPECT_EQ(binary->value_length(0), 2 * sizeof(float));
+    EXPECT_EQ(binary->value_length(1), 0);
+    EXPECT_EQ(binary->value_length(2), 0);
+}
+
+TEST(NormalizeVectorArraysToFixedSizeBinary,
+     NullableListPartialNullPolicyErrorReturnsDataFormatBroken) {
+    ScopedExternalVectorPartialNullPolicy policy(false);
+    arrow::FloatBuilder values_builder;
+    ASSERT_TRUE(values_builder.Append(1.0f).ok());
+    ASSERT_TRUE(values_builder.AppendNull().ok());
+    std::shared_ptr<arrow::Array> values;
+    ASSERT_TRUE(values_builder.Finish(&values).ok());
+
+    arrow::Int32Builder offsets_builder;
+    ASSERT_TRUE(offsets_builder.AppendValues({0, 2}).ok());
+    std::shared_ptr<arrow::Array> offsets;
+    ASSERT_TRUE(offsets_builder.Finish(&offsets).ok());
+
+    auto input = *arrow::ListArray::FromArrays(*offsets, *values);
+    try {
+        static_cast<void>(NormalizeVectorArraysToFixedSizeBinaryForTest(
+            {input}, milvus::DataType::VECTOR_FLOAT, 2, true));
+        FAIL() << "expected partial-null vector to be rejected";
+    } catch (const milvus::SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), milvus::DataFormatBroken);
+    }
+}
+
+TEST(NormalizeVectorArraysToFixedSizeBinary,
+     NullableListPartialNullPolicyNullBecomesRowNull) {
+    ScopedExternalVectorPartialNullPolicy policy(true);
+    arrow::FloatBuilder values_builder;
+    ASSERT_TRUE(values_builder.Append(1.0f).ok());
+    ASSERT_TRUE(values_builder.AppendNull().ok());
+    std::shared_ptr<arrow::Array> values;
+    ASSERT_TRUE(values_builder.Finish(&values).ok());
+
+    arrow::Int32Builder offsets_builder;
+    ASSERT_TRUE(offsets_builder.AppendValues({0, 2}).ok());
+    std::shared_ptr<arrow::Array> offsets;
+    ASSERT_TRUE(offsets_builder.Finish(&offsets).ok());
+
+    auto input = *arrow::ListArray::FromArrays(*offsets, *values);
+    auto output = NormalizeVectorArraysToFixedSizeBinaryForTest(
+        {input}, milvus::DataType::VECTOR_FLOAT, 2, true);
+    ASSERT_EQ(output->type_id(), arrow::Type::BINARY);
+    EXPECT_TRUE(output->IsNull(0));
+}
+
+TEST(NormalizeVectorArraysToFixedSizeBinary,
+     NonNullableListPartialNullPolicyNullStillRejects) {
+    ScopedExternalVectorPartialNullPolicy policy(true);
+    arrow::FloatBuilder values_builder;
+    ASSERT_TRUE(values_builder.Append(1.0f).ok());
+    ASSERT_TRUE(values_builder.AppendNull().ok());
+    std::shared_ptr<arrow::Array> values;
+    ASSERT_TRUE(values_builder.Finish(&values).ok());
+
+    arrow::Int32Builder offsets_builder;
+    ASSERT_TRUE(offsets_builder.AppendValues({0, 2}).ok());
+    std::shared_ptr<arrow::Array> offsets;
+    ASSERT_TRUE(offsets_builder.Finish(&offsets).ok());
+
+    auto input = *arrow::ListArray::FromArrays(*offsets, *values);
+    EXPECT_THROW(NormalizeVectorArraysToFixedSizeBinaryForTest(
+                     {input}, milvus::DataType::VECTOR_FLOAT, 2, false),
+                 milvus::SegcoreError);
 }
 
 TEST(NormalizeVectorArraysToFixedSizeBinary, FixedSizeListDimMismatchAsserts) {

--- a/internal/datanode/index/init_segcore.go
+++ b/internal/datanode/index/init_segcore.go
@@ -101,6 +101,9 @@ func InitSegcore(nodeID int64) error {
 	if err := initcore.InitArrowReaderConfig(paramtable.Get()); err != nil {
 		return err
 	}
+	if err := initcore.InitExternalVectorNullPolicy(paramtable.Get()); err != nil {
+		return err
+	}
 
 	// Publish the External Table IOPS policy once for native IndexBuilder
 	// readers. Reader config watchers must not rewrite this startup policy.

--- a/internal/datanode/index/scheduler.go
+++ b/internal/datanode/index/scheduler.go
@@ -219,8 +219,9 @@ func NewTaskScheduler(ctx context.Context) *TaskScheduler {
 func getStateFromError(err error) indexpb.JobState {
 	if errors.Is(err, errCancel) {
 		return indexpb.JobState_JobStateRetry
-	} else if errors.Is(err, merr.ErrIoKeyNotFound) || errors.Is(err, merr.ErrSegcoreUnsupported) {
-		// NoSuchKey or unsupported error
+	} else if errors.Is(err, merr.ErrIoKeyNotFound) || errors.Is(err, merr.ErrSegcoreUnsupported) ||
+		merr.IsSegcoreDataFormatBroken(err) {
+		// NoSuchKey, unsupported, or malformed persisted data cannot be fixed by retrying.
 		return indexpb.JobState_JobStateFailed
 	} else if errors.Is(err, merr.ErrSegcorePretendFinished) {
 		return indexpb.JobState_JobStateFinished

--- a/internal/datanode/index/scheduler_test.go
+++ b/internal/datanode/index/scheduler_test.go
@@ -33,8 +33,23 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/workerpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/hardware"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
+
+func TestGetStateFromError(t *testing.T) {
+	t.Run("data format broken is terminal", func(t *testing.T) {
+		assert.Equal(t, indexpb.JobState_JobStateFailed, getStateFromError(merr.SegcoreError(2024, "malformed vector data")))
+	})
+
+	t.Run("generic segcore error still retries", func(t *testing.T) {
+		assert.Equal(t, indexpb.JobState_JobStateRetry, getStateFromError(merr.SegcoreError(2001, "unexpected")))
+	})
+
+	t.Run("transient segcore error still retries", func(t *testing.T) {
+		assert.Equal(t, indexpb.JobState_JobStateRetry, getStateFromError(merr.SegcoreError(2045, "transient storage error")))
+	})
+}
 
 type fakeTaskState int
 

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -33,6 +33,7 @@ import (
 	"context"
 	"encoding/base64"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 	"unsafe"
@@ -586,6 +587,29 @@ func InitArrowReaderConfig(params *paramtable.ComponentParam) error {
 	}
 	status := C.InitArrowReaderConfig(arrowReaderConfig)
 	return HandleCStatus(&status, "InitArrowReaderConfig failed")
+}
+
+// InitExternalVectorNullPolicy publishes the process-wide normalization policy
+// used by both QueryNode external reads and DataNode index builds. The setting
+// is intentionally startup-only so one task cannot observe different semantics
+// across record batches.
+func InitExternalVectorNullPolicy(params *paramtable.ComponentParam) error {
+	policy := strings.ToLower(strings.TrimSpace(params.CommonCfg.ExternalVectorPartialNullPolicy.GetValue()))
+	switch policy {
+	case "error":
+		C.SetExternalVectorPartialNullAsRowNull(C.bool(false))
+	case "null":
+		C.SetExternalVectorPartialNullAsRowNull(C.bool(true))
+	default:
+		return merr.WrapErrParameterInvalidMsg(
+			"common.storage.externalVector.partialNullPolicy must be one of [error, null], got %q",
+			params.CommonCfg.ExternalVectorPartialNullPolicy.GetValue())
+	}
+	return nil
+}
+
+func externalVectorPartialNullAsRowNullEnabled() bool {
+	return bool(C.GetExternalVectorPartialNullAsRowNull())
 }
 
 var coreParamCallbackInitOnce sync.Once

--- a/internal/util/initcore/init_core_test.go
+++ b/internal/util/initcore/init_core_test.go
@@ -160,6 +160,29 @@ func TestInitArrowReaderConfig(t *testing.T) {
 	assert.NoError(t, InitArrowReaderConfig(pt))
 }
 
+func TestInitExternalVectorNullPolicy(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	defer pt.Reset(pt.CommonCfg.ExternalVectorPartialNullPolicy.Key)
+	defer func() {
+		_ = pt.Save(pt.CommonCfg.ExternalVectorPartialNullPolicy.Key, "error")
+		assert.NoError(t, InitExternalVectorNullPolicy(pt))
+	}()
+
+	assert.NoError(t, pt.Save(pt.CommonCfg.ExternalVectorPartialNullPolicy.Key, "error"))
+	assert.NoError(t, InitExternalVectorNullPolicy(pt))
+	assert.False(t, externalVectorPartialNullAsRowNullEnabled())
+
+	assert.NoError(t, pt.Save(pt.CommonCfg.ExternalVectorPartialNullPolicy.Key, " NULL "))
+	assert.NoError(t, InitExternalVectorNullPolicy(pt))
+	assert.True(t, externalVectorPartialNullAsRowNullEnabled())
+
+	assert.NoError(t, pt.Save(pt.CommonCfg.ExternalVectorPartialNullPolicy.Key, "zero"))
+	err := InitExternalVectorNullPolicy(pt)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+}
+
 func TestInitLoonReaderConfigRejectsOutOfRangePoolSize(t *testing.T) {
 	paramtable.Init()
 	pt := paramtable.Get()

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -181,6 +181,9 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if err := InitExternalVectorNullPolicy(paramtable.Get()); err != nil {
+		return err
+	}
 
 	localDataRootPath := pathutil.GetPath(pathutil.LocalChunkPath, nodeID)
 

--- a/pkg/util/merr/segcore.go
+++ b/pkg/util/merr/segcore.go
@@ -56,6 +56,21 @@ type segcoreClass struct {
 	retriable bool
 }
 
+// segcoreErrorCode preserves the exact C++ ErrorCode without changing the
+// client-visible merr code projected by the wrapped sentinel.
+type segcoreErrorCode struct {
+	code int32
+	err  error
+}
+
+func (e *segcoreErrorCode) Error() string {
+	return e.err.Error()
+}
+
+func (e *segcoreErrorCode) Unwrap() error {
+	return e.err
+}
+
 // segcoreCodeTable is the registry of known C++ segcore error codes. Codes
 // absent here fall back to ErrSegcore (see classifySegcoreError).
 //
@@ -179,7 +194,15 @@ func classifySegcoreError(code int32, msg string) error {
 	if msg != "" {
 		err = errors.Wrap(err, msg)
 	}
-	return err
+	return &segcoreErrorCode{code: code, err: err}
+}
+
+// IsSegcoreDataFormatBroken reports whether err originated from the C++
+// DataFormatBroken (2024) error. The exact identity is intentionally separate
+// from the client-visible merr code, which remains ErrSegcore for compatibility.
+func IsSegcoreDataFormatBroken(err error) bool {
+	var segcoreErr *segcoreErrorCode
+	return errors.As(err, &segcoreErr) && segcoreErr.code == 2024
 }
 
 // IsSegcoreSignal reports whether a segcore error code is a control-flow signal

--- a/pkg/util/merr/segcore_test.go
+++ b/pkg/util/merr/segcore_test.go
@@ -142,6 +142,14 @@ func TestSegcoreErrorClassification(t *testing.T) {
 		assert.Equal(t, ErrSegcore.code(), Status(SegcoreError(9999, "x")).GetCode())
 	})
 
+	t.Run("data_format_broken_identity", func(t *testing.T) {
+		err := SegcoreError(2024, "malformed vector data")
+		assert.True(t, IsSegcoreDataFormatBroken(err))
+		assert.False(t, IsSegcoreDataFormatBroken(SegcoreError(2001, "unexpected")))
+		assert.ErrorIs(t, err, ErrSegcore)
+		assert.Equal(t, ErrSegcore.code(), Status(err).GetCode())
+	})
+
 	t.Run("empty_message", func(t *testing.T) {
 		err := SegcoreError(2000, "")
 		assert.ErrorIs(t, err, ErrSegcore)

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -312,11 +312,12 @@ type commonConfig struct {
 	UseLoonFFI                           ParamItem `refreshable:"true"`
 	EnableGrowingSourceFlush             ParamItem `refreshable:"false"`
 
-	StoragePathPrefix        ParamItem `refreshable:"false"`
-	StorageZstdConcurrency   ParamItem `refreshable:"false"`
-	StorageReadRetryAttempts ParamItem `refreshable:"true"`
-	StorageIopsInitialRate   ParamItem `refreshable:"false"`
-	StorageIopsMaxRate       ParamItem `refreshable:"false"`
+	StoragePathPrefix               ParamItem `refreshable:"false"`
+	StorageZstdConcurrency          ParamItem `refreshable:"false"`
+	StorageReadRetryAttempts        ParamItem `refreshable:"true"`
+	StorageIopsInitialRate          ParamItem `refreshable:"false"`
+	StorageIopsMaxRate              ParamItem `refreshable:"false"`
+	ExternalVectorPartialNullPolicy ParamItem `refreshable:"false"`
 
 	TraceLogMode              ParamItem `refreshable:"true"`
 	BloomFilterEnabled        ParamItem `refreshable:"false"`
@@ -1236,6 +1237,17 @@ The default value is 1, which is enough for most cases.`,
 		Export:       false,
 	}
 	p.StorageReadRetryAttempts.Init(base.mgr)
+
+	p.ExternalVectorPartialNullPolicy = ParamItem{
+		Key:          "common.storage.externalVector.partialNullPolicy",
+		Version:      "3.0.1",
+		DefaultValue: "error",
+		Doc: `Policy for parent-valid external dense-vector rows containing a mix of valid and null child elements.
+Options: error, null. error rejects the row as malformed input; null promotes the whole row to a row-level null when the field is nullable.
+Rows whose child elements are all null are always promoted to row-level null for nullable fields, regardless of this setting.`,
+		Export: false,
+	}
+	p.ExternalVectorPartialNullPolicy.Init(base.mgr)
 
 	p.StorageIopsInitialRate = ParamItem{
 		Key:          "common.storage.iops.initialRate",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1245,7 +1245,7 @@ The default value is 1, which is enough for most cases.`,
 		Doc: `Policy for parent-valid external dense-vector rows containing a mix of valid and null child elements.
 Options: error, null. error rejects the row as malformed input; null promotes the whole row to a row-level null when the field is nullable.
 Rows whose child elements are all null are always promoted to row-level null for nullable fields, regardless of this setting.`,
-		Export: false,
+		Export: true,
 	}
 	p.ExternalVectorPartialNullPolicy.Init(base.mgr)
 

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -142,6 +142,11 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, int32(16), Params.StorageReaderThreadPoolSize.GetAsInt32())
 		assert.Equal(t, int64(536870912), Params.IndexBuildReadWindowBytes.GetAsInt64())
 
+		defer params.Reset(Params.ExternalVectorPartialNullPolicy.Key)
+		assert.Equal(t, "error", Params.ExternalVectorPartialNullPolicy.GetValue())
+		params.Save(Params.ExternalVectorPartialNullPolicy.Key, "null")
+		assert.Equal(t, "null", Params.ExternalVectorPartialNullPolicy.GetValue())
+
 		assert.Equal(t, Params.GracefulTime.GetAsInt64(), int64(DefaultGracefulTime))
 		t.Logf("default grafeful time = %d", Params.GracefulTime.GetAsInt64())
 


### PR DESCRIPTION
issue: #52967
pr: #52976

## What changed

- Normalize an all-null child vector to a row-level null for nullable dense vector fields.
- Add `common.storage.externalVector.partialNullPolicy` (`error` by default, or `null`) for partially-null child vectors.
- Keep non-nullable vector fields strict and reject any child null.
- Wire the startup-only policy into DataNode and QueryNode.
- Use Arrow bitmap counting and skip per-row scans when the child array has no nulls.
- Rebase parent validity bitmaps for sliced Arrow arrays before constructing offset-zero output.
- Treat the exact C++ DataFormatBroken (2024) error as a terminal index-build failure.

## Behavior

| Field / row | Result |
| --- | --- |
| Nullable, all child values null | Convert to row-level null |
| Nullable, partially null, policy `error` | Return DataFormatBroken (2024) |
| Nullable, partially null, policy `null` | Convert to row-level null |
| Non-nullable, any child null | Return DataFormatBroken (2024) |

VectorArray inner values are intentionally excluded from coercion.

## Verification

- Clean GCC 12.3 build of C++ `all_tests` completed and linked successfully.
- GCC 12 C++ `NormalizeVectorArraysToFixedSizeBinary.*`: 21/21 passed, including sliced parent validity and LIST/FIXED_SIZE_LIST partial-null cases.
- Go paramtable and initcore policy tests passed with required Milvus test tags/gcflags.
- Go `pkg/util/merr` and full `internal/datanode/index` test packages passed with required Milvus test tags/gcflags.
- DataNode index package compiled successfully against the GCC 12 core library.
- GCC 11 is blocked by an unrelated existing constexpr/libstdc++ incompatibility in `storage/TypesTest.cpp`; GCC 12 resolves it.

## Scope note

Only DataFormatBroken (2024) is terminal in the index scheduler. Generic UnexpectedError (2001) and transient StorageTransientError (2045) remain retryable, and the client-visible ErrSegcore wire code is unchanged.