### PR TITLE
enhance: replace proto serialization with Arrow at retrieve CGO boundary

### DIFF
--- a/internal/core/src/segcore/arrow_field_utils.cpp
+++ b/internal/core/src/segcore/arrow_field_utils.cpp
@@ -1,0 +1,491 @@
+// Copyright (C) 2019-2026 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include "segcore/arrow_field_utils.h"
+
+#include <arrow/api.h>
+
+#include <string>
+#include <utility>
+
+#include "common/EasyAssert.h"
+#include "common/Utils.h"
+
+namespace milvus::segcore {
+
+namespace {
+
+constexpr const char* kMilvusFieldIDMetadataKey = "milvus.field_id";
+constexpr const char* kMilvusDataTypeMetadataKey = "milvus.data_type";
+
+// BuildFixedWidthArray builds an Arrow Array from a fixed-width protobuf repeated field.
+template <typename BuilderType, typename DataContainer>
+arrow::Result<std::shared_ptr<arrow::Array>>
+BuildFixedWidthArray(const DataContainer& data,
+                     const milvus::DataArray& field_data,
+                     size_t total_valid) {
+    AssertInfo(static_cast<size_t>(data.size()) >= total_valid,
+               "field data length {} is smaller than expected row count {}",
+               data.size(),
+               total_valid);
+    const auto& valid_data = milvus::GetFieldDataRowValidData(field_data);
+    const bool has_valid_data = !valid_data.empty();
+    if (has_valid_data) {
+        AssertInfo(static_cast<size_t>(valid_data.size()) == total_valid,
+                   "valid_data length {} does not match expected row count {}",
+                   valid_data.size(),
+                   total_valid);
+    }
+
+    BuilderType builder;
+    ARROW_RETURN_NOT_OK(builder.Reserve(total_valid));
+    for (size_t i = 0; i < total_valid; ++i) {
+        if (has_valid_data && !valid_data[i]) {
+            ARROW_RETURN_NOT_OK(builder.AppendNull());
+            continue;
+        }
+        builder.UnsafeAppend(data[i]);
+    }
+    std::shared_ptr<arrow::Array> arr;
+    ARROW_RETURN_NOT_OK(builder.Finish(&arr));
+    return arr;
+}
+
+// BuildVarLenArray builds an Arrow Array from a variable-length protobuf
+// repeated field whose payload has one entry per logical row (including
+// placeholders for nulls).  MergeDataArray uses this layout for scalar
+// fields (STRING, JSON, GEOMETRY).
+template <typename BuilderType, typename DataContainer>
+arrow::Result<std::shared_ptr<arrow::Array>>
+BuildVarLenArray(const DataContainer& data,
+                 const milvus::DataArray& field_data,
+                 size_t total_valid) {
+    AssertInfo(static_cast<size_t>(data.size()) >= total_valid,
+               "field data length {} is smaller than expected row count {}",
+               data.size(),
+               total_valid);
+    const auto& valid_data = milvus::GetFieldDataRowValidData(field_data);
+    const bool has_valid_data = !valid_data.empty();
+    if (has_valid_data) {
+        AssertInfo(static_cast<size_t>(valid_data.size()) == total_valid,
+                   "valid_data length {} does not match expected row count {}",
+                   valid_data.size(),
+                   total_valid);
+    }
+
+    BuilderType builder;
+    ARROW_RETURN_NOT_OK(builder.Reserve(total_valid));
+    for (size_t i = 0; i < total_valid; ++i) {
+        if (has_valid_data && !valid_data[i]) {
+            ARROW_RETURN_NOT_OK(builder.AppendNull());
+            continue;
+        }
+        ARROW_RETURN_NOT_OK(builder.Append(data[i]));
+    }
+    std::shared_ptr<arrow::Array> arr;
+    ARROW_RETURN_NOT_OK(builder.Finish(&arr));
+    return arr;
+}
+
+// BuildCompactVarLenArray builds an Arrow Array from a variable-length
+// protobuf repeated field whose payload is compact — only valid rows have
+// physical entries.  MergeDataArray uses this layout for sparse vectors.
+template <typename BuilderType, typename DataContainer>
+arrow::Result<std::shared_ptr<arrow::Array>>
+BuildCompactVarLenArray(const DataContainer& data,
+                        const milvus::DataArray& field_data,
+                        size_t total_valid) {
+    const auto& valid_data = milvus::GetFieldDataRowValidData(field_data);
+    const bool has_valid_data = !valid_data.empty();
+    if (has_valid_data) {
+        AssertInfo(static_cast<size_t>(valid_data.size()) == total_valid,
+                   "valid_data length {} does not match expected row count {}",
+                   valid_data.size(),
+                   total_valid);
+    } else {
+        AssertInfo(static_cast<size_t>(data.size()) >= total_valid,
+                   "field data length {} is smaller than expected row count {}",
+                   data.size(),
+                   total_valid);
+    }
+
+    BuilderType builder;
+    ARROW_RETURN_NOT_OK(builder.Reserve(total_valid));
+    size_t physical = 0;
+    for (size_t i = 0; i < total_valid; ++i) {
+        if (has_valid_data && !valid_data[i]) {
+            ARROW_RETURN_NOT_OK(builder.AppendNull());
+            continue;
+        }
+        ARROW_RETURN_NOT_OK(builder.Append(data[physical]));
+        ++physical;
+    }
+    std::shared_ptr<arrow::Array> arr;
+    ARROW_RETURN_NOT_OK(builder.Finish(&arr));
+    return arr;
+}
+
+}  // namespace
+
+std::shared_ptr<arrow::KeyValueMetadata>
+MilvusFieldMetadata(milvus::FieldId field_id, milvus::DataType data_type) {
+    return arrow::key_value_metadata(
+        {kMilvusFieldIDMetadataKey, kMilvusDataTypeMetadataKey},
+        {std::to_string(field_id.get()),
+         std::to_string(static_cast<int32_t>(data_type))});
+}
+
+std::shared_ptr<arrow::Field>
+MilvusField(const std::string& name,
+            const std::shared_ptr<arrow::DataType>& arrow_type,
+            bool nullable,
+            milvus::FieldId field_id,
+            milvus::DataType data_type) {
+    return arrow::field(
+        name, arrow_type, nullable, MilvusFieldMetadata(field_id, data_type));
+}
+
+arrow::Result<std::shared_ptr<arrow::DataType>>
+EmptyExtraFieldArrowType(const milvus::FieldMeta& field_meta) {
+    switch (field_meta.get_data_type()) {
+        case milvus::DataType::BOOL:
+            return arrow::boolean();
+        case milvus::DataType::INT8:
+        case milvus::DataType::INT16:
+        case milvus::DataType::INT32:
+            return arrow::int32();
+        case milvus::DataType::INT64:
+        case milvus::DataType::TIMESTAMPTZ:
+            return arrow::int64();
+        case milvus::DataType::FLOAT:
+            return arrow::float32();
+        case milvus::DataType::DOUBLE:
+            return arrow::float64();
+        case milvus::DataType::STRING:
+        case milvus::DataType::VARCHAR:
+        case milvus::DataType::TEXT:
+            return arrow::utf8();
+        case milvus::DataType::JSON:
+            return arrow::binary();
+        case milvus::DataType::GEOMETRY:
+            return arrow::binary();
+        case milvus::DataType::VECTOR_ARRAY: {
+            return milvus::GetArrowDataTypeForVectorArray(
+                field_meta.get_element_type(), field_meta.get_dim());
+        }
+        default: {
+            int dim = 1;
+            if (field_meta.is_vector() &&
+                field_meta.get_data_type() !=
+                    milvus::DataType::VECTOR_SPARSE_U32_F32) {
+                dim = field_meta.get_dim();
+            }
+            return milvus::GetArrowDataType(field_meta.get_data_type(), dim);
+        }
+    }
+}
+
+namespace {
+
+// BuildDenseVectorArray builds an Arrow FixedSizeBinary array from a dense
+// vector buffer. Nullable vectors produced by MergeDataArray are compacted:
+// the physical buffer has only valid_count entries while valid_data has
+// total_valid entries. This helper uses separate logical/physical indices
+// to avoid reading beyond the buffer.
+template <typename RawPtr>
+arrow::Result<std::shared_ptr<arrow::Array>>
+BuildDenseVectorArray(RawPtr raw,
+                      int32_t byte_width,
+                      const milvus::DataArray& field_data,
+                      size_t total_valid) {
+    auto type = arrow::fixed_size_binary(byte_width);
+    arrow::FixedSizeBinaryBuilder builder(type);
+    ARROW_RETURN_NOT_OK(builder.Reserve(total_valid));
+    const auto& valid_data = milvus::GetFieldDataRowValidData(field_data);
+    const bool has_valid_data = !valid_data.empty();
+    size_t physical = 0;
+    for (size_t i = 0; i < total_valid; ++i) {
+        if (has_valid_data && !valid_data[i]) {
+            ARROW_RETURN_NOT_OK(builder.AppendNull());
+            continue;
+        }
+        ARROW_RETURN_NOT_OK(builder.Append(raw + physical * byte_width));
+        ++physical;
+    }
+    std::shared_ptr<arrow::Array> arr;
+    ARROW_RETURN_NOT_OK(builder.Finish(&arr));
+    return arr;
+}
+
+}  // namespace
+
+arrow::Result<
+    std::pair<std::shared_ptr<arrow::Field>, std::shared_ptr<arrow::Array>>>
+FieldDataToArrow(const std::string& field_name,
+                 const milvus::DataArray& field_data,
+                 size_t total_valid) {
+    if (field_data.has_vectors()) {
+        const auto& vectors = field_data.vectors();
+        int64_t dim = vectors.dim();
+        if (vectors.has_float_vector()) {
+            const auto& fv = vectors.float_vector().data();
+            int32_t byte_width = dim * sizeof(float);
+            auto raw = reinterpret_cast<const uint8_t*>(fv.data());
+            ARROW_ASSIGN_OR_RAISE(
+                auto arr,
+                BuildDenseVectorArray(
+                    raw, byte_width, field_data, total_valid));
+            return std::make_pair(
+                arrow::field(field_name, arrow::fixed_size_binary(byte_width)),
+                arr);
+        }
+        if (vectors.has_binary_vector()) {
+            const auto& bv = vectors.binary_vector();
+            int32_t byte_width = dim / 8;
+            auto raw = reinterpret_cast<const uint8_t*>(bv.data());
+            ARROW_ASSIGN_OR_RAISE(
+                auto arr,
+                BuildDenseVectorArray(
+                    raw, byte_width, field_data, total_valid));
+            return std::make_pair(
+                arrow::field(field_name, arrow::fixed_size_binary(byte_width)),
+                arr);
+        }
+        if (vectors.has_float16_vector()) {
+            const auto& f16v = vectors.float16_vector();
+            int32_t byte_width = dim * 2;
+            auto raw = reinterpret_cast<const uint8_t*>(f16v.data());
+            ARROW_ASSIGN_OR_RAISE(
+                auto arr,
+                BuildDenseVectorArray(
+                    raw, byte_width, field_data, total_valid));
+            return std::make_pair(
+                arrow::field(field_name, arrow::fixed_size_binary(byte_width)),
+                arr);
+        }
+        if (vectors.has_bfloat16_vector()) {
+            const auto& bf16v = vectors.bfloat16_vector();
+            int32_t byte_width = dim * 2;
+            auto raw = reinterpret_cast<const uint8_t*>(bf16v.data());
+            ARROW_ASSIGN_OR_RAISE(
+                auto arr,
+                BuildDenseVectorArray(
+                    raw, byte_width, field_data, total_valid));
+            return std::make_pair(
+                arrow::field(field_name, arrow::fixed_size_binary(byte_width)),
+                arr);
+        }
+        if (vectors.has_int8_vector()) {
+            const auto& i8v = vectors.int8_vector();
+            int32_t byte_width = dim;
+            auto raw = reinterpret_cast<const uint8_t*>(i8v.data());
+            ARROW_ASSIGN_OR_RAISE(
+                auto arr,
+                BuildDenseVectorArray(
+                    raw, byte_width, field_data, total_valid));
+            return std::make_pair(
+                arrow::field(field_name, arrow::fixed_size_binary(byte_width)),
+                arr);
+        }
+        if (vectors.has_sparse_float_vector()) {
+            ARROW_ASSIGN_OR_RAISE(auto arr,
+                                  BuildCompactVarLenArray<arrow::BinaryBuilder>(
+                                      vectors.sparse_float_vector().contents(),
+                                      field_data,
+                                      total_valid));
+            return std::make_pair(arrow::field(field_name, arrow::binary()),
+                                  arr);
+        }
+        if (vectors.has_vector_array()) {
+            const auto& va = vectors.vector_array();
+            int32_t byte_width = 0;
+            auto elem_type = va.element_type();
+            switch (elem_type) {
+                case milvus::proto::schema::FloatVector:
+                    byte_width = dim * sizeof(float);
+                    break;
+                case milvus::proto::schema::BinaryVector:
+                    byte_width = dim / 8;
+                    break;
+                case milvus::proto::schema::Float16Vector:
+                case milvus::proto::schema::BFloat16Vector:
+                    byte_width = dim * 2;
+                    break;
+                case milvus::proto::schema::Int8Vector:
+                    byte_width = dim;
+                    break;
+                default:
+                    return arrow::Status::NotImplemented(
+                        "unsupported VectorArray element type");
+            }
+            auto value_type = arrow::fixed_size_binary(byte_width);
+            auto inner_builder =
+                std::make_shared<arrow::FixedSizeBinaryBuilder>(value_type);
+            arrow::ListBuilder list_builder(arrow::default_memory_pool(),
+                                            inner_builder);
+            const auto& valid_data =
+                milvus::GetFieldDataRowValidData(field_data);
+            const bool has_valid_data = !valid_data.empty();
+            for (size_t i = 0; i < total_valid; ++i) {
+                if (has_valid_data && !valid_data[i]) {
+                    ARROW_RETURN_NOT_OK(list_builder.AppendNull());
+                    continue;
+                }
+                ARROW_RETURN_NOT_OK(list_builder.Append());
+                const auto& row = va.data(i);
+                const uint8_t* raw = nullptr;
+                size_t vec_count = 0;
+                switch (elem_type) {
+                    case milvus::proto::schema::FloatVector: {
+                        const auto& fv = row.float_vector().data();
+                        raw = reinterpret_cast<const uint8_t*>(fv.data());
+                        vec_count = fv.size() / dim;
+                        break;
+                    }
+                    case milvus::proto::schema::BinaryVector: {
+                        const auto& bv = row.binary_vector();
+                        raw = reinterpret_cast<const uint8_t*>(bv.data());
+                        vec_count = bv.size() / byte_width;
+                        break;
+                    }
+                    case milvus::proto::schema::Float16Vector: {
+                        const auto& f16v = row.float16_vector();
+                        raw = reinterpret_cast<const uint8_t*>(f16v.data());
+                        vec_count = f16v.size() / byte_width;
+                        break;
+                    }
+                    case milvus::proto::schema::BFloat16Vector: {
+                        const auto& bf16v = row.bfloat16_vector();
+                        raw = reinterpret_cast<const uint8_t*>(bf16v.data());
+                        vec_count = bf16v.size() / byte_width;
+                        break;
+                    }
+                    case milvus::proto::schema::Int8Vector: {
+                        const auto& i8v = row.int8_vector();
+                        raw = reinterpret_cast<const uint8_t*>(i8v.data());
+                        vec_count = i8v.size() / byte_width;
+                        break;
+                    }
+                    default:
+                        break;
+                }
+                for (size_t v = 0; v < vec_count; ++v) {
+                    ARROW_RETURN_NOT_OK(
+                        inner_builder->Append(raw + v * byte_width));
+                }
+            }
+            std::shared_ptr<arrow::Array> arr;
+            ARROW_RETURN_NOT_OK(list_builder.Finish(&arr));
+            return std::make_pair(
+                arrow::field(field_name, arrow::list(value_type)), arr);
+        }
+        return arrow::Status::NotImplemented(
+            "unsupported vector type in Arrow export");
+    }
+
+    if (!field_data.has_scalars()) {
+        return arrow::Status::NotImplemented(
+            "non-scalar/non-vector output field not supported in Arrow export");
+    }
+    const auto& scalars = field_data.scalars();
+
+    if (scalars.has_bool_data()) {
+        ARROW_ASSIGN_OR_RAISE(
+            auto arr,
+            BuildFixedWidthArray<arrow::BooleanBuilder>(
+                scalars.bool_data().data(), field_data, total_valid));
+        return std::make_pair(arrow::field(field_name, arrow::boolean()), arr);
+    }
+    if (scalars.has_int_data()) {
+        ARROW_ASSIGN_OR_RAISE(
+            auto arr,
+            BuildFixedWidthArray<arrow::Int32Builder>(
+                scalars.int_data().data(), field_data, total_valid));
+        return std::make_pair(arrow::field(field_name, arrow::int32()), arr);
+    }
+    if (scalars.has_long_data()) {
+        ARROW_ASSIGN_OR_RAISE(
+            auto arr,
+            BuildFixedWidthArray<arrow::Int64Builder>(
+                scalars.long_data().data(), field_data, total_valid));
+        return std::make_pair(arrow::field(field_name, arrow::int64()), arr);
+    }
+    if (scalars.has_timestamptz_data()) {
+        ARROW_ASSIGN_OR_RAISE(
+            auto arr,
+            BuildFixedWidthArray<arrow::Int64Builder>(
+                scalars.timestamptz_data().data(), field_data, total_valid));
+        return std::make_pair(arrow::field(field_name, arrow::int64()), arr);
+    }
+    if (scalars.has_float_data()) {
+        ARROW_ASSIGN_OR_RAISE(
+            auto arr,
+            BuildFixedWidthArray<arrow::FloatBuilder>(
+                scalars.float_data().data(), field_data, total_valid));
+        return std::make_pair(arrow::field(field_name, arrow::float32()), arr);
+    }
+    if (scalars.has_double_data()) {
+        ARROW_ASSIGN_OR_RAISE(
+            auto arr,
+            BuildFixedWidthArray<arrow::DoubleBuilder>(
+                scalars.double_data().data(), field_data, total_valid));
+        return std::make_pair(arrow::field(field_name, arrow::float64()), arr);
+    }
+    if (scalars.has_string_data()) {
+        ARROW_ASSIGN_OR_RAISE(
+            auto arr,
+            BuildVarLenArray<arrow::StringBuilder>(
+                scalars.string_data().data(), field_data, total_valid));
+        return std::make_pair(arrow::field(field_name, arrow::utf8()), arr);
+    }
+    if (scalars.has_json_data()) {
+        ARROW_ASSIGN_OR_RAISE(
+            auto arr,
+            BuildVarLenArray<arrow::BinaryBuilder>(
+                scalars.json_data().data(), field_data, total_valid));
+        return std::make_pair(arrow::field(field_name, arrow::binary()), arr);
+    }
+    if (scalars.has_geometry_data()) {
+        ARROW_ASSIGN_OR_RAISE(
+            auto arr,
+            BuildVarLenArray<arrow::BinaryBuilder>(
+                scalars.geometry_data().data(), field_data, total_valid));
+        return std::make_pair(arrow::field(field_name, arrow::binary()), arr);
+    }
+
+    if (scalars.has_array_data()) {
+        const auto& ad = scalars.array_data();
+        const auto& valid_data = milvus::GetFieldDataRowValidData(field_data);
+        const bool has_valid_data = !valid_data.empty();
+        arrow::BinaryBuilder builder;
+        ARROW_RETURN_NOT_OK(builder.Reserve(total_valid));
+        for (size_t i = 0; i < total_valid; ++i) {
+            if (has_valid_data && !valid_data[i]) {
+                ARROW_RETURN_NOT_OK(builder.AppendNull());
+                continue;
+            }
+            std::string serialized;
+            if (!ad.data(i).SerializeToString(&serialized)) {
+                return arrow::Status::SerializationError(
+                    "failed to serialize ArrayArray element");
+            }
+            ARROW_RETURN_NOT_OK(builder.Append(serialized));
+        }
+        std::shared_ptr<arrow::Array> arr;
+        ARROW_RETURN_NOT_OK(builder.Finish(&arr));
+        return std::make_pair(arrow::field(field_name, arrow::binary()), arr);
+    }
+
+    return arrow::Status::NotImplemented(
+        "unsupported scalar type in Arrow export");
+}
+
+}  // namespace milvus::segcore

--- a/internal/core/src/segcore/arrow_field_utils.h
+++ b/internal/core/src/segcore/arrow_field_utils.h
@@ -1,0 +1,52 @@
+// Copyright (C) 2019-2026 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#pragma once
+
+#include <arrow/type_fwd.h>
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "common/FieldMeta.h"
+#include "common/QueryResult.h"
+#include "common/Types.h"
+
+namespace milvus::segcore {
+
+// Build the Arrow field metadata (field id + Milvus data type) attached to
+// every exported Arrow field, so downstream consumers can recover the
+// originating Milvus field without relying on column name/order alone.
+std::shared_ptr<arrow::KeyValueMetadata>
+MilvusFieldMetadata(milvus::FieldId field_id, milvus::DataType data_type);
+
+// Build an arrow::Field carrying MilvusFieldMetadata.
+std::shared_ptr<arrow::Field>
+MilvusField(const std::string& name,
+            const std::shared_ptr<arrow::DataType>& arrow_type,
+            bool nullable,
+            milvus::FieldId field_id,
+            milvus::DataType data_type);
+
+// Resolve the Arrow physical type used to build an empty (0-row) Arrow array
+// for this scalar field, without requiring materialized field data.
+arrow::Result<std::shared_ptr<arrow::DataType>>
+EmptyExtraFieldArrowType(const milvus::FieldMeta& field_meta);
+
+// Convert a protobuf FieldData (scalar or vector) to an Arrow Array + Field.
+arrow::Result<
+    std::pair<std::shared_ptr<arrow::Field>, std::shared_ptr<arrow::Array>>>
+FieldDataToArrow(const std::string& field_name,
+                 const milvus::DataArray& field_data,
+                 size_t total_valid);
+
+}  // namespace milvus::segcore

