### PR TITLE
fix: avoid collecting DataCoord self metrics in health checks

### DIFF
--- a/internal/coordinator/mix_coord.go
+++ b/internal/coordinator/mix_coord.go
@@ -912,6 +912,10 @@ func (s *mixCoordImpl) GetDataCoordTopology(ctx context.Context, req *milvuspb.G
 	return s.datacoordServer.GetDataCoordTopology(ctx, req)
 }
 
+func (s *mixCoordImpl) GetConnectedDataNodeMetrics(ctx context.Context, req *milvuspb.GetMetricsRequest) ([]metricsinfo.DataNodeInfos, error) {
+	return s.datacoordServer.GetConnectedDataNodeMetrics(ctx, req)
+}
+
 func (s *mixCoordImpl) GetQueryCoordTopology(ctx context.Context, req *milvuspb.GetMetricsRequest) (*metricsinfo.QueryCoordTopology, error) {
 	return s.queryCoordServer.GetQueryCoordTopology(ctx, req)
 }

--- a/internal/datacoord/metrics_info.go
+++ b/internal/datacoord/metrics_info.go
@@ -184,20 +184,9 @@ func (s *Server) getDataCoordTopology(
 	// TODO(dragondriver): add more detail metrics
 
 	// get datacoord info
-	nodes := s.nodeManager.GetClientIDs()
 	clusterTopology := metricsinfo.DataClusterTopology{
 		Self:               s.getDataCoordMetrics(ctx),
-		ConnectedDataNodes: make([]metricsinfo.DataNodeInfos, 0, len(nodes)),
-	}
-
-	// for each data node, fetch metrics info
-	for _, node := range nodes {
-		infos, err := s.getDataNodeMetrics(ctx, req, node)
-		if err != nil {
-			mlog.Warn(ctx, "fails to get DataNode metrics", mlog.Err(err))
-			continue
-		}
-		clusterTopology.ConnectedDataNodes = append(clusterTopology.ConnectedDataNodes, infos)
+		ConnectedDataNodes: s.getConnectedDataNodeMetrics(ctx, req),
 	}
 
 	// compose topology struct
@@ -209,6 +198,22 @@ func (s *Server) getDataCoordTopology(
 			ConnectedComponents: []metricsinfo.ConnectionInfo{},
 		},
 	}
+}
+
+func (s *Server) getConnectedDataNodeMetrics(ctx context.Context, req *milvuspb.GetMetricsRequest) []metricsinfo.DataNodeInfos {
+	nodes := s.nodeManager.GetClientIDs()
+	connectedDataNodes := make([]metricsinfo.DataNodeInfos, 0, len(nodes))
+
+	for _, node := range nodes {
+		infos, err := s.getDataNodeMetrics(ctx, req, node)
+		if err != nil {
+			mlog.Warn(ctx, "fails to get DataNode metrics", mlog.Err(err))
+			continue
+		}
+		connectedDataNodes = append(connectedDataNodes, infos)
+	}
+
+	return connectedDataNodes
 }
 
 // getDataCoordMetrics composes datacoord infos
@@ -386,4 +391,12 @@ func (s *Server) GetDataCoordTopology(ctx context.Context, req *milvuspb.GetMetr
 	}
 	topology := s.getDataCoordTopology(ctx, req)
 	return &topology, nil
+}
+
+// GetConnectedDataNodeMetrics returns metrics for all DataNodes connected to DataCoord.
+func (s *Server) GetConnectedDataNodeMetrics(ctx context.Context, req *milvuspb.GetMetricsRequest) ([]metricsinfo.DataNodeInfos, error) {
+	if err := merr.CheckHealthy(s.GetStateCode()); err != nil {
+		return nil, err
+	}
+	return s.getConnectedDataNodeMetrics(ctx, req), nil
 }

