### PR TITLE
fix: converge empty client telemetry config hashes

### DIFF
--- a/docs/design-docs/design_docs/20260131-client_side_telemetry.md
+++ b/docs/design-docs/design_docs/20260131-client_side_telemetry.md
@@ -579,6 +579,28 @@ The server computes it over the configs **already filtered to this client's scop
 sends persistent configs only when `request.ConfigHash != serverHash`. The response has no
 "new hash" field — the client recomputes it locally after processing commands.
 
+An empty command list is otherwise ambiguous: it can mean either that a non-empty client
+hash already matches or that the last matching config was deleted. Clearing the hash for
+every empty response would make a matching non-empty config alternate between suppression
+and re-delivery. To let existing SDKs converge without a protobuf change, the server uses a
+reserved empty-config sentinel only when the effective config set is empty and the client
+reports some other non-empty hash:
+
+```
+ID:          00000000-0000-0000-0000-000000000000
+Type:        push_config
+Payload:     {}
+Persistent:  true
+CreateTime:  0
+Hash:        d34aea1518ff0217
+```
+
+Every telemetry SDK treats this as a successful no-op and adopts its hash. The server
+accepts both `""` and `d34aea1518ff0217` as an empty effective-config hash, so fresh clients
+receive no sentinel and transitioned clients do not receive it again. The command is
+synthesized in the heartbeat response, never stored in etcd or exposed through List/Delete,
+and its acknowledgement is omitted from ordinary command reply history.
+
 #### Command delivery and deduplication
 
 One-time commands are returned only when `command.CreateTime > request.LastCommandTimestamp`

