### PR TITLE
fix: support nested V3 text stats paths

### DIFF
--- a/internal/storagev2/packed/stats_resolver.go
+++ b/internal/storagev2/packed/stats_resolver.go
@@ -262,10 +262,19 @@ func (r *StatsResolver) TextAndJSONIndexStatsWithBasePaths() *StatsResultWithErr
 
 		switch prefix {
 		case "text_index":
-			// For V3: extract basePath and convert to relative paths
+			// For V3: extract basePath and convert to relative paths.
 			statBasePath := basePath + "/_stats/" + key
 			resolvedPaths := r.resolveStatPaths(stat.Paths)
 			relativeFiles := stripBasePathPrefix(resolvedPaths, statBasePath)
+			// Unified text indexes are opened through FileManager, which resolves
+			// the remote object from StatsBasePath plus the file basename. A manifest
+			// may place the object under attempt directories such as taskID/version,
+			// so use the actual object directory as StatsBasePath. This also accepts
+			// older writers that keep the file directly under the field directory.
+			if len(resolvedPaths) == 1 && strings.HasSuffix(resolvedPaths[0], ".v3") {
+				statBasePath = path.Dir(resolvedPaths[0])
+				relativeFiles = []string{path.Base(resolvedPaths[0])}
+			}
 
 			version, _ := strconv.ParseInt(stat.Metadata["version"], 10, 64)
 			buildID, _ := strconv.ParseInt(stat.Metadata["build_id"], 10, 64)

--- a/internal/storagev2/packed/stats_resolver_test.go
+++ b/internal/storagev2/packed/stats_resolver_test.go
@@ -267,6 +267,7 @@ func TestStatsResolverManifest(t *testing.T) {
 	bfPath := filepath.Join(bp, "_stats/bloom_filter.100/42")
 	bm25Path := filepath.Join(bp, "_stats/bm25.200/43")
 	jsonPath := filepath.Join(bp, "_stats/json_stats.300/shared_key_index/.managed.json_0")
+	textPath := filepath.Join(bp, "_stats/text_index.400/9001/7/milvus_packed_inverted_index.v3")
 	newManifest, err := AddStatsToManifest(manifestPath, storageConfig, []StatEntry{
 		{
 			Key:      "bloom_filter.100",
@@ -286,6 +287,16 @@ func TestStatsResolverManifest(t *testing.T) {
 				"log_size":                   "1024",
 				"memory_size":                "2048",
 				"json_key_stats_data_format": "3",
+			},
+		},
+		{
+			Key:   "text_index.400",
+			Files: []string{textPath},
+			Metadata: map[string]string{
+				"version":     "7",
+				"build_id":    "9001",
+				"log_size":    "1024",
+				"memory_size": "2048",
 			},
 		},
 	})
@@ -327,6 +338,10 @@ func TestStatsResolverManifest(t *testing.T) {
 
 		assert.Empty(t, result.JSONKeyStats)
 		assert.Empty(t, result.JSONBasePaths)
+		require.Contains(t, result.TextIndexStats, int64(400))
+		assert.Equal(t, []string{"milvus_packed_inverted_index.v3"}, result.TextIndexStats[400].GetFiles())
+		assert.Equal(t, int64(7), result.TextIndexStats[400].GetVersion())
+		assert.Equal(t, filepath.ToSlash(filepath.Dir(textPath)), filepath.ToSlash(result.TextBasePaths[400]))
 	})
 
 	t.Run("TextAndJSONIndexStatsWithBasePaths returns json stats with metadata placeholder", func(t *testing.T) {


### PR DESCRIPTION
issue: #53060

## What was changed

- Derive the V3 text stats base path from the exact single `.v3` object recorded in the manifest.
- Pass only the object basename to the existing C++ FileManager.
- Cover an attempt-isolated `_stats/text_index.<fieldID>/<taskID>/<version>/...` path.

## Why

The C++ text index loader resolves `StatsBasePath + basename`. QueryNode previously fixed `StatsBasePath` at the field directory, so nested attempt components from the manifest were discarded and the packed file could not be opened.

## Compatibility

This is a reader-only change. Existing V3 files directly under the field stats directory continue to resolve to the same base path. DataNode writer paths are unchanged.

## Verification

- `git diff --check`
- Focused Go test added for the nested task/version path.
- Local execution of `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/storagev2/packed -run "^TestStatsResolverManifest$"` is blocked by stale local Loon/Segcore CGo headers that do not expose symbols required by the current branch; CI should execute it with matching native artifacts.