### PR TITLE
enhance: [3.0] make growing interim index build thread num configurable

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -548,6 +548,13 @@ queryNode:
       denseVectorIndexType: IVF_FLAT_CC # Dense vector intermin index type
       memExpansionRate: 1.15 # extra memory needed by building interim index
       buildParallelRate: 0.5 # the ratio of building interim index parallel matched with cpu num
+      # The fraction of the interim index build thread pool that a single growing segment index build may use.
+      # The pool size is buildParallelRate * cpu num, so the thread number of one growing index build is
+      # buildParallelRate * cpu num * growingBuildThreadRate, at least 1.
+      # 0 by default, which keeps every growing index build single threaded.
+      # Note this only bounds a single build: multiple growing segments may still build concurrently, so the
+      # worst case thread number is the pool size multiplied by this resolved thread number.
+      growingBuildThreadRate: 0
     multipleChunkedEnable: true # Deprecated. Enable multiple chunked search
     enableGeometryCache: false # Enable geometry cache for geometry data
     enableGISSplitFusion: true # Enable GIS filter coarse/refine split + same-column fusion optimization

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -549,8 +549,10 @@ queryNode:
       memExpansionRate: 1.15 # extra memory needed by building interim index
       buildParallelRate: 0.5 # the ratio of building interim index parallel matched with cpu num
       # The fraction of the interim index build thread pool that a single growing segment index build may use.
-      # The pool size is buildParallelRate * cpu num, so the thread number of one growing index build is
-      # buildParallelRate * cpu num * growingBuildThreadRate, at least 1.
+      # The thread number of one growing index build is round(growingBuildThreadRate * build thread pool size),
+      # clamped to [1, pool size]. The pool size is buildParallelRate * cpu num on a QueryNode; in standalone
+      # the DataNode initializes the same process-global pool from common.buildIndexThreadPoolRatio instead,
+      # so the effective pool size there depends on which component initializes it last.
       # 0 by default, which keeps every growing index build single threaded.
       # Note this only bounds a single build: multiple growing segments may still build concurrently, so the
       # worst case thread number is the pool size multiplied by this resolved thread number.

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -548,15 +548,7 @@ queryNode:
       denseVectorIndexType: IVF_FLAT_CC # Dense vector intermin index type
       memExpansionRate: 1.15 # extra memory needed by building interim index
       buildParallelRate: 0.5 # the ratio of building interim index parallel matched with cpu num
-      # The fraction of the interim index build thread pool that a single growing segment index build may use.
-      # The thread number of one growing index build is round(growingBuildThreadRate * build thread pool size),
-      # clamped to [1, pool size]. The pool size is buildParallelRate * cpu num on a QueryNode; in standalone
-      # the DataNode initializes the same process-global pool from common.buildIndexThreadPoolRatio instead,
-      # so the effective pool size there depends on which component initializes it last.
-      # 0 by default, which keeps every growing index build single threaded.
-      # Note this only bounds a single build: multiple growing segments may still build concurrently, so the
-      # worst case thread number is the pool size multiplied by this resolved thread number.
-      growingBuildThreadRate: 0
+      growingBuildThreadRate: 0 # The ratio of the interim index build thread pool that one growing segment index build may use, resolved as round(rate * pool size) and clamped to [1, pool size]. 0 means single threaded
     multipleChunkedEnable: true # Deprecated. Enable multiple chunked search
     enableGeometryCache: false # Enable geometry cache for geometry data
     enableGISSplitFusion: true # Enable GIS filter coarse/refine split + same-column fusion optimization

