### PR TITLE
doc: clarify tiered storage disk watermark limits

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -618,7 +618,12 @@ queryNode:
       # eviction is necessary and the amount of data to evict from memory/disk.
       # - If the current memory/disk usage exceeds the high watermark, an eviction will be triggered to evict data from memory/disk
       #   until the memory/disk usage is below the low watermark.
-      # - The max amount of memory/disk that can be used for cache is controlled by overloadedMemoryThresholdPercentage and diskMaxUsagePercentage.
+      # - Disk watermark ratios are fractions of the effective local-storage disk capacity, not fractions of
+      #   queryNode.maxDiskUsagePercentage. They must satisfy diskLowWatermarkRatio <= diskHighWatermarkRatio <=
+      #   queryNode.maxDiskUsagePercentage / 100. When lowering queryNode.maxDiskUsagePercentage, adjust the
+      #   disk watermarks as needed to preserve this ordering.
+      # - The max amount of memory/disk that can be used for cache is controlled by
+      #   queryCoord.overloadedMemoryThresholdPercentage and queryNode.maxDiskUsagePercentage.
       memoryLowWatermarkRatio: 0.75
       memoryHighWatermarkRatio: 0.8
       diskLowWatermarkRatio: 0.75
@@ -645,7 +650,7 @@ queryNode:
   fmindexCostRatio: 0.001 # FM-index count-first guard threshold. An FMINDEX-accelerated LIKE (prefix/infix/suffix and general LIKE with interior wildcards) runs through the index only when occ * sa_sample_rate < fmindexCostRatio * total_tokens; otherwise it falls back to the raw-data scan (all paths are exact, this only picks the cheaper one). For the anchored forms the index answer is exact; for general LIKE it is candidate generation followed by an exact recheck of the candidate rows on the original VARCHAR data. The bound prices only FM locate, not the recheck bytes, so it stays row-length invariant only for the anchored forms; very long rows with unselective fragments may be routed to a path slower than the scan. Must be in (0, 1]; larger favors the index. Default 0.001 is the conservative crossover measured in benchmarks.
   loadMemoryUsageFactor: 1 # The multiply factor of calculating the memory usage while loading segments
   enableDisk: false # enable querynode load disk index, and search on disk index
-  maxDiskUsagePercentage: 95
+  maxDiskUsagePercentage: 95 # Maximum disk usage as a percentage of the effective local-storage disk capacity.
   cache:
     memoryLimit: 2147483648 # Deprecated: 2 GB, 2 * 1024 *1024 *1024
     readAheadPolicy: willneed # The read ahead policy of chunk cache, options: `normal, random, sequential, willneed, dontneed`

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4302,7 +4302,12 @@ It defaults to 0.3 (meaning about 30% of evictable on-disk data can be cached), 
 eviction is necessary and the amount of data to evict from memory/disk.
 - If the current memory/disk usage exceeds the high watermark, an eviction will be triggered to evict data from memory/disk
   until the memory/disk usage is below the low watermark.
-- The max amount of memory/disk that can be used for cache is controlled by overloadedMemoryThresholdPercentage and diskMaxUsagePercentage.`,
+- Disk watermark ratios are fractions of the effective local-storage disk capacity, not fractions of
+  queryNode.maxDiskUsagePercentage. They must satisfy diskLowWatermarkRatio <= diskHighWatermarkRatio <=
+  queryNode.maxDiskUsagePercentage / 100. When lowering queryNode.maxDiskUsagePercentage, adjust the
+  disk watermarks as needed to preserve this ordering.
+- The max amount of memory/disk that can be used for cache is controlled by
+  queryCoord.overloadedMemoryThresholdPercentage and queryNode.maxDiskUsagePercentage.`,
 		Export: true,
 	}
 	p.TieredMemoryLowWatermarkRatio.Init(base.mgr)
@@ -5081,6 +5086,7 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 		Formatter: func(v string) string {
 			return fmt.Sprintf("%f", getAsFloat(v)/100)
 		},
+		Doc:    "Maximum disk usage as a percentage of the effective local-storage disk capacity.",
 		Export: true,
 	}
 	p.MaxDiskUsagePercentage.Init(base.mgr)


### PR DESCRIPTION
Relates to #53053

## What changed

- Clarify that `diskLowWatermarkRatio` and `diskHighWatermarkRatio` are
  fractions of the effective local-storage disk capacity, rather than
  fractions of `queryNode.maxDiskUsagePercentage`.
- Document the required ordering:
  `diskLowWatermarkRatio <= diskHighWatermarkRatio <= queryNode.maxDiskUsagePercentage / 100`.
- Replace the stale `diskMaxUsagePercentage` reference with the actual
  `queryNode.maxDiskUsagePercentage` configuration key, and qualify the
  related memory threshold as `queryCoord.overloadedMemoryThresholdPercentage`.
- Add the same disk-capacity description to the `MaxDiskUsagePercentage`
  parameter metadata.

## Scope

This change updates configuration documentation only. It does not change the
validation logic, automatically clamp the watermarks, change QueryNode startup
behavior, or change health reporting. Therefore, it does not claim to resolve
the crash-loop behavior described in #53053.

## Tests

- `gofmt -s -d pkg/util/paramtable/component_param.go` — no diff.
- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./util/paramtable/...`
  from `pkg`, with `GOFLAGS=-mod=readonly -buildvcs=false` — passed.
- `git diff --check` — passed.

## AI assistance

OpenAI Codex assisted with source analysis, drafting, and running the checks
listed above.
