### PR TITLE
fix: honor function score on hybrid sub-requests

### DIFF
--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -3243,7 +3243,7 @@ func (node *Proxy) hybridSearch(ctx context.Context, request *milvuspb.HybridSea
 
 	ctx, sp := otel.Tracer(typeutil.ProxyRole).Start(ctx, "Proxy-HybridSearch")
 	defer sp.End()
-	newSearchReq, subReqFunctionScores := convertHybridSearchToSearch(request)
+	newSearchReq, hybridSubRequests := convertHybridSearchToSearch(request)
 	qt := &searchTask{
 		baseTask: baseTask{
 			metaCache: node.getMetaCache(),
@@ -3258,15 +3258,15 @@ func (node *Proxy) hybridSearch(ctx context.Context, request *milvuspb.HybridSea
 			ReqID:        paramtable.GetNodeID(),
 			IsTopkReduce: optimizedSearch,
 		},
-		request:              newSearchReq,
-		subReqFunctionScores: subReqFunctionScores,
-		tr:                   timerecord.NewTimeRecorder(method),
-		mixCoord:             node.mixCoord,
-		node:                 node,
-		lb:                   node.lbPolicy,
-		shardClientMgr:       node.shardMgr,
-		mustUsePartitionKey:  Params.ProxyCfg.MustUsePartitionKey.GetAsBool(),
-		chMgr:                node.chMgr,
+		request:             newSearchReq,
+		hybridSubRequests:   hybridSubRequests,
+		tr:                  timerecord.NewTimeRecorder(method),
+		mixCoord:            node.mixCoord,
+		node:                node,
+		lb:                  node.lbPolicy,
+		shardClientMgr:      node.shardMgr,
+		mustUsePartitionKey: Params.ProxyCfg.MustUsePartitionKey.GetAsBool(),
+		chMgr:               node.chMgr,
 	}
 
 	succeeded := false

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -3243,7 +3243,7 @@ func (node *Proxy) hybridSearch(ctx context.Context, request *milvuspb.HybridSea
 
 	ctx, sp := otel.Tracer(typeutil.ProxyRole).Start(ctx, "Proxy-HybridSearch")
 	defer sp.End()
-	newSearchReq := convertHybridSearchToSearch(request)
+	newSearchReq, subReqFunctionScores := convertHybridSearchToSearch(request)
 	qt := &searchTask{
 		baseTask: baseTask{
 			metaCache: node.getMetaCache(),
@@ -3258,14 +3258,15 @@ func (node *Proxy) hybridSearch(ctx context.Context, request *milvuspb.HybridSea
 			ReqID:        paramtable.GetNodeID(),
 			IsTopkReduce: optimizedSearch,
 		},
-		request:             newSearchReq,
-		tr:                  timerecord.NewTimeRecorder(method),
-		mixCoord:            node.mixCoord,
-		node:                node,
-		lb:                  node.lbPolicy,
-		shardClientMgr:      node.shardMgr,
-		mustUsePartitionKey: Params.ProxyCfg.MustUsePartitionKey.GetAsBool(),
-		chMgr:               node.chMgr,
+		request:              newSearchReq,
+		subReqFunctionScores: subReqFunctionScores,
+		tr:                   timerecord.NewTimeRecorder(method),
+		mixCoord:             node.mixCoord,
+		node:                 node,
+		lb:                   node.lbPolicy,
+		shardClientMgr:       node.shardMgr,
+		mustUsePartitionKey:  Params.ProxyCfg.MustUsePartitionKey.GetAsBool(),
+		chMgr:                node.chMgr,
 	}
 
 	succeeded := false

--- a/internal/proxy/search_util.go
+++ b/internal/proxy/search_util.go
@@ -1155,7 +1155,7 @@ func getGroupScorerStr(params []*commonpb.KeyValuePair) string {
 	return groupScorerStr
 }
 
-func convertHybridSearchToSearch(req *milvuspb.HybridSearchRequest) *milvuspb.SearchRequest {
+func convertHybridSearchToSearch(req *milvuspb.HybridSearchRequest) (*milvuspb.SearchRequest, []*schemapb.FunctionScore) {
 	ret := &milvuspb.SearchRequest{
 		Base:                  req.GetBase(),
 		DbName:                req.GetDbName(),
@@ -1174,6 +1174,7 @@ func convertHybridSearchToSearch(req *milvuspb.HybridSearchRequest) *milvuspb.Se
 		SubReqs:               nil,
 		FunctionScore:         req.FunctionScore,
 	}
+	subReqFunctionScores := make([]*schemapb.FunctionScore, 0, len(req.GetRequests()))
 
 	for _, sub := range req.GetRequests() {
 		subReq := &milvuspb.SubSearchRequest{
@@ -1185,8 +1186,9 @@ func convertHybridSearchToSearch(req *milvuspb.HybridSearchRequest) *milvuspb.Se
 			ExprTemplateValues: sub.GetExprTemplateValues(),
 		}
 		ret.SubReqs = append(ret.SubReqs, subReq)
+		subReqFunctionScores = append(subReqFunctionScores, sub.GetFunctionScore())
 	}
-	return ret
+	return ret, subReqFunctionScores
 }
 
 func getMetricType(toReduceResults []*internalpb.SearchResults) string {

--- a/internal/proxy/search_util.go
+++ b/internal/proxy/search_util.go
@@ -1155,7 +1155,7 @@ func getGroupScorerStr(params []*commonpb.KeyValuePair) string {
 	return groupScorerStr
 }
 
-func convertHybridSearchToSearch(req *milvuspb.HybridSearchRequest) (*milvuspb.SearchRequest, []*schemapb.FunctionScore) {
+func convertHybridSearchToSearch(req *milvuspb.HybridSearchRequest) (*milvuspb.SearchRequest, []hybridSubSearchRequest) {
 	ret := &milvuspb.SearchRequest{
 		Base:                  req.GetBase(),
 		DbName:                req.GetDbName(),
@@ -1174,7 +1174,7 @@ func convertHybridSearchToSearch(req *milvuspb.HybridSearchRequest) (*milvuspb.S
 		SubReqs:               nil,
 		FunctionScore:         req.FunctionScore,
 	}
-	subReqFunctionScores := make([]*schemapb.FunctionScore, 0, len(req.GetRequests()))
+	hybridSubRequests := make([]hybridSubSearchRequest, 0, len(req.GetRequests()))
 
 	for _, sub := range req.GetRequests() {
 		subReq := &milvuspb.SubSearchRequest{
@@ -1186,9 +1186,12 @@ func convertHybridSearchToSearch(req *milvuspb.HybridSearchRequest) (*milvuspb.S
 			ExprTemplateValues: sub.GetExprTemplateValues(),
 		}
 		ret.SubReqs = append(ret.SubReqs, subReq)
-		subReqFunctionScores = append(subReqFunctionScores, sub.GetFunctionScore())
+		hybridSubRequests = append(hybridSubRequests, hybridSubSearchRequest{
+			request:       subReq,
+			functionScore: sub.GetFunctionScore(),
+		})
 	}
-	return ret, subReqFunctionScores
+	return ret, hybridSubRequests
 }
 
 func getMetricType(toReduceResults []*internalpb.SearchResults) string {

--- a/internal/proxy/search_util_test.go
+++ b/internal/proxy/search_util_test.go
@@ -30,7 +30,7 @@ import (
 func TestConvertHybridSearchToSearchKeepsNamespace(t *testing.T) {
 	namespace := "tenant_a"
 
-	searchReq := convertHybridSearchToSearch(&milvuspb.HybridSearchRequest{
+	searchReq, _ := convertHybridSearchToSearch(&milvuspb.HybridSearchRequest{
 		CollectionName: "coll",
 		Namespace:      &namespace,
 		Requests: []*milvuspb.SearchRequest{

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -103,8 +103,9 @@ type searchTask struct {
 	relatedDataSize   int64
 
 	// Rerank configuration metadata (nil means no rerank)
-	rerankMeta rerankMeta
-	rankParams *rankParams
+	rerankMeta           rerankMeta
+	rankParams           *rankParams
+	subReqFunctionScores []*schemapb.FunctionScore
 
 	// Order by fields for sorting results
 	orderByFields []OrderByField
@@ -554,9 +555,14 @@ func (t *searchTask) initAdvancedSearchRequest(ctx context.Context) error {
 	t.hybridElementLevel = false
 	queryFieldIDs := []int64{}
 	for index, subReq := range t.request.GetSubReqs() {
+		functionScore := t.request.GetFunctionScore()
+		if index < len(t.subReqFunctionScores) && t.subReqFunctionScores[index] != nil {
+			functionScore = t.subReqFunctionScores[index]
+		}
+
 		// For hybrid search, order_by_fields comes from main search params, not sub-search params
 		plan, queryInfo, offset, subIsIterator, _, searchType, err := t.tryGeneratePlan(
-			subReq.GetSearchParams(), subReq.GetDsl(), subReq.GetExprTemplateValues(), membershipPreflightBudget)
+			subReq.GetSearchParams(), subReq.GetDsl(), subReq.GetExprTemplateValues(), membershipPreflightBudget, functionScore)
 		if err != nil {
 			return err
 		}
@@ -882,7 +888,7 @@ func (t *searchTask) initSearchRequest(ctx context.Context) error {
 	t.legacyGroupByWire = errGroupByField == nil && errGroupByFields != nil && t.request.GetSearchAggregation() == nil
 
 	plan, queryInfo, offset, isIterator, orderByFields, searchType, err := t.tryGeneratePlan(
-		t.request.GetSearchParams(), t.request.GetDsl(), t.request.GetExprTemplateValues(), nil)
+		t.request.GetSearchParams(), t.request.GetDsl(), t.request.GetExprTemplateValues(), nil, t.request.GetFunctionScore())
 	if err != nil {
 		return err
 	}
@@ -1153,6 +1159,7 @@ func (t *searchTask) tryGeneratePlan(
 	dsl string,
 	exprTemplateValues map[string]*schemapb.TemplateValue,
 	membershipBudget *planparserv2.MembershipPreflightBudget,
+	functionScore *schemapb.FunctionScore,
 ) (*planpb.PlanNode, *planpb.QueryInfo, int64, bool, []OrderByField, internalpb.SearchType, error) {
 	annsFieldName, err := funcutil.GetAttrByKeyFromRepeatedKV(AnnsFieldKey, params)
 	if err != nil || len(annsFieldName) == 0 {
@@ -1185,7 +1192,7 @@ func (t *searchTask) tryGeneratePlan(
 	hasFilter := dsl != "" || len(exprTemplateValues) > 0
 	searchType := internalpb.SearchType_DEFAULT
 	// if function rerank is set, keep searchType DEFAULT; optimizations will be disabled in queryhook
-	if !hasFunctionRerank(t.request) {
+	if functionScore == nil && !hasFunctionRerank(t.request) {
 		searchType = searchInfo.DetermineSearchType(hasFilter)
 	}
 
@@ -1196,7 +1203,7 @@ func (t *searchTask) tryGeneratePlan(
 		annsFieldName,
 		searchInfo.planInfo,
 		exprTemplateValues,
-		t.request.GetFunctionScore(),
+		functionScore,
 		&planparserv2.ParserVisitorArgs{
 			Timezone:         t.resolvedTimezoneStr,
 			MembershipBudget: membershipBudget,

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -28,6 +28,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/exprutil"
 	"github.com/milvus-io/milvus/internal/util/function/embedding"
 	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/internal/util/function/rerank"
 	"github.com/milvus-io/milvus/internal/util/segcore"
 	"github.com/milvus-io/milvus/internal/util/shallowcopy"
 	"github.com/milvus-io/milvus/pkg/v3/common"
@@ -103,9 +104,9 @@ type searchTask struct {
 	relatedDataSize   int64
 
 	// Rerank configuration metadata (nil means no rerank)
-	rerankMeta           rerankMeta
-	rankParams           *rankParams
-	subReqFunctionScores []*schemapb.FunctionScore
+	rerankMeta        rerankMeta
+	rankParams        *rankParams
+	hybridSubRequests []hybridSubSearchRequest
 
 	// Order by fields for sorting results
 	orderByFields []OrderByField
@@ -129,6 +130,35 @@ type searchTask struct {
 	hybridElementLevel   bool
 
 	chMgr channelmgr.ChannelsMgr
+}
+
+// hybridSubSearchRequest keeps a public HybridSearch sub-request and its
+// function score together while the request is converted to the advanced
+// search representation. milvuspb.SubSearchRequest does not currently expose
+// a function_score field, so keeping a paired value here avoids relying on two
+// index-aligned slices inside the search task.
+type hybridSubSearchRequest struct {
+	request       *milvuspb.SubSearchRequest
+	functionScore *schemapb.FunctionScore
+}
+
+func validateHybridSubRequestFunctionScore(functionScore *schemapb.FunctionScore) error {
+	if len(functionScore.GetFunctions()) == 0 {
+		return merr.WrapErrParameterInvalidMsg("hybrid sub-request function_score must contain at least one boost reranker")
+	}
+
+	for _, function := range functionScore.GetFunctions() {
+		if function == nil {
+			return merr.WrapErrParameterInvalidMsg("hybrid sub-request function_score contains an empty function")
+		}
+		rerankerName := rerank.GetRerankName(function)
+		if rerankerName != rerank.BoostName {
+			return merr.WrapErrParameterInvalidMsg(
+				"hybrid sub-request function_score only supports boost rerankers, got %q", rerankerName)
+		}
+	}
+
+	return nil
 }
 
 func (t *searchTask) CanSkipAllocTimestamp() bool {
@@ -549,15 +579,27 @@ func (t *searchTask) initAdvancedSearchRequest(ctx context.Context) error {
 		t.needRequery = false
 	}
 
-	t.SubReqs = make([]*internalpb.SubSearchRequest, len(t.request.GetSubReqs()))
-	t.queryInfos = make([]*planpb.QueryInfo, len(t.request.GetSubReqs()))
-	t.hybridSubSearchInfos = make([]hybridSubSearchInfo, len(t.request.GetSubReqs()))
+	subRequests := t.hybridSubRequests
+	if subRequests == nil {
+		subRequests = make([]hybridSubSearchRequest, 0, len(t.request.GetSubReqs()))
+		for _, subReq := range t.request.GetSubReqs() {
+			subRequests = append(subRequests, hybridSubSearchRequest{request: subReq})
+		}
+	}
+
+	t.SubReqs = make([]*internalpb.SubSearchRequest, len(subRequests))
+	t.queryInfos = make([]*planpb.QueryInfo, len(subRequests))
+	t.hybridSubSearchInfos = make([]hybridSubSearchInfo, len(subRequests))
 	t.hybridElementLevel = false
 	queryFieldIDs := []int64{}
-	for index, subReq := range t.request.GetSubReqs() {
+	for index, hybridSubReq := range subRequests {
+		subReq := hybridSubReq.request
 		functionScore := t.request.GetFunctionScore()
-		if index < len(t.subReqFunctionScores) && t.subReqFunctionScores[index] != nil {
-			functionScore = t.subReqFunctionScores[index]
+		if hybridSubReq.functionScore != nil {
+			if err := validateHybridSubRequestFunctionScore(hybridSubReq.functionScore); err != nil {
+				return merr.Wrapf(err, "invalid function_score for hybrid sub-request %d", index)
+			}
+			functionScore = hybridSubReq.functionScore
 		}
 
 		// For hybrid search, order_by_fields comes from main search params, not sub-search params

--- a/internal/proxy/task_search_namespace_test.go
+++ b/internal/proxy/task_search_namespace_test.go
@@ -44,7 +44,7 @@ func TestSearchTask_PlanNamespace_AfterPreExecute(t *testing.T) {
 
 		// Capture plan to verify namespace by mocking tryGeneratePlan
 		var capturedPlan *planpb.PlanNode
-		mockey.Mock((*searchTask).tryGeneratePlan).To(func(_ *searchTask, _ []*commonpb.KeyValuePair, _ string, _ map[string]*schemapb.TemplateValue, _ *planparserv2.MembershipPreflightBudget) (*planpb.PlanNode, *planpb.QueryInfo, int64, bool, []OrderByField, internalpb.SearchType, error) {
+		mockey.Mock((*searchTask).tryGeneratePlan).To(func(_ *searchTask, _ []*commonpb.KeyValuePair, _ string, _ map[string]*schemapb.TemplateValue, _ *planparserv2.MembershipPreflightBudget, _ *schemapb.FunctionScore) (*planpb.PlanNode, *planpb.QueryInfo, int64, bool, []OrderByField, internalpb.SearchType, error) {
 			capturedPlan = &planpb.PlanNode{}
 			qi := &planpb.QueryInfo{Topk: 10, MetricType: "L2", QueryFieldId: 101, GroupByFieldId: -1}
 			return capturedPlan, qi, 0, false, nil, internalpb.SearchType_DEFAULT, nil
@@ -90,7 +90,7 @@ func TestSearchTask_NamespaceSetsPartitionIDs(t *testing.T) {
 		mockey.Mock((*MetaCache).GetPartitions).Return(partitionIDs, nil).Build()
 		mockey.Mock(isIgnoreGrowing).Return(false, nil).Build()
 		mockey.Mock((*searchTask).checkNq).Return(int64(1), nil).Build()
-		mockey.Mock((*searchTask).tryGeneratePlan).To(func(_ *searchTask, _ []*commonpb.KeyValuePair, _ string, _ map[string]*schemapb.TemplateValue, _ *planparserv2.MembershipPreflightBudget) (*planpb.PlanNode, *planpb.QueryInfo, int64, bool, []OrderByField, internalpb.SearchType, error) {
+		mockey.Mock((*searchTask).tryGeneratePlan).To(func(_ *searchTask, _ []*commonpb.KeyValuePair, _ string, _ map[string]*schemapb.TemplateValue, _ *planparserv2.MembershipPreflightBudget, _ *schemapb.FunctionScore) (*planpb.PlanNode, *planpb.QueryInfo, int64, bool, []OrderByField, internalpb.SearchType, error) {
 			plan := &planpb.PlanNode{
 				Node: &planpb.PlanNode_VectorAnns{
 					VectorAnns: &planpb.VectorANNS{

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -5890,6 +5890,76 @@ func TestSearchTask_FunctionChainRerankMeta(t *testing.T) {
 	})
 }
 
+func TestSearchTaskHybridSearchSubRequestFunctionScore(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	schema := &schemapb.CollectionSchema{
+		Name: "test_hybrid_sub_request_function_score",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, Name: "vec", DataType: schemapb.DataType_FloatVector, TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "4"}}},
+		},
+	}
+
+	placeholderGroup, err := proto.Marshal(&commonpb.PlaceholderGroup{
+		Placeholders: []*commonpb.PlaceholderValue{{
+			Tag:    "$0",
+			Type:   commonpb.PlaceholderType_FloatVector,
+			Values: [][]byte{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
+		}},
+	})
+	require.NoError(t, err)
+
+	subRequestFunctionScore := &schemapb.FunctionScore{
+		Functions: []*schemapb.FunctionSchema{{
+			Type: schemapb.FunctionType_Rerank,
+			Params: []*commonpb.KeyValuePair{
+				{Key: "reranker", Value: "boost"},
+				{Key: "weight", Value: "2.0"},
+			},
+		}},
+	}
+	subRequest := &milvuspb.SearchRequest{
+		Nq: 1,
+		SearchParams: []*commonpb.KeyValuePair{
+			{Key: AnnsFieldKey, Value: "vec"},
+			{Key: TopKKey, Value: "10"},
+			{Key: common.MetricTypeKey, Value: metric.L2},
+			{Key: ParamsKey, Value: `{"nprobe": 10}`},
+		},
+		SearchInput: &milvuspb.SearchRequest_PlaceholderGroup{PlaceholderGroup: placeholderGroup},
+	}
+	boostSubRequest := proto.Clone(subRequest).(*milvuspb.SearchRequest)
+	boostSubRequest.FunctionScore = subRequestFunctionScore
+
+	searchRequest, subReqFunctionScores := convertHybridSearchToSearch(&milvuspb.HybridSearchRequest{
+		CollectionName: "test_hybrid_sub_request_function_score",
+		RankParams:     []*commonpb.KeyValuePair{{Key: LimitKey, Value: "10"}},
+		Requests:       []*milvuspb.SearchRequest{subRequest, boostSubRequest},
+	})
+
+	task := &searchTask{
+		ctx:                    ctx,
+		collectionName:         searchRequest.GetCollectionName(),
+		SearchRequest:          &internalpb.SearchRequest{CollectionID: 1, PartitionIDs: []int64{1}, OutputFieldsId: []int64{100}},
+		request:                searchRequest,
+		subReqFunctionScores:   subReqFunctionScores,
+		schema:                 mustNewSchemaInfo(schema),
+		translatedOutputFields: []string{"pk"},
+		tr:                     timerecord.NewTimeRecorder("test"),
+	}
+
+	require.NoError(t, task.initAdvancedSearchRequest(ctx))
+	require.Len(t, task.SubReqs, 2)
+	firstPlan := &planpb.PlanNode{}
+	require.NoError(t, proto.Unmarshal(task.SubReqs[0].GetSerializedExprPlan(), firstPlan))
+	assert.Empty(t, firstPlan.GetScorers())
+	secondPlan := &planpb.PlanNode{}
+	require.NoError(t, proto.Unmarshal(task.SubReqs[1].GetSerializedExprPlan(), secondPlan))
+	require.Len(t, secondPlan.GetScorers(), 1)
+	assert.Equal(t, float64(2), secondPlan.GetScorers()[0].GetWeight())
+}
+
 func TestSearchTask_AddHighlightTask(t *testing.T) {
 	paramtable.Init()
 

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -5957,7 +5957,7 @@ func TestSearchTaskHybridSearchSubRequestFunctionScore(t *testing.T) {
 	secondPlan := &planpb.PlanNode{}
 	require.NoError(t, proto.Unmarshal(task.SubReqs[1].GetSerializedExprPlan(), secondPlan))
 	require.Len(t, secondPlan.GetScorers(), 1)
-	assert.Equal(t, float64(2), secondPlan.GetScorers()[0].GetWeight())
+	assert.Equal(t, float32(2), secondPlan.GetScorers()[0].GetWeight())
 }
 
 func TestSearchTask_AddHighlightTask(t *testing.T) {

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -5911,10 +5911,12 @@ func TestSearchTaskHybridSearchSubRequestFunctionScore(t *testing.T) {
 	require.NoError(t, err)
 
 	subRequestFunctionScore := &schemapb.FunctionScore{
+		Params: []*commonpb.KeyValuePair{{Key: "boost_mode", Value: "sum"}},
 		Functions: []*schemapb.FunctionSchema{{
 			Type: schemapb.FunctionType_Rerank,
 			Params: []*commonpb.KeyValuePair{
 				{Key: "reranker", Value: "boost"},
+				{Key: "filter", Value: "pk == 7"},
 				{Key: "weight", Value: "2.0"},
 			},
 		}},
@@ -5932,23 +5934,33 @@ func TestSearchTaskHybridSearchSubRequestFunctionScore(t *testing.T) {
 	boostSubRequest := proto.Clone(subRequest).(*milvuspb.SearchRequest)
 	boostSubRequest.FunctionScore = subRequestFunctionScore
 
-	searchRequest, subReqFunctionScores := convertHybridSearchToSearch(&milvuspb.HybridSearchRequest{
-		CollectionName: "test_hybrid_sub_request_function_score",
-		RankParams:     []*commonpb.KeyValuePair{{Key: LimitKey, Value: "10"}},
-		Requests:       []*milvuspb.SearchRequest{subRequest, boostSubRequest},
-	})
+	newTask := func(requests ...*milvuspb.SearchRequest) *searchTask {
+		searchRequest, hybridSubRequests := convertHybridSearchToSearch(&milvuspb.HybridSearchRequest{
+			CollectionName: "test_hybrid_sub_request_function_score",
+			RankParams:     []*commonpb.KeyValuePair{{Key: LimitKey, Value: "10"}},
+			Requests:       requests,
+			FunctionScore: &schemapb.FunctionScore{Functions: []*schemapb.FunctionSchema{{
+				Type: schemapb.FunctionType_Rerank,
+				Params: []*commonpb.KeyValuePair{
+					{Key: "reranker", Value: "weighted"},
+					{Key: "weights", Value: "[0.5, 0.5]"},
+				},
+			}}},
+		})
 
-	task := &searchTask{
-		ctx:                    ctx,
-		collectionName:         searchRequest.GetCollectionName(),
-		SearchRequest:          &internalpb.SearchRequest{CollectionID: 1, PartitionIDs: []int64{1}, OutputFieldsId: []int64{100}},
-		request:                searchRequest,
-		subReqFunctionScores:   subReqFunctionScores,
-		schema:                 mustNewSchemaInfo(schema),
-		translatedOutputFields: []string{"pk"},
-		tr:                     timerecord.NewTimeRecorder("test"),
+		return &searchTask{
+			ctx:                    ctx,
+			collectionName:         searchRequest.GetCollectionName(),
+			SearchRequest:          &internalpb.SearchRequest{CollectionID: 1, PartitionIDs: []int64{1}, OutputFieldsId: []int64{100}},
+			request:                searchRequest,
+			hybridSubRequests:      hybridSubRequests,
+			schema:                 mustNewSchemaInfo(schema),
+			translatedOutputFields: []string{"pk"},
+			tr:                     timerecord.NewTimeRecorder("test"),
+		}
 	}
 
+	task := newTask(subRequest, boostSubRequest)
 	require.NoError(t, task.initAdvancedSearchRequest(ctx))
 	require.Len(t, task.SubReqs, 2)
 	firstPlan := &planpb.PlanNode{}
@@ -5958,6 +5970,33 @@ func TestSearchTaskHybridSearchSubRequestFunctionScore(t *testing.T) {
 	require.NoError(t, proto.Unmarshal(task.SubReqs[1].GetSerializedExprPlan(), secondPlan))
 	require.Len(t, secondPlan.GetScorers(), 1)
 	assert.Equal(t, float32(2), secondPlan.GetScorers()[0].GetWeight())
+	assert.NotNil(t, secondPlan.GetScorers()[0].GetFilter())
+	assert.Equal(t, planpb.BoostMode_BoostModeSum, secondPlan.GetScoreOption().GetBoostMode())
+
+	for _, rerankerName := range []string{"decay", "weighted", "rrf", "model"} {
+		t.Run("rejects_"+rerankerName, func(t *testing.T) {
+			invalidSubRequest := proto.Clone(subRequest).(*milvuspb.SearchRequest)
+			invalidSubRequest.FunctionScore = &schemapb.FunctionScore{Functions: []*schemapb.FunctionSchema{{
+				Type:   schemapb.FunctionType_Rerank,
+				Params: []*commonpb.KeyValuePair{{Key: "reranker", Value: rerankerName}},
+			}}}
+
+			err := newTask(invalidSubRequest).initAdvancedSearchRequest(ctx)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+			assert.Contains(t, err.Error(), "only supports boost rerankers")
+		})
+	}
+
+	t.Run("rejects_empty_function_score", func(t *testing.T) {
+		invalidSubRequest := proto.Clone(subRequest).(*milvuspb.SearchRequest)
+		invalidSubRequest.FunctionScore = &schemapb.FunctionScore{}
+
+		err := newTask(invalidSubRequest).initAdvancedSearchRequest(ctx)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "must contain at least one boost reranker")
+	})
 }
 
 func TestSearchTask_AddHighlightTask(t *testing.T) {

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -309,7 +309,7 @@ func TestConvertHybridSearchToSearchCopiesNamespace(t *testing.T) {
 		},
 	}
 
-	searchReq := convertHybridSearchToSearch(req)
+	searchReq, _ := convertHybridSearchToSearch(req)
 	require.NotNil(t, searchReq.Namespace)
 	assert.Equal(t, namespace, searchReq.GetNamespace())
 }


### PR DESCRIPTION
## Summary

- preserve function_score supplied on each public HybridSearch sub-request
- keep each converted sub-request paired with its function score instead of relying on parallel index-aligned slices
- apply boost scorers to the corresponding sub-plan and reject empty or non-boost sub-request scores instead of silently ignoring them
- cover scorer filter parsing, boost mode, top-level weighted fusion coexistence, and rejection of decay, weighted, rrf, and model sub-request rerankers

## Testing

- gofmt and git diff --check
- go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/parser/planparserv2 -run ^Test_SegmentScorers$ passes
- the focused Proxy test is blocked locally because the Milvus C++ build dependencies are absent: librdkafka, RocksDB, and milvus_core; repository CI will run it in the supported environment

issue: #52956