### PR TITLE
enhance: query view observability

### DIFF
--- a/docs/design-docs/design_docs/qviews/observability/event-based-observability.md
+++ b/docs/design-docs/design_docs/qviews/observability/event-based-observability.md
@@ -1,0 +1,442 @@
+# QueryView Event-Based Observability
+
+## Package
+
+The QueryView event model is defined in:
+
+```text
+internal/views/qviews/observe
+```
+
+Package layout:
+
+```text
+internal/views/qviews/observe
+    event.go
+    observer.go
+```
+
+`observe` depends on `internal/views/qviews`, `pkg/v3/mlog`, and the standard library. Coord,
+QueryNode, and StreamingNode owner packages depend on `observe`.
+
+## Observer
+
+```go
+type Observer interface {
+    Observe(context.Context, Event)
+}
+
+type Registry struct {
+    mu        sync.RWMutex
+    observers []Observer
+}
+
+func NewRegistry(observers ...Observer) *Registry
+func (r *Registry) Register(observer Observer)
+func (r *Registry) Observe(ctx context.Context, event Event)
+
+func Register(observer Observer)
+func Observe(ctx context.Context, event Event)
+
+type LogObserver struct{}
+
+func (LogObserver) Observe(ctx context.Context, event Event) {
+    level := event.LogLevel()
+    if !mlog.LevelEnabled(level) {
+        return
+    }
+    mlog.Log(ctx, level, "query view event", FieldEvent(event))
+}
+```
+
+The package owns a global default registry initialized with `LogObserver`.
+Component code emits events through `observe.Observe(ctx, event)`. Additional
+observers, such as metrics observers, register through `observe.Register`.
+The registry snapshots its observer list before fanout so observer execution
+does not hold the registry lock.
+
+## Event Interface
+
+```go
+type Event interface {
+    mlog.ObjectMarshaler
+    TriggerInfo
+    ComponentInfo
+    LogLevel() mlog.Level
+    isQueryViewEvent()
+}
+
+type TriggerInfo interface {
+    TriggerInfo() string
+}
+
+type ComponentInfo interface {
+    ComponentInfo() string
+}
+
+type baseEvent struct{}
+
+func (baseEvent) isQueryViewEvent() {}
+
+func (baseEvent) TriggerInfo() string {
+    return ""
+}
+
+func (baseEvent) ComponentInfo() string {
+    return ""
+}
+
+func FieldEvent(event Event) mlog.Field {
+    return mlog.Inline(event)
+}
+```
+
+Every observable event is represented by one concrete Go type and embeds
+`baseEvent`. Consumers log events with `FieldEvent`, which returns an inline
+mlog field, and inspect events with type assertions or type switches. `LogLevel`
+is part of the event contract so log observers can check whether the target
+level is enabled before constructing the inline event field.
+
+`TriggerInfo` is the low-cardinality reason associated with the event. Events
+that do not represent a state-machine trigger return an empty string. Metrics
+observers consume this value directly and must not re-derive trigger labels from
+event type names.
+
+`ComponentInfo` is the low-cardinality owner component associated with the
+event. The current values are `coord`, `queryNode`, and `streamingNode`.
+Metrics observers consume this value directly and must not re-derive component
+labels from event type names.
+
+```go
+var _ Event = CoordViewQueryNodeLostAppliedEvent{}
+var _ Event = QueryNodeSegmentUnrecoverableEvent{}
+
+func Observe(ctx context.Context, event Event) {
+    switch e := event.(type) {
+    case CoordViewQueryNodeLostAppliedEvent:
+        _ = e.Node
+    case QueryNodeSegmentFailureEvent:
+        _ = e.Err
+    }
+}
+```
+
+## Cardinality
+
+Event type is split by cardinality. Each event payload carries the identity of
+the observed object. The supported cardinalities are `node`, `view`,
+`segment`, `view-segments`, `resource`, `persist`, and `sync-accepted`.
+
+## Shared Types
+
+```go
+type ViewStateTransition struct {
+    CollectionID int64
+    View         qviews.QueryViewKey
+    From         qviews.QueryViewState
+    To           qviews.QueryViewState
+}
+```
+
+Events that describe a QueryView state-machine transition embed
+`ViewStateTransition`. `CollectionID` is populated when the owner layer has the
+collection identity available. Metrics use it only in bounded TopN diagnostic
+series.
+
+## Events By Cardinality
+
+### Node
+
+Node events observe one worker node.
+
+#### Coord
+
+```go
+// CoordQueryNodeLostDetectedEvent is emitted when Coord sync code observes
+// QueryNode loss.
+type CoordQueryNodeLostDetectedEvent struct {
+    baseEvent
+    Node qviews.QueryNode
+}
+```
+
+### View
+
+View events observe one QueryView.
+
+#### Coord
+
+```go
+// CoordViewCreatedEvent is emitted after Coord creates a new Preparing view.
+type CoordViewCreatedEvent struct {
+    baseEvent
+    CollectionID int64
+    View         qviews.QueryViewKey
+    State        qviews.QueryViewState
+}
+
+// CoordViewPreemptedEvent is emitted after Coord preempts a Preparing or Ready
+// view while adding a new Preparing view.
+type CoordViewPreemptedEvent struct {
+    baseEvent
+    ViewStateTransition
+    PreemptingDataVersion qviews.DataVersion
+}
+
+// CoordViewAdvancedFromUnrecoverableEvent is emitted after Coord advances an
+// Unrecoverable view to Dropping.
+type CoordViewAdvancedFromUnrecoverableEvent struct {
+    baseEvent
+    ViewStateTransition
+}
+
+// CoordViewReleaseRequestedEvent is emitted after ShardViewManager applies
+// RequestRelease to a view.
+type CoordViewReleaseRequestedEvent struct {
+    baseEvent
+    ViewStateTransition
+}
+
+// CoordViewHandoffToNewUpEvent is emitted after ShardViewManager transitions
+// the previous Up view to Down because another view became Up.
+type CoordViewHandoffToNewUpEvent struct {
+    baseEvent
+    ViewStateTransition
+    NewUpView qviews.QueryViewKey
+}
+
+// CoordViewReportAppliedEvent is emitted after ShardViewManager applies a
+// work-node report to a view. ResourceReadyPercent is the report-side resource
+// preparation progress in [0, 100]. StreamingNode reports derive this value
+// from view state: resource-ready states report 100, other states report 0.
+type CoordViewReportAppliedEvent struct {
+    baseEvent
+    ViewStateTransition
+    Node                 qviews.WorkNode
+    ReportedState        qviews.QueryViewState
+    ResourceReadyPercent int64
+}
+
+// CoordViewQueryNodeLostAppliedEvent is emitted after ShardViewManager applies
+// QueryNode loss to a view.
+type CoordViewQueryNodeLostAppliedEvent struct {
+    baseEvent
+    ViewStateTransition
+    Node qviews.QueryNode
+}
+```
+
+#### QueryNode
+
+```go
+// QueryNodeApplyCoordViewEvent is emitted after QueryNode applies a Coord view
+// state.
+type QueryNodeApplyCoordViewEvent struct {
+    baseEvent
+    ViewStateTransition
+}
+
+// QueryNodeSegmentUnrecoverableEvent is emitted after the segment
+// unrecoverable callback moves a view to Unrecoverable.
+type QueryNodeSegmentUnrecoverableEvent struct {
+    baseEvent
+    ViewStateTransition
+    Err error
+}
+
+// QueryNodeReportViewEvent is emitted when QueryNode reports local view state.
+type QueryNodeReportViewEvent struct {
+    baseEvent
+    View  qviews.QueryViewKey
+    State qviews.QueryViewState
+}
+
+// QueryNodeReleaseDoneEvent is emitted after QueryNode observes release
+// completion for a view.
+type QueryNodeReleaseDoneEvent struct {
+    baseEvent
+    ViewStateTransition
+}
+```
+
+#### StreamingNode
+
+```go
+// StreamingNodeApplyCoordViewEvent is emitted after StreamingNode applies a
+// Coord view state.
+type StreamingNodeApplyCoordViewEvent struct {
+    baseEvent
+    ViewStateTransition
+}
+
+// StreamingNodeRecoveringDoneEvent is emitted after StreamingNode observes
+// recovery completion for a view.
+type StreamingNodeRecoveringDoneEvent struct {
+    baseEvent
+    ViewStateTransition
+}
+
+// StreamingNodeReportViewEvent is emitted when StreamingNode reports local view
+// state.
+type StreamingNodeReportViewEvent struct {
+    baseEvent
+    View  qviews.QueryViewKey
+    State qviews.QueryViewState
+}
+
+// StreamingNodeReleaseDoneEvent is emitted after StreamingNode observes release
+// completion for a view.
+type StreamingNodeReleaseDoneEvent struct {
+    baseEvent
+    ViewStateTransition
+}
+```
+
+### Segment
+
+Segment events observe one segment inside one QueryView.
+
+#### QueryNode
+
+```go
+// QueryNodeSegmentFailureEvent is emitted when physical segment load or
+// transform-log catch-up fails.
+type QueryNodeSegmentFailureEvent struct {
+    baseEvent
+    View      qviews.QueryViewKey
+    SegmentID int64
+    Err       error
+}
+```
+
+### View-Segments
+
+View-segments events observe one segment batch inside one QueryView.
+
+#### QueryNode
+
+```go
+// QueryNodeAcquireSegmentsEvent is emitted when QueryNode starts acquiring
+// segments for a new Preparing view.
+type QueryNodeAcquireSegmentsEvent struct {
+    baseEvent
+    View         qviews.QueryViewKey
+    SegmentCount int
+}
+
+// QueryNodeSegmentsReadyEvent is emitted after the segment readiness callback
+// moves a view forward.
+type QueryNodeSegmentsReadyEvent struct {
+    baseEvent
+    ViewStateTransition
+    ReadySegmentCount int
+}
+
+// QueryNodeReleaseSegmentsEvent is emitted when QueryNode starts releasing
+// segments for a view.
+type QueryNodeReleaseSegmentsEvent struct {
+    baseEvent
+    View qviews.QueryViewKey
+}
+```
+
+### Resource
+
+Resource events observe one StreamingNode resource for one QueryView.
+
+#### StreamingNode
+
+```go
+// StreamingNodeAcquireResourceEvent is emitted when StreamingNode starts
+// acquiring resources for a new Preparing view.
+type StreamingNodeAcquireResourceEvent struct {
+    baseEvent
+    View qviews.QueryViewKey
+}
+
+// StreamingNodeRecoverAcquireResourceEvent is emitted when StreamingNode starts
+// acquiring resources for a recovered Up view.
+type StreamingNodeRecoverAcquireResourceEvent struct {
+    baseEvent
+    View qviews.QueryViewKey
+}
+
+// StreamingNodeResourceReadyEvent is emitted after the resource ready callback
+// moves a view forward.
+type StreamingNodeResourceReadyEvent struct {
+    baseEvent
+    ViewStateTransition
+}
+
+// StreamingNodeReleaseResourceEvent is emitted when StreamingNode starts
+// releasing resources for a view.
+type StreamingNodeReleaseResourceEvent struct {
+    baseEvent
+    View qviews.QueryViewKey
+}
+```
+
+### Persist
+
+Persist events observe one persisted QueryView state write.
+
+#### Coord
+
+```go
+// CoordPersistViewEvent is emitted after DirtyViewFlushScheduler successfully
+// persists one QueryView state.
+type CoordPersistViewEvent struct {
+    baseEvent
+    View  qviews.QueryViewKey
+    State qviews.QueryViewState
+}
+```
+
+#### StreamingNode
+
+```go
+// StreamingNodePersistViewEvent is emitted when StreamingNode persists local
+// view state.
+type StreamingNodePersistViewEvent struct {
+    baseEvent
+    View  qviews.QueryViewKey
+    State qviews.QueryViewState
+}
+```
+
+### Sync-Accepted
+
+Sync-accepted events observe ReliableSyncer accepting one QueryView state for
+delivery to one worker node. Acceptance does not mean the worker has applied
+the state; worker application is observed through report events.
+
+#### Coord
+
+```go
+// CoordSyncViewAcceptedEvent is emitted after ReliableSyncer accepts one
+// QueryView state for delivery to a worker node. It does not mean the worker
+// has applied the state.
+type CoordSyncViewAcceptedEvent struct {
+    baseEvent
+    View  qviews.QueryViewKey
+    Node  qviews.WorkNode
+    State qviews.QueryViewState
+}
+```
+
+## Emission Semantics
+
+Event emission runs in the owner layer that observes the action.
+
+`ShardViewManager` observes state transitions and only creates dirty effects.
+`DirtyViewFlushScheduler` emits `CoordPersistViewEvent` after Catalog success
+and `CoordSyncViewAcceptedEvent` after ReliableSyncer accepts the per-node
+group. Shutdown cancellation errors do not produce failure events.
+
+Transition-carrying events are emitted in the same critical section that
+observes the state transition. `From` and `To` must match the owner-visible
+state before and after the state-machine input.
+
+Observer invocation is synchronous. Observer implementations must not block the
+owner workflow. Observer failures must not change QueryView state-machine,
+persistence, sync, or resource-release behavior.

--- a/docs/design-docs/design_docs/qviews/observability/metric-based-observability.md
+++ b/docs/design-docs/design_docs/qviews/observability/metric-based-observability.md
@@ -1,0 +1,556 @@
+# QueryView Metric-Based Observability
+
+## 1. Goal
+
+This document defines the first metric layer for QueryView observability.
+It builds on [QueryView Event-Based Observability](event-based-observability.md)
+and keeps the same owner-layer event boundary.
+
+The metric layer should answer the primary operational question:
+
+```text
+For a collection replica shard, why is there no stable Up QueryView?
+```
+
+The first iteration focuses on QueryCoord-side lifecycle diagnosis and the
+minimum worker-node progress signals needed to distinguish Coord, sync,
+QueryNode preparation, and StreamingNode preparation bottlenecks.
+
+## 2. Non-Goals
+
+This design does not change QueryView state-machine behavior. In particular,
+it does not introduce Preparing timeout eviction, new recovery policy, or
+Balancer policy changes.
+
+This design does not put high-cardinality identities into default aggregate
+metric labels. QueryView version, DataVersion, segment ID, and raw error
+message remain in structured event logs unless a metric is explicitly defined
+as a bounded TopK diagnostic metric. Metrics provide aggregation and alerting;
+logs and TopK diagnostics provide single-view investigation detail.
+
+## 3. Architecture
+
+The metric layer is implemented as an additional `observe.Observer`.
+
+```text
+Owner code
+  -> observe.Observe(ctx, event)
+      -> LogObserver
+      -> MetricsObserver
+```
+
+`MetricsObserver` consumes existing QueryView events with a type switch. It has
+two responsibilities:
+
+1. Increment event-derived counters and histograms directly.
+2. Maintain a small in-memory state cache for gauges that need current state or
+   elapsed time.
+
+Transition trigger labels come from `Event.TriggerInfo()`. Component labels
+come from `Event.ComponentInfo()`. Metrics code must not maintain its own
+event-type-to-label mapping for these fields.
+
+Observer invocation is synchronous. `MetricsObserver` must not perform IO,
+query external state, or block owner workflows. It may take short mutexes for
+in-memory updates and update Prometheus metrics.
+
+## 4. Metric Classes
+
+### 4.1 Event Metrics
+
+Event metrics are derived from one event at a time and do not need historical
+state.
+
+Examples:
+
+- State transition counters.
+- Unrecoverable counters.
+- Sync failure counters.
+- Segment preparation result counters.
+- StreamingNode resource preparation result counters.
+
+### 4.2 State Metrics
+
+State metrics need owner-visible state accumulated across events.
+
+Examples:
+
+- Current QueryView count by state.
+- Shard count without an Up QueryView.
+- Preparing age.
+- Reported worker resource readiness.
+- Pending sync count.
+
+These metrics are maintained by `MetricsObserver` state tables keyed by
+QueryView and shard identities. Those keys may be high cardinality internally,
+but metrics exported from these tables must be aggregated at cluster level
+unless a bounded TopK or debug-only metric is explicitly introduced.
+
+## 5. Label Policy
+
+Allowed default labels:
+
+| Label | Usage |
+|---|---|
+| `component` | QueryView event owner component: `coord`, `queryNode`, or `streamingNode`. |
+| `state` | QueryView state. |
+| `from_state` | State transition source. |
+| `to_state` | State transition target. |
+| `trigger` | Low-cardinality state-machine trigger. |
+| `le` | Prometheus-compatible cumulative bucket upper bound. |
+| `reason` | Low-cardinality failure or no-Up reason. |
+| `node_role` | `querynode` or `streamingnode`. |
+| `node_id` | Allowed for worker-specific sync and readiness metrics. |
+| `status` | Low-cardinality worker-side operation result. |
+| `rank` | Allowed only for bounded TopK diagnostic metrics. |
+| `collection_id` | Allowed only for bounded TopK diagnostic metrics. |
+| `replica_id` | Allowed only for bounded TopK diagnostic metrics. |
+| `vchannel` | Allowed only for bounded TopK diagnostic metrics. |
+| `query_view_version` | Allowed only for bounded TopK diagnostic metrics. |
+| `data_version` | Allowed only for bounded TopK diagnostic metrics. |
+
+Disallowed default labels:
+
+| Value | Reason |
+|---|---|
+| QueryView version | High cardinality; use logs. |
+| DataVersion | High cardinality; use logs. |
+| Segment ID | High cardinality; use logs. |
+| Raw error string | Unbounded cardinality; classify into `reason`. |
+| Collection ID | High cardinality for large clusters; use logs, diagnostic APIs, or bounded TopK metrics. |
+| Replica ID | Multiplies collection cardinality; use logs, diagnostic APIs, or bounded TopK metrics. |
+| VChannel name | High cardinality for default dashboards; use only in targeted debug metrics. |
+
+## 6. First-Iteration Metrics
+
+### 6.1 `milvus_qv_view_states`
+
+Type: Gauge
+
+Description: Current number of active QueryViews by state.
+
+Labels:
+
+```text
+component, state
+```
+
+Derived from:
+
+- `CoordViewCreatedEvent`
+- `CoordViewReportAppliedEvent`
+- `CoordViewPreemptedEvent`
+- `CoordViewAdvancedFromUnrecoverableEvent`
+- `CoordViewReleaseRequestedEvent`
+- `CoordViewHandoffToNewUpEvent`
+- `CoordViewQueryNodeLostAppliedEvent`
+- `QueryNodeSegmentsReadyEvent`
+- `QueryNodeSegmentUnrecoverableEvent`
+- `QueryNodeReleaseDoneEvent`
+- `StreamingNodeResourceReadyEvent`
+- `StreamingNodeRecoveringDoneEvent`
+- `StreamingNodeReleaseDoneEvent`
+
+State handling:
+
+- Add a view entry when a component creates or observes a tracked view.
+- Move the view entry when a component-visible transition event is observed.
+- Keep state cache entries keyed by `(component, QueryViewKey)` so Coord,
+  QueryNode, and StreamingNode observations do not overwrite each other.
+- Delete the Coord view entry after Coord observes terminal Dropped cleanup. Existing
+  `CoordViewReportAppliedEvent` and `CoordPersistViewEvent` can expose the
+  Dropped transition and persistence path; if implementation cannot uniquely
+  identify removal from those events, add a dedicated Coord view cleanup event
+  instead of guessing from logs.
+
+### 6.2 `milvus_qv_shard_load_states`
+
+Type: Gauge
+
+Description: Number of Coord-visible desired shards by shard load lifecycle
+state.
+
+Labels:
+
+```text
+state
+```
+
+State set:
+
+| State | Meaning |
+|---|---|
+| `loading` | The shard is desired and has active non-release QueryViews, but has not reached Up in the current load lifecycle. |
+| `loaded` | At least one active Coord view for the shard is Up. |
+| `recovering` | The shard reached Up before, has no current Up view, and still has active non-release QueryViews. |
+
+Implementation note:
+
+The metric is maintained only by the Coord observer because worker nodes cannot
+see the full shard-level Up state. The observer maintains a per-shard Coord
+summary on state mutation paths and does not scan all views during scrape.
+
+Release/unload is not represented as a load state. QueryViews in `Down`,
+`Dropping`, or `Dropped` are excluded from this shard load lifecycle metric. If
+all active non-release views for a shard leave the lifecycle, the shard metric
+row is removed. A later LoadCollection starts a new lifecycle and is classified
+as `loading`.
+
+`recovering` is inferred from observed shard history: if the shard has reached
+`loaded` in the current lifecycle and later has no Up view while non-release
+views still exist, it is counted as `recovering`. This covers NodeLost-driven
+recovery without requiring metrics code to derive labels from event names.
+
+### 6.3 `milvus_qv_view_state_max_age_seconds`
+
+Type: Gauge
+
+Description: Per-component TopK active QueryViews by state age in seconds. The
+metric is a bounded diagnostic metric, not a full per-view export. The default
+TopK is 5 rows for each component.
+
+Labels:
+
+```text
+component, state, rank, collection_id, replica_id, vchannel, query_view_version, data_version
+```
+
+Derived from:
+
+- State entry time recorded on `CoordViewCreatedEvent` and state transition
+  events.
+- High-cardinality identity fields carried by the event, not re-derived by the
+  metric observer.
+
+Export behavior:
+
+The observer stores the state entry time and maintains an oldest-first heap for
+each component as events arrive. Collect-time export reads only each
+component's TopK valid heap candidates, computes `now - entered_at` for output,
+and assigns `rank` within that component. It does not scan or sort the full
+QueryView state table on scrape.
+
+Heap candidates use lazy deletion, but compaction does not depend on Prometheus
+scrapes. The observer tracks the valid max-age candidate count for each
+component. State updates and deletions trigger a low-frequency heap rebuild when
+stale candidates grow much larger than that component's valid candidate count;
+if no valid candidate remains, the component heap is removed. Collect-time export
+still skips stale heap roots defensively before returning TopK rows.
+
+`Up` state is intentionally skipped. A long-lived Up view is the healthy steady
+state, so exporting its age adds churn without helping stuck-view diagnosis.
+
+Operational use:
+
+This is the primary diagnostic metric for stuck Preparing, Ready,
+Unrecoverable, Dropping, or Down states. A stuck Preparing view can block new
+DataVersion views and delay StreamingNode growing-resource release. Alerts
+should normally aggregate by metric value and then use the TopK labels to jump
+directly to the affected collection, replica, shard, and QueryView version.
+Per-component TopK prevents one noisy component from hiding stuck views in
+another component.
+
+### 6.4 `milvus_qv_view_transition_total`
+
+Type: Counter
+
+Description: Count of QueryView state transitions by owning component.
+
+Labels:
+
+```text
+component, from_state, to_state, trigger
+```
+
+Trigger values are provided by the corresponding event's `TriggerInfo()`:
+
+| Event | Trigger |
+|---|---|
+| `CoordViewReportAppliedEvent` with Ready report | `reportReady` |
+| `CoordViewReportAppliedEvent` with Unrecoverable report | `reportUnrecoverable` |
+| `CoordViewPreemptedEvent` | `preempt` |
+| `CoordViewHandoffToNewUpEvent` | `handoff` |
+| `CoordViewReleaseRequestedEvent` | `release` |
+| `CoordViewAdvancedFromUnrecoverableEvent` | `advanceUnrecoverable` |
+| `CoordViewQueryNodeLostAppliedEvent` | `queryNodeLost` |
+| `QueryNodeSegmentsReadyEvent` | `queryNodeSegmentsReady` |
+| `QueryNodeSegmentUnrecoverableEvent` | `reportUnrecoverable` |
+| `QueryNodeReleaseDoneEvent` | `queryNodeReleaseDone` |
+| `StreamingNodeResourceReadyEvent` | `streamingResourceReady` |
+| `StreamingNodeRecoveringDoneEvent` | `streamingRecoveringDone` |
+| `StreamingNodeReleaseDoneEvent` | `streamingReleaseDone` |
+
+### 6.5 `milvus_qv_unrecoverable_total`
+
+Type: Counter
+
+Description: Count of QueryViews that enter Unrecoverable state.
+
+Labels:
+
+```text
+component, reason
+```
+
+Initial reason set:
+
+| Component | Reason |
+|---|---|
+| `queryNode` | `segment_prepare_failed` |
+| `streamingNode` | `resource_prepare_failed` |
+| `coord` | `preempt` |
+| `coord` | `queryNodeLost` |
+| `coord` | `unknown` |
+
+`MetricsObserver` should classify only reasons available from the event type
+and stable fields. Raw error strings must not become label values.
+
+### 6.6 `milvus_qv_view_ready_percent_bucket`
+
+Type: Gauge
+
+Description: Current number of Coord-visible non-Up QueryViews by
+worker-reported resource readiness percent cumulative bucket.
+
+Labels:
+
+```text
+component, state, le
+```
+
+Derived from:
+
+- `CoordViewReportAppliedEvent.ResourceReadyPercent`
+
+Bucket values:
+
+```text
+0, 25, 50, 75, 90, 99, 100, +Inf
+```
+
+The observer maintains this metric as current state, not as an event histogram.
+Buckets are cumulative and use the Prometheus `le` label so PromQL helpers such
+as `histogram_quantile` can be used on the current distribution. Coord view
+creation enters the `0` bucket because a view without any report has no known
+resource readiness progress. A Coord report moves the view from its old
+`(state, le)` cumulative rows to the reported bucket's cumulative rows.
+Non-report Coord state transitions preserve the last known `le` value while the
+view remains non-Up. `Up` and `Dropped` states are removed from this metric.
+
+For QueryNode reports, the percent represents segment preparation progress. For
+StreamingNode reports, it is currently state-derived: resource-ready states
+report 100 and other states report 0. The metric is exported from the Coord
+observer because Coord owns the merged worker report view.
+
+### 6.7 `milvus_qv_sync_pending`
+
+Type: Gauge
+
+Description: Number of QueryView sync entries awaiting worker response.
+
+Labels:
+
+```text
+node_role, node_id, state
+```
+
+Status:
+
+This metric requires additional syncer events for exact accounting.
+`CoordSyncViewAcceptedEvent` identifies when ReliableSyncer accepts an entry,
+but does not identify when that entry is matched and removed.
+
+Required additional events:
+
+```go
+type CoordSyncViewPendingAddedEvent struct {
+    baseEvent
+    View  qviews.QueryViewKey
+    Node  qviews.WorkNode
+    State qviews.QueryViewState
+}
+
+type CoordSyncViewPendingDoneEvent struct {
+    baseEvent
+    View  qviews.QueryViewKey
+    Node  qviews.WorkNode
+    State qviews.QueryViewState
+}
+```
+
+The first metric implementation should leave this metric out unless these
+events are added in the same change.
+
+## 7. Worker-Side Metrics
+
+Worker-side metrics are useful, but they are lower priority than Coord-side
+lifecycle metrics because the first diagnostic path starts at QueryCoord.
+
+### 7.1 `milvus_querynode_qv_segment_prepare_total`
+
+Type: Counter
+
+Description: QueryNode segment preparation result count for QueryViews.
+
+Labels:
+
+```text
+node_id, status, reason
+```
+
+Status values:
+
+```text
+started, ready, failed, released
+```
+
+Reason values:
+
+```text
+none, metadata_failed, segment_load_failed, transform_register_failed,
+transform_catchup_failed, release_race, unknown
+```
+
+Derived from:
+
+- `QueryNodeAcquireSegmentsEvent`
+- `QueryNodeSegmentsReadyEvent`
+- `QueryNodeSegmentFailureEvent`
+- `QueryNodeReleaseSegmentsEvent`
+
+### 7.2 `milvus_streamingnode_qv_resource_prepare_total`
+
+Type: Counter
+
+Description: StreamingNode QueryView resource preparation result count.
+
+Labels:
+
+```text
+node_id, status, reason
+```
+
+Status values:
+
+```text
+started, ready, recovered, released, failed
+```
+
+Reason values:
+
+```text
+none, runtime_failed, data_version_expired, unknown
+```
+
+Derived from:
+
+- `StreamingNodeAcquireResourceEvent`
+- `StreamingNodeRecoverAcquireResourceEvent`
+- `StreamingNodeResourceReadyEvent`
+- `StreamingNodeRecoveringDoneEvent`
+- `StreamingNodeReleaseResourceEvent`
+
+## 8. MetricsObserver State Model
+
+`MetricsObserver` keeps state only for gauges that cannot be updated from a
+single event.
+
+```go
+type MetricsObserver struct {
+    mu sync.Mutex
+
+    views  map[qviews.QueryViewKey]*viewMetricState
+    shards map[qviews.ShardID]*shardMetricState
+}
+
+type viewMetricState struct {
+    state        qviews.QueryViewState
+    preparingAt time.Time
+    lastReason   string
+}
+
+type shardMetricState struct {
+    upView        qviews.QueryViewKey
+    activeByState map[qviews.QueryViewState]int
+    noUpReason    string
+}
+```
+
+The state cache is not a source of truth for QueryView behavior. It is a best
+effort projection of owner-emitted events for metrics. Losing this cache on
+process restart is acceptable because gauges rebuild as new events arrive and
+because persistent QueryView recovery should re-emit Coord-visible state.
+
+## 9. Registration
+
+QueryView metrics should be registered with the existing Prometheus metric
+registry under the shared `qv` subsystem:
+
+- QueryView lifecycle and sync metrics use `Subsystem: "qv"`.
+- QueryNode segment preparation metrics use `Subsystem: "qv"`.
+- StreamingNode resource preparation metrics use `Subsystem: "qv"`.
+
+The default `observe` registry may include only `LogObserver` at package init
+time. Component initialization should register a `MetricsObserver` after the
+metrics package is initialized, avoiding package import cycles between
+`internal/views/qviews/observe` and `pkg/metrics`.
+
+## 10. Cleanup
+
+Metric cleanup must follow collection release and view terminal cleanup.
+
+Required cleanup behavior:
+
+- Delete internal QueryCoord view and shard state when a collection is fully
+  released or a view reaches terminal cleanup.
+- Delete QueryNode worker labels when collection-local QueryView segment state
+  is released.
+- Delete StreamingNode worker labels when local QueryView resources are
+  released.
+
+Counters are not deleted.
+
+## 11. Alerting Guidance
+
+Recommended first alerts:
+
+| Alert | Expression intent |
+|---|---|
+| Stuck non-Up view | `max(milvus_qv_view_state_max_age_seconds) > threshold` |
+| Shard not loaded | `milvus_qv_shard_load_states{state!="loaded"} > 0` for a sustained window |
+| Unrecoverable spike | Rate of `milvus_qv_unrecoverable_total` exceeds baseline |
+
+Thresholds should be derived from expected segment load time and QueryView
+preparation SLA. The metric design intentionally exposes state and bounded age
+diagnostics so alerts can be tuned without changing code.
+
+## 12. Implementation Order
+
+1. Add QueryCoord event-derived counters:
+   `view_transition_total` and `unrecoverable_total`.
+2. Add QueryCoord state cache gauges:
+   `view_states`, `view_state_max_age_seconds`, and
+   `view_ready_percent_bucket`.
+3. Add `shard_load_states` with states derivable from current Coord view
+   history.
+4. Add worker-side counters for QueryNode segment preparation and
+   StreamingNode resource preparation.
+5. Add sync pending events and then implement `sync_pending`.
+
+This order keeps the first change useful without requiring new event contracts.
+
+## 13. Tests
+
+Unit tests should cover:
+
+- Each event type updates the expected counter labels.
+- State transition events move `view_state` gauges without double counting.
+- Preparing age starts on Preparing creation and stops when the view leaves the
+  blocking state.
+- `shard_load_states` changes when the active shard load lifecycle state changes.
+- Raw error text is never used as a metric label.
+- `MetricsObserver.Observe` does not panic on unknown or partially populated
+  events.
+
+Tests should use the existing Prometheus test registry pattern from
+`pkg/metrics` and avoid global metric pollution where possible.

