### PR TITLE
test: retry CDC topology restore in force-promote teardown

### DIFF
--- a/tests/python_client/cdc/conftest.py
+++ b/tests/python_client/cdc/conftest.py
@@ -12,6 +12,7 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(level
 logger = logging.getLogger(__name__)
 
 CDC_UPDATE_REPLICATE_TIMEOUT_SECONDS = 600
+CDC_SWITCHOVER_CONNECT_TIMEOUT_SECONDS = 180
 
 
 def apply_replicate_configuration(tasks, timeout=CDC_UPDATE_REPLICATE_TIMEOUT_SECONDS):
@@ -290,7 +291,7 @@ def switchover_helper(request, upstream_client, downstream_client):
         original_target: {"uri": downstream_uri, "token": downstream_token},
     }
 
-    def do_switchover(new_source_id, new_target_id):
+    def do_switchover(new_source_id, new_target_id, connect_timeout=CDC_SWITCHOVER_CONNECT_TIMEOUT_SECONDS):
         logger.info(f"Performing switchover: {new_source_id} -> {new_target_id}")
         config = {
             "clusters": [
@@ -315,13 +316,32 @@ def switchover_helper(request, upstream_client, downstream_client):
         # update_replicate_configuration RPC is in flight on the same
         # channel, the latter surfaces "Cannot invoke RPC on closed
         # channel!". Separate clients = separate channels = no race.
-        up_tmp = MilvusClient(uri=upstream_uri, token=upstream_token)
-        dn_tmp = MilvusClient(uri=downstream_uri, token=downstream_token)
-        try:
-            apply_replicate_configuration([(up_tmp, config), (dn_tmp, config)])
-        finally:
-            up_tmp.close()
-            dn_tmp.close()
+        #
+        # Retry while an attempt fails, until both clusters accept the RPC: a
+        # chaos test that just killed containers leaves a proxy that refuses
+        # connections (or drops RPCs) for a while after its Pod reports Ready,
+        # so a single attempt loses the race and leaves the topology unrestored
+        # for every later test. Any failure is retried; a deterministic error
+        # therefore surfaces only after the budget is spent.
+        deadline = time.time() + connect_timeout
+        attempt = 0
+        while True:
+            attempt += 1
+            up_tmp = dn_tmp = None
+            try:
+                up_tmp = MilvusClient(uri=upstream_uri, token=upstream_token)
+                dn_tmp = MilvusClient(uri=downstream_uri, token=downstream_token)
+                apply_replicate_configuration([(up_tmp, config), (dn_tmp, config)])
+                break
+            except Exception as e:
+                if time.time() >= deadline:
+                    raise
+                logger.warning(f"switchover attempt {attempt} failed, retrying in 5s: {e}")
+                time.sleep(5)
+            finally:
+                for client in (up_tmp, dn_tmp):
+                    if client is not None:
+                        client.close()
         logger.info("Switchover completed, waiting 10s for stabilization...")
         time.sleep(10)
 

--- a/tests/python_client/cdc/testcases/test_force_promote.py
+++ b/tests/python_client/cdc/testcases/test_force_promote.py
@@ -16,6 +16,7 @@ subsequent tests start from a known state.
 
 import os
 import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -274,16 +275,26 @@ class TestCDCForcePromote(TestCDCSyncBase):
             res = downstream_client.query(collection_name=c_after, filter="", output_fields=["count(*)"])
             assert res and res[0]["count(*)"] >= 100, f"downstream not writable after force_promote: count={res}"
         finally:
+            body_failed = sys.exc_info()[0] is not None
             logger.info("[TEARDOWN] Waiting for source pods before topology restore...")
-            kubectl_helper.wait_for_pods_ready(source_cluster_id, timeout=300)
+            try:
+                kubectl_helper.wait_for_pods_ready(source_cluster_id, timeout=300)
+            except Exception as e:
+                logger.error(f"pods not ready before restore, attempting restore anyway: {e}")
             self.cleanup_downstream_only_collection(c_after)
             logger.info("[TEARDOWN] Restoring A→B topology...")
+            restore_error = None
             try:
                 switchover_helper(source_cluster_id, target_cluster_id)
             except Exception as e:
-                logger.warning(f"switchover restore failed: {e}")
+                logger.error(f"switchover restore failed: {e}")
+                restore_error = e
             self.cleanup_resources()
-            self.log_test_end("test_force_promote_basic", True, time.time() - start_time)
+            self.log_test_end(
+                "test_force_promote_basic", restore_error is None and not body_failed, time.time() - start_time
+            )
+            if restore_error is not None and not body_failed:
+                raise restore_error
 
     def test_force_promote_during_target_restart(
         self,
@@ -407,20 +418,28 @@ class TestCDCForcePromote(TestCDCSyncBase):
             res = downstream_client.query(collection_name=c_after, filter="", output_fields=["count(*)"])
             assert res and res[0]["count(*)"] >= 100, f"downstream not writable after target restart: {res}"
         finally:
+            body_failed = sys.exc_info()[0] is not None
             logger.info("[TEARDOWN] Waiting for target pods before topology restore...")
-            kubectl_helper.wait_for_pods_ready(target_cluster_id, timeout=300)
+            try:
+                kubectl_helper.wait_for_pods_ready(target_cluster_id, timeout=300)
+            except Exception as e:
+                logger.error(f"pods not ready before restore, attempting restore anyway: {e}")
             self.cleanup_downstream_only_collection(c_after)
             logger.info("[TEARDOWN] Restoring A→B topology...")
+            restore_error = None
             try:
                 switchover_helper(source_cluster_id, target_cluster_id)
             except Exception as e:
-                logger.warning(f"switchover restore failed: {e}")
+                logger.error(f"switchover restore failed: {e}")
+                restore_error = e
             self.cleanup_resources()
             self.log_test_end(
                 "test_force_promote_during_target_restart",
-                True,
+                restore_error is None and not body_failed,
                 time.time() - start_time,
             )
+            if restore_error is not None and not body_failed:
+                raise restore_error
 
     def test_force_promote_during_source_restart(
         self,
@@ -540,20 +559,28 @@ class TestCDCForcePromote(TestCDCSyncBase):
             res = downstream_client.query(collection_name=c_after, filter="", output_fields=["count(*)"])
             assert res and res[0]["count(*)"] >= 100, f"downstream not writable after source restart: {res}"
         finally:
+            body_failed = sys.exc_info()[0] is not None
             logger.info("[TEARDOWN] Waiting for source pods before topology restore...")
-            kubectl_helper.wait_for_pods_ready(source_cluster_id, timeout=300)
+            try:
+                kubectl_helper.wait_for_pods_ready(source_cluster_id, timeout=300)
+            except Exception as e:
+                logger.error(f"pods not ready before restore, attempting restore anyway: {e}")
             self.cleanup_downstream_only_collection(c_after)
             logger.info("[TEARDOWN] Restoring A→B topology...")
+            restore_error = None
             try:
                 switchover_helper(source_cluster_id, target_cluster_id)
             except Exception as e:
-                logger.warning(f"switchover restore failed: {e}")
+                logger.error(f"switchover restore failed: {e}")
+                restore_error = e
             self.cleanup_resources()
             self.log_test_end(
                 "test_force_promote_during_source_restart",
-                True,
+                restore_error is None and not body_failed,
                 time.time() - start_time,
             )
+            if restore_error is not None and not body_failed:
+                raise restore_error
 
     def test_force_promote_with_incomplete_ddl(
         self,
@@ -655,18 +682,23 @@ class TestCDCForcePromote(TestCDCSyncBase):
             res = downstream_client.query(collection_name=c_after, filter="", output_fields=["count(*)"])
             assert res and res[0]["count(*)"] >= 100, f"downstream not writable after incomplete DDL: {res}"
         finally:
+            body_failed = sys.exc_info()[0] is not None
             self.cleanup_downstream_only_collection(c_after)
             logger.info("[TEARDOWN] Restoring A→B topology...")
+            restore_error = None
             try:
                 switchover_helper(source_cluster_id, target_cluster_id)
             except Exception as e:
-                logger.warning(f"switchover restore failed: {e}")
+                logger.error(f"switchover restore failed: {e}")
+                restore_error = e
             self.cleanup_resources()
             self.log_test_end(
                 "test_force_promote_with_incomplete_ddl",
-                True,
+                restore_error is None and not body_failed,
                 time.time() - start_time,
             )
+            if restore_error is not None and not body_failed:
+                raise restore_error
 
     def _build_partition_manifest(self, source_cluster_id, target_cluster_id, milvus_ns):
         """Return a NetworkChaos dict that bidirectionally partitions source ↔ target."""
@@ -808,6 +840,7 @@ class TestCDCForcePromote(TestCDCSyncBase):
             res = downstream_client.query(collection_name=c_after, filter="", output_fields=["count(*)"])
             assert res and res[0]["count(*)"] >= 100, f"downstream not writable after partition+promote: {res}"
         finally:
+            body_failed = sys.exc_info()[0] is not None
             # Remove the partition first so switchover can fan-out across clusters
             logger.info(f"[CHAOS] cleaning up NetworkChaos {chaos_name}")
             subprocess.run(
@@ -822,16 +855,20 @@ class TestCDCForcePromote(TestCDCSyncBase):
             time.sleep(10)
             self.cleanup_downstream_only_collection(c_after)
             logger.info("[TEARDOWN] Restoring A→B topology...")
+            restore_error = None
             try:
                 switchover_helper(source_cluster_id, target_cluster_id)
             except Exception as e:
-                logger.warning(f"switchover restore failed: {e}")
+                logger.error(f"switchover restore failed: {e}")
+                restore_error = e
             self.cleanup_resources()
             self.log_test_end(
                 "test_force_promote_with_network_partition",
-                True,
+                restore_error is None and not body_failed,
                 time.time() - start_time,
             )
+            if restore_error is not None and not body_failed:
+                raise restore_error
 
     def _do_one_endurance_iteration(
         self,
@@ -976,9 +1013,16 @@ class TestCDCForcePromote(TestCDCSyncBase):
                 )
             logger.info(f"PASSED endurance: {iteration} iterations in {duration_minutes}m")
         finally:
+            body_failed = sys.exc_info()[0] is not None
             logger.info("[TEARDOWN] Restoring A→B topology after endurance...")
+            restore_error = None
             try:
                 switchover_helper(source_cluster_id, target_cluster_id)
             except Exception as e:
-                logger.warning(f"switchover restore failed: {e}")
-            self.log_test_end("test_endurance_force_promote", True, time.time() - start_time)
+                logger.error(f"switchover restore failed: {e}")
+                restore_error = e
+            self.log_test_end(
+                "test_endurance_force_promote", restore_error is None and not body_failed, time.time() - start_time
+            )
+            if restore_error is not None and not body_failed:
+                raise restore_error


### PR DESCRIPTION
## Problem

The CDC force-promote failover tests kill containers with chaos-mesh and restore the A→B topology in teardown. `wait_for_pods_ready` returns as soon as the Pod reports Ready, but the proxy can still refuse connections for a few seconds after that, so the single-shot switchover loses the race — and the teardown swallowed the failure as a warning, letting the test pass with the topology left broken for every later test.

Observed in `milvus_cdc_failover_test` #55:

- `03:08:23` `wait pods mcf-s-55: rc=0` (pods reported Ready)
- `03:08:24` teardown starts restoring A→B
- `03:08:25` `Fail connecting to server on <upstream>:19530` → logged as a warning, test still PASSED
- next test then failed with `create collection ... sync failed after 30.11s timeout`, and its cleanup reported `cluster is not primary, cannot do any DDL/DCL`

One root cause, a misleading failure in a different test.

## Changes

**`tests/python_client/cdc/conftest.py`**
- `switchover_helper` retries for up to 180s while a cluster is still refusing connections, rebuilding and closing its clients on each attempt. This covers every caller, including `test_switchover.py`.

**`tests/python_client/cdc/testcases/test_force_promote.py`**
- The six teardowns record a restore failure, still run `cleanup_resources()`, then re-raise it instead of warning — a broken topology can no longer silently poison later tests.

## Test Plan

Injected connection failures into the shipped `do_switchover` path:

- [x] transient refusals (the #55 scenario): retries, restores the topology, sends the config once
- [x] cluster never recovers: raises after the deadline instead of continuing silently
- [x] healthy cluster: succeeds on the first attempt, both clients closed, behavior unchanged
- [x] `ruff check` with the repo's `tests/ruff.toml` passes

Not exercised against a live cluster; the retry window (180s) is a first estimate based on the ~1s gap seen in #55 plus headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)