### PR TITLE
fix: [3.0] upgrade librdkafka to 2.6.1 for SASL/SCRAM against Kafka 4.x

### DIFF
--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -31,7 +31,7 @@ class MilvusConan(ConanFile):
         "milvus-common/1.0.0-b589c5a@milvus/dev#d431af735c8acb829feb7a94f05daf42",
         "google-cloud-cpp/2.28.0@milvus/dev#468918b43cec43624531a0340398cf43",
         "opentelemetry-cpp/1.23.0@milvus/dev#11bc565ec6e82910ae8f7471da756720",
-        "librdkafka/1.9.1#ec1a00d5414f618555799be9566adfb7",
+        "librdkafka/2.6.1@milvus/dev#a15d9fefad917290d59fa3fcbc144888",
         "roaring/3.0.0#25a703f80eda0764a31ef939229e202d",
         "crc32c/1.1.2",
         "simde/0.8.2#5e1edfd5cba92f25d79bf6ef4616b972",

--- a/pkg/mq/msgstream/mqwrapper/kafka/kafka_consumer_test.go
+++ b/pkg/mq/msgstream/mqwrapper/kafka/kafka_consumer_test.go
@@ -162,9 +162,15 @@ func TestKafkaConsumer_GetLatestMsgID(t *testing.T) {
 	assert.NoError(t, err)
 	defer consumer.Close()
 
+	// GetLatestMsgID queries the watermark offsets without allowing topic
+	// auto-creation, so the topic must exist before the first call. The
+	// mock cluster bundled with older librdkafka (<= 1.9.x, Metadata API
+	// v2) created it implicitly; newer versions follow the request flag.
+	createTopic(t, topic)
+
 	latestMsgID, err := consumer.GetLatestMsgID()
-	assert.Equal(t, int64(0), latestMsgID.(*KafkaID).MessageID)
 	assert.NoError(t, err)
+	assert.Equal(t, int64(0), latestMsgID.(*KafkaID).MessageID)
 
 	data1 := []int{111, 222, 333}
 	data2 := []string{"111", "222", "333"}
@@ -246,6 +252,16 @@ func testKafkaConsumerProduceData(t *testing.T, topic string, data []int, arr []
 	producer.(*kafkaProducer).p.Flush(500)
 }
 
+// createTopic makes sure topic exists on the broker by issuing a metadata
+// request from a producer, which allows automatic topic creation by default.
+func createTopic(t *testing.T, topic string) {
+	p, err := kafka.NewProducer(&kafka.ConfigMap{"bootstrap.servers": getKafkaBrokerList()})
+	assert.NoError(t, err)
+	defer p.Close()
+	_, err = p.GetMetadata(&topic, false, 10000)
+	assert.NoError(t, err)
+}
+
 func createConfig(groupID string) *kafka.ConfigMap {
 	kafkaAddress := getKafkaBrokerList()
 	return &kafka.ConfigMap{
@@ -259,6 +275,10 @@ func TestKafkaConsumer_CheckPreTopicValid(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	groupID := fmt.Sprintf("test-groupid-%d", rand.Int())
 	topic := fmt.Sprintf("test-topicName-%d", rand.Int())
+
+	// CheckTopicValid reports an error for a topic that does not exist on
+	// the broker, so make sure it exists first.
+	createTopic(t, topic)
 
 	config := createConfig(groupID)
 	consumer, err := newKafkaConsumer(config, 16, topic, groupID, mqcommon.SubscriptionPositionEarliest)


### PR DESCRIPTION
issue: #52601
pr: #52602

Milvus cannot authenticate to an Apache Kafka 4.x broker when the listener
uses SASL with SCRAM-SHA-256. Every attempt fails with "invalid credentials"
while the Java client authenticates with the same user and password, and the
same Milvus build works against Kafka 3.9.1.

librdkafka appended the client nonce to the server-sent nonce a second time
when building the SCRAM client-final-message (present since v0.0.99). Kafka
4.x restored the strict nonce comparison required by RFC 5802, so brokers on
the 4.x line reject the proof. Fixed upstream in librdkafka 2.6.1
(confluentinc/librdkafka#4895). 2.6.0 still fails, so 2.6.1 is the lowest
usable version.

No Go changes are needed: Milvus builds with -tags dynamic, so
confluent-kafka-go links whatever librdkafka the build provides and only
requires a minimum of 1.9.0.

Two unit tests relied on the librdkafka mock cluster creating topics
implicitly; the 2.6.1 mock cluster honours AllowAutoTopicCreation, so the
tests now create the topic first via a producer metadata request (same
change as the master PR).

Clean cherry-pick of #52602. The 3.0 branch shares master's conan setup
(default-conan-local2, @milvus/dev references), so it pins the same
librdkafka/2.6.1@milvus/dev recipe revision. Verified locally on 3.0:
build-cpp resolves librdkafka 2.6.1 through conan, and both
pkg/mq/msgstream/mqwrapper/kafka and pkg/streaming/walimpls/impls/kafka
tests pass against the new library.
