### PR TITLE
fix: reclaim compacted segments without active indexes

### DIFF
--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -875,7 +875,7 @@ func (gc *garbageCollector) recycleDroppedSegments(ctx context.Context, signal <
 			droppedCompactTo[to.GetID()] = to
 		}
 	}
-	indexedSegments := FilterInIndexedSegments(ctx, gc.handler, gc.meta, false, lo.Values(droppedCompactTo)...)
+	indexedSegments := FilterInIndexedSegments(ctx, gc.handler, gc.meta, true, lo.Values(droppedCompactTo)...)
 	if ctx.Err() != nil {
 		return
 	}

--- a/internal/datacoord/garbage_collector_test.go
+++ b/internal/datacoord/garbage_collector_test.go
@@ -2490,6 +2490,84 @@ func TestGarbageCollector(t *testing.T) {
 	suite.Run(t, new(GarbageCollectorSuite))
 }
 
+func TestGarbageCollector_recycleDroppedSegments_NoIndexCollection(t *testing.T) {
+	const (
+		collectionID    = int64(100)
+		indexID         = int64(200)
+		parentSegmentID = int64(1000)
+		childSegmentID  = int64(1001)
+		channelName     = "no-index-channel"
+	)
+
+	tests := []struct {
+		name    string
+		indexes map[UniqueID]map[UniqueID]*model.Index
+	}{
+		{
+			name:    "without index definitions",
+			indexes: make(map[UniqueID]map[UniqueID]*model.Index),
+		},
+		{
+			name: "with deleted index definition",
+			indexes: map[UniqueID]map[UniqueID]*model.Index{
+				collectionID: {
+					indexID: {
+						CollectionID: collectionID,
+						IndexID:      indexID,
+						IsDeleted:    true,
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			catalog := catalogmocks.NewDataCoordCatalog(t)
+			catalog.EXPECT().ChannelExists(mock.Anything, channelName).Return(false).Once()
+
+			meta := &meta{
+				catalog:    catalog,
+				segments:   NewSegmentsInfo(),
+				channelCPs: newChannelCps(),
+				indexMeta: &indexMeta{
+					indexes: test.indexes,
+				},
+			}
+			meta.segments.SetSegment(parentSegmentID, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+				ID:            parentSegmentID,
+				CollectionID:  collectionID,
+				InsertChannel: channelName,
+				State:         commonpb.SegmentState_Dropped,
+				DroppedAt:     uint64(time.Now().Add(-time.Hour).UnixNano()),
+			}})
+			meta.segments.SetSegment(childSegmentID, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+				ID:             childSegmentID,
+				CollectionID:   collectionID,
+				InsertChannel:  channelName,
+				State:          commonpb.SegmentState_Flushed,
+				CompactionFrom: []int64{parentSegmentID},
+			}})
+
+			handler := NewNMockHandler(t)
+			handler.EXPECT().ListLoadedSegments(mock.Anything).Return(nil, nil).Once()
+
+			recycled := make([]int64, 0, 1)
+			mockRecycle := mockey.Mock((*garbageCollector).recycleDroppedSegment).
+				To(func(_ *garbageCollector, _ context.Context, segmentID int64, _ *SegmentInfo) {
+					recycled = append(recycled, segmentID)
+				}).Build()
+			defer mockRecycle.UnPatch()
+
+			gc := newGarbageCollector(meta, handler, GcOption{dropTolerance: 0})
+			gc.recycleDroppedSegments(context.Background(), nil)
+
+			require.Equal(t, []int64{parentSegmentID}, recycled)
+			handler.AssertNotCalled(t, "GetCollection", mock.Anything, mock.Anything)
+		})
+	}
+}
+
 // TestGarbageCollector_recycleDroppedSegments_SnapshotReference tests that segments referenced by snapshots are not garbage collected
 func TestGarbageCollector_recycleDroppedSegments_SnapshotReference(t *testing.T) {
 	// Setup


### PR DESCRIPTION
issue: #53064

## What was changed

- Treat compact targets as index-ready for the dropped-segment GC gate when their collection has no active index definitions.
- Preserve the existing index-readiness check when active index definitions still exist.
- Add regression coverage for collections that never had an index and collections whose index definitions were marked deleted during DropCollection.

## Why this change is needed

### Collections that never had an index

`recycleDroppedSegments` previously required every compact target to be returned by `FilterInIndexedSegments`. A collection with no index definitions can never satisfy that requirement, so its expired dropped compacted source segments remain protected from GC while the target exists.

### Collections dropped after having an index

DropCollection marks index definitions deleted before removing the collection metadata. Deleted definitions are no longer active, but the old GC path still requested the collection schema. Once RootCoord no longer has the collection, the lookup returns `CollectionNotFound`, excluding the compact target from the indexed set and delaying parent-segment cleanup.

When no active indexes remain, there is no indexed-query performance state to preserve. Skipping the schema lookup makes the index-readiness condition vacuously satisfied without weakening the safeguard for collections that still have active indexes.

## Test plan

- [x] `TestGarbageCollector_recycleDroppedSegments_NoIndexCollection/without_index_definitions`
- [x] `TestGarbageCollector_recycleDroppedSegments_NoIndexCollection/with_deleted_index_definition`
- [x] `make static-check`
