### PR TITLE
fix: use element ID space for StructArray vector indexes

### DIFF
--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -46,6 +46,7 @@
 #include "knowhere/binaryset.h"
 #include "knowhere/comp/index_param.h"
 #include "knowhere/dataset.h"
+#include "knowhere/emb_list_utils.h"
 #include "knowhere/index/index_factory.h"
 #include "log/Log.h"
 #include "nlohmann/json.hpp"
@@ -455,7 +456,12 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
     auto index_lease =
         file_manager_->AcquireLocalDirWriteLease(local_index_path_prefix);
     auto valid_data_path = local_index_path_prefix + "/" + VALID_DATA_KEY;
-    config_with_emb_list[VALID_DATA_PATH_KEY] = valid_data_path;
+    const bool use_element_id_space =
+        elem_type_ != DataType::NONE &&
+        !knowhere::get_el_metric_type(GetMetricType()).has_value();
+    if (!use_element_id_space) {
+        config_with_emb_list[VALID_DATA_PATH_KEY] = valid_data_path;
+    }
 
     auto local_data_path =
         file_manager_->CacheRawDataToDisk<T>(config_with_emb_list);
@@ -613,6 +619,20 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
     auto index_lease =
         file_manager_->AcquireLocalDirWriteLease(local_index_path_prefix);
     build_config[DISK_ANN_PREFIX_PATH] = local_index_path_prefix;
