### PR TITLE
fix: [3.0] Allow added TEXT field on V2 growing load (#52972)

### DIFF
--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -365,14 +365,22 @@ ValidateGeometryInsertDataShape(const proto::schema::FieldData& field_data,
     }
 }
 
+// A StorageV2 column-group load only carries fields that were written to
+// binlogs. A TEXT field added to the schema after the segment was written
+// (AddField) has no binlog column, so the schema alone must not reject the
+// load: the empty column is backfilled by FillAbsentFields. Only a load info
+// that actually carries TEXT field data is invalid, because TEXT cannot be
+// persisted without a StorageV3 manifest (LOB spillover / query path).
 bool
-SchemaHasTextField(const Schema& schema) {
-    return std::any_of(schema.get_fields().begin(),
-                       schema.get_fields().end(),
-                       [](const auto& field) {
-                           return field.second.get_data_type() ==
-                                  DataType::TEXT;
-                       });
+LoadInfoHasTextField(const LoadFieldDataInfo& load_info, const Schema& schema) {
+    for (const auto& [_, info] : load_info.field_infos) {
+        auto fid = FieldId(info.field_id);
+        if (schema.has_field(fid) &&
+            schema.operator[](fid).get_data_type() == DataType::TEXT) {
+            return true;
+        }
+    }
+    return false;
 }
 
 }  // anonymous namespace
