### PR TITLE
enhance: gate write-before function materialization on cluster version

### DIFF
--- a/cmd/roles/roles.go
+++ b/cmd/roles/roles.go
@@ -528,6 +528,11 @@ func (mr *MilvusRoles) Run() {
 
 	if (mr.EnableRootCoord && mr.EnableDataCoord && mr.EnableQueryCoord) || mr.EnableMixCoord {
 		paramtable.SetLocalComponentEnabled(typeutil.MixCoordRole)
+		// The version-gate switcher is a cluster-wide, one-shot capability:
+		// only the MixCoord role starts it, so a single coordinator drives the
+		// flip of every version-gated config item. Other roles observe the
+		// flipped value through the regular config refresh.
+		paramtable.StartVersionGateSwitcher()
 		mixCoord := mr.runMixCoord(ctx, local)
 		componentFutureMap[typeutil.MixCoordRole] = mixCoord
 	}

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1760,4 +1760,3 @@ function:
     local_resource_path: /var/lib/milvus/analyzer
     concurrency_per_cpu_core: 8 # The concurrency per cpu core for analyzer, pipeline not included
     runner_concurrency: 8 # The concurrency for each function runner to tokenize text
-  enableWriteBeforeMaterialization: auto # Whether to materialize function output fields (e.g. BM25 sparse vectors) before WAL append. auto: switch on automatically once the whole cluster reaches 2.6.23 and the stability window elapses; false: always keep the legacy format (escape hatch); true: force enable and bypass the version gate (use with caution).

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1760,3 +1760,4 @@ function:
     local_resource_path: /var/lib/milvus/analyzer
     concurrency_per_cpu_core: 8 # The concurrency per cpu core for analyzer, pipeline not included
     runner_concurrency: 8 # The concurrency for each function runner to tokenize text
+  enableWriteBeforeMaterialization: auto # Whether to materialize function output fields (e.g. BM25 sparse vectors) before WAL append. auto: switch on automatically once the whole cluster reaches 2.6.23 and the stability window elapses; false: always keep the legacy format (escape hatch); true: force enable and bypass the version gate (use with caution).

--- a/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor.go
@@ -190,8 +190,10 @@ func (impl *shardInterceptor) handleInsertMessage(ctx context.Context, msg messa
 	}
 	// Write-before function materialization is version-gated: it only runs once
 	// the whole cluster has confirmed version >= GateVersion (config default
-	// "auto"); before that the write path keeps the legacy format.
-	if paramtable.Get().FunctionCfg.EnableWriteBeforeMaterialization.GetAsBoolEffective() {
+	// "auto"); before that the write path keeps the legacy format. The gate is
+	// applied at the config-item read layer, so GetAsBool already returns the
+	// effective value.
+	if paramtable.Get().FunctionCfg.EnableWriteBeforeMaterialization.GetAsBool() {
 		if err := impl.materializeFunctionFields(ctx, insertMsg, header.GetCollectionId(), schemaVersion); err != nil {
 			impl.shardManager.Logger().Warn(ctx, "failed to materialize function fields before WAL append",
 				mlog.Int64("collectionID", header.GetCollectionId()),

--- a/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor.go
@@ -204,8 +204,9 @@ func (impl *shardInterceptor) handleInsertMessage(ctx context.Context, msg messa
 	}
 	for _, partition := range header.GetPartitions() {
 		if partition.BinarySize == 0 {
-			// Proxy does not estimate binary size today. Use payload size after
-			// write-before materialization when the estimate is absent.
+			// Proxy does not estimate binary size today. Use the payload size;
+			// note this excludes materialized function output fields while the
+			// version gate is off (matching pre-feature behavior).
 			partition.BinarySize = uint64(msg.EstimateSize())
 		}
 		req := &shards.AssignSegmentRequest{

--- a/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message/messageutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 const interceptorName = "shard"
@@ -187,12 +188,17 @@ func (impl *shardInterceptor) handleInsertMessage(ctx context.Context, msg messa
 	if header.SchemaVersion == nil {
 		schemaVersion = function.LatestFunctionRunnerVersion
 	}
-	if err := impl.materializeFunctionFields(ctx, insertMsg, header.GetCollectionId(), schemaVersion); err != nil {
-		impl.shardManager.Logger().Warn(ctx, "failed to materialize function fields before WAL append",
-			mlog.Int64("collectionID", header.GetCollectionId()),
-			mlog.Int32("schemaVersion", schemaVersion),
-			mlog.Err(err))
-		return nil, status.NewUnrecoverableError("failed to materialize function fields before WAL append: %s", err.Error())
+	// Write-before function materialization is version-gated: it only runs once
+	// the whole cluster has confirmed version >= GateVersion (config default
+	// "auto"); before that the write path keeps the legacy format.
+	if paramtable.Get().FunctionCfg.EnableWriteBeforeMaterialization.GetAsBoolEffective() {
+		if err := impl.materializeFunctionFields(ctx, insertMsg, header.GetCollectionId(), schemaVersion); err != nil {
+			impl.shardManager.Logger().Warn(ctx, "failed to materialize function fields before WAL append",
+				mlog.Int64("collectionID", header.GetCollectionId()),
+				mlog.Int32("schemaVersion", schemaVersion),
+				mlog.Err(err))
+			return nil, status.NewUnrecoverableError("failed to materialize function fields before WAL append: %s", err.Error())
+		}
 	}
 	for _, partition := range header.GetPartitions() {
 		if partition.BinarySize == 0 {

--- a/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/impls/rmq"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 func allocWALSchemaForTest(t *testing.T, collectionID int64, vchannel string, schemaVersion int32) {
@@ -439,6 +440,13 @@ func TestShardInterceptorPassesExplicitZeroSchemaVersion(t *testing.T) {
 }
 
 func TestShardInterceptorRejectsMissingWALFunctionSnapshot(t *testing.T) {
+	// This test exercises the write-before materialization failure path, so the
+	// version gate must be activated (otherwise materialization is skipped and
+	// the append falls through to segment assignment).
+	item := &paramtable.Get().FunctionCfg.EnableWriteBeforeMaterialization
+	old := item.SwapTempValue("true")
+	defer item.SwapTempValue(old)
+
 	b := NewInterceptorBuilder()
 	shardManager := mock_shards.NewMockShardManager(t)
 	shardManager.EXPECT().Logger().Return(mlog.With()).Maybe()

--- a/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor_test.go
@@ -361,6 +361,13 @@ func TestShardInterceptorDeleteAppliesBeforeAppend(t *testing.T) {
 }
 
 func TestShardInterceptorPassesExplicitNonZeroSchemaVersion(t *testing.T) {
+	// This test exercises the write-before materialization path, so the version
+	// gate must be activated (otherwise materialization is skipped and the
+	// append falls through to segment assignment).
+	item := &paramtable.Get().FunctionCfg.EnableWriteBeforeMaterialization
+	old := item.SwapTempValue("true")
+	defer item.SwapTempValue(old)
+
 	allocWALSchemaForTest(t, 1, "v1", 3)
 	b := NewInterceptorBuilder()
 	shardManager := mock_shards.NewMockShardManager(t)
@@ -400,6 +407,13 @@ func TestShardInterceptorPassesExplicitNonZeroSchemaVersion(t *testing.T) {
 }
 
 func TestShardInterceptorPassesExplicitZeroSchemaVersion(t *testing.T) {
+	// This test exercises the write-before materialization path, so the version
+	// gate must be activated (otherwise materialization is skipped and the
+	// append falls through to segment assignment).
+	item := &paramtable.Get().FunctionCfg.EnableWriteBeforeMaterialization
+	old := item.SwapTempValue("true")
+	defer item.SwapTempValue(old)
+
 	allocWALSchemaForTest(t, 1, "v1", 0)
 	b := NewInterceptorBuilder()
 	shardManager := mock_shards.NewMockShardManager(t)

--- a/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor_version_gate_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor_version_gate_test.go
@@ -1,0 +1,117 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shard
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bytedance/mockey"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus/internal/mocks/streamingnode/server/wal/interceptors/shard/mock_shards"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/shards"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/impls/rmq"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+// TestShardInterceptorWriteBeforeMaterializationGate verifies that the
+// write-before function materialization only runs when the version-gated
+// config is effective:
+//   - gate off (legacy)   -> materializeFunctionFields is NOT called, append succeeds;
+//   - gate on (activated) -> materializeFunctionFields IS called before append.
+func TestShardInterceptorWriteBeforeMaterializationGate(t *testing.T) {
+	mockErr := errors.New("mock materialize error")
+	vchannel := "v1-gated"
+	collectionID := int64(99010)
+
+	b := NewInterceptorBuilder()
+	shardManager := mock_shards.NewMockShardManager(t)
+	shardManager.EXPECT().Logger().Return(mlog.With()).Maybe()
+	// handleInsertMessage checks the collection schema version before the
+	// materialization gate (master-specific); stub it to pass through so the
+	// tests exercise the gate itself.
+	shardManager.EXPECT().CheckIfCollectionSchemaVersionMatch(mock.Anything).Return(int32(0), nil)
+	i := b.Build(&interceptors.InterceptorBuildParam{
+		ShardManager: shardManager,
+	})
+	defer i.Close()
+	ctx := context.Background()
+	appender := func(ctx context.Context, msg message.MutableMessage) (message.MessageID, error) {
+		return rmq.NewRmqID(1), nil
+	}
+
+	buildInsert := func() message.MutableMessage {
+		return message.NewInsertMessageBuilderV1().
+			WithVChannel(vchannel).
+			WithHeader(&messagespb.InsertMessageHeader{
+				CollectionId: collectionID,
+				Partitions: []*messagespb.PartitionSegmentAssignment{
+					{
+						PartitionId: 1,
+						Rows:        1,
+						BinarySize:  100,
+					},
+				},
+			}).
+			WithBody(&msgpb.InsertRequest{}).
+			MustBuildMutable().WithTimeTick(1)
+	}
+
+	// Patch materializeFunctionFields so we can observe whether the gate lets
+	// it run (returning an error makes the append fail when it is called).
+	m := mockey.Mock((*shardInterceptor).materializeFunctionFields).
+		Return(mockErr).Build()
+	defer m.UnPatch()
+
+	item := &paramtable.Get().FunctionCfg.EnableWriteBeforeMaterialization
+
+	t.Run("gate off keeps legacy format (materialize not called)", func(t *testing.T) {
+		// Swap the config value to the sentinel: the gate is not flipped, so
+		// the pre-switch value (false) takes effect.
+		old := item.SwapTempValue("auto")
+		defer item.SwapTempValue(old)
+
+		shardManager.EXPECT().AssignSegment(mock.Anything).
+			Return(&shards.AssignSegmentResult{SegmentID: 1, Acknowledge: atomic.NewInt32(1)}, nil).Once()
+		msgID, err := i.DoAppend(ctx, buildInsert(), appender)
+		assert.NoError(t, err)
+		assert.NotNil(t, msgID)
+	})
+
+	t.Run("gate on materializes before append", func(t *testing.T) {
+		// Swap the config value to the target (flipped value): the gate is
+		// resolved and materialization runs.
+		old := item.SwapTempValue("true")
+		defer item.SwapTempValue(old)
+
+		// materializeFunctionFields returns mockErr -> the append must fail
+		// before reaching AssignSegment.
+		msgID, err := i.DoAppend(ctx, buildInsert(), appender)
+		require.Error(t, err)
+		assert.Nil(t, msgID)
+	})
+}

--- a/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor_version_gate_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor_version_gate_test.go
@@ -52,8 +52,8 @@ func TestShardInterceptorWriteBeforeMaterializationGate(t *testing.T) {
 	shardManager := mock_shards.NewMockShardManager(t)
 	shardManager.EXPECT().Logger().Return(mlog.With()).Maybe()
 	// handleInsertMessage checks the collection schema version before the
-	// materialization gate (master-specific); stub it to pass through so the
-	// tests exercise the gate itself.
+	// materialization gate; stub it to pass through so the tests exercise the
+	// gate itself.
 	shardManager.EXPECT().CheckIfCollectionSchemaVersionMatch(mock.Anything).Return(int32(0), nil)
 	i := b.Build(&interceptors.InterceptorBuildParam{
 		ShardManager: shardManager,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,7 +69,11 @@ func Init(opts ...Option) (*Manager, error) {
 		sourceManager.AddSource(NewEnvSource(o.EnvKeyFormatter))
 	}
 	if o.EtcdInfo != nil {
-		s, err := NewEtcdSource(o.EtcdInfo)
+		etcdCli, err := newEtcdClient(o.EtcdInfo)
+		if err != nil {
+			return nil, err
+		}
+		s, err := NewEtcdSource(etcdCli, o.EtcdInfo)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -100,6 +100,14 @@ func formatKey(key string) string {
 	return result
 }
 
+// FormatKey formats a config key for storage/retrieval in the config sources
+// (lowercased, with '/', '_' and '.' stripped). It is the exported form of
+// formatKey for callers that must address config keys directly, e.g. writing
+// to the config center from outside pkg/config.
+func FormatKey(key string) string {
+	return formatKey(key)
+}
+
 func flattenAndMergeMap(prefix string, m map[string]interface{}, result map[string]string) {
 	for k, v := range m {
 		fullKey := k

--- a/pkg/config/etcd_source.go
+++ b/pkg/config/etcd_source.go
@@ -48,9 +48,11 @@ type EtcdSource struct {
 	manager         ConfigManager
 }
 
-func NewEtcdSource(etcdInfo *EtcdInfo) (*EtcdSource, error) {
-	mlog.Debug(context.TODO(), "init etcd source", mlog.Any("etcdInfo", etcdInfo))
-	etcdCli, err := etcd.CreateEtcdClient(
+// newEtcdClient creates the etcd client described by info. The client is owned
+// by the caller: it is passed into NewEtcdSource (which never constructs its
+// own client) and may be shared with other etcd users.
+func newEtcdClient(etcdInfo *EtcdInfo) (*clientv3.Client, error) {
+	return etcd.CreateEtcdClient(
 		etcdInfo.UseEmbed,
 		etcdInfo.EnableAuth,
 		etcdInfo.UserName,
@@ -62,9 +64,18 @@ func NewEtcdSource(etcdInfo *EtcdInfo) (*EtcdSource, error) {
 		etcdInfo.CaCertFile,
 		etcdInfo.MinVersion,
 		etcd.WithDialTimeout(etcdInfo.DialTimeout))
-	if err != nil {
-		return nil, err
+}
+
+// NewEtcdSource creates an etcd config source over the given client. The
+// client is injected by the caller and never constructed here, so it can be
+// shared with other etcd users (e.g. the version gate confirmator); the source
+// does not own it and Close does not close it. A nil client is rejected: the
+// source would otherwise fail asynchronously in its refresher.
+func NewEtcdSource(etcdCli *clientv3.Client, etcdInfo *EtcdInfo) (*EtcdSource, error) {
+	if etcdCli == nil {
+		return nil, errors.New("nil etcd client")
 	}
+	mlog.Debug(context.TODO(), "init etcd source", mlog.Any("etcdInfo", etcdInfo))
 	es := &EtcdSource{
 		etcdCli:        etcdCli,
 		ctx:            context.Background(),

--- a/pkg/config/etcd_source.go
+++ b/pkg/config/etcd_source.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/util/etcd"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 const (
@@ -73,7 +74,7 @@ func newEtcdClient(etcdInfo *EtcdInfo) (*clientv3.Client, error) {
 // source would otherwise fail asynchronously in its refresher.
 func NewEtcdSource(etcdCli *clientv3.Client, etcdInfo *EtcdInfo) (*EtcdSource, error) {
 	if etcdCli == nil {
-		return nil, errors.New("nil etcd client")
+		return nil, merr.WrapErrServiceInternal("nil etcd client")
 	}
 	mlog.Debug(context.TODO(), "init etcd source", mlog.Any("etcdInfo", etcdInfo))
 	es := &EtcdSource{

--- a/pkg/config/etcd_source_test.go
+++ b/pkg/config/etcd_source_test.go
@@ -47,7 +47,10 @@ func (s *EtcdSourceSuite) TearDownSuite() {
 }
 
 func (s *EtcdSourceSuite) TestNewSource() {
-	source, err := NewEtcdSource(&EtcdInfo{
+	etcdCli, err := newEtcdClient(&EtcdInfo{Endpoints: s.endpoints, DialTimeout: 5 * time.Second})
+	s.Require().NoError(err)
+	defer etcdCli.Close()
+	source, err := NewEtcdSource(etcdCli, &EtcdInfo{
 		Endpoints:       s.endpoints,
 		KeyPrefix:       "by-dev",
 		DialTimeout:     5 * time.Second,
@@ -59,7 +62,10 @@ func (s *EtcdSourceSuite) TestNewSource() {
 }
 
 func (s *EtcdSourceSuite) TestUpdateOptions() {
-	source, err := NewEtcdSource(&EtcdInfo{
+	etcdCli, err := newEtcdClient(&EtcdInfo{Endpoints: s.endpoints, DialTimeout: 5 * time.Second})
+	s.Require().NoError(err)
+	defer etcdCli.Close()
+	source, err := NewEtcdSource(etcdCli, &EtcdInfo{
 		Endpoints:       s.endpoints,
 		KeyPrefix:       "test_update_options_1",
 		RefreshInterval: time.Second,

--- a/pkg/util/paramtable/base_table.go
+++ b/pkg/util/paramtable/base_table.go
@@ -29,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 // UniqueID is type alias of typeutil.UniqueID
@@ -74,6 +75,12 @@ type BaseTable struct {
 	once   sync.Once
 	mgr    *config.Manager
 	config *baseTableConfig
+
+	// etcdClient is the single etcd client created when remote config is
+	// enabled. It is injected into the config etcd source and shared with other
+	// etcd users (e.g. the version gate confirmator); it lives for the process
+	// lifetime and is never closed by the source.
+	etcdClient *clientv3.Client
 }
 
 type baseTableConfig struct {
@@ -202,23 +209,29 @@ func (bt *BaseTable) initConfigsFromRemote() {
 	if etcdConfig.UseEmbedEtcd.GetAsBool() && !etcd.HasServer() {
 		return
 	}
+	etcdCli, err := etcd.CreateEtcdClient(
+		etcdConfig.UseEmbedEtcd.GetAsBool(),
+		etcdConfig.EtcdEnableAuth.GetAsBool(),
+		etcdConfig.EtcdAuthUserName.GetValue(),
+		etcdConfig.EtcdAuthPassword.GetValue(),
+		etcdConfig.EtcdUseSSL.GetAsBool(),
+		etcdConfig.Endpoints.GetAsStrings(),
+		etcdConfig.EtcdTLSCert.GetValue(),
+		etcdConfig.EtcdTLSKey.GetValue(),
+		etcdConfig.EtcdTLSCACert.GetValue(),
+		etcdConfig.EtcdTLSMinVersion.GetValue(),
+		etcd.WithDialTimeout(etcdConfig.DialTimeout.GetAsDuration(time.Millisecond)))
+	if err != nil {
+		mlog.Warn(context.TODO(), "init with etcd client failed", mlog.Err(err))
+		return
+	}
+	bt.etcdClient = etcdCli
+
 	info := &config.EtcdInfo{
-		UseEmbed:        etcdConfig.UseEmbedEtcd.GetAsBool(),
-		EnableAuth:      etcdConfig.EtcdEnableAuth.GetAsBool(),
-		UserName:        etcdConfig.EtcdAuthUserName.GetValue(),
-		PassWord:        etcdConfig.EtcdAuthPassword.GetValue(),
-		UseSSL:          etcdConfig.EtcdUseSSL.GetAsBool(),
-		Endpoints:       etcdConfig.Endpoints.GetAsStrings(),
-		CertFile:        etcdConfig.EtcdTLSCert.GetValue(),
-		KeyFile:         etcdConfig.EtcdTLSKey.GetValue(),
-		CaCertFile:      etcdConfig.EtcdTLSCACert.GetValue(),
-		MinVersion:      etcdConfig.EtcdTLSMinVersion.GetValue(),
 		KeyPrefix:       etcdConfig.RootPath.GetValue(),
-		DialTimeout:     etcdConfig.DialTimeout.GetAsDuration(time.Millisecond),
 		RefreshInterval: refreshInterval,
 	}
-
-	s, err := config.NewEtcdSource(info)
+	s, err := config.NewEtcdSource(etcdCli, info)
 	if err != nil {
 		mlog.Info(context.TODO(), "init with etcd failed", mlog.Err(err))
 		return

--- a/pkg/util/paramtable/base_table.go
+++ b/pkg/util/paramtable/base_table.go
@@ -25,11 +25,12 @@ import (
 	"sync"
 	"time"
 
+	clientv3 "go.etcd.io/etcd/client/v3"
+
 	"github.com/milvus-io/milvus/pkg/v3/config"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
-	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 // UniqueID is type alias of typeutil.UniqueID

--- a/pkg/util/paramtable/base_table_test.go
+++ b/pkg/util/paramtable/base_table_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus/pkg/v3/config"
+	etcdkv "github.com/milvus-io/milvus/pkg/v3/util/etcd"
 )
 
 var baseParams = NewBaseTable(SkipRemote(true))
@@ -31,6 +32,11 @@ var baseParams = NewBaseTable(SkipRemote(true))
 func TestMain(m *testing.M) {
 	baseParams.init()
 	code := m.Run()
+	// Stop the shared embedded etcd server (started lazily by the version-gate
+	// tests) after all tests.
+	if etcdkv.HasServer() {
+		etcdkv.StopEtcdServer()
+	}
 	os.Exit(code)
 }
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -27,9 +27,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/shirou/gopsutil/v4/disk"
 	"go.uber.org/atomic"
+	"go.uber.org/zap"
 
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/config"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/util/fips"
@@ -213,6 +216,31 @@ func (p *ComponentParam) versionGateItems() []*ParamItem {
 // confirmator stops itself.
 func (p *ComponentParam) initVersionGates() {
 	if p.baseTable == nil || p.baseTable.config.skipRemote {
+		return
+	}
+	// Embedded-etcd deployments are single-process (service_param.go enforces
+	// "embedded etcd can not be used under distributed mode"): the local process
+	// is the whole cluster, so when the local version already satisfies a gate
+	// there is nothing to coordinate across nodes — resolve the gate directly
+	// and skip the confirmator (there is no usable etcd client anyway).
+	if p.ServiceParam.EtcdCfg.UseEmbedEtcd.GetAsBool() {
+		for _, item := range p.versionGateItems() {
+			if item == nil || item.VersionGateSwitcher == nil {
+				continue
+			}
+			gv, err := semver.Parse(item.VersionGateSwitcher.GateVersion)
+			if err != nil {
+				// Validate() at Init already rejected malformed versions; on any
+				// residual parse issue keep the gate unresolved (PreSwitchValue).
+				continue
+			}
+			if common.Version.GE(gv) {
+				item.VersionGateSwitcher.localSatisfied = true
+				mlog.Info(context.TODO(), "version gate: embedded-etcd deployment, local version satisfies the gate",
+					zap.String("key", item.Key), zap.String("localVersion", common.Version.String()),
+					zap.String("gateVersion", item.VersionGateSwitcher.GateVersion))
+			}
+		}
 		return
 	}
 	// The confirmator shares the etcd client created for the config etcd

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -85,9 +85,9 @@ type ComponentParam struct {
 	baseTable *BaseTable
 
 	// versionGates drives the version-gated config items (e.g. write-before
-	// function materialization). It is created and started right after
-	// paramtable initialization; see initVersionGates.
-	versionGates *Confirmator
+	// function materialization). It is created and started by the MixCoord
+	// role after the role has been set; see StartVersionGateSwitcher.
+	versionGates *confirmator
 
 	CommonCfg       commonConfig
 	QuotaConfig     quotaConfig
@@ -194,8 +194,6 @@ func (p *ComponentParam) init(bt *BaseTable) {
 	p.StreamingNodeGrpcClientCfg.Init("streamingNode", bt)
 
 	p.IntegrationTestCfg.init(bt)
-
-	p.initVersionGates()
 }
 
 // versionGateItems returns every version-gated config item of the param table.
@@ -207,21 +205,34 @@ func (p *ComponentParam) versionGateItems() []*ParamItem {
 	}
 }
 
-// initVersionGates creates and starts the cluster version confirmator for
-// every version-gated config item, right after paramtable initialization. It
-// is a no-op when remote config is skipped (e.g. tests) or there is no usable
-// etcd, and it never blocks paramtable initialization: the initial resolution
-// reads etcd, so it runs in the background. Once every gate is resolved the
-// confirmator stops itself.
-func (p *ComponentParam) initVersionGates() {
-	if p.baseTable == nil || p.baseTable.config.skipRemote {
+// startVersionGateSwitcherOnce guards the one-shot global version-gate
+// switcher: only the MixCoord role calls StartVersionGateSwitcher, but the
+// once keeps the driving logic idempotent however it is reached.
+var startVersionGateSwitcherOnce sync.Once
+
+// StartVersionGateSwitcher drives every version-gated config item of the
+// process, exactly once. It is only called by the MixCoord role (the single
+// coordinator per cluster) after the role has been set; other roles observe
+// the flipped config value through the regular config refresh. Embedded-etcd
+// deployments are single-process (service_param.go enforces "embedded etcd
+// can not be used under distributed mode"): the local process is the whole
+// cluster, so when the local version already satisfies a gate there is
+// nothing to coordinate across nodes — resolve the gate directly and skip the
+// confirmator (there is no usable etcd client anyway). Otherwise the cluster
+// confirmator is created and started; it runs in the background and stops
+// itself once every gate is resolved. It is a no-op when remote config is
+// skipped (e.g. tests) or there is no usable etcd.
+func StartVersionGateSwitcher() {
+	startVersionGateSwitcherOnce.Do(func() {
+		Get().startVersionGates()
+	})
+}
+
+// startVersionGates implements StartVersionGateSwitcher on a param table.
+func (p *ComponentParam) startVersionGates() {
+	if p == nil || p.baseTable == nil || p.baseTable.config.skipRemote {
 		return
 	}
-	// Embedded-etcd deployments are single-process (service_param.go enforces
-	// "embedded etcd can not be used under distributed mode"): the local process
-	// is the whole cluster, so when the local version already satisfies a gate
-	// there is nothing to coordinate across nodes — resolve the gate directly
-	// and skip the confirmator (there is no usable etcd client anyway).
 	if p.EtcdCfg.UseEmbedEtcd.GetAsBool() {
 		for _, item := range p.versionGateItems() {
 			if item == nil || item.VersionGateSwitcher == nil {
@@ -253,7 +264,7 @@ func (p *ComponentParam) initVersionGates() {
 	if p.baseTable.etcdClient == nil {
 		return
 	}
-	vg, err := RecoverConfirmator(p.baseTable.etcdClient,
+	vg, err := recoverConfirmator(p.baseTable.etcdClient,
 		p.EtcdCfg.MetaRootPath.GetValue(), p.EtcdCfg.RootPath.GetValue(), p.versionGateItems())
 	if err != nil {
 		mlog.Warn(context.TODO(), "recover version gate confirmator failed", mlog.Err(err))

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -30,7 +30,6 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/shirou/gopsutil/v4/disk"
 	"go.uber.org/atomic"
-	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/config"
@@ -223,7 +222,7 @@ func (p *ComponentParam) initVersionGates() {
 	// is the whole cluster, so when the local version already satisfies a gate
 	// there is nothing to coordinate across nodes — resolve the gate directly
 	// and skip the confirmator (there is no usable etcd client anyway).
-	if p.ServiceParam.EtcdCfg.UseEmbedEtcd.GetAsBool() {
+	if p.EtcdCfg.UseEmbedEtcd.GetAsBool() {
 		for _, item := range p.versionGateItems() {
 			if item == nil || item.VersionGateSwitcher == nil {
 				continue
@@ -237,8 +236,8 @@ func (p *ComponentParam) initVersionGates() {
 			if common.Version.GE(gv) {
 				item.VersionGateSwitcher.localSatisfied = true
 				mlog.Info(context.TODO(), "version gate: embedded-etcd deployment, local version satisfies the gate",
-					zap.String("key", item.Key), zap.String("localVersion", common.Version.String()),
-					zap.String("gateVersion", item.VersionGateSwitcher.GateVersion))
+					mlog.String("key", item.Key), mlog.String("localVersion", common.Version.String()),
+					mlog.String("gateVersion", item.VersionGateSwitcher.GateVersion))
 			}
 		}
 		return

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -29,11 +29,9 @@ import (
 
 	"github.com/shirou/gopsutil/v4/disk"
 	"go.uber.org/atomic"
-	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/v3/config"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
-	"github.com/milvus-io/milvus/pkg/v3/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v3/util/fips"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/hardware"
@@ -217,37 +215,18 @@ func (p *ComponentParam) initVersionGates() {
 	if p.baseTable == nil || p.baseTable.config.skipRemote {
 		return
 	}
-	if p.EtcdCfg.Endpoints.GetValue() == "" {
+	// The confirmator shares the etcd client created for the config etcd
+	// source: when remote config is disabled or there is no usable etcd, no
+	// client exists and there is nothing to confirm against.
+	if p.baseTable.etcdClient == nil {
 		return
 	}
-	if p.EtcdCfg.UseEmbedEtcd.GetAsBool() && !etcd.HasServer() {
-		return
-	}
-	vg, err := NewConfirmator(&p.EtcdCfg, p.EtcdCfg.MetaRootPath.GetValue(), p.EtcdCfg.RootPath.GetValue())
+	vg, err := RecoverConfirmator(p.baseTable.etcdClient,
+		p.EtcdCfg.MetaRootPath.GetValue(), p.EtcdCfg.RootPath.GetValue(), p.versionGateItems())
 	if err != nil {
-		mlog.Warn(context.TODO(), "create version gate confirmator failed", mlog.Err(err))
+		mlog.Warn(context.TODO(), "recover version gate confirmator failed", mlog.Err(err))
 		return
 	}
-	for _, item := range p.versionGateItems() {
-		if item == nil || item.VersionGateSwitcher == nil {
-			continue
-		}
-		if err := vg.RegisterGate(item.Key, item.VersionGateSwitcher); err != nil {
-			mlog.Warn(context.TODO(), "register version gate failed, skip", zap.String("key", item.Key), mlog.Err(err))
-			continue
-		}
-	}
-	if len(vg.gates) == 0 {
-		vg.Stop()
-		return
-	}
-	// Start asynchronously: the initial gate resolution reads etcd and must
-	// not block paramtable initialization.
-	go func() {
-		if err := vg.Start(context.TODO()); err != nil {
-			mlog.Warn(context.TODO(), "start version gate confirmator failed", mlog.Err(err))
-		}
-	}()
 	p.versionGates = vg
 }
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -235,6 +235,11 @@ func (p *ComponentParam) initVersionGates() {
 			}
 			if common.Version.GE(gv) {
 				item.VersionGateSwitcher.localSatisfied = true
+				// GetAs* accessors short-circuit on the value cache, which is
+				// keyed by config key only and is blind to the runtime
+				// localSatisfied hint, so evict the cached entry to make the
+				// resolved value observable immediately.
+				p.baseTable.mgr.EvictCachedValue(item.Key)
 				mlog.Info(context.TODO(), "version gate: embedded-etcd deployment, local version satisfies the gate",
 					mlog.String("key", item.Key), mlog.String("localVersion", common.Version.String()),
 					mlog.String("gateVersion", item.VersionGateSwitcher.GateVersion))

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -29,9 +29,11 @@ import (
 
 	"github.com/shirou/gopsutil/v4/disk"
 	"go.uber.org/atomic"
+	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/v3/config"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v3/util/fips"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/hardware"
@@ -81,6 +83,11 @@ type ComponentParam struct {
 	ServiceParam
 	once      sync.Once
 	baseTable *BaseTable
+
+	// versionGates drives the version-gated config items (e.g. write-before
+	// function materialization). It is created and started right after
+	// paramtable initialization; see initVersionGates.
+	versionGates *Confirmator
 
 	CommonCfg       commonConfig
 	QuotaConfig     quotaConfig
@@ -187,6 +194,61 @@ func (p *ComponentParam) init(bt *BaseTable) {
 	p.StreamingNodeGrpcClientCfg.Init("streamingNode", bt)
 
 	p.IntegrationTestCfg.init(bt)
+
+	p.initVersionGates()
+}
+
+// versionGateItems returns every version-gated config item of the param table.
+// Gate registration follows paramtable initialization: a single confirmator
+// (a paramtable-level capability) drives all of them together.
+func (p *ComponentParam) versionGateItems() []*ParamItem {
+	return []*ParamItem{
+		&p.FunctionCfg.EnableWriteBeforeMaterialization,
+	}
+}
+
+// initVersionGates creates and starts the cluster version confirmator for
+// every version-gated config item, right after paramtable initialization. It
+// is a no-op when remote config is skipped (e.g. tests) or there is no usable
+// etcd, and it never blocks paramtable initialization: the initial resolution
+// reads etcd, so it runs in the background. Once every gate is resolved the
+// confirmator stops itself.
+func (p *ComponentParam) initVersionGates() {
+	if p.baseTable == nil || p.baseTable.config.skipRemote {
+		return
+	}
+	if p.EtcdCfg.Endpoints.GetValue() == "" {
+		return
+	}
+	if p.EtcdCfg.UseEmbedEtcd.GetAsBool() && !etcd.HasServer() {
+		return
+	}
+	vg, err := NewConfirmator(&p.EtcdCfg, p.EtcdCfg.MetaRootPath.GetValue(), p.EtcdCfg.RootPath.GetValue())
+	if err != nil {
+		mlog.Warn(context.TODO(), "create version gate confirmator failed", mlog.Err(err))
+		return
+	}
+	for _, item := range p.versionGateItems() {
+		if item == nil || item.VersionGateSwitcher == nil {
+			continue
+		}
+		if err := vg.RegisterGate(item.Key, item.VersionGateSwitcher); err != nil {
+			mlog.Warn(context.TODO(), "register version gate failed, skip", zap.String("key", item.Key), mlog.Err(err))
+			continue
+		}
+	}
+	if len(vg.gates) == 0 {
+		vg.Stop()
+		return
+	}
+	// Start asynchronously: the initial gate resolution reads etcd and must
+	// not block paramtable initialization.
+	go func() {
+		if err := vg.Start(context.TODO()); err != nil {
+			mlog.Warn(context.TODO(), "start version gate confirmator failed", mlog.Err(err))
+		}
+	}()
+	p.versionGates = vg
 }
 
 func (p *ComponentParam) GetComponentConfigurations(componentName string, sub string) map[string]string {

--- a/pkg/util/paramtable/function_param.go
+++ b/pkg/util/paramtable/function_param.go
@@ -39,7 +39,7 @@ type functionConfig struct {
 	// the legacy format. Explicit "false" keeps legacy format forever (escape
 	// hatch); explicit "true" force-enables and bypasses the version gate (use
 	// with caution).
-	EnableWriteBeforeMaterialization ParamItem `refreshable:"false"`
+	EnableWriteBeforeMaterialization ParamItem `refreshable:"true"`
 }
 
 func (p *functionConfig) init(base *BaseTable) {

--- a/pkg/util/paramtable/function_param.go
+++ b/pkg/util/paramtable/function_param.go
@@ -18,6 +18,7 @@ package paramtable
 
 import (
 	"strings"
+	"time"
 )
 
 type functionConfig struct {
@@ -30,6 +31,15 @@ type functionConfig struct {
 	ZillizProviders               ParamGroup `refreshable:"true"`
 	AnalyzerConcurrencyPerCPUCore ParamItem  `refreshable:"true"`
 	AnalyzerRunnerConcurrency     ParamItem  `refreshable:"true"`
+	// EnableWriteBeforeMaterialization gates the write-before function
+	// materialization (streamingnode materializes BM25/embedding function
+	// output fields before WAL append). Default "auto": it is switched on
+	// automatically once the whole cluster has confirmed version >= 2.6.23
+	// (plus the SwitchDelay stability window); before that the write path keeps
+	// the legacy format. Explicit "false" keeps legacy format forever (escape
+	// hatch); explicit "true" force-enables and bypasses the version gate (use
+	// with caution).
+	EnableWriteBeforeMaterialization ParamItem `refreshable:"false"`
 }
 
 func (p *functionConfig) init(base *BaseTable) {
@@ -214,6 +224,22 @@ func (p *functionConfig) init(base *BaseTable) {
 		DefaultValue: "8",
 	}
 	p.AnalyzerRunnerConcurrency.Init(base.mgr)
+
+	p.EnableWriteBeforeMaterialization = ParamItem{
+		Key:          "function.enableWriteBeforeMaterialization",
+		Version:      "2.6.23",
+		Export:       false,
+		Doc:          "Whether to materialize function output fields (e.g. BM25 sparse vectors) before WAL append. auto: switch on automatically once the whole cluster reaches 2.6.23 and the stability window elapses; false: always keep the legacy format (escape hatch); true: force enable and bypass the version gate (use with caution).",
+		DefaultValue: "auto",
+		VersionGateSwitcher: &VersionGateSwitcher{
+			EnableAutoSwitchValue: "auto",
+			PreSwitchValue:        "false", // before the gate is activated the write path keeps the legacy format
+			GateVersion:           "2.6.23",
+			TargetValue:           "true",
+			SwitchDelay:           1 * time.Minute,
+		},
+	}
+	p.EnableWriteBeforeMaterialization.Init(base.mgr)
 }
 
 func (p *functionConfig) GetTextEmbeddingProviderConfig(providerName string) map[string]string {

--- a/pkg/util/paramtable/function_param.go
+++ b/pkg/util/paramtable/function_param.go
@@ -39,6 +39,21 @@ type functionConfig struct {
 	// the legacy format. Explicit "false" keeps legacy format forever (escape
 	// hatch); explicit "true" force-enables and bypasses the version gate (use
 	// with caution).
+	//
+	// Notes on the auto-switch behavior:
+	//   - The flip is a one-shot decision taken by the MixCoord confirmator:
+	//     once it flips the value to "true" it writes the config-center (etcd)
+	//     key, which then outranks file/env sources per the usual config
+	//     priority. After the flip, the only working override is the etcd
+	//     config-center key itself (`<etcd.rootPath>/config/<key>`); a "false"
+	//     set in milvus.yaml or env afterwards is silently ignored. Explicit
+	//     "false"/"true" set before the flip (in any source) is honored and
+	//     skips the etcd write.
+	//   - Setting "false" at startup makes the gate resolve immediately and the
+	//     confirmator exits; reverting "false" back to "auto" at runtime does
+	//     not re-arm the gate (the confirmator is one-shot), so the flip only
+	//     takes effect after a MixCoord restart. Operators can still intervene
+	//     at any time by setting "true" or "false" explicitly.
 	EnableWriteBeforeMaterialization ParamItem `refreshable:"true"`
 }
 

--- a/pkg/util/paramtable/param_item.go
+++ b/pkg/util/paramtable/param_item.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/samber/lo"
 	"go.uber.org/atomic"
 
@@ -39,15 +40,19 @@ type ParamChangeCallback func(ctx context.Context, key, oldValue, newValue strin
 //     sentinel), AutoSwitch is triggered;
 //   - once the cluster-wide confirmed version reaches GateVersion and the
 //     SwitchDelay stability window has elapsed since the confirmation, the
-//     effective value of the item becomes TargetValue;
-//   - before that the item keeps PreSwitchValue (the value used before the
-//     switch, i.e. the pre-change behavior) and EffectiveValue returns
-//     activated=false so callers know the gated behavior is not yet in effect.
+//     one-shot confirmator flips the config-center value to TargetValue;
+//   - before that the item resolves to PreSwitchValue (the value used before
+//     the switch, i.e. the pre-change behavior) on every read path.
 //
 // DefaultValue is allowed to equal EnableAutoSwitchValue, which means the item
 // is in AutoSwitch mode by default (no explicit user configuration needed);
-// the "not activated" state is expressed by the activated flag plus
-// PreSwitchValue instead of a sentinel value leaking to callers.
+// the "not yet switched" state is expressed by resolving reads to
+// PreSwitchValue instead of leaking the sentinel value to callers.
+//
+// The gate is applied at the value-resolution layer (getWithRaw), so GetValue
+// and all GetAs* accessors uniformly return the effective value. The raw
+// configured value is left untouched for callers that need to detect the
+// sentinel (e.g. the version gate confirmator).
 //
 // nil means no version gating (default, backward compatible).
 type VersionGateSwitcher struct {
@@ -56,6 +61,37 @@ type VersionGateSwitcher struct {
 	GateVersion           string        // minimum cluster version (semver) required to switch
 	TargetValue           string        // effective value after AutoSwitch takes effect
 	SwitchDelay           time.Duration // stability window to wait after cluster-wide confirmation before switching
+}
+
+// Validate checks the switcher's field contract, panicking on a missing or
+// malformed field. A version-gated item must declare its full semantics:
+//   - EnableAutoSwitchValue: the sentinel that triggers AutoSwitch;
+//   - PreSwitchValue:        the pre-change behavior — without it the sentinel
+//     would leak to callers, so an empty value is a coding error;
+//   - GateVersion:           a valid semver (the confirmator parses it);
+//   - TargetValue:           the post-switch value.
+//
+// Validate is called from ParamItem.Init, so a misconfigured gated item fails
+// fast at startup instead of silently degrading at runtime.
+func (sw *VersionGateSwitcher) Validate() {
+	if sw.EnableAutoSwitchValue == "" {
+		panic("version gate: EnableAutoSwitchValue must not be empty")
+	}
+	if sw.PreSwitchValue == "" {
+		panic("version gate: PreSwitchValue must not be empty (the pre-change behavior is required)")
+	}
+	if sw.GateVersion == "" {
+		panic("version gate: GateVersion must not be empty")
+	}
+	if _, err := semver.Parse(sw.GateVersion); err != nil {
+		panic(fmt.Sprintf("version gate: invalid GateVersion %q: %v", sw.GateVersion, err))
+	}
+	if sw.TargetValue == "" {
+		panic("version gate: TargetValue must not be empty")
+	}
+	if sw.SwitchDelay < 0 {
+		panic("version gate: SwitchDelay must not be negative")
+	}
 }
 
 type ParamItem struct {
@@ -86,6 +122,11 @@ type ParamItem struct {
 
 func (pi *ParamItem) Init(manager *config.Manager) {
 	pi.manager = manager
+	if pi.VersionGateSwitcher != nil {
+		// A version-gated item must declare its full semantics; a
+		// misconfigured switcher is a coding error and must fail fast.
+		pi.VersionGateSwitcher.Validate()
+	}
 	if pi.Forbidden {
 		pi.manager.ForbidUpdate(pi.Key)
 	}
@@ -155,7 +196,7 @@ func (pi *ParamItem) get() (string, error) {
 func (pi *ParamItem) getWithRaw() (result, raw string, err error) {
 	// For unittest.
 	if s := pi.tempValue.Load(); s != nil {
-		return *s, *s, nil
+		return pi.gateValue(*s), *s, nil
 	}
 
 	if pi.manager == nil {
@@ -183,7 +224,7 @@ func (pi *ParamItem) getWithRaw() (result, raw string, err error) {
 		effectiveRaw = pi.DefaultValue
 		raw = pi.DefaultValue
 	}
-	result = effectiveRaw
+	result = pi.gateValue(effectiveRaw)
 	if pi.Formatter != nil {
 		result = pi.Formatter(result)
 	}
@@ -191,6 +232,21 @@ func (pi *ParamItem) getWithRaw() (result, raw string, err error) {
 		panic(fmt.Sprintf("%s is empty", pi.Key))
 	}
 	return result, raw, err
+}
+
+// gateValue applies the version-gated auto-switch semantics to a configured
+// value: when the item carries a VersionGateSwitcher and the value is the
+// sentinel (EnableAutoSwitchValue), the effective value is PreSwitchValue
+// (the pre-change behavior) until the one-shot confirmator flips the config
+// center value to TargetValue. Every read path (GetValue and all GetAs*)
+// resolves through this, so the gate is uniformly visible regardless of the
+// caller's accessor type. The raw value is unaffected: callers that need to
+// detect the sentinel (e.g. the version gate confirmator) still see it.
+func (pi *ParamItem) gateValue(v string) string {
+	if pi.VersionGateSwitcher == nil || v != pi.VersionGateSwitcher.EnableAutoSwitchValue {
+		return v
+	}
+	return pi.VersionGateSwitcher.PreSwitchValue
 }
 
 // SetTempValue set the value for this ParamItem,
@@ -212,38 +268,6 @@ func (pi *ParamItem) SwapTempValue(s string) string {
 func (pi *ParamItem) GetValue() string {
 	v, _ := pi.get()
 	return v
-}
-
-// EffectiveValue returns the effective (version-gated) value and whether the
-// gated behavior is activated:
-//   - no VersionGateSwitcher   -> (GetValue(), true)            // unchanged behavior
-//   - value == EnableAutoSwitchValue (sentinel) -> (PreSwitchValue, false)
-//     // the gate is not yet flipped: the caller gets the pre-switch value
-//     // (pre-change behavior) and activated=false; once the one-shot
-//     // confirmator flips the config value to TargetValue, GetValue() itself
-//     // returns TargetValue and this branch is no longer taken
-//   - any other explicit value -> (GetValue(), true)            // explicit config wins
-func (pi *ParamItem) EffectiveValue() (string, bool) {
-	if pi.VersionGateSwitcher == nil {
-		return pi.GetValue(), true
-	}
-	sw := pi.VersionGateSwitcher
-	v := pi.GetValue()
-	if v == sw.EnableAutoSwitchValue {
-		if sw.PreSwitchValue != "" {
-			return sw.PreSwitchValue, false
-		}
-		return pi.DefaultValue, false
-	}
-	return v, true
-}
-
-// GetAsBoolEffective returns the effective value parsed as bool. When the
-// gated behavior is not activated it always returns false (the pre-change
-// behavior of a bool config).
-func (pi *ParamItem) GetAsBoolEffective() bool {
-	v, ok := pi.EffectiveValue()
-	return ok && getAsBool(v)
 }
 
 func (pi *ParamItem) GetAsStrings() []string {

--- a/pkg/util/paramtable/param_item.go
+++ b/pkg/util/paramtable/param_item.go
@@ -61,6 +61,13 @@ type VersionGateSwitcher struct {
 	GateVersion           string        // minimum cluster version (semver) required to switch
 	TargetValue           string        // effective value after AutoSwitch takes effect
 	SwitchDelay           time.Duration // stability window to wait after cluster-wide confirmation before switching
+
+	// localSatisfied is set by ComponentParam.initVersionGates for embedded-etcd
+	// (single-process) deployments: the local process is the entire cluster, so
+	// when the local version is already >= GateVersion there is nothing to
+	// coordinate and the gate resolves directly to TargetValue. It is a pure
+	// paramtable-internal hint, never part of the configurable contract.
+	localSatisfied bool
 }
 
 // Validate checks the switcher's field contract, panicking on a missing or
@@ -236,8 +243,10 @@ func (pi *ParamItem) getWithRaw() (result, raw string, err error) {
 
 // gateValue applies the version-gated auto-switch semantics to a configured
 // value: when the item carries a VersionGateSwitcher and the value is the
-// sentinel (EnableAutoSwitchValue), the effective value is PreSwitchValue
-// (the pre-change behavior) until the one-shot confirmator flips the config
+// sentinel (EnableAutoSwitchValue), the effective value is TargetValue when
+// the gate is locally satisfied (embedded-etcd single-process deployments
+// where the local version is already >= GateVersion, see localSatisfied), and
+// PreSwitchValue otherwise, until the one-shot confirmator flips the config
 // center value to TargetValue. Every read path (GetValue and all GetAs*)
 // resolves through this, so the gate is uniformly visible regardless of the
 // caller's accessor type. The raw value is unaffected: callers that need to
@@ -245,6 +254,9 @@ func (pi *ParamItem) getWithRaw() (result, raw string, err error) {
 func (pi *ParamItem) gateValue(v string) string {
 	if pi.VersionGateSwitcher == nil || v != pi.VersionGateSwitcher.EnableAutoSwitchValue {
 		return v
+	}
+	if pi.VersionGateSwitcher.localSatisfied {
+		return pi.VersionGateSwitcher.TargetValue
 	}
 	return pi.VersionGateSwitcher.PreSwitchValue
 }

--- a/pkg/util/paramtable/param_item.go
+++ b/pkg/util/paramtable/param_item.go
@@ -33,6 +33,31 @@ import (
 
 type ParamChangeCallback func(ctx context.Context, key, oldValue, newValue string) error
 
+// VersionGateSwitcher describes the "version-gated auto-switch" semantics of a
+// configuration item:
+//   - when the user configures the item with EnableAutoSwitchValue (the
+//     sentinel), AutoSwitch is triggered;
+//   - once the cluster-wide confirmed version reaches GateVersion and the
+//     SwitchDelay stability window has elapsed since the confirmation, the
+//     effective value of the item becomes TargetValue;
+//   - before that the item keeps PreSwitchValue (the value used before the
+//     switch, i.e. the pre-change behavior) and EffectiveValue returns
+//     activated=false so callers know the gated behavior is not yet in effect.
+//
+// DefaultValue is allowed to equal EnableAutoSwitchValue, which means the item
+// is in AutoSwitch mode by default (no explicit user configuration needed);
+// the "not activated" state is expressed by the activated flag plus
+// PreSwitchValue instead of a sentinel value leaking to callers.
+//
+// nil means no version gating (default, backward compatible).
+type VersionGateSwitcher struct {
+	EnableAutoSwitchValue string        // sentinel value: configuring this value triggers AutoSwitch
+	PreSwitchValue        string        // effective value while the gate is not yet activated (pre-change behavior)
+	GateVersion           string        // minimum cluster version (semver) required to switch
+	TargetValue           string        // effective value after AutoSwitch takes effect
+	SwitchDelay           time.Duration // stability window to wait after cluster-wide confirmation before switching
+}
+
 type ParamItem struct {
 	Key          string // which should be named as "A.B.C"
 	Version      string
@@ -45,6 +70,10 @@ type ParamItem struct {
 	Formatter func(originValue string) string
 	Forbidden bool
 	Immutable bool
+
+	// VersionGateSwitcher attaches version-gated auto-switch semantics to this
+	// item; nil means no version gating (backward compatible).
+	VersionGateSwitcher *VersionGateSwitcher
 
 	manager *config.Manager
 
@@ -183,6 +212,38 @@ func (pi *ParamItem) SwapTempValue(s string) string {
 func (pi *ParamItem) GetValue() string {
 	v, _ := pi.get()
 	return v
+}
+
+// EffectiveValue returns the effective (version-gated) value and whether the
+// gated behavior is activated:
+//   - no VersionGateSwitcher   -> (GetValue(), true)            // unchanged behavior
+//   - value == EnableAutoSwitchValue (sentinel) -> (PreSwitchValue, false)
+//     // the gate is not yet flipped: the caller gets the pre-switch value
+//     // (pre-change behavior) and activated=false; once the one-shot
+//     // confirmator flips the config value to TargetValue, GetValue() itself
+//     // returns TargetValue and this branch is no longer taken
+//   - any other explicit value -> (GetValue(), true)            // explicit config wins
+func (pi *ParamItem) EffectiveValue() (string, bool) {
+	if pi.VersionGateSwitcher == nil {
+		return pi.GetValue(), true
+	}
+	sw := pi.VersionGateSwitcher
+	v := pi.GetValue()
+	if v == sw.EnableAutoSwitchValue {
+		if sw.PreSwitchValue != "" {
+			return sw.PreSwitchValue, false
+		}
+		return pi.DefaultValue, false
+	}
+	return v, true
+}
+
+// GetAsBoolEffective returns the effective value parsed as bool. When the
+// gated behavior is not activated it always returns false (the pre-change
+// behavior of a bool config).
+func (pi *ParamItem) GetAsBoolEffective() bool {
+	v, ok := pi.EffectiveValue()
+	return ok && getAsBool(v)
 }
 
 func (pi *ParamItem) GetAsStrings() []string {

--- a/pkg/util/paramtable/param_item.go
+++ b/pkg/util/paramtable/param_item.go
@@ -62,7 +62,7 @@ type VersionGateSwitcher struct {
 	TargetValue           string        // effective value after AutoSwitch takes effect
 	SwitchDelay           time.Duration // stability window to wait after cluster-wide confirmation before switching
 
-	// localSatisfied is set by ComponentParam.initVersionGates for embedded-etcd
+	// localSatisfied is set by StartVersionGateSwitcher for embedded-etcd
 	// (single-process) deployments: the local process is the entire cluster, so
 	// when the local version is already >= GateVersion there is nothing to
 	// coordinate and the gate resolves directly to TargetValue. It is a pure

--- a/pkg/util/paramtable/param_item_version_gate_test.go
+++ b/pkg/util/paramtable/param_item_version_gate_test.go
@@ -23,6 +23,41 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestVersionGateSwitcher_Validate(t *testing.T) {
+	valid := func() *VersionGateSwitcher {
+		return &VersionGateSwitcher{
+			EnableAutoSwitchValue: "auto",
+			PreSwitchValue:        "false",
+			GateVersion:           "2.6.23",
+			TargetValue:           "true",
+			SwitchDelay:           time.Second,
+		}
+	}
+
+	t.Run("valid switcher passes", func(t *testing.T) {
+		assert.NotPanics(t, func() { valid().Validate() })
+	})
+
+	cases := []struct {
+		name   string
+		mutate func(*VersionGateSwitcher)
+	}{
+		{"empty sentinel", func(s *VersionGateSwitcher) { s.EnableAutoSwitchValue = "" }},
+		{"empty pre-switch value", func(s *VersionGateSwitcher) { s.PreSwitchValue = "" }},
+		{"empty gate version", func(s *VersionGateSwitcher) { s.GateVersion = "" }},
+		{"malformed gate version", func(s *VersionGateSwitcher) { s.GateVersion = "not-a-version" }},
+		{"empty target value", func(s *VersionGateSwitcher) { s.TargetValue = "" }},
+		{"negative switch delay", func(s *VersionGateSwitcher) { s.SwitchDelay = -time.Second }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := valid()
+			tc.mutate(s)
+			assert.Panics(t, func() { s.Validate() })
+		})
+	}
+}
+
 func TestVersionGateSwitcher_EffectiveValue(t *testing.T) {
 	// ComponentParam.Init is guarded by sync.Once, so one initialized instance
 	// is shared by all subtests (they never run in parallel).
@@ -31,9 +66,8 @@ func TestVersionGateSwitcher_EffectiveValue(t *testing.T) {
 
 	t.Run("no switcher keeps original behavior", func(t *testing.T) {
 		item := &params.FunctionCfg.BatchFactor // no VersionGateSwitcher
-		v, ok := item.EffectiveValue()
-		assert.True(t, ok)
-		assert.Equal(t, item.GetValue(), v)
+		assert.Equal(t, "5", item.GetValue())
+		assert.Equal(t, 5, item.GetAsInt())
 	})
 
 	t.Run("write-before-materialization default is auto (default equals sentinel)", func(t *testing.T) {
@@ -46,32 +80,28 @@ func TestVersionGateSwitcher_EffectiveValue(t *testing.T) {
 		assert.Equal(t, "auto", item.DefaultValue) // default == sentinel -> auto switch by default
 	})
 
-	t.Run("sentinel value -> not activated, keeps pre-switch value", func(t *testing.T) {
+	t.Run("sentinel value -> gate not flipped, keeps pre-switch value", func(t *testing.T) {
 		item := &params.FunctionCfg.EnableWriteBeforeMaterialization
-		v, ok := item.EffectiveValue()
-		assert.False(t, ok) // the gate has not flipped (value is still the sentinel)
-		assert.Equal(t, "false", v)
-		assert.False(t, item.GetAsBoolEffective())
+		// The value is still the sentinel (default "auto"): every read path
+		// resolves the pre-switch value until the confirmator flips it.
+		assert.Equal(t, "false", item.GetValue())
+		assert.False(t, item.GetAsBool())
 	})
 
 	t.Run("explicit false keeps legacy value", func(t *testing.T) {
 		item := &params.FunctionCfg.EnableWriteBeforeMaterialization
 		old := item.SwapTempValue("false")
 		defer item.SwapTempValue(old)
-		v, ok := item.EffectiveValue()
-		assert.True(t, ok)
-		assert.Equal(t, "false", v)
-		assert.False(t, item.GetAsBoolEffective())
+		assert.Equal(t, "false", item.GetValue())
+		assert.False(t, item.GetAsBool())
 	})
 
 	t.Run("explicit true force enables and bypasses the gate", func(t *testing.T) {
 		item := &params.FunctionCfg.EnableWriteBeforeMaterialization
 		old := item.SwapTempValue("true")
 		defer item.SwapTempValue(old)
-		v, ok := item.EffectiveValue()
-		assert.True(t, ok)
-		assert.Equal(t, "true", v)
-		assert.True(t, item.GetAsBoolEffective())
+		assert.Equal(t, "true", item.GetValue())
+		assert.True(t, item.GetAsBool())
 	})
 
 	t.Run("different switchers keep their own pre-switch values", func(t *testing.T) {
@@ -103,11 +133,7 @@ func TestVersionGateSwitcher_EffectiveValue(t *testing.T) {
 		auto := "auto"
 		a.tempValue.Store(&auto)
 		b.tempValue.Store(&auto)
-		av, aok := a.EffectiveValue()
-		assert.False(t, aok)
-		assert.Equal(t, "false", av)
-		bv, bok := b.EffectiveValue()
-		assert.False(t, bok)
-		assert.Equal(t, "zstd-v1", bv)
+		assert.Equal(t, "false", a.GetValue())
+		assert.Equal(t, "zstd-v1", b.GetValue())
 	})
 }

--- a/pkg/util/paramtable/param_item_version_gate_test.go
+++ b/pkg/util/paramtable/param_item_version_gate_test.go
@@ -139,7 +139,7 @@ func TestVersionGateSwitcher_EffectiveValue(t *testing.T) {
 
 	t.Run("embedded-etcd localSatisfied resolves sentinel to TargetValue", func(t *testing.T) {
 		// A single-process (embedded-etcd) deployment whose local version already
-		// satisfies the gate: initVersionGates marks the switcher localSatisfied,
+		// satisfies the gate: StartVersionGateSwitcher marks the switcher localSatisfied,
 		// so the sentinel resolves to TargetValue instead of PreSwitchValue.
 		// Use the initialized shared item (it has a manager). GetAsBool caches by
 		// raw value, and localSatisfied is a runtime hint invisible to the cache,

--- a/pkg/util/paramtable/param_item_version_gate_test.go
+++ b/pkg/util/paramtable/param_item_version_gate_test.go
@@ -136,4 +136,26 @@ func TestVersionGateSwitcher_EffectiveValue(t *testing.T) {
 		assert.Equal(t, "false", a.GetValue())
 		assert.Equal(t, "zstd-v1", b.GetValue())
 	})
+
+	t.Run("embedded-etcd localSatisfied resolves sentinel to TargetValue", func(t *testing.T) {
+		// A single-process (embedded-etcd) deployment whose local version already
+		// satisfies the gate: initVersionGates marks the switcher localSatisfied,
+		// so the sentinel resolves to TargetValue instead of PreSwitchValue.
+		// Use the initialized shared item (it has a manager). GetAsBool caches by
+		// raw value, and localSatisfied is a runtime hint invisible to the cache,
+		// so evict the cached value whenever the hint or the temp value changes.
+		item := &params.FunctionCfg.EnableWriteBeforeMaterialization
+		old := item.SwapTempValue("auto")
+		defer item.SwapTempValue(old)
+		item.manager.EvictCachedValue(item.Key)
+		assert.False(t, item.GetAsBool())
+		item.VersionGateSwitcher.localSatisfied = true
+		item.manager.EvictCachedValue(item.Key)
+		assert.Equal(t, "true", item.GetValue())
+		assert.True(t, item.GetAsBool())
+		// An explicit value still wins over the local-satisfied hint.
+		item.SwapTempValue("false")
+		assert.Equal(t, "false", item.GetValue())
+		assert.False(t, item.GetAsBool())
+	})
 }

--- a/pkg/util/paramtable/param_item_version_gate_test.go
+++ b/pkg/util/paramtable/param_item_version_gate_test.go
@@ -1,0 +1,113 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package paramtable
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersionGateSwitcher_EffectiveValue(t *testing.T) {
+	// ComponentParam.Init is guarded by sync.Once, so one initialized instance
+	// is shared by all subtests (they never run in parallel).
+	params := &ComponentParam{}
+	params.Init(NewBaseTable(SkipRemote(true)))
+
+	t.Run("no switcher keeps original behavior", func(t *testing.T) {
+		item := &params.FunctionCfg.BatchFactor // no VersionGateSwitcher
+		v, ok := item.EffectiveValue()
+		assert.True(t, ok)
+		assert.Equal(t, item.GetValue(), v)
+	})
+
+	t.Run("write-before-materialization default is auto (default equals sentinel)", func(t *testing.T) {
+		item := &params.FunctionCfg.EnableWriteBeforeMaterialization
+		assert.NotNil(t, item.VersionGateSwitcher)
+		assert.Equal(t, "auto", item.VersionGateSwitcher.EnableAutoSwitchValue)
+		assert.Equal(t, "false", item.VersionGateSwitcher.PreSwitchValue)
+		assert.Equal(t, "2.6.23", item.VersionGateSwitcher.GateVersion)
+		assert.Equal(t, "true", item.VersionGateSwitcher.TargetValue)
+		assert.Equal(t, "auto", item.DefaultValue) // default == sentinel -> auto switch by default
+	})
+
+	t.Run("sentinel value -> not activated, keeps pre-switch value", func(t *testing.T) {
+		item := &params.FunctionCfg.EnableWriteBeforeMaterialization
+		v, ok := item.EffectiveValue()
+		assert.False(t, ok) // the gate has not flipped (value is still the sentinel)
+		assert.Equal(t, "false", v)
+		assert.False(t, item.GetAsBoolEffective())
+	})
+
+	t.Run("explicit false keeps legacy value", func(t *testing.T) {
+		item := &params.FunctionCfg.EnableWriteBeforeMaterialization
+		old := item.SwapTempValue("false")
+		defer item.SwapTempValue(old)
+		v, ok := item.EffectiveValue()
+		assert.True(t, ok)
+		assert.Equal(t, "false", v)
+		assert.False(t, item.GetAsBoolEffective())
+	})
+
+	t.Run("explicit true force enables and bypasses the gate", func(t *testing.T) {
+		item := &params.FunctionCfg.EnableWriteBeforeMaterialization
+		old := item.SwapTempValue("true")
+		defer item.SwapTempValue(old)
+		v, ok := item.EffectiveValue()
+		assert.True(t, ok)
+		assert.Equal(t, "true", v)
+		assert.True(t, item.GetAsBoolEffective())
+	})
+
+	t.Run("different switchers keep their own pre-switch values", func(t *testing.T) {
+		a := &ParamItem{
+			Key:          "test.a",
+			DefaultValue: "auto",
+			VersionGateSwitcher: &VersionGateSwitcher{
+				EnableAutoSwitchValue: "auto",
+				PreSwitchValue:        "false",
+				GateVersion:           "2.6.23",
+				TargetValue:           "true",
+				SwitchDelay:           time.Second,
+			},
+		}
+		b := &ParamItem{
+			Key:          "test.b",
+			DefaultValue: "auto",
+			VersionGateSwitcher: &VersionGateSwitcher{
+				EnableAutoSwitchValue: "auto",
+				PreSwitchValue:        "zstd-v1",
+				GateVersion:           "3.0.0",
+				TargetValue:           "zstd-v2",
+				SwitchDelay:           time.Second,
+			},
+		}
+		// Both items read the sentinel value (default): neither is activated,
+		// and each falls back to its own PreSwitchValue.
+		// (same-package test: set tempValue directly, bare ParamItem has no manager)
+		auto := "auto"
+		a.tempValue.Store(&auto)
+		b.tempValue.Store(&auto)
+		av, aok := a.EffectiveValue()
+		assert.False(t, aok)
+		assert.Equal(t, "false", av)
+		bv, bok := b.EffectiveValue()
+		assert.False(t, bok)
+		assert.Equal(t, "zstd-v1", bv)
+	})
+}

--- a/pkg/util/paramtable/version_gate.go
+++ b/pkg/util/paramtable/version_gate.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v3/config"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
-	"github.com/milvus-io/milvus/pkg/v3/util/etcd"
 )
 
 // checkInterval is the polling interval of the gate-processing loop. The
@@ -59,16 +58,16 @@ type gate struct {
 }
 
 // Confirmator is the one-shot cluster version confirmator. It is a
-// paramtable-level capability: it is created and started right after paramtable
-// initialization, builds its own etcd client from the etcd config (the same
-// way paramtable accesses etcd) and needs no external wiring. A single session
-// watch maintains the minimum online version across all nodes; every
+// paramtable-level capability: it is recovered right after paramtable
+// initialization (see RecoverConfirmator), reusing the etcd client paramtable
+// created for its config etcd source, and needs no external wiring. A single
+// session watch maintains the minimum online version across all nodes; every
 // registered gate is then driven by that minimum version: once the cluster
 // stays above the gate's GateVersion for the whole SwitchDelay stability
 // window, the gate flips its config item's value to TargetValue in the config
 // center (etcd source). The flip is guarded so an explicit operator value is
 // never overwritten. When every registered gate is resolved the confirmator
-// exits; nothing keeps running afterwards.
+// exits; nothing keeps running afterwards. Use Close to stop it.
 type Confirmator struct {
 	cli           *clientv3.Client
 	sessionPrefix string // prefix of the session keys (<metaRoot>/session)
@@ -83,38 +82,59 @@ type Confirmator struct {
 	wg     sync.WaitGroup
 }
 
-// NewConfirmator creates a confirmator that watches the sessions of all roles
-// under metaRoot. The etcd client is built internally from the given etcd
-// config, the same way paramtable accesses etcd (etcd.CreateEtcdClient), so
-// the confirmator never depends on clients injected from outside. The
-// confirmator owns the client and closes it in Stop.
-func NewConfirmator(etcdCfg *EtcdConfig, metaRoot, configRoot string) (*Confirmator, error) {
-	cli, err := etcd.CreateEtcdClient(
-		etcdCfg.UseEmbedEtcd.GetAsBool(),
-		etcdCfg.EtcdEnableAuth.GetAsBool(),
-		etcdCfg.EtcdAuthUserName.GetValue(),
-		etcdCfg.EtcdAuthPassword.GetValue(),
-		etcdCfg.EtcdUseSSL.GetAsBool(),
-		etcdCfg.Endpoints.GetAsStrings(),
-		etcdCfg.EtcdTLSCert.GetValue(),
-		etcdCfg.EtcdTLSKey.GetValue(),
-		etcdCfg.EtcdTLSCACert.GetValue(),
-		etcdCfg.EtcdTLSMinVersion.GetValue(),
-		etcd.WithDialTimeout(etcdCfg.DialTimeout.GetAsDuration(time.Millisecond)))
-	if err != nil {
-		return nil, err
-	}
+// newConfirmator creates a confirmator that watches the sessions of all roles
+// under metaRoot. The etcd client is injected by the caller — the same client
+// paramtable uses for its config etcd source — so the confirmator never opens
+// a second connection and does not own the client (Close does not close it).
+// Use RecoverConfirmator to create, register and start a confirmator.
+func newConfirmator(etcdCli *clientv3.Client, metaRoot, configRoot string) *Confirmator {
 	return &Confirmator{
-		cli:           cli,
+		cli:           etcdCli,
 		sessionPrefix: path.Join(metaRoot, "session"),
 		configRoot:    configRoot,
-	}, nil
+	}
 }
 
-// RegisterGate registers a version-gated config item. Registration is only
-// allowed before Start: the confirmator is one-shot and does not support gates
+// RecoverConfirmator creates and starts a cluster version confirmator in one
+// call: it registers a gate for every version-gated config item, then starts
+// the session watch and gate loop in the background. Gates are registered
+// before start (one-shot); items without a VersionGateSwitcher are skipped.
+// When no gate is left pending (all items skipped) it returns a nil
+// confirmator; when every registered gate is already resolved (explicit config
+// or flipped by a previous run) the confirmator exits on its own after the
+// initial pass. The etcd client is injected by the caller and shared with the
+// config etcd source; the confirmator does not own it. Call Close on the
+// returned confirmator to stop it.
+func RecoverConfirmator(etcdCli *clientv3.Client, metaRoot, configRoot string, items []*ParamItem) (*Confirmator, error) {
+	vg := newConfirmator(etcdCli, metaRoot, configRoot)
+	for _, item := range items {
+		if item == nil || item.VersionGateSwitcher == nil {
+			continue
+		}
+		if err := vg.registerGate(item.Key, item.VersionGateSwitcher); err != nil {
+			mlog.Warn(context.TODO(), "version gate: register gate failed, skip", zap.String("key", item.Key), mlog.Err(err))
+			continue
+		}
+	}
+	if len(vg.gates) == 0 {
+		vg.Close()
+		return nil, nil
+	}
+	// Start in the background: the initial resolution reads etcd and must not
+	// block paramtable initialization. Once every gate is resolved the
+	// confirmator stops itself.
+	go func() {
+		if err := vg.start(context.TODO()); err != nil {
+			mlog.Warn(context.TODO(), "version gate: start confirmator failed", mlog.Err(err))
+		}
+	}()
+	return vg, nil
+}
+
+// registerGate registers a version-gated config item. Registration is only
+// allowed before start: the confirmator is one-shot and does not support gates
 // registered at runtime.
-func (c *Confirmator) RegisterGate(key string, switcher *VersionGateSwitcher) error {
+func (c *Confirmator) registerGate(key string, switcher *VersionGateSwitcher) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.started {
@@ -131,12 +151,12 @@ func (c *Confirmator) RegisterGate(key string, switcher *VersionGateSwitcher) er
 	return nil
 }
 
-// Start resolves every registered gate. Gates whose config value is no longer
+// start resolves every registered gate. Gates whose config value is no longer
 // the sentinel (flipped earlier or explicitly configured by the operator) are
 // resolved immediately; for the remaining gates a single session watch and one
-// gate-processing loop are started in the background. Start returns after the
+// gate-processing loop are started in the background. start returns after the
 // initial pass. When all gates are resolved the confirmator stops itself.
-func (c *Confirmator) Start(ctx context.Context) error {
+func (c *Confirmator) start(ctx context.Context) error {
 	c.mu.Lock()
 	if c.started {
 		return errors.New("version gate: already started")
@@ -173,16 +193,15 @@ func (c *Confirmator) Start(ctx context.Context) error {
 	return nil
 }
 
-// Stop stops the confirmator and cancels the background session watch and
-// gate-processing loop, then closes the internally created etcd client.
-func (c *Confirmator) Stop() {
+// Close stops the confirmator and cancels the background session watch and
+// gate-processing loop, waiting for them to exit. The etcd client is injected
+// by the caller and shared with the config etcd source, so it is not closed
+// here.
+func (c *Confirmator) Close() {
 	if c.cancel != nil {
 		c.cancel()
 	}
 	c.wg.Wait()
-	if c.cli != nil {
-		c.cli.Close()
-	}
 }
 
 // watchLoop watches the session prefix and maintains the minimum online

--- a/pkg/util/paramtable/version_gate.go
+++ b/pkg/util/paramtable/version_gate.go
@@ -1,0 +1,498 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package paramtable
+
+import (
+	"context"
+	"encoding/json"
+	"path"
+	"sync"
+	"time"
+
+	"github.com/blang/semver/v4"
+	"github.com/cockroachdb/errors"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/pkg/v3/config"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/util/etcd"
+)
+
+// checkInterval is the polling interval of the gate-processing loop. The
+// cluster version itself is event-driven (session watch); the ticker only
+// applies the per-gate SwitchDelay stability window.
+const checkInterval = 100 * time.Millisecond
+
+// sessionVersion is the minimal session info used for scanning, carrying only
+// the registered node version.
+type sessionVersion struct {
+	Version string `json:"Version"`
+}
+
+// gate tracks one version-gated config item for this process run. The
+// confirmator is one-shot: every gate is registered before Start, and once all
+// gates are resolved the confirmator exits. No gate can be registered at
+// runtime afterwards.
+type gate struct {
+	key      string
+	switcher *VersionGateSwitcher
+	version  semver.Version // parsed GateVersion
+
+	resolved bool
+	armedAt  time.Time // when the cluster first stayed above GateVersion (zero = not armed)
+	wasAbove bool      // whether the cluster was above GateVersion at the last check
+}
+
+// Confirmator is the one-shot cluster version confirmator. It is a
+// paramtable-level capability: it is created and started right after paramtable
+// initialization, builds its own etcd client from the etcd config (the same
+// way paramtable accesses etcd) and needs no external wiring. A single session
+// watch maintains the minimum online version across all nodes; every
+// registered gate is then driven by that minimum version: once the cluster
+// stays above the gate's GateVersion for the whole SwitchDelay stability
+// window, the gate flips its config item's value to TargetValue in the config
+// center (etcd source). The flip is guarded so an explicit operator value is
+// never overwritten. When every registered gate is resolved the confirmator
+// exits; nothing keeps running afterwards.
+type Confirmator struct {
+	cli           *clientv3.Client
+	sessionPrefix string // prefix of the session keys (<metaRoot>/session)
+	configRoot    string // root of the config center keys (<configRoot>/config/<key>)
+
+	mu        sync.Mutex
+	gates     []*gate
+	minOnline semver.Version // minimum version among all sessions (zero = unknown)
+	started   bool
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// NewConfirmator creates a confirmator that watches the sessions of all roles
+// under metaRoot. The etcd client is built internally from the given etcd
+// config, the same way paramtable accesses etcd (etcd.CreateEtcdClient), so
+// the confirmator never depends on clients injected from outside. The
+// confirmator owns the client and closes it in Stop.
+func NewConfirmator(etcdCfg *EtcdConfig, metaRoot, configRoot string) (*Confirmator, error) {
+	cli, err := etcd.CreateEtcdClient(
+		etcdCfg.UseEmbedEtcd.GetAsBool(),
+		etcdCfg.EtcdEnableAuth.GetAsBool(),
+		etcdCfg.EtcdAuthUserName.GetValue(),
+		etcdCfg.EtcdAuthPassword.GetValue(),
+		etcdCfg.EtcdUseSSL.GetAsBool(),
+		etcdCfg.Endpoints.GetAsStrings(),
+		etcdCfg.EtcdTLSCert.GetValue(),
+		etcdCfg.EtcdTLSKey.GetValue(),
+		etcdCfg.EtcdTLSCACert.GetValue(),
+		etcdCfg.EtcdTLSMinVersion.GetValue(),
+		etcd.WithDialTimeout(etcdCfg.DialTimeout.GetAsDuration(time.Millisecond)))
+	if err != nil {
+		return nil, err
+	}
+	return &Confirmator{
+		cli:           cli,
+		sessionPrefix: path.Join(metaRoot, "session"),
+		configRoot:    configRoot,
+	}, nil
+}
+
+// RegisterGate registers a version-gated config item. Registration is only
+// allowed before Start: the confirmator is one-shot and does not support gates
+// registered at runtime.
+func (c *Confirmator) RegisterGate(key string, switcher *VersionGateSwitcher) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.started {
+		return errors.New("version gate: register gate after start is not supported")
+	}
+	if switcher == nil {
+		return errors.New("version gate: nil switcher")
+	}
+	if _, err := semver.Parse(switcher.GateVersion); err != nil {
+		return errors.Wrapf(err, "version gate: parse gate version %s", switcher.GateVersion)
+	}
+	v, _ := semver.Parse(switcher.GateVersion)
+	c.gates = append(c.gates, &gate{key: key, switcher: switcher, version: v})
+	return nil
+}
+
+// Start resolves every registered gate. Gates whose config value is no longer
+// the sentinel (flipped earlier or explicitly configured by the operator) are
+// resolved immediately; for the remaining gates a single session watch and one
+// gate-processing loop are started in the background. Start returns after the
+// initial pass. When all gates are resolved the confirmator stops itself.
+func (c *Confirmator) Start(ctx context.Context) error {
+	c.mu.Lock()
+	if c.started {
+		return errors.New("version gate: already started")
+	}
+	c.started = true
+	c.mu.Unlock()
+
+	startCtx, cancel := context.WithCancel(ctx)
+	c.cancel = cancel
+	pending := 0
+	for _, g := range c.gates {
+		c.mu.Lock()
+		if c.gateResolvedLocked(g) {
+			g.resolved = true
+			mlog.Info(startCtx, "version gate: gate resolved at startup (explicit config or already flipped)",
+				zap.String("key", g.key))
+		}
+		c.mu.Unlock()
+		if !g.resolved {
+			pending++
+		}
+	}
+	if pending == 0 {
+		mlog.Info(startCtx, "version gate: all gates resolved at startup, confirmator exits",
+			zap.Int("gates", len(c.gates)))
+		return nil
+	}
+	// One shared session watch maintaining the minimum online version...
+	c.wg.Add(1)
+	go c.watchLoop(startCtx)
+	// ...and one loop driving every gate from that minimum version.
+	c.wg.Add(1)
+	go c.gateLoop(startCtx)
+	return nil
+}
+
+// Stop stops the confirmator and cancels the background session watch and
+// gate-processing loop, then closes the internally created etcd client.
+func (c *Confirmator) Stop() {
+	if c.cancel != nil {
+		c.cancel()
+	}
+	c.wg.Wait()
+	if c.cli != nil {
+		c.cli.Close()
+	}
+}
+
+// watchLoop watches the session prefix and maintains the minimum online
+// version. Every watch event triggers a full rescan of the session prefix, so
+// the maintained state is always consistent with etcd even across watch
+// restarts (e.g. after a compaction): the watch is only the "something changed"
+// trigger, correctness comes from the rescan. On watch failure the loop
+// rebuilds the watch from a fresh revision.
+func (c *Confirmator) watchLoop(ctx context.Context) {
+	defer c.wg.Done()
+	for {
+		rev, err := c.reloadSessions(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			mlog.Warn(ctx, "version gate: session scan failed, retry", zap.Error(err))
+			if !sleepCtx(ctx, checkInterval) {
+				return
+			}
+			continue
+		}
+		wch := c.cli.Watch(ctx, c.sessionPrefix, clientv3.WithPrefix(), clientv3.WithRev(rev))
+		for resp := range wch {
+			if err := resp.Err(); err != nil {
+				// e.g. compacted revision: rebuild from a fresh scan.
+				mlog.Warn(ctx, "version gate: session watch error, rescan", zap.Error(err))
+				break
+			}
+			if len(resp.Events) == 0 {
+				continue
+			}
+			if _, err := c.reloadSessions(ctx); err != nil {
+				mlog.Warn(ctx, "version gate: session rescan failed", zap.Error(err))
+			}
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		// The watch channel ended unexpectedly; rebuild it from the outer loop.
+	}
+}
+
+// sleepCtx sleeps for d unless ctx is done first.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(d):
+		return true
+	}
+}
+
+// reloadSessions rescans the session prefix, recomputes the minimum online
+// version and returns the next watch revision (current revision + 1) so no
+// event committed between the scan and the watch is missed.
+func (c *Confirmator) reloadSessions(ctx context.Context) (int64, error) {
+	min, rev, err := c.scanSessions(ctx)
+	if err != nil {
+		return 0, err
+	}
+	c.mu.Lock()
+	c.minOnline = min
+	c.mu.Unlock()
+	return rev, nil
+}
+
+// scanSessions returns the minimum online version and the current etcd
+// revision from a fresh scan of the session prefix. Sessions with an
+// unparseable version are skipped; an empty session set yields the zero
+// version.
+func (c *Confirmator) scanSessions(ctx context.Context) (semver.Version, int64, error) {
+	resp, err := c.cli.Get(ctx, c.sessionPrefix, clientv3.WithPrefix())
+	if err != nil {
+		return semver.Version{}, 0, err
+	}
+	var min semver.Version
+	for _, kv := range resp.Kvs {
+		session := &sessionVersion{}
+		if err := json.Unmarshal(kv.Value, session); err != nil {
+			continue
+		}
+		v, err := semver.Parse(session.Version)
+		if err != nil {
+			continue
+		}
+		if isZero(min) || v.LT(min) {
+			min = v
+		}
+	}
+	return min, resp.Header.Revision + 1, nil
+}
+
+// gateLoop periodically applies the per-gate SwitchDelay stability window and
+// flips the gates whose window has elapsed. It stops the confirmator once
+// every gate is resolved.
+func (c *Confirmator) gateLoop(ctx context.Context) {
+	defer c.wg.Done()
+	ticker := time.NewTicker(checkInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if c.processGates(ctx) {
+				// One-shot: all gates resolved, nothing keeps running.
+				mlog.Info(ctx, "version gate: all gates resolved, confirmator exits")
+				c.cancel()
+				return
+			}
+		}
+	}
+}
+
+// processGates drives every unresolved gate from the current minimum online
+// version: it arms the gate (starts the SwitchDelay window) when the cluster
+// is above the gate's GateVersion and disarms it otherwise. Gates whose
+// stability window has elapsed are flipped. It returns true when every gate is
+// resolved.
+func (c *Confirmator) processGates(ctx context.Context) bool {
+	allDone := true
+	now := time.Now()
+	for _, g := range c.gates {
+		c.mu.Lock()
+		if g.resolved {
+			c.mu.Unlock()
+			continue
+		}
+		above := !isZero(c.minOnline) && c.minOnline.GE(g.version)
+		switch {
+		case above && !g.wasAbove:
+			g.armedAt = now
+			mlog.Info(ctx, "version gate: cluster above gate version, start stability window",
+				zap.String("key", g.key), zap.String("gateVersion", g.switcher.GateVersion),
+				zap.String("minOnline", c.minOnline.String()))
+		case !above && g.wasAbove:
+			g.armedAt = time.Time{}
+			mlog.Warn(ctx, "version gate: cluster below gate version, reset stability window",
+				zap.String("key", g.key), zap.String("gateVersion", g.switcher.GateVersion),
+				zap.String("minOnline", c.minOnline.String()))
+		}
+		g.wasAbove = above
+		due := above && !g.armedAt.IsZero() && now.Sub(g.armedAt) >= g.switcher.SwitchDelay
+		c.mu.Unlock()
+
+		if due {
+			if !c.recheckAndFlip(ctx, g) {
+				allDone = false
+				continue
+			}
+			c.mu.Lock()
+			g.resolved = true
+			c.mu.Unlock()
+			mlog.Info(ctx, "version gate: gate flipped",
+				zap.String("key", g.key), zap.String("value", g.switcher.TargetValue))
+			continue
+		}
+		allDone = false
+	}
+	return allDone
+}
+
+// recheckAndFlip re-evaluates the minimum online version against a fresh etcd
+// read before the irreversible flip (the session watch is event-driven and its
+// events may lag behind the flip check), then performs the flip. It returns
+// true when the gate is resolved (flipped, or superseded by an explicit config
+// value).
+func (c *Confirmator) recheckAndFlip(ctx context.Context, g *gate) bool {
+	min, _, err := c.scanSessions(ctx)
+	if err != nil {
+		mlog.Warn(ctx, "version gate: re-check sessions failed, retry later",
+			zap.String("key", g.key), zap.Error(err))
+		return false
+	}
+	if isZero(min) || !min.GE(g.version) {
+		c.mu.Lock()
+		g.armedAt = time.Time{}
+		g.wasAbove = false
+		c.mu.Unlock()
+		mlog.Warn(ctx, "version gate: cluster below gate version at flip time, reset stability window",
+			zap.String("key", g.key), zap.String("gateVersion", g.switcher.GateVersion),
+			zap.String("minOnline", min.String()))
+		return false
+	}
+	if err := c.flip(ctx, g); err != nil {
+		mlog.Warn(ctx, "version gate: flip failed, will retry",
+			zap.String("key", g.key), zap.Error(err))
+		return false
+	}
+	return true
+}
+
+// flip writes the gate's TargetValue into the config center once. The write is
+// guarded so an explicit operator value is never overwritten: the etcd-level
+// CAS only writes when the key is absent or still holds the sentinel value, so
+// a concurrently written explicit value wins. (Values from file/env sources
+// are covered by the explicit-config resolution at Start.)
+func (c *Confirmator) flip(ctx context.Context, g *gate) error {
+	key := c.configKey(g.key)
+	resp, err := c.cli.Get(ctx, key)
+	if err != nil {
+		return err
+	}
+	txn := c.cli.Txn(ctx)
+	switch {
+	case len(resp.Kvs) == 0:
+		txn.If(clientv3.Compare(clientv3.CreateRevision(key), "=", 0))
+	case string(resp.Kvs[0].Value) == g.switcher.EnableAutoSwitchValue:
+		txn.If(clientv3.Compare(clientv3.Value(key), "=", g.switcher.EnableAutoSwitchValue))
+	default:
+		// An explicit etcd value is present: nothing to flip.
+		mlog.Info(ctx, "version gate: explicit etcd config value wins, skip flip",
+			zap.String("key", g.key), zap.String("value", string(resp.Kvs[0].Value)))
+		return nil
+	}
+	txn.Then(clientv3.OpPut(key, g.switcher.TargetValue))
+	txnResp, err := txn.Commit()
+	if err != nil {
+		return err
+	}
+	if !txnResp.Succeeded {
+		// Another writer won the CAS: if it moved the value away from the
+		// sentinel the gate is resolved; otherwise retry later.
+		cur, present, err := c.configValue(g.key)
+		if err != nil {
+			return err
+		}
+		if present && cur != g.switcher.EnableAutoSwitchValue {
+			mlog.Info(ctx, "version gate: concurrent writer resolved the gate, skip flip",
+				zap.String("key", g.key), zap.String("value", cur))
+			return nil
+		}
+		return errors.New("version gate: config flip CAS failed, value unchanged")
+	}
+	// Make the flip visible in this process immediately instead of waiting for
+	// the periodic config refresher.
+	refreshLocalConfig()
+	return nil
+}
+
+// gateResolvedLocked reports whether the gate needs no flipping: the effective
+// config value is no longer the sentinel (explicit operator value, or the
+// value was already flipped by a previous run). Caller must hold c.mu.
+func (c *Confirmator) gateResolvedLocked(g *gate) bool {
+	if v, ok := currentConfigValue(g.key); ok {
+		return v != g.switcher.EnableAutoSwitchValue
+	}
+	// The process config manager does not expose the value (e.g. the key only
+	// has a default): fall back to the config-center value.
+	v, present, err := c.configValue(g.key)
+	if err != nil {
+		return false
+	}
+	return present && v != g.switcher.EnableAutoSwitchValue
+}
+
+// isZero reports whether v is the zero semver version.
+func isZero(v semver.Version) bool {
+	return v.EQ(semver.Version{})
+}
+
+// configKey returns the config-center etcd key of a config item.
+func (c *Confirmator) configKey(key string) string {
+	return path.Join(c.configRoot, "config", config.FormatKey(key))
+}
+
+// configValue reads the config-center etcd key of a config item.
+func (c *Confirmator) configValue(key string) (string, bool, error) {
+	resp, err := c.cli.Get(context.Background(), c.configKey(key))
+	if err != nil {
+		return "", false, err
+	}
+	if len(resp.Kvs) == 0 {
+		return "", false, nil
+	}
+	return string(resp.Kvs[0].Value), true, nil
+}
+
+// currentConfigValue returns the effective value of the config item as
+// resolved by the process config manager. It reports ok=false when the manager
+// is unavailable or the key is not registered; callers must not treat that as
+// "sentinel" — the etcd-level CAS in flip remains the authoritative guard
+// against overwriting explicit values.
+func currentConfigValue(key string) (string, bool) {
+	bt := GetBaseTable()
+	if bt == nil {
+		return "", false
+	}
+	_, v, err := bt.Manager().GetConfig(key)
+	if err != nil {
+		return "", false
+	}
+	return v, true
+}
+
+// refreshLocalConfig triggers a linearizable refresh of the local etcd config
+// source so a flip performed by this process becomes visible immediately. It
+// is best-effort: when the etcd config source is unavailable the periodic
+// refresher picks the change up later.
+func refreshLocalConfig() {
+	bt := GetBaseTable()
+	if bt == nil {
+		return
+	}
+	etcdSource, ok := bt.Manager().GetEtcdSource()
+	if !ok {
+		return
+	}
+	if err := etcdSource.RefreshConfigurationsLinearizable(); err != nil {
+		mlog.Warn(context.TODO(), "version gate: refresh local config failed", zap.Error(err))
+	}
+}

--- a/pkg/util/paramtable/version_gate.go
+++ b/pkg/util/paramtable/version_gate.go
@@ -26,10 +26,10 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/cockroachdb/errors"
 	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/v3/config"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // checkInterval is the polling interval of the gate-processing loop. The
@@ -112,7 +112,7 @@ func RecoverConfirmator(etcdCli *clientv3.Client, metaRoot, configRoot string, i
 			continue
 		}
 		if err := vg.registerGate(item.Key, item.VersionGateSwitcher); err != nil {
-			mlog.Warn(context.TODO(), "version gate: register gate failed, skip", zap.String("key", item.Key), mlog.Err(err))
+			mlog.Warn(context.TODO(), "version gate: register gate failed, skip", mlog.String("key", item.Key), mlog.Err(err))
 			continue
 		}
 	}
@@ -138,10 +138,10 @@ func (c *Confirmator) registerGate(key string, switcher *VersionGateSwitcher) er
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.started {
-		return errors.New("version gate: register gate after start is not supported")
+		return merr.WrapErrServiceInternal("version gate: register gate after start is not supported")
 	}
 	if switcher == nil {
-		return errors.New("version gate: nil switcher")
+		return merr.WrapErrServiceInternal("version gate: nil switcher")
 	}
 	if _, err := semver.Parse(switcher.GateVersion); err != nil {
 		return errors.Wrapf(err, "version gate: parse gate version %s", switcher.GateVersion)
@@ -160,7 +160,7 @@ func (c *Confirmator) start(ctx context.Context) error {
 	c.mu.Lock()
 	if c.started {
 		c.mu.Unlock()
-		return errors.New("version gate: already started")
+		return merr.WrapErrServiceInternal("version gate: already started")
 	}
 	c.started = true
 	c.mu.Unlock()
@@ -173,7 +173,7 @@ func (c *Confirmator) start(ctx context.Context) error {
 		if c.gateResolvedLocked(g) {
 			g.resolved = true
 			mlog.Info(startCtx, "version gate: gate resolved at startup (explicit config or already flipped)",
-				zap.String("key", g.key))
+				mlog.String("key", g.key))
 		}
 		c.mu.Unlock()
 		if !g.resolved {
@@ -182,7 +182,7 @@ func (c *Confirmator) start(ctx context.Context) error {
 	}
 	if pending == 0 {
 		mlog.Info(startCtx, "version gate: all gates resolved at startup, confirmator exits",
-			zap.Int("gates", len(c.gates)))
+			mlog.Int("gates", len(c.gates)))
 		return nil
 	}
 	// One shared session watch maintaining the minimum online version...
@@ -219,7 +219,7 @@ func (c *Confirmator) watchLoop(ctx context.Context) {
 			if ctx.Err() != nil {
 				return
 			}
-			mlog.Warn(ctx, "version gate: session scan failed, retry", zap.Error(err))
+			mlog.Warn(ctx, "version gate: session scan failed, retry", mlog.Err(err))
 			if !sleepCtx(ctx, checkInterval) {
 				return
 			}
@@ -229,14 +229,14 @@ func (c *Confirmator) watchLoop(ctx context.Context) {
 		for resp := range wch {
 			if err := resp.Err(); err != nil {
 				// e.g. compacted revision: rebuild from a fresh scan.
-				mlog.Warn(ctx, "version gate: session watch error, rescan", zap.Error(err))
+				mlog.Warn(ctx, "version gate: session watch error, rescan", mlog.Err(err))
 				break
 			}
 			if len(resp.Events) == 0 {
 				continue
 			}
 			if _, err := c.reloadSessions(ctx); err != nil {
-				mlog.Warn(ctx, "version gate: session rescan failed", zap.Error(err))
+				mlog.Warn(ctx, "version gate: session rescan failed", mlog.Err(err))
 			}
 		}
 		if ctx.Err() != nil {
@@ -337,13 +337,13 @@ func (c *Confirmator) processGates(ctx context.Context) bool {
 		case above && !g.wasAbove:
 			g.armedAt = now
 			mlog.Info(ctx, "version gate: cluster above gate version, start stability window",
-				zap.String("key", g.key), zap.String("gateVersion", g.switcher.GateVersion),
-				zap.String("minOnline", c.minOnline.String()))
+				mlog.String("key", g.key), mlog.String("gateVersion", g.switcher.GateVersion),
+				mlog.String("minOnline", c.minOnline.String()))
 		case !above && g.wasAbove:
 			g.armedAt = time.Time{}
 			mlog.Warn(ctx, "version gate: cluster below gate version, reset stability window",
-				zap.String("key", g.key), zap.String("gateVersion", g.switcher.GateVersion),
-				zap.String("minOnline", c.minOnline.String()))
+				mlog.String("key", g.key), mlog.String("gateVersion", g.switcher.GateVersion),
+				mlog.String("minOnline", c.minOnline.String()))
 		}
 		g.wasAbove = above
 		due := above && !g.armedAt.IsZero() && now.Sub(g.armedAt) >= g.switcher.SwitchDelay
@@ -358,7 +358,7 @@ func (c *Confirmator) processGates(ctx context.Context) bool {
 			g.resolved = true
 			c.mu.Unlock()
 			mlog.Info(ctx, "version gate: gate flipped",
-				zap.String("key", g.key), zap.String("value", g.switcher.TargetValue))
+				mlog.String("key", g.key), mlog.String("value", g.switcher.TargetValue))
 			continue
 		}
 		allDone = false
@@ -375,7 +375,7 @@ func (c *Confirmator) recheckAndFlip(ctx context.Context, g *gate) bool {
 	min, _, err := c.scanSessions(ctx)
 	if err != nil {
 		mlog.Warn(ctx, "version gate: re-check sessions failed, retry later",
-			zap.String("key", g.key), zap.Error(err))
+			mlog.String("key", g.key), mlog.Err(err))
 		return false
 	}
 	if isZero(min) || !min.GE(g.version) {
@@ -384,13 +384,13 @@ func (c *Confirmator) recheckAndFlip(ctx context.Context, g *gate) bool {
 		g.wasAbove = false
 		c.mu.Unlock()
 		mlog.Warn(ctx, "version gate: cluster below gate version at flip time, reset stability window",
-			zap.String("key", g.key), zap.String("gateVersion", g.switcher.GateVersion),
-			zap.String("minOnline", min.String()))
+			mlog.String("key", g.key), mlog.String("gateVersion", g.switcher.GateVersion),
+			mlog.String("minOnline", min.String()))
 		return false
 	}
 	if err := c.flip(ctx, g); err != nil {
 		mlog.Warn(ctx, "version gate: flip failed, will retry",
-			zap.String("key", g.key), zap.Error(err))
+			mlog.String("key", g.key), mlog.Err(err))
 		return false
 	}
 	return true
@@ -416,7 +416,7 @@ func (c *Confirmator) flip(ctx context.Context, g *gate) error {
 	default:
 		// An explicit etcd value is present: nothing to flip.
 		mlog.Info(ctx, "version gate: explicit etcd config value wins, skip flip",
-			zap.String("key", g.key), zap.String("value", string(resp.Kvs[0].Value)))
+			mlog.String("key", g.key), mlog.String("value", string(resp.Kvs[0].Value)))
 		return nil
 	}
 	txn.Then(clientv3.OpPut(key, g.switcher.TargetValue))
@@ -433,10 +433,10 @@ func (c *Confirmator) flip(ctx context.Context, g *gate) error {
 		}
 		if present && cur != g.switcher.EnableAutoSwitchValue {
 			mlog.Info(ctx, "version gate: concurrent writer resolved the gate, skip flip",
-				zap.String("key", g.key), zap.String("value", cur))
+				mlog.String("key", g.key), mlog.String("value", cur))
 			return nil
 		}
-		return errors.New("version gate: config flip CAS failed, value unchanged")
+		return merr.WrapErrServiceInternal("version gate: config flip CAS failed, value unchanged")
 	}
 	// Make the flip visible in this process immediately instead of waiting for
 	// the periodic config refresher.
@@ -513,6 +513,6 @@ func refreshLocalConfig() {
 		return
 	}
 	if err := etcdSource.RefreshConfigurationsLinearizable(); err != nil {
-		mlog.Warn(context.TODO(), "version gate: refresh local config failed", zap.Error(err))
+		mlog.Warn(context.TODO(), "version gate: refresh local config failed", mlog.Err(err))
 	}
 }

--- a/pkg/util/paramtable/version_gate.go
+++ b/pkg/util/paramtable/version_gate.go
@@ -143,10 +143,10 @@ func (c *Confirmator) registerGate(key string, switcher *VersionGateSwitcher) er
 	if switcher == nil {
 		return merr.WrapErrServiceInternal("version gate: nil switcher")
 	}
-	if _, err := semver.Parse(switcher.GateVersion); err != nil {
+	v, err := semver.Parse(switcher.GateVersion)
+	if err != nil {
 		return errors.Wrapf(err, "version gate: parse gate version %s", switcher.GateVersion)
 	}
-	v, _ := semver.Parse(switcher.GateVersion)
 	c.gates = append(c.gates, &gate{key: key, switcher: switcher, version: v})
 	return nil
 }
@@ -354,11 +354,12 @@ func (c *Confirmator) processGates(ctx context.Context) bool {
 				allDone = false
 				continue
 			}
+			// recheckAndFlip returned true: the gate is resolved (flipped, or
+			// superseded by an explicit config value). flip logs the actual
+			// outcome; mark the gate resolved and move on.
 			c.mu.Lock()
 			g.resolved = true
 			c.mu.Unlock()
-			mlog.Info(ctx, "version gate: gate flipped",
-				mlog.String("key", g.key), mlog.String("value", g.switcher.TargetValue))
 			continue
 		}
 		allDone = false
@@ -441,6 +442,8 @@ func (c *Confirmator) flip(ctx context.Context, g *gate) error {
 	// Make the flip visible in this process immediately instead of waiting for
 	// the periodic config refresher.
 	refreshLocalConfig()
+	mlog.Info(ctx, "version gate: gate flipped",
+		mlog.String("key", g.key), mlog.String("value", g.switcher.TargetValue))
 	return nil
 }
 

--- a/pkg/util/paramtable/version_gate.go
+++ b/pkg/util/paramtable/version_gate.go
@@ -159,6 +159,7 @@ func (c *Confirmator) registerGate(key string, switcher *VersionGateSwitcher) er
 func (c *Confirmator) start(ctx context.Context) error {
 	c.mu.Lock()
 	if c.started {
+		c.mu.Unlock()
 		return errors.New("version gate: already started")
 	}
 	c.started = true

--- a/pkg/util/paramtable/version_gate.go
+++ b/pkg/util/paramtable/version_gate.go
@@ -57,18 +57,19 @@ type gate struct {
 	wasAbove bool      // whether the cluster was above GateVersion at the last check
 }
 
-// Confirmator is the one-shot cluster version confirmator. It is a
-// paramtable-level capability: it is recovered right after paramtable
-// initialization (see RecoverConfirmator), reusing the etcd client paramtable
-// created for its config etcd source, and needs no external wiring. A single
-// session watch maintains the minimum online version across all nodes; every
-// registered gate is then driven by that minimum version: once the cluster
-// stays above the gate's GateVersion for the whole SwitchDelay stability
-// window, the gate flips its config item's value to TargetValue in the config
-// center (etcd source). The flip is guarded so an explicit operator value is
-// never overwritten. When every registered gate is resolved the confirmator
-// exits; nothing keeps running afterwards. Use Close to stop it.
-type Confirmator struct {
+// confirmator is the one-shot cluster version confirmator. It is a
+// paramtable-level capability: the MixCoord role starts it via
+// StartVersionGateSwitcher (see recoverConfirmator), reusing the etcd client
+// paramtable created for its config etcd source, and needs no external
+// wiring. A single session watch maintains the minimum online version across
+// all nodes; every registered gate is then driven by that minimum version:
+// once the cluster stays above the gate's GateVersion for the whole
+// SwitchDelay stability window, the gate flips its config item's value to
+// TargetValue in the config center (etcd source). The flip is guarded so an
+// explicit operator value is never overwritten. When every registered gate is
+// resolved the confirmator exits; nothing keeps running afterwards. Use close
+// to stop it.
+type confirmator struct {
 	cli           *clientv3.Client
 	sessionPrefix string // prefix of the session keys (<metaRoot>/session)
 	configRoot    string // root of the config center keys (<configRoot>/config/<key>)
@@ -85,17 +86,17 @@ type Confirmator struct {
 // newConfirmator creates a confirmator that watches the sessions of all roles
 // under metaRoot. The etcd client is injected by the caller — the same client
 // paramtable uses for its config etcd source — so the confirmator never opens
-// a second connection and does not own the client (Close does not close it).
-// Use RecoverConfirmator to create, register and start a confirmator.
-func newConfirmator(etcdCli *clientv3.Client, metaRoot, configRoot string) *Confirmator {
-	return &Confirmator{
+// a second connection and does not own the client (close does not close it).
+// Use recoverConfirmator to create, register and start a confirmator.
+func newConfirmator(etcdCli *clientv3.Client, metaRoot, configRoot string) *confirmator {
+	return &confirmator{
 		cli:           etcdCli,
 		sessionPrefix: path.Join(metaRoot, "session"),
 		configRoot:    configRoot,
 	}
 }
 
-// RecoverConfirmator creates and starts a cluster version confirmator in one
+// recoverConfirmator creates and starts a cluster version confirmator in one
 // call: it registers a gate for every version-gated config item, then starts
 // the session watch and gate loop in the background. Gates are registered
 // before start (one-shot); items without a VersionGateSwitcher are skipped.
@@ -103,9 +104,9 @@ func newConfirmator(etcdCli *clientv3.Client, metaRoot, configRoot string) *Conf
 // confirmator; when every registered gate is already resolved (explicit config
 // or flipped by a previous run) the confirmator exits on its own after the
 // initial pass. The etcd client is injected by the caller and shared with the
-// config etcd source; the confirmator does not own it. Call Close on the
+// config etcd source; the confirmator does not own it. Call close on the
 // returned confirmator to stop it.
-func RecoverConfirmator(etcdCli *clientv3.Client, metaRoot, configRoot string, items []*ParamItem) (*Confirmator, error) {
+func recoverConfirmator(etcdCli *clientv3.Client, metaRoot, configRoot string, items []*ParamItem) (*confirmator, error) {
 	vg := newConfirmator(etcdCli, metaRoot, configRoot)
 	for _, item := range items {
 		if item == nil || item.VersionGateSwitcher == nil {
@@ -117,7 +118,7 @@ func RecoverConfirmator(etcdCli *clientv3.Client, metaRoot, configRoot string, i
 		}
 	}
 	if len(vg.gates) == 0 {
-		vg.Close()
+		vg.close()
 		return nil, nil
 	}
 	// Start in the background: the initial resolution reads etcd and must not
@@ -134,7 +135,7 @@ func RecoverConfirmator(etcdCli *clientv3.Client, metaRoot, configRoot string, i
 // registerGate registers a version-gated config item. Registration is only
 // allowed before start: the confirmator is one-shot and does not support gates
 // registered at runtime.
-func (c *Confirmator) registerGate(key string, switcher *VersionGateSwitcher) error {
+func (c *confirmator) registerGate(key string, switcher *VersionGateSwitcher) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.started {
@@ -156,7 +157,7 @@ func (c *Confirmator) registerGate(key string, switcher *VersionGateSwitcher) er
 // resolved immediately; for the remaining gates a single session watch and one
 // gate-processing loop are started in the background. start returns after the
 // initial pass. When all gates are resolved the confirmator stops itself.
-func (c *Confirmator) start(ctx context.Context) error {
+func (c *confirmator) start(ctx context.Context) error {
 	c.mu.Lock()
 	if c.started {
 		c.mu.Unlock()
@@ -198,7 +199,7 @@ func (c *Confirmator) start(ctx context.Context) error {
 // gate-processing loop, waiting for them to exit. The etcd client is injected
 // by the caller and shared with the config etcd source, so it is not closed
 // here.
-func (c *Confirmator) Close() {
+func (c *confirmator) close() {
 	if c.cancel != nil {
 		c.cancel()
 	}
@@ -211,7 +212,7 @@ func (c *Confirmator) Close() {
 // restarts (e.g. after a compaction): the watch is only the "something changed"
 // trigger, correctness comes from the rescan. On watch failure the loop
 // rebuilds the watch from a fresh revision.
-func (c *Confirmator) watchLoop(ctx context.Context) {
+func (c *confirmator) watchLoop(ctx context.Context) {
 	defer c.wg.Done()
 	for {
 		rev, err := c.reloadSessions(ctx)
@@ -259,7 +260,7 @@ func sleepCtx(ctx context.Context, d time.Duration) bool {
 // reloadSessions rescans the session prefix, recomputes the minimum online
 // version and returns the next watch revision (current revision + 1) so no
 // event committed between the scan and the watch is missed.
-func (c *Confirmator) reloadSessions(ctx context.Context) (int64, error) {
+func (c *confirmator) reloadSessions(ctx context.Context) (int64, error) {
 	min, rev, err := c.scanSessions(ctx)
 	if err != nil {
 		return 0, err
@@ -274,7 +275,7 @@ func (c *Confirmator) reloadSessions(ctx context.Context) (int64, error) {
 // revision from a fresh scan of the session prefix. Sessions with an
 // unparseable version are skipped; an empty session set yields the zero
 // version.
-func (c *Confirmator) scanSessions(ctx context.Context) (semver.Version, int64, error) {
+func (c *confirmator) scanSessions(ctx context.Context) (semver.Version, int64, error) {
 	resp, err := c.cli.Get(ctx, c.sessionPrefix, clientv3.WithPrefix())
 	if err != nil {
 		return semver.Version{}, 0, err
@@ -299,7 +300,7 @@ func (c *Confirmator) scanSessions(ctx context.Context) (semver.Version, int64, 
 // gateLoop periodically applies the per-gate SwitchDelay stability window and
 // flips the gates whose window has elapsed. It stops the confirmator once
 // every gate is resolved.
-func (c *Confirmator) gateLoop(ctx context.Context) {
+func (c *confirmator) gateLoop(ctx context.Context) {
 	defer c.wg.Done()
 	ticker := time.NewTicker(checkInterval)
 	defer ticker.Stop()
@@ -323,7 +324,7 @@ func (c *Confirmator) gateLoop(ctx context.Context) {
 // is above the gate's GateVersion and disarms it otherwise. Gates whose
 // stability window has elapsed are flipped. It returns true when every gate is
 // resolved.
-func (c *Confirmator) processGates(ctx context.Context) bool {
+func (c *confirmator) processGates(ctx context.Context) bool {
 	allDone := true
 	now := time.Now()
 	for _, g := range c.gates {
@@ -372,7 +373,7 @@ func (c *Confirmator) processGates(ctx context.Context) bool {
 // events may lag behind the flip check), then performs the flip. It returns
 // true when the gate is resolved (flipped, or superseded by an explicit config
 // value).
-func (c *Confirmator) recheckAndFlip(ctx context.Context, g *gate) bool {
+func (c *confirmator) recheckAndFlip(ctx context.Context, g *gate) bool {
 	min, _, err := c.scanSessions(ctx)
 	if err != nil {
 		mlog.Warn(ctx, "version gate: re-check sessions failed, retry later",
@@ -400,9 +401,20 @@ func (c *Confirmator) recheckAndFlip(ctx context.Context, g *gate) bool {
 // flip writes the gate's TargetValue into the config center once. The write is
 // guarded so an explicit operator value is never overwritten: the etcd-level
 // CAS only writes when the key is absent or still holds the sentinel value, so
-// a concurrently written explicit value wins. (Values from file/env sources
-// are covered by the explicit-config resolution at Start.)
-func (c *Confirmator) flip(ctx context.Context, g *gate) error {
+// a concurrently written explicit value wins. The process-local effective
+// value (file/env sources) is re-read right before the write: an explicit
+// non-sentinel value set while the confirmator is running (e.g. the false
+// escape hatch during a rolling upgrade) resolves the gate without touching
+// etcd, which would otherwise mask it forever.
+func (c *confirmator) flip(ctx context.Context, g *gate) error {
+	// The FileSource hot-reloads and the item is refreshable, so an operator
+	// may have set an explicit value (e.g. the false escape hatch) after the
+	// confirmator started; that value must win over the flip.
+	if v, ok := currentConfigValue(g.key); ok && v != g.switcher.EnableAutoSwitchValue {
+		mlog.Info(ctx, "version gate: local config value is explicit, skip flip",
+			mlog.String("key", g.key), mlog.String("value", v))
+		return nil
+	}
 	key := c.configKey(g.key)
 	resp, err := c.cli.Get(ctx, key)
 	if err != nil {
@@ -450,7 +462,7 @@ func (c *Confirmator) flip(ctx context.Context, g *gate) error {
 // gateResolvedLocked reports whether the gate needs no flipping: the effective
 // config value is no longer the sentinel (explicit operator value, or the
 // value was already flipped by a previous run). Caller must hold c.mu.
-func (c *Confirmator) gateResolvedLocked(g *gate) bool {
+func (c *confirmator) gateResolvedLocked(g *gate) bool {
 	if v, ok := currentConfigValue(g.key); ok {
 		return v != g.switcher.EnableAutoSwitchValue
 	}
@@ -469,12 +481,12 @@ func isZero(v semver.Version) bool {
 }
 
 // configKey returns the config-center etcd key of a config item.
-func (c *Confirmator) configKey(key string) string {
+func (c *confirmator) configKey(key string) string {
 	return path.Join(c.configRoot, "config", config.FormatKey(key))
 }
 
 // configValue reads the config-center etcd key of a config item.
-func (c *Confirmator) configValue(key string) (string, bool, error) {
+func (c *confirmator) configValue(key string) (string, bool, error) {
 	resp, err := c.cli.Get(context.Background(), c.configKey(key))
 	if err != nil {
 		return "", false, err

--- a/pkg/util/paramtable/version_gate.go
+++ b/pkg/util/paramtable/version_gate.go
@@ -37,6 +37,10 @@ import (
 // applies the per-gate SwitchDelay stability window.
 const checkInterval = 100 * time.Millisecond
 
+// maxScanBackoff caps the exponential backoff of the session-scan retry in
+// watchLoop, so an unreachable etcd is not polled at the check rate forever.
+const maxScanBackoff = 5 * time.Second
+
 // sessionVersion is the minimal session info used for scanning, carrying only
 // the registered node version.
 type sessionVersion struct {
@@ -55,6 +59,13 @@ type gate struct {
 	resolved bool
 	armedAt  time.Time // when the cluster first stayed above GateVersion (zero = not armed)
 	wasAbove bool      // whether the cluster was above GateVersion at the last check
+
+	// retryAt is the earliest time the due flip may be retried after a
+	// transient failure (etcd unreachable, flip CAS error). The retry backs
+	// off exponentially up to SwitchDelay so a broken config center is not
+	// hammered at the check interval; zero means no backoff pending.
+	retryAt time.Time
+	backoff time.Duration
 }
 
 // confirmator is the one-shot cluster version confirmator. It is a
@@ -214,6 +225,7 @@ func (c *confirmator) close() {
 // rebuilds the watch from a fresh revision.
 func (c *confirmator) watchLoop(ctx context.Context) {
 	defer c.wg.Done()
+	scanBackoff := checkInterval
 	for {
 		rev, err := c.reloadSessions(ctx)
 		if err != nil {
@@ -221,11 +233,16 @@ func (c *confirmator) watchLoop(ctx context.Context) {
 				return
 			}
 			mlog.Warn(ctx, "version gate: session scan failed, retry", mlog.Err(err))
-			if !sleepCtx(ctx, checkInterval) {
+			if !sleepCtx(ctx, scanBackoff) {
 				return
+			}
+			scanBackoff *= 2
+			if scanBackoff > maxScanBackoff {
+				scanBackoff = maxScanBackoff
 			}
 			continue
 		}
+		scanBackoff = checkInterval
 		wch := c.cli.Watch(ctx, c.sessionPrefix, clientv3.WithPrefix(), clientv3.WithRev(rev))
 		for resp := range wch {
 			if err := resp.Err(); err != nil {
@@ -348,9 +365,16 @@ func (c *confirmator) processGates(ctx context.Context) bool {
 		}
 		g.wasAbove = above
 		due := above && !g.armedAt.IsZero() && now.Sub(g.armedAt) >= g.switcher.SwitchDelay
+		retryAt := g.retryAt
 		c.mu.Unlock()
 
 		if due {
+			if now.Before(retryAt) {
+				// A previous flip attempt failed transiently; back off instead
+				// of hammering the config center at the check interval.
+				allDone = false
+				continue
+			}
 			if !c.recheckAndFlip(ctx, g) {
 				allDone = false
 				continue
@@ -372,10 +396,12 @@ func (c *confirmator) processGates(ctx context.Context) bool {
 // read before the irreversible flip (the session watch is event-driven and its
 // events may lag behind the flip check), then performs the flip. It returns
 // true when the gate is resolved (flipped, or superseded by an explicit config
-// value).
+// value). Transient failures (etcd scan/flip errors) grow the gate's retry
+// backoff exponentially up to the SwitchDelay cap.
 func (c *confirmator) recheckAndFlip(ctx context.Context, g *gate) bool {
 	min, _, err := c.scanSessions(ctx)
 	if err != nil {
+		c.backoffForRetryLocked(g)
 		mlog.Warn(ctx, "version gate: re-check sessions failed, retry later",
 			mlog.String("key", g.key), mlog.Err(err))
 		return false
@@ -384,6 +410,8 @@ func (c *confirmator) recheckAndFlip(ctx context.Context, g *gate) bool {
 		c.mu.Lock()
 		g.armedAt = time.Time{}
 		g.wasAbove = false
+		g.retryAt = time.Time{}
+		g.backoff = 0
 		c.mu.Unlock()
 		mlog.Warn(ctx, "version gate: cluster below gate version at flip time, reset stability window",
 			mlog.String("key", g.key), mlog.String("gateVersion", g.switcher.GateVersion),
@@ -391,11 +419,33 @@ func (c *confirmator) recheckAndFlip(ctx context.Context, g *gate) bool {
 		return false
 	}
 	if err := c.flip(ctx, g); err != nil {
+		c.backoffForRetryLocked(g)
 		mlog.Warn(ctx, "version gate: flip failed, will retry",
 			mlog.String("key", g.key), mlog.Err(err))
 		return false
 	}
+	// Flip succeeded (or the gate was superseded by an explicit value):
+	// clear any accumulated backoff.
+	c.mu.Lock()
+	g.retryAt = time.Time{}
+	g.backoff = 0
+	c.mu.Unlock()
 	return true
+}
+
+// backoffForRetryLocked grows the gate's flip-retry backoff exponentially up
+// to the SwitchDelay cap and schedules the next retry at now+backoff. Caller
+// must hold c.mu.
+func (c *confirmator) backoffForRetryLocked(g *gate) {
+	if g.backoff == 0 {
+		g.backoff = checkInterval
+	} else {
+		g.backoff *= 2
+	}
+	if g.backoff > g.switcher.SwitchDelay {
+		g.backoff = g.switcher.SwitchDelay
+	}
+	g.retryAt = time.Now().Add(g.backoff)
 }
 
 // flip writes the gate's TargetValue into the config center once. The write is

--- a/pkg/util/paramtable/version_gate_test.go
+++ b/pkg/util/paramtable/version_gate_test.go
@@ -226,14 +226,26 @@ func TestInitVersionGatesEmbeddedEtcd(t *testing.T) {
 
 	p.initVersionGates()
 	// Local version (common.Version, 3.0.0-beta on master) >= 2.6.23: the gate
-	// is locally satisfied and no confirmator is created.
+	// is locally satisfied and no confirmator is created. initVersionGates
+	// itself evicts the value cache, so the resolution is observable directly.
 	assert.True(t, item.VersionGateSwitcher.localSatisfied)
 	assert.Nil(t, p.versionGates)
-	// The sentinel default now resolves to TargetValue. (GetAsBool caches by
-	// raw value, which is unchanged, so evict to observe the runtime hint.)
-	item.manager.EvictCachedValue(item.Key)
 	assert.Equal(t, "true", item.GetValue())
 	assert.True(t, item.GetAsBool())
+
+	// Negative branch: a gate whose version is above the local version stays
+	// closed — localSatisfied remains false and the item reads PreSwitchValue.
+	// (Reset the hint set by the positive branch, then re-run.)
+	item.VersionGateSwitcher.localSatisfied = false
+	oldGateVersion := item.VersionGateSwitcher.GateVersion
+	item.VersionGateSwitcher.GateVersion = "99.0.0"
+	defer func() { item.VersionGateSwitcher.GateVersion = oldGateVersion }()
+
+	p.initVersionGates()
+	assert.False(t, item.VersionGateSwitcher.localSatisfied)
+	item.manager.EvictCachedValue(item.Key)
+	assert.Equal(t, "false", item.GetValue())
+	assert.False(t, item.GetAsBool())
 }
 
 func gateSwitcher(gateVersion string, delay time.Duration) *VersionGateSwitcher {

--- a/pkg/util/paramtable/version_gate_test.go
+++ b/pkg/util/paramtable/version_gate_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v3/config"
 	etcdkv "github.com/milvus-io/milvus/pkg/v3/util/etcd"
+	"github.com/milvus-io/milvus/pkg/v3/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -200,6 +201,39 @@ func TestInitVersionGatesSkipRemote(t *testing.T) {
 	p := &ComponentParam{}
 	p.Init(NewBaseTable(SkipRemote(true)))
 	assert.Nil(t, p.versionGates)
+}
+
+func TestInitVersionGatesEmbeddedEtcd(t *testing.T) {
+	// Embedded-etcd deployments are single-process: when the local version
+	// already satisfies the gate, initVersionGates resolves the item directly
+	// (localSatisfied -> TargetValue) instead of creating a confirmator.
+	t.Setenv(metricsinfo.DeployModeEnvKey, metricsinfo.StandaloneDeployMode)
+	p := &ComponentParam{}
+	bt := NewBaseTable(SkipRemote(true))
+	p.Init(bt)
+	item := &p.FunctionCfg.EnableWriteBeforeMaterialization
+	require.NotNil(t, item.VersionGateSwitcher)
+	assert.False(t, item.VersionGateSwitcher.localSatisfied)
+
+	// Same package: flip skipRemote off so initVersionGates actually runs, and
+	// enable embedded etcd. FunctionCfg is already initialized by Init.
+	bt.config.skipRemote = false
+	p.ServiceParam.EtcdCfg.UseEmbedEtcd.SwapTempValue("true")
+	defer func() {
+		p.ServiceParam.EtcdCfg.UseEmbedEtcd.SwapTempValue("")
+		bt.config.skipRemote = true
+	}()
+
+	p.initVersionGates()
+	// Local version (common.Version, 3.0.0-beta on master) >= 2.6.23: the gate
+	// is locally satisfied and no confirmator is created.
+	assert.True(t, item.VersionGateSwitcher.localSatisfied)
+	assert.Nil(t, p.versionGates)
+	// The sentinel default now resolves to TargetValue. (GetAsBool caches by
+	// raw value, which is unchanged, so evict to observe the runtime hint.)
+	item.manager.EvictCachedValue(item.Key)
+	assert.Equal(t, "true", item.GetValue())
+	assert.True(t, item.GetAsBool())
 }
 
 func gateSwitcher(gateVersion string, delay time.Duration) *VersionGateSwitcher {

--- a/pkg/util/paramtable/version_gate_test.go
+++ b/pkg/util/paramtable/version_gate_test.go
@@ -56,45 +56,40 @@ func testRoots(t *testing.T) (metaRoot, configRoot string) {
 }
 
 // newTestConfirmator builds a confirmator against the embedded etcd server
-// through the same paramtable etcd-config path used in production (the
-// confirmator creates its own client from the etcd config).
-func newTestConfirmator(t *testing.T, clientPort int, metaRoot, configRoot string) *Confirmator {
+// using the same shared etcd client that production injects (the confirmator
+// never opens its own connection).
+func newTestConfirmator(t *testing.T, etcdCli *clientv3.Client, metaRoot, configRoot string) *Confirmator {
 	t.Helper()
-	etcdCfg := &EtcdConfig{}
-	etcdCfg.Init(NewBaseTable(SkipRemote(true)))
-	etcdCfg.Endpoints.SwapTempValue(fmt.Sprintf("127.0.0.1:%d", clientPort))
-	c, err := NewConfirmator(etcdCfg, metaRoot, configRoot)
-	require.NoError(t, err)
-	return c
+	return newConfirmator(etcdCli, metaRoot, configRoot)
 }
 
 func TestConfirmator_RegisterGate(t *testing.T) {
-	_, clientPort := setupEmbedEtcd(t)
+	cli, _ := setupEmbedEtcd(t)
 	metaRoot, configRoot := testRoots(t)
-	c := newTestConfirmator(t, clientPort, metaRoot, configRoot)
+	c := newTestConfirmator(t, cli, metaRoot, configRoot)
 
 	// nil switcher is rejected.
-	assert.Error(t, c.RegisterGate(testConfigKey, nil))
+	assert.Error(t, c.registerGate(testConfigKey, nil))
 	// unparseable gate version is rejected.
-	assert.Error(t, c.RegisterGate(testConfigKey, &VersionGateSwitcher{GateVersion: "not-a-version"}))
+	assert.Error(t, c.registerGate(testConfigKey, &VersionGateSwitcher{GateVersion: "not-a-version"}))
 
-	require.NoError(t, c.RegisterGate(testConfigKey, gateSwitcher("2.6.23", 10*time.Millisecond)))
-	require.NoError(t, c.Start(context.Background()))
-	defer c.Stop()
+	require.NoError(t, c.registerGate(testConfigKey, gateSwitcher("2.6.23", 10*time.Millisecond)))
+	require.NoError(t, c.start(context.Background()))
+	defer c.Close()
 
 	// one-shot: no gate can be registered after Start.
-	assert.Error(t, c.RegisterGate(testConfigKey, gateSwitcher("2.6.23", 10*time.Millisecond)))
+	assert.Error(t, c.registerGate(testConfigKey, gateSwitcher("2.6.23", 10*time.Millisecond)))
 }
 
 func TestConfirmator_FlipsAfterAllUpAndDelay(t *testing.T) {
-	cli, clientPort := setupEmbedEtcd(t)
+	cli, _ := setupEmbedEtcd(t)
 	metaRoot, configRoot := testRoots(t)
 	putAllUpSessions(t, cli, metaRoot)
 
-	c := newTestConfirmator(t, clientPort, metaRoot, configRoot)
-	require.NoError(t, c.RegisterGate(testConfigKey, gateSwitcher("2.6.23", 50*time.Millisecond)))
-	require.NoError(t, c.Start(context.Background()))
-	defer c.Stop()
+	c := newTestConfirmator(t, cli, metaRoot, configRoot)
+	require.NoError(t, c.registerGate(testConfigKey, gateSwitcher("2.6.23", 50*time.Millisecond)))
+	require.NoError(t, c.start(context.Background()))
+	defer c.Close()
 
 	waitConfigValue(t, cli, configRoot, testConfigKey, testConfigValue)
 }
@@ -102,41 +97,41 @@ func TestConfirmator_FlipsAfterAllUpAndDelay(t *testing.T) {
 func TestConfirmator_NoSessionsNoFlip(t *testing.T) {
 	// No session at all: the minimum online version is unknown (zero), so no
 	// gate can ever be above its GateVersion and nothing is flipped.
-	cli, clientPort := setupEmbedEtcd(t)
+	cli, _ := setupEmbedEtcd(t)
 	metaRoot, configRoot := testRoots(t)
 
-	c := newTestConfirmator(t, clientPort, metaRoot, configRoot)
-	require.NoError(t, c.RegisterGate(testConfigKey, gateSwitcher("2.6.23", 50*time.Millisecond)))
-	require.NoError(t, c.Start(context.Background()))
-	defer c.Stop()
+	c := newTestConfirmator(t, cli, metaRoot, configRoot)
+	require.NoError(t, c.registerGate(testConfigKey, gateSwitcher("2.6.23", 50*time.Millisecond)))
+	require.NoError(t, c.start(context.Background()))
+	defer c.Close()
 
 	assertNoFlip(t, cli, configRoot, testConfigKey)
 }
 
 func TestConfirmator_MixedVersionsNoFlip(t *testing.T) {
-	cli, clientPort := setupEmbedEtcd(t)
+	cli, _ := setupEmbedEtcd(t)
 	metaRoot, configRoot := testRoots(t)
 	putSession(t, cli, metaRoot, typeutil.DataNodeRole, "node-1", "2.6.23")
 	putSession(t, cli, metaRoot, typeutil.ProxyRole, "node-1", "2.6.22")
 
-	c := newTestConfirmator(t, clientPort, metaRoot, configRoot)
-	require.NoError(t, c.RegisterGate(testConfigKey, gateSwitcher("2.6.23", 30*time.Millisecond)))
-	require.NoError(t, c.Start(context.Background()))
-	defer c.Stop()
+	c := newTestConfirmator(t, cli, metaRoot, configRoot)
+	require.NoError(t, c.registerGate(testConfigKey, gateSwitcher("2.6.23", 30*time.Millisecond)))
+	require.NoError(t, c.start(context.Background()))
+	defer c.Close()
 
 	assertNoFlip(t, cli, configRoot, testConfigKey)
 }
 
 func TestConfirmator_SessionDipResetsStabilityWindow(t *testing.T) {
-	cli, clientPort := setupEmbedEtcd(t)
+	cli, _ := setupEmbedEtcd(t)
 	metaRoot, configRoot := testRoots(t)
 	putSession(t, cli, metaRoot, typeutil.ProxyRole, "node-1", "2.6.23")
 	putSession(t, cli, metaRoot, typeutil.QueryNodeRole, "node-1", "2.6.23")
 
-	c := newTestConfirmator(t, clientPort, metaRoot, configRoot)
-	require.NoError(t, c.RegisterGate(testConfigKey, gateSwitcher("2.6.23", 200*time.Millisecond)))
-	require.NoError(t, c.Start(context.Background()))
-	defer c.Stop()
+	c := newTestConfirmator(t, cli, metaRoot, configRoot)
+	require.NoError(t, c.registerGate(testConfigKey, gateSwitcher("2.6.23", 200*time.Millisecond)))
+	require.NoError(t, c.start(context.Background()))
+	defer c.Close()
 
 	// A session dips below the gate version during the stability window:
 	// the window must reset and the flip must not happen.
@@ -151,29 +146,29 @@ func TestConfirmator_SessionDipResetsStabilityWindow(t *testing.T) {
 }
 
 func TestConfirmator_ExplicitEtcdValueWins(t *testing.T) {
-	cli, clientPort := setupEmbedEtcd(t)
+	cli, _ := setupEmbedEtcd(t)
 	metaRoot, configRoot := testRoots(t)
 	putAllUpSessions(t, cli, metaRoot)
 	putConfig(t, cli, configRoot, testConfigKey, "false")
 
-	c := newTestConfirmator(t, clientPort, metaRoot, configRoot)
-	require.NoError(t, c.RegisterGate(testConfigKey, gateSwitcher("2.6.23", 30*time.Millisecond)))
-	require.NoError(t, c.Start(context.Background()))
-	defer c.Stop()
+	c := newTestConfirmator(t, cli, metaRoot, configRoot)
+	require.NoError(t, c.registerGate(testConfigKey, gateSwitcher("2.6.23", 30*time.Millisecond)))
+	require.NoError(t, c.start(context.Background()))
+	defer c.Close()
 
 	// The explicit value must not be overwritten by the flip.
 	waitConfigValue(t, cli, configRoot, testConfigKey, "false")
 }
 
 func TestConfirmator_AlreadyFlippedAtStart(t *testing.T) {
-	cli, clientPort := setupEmbedEtcd(t)
+	cli, _ := setupEmbedEtcd(t)
 	metaRoot, configRoot := testRoots(t)
 	putConfig(t, cli, configRoot, testConfigKey, testConfigValue)
 
-	c := newTestConfirmator(t, clientPort, metaRoot, configRoot)
-	require.NoError(t, c.RegisterGate(testConfigKey, gateSwitcher("2.6.23", 10*time.Millisecond)))
-	require.NoError(t, c.Start(context.Background()))
-	defer c.Stop()
+	c := newTestConfirmator(t, cli, metaRoot, configRoot)
+	require.NoError(t, c.registerGate(testConfigKey, gateSwitcher("2.6.23", 10*time.Millisecond)))
+	require.NoError(t, c.start(context.Background()))
+	defer c.Close()
 
 	// The gate is resolved immediately: no session watch is running.
 	c.mu.Lock()
@@ -183,15 +178,15 @@ func TestConfirmator_AlreadyFlippedAtStart(t *testing.T) {
 }
 
 func TestConfirmator_MultipleGatesIndependent(t *testing.T) {
-	cli, clientPort := setupEmbedEtcd(t)
+	cli, _ := setupEmbedEtcd(t)
 	metaRoot, configRoot := testRoots(t)
 	putAllUpSessions(t, cli, metaRoot)
 
-	c := newTestConfirmator(t, clientPort, metaRoot, configRoot)
-	require.NoError(t, c.RegisterGate(testConfigKey, gateSwitcher("2.6.23", 50*time.Millisecond)))
-	require.NoError(t, c.RegisterGate("function.testGate2", gateSwitcher("3.0.0", 50*time.Millisecond)))
-	require.NoError(t, c.Start(context.Background()))
-	defer c.Stop()
+	c := newTestConfirmator(t, cli, metaRoot, configRoot)
+	require.NoError(t, c.registerGate(testConfigKey, gateSwitcher("2.6.23", 50*time.Millisecond)))
+	require.NoError(t, c.registerGate("function.testGate2", gateSwitcher("3.0.0", 50*time.Millisecond)))
+	require.NoError(t, c.start(context.Background()))
+	defer c.Close()
 
 	// The 2.6.23 gate flips; the 3.0.0 gate stays pending.
 	waitConfigValue(t, cli, configRoot, testConfigKey, testConfigValue)

--- a/pkg/util/paramtable/version_gate_test.go
+++ b/pkg/util/paramtable/version_gate_test.go
@@ -1,0 +1,346 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package paramtable
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"github.com/milvus-io/milvus/pkg/v3/config"
+	etcdkv "github.com/milvus-io/milvus/pkg/v3/util/etcd"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+const (
+	testConfigKey   = "function.testGate"
+	testConfigValue = "true"
+)
+
+// testRootSeq makes each testRoots() call unique, so repeated runs (-count=N)
+// against the shared embedded etcd server never see leftovers of a previous
+// iteration (e.g. a config key flipped by the same test name).
+var testRootSeq int64
+
+// testRoots returns an etcd key root unique to the test, so tests running
+// against the shared embedded etcd server never see each other's sessions or
+// flipped config values.
+func testRoots(t *testing.T) (metaRoot, configRoot string) {
+	t.Helper()
+	root := fmt.Sprintf("test-root-%s-%d", strings.ReplaceAll(t.Name(), "/", "-"), atomic.AddInt64(&testRootSeq, 1))
+	return path.Join(root, "meta"), root
+}
+
+// newTestConfirmator builds a confirmator against the embedded etcd server
+// through the same paramtable etcd-config path used in production (the
+// confirmator creates its own client from the etcd config).
+func newTestConfirmator(t *testing.T, clientPort int, metaRoot, configRoot string) *Confirmator {
+	t.Helper()
+	etcdCfg := &EtcdConfig{}
+	etcdCfg.Init(NewBaseTable(SkipRemote(true)))
+	etcdCfg.Endpoints.SwapTempValue(fmt.Sprintf("127.0.0.1:%d", clientPort))
+	c, err := NewConfirmator(etcdCfg, metaRoot, configRoot)
+	require.NoError(t, err)
+	return c
+}
+
+func TestConfirmator_RegisterGate(t *testing.T) {
+	_, clientPort := setupEmbedEtcd(t)
+	metaRoot, configRoot := testRoots(t)
+	c := newTestConfirmator(t, clientPort, metaRoot, configRoot)
+
+	// nil switcher is rejected.
+	assert.Error(t, c.RegisterGate(testConfigKey, nil))
+	// unparseable gate version is rejected.
+	assert.Error(t, c.RegisterGate(testConfigKey, &VersionGateSwitcher{GateVersion: "not-a-version"}))
+
+	require.NoError(t, c.RegisterGate(testConfigKey, gateSwitcher("2.6.23", 10*time.Millisecond)))
+	require.NoError(t, c.Start(context.Background()))
+	defer c.Stop()
+
+	// one-shot: no gate can be registered after Start.
+	assert.Error(t, c.RegisterGate(testConfigKey, gateSwitcher("2.6.23", 10*time.Millisecond)))
+}
+
+func TestConfirmator_FlipsAfterAllUpAndDelay(t *testing.T) {
+	cli, clientPort := setupEmbedEtcd(t)
+	metaRoot, configRoot := testRoots(t)
+	putAllUpSessions(t, cli, metaRoot)
+
+	c := newTestConfirmator(t, clientPort, metaRoot, configRoot)
+	require.NoError(t, c.RegisterGate(testConfigKey, gateSwitcher("2.6.23", 50*time.Millisecond)))
+	require.NoError(t, c.Start(context.Background()))
+	defer c.Stop()
+
+	waitConfigValue(t, cli, configRoot, testConfigKey, testConfigValue)
+}
+
+func TestConfirmator_NoSessionsNoFlip(t *testing.T) {
+	// No session at all: the minimum online version is unknown (zero), so no
+	// gate can ever be above its GateVersion and nothing is flipped.
+	cli, clientPort := setupEmbedEtcd(t)
+	metaRoot, configRoot := testRoots(t)
+
+	c := newTestConfirmator(t, clientPort, metaRoot, configRoot)
+	require.NoError(t, c.RegisterGate(testConfigKey, gateSwitcher("2.6.23", 50*time.Millisecond)))
+	require.NoError(t, c.Start(context.Background()))
+	defer c.Stop()
+
+	assertNoFlip(t, cli, configRoot, testConfigKey)
+}
+
+func TestConfirmator_MixedVersionsNoFlip(t *testing.T) {
+	cli, clientPort := setupEmbedEtcd(t)
+	metaRoot, configRoot := testRoots(t)
+	putSession(t, cli, metaRoot, typeutil.DataNodeRole, "node-1", "2.6.23")
+	putSession(t, cli, metaRoot, typeutil.ProxyRole, "node-1", "2.6.22")
+
+	c := newTestConfirmator(t, clientPort, metaRoot, configRoot)
+	require.NoError(t, c.RegisterGate(testConfigKey, gateSwitcher("2.6.23", 30*time.Millisecond)))
+	require.NoError(t, c.Start(context.Background()))
+	defer c.Stop()
+
+	assertNoFlip(t, cli, configRoot, testConfigKey)
+}
+
+func TestConfirmator_SessionDipResetsStabilityWindow(t *testing.T) {
+	cli, clientPort := setupEmbedEtcd(t)
+	metaRoot, configRoot := testRoots(t)
+	putSession(t, cli, metaRoot, typeutil.ProxyRole, "node-1", "2.6.23")
+	putSession(t, cli, metaRoot, typeutil.QueryNodeRole, "node-1", "2.6.23")
+
+	c := newTestConfirmator(t, clientPort, metaRoot, configRoot)
+	require.NoError(t, c.RegisterGate(testConfigKey, gateSwitcher("2.6.23", 200*time.Millisecond)))
+	require.NoError(t, c.Start(context.Background()))
+	defer c.Stop()
+
+	// A session dips below the gate version during the stability window:
+	// the window must reset and the flip must not happen.
+	time.Sleep(50 * time.Millisecond)
+	putSession(t, cli, metaRoot, typeutil.ProxyRole, "node-1", "2.6.22")
+	assertNoFlip(t, cli, configRoot, testConfigKey)
+
+	// The session comes back above the gate version: the window restarts and
+	// the gate flips.
+	putSession(t, cli, metaRoot, typeutil.ProxyRole, "node-1", "2.6.23")
+	waitConfigValue(t, cli, configRoot, testConfigKey, testConfigValue)
+}
+
+func TestConfirmator_ExplicitEtcdValueWins(t *testing.T) {
+	cli, clientPort := setupEmbedEtcd(t)
+	metaRoot, configRoot := testRoots(t)
+	putAllUpSessions(t, cli, metaRoot)
+	putConfig(t, cli, configRoot, testConfigKey, "false")
+
+	c := newTestConfirmator(t, clientPort, metaRoot, configRoot)
+	require.NoError(t, c.RegisterGate(testConfigKey, gateSwitcher("2.6.23", 30*time.Millisecond)))
+	require.NoError(t, c.Start(context.Background()))
+	defer c.Stop()
+
+	// The explicit value must not be overwritten by the flip.
+	waitConfigValue(t, cli, configRoot, testConfigKey, "false")
+}
+
+func TestConfirmator_AlreadyFlippedAtStart(t *testing.T) {
+	cli, clientPort := setupEmbedEtcd(t)
+	metaRoot, configRoot := testRoots(t)
+	putConfig(t, cli, configRoot, testConfigKey, testConfigValue)
+
+	c := newTestConfirmator(t, clientPort, metaRoot, configRoot)
+	require.NoError(t, c.RegisterGate(testConfigKey, gateSwitcher("2.6.23", 10*time.Millisecond)))
+	require.NoError(t, c.Start(context.Background()))
+	defer c.Stop()
+
+	// The gate is resolved immediately: no session watch is running.
+	c.mu.Lock()
+	resolved := c.gates[0].resolved
+	c.mu.Unlock()
+	assert.True(t, resolved)
+}
+
+func TestConfirmator_MultipleGatesIndependent(t *testing.T) {
+	cli, clientPort := setupEmbedEtcd(t)
+	metaRoot, configRoot := testRoots(t)
+	putAllUpSessions(t, cli, metaRoot)
+
+	c := newTestConfirmator(t, clientPort, metaRoot, configRoot)
+	require.NoError(t, c.RegisterGate(testConfigKey, gateSwitcher("2.6.23", 50*time.Millisecond)))
+	require.NoError(t, c.RegisterGate("function.testGate2", gateSwitcher("3.0.0", 50*time.Millisecond)))
+	require.NoError(t, c.Start(context.Background()))
+	defer c.Stop()
+
+	// The 2.6.23 gate flips; the 3.0.0 gate stays pending.
+	waitConfigValue(t, cli, configRoot, testConfigKey, testConfigValue)
+	time.Sleep(150 * time.Millisecond)
+	assertConfigAbsent(t, cli, configRoot, "function.testGate2")
+}
+
+func TestInitVersionGatesSkipRemote(t *testing.T) {
+	// initVersionGates is a no-op for a skip-remote param table (the common
+	// test setup): no confirmator is created and no goroutine leaks.
+	p := &ComponentParam{}
+	p.Init(NewBaseTable(SkipRemote(true)))
+	assert.Nil(t, p.versionGates)
+}
+
+func gateSwitcher(gateVersion string, delay time.Duration) *VersionGateSwitcher {
+	return &VersionGateSwitcher{
+		EnableAutoSwitchValue: "auto",
+		PreSwitchValue:        "false",
+		GateVersion:           gateVersion,
+		TargetValue:           testConfigValue,
+		SwitchDelay:           delay,
+	}
+}
+
+// putAllUpSessions registers one session above the gate version for each of
+// the common roles, so a watch over the whole session prefix sees them all.
+func putAllUpSessions(t *testing.T, cli *clientv3.Client, metaRoot string) {
+	t.Helper()
+	for _, role := range []string{
+		typeutil.ProxyRole,
+		typeutil.DataNodeRole,
+		typeutil.QueryNodeRole,
+		typeutil.StreamingNodeRole,
+	} {
+		putSession(t, cli, metaRoot, role, "node-1", "2.6.23")
+	}
+}
+
+func putConfig(t *testing.T, cli *clientv3.Client, configRoot, key, value string) {
+	t.Helper()
+	_, err := cli.Put(context.Background(), path.Join(configRoot, "config", config.FormatKey(key)), value)
+	require.NoError(t, err)
+}
+
+func getConfigValue(t *testing.T, cli *clientv3.Client, configRoot, key string) (string, bool) {
+	t.Helper()
+	resp, err := cli.Get(context.Background(), path.Join(configRoot, "config", config.FormatKey(key)))
+	require.NoError(t, err)
+	if len(resp.Kvs) == 0 {
+		return "", false
+	}
+	return string(resp.Kvs[0].Value), true
+}
+
+// waitConfigValue polls until the config-center key holds the expected value.
+func waitConfigValue(t *testing.T, cli *clientv3.Client, configRoot, key, expected string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if v, ok := getConfigValue(t, cli, configRoot, key); ok && v == expected {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("config %s did not reach value %q", key, expected)
+}
+
+// assertNoFlip asserts that the config-center key stays absent/unchanged for a
+// while, i.e. the gate did not flip.
+func assertNoFlip(t *testing.T, cli *clientv3.Client, configRoot, key string) {
+	t.Helper()
+	time.Sleep(300 * time.Millisecond)
+	assertConfigAbsent(t, cli, configRoot, key)
+}
+
+func assertConfigAbsent(t *testing.T, cli *clientv3.Client, configRoot, key string) {
+	t.Helper()
+	_, ok := getConfigValue(t, cli, configRoot, key)
+	assert.False(t, ok, "config %s should not be flipped", key)
+}
+
+// embedEtcdClientPort remembers the client port of the singleton embedded etcd
+// server, so later tests can point their own confirmator client at it.
+var embedEtcdClientPort int
+
+// setupEmbedEtcd starts the embedded etcd server (singleton) and returns a
+// client plus the client port. The server is stopped by TestMain after all
+// tests.
+func setupEmbedEtcd(t *testing.T) (*clientv3.Client, int) {
+	t.Helper()
+	if etcdkv.HasServer() {
+		cli, err := etcdkv.GetEmbedEtcdClient()
+		require.NoError(t, err)
+		return cli, embedEtcdClientPort
+	}
+	clientPort, peerPort := freePort(t), freePort(t)
+	dataDir, err := os.MkdirTemp("", "test-versiongate-etcd-*")
+	require.NoError(t, err)
+	cfgFile, err := os.CreateTemp("", "test-versiongate-etcd-*.yaml")
+	require.NoError(t, err)
+	_, err = fmt.Fprintf(cfgFile, `name: default
+data-dir: %s
+listen-client-urls: http://127.0.0.1:%d
+advertise-client-urls: http://127.0.0.1:%d
+listen-peer-urls: http://127.0.0.1:%d
+initial-advertise-peer-urls: http://127.0.0.1:%d
+initial-cluster: default=http://127.0.0.1:%d
+initial-cluster-state: new
+`, dataDir, clientPort, clientPort, peerPort, peerPort, peerPort)
+	require.NoError(t, err)
+	require.NoError(t, cfgFile.Close())
+	t.Cleanup(func() {
+		os.RemoveAll(dataDir)
+		os.Remove(cfgFile.Name())
+	})
+
+	require.NoError(t, etcdkv.InitEtcdServer(true, cfgFile.Name(), dataDir, "stdout", "error"))
+	cli, err := etcdkv.GetEmbedEtcdClient()
+	require.NoError(t, err)
+	embedEtcdClientPort = clientPort
+	// The embedded etcd server starts asynchronously; wait until it is ready.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		_, err := cli.Get(context.Background(), "health")
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			require.NoError(t, err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return cli, clientPort
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+	return port
+}
+
+// putSession registers a fake session with the given version into etcd.
+func putSession(t *testing.T, cli *clientv3.Client, metaRoot, role, nodeID, version string) {
+	t.Helper()
+	key := path.Join(metaRoot, "session", role, nodeID)
+	_, err := cli.Put(context.Background(), key, fmt.Sprintf(`{"Version":%q}`, version))
+	require.NoError(t, err)
+}

--- a/pkg/util/paramtable/version_gate_test.go
+++ b/pkg/util/paramtable/version_gate_test.go
@@ -218,9 +218,9 @@ func TestInitVersionGatesEmbeddedEtcd(t *testing.T) {
 	// Same package: flip skipRemote off so initVersionGates actually runs, and
 	// enable embedded etcd. FunctionCfg is already initialized by Init.
 	bt.config.skipRemote = false
-	p.ServiceParam.EtcdCfg.UseEmbedEtcd.SwapTempValue("true")
+	p.EtcdCfg.UseEmbedEtcd.SwapTempValue("true")
 	defer func() {
-		p.ServiceParam.EtcdCfg.UseEmbedEtcd.SwapTempValue("")
+		p.EtcdCfg.UseEmbedEtcd.SwapTempValue("")
 		bt.config.skipRemote = true
 	}()
 

--- a/pkg/util/paramtable/version_gate_test.go
+++ b/pkg/util/paramtable/version_gate_test.go
@@ -59,7 +59,7 @@ func testRoots(t *testing.T) (metaRoot, configRoot string) {
 // newTestConfirmator builds a confirmator against the embedded etcd server
 // using the same shared etcd client that production injects (the confirmator
 // never opens its own connection).
-func newTestConfirmator(t *testing.T, etcdCli *clientv3.Client, metaRoot, configRoot string) *Confirmator {
+func newTestConfirmator(t *testing.T, etcdCli *clientv3.Client, metaRoot, configRoot string) *confirmator {
 	t.Helper()
 	return newConfirmator(etcdCli, metaRoot, configRoot)
 }
@@ -76,7 +76,7 @@ func TestConfirmator_RegisterGate(t *testing.T) {
 
 	require.NoError(t, c.registerGate(testConfigKey, gateSwitcher("2.6.23", 10*time.Millisecond)))
 	require.NoError(t, c.start(context.Background()))
-	defer c.Close()
+	defer c.close()
 
 	// one-shot: no gate can be registered after Start.
 	assert.Error(t, c.registerGate(testConfigKey, gateSwitcher("2.6.23", 10*time.Millisecond)))
@@ -90,7 +90,7 @@ func TestConfirmator_FlipsAfterAllUpAndDelay(t *testing.T) {
 	c := newTestConfirmator(t, cli, metaRoot, configRoot)
 	require.NoError(t, c.registerGate(testConfigKey, gateSwitcher("2.6.23", 50*time.Millisecond)))
 	require.NoError(t, c.start(context.Background()))
-	defer c.Close()
+	defer c.close()
 
 	waitConfigValue(t, cli, configRoot, testConfigKey, testConfigValue)
 }
@@ -104,7 +104,7 @@ func TestConfirmator_NoSessionsNoFlip(t *testing.T) {
 	c := newTestConfirmator(t, cli, metaRoot, configRoot)
 	require.NoError(t, c.registerGate(testConfigKey, gateSwitcher("2.6.23", 50*time.Millisecond)))
 	require.NoError(t, c.start(context.Background()))
-	defer c.Close()
+	defer c.close()
 
 	assertNoFlip(t, cli, configRoot, testConfigKey)
 }
@@ -118,7 +118,7 @@ func TestConfirmator_MixedVersionsNoFlip(t *testing.T) {
 	c := newTestConfirmator(t, cli, metaRoot, configRoot)
 	require.NoError(t, c.registerGate(testConfigKey, gateSwitcher("2.6.23", 30*time.Millisecond)))
 	require.NoError(t, c.start(context.Background()))
-	defer c.Close()
+	defer c.close()
 
 	assertNoFlip(t, cli, configRoot, testConfigKey)
 }
@@ -132,7 +132,7 @@ func TestConfirmator_SessionDipResetsStabilityWindow(t *testing.T) {
 	c := newTestConfirmator(t, cli, metaRoot, configRoot)
 	require.NoError(t, c.registerGate(testConfigKey, gateSwitcher("2.6.23", 200*time.Millisecond)))
 	require.NoError(t, c.start(context.Background()))
-	defer c.Close()
+	defer c.close()
 
 	// A session dips below the gate version during the stability window:
 	// the window must reset and the flip must not happen.
@@ -155,10 +155,40 @@ func TestConfirmator_ExplicitEtcdValueWins(t *testing.T) {
 	c := newTestConfirmator(t, cli, metaRoot, configRoot)
 	require.NoError(t, c.registerGate(testConfigKey, gateSwitcher("2.6.23", 30*time.Millisecond)))
 	require.NoError(t, c.start(context.Background()))
-	defer c.Close()
+	defer c.close()
 
 	// The explicit value must not be overwritten by the flip.
 	waitConfigValue(t, cli, configRoot, testConfigKey, "false")
+}
+
+func TestConfirmator_LocalValueChangeBeforeFlipWins(t *testing.T) {
+	// An explicit value set from a non-etcd source (file/env) while the
+	// confirmator is running — after start but before the stability window
+	// expires — must win over the flip: no etcd write occurs and the gate
+	// resolves as-is (adversarial review finding on flip).
+	cli, _ := setupEmbedEtcd(t)
+	metaRoot, configRoot := testRoots(t)
+	putAllUpSessions(t, cli, metaRoot)
+
+	// Point the process-local config at a test base table so flip's
+	// currentConfigValue re-read can observe the runtime value change.
+	oldBaseTable := params.baseTable
+	bt := NewBaseTable(SkipRemote(true))
+	params.baseTable = bt
+	defer func() { params.baseTable = oldBaseTable }()
+
+	c := newTestConfirmator(t, cli, metaRoot, configRoot)
+	require.NoError(t, c.registerGate(testConfigKey, gateSwitcher("2.6.23", 300*time.Millisecond)))
+	require.NoError(t, c.start(context.Background()))
+	defer c.close()
+
+	// Operator sets the "false" escape hatch in a non-etcd source while the
+	// confirmator is running, before the stability window elapses.
+	bt.Manager().SetConfig(testConfigKey, "false")
+
+	// The gate resolves without writing the config-center key.
+	waitGateResolved(t, c)
+	assertConfigAbsent(t, cli, configRoot, testConfigKey)
 }
 
 func TestConfirmator_AlreadyFlippedAtStart(t *testing.T) {
@@ -169,7 +199,7 @@ func TestConfirmator_AlreadyFlippedAtStart(t *testing.T) {
 	c := newTestConfirmator(t, cli, metaRoot, configRoot)
 	require.NoError(t, c.registerGate(testConfigKey, gateSwitcher("2.6.23", 10*time.Millisecond)))
 	require.NoError(t, c.start(context.Background()))
-	defer c.Close()
+	defer c.close()
 
 	// The gate is resolved immediately: no session watch is running.
 	c.mu.Lock()
@@ -187,7 +217,7 @@ func TestConfirmator_MultipleGatesIndependent(t *testing.T) {
 	require.NoError(t, c.registerGate(testConfigKey, gateSwitcher("2.6.23", 50*time.Millisecond)))
 	require.NoError(t, c.registerGate("function.testGate2", gateSwitcher("3.0.0", 50*time.Millisecond)))
 	require.NoError(t, c.start(context.Background()))
-	defer c.Close()
+	defer c.close()
 
 	// The 2.6.23 gate flips; the 3.0.0 gate stays pending.
 	waitConfigValue(t, cli, configRoot, testConfigKey, testConfigValue)
@@ -195,17 +225,18 @@ func TestConfirmator_MultipleGatesIndependent(t *testing.T) {
 	assertConfigAbsent(t, cli, configRoot, "function.testGate2")
 }
 
-func TestInitVersionGatesSkipRemote(t *testing.T) {
-	// initVersionGates is a no-op for a skip-remote param table (the common
+func TestStartVersionGatesSkipRemote(t *testing.T) {
+	// startVersionGates is a no-op for a skip-remote param table (the common
 	// test setup): no confirmator is created and no goroutine leaks.
 	p := &ComponentParam{}
 	p.Init(NewBaseTable(SkipRemote(true)))
+	p.startVersionGates()
 	assert.Nil(t, p.versionGates)
 }
 
-func TestInitVersionGatesEmbeddedEtcd(t *testing.T) {
+func TestStartVersionGatesEmbeddedEtcd(t *testing.T) {
 	// Embedded-etcd deployments are single-process: when the local version
-	// already satisfies the gate, initVersionGates resolves the item directly
+	// already satisfies the gate, startVersionGates resolves the item directly
 	// (localSatisfied -> TargetValue) instead of creating a confirmator.
 	t.Setenv(metricsinfo.DeployModeEnvKey, metricsinfo.StandaloneDeployMode)
 	p := &ComponentParam{}
@@ -215,7 +246,7 @@ func TestInitVersionGatesEmbeddedEtcd(t *testing.T) {
 	require.NotNil(t, item.VersionGateSwitcher)
 	assert.False(t, item.VersionGateSwitcher.localSatisfied)
 
-	// Same package: flip skipRemote off so initVersionGates actually runs, and
+	// Same package: flip skipRemote off so startVersionGates actually runs, and
 	// enable embedded etcd. FunctionCfg is already initialized by Init.
 	bt.config.skipRemote = false
 	p.EtcdCfg.UseEmbedEtcd.SwapTempValue("true")
@@ -224,9 +255,9 @@ func TestInitVersionGatesEmbeddedEtcd(t *testing.T) {
 		bt.config.skipRemote = true
 	}()
 
-	p.initVersionGates()
+	p.startVersionGates()
 	// Local version (common.Version, 3.0.0-beta on master) >= 2.6.23: the gate
-	// is locally satisfied and no confirmator is created. initVersionGates
+	// is locally satisfied and no confirmator is created. startVersionGates
 	// itself evicts the value cache, so the resolution is observable directly.
 	assert.True(t, item.VersionGateSwitcher.localSatisfied)
 	assert.Nil(t, p.versionGates)
@@ -241,7 +272,7 @@ func TestInitVersionGatesEmbeddedEtcd(t *testing.T) {
 	item.VersionGateSwitcher.GateVersion = "99.0.0"
 	defer func() { item.VersionGateSwitcher.GateVersion = oldGateVersion }()
 
-	p.initVersionGates()
+	p.startVersionGates()
 	assert.False(t, item.VersionGateSwitcher.localSatisfied)
 	item.manager.EvictCachedValue(item.Key)
 	assert.Equal(t, "false", item.GetValue())
@@ -313,6 +344,23 @@ func assertConfigAbsent(t *testing.T, cli *clientv3.Client, configRoot, key stri
 	t.Helper()
 	_, ok := getConfigValue(t, cli, configRoot, key)
 	assert.False(t, ok, "config %s should not be flipped", key)
+}
+
+// waitGateResolved polls until the confirmator has marked the (single) gate as
+// resolved, e.g. superseded by an explicit value without an etcd write.
+func waitGateResolved(t *testing.T, c *confirmator) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		c.mu.Lock()
+		resolved := len(c.gates) == 1 && c.gates[0].resolved
+		c.mu.Unlock()
+		if resolved {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("gate did not resolve within timeout")
 }
 
 // embedEtcdClientPort remembers the client port of the singleton embedded etcd


### PR DESCRIPTION
issue: #52988

- paramtable version gate: add VersionGateSwitcher (EnableAutoSwitchValue/PreSwitchValue/GateVersion/TargetValue/SwitchDelay) with EffectiveValue()/GetAsBoolEffective() and a one-shot Confirmator that watches cluster sessions, maintains the minimum online version and flips gated config items into the etcd config center once the whole cluster stays above the gate version for the SwitchDelay stability window
- version gate startup: the global once `StartVersionGateSwitcher()` is called by the MixCoord role only (after the role has been set); other roles observe the flipped value through the regular config refresh. Embedded-etcd (single-process) deployments resolve gates locally and skip the confirmator; cluster deployments start it in the background. The flip re-reads the process-local config value (file/env sources) right before the write, so an explicit operator value set while the confirmator is running wins and no etcd write happens
- function config: gate function.enableWriteBeforeMaterialization (auto -> flip to true, false escape hatch, true force) behind cluster version 2.6.23; non-exported
- streamingnode shard interceptor: materialize function output fields (e.g. BM25 sparse vectors) before WAL append only when the gated config is effective