+
+    const bool use_element_id_space =
+        elem_type_ != DataType::NONE &&
+        !knowhere::get_el_metric_type(GetMetricType()).has_value();
+    const auto parent_id_map_data =
+        dataset == nullptr ? knowhere::IdMapData{} : dataset->GetIdMapData();
+    if (use_element_id_space && parent_id_map_data.HasValue()) {
+        dataset->ClearIdMapData();
+    }
+    Defer restore_parent_id_map([&]() {
+        if (use_element_id_space && parent_id_map_data.HasValue()) {
+            dataset->SetIdMapData(parent_id_map_data);
+        }
+    });
 
     if (dataset != nullptr && dataset->HasIdMapData() &&
         !index_.GetIdMap().IsEnabled()) {

--- a/internal/core/src/index/VectorMemIndex.cpp
+++ b/internal/core/src/index/VectorMemIndex.cpp
@@ -499,6 +499,20 @@ VectorMemIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
     knowhere::Json index_config;
     index_config.update(config);
 
+    const bool use_element_id_space =
+        elem_type_ != DataType::NONE &&
+        !knowhere::get_el_metric_type(GetMetricType()).has_value();
+    const auto parent_id_map_data =
+        dataset == nullptr ? knowhere::IdMapData{} : dataset->GetIdMapData();
+    if (use_element_id_space && parent_id_map_data.HasValue()) {
+        dataset->ClearIdMapData();
+    }
+    Defer restore_parent_id_map([&]() {
+        if (use_element_id_space && parent_id_map_data.HasValue()) {
+            dataset->SetIdMapData(parent_id_map_data);
+        }
+    });
+
     if (dataset != nullptr && dataset->HasIdMapData() &&
         !index_.GetIdMap().IsEnabled()) {
         index_.GetIdMap().SetType(knowhere::IdMap::Type::SEALED);
@@ -586,7 +600,12 @@ VectorMemIndex<T>::Build(const Config& config) {
         if (is_sparse) {
             dataset->SetIsSparse(true);
         }
-        if (nullable) {
+        const bool use_element_id_space =
+            elem_type_ != DataType::NONE &&
+            !knowhere::get_el_metric_type(GetMetricType()).has_value();
+        // Element-level vector-array indexes use flattened element IDs. Null
+        // parent rows contribute no elements, so their IdMap is not applicable.
+        if (nullable && !use_element_id_space) {
             dataset->SetIdMapData(knowhere::IdMapData::FromValidData(
                 valid_data.get(), static_cast<size_t>(total_num_rows)));
         }

--- a/internal/core/unittest/test_indexing.cpp
+++ b/internal/core/unittest/test_indexing.cpp
@@ -900,6 +900,94 @@ TEST(Indexing, HnswEmbListEmptyNullableUsesLogicalIds) {
     EXPECT_ANY_THROW(vec_index->GetEmbListByIds(null_ids_ds, metric_type));
 }
 
+TEST(Indexing, HnswStructSubFieldUsesElementIdSpace) {
+    constexpr int64_t row_count = 4;
+    constexpr int64_t vectors_per_row = 2;
+    constexpr int64_t dim = DIM;
+    constexpr int64_t field_id = 100;
+    const auto metric_type = knowhere::metric::COSINE;
+
+    auto schema = std::make_shared<Schema>();
+    auto pk_field = schema->AddDebugField("pk", DataType::INT64);
+    auto vector_field = schema->AddDebugVectorArrayField(
+        "emb", DataType::VECTOR_FLOAT, dim, metric_type);
+    schema->set_primary_field_id(pk_field);
+    auto dataset = DataGen(schema, row_count, 42, 0, 1, vectors_per_row);
+
+    auto field_data = storage::CreateFieldData(
+        DataType::VECTOR_ARRAY, DataType::VECTOR_FLOAT, true, dim);
+    auto vector_protos = dataset.get_col<VectorFieldProto>(vector_field);
+    std::vector<milvus::VectorArray> vector_arrays;
+    vector_arrays.reserve(vector_protos.size());
+    for (const auto& vector_proto : vector_protos) {
+        vector_arrays.emplace_back(vector_proto);
+    }
+    auto valid_data = MakeValidBitmap(row_count, true);
+    field_data->FillFieldData(
+        vector_arrays.data(), valid_data.data(), row_count, 0);
+
+    auto storage_config = get_default_local_storage_config();
+    auto chunk_manager = storage::CreateChunkManager(storage_config);
+    auto fs = milvus::storage::InitArrowFileSystem(storage_config);
+    auto field_data_meta =
+        milvus::segcore::gen_field_meta(1,
+                                        2,
+                                        3,
+                                        field_id,
+                                        DataType::VECTOR_ARRAY,
+                                        DataType::VECTOR_FLOAT,
+                                        true);
+    auto log_path =
+        WriteInsertBinlog(field_data, field_data_meta, chunk_manager, 0);
+    milvus::storage::IndexMeta index_meta{3, field_id, 1000, 1};
+    index_meta.field_type = DataType::VECTOR_ARRAY;
+    index_meta.dim = dim;
+    milvus::storage::FileManagerContext file_manager_context(
+        field_data_meta, index_meta, chunk_manager, fs);
+
+    milvus::index::CreateIndexInfo create_index_info;
+    create_index_info.index_type = knowhere::IndexEnum::INDEX_HNSW;
+    create_index_info.metric_type = metric_type;
+    create_index_info.field_type = DataType::VECTOR_ARRAY;
+    create_index_info.index_engine_version =
+        knowhere::Version::GetCurrentVersion().VersionNumber();
+    auto index = milvus::index::IndexFactory::GetInstance().CreateIndex(
+        create_index_info, file_manager_context);
+
+    Config build_conf;
+    build_conf[milvus::index::INDEX_TYPE] = knowhere::IndexEnum::INDEX_HNSW;
+    build_conf[INSERT_FILES_KEY] = std::vector<std::string>{log_path};
+    build_conf[knowhere::meta::METRIC_TYPE] = metric_type;
+    build_conf[knowhere::indexparam::M] = "16";
+    build_conf[knowhere::indexparam::EF] = "10";
+    build_conf[DIM_KEY] = dim;
+    ASSERT_NO_THROW(index->Build(build_conf));
+
+    auto* vec_index = dynamic_cast<milvus::index::VectorIndex*>(index.get());
+    ASSERT_NE(vec_index, nullptr);
+    const auto element_count = row_count * vectors_per_row;
+    EXPECT_EQ(vec_index->Count(), element_count);
+    EXPECT_FALSE(vec_index->HasValidData());
+
+    std::vector<float> query(dim, 0.0F);
+    query[0] = 1.0F;
+    auto query_dataset = knowhere::GenDataSet(1, dim, query.data());
+    TargetBitmap excluded(element_count, false);
+    SearchInfo search_info;
+    search_info.topk_ = 1;
+    search_info.metric_type_ = metric_type;
+    search_info.search_params_ = Config{
+        {knowhere::meta::METRIC_TYPE, metric_type},
+        {knowhere::indexparam::EF, 10},
+    };
+    SearchResult result;
+    ASSERT_NO_THROW(vec_index->Query(
+        query_dataset, search_info, BitsetView(excluded), nullptr, result));
+    ASSERT_EQ(result.seg_offsets_.size(), 1);
+    EXPECT_GE(result.seg_offsets_[0], 0);
+    EXPECT_LT(result.seg_offsets_[0], element_count);
+}
+
 TEST(Indexing, HnswEmbListBuildAllNullNullableFromBinlog) {
     constexpr int64_t row_count = 8;
     constexpr int64_t dim = DIM;

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
@@ -3036,6 +3036,135 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
             assert_profile_equal(row[STRUCT_FIELD], expected[STRUCT_FIELD])
 
     @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.parametrize(
+        "index_type,index_params,search_params",
+        [
+            pytest.param("HNSW", HNSW_INDEX_PARAMS, {"ef": 128}, id="HNSW"),
+            pytest.param("DISKANN", STRUCT_VECTOR_DISKANN_INDEX_PARAMS, {"search_list": 128}, id="DISKANN"),
+        ],
+    )
+    def test_create_struct_array_field_with_vector_index_search_mixed_segments(
+        self,
+        index_type,
+        index_params,
+        search_params,
+    ):
+        """
+        target: test element search on a nullable Struct Array through indexed, unindexed sealed, and growing paths
+        method: insert 3000 indexed sealed, 500 unindexed sealed, and 500 growing rows with two vectors per row,
+            then search the Struct vector sub-field with HNSW and DISKANN
+        expected: every segment path returns the target row and element offset without a bitset size mismatch
+        """
+        collection_name = cf.gen_unique_str(f"{prefix}_nullable_struct_vector_{index_type.lower()}_mixed")
+        client = self._client()
+        dim = 8
+        indexed_sealed_count = 3000
+        unindexed_sealed_count = 500
+        growing_count = 500
+
+        schema = gen_schema(self, client, auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name=PK_FIELD, datatype=PK_TYPE, is_primary=True)
+        schema.add_field(field_name=VECTOR_FIELD, datatype=VECTOR_TYPE, dim=dim)
+        schema.add_field(field_name=TAG_FIELD, datatype=TAG_TYPE, max_length=TAG_MAX_LENGTH)
+        profile_schema = gen_struct_schema(self, client)
+        profile_schema.add_field(INT_SUBFIELD, INT_SUBFIELD_TYPE)
+        profile_schema.add_field(TAG_SUBFIELD, TAG_SUBFIELD_TYPE, max_length=TAG_MAX_LENGTH)
+        profile_schema.add_field(VECTOR_SUBFIELD, VECTOR_SUBFIELD_TYPE, dim=dim)
+        schema.add_field(
+            STRUCT_FIELD,
+            datatype=STRUCT_TYPE,
+            element_type=STRUCT_ELEMENT_TYPE,
+            struct_schema=profile_schema,
+            max_capacity=STRUCT_MAX_CAPACITY,
+            nullable=True,
+        )
+        self.create_collection(client, collection_name, schema=schema, consistency_level="Strong")
+        self.alter_collection_properties(
+            client,
+            collection_name,
+            properties={"collection.autocompaction.enabled": "false"},
+        )
+
+        def build_rows(start_id, count, tag_prefix):
+            return [
+                {
+                    PK_FIELD: row_id,
+                    VECTOR_FIELD: gen_unit_vector(row_id, dim),
+                    TAG_FIELD: f"{tag_prefix}_{row_id}",
+                    STRUCT_FIELD: [
+                        {
+                            INT_SUBFIELD: row_id * 10 + offset,
+                            TAG_SUBFIELD: f"profile_{row_id}_{offset}",
+                            VECTOR_SUBFIELD: gen_unit_vector(row_id * 2 + offset, dim),
+                        }
+                        for offset in range(2)
+                    ],
+                }
+                for row_id in range(start_id, start_id + count)
+            ]
+
+        indexed_rows = build_rows(0, indexed_sealed_count, "indexed")
+        self.insert(client, collection_name, indexed_rows)
+        self.flush(client, collection_name)
+
+        unindexed_start = indexed_sealed_count
+        unindexed_rows = build_rows(unindexed_start, unindexed_sealed_count, "unindexed")
+        self.insert(client, collection_name, unindexed_rows)
+        self.flush(client, collection_name)
+
+        prepared_indexes = gen_index_params(self, client)
+        prepared_indexes.add_index(
+            field_name=VECTOR_FIELD,
+            index_type=NORMAL_VECTOR_INDEX_TYPE,
+            metric_type=NORMAL_VECTOR_METRIC_TYPE,
+        )
+        prepared_indexes.add_index(
+            field_name=STRUCT_VECTOR_FIELD,
+            index_type=index_type,
+            metric_type="COSINE",
+            params=index_params,
+        )
+        self.create_index(client, collection_name, prepared_indexes)
+        assert self.wait_for_index_ready(client, collection_name, STRUCT_VECTOR_FIELD, timeout=300)
+        self.load_collection(client, collection_name, timeout=300)
+
+        loaded_segments = client.list_loaded_segments(collection_name)
+        assert sorted(segment.num_rows for segment in loaded_segments) == [
+            unindexed_sealed_count,
+            indexed_sealed_count,
+        ]
+        sealed_segment_ids = {segment.segment_id for segment in loaded_segments}
+
+        growing_start = unindexed_start + unindexed_sealed_count
+        growing_rows = build_rows(growing_start, growing_count, "growing")
+        self.insert(client, collection_name, growing_rows)
+
+        count_results, _ = self.query(
+            client,
+            collection_name,
+            filter="",
+            output_fields=["count(*)"],
+        )
+        assert count_results[0]["count(*)"] == indexed_sealed_count + unindexed_sealed_count + growing_count
+        assert {segment.segment_id for segment in client.list_loaded_segments(collection_name)} == sealed_segment_ids
+
+        target_ids = [unindexed_start, growing_start, 0]
+        for target_id in target_ids:
+            results, _ = self.search(
+                client,
+                collection_name,
+                data=[gen_unit_vector(target_id * 2, dim)],
+                anns_field=STRUCT_VECTOR_FIELD,
+                search_params={"metric_type": "COSINE", "params": search_params},
+                filter=f"{PK_FIELD} == {target_id}",
+                output_fields=[PK_FIELD],
+                limit=1,
+            )
+            assert len(results[0]) == 1
+            assert results[0][0][PK_FIELD] == target_id
+            assert results[0][0]["offset"] == 0
+
+    @pytest.mark.tags(CaseLabel.L0)
     def test_create_struct_array_field_with_vector_single_element_after_empty_sealed_output(self):
         """
         target: test sealed segment output for a nullable struct array vector sub-field after an empty row


### PR DESCRIPTION
issue: #53028

## What this PR does

Nullable StructArray vector subfields store validity information in the parent-row space, while ordinary HNSW and DISKANN indexes operate in the flattened vector-element space. Attaching the parent-row IdMap causes Knowhere to reject search bitsets when these counts differ.

This PR:

- skips the parent-row IdMap for ordinary element-level vector-array indexes
- preserves the parent-row IdMap for embedding-list metrics such as MAX_SIM
- adds C++ regression coverage for both ID-space behaviors
- adds an L0 Python E2E regression covering HNSW and DISKANN
- covers indexed sealed, unindexed sealed, and growing segments

## Verification

- C++ unit tests:
  `Indexing.HnswEmbListEmptyNullableUsesLogicalIds`
  `Indexing.HnswStructSubFieldUsesElementIdSpace`
- Python E2E: 2 passed
  - HNSW passed
  - DISKANN passed