--- a/internal/core/src/segcore/retrieve_result_export_c.cpp
+++ b/internal/core/src/segcore/retrieve_result_export_c.cpp
@@ -1,0 +1,346 @@
+// Copyright (C) 2019-2026 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include "segcore/retrieve_result_export_c.h"
+
+#include <arrow/api.h>
+#include <arrow/c/bridge.h>
+#include <arrow/c/abi.h>
+#include <folly/CancellationToken.h>
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "common/EasyAssert.h"
+#include "common/FieldMeta.h"
+#include "common/Types.h"
+#include "common/Utils.h"
+#include "futures/Future.h"
+#include "monitor/scope_metric.h"
+#include "query/PlanImpl.h"
+#include "segcore/ChunkedSegmentSealedImpl.h"
+#include "segcore/SegmentInterface.h"
+#include "segcore/SegmentReadLease.h"
+#include "segcore/Utils.h"
+#include "segcore/arrow_field_utils.h"
+
+using milvus::DataArray;
+using milvus::FieldId;
+using milvus::segcore::EmptyExtraFieldArrowType;
+using milvus::segcore::FieldDataToArrow;
+using milvus::segcore::MergeBase;
+using milvus::segcore::MergeDataArray;
+using milvus::segcore::MilvusField;
+using milvus::segcore::SegmentInternalInterface;
+
+namespace {
+
+void
+ReleaseArrowSchemaIfNeeded(ArrowSchema* schema) {
+    if (schema != nullptr && schema->release != nullptr) {
+        schema->release(schema);
+    }
+}
+
+void
+ReleaseArrowArrayIfNeeded(ArrowArray* array) {
+    if (array != nullptr && array->release != nullptr) {
+        array->release(array);
+    }
+}
+
+// Mirrors AcquireSegmentReadLease in segment_c.cpp: growing segments are not
+// gated (there is no lazy-load publish to race with), while sealed segments
+// require a read lease held for the duration of the bulk_subscript calls to
+// prevent torn reads during concurrent lazy-load publish.
+std::shared_ptr<milvus::segcore::SegmentReadLease>
+AcquireSegmentReadLease(milvus::segcore::SegmentInterface* segment,
+                        const folly::CancellationToken& cancel_token) {
+    if (segment->type() == SegmentType::Growing) {
+        return nullptr;
+    }
+
+    auto sealed =
+        dynamic_cast<milvus::segcore::ChunkedSegmentSealedImpl*>(segment);
+    AssertInfo(sealed != nullptr,
+               "sealed segment {} does not support request read leases",
+               segment->get_segment_id());
+    return sealed->AcquireReadLease(cancel_token);
+}
+
+// Groups the rows of one FillRetrieveFieldsOrdered call that belong to the
+// same segment, mirroring OrderedSegmentFields in search_result_export_c.cpp.
+struct RetrieveSegmentFields {
+    SegmentInternalInterface* segment{nullptr};
+    std::vector<int64_t> segment_offsets;
+    std::vector<int64_t> result_positions;
+    std::map<FieldId, std::unique_ptr<DataArray>> fields;
+};
+
+// Build a RecordBatch with the correctly typed but empty columns for the
+// requested output fields. When field_ids_ is empty (zero columns) but
+// total_rows > 0, the batch still reports total_rows rows so that callers
+// see the right row count.
+arrow::Result<std::shared_ptr<arrow::RecordBatch>>
+BuildEmptyRetrieveBatch(milvus::query::RetrievePlan* plan, int64_t total_rows) {
+    std::vector<std::shared_ptr<arrow::Field>> fields;
+    std::vector<std::shared_ptr<arrow::Array>> arrays;
+    fields.reserve(plan->field_ids_.size());
+    arrays.reserve(plan->field_ids_.size());
+
+    for (auto field_id : plan->field_ids_) {
+        auto& field_meta = plan->schema_->operator[](field_id);
+        auto name = std::string(field_meta.get_name().get());
+        ARROW_ASSIGN_OR_RAISE(auto arrow_type,
+                              EmptyExtraFieldArrowType(field_meta));
+        ARROW_ASSIGN_OR_RAISE(auto arr, arrow::MakeEmptyArray(arrow_type));
+        fields.push_back(MilvusField(name,
+                                     arrow_type,
+                                     field_meta.is_nullable(),
+                                     field_id,
+                                     field_meta.get_data_type()));
+        arrays.push_back(std::move(arr));
+    }
+
+    // With zero columns there is no array length to stay consistent with,
+    // so report the true row count. With columns present, each array was
+    // built as MakeEmptyArray (length 0), so the batch must report 0 rows.
+    int64_t num_rows = fields.empty() ? total_rows : 0;
+    return arrow::RecordBatch::Make(
+        arrow::schema(std::move(fields)), num_rows, std::move(arrays));
+}
+
+// Build the non-empty RecordBatch from the field data merged into
+// caller-requested row order, mirroring BuildExplicitFieldsBatch in
+// search_result_export_c.cpp.
+arrow::Result<std::shared_ptr<arrow::RecordBatch>>
+BuildRetrieveFieldsBatch(
+    milvus::query::RetrievePlan* plan,
+    const std::map<FieldId, std::unique_ptr<DataArray>>& ordered_fields,
+    int64_t total_rows) {
+    std::vector<std::shared_ptr<arrow::Field>> fields;
+    std::vector<std::shared_ptr<arrow::Array>> arrays;
+    fields.reserve(plan->field_ids_.size());
+    arrays.reserve(plan->field_ids_.size());
+
+    for (auto field_id : plan->field_ids_) {
+        auto& field_meta = plan->schema_->operator[](field_id);
+        auto name = std::string(field_meta.get_name().get());
+        auto it = ordered_fields.find(field_id);
+        if (it == ordered_fields.end()) {
+            return arrow::Status::Invalid(
+                "missing ordered field data for field id ", field_id.get());
+        }
+        ARROW_ASSIGN_OR_RAISE(auto converted,
+                              FieldDataToArrow(name, *it->second, total_rows));
+        auto array = converted.second;
+        fields.push_back(MilvusField(name,
+                                     array->type(),
+                                     field_meta.is_nullable(),
+                                     field_id,
+                                     field_meta.get_data_type()));
+        arrays.push_back(std::move(array));
+    }
+
+    return arrow::RecordBatch::Make(
+        arrow::schema(std::move(fields)), total_rows, std::move(arrays));
+}
+
+}  // namespace
+
+CStatus
+FillRetrieveFieldsOrdered(CSegmentInterface* segments,
+                          int64_t num_segments,
+                          CRetrievePlan c_plan,
+                          const int32_t* seg_indices,
+                          const int64_t* seg_offsets,
+                          int64_t total_rows,
+                          ArrowSchema* out_schema,
+                          ArrowArray* out_array,
+                          void* cancellation_source) {
+    SCOPE_CGO_CALL_METRIC();
+
+    try {
+        AssertInfo(segments != nullptr, "null segments");
+        AssertInfo(num_segments > 0, "num_segments must be positive");
+        AssertInfo(c_plan != nullptr, "null retrieve plan");
+        AssertInfo(total_rows >= 0, "total_rows must not be negative");
+        AssertInfo(total_rows == 0 || seg_indices != nullptr,
+                   "null seg_indices for non-empty rows");
+        AssertInfo(total_rows == 0 || seg_offsets != nullptr,
+                   "null seg_offsets for non-empty rows");
+        AssertInfo(out_schema != nullptr, "null ArrowSchema output");
+        AssertInfo(out_array != nullptr, "null ArrowArray output");
+        AssertInfo(out_schema->release == nullptr,
+                   "ArrowSchema output must be empty before export");
+        AssertInfo(out_array->release == nullptr,
+                   "ArrowArray output must be empty before export");
+
+        auto cancel_token = folly::CancellationToken();
+        if (cancellation_source != nullptr) {
+            auto source =
+                static_cast<folly::CancellationSource*>(cancellation_source);
+            cancel_token = source->getToken();
+        }
+
+        auto* plan = static_cast<milvus::query::RetrievePlan*>(c_plan);
+
+        std::shared_ptr<arrow::RecordBatch> batch;
+        if (total_rows == 0 || plan->field_ids_.empty()) {
+            auto empty_batch_result = BuildEmptyRetrieveBatch(plan, total_rows);
+            if (!empty_batch_result.ok()) {
+                return milvus::FailureCStatus(
+                    milvus::ErrorCode::UnexpectedError,
+                    empty_batch_result.status().ToString());
+            }
+            batch = *empty_batch_result;
+        } else {
+            // Group rows by segment index (dense, so vector is ideal).
+            std::vector<RetrieveSegmentFields> segment_fields(num_segments);
+            for (int64_t i = 0; i < num_segments; ++i) {
+                segment_fields[i].segment =
+                    static_cast<SegmentInternalInterface*>(segments[i]);
+            }
+            for (int64_t pos = 0; pos < total_rows; ++pos) {
+                auto seg_idx = seg_indices[pos];
+                AssertInfo(seg_idx >= 0 && seg_idx < num_segments,
+                           "segment index {} out of range [0, {})",
+                           seg_idx,
+                           num_segments);
+                segment_fields[seg_idx].result_positions.push_back(pos);
+                segment_fields[seg_idx].segment_offsets.push_back(
+                    seg_offsets[pos]);
+            }
+
+            auto dynamic_field_id = plan->schema_->get_dynamic_field_id();
+
+            // Materialize fields per segment via bulk_subscript.
+            for (auto& materialized : segment_fields) {
+                if (materialized.segment_offsets.empty()) {
+                    continue;
+                }
+                milvus::futures::throwIfCancelled(cancel_token);
+                milvus::OpContext op_ctx(cancel_token);
+                auto read_lease =
+                    AcquireSegmentReadLease(materialized.segment, cancel_token);
+                for (auto field_id : plan->field_ids_) {
+                    milvus::futures::throwIfCancelled(cancel_token);
+                    auto& field_meta = plan->schema_->operator[](field_id);
+                    std::unique_ptr<DataArray> data;
+                    if (dynamic_field_id.has_value() &&
+                        dynamic_field_id.value() == field_id &&
+                        !plan->target_dynamic_fields_.empty()) {
+                        data = materialized.segment->bulk_subscript(
+                            &op_ctx,
+                            field_id,
+                            materialized.segment_offsets.data(),
+                            materialized.segment_offsets.size(),
+                            plan->target_dynamic_fields_);
+                    } else if (!materialized.segment->is_field_exist(
+                                   field_id)) {
+                        data = materialized.segment
+                                   ->bulk_subscript_not_exist_field(
+                                       field_meta,
+                                       materialized.segment_offsets.size());
+                    } else {
+                        data = materialized.segment->bulk_subscript(
+                            &op_ctx,
+                            field_id,
+                            materialized.segment_offsets.data(),
+                            materialized.segment_offsets.size());
+                    }
+                    materialized.fields[field_id] = std::move(data);
+                }
+            }
+
+            // Build result_pairs for MergeDataArray.
+            std::vector<MergeBase> result_pairs(total_rows);
+            for (auto& materialized : segment_fields) {
+                for (size_t row_idx = 0;
+                     row_idx < materialized.result_positions.size();
+                     ++row_idx) {
+                    auto position = materialized.result_positions[row_idx];
+                    result_pairs[position] = {&materialized.fields, row_idx};
+                }
+            }
+
+            // Nullable vector materialization may compact physical vector
+            // values while retaining a logical validity bitmap. Record the
+            // compacted physical offset for each output row before
+            // MergeDataArray scatters rows into final order.
+            for (auto& materialized : segment_fields) {
+                if (materialized.segment_offsets.empty()) {
+                    continue;
+                }
+                for (auto field_id : plan->field_ids_) {
+                    auto& field_meta = plan->schema_->operator[](field_id);
+                    if (!field_meta.is_vector() || !field_meta.is_nullable()) {
+                        continue;
+                    }
+                    auto it = materialized.fields.find(field_id);
+                    if (it == materialized.fields.end()) {
+                        continue;
+                    }
+                    const auto& valid_data =
+                        milvus::GetFieldDataRowValidData(*it->second);
+                    if (valid_data.empty()) {
+                        continue;
+                    }
+                    int64_t valid_index = 0;
+                    for (size_t row_idx = 0;
+                         row_idx < materialized.result_positions.size();
+                         ++row_idx) {
+                        auto position = materialized.result_positions[row_idx];
+                        result_pairs[position].setValidDataOffset(field_id,
+                                                                  valid_index);
+                        if (valid_data[row_idx]) {
+                            ++valid_index;
+                        }
+                    }
+                }
+            }
+
+            // Merge into ordered fields.
+            std::map<FieldId, std::unique_ptr<DataArray>> ordered_fields;
+            for (auto field_id : plan->field_ids_) {
+                auto& field_meta = plan->schema_->operator[](field_id);
+                ordered_fields[field_id] =
+                    MergeDataArray(result_pairs, field_meta);
+            }
+
+            auto batch_result =
+                BuildRetrieveFieldsBatch(plan, ordered_fields, total_rows);
+            if (!batch_result.ok()) {
+                return milvus::FailureCStatus(
+                    milvus::ErrorCode::UnexpectedError,
+                    batch_result.status().ToString());
+            }
+            batch = *batch_result;
+        }
+
+        auto export_status =
+            arrow::ExportRecordBatch(*batch, out_array, out_schema);
+        if (!export_status.ok()) {
+            ReleaseArrowArrayIfNeeded(out_array);
+            ReleaseArrowSchemaIfNeeded(out_schema);
+            return milvus::FailureCStatus(milvus::ErrorCode::UnexpectedError,
+                                          export_status.ToString());
+        }
+        return milvus::SuccessCStatus();
+    } catch (folly::FutureCancellation& e) {
+        return milvus::FailureCStatus(milvus::ErrorCode::FollyCancel, e.what());
+    } catch (std::exception& e) {
+        return milvus::FailureCStatus(&e);
+    }
+}

--- a/internal/core/src/segcore/retrieve_result_export_c.cpp
+++ b/internal/core/src/segcore/retrieve_result_export_c.cpp
@@ -24,6 +24,7 @@
 
 #include "common/EasyAssert.h"
 #include "common/FieldMeta.h"
+#include "common/SystemProperty.h"
 #include "common/Types.h"
 #include "common/Utils.h"
 #include "futures/Future.h"
