### PR TITLE
enhance: [3.0] accelerate C++ builds with scoped unity (#52917)

### DIFF
--- a/internal/core/CMakeLists.txt
+++ b/internal/core/CMakeLists.txt
@@ -115,13 +115,11 @@ set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
 # **************************** Project ****************************
 project( milvus VERSION "${MILVUS_VERSION}" )
 
-# Unity (jumbo) build: merge multiple .cpp files per target into fewer
-# translation units, dramatically reducing redundant header parsing.
+# Unity (jumbo) build is applied to Milvus-owned targets in src/CMakeLists.txt.
+# Do not set CMAKE_UNITY_BUILD globally: that also changes vendored dependency
+# targets such as Knowhere/FAISS, some of which are not unity-build compatible.
 if ( MILVUS_UNITY_BUILD )
-    set( CMAKE_UNITY_BUILD ON )
-    # ~8 sources per unity chunk is a good balance between speed and memory.
-    set( CMAKE_UNITY_BUILD_BATCH_SIZE 8 )
-    message( STATUS "Unity build enabled (batch size ${CMAKE_UNITY_BUILD_BATCH_SIZE})" )
+    message( STATUS "Unity build enabled for Milvus-owned targets" )
 endif ()
 
 set( CMAKE_CXX_STANDARD 20 )
@@ -203,7 +201,6 @@ find_package(Azure REQUIRED)
 include( CTest )
 include( BuildUtils )
 include( DefineOptions )
-using_ccache_if_defined(MILVUS_USE_CCACHE)
 
 include( ExternalProject )
 include( GNUInstallDirs )
@@ -396,7 +393,11 @@ ADD_DEFINITIONS(-DBOOST_GEOMETRY_INDEX_DETAIL_EXPERIMENTAL)
 
 # Warning: add_subdirectory(src) must be after append_flags("-ftest-coverage"),
 # otherwise cpp code coverage tool will miss src folder
+using_ccache_if_defined(MILVUS_USE_CCACHE)
 add_subdirectory( thirdparty )
+# Vendored projects may set global launch rules while they configure. Their
+# targets already retain the compiler launcher configured above.
+clear_global_ccache_launchers()
 add_subdirectory( src )
 
 # Unittest lib

--- a/internal/core/cmake/BuildUtils.cmake
+++ b/internal/core/cmake/BuildUtils.cmake
@@ -226,14 +226,25 @@ MACRO(using_ccache_if_defined MILVUS_USE_CCACHE)
         find_program(CCACHE_FOUND ccache)
         if (CCACHE_FOUND)
             message(STATUS "Using ccache: ${CCACHE_FOUND}")
-            set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_FOUND})
-            set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ${CCACHE_FOUND})
-            # let ccache preserve C++ comments, because some of them may be
-            # meaningful to the compiler
-            set(ENV{CCACHE_COMMENTS} "1")
+            set(_ccache_launcher
+                "${CMAKE_COMMAND};-E;env;CCACHE_COMMENTS=1;${CCACHE_FOUND}")
+            set(CMAKE_C_COMPILER_LAUNCHER "${_ccache_launcher}")
+            set(CMAKE_CXX_COMPILER_LAUNCHER "${_ccache_launcher}")
+
+            # PCH caching needs relaxed checks for state captured in the PCH.
+            # Keep those settings separate so only PCH-enabled targets use them.
+            set(MILVUS_PCH_CXX_COMPILER_LAUNCHER
+                "${CMAKE_COMMAND};-E;env;CCACHE_SLOPPINESS=pch_defines,time_macros,include_file_mtime,include_file_ctime;CCACHE_COMMENTS=1;${CCACHE_FOUND}")
+            unset(_ccache_launcher)
         else()
             message(WARNING "ccache not found!")
         endif()
     endif ()
 ENDMACRO(using_ccache_if_defined)
 
+MACRO(clear_global_ccache_launchers)
+    # Some vendored projects set these global properties while configuring.
+    # Targets already retain their compiler launcher; links should never use ccache.
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "")
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "")
+ENDMACRO(clear_global_ccache_launchers)

--- a/internal/core/src/CMakeLists.txt
+++ b/internal/core/src/CMakeLists.txt
@@ -114,6 +114,21 @@ add_subdirectory( minhash )
 
 milvus_add_pkg_config("milvus_core")
 
+# Keep unity builds scoped to first-party code. Enabling CMAKE_UNITY_BUILD
+# globally also changes vendored targets (notably Knowhere/FAISS), which contain
+# translation-unit-local symbols that collide when their sources are merged.
+# Protobuf-generated sources are not unity-compatible, while milvus_query was
+# slower in isolation because merging its ten sources reduced parallelism.
+if (MILVUS_UNITY_BUILD)
+    foreach(_target
+        milvus_common milvus_storage milvus_index milvus_segcore
+        milvus_exec)
+        set_target_properties(${_target} PROPERTIES
+            UNITY_BUILD ON
+            UNITY_BUILD_BATCH_SIZE 8)
+    endforeach()
+endif()
+
 # ---- Precompiled Headers (PCH) ----
 # Apply the same STL PCH to all OBJECT libraries. Each target generates its
 # own PCH binary (small per-target overhead) but avoids cross-directory
@@ -135,6 +150,10 @@ if (MILVUS_USE_PCH)
         milvus_exec milvus_futures milvus_rescores
         milvus_plan)
         target_precompile_headers(${_target} PRIVATE ${MILVUS_PCH_HEADERS})
+        if (MILVUS_PCH_CXX_COMPILER_LAUNCHER)
+            set_property(TARGET ${_target} PROPERTY
+                CXX_COMPILER_LAUNCHER "${MILVUS_PCH_CXX_COMPILER_LAUNCHER}")
+        endif()
     endforeach()
 endif()
 

--- a/internal/core/src/exec/CMakeLists.txt
+++ b/internal/core/src/exec/CMakeLists.txt
@@ -10,6 +10,16 @@
 # or implied. See the License for the specific language governing permissions and limitations under the License
 
 add_source_at_current_directory_recursively()
+
+# Keep the generated unity composition platform-independent. CMake excludes
+# sources with per-architecture flags automatically, but only on architectures
+# where those flags are attached.
+set_source_files_properties(
+    expression/SimdFilter.cpp
+    expression/SimdFilterAvx2.cpp
+    expression/SimdFilterAvx512.cpp
+    PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+
 add_library(milvus_exec OBJECT ${SOURCE_FILES})
 target_link_libraries(milvus_exec PUBLIC milvus_conan_deps)
 

--- a/internal/core/src/exec/Driver.cpp
+++ b/internal/core/src/exec/Driver.cpp
@@ -539,3 +539,5 @@ LocalPlanner::Plan(
 
 }  // namespace exec
 }  // namespace milvus
+
+#undef CALL_OPERATOR

--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
@@ -2708,3 +2708,7 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImpl<int64_t>(
 
 }  //namespace exec
 }  // namespace milvus
+
+#undef BinaryArithRangeJSONCompare
+#undef BinaryArithRangeJONCompareArrayLength
+#undef BinaryArithRangeArrayCompare

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
@@ -804,3 +804,7 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
 
 }  //namespace exec
 }  // namespace milvus
+
+#undef GEOMETRY_EXECUTE_SUB_BATCH_WITH_COMPARISON
+#undef GEOMETRY_EXECUTE_SUB_BATCH_WITH_COMPARISON_DISTANCE
+#undef GEOMETRY_EXECUTE_SUB_BATCH_UNARY

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -2508,3 +2508,5 @@ PhyUnaryRangeFilterExpr::PrefetchRawData() {
 
 }  // namespace exec
 }  // namespace milvus
+
+#undef UnaryRangeJSONCompare

