### PR TITLE
fix: [hotfix] Use AutoSpan::SetAttribute in filter eval hot path

### DIFF
--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
@@ -39,8 +39,7 @@ void
 PhyBinaryArithOpEvalRangeExpr::Eval(EvalCtx& context, VectorPtr& result) {
     tracer::AutoSpan span(
         "PhyBinaryArithOpEvalRangeExpr::Eval", tracer::GetRootSpan(), true);
-    span.SetAttribute("data_type",
-                                 static_cast<int>(expr_->column_.data_type_));
+    span.SetAttribute("data_type", static_cast<int>(expr_->column_.data_type_));
     span.SetAttribute("op_type", static_cast<int>(expr_->op_type_));
 
     auto input = context.get_offset_input();

--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
@@ -39,9 +39,9 @@ void
 PhyBinaryArithOpEvalRangeExpr::Eval(EvalCtx& context, VectorPtr& result) {
     tracer::AutoSpan span(
         "PhyBinaryArithOpEvalRangeExpr::Eval", tracer::GetRootSpan(), true);
-    span.GetSpan()->SetAttribute("data_type",
+    span.SetAttribute("data_type",
                                  static_cast<int>(expr_->column_.data_type_));
-    span.GetSpan()->SetAttribute("op_type", static_cast<int>(expr_->op_type_));
+    span.SetAttribute("op_type", static_cast<int>(expr_->op_type_));
 
     auto input = context.get_offset_input();
     SetHasOffsetInput((input != nullptr));

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -30,7 +30,7 @@ void
 PhyBinaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
     tracer::AutoSpan span(
         "PhyBinaryRangeFilterExpr::Eval", tracer::GetRootSpan(), true);
-    span.GetSpan()->SetAttribute("data_type",
+    span.SetAttribute("data_type",
                                  static_cast<int>(expr_->column_.data_type_));
 
     auto input = context.get_offset_input();

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -30,8 +30,7 @@ void
 PhyBinaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
     tracer::AutoSpan span(
         "PhyBinaryRangeFilterExpr::Eval", tracer::GetRootSpan(), true);
-    span.SetAttribute("data_type",
-                                 static_cast<int>(expr_->column_.data_type_));
+    span.SetAttribute("data_type", static_cast<int>(expr_->column_.data_type_));
 
     auto input = context.get_offset_input();
     SetHasOffsetInput((input != nullptr));

--- a/internal/core/src/exec/expression/CallExpr.cpp
+++ b/internal/core/src/exec/expression/CallExpr.cpp
@@ -29,7 +29,7 @@ namespace exec {
 void
 PhyCallExpr::Eval(EvalCtx& context, VectorPtr& result) {
     tracer::AutoSpan span("PhyCallExpr::Eval", tracer::GetRootSpan(), true);
-    span.GetSpan()->SetAttribute("function_name", expr_->fun_name());
+    span.SetAttribute("function_name", expr_->fun_name());
 
     auto offset_input = context.get_offset_input();
     SetHasOffsetInput(offset_input != nullptr);

--- a/internal/core/src/exec/expression/ColumnExpr.cpp
+++ b/internal/core/src/exec/expression/ColumnExpr.cpp
@@ -31,7 +31,7 @@ PhyColumnExpr::GetNextBatchSize() {
 void
 PhyColumnExpr::Eval(EvalCtx& context, VectorPtr& result) {
     tracer::AutoSpan span("PhyColumnExpr::Eval", tracer::GetRootSpan(), true);
-    span.GetSpan()->SetAttribute("data_type", static_cast<int>(expr_->type()));
+    span.SetAttribute("data_type", static_cast<int>(expr_->type()));
 
     auto input = context.get_offset_input();
     SetHasOffsetInput(input != nullptr);

--- a/internal/core/src/exec/expression/CompareExpr.cpp
+++ b/internal/core/src/exec/expression/CompareExpr.cpp
@@ -210,9 +210,9 @@ void
 PhyCompareFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
     tracer::AutoSpan span(
         "PhyCompareFilterExpr::Eval", tracer::GetRootSpan(), true);
-    span.GetSpan()->SetAttribute("op_type", static_cast<int>(expr_->op_type_));
-    span.GetSpan()->SetAttribute("left_indexed", is_left_indexed_);
-    span.GetSpan()->SetAttribute("right_indexed", is_right_indexed_);
+    span.SetAttribute("op_type", static_cast<int>(expr_->op_type_));
+    span.SetAttribute("left_indexed", is_left_indexed_);
+    span.SetAttribute("right_indexed", is_right_indexed_);
 
     auto input = context.get_offset_input();
     SetHasOffsetInput((input != nullptr));

--- a/internal/core/src/exec/expression/ConjunctExpr.cpp
+++ b/internal/core/src/exec/expression/ConjunctExpr.cpp
@@ -92,7 +92,7 @@ void
 PhyConjunctFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
     tracer::AutoSpan span(
         "PhyConjunctFilterExpr::Eval", tracer::GetRootSpan(), true);
-    span.GetSpan()->SetAttribute("is_and", is_and_);
+    span.SetAttribute("is_and", is_and_);
 
     if (input_order_.empty()) {
         input_order_.resize(inputs_.size());

--- a/internal/core/src/exec/expression/ExistsExpr.cpp
+++ b/internal/core/src/exec/expression/ExistsExpr.cpp
@@ -29,8 +29,7 @@ void
 PhyExistsFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
     tracer::AutoSpan span(
         "PhyExistsFilterExpr::Eval", tracer::GetRootSpan(), true);
-    span.SetAttribute("data_type",
-                                 static_cast<int>(expr_->column_.data_type_));
+    span.SetAttribute("data_type", static_cast<int>(expr_->column_.data_type_));
 
     auto input = context.get_offset_input();
     SetHasOffsetInput((input != nullptr));

--- a/internal/core/src/exec/expression/ExistsExpr.cpp
+++ b/internal/core/src/exec/expression/ExistsExpr.cpp
@@ -29,7 +29,7 @@ void
 PhyExistsFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
     tracer::AutoSpan span(
         "PhyExistsFilterExpr::Eval", tracer::GetRootSpan(), true);
-    span.GetSpan()->SetAttribute("data_type",
+    span.SetAttribute("data_type",
                                  static_cast<int>(expr_->column_.data_type_));
 
     auto input = context.get_offset_input();

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -106,7 +106,7 @@ void
 PhyJsonContainsFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
     tracer::AutoSpan span(
         "PhyJsonContainsFilterExpr::Eval", tracer::GetRootSpan(), true);
-    span.GetSpan()->SetAttribute("data_type",
+    span.SetAttribute("data_type",
                                  static_cast<int>(expr_->column_.data_type_));
 
     auto input = context.get_offset_input();

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -106,8 +106,7 @@ void
 PhyJsonContainsFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
     tracer::AutoSpan span(
         "PhyJsonContainsFilterExpr::Eval", tracer::GetRootSpan(), true);
-    span.SetAttribute("data_type",
-                                 static_cast<int>(expr_->column_.data_type_));
+    span.SetAttribute("data_type", static_cast<int>(expr_->column_.data_type_));
 
     auto input = context.get_offset_input();
     SetHasOffsetInput((input != nullptr));

--- a/internal/core/src/exec/expression/NullExpr.cpp
+++ b/internal/core/src/exec/expression/NullExpr.cpp
@@ -27,7 +27,7 @@ namespace exec {
 void
 PhyNullExpr::Eval(EvalCtx& context, VectorPtr& result) {
     tracer::AutoSpan span("PhyNullExpr::Eval", tracer::GetRootSpan(), true);
-    span.GetSpan()->SetAttribute("data_type",
+    span.SetAttribute("data_type",
                                  static_cast<int>(expr_->column_.data_type_));
 
     auto input = context.get_offset_input();

--- a/internal/core/src/exec/expression/NullExpr.cpp
+++ b/internal/core/src/exec/expression/NullExpr.cpp
@@ -27,8 +27,7 @@ namespace exec {
 void
 PhyNullExpr::Eval(EvalCtx& context, VectorPtr& result) {
     tracer::AutoSpan span("PhyNullExpr::Eval", tracer::GetRootSpan(), true);
-    span.SetAttribute("data_type",
-                                 static_cast<int>(expr_->column_.data_type_));
+    span.SetAttribute("data_type", static_cast<int>(expr_->column_.data_type_));
 
     auto input = context.get_offset_input();
     switch (expr_->column_.data_type_) {

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -28,7 +28,7 @@ void
 PhyTermFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
     tracer::AutoSpan span(
         "PhyTermFilterExpr::Eval", tracer::GetRootSpan(), true);
-    span.GetSpan()->SetAttribute("data_type",
+    span.SetAttribute("data_type",
                                  static_cast<int>(expr_->column_.data_type_));
 
     auto input = context.get_offset_input();

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -28,8 +28,7 @@ void
 PhyTermFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
     tracer::AutoSpan span(
         "PhyTermFilterExpr::Eval", tracer::GetRootSpan(), true);
-    span.SetAttribute("data_type",
-                                 static_cast<int>(expr_->column_.data_type_));
+    span.SetAttribute("data_type", static_cast<int>(expr_->column_.data_type_));
 
     auto input = context.get_offset_input();
     SetHasOffsetInput((input != nullptr));

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -177,8 +177,7 @@ void
 PhyUnaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
     tracer::AutoSpan span(
         "PhyUnaryRangeFilterExpr::Eval", tracer::GetRootSpan(), true);
-    span.SetAttribute("data_type",
-                                 static_cast<int>(expr_->column_.data_type_));
+    span.SetAttribute("data_type", static_cast<int>(expr_->column_.data_type_));
     span.SetAttribute("op_type", static_cast<int>(expr_->op_type_));
 
     auto input = context.get_offset_input();

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -177,9 +177,9 @@ void
 PhyUnaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
     tracer::AutoSpan span(
         "PhyUnaryRangeFilterExpr::Eval", tracer::GetRootSpan(), true);
-    span.GetSpan()->SetAttribute("data_type",
+    span.SetAttribute("data_type",
                                  static_cast<int>(expr_->column_.data_type_));
-    span.GetSpan()->SetAttribute("op_type", static_cast<int>(expr_->op_type_));
+    span.SetAttribute("op_type", static_cast<int>(expr_->op_type_));
 
     auto input = context.get_offset_input();
     SetHasOffsetInput((input != nullptr));

--- a/internal/core/src/exec/expression/ValueExpr.cpp
+++ b/internal/core/src/exec/expression/ValueExpr.cpp
@@ -23,7 +23,7 @@ namespace exec {
 void
 PhyValueExpr::Eval(EvalCtx& context, VectorPtr& result) {
     tracer::AutoSpan span("PhyValueExpr::Eval", tracer::GetRootSpan(), true);
-    span.GetSpan()->SetAttribute("data_type", static_cast<int>(expr_->type()));
+    span.SetAttribute("data_type", static_cast<int>(expr_->type()));
 
     auto input = context.get_offset_input();
     SetHasOffsetInput((input != nullptr));

--- a/internal/core/src/exec/operator/VectorSearchNode.cpp
+++ b/internal/core/src/exec/operator/VectorSearchNode.cpp
@@ -73,8 +73,8 @@ PhyVectorSearchNode::GetOutput() {
         return nullptr;
     }
 
-    span.GetSpan()->SetAttribute("search_type", search_info_.metric_type_);
-    span.GetSpan()->SetAttribute("topk", search_info_.topk_);
+    span.SetAttribute("search_type", search_info_.metric_type_);
+    span.SetAttribute("topk", search_info_.topk_);
 
     std::chrono::high_resolution_clock::time_point vector_start =
         std::chrono::high_resolution_clock::now();
@@ -154,7 +154,7 @@ PhyVectorSearchNode::GetOutput() {
     search_result.total_data_cnt_ = data_cnt;
     search_result.element_level_ = ph.element_level_;
 
-    span.GetSpan()->SetAttribute(
+    span.SetAttribute(
         "result_count", static_cast<int>(search_result.seg_offsets_.size()));
     query_context_->set_search_result(std::move(search_result));
 

--- a/internal/core/src/exec/operator/VectorSearchNode.cpp
+++ b/internal/core/src/exec/operator/VectorSearchNode.cpp
@@ -154,8 +154,8 @@ PhyVectorSearchNode::GetOutput() {
     search_result.total_data_cnt_ = data_cnt;
     search_result.element_level_ = ph.element_level_;
 
-    span.SetAttribute(
-        "result_count", static_cast<int>(search_result.seg_offsets_.size()));
+    span.SetAttribute("result_count",
+                      static_cast<int>(search_result.seg_offsets_.size()));
     query_context_->set_search_result(std::move(search_result));
 
     std::chrono::high_resolution_clock::time_point vector_end =

--- a/internal/core/src/index/NgramInvertedIndex.cpp
+++ b/internal/core/src/index/NgramInvertedIndex.cpp
@@ -318,11 +318,11 @@ NgramInvertedIndex::ExecuteQuery(const std::string& literal,
         case proto::plan::OpType::Match:
             return MatchQuery(literal, segment);
         case proto::plan::OpType::InnerMatch: {
-            span.GetSpan()->SetAttribute("op_type", "InnerMatch");
-            span.GetSpan()->SetAttribute("query_literal_length",
+            span.SetAttribute("op_type", "InnerMatch");
+            span.SetAttribute("query_literal_length",
                                          static_cast<int>(literal.length()));
-            span.GetSpan()->SetAttribute("min_gram", min_gram_);
-            span.GetSpan()->SetAttribute("max_gram", max_gram_);
+            span.SetAttribute("min_gram", min_gram_);
+            span.SetAttribute("max_gram", max_gram_);
             bool need_post_filter = literal.length() > max_gram_;
 
             if (schema_.data_type() == proto::schema::DataType::JSON) {
@@ -348,11 +348,11 @@ NgramInvertedIndex::ExecuteQuery(const std::string& literal,
             }
         }
         case proto::plan::OpType::PrefixMatch: {
-            span.GetSpan()->SetAttribute("op_type", "PrefixMatch");
-            span.GetSpan()->SetAttribute("query_literal_length",
+            span.SetAttribute("op_type", "PrefixMatch");
+            span.SetAttribute("query_literal_length",
                                          static_cast<int>(literal.length()));
-            span.GetSpan()->SetAttribute("min_gram", min_gram_);
-            span.GetSpan()->SetAttribute("max_gram", max_gram_);
+            span.SetAttribute("min_gram", min_gram_);
+            span.SetAttribute("max_gram", max_gram_);
             if (schema_.data_type() == proto::schema::DataType::JSON) {
                 auto predicate = [&literal, this](const milvus::Json& data) {
                     auto x =
@@ -381,11 +381,11 @@ NgramInvertedIndex::ExecuteQuery(const std::string& literal,
             }
         }
         case proto::plan::OpType::PostfixMatch: {
-            span.GetSpan()->SetAttribute("op_type", "PostfixMatch");
-            span.GetSpan()->SetAttribute("query_literal_length",
+            span.SetAttribute("op_type", "PostfixMatch");
+            span.SetAttribute("query_literal_length",
                                          static_cast<int>(literal.length()));
-            span.GetSpan()->SetAttribute("min_gram", min_gram_);
-            span.GetSpan()->SetAttribute("max_gram", max_gram_);
+            span.SetAttribute("min_gram", min_gram_);
+            span.SetAttribute("max_gram", max_gram_);
             if (schema_.data_type() == proto::schema::DataType::JSON) {
                 auto predicate = [&literal, this](const milvus::Json& data) {
                     auto x =

--- a/internal/core/src/index/NgramInvertedIndex.cpp
+++ b/internal/core/src/index/NgramInvertedIndex.cpp
@@ -320,7 +320,7 @@ NgramInvertedIndex::ExecuteQuery(const std::string& literal,
         case proto::plan::OpType::InnerMatch: {
             span.SetAttribute("op_type", "InnerMatch");
             span.SetAttribute("query_literal_length",
-                                         static_cast<int>(literal.length()));
+                              static_cast<int>(literal.length()));
             span.SetAttribute("min_gram", min_gram_);
             span.SetAttribute("max_gram", max_gram_);
             bool need_post_filter = literal.length() > max_gram_;
@@ -350,7 +350,7 @@ NgramInvertedIndex::ExecuteQuery(const std::string& literal,
         case proto::plan::OpType::PrefixMatch: {
             span.SetAttribute("op_type", "PrefixMatch");
             span.SetAttribute("query_literal_length",
-                                         static_cast<int>(literal.length()));
+                              static_cast<int>(literal.length()));
             span.SetAttribute("min_gram", min_gram_);
             span.SetAttribute("max_gram", max_gram_);
             if (schema_.data_type() == proto::schema::DataType::JSON) {
@@ -383,7 +383,7 @@ NgramInvertedIndex::ExecuteQuery(const std::string& literal,
         case proto::plan::OpType::PostfixMatch: {
             span.SetAttribute("op_type", "PostfixMatch");
             span.SetAttribute("query_literal_length",
-                                         static_cast<int>(literal.length()));
+                              static_cast<int>(literal.length()));
             span.SetAttribute("min_gram", min_gram_);
             span.SetAttribute("max_gram", max_gram_);
             if (schema_.data_type() == proto::schema::DataType::JSON) {

--- a/internal/core/src/query/ExecPlanNodeVisitor.cpp
+++ b/internal/core/src/query/ExecPlanNodeVisitor.cpp
@@ -43,8 +43,7 @@ ExecPlanNodeVisitor::ExecuteTask(
     std::shared_ptr<milvus::exec::QueryContext> query_context,
     bool collect_bitset) {
     tracer::AutoSpan span("ExecuteTask", tracer::GetRootSpan(), true);
-    span.SetAttribute("active_count",
-                                 query_context->get_active_count());
+    span.SetAttribute("active_count", query_context->get_active_count());
 
     LOG_DEBUG("plannode: {}, active_count: {}, timestamp: {}",
               plan.plan_node_->ToString(),

--- a/internal/core/src/query/ExecPlanNodeVisitor.cpp
+++ b/internal/core/src/query/ExecPlanNodeVisitor.cpp
@@ -43,7 +43,7 @@ ExecPlanNodeVisitor::ExecuteTask(
     std::shared_ptr<milvus::exec::QueryContext> query_context,
     bool collect_bitset) {
     tracer::AutoSpan span("ExecuteTask", tracer::GetRootSpan(), true);
-    span.GetSpan()->SetAttribute("active_count",
+    span.SetAttribute("active_count",
                                  query_context->get_active_count());
 
     LOG_DEBUG("plannode: {}, active_count: {}, timestamp: {}",
@@ -80,7 +80,7 @@ ExecPlanNodeVisitor::ExecuteTask(
         }
     }
 
-    span.GetSpan()->SetAttribute("total_rows", processed_num);
+    span.SetAttribute("total_rows", processed_num);
 
     return bitset_holder;
 }

--- a/internal/core/thirdparty/milvus-common/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-common/CMakeLists.txt
@@ -13,7 +13,7 @@
 
 milvus_add_pkg_config("milvus-common")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( MILVUS-COMMON-VERSION 9dc0923 )
+set( MILVUS-COMMON-VERSION c4ea184 )
 set( GIT_REPOSITORY "https://github.com/zilliztech/milvus-common.git")
 
 message(STATUS "milvus-common repo: ${GIT_REPOSITORY}")


### PR DESCRIPTION
Related to #53069

Replace span.GetSpan()->SetAttribute() with span.SetAttribute() in the scalar filter evaluation hot path (UnaryExpr, ConjunctExpr, CompareExpr, TermExpr, ValueExpr, VectorSearchNode, NgramInvertedIndex, ExecPlanNodeVisitor, etc.) and pin milvus-common to c4ea184, which adds the new no-op AutoSpan::SetAttribute API.

GetSpan() returns a copy of the process-global noop_span shared_ptr. Every copy does an atomic refcount increment on return and a decrement when the temporary is destroyed, so each Eval issues multiple LDADD/CAS atomic ops on the same global control block, contended by all search threads. This was the top CPU hotspot (~48% leaf time) in the search flame graph.

When tracing is disabled, span_ is always nullptr, so SetAttribute() short-circuits to a single fully inlined branch with no shared_ptr refcount traffic and no virtual call, eliminating the atomic hotspot.