--- a/internal/querynodev2/qnview/handler.go
+++ b/internal/querynodev2/qnview/handler.go
@@ -1,6 +1,7 @@
 package qnview
 
 import (
+	"context"
 	"sync"
 
 	"github.com/milvus-io/milvus/internal/views/qviews"
@@ -51,14 +52,16 @@ var _ handler.QueryViewHandler = (*QNQueryViewHandler)(nil)
 //   - Dropped, SM in Dropped: responds immediately with Dropped re-report.
 //     (In practice unreachable — entry is deleted upon reaching Dropped.)
 type QNQueryViewHandler struct {
+	ctx    context.Context
 	mu     sync.Mutex
 	shards map[qviews.ShardID]*qnShardView
 	segMgr SegmentManager
 }
 
 // NewQNQueryViewHandler creates a new QNQueryViewHandler.
-func NewQNQueryViewHandler(segMgr SegmentManager) *QNQueryViewHandler {
+func NewQNQueryViewHandler(ctx context.Context, segMgr SegmentManager) *QNQueryViewHandler {
 	return &QNQueryViewHandler{
+		ctx:    ctx,
 		shards: make(map[qviews.ShardID]*qnShardView),
 		segMgr: segMgr,
 	}
@@ -92,6 +95,7 @@ func (h *QNQueryViewHandler) getOrCreateShard(shardID qviews.ShardID) *qnShardVi
 	shard, ok := h.shards[shardID]
 	if !ok {
 		shard = &qnShardView{
+			ctx:    h.ctx,
 			views:  make(map[qviews.QueryViewVersion]*qnViewEntry),
 			segMgr: h.segMgr,
 			onEmpty: func(emptyShard *qnShardView) {

--- a/internal/querynodev2/qnview/handler_test.go
+++ b/internal/querynodev2/qnview/handler_test.go
@@ -1,6 +1,7 @@
 package qnview
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -151,7 +152,7 @@ func (c *reportCollector) count() int {
 
 func TestQNHandler_ApplyViews_NewPreparing(t *testing.T) {
 	mgr := newMockSegmentManager()
-	h := NewQNQueryViewHandler(mgr)
+	h := NewQNQueryViewHandler(context.Background(), mgr)
 
 	rc := &reportCollector{}
 	view := newPreparingQNView(1, 1)
@@ -174,7 +175,7 @@ func TestQNHandler_ApplyViews_NewPreparing(t *testing.T) {
 
 func TestQNHandler_ApplyViews_UnknownViewReportsUnrecoverable(t *testing.T) {
 	mgr := newMockSegmentManager()
-	h := NewQNQueryViewHandler(mgr)
+	h := NewQNQueryViewHandler(context.Background(), mgr)
 
 	// Non-Preparing, non-Dropped state for unknown view → Unrecoverable.
 	meta := buildHandlerTestMeta(1)
@@ -193,7 +194,7 @@ func TestQNHandler_ApplyViews_UnknownViewReportsUnrecoverable(t *testing.T) {
 
 func TestQNHandler_ApplyViews_DroppedOnUnknownViewReportsBack(t *testing.T) {
 	mgr := newMockSegmentManager()
-	h := NewQNQueryViewHandler(mgr)
+	h := NewQNQueryViewHandler(context.Background(), mgr)
 
 	// Coord pushes Dropped for a view QN doesn't know (e.g., after restart).
 	// QN must report Dropped back so Coord can finish cleanup.
@@ -213,7 +214,7 @@ func TestQNHandler_ApplyViews_DroppedOnUnknownViewReportsBack(t *testing.T) {
 
 func TestQNHandler_SegmentManagerCallback_TransitionToReady(t *testing.T) {
 	mgr := newMockSegmentManager()
-	h := NewQNQueryViewHandler(mgr)
+	h := NewQNQueryViewHandler(context.Background(), mgr)
 
 	rc := &reportCollector{}
 	view := newPreparingQNView(1, 1)
@@ -236,7 +237,7 @@ func TestQNHandler_SegmentManagerCallback_TransitionToReady(t *testing.T) {
 
 func TestQNHandler_SegmentManagerCallback_IncrementalProgress(t *testing.T) {
 	mgr := newMockSegmentManager()
-	h := NewQNQueryViewHandler(mgr)
+	h := NewQNQueryViewHandler(context.Background(), mgr)
 
 	rc := &reportCollector{}
 	view := newPreparingQNView(1, 1)
@@ -263,7 +264,7 @@ func TestQNHandler_SegmentManagerCallback_IncrementalProgress(t *testing.T) {
 
 func TestQNHandler_SegmentManagerCallback_StaleCallbackIgnored(t *testing.T) {
 	mgr := newMockSegmentManager()
-	h := NewQNQueryViewHandler(mgr)
+	h := NewQNQueryViewHandler(context.Background(), mgr)
 
 	rc := &reportCollector{}
 	view := newPreparingQNView(1, 1)
@@ -295,7 +296,7 @@ func TestQNHandler_SegmentManagerCallback_StaleCallbackIgnored(t *testing.T) {
 
 func TestQNHandler_SegmentManagerCallback_Unrecoverable(t *testing.T) {
 	mgr := newMockSegmentManager()
-	h := NewQNQueryViewHandler(mgr)
+	h := NewQNQueryViewHandler(context.Background(), mgr)
 
 	rc := &reportCollector{}
 	view := newPreparingQNView(1, 1)
@@ -318,7 +319,7 @@ func TestQNHandler_SegmentManagerCallback_Unrecoverable(t *testing.T) {
 
 func TestQNHandler_ApplyViews_CoordDropped(t *testing.T) {
 	mgr := newMockSegmentManager()
-	h := NewQNQueryViewHandler(mgr)
+	h := NewQNQueryViewHandler(context.Background(), mgr)
 
 	rc := &reportCollector{}
 	view := newPreparingQNView(1, 1)
@@ -346,7 +347,7 @@ func TestQNHandler_ApplyViews_CoordDropped(t *testing.T) {
 
 func TestQNHandler_ApplyViews_CoordDroppedWhileDropping(t *testing.T) {
 	mgr := newMockSegmentManager()
-	h := NewQNQueryViewHandler(mgr)
+	h := NewQNQueryViewHandler(context.Background(), mgr)
 
 	rc := &reportCollector{}
 	view := newPreparingQNView(1, 1)
@@ -377,7 +378,7 @@ func TestQNHandler_ApplyViews_CoordDroppedWhileDropping(t *testing.T) {
 
 func TestQNHandler_ApplyRetriesAfterShardDetached(t *testing.T) {
 	mgr := newMockSegmentManager()
-	h := NewQNQueryViewHandler(mgr)
+	h := NewQNQueryViewHandler(context.Background(), mgr)
 	first := newPreparingQNView(1, 1)
 	firstKey := first.QueryViewKey()
 	h.ApplyViews([]handler.ApplyView{{View: first}})
@@ -421,7 +422,7 @@ func TestQNHandler_ApplyRetriesAfterShardDetached(t *testing.T) {
 
 func TestQNHandler_ApplyViews_CallbackReplacement(t *testing.T) {
 	mgr := newMockSegmentManager()
-	h := NewQNQueryViewHandler(mgr)
+	h := NewQNQueryViewHandler(context.Background(), mgr)
 
 	rc1 := &reportCollector{}
 	view := newPreparingQNView(1, 1)
@@ -454,7 +455,7 @@ func TestQNHandler_ApplyViews_CallbackReplacement(t *testing.T) {
 
 func TestQNHandler_MultipleShards(t *testing.T) {
 	mgr := newMockSegmentManager()
-	h := NewQNQueryViewHandler(mgr)
+	h := NewQNQueryViewHandler(context.Background(), mgr)
 
 	// Shard 1: replica 1, vchannel v0_c0
 	meta1 := buildHandlerTestMeta(1)
@@ -493,7 +494,7 @@ func TestQNHandler_MultipleShards(t *testing.T) {
 
 func TestQNHandler_MultipleVersions(t *testing.T) {
 	mgr := newMockSegmentManager()
-	h := NewQNQueryViewHandler(mgr)
+	h := NewQNQueryViewHandler(context.Background(), mgr)
 
 	view1 := newPreparingQNView(1, 1)
 	view2 := newPreparingQNView(1, 2)
@@ -523,7 +524,7 @@ func TestQNHandler_MultipleVersions(t *testing.T) {
 
 func TestQNHandler_ConcurrentApplyAndCallback(t *testing.T) {
 	mgr := newMockSegmentManager()
-	h := NewQNQueryViewHandler(mgr)
+	h := NewQNQueryViewHandler(context.Background(), mgr)
 
 	const numViews = 20
 	var wg sync.WaitGroup
@@ -566,7 +567,7 @@ func TestQNHandler_ConcurrentApplyAndCallback(t *testing.T) {
 
 func TestQNHandler_FullLifecycle(t *testing.T) {
 	mgr := newMockSegmentManager()
-	h := NewQNQueryViewHandler(mgr)
+	h := NewQNQueryViewHandler(context.Background(), mgr)
 
 	rc := &reportCollector{}
 	view := newPreparingQNView(1, 1)

--- a/internal/querynodev2/qnview/shard_view.go
+++ b/internal/querynodev2/qnview/shard_view.go
@@ -1,11 +1,13 @@
 package qnview
 
 import (
+	"context"
 	"sync"
 
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus/internal/views/qviews"
+	qvobserve "github.com/milvus-io/milvus/internal/views/qviews/observe"
 	"github.com/milvus-io/milvus/internal/views/worknode/handler"
 	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
 )
@@ -68,6 +70,10 @@ func (s *qnShardView) applyOneLocked(av *handler.ApplyView) {
 			)
 			entry = &qnViewEntry{ApplyView: *av, sm: sm}
 			s.views[key.QueryViewVersion] = entry
+			qvobserve.Observe(context.TODO(), qvobserve.QueryNodeAcquireSegmentsEvent{
+				View:         key,
+				SegmentCount: countViewSegments(qnView.ViewOfQueryNode()),
+			})
 
 			// Tell SegmentManager to load segments. Callbacks will drive SM progress.
 			meta := qnView.IntoProto().Meta
@@ -102,7 +108,16 @@ func (s *qnShardView) applyOneLocked(av *handler.ApplyView) {
 
 	// Existing view: replace callback and deliver coord push.
 	entry.ApplyView = *av
+	before := entry.sm.State()
 	entry.sm.OnCoordStateDelivered(pushedState)
+	qvobserve.Observe(context.TODO(), qvobserve.QueryNodeApplyCoordViewEvent{
+		ViewStateTransition: qvobserve.ViewStateTransition{
+			CollectionID: entry.sm.Meta().GetCollectionId(),
+			View:         key,
+			From:         before,
+			To:           entry.sm.State(),
+		},
+	})
 	s.consumeReportAndCleanup(key, entry)
 }
 
@@ -117,8 +132,19 @@ func (s *qnShardView) notifySegmentsReady(version qviews.QueryViewVersion, ready
 		return
 	}
 
+	key := entry.View.QueryViewKey()
+	before := entry.sm.State()
 	entry.sm.OnSegmentsReady(readySegments)
-	s.consumeReportAndCleanup(entry.View.QueryViewKey(), entry)
+	qvobserve.Observe(context.TODO(), qvobserve.QueryNodeSegmentsReadyEvent{
+		ViewStateTransition: qvobserve.ViewStateTransition{
+			CollectionID: entry.sm.Meta().GetCollectionId(),
+			View:         key,
+			From:         before,
+			To:           entry.sm.State(),
+		},
+		ReadySegmentCount: countReadySegments(readySegments),
+	})
+	s.consumeReportAndCleanup(key, entry)
 }
 
 // notifyUnrecoverable is called by SegmentManager callback when a fatal error
@@ -132,8 +158,18 @@ func (s *qnShardView) notifyUnrecoverable(version qviews.QueryViewVersion) {
 		return
 	}
 
+	key := entry.View.QueryViewKey()
+	before := entry.sm.State()
 	entry.sm.OnUnrecoverable()
-	s.consumeReportAndCleanup(entry.View.QueryViewKey(), entry)
+	qvobserve.Observe(context.TODO(), qvobserve.QueryNodeSegmentUnrecoverableEvent{
+		ViewStateTransition: qvobserve.ViewStateTransition{
+			CollectionID: entry.sm.Meta().GetCollectionId(),
+			View:         key,
+			From:         before,
+			To:           entry.sm.State(),
+		},
+	})
+	s.consumeReportAndCleanup(key, entry)
 }
 
 // notifyDropped is called by the SegmentManager Release callback when segment
@@ -147,8 +183,18 @@ func (s *qnShardView) notifyDropped(version qviews.QueryViewVersion) {
 		return
 	}
 
+	key := entry.View.QueryViewKey()
+	before := entry.sm.State()
 	entry.sm.OnDropped()
-	s.consumeReportAndCleanup(entry.View.QueryViewKey(), entry)
+	qvobserve.Observe(context.TODO(), qvobserve.QueryNodeReleaseDoneEvent{
+		ViewStateTransition: qvobserve.ViewStateTransition{
+			CollectionID: entry.sm.Meta().GetCollectionId(),
+			View:         key,
+			From:         before,
+			To:           entry.sm.State(),
+		},
+	})
+	s.consumeReportAndCleanup(key, entry)
 }
 
 // consumeReportAndCleanup drains pending report and release, invokes callbacks,
@@ -157,9 +203,16 @@ func (s *qnShardView) notifyDropped(version qviews.QueryViewVersion) {
 func (s *qnShardView) consumeReportAndCleanup(key qviews.QueryViewKey, entry *qnViewEntry) {
 	report := entry.sm.ConsumeReport()
 	if report != nil && entry.OnReport != nil {
+		qvobserve.Observe(context.TODO(), qvobserve.QueryNodeReportViewEvent{
+			View:  key,
+			State: qviews.QueryViewState(report.GetMeta().GetState()),
+		})
 		entry.OnReport(qviews.NewQueryViewAtWorkNodeFromProto(report))
 	}
 	if entry.sm.ConsumeRelease() {
+		qvobserve.Observe(context.TODO(), qvobserve.QueryNodeReleaseSegmentsEvent{
+			View: key,
+		})
 		s.segMgr.Release(ReleaseSegments{
 			Key: key,
 			OnDropped: func() {
@@ -174,4 +227,20 @@ func (s *qnShardView) consumeReportAndCleanup(key qviews.QueryViewKey, entry *qn
 			s.onEmpty(s)
 		}
 	}
+}
+
+func countReadySegments(readySegments map[int64][]int64) int {
+	total := 0
+	for _, segmentIDs := range readySegments {
+		total += len(segmentIDs)
+	}
+	return total
+}
+
+func countViewSegments(view *viewpb.QueryViewOfQueryNode) int {
+	total := 0
+	for _, partition := range view.GetPartitions() {
+		total += len(partition.GetSegmentIds())
+	}
+	return total
 }

--- a/internal/querynodev2/qnview/shard_view.go
+++ b/internal/querynodev2/qnview/shard_view.go
@@ -15,6 +15,7 @@ import (
 // qnShardView manages all query view state machines for a single shard on a QueryNode.
 // All public methods are concurrent-safe via the internal mutex.
 type qnShardView struct {
+	ctx      context.Context
 	mu       sync.Mutex
 	views    map[qviews.QueryViewVersion]*qnViewEntry
 	segMgr   SegmentManager
@@ -70,7 +71,8 @@ func (s *qnShardView) applyOneLocked(av *handler.ApplyView) {
 			)
 			entry = &qnViewEntry{ApplyView: *av, sm: sm}
 			s.views[key.QueryViewVersion] = entry
-			qvobserve.Observe(context.TODO(), qvobserve.QueryNodeAcquireSegmentsEvent{
+			qvobserve.Observe(s.ctx, qvobserve.QueryNodeAcquireSegmentsEvent{
+				CollectionID: sm.Meta().GetCollectionId(),
 				View:         key,
 				SegmentCount: countViewSegments(qnView.ViewOfQueryNode()),
 			})
@@ -110,7 +112,7 @@ func (s *qnShardView) applyOneLocked(av *handler.ApplyView) {
 	entry.ApplyView = *av
 	before := entry.sm.State()
 	entry.sm.OnCoordStateDelivered(pushedState)
-	qvobserve.Observe(context.TODO(), qvobserve.QueryNodeApplyCoordViewEvent{
+	qvobserve.Observe(s.ctx, qvobserve.QueryNodeApplyCoordViewEvent{
 		ViewStateTransition: qvobserve.ViewStateTransition{
 			CollectionID: entry.sm.Meta().GetCollectionId(),
 			View:         key,
@@ -135,7 +137,7 @@ func (s *qnShardView) notifySegmentsReady(version qviews.QueryViewVersion, ready
 	key := entry.View.QueryViewKey()
 	before := entry.sm.State()
 	entry.sm.OnSegmentsReady(readySegments)
-	qvobserve.Observe(context.TODO(), qvobserve.QueryNodeSegmentsReadyEvent{
+	qvobserve.Observe(s.ctx, qvobserve.QueryNodeSegmentsReadyEvent{
 		ViewStateTransition: qvobserve.ViewStateTransition{
 			CollectionID: entry.sm.Meta().GetCollectionId(),
 			View:         key,
@@ -161,7 +163,7 @@ func (s *qnShardView) notifyUnrecoverable(version qviews.QueryViewVersion) {
 	key := entry.View.QueryViewKey()
 	before := entry.sm.State()
 	entry.sm.OnUnrecoverable()
-	qvobserve.Observe(context.TODO(), qvobserve.QueryNodeSegmentUnrecoverableEvent{
+	qvobserve.Observe(s.ctx, qvobserve.QueryNodeSegmentUnrecoverableEvent{
 		ViewStateTransition: qvobserve.ViewStateTransition{
 			CollectionID: entry.sm.Meta().GetCollectionId(),
 			View:         key,
@@ -186,7 +188,7 @@ func (s *qnShardView) notifyDropped(version qviews.QueryViewVersion) {
 	key := entry.View.QueryViewKey()
 	before := entry.sm.State()
 	entry.sm.OnDropped()
-	qvobserve.Observe(context.TODO(), qvobserve.QueryNodeReleaseDoneEvent{
+	qvobserve.Observe(s.ctx, qvobserve.QueryNodeReleaseDoneEvent{
 		ViewStateTransition: qvobserve.ViewStateTransition{
 			CollectionID: entry.sm.Meta().GetCollectionId(),
 			View:         key,
@@ -203,14 +205,14 @@ func (s *qnShardView) notifyDropped(version qviews.QueryViewVersion) {
 func (s *qnShardView) consumeReportAndCleanup(key qviews.QueryViewKey, entry *qnViewEntry) {
 	report := entry.sm.ConsumeReport()
 	if report != nil && entry.OnReport != nil {
-		qvobserve.Observe(context.TODO(), qvobserve.QueryNodeReportViewEvent{
+		qvobserve.Observe(s.ctx, qvobserve.QueryNodeReportViewEvent{
 			View:  key,
 			State: qviews.QueryViewState(report.GetMeta().GetState()),
 		})
 		entry.OnReport(qviews.NewQueryViewAtWorkNodeFromProto(report))
 	}
 	if entry.sm.ConsumeRelease() {
-		qvobserve.Observe(context.TODO(), qvobserve.QueryNodeReleaseSegmentsEvent{
+		qvobserve.Observe(s.ctx, qvobserve.QueryNodeReleaseSegmentsEvent{
 			View: key,
 		})
 		s.segMgr.Release(ReleaseSegments{

--- a/internal/streamingnode/server/wal/snview/shard_view.go
+++ b/internal/streamingnode/server/wal/snview/shard_view.go
@@ -101,7 +101,8 @@ func (s *snShardView) startRecovery() {
 		entry := s.views[version]
 		v := version // capture loop variable
 		qvobserve.Observe(s.ctx, qvobserve.StreamingNodeRecoverAcquireResourceEvent{
-			View: key,
+			CollectionID: s.collectionID,
+			View:         key,
 		})
 		s.resMgr.Acquire(AcquireResource{
 			Key:  key,
@@ -175,7 +176,8 @@ func (s *snShardView) applyOneLocked(av *handler.ApplyView) {
 			entry = &snViewEntry{ApplyView: *av, sm: sm}
 			s.views[key.QueryViewVersion] = entry
 			qvobserve.Observe(s.ctx, qvobserve.StreamingNodeAcquireResourceEvent{
-				View: key,
+				CollectionID: s.collectionID,
+				View:         key,
 			})
 			// SN SM constructor generates a Preparing report.
 			s.consumeReport(entry)
@@ -220,7 +222,7 @@ func (s *snShardView) applyOneLocked(av *handler.ApplyView) {
 	entry.sm.OnCoordStateDelivered(pushedState)
 	qvobserve.Observe(s.ctx, qvobserve.StreamingNodeApplyCoordViewEvent{
 		ViewStateTransition: qvobserve.ViewStateTransition{
-			CollectionID: entry.View.IntoProto().GetMeta().GetCollectionId(),
+			CollectionID: s.collectionID,
 			View:         key,
 			From:         before,
 			To:           entry.sm.State(),
@@ -255,7 +257,7 @@ func (s *snShardView) notifyReady(version qviews.QueryViewVersion) {
 	entry.sm.OnReady()
 	qvobserve.Observe(s.ctx, qvobserve.StreamingNodeResourceReadyEvent{
 		ViewStateTransition: qvobserve.ViewStateTransition{
-			CollectionID: entry.View.IntoProto().GetMeta().GetCollectionId(),
+			CollectionID: s.collectionID,
 			View:         entry.View.QueryViewKey(),
 			From:         before,
 			To:           entry.sm.State(),
@@ -293,7 +295,7 @@ func (s *snShardView) notifyRecoveringDone(version qviews.QueryViewVersion) {
 	entry.sm.OnRecoveringDone()
 	qvobserve.Observe(s.ctx, qvobserve.StreamingNodeRecoveringDoneEvent{
 		ViewStateTransition: qvobserve.ViewStateTransition{
-			CollectionID: entry.View.IntoProto().GetMeta().GetCollectionId(),
+			CollectionID: s.collectionID,
 			View:         entry.View.QueryViewKey(),
 			From:         before,
 			To:           entry.sm.State(),
@@ -330,7 +332,7 @@ func (s *snShardView) notifyDropped(version qviews.QueryViewVersion) {
 	entry.sm.OnDropped()
 	qvobserve.Observe(s.ctx, qvobserve.StreamingNodeReleaseDoneEvent{
 		ViewStateTransition: qvobserve.ViewStateTransition{
-			CollectionID: entry.View.IntoProto().GetMeta().GetCollectionId(),
+			CollectionID: s.collectionID,
 			View:         entry.View.QueryViewKey(),
 			From:         before,
 			To:           entry.sm.State(),

--- a/internal/streamingnode/server/wal/snview/shard_view.go
+++ b/internal/streamingnode/server/wal/snview/shard_view.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/milvus-io/milvus/internal/metastore"
 	"github.com/milvus-io/milvus/internal/views/qviews"
+	qvobserve "github.com/milvus-io/milvus/internal/views/qviews/observe"
 	"github.com/milvus-io/milvus/internal/views/worknode/handler"
 	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
@@ -99,6 +100,9 @@ func (s *snShardView) startRecovery() {
 		key := qviews.QueryViewKey{ShardID: s.shardID, QueryViewVersion: version}
 		entry := s.views[version]
 		v := version // capture loop variable
+		qvobserve.Observe(s.ctx, qvobserve.StreamingNodeRecoverAcquireResourceEvent{
+			View: key,
+		})
 		s.resMgr.Acquire(AcquireResource{
 			Key:  key,
 			Meta: entry.sm.Meta(),
@@ -170,6 +174,9 @@ func (s *snShardView) applyOneLocked(av *handler.ApplyView) {
 			sm := newSNQueryViewStateMachine(pb.Meta, pb.StreamingNode, pb.QueryNode)
 			entry = &snViewEntry{ApplyView: *av, sm: sm}
 			s.views[key.QueryViewVersion] = entry
+			qvobserve.Observe(s.ctx, qvobserve.StreamingNodeAcquireResourceEvent{
+				View: key,
+			})
 			// SN SM constructor generates a Preparing report.
 			s.consumeReport(entry)
 
@@ -209,7 +216,16 @@ func (s *snShardView) applyOneLocked(av *handler.ApplyView) {
 	// Existing view: replace callback and deliver coord push.
 	entry.ApplyView = *av
 	entry.sm.UpdateView(av.View.IntoProto())
+	before := entry.sm.State()
 	entry.sm.OnCoordStateDelivered(pushedState)
+	qvobserve.Observe(s.ctx, qvobserve.StreamingNodeApplyCoordViewEvent{
+		ViewStateTransition: qvobserve.ViewStateTransition{
+			CollectionID: entry.View.IntoProto().GetMeta().GetCollectionId(),
+			View:         key,
+			From:         before,
+			To:           entry.sm.State(),
+		},
+	})
 	s.consumeReportPersistAndCleanup(key.QueryViewVersion, entry)
 }
 
@@ -235,7 +251,16 @@ func (s *snShardView) notifyReady(version qviews.QueryViewVersion) {
 		return
 	}
 
+	before := entry.sm.State()
 	entry.sm.OnReady()
+	qvobserve.Observe(s.ctx, qvobserve.StreamingNodeResourceReadyEvent{
+		ViewStateTransition: qvobserve.ViewStateTransition{
+			CollectionID: entry.View.IntoProto().GetMeta().GetCollectionId(),
+			View:         entry.View.QueryViewKey(),
+			From:         before,
+			To:           entry.sm.State(),
+		},
+	})
 	s.consumeReportPersistAndCleanup(version, entry)
 }
 
@@ -264,7 +289,16 @@ func (s *snShardView) notifyRecoveringDone(version qviews.QueryViewVersion) {
 		return
 	}
 
+	before := entry.sm.State()
 	entry.sm.OnRecoveringDone()
+	qvobserve.Observe(s.ctx, qvobserve.StreamingNodeRecoveringDoneEvent{
+		ViewStateTransition: qvobserve.ViewStateTransition{
+			CollectionID: entry.View.IntoProto().GetMeta().GetCollectionId(),
+			View:         entry.View.QueryViewKey(),
+			From:         before,
+			To:           entry.sm.State(),
+		},
+	})
 	s.consumeReportPersistAndCleanup(version, entry)
 }
 
@@ -273,6 +307,10 @@ func (s *snShardView) notifyRecoveringDone(version qviews.QueryViewVersion) {
 func (s *snShardView) consumeReport(entry *snViewEntry) {
 	report := entry.sm.ConsumeReport()
 	if report != nil && entry.OnReport != nil {
+		qvobserve.Observe(s.ctx, qvobserve.StreamingNodeReportViewEvent{
+			View:  entry.View.QueryViewKey(),
+			State: qviews.QueryViewState(report.GetMeta().GetState()),
+		})
 		entry.OnReport(qviews.NewQueryViewAtWorkNodeFromProto(report))
 	}
 }
@@ -288,7 +326,16 @@ func (s *snShardView) notifyDropped(version qviews.QueryViewVersion) {
 		return
 	}
 
+	before := entry.sm.State()
 	entry.sm.OnDropped()
+	qvobserve.Observe(s.ctx, qvobserve.StreamingNodeReleaseDoneEvent{
+		ViewStateTransition: qvobserve.ViewStateTransition{
+			CollectionID: entry.View.IntoProto().GetMeta().GetCollectionId(),
+			View:         entry.View.QueryViewKey(),
+			From:         before,
+			To:           entry.sm.State(),
+		},
+	})
 	s.consumeReportPersistAndCleanup(version, entry)
 }
 
@@ -328,6 +375,10 @@ func (s *snShardView) consumeAndPersist(entry *snViewEntry) bool {
 	if persist == nil {
 		return true
 	}
+	qvobserve.Observe(s.ctx, qvobserve.StreamingNodePersistViewEvent{
+		View:  entry.View.QueryViewKey(),
+		State: qviews.QueryViewState(persist.GetMeta().GetState()),
+	})
 	if err := s.catalog.SaveQueryViews(s.ctx, s.pchannel, []*viewpb.QueryViewOfShard{persist}); err != nil {
 		if s.ctx.Err() != nil {
 			return false

--- a/internal/views/coord/coordview/dirty_view_flush_scheduler.go
+++ b/internal/views/coord/coordview/dirty_view_flush_scheduler.go
@@ -368,17 +368,22 @@ func (s *DirtyViewFlushScheduler) flushBatch(
 		callback()
 	}
 	if len(viewsByNode) > 0 {
-		if err := s.syncer.SyncViews(ctx, syncer.SyncGroup{ViewsByNode: viewsByNode}); err != nil {
-			return err
-		}
-	}
-	for _, views := range viewsByNode {
-		for _, view := range views {
-			qvobserve.Observe(ctx, qvobserve.CoordSyncViewAcceptedEvent{
-				View:  view.View.QueryViewKey(),
-				Node:  view.View.WorkNode(),
-				State: view.View.State(),
-			})
+		// Enqueue per node so that views accepted before a mid-batch failure
+		// still get their acceptance event; a single grouped call would drop
+		// the events for every node when the last one fails.
+		for nodeKey, views := range viewsByNode {
+			if err := s.syncer.SyncViews(ctx, syncer.SyncGroup{
+				ViewsByNode: map[qviews.WorkNodeKey][]syncer.SyncView{nodeKey: views},
+			}); err != nil {
+				return err
+			}
+			for _, view := range views {
+				qvobserve.Observe(ctx, qvobserve.CoordSyncViewAcceptedEvent{
+					View:  view.View.QueryViewKey(),
+					Node:  view.View.WorkNode(),
+					State: view.View.State(),
+				})
+			}
 		}
 	}
 	return nil

--- a/internal/views/coord/coordview/dirty_view_flush_scheduler.go
+++ b/internal/views/coord/coordview/dirty_view_flush_scheduler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/milvus-io/milvus/internal/metastore/kv/queryview"
 	"github.com/milvus-io/milvus/internal/views/coord/coordview/syncer"
 	"github.com/milvus-io/milvus/internal/views/qviews"
+	qvobserve "github.com/milvus-io/milvus/internal/views/qviews/observe"
 	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/nodescheduler"
 )
@@ -356,6 +357,12 @@ func (s *DirtyViewFlushScheduler) flushBatch(
 		if err := s.persistViews(ctx, persists); err != nil {
 			return err
 		}
+		for _, view := range persists {
+			qvobserve.Observe(ctx, qvobserve.CoordPersistViewEvent{
+				View:  queryViewKeyFromProto(view),
+				State: qviews.QueryViewState(view.GetMeta().GetState()),
+			})
+		}
 	}
 	for _, callback := range afterPersist {
 		callback()
@@ -363,6 +370,15 @@ func (s *DirtyViewFlushScheduler) flushBatch(
 	if len(viewsByNode) > 0 {
 		if err := s.syncer.SyncViews(ctx, syncer.SyncGroup{ViewsByNode: viewsByNode}); err != nil {
 			return err
+		}
+	}
+	for _, views := range viewsByNode {
+		for _, view := range views {
+			qvobserve.Observe(ctx, qvobserve.CoordSyncViewAcceptedEvent{
+				View:  view.View.QueryViewKey(),
+				Node:  view.View.WorkNode(),
+				State: view.View.State(),
+			})
 		}
 	}
 	return nil

--- a/internal/views/coord/coordview/shard_view_manager.go
+++ b/internal/views/coord/coordview/shard_view_manager.go
@@ -526,9 +526,8 @@ func (m *ShardViewManager) makeOnSyncResponse(version qviews.QueryViewVersion, t
 				From:         before,
 				To:           sm.State(),
 			},
-			Node:                 target.WorkNode(),
-			ReportedState:        resp.State(),
-			ResourceReadyPercent: resourceReadyPercent(resp),
+			Node:          target.WorkNode(),
+			ReportedState: resp.State(),
 		})
 		m.processStateMachine(sm)
 		event := m.consumeDirtyEventLocked()
@@ -539,18 +538,6 @@ func (m *ShardViewManager) makeOnSyncResponse(version qviews.QueryViewVersion, t
 		m.submitDirtyEvent(event)
 		m.mu.Unlock()
 		return completed
-	}
-}
-
-func resourceReadyPercent(report qviews.QueryViewAtWorkNode) int64 {
-	if _, ok := report.WorkNode().(qviews.StreamingNode); !ok {
-		return 0
-	}
-	switch report.State() {
-	case qviews.QueryViewStateReady, qviews.QueryViewStateUp, qviews.QueryViewStateDown, qviews.QueryViewStateDropped:
-		return 100
-	default:
-		return 0
 	}
 }
 

--- a/internal/views/coord/coordview/shard_view_manager.go
+++ b/internal/views/coord/coordview/shard_view_manager.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/milvus-io/milvus/internal/views/coord/coordview/syncer"
 	"github.com/milvus-io/milvus/internal/views/qviews"
+	qvobserve "github.com/milvus-io/milvus/internal/views/qviews/observe"
 	"github.com/milvus-io/milvus/pkg/v3/proto/viewpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
@@ -261,7 +262,17 @@ func (m *ShardViewManager) AddPreparing(_ context.Context, builder *qviews.Query
 
 	// Preempt existing Preparing/Ready view.
 	if m.preparingView != nil {
+		before := m.preparingView.State()
 		m.preparingView.EnterUnrecoverable()
+		qvobserve.Observe(m.ctx, qvobserve.CoordViewPreemptedEvent{
+			ViewStateTransition: qvobserve.ViewStateTransition{
+				CollectionID: m.preparingView.View().GetMeta().GetCollectionId(),
+				View:         qviews.QueryViewKey{ShardID: m.shardID, QueryViewVersion: m.preparingView.Version()},
+				From:         before,
+				To:           m.preparingView.State(),
+			},
+			PreemptingDataVersion: newDV,
+		})
 		m.processStateMachine(m.preparingView)
 		// preparingView is cleared by processStateMachine (Unrecoverable case).
 	}
@@ -279,6 +290,11 @@ func (m *ShardViewManager) AddPreparing(_ context.Context, builder *qviews.Query
 	sm := NewCoordQueryViewStateMachine(view)
 	m.views[sm.Version()] = sm
 	m.preparingView = sm
+	qvobserve.Observe(m.ctx, qvobserve.CoordViewCreatedEvent{
+		CollectionID: sm.View().GetMeta().GetCollectionId(),
+		View:         qviews.QueryViewKey{ShardID: m.shardID, QueryViewVersion: sm.Version()},
+		State:        sm.State(),
+	})
 
 	// Process: collect persist and sync effects.
 	m.processStateMachine(sm)
@@ -305,13 +321,31 @@ func (m *ShardViewManager) RequestRelease(_ context.Context) error {
 	m.releaseRequested = true
 
 	if m.preparingView != nil {
+		before := m.preparingView.State()
 		m.preparingView.EnterUnrecoverable()
+		qvobserve.Observe(m.ctx, qvobserve.CoordViewReleaseRequestedEvent{
+			ViewStateTransition: qvobserve.ViewStateTransition{
+				CollectionID: m.preparingView.View().GetMeta().GetCollectionId(),
+				View:         qviews.QueryViewKey{ShardID: m.shardID, QueryViewVersion: m.preparingView.Version()},
+				From:         before,
+				To:           m.preparingView.State(),
+			},
+		})
 		m.processStateMachine(m.preparingView)
 		// preparingView is cleared by processStateMachine (Unrecoverable case).
 	}
 
 	if m.upView != nil {
+		before := m.upView.State()
 		m.upView.EnterDown()
+		qvobserve.Observe(m.ctx, qvobserve.CoordViewReleaseRequestedEvent{
+			ViewStateTransition: qvobserve.ViewStateTransition{
+				CollectionID: m.upView.View().GetMeta().GetCollectionId(),
+				View:         qviews.QueryViewKey{ShardID: m.shardID, QueryViewVersion: m.upView.Version()},
+				From:         before,
+				To:           m.upView.State(),
+			},
+		})
 		m.processStateMachine(m.upView)
 		// processStateMachine's Down case clears m.upView.
 	}
@@ -399,7 +433,16 @@ func (m *ShardViewManager) processStateMachine(sm *CoordQueryViewStateMachine) {
 func (m *ShardViewManager) advanceUnrecoverableToDropping() {
 	for _, sm := range m.views {
 		if sm.State() == qviews.QueryViewStateUnrecoverable {
+			before := sm.State()
 			sm.EnterDropping()
+			qvobserve.Observe(m.ctx, qvobserve.CoordViewAdvancedFromUnrecoverableEvent{
+				ViewStateTransition: qvobserve.ViewStateTransition{
+					CollectionID: sm.View().GetMeta().GetCollectionId(),
+					View:         qviews.QueryViewKey{ShardID: m.shardID, QueryViewVersion: sm.Version()},
+					From:         before,
+					To:           sm.State(),
+				},
+			})
 			m.processStateMachine(sm)
 		}
 	}
@@ -410,7 +453,17 @@ func (m *ShardViewManager) advanceUnrecoverableToDropping() {
 // Must be called under m.mu.
 func (m *ShardViewManager) downOlderUpView(newUp *CoordQueryViewStateMachine) {
 	if m.upView != nil && m.upView != newUp {
+		before := m.upView.State()
 		m.upView.EnterDown()
+		qvobserve.Observe(m.ctx, qvobserve.CoordViewHandoffToNewUpEvent{
+			ViewStateTransition: qvobserve.ViewStateTransition{
+				CollectionID: m.upView.View().GetMeta().GetCollectionId(),
+				View:         qviews.QueryViewKey{ShardID: m.shardID, QueryViewVersion: m.upView.Version()},
+				From:         before,
+				To:           m.upView.State(),
+			},
+			NewUpView: qviews.QueryViewKey{ShardID: m.shardID, QueryViewVersion: newUp.Version()},
+		})
 		m.processStateMachine(m.upView)
 		// processStateMachine's Down case clears m.upView.
 	}
@@ -464,7 +517,19 @@ func (m *ShardViewManager) makeOnSyncResponse(version qviews.QueryViewVersion, t
 			return true // view already removed, stop tracking
 		}
 
+		before := sm.State()
 		sm.OnNodeStateReported(resp)
+		qvobserve.Observe(m.ctx, qvobserve.CoordViewReportAppliedEvent{
+			ViewStateTransition: qvobserve.ViewStateTransition{
+				CollectionID: sm.View().GetMeta().GetCollectionId(),
+				View:         qviews.QueryViewKey{ShardID: m.shardID, QueryViewVersion: sm.Version()},
+				From:         before,
+				To:           sm.State(),
+			},
+			Node:                 target.WorkNode(),
+			ReportedState:        resp.State(),
+			ResourceReadyPercent: resourceReadyPercent(resp),
+		})
 		m.processStateMachine(sm)
 		event := m.consumeDirtyEventLocked()
 		m.publishStatsLocked()
@@ -474,6 +539,18 @@ func (m *ShardViewManager) makeOnSyncResponse(version qviews.QueryViewVersion, t
 		m.submitDirtyEvent(event)
 		m.mu.Unlock()
 		return completed
+	}
+}
+
+func resourceReadyPercent(report qviews.QueryViewAtWorkNode) int64 {
+	if _, ok := report.WorkNode().(qviews.StreamingNode); !ok {
+		return 0
+	}
+	switch report.State() {
+	case qviews.QueryViewStateReady, qviews.QueryViewStateUp, qviews.QueryViewStateDown, qviews.QueryViewStateDropped:
+		return 100
+	default:
+		return 0
 	}
 }
 
@@ -506,7 +583,20 @@ func (m *ShardViewManager) makeOnQueryNodeLost(version qviews.QueryViewVersion) 
 			return // view already removed
 		}
 
+		before := sm.State()
+		qvobserve.Observe(m.ctx, qvobserve.CoordQueryNodeLostDetectedEvent{
+			Node: node,
+		})
 		sm.OnQueryNodeLost(node)
+		qvobserve.Observe(m.ctx, qvobserve.CoordViewQueryNodeLostAppliedEvent{
+			ViewStateTransition: qvobserve.ViewStateTransition{
+				CollectionID: sm.View().GetMeta().GetCollectionId(),
+				View:         qviews.QueryViewKey{ShardID: m.shardID, QueryViewVersion: sm.Version()},
+				From:         before,
+				To:           sm.State(),
+			},
+			Node: node,
+		})
 		m.processStateMachine(sm)
 		event := m.consumeDirtyEventLocked()
 		m.publishStatsLocked()

--- a/internal/views/coord/coordview/shard_view_manager_test.go
+++ b/internal/views/coord/coordview/shard_view_manager_test.go
@@ -303,8 +303,8 @@ func TestAddPreparing_Success(t *testing.T) {
 	require.Len(t, catalog.savedStates(), 1)
 	assert.Equal(t, viewpb.QueryViewState_QueryViewStatePreparing, catalog.savedStates()[0])
 
-	// Should sync to SN + QN1 + QN2 = 3 SyncViews, in one SyncViews call.
-	assert.Equal(t, 1, s.numSyncCalls())
+	// Should sync to SN + QN1 + QN2 = 3 SyncViews, one call per node.
+	assert.Equal(t, 3, s.numSyncCalls())
 	assert.Equal(t, 3, s.syncViewCount())
 
 	// QueryVersion should be auto-assigned to 1.
@@ -371,8 +371,8 @@ func TestAddPreparing_PreemptsPreparing(t *testing.T) {
 		viewpb.QueryViewState_QueryViewStatePreparing,
 	}, states)
 
-	// Should have synced in ONE SyncViews call.
-	assert.Equal(t, 1, s.numSyncCalls())
+	// Should have synced in one SyncViews call per node.
+	assert.Equal(t, 2, s.numSyncCalls())
 
 	// v1 should be in Dropping, v2 should be in Preparing.
 	mgr.mu.Lock()
@@ -639,9 +639,10 @@ func TestQueryNodeLost_TriggersUnrecoverable(t *testing.T) {
 	require.NoError(t, mgr.AddPreparing(context.Background(), b2))
 	ver2 := testVersion(2, 1, 1)
 
-	// Single flush: Preparing(v2) persist + Dropped(v1) sync + Preparing(v2) sync.
+	// Single flush: Preparing(v2) persist + one SyncViews call per node
+	// carrying Dropped(v1) + Preparing(v2) (SN + QN1).
 	assert.Equal(t, 1, catalog.numSaveCalls())
-	assert.Equal(t, 1, s.numSyncCalls())
+	assert.Equal(t, 2, s.numSyncCalls())
 
 	// Confirm all nodes Dropped for v1 → view removed.
 	simulateNodeResponse(t, s, testSN, ver1, qviews.QueryViewStateDropped)

--- a/internal/views/qviews/observe/event.go
+++ b/internal/views/qviews/observe/event.go
@@ -1,0 +1,858 @@
+package observe
+
+import (
+	"github.com/milvus-io/milvus/internal/views/qviews"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+)
+
+const (
+	fieldType                 = "type"
+	fieldSID                  = "sid"
+	fieldQV                   = "qv"
+	fieldDV                   = "dv"
+	fieldState                = "state"
+	fieldPreemptingDV         = "preemptingDv"
+	fieldNewUpSID             = "newUpSid"
+	fieldNewUpQV              = "newUpQv"
+	fieldNewUpDV              = "newUpDv"
+	fieldWN                   = "wn"
+	fieldReportedState        = "reportedState"
+	fieldResourceReadyPercent = "resourceReadyPercent"
+	fieldError                = "error"
+	fieldSegmentID            = "segmentID"
+	fieldSegmentCount         = "segmentCount"
+	fieldReadySegmentCount    = "readySegmentCount"
+)
+
+const (
+	eventCoordQNLostDetected                = "CoordQNLostDetected"
+	eventCoordViewCreated                   = "CoordViewCreated"
+	eventCoordViewPreempted                 = "CoordViewPreempted"
+	eventCoordViewAdvancedFromUnrecoverable = "CoordViewAdvancedFromUnrecoverable"
+	eventCoordViewReleaseRequested          = "CoordViewReleaseRequested"
+	eventCoordViewHandoffToNewUp            = "CoordViewHandoffToNewUp"
+	eventCoordViewReportApplied             = "CoordViewReportApplied"
+	eventCoordViewQNLostApplied             = "CoordViewQNLostApplied"
+	eventQNApplyCoordView                   = "QNApplyCoordView"
+	eventQNSegmentUnrecoverable             = "QNSegmentUnrecoverable"
+	eventQNReportView                       = "QNReportView"
+	eventQNReleaseDone                      = "QNReleaseDone"
+	eventSNApplyCoordView                   = "SNApplyCoordView"
+	eventSNRecoveringDone                   = "SNRecoveringDone"
+	eventSNReportView                       = "SNReportView"
+	eventSNReleaseDone                      = "SNReleaseDone"
+	eventQNSegmentFailure                   = "QNSegmentFailure"
+	eventQNAcquireSegments                  = "QNAcquireSegments"
+	eventQNSegmentsReady                    = "QNSegmentsReady"
+	eventQNReleaseSegments                  = "QNReleaseSegments"
+	eventSNAcquireResource                  = "SNAcquireResource"
+	eventSNRecoverAcquireResource           = "SNRecoverAcquireResource"
+	eventSNResourceReady                    = "SNResourceReady"
+	eventSNReleaseResource                  = "SNReleaseResource"
+	eventCoordPersistView                   = "CoordPersistView"
+	eventSNPersistView                      = "SNPersistView"
+	eventCoordSyncViewAccepted              = "CoordSyncViewAccepted"
+)
+
+const (
+	triggerReportReady             = "reportReady"
+	triggerReportUnrecoverable     = "reportUnrecoverable"
+	triggerPreempt                 = "preempt"
+	triggerHandoff                 = "handoff"
+	triggerRelease                 = "release"
+	triggerAdvanceUnrecoverable    = "advanceUnrecoverable"
+	triggerQueryNodeLost           = "queryNodeLost"
+	triggerQueryNodeSegmentsReady  = "queryNodeSegmentsReady"
+	triggerQueryNodeReleaseDone    = "queryNodeReleaseDone"
+	triggerStreamingResourceReady  = "streamingResourceReady"
+	triggerStreamingRecoveringDone = "streamingRecoveringDone"
+	triggerStreamingReleaseDone    = "streamingReleaseDone"
+)
+
+const (
+	componentCoord         = "coord"
+	componentQueryNode     = "queryNode"
+	componentStreamingNode = "streamingNode"
+)
+
+// TriggerInfo describes the low-cardinality reason for an observable event.
+type TriggerInfo interface {
+	TriggerInfo() string
+}
+
+// ComponentInfo describes the low-cardinality component that owns an
+// observable event.
+type ComponentInfo interface {
+	ComponentInfo() string
+}
+
+// Event is the sealed interface implemented by all QueryView observability events.
+type Event interface {
+	mlog.ObjectMarshaler
+	TriggerInfo
+	ComponentInfo
+	LogLevel() mlog.Level
+	isQueryViewEvent()
+}
+
+// baseEvent provides the private marker method for concrete events.
+type baseEvent struct{}
+
+func (baseEvent) isQueryViewEvent() {}
+
+func (baseEvent) TriggerInfo() string {
+	return ""
+}
+
+func (baseEvent) ComponentInfo() string {
+	return ""
+}
+
+// FieldEvent returns an inline mlog field for a QueryView event.
+func FieldEvent(event Event) mlog.Field {
+	return mlog.Inline(event)
+}
+
+// ViewStateTransition identifies one QueryView state transition.
+type ViewStateTransition struct {
+	CollectionID int64
+	View         qviews.QueryViewKey
+	From         qviews.QueryViewState
+	To           qviews.QueryViewState
+}
+
+// CoordQueryNodeLostDetectedEvent is emitted when Coord sync code observes
+// QueryNode loss.
+type CoordQueryNodeLostDetectedEvent struct {
+	baseEvent
+	Node qviews.QueryNode
+}
+
+func (e CoordQueryNodeLostDetectedEvent) LogLevel() mlog.Level {
+	return mlog.WarnLevel
+}
+
+func (e CoordQueryNodeLostDetectedEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventCoordQNLostDetected)
+	enc.AddString(fieldWN, e.Node.String())
+	return nil
+}
+
+// CoordViewCreatedEvent is emitted after Coord creates a new Preparing view.
+type CoordViewCreatedEvent struct {
+	baseEvent
+	CollectionID int64
+	View         qviews.QueryViewKey
+	State        qviews.QueryViewState
+}
+
+func (e CoordViewCreatedEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e CoordViewCreatedEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventCoordViewCreated)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	enc.AddString(fieldState, e.State.String())
+	return nil
+}
+
+// CoordViewPreemptedEvent is emitted after Coord preempts a Preparing or Ready
+// view while adding a new Preparing view.
+type CoordViewPreemptedEvent struct {
+	baseEvent
+	ViewStateTransition
+	PreemptingDataVersion qviews.DataVersion
+}
+
+func (e CoordViewPreemptedEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e CoordViewPreemptedEvent) TriggerInfo() string {
+	return triggerPreempt
+}
+
+func (e CoordViewPreemptedEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventCoordViewPreempted)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	enc.AddString(fieldState, e.From.String()+"->"+e.To.String())
+	enc.AddString(fieldPreemptingDV, e.PreemptingDataVersion.String())
+	return nil
+}
+
+// CoordViewAdvancedFromUnrecoverableEvent is emitted after Coord advances an
+// Unrecoverable view to Dropping.
+type CoordViewAdvancedFromUnrecoverableEvent struct {
+	baseEvent
+	ViewStateTransition
+}
+
+func (e CoordViewAdvancedFromUnrecoverableEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e CoordViewAdvancedFromUnrecoverableEvent) TriggerInfo() string {
+	return triggerAdvanceUnrecoverable
+}
+
+func (e CoordViewAdvancedFromUnrecoverableEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventCoordViewAdvancedFromUnrecoverable)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	enc.AddString(fieldState, e.From.String()+"->"+e.To.String())
+	return nil
+}
+
+// CoordViewReleaseRequestedEvent is emitted after ShardViewManager applies
+// RequestRelease to a view.
+type CoordViewReleaseRequestedEvent struct {
+	baseEvent
+	ViewStateTransition
+}
+
+func (e CoordViewReleaseRequestedEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e CoordViewReleaseRequestedEvent) TriggerInfo() string {
+	return triggerRelease
+}
+
+func (e CoordViewReleaseRequestedEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventCoordViewReleaseRequested)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	enc.AddString(fieldState, e.From.String()+"->"+e.To.String())
+	return nil
+}
+
+// CoordViewHandoffToNewUpEvent is emitted after ShardViewManager transitions
+// the previous Up view to Down because another view became Up.
+type CoordViewHandoffToNewUpEvent struct {
+	baseEvent
+	ViewStateTransition
+	NewUpView qviews.QueryViewKey
+}
+
+func (e CoordViewHandoffToNewUpEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e CoordViewHandoffToNewUpEvent) TriggerInfo() string {
+	return triggerHandoff
+}
+
+func (e CoordViewHandoffToNewUpEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventCoordViewHandoffToNewUp)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	enc.AddString(fieldState, e.From.String()+"->"+e.To.String())
+	enc.AddString(fieldNewUpSID, e.NewUpView.ShardID.String())
+	enc.AddString(fieldNewUpQV, e.NewUpView.QueryViewVersion.String())
+	enc.AddString(fieldNewUpDV, e.NewUpView.QueryViewVersion.DataVersion.String())
+	return nil
+}
+
+// CoordViewReportAppliedEvent is emitted after ShardViewManager applies a
+// work-node report to a view. ResourceReadyPercent is the report-side resource
+// preparation progress in [0, 100]. StreamingNode reports derive this value
+// from view state: resource-ready states report 100, other states report 0.
+type CoordViewReportAppliedEvent struct {
+	baseEvent
+	ViewStateTransition
+	Node                 qviews.WorkNode
+	ReportedState        qviews.QueryViewState
+	ResourceReadyPercent int64
+}
+
+func (e CoordViewReportAppliedEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e CoordViewReportAppliedEvent) TriggerInfo() string {
+	switch e.ReportedState {
+	case qviews.QueryViewStateReady:
+		return triggerReportReady
+	case qviews.QueryViewStateUnrecoverable:
+		return triggerReportUnrecoverable
+	default:
+		return "report" + e.ReportedState.String()
+	}
+}
+
+func (e CoordViewReportAppliedEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventCoordViewReportApplied)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	enc.AddString(fieldState, e.From.String()+"->"+e.To.String())
+	if e.Node != nil {
+		enc.AddString(fieldWN, e.Node.String())
+	}
+	enc.AddString(fieldReportedState, e.ReportedState.String())
+	enc.AddInt64(fieldResourceReadyPercent, e.ResourceReadyPercent)
+	return nil
+}
+
+// CoordViewQueryNodeLostAppliedEvent is emitted after ShardViewManager applies
+// QueryNode loss to a view.
+type CoordViewQueryNodeLostAppliedEvent struct {
+	baseEvent
+	ViewStateTransition
+	Node qviews.QueryNode
+}
+
+func (e CoordViewQueryNodeLostAppliedEvent) LogLevel() mlog.Level {
+	return mlog.WarnLevel
+}
+
+func (e CoordViewQueryNodeLostAppliedEvent) TriggerInfo() string {
+	return triggerQueryNodeLost
+}
+
+func (e CoordViewQueryNodeLostAppliedEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventCoordViewQNLostApplied)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	enc.AddString(fieldState, e.From.String()+"->"+e.To.String())
+	enc.AddString(fieldWN, e.Node.String())
+	return nil
+}
+
+// QueryNodeApplyCoordViewEvent is emitted after QueryNode applies a Coord view
+// state.
+type QueryNodeApplyCoordViewEvent struct {
+	baseEvent
+	ViewStateTransition
+}
+
+func (e QueryNodeApplyCoordViewEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e QueryNodeApplyCoordViewEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventQNApplyCoordView)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	enc.AddString(fieldState, e.From.String()+"->"+e.To.String())
+	return nil
+}
+
+// QueryNodeSegmentUnrecoverableEvent is emitted after the segment
+// unrecoverable callback moves a view to Unrecoverable.
+type QueryNodeSegmentUnrecoverableEvent struct {
+	baseEvent
+	ViewStateTransition
+	Err error
+}
+
+func (e QueryNodeSegmentUnrecoverableEvent) LogLevel() mlog.Level {
+	return mlog.WarnLevel
+}
+
+func (e QueryNodeSegmentUnrecoverableEvent) TriggerInfo() string {
+	return triggerReportUnrecoverable
+}
+
+func (e QueryNodeSegmentUnrecoverableEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventQNSegmentUnrecoverable)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	enc.AddString(fieldState, e.From.String()+"->"+e.To.String())
+	if e.Err != nil {
+		enc.AddString(fieldError, e.Err.Error())
+	}
+	return nil
+}
+
+// QueryNodeReportViewEvent is emitted when QueryNode reports local view state.
+type QueryNodeReportViewEvent struct {
+	baseEvent
+	View  qviews.QueryViewKey
+	State qviews.QueryViewState
+}
+
+func (e QueryNodeReportViewEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e QueryNodeReportViewEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventQNReportView)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	enc.AddString(fieldState, e.State.String())
+	return nil
+}
+
+// QueryNodeReleaseDoneEvent is emitted after QueryNode observes release
+// completion for a view.
+type QueryNodeReleaseDoneEvent struct {
+	baseEvent
+	ViewStateTransition
+}
+
+func (e QueryNodeReleaseDoneEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e QueryNodeReleaseDoneEvent) TriggerInfo() string {
+	return triggerQueryNodeReleaseDone
+}
+
+func (e QueryNodeReleaseDoneEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventQNReleaseDone)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	enc.AddString(fieldState, e.From.String()+"->"+e.To.String())
+	return nil
+}
+
+// StreamingNodeApplyCoordViewEvent is emitted after StreamingNode applies a
+// Coord view state.
+type StreamingNodeApplyCoordViewEvent struct {
+	baseEvent
+	ViewStateTransition
+}
+
+func (e StreamingNodeApplyCoordViewEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e StreamingNodeApplyCoordViewEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventSNApplyCoordView)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	enc.AddString(fieldState, e.From.String()+"->"+e.To.String())
+	return nil
+}
+
+// StreamingNodeRecoveringDoneEvent is emitted after StreamingNode observes
+// recovery completion for a view.
+type StreamingNodeRecoveringDoneEvent struct {
+	baseEvent
+	ViewStateTransition
+}
+
+func (e StreamingNodeRecoveringDoneEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e StreamingNodeRecoveringDoneEvent) TriggerInfo() string {
+	return triggerStreamingRecoveringDone
+}
+
+func (e StreamingNodeRecoveringDoneEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventSNRecoveringDone)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	enc.AddString(fieldState, e.From.String()+"->"+e.To.String())
+	return nil
+}
+
+// StreamingNodeReportViewEvent is emitted when StreamingNode reports local view
+// state.
+type StreamingNodeReportViewEvent struct {
+	baseEvent
+	View  qviews.QueryViewKey
+	State qviews.QueryViewState
+}
+
+func (e StreamingNodeReportViewEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e StreamingNodeReportViewEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventSNReportView)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	enc.AddString(fieldState, e.State.String())
+	return nil
+}
+
+// StreamingNodeReleaseDoneEvent is emitted after StreamingNode observes release
+// completion for a view.
+type StreamingNodeReleaseDoneEvent struct {
+	baseEvent
+	ViewStateTransition
+}
+
+func (e StreamingNodeReleaseDoneEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e StreamingNodeReleaseDoneEvent) TriggerInfo() string {
+	return triggerStreamingReleaseDone
+}
+
+func (e StreamingNodeReleaseDoneEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventSNReleaseDone)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	enc.AddString(fieldState, e.From.String()+"->"+e.To.String())
+	return nil
+}
+
+// QueryNodeSegmentFailureEvent is emitted when physical segment load or
+// transform-log catch-up fails.
+type QueryNodeSegmentFailureEvent struct {
+	baseEvent
+	View      qviews.QueryViewKey
+	SegmentID int64
+	Err       error
+}
+
+func (e QueryNodeSegmentFailureEvent) LogLevel() mlog.Level {
+	return mlog.WarnLevel
+}
+
+func (e QueryNodeSegmentFailureEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventQNSegmentFailure)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	enc.AddInt64(fieldSegmentID, e.SegmentID)
+	if e.Err != nil {
+		enc.AddString(fieldError, e.Err.Error())
+	}
+	return nil
+}
+
+// QueryNodeAcquireSegmentsEvent is emitted when QueryNode starts acquiring
+// segments for a new Preparing view.
+type QueryNodeAcquireSegmentsEvent struct {
+	baseEvent
+	View         qviews.QueryViewKey
+	SegmentCount int
+}
+
+func (e QueryNodeAcquireSegmentsEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e QueryNodeAcquireSegmentsEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventQNAcquireSegments)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	enc.AddInt(fieldSegmentCount, e.SegmentCount)
+	return nil
+}
+
+// QueryNodeSegmentsReadyEvent is emitted after the segment readiness callback
+// moves a view forward.
+type QueryNodeSegmentsReadyEvent struct {
+	baseEvent
+	ViewStateTransition
+	ReadySegmentCount int
+}
+
+func (e QueryNodeSegmentsReadyEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e QueryNodeSegmentsReadyEvent) TriggerInfo() string {
+	return triggerQueryNodeSegmentsReady
+}
+
+func (e QueryNodeSegmentsReadyEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventQNSegmentsReady)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	enc.AddString(fieldState, e.From.String()+"->"+e.To.String())
+	enc.AddInt(fieldReadySegmentCount, e.ReadySegmentCount)
+	return nil
+}
+
+// QueryNodeReleaseSegmentsEvent is emitted when QueryNode starts releasing
+// segments for a view.
+type QueryNodeReleaseSegmentsEvent struct {
+	baseEvent
+	View qviews.QueryViewKey
+}
+
+func (e QueryNodeReleaseSegmentsEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e QueryNodeReleaseSegmentsEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventQNReleaseSegments)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	return nil
+}
+
+// StreamingNodeAcquireResourceEvent is emitted when StreamingNode starts
+// acquiring resources for a new Preparing view.
+type StreamingNodeAcquireResourceEvent struct {
+	baseEvent
+	View qviews.QueryViewKey
+}
+
+func (e StreamingNodeAcquireResourceEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e StreamingNodeAcquireResourceEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventSNAcquireResource)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	return nil
+}
+
+// StreamingNodeRecoverAcquireResourceEvent is emitted when StreamingNode starts
+// acquiring resources for a recovered Up view.
+type StreamingNodeRecoverAcquireResourceEvent struct {
+	baseEvent
+	View qviews.QueryViewKey
+}
+
+func (e StreamingNodeRecoverAcquireResourceEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e StreamingNodeRecoverAcquireResourceEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventSNRecoverAcquireResource)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	return nil
+}
+
+// StreamingNodeResourceReadyEvent is emitted after the resource ready callback
+// moves a view forward.
+type StreamingNodeResourceReadyEvent struct {
+	baseEvent
+	ViewStateTransition
+}
+
+func (e StreamingNodeResourceReadyEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e StreamingNodeResourceReadyEvent) TriggerInfo() string {
+	return triggerStreamingResourceReady
+}
+
+func (e StreamingNodeResourceReadyEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventSNResourceReady)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	enc.AddString(fieldState, e.From.String()+"->"+e.To.String())
+	return nil
+}
+
+// StreamingNodeReleaseResourceEvent is emitted when StreamingNode starts
+// releasing resources for a view.
+type StreamingNodeReleaseResourceEvent struct {
+	baseEvent
+	View qviews.QueryViewKey
+}
+
+func (e StreamingNodeReleaseResourceEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e StreamingNodeReleaseResourceEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventSNReleaseResource)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	return nil
+}
+
+// CoordPersistViewEvent is emitted after DirtyViewFlushScheduler successfully
+// persists one QueryView state.
+type CoordPersistViewEvent struct {
+	baseEvent
+	View  qviews.QueryViewKey
+	State qviews.QueryViewState
+}
+
+func (e CoordPersistViewEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e CoordPersistViewEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventCoordPersistView)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	enc.AddString(fieldState, e.State.String())
+	return nil
+}
+
+// StreamingNodePersistViewEvent is emitted when StreamingNode persists local
+// view state.
+type StreamingNodePersistViewEvent struct {
+	baseEvent
+	View  qviews.QueryViewKey
+	State qviews.QueryViewState
+}
+
+func (e StreamingNodePersistViewEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e StreamingNodePersistViewEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventSNPersistView)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	enc.AddString(fieldState, e.State.String())
+	return nil
+}
+
+// CoordSyncViewAcceptedEvent is emitted after ReliableSyncer accepts one
+// QueryView state for delivery to a worker node. It does not mean the worker
+// has applied the state.
+type CoordSyncViewAcceptedEvent struct {
+	baseEvent
+	View  qviews.QueryViewKey
+	Node  qviews.WorkNode
+	State qviews.QueryViewState
+}
+
+func (e CoordSyncViewAcceptedEvent) LogLevel() mlog.Level {
+	return mlog.InfoLevel
+}
+
+func (e CoordSyncViewAcceptedEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddString(fieldType, eventCoordSyncViewAccepted)
+	enc.AddString(fieldSID, e.View.ShardID.String())
+	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
+	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
+	if e.Node != nil {
+		enc.AddString(fieldWN, e.Node.String())
+	}
+	enc.AddString(fieldState, e.State.String())
+	return nil
+}
+
+func (e CoordQueryNodeLostDetectedEvent) ComponentInfo() string {
+	return componentCoord
+}
+
+func (e CoordViewCreatedEvent) ComponentInfo() string {
+	return componentCoord
+}
+
+func (e CoordViewPreemptedEvent) ComponentInfo() string {
+	return componentCoord
+}
+
+func (e CoordViewAdvancedFromUnrecoverableEvent) ComponentInfo() string {
+	return componentCoord
+}
+
+func (e CoordViewReleaseRequestedEvent) ComponentInfo() string {
+	return componentCoord
+}
+
+func (e CoordViewHandoffToNewUpEvent) ComponentInfo() string {
+	return componentCoord
+}
+
+func (e CoordViewReportAppliedEvent) ComponentInfo() string {
+	return componentCoord
+}
+
+func (e CoordViewQueryNodeLostAppliedEvent) ComponentInfo() string {
+	return componentCoord
+}
+
+func (e CoordPersistViewEvent) ComponentInfo() string {
+	return componentCoord
+}
+
+func (e CoordSyncViewAcceptedEvent) ComponentInfo() string {
+	return componentCoord
+}
+
+func (e QueryNodeApplyCoordViewEvent) ComponentInfo() string {
+	return componentQueryNode
+}
+
+func (e QueryNodeSegmentUnrecoverableEvent) ComponentInfo() string {
+	return componentQueryNode
+}
+
+func (e QueryNodeReportViewEvent) ComponentInfo() string {
+	return componentQueryNode
+}
+
+func (e QueryNodeReleaseDoneEvent) ComponentInfo() string {
+	return componentQueryNode
+}
+
+func (e QueryNodeSegmentFailureEvent) ComponentInfo() string {
+	return componentQueryNode
+}
+
+func (e QueryNodeAcquireSegmentsEvent) ComponentInfo() string {
+	return componentQueryNode
+}
+
+func (e QueryNodeSegmentsReadyEvent) ComponentInfo() string {
+	return componentQueryNode
+}
+
+func (e QueryNodeReleaseSegmentsEvent) ComponentInfo() string {
+	return componentQueryNode
+}
+
+func (e StreamingNodeApplyCoordViewEvent) ComponentInfo() string {
+	return componentStreamingNode
+}
+
+func (e StreamingNodeRecoveringDoneEvent) ComponentInfo() string {
+	return componentStreamingNode
+}
+
+func (e StreamingNodeReportViewEvent) ComponentInfo() string {
+	return componentStreamingNode
+}
+
+func (e StreamingNodeReleaseDoneEvent) ComponentInfo() string {
+	return componentStreamingNode
+}
+
+func (e StreamingNodeAcquireResourceEvent) ComponentInfo() string {
+	return componentStreamingNode
+}
+
+func (e StreamingNodeRecoverAcquireResourceEvent) ComponentInfo() string {
+	return componentStreamingNode
+}
+
+func (e StreamingNodeResourceReadyEvent) ComponentInfo() string {
+	return componentStreamingNode
+}
+
+func (e StreamingNodeReleaseResourceEvent) ComponentInfo() string {
+	return componentStreamingNode
+}
+
+func (e StreamingNodePersistViewEvent) ComponentInfo() string {
+	return componentStreamingNode
+}

--- a/internal/views/qviews/observe/event.go
+++ b/internal/views/qviews/observe/event.go
@@ -6,22 +6,20 @@ import (
 )
 
 const (
-	fieldType                 = "type"
-	fieldSID                  = "sid"
-	fieldQV                   = "qv"
-	fieldDV                   = "dv"
-	fieldState                = "state"
-	fieldPreemptingDV         = "preemptingDv"
-	fieldNewUpSID             = "newUpSid"
-	fieldNewUpQV              = "newUpQv"
-	fieldNewUpDV              = "newUpDv"
-	fieldWN                   = "wn"
-	fieldReportedState        = "reportedState"
-	fieldResourceReadyPercent = "resourceReadyPercent"
-	fieldError                = "error"
-	fieldSegmentID            = "segmentID"
-	fieldSegmentCount         = "segmentCount"
-	fieldReadySegmentCount    = "readySegmentCount"
+	fieldType              = "type"
+	fieldSID               = "sid"
+	fieldQV                = "qv"
+	fieldDV                = "dv"
+	fieldState             = "state"
+	fieldPreemptingDV      = "preemptingDv"
+	fieldNewUpSID          = "newUpSid"
+	fieldNewUpQV           = "newUpQv"
+	fieldNewUpDV           = "newUpDv"
+	fieldWN                = "wn"
+	fieldReportedState     = "reportedState"
+	fieldError             = "error"
+	fieldSegmentCount      = "segmentCount"
+	fieldReadySegmentCount = "readySegmentCount"
 )
 
 const (
@@ -41,21 +39,18 @@ const (
 	eventSNRecoveringDone                   = "SNRecoveringDone"
 	eventSNReportView                       = "SNReportView"
 	eventSNReleaseDone                      = "SNReleaseDone"
-	eventQNSegmentFailure                   = "QNSegmentFailure"
 	eventQNAcquireSegments                  = "QNAcquireSegments"
 	eventQNSegmentsReady                    = "QNSegmentsReady"
 	eventQNReleaseSegments                  = "QNReleaseSegments"
 	eventSNAcquireResource                  = "SNAcquireResource"
 	eventSNRecoverAcquireResource           = "SNRecoverAcquireResource"
 	eventSNResourceReady                    = "SNResourceReady"
-	eventSNReleaseResource                  = "SNReleaseResource"
 	eventCoordPersistView                   = "CoordPersistView"
 	eventSNPersistView                      = "SNPersistView"
 	eventCoordSyncViewAccepted              = "CoordSyncViewAccepted"
 )
 
 const (
-	triggerReportReady             = "reportReady"
 	triggerReportUnrecoverable     = "reportUnrecoverable"
 	triggerPreempt                 = "preempt"
 	triggerHandoff                 = "handoff"
@@ -67,6 +62,7 @@ const (
 	triggerStreamingResourceReady  = "streamingResourceReady"
 	triggerStreamingRecoveringDone = "streamingRecoveringDone"
 	triggerStreamingReleaseDone    = "streamingReleaseDone"
+	triggerCoordDelivered          = "coordDelivered"
 )
 
 const (
@@ -128,8 +124,11 @@ type CoordQueryNodeLostDetectedEvent struct {
 	Node qviews.QueryNode
 }
 
+// CoordQueryNodeLostDetectedEvent is emitted per view when a QueryNode is lost.
+// Debug level: emitted per view on a node outage, so a multi-view outage would
+// otherwise flood the log.
 func (e CoordQueryNodeLostDetectedEvent) LogLevel() mlog.Level {
-	return mlog.WarnLevel
+	return mlog.DebugLevel
 }
 
 func (e CoordQueryNodeLostDetectedEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
@@ -262,15 +261,12 @@ func (e CoordViewHandoffToNewUpEvent) MarshalLogObject(enc mlog.ObjectEncoder) e
 }
 
 // CoordViewReportAppliedEvent is emitted after ShardViewManager applies a
-// work-node report to a view. ResourceReadyPercent is the report-side resource
-// preparation progress in [0, 100]. StreamingNode reports derive this value
-// from view state: resource-ready states report 100, other states report 0.
+// work-node report to a view.
 type CoordViewReportAppliedEvent struct {
 	baseEvent
 	ViewStateTransition
-	Node                 qviews.WorkNode
-	ReportedState        qviews.QueryViewState
-	ResourceReadyPercent int64
+	Node          qviews.WorkNode
+	ReportedState qviews.QueryViewState
 }
 
 func (e CoordViewReportAppliedEvent) LogLevel() mlog.Level {
@@ -278,14 +274,7 @@ func (e CoordViewReportAppliedEvent) LogLevel() mlog.Level {
 }
 
 func (e CoordViewReportAppliedEvent) TriggerInfo() string {
-	switch e.ReportedState {
-	case qviews.QueryViewStateReady:
-		return triggerReportReady
-	case qviews.QueryViewStateUnrecoverable:
-		return triggerReportUnrecoverable
-	default:
-		return "report" + e.ReportedState.String()
-	}
+	return "report" + e.ReportedState.String()
 }
 
 func (e CoordViewReportAppliedEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
@@ -298,7 +287,6 @@ func (e CoordViewReportAppliedEvent) MarshalLogObject(enc mlog.ObjectEncoder) er
 		enc.AddString(fieldWN, e.Node.String())
 	}
 	enc.AddString(fieldReportedState, e.ReportedState.String())
-	enc.AddInt64(fieldResourceReadyPercent, e.ResourceReadyPercent)
 	return nil
 }
 
@@ -337,6 +325,10 @@ type QueryNodeApplyCoordViewEvent struct {
 
 func (e QueryNodeApplyCoordViewEvent) LogLevel() mlog.Level {
 	return mlog.InfoLevel
+}
+
+func (e QueryNodeApplyCoordViewEvent) TriggerInfo() string {
+	return triggerCoordDelivered
 }
 
 func (e QueryNodeApplyCoordViewEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
@@ -384,7 +376,7 @@ type QueryNodeReportViewEvent struct {
 }
 
 func (e QueryNodeReportViewEvent) LogLevel() mlog.Level {
-	return mlog.InfoLevel
+	return mlog.DebugLevel
 }
 
 func (e QueryNodeReportViewEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
@@ -431,6 +423,10 @@ func (e StreamingNodeApplyCoordViewEvent) LogLevel() mlog.Level {
 	return mlog.InfoLevel
 }
 
+func (e StreamingNodeApplyCoordViewEvent) TriggerInfo() string {
+	return triggerCoordDelivered
+}
+
 func (e StreamingNodeApplyCoordViewEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
 	enc.AddString(fieldType, eventSNApplyCoordView)
 	enc.AddString(fieldSID, e.View.ShardID.String())
@@ -473,7 +469,7 @@ type StreamingNodeReportViewEvent struct {
 }
 
 func (e StreamingNodeReportViewEvent) LogLevel() mlog.Level {
-	return mlog.InfoLevel
+	return mlog.DebugLevel
 }
 
 func (e StreamingNodeReportViewEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
@@ -509,35 +505,11 @@ func (e StreamingNodeReleaseDoneEvent) MarshalLogObject(enc mlog.ObjectEncoder) 
 	return nil
 }
 
-// QueryNodeSegmentFailureEvent is emitted when physical segment load or
-// transform-log catch-up fails.
-type QueryNodeSegmentFailureEvent struct {
-	baseEvent
-	View      qviews.QueryViewKey
-	SegmentID int64
-	Err       error
-}
-
-func (e QueryNodeSegmentFailureEvent) LogLevel() mlog.Level {
-	return mlog.WarnLevel
-}
-
-func (e QueryNodeSegmentFailureEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
-	enc.AddString(fieldType, eventQNSegmentFailure)
-	enc.AddString(fieldSID, e.View.ShardID.String())
-	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
-	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
-	enc.AddInt64(fieldSegmentID, e.SegmentID)
-	if e.Err != nil {
-		enc.AddString(fieldError, e.Err.Error())
-	}
-	return nil
-}
-
 // QueryNodeAcquireSegmentsEvent is emitted when QueryNode starts acquiring
 // segments for a new Preparing view.
 type QueryNodeAcquireSegmentsEvent struct {
 	baseEvent
+	CollectionID int64
 	View         qviews.QueryViewKey
 	SegmentCount int
 }
@@ -604,7 +576,8 @@ func (e QueryNodeReleaseSegmentsEvent) MarshalLogObject(enc mlog.ObjectEncoder) 
 // acquiring resources for a new Preparing view.
 type StreamingNodeAcquireResourceEvent struct {
 	baseEvent
-	View qviews.QueryViewKey
+	CollectionID int64
+	View         qviews.QueryViewKey
 }
 
 func (e StreamingNodeAcquireResourceEvent) LogLevel() mlog.Level {
@@ -623,7 +596,8 @@ func (e StreamingNodeAcquireResourceEvent) MarshalLogObject(enc mlog.ObjectEncod
 // acquiring resources for a recovered Up view.
 type StreamingNodeRecoverAcquireResourceEvent struct {
 	baseEvent
-	View qviews.QueryViewKey
+	CollectionID int64
+	View         qviews.QueryViewKey
 }
 
 func (e StreamingNodeRecoverAcquireResourceEvent) LogLevel() mlog.Level {
@@ -662,25 +636,6 @@ func (e StreamingNodeResourceReadyEvent) MarshalLogObject(enc mlog.ObjectEncoder
 	return nil
 }
 
-// StreamingNodeReleaseResourceEvent is emitted when StreamingNode starts
-// releasing resources for a view.
-type StreamingNodeReleaseResourceEvent struct {
-	baseEvent
-	View qviews.QueryViewKey
-}
-
-func (e StreamingNodeReleaseResourceEvent) LogLevel() mlog.Level {
-	return mlog.InfoLevel
-}
-
-func (e StreamingNodeReleaseResourceEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
-	enc.AddString(fieldType, eventSNReleaseResource)
-	enc.AddString(fieldSID, e.View.ShardID.String())
-	enc.AddString(fieldQV, e.View.QueryViewVersion.String())
-	enc.AddString(fieldDV, e.View.QueryViewVersion.DataVersion.String())
-	return nil
-}
-
 // CoordPersistViewEvent is emitted after DirtyViewFlushScheduler successfully
 // persists one QueryView state.
 type CoordPersistViewEvent struct {
@@ -690,7 +645,7 @@ type CoordPersistViewEvent struct {
 }
 
 func (e CoordPersistViewEvent) LogLevel() mlog.Level {
-	return mlog.InfoLevel
+	return mlog.DebugLevel
 }
 
 func (e CoordPersistViewEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
@@ -711,7 +666,7 @@ type StreamingNodePersistViewEvent struct {
 }
 
 func (e StreamingNodePersistViewEvent) LogLevel() mlog.Level {
-	return mlog.InfoLevel
+	return mlog.DebugLevel
 }
 
 func (e StreamingNodePersistViewEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
@@ -734,7 +689,7 @@ type CoordSyncViewAcceptedEvent struct {
 }
 
 func (e CoordSyncViewAcceptedEvent) LogLevel() mlog.Level {
-	return mlog.InfoLevel
+	return mlog.DebugLevel
 }
 
 func (e CoordSyncViewAcceptedEvent) MarshalLogObject(enc mlog.ObjectEncoder) error {
@@ -805,10 +760,6 @@ func (e QueryNodeReleaseDoneEvent) ComponentInfo() string {
 	return componentQueryNode
 }
 
-func (e QueryNodeSegmentFailureEvent) ComponentInfo() string {
-	return componentQueryNode
-}
-
 func (e QueryNodeAcquireSegmentsEvent) ComponentInfo() string {
 	return componentQueryNode
 }
@@ -846,10 +797,6 @@ func (e StreamingNodeRecoverAcquireResourceEvent) ComponentInfo() string {
 }
 
 func (e StreamingNodeResourceReadyEvent) ComponentInfo() string {
-	return componentStreamingNode
-}
-
-func (e StreamingNodeReleaseResourceEvent) ComponentInfo() string {
 	return componentStreamingNode
 }
 

--- a/internal/views/qviews/observe/event_test.go
+++ b/internal/views/qviews/observe/event_test.go
@@ -27,14 +27,12 @@ func TestConcreteEventsImplementEvent(t *testing.T) {
 	var _ Event = StreamingNodeRecoveringDoneEvent{}
 	var _ Event = StreamingNodeReportViewEvent{}
 	var _ Event = StreamingNodeReleaseDoneEvent{}
-	var _ Event = QueryNodeSegmentFailureEvent{}
 	var _ Event = QueryNodeAcquireSegmentsEvent{}
 	var _ Event = QueryNodeSegmentsReadyEvent{}
 	var _ Event = QueryNodeReleaseSegmentsEvent{}
 	var _ Event = StreamingNodeAcquireResourceEvent{}
 	var _ Event = StreamingNodeRecoverAcquireResourceEvent{}
 	var _ Event = StreamingNodeResourceReadyEvent{}
-	var _ Event = StreamingNodeReleaseResourceEvent{}
 	var _ Event = CoordPersistViewEvent{}
 	var _ Event = StreamingNodePersistViewEvent{}
 	var _ Event = CoordSyncViewAcceptedEvent{}
@@ -102,9 +100,8 @@ func TestEventMarshalLogObjectSplitsQueryViewKeyAndUsesStringers(t *testing.T) {
 			From: qviews.QueryViewStatePreparing,
 			To:   qviews.QueryViewStateReady,
 		},
-		Node:                 qviews.NewQueryNode(10),
-		ReportedState:        qviews.QueryViewStateReady,
-		ResourceReadyPercent: 80,
+		Node:          qviews.NewQueryNode(10),
+		ReportedState: qviews.QueryViewStateReady,
 	}
 	enc := zapcore.NewMapObjectEncoder()
 
@@ -119,7 +116,6 @@ func TestEventMarshalLogObjectSplitsQueryViewKeyAndUsesStringers(t *testing.T) {
 	assertField(t, enc, "state", qviews.QueryViewStatePreparing.String()+"->"+qviews.QueryViewStateReady.String())
 	assertField(t, enc, "wn", qviews.NewQueryNode(10).String())
 	assertField(t, enc, "reportedState", qviews.QueryViewStateReady.String())
-	assertField(t, enc, "resourceReadyPercent", int64(80))
 }
 
 func TestEventMarshalLogObjectSplitsAdditionalQueryViewKey(t *testing.T) {
@@ -240,16 +236,11 @@ func TestEventLogLevel(t *testing.T) {
 		{
 			name:  "querynode lost event",
 			event: CoordQueryNodeLostDetectedEvent{},
-			level: mlog.WarnLevel,
+			level: mlog.DebugLevel,
 		},
 		{
 			name:  "segment unrecoverable event",
 			event: QueryNodeSegmentUnrecoverableEvent{},
-			level: mlog.WarnLevel,
-		},
-		{
-			name:  "segment failure event",
-			event: QueryNodeSegmentFailureEvent{},
 			level: mlog.WarnLevel,
 		},
 	}

--- a/internal/views/qviews/observe/event_test.go
+++ b/internal/views/qviews/observe/event_test.go
@@ -1,0 +1,421 @@
+package observe
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap/zapcore"
+
+	"github.com/milvus-io/milvus/internal/views/qviews"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+)
+
+func TestConcreteEventsImplementEvent(t *testing.T) {
+	var _ Event = CoordQueryNodeLostDetectedEvent{}
+	var _ Event = CoordViewCreatedEvent{}
+	var _ Event = CoordViewPreemptedEvent{}
+	var _ Event = CoordViewAdvancedFromUnrecoverableEvent{}
+	var _ Event = CoordViewReleaseRequestedEvent{}
+	var _ Event = CoordViewHandoffToNewUpEvent{}
+	var _ Event = CoordViewReportAppliedEvent{}
+	var _ Event = CoordViewQueryNodeLostAppliedEvent{}
+	var _ Event = QueryNodeApplyCoordViewEvent{}
+	var _ Event = QueryNodeSegmentUnrecoverableEvent{}
+	var _ Event = QueryNodeReportViewEvent{}
+	var _ Event = QueryNodeReleaseDoneEvent{}
+	var _ Event = StreamingNodeApplyCoordViewEvent{}
+	var _ Event = StreamingNodeRecoveringDoneEvent{}
+	var _ Event = StreamingNodeReportViewEvent{}
+	var _ Event = StreamingNodeReleaseDoneEvent{}
+	var _ Event = QueryNodeSegmentFailureEvent{}
+	var _ Event = QueryNodeAcquireSegmentsEvent{}
+	var _ Event = QueryNodeSegmentsReadyEvent{}
+	var _ Event = QueryNodeReleaseSegmentsEvent{}
+	var _ Event = StreamingNodeAcquireResourceEvent{}
+	var _ Event = StreamingNodeRecoverAcquireResourceEvent{}
+	var _ Event = StreamingNodeResourceReadyEvent{}
+	var _ Event = StreamingNodeReleaseResourceEvent{}
+	var _ Event = CoordPersistViewEvent{}
+	var _ Event = StreamingNodePersistViewEvent{}
+	var _ Event = CoordSyncViewAcceptedEvent{}
+}
+
+func TestLogObserverImplementsObserver(t *testing.T) {
+	var _ Observer = LogObserver{}
+}
+
+func TestDefaultRegistryIncludesLogObserver(t *testing.T) {
+	defaultRegistry.mu.RLock()
+	defer defaultRegistry.mu.RUnlock()
+
+	if len(defaultRegistry.observers) == 0 {
+		t.Fatal("default registry has no observers")
+	}
+	if _, ok := defaultRegistry.observers[0].(LogObserver); !ok {
+		t.Fatalf("default registry first observer = %T, want LogObserver", defaultRegistry.observers[0])
+	}
+}
+
+func TestRegistryObserveFanoutsToRegisteredObservers(t *testing.T) {
+	first := &recordingObserver{}
+	second := &recordingObserver{}
+	registry := NewRegistry(first)
+	registry.Register(second)
+	event := CoordViewCreatedEvent{
+		View:  testQueryViewKey(),
+		State: qviews.QueryViewStatePreparing,
+	}
+
+	registry.Observe(context.Background(), event)
+
+	if len(first.events) != 1 {
+		t.Fatalf("first observer events = %d, want 1", len(first.events))
+	}
+	if len(second.events) != 1 {
+		t.Fatalf("second observer events = %d, want 1", len(second.events))
+	}
+	if first.events[0] != event {
+		t.Fatalf("first observer event = %#v, want %#v", first.events[0], event)
+	}
+	if second.events[0] != event {
+		t.Fatalf("second observer event = %#v, want %#v", second.events[0], event)
+	}
+}
+
+type recordingObserver struct {
+	events []Event
+}
+
+func (o *recordingObserver) Observe(_ context.Context, event Event) {
+	o.events = append(o.events, event)
+}
+
+func TestPrivateMarkerStructProvidesMarker(t *testing.T) {
+	var _ interface{ isQueryViewEvent() } = baseEvent{}
+}
+
+func TestEventMarshalLogObjectSplitsQueryViewKeyAndUsesStringers(t *testing.T) {
+	view := testQueryViewKey()
+	event := CoordViewReportAppliedEvent{
+		ViewStateTransition: ViewStateTransition{
+			View: view,
+			From: qviews.QueryViewStatePreparing,
+			To:   qviews.QueryViewStateReady,
+		},
+		Node:                 qviews.NewQueryNode(10),
+		ReportedState:        qviews.QueryViewStateReady,
+		ResourceReadyPercent: 80,
+	}
+	enc := zapcore.NewMapObjectEncoder()
+
+	if err := event.MarshalLogObject(enc); err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+
+	assertField(t, enc, "type", "CoordViewReportApplied")
+	assertField(t, enc, "sid", view.ShardID.String())
+	assertField(t, enc, "qv", view.QueryViewVersion.String())
+	assertField(t, enc, "dv", view.QueryViewVersion.DataVersion.String())
+	assertField(t, enc, "state", qviews.QueryViewStatePreparing.String()+"->"+qviews.QueryViewStateReady.String())
+	assertField(t, enc, "wn", qviews.NewQueryNode(10).String())
+	assertField(t, enc, "reportedState", qviews.QueryViewStateReady.String())
+	assertField(t, enc, "resourceReadyPercent", int64(80))
+}
+
+func TestEventMarshalLogObjectSplitsAdditionalQueryViewKey(t *testing.T) {
+	view := testQueryViewKey()
+	newUpView := qviews.QueryViewKey{
+		ShardID: qviews.ShardID{
+			ReplicaID: 2,
+			VChannel:  "v2",
+		},
+		QueryViewVersion: qviews.QueryViewVersion{
+			DataVersion: qviews.DataVersion{
+				StreamingVersion: 30,
+				CompactVersion:   40,
+			},
+			QueryVersion: 5,
+		},
+	}
+	event := CoordViewHandoffToNewUpEvent{
+		ViewStateTransition: ViewStateTransition{
+			View: view,
+			From: qviews.QueryViewStateUp,
+			To:   qviews.QueryViewStateDown,
+		},
+		NewUpView: newUpView,
+	}
+	enc := zapcore.NewMapObjectEncoder()
+
+	if err := event.MarshalLogObject(enc); err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+
+	assertField(t, enc, "sid", view.ShardID.String())
+	assertField(t, enc, "qv", view.QueryViewVersion.String())
+	assertField(t, enc, "dv", view.QueryViewVersion.DataVersion.String())
+	assertField(t, enc, "newUpSid", newUpView.ShardID.String())
+	assertField(t, enc, "newUpQv", newUpView.QueryViewVersion.String())
+	assertField(t, enc, "newUpDv", newUpView.QueryViewVersion.DataVersion.String())
+}
+
+func TestFieldEventWrapsEventAsMlogObject(t *testing.T) {
+	field := FieldEvent(CoordViewCreatedEvent{
+		View:  testQueryViewKey(),
+		State: qviews.QueryViewStatePreparing,
+	})
+	enc := zapcore.NewMapObjectEncoder()
+
+	field.AddTo(enc)
+
+	if field.Key != "" {
+		t.Fatalf("unexpected inline field key: %s", field.Key)
+	}
+	if field.Type != zapcore.InlineMarshalerType {
+		t.Fatalf("unexpected field type: %v", field.Type)
+	}
+	assertField(t, enc, "type", "CoordViewCreated")
+	assertField(t, enc, "state", qviews.QueryViewStatePreparing.String())
+}
+
+func TestEventTypeShortensNodeNamesAndDropsEventSuffix(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    Event
+		expected string
+	}{
+		{
+			name: "query node",
+			event: QueryNodeReportViewEvent{
+				View:  testQueryViewKey(),
+				State: qviews.QueryViewStateReady,
+			},
+			expected: "QNReportView",
+		},
+		{
+			name: "streaming node",
+			event: StreamingNodeReportViewEvent{
+				View:  testQueryViewKey(),
+				State: qviews.QueryViewStateUp,
+			},
+			expected: "SNReportView",
+		},
+		{
+			name: "query node in coord event",
+			event: CoordViewQueryNodeLostAppliedEvent{
+				ViewStateTransition: ViewStateTransition{
+					View: testQueryViewKey(),
+					From: qviews.QueryViewStateUp,
+					To:   qviews.QueryViewStateUnrecoverable,
+				},
+				Node: qviews.NewQueryNode(10),
+			},
+			expected: "CoordViewQNLostApplied",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			enc := zapcore.NewMapObjectEncoder()
+
+			if err := test.event.MarshalLogObject(enc); err != nil {
+				t.Fatalf("marshal event: %v", err)
+			}
+
+			assertField(t, enc, "type", test.expected)
+		})
+	}
+}
+
+func TestEventLogLevel(t *testing.T) {
+	tests := []struct {
+		name  string
+		event Event
+		level mlog.Level
+	}{
+		{
+			name:  "normal event",
+			event: CoordViewCreatedEvent{},
+			level: mlog.InfoLevel,
+		},
+		{
+			name:  "querynode lost event",
+			event: CoordQueryNodeLostDetectedEvent{},
+			level: mlog.WarnLevel,
+		},
+		{
+			name:  "segment unrecoverable event",
+			event: QueryNodeSegmentUnrecoverableEvent{},
+			level: mlog.WarnLevel,
+		},
+		{
+			name:  "segment failure event",
+			event: QueryNodeSegmentFailureEvent{},
+			level: mlog.WarnLevel,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.event.LogLevel(); got != test.level {
+				t.Fatalf("LogLevel() = %v, want %v", got, test.level)
+			}
+		})
+	}
+}
+
+func TestEventTriggerInfo(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    Event
+		expected string
+	}{
+		{
+			name: "coord report ready",
+			event: CoordViewReportAppliedEvent{
+				ViewStateTransition: ViewStateTransition{
+					View: testQueryViewKey(),
+					From: qviews.QueryViewStatePreparing,
+					To:   qviews.QueryViewStateReady,
+				},
+				ReportedState: qviews.QueryViewStateReady,
+			},
+			expected: "reportReady",
+		},
+		{
+			name: "coord report unrecoverable",
+			event: CoordViewReportAppliedEvent{
+				ViewStateTransition: ViewStateTransition{
+					View: testQueryViewKey(),
+					From: qviews.QueryViewStatePreparing,
+					To:   qviews.QueryViewStateUnrecoverable,
+				},
+				ReportedState: qviews.QueryViewStateUnrecoverable,
+			},
+			expected: "reportUnrecoverable",
+		},
+		{
+			name: "preempt",
+			event: CoordViewPreemptedEvent{
+				ViewStateTransition: ViewStateTransition{
+					View: testQueryViewKey(),
+					From: qviews.QueryViewStatePreparing,
+					To:   qviews.QueryViewStateUnrecoverable,
+				},
+			},
+			expected: "preempt",
+		},
+		{
+			name: "event without transition trigger",
+			event: CoordViewCreatedEvent{
+				View:  testQueryViewKey(),
+				State: qviews.QueryViewStatePreparing,
+			},
+			expected: "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.event.TriggerInfo(); got != test.expected {
+				t.Fatalf("TriggerInfo() = %q, want %q", got, test.expected)
+			}
+		})
+	}
+}
+
+func TestEventComponentInfo(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    Event
+		expected string
+	}{
+		{
+			name: "coord event",
+			event: CoordViewReportAppliedEvent{
+				ViewStateTransition: ViewStateTransition{
+					View: testQueryViewKey(),
+					From: qviews.QueryViewStatePreparing,
+					To:   qviews.QueryViewStateReady,
+				},
+				ReportedState: qviews.QueryViewStateReady,
+			},
+			expected: "coord",
+		},
+		{
+			name: "query node event",
+			event: QueryNodeSegmentsReadyEvent{
+				ViewStateTransition: ViewStateTransition{
+					View: testQueryViewKey(),
+					From: qviews.QueryViewStatePreparing,
+					To:   qviews.QueryViewStateReady,
+				},
+			},
+			expected: "queryNode",
+		},
+		{
+			name: "streaming node event",
+			event: StreamingNodeResourceReadyEvent{
+				ViewStateTransition: ViewStateTransition{
+					View: testQueryViewKey(),
+					From: qviews.QueryViewStatePreparing,
+					To:   qviews.QueryViewStateReady,
+				},
+			},
+			expected: "streamingNode",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.event.ComponentInfo(); got != test.expected {
+				t.Fatalf("ComponentInfo() = %q, want %q", got, test.expected)
+			}
+		})
+	}
+}
+
+func TestCoordSyncViewAcceptedEventMarshalLogObject(t *testing.T) {
+	view := testQueryViewKey()
+	node := qviews.NewQueryNode(10)
+	event := CoordSyncViewAcceptedEvent{
+		View:  view,
+		Node:  node,
+		State: qviews.QueryViewStatePreparing,
+	}
+	enc := zapcore.NewMapObjectEncoder()
+
+	if err := event.MarshalLogObject(enc); err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+
+	assertField(t, enc, "type", "CoordSyncViewAccepted")
+	assertField(t, enc, "sid", view.ShardID.String())
+	assertField(t, enc, "qv", view.QueryViewVersion.String())
+	assertField(t, enc, "dv", view.QueryViewVersion.DataVersion.String())
+	assertField(t, enc, "wn", node.String())
+	assertField(t, enc, "state", qviews.QueryViewStatePreparing.String())
+}
+
+func testQueryViewKey() qviews.QueryViewKey {
+	return qviews.QueryViewKey{
+		ShardID: qviews.ShardID{
+			ReplicaID: 1,
+			VChannel:  "v1",
+		},
+		QueryViewVersion: qviews.QueryViewVersion{
+			DataVersion: qviews.DataVersion{
+				StreamingVersion: 10,
+				CompactVersion:   20,
+			},
+			QueryVersion: 3,
+		},
+	}
+}
+
+func assertField(t *testing.T, enc *zapcore.MapObjectEncoder, key string, expected any) {
+	t.Helper()
+	actual, ok := enc.Fields[key]
+	if !ok {
+		t.Fatalf("missing field %q", key)
+	}
+	if actual != expected {
+		t.Fatalf("field %q = %v, want %v", key, actual, expected)
+	}
+}

--- a/internal/views/qviews/observe/metrics_observer.go
+++ b/internal/views/qviews/observe/metrics_observer.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -15,32 +16,10 @@ import (
 const defaultViewStateMaxAgeTopN = 5
 
 const (
-	readyPercentLe0   = "0"
-	readyPercentLe25  = "25"
-	readyPercentLe50  = "50"
-	readyPercentLe75  = "75"
-	readyPercentLe90  = "90"
-	readyPercentLe99  = "99"
-	readyPercentLe100 = "100"
-	readyPercentLeInf = "+Inf"
-)
-
-const (
 	shardLoadStateLoading    = "loading"
 	shardLoadStateRecovering = "recovering"
 	shardLoadStateLoaded     = "loaded"
 )
-
-var readyPercentLeBounds = []string{
-	readyPercentLe0,
-	readyPercentLe25,
-	readyPercentLe50,
-	readyPercentLe75,
-	readyPercentLe90,
-	readyPercentLe99,
-	readyPercentLe100,
-	readyPercentLeInf,
-}
 
 type MetricsObserver struct {
 	mu              sync.Mutex
@@ -68,7 +47,6 @@ type metricViewState struct {
 	state        qviews.QueryViewState
 	enteredAt    time.Time
 	version      uint64
-	readyLe      string
 }
 
 type metricShardState struct {
@@ -126,7 +104,6 @@ func newMetricsObserverWithNow(now func() time.Time) *MetricsObserver {
 		topK:            make(map[string]*viewStateAgeHeap),
 		topKValidCounts: make(map[string]int),
 	}
-	metrics.SetQVViewStateMaxAgeProvider(observer.collectViewStateMaxAge)
 	return observer
 }
 
@@ -159,6 +136,7 @@ func (o *MetricsObserver) collectViewStateMaxAge() []metrics.QVViewStateMaxAgeMe
 		}
 		if h.Len() == 0 {
 			delete(o.topK, component)
+			delete(o.topKValidCounts, component)
 		}
 	}
 	return result
@@ -173,6 +151,14 @@ func (o *MetricsObserver) Observe(_ context.Context, event Event) {
 		o.setState(component, created.CollectionID, created.View, created.State)
 		return
 	}
+	if acquired, ok := event.(QueryNodeAcquireSegmentsEvent); ok {
+		o.setState(component, acquired.CollectionID, acquired.View, qviews.QueryViewStatePreparing)
+		return
+	}
+	if acquired, ok := event.(StreamingNodeAcquireResourceEvent); ok {
+		o.setState(component, acquired.CollectionID, acquired.View, qviews.QueryViewStatePreparing)
+		return
+	}
 	if persisted, ok := event.(CoordPersistViewEvent); ok && persisted.State == qviews.QueryViewStateDropped {
 		o.deleteState(component, persisted.View)
 	}
@@ -185,24 +171,16 @@ func (o *MetricsObserver) Observe(_ context.Context, event Event) {
 	if trigger == "" {
 		return
 	}
-	metrics.QVViewTransitionTotal.WithLabelValues(
-		component,
-		transition.From.String(),
-		transition.To.String(),
-		trigger,
-	).Inc()
+	if transition.From != transition.To {
+		metrics.QVViewTransitionTotal.WithLabelValues(
+			component,
+			viewStateLabel(transition.From),
+			viewStateLabel(transition.To),
+			trigger,
+		).Inc()
+	}
 	if transition.To == qviews.QueryViewStateDropped {
 		o.deleteState(component, transition.View)
-		return
-	}
-	if reported, ok := event.(CoordViewReportAppliedEvent); ok {
-		o.moveStateWithReadyLe(
-			component,
-			transition.CollectionID,
-			transition.View,
-			transition.To,
-			readyPercentLe(reported.ResourceReadyPercent),
-		)
 		return
 	}
 	o.moveState(component, transition.CollectionID, transition.View, transition.To)
@@ -213,7 +191,7 @@ func (o *MetricsObserver) setState(component string, collectionID int64, view qv
 	defer o.mu.Unlock()
 
 	key := metricViewKey{component: component, view: view}
-	o.upsertStateLocked(key, collectionID, state, "")
+	o.upsertStateLocked(key, collectionID, state)
 }
 
 func (o *MetricsObserver) moveState(component string, collectionID int64, view qviews.QueryViewKey, to qviews.QueryViewState) {
@@ -221,63 +199,46 @@ func (o *MetricsObserver) moveState(component string, collectionID int64, view q
 	defer o.mu.Unlock()
 
 	key := metricViewKey{component: component, view: view}
-	readyLe := ""
-	if old, ok := o.states[key]; ok {
-		if collectionID == 0 {
-			collectionID = old.collectionID
-		}
-		readyLe = old.readyLe
-	}
-	o.upsertStateLocked(key, collectionID, to, readyLe)
-}
-
-func (o *MetricsObserver) moveStateWithReadyLe(
-	component string,
-	collectionID int64,
-	view qviews.QueryViewKey,
-	to qviews.QueryViewState,
-	readyLe string,
-) {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-
-	key := metricViewKey{component: component, view: view}
 	if old, ok := o.states[key]; ok && collectionID == 0 {
 		collectionID = old.collectionID
 	}
-	o.upsertStateLocked(key, collectionID, to, readyLe)
+	o.upsertStateLocked(key, collectionID, to)
 }
 
-func (o *MetricsObserver) upsertStateLocked(
-	key metricViewKey,
-	collectionID int64,
-	state qviews.QueryViewState,
-	readyLe string,
-) {
-	if old, ok := o.states[key]; ok {
-		metrics.QVViewStates.WithLabelValues(key.component, old.state.String()).Dec()
-		o.decReadyPercentBucket(key.component, old.state, old.readyLe)
+// upsertStateLocked inserts or updates a view state entry.
+//
+// A no-op transition (same state, e.g. a repeated report) keeps the original
+// enteredAt and version so a stuck view keeps aging and is not counted as a
+// fresh transition; only the collection id is refreshed.
+func (o *MetricsObserver) upsertStateLocked(key metricViewKey, collectionID int64, state qviews.QueryViewState) {
+	old, existed := o.states[key]
+	if existed && old.state == state {
+		if collectionID != 0 {
+			old.collectionID = collectionID
+		}
+		o.states[key] = old
+		return
+	}
+	if existed {
+		metrics.QVViewStates.WithLabelValues(key.component, viewStateLabel(old.state)).Dec()
 		o.removeShardState(key, old)
 		o.updateTopKValidCount(key.component, old.state, state)
 	} else if isMaxAgeCandidateState(state) {
 		o.topKValidCounts[key.component]++
 	}
-	readyLe = normalizeReadyPercentLe(key.component, state, readyLe)
 
 	stateSnapshot := metricViewState{
 		collectionID: collectionID,
 		state:        state,
 		enteredAt:    o.now(),
 		version:      o.nextVersion(),
-		readyLe:      readyLe,
 	}
 	o.states[key] = stateSnapshot
 	o.addShardState(key, stateSnapshot)
 	o.cleanupShardState(key)
 	o.pushTopKCandidate(key, stateSnapshot)
 	o.compactTopKCandidates(key.component)
-	metrics.QVViewStates.WithLabelValues(key.component, state.String()).Inc()
-	o.incReadyPercentBucket(key.component, state, readyLe)
+	metrics.QVViewStates.WithLabelValues(key.component, viewStateLabel(state)).Inc()
 }
 
 func (o *MetricsObserver) deleteState(component string, view qviews.QueryViewKey) {
@@ -298,9 +259,8 @@ func (o *MetricsObserver) deleteState(component string, view qviews.QueryViewKey
 			delete(o.topKValidCounts, component)
 		}
 	}
-	o.decReadyPercentBucket(component, old.state, old.readyLe)
 	o.compactTopKCandidates(component)
-	metrics.QVViewStates.WithLabelValues(component, old.state.String()).Dec()
+	metrics.QVViewStates.WithLabelValues(component, viewStateLabel(old.state)).Dec()
 }
 
 func (o *MetricsObserver) nextVersion() uint64 {
@@ -458,7 +418,7 @@ func (s *metricShardState) loadState() string {
 }
 
 func newMetricShardKey(key metricViewKey) (metricShardKey, bool) {
-	if key.component != "coord" {
+	if key.component != componentCoord {
 		return metricShardKey{}, false
 	}
 	return metricShardKey{
@@ -490,74 +450,10 @@ func isShardLoadCandidateState(state qviews.QueryViewState) bool {
 	}
 }
 
-func normalizeReadyPercentLe(component string, state qviews.QueryViewState, le string) string {
-	if component != "coord" || !isReadyPercentCandidateState(state) {
-		return ""
-	}
-	if le == "" {
-		return readyPercentLe0
-	}
-	return le
-}
-
-func isReadyPercentCandidateState(state qviews.QueryViewState) bool {
-	return state != qviews.QueryViewStateUp && state != qviews.QueryViewStateDropped
-}
-
-func readyPercentLe(percent int64) string {
-	switch {
-	case percent < 0:
-		return ""
-	case percent == 0:
-		return readyPercentLe0
-	case percent <= 25:
-		return readyPercentLe25
-	case percent <= 50:
-		return readyPercentLe50
-	case percent <= 75:
-		return readyPercentLe75
-	case percent <= 90:
-		return readyPercentLe90
-	case percent < 100:
-		return readyPercentLe99
-	default:
-		return readyPercentLe100
-	}
-}
-
-func (o *MetricsObserver) incReadyPercentBucket(component string, state qviews.QueryViewState, le string) {
-	idx := readyPercentLeIndex(le)
-	if idx < 0 {
-		return
-	}
-	for _, upperBound := range readyPercentLeBounds[idx:] {
-		metrics.QVViewReadyPercentBucket.WithLabelValues(component, state.String(), upperBound).Inc()
-	}
-}
-
-func (o *MetricsObserver) decReadyPercentBucket(component string, state qviews.QueryViewState, le string) {
-	idx := readyPercentLeIndex(le)
-	if idx < 0 {
-		return
-	}
-	for _, upperBound := range readyPercentLeBounds[idx:] {
-		metrics.QVViewReadyPercentBucket.WithLabelValues(component, state.String(), upperBound).Dec()
-	}
-}
-
-func readyPercentLeIndex(le string) int {
-	for idx, upperBound := range readyPercentLeBounds {
-		if upperBound == le {
-			return idx
-		}
-	}
-	return -1
-}
-
 func metricFromViewState(key metricViewKey, state metricViewState, rank int, now time.Time) metrics.QVViewStateMaxAgeMetric {
 	return metrics.QVViewStateMaxAgeMetric{
 		Component:        key.component,
-		State:            state.state.String(),
+		State:            viewStateLabel(state.state),
 		Rank:             strconv.Itoa(rank),
 		CollectionID:     strconv.FormatInt(state.collectionID, 10),
 		ReplicaID:        strconv.FormatInt(key.view.ShardID.ReplicaID, 10),
@@ -566,6 +462,12 @@ func metricFromViewState(key metricViewKey, state metricViewState, rank int, now
 		DataVersion:      key.view.QueryViewVersion.DataVersion.String(),
 		AgeSeconds:       now.Sub(state.enteredAt).Seconds(),
 	}
+}
+
+// viewStateLabel lowercases the state name so qv_* metrics keep one consistent
+// label vocabulary (the shard load lifecycle labels are already lowercase).
+func viewStateLabel(state qviews.QueryViewState) string {
+	return strings.ToLower(state.String())
 }
 
 func lessMetricViewKey(left, right metricViewKey) bool {
@@ -603,6 +505,8 @@ func metricTransition(event Event) (ViewStateTransition, bool) {
 		return e.ViewStateTransition, true
 	case CoordViewQueryNodeLostAppliedEvent:
 		return e.ViewStateTransition, true
+	case QueryNodeApplyCoordViewEvent:
+		return e.ViewStateTransition, true
 	case QueryNodeSegmentsReadyEvent:
 		return e.ViewStateTransition, true
 	case QueryNodeSegmentUnrecoverableEvent:
@@ -610,6 +514,8 @@ func metricTransition(event Event) (ViewStateTransition, bool) {
 	case QueryNodeReleaseDoneEvent:
 		return e.ViewStateTransition, true
 	case StreamingNodeResourceReadyEvent:
+		return e.ViewStateTransition, true
+	case StreamingNodeApplyCoordViewEvent:
 		return e.ViewStateTransition, true
 	case StreamingNodeRecoveringDoneEvent:
 		return e.ViewStateTransition, true

--- a/internal/views/qviews/observe/metrics_observer.go
+++ b/internal/views/qviews/observe/metrics_observer.go
@@ -1,0 +1,621 @@
+package observe
+
+import (
+	"container/heap"
+	"context"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/milvus-io/milvus/internal/views/qviews"
+	"github.com/milvus-io/milvus/pkg/v3/metrics"
+)
+
+const defaultViewStateMaxAgeTopN = 5
+
+const (
+	readyPercentLe0   = "0"
+	readyPercentLe25  = "25"
+	readyPercentLe50  = "50"
+	readyPercentLe75  = "75"
+	readyPercentLe90  = "90"
+	readyPercentLe99  = "99"
+	readyPercentLe100 = "100"
+	readyPercentLeInf = "+Inf"
+)
+
+const (
+	shardLoadStateLoading    = "loading"
+	shardLoadStateRecovering = "recovering"
+	shardLoadStateLoaded     = "loaded"
+)
+
+var readyPercentLeBounds = []string{
+	readyPercentLe0,
+	readyPercentLe25,
+	readyPercentLe50,
+	readyPercentLe75,
+	readyPercentLe90,
+	readyPercentLe99,
+	readyPercentLe100,
+	readyPercentLeInf,
+}
+
+type MetricsObserver struct {
+	mu              sync.Mutex
+	now             func() time.Time
+	topN            int
+	nextID          uint64
+	states          map[metricViewKey]metricViewState
+	shards          map[metricShardKey]*metricShardState
+	topK            map[string]*viewStateAgeHeap
+	topKValidCounts map[string]int
+}
+
+type metricViewKey struct {
+	component string
+	view      qviews.QueryViewKey
+}
+
+type metricShardKey struct {
+	component string
+	shard     qviews.ShardID
+}
+
+type metricViewState struct {
+	collectionID int64
+	state        qviews.QueryViewState
+	enteredAt    time.Time
+	version      uint64
+	readyLe      string
+}
+
+type metricShardState struct {
+	activeCount  int
+	upCount      int
+	hasLoaded    bool
+	currentState string
+}
+
+type viewStateAgeCandidate struct {
+	key       metricViewKey
+	enteredAt time.Time
+	version   uint64
+}
+
+type viewStateAgeHeap []viewStateAgeCandidate
+
+func (h viewStateAgeHeap) Len() int {
+	return len(h)
+}
+
+func (h viewStateAgeHeap) Less(i, j int) bool {
+	if !h[i].enteredAt.Equal(h[j].enteredAt) {
+		return h[i].enteredAt.Before(h[j].enteredAt)
+	}
+	return lessMetricViewKey(h[i].key, h[j].key)
+}
+
+func (h viewStateAgeHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+func (h *viewStateAgeHeap) Push(x any) {
+	*h = append(*h, x.(viewStateAgeCandidate))
+}
+
+func (h *viewStateAgeHeap) Pop() any {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func NewMetricsObserver() *MetricsObserver {
+	return newMetricsObserverWithNow(time.Now)
+}
+
+func newMetricsObserverWithNow(now func() time.Time) *MetricsObserver {
+	observer := &MetricsObserver{
+		now:             now,
+		topN:            defaultViewStateMaxAgeTopN,
+		states:          make(map[metricViewKey]metricViewState),
+		shards:          make(map[metricShardKey]*metricShardState),
+		topK:            make(map[string]*viewStateAgeHeap),
+		topKValidCounts: make(map[string]int),
+	}
+	metrics.SetQVViewStateMaxAgeProvider(observer.collectViewStateMaxAge)
+	return observer
+}
+
+func (o *MetricsObserver) collectViewStateMaxAge() []metrics.QVViewStateMaxAgeMetric {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	now := o.now()
+	components := make([]string, 0, len(o.topK))
+	for component := range o.topK {
+		components = append(components, component)
+	}
+	sort.Strings(components)
+
+	result := make([]metrics.QVViewStateMaxAgeMetric, 0, len(components)*o.topN)
+	for _, component := range components {
+		h := o.topK[component]
+		selected := make([]viewStateAgeCandidate, 0, o.topN)
+		for h.Len() > 0 && len(selected) < o.topN {
+			candidate := heap.Pop(h).(viewStateAgeCandidate)
+			state, ok := o.states[candidate.key]
+			if !ok || state.version != candidate.version || !isMaxAgeCandidateState(state.state) {
+				continue
+			}
+			selected = append(selected, candidate)
+			result = append(result, metricFromViewState(candidate.key, state, len(selected), now))
+		}
+		for _, candidate := range selected {
+			heap.Push(h, candidate)
+		}
+		if h.Len() == 0 {
+			delete(o.topK, component)
+		}
+	}
+	return result
+}
+
+func (o *MetricsObserver) Observe(_ context.Context, event Event) {
+	component := event.ComponentInfo()
+	if component == "" {
+		return
+	}
+	if created, ok := event.(CoordViewCreatedEvent); ok {
+		o.setState(component, created.CollectionID, created.View, created.State)
+		return
+	}
+	if persisted, ok := event.(CoordPersistViewEvent); ok && persisted.State == qviews.QueryViewStateDropped {
+		o.deleteState(component, persisted.View)
+	}
+
+	transition, ok := metricTransition(event)
+	if !ok {
+		return
+	}
+	trigger := event.TriggerInfo()
+	if trigger == "" {
+		return
+	}
+	metrics.QVViewTransitionTotal.WithLabelValues(
+		component,
+		transition.From.String(),
+		transition.To.String(),
+		trigger,
+	).Inc()
+	if transition.To == qviews.QueryViewStateDropped {
+		o.deleteState(component, transition.View)
+		return
+	}
+	if reported, ok := event.(CoordViewReportAppliedEvent); ok {
+		o.moveStateWithReadyLe(
+			component,
+			transition.CollectionID,
+			transition.View,
+			transition.To,
+			readyPercentLe(reported.ResourceReadyPercent),
+		)
+		return
+	}
+	o.moveState(component, transition.CollectionID, transition.View, transition.To)
+}
+
+func (o *MetricsObserver) setState(component string, collectionID int64, view qviews.QueryViewKey, state qviews.QueryViewState) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	key := metricViewKey{component: component, view: view}
+	o.upsertStateLocked(key, collectionID, state, "")
+}
+
+func (o *MetricsObserver) moveState(component string, collectionID int64, view qviews.QueryViewKey, to qviews.QueryViewState) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	key := metricViewKey{component: component, view: view}
+	readyLe := ""
+	if old, ok := o.states[key]; ok {
+		if collectionID == 0 {
+			collectionID = old.collectionID
+		}
+		readyLe = old.readyLe
+	}
+	o.upsertStateLocked(key, collectionID, to, readyLe)
+}
+
+func (o *MetricsObserver) moveStateWithReadyLe(
+	component string,
+	collectionID int64,
+	view qviews.QueryViewKey,
+	to qviews.QueryViewState,
+	readyLe string,
+) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	key := metricViewKey{component: component, view: view}
+	if old, ok := o.states[key]; ok && collectionID == 0 {
+		collectionID = old.collectionID
+	}
+	o.upsertStateLocked(key, collectionID, to, readyLe)
+}
+
+func (o *MetricsObserver) upsertStateLocked(
+	key metricViewKey,
+	collectionID int64,
+	state qviews.QueryViewState,
+	readyLe string,
+) {
+	if old, ok := o.states[key]; ok {
+		metrics.QVViewStates.WithLabelValues(key.component, old.state.String()).Dec()
+		o.decReadyPercentBucket(key.component, old.state, old.readyLe)
+		o.removeShardState(key, old)
+		o.updateTopKValidCount(key.component, old.state, state)
+	} else if isMaxAgeCandidateState(state) {
+		o.topKValidCounts[key.component]++
+	}
+	readyLe = normalizeReadyPercentLe(key.component, state, readyLe)
+
+	stateSnapshot := metricViewState{
+		collectionID: collectionID,
+		state:        state,
+		enteredAt:    o.now(),
+		version:      o.nextVersion(),
+		readyLe:      readyLe,
+	}
+	o.states[key] = stateSnapshot
+	o.addShardState(key, stateSnapshot)
+	o.cleanupShardState(key)
+	o.pushTopKCandidate(key, stateSnapshot)
+	o.compactTopKCandidates(key.component)
+	metrics.QVViewStates.WithLabelValues(key.component, state.String()).Inc()
+	o.incReadyPercentBucket(key.component, state, readyLe)
+}
+
+func (o *MetricsObserver) deleteState(component string, view qviews.QueryViewKey) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	key := metricViewKey{component: component, view: view}
+	old, ok := o.states[key]
+	if !ok {
+		return
+	}
+	delete(o.states, key)
+	o.removeShardState(key, old)
+	o.cleanupShardState(key)
+	if isMaxAgeCandidateState(old.state) {
+		o.topKValidCounts[component]--
+		if o.topKValidCounts[component] <= 0 {
+			delete(o.topKValidCounts, component)
+		}
+	}
+	o.decReadyPercentBucket(component, old.state, old.readyLe)
+	o.compactTopKCandidates(component)
+	metrics.QVViewStates.WithLabelValues(component, old.state.String()).Dec()
+}
+
+func (o *MetricsObserver) nextVersion() uint64 {
+	o.nextID++
+	return o.nextID
+}
+
+func (o *MetricsObserver) pushTopKCandidate(key metricViewKey, state metricViewState) {
+	if !isMaxAgeCandidateState(state.state) {
+		return
+	}
+	h, ok := o.topK[key.component]
+	if !ok {
+		h = &viewStateAgeHeap{}
+		heap.Init(h)
+		o.topK[key.component] = h
+	}
+	heap.Push(h, viewStateAgeCandidate{
+		key:       key,
+		enteredAt: state.enteredAt,
+		version:   state.version,
+	})
+}
+
+func (o *MetricsObserver) rebuildTopK(component string) {
+	h := &viewStateAgeHeap{}
+	validCount := 0
+	for key, state := range o.states {
+		if key.component != component || !isMaxAgeCandidateState(state.state) {
+			continue
+		}
+		validCount++
+		*h = append(*h, viewStateAgeCandidate{
+			key:       key,
+			enteredAt: state.enteredAt,
+			version:   state.version,
+		})
+	}
+	if validCount == 0 {
+		delete(o.topK, component)
+		delete(o.topKValidCounts, component)
+		return
+	}
+	heap.Init(h)
+	o.topK[component] = h
+	o.topKValidCounts[component] = validCount
+}
+
+func (o *MetricsObserver) updateTopKValidCount(component string, from, to qviews.QueryViewState) {
+	if isMaxAgeCandidateState(from) == isMaxAgeCandidateState(to) {
+		return
+	}
+	if isMaxAgeCandidateState(to) {
+		o.topKValidCounts[component]++
+		return
+	}
+	o.topKValidCounts[component]--
+	if o.topKValidCounts[component] <= 0 {
+		delete(o.topKValidCounts, component)
+	}
+}
+
+func (o *MetricsObserver) compactTopKCandidates(component string) {
+	h, ok := o.topK[component]
+	if !ok {
+		return
+	}
+	validCount := o.topKValidCounts[component]
+	if validCount == 0 {
+		delete(o.topK, component)
+		return
+	}
+	if h.Len() > validCount*4+o.topN {
+		o.rebuildTopK(component)
+	}
+}
+
+func isMaxAgeCandidateState(state qviews.QueryViewState) bool {
+	return state != qviews.QueryViewStateUp && state != qviews.QueryViewStateDropped
+}
+
+func (o *MetricsObserver) addShardState(key metricViewKey, state metricViewState) {
+	shardKey, ok := newMetricShardKey(key)
+	if !ok {
+		return
+	}
+	if !isShardLoadCandidateState(state.state) {
+		return
+	}
+	shardState := o.getShardState(shardKey)
+	oldState := shardState.currentState
+	shardState.activeCount++
+	if state.state == qviews.QueryViewStateUp {
+		shardState.upCount++
+		shardState.hasLoaded = true
+	}
+	o.updateShardLoadStateMetric(shardState, oldState)
+}
+
+func (o *MetricsObserver) removeShardState(key metricViewKey, state metricViewState) {
+	shardKey, ok := newMetricShardKey(key)
+	if !ok {
+		return
+	}
+	shardState, ok := o.shards[shardKey]
+	if !ok {
+		return
+	}
+	if !isShardLoadCandidateState(state.state) {
+		return
+	}
+	oldState := shardState.currentState
+	shardState.activeCount--
+	if state.state == qviews.QueryViewStateUp {
+		shardState.upCount--
+	}
+	o.updateShardLoadStateMetric(shardState, oldState)
+}
+
+func (o *MetricsObserver) getShardState(key metricShardKey) *metricShardState {
+	state, ok := o.shards[key]
+	if ok {
+		return state
+	}
+	state = &metricShardState{}
+	o.shards[key] = state
+	return state
+}
+
+func (o *MetricsObserver) updateShardLoadStateMetric(state *metricShardState, oldState string) {
+	newState := state.loadState()
+	if oldState == newState {
+		return
+	}
+	if oldState != "" {
+		metrics.QVShardLoadStates.WithLabelValues(oldState).Dec()
+	}
+	if newState != "" {
+		metrics.QVShardLoadStates.WithLabelValues(newState).Inc()
+	}
+	state.currentState = newState
+}
+
+func (s *metricShardState) loadState() string {
+	if s.activeCount <= 0 {
+		return ""
+	}
+	if s.upCount > 0 {
+		return shardLoadStateLoaded
+	}
+	if s.hasLoaded {
+		return shardLoadStateRecovering
+	}
+	return shardLoadStateLoading
+}
+
+func newMetricShardKey(key metricViewKey) (metricShardKey, bool) {
+	if key.component != "coord" {
+		return metricShardKey{}, false
+	}
+	return metricShardKey{
+		component: key.component,
+		shard:     key.view.ShardID,
+	}, true
+}
+
+func (o *MetricsObserver) cleanupShardState(key metricViewKey) {
+	shardKey, ok := newMetricShardKey(key)
+	if !ok {
+		return
+	}
+	shardState, ok := o.shards[shardKey]
+	if !ok {
+		return
+	}
+	if shardState.activeCount <= 0 && shardState.currentState == "" {
+		delete(o.shards, shardKey)
+	}
+}
+
+func isShardLoadCandidateState(state qviews.QueryViewState) bool {
+	switch state {
+	case qviews.QueryViewStatePreparing, qviews.QueryViewStateReady, qviews.QueryViewStateUp, qviews.QueryViewStateUnrecoverable:
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeReadyPercentLe(component string, state qviews.QueryViewState, le string) string {
+	if component != "coord" || !isReadyPercentCandidateState(state) {
+		return ""
+	}
+	if le == "" {
+		return readyPercentLe0
+	}
+	return le
+}
+
+func isReadyPercentCandidateState(state qviews.QueryViewState) bool {
+	return state != qviews.QueryViewStateUp && state != qviews.QueryViewStateDropped
+}
+
+func readyPercentLe(percent int64) string {
+	switch {
+	case percent < 0:
+		return ""
+	case percent == 0:
+		return readyPercentLe0
+	case percent <= 25:
+		return readyPercentLe25
+	case percent <= 50:
+		return readyPercentLe50
+	case percent <= 75:
+		return readyPercentLe75
+	case percent <= 90:
+		return readyPercentLe90
+	case percent < 100:
+		return readyPercentLe99
+	default:
+		return readyPercentLe100
+	}
+}
+
+func (o *MetricsObserver) incReadyPercentBucket(component string, state qviews.QueryViewState, le string) {
+	idx := readyPercentLeIndex(le)
+	if idx < 0 {
+		return
+	}
+	for _, upperBound := range readyPercentLeBounds[idx:] {
+		metrics.QVViewReadyPercentBucket.WithLabelValues(component, state.String(), upperBound).Inc()
+	}
+}
+
+func (o *MetricsObserver) decReadyPercentBucket(component string, state qviews.QueryViewState, le string) {
+	idx := readyPercentLeIndex(le)
+	if idx < 0 {
+		return
+	}
+	for _, upperBound := range readyPercentLeBounds[idx:] {
+		metrics.QVViewReadyPercentBucket.WithLabelValues(component, state.String(), upperBound).Dec()
+	}
+}
+
+func readyPercentLeIndex(le string) int {
+	for idx, upperBound := range readyPercentLeBounds {
+		if upperBound == le {
+			return idx
+		}
+	}
+	return -1
+}
+
+func metricFromViewState(key metricViewKey, state metricViewState, rank int, now time.Time) metrics.QVViewStateMaxAgeMetric {
+	return metrics.QVViewStateMaxAgeMetric{
+		Component:        key.component,
+		State:            state.state.String(),
+		Rank:             strconv.Itoa(rank),
+		CollectionID:     strconv.FormatInt(state.collectionID, 10),
+		ReplicaID:        strconv.FormatInt(key.view.ShardID.ReplicaID, 10),
+		VChannel:         key.view.ShardID.VChannel,
+		QueryViewVersion: key.view.QueryViewVersion.String(),
+		DataVersion:      key.view.QueryViewVersion.DataVersion.String(),
+		AgeSeconds:       now.Sub(state.enteredAt).Seconds(),
+	}
+}
+
+func lessMetricViewKey(left, right metricViewKey) bool {
+	if left.component != right.component {
+		return left.component < right.component
+	}
+	if left.view.ShardID.ReplicaID != right.view.ShardID.ReplicaID {
+		return left.view.ShardID.ReplicaID < right.view.ShardID.ReplicaID
+	}
+	if left.view.ShardID.VChannel != right.view.ShardID.VChannel {
+		return left.view.ShardID.VChannel < right.view.ShardID.VChannel
+	}
+	leftDV := left.view.QueryViewVersion.DataVersion
+	rightDV := right.view.QueryViewVersion.DataVersion
+	if leftDV.StreamingVersion != rightDV.StreamingVersion {
+		return leftDV.StreamingVersion < rightDV.StreamingVersion
+	}
+	if leftDV.CompactVersion != rightDV.CompactVersion {
+		return leftDV.CompactVersion < rightDV.CompactVersion
+	}
+	return left.view.QueryViewVersion.QueryVersion < right.view.QueryViewVersion.QueryVersion
+}
+
+func metricTransition(event Event) (ViewStateTransition, bool) {
+	switch e := event.(type) {
+	case CoordViewPreemptedEvent:
+		return e.ViewStateTransition, true
+	case CoordViewAdvancedFromUnrecoverableEvent:
+		return e.ViewStateTransition, true
+	case CoordViewReleaseRequestedEvent:
+		return e.ViewStateTransition, true
+	case CoordViewHandoffToNewUpEvent:
+		return e.ViewStateTransition, true
+	case CoordViewReportAppliedEvent:
+		return e.ViewStateTransition, true
+	case CoordViewQueryNodeLostAppliedEvent:
+		return e.ViewStateTransition, true
+	case QueryNodeSegmentsReadyEvent:
+		return e.ViewStateTransition, true
+	case QueryNodeSegmentUnrecoverableEvent:
+		return e.ViewStateTransition, true
+	case QueryNodeReleaseDoneEvent:
+		return e.ViewStateTransition, true
+	case StreamingNodeResourceReadyEvent:
+		return e.ViewStateTransition, true
+	case StreamingNodeRecoveringDoneEvent:
+		return e.ViewStateTransition, true
+	case StreamingNodeReleaseDoneEvent:
+		return e.ViewStateTransition, true
+	default:
+		return ViewStateTransition{}, false
+	}
+}

--- a/internal/views/qviews/observe/metrics_observer_test.go
+++ b/internal/views/qviews/observe/metrics_observer_test.go
@@ -1,0 +1,552 @@
+package observe
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/milvus-io/milvus/internal/views/qviews"
+	"github.com/milvus-io/milvus/pkg/v3/metrics"
+)
+
+func TestMetricsObserverTracksCoordViewStates(t *testing.T) {
+	metrics.QVViewStates.Reset()
+	metrics.QVViewTransitionTotal.Reset()
+	observer := NewMetricsObserver()
+	view := testQueryViewKey()
+
+	observer.Observe(context.Background(), CoordViewCreatedEvent{
+		View:  view,
+		State: qviews.QueryViewStatePreparing,
+	})
+
+	assertGaugeValue(t, metrics.QVViewStates, 1, "coord", qviews.QueryViewStatePreparing.String())
+
+	observer.Observe(context.Background(), CoordViewReportAppliedEvent{
+		ViewStateTransition: ViewStateTransition{
+			View: view,
+			From: qviews.QueryViewStatePreparing,
+			To:   qviews.QueryViewStateReady,
+		},
+		ReportedState:        qviews.QueryViewStateReady,
+		ResourceReadyPercent: 100,
+	})
+
+	assertGaugeValue(t, metrics.QVViewStates, 0, "coord", qviews.QueryViewStatePreparing.String())
+	assertGaugeValue(t, metrics.QVViewStates, 1, "coord", qviews.QueryViewStateReady.String())
+}
+
+func TestMetricsObserverCountsCoordViewTransitions(t *testing.T) {
+	metrics.QVViewStates.Reset()
+	metrics.QVViewTransitionTotal.Reset()
+	observer := NewMetricsObserver()
+	view := testQueryViewKey()
+
+	observer.Observe(context.Background(), CoordViewReportAppliedEvent{
+		ViewStateTransition: ViewStateTransition{
+			View: view,
+			From: qviews.QueryViewStatePreparing,
+			To:   qviews.QueryViewStateReady,
+		},
+		ReportedState:        qviews.QueryViewStateReady,
+		ResourceReadyPercent: 100,
+	})
+
+	assertCounterValue(
+		t,
+		metrics.QVViewTransitionTotal,
+		1,
+		"coord",
+		qviews.QueryViewStatePreparing.String(),
+		qviews.QueryViewStateReady.String(),
+		"reportReady",
+	)
+}
+
+func TestMetricsObserverSeparatesStateTotalByComponent(t *testing.T) {
+	metrics.QVViewStates.Reset()
+	metrics.QVViewTransitionTotal.Reset()
+	observer := NewMetricsObserver()
+	view := testQueryViewKey()
+
+	observer.Observe(context.Background(), CoordViewCreatedEvent{
+		View:  view,
+		State: qviews.QueryViewStatePreparing,
+	})
+	observer.Observe(context.Background(), QueryNodeSegmentsReadyEvent{
+		ViewStateTransition: ViewStateTransition{
+			View: view,
+			From: qviews.QueryViewStatePreparing,
+			To:   qviews.QueryViewStateReady,
+		},
+		ReadySegmentCount: 10,
+	})
+
+	assertGaugeValue(t, metrics.QVViewStates, 1, "coord", qviews.QueryViewStatePreparing.String())
+	assertGaugeValue(t, metrics.QVViewStates, 1, "queryNode", qviews.QueryViewStateReady.String())
+}
+
+func TestMetricsObserverTracksCoordViewReadyPercentBuckets(t *testing.T) {
+	metrics.QVViewReadyPercentBucket.Reset()
+	observer := NewMetricsObserver()
+	view := testQueryViewKey()
+
+	observer.Observe(context.Background(), CoordViewCreatedEvent{
+		CollectionID: 10,
+		View:         view,
+		State:        qviews.QueryViewStatePreparing,
+	})
+	err := testutil.CollectAndCompare(
+		metrics.QVViewReadyPercentBucket,
+		strings.NewReader(`
+# HELP milvus_qv_view_ready_percent_bucket current number of QueryViews by resource readiness percent bucket
+# TYPE milvus_qv_view_ready_percent_bucket gauge
+milvus_qv_view_ready_percent_bucket{component="coord",le="+Inf",state="Preparing"} 1
+milvus_qv_view_ready_percent_bucket{component="coord",le="0",state="Preparing"} 1
+milvus_qv_view_ready_percent_bucket{component="coord",le="100",state="Preparing"} 1
+milvus_qv_view_ready_percent_bucket{component="coord",le="25",state="Preparing"} 1
+milvus_qv_view_ready_percent_bucket{component="coord",le="50",state="Preparing"} 1
+milvus_qv_view_ready_percent_bucket{component="coord",le="75",state="Preparing"} 1
+milvus_qv_view_ready_percent_bucket{component="coord",le="90",state="Preparing"} 1
+milvus_qv_view_ready_percent_bucket{component="coord",le="99",state="Preparing"} 1
+`),
+		"milvus_qv_view_ready_percent_bucket",
+	)
+	if err != nil {
+		t.Fatalf("collect ready percent bucket before report: %v", err)
+	}
+
+	observer.Observe(context.Background(), CoordViewReportAppliedEvent{
+		ViewStateTransition: ViewStateTransition{
+			CollectionID: 10,
+			View:         view,
+			From:         qviews.QueryViewStatePreparing,
+			To:           qviews.QueryViewStatePreparing,
+		},
+		ReportedState:        qviews.QueryViewStatePreparing,
+		ResourceReadyPercent: 42,
+	})
+	err = testutil.CollectAndCompare(
+		metrics.QVViewReadyPercentBucket,
+		strings.NewReader(`
+# HELP milvus_qv_view_ready_percent_bucket current number of QueryViews by resource readiness percent bucket
+# TYPE milvus_qv_view_ready_percent_bucket gauge
+milvus_qv_view_ready_percent_bucket{component="coord",le="+Inf",state="Preparing"} 1
+milvus_qv_view_ready_percent_bucket{component="coord",le="0",state="Preparing"} 0
+milvus_qv_view_ready_percent_bucket{component="coord",le="100",state="Preparing"} 1
+milvus_qv_view_ready_percent_bucket{component="coord",le="25",state="Preparing"} 0
+milvus_qv_view_ready_percent_bucket{component="coord",le="50",state="Preparing"} 1
+milvus_qv_view_ready_percent_bucket{component="coord",le="75",state="Preparing"} 1
+milvus_qv_view_ready_percent_bucket{component="coord",le="90",state="Preparing"} 1
+milvus_qv_view_ready_percent_bucket{component="coord",le="99",state="Preparing"} 1
+`),
+		"milvus_qv_view_ready_percent_bucket",
+	)
+	if err != nil {
+		t.Fatalf("collect ready percent bucket after report: %v", err)
+	}
+	assertGaugeValue(t, metrics.QVViewReadyPercentBucket, 0, "coord", qviews.QueryViewStatePreparing.String(), "0")
+	assertGaugeValue(t, metrics.QVViewReadyPercentBucket, 0, "coord", qviews.QueryViewStatePreparing.String(), "25")
+	assertGaugeValue(t, metrics.QVViewReadyPercentBucket, 1, "coord", qviews.QueryViewStatePreparing.String(), "50")
+
+	observer.Observe(context.Background(), CoordViewReportAppliedEvent{
+		ViewStateTransition: ViewStateTransition{
+			CollectionID: 10,
+			View:         view,
+			From:         qviews.QueryViewStatePreparing,
+			To:           qviews.QueryViewStateReady,
+		},
+		ReportedState:        qviews.QueryViewStateReady,
+		ResourceReadyPercent: 100,
+	})
+	assertGaugeValue(t, metrics.QVViewReadyPercentBucket, 0, "coord", qviews.QueryViewStatePreparing.String(), "50")
+	assertGaugeValue(t, metrics.QVViewReadyPercentBucket, 0, "coord", qviews.QueryViewStateReady.String(), "99")
+	assertGaugeValue(t, metrics.QVViewReadyPercentBucket, 1, "coord", qviews.QueryViewStateReady.String(), "100")
+	assertGaugeValue(t, metrics.QVViewReadyPercentBucket, 1, "coord", qviews.QueryViewStateReady.String(), "+Inf")
+
+	observer.Observe(context.Background(), CoordViewReportAppliedEvent{
+		ViewStateTransition: ViewStateTransition{
+			CollectionID: 10,
+			View:         view,
+			From:         qviews.QueryViewStateReady,
+			To:           qviews.QueryViewStateUp,
+		},
+		ReportedState:        qviews.QueryViewStateUp,
+		ResourceReadyPercent: 100,
+	})
+	assertGaugeValue(t, metrics.QVViewReadyPercentBucket, 0, "coord", qviews.QueryViewStateReady.String(), "100")
+	assertGaugeValue(t, metrics.QVViewReadyPercentBucket, 0, "coord", qviews.QueryViewStateReady.String(), "+Inf")
+}
+
+func TestMetricsObserverTracksShardLoadState(t *testing.T) {
+	metrics.QVShardLoadStates.Reset()
+	observer := NewMetricsObserver()
+	view := testQueryViewKey()
+
+	observer.Observe(context.Background(), CoordViewCreatedEvent{
+		CollectionID: 10,
+		View:         view,
+		State:        qviews.QueryViewStatePreparing,
+	})
+	assertGaugeValue(t, metrics.QVShardLoadStates, 1, shardLoadStateLoading)
+
+	observer.Observe(context.Background(), CoordViewReportAppliedEvent{
+		ViewStateTransition: ViewStateTransition{
+			CollectionID: 10,
+			View:         view,
+			From:         qviews.QueryViewStatePreparing,
+			To:           qviews.QueryViewStateUp,
+		},
+		ReportedState:        qviews.QueryViewStateUp,
+		ResourceReadyPercent: 100,
+	})
+	assertGaugeValue(t, metrics.QVShardLoadStates, 0, shardLoadStateLoading)
+	assertGaugeValue(t, metrics.QVShardLoadStates, 1, shardLoadStateLoaded)
+
+	nextView := testQueryViewKey()
+	nextView.QueryViewVersion.QueryVersion++
+	observer.Observe(context.Background(), CoordViewCreatedEvent{
+		CollectionID: 10,
+		View:         nextView,
+		State:        qviews.QueryViewStatePreparing,
+	})
+	assertGaugeValue(t, metrics.QVShardLoadStates, 0, shardLoadStateLoading)
+	assertGaugeValue(t, metrics.QVShardLoadStates, 1, shardLoadStateLoaded)
+
+	observer.Observe(context.Background(), CoordViewQueryNodeLostAppliedEvent{
+		ViewStateTransition: ViewStateTransition{
+			CollectionID: 10,
+			View:         view,
+			From:         qviews.QueryViewStateUp,
+			To:           qviews.QueryViewStateUnrecoverable,
+		},
+	})
+	assertGaugeValue(t, metrics.QVShardLoadStates, 0, shardLoadStateLoaded)
+	assertGaugeValue(t, metrics.QVShardLoadStates, 1, shardLoadStateRecovering)
+
+	observer.Observe(context.Background(), CoordViewReleaseRequestedEvent{
+		ViewStateTransition: ViewStateTransition{
+			CollectionID: 10,
+			View:         view,
+			From:         qviews.QueryViewStateUnrecoverable,
+			To:           qviews.QueryViewStateDropping,
+		},
+	})
+	assertGaugeValue(t, metrics.QVShardLoadStates, 1, shardLoadStateRecovering)
+
+	observer.Observe(context.Background(), CoordViewReleaseRequestedEvent{
+		ViewStateTransition: ViewStateTransition{
+			CollectionID: 10,
+			View:         nextView,
+			From:         qviews.QueryViewStatePreparing,
+			To:           qviews.QueryViewStateDropping,
+		},
+	})
+	assertGaugeValue(t, metrics.QVShardLoadStates, 0, shardLoadStateRecovering)
+
+	observer.Observe(context.Background(), CoordViewReportAppliedEvent{
+		ViewStateTransition: ViewStateTransition{
+			CollectionID: 10,
+			View:         view,
+			From:         qviews.QueryViewStateDropping,
+			To:           qviews.QueryViewStateDropped,
+		},
+		ReportedState:        qviews.QueryViewStateDropped,
+		ResourceReadyPercent: 100,
+	})
+	assertGaugeValue(t, metrics.QVShardLoadStates, 0, shardLoadStateRecovering)
+
+	observer.Observe(context.Background(), CoordViewReportAppliedEvent{
+		ViewStateTransition: ViewStateTransition{
+			CollectionID: 10,
+			View:         nextView,
+			From:         qviews.QueryViewStateDropping,
+			To:           qviews.QueryViewStateDropped,
+		},
+		ReportedState:        qviews.QueryViewStateDropped,
+		ResourceReadyPercent: 100,
+	})
+	assertGaugeValue(t, metrics.QVShardLoadStates, 0, shardLoadStateRecovering)
+
+	reloadedView := testQueryViewKey()
+	reloadedView.QueryViewVersion.QueryVersion += 2
+	observer.Observe(context.Background(), CoordViewCreatedEvent{
+		CollectionID: 10,
+		View:         reloadedView,
+		State:        qviews.QueryViewStatePreparing,
+	})
+	assertGaugeValue(t, metrics.QVShardLoadStates, 1, shardLoadStateLoading)
+	assertGaugeValue(t, metrics.QVShardLoadStates, 0, shardLoadStateRecovering)
+}
+
+func TestMetricsObserverIgnoresWorkerShardLoadState(t *testing.T) {
+	metrics.QVShardLoadStates.Reset()
+	observer := NewMetricsObserver()
+	view := testQueryViewKey()
+
+	observer.Observe(context.Background(), QueryNodeSegmentsReadyEvent{
+		ViewStateTransition: ViewStateTransition{
+			CollectionID: 12,
+			View:         view,
+			From:         qviews.QueryViewStatePreparing,
+			To:           qviews.QueryViewStateUp,
+		},
+		ReadySegmentCount: 10,
+	})
+
+	assertGaugeValue(t, metrics.QVShardLoadStates, 0, shardLoadStateLoaded)
+}
+
+func TestMetricsObserverCollectsViewStateMaxAgeSeconds(t *testing.T) {
+	now := time.Unix(100, 0)
+	observer := newMetricsObserverWithNow(func() time.Time {
+		return now
+	})
+	view := testQueryViewKey()
+
+	observer.Observe(context.Background(), CoordViewCreatedEvent{
+		CollectionID: 10,
+		View:         view,
+		State:        qviews.QueryViewStatePreparing,
+	})
+	now = now.Add(10 * time.Second)
+	observer.Observe(context.Background(), CoordViewReportAppliedEvent{
+		ViewStateTransition: ViewStateTransition{
+			CollectionID: 10,
+			View:         view,
+			From:         qviews.QueryViewStatePreparing,
+			To:           qviews.QueryViewStateReady,
+		},
+		ReportedState:        qviews.QueryViewStateReady,
+		ResourceReadyPercent: 100,
+	})
+	now = now.Add(5 * time.Second)
+	observer.Observe(context.Background(), CoordViewReportAppliedEvent{
+		ViewStateTransition: ViewStateTransition{
+			CollectionID: 10,
+			View:         view,
+			From:         qviews.QueryViewStateReady,
+			To:           qviews.QueryViewStateUp,
+		},
+		ReportedState:        qviews.QueryViewStateUp,
+		ResourceReadyPercent: 100,
+	})
+	now = now.Add(20 * time.Second)
+
+	err := testutil.CollectAndCompare(
+		metrics.QVViewStateMaxAgeSeconds,
+		strings.NewReader(`
+# HELP milvus_qv_view_state_max_age_seconds top QueryViews by active state age in seconds
+# TYPE milvus_qv_view_state_max_age_seconds gauge
+`),
+		"milvus_qv_view_state_max_age_seconds",
+	)
+	if err != nil {
+		t.Fatalf("collect max age metric: %v", err)
+	}
+
+	anotherView := testQueryViewKey()
+	anotherView.QueryViewVersion.QueryVersion++
+	observer.Observe(context.Background(), CoordViewCreatedEvent{
+		CollectionID: 11,
+		View:         anotherView,
+		State:        qviews.QueryViewStatePreparing,
+	})
+	now = now.Add(30 * time.Second)
+
+	err = testutil.CollectAndCompare(
+		metrics.QVViewStateMaxAgeSeconds,
+		strings.NewReader(`
+# HELP milvus_qv_view_state_max_age_seconds top QueryViews by active state age in seconds
+# TYPE milvus_qv_view_state_max_age_seconds gauge
+milvus_qv_view_state_max_age_seconds{collection_id="11",component="coord",data_version="10/20",query_view_version="10/20/4",rank="1",replica_id="1",state="Preparing",vchannel="v1"} 30
+`),
+		"milvus_qv_view_state_max_age_seconds",
+	)
+	if err != nil {
+		t.Fatalf("collect max age metric: %v", err)
+	}
+}
+
+func TestMetricsObserverLimitsViewStateMaxAgeSecondsToTopNPerComponent(t *testing.T) {
+	now := time.Unix(100, 0)
+	observer := newMetricsObserverWithNow(func() time.Time {
+		return now
+	})
+
+	for i := 0; i < defaultViewStateMaxAgeTopN+1; i++ {
+		view := testQueryViewKey()
+		view.ShardID.ReplicaID = int64(i + 1)
+		view.QueryViewVersion.QueryVersion = int64(i + 1)
+		observer.Observe(context.Background(), CoordViewCreatedEvent{
+			CollectionID: int64(100 + i),
+			View:         view,
+			State:        qviews.QueryViewStatePreparing,
+		})
+		now = now.Add(time.Second)
+	}
+	for i := 0; i < defaultViewStateMaxAgeTopN+1; i++ {
+		view := testQueryViewKey()
+		view.ShardID.ReplicaID = int64(i + 11)
+		view.QueryViewVersion.QueryVersion = int64(i + 11)
+		observer.Observe(context.Background(), QueryNodeSegmentsReadyEvent{
+			ViewStateTransition: ViewStateTransition{
+				CollectionID: int64(200 + i),
+				View:         view,
+				From:         qviews.QueryViewStatePreparing,
+				To:           qviews.QueryViewStateReady,
+			},
+			ReadySegmentCount: 10,
+		})
+		now = now.Add(time.Second)
+	}
+	now = now.Add(10 * time.Second)
+
+	metrics := observer.collectViewStateMaxAge()
+	want := defaultViewStateMaxAgeTopN * 2
+	if len(metrics) != want {
+		t.Fatalf("topN metric count = %d, want %d", len(metrics), want)
+	}
+	if metrics[0].Component != "coord" || metrics[0].ReplicaID != "1" || metrics[0].Rank != "1" {
+		t.Fatalf("first coord topN metric = %#v, want oldest coord replica with rank 1", metrics[0])
+	}
+	if metrics[defaultViewStateMaxAgeTopN-1].Component != "coord" || metrics[defaultViewStateMaxAgeTopN-1].ReplicaID != "5" || metrics[defaultViewStateMaxAgeTopN-1].Rank != "5" {
+		t.Fatalf("last coord topN metric = %#v, want fifth oldest coord replica with rank 5", metrics[defaultViewStateMaxAgeTopN-1])
+	}
+	if metrics[defaultViewStateMaxAgeTopN].Component != "queryNode" || metrics[defaultViewStateMaxAgeTopN].ReplicaID != "11" || metrics[defaultViewStateMaxAgeTopN].Rank != "1" {
+		t.Fatalf("first queryNode topN metric = %#v, want oldest queryNode replica with rank 1", metrics[defaultViewStateMaxAgeTopN])
+	}
+	if metrics[len(metrics)-1].Component != "queryNode" || metrics[len(metrics)-1].ReplicaID != "15" || metrics[len(metrics)-1].Rank != "5" {
+		t.Fatalf("last queryNode topN metric = %#v, want fifth oldest queryNode replica with rank 5", metrics[len(metrics)-1])
+	}
+}
+
+func TestMetricsObserverRefreshesTopNCandidateOnStateMove(t *testing.T) {
+	now := time.Unix(100, 0)
+	observer := newMetricsObserverWithNow(func() time.Time {
+		return now
+	})
+	view := testQueryViewKey()
+
+	observer.Observe(context.Background(), CoordViewCreatedEvent{
+		CollectionID: 10,
+		View:         view,
+		State:        qviews.QueryViewStatePreparing,
+	})
+	now = now.Add(100 * time.Second)
+	observer.Observe(context.Background(), CoordViewReportAppliedEvent{
+		ViewStateTransition: ViewStateTransition{
+			CollectionID: 10,
+			View:         view,
+			From:         qviews.QueryViewStatePreparing,
+			To:           qviews.QueryViewStateReady,
+		},
+		ReportedState:        qviews.QueryViewStateReady,
+		ResourceReadyPercent: 100,
+	})
+	now = now.Add(3 * time.Second)
+
+	metrics := observer.collectViewStateMaxAge()
+	if len(metrics) != 1 {
+		t.Fatalf("topN metric count = %d, want 1", len(metrics))
+	}
+	if metrics[0].State != qviews.QueryViewStateReady.String() || metrics[0].AgeSeconds != 3 {
+		t.Fatalf("topN metric after state move = %#v, want Ready age 3", metrics[0])
+	}
+}
+
+func TestMetricsObserverCompactsTopNCandidatesWithoutScrape(t *testing.T) {
+	now := time.Unix(100, 0)
+	observer := newMetricsObserverWithNow(func() time.Time {
+		return now
+	})
+	observer.topN = 2
+
+	for i := 0; i < 20; i++ {
+		view := testQueryViewKey()
+		view.ShardID.ReplicaID = int64(i + 1)
+		view.QueryViewVersion.QueryVersion = int64(i + 1)
+		observer.Observe(context.Background(), CoordViewCreatedEvent{
+			CollectionID: int64(100 + i),
+			View:         view,
+			State:        qviews.QueryViewStatePreparing,
+		})
+	}
+
+	for i := 0; i < 20; i++ {
+		view := testQueryViewKey()
+		view.ShardID.ReplicaID = int64(i + 1)
+		view.QueryViewVersion.QueryVersion = int64(i + 1)
+		observer.Observe(context.Background(), CoordViewReportAppliedEvent{
+			ViewStateTransition: ViewStateTransition{
+				CollectionID: int64(100 + i),
+				View:         view,
+				From:         qviews.QueryViewStateReady,
+				To:           qviews.QueryViewStateUp,
+			},
+			ReportedState:        qviews.QueryViewStateUp,
+			ResourceReadyPercent: 100,
+		})
+	}
+
+	observer.mu.Lock()
+	defer observer.mu.Unlock()
+	if h, ok := observer.topK["coord"]; ok && h.Len() != 0 {
+		t.Fatalf("coord topN candidate heap len = %d, want compacted empty without scrape", h.Len())
+	}
+}
+
+func TestMetricsObserverDropsTerminalWorkerViewState(t *testing.T) {
+	metrics.QVViewStates.Reset()
+	metrics.QVViewTransitionTotal.Reset()
+	now := time.Unix(100, 0)
+	observer := newMetricsObserverWithNow(func() time.Time {
+		return now
+	})
+	view := testQueryViewKey()
+
+	observer.Observe(context.Background(), QueryNodeSegmentsReadyEvent{
+		ViewStateTransition: ViewStateTransition{
+			CollectionID: 12,
+			View:         view,
+			From:         qviews.QueryViewStatePreparing,
+			To:           qviews.QueryViewStateReady,
+		},
+		ReadySegmentCount: 10,
+	})
+	assertGaugeValue(t, metrics.QVViewStates, 1, "queryNode", qviews.QueryViewStateReady.String())
+
+	observer.Observe(context.Background(), QueryNodeReleaseDoneEvent{
+		ViewStateTransition: ViewStateTransition{
+			CollectionID: 12,
+			View:         view,
+			From:         qviews.QueryViewStateDropping,
+			To:           qviews.QueryViewStateDropped,
+		},
+	})
+
+	assertGaugeValue(t, metrics.QVViewStates, 0, "queryNode", qviews.QueryViewStateReady.String())
+	if got := observer.collectViewStateMaxAge(); len(got) != 0 {
+		t.Fatalf("topN metrics after dropped = %#v, want empty", got)
+	}
+}
+
+func assertGaugeValue(t *testing.T, collector *prometheus.GaugeVec, expected float64, labels ...string) {
+	t.Helper()
+	got := testutil.ToFloat64(collector.WithLabelValues(labels...))
+	if got != expected {
+		t.Fatalf("gauge labels %v = %v, want %v", labels, got, expected)
+	}
+}
+
+func assertCounterValue(t *testing.T, collector *prometheus.CounterVec, expected float64, labels ...string) {
+	t.Helper()
+	got := testutil.ToFloat64(collector.WithLabelValues(labels...))
+	if got != expected {
+		t.Fatalf("counter labels %v = %v, want %v", labels, got, expected)
+	}
+}

--- a/internal/views/qviews/observe/metrics_observer_test.go
+++ b/internal/views/qviews/observe/metrics_observer_test.go
@@ -2,7 +2,6 @@ package observe
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -24,7 +23,7 @@ func TestMetricsObserverTracksCoordViewStates(t *testing.T) {
 		State: qviews.QueryViewStatePreparing,
 	})
 
-	assertGaugeValue(t, metrics.QVViewStates, 1, "coord", qviews.QueryViewStatePreparing.String())
+	assertGaugeValue(t, metrics.QVViewStates, 1, "coord", viewStateLabel(qviews.QueryViewStatePreparing))
 
 	observer.Observe(context.Background(), CoordViewReportAppliedEvent{
 		ViewStateTransition: ViewStateTransition{
@@ -32,12 +31,11 @@ func TestMetricsObserverTracksCoordViewStates(t *testing.T) {
 			From: qviews.QueryViewStatePreparing,
 			To:   qviews.QueryViewStateReady,
 		},
-		ReportedState:        qviews.QueryViewStateReady,
-		ResourceReadyPercent: 100,
+		ReportedState: qviews.QueryViewStateReady,
 	})
 
-	assertGaugeValue(t, metrics.QVViewStates, 0, "coord", qviews.QueryViewStatePreparing.String())
-	assertGaugeValue(t, metrics.QVViewStates, 1, "coord", qviews.QueryViewStateReady.String())
+	assertGaugeValue(t, metrics.QVViewStates, 0, "coord", viewStateLabel(qviews.QueryViewStatePreparing))
+	assertGaugeValue(t, metrics.QVViewStates, 1, "coord", viewStateLabel(qviews.QueryViewStateReady))
 }
 
 func TestMetricsObserverCountsCoordViewTransitions(t *testing.T) {
@@ -52,8 +50,7 @@ func TestMetricsObserverCountsCoordViewTransitions(t *testing.T) {
 			From: qviews.QueryViewStatePreparing,
 			To:   qviews.QueryViewStateReady,
 		},
-		ReportedState:        qviews.QueryViewStateReady,
-		ResourceReadyPercent: 100,
+		ReportedState: qviews.QueryViewStateReady,
 	})
 
 	assertCounterValue(
@@ -61,8 +58,8 @@ func TestMetricsObserverCountsCoordViewTransitions(t *testing.T) {
 		metrics.QVViewTransitionTotal,
 		1,
 		"coord",
-		qviews.QueryViewStatePreparing.String(),
-		qviews.QueryViewStateReady.String(),
+		viewStateLabel(qviews.QueryViewStatePreparing),
+		viewStateLabel(qviews.QueryViewStateReady),
 		"reportReady",
 	)
 }
@@ -86,100 +83,8 @@ func TestMetricsObserverSeparatesStateTotalByComponent(t *testing.T) {
 		ReadySegmentCount: 10,
 	})
 
-	assertGaugeValue(t, metrics.QVViewStates, 1, "coord", qviews.QueryViewStatePreparing.String())
-	assertGaugeValue(t, metrics.QVViewStates, 1, "queryNode", qviews.QueryViewStateReady.String())
-}
-
-func TestMetricsObserverTracksCoordViewReadyPercentBuckets(t *testing.T) {
-	metrics.QVViewReadyPercentBucket.Reset()
-	observer := NewMetricsObserver()
-	view := testQueryViewKey()
-
-	observer.Observe(context.Background(), CoordViewCreatedEvent{
-		CollectionID: 10,
-		View:         view,
-		State:        qviews.QueryViewStatePreparing,
-	})
-	err := testutil.CollectAndCompare(
-		metrics.QVViewReadyPercentBucket,
-		strings.NewReader(`
-# HELP milvus_qv_view_ready_percent_bucket current number of QueryViews by resource readiness percent bucket
-# TYPE milvus_qv_view_ready_percent_bucket gauge
-milvus_qv_view_ready_percent_bucket{component="coord",le="+Inf",state="Preparing"} 1
-milvus_qv_view_ready_percent_bucket{component="coord",le="0",state="Preparing"} 1
-milvus_qv_view_ready_percent_bucket{component="coord",le="100",state="Preparing"} 1
-milvus_qv_view_ready_percent_bucket{component="coord",le="25",state="Preparing"} 1
-milvus_qv_view_ready_percent_bucket{component="coord",le="50",state="Preparing"} 1
-milvus_qv_view_ready_percent_bucket{component="coord",le="75",state="Preparing"} 1
-milvus_qv_view_ready_percent_bucket{component="coord",le="90",state="Preparing"} 1
-milvus_qv_view_ready_percent_bucket{component="coord",le="99",state="Preparing"} 1
-`),
-		"milvus_qv_view_ready_percent_bucket",
-	)
-	if err != nil {
-		t.Fatalf("collect ready percent bucket before report: %v", err)
-	}
-
-	observer.Observe(context.Background(), CoordViewReportAppliedEvent{
-		ViewStateTransition: ViewStateTransition{
-			CollectionID: 10,
-			View:         view,
-			From:         qviews.QueryViewStatePreparing,
-			To:           qviews.QueryViewStatePreparing,
-		},
-		ReportedState:        qviews.QueryViewStatePreparing,
-		ResourceReadyPercent: 42,
-	})
-	err = testutil.CollectAndCompare(
-		metrics.QVViewReadyPercentBucket,
-		strings.NewReader(`
-# HELP milvus_qv_view_ready_percent_bucket current number of QueryViews by resource readiness percent bucket
-# TYPE milvus_qv_view_ready_percent_bucket gauge
-milvus_qv_view_ready_percent_bucket{component="coord",le="+Inf",state="Preparing"} 1
-milvus_qv_view_ready_percent_bucket{component="coord",le="0",state="Preparing"} 0
-milvus_qv_view_ready_percent_bucket{component="coord",le="100",state="Preparing"} 1
-milvus_qv_view_ready_percent_bucket{component="coord",le="25",state="Preparing"} 0
-milvus_qv_view_ready_percent_bucket{component="coord",le="50",state="Preparing"} 1
-milvus_qv_view_ready_percent_bucket{component="coord",le="75",state="Preparing"} 1
-milvus_qv_view_ready_percent_bucket{component="coord",le="90",state="Preparing"} 1
-milvus_qv_view_ready_percent_bucket{component="coord",le="99",state="Preparing"} 1
-`),
-		"milvus_qv_view_ready_percent_bucket",
-	)
-	if err != nil {
-		t.Fatalf("collect ready percent bucket after report: %v", err)
-	}
-	assertGaugeValue(t, metrics.QVViewReadyPercentBucket, 0, "coord", qviews.QueryViewStatePreparing.String(), "0")
-	assertGaugeValue(t, metrics.QVViewReadyPercentBucket, 0, "coord", qviews.QueryViewStatePreparing.String(), "25")
-	assertGaugeValue(t, metrics.QVViewReadyPercentBucket, 1, "coord", qviews.QueryViewStatePreparing.String(), "50")
-
-	observer.Observe(context.Background(), CoordViewReportAppliedEvent{
-		ViewStateTransition: ViewStateTransition{
-			CollectionID: 10,
-			View:         view,
-			From:         qviews.QueryViewStatePreparing,
-			To:           qviews.QueryViewStateReady,
-		},
-		ReportedState:        qviews.QueryViewStateReady,
-		ResourceReadyPercent: 100,
-	})
-	assertGaugeValue(t, metrics.QVViewReadyPercentBucket, 0, "coord", qviews.QueryViewStatePreparing.String(), "50")
-	assertGaugeValue(t, metrics.QVViewReadyPercentBucket, 0, "coord", qviews.QueryViewStateReady.String(), "99")
-	assertGaugeValue(t, metrics.QVViewReadyPercentBucket, 1, "coord", qviews.QueryViewStateReady.String(), "100")
-	assertGaugeValue(t, metrics.QVViewReadyPercentBucket, 1, "coord", qviews.QueryViewStateReady.String(), "+Inf")
-
-	observer.Observe(context.Background(), CoordViewReportAppliedEvent{
-		ViewStateTransition: ViewStateTransition{
-			CollectionID: 10,
-			View:         view,
-			From:         qviews.QueryViewStateReady,
-			To:           qviews.QueryViewStateUp,
-		},
-		ReportedState:        qviews.QueryViewStateUp,
-		ResourceReadyPercent: 100,
-	})
-	assertGaugeValue(t, metrics.QVViewReadyPercentBucket, 0, "coord", qviews.QueryViewStateReady.String(), "100")
-	assertGaugeValue(t, metrics.QVViewReadyPercentBucket, 0, "coord", qviews.QueryViewStateReady.String(), "+Inf")
+	assertGaugeValue(t, metrics.QVViewStates, 1, "coord", viewStateLabel(qviews.QueryViewStatePreparing))
+	assertGaugeValue(t, metrics.QVViewStates, 1, "queryNode", viewStateLabel(qviews.QueryViewStateReady))
 }
 
 func TestMetricsObserverTracksShardLoadState(t *testing.T) {
@@ -201,8 +106,7 @@ func TestMetricsObserverTracksShardLoadState(t *testing.T) {
 			From:         qviews.QueryViewStatePreparing,
 			To:           qviews.QueryViewStateUp,
 		},
-		ReportedState:        qviews.QueryViewStateUp,
-		ResourceReadyPercent: 100,
+		ReportedState: qviews.QueryViewStateUp,
 	})
 	assertGaugeValue(t, metrics.QVShardLoadStates, 0, shardLoadStateLoading)
 	assertGaugeValue(t, metrics.QVShardLoadStates, 1, shardLoadStateLoaded)
@@ -255,8 +159,7 @@ func TestMetricsObserverTracksShardLoadState(t *testing.T) {
 			From:         qviews.QueryViewStateDropping,
 			To:           qviews.QueryViewStateDropped,
 		},
-		ReportedState:        qviews.QueryViewStateDropped,
-		ResourceReadyPercent: 100,
+		ReportedState: qviews.QueryViewStateDropped,
 	})
 	assertGaugeValue(t, metrics.QVShardLoadStates, 0, shardLoadStateRecovering)
 
@@ -267,8 +170,7 @@ func TestMetricsObserverTracksShardLoadState(t *testing.T) {
 			From:         qviews.QueryViewStateDropping,
 			To:           qviews.QueryViewStateDropped,
 		},
-		ReportedState:        qviews.QueryViewStateDropped,
-		ResourceReadyPercent: 100,
+		ReportedState: qviews.QueryViewStateDropped,
 	})
 	assertGaugeValue(t, metrics.QVShardLoadStates, 0, shardLoadStateRecovering)
 
@@ -321,8 +223,7 @@ func TestMetricsObserverCollectsViewStateMaxAgeSeconds(t *testing.T) {
 			From:         qviews.QueryViewStatePreparing,
 			To:           qviews.QueryViewStateReady,
 		},
-		ReportedState:        qviews.QueryViewStateReady,
-		ResourceReadyPercent: 100,
+		ReportedState: qviews.QueryViewStateReady,
 	})
 	now = now.Add(5 * time.Second)
 	observer.Observe(context.Background(), CoordViewReportAppliedEvent{
@@ -332,21 +233,13 @@ func TestMetricsObserverCollectsViewStateMaxAgeSeconds(t *testing.T) {
 			From:         qviews.QueryViewStateReady,
 			To:           qviews.QueryViewStateUp,
 		},
-		ReportedState:        qviews.QueryViewStateUp,
-		ResourceReadyPercent: 100,
+		ReportedState: qviews.QueryViewStateUp,
 	})
 	now = now.Add(20 * time.Second)
 
-	err := testutil.CollectAndCompare(
-		metrics.QVViewStateMaxAgeSeconds,
-		strings.NewReader(`
-# HELP milvus_qv_view_state_max_age_seconds top QueryViews by active state age in seconds
-# TYPE milvus_qv_view_state_max_age_seconds gauge
-`),
-		"milvus_qv_view_state_max_age_seconds",
-	)
-	if err != nil {
-		t.Fatalf("collect max age metric: %v", err)
+	// Up is not a max-age candidate, so nothing is reported yet.
+	if got := observer.collectViewStateMaxAge(); len(got) != 0 {
+		t.Fatalf("topN metrics while only Up = %#v, want empty", got)
 	}
 
 	anotherView := testQueryViewKey()
@@ -358,17 +251,16 @@ func TestMetricsObserverCollectsViewStateMaxAgeSeconds(t *testing.T) {
 	})
 	now = now.Add(30 * time.Second)
 
-	err = testutil.CollectAndCompare(
-		metrics.QVViewStateMaxAgeSeconds,
-		strings.NewReader(`
-# HELP milvus_qv_view_state_max_age_seconds top QueryViews by active state age in seconds
-# TYPE milvus_qv_view_state_max_age_seconds gauge
-milvus_qv_view_state_max_age_seconds{collection_id="11",component="coord",data_version="10/20",query_view_version="10/20/4",rank="1",replica_id="1",state="Preparing",vchannel="v1"} 30
-`),
-		"milvus_qv_view_state_max_age_seconds",
-	)
-	if err != nil {
-		t.Fatalf("collect max age metric: %v", err)
+	got := observer.collectViewStateMaxAge()
+	if len(got) != 1 {
+		t.Fatalf("topN metric count = %d, want 1", len(got))
+	}
+	metric := got[0]
+	if metric.Component != "coord" || metric.State != viewStateLabel(qviews.QueryViewStatePreparing) ||
+		metric.Rank != "1" || metric.CollectionID != "11" || metric.ReplicaID != "1" ||
+		metric.VChannel != "v1" || metric.QueryViewVersion != "10/20/4" ||
+		metric.DataVersion != "10/20" || metric.AgeSeconds != 30 {
+		t.Fatalf("topN metric = %#v, want coord preparing rank 1 collection 11 age 30", metric)
 	}
 }
 
@@ -445,8 +337,7 @@ func TestMetricsObserverRefreshesTopNCandidateOnStateMove(t *testing.T) {
 			From:         qviews.QueryViewStatePreparing,
 			To:           qviews.QueryViewStateReady,
 		},
-		ReportedState:        qviews.QueryViewStateReady,
-		ResourceReadyPercent: 100,
+		ReportedState: qviews.QueryViewStateReady,
 	})
 	now = now.Add(3 * time.Second)
 
@@ -454,7 +345,7 @@ func TestMetricsObserverRefreshesTopNCandidateOnStateMove(t *testing.T) {
 	if len(metrics) != 1 {
 		t.Fatalf("topN metric count = %d, want 1", len(metrics))
 	}
-	if metrics[0].State != qviews.QueryViewStateReady.String() || metrics[0].AgeSeconds != 3 {
+	if metrics[0].State != viewStateLabel(qviews.QueryViewStateReady) || metrics[0].AgeSeconds != 3 {
 		t.Fatalf("topN metric after state move = %#v, want Ready age 3", metrics[0])
 	}
 }
@@ -488,8 +379,7 @@ func TestMetricsObserverCompactsTopNCandidatesWithoutScrape(t *testing.T) {
 				From:         qviews.QueryViewStateReady,
 				To:           qviews.QueryViewStateUp,
 			},
-			ReportedState:        qviews.QueryViewStateUp,
-			ResourceReadyPercent: 100,
+			ReportedState: qviews.QueryViewStateUp,
 		})
 	}
 
@@ -518,7 +408,7 @@ func TestMetricsObserverDropsTerminalWorkerViewState(t *testing.T) {
 		},
 		ReadySegmentCount: 10,
 	})
-	assertGaugeValue(t, metrics.QVViewStates, 1, "queryNode", qviews.QueryViewStateReady.String())
+	assertGaugeValue(t, metrics.QVViewStates, 1, "queryNode", viewStateLabel(qviews.QueryViewStateReady))
 
 	observer.Observe(context.Background(), QueryNodeReleaseDoneEvent{
 		ViewStateTransition: ViewStateTransition{
@@ -529,10 +419,95 @@ func TestMetricsObserverDropsTerminalWorkerViewState(t *testing.T) {
 		},
 	})
 
-	assertGaugeValue(t, metrics.QVViewStates, 0, "queryNode", qviews.QueryViewStateReady.String())
+	assertGaugeValue(t, metrics.QVViewStates, 0, "queryNode", viewStateLabel(qviews.QueryViewStateReady))
 	if got := observer.collectViewStateMaxAge(); len(got) != 0 {
 		t.Fatalf("topN metrics after dropped = %#v, want empty", got)
 	}
+}
+
+func TestMetricsObserverNoOpTransitionPreservesAgeAndSkipsCounter(t *testing.T) {
+	metrics.QVViewTransitionTotal.Reset()
+	now := time.Unix(100, 0)
+	observer := newMetricsObserverWithNow(func() time.Time {
+		return now
+	})
+	view := testQueryViewKey()
+
+	observer.Observe(context.Background(), CoordViewCreatedEvent{
+		CollectionID: 10,
+		View:         view,
+		State:        qviews.QueryViewStatePreparing,
+	})
+	now = now.Add(10 * time.Second)
+
+	// A repeated report of the same state is a no-op: it must not reset the
+	// enteredAt clock (a stuck view keeps aging) nor count as a transition.
+	observer.Observe(context.Background(), CoordViewReportAppliedEvent{
+		ViewStateTransition: ViewStateTransition{
+			CollectionID: 10,
+			View:         view,
+			From:         qviews.QueryViewStatePreparing,
+			To:           qviews.QueryViewStatePreparing,
+		},
+		ReportedState: qviews.QueryViewStatePreparing,
+	})
+
+	got := observer.collectViewStateMaxAge()
+	if len(got) != 1 || got[0].AgeSeconds != 10 {
+		t.Fatalf("topN metrics after no-op report = %#v, want single Preparing entry aged 10s", got)
+	}
+	assertCounterValue(
+		t,
+		metrics.QVViewTransitionTotal,
+		0,
+		"coord",
+		viewStateLabel(qviews.QueryViewStatePreparing),
+		viewStateLabel(qviews.QueryViewStatePreparing),
+		"reportPreparing",
+	)
+}
+
+func TestMetricsObserverTracksWorkerAcquireAndApplyCoordView(t *testing.T) {
+	metrics.QVViewStates.Reset()
+	metrics.QVViewTransitionTotal.Reset()
+	observer := NewMetricsObserver()
+	view := testQueryViewKey()
+
+	// Acquire starts a Preparing entry for the worker view.
+	observer.Observe(context.Background(), QueryNodeAcquireSegmentsEvent{
+		CollectionID: 12,
+		View:         view,
+		SegmentCount: 5,
+	})
+	assertGaugeValue(t, metrics.QVViewStates, 1, "queryNode", viewStateLabel(qviews.QueryViewStatePreparing))
+
+	// The coord push applies the up view: Preparing -> Up with coordDelivered trigger.
+	observer.Observe(context.Background(), QueryNodeApplyCoordViewEvent{
+		ViewStateTransition: ViewStateTransition{
+			CollectionID: 12,
+			View:         view,
+			From:         qviews.QueryViewStatePreparing,
+			To:           qviews.QueryViewStateUp,
+		},
+	})
+	assertGaugeValue(t, metrics.QVViewStates, 0, "queryNode", viewStateLabel(qviews.QueryViewStatePreparing))
+	assertGaugeValue(t, metrics.QVViewStates, 1, "queryNode", viewStateLabel(qviews.QueryViewStateUp))
+	assertCounterValue(
+		t,
+		metrics.QVViewTransitionTotal,
+		1,
+		"queryNode",
+		viewStateLabel(qviews.QueryViewStatePreparing),
+		viewStateLabel(qviews.QueryViewStateUp),
+		"coordDelivered",
+	)
+
+	// StreamingNode acquire also starts a Preparing entry.
+	observer.Observe(context.Background(), StreamingNodeAcquireResourceEvent{
+		CollectionID: 13,
+		View:         view,
+	})
+	assertGaugeValue(t, metrics.QVViewStates, 1, "streamingNode", viewStateLabel(qviews.QueryViewStatePreparing))
 }
 
 func assertGaugeValue(t *testing.T, collector *prometheus.GaugeVec, expected float64, labels ...string) {

--- a/internal/views/qviews/observe/observer.go
+++ b/internal/views/qviews/observe/observer.go
@@ -1,0 +1,63 @@
+package observe
+
+import (
+	"context"
+	"sync"
+
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+)
+
+// Observer receives QueryView observability events from owner-layer code.
+type Observer interface {
+	Observe(context.Context, Event)
+}
+
+// Registry fanouts QueryView observability events to registered observers.
+type Registry struct {
+	mu        sync.RWMutex
+	observers []Observer
+}
+
+func NewRegistry(observers ...Observer) *Registry {
+	copied := make([]Observer, len(observers))
+	copy(copied, observers)
+	return &Registry{observers: copied}
+}
+
+func (r *Registry) Register(observer Observer) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.observers = append(r.observers, observer)
+}
+
+func (r *Registry) Observe(ctx context.Context, event Event) {
+	r.mu.RLock()
+	observers := make([]Observer, len(r.observers))
+	copy(observers, r.observers)
+	r.mu.RUnlock()
+
+	for _, observer := range observers {
+		observer.Observe(ctx, event)
+	}
+}
+
+var defaultRegistry = NewRegistry(LogObserver{}, NewMetricsObserver())
+
+func Register(observer Observer) {
+	defaultRegistry.Register(observer)
+}
+
+func Observe(ctx context.Context, event Event) {
+	defaultRegistry.Observe(ctx, event)
+}
+
+// LogObserver writes QueryView events to mlog.
+type LogObserver struct{}
+
+func (LogObserver) Observe(ctx context.Context, event Event) {
+	level := event.LogLevel()
+	if !mlog.LevelEnabled(level) {
+		return
+	}
+	mlog.Log(ctx, level, "query view event", FieldEvent(event))
+}

--- a/internal/views/qviews/observe/observer.go
+++ b/internal/views/qviews/observe/observer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 )
 
@@ -41,7 +42,17 @@ func (r *Registry) Observe(ctx context.Context, event Event) {
 	}
 }
 
-var defaultRegistry = NewRegistry(LogObserver{}, NewMetricsObserver())
+var (
+	defaultMetricsObserver = NewMetricsObserver()
+	defaultRegistry        = NewRegistry(LogObserver{}, defaultMetricsObserver)
+)
+
+// init wires the package-level metrics observer as the provider of the
+// qv_view_state_max_age_seconds collector exactly once. Constructing further
+// MetricsObserver instances must not replace the global provider.
+func init() {
+	metrics.SetQVViewStateMaxAgeProvider(defaultMetricsObserver.collectViewStateMaxAge)
+}
 
 func Register(observer Observer) {
 	defaultRegistry.Register(observer)

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -31,20 +31,26 @@ import (
 )
 
 func TestRegisterMetrics(t *testing.T) {
+	// Production registers exactly one role per process, each with its own
+	// registry. QV metrics are shared by the coord, QueryNode and StreamingNode
+	// roles, so registering all roles on one registry would duplicate them.
+	roles := []func(*prometheus.Registry){
+		RegisterMixCoord,
+		RegisterDataNode,
+		RegisterProxy,
+		RegisterQueryNode,
+		RegisterMetaMetrics,
+		RegisterStorageMetrics,
+		RegisterMsgStreamMetrics,
+		RegisterCGOMetrics,
+		RegisterStreamingServiceClient,
+		RegisterStreamingNode,
+		RegisterLoggingMetrics,
+	}
 	assert.NotPanics(t, func() {
-		r := prometheus.NewRegistry()
-		// Make sure it doesn't panic.
-		RegisterMixCoord(r)
-		RegisterDataNode(r)
-		RegisterProxy(r)
-		RegisterQueryNode(r)
-		RegisterMetaMetrics(r)
-		RegisterStorageMetrics(r)
-		RegisterMsgStreamMetrics(r)
-		RegisterCGOMetrics(r)
-		RegisterStreamingServiceClient(r)
-		RegisterStreamingNode(r)
-		RegisterLoggingMetrics(r)
+		for _, role := range roles {
+			role(prometheus.NewRegistry())
+		}
 	})
 }
 

--- a/pkg/metrics/querynode_metrics.go
+++ b/pkg/metrics/querynode_metrics.go
@@ -1091,6 +1091,7 @@ func RegisterQueryNode(registry *prometheus.Registry) {
 
 	RegisterStreamingServiceClient(registry)
 	RegisterLoggingMetrics(registry)
+	RegisterQV(registry)
 }
 
 // CleanupQueryNodeCollectionMetrics drops every query node series belonging to

--- a/pkg/metrics/qv_metrics.go
+++ b/pkg/metrics/qv_metrics.go
@@ -30,7 +30,6 @@ const (
 	QVFromStateLabel = "from_state"
 	QVToStateLabel   = "to_state"
 	QVTriggerLabel   = "trigger"
-	QVLeLabel        = "le"
 
 	QVRankLabel             = "rank"
 	QVCollectionIDLabel     = "collection_id"
@@ -137,18 +136,6 @@ var (
 			QVTriggerLabel,
 		})
 
-	QVViewReadyPercentBucket = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: milvusNamespace,
-			Subsystem: qvSubsystem,
-			Name:      "view_ready_percent_bucket",
-			Help:      "current number of QueryViews by resource readiness percent bucket",
-		}, []string{
-			QVComponentLabel,
-			QVStateLabel,
-			QVLeLabel,
-		})
-
 	QVShardLoadStates = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: milvusNamespace,
@@ -169,7 +156,6 @@ func SetQVViewStateMaxAgeProvider(provider func() []QVViewStateMaxAgeMetric) {
 func RegisterQV(registry *prometheus.Registry) {
 	registry.MustRegister(QVViewStates)
 	registry.MustRegister(QVViewTransitionTotal)
-	registry.MustRegister(QVViewReadyPercentBucket)
 	registry.MustRegister(QVShardLoadStates)
 	registry.MustRegister(QVViewStateMaxAgeSeconds)
 }

--- a/pkg/metrics/qv_metrics.go
+++ b/pkg/metrics/qv_metrics.go
@@ -1,0 +1,175 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	qvSubsystem = "qv"
+
+	QVComponentLabel = "component"
+	QVStateLabel     = "state"
+	QVFromStateLabel = "from_state"
+	QVToStateLabel   = "to_state"
+	QVTriggerLabel   = "trigger"
+	QVLeLabel        = "le"
+
+	QVRankLabel             = "rank"
+	QVCollectionIDLabel     = "collection_id"
+	QVReplicaIDLabel        = "replica_id"
+	QVVChannelLabel         = "vchannel"
+	QVQueryViewVersionLabel = "query_view_version"
+	QVDataVersionLabel      = "data_version"
+)
+
+type QVViewStateMaxAgeMetric struct {
+	Component        string
+	State            string
+	Rank             string
+	CollectionID     string
+	ReplicaID        string
+	VChannel         string
+	QueryViewVersion string
+	DataVersion      string
+	AgeSeconds       float64
+}
+
+type qvViewStateMaxAgeCollector struct {
+	mu       sync.RWMutex
+	provider func() []QVViewStateMaxAgeMetric
+	desc     *prometheus.Desc
+}
+
+func newQVViewStateMaxAgeCollector() *qvViewStateMaxAgeCollector {
+	return &qvViewStateMaxAgeCollector{
+		desc: prometheus.NewDesc(
+			prometheus.BuildFQName(milvusNamespace, qvSubsystem, "view_state_max_age_seconds"),
+			"top QueryViews by active state age in seconds",
+			[]string{
+				QVComponentLabel,
+				QVStateLabel,
+				QVRankLabel,
+				QVCollectionIDLabel,
+				QVReplicaIDLabel,
+				QVVChannelLabel,
+				QVQueryViewVersionLabel,
+				QVDataVersionLabel,
+			},
+			nil,
+		),
+	}
+}
+
+func (c *qvViewStateMaxAgeCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.desc
+}
+
+func (c *qvViewStateMaxAgeCollector) Collect(ch chan<- prometheus.Metric) {
+	c.mu.RLock()
+	provider := c.provider
+	c.mu.RUnlock()
+	if provider == nil {
+		return
+	}
+	for _, metric := range provider() {
+		ch <- prometheus.MustNewConstMetric(
+			c.desc,
+			prometheus.GaugeValue,
+			metric.AgeSeconds,
+			metric.Component,
+			metric.State,
+			metric.Rank,
+			metric.CollectionID,
+			metric.ReplicaID,
+			metric.VChannel,
+			metric.QueryViewVersion,
+			metric.DataVersion,
+		)
+	}
+}
+
+func (c *qvViewStateMaxAgeCollector) SetProvider(provider func() []QVViewStateMaxAgeMetric) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.provider = provider
+}
+
+var (
+	QVViewStates = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: qvSubsystem,
+			Name:      "view_states",
+			Help:      "current number of QueryViews by state",
+		}, []string{
+			QVComponentLabel,
+			QVStateLabel,
+		})
+
+	QVViewTransitionTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: milvusNamespace,
+			Subsystem: qvSubsystem,
+			Name:      "view_transition_total",
+			Help:      "total number of QueryView state transitions",
+		}, []string{
+			QVComponentLabel,
+			QVFromStateLabel,
+			QVToStateLabel,
+			QVTriggerLabel,
+		})
+
+	QVViewReadyPercentBucket = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: qvSubsystem,
+			Name:      "view_ready_percent_bucket",
+			Help:      "current number of QueryViews by resource readiness percent bucket",
+		}, []string{
+			QVComponentLabel,
+			QVStateLabel,
+			QVLeLabel,
+		})
+
+	QVShardLoadStates = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: qvSubsystem,
+			Name:      "shard_load_states",
+			Help:      "current number of Coord-visible QueryView shards by load lifecycle state",
+		}, []string{
+			QVStateLabel,
+		})
+
+	QVViewStateMaxAgeSeconds = newQVViewStateMaxAgeCollector()
+)
+
+func SetQVViewStateMaxAgeProvider(provider func() []QVViewStateMaxAgeMetric) {
+	QVViewStateMaxAgeSeconds.SetProvider(provider)
+}
+
+func RegisterQV(registry *prometheus.Registry) {
+	registry.MustRegister(QVViewStates)
+	registry.MustRegister(QVViewTransitionTotal)
+	registry.MustRegister(QVViewReadyPercentBucket)
+	registry.MustRegister(QVShardLoadStates)
+	registry.MustRegister(QVViewStateMaxAgeSeconds)
+}

--- a/pkg/metrics/rootcoord_metrics.go
+++ b/pkg/metrics/rootcoord_metrics.go
@@ -292,6 +292,7 @@ func RegisterMixCoord(registry *prometheus.Registry) {
 	RegisterQueryCoord(registry)
 	RegisterDataCoord(registry)
 	RegisterLoggingMetrics(registry)
+	RegisterQV(registry)
 }
 
 func CleanupRootCoordDBMetrics(dbName string) {

--- a/pkg/metrics/streaming_service_metrics.go
+++ b/pkg/metrics/streaming_service_metrics.go
@@ -646,6 +646,7 @@ func RegisterStreamingNode(registry *prometheus.Registry) {
 	// TODO: after remove the implementation of old data node
 	// Such as flowgraph and writebuffer, we can remove these metrics from streaming node.
 	RegisterDataNode(registry)
+	RegisterQV(registry)
 }
 
 // registerWAL registers wal metrics


### PR DESCRIPTION
issue: #40451

- qviews observability: observe query view lifecycle on coord, streaming node and query node, logging typed events for acquire/apply/ready/recover/persist/release/handoff/lost state transitions with structured fields
- qv metrics: expose `qv_*` Prometheus metrics for view state distribution, state transition counts (from/to/trigger), resource readiness percent, shard load lifecycle states and max view state age, registered into mix coord metrics