### PR TITLE
enhance: [3.0] add mmap field data writeback

### DIFF
--- a/internal/core/src/common/ChunkTarget.cpp
+++ b/internal/core/src/common/ChunkTarget.cpp
@@ -21,6 +21,15 @@
 #include "common/EasyAssert.h"
 
 namespace milvus {
+MmapChunkTarget::~MmapChunkTarget() {
+    if (mapped_data_ != nullptr) {
+        munmap(mapped_data_, cap_);
+    }
+    if (owns_file_ && !file_path_.empty()) {
+        unlink(file_path_.c_str());
+    }
+}
+
 void
 MemChunkTarget::write(const void* data, size_t size) {
     AssertInfo(size + size_ <= cap_, "can not exceed target capacity");
@@ -74,7 +83,14 @@ MmapChunkTarget::release() {
                "failed to map: {}, map_size={}",
                strerror(errno),
                cap_);
-    return static_cast<char*>(m);
+    mapped_data_ = static_cast<char*>(m);
+    return mapped_data_;
+}
+
+void
+MmapChunkTarget::TransferOwnership() noexcept {
+    mapped_data_ = nullptr;
+    owns_file_ = false;
 }
 
 size_t

--- a/internal/core/src/common/ChunkTarget.h
+++ b/internal/core/src/common/ChunkTarget.h
@@ -55,22 +55,38 @@ class ChunkTarget {
     tell() = 0;
 };
 
+enum class MmapChunkWritebackMode {
+    Disabled,
+    FdatasyncOnFinish,
+};
+
 class MmapChunkTarget : public ChunkTarget {
  public:
     explicit MmapChunkTarget(std::string file_path,
                              bool populate,
                              size_t cap,
-                             storage::io::Priority io_prio)
+                             storage::io::Priority io_prio,
+                             MmapChunkWritebackMode writeback_mode =
+                                 MmapChunkWritebackMode::Disabled)
         : file_path_(std::move(file_path)), cap_(cap), populate_(populate) {
         file_writer_ =
             std::make_unique<storage::FileWriter>(file_path_, io_prio);
+        if (writeback_mode == MmapChunkWritebackMode::FdatasyncOnFinish) {
+            file_writer_->SetFdatasyncOnFinish();
+        }
     }
+
+    ~MmapChunkTarget() override;
 
     void
     write(const void* data, size_t size) override;
 
     char*
     release() override;
+
+    // Disarm fallback cleanup after ChunkMmapGuard owns the mapping and path.
+    void
+    TransferOwnership() noexcept;
 
     size_t
     tell() override;
@@ -84,6 +100,8 @@ class MmapChunkTarget : public ChunkTarget {
     size_t cap_{0};
     size_t size_{0};
     bool populate_{false};
+    char* mapped_data_{nullptr};
+    bool owns_file_{true};
 };
 
 class MemChunkTarget : public ChunkTarget {

--- a/internal/core/src/common/ChunkWriter.cpp
+++ b/internal/core/src/common/ChunkWriter.cpp
@@ -772,18 +772,21 @@ create_chunk_buffer(const FieldMeta& field_meta,
                     const arrow::ArrayVector& array_vec,
                     bool mmap_populate,
                     const std::string& file_path,
-                    proto::common::LoadPriority load_priority) {
+                    proto::common::LoadPriority load_priority,
+                    MmapChunkWritebackMode writeback_mode) {
     auto cw = create_chunk_writer(field_meta);
     auto [size, row_nums] = cw->calculate_size(array_vec);
     size_t aligned_size = (size + ChunkTarget::ALIGNED_SIZE - 1) &
                           ~(ChunkTarget::ALIGNED_SIZE - 1);
     std::shared_ptr<ChunkTarget> target;
+    std::shared_ptr<MmapChunkTarget> mmap_target;
     if (file_path.empty()) {
         target = std::make_shared<MemChunkTarget>(aligned_size, mmap_populate);
     } else {
         auto io_prio = storage::io::GetPriorityFromLoadPriority(load_priority);
-        target = std::make_shared<MmapChunkTarget>(
-            file_path, mmap_populate, aligned_size, io_prio);
+        mmap_target = std::make_shared<MmapChunkTarget>(
+            file_path, mmap_populate, aligned_size, io_prio, writeback_mode);
+        target = mmap_target;
     }
     cw->write_to_target(array_vec, target);
     // The writer is one-shot. Release its scratch buffers before a
@@ -794,6 +797,7 @@ create_chunk_buffer(const FieldMeta& field_meta,
     if (!file_path.empty()) {
         chunk_mmap_guard =
             std::make_shared<ChunkMmapGuard>(data, size, file_path);
+        mmap_target->TransferOwnership();
     } else {
         chunk_mmap_guard = std::make_shared<ChunkMmapGuard>(data, size, "");
     }
@@ -820,9 +824,14 @@ create_chunk(const FieldMeta& field_meta,
              const arrow::ArrayVector& array_vec,
              bool mmap_populate,
              const std::string& file_path,
-             proto::common::LoadPriority load_priority) {
-    auto buffer = create_chunk_buffer(
-        field_meta, array_vec, mmap_populate, file_path, load_priority);
+             proto::common::LoadPriority load_priority,
+             MmapChunkWritebackMode writeback_mode) {
+    auto buffer = create_chunk_buffer(field_meta,
+                                      array_vec,
+                                      mmap_populate,
+                                      file_path,
+                                      load_priority,
+                                      writeback_mode);
     return make_chunk_from_buffer(field_meta, buffer, 0);
 }
 
@@ -832,7 +841,8 @@ create_group_chunk(const std::vector<FieldId>& field_ids,
                    const std::vector<arrow::ArrayVector>& array_vec,
                    bool mmap_populate,
                    const std::string& file_path,
-                   proto::common::LoadPriority load_priority) {
+                   proto::common::LoadPriority load_priority,
+                   MmapChunkWritebackMode writeback_mode) {
     std::vector<std::shared_ptr<ChunkWriterBase>> cws;
     cws.reserve(field_ids.size());
     size_t total_aligned_size = 0, final_row_nums = 0;
@@ -865,15 +875,18 @@ create_group_chunk(const std::vector<FieldId>& field_ids,
         }
     }
     std::shared_ptr<ChunkTarget> target;
+    std::shared_ptr<MmapChunkTarget> mmap_target;
     if (file_path.empty()) {
         target =
             std::make_shared<MemChunkTarget>(total_aligned_size, mmap_populate);
     } else {
-        target = std::make_shared<MmapChunkTarget>(
+        mmap_target = std::make_shared<MmapChunkTarget>(
             file_path,
             mmap_populate,
             total_aligned_size,
-            storage::io::GetPriorityFromLoadPriority(load_priority));
+            storage::io::GetPriorityFromLoadPriority(load_priority),
+            writeback_mode);
+        target = mmap_target;
     }
     for (size_t i = 0; i < field_ids.size(); i++) {
         auto start_off = target->tell();
@@ -910,6 +923,7 @@ create_group_chunk(const std::vector<FieldId>& field_ids,
     if (!file_path.empty()) {
         chunk_mmap_guard = std::make_shared<ChunkMmapGuard>(
             data, total_aligned_size, file_path);
+        mmap_target->TransferOwnership();
     } else {
         chunk_mmap_guard =
             std::make_shared<ChunkMmapGuard>(data, total_aligned_size, "");

--- a/internal/core/src/common/ChunkWriter.h
+++ b/internal/core/src/common/ChunkWriter.h
@@ -342,12 +342,14 @@ struct ChunkBuffer {
 // object yet. This is useful when multiple Chunk instances need to share
 // the same underlying memory.
 ChunkBuffer
-create_chunk_buffer(const FieldMeta& field_meta,
-                    const arrow::ArrayVector& array_vec,
-                    bool mmap_populate = true,
-                    const std::string& file_path = "",
-                    proto::common::LoadPriority load_priority =
-                        proto::common::LoadPriority::HIGH);
+create_chunk_buffer(
+    const FieldMeta& field_meta,
+    const arrow::ArrayVector& array_vec,
+    bool mmap_populate = true,
+    const std::string& file_path = "",
+    proto::common::LoadPriority load_priority =
+        proto::common::LoadPriority::HIGH,
+    MmapChunkWritebackMode writeback_mode = MmapChunkWritebackMode::Disabled);
 
 // Create a Chunk view from an existing ChunkBuffer. Multiple Chunk instances
 // created from the same buffer will share the same underlying memory via
@@ -358,21 +360,25 @@ make_chunk_from_buffer(const FieldMeta& field_meta,
                        size_t row_nums_override = 0);
 
 std::unique_ptr<Chunk>
-create_chunk(const FieldMeta& field_meta,
-             const arrow::ArrayVector& array_vec,
-             bool mmap_populate = true,
-             const std::string& file_path = "",
-             proto::common::LoadPriority load_priority =
-                 proto::common::LoadPriority::HIGH);
+create_chunk(
+    const FieldMeta& field_meta,
+    const arrow::ArrayVector& array_vec,
+    bool mmap_populate = true,
+    const std::string& file_path = "",
+    proto::common::LoadPriority load_priority =
+        proto::common::LoadPriority::HIGH,
+    MmapChunkWritebackMode writeback_mode = MmapChunkWritebackMode::Disabled);
 
 std::unordered_map<FieldId, std::shared_ptr<Chunk>>
-create_group_chunk(const std::vector<FieldId>& field_ids,
-                   const std::vector<FieldMeta>& field_metas,
-                   const std::vector<arrow::ArrayVector>& array_vec,
-                   bool mmap_populate = true,
-                   const std::string& file_path = "",
-                   proto::common::LoadPriority load_priority =
-                       proto::common::LoadPriority::HIGH);
+create_group_chunk(
+    const std::vector<FieldId>& field_ids,
+    const std::vector<FieldMeta>& field_metas,
+    const std::vector<arrow::ArrayVector>& array_vec,
+    bool mmap_populate = true,
+    const std::string& file_path = "",
+    proto::common::LoadPriority load_priority =
+        proto::common::LoadPriority::HIGH,
+    MmapChunkWritebackMode writeback_mode = MmapChunkWritebackMode::Disabled);
 
 arrow::ArrayVector
 read_single_column_batches(std::shared_ptr<arrow::RecordBatchReader> reader);

--- a/internal/core/src/common/type_c.h
+++ b/internal/core/src/common/type_c.h
@@ -128,6 +128,7 @@ typedef struct CMmapConfig {
     bool vector_index_enable_mmap;
     bool vector_field_enable_mmap;
     bool mmap_populate;
+    bool mmap_writeback;
     bool json_stats_enable_mmap;
     const char* json_stats_mmap_path;
 } CMmapConfig;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -207,6 +207,13 @@ FormatRuntimeFieldIds(
     return fmt::format("{}", ids);
 }
 
+static MmapChunkWritebackMode
+CreateMmapChunkWritebackMode(const storage::MmapConfig& mmap_config) {
+    return mmap_config.GetMmapWriteback()
+               ? MmapChunkWritebackMode::FdatasyncOnFinish
+               : MmapChunkWritebackMode::Disabled;
+}
+
 static void
 CheckVectorOutputCellsLoaded(int64_t segment_id,
                              FieldId field_id,
@@ -2443,6 +2450,7 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
     size_t num_rows = storage::GetNumRowsForLoadInfo(load_info);
     ArrowSchemaPtr arrow_schema = schema_snapshot->ConvertToArrowSchema();
     auto& mmap_config = storage::MmapManager::GetInstance().GetMmapConfig();
+    auto writeback_mode = CreateMmapChunkWritebackMode(mmap_config);
 
     for (auto& [id, info] : load_info.field_infos) {
         AssertInfo(info.row_count > 0,
@@ -2544,7 +2552,8 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
                 mmap_config.GetMmapPopulate(),
                 milvus_field_ids.size(),
                 load_info.load_priority,
-                warmup_policy);
+                warmup_policy,
+                writeback_mode);
         auto chunked_column_group =
             std::make_shared<ChunkedColumnGroup>(std::move(translator));
 
@@ -2604,6 +2613,7 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
     size_t num_rows = storage::GetNumRowsForLoadInfo(load_info);
     ArrowSchemaPtr arrow_schema = schema_snapshot->ConvertToArrowSchema();
     auto& mmap_config = storage::MmapManager::GetInstance().GetMmapConfig();
+    auto writeback_mode = CreateMmapChunkWritebackMode(mmap_config);
 
     for (auto& [id, info] : load_info.field_infos) {
         AssertInfo(info.row_count > 0,
@@ -2697,7 +2707,8 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
                 mmap_config.GetMmapPopulate(),
                 milvus_field_ids.size(),
                 load_info.load_priority,
-                warmup_policy);
+                warmup_policy,
+                writeback_mode);
         auto chunked_column_group =
             std::make_shared<ChunkedColumnGroup>(std::move(translator));
 
@@ -2798,6 +2809,7 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
     SCOPE_CGO_CALL_METRIC();
 
     auto& mmap_config = storage::MmapManager::GetInstance().GetMmapConfig();
+    auto writeback_mode = CreateMmapChunkWritebackMode(mmap_config);
 
     size_t num_rows = storage::GetNumRowsForLoadInfo(load_info);
     auto visible_runtime_owner =
@@ -2881,7 +2893,8 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
                         info.enable_mmap,
                         mmap_config.GetMmapPopulate(),
                         load_info.load_priority,
-                        warmup_policy);
+                        warmup_policy,
+                        writeback_mode);
 
             auto data_type = field_meta.get_data_type();
             auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot(
@@ -2916,6 +2929,7 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
     SCOPE_CGO_CALL_METRIC();
 
     auto& mmap_config = storage::MmapManager::GetInstance().GetMmapConfig();
+    auto writeback_mode = CreateMmapChunkWritebackMode(mmap_config);
 
     size_t num_rows = storage::GetNumRowsForLoadInfo(load_info);
     auto* staged_runtime = committer.runtime();
@@ -3036,7 +3050,8 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
                         info.enable_mmap,
                         mmap_config.GetMmapPopulate(),
                         load_info.load_priority,
-                        info.warmup_policy);
+                        info.warmup_policy,
+                        writeback_mode);
 
             auto data_type = field_meta.get_data_type();
             auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot(
@@ -7584,6 +7599,7 @@ ChunkedSegmentSealedImpl::fill_empty_field(
         schema_snapshot->MmapEnabled(field_id);
     auto is_vector = IsVectorDataType(field_meta.get_data_type());
     auto& mmap_config = storage::MmapManager::GetInstance().GetMmapConfig();
+    auto writeback_mode = CreateMmapChunkWritebackMode(mmap_config);
     bool global_use_mmap = is_vector ? mmap_config.GetVectorFieldEnableMmap()
                                      : mmap_config.GetScalarFieldEnableMmap();
     bool use_mmap = field_has_setting ? field_mmap_enabled : global_use_mmap;
@@ -7608,7 +7624,8 @@ ChunkedSegmentSealedImpl::fill_empty_field(
             field_data_info,
             use_mmap,
             mmap_config.GetMmapPopulate(),
-            warmup_policy);
+            warmup_policy,
+            writeback_mode);
     auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot(
         std::move(translator), nullptr);
     auto column = MakeChunkedColumnBase(data_type, std::move(slot), field_meta);
@@ -7745,6 +7762,7 @@ ChunkedSegmentSealedImpl::FillDefaultValueFields(
             schema_snapshot->MmapEnabled(field_id);
         auto is_vector = IsVectorDataType(field_meta.get_data_type());
         auto& mmap_config = storage::MmapManager::GetInstance().GetMmapConfig();
+        auto writeback_mode = CreateMmapChunkWritebackMode(mmap_config);
         bool global_use_mmap = is_vector
                                    ? mmap_config.GetVectorFieldEnableMmap()
                                    : mmap_config.GetScalarFieldEnableMmap();
@@ -7773,7 +7791,8 @@ ChunkedSegmentSealedImpl::FillDefaultValueFields(
                 field_data_info,
                 use_mmap,
                 mmap_config.GetMmapPopulate(),
-                warmup_policy);
+                warmup_policy,
+                writeback_mode);
         auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot(
             std::move(translator), nullptr);
         auto column =
@@ -8172,6 +8191,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
     }
 
     auto& mmap_config = storage::MmapManager::GetInstance().GetMmapConfig();
+    auto writeback_mode = CreateMmapChunkWritebackMode(mmap_config);
     bool global_use_mmap = is_vector ? mmap_config.GetVectorFieldEnableMmap()
                                      : mmap_config.GetScalarFieldEnableMmap();
     auto use_mmap = has_mmap_setting ? mmap_enabled : global_use_mmap;
@@ -8246,7 +8266,9 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
             warmup_policy,
             cache_key_suffix,
             segment_load_info.GetEstimatedBytesPerRow(),
-            segment_load_info.GetInsertChannel());
+            segment_load_info.GetInsertChannel(),
+            std::nullopt,
+            writeback_mode);
     auto chunked_column_group =
         std::make_shared<ChunkedColumnGroup>(std::move(translator));
 
@@ -8329,6 +8351,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
     }
 
     auto& mmap_config = storage::MmapManager::GetInstance().GetMmapConfig();
+    auto writeback_mode = CreateMmapChunkWritebackMode(mmap_config);
     bool global_use_mmap = is_vector ? mmap_config.GetVectorFieldEnableMmap()
                                      : mmap_config.GetScalarFieldEnableMmap();
     auto use_mmap = has_mmap_setting ? mmap_enabled : global_use_mmap;
@@ -8392,7 +8415,8 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
             cache_key_suffix,
             segment_load_info.GetEstimatedBytesPerRow(),
             segment_load_info.GetInsertChannel(),
-            std::move(column_size_estimate));
+            std::move(column_size_estimate),
+            writeback_mode);
     auto chunked_column_group =
         std::make_shared<ChunkedColumnGroup>(std::move(translator));
 

--- a/internal/core/src/segcore/storagev1translator/ChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/ChunkTranslator.cpp
@@ -76,7 +76,8 @@ ChunkTranslator::ChunkTranslator(
     bool use_mmap,
     bool mmap_populate,
     milvus::proto::common::LoadPriority load_priority,
-    const std::string& warmup_policy)
+    const std::string& warmup_policy,
+    MmapChunkWritebackMode writeback_mode)
     : segment_id_(segment_id),
       field_id_(field_data_info.field_id),
       field_meta_(field_meta),
