### PR TITLE
fix: normalize the default port when comparing Azure snapshot endpoints

### DIFF
--- a/internal/snapshotio/storage/path.go
+++ b/internal/snapshotio/storage/path.go
@@ -186,6 +186,13 @@ func buildSnapshotObjectURI(cfg *objectstorage.Config, bucket, objectPath string
 	return result, nil
 }
 
+// effectiveAzureSnapshotEndpoint returns the canonical account-qualified Azure
+// endpoint, "<account>.blob.<suffix>". The Milvus instance config carries the
+// port minio.address was normalized with (cloud deployments typically resolve
+// to "core.windows.net:443"), while snapshot URIs and endpoint identity
+// parsing drop ports, so all comparisons and emitted URIs would disagree on
+// the port spelling alone. Strip the scheme's default port here so every
+// consumer sees one canonical form; non-default ports are preserved.
 func effectiveAzureSnapshotEndpoint(cfg *objectstorage.Config) (string, error) {
 	if cfg == nil {
 		return "", merr.WrapErrServiceInternalMsg("Azure storage config is nil")
@@ -206,7 +213,7 @@ func effectiveAzureSnapshotEndpoint(cfg *objectstorage.Config) (string, error) {
 			if strings.Trim(endpoint.Path, "/") != "" {
 				return "", merr.WrapErrServiceInternalMsg("Azure storage endpoints with path prefixes are not supported")
 			}
-			return endpoint.Host, nil
+			return stripDefaultEndpointPort(endpoint.Host, endpoint.Scheme != "http"), nil
 		}
 	}
 
@@ -215,7 +222,7 @@ func effectiveAzureSnapshotEndpoint(cfg *objectstorage.Config) (string, error) {
 	if account == "" || suffix == "" {
 		return "", merr.WrapErrServiceInternalMsg("Azure account name and endpoint suffix are required")
 	}
-	return account + ".blob." + suffix, nil
+	return stripDefaultEndpointPort(account+".blob."+suffix, cfg.UseSSL), nil
 }
 
 func parseForeignURI(raw string, allowEmptyObjectKey bool) (bucket, objectKey, endpointHost string, err error) {

--- a/internal/snapshotio/storage/resolver.go
+++ b/internal/snapshotio/storage/resolver.go
@@ -450,8 +450,9 @@ func azureEndpointCloudSuffix(cfg *objectstorage.Config) string {
 	if err != nil {
 		return ""
 	}
-	// effectiveAzureSnapshotEndpoint yields "<account>.blob.<suffix>"; both
-	// parts are single DNS labels by construction, so the first marker wins.
+	// effectiveAzureSnapshotEndpoint yields "<account>.blob.<suffix>" with the
+	// default port already stripped; account and suffix are single DNS labels
+	// by construction, so the first marker wins.
 	if i := strings.Index(strings.ToLower(endpoint), ".blob."); i >= 0 {
 		return endpoint[i+len(".blob."):]
 	}

--- a/internal/snapshotio/storage/resolver_test.go
+++ b/internal/snapshotio/storage/resolver_test.go
@@ -590,6 +590,83 @@ func TestResolveForeignStorageAzureCrossAccountExportWithSourceSAS(t *testing.T)
 	assert.False(t, captured[0].AzureSourceUseSSL)
 }
 
+func TestResolveForeignStorageAzureCrossAccountExportWithSourceSASDefaultPort(t *testing.T) {
+	// Regression: Milvus normalizes minio.address to host:port, so a real
+	// instance config reads "core.windows.net:443", while snapshot URI parsing
+	// drops ports. The default-port spelling difference must not break the
+	// same-cloud comparison that gates a SAS-authorized cross-account copy.
+	t.Setenv("AZURE_STORAGE_CONNECTION_STRING", "")
+
+	var captured []objectstorage.Config
+	patchRemoteChunkManager(t, &captured)
+
+	instanceCfg := azureInstanceCfg()
+	instanceCfg.Address = "core.windows.net:443"
+	instanceCfg.UseSSL = true
+
+	resolved, err := ResolveForeignStorage(
+		context.Background(),
+		instanceCfg,
+		DirectionExport,
+		"azure://backup-account.blob.core.windows.net/backup-container/export-root",
+		`{"extfs":{"cloud_provider":"azure","access_key_id":"backup-account","access_key_value":"backup-key","source_sas_token":"sv=2024-08-04&sig=abc"}}`,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "backup-container", resolved.ForeignBucket)
+
+	// The copy source endpoint is emitted in the canonical portless form.
+	require.Len(t, captured, 1)
+	assert.Equal(t, "instance-account.blob.core.windows.net", captured[0].AzureSourceEndpoint)
+	assert.True(t, captured[0].AzureSourceUseSSL)
+}
+
+func TestResolveForeignStorageAzureSameAccountExportDefaultPort(t *testing.T) {
+	// Same regression on the no-SAS path: a same-account export must not be
+	// misclassified as cross-account just because the instance address carries
+	// the default https port.
+	t.Setenv("AZURE_STORAGE_CONNECTION_STRING", "")
+
+	var captured []objectstorage.Config
+	patchRemoteChunkManager(t, &captured)
+
+	instanceCfg := azureInstanceCfg()
+	instanceCfg.Address = "core.windows.net:443"
+	instanceCfg.UseSSL = true
+
+	_, err := ResolveForeignStorage(
+		context.Background(),
+		instanceCfg,
+		DirectionExport,
+		"azure://instance-account.blob.core.windows.net/instance-container/export-root",
+		`{"extfs":{"cloud_provider":"azure","access_key_id":"instance-account","access_key_value":"instance-key"}}`,
+	)
+	require.NoError(t, err)
+	require.Len(t, captured, 1)
+}
+
+func TestResolveForeignStorageAzureCrossAccountSourceSASNonDefaultPort(t *testing.T) {
+	// Only the scheme's default port is normalized away; a non-default port is
+	// preserved and still fails the same-cloud check.
+	t.Setenv("AZURE_STORAGE_CONNECTION_STRING", "")
+
+	var captured []objectstorage.Config
+	patchRemoteChunkManager(t, &captured)
+
+	instanceCfg := azureInstanceCfg()
+	instanceCfg.Address = "core.windows.net:1443"
+	instanceCfg.UseSSL = true
+
+	_, err := ResolveForeignStorage(
+		context.Background(),
+		instanceCfg,
+		DirectionExport,
+		"azure://backup-account.blob.core.windows.net/backup-container/export-root",
+		`{"extfs":{"cloud_provider":"azure","access_key_id":"backup-account","access_key_value":"backup-key","source_sas_token":"sv=2024-08-04&sig=abc"}}`,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must stay within one Azure cloud")
+}
+
 func TestResolveForeignStorageAzureCrossAccountRestoreWithSourceSAS(t *testing.T) {
 	t.Setenv("AZURE_STORAGE_CONNECTION_STRING", "")
 

--- a/internal/snapshotio/storage/validator.go
+++ b/internal/snapshotio/storage/validator.go
@@ -120,7 +120,9 @@ func applySnapshotExternalSpecToConfig(
 			if err != nil {
 				return false, "", err
 			}
-			if !strings.EqualFold(configuredEndpoint, endpoint) {
+			// azure:// snapshot URIs are TLS; an explicit :443 on the URI host
+			// names the same endpoint as the canonical configured form.
+			if !strings.EqualFold(configuredEndpoint, stripDefaultEndpointPort(endpoint, true)) {
 				return false, "", merr.WrapErrParameterInvalidMsg(
 					"snapshot URI Azure account does not match the instance storage credential",
 				)
@@ -287,7 +289,9 @@ func applySnapshotURILocationToConfig(
 				if err != nil {
 					return storageEndpointIdentity{}, false, err
 				}
-				if !strings.EqualFold(configuredEndpoint, endpoint) {
+				// azure:// snapshot URIs are TLS; an explicit :443 on the URI
+				// host names the same endpoint as the canonical configured form.
+				if !strings.EqualFold(configuredEndpoint, stripDefaultEndpointPort(endpoint, true)) {
 					return storageEndpointIdentity{}, false, merr.WrapErrParameterInvalidMsg(
 						"Azure snapshot URI endpoint %q does not match the configured endpoint",
 						endpoint,

--- a/internal/snapshotio/storage/validator_test.go
+++ b/internal/snapshotio/storage/validator_test.go
@@ -538,6 +538,58 @@ func TestApplySnapshotExternalSpecRejectsURIProviderConflict(t *testing.T) {
 	assert.Contains(t, err.Error(), "does not match snapshot URI provider")
 }
 
+func TestApplySnapshotExternalSpecAzureNoSpecDefaultPort(t *testing.T) {
+	// The no-spec same-account check compares the configured endpoint against
+	// the URI host; the default https port may appear on either side — Milvus
+	// normalizes minio.address to host:port, while URI writing usually drops
+	// it — and must not turn the comparison into a mismatch.
+	t.Setenv("AZURE_STORAGE_CONNECTION_STRING", "")
+	newCfg := func(address string) *objectstorage.Config {
+		return &objectstorage.Config{
+			Address:                     address,
+			BucketName:                  "snapshot-container",
+			AccessKeyID:                 "snapshot-account",
+			SecretAccessKeyID:           "key",
+			CloudProvider:               objectstorage.CloudProviderAzure,
+			UseSSL:                      true,
+			IgnoreAzureConnectionString: true,
+		}
+	}
+
+	t.Run("port on the configured side", func(t *testing.T) {
+		hasSpec, _, err := applySnapshotExternalSpecToConfig(
+			newCfg("core.windows.net:443"),
+			"azure",
+			"snapshot-account.blob.core.windows.net",
+			"",
+		)
+		require.NoError(t, err)
+		assert.False(t, hasSpec)
+	})
+
+	t.Run("port on the URI side", func(t *testing.T) {
+		hasSpec, _, err := applySnapshotExternalSpecToConfig(
+			newCfg("core.windows.net"),
+			"azure",
+			"snapshot-account.blob.core.windows.net:443",
+			"",
+		)
+		require.NoError(t, err)
+		assert.False(t, hasSpec)
+	})
+
+	t.Run("different account still rejected", func(t *testing.T) {
+		_, _, err := applySnapshotExternalSpecToConfig(
+			newCfg("core.windows.net:443"),
+			"azure",
+			"other-account.blob.core.windows.net",
+			"",
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not match the instance storage credential")
+	})
+}
+
 func TestBuildStorageConfigSnapshotURIQualifiesObjectKey(t *testing.T) {
 	cfg := storageConfigFromObjectConfig(&objectstorage.Config{
 		BucketName:    "snapshot-bucket",


### PR DESCRIPTION
issue: #53049

## What

`effectiveAzureSnapshotEndpoint` now strips the scheme's default port (443 for TLS, 80 otherwise), and the two `validator.go` configured-vs-URI comparisons normalize the URI host the same way. Non-default ports are preserved.

## Why

The instance side of every snapshot endpoint comparison reads `minio.address`, whose paramtable formatter always produces `host:port` (`core.windows.net:443` in cloud deployments), while `azure://` snapshot URIs and endpoint identity parsing drop ports. Every comparison in the snapshot path then failed on the port spelling alone, so on real Azure deployments:

- a SAS-authorized cross-account copy (#52770) was rejected with `cross-account Azure snapshot copy with a source SAS must stay within one Azure cloud` — observed live on UAT (instance `in01-d35e029c87cade1`) with the #52770 build + milvus-backup#1181 sending the SAS correctly;
- same-account exports were misclassified as cross-account by `sameAzureAccountEndpoint` and rejected with `server-side cross-bucket copy is unsupported...`;
- the no-spec same-account check and the custom-endpoint check in `validator.go` mismatched whenever only one side carried `:443`.

Existing fixtures all used portless `core.windows.net`, hiding this; the canonical portless form this fix emits also matches what milvus-backup already expects when cross-checking export metadata URIs (zilliztech/milvus-backup `internal/storage/snapshot.go`).

## Tests

New regression cases with `core.windows.net:443` on the instance side: cross-account export with source SAS resolves and emits the portless canonical source endpoint, same-account export is no longer misclassified, a non-default port still fails the same-cloud check, and the no-spec validator accepts the port on either side while still rejecting a different account.

`internal/snapshotio/storage` package tests pass (incremental go-ut, 4 shards).