### PR TITLE
enhance: move deprecated task cleanup off DataCoord init path

### DIFF
--- a/internal/datacoord/compaction_inspector.go
+++ b/internal/datacoord/compaction_inspector.go
@@ -313,8 +313,8 @@ func (c *compactionInspector) start() {
 }
 
 func (c *compactionInspector) loadMeta() {
-	// TODO: make it compatible to all types of compaction with persist meta
 	triggers := c.meta.GetCompactionTasks(context.TODO())
+	var failedTasks []*datapb.CompactionTask
 	for _, tasks := range triggers {
 		for _, task := range tasks {
 			if isCompactionTaskCleaned(task) {
@@ -323,49 +323,89 @@ func (c *compactionInspector) loadMeta() {
 					mlog.String("type", task.GetType().String()),
 					mlog.String("state", task.GetState().String()))
 				continue
-			} else {
-				t, err := c.createCompactTask(task)
-				if err != nil {
-					mlog.Info(context.TODO(), "compactionInspector loadMeta create compactionTask failed, try to clean it",
+			}
+
+			t, err := c.createCompactTask(task)
+			if err != nil {
+				mlog.Info(context.TODO(), "compactionInspector loadMeta create compactionTask failed, defer cleanup",
+					mlog.Int64("planID", task.GetPlanID()),
+					mlog.String("type", task.GetType().String()),
+					mlog.String("state", task.GetState().String()),
+					mlog.Err(err),
+				)
+				failedTasks = append(failedTasks, task)
+				continue
+			}
+			if t.NeedReAssignNodeID() {
+				if err = c.submitTask(t); err != nil {
+					mlog.Info(context.TODO(), "compactionInspector loadMeta submit task failed, defer cleanup",
 						mlog.Int64("planID", task.GetPlanID()),
 						mlog.String("type", task.GetType().String()),
 						mlog.String("state", task.GetState().String()),
 						mlog.Err(err),
 					)
-					// ignore the drop error
-					c.meta.DropCompactionTask(context.TODO(), task)
+					failedTasks = append(failedTasks, task)
 					continue
 				}
-				if t.NeedReAssignNodeID() {
-					if err = c.submitTask(t); err != nil {
-						mlog.Info(context.TODO(), "compactionInspector loadMeta submit task failed, try to clean it",
-							mlog.Int64("planID", task.GetPlanID()),
-							mlog.String("type", task.GetType().String()),
-							mlog.String("state", task.GetState().String()),
-							mlog.Err(err),
-						)
-						// ignore the drop error
-						c.meta.DropCompactionTask(context.Background(), task)
-						continue
-					}
-					mlog.Info(context.TODO(), "compactionInspector loadMeta submitTask",
-						mlog.Int64("planID", t.GetTaskProto().GetPlanID()),
-						mlog.Int64("triggerID", t.GetTaskProto().GetTriggerID()),
-						mlog.FieldCollectionID(t.GetTaskProto().GetCollectionID()),
-						mlog.String("type", task.GetType().String()),
-						mlog.String("state", t.GetTaskProto().GetState().String()))
-				} else {
-					c.restoreTask(t)
-					mlog.Info(context.TODO(), "compactionInspector loadMeta restoreTask",
-						mlog.Int64("planID", t.GetTaskProto().GetPlanID()),
-						mlog.Int64("triggerID", t.GetTaskProto().GetTriggerID()),
-						mlog.FieldCollectionID(t.GetTaskProto().GetCollectionID()),
-						mlog.String("type", task.GetType().String()),
-						mlog.String("state", t.GetTaskProto().GetState().String()))
-				}
+				mlog.Info(context.TODO(), "compactionInspector loadMeta submitTask",
+					mlog.Int64("planID", t.GetTaskProto().GetPlanID()),
+					mlog.Int64("triggerID", t.GetTaskProto().GetTriggerID()),
+					mlog.FieldCollectionID(t.GetTaskProto().GetCollectionID()),
+					mlog.String("type", task.GetType().String()),
+					mlog.String("state", t.GetTaskProto().GetState().String()))
+			} else {
+				c.restoreTask(t)
+				mlog.Info(context.TODO(), "compactionInspector loadMeta restoreTask",
+					mlog.Int64("planID", t.GetTaskProto().GetPlanID()),
+					mlog.Int64("triggerID", t.GetTaskProto().GetTriggerID()),
+					mlog.FieldCollectionID(t.GetTaskProto().GetCollectionID()),
+					mlog.String("type", task.GetType().String()),
+					mlog.String("state", t.GetTaskProto().GetState().String()))
 			}
 		}
 	}
+
+	if len(failedTasks) > 0 {
+		c.stopWg.Add(1)
+		go c.cleanupFailedCompactionTasks(failedTasks)
+	}
+}
+
+func (c *compactionInspector) cleanupFailedCompactionTasks(tasks []*datapb.CompactionTask) {
+	defer c.stopWg.Done()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		select {
+		case <-c.stopCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	total := len(tasks)
+	mlog.Info(ctx, "start cleaning up failed compaction tasks", mlog.Int("total", total))
+	cleaned := 0
+	for _, task := range tasks {
+		select {
+		case <-ctx.Done():
+			mlog.Info(ctx, "failed compaction task cleanup aborted",
+				mlog.Int("cleaned", cleaned),
+				mlog.Int("remaining", total-cleaned))
+			return
+		default:
+		}
+		if err := c.meta.DropCompactionTask(ctx, task); err != nil {
+			mlog.Warn(ctx, "drop failed compaction task failed",
+				mlog.Int64("planID", task.GetPlanID()), mlog.Err(err))
+			continue
+		}
+		cleaned++
+	}
+	mlog.Info(ctx, "failed compaction task cleanup finished",
+		mlog.Int("cleaned", cleaned),
+		mlog.Int("total", total))
 }
 
 func (c *compactionInspector) loopSchedule() {

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -738,6 +738,8 @@ func (s *Server) startServerLoop() {
 	}
 
 	s.garbageCollector.start()
+
+	s.meta.statsTaskMeta.StartCleanupDeprecatedSortTasks(s.serverLoopCtx, &s.serverLoopWg)
 }
 
 func (s *Server) startCollectMetaMetrics(ctx context.Context) {

--- a/internal/datacoord/stats_task_meta.go
+++ b/internal/datacoord/stats_task_meta.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"sync"
 
 	"golang.org/x/time/rate"
 	"google.golang.org/protobuf/proto"
@@ -45,6 +46,8 @@ type statsTaskMeta struct {
 
 	// segmentID + SubJobType -> statsTask
 	segmentID2Tasks *typeutil.ConcurrentMap[string, *indexpb.StatsTask]
+
+	deprecatedSortTaskIDs []int64
 }
 
 func newStatsTaskMeta(ctx context.Context, catalog metastore.DataCoordCatalog) (*statsTaskMeta, error) {
@@ -67,21 +70,16 @@ func createSecondaryIndexKey(segmentID UniqueID, subJobType string) string {
 
 func (stm *statsTaskMeta) reloadFromKV() error {
 	record := timerecord.NewTimeRecorder("statsTaskMeta-reloadFromKV")
-	// load stats task
 	statsTasks, err := stm.catalog.ListStatsTasks(stm.ctx)
 	if err != nil {
 		mlog.Error(stm.ctx, "statsTaskMeta reloadFromKV load stats tasks failed", mlog.Err(err))
 		return err
 	}
+
+	deprecatedSortTaskIDs := make([]int64, 0, len(statsTasks))
 	for _, t := range statsTasks {
-		// sort stats task no need to reload
 		if t.GetSubJobType() == indexpb.StatsSubJob_Sort {
-			if err := stm.catalog.DropStatsTask(stm.ctx, t.GetTaskID()); err != nil {
-				mlog.Warn(stm.ctx, "drop stats task failed",
-					mlog.FieldTaskID(t.GetTaskID()),
-					mlog.FieldSegmentID(t.GetSegmentID()),
-					mlog.Err(err))
-			}
+			deprecatedSortTaskIDs = append(deprecatedSortTaskIDs, t.GetTaskID())
 			continue
 		}
 		stm.tasks.Insert(t.GetTaskID(), t)
@@ -90,8 +88,54 @@ func (stm *statsTaskMeta) reloadFromKV() error {
 		stm.segmentID2Tasks.Insert(secondaryKey, t)
 	}
 
-	mlog.Info(stm.ctx, "statsTaskMeta reloadFromKV done", mlog.Duration("duration", record.ElapseSpan()))
+	stm.deprecatedSortTaskIDs = deprecatedSortTaskIDs
+	mlog.Info(stm.ctx, "statsTaskMeta reloadFromKV done",
+		mlog.Duration("duration", record.ElapseSpan()),
+		mlog.Int("deprecatedSortTasks", len(deprecatedSortTaskIDs)))
 	return nil
+}
+
+func (stm *statsTaskMeta) StartCleanupDeprecatedSortTasks(ctx context.Context, wg *sync.WaitGroup) {
+	taskIDs := stm.deprecatedSortTaskIDs
+	if len(taskIDs) == 0 {
+		return
+	}
+	stm.deprecatedSortTaskIDs = nil
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		stm.cleanupDeprecatedSortTasks(ctx, taskIDs)
+	}()
+}
+
+func (stm *statsTaskMeta) cleanupDeprecatedSortTasks(ctx context.Context, taskIDs []int64) {
+	total := len(taskIDs)
+	mlog.Info(ctx, "start cleaning up deprecated sort tasks", mlog.Int("total", total))
+	cleaned := 0
+	for _, id := range taskIDs {
+		select {
+		case <-ctx.Done():
+			mlog.Info(ctx, "deprecated sort task cleanup aborted",
+				mlog.Int("cleaned", cleaned),
+				mlog.Int("remaining", total-cleaned))
+			return
+		default:
+		}
+		if err := stm.catalog.DropStatsTask(ctx, id); err != nil {
+			mlog.RatedWarn(ctx, rate.Limit(10), "drop deprecated sort task failed",
+				mlog.FieldTaskID(id), mlog.Err(err))
+			continue
+		}
+		cleaned++
+		if cleaned%10000 == 0 {
+			mlog.Info(ctx, "deprecated sort task cleanup progress",
+				mlog.Int("cleaned", cleaned),
+				mlog.Int("total", total))
+		}
+	}
+	mlog.Info(ctx, "deprecated sort task cleanup finished",
+		mlog.Int("cleaned", cleaned),
+		mlog.Int("total", total))
 }
 
 func (stm *statsTaskMeta) updateMetrics() {

--- a/internal/datacoord/stats_task_meta_test.go
+++ b/internal/datacoord/stats_task_meta_test.go
@@ -18,6 +18,7 @@ package datacoord
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/cockroachdb/errors"
@@ -50,32 +51,6 @@ func (s *statsTaskMetaSuite) SetupTest() {
 
 func (s *statsTaskMetaSuite) Test_Method() {
 	s.Run("newStatsTaskMeta", func() {
-		s.Run("normal case", func() {
-			catalog := mocks.NewDataCoordCatalog(s.T())
-			catalog.EXPECT().ListStatsTasks(mock.Anything).Return([]*indexpb.StatsTask{
-				{
-					CollectionID:    s.collectionID,
-					PartitionID:     s.partitionID,
-					SegmentID:       10000,
-					InsertChannel:   "ch1",
-					TaskID:          10001,
-					Version:         1,
-					NodeID:          0,
-					State:           indexpb.JobState_JobStateFinished,
-					FailReason:      "",
-					TargetSegmentID: 10002,
-					SubJobType:      indexpb.StatsSubJob_Sort,
-					CanRecycle:      true,
-				},
-			}, nil)
-
-			catalog.EXPECT().DropStatsTask(mock.Anything, mock.Anything).Return(nil)
-
-			m, err := newStatsTaskMeta(context.Background(), catalog)
-			s.NoError(err)
-			s.NotNil(m)
-		})
-
 		s.Run("failed case", func() {
 			catalog := mocks.NewDataCoordCatalog(s.T())
 			catalog.EXPECT().ListStatsTasks(mock.Anything).Return(nil, errors.New("mock error"))
@@ -83,6 +58,47 @@ func (s *statsTaskMetaSuite) Test_Method() {
 			m, err := newStatsTaskMeta(context.Background(), catalog)
 			s.Error(err)
 			s.Nil(m)
+		})
+
+		s.Run("skips sort tasks and loads others", func() {
+			catalog := mocks.NewDataCoordCatalog(s.T())
+			catalog.EXPECT().ListStatsTasks(mock.Anything).Return([]*indexpb.StatsTask{
+				{
+					TaskID:     1,
+					SegmentID:  100,
+					SubJobType: indexpb.StatsSubJob_Sort,
+				},
+				{
+					TaskID:     2,
+					SegmentID:  200,
+					SubJobType: indexpb.StatsSubJob_TextIndexJob,
+				},
+				{
+					TaskID:     3,
+					SegmentID:  300,
+					SubJobType: indexpb.StatsSubJob_Sort,
+				},
+			}, nil)
+			catalog.EXPECT().DropStatsTask(mock.Anything, mock.Anything).Return(nil).Times(2)
+
+			m, err := newStatsTaskMeta(context.Background(), catalog)
+			s.NoError(err)
+			s.NotNil(m)
+
+			_, ok := m.tasks.Get(int64(2))
+			s.True(ok)
+			_, ok = m.tasks.Get(int64(1))
+			s.False(ok)
+			_, ok = m.tasks.Get(int64(3))
+			s.False(ok)
+
+			s.Equal([]int64{1, 3}, m.deprecatedSortTaskIDs)
+
+			var wg sync.WaitGroup
+			m.StartCleanupDeprecatedSortTasks(context.Background(), &wg)
+			wg.Wait()
+
+			s.Nil(m.deprecatedSortTaskIDs)
 		})
 	})
 


### PR DESCRIPTION
See #53043

During 2.5-to-2.6 upgrade, DataCoord blocks for 2+ hours
in reloadFromKV() due to synchronous one-by-one deletion
of ~2M orphaned sort-stats-tasks from etcd. Sort stats
tasks were deprecated in #42562.

This moves the deletion into a fire-and-forget background
goroutine so it no longer blocks the DataCoord init
critical path. The same pattern is applied preventively
to compactionInspector.loadMeta() which had a similar
blocking-delete anti-pattern for failed compaction tasks.

statsTaskMeta.reloadFromKV now collects deprecated sort
task IDs during load and spawns a background goroutine
(cleanupDeprecatedSortTasks) to delete them sequentially
with context cancellation and progress logging.

compactionInspector.loadMeta now collects tasks that fail
createCompactTask/submitTask and spawns a background
goroutine (cleanupFailedCompactionTasks) with proper
stopWg/stopCh lifecycle integration so in-flight deletes
are cancelled on shutdown.