### PR TITLE
fix: [3.0] exclude uncommitted V3 manifests from snapshots

### DIFF
--- a/internal/datacoord/handler.go
+++ b/internal/datacoord/handler.go
@@ -34,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	snapshotstorage "github.com/milvus-io/milvus/internal/snapshotio/storage"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
@@ -651,6 +652,22 @@ func (h *ServerHandler) GetSnapshotSeekPositions(ctx context.Context, collection
 	return positions, minTs, nil
 }
 
+// hasCommittedManifest reports whether a Storage V3 manifest references
+// committed files. ManifestEarliest is only the placeholder assigned to a new
+// Growing segment before its first manifest commit.
+func hasCommittedManifest(info *SegmentInfo) (bool, error) {
+	if info.GetStorageVersion() != storage.StorageV3 || info.GetManifestPath() == "" {
+		return false, nil
+	}
+
+	_, version, err := packed.UnmarshalManifestPath(info.GetManifestPath())
+	if err != nil {
+		return false, merr.WrapErrDataIntegrity(err,
+			"invalid manifest path for segment %d", info.GetID())
+	}
+	return version > packed.ManifestEarliest, nil
+}
+
 // GenSnapshot generates a point-in-time snapshot of a collection's data and metadata.
 //
 // This function captures a consistent view of a collection at a specific timestamp, including:
@@ -685,7 +702,7 @@ func (h *ServerHandler) GetSnapshotSeekPositions(ctx context.Context, collection
 //   - Collections with partition key: Include all partitions (filtering handled elsewhere)
 //
 // Segment selection criteria:
-// - Must have data (binlogs or deltalogs present)
+// - Must have data (binlogs, deltalogs, or a committed V3 manifest present)
 // - StartPosition timestamp < channel seek timestamp (data started before snapshot)
 // - State != Dropped (still valid)
 // - Not importing (stable segments only)
@@ -752,16 +769,21 @@ func (h *ServerHandler) GenSnapshot(ctx context.Context, collectionID UniqueID) 
 
 	// get segment info
 	candidateSegments := h.s.meta.SelectSegments(ctx, WithCollection(collectionID), SegmentFilterFunc(func(info *SegmentInfo) bool {
-		// A V3 segment persists its file paths in the LOON manifest, and after a
-		// DataCoord restart it reloads from etcd with empty Binlogs/Deltalogs
-		// arrays (AlterSegments skips the per-FieldBinlog KVs for V3). A non-empty
-		// ManifestPath therefore also means the segment has data; without this the
-		// snapshot silently drops restarted V3 segments and loses them on restore.
-		segmentHasData := len(info.GetBinlogs()) > 0 || len(info.GetDeltalogs()) > 0 || info.GetManifestPath() != ""
-		return segmentHasData && info.GetState() != commonpb.SegmentState_Dropped && !info.GetIsImporting()
+		return info.GetState() != commonpb.SegmentState_Dropped && !info.GetIsImporting()
 	}))
 	segments := make([]*SegmentInfo, 0, len(candidateSegments))
 	for _, info := range candidateSegments {
+		segmentHasData := len(info.GetBinlogs()) > 0 || len(info.GetDeltalogs()) > 0
+		if !segmentHasData {
+			segmentHasData, err = hasCommittedManifest(info)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if !segmentHasData {
+			continue
+		}
+
 		seekTs, ok := channelSeekTs[info.GetInsertChannel()]
 		if !ok {
 			return nil, merr.WrapErrServiceInternalMsg(

--- a/internal/datacoord/handler_test.go
+++ b/internal/datacoord/handler_test.go
@@ -2100,14 +2100,80 @@ func TestGenSnapshot_UsesPerChannelSeekPositions(t *testing.T) {
 	assert.Equal(t, "ch-2", snapshotData.Segments[0].GetChannelName())
 }
 
+func TestHasCommittedManifest(t *testing.T) {
+	tests := []struct {
+		name        string
+		segment     *SegmentInfo
+		expected    bool
+		expectedErr error
+	}{
+		{
+			name: "empty manifest path",
+			segment: NewSegmentInfo(&datapb.SegmentInfo{
+				StorageVersion: storage.StorageV3,
+			}),
+		},
+		{
+			name: "non-v3 manifest path",
+			segment: NewSegmentInfo(&datapb.SegmentInfo{
+				ManifestPath: packed.MarshalManifestPath("/data/segments/2000", 1),
+			}),
+		},
+		{
+			name: "earliest manifest",
+			segment: NewSegmentInfo(&datapb.SegmentInfo{
+				StorageVersion: storage.StorageV3,
+				ManifestPath:   packed.MarshalManifestPath("/data/segments/2001", packed.ManifestEarliest),
+			}),
+		},
+		{
+			name: "committed manifest version one",
+			segment: NewSegmentInfo(&datapb.SegmentInfo{
+				StorageVersion: storage.StorageV3,
+				ManifestPath:   packed.MarshalManifestPath("/data/segments/2002", 1),
+			}),
+			expected: true,
+		},
+		{
+			name: "committed manifest version three",
+			segment: NewSegmentInfo(&datapb.SegmentInfo{
+				StorageVersion: storage.StorageV3,
+				ManifestPath:   packed.MarshalManifestPath("/data/segments/2003", 3),
+			}),
+			expected: true,
+		},
+		{
+			name: "invalid manifest path",
+			segment: NewSegmentInfo(&datapb.SegmentInfo{
+				ID:             2004,
+				StorageVersion: storage.StorageV3,
+				ManifestPath:   "invalid",
+			}),
+			expectedErr: merr.ErrDataIntegrity,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := hasCommittedManifest(test.segment)
+			if test.expectedErr != nil {
+				require.ErrorIs(t, err, test.expectedErr)
+				assert.Contains(t, err.Error(), "invalid manifest path for segment 2004")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
 // TestGenSnapshot_IncludesV3ManifestOnlySegment guards the snapshot filter: a
 // V3 segment that reloaded from etcd with empty Binlogs/Deltalogs (per-field
-// KVs are not persisted for V3) but a non-empty ManifestPath still carries
-// data and must not be dropped from the snapshot. An empty segment with no
-// manifest is the negative control.
+// KVs are not persisted for V3) must be retained only after its manifest is
+// committed. A growing segment's earliest manifest is only a placeholder.
 func TestGenSnapshot_IncludesV3ManifestOnlySegment(t *testing.T) {
 	schema := newTestSchema()
-	// V3 segment: empty binlog arrays but a live manifest path — must be kept.
+	// Committed V3 manifest with empty legacy arrays must be kept.
 	manifestSeg := NewSegmentInfo(&datapb.SegmentInfo{
 		ID:             2001,
 		CollectionID:   200,
@@ -2119,9 +2185,21 @@ func TestGenSnapshot_IncludesV3ManifestOnlySegment(t *testing.T) {
 		StorageVersion: storage.StorageV3,
 		ManifestPath:   packed.MarshalManifestPath("/data/segments/2001", 3),
 	})
+	// A growing V3 segment only has an allocation placeholder and must be dropped.
+	growingSeg := NewSegmentInfo(&datapb.SegmentInfo{
+		ID:             2002,
+		CollectionID:   200,
+		PartitionID:    0,
+		InsertChannel:  "ch-1",
+		State:          commonpb.SegmentState_Growing,
+		StartPosition:  &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 500},
+		DmlPosition:    &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 600},
+		StorageVersion: storage.StorageV3,
+		ManifestPath:   packed.MarshalManifestPath("/data/segments/2002", packed.ManifestEarliest),
+	})
 	// Empty segment with no manifest — must be dropped.
 	emptySeg := NewSegmentInfo(&datapb.SegmentInfo{
-		ID:            2002,
+		ID:            2003,
 		CollectionID:  200,
 		PartitionID:   0,
 		InsertChannel: "ch-1",
@@ -2129,6 +2207,7 @@ func TestGenSnapshot_IncludesV3ManifestOnlySegment(t *testing.T) {
 		StartPosition: &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 500},
 		DmlPosition:   &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 600},
 	})
+	candidates := []*SegmentInfo{manifestSeg, growingSeg, emptySeg}
 
 	mockMeta := &meta{indexMeta: &indexMeta{}}
 	handler := &ServerHandler{
@@ -2178,7 +2257,6 @@ func TestGenSnapshot_IncludesV3ManifestOnlySegment(t *testing.T) {
 
 	mockSelectSegments := mockey.Mock((*meta).SelectSegments).To(
 		func(m *meta, ctx context.Context, filters ...SegmentFilter) []*SegmentInfo {
-			candidates := []*SegmentInfo{manifestSeg, emptySeg}
 			var result []*SegmentInfo
 			for _, seg := range candidates {
 				pass := true
@@ -2213,6 +2291,22 @@ func TestGenSnapshot_IncludesV3ManifestOnlySegment(t *testing.T) {
 	require.Len(t, snapshotData.Segments, 1)
 	assert.Equal(t, int64(2001), snapshotData.Segments[0].GetSegmentId())
 	assert.NotEmpty(t, snapshotData.Segments[0].GetManifestPath())
+
+	candidates = []*SegmentInfo{NewSegmentInfo(&datapb.SegmentInfo{
+		ID:             2004,
+		CollectionID:   200,
+		PartitionID:    0,
+		InsertChannel:  "ch-1",
+		State:          commonpb.SegmentState_Flushed,
+		StartPosition:  &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 500},
+		DmlPosition:    &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 600},
+		StorageVersion: storage.StorageV3,
+		ManifestPath:   "invalid",
+	})}
+	snapshotData, err = handler.GenSnapshot(context.Background(), 200)
+	assert.Nil(t, snapshotData)
+	require.ErrorIs(t, err, merr.ErrDataIntegrity)
+	assert.Contains(t, err.Error(), "invalid manifest path for segment 2004")
 }
 
 func TestGenSnapshot_RejectsSegmentWithoutChannelSeekPosition(t *testing.T) {


### PR DESCRIPTION
issue: #52989
pr: #52044

## What changed

Backport the master fix that distinguishes committed Storage V3 manifests
from the version 0 placeholder assigned to new Growing segments.

- Exclude manifest-only segments whose manifest is still
  `ManifestEarliest`.
- Preserve committed manifest-only segments after DataCoord metadata
  reload.
- Return a data-integrity error for malformed manifest paths.

## Why

The `3.0` branch still considered any non-empty `ManifestPath` proof that
a segment owned durable data. That allowed an unflushed Growing segment
with zero rows and no files into a snapshot. Restore then published a
zero-row L1 segment and reported completion, while QueryNode could not
load it.

## Backport

This is a clean backport of the behavior from PR #52044 to `3.0`.
The original fix was tracked by issue #52043. No conflicts required
branch-specific resolution.

## Validation

- `git diff --check`
- Build and tests were not run at the user's request.
