### PR TITLE
enhance: hoist loop-invariant meta lookups in segment checker

### DIFF
--- a/internal/querycoordv2/checkers/segment_checker.go
+++ b/internal/querycoordv2/checkers/segment_checker.go
@@ -259,13 +259,28 @@ func (c *SegmentChecker) getGrowingSegmentDiff(ctx context.Context, collectionID
 	replica *meta.Replica,
 	delegatorList []*meta.DmChannel,
 ) (toLoad []*datapb.SegmentInfo, toRelease []*meta.Segment) {
+	if len(delegatorList) == 0 {
+		return toLoad, toRelease
+	}
+
 	log := mlog.With(
 		mlog.FieldCollectionID(collectionID),
 		mlog.Int64("replicaID", replica.GetID()))
 
+	// Hoisted out of the loop: all five depend only on collectionID. The two
+	// GetGrowingSegmentsByCollection calls rebuild a UniqueSet over every DM
+	// channel of the target, so an N-shard collection paid that N times per
+	// replica per check round. Trade-off: all five now run even when every
+	// delegator fails the version gate below, where the per-iteration form ran
+	// only the first.
+	targetVersion := c.targetMgr.GetCollectionTargetVersion(ctx, collectionID, meta.CurrentTarget)
+	nextTargetExist := c.targetMgr.IsNextTargetExist(ctx, collectionID)
+	nextTargetSegmentIDs := c.targetMgr.GetGrowingSegmentsByCollection(ctx, collectionID, meta.NextTarget)
+	currentTargetSegmentIDs := c.targetMgr.GetGrowingSegmentsByCollection(ctx, collectionID, meta.CurrentTarget)
+	currentTargetChannelMap := c.targetMgr.GetDmChannelsByCollection(ctx, collectionID, meta.CurrentTarget)
+
 	for _, d := range delegatorList {
 		view := d.View
-		targetVersion := c.targetMgr.GetCollectionTargetVersion(ctx, collectionID, meta.CurrentTarget)
 		if view.TargetVersion != targetVersion {
 			// before shard delegator update it's readable version, skip release segment
 			log.RatedInfo(ctx, rate.Limit(20), "before shard delegator update it's readable version, skip release segment",
@@ -276,11 +291,6 @@ func (c *SegmentChecker) getGrowingSegmentDiff(ctx context.Context, collectionID
 			)
 			continue
 		}
-
-		nextTargetExist := c.targetMgr.IsNextTargetExist(ctx, collectionID)
-		nextTargetSegmentIDs := c.targetMgr.GetGrowingSegmentsByCollection(ctx, collectionID, meta.NextTarget)
-		currentTargetSegmentIDs := c.targetMgr.GetGrowingSegmentsByCollection(ctx, collectionID, meta.CurrentTarget)
-		currentTargetChannelMap := c.targetMgr.GetDmChannelsByCollection(ctx, collectionID, meta.CurrentTarget)
 
 		// get segment which exist on leader view, but not on current target and next target
 		for _, segment := range view.GrowingSegments {
@@ -362,6 +372,13 @@ func (c *SegmentChecker) getSealedSegmentDiff(
 	currentTargetExist := c.targetMgr.IsCurrentTargetExist(ctx, collectionID, common.AllPartitionsID)
 	currentTargetMap := c.targetMgr.GetSealedSegmentsByCollection(ctx, collectionID, meta.CurrentTarget)
 
+	// Hoisted out of the loop below, where it was resolved once per segment on
+	// the refresh/import path and each call read-locks the collection manager's
+	// coordinator-wide RWMutex. The pointer only: IsRefreshed() still reads live
+	// state under the collection's own lock, so a refresh landing mid-loop is
+	// still observed.
+	collection := c.meta.GetCollection(ctx, collectionID)
+
 	// Segment which exist on next target, but not on dist
 	for _, segment := range nextTargetMap {
 		if isSegmentLack(segment) {
@@ -372,7 +389,6 @@ func (c *SegmentChecker) getSealedSegmentDiff(
 					loadPriorities = append(loadPriorities, commonpb.LoadPriority_HIGH)
 				} else {
 					// Segment not in current target -> check if refresh in progress
-					collection := c.meta.GetCollection(ctx, collectionID)
 					if collection != nil && !collection.IsRefreshed() {
 						// Refresh scenario (import) -> Use user's configured priority
 						loadPriorities = append(loadPriorities, replica.LoadPriority())


### PR DESCRIPTION
Both segment diff helpers in `SegmentChecker` repeat lookups inside a loop that only depend on `collectionID`, which is fixed for the whole call.

### `getGrowingSegmentDiff`

Five target manager lookups sat inside the `for _, d := range delegatorList` loop:

```go
for _, d := range delegatorList {
    targetVersion := c.targetMgr.GetCollectionTargetVersion(ctx, collectionID, meta.CurrentTarget)
    ...
    nextTargetExist := c.targetMgr.IsNextTargetExist(ctx, collectionID)
    nextTargetSegmentIDs := c.targetMgr.GetGrowingSegmentsByCollection(ctx, collectionID, meta.NextTarget)
    currentTargetSegmentIDs := c.targetMgr.GetGrowingSegmentsByCollection(ctx, collectionID, meta.CurrentTarget)
    currentTargetChannelMap := c.targetMgr.GetDmChannelsByCollection(ctx, collectionID, meta.CurrentTarget)
```

The two `GetGrowingSegmentsByCollection` calls are the expensive ones: each rebuilds a `UniqueSet` by walking every DM channel of the target and inserting its unflushed segment ids (`meta/target_manager.go:380`), so a collection with N shards did that construction N times per replica per check round.

Target reads themselves go through a `ConcurrentMap` with no reader-side lock, so this is redundant work and allocation, not lock contention. The trade is that all five lookups now run even when every delegator fails the version gate, where the per-iteration form ran only the first.

### `getSealedSegmentDiff`

`c.meta.GetCollection(ctx, collectionID)` was resolved once per segment that is in the next target, missing from dist, and absent from the current target — the refresh/import and handoff path, where `nextTargetMap` can hold thousands of segments. (On an initial load `currentTargetExist` is false, so the lookup was never reached at all.)

Each call read-locks the collection manager's coordinator-wide `RWMutex` (`meta/collection_manager.go:267`), which every collection write also takes exclusively.

The four target lookups directly above it in the same function were already hoisted this way — this only makes the fifth consistent with them.

### Behavior: two narrow concurrency deltas

Neither affects which segments are loaded or released.

1. **Growing path.** Under a target swap landing mid-loop, which delegators get skipped can differ from before, and a delegator can still pass the gate on a pre-swap version while the sets come from the post-swap target. That torn read is not new — the version and the sets are separate `ConcurrentMap` reads with no reader-side lock (`target.keyLock` guards writers only), so neither form yields a version and a snapshot taken from the same target object. It stays narrow: releasing a growing segment still requires absence from both targets plus either a dropped-id match or a seek position past the segment, and anything skipped is picked up next round.

2. **Sealed path.** Only the `*Collection` pointer is hoisted. `IsRefreshed()` stays inside the loop and still reads live state under the collection's own mutex, and `refreshCollection` mutates that field in place, so a refresh completing mid-loop is still observed. What is no longer seen is the map entry being swapped for a *different* `Collection` mid-loop — a concurrent `LoadCollection` installs a fresh object whose notifier is nil. That can only change the load priority chosen for those segments.

`getGrowingSegmentDiff` also returns early on an empty `delegatorList`, so the hoisted lookups are skipped when there is no work.

### Verification

`go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/querycoordv2/...` — all 11 packages pass.

The existing suite covers both changed paths:
- `TestReleaseGrowingSegments`, `TestReleaseCompactedGrowingSegments` and `TestSkipReleaseGrowingSegments` exercise the growing path, including the target-version skip branch that the hoisted `targetVersion` feeds.
- The sealed priority tests cover both the handoff branch (`IsRefreshed()` true → `LoadPriority_LOW`) and the refresh-in-progress branch (`IsRefreshed()` false → replica priority).

No benchmark was run. The claim is the reduction in redundant set construction and in acquisitions of the collection manager lock, both visible in the diff.