@@ -1181,7 +1189,7 @@ void
 SegmentGrowingImpl::load_column_group_data_internal(
     const LoadFieldDataInfo& infos) {
     auto schema = get_schema_snapshot();
-    AssertInfo(!SchemaHasTextField(*schema),
+    AssertInfo(!LoadInfoHasTextField(infos, *schema),
                "TEXT growing segment cannot be loaded from StorageV2 column "
                "groups; StorageV3 manifest is required");
 

--- a/internal/core/src/segcore/SegmentGrowingStorageV2Test.cpp
+++ b/internal/core/src/segcore/SegmentGrowingStorageV2Test.cpp
@@ -42,6 +42,7 @@
 #include "common/Schema.h"
 #include "common/TracerBase.h"
 #include "common/Types.h"
+#include "common/Utils.h"
 #include "common/protobuf_utils.h"
 #include "gtest/gtest.h"
 #include "knowhere/comp/index_param.h"
@@ -198,6 +199,110 @@ TEST_F(TestGrowingStorageV2, LoadFieldData) {
     };
     load_info.storage_version = 2;
     segment->LoadFieldData(load_info);
+}
+
+// Regression for add-field + legacy StorageV2 data: a growing segment written
+// by StorageV2 can have a TEXT field added to its schema afterwards (AddField)
+// while its binlogs carry no TEXT column and it has no StorageV3 manifest. The
+// V2 column-group load must NOT be rejected on the schema alone; the missing
+// TEXT column is backfilled with empty values by FillAbsentFields.
+TEST_F(TestGrowingStorageV2, LoadFieldDataWithAddedTextFieldBackfillsEmpty) {
+    int batch_size = 1000;
+
+    auto paths = std::vector<std::string>{path_ + "/10002.parquet",
+                                          path_ + "/10003.parquet"};
+    auto column_groups = std::vector<std::vector<int>>{{2}, {0, 1}};
+    auto writer_memory = 16 * 1024 * 1024;
+    auto storage_config = milvus_storage::StorageConfig();
+    auto result = milvus_storage::PackedRecordBatchWriter::Make(
+        fs_,
+        paths,
+        schema_,
+        storage_config,
+        column_groups,
+        writer_memory,
+        ::parquet::default_writer_properties());
+    EXPECT_TRUE(result.ok());
+    auto writer = result.ValueOrDie();
+    for (int i = 0; i < batch_size; ++i) {
+        EXPECT_TRUE(writer->Write(record_batch_).ok());
+    }
+    EXPECT_TRUE(writer->Close().ok());
+
+    // Binlog fields match the parquet (ts/pk/str -> field ids 100/101/102);
+    // the TEXT field (103) was added after the binlogs were written. Added
+    // fields must be nullable (proxy/task.go enforces this) so old rows read
+    // back as null.
+    auto schema = std::make_shared<milvus::Schema>();
+    schema->AddDebugField("ts", milvus::DataType::INT64, true);
+    auto pk_fid = schema->AddDebugField("pk", milvus::DataType::INT64, false);
+    schema->AddDebugField("str", milvus::DataType::VARCHAR, true);
+    auto text_fid = schema->AddDebugField("text", milvus::DataType::TEXT, true);
+    schema->set_primary_field_id(pk_fid);
+
+    auto segment =
+        milvus::segcore::CreateGrowingSegment(schema, milvus::empty_index_meta);
+    auto* segment_impl = dynamic_cast<SegmentGrowingImpl*>(segment.get());
+    ASSERT_NE(segment_impl, nullptr);
+
+    LoadFieldDataInfo load_info;
+    load_info.field_infos = {
+        {0,
+         FieldBinlogInfo{0,
+                         3000,
+                         std::vector<int64_t>{3000},
+                         std::vector<int64_t>{3000},
+                         false,
+                         "",
+                         std::vector<std::string>{paths[0]}}},
+        {1,
+         FieldBinlogInfo{1,
+                         3000,
+                         std::vector<int64_t>{3000},
+                         std::vector<int64_t>{3000},
+                         false,
+                         "",
+                         std::vector<std::string>{paths[1]}}},
+    };
+    load_info.storage_version = 2;
+
+    // Before the fix this asserted: the schema has a TEXT field so the V2
+    // column-group load was rejected even though the binlogs carry no TEXT
+    // column and the field is empty by construction.
+    segment->LoadFieldData(load_info);
+    ASSERT_EQ(segment->get_row_count(), 3000);
+
+    segment_impl->FillAbsentFields();
+
+    // The added TEXT column must be backfilled rather than left uninitialized:
+    // every old row reads back as null (validity false) and the raw column
+    // holds empty values.
+    auto* text_column = dynamic_cast<const ConcurrentVector<std::string>*>(
+        segment_impl->get_insert_record().get_data_base(text_fid));
+    ASSERT_NE(text_column, nullptr);
+    auto valid_data =
+        segment_impl->get_insert_record().get_valid_data(text_fid);
+    ASSERT_NE(valid_data, nullptr);
+    for (int64_t i = 0; i < 3000; ++i) {
+        EXPECT_FALSE(valid_data->is_valid(i)) << "row " << i << " not null";
+        EXPECT_TRUE(text_column->view_element(i).empty())
+            << "row " << i << " TEXT value is not empty";
+    }
+
+    // Exercise the query read path: backfilled rows must retrieve as null with
+    // an empty value, not be misread as LOB references (the loaded region
+    // [0, text_loaded_row_count_) is normally decoded via the LOB reader).
+    std::vector<int64_t> offsets(3000);
+    std::iota(offsets.begin(), offsets.end(), 0);
+    auto out = segment->bulk_subscript(nullptr, text_fid, offsets.data(), 3000);
+    ASSERT_NE(out, nullptr);
+    const auto& valid = GetFieldDataRowValidData(*out);
+    ASSERT_EQ(valid.size(), 3000);
+    for (int64_t i = 0; i < 3000; ++i) {
+        EXPECT_FALSE(valid[i]) << "row " << i << " not null via bulk_subscript";
+        EXPECT_TRUE(out->scalars().string_data().data(i).empty())
+            << "row " << i << " TEXT value is not empty via bulk_subscript";
+    }
 }
 
 TEST_F(TestGrowingStorageV2, LoadWithStrategy) {

--- a/internal/core/src/segcore/SegmentGrowingStorageV2Test.cpp
+++ b/internal/core/src/segcore/SegmentGrowingStorageV2Test.cpp
@@ -42,7 +42,6 @@
 #include "common/Schema.h"
 #include "common/TracerBase.h"
 #include "common/Types.h"
-#include "common/Utils.h"
 #include "common/protobuf_utils.h"
 #include "gtest/gtest.h"
 #include "knowhere/comp/index_param.h"
@@ -296,7 +295,7 @@ TEST_F(TestGrowingStorageV2, LoadFieldDataWithAddedTextFieldBackfillsEmpty) {
     std::iota(offsets.begin(), offsets.end(), 0);
     auto out = segment->bulk_subscript(nullptr, text_fid, offsets.data(), 3000);
     ASSERT_NE(out, nullptr);
-    const auto& valid = GetFieldDataRowValidData(*out);
+    const auto& valid = out->valid_data();
     ASSERT_EQ(valid.size(), 3000);
     for (int64_t i = 0; i < 3000; ++i) {
         EXPECT_FALSE(valid[i]) << "row " << i << " not null via bulk_subscript";


### PR DESCRIPTION
Cherry-pick from master
pr: #52972
The growing segment's StorageV2 column-group load rejected any segment whose schema contained a TEXT field, even when that TEXT field was added via AddField after the binlogs were written and so carries no data in this segment.

After enabling StorageV3 and adding a TEXT field to a legacy V2 collection, existing V2 growing segments could no longer load: the schema-wide guard fired, breaking the flush/sort/index pipelines backed by those segments. The "TEXT requires a StorageV3 manifest" invariant holds only for segments that actually contain TEXT data, not for an empty column added later.

Guard on the load info's actual fields (LoadInfoHasTextField) instead of the whole schema, matching the sealed-segment path and the DataCoord flush validation; the missing TEXT column is backfilled with null/empty values by FillAbsentFields. Covered by a new unit test that loads V2 binlogs without a TEXT column onto a schema that has one.

Related: #52454