### PR TITLE
enhance: read per-row config values once on the insert path

### DIFF
--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -2928,6 +2928,9 @@ func anyToColumns(rows []map[string]interface{}, validDataMap map[string][]bool,
 
 	dynamicCol := make([][]byte, 0, rowsLen)
 	fieldLen := make(map[string]int)
+	// Escape hatch for clients that relied on the previous value handling.
+	// Read once per request rather than per row, like checkAndSetData does.
+	compatibilityMode := paramtable.Get().HTTPCfg.CompatibilityMode.GetAsBool()
 
 	for _, row := range rows {
 		// collection schema name need not be same, since receiver could have other names
@@ -3046,7 +3049,7 @@ func anyToColumns(rows []map[string]interface{}, validDataMap map[string][]bool,
 			// distinct keys into one. Check the bytes that actually land.
 			// Gated like the per-value checks above: compatibilityMode restores
 			// the previous handling, which stored the wrapper unexamined.
-			if !paramtable.Get().HTTPCfg.CompatibilityMode.GetAsBool() {
+			if !compatibilityMode {
 				if err := checkEngineCompatible(common.MetaFieldName, string(bs)); err != nil {
 					return nil, err
 				}

--- a/internal/proxy/fieldvalidator/validate_util.go
+++ b/internal/proxy/fieldvalidator/validate_util.go
@@ -997,15 +997,21 @@ func (v *ValidateUtil) checkJSONFieldData(field *schemapb.FieldData, fieldSchema
 	}
 
 	if v.checkMaxLen {
+		// Resolved once per field rather than once per row: the GetAsX scalar
+		// getters go through config.Manager.GetCachedValue, which read-locks the config
+		// manager's cache before the map lookup, and this loop runs for every
+		// row of every insert that carries a JSON or dynamic field.
+		// checkVarCharFieldData likewise resolves its limit before its row loop
+		// (from the schema's type params rather than from config).
+		maxLength := paramtable.Get().CommonCfg.JSONMaxLength.GetAsInt64()
 		for _, s := range jsonArray {
-			if int64(len(s)) > paramtable.Get().CommonCfg.JSONMaxLength.GetAsInt64() {
+			if int64(len(s)) > maxLength {
 				if field.GetIsDynamic() {
-					msg := fmt.Sprintf("the length (%d) of dynamic field exceeds max length (%d)", len(s),
-						paramtable.Get().CommonCfg.JSONMaxLength.GetAsInt64())
+					msg := fmt.Sprintf("the length (%d) of dynamic field exceeds max length (%d)", len(s), maxLength)
 					return merr.WrapErrParameterInvalid("valid length dynamic field", "length exceeds max length", msg)
 				}
 				msg := fmt.Sprintf("the length (%d) of json field (%s) exceeds max length (%d)", len(s),
-					field.GetFieldName(), paramtable.Get().CommonCfg.JSONMaxLength.GetAsInt64())
+					field.GetFieldName(), maxLength)
 				return merr.WrapErrParameterInvalid("valid length json string", "length exceeds max length", msg)
 			}
 		}

--- a/internal/proxy/fieldvalidator/validate_util_test.go
+++ b/internal/proxy/fieldvalidator/validate_util_test.go
@@ -7771,6 +7771,10 @@ func Test_ValidateUtil_checkJSONData(t *testing.T) {
 
 		err := v.checkJSONFieldData(data, f)
 		assert.Error(t, err)
+		// pin the limit the message reports, so a hoist that resolved the wrong
+		// config item shows up here
+		assert.Contains(t, err.Error(), fmt.Sprintf("of json field (json) exceeds max length (%d)",
+			paramtable.Get().CommonCfg.JSONMaxLength.GetAsInt64()))
 	})
 
 	t.Run("dynamic field exceed max length", func(t *testing.T) {
@@ -7799,6 +7803,8 @@ func Test_ValidateUtil_checkJSONData(t *testing.T) {
 
 		err := v.checkJSONFieldData(data, f)
 		assert.Error(t, err)
+		assert.Contains(t, err.Error(), fmt.Sprintf("of dynamic field exceeds max length (%d)",
+			paramtable.Get().CommonCfg.JSONMaxLength.GetAsInt64()))
 	})
 }
 


### PR DESCRIPTION
Two spots on the insert path resolve a config value once per row.

The `GetAsX` scalar getters go through `config.Manager.GetCachedValue`, which read-locks the config manager's cache before the map lookup (`pkg/config/manager.go:116`). So this is per-row traffic on a lock shared by every goroutine in the process that reads any config, not a local read.

### `checkJSONFieldData` (`internal/proxy/fieldvalidator/validate_util.go`)

```go
for _, s := range jsonArray {
    if int64(len(s)) > paramtable.Get().CommonCfg.JSONMaxLength.GetAsInt64() {
```

Runs for every JSON field and for the dynamic field, so any collection created with `enable_dynamic_field` pays this on every row of every insert. The sibling `checkVarCharFieldData` likewise resolves its limit before its row loop (from the schema's type params rather than from config).

### `anyToColumns` (`internal/distributed/proxy/httpserver/utils.go`)

`HTTPCfg.CompatibilityMode` was read inside the per-row loop when building the dynamic field wrapper, so it scaled with the row count of a REST insert or upsert. The other three readers of that same key in this file — `checkAndSetData` and both serialize paths — already hoist it, with the comment "Read once per request rather than per field."

### Notes on behavior

No behavior change. Both values are request-scoped. Reading once also stops a mid-request config refresh from applying different limits to different rows of the same batch.

### Verification

```
go test -tags dynamic,test -gcflags="all=-N -l" -count=1 \
  ./internal/proxy/fieldvalidator/... ./internal/distributed/proxy/httpserver/...
ok  github.com/milvus-io/milvus/internal/proxy/fieldvalidator            16.836s
ok  github.com/milvus-io/milvus/internal/distributed/proxy/httpserver   115.306s
```

The existing suites cover the exact lines touched:
- `TestDynamicWrapperCheckHonorsCompatibilityMode` drives the dynamic wrapper gate in both compatibility modes.
- `Test_ValidateUtil_checkJSONData` covers the JSON and dynamic-field over-length errors. Those two subtests now also assert the limit the message reports, so a hoist that resolved the wrong config item shows up there.

No benchmark was run; the claim is the removal of per-row acquisitions of the shared config cache lock, which is visible in the diff.
