### PR TITLE
enhance: [3.0] update Knowhere to v3.0.10

### DIFF
--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update KNOWHERE_VERSION for the first occurrence
 milvus_add_pkg_config("knowhere")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( KNOWHERE_VERSION 59c51f0a )
+set( KNOWHERE_VERSION v3.0.10 )
 set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
 
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")


### PR DESCRIPTION
pr: #53008

Cherry-pick from master.

## What

Pin Knowhere tag `v3.0.10` (= `main` commit `dd3dce0f`, zilliztech/knowhere#1799), refreshing the pinned dependency versions.

## Validation

- No local build/test for this dependency-pin-only change; validation is delegated to Milvus PR CI.
- `v3.0.10` is tagged on zilliztech/knowhere at `dd3dce0f`.
- The `3.0` base already pins Knowhere containing knowhere#1788 (min engine version 11), and Milvus #52800 updated the CI target vector index version to 11, so the Muvera/Lemur EBL matrix stays enabled with no test changes here (same as #52821).
