### PR TITLE
fix: exclude growing segments from snapshots

### DIFF
--- a/internal/datacoord/handler.go
+++ b/internal/datacoord/handler.go
@@ -769,7 +769,8 @@ func (h *ServerHandler) GenSnapshot(ctx context.Context, collectionID UniqueID) 
 
 	// get segment info
 	candidateSegments := h.s.meta.SelectSegments(ctx, WithCollection(collectionID), SegmentFilterFunc(func(info *SegmentInfo) bool {
-		return info.GetState() != commonpb.SegmentState_Dropped && !info.GetIsImporting()
+		return info.GetState() != commonpb.SegmentState_Dropped &&
+			info.GetState() != commonpb.SegmentState_Growing && !info.GetIsImporting()
 	}))
 	segments := make([]*SegmentInfo, 0, len(candidateSegments))
 	for _, info := range candidateSegments {

--- a/internal/datacoord/handler_test.go
+++ b/internal/datacoord/handler_test.go
@@ -1859,7 +1859,27 @@ func TestGenSnapshot(t *testing.T) {
 				},
 			},
 		})
-		return []*SegmentInfo{seg}
+		growing := NewSegmentInfo(&datapb.SegmentInfo{
+			ID:            1002,
+			CollectionID:  200,
+			PartitionID:   0,
+			InsertChannel: "dml_0_200v0",
+			State:         commonpb.SegmentState_Growing,
+			StartPosition: &msgpb.MsgPosition{Timestamp: 10000},
+			Binlogs: []*datapb.FieldBinlog{{
+				FieldID: 1,
+				Binlogs: []*datapb.Binlog{{LogID: 2, LogSize: 100}},
+			}},
+		})
+		segments := []*SegmentInfo{seg, growing}
+		for _, filter := range filters {
+			if filterFunc, ok := filter.(SegmentFilterFunc); ok {
+				segments = lo.Filter(segments, func(segment *SegmentInfo, _ int) bool {
+					return filterFunc.Match(segment)
+				})
+			}
+		}
+		return segments
 	}).Build()
 	defer mock5.UnPatch()
 


### PR DESCRIPTION
## Issue

Fixes #52989

## Background

`GenSnapshot` documented that snapshots contain stable segments, but its candidate filter excluded only dropped and importing segments. A Growing segment with persisted binlogs could therefore be serialized into a snapshot and later restored as an invalid zero-row sealed segment.

## Changes

- Exclude Growing segments when selecting segments for snapshot generation.
- Extend the existing `GenSnapshot` unit test with a Growing segment that has binlogs and meets the snapshot timestamp condition.

## Compatibility

Flushing and Flushed segments retain the existing behavior. Importing and Dropped segments remain excluded. External restore behavior is unchanged.

## Validation

Passed locally:

- `gofmt -w internal/datacoord/handler.go internal/datacoord/handler_test.go`
- `git diff --check`
- PR body validation and DCO sign-off check

Attempted locally:

- `go test ./internal/datacoord -tags dynamic,test -run '^TestGenSnapshot$' -count=1`

The focused test reached package compilation but could not complete on the local Windows host. Compilation is blocked by unavailable CGO-dependent optional components, including RocksDB, Kafka, and storagev2 FFI (`build constraints exclude all Go files` / missing CGO-backed symbols). No test assertion failure was observed.

GitHub CI status at submission: DCO and Mergify Summary passed; the build/UT, E2E, Go SDK, Jenkins merge, label-manager, and Tide checks were pending. These remote checks are expected to provide the Linux/CI validation unavailable on this host.

## Limitations

The local focused Go test could not complete because this Windows environment does not provide the repository's CGO-dependent optional components. Full CI validation remains pending.
