### PR TITLE
fix: provide explicit embedding list count to knowhere

### DIFF
--- a/internal/core/src/common/VectorArrayStorageV2Test.cpp
+++ b/internal/core/src/common/VectorArrayStorageV2Test.cpp
@@ -391,6 +391,8 @@ TEST_F(TestVectorArrayStorageV2, BuildEmbListHNSWIndex) {
         query_vec_offsets.push_back(10);
         query_dataset->Set(knowhere::meta::EMB_LIST_OFFSET,
                            const_cast<const size_t*>(query_vec_offsets.data()));
+        query_dataset->Set(knowhere::meta::EMB_LIST_COUNT,
+                           static_cast<int64_t>(query_vec_offsets.size() - 1));
 
         auto search_conf = knowhere::Json{{knowhere::indexparam::NPROBE, 10}};
         milvus::SearchInfo searchInfo;
@@ -531,6 +533,8 @@ TEST_F(TestVectorArrayStorageV2, BuildEmbListHNSWIndexWithMmap) {
         query_vec_lims.push_back(10);
         query_dataset->Set(knowhere::meta::EMB_LIST_OFFSET,
                            const_cast<const size_t*>(query_vec_lims.data()));
+        query_dataset->Set(knowhere::meta::EMB_LIST_COUNT,
+                           static_cast<int64_t>(query_vec_lims.size() - 1));
 
         auto search_conf = knowhere::Json{{knowhere::indexparam::NPROBE, 10}};
         milvus::SearchInfo searchInfo;
@@ -675,6 +679,8 @@ TEST_F(TestVectorArrayStorageV2, BuildEncodedEmbListHNSWIndexWithMmap) {
         std::vector<size_t> query_vec_lims = {0, 3, 10};
         query_dataset->Set(knowhere::meta::EMB_LIST_OFFSET,
                            const_cast<const size_t*>(query_vec_lims.data()));
+        query_dataset->Set(knowhere::meta::EMB_LIST_COUNT,
+                           static_cast<int64_t>(query_vec_lims.size() - 1));
 
         auto search_conf = knowhere::Json{
             {knowhere::indexparam::EF, 64},

--- a/internal/core/src/index/VectorMemIndex.cpp
+++ b/internal/core/src/index/VectorMemIndex.cpp
@@ -693,6 +693,13 @@ VectorMemIndex<T>::Build(const Config& config) {
         if (!offsets.empty()) {
             dataset->Set(knowhere::meta::EMB_LIST_OFFSET,
                          const_cast<const size_t*>(offsets.data()));
+            // offsets holds the prefix sums of every embedding list plus the
+            // terminal total, so the embedding list count is one less than its
+            // size. Knowhere requires this count explicitly: it cannot infer
+            // the array length from the offsets alone, and scanning for a
+            // sentinel silently drops trailing empty lists.
+            dataset->Set(knowhere::meta::EMB_LIST_COUNT,
+                         static_cast<int64_t>(offsets.size() - 1));
         }
         BuildWithDataset(dataset, build_config);
     } else {

--- a/internal/core/src/query/SearchBruteForce.cpp
+++ b/internal/core/src/query/SearchBruteForce.cpp
@@ -188,6 +188,7 @@ PrepareBFDataSet(const dataset::SearchDataset& query_ds,
         // in offsets which equals to the total number of vectors.
         base_dataset->Set(knowhere::meta::EMB_LIST_OFFSET,
                           raw_ds.raw_data_offsets);
+        base_dataset->Set(knowhere::meta::EMB_LIST_COUNT, raw_ds.num_raw_data);
 
         // the length of offsets equals to the number of embedding lists + 1
         base_dataset->SetRows(raw_ds.raw_data_offsets[raw_ds.num_raw_data]);
@@ -199,6 +200,8 @@ PrepareBFDataSet(const dataset::SearchDataset& query_ds,
         // ditto
         query_dataset->Set(knowhere::meta::EMB_LIST_OFFSET,
                            query_ds.query_offsets);
+        query_dataset->Set(knowhere::meta::EMB_LIST_COUNT,
+                           query_ds.num_queries);
         query_dataset->Set(knowhere::meta::NQ, query_ds.num_queries);
 
         query_dataset->SetRows(query_ds.query_offsets[query_ds.num_queries]);

--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -82,6 +82,7 @@ SearchOnSealedIndex(const Schema& schema,
         auto num_vectors = query_offsets[num_queries];
         dataset = knowhere::GenDataSet(num_vectors, dim, query_data);
         dataset->Set(knowhere::meta::EMB_LIST_OFFSET, query_offsets);
+        dataset->Set(knowhere::meta::EMB_LIST_COUNT, num_queries);
         dataset->Set(knowhere::meta::NQ, num_queries);
     }
 

--- a/internal/core/src/storage/DiskFileManagerTest.cpp
+++ b/internal/core/src/storage/DiskFileManagerTest.cpp
@@ -2031,6 +2031,7 @@ TEST_F(DiskAnnFileManagerTest, BuildAllValidEmptyEmbListDiskIndexFromBinlog) {
     std::vector<size_t> query_offsets(num_rows + 1, 0);
     query_dataset->Set(knowhere::meta::EMB_LIST_OFFSET,
                        const_cast<const size_t*>(query_offsets.data()));
+    query_dataset->Set(knowhere::meta::EMB_LIST_COUNT, num_rows);
     query_dataset->Set(knowhere::meta::NQ, num_rows);
 
     SearchInfo search_info;

--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update KNOWHERE_VERSION for the first occurrence
 milvus_add_pkg_config("knowhere")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( KNOWHERE_VERSION dd3dce0f )
+set( KNOWHERE_VERSION 2868882b )
 set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
 
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")


### PR DESCRIPTION
## Summary

Knowhere no longer infers the number of embedding lists from the offset array alone. Scanning the offsets for a sentinel value silently swallows trailing empty lists: an empty list does not advance the cumulative offset, so a run of empty lists at the tail of a batch appears as a run of repeated terminal values and the scan stopped at the first of them.

zilliztech/knowhere#1801 removes that scan and requires the list count to be passed explicitly through the new `EMB_LIST_COUNT` dataset metadata key. This PR moves the pin from `dd3dce0f` to `2868882b` and populates the key at every site where Milvus hands Knowhere an embedding-list dataset:

- `VectorMemIndex::Build` — index build (`offsets.size() - 1`)
- `SearchOnSealedIndex` — sealed index search (`num_queries`)
- `PrepareBFDataSet` — brute-force base (`num_raw_data`) and query (`num_queries`) datasets

The key becomes mandatory with this pin, so the dependency update and the adaptation have to land together; the affected unit tests are updated in the same commit.

This is what fixes #52933: a query batch of `[non-empty, empty, empty]` passes `NQ=3`, but the indexed search path used to produce a single result set and Reduce failed with `wrong seg offsets size, size = 10, expected size = 30`.

issue: #53080

## Test Plan

- [x] `clang-format-15` clean on every touched file
- [ ] CI build, `ut-cpp`, and e2e