@@ -100,6 +101,18 @@ BuildEmptyRetrieveBatch(milvus::query::RetrievePlan* plan, int64_t total_rows) {
     arrays.reserve(plan->field_ids_.size());
 
     for (auto field_id : plan->field_ids_) {
+        if (milvus::SystemProperty::Instance().IsSystem(field_id)) {
+            auto arrow_type = arrow::int64();
+            ARROW_ASSIGN_OR_RAISE(auto arr, arrow::MakeEmptyArray(arrow_type));
+            fields.push_back(MilvusField(
+                field_id.get() == 0 ? "RowID" : "Timestamp",
+                arrow_type,
+                false,
+                field_id,
+                milvus::DataType::INT64));
+            arrays.push_back(std::move(arr));
+            continue;
+        }
         auto& field_meta = plan->schema_->operator[](field_id);
         auto name = std::string(field_meta.get_name().get());
         ARROW_ASSIGN_OR_RAISE(auto arrow_type,
@@ -135,13 +148,25 @@ BuildRetrieveFieldsBatch(
     arrays.reserve(plan->field_ids_.size());
 
     for (auto field_id : plan->field_ids_) {
-        auto& field_meta = plan->schema_->operator[](field_id);
-        auto name = std::string(field_meta.get_name().get());
         auto it = ordered_fields.find(field_id);
         if (it == ordered_fields.end()) {
             return arrow::Status::Invalid(
                 "missing ordered field data for field id ", field_id.get());
         }
+        if (milvus::SystemProperty::Instance().IsSystem(field_id)) {
+            auto name =
+                field_id.get() == 0 ? std::string("RowID") : std::string("Timestamp");
+            ARROW_ASSIGN_OR_RAISE(
+                auto converted,
+                FieldDataToArrow(name, *it->second, total_rows));
+            auto array = converted.second;
+            fields.push_back(MilvusField(
+                name, array->type(), false, field_id, milvus::DataType::INT64));
+            arrays.push_back(std::move(array));
+            continue;
+        }
+        auto& field_meta = plan->schema_->operator[](field_id);
+        auto name = std::string(field_meta.get_name().get());
         ARROW_ASSIGN_OR_RAISE(auto converted,
                               FieldDataToArrow(name, *it->second, total_rows));
         auto array = converted.second;
@@ -236,6 +261,30 @@ FillRetrieveFieldsOrdered(CSegmentInterface* segments,
                     AcquireSegmentReadLease(materialized.segment, cancel_token);
                 for (auto field_id : plan->field_ids_) {
                     milvus::futures::throwIfCancelled(cancel_token);
+                    if (milvus::SystemProperty::Instance().IsSystem(
+                            field_id)) {
+                        auto system_type = milvus::SystemProperty::Instance()
+                                               .GetSystemFieldType(field_id);
+                        auto count = materialized.segment_offsets.size();
+                        milvus::FixedVector<int64_t> output(count);
+                        materialized.segment->bulk_subscript(
+                            &op_ctx,
+                            system_type,
+                            materialized.segment_offsets.data(),
+                            count,
+                            output.data());
+                        auto data_array = std::make_unique<DataArray>();
+                        data_array->set_field_id(field_id.get());
+                        data_array->set_type(
+                            milvus::proto::schema::DataType::Int64);
+                        auto* obj = data_array->mutable_scalars()
+                                        ->mutable_long_data();
+                        auto* raw =
+                            reinterpret_cast<const int64_t*>(output.data());
+                        obj->mutable_data()->Add(raw, raw + count);
+                        materialized.fields[field_id] = std::move(data_array);
+                        continue;
+                    }
                     auto& field_meta = plan->schema_->operator[](field_id);
                     std::unique_ptr<DataArray> data;
                     if (dynamic_field_id.has_value() &&
@@ -284,6 +333,10 @@ FillRetrieveFieldsOrdered(CSegmentInterface* segments,
                     continue;
                 }
                 for (auto field_id : plan->field_ids_) {
+                    if (milvus::SystemProperty::Instance().IsSystem(
+                            field_id)) {
+                        continue;
+                    }
                     auto& field_meta = plan->schema_->operator[](field_id);
                     if (!field_meta.is_vector() || !field_meta.is_nullable()) {
                         continue;
@@ -314,9 +367,81 @@ FillRetrieveFieldsOrdered(CSegmentInterface* segments,
             // Merge into ordered fields.
             std::map<FieldId, std::unique_ptr<DataArray>> ordered_fields;
             for (auto field_id : plan->field_ids_) {
+                if (milvus::SystemProperty::Instance().IsSystem(field_id)) {
+                    auto merged = std::make_unique<DataArray>();
+                    merged->set_field_id(field_id.get());
+                    merged->set_type(
+                        milvus::proto::schema::DataType::Int64);
+                    auto* obj =
+                        merged->mutable_scalars()->mutable_long_data();
+                    for (int64_t i = 0; i < total_rows; ++i) {
+                        auto& base = result_pairs[i];
+                        auto it = base.fields_data_->find(field_id);
+                        AssertInfo(
+                            it != base.fields_data_->end(),
+                            "missing system field {} in segment data",
+                            field_id.get());
+                        auto val = it->second->scalars()
+                                       .long_data()
+                                       .data(base.src_offset_);
+                        obj->add_data(val);
+                    }
+                    ordered_fields[field_id] = std::move(merged);
+                    continue;
+                }
                 auto& field_meta = plan->schema_->operator[](field_id);
                 ordered_fields[field_id] =
                     MergeDataArray(result_pairs, field_meta);
+                if (field_meta.is_vector() && field_meta.is_nullable()) {
+                    auto& da = ordered_fields[field_id];
+                    auto& vecs = *da->mutable_vectors();
+                    bool has_subtype =
+                        vecs.has_float_vector() || vecs.has_binary_vector() ||
+                        vecs.has_float16_vector() ||
+                        vecs.has_bfloat16_vector() ||
+                        vecs.has_int8_vector() ||
+                        vecs.has_sparse_float_vector() ||
+                        vecs.has_vector_array();
+                    if (!has_subtype) {
+                        auto dt = field_meta.get_data_type();
+                        auto dim = milvus::IsSparseFloatVectorDataType(dt)
+                                       ? 0
+                                       : field_meta.get_dim();
+                        if (dim > 0) {
+                            vecs.set_dim(dim);
+                        }
+                        switch (dt) {
+                            case milvus::DataType::VECTOR_FLOAT:
+                                vecs.mutable_float_vector();
+                                break;
+                            case milvus::DataType::VECTOR_BINARY:
+                                vecs.mutable_binary_vector();
+                                break;
+                            case milvus::DataType::VECTOR_FLOAT16:
+                                vecs.mutable_float16_vector();
+                                break;
+                            case milvus::DataType::VECTOR_BFLOAT16:
+                                vecs.mutable_bfloat16_vector();
+                                break;
+                            case milvus::DataType::VECTOR_INT8:
+                                vecs.mutable_int8_vector();
+                                break;
+                            case milvus::DataType::VECTOR_SPARSE_U32_F32:
+                                vecs.mutable_sparse_float_vector();
+                                break;
+                            case milvus::DataType::VECTOR_ARRAY: {
+                                auto* obj = vecs.mutable_vector_array();
+                                obj->set_dim(dim);
+                                obj->set_element_type(
+                                    milvus::proto::schema::DataType(
+                                        field_meta.get_element_type()));
+                                break;
+                            }
+                            default:
+                                break;
+                        }
+                    }
+                }
             }
 
             auto batch_result =

--- a/internal/core/src/segcore/retrieve_result_export_c.cpp
+++ b/internal/core/src/segcore/retrieve_result_export_c.cpp
@@ -104,12 +104,12 @@ BuildEmptyRetrieveBatch(milvus::query::RetrievePlan* plan, int64_t total_rows) {
         if (milvus::SystemProperty::Instance().IsSystem(field_id)) {
             auto arrow_type = arrow::int64();
             ARROW_ASSIGN_OR_RAISE(auto arr, arrow::MakeEmptyArray(arrow_type));
-            fields.push_back(MilvusField(
-                field_id.get() == 0 ? "RowID" : "Timestamp",
-                arrow_type,
-                false,
-                field_id,
-                milvus::DataType::INT64));
+            fields.push_back(
+                MilvusField(field_id.get() == 0 ? "RowID" : "Timestamp",
+                            arrow_type,
+                            false,
+                            field_id,
+                            milvus::DataType::INT64));
             arrays.push_back(std::move(arr));
             continue;
         }
@@ -154,8 +154,8 @@ BuildRetrieveFieldsBatch(
                 "missing ordered field data for field id ", field_id.get());
         }
         if (milvus::SystemProperty::Instance().IsSystem(field_id)) {
-            auto name =
-                field_id.get() == 0 ? std::string("RowID") : std::string("Timestamp");
+            auto name = field_id.get() == 0 ? std::string("RowID")
+                                            : std::string("Timestamp");
             ARROW_ASSIGN_OR_RAISE(
                 auto converted,
                 FieldDataToArrow(name, *it->second, total_rows));
@@ -261,8 +261,7 @@ FillRetrieveFieldsOrdered(CSegmentInterface* segments,
                     AcquireSegmentReadLease(materialized.segment, cancel_token);
                 for (auto field_id : plan->field_ids_) {
                     milvus::futures::throwIfCancelled(cancel_token);
-                    if (milvus::SystemProperty::Instance().IsSystem(
-                            field_id)) {
+                    if (milvus::SystemProperty::Instance().IsSystem(field_id)) {
                         auto system_type = milvus::SystemProperty::Instance()
                                                .GetSystemFieldType(field_id);
                         auto count = materialized.segment_offsets.size();
@@ -277,8 +276,8 @@ FillRetrieveFieldsOrdered(CSegmentInterface* segments,
                         data_array->set_field_id(field_id.get());
                         data_array->set_type(
                             milvus::proto::schema::DataType::Int64);
-                        auto* obj = data_array->mutable_scalars()
-                                        ->mutable_long_data();
+                        auto* obj =
+                            data_array->mutable_scalars()->mutable_long_data();
                         auto* raw =
                             reinterpret_cast<const int64_t*>(output.data());
                         obj->mutable_data()->Add(raw, raw + count);
@@ -333,8 +332,7 @@ FillRetrieveFieldsOrdered(CSegmentInterface* segments,
                     continue;
                 }
                 for (auto field_id : plan->field_ids_) {
-                    if (milvus::SystemProperty::Instance().IsSystem(
-                            field_id)) {
+                    if (milvus::SystemProperty::Instance().IsSystem(field_id)) {
                         continue;
                     }
                     auto& field_meta = plan->schema_->operator[](field_id);
@@ -370,20 +368,16 @@ FillRetrieveFieldsOrdered(CSegmentInterface* segments,
                 if (milvus::SystemProperty::Instance().IsSystem(field_id)) {
                     auto merged = std::make_unique<DataArray>();
                     merged->set_field_id(field_id.get());
-                    merged->set_type(
-                        milvus::proto::schema::DataType::Int64);
-                    auto* obj =
-                        merged->mutable_scalars()->mutable_long_data();
+                    merged->set_type(milvus::proto::schema::DataType::Int64);
+                    auto* obj = merged->mutable_scalars()->mutable_long_data();
                     for (int64_t i = 0; i < total_rows; ++i) {
                         auto& base = result_pairs[i];
-                        auto it = base.fields_data_->find(field_id);
-                        AssertInfo(
-                            it != base.fields_data_->end(),
-                            "missing system field {} in segment data",
-                            field_id.get());
-                        auto val = it->second->scalars()
-                                       .long_data()
-                                       .data(base.src_offset_);
+                        auto* da = base.get_field_data(field_id);
+                        AssertInfo(da != nullptr,
+                                   "missing system field {} in segment data",
+                                   field_id.get());
+                        auto val =
+                            da->scalars().long_data().data(base.getOffset());
                         obj->add_data(val);
                     }
                     ordered_fields[field_id] = std::move(merged);
@@ -398,8 +392,7 @@ FillRetrieveFieldsOrdered(CSegmentInterface* segments,
                     bool has_subtype =
                         vecs.has_float_vector() || vecs.has_binary_vector() ||
                         vecs.has_float16_vector() ||
-                        vecs.has_bfloat16_vector() ||
-                        vecs.has_int8_vector() ||
+                        vecs.has_bfloat16_vector() || vecs.has_int8_vector() ||
                         vecs.has_sparse_float_vector() ||
                         vecs.has_vector_array();
                     if (!has_subtype) {

--- a/internal/core/src/segcore/retrieve_result_export_c.h
+++ b/internal/core/src/segcore/retrieve_result_export_c.h
@@ -1,0 +1,53 @@
+// Copyright (C) 2019-2026 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+#include "common/type_c.h"
+#include "segcore/segment_c.h"
+#include "segcore/plan_c.h"
+
+struct ArrowSchema;
+struct ArrowArray;
+
+// Read output fields from multiple segments and export one Arrow
+// RecordBatch in the caller-provided row order.
+//
+// segments[seg_indices[i]] provides the data for output row i,
+// at the segment-internal offset seg_offsets[i].
+//
+// Internally: groups rows by segment, calls bulk_subscript per
+// segment, merges via MergeDataArray into the requested order,
+// converts to Arrow via BuildExplicitFieldsBatch, and exports
+// via arrow::ExportRecordBatch.
+//
+// Caller owns out_schema/out_array and must release them through
+// the Arrow C Data Interface.
+CStatus
+FillRetrieveFieldsOrdered(CSegmentInterface* segments,
+                          int64_t num_segments,
+                          CRetrievePlan c_plan,
+                          const int32_t* seg_indices,
+                          const int64_t* seg_offsets,
+                          int64_t total_rows,
+                          struct ArrowSchema* out_schema,
+                          struct ArrowArray* out_array,
+                          void* cancellation_source);
+
+#ifdef __cplusplus
+}
+#endif

--- a/internal/core/src/segcore/search_result_export_c.cpp
+++ b/internal/core/src/segcore/search_result_export_c.cpp
@@ -42,10 +42,14 @@
 #include "segcore/SegmentInterface.h"
 #include "segcore/SegmentReadLease.h"
 #include "segcore/Utils.h"
+#include "segcore/arrow_field_utils.h"
 #include "segcore/reduce/Reduce.h"
 #include "storage/ThreadPools.h"
 
 using SearchResult = milvus::SearchResult;
+using milvus::segcore::EmptyExtraFieldArrowType;
+using milvus::segcore::FieldDataToArrow;
+using milvus::segcore::MilvusField;
 
 namespace {
 
@@ -108,27 +112,6 @@ AssertSearchResultReadLease(const SearchResult* result) {
     }
 }
 
-constexpr const char* kMilvusFieldIDMetadataKey = "milvus.field_id";
-constexpr const char* kMilvusDataTypeMetadataKey = "milvus.data_type";
-
-std::shared_ptr<arrow::KeyValueMetadata>
-MilvusFieldMetadata(milvus::FieldId field_id, milvus::DataType data_type) {
-    return arrow::key_value_metadata(
-        {kMilvusFieldIDMetadataKey, kMilvusDataTypeMetadataKey},
-        {std::to_string(field_id.get()),
-         std::to_string(static_cast<int32_t>(data_type))});
-}
-
-std::shared_ptr<arrow::Field>
-MilvusField(const std::string& name,
-            const std::shared_ptr<arrow::DataType>& arrow_type,
-            bool nullable,
-            milvus::FieldId field_id,
-            milvus::DataType data_type) {
-    return arrow::field(
-        name, arrow_type, nullable, MilvusFieldMetadata(field_id, data_type));
-}
-
 void
 SetFieldDataElementTypeIfNeeded(milvus::proto::schema::FieldData* field_data,
                                 const milvus::FieldMeta& field_meta) {
@@ -166,36 +149,6 @@ SerializeSearchResultDataToCProto(
 std::string
 GroupByColumnName(milvus::FieldId field_id) {
     return "$group_by_" + std::to_string(field_id.get());
-}
-
-arrow::Result<std::shared_ptr<arrow::DataType>>
-EmptyExtraFieldArrowType(const milvus::FieldMeta& field_meta) {
-    switch (field_meta.get_data_type()) {
-        case milvus::DataType::BOOL:
-            return arrow::boolean();
-        case milvus::DataType::INT8:
-        case milvus::DataType::INT16:
-        case milvus::DataType::INT32:
-            return arrow::int32();
-        case milvus::DataType::INT64:
-        case milvus::DataType::TIMESTAMPTZ:
-            return arrow::int64();
-        case milvus::DataType::FLOAT:
-            return arrow::float32();
-        case milvus::DataType::DOUBLE:
-            return arrow::float64();
-        case milvus::DataType::STRING:
-        case milvus::DataType::VARCHAR:
-        case milvus::DataType::TEXT:
-            return arrow::utf8();
-        case milvus::DataType::JSON:
-            return arrow::binary();
-        case milvus::DataType::GEOMETRY:
-            return arrow::Status::NotImplemented(
-                "GEOMETRY extra field Arrow export is not implemented");
-        default:
-            return milvus::GetArrowDataType(field_meta.get_data_type());
-    }
 }
 
 std::vector<GroupByArrowInfo>
@@ -324,72 +277,6 @@ BuildEmptyBatch(milvus::query::Plan* plan,
     return arrow::RecordBatch::Make(arrow::schema(fields), 0, arrays);
 }
 
-// BuildFixedWidthArray builds an Arrow Array from a fixed-width protobuf repeated field.
-template <typename BuilderType, typename DataContainer>
-arrow::Result<std::shared_ptr<arrow::Array>>
-BuildFixedWidthArray(const DataContainer& data,
-                     const milvus::DataArray& field_data,
-                     size_t total_valid) {
-    AssertInfo(static_cast<size_t>(data.size()) >= total_valid,
-               "field data length {} is smaller than expected row count {}",
-               data.size(),
-               total_valid);
-    const auto& valid_data = milvus::GetFieldDataRowValidData(field_data);
-    const bool has_valid_data = !valid_data.empty();
-    if (has_valid_data) {
-        AssertInfo(static_cast<size_t>(valid_data.size()) == total_valid,
-                   "valid_data length {} does not match expected row count {}",
-                   valid_data.size(),
-                   total_valid);
-    }
-
-    BuilderType builder;
-    ARROW_RETURN_NOT_OK(builder.Reserve(total_valid));
-    for (size_t i = 0; i < total_valid; ++i) {
-        if (has_valid_data && !valid_data[i]) {
-            ARROW_RETURN_NOT_OK(builder.AppendNull());
-            continue;
-        }
-        builder.UnsafeAppend(data[i]);
-    }
-    std::shared_ptr<arrow::Array> arr;
-    ARROW_RETURN_NOT_OK(builder.Finish(&arr));
-    return arr;
-}
-
-// BuildVarLenArray builds an Arrow Array from a variable-length protobuf repeated field.
-template <typename BuilderType, typename DataContainer>
-arrow::Result<std::shared_ptr<arrow::Array>>
-BuildVarLenArray(const DataContainer& data,
-                 const milvus::DataArray& field_data,
-                 size_t total_valid) {
-    AssertInfo(static_cast<size_t>(data.size()) >= total_valid,
-               "field data length {} is smaller than expected row count {}",
-               data.size(),
-               total_valid);
-    const auto& valid_data = milvus::GetFieldDataRowValidData(field_data);
-    const bool has_valid_data = !valid_data.empty();
-    if (has_valid_data) {
-        AssertInfo(static_cast<size_t>(valid_data.size()) == total_valid,
-                   "valid_data length {} does not match expected row count {}",
-                   valid_data.size(),
-                   total_valid);
-    }
-
-    BuilderType builder;
-    ARROW_RETURN_NOT_OK(builder.Reserve(total_valid));
-    for (size_t i = 0; i < total_valid; ++i) {
-        if (has_valid_data && !valid_data[i]) {
-            ARROW_RETURN_NOT_OK(builder.AppendNull());
-            continue;
-        }
-        ARROW_RETURN_NOT_OK(builder.Append(data[i]));
-    }
-    std::shared_ptr<arrow::Array> arr;
-    ARROW_RETURN_NOT_OK(builder.Finish(&arr));
-    return arr;
-}
-
 // Build the $group_by Arrow array from SearchResult::composite_group_by_values_,
 // dispatching on the resolved element type. Each entry in `values` is an
 // std::optional<std::variant<monostate, ints..., bool, string>>; entries that
@@ -439,79 +326,6 @@ BuildGroupByArray(const std::vector<milvus::GroupByValueType>& values,
             return arrow::Status::NotImplemented(
                 "unsupported group-by element type in Arrow export");
     }
-}
-
-// Convert a protobuf FieldData (scalar) to an Arrow Array + Field.
-arrow::Result<
-    std::pair<std::shared_ptr<arrow::Field>, std::shared_ptr<arrow::Array>>>
-FieldDataToArrow(const std::string& field_name,
-                 const milvus::DataArray& field_data,
-                 size_t total_valid) {
-    if (!field_data.has_scalars()) {
-        return arrow::Status::NotImplemented(
-            "non-scalar output field not supported in Arrow export");
-    }
-    const auto& scalars = field_data.scalars();
-
-    if (scalars.has_bool_data()) {
-        ARROW_ASSIGN_OR_RAISE(
-            auto arr,
-            BuildFixedWidthArray<arrow::BooleanBuilder>(
-                scalars.bool_data().data(), field_data, total_valid));
-        return std::make_pair(arrow::field(field_name, arrow::boolean()), arr);
-    }
-    if (scalars.has_int_data()) {
-        ARROW_ASSIGN_OR_RAISE(
-            auto arr,
-            BuildFixedWidthArray<arrow::Int32Builder>(
-                scalars.int_data().data(), field_data, total_valid));
-        return std::make_pair(arrow::field(field_name, arrow::int32()), arr);
-    }
-    if (scalars.has_long_data()) {
-        ARROW_ASSIGN_OR_RAISE(
-            auto arr,
-            BuildFixedWidthArray<arrow::Int64Builder>(
-                scalars.long_data().data(), field_data, total_valid));
-        return std::make_pair(arrow::field(field_name, arrow::int64()), arr);
-    }
-    if (scalars.has_timestamptz_data()) {
-        ARROW_ASSIGN_OR_RAISE(
-            auto arr,
-            BuildFixedWidthArray<arrow::Int64Builder>(
-                scalars.timestamptz_data().data(), field_data, total_valid));
-        return std::make_pair(arrow::field(field_name, arrow::int64()), arr);
-    }
-    if (scalars.has_float_data()) {
-        ARROW_ASSIGN_OR_RAISE(
-            auto arr,
-            BuildFixedWidthArray<arrow::FloatBuilder>(
-                scalars.float_data().data(), field_data, total_valid));
-        return std::make_pair(arrow::field(field_name, arrow::float32()), arr);
-    }
-    if (scalars.has_double_data()) {
-        ARROW_ASSIGN_OR_RAISE(
-            auto arr,
-            BuildFixedWidthArray<arrow::DoubleBuilder>(
-                scalars.double_data().data(), field_data, total_valid));
-        return std::make_pair(arrow::field(field_name, arrow::float64()), arr);
-    }
-    if (scalars.has_string_data()) {
-        ARROW_ASSIGN_OR_RAISE(
-            auto arr,
-            BuildVarLenArray<arrow::StringBuilder>(
-                scalars.string_data().data(), field_data, total_valid));
-        return std::make_pair(arrow::field(field_name, arrow::utf8()), arr);
-    }
-    if (scalars.has_json_data()) {
-        ARROW_ASSIGN_OR_RAISE(
-            auto arr,
-            BuildVarLenArray<arrow::BinaryBuilder>(
-                scalars.json_data().data(), field_data, total_valid));
-        return std::make_pair(arrow::field(field_name, arrow::binary()), arr);
-    }
-
-    return arrow::Status::NotImplemented(
-        "unsupported scalar type in Arrow export");
 }
 
 // Build Arrow RecordBatch from a SearchResult that has been filtered and had PKs filled.

--- a/internal/core/src/segcore/search_result_export_c_test.cpp
+++ b/internal/core/src/segcore/search_result_export_c_test.cpp
@@ -953,9 +953,8 @@ TEST(
         (*batch_result)->schema()->field(4)->type()->Equals(arrow::int32()));
 }
 
-TEST(
-    SearchResultExport,
-    ExportSearchResultAsArrowRecordBatch_EmptyGeometryExtraFieldNotImplemented) {
+TEST(SearchResultExport,
+     ExportSearchResultAsArrowRecordBatch_EmptyGeometryExtraField) {
     using namespace milvus;
 
     auto schema = std::make_shared<Schema>();
@@ -991,11 +990,16 @@ TEST(
         nullptr);
     [[maybe_unused]] auto stream_chunk_sizes_guard =
         AdoptChunkSizes(stream_chunk_sizes);
-    EXPECT_NE(status.error_code, 0);
-    EXPECT_NE(std::string(status.error_msg)
-                  .find("GEOMETRY extra field Arrow export is not implemented"),
-              std::string::npos);
-    free(const_cast<char*>(status.error_msg));
+    ASSERT_EQ(status.error_code, 0) << status.error_msg;
+
+    auto batch_result =
+        ImportExportedRecordBatch(&stream_array, &stream_schema);
+    ASSERT_TRUE(batch_result.ok()) << batch_result.status().ToString();
+    auto batch = *batch_result;
+    EXPECT_EQ(batch->num_rows(), 0);
+    auto geom_col = batch->GetColumnByName("extra_geom");
+    ASSERT_NE(geom_col, nullptr);
+    EXPECT_TRUE(geom_col->type()->Equals(arrow::binary()));
 }
 
 TEST(SearchResultExport,

--- a/internal/querynodev2/segments/ignore_non_pk_arrow_test.go
+++ b/internal/querynodev2/segments/ignore_non_pk_arrow_test.go
@@ -1,0 +1,575 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package segments
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/mocks/util/mock_segcore"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/initcore"
+	"github.com/milvus-io/milvus/internal/util/segcore"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/segcorepb"
+	"github.com/milvus-io/milvus/pkg/v3/util/conc"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+// =========================================================================
+// Shared fixture: 2 sealed segments, PK/Float/FloatVector output fields.
+//
+// mock_segcore.GenSimpleRetrievePlan only sets OutputFieldIds to the PK
+// field, which is not enough to exercise the Arrow bulk column path (we
+// need a scalar and a vector column too). fetchFieldsAsRecord/
+// fetchFieldsViaProto are offset-based (segIndices/segOffsets are supplied
+// explicitly), so the plan's predicate expr is never evaluated for these
+// calls -- only plan.OutputFieldIds (which becomes the C++ side's
+// field_ids_, i.e. the Arrow record's column order) matters. We therefore
+// build a small retrieve plan here mirroring
+// mock_segcore.genSimpleRetrievePlanExpr but with a 3-field OutputFieldIds
+// list, and pass the exact same field order as fieldSchemas to
+// segcore.ArrowFieldsToProto (matching how query_pipeline.go's
+// buildIgnoreNonPkPipeline builds fieldSchemas from OutputFieldsId).
+// =========================================================================
+
+// buildArrowTestRetrievePlanExpr mirrors mock_segcore's internal
+// genSimpleRetrievePlanExpr, but allows the caller to choose which fields
+// are requested as output (OutputFieldIds -> plan.field_ids_ -> the Arrow
+// record's column order).
+func buildArrowTestRetrievePlanExpr(schema *schemapb.CollectionSchema, outputFieldIDs []int64) ([]byte, error) {
+	pkField, err := typeutil.GetPrimaryFieldSchema(schema)
+	if err != nil {
+		return nil, err
+	}
+	planNode := &planpb.PlanNode{
+		Node: &planpb.PlanNode_Predicates{
+			Predicates: &planpb.Expr{
+				Expr: &planpb.Expr_TermExpr{
+					TermExpr: &planpb.TermExpr{
+						ColumnInfo: &planpb.ColumnInfo{
+							FieldId:  pkField.FieldID,
+							DataType: pkField.DataType,
+						},
+						Values: []*planpb.GenericValue{
+							{Val: &planpb.GenericValue_Int64Val{Int64Val: 1}},
+							{Val: &planpb.GenericValue_Int64Val{Int64Val: 2}},
+							{Val: &planpb.GenericValue_Int64Val{Int64Val: 3}},
+						},
+					},
+				},
+			},
+		},
+		OutputFieldIds: outputFieldIDs,
+	}
+	return proto.Marshal(planNode)
+}
+
+func buildArrowTestRetrievePlan(collection *segcore.CCollection, outputFieldIDs []int64) (*segcore.RetrievePlan, error) {
+	exprBytes, err := buildArrowTestRetrievePlanExpr(collection.Schema(), outputFieldIDs)
+	if err != nil {
+		return nil, err
+	}
+	return segcore.NewRetrievePlan(collection, exprBytes, typeutil.Timestamp(1000), 100, 0, 0, 0)
+}
+
+func mustFindFieldByType(tb testing.TB, schema *schemapb.CollectionSchema, dt schemapb.DataType) *schemapb.FieldSchema {
+	tb.Helper()
+	for _, f := range schema.GetFields() {
+		if f.GetDataType() == dt {
+			return f
+		}
+	}
+	tb.Fatalf("schema has no field of type %s", dt)
+	return nil
+}
+
+type arrowFetchFixture struct {
+	ctx          context.Context
+	rootPath     string
+	chunkManager storage.ChunkManager
+	manager      *Manager
+	collection   *Collection
+	segments     []Segment
+	plan         *segcore.RetrievePlan
+	fieldSchemas []*schemapb.FieldSchema // in plan.OutputFieldIds order
+	merged       *MergedResultWithOffsets
+}
+
+// setupArrowFetchFixture loads 2 sealed segments with rowsPerSegment rows
+// each (Int64 PK, Float scalar, FloatVector -- dim taken from
+// mock_segcore.GenTestCollectionSchema, currently mock_segcore.DefaultDim
+// = 128) and builds a MergedResultWithOffsets that selects every row from
+// both segments (interleaved by segment), simulating the output of
+// Phase 1 (NewMergeByPKWithOffsetsOperator) for the correctness test and
+// the benchmarks below.
+func setupArrowFetchFixture(tb testing.TB, rowsPerSegment int) *arrowFetchFixture {
+	tb.Helper()
+	paramtable.Init()
+
+	ctx := context.Background()
+	rootPath := tb.Name()
+
+	chunkManagerFactory := storage.NewTestChunkManagerFactory(paramtable.Get(), rootPath)
+	chunkManager, err := chunkManagerFactory.NewPersistentStorageChunkManager(ctx)
+	require.NoError(tb, err)
+	initcore.InitRemoteChunkManager(paramtable.Get())
+	initcore.InitLocalChunkManager(rootPath)
+	initcore.InitMmapManager(paramtable.Get(), 1)
+	initcore.InitTieredStorage(paramtable.Get())
+
+	collectionID := int64(90000)
+	partitionID := int64(9000)
+
+	manager := NewManager()
+	schema := mock_segcore.GenTestCollectionSchema("test-arrow-fetch", schemapb.DataType_Int64, true)
+	indexMeta := mock_segcore.GenTestIndexMeta(collectionID, schema)
+	err = manager.Collection.PutOrRef(collectionID, schema, indexMeta, &querypb.LoadMetaInfo{
+		LoadType:     querypb.LoadType_LoadCollection,
+		CollectionID: collectionID,
+		PartitionIDs: []int64{partitionID},
+	})
+	require.NoError(tb, err)
+	collection := manager.Collection.Get(collectionID)
+	loader := NewLoader(ctx, manager, chunkManager)
+
+	segments := make([]Segment, 0, 2)
+	for i := range 2 {
+		segmentID := int64(90100 + i)
+		binlogs, statslogs, err := mock_segcore.SaveBinLog(ctx,
+			collectionID, partitionID, segmentID, rowsPerSegment, schema, chunkManager)
+		require.NoError(tb, err)
+
+		loadInfo := &querypb.SegmentLoadInfo{
+			SegmentID:     segmentID,
+			CollectionID:  collectionID,
+			PartitionID:   partitionID,
+			NumOfRows:     int64(rowsPerSegment),
+			BinlogPaths:   binlogs,
+			Statslogs:     statslogs,
+			InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID),
+			Level:         datapb.SegmentLevel_Legacy,
+		}
+
+		seg, err := NewSegment(ctx, collection, manager.Segment, SegmentTypeSealed, 0, loadInfo)
+		require.NoError(tb, err)
+
+		bfs, err := loader.loadSingleBloomFilterSet(ctx, collectionID, loadInfo, SegmentTypeSealed)
+		require.NoError(tb, err)
+		seg.SetPKCandidate(bfs)
+
+		localSeg, ok := seg.(*LocalSegment)
+		require.True(tb, ok, "sealed segment must be *LocalSegment for the Arrow retrieve path")
+		for _, binlog := range binlogs {
+			require.NoError(tb, localSeg.LoadFieldData(ctx, binlog.FieldID, int64(rowsPerSegment), binlog))
+		}
+
+		manager.Segment.Put(ctx, SegmentTypeSealed, seg)
+		segments = append(segments, seg)
+	}
+
+	pkField, err := typeutil.GetPrimaryFieldSchema(schema)
+	require.NoError(tb, err)
+	floatField := mustFindFieldByType(tb, schema, schemapb.DataType_Float)
+	floatVecField := mustFindFieldByType(tb, schema, schemapb.DataType_FloatVector)
+
+	fieldSchemas := []*schemapb.FieldSchema{pkField, floatField, floatVecField}
+	outputFieldIDs := []int64{pkField.GetFieldID(), floatField.GetFieldID(), floatVecField.GetFieldID()}
+
+	plan, err := buildArrowTestRetrievePlan(collection.GetCCollection(), outputFieldIDs)
+	require.NoError(tb, err)
+
+	selections := make([]OffsetSelection, 0, rowsPerSegment*len(segments))
+	ids := make([]int64, 0, rowsPerSegment*len(segments))
+	var pk int64
+	for segIdx := range segments {
+		for off := 0; off < rowsPerSegment; off++ {
+			selections = append(selections, OffsetSelection{SegmentIndex: segIdx, Offset: int64(off)})
+			ids = append(ids, pk)
+			pk++
+		}
+	}
+
+	merged := &MergedResultWithOffsets{
+		IDs:        makeSegcoreIntIDs(ids),
+		Selections: selections,
+	}
+
+	return &arrowFetchFixture{
+		ctx:          ctx,
+		rootPath:     rootPath,
+		chunkManager: chunkManager,
+		manager:      manager,
+		collection:   collection,
+		segments:     segments,
+		plan:         plan,
+		fieldSchemas: fieldSchemas,
+		merged:       merged,
+	}
+}
+
+func (f *arrowFetchFixture) teardown() {
+	f.plan.Delete()
+	for _, seg := range f.segments {
+		seg.Release(f.ctx)
+	}
+	DeleteCollection(f.collection)
+	f.chunkManager.RemoveWithPrefix(f.ctx, f.rootPath)
+}
+
+// =========================================================================
+// Correctness test
+// =========================================================================
+
+// TestFetchFieldsData_ArrowMatchesRetrieveByOffsets verifies that
+// fetchFieldsAsRecord (+ segcore.ArrowFieldsToProto) produces the same
+// data as per-segment RetrieveByOffsets, manually interleaved in
+// PK-sorted order (the reference path).
+func TestFetchFieldsData_ArrowMatchesRetrieveByOffsets(t *testing.T) {
+	fx := setupArrowFetchFixture(t, 50)
+	defer fx.teardown()
+
+	// Arrow path.
+	rec, err := fetchFieldsAsRecord(fx.ctx, fx.segments, fx.plan, fx.merged)
+	require.NoError(t, err)
+	defer rec.Release()
+	require.Equal(t, len(fx.fieldSchemas), int(rec.NumCols()), "Arrow record column count must match requested output fields")
+	require.Equal(t, int64(len(fx.merged.Selections)), rec.NumRows())
+
+	arrowFieldsData, err := segcore.ArrowFieldsToProto(rec, fx.fieldSchemas)
+	require.NoError(t, err)
+	require.Len(t, arrowFieldsData, len(fx.fieldSchemas))
+
+	// Reference: per-segment RetrieveByOffsets + manual interleave.
+	offsetsBySegment := make([][]int64, len(fx.segments))
+	for _, sel := range fx.merged.Selections {
+		offsetsBySegment[sel.SegmentIndex] = append(offsetsBySegment[sel.SegmentIndex], sel.Offset)
+	}
+	segResults := make([]*segcorepb.RetrieveResults, len(fx.segments))
+	for segIdx, offsets := range offsetsBySegment {
+		r, err := fx.segments[segIdx].RetrieveByOffsets(fx.ctx, &segcore.RetrievePlanWithOffsets{
+			RetrievePlan: fx.plan,
+			Offsets:      offsets,
+		})
+		require.NoError(t, err)
+		segResults[segIdx] = r
+	}
+
+	// Interleave per-segment results into PK-sorted order.
+	var refFieldsData []*schemapb.FieldData
+	for _, r := range segResults {
+		if r != nil && len(r.GetFieldsData()) != 0 {
+			refFieldsData = typeutil.PrepareResultFieldData(r.GetFieldsData(), int64(len(fx.merged.Selections)))
+			break
+		}
+	}
+	require.NotNil(t, refFieldsData, "reference path produced no fields")
+
+	idxComputers := make([]*typeutil.FieldDataIdxComputer, len(segResults))
+	for i, r := range segResults {
+		if r != nil {
+			idxComputers[i] = typeutil.NewFieldDataIdxComputer(r.GetFieldsData())
+		}
+	}
+	segResOffset := make([]int64, len(segResults))
+	for _, sel := range fx.merged.Selections {
+		r := segResults[sel.SegmentIndex]
+		if r == nil {
+			continue
+		}
+		fieldIdxs := idxComputers[sel.SegmentIndex].Compute(segResOffset[sel.SegmentIndex])
+		typeutil.AppendFieldData(refFieldsData, r.GetFieldsData(), segResOffset[sel.SegmentIndex], fieldIdxs...)
+		segResOffset[sel.SegmentIndex]++
+	}
+
+	require.Len(t, refFieldsData, len(arrowFieldsData), "Arrow and reference paths must return the same number of fields")
+
+	for i, arrowFD := range arrowFieldsData {
+		refFD := refFieldsData[i]
+		require.NotNil(t, arrowFD, "arrow field %d has nil FieldData", i)
+		require.NotNil(t, refFD, "reference field %d has nil FieldData", i)
+
+		// The Arrow path populates FieldName/FieldId/Type from the Go-side
+		// schema, while RetrieveByOffsets's C++ segcore leaves FieldName
+		// empty and may not set FieldId. Normalize metadata before comparing.
+		refFD.FieldName = arrowFD.GetFieldName()
+		refFD.FieldId = arrowFD.GetFieldId()
+		refFD.Type = arrowFD.GetType()
+
+		require.Truef(t, proto.Equal(refFD, arrowFD),
+			"field %q (id=%d): Arrow and reference FieldData diverge\narrow=%v\nref=%v",
+			arrowFD.GetFieldName(), arrowFD.GetFieldId(), arrowFD, refFD)
+	}
+}
+
+// =========================================================================
+// Benchmarks
+//
+// Both benchmarks share the same 2-segment / 100-row / dim-128 fixture as
+// the correctness test above. Custom metrics approximate the brief's
+// requested breakdown by timing the same production functions the
+// integrated NewFetchFieldsDataOperator calls, just orchestrated directly
+// here (sequential per-segment loop instead of the operator's conc.Pool
+// fan-out) so each phase can be isolated:
+//
+//   - cgo-ns/op:        the single-shot cgo call into segcore
+//                        (segcore.FillRetrieveFieldsOrdered for Arrow,
+//                        the sum of per-segment Segment.RetrieveByOffsets
+//                        calls for proto).
+//   - convert-ns/op:    segcore.ArrowFieldsToProto (Arrow only).
+//   - interleave-ns/op: the Go-side typeutil.AppendFieldData merge loop
+//                        that reorders per-segment RetrieveByOffsets
+//                        results into PK-sorted order (proto only).
+// =========================================================================
+
+func BenchmarkFetchFieldsData_Arrow(b *testing.B) {
+	fx := setupArrowFetchFixture(b, 50)
+	defer fx.teardown()
+
+	cSegments := make([]segcore.CSegment, len(fx.segments))
+	for i, seg := range fx.segments {
+		cSegments[i] = seg.(*LocalSegment).csegment
+	}
+	segIndices := make([]int32, len(fx.merged.Selections))
+	segOffsets := make([]int64, len(fx.merged.Selections))
+	for i, sel := range fx.merged.Selections {
+		segIndices[i] = int32(sel.SegmentIndex)
+		segOffsets[i] = sel.Offset
+	}
+
+	var cgoNs, convertNs int64
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		cgoStart := time.Now()
+		rec, err := segcore.FillRetrieveFieldsOrdered(fx.ctx, cSegments, fx.plan, segIndices, segOffsets)
+		cgoNs += time.Since(cgoStart).Nanoseconds()
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		convertStart := time.Now()
+		fieldsData, err := segcore.ArrowFieldsToProto(rec, fx.fieldSchemas)
+		convertNs += time.Since(convertStart).Nanoseconds()
+		rec.Release()
+
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(fieldsData) != len(fx.fieldSchemas) {
+			b.Fatalf("unexpected field count: got %d, want %d", len(fieldsData), len(fx.fieldSchemas))
+		}
+	}
+	b.StopTimer()
+
+	b.ReportMetric(float64(cgoNs)/float64(b.N), "cgo-ns/op")
+	b.ReportMetric(float64(convertNs)/float64(b.N), "convert-ns/op")
+}
+
+func BenchmarkFetchFieldsData_Proto(b *testing.B) {
+	fx := setupArrowFetchFixture(b, 50)
+	defer fx.teardown()
+
+	offsetsBySegment := make([][]int64, len(fx.segments))
+	for _, sel := range fx.merged.Selections {
+		offsetsBySegment[sel.SegmentIndex] = append(offsetsBySegment[sel.SegmentIndex], sel.Offset)
+	}
+
+	var cgoNs, interleaveNs int64
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		cgoStart := time.Now()
+		segmentResults := make([]*segcorepb.RetrieveResults, len(fx.segments))
+		futures := make([]*conc.Future[any], 0, len(offsetsBySegment))
+		for segIdx, offsets := range offsetsBySegment {
+			if offsets == nil {
+				continue
+			}
+			idx := segIdx
+			offs := offsets
+			future := GetSQPool().Submit(func() (any, error) {
+				r, err := fx.segments[idx].RetrieveByOffsets(fx.ctx, &segcore.RetrievePlanWithOffsets{
+					RetrievePlan: fx.plan,
+					Offsets:      offs,
+				})
+				if err != nil {
+					return nil, err
+				}
+				segmentResults[idx] = r
+				return nil, nil
+			})
+			futures = append(futures, future)
+		}
+		if err := conc.BlockOnAll(futures...); err != nil {
+			b.Fatal(err)
+		}
+		cgoNs += time.Since(cgoStart).Nanoseconds()
+
+		interleaveStart := time.Now()
+		var fieldsData []*schemapb.FieldData
+		for _, r := range segmentResults {
+			if r != nil && len(r.GetFieldsData()) != 0 {
+				fieldsData = typeutil.PrepareResultFieldData(r.GetFieldsData(), int64(len(fx.merged.Selections)))
+				break
+			}
+		}
+		if fieldsData != nil {
+			idxComputers := make([]*typeutil.FieldDataIdxComputer, len(segmentResults))
+			for idx, r := range segmentResults {
+				if r != nil {
+					idxComputers[idx] = typeutil.NewFieldDataIdxComputer(r.GetFieldsData())
+				}
+			}
+			segmentResOffset := make([]int64, len(segmentResults))
+			for _, sel := range fx.merged.Selections {
+				r := segmentResults[sel.SegmentIndex]
+				if r == nil {
+					continue
+				}
+				fieldIdxs := idxComputers[sel.SegmentIndex].Compute(segmentResOffset[sel.SegmentIndex])
+				typeutil.AppendFieldData(fieldsData, r.GetFieldsData(), segmentResOffset[sel.SegmentIndex], fieldIdxs...)
+				segmentResOffset[sel.SegmentIndex]++
+			}
+		}
+		interleaveNs += time.Since(interleaveStart).Nanoseconds()
+
+		if len(fieldsData) != len(fx.fieldSchemas) {
+			b.Fatalf("unexpected field count: got %d, want %d", len(fieldsData), len(fx.fieldSchemas))
+		}
+	}
+	b.StopTimer()
+
+	b.ReportMetric(float64(cgoNs)/float64(b.N), "cgo-ns/op")
+	b.ReportMetric(float64(interleaveNs)/float64(b.N), "interleave-ns/op")
+}
+
+// =========================================================================
+// E2E overhead ratio benchmark
+//
+// Measures the retrieve phase (Phase 2 of IgnoreNonPk) as a fraction of
+// a full ANN search on the same data. This answers: "if I run a search
+// and then fetch output fields, how much of the total time is retrieval?"
+//
+// Setup: 2 sealed segments × 50 rows each, dim=128 (DefaultDim),
+// brute-force flat scan (no index), topK=10, nq=1.
+// Output fields: PK + Float + FloatVector.
+// =========================================================================
+
+func BenchmarkOverheadRatio_SearchVsRetrieve(b *testing.B) {
+	fx := setupArrowFetchFixture(b, 50)
+	defer fx.teardown()
+
+	segIDs := make([]int64, len(fx.segments))
+	for i, seg := range fx.segments {
+		segIDs[i] = seg.ID()
+	}
+
+	topK := int64(10)
+	outputFieldIDs := make([]int64, len(fx.fieldSchemas))
+	for i, fs := range fx.fieldSchemas {
+		outputFieldIDs[i] = fs.GetFieldID()
+	}
+	searchReq, err := mock_segcore.GenSearchPlanAndRequestsWithOutputFields(
+		fx.collection.GetCCollection(), segIDs, 1, topK, outputFieldIDs,
+	)
+	require.NoError(b, err)
+
+	// Precompute Arrow retrieve args.
+	cSegments := make([]segcore.CSegment, len(fx.segments))
+	for i, seg := range fx.segments {
+		cSegments[i] = seg.(*LocalSegment).csegment
+	}
+	segIndices := make([]int32, len(fx.merged.Selections))
+	segOffsets := make([]int64, len(fx.merged.Selections))
+	for i, sel := range fx.merged.Selections {
+		segIndices[i] = int32(sel.SegmentIndex)
+		segOffsets[i] = sel.Offset
+	}
+
+	// Precompute proto per-segment offsets outside the timed loop.
+	protoOffsetsBySegment := make([][]int64, len(fx.segments))
+	for _, sel := range fx.merged.Selections {
+		protoOffsetsBySegment[sel.SegmentIndex] = append(protoOffsetsBySegment[sel.SegmentIndex], sel.Offset)
+	}
+
+	var searchNs, retrieveArrowNs, retrieveProtoNs int64
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		// ANN search (brute force flat scan, dim=128, nq=1, topK=10).
+		searchStart := time.Now()
+		for _, seg := range fx.segments {
+			res, err := seg.Search(fx.ctx, searchReq)
+			if err != nil {
+				b.Fatal(err)
+			}
+			res.Release()
+		}
+		searchNs += time.Since(searchStart).Nanoseconds()
+
+		// Retrieve via Arrow (100 rows × 3 fields incl. FloatVector dim=128).
+		arrowStart := time.Now()
+		rec, err := segcore.FillRetrieveFieldsOrdered(fx.ctx, cSegments, fx.plan, segIndices, segOffsets)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, err = segcore.ArrowFieldsToProto(rec, fx.fieldSchemas)
+		if err != nil {
+			b.Fatal(err)
+		}
+		rec.Release()
+		retrieveArrowNs += time.Since(arrowStart).Nanoseconds()
+
+		// Retrieve via Proto (same 100 rows).
+		protoStart := time.Now()
+		for segIdx, offsets := range protoOffsetsBySegment {
+			r, err := fx.segments[segIdx].RetrieveByOffsets(fx.ctx, &segcore.RetrievePlanWithOffsets{
+				RetrievePlan: fx.plan,
+				Offsets:      offsets,
+			})
+			if err != nil {
+				b.Fatal(err)
+			}
+			_ = r
+		}
+		retrieveProtoNs += time.Since(protoStart).Nanoseconds()
+	}
+	b.StopTimer()
+
+	searchAvg := float64(searchNs) / float64(b.N)
+	arrowAvg := float64(retrieveArrowNs) / float64(b.N)
+	protoAvg := float64(retrieveProtoNs) / float64(b.N)
+
+	b.ReportMetric(searchAvg, "search-ns/op")
+	b.ReportMetric(arrowAvg, "retrieve-arrow-ns/op")
+	b.ReportMetric(protoAvg, "retrieve-proto-ns/op")
+	b.ReportMetric(arrowAvg/(searchAvg+arrowAvg)*100, "arrow-overhead-%")
+	b.ReportMetric(protoAvg/(searchAvg+protoAvg)*100, "proto-overhead-%")
+}

--- a/internal/querynodev2/segments/ignore_non_pk_arrow_test.go
+++ b/internal/querynodev2/segments/ignore_non_pk_arrow_test.go
@@ -108,15 +108,15 @@ func mustFindFieldByType(tb testing.TB, schema *schemapb.CollectionSchema, dt sc
 }
 
 type arrowFetchFixture struct {
-	ctx          context.Context
-	rootPath     string
-	chunkManager storage.ChunkManager
-	manager      *Manager
-	collection   *Collection
-	segments     []Segment
-	plan         *segcore.RetrievePlan
-	fieldSchemas []*schemapb.FieldSchema // in plan.OutputFieldIds order
-	merged       *MergedResultWithOffsets
+	ctx            context.Context
+	rootPath       string
+	chunkManager   storage.ChunkManager
+	manager        *Manager
+	collection     *Collection
+	segments       []Segment
+	plan           *segcore.RetrievePlan
+	fieldSchemaMap map[int64]*schemapb.FieldSchema // keyed by field ID
+	merged         *MergedResultWithOffsets
 }
 
 // setupArrowFetchFixture loads 2 sealed segments with rowsPerSegment rows
@@ -196,7 +196,11 @@ func setupArrowFetchFixture(tb testing.TB, rowsPerSegment int) *arrowFetchFixtur
 	floatField := mustFindFieldByType(tb, schema, schemapb.DataType_Float)
 	floatVecField := mustFindFieldByType(tb, schema, schemapb.DataType_FloatVector)
 
-	fieldSchemas := []*schemapb.FieldSchema{pkField, floatField, floatVecField}
+	fieldSchemaMap := map[int64]*schemapb.FieldSchema{
+		pkField.GetFieldID():       pkField,
+		floatField.GetFieldID():    floatField,
+		floatVecField.GetFieldID(): floatVecField,
+	}
 	outputFieldIDs := []int64{pkField.GetFieldID(), floatField.GetFieldID(), floatVecField.GetFieldID()}
 
 	plan, err := buildArrowTestRetrievePlan(collection.GetCCollection(), outputFieldIDs)
@@ -219,15 +223,15 @@ func setupArrowFetchFixture(tb testing.TB, rowsPerSegment int) *arrowFetchFixtur
 	}
 
 	return &arrowFetchFixture{
-		ctx:          ctx,
-		rootPath:     rootPath,
-		chunkManager: chunkManager,
-		manager:      manager,
-		collection:   collection,
-		segments:     segments,
-		plan:         plan,
-		fieldSchemas: fieldSchemas,
-		merged:       merged,
+		ctx:            ctx,
+		rootPath:       rootPath,
+		chunkManager:   chunkManager,
+		manager:        manager,
+		collection:     collection,
+		segments:       segments,
+		plan:           plan,
+		fieldSchemaMap: fieldSchemaMap,
+		merged:         merged,
 	}
 }
 
@@ -256,12 +260,12 @@ func TestFetchFieldsData_ArrowMatchesRetrieveByOffsets(t *testing.T) {
 	rec, err := fetchFieldsAsRecord(fx.ctx, fx.segments, fx.plan, fx.merged)
 	require.NoError(t, err)
 	defer rec.Release()
-	require.Equal(t, len(fx.fieldSchemas), int(rec.NumCols()), "Arrow record column count must match requested output fields")
+	require.Equal(t, len(fx.fieldSchemaMap), int(rec.NumCols()), "Arrow record column count must match requested output fields")
 	require.Equal(t, int64(len(fx.merged.Selections)), rec.NumRows())
 
-	arrowFieldsData, err := segcore.ArrowFieldsToProto(rec, fx.fieldSchemas)
+	arrowFieldsData, err := segcore.ArrowFieldsToProto(rec, fx.fieldSchemaMap)
 	require.NoError(t, err)
-	require.Len(t, arrowFieldsData, len(fx.fieldSchemas))
+	require.Len(t, arrowFieldsData, len(fx.fieldSchemaMap))
 
 	// Reference: per-segment RetrieveByOffsets + manual interleave.
 	offsetsBySegment := make([][]int64, len(fx.segments))
@@ -373,15 +377,15 @@ func BenchmarkFetchFieldsData_Arrow(b *testing.B) {
 		}
 
 		convertStart := time.Now()
-		fieldsData, err := segcore.ArrowFieldsToProto(rec, fx.fieldSchemas)
+		fieldsData, err := segcore.ArrowFieldsToProto(rec, fx.fieldSchemaMap)
 		convertNs += time.Since(convertStart).Nanoseconds()
 		rec.Release()
 
 		if err != nil {
 			b.Fatal(err)
 		}
-		if len(fieldsData) != len(fx.fieldSchemas) {
-			b.Fatalf("unexpected field count: got %d, want %d", len(fieldsData), len(fx.fieldSchemas))
+		if len(fieldsData) != len(fx.fieldSchemaMap) {
+			b.Fatalf("unexpected field count: got %d, want %d", len(fieldsData), len(fx.fieldSchemaMap))
 		}
 	}
 	b.StopTimer()
@@ -459,8 +463,8 @@ func BenchmarkFetchFieldsData_Proto(b *testing.B) {
 		}
 		interleaveNs += time.Since(interleaveStart).Nanoseconds()
 
-		if len(fieldsData) != len(fx.fieldSchemas) {
-			b.Fatalf("unexpected field count: got %d, want %d", len(fieldsData), len(fx.fieldSchemas))
+		if len(fieldsData) != len(fx.fieldSchemaMap) {
+			b.Fatalf("unexpected field count: got %d, want %d", len(fieldsData), len(fx.fieldSchemaMap))
 		}
 	}
 	b.StopTimer()
@@ -491,9 +495,9 @@ func BenchmarkOverheadRatio_SearchVsRetrieve(b *testing.B) {
 	}
 
 	topK := int64(10)
-	outputFieldIDs := make([]int64, len(fx.fieldSchemas))
-	for i, fs := range fx.fieldSchemas {
-		outputFieldIDs[i] = fs.GetFieldID()
+	outputFieldIDs := make([]int64, 0, len(fx.fieldSchemaMap))
+	for fid := range fx.fieldSchemaMap {
+		outputFieldIDs = append(outputFieldIDs, fid)
 	}
 	searchReq, err := mock_segcore.GenSearchPlanAndRequestsWithOutputFields(
 		fx.collection.GetCCollection(), segIDs, 1, topK, outputFieldIDs,
@@ -540,7 +544,7 @@ func BenchmarkOverheadRatio_SearchVsRetrieve(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		_, err = segcore.ArrowFieldsToProto(rec, fx.fieldSchemas)
+		_, err = segcore.ArrowFieldsToProto(rec, fx.fieldSchemaMap)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/querynodev2/segments/ignore_non_pk_arrow_test.go
+++ b/internal/querynodev2/segments/ignore_non_pk_arrow_test.go
@@ -136,10 +136,14 @@ func setupArrowFetchFixture(tb testing.TB, rowsPerSegment int) *arrowFetchFixtur
 	chunkManagerFactory := storage.NewTestChunkManagerFactory(paramtable.Get(), rootPath)
 	chunkManager, err := chunkManagerFactory.NewPersistentStorageChunkManager(ctx)
 	require.NoError(tb, err)
-	initcore.InitRemoteChunkManager(paramtable.Get())
-	initcore.InitLocalChunkManager(rootPath)
-	initcore.InitMmapManager(paramtable.Get(), 1)
-	initcore.InitTieredStorage(paramtable.Get())
+	err = initcore.InitRemoteChunkManager(paramtable.Get())
+	require.NoError(tb, err)
+	err = initcore.InitLocalChunkManager(rootPath)
+	require.NoError(tb, err)
+	err = initcore.InitMmapManager(paramtable.Get(), 1)
+	require.NoError(tb, err)
+	err = initcore.InitTieredStorage(paramtable.Get())
+	require.NoError(tb, err)
 
 	collectionID := int64(90000)
 	partitionID := int64(9000)
@@ -241,7 +245,7 @@ func (f *arrowFetchFixture) teardown() {
 		seg.Release(f.ctx)
 	}
 	DeleteCollection(f.collection)
-	f.chunkManager.RemoveWithPrefix(f.ctx, f.rootPath)
+	_ = f.chunkManager.RemoveWithPrefix(f.ctx, f.rootPath)
 }
 
 // =========================================================================

--- a/internal/querynodev2/segments/ignore_non_pk_ops.go
+++ b/internal/querynodev2/segments/ignore_non_pk_ops.go
@@ -19,8 +19,10 @@ package segments
 import (
 	"context"
 
+	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/samber/lo"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/queryutil"
@@ -186,12 +188,17 @@ func NewMergeByPKWithOffsetsOperator(
 // IgnoreNonPk pipeline: after PK merge + dedup + topK, fetch actual field data
 // only for the selected rows.
 //
+// When ArrowRetrieveEnabled is true, uses the Arrow code path which performs
+// a single CGO call returning an Arrow RecordBatch. Otherwise, falls back to
+// the per-segment proto serialization path.
+//
 // Input[0]: *MergedResultWithOffsets
 // Output[0]: *segcorepb.RetrieveResults (with IDs and full FieldsData)
 func NewFetchFieldsDataOperator(
 	validSegments []Segment,
 	manager *Manager,
 	retrievePlan *segcore.RetrievePlan,
+	fieldSchemas []*schemapb.FieldSchema,
 ) queryutil.Operator {
 	return queryutil.NewLambdaOperator(queryutil.OpFetchFields, func(ctx context.Context, span trace.Span, inputs ...any) ([]any, error) {
 		merged := inputs[0].(*MergedResultWithOffsets)
@@ -205,88 +212,160 @@ func NewFetchFieldsDataOperator(
 			return []any{ret}, nil
 		}
 
-		// Group selections by segment index
-		groups := lo.GroupBy(merged.Selections, func(sel OffsetSelection) int {
-			return sel.SegmentIndex
-		})
-
-		// Parallel RetrieveByOffsets per segment
-		segmentResults := make([]*segcorepb.RetrieveResults, len(validSegments))
-		futures := make([]*conc.Future[any], 0, len(groups))
-		for segIdx, sels := range groups {
-			idx := segIdx
-			offsets := lo.Map(sels, func(sel OffsetSelection, _ int) int64 { return sel.Offset })
-			future := GetSQPool().Submit(func() (any, error) {
-				var r *segcorepb.RetrieveResults
-				var err error
-				if err := doOnSegment(ctx, manager, validSegments[idx], func(ctx context.Context, segment Segment) error {
-					r, err = segment.RetrieveByOffsets(ctx, &segcore.RetrievePlanWithOffsets{
-						RetrievePlan: retrievePlan,
-						Offsets:      offsets,
-					})
-					return err
-				}); err != nil {
-					return nil, err
-				}
-				segmentResults[idx] = r
-				return nil, nil
-			})
-			futures = append(futures, future)
+		if paramtable.Get().CommonCfg.InterfaceZeroCopyEnabled.GetAsBool() {
+			return fetchFieldsArrow(ctx, validSegments, retrievePlan, fieldSchemas, merged, ret)
 		}
-
-		// Must be BlockOnAll: if we fast-fail, cgo struct like `plan` could be used after free.
-		if err := conc.BlockOnAll(futures...); err != nil {
-			return nil, err
-		}
-
-		// Find a non-empty result to initialize FieldsData layout
-		for _, r := range segmentResults {
-			if r != nil && len(r.GetFieldsData()) != 0 {
-				ret.FieldsData = typeutil.PrepareResultFieldData(r.GetFieldsData(), int64(len(merged.Selections)))
-				break
-			}
-		}
-
-		if ret.FieldsData == nil {
-			return []any{ret}, nil
-		}
-
-		// Build FieldsData in PK-sorted order (matching selections order)
-		idxComputers := make([]*typeutil.FieldDataIdxComputer, len(segmentResults))
-		for i, r := range segmentResults {
-			if r != nil {
-				idxComputers[i] = typeutil.NewFieldDataIdxComputer(r.GetFieldsData())
-			}
-		}
-
-		// Track consumption position per segment's RetrieveByOffsets result.
-		// RetrieveByOffsets returns results compacted: row 0, 1, 2, ...
-		segmentResOffset := make([]int64, len(segmentResults))
-		maxOutputSize := paramtable.Get().QuotaConfig.MaxOutputSize.GetAsInt64()
-		var retSize int64
-
-		for _, sel := range merged.Selections {
-			r := segmentResults[sel.SegmentIndex]
-			if r == nil {
-				continue
-			}
-			fieldsData := r.GetFieldsData()
-			fieldIdxs := idxComputers[sel.SegmentIndex].Compute(segmentResOffset[sel.SegmentIndex])
-			retSize += typeutil.AppendFieldData(ret.FieldsData, fieldsData, segmentResOffset[sel.SegmentIndex], fieldIdxs...)
-			segmentResOffset[sel.SegmentIndex]++
-
-			if retSize > maxOutputSize {
-				return nil, merr.WrapErrParameterInvalidMsg("query results exceed the maxOutputSize Limit %d", maxOutputSize)
-			}
-		}
-
-		// Fill ElementIndices for element-level query
-		if merged.ElementLevel {
-			for _, sel := range merged.Selections {
-				ret.ElementIndices = append(ret.ElementIndices, sel.ElementIndices)
-			}
-		}
-
-		return []any{ret}, nil
+		return fetchFieldsProto(ctx, validSegments, manager, retrievePlan, merged, ret)
 	})
+}
+
+// fetchFieldsArrow retrieves fields via a single CGO call returning an Arrow
+// RecordBatch, then converts to proto.
+func fetchFieldsArrow(
+	ctx context.Context,
+	validSegments []Segment,
+	retrievePlan *segcore.RetrievePlan,
+	fieldSchemas []*schemapb.FieldSchema,
+	merged *MergedResultWithOffsets,
+	ret *segcorepb.RetrieveResults,
+) ([]any, error) {
+	rec, err := fetchFieldsAsRecord(ctx, validSegments, retrievePlan, merged)
+	if err != nil {
+		return nil, err
+	}
+	defer rec.Release()
+
+	fieldsData, err := segcore.ArrowFieldsToProto(rec, fieldSchemas)
+	if err != nil {
+		return nil, err
+	}
+	ret.FieldsData = fieldsData
+
+	maxOutputSize := paramtable.Get().QuotaConfig.MaxOutputSize.GetAsInt64()
+	var retSize int64
+	for _, fd := range ret.FieldsData {
+		retSize += int64(proto.Size(fd))
+	}
+	if retSize > maxOutputSize {
+		ret.FieldsData = nil
+		return nil, merr.WrapErrParameterInvalidMsg("query results exceed the maxOutputSize Limit %d", maxOutputSize)
+	}
+
+	if merged.ElementLevel {
+		for _, sel := range merged.Selections {
+			ret.ElementIndices = append(ret.ElementIndices, sel.ElementIndices)
+		}
+	}
+	return []any{ret}, nil
+}
+
+// fetchFieldsProto retrieves fields via per-segment RetrieveByOffsets (proto
+// serialize/unmarshal), then interleaves rows in PK order.
+func fetchFieldsProto(
+	ctx context.Context,
+	validSegments []Segment,
+	manager *Manager,
+	retrievePlan *segcore.RetrievePlan,
+	merged *MergedResultWithOffsets,
+	ret *segcorepb.RetrieveResults,
+) ([]any, error) {
+	groups := lo.GroupBy(merged.Selections, func(sel OffsetSelection) int {
+		return sel.SegmentIndex
+	})
+
+	segmentResults := make([]*segcorepb.RetrieveResults, len(validSegments))
+	futures := make([]*conc.Future[any], 0, len(groups))
+	for segIdx, sels := range groups {
+		idx := segIdx
+		offsets := lo.Map(sels, func(sel OffsetSelection, _ int) int64 { return sel.Offset })
+		future := GetSQPool().Submit(func() (any, error) {
+			var r *segcorepb.RetrieveResults
+			var err error
+			if err := doOnSegment(ctx, manager, validSegments[idx], func(ctx context.Context, segment Segment) error {
+				r, err = segment.RetrieveByOffsets(ctx, &segcore.RetrievePlanWithOffsets{
+					RetrievePlan: retrievePlan,
+					Offsets:      offsets,
+				})
+				return err
+			}); err != nil {
+				return nil, err
+			}
+			segmentResults[idx] = r
+			return nil, nil
+		})
+		futures = append(futures, future)
+	}
+
+	if err := conc.BlockOnAll(futures...); err != nil {
+		return nil, err
+	}
+
+	for _, r := range segmentResults {
+		if r != nil && len(r.GetFieldsData()) != 0 {
+			ret.FieldsData = typeutil.PrepareResultFieldData(r.GetFieldsData(), int64(len(merged.Selections)))
+			break
+		}
+	}
+
+	if ret.FieldsData == nil {
+		return []any{ret}, nil
+	}
+
+	idxComputers := make([]*typeutil.FieldDataIdxComputer, len(segmentResults))
+	for i, r := range segmentResults {
+		if r != nil {
+			idxComputers[i] = typeutil.NewFieldDataIdxComputer(r.GetFieldsData())
+		}
+	}
+
+	segmentResOffset := make([]int64, len(segmentResults))
+	maxOutputSize := paramtable.Get().QuotaConfig.MaxOutputSize.GetAsInt64()
+	var retSize int64
+
+	for _, sel := range merged.Selections {
+		r := segmentResults[sel.SegmentIndex]
+		if r == nil {
+			continue
+		}
+		fieldsData := r.GetFieldsData()
+		fieldIdxs := idxComputers[sel.SegmentIndex].Compute(segmentResOffset[sel.SegmentIndex])
+		retSize += typeutil.AppendFieldData(ret.FieldsData, fieldsData, segmentResOffset[sel.SegmentIndex], fieldIdxs...)
+		segmentResOffset[sel.SegmentIndex]++
+
+		if retSize > maxOutputSize {
+			return nil, merr.WrapErrParameterInvalidMsg("query results exceed the maxOutputSize Limit %d", maxOutputSize)
+		}
+	}
+
+	if merged.ElementLevel {
+		for _, sel := range merged.Selections {
+			ret.ElementIndices = append(ret.ElementIndices, sel.ElementIndices)
+		}
+	}
+
+	return []any{ret}, nil
+}
+
+// fetchFieldsAsRecord retrieves field data for the selected rows as a
+// single Arrow RecordBatch across all segments, ordered by
+// merged.Selections.
+func fetchFieldsAsRecord(
+	ctx context.Context,
+	validSegments []Segment,
+	retrievePlan *segcore.RetrievePlan,
+	merged *MergedResultWithOffsets,
+) (arrow.Record, error) {
+	cSegments := make([]segcore.CSegment, len(validSegments))
+	for i, seg := range validSegments {
+		cSegments[i] = seg.(*LocalSegment).csegment
+	}
+
+	segIndices := make([]int32, len(merged.Selections))
+	segOffsets := make([]int64, len(merged.Selections))
+	for i, sel := range merged.Selections {
+		segIndices[i] = int32(sel.SegmentIndex)
+		segOffsets[i] = sel.Offset
+	}
+
+	return segcore.FillRetrieveFieldsOrdered(ctx, cSegments, retrievePlan, segIndices, segOffsets)
 }

--- a/internal/querynodev2/segments/ignore_non_pk_ops.go
+++ b/internal/querynodev2/segments/ignore_non_pk_ops.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/querynodev2/segments/state"
 	"github.com/milvus-io/milvus/internal/util/queryutil"
 	"github.com/milvus-io/milvus/internal/util/reduce"
 	"github.com/milvus-io/milvus/internal/util/segcore"
@@ -198,7 +199,7 @@ func NewFetchFieldsDataOperator(
 	validSegments []Segment,
 	manager *Manager,
 	retrievePlan *segcore.RetrievePlan,
-	fieldSchemas []*schemapb.FieldSchema,
+	fieldSchemaMap map[int64]*schemapb.FieldSchema,
 ) queryutil.Operator {
 	return queryutil.NewLambdaOperator(queryutil.OpFetchFields, func(ctx context.Context, span trace.Span, inputs ...any) ([]any, error) {
 		merged := inputs[0].(*MergedResultWithOffsets)
@@ -213,7 +214,7 @@ func NewFetchFieldsDataOperator(
 		}
 
 		if paramtable.Get().CommonCfg.InterfaceZeroCopyEnabled.GetAsBool() {
-			return fetchFieldsArrow(ctx, validSegments, retrievePlan, fieldSchemas, merged, ret)
+			return fetchFieldsArrow(ctx, validSegments, retrievePlan, fieldSchemaMap, merged, ret)
 		}
 		return fetchFieldsProto(ctx, validSegments, manager, retrievePlan, merged, ret)
 	})
@@ -225,7 +226,7 @@ func fetchFieldsArrow(
 	ctx context.Context,
 	validSegments []Segment,
 	retrievePlan *segcore.RetrievePlan,
-	fieldSchemas []*schemapb.FieldSchema,
+	fieldSchemaMap map[int64]*schemapb.FieldSchema,
 	merged *MergedResultWithOffsets,
 	ret *segcorepb.RetrieveResults,
 ) ([]any, error) {
@@ -235,7 +236,7 @@ func fetchFieldsArrow(
 	}
 	defer rec.Release()
 
-	fieldsData, err := segcore.ArrowFieldsToProto(rec, fieldSchemas)
+	fieldsData, err := segcore.ArrowFieldsToProto(rec, fieldSchemaMap)
 	if err != nil {
 		return nil, err
 	}
@@ -355,9 +356,30 @@ func fetchFieldsAsRecord(
 	retrievePlan *segcore.RetrievePlan,
 	merged *MergedResultWithOffsets,
 ) (arrow.Record, error) {
-	cSegments := make([]segcore.CSegment, len(validSegments))
+	type pinned struct {
+		ls *LocalSegment
+		cs segcore.CSegment
+	}
+	segs := make([]pinned, len(validSegments))
 	for i, seg := range validSegments {
-		cSegments[i] = seg.(*LocalSegment).csegment
+		ls := seg.(*LocalSegment)
+		if !ls.ptrLock.PinIf(state.IsNotReleased) {
+			for j := 0; j < i; j++ {
+				segs[j].ls.ptrLock.Unpin()
+			}
+			return nil, merr.WrapErrSegmentNotLoaded(ls.ID(), "segment released")
+		}
+		segs[i] = pinned{ls, ls.csegment}
+	}
+	defer func() {
+		for _, s := range segs {
+			s.ls.ptrLock.Unpin()
+		}
+	}()
+
+	cSegments := make([]segcore.CSegment, len(segs))
+	for i, s := range segs {
+		cSegments[i] = s.cs
 	}
 
 	segIndices := make([]int32, len(merged.Selections))
@@ -367,5 +389,8 @@ func fetchFieldsAsRecord(
 		segOffsets[i] = sel.Offset
 	}
 
-	return segcore.FillRetrieveFieldsOrdered(ctx, cSegments, retrievePlan, segIndices, segOffsets)
+	return retrySegmentReadGate(ctx, SegmentTypeSealed,
+		func() (arrow.Record, error) {
+			return segcore.FillRetrieveFieldsOrdered(ctx, cSegments, retrievePlan, segIndices, segOffsets)
+		}, waitSegmentReadGateRetry)
 }

--- a/internal/querynodev2/segments/ignore_non_pk_ops_test.go
+++ b/internal/querynodev2/segments/ignore_non_pk_ops_test.go
@@ -18,18 +18,16 @@ package segments
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/reduce"
-	"github.com/milvus-io/milvus/internal/util/segcore"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/segcorepb"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 func makeSegcoreIntIDs(ids []int64) *schemapb.IDs {
@@ -132,122 +130,13 @@ func TestMergeByPKWithOffsetsOperator(t *testing.T) {
 }
 
 func TestFetchFieldsDataOperator_EmptySelections(t *testing.T) {
-	op := NewFetchFieldsDataOperator(nil, nil, nil)
+	paramtable.Init()
+	op := NewFetchFieldsDataOperator(nil, nil, nil, nil)
 	outs, err := op.Run(context.Background(), nil, &MergedResultWithOffsets{IDs: makeSegcoreIntIDs([]int64{1, 2}), Selections: nil})
 	require.NoError(t, err)
 	out := outs[0].(*segcorepb.RetrieveResults)
 	assert.Equal(t, []int64{1, 2}, out.GetIds().GetIntId().GetData())
 	assert.Empty(t, out.GetFieldsData())
-}
-
-func TestFetchFieldsDataOperator_SingleSegment(t *testing.T) {
-	seg := NewMockSegment(t)
-	seg.EXPECT().DatabaseName().Return("default").Maybe()
-	seg.EXPECT().ResourceGroup().Return("rg").Maybe()
-	seg.EXPECT().RetrieveByOffsets(mock.Anything, mock.AnythingOfType("*segcore.RetrievePlanWithOffsets")).
-		RunAndReturn(func(ctx context.Context, plan *segcore.RetrievePlanWithOffsets) (*segcorepb.RetrieveResults, error) {
-			assert.Equal(t, []int64{101, 103, 102}, plan.Offsets)
-			return &segcorepb.RetrieveResults{
-				FieldsData: []*schemapb.FieldData{
-					{
-						FieldId:   101,
-						FieldName: "age",
-						Type:      schemapb.DataType_Int64,
-						Field: &schemapb.FieldData_Scalars{
-							Scalars: &schemapb.ScalarField{
-								Data: &schemapb.ScalarField_LongData{
-									LongData: &schemapb.LongArray{Data: []int64{30, 10, 20}},
-								},
-							},
-						},
-					},
-				},
-			}, nil
-		}).Once()
-
-	op := NewFetchFieldsDataOperator([]Segment{seg}, nil, nil)
-	merged := &MergedResultWithOffsets{
-		IDs: makeSegcoreIntIDs([]int64{1, 2, 3}),
-		Selections: []OffsetSelection{
-			{SegmentIndex: 0, Offset: 101},
-			{SegmentIndex: 0, Offset: 103},
-			{SegmentIndex: 0, Offset: 102},
-		},
-	}
-
-	outs, err := op.Run(context.Background(), nil, merged)
-	require.NoError(t, err)
-	out := outs[0].(*segcorepb.RetrieveResults)
-	assert.Equal(t, []int64{1, 2, 3}, out.GetIds().GetIntId().GetData())
-	assert.Equal(t, []int64{30, 10, 20}, out.GetFieldsData()[0].GetScalars().GetLongData().GetData())
-}
-
-func TestFetchFieldsDataOperator_MultipleSegments(t *testing.T) {
-	seg0 := NewMockSegment(t)
-	seg1 := NewMockSegment(t)
-	seg0.EXPECT().DatabaseName().Return("default").Maybe()
-	seg0.EXPECT().ResourceGroup().Return("rg").Maybe()
-	seg1.EXPECT().DatabaseName().Return("default").Maybe()
-	seg1.EXPECT().ResourceGroup().Return("rg").Maybe()
-
-	seg0.EXPECT().RetrieveByOffsets(mock.Anything, mock.AnythingOfType("*segcore.RetrievePlanWithOffsets")).
-		RunAndReturn(func(ctx context.Context, plan *segcore.RetrievePlanWithOffsets) (*segcorepb.RetrieveResults, error) {
-			assert.Equal(t, []int64{10, 11}, plan.Offsets)
-			return &segcorepb.RetrieveResults{
-				FieldsData: []*schemapb.FieldData{
-					{
-						FieldId:   101,
-						FieldName: "age",
-						Type:      schemapb.DataType_Int64,
-						Field: &schemapb.FieldData_Scalars{
-							Scalars: &schemapb.ScalarField{
-								Data: &schemapb.ScalarField_LongData{
-									LongData: &schemapb.LongArray{Data: []int64{100, 110}},
-								},
-							},
-						},
-					},
-				},
-			}, nil
-		}).Once()
-
-	seg1.EXPECT().RetrieveByOffsets(mock.Anything, mock.AnythingOfType("*segcore.RetrievePlanWithOffsets")).
-		RunAndReturn(func(ctx context.Context, plan *segcore.RetrievePlanWithOffsets) (*segcorepb.RetrieveResults, error) {
-			assert.Equal(t, []int64{20, 21}, plan.Offsets)
-			return &segcorepb.RetrieveResults{
-				FieldsData: []*schemapb.FieldData{
-					{
-						FieldId:   101,
-						FieldName: "age",
-						Type:      schemapb.DataType_Int64,
-						Field: &schemapb.FieldData_Scalars{
-							Scalars: &schemapb.ScalarField{
-								Data: &schemapb.ScalarField_LongData{
-									LongData: &schemapb.LongArray{Data: []int64{200, 210}},
-								},
-							},
-						},
-					},
-				},
-			}, nil
-		}).Once()
-
-	op := NewFetchFieldsDataOperator([]Segment{seg0, seg1}, nil, nil)
-	merged := &MergedResultWithOffsets{
-		IDs: makeSegcoreIntIDs([]int64{1, 2, 3, 4}),
-		Selections: []OffsetSelection{
-			{SegmentIndex: 0, Offset: 10},
-			{SegmentIndex: 1, Offset: 20},
-			{SegmentIndex: 0, Offset: 11},
-			{SegmentIndex: 1, Offset: 21},
-		},
-	}
-
-	outs, err := op.Run(context.Background(), nil, merged)
-	require.NoError(t, err)
-	out := outs[0].(*segcorepb.RetrieveResults)
-	assert.Equal(t, []int64{1, 2, 3, 4}, out.GetIds().GetIntId().GetData())
-	assert.Equal(t, []int64{100, 200, 110, 210}, out.GetFieldsData()[0].GetScalars().GetLongData().GetData())
 }
 
 // =========================================================================
@@ -378,61 +267,4 @@ func TestMergeByPKWithOffsetsOperator_ElementLevel_IndicesLengthMismatch(t *test
 	_, err := op.Run(ctx, nil, []*segcorepb.RetrieveResults{res})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "element_indices length")
-}
-
-func TestFetchFieldsDataOperator_ElementLevel_Propagation(t *testing.T) {
-	seg := NewMockSegment(t)
-	seg.EXPECT().DatabaseName().Return("default").Maybe()
-	seg.EXPECT().ResourceGroup().Return("rg").Maybe()
-	seg.EXPECT().RetrieveByOffsets(mock.Anything, mock.Anything).
-		Return(&segcorepb.RetrieveResults{
-			FieldsData: []*schemapb.FieldData{
-				{
-					FieldId: 101, FieldName: "val", Type: schemapb.DataType_Int64,
-					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
-						Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{10, 20}}},
-					}},
-				},
-			},
-		}, nil).Once()
-
-	op := NewFetchFieldsDataOperator([]Segment{seg}, nil, nil)
-	merged := &MergedResultWithOffsets{
-		IDs: makeSegcoreIntIDs([]int64{1, 2}),
-		Selections: []OffsetSelection{
-			{SegmentIndex: 0, Offset: 10, ElementIndices: makeElementIndices(0, 1)},
-			{SegmentIndex: 0, Offset: 20, ElementIndices: makeElementIndices(2)},
-		},
-		ElementLevel: true,
-	}
-
-	outs, err := op.Run(context.Background(), nil, merged)
-	require.NoError(t, err)
-	out := outs[0].(*segcorepb.RetrieveResults)
-
-	assert.True(t, out.GetElementLevel())
-	assert.Len(t, out.GetElementIndices(), 2)
-	assert.Equal(t, []int32{0, 1}, out.GetElementIndices()[0].GetIndices())
-	assert.Equal(t, []int32{2}, out.GetElementIndices()[1].GetIndices())
-	assert.Equal(t, []int64{10, 20}, out.GetFieldsData()[0].GetScalars().GetLongData().GetData())
-}
-
-func TestFetchFieldsDataOperator_SegmentRetrieveError(t *testing.T) {
-	seg := NewMockSegment(t)
-	seg.EXPECT().DatabaseName().Return("default").Maybe()
-	seg.EXPECT().ResourceGroup().Return("rg").Maybe()
-	seg.EXPECT().RetrieveByOffsets(mock.Anything, mock.Anything).
-		Return(nil, fmt.Errorf("segment not available")).Once()
-
-	op := NewFetchFieldsDataOperator([]Segment{seg}, nil, nil)
-	merged := &MergedResultWithOffsets{
-		IDs: makeSegcoreIntIDs([]int64{1}),
-		Selections: []OffsetSelection{
-			{SegmentIndex: 0, Offset: 10},
-		},
-	}
-
-	_, err := op.Run(context.Background(), nil, merged)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "segment not available")
 }

--- a/internal/querynodev2/segments/query_pipeline.go
+++ b/internal/querynodev2/segments/query_pipeline.go
@@ -66,7 +66,7 @@ func RunQNQueryPipeline(
 	var err error
 
 	if retrievePlan.IsIgnoreNonPk() {
-		pipeline, msg, err = buildIgnoreNonPkPipeline(req, segcoreResults, segments, manager, retrievePlan)
+		pipeline, msg, err = buildIgnoreNonPkPipeline(req, schema, segcoreResults, segments, manager, retrievePlan)
 	} else {
 		pipeline, msg, err = buildStandardQNPipeline(req, schema, plan, segcoreResults)
 	}
@@ -88,6 +88,7 @@ func RunQNQueryPipeline(
 // [MergeByPKWithOffsets(topK)] → [FetchFieldsData] → output
 func buildIgnoreNonPkPipeline(
 	req *querypb.QueryRequest,
+	schema *schemapb.CollectionSchema,
 	segcoreResults []*segcorepb.RetrieveResults,
 	segments []Segment,
 	manager *Manager,
@@ -108,16 +109,32 @@ func buildIgnoreNonPkPipeline(
 		validSegments = append(validSegments, segments[i])
 	}
 
+	// Build the output field schemas, aligned with OutputFieldsId, needed by
+	// the Arrow path to convert Arrow record columns back to proto FieldData.
+	fieldSchemaMap := make(map[int64]*schemapb.FieldSchema, len(schema.GetFields()))
+	for _, f := range schema.GetFields() {
+		fieldSchemaMap[f.GetFieldID()] = f
+	}
+	outputFieldsId := req.GetReq().GetOutputFieldsId()
+	fieldSchemas := make([]*schemapb.FieldSchema, 0, len(outputFieldsId))
+	for _, fid := range outputFieldsId {
+		if fs, ok := fieldSchemaMap[fid]; ok {
+			fieldSchemas = append(fieldSchemas, fs)
+		}
+	}
+
 	builder := queryutil.NewPipelineBuilder(queryutil.PipelineNameQNIgnoreNonPk)
-	builder.Add(queryutil.OpMergeByPKOffsets,
+	builder.Add(
+		queryutil.OpMergeByPKOffsets,
 		[]string{queryutil.PipelineInput},
 		[]string{queryutil.ChannelMerged},
 		NewMergeByPKWithOffsetsOperator(topK, reduceType),
 	)
-	builder.Add(queryutil.OpFetchFields,
+	builder.Add(
+		queryutil.OpFetchFields,
 		[]string{queryutil.ChannelMerged},
 		[]string{queryutil.PipelineOutput},
-		NewFetchFieldsDataOperator(validSegments, manager, retrievePlan),
+		NewFetchFieldsDataOperator(validSegments, manager, retrievePlan, fieldSchemas),
 	)
 
 	msg := queryutil.OpMsg{queryutil.PipelineInput: validResults}

--- a/internal/querynodev2/segments/query_pipeline.go
+++ b/internal/querynodev2/segments/query_pipeline.go
@@ -109,18 +109,10 @@ func buildIgnoreNonPkPipeline(
 		validSegments = append(validSegments, segments[i])
 	}
 
-	// Build the output field schemas, aligned with OutputFieldsId, needed by
-	// the Arrow path to convert Arrow record columns back to proto FieldData.
-	fieldSchemaMap := make(map[int64]*schemapb.FieldSchema, len(schema.GetFields()))
-	for _, f := range schema.GetFields() {
+	allFields := typeutil.GetAllFieldSchemas(schema)
+	fieldSchemaMap := make(map[int64]*schemapb.FieldSchema, len(allFields))
+	for _, f := range allFields {
 		fieldSchemaMap[f.GetFieldID()] = f
-	}
-	outputFieldsId := req.GetReq().GetOutputFieldsId()
-	fieldSchemas := make([]*schemapb.FieldSchema, 0, len(outputFieldsId))
-	for _, fid := range outputFieldsId {
-		if fs, ok := fieldSchemaMap[fid]; ok {
-			fieldSchemas = append(fieldSchemas, fs)
-		}
 	}
 
 	builder := queryutil.NewPipelineBuilder(queryutil.PipelineNameQNIgnoreNonPk)
@@ -134,7 +126,7 @@ func buildIgnoreNonPkPipeline(
 		queryutil.OpFetchFields,
 		[]string{queryutil.ChannelMerged},
 		[]string{queryutil.PipelineOutput},
-		NewFetchFieldsDataOperator(validSegments, manager, retrievePlan, fieldSchemas),
+		NewFetchFieldsDataOperator(validSegments, manager, retrievePlan, fieldSchemaMap),
 	)
 
 	msg := queryutil.OpMsg{queryutil.PipelineInput: validResults}

--- a/internal/querynodev2/segments/query_pipeline_test.go
+++ b/internal/querynodev2/segments/query_pipeline_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
@@ -167,7 +166,8 @@ func TestRunDelegatorQueryPipeline_GroupBy(t *testing.T) {
 	schema := testQueryPipelineSchema()
 	ctx := context.Background()
 
-	req := buildQueryReqForDelegator(10, nil,
+	req := buildQueryReqForDelegator(
+		10, nil,
 		nil,          // no ORDER BY
 		[]int64{200}, // GROUP BY color
 		[]*planpb.Aggregate{{Op: planpb.AggregateOp_count, FieldId: 500}},
@@ -264,59 +264,6 @@ func TestRunQNQueryPipeline(t *testing.T) {
 		out, err := RunQNQueryPipeline(ctx, req, schema, plan, segcoreResults, nil, nil, rp)
 		require.NoError(t, err)
 		assert.Equal(t, []int64{1, 2, 3}, out.GetIds().GetIntId().GetData())
-		assert.Equal(t, int64(5), out.GetAllRetrieveCount())
-	})
-
-	t.Run("ignore non pk path", func(t *testing.T) {
-		req := &querypb.QueryRequest{Req: &internalpb.RetrieveRequest{Limit: 2, OutputFieldsId: []int64{100, 101}}}
-		rp := &segcore.RetrievePlan{}
-		rp.SetIgnoreNonPk(true)
-
-		seg0 := NewMockSegment(t)
-		seg1 := NewMockSegment(t)
-		seg0.EXPECT().DatabaseName().Return("default").Maybe()
-		seg0.EXPECT().ResourceGroup().Return("rg").Maybe()
-		seg1.EXPECT().DatabaseName().Return("default").Maybe()
-		seg1.EXPECT().ResourceGroup().Return("rg").Maybe()
-
-		seg0.EXPECT().RetrieveByOffsets(mock.Anything, mock.AnythingOfType("*segcore.RetrievePlanWithOffsets")).
-			RunAndReturn(func(ctx context.Context, plan *segcore.RetrievePlanWithOffsets) (*segcorepb.RetrieveResults, error) {
-				assert.Equal(t, []int64{10}, plan.Offsets)
-				return &segcorepb.RetrieveResults{
-					FieldsData: []*schemapb.FieldData{
-						makeInt64Field(101, "age", []int64{100}),
-					},
-				}, nil
-			}).Once()
-		seg1.EXPECT().RetrieveByOffsets(mock.Anything, mock.AnythingOfType("*segcore.RetrievePlanWithOffsets")).
-			RunAndReturn(func(ctx context.Context, plan *segcore.RetrievePlanWithOffsets) (*segcorepb.RetrieveResults, error) {
-				assert.Equal(t, []int64{20}, plan.Offsets)
-				return &segcorepb.RetrieveResults{
-					FieldsData: []*schemapb.FieldData{
-						makeInt64Field(101, "age", []int64{200}),
-					},
-				}, nil
-			}).Once()
-
-		segcoreResults := []*segcorepb.RetrieveResults{
-			{
-				Ids:              makeInternalIntIDs([]int64{1}),
-				Offset:           []int64{10},
-				FieldsData:       []*schemapb.FieldData{makeSegcoreTsField([]int64{100})},
-				AllRetrieveCount: 2,
-			},
-			{
-				Ids:              makeInternalIntIDs([]int64{2}),
-				Offset:           []int64{20},
-				FieldsData:       []*schemapb.FieldData{makeSegcoreTsField([]int64{200})},
-				AllRetrieveCount: 3,
-			},
-		}
-
-		out, err := RunQNQueryPipeline(ctx, req, schema, plan, segcoreResults, []Segment{seg0, seg1}, nil, rp)
-		require.NoError(t, err)
-		assert.Equal(t, []int64{1, 2}, out.GetIds().GetIntId().GetData())
-		assert.Equal(t, []int64{100, 200}, out.GetFieldsData()[0].GetScalars().GetLongData().GetData())
 		assert.Equal(t, int64(5), out.GetAllRetrieveCount())
 	})
 

--- a/internal/querynodev2/tasks/query_task.go
+++ b/internal/querynodev2/tasks/query_task.go
@@ -92,7 +92,8 @@ func (t *QueryTask) PreExecute() error {
 	metrics.QueryNodeSQPerUserLatencyInQueue.WithLabelValues(
 		nodeID,
 		queryLabel,
-		username).
+		username,
+	).
 		Observe(inQueueDurationMS)
 
 	// Unmarshal the origin plan
@@ -143,7 +144,8 @@ func (t *QueryTask) Execute() error {
 		paramtable.GetStringNodeID(),
 		contextutil.GetQueryLabel(t.ctx),
 		metrics.ReduceSegments,
-		metrics.BatchReduce).Observe(float64(time.Since(beforeReduce).Microseconds()) / 1000.0)
+		metrics.BatchReduce,
+	).Observe(float64(time.Since(beforeReduce).Microseconds()) / 1000.0)
 	if err != nil {
 		return err
 	}

--- a/internal/util/segcore/arrow_to_fielddata.go
+++ b/internal/util/segcore/arrow_to_fielddata.go
@@ -19,6 +19,7 @@ package segcore
 import (
 	"encoding/binary"
 	"fmt"
+	"strconv"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
@@ -30,23 +31,38 @@ import (
 )
 
 // ArrowFieldsToProto converts the columns of an Arrow RecordBatch into proto
-// FieldData. The column at index i in rec must correspond to the FieldSchema
-// at index i in fieldSchemas.
-func ArrowFieldsToProto(rec arrow.Record, fieldSchemas []*schemapb.FieldSchema) ([]*schemapb.FieldData, error) {
+// FieldData. Each Arrow column carries milvus.field_id metadata; the column
+// is matched to its FieldSchema via fieldSchemaMap. Columns whose field_id
+// is not in the map are skipped (the field may have been dropped).
+func ArrowFieldsToProto(rec arrow.Record, fieldSchemaMap map[int64]*schemapb.FieldSchema) ([]*schemapb.FieldData, error) {
 	numCols := int(rec.NumCols())
 	numRows := int(rec.NumRows())
-	result := make([]*schemapb.FieldData, numCols)
+	result := make([]*schemapb.FieldData, 0, numCols)
 
 	for i := 0; i < numCols; i++ {
-		fd, err := arrowColumnToFieldData(rec.Column(i), fieldSchemas[i], numRows)
+		field := rec.Schema().Field(i)
+		md := field.Metadata
+		fidStr, ok := md.GetValue("milvus.field_id")
+		if !ok {
+			continue
+		}
+		fid, err := strconv.ParseInt(fidStr, 10, 64)
+		if err != nil {
+			continue
+		}
+		schema, ok := fieldSchemaMap[fid]
+		if !ok {
+			continue
+		}
+		fd, err := arrowColumnToFieldData(rec.Column(i), schema, numRows)
 		if err != nil {
 			return nil, merr.WrapErrServiceInternal(
 				fmt.Sprintf("failed to convert Arrow column %q (field %d)",
-					fieldSchemas[i].GetName(), fieldSchemas[i].GetFieldID()),
+					schema.GetName(), schema.GetFieldID()),
 				err.Error(),
 			)
 		}
-		result[i] = fd
+		result = append(result, fd)
 	}
 	return result, nil
 }
@@ -243,21 +259,26 @@ func arrowColumnToFieldData(col arrow.Array, schema *schemapb.FieldSchema, numRo
 			schema.GetDataType().String(), schema.GetName(), schema.GetFieldID())
 	}
 
-	setArrowValidData(fd, col, numRows)
+	setArrowValidData(fd, col, numRows, schema.GetNullable())
 	return fd, nil
 }
 
-// setArrowValidData extracts the Arrow validity bitmap and writes it to the
-// field-specific ValidData location when nulls are present.
-func setArrowValidData(fd *schemapb.FieldData, col arrow.Array, numRows int) {
-	if col.NullN() == 0 {
+func setArrowValidData(fd *schemapb.FieldData, col arrow.Array, numRows int, nullable bool) {
+	if col.NullN() > 0 {
+		validData := make([]bool, numRows)
+		for j := 0; j < numRows; j++ {
+			validData[j] = col.IsValid(j)
+		}
+		typeutil.SetFieldDataValidData(fd, validData)
 		return
 	}
-	validData := make([]bool, numRows)
-	for j := 0; j < numRows; j++ {
-		validData[j] = col.IsValid(j)
+	if nullable {
+		validData := make([]bool, numRows)
+		for j := range validData {
+			validData[j] = true
+		}
+		typeutil.SetFieldDataValidData(fd, validData)
 	}
-	typeutil.SetFieldDataValidData(fd, validData)
 }
 
 // resolveVectorDim returns the vector dimension for a FixedSizeBinary vector

--- a/internal/util/segcore/arrow_to_fielddata.go
+++ b/internal/util/segcore/arrow_to_fielddata.go
@@ -1,0 +1,462 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package segcore
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+// ArrowFieldsToProto converts the columns of an Arrow RecordBatch into proto
+// FieldData. The column at index i in rec must correspond to the FieldSchema
+// at index i in fieldSchemas.
+func ArrowFieldsToProto(rec arrow.Record, fieldSchemas []*schemapb.FieldSchema) ([]*schemapb.FieldData, error) {
+	numCols := int(rec.NumCols())
+	numRows := int(rec.NumRows())
+	result := make([]*schemapb.FieldData, numCols)
+
+	for i := 0; i < numCols; i++ {
+		fd, err := arrowColumnToFieldData(rec.Column(i), fieldSchemas[i], numRows)
+		if err != nil {
+			return nil, merr.WrapErrServiceInternal(
+				fmt.Sprintf("failed to convert Arrow column %q (field %d)",
+					fieldSchemas[i].GetName(), fieldSchemas[i].GetFieldID()),
+				err.Error(),
+			)
+		}
+		result[i] = fd
+	}
+	return result, nil
+}
+
+func arrowColumnToFieldData(col arrow.Array, schema *schemapb.FieldSchema, numRows int) (*schemapb.FieldData, error) {
+	fd := &schemapb.FieldData{
+		Type:      schema.GetDataType(),
+		FieldName: schema.GetName(),
+		FieldId:   schema.GetFieldID(),
+	}
+
+	switch schema.GetDataType() {
+	case schemapb.DataType_Bool:
+		arr := col.(*array.Boolean)
+		data := make([]bool, numRows)
+		for j := 0; j < numRows; j++ {
+			data[j] = arr.Value(j)
+		}
+		fd.Field = &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_BoolData{
+					BoolData: &schemapb.BoolArray{Data: data},
+				},
+			},
+		}
+
+	case schemapb.DataType_Int8, schemapb.DataType_Int16, schemapb.DataType_Int32:
+		arr := col.(*array.Int32)
+		data := make([]int32, numRows)
+		copy(data, arr.Int32Values())
+		fd.Field = intFieldData(data)
+
+	case schemapb.DataType_Int64, schemapb.DataType_Timestamptz:
+		arr := col.(*array.Int64)
+		data := make([]int64, numRows)
+		copy(data, arr.Int64Values())
+		if schema.GetDataType() == schemapb.DataType_Timestamptz {
+			fd.Field = &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_TimestamptzData{
+						TimestamptzData: &schemapb.TimestamptzArray{Data: data},
+					},
+				},
+			}
+		} else {
+			fd.Field = &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: data},
+					},
+				},
+			}
+		}
+
+	case schemapb.DataType_Float:
+		arr := col.(*array.Float32)
+		data := make([]float32, numRows)
+		copy(data, arr.Float32Values())
+		fd.Field = &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_FloatData{
+					FloatData: &schemapb.FloatArray{Data: data},
+				},
+			},
+		}
+
+	case schemapb.DataType_Double:
+		arr := col.(*array.Float64)
+		data := make([]float64, numRows)
+		copy(data, arr.Float64Values())
+		fd.Field = &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_DoubleData{
+					DoubleData: &schemapb.DoubleArray{Data: data},
+				},
+			},
+		}
+
+	case schemapb.DataType_VarChar, schemapb.DataType_String, schemapb.DataType_Text:
+		arr := col.(*array.String)
+		data := make([]string, numRows)
+		for j := 0; j < numRows; j++ {
+			data[j] = arr.Value(j)
+		}
+		fd.Field = &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_StringData{
+					StringData: &schemapb.StringArray{Data: data},
+				},
+			},
+		}
+
+	case schemapb.DataType_FloatVector:
+		arr := col.(*array.FixedSizeBinary)
+		dim := resolveVectorDim(schema, arr)
+		floatData := compactFloatVector(arr, numRows, int(dim))
+		fd.Field = &schemapb.FieldData_Vectors{
+			Vectors: &schemapb.VectorField{
+				Dim: dim,
+				Data: &schemapb.VectorField_FloatVector{
+					FloatVector: &schemapb.FloatArray{Data: floatData},
+				},
+			},
+		}
+
+	case schemapb.DataType_BinaryVector, schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector:
+		fd.Field = bytesVectorFieldData(col.(*array.FixedSizeBinary), schema, numRows)
+
+	case schemapb.DataType_JSON:
+		arr := col.(*array.Binary)
+		rows := make([][]byte, numRows)
+		for j := 0; j < numRows; j++ {
+			rows[j] = append([]byte{}, arr.Value(j)...)
+		}
+		fd.Field = &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_JsonData{
+					JsonData: &schemapb.JSONArray{Data: rows},
+				},
+			},
+		}
+
+	case schemapb.DataType_SparseFloatVector:
+		arr := col.(*array.Binary)
+		contents, maxDim := compactSparseVector(arr, numRows)
+		fd.Field = &schemapb.FieldData_Vectors{
+			Vectors: &schemapb.VectorField{
+				Dim: maxDim,
+				Data: &schemapb.VectorField_SparseFloatVector{
+					SparseFloatVector: &schemapb.SparseFloatArray{
+						Contents: contents,
+						Dim:      maxDim,
+					},
+				},
+			},
+		}
+
+	case schemapb.DataType_Geometry:
+		arr := col.(*array.Binary)
+		rows := make([][]byte, numRows)
+		for j := 0; j < numRows; j++ {
+			rows[j] = append([]byte{}, arr.Value(j)...)
+		}
+		fd.Field = &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_GeometryData{
+					GeometryData: &schemapb.GeometryArray{Data: rows},
+				},
+			},
+		}
+
+	case schemapb.DataType_Int8Vector:
+		arr := col.(*array.FixedSizeBinary)
+		dim := resolveVectorDim(schema, arr)
+		data := compactBytesVector(arr, numRows)
+		fd.Field = &schemapb.FieldData_Vectors{
+			Vectors: &schemapb.VectorField{
+				Dim:  dim,
+				Data: &schemapb.VectorField_Int8Vector{Int8Vector: data},
+			},
+		}
+
+	case schemapb.DataType_ArrayOfVector:
+		fieldsData, err := arrowListToVectorArray(col, schema, numRows)
+		if err != nil {
+			return nil, err
+		}
+		fd.Field = fieldsData
+
+	case schemapb.DataType_Array:
+		arr := col.(*array.Binary)
+		data := make([]*schemapb.ScalarField, numRows)
+		for j := 0; j < numRows; j++ {
+			sf := &schemapb.ScalarField{}
+			if err := proto.Unmarshal(arr.Value(j), sf); err != nil {
+				return nil, merr.WrapErrServiceInternalMsg("failed to unmarshal Array element at row %d for field %q: %s",
+					j, schema.GetName(), err)
+			}
+			data[j] = sf
+		}
+		fd.Field = &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_ArrayData{
+					ArrayData: &schemapb.ArrayArray{
+						Data:        data,
+						ElementType: schema.GetElementType(),
+					},
+				},
+			},
+		}
+
+	default:
+		return nil, merr.WrapErrServiceInternalMsg("unsupported data type %s for field %q (id=%d) in Arrow-to-proto conversion",
+			schema.GetDataType().String(), schema.GetName(), schema.GetFieldID())
+	}
+
+	setArrowValidData(fd, col, numRows)
+	return fd, nil
+}
+
+// setArrowValidData extracts the Arrow validity bitmap and writes it to the
+// field-specific ValidData location when nulls are present.
+func setArrowValidData(fd *schemapb.FieldData, col arrow.Array, numRows int) {
+	if col.NullN() == 0 {
+		return
+	}
+	validData := make([]bool, numRows)
+	for j := 0; j < numRows; j++ {
+		validData[j] = col.IsValid(j)
+	}
+	typeutil.SetFieldDataValidData(fd, validData)
+}
+
+// resolveVectorDim returns the vector dimension for a FixedSizeBinary vector
+// column, preferring the FieldSchema's declared dim. If the schema doesn't
+// carry a usable dim (typeutil.GetDim fails), it falls back to deriving the
+// dim from the Arrow column's own byte width.
+func resolveVectorDim(schema *schemapb.FieldSchema, arr *array.FixedSizeBinary) int64 {
+	dim, err := typeutil.GetDim(schema)
+	if err == nil {
+		return dim
+	}
+
+	byteWidth := arr.DataType().(*arrow.FixedSizeBinaryType).ByteWidth
+	var fallback int64
+	switch schema.GetDataType() {
+	case schemapb.DataType_FloatVector:
+		fallback = int64(byteWidth / 4)
+	case schemapb.DataType_BinaryVector:
+		fallback = int64(byteWidth * 8)
+	case schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector:
+		fallback = int64(byteWidth / 2)
+	}
+	return fallback
+}
+
+func bytesVectorFieldData(arr *array.FixedSizeBinary, schema *schemapb.FieldSchema, numRows int) *schemapb.FieldData_Vectors {
+	dim := resolveVectorDim(schema, arr)
+	data := compactBytesVector(arr, numRows)
+
+	vf := &schemapb.VectorField{Dim: dim}
+	switch schema.GetDataType() {
+	case schemapb.DataType_BinaryVector:
+		vf.Data = &schemapb.VectorField_BinaryVector{BinaryVector: data}
+	case schemapb.DataType_Float16Vector:
+		vf.Data = &schemapb.VectorField_Float16Vector{Float16Vector: data}
+	case schemapb.DataType_BFloat16Vector:
+		vf.Data = &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: data}
+	}
+	return &schemapb.FieldData_Vectors{Vectors: vf}
+}
+
+// compactFloatVector copies only valid rows from an Arrow FixedSizeBinary
+// column into a compact float32 slice.  Milvus FieldData pairs ValidData
+// with a compact payload containing only valid rows.
+func compactFloatVector(arr *array.FixedSizeBinary, numRows, dim int) []float32 {
+	if arr.NullN() == 0 {
+		raw := fixedSizeBinaryBytes(arr, numRows)
+		floatData := make([]float32, numRows*dim)
+		copy(floatData, arrow.Float32Traits.CastFromBytes(raw))
+		return floatData
+	}
+	validCount := numRows - arr.NullN()
+	floatData := make([]float32, validCount*dim)
+	physical := 0
+	for j := 0; j < numRows; j++ {
+		if arr.IsValid(j) {
+			src := arr.Value(j)
+			copy(floatData[physical*dim:(physical+1)*dim], arrow.Float32Traits.CastFromBytes(src))
+			physical++
+		}
+	}
+	return floatData
+}
+
+// compactSparseVector copies only valid rows from an Arrow Binary column
+// into a compact contents slice for sparse float vectors.
+func compactSparseVector(arr *array.Binary, numRows int) ([][]byte, int64) {
+	validCount := numRows - arr.NullN()
+	contents := make([][]byte, validCount)
+	var maxDim int64
+	physical := 0
+	for j := 0; j < numRows; j++ {
+		if !arr.IsValid(j) {
+			continue
+		}
+		row := arr.Value(j)
+		contents[physical] = append([]byte{}, row...)
+		numPairs := len(row) / 8
+		for k := 0; k < numPairs; k++ {
+			idx := int64(binary.LittleEndian.Uint32(row[k*8:])) + 1
+			if idx > maxDim {
+				maxDim = idx
+			}
+		}
+		physical++
+	}
+	return contents, maxDim
+}
+
+// compactBytesVector copies only valid rows from an Arrow FixedSizeBinary
+// column into a compact byte slice for binary/float16/bfloat16 vectors.
+func compactBytesVector(arr *array.FixedSizeBinary, numRows int) []byte {
+	if arr.NullN() == 0 {
+		raw := fixedSizeBinaryBytes(arr, numRows)
+		data := make([]byte, len(raw))
+		copy(data, raw)
+		return data
+	}
+	byteWidth := arr.DataType().(*arrow.FixedSizeBinaryType).ByteWidth
+	validCount := numRows - arr.NullN()
+	data := make([]byte, validCount*byteWidth)
+	physical := 0
+	for j := 0; j < numRows; j++ {
+		if arr.IsValid(j) {
+			copy(data[physical*byteWidth:(physical+1)*byteWidth], arr.Value(j))
+			physical++
+		}
+	}
+	return data
+}
+
+// arrowListToVectorArray converts an Arrow List(FixedSizeBinary) column into
+// a proto VectorField_VectorArray.  Each list element is a single vector.
+func arrowListToVectorArray(col arrow.Array, schema *schemapb.FieldSchema, numRows int) (*schemapb.FieldData_Vectors, error) {
+	listArr := col.(*array.List)
+	elemType := schema.GetElementType()
+	dim, _ := typeutil.GetDim(schema)
+
+	vectors := make([]*schemapb.VectorField, numRows)
+	for j := 0; j < numRows; j++ {
+		if !listArr.IsValid(j) {
+			vectors[j] = &schemapb.VectorField{Dim: dim}
+			continue
+		}
+		start, end := listArr.ValueOffsets(j)
+		innerArr := listArr.ListValues().(*array.FixedSizeBinary)
+
+		vf := &schemapb.VectorField{Dim: dim}
+		length := int(end - start)
+		switch elemType {
+		case schemapb.DataType_FloatVector:
+			floatData := make([]float32, 0, length*int(dim))
+			for k := int(start); k < int(end); k++ {
+				floatData = append(floatData, arrow.Float32Traits.CastFromBytes(innerArr.Value(k))...)
+			}
+			vf.Data = &schemapb.VectorField_FloatVector{
+				FloatVector: &schemapb.FloatArray{Data: floatData},
+			}
+		case schemapb.DataType_BinaryVector,
+			schemapb.DataType_Float16Vector,
+			schemapb.DataType_BFloat16Vector,
+			schemapb.DataType_Int8Vector:
+			byteWidth := innerArr.DataType().(*arrow.FixedSizeBinaryType).ByteWidth
+			raw := make([]byte, 0, length*byteWidth)
+			for k := int(start); k < int(end); k++ {
+				raw = append(raw, innerArr.Value(k)...)
+			}
+			switch elemType {
+			case schemapb.DataType_BinaryVector:
+				vf.Data = &schemapb.VectorField_BinaryVector{BinaryVector: raw}
+			case schemapb.DataType_Float16Vector:
+				vf.Data = &schemapb.VectorField_Float16Vector{Float16Vector: raw}
+			case schemapb.DataType_BFloat16Vector:
+				vf.Data = &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: raw}
+			case schemapb.DataType_Int8Vector:
+				vf.Data = &schemapb.VectorField_Int8Vector{Int8Vector: raw}
+			}
+		default:
+			return nil, merr.WrapErrServiceInternalMsg(
+				"unsupported VectorArray element type %s", elemType.String(),
+			)
+		}
+		vectors[j] = vf
+	}
+
+	return &schemapb.FieldData_Vectors{
+		Vectors: &schemapb.VectorField{
+			Dim: dim,
+			Data: &schemapb.VectorField_VectorArray{
+				VectorArray: &schemapb.VectorArray{
+					Dim:         dim,
+					Data:        vectors,
+					ElementType: elemType,
+				},
+			},
+		},
+	}, nil
+}
+
+func intFieldData(data []int32) *schemapb.FieldData_Scalars {
+	return &schemapb.FieldData_Scalars{
+		Scalars: &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_IntData{
+				IntData: &schemapb.IntArray{Data: data},
+			},
+		},
+	}
+}
+
+// fixedSizeBinaryBytes returns the raw bytes backing the first numRows values
+// of a FixedSizeBinary array, honoring the array's offset into its buffer.
+// The returned slice aliases Arrow's underlying buffer and must not be
+// retained beyond the lifetime of arr; callers copy out of it immediately.
+func fixedSizeBinaryBytes(arr *array.FixedSizeBinary, numRows int) []byte {
+	byteWidth := arr.DataType().(*arrow.FixedSizeBinaryType).ByteWidth
+	buf := arr.Data().Buffers()[1]
+	if buf == nil {
+		return nil
+	}
+	offset := arr.Data().Offset() * byteWidth
+	return buf.Bytes()[offset : offset+numRows*byteWidth]
+}

--- a/internal/util/segcore/arrow_to_fielddata.go
+++ b/internal/util/segcore/arrow_to_fielddata.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
@@ -145,7 +146,9 @@ func arrowColumnToFieldData(col arrow.Array, schema *schemapb.FieldSchema, numRo
 		arr := col.(*array.String)
 		data := make([]string, numRows)
 		for j := 0; j < numRows; j++ {
-			data[j] = arr.Value(j)
+			// arr.Value returns a zero-copy view into the Arrow buffer;
+			// Clone so the string outlives rec.Release().
+			data[j] = strings.Clone(arr.Value(j))
 		}
 		fd.Field = &schemapb.FieldData_Scalars{
 			Scalars: &schemapb.ScalarField{

--- a/internal/util/segcore/arrow_to_fielddata_test.go
+++ b/internal/util/segcore/arrow_to_fielddata_test.go
@@ -1,0 +1,517 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package segcore
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+)
+
+func buildTestRecord(pool memory.Allocator, fields []arrow.Field, builders func([]array.Builder)) arrow.Record {
+	schema := arrow.NewSchema(fields, nil)
+	bldr := array.NewRecordBuilder(pool, schema)
+	defer bldr.Release()
+	builders(bldr.Fields())
+	return bldr.NewRecord()
+}
+
+func dimTypeParams(dim int) []*commonpb.KeyValuePair {
+	return []*commonpb.KeyValuePair{{Key: "dim", Value: strconv.Itoa(dim)}}
+}
+
+func TestArrowFieldsToProto_Int64(t *testing.T) {
+	pool := memory.NewGoAllocator()
+	rec := buildTestRecord(
+		pool,
+		[]arrow.Field{{Name: "pk", Type: arrow.PrimitiveTypes.Int64}},
+		func(bs []array.Builder) {
+			b := bs[0].(*array.Int64Builder)
+			b.AppendValues([]int64{10, 20, 30}, nil)
+		},
+	)
+	defer rec.Release()
+
+	schemas := []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64},
+	}
+	result, err := ArrowFieldsToProto(rec, schemas)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "pk", result[0].GetFieldName())
+	assert.Equal(t, int64(100), result[0].GetFieldId())
+	assert.Equal(t, schemapb.DataType_Int64, result[0].GetType())
+	assert.Equal(t, []int64{10, 20, 30}, result[0].GetScalars().GetLongData().GetData())
+}
+
+func TestArrowFieldsToProto_Float32(t *testing.T) {
+	pool := memory.NewGoAllocator()
+	rec := buildTestRecord(
+		pool,
+		[]arrow.Field{{Name: "score", Type: arrow.PrimitiveTypes.Float32}},
+		func(bs []array.Builder) {
+			b := bs[0].(*array.Float32Builder)
+			b.AppendValues([]float32{1.5, 2.5, 3.5}, nil)
+		},
+	)
+	defer rec.Release()
+
+	schemas := []*schemapb.FieldSchema{
+		{FieldID: 101, Name: "score", DataType: schemapb.DataType_Float},
+	}
+	result, err := ArrowFieldsToProto(rec, schemas)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, []float32{1.5, 2.5, 3.5}, result[0].GetScalars().GetFloatData().GetData())
+}
+
+func TestArrowFieldsToProto_Double(t *testing.T) {
+	pool := memory.NewGoAllocator()
+	rec := buildTestRecord(
+		pool,
+		[]arrow.Field{{Name: "score", Type: arrow.PrimitiveTypes.Float64}},
+		func(bs []array.Builder) {
+			b := bs[0].(*array.Float64Builder)
+			b.AppendValues([]float64{1.1, 2.2, 3.3}, nil)
+		},
+	)
+	defer rec.Release()
+
+	schemas := []*schemapb.FieldSchema{
+		{FieldID: 102, Name: "score", DataType: schemapb.DataType_Double},
+	}
+	result, err := ArrowFieldsToProto(rec, schemas)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, []float64{1.1, 2.2, 3.3}, result[0].GetScalars().GetDoubleData().GetData())
+}
+
+func TestArrowFieldsToProto_Bool(t *testing.T) {
+	pool := memory.NewGoAllocator()
+	rec := buildTestRecord(
+		pool,
+		[]arrow.Field{{Name: "flag", Type: arrow.FixedWidthTypes.Boolean}},
+		func(bs []array.Builder) {
+			b := bs[0].(*array.BooleanBuilder)
+			b.AppendValues([]bool{true, false, true}, nil)
+		},
+	)
+	defer rec.Release()
+
+	schemas := []*schemapb.FieldSchema{
+		{FieldID: 103, Name: "flag", DataType: schemapb.DataType_Bool},
+	}
+	result, err := ArrowFieldsToProto(rec, schemas)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, []bool{true, false, true}, result[0].GetScalars().GetBoolData().GetData())
+}
+
+func TestArrowFieldsToProto_String(t *testing.T) {
+	pool := memory.NewGoAllocator()
+	rec := buildTestRecord(
+		pool,
+		[]arrow.Field{{Name: "name", Type: arrow.BinaryTypes.String}},
+		func(bs []array.Builder) {
+			b := bs[0].(*array.StringBuilder)
+			b.AppendValues([]string{"alice", "bob", "carol"}, nil)
+		},
+	)
+	defer rec.Release()
+
+	schemas := []*schemapb.FieldSchema{
+		{FieldID: 104, Name: "name", DataType: schemapb.DataType_VarChar},
+	}
+	result, err := ArrowFieldsToProto(rec, schemas)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, []string{"alice", "bob", "carol"}, result[0].GetScalars().GetStringData().GetData())
+}
+
+func TestArrowFieldsToProto_FloatVector(t *testing.T) {
+	pool := memory.NewGoAllocator()
+	dim := 4
+	bytesPerVec := dim * 4
+	rec := buildTestRecord(
+		pool,
+		[]arrow.Field{{Name: "vec", Type: &arrow.FixedSizeBinaryType{ByteWidth: bytesPerVec}}},
+		func(bs []array.Builder) {
+			b := bs[0].(*array.FixedSizeBinaryBuilder)
+			// Write 2 vectors of dim=4
+			for i := 0; i < 2; i++ {
+				vec := make([]float32, dim)
+				for j := range vec {
+					vec[j] = float32(i*dim + j)
+				}
+				b.Append(arrow.Float32Traits.CastToBytes(vec))
+			}
+		},
+	)
+	defer rec.Release()
+
+	schemas := []*schemapb.FieldSchema{
+		{
+			FieldID: 101, Name: "vec", DataType: schemapb.DataType_FloatVector,
+			TypeParams: dimTypeParams(dim),
+		},
+	}
+	result, err := ArrowFieldsToProto(rec, schemas)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, int64(dim), result[0].GetVectors().GetDim())
+	floatVec := result[0].GetVectors().GetFloatVector().GetData()
+	assert.Len(t, floatVec, 8) // 2 vectors * dim 4
+	assert.InDelta(t, float32(0), floatVec[0], 1e-6)
+	assert.InDelta(t, float32(4), floatVec[4], 1e-6)
+}
+
+func TestArrowFieldsToProto_BinaryVector(t *testing.T) {
+	pool := memory.NewGoAllocator()
+	dim := 16
+	bytesPerVec := dim / 8
+	rec := buildTestRecord(
+		pool,
+		[]arrow.Field{{Name: "vec", Type: &arrow.FixedSizeBinaryType{ByteWidth: bytesPerVec}}},
+		func(bs []array.Builder) {
+			b := bs[0].(*array.FixedSizeBinaryBuilder)
+			b.Append([]byte{0xFF, 0x00})
+			b.Append([]byte{0x0F, 0xF0})
+		},
+	)
+	defer rec.Release()
+
+	schemas := []*schemapb.FieldSchema{
+		{
+			FieldID: 105, Name: "vec", DataType: schemapb.DataType_BinaryVector,
+			TypeParams: dimTypeParams(dim),
+		},
+	}
+	result, err := ArrowFieldsToProto(rec, schemas)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, int64(dim), result[0].GetVectors().GetDim())
+	assert.Equal(t, []byte{0xFF, 0x00, 0x0F, 0xF0}, result[0].GetVectors().GetBinaryVector())
+}
+
+func TestArrowFieldsToProto_Float16Vector(t *testing.T) {
+	pool := memory.NewGoAllocator()
+	dim := 4
+	bytesPerVec := dim * 2
+	rec := buildTestRecord(
+		pool,
+		[]arrow.Field{{Name: "vec", Type: &arrow.FixedSizeBinaryType{ByteWidth: bytesPerVec}}},
+		func(bs []array.Builder) {
+			b := bs[0].(*array.FixedSizeBinaryBuilder)
+			b.Append(make([]byte, bytesPerVec))
+			raw := make([]byte, bytesPerVec)
+			for i := range raw {
+				raw[i] = byte(i + 1)
+			}
+			b.Append(raw)
+		},
+	)
+	defer rec.Release()
+
+	schemas := []*schemapb.FieldSchema{
+		{
+			FieldID: 106, Name: "vec", DataType: schemapb.DataType_Float16Vector,
+			TypeParams: dimTypeParams(dim),
+		},
+	}
+	result, err := ArrowFieldsToProto(rec, schemas)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, int64(dim), result[0].GetVectors().GetDim())
+	data := result[0].GetVectors().GetFloat16Vector()
+	assert.Len(t, data, 2*bytesPerVec)
+	assert.Equal(t, byte(1), data[bytesPerVec])
+}
+
+func TestArrowFieldsToProto_BFloat16Vector(t *testing.T) {
+	pool := memory.NewGoAllocator()
+	dim := 4
+	bytesPerVec := dim * 2
+	rec := buildTestRecord(
+		pool,
+		[]arrow.Field{{Name: "vec", Type: &arrow.FixedSizeBinaryType{ByteWidth: bytesPerVec}}},
+		func(bs []array.Builder) {
+			b := bs[0].(*array.FixedSizeBinaryBuilder)
+			b.Append(make([]byte, bytesPerVec))
+			raw := make([]byte, bytesPerVec)
+			for i := range raw {
+				raw[i] = byte(i + 1)
+			}
+			b.Append(raw)
+		},
+	)
+	defer rec.Release()
+
+	schemas := []*schemapb.FieldSchema{
+		{
+			FieldID: 107, Name: "vec", DataType: schemapb.DataType_BFloat16Vector,
+			TypeParams: dimTypeParams(dim),
+		},
+	}
+	result, err := ArrowFieldsToProto(rec, schemas)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, int64(dim), result[0].GetVectors().GetDim())
+	data := result[0].GetVectors().GetBfloat16Vector()
+	assert.Len(t, data, 2*bytesPerVec)
+	assert.Equal(t, byte(1), data[bytesPerVec])
+}
+
+func TestArrowFieldsToProto_MultiColumn(t *testing.T) {
+	pool := memory.NewGoAllocator()
+	dim := 768
+	bytesPerVec := dim * 4
+	rec := buildTestRecord(
+		pool,
+		[]arrow.Field{
+			{Name: "pk", Type: arrow.PrimitiveTypes.Int64},
+			{Name: "score", Type: arrow.PrimitiveTypes.Float32},
+			{Name: "vec", Type: &arrow.FixedSizeBinaryType{ByteWidth: bytesPerVec}},
+		},
+		func(bs []array.Builder) {
+			pkB := bs[0].(*array.Int64Builder)
+			pkB.AppendValues([]int64{1, 2}, nil)
+
+			scoreB := bs[1].(*array.Float32Builder)
+			scoreB.AppendValues([]float32{0.1, 0.2}, nil)
+
+			vecB := bs[2].(*array.FixedSizeBinaryBuilder)
+			for i := 0; i < 2; i++ {
+				vec := make([]float32, dim)
+				for j := range vec {
+					vec[j] = float32(i*dim + j)
+				}
+				vecB.Append(arrow.Float32Traits.CastToBytes(vec))
+			}
+		},
+	)
+	defer rec.Release()
+
+	schemas := []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64},
+		{FieldID: 101, Name: "score", DataType: schemapb.DataType_Float},
+		{FieldID: 102, Name: "vec", DataType: schemapb.DataType_FloatVector, TypeParams: dimTypeParams(dim)},
+	}
+	result, err := ArrowFieldsToProto(rec, schemas)
+	assert.NoError(t, err)
+	assert.Len(t, result, 3)
+	assert.Equal(t, []int64{1, 2}, result[0].GetScalars().GetLongData().GetData())
+	assert.Equal(t, []float32{0.1, 0.2}, result[1].GetScalars().GetFloatData().GetData())
+	assert.Equal(t, int64(dim), result[2].GetVectors().GetDim())
+	assert.Len(t, result[2].GetVectors().GetFloatVector().GetData(), 2*dim)
+}
+
+func TestArrowFieldsToProto_EmptyRecord(t *testing.T) {
+	pool := memory.NewGoAllocator()
+	rec := buildTestRecord(
+		pool,
+		[]arrow.Field{
+			{Name: "pk", Type: arrow.PrimitiveTypes.Int64},
+			{Name: "name", Type: arrow.BinaryTypes.String},
+		},
+		func(bs []array.Builder) {},
+	)
+	defer rec.Release()
+
+	schemas := []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64},
+		{FieldID: 104, Name: "name", DataType: schemapb.DataType_VarChar},
+	}
+	result, err := ArrowFieldsToProto(rec, schemas)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Empty(t, result[0].GetScalars().GetLongData().GetData())
+	assert.Empty(t, result[1].GetScalars().GetStringData().GetData())
+}
+
+// TestArrowFieldsToProto_Int8_via_Int32 verifies that Int8 schema fields
+// are correctly read from arrow.Int32 columns (C++ FieldDataToArrow stores
+// Int8/Int16/Int32 as arrow::int32 because protobuf uses int_data for all).
+func TestArrowFieldsToProto_Int8_via_Int32(t *testing.T) {
+	pool := memory.NewGoAllocator()
+	rec := buildTestRecord(
+		pool,
+		[]arrow.Field{{Name: "age", Type: arrow.PrimitiveTypes.Int32}},
+		func(bs []array.Builder) {
+			b := bs[0].(*array.Int32Builder)
+			b.AppendValues([]int32{-1, 0, 127}, nil)
+		},
+	)
+	defer rec.Release()
+
+	schemas := []*schemapb.FieldSchema{
+		{FieldID: 109, Name: "age", DataType: schemapb.DataType_Int8},
+	}
+	result, err := ArrowFieldsToProto(rec, schemas)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, schemapb.DataType_Int8, result[0].GetType())
+	assert.Equal(t, []int32{-1, 0, 127}, result[0].GetScalars().GetIntData().GetData())
+}
+
+// TestArrowFieldsToProto_Int16_via_Int32 verifies Int16 schema fields
+// from arrow.Int32 columns.
+func TestArrowFieldsToProto_Int16_via_Int32(t *testing.T) {
+	pool := memory.NewGoAllocator()
+	rec := buildTestRecord(
+		pool,
+		[]arrow.Field{{Name: "val", Type: arrow.PrimitiveTypes.Int32}},
+		func(bs []array.Builder) {
+			b := bs[0].(*array.Int32Builder)
+			b.AppendValues([]int32{-32768, 0, 32767}, nil)
+		},
+	)
+	defer rec.Release()
+
+	schemas := []*schemapb.FieldSchema{
+		{FieldID: 110, Name: "val", DataType: schemapb.DataType_Int16},
+	}
+	result, err := ArrowFieldsToProto(rec, schemas)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, schemapb.DataType_Int16, result[0].GetType())
+	assert.Equal(t, []int32{-32768, 0, 32767}, result[0].GetScalars().GetIntData().GetData())
+}
+
+// TestArrowFieldsToProto_JSON verifies JSON fields from arrow.Binary columns.
+func TestArrowFieldsToProto_JSON(t *testing.T) {
+	pool := memory.NewGoAllocator()
+	rec := buildTestRecord(
+		pool,
+		[]arrow.Field{{Name: "meta", Type: arrow.BinaryTypes.Binary}},
+		func(bs []array.Builder) {
+			b := bs[0].(*array.BinaryBuilder)
+			b.Append([]byte(`{"a":1}`))
+			b.Append([]byte(`{"b":2}`))
+		},
+	)
+	defer rec.Release()
+
+	schemas := []*schemapb.FieldSchema{
+		{FieldID: 108, Name: "meta", DataType: schemapb.DataType_JSON},
+	}
+	result, err := ArrowFieldsToProto(rec, schemas)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "meta", result[0].GetFieldName())
+	assert.Equal(t, schemapb.DataType_JSON, result[0].GetType())
+	assert.NotNil(t, result[0].GetField())
+	jsonData := result[0].GetScalars().GetJsonData().GetData()
+	assert.Len(t, jsonData, 2)
+	assert.Equal(t, []byte(`{"a":1}`), jsonData[0])
+	assert.Equal(t, []byte(`{"b":2}`), jsonData[1])
+}
+
+// TestArrowFieldsToProto_UnmappedDataType covers the default branch of the
+// type switch: a DataType this converter does not (yet) handle must return
+// an error instead of silently producing an empty field.
+func TestArrowFieldsToProto_UnmappedDataType(t *testing.T) {
+	pool := memory.NewGoAllocator()
+	rec := buildTestRecord(
+		pool,
+		[]arrow.Field{{Name: "arr", Type: arrow.BinaryTypes.Binary}},
+		func(bs []array.Builder) {
+			b := bs[0].(*array.BinaryBuilder)
+			b.Append([]byte{1, 2, 3})
+		},
+	)
+	defer rec.Release()
+
+	schemas := []*schemapb.FieldSchema{
+		{FieldID: 111, Name: "arr", DataType: schemapb.DataType_None},
+	}
+	_, err := ArrowFieldsToProto(rec, schemas)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "arr")
+}
+
+// TestArrowFieldsToProto_FloatVector_DimFallback covers the case where the
+// FieldSchema is missing a resolvable "dim" (typeutil.GetDim fails): the
+// converter must fall back to the Arrow column's own byte width instead of
+// silently producing a zero-length vector.
+func TestArrowFieldsToProto_FloatVector_DimFallback(t *testing.T) {
+	pool := memory.NewGoAllocator()
+	dim := 4
+	bytesPerVec := dim * 4
+	rec := buildTestRecord(
+		pool,
+		[]arrow.Field{{Name: "vec", Type: &arrow.FixedSizeBinaryType{ByteWidth: bytesPerVec}}},
+		func(bs []array.Builder) {
+			b := bs[0].(*array.FixedSizeBinaryBuilder)
+			for i := 0; i < 2; i++ {
+				vec := make([]float32, dim)
+				for j := range vec {
+					vec[j] = float32(i*dim + j)
+				}
+				b.Append(arrow.Float32Traits.CastToBytes(vec))
+			}
+		},
+	)
+	defer rec.Release()
+
+	// No TypeParams at all, so typeutil.GetDim fails and the fallback path
+	// (byteWidth / 4) must kick in.
+	schemas := []*schemapb.FieldSchema{
+		{FieldID: 109, Name: "vec", DataType: schemapb.DataType_FloatVector},
+	}
+	result, err := ArrowFieldsToProto(rec, schemas)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, int64(dim), result[0].GetVectors().GetDim())
+	floatVec := result[0].GetVectors().GetFloatVector().GetData()
+	assert.Len(t, floatVec, 2*dim)
+	assert.InDelta(t, float32(0), floatVec[0], 1e-6)
+	assert.InDelta(t, float32(4), floatVec[4], 1e-6)
+}
+
+// TestArrowFieldsToProto_BinaryVector_DimFallback mirrors the FloatVector
+// fallback test for BinaryVector's byteWidth*8 fallback formula.
+func TestArrowFieldsToProto_BinaryVector_DimFallback(t *testing.T) {
+	pool := memory.NewGoAllocator()
+	dim := 16
+	bytesPerVec := dim / 8
+	rec := buildTestRecord(
+		pool,
+		[]arrow.Field{{Name: "vec", Type: &arrow.FixedSizeBinaryType{ByteWidth: bytesPerVec}}},
+		func(bs []array.Builder) {
+			b := bs[0].(*array.FixedSizeBinaryBuilder)
+			b.Append([]byte{0xFF, 0x00})
+			b.Append([]byte{0x0F, 0xF0})
+		},
+	)
+	defer rec.Release()
+
+	schemas := []*schemapb.FieldSchema{
+		{FieldID: 110, Name: "vec", DataType: schemapb.DataType_BinaryVector},
+	}
+	result, err := ArrowFieldsToProto(rec, schemas)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, int64(dim), result[0].GetVectors().GetDim())
+	assert.Equal(t, []byte{0xFF, 0x00, 0x0F, 0xF0}, result[0].GetVectors().GetBinaryVector())
+}