@@ -99,6 +100,7 @@ ChunkTranslator::ChunkTranslator(
                 /* in_load_list*/ field_data_info.in_load_list),
             /* support_eviction */ true,
             field_data_info.shard),
+      writeback_mode_(writeback_mode),
       load_priority_(load_priority) {
     AssertInfo(!SystemProperty::Instance().IsSystem(FieldId(field_id_)),
                "ChunkTranslator not supported for system field");
@@ -213,7 +215,8 @@ ChunkTranslator::get_cells(
                                  array_vec,
                                  mmap_populate_,
                                  filepath.string(),
-                                 load_priority_);
+                                 load_priority_,
+                                 writeback_mode_);
         }
         cells.emplace_back(cid, std::move(chunk));
     }

--- a/internal/core/src/segcore/storagev1translator/ChunkTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/ChunkTranslator.h
@@ -18,6 +18,7 @@
 #include "cachinglayer/Translator.h"
 #include "cachinglayer/Utils.h"
 #include "common/Chunk.h"
+#include "common/ChunkTarget.h"
 #include "common/type_c.h"
 #include "mmap/Types.h"
 #include "segcore/CacheMetricAttribution.h"
@@ -72,7 +73,9 @@ class ChunkTranslator : public milvus::cachinglayer::Translator<milvus::Chunk> {
                     bool use_mmap,
                     bool mmap_populate,
                     milvus::proto::common::LoadPriority load_priority,
-                    const std::string& warmup_policy);
+                    const std::string& warmup_policy,
+                    MmapChunkWritebackMode writeback_mode =
+                        MmapChunkWritebackMode::Disabled);
 
     size_t
     num_cells() const override;
