### PR TITLE
Skip unstable source segments during snapshot restore

### DIFF
--- a/internal/datacoord/snapshot_manager.go
+++ b/internal/datacoord/snapshot_manager.go
@@ -1604,6 +1604,12 @@ func (sm *snapshotManager) createRestoreJob(
 					mlog.Int64("sourceSegmentID", sourceSegmentID))
 				continue
 			}
+			if segInfo.GetState() != commonpb.SegmentState_Sealed && segInfo.GetState() != commonpb.SegmentState_Flushed {
+				mlog.Warn(ctx, "source segment is not stable, skipping",
+					mlog.Int64("sourceSegmentID", sourceSegmentID),
+					mlog.String("state", segInfo.GetState().String()))
+				continue
+			}
 		}
 		validSegments = append(validSegments, segDesc)
 	}

--- a/internal/datacoord/snapshot_manager_test.go
+++ b/internal/datacoord/snapshot_manager_test.go
@@ -1881,7 +1881,7 @@ func TestCreateRestoreJob_PreRegistersTargetSegmentsAsImporting(t *testing.T) {
 	catalog.EXPECT().SaveChannelCheckpoint(mock.Anything, "dst-ch", mock.Anything).Return(nil).Once()
 
 	mt := &meta{ctx: ctx, catalog: catalog, segments: NewSegmentsInfo(), channelCPs: newChannelCps()}
-	mt.segments.SetSegment(11, NewSegmentInfo(&datapb.SegmentInfo{ID: 11}))
+	mt.segments.SetSegment(11, NewSegmentInfo(&datapb.SegmentInfo{ID: 11, State: commonpb.SegmentState_Flushed}))
 
 	var err error
 
@@ -1909,6 +1909,30 @@ func TestCreateRestoreJob_PreRegistersTargetSegmentsAsImporting(t *testing.T) {
 	err = sm.createRestoreJob(ctx, int64(200), map[string]string{"src-ch": "dst-ch"}, map[int64]int64{10: 20}, snapshotData, int64(42), int64(7), false, "", "", "")
 	require.NoError(t, err)
 	assert.True(t, addJobCalled)
+}
+
+func TestCreateRestoreJob_SkipsUnstableSourceSegments(t *testing.T) {
+	ctx := context.Background()
+	snapshotData := &snapshotstorage.SnapshotData{
+		SnapshotInfo: &datapb.SnapshotInfo{Name: "snap1", CollectionId: 100},
+		Collection:   &datapb.CollectionDescription{},
+		Segments: []*datapb.SegmentDescription{{
+			SegmentId: 11, PartitionId: 10, SegmentLevel: datapb.SegmentLevel_L1,
+			ChannelName: "src-ch", NumOfRows: 123,
+		}},
+	}
+	mt := &meta{ctx: ctx, segments: NewSegmentsInfo()}
+	mt.segments.SetSegment(11, NewSegmentInfo(&datapb.SegmentInfo{ID: 11, State: commonpb.SegmentState_Growing}))
+	mockAlloc := allocator.NewMockAllocator(t)
+	mockAlloc.EXPECT().AllocN(int64(0)).Return(int64(0), int64(0), nil)
+	mockHandler := NewNMockHandler(t)
+	mockHandler.EXPECT().GetCollection(mock.Anything, int64(200)).Return(&collectionInfo{}, nil)
+	mAddJob := mockey.Mock((*copySegmentMeta).AddJob).Return(nil).Build()
+	defer mAddJob.UnPatch()
+	sm := &snapshotManager{meta: mt, allocator: mockAlloc, handler: mockHandler, copySegmentMeta: &copySegmentMeta{}}
+
+	err := sm.createRestoreJob(ctx, 200, map[string]string{"src-ch": "dst-ch"}, map[int64]int64{10: 20}, snapshotData, 42, 7, false, "", "", "")
+	assert.NoError(t, err)
 }
 
 func TestCreateRestoreJob_ExternalPersistsSourceLocationAndSkipsLocalSegmentLookup(t *testing.T) {


### PR DESCRIPTION
## Issue

Closes #52989

## Background

Snapshot restore can include a source segment that is still Growing or otherwise unstable. The restore path then allocates and publishes a target segment for data that is not a stable snapshot, which can leave an unloadable zero-row sealed segment.

## Changes

- Skip non-existed, Growing, and other non-stable local source segments when creating a same-cluster restore job.
- Add a regression test proving unstable source segments do not produce restore mappings.

## Compatibility

Stable Sealed and Flushed segments continue to restore as before. External restores retain their existing behavior because source segments are not available in local metadata.

## Validation

- `gofmt -w internal/datacoord/snapshot_manager.go internal/datacoord/snapshot_manager_test.go`
- `git diff --check` passed.
- `go test ./internal/datacoord -run 'TestCreateRestoreJob_(PreRegistersTargetSegmentsAsImporting|SkipsUnstableSourceSegments)' -count=1` was attempted.

## Limitations

The focused Go test could not complete because the sparse checkout omitted the local `client` replacement module and several Go module downloads terminated with unexpected EOF/TLS timeouts from `proxy.golang.org`. No Docker test environment was available in the checkout.
