### PR TITLE
test: [3.0] update outdated Python client expectations

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_collection.py
+++ b/tests/python_client/milvus_client/test_milvus_client_collection.py
@@ -750,31 +750,33 @@ class TestMilvusClientCollectionInvalid(TestMilvusClientV2Base):
     @pytest.mark.tags(CaseLabel.L2)
     def test_milvus_client_collection_invalid_schema_multi_pk(self):
         """
-        target: test create collection with schema containing multiple primary key fields
-        method: create schema with two primary key fields and use it to create collection
-        expected: raise exception due to multiple primary keys
+        target: test schema rejects multiple primary key fields
+        method: add conflicting primary key definitions to a schema
+        expected: raise exception while adding the conflicting field
         """
         client = self._client()
-        collection_name = cf.gen_collection_name_by_testcase_name()
-        # Create schema with multiple primary key fields
+        error = {ct.err_code: 1, ct.err_msg: "Expected only one primary key field"}
+
         schema_1 = self.create_schema(client, enable_dynamic_field=False)[0]
         schema_1.add_field("field1", DataType.INT64, is_primary=True, auto_id=False)
-        schema_1.add_field("field2", DataType.INT64, is_primary=True, auto_id=False)  # Second primary key
-        schema_1.add_field("vector_field", DataType.FLOAT_VECTOR, dim=32)
-        # Try to create collection with multiple primary keys
-        error = {ct.err_code: 999, ct.err_msg: "Expected only one primary key field"}
-        self.create_collection(
-            client, collection_name, schema=schema_1, check_task=CheckTasks.err_res, check_items=error
+        self.add_field(
+            schema_1,
+            "field2",
+            DataType.INT64,
+            is_primary=True,
+            auto_id=False,
+            check_task=CheckTasks.err_res,
+            check_items=error,
         )
 
         schema_2 = self.create_schema(client, enable_dynamic_field=False, primary_field="field2")[0]
         schema_2.add_field("field1", DataType.INT64, is_primary=True, auto_id=False)
-        schema_2.add_field("field2", DataType.INT64)  # Second primary key
-        schema_2.add_field("vector_field", DataType.FLOAT_VECTOR, dim=32)
-        # Try to create collection with multiple primary keys
-        error = {ct.err_code: 999, ct.err_msg: "Expected only one primary key field"}
-        self.create_collection(
-            client, collection_name, schema=schema_2, check_task=CheckTasks.err_res, check_items=error
+        self.add_field(
+            schema_2,
+            "field2",
+            DataType.INT64,
+            check_task=CheckTasks.err_res,
+            check_items=error,
         )
 
     @pytest.mark.tags(CaseLabel.L2)

--- a/tests/python_client/milvus_client/test_milvus_client_external_table.py
+++ b/tests/python_client/milvus_client/test_milvus_client_external_table.py
@@ -78,6 +78,9 @@ _EXTERNAL_ADD_FIELD_UNSUPPORTED_PUBLIC_TYPES = {
 }
 _EXTERNAL_ADD_FIELD_PROTO_ONLY_UNSUPPORTED_TYPES = {
     "Mol": 27,
+    "Date": 28,
+    "Time": 29,
+    "Decimal": 30,
 }
 _EXTERNAL_ADD_FIELD_INTERNAL_TYPES = {
     DataType.NONE,
@@ -2965,7 +2968,7 @@ class TestMilvusClientExternalTableAddField(ExternalTableTestBase):
 
         error = {
             ct.err_code: 1100,
-            ct.err_msg: "DropCollectionFunction RPC is no longer supported; drop a function via drop_function_field",
+            ct.err_msg: "alter collection schema operation is not supported for external collection",
         }
         self.drop_function_field(
             client,

--- a/tests/python_client/milvus_client/test_milvus_client_sparse_inverted_index.py
+++ b/tests/python_client/milvus_client/test_milvus_client_sparse_inverted_index.py
@@ -1124,7 +1124,9 @@ class TestSparseInvertedIndexV3Negative(_SparseInvertedIndexV3Base):
             "bad_codec",
             "IP",
             {"inverted_index_algo": "DAAT_MAXSCORE", "inverted_index_codec": "invalid_codec"},
-            "inverted_index_codec invalid_codec not found or not supported, supported: [block_streamvbyte block_maskedvbyte]: invalid parameter",
+            # The supported codec list is generated from the knowhere registry and
+            # can grow between releases, so assert only the stable rejection prefix.
+            "inverted_index_codec invalid_codec not found or not supported",
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
pr: #52997
pr: #52674
pr: #52758

### What this PR does

Update four outdated Python SDK E2E expectations on the 3.0 branch:

- Validate duplicate primary keys during schema construction.
- Classify the protobuf-only `Date`, `Time`, and `Decimal` data types.
- Expect the external-collection schema mutation error from `drop_function_field`.
- Stop pinning the complete Knowhere sparse codec list.

### Verification

- Ruff checks passed.
- Python compilation passed.
- All four affected pytest nodes were collected successfully.
- All four cases passed against the latest 3.0 build.