--- a/internal/core/src/segcore/FieldIndexing.cpp
+++ b/internal/core/src/segcore/FieldIndexing.cpp
@@ -631,14 +631,10 @@ VectorFieldIndexing::AppendSegmentIndexDense(int64_t reserved_offset,
 
 int64_t
 VectorFieldIndexing::resolve_build_thread_num() const {
-    // A growing interim index build occupies one slot of the knowhere build
-    // thread pool and may fan out into `num_build_thread` OMP threads inside
-    // that slot. The pool is the cpu budget of index building, so the rate is
-    // resolved against its live size rather than against the cpu num directly.
-    // The result is clamped to [1, pool size]: knowhere declares
-    // `num_build_thread` without a range and hands it straight to
-    // `omp_set_num_threads`, and this config is refreshable, so an out of range
-    // value must not be able to reach that call.
+    // Resolved against the live build pool size, the cpu budget of index
+    // building. Clamped to [1, pool size] because knowhere declares
+    // num_build_thread without a range and passes it to omp_set_num_threads,
+    // and this config is refreshable.
     auto rate = segcore_config_.get_growing_index_build_thread_rate();
     if (!std::isfinite(rate) || rate <= 0.0f) {
         return 1;

--- a/internal/core/src/segcore/FieldIndexing.cpp
+++ b/internal/core/src/segcore/FieldIndexing.cpp
@@ -12,6 +12,7 @@
 #include <string.h>
 #include "common/FastMem.h"
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <exception>
 #include <map>
@@ -39,6 +40,7 @@
 #include "index/VectorIndexValidDataUtils.h"
 #include "index/VectorMemIndex.h"
 #include "knowhere/comp/index_param.h"
+#include "knowhere/comp/knowhere_config.h"
 #include "knowhere/dataset.h"
 #include "knowhere/expected.h"
 #include "knowhere/object.h"
@@ -627,13 +629,31 @@ VectorFieldIndexing::AppendSegmentIndexDense(int64_t reserved_offset,
     }
 }
 
+int64_t
+VectorFieldIndexing::resolve_build_thread_num() const {
+    // A growing interim index build occupies one slot of the knowhere build
+    // thread pool and may fan out into `num_build_thread` OMP threads inside
+    // that slot. The pool size (queryNode.segcore.interimIndex.buildParallelRate
+    // x cpu num) is the cpu budget of index building, so the rate is resolved
+    // against the live pool size rather than against the cpu num directly.
+    auto rate = segcore_config_.get_growing_index_build_thread_rate();
+    if (rate <= 0.0f) {
+        return 1;
+    }
+    auto pool_size =
+        static_cast<double>(knowhere::KnowhereConfig::GetBuildThreadPoolSize());
+    auto thread_num = static_cast<int64_t>(std::llround(rate * pool_size));
+    return std::max<int64_t>(thread_num, 1);
+}
+
 knowhere::Json
 VectorFieldIndexing::get_build_params(DataType data_type) const {
     auto config = config_->GetBuildBaseParams(data_type);
     if (!IsSparseFloatVectorDataType(get_data_type())) {
         config[knowhere::meta::DIM] = std::to_string(get_dim());
     }
-    config[knowhere::meta::NUM_BUILD_THREAD] = std::to_string(1);
+    config[knowhere::meta::NUM_BUILD_THREAD] =
+        std::to_string(resolve_build_thread_num());
     // for sparse float vector: drop_ratio_build config is not allowed to be set
     // on growing segment index.
     return config;

--- a/internal/core/src/segcore/FieldIndexing.cpp
+++ b/internal/core/src/segcore/FieldIndexing.cpp
@@ -633,17 +633,26 @@ int64_t
 VectorFieldIndexing::resolve_build_thread_num() const {
     // A growing interim index build occupies one slot of the knowhere build
     // thread pool and may fan out into `num_build_thread` OMP threads inside
-    // that slot. The pool size (queryNode.segcore.interimIndex.buildParallelRate
-    // x cpu num) is the cpu budget of index building, so the rate is resolved
-    // against the live pool size rather than against the cpu num directly.
+    // that slot. The pool is the cpu budget of index building, so the rate is
+    // resolved against its live size rather than against the cpu num directly.
+    // The result is clamped to [1, pool size]: knowhere declares
+    // `num_build_thread` without a range and hands it straight to
+    // `omp_set_num_threads`, and this config is refreshable, so an out of range
+    // value must not be able to reach that call.
     auto rate = segcore_config_.get_growing_index_build_thread_rate();
-    if (rate <= 0.0f) {
+    if (!std::isfinite(rate) || rate <= 0.0f) {
         return 1;
     }
-    auto pool_size =
-        static_cast<double>(knowhere::KnowhereConfig::GetBuildThreadPoolSize());
-    auto thread_num = static_cast<int64_t>(std::llround(rate * pool_size));
-    return std::max<int64_t>(thread_num, 1);
+    auto pool_size = static_cast<int64_t>(
+        knowhere::KnowhereConfig::GetBuildThreadPoolSize());
+    if (pool_size <= 1) {
+        return 1;
+    }
+    // Cap the rate before scaling so the product can never overflow llround.
+    auto capped_rate = std::min(static_cast<double>(rate), 1.0);
+    auto thread_num = static_cast<int64_t>(
+        std::llround(capped_rate * static_cast<double>(pool_size)));
+    return std::clamp<int64_t>(thread_num, 1, pool_size);
 }
 
 knowhere::Json

--- a/internal/core/src/segcore/FieldIndexing.h
+++ b/internal/core/src/segcore/FieldIndexing.h
@@ -353,6 +353,11 @@ class VectorFieldIndexing : public FieldIndexing {
     void
     DisableIndexAfterBuildFailure();
 
+    // Number of threads a single growing index build/add may use, derived from
+    // queryNode.segcore.interimIndex.growingBuildThreadRate.
+    int64_t
+    resolve_build_thread_num() const;
+
     // current number of rows in index.
     std::atomic<idx_t> index_cur_ = 0;
     // whether the growing index has been built.

--- a/internal/core/src/segcore/SegcoreConfig.h
+++ b/internal/core/src/segcore/SegcoreConfig.h
@@ -133,6 +133,21 @@ class SegcoreConfig {
         return build_ratio_;
     }
 
+    // Fraction of the knowhere build thread pool that a single growing
+    // segment interim index build may use
+    // (queryNode.segcore.interimIndex.growingBuildThreadRate). 0 keeps the
+    // build single threaded, which is the legacy behavior. Resolved against
+    // the live pool size in VectorFieldIndexing::get_build_params.
+    void
+    set_growing_index_build_thread_rate(float rate) {
+        growing_index_build_thread_rate_.store(rate);
+    }
+
+    float
+    get_growing_index_build_thread_rate() const {
+        return growing_index_build_thread_rate_.load();
+    }
+
     int64_t
     get_refine_ratio() const {
         return refine_ratio_;
@@ -273,6 +288,7 @@ class SegcoreConfig {
     inline static int64_t sub_dim_ = 2;
     inline static float refine_ratio_ = 3.0;
     inline static float build_ratio_ = 0.1;
+    inline static std::atomic<float> growing_index_build_thread_rate_{0.0f};
     inline static std::string dense_index_type_ =
         knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC;
     inline static knowhere::RefineType refine_type_ =

--- a/internal/core/src/segcore/SegmentGrowingIndexTest.cpp
+++ b/internal/core/src/segcore/SegmentGrowingIndexTest.cpp
@@ -37,6 +37,7 @@
 #include "index/IndexInfo.h"
 #include "index/VectorMemIndex.h"
 #include "knowhere/comp/index_param.h"
+#include "knowhere/comp/knowhere_config.h"
 #include "knowhere/dataset.h"
 #include "knowhere/expected.h"
 #include "knowhere/object.h"
@@ -706,6 +707,156 @@ TEST_P(GrowingIndexTest, AddWithoutBuildPool) {
         EXPECT_EQ(index->Count(), (add_cont + 1) * N);
     } else {
         throw std::invalid_argument("Unsupported data type");
+    }
+}
+
+TEST(GrowingIndexBuildThreadRateTest, ResolvedAgainstBuildThreadPoolSize) {
+    constexpr int64_t dim = 4;
+    auto schema = std::make_shared<Schema>();
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    auto vec = schema->AddDebugField(
+        "embeddings", DataType::VECTOR_FLOAT, dim, knowhere::metric::L2);
+    schema->set_primary_field_id(pk);
+
+    std::map<std::string, std::string> index_params = {
+        {"index_type", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT},
+        {"metric_type", knowhere::metric::L2},
+        {"nlist", "128"}};
+    std::map<std::string, std::string> type_params = {
+        {"dim", std::to_string(dim)}};
+    FieldIndexMeta field_index_meta(
+        vec, std::move(index_params), std::move(type_params));
+    std::map<FieldId, FieldIndexMeta> field_map = {{vec, field_index_meta}};
+    IndexMetaPtr meta_ptr =
+        std::make_shared<CollectionIndexMeta>(226985, std::move(field_map));
+
+    auto& config = SegcoreConfig::default_config();
+    ScopedSegcoreConfigRestore config_restore(config);
+    InterimIndexConfigForTest interim_config;
+    interim_config.chunk_rows = 1024;
+    ApplyInterimIndexConfigForTest(interim_config, config);
+
+    auto segment = CreateGrowingSegment(schema, meta_ptr);
+    auto* growing_segment = dynamic_cast<SegmentGrowingImpl*>(segment.get());
+    ASSERT_NE(growing_segment, nullptr);
+    const auto& indexing =
+        growing_segment->get_indexing_record().get_vec_field_indexing(vec);
+
+    const auto pool_size = static_cast<int64_t>(
+        knowhere::KnowhereConfig::GetBuildThreadPoolSize());
+    ASSERT_GT(pool_size, 0);
+
+    auto build_thread_num = [&]() {
+        auto params = indexing.get_build_params(DataType::VECTOR_FLOAT);
+        return std::stoll(
+            params[knowhere::meta::NUM_BUILD_THREAD].get<std::string>());
+    };
+
+    // 0 is the default and keeps every growing index build single threaded.
+    config.set_growing_index_build_thread_rate(0.0F);
+    EXPECT_EQ(build_thread_num(), 1);
+
+    // The rate is a fraction of the build thread pool size, not of cpu num.
+    config.set_growing_index_build_thread_rate(1.0F);
+    EXPECT_EQ(build_thread_num(), pool_size);
+
+    // A rate too small to reach a whole thread still resolves to one thread.
+    config.set_growing_index_build_thread_rate(
+        1.0F / static_cast<float>(pool_size * 8));
+    EXPECT_EQ(build_thread_num(), 1);
+}
+
+TEST(GrowingIndexBuildThreadRateTest, MultiThreadedBuildKeepsSearchCorrect) {
+    constexpr int64_t dim = 16;
+    constexpr int64_t per_batch = 10000;
+    constexpr int64_t n_batch = 3;
+    constexpr int64_t top_k = 5;
+    constexpr int64_t num_queries = 5;
+
+    auto build_and_search = [&](float build_thread_rate) {
+        auto schema = std::make_shared<Schema>();
+        auto pk = schema->AddDebugField("pk", DataType::INT64);
+        auto vec = schema->AddDebugField(
+            "embeddings", DataType::VECTOR_FLOAT, dim, knowhere::metric::L2);
+        schema->set_primary_field_id(pk);
+
+        std::map<std::string, std::string> index_params = {
+            {"index_type", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT},
+            {"metric_type", knowhere::metric::L2},
+            {"nlist", "128"}};
+        std::map<std::string, std::string> type_params = {
+            {"dim", std::to_string(dim)}};
+        FieldIndexMeta field_index_meta(
+            vec, std::move(index_params), std::move(type_params));
+        std::map<FieldId, FieldIndexMeta> field_map = {{vec, field_index_meta}};
+        IndexMetaPtr meta_ptr =
+            std::make_shared<CollectionIndexMeta>(226985, std::move(field_map));
+
+        auto& config = SegcoreConfig::default_config();
+        ScopedSegcoreConfigRestore config_restore(config);
+        InterimIndexConfigForTest interim_config;
+        interim_config.chunk_rows = 1024;
+        // Scan every inverted list so that the compared distances are exact and
+        // independent of how the coarse quantizer happens to be trained.
+        interim_config.nprobe = interim_config.nlist;
+        interim_config.growing_index_build_thread_rate = build_thread_rate;
+        ApplyInterimIndexConfigForTest(interim_config, config);
+
+        auto segment = CreateGrowingSegment(schema, meta_ptr);
+
+        milvus::proto::plan::PlanNode plan_node;
+        auto* vector_anns = plan_node.mutable_vector_anns();
+        vector_anns->set_vector_type(
+            milvus::proto::plan::VectorType::FloatVector);
+        vector_anns->set_placeholder_tag("$0");
+        vector_anns->set_field_id(vec.get());
+        auto* query_info = vector_anns->mutable_query_info();
+        query_info->set_topk(top_k);
+        query_info->set_round_decimal(3);
+        query_info->set_metric_type(knowhere::metric::L2);
+        query_info->set_search_params(R"({})");
+        auto plan_str = plan_node.SerializeAsString();
+
+        for (int64_t i = 0; i < n_batch; i++) {
+            auto dataset = DataGen(schema, per_batch, 42 + i);
+            auto offset = segment->PreInsert(per_batch);
+            segment->Insert(offset,
+                            per_batch,
+                            dataset.row_ids_.data(),
+                            dataset.timestamps_.data(),
+                            dataset.raw_);
+        }
+
+        // Guard against a vacuous comparison: if the interim index were never
+        // built, both runs would fall back to brute force and match trivially.
+        auto* growing_segment =
+            dynamic_cast<SegmentGrowingImpl*>(segment.get());
+        EXPECT_NE(growing_segment, nullptr);
+        EXPECT_TRUE(
+            growing_segment != nullptr &&
+            growing_segment->get_indexing_record().SyncDataWithIndex(vec));
+
+        auto ph_group_raw = CreatePlaceholderGroup(num_queries, dim, 1024);
+        auto plan = milvus::query::CreateSearchPlanByExpr(
+            schema, plan_str.data(), plan_str.size());
+        auto ph_group =
+            ParsePlaceholderGroup(plan.get(), ph_group_raw.SerializeAsString());
+        auto sr = segment->Search(plan.get(), ph_group.get(), 1000000);
+        EXPECT_EQ(sr->total_nq_, num_queries);
+        EXPECT_EQ(sr->unity_topK_, top_k);
+        EXPECT_EQ(sr->distances_.size(), num_queries * top_k);
+        return sr->distances_;
+    };
+
+    // A growing index built with the whole build thread pool must return the
+    // same results as the single threaded build: IVF_FLAT_CC partitions the
+    // inverted lists across the OMP threads, so parallelism must not drop or
+    // duplicate any row.
+    auto single_threaded = build_and_search(0.0F);
+    auto multi_threaded = build_and_search(1.0F);
+    ASSERT_EQ(single_threaded.size(), multi_threaded.size());
+    for (size_t i = 0; i < single_threaded.size(); i++) {
+        EXPECT_FLOAT_EQ(single_threaded[i], multi_threaded[i]);
     }
 }
 

--- a/internal/core/src/segcore/SegmentGrowingIndexTest.cpp
+++ b/internal/core/src/segcore/SegmentGrowingIndexTest.cpp
@@ -16,6 +16,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <map>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -763,6 +764,22 @@ TEST(GrowingIndexBuildThreadRateTest, ResolvedAgainstBuildThreadPoolSize) {
     // A rate too small to reach a whole thread still resolves to one thread.
     config.set_growing_index_build_thread_rate(
         1.0F / static_cast<float>(pool_size * 8));
+    EXPECT_EQ(build_thread_num(), 1);
+
+    // knowhere declares num_build_thread without a range and passes it straight
+    // to omp_set_num_threads, and this config is refreshable, so an out of range
+    // rate must be clamped to the pool size rather than reach that call.
+    config.set_growing_index_build_thread_rate(8.0F);
+    EXPECT_EQ(build_thread_num(), pool_size);
+
+    // Non-finite values must not reach llround or knowhere either.
+    config.set_growing_index_build_thread_rate(
+        std::numeric_limits<float>::infinity());
+    EXPECT_EQ(build_thread_num(), 1);
+    config.set_growing_index_build_thread_rate(
+        std::numeric_limits<float>::quiet_NaN());
+    EXPECT_EQ(build_thread_num(), 1);
+    config.set_growing_index_build_thread_rate(-1.0F);
     EXPECT_EQ(build_thread_num(), 1);
 }
 

--- a/internal/core/src/segcore/segcore_init_c.cpp
+++ b/internal/core/src/segcore/segcore_init_c.cpp
@@ -220,6 +220,13 @@ SegcoreSetIndexBuildRatio(const float value) {
 }
 
 extern "C" void
+SegcoreSetGrowingIndexBuildThreadRate(const float value) {
+    milvus::segcore::SegcoreConfig& config =
+        milvus::segcore::SegcoreConfig::default_config();
+    config.set_growing_index_build_thread_rate(value);
+}
+
+extern "C" void
 SegcoreSetKnowhereBuildThreadPoolNum(const uint32_t num_threads) {
     milvus::config::KnowhereInitBuildThreadPool(num_threads);
 }

--- a/internal/core/src/segcore/segcore_init_c.h
+++ b/internal/core/src/segcore/segcore_init_c.h
@@ -62,6 +62,9 @@ SegcoreSetRefineRatio(const float);
 void
 SegcoreSetIndexBuildRatio(const float);
 
+void
+SegcoreSetGrowingIndexBuildThreadRate(const float);
+
 CStatus
 SegcoreSetDenseVectorInterminIndexRefineQuantType(const char*);
 

--- a/internal/core/unittest/test_utils/SegcoreConfigUtils.h
+++ b/internal/core/unittest/test_utils/SegcoreConfigUtils.h
@@ -57,7 +57,9 @@ class ScopedSegcoreConfigRestore {
               config.get_dense_vector_intermin_index_type()),
           refine_quant_type_(
               RefineTypeToConfigStringForTest(config.get_refine_quant_type())),
-          refine_with_quant_flag_(config.get_refine_with_quant_flag()) {
+          refine_with_quant_flag_(config.get_refine_with_quant_flag()),
+          growing_index_build_thread_rate_(
+              config.get_growing_index_build_thread_rate()) {
     }
 
     ~ScopedSegcoreConfigRestore() {
@@ -74,6 +76,8 @@ class ScopedSegcoreConfigRestore {
             dense_vector_interim_index_type_);
         config_.set_refine_quant_type(refine_quant_type_);
         config_.set_refine_with_quant_flag(refine_with_quant_flag_);
+        config_.set_growing_index_build_thread_rate(
+            growing_index_build_thread_rate_);
     }
 
     ScopedSegcoreConfigRestore(const ScopedSegcoreConfigRestore&) = delete;
@@ -94,6 +98,7 @@ class ScopedSegcoreConfigRestore {
     std::string dense_vector_interim_index_type_;
     std::string refine_quant_type_;
     bool refine_with_quant_flag_;
+    float growing_index_build_thread_rate_;
 };
 
 struct InterimIndexConfigForTest {
@@ -107,6 +112,7 @@ struct InterimIndexConfigForTest {
     float refine_ratio = 3.0F;
     std::string refine_quant_type = "NONE";
     bool refine_with_quant_flag = false;
+    float growing_index_build_thread_rate = 0.0F;
 };
 
 inline void
@@ -119,6 +125,8 @@ ApplyInterimIndexConfigForTest(
     config.set_interim_index_target_version(options.target_index_version);
     config.set_nlist(options.nlist);
     config.set_nprobe(options.nprobe);
+    config.set_growing_index_build_thread_rate(
+        options.growing_index_build_thread_rate);
     if (options.dense_vector_interim_index_type.has_value()) {
         config.set_dense_vector_intermin_index_type(
             options.dense_vector_interim_index_type.value());

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -779,6 +779,15 @@ func SetupCoreConfigChangelCallback() {
 			return nil
 		})
 
+		paramtable.Get().QueryNodeCfg.InterimIndexGrowingBuildThreadRate.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
+			rate, err := strconv.ParseFloat(newValue, 32)
+			if err != nil {
+				return err
+			}
+			C.SegcoreSetGrowingIndexBuildThreadRate(C.float(rate))
+			return nil
+		})
+
 		paramtable.Get().QueryNodeCfg.ExprResCacheEnabled.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
 			enable, err := strconv.ParseBool(newValue)
 			if err != nil {
@@ -846,6 +855,9 @@ func InitInterminIndexConfig(params *paramtable.ComponentParam) error {
 
 	indexBuildRatio := C.float(params.QueryNodeCfg.InterimIndexBuildRatio.GetAsFloat())
 	C.SegcoreSetIndexBuildRatio(indexBuildRatio)
+
+	growingBuildThreadRate := C.float(params.QueryNodeCfg.InterimIndexGrowingBuildThreadRate.GetAsFloat())
+	C.SegcoreSetGrowingIndexBuildThreadRate(growingBuildThreadRate)
 
 	denseVecIndexType := C.CString(params.QueryNodeCfg.DenseVectorInterminIndexType.GetValue())
 	defer C.free(unsafe.Pointer(denseVecIndexType))

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -32,6 +32,7 @@ import "C"
 import (
 	"context"
 	"encoding/base64"
+	"math"
 	"strconv"
 	"strings"
 	"sync"
@@ -783,6 +784,12 @@ func SetupCoreConfigChangelCallback() {
 			rate, err := strconv.ParseFloat(newValue, 32)
 			if err != nil {
 				return err
+			}
+			// ParseFloat accepts "Inf" and "NaN"; reject them here so the
+			// operator gets an error instead of a silently clamped value.
+			if math.IsNaN(rate) || math.IsInf(rate, 0) || rate < 0 {
+				return merr.WrapErrParameterInvalidMsg(
+					"%s must be a finite non-negative number, got %s", key, newValue)
 			}
 			C.SegcoreSetGrowingIndexBuildThreadRate(C.float(rate))
 			return nil

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3721,24 +3721,25 @@ type queryNodeConfig struct {
 	StatsPublishInterval ParamItem `refreshable:"true"`
 
 	// segcore
-	KnowhereFetchThreadPoolSize    ParamItem `refreshable:"true"`
-	KnowhereThreadPoolSize         ParamItem `refreshable:"true"`
-	ChunkRows                      ParamItem `refreshable:"false"`
-	EnableInterminSegmentIndex     ParamItem `refreshable:"false"`
-	InterimIndexNlist              ParamItem `refreshable:"false"`
-	InterimIndexNProbe             ParamItem `refreshable:"false"`
-	InterimIndexSubDim             ParamItem `refreshable:"false"`
-	InterimIndexRefineRatio        ParamItem `refreshable:"false"`
-	InterimIndexBuildRatio         ParamItem `refreshable:"false"`
-	InterimIndexRefineQuantType    ParamItem `refreshable:"false"`
-	InterimIndexRefineWithQuant    ParamItem `refreshable:"false"`
-	DenseVectorInterminIndexType   ParamItem `refreshable:"false"`
-	InterimIndexMemExpandRate      ParamItem `refreshable:"false"`
-	InterimIndexBuildParallelRate  ParamItem `refreshable:"false"`
-	InterimIndexTargetIndexVersion ParamItem `refreshable:"false"`
-	MultipleChunkedEnable          ParamItem `refreshable:"false"` // Deprecated
-	EnableGeometryCache            ParamItem `refreshable:"false"`
-	EnableGISSplitFusion           ParamItem `refreshable:"false"`
+	KnowhereFetchThreadPoolSize        ParamItem `refreshable:"true"`
+	KnowhereThreadPoolSize             ParamItem `refreshable:"true"`
+	ChunkRows                          ParamItem `refreshable:"false"`
+	EnableInterminSegmentIndex         ParamItem `refreshable:"false"`
+	InterimIndexNlist                  ParamItem `refreshable:"false"`
+	InterimIndexNProbe                 ParamItem `refreshable:"false"`
+	InterimIndexSubDim                 ParamItem `refreshable:"false"`
+	InterimIndexRefineRatio            ParamItem `refreshable:"false"`
+	InterimIndexBuildRatio             ParamItem `refreshable:"false"`
+	InterimIndexRefineQuantType        ParamItem `refreshable:"false"`
+	InterimIndexRefineWithQuant        ParamItem `refreshable:"false"`
+	DenseVectorInterminIndexType       ParamItem `refreshable:"false"`
+	InterimIndexMemExpandRate          ParamItem `refreshable:"false"`
+	InterimIndexBuildParallelRate      ParamItem `refreshable:"false"`
+	InterimIndexGrowingBuildThreadRate ParamItem `refreshable:"true"`
+	InterimIndexTargetIndexVersion     ParamItem `refreshable:"false"`
+	MultipleChunkedEnable              ParamItem `refreshable:"false"` // Deprecated
+	EnableGeometryCache                ParamItem `refreshable:"false"`
+	EnableGISSplitFusion               ParamItem `refreshable:"false"`
 
 	TieredWarmupScalarField         ParamItem `refreshable:"true"`
 	TieredWarmupScalarIndex         ParamItem `refreshable:"true"`
@@ -4427,6 +4428,20 @@ This defaults to true, indicating that Milvus creates temporary index for growin
 		Export:       true,
 	}
 	p.InterimIndexBuildParallelRate.Init(base.mgr)
+
+	p.InterimIndexGrowingBuildThreadRate = ParamItem{
+		Key:          "queryNode.segcore.interimIndex.growingBuildThreadRate",
+		Version:      "3.0.1",
+		DefaultValue: "0",
+		Doc: `The fraction of the interim index build thread pool that a single growing segment index build may use.
+The pool size is buildParallelRate * cpu num, so the thread number of one growing index build is
+buildParallelRate * cpu num * growingBuildThreadRate, at least 1.
+0 by default, which keeps every growing index build single threaded.
+Note this only bounds a single build: multiple growing segments may still build concurrently, so the
+worst case thread number is the pool size multiplied by this resolved thread number.`,
+		Export: true,
+	}
+	p.InterimIndexGrowingBuildThreadRate.Init(base.mgr)
 
 	p.InterimIndexTargetIndexVersion = ParamItem{
 		Key:          "queryNode.segcore.interimIndex.targetIndexVersion",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4433,15 +4433,8 @@ This defaults to true, indicating that Milvus creates temporary index for growin
 		Key:          "queryNode.segcore.interimIndex.growingBuildThreadRate",
 		Version:      "3.0.1",
 		DefaultValue: "0",
-		Doc: `The fraction of the interim index build thread pool that a single growing segment index build may use.
-The thread number of one growing index build is round(growingBuildThreadRate * build thread pool size),
-clamped to [1, pool size]. The pool size is buildParallelRate * cpu num on a QueryNode; in standalone the
-DataNode initializes the same process-global pool from common.buildIndexThreadPoolRatio instead, so the
-effective pool size there depends on which component initializes it last.
-0 by default, which keeps every growing index build single threaded.
-Note this only bounds a single build: multiple growing segments may still build concurrently, so the
-worst case thread number is the pool size multiplied by this resolved thread number.`,
-		Export: true,
+		Doc:          "The ratio of the interim index build thread pool that one growing segment index build may use, resolved as round(rate * pool size) and clamped to [1, pool size]. 0 means single threaded",
+		Export:       true,
 	}
 	p.InterimIndexGrowingBuildThreadRate.Init(base.mgr)
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4434,8 +4434,10 @@ This defaults to true, indicating that Milvus creates temporary index for growin
 		Version:      "3.0.1",
 		DefaultValue: "0",
 		Doc: `The fraction of the interim index build thread pool that a single growing segment index build may use.
-The pool size is buildParallelRate * cpu num, so the thread number of one growing index build is
-buildParallelRate * cpu num * growingBuildThreadRate, at least 1.
+The thread number of one growing index build is round(growingBuildThreadRate * build thread pool size),
+clamped to [1, pool size]. The pool size is buildParallelRate * cpu num on a QueryNode; in standalone the
+DataNode initializes the same process-global pool from common.buildIndexThreadPoolRatio instead, so the
+effective pool size there depends on which component initializes it last.
 0 by default, which keeps every growing index build single threaded.
 Note this only bounds a single build: multiple growing segments may still build concurrently, so the
 worst case thread number is the pool size multiplied by this resolved thread number.`,

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -576,6 +576,14 @@ func TestComponentParam(t *testing.T) {
 		nprobe := Params.InterimIndexNProbe.GetAsInt64()
 		assert.Equal(t, int64(16), nprobe)
 
+		assert.Equal(t, 0.5, Params.InterimIndexBuildParallelRate.GetAsFloat())
+		// growingBuildThreadRate defaults to 0, which keeps growing index build single threaded.
+		assert.Equal(t, 0.0, Params.InterimIndexGrowingBuildThreadRate.GetAsFloat())
+		params.Save(Params.InterimIndexGrowingBuildThreadRate.Key, "0.25")
+		assert.Equal(t, 0.25, Params.InterimIndexGrowingBuildThreadRate.GetAsFloat())
+		params.Reset(Params.InterimIndexGrowingBuildThreadRate.Key)
+		assert.Equal(t, 0.0, Params.InterimIndexGrowingBuildThreadRate.GetAsFloat())
+
 		// enableGISSplitFusion defaults to true: the GIS coarse/refine split and
 		// same-column fusion rewrite is on unless explicitly disabled.
 		assert.True(t, Params.EnableGISSplitFusion.GetAsBool())


### PR DESCRIPTION
## Summary

Cherry-pick of #53030 to 3.0.

`VectorFieldIndexing::get_build_params` hard codes `knowhere::meta::NUM_BUILD_THREAD` to `1`, and that
config object is shared by every `BuildWithDataset` / `AddWithDataset` call of the growing interim index,
so a growing index build always runs single threaded.

This adds `queryNode.segcore.interimIndex.growingBuildThreadRate` to make that thread number configurable.
The rate is a fraction of the interim index build thread pool, whose size is already
`buildParallelRate * cpu num`:

```
thread num of one growing index build = max(1, round(buildParallelRate * cpuNum * growingBuildThreadRate))
```

The default `0` resolves to 1 thread, so the default behavior is unchanged. The parameter is refreshable
and takes effect on the next build. The sealed segment interim index is deliberately left at a single
thread.

This bounds a single build only. Growing segments may still build concurrently, each taking one slot of
the build thread pool, so the worst case thread number is the pool size multiplied by the resolved
per-build thread number, as the config doc states. Bounding the aggregate needs a separate concurrency
gate and is left as follow-up.

### Conflict resolution

The cherry-pick conflicted because master has `fmindex_cost_ratio` in `SegcoreConfig` and a
`GrowingIndexNullableVectorTest` case that 3.0 does not. Only the additions belonging to this change were
kept; no master-only symbol was pulled in.

### Verification on this branch

- C++ build: clean.
- `all_tests --gtest_filter=*GrowingIndexBuildThreadRate*`: 2/2 pass.
- `all_tests --gtest_filter=*GrowingIndex*:*Segcore*:*Interim*`: 114/114 pass.
- `go test ./pkg/util/paramtable/ -run TestComponentParam`: pass.

issue: #53029
pr: #53030
