### PR TITLE
fix: qualify struct array sub-field names on the replicate ingress

### DIFF
--- a/internal/distributed/streaming/replicate_service.go
+++ b/internal/distributed/streaming/replicate_service.go
@@ -5,12 +5,15 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/streamingcoord/client/assignment"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
@@ -173,7 +176,7 @@ func (s replicateService) overwriteReplicateMessage(ctx context.Context, msg mes
 	// create collection message will set the vchannel in its body, so we need to overwrite it.
 	switch msg.MessageType() {
 	case message.MessageTypeCreateCollection:
-		if err := s.overwriteCreateCollectionMessage(sourceCluster, msg); err != nil {
+		if err := s.overwriteCreateCollectionMessage(ctx, sourceCluster, msg); err != nil {
 			return nil, err
 		}
 	case message.MessageTypeAlterReplicateConfig:
@@ -207,7 +210,7 @@ func (s replicateService) getTargetVChannel(sourceCluster *replicateutil.MilvusC
 }
 
 // overwriteCreateCollectionMessage overwrites the create collection message.
-func (s replicateService) overwriteCreateCollectionMessage(sourceCluster *replicateutil.MilvusCluster, msg message.ReplicateMutableMessage) error {
+func (s replicateService) overwriteCreateCollectionMessage(ctx context.Context, sourceCluster *replicateutil.MilvusCluster, msg message.ReplicateMutableMessage) error {
 	createCollectionMsg := message.MustAsMutableCreateCollectionMessageV1(msg)
 	body := createCollectionMsg.MustBody()
 	for idx, sourcePChannel := range body.PhysicalChannelNames {
@@ -218,8 +221,52 @@ func (s replicateService) overwriteCreateCollectionMessage(sourceCluster *replic
 		body.PhysicalChannelNames[idx] = targetPChannel
 		body.VirtualChannelNames[idx] = strings.Replace(body.VirtualChannelNames[idx], sourcePChannel, targetPChannel, 1)
 	}
+	// Struct array sub-fields are stored as struct[sub]; the proxy applies that
+	// on the user-facing create path, which a replicated create never takes. A
+	// message forwarded from a peer cluster's WAL already carries qualified
+	// names and is left as is. One built by another producer from a
+	// DescribeCollection result carries the bare names DescribeCollection hands
+	// back, and has to be qualified here -- before the append -- so that the
+	// WAL, the streaming node's recovery state and RootCoord all agree.
+	changed, err := qualifyStructSubFieldNames(body)
+	if err != nil {
+		return status.NewReplicateViolation("failed to read collection schema, %s", err.Error())
+	}
+	if changed {
+		mlog.Warn(ctx, "create collection message carried unqualified struct array sub-field names, qualified them before append",
+			mlog.String("sourceCluster", sourceCluster.GetClusterId()),
+			mlog.String("dbName", body.GetDbName()),
+			mlog.String("collection", body.GetCollectionName()),
+			mlog.Int64("collectionID", body.GetCollectionID()))
+	}
 	createCollectionMsg.OverwriteBody(body)
 	return nil
+}
+
+// qualifyStructSubFieldNames qualifies the struct array sub-field names in
+// whichever schema representation the request carries, mirroring the read
+// side's precedence: collection_schema when set, else the legacy serialized
+// schema. It reports whether anything was rewritten.
+func qualifyStructSubFieldNames(body *message.CreateCollectionRequest) (bool, error) {
+	if schema := body.GetCollectionSchema(); schema != nil {
+		return typeutil.QualifyStructSubFieldNames(schema), nil
+	}
+	if len(body.GetSchema()) == 0 {
+		return false, nil
+	}
+	schema := &schemapb.CollectionSchema{}
+	if err := proto.Unmarshal(body.GetSchema(), schema); err != nil {
+		return false, err
+	}
+	if !typeutil.QualifyStructSubFieldNames(schema) {
+		return false, nil
+	}
+	bytes, err := proto.Marshal(schema)
+	if err != nil {
+		return false, err
+	}
+	body.Schema = bytes
+	return true, nil
 }
 
 // overwriteAlterReplicateConfigMessage overwrites the alter replicate configuration message.

--- a/internal/distributed/streaming/replicate_service_test.go
+++ b/internal/distributed/streaming/replicate_service_test.go
@@ -1373,3 +1373,97 @@ func createReplicateControlChannelMessages() []message.ReplicateMutableMessage {
 	replicateMsg := message.MustNewReplicateMessage("primary", immutableMsg.IntoImmutableMessageProto())
 	return []message.ReplicateMutableMessage{replicateMsg}
 }
+
+// A CreateCollection that enters through the replicate ingress never passes the
+// proxy, which is where struct array sub-field names are normally qualified to
+// struct[sub]. A producer that built the message from a DescribeCollection result
+// sends the bare names DescribeCollection hands back; the ingress has to qualify
+// them before the append so the WAL, the streaming node and RootCoord agree.
+func TestReplicateService_OverwriteCreateCollectionQualifiesStructSubFields(t *testing.T) {
+	sourceCluster := replicateutil.MustNewConfigHelper("by-dev", &commonpb.ReplicateConfiguration{
+		Clusters: []*commonpb.MilvusCluster{
+			{ClusterId: "primary", Pchannels: []string{"primary-rootcoord-dml_0"}},
+			{ClusterId: "by-dev", Pchannels: []string{"by-dev-rootcoord-dml_0"}},
+		},
+		CrossClusterTopology: []*commonpb.CrossClusterTopology{
+			{SourceClusterId: "primary", TargetClusterId: "by-dev"},
+		},
+	}).MustGetCluster("primary")
+	rs := replicateService{walAccesserImpl: &walAccesserImpl{clusterID: "by-dev"}}
+
+	structSchema := func(sub1, sub2 string) *schemapb.CollectionSchema {
+		return &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			},
+			StructArrayFields: []*schemapb.StructArrayFieldSchema{
+				{FieldID: 138, Name: "duplicate_radar_struct", Fields: []*schemapb.FieldSchema{
+					{FieldID: 139, Name: sub1, DataType: schemapb.DataType_Array},
+					{FieldID: 141, Name: sub2, DataType: schemapb.DataType_ArrayOfVector},
+				}},
+			},
+		}
+	}
+	buildMsg := func(body *msgpb.CreateCollectionRequest) message.ReplicateMutableMessage {
+		body.CollectionID = 1
+		body.CollectionName = "collection"
+		body.PhysicalChannelNames = []string{"primary-rootcoord-dml_0"}
+		body.VirtualChannelNames = []string{"primary-rootcoord-dml_0_1v0"}
+		msg := message.NewCreateCollectionMessageBuilderV1().
+			WithHeader(&message.CreateCollectionMessageHeader{CollectionId: 1, PartitionIds: []int64{2}}).
+			WithBody(body).
+			WithBroadcast([]string{"primary-rootcoord-dml_0_1v0"}).
+			MustBuildBroadcast()
+		mutable := msg.WithBroadcastID(100).SplitIntoMutableMessage()[0]
+		immutable := mutable.WithLastConfirmedUseMessageID().WithTimeTick(1).
+			IntoImmutableMessage(pulsar2.NewPulsarID(pulsar.NewMessageID(1, 2, 3, 4)))
+		return message.MustNewReplicateMessage("primary", immutable.IntoImmutableMessageProto())
+	}
+	subFieldNames := func(msg message.ReplicateMutableMessage) []string {
+		body := message.MustAsMutableCreateCollectionMessageV1(msg).MustBody()
+		var out []string
+		for _, sf := range body.GetCollectionSchema().GetStructArrayFields() {
+			for _, f := range sf.GetFields() {
+				out = append(out, f.GetName())
+			}
+		}
+		return out
+	}
+	qualified := []string{"duplicate_radar_struct[chunk_number]", "duplicate_radar_struct[chunk_vector]"}
+
+	t.Run("bare names in collection_schema are qualified", func(t *testing.T) {
+		msg := buildMsg(&msgpb.CreateCollectionRequest{CollectionSchema: structSchema("chunk_number", "chunk_vector")})
+		assert.NoError(t, rs.overwriteCreateCollectionMessage(context.Background(), sourceCluster, msg))
+		assert.Equal(t, qualified, subFieldNames(msg))
+	})
+
+	// What a peer cluster's own WAL carries: already qualified by its proxy.
+	t.Run("qualified names are left as they are", func(t *testing.T) {
+		msg := buildMsg(&msgpb.CreateCollectionRequest{CollectionSchema: structSchema(qualified[0], qualified[1])})
+		assert.NoError(t, rs.overwriteCreateCollectionMessage(context.Background(), sourceCluster, msg))
+		assert.Equal(t, qualified, subFieldNames(msg))
+	})
+
+	// The legacy serialized schema field, set by producers predating collection_schema.
+	t.Run("bare names in the legacy schema bytes are qualified", func(t *testing.T) {
+		bytes, err := proto.Marshal(structSchema("chunk_number", "chunk_vector"))
+		assert.NoError(t, err)
+		msg := buildMsg(&msgpb.CreateCollectionRequest{Schema: bytes})
+		assert.NoError(t, rs.overwriteCreateCollectionMessage(context.Background(), sourceCluster, msg))
+
+		body := message.MustAsMutableCreateCollectionMessageV1(msg).MustBody()
+		got := &schemapb.CollectionSchema{}
+		assert.NoError(t, proto.Unmarshal(body.GetSchema(), got))
+		assert.Equal(t, qualified[0], got.StructArrayFields[0].Fields[0].Name)
+		assert.Equal(t, qualified[1], got.StructArrayFields[0].Fields[1].Name)
+	})
+
+	// The channel rewrite this function already did keeps working alongside.
+	t.Run("channel names are still rewritten to the target's", func(t *testing.T) {
+		msg := buildMsg(&msgpb.CreateCollectionRequest{CollectionSchema: structSchema("chunk_number", "chunk_vector")})
+		assert.NoError(t, rs.overwriteCreateCollectionMessage(context.Background(), sourceCluster, msg))
+		body := message.MustAsMutableCreateCollectionMessageV1(msg).MustBody()
+		assert.Equal(t, []string{"by-dev-rootcoord-dml_0"}, body.PhysicalChannelNames)
+		assert.Equal(t, []string{"by-dev-rootcoord-dml_0_1v0"}, body.VirtualChannelNames)
+	})
+}

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -91,15 +91,7 @@ var logger = mlog.With(mlog.String("role", typeutil.ProxyRole))
 // transformStructFieldNames transforms struct field names to structName[fieldName] format
 // This ensures global uniqueness while allowing same field names across different structs
 func transformStructFieldNames(schema *schemapb.CollectionSchema) error {
-	for _, structArrayField := range schema.StructArrayFields {
-		structName := structArrayField.Name
-		for _, field := range structArrayField.Fields {
-			// Create transformed name: structName[fieldName]
-			newName := typeutil.ConcatStructFieldName(structName, field.Name)
-			field.Name = newName
-		}
-	}
-
+	typeutil.QualifyStructSubFieldNames(schema)
 	return nil
 }
 

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -4211,6 +4211,36 @@ func ConcatStructFieldName(structName string, fieldName string) string {
 	return fmt.Sprintf("%s[%s]", structName, fieldName)
 }
 
+// IsQualifiedStructSubFieldName reports whether fieldName is already in the
+// structName[fieldName] form for the given struct.
+func IsQualifiedStructSubFieldName(structName string, fieldName string) bool {
+	return strings.HasPrefix(fieldName, structName+"[") && strings.HasSuffix(fieldName, "]")
+}
+
+// QualifyStructSubFieldNames rewrites every struct array sub-field name in the
+// schema into the structName[fieldName] form the schema is stored under, and
+// reports whether anything was rewritten.
+//
+// The proxy applies this on the user-facing create path. A CreateCollection that
+// enters through the replicate ingress does not pass the proxy, and a producer
+// that built it from a DescribeCollection result carries the bare names that
+// DescribeCollection hands back. Qualifying again is idempotent, so a message
+// that already carries qualified names -- one forwarded from a peer cluster's
+// WAL -- is left untouched.
+func QualifyStructSubFieldNames(schema *schemapb.CollectionSchema) bool {
+	changed := false
+	for _, structField := range schema.GetStructArrayFields() {
+		for _, field := range structField.GetFields() {
+			if IsQualifiedStructSubFieldName(structField.GetName(), field.GetName()) {
+				continue
+			}
+			field.Name = ConcatStructFieldName(structField.GetName(), field.GetName())
+			changed = true
+		}
+	}
+	return changed
+}
+
 // IsStructSubField checks if a field name follows the "structName[fieldName]" convention,
 // indicating it is a sub-field within a StructArrayField.
 func IsStructSubField(fieldName string) bool {

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -7243,3 +7243,71 @@ func TestMergeDynamicJSONKeepsUntouchedValues(t *testing.T) {
 	assert.Contains(t, string(merged), `"big":12345678901234567890`)
 	assert.Contains(t, string(merged), `"tag":"new"`)
 }
+
+func TestQualifyStructSubFieldNames(t *testing.T) {
+	newSchema := func(names ...string) *schemapb.CollectionSchema {
+		// Two structs that share sub-field names: the case the qualification
+		// exists for.
+		return &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{{FieldID: 100, Name: "id"}},
+			StructArrayFields: []*schemapb.StructArrayFieldSchema{
+				{FieldID: 138, Name: "duplicate_radar_struct", Fields: []*schemapb.FieldSchema{
+					{FieldID: 139, Name: names[0]},
+					{FieldID: 141, Name: names[1]},
+				}},
+				{FieldID: 142, Name: "title_struct", Fields: []*schemapb.FieldSchema{
+					{FieldID: 143, Name: names[2]},
+					{FieldID: 145, Name: names[3]},
+				}},
+			},
+		}
+	}
+	subFieldNames := func(s *schemapb.CollectionSchema) []string {
+		var out []string
+		for _, sf := range s.GetStructArrayFields() {
+			for _, f := range sf.GetFields() {
+				out = append(out, f.GetName())
+			}
+		}
+		return out
+	}
+	qualified := []string{
+		"duplicate_radar_struct[chunk_number]",
+		"duplicate_radar_struct[chunk_vector]",
+		"title_struct[chunk_number]",
+		"title_struct[chunk_vector]",
+	}
+
+	t.Run("bare names are qualified", func(t *testing.T) {
+		s := newSchema("chunk_number", "chunk_vector", "chunk_number", "chunk_vector")
+		assert.True(t, QualifyStructSubFieldNames(s))
+		assert.Equal(t, qualified, subFieldNames(s))
+		// Flat fields and field ids are untouched.
+		assert.Equal(t, "id", s.Fields[0].Name)
+		assert.EqualValues(t, 141, s.StructArrayFields[0].Fields[1].FieldID)
+	})
+
+	t.Run("already qualified names are left alone", func(t *testing.T) {
+		s := newSchema(qualified[0], qualified[1], qualified[2], qualified[3])
+		assert.False(t, QualifyStructSubFieldNames(s))
+		assert.Equal(t, qualified, subFieldNames(s))
+	})
+
+	t.Run("a mix is qualified only where needed", func(t *testing.T) {
+		s := newSchema(qualified[0], "chunk_vector", "chunk_number", qualified[3])
+		assert.True(t, QualifyStructSubFieldNames(s))
+		assert.Equal(t, qualified, subFieldNames(s))
+	})
+
+	t.Run("a name qualified for a different struct is not mistaken for qualified", func(t *testing.T) {
+		s := newSchema("title_struct[chunk_number]", "chunk_vector", "chunk_number", "chunk_vector")
+		assert.True(t, QualifyStructSubFieldNames(s))
+		// It belongs to duplicate_radar_struct, so it is qualified under that name.
+		assert.Equal(t, "duplicate_radar_struct[title_struct[chunk_number]]", s.StructArrayFields[0].Fields[0].Name)
+	})
+
+	t.Run("no struct fields is a no-op", func(t *testing.T) {
+		s := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{{FieldID: 100, Name: "id"}}}
+		assert.False(t, QualifyStructSubFieldNames(s))
+	})
+}


### PR DESCRIPTION
issue: #53084

Milvus stores a struct array's sub-fields under `struct[sub]`, so the same sub-field name may appear in more than one struct. That qualification is applied in exactly one place — the proxy's `createCollectionTask.PreExecute` — and `DescribeCollection` strips it again before returning the schema.

A CreateCollection that arrives through the replicate ingress never passes the proxy. When the producer built it from a `DescribeCollection` result, as backup tooling does, the bare names are appended to the WAL as they came and persisted that way. Read from etcd, the same collection on the source and on a target restored into as a secondary:

```
source  duplicate_radar_struct[chunk_number]  duplicate_radar_struct[chunk_vector]
target  chunk_number                          chunk_vector
```

Nothing reports an error. On the target a search naming the field as `struct[sub]` does not resolve it (`GetFieldByName` matches the stored name), and two structs sharing a sub-field name collide — which is the collision the qualification exists to prevent.

## Why here and not in RootCoord

The streaming node reads the schema from the CreateCollection message in the WAL itself (`vchannel_recovery_info.go`, `MustGetSchemaFromCreateCollectionMessage`). Normalizing only in `newCollectionModel` / `AddCollection` would leave the WAL and the streaming node's recovery state disagreeing with RootCoord. It has to happen before the append.

`replicateService.overwriteCreateCollectionMessage` already rewrites the message body at the ingress (source → target channel names) and writes it back with `OverwriteBody`. This adds the qualification alongside.

## Changes

- `pkg/util/typeutil`: `IsQualifiedStructSubFieldName` and an idempotent `QualifyStructSubFieldNames(schema) bool`.
- `internal/proxy`: `transformStructFieldNames` delegates to it, so there is one implementation of the rule (and the proxy path becomes idempotent as a side effect).
- `internal/distributed/streaming`: `overwriteCreateCollectionMessage` qualifies the names before the append and logs a warning naming the producer. Both schema representations are handled, mirroring the read side's precedence: `collection_schema` when set, else the legacy serialized `schema`.

Real CDC is unaffected: it forwards the source's own WAL message, already qualified by that cluster's proxy, so the idempotent check is a no-op.

## Normalize vs reject

Rejecting with a `ReplicateViolation` would match the function's existing style and is the stricter option. This PR normalizes and warns instead: existing producers keep working with correct results, and the producer's mistake is still surfaced. Happy to switch to reject if that is preferred.

## Tests

- `typeutil`: bare names qualified; already-qualified left alone; mixed; a name qualified for a *different* struct is not mistaken for qualified; no struct fields is a no-op.
- `replicate_service`: bare names in `collection_schema` qualified; qualified left as is; bare names in legacy `schema` bytes qualified; the existing channel rewrite still works alongside.

## Related

#52924 describes the same structural gap for nullable propagation. More generally none of the schema normalizations in `createCollectionTask.PreExecute` run on the replicate ingress, which assumes the producer is a peer Milvus whose proxy already did them. This PR covers the one that has bitten in the field.
