### PR TITLE
fix: [cp3.0]keep the inclusive lower bound when OR-merging two ranges

### DIFF
--- a/internal/parser/planparserv2/rewriter/range.go
+++ b/internal/parser/planparserv2/rewriter/range.go
@@ -963,6 +963,11 @@ func (v *visitor) combineOrBinaryRanges(parts []*planpb.Expr) []*planpb.Expr {
 				mergedUpper := second.upper
 				mergedUpperInc := second.upperInc
 
+				// Lower bound: same value, prefer inclusive
+				if cmpGeneric(g.effDt, first.lower, second.lower) == 0 && second.lowerInc {
+					mergedLowerInc = true
+				}
+
 				// Upper bound: take maximum
 				cmpUppers := cmpGeneric(g.effDt, first.upper, second.upper)
 				if cmpUppers > 0 {

--- a/internal/parser/planparserv2/rewriter/range_binary_test.go
+++ b/internal/parser/planparserv2/rewriter/range_binary_test.go
@@ -194,6 +194,53 @@ func TestRewrite_BinaryRange_OR_BinaryRange_PreferInclusive(t *testing.T) {
 	require.Equal(t, int64(30), bre.GetUpperValue().GetInt64Val())
 }
 
+// Test BinaryRangeExpr OR BinaryRangeExpr - equal lower values, mixed inclusivity.
+// A union must keep the weaker (inclusive) bound regardless of operand order.
+func TestRewrite_BinaryRange_OR_BinaryRange_EqualLower_PreferInclusive(t *testing.T) {
+	helper := buildSchemaHelperForRewriteT(t)
+	// (10 < x < 30) OR (10 <= x < 20) → (10 <= x < 30)
+	expr, err := parser.ParseExpr(helper, `(Int64Field > 10 and Int64Field < 30) or (Int64Field >= 10 and Int64Field < 20)`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+	bre := expr.GetBinaryRangeExpr()
+	require.NotNil(t, bre)
+	require.Equal(t, true, bre.GetLowerInclusive(), "union must keep the inclusive lower bound")
+	require.Equal(t, false, bre.GetUpperInclusive())
+	require.Equal(t, int64(10), bre.GetLowerValue().GetInt64Val())
+	require.Equal(t, int64(30), bre.GetUpperValue().GetInt64Val())
+}
+
+// Test BinaryRangeExpr OR BinaryRangeExpr - same as above with the operands swapped.
+// Both orders must produce the same plan.
+func TestRewrite_BinaryRange_OR_BinaryRange_EqualLower_PreferInclusive_Swapped(t *testing.T) {
+	helper := buildSchemaHelperForRewriteT(t)
+	// (10 <= x < 20) OR (10 < x < 30) → (10 <= x < 30)
+	expr, err := parser.ParseExpr(helper, `(Int64Field >= 10 and Int64Field < 20) or (Int64Field > 10 and Int64Field < 30)`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+	bre := expr.GetBinaryRangeExpr()
+	require.NotNil(t, bre)
+	require.Equal(t, true, bre.GetLowerInclusive(), "union must keep the inclusive lower bound")
+	require.Equal(t, false, bre.GetUpperInclusive())
+	require.Equal(t, int64(10), bre.GetLowerValue().GetInt64Val())
+	require.Equal(t, int64(30), bre.GetUpperValue().GetInt64Val())
+}
+
+// Test BinaryRangeExpr OR BinaryRangeExpr - equal lower values on VarChar.
+func TestRewrite_BinaryRange_OR_BinaryRange_EqualLower_VarChar(t *testing.T) {
+	helper := buildSchemaHelperForRewriteT(t)
+	// ("b" < x <= "d") OR ("b" <= x <= "c") → ("b" <= x <= "d")
+	expr, err := parser.ParseExpr(helper, `(VarCharField > "b" and VarCharField <= "d") or (VarCharField >= "b" and VarCharField <= "c")`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+	bre := expr.GetBinaryRangeExpr()
+	require.NotNil(t, bre)
+	require.Equal(t, true, bre.GetLowerInclusive(), "union must keep the inclusive lower bound")
+	require.Equal(t, true, bre.GetUpperInclusive())
+	require.Equal(t, "b", bre.GetLowerValue().GetStringVal())
+	require.Equal(t, "d", bre.GetUpperValue().GetStringVal())
+}
+
 // Test with Float fields
 func TestRewrite_BinaryRange_AND_Float(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)


### PR DESCRIPTION
Cherry-pick from master (PR still open)

pr: #52853
issue: #52852

## Summary

Cherry-picked from master PR #52853 (open - preemptive backport)

**Note**: Original PR is still open. This CP PR should be updated if the original PR changes.

## Verification

- [x] File count matches original PR (2 files, +52/-0)
- [x] Per-file diff verified identical to the master PR
- [x] No conflict markers
- [x] `go build` + `go vet -tags dynamic,test ./internal/parser/planparserv2/rewriter/` clean on 3.0
- [ ] make static-check (skipped by cherry-pick workflow)