--- a/internal/core/src/index/BitmapIndex.cpp
+++ b/internal/core/src/index/BitmapIndex.cpp
@@ -46,7 +46,7 @@
 namespace milvus {
 namespace index {
 
-constexpr size_t ALIGNMENT = 32;  // 32-byte alignment
+constexpr size_t BITMAP_INDEX_ALIGNMENT = 32;  // 32-byte alignment
 constexpr const char* BITMAP_INDEX_IS_NESTED = "is_nested_index";
 constexpr const char* BITMAP_INDEX_IS_NESTED_META = "is_nested";
 
@@ -591,8 +591,9 @@ BitmapIndex<T>::MMapIndexData(const std::string& file_name,
 
             // convert roaring vaule to frozen mode
             int32_t frozen_size = value.getFrozenSizeInBytes();
-            auto aligned_size =
-                ((frozen_size + ALIGNMENT - 1) / ALIGNMENT) * ALIGNMENT;
+            auto aligned_size = ((frozen_size + BITMAP_INDEX_ALIGNMENT - 1) /
+                                 BITMAP_INDEX_ALIGNMENT) *
+                                BITMAP_INDEX_ALIGNMENT;
             std::vector<uint8_t> buf(aligned_size, 0);
             value.writeFrozen(reinterpret_cast<char*>(buf.data()));
 

--- a/internal/core/src/index/CMakeLists.txt
+++ b/internal/core/src/index/CMakeLists.txt
@@ -10,5 +10,13 @@
 # or implied. See the License for the specific language governing permissions and limitations under the License
 
 add_source_at_current_directory_recursively()
+
+# These files intentionally define matching translation-unit-local helpers.
+# Keep them separate when the target uses unity builds.
+set_source_files_properties(
+    VectorDiskIndex.cpp
+    VectorMemIndex.cpp
+    PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+
 add_library(milvus_index OBJECT ${SOURCE_FILES})
 target_link_libraries(milvus_index PUBLIC milvus_conan_deps)

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -225,7 +225,7 @@ MarisaLegacyCsrBytes(int64_t num_rows, uint64_t arrays_per_row) {
 }
 
 std::string
-GetFileName(const std::string& path) {
+GetIndexFileBaseName(const std::string& path) {
     auto pos = path.find_last_of('/');
     return pos == std::string::npos ? path : path.substr(pos + 1);
 }
@@ -263,7 +263,7 @@ ResolveHybridInternalIndexType(
 
     auto index_type_file =
         std::find_if(index_files.begin(), index_files.end(), [](const auto& f) {
-            return GetFileName(f) == INDEX_TYPE;
+            return GetIndexFileBaseName(f) == INDEX_TYPE;
         });
     if (index_type_file != index_files.end()) {
         auto index_datas = file_manager.LoadIndexToMemory(

--- a/internal/core/src/index/InvertedIndexTantivy.h
+++ b/internal/core/src/index/InvertedIndexTantivy.h
@@ -454,4 +454,28 @@ class InvertedIndexTantivy : public ScalarIndex<T> {
     // every element in the array is treated as a separate document in the index.
     bool is_nested_index_{false};
 };
+
+template <>
+const TargetBitmap
+InvertedIndexTantivy<std::string>::Query(const DatasetPtr& dataset);
+
+template <>
+void
+InvertedIndexTantivy<std::string>::build_index_for_array(
+    const std::vector<std::shared_ptr<FieldDataBase>>& field_datas);
+
+template <>
+void
+InvertedIndexTantivy<std::string>::build_index_for_array_nested(
+    const std::vector<std::shared_ptr<FieldDataBase>>& field_datas);
+
+extern template class InvertedIndexTantivy<bool>;
+extern template class InvertedIndexTantivy<int8_t>;
+extern template class InvertedIndexTantivy<int16_t>;
+extern template class InvertedIndexTantivy<int32_t>;
+extern template class InvertedIndexTantivy<int64_t>;
+extern template class InvertedIndexTantivy<uint64_t>;
+extern template class InvertedIndexTantivy<float>;
+extern template class InvertedIndexTantivy<double>;
+extern template class InvertedIndexTantivy<std::string>;
 }  // namespace milvus::index

--- a/internal/core/src/index/RTreeIndex.cpp
+++ b/internal/core/src/index/RTreeIndex.cpp
@@ -139,7 +139,7 @@ RTreeIndex<T>::~RTreeIndex() {
 }
 
 static std::string
-GetFileName(const std::string& path) {
+GetRTreeFileName(const std::string& path) {
     auto pos = path.find_last_of('/');
     return pos == std::string::npos ? path : path.substr(pos + 1);
 }
@@ -165,7 +165,7 @@ RTreeIndex<T>::Load(milvus::tracer::TraceContext ctx, const Config& config) {
         auto find_file = [&](const std::string& target) -> auto{
             return std::find_if(
                 files.begin(), files.end(), [&](const std::string& filename) {
-                    return GetFileName(filename) == target;
+                    return GetRTreeFileName(filename) == target;
                 });
         };
 
@@ -196,7 +196,7 @@ RTreeIndex<T>::Load(milvus::tracer::TraceContext ctx, const Config& config) {
             // sliced case: collect all parts with prefix index_null_offset
             null_offset_files.push_back(*it);
             for (auto& f : files) {
-                auto filename = GetFileName(f);
+                auto filename = GetRTreeFileName(f);
                 static constexpr std::string_view kName = "index_null_offset_";
                 if (filename.size() > kName.size() &&
                     filename.compare(

--- a/internal/core/src/index/ScalarIndexSort.cpp
+++ b/internal/core/src/index/ScalarIndexSort.cpp
@@ -63,14 +63,14 @@ const std::string MMAP_PATH_FOR_TEST = "/tmp/milvus/mmap_test";
 
 const std::string STLSORT_INDEX_FILE_NAME = "stlsort-index";
 
-constexpr size_t ALIGNMENT = 32;  // 32-byte alignment
+constexpr size_t SCALAR_SORT_ALIGNMENT = 32;  // 32-byte alignment
 
-const uint64_t MMAP_INDEX_PADDING = 1;
+const uint64_t SCALAR_SORT_MMAP_INDEX_PADDING = 1;
 
 namespace {
 
 bool
-IsArrayField(const storage::FileManagerContext& file_manager_context) {
+IsScalarArrayField(const storage::FileManagerContext& file_manager_context) {
     return file_manager_context.Valid() &&
            file_manager_context.fieldDataMeta.field_schema.data_type() ==
                proto::schema::DataType::Array;
@@ -84,7 +84,7 @@ ScalarIndexSort<T>::ScalarIndexSort(
     bool is_nested_index)
     : ScalarIndex<T>(ASCENDING_SORT),
       is_nested_index_(is_nested_index),
-      is_array_field_(IsArrayField(file_manager_context)),
+      is_array_field_(IsScalarArrayField(file_manager_context)),
       is_built_(false),
       data_() {
     // not valid means we are in unit test
@@ -321,7 +321,9 @@ ScalarIndexSort<T>::SetupMmapFromData(
     std::filesystem::create_directories(
         std::filesystem::path(mmap_filepath_).parent_path());
 
-    auto aligned_size = ((size + ALIGNMENT - 1) / ALIGNMENT) * ALIGNMENT;
+    auto aligned_size =
+        ((size + SCALAR_SORT_ALIGNMENT - 1) / SCALAR_SORT_ALIGNMENT) *
+        SCALAR_SORT_ALIGNMENT;
 
     // Write data to file with alignment padding
     {
@@ -334,19 +336,20 @@ ScalarIndexSort<T>::SetupMmapFromData(
             file_writer.Write(padding.data(), padding.size());
         }
         // Write extra padding for safety
-        std::vector<uint8_t> padding(MMAP_INDEX_PADDING, 0);
+        std::vector<uint8_t> padding(SCALAR_SORT_MMAP_INDEX_PADDING, 0);
         file_writer.Write(padding.data(), padding.size());
         file_writer.Finish();
     }
 
     // mmap the file
     auto file = File::Open(mmap_filepath_, O_RDONLY);
-    mmap_data_ = static_cast<char*>(mmap(NULL,
-                                         aligned_size + MMAP_INDEX_PADDING,
-                                         PROT_READ,
-                                         MAP_PRIVATE,
-                                         file.Descriptor(),
-                                         0));
+    mmap_data_ =
+        static_cast<char*>(mmap(NULL,
+                                aligned_size + SCALAR_SORT_MMAP_INDEX_PADDING,
+                                PROT_READ,
+                                MAP_PRIVATE,
+                                file.Descriptor(),
+                                0));
 
     if (mmap_data_ == MAP_FAILED) {
         file.Close();
@@ -355,7 +358,7 @@ ScalarIndexSort<T>::SetupMmapFromData(
             ErrorCode::UnexpectedError, "failed to mmap: {}", strerror(errno));
     }
 
-    mmap_size_ = aligned_size + MMAP_INDEX_PADDING;
+    mmap_size_ = aligned_size + SCALAR_SORT_MMAP_INDEX_PADDING;
     data_size_ = size;
     file.Close();
 }
@@ -742,18 +745,19 @@ ScalarIndexSort<T>::LoadEntries(storage::IndexEntryReader& reader,
                                        total_data_size += len;
                                    });
 
-            auto aligned_size =
-                ((total_data_size + ALIGNMENT - 1) / ALIGNMENT) * ALIGNMENT;
+            auto aligned_size = ((total_data_size + SCALAR_SORT_ALIGNMENT - 1) /
+                                 SCALAR_SORT_ALIGNMENT) *
+                                SCALAR_SORT_ALIGNMENT;
             if (aligned_size > total_data_size) {
                 std::vector<uint8_t> padding(aligned_size - total_data_size, 0);
                 file_writer.Write(padding.data(), padding.size());
             }
-            std::vector<uint8_t> mmap_pad(MMAP_INDEX_PADDING, 0);
+            std::vector<uint8_t> mmap_pad(SCALAR_SORT_MMAP_INDEX_PADDING, 0);
             file_writer.Write(mmap_pad.data(), mmap_pad.size());
             file_writer.Finish();
 
             data_size_ = total_data_size;
-            mmap_size_ = aligned_size + MMAP_INDEX_PADDING;
+            mmap_size_ = aligned_size + SCALAR_SORT_MMAP_INDEX_PADDING;
         }
 
         auto file = File::Open(mmap_filepath_, O_RDONLY);

--- a/internal/core/src/index/StringIndexSort.cpp
+++ b/internal/core/src/index/StringIndexSort.cpp
@@ -75,7 +75,7 @@ SetIdxToOffset(std::vector<int32_t>& idx_to_offsets,
 }
 
 bool
-IsArrayField(const storage::FileManagerContext& file_manager_context) {
+IsStringArrayField(const storage::FileManagerContext& file_manager_context) {
     return file_manager_context.Valid() &&
            file_manager_context.fieldDataMeta.field_schema.data_type() ==
                proto::schema::DataType::Array;
@@ -140,9 +140,9 @@ StringIndexSortImpl::ParseBinaryData(const uint8_t* data, size_t data_size) {
 
 const std::string STRING_INDEX_SORT_FILE = "string_index_sort";
 
-constexpr size_t ALIGNMENT = 32;  // 32-byte alignment
+constexpr size_t STRING_SORT_ALIGNMENT = 32;  // 32-byte alignment
 
-const uint64_t MMAP_INDEX_PADDING = 1;
+const uint64_t STRING_SORT_MMAP_INDEX_PADDING = 1;
 
 StringIndexSort::StringIndexSort(
     const storage::FileManagerContext& file_manager_context,
@@ -150,7 +150,7 @@ StringIndexSort::StringIndexSort(
     : StringIndex(ASCENDING_SORT),
       is_built_(false),
       is_nested_index_(is_nested_index),
-      is_array_field_(IsArrayField(file_manager_context)) {
+      is_array_field_(IsStringArrayField(file_manager_context)) {
     if (file_manager_context.Valid()) {
         field_id_ = file_manager_context.fieldDataMeta.field_id;
         this->file_manager_ =
@@ -674,13 +674,14 @@ StringIndexSort::LoadEntries(storage::IndexEntryReader& reader,
                 "index_data",
                 [&](const uint8_t* d, size_t len) { fw.Write(d, len); });
 
-            auto aligned =
-                ((data_size + ALIGNMENT - 1) / ALIGNMENT) * ALIGNMENT;
+            auto aligned = ((data_size + STRING_SORT_ALIGNMENT - 1) /
+                            STRING_SORT_ALIGNMENT) *
+                           STRING_SORT_ALIGNMENT;
             if (aligned > data_size) {
                 std::vector<uint8_t> padding(aligned - data_size, 0);
                 fw.Write(padding.data(), padding.size());
             }
-            std::vector<uint8_t> mmap_pad(MMAP_INDEX_PADDING, 0);
+            std::vector<uint8_t> mmap_pad(STRING_SORT_MMAP_INDEX_PADDING, 0);
             fw.Write(mmap_pad.data(), mmap_pad.size());
             fw.Finish();
         }
@@ -1424,7 +1425,9 @@ StringIndexSortMmapImpl::LoadFromData(const uint8_t* data,
     std::filesystem::create_directories(
         std::filesystem::path(mmap_filepath_).parent_path());
 
-    auto aligned_size = ((data_size + ALIGNMENT - 1) / ALIGNMENT) * ALIGNMENT;
+    auto aligned_size =
+        ((data_size + STRING_SORT_ALIGNMENT - 1) / STRING_SORT_ALIGNMENT) *
+        STRING_SORT_ALIGNMENT;
     {
         auto file_writer = storage::FileWriter(mmap_filepath_);
         file_writer.Write(data, data_size);
@@ -1434,7 +1437,7 @@ StringIndexSortMmapImpl::LoadFromData(const uint8_t* data,
             file_writer.Write(padding.data(), padding.size());
         }
         // write padding in case of all null values
-        std::vector<uint8_t> padding(MMAP_INDEX_PADDING, 0);
+        std::vector<uint8_t> padding(STRING_SORT_MMAP_INDEX_PADDING, 0);
         file_writer.Write(padding.data(), padding.size());
         file_writer.Finish();
     }
@@ -1490,14 +1493,16 @@ StringIndexSortMmapImpl::MmapAndParse(size_t data_size,
                                       TargetBitmap& valid_bitset,
                                       std::vector<int32_t>& idx_to_offsets,
                                       bool skip_idx_to_offsets) {
-    auto aligned_size = ((data_size + ALIGNMENT - 1) / ALIGNMENT) * ALIGNMENT;
+    auto aligned_size =
+        ((data_size + STRING_SORT_ALIGNMENT - 1) / STRING_SORT_ALIGNMENT) *
+        STRING_SORT_ALIGNMENT;
 
     auto fd = open(mmap_filepath_.c_str(), O_RDONLY);
     if (fd == -1) {
         ThrowInfo(DataFormatBroken, "Failed to open mmap file");
     }
 
-    mmap_size_ = aligned_size + MMAP_INDEX_PADDING;
+    mmap_size_ = aligned_size + STRING_SORT_MMAP_INDEX_PADDING;
     data_size_ = data_size;
     mmap_data_ = static_cast<char*>(
         mmap(nullptr, mmap_size_, PROT_READ, MAP_PRIVATE, fd, 0));

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -149,7 +149,6 @@
 #include "storage/loon_ffi/util.h"
 
 namespace milvus::segcore {
-using namespace milvus::cachinglayer;
 
 constexpr auto kCollectionSchemaVersionNotReady = static_cast<ErrorCode>(2046);
 
@@ -274,23 +273,24 @@ cancel_and_erase_scalar_index(
     }
 }
 
-PinWrapper<const storagev2translator::TimestampIndexCell*>
+cachinglayer::PinWrapper<const storagev2translator::TimestampIndexCell*>
 ChunkedSegmentSealedImpl::PinTimestampIndex(
     const std::shared_ptr<const RuntimeResourceState>& runtime,
     milvus::OpContext* op_ctx) const {
     auto slot = runtime != nullptr ? runtime->timestamp_index_slot : nullptr;
     if (!slot) {
-        return PinWrapper<const storagev2translator::TimestampIndexCell*>(
-            nullptr);
+        return cachinglayer::PinWrapper<
+            const storagev2translator::TimestampIndexCell*>(nullptr);
     }
-    auto ca = SemiInlineGet(slot->PinCells(op_ctx, {0}));
+    auto ca = cachinglayer::SemiInlineGet(slot->PinCells(op_ctx, {0}));
     auto* cell = ca->get_cell_of(0);
     AssertInfo(
         cell != nullptr, "timestamp index cache is corrupted, segment {}", id_);
-    return PinWrapper<const storagev2translator::TimestampIndexCell*>(ca, cell);
+    return cachinglayer::PinWrapper<
+        const storagev2translator::TimestampIndexCell*>(ca, cell);
 }
 
-PinWrapper<const storagev2translator::TimestampIndexCell*>
+cachinglayer::PinWrapper<const storagev2translator::TimestampIndexCell*>
 ChunkedSegmentSealedImpl::PinTimestampIndex(milvus::OpContext* op_ctx) const {
     return PinTimestampIndex(CaptureRuntimeResourceState(), op_ctx);
 }
@@ -330,21 +330,23 @@ ChunkedSegmentSealedImpl::ReadTimestamp(
     return span[chunk_pos.second];
 }
 
-PinWrapper<const storagev2translator::PkIndexCell*>
+cachinglayer::PinWrapper<const storagev2translator::PkIndexCell*>
 ChunkedSegmentSealedImpl::PinPkIndex(
     const std::shared_ptr<const RuntimeResourceState>& runtime,
     milvus::OpContext* op_ctx) const {
     auto slot = runtime != nullptr ? runtime->pk_index_slot : nullptr;
     if (!slot) {
-        return PinWrapper<const storagev2translator::PkIndexCell*>(nullptr);
+        return cachinglayer::PinWrapper<
+            const storagev2translator::PkIndexCell*>(nullptr);
     }
-    auto ca = SemiInlineGet(slot->PinCells(op_ctx, {0}));
+    auto ca = cachinglayer::SemiInlineGet(slot->PinCells(op_ctx, {0}));
     auto* cell = ca->get_cell_of(0);
     AssertInfo(cell != nullptr, "pk index cache is corrupted, segment {}", id_);
-    return PinWrapper<const storagev2translator::PkIndexCell*>(ca, cell);
+    return cachinglayer::PinWrapper<const storagev2translator::PkIndexCell*>(
+        ca, cell);
 }
 
-std::vector<PinWrapper<const index::IndexBase*>>
+std::vector<cachinglayer::PinWrapper<const index::IndexBase*>>
 ChunkedSegmentSealedImpl::PinJsonIndex(milvus::OpContext* op_ctx,
                                        FieldId field_id,
                                        const std::string& path,
@@ -391,9 +393,10 @@ ChunkedSegmentSealedImpl::PinJsonIndex(milvus::OpContext* op_ctx,
     if (best_match == nullptr) {
         return {};
     }
-    auto ca = SemiInlineGet(best_match->PinCells(op_ctx, {0}));
+    auto ca = cachinglayer::SemiInlineGet(best_match->PinCells(op_ctx, {0}));
     auto pinned_index = ca->get_cell_of(0);
-    return {PinWrapper<const index::IndexBase*>(std::move(ca), pinned_index)};
+    return {cachinglayer::PinWrapper<const index::IndexBase*>(std::move(ca),
+                                                              pinned_index)};
 }
 
 std::string
@@ -498,12 +501,15 @@ ChunkedSegmentSealedImpl::init_storage_v2_timestamp_index(
     size_t num_rows,
     const std::string& warmup_policy,
     RuntimeResourceState* runtime) {
-    std::unique_ptr<Translator<storagev2translator::TimestampIndexCell>>
+    std::unique_ptr<
+        cachinglayer::Translator<storagev2translator::TimestampIndexCell>>
         translator =
             std::make_unique<storagev2translator::TimestampIndexTranslator>(
                 id_, column, num_rows, warmup_policy);
-    auto slot = Manager::GetInstance().CreateCacheSlot(std::move(translator));
-    auto cell_holder = SemiInlineGet(slot->PinCells(nullptr, {0}));
+    auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot(
+        std::move(translator));
+    auto cell_holder =
+        cachinglayer::SemiInlineGet(slot->PinCells(nullptr, {0}));
     auto* cell = cell_holder->get_cell_of(0);
     AssertInfo(
         cell != nullptr, "timestamp index cache is corrupted, segment {}", id_);
@@ -563,18 +569,20 @@ ChunkedSegmentSealedImpl::init_storage_v1_timestamp_index(
     init_storage_v1_timestamp_index(std::move(timestamps), num_rows, nullptr);
 }
 
-std::shared_ptr<CacheSlot<storagev2translator::PkIndexCell>>
+std::shared_ptr<cachinglayer::CacheSlot<storagev2translator::PkIndexCell>>
 ChunkedSegmentSealedImpl::BuildPkIndexSlot(
     const std::shared_ptr<ChunkedColumnInterface>& column,
     DataType data_type,
     bool eager,
     milvus::OpContext* op_ctx) const {
-    std::unique_ptr<Translator<storagev2translator::PkIndexCell>> translator =
-        std::make_unique<storagev2translator::PkIndexTranslator>(
+    std::unique_ptr<cachinglayer::Translator<storagev2translator::PkIndexCell>>
+        translator = std::make_unique<storagev2translator::PkIndexTranslator>(
             id_, column, data_type, is_sorted_by_pk_);
-    auto slot = Manager::GetInstance().CreateCacheSlot(std::move(translator));
+    auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot(
+        std::move(translator));
     if (eager) {
-        auto cell_holder = SemiInlineGet(slot->PinCells(op_ctx, {0}));
+        auto cell_holder =
+            cachinglayer::SemiInlineGet(slot->PinCells(op_ctx, {0}));
         AssertInfo(cell_holder->get_cell_of(0) != nullptr,
                    "primary key index cache is corrupted, segment {}",
                    id_);
@@ -1812,7 +1820,7 @@ ChunkedSegmentSealedImpl::PublishRuntimeStateLocked(
         MakeStateDelta(
             current->schema, current->load_info, runtime, current->commit_ts)));
 }
-PinWrapper<index::TextMatchIndex*>
+cachinglayer::PinWrapper<index::TextMatchIndex*>
 ChunkedSegmentSealedImpl::GetTextIndex(milvus::OpContext* op_ctx,
                                        FieldId field_id) const {
     auto snapshot = CapturePublishedState();
@@ -1830,21 +1838,24 @@ ChunkedSegmentSealedImpl::GetTextIndex(milvus::OpContext* op_ctx,
                   field_id.get());
     }
 
-    auto make_pin = [&](auto&& alt) -> PinWrapper<index::TextMatchIndex*> {
+    auto make_pin =
+        [&](auto&& alt) -> cachinglayer::PinWrapper<index::TextMatchIndex*> {
         using Alt = std::decay_t<decltype(alt)>;
         if constexpr (std::is_same_v<
                           Alt,
                           std::shared_ptr<
                               milvus::index::TextMatchIndexHolder>>) {
-            return PinWrapper<index::TextMatchIndex*>(alt, alt->get());
+            return cachinglayer::PinWrapper<index::TextMatchIndex*>(alt,
+                                                                    alt->get());
         } else if constexpr (std::is_same_v<
                                  Alt,
                                  std::shared_ptr<
                                      milvus::cachinglayer::CacheSlot<
                                          milvus::index::TextMatchIndex>>>) {
-            auto ca = SemiInlineGet(alt->PinCells(op_ctx, {0}));
+            auto ca = cachinglayer::SemiInlineGet(alt->PinCells(op_ctx, {0}));
             auto index = ca->get_cell_of(0);
-            return PinWrapper<index::TextMatchIndex*>(std::move(ca), index);
+            return cachinglayer::PinWrapper<index::TextMatchIndex*>(
+                std::move(ca), index);
         } else {
             ThrowInfo(milvus::ErrorCode::UnexpectedError,
                       "text index of segment is not supported for field {}",
@@ -2735,15 +2746,16 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
                             stats_.mem_size += sizeof(Timestamp) * num_rows;
                         });
                 } else {
-                    std::unique_ptr<
-                        Translator<storagev2translator::TimestampIndexCell>>
+                    std::unique_ptr<cachinglayer::Translator<
+                        storagev2translator::TimestampIndexCell>>
                         translator = std::make_unique<
                             storagev2translator::TimestampIndexTranslator>(
                             id_, column, num_rows, info.warmup_policy);
-                    auto slot = Manager::GetInstance().CreateCacheSlot(
-                        std::move(translator));
-                    auto cell_holder =
-                        SemiInlineGet(slot->PinCells(nullptr, {0}));
+                    auto slot =
+                        cachinglayer::Manager::GetInstance().CreateCacheSlot(
+                            std::move(translator));
+                    auto cell_holder = cachinglayer::SemiInlineGet(
+                        slot->PinCells(nullptr, {0}));
                     auto* cell = cell_holder->get_cell_of(0);
                     AssertInfo(cell != nullptr,
                                "timestamp index cache is corrupted, segment {}",
@@ -2859,16 +2871,17 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
                                                  segment_load_info,
                                                  schema_snapshot,
                                                  info.warmup_policy);
-            std::unique_ptr<Translator<milvus::Chunk>> translator =
-                std::make_unique<storagev1translator::ChunkTranslator>(
-                    this->get_segment_id(),
-                    field_meta,
-                    field_data_info,
-                    std::move(file_infos),
-                    info.enable_mmap,
-                    mmap_config.GetMmapPopulate(),
-                    load_info.load_priority,
-                    warmup_policy);
+            std::unique_ptr<cachinglayer::Translator<milvus::Chunk>>
+                translator =
+                    std::make_unique<storagev1translator::ChunkTranslator>(
+                        this->get_segment_id(),
+                        field_meta,
+                        field_data_info,
+                        std::move(file_infos),
+                        info.enable_mmap,
+                        mmap_config.GetMmapPopulate(),
+                        load_info.load_priority,
+                        warmup_policy);
 
             auto data_type = field_meta.get_data_type();
             auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot(
@@ -3013,16 +3026,17 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
             storage::SortByPath(file_infos);
 
             auto field_meta = schema_snapshot->operator[](field_id);
-            std::unique_ptr<Translator<milvus::Chunk>> translator =
-                std::make_unique<storagev1translator::ChunkTranslator>(
-                    this->get_segment_id(),
-                    field_meta,
-                    field_data_info,
-                    std::move(file_infos),
-                    info.enable_mmap,
-                    mmap_config.GetMmapPopulate(),
-                    load_info.load_priority,
-                    info.warmup_policy);
+            std::unique_ptr<cachinglayer::Translator<milvus::Chunk>>
+                translator =
+                    std::make_unique<storagev1translator::ChunkTranslator>(
+                        this->get_segment_id(),
+                        field_meta,
+                        field_data_info,
+                        std::move(file_infos),
+                        info.enable_mmap,
+                        mmap_config.GetMmapPopulate(),
+                        load_info.load_priority,
+                        info.warmup_policy);
 
             auto data_type = field_meta.get_data_type();
             auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot(
@@ -3306,7 +3320,7 @@ ChunkedSegmentSealedImpl::ApplyFieldValidDataByOffsets(
         count);
 }
 
-PinWrapper<SpanBase>
+cachinglayer::PinWrapper<SpanBase>
 ChunkedSegmentSealedImpl::chunk_data_impl(milvus::OpContext* op_ctx,
                                           FieldId field_id,
                                           int64_t chunk_id) const {
@@ -3320,7 +3334,7 @@ ChunkedSegmentSealedImpl::chunk_data_impl(milvus::OpContext* op_ctx,
               "chunk_data_impl only used for chunk column field ");
 }
 
-PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
+cachinglayer::PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
 ChunkedSegmentSealedImpl::chunk_array_view_impl(
     milvus::OpContext* op_ctx,
     FieldId field_id,
@@ -3336,7 +3350,7 @@ ChunkedSegmentSealedImpl::chunk_array_view_impl(
               "chunk_array_view_impl only used for chunk column field ");
 }
 
-PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
+cachinglayer::PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
 ChunkedSegmentSealedImpl::chunk_vector_array_view_impl(
     milvus::OpContext* op_ctx,
     FieldId field_id,
@@ -3352,7 +3366,7 @@ ChunkedSegmentSealedImpl::chunk_vector_array_view_impl(
               "chunk_vector_array_view_impl only used for chunk column field ");
 }
 
-PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
+cachinglayer::PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
 ChunkedSegmentSealedImpl::chunk_string_view_impl(
     milvus::OpContext* op_ctx,
     FieldId field_id,
@@ -3368,7 +3382,8 @@ ChunkedSegmentSealedImpl::chunk_string_view_impl(
               "chunk_string_view_impl only used for variable column field ");
 }
 
-PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+cachinglayer::PinWrapper<
+    std::pair<std::vector<std::string_view>, FixedVector<bool>>>
 ChunkedSegmentSealedImpl::chunk_string_views_by_offsets(
     milvus::OpContext* op_ctx,
     FieldId field_id,
@@ -3384,7 +3399,7 @@ ChunkedSegmentSealedImpl::chunk_string_views_by_offsets(
               "chunk_view_by_offsets only used for variable column field ");
 }
 
-PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+cachinglayer::PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
 ChunkedSegmentSealedImpl::chunk_array_views_by_offsets(
     milvus::OpContext* op_ctx,
     FieldId field_id,
@@ -3401,28 +3416,29 @@ ChunkedSegmentSealedImpl::chunk_array_views_by_offsets(
               "field ");
 }
 
-PinWrapper<index::NgramInvertedIndex*>
+cachinglayer::PinWrapper<index::NgramInvertedIndex*>
 ChunkedSegmentSealedImpl::GetNgramIndex(milvus::OpContext* op_ctx,
                                         FieldId field_id) const {
     auto runtime = CaptureRuntimeResourceState();
     if (runtime->ngram_fields.find(field_id) == runtime->ngram_fields.end()) {
-        return PinWrapper<index::NgramInvertedIndex*>(nullptr);
+        return cachinglayer::PinWrapper<index::NgramInvertedIndex*>(nullptr);
     }
 
     auto iter = runtime->scalar_indexings.find(field_id);
     if (iter == runtime->scalar_indexings.end()) {
-        return PinWrapper<index::NgramInvertedIndex*>(nullptr);
+        return cachinglayer::PinWrapper<index::NgramInvertedIndex*>(nullptr);
     }
 
-    auto ca = SemiInlineGet(iter->second->PinCells(op_ctx, {0}));
+    auto ca = cachinglayer::SemiInlineGet(iter->second->PinCells(op_ctx, {0}));
     auto index = dynamic_cast<index::NgramInvertedIndex*>(ca->get_cell_of(0));
     AssertInfo(index != nullptr,
                "ngram index cache is corrupted, field_id: {}",
                field_id.get());
-    return PinWrapper<index::NgramInvertedIndex*>(std::move(ca), index);
+    return cachinglayer::PinWrapper<index::NgramInvertedIndex*>(std::move(ca),
+                                                                index);
 }
 
-PinWrapper<index::NgramInvertedIndex*>
+cachinglayer::PinWrapper<index::NgramInvertedIndex*>
 ChunkedSegmentSealedImpl::GetNgramIndexForJson(
     milvus::OpContext* op_ctx,
     FieldId field_id,
@@ -3430,21 +3446,23 @@ ChunkedSegmentSealedImpl::GetNgramIndexForJson(
     auto runtime = CaptureRuntimeResourceState();
     auto iter = runtime->ngram_indexings.find(field_id);
     if (iter == runtime->ngram_indexings.end()) {
-        return PinWrapper<index::NgramInvertedIndex*>(nullptr);
+        return cachinglayer::PinWrapper<index::NgramInvertedIndex*>(nullptr);
     }
     auto nested_iter = iter->second.find(nested_path);
     if (nested_iter == iter->second.end()) {
-        return PinWrapper<index::NgramInvertedIndex*>(nullptr);
+        return cachinglayer::PinWrapper<index::NgramInvertedIndex*>(nullptr);
     }
 
-    auto ca = SemiInlineGet(nested_iter->second->PinCells(op_ctx, {0}));
+    auto ca =
+        cachinglayer::SemiInlineGet(nested_iter->second->PinCells(op_ctx, {0}));
     auto index = dynamic_cast<index::NgramInvertedIndex*>(ca->get_cell_of(0));
     AssertInfo(index != nullptr,
                "ngram index cache for json is corrupted, field_id: {}, "
                "nested_path: {}",
                field_id.get(),
                nested_path);
-    return PinWrapper<index::NgramInvertedIndex*>(std::move(ca), index);
+    return cachinglayer::PinWrapper<index::NgramInvertedIndex*>(std::move(ca),
+                                                                index);
 }
 
 int64_t
@@ -3634,7 +3652,8 @@ ChunkedSegmentSealedImpl::FilterVectorValidOffsetsFromIndex(
     ValidResult result;
     result.valid_count = count;
 
-    auto ca = SemiInlineGet(entry.indexing_->PinCells(op_ctx, {0}));
+    auto ca =
+        cachinglayer::SemiInlineGet(entry.indexing_->PinCells(op_ctx, {0}));
     auto vec_index = dynamic_cast<index::VectorIndex*>(ca->get_cell_of(0));
     AssertInfo(vec_index != nullptr, "invalid vector indexing");
     AssertInfo(vec_index->HasValidData(),
@@ -3693,7 +3712,8 @@ ChunkedSegmentSealedImpl::get_vector(milvus::OpContext* op_ctx,
 
     auto vector_entry = GetVectorIndexing(snapshot->runtime, field_id);
     AssertInfo(vector_entry != nullptr, "vector index is not ready");
-    auto ca = SemiInlineGet(vector_entry->indexing_->PinCells(op_ctx, {0}));
+    auto ca = cachinglayer::SemiInlineGet(
+        vector_entry->indexing_->PinCells(op_ctx, {0}));
     auto vec_index = dynamic_cast<index::VectorIndex*>(ca->get_cell_of(0));
     AssertInfo(vec_index, "invalid vector indexing");
 
@@ -3761,7 +3781,8 @@ ChunkedSegmentSealedImpl::get_emb_list(milvus::OpContext* op_ctx,
 
     auto vector_entry = GetVectorIndexing(snapshot->runtime, field_id);
     AssertInfo(vector_entry != nullptr, "vector index is not ready");
-    auto ca = SemiInlineGet(vector_entry->indexing_->PinCells(op_ctx, {0}));
+    auto ca = cachinglayer::SemiInlineGet(
+        vector_entry->indexing_->PinCells(op_ctx, {0}));
     auto vec_index = dynamic_cast<index::VectorIndex*>(ca->get_cell_of(0));
     AssertInfo(vec_index, "invalid vector indexing");
     auto has_raw_data = vec_index->HasRawData();
@@ -5365,8 +5386,8 @@ ChunkedSegmentSealedImpl::CreateTextIndexWithSchema(
                 field_index_iter != target_runtime->scalar_indexings.end(),
                 "failed to create text index, neither raw data nor "
                 "index are found");
-            auto accessor =
-                SemiInlineGet(field_index_iter->second->PinCells(op_ctx, {0}));
+            auto accessor = cachinglayer::SemiInlineGet(
+                field_index_iter->second->PinCells(op_ctx, {0}));
             auto ptr = accessor->get_cell_of(0);
             AssertInfo(ptr->HasRawData(),
                        "text raw data not found, trying to create text index "
@@ -6084,7 +6105,8 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
         // === Scalar field ===
         if (!use_field_data && IndexHasRawData(field_id)) {
             // Try index first: if scalar index exists and has raw data, read from index
-            PinWrapper<const index::IndexBase*> pin_scalar_index_ptr;
+            cachinglayer::PinWrapper<const index::IndexBase*>
+                pin_scalar_index_ptr;
             auto scalar_indexes = PinIndex(op_ctx, field_id);
             if (!scalar_indexes.empty()) {
                 pin_scalar_index_ptr = std::move(scalar_indexes[0]);
@@ -6263,8 +6285,8 @@ ChunkedSegmentSealedImpl::CalcDistByIDs(
     if (vector_entry == nullptr) {
         return false;
     }
-    auto accessor =
-        SemiInlineGet(vector_entry->indexing_->PinCells(op_ctx, {0}));
+    auto accessor = cachinglayer::SemiInlineGet(
+        vector_entry->indexing_->PinCells(op_ctx, {0}));
     auto vec_index =
         dynamic_cast<index::VectorIndex*>(accessor->get_cell_of(0));
     if (vec_index == nullptr) {
@@ -6293,8 +6315,8 @@ ChunkedSegmentSealedImpl::IsIndexRefineEnabledLocked(
     if (vector_entry == nullptr) {
         return false;
     }
-    auto accessor =
-        SemiInlineGet(vector_entry->indexing_->PinCells(op_ctx, {0}));
+    auto accessor = cachinglayer::SemiInlineGet(
+        vector_entry->indexing_->PinCells(op_ctx, {0}));
     auto vec_index =
         dynamic_cast<index::VectorIndex*>(accessor->get_cell_of(0));
     return vec_index != nullptr && vec_index->IsIndexRefineEnabled();
@@ -6865,7 +6887,8 @@ ChunkedSegmentSealedImpl::load_field_data_common(
         return snapshot;
     };
 
-    std::shared_ptr<CacheSlot<storagev2translator::PkIndexCell>> pk_index_slot;
+    std::shared_ptr<cachinglayer::CacheSlot<storagev2translator::PkIndexCell>>
+        pk_index_slot;
     const bool is_primary_field =
         schema_snapshot->get_primary_field_id().value_or(FieldId(-1)) ==
         field_id;
@@ -7578,7 +7601,7 @@ ChunkedSegmentSealedImpl::fill_empty_field(
 
     auto warmup_policy = resolve_field_data_warmup_policy(
         field_id, segment_load_info, schema_snapshot);
-    std::unique_ptr<Translator<milvus::Chunk>> translator =
+    std::unique_ptr<cachinglayer::Translator<milvus::Chunk>> translator =
         std::make_unique<storagev1translator::DefaultValueChunkTranslator>(
             get_segment_id(),
             field_meta,
@@ -7743,7 +7766,7 @@ ChunkedSegmentSealedImpl::FillDefaultValueFields(
 
         auto warmup_policy = resolve_field_data_warmup_policy(
             field_id, segment_load_info, schema_snapshot);
-        std::unique_ptr<Translator<milvus::Chunk>> translator =
+        std::unique_ptr<cachinglayer::Translator<milvus::Chunk>> translator =
             std::make_unique<storagev1translator::DefaultValueChunkTranslator>(
                 get_segment_id(),
                 field_meta,
@@ -8410,14 +8433,16 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
                     stats_.mem_size += sizeof(Timestamp) * num_rows;
                 });
             } else {
-                std::unique_ptr<
-                    Translator<storagev2translator::TimestampIndexCell>>
+                std::unique_ptr<cachinglayer::Translator<
+                    storagev2translator::TimestampIndexCell>>
                     translator = std::make_unique<
                         storagev2translator::TimestampIndexTranslator>(
                         id_, column, num_rows, "");
-                auto slot = Manager::GetInstance().CreateCacheSlot(
-                    std::move(translator));
-                auto cell_holder = SemiInlineGet(slot->PinCells(nullptr, {0}));
+                auto slot =
+                    cachinglayer::Manager::GetInstance().CreateCacheSlot(
+                        std::move(translator));
+                auto cell_holder =
+                    cachinglayer::SemiInlineGet(slot->PinCells(nullptr, {0}));
                 auto* cell = cell_holder->get_cell_of(0);
                 AssertInfo(cell != nullptr,
                            "timestamp index cache is corrupted, segment {}",
@@ -9851,7 +9876,8 @@ ChunkedSegmentSealedImpl::prefetch_vector(milvus::OpContext* op_ctx,
     auto runtime = CaptureRuntimeResourceState();
     auto vector_entry = GetVectorIndexing(runtime, field_id);
     if (vector_entry != nullptr) {
-        SemiInlineGet(vector_entry->indexing_->PinCells(op_ctx, {0}));
+        cachinglayer::SemiInlineGet(
+            vector_entry->indexing_->PinCells(op_ctx, {0}));
     } else {
         this->prefetch_chunks_locked(op_ctx, field_id);
     }

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -93,8 +93,6 @@
 
 namespace milvus::segcore {
 
-using namespace milvus::cachinglayer;
-
 namespace {
 
 int64_t
@@ -451,17 +449,17 @@ SegmentGrowingImpl::try_remove_chunks(FieldId fieldId, const Schema& schema) {
     }
 }
 
-ResourceUsage
+cachinglayer::ResourceUsage
 SegmentGrowingImpl::EstimateSegmentResourceUsage() const {
     auto schema = get_schema_snapshot();
     return EstimateSegmentResourceUsage(*schema);
 }
 
-ResourceUsage
+cachinglayer::ResourceUsage
 SegmentGrowingImpl::EstimateSegmentResourceUsage(const Schema& schema) const {
     int64_t num_rows = get_row_count();
     if (num_rows == 0) {
-        return ResourceUsage{0, 0};
+        return cachinglayer::ResourceUsage{0, 0};
     }
 
     bool growing_mmap_enabled = storage::MmapManager::GetInstance()
@@ -648,7 +646,7 @@ SegmentGrowingImpl::EstimateSegmentResourceUsage(const Schema& schema) const {
     memory_bytes = static_cast<int64_t>(memory_bytes * kResourceSafetyMargin);
     disk_bytes = static_cast<int64_t>(disk_bytes * kResourceSafetyMargin);
 
-    return ResourceUsage{memory_bytes, disk_bytes};
+    return cachinglayer::ResourceUsage{memory_bytes, disk_bytes};
 }
 
 void
@@ -667,12 +665,12 @@ SegmentGrowingImpl::UpdateResourceTracking(const Schema& schema) {
     auto old_resource = tracked_resource_;
 
     if (old_resource.AnyGTZero()) {
-        Manager::GetInstance().RefundLoadedResource(
+        cachinglayer::Manager::GetInstance().RefundLoadedResource(
             old_resource, fmt::format("growing_segment_{}_refund", id_));
     }
 
     if (new_resource.AnyGTZero()) {
-        Manager::GetInstance().ChargeLoadedResource(
+        cachinglayer::Manager::GetInstance().ChargeLoadedResource(
             new_resource, fmt::format("growing_segment_{}_charge", id_));
     }
 
@@ -1407,11 +1405,11 @@ SegmentGrowingImpl::LoadDeletedRecord(const LoadDeletedRecordInfo& info) {
     deleted_record_.LoadPush(pks, timestamps);
 }
 
-PinWrapper<SpanBase>
+cachinglayer::PinWrapper<SpanBase>
 SegmentGrowingImpl::chunk_data_impl(milvus::OpContext* op_ctx,
                                     FieldId field_id,
                                     int64_t chunk_id) const {
-    return PinWrapper<SpanBase>(
+    return cachinglayer::PinWrapper<SpanBase>(
         get_insert_record().get_span_base(field_id, chunk_id));
 }
 
@@ -1468,7 +1466,7 @@ SegmentGrowingImpl::ApplyFieldValidDataByOffsets(
     }
 }
 
-PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
+cachinglayer::PinWrapper<std::pair<std::vector<std::string_view>, ValidityView>>
 SegmentGrowingImpl::chunk_string_view_impl(
     milvus::OpContext* op_ctx,
     FieldId field_id,
@@ -1478,7 +1476,7 @@ SegmentGrowingImpl::chunk_string_view_impl(
               "chunk string view impl not implement for growing segment");
 }
 
-PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
+cachinglayer::PinWrapper<std::pair<std::vector<ArrayView>, ValidityView>>
 SegmentGrowingImpl::chunk_array_view_impl(
     milvus::OpContext* op_ctx,
     FieldId field_id,
@@ -1488,7 +1486,7 @@ SegmentGrowingImpl::chunk_array_view_impl(
               "chunk array view impl not implement for growing segment");
 }
 
-PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
+cachinglayer::PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>
 SegmentGrowingImpl::chunk_vector_array_view_impl(
     milvus::OpContext* op_ctx,
     FieldId field_id,
@@ -1588,7 +1586,7 @@ SegmentGrowingImpl::chunk_vector_array_view_impl(
         }
         std::pair<std::vector<VectorArrayView>, ValidityView> content{
             std::move(views), ValidityView::FromExpanded(valid_data->data())};
-        return PinWrapper<
+        return cachinglayer::PinWrapper<
             std::pair<std::vector<VectorArrayView>, ValidityView>>(
             std::move(valid_data), std::move(content));
     }
@@ -1602,11 +1600,13 @@ SegmentGrowingImpl::chunk_vector_array_view_impl(
     }
     std::pair<std::vector<VectorArrayView>, ValidityView> content{
         std::move(views), ValidityView{}};
-    return PinWrapper<std::pair<std::vector<VectorArrayView>, ValidityView>>(
+    return cachinglayer::PinWrapper<
+        std::pair<std::vector<VectorArrayView>, ValidityView>>(
         std::move(content));
 }
 
-PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+cachinglayer::PinWrapper<
+    std::pair<std::vector<std::string_view>, FixedVector<bool>>>
 SegmentGrowingImpl::chunk_string_views_by_offsets(
     milvus::OpContext* op_ctx,
     FieldId field_id,
@@ -1616,7 +1616,7 @@ SegmentGrowingImpl::chunk_string_views_by_offsets(
               "chunk view by offsets not implemented for growing segment");
 }
 
-PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+cachinglayer::PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
 SegmentGrowingImpl::chunk_array_views_by_offsets(
     milvus::OpContext* op_ctx,
     FieldId field_id,

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -38,6 +38,7 @@
 #include "expr/ITypeExpr.h"
 #include "fmt/core.h"
 #include "futures/Future.h"
+#include "index/json_stats/JsonKeyStats.h"
 #include "monitor/Monitor.h"
 #include "pb/schema.pb.h"
 #include "plan/PlanNode.h"

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -60,7 +60,6 @@
 #include "index/NgramInvertedIndex.h"
 #include "index/SkipIndex.h"
 #include "index/TextMatchIndex.h"
-#include "index/json_stats/JsonKeyStats.h"
 #include "mmap/ChunkedColumnInterface.h"
 #include "parquet/statistics.h"
 #include "pb/plan.pb.h"
@@ -71,6 +70,10 @@
 
 namespace milvus::exec {
 class SimpleGeometryCache;
+}
+
+namespace milvus::index {
+class JsonKeyStats;
 }
 
 namespace milvus::segcore {

--- a/internal/core/src/segcore/TextColumnCache.cpp
+++ b/internal/core/src/segcore/TextColumnCache.cpp
@@ -23,14 +23,14 @@
 
 namespace milvus::segcore {
 
-using namespace milvus_storage::lob_column;
-
 namespace {
 
-arrow::Result<std::unique_ptr<LobColumnReader>>
-DefaultTextLobReaderFactory(std::shared_ptr<arrow::fs::FileSystem> fs,
-                            const LobColumnConfig& config) {
-    return CreateLobColumnReader(std::move(fs), config);
+arrow::Result<std::unique_ptr<milvus_storage::lob_column::LobColumnReader>>
+DefaultTextLobReaderFactory(
+    std::shared_ptr<arrow::fs::FileSystem> fs,
+    const milvus_storage::lob_column::LobColumnConfig& config) {
+    return milvus_storage::lob_column::CreateLobColumnReader(std::move(fs),
+                                                             config);
 }
 
 }  // namespace
@@ -66,7 +66,7 @@ TextColumnCache::GetOrCreateReader(
 
     file_cache_misses_.fetch_add(1, std::memory_order_relaxed);
 
-    LobColumnConfig config;
+    milvus_storage::lob_column::LobColumnConfig config;
     config.lob_base_path = lob_base_path;
     config.properties = properties;
 
@@ -79,7 +79,7 @@ TextColumnCache::GetOrCreateReader(
                   error.what());
     }
 
-    auto reader = std::shared_ptr<LobColumnReader>(
+    auto reader = std::shared_ptr<milvus_storage::lob_column::LobColumnReader>(
         std::move(reader_result).ValueOrDie().release());
     auto cached_reader =
         std::make_shared<CachedTextLobReader>(std::move(reader));
@@ -97,10 +97,11 @@ TextColumnCache::GetOrCreateReader(
 }
 
 std::vector<std::string>
-TextColumnCache::ReadBatch(const std::string& lob_base_path,
-                           std::shared_ptr<arrow::fs::FileSystem> fs,
-                           const milvus_storage::api::Properties& properties,
-                           const std::vector<EncodedRef>& encoded_refs) {
+TextColumnCache::ReadBatch(
+    const std::string& lob_base_path,
+    std::shared_ptr<arrow::fs::FileSystem> fs,
+    const milvus_storage::api::Properties& properties,
+    const std::vector<milvus_storage::lob_column::EncodedRef>& encoded_refs) {
     if (encoded_refs.empty()) {
         return {};
     }
@@ -108,7 +109,7 @@ TextColumnCache::ReadBatch(const std::string& lob_base_path,
     std::vector<std::string> results(encoded_refs.size());
     std::vector<size_t>
         pending_indices;  // Indices that need to be read from file
-    std::vector<EncodedRef> pending_refs;
+    std::vector<milvus_storage::lob_column::EncodedRef> pending_refs;
 
     for (size_t i = 0; i < encoded_refs.size(); i++) {
         const auto& ref = encoded_refs[i];
@@ -118,8 +119,9 @@ TextColumnCache::ReadBatch(const std::string& lob_base_path,
             continue;
         }
 
-        if (IsInlineData(ref.data)) {
-            results[i] = DecodeInlineText(ref.data, ref.size);
+        if (milvus_storage::lob_column::IsInlineData(ref.data)) {
+            results[i] = milvus_storage::lob_column::DecodeInlineText(ref.data,
+                                                                      ref.size);
             continue;
         }
 
@@ -160,14 +162,14 @@ TextColumnCache::ReadBatchInto(
     const std::string& lob_base_path,
     std::shared_ptr<arrow::fs::FileSystem> fs,
     const milvus_storage::api::Properties& properties,
-    const std::vector<EncodedRef>& encoded_refs,
+    const std::vector<milvus_storage::lob_column::EncodedRef>& encoded_refs,
     google::protobuf::RepeatedPtrField<std::string>* dst) {
     if (encoded_refs.empty()) {
         return;
     }
 
     std::vector<size_t> pending_indices;
-    std::vector<EncodedRef> pending_refs;
+    std::vector<milvus_storage::lob_column::EncodedRef> pending_refs;
 
     for (size_t i = 0; i < encoded_refs.size(); i++) {
         const auto& ref = encoded_refs[i];
@@ -177,8 +179,9 @@ TextColumnCache::ReadBatchInto(
             continue;
         }
 
-        if (IsInlineData(ref.data)) {
-            *dst->Mutable(i) = DecodeInlineText(ref.data, ref.size);
+        if (milvus_storage::lob_column::IsInlineData(ref.data)) {
+            *dst->Mutable(i) = milvus_storage::lob_column::DecodeInlineText(
+                ref.data, ref.size);
             continue;
         }
 

--- a/internal/core/src/storage/CMakeLists.txt
+++ b/internal/core/src/storage/CMakeLists.txt
@@ -38,5 +38,16 @@ add_subdirectory(loon_ffi)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/loon_ffi)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/plugin)
 
+# Cloud credential providers intentionally use matching file-local constant
+# names. Compile them separately so those names do not collide in unity mode.
+set_source_files_properties(
+    aliyun/AliyunCredentialsProvider.cpp
+    aliyun/AliyunSTSClient.cpp
+    tencent/TencentCloudCredentialsProvider.cpp
+    tencent/TencentCloudSTSClient.cpp
+    huawei/HuaweiCloudCredentialsProvider.cpp
+    huawei/HuaweiCloudSTSClient.cpp
+    PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+
 add_library(milvus_storage OBJECT ${SOURCE_FILES})
 target_link_libraries(milvus_storage PUBLIC milvus_conan_deps)

--- a/internal/core/src/storage/ChunkManager.cpp
+++ b/internal/core/src/storage/ChunkManager.cpp
@@ -34,8 +34,8 @@
 
 namespace milvus::storage {
 
-Aws::String
-ConvertToAwsString(const std::string& str) {
+static Aws::String
+ConvertChunkManagerToAwsString(const std::string& str) {
     return Aws::String(str.c_str(), str.size());
 }
 
@@ -45,7 +45,8 @@ generateConfig(const StorageConfig& storage_config) {
     // For more details, please refer to https://github.com/aws/aws-sdk-cpp/issues/1440
     static Aws::Client::ClientConfiguration g_config;
     Aws::Client::ClientConfiguration config = g_config;
-    config.endpointOverride = ConvertToAwsString(storage_config.address);
+    config.endpointOverride =
+        ConvertChunkManagerToAwsString(storage_config.address);
 
     // Three cases:
     // 1. no ssl, verifySSL=false
@@ -55,7 +56,8 @@ generateConfig(const StorageConfig& storage_config) {
         config.scheme = Aws::Http::Scheme::HTTPS;
         config.verifySSL = true;
         if (!storage_config.sslCACert.empty()) {
-            config.caPath = ConvertToAwsString(storage_config.sslCACert);
+            config.caPath =
+                ConvertChunkManagerToAwsString(storage_config.sslCACert);
             config.verifySSL = false;
         }
     } else {
@@ -64,7 +66,7 @@ generateConfig(const StorageConfig& storage_config) {
     }
 
     if (!storage_config.region.empty()) {
-        config.region = ConvertToAwsString(storage_config.region);
+        config.region = ConvertChunkManagerToAwsString(storage_config.region);
     }
 
     config.requestTimeoutMs = storage_config.requestTimeoutMs == 0

--- a/internal/core/src/storage/KeyRetriever.h
+++ b/internal/core/src/storage/KeyRetriever.h
@@ -9,6 +9,8 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#pragma once
+
 #include "common/type_c.h"
 #include "parquet/encryption/encryption.h"
 #include "parquet/properties.h"

--- a/internal/core/src/storage/minio/MinioChunkManager.cpp
+++ b/internal/core/src/storage/minio/MinioChunkManager.cpp
@@ -106,7 +106,7 @@ SwallowHandler(int signal) {
  * @return Aws::String
  */
 inline Aws::String
-ConvertToAwsString(const std::string& str) {
+ConvertMinioToAwsString(const std::string& str) {
     return Aws::String(str.c_str(), str.size());
 }
 
@@ -295,8 +295,8 @@ MinioChunkManager::BuildAccessKeyClient(
 
     client_ = std::make_shared<Aws::S3::S3Client>(
         Aws::Auth::AWSCredentials(
-            ConvertToAwsString(storage_config.access_key_id),
-            ConvertToAwsString(storage_config.access_key_value)),
+            ConvertMinioToAwsString(storage_config.access_key_id),
+            ConvertMinioToAwsString(storage_config.access_key_value)),
         config,
         Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
         storage_config.useVirtualHost);
@@ -392,7 +392,7 @@ MinioChunkManager::MinioChunkManager(const StorageConfig& storage_config)
     // For more details, please refer to https://github.com/aws/aws-sdk-cpp/issues/1440
     static Aws::Client::ClientConfiguration g_config;
     Aws::Client::ClientConfiguration config = g_config;
-    config.endpointOverride = ConvertToAwsString(storage_config.address);
+    config.endpointOverride = ConvertMinioToAwsString(storage_config.address);
 
     // Three cases:
     // 1. no ssl, verifySSL=false
@@ -402,7 +402,7 @@ MinioChunkManager::MinioChunkManager(const StorageConfig& storage_config)
         config.scheme = Aws::Http::Scheme::HTTPS;
         config.verifySSL = true;
         if (!storage_config.sslCACert.empty()) {
-            config.caPath = ConvertToAwsString(storage_config.sslCACert);
+            config.caPath = ConvertMinioToAwsString(storage_config.sslCACert);
             config.verifySSL = false;
         }
     } else {
@@ -419,7 +419,7 @@ MinioChunkManager::MinioChunkManager(const StorageConfig& storage_config)
     }
 
     if (!storage_config.region.empty()) {
-        config.region = ConvertToAwsString(storage_config.region);
+        config.region = ConvertMinioToAwsString(storage_config.region);
     }
 
     if (NeedChecksumOverride(storage_config.cloud_provider)) {


### PR DESCRIPTION
issue: #48695
pr: #52917

## What changed

Backport the scoped C++ unity-build acceleration from #52917 to 3.0.

- Scope unity builds to compatible Milvus-owned targets instead of vendored dependencies.
- Keep SIMD and translation units with local symbol collisions out of unity batches.
- Make PCH compilations cacheable by ccache and stop wrapping link commands with ccache.
- Reduce transitive header parsing from SegmentInterface.
- Suppress duplicate InvertedIndexTantivy template instantiation.
- Add the missing include guard to KeyRetriever.h.

## Backport notes

- Cherry-picked source commit eac42964cb onto current 3.0.
- Resolved conflicts in ChunkedSegmentSealedImpl.cpp and SegmentGrowingImpl.cpp caused by recursive nested ARRAY APIs that exist on master but not on 3.0.
- Kept the 3.0 method set and applied the cachinglayer qualifications only to existing 3.0 call sites; no nested ARRAY functionality was backported.
- Range-diff differences are limited to those absent master-only APIs and the pre-existing 3.0 milvus_index target-link layout.

## Validation

- git diff --check
- clang-format 15 --dry-run --Werror on all changed C++ files
- Source-versus-backport range-diff and changed-file audit
- Source PR #52917 validated configure/link of libmilvus_core.so with unity OFF and ON, ccache link-command handling, and Tantivy instantiation symbols.
- A branch-local full C++ rebuild was attempted, but this macOS Conan profile has no compatible binaries and began rebuilding the full third-party graph; target-branch compile coverage is delegated to PR CI.