### PR TITLE
enhance: avoid repeated global JSON stats scans

### DIFF
--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -1831,6 +1831,7 @@ func (gc *garbageCollector) recycleUnusedJSONStatsFiles(ctx context.Context, sig
 	}))
 	fileNum := 0
 	deletedFilesNum := atomic.NewInt32(0)
+	maxJSONStatsDataFormat := int64(1)
 
 	snapshotMeta := gc.meta.GetSnapshotMeta()
 
@@ -1855,6 +1856,9 @@ func (gc *garbageCollector) recycleUnusedJSONStatsFiles(ctx context.Context, sig
 		gc.ackSignal(signal)
 		for _, fieldStats := range seg.GetJsonKeyStats() {
 			log := mlog.With(mlog.Int64("segmentID", seg.GetID()), mlog.Int64("fieldID", fieldStats.GetFieldID()))
+			if fieldStats.GetJsonKeyStatsDataFormat() > maxJSONStatsDataFormat {
+				maxJSONStatsDataFormat = fieldStats.GetJsonKeyStatsDataFormat()
+			}
 			// clear low version task
 			for i := int64(1); i < fieldStats.GetVersion(); i++ {
 				prefix := metautil.BuildJSONKeyStatsPrefix(gc.option.cli.RootPath(), fieldStats.GetJsonKeyStatsDataFormat(),
@@ -1892,44 +1896,47 @@ func (gc *garbageCollector) recycleUnusedJSONStatsFiles(ctx context.Context, sig
 					return
 				}
 			}
+		}
+	}
 
-			// clear low data format version stats file
-			// for upgrade from old version to new version, we need to clear the old data format version stats file
-			for i := int64(1); i < fieldStats.GetJsonKeyStatsDataFormat(); i++ {
-				prefix := fmt.Sprintf("%s/%s/%d", gc.option.cli.RootPath(), common.JSONStatsPath, i)
-				futures := make([]*conc.Future[struct{}], 0)
+	// Clear files from older data formats once per global format prefix.
+	for dataFormat := int64(1); dataFormat < maxJSONStatsDataFormat; dataFormat++ {
+		if ctx.Err() != nil {
+			return
+		}
+		gc.ackSignal(signal)
+		prefix := fmt.Sprintf("%s/%s/%d", gc.option.cli.RootPath(), common.JSONStatsPath, dataFormat)
+		futures := make([]*conc.Future[struct{}], 0)
 
-				err := gc.option.cli.WalkWithPrefix(ctx, prefix, true, func(files *storage.ChunkObjectInfo) bool {
-					fileNum++
-					file := files.FilePath
+		err := gc.option.cli.WalkWithPrefix(ctx, prefix, true, func(files *storage.ChunkObjectInfo) bool {
+			fileNum++
+			file := files.FilePath
 
-					future := gc.option.removeObjectPool.Submit(func() (struct{}, error) {
-						log := mlog.With(mlog.String("file", file))
-						log.Info(ctx, "garbageCollector recycleUnusedJSONStatsFiles remove file...")
+			future := gc.option.removeObjectPool.Submit(func() (struct{}, error) {
+				log := mlog.With(mlog.String("file", file))
+				log.Info(ctx, "garbageCollector recycleUnusedJSONStatsFiles remove file...")
 
-						if err := gc.option.cli.Remove(ctx, file); err != nil {
-							log.Warn(ctx, "garbageCollector recycleUnusedJSONStatsFiles remove file failed", mlog.Err(err))
-							return struct{}{}, err
-						}
-						deletedFilesNum.Inc()
-						log.Info(ctx, "garbageCollector recycleUnusedJSONStatsFiles remove file success")
-						return struct{}{}, nil
-					})
-					futures = append(futures, future)
-					return true
-				})
-
-				// Wait for all remove tasks done.
-				if err := conc.BlockOnAll(futures...); err != nil {
-					// error is logged, and can be ignored here.
-					log.Warn(ctx, "some task failure in remove object pool", mlog.Err(err))
+				if err := gc.option.cli.Remove(ctx, file); err != nil {
+					log.Warn(ctx, "garbageCollector recycleUnusedJSONStatsFiles remove file failed", mlog.Err(err))
+					return struct{}{}, err
 				}
+				deletedFilesNum.Inc()
+				log.Info(ctx, "garbageCollector recycleUnusedJSONStatsFiles remove file success")
+				return struct{}{}, nil
+			})
+			futures = append(futures, future)
+			return true
+		})
 
-				if err != nil {
-					log.Warn(ctx, "json stats lower data format files recycle failed when walk with prefix", mlog.Err(err))
-					return
-				}
-			}
+		// Wait for all remove tasks done.
+		if err := conc.BlockOnAll(futures...); err != nil {
+			// error is logged, and can be ignored here.
+			log.Warn(ctx, "some task failure in remove object pool", mlog.Err(err))
+		}
+
+		if err != nil {
+			log.Warn(ctx, "json stats lower data format files recycle failed when walk with prefix", mlog.Err(err))
+			return
 		}
 	}
 	log.Info(ctx, "json stats files recycle done",

--- a/internal/datacoord/garbage_collector_test.go
+++ b/internal/datacoord/garbage_collector_test.go
@@ -4138,6 +4138,53 @@ func TestGarbageCollector_recycleUnusedJSONStatsFiles_SnapshotReference(t *testi
 		"JSON stats files should not be removed when segment is referenced by snapshot")
 }
 
+func TestGarbageCollector_recycleUnusedJSONStatsFiles_GlobalFormatPrefixOnce(t *testing.T) {
+	ctx := context.Background()
+	segments := make(map[int64]*SegmentInfo)
+	for segmentID := int64(1); segmentID <= 2; segmentID++ {
+		segments[segmentID] = &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:           segmentID,
+				CollectionID: 100,
+				PartitionID:  10,
+				State:        commonpb.SegmentState_Flushed,
+				JsonKeyStats: map[int64]*datapb.JsonKeyStats{
+					102: {
+						FieldID:                102,
+						Version:                1,
+						JsonKeyStatsDataFormat: 3,
+					},
+				},
+			},
+		}
+	}
+
+	meta := &meta{
+		catalog:    &datacoord.Catalog{},
+		segments:   &SegmentsInfo{segments: segments},
+		channelCPs: newChannelCps(),
+	}
+	cli := storage.NewLocalChunkManager(objectstorage.RootPath("gc"))
+	gc := newGarbageCollector(meta, &ServerHandler{}, GcOption{cli: cli})
+
+	walkCalls := make(map[string]int)
+	mockWalk := mockey.Mock((*storage.LocalChunkManager).WalkWithPrefix).To(
+		func(cm *storage.LocalChunkManager, ctx context.Context, prefix string,
+			recursive bool, fn storage.ChunkObjectWalkFunc,
+		) error {
+			walkCalls[prefix]++
+			return nil
+		}).Build()
+	defer mockWalk.UnPatch()
+
+	gc.recycleUnusedJSONStatsFiles(ctx, nil)
+
+	assert.Equal(t, map[string]int{
+		"gc/json_stats/1": 1,
+		"gc/json_stats/2": 1,
+	}, walkCalls)
+}
+
 func Test_parseV3SegmentID(t *testing.T) {
 	rootPath := "files"
 


### PR DESCRIPTION
issue: #53137

## What problem does this PR solve?

`recycleUnusedJSONStatsFiles` removes JSON stats from obsolete data formats by walking global object-storage prefixes such as `json_stats/1` and `json_stats/2`. The cleanup currently runs inside every segment field-stats loop. With N eligible segment/field entries using data format 3, each obsolete global prefix is walked N times in the same GC cycle even though the first walk has already removed its contents. This makes object-storage listing work grow with the number of segments and JSON fields.

## What is changed?

- Track the highest JSON stats data format while walking eligible segments.
- Keep per-segment stale build-version cleanup unchanged.
- After the segment walk, scan each obsolete global data-format prefix once per GC cycle.
- Add regression coverage that verifies two format-3 segments walk `json_stats/1` and `json_stats/2` exactly once each.

## Verification

- `make static-check`
- `go test -v -count=1 -tags dynamic,test -gcflags="all=-N -l" ./internal/datacoord -run "TestGarbageCollector_recycleUnusedJSONStatsFiles_(GlobalFormatPrefixOnce|SnapshotReference)$"`