### PR TITLE
enhance: update Knowhere to dd3dce0f

### DIFF
--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update KNOWHERE_VERSION for the first occurrence
 milvus_add_pkg_config("knowhere")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( KNOWHERE_VERSION d7cfd888 )
+set( KNOWHERE_VERSION dd3dce0f )
 set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
 
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")

--- a/tests/_helm/values/e2e-amd/distributed-pulsar
+++ b/tests/_helm/values/e2e-amd/distributed-pulsar
@@ -85,6 +85,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-amd/distributed-woodpecker-service-boundary
+++ b/tests/_helm/values/e2e-amd/distributed-woodpecker-service-boundary
@@ -91,6 +91,9 @@ extraConfigFiles:
       segment:
         insertBufSize: 1048576
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 5
       enableCompaction: true
       compaction:
         enableAutoCompaction: false

--- a/tests/_helm/values/e2e-amd/standalone
+++ b/tests/_helm/values/e2e-amd/standalone
@@ -44,6 +44,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-amd/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e-amd/standalone-kafka-mmap
@@ -40,6 +40,9 @@ extraConfigFiles:
         # enable storage v3
         useLoonFFI: true
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-amd/standalone-wp-embed
+++ b/tests/_helm/values/e2e-amd/standalone-wp-embed
@@ -44,6 +44,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-arm/distributed-pulsar
+++ b/tests/_helm/values/e2e-arm/distributed-pulsar
@@ -72,6 +72,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-arm/distributed-woodpecker-service-boundary
+++ b/tests/_helm/values/e2e-arm/distributed-woodpecker-service-boundary
@@ -1,24 +1,17 @@
-affinity:
-  nodeAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-    - preference:
-        matchExpressions:
-        - key: jenkins-e2e-amd
-          operator: In
-          values:
-          - "true"
-      weight: 100
-    - preference:
-        matchExpressions:
-        - key: node-role.kubernetes.io/e2e
-          operator: Exists
-      weight: 1
+nodeSelector:
+  jenkins-e2e-arm: "true"
 cluster:
   enabled: true
 woodpecker:
   enabled: true
+  image:
+    repository: harbor.milvus.io/woodpecker/woodpecker
+    tag: v0.1.37
+    pullPolicy: Always
 streaming:
   enabled: true
+  woodpecker:
+    embedded: false
 proxy:
   replicas: 2
   resources:
@@ -39,16 +32,6 @@ dataNode:
       memory: 500Mi
 indexNode:
   enabled: false
-  replicas: 2
-  disk:
-    enabled: true
-  resources:
-    limits:
-      cpu: "2"
-      memory: 8Gi
-    requests:
-      cpu: "0.5"
-      memory: 500Mi
 queryNode:
   replicas: 2
   disk:
@@ -84,6 +67,7 @@ log:
 extraConfigFiles:
   user.yaml: |+
     common:
+      bloomFilterApplyBatchSize: 511
       storage:
         enablev2: true
         # enable storage v3
@@ -91,46 +75,53 @@ extraConfigFiles:
     dataNode:
       storage:
         format: vortex
+      segment:
+        insertBufSize: 1048576
     dataCoord:
       targetVecIndexVersion: 11
       forceRebuildScalarSegmentIndex: true
       targetScalarIndexVersion: 5
+      enableCompaction: true
       compaction:
+        enableAutoCompaction: false
         storageVersion:
           enabled: true
         storageFormat:
           enabled: true
         bumpSchemaVersion:
           enabled: true
+      segment:
+        maxSize: 64
+        sealProportion: 0.05
+        sealProportionJitter: 0
       gc:
         interval: 1800
         missingTolerance: 1800
         dropTolerance: 1800
     queryNode:
       segcore:
-        exprEvalBatchSize: 512
+        exprEvalBatchSize: 511
+        storageV2:
+          cellTargetSizeBytes: 1048576
+      mmap:
+        vectorField: true
+        vectorIndex: true
+        scalarField: true
+        scalarIndex: true
+        growingMmapEnabled: true
     queryCoord:
       checkNodeInReplicaInterval: 3
+    quotaAndLimits:
+      flushRate:
+        collection:
+          max: 4
 metrics:
   serviceMonitor:
     enabled: true
 # dependencies
 etcd:
-  affinity:
-    nodeAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - preference:
-          matchExpressions:
-          - key: jenkins-e2e-amd
-            operator: In
-            values:
-            - "true"
-        weight: 100
-      - preference:
-          matchExpressions:
-          - key: node-role.kubernetes.io/e2e
-            operator: Exists
-        weight: 1
+  nodeSelector:
+    jenkins-e2e-arm: "true"
   metrics:
     enabled: true
     podMonitor:
@@ -144,29 +135,12 @@ etcd:
       cpu: "1"
       memory: 4Gi
   tolerations:
-  - effect: PreferNoSchedule
-    key: jenkins-milvus-ci-only
-    operator: Equal
-    value: "true"
   - effect: NoSchedule