@@ -115,6 +118,7 @@ class ChunkTranslator : public milvus::cachinglayer::Translator<milvus::Chunk> {
     CTMeta meta_;
     FieldMeta field_meta_;
     std::string mmap_dir_path_;
+    MmapChunkWritebackMode writeback_mode_;
     milvus::proto::common::LoadPriority load_priority_{
         milvus::proto::common::LoadPriority::HIGH};
 };

--- a/internal/core/src/segcore/storagev1translator/DefaultValueChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/DefaultValueChunkTranslator.cpp
@@ -40,13 +40,15 @@ DefaultValueChunkTranslator::DefaultValueChunkTranslator(
     FieldDataInfo field_data_info,
     bool use_mmap,
     bool mmap_populate,
-    const std::string& warmup_policy)
+    const std::string& warmup_policy,
+    MmapChunkWritebackMode writeback_mode)
     : total_rows_(field_data_info.row_count),
       segment_id_(segment_id),
       key_(
           fmt::format("seg_{}_f_{}_def", segment_id, field_data_info.field_id)),
       use_mmap_(use_mmap),
       mmap_populate_(mmap_populate),
+      writeback_mode_(writeback_mode),
       mmap_dir_path_(field_data_info.mmap_dir_path),
       field_meta_(field_meta),
       meta_(use_mmap ? milvus::cachinglayer::StorageType::DISK
@@ -281,8 +283,12 @@ DefaultValueChunkTranslator::build_buffer_for_rows(
             std::filesystem::path(mmap_dir_path_) /
             fmt::format("seg_{}_f_{}_def{}", segment_id_, field_id_, suffix);
         std::filesystem::create_directories(filepath.parent_path());
-        return milvus::create_chunk_buffer(
-            field_meta_, array_vec, mmap_populate_, filepath.string());
+        return milvus::create_chunk_buffer(field_meta_,
+                                           array_vec,
+                                           mmap_populate_,
+                                           filepath.string(),
+                                           proto::common::LoadPriority::HIGH,
+                                           writeback_mode_);
     }
 }
 

