### PR TITLE
fix: [3.0] honor checkpoint row count for V3 segments (#52961)

### DIFF
--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -1659,7 +1659,23 @@ func UpdateCheckPointOperator(segmentID int64, checkpoints []*datapb.CheckPoint,
 
 		// update segments num rows
 		count := segmentutil.CalcRowCountFromBinLog(segment.SegmentInfo)
-		if count > 0 {
+		// V3 segments carry the authoritative cumulative row count on the
+		// checkpoint (FlushedRows + batchRows maintained on the writer). Their
+		// in-memory binlog arrays are a pass-through cache that may be empty
+		// (V3 recovery) or delta-only (growing source flush), so the
+		// array-derived count must never override the checkpoint.
+		if segment.GetStorageVersion() == storage.StorageV3 {
+			if cpNumRows > 0 {
+				if cpNumRows != count && count > 0 {
+					mlog.Info(modPack.meta.ctx, "check point reported row count inconsistent with binlog row count",
+						mlog.Int64("segmentID", segmentID),
+						mlog.Int64("binlog reported (wrong)", cpNumRows),
+						mlog.Int64("segment binlog row count (correct)", count))
+				}
+				segment.NumOfRows = cpNumRows
+			}
+			// no valid checkpoint: keep the current NumOfRows
+		} else if count > 0 {
 			if cpNumRows != count {
 				mlog.Info(context.TODO(), "check point reported row count inconsistent with binlog row count",
 					mlog.Int64("segmentID", segmentID),
@@ -1667,9 +1683,6 @@ func UpdateCheckPointOperator(segmentID int64, checkpoints []*datapb.CheckPoint,
 					mlog.Int64("segment binlog row count (correct)", count))
 			}
 			segment.NumOfRows = count
-		} else if cpNumRows > 0 && segment.GetStorageVersion() == storage.StorageV3 {
-			// V3 storage: binlogs are empty, use checkpoint's NumOfRows
-			segment.NumOfRows = cpNumRows
 		}
 
 		return true

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -978,13 +978,19 @@ func (s *Server) GetRecoveryInfo(ctx context.Context, req *datapb.GetRecoveryInf
 			segment2Binlogs[id] = append(segment2Binlogs[id], fieldBinlogs)
 		}
 
-		if newCount := segmentutil.CalcRowCountFromBinLog(segment.SegmentInfo); newCount != segment.NumOfRows && newCount > 0 {
-			mlog.Warn(context.TODO(), "segment row number meta inconsistent with bin log row count and will be corrected",
-				mlog.Int64("segmentID", segment.GetID()),
-				mlog.Int64("segment meta row count (wrong)", segment.GetNumOfRows()),
-				mlog.Int64("segment bin log row count (correct)", newCount))
-			segmentsNumOfRows[id] = newCount
+		if segment.GetStorageVersion() != storage.StorageV3 {
+			if newCount := segmentutil.CalcRowCountFromBinLog(segment.SegmentInfo); newCount != segment.NumOfRows && newCount > 0 {
+				mlog.Warn(context.TODO(), "segment row number meta inconsistent with bin log row count and will be corrected",
+					mlog.Int64("segmentID", segment.GetID()),
+					mlog.Int64("segment meta row count (wrong)", segment.GetNumOfRows()),
+					mlog.Int64("segment bin log row count (correct)", newCount))
+				segmentsNumOfRows[id] = newCount
+			} else {
+				segmentsNumOfRows[id] = segment.NumOfRows
+			}
 		} else {
+			// V3 segments: NumOfRows is authoritative (advanced from the writer
+			// checkpoint); binlog arrays may be empty or delta-only.
 			segmentsNumOfRows[id] = segment.NumOfRows
 		}
 
@@ -1088,14 +1094,15 @@ func (s *Server) GetRecoveryInfoV2(ctx context.Context, req *datapb.GetRecoveryI
 		if len(binlogs) == 0 && segment.GetLevel() != datapb.SegmentLevel_L0 && segment.GetManifestPath() == "" {
 			continue
 		}
-		rowCount := segmentutil.CalcRowCountFromBinLog(segment.SegmentInfo)
-		if rowCount != segment.NumOfRows && rowCount > 0 {
-			mlog.Warn(context.TODO(), "segment row number meta inconsistent with bin log row count and will be corrected",
-				mlog.Int64("segmentID", segment.GetID()),
-				mlog.Int64("segment meta row count (wrong)", segment.GetNumOfRows()),
-				mlog.Int64("segment bin log row count (correct)", rowCount))
-		} else {
-			rowCount = segment.NumOfRows
+		rowCount := segment.NumOfRows
+		if segment.GetStorageVersion() != storage.StorageV3 {
+			if binlogCount := segmentutil.CalcRowCountFromBinLog(segment.SegmentInfo); binlogCount != segment.NumOfRows && binlogCount > 0 {
+				mlog.Warn(context.TODO(), "segment row number meta inconsistent with bin log row count and will be corrected",
+					mlog.Int64("segmentID", segment.GetID()),
+					mlog.Int64("segment meta row count (wrong)", segment.GetNumOfRows()),
+					mlog.Int64("segment bin log row count (correct)", binlogCount))
+				rowCount = binlogCount
+			}
 		}
 
 		segmentInfos = append(segmentInfos, &datapb.SegmentInfo{

--- a/internal/flushcommon/syncmgr/meta_writer.go
+++ b/internal/flushcommon/syncmgr/meta_writer.go
@@ -241,10 +241,10 @@ func (b *brokerMetaWriter) UpdateGrowingSourceSync(ctx context.Context, task *Gr
 		SegmentID:           task.segmentID,
 		CollectionID:        task.collectionID,
 		PartitionID:         task.partitionID,
-		Field2BinlogPaths:   insertFieldBinlogs,
-		Field2StatslogPaths: statsFieldBinlogs,
-		Field2Bm25LogPaths:  bm25FieldBinlogs,
-		Deltalogs:           deltaFieldBinlogs,
+		Field2BinlogPaths:   nil,
+		Field2StatslogPaths: nil,
+		Field2Bm25LogPaths:  nil,
+		Deltalogs:           nil,
 		CheckPoints:         checkPoints,
 		StartPositions:      startPos,
 		Flushed:             task.IsFlush(),
@@ -254,7 +254,13 @@ func (b *brokerMetaWriter) UpdateGrowingSourceSync(ctx context.Context, task *Gr
 		StorageVersion:      segment.GetStorageVersion(),
 		WithFullBinlogs:     true,
 		ManifestPath:        task.manifestPath,
-		Stats:               stats,
+		// V3 growing-source flush ships no per-FieldBinlog arrays: the LOON
+		// manifest is the authoritative source of paths, and the cumulative
+		// Statistics below carries the aggregates. The in-memory binlog arrays
+		// are empty after a V3 recovery, so shipping them would replace
+		// DataCoord's segment arrays with a delta-only list and break its
+		// cumulative row-count accounting (see UpdateCheckPointOperator).
+		Stats: stats,
 	}
 
 	err := retry.Handle(ctx, func() (bool, error) {

--- a/internal/flushcommon/syncmgr/meta_writer_test.go
+++ b/internal/flushcommon/syncmgr/meta_writer_test.go
@@ -179,27 +179,14 @@ func (s *MetaWriterSuite) TestGrowingSourceSyncPersistsColumnGroupBinlogs() {
 			s.True(req.GetWithFullBinlogs())
 			s.EqualValues(storage.StorageV3, req.GetStorageVersion())
 			s.Equal("manifest", req.GetManifestPath())
-			s.Len(req.GetField2BinlogPaths(), 2)
-			s.EqualValues(0, req.GetField2BinlogPaths()[0].GetFieldID())
-			s.EqualValues([]int64{100}, req.GetField2BinlogPaths()[0].GetChildFields())
-			s.Equal("parquet", req.GetField2BinlogPaths()[0].GetFormat())
-			s.Len(req.GetField2BinlogPaths()[0].GetBinlogs(), 1)
-			s.EqualValues(10, req.GetField2BinlogPaths()[0].GetBinlogs()[0].GetEntriesNum())
-			s.EqualValues(101, req.GetField2BinlogPaths()[0].GetBinlogs()[0].GetTimestampFrom())
-			s.EqualValues(200, req.GetField2BinlogPaths()[0].GetBinlogs()[0].GetTimestampTo())
-			s.EqualValues(1000, req.GetField2BinlogPaths()[0].GetBinlogs()[0].GetMemorySize())
-			s.EqualValues(2000, req.GetField2BinlogPaths()[0].GetBinlogs()[0].GetLogID())
-			s.EqualValues(0, req.GetField2BinlogPaths()[0].GetBinlogs()[0].GetFieldNullCounts()[100])
-			s.EqualValues(101, req.GetField2BinlogPaths()[1].GetFieldID())
-			s.EqualValues([]int64{101}, req.GetField2BinlogPaths()[1].GetChildFields())
-			s.Len(req.GetField2StatslogPaths(), 1)
-			s.EqualValues(100, req.GetField2StatslogPaths()[0].GetFieldID())
-			s.Equal("stats/100/31", req.GetField2StatslogPaths()[0].GetBinlogs()[0].GetLogPath())
-			s.Len(req.GetDeltalogs(), 1)
-			s.Equal("delta/41", req.GetDeltalogs()[0].GetBinlogs()[0].GetLogPath())
-			s.Len(req.GetField2Bm25LogPaths(), 1)
-			s.EqualValues(102, req.GetField2Bm25LogPaths()[0].GetFieldID())
-			s.Equal("bm25/102/51", req.GetField2Bm25LogPaths()[0].GetBinlogs()[0].GetLogPath())
+			// V3 growing-source flush ships no per-FieldBinlog arrays: the
+			// manifest is the authoritative source of paths and the Statistics
+			// carries the aggregates.
+			s.Empty(req.GetField2BinlogPaths())
+			s.Empty(req.GetField2StatslogPaths())
+			s.Empty(req.GetField2Bm25LogPaths())
+			s.Empty(req.GetDeltalogs())
+			s.NotNil(req.GetStats())
 			return nil
 		})
 
@@ -273,14 +260,14 @@ func (s *MetaWriterSuite) TestGrowingSourceSyncAppendsColumnGroupBinlogs() {
 		func(ctx context.Context, req *datapb.SaveBinlogPathsRequest) error {
 			s.True(req.GetWithFullBinlogs())
 			s.Equal("manifest", req.GetManifestPath())
-			s.Len(req.GetField2BinlogPaths(), 4)
-			s.EqualValues(0, req.GetField2BinlogPaths()[0].GetFieldID())
-			s.EqualValues([]int64{100}, req.GetField2BinlogPaths()[0].GetChildFields())
-			s.Equal("parquet", req.GetField2BinlogPaths()[0].GetFormat())
-			s.EqualValues(5, req.GetField2BinlogPaths()[0].GetBinlogs()[0].GetEntriesNum())
-			s.EqualValues(101, req.GetField2BinlogPaths()[1].GetFieldID())
-			s.EqualValues(10, req.GetField2BinlogPaths()[2].GetBinlogs()[0].GetEntriesNum())
-			s.EqualValues(30, req.GetField2BinlogPaths()[2].GetBinlogs()[0].GetTimestampFrom())
+			// V3 growing-source flush ships no per-FieldBinlog arrays: the
+			// manifest is the authoritative source of paths and the Statistics
+			// carries the aggregates.
+			s.Empty(req.GetField2BinlogPaths())
+			s.Empty(req.GetField2StatslogPaths())
+			s.Empty(req.GetField2Bm25LogPaths())
+			s.Empty(req.GetDeltalogs())
+			s.NotNil(req.GetStats())
 			return nil
 		})
 

--- a/internal/util/segmentutil/utils.go
+++ b/internal/util/segmentutil/utils.go
@@ -3,6 +3,7 @@ package segmentutil
 import (
 	"context"
 
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
@@ -12,6 +13,13 @@ import (
 // cloned copy, which is `newSeg`.
 // Note that `segCloned` should be a copied version of `seg`.
 func ReCalcRowCount(seg, segCloned *datapb.SegmentInfo) {
+	// V3 segments resolve row counts via SegmentInfo.NumOfRows (advanced from
+	// the writer checkpoint) and Statistics; their binlog arrays are a
+	// pass-through cache that may be empty (recovery) or delta-only (growing
+	// source flush), so array-derived counts are never authoritative for them.
+	if seg.GetStorageVersion() == storage.StorageV3 {
+		return
+	}
 	// `segment` is not mutated but only cloned above and is safe to be referred here.
 	if newCount := CalcRowCountFromBinLog(seg); newCount != seg.GetNumOfRows() && newCount > 0 {
 		mlog.Warn(context.TODO(), "segment row number meta inconsistent with bin log row count and will be corrected",


### PR DESCRIPTION
Cherry-pick from master
pr: #52961
Related to #52949

**What**

V3 segments resolve paths via the LOON manifest and cumulative row counts via SegmentInfo.NumOfRows (advanced from the writer checkpoint) and Statistics. Their in-memory binlog arrays are a pass-through cache that may be empty after a V3 recovery or delta-only after a growing-source flush, so array-derived row counts are never authoritative for them.

Several DataCoord sites still trusted CalcRowCountFromBinLog / ReCalcRowCount as the source of truth. After a streamingnode failover, a growing-source flush ships delta-only binlogs with a cumulative checkpoint (e.g. 3043 vs 7592), so UpdateCheckPointOperator overwrote the correct cumulative NumOfRows with the delta count and emitted "check point reported row count inconsistent with binlog row count", under-reporting the segment rows and repeatedly failing sort compaction.

**Fix**

- UpdateCheckPointOperator: for V3 segments always take the checkpoint's NumOfRows when present; keep the binlog-array sum only for the diagnostic log.
- ReCalcRowCount: skip V3 segments (covers GetSegmentInfo and the catalog persist/drop paths).
- GetRecoveryInfo / GetRecoveryInfoV2: skip binlog-array row-count correction for V3 segments.
- Growing-source flush (UpdateGrowingSourceSync) no longer ships per-field binlog arrays; DataCoord receives only the manifest path, the cumulative Statistics and the checkpoint, so its V3 segment arrays can no longer be replaced by a delta-only list.