--- a/internal/util/segcore/arrow_to_fielddata_test.go
+++ b/internal/util/segcore/arrow_to_fielddata_test.go
@@ -29,12 +29,27 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 )
 
-func buildTestRecord(pool memory.Allocator, fields []arrow.Field, builders func([]array.Builder)) arrow.Record {
-	schema := arrow.NewSchema(fields, nil)
+func buildTestRecordWithFieldIDs(pool memory.Allocator, fields []arrow.Field, fieldIDs []int64, builders func([]array.Builder)) arrow.Record {
+	tagged := make([]arrow.Field, len(fields))
+	for i, f := range fields {
+		md := arrow.MetadataFrom(map[string]string{
+			"milvus.field_id": strconv.FormatInt(fieldIDs[i], 10),
+		})
+		tagged[i] = arrow.Field{Name: f.Name, Type: f.Type, Nullable: f.Nullable, Metadata: md}
+	}
+	schema := arrow.NewSchema(tagged, nil)
 	bldr := array.NewRecordBuilder(pool, schema)
 	defer bldr.Release()
 	builders(bldr.Fields())
 	return bldr.NewRecord()
+}
+
+func schemaMap(schemas ...*schemapb.FieldSchema) map[int64]*schemapb.FieldSchema {
+	m := make(map[int64]*schemapb.FieldSchema, len(schemas))
+	for _, s := range schemas {
+		m[s.GetFieldID()] = s
+	}
+	return m
 }
 
 func dimTypeParams(dim int) []*commonpb.KeyValuePair {
@@ -43,9 +58,10 @@ func dimTypeParams(dim int) []*commonpb.KeyValuePair {
 
 func TestArrowFieldsToProto_Int64(t *testing.T) {
 	pool := memory.NewGoAllocator()
-	rec := buildTestRecord(
+	rec := buildTestRecordWithFieldIDs(
 		pool,
 		[]arrow.Field{{Name: "pk", Type: arrow.PrimitiveTypes.Int64}},
+		[]int64{100},
 		func(bs []array.Builder) {
 			b := bs[0].(*array.Int64Builder)
 			b.AppendValues([]int64{10, 20, 30}, nil)
@@ -53,10 +69,9 @@ func TestArrowFieldsToProto_Int64(t *testing.T) {
 	)
 	defer rec.Release()
 
-	schemas := []*schemapb.FieldSchema{
-		{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64},
-	}
-	result, err := ArrowFieldsToProto(rec, schemas)
+	result, err := ArrowFieldsToProto(rec, schemaMap(
+		&schemapb.FieldSchema{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64},
+	))
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, "pk", result[0].GetFieldName())
@@ -67,9 +82,10 @@ func TestArrowFieldsToProto_Int64(t *testing.T) {
 
 func TestArrowFieldsToProto_Float32(t *testing.T) {
 	pool := memory.NewGoAllocator()
-	rec := buildTestRecord(
+	rec := buildTestRecordWithFieldIDs(
 		pool,
 		[]arrow.Field{{Name: "score", Type: arrow.PrimitiveTypes.Float32}},
+		[]int64{101},
 		func(bs []array.Builder) {
 			b := bs[0].(*array.Float32Builder)
 			b.AppendValues([]float32{1.5, 2.5, 3.5}, nil)
@@ -77,10 +93,9 @@ func TestArrowFieldsToProto_Float32(t *testing.T) {
 	)
 	defer rec.Release()
 
-	schemas := []*schemapb.FieldSchema{
-		{FieldID: 101, Name: "score", DataType: schemapb.DataType_Float},
-	}
-	result, err := ArrowFieldsToProto(rec, schemas)
+	result, err := ArrowFieldsToProto(rec, schemaMap(
+		&schemapb.FieldSchema{FieldID: 101, Name: "score", DataType: schemapb.DataType_Float},
+	))
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, []float32{1.5, 2.5, 3.5}, result[0].GetScalars().GetFloatData().GetData())
@@ -88,9 +103,10 @@ func TestArrowFieldsToProto_Float32(t *testing.T) {
 
 func TestArrowFieldsToProto_Double(t *testing.T) {
 	pool := memory.NewGoAllocator()
-	rec := buildTestRecord(
+	rec := buildTestRecordWithFieldIDs(
 		pool,
 		[]arrow.Field{{Name: "score", Type: arrow.PrimitiveTypes.Float64}},
+		[]int64{102},
 		func(bs []array.Builder) {
 			b := bs[0].(*array.Float64Builder)
 			b.AppendValues([]float64{1.1, 2.2, 3.3}, nil)
@@ -98,10 +114,9 @@ func TestArrowFieldsToProto_Double(t *testing.T) {
 	)
 	defer rec.Release()
 
-	schemas := []*schemapb.FieldSchema{
-		{FieldID: 102, Name: "score", DataType: schemapb.DataType_Double},
-	}
-	result, err := ArrowFieldsToProto(rec, schemas)
+	result, err := ArrowFieldsToProto(rec, schemaMap(
+		&schemapb.FieldSchema{FieldID: 102, Name: "score", DataType: schemapb.DataType_Double},
+	))
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, []float64{1.1, 2.2, 3.3}, result[0].GetScalars().GetDoubleData().GetData())
@@ -109,9 +124,10 @@ func TestArrowFieldsToProto_Double(t *testing.T) {
 
 func TestArrowFieldsToProto_Bool(t *testing.T) {
 	pool := memory.NewGoAllocator()
-	rec := buildTestRecord(
+	rec := buildTestRecordWithFieldIDs(
 		pool,
 		[]arrow.Field{{Name: "flag", Type: arrow.FixedWidthTypes.Boolean}},
+		[]int64{103},
 		func(bs []array.Builder) {
 			b := bs[0].(*array.BooleanBuilder)
 			b.AppendValues([]bool{true, false, true}, nil)
@@ -119,10 +135,9 @@ func TestArrowFieldsToProto_Bool(t *testing.T) {
 	)
 	defer rec.Release()
 
-	schemas := []*schemapb.FieldSchema{
-		{FieldID: 103, Name: "flag", DataType: schemapb.DataType_Bool},
-	}
-	result, err := ArrowFieldsToProto(rec, schemas)
+	result, err := ArrowFieldsToProto(rec, schemaMap(
+		&schemapb.FieldSchema{FieldID: 103, Name: "flag", DataType: schemapb.DataType_Bool},
+	))
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, []bool{true, false, true}, result[0].GetScalars().GetBoolData().GetData())
@@ -130,9 +145,10 @@ func TestArrowFieldsToProto_Bool(t *testing.T) {
 
 func TestArrowFieldsToProto_String(t *testing.T) {
 	pool := memory.NewGoAllocator()
-	rec := buildTestRecord(
+	rec := buildTestRecordWithFieldIDs(
 		pool,
 		[]arrow.Field{{Name: "name", Type: arrow.BinaryTypes.String}},
+		[]int64{104},
 		func(bs []array.Builder) {
 			b := bs[0].(*array.StringBuilder)
 			b.AppendValues([]string{"alice", "bob", "carol"}, nil)
@@ -140,10 +156,9 @@ func TestArrowFieldsToProto_String(t *testing.T) {
 	)
 	defer rec.Release()
 
-	schemas := []*schemapb.FieldSchema{
-		{FieldID: 104, Name: "name", DataType: schemapb.DataType_VarChar},
-	}
-	result, err := ArrowFieldsToProto(rec, schemas)
+	result, err := ArrowFieldsToProto(rec, schemaMap(
+		&schemapb.FieldSchema{FieldID: 104, Name: "name", DataType: schemapb.DataType_VarChar},
+	))
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, []string{"alice", "bob", "carol"}, result[0].GetScalars().GetStringData().GetData())
@@ -153,9 +168,10 @@ func TestArrowFieldsToProto_FloatVector(t *testing.T) {
 	pool := memory.NewGoAllocator()
 	dim := 4
 	bytesPerVec := dim * 4
-	rec := buildTestRecord(
+	rec := buildTestRecordWithFieldIDs(
 		pool,
 		[]arrow.Field{{Name: "vec", Type: &arrow.FixedSizeBinaryType{ByteWidth: bytesPerVec}}},
+		[]int64{101},
 		func(bs []array.Builder) {
 			b := bs[0].(*array.FixedSizeBinaryBuilder)
 			// Write 2 vectors of dim=4
@@ -170,13 +186,12 @@ func TestArrowFieldsToProto_FloatVector(t *testing.T) {
 	)
 	defer rec.Release()
 
-	schemas := []*schemapb.FieldSchema{
-		{
+	result, err := ArrowFieldsToProto(rec, schemaMap(
+		&schemapb.FieldSchema{
 			FieldID: 101, Name: "vec", DataType: schemapb.DataType_FloatVector,
 			TypeParams: dimTypeParams(dim),
 		},
-	}
-	result, err := ArrowFieldsToProto(rec, schemas)
+	))
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, int64(dim), result[0].GetVectors().GetDim())
@@ -190,9 +205,10 @@ func TestArrowFieldsToProto_BinaryVector(t *testing.T) {
 	pool := memory.NewGoAllocator()
 	dim := 16
 	bytesPerVec := dim / 8
-	rec := buildTestRecord(
+	rec := buildTestRecordWithFieldIDs(
 		pool,
 		[]arrow.Field{{Name: "vec", Type: &arrow.FixedSizeBinaryType{ByteWidth: bytesPerVec}}},
+		[]int64{105},
 		func(bs []array.Builder) {
 			b := bs[0].(*array.FixedSizeBinaryBuilder)
 			b.Append([]byte{0xFF, 0x00})
@@ -201,13 +217,12 @@ func TestArrowFieldsToProto_BinaryVector(t *testing.T) {
 	)
 	defer rec.Release()
 
-	schemas := []*schemapb.FieldSchema{
-		{
+	result, err := ArrowFieldsToProto(rec, schemaMap(
+		&schemapb.FieldSchema{
 			FieldID: 105, Name: "vec", DataType: schemapb.DataType_BinaryVector,
 			TypeParams: dimTypeParams(dim),
 		},
-	}
-	result, err := ArrowFieldsToProto(rec, schemas)
+	))
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, int64(dim), result[0].GetVectors().GetDim())
@@ -218,9 +233,10 @@ func TestArrowFieldsToProto_Float16Vector(t *testing.T) {
 	pool := memory.NewGoAllocator()
 	dim := 4
 	bytesPerVec := dim * 2
-	rec := buildTestRecord(
+	rec := buildTestRecordWithFieldIDs(
 		pool,
 		[]arrow.Field{{Name: "vec", Type: &arrow.FixedSizeBinaryType{ByteWidth: bytesPerVec}}},
+		[]int64{106},
 		func(bs []array.Builder) {
 			b := bs[0].(*array.FixedSizeBinaryBuilder)
 			b.Append(make([]byte, bytesPerVec))
@@ -233,13 +249,12 @@ func TestArrowFieldsToProto_Float16Vector(t *testing.T) {
 	)
 	defer rec.Release()
 
-	schemas := []*schemapb.FieldSchema{
-		{
+	result, err := ArrowFieldsToProto(rec, schemaMap(
+		&schemapb.FieldSchema{
 			FieldID: 106, Name: "vec", DataType: schemapb.DataType_Float16Vector,
 			TypeParams: dimTypeParams(dim),
 		},
-	}
-	result, err := ArrowFieldsToProto(rec, schemas)
+	))
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, int64(dim), result[0].GetVectors().GetDim())
@@ -252,9 +267,10 @@ func TestArrowFieldsToProto_BFloat16Vector(t *testing.T) {
 	pool := memory.NewGoAllocator()
 	dim := 4
 	bytesPerVec := dim * 2
-	rec := buildTestRecord(
+	rec := buildTestRecordWithFieldIDs(
 		pool,
 		[]arrow.Field{{Name: "vec", Type: &arrow.FixedSizeBinaryType{ByteWidth: bytesPerVec}}},
+		[]int64{107},
 		func(bs []array.Builder) {
 			b := bs[0].(*array.FixedSizeBinaryBuilder)
 			b.Append(make([]byte, bytesPerVec))
@@ -267,13 +283,12 @@ func TestArrowFieldsToProto_BFloat16Vector(t *testing.T) {
 	)
 	defer rec.Release()
 
-	schemas := []*schemapb.FieldSchema{
-		{
+	result, err := ArrowFieldsToProto(rec, schemaMap(
+		&schemapb.FieldSchema{
 			FieldID: 107, Name: "vec", DataType: schemapb.DataType_BFloat16Vector,
 			TypeParams: dimTypeParams(dim),
 		},
-	}
-	result, err := ArrowFieldsToProto(rec, schemas)
+	))
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, int64(dim), result[0].GetVectors().GetDim())
@@ -286,13 +301,14 @@ func TestArrowFieldsToProto_MultiColumn(t *testing.T) {
 	pool := memory.NewGoAllocator()
 	dim := 768
 	bytesPerVec := dim * 4
-	rec := buildTestRecord(
+	rec := buildTestRecordWithFieldIDs(
 		pool,
 		[]arrow.Field{
 			{Name: "pk", Type: arrow.PrimitiveTypes.Int64},
 			{Name: "score", Type: arrow.PrimitiveTypes.Float32},
 			{Name: "vec", Type: &arrow.FixedSizeBinaryType{ByteWidth: bytesPerVec}},
 		},
+		[]int64{100, 101, 102},
 		func(bs []array.Builder) {
 			pkB := bs[0].(*array.Int64Builder)
 			pkB.AppendValues([]int64{1, 2}, nil)
@@ -312,12 +328,11 @@ func TestArrowFieldsToProto_MultiColumn(t *testing.T) {
 	)
 	defer rec.Release()
 
-	schemas := []*schemapb.FieldSchema{
-		{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64},
-		{FieldID: 101, Name: "score", DataType: schemapb.DataType_Float},
-		{FieldID: 102, Name: "vec", DataType: schemapb.DataType_FloatVector, TypeParams: dimTypeParams(dim)},
-	}
-	result, err := ArrowFieldsToProto(rec, schemas)
+	result, err := ArrowFieldsToProto(rec, schemaMap(
+		&schemapb.FieldSchema{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64},
+		&schemapb.FieldSchema{FieldID: 101, Name: "score", DataType: schemapb.DataType_Float},
+		&schemapb.FieldSchema{FieldID: 102, Name: "vec", DataType: schemapb.DataType_FloatVector, TypeParams: dimTypeParams(dim)},
+	))
 	assert.NoError(t, err)
 	assert.Len(t, result, 3)
 	assert.Equal(t, []int64{1, 2}, result[0].GetScalars().GetLongData().GetData())
@@ -328,21 +343,21 @@ func TestArrowFieldsToProto_MultiColumn(t *testing.T) {
 
 func TestArrowFieldsToProto_EmptyRecord(t *testing.T) {
 	pool := memory.NewGoAllocator()
-	rec := buildTestRecord(
+	rec := buildTestRecordWithFieldIDs(
 		pool,
 		[]arrow.Field{
 			{Name: "pk", Type: arrow.PrimitiveTypes.Int64},
 			{Name: "name", Type: arrow.BinaryTypes.String},
 		},
+		[]int64{100, 104},
 		func(bs []array.Builder) {},
 	)
 	defer rec.Release()
 
-	schemas := []*schemapb.FieldSchema{
-		{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64},
-		{FieldID: 104, Name: "name", DataType: schemapb.DataType_VarChar},
-	}
-	result, err := ArrowFieldsToProto(rec, schemas)
+	result, err := ArrowFieldsToProto(rec, schemaMap(
+		&schemapb.FieldSchema{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64},
+		&schemapb.FieldSchema{FieldID: 104, Name: "name", DataType: schemapb.DataType_VarChar},
+	))
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
 	assert.Empty(t, result[0].GetScalars().GetLongData().GetData())
@@ -354,9 +369,10 @@ func TestArrowFieldsToProto_EmptyRecord(t *testing.T) {
 // Int8/Int16/Int32 as arrow::int32 because protobuf uses int_data for all).
 func TestArrowFieldsToProto_Int8_via_Int32(t *testing.T) {
 	pool := memory.NewGoAllocator()
-	rec := buildTestRecord(
+	rec := buildTestRecordWithFieldIDs(
 		pool,
 		[]arrow.Field{{Name: "age", Type: arrow.PrimitiveTypes.Int32}},
+		[]int64{109},
 		func(bs []array.Builder) {
 			b := bs[0].(*array.Int32Builder)
 			b.AppendValues([]int32{-1, 0, 127}, nil)
@@ -364,10 +380,9 @@ func TestArrowFieldsToProto_Int8_via_Int32(t *testing.T) {
 	)
 	defer rec.Release()
 
-	schemas := []*schemapb.FieldSchema{
-		{FieldID: 109, Name: "age", DataType: schemapb.DataType_Int8},
-	}
-	result, err := ArrowFieldsToProto(rec, schemas)
+	result, err := ArrowFieldsToProto(rec, schemaMap(
+		&schemapb.FieldSchema{FieldID: 109, Name: "age", DataType: schemapb.DataType_Int8},
+	))
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, schemapb.DataType_Int8, result[0].GetType())
@@ -378,9 +393,10 @@ func TestArrowFieldsToProto_Int8_via_Int32(t *testing.T) {
 // from arrow.Int32 columns.
 func TestArrowFieldsToProto_Int16_via_Int32(t *testing.T) {
 	pool := memory.NewGoAllocator()
-	rec := buildTestRecord(
+	rec := buildTestRecordWithFieldIDs(
 		pool,
 		[]arrow.Field{{Name: "val", Type: arrow.PrimitiveTypes.Int32}},
+		[]int64{110},
 		func(bs []array.Builder) {
 			b := bs[0].(*array.Int32Builder)
 			b.AppendValues([]int32{-32768, 0, 32767}, nil)
@@ -388,10 +404,9 @@ func TestArrowFieldsToProto_Int16_via_Int32(t *testing.T) {
 	)
 	defer rec.Release()
 
-	schemas := []*schemapb.FieldSchema{
-		{FieldID: 110, Name: "val", DataType: schemapb.DataType_Int16},
-	}
-	result, err := ArrowFieldsToProto(rec, schemas)
+	result, err := ArrowFieldsToProto(rec, schemaMap(
+		&schemapb.FieldSchema{FieldID: 110, Name: "val", DataType: schemapb.DataType_Int16},
+	))
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, schemapb.DataType_Int16, result[0].GetType())
@@ -401,9 +416,10 @@ func TestArrowFieldsToProto_Int16_via_Int32(t *testing.T) {
 // TestArrowFieldsToProto_JSON verifies JSON fields from arrow.Binary columns.
 func TestArrowFieldsToProto_JSON(t *testing.T) {
 	pool := memory.NewGoAllocator()
-	rec := buildTestRecord(
+	rec := buildTestRecordWithFieldIDs(
 		pool,
 		[]arrow.Field{{Name: "meta", Type: arrow.BinaryTypes.Binary}},
+		[]int64{108},
 		func(bs []array.Builder) {
 			b := bs[0].(*array.BinaryBuilder)
 			b.Append([]byte(`{"a":1}`))
@@ -412,10 +428,9 @@ func TestArrowFieldsToProto_JSON(t *testing.T) {
 	)
 	defer rec.Release()
 
-	schemas := []*schemapb.FieldSchema{
-		{FieldID: 108, Name: "meta", DataType: schemapb.DataType_JSON},
-	}
-	result, err := ArrowFieldsToProto(rec, schemas)
+	result, err := ArrowFieldsToProto(rec, schemaMap(
+		&schemapb.FieldSchema{FieldID: 108, Name: "meta", DataType: schemapb.DataType_JSON},
+	))
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, "meta", result[0].GetFieldName())
@@ -432,9 +447,10 @@ func TestArrowFieldsToProto_JSON(t *testing.T) {
 // an error instead of silently producing an empty field.
 func TestArrowFieldsToProto_UnmappedDataType(t *testing.T) {
 	pool := memory.NewGoAllocator()
-	rec := buildTestRecord(
+	rec := buildTestRecordWithFieldIDs(
 		pool,
 		[]arrow.Field{{Name: "arr", Type: arrow.BinaryTypes.Binary}},
+		[]int64{111},
 		func(bs []array.Builder) {
 			b := bs[0].(*array.BinaryBuilder)
 			b.Append([]byte{1, 2, 3})
@@ -442,10 +458,9 @@ func TestArrowFieldsToProto_UnmappedDataType(t *testing.T) {
 	)
 	defer rec.Release()
 
-	schemas := []*schemapb.FieldSchema{
-		{FieldID: 111, Name: "arr", DataType: schemapb.DataType_None},
-	}
-	_, err := ArrowFieldsToProto(rec, schemas)
+	_, err := ArrowFieldsToProto(rec, schemaMap(
+		&schemapb.FieldSchema{FieldID: 111, Name: "arr", DataType: schemapb.DataType_None},
+	))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "arr")
 }
@@ -458,9 +473,10 @@ func TestArrowFieldsToProto_FloatVector_DimFallback(t *testing.T) {
 	pool := memory.NewGoAllocator()
 	dim := 4
 	bytesPerVec := dim * 4
-	rec := buildTestRecord(
+	rec := buildTestRecordWithFieldIDs(
 		pool,
 		[]arrow.Field{{Name: "vec", Type: &arrow.FixedSizeBinaryType{ByteWidth: bytesPerVec}}},
+		[]int64{109},
 		func(bs []array.Builder) {
 			b := bs[0].(*array.FixedSizeBinaryBuilder)
 			for i := 0; i < 2; i++ {
@@ -476,10 +492,9 @@ func TestArrowFieldsToProto_FloatVector_DimFallback(t *testing.T) {
 
 	// No TypeParams at all, so typeutil.GetDim fails and the fallback path
 	// (byteWidth / 4) must kick in.
-	schemas := []*schemapb.FieldSchema{
-		{FieldID: 109, Name: "vec", DataType: schemapb.DataType_FloatVector},
-	}
-	result, err := ArrowFieldsToProto(rec, schemas)
+	result, err := ArrowFieldsToProto(rec, schemaMap(
+		&schemapb.FieldSchema{FieldID: 109, Name: "vec", DataType: schemapb.DataType_FloatVector},
+	))
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, int64(dim), result[0].GetVectors().GetDim())
@@ -495,9 +510,10 @@ func TestArrowFieldsToProto_BinaryVector_DimFallback(t *testing.T) {
 	pool := memory.NewGoAllocator()
 	dim := 16
 	bytesPerVec := dim / 8
-	rec := buildTestRecord(
+	rec := buildTestRecordWithFieldIDs(
 		pool,
 		[]arrow.Field{{Name: "vec", Type: &arrow.FixedSizeBinaryType{ByteWidth: bytesPerVec}}},
+		[]int64{110},
 		func(bs []array.Builder) {
 			b := bs[0].(*array.FixedSizeBinaryBuilder)
 			b.Append([]byte{0xFF, 0x00})
@@ -506,10 +522,9 @@ func TestArrowFieldsToProto_BinaryVector_DimFallback(t *testing.T) {
 	)
 	defer rec.Release()
 
-	schemas := []*schemapb.FieldSchema{
-		{FieldID: 110, Name: "vec", DataType: schemapb.DataType_BinaryVector},
-	}
-	result, err := ArrowFieldsToProto(rec, schemas)
+	result, err := ArrowFieldsToProto(rec, schemaMap(
+		&schemapb.FieldSchema{FieldID: 110, Name: "vec", DataType: schemapb.DataType_BinaryVector},
+	))
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, int64(dim), result[0].GetVectors().GetDim())

--- a/internal/util/segcore/arrow_to_fielddata_test.go
+++ b/internal/util/segcore/arrow_to_fielddata_test.go
@@ -530,3 +530,60 @@ func TestArrowFieldsToProto_BinaryVector_DimFallback(t *testing.T) {
 	assert.Equal(t, int64(dim), result[0].GetVectors().GetDim())
 	assert.Equal(t, []byte{0xFF, 0x00, 0x0F, 0xF0}, result[0].GetVectors().GetBinaryVector())
 }
+
+// TestArrowFieldsToProto_StringOwnedAfterRelease verifies that converted
+// string data is owned by Go and remains valid after the Arrow record is
+// released. Before the fix, arr.Value() returned a zero-copy view into the
+// Arrow buffer, causing use-after-free once rec.Release() freed the C memory.
+func TestArrowFieldsToProto_StringOwnedAfterRelease(t *testing.T) {
+	pool := memory.NewGoAllocator()
+	rec := buildTestRecordWithFieldIDs(
+		pool,
+		[]arrow.Field{{Name: "name", Type: arrow.BinaryTypes.String}},
+		[]int64{200},
+		func(bs []array.Builder) {
+			b := bs[0].(*array.StringBuilder)
+			b.AppendValues([]string{"hello", "world", "zero-copy"}, nil)
+		},
+	)
+
+	result, err := ArrowFieldsToProto(rec, schemaMap(
+		&schemapb.FieldSchema{FieldID: 200, Name: "name", DataType: schemapb.DataType_VarChar},
+	))
+	assert.NoError(t, err)
+
+	// Release the Arrow record — this frees the underlying buffer.
+	rec.Release()
+
+	// The converted strings must still be valid because ArrowFieldsToProto
+	// clones them into Go-managed memory.
+	data := result[0].GetScalars().GetStringData().GetData()
+	assert.Equal(t, []string{"hello", "world", "zero-copy"}, data)
+}
+
+// TestArrowFieldsToProto_JSONOwnedAfterRelease verifies JSON byte slices are
+// owned copies, not views into the Arrow buffer.
+func TestArrowFieldsToProto_JSONOwnedAfterRelease(t *testing.T) {
+	pool := memory.NewGoAllocator()
+	rec := buildTestRecordWithFieldIDs(
+		pool,
+		[]arrow.Field{{Name: "meta", Type: arrow.BinaryTypes.Binary}},
+		[]int64{201},
+		func(bs []array.Builder) {
+			b := bs[0].(*array.BinaryBuilder)
+			b.Append([]byte(`{"key":"val"}`))
+			b.Append([]byte(`[1,2,3]`))
+		},
+	)
+
+	result, err := ArrowFieldsToProto(rec, schemaMap(
+		&schemapb.FieldSchema{FieldID: 201, Name: "meta", DataType: schemapb.DataType_JSON},
+	))
+	assert.NoError(t, err)
+
+	rec.Release()
+
+	data := result[0].GetScalars().GetJsonData().GetData()
+	assert.Equal(t, []byte(`{"key":"val"}`), data[0])
+	assert.Equal(t, []byte(`[1,2,3]`), data[1])
+}

--- a/internal/util/segcore/retrieve_result_arrow.go
+++ b/internal/util/segcore/retrieve_result_arrow.go
@@ -1,0 +1,135 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package segcore
+
+/*
+#cgo pkg-config: milvus_core
+
+#include <stdlib.h>
+#include <stdint.h>
+#include "common/arrow_c_data_c.h"
+#include "common/type_c.h"
+#include "segcore/segment_c.h"
+#include "segcore/plan_c.h"
+
+CStatus
+FillRetrieveFieldsOrdered(CSegmentInterface* segments,
+                          int64_t num_segments,
+                          CRetrievePlan c_plan,
+                          const int32_t* seg_indices,
+                          const int64_t* seg_offsets,
+                          int64_t total_rows,
+                          struct ArrowSchema* out_schema,
+                          struct ArrowArray* out_array,
+                          void* cancellation_source);
+*/
+import "C"
+
+import (
+	"context"
+	"runtime"
+	"unsafe"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/cdata"
+
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+// FillRetrieveFieldsOrdered reads output fields from multiple segments
+// and returns one Arrow RecordBatch in the specified row order.
+// The caller is responsible for releasing the returned record.
+func FillRetrieveFieldsOrdered(
+	ctx context.Context,
+	segments []CSegment,
+	plan *RetrievePlan,
+	segIndices []int32,
+	segOffsets []int64,
+) (arrow.Record, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if plan == nil || plan.cRetrievePlan == nil {
+		return nil, merr.WrapErrParameterInvalidMsg("nil retrieve plan")
+	}
+	if len(segments) == 0 {
+		return nil, merr.WrapErrParameterInvalidMsg("empty segments")
+	}
+	if len(segIndices) != len(segOffsets) {
+		return nil, merr.WrapErrParameterInvalidMsg(
+			"unaligned segment indices (%d) and offsets (%d)",
+			len(segIndices), len(segOffsets))
+	}
+
+	cSegments := make([]C.CSegmentInterface, len(segments))
+	for i, seg := range segments {
+		if seg == nil {
+			return nil, merr.WrapErrParameterInvalidMsg("nil segment at index %d", i)
+		}
+		cSegments[i] = C.CSegmentInterface(seg.RawPointer())
+	}
+
+	var segIndicesPtr *C.int32_t
+	var segOffsetsPtr *C.int64_t
+	if len(segIndices) > 0 {
+		segIndicesPtr = (*C.int32_t)(unsafe.Pointer(&segIndices[0]))
+		segOffsetsPtr = (*C.int64_t)(unsafe.Pointer(&segOffsets[0]))
+	}
+
+	var cSchema C.struct_ArrowSchema
+	var cArray C.struct_ArrowArray
+	guard := NewCancellationGuard(ctx)
+	defer guard.Close()
+	status := C.FillRetrieveFieldsOrdered(
+		&cSegments[0],
+		C.int64_t(len(cSegments)),
+		plan.cRetrievePlan,
+		segIndicesPtr,
+		segOffsetsPtr,
+		C.int64_t(len(segIndices)),
+		&cSchema,
+		&cArray,
+		guard.Source(),
+	)
+	runtime.KeepAlive(segIndices)
+	runtime.KeepAlive(segOffsets)
+	runtime.KeepAlive(cSegments)
+	runtime.KeepAlive(segments)
+	runtime.KeepAlive(plan)
+	if err := ConsumeCStatusIntoError(&status); err != nil {
+		C.MilvusGoArrowSchemaRelease(&cSchema)
+		C.MilvusGoArrowArrayRelease(&cArray)
+		return nil, err
+	}
+
+	schema, err := cdata.ImportCArrowSchema(
+		(*cdata.CArrowSchema)(unsafe.Pointer(&cSchema)))
+	C.MilvusGoArrowSchemaRelease(&cSchema)
+	if err != nil {
+		C.MilvusGoArrowArrayRelease(&cArray)
+		return nil, merr.WrapErrServiceInternal(
+			"failed to import Arrow schema", err.Error())
+	}
+	record, err := cdata.ImportCRecordBatchWithSchema(
+		(*cdata.CArrowArray)(unsafe.Pointer(&cArray)), schema)
+	if err != nil {
+		C.MilvusGoArrowArrayRelease(&cArray)
+		return nil, merr.WrapErrServiceInternal(
+			"failed to import Arrow RecordBatch", err.Error())
+	}
+	return record, nil
+}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -355,6 +355,8 @@ type commonConfig struct {
 	// Local RPC enabled for milvus internal communication when mix or standalone mode.
 	LocalRPCEnabled ParamItem `refreshable:"false"`
 
+	InterfaceZeroCopyEnabled ParamItem `refreshable:"true"`
+
 	PreferIPv6LocalIP ParamItem `refreshable:"false"`
 
 	SyncTaskPoolReleaseTimeoutSeconds ParamItem `refreshable:"true"`
@@ -1485,6 +1487,13 @@ The default matches the milvus-storage default.`,
 		Export:       true,
 	}
 	p.LocalRPCEnabled.Init(base.mgr)
+
+	p.InterfaceZeroCopyEnabled = ParamItem{
+		Key:          "common.interface.zeroCopy",
+		Version:      "2.6.14",
+		DefaultValue: "false",
+	}
+	p.InterfaceZeroCopyEnabled.Init(base.mgr)
 
 	p.PreferIPv6LocalIP = ParamItem{
 		Key:          "common.preferIPv6",


### PR DESCRIPTION
See #52935

Replace proto serialize/deserialize with Arrow C Data Interface
at the retrieve CGO boundary in the IgnoreNonPk pipeline.

C++ side: new FillRetrieveFieldsOrdered exports retrieve results
as Arrow RecordBatch via ExportRecordBatch, reusing the existing
bulk_subscript + MergeDataArray pipeline.

Go side: ArrowFieldsToProto converts Arrow columns back to proto
FieldData using bulk buffer copies for fixed-width types.

All field types supported: bool, int8/16/32/64, float, double,
varchar, JSON, all vector types (float/binary/float16/bfloat16/
sparse), and array.

Both Arrow and proto retrieve paths are preserved. A feature
gate common.interface.zeroCopy (default false, not exported)
switches between them. The proto path remains the default
until the Arrow path is fully validated, at which point
zeroCopy will default to true.