-    key: node-role.kubernetes.io/e2e
+    key: jenkins-e2e-arm
     operator: Exists
 minio:
-  affinity:
-    nodeAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - preference:
-          matchExpressions:
-          - key: jenkins-e2e-amd
-            operator: In
-            values:
-            - "true"
-        weight: 100
-      - preference:
-          matchExpressions:
-          - key: node-role.kubernetes.io/e2e
-            operator: Exists
-        weight: 1
+  nodeSelector:
+    jenkins-e2e-arm: "true"
   mode: standalone
   resources:
     requests:
@@ -176,13 +150,11 @@ minio:
       cpu: "1"
       memory: 4Gi
   tolerations:
-  - effect: PreferNoSchedule
-    key: jenkins-milvus-ci-only
-    operator: Equal
-    value: "true"
   - effect: NoSchedule
-    key: node-role.kubernetes.io/e2e
+    key: jenkins-e2e-arm
     operator: Exists
+kafka:
+  enabled: false
 pulsarv3:
   enabled: false
 # others
@@ -191,3 +163,7 @@ image:
     pullPolicy: Always
     repository: harbor.milvus.io/milvus/milvus
     tag: nightly-20240821-ed4eaff
+tolerations:
+- effect: NoSchedule
+  key: jenkins-e2e-arm
+  operator: Exists

--- a/tests/_helm/values/e2e-arm/standalone
+++ b/tests/_helm/values/e2e-arm/standalone
@@ -31,6 +31,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-arm/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e-arm/standalone-kafka-mmap
@@ -27,6 +27,9 @@ extraConfigFiles:
         # enable storage v3
         useLoonFFI: true
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-arm/standalone-wp-embed
+++ b/tests/_helm/values/e2e-arm/standalone-wp-embed
@@ -31,6 +31,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e/distributed-pulsar
+++ b/tests/_helm/values/e2e/distributed-pulsar
@@ -85,6 +85,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e/standalone
+++ b/tests/_helm/values/e2e/standalone
@@ -44,6 +44,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e/standalone-kafka-mmap
@@ -40,6 +40,9 @@ extraConfigFiles:
         # enable storage v3
         useLoonFFI: true
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-kafka
+++ b/tests/_helm/values/nightly/distributed-kafka
@@ -86,6 +86,9 @@ extraConfigFiles:
         # enable storage v3
         useLoonFFI: true
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-pulsar-mmap
+++ b/tests/_helm/values/nightly/distributed-pulsar-mmap
@@ -87,6 +87,9 @@ extraConfigFiles:
         # enable storage v3
         useLoonFFI: true
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-woodpecker-service
+++ b/tests/_helm/values/nightly/distributed-woodpecker-service
@@ -98,6 +98,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 5
       compaction:
         storageVersion:
           enabled: true

--- a/tests/_helm/values/nightly/standalone-authentication-mmap
+++ b/tests/_helm/values/nightly/standalone-authentication-mmap
@@ -37,6 +37,9 @@ log:
 extraConfigFiles:
   user.yaml: |+
     dataCoord:
+      targetVecIndexVersion: 11
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 5
       compaction:
         bumpSchemaVersion:
           enabled: true


### PR DESCRIPTION
## What

- Update Knowhere from `d7cfd888` to commit `dd3dce0f`.
- Pick up zilliztech/knowhere#1788 (bump `kEmbListMetaV2MinVersion` 10 → 11).
- Pick up zilliztech/knowhere#1790 (fix growable index for `block_max_maxscore` / `block_max_wand`).
- Pick up zilliztech/knowhere#1789 (dependency pin refresh).
- Pick up zilliztech/knowhere#1787 (bound `AioContextPool` waits, fail fast on empty pool).
- Pick up zilliztech/knowhere#1792 (preserve SVS all-pass selector semantics).
- Pick up zilliztech/knowhere#1799 (dependency pin refresh).
- Pick up #52799: bump CI Helm values to `targetVecIndexVersion: 11` / `targetScalarIndexVersion: 5`.

## Why

Picks up the latest Knowhere `main`, including its refreshed dependency pins.

The Helm values pick is required by this upgrade. knowhere#1788 raises
`kEmbListMetaV2MinVersion` to 11, so the embedding-list Muvera/Lemur strategies now
need index engine version >= 11 to emit the V2 metadata format. The CI clusters
previously resolved new vector indexes to version 10, which falls back to the legacy
TokenANN-only serialization path and fails the build, so `create_index` never completed
and all 12 `test_search_emb_list_with_explicit_strategy[{muvera,lemur}-*]` cases timed
out after 120s in `ci-v2/e2e-default`. The same values change is already merged on the
3.0 branch (#52800), which is why the 3.0 companion PR passes on the identical pin.

## Validation

- No local build/test for this dependency-pin-only change; validation is delegated to Milvus PR CI.
- `dd3dce0f` is the merge commit of Knowhere PR #1799 and current Knowhere `main` HEAD.
- Helm values content is identical to #52799.

3.0 companion: #53009