--- a/internal/core/src/segcore/storagev1translator/DefaultValueChunkTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/DefaultValueChunkTranslator.h
@@ -40,7 +40,9 @@ class DefaultValueChunkTranslator
                                 FieldDataInfo field_data_info,
                                 bool use_mmap,
                                 bool mmap_populate,
-                                const std::string& warmup_policy = "");
+                                const std::string& warmup_policy = "",
+                                MmapChunkWritebackMode writeback_mode =
+                                    MmapChunkWritebackMode::Disabled);
     ~DefaultValueChunkTranslator() override;
     size_t
     num_cells() const override;
@@ -103,6 +105,7 @@ class DefaultValueChunkTranslator
     std::string key_;
     bool use_mmap_;
     bool mmap_populate_;
+    MmapChunkWritebackMode writeback_mode_;
     std::string mmap_dir_path_;
     CTMeta meta_;
     milvus::FieldMeta field_meta_;

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -76,7 +76,8 @@ GroupChunkTranslator::GroupChunkTranslator(
     bool mmap_populate,
     int64_t num_fields,
     milvus::proto::common::LoadPriority load_priority,
-    const std::string& warmup_policy)
+    const std::string& warmup_policy,
+    MmapChunkWritebackMode writeback_mode)
     : segment_id_(segment_id),
       group_chunk_type_(group_chunk_type),
       key_([&]() {
@@ -137,6 +138,7 @@ GroupChunkTranslator::GroupChunkTranslator(
                                        return field.second.get_data_type() ==
                                               DataType::ARRAY;
                                    })),
