### PR TITLE
fix: gracefully complete clustering compaction when data is too small

### DIFF
--- a/internal/datacoord/compaction_task_clustering.go
+++ b/internal/datacoord/compaction_task_clustering.go
@@ -621,6 +621,12 @@ func (t *clusteringCompactionTask) processAnalyzing() error {
 	switch analyzeTask.State {
 	case indexpb.JobState_JobStateFinished:
 		if analyzeTask.GetCentroidsFile() == "" {
+			if analyzeTask.GetFailReason() == "data size too small to cluster" {
+				mlog.Info(context.TODO(), "skip clustering compaction, data too small",
+					mlog.Int64("planID", t.GetTaskProto().GetPlanID()),
+					mlog.Int64("analyzeID", t.GetTaskProto().GetAnalyzeTaskID()))
+				return t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_completed))
+			}
 			// not retryable, fake finished vector clustering is not supported in opensource
 			return merr.WrapErrClusteringCompactionNotSupportVector()
 		} else {
@@ -644,8 +650,15 @@ func (t *clusteringCompactionTask) doClean() error {
 		mlog.String("state", t.GetTaskProto().GetState().String()))
 
 	if t.GetTaskProto().GetState() == datapb.CompactionTaskState_completed {
-		if err := t.markInputSegmentsDropped(); err != nil {
-			return err
+		// Only drop the input segments when the compaction actually produced replacement result segments.
+		if len(t.GetTaskProto().GetResultSegments()) > 0 {
+			if err := t.markInputSegmentsDropped(); err != nil {
+				return err
+			}
+		} else {
+			mlog.Info(context.TODO(), "clustering compaction completed with no result segments, keep input segments",
+				mlog.Int64("planID", t.GetTaskProto().GetPlanID()),
+				mlog.Int64("triggerID", t.GetTaskProto().GetTriggerID()))
 		}
 	} else {
 		isInputDropped := false

--- a/internal/datacoord/compaction_task_clustering_test.go
+++ b/internal/datacoord/compaction_task_clustering_test.go
@@ -814,6 +814,27 @@ func (s *ClusteringCompactionTaskSuite) TestProcessAnalyzingState() {
 		s.Equal(datapb.CompactionTaskState_failed, task.GetTaskProto().GetState())
 	})
 
+	s.Run("analyze task finished but data too small, gracefully complete", func() {
+		task := s.generateBasicTask(false)
+		task.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_analyzing), setAnalyzeTaskID(7))
+		t := &indexpb.AnalyzeTask{
+			CollectionID: task.GetTaskProto().CollectionID,
+			PartitionID:  task.GetTaskProto().PartitionID,
+			FieldID:      task.GetTaskProto().ClusteringKeyField.FieldID,
+			SegmentIDs:   task.GetTaskProto().InputSegments,
+			TaskID:       7,
+			State:        indexpb.JobState_JobStateFinished,
+			// empty centroids file + the skip reason set by the analyze task when
+			// data is too small to cluster: must NOT be treated as "vector not
+			// support", but as a no-op that completes the compaction gracefully.
+			CentroidsFile: "",
+			FailReason:    "data size too small to cluster",
+		}
+		s.meta.analyzeMeta.AddAnalyzeTask(t)
+		s.True(task.Process())
+		s.Equal(datapb.CompactionTaskState_completed, task.GetTaskProto().GetState())
+	})
+
 	s.Run("analyze task finished", func() {
 		task := s.generateBasicTask(false)
 		task.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_analyzing), setAnalyzeTaskID(7))

--- a/internal/datacoord/task_analyze.go
+++ b/internal/datacoord/task_analyze.go
@@ -211,7 +211,7 @@ func (at *analyzeTask) CreateTaskOnWorker(nodeID int64, cluster session.Cluster)
 						mlog.Float64("raw data size", totalSegmentsRawDataSize),
 						mlog.Int64("num clusters", numClusters),
 						mlog.Int64("minimum num clusters required", Params.DataCoordCfg.ClusteringCompactionMinCentroidsNum.GetAsInt64()))
-					if err := at.UpdateStateWithMeta(indexpb.JobState_JobStateFinished, ""); err != nil {
+					if err := at.UpdateStateWithMeta(indexpb.JobState_JobStateFinished, "data size too small to cluster"); err != nil {
 						// State is left untouched, so the scheduler re-enqueues the task and retries.
 						log.Warn(context.TODO(), "failed to persist the finished state of the analyze task", mlog.Err(err))
 					}

--- a/internal/datacoord/task_analyze_test.go
+++ b/internal/datacoord/task_analyze_test.go
@@ -290,8 +290,15 @@ func (s *analyzeTaskSuite) TestCreateTaskOnWorker_DataTooSmall() {
 	at.CreateTaskOnWorker(1, session.NewMockCluster(s.T()))
 	// data too small → skip → mark as finished
 	s.Equal(indexpb.JobState_JobStateFinished, at.GetState())
-	// Persisting Finished is what lets the GC recycle the task's analyze stats files.
-	s.Equal(indexpb.JobState_JobStateFinished, s.mt.analyzeMeta.GetTask(s.taskID).GetState())
+	// ... and, crucially, the state must be persisted into analyzeMeta with the
+	// skip reason. The original bug used SetState (in-memory only), leaving the
+	// persisted task at Init so the parent clustering task could never observe
+	// completion and hung in `analyzing`. Assert the persisted reason here so a
+	// regression back to SetState is caught.
+	persisted := s.mt.analyzeMeta.GetTask(s.taskID)
+	s.Require().NotNil(persisted)
+	s.Equal(indexpb.JobState_JobStateFinished, persisted.GetState())
+	s.Equal("data size too small to cluster", persisted.GetFailReason())
 }
 
 func (s *analyzeTaskSuite) TestCreateTaskOnWorker_TerminalStateNotPersisted() {


### PR DESCRIPTION
Related to #52983

When an analyze task skips clustering because the data volume is below the
minimum centroid threshold, it finishes with an empty centroids file. The
parent clustering compaction task previously mistook this empty result for
"vector clustering not supported" and returned an unretryable error, driving
the whole compaction task into a permanent failed state.

Distinguish the two cases via the analyze task's FailReason:
  - persist "data size too small to cluster" into analyzeMeta (not just the
    in-memory task) when skipping, so the parent task can observe it;
  - in processAnalyzing, treat an empty centroids file carrying this reason
    as a no-op and complete the compaction gracefully instead of failing.

Also harden doClean to only drop the input segments when the compaction
actually produced result segments, avoiding data loss on no-op completions.