--- a/internal/datacoord/metrics_info_test.go
+++ b/internal/datacoord/metrics_info_test.go
@@ -42,6 +42,35 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
+func TestGetConnectedDataNodeMetrics(t *testing.T) {
+	const nodeID int64 = 100
+	nodeInfos := metricsinfo.DataNodeInfos{
+		BaseComponentInfos: metricsinfo.BaseComponentInfos{
+			Name: metricsinfo.ConstructComponentName(typeutil.DataNodeRole, nodeID),
+			ID:   nodeID,
+		},
+	}
+	response, err := metricsinfo.MarshalComponentInfos(nodeInfos)
+	assert.NoError(t, err)
+
+	dn := mocks.NewMockDataNodeClient(t)
+	dn.EXPECT().GetMetrics(mock.Anything, mock.Anything).Return(&milvuspb.GetMetricsResponse{
+		Status:        merr.Success(),
+		Response:      response,
+		ComponentName: nodeInfos.Name,
+	}, nil).Once()
+
+	nodeManager := session.NewMockNodeManager(t)
+	nodeManager.EXPECT().GetClientIDs().Return([]int64{nodeID}).Once()
+	nodeManager.EXPECT().GetClient(nodeID).Return(dn, nil).Once()
+
+	svr := &Server{nodeManager: nodeManager}
+	metrics := svr.getConnectedDataNodeMetrics(context.Background(), &milvuspb.GetMetricsRequest{})
+	assert.Len(t, metrics, 1)
+	assert.Equal(t, nodeInfos.Name, metrics[0].Name)
+	assert.Equal(t, nodeID, metrics[0].ID)
+}
+
 func TestGetDataNodeMetrics(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/datacoord/mock_test.go
+++ b/internal/datacoord/mock_test.go
@@ -558,6 +558,10 @@ func (m *mockMixCoord) GetDataCoordTopology(ctx context.Context, req *milvuspb.G
 	panic("not implemented") // TODO: Implement
 }
 
+func (m *mockMixCoord) GetConnectedDataNodeMetrics(ctx context.Context, req *milvuspb.GetMetricsRequest) ([]metricsinfo.DataNodeInfos, error) {
+	panic("not implemented") // TODO: Implement
+}
+
 func (m *mockMixCoord) GetQueryCoordTopology(ctx context.Context, req *milvuspb.GetMetricsRequest) (*metricsinfo.QueryCoordTopology, error) {
 	panic("not implemented") // TODO: Implement
 }

--- a/internal/mocks/mock_mixcoord.go
+++ b/internal/mocks/mock_mixcoord.go
@@ -4389,6 +4389,65 @@ func (_c *MixCoord_GetComponentStates_Call) RunAndReturn(run func(context.Contex
 	return _c
 }
 
+// GetConnectedDataNodeMetrics provides a mock function with given fields: ctx, req
+func (_m *MixCoord) GetConnectedDataNodeMetrics(ctx context.Context, req *milvuspb.GetMetricsRequest) ([]metricsinfo.DataNodeInfos, error) {
+	ret := _m.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetConnectedDataNodeMetrics")
+	}
+
+	var r0 []metricsinfo.DataNodeInfos
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.GetMetricsRequest) ([]metricsinfo.DataNodeInfos, error)); ok {
+		return rf(ctx, req)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *milvuspb.GetMetricsRequest) []metricsinfo.DataNodeInfos); ok {
+		r0 = rf(ctx, req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]metricsinfo.DataNodeInfos)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *milvuspb.GetMetricsRequest) error); ok {
+		r1 = rf(ctx, req)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MixCoord_GetConnectedDataNodeMetrics_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetConnectedDataNodeMetrics'
+type MixCoord_GetConnectedDataNodeMetrics_Call struct {
+	*mock.Call
+}
+
+// GetConnectedDataNodeMetrics is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req *milvuspb.GetMetricsRequest
+func (_e *MixCoord_Expecter) GetConnectedDataNodeMetrics(ctx interface{}, req interface{}) *MixCoord_GetConnectedDataNodeMetrics_Call {
+	return &MixCoord_GetConnectedDataNodeMetrics_Call{Call: _e.mock.On("GetConnectedDataNodeMetrics", ctx, req)}
+}
+
+func (_c *MixCoord_GetConnectedDataNodeMetrics_Call) Run(run func(ctx context.Context, req *milvuspb.GetMetricsRequest)) *MixCoord_GetConnectedDataNodeMetrics_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*milvuspb.GetMetricsRequest))
+	})
+	return _c
+}
+
+func (_c *MixCoord_GetConnectedDataNodeMetrics_Call) Return(_a0 []metricsinfo.DataNodeInfos, _a1 error) *MixCoord_GetConnectedDataNodeMetrics_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MixCoord_GetConnectedDataNodeMetrics_Call) RunAndReturn(run func(context.Context, *milvuspb.GetMetricsRequest) ([]metricsinfo.DataNodeInfos, error)) *MixCoord_GetConnectedDataNodeMetrics_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetCredential provides a mock function with given fields: _a0, _a1
 func (_m *MixCoord) GetCredential(_a0 context.Context, _a1 *rootcoordpb.GetCredentialRequest) (*rootcoordpb.GetCredentialResponse, error) {
 	ret := _m.Called(_a0, _a1)

--- a/internal/rootcoord/quota_center.go
+++ b/internal/rootcoord/quota_center.go
@@ -471,7 +471,7 @@ func (q *QuotaCenter) collectMetrics() error {
 	})
 	// get Data cluster metrics
 	group.Go(func() error {
-		dataCoordTopology, err := getDataCoordMetrics(ctx, q.mixCoord)
+		dataCoordTopology, err := getDataCoordTopology(ctx, q.mixCoord)
 		if err != nil {
 			return err
 		}

--- a/internal/rootcoord/util.go
+++ b/internal/rootcoord/util.go
@@ -215,13 +215,21 @@ func getQueryCoordMetrics(ctx context.Context, mixCoord types.MixCoord) (*metric
 	return mixCoord.GetQueryCoordTopology(ctx, req)
 }
 
-func getDataCoordMetrics(ctx context.Context, mixCoord types.MixCoord) (*metricsinfo.DataCoordTopology, error) {
+func getDataCoordTopology(ctx context.Context, mixCoord types.MixCoord) (*metricsinfo.DataCoordTopology, error) {
 	req, err := metricsinfo.ConstructRequestByMetricType(metricsinfo.SystemInfoMetrics)
 	if err != nil {
 		return nil, err
 	}
 	// Use direct topology method to avoid JSON marshal/unmarshal overhead in MixCoord mode
 	return mixCoord.GetDataCoordTopology(ctx, req)
+}
+
+func getConnectedDataNodeMetrics(ctx context.Context, mixCoord types.MixCoord) ([]metricsinfo.DataNodeInfos, error) {
+	req, err := metricsinfo.ConstructRequestByMetricType(metricsinfo.SystemInfoMetrics)
+	if err != nil {
+		return nil, err
+	}
+	return mixCoord.GetConnectedDataNodeMetrics(ctx, req)
 }
 
 func getProxyMetrics(ctx context.Context, proxies proxyutil.ProxyClientManagerInterface) ([]*metricsinfo.ProxyInfos, error) {
@@ -276,12 +284,12 @@ func CheckTimeTickLagExceeded(ctx context.Context, mixcoord types.MixCoord, maxD
 
 	// get Data cluster metrics
 	group.Go(func() error {
-		dataCoordTopology, err := getDataCoordMetrics(ctx, mixcoord)
+		dataNodeMetrics, err := getConnectedDataNodeMetrics(ctx, mixcoord)
 		if err != nil {
 			return err
 		}
 
-		for _, dataNodeMetric := range dataCoordTopology.Cluster.ConnectedDataNodes {
+		for _, dataNodeMetric := range dataNodeMetrics {
 			dm := dataNodeMetric.QuotaMetrics
 			if dm != nil {
 				if dm.Fgm.NumFlowGraph > 0 && dm.Fgm.MinFlowGraphChannel != "" {

--- a/internal/rootcoord/util_test.go
+++ b/internal/rootcoord/util_test.go
@@ -17,20 +17,35 @@
 package rootcoord
 
 import (
+	"context"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/metastore/model"
+	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
+	"github.com/milvus-io/milvus/pkg/v3/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
+
+func TestCheckTimeTickLagExceededUsesConnectedDataNodeMetrics(t *testing.T) {
+	mixCoord := mocks.NewMixCoord(t)
+	mixCoord.EXPECT().GetQueryCoordTopology(mock.Anything, mock.Anything).
+		Return(&metricsinfo.QueryCoordTopology{}, nil).Once()
+	mixCoord.EXPECT().GetConnectedDataNodeMetrics(mock.Anything, mock.Anything).
+		Return([]metricsinfo.DataNodeInfos{}, nil).Once()
+
+	require.NoError(t, CheckTimeTickLagExceeded(context.Background(), mixCoord, time.Second))
+}
 
 func Test_EncodeMsgPositions(t *testing.T) {
 	mp := &msgstream.MsgPosition{

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -303,6 +303,9 @@ type MixCoord interface {
 
 	GetDataCoordTopology(ctx context.Context, req *milvuspb.GetMetricsRequest) (*DataCoordTopology, error)
 
+	// GetConnectedDataNodeMetrics collects metrics from DataNodes registered with DataCoord.
+	GetConnectedDataNodeMetrics(ctx context.Context, req *milvuspb.GetMetricsRequest) ([]metricsinfo.DataNodeInfos, error)
+
 	GetQueryCoordTopology(ctx context.Context, req *milvuspb.GetMetricsRequest) (*QueryCoordTopology, error)
 
 	// GetMetrics notifies MixCoordComponent to collect metrics for specified component


### PR DESCRIPTION
issue: #53058

### What problem does this PR solve?

`CheckHealth` uses DataCoord metrics only to validate connected DataNode flowgraph time ticks. The existing path requests the full DataCoord topology, which also collects DataCoord self metrics. Self-metric collection calls `GetQuotaInfo` and scans all segments while holding `segMu` for reading, adding unrelated O(number of segments) work to health checks.

On deployments with large segment metadata, this extra collection can increase health-check latency and contribute to metrics-request timeouts.

### What is changed?

- Add an internal `GetConnectedDataNodeMetrics` path to `MixCoord`.
- Use the narrow path for time-tick lag validation in `CheckHealth`.
- Keep full DataCoord topology collection unchanged for quota and system-metrics consumers.
- Add tests verifying the narrow DataCoord path and the RootCoord health-check call selection.

### Verification

- `make build-go`
- `go test -v -count=1 -tags dynamic,test -gcflags="all=-N -l" ./internal/datacoord -run "TestGetConnectedDataNodeMetrics$"` (with the required macOS rpaths)
- `go test -v -count=1 -tags dynamic,test -gcflags="all=-N -l" ./internal/rootcoord -run "TestCheckTimeTickLagExceededUsesConnectedDataNodeMetrics$"` (with the required macOS rpaths)
- `make static-check`