### PR TITLE
enhance: gate placement on analyzer file resources

### DIFF
--- a/internal/coordinator/file_resource_observer.go
+++ b/internal/coordinator/file_resource_observer.go
@@ -19,6 +19,7 @@ package coordinator
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -55,6 +56,12 @@ type FileResourceMeta interface {
 	GetResources() ([]*internalpb.FileResourceInfo, uint64)
 }
 
+// gateState is the snapshot CheckNodesSynced judges against without a lock.
+type gateState struct {
+	version uint64
+	gated   bool
+}
+
 type FileResourceObserver struct {
 	ctx  context.Context
 	meta rootcoord.IMetaTable
@@ -72,6 +79,14 @@ type FileResourceObserver struct {
 	qnMode    fileresource.Mode // tips: streaming node used as query node now
 	dnMode    fileresource.Mode
 	proxyMode fileresource.Mode
+
+	// gateSnapshot caches the one fact CheckNodesSynced needs from the meta
+	// table - whether file resources are registered, and at which version - so
+	// the task executors' per-dispatch gate never takes rootcoord's ddLock.
+	// Refreshed by every Sync pass; between a resource change and the next
+	// pass the gate may briefly judge against the previous version, which is
+	// the same convergence window the node syncs themselves have.
+	gateSnapshot atomic.Pointer[gateState]
 
 	notifyCh  chan struct{}
 	closeCh   chan struct{}
@@ -199,12 +214,79 @@ func (m *FileResourceObserver) CheckAllQnReady() error {
 	return err
 }
 
+// CheckNodesSynced reports whether the given query nodes hold the current
+// analyzer file resources.
+//
+// This is the query-side counterpart of CheckAllQnReady. A DDL only needs
+// whatever process validates analyzer parameters to hold the files; a node
+// that actually runs an analyzer over data - BM25, raw text match - needs them
+// on its own disk. Callers pass the nodes they are about to put data on, so a
+// lagging node they are not using cannot block them.
+//
+// A node with no record has confirmed nothing and must not be read as ready: a
+// node registers its session, which is what puts it in a resource group and in
+// the task executor, before its first sync has been asked for. The comparison
+// is against the version rather than mere presence for the same reason - a node
+// that acknowledged one sync keeps its record, so presence alone would pass a
+// node still downloading the version registered after it.
+func (m *FileResourceObserver) CheckNodesSynced(nodeIDs []int64) error {
+	if len(nodeIDs) == 0 {
+		return nil
+	}
+	// Mode first: it is a plain field, and on a deployment that does not sync
+	// query nodes the gate must cost nothing.
+	if m.qnMode != fileresource.SyncMode {
+		return nil
+	}
+	if m.meta == nil {
+		return merr.WrapErrServiceUnavailable("rootcoord meta is not ready")
+	}
+
+	// The cached snapshot keeps this off rootcoord's ddLock: the task
+	// executors consult the gate for every pending grow action on every
+	// dispatch, and taking a DDL lock there couples querycoord's scheduling
+	// tick to rootcoord's DDL throughput. Only the first call before any Sync
+	// pass reads the meta table directly.
+	snap := m.gateSnapshot.Load()
+	if snap == nil {
+		resources, version := m.meta.ListFileResource(m.ctx)
+		snap = &gateState{version: version, gated: version != 0 && len(resources) > 0}
+		// CAS, not Store: a Sync pass finishing right now has fresher data,
+		// and this lazy first read must not clobber it with an older view.
+		if !m.gateSnapshot.CompareAndSwap(nil, snap) {
+			snap = m.gateSnapshot.Load()
+		}
+	}
+	if !snap.gated {
+		return nil
+	}
+	version := snap.version
+
+	for _, nodeID := range nodeIDs {
+		info, ok := m.distribution.Get(nodeID)
+		if !ok {
+			return merr.WrapErrServiceUnavailableMsg(
+				"node %d has not synced any analyzer file resource yet", nodeID)
+		}
+		if info.Version < version {
+			return merr.WrapErrServiceUnavailableMsg(
+				"node %d analyzer file resource version %d is behind %d", nodeID, info.Version, version)
+		}
+	}
+	return nil
+}
+
 func (m *FileResourceObserver) Sync() error {
 	m.syncMu.Lock()
 	defer m.syncMu.Unlock()
 	var syncErr error
 	activeNodes := make(map[int64]struct{})
 	resources, targetVersion := m.meta.ListFileResource(m.ctx)
+	// Refresh the gate before the early return below: a version-0 meta table
+	// still has a definite answer for CheckNodesSynced - not gated - and
+	// publishing it here is what keeps that call off rootcoord's ddLock.
+	m.gateSnapshot.Store(&gateState{version: targetVersion, gated: targetVersion != 0 && len(resources) > 0})
+
 	// Version 0 means no file resource has ever been added successfully.
 	if targetVersion == 0 {
 		return nil
@@ -219,6 +301,15 @@ func (m *FileResourceObserver) Sync() error {
 					Resources: resources,
 					Version:   targetVersion,
 				})
+				// A node that does not implement the RPC cannot be asked to
+				// download anything, and holding grow actions off it forever
+				// would wedge a rolling upgrade on its oldest node. It is
+				// recorded as synced: whatever it serves, it served before
+				// file resources existed, which is the compatibility floor.
+				if errors.Is(err, merr.ErrServiceUnimplemented) {
+					err = nil
+					status = merr.Success()
+				}
 				if err != nil {
 					mlog.Warn(m.ctx, "sync file resource failed", mlog.FieldNodeID(node.ID()), mlog.Err(err))
 					syncErr = err

--- a/internal/coordinator/file_resource_observer_test.go
+++ b/internal/coordinator/file_resource_observer_test.go
@@ -21,14 +21,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	dcsession "github.com/milvus-io/milvus/internal/datacoord/session"
 	"github.com/milvus-io/milvus/internal/mocks"
 	qcsession "github.com/milvus-io/milvus/internal/querycoordv2/session"
+	"github.com/milvus-io/milvus/internal/rootcoord"
 	mockrootcoord "github.com/milvus-io/milvus/internal/rootcoord/mocks"
 	"github.com/milvus-io/milvus/internal/util/fileresource"
 	"github.com/milvus-io/milvus/internal/util/proxyutil"
@@ -802,4 +806,53 @@ func (s *FileResourceObserverSuite) TestRetryNotify() {
 
 func TestFileResourceObserverSuite(t *testing.T) {
 	suite.Run(t, new(FileResourceObserverSuite))
+}
+
+// The per-dispatch gate must not take rootcoord's ddLock: after one Sync pass
+// the answer comes from the cached snapshot, and a deployment with no file
+// resources answers nil without ever reaching the meta table again.
+func TestCheckNodesSyncedJudgesFromTheSnapshotNotTheLock(t *testing.T) {
+	listCalls := 0
+	mockList := mockey.Mock((*rootcoord.MetaTable).ListFileResource).To(
+		func(*rootcoord.MetaTable, context.Context) ([]*internalpb.FileResourceInfo, uint64) {
+			listCalls++
+			return nil, 0
+		}).Build()
+	defer mockList.UnPatch()
+
+	m := &FileResourceObserver{
+		ctx:          context.Background(),
+		meta:         &rootcoord.MetaTable{},
+		distribution: typeutil.NewConcurrentMap[int64, *NodeInfo](),
+		qnMode:       fileresource.SyncMode,
+	}
+
+	require.NoError(t, m.CheckNodesSynced([]int64{1}), "no resources registered: the gate answers nil")
+	first := listCalls
+	require.NoError(t, m.CheckNodesSynced([]int64{1}))
+	require.NoError(t, m.CheckNodesSynced([]int64{1}))
+	assert.Equal(t, first, listCalls,
+		"after the first read the gate must judge from the snapshot, not re-take the DDL lock per dispatch")
+}
+
+// A node recorded at the target version passes the gate - which is the state
+// the Unimplemented branch of Sync() leaves an old query node in. (The branch
+// itself lives in Sync and is not driven here; this pins the gate's side.)
+func TestCheckNodesSyncedPassesANodeRecordedAtTargetVersion(t *testing.T) {
+	// The snapshot path is exercised through CheckNodesSynced after a manual
+	// distribution insert, which is what the Unimplemented branch performs.
+	m := &FileResourceObserver{
+		ctx:          context.Background(),
+		distribution: typeutil.NewConcurrentMap[int64, *NodeInfo](),
+		qnMode:       fileresource.SyncMode,
+		meta:         &rootcoord.MetaTable{},
+	}
+	m.gateSnapshot.Store(&gateState{version: 3, gated: true})
+
+	err := m.CheckNodesSynced([]int64{7})
+	require.Error(t, err, "an unrecorded node is behind")
+
+	m.distribution.Insert(7, &NodeInfo{NodeID: 7, NodeType: QueryNode, Version: 3})
+	assert.NoError(t, m.CheckNodesSynced([]int64{7}),
+		"a node recorded at the target version - including via the Unimplemented floor - passes")
 }

--- a/internal/coordinator/file_resource_observer_test.go
+++ b/internal/coordinator/file_resource_observer_test.go
@@ -856,3 +856,39 @@ func TestCheckNodesSyncedPassesANodeRecordedAtTargetVersion(t *testing.T) {
 	assert.NoError(t, m.CheckNodesSynced([]int64{7}),
 		"a node recorded at the target version - including via the Unimplemented floor - passes")
 }
+
+// Sync() returns early on a version-0 meta table - nothing has ever been
+// registered, so there is nothing to push to any node. It must still publish
+// the snapshot on the way out: "version 0" is a definite answer for the gate,
+// and leaving the snapshot nil sends every CheckNodesSynced call back to the
+// meta table, which is rootcoord's ddLock - exactly what the cache exists to
+// avoid.
+func TestSyncPublishesTheSnapshotBeforeTheVersionZeroEarlyReturn(t *testing.T) {
+	listCalls := 0
+	mockList := mockey.Mock((*rootcoord.MetaTable).ListFileResource).To(
+		func(*rootcoord.MetaTable, context.Context) ([]*internalpb.FileResourceInfo, uint64) {
+			listCalls++
+			return nil, 0
+		}).Build()
+	defer mockList.UnPatch()
+
+	m := &FileResourceObserver{
+		ctx:          context.Background(),
+		meta:         &rootcoord.MetaTable{},
+		distribution: typeutil.NewConcurrentMap[int64, *NodeInfo](),
+		qnMode:       fileresource.SyncMode,
+	}
+
+	require.NoError(t, m.Sync(), "a version-0 meta table has nothing to sync")
+
+	snap := m.gateSnapshot.Load()
+	require.NotNil(t, snap, "the early return must not skip publishing the snapshot")
+	assert.EqualValues(t, 0, snap.version)
+	assert.False(t, snap.gated, "nothing registered: the gate must be inert")
+
+	after := listCalls
+	require.NoError(t, m.CheckNodesSynced([]int64{1}))
+	require.NoError(t, m.CheckNodesSynced([]int64{2}))
+	assert.Equal(t, after, listCalls,
+		"the gate must judge from the snapshot Sync published, not re-take the DDL lock")
+}

--- a/internal/querycoordv2/file_resource_gate.go
+++ b/internal/querycoordv2/file_resource_gate.go
@@ -1,0 +1,55 @@
+package querycoordv2
+
+import (
+	"github.com/milvus-io/milvus/internal/querycoordv2/task"
+)
+
+// This file holds querycoord's barrier on analyzer file resources: the
+// dictionaries, stop-word lists and synonym files an analyzer needs on local
+// disk before it can resolve a resource an analyzer parameter names.
+//
+// A query node becomes visible to querycoord as soon as its session registers,
+// which is earlier than its file resource download finishes. Anything that puts
+// data on it before then - a segment carrying a BM25 field, a channel whose
+// delegator runs an analyzer over the growing data - races that download.
+//
+// The barrier answers nil when no file resource is registered at all, which is
+// every deployment that does not use them.
+
+// nodeFileResourceGate returns the gate the task executors defer grow actions
+// on, or nil when the observer is absent and the executors consult nothing.
+//
+// The gate sits on the action rather than on the load request. A load-time
+// check would only see the resource group membership at the moment the request
+// arrives: it would not cover a node that crashes and rejoins, is
+// rolling-replaced, or joins the resource group afterwards, because those paths
+// put segments and channels back through the checkers with no load request
+// involved. Gating the action is what makes "a node serving a shard holds the
+// files its analyzers need" hold on every path - and it defers the action
+// instead of failing the user's load, so a node still downloading delays
+// placement rather than turning the load into an error.
+func (s *Server) nodeFileResourceGate() task.NodeFileResourceGate {
+	if s.fileResourceObserver == nil {
+		return nil
+	}
+	observer := s.fileResourceObserver
+	return func(nodeID int64) error {
+		return observer.CheckNodesSynced([]int64{nodeID})
+	}
+}
+
+// notifyFileResourceOnNodeRediscovery asks the observer to sync file resources
+// after querycoord rediscovers the nodes already in the session directory.
+//
+// Those nodes never went through the session-add path, which is the only thing
+// that notifies the observer natively, so nothing else would trigger a sync for
+// them. That is harmless when nothing gates on the result and a deadlock when
+// something does: a node rediscovered on querycoord restart or on an etcd
+// reconnect would sit behind the gate above until an unrelated event happened
+// to notify the observer.
+func (s *Server) notifyFileResourceOnNodeRediscovery() {
+	if s.fileResourceObserver == nil {
+		return
+	}
+	s.fileResourceObserver.Notify()
+}

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -139,6 +139,12 @@ type FileResourceObserver interface {
 	InitQueryCoord(manager *session.NodeManager, cluster session.Cluster)
 	IsEmpty() bool
 	Notify()
+	// CheckNodesSynced reports whether the given query nodes hold the current
+	// analyzer file resources. It answers nil whenever no file resource is
+	// registered or the query-node sync mode is off, which is every deployment
+	// that does not use analyzer file resources - this barrier is part of the
+	// file-resource feature itself, not of any extension.
+	CheckNodesSynced(nodeIDs []int64) error
 }
 
 func NewQueryCoord(ctx context.Context) (*Server, error) {
@@ -312,7 +318,7 @@ func (s *Server) initQueryCoord() error {
 	// Init schedulers
 	mlog.Info(s.ctx, "init schedulers")
 	s.jobScheduler = job.NewScheduler()
-	s.taskScheduler = task.NewScheduler(
+	taskScheduler := task.NewScheduler(
 		s.ctx,
 		s.meta,
 		s.dist,
@@ -321,6 +327,11 @@ func (s *Server) initQueryCoord() error {
 		s.cluster,
 		s.nodeMgr,
 	)
+	// Install the analyzer file resource gate on the task executors. It is nil
+	// unless a form took the analyzer runtime over, and a nil gate is the
+	// native path: no executor consults anything.
+	taskScheduler.SetFileResourceGate(s.nodeFileResourceGate())
+	s.taskScheduler = taskScheduler
 
 	// init proxy client manager
 	s.proxyClientManager = proxyutil.NewProxyClientManager(proxyutil.DefaultProxyCreator)
@@ -749,6 +760,8 @@ func (s *Server) rewatchNodes(sessions map[string]*sessionutil.Session) error {
 	// update all node statuses in resource manager based on session and node manager's node list.
 	// Therefore, manual status checking of all nodes in resource manager is needed.
 	s.meta.CheckNodesInResourceGroup(s.ctx)
+
+	s.notifyFileResourceOnNodeRediscovery()
 
 	return nil
 }

--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -55,16 +55,29 @@ var segmentsVersion = semver.Version{
 	Patch: 4,
 }
 
+// NodeFileResourceGate reports whether a query node holds the current analyzer
+// file resources. A nil gate is the native path: nothing is consulted and
+// every action runs as it always did.
+//
+// A node joins the executor, the distribution and its resource group before any
+// out-of-band file sync for it completes, and rejoins the same way after a
+// crash or a rolling replacement - through the checkers, with no load request
+// involved. Gating the action itself is therefore what makes "a node serving a
+// shard holds the files its analyzers need" an invariant rather than a
+// property of the load path.
+type NodeFileResourceGate func(nodeID int64) error
+
 type Executor struct {
-	nodeID    int64
-	doneCh    chan struct{}
-	wg        sync.WaitGroup
-	meta      *meta.Meta
-	dist      *meta.DistributionManager
-	broker    meta.Broker
-	targetMgr meta.TargetManagerInterface
-	cluster   session.Cluster
-	nodeMgr   *session.NodeManager
+	nodeID           int64
+	doneCh           chan struct{}
+	wg               sync.WaitGroup
+	meta             *meta.Meta
+	dist             *meta.DistributionManager
+	broker           meta.Broker
+	targetMgr        meta.TargetManagerInterface
+	cluster          session.Cluster
+	nodeMgr          *session.NodeManager
+	fileResourceGate NodeFileResourceGate
 
 	executingTasks    *typeutil.ConcurrentSet[string] // task index
 	channelTaskNum    atomic.Int32                    // channel task pool counter
@@ -143,12 +156,64 @@ func (ex *Executor) GetNonChannelTaskCap() int32 {
 	return nonChannelCap
 }
 
+// checkFileResourceReady reports whether the action may run on this node given
+// its analyzer file resource state.
+//
+// Only grow actions are gated, and only the two that put data on the node.
+// Reductions and leader updates must stay unblocked: a node that is behind
+// could otherwise never be drained, which would turn a lagging download into a
+// node that can neither serve nor be released.
+func (ex *Executor) checkFileResourceReady(action Action) error {
+	if ex.fileResourceGate == nil || action.Type() != ActionTypeGrow {
+		return nil
+	}
+	switch action.(type) {
+	case *SegmentAction, *ChannelAction:
+		return ex.fileResourceGate(ex.nodeID)
+	default:
+		return nil
+	}
+}
+
 // Execute executes the given action,
 // does nothing and returns false if the action is already committed,
 // returns true otherwise.
 func (ex *Executor) Execute(task Task, step int) bool {
 	exist := !ex.executingTasks.Insert(task.Index())
 	if exist {
+		return false
+	}
+
+	// Hold grow actions back until this node holds its analyzer file resources.
+	// Checked before the pool counters are taken so a held task does not occupy
+	// a slot; returning false leaves the task queued for the scheduler to retry,
+	// exactly like the pool-full paths below.
+	//
+	// Reported at info rather than debug: a deferral that never clears is
+	// invisible from the outside - the delegator is simply never built and the
+	// collection never becomes queryable - and the sync failure behind it is
+	// logged somewhere else entirely, on the observer. This is the only line
+	// that ties the two together. It is silent unless the deployment registers
+	// analyzer file resources at all, so it costs nothing to leave on.
+	if err := ex.checkFileResourceReady(task.Actions()[step]); err != nil {
+		ex.executingTasks.Remove(task.Index())
+		action := task.Actions()[step]
+		fields := []mlog.Field{
+			mlog.Int64("nodeID", ex.nodeID),
+			mlog.Int64("taskID", task.ID()),
+			mlog.Int64("collectionID", task.CollectionID()),
+			mlog.Err(err),
+		}
+		// Which action was held decides how bad this is: a channel is the
+		// shard's delegator, so the collection cannot be queried at all until
+		// it lands, while a segment leaves the rest of the shard serving.
+		switch a := action.(type) {
+		case *ChannelAction:
+			fields = append(fields, mlog.String("channel", a.ChannelName()))
+		case *SegmentAction:
+			fields = append(fields, mlog.Int64("segmentID", a.SegmentID))
+		}
+		mlog.RatedInfo(context.TODO(), 0.1, "task deferred: analyzer file resources not ready on node", fields...)
 		return false
 	}
 

--- a/internal/querycoordv2/task/executor_file_resource_test.go
+++ b/internal/querycoordv2/task/executor_file_resource_test.go
@@ -1,0 +1,159 @@
+package task
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+// gateSpy records the nodes it was asked about and answers what the test set.
+type gateSpy struct {
+	calls int
+	nodes []int64
+	err   error
+}
+
+func (g *gateSpy) gate(nodeID int64) error {
+	g.calls++
+	g.nodes = append(g.nodes, nodeID)
+	return g.err
+}
+
+func TestExecutorWithoutGateRunsEveryActionAsBefore(t *testing.T) {
+	paramtable.Init()
+	ex := newTestExecutor(1)
+	require.Nil(t, ex.fileResourceGate, "a stock executor holds no gate")
+
+	for _, action := range []Action{
+		NewSegmentAction(1, ActionTypeGrow, "shard-0", 100),
+		NewChannelAction(1, ActionTypeGrow, "ch-0"),
+		NewSegmentAction(1, ActionTypeReduce, "shard-0", 100),
+	} {
+		assert.NoError(t, ex.checkFileResourceReady(action),
+			"a nil gate must let every action through untouched")
+	}
+}
+
+func TestExecutorGateOnlyAppliesToGrowActionsThatPutDataOnTheNode(t *testing.T) {
+	paramtable.Init()
+
+	cases := []struct {
+		name     string
+		action   Action
+		consults bool
+	}{
+		{"grow segment", NewSegmentAction(1, ActionTypeGrow, "shard-0", 100), true},
+		{"grow channel", NewChannelAction(1, ActionTypeGrow, "ch-0"), true},
+		{"reduce segment", NewSegmentAction(1, ActionTypeReduce, "shard-0", 100), false},
+		{"reduce channel", NewChannelAction(1, ActionTypeReduce, "ch-0"), false},
+		{"grow leader", NewLeaderAction(1, 2, ActionTypeGrow, "shard-0", 100, 1), false},
+		{"update leader", NewLeaderAction(1, 2, ActionTypeUpdate, "shard-0", 100, 1), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spy := &gateSpy{err: merr.WrapErrServiceUnavailable("not synced")}
+			ex := newTestExecutor(1)
+			ex.fileResourceGate = spy.gate
+
+			err := ex.checkFileResourceReady(tc.action)
+			if tc.consults {
+				assert.ErrorIs(t, err, merr.ErrServiceUnavailable)
+				assert.Equal(t, 1, spy.calls)
+				assert.Equal(t, []int64{1}, spy.nodes, "the gate must be asked about this executor's node")
+			} else {
+				assert.NoError(t, err, "only a grow that puts data on the node may be held back")
+				assert.Equal(t, 0, spy.calls, "the gate must not even be consulted")
+			}
+		})
+	}
+}
+
+// A held-back task must be deferred, not failed and not counted: it has to be
+// retriable, and it must not consume a slot of either execution pool while it
+// waits.
+func TestExecutorDefersAGrowActionRatherThanConsumingAPoolSlot(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	replica := newTestReplica(1000, 1)
+
+	t.Run("channel task", func(t *testing.T) {
+		spy := &gateSpy{err: merr.WrapErrServiceUnavailable("not synced")}
+		ex := newTestExecutor(1)
+		ex.fileResourceGate = spy.gate
+
+		task, err := NewChannelTask(ctx, 10*time.Second, testSource("test"), 1000, replica,
+			NewChannelAction(1, ActionTypeGrow, "ch-0"))
+		require.NoError(t, err)
+		task.SetID(1)
+
+		assert.False(t, ex.Execute(task, 0), "a node that is behind must not run the action")
+		assert.Equal(t, int32(0), ex.channelTaskNum.Load(),
+			"a deferred task must not hold a channel pool slot")
+		assert.Equal(t, int32(0), ex.nonChannelTaskNum.Load(),
+			"a deferred task must not hold a non-channel pool slot")
+		assert.False(t, ex.executingTasks.Contain(task.Index()),
+			"a deferred task must be retriable, so it must not stay marked as executing")
+		assert.NoError(t, task.Err(), "deferring is not failing")
+	})
+
+	t.Run("segment task", func(t *testing.T) {
+		spy := &gateSpy{err: merr.WrapErrServiceUnavailable("not synced")}
+		ex := newTestExecutor(1)
+		ex.fileResourceGate = spy.gate
+
+		task, err := NewSegmentTask(ctx, 10*time.Second, testSource("test"), 1000, replica, 0,
+			NewSegmentAction(1, ActionTypeGrow, "shard-0", 100))
+		require.NoError(t, err)
+		task.SetID(2)
+
+		assert.False(t, ex.Execute(task, 0))
+		assert.Equal(t, int32(0), ex.nonChannelTaskNum.Load())
+		assert.Equal(t, int32(0), ex.channelTaskNum.Load())
+		assert.False(t, ex.executingTasks.Contain(task.Index()))
+		assert.NoError(t, task.Err(), "deferring is not failing")
+	})
+}
+
+func TestExecutorGateIsHandedToEveryExecutorTheSchedulerCreates(t *testing.T) {
+	paramtable.Init()
+	spy := &gateSpy{}
+	scheduler := NewScheduler(context.Background(), nil, nil, nil, nil, nil, nil)
+	scheduler.SetFileResourceGate(spy.gate)
+
+	scheduler.AddExecutor(11)
+	scheduler.AddExecutor(12)
+	t.Cleanup(func() {
+		scheduler.RemoveExecutor(11)
+		scheduler.RemoveExecutor(12)
+	})
+
+	for _, nodeID := range []int64{11, 12} {
+		executor, ok := scheduler.executors.Get(nodeID)
+		require.True(t, ok)
+		require.NotNil(t, executor.fileResourceGate,
+			"an executor added after the gate was installed must carry it")
+		assert.NoError(t, executor.fileResourceGate(nodeID))
+	}
+	assert.Equal(t, []int64{11, 12}, spy.nodes)
+}
+
+func TestSchedulerWithoutGateLeavesItsExecutorsUngated(t *testing.T) {
+	paramtable.Init()
+	scheduler := NewScheduler(context.Background(), nil, nil, nil, nil, nil, nil)
+	scheduler.SetFileResourceGate(nil)
+
+	scheduler.AddExecutor(21)
+	t.Cleanup(func() { scheduler.RemoveExecutor(21) })
+
+	executor, ok := scheduler.executors.Get(21)
+	require.True(t, ok)
+	assert.Nil(t, executor.fileResourceGate,
+		"a stock binary must leave every executor on the native path")
+}

--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -581,6 +581,23 @@ type taskScheduler struct {
 
 	segmentTaskDelta *SegmentTaskDelta
 	channelTaskDelta *ChannelTaskDelta
+
+	// fileResourceGate holds grow actions back on a node whose analyzer file
+	// resources are behind. The coordinator installs it whenever the
+	// file-resource observer exists - which is every mixcoord deployment - so
+	// "native" here is not the gate being nil but the gate answering nil,
+	// which it does whenever no file resource is registered or query-node
+	// sync is off. It is handed to every executor this scheduler creates.
+	fileResourceGate NodeFileResourceGate
+}
+
+// SetFileResourceGate installs the gate the executors defer grow actions on.
+//
+// It is called once, before the scheduler starts and before any executor is
+// added, so that every executor sees the same gate. A nil gate leaves the
+// executors on the native path.
+func (scheduler *taskScheduler) SetFileResourceGate(gate NodeFileResourceGate) {
+	scheduler.fileResourceGate = gate
 }
 
 func NewScheduler(ctx context.Context,
@@ -644,6 +661,7 @@ func (scheduler *taskScheduler) AddExecutor(nodeID int64) {
 		scheduler.targetMgr,
 		scheduler.cluster,
 		scheduler.nodeMgr)
+	executor.fileResourceGate = scheduler.fileResourceGate
 
 	if _, exist := scheduler.executors.GetOrInsert(nodeID, executor); exist {
 		return


### PR DESCRIPTION
issue: #53031

Split out of #52500, which mixed these querycoord behaviors in with an extension mechanism they do not depend on. Other split-outs: #52716, #52717 (merged), #52981.

## Analyzer file resource barrier

Analyzer file resources are the dictionaries, stop-word lists and synonym files an analyzer needs on local disk. A query node becomes visible to querycoord when its session registers, which is earlier than its download finishes, so anything placed on it before then races that download — a segment carrying a BM25 field, or a channel whose delegator runs an analyzer over the growing data.

`CreateCollection` already waits for this: `validateAnalyzerInfos` retries `CheckAllQnReady` before validating the schema. But that only covers the nodes present at DDL time. A node that joins afterwards — scale-out, restart, rolling replacement — gets segments and channels through the checkers, with no load request anywhere to gate on. This closes that window.

- **The task executor defers a grow action** on a node whose resources are behind. Only grow, and only the two action types that put data on the node: reductions and leader updates stay unblocked, or a node that is behind could never be drained.
- **Deferral, not rejection.** The check runs before the pool counters are taken, so a held task does not occupy a slot; it stays queued for the scheduler to retry, exactly like the existing pool-full paths. It also does not arm the step deadline, so queueing does not eat into the RPC budget.
- **querycoord notifies the observer for rediscovered nodes.** Nodes already in the session directory never go through the session-add path, which is the only thing that natively triggers a sync — without this a node rediscovered on querycoord restart or an etcd reconnect would sit behind the gate until an unrelated event happened to notify the observer.
- **A node that does not implement the RPC is recorded as synced.** Otherwise the oldest node in a rolling upgrade would be gated forever. `grpcclient` maps gRPC `Unimplemented` to `merr.ErrServiceUnimplemented`, which is what the branch keys on.
- **Inert without file resources.** The gate answers nil whenever no file resource is registered or query-node sync is off, so a deployment that does not use analyzer file resources never reaches any of it.

The load path is deliberately **not** gated. Rejecting in `LoadCollection`/`LoadPartitions` was the wrong place — it read `s.meta.GetNodes`, which returns ResourceManager members and therefore excludes the query nodes embedded in streaming nodes, precisely the ones running analyzers — and the wrong verdict, since the executor gate already keeps data off an unsynced node.

## Removed from this PR: `STREAMING_NOQUERY` and the delegator fallback

An earlier revision of this PR also let a resource group declare that its streaming nodes serve no shard queries, so its delegators would go on regular query nodes instead. That change has been **dropped**, because it could not fire in the deployment it was written for.

Its trigger is "every streaming node of this resource group declares no-query-service". But the deployment that needs the fallback has *no streaming node in the resource group at all* — the streaming nodes sit outside the groups that serve queries. Such a group never enters the declared set, so the checker keeps waiting for a streaming node that will never appear, and the collection gets no delegator anywhere.

Two further problems found while reviewing it:

- With `streaming.strictResourceGroupIsolation.enabled` off (the default), a declared group's replicas become *uncovered* in `buildSQNodeAssignmentHelpers` and get pooled across resource groups — so they receive streaming query nodes belonging to a **different** group, which is both an isolation violation and the opposite of what the label asks for.
- The candidate's resource group was resolved from its session label, which is not where a regular query node's resource group lives: `ResourceManager` assigns unlabeled nodes to groups on its own and `AcceptNode` admits them to a non-default group. Deployments that build groups through the API resolved every such node to the default group. (Deployments that bind nodes with `MILVUS_SERVER_LABEL_QUERYNODE_RESOURCE_GROUP` are unaffected by this one.)

The underlying requirement — streaming nodes that own the WAL without serving shard queries, while queries run on separate resource groups — turns out to be satisfiable with configuration alone, no code change:

- label the WAL-owning streaming nodes into their own resource group and set `streaming.primaryResourceGroup` to it, so `balance()` restricts WAL placement to those nodes;
- give each query-serving resource group a streaming node of its own. It gets no WAL, but it is a valid streaming node, so the replicas of that group place their delegators on it and consume the WAL remotely — which is already what happens for every replica beyond the first, since only one delegator can sit on the node the WAL is located at.

So the fallback has no user. It is gone from this branch; only the analyzer file resource barrier above remains.

## Compatibility

- No proto change, no new configuration.
- Without analyzer file resources registered (or with query-node sync off) the gate answers nil and nothing is consulted.

## Testing

`executor_file_resource_test.go`, `file_resource_observer_test.go`. Covers: the gate off costing nothing; grow deferred and reductions not; a deferred task holding neither pool slot and staying retriable; the gate reaching every executor the scheduler creates.

`golangci-lint` clean on every touched package. `internal/querycoordv2/...`, `internal/coordinator/snmanager` and `internal/streamingnode/client/manager` pass. `internal/querycoordv2/session`'s `TestClusterSuite` hangs on this machine, including on an unmodified checkout of this branch — it blocks in `grpc.Dial(..., WithBlock())` with no deadline, unrelated to this change.

### Known gap, not addressed here

`AssignReplica` caps `replica_number` at the **global** streaming node count (`utils/meta.go:114`), described as a delegator-capacity check. That count is the wrong denominator once delegators are not necessarily one-per-streaming-node, but no current deployment is blocked by it, so it is left alone.