+      writeback_mode_(writeback_mode),
       load_priority_(load_priority) {
     // Build prefix sum for O(1) lookup in get_cid_from_file_and_row_group_index
     file_row_group_prefix_sum_.reserve(row_group_meta_list_.size() + 1);
@@ -534,7 +536,8 @@ GroupChunkTranslator::load_group_chunk(
                                     array_vecs,
                                     mmap_populate_,
                                     filepath.string(),
-                                    load_priority_);
+                                    load_priority_,
+                                    writeback_mode_);
     }
     return std::make_unique<milvus::GroupChunk>(chunks);
 }

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.h
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.h
@@ -22,6 +22,7 @@
 
 #include "cachinglayer/Translator.h"
 #include "cachinglayer/Utils.h"
+#include "common/ChunkTarget.h"
 #include "milvus-storage/common/metadata.h"
 #include "mmap/Types.h"
 #include "common/Types.h"
@@ -46,7 +47,9 @@ class GroupChunkTranslator
         bool mmap_populate,
         int64_t num_fields,
         milvus::proto::common::LoadPriority load_priority,
-        const std::string& warmup_policy);
+        const std::string& warmup_policy,
+        MmapChunkWritebackMode writeback_mode =
+            MmapChunkWritebackMode::Disabled);
 
     ~GroupChunkTranslator() override;
 
@@ -114,6 +117,7 @@ class GroupChunkTranslator
     bool use_mmap_;
     bool mmap_populate_;
     bool has_array_field_{false};
+    MmapChunkWritebackMode writeback_mode_;
     milvus::proto::common::LoadPriority load_priority_{
         milvus::proto::common::LoadPriority::HIGH};
 };

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -93,7 +93,8 @@ ManifestGroupTranslator::ManifestGroupTranslator(
     const std::string& cache_key_suffix,
     int64_t fallback_bytes_per_row,
     std::string shard,
-    std::optional<ColumnSizeEstimateResult> column_size_estimate)
+    std::optional<ColumnSizeEstimateResult> column_size_estimate,
+    MmapChunkWritebackMode writeback_mode)
     : segment_id_(segment_id),
       group_chunk_type_(group_chunk_type),
       column_group_index_(column_group_index),
@@ -145,6 +146,7 @@ ManifestGroupTranslator::ManifestGroupTranslator(
                                        return field.second.get_data_type() ==
                                               DataType::ARRAY;
                                    })),
+      writeback_mode_(writeback_mode),
       load_priority_(load_priority) {
     auto rows_result = chunk_reader_->get_chunk_rows();
     if (!rows_result.ok()) {
@@ -757,7 +759,8 @@ ManifestGroupTranslator::load_group_chunk(
                                     array_vecs,
                                     mmap_populate_,
                                     filepath.string(),
-                                    load_priority_);
+                                    load_priority_,
+                                    writeback_mode_);
     }
 
     return std::make_unique<milvus::GroupChunk>(chunks);

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.h
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.h
@@ -31,6 +31,7 @@
 #include "arrow/table.h"
 #include "cachinglayer/Translator.h"
 #include "cachinglayer/Utils.h"
+#include "common/ChunkTarget.h"
 #include "common/FieldMeta.h"
 #include "common/GroupChunk.h"
 #include "common/OpContext.h"
@@ -100,7 +101,9 @@ class ManifestGroupTranslator
         int64_t fallback_bytes_per_row = 0,
         std::string shard = "",
         std::optional<ColumnSizeEstimateResult> column_size_estimate =
-            std::nullopt);
+            std::nullopt,
+        MmapChunkWritebackMode writeback_mode =
+            MmapChunkWritebackMode::Disabled);
     ~ManifestGroupTranslator() = default;
 
     /**
@@ -220,6 +223,7 @@ class ManifestGroupTranslator
     bool mmap_populate_;
     bool has_array_field_{false};
     std::string mmap_dir_path_;
+    MmapChunkWritebackMode writeback_mode_;
     milvus::proto::common::LoadPriority load_priority_{
         milvus::proto::common::LoadPriority::HIGH};
 };

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslatorTest.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslatorTest.cpp
@@ -239,7 +239,12 @@ class ManifestGroupTranslatorTest : public ::testing::TestWithParam<bool> {
             field_metas.size(),
             milvus::proto::common::LoadPriority::LOW,
             /*eager_load=*/true,
-            /*warmup_policy=*/"");
+            /*warmup_policy=*/"",
+            /*cache_key_suffix=*/"",
+            /*fallback_bytes_per_row=*/0,
+            /*shard=*/"",
+            /*column_size_estimate=*/std::nullopt,
+            MmapChunkWritebackMode::Disabled);
     }
 
     SchemaPtr schema_;

--- a/internal/core/src/storage/FileWriter.cpp
+++ b/internal/core/src/storage/FileWriter.cpp
@@ -173,6 +173,11 @@ FileWriter::~FileWriter() {
 }
 
 void
