### PR TITLE
enhance: [3.0] extract proxy fieldvalidator package (#52840)

### DIFF
--- a/internal/proxy/fieldvalidator/OWNERS
+++ b/internal/proxy/fieldvalidator/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - SpadeA-Tang
+  - xiaocai2333
+  - czs007
+  - congqixia
+
+approvers:
+  - maintainers

--- a/internal/proxy/fieldvalidator/README.md
+++ b/internal/proxy/fieldvalidator/README.md
@@ -1,0 +1,98 @@
+# FieldValidator Package
+
+The `fieldvalidator` package validates Milvus `FieldData` payloads (insert /
+upsert rows) and fills null/default values. It is a pure leaf: it imports only
+`pkg/v3` and protobuf types and has **no dependency on the proxy root package or
+any sibling proxy sub-package**.
+
+## Overview
+
+Before DML rows are packed and dispatched, the proxy must guarantee the payload
+is well-formed:
+
+- **Aligned**: every field has the same row count (`CheckAligned`).
+- **Type-correct**: each field's data matches its schema type — vector dims,
+  varchar/array length and capacity, integer overflow, NaN in float vectors,
+  JSON/timestamptz constraints
+  (`ValidateUtil.Validate` with `With*Check` options).
+- **Complete**: nullable / defaultable fields are expanded so downstream
+  consumers always see dense payloads (`FillWithNullValue`,
+  `FillWithDefaultValue`).
+
+This package is the "VALIDATE" component of the proxy extraction plan (issue
+#44761); it was extracted verbatim from the proxy root package
+(`validate_util.go`).
+
+## Responsibilities
+
+1. **`ValidateUtil`** — a configurable validator built with functional options
+   (`NewValidateUtil(WithNANCheck(), WithMaxLenCheck(), WithOverflowCheck(),
+   WithMaxCapCheck())`). Its `Validate` method checks a batch of `FieldData`
+   against a `*typeutil.SchemaHelper`.
+2. **`CheckAligned`** — cheap row-count alignment guard run before the full
+   validation to avoid index-out-of-range panics.
+3. **`FillWithNullValue` / `FillWithDefaultValue`** — expand compact `ValidData`
+   payloads into dense field data, honoring nullable/defaultable schemas and
+   nested (ArrayOfVector / struct) fields.
+4. **`ValidateGeometryFieldSearchResult`** — geometry result sanity check used
+   by the search/query reduce path.
+5. **`ValidateAutoIndexMmapConfig`** — AutoIndex mmap config compatibility check.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────┐
+│               fieldvalidator                 │
+│                                              │
+│   ValidateUtil ── options ──► Validate()     │
+│        │                                     │
+│        └──► CheckAligned()                   │
+│                                              │
+│   FillWithNullValue / FillWithDefaultValue   │
+│   ValidateGeometryFieldSearchResult          │
+│   ValidateAutoIndexMmapConfig                │
+└──────────────────────────────────────────────┘
+```
+
+### Key types
+
+```go
+type ValidateUtil struct{ ... }
+
+type ValidateOption func(*ValidateUtil)
+
+func NewValidateUtil(opts ...ValidateOption) *ValidateUtil
+
+func (v *ValidateUtil) Validate(data []*schemapb.FieldData,
+    helper *typeutil.SchemaHelper, numRows uint64) error
+
+func (v *ValidateUtil) CheckAligned(data []*schemapb.FieldData,
+    schema *typeutil.SchemaHelper, numRows uint64) error
+```
+
+## Usage
+
+- **Insert / upsert tasks** call
+  `fieldvalidator.NewValidateUtil(fieldvalidator.WithNANCheck(), ...)` then
+  `Validate(...)` on the request's `FieldData`; upsert additionally uses
+  `CheckAligned` and `FillWith*` for nullable payloads.
+- **Search / query** call `fieldvalidator.ValidateGeometryFieldSearchResult` on
+  result field data in the reduce path.
+- **Index** calls `fieldvalidator.ValidateAutoIndexMmapConfig`.
+
+The package holds **no state** and reads config only through
+`paramtable.Get()` (never the proxy `Params` global), so every entry point is
+pure and unit-testable.
+
+## Testing
+
+`validate_util_test.go` is a package-local white-box suite (moved verbatim with
+the code) exercising every `check*` method, alignment, and fill path with
+`schemapb` data only — no coordinators, no mocks.
+
+## Related Components
+
+- **TASKS** (`internal/proxy/task_*.go`): the only consumers. Edges are one-way
+  (tasks → fieldvalidator).
+- **Proxy root** (`internal/proxy/`): `util.go` also calls
+  `ValidateAutoIndexMmapConfig`.

--- a/internal/proxy/fieldvalidator/validate_util.go
+++ b/internal/proxy/fieldvalidator/validate_util.go
@@ -1,4 +1,4 @@
-package proxy
+package fieldvalidator
 
 import (
 	"context"
@@ -20,40 +20,40 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
-type validateUtil struct {
+type ValidateUtil struct {
 	checkNAN      bool
 	checkMaxLen   bool
 	checkOverflow bool
 	checkMaxCap   bool
 }
 
-type validateOption func(*validateUtil)
+type ValidateOption func(*ValidateUtil)
 
-func withNANCheck() validateOption {
-	return func(v *validateUtil) {
+func WithNANCheck() ValidateOption {
+	return func(v *ValidateUtil) {
 		v.checkNAN = true
 	}
 }
 
-func withMaxLenCheck() validateOption {
-	return func(v *validateUtil) {
+func WithMaxLenCheck() ValidateOption {
+	return func(v *ValidateUtil) {
 		v.checkMaxLen = true
 	}
 }
 
-func withOverflowCheck() validateOption {
-	return func(v *validateUtil) {
+func WithOverflowCheck() ValidateOption {
+	return func(v *ValidateUtil) {
 		v.checkOverflow = true
 	}
 }
 
-func withMaxCapCheck() validateOption {
-	return func(v *validateUtil) {
+func WithMaxCapCheck() ValidateOption {
+	return func(v *ValidateUtil) {
 		v.checkMaxCap = true
 	}
 }
 
-func validateGeometryFieldSearchResult(fieldData **schemapb.FieldData) error {
+func ValidateGeometryFieldSearchResult(fieldData **schemapb.FieldData) error {
 	if *fieldData == nil || (*fieldData).GetScalars() == nil || (*fieldData).GetScalars().Data == nil {
 		return nil
 	}
@@ -99,13 +99,13 @@ func validateGeometryFieldSearchResult(fieldData **schemapb.FieldData) error {
 	return nil
 }
 
-func (v *validateUtil) apply(opts ...validateOption) {
+func (v *ValidateUtil) apply(opts ...ValidateOption) {
 	for _, opt := range opts {
 		opt(v)
 	}
 }
 
-func (v *validateUtil) Validate(data []*schemapb.FieldData, helper *typeutil.SchemaHelper, numRows uint64) error {
+func (v *ValidateUtil) Validate(data []*schemapb.FieldData, helper *typeutil.SchemaHelper, numRows uint64) error {
 	if helper == nil {
 		return merr.WrapErrServiceInternal("nil schema helper provided for Validation")
 	}
@@ -195,14 +195,14 @@ func (v *validateUtil) Validate(data []*schemapb.FieldData, helper *typeutil.Sch
 		return err
 	}
 
-	if err := v.checkAligned(data, helper, numRows); err != nil {
+	if err := v.CheckAligned(data, helper, numRows); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (v *validateUtil) checkAligned(data []*schemapb.FieldData, schema *typeutil.SchemaHelper, numRows uint64) error {
+func (v *ValidateUtil) CheckAligned(data []*schemapb.FieldData, schema *typeutil.SchemaHelper, numRows uint64) error {
 	errNumRowsMismatch := func(fieldName string, fieldNumRows uint64) error {
 		msg := fmt.Sprintf("the num_rows (%d) of field (%s) is not equal to passed num_rows (%d)", fieldNumRows, fieldName, numRows)
 		return merr.WrapErrParameterInvalid(numRows, fieldNumRows, msg)
@@ -214,7 +214,7 @@ func (v *validateUtil) checkAligned(data []*schemapb.FieldData, schema *typeutil
 	getExpectedVectorRows := func(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) uint64 {
 		validData := field.GetValidData()
 		if fieldSchema.GetNullable() && len(validData) > 0 {
-			return uint64(getValidNumber(validData))
+			return uint64(GetValidNumber(validData))
 		}
 		return numRows
 	}
@@ -455,7 +455,7 @@ func (v *validateUtil) checkAligned(data []*schemapb.FieldData, schema *typeutil
 //     will fill default_value when passed num_rows not equal to expected num_rows,
 //
 // after fillWithValue, only nullable field will has valid_data, the length of all data will be passed num_rows
-func (v *validateUtil) fillWithValue(data []*schemapb.FieldData, schema *typeutil.SchemaHelper, numRows int) error {
+func (v *ValidateUtil) fillWithValue(data []*schemapb.FieldData, schema *typeutil.SchemaHelper, numRows int) error {
 	for _, field := range data {
 		fieldSchema, err := schema.GetFieldFromName(field.GetFieldName())
 		if err != nil {
@@ -588,7 +588,7 @@ func FillWithNullValue(field *schemapb.FieldData, fieldSchema *schemapb.FieldSch
 }
 
 func fillVectorArrayNullValueImpl(array []*schemapb.VectorField, validData []bool, dim int64, elementType schemapb.DataType) ([]*schemapb.VectorField, error) {
-	n := getValidNumber(validData)
+	n := GetValidNumber(validData)
 	if len(array) != n {
 		return nil, merr.WrapErrParameterInvalid(n, len(array), "the length of field is wrong")
 	}
@@ -780,7 +780,7 @@ func FillWithDefaultValue(field *schemapb.FieldData, fieldSchema *schemapb.Field
 }
 
 func fillWithNullValueImpl[T any](array []T, validData []bool) ([]T, error) {
-	n := getValidNumber(validData)
+	n := GetValidNumber(validData)
 	if len(array) != n {
 		return nil, merr.WrapErrParameterInvalid(n, len(array), "the length of field is wrong")
 	}
@@ -799,7 +799,7 @@ func fillWithNullValueImpl[T any](array []T, validData []bool) ([]T, error) {
 }
 
 func fillWithDefaultValueImpl[T any](array []T, value T, validData []bool) ([]T, error) {
-	n := getValidNumber(validData)
+	n := GetValidNumber(validData)
 	if len(array) != n {
 		return nil, merr.WrapErrParameterInvalid(n, len(array), "the length of field is wrong")
 	}
@@ -819,7 +819,7 @@ func fillWithDefaultValueImpl[T any](array []T, value T, validData []bool) ([]T,
 	return res, nil
 }
 
-func getValidNumber(validData []bool) int {
+func GetValidNumber(validData []bool) int {
 	res := 0
 	for _, v := range validData {
 		if v {
@@ -829,7 +829,7 @@ func getValidNumber(validData []bool) int {
 	return res
 }
 
-func (v *validateUtil) checkFloatVectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkFloatVectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	floatArray := field.GetVectors().GetFloatVector().GetData()
 	if floatArray == nil && !fieldSchema.GetNullable() {
 		msg := fmt.Sprintf("float vector field '%v' is illegal, array type mismatch", field.GetFieldName())
@@ -843,7 +843,7 @@ func (v *validateUtil) checkFloatVectorFieldData(field *schemapb.FieldData, fiel
 	return nil
 }
 
-func (v *validateUtil) checkFloat16VectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkFloat16VectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	float16VecArray := field.GetVectors().GetFloat16Vector()
 	if float16VecArray == nil {
 		if !fieldSchema.GetNullable() {
@@ -858,7 +858,7 @@ func (v *validateUtil) checkFloat16VectorFieldData(field *schemapb.FieldData, fi
 	return nil
 }
 
-func (v *validateUtil) checkBFloat16VectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkBFloat16VectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	bfloat16VecArray := field.GetVectors().GetBfloat16Vector()
 	if bfloat16VecArray == nil {
 		if !fieldSchema.GetNullable() {
@@ -873,7 +873,7 @@ func (v *validateUtil) checkBFloat16VectorFieldData(field *schemapb.FieldData, f
 	return nil
 }
 
-func (v *validateUtil) checkBinaryVectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkBinaryVectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	bVecArray := field.GetVectors().GetBinaryVector()
 	if bVecArray == nil && !fieldSchema.GetNullable() {
 		msg := fmt.Sprintf("binary vector field '%v' is illegal, array type mismatch", field.GetFieldName())
@@ -882,7 +882,7 @@ func (v *validateUtil) checkBinaryVectorFieldData(field *schemapb.FieldData, fie
 	return nil
 }
 
-func (v *validateUtil) checkSparseFloatVectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkSparseFloatVectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	if field.GetVectors() == nil || field.GetVectors().GetSparseFloatVector() == nil {
 		if !fieldSchema.GetNullable() {
 			msg := fmt.Sprintf("sparse float vector field '%v' is illegal, array type mismatch", field.GetFieldName())
@@ -894,7 +894,7 @@ func (v *validateUtil) checkSparseFloatVectorFieldData(field *schemapb.FieldData
 	return typeutil.ValidateSparseFloatRows(sparseRows...)
 }
 
-func (v *validateUtil) checkInt8VectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkInt8VectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	int8VecArray := field.GetVectors().GetInt8Vector()
 	if int8VecArray == nil {
 		if !fieldSchema.GetNullable() {
@@ -906,7 +906,7 @@ func (v *validateUtil) checkInt8VectorFieldData(field *schemapb.FieldData, field
 	return nil
 }
 
-func (v *validateUtil) checkVarCharFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkVarCharFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	strArr := field.GetScalars().GetStringData().GetData()
 	if strArr == nil && fieldSchema.GetDefaultValue() == nil && !fieldSchema.GetNullable() {
 		msg := fmt.Sprintf("varchar field '%v' is illegal, array type mismatch", field.GetFieldName())
@@ -933,7 +933,7 @@ func (v *validateUtil) checkVarCharFieldData(field *schemapb.FieldData, fieldSch
 	return nil
 }
 
-func (v *validateUtil) checkTextFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkTextFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	strArr := field.GetScalars().GetStringData().GetData()
 	if strArr == nil && fieldSchema.GetDefaultValue() == nil && !fieldSchema.GetNullable() {
 		msg := fmt.Sprintf("text field '%v' is illegal", field.GetFieldName())
@@ -944,7 +944,7 @@ func (v *validateUtil) checkTextFieldData(field *schemapb.FieldData, fieldSchema
 	return nil
 }
 
-func (v *validateUtil) checkGeometryFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkGeometryFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	geometryArray := field.GetScalars().GetGeometryWktData().GetData()
 	wkbArray := make([][]byte, len(geometryArray))
 	if geometryArray == nil && fieldSchema.GetDefaultValue() == nil && !fieldSchema.GetNullable() {
@@ -977,7 +977,7 @@ func (v *validateUtil) checkGeometryFieldData(field *schemapb.FieldData, fieldSc
 	return nil
 }
 
-func (v *validateUtil) checkJSONFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkJSONFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	jsonArray := field.GetScalars().GetJsonData().GetData()
 	if jsonArray == nil && fieldSchema.GetDefaultValue() == nil && !fieldSchema.GetNullable() {
 		msg := fmt.Sprintf("json field '%v' is illegal, array type mismatch", field.GetFieldName())
@@ -1001,7 +1001,7 @@ func (v *validateUtil) checkJSONFieldData(field *schemapb.FieldData, fieldSchema
 	return nil
 }
 
-func (v *validateUtil) checkIntegerFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkIntegerFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	data := field.GetScalars().GetIntData().GetData()
 	if data == nil && fieldSchema.GetDefaultValue() == nil && !fieldSchema.GetNullable() {
 		msg := fmt.Sprintf("field '%v' is illegal, array type mismatch", field.GetFieldName())
@@ -1020,7 +1020,7 @@ func (v *validateUtil) checkIntegerFieldData(field *schemapb.FieldData, fieldSch
 	return nil
 }
 
-func (v *validateUtil) checkLongFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkLongFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	data := field.GetScalars().GetLongData().GetData()
 	if data == nil && fieldSchema.GetDefaultValue() == nil && !fieldSchema.GetNullable() {
 		msg := fmt.Sprintf("field '%v' is illegal, array type mismatch", field.GetFieldName())
@@ -1030,7 +1030,7 @@ func (v *validateUtil) checkLongFieldData(field *schemapb.FieldData, fieldSchema
 	return nil
 }
 
-func (v *validateUtil) checkFloatFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkFloatFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	data := field.GetScalars().GetFloatData().GetData()
 	if data == nil && fieldSchema.GetDefaultValue() == nil && !fieldSchema.GetNullable() {
 		msg := fmt.Sprintf("field '%v' is illegal, array type mismatch", field.GetFieldName())
@@ -1044,7 +1044,7 @@ func (v *validateUtil) checkFloatFieldData(field *schemapb.FieldData, fieldSchem
 	return nil
 }
 
-func (v *validateUtil) checkDoubleFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkDoubleFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	data := field.GetScalars().GetDoubleData().GetData()
 	if data == nil && fieldSchema.GetDefaultValue() == nil && !fieldSchema.GetNullable() {
 		msg := fmt.Sprintf("field '%v' is illegal, array type mismatch", field.GetFieldName())
@@ -1058,7 +1058,7 @@ func (v *validateUtil) checkDoubleFieldData(field *schemapb.FieldData, fieldSche
 	return nil
 }
 
-func (v *validateUtil) checkArrayElement(array *schemapb.ArrayArray, field *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkArrayElement(array *schemapb.ArrayArray, field *schemapb.FieldSchema) error {
 	switch field.GetElementType() {
 	case schemapb.DataType_Bool:
 		for _, row := range array.GetData() {
@@ -1153,7 +1153,7 @@ func (v *validateUtil) checkArrayElement(array *schemapb.ArrayArray, field *sche
 	return nil
 }
 
-func (v *validateUtil) checkArrayFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkArrayFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	data := field.GetScalars().GetArrayData()
 	if data == nil {
 		elementTypeStr := fieldSchema.GetElementType().String()
@@ -1173,7 +1173,7 @@ func (v *validateUtil) checkArrayFieldData(field *schemapb.FieldData, fieldSchem
 	return v.checkArrayElement(data, fieldSchema)
 }
 
-func (v *validateUtil) checkArrayOfVectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+func (v *ValidateUtil) checkArrayOfVectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
 	data := field.GetVectors().GetVectorArray()
 	if data == nil {
 		elementTypeStr := fieldSchema.GetElementType().String()
@@ -1319,7 +1319,7 @@ func (v *validateUtil) checkArrayOfVectorFieldData(field *schemapb.FieldData, fi
 
 // checkTimestamptzFieldData validates the input string data for a Timestamptz field,
 // converts it into UTC Unix Microseconds (int64), and replaces the data in place.
-func (v *validateUtil) checkTimestamptzFieldData(field *schemapb.FieldData, timezone string) error {
+func (v *ValidateUtil) checkTimestamptzFieldData(field *schemapb.FieldData, timezone string) error {
 	// 1. Structural Check: Data must be present and must be a string array
 	scalarField := field.GetScalars()
 	if scalarField == nil || scalarField.GetStringData() == nil {
@@ -1405,8 +1405,8 @@ func verifyOverflowByRange(arr []int32, lb int64, ub int64) error {
 	return nil
 }
 
-func newValidateUtil(opts ...validateOption) *validateUtil {
-	v := &validateUtil{
+func NewValidateUtil(opts ...ValidateOption) *ValidateUtil {
+	v := &ValidateUtil{
 		checkNAN:      true,
 		checkMaxLen:   false,
 		checkOverflow: false,

--- a/internal/proxy/fieldvalidator/validate_util_test.go
+++ b/internal/proxy/fieldvalidator/validate_util_test.go
@@ -1,4 +1,4 @@
-package proxy
+package fieldvalidator
 
 import (
 	"fmt"
@@ -19,6 +19,39 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/testutils"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
+
+func autoGenDynamicFieldData(schema *schemapb.CollectionSchema, data [][]byte) *schemapb.FieldData {
+	fd := &schemapb.FieldData{
+		FieldName: common.MetaFieldName,
+		Type:      schemapb.DataType_JSON,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_JsonData{
+					JsonData: &schemapb.JSONArray{
+						Data: data,
+					},
+				},
+			},
+		},
+		IsDynamic: true,
+	}
+
+	// Only set ValidData when the $meta field is nullable or has a default value.
+	// For 2.5 collections (non-nullable, no default), CheckValidData expects
+	// len(ValidData)==0, so we must NOT set it.
+	for _, f := range schema.Fields {
+		if f.GetIsDynamic() && (f.GetNullable() || f.GetDefaultValue() != nil) {
+			validData := make([]bool, len(data))
+			for i := range validData {
+				validData[i] = true
+			}
+			fd.ValidData = validData
+			break
+		}
+	}
+
+	return fd
+}
 
 func Test_verifyLengthPerRow(t *testing.T) {
 	maxLength := 16
@@ -42,10 +75,10 @@ func Test_verifyLengthPerRow(t *testing.T) {
 	assert.Equal(t, 1, row)
 }
 
-func Test_validateUtil_checkVarCharFieldData(t *testing.T) {
+func Test_ValidateUtil_checkVarCharFieldData(t *testing.T) {
 	t.Run("type mismatch", func(t *testing.T) {
 		f := &schemapb.FieldData{}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		assert.Error(t, v.checkVarCharFieldData(f, nil))
 	})
 
@@ -66,7 +99,7 @@ func Test_validateUtil_checkVarCharFieldData(t *testing.T) {
 			DataType: schemapb.DataType_VarChar,
 		}
 
-		v := newValidateUtil(withMaxLenCheck())
+		v := NewValidateUtil(WithMaxLenCheck())
 
 		err := v.checkVarCharFieldData(f, fs)
 		assert.Error(t, err)
@@ -95,7 +128,7 @@ func Test_validateUtil_checkVarCharFieldData(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withMaxLenCheck())
+		v := NewValidateUtil(WithMaxLenCheck())
 
 		err := v.checkVarCharFieldData(f, fs)
 		assert.Error(t, err)
@@ -124,7 +157,7 @@ func Test_validateUtil_checkVarCharFieldData(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withMaxLenCheck())
+		v := NewValidateUtil(WithMaxLenCheck())
 
 		err := v.checkVarCharFieldData(f, fs)
 		assert.NoError(t, err)
@@ -153,7 +186,7 @@ func Test_validateUtil_checkVarCharFieldData(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err := v.checkVarCharFieldData(f, fs)
 		assert.NoError(t, err)
@@ -184,17 +217,17 @@ func Test_validateUtil_checkVarCharFieldData(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withMaxLenCheck())
+		v := NewValidateUtil(WithMaxLenCheck())
 
 		err := v.checkVarCharFieldData(f, fs)
 		assert.NoError(t, err)
 	})
 }
 
-func Test_validateUtil_checkTextFieldData(t *testing.T) {
+func Test_ValidateUtil_checkTextFieldData(t *testing.T) {
 	t.Run("type mismatch", func(t *testing.T) {
 		f := &schemapb.FieldData{}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		assert.Error(t, v.checkTextFieldData(f, nil))
 	})
 
@@ -215,7 +248,7 @@ func Test_validateUtil_checkTextFieldData(t *testing.T) {
 			DataType: schemapb.DataType_Text,
 		}
 
-		v := newValidateUtil(withMaxLenCheck())
+		v := NewValidateUtil(WithMaxLenCheck())
 
 		err := v.checkTextFieldData(f, fs)
 		assert.NoError(t, err)
@@ -244,7 +277,7 @@ func Test_validateUtil_checkTextFieldData(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withMaxLenCheck())
+		v := NewValidateUtil(WithMaxLenCheck())
 
 		err := v.checkTextFieldData(f, fs)
 		assert.NoError(t, err)
@@ -273,7 +306,7 @@ func Test_validateUtil_checkTextFieldData(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withMaxLenCheck())
+		v := NewValidateUtil(WithMaxLenCheck())
 
 		err := v.checkTextFieldData(f, fs)
 		assert.NoError(t, err)
@@ -302,22 +335,22 @@ func Test_validateUtil_checkTextFieldData(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err := v.checkTextFieldData(f, fs)
 		assert.NoError(t, err)
 	})
 }
 
-func Test_validateUtil_checkBinaryVectorFieldData(t *testing.T) {
+func Test_ValidateUtil_checkBinaryVectorFieldData(t *testing.T) {
 	t.Run("not binary vector", func(t *testing.T) {
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkBinaryVectorFieldData(&schemapb.FieldData{Field: &schemapb.FieldData_Scalars{}}, nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("normal case", func(t *testing.T) {
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkBinaryVectorFieldData(&schemapb.FieldData{Field: &schemapb.FieldData_Vectors{
 			Vectors: &schemapb.VectorField{
 				Dim: 128,
@@ -345,7 +378,7 @@ func Test_validateUtil_checkBinaryVectorFieldData(t *testing.T) {
 			DataType: schemapb.DataType_BinaryVector,
 			Nullable: false,
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkBinaryVectorFieldData(data, schema)
 		assert.Error(t, err)
 	})
@@ -366,20 +399,20 @@ func Test_validateUtil_checkBinaryVectorFieldData(t *testing.T) {
 			DataType: schemapb.DataType_BinaryVector,
 			Nullable: true,
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkBinaryVectorFieldData(data, schema)
 		assert.NoError(t, err)
 	})
 }
 
-func Test_validateUtil_checkFloatVectorFieldData(t *testing.T) {
+func Test_ValidateUtil_checkFloatVectorFieldData(t *testing.T) {
 	nb := 5
 	dim := int64(8)
 	data := testutils.GenerateFloatVectors(nb, int(dim))
 	invalidData := testutils.GenerateFloatVectorsWithInvalidData(nb, int(dim))
 
 	t.Run("not float vector", func(t *testing.T) {
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkFloatVectorFieldData(&schemapb.FieldData{Field: &schemapb.FieldData_Scalars{}}, nil)
 		assert.Error(t, err)
 	})
@@ -396,7 +429,7 @@ func Test_validateUtil_checkFloatVectorFieldData(t *testing.T) {
 				},
 			},
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		v.checkNAN = false
 		err := v.checkFloatVectorFieldData(f, nil)
 		assert.NoError(t, err)
@@ -414,7 +447,7 @@ func Test_validateUtil_checkFloatVectorFieldData(t *testing.T) {
 				},
 			},
 		}
-		v := newValidateUtil(withNANCheck())
+		v := NewValidateUtil(WithNANCheck())
 		err := v.checkFloatVectorFieldData(f, nil)
 		assert.Error(t, err)
 	})
@@ -431,7 +464,7 @@ func Test_validateUtil_checkFloatVectorFieldData(t *testing.T) {
 				},
 			},
 		}
-		v := newValidateUtil(withNANCheck())
+		v := NewValidateUtil(WithNANCheck())
 		err := v.checkFloatVectorFieldData(f, nil)
 		assert.NoError(t, err)
 	})
@@ -459,7 +492,7 @@ func Test_validateUtil_checkFloatVectorFieldData(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err = v.fillWithValue(data, h, 1)
 		assert.Error(t, err)
 	})
@@ -480,7 +513,7 @@ func Test_validateUtil_checkFloatVectorFieldData(t *testing.T) {
 			DataType: schemapb.DataType_FloatVector,
 			Nullable: false,
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkFloatVectorFieldData(data, schema)
 		assert.Error(t, err)
 	})
@@ -502,20 +535,20 @@ func Test_validateUtil_checkFloatVectorFieldData(t *testing.T) {
 			Nullable: true,
 		}
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkFloatVectorFieldData(data, schema)
 		assert.NoError(t, err)
 	})
 }
 
-func Test_validateUtil_checkFloat16VectorFieldData(t *testing.T) {
+func Test_ValidateUtil_checkFloat16VectorFieldData(t *testing.T) {
 	nb := 5
 	dim := int64(8)
 	data := testutils.GenerateFloat16Vectors(nb, int(dim))
 	invalidData := testutils.GenerateFloat16VectorsWithInvalidData(nb, int(dim))
 
 	t.Run("not float16 vector", func(t *testing.T) {
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkFloat16VectorFieldData(&schemapb.FieldData{Field: &schemapb.FieldData_Scalars{}}, nil)
 		assert.Error(t, err)
 	})
@@ -531,7 +564,7 @@ func Test_validateUtil_checkFloat16VectorFieldData(t *testing.T) {
 				},
 			},
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		v.checkNAN = false
 		err := v.checkFloat16VectorFieldData(f, nil)
 		assert.NoError(t, err)
@@ -548,7 +581,7 @@ func Test_validateUtil_checkFloat16VectorFieldData(t *testing.T) {
 				},
 			},
 		}
-		v := newValidateUtil(withNANCheck())
+		v := NewValidateUtil(WithNANCheck())
 		err := v.checkFloat16VectorFieldData(f, nil)
 		assert.Error(t, err)
 	})
@@ -564,7 +597,7 @@ func Test_validateUtil_checkFloat16VectorFieldData(t *testing.T) {
 				},
 			},
 		}
-		v := newValidateUtil(withNANCheck())
+		v := NewValidateUtil(WithNANCheck())
 		err := v.checkFloat16VectorFieldData(f, nil)
 		assert.NoError(t, err)
 	})
@@ -592,7 +625,7 @@ func Test_validateUtil_checkFloat16VectorFieldData(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err = v.fillWithValue(data, h, 1)
 		assert.Error(t, err)
 	})
@@ -613,7 +646,7 @@ func Test_validateUtil_checkFloat16VectorFieldData(t *testing.T) {
 			DataType: schemapb.DataType_Float16Vector,
 			Nullable: false,
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkFloat16VectorFieldData(data, schema)
 		assert.Error(t, err)
 	})
@@ -635,20 +668,20 @@ func Test_validateUtil_checkFloat16VectorFieldData(t *testing.T) {
 			Nullable: true,
 		}
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkFloat16VectorFieldData(data, schema)
 		assert.NoError(t, err)
 	})
 }
 
-func Test_validateUtil_checkBFloat16VectorFieldData(t *testing.T) {
+func Test_ValidateUtil_checkBFloat16VectorFieldData(t *testing.T) {
 	nb := 5
 	dim := int64(8)
 	data := testutils.GenerateBFloat16Vectors(nb, int(dim))
 	invalidData := testutils.GenerateBFloat16VectorsWithInvalidData(nb, int(dim))
 
 	t.Run("not bfloat16 vector", func(t *testing.T) {
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkBFloat16VectorFieldData(&schemapb.FieldData{Field: &schemapb.FieldData_Scalars{}}, nil)
 		assert.Error(t, err)
 	})
@@ -664,7 +697,7 @@ func Test_validateUtil_checkBFloat16VectorFieldData(t *testing.T) {
 				},
 			},
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		v.checkNAN = false
 		err := v.checkBFloat16VectorFieldData(f, nil)
 		assert.NoError(t, err)
@@ -681,7 +714,7 @@ func Test_validateUtil_checkBFloat16VectorFieldData(t *testing.T) {
 				},
 			},
 		}
-		v := newValidateUtil(withNANCheck())
+		v := NewValidateUtil(WithNANCheck())
 		err := v.checkBFloat16VectorFieldData(f, nil)
 		assert.Error(t, err)
 	})
@@ -697,7 +730,7 @@ func Test_validateUtil_checkBFloat16VectorFieldData(t *testing.T) {
 				},
 			},
 		}
-		v := newValidateUtil(withNANCheck())
+		v := NewValidateUtil(WithNANCheck())
 		err := v.checkBFloat16VectorFieldData(f, nil)
 		assert.NoError(t, err)
 	})
@@ -725,7 +758,7 @@ func Test_validateUtil_checkBFloat16VectorFieldData(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err = v.fillWithValue(data, h, 1)
 		assert.Error(t, err)
 	})
@@ -746,7 +779,7 @@ func Test_validateUtil_checkBFloat16VectorFieldData(t *testing.T) {
 			DataType: schemapb.DataType_BFloat16Vector,
 			Nullable: false,
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkBFloat16VectorFieldData(data, schema)
 		assert.Error(t, err)
 	})
@@ -768,18 +801,18 @@ func Test_validateUtil_checkBFloat16VectorFieldData(t *testing.T) {
 			Nullable: true,
 		}
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkBFloat16VectorFieldData(data, schema)
 		assert.NoError(t, err)
 	})
 }
 
-func Test_validateUtil_checkSparseFloatVectorFieldData(t *testing.T) {
+func Test_ValidateUtil_checkSparseFloatVectorFieldData(t *testing.T) {
 	nb := 5
 	sparseContents, dim := testutils.GenerateSparseFloatVectorsData(nb)
 
 	t.Run("not sparse float vector", func(t *testing.T) {
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkSparseFloatVectorFieldData(&schemapb.FieldData{Field: &schemapb.FieldData_Scalars{}}, nil)
 		assert.Error(t, err)
 	})
@@ -803,7 +836,7 @@ func Test_validateUtil_checkSparseFloatVectorFieldData(t *testing.T) {
 			Name:     "vec",
 			DataType: schemapb.DataType_SparseFloatVector,
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkSparseFloatVectorFieldData(fieldData, schema)
 		assert.NoError(t, err)
 	})
@@ -824,7 +857,7 @@ func Test_validateUtil_checkSparseFloatVectorFieldData(t *testing.T) {
 			DataType: schemapb.DataType_SparseFloatVector,
 			Nullable: false,
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkSparseFloatVectorFieldData(data, schema)
 		assert.Error(t, err)
 	})
@@ -846,19 +879,19 @@ func Test_validateUtil_checkSparseFloatVectorFieldData(t *testing.T) {
 			Nullable: true,
 		}
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkSparseFloatVectorFieldData(data, schema)
 		assert.NoError(t, err)
 	})
 }
 
-func Test_validateUtil_checkInt8VectorFieldData(t *testing.T) {
+func Test_ValidateUtil_checkInt8VectorFieldData(t *testing.T) {
 	nb := 5
 	dim := int64(8)
 	data := typeutil.Int8ArrayToBytes(testutils.GenerateInt8Vectors(nb, int(dim)))
 
 	t.Run("not int8 vector", func(t *testing.T) {
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkInt8VectorFieldData(&schemapb.FieldData{Field: &schemapb.FieldData_Scalars{}}, nil)
 		assert.Error(t, err)
 	})
@@ -879,7 +912,7 @@ func Test_validateUtil_checkInt8VectorFieldData(t *testing.T) {
 			Name:     "vec",
 			DataType: schemapb.DataType_Int8Vector,
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkInt8VectorFieldData(fieldData, schema)
 		assert.NoError(t, err)
 	})
@@ -900,7 +933,7 @@ func Test_validateUtil_checkInt8VectorFieldData(t *testing.T) {
 			DataType: schemapb.DataType_Int8Vector,
 			Nullable: false,
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkInt8VectorFieldData(fieldData, schema)
 		assert.Error(t, err)
 	})
@@ -922,13 +955,13 @@ func Test_validateUtil_checkInt8VectorFieldData(t *testing.T) {
 			Nullable: true,
 		}
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkInt8VectorFieldData(fieldData, schema)
 		assert.NoError(t, err)
 	})
 }
 
-func Test_validateUtil_checkAligned(t *testing.T) {
+func Test_ValidateUtil_checkAligned(t *testing.T) {
 	t.Run("float vector column not found", func(t *testing.T) {
 		data := []*schemapb.FieldData{
 			{
@@ -941,9 +974,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -967,9 +1000,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1009,9 +1042,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 1)
+		err = v.CheckAligned(data, h, 1)
 
 		assert.Error(t, err)
 	})
@@ -1051,9 +1084,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1093,9 +1126,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1114,9 +1147,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1140,9 +1173,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1180,9 +1213,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1220,9 +1253,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1260,9 +1293,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1281,9 +1314,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1307,9 +1340,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1347,9 +1380,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1387,9 +1420,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1427,9 +1460,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 1)
+		err = v.CheckAligned(data, h, 1)
 
 		assert.Error(t, err)
 	})
@@ -1448,9 +1481,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1474,9 +1507,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1514,9 +1547,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 1)
+		err = v.CheckAligned(data, h, 1)
 
 		assert.Error(t, err)
 	})
@@ -1554,9 +1587,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1594,9 +1627,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1614,9 +1647,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1640,9 +1673,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1680,9 +1713,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 1)
+		err = v.CheckAligned(data, h, 1)
 
 		assert.Error(t, err)
 	})
@@ -1720,9 +1753,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1760,9 +1793,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1790,9 +1823,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1831,9 +1864,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 100)
+		err = v.CheckAligned(data, h, 100)
 
 		assert.Error(t, err)
 	})
@@ -1876,9 +1909,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 3)
+		err = v.CheckAligned(data, h, 3)
 
 		assert.Error(t, err)
 	})
@@ -1992,9 +2025,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 10)
+		err = v.CheckAligned(data, h, 10)
 
 		assert.NoError(t, err)
 	})
@@ -2026,9 +2059,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 3)
+		err = v.CheckAligned(data, h, 3)
 
 		assert.NoError(t, err)
 	})
@@ -2070,9 +2103,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 4)
+		err = v.CheckAligned(data, h, 4)
 
 		assert.NoError(t, err)
 	})
@@ -2114,9 +2147,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 4)
+		err = v.CheckAligned(data, h, 4)
 
 		assert.Error(t, err)
 	})
@@ -2148,9 +2181,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 3)
+		err = v.CheckAligned(data, h, 3)
 
 		assert.NoError(t, err)
 	})
@@ -2182,9 +2215,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 3)
+		err = v.CheckAligned(data, h, 3)
 
 		assert.NoError(t, err)
 	})
@@ -2216,9 +2249,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 3)
+		err = v.CheckAligned(data, h, 3)
 
 		assert.NoError(t, err)
 	})
@@ -2277,7 +2310,7 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 				h, err := typeutil.CreateSchemaHelper(schema)
 				require.NoError(t, err)
 
-				err = newValidateUtil().checkAligned(data, h, 2)
+				err = NewValidateUtil().CheckAligned(data, h, 2)
 				require.Error(t, err)
 			})
 		}
@@ -2310,9 +2343,9 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 3)
+		err = v.CheckAligned(data, h, 3)
 
 		assert.NoError(t, err)
 	})
@@ -2338,15 +2371,15 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
-		err = v.checkAligned(data, h, 3)
+		err = v.CheckAligned(data, h, 3)
 
 		assert.NoError(t, err)
 	})
 }
 
-func Test_validateUtil_Validate(t *testing.T) {
+func Test_ValidateUtil_Validate(t *testing.T) {
 	paramtable.Init()
 
 	t.Run("nil schema", func(t *testing.T) {
@@ -2357,7 +2390,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err := v.Validate(data, nil, 100)
 
@@ -2472,7 +2505,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				err = newValidateUtil().Validate([]*schemapb.FieldData{tc.fieldData}, h, 2)
+				err = NewValidateUtil().Validate([]*schemapb.FieldData{tc.fieldData}, h, 2)
 				require.NoError(t, err)
 				assert.Equal(t, []bool{true, true}, tc.fieldData.GetValidData())
 			})
@@ -2511,7 +2544,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
@@ -2665,7 +2698,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withNANCheck(), withMaxLenCheck())
+		v := NewValidateUtil(WithNANCheck(), WithMaxLenCheck())
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
@@ -2819,7 +2852,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withNANCheck(), withMaxLenCheck())
+		v := NewValidateUtil(WithNANCheck(), WithMaxLenCheck())
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 		err = v.Validate(data, helper, 2)
@@ -2884,7 +2917,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 		err = v.Validate(data, helper, 2)
@@ -2922,7 +2955,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
@@ -2972,7 +3005,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withMaxCapCheck())
+		v := NewValidateUtil(WithMaxCapCheck())
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
@@ -3027,7 +3060,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withMaxCapCheck(), withMaxLenCheck())
+		v := NewValidateUtil(WithMaxCapCheck(), WithMaxLenCheck())
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
@@ -3072,7 +3105,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withMaxCapCheck())
+		v := NewValidateUtil(WithMaxCapCheck())
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
@@ -3122,7 +3155,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withMaxCapCheck())
+		v := NewValidateUtil(WithMaxCapCheck())
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
@@ -3179,7 +3212,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withMaxCapCheck())
+		v := NewValidateUtil(WithMaxCapCheck())
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 		err = v.Validate(data, helper, 1)
@@ -3234,7 +3267,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 		helper, err = typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
-		err = newValidateUtil(withMaxCapCheck()).Validate(data, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck()).Validate(data, helper, 1)
 		assert.Error(t, err)
 
 		schema = &schemapb.CollectionSchema{
@@ -3255,7 +3288,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 		helper, err = typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
-		err = newValidateUtil(withMaxCapCheck()).Validate(data, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck()).Validate(data, helper, 1)
 		assert.Error(t, err)
 
 		schema = &schemapb.CollectionSchema{
@@ -3277,7 +3310,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 		helper, err = typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
-		err = newValidateUtil(withMaxCapCheck()).Validate(data, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck()).Validate(data, helper, 1)
 		assert.Error(t, err)
 
 		data = []*schemapb.FieldData{
@@ -3328,7 +3361,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 		}
 		helper, err = typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
-		err = newValidateUtil(withMaxCapCheck()).Validate(data, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck()).Validate(data, helper, 1)
 		assert.Error(t, err)
 
 		data = []*schemapb.FieldData{
@@ -3380,7 +3413,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 		helper, err = typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
-		err = newValidateUtil(withMaxCapCheck()).Validate(data, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck()).Validate(data, helper, 1)
 		assert.Error(t, err)
 
 		data = []*schemapb.FieldData{
@@ -3432,7 +3465,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 		helper, err = typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
-		err = newValidateUtil(withMaxCapCheck()).Validate(data, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck()).Validate(data, helper, 1)
 		assert.Error(t, err)
 
 		data = []*schemapb.FieldData{
@@ -3484,7 +3517,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 		helper, err = typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
-		err = newValidateUtil(withMaxCapCheck()).Validate(data, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck()).Validate(data, helper, 1)
 		assert.Error(t, err)
 	})
 
@@ -3530,7 +3563,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 		}
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
-		err = newValidateUtil(withMaxCapCheck(), withOverflowCheck()).Validate(data, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck(), WithOverflowCheck()).Validate(data, helper, 1)
 		assert.Error(t, err)
 
 		data = []*schemapb.FieldData{
@@ -3575,7 +3608,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 		helper, err = typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
-		err = newValidateUtil(withMaxCapCheck(), withOverflowCheck()).Validate(data, helper, 1)
+		err = NewValidateUtil(WithMaxCapCheck(), WithOverflowCheck()).Validate(data, helper, 1)
 		assert.Error(t, err)
 	})
 
@@ -3994,7 +4027,7 @@ func Test_validateUtil_Validate(t *testing.T) {
 			},
 		}
 
-		v := newValidateUtil(withNANCheck(), withMaxLenCheck(), withOverflowCheck(), withMaxCapCheck())
+		v := NewValidateUtil(WithNANCheck(), WithMaxLenCheck(), WithOverflowCheck(), WithMaxCapCheck())
 		helper, err := typeutil.CreateSchemaHelper(schema)
 		require.NoError(t, err)
 
@@ -4041,7 +4074,7 @@ func checkJsonfillWithValueData(values [][]byte, v []byte, length int) (bool, er
 	return true, nil
 }
 
-func Test_validateUtil_fillWithValue(t *testing.T) {
+func Test_ValidateUtil_fillWithValue(t *testing.T) {
 	t.Run("bool scalars schema not found", func(t *testing.T) {
 		data := []*schemapb.FieldData{
 			{
@@ -4054,7 +4087,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -4089,7 +4122,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4128,7 +4161,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4163,7 +4196,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4207,7 +4240,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4253,7 +4286,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4299,7 +4332,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 3)
 
@@ -4334,7 +4367,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -4378,7 +4411,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4422,7 +4455,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -4461,7 +4494,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -4485,7 +4518,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -4520,7 +4553,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4559,7 +4592,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4596,7 +4629,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4640,7 +4673,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4686,7 +4719,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4731,7 +4764,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 3)
 
@@ -4767,7 +4800,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -4812,7 +4845,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4857,7 +4890,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -4898,7 +4931,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -4921,7 +4954,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -4956,7 +4989,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -4995,7 +5028,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5032,7 +5065,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5075,7 +5108,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5120,7 +5153,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5164,7 +5197,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 3)
 
@@ -5200,7 +5233,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 		assert.NoError(t, err)
@@ -5244,7 +5277,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5289,7 +5322,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -5330,7 +5363,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -5354,7 +5387,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -5389,7 +5422,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5428,7 +5461,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5465,7 +5498,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5509,7 +5542,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5555,7 +5588,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5600,7 +5633,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 3)
 
@@ -5636,7 +5669,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 		assert.NoError(t, err)
@@ -5680,7 +5713,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5725,7 +5758,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -5766,7 +5799,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -5789,7 +5822,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -5824,7 +5857,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5863,7 +5896,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5900,7 +5933,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5944,7 +5977,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -5990,7 +6023,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6035,7 +6068,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 3)
 
@@ -6071,7 +6104,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 		assert.NoError(t, err)
@@ -6115,7 +6148,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6160,7 +6193,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -6200,7 +6233,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -6224,7 +6257,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -6259,7 +6292,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6298,7 +6331,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6335,7 +6368,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6379,7 +6412,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6425,7 +6458,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6471,7 +6504,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6516,7 +6549,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -6559,7 +6592,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 3)
 
@@ -6595,7 +6628,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 3)
 
@@ -6631,7 +6664,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -6653,7 +6686,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -6688,7 +6721,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6727,7 +6760,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6764,7 +6797,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6807,7 +6840,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6854,7 +6887,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -6900,7 +6933,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 3)
 
@@ -6935,7 +6968,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 		assert.NoError(t, err)
@@ -6979,7 +7012,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -7023,7 +7056,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -7063,7 +7096,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -7104,7 +7137,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -7142,7 +7175,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -7188,7 +7221,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 
@@ -7237,7 +7270,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -7281,7 +7314,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 2)
 
@@ -7348,7 +7381,7 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
+		v := NewValidateUtil()
 
 		err = v.fillWithValue(data, h, 1)
 		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
@@ -7401,9 +7434,9 @@ func Test_verifyOverflowByRange(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func Test_validateUtil_checkIntegerFieldData(t *testing.T) {
+func Test_ValidateUtil_checkIntegerFieldData(t *testing.T) {
 	t.Run("no check", func(t *testing.T) {
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		assert.Error(t, v.checkIntegerFieldData(&schemapb.FieldData{Field: &schemapb.FieldData_Vectors{}}, nil))
 		assert.NoError(t, v.checkIntegerFieldData(&schemapb.FieldData{Field: &schemapb.FieldData_Scalars{
 			Scalars: &schemapb.ScalarField{
@@ -7417,7 +7450,7 @@ func Test_validateUtil_checkIntegerFieldData(t *testing.T) {
 	})
 
 	t.Run("no int data but set nullable==true or set default_value", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 
 		f := &schemapb.FieldSchema{
 			DataType: schemapb.DataType_Int8,
@@ -7461,7 +7494,7 @@ func Test_validateUtil_checkIntegerFieldData(t *testing.T) {
 	})
 
 	t.Run("tiny int, type mismatch", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 
 		f := &schemapb.FieldSchema{
 			DataType: schemapb.DataType_Int8,
@@ -7479,7 +7512,7 @@ func Test_validateUtil_checkIntegerFieldData(t *testing.T) {
 	})
 
 	t.Run("tiny int, overflow", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 
 		f := &schemapb.FieldSchema{
 			DataType: schemapb.DataType_Int8,
@@ -7501,7 +7534,7 @@ func Test_validateUtil_checkIntegerFieldData(t *testing.T) {
 	})
 
 	t.Run("tiny int, normal case", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 
 		f := &schemapb.FieldSchema{
 			DataType: schemapb.DataType_Int8,
@@ -7523,7 +7556,7 @@ func Test_validateUtil_checkIntegerFieldData(t *testing.T) {
 	})
 
 	t.Run("small int, overflow", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 
 		f := &schemapb.FieldSchema{
 			DataType: schemapb.DataType_Int16,
@@ -7545,7 +7578,7 @@ func Test_validateUtil_checkIntegerFieldData(t *testing.T) {
 	})
 
 	t.Run("small int, normal case", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 
 		f := &schemapb.FieldSchema{
 			DataType: schemapb.DataType_Int16,
@@ -7567,9 +7600,9 @@ func Test_validateUtil_checkIntegerFieldData(t *testing.T) {
 	})
 }
 
-func Test_validateUtil_checkJSONData(t *testing.T) {
+func Test_ValidateUtil_checkJSONData(t *testing.T) {
 	t.Run("no json data", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 
 		f := &schemapb.FieldSchema{
 			DataType: schemapb.DataType_JSON,
@@ -7591,7 +7624,7 @@ func Test_validateUtil_checkJSONData(t *testing.T) {
 	})
 
 	t.Run("no json data but set nullable==true or set default_value", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 
 		f := &schemapb.FieldSchema{
 			DataType: schemapb.DataType_JSON,
@@ -7633,9 +7666,9 @@ func Test_validateUtil_checkJSONData(t *testing.T) {
 	})
 
 	t.Run("json string exceed max length", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck(), withMaxLenCheck())
+		v := NewValidateUtil(WithOverflowCheck(), WithMaxLenCheck())
 		jsonString := ""
-		for i := 0; i < Params.CommonCfg.JSONMaxLength.GetAsInt(); i++ {
+		for i := 0; i < paramtable.Get().CommonCfg.JSONMaxLength.GetAsInt(); i++ {
 			jsonString += fmt.Sprintf("key: %d, value: %d", i, i)
 		}
 		jsonString = "{" + jsonString + "}"
@@ -7660,9 +7693,9 @@ func Test_validateUtil_checkJSONData(t *testing.T) {
 	})
 
 	t.Run("dynamic field exceed max length", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck(), withMaxLenCheck())
+		v := NewValidateUtil(WithOverflowCheck(), WithMaxLenCheck())
 		jsonString := ""
-		for i := 0; i < Params.CommonCfg.JSONMaxLength.GetAsInt(); i++ {
+		for i := 0; i < paramtable.Get().CommonCfg.JSONMaxLength.GetAsInt(); i++ {
 			jsonString += fmt.Sprintf("key: %d, value: %d", i, i)
 		}
 		jsonString = "{" + jsonString + "}"
@@ -7688,8 +7721,8 @@ func Test_validateUtil_checkJSONData(t *testing.T) {
 	})
 }
 
-func Test_validateUtil_checkLongFieldData(t *testing.T) {
-	v := newValidateUtil()
+func Test_ValidateUtil_checkLongFieldData(t *testing.T) {
+	v := NewValidateUtil()
 	assert.Error(t, v.checkLongFieldData(&schemapb.FieldData{
 		Field: &schemapb.FieldData_Vectors{},
 	}, nil))
@@ -7706,7 +7739,7 @@ func Test_validateUtil_checkLongFieldData(t *testing.T) {
 	}, nil))
 
 	t.Run("no long data but set nullable==true or set default_value", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 
 		f := &schemapb.FieldSchema{
 			DataType: schemapb.DataType_Int64,
@@ -7749,8 +7782,8 @@ func Test_validateUtil_checkLongFieldData(t *testing.T) {
 	})
 }
 
-func Test_validateUtil_checkFloatFieldData(t *testing.T) {
-	v := newValidateUtil(withNANCheck())
+func Test_ValidateUtil_checkFloatFieldData(t *testing.T) {
+	v := NewValidateUtil(WithNANCheck())
 	assert.Error(t, v.checkFloatFieldData(&schemapb.FieldData{
 		Field: &schemapb.FieldData_Vectors{},
 	}, nil))
@@ -7778,7 +7811,7 @@ func Test_validateUtil_checkFloatFieldData(t *testing.T) {
 	}, nil))
 
 	t.Run("no float data but set nullable==true or set default_value", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 
 		f := &schemapb.FieldSchema{
 			Nullable: true,
@@ -7819,8 +7852,8 @@ func Test_validateUtil_checkFloatFieldData(t *testing.T) {
 	})
 }
 
-func Test_validateUtil_checkDoubleFieldData(t *testing.T) {
-	v := newValidateUtil(withNANCheck())
+func Test_ValidateUtil_checkDoubleFieldData(t *testing.T) {
+	v := NewValidateUtil(WithNANCheck())
 	assert.Error(t, v.checkDoubleFieldData(&schemapb.FieldData{
 		Field: &schemapb.FieldData_Vectors{},
 	}, nil))
@@ -7848,7 +7881,7 @@ func Test_validateUtil_checkDoubleFieldData(t *testing.T) {
 	}, nil))
 
 	t.Run("no float data but set nullable==true or set default_value", func(t *testing.T) {
-		v := newValidateUtil(withOverflowCheck())
+		v := NewValidateUtil(WithOverflowCheck())
 
 		f := &schemapb.FieldSchema{
 			Nullable: true,
@@ -7900,12 +7933,12 @@ func TestCheckArrayElementNilData(t *testing.T) {
 		ElementType: schemapb.DataType_Int64,
 	}
 
-	v := newValidateUtil()
+	v := NewValidateUtil()
 	err := v.checkArrayElement(data, fieldSchema)
 	assert.True(t, merr.ErrParameterInvalid.Is(err))
 }
 
-func Test_validateUtil_checkArrayOfVectorFieldData(t *testing.T) {
+func Test_ValidateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 	t.Run("nil data", func(t *testing.T) {
 		f := &schemapb.FieldData{
 			Field: &schemapb.FieldData_Vectors{
@@ -7917,7 +7950,7 @@ func Test_validateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 			ElementType: schemapb.DataType_FloatVector,
 			TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkArrayOfVectorFieldData(f, fieldSchema)
 		assert.Error(t, err)
 	})
@@ -7939,7 +7972,7 @@ func Test_validateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 			ElementType: schemapb.DataType_FloatVector,
 			TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkArrayOfVectorFieldData(f, fieldSchema)
 		assert.Error(t, err)
 	})
@@ -7969,7 +8002,7 @@ func Test_validateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 			ElementType: schemapb.DataType_FloatVector,
 			TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "3"}},
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		v.checkNAN = false
 		err := v.checkArrayOfVectorFieldData(f, fieldSchema)
 		assert.NoError(t, err)
@@ -8000,7 +8033,7 @@ func Test_validateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 			ElementType: schemapb.DataType_FloatVector,
 			TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "1"}},
 		}
-		v := newValidateUtil(withNANCheck())
+		v := NewValidateUtil(WithNANCheck())
 		err := v.checkArrayOfVectorFieldData(f, fieldSchema)
 		assert.Error(t, err)
 	})
@@ -8037,7 +8070,7 @@ func Test_validateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 			ElementType: schemapb.DataType_FloatVector,
 			TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
 		}
-		v := newValidateUtil(withNANCheck())
+		v := NewValidateUtil(WithNANCheck())
 		err := v.checkArrayOfVectorFieldData(f, fieldSchema)
 		assert.NoError(t, err)
 	})
@@ -8071,7 +8104,7 @@ func Test_validateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 				{Key: common.MaxCapacityKey, Value: "1"},
 			},
 		}
-		v := newValidateUtil(withMaxCapCheck())
+		v := NewValidateUtil(WithMaxCapCheck())
 		err := v.checkArrayOfVectorFieldData(f, fieldSchema)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "max capacity")
@@ -8103,14 +8136,14 @@ func Test_validateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 			ElementType: schemapb.DataType_FloatVector,
 			TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
 		}
-		v := newValidateUtil()
+		v := NewValidateUtil()
 		err := v.checkArrayOfVectorFieldData(f, fieldSchema)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "divisible")
 	})
 }
 
-func Test_validateUtil_checkAligned_ArrayOfVector(t *testing.T) {
+func Test_ValidateUtil_checkAligned_ArrayOfVector(t *testing.T) {
 	t.Run("array of vector dim mismatch", func(t *testing.T) {
 		data := []*schemapb.FieldData{
 			{
@@ -8152,8 +8185,8 @@ func Test_validateUtil_checkAligned_ArrayOfVector(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
-		err = v.checkAligned(data, h, 1)
+		v := NewValidateUtil()
+		err = v.CheckAligned(data, h, 1)
 		assert.Error(t, err)
 	})
 
@@ -8198,8 +8231,8 @@ func Test_validateUtil_checkAligned_ArrayOfVector(t *testing.T) {
 		h, err := typeutil.CreateSchemaHelper(schema)
 		assert.NoError(t, err)
 
-		v := newValidateUtil()
-		err = v.checkAligned(data, h, 100)
+		v := NewValidateUtil()
+		err = v.CheckAligned(data, h, 100)
 		assert.Error(t, err)
 	})
 }
@@ -8385,7 +8418,7 @@ func Test_MetaNullableCompat_v25_vs_v26(t *testing.T) {
 		require.NoError(t, err)
 
 		data := []*schemapb.FieldData{sdkMetaFieldData()}
-		err = newValidateUtil().fillWithValue(data, h, numRows)
+		err = NewValidateUtil().fillWithValue(data, h, numRows)
 		assert.NoError(t, err, "2.6 schema + SDK-provided $meta should pass fillWithValue")
 	})
 
@@ -8395,7 +8428,7 @@ func Test_MetaNullableCompat_v25_vs_v26(t *testing.T) {
 		require.NoError(t, err)
 
 		data := []*schemapb.FieldData{sdkMetaFieldData()}
-		err = newValidateUtil().fillWithValue(data, h, numRows)
+		err = NewValidateUtil().fillWithValue(data, h, numRows)
 		assert.NoError(t, err, "2.5 schema + SDK-provided $meta (no ValidData) should pass fillWithValue")
 	})
 
@@ -8405,7 +8438,7 @@ func Test_MetaNullableCompat_v25_vs_v26(t *testing.T) {
 		require.NoError(t, err)
 
 		data := []*schemapb.FieldData{autoGenMetaFieldData(schema)}
-		err = newValidateUtil().fillWithValue(data, h, numRows)
+		err = NewValidateUtil().fillWithValue(data, h, numRows)
 		assert.NoError(t, err, "2.6 schema + auto-generated $meta should pass fillWithValue")
 	})
 
@@ -8417,7 +8450,7 @@ func Test_MetaNullableCompat_v25_vs_v26(t *testing.T) {
 		require.NoError(t, err)
 
 		data := []*schemapb.FieldData{autoGenMetaFieldData(schema)}
-		err = newValidateUtil().fillWithValue(data, h, numRows)
+		err = NewValidateUtil().fillWithValue(data, h, numRows)
 		assert.NoError(t, err, "2.5 schema + auto-generated $meta should pass fillWithValue")
 		// ValidData should remain empty for non-nullable field
 		assert.Empty(t, data[0].GetValidData(), "non-nullable $meta should not have ValidData")

--- a/internal/proxy/search_pipeline.go
+++ b/internal/proxy/search_pipeline.go
@@ -2257,7 +2257,7 @@ func isSameGroupByValue(field *schemapb.FieldData, i, j int) bool {
 //
 // Note on Float/Double NaN handling: This function does not explicitly handle NaN values
 // because Milvus rejects NaN and Infinity at insert time via proxy validation
-// (see task_insert.go withNANCheck() -> validate_util.go -> typeutil.VerifyFloat).
+// (see internal/proxy/fieldvalidator WithNANCheck -> Validate -> typeutil.VerifyFloat).
 // Therefore, NaN values cannot exist in stored data and will never reach this comparison.
 func compareFieldDataAt(field *schemapb.FieldData, i, j int, nullsFirst bool) (int, error) {
 	if cmp, handled := compareNulls(field.ValidData, i, j, nullsFirst); handled {

--- a/internal/proxy/task_index.go
+++ b/internal/proxy/task_index.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/proxy/fieldvalidator"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/internal/util/vecindexmgr"
@@ -172,7 +173,7 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 		return merr.WrapErrParameterInvalidMsg("TEXT field does not support user-created scalar index")
 	}
 
-	if err := ValidateAutoIndexMmapConfig(isVecIndex, indexParamsMap); err != nil {
+	if err := fieldvalidator.ValidateAutoIndexMmapConfig(isVecIndex, indexParamsMap); err != nil {
 		return err
 	}
 

--- a/internal/proxy/task_insert.go
+++ b/internal/proxy/task_insert.go
@@ -11,6 +11,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/proxy/channelmgr"
+	"github.com/milvus-io/milvus/internal/proxy/fieldvalidator"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -287,7 +288,7 @@ func (it *insertTask) PreExecute(ctx context.Context) error {
 		}
 	}
 
-	if err := newValidateUtil(withNANCheck(), withOverflowCheck(), withMaxLenCheck(), withMaxCapCheck()).
+	if err := fieldvalidator.NewValidateUtil(fieldvalidator.WithNANCheck(), fieldvalidator.WithOverflowCheck(), fieldvalidator.WithMaxLenCheck(), fieldvalidator.WithMaxCapCheck()).
 		Validate(it.insertMsg.GetFieldsData(), schema.SchemaHelper, it.insertMsg.NRows()); err != nil {
 		return merr.WrapErrAsInputError(err)
 	}

--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -18,6 +18,7 @@ import (
 	"github.com/milvus-io/milvus/internal/parser/planparserv2"
 	"github.com/milvus-io/milvus/internal/proxy/accesslog"
 	"github.com/milvus-io/milvus/internal/proxy/channelmgr"
+	"github.com/milvus-io/milvus/internal/proxy/fieldvalidator"
 	"github.com/milvus-io/milvus/internal/proxy/shardclient"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/exprutil"
@@ -1065,7 +1066,7 @@ func (t *queryTask) PostExecute(ctx context.Context) error {
 	// Only geometry WKB→WKT conversion still needs to happen here.
 	for i, fieldData := range t.result.FieldsData {
 		if fieldData.Type == schemapb.DataType_Geometry {
-			if err := validateGeometryFieldSearchResult(&t.result.FieldsData[i]); err != nil {
+			if err := fieldvalidator.ValidateGeometryFieldSearchResult(&t.result.FieldsData[i]); err != nil {
 				log.Warn(ctx, "fail to validate geometry field search result", mlog.Err(err))
 				return err
 			}

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -21,6 +21,7 @@ import (
 	"github.com/milvus-io/milvus/internal/parser/planparserv2"
 	"github.com/milvus-io/milvus/internal/proxy/accesslog"
 	"github.com/milvus-io/milvus/internal/proxy/channelmgr"
+	"github.com/milvus-io/milvus/internal/proxy/fieldvalidator"
 	"github.com/milvus-io/milvus/internal/proxy/search_agg"
 	"github.com/milvus-io/milvus/internal/proxy/shardclient"
 	"github.com/milvus-io/milvus/internal/types"
@@ -1449,7 +1450,7 @@ func (t *searchTask) PostExecute(ctx context.Context) error {
 	fieldsData := t.result.GetResults().GetFieldsData()
 	for i, fieldData := range fieldsData {
 		if fieldData.Type == schemapb.DataType_Geometry {
-			if err := validateGeometryFieldSearchResult(&fieldsData[i]); err != nil {
+			if err := fieldvalidator.ValidateGeometryFieldSearchResult(&fieldsData[i]); err != nil {
 				log.Warn(ctx, "fail to validate geometry field search result", mlog.Err(err))
 				return err
 			}
@@ -1459,7 +1460,7 @@ func (t *searchTask) PostExecute(ctx context.Context) error {
 	// stages emit plural; runs before the legacy-wire downgrade below.
 	for i, gbv := range t.result.GetResults().GetGroupByFieldValues() {
 		if gbv != nil && gbv.GetType() == schemapb.DataType_Geometry {
-			if err := validateGeometryFieldSearchResult(&t.result.Results.GroupByFieldValues[i]); err != nil {
+			if err := fieldvalidator.ValidateGeometryFieldSearchResult(&t.result.Results.GroupByFieldValues[i]); err != nil {
 				log.Warn(ctx, "fail to validate geometry field search result", mlog.Err(err))
 				return err
 			}

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -30,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/parser/planparserv2"
 	"github.com/milvus-io/milvus/internal/proxy/channelmgr"
+	"github.com/milvus-io/milvus/internal/proxy/fieldvalidator"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/segcore"
 	"github.com/milvus-io/milvus/pkg/v3/common"
@@ -349,9 +350,9 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 						return err
 					}
 					if subFieldSchema.GetDefaultValue() != nil {
-						err = FillWithDefaultValue(subField, subFieldSchema, int(it.upsertMsg.InsertMsg.NRows()))
+						err = fieldvalidator.FillWithDefaultValue(subField, subFieldSchema, int(it.upsertMsg.InsertMsg.NRows()))
 					} else {
-						err = FillWithNullValue(subField, subFieldSchema, int(it.upsertMsg.InsertMsg.NRows()))
+						err = fieldvalidator.FillWithNullValue(subField, subFieldSchema, int(it.upsertMsg.InsertMsg.NRows()))
 					}
 					if err != nil {
 						log.Info(ctx, "unify struct field data format failed", mlog.Err(err))
@@ -388,9 +389,9 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 		if len(fieldData.GetValidData()) != 0 {
 			var err error
 			if fieldSchema.GetDefaultValue() != nil {
-				err = FillWithDefaultValue(fieldData, fieldSchema, int(it.upsertMsg.InsertMsg.NRows()))
+				err = fieldvalidator.FillWithDefaultValue(fieldData, fieldSchema, int(it.upsertMsg.InsertMsg.NRows()))
 			} else {
-				err = FillWithNullValue(fieldData, fieldSchema, int(it.upsertMsg.InsertMsg.NRows()))
+				err = fieldvalidator.FillWithNullValue(fieldData, fieldSchema, int(it.upsertMsg.InsertMsg.NRows()))
 			}
 			if err != nil {
 				log.Info(ctx, "unify field data format failed", mlog.Err(err))
@@ -401,7 +402,7 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 	}
 
 	// Validate field data alignment before processing to prevent index out of range panic
-	if err := newValidateUtil().checkAligned(fieldsDataToCheckAligned, it.schema.SchemaHelper, uint64(upsertIDSize)); err != nil {
+	if err := fieldvalidator.NewValidateUtil().CheckAligned(fieldsDataToCheckAligned, it.schema.SchemaHelper, uint64(upsertIDSize)); err != nil {
 		log.Warn(ctx, "check field data aligned failed", mlog.Err(err))
 		return err
 	}
@@ -671,14 +672,15 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 
 // ToCompressedFormatNullable converts nullable field data from full format to compressed format.
 func ToCompressedFormatNullable(field *schemapb.FieldData) error {
-	if getValidNumber(field.GetValidData()) == len(field.GetValidData()) {
+	validData := field.GetValidData()
+	if fieldvalidator.GetValidNumber(validData) == len(validData) {
 		return nil
 	}
 	switch field.Field.(type) {
 	case *schemapb.FieldData_Scalars:
 		switch sd := field.GetScalars().GetData().(type) {
 		case *schemapb.ScalarField_BoolData:
-			validRowNum := getValidNumber(field.GetValidData())
+			validRowNum := fieldvalidator.GetValidNumber(validData)
 			if validRowNum == 0 {
 				sd.BoolData.Data = make([]bool, 0)
 			} else {
@@ -692,7 +694,7 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 			}
 
 		case *schemapb.ScalarField_IntData:
-			validRowNum := getValidNumber(field.GetValidData())
+			validRowNum := fieldvalidator.GetValidNumber(validData)
 			if validRowNum == 0 {
 				sd.IntData.Data = make([]int32, 0)
 			} else {
@@ -706,7 +708,7 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 			}
 
 		case *schemapb.ScalarField_LongData:
-			validRowNum := getValidNumber(field.GetValidData())
+			validRowNum := fieldvalidator.GetValidNumber(validData)
 			if validRowNum == 0 {
 				sd.LongData.Data = make([]int64, 0)
 			} else {
@@ -720,7 +722,7 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 			}
 
 		case *schemapb.ScalarField_FloatData:
-			validRowNum := getValidNumber(field.GetValidData())
+			validRowNum := fieldvalidator.GetValidNumber(validData)
 			if validRowNum == 0 {
 				sd.FloatData.Data = make([]float32, 0)
 			} else {
@@ -734,7 +736,7 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 			}
 
 		case *schemapb.ScalarField_DoubleData:
-			validRowNum := getValidNumber(field.GetValidData())
+			validRowNum := fieldvalidator.GetValidNumber(validData)
 			if validRowNum == 0 {
 				sd.DoubleData.Data = make([]float64, 0)
 			} else {
@@ -748,7 +750,7 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 			}
 
 		case *schemapb.ScalarField_StringData:
-			validRowNum := getValidNumber(field.GetValidData())
+			validRowNum := fieldvalidator.GetValidNumber(validData)
 			if validRowNum == 0 {
 				sd.StringData.Data = make([]string, 0)
 			} else {
@@ -762,7 +764,7 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 			}
 
 		case *schemapb.ScalarField_JsonData:
-			validRowNum := getValidNumber(field.GetValidData())
+			validRowNum := fieldvalidator.GetValidNumber(validData)
 			if validRowNum == 0 {
 				sd.JsonData.Data = make([][]byte, 0)
 			} else {
@@ -776,7 +778,7 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 			}
 
 		case *schemapb.ScalarField_ArrayData:
-			validRowNum := getValidNumber(field.GetValidData())
+			validRowNum := fieldvalidator.GetValidNumber(validData)
 			if validRowNum == 0 {
 				sd.ArrayData.Data = make([]*schemapb.ScalarField, 0)
 			} else {
@@ -789,7 +791,7 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 				sd.ArrayData.Data = ret
 			}
 		case *schemapb.ScalarField_TimestamptzData:
-			validRowNum := getValidNumber(field.GetValidData())
+			validRowNum := fieldvalidator.GetValidNumber(validData)
 			if validRowNum == 0 {
 				sd.TimestamptzData.Data = make([]int64, 0)
 			} else {
@@ -803,7 +805,7 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 			}
 
 		case *schemapb.ScalarField_GeometryWktData:
-			validRowNum := getValidNumber(field.GetValidData())
+			validRowNum := fieldvalidator.GetValidNumber(validData)
 			if validRowNum == 0 {
 				sd.GeometryWktData.Data = make([]string, 0)
 			} else {
@@ -817,7 +819,7 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 			}
 
 		case *schemapb.ScalarField_GeometryData:
-			validRowNum := getValidNumber(field.GetValidData())
+			validRowNum := fieldvalidator.GetValidNumber(validData)
 			if validRowNum == 0 {
 				sd.GeometryData.Data = make([][]byte, 0)
 			} else {
@@ -1182,7 +1184,7 @@ func ToCompressedFormatNullableStructField(fieldData *schemapb.FieldData) error 
 		}
 
 		validData := subField.GetValidData()
-		validRows := getValidNumber(validData)
+		validRows := fieldvalidator.GetValidNumber(validData)
 		if validRows == 0 && !subFieldHasData(subField) {
 			continue
 		}
@@ -1325,7 +1327,7 @@ func validateWholeStructFieldDataForPartialUpdate(schemaHelper *typeutil.SchemaH
 			}
 			continue
 		}
-		validRows := getValidNumber(subField.GetValidData())
+		validRows := fieldvalidator.GetValidNumber(subField.GetValidData())
 		if payloadRows != validRows {
 			return merr.WrapErrParameterInvalidMsg("nullable struct sub-field '%s' payload must be compact: payload row count %d does not match valid rows %d",
 				subField.GetFieldName(), payloadRows, validRows)
@@ -1497,7 +1499,7 @@ func (it *upsertTask) insertPreExecute(ctx context.Context) error {
 		}
 	}
 
-	if err := newValidateUtil(withNANCheck(), withOverflowCheck(), withMaxLenCheck(), withMaxCapCheck()).
+	if err := fieldvalidator.NewValidateUtil(fieldvalidator.WithNANCheck(), fieldvalidator.WithOverflowCheck(), fieldvalidator.WithMaxLenCheck(), fieldvalidator.WithMaxCapCheck()).
 		Validate(it.upsertMsg.InsertMsg.GetFieldsData(), it.schema.SchemaHelper, it.upsertMsg.InsertMsg.NRows()); err != nil {
 		return err
 	}

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -39,6 +39,7 @@ import (
 	"github.com/milvus-io/milvus/internal/agg"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/internal/parser/planparserv2"
+	"github.com/milvus-io/milvus/internal/proxy/fieldvalidator"
 	"github.com/milvus-io/milvus/internal/proxy/privilege"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/function/embedding"
@@ -659,7 +660,7 @@ func ValidateField(field *schemapb.FieldSchema, schema *schemapb.CollectionSchem
 
 	// TODO should remove the index params in the field schema
 	indexParams := funcutil.KeyValuePair2Map(field.GetIndexParams())
-	if err = ValidateAutoIndexMmapConfig(isVectorType, indexParams); err != nil {
+	if err = fieldvalidator.ValidateAutoIndexMmapConfig(isVectorType, indexParams); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Cherry-pick from master
pr: #52840
Related to #44761

Move validate_util.go out of the monolithic proxy package into the new leaf subpackage internal/proxy/fieldvalidator, part of the proxy component extraction.

The 1.5k-line file had no proxy-internal references - it only consumes schemapb, internal/util/nullutil and pkg/v3 - so the move is a pure symbol-for-symbol extraction with no behavior change. Export the surface tasks relied on: ValidateUtil / NewValidateUtil / ValidateOption / With*Check, ValidateGeometryFieldSearchResult, CheckAligned, GetValidNumber, and the already-exported FillWith* and ValidateAutoIndexMmapConfig.

The 8.8k-line test file moves with the code and now runs as a true package-local unit test: it builds schemapb data directly and reads config via paramtable.Get() instead of the proxy Params global. Root-package consumers (task_insert, task_upsert, task_search, task_query, task_index, util.go) call the package-qualified names.

Verification: go build ./internal/proxy/... and go vet -tags dynamic,test pass; fieldvalidator and affected consumer tests are green.