### PR TITLE
test: run growing segment snapshot regression in CI

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_snapshot.py
+++ b/tests/python_client/milvus_client/test_milvus_client_snapshot.py
@@ -1152,7 +1152,7 @@ class TestMilvusClientSnapshotDataOperations(TestMilvusClientSnapshotBase):
         self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
-    @pytest.mark.tags(CaseLabel.L2)
+    @pytest.mark.tags(CaseLabel.L0)
     def test_snapshot_growing_segment_without_flush(self):
         """
         target: test snapshot behavior with growing segment (unflushed data)


### PR DESCRIPTION
issue: #52989

## What changed

Promote `test_snapshot_growing_segment_without_flush` from L2 to L0 so the regression test runs in CI.

## Why

This test directly covers the snapshot restore regression reported in #52989. Running it in CI helps prevent the issue from recurring.

## Validation

- `ruff check tests/python_client/milvus_client/test_milvus_client_snapshot.py`
- Python syntax compilation passed
- L0 collection check: 1 test collected
- Targeted Python SDK E2E: 1 passed