--- a/internal/rootcoord/telemetry/manager.go
+++ b/internal/rootcoord/telemetry/manager.go
@@ -74,6 +74,33 @@ type TelemetryConfig struct {
 // window to serve and one to absorb the quiet one.
 const defaultRetainedWindows = 2
 
+// The heartbeat response has no authoritative config hash, so an empty command list is
+// ambiguous to existing clients: it can mean either "your non-empty hash still matches" or
+// "the effective config set is now empty". When the latter follows deletion of the last
+// matching config, send this stable no-op persistent command once. All telemetry SDKs accept
+// an empty push_config object without changing runtime settings and compute the same hash from
+// command ID, type, and payload.
+//
+// Empty-string and sentinel hashes are both accepted as the empty state. That keeps fresh
+// clients on the original empty hash while allowing a client with a stale non-empty hash to
+// converge without a protobuf change. The sentinel is synthesized at response time; it must
+// never be stored or exposed through the command APIs.
+const (
+	emptyConfigSentinelCommandID = "00000000-0000-0000-0000-000000000000"
+	emptyConfigSentinelHash      = "d34aea1518ff0217"
+)
+
+func newEmptyConfigSentinelCommand() *commonpb.ClientCommand {
+	return &commonpb.ClientCommand{
+		CommandId:   emptyConfigSentinelCommandID,
+		CommandType: "push_config",
+		Payload:     []byte("{}"),
+		CreateTime:  0,
+		TargetScope: "global",
+		Persistent:  true,
+	}
+}
+
 // normalize replaces values that cannot mean what they say with their defaults.
 //
 // It exists because a caller may build a TelemetryConfig field by field and leave zeroes
@@ -645,6 +672,12 @@ func (m *TelemetryManager) processCommandReplies(cache *ClientMetricsCache, repl
 		if reply == nil {
 			continue
 		}
+		// The empty-config sentinel is synthesized and has no command-store entry. Its ACK
+		// only confirms that the client adopted the sentinel hash; retaining it would expose
+		// a phantom command in reply history and make cleanup probe a reserved ID.
+		if reply.CommandId == emptyConfigSentinelCommandID {
+			continue
+		}
 
 		cmdType, cmdPayload := m.lookupCommandInfo(reply.CommandId)
 		stored = append(stored, &StoredCommandReply{
@@ -791,7 +824,19 @@ func (m *TelemetryManager) getCommandsForClientWithID(clientID string, req *milv
 		}
 	}
 
-	// Compute hash only over configs this client will receive
+	// The wire response has no authoritative hash. If the last matching config was deleted,
+	// an existing client still reports its old non-empty hash but an ordinary empty response
+	// cannot tell it to clear that hash. Transition only that stale state through a stable
+	// no-op persistent command. Fresh clients keep using the original empty hash, while both
+	// empty representations suppress future sentinel delivery.
+	if len(filteredConfigs) == 0 {
+		if req.ConfigHash != "" && req.ConfigHash != emptyConfigSentinelHash {
+			result = append(result, newEmptyConfigSentinelCommand())
+		}
+		return result
+	}
+
+	// Compute hash only over configs this client will receive.
 	filteredConfigHash := computeClientConfigHash(filteredConfigs)
 
 	// Only send configs if client's hash differs from filtered hash

--- a/internal/rootcoord/telemetry/manager_test.go
+++ b/internal/rootcoord/telemetry/manager_test.go
@@ -1496,6 +1496,91 @@ func TestGetCommandsForClientWithConfigHashChange(t *testing.T) {
 	assert.Empty(t, commands2)
 }
 
+func TestEmptyConfigSentinelConvergesAfterLastConfigDeleted(t *testing.T) {
+	mgr := NewTelemetryManager(nil)
+	mockStore := newMockCommandStore()
+	mgr.SetCommandStore(mockStore)
+	ctx := context.Background()
+	clientID := "empty-config-client"
+
+	configID, err := mockStore.PushCommand(ctx, &milvuspb.PushClientCommandRequest{
+		CommandType: "push_config",
+		Payload:     []byte(`{"sampling_rate":0.5}`),
+		Persistent:  true,
+	})
+	require.NoError(t, err)
+
+	initial := mgr.getCommandsForClientWithID(clientID, &milvuspb.ClientHeartbeatRequest{
+		ClientInfo: &commonpb.ClientInfo{Reserved: map[string]string{"client_id": clientID}},
+	})
+	require.Len(t, initial, 1)
+	oldHash := computeClientConfigHash([]*ClientConfig{{
+		ConfigId:   initial[0].CommandId,
+		ConfigType: initial[0].CommandType,
+		Payload:    initial[0].Payload,
+	}})
+	require.NotEmpty(t, oldHash)
+
+	require.NoError(t, mockStore.DeleteCommand(ctx, configID))
+	transition := mgr.getCommandsForClientWithID(clientID, &milvuspb.ClientHeartbeatRequest{
+		ClientInfo: &commonpb.ClientInfo{Reserved: map[string]string{"client_id": clientID}},
+		ConfigHash: oldHash,
+	})
+	require.Len(t, transition, 1)
+	sentinel := transition[0]
+	assert.Equal(t, emptyConfigSentinelCommandID, sentinel.CommandId)
+	assert.Equal(t, "push_config", sentinel.CommandType)
+	assert.Equal(t, []byte("{}"), sentinel.Payload)
+	assert.Zero(t, sentinel.CreateTime)
+	assert.True(t, sentinel.Persistent)
+	assert.Equal(t, emptyConfigSentinelHash, computeClientConfigHash([]*ClientConfig{{
+		ConfigId:   sentinel.CommandId,
+		ConfigType: sentinel.CommandType,
+		Payload:    sentinel.Payload,
+	}}))
+
+	for name, hash := range map[string]string{
+		"fresh empty hash":    "",
+		"sentinel empty hash": emptyConfigSentinelHash,
+	} {
+		t.Run(name, func(t *testing.T) {
+			commands := mgr.getCommandsForClientWithID(clientID, &milvuspb.ClientHeartbeatRequest{
+				ClientInfo: &commonpb.ClientInfo{Reserved: map[string]string{"client_id": clientID}},
+				ConfigHash: hash,
+			})
+			assert.Empty(t, commands)
+		})
+	}
+
+	_, err = mockStore.PushCommand(ctx, &milvuspb.PushClientCommandRequest{
+		CommandType: "push_config",
+		Payload:     []byte(`{"enabled":false}`),
+		Persistent:  true,
+	})
+	require.NoError(t, err)
+	replacement := mgr.getCommandsForClientWithID(clientID, &milvuspb.ClientHeartbeatRequest{
+		ClientInfo: &commonpb.ClientInfo{Reserved: map[string]string{"client_id": clientID}},
+		ConfigHash: emptyConfigSentinelHash,
+	})
+	require.Len(t, replacement, 1)
+	assert.NotEqual(t, emptyConfigSentinelCommandID, replacement[0].CommandId)
+}
+
+func TestEmptyConfigSentinelReplyIsNotStored(t *testing.T) {
+	mgr := NewTelemetryManager(nil)
+	mgr.SetCommandStore(newMockCommandStore())
+	cache := &ClientMetricsCache{ClientID: "empty-config-client"}
+
+	repliedIDs := mgr.processCommandReplies(cache, []*commonpb.CommandReply{{
+		CommandId: emptyConfigSentinelCommandID,
+		Success:   true,
+		Payload:   []byte(`{"applied":[]}`),
+	}})
+
+	assert.Empty(t, repliedIDs)
+	assert.Empty(t, cache.replies())
+}
+
 func TestGetCommandsForClientWithOneTimeCommand(t *testing.T) {
 	mgr := NewTelemetryManager(nil)
 	mockStore := newMockCommandStore()


### PR DESCRIPTION
issue: #53099

## What problem does this PR solve?

After the last persistent telemetry config matching a client is deleted, the client continues to report its old non-empty config hash. The heartbeat response contains only commands, so an empty command list cannot distinguish an already-matching non-empty config set from an authoritative empty set. Existing SDKs therefore preserve the old hash and never converge.

Related design: https://github.com/milvus-io/milvus/blob/master/docs/design-docs/design_docs/20260131-client_side_telemetry.md

PyMilvus discussion: https://github.com/milvus-io/pymilvus/pull/3770#discussion_r3859469709

## What is changed and how does it work?

- Synthesize a stable persistent no-op push_config sentinel only when the effective config set is empty and the client reports another non-empty hash.
- Accept both the original empty hash and the sentinel hash as converged empty states, so fresh clients receive no extra command.
- Keep the sentinel out of etcd and command List/Delete APIs, and ignore its ACK in ordinary reply history.
- Document the compatibility behavior and its cross-SDK hash vector.

This is a server-only rolling-upgrade fix. It requires no protobuf or SDK change because all telemetry SDKs already accept an empty push_config object as a no-op and calculate the same persistent-command hash.

## Verification

- go test ./internal/rootcoord/telemetry
- go test -race ./internal/rootcoord/telemetry
- go vet ./internal/rootcoord/telemetry
- git diff --check

A broader local go test ./internal/rootcoord/... reaches an unrelated existing Loon CGo ABI mismatch in internal/storagev2/packed; the telemetry package and race suite pass, and PR CI will provide the clean broader build signal.
