### PR TITLE
doc: fix typo implmentation -> implementation in the streamingnode WAL README

### DIFF
--- a/internal/streamingnode/server/wal/README.md
+++ b/internal/streamingnode/server/wal/README.md
@@ -32,7 +32,7 @@ developper who want to add a new implementation of `wal` should implements the `
 - `walimpls.WALImpls`
 
 `OpenerBuilderImpls` create `OpenerImpls`; `OpenerImpls` creates `WALImpls`; `WALImpls` create `ScannerImpls`. 
-Then register the implmentation of `walimpls.OpenerBuilderImpls` into `github.com/milvus-io/milvus/pkg/streaming/walimpls/registry` package.
+Then register the implementation of `walimpls.OpenerBuilderImpls` into `github.com/milvus-io/milvus/pkg/streaming/walimpls/registry` package.
 
 ```
 import "github.com/milvus-io/milvus/pkg/streaming/walimpls/registry"


### PR DESCRIPTION
Corrects a single misspelling of `implmentation` in `internal/streamingnode/server/wal/README.md`.

Documentation only, no behaviour change.