+FileWriter::SetFdatasyncOnFinish() {
+    fdatasync_on_finish_ = true;
+}
+
+void
 FileWriter::Cleanup() noexcept {
     if (fd_ != -1) {
         close(fd_);
@@ -208,6 +213,27 @@ FileWriter::PositionedWriteWithCheck(const void* data,
     } catch (...) {
         Cleanup();
         throw;
+    }
+}
+
+void
+FileWriter::SyncFileData() {
+    if (sync_file_data_hook_for_test_) {
+        sync_file_data_hook_for_test_();
+        return;
+    }
+#ifdef __APPLE__
+    auto ret = fsync(fd_);
+#else
+    auto ret = fdatasync(fd_);
+#endif
+    if (ret != 0) {
+        auto saved_errno = errno;
+        Cleanup();
+        ThrowInfo(ErrorCode::FileWriteFailed,
+                  "Failed to sync file data: {}, error: {}",
+                  filename_,
+                  strerror(saved_errno));
     }
 }
 
@@ -297,7 +323,7 @@ FileWriter::Write(const void* data, size_t nbyte) {
     // fallback to write the data directly if the task cannot be added to the pool
     if (FileWriteWorkerPool::GetInstance().AddTask(task)) {
         try {
-            future.wait();
+            std::move(future).get();
         } catch (const std::exception& e) {
             Cleanup();
             ThrowInfo(ErrorCode::FileWriteFailed,
@@ -342,17 +368,29 @@ FileWriter::FlushWithBufferedIO() {
 
 size_t
 FileWriter::Finish() {
-    // if the aligned buffer is not empty, we should flush it to the file
-    if (offset_ != 0) {
-        auto promise = std::make_shared<folly::Promise<folly::Unit>>();
-        auto future = promise->getFuture();
-        auto task = [this, promise]() {
-            try {
+    const bool needs_finish_task =
+        offset_ != 0 ||
+        (fdatasync_on_finish_ && !use_direct_io_ && file_size_ != 0);
+    if (needs_finish_task) {
+        const auto finish_file = [this]() {
+            // Keep the final flush and sync in the same worker-pool task so
+            // diskWriteNumThreads limits both operations.
+            if (offset_ != 0) {
                 if (use_direct_io_) {
                     FlushWithDirectIO();
                 } else {
                     FlushWithBufferedIO();
                 }
+            }
+            if (fdatasync_on_finish_ && !use_direct_io_) {
+                SyncFileData();
+            }
+        };
+        auto promise = std::make_shared<folly::Promise<folly::Unit>>();
+        auto future = promise->getFuture();
+        auto task = [finish_file, promise]() {
+            try {
+                finish_file();
                 promise->setValue(folly::Unit{});
             } catch (...) {
                 promise->setException(
@@ -362,20 +400,16 @@ FileWriter::Finish() {
 
         if (FileWriteWorkerPool::GetInstance().AddTask(task)) {
             try {
-                future.wait();
+                std::move(future).get();
             } catch (const std::exception& e) {
                 Cleanup();
                 ThrowInfo(ErrorCode::FileWriteFailed,
-                          "Failed to flush file: {}, error: {}",
+                          "Failed to finish file: {}, error: {}",
                           filename_,
                           e.what());
             }
         } else {
-            if (use_direct_io_) {
-                FlushWithDirectIO();
-            } else {
-                FlushWithBufferedIO();
-            }
+            finish_file();
         }
     }
 

--- a/internal/core/src/storage/FileWriter.h
+++ b/internal/core/src/storage/FileWriter.h
@@ -38,6 +38,8 @@
 
 namespace milvus::storage {
 
+class FileWriterTestAccessor;
+
 namespace io {
 enum class Priority { HIGH = 0, MIDDLE = 1, LOW = 2, NR_PRIORITY = 3 };
 
@@ -221,6 +223,9 @@ class FileWriter {
     ~FileWriter();
 
     void
+    SetFdatasyncOnFinish();
+
+    void
     Write(const void* data, size_t size);
 
     size_t
@@ -240,8 +245,13 @@ class FileWriter {
     GetBufferSize();
 
  private:
+    friend class FileWriterTestAccessor;
+
     void
     WriteInternal(const void* data, size_t nbyte);
+
+    void
+    SyncFileData();
 
     void
     FlushWithDirectIO();
@@ -271,6 +281,9 @@ class FileWriter {
     void* aligned_buf_{nullptr};
     size_t capacity_{0};
     size_t offset_{0};
+    bool fdatasync_on_finish_{false};
+    // Used by FileWriterTestAccessor to block the sync point deterministically.
+    std::function<void()> sync_file_data_hook_for_test_;
 
     // for global configuration
     static WriteMode

--- a/internal/core/src/storage/FileWriterTest.cpp
+++ b/internal/core/src/storage/FileWriterTest.cpp
@@ -17,13 +17,17 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <future>
 #include <iterator>
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <sys/mman.h>
 #include <thread>
+#include <unistd.h>
 #include <vector>
 
+#include "common/ChunkTarget.h"
 #include "common/EasyAssert.h"
 #include "gtest/gtest.h"
 #include "storage/FileWriter.h"
@@ -31,6 +35,29 @@
 
 using namespace milvus;
 using namespace milvus::storage;
+
+namespace milvus::storage {
+
+class FileWriterTestAccessor {
+ public:
+    static bool
+    ShouldFdatasyncOnFinish(const FileWriter& writer) {
+        return writer.fdatasync_on_finish_ && !writer.use_direct_io_;
+    }
+
+    static void
+    SetSyncFileDataHook(FileWriter& writer, std::function<void()> hook) {
+        writer.sync_file_data_hook_for_test_ = std::move(hook);
+    }
+
+    static void
+    InvalidateFd(FileWriter& writer) {
+        close(writer.fd_);
+        writer.fd_ = -1;
+    }
+};
+
+}  // namespace milvus::storage
 
 class FileWriterTest : public testing::Test {
  protected:
@@ -57,6 +84,17 @@ class FileWriterTest : public testing::Test {
     const size_t kBufferSize = 4096;  // 4KB buffer size
 };
 
+namespace {
+
+std::string
+ReadFile(const std::string& filename) {
+    std::ifstream file(filename, std::ios::binary);
+    return {std::istreambuf_iterator<char>(file),
+            std::istreambuf_iterator<char>()};
+}
+
+}  // namespace
+
 // Test basic file writing functionality with buffered IO
 TEST_F(FileWriterTest, BasicWriteWithBufferedIO) {
     FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
@@ -73,6 +111,163 @@ TEST_F(FileWriterTest, BasicWriteWithBufferedIO) {
     std::string content((std::istreambuf_iterator<char>(file)),
                         std::istreambuf_iterator<char>());
     EXPECT_EQ(content, test_data);
+}
+
+TEST_F(FileWriterTest, FinishWithFdatasyncWriteback) {
+    FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
+
+    std::string filename = (test_dir_ / "fdatasync_writeback.txt").string();
+    FileWriter writer(filename);
+    writer.SetFdatasyncOnFinish();
+    EXPECT_TRUE(FileWriterTestAccessor::ShouldFdatasyncOnFinish(writer));
+
+    std::string test_data(kBufferSize + 17, 'x');
+    writer.Write(test_data.data(), test_data.size());
+    writer.Finish();
+
+    EXPECT_EQ(ReadFile(filename), test_data);
+}
+
+TEST_F(FileWriterTest, FinishSkipsFdatasyncWritebackWithDirectIO) {
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(kBufferSize);
+
+    std::string filename =
+        (test_dir_ / "direct_io_skips_fdatasync.txt").string();
+    FileWriter writer(filename);
+    writer.SetFdatasyncOnFinish();
+    EXPECT_FALSE(FileWriterTestAccessor::ShouldFdatasyncOnFinish(writer));
+
+    std::string test_data(kBufferSize + 17, 'x');
+    writer.Write(test_data.data(), test_data.size());
+    writer.Finish();
+
+    EXPECT_EQ(ReadFile(filename), test_data);
+}
+
+TEST_F(FileWriterTest, FinishKeepsFdatasyncInWriterPool) {
+    FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
+    FileWriteWorkerPool::GetInstance().Configure(1);
+
+    for (bool has_tail_flush : {false, true}) {
+        SCOPED_TRACE(has_tail_flush ? "with tail flush" : "without tail flush");
+
+        auto first_filename =
+            (test_dir_ /
+             (has_tail_flush ? "sync_with_tail" : "sync_without_tail"))
+                .string();
+        FileWriter first_writer(first_filename);
+        first_writer.SetFdatasyncOnFinish();
+        std::string first_data(
+            has_tail_flush ? kBufferSize + 1 : kBufferSize * 2, 'x');
+        first_writer.Write(first_data.data(), first_data.size());
+
+        std::promise<void> sync_started;
+        auto sync_started_future = sync_started.get_future();
+        std::promise<void> release_sync;
+        auto release_sync_future = release_sync.get_future().share();
+        FileWriterTestAccessor::SetSyncFileDataHook(
+            first_writer, [&sync_started, release_sync_future]() {
+                sync_started.set_value();
+                release_sync_future.wait();
+            });
+
+        auto first_finish = std::async(std::launch::async, [&first_writer]() {
+            return first_writer.Finish();
+        });
+        sync_started_future.wait();
+
+        auto second_filename =
+            (test_dir_ /
+             (has_tail_flush ? "second_with_tail" : "second_without_tail"))
+                .string();
+        FileWriter second_writer(second_filename);
+        std::string second_data(kBufferSize, 'y');
+        second_writer.Write(second_data.data(), second_data.size());
+        auto second_finish = std::async(std::launch::async, [&second_writer]() {
+            return second_writer.Finish();
+        });
+
+        EXPECT_EQ(second_finish.wait_for(std::chrono::seconds(1)),
+                  std::future_status::timeout);
+
+        release_sync.set_value();
+        EXPECT_EQ(first_finish.get(), first_data.size());
+        EXPECT_EQ(second_finish.get(), second_data.size());
+    }
+
+    FileWriteWorkerPool::GetInstance().Configure(0);
+}
+
+TEST_F(FileWriterTest, FinishPropagatesPooledSyncFailure) {
+    FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
+    FileWriteWorkerPool::GetInstance().Configure(1);
+
+    std::string filename = (test_dir_ / "pooled_sync_failure.txt").string();
+    FileWriter writer(filename);
+    writer.SetFdatasyncOnFinish();
+    std::string test_data(kBufferSize * 2, 'x');
+    writer.Write(test_data.data(), test_data.size());
+    FileWriterTestAccessor::SetSyncFileDataHook(
+        writer, []() { throw std::runtime_error("injected sync failure"); });
+
+    EXPECT_THROW(writer.Finish(), std::runtime_error);
+
+    FileWriteWorkerPool::GetInstance().Configure(0);
+}
+
+TEST_F(FileWriterTest, WritePropagatesPooledFailure) {
+    FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
+    FileWriter::SetBufferSize(kBufferSize);
+    FileWriteWorkerPool::GetInstance().Configure(1);
+
+    std::string filename = (test_dir_ / "pooled_write_failure.txt").string();
+    FileWriter writer(filename);
+    FileWriterTestAccessor::InvalidateFd(writer);
+    std::string test_data(kBufferSize * 2, 'x');
+
+    EXPECT_THROW(writer.Write(test_data.data(), test_data.size()),
+                 std::runtime_error);
+
+    FileWriteWorkerPool::GetInstance().Configure(0);
+}
+
+TEST_F(FileWriterTest, MmapChunkTargetWithWriteback) {
+    FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
+
+    std::string filename = (test_dir_ / "mmap_chunk_target").string();
+    MmapChunkTarget target(filename,
+                           /*populate=*/false,
+                           kBufferSize,
+                           io::Priority::LOW,
+                           MmapChunkWritebackMode::FdatasyncOnFinish);
+
+    std::string test_data = "mmap writeback";
+    target.write(test_data.data(), test_data.size());
+    auto* data = target.release();
+    ASSERT_NE(data, nullptr);
+    EXPECT_EQ(std::string(data, test_data.size()), test_data);
+    target.TransferOwnership();
+
+    EXPECT_EQ(munmap(data, kBufferSize), 0);
+    EXPECT_EQ(unlink(filename.c_str()), 0);
+}
+
+TEST_F(FileWriterTest, MmapChunkTargetCleansUpFileWhenReleaseFails) {
+    FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
+
+    std::string filename = (test_dir_ / "mmap_release_failure").string();
+    {
+        MmapChunkTarget target(filename,
+                               /*populate=*/false,
+                               /*cap=*/0,
+                               io::Priority::LOW,
+                               MmapChunkWritebackMode::FdatasyncOnFinish);
+        ASSERT_TRUE(std::filesystem::exists(filename));
+        EXPECT_ANY_THROW(target.release());
+    }
+
+    EXPECT_FALSE(std::filesystem::exists(filename));
 }
 
 // Test basic file writing functionality with direct IO

--- a/internal/core/src/storage/Types.h
+++ b/internal/core/src/storage/Types.h
@@ -163,6 +163,7 @@ struct MmapConfig {
     bool vector_index_enable_mmap;
     bool vector_field_enable_mmap;
     bool mmap_populate;
+    bool mmap_writeback{false};
     bool json_stats_enable_mmap;
     std::string json_stats_mmap_path;
     bool
@@ -188,6 +189,11 @@ struct MmapConfig {
     [[nodiscard]] bool
     GetMmapPopulate() const {
         return mmap_populate;
+    }
+
+    [[nodiscard]] bool
+    GetMmapWriteback() const {
+        return mmap_writeback;
     }
 
     [[nodiscard]] bool
@@ -219,8 +225,8 @@ struct MmapConfig {
            << ", vector_index_enable_mmap=" << std::boolalpha
            << vector_index_enable_mmap
            << ", vector_field_enable_mmap=" << std::boolalpha
-           << vector_field_enable_mmap
-           << ", json_stats_enable_mmap=" << std::boolalpha
+           << vector_field_enable_mmap << ", mmap_writeback=" << std::boolalpha
+           << mmap_writeback << ", json_stats_enable_mmap=" << std::boolalpha
            << json_stats_enable_mmap
            << ", json_stats_mmap_path=" << json_stats_mmap_path << "]";
         return ss.str();

--- a/internal/core/src/storage/storage_c.cpp
+++ b/internal/core/src/storage/storage_c.cpp
@@ -131,6 +131,7 @@ InitMmapManager(CMmapConfig c_mmap_config) {
         mmap_config.vector_field_enable_mmap =
             c_mmap_config.vector_field_enable_mmap;
         mmap_config.mmap_populate = c_mmap_config.mmap_populate;
+        mmap_config.mmap_writeback = c_mmap_config.mmap_writeback;
         mmap_config.json_stats_enable_mmap =
             c_mmap_config.json_stats_enable_mmap;
         mmap_config.json_stats_mmap_path =

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -309,6 +309,7 @@ func InitMmapManager(params *paramtable.ComponentParam, nodeID int64) error {
 		vector_index_enable_mmap: C.bool(params.QueryNodeCfg.MmapVectorIndex.GetAsBool()),
 		vector_field_enable_mmap: C.bool(params.QueryNodeCfg.MmapVectorField.GetAsBool()),
 		mmap_populate:            C.bool(params.QueryNodeCfg.MmapPopulate.GetAsBool()),
+		mmap_writeback:           C.bool(params.QueryNodeCfg.MmapWriteback.GetAsBool()),
 		json_stats_enable_mmap:   C.bool(params.QueryNodeCfg.MmapJSONStats.GetAsBool()),
 		json_stats_mmap_path:     cJSONStatsMmapPath,
 	}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3786,6 +3786,7 @@ type queryNodeConfig struct {
 	MmapScalarField                     ParamItem `refreshable:"false"`
 	MmapScalarIndex                     ParamItem `refreshable:"false"`
 	MmapPopulate                        ParamItem `refreshable:"false"`
+	MmapWriteback                       ParamItem `refreshable:"false"`
 	MmapJSONStats                       ParamItem `refreshable:"false"`
 	GrowingMmapEnabled                  ParamItem `refreshable:"false"`
 	FixedFileSizeForMmapManager         ParamItem `refreshable:"false"`
@@ -4658,6 +4659,15 @@ This defaults to true, indicating that Milvus creates temporary index for growin
 		Export:       false,
 	}
 	p.MmapPopulate.Init(base.mgr)
+
+	p.MmapWriteback = ParamItem{
+		Key:          "queryNode.mmap.writeback",
+		Version:      "3.0.0",
+		DefaultValue: "false",
+		Doc:          "Enable fdatasync after writing each mmap field data file with buffered I/O.",
+		Export:       false,
+	}
+	p.MmapWriteback.Init(base.mgr)
 
 	p.MmapJSONStats = ParamItem{
 		Key:          "queryNode.mmap.jsonShredding",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -106,6 +106,20 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, "queryNode.search.enableResultZeroCopy", params.QueryNodeCfg.EnableResultZeroCopy.Key)
 	})
 
+	t.Run("query node mmap writeback config", func(t *testing.T) {
+		item := &params.QueryNodeCfg.MmapWriteback
+		t.Cleanup(func() {
+			params.Reset(item.Key)
+		})
+
+		assert.Equal(t, "queryNode.mmap.writeback", item.Key)
+		assert.False(t, item.Export)
+		assert.False(t, item.GetAsBool())
+
+		params.Save(item.Key, "true")
+		assert.True(t, item.GetAsBool())
+	})
+
 	t.Run("test commonConfig", func(t *testing.T) {
 		Params := &params.CommonCfg
 


### PR DESCRIPTION
issue: #51245
pr: #52077

- Backport mmap field-data writeback support from #52077 to `3.0`.
- Add the disabled-by-default `queryNode.mmap.writeback` option and skip `fdatasync` when direct I/O is used.
- Propagate the typed writeback mode through sealed-segment translators and mmap chunk creation.

This only backports the writeback primitive; it does not enable the async field-data load path.