### PR TITLE
feat: [3.0] support cross-account Azure snapshot copy via source SAS (#52770)

### DIFF
--- a/docs/design-docs/design_docs/20260609-external-snapshot-export-restore.md
+++ b/docs/design-docs/design_docs/20260609-external-snapshot-export-restore.md
@@ -36,7 +36,9 @@ The feature has explicit non-goals:
 - No streaming copy. Milvus must not download object bytes to a node and upload
   them again just to cross buckets.
 - No cross-provider copy, cross-endpoint copy, or provider-specific source-auth
-  extension.
+  extension — except the Azure source-read SAS added in
+  [§10](#10-azure-cross-account-copy-via-source-sas), which is a scoped
+  exception, not a general source-auth mechanism.
 - No external collection export. Its StorageV3 manifests may reference lake
   fragments outside the snapshot file set. Full support requires copying those
   fragments, rewriting the manifest references, and clearing
@@ -335,8 +337,10 @@ Layer 2: request `external_spec.extfs`.
 - An explicit request credential mode replaces inherited instance credentials.
   `use_iam=true`, raw AK/SK, and `credential_json` are mutually exclusive.
 - Snapshot validation is stricter than a generic external spec parser. It must
-  reject generic `role_arn`, `gcp_target_service_account`, SAS, anonymous auth,
-  source-auth URLs, and independent dual credentials.
+  reject generic `role_arn`, `gcp_target_service_account`, SAS as a credential
+  mode, anonymous auth, source-auth URLs, and independent dual credentials; the
+  only accepted SAS is the Azure source-read token of
+  [§10](#10-azure-cross-account-copy-via-source-sas).
 - Endpoint, provider, region, and TLS information encoded by the metadata URI
   is authoritative. Conflicting `external_spec` values are rejected. Standard
   AWS, Aliyun, Tencent, Huawei, GCP, and Azure endpoints are recognized;
@@ -353,7 +357,8 @@ Provider notes:
 - Azure storage supports account key mode and the existing workload/managed
   identity path. Request-level account key fields take precedence over the
   process-level `AZURE_STORAGE_CONNECTION_STRING`; a request SAS token is not
-  supported.
+  supported as a credential mode — the one SAS the API accepts is the
+  cross-account source-read grant of [§10](#10-azure-cross-account-copy-via-source-sas).
 
 Restore persistence red line:
 
@@ -445,7 +450,10 @@ Provider limitations fail closed:
 - Different providers cannot be copied by one server-side request.
 - Different endpoints or independent MinIO/S3-compatible services cannot be
   copied by one server-side request.
-- Request-only source-auth mechanisms such as SAS are outside the snapshot API.
+- Request-only source-auth mechanisms such as SAS are outside the snapshot API,
+  with the scoped Azure exception of
+  [§10](#10-azure-cross-account-copy-via-source-sas), where the SAS is the only
+  way one provider-side request can read a cross-account source.
 - If provider, endpoint, region, or credential probing shows that copy cannot be
   expressed as one provider-side request, Milvus rejects the request before
   scheduling work.
@@ -732,3 +740,99 @@ Standalone client build:
 
 - Root module and standalone `client/` module both build against the published
   milvus-proto version that contains the snapshot APIs.
+
+## 10. Azure Cross-Account Copy via Source SAS
+
+- **Added:** 2026-08-22
+- **Issue:** https://github.com/milvus-io/milvus/issues/52769
+- **Status:** Proposed
+
+This section is a scoped exception to the non-goal "no provider-specific
+source-auth extension": Azure is the one provider whose copy API cannot read a
+cross-account source under any single-principal credential, yet trivially can
+with a read-scoped SAS on the source URL.
+
+### Motivation
+
+On Azure the instance bucket and the backup bucket commonly live in different
+storage accounts. Azure's copy authorization table ([Copy Blob From URL]) says
+that for a source blob in another storage account, neither Shared Key
+authorization nor the request's own Microsoft Entra ID token may authorize the
+source read — only a SAS token with Read (`r`) permission on the source URL
+(or a public source). Since the snapshot copy is one `StartCopyFromURL` request
+authorized by the destination account's credential, a cross-account copy is
+impossible to express without source-URL auth, which is why
+`validateProviderEndpointPair` fails closed on `sameAzureAccountEndpoint`.
+
+### Contract
+
+`external_spec.extfs` gains one Azure-only key:
+
+```json
+{"extfs": {
+  "cloud_provider": "azure",
+  "access_key_id": "backup-account", "access_key_value": "...",
+  "source_sas_token": "sv=2024-08-04&sig=...&sp=r"
+}}
+```
+
+- `source_sas_token` is a read-scoped SAS (user delegation, service, or account
+  SAS) for the **copy source** container: the instance bucket for export, the
+  foreign bucket for restore. A leading `?` is tolerated and trimmed.
+- It is **not** a credential mode: the destination side still uses exactly one
+  of the existing modes (instance credential, `use_iam`, raw AK/SK), and the
+  mutual-exclusion rules of §4 are unchanged.
+- It is valid only when the copy actually crosses storage accounts, and only
+  within one sovereign cloud (public, China, US Gov, Germany). Same-account
+  requests carrying a SAS, and cross-cloud requests, are rejected as input
+  errors — an unused or meaningless SAS signals misconfiguration.
+- The value is redacted like `credential_json` on every log, error, and
+  user-visible surface, and follows the same `external_spec` persistence
+  lifecycle: retained only while an export job is non-terminal, cleared on the
+  first terminal update.
+
+### Authorization model
+
+The core invariant of §6 still holds — there must exist one provider-side copy
+request that can read the source and write the destination:
+
+- **Export** (source = instance account, destination = foreign account): the
+  copier client is the foreign-account client (Layer 2 raw credentials or IAM).
+  Its credential authorizes the destination write; source URLs are built
+  against the instance account's service endpoint with the SAS appended, which
+  authorizes the source read.
+- **Restore / copy-source** (source = foreign account, destination = instance
+  account): the copier client is the instance-credential client, whose
+  credential authorizes the destination write; source URLs are built against
+  the foreign account's service endpoint with the SAS appended.
+
+Metadata reads and writes keep using each side's own client, exactly as
+before; only the large-object copy request changes.
+
+### Implementation notes
+
+- `objectstorage.Config` carries `AzureSourceEndpoint` (source account service
+  host), `AzureSourceUseSSL` (source account transport), and `AzureSourceSAS`;
+  the Azure object-storage client builds copy source URLs from an
+  anonymous-credential service client at that host and appends the SAS per
+  URL. The source URL scheme must come from the source account's own config —
+  export and restore put opposite accounts on the source side, so reusing the
+  client config's `UseSSL` would give the source URL the destination's scheme
+  and break sources that require a specific transport (e.g. a SAS minted with
+  `spr=https`).
+- Copy-source verification during Azure copy polling compares URL identities
+  without the query string, because the service does not guarantee that
+  `x-ms-copy-source` echoes the SAS. The verification failure error reports
+  only these credential-free identities, so the SAS never reaches an error
+  string, a snapshot job failure reason, or a log line; the export-reason
+  scrubber also lists `source_sas_token` alongside `credential_json` in case a
+  provider SDK error echoes the SAS-bearing source URL.
+- `restoreProviderCopyConfig` is unchanged for same-account Layer 2 copies; a
+  SAS-bearing restore resolves to a different copier config
+  (instance credential + source endpoint/SAS) instead.
+- No proto or C++ changes: the SAS rides inside the opaque `external_spec`
+  JSON that already propagates from Proxy through DataCoord, WAL, job state,
+  and DataNode tasks, and the C++ LOB paths keep reading the foreign bucket
+  with its own credential as before.
+
+[Copy Blob From URL]: https://learn.microsoft.com/en-us/rest/api/storageservices/copy-blob-from-url

--- a/internal/datacoord/snapshot_export_manager.go
+++ b/internal/datacoord/snapshot_export_manager.go
@@ -964,6 +964,9 @@ func snapshotExportSecretValues(externalSpec string) []string {
 		externalspec.ExtfsKeySSLCACert,
 		externalspec.ExtfsKeyExternalID,
 		"credential_json",
+		// Azure source-read SAS: SDK copy errors can echo the SAS-bearing
+		// source URL, so scrub the token from failure reasons too.
+		"source_sas_token",
 	} {
 		var value string
 		if err := json.Unmarshal(spec.Extfs[key], &value); err == nil && value != "" {

--- a/internal/datacoord/snapshot_manager_test.go
+++ b/internal/datacoord/snapshot_manager_test.go
@@ -4386,13 +4386,16 @@ func TestSnapshotExportManager_Observability(t *testing.T) {
 
 func TestSanitizeSnapshotExportReason(t *testing.T) {
 	secret := "SUPERSECRET"
-	externalSpec := `{"extfs":{"access_key_id":"AKIAEXAMPLE","access_key_value":"` + secret + `"}}`
-	err := errors.New("copy failed for AKIAEXAMPLE using " + secret + strings.Repeat("x", snapshotExportFailureReasonLimit))
+	sas := "sv=2024-08-04&sig=SECRETSAS&sp=r"
+	externalSpec := `{"extfs":{"access_key_id":"AKIAEXAMPLE","access_key_value":"` + secret + `","source_sas_token":"` + sas + `"}}`
+	err := errors.New("copy failed for AKIAEXAMPLE using " + secret +
+		" from https://src.blob.core.windows.net/c/o?" + sas + strings.Repeat("x", snapshotExportFailureReasonLimit))
 
 	reason := sanitizeSnapshotExportReason(err, externalSpec)
 
 	assert.NotContains(t, reason, "AKIAEXAMPLE")
 	assert.NotContains(t, reason, secret)
+	assert.NotContains(t, reason, "SECRETSAS")
 	assert.LessOrEqual(t, len(reason), snapshotExportFailureReasonLimit)
 
 	truncated := sanitizeSnapshotExportReason(

--- a/internal/snapshotio/storage/resolver.go
+++ b/internal/snapshotio/storage/resolver.go
@@ -65,15 +65,42 @@ func ResolveForeignStorage(
 	if err != nil {
 		return nil, err
 	}
-	foreignCM, err := milvusstorage.NewRemoteChunkManager(ctx, resolvedCfg.foreignCfg)
+	// The metadata client only reads and writes the foreign bucket with the
+	// foreign credential, so it must not carry the Azure source-copy fields.
+	// Besides being wrong in principle, they break construction for
+	// Restore/CopySource: AzureSourceEndpoint is populated only on the copier
+	// config below, and a source SAS without an endpoint fails client
+	// construction. Export keeps the fields because there foreignCM is the
+	// copier.
+	metadataCfg := resolvedCfg.foreignCfg
+	if direction == DirectionRestore || direction == DirectionCopySource {
+		metadataCfg = cloneObjectStorageConfig(resolvedCfg.foreignCfg)
+		metadataCfg.AzureSourceEndpoint = ""
+		metadataCfg.AzureSourceUseSSL = false
+		metadataCfg.AzureSourceSAS = ""
+	}
+	foreignCM, err := milvusstorage.NewRemoteChunkManager(ctx, metadataCfg)
 	if err != nil {
 		return nil, err
 	}
 	var copier milvusstorage.CrossBucketCopier = foreignCM
 	if resolvedCfg.hasSpec && (direction == DirectionRestore || direction == DirectionCopySource) {
-		// Layer 2 restore uses foreign credentials against the target endpoint so
-		// the provider can authorize both sides of the server-side copy request.
-		copier, err = milvusstorage.NewRemoteChunkManager(ctx, restoreProviderCopyConfig(instanceCfg, resolvedCfg.foreignCfg))
+		var copyCfg *objectstorage.Config
+		if strings.TrimSpace(resolvedCfg.foreignCfg.AzureSourceSAS) != "" {
+			// Cross-account Azure copies issue the copy request from the
+			// instance side: the destination write needs the instance account's
+			// credential, and the foreign source read is authorized by the SAS
+			// carried on the source URL.
+			copyCfg, err = restoreSASCopyConfig(instanceCfg, resolvedCfg.foreignCfg)
+		} else {
+			// Layer 2 restore uses foreign credentials against the target endpoint so
+			// the provider can authorize both sides of the server-side copy request.
+			copyCfg = restoreProviderCopyConfig(instanceCfg, resolvedCfg.foreignCfg)
+		}
+		if err != nil {
+			return nil, err
+		}
+		copier, err = milvusstorage.NewRemoteChunkManager(ctx, copyCfg)
 		if err != nil {
 			return nil, err
 		}
@@ -151,6 +178,19 @@ func resolveForeignStorageConfig(
 	if err := validateProviderEndpointPair(instanceCfg, foreignCfg, uriScheme); err != nil {
 		return nil, err
 	}
+	if direction == DirectionExport && strings.TrimSpace(foreignCfg.AzureSourceSAS) != "" {
+		// The export copier works from the foreign account, so the cross-account
+		// source URLs must address the instance account directly, authorized by
+		// the SAS minted for it.
+		instanceEndpoint, err := effectiveAzureSnapshotEndpoint(instanceCfg)
+		if err != nil {
+			return nil, err
+		}
+		foreignCfg.AzureSourceEndpoint = instanceEndpoint
+		// The source here is the instance account, so the source URL scheme
+		// comes from the instance config, not from foreignCfg.
+		foreignCfg.AzureSourceUseSSL = instanceCfg.UseSSL
+	}
 	return &resolvedForeignStorageConfig{
 		foreignBucket: foreignBucket,
 		foreignCfg:    foreignCfg,
@@ -206,6 +246,25 @@ func validateProviderEndpointPair(
 			return nil
 		}
 	case providerFamilyAzure:
+		if sourceSAS := strings.TrimSpace(foreignCfg.AzureSourceSAS); sourceSAS != "" {
+			// A read-scoped SAS on the source URL is the only way Azure lets one
+			// request read a blob in another storage account: neither account's
+			// shared key nor the request's own OAuth token covers it. With that
+			// grant the copy is still one provider-side request, so allow the
+			// account crossing within one sovereign cloud, but never without the
+			// SAS — that would only move the rejection to a runtime 403.
+			if sameAzureAccountEndpoint(instanceCfg, foreignCfg) {
+				return merr.WrapErrParameterInvalidMsg(
+					"extfs.source_sas_token applies only when the copy crosses Azure storage accounts",
+				)
+			}
+			if sameAzureCloudSuffix(instanceCfg, foreignCfg) {
+				return nil
+			}
+			return merr.WrapErrParameterInvalidMsg(
+				"cross-account Azure snapshot copy with a source SAS must stay within one Azure cloud",
+			)
+		}
 		if !sameAzureAccountEndpoint(instanceCfg, foreignCfg) {
 			break
 		}
@@ -281,6 +340,26 @@ func restoreProviderCopyConfig(instanceCfg, foreignCfg *objectstorage.Config) *o
 	return copyCfg
 }
 
+// restoreSASCopyConfig builds the copier for an Azure restore whose source lives
+// in another storage account. The copy request is authorized by the instance
+// account's credential — it writes the instance bucket — while the foreign
+// source read is authorized by the SAS appended to each source URL.
+func restoreSASCopyConfig(instanceCfg, foreignCfg *objectstorage.Config) (*objectstorage.Config, error) {
+	foreignEndpoint, err := effectiveAzureSnapshotEndpoint(foreignCfg)
+	if err != nil {
+		return nil, err
+	}
+	copyCfg := cloneObjectStorageConfig(instanceCfg)
+	copyCfg.CreateBucket = false
+	copyCfg.SkipBucketCheck = true
+	copyCfg.AzureSourceEndpoint = foreignEndpoint
+	// The copy destination is the instance account (copyCfg), but the source is
+	// the foreign account, so the source URL scheme comes from foreignCfg.
+	copyCfg.AzureSourceUseSSL = foreignCfg.UseSSL
+	copyCfg.AzureSourceSAS = foreignCfg.AzureSourceSAS
+	return copyCfg, nil
+}
+
 func storageConfigFromObjectConfig(cfg *objectstorage.Config, storageType string) *indexpb.StorageConfig {
 	if storageType == "" {
 		storageType = "remote"
@@ -354,4 +433,27 @@ func sameAzureAccountEndpoint(instanceCfg, foreignCfg *objectstorage.Config) boo
 		return false
 	}
 	return strings.EqualFold(instanceEndpoint, foreignEndpoint)
+}
+
+// sameAzureCloudSuffix reports whether both Azure configs resolve into the same
+// sovereign cloud (public, China, US Gov, Germany). A SAS minted in one cloud
+// is meaningless in another, so a cross-account copy with a source SAS is
+// rejected across clouds.
+func sameAzureCloudSuffix(instanceCfg, foreignCfg *objectstorage.Config) bool {
+	instanceSuffix := azureEndpointCloudSuffix(instanceCfg)
+	foreignSuffix := azureEndpointCloudSuffix(foreignCfg)
+	return instanceSuffix != "" && strings.EqualFold(instanceSuffix, foreignSuffix)
+}
+
+func azureEndpointCloudSuffix(cfg *objectstorage.Config) string {
+	endpoint, err := effectiveAzureSnapshotEndpoint(cfg)
+	if err != nil {
+		return ""
+	}
+	// effectiveAzureSnapshotEndpoint yields "<account>.blob.<suffix>"; both
+	// parts are single DNS labels by construction, so the first marker wins.
+	if i := strings.Index(strings.ToLower(endpoint), ".blob."); i >= 0 {
+		return endpoint[i+len(".blob."):]
+	}
+	return ""
 }

--- a/internal/snapshotio/storage/resolver_test.go
+++ b/internal/snapshotio/storage/resolver_test.go
@@ -549,3 +549,183 @@ func TestS3EndpointCompatibilityRejectsNonObjectStorageAWSHost(t *testing.T) {
 		"us-west-2",
 	))
 }
+
+func azureInstanceCfg() *objectstorage.Config {
+	return &objectstorage.Config{
+		Address:           "core.windows.net",
+		BucketName:        "instance-container",
+		RootPath:          "by-dev",
+		AccessKeyID:       "instance-account",
+		SecretAccessKeyID: "instance-key",
+		CloudProvider:     objectstorage.CloudProviderAzure,
+	}
+}
+
+func TestResolveForeignStorageAzureCrossAccountExportWithSourceSAS(t *testing.T) {
+	t.Setenv("AZURE_STORAGE_CONNECTION_STRING", "")
+
+	var captured []objectstorage.Config
+	patchRemoteChunkManager(t, &captured)
+
+	resolved, err := ResolveForeignStorage(
+		context.Background(),
+		azureInstanceCfg(),
+		DirectionExport,
+		"azure://backup-account.blob.core.windows.net/backup-container/export-root",
+		`{"extfs":{"cloud_provider":"azure","access_key_id":"backup-account","access_key_value":"backup-key","source_sas_token":"?sv=2024-08-04&sig=abc"}}`,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "backup-container", resolved.ForeignBucket)
+
+	// Export builds one client: the foreign-account copier, whose cross-account
+	// source URLs must address the instance account under the read SAS.
+	require.Len(t, captured, 1)
+	assert.Equal(t, "backup-account", captured[0].AccessKeyID)
+	assert.Equal(t, "instance-account.blob.core.windows.net", captured[0].AzureSourceEndpoint)
+	assert.Equal(t, "sv=2024-08-04&sig=abc", captured[0].AzureSourceSAS)
+	// The destination (foreign) transport is forced to TLS for canonical Azure
+	// endpoints, but the source URL scheme must follow the source — here the
+	// instance account, which has UseSSL=false.
+	assert.True(t, captured[0].UseSSL)
+	assert.False(t, captured[0].AzureSourceUseSSL)
+}
+
+func TestResolveForeignStorageAzureCrossAccountRestoreWithSourceSAS(t *testing.T) {
+	t.Setenv("AZURE_STORAGE_CONNECTION_STRING", "")
+
+	var captured []objectstorage.Config
+	patchRemoteChunkManager(t, &captured)
+
+	_, err := ResolveForeignStorage(
+		context.Background(),
+		azureInstanceCfg(),
+		DirectionRestore,
+		"azure://backup-account.blob.core.windows.net/backup-container/root/snapshots/1/metadata/1.json",
+		`{"extfs":{"cloud_provider":"azure","access_key_id":"backup-account","access_key_value":"backup-key","source_sas_token":"sv=2024-08-04&sig=abc"}}`,
+	)
+	require.NoError(t, err)
+
+	require.Len(t, captured, 2)
+	foreignCM, copier := captured[0], captured[1]
+	// Metadata still reads from the foreign account with its own credential,
+	// and the metadata client config must not carry the source-copy fields.
+	assert.Equal(t, "backup-account", foreignCM.AccessKeyID)
+	assert.Empty(t, foreignCM.AzureSourceEndpoint)
+	assert.Empty(t, foreignCM.AzureSourceSAS)
+	// The copy request writes the instance bucket, so the instance credential
+	// authorizes it and the source side is the foreign account under the SAS.
+	assert.Equal(t, "instance-account", copier.AccessKeyID)
+	assert.Equal(t, "instance-container", copier.BucketName)
+	assert.Equal(t, "backup-account.blob.core.windows.net", copier.AzureSourceEndpoint)
+	assert.Equal(t, "sv=2024-08-04&sig=abc", copier.AzureSourceSAS)
+	// The destination is the instance account (UseSSL=false), but the source
+	// URL scheme must follow the source — the foreign canonical Azure account,
+	// whose transport is TLS.
+	assert.False(t, copier.UseSSL)
+	assert.True(t, copier.AzureSourceUseSSL)
+}
+
+func TestResolveForeignStorageAzureCrossAccountRestoreConstructsRealClients(t *testing.T) {
+	t.Setenv("AZURE_STORAGE_CONNECTION_STRING", "")
+
+	// Regression test: a restore/copy-source request carrying a source SAS used
+	// to fail before doing any work, because the foreign metadata client was
+	// constructed from a config that had AzureSourceSAS but no
+	// AzureSourceEndpoint, a combination the Azure client constructor rejects.
+	// Exercise the real NewRemoteChunkManager constructor (client construction
+	// is offline) instead of mocking it. The fixture keys are base64
+	// ("instance-key"/"backup-key") because the Azure SDK decodes the account
+	// key eagerly at construction; nothing is ever signed here.
+	// #nosec G101 -- offline fixture credentials, see above.
+	instanceCfg := &objectstorage.Config{
+		Address:           "core.windows.net",
+		BucketName:        "instance-container",
+		RootPath:          "by-dev",
+		AccessKeyID:       "instance-account",
+		SecretAccessKeyID: "aW5zdGFuY2Uta2V5",
+		CloudProvider:     objectstorage.CloudProviderAzure,
+	}
+	externalSpec := `{"extfs":{"cloud_provider":"azure","access_key_id":"backup-account","access_key_value":"YmFja3VwLWtleQ==","source_sas_token":"sv=2024-08-04&sig=abc"}}`
+
+	t.Run("restore", func(t *testing.T) {
+		resolved, err := ResolveForeignStorage(
+			context.Background(),
+			instanceCfg,
+			DirectionRestore,
+			"azure://backup-account.blob.core.windows.net/backup-container/root/snapshots/1/metadata/1.json",
+			externalSpec,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "backup-container", resolved.ForeignBucket)
+		assert.NotNil(t, resolved.ForeignCM)
+		assert.NotNil(t, resolved.Copier)
+	})
+
+	t.Run("copy source", func(t *testing.T) {
+		resolved, err := ResolveForeignStorage(
+			context.Background(),
+			instanceCfg,
+			DirectionCopySource,
+			"azure://backup-account.blob.core.windows.net/backup-container/root",
+			externalSpec,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "backup-container", resolved.ForeignBucket)
+		assert.NotNil(t, resolved.ForeignCM)
+		assert.NotNil(t, resolved.Copier)
+	})
+}
+
+func TestResolveForeignStorageAzureCrossAccountWithoutSASRejected(t *testing.T) {
+	t.Setenv("AZURE_STORAGE_CONNECTION_STRING", "")
+
+	var captured []objectstorage.Config
+	patchRemoteChunkManager(t, &captured)
+
+	_, err := ResolveForeignStorage(
+		context.Background(),
+		azureInstanceCfg(),
+		DirectionExport,
+		"azure://backup-account.blob.core.windows.net/backup-container/export-root",
+		`{"extfs":{"cloud_provider":"azure","access_key_id":"backup-account","access_key_value":"backup-key"}}`,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), unsupportedServerSideCopyMessage)
+	assert.Empty(t, captured)
+}
+
+func TestResolveForeignStorageAzureSameAccountWithSASRejected(t *testing.T) {
+	t.Setenv("AZURE_STORAGE_CONNECTION_STRING", "")
+
+	var captured []objectstorage.Config
+	patchRemoteChunkManager(t, &captured)
+
+	_, err := ResolveForeignStorage(
+		context.Background(),
+		azureInstanceCfg(),
+		DirectionExport,
+		"azure://instance-account.blob.core.windows.net/backup-container/export-root",
+		`{"extfs":{"cloud_provider":"azure","access_key_id":"instance-account","access_key_value":"backup-key","source_sas_token":"sv=2024-08-04&sig=abc"}}`,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "source_sas_token applies only when the copy crosses Azure storage accounts")
+	assert.Empty(t, captured)
+}
+
+func TestResolveForeignStorageAzureCrossCloudSASRejected(t *testing.T) {
+	t.Setenv("AZURE_STORAGE_CONNECTION_STRING", "")
+
+	var captured []objectstorage.Config
+	patchRemoteChunkManager(t, &captured)
+
+	_, err := ResolveForeignStorage(
+		context.Background(),
+		azureInstanceCfg(),
+		DirectionExport,
+		"azure://backup-account.blob.core.chinacloudapi.cn/backup-container/export-root",
+		`{"extfs":{"cloud_provider":"azure","access_key_id":"backup-account","access_key_value":"backup-key","source_sas_token":"sv=2024-08-04&sig=abc"}}`,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must stay within one Azure cloud")
+	assert.Empty(t, captured)
+}

--- a/internal/snapshotio/storage/validator.go
+++ b/internal/snapshotio/storage/validator.go
@@ -29,6 +29,17 @@ import (
 // #nosec G101 -- this is an external spec field name, not a credential value.
 const snapshotExtfsKeyCredentialJSON = "credential_json"
 
+// #nosec G101 -- this is an external spec field name, not a credential value.
+const snapshotExtfsKeySourceSAS = "source_sas_token"
+
+// snapshotExtfsOnlyKeys are snapshot-specific and unknown to the generic
+// external-spec parser, so parseSnapshotExternalSpec strips them before that
+// parse and re-injects them afterwards.
+var snapshotExtfsOnlyKeys = map[string]struct{}{
+	snapshotExtfsKeyCredentialJSON: {},
+	snapshotExtfsKeySourceSAS:      {},
+}
+
 var snapshotExtfsKeys = map[string]struct{}{
 	externalspec.ExtfsKeyAccessKeyID:    {},
 	externalspec.ExtfsKeyAccessKeyValue: {},
@@ -41,6 +52,7 @@ var snapshotExtfsKeys = map[string]struct{}{
 	externalspec.ExtfsKeyUseSSL:         {},
 	externalspec.ExtfsKeyUseVirtualHost: {},
 	snapshotExtfsKeyCredentialJSON:      {},
+	snapshotExtfsKeySourceSAS:           {},
 }
 
 func parseSnapshotForeignURI(direction Direction, foreignURI string) (bucket, root, scheme, endpoint string, err error) {
@@ -89,9 +101,12 @@ func applySnapshotExternalSpecToConfig(
 		return false, "", err
 	}
 	// Snapshot APIs intentionally mirror Milvus instance storage config:
-	// instance credentials, IAM mode, or raw AK/SK. Generic role_arn, SAS,
+	// instance credentials, IAM mode, or raw AK/SK. Generic role_arn,
 	// service-account impersonation, and dual credential modes are not accepted
-	// here because there is no corresponding instance-config contract.
+	// here because there is no corresponding instance-config contract. The one
+	// exception is the Azure source SAS: it authorizes the read side of a
+	// cross-account server-side copy, which no destination credential can do,
+	// and is not a credential mode of its own.
 	if err := validateCredentialModes(parsed.Extfs); err != nil {
 		return false, "", err
 	}
@@ -201,6 +216,17 @@ func applySnapshotExternalSpecToConfig(
 		if strings.EqualFold(cfg.CloudProvider, objectstorage.CloudProviderAzure) {
 			cfg.IgnoreAzureConnectionString = true
 		}
+	}
+
+	if sourceSAS := strings.TrimSpace(extfs[snapshotExtfsKeySourceSAS]); sourceSAS != "" {
+		if !strings.EqualFold(cfg.CloudProvider, objectstorage.CloudProviderAzure) {
+			return false, "", merr.WrapErrParameterInvalidMsg(
+				"extfs.%s requires cloud_provider=%q",
+				snapshotExtfsKeySourceSAS,
+				objectstorage.CloudProviderAzure,
+			)
+		}
+		cfg.AzureSourceSAS = strings.TrimPrefix(sourceSAS, "?")
 	}
 
 	if value := strings.ToLower(strings.TrimSpace(extfs[externalspec.ExtfsKeyStorageType])); value != "" {
@@ -316,11 +342,16 @@ func parseSnapshotExternalSpec(externalSpec string) (*externalspec.ExternalSpec,
 	if err := json.Unmarshal([]byte(externalSpec), &snapshotSpec); err != nil {
 		return nil, merr.WrapErrParameterInvalidErr(err, "invalid external spec JSON")
 	}
-	credentialJSON, ok := snapshotSpec.Extfs[snapshotExtfsKeyCredentialJSON]
-	if !ok {
+	snapshotOnly := make(map[string]string)
+	for key := range snapshotExtfsOnlyKeys {
+		if value, ok := snapshotSpec.Extfs[key]; ok {
+			snapshotOnly[key] = value
+			delete(snapshotSpec.Extfs, key)
+		}
+	}
+	if len(snapshotOnly) == 0 {
 		return externalspec.ParseExternalSpec(externalSpec)
 	}
-	delete(snapshotSpec.Extfs, snapshotExtfsKeyCredentialJSON)
 	sanitizedSpec, err := json.Marshal(snapshotSpec)
 	if err != nil {
 		return nil, merr.WrapErrParameterInvalidErr(err, "failed to validate external_spec")
@@ -332,7 +363,9 @@ func parseSnapshotExternalSpec(externalSpec string) (*externalspec.ExternalSpec,
 	if parsed.Extfs == nil {
 		parsed.Extfs = make(map[string]string)
 	}
-	parsed.Extfs[snapshotExtfsKeyCredentialJSON] = credentialJSON
+	for key, value := range snapshotOnly {
+		parsed.Extfs[key] = value
+	}
 	return parsed, nil
 }
 
@@ -386,6 +419,14 @@ func validateCredentialModes(extfs map[string]string) error {
 	if credentialModeCount > 1 {
 		return merr.WrapErrParameterInvalidMsg(
 			"snapshot foreign storage credential modes are mutually exclusive: use_iam, raw credentials, and credential_json",
+		)
+	}
+	sourceSAS := strings.TrimSpace(extfs[snapshotExtfsKeySourceSAS])
+	_, sourceSASSet := extfs[snapshotExtfsKeySourceSAS]
+	if sourceSASSet && sourceSAS == "" {
+		return merr.WrapErrParameterInvalidMsg(
+			"extfs.%s must be non-empty for snapshot foreign storage",
+			snapshotExtfsKeySourceSAS,
 		)
 	}
 	return nil

--- a/internal/snapshotio/storage/validator_test.go
+++ b/internal/snapshotio/storage/validator_test.go
@@ -707,3 +707,72 @@ func TestSnapshotReaderReadSnapshotRejectsMissingSnapshotInfo(t *testing.T) {
 	assert.Nil(t, readSnapshot)
 	assert.Contains(t, err.Error(), "snapshot info cannot be nil")
 }
+
+func TestApplySnapshotExternalSpecAzureSourceSAS(t *testing.T) {
+	newAzureCfg := func() *objectstorage.Config {
+		return &objectstorage.Config{
+			Address:           "core.windows.net",
+			BucketName:        "instance-container",
+			AccessKeyID:       "instance-account",
+			SecretAccessKeyID: "instance-key",
+			CloudProvider:     objectstorage.CloudProviderAzure,
+		}
+	}
+
+	t.Run("sets the SAS and trims the leading question mark", func(t *testing.T) {
+		cfg := newAzureCfg()
+		_, _, err := applySnapshotExternalSpecToConfig(
+			cfg,
+			"azure",
+			"core.windows.net",
+			`{"extfs":{"cloud_provider":"azure","access_key_id":"backup-account","access_key_value":"backup-key","source_sas_token":"?sv=2024-08-04&sig=abc"}}`,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "sv=2024-08-04&sig=abc", cfg.AzureSourceSAS)
+	})
+
+	t.Run("requires the azure provider", func(t *testing.T) {
+		cfg := &objectstorage.Config{
+			Address:           "s3.us-west-2.amazonaws.com",
+			BucketName:        "instance-bucket",
+			AccessKeyID:       "instance-ak",
+			SecretAccessKeyID: "instance-sk",
+			CloudProvider:     objectstorage.CloudProviderAWS,
+			Region:            "us-west-2",
+		}
+		_, _, err := applySnapshotExternalSpecToConfig(
+			cfg,
+			"s3",
+			"",
+			`{"extfs":{"cloud_provider":"aws","region":"us-west-2","source_sas_token":"sv=2024-08-04&sig=abc"}}`,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "source_sas_token requires cloud_provider=")
+	})
+
+	t.Run("rejects an empty token", func(t *testing.T) {
+		cfg := newAzureCfg()
+		_, _, err := applySnapshotExternalSpecToConfig(
+			cfg,
+			"azure",
+			"core.windows.net",
+			`{"extfs":{"cloud_provider":"azure","source_sas_token":""}}`,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "source_sas_token must be non-empty")
+	})
+
+	t.Run("is not a credential mode and combines with raw credentials", func(t *testing.T) {
+		cfg := newAzureCfg()
+		hasSpec, _, err := applySnapshotExternalSpecToConfig(
+			cfg,
+			"azure",
+			"core.windows.net",
+			`{"extfs":{"cloud_provider":"azure","access_key_id":"backup-account","access_key_value":"backup-key","source_sas_token":"sv=2024-08-04&sig=abc"}}`,
+		)
+		require.NoError(t, err)
+		assert.True(t, hasSpec)
+		assert.Equal(t, "backup-account", cfg.AccessKeyID)
+		assert.Equal(t, "sv=2024-08-04&sig=abc", cfg.AzureSourceSAS)
+	})
+}

--- a/internal/storage/azure_object_storage.go
+++ b/internal/storage/azure_object_storage.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
@@ -35,6 +37,12 @@ import (
 
 type AzureObjectStorage struct {
 	*service.Client
+
+	// sourceService addresses the copy source account when it differs from the
+	// client's own account. Cross-account source reads cannot be authorized by
+	// the client credential, so source URLs built from it carry sourceSAS.
+	sourceService *service.Client
+	sourceSAS     string
 }
 
 const (
@@ -49,7 +57,43 @@ func newAzureObjectStorageWithConfig(ctx context.Context, c *objectstorage.Confi
 	if err != nil {
 		return nil, err
 	}
-	return &AzureObjectStorage{Client: client}, nil
+	storage := &AzureObjectStorage{Client: client}
+	if c.AzureSourceSAS == "" {
+		return storage, nil
+	}
+	sourceURL, err := azureServiceURL(c.AzureSourceEndpoint, c.AzureSourceUseSSL)
+	if err != nil {
+		return nil, err
+	}
+	// NoCredential keeps this client anonymous: the source account is
+	// authorized by the SAS token carried on each source URL, not by any
+	// credential pipeline of its own.
+	sourceService, err := service.NewClientWithNoCredential(sourceURL, nil)
+	if err != nil {
+		return nil, merr.WrapErrParameterInvalidErr(err, "invalid azure copy source endpoint")
+	}
+	storage.sourceService = sourceService
+	storage.sourceSAS = strings.TrimPrefix(c.AzureSourceSAS, "?")
+	return storage, nil
+}
+
+func azureServiceURL(host string, useSSL bool) (string, error) {
+	host = strings.ToLower(strings.TrimSpace(strings.TrimSuffix(host, ".")))
+	if host == "" {
+		return "", merr.WrapErrParameterInvalidMsg("azure copy source endpoint is empty")
+	}
+	scheme := "https"
+	if !useSSL {
+		scheme = "http"
+	}
+	// Round-trip through url.Parse so anything that is not a bare host — a
+	// path, query, fragment, userinfo, or an invalid character — is rejected
+	// here rather than producing a malformed copy source URL.
+	u, err := url.Parse(scheme + "://" + host + "/")
+	if err != nil || u.Host != host || u.Path != "/" || u.RawQuery != "" || u.Fragment != "" {
+		return "", merr.WrapErrParameterInvalidMsg("azure copy source endpoint %q must be a bare service host", host)
+	}
+	return u.String(), nil
 }
 
 // BlobReader is implemented because Azure's stream body does not have ReadAt and Seek interfaces.
@@ -205,9 +249,20 @@ func (AzureObjectStorage *AzureObjectStorage) RemoveObject(ctx context.Context, 
 }
 
 func (AzureObjectStorage *AzureObjectStorage) CopyObjectCrossBucket(ctx context.Context, srcContainer, srcObjectName, dstContainer, dstObjectName string) error {
-	srcURL := AzureObjectStorage.NewContainerClient(srcContainer).NewBlockBlobClient(srcObjectName).URL()
+	srcURL := AzureObjectStorage.sourceCopyURL(srcContainer, srcObjectName)
 	dstBlobClient := AzureObjectStorage.NewContainerClient(dstContainer).NewBlockBlobClient(dstObjectName)
 	return startOrResumeAzureCopy(ctx, dstBlobClient, srcURL, dstObjectName)
+}
+
+// sourceCopyURL builds the read-side URL of a server-side copy. Same-account
+// copies reuse the client's own service URL; cross-account copies address the
+// source account directly and append the SAS that authorizes the read.
+func (AzureObjectStorage *AzureObjectStorage) sourceCopyURL(srcContainer, srcObjectName string) string {
+	if AzureObjectStorage.sourceService == nil {
+		return AzureObjectStorage.NewContainerClient(srcContainer).NewBlockBlobClient(srcObjectName).URL()
+	}
+	return AzureObjectStorage.sourceService.NewContainerClient(srcContainer).NewBlockBlobClient(srcObjectName).URL() +
+		"?" + AzureObjectStorage.sourceSAS
 }
 
 // startOrResumeAzureCopy starts one asynchronous Azure copy. If an SDK retry
@@ -267,14 +322,21 @@ func waitAzureCopyComplete(
 			continue
 		}
 		if expectedSource != "" {
-			if props.CopySource == nil || *props.CopySource != expectedSource {
-				actualSource := ""
-				if props.CopySource != nil {
-					actualSource = *props.CopySource
-				}
+			// The service echoes the copy source without a guarantee about the
+			// query string, so compare the URL identity only: a SAS-bearing
+			// source must still verify against its credential-free form.
+			expectedIdentity := azureCopySourceIdentity(expectedSource)
+			actualIdentity := ""
+			if props.CopySource != nil {
+				actualIdentity = azureCopySourceIdentity(*props.CopySource)
+			}
+			if actualIdentity != expectedIdentity {
+				// Report credential-free identities only: the raw URLs may carry
+				// the source SAS in their query strings, and this error bubbles
+				// into snapshot job failure reasons and logs.
 				return merr.WrapErrIoFailedMsg(
 					"azure copy source mismatch for %s: expected %s, actual %s",
-					dstObjectName, expectedSource, actualSource)
+					dstObjectName, expectedIdentity, actualIdentity)
 			}
 		}
 		if copyID == "" && props.CopyID != nil {
@@ -320,4 +382,16 @@ func waitAzureCopyPoll(ctx context.Context, ticker *time.Ticker) error {
 	case <-ticker.C:
 		return nil
 	}
+}
+
+func azureCopySourceIdentity(sourceURL string) string {
+	if i := strings.Index(sourceURL, "?"); i >= 0 {
+		sourceURL = sourceURL[:i]
+	}
+	// Compare the unescaped form: the service may echo an equivalent source
+	// URL with different percent-encoding than the request carried.
+	if unescaped, err := url.PathUnescape(sourceURL); err == nil {
+		return unescaped
+	}
+	return sourceURL
 }

--- a/internal/storage/azure_object_storage_test.go
+++ b/internal/storage/azure_object_storage_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -92,6 +93,19 @@ func TestWaitAzureCopyComplete(t *testing.T) {
 		assert.Contains(t, err.Error(), "copy source mismatch")
 	})
 
+	t.Run("mismatch error never carries the source SAS", func(t *testing.T) {
+		statuses := []blob.CopyStatusType{blob.CopyStatusTypePending}
+		actual := "https://other-account.blob.core.windows.net/src-container/srcobj?sv=2024-08-04&sig=other"
+		client, _ := mockAzureCopyStatuses(t, statuses, actual, "copy-id", "")
+
+		err := waitAzureCopyComplete(context.Background(), client, "dst",
+			"https://src-account.blob.core.windows.net/src-container/srcobj?sv=2024-08-04&sig=abc", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "https://src-account.blob.core.windows.net/src-container/srcobj")
+		assert.NotContains(t, err.Error(), "sig=abc")
+		assert.NotContains(t, err.Error(), "sig=other")
+	})
+
 	t.Run("rejects replaced copy ID", func(t *testing.T) {
 		statuses := []blob.CopyStatusType{blob.CopyStatusTypePending}
 		client, _ := mockAzureCopyStatuses(t, statuses, "source", "other-copy-id", "")
@@ -113,6 +127,125 @@ func TestWaitAzureCopyComplete(t *testing.T) {
 		err := waitAzureCopyComplete(context.Background(), new(blockblob.Client), "dst", "source", "copy-id")
 		require.ErrorIs(t, err, merr.ErrIoPermissionDenied)
 		assert.Equal(t, 1, calls)
+	})
+}
+
+func TestStartOrResumeAzureCopySourceIdentityIgnoresQuery(t *testing.T) {
+	// The service echoes the copy source without a guarantee about the query
+	// string or percent-encoding; a SAS-bearing, escaped expected source must
+	// verify against its bare, unescaped form.
+	status := blob.CopyStatusTypeSuccess
+	copyID := "copy-id"
+	bareSource := "https://src-account.blob.core.windows.net/src-container/src/obj"
+	client, calls := mockAzureCopyStatuses(t, []blob.CopyStatusType{status}, bareSource, copyID, "")
+
+	err := waitAzureCopyComplete(context.Background(), client, "dst",
+		"https://src-account.blob.core.windows.net/src-container/src%2Fobj?sv=2024-08-04&sig=abc", copyID)
+	require.NoError(t, err)
+	require.Equal(t, 1, *calls)
+}
+
+func TestAzureObjectStorageCopyObjectCrossBucketSourceSAS(t *testing.T) {
+	newStorage := func(t *testing.T, sourceEndpoint, sourceSAS string, sourceUseSSL bool) *AzureObjectStorage {
+		t.Helper()
+		// #nosec G101 -- "ZmFrZS1rZXk=" is base64 for "fake-key", an offline
+		// fixture credential; all requests are mocked, nothing is ever signed.
+		cfg := &objectstorage.Config{
+			Address:                     "core.windows.net",
+			BucketName:                  "dst-container",
+			AccessKeyID:                 "dst-account",
+			SecretAccessKeyID:           "ZmFrZS1rZXk=",
+			CloudProvider:               objectstorage.CloudProviderAzure,
+			UseSSL:                      true,
+			SkipBucketCheck:             true,
+			IgnoreAzureConnectionString: true,
+			AzureSourceEndpoint:         sourceEndpoint,
+			AzureSourceUseSSL:           sourceUseSSL,
+			AzureSourceSAS:              sourceSAS,
+		}
+		storage, err := newAzureObjectStorageWithConfig(context.Background(), cfg)
+		require.NoError(t, err)
+		return storage
+	}
+
+	mockCopy := func(t *testing.T, source *string, echoSourceWithQuery bool) {
+		t.Helper()
+		copyID := "copy-id"
+		status := blob.CopyStatusTypeSuccess
+		startPatch := mockey.Mock((*blockblob.Client).StartCopyFromURL).To(
+			func(_ *blockblob.Client, _ context.Context, url string, _ *blob.StartCopyFromURLOptions) (blob.StartCopyFromURLResponse, error) {
+				*source = url
+				return blob.StartCopyFromURLResponse{CopyID: &copyID}, nil
+			}).Build()
+		t.Cleanup(func() { startPatch.UnPatch() })
+		echoedSource := ""
+		pollPatch := mockey.Mock((*blockblob.Client).GetProperties).To(
+			func(_ *blockblob.Client, _ context.Context, _ *blob.GetPropertiesOptions) (blob.GetPropertiesResponse, error) {
+				echoedSource = *source
+				if !echoSourceWithQuery {
+					if i := strings.IndexByte(echoedSource, '?'); i >= 0 {
+						echoedSource = echoedSource[:i]
+					}
+				}
+				return blob.GetPropertiesResponse{
+					CopyID:     &copyID,
+					CopySource: &echoedSource,
+					CopyStatus: &status,
+				}, nil
+			}).Build()
+		t.Cleanup(func() { pollPatch.UnPatch() })
+	}
+
+	t.Run("cross-account source URL addresses the source account and carries the SAS", func(t *testing.T) {
+		storage := newStorage(t, "src-account.blob.core.windows.net", "sv=2024-08-04&sig=abc", true)
+		var captured string
+		mockCopy(t, &captured, false)
+
+		err := storage.CopyObjectCrossBucket(context.Background(), "src-container", "srcobj", "dst-container", "dstobj")
+		require.NoError(t, err)
+		assert.Equal(t, "https://src-account.blob.core.windows.net/src-container/srcobj?sv=2024-08-04&sig=abc", captured)
+	})
+
+	t.Run("source URL scheme follows the source config, not the destination", func(t *testing.T) {
+		// The destination config uses SSL; the source account does not, so the
+		// source URL must be http even though the client config has UseSSL=true.
+		storage := newStorage(t, "src-account.blob.core.windows.net", "sv=2024-08-04&sig=abc", false)
+		var captured string
+		mockCopy(t, &captured, false)
+
+		err := storage.CopyObjectCrossBucket(context.Background(), "src-container", "srcobj", "dst-container", "dstobj")
+		require.NoError(t, err)
+		assert.Equal(t, "http://src-account.blob.core.windows.net/src-container/srcobj?sv=2024-08-04&sig=abc", captured)
+	})
+
+	t.Run("same-account source URL stays on the client service", func(t *testing.T) {
+		storage := newStorage(t, "", "", true)
+		var captured string
+		mockCopy(t, &captured, true)
+
+		err := storage.CopyObjectCrossBucket(context.Background(), "dst-container", "srcobj", "dst-container", "dstobj")
+		require.NoError(t, err)
+		assert.Equal(t, "https://dst-account.blob.core.windows.net/dst-container/srcobj", captured)
+	})
+
+	t.Run("invalid source endpoint host is rejected at construction", func(t *testing.T) {
+		// #nosec G101 -- "ZmFrZS1rZXk=" is base64 for "fake-key", an offline
+		// fixture credential; all requests are mocked, nothing is ever signed.
+		cfg := &objectstorage.Config{
+			Address:                     "core.windows.net",
+			BucketName:                  "dst-container",
+			AccessKeyID:                 "dst-account",
+			SecretAccessKeyID:           "ZmFrZS1rZXk=",
+			CloudProvider:               objectstorage.CloudProviderAzure,
+			UseSSL:                      true,
+			SkipBucketCheck:             true,
+			IgnoreAzureConnectionString: true,
+			AzureSourceEndpoint:         "not a host",
+			AzureSourceSAS:              "sv=2024-08-04&sig=abc",
+		}
+		_, err := newAzureObjectStorageWithConfig(context.Background(), cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a bare service host")
 	})
 }
 

--- a/pkg/objectstorage/options.go
+++ b/pkg/objectstorage/options.go
@@ -30,6 +30,24 @@ type Config struct {
 	// IgnoreAzureConnectionString keeps request-scoped Azure account credentials
 	// from being overridden by the process-level connection string.
 	IgnoreAzureConnectionString bool
+
+	// AzureSourceEndpoint is the blob service endpoint host of a copy source that
+	// lives in a different Azure storage account than the client's own
+	// credential, e.g. "otheraccount.blob.core.windows.net". It is set together
+	// with AzureSourceSAS for cross-account server-side copies only.
+	AzureSourceEndpoint string
+
+	// AzureSourceUseSSL selects the scheme of AzureSourceEndpoint URLs. It must
+	// be carried from the source account's own config, not from this client's:
+	// the two accounts may differ in transport, and a SAS minted with spr=https
+	// fails on an http source URL.
+	AzureSourceUseSSL bool
+
+	// AzureSourceSAS is a read-scoped SAS token appended to copy source blob
+	// URLs when the source is in a different Azure storage account: neither a
+	// shared key nor the request's own OAuth token can authorize reading a
+	// foreign account's blob, so the source URL must carry its own grant.
+	AzureSourceSAS string
 }
 
 func NewDefaultConfig() *Config {

--- a/pkg/util/externalspec/external_spec.go
+++ b/pkg/util/externalspec/external_spec.go
@@ -147,6 +147,7 @@ var secretExtfsKeys = map[string]bool{
 	ExtfsKeySSLCACert:      true,
 	ExtfsKeyExternalID:     true, // STS shared secret; confused-deputy guard.
 	"credential_json":      true, // Snapshot request-level GCP service-account JSON.
+	"source_sas_token":     true, // Snapshot request-level Azure source-read SAS.
 }
 
 // ParseExternalSpec parses the JSON external spec string

--- a/pkg/util/externalspec/external_spec_test.go
+++ b/pkg/util/externalspec/external_spec_test.go
@@ -393,14 +393,16 @@ func TestRedactExternalSpec(t *testing.T) {
 	})
 
 	t.Run("secrets_masked", func(t *testing.T) {
-		out := RedactExternalSpec(`{"format":"parquet","extfs":{"access_key_id":"AKIA","access_key_value":"SEC","credential_json":"{\"private_key\":\"SECRET\"}","region":"us"}}`)
+		out := RedactExternalSpec(`{"format":"parquet","extfs":{"access_key_id":"AKIA","access_key_value":"SEC","credential_json":"{\"private_key\":\"SECRET\"}","source_sas_token":"sv=2024-08-04&sig=SECRET","region":"us"}}`)
 		assert.Contains(t, out, `"access_key_id":"***"`)
 		assert.Contains(t, out, `"access_key_value":"***"`)
 		assert.Contains(t, out, `"credential_json":"***"`)
+		assert.Contains(t, out, `"source_sas_token":"***"`)
 		assert.Contains(t, out, `"region":"us"`)
 		assert.NotContains(t, out, "AKIA")
 		assert.NotContains(t, out, "SEC")
 		assert.NotContains(t, out, "private_key")
+		assert.NotContains(t, out, "sig=SECRET")
 	})
 
 	t.Run("empty_secret_values_untouched", func(t *testing.T) {


### PR DESCRIPTION
pr: #52770
issue: #52769
design doc: `docs/design-docs/design_docs/20260609-external-snapshot-export-restore.md` (§10)

Rebase of #52770 (master squash commit `9482123d9568`) onto the latest 3.0 head (`37ccd72fe4`). One conflict, in `pkg/util/externalspec/external_spec_test.go` (`TestRedactExternalSpec/secrets_masked`): 3.0's version asserts `endpoint_url` is preserved, the PR adds `source_sas_token` masking — resolved by keeping both keys and both assertions in the test. All other hunks apply content-identically to the merged master change (12 files, +756/−26).

## What

Adds a scoped exception to the snapshot API's "no source-auth" rule: Azure cross-storage-account server-side copy, authorized on the read side by a read-scoped SAS token carried on the copy source URL.

`external_spec.extfs` gains one Azure-only key:

```json
{"extfs": {
  "cloud_provider": "azure",
  "access_key_id": "backup-account", "access_key_value": "...",
  "source_sas_token": "sv=2024-08-04&sig=...&sp=r"
}}
```

## Why

Azure's copy authorization rules ([Copy Blob From URL], Authorization table) allow a source blob in **another** storage account to be read only via a read-scoped SAS on the source URL — neither account's Shared Key nor the request's own Entra ID token covers it. The snapshot export/restore copy is a single `StartCopyFromURL` authorized by the destination account, so until now `validateProviderEndpointPair` failed closed on any Azure account crossing, and a cross-account copy could not be expressed at all. With the SAS the copy is still one provider-side request — it satisfies the design's core invariant from §6 of the MEP — so this is a credential-model extension, not a streaming fallback.

Concrete impact: milvus-backup's snapshot-format backup targets a dedicated backup storage account in the common Azure DR topology and is currently rejected up front (`IllegalArgument ... server-side cross-bucket copy is unsupported for this provider/endpoint pair`).

## How

- **Validation** (`internal/snapshotio/storage/validator.go`): `source_sas_token` is a snapshot-only extfs key (strip/re-inject like `credential_json`), valid only for `cloud_provider=azure`, non-empty, and **not** a credential mode — the destination side still uses exactly one existing mode. Value is redacted in `secretExtfsKeys` alongside `credential_json`.
- **Endpoint pair check** (`resolver.go`): with a SAS, the Azure family allows different account endpoints within one sovereign cloud. Same-account requests carrying a SAS and cross-cloud requests are rejected as input errors — an unused or meaningless SAS signals misconfiguration.
- **Copy execution** (`internal/storage/azure_object_storage.go`): a second, credential-less service client addresses the source account; cross-account source URLs are built from it with the SAS appended. Copy-source verification during polling now compares URL identities without the query string, since the service does not guarantee `x-ms-copy-source` echoes the SAS.
- **Copier selection** (`resolver.go`): export keeps the foreign-account copier (destination = foreign account) with the instance endpoint + SAS as the source; restore/copy-source switch to an instance-credential copier (destination = instance bucket) with the foreign endpoint + SAS as the source. Metadata reads/writes keep their existing clients.
- No proto or C++ changes: the SAS rides inside the opaque `external_spec` JSON that already propagates Proxy → DataCoord → WAL/job/task state → DataNode.

## Failure modes traced (per repo verification gate)

- SAS expired / lacking read on the source container → first `StartCopyFromURL` returns 403 → export job fails before `Publishing` through the existing permission-failure path; no metadata published.
- SAS echoed with or without query by the service during polling → source verification compares credential-free URL identities, covered by unit test.
- Same-account + SAS, cross-cloud + SAS, non-Azure provider + SAS, empty SAS → rejected as input errors at validation, covered by unit tests.
- Cross-account without SAS → still rejected up front with the existing `unsupportedServerSideCopyMessage` (unchanged behavior).

## Tests

- `internal/snapshotio/storage`: resolver accepts cross-account export/restore with a SAS (asserting both resolved client configs), rejects cross-account without SAS, same-account with SAS, and cross-cloud with SAS; validator applies/trims the token, enforces azure-only and non-empty, and allows it alongside raw credentials.
- `internal/storage`: `CopyObjectCrossBucket` builds the cross-account source URL with the SAS, keeps the same-account URL unchanged, and rejects an invalid source host at construction; poll verification ignores the query.
- `pkg/util/externalspec`: `source_sas_token` is redacted.

## Follow-ups

- milvus-backup: mint/send the source SAS in its `ExternalSpec` for cross-account Azure snapshot backups (milvus-backup repo, separate PR).
- A real-account e2e against two storage accounts is not covered by CI; the change is verified at the unit/contract level here.

[Copy Blob From URL]: https://learn.microsoft.com/en-us/rest/api/storageservices/copy-blob-from-url

