### PR TITLE
fix: gate segment load on delegator schema version

### DIFF
--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -27,6 +27,8 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/atomic"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -230,13 +232,23 @@ func (ex *Executor) executeSegmentAction(task *SegmentTask, step int) {
 // not really executes the request
 func (ex *Executor) loadSegment(task *SegmentTask, step int) error {
 	action := task.Actions()[step].(*SegmentAction)
-	defer action.rpcReturned.Store(true)
+	markRPCReturned := true
+	defer func() {
+		if markRPCReturned {
+			action.rpcReturned.Store(true)
+		}
+	}()
 	ctx := task.Context()
 
 	var err error
 	defer func() {
 		if err != nil {
-			task.Fail(err)
+			if isLoadSegmentPendingError(err) {
+				markRPCReturned = false
+				task.SetReason(err.Error())
+			} else {
+				task.Fail(err)
+			}
 		}
 		ex.removeTask(task, step)
 	}()
@@ -286,7 +298,11 @@ func (ex *Executor) loadSegment(task *SegmentTask, step int) error {
 	status, err := ex.cluster.LoadSegments(task.Context(), view.Node, req)
 	err = merr.CheckRPCCall(status, err)
 	if err != nil {
-		mlog.Warn(context.TODO(), "failed to load segment", mlog.Err(err))
+		if isLoadSegmentPendingError(err) {
+			mlog.Info(ctx, "load segment waits for transient runtime readiness", mlog.Err(err))
+		} else {
+			mlog.Warn(ctx, "failed to load segment", mlog.Err(err))
+		}
 		return err
 	}
 
@@ -294,6 +310,25 @@ func (ex *Executor) loadSegment(task *SegmentTask, step int) error {
 	mlog.Info(context.TODO(), "load segments done", mlog.Duration("elapsed", elapsed))
 
 	return nil
+}
+
+func isLoadSegmentPendingError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if merr.IsRetryableErr(err) {
+		return true
+	}
+	if errors.IsAny(err,
+		context.DeadlineExceeded,
+		grpc.ErrClientConnClosing,
+		merr.ErrChannelNotAvailable,
+		merr.ErrNodeNotAvailable,
+		merr.ErrNodeNotFound,
+	) {
+		return true
+	}
+	return funcutil.IsGrpcErr(err, codes.Unavailable, codes.DeadlineExceeded, codes.Aborted)
 }
 
 // If we enable following checking when loading segments,

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -181,6 +181,7 @@ func (suite *TaskSuite) BeforeTest(suiteName, testName string) {
 		"TestLoadSegmentTask",
 		"TestLoadSegmentTaskNotIndex",
 		"TestSegmentTaskWaitsDistAfterLoadRPC",
+		"TestLoadSegmentTaskWaitsDelegatorSchema",
 		"TestLoadSegmentTaskFailed",
 		"TestTaskCanceled",
 		"TestMoveSegmentTask",
@@ -637,6 +638,126 @@ func (suite *TaskSuite) TestLoadSegmentTaskNotIndex() {
 		suite.Equal(TaskStatusSucceeded, task.Status())
 		suite.NoError(task.Err())
 	}
+}
+
+func (suite *TaskSuite) TestLoadSegmentTaskWaitsDelegatorSchema() {
+	ctx := context.Background()
+	timeout := 10 * time.Second
+	targetNode := int64(3)
+	partition := int64(100)
+	segment := suite.loadSegments[0]
+	channel := &datapb.VchannelInfo{
+		CollectionID: suite.collection,
+		ChannelName:  Params.CommonCfg.RootCoordDml.GetValue() + "-test",
+	}
+
+	suite.broker.EXPECT().DescribeCollection(mock.Anything, suite.collection).RunAndReturn(func(ctx context.Context, i int64) (*milvuspb.DescribeCollectionResponse, error) {
+		return &milvuspb.DescribeCollectionResponse{
+			Schema: &schemapb.CollectionSchema{
+				Name:    "TestLoadSegmentTaskWaitsDelegatorSchema",
+				Version: 1,
+				Fields: []*schemapb.FieldSchema{
+					{FieldID: 100, Name: "vec", DataType: schemapb.DataType_FloatVector},
+				},
+			},
+		}, nil
+	}).Times(3)
+	suite.broker.EXPECT().ListIndexes(mock.Anything, suite.collection).Return([]*indexpb.IndexInfo{
+		{
+			CollectionID: suite.collection,
+		},
+	}, nil).Times(3)
+	suite.broker.EXPECT().GetSegmentInfo(mock.Anything, segment).Return([]*datapb.SegmentInfo{
+		{
+			ID:            segment,
+			CollectionID:  suite.collection,
+			PartitionID:   partition,
+			InsertChannel: channel.ChannelName,
+		},
+	}, nil).Times(3)
+	suite.broker.EXPECT().GetIndexInfo(mock.Anything, suite.collection, segment).Return(nil, nil).Times(3)
+	schemaErr := merr.WrapErrCollectionSchemaVersionNotReadyWithVersion("TestLoadSegmentTaskWaitsDelegatorSchema", 0, 1)
+	suite.cluster.EXPECT().LoadSegments(mock.Anything, targetNode, mock.Anything).Return(merr.Status(schemaErr), nil).Once()
+	suite.cluster.EXPECT().LoadSegments(mock.Anything, targetNode, mock.Anything).Return(merr.Status(merr.WrapErrNodeNotAvailable(targetNode, "worker churn")), nil).Once()
+	suite.cluster.EXPECT().LoadSegments(mock.Anything, targetNode, mock.Anything).Return(merr.Success(), nil).Once()
+
+	suite.dist.ChannelDistManager.Update(targetNode, &meta.DmChannel{
+		VchannelInfo: channel,
+		Node:         targetNode,
+		Version:      1,
+		View: &meta.LeaderView{
+			ID:           targetNode,
+			CollectionID: suite.collection,
+			Channel:      channel.ChannelName,
+			Status:       &querypb.LeaderViewStatus{Serviceable: true},
+		},
+	})
+	task, err := NewSegmentTask(
+		ctx,
+		timeout,
+		WrapIDSource(0),
+		suite.collection,
+		suite.replica,
+		commonpb.LoadPriority_LOW,
+		NewSegmentAction(targetNode, ActionTypeGrow, channel.GetChannelName(), segment),
+	)
+	suite.NoError(err)
+	suite.NoError(suite.scheduler.Add(task))
+
+	segments := []*datapb.SegmentInfo{{
+		ID:            segment,
+		InsertChannel: channel.ChannelName,
+		PartitionID:   1,
+	}}
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return([]*datapb.VchannelInfo{channel}, segments, nil)
+	suite.target.UpdateCollectionNextTarget(ctx, suite.collection)
+	suite.AssertTaskNum(0, 1, 0, 1)
+
+	suite.dispatchAndWait(targetNode)
+	suite.AssertTaskNum(1, 0, 0, 1)
+	suite.Equal(TaskStatusStarted, task.Status())
+	suite.NoError(task.Err())
+	suite.Contains(task.GetReason(), "collection schema version not ready")
+	action := task.Actions()[0].(*SegmentAction)
+	suite.False(action.rpcReturned.Load())
+
+	suite.dispatchAndWait(targetNode)
+	suite.AssertTaskNum(1, 0, 0, 1)
+	suite.Equal(TaskStatusStarted, task.Status())
+	suite.NoError(task.Err())
+	suite.Contains(task.GetReason(), "node not available")
+	suite.False(action.rpcReturned.Load())
+
+	suite.dispatchAndWait(targetNode)
+	suite.AssertTaskNum(1, 0, 0, 1)
+	suite.Equal(TaskStatusStarted, task.Status())
+	suite.NoError(task.Err())
+	suite.True(action.rpcReturned.Load())
+
+	view := &meta.LeaderView{
+		ID:           targetNode,
+		CollectionID: suite.collection,
+		Segments: map[int64]*querypb.SegmentDist{
+			segment: {NodeID: targetNode, Version: 0},
+		},
+		Channel: channel.ChannelName,
+	}
+	suite.dist.SegmentDistManager.Update(targetNode, meta.SegmentFromInfo(&datapb.SegmentInfo{
+		ID:            segment,
+		CollectionID:  suite.collection,
+		PartitionID:   partition,
+		InsertChannel: channel.ChannelName,
+	}))
+	suite.dist.ChannelDistManager.Update(targetNode, &meta.DmChannel{
+		VchannelInfo: channel,
+		Node:         targetNode,
+		Version:      1,
+		View:         view,
+	})
+	suite.dispatchAndWait(targetNode)
+	suite.AssertTaskNum(0, 0, 0, 0)
+	suite.Equal(TaskStatusSucceeded, task.Status())
+	suite.NoError(task.Err())
 }
 
 func (suite *TaskSuite) TestLoadSegmentTaskFailed() {

--- a/internal/querycoordv2/task/utils.go
+++ b/internal/querycoordv2/task/utils.go
@@ -193,8 +193,8 @@ func packLoadMeta(loadType querypb.LoadType, collectionInfo *milvuspb.DescribeCo
 		DbName:        collectionInfo.GetDbName(),
 		ResourceGroup: resourceGroup,
 		LoadFields:    loadFields,
-		// The update timestamp is a load barrier, not the logical schema version.
-		// QueryNode uses it only to reject stale load results after schema changes.
+		// Keep the collection update timestamp in load meta for compatibility.
+		// Delegator load freshness is gated by the request schema version.
 		SchemaBarrierTs: collectionInfo.GetUpdateTimestamp(),
 	}
 }

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -124,21 +124,39 @@ type ShardDelegator interface {
 
 var _ ShardDelegator = (*shardDelegator)(nil)
 
+type shardDelegatorBuildOptions struct {
+	initialSchema             *schemapb.CollectionSchema
+	leaderViewUpdatedCallback func(channel string)
+}
+
 // ShardDelegatorOption customizes shard delegator creation.
-type ShardDelegatorOption func(*shardDelegator)
+type ShardDelegatorOption func(*shardDelegatorBuildOptions)
+
+// WithInitialSchema sets the per-vchannel initial schema snapshot. WatchDmChannels
+// must use the schema carried by the watch request, not the shared collection
+// snapshot that another vchannel may have already advanced.
+func WithInitialSchema(schema *schemapb.CollectionSchema) ShardDelegatorOption {
+	return func(opts *shardDelegatorBuildOptions) {
+		if schema != nil {
+			opts.initialSchema = typeutil.Clone(schema)
+		}
+	}
+}
 
 // WithLeaderViewUpdatedCallback registers a callback for leader view changes.
 func WithLeaderViewUpdatedCallback(callback func(channel string)) ShardDelegatorOption {
-	return func(sd *shardDelegator) {
-		sd.leaderViewUpdatedCallback = callback
-		if sd.distribution != nil {
-			sd.distribution.leaderViewUpdatedCallback = callback
-		}
+	return func(opts *shardDelegatorBuildOptions) {
+		opts.leaderViewUpdatedCallback = callback
 	}
 }
 
 type idfOracleHolder struct {
 	oracle IDFOracle
+}
+
+type delegatorSchemaView struct {
+	schema  *schemapb.CollectionSchema
+	version uint64
 }
 
 // shardDelegator maintains the shard distribution and streaming part of the data.
@@ -184,9 +202,12 @@ type shardDelegator struct {
 	// current forward policy
 	l0ForwardPolicy string
 
-	// schemaBarrierTs fences load results started before the latest schema update.
+	// schemaView is the delegator's WAL-driven schema snapshot. Load requests
+	// may require a matching version, but must never advance this view.
 	schemaChangeMutex sync.RWMutex
-	schemaBarrierTs   uint64
+	schemaView        delegatorSchemaView
+	// schemaBarrierTs fences load results started before the latest schema update.
+	schemaBarrierTs uint64
 	// collectionVersion is the collection schema version applied to this delegator's
 	// channel-local FunctionRunner and IDF runtime.
 	collectionVersion atomic.Uint64
@@ -214,6 +235,63 @@ type shardDelegator struct {
 	growingSourceProvider     *delegatorGrowingSourceProvider
 
 	leaderViewUpdatedCallback func(channel string)
+}
+
+func newDelegatorSchemaView(schema *schemapb.CollectionSchema) delegatorSchemaView {
+	if schema == nil {
+		return delegatorSchemaView{}
+	}
+	return delegatorSchemaView{
+		schema:  typeutil.Clone(schema),
+		version: uint64(schema.GetVersion()),
+	}
+}
+
+func (sd *shardDelegator) ensureDelegatorSchemaViewLocked() {
+	if sd.schemaView.schema != nil || sd.collection == nil {
+		return
+	}
+	schema, version := sd.collection.SchemaAndVersion()
+	if schema == nil {
+		return
+	}
+	sd.schemaView = delegatorSchemaView{
+		schema:  typeutil.Clone(schema),
+		version: version,
+	}
+}
+
+func (sd *shardDelegator) delegatorSchemaSnapshot() (*schemapb.CollectionSchema, uint64) {
+	sd.schemaChangeMutex.RLock()
+	schema, version := sd.delegatorSchemaSnapshotLocked()
+	sd.schemaChangeMutex.RUnlock()
+	if schema != nil {
+		return schema, version
+	}
+
+	sd.schemaChangeMutex.Lock()
+	defer sd.schemaChangeMutex.Unlock()
+	sd.ensureDelegatorSchemaViewLocked()
+	return sd.delegatorSchemaSnapshotLocked()
+}
+
+func (sd *shardDelegator) delegatorSchemaSnapshotLocked() (*schemapb.CollectionSchema, uint64) {
+	if sd.schemaView.schema == nil {
+		return nil, 0
+	}
+	return typeutil.Clone(sd.schemaView.schema), sd.schemaView.version
+}
+
+func (sd *shardDelegator) shouldUpdateDelegatorSchemaLocked(schema *schemapb.CollectionSchema) bool {
+	if schema == nil {
+		return false
+	}
+	sd.ensureDelegatorSchemaViewLocked()
+	return uint64(schema.GetVersion()) > sd.schemaView.version
+}
+
+func (sd *shardDelegator) publishDelegatorSchemaLocked(schema *schemapb.CollectionSchema) {
+	sd.schemaView = newDelegatorSchemaView(schema)
 }
 
 // getLogger returns the logger with pre-defined shard attributes.
@@ -989,6 +1067,7 @@ type subTask[T any] struct {
 	req      T
 	targetID int64
 	worker   cluster.Worker
+	err      error
 }
 
 func organizeSubTask[T any](ctx context.Context,
@@ -1006,7 +1085,7 @@ func organizeSubTask[T any](ctx context.Context,
 		segmentIDs := lo.Map(segments, func(item SegmentEntry, _ int) int64 {
 			return item.SegmentID
 		})
-		if skipEmpty && len(segmentIDs) == 0 {
+		if len(segmentIDs) == 0 && (skipEmpty || workerID != paramtable.GetNodeID()) {
 			return nil
 		}
 		// update request
@@ -1026,6 +1105,7 @@ func organizeSubTask[T any](ctx context.Context,
 			req:      req,
 			targetID: workerID,
 			worker:   worker,
+			err:      err,
 		})
 		return nil
 	}
@@ -1070,14 +1150,20 @@ func executeSubTasks[T any, R interface {
 		wg.Go(func() error {
 			var result R
 			var err error
-			if task.targetID == -1 || task.worker == nil {
+			if task.err != nil {
+				err = task.err
+			} else if task.targetID == -1 || task.worker == nil {
 				var segments []int64
 				if req, ok := any(task.req).(interface{ GetSegmentIDs() []int64 }); ok {
 					segments = req.GetSegmentIDs()
 				} else {
 					segments = []int64{}
 				}
-				err = merr.WrapErrServiceInternalMsg("segments not loaded in any worker: %v", segments[:min(len(segments), 10)])
+				if taskType == "UpdateSchema" {
+					err = merr.WrapErrServiceUnavailableMsg("segments not loaded in any worker: %v", segments[:min(len(segments), 10)])
+				} else {
+					err = merr.WrapErrServiceInternalMsg("segments not loaded in any worker: %v", segments[:min(len(segments), 10)])
+				}
 			} else {
 				result, err = execute(ctx, task.req, task.worker)
 				if result.GetStatus().GetErrorCode() != commonpb.ErrorCode_Success {
@@ -1348,7 +1434,7 @@ func (sd *shardDelegator) CatchingUpStreamingData() bool {
 
 func (sd *shardDelegator) UpdateSchema(ctx context.Context, schema *schemapb.CollectionSchema, schemaBarrierTs uint64) error {
 	log := sd.getLogger(ctx)
-	if err := sd.lifetime.Add(sd.IsWorking); err != nil {
+	if err := sd.lifetime.Add(sd.NotStopped); err != nil {
 		return err
 	}
 	defer sd.lifetime.Done()
@@ -1362,7 +1448,7 @@ func (sd *shardDelegator) UpdateSchema(ctx context.Context, schema *schemapb.Col
 	sd.schemaChangeMutex.Lock()
 	defer sd.schemaChangeMutex.Unlock()
 
-	if !segments.ShouldUpdateCollectionSchema(sd.collection, schema, schemaBarrierTs) {
+	if !sd.shouldUpdateDelegatorSchemaLocked(schema) {
 		mlog.Info(ctx, "delegator skip stale or no-op schema event",
 			mlog.Uint64("schemaVersion", schemaVersion),
 			mlog.Uint64("schemaBarrierTs", schemaBarrierTs),
@@ -1384,9 +1470,9 @@ func (sd *shardDelegator) UpdateSchema(ctx context.Context, schema *schemapb.Col
 		),
 		CollectionID: sd.collectionID,
 		Schema:       schema,
-		// SchemaBarrierTs fences stale load results and lets QueryNode refresh
-		// same-version schema payloads such as collection properties. Logical
-		// schema freshness is still guarded by schema.version in collectionManager.
+		// Keep sending SchemaBarrierTs to workers and the collection manager for
+		// same-version schema payloads such as collection properties. Delegator
+		// load freshness is gated by schema.Version, not this timestamp.
 		SchemaBarrierTs: schemaBarrierTs,
 	},
 		sealed,
@@ -1429,9 +1515,13 @@ func (sd *shardDelegator) UpdateSchema(ctx context.Context, schema *schemapb.Col
 		return err
 	}
 
+	// Publish the WAL-driven delegator schema view. Load requests observe this
+	// view for schema-version gating; it must not be advanced by the load path.
+	sd.publishDelegatorSchemaLocked(schema)
 	mlog.Info(ctx, "delegator finished update schema event",
 		mlog.Uint64("schemaVersion", schemaVersion),
 		mlog.Uint64("schemaBarrierTs", schemaBarrierTs),
+		mlog.Uint64("delegatorSchemaVersion", sd.schemaView.version),
 		mlog.Int("sealedNum", len(sealed)),
 		mlog.Int("growingNum", len(growing)),
 		mlog.Int("bm25FunctionNum", len(newBM25FunctionSet(schema))),
@@ -1536,6 +1626,11 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 	binlogSaver segments.BinlogSaver,
 	opts ...ShardDelegatorOption,
 ) (ShardDelegator, error) {
+	buildOptions := &shardDelegatorBuildOptions{}
+	for _, opt := range opts {
+		opt(buildOptions)
+	}
+
 	log := mlog.With(mlog.Int64("collectionID", collectionID),
 		mlog.Int64("replicaID", replicaID),
 		mlog.String("channel", channel),
@@ -1548,11 +1643,15 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 		return nil, merr.WrapErrCollectionNotFound(collectionID, "not in delegator manager")
 	}
 	schema, schemaVersion, schemaBarrierTs := collection.SchemaSnapshot()
-	if err := function.GetManager().Alloc(collectionID, delegatorFunctionRunnerKey(channel), schema); err != nil {
+	initialSchema := buildOptions.initialSchema
+	if initialSchema == nil {
+		initialSchema = collection.Schema()
+	}
+	if err := function.GetManager().Alloc(collectionID, delegatorFunctionRunnerKey(channel), initialSchema); err != nil {
 		return nil, err
 	}
 
-	skipStreamingForExternalTable := typeutil.IsExternalCollection(schema)
+	skipStreamingForExternalTable := typeutil.IsExternalCollection(initialSchema)
 	catchingUpStreamingData := !skipStreamingForExternalTable
 	if skipStreamingForExternalTable {
 		log.Info(ctx, "skip streaming data catchup for read-only external collection",
@@ -1581,6 +1680,7 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 		vchannelName:      channel,
 		version:           version,
 		collection:        collection,
+		schemaView:        newDelegatorSchemaView(initialSchema),
 		collectionManager: manager.Collection,
 		segmentManager:    manager.Segment,
 		workerManager:     workerManager,
@@ -1601,9 +1701,10 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 		skipStreamingForExternalTable: skipStreamingForExternalTable,
 		latestRequiredMVCCTimeTick:    atomic.NewUint64(0),
 		schemaBarrierTs:               schemaBarrierTs,
+		leaderViewUpdatedCallback:     buildOptions.leaderViewUpdatedCallback,
 	}
-	for _, opt := range opts {
-		opt(sd)
+	if sd.distribution != nil {
+		sd.distribution.leaderViewUpdatedCallback = buildOptions.leaderViewUpdatedCallback
 	}
 	sd.bm25Functions = newBM25FunctionSet(schema)
 

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/time/rate"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -455,6 +456,35 @@ func (sd *shardDelegator) addGrowing(entries ...SegmentEntry) {
 	sd.distribution.AddGrowing(entries...)
 }
 
+func (sd *shardDelegator) checkLoadSchemaVersionReady(ctx context.Context, req *querypb.LoadSegmentsRequest) error {
+	_, currentVersion := sd.delegatorSchemaSnapshot()
+	return sd.checkLoadSchemaVersionReadyWithVersion(ctx, req, currentVersion)
+}
+
+func (sd *shardDelegator) checkLoadSchemaVersionReadyWithVersion(ctx context.Context, req *querypb.LoadSegmentsRequest, currentVersion uint64) error {
+	requiredSchema := req.GetSchema()
+	if requiredSchema == nil {
+		return nil
+	}
+
+	requiredVersion := uint64(requiredSchema.GetVersion())
+	if currentVersion == requiredVersion {
+		return nil
+	}
+
+	err := merr.WrapErrCollectionSchemaVersionNotReadyWithVersion(requiredSchema.GetName(), currentVersion, requiredVersion)
+	sd.getLogger(ctx).RatedInfo(ctx, rate.Limit(10), "delegator rejects load request due to schema version mismatch",
+		mlog.Uint64("currentSchemaVersion", currentVersion),
+		mlog.Uint64("requiredSchemaVersion", requiredVersion),
+		mlog.String("loadScope", req.GetLoadScope().String()),
+		mlog.Int64s("segmentIDs", lo.Map(req.GetInfos(), func(info *querypb.SegmentLoadInfo, _ int) int64 {
+			return info.GetSegmentID()
+		})),
+		mlog.Err(err),
+	)
+	return err
+}
+
 // LoadGrowing load growing segments locally.
 func (sd *shardDelegator) LoadGrowing(ctx context.Context, infos []*querypb.SegmentLoadInfo, version int64) error {
 	log := sd.getLogger(ctx)
@@ -518,7 +548,7 @@ func (sd *shardDelegator) loadBM25Stats(ctx context.Context, infos []*querypb.Se
 	for _, info := range infos {
 		info := info
 		futures = append(futures, pool.Submit(func() (any, error) {
-			if err := idfOracle.LoadSealed(ctx, info.GetSegmentID(), info, cm); err != nil {
+			if err := idfOracle.LoadSealedForReopen(ctx, info.GetSegmentID(), info, cm, false); err != nil {
 				mlog.Warn(ctx, "failed to load bm25 stats for segment",
 					mlog.FieldCollectionID(req.GetCollectionID()),
 					mlog.FieldSegmentID(info.GetSegmentID()),
@@ -602,33 +632,47 @@ func (sd *shardDelegator) loadBM25StatsForReopen(ctx context.Context, infos []*q
 	return nil
 }
 
-// syncCollectionMeta refreshes the delegator node's CCollection IndexMeta and
-// channel-local function runtime after a forwarded worker load. Worker LoadSegments
-// already updates IndexMeta on the target worker, but the delegator must stay in sync.
-func (sd *shardDelegator) syncCollectionMeta(ctx context.Context, req *querypb.LoadSegmentsRequest) error {
-	if len(req.GetIndexInfoList()) > 0 {
-		schema := req.GetSchema()
-		if schema == nil {
-			schema = sd.collection.Schema()
+// syncCollectionIndexMeta refreshes the delegator node's CCollection IndexMeta after a
+// forwarded worker load. Worker LoadSegments already updates IndexMeta on the target
+// worker, but the delegator (which executes growing search locally) must stay in sync.
+// The delegator schema snapshot (advanced only by WAL UpdateSchema events) is used as
+// the schema source and SchemaBarrierTs is zeroed so a load cannot advance the shared
+// Collection schema ahead of the WAL event stream.
+func (sd *shardDelegator) syncCollectionIndexMeta(ctx context.Context, req *querypb.LoadSegmentsRequest) error {
+	if len(req.GetIndexInfoList()) == 0 {
+		return nil
+	}
+	if req.GetSchema() != nil {
+		if current := sd.collectionManager.Get(req.GetCollectionID()); current != nil &&
+			current.SchemaVersion() > uint64(req.GetSchema().GetVersion()) {
+			sd.getLogger(ctx).Info(ctx, "skip stale collection index meta sync",
+				mlog.Uint64("currentSchemaVersion", current.SchemaVersion()),
+				mlog.Int32("requestSchemaVersion", req.GetSchema().GetVersion()))
+			return nil
 		}
-
-		loadMeta := req.GetLoadMeta()
-		if loadMeta == nil {
-			loadMeta = &querypb.LoadMetaInfo{
-				CollectionID: req.GetCollectionID(),
-			}
-		}
-
-		meta := segments.ComposeIndexMeta(ctx, req.GetIndexInfoList(), schema)
-		if err := sd.collectionManager.PutOrRef(req.GetCollectionID(), schema, meta, loadMeta); err != nil {
-			return err
-		}
-		sd.collectionManager.Unref(req.GetCollectionID(), 1)
 	}
 
-	// Reopen and concurrent loads also provide a deterministic catch-up point when
-	// another channel has already advanced the shared Collection schema.
-	return sd.UpdateDelegatorSchema(ctx)
+	schema, _ := sd.delegatorSchemaSnapshot()
+	if schema == nil {
+		schema = req.GetSchema()
+	}
+
+	loadMeta := req.GetLoadMeta()
+	if loadMeta == nil {
+		loadMeta = &querypb.LoadMetaInfo{
+			CollectionID: req.GetCollectionID(),
+		}
+	} else {
+		loadMeta = typeutil.Clone(loadMeta)
+	}
+	loadMeta.SchemaBarrierTs = 0
+
+	meta := segments.ComposeIndexMeta(ctx, req.GetIndexInfoList(), schema)
+	if err := sd.collectionManager.PutOrRef(req.GetCollectionID(), schema, meta, loadMeta); err != nil {
+		return err
+	}
+	sd.collectionManager.Unref(req.GetCollectionID(), 1)
+	return nil
 }
 
 // LoadSegments load segments local or remotely depends on the target node.
@@ -648,6 +692,10 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 
 	if req.GetInfos()[0].GetLevel() == datapb.SegmentLevel_L0 {
 		return merr.WrapErrServiceInternal("load L0 segment is not supported, l0 segment should only be loaded by watchChannel")
+	}
+
+	if err := sd.checkLoadSchemaVersionReady(ctx, req); err != nil {
+		return err
 	}
 
 	// pin all segments to prevent delete buffer has been cleaned up during worker load segments
@@ -713,8 +761,12 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 	}
 	log.Debug(ctx, "work loads segments done")
 
-	if err := sd.syncCollectionMeta(ctx, req); err != nil {
-		log.Warn(ctx, "failed to sync collection metadata on delegator", mlog.Err(err))
+	if err := sd.checkLoadSchemaVersionReady(ctx, req); err != nil {
+		return err
+	}
+
+	if err := sd.syncCollectionIndexMeta(ctx, req); err != nil {
+		log.Warn(ctx, "failed to sync collection index meta on delegator", mlog.Err(err))
 		return err
 	}
 
@@ -764,8 +816,7 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 
 		log.Debug(ctx, "load delete...")
 		// loadStreamDelete now handles distribution add atomically in Phase 3
-		err = sd.loadStreamDelete(ctx, candidates, infos, req, targetNodeID, worker,
-			entries, req.GetLoadMeta().GetSchemaBarrierTs())
+		err = sd.loadStreamDelete(ctx, candidates, infos, req, targetNodeID, worker, entries)
 		if err != nil {
 			log.Warn(ctx, "load stream delete failed", mlog.Err(err))
 			// BM25 stats already loaded into idf oracle will be cleaned up
@@ -796,13 +847,14 @@ func (sd *shardDelegator) withPostLoadLimit(ctx context.Context, fn func() error
 	return fn()
 }
 
-func (sd *shardDelegator) addDistributionIfSchemaBarrierOK(schemaBarrierTs uint64, entries ...SegmentEntry) error {
+func (sd *shardDelegator) addDistributionIfLoadSchemaOK(ctx context.Context, req *querypb.LoadSegmentsRequest, entries ...SegmentEntry) error {
 	sd.schemaChangeMutex.RLock()
 	defer sd.schemaChangeMutex.RUnlock()
-	if schemaBarrierTs < sd.schemaBarrierTs {
-		return merr.WrapErrServiceInternal("schema barrier changed")
-	}
 
+	_, currentVersion := sd.delegatorSchemaSnapshotLocked()
+	if err := sd.checkLoadSchemaVersionReadyWithVersion(ctx, req, currentVersion); err != nil {
+		return err
+	}
 	// alter distribution
 	sd.distribution.AddDistributions(entries...)
 	return nil
@@ -1015,7 +1067,6 @@ func (sd *shardDelegator) loadStreamDelete(ctx context.Context,
 	targetNodeID int64,
 	worker cluster.Worker,
 	entries []SegmentEntry,
-	schemaBarrierTs uint64,
 ) error {
 	log := sd.getLogger(ctx)
 
@@ -1145,7 +1196,7 @@ func (sd *shardDelegator) loadStreamDelete(ctx context.Context,
 			// Atomically add to distribution while still holding RLock, so no
 			// ProcessDelete can run between "deletes applied" and "segment
 			// visible".
-			if err := sd.addDistributionIfSchemaBarrierOK(schemaBarrierTs, entries...); err != nil {
+			if err := sd.addDistributionIfLoadSchemaOK(ctx, req, entries...); err != nil {
 				sd.deleteMut.RUnlock()
 				return err
 			}
@@ -1181,7 +1232,7 @@ func (sd *shardDelegator) loadStreamDelete(ctx context.Context,
 					mlog.Int64("bfCost", time.Since(start).Milliseconds()),
 				)
 			}
-			if err := sd.addDistributionIfSchemaBarrierOK(schemaBarrierTs, entries...); err != nil {
+			if err := sd.addDistributionIfLoadSchemaOK(ctx, req, entries...); err != nil {
 				sd.deleteMut.RUnlock()
 				return err
 			}

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -1335,44 +1335,87 @@ func (s *DelegatorDataSuite) TestLoadSegments() {
 	})
 }
 
-func (s *DelegatorDataSuite) TestSyncCollectionMetaUpdatesFunctionRunners() {
+func (s *DelegatorDataSuite) TestLoadSegmentsSchemaVersionGate() {
+	newSchema := typeutil.Clone(s.delegator.collection.Schema())
+	newSchema.Version = s.delegator.collection.Schema().GetVersion() + 1
+	req := &querypb.LoadSegmentsRequest{
+		Base:         commonpbutil.NewMsgBase(),
+		DstNodeID:    1,
+		CollectionID: s.collectionID,
+		Schema:       newSchema,
+		LoadScope:    querypb.LoadScope_Reopen,
+		Infos: []*querypb.SegmentLoadInfo{
+			{
+				SegmentID:     100,
+				PartitionID:   500,
+				StartPosition: &msgpb.MsgPosition{Timestamp: 20000},
+				DeltaPosition: &msgpb.MsgPosition{Timestamp: 20000},
+				Level:         datapb.SegmentLevel_L1,
+				InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
+			},
+		},
+	}
+
+	err := s.delegator.LoadSegments(context.Background(), req)
+	s.ErrorIs(err, merr.ErrCollectionSchemaVersionNotReady)
+
+	// UpdateSchema broadcasts to the local node even with no online segments
+	// (skipEmpty=false for the streaming scope), so stub the local worker.
+	worker := &cluster.MockWorker{}
+	worker.EXPECT().UpdateSchema(mock.Anything, mock.AnythingOfType("*querypb.UpdateSchemaRequest")).Return(merr.Success(), nil).Once()
+	s.workerManager.EXPECT().GetWorker(mock.Anything, int64(paramtable.GetNodeID())).Return(worker, nil).Once()
+
+	s.Require().NoError(s.delegator.UpdateSchema(context.Background(), newSchema, 100))
+	_, version := s.delegator.delegatorSchemaSnapshot()
+	s.Equal(uint64(newSchema.GetVersion()), version)
+
+	worker.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).Return(nil).Once()
+	s.workerManager.EXPECT().GetWorker(mock.Anything, int64(1)).Return(worker, nil).Once()
+
+	err = s.delegator.LoadSegments(context.Background(), req)
+	s.NoError(err)
+
+	staleSchema := typeutil.Clone(newSchema)
+	staleSchema.Version--
+	staleReq := typeutil.Clone(req)
+	staleReq.Schema = staleSchema
+	err = s.delegator.LoadSegments(context.Background(), staleReq)
+	s.ErrorIs(err, merr.ErrCollectionSchemaVersionNotReady)
+}
+
+func (s *DelegatorDataSuite) TestSyncCollectionIndexMetaDoesNotUpdateFunctionRunners() {
 	ctx := context.Background()
 	s.delegator.Start()
-	schema := newFunctionRuntimeTestSchemaWithVersion(1, newBM25FunctionSchema())
-	s.Require().Nil(s.delegator.getIDFOracle())
-	err := s.delegator.syncCollectionMeta(ctx, &querypb.LoadSegmentsRequest{
+	// Seed the delegator function-runner key with a schema that contains field
+	// 102 as a plain field but has no BM25 output registered yet. The version
+	// bump is required so function.GetManager().Update actually applies.
+	s.Require().NoError(function.GetManager().Update(s.collectionID, delegatorFunctionRunnerKey(s.vchannelName), newFunctionRuntimeTestSchemaWithVersion(1)))
+	schema := newFunctionRuntimeTestSchemaWithVersion(2, newBM25FunctionSchema())
+	err := s.delegator.syncCollectionIndexMeta(ctx, &querypb.LoadSegmentsRequest{
 		CollectionID:  s.collectionID,
 		Schema:        schema,
 		LoadMeta:      &querypb.LoadMetaInfo{SchemaBarrierTs: 1},
 		IndexInfoList: mock_segcore.GenTestIndexInfoList(s.collectionID, schema),
 	})
 	s.Require().NoError(err)
-	s.Equal(uint64(1), s.delegator.collectionVersion.Load())
-	s.Equal(uint64(1), s.delegator.schemaBarrierTs)
-	s.Require().NotNil(s.delegator.getIDFOracle())
 
-	// The load path has already advanced the collection snapshot, so the DDL
-	// event is skipped as a no-op. The function runner key must still point at
-	// the schema installed by the load path.
-	s.Require().NoError(s.delegator.UpdateSchema(ctx, schema, 1))
 	ok, err := function.GetManager().RunWithRunner(ctx, s.collectionID, delegatorFunctionRunnerKey(s.vchannelName), 102, func(function.FunctionRunner) error {
 		return nil
 	})
 	s.Require().NoError(err)
+	s.False(ok)
+
+	// Only the WAL UpdateSchema path advances the delegator schema/function view.
+	worker := &cluster.MockWorker{}
+	worker.EXPECT().UpdateSchema(mock.Anything, mock.AnythingOfType("*querypb.UpdateSchemaRequest")).Return(merr.Success(), nil).Once()
+	s.workerManager.EXPECT().GetWorker(mock.Anything, int64(paramtable.GetNodeID())).Return(worker, nil).Once()
+
+	s.Require().NoError(s.delegator.UpdateSchema(ctx, schema, 100))
+	ok, err = function.GetManager().RunWithRunner(ctx, s.collectionID, delegatorFunctionRunnerKey(s.vchannelName), 102, func(function.FunctionRunner) error {
+		return nil
+	})
+	s.Require().NoError(err)
 	s.True(ok)
-}
-
-func (s *DelegatorDataSuite) TestSyncCollectionMetaWithoutIndexInfoUpdatesDelegatorSchema() {
-	ctx := context.Background()
-	s.delegator.Start()
-	schema := proto.Clone(s.delegator.collection.Schema()).(*schemapb.CollectionSchema)
-	schema.Version = 1
-	s.Require().NoError(s.manager.Collection.PutOrRef(s.collectionID, schema, nil, &querypb.LoadMetaInfo{SchemaBarrierTs: 100}))
-	s.manager.Collection.Unref(s.collectionID, 1)
-
-	s.Require().NoError(s.delegator.syncCollectionMeta(ctx, &querypb.LoadSegmentsRequest{CollectionID: s.collectionID}))
-	s.Equal(uint64(1), s.delegator.collectionVersion.Load())
-	s.Equal(uint64(100), s.delegator.schemaBarrierTs)
 }
 
 func (s *DelegatorDataSuite) TestLoadSegmentsWithoutBloomFilter() {

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -1152,7 +1152,7 @@ func (s *DelegatorSuite) TestQueryStream() {
 			DmlChannels: []string{s.vchannelName},
 		}, server)
 		s.Error(err)
-		s.ErrorContains(err, "segments not loaded in any worker")
+		s.ErrorContains(err, "mock error")
 	})
 
 	s.Run("worker_return_error", func() {
@@ -1661,6 +1661,19 @@ func (s *DelegatorSuite) TestUpdateSchema() {
 		err := s.delegator.UpdateSchema(ctx, &schemapb.CollectionSchema{}, 100)
 		s.Error(err)
 	})
+}
+
+func (s *DelegatorSuite) TestUpdateSchemaAllowedWhileInitializing() {
+	s.ResetDelegator()
+	collection := s.manager.Collection.Get(s.collectionID)
+	s.Require().NotNil(collection)
+	schema := collection.Schema()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := s.delegator.UpdateSchema(ctx, schema, 100)
+	s.NoError(err)
 }
 
 func (s *DelegatorSuite) ResetDelegator() {
@@ -2183,10 +2196,10 @@ func (s *DelegatorSuite) TestDelegatorLifetimeIntegration() {
 		s.Error(err)
 		s.Contains(err.Error(), "delegator is not ready")
 
-		// UpdateSchema should fail when not ready
+		// UpdateSchema is allowed while Initializing so WAL schema events can be
+		// applied before the delegator transitions to Working.
 		err = sd.UpdateSchema(ctx, &schemapb.CollectionSchema{Name: "test"}, 1)
-		s.Error(err)
-		s.Contains(err.Error(), "delegator is not ready")
+		s.NoError(err)
 	})
 
 	s.Run("test_methods_fail_when_stopped", func() {
@@ -2769,7 +2782,11 @@ func TestUpdateSchemaUpdatesDelegatorRuntimeAfterCollectionAdvanced(t *testing.T
 	require.NoError(t, sd.UpdateSchema(context.Background(), newSchema, 100))
 	require.Equal(t, uint64(1), sd.collectionVersion.Load())
 	require.Equal(t, uint64(100), sd.schemaBarrierTs)
-	require.Error(t, sd.addDistributionIfSchemaBarrierOK(99))
+	staleReq := &querypb.LoadSegmentsRequest{
+		Schema: typeutil.Clone(newSchema),
+	}
+	staleReq.Schema.Version--
+	require.Error(t, sd.addDistributionIfLoadSchemaOK(context.Background(), staleReq))
 	require.NotNil(t, sd.getIDFOracle())
 	ok, err := function.GetManager().RunWithRunner(context.Background(), 1000, key, 102, func(function.FunctionRunner) error {
 		return nil
@@ -2873,7 +2890,6 @@ func TestUpdateSchemaSkipsStaleSchemaBeforeSideEffects(t *testing.T) {
 		lifetime:                   lifetime.NewLifetime(lifetime.Working),
 		distribution:               NewDistribution("test-channel", NewChannelQueryView(nil, nil, nil, initialTargetVersion)),
 		workerManager:              workerManager,
-		schemaBarrierTs:            100,
 		deleteBuffer:               deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](0, 0, []string{"1", "test-channel"}),
 		tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
 		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
@@ -2884,7 +2900,8 @@ func TestUpdateSchemaSkipsStaleSchemaBeforeSideEffects(t *testing.T) {
 	err := sd.UpdateSchema(context.Background(), staleSchema, 200)
 	require.NoError(t, err)
 
-	assert.Equal(t, uint64(100), sd.schemaBarrierTs)
+	_, delegatorSchemaVersion := sd.delegatorSchemaSnapshot()
+	assert.Equal(t, uint64(2), delegatorSchemaVersion)
 	assert.Equal(t, uint64(2), sd.collection.SchemaVersion())
 }
 

--- a/internal/querynodev2/handlers.go
+++ b/internal/querynodev2/handlers.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/querynodev2/delegator"
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
 	"github.com/milvus-io/milvus/internal/querynodev2/tasks"
@@ -151,7 +152,14 @@ func (node *QueryNode) reopenSegments(ctx context.Context, req *querypb.LoadSegm
 	)
 
 	log.Info(ctx, "start to reopen segments")
-	err := node.loader.ReopenSegments(ctx, req.GetInfos())
+	var err error
+	if loader, ok := node.loader.(interface {
+		ReopenSegmentsWithSchema(context.Context, *schemapb.CollectionSchema, []*querypb.SegmentLoadInfo) error
+	}); ok {
+		err = loader.ReopenSegmentsWithSchema(ctx, req.GetSchema(), req.GetInfos())
+	} else {
+		err = node.loader.ReopenSegments(ctx, req.GetInfos())
+	}
 	if err != nil {
 		log.Warn(ctx, "failed to reopen segments", mlog.Err(err))
 		return merr.Status(err)

--- a/internal/querynodev2/pipeline/delete_node.go
+++ b/internal/querynodev2/pipeline/delete_node.go
@@ -19,14 +19,23 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/milvus-io/milvus/internal/querynodev2/delegator"
 	"github.com/milvus-io/milvus/internal/storage"
 	base "github.com/milvus-io/milvus/internal/util/pipeline"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -37,7 +46,17 @@ type deleteNode struct {
 
 	manager   *DataManager
 	delegator delegator.ShardDelegator
+	closed    atomic.Bool
+	ctx       context.Context
+	cancel    context.CancelFunc
+	closeCh   chan struct{}
+	closeOnce sync.Once
 }
+
+var (
+	deleteNodeUpdateSchemaRetryInterval    = 200 * time.Millisecond
+	deleteNodeUpdateSchemaMaxRetryDuration = 5 * time.Minute
+)
 
 // addDeleteData find the segment of delete column in DeleteMsg and save in deleteData
 func (dNode *deleteNode) addDeleteData(deleteDatas map[UniqueID]*delegator.DeleteData, msg *DeleteMsg) {
@@ -94,9 +113,8 @@ func (dNode *deleteNode) Operate(in Msg) Msg {
 	}
 
 	if nodeMsg.schema != nil {
-		ctx := context.TODO()
-		if err := dNode.delegator.UpdateSchema(ctx, nodeMsg.schema, nodeMsg.schemaBarrierTs); err != nil {
-			panic(err)
+		if !dNode.updateSchemaUntilApplied(dNode.ctx, nodeMsg) {
+			return nil
 		}
 	}
 
@@ -105,16 +123,128 @@ func (dNode *deleteNode) Operate(in Msg) Msg {
 	return nil
 }
 
+func (dNode *deleteNode) updateSchemaUntilApplied(ctx context.Context, nodeMsg *deleteNodeMsg) bool {
+	start := time.Now()
+	applyCtx, cancel := context.WithTimeout(ctx, deleteNodeUpdateSchemaMaxRetryDuration)
+	defer cancel()
+
+	panicRetryLimit := func(err error) {
+		wrapped := merr.Wrap(err, "schema update retry limit reached in delete node")
+		mlog.Error(ctx, "schema update retry limit reached in delete node, stop process to replay WAL after restart",
+			mlog.Int64("collectionID", dNode.collectionID),
+			mlog.String("channel", dNode.channel),
+			mlog.Int32("schemaVersion", nodeMsg.schema.GetVersion()),
+			mlog.Uint64("schemaBarrierTs", nodeMsg.schemaBarrierTs),
+			mlog.Duration("retryDuration", time.Since(start)),
+			mlog.Err(wrapped))
+		panic(wrapped)
+	}
+
+	for {
+		if dNode.closed.Load() {
+			return false
+		}
+		err := dNode.delegator.UpdateSchema(applyCtx, nodeMsg.schema, nodeMsg.schemaBarrierTs)
+		if err == nil {
+			return true
+		}
+
+		if dNode.closed.Load() {
+			return false
+		}
+		if errors.Is(applyCtx.Err(), context.Canceled) {
+			return false
+		}
+		if errors.Is(applyCtx.Err(), context.DeadlineExceeded) {
+			panicRetryLimit(err)
+		}
+		if !isUpdateSchemaRetryable(err) {
+			wrapped := merr.Wrap(err, "non-retryable schema update failure in delete node")
+			mlog.Error(ctx, "non-retryable schema update failure in delete node, stop process to replay WAL after restart",
+				mlog.Int64("collectionID", dNode.collectionID),
+				mlog.String("channel", dNode.channel),
+				mlog.Int32("schemaVersion", nodeMsg.schema.GetVersion()),
+				mlog.Uint64("schemaBarrierTs", nodeMsg.schemaBarrierTs),
+				mlog.Err(wrapped))
+			panic(wrapped)
+		}
+		if time.Since(start) >= deleteNodeUpdateSchemaMaxRetryDuration {
+			panicRetryLimit(err)
+		}
+
+		mlog.RatedWarn(ctx, rate.Limit(1), "failed to update schema in delete node, retrying before advancing tsafe",
+			mlog.Int64("collectionID", dNode.collectionID),
+			mlog.String("channel", dNode.channel),
+			mlog.Int32("schemaVersion", nodeMsg.schema.GetVersion()),
+			mlog.Uint64("schemaBarrierTs", nodeMsg.schemaBarrierTs),
+			mlog.Err(err))
+
+		if dNode.closed.Load() {
+			return false
+		}
+		timer := time.NewTimer(deleteNodeUpdateSchemaRetryInterval)
+		select {
+		case <-timer.C:
+		case <-dNode.closeCh:
+			timer.Stop()
+			return false
+		case <-applyCtx.Done():
+			timer.Stop()
+			if dNode.closed.Load() || errors.Is(applyCtx.Err(), context.Canceled) {
+				return false
+			}
+			panicRetryLimit(applyCtx.Err())
+		}
+		timer.Stop()
+	}
+}
+
+func isUpdateSchemaRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if merr.IsRetryableErr(err) {
+		return true
+	}
+	if errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, grpc.ErrClientConnClosing) ||
+		errors.Is(err, merr.ErrChannelNotAvailable) ||
+		errors.Is(err, merr.ErrNodeNotAvailable) {
+		return true
+	}
+	switch status.Code(err) {
+	case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted, codes.Aborted:
+		return true
+	default:
+		return false
+	}
+}
+
+func (dNode *deleteNode) PreClose() {
+	dNode.closeOnce.Do(func() {
+		dNode.closed.Store(true)
+		dNode.cancel()
+		close(dNode.closeCh)
+	})
+}
+
+func (dNode *deleteNode) Close() { dNode.PreClose() }
+
 func newDeleteNode(
 	collectionID UniqueID, channel string,
 	manager *DataManager, delegator delegator.ShardDelegator,
 	maxQueueLength int32,
 ) *deleteNode {
+	// #nosec G118 -- cancel is stored on deleteNode and called by PreClose/Close.
+	ctx, cancel := context.WithCancel(context.Background())
 	return &deleteNode{
 		BaseNode:     base.NewBaseNode(fmt.Sprintf("DeleteNode-%s", channel), maxQueueLength),
 		collectionID: collectionID,
 		channel:      channel,
 		manager:      manager,
 		delegator:    delegator,
+		ctx:          ctx,
+		cancel:       cancel,
+		closeCh:      make(chan struct{}),
 	}
 }

--- a/internal/querynodev2/pipeline/delete_node_test.go
+++ b/internal/querynodev2/pipeline/delete_node_test.go
@@ -17,11 +17,16 @@
 package pipeline
 
 import (
+	"context"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/querynodev2/delegator"
@@ -149,7 +154,49 @@ func (suite *DeleteNodeSuite) TestProcessDeleteBatchesUseDeleteMsgEndTs() {
 	suite.Nil(out)
 }
 
-func (suite *DeleteNodeSuite) TestUpdateSchemaErrorPanics() {
+func (suite *DeleteNodeSuite) TestUpdateSchemaErrorDoesNotAdvanceTSafe() {
+	manager := &segments.Manager{
+		Collection: segments.NewMockCollectionManager(suite.T()),
+		Segment:    segments.NewMockSegmentManager(suite.T()),
+	}
+	delegator := delegator.NewMockShardDelegator(suite.T())
+	schema := &schemapb.CollectionSchema{Version: 2}
+	expectedErr := merr.WrapErrServiceUnavailableMsg("delegator is not ready")
+	var updateSchemaCalled atomic.Bool
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).Run(func(context.Context, *schemapb.CollectionSchema, uint64) {
+		updateSchemaCalled.Store(true)
+	}).Return(expectedErr)
+
+	node := newDeleteNode(suite.collectionID, suite.channel, manager, delegator, 8)
+	oldInterval := deleteNodeUpdateSchemaRetryInterval
+	deleteNodeUpdateSchemaRetryInterval = time.Millisecond
+	suite.T().Cleanup(func() {
+		deleteNodeUpdateSchemaRetryInterval = oldInterval
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		suite.Nil(node.Operate(&deleteNodeMsg{
+			schema:          schema,
+			schemaBarrierTs: 10,
+			timeRange:       TimeRange{timestampMax: 10},
+		}))
+	}()
+
+	suite.Eventually(updateSchemaCalled.Load, time.Second, time.Millisecond)
+	node.Close()
+	suite.Eventually(func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+}
+
+func (suite *DeleteNodeSuite) TestUpdateSchemaRetriesBeforeTSafe() {
 	manager := &segments.Manager{
 		Collection: segments.NewMockCollectionManager(suite.T()),
 		Segment:    segments.NewMockSegmentManager(suite.T()),
@@ -158,15 +205,171 @@ func (suite *DeleteNodeSuite) TestUpdateSchemaErrorPanics() {
 	schema := &schemapb.CollectionSchema{Version: 2}
 	expectedErr := merr.WrapErrServiceUnavailableMsg("delegator is not ready")
 	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).Return(expectedErr).Once()
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).Return(nil).Once()
+	delegator.EXPECT().UpdateTSafe(uint64(10)).Return().Once()
 
 	node := newDeleteNode(suite.collectionID, suite.channel, manager, delegator, 8)
-	suite.PanicsWithError(expectedErr.Error(), func() {
+	oldInterval := deleteNodeUpdateSchemaRetryInterval
+	deleteNodeUpdateSchemaRetryInterval = time.Millisecond
+	suite.T().Cleanup(func() {
+		deleteNodeUpdateSchemaRetryInterval = oldInterval
+	})
+
+	suite.Nil(node.Operate(&deleteNodeMsg{
+		schema:          schema,
+		schemaBarrierTs: 10,
+		timeRange:       TimeRange{timestampMax: 10},
+	}))
+}
+
+func (suite *DeleteNodeSuite) TestUpdateSchemaRetriesTransientErrorsBeforeTSafe() {
+	manager := &segments.Manager{
+		Collection: segments.NewMockCollectionManager(suite.T()),
+		Segment:    segments.NewMockSegmentManager(suite.T()),
+	}
+	delegator := delegator.NewMockShardDelegator(suite.T())
+	schema := &schemapb.CollectionSchema{Version: 2}
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).
+		Return(merr.WrapErrChannelNotAvailable(suite.channel, "delegator initializing")).Once()
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).
+		Return(merr.WrapErrNodeNotAvailable(10, "worker unhealthy")).Once()
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).
+		Return(status.Error(codes.Unavailable, "worker unavailable")).Once()
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).Return(nil).Once()
+	delegator.EXPECT().UpdateTSafe(uint64(10)).Return().Once()
+
+	node := newDeleteNode(suite.collectionID, suite.channel, manager, delegator, 8)
+	oldInterval := deleteNodeUpdateSchemaRetryInterval
+	deleteNodeUpdateSchemaRetryInterval = time.Millisecond
+	suite.T().Cleanup(func() {
+		deleteNodeUpdateSchemaRetryInterval = oldInterval
+	})
+
+	suite.Nil(node.Operate(&deleteNodeMsg{
+		schema:          schema,
+		schemaBarrierTs: 10,
+		timeRange:       TimeRange{timestampMax: 10},
+	}))
+}
+
+func (suite *DeleteNodeSuite) TestUpdateSchemaNonRetryableErrorPanicsWithoutTSafe() {
+	manager := &segments.Manager{
+		Collection: segments.NewMockCollectionManager(suite.T()),
+		Segment:    segments.NewMockSegmentManager(suite.T()),
+	}
+	delegator := delegator.NewMockShardDelegator(suite.T())
+	schema := &schemapb.CollectionSchema{Version: 2}
+	expectedErr := merr.WrapErrServiceInternal("unsupported incompatible schema change")
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).Return(expectedErr).Once()
+
+	node := newDeleteNode(suite.collectionID, suite.channel, manager, delegator, 8)
+	suite.Panics(func() {
 		node.Operate(&deleteNodeMsg{
 			schema:          schema,
 			schemaBarrierTs: 10,
 			timeRange:       TimeRange{timestampMax: 10},
 		})
 	})
+}
+
+func (suite *DeleteNodeSuite) TestUpdateSchemaRetryLimitPanicsWithoutTSafe() {
+	manager := &segments.Manager{
+		Collection: segments.NewMockCollectionManager(suite.T()),
+		Segment:    segments.NewMockSegmentManager(suite.T()),
+	}
+	delegator := delegator.NewMockShardDelegator(suite.T())
+	schema := &schemapb.CollectionSchema{Version: 2}
+	expectedErr := merr.WrapErrChannelNotAvailable(suite.channel, "delegator initializing")
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).Return(expectedErr).Once()
+
+	node := newDeleteNode(suite.collectionID, suite.channel, manager, delegator, 8)
+	oldMaxRetryDuration := deleteNodeUpdateSchemaMaxRetryDuration
+	deleteNodeUpdateSchemaMaxRetryDuration = 0
+	suite.T().Cleanup(func() {
+		deleteNodeUpdateSchemaMaxRetryDuration = oldMaxRetryDuration
+	})
+
+	suite.Panics(func() {
+		node.Operate(&deleteNodeMsg{
+			schema:          schema,
+			schemaBarrierTs: 10,
+			timeRange:       TimeRange{timestampMax: 10},
+		})
+	})
+}
+
+func (suite *DeleteNodeSuite) TestUpdateSchemaRetryLimitCancelsInFlightUpdate() {
+	manager := &segments.Manager{
+		Collection: segments.NewMockCollectionManager(suite.T()),
+		Segment:    segments.NewMockSegmentManager(suite.T()),
+	}
+	delegator := delegator.NewMockShardDelegator(suite.T())
+	schema := &schemapb.CollectionSchema{Version: 2}
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).
+		RunAndReturn(func(ctx context.Context, sch *schemapb.CollectionSchema, schemaBarrierTs uint64) error {
+			<-ctx.Done()
+			return ctx.Err()
+		}).Once()
+
+	node := newDeleteNode(suite.collectionID, suite.channel, manager, delegator, 8)
+	oldMaxRetryDuration := deleteNodeUpdateSchemaMaxRetryDuration
+	deleteNodeUpdateSchemaMaxRetryDuration = time.Millisecond
+	suite.T().Cleanup(func() {
+		deleteNodeUpdateSchemaMaxRetryDuration = oldMaxRetryDuration
+	})
+
+	suite.Panics(func() {
+		node.Operate(&deleteNodeMsg{
+			schema:          schema,
+			schemaBarrierTs: 10,
+			timeRange:       TimeRange{timestampMax: 10},
+		})
+	})
+}
+
+func (suite *DeleteNodeSuite) TestUpdateSchemaPreCloseCancelsInFlightUpdate() {
+	manager := &segments.Manager{
+		Collection: segments.NewMockCollectionManager(suite.T()),
+		Segment:    segments.NewMockSegmentManager(suite.T()),
+	}
+	delegator := delegator.NewMockShardDelegator(suite.T())
+	schema := &schemapb.CollectionSchema{Version: 2}
+	updateStarted := make(chan struct{})
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).
+		RunAndReturn(func(ctx context.Context, sch *schemapb.CollectionSchema, schemaBarrierTs uint64) error {
+			close(updateStarted)
+			<-ctx.Done()
+			return ctx.Err()
+		}).Once()
+
+	node := newDeleteNode(suite.collectionID, suite.channel, manager, delegator, 8)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		suite.Nil(node.Operate(&deleteNodeMsg{
+			schema:          schema,
+			schemaBarrierTs: 10,
+			timeRange:       TimeRange{timestampMax: 10},
+		}))
+	}()
+
+	suite.Eventually(func() bool {
+		select {
+		case <-updateStarted:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+	node.PreClose()
+	suite.Eventually(func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
 }
 
 func TestDeleteNode(t *testing.T) {

--- a/internal/querynodev2/pipeline/filter_node.go
+++ b/internal/querynodev2/pipeline/filter_node.go
@@ -95,7 +95,15 @@ func (fNode *filterNode) Operate(in Msg) Msg {
 				mlog.Err(err),
 			)
 		} else {
-			out.append(msg)
+			if err := out.append(msg); err != nil {
+				wrapped := merr.Wrap(err, "failed to append filtered message")
+				mlog.Error(ctx, "failed to append filtered message, stop process to replay WAL",
+					mlog.String("message type", msg.Type().String()),
+					mlog.String("channel", fNode.channel),
+					mlog.FieldCollectionID(fNode.collectionID),
+					mlog.Err(wrapped))
+				panic(wrapped)
+			}
 		}
 	}
 	fNode.delegator.TryCleanExcludedSegments(streamMsgPack.EndTs)

--- a/internal/querynodev2/pipeline/filter_node_test.go
+++ b/internal/querynodev2/pipeline/filter_node_test.go
@@ -26,10 +26,14 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/querynodev2/delegator"
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
+	"github.com/milvus-io/milvus/pkg/v3/mocks/streaming/util/mock_message"
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message/adaptor"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -106,6 +110,42 @@ func (suite *FilterNodeSuite) TestWithLoadCollection() {
 		suite.True(lo.Contains(suite.validSegmentIDs, msg.SegmentID))
 	}
 	suite.Equal(suite.deleteSegmentSum, len(nodeMsg.deleteMsgs))
+}
+
+func (suite *FilterNodeSuite) TestSchemaChangeAppendErrorPanics() {
+	collection := segments.NewTestCollection(suite.collectionID, querypb.LoadType_LoadCollection, nil)
+	mockCollectionManager := segments.NewMockCollectionManager(suite.T())
+	mockCollectionManager.EXPECT().Get(suite.collectionID).Return(collection)
+
+	suite.manager = &segments.Manager{
+		Collection: mockCollectionManager,
+		Segment:    segments.NewMockSegmentManager(suite.T()),
+	}
+
+	validMutable := message.NewSchemaChangeMessageBuilderV2().
+		WithVChannel(suite.channel).
+		WithHeader(&message.SchemaChangeMessageHeader{
+			CollectionId: suite.collectionID,
+		}).
+		WithBody(&message.SchemaChangeMessageBody{
+			Schema: &schemapb.CollectionSchema{Version: 1},
+		}).
+		MustBuildMutable()
+	raw := validMutable.IntoMessageProto()
+	corruptedMutable := message.NewMutableMessageBeforeAppend([]byte{0xff}, raw.GetProperties()).WithTimeTick(10)
+	msgID := mock_message.NewMockMessageID(suite.T())
+	msgID.EXPECT().String().Return("mock-id").Maybe()
+	tsMsg, err := adaptor.NewSchemaChangeMessageBody(corruptedMutable.IntoImmutableMessage(msgID))
+	suite.Require().NoError(err)
+
+	node := newFilterNode(suite.collectionID, suite.channel, suite.manager, suite.delegator, 8)
+	suite.Panics(func() {
+		node.Operate(&msgstream.MsgPack{
+			BeginTs: 10,
+			EndTs:   10,
+			Msgs:    []msgstream.TsMsg{tsMsg},
+		})
+	})
 }
 
 // test filter node with collection load partition

--- a/internal/querynodev2/segments/collection.go
+++ b/internal/querynodev2/segments/collection.go
@@ -64,8 +64,8 @@ type collectionSchemaUpdatePlan struct {
 	// logicalSchemaVersion is schema.Version from the accepted schema payload.
 	// It is the Go-side structural schema freshness key.
 	logicalSchemaVersion uint64
-	// schemaBarrierTs fences stale load results and orders same-version schema
-	// payload refreshes such as collection property snapshots.
+	// schemaBarrierTs is retained for snapshot metadata and compatibility. It
+	// does not make a same-version schema payload fresh.
 	schemaBarrierTs uint64
 	// segcoreSchemaVersion is only passed to C++ segcore UpdateSchema. Segcore
 	// still has a single increasing version gate, so QueryNode keeps this
@@ -149,10 +149,9 @@ func (m *collectionManager) PutOrRef(collectionID int64, schema *schemapb.Collec
 }
 
 func (m *collectionManager) putOrRefExisting(collectionID int64, collection *Collection, schema *schemapb.CollectionSchema, meta *segcorepb.CollectionIndexMeta, logicalSchemaVersion uint64, schemaBarrierTs uint64) error {
-	// Existing collections may be reached by a later load result or by a
-	// same-version properties refresh. Keep the Go-side logical schema version
-	// separate from the barrier timestamp so stale schema payloads cannot roll
-	// back fields, while newer properties-only payloads can still refresh.
+	// Existing collections may be reached by an older load result. Only a newer
+	// schema.Version can refresh the schema payload; schemaBarrierTs is metadata,
+	// not a schema freshness key.
 	plan, shouldUpdate, err := collection.applyLoadUpdate(schema, meta, logicalSchemaVersion, schemaBarrierTs)
 	if err != nil {
 		return err
@@ -177,11 +176,9 @@ func (m *collectionManager) UpdateSchema(collectionID int64, schema *schemapb.Co
 	defer m.Unref(collectionID, 1)
 
 	logicalSchemaVersion := getUpdateSchemaVersion(schema, schemaBarrierTs)
-	// A schema update carries two ordering domains:
-	// - schema.Version is the logical collection schema version and prevents
-	//   older schema payloads from overwriting newer fields/functions.
-	// - schemaBarrierTs is the DDL barrier timestamp and advances for
-	//   properties-only schema snapshots such as ttl_field changes.
+	// schema.Version is the only schema payload freshness key. schemaBarrierTs is
+	// still carried for compatibility and diagnostics, but it cannot advance a
+	// same-version payload.
 	_, _, err := collection.applySchemaUpdate(schema, logicalSchemaVersion, schemaBarrierTs)
 	return err
 }
@@ -201,16 +198,10 @@ func ShouldUpdateCollectionSchema(collection *Collection, schema *schemapb.Colle
 
 func prepareCollectionSchemaUpdate(collection *Collection, logicalSchemaVersion uint64, schemaBarrierTs uint64) (collectionSchemaUpdatePlan, bool) {
 	_, currentVersion, currentBarrierTs, currentSegcoreSchemaVersion := collection.schemaSnapshotWithSegcoreSchemaVersion()
-	// Never allow logical schema version rollback, even if the incoming message
-	// has a larger timestamp. This preserves the fix for out-of-order schema
-	// messages across replay/channel delivery.
-	if logicalSchemaVersion < currentVersion {
-		return collectionSchemaUpdatePlan{}, false
-	}
-	// For the same logical schema version, only a newer barrier can update the
-	// payload. This is required for collection properties embedded in schema
-	// snapshots because those updates do not necessarily bump schema.Version.
-	if logicalSchemaVersion == currentVersion && schemaBarrierTs <= currentBarrierTs {
+	// Never allow logical schema version rollback or same-version payload refresh,
+	// even if the incoming message has a larger timestamp. Every schema payload
+	// change must bump schema.Version and be replayed from WAL.
+	if logicalSchemaVersion <= currentVersion {
 		return collectionSchemaUpdatePlan{}, false
 	}
 
@@ -310,7 +301,7 @@ type collectionSchemaSnapshot struct {
 	schemaBarrierTs      uint64
 	// segcoreSchemaVersion is an internal monotonic version passed to C++
 	// segcore. It is not the logical collection schema version; Go-side schema
-	// freshness is tracked by logicalSchemaVersion and schemaBarrierTs.
+	// freshness is tracked by logicalSchemaVersion.
 	segcoreSchemaVersion uint64
 }
 

--- a/internal/querynodev2/segments/collection_test.go
+++ b/internal/querynodev2/segments/collection_test.go
@@ -167,7 +167,7 @@ func (s *CollectionManagerSuite) TestUpdateSchema() {
 		s.Same(schemaV8, updatedSchema)
 	})
 
-	s.Run("same_schema_version_with_newer_barrier_updates_properties", func() {
+	s.Run("same_schema_version_with_newer_barrier_does_not_update_payload", func() {
 		cm := NewCollectionManager()
 		baseSchema := mock_segcore.GenTestCollectionSchema("collection_v0", schemapb.DataType_Int64, false)
 		err := cm.PutOrRef(10, baseSchema, mock_segcore.GenTestIndexMeta(10, baseSchema), &querypb.LoadMetaInfo{
@@ -188,8 +188,8 @@ func (s *CollectionManagerSuite) TestUpdateSchema() {
 
 		schema, version := cm.Get(10).SchemaAndVersion()
 		s.Equal(uint64(0), version)
-		s.Same(updatedSchema, schema)
-		s.Equal("int64Field", common.CloneKeyValuePairs(schema.GetProperties()).ToMap()[common.CollectionTTLFieldKey])
+		s.Same(baseSchema, schema)
+		s.NotContains(common.CloneKeyValuePairs(schema.GetProperties()).ToMap(), common.CollectionTTLFieldKey)
 	})
 
 	s.Run("higher_schema_version_after_high_barrier_refresh_uses_monotonic_segcore_schema_version", func() {

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -96,6 +96,7 @@ type baseSegment struct {
 	resourceUsageCache *atomic.Pointer[ResourceUsage]
 
 	needUpdatedVersion *atomic.Int64 // only for lazy load mode update index
+	loadSchemaVersion  *atomic.Uint64
 }
 
 func newBaseSegment(collection *Collection, segmentType SegmentType, version int64, loadInfo *querypb.SegmentLoadInfo) (baseSegment, error) {
@@ -114,6 +115,7 @@ func newBaseSegment(collection *Collection, segmentType SegmentType, version int
 
 		resourceUsageCache: atomic.NewPointer[ResourceUsage](nil),
 		needUpdatedVersion: atomic.NewInt64(0),
+		loadSchemaVersion:  atomic.NewUint64(collection.SchemaVersion()),
 	}
 	return bs, nil
 }
@@ -418,6 +420,21 @@ func (s *baseSegment) SetNeedUpdatedVersion(version int64) {
 	s.needUpdatedVersion.Store(version)
 }
 
+func (s *baseSegment) LoadSchemaVersion() uint64 {
+	if s.loadSchemaVersion == nil {
+		return 0
+	}
+	return s.loadSchemaVersion.Load()
+}
+
+func (s *baseSegment) SetLoadSchemaVersion(version uint64) {
+	if s.loadSchemaVersion == nil {
+		s.loadSchemaVersion = atomic.NewUint64(version)
+		return
+	}
+	s.loadSchemaVersion.Store(version)
+}
+
 type FieldInfo struct {
 	*datapb.FieldBinlog
 	RowCount int64
@@ -458,18 +475,37 @@ func NewSegment(ctx context.Context,
 	version int64,
 	loadInfo *querypb.SegmentLoadInfo,
 ) (Segment, error) {
+	return newSegmentWithLoadSchemaVersion(ctx, collection, manager, segmentType, version, collection.SchemaVersion(), loadInfo)
+}
+
+func newSegmentWithLoadSchemaVersion(ctx context.Context,
+	collection *Collection,
+	manager SegmentManager,
+	segmentType SegmentType,
+	version int64,
+	loadSchemaVersion uint64,
+	loadInfo *querypb.SegmentLoadInfo,
+) (Segment, error) {
 	/*
 		CStatus
 		NewSegment(CCollection collection, uint64_t segment_id, SegmentType seg_type, CSegmentInterface* newSegment);
 	*/
 	if loadInfo.GetLevel() == datapb.SegmentLevel_L0 {
-		return NewL0Segment(collection, segmentType, version, loadInfo)
+		segment, err := NewL0Segment(collection, segmentType, version, loadInfo)
+		if err != nil {
+			return nil, err
+		}
+		if versioned, ok := segment.(interface{ SetLoadSchemaVersion(uint64) }); ok {
+			versioned.SetLoadSchemaVersion(loadSchemaVersion)
+		}
+		return segment, nil
 	}
 
 	base, err := newBaseSegment(collection, segmentType, version, loadInfo)
 	if err != nil {
 		return nil, err
 	}
+	base.SetLoadSchemaVersion(loadSchemaVersion)
 
 	var locker *state.LoadStateLock
 	switch segmentType {
@@ -1283,6 +1319,11 @@ func (s *LocalSegment) Load(ctx context.Context) error {
 }
 
 func (s *LocalSegment) Reopen(ctx context.Context, newLoadInfo *querypb.SegmentLoadInfo) error {
+	schema, schemaVersion := s.collection.SchemaAndSegcoreVersion()
+	return s.reopenWithSchema(ctx, newLoadInfo, schema, schemaVersion, s.collection.SchemaVersion())
+}
+
+func (s *LocalSegment) reopenWithSchema(ctx context.Context, newLoadInfo *querypb.SegmentLoadInfo, schema *schemapb.CollectionSchema, segcoreSchemaVersion uint64, loadSchemaVersion uint64) error {
 	if !s.ptrLock.PinIfNotReleased() {
 		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released during reopen")
 	}
@@ -1295,16 +1336,16 @@ func (s *LocalSegment) Reopen(ctx context.Context, newLoadInfo *querypb.SegmentL
 		return err
 	}
 
-	schema, schemaVersion := s.collection.SchemaAndSegcoreVersion()
 	err := s.csegment.Reopen(ctx, &segcore.ReopenRequest{
 		LoadInfo:      newLoadInfo,
 		Schema:        schema,
-		SchemaVersion: schemaVersion,
+		SchemaVersion: segcoreSchemaVersion,
 	})
 	if err != nil {
 		return err
 	}
 	s.syncFieldIndexes(newLoadInfo.GetIndexInfos())
+	s.SetLoadSchemaVersion(loadSchemaVersion)
 	if s.relatedDataSize != nil {
 		s.relatedDataSize.Store(calculateSegmentLogSize(newLoadInfo))
 	}

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -244,6 +244,16 @@ func (loader *segmentLoader) Load(ctx context.Context,
 	version int64,
 	segments ...*querypb.SegmentLoadInfo,
 ) ([]Segment, error) {
+	return loader.LoadWithSchema(ctx, collectionID, segmentType, version, nil, segments...)
+}
+
+func (loader *segmentLoader) LoadWithSchema(ctx context.Context,
+	collectionID int64,
+	segmentType SegmentType,
+	version int64,
+	requestSchema *schemapb.CollectionSchema,
+	segments ...*querypb.SegmentLoadInfo,
+) ([]Segment, error) {
 	if len(segments) == 0 {
 		mlog.Info(context.TODO(), "no segment to load")
 		return nil, nil
@@ -255,8 +265,15 @@ func (loader *segmentLoader) Load(ctx context.Context,
 		mlog.Warn(context.TODO(), "failed to get collection", mlog.Err(err))
 		return nil, err
 	}
+	if requestSchema == nil {
+		requestSchema = collection.Schema()
+	}
+	requestSchemaVersion := uint64(requestSchema.GetVersion())
 	for _, segment := range segments {
-		configureUseTakeForOutput(segment, collection.Schema())
+		configureUseTakeForOutput(segment, requestSchema)
+	}
+	if err := loader.reopenLoadedSegmentsIfStale(ctx, collection, requestSchema, segmentType, segments...); err != nil {
+		return nil, err
 	}
 	// Filter out loaded & loading segments
 	infos := loader.prepare(ctx, segmentType, segments...)
@@ -297,12 +314,13 @@ func (loader *segmentLoader) Load(ctx context.Context,
 			return nil, err
 		}
 
-		segment, err := NewSegment(
+		segment, err := newSegmentWithLoadSchemaVersion(
 			ctx,
 			collection,
 			loader.manager.Segment,
 			segmentType,
 			version,
+			requestSchemaVersion,
 			loadInfo,
 		)
 		if err != nil {
@@ -348,16 +366,15 @@ func (loader *segmentLoader) Load(ctx context.Context,
 			return merr.Wrap(err, "At LoadDeltaLogs")
 		}
 
-		schema := collection.Schema()
-		isExternalCollection := typeutil.IsExternalCollection(schema)
-		isMilvusTableRealPK := typeutil.NewStorageColumnResolver(schema).IsMilvusTable() &&
-			HasExternalPrimaryKey(schema)
+		isExternalCollection := typeutil.IsExternalCollection(requestSchema)
+		isMilvusTableRealPK := typeutil.NewStorageColumnResolver(requestSchema).IsMilvusTable() &&
+			HasExternalPrimaryKey(requestSchema)
 		if !segment.PkCandidateExist() {
 			mlog.Debug(context.TODO(), "loading PK candidate for segment", mlog.Int64("segmentID", segment.ID()))
 			if isExternalCollection {
 				var candidate pkoracle.Candidate
 				if isMilvusTableRealPK {
-					bfs, err := loader.loadSingleBloomFilterSet(ctx, loadInfo.GetCollectionID(), loadInfo, segment.Type())
+					bfs, err := loader.loadSingleBloomFilterSet(ctx, loadInfo.GetCollectionID(), loadInfo, segment.Type(), requestSchema)
 					if err != nil {
 						return merr.Wrap(err, "At LoadBloomFilter")
 					}
@@ -395,7 +412,7 @@ func (loader *segmentLoader) Load(ctx context.Context,
 					}
 				}
 			} else if paramtable.Get().CommonCfg.BloomFilterEnabled.GetAsBool() {
-				bfs, err := loader.loadSingleBloomFilterSet(ctx, loadInfo.GetCollectionID(), loadInfo, segment.Type())
+				bfs, err := loader.loadSingleBloomFilterSet(ctx, loadInfo.GetCollectionID(), loadInfo, segment.Type(), requestSchema)
 				if err != nil {
 					return merr.Wrap(err, "At LoadBloomFilter")
 				}
@@ -433,8 +450,7 @@ func (loader *segmentLoader) Load(ctx context.Context,
 	}
 
 	// Wait for all segments loaded
-	segmentIDs := lo.Map(segments, func(info *querypb.SegmentLoadInfo, _ int) int64 { return info.GetSegmentID() })
-	if err := loader.waitSegmentLoadDone(ctx, segmentType, segmentIDs, version); err != nil {
+	if err := loader.waitSegmentLoadDone(ctx, segmentType, segments, version, requestSchema); err != nil {
 		mlog.Warn(context.TODO(), "failed to wait the filtered out segments load done", mlog.Err(err))
 		return nil, err
 	}
@@ -470,6 +486,59 @@ func (loader *segmentLoader) prepare(ctx context.Context, segmentType SegmentTyp
 	}
 
 	return infos
+}
+
+type loadSchemaVersionedSegment interface {
+	LoadSchemaVersion() uint64
+}
+
+func (loader *segmentLoader) reopenLoadedSegmentsIfStale(ctx context.Context, collection *Collection, requestSchema *schemapb.CollectionSchema, segmentType SegmentType, infos ...*querypb.SegmentLoadInfo) error {
+	if segmentType != SegmentTypeSealed {
+		return nil
+	}
+
+	requiredSchemaVersion := uint64(requestSchema.GetVersion())
+	staleInfos := make([]*querypb.SegmentLoadInfo, 0)
+	for _, info := range infos {
+		segment := loader.manager.Segment.GetWithType(info.GetSegmentID(), segmentType)
+		if segment == nil {
+			continue
+		}
+		if loadedSegmentNeedsReopen(segment, info, requiredSchemaVersion) {
+			staleInfos = append(staleInfos, info)
+		}
+	}
+	if len(staleInfos) == 0 {
+		return nil
+	}
+
+	mlog.Info(ctx, "reopen stale loaded segments before full load",
+		mlog.Int64("collectionID", collection.ID()),
+		mlog.Uint64("requiredSchemaVersion", requiredSchemaVersion),
+		mlog.Int64s("segmentIDs", lo.Map(staleInfos, func(info *querypb.SegmentLoadInfo, _ int) int64 {
+			return info.GetSegmentID()
+		})))
+	return loader.ReopenSegmentsWithSchema(ctx, requestSchema, staleInfos)
+}
+
+func loadedSegmentNeedsReopen(segment Segment, incoming *querypb.SegmentLoadInfo, requiredSchemaVersion uint64) bool {
+	current := segment.LoadInfo()
+	if incoming.GetDataVersion() > current.GetDataVersion() {
+		return true
+	}
+	if incoming.GetStorageVersion() > current.GetStorageVersion() {
+		return true
+	}
+	if incoming.GetManifestPath() != "" && incoming.GetManifestPath() != current.GetManifestPath() {
+		cmp, err := packed.CompareManifestPath(incoming.GetManifestPath(), current.GetManifestPath())
+		if err == nil && cmp > 0 {
+			return true
+		}
+	}
+	if versioned, ok := segment.(loadSchemaVersionedSegment); ok {
+		return versioned.LoadSchemaVersion() < requiredSchemaVersion
+	}
+	return false
 }
 
 func configureUseTakeForOutput(loadInfo *querypb.SegmentLoadInfo, schema *schemapb.CollectionSchema) {
@@ -596,9 +665,16 @@ func (loader *segmentLoader) freeRequestResource(requestResourceResult requestRe
 	loader.committedResourceNotifier.NotifyAll()
 }
 
-func (loader *segmentLoader) waitSegmentLoadDone(ctx context.Context, segmentType SegmentType, segmentIDs []int64, version int64) error {
-	for _, segmentID := range segmentIDs {
-		if loader.manager.Segment.GetWithType(segmentID, segmentType) != nil {
+func (loader *segmentLoader) waitSegmentLoadDone(ctx context.Context, segmentType SegmentType, loadInfos []*querypb.SegmentLoadInfo, version int64, requestSchema *schemapb.CollectionSchema) error {
+	requestSchemaVersion := uint64(requestSchema.GetVersion())
+	for _, loadInfo := range loadInfos {
+		segmentID := loadInfo.GetSegmentID()
+		if segment := loader.manager.Segment.GetWithType(segmentID, segmentType); segment != nil {
+			if loadedSegmentNeedsReopen(segment, loadInfo, requestSchemaVersion) {
+				if err := loader.reopenSegmentsWithSchema(ctx, requestSchema, []*querypb.SegmentLoadInfo{loadInfo}); err != nil {
+					return err
+				}
+			}
 			continue
 		}
 
@@ -637,6 +713,12 @@ func (loader *segmentLoader) waitSegmentLoadDone(ctx context.Context, segmentTyp
 
 		// try to update segment version after wait segment loaded
 		loader.manager.Segment.UpdateBy(IncreaseVersion(version), WithType(segmentType), WithID(segmentID))
+		if segment := loader.manager.Segment.GetWithType(segmentID, segmentType); segment != nil &&
+			loadedSegmentNeedsReopen(segment, loadInfo, requestSchemaVersion) {
+			if err := loader.reopenSegmentsWithSchema(ctx, requestSchema, []*querypb.SegmentLoadInfo{loadInfo}); err != nil {
+				return err
+			}
+		}
 
 		mlog.Info(context.TODO(), "segment loaded...", mlog.Int64("segmentID", segmentID))
 	}
@@ -648,7 +730,7 @@ func (loader *segmentLoader) GetChunkManager() storage.ChunkManager {
 }
 
 // load single bloom filter
-func (loader *segmentLoader) loadSingleBloomFilterSet(ctx context.Context, collectionID int64, loadInfo *querypb.SegmentLoadInfo, segtype SegmentType) (*pkoracle.BloomFilterSet, error) {
+func (loader *segmentLoader) loadSingleBloomFilterSet(ctx context.Context, collectionID int64, loadInfo *querypb.SegmentLoadInfo, segtype SegmentType, requestSchemas ...*schemapb.CollectionSchema) (*pkoracle.BloomFilterSet, error) {
 	partitionID := loadInfo.PartitionID
 	segmentID := loadInfo.SegmentID
 	bfs := pkoracle.NewBloomFilterSet(segmentID, partitionID, segtype)
@@ -663,6 +745,9 @@ func (loader *segmentLoader) loadSingleBloomFilterSet(ctx context.Context, colle
 	mlog.Info(context.TODO(), "start loading remote...", mlog.Int("segmentNum", 1))
 
 	schema := collection.Schema()
+	if len(requestSchemas) > 0 && requestSchemas[0] != nil {
+		schema = requestSchemas[0]
+	}
 	isExternalCollection := typeutil.IsExternalCollection(schema)
 	isMilvusTableRealPK := typeutil.NewStorageColumnResolver(schema).IsMilvusTable() &&
 		HasExternalPrimaryKey(schema)
@@ -2522,11 +2607,25 @@ func prepareIndexLoadParams(indexInfos []*querypb.FieldIndexInfo) error {
 func (loader *segmentLoader) ReopenSegments(ctx context.Context,
 	loadInfos []*querypb.SegmentLoadInfo,
 ) error {
+	return loader.ReopenSegmentsWithSchema(ctx, nil, loadInfos)
+}
+
+func (loader *segmentLoader) ReopenSegmentsWithSchema(ctx context.Context,
+	requestSchema *schemapb.CollectionSchema,
+	loadInfos []*querypb.SegmentLoadInfo,
+) error {
 	// Filter out LOADING segments only
 	// use None to avoid loaded check
 	infos := loader.prepare(ctx, commonpb.SegmentState_SegmentStateNone, loadInfos...)
 	defer loader.unregister(infos...)
 
+	return loader.reopenSegmentsWithSchema(ctx, requestSchema, infos)
+}
+
+func (loader *segmentLoader) reopenSegmentsWithSchema(ctx context.Context,
+	requestSchema *schemapb.CollectionSchema,
+	infos []*querypb.SegmentLoadInfo,
+) error {
 	// use full resource in case of whole segment reopen
 	// TODO use calculated resource from segcore after supported
 	requestResourceResult, err := loader.requestResource(ctx, infos...)
@@ -2543,11 +2642,23 @@ func (loader *segmentLoader) ReopenSegments(ctx context.Context,
 			continue
 		}
 		collection := loader.manager.Collection.Get(info.GetCollectionID())
+		reopenSchema := requestSchema
+		segcoreSchemaVersion := uint64(0)
 		if collection != nil {
-			configureUseTakeForOutput(info, collection.Schema())
+			_, segcoreSchemaVersion = collection.SchemaAndSegcoreVersion()
+			if reopenSchema == nil {
+				reopenSchema = collection.Schema()
+			}
+			configureUseTakeForOutput(info, reopenSchema)
 		}
 
-		err := segment.Reopen(ctx, info)
+		var err error
+		if localSegment, ok := segment.(*LocalSegment); ok && reopenSchema != nil && segcoreSchemaVersion > 0 {
+			requestSchemaVersion := uint64(reopenSchema.GetVersion())
+			err = localSegment.reopenWithSchema(ctx, info, reopenSchema, segcoreSchemaVersion, requestSchemaVersion)
+		} else {
+			err = segment.Reopen(ctx, info)
+		}
 		if err != nil {
 			mlog.Warn(context.TODO(), "failed to reopen segment", mlog.Int64("segmentID", info.GetSegmentID()), mlog.Err(err))
 			return err

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -27,15 +27,19 @@ import (
 	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/atomic"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/mocks/util/mock_segcore"
+	"github.com/milvus-io/milvus/internal/querynodev2/pkoracle"
+	"github.com/milvus-io/milvus/internal/querynodev2/segments/state"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/internal/util/initcore"
+	"github.com/milvus-io/milvus/internal/util/segcore"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
@@ -260,6 +264,124 @@ func (suite *SegmentLoaderSuite) TearDownTest() {
 		suite.manager.Segment.Remove(context.Background(), suite.segmentID+int64(i), querypb.DataScope_All)
 	}
 	suite.chunkManager.RemoveWithPrefix(ctx, suite.rootPath)
+}
+
+func (suite *SegmentLoaderSuite) TestReopenLoadedSegmentWithStaleSchemaVersionBeforeFullLoad() {
+	ctx := context.Background()
+	loader := suite.loader.(*segmentLoader)
+
+	oldSchema := suite.manager.Collection.Get(suite.collectionID).Schema()
+	oldSchema.Version = 1
+	newSchema := typeutil.Clone(oldSchema)
+	newSchema.Version = 2
+	collection := suite.manager.Collection.Get(suite.collectionID)
+	collection.setSchema(oldSchema, 1, 1, 1)
+
+	oldLoadInfo := &querypb.SegmentLoadInfo{
+		CollectionID:  suite.collectionID,
+		SegmentID:     suite.segmentID,
+		PartitionID:   suite.partitionID,
+		InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", suite.collectionID),
+		DataVersion:   1,
+	}
+	newLoadInfo := typeutil.Clone(oldLoadInfo)
+	csegment := mock_segcore.NewMockCSegment(suite.T())
+	csegment.EXPECT().
+		Reopen(mock.Anything, mock.MatchedBy(func(req *segcore.ReopenRequest) bool {
+			return req.LoadInfo == newLoadInfo &&
+				req.Schema.GetVersion() == 2 &&
+				req.SchemaVersion == 42
+		})).
+		Return(nil).
+		Once()
+
+	segment := &LocalSegment{
+		baseSegment: baseSegment{
+			collection:         collection,
+			loadInfo:           atomic.NewPointer(oldLoadInfo),
+			version:            atomic.NewInt64(1),
+			segmentType:        SegmentTypeSealed,
+			resourceUsageCache: atomic.NewPointer[ResourceUsage](nil),
+			needUpdatedVersion: atomic.NewInt64(0),
+			loadSchemaVersion:  atomic.NewUint64(1),
+			pkCandidate:        pkoracle.NewBloomFilterSet(suite.segmentID, suite.partitionID, SegmentTypeSealed),
+		},
+		ptrLock:        state.NewLoadStateLock(state.LoadStateDataLoaded),
+		csegment:       csegment,
+		fieldIndexes:   typeutil.NewConcurrentMap[int64, *IndexedFieldInfo](),
+		fieldJSONStats: make(map[int64]*querypb.JsonStatsInfo),
+		insertCount:    atomic.NewInt64(0),
+		binlogSize:     atomic.NewInt64(0),
+	}
+	suite.manager.Segment.Put(ctx, SegmentTypeSealed, segment)
+	collection.setSchema(newSchema, 2, 2, 42)
+
+	suite.Require().NoError(loader.reopenLoadedSegmentsIfStale(ctx, collection, newSchema, SegmentTypeSealed, newLoadInfo))
+	suite.Equal(uint64(2), segment.LoadSchemaVersion())
+	suite.Equal(int32(1), segment.LoadInfo().GetDataVersion())
+}
+
+func (suite *SegmentLoaderSuite) TestWaitSegmentLoadDoneReopensStaleInFlightLoadResult() {
+	ctx := context.Background()
+	loader := suite.loader.(*segmentLoader)
+
+	oldSchema := suite.manager.Collection.Get(suite.collectionID).Schema()
+	oldSchema.Version = 1
+	newSchema := typeutil.Clone(oldSchema)
+	newSchema.Version = 2
+	collection := suite.manager.Collection.Get(suite.collectionID)
+	collection.setSchema(newSchema, 2, 2, 42)
+
+	oldLoadInfo := &querypb.SegmentLoadInfo{
+		CollectionID:  suite.collectionID,
+		SegmentID:     suite.segmentID,
+		PartitionID:   suite.partitionID,
+		InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", suite.collectionID),
+		DataVersion:   1,
+	}
+	newLoadInfo := typeutil.Clone(oldLoadInfo)
+
+	csegment := mock_segcore.NewMockCSegment(suite.T())
+	csegment.EXPECT().
+		Reopen(mock.Anything, mock.MatchedBy(func(req *segcore.ReopenRequest) bool {
+			return req.LoadInfo == newLoadInfo &&
+				req.Schema.GetVersion() == 2 &&
+				req.SchemaVersion == 42
+		})).
+		Return(nil).
+		Once()
+
+	result := newLoadResult()
+	loader.loadingSegments.Insert(suite.segmentID, result)
+	defer loader.loadingSegments.GetAndRemove(suite.segmentID)
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		segment := &LocalSegment{
+			baseSegment: baseSegment{
+				collection:         collection,
+				loadInfo:           atomic.NewPointer(oldLoadInfo),
+				version:            atomic.NewInt64(1),
+				segmentType:        SegmentTypeSealed,
+				resourceUsageCache: atomic.NewPointer[ResourceUsage](nil),
+				needUpdatedVersion: atomic.NewInt64(0),
+				loadSchemaVersion:  atomic.NewUint64(1),
+				pkCandidate:        pkoracle.NewBloomFilterSet(suite.segmentID, suite.partitionID, SegmentTypeSealed),
+			},
+			ptrLock:        state.NewLoadStateLock(state.LoadStateDataLoaded),
+			csegment:       csegment,
+			fieldIndexes:   typeutil.NewConcurrentMap[int64, *IndexedFieldInfo](),
+			fieldJSONStats: make(map[int64]*querypb.JsonStatsInfo),
+			insertCount:    atomic.NewInt64(0),
+			binlogSize:     atomic.NewInt64(0),
+		}
+		suite.manager.Segment.Put(ctx, SegmentTypeSealed, segment)
+		result.SetResult(success)
+	}()
+
+	suite.Require().NoError(loader.waitSegmentLoadDone(ctx, SegmentTypeSealed, []*querypb.SegmentLoadInfo{newLoadInfo}, 2, newSchema))
+	segment := suite.manager.Segment.GetSealed(suite.segmentID).(loadSchemaVersionedSegment)
+	suite.Equal(uint64(2), segment.LoadSchemaVersion())
 }
 
 func (suite *SegmentLoaderSuite) TestLoad() {
@@ -1582,7 +1704,7 @@ func (suite *SegmentLoaderDetailSuite) TestWaitSegmentLoadDone() {
 			suite.loader.notifyLoadFinish(infos...)
 		}()
 
-		err := suite.loader.waitSegmentLoadDone(context.Background(), SegmentTypeSealed, []int64{suite.segmentID}, 0)
+		err := suite.loader.waitSegmentLoadDone(context.Background(), SegmentTypeSealed, infos, 0, suite.manager.Collection.Get(suite.collectionID).Schema())
 		suite.NoError(err)
 	})
 
@@ -1601,14 +1723,14 @@ func (suite *SegmentLoaderDetailSuite) TestWaitSegmentLoadDone() {
 			suite.loader.unregister(infos...)
 		}()
 
-		err := suite.loader.waitSegmentLoadDone(context.Background(), SegmentTypeSealed, []int64{suite.segmentID}, 0)
+		err := suite.loader.waitSegmentLoadDone(context.Background(), SegmentTypeSealed, infos, 0, suite.manager.Collection.Get(suite.collectionID).Schema())
 		suite.Error(err)
 	})
 
 	suite.Run("wait_timeout", func() {
 		suite.SetupTest()
 
-		suite.loader.prepare(context.Background(), SegmentTypeSealed, &querypb.SegmentLoadInfo{
+		infos := suite.loader.prepare(context.Background(), SegmentTypeSealed, &querypb.SegmentLoadInfo{
 			SegmentID:     suite.segmentID,
 			PartitionID:   suite.partitionID,
 			CollectionID:  suite.collectionID,
@@ -1619,7 +1741,7 @@ func (suite *SegmentLoaderDetailSuite) TestWaitSegmentLoadDone() {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		err := suite.loader.waitSegmentLoadDone(ctx, SegmentTypeSealed, []int64{suite.segmentID}, 0)
+		err := suite.loader.waitSegmentLoadDone(ctx, SegmentTypeSealed, infos, 0, suite.manager.Collection.Get(suite.collectionID).Schema())
 		suite.Error(err)
 		suite.True(merr.IsCanceledOrTimeout(err))
 	})

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -384,7 +384,7 @@ func (node *QueryNode) Init() error {
 				return NewLocalWorker(node), nil
 			}
 
-			sessions, _, err := node.session.GetSessions(node.ctx, typeutil.QueryNodeRole)
+			sessions, _, err := node.session.GetSessions(ctx, typeutil.QueryNodeRole)
 			if err != nil {
 				return nil, err
 			}
@@ -396,9 +396,12 @@ func (node *QueryNode) Init() error {
 					break
 				}
 			}
+			if addr == "" {
+				return nil, merr.WrapErrNodeNotAvailable(nodeID, "querynode session address not found")
+			}
 
 			return cluster.NewPoolingRemoteWorker(func() (types.QueryNodeClient, error) {
-				return grpcquerynodeclient.NewClient(node.ctx, addr, nodeID)
+				return grpcquerynodeclient.NewClient(ctx, addr, nodeID)
 			})
 		})
 		node.delegators = typeutil.NewConcurrentMap[string, delegator.ShardDelegator]()

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -32,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/flushcommon/syncmgr"
 	"github.com/milvus-io/milvus/internal/querynodev2/delegator"
@@ -260,6 +261,7 @@ func (node *QueryNode) WatchDmChannels(ctx context.Context, req *querypb.WatchDm
 		node.chunkManager,
 		queryView,
 		node.binlogSaver,
+		delegator.WithInitialSchema(req.GetSchema()),
 		delegator.WithLeaderViewUpdatedCallback(node.markLeaderViewUpdated),
 	)
 	if err != nil {
@@ -578,12 +580,25 @@ func (node *QueryNode) LoadSegments(ctx context.Context, req *querypb.LoadSegmen
 
 	// Actual load segment
 	log.Info(ctx, "start to load segments...")
-	loaded, err := node.loader.Load(ctx,
-		req.GetCollectionID(),
-		segments.SegmentTypeSealed,
-		req.GetVersion(),
-		req.GetInfos()...,
-	)
+	var loaded []segments.Segment
+	if loader, ok := node.loader.(interface {
+		LoadWithSchema(context.Context, int64, segments.SegmentType, int64, *schemapb.CollectionSchema, ...*querypb.SegmentLoadInfo) ([]segments.Segment, error)
+	}); ok {
+		loaded, err = loader.LoadWithSchema(ctx,
+			req.GetCollectionID(),
+			segments.SegmentTypeSealed,
+			req.GetVersion(),
+			req.GetSchema(),
+			req.GetInfos()...,
+		)
+	} else {
+		loaded, err = node.loader.Load(ctx,
+			req.GetCollectionID(),
+			segments.SegmentTypeSealed,
+			req.GetVersion(),
+			req.GetInfos()...,
+		)
+	}
 	if err != nil {
 		return merr.Status(err), nil
 	}

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
@@ -123,20 +123,24 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 				header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionConsistencyLevel)
 			}
 		case common.CollectionExternalSource:
-			if udpates.Schema == nil {
-				udpates.Schema = &schemapb.CollectionSchema{}
-			}
-			udpates.Schema.ExternalSource = prop.GetValue()
-			if !funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec) {
-				header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
+			if prop.GetValue() != coll.ExternalSource {
+				if udpates.Schema == nil {
+					udpates.Schema = &schemapb.CollectionSchema{}
+				}
+				udpates.Schema.ExternalSource = prop.GetValue()
+				if !funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec) {
+					header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
+				}
 			}
 		case common.CollectionExternalSpec:
-			if udpates.Schema == nil {
-				udpates.Schema = &schemapb.CollectionSchema{}
-			}
-			udpates.Schema.ExternalSpec = prop.GetValue()
-			if !funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec) {
-				header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
+			if prop.GetValue() != coll.ExternalSpec {
+				if udpates.Schema == nil {
+					udpates.Schema = &schemapb.CollectionSchema{}
+				}
+				udpates.Schema.ExternalSpec = prop.GetValue()
+				if !funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec) {
+					header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
+				}
 			}
 		default:
 			newProperties[prop.GetKey()] = prop.GetValue()
@@ -153,12 +157,15 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 		header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionProperties)
 	}
 
-	// If TTL field is changed through properties, also broadcast an updated schema snapshot and mark it as schema change,
-	// so QueryNode can refresh runtime schema properties without requiring release/load.
+	// If a property alter changes schema payload, broadcast a full schema
+	// snapshot and mark it as schema change so WAL consumers advance by
+	// schema.Version instead of relying on the broadcast timestamp.
 	ttlOld, okOld := oldProperties[common.CollectionTTLFieldKey]
 	ttlNew, okNew := newProperties[common.CollectionTTLFieldKey]
 	needTTLFieldSchemaRefresh := (okOld != okNew) || (okOld && okNew && ttlOld != ttlNew)
-	if needTTLFieldSchemaRefresh {
+	needExternalSpecSchemaRefresh := funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
+	if needTTLFieldSchemaRefresh || needExternalSpecSchemaRefresh {
+		schemaUpdate := udpates.Schema
 		// validate ttl field name exists in schema fields when setting it
 		if okNew {
 			found := false
@@ -178,16 +185,18 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 			header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionSchema)
 		}
 
-		// Build schema snapshot with updated properties (schema version should NOT be changed for properties-only alter).
+		// Build schema snapshot with updated properties. Any schema payload
+		// change must advance schema.Version so WAL consumers can gate on it.
 		schema := coll.ToCollectionSchemaPB()
+		schema.Version = coll.SchemaVersion + 1
 		schema.Properties = newPropsKeyValuePairs
 		// Preserve ExternalSource/ExternalSpec from current collection state
 		// unless this alter is itself updating them (refresh-completion sync).
-		if udpates.Schema != nil && udpates.Schema.ExternalSource != "" {
-			schema.ExternalSource = udpates.Schema.ExternalSource
+		if schemaUpdate != nil && schemaUpdate.ExternalSource != "" {
+			schema.ExternalSource = schemaUpdate.ExternalSource
 		}
-		if udpates.Schema != nil && udpates.Schema.ExternalSpec != "" {
-			schema.ExternalSpec = udpates.Schema.ExternalSpec
+		if schemaUpdate != nil && schemaUpdate.ExternalSpec != "" {
+			schema.ExternalSpec = schemaUpdate.ExternalSpec
 		}
 		udpates.Schema = schema
 	}
@@ -199,6 +208,10 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 
 	// fill the put load config if rg or replica number is changed.
 	udpates.AlterLoadConfig = c.getAlterLoadConfigOfAlterCollection(coll.Properties, udpates.Properties)
+
+	if err := validateAlterCollectionSchemaPayloadVersion(coll.SchemaVersion, header, udpates); err != nil {
+		return err
+	}
 
 	channels := make([]string, 0, len(coll.VirtualChannelNames)+1)
 	channels = append(channels, streaming.WAL().ControlChannel())
@@ -212,6 +225,23 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
 		return err
+	}
+	return nil
+}
+
+func validateAlterCollectionSchemaPayloadVersion(currentVersion int32, header *messagespb.AlterCollectionMessageHeader, updates *messagespb.AlterCollectionMessageUpdates) error {
+	if header == nil || header.GetUpdateMask() == nil || !funcutil.SliceContain(header.GetUpdateMask().GetPaths(), message.FieldMaskCollectionSchema) {
+		return nil
+	}
+	if updates == nil || updates.GetSchema() == nil {
+		return merr.WrapErrServiceInternalMsg("alter collection schema update mask requires schema payload")
+	}
+	if updates.GetSchema().GetVersion() <= currentVersion {
+		return merr.WrapErrServiceInternalMsg(
+			"alter collection schema payload must advance schema version, current=%d, payload=%d",
+			currentVersion,
+			updates.GetSchema().GetVersion(),
+		)
 	}
 	return nil
 }

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -345,6 +346,23 @@ func TestDDLCallbacksAlterCollectionV2AckCallback_UpdateLoadConfigRPCError(t *te
 		Results: map[string]*message.AppendResult{},
 	})
 	require.Error(t, err)
+}
+
+func TestValidateAlterCollectionSchemaPayloadVersion(t *testing.T) {
+	header := &messagespb.AlterCollectionMessageHeader{
+		UpdateMask: &fieldmaskpb.FieldMask{
+			Paths: []string{message.FieldMaskCollectionSchema},
+		},
+	}
+
+	require.NoError(t, validateAlterCollectionSchemaPayloadVersion(10, &messagespb.AlterCollectionMessageHeader{}, nil))
+	require.Error(t, validateAlterCollectionSchemaPayloadVersion(10, header, nil))
+	require.Error(t, validateAlterCollectionSchemaPayloadVersion(10, header, &messagespb.AlterCollectionMessageUpdates{
+		Schema: &schemapb.CollectionSchema{Version: 10},
+	}))
+	require.NoError(t, validateAlterCollectionSchemaPayloadVersion(10, header, &messagespb.AlterCollectionMessageUpdates{
+		Schema: &schemapb.CollectionSchema{Version: 11},
+	}))
 }
 
 func TestDDLCallbacksAlterCollectionV2AckCallback_UpdateLoadConfigNonRGNotFoundError(t *testing.T) {
@@ -685,14 +703,14 @@ func TestDDLCallbacksAlterCollectionProperties_TTLFieldShouldBroadcastSchema(t *
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertSchemaVersion(t, ctx, core, dbName, collectionName, 0)
 
-	// Alter properties to set ttl field should succeed and should NOT change schema version in meta.
+	// Alter properties to set ttl field should bump schema version because it broadcasts a schema payload.
 	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
 		DbName:         dbName,
 		CollectionName: collectionName,
 		Properties:     []*commonpb.KeyValuePair{{Key: common.CollectionTTLFieldKey, Value: "ttl"}},
 	})
 	require.NoError(t, merr.CheckRPCCall(resp, err))
-	assertSchemaVersion(t, ctx, core, dbName, collectionName, 0)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 1)
 }
 
 func TestDDLCallbacksAlterCollectionProperties_TTLFieldPreservesExternalSpec(t *testing.T) {
@@ -738,6 +756,7 @@ func TestDDLCallbacksAlterCollectionProperties_TTLFieldPreservesExternalSpec(t *
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/ttl-path")
 	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1","cloud_provider":"aws"}}`)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 0)
 
 	// Alter TTL field only — must preserve previously persisted external source/spec.
 	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
@@ -750,6 +769,7 @@ func TestDDLCallbacksAlterCollectionProperties_TTLFieldPreservesExternalSpec(t *
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/ttl-path")
 	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1","cloud_provider":"aws"}}`)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 1)
 
 	// TTL with invalid field name still rejected.
 	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
@@ -818,6 +838,7 @@ func TestDDLCallbacksAlterCollectionProperties_AcceptExternalSourceSpec(t *testi
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/new/")
 	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1","cloud_provider":"aws"}}`)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 1)
 }
 
 // Regression for #49335: refresh override path may carry source-only updates
@@ -861,6 +882,7 @@ func TestDDLCallbacksAlterCollectionProperties_PartialExternalUpdatePreservesOth
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/new/")
 	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1","cloud_provider":"aws"}}`)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 1)
 }
 
 // Regression for #49335: alter that mixes external_source with a regular
@@ -905,6 +927,7 @@ func TestDDLCallbacksAlterCollectionProperties_MixedExternalAndRegular(t *testin
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/new/")
 	assertReplicaNumber(t, ctx, core, dbName, collectionName, 2)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 1)
 }
 
 func createCollectionForTest(t *testing.T, ctx context.Context, core *Core, dbName string, collectionName string) {

--- a/internal/util/pipeline/node.go
+++ b/internal/util/pipeline/node.go
@@ -28,6 +28,10 @@ type Node interface {
 	Close()
 }
 
+type preCloser interface {
+	PreClose()
+}
+
 type nodeCtx struct {
 	node         Node
 	InputChannel chan Msg

--- a/internal/util/pipeline/pipeline.go
+++ b/internal/util/pipeline/pipeline.go
@@ -77,6 +77,14 @@ func (p *pipeline) Close() {
 	}
 }
 
+func (p *pipeline) PreClose() {
+	for _, node := range p.nodes {
+		if preCloser, ok := node.node.(preCloser); ok {
+			preCloser.PreClose()
+		}
+	}
+}
+
 func (p *pipeline) process() {
 	if len(p.nodes) == 0 {
 		return

--- a/internal/util/pipeline/stream_pipeline.go
+++ b/internal/util/pipeline/stream_pipeline.go
@@ -161,6 +161,7 @@ func (p *streamPipeline) Close() {
 		p.dispatcher.Deregister(p.vChannel)
 		// close stream input
 		close(p.closeCh)
+		p.pipeline.PreClose()
 		p.closeWg.Wait()
 		if p.scanner != nil {
 			p.scanner.Close()

--- a/internal/util/pipeline/stream_pipeline_test.go
+++ b/internal/util/pipeline/stream_pipeline_test.go
@@ -20,6 +20,7 @@ import (
 	context2 "context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -170,6 +171,44 @@ func (suite *StreamPipelineSuite) TestDMLMsgPackBatcherKeepsBufferedInsertPacksS
 	suite.Len(second.Msgs, 1)
 }
 
+func (suite *StreamPipelineSuite) TestClosePreClosesNodesBeforeWaitingWorkDone() {
+	node := &preCloseBlockingNode{
+		BaseNode:  NewBaseNode("pre-close-blocking", 8),
+		operating: make(chan struct{}),
+		preClosed: make(chan struct{}),
+	}
+	suite.pipeline.Add(node)
+
+	err := suite.pipeline.ConsumeMsgStream(context2.Background(), &msgpb.MsgPosition{})
+	suite.NoError(err)
+	suite.NoError(suite.pipeline.Start())
+	suite.inChannel <- &msgstream.MsgPack{BeginTs: 1001}
+
+	suite.Eventually(func() bool {
+		select {
+		case <-node.operating:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		suite.pipeline.Close()
+	}()
+
+	suite.Eventually(func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+}
+
 func TestDMLMsgPackBatcherLimitsByTotalMessageNum(t *testing.T) {
 	maxMsgNum := 3
 	batcher := NewDMLMsgPackBatcher(func() int { return maxMsgNum })
@@ -277,6 +316,22 @@ type captureMsgPackNode struct {
 func (node *captureMsgPackNode) Operate(in Msg) Msg {
 	node.outChannel <- in.(*msgstream.MsgPack)
 	return nil
+}
+
+type preCloseBlockingNode struct {
+	*BaseNode
+	operating chan struct{}
+	preClosed chan struct{}
+}
+
+func (node *preCloseBlockingNode) Operate(in Msg) Msg {
+	close(node.operating)
+	<-node.preClosed
+	return in
+}
+
+func (node *preCloseBlockingNode) PreClose() {
+	close(node.preClosed)
 }
 
 func newDMLMsgPack(beginTs, endTs uint64, msgs ...msgstream.TsMsg) *msgstream.MsgPack {

--- a/pkg/util/merr/errors_test.go
+++ b/pkg/util/merr/errors_test.go
@@ -103,6 +103,9 @@ func (s *ErrSuite) TestWrap() {
 	s.ErrorIs(WrapErrCollectionSchemaVersionNotReady("test_collection", 1, 3), ErrCollectionSchemaVersionNotReady)
 	s.True(Status(WrapErrCollectionSchemaVersionNotReady("test_collection", 1, 3)).GetRetriable())
 	s.Equal(commonpb.ErrorCode_NotReadyServe, Status(WrapErrCollectionSchemaVersionNotReady("test_collection", 1, 3)).GetErrorCode())
+	s.ErrorIs(WrapErrCollectionSchemaVersionNotReadyWithVersion("test_collection", 1, 3), ErrCollectionSchemaVersionNotReady)
+	s.True(Status(WrapErrCollectionSchemaVersionNotReadyWithVersion("test_collection", 1, 3)).GetRetriable())
+	s.Equal(commonpb.ErrorCode_NotReadyServe, Status(WrapErrCollectionSchemaVersionNotReadyWithVersion("test_collection", 1, 3)).GetErrorCode())
 	// Partition related
 	s.ErrorIs(WrapErrPartitionNotFound("test_partition", "failed to get partition"), ErrPartitionNotFound)
 	s.ErrorIs(WrapErrPartitionNotLoaded("test_partition", "failed to query"), ErrPartitionNotLoaded)

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -700,6 +700,14 @@ func WrapErrCollectionPartialUpdateConflictErr(err error, format string, args ..
 	return wrapInner(ErrCollectionPartialUpdateConflict, formatMsg(format, args...), err)
 }
 
+func WrapErrCollectionSchemaVersionNotReadyWithVersion(collection any, currentVersion, requiredVersion uint64) error {
+	return wrapFieldsWithDesc(
+		ErrCollectionSchemaVersionNotReady,
+		fmt.Sprintf("current schema version %d, required schema version %d", currentVersion, requiredVersion),
+		value("collection", collection),
+	)
+}
+
 func WrapErrAliasNotFound(db any, alias any, msg ...string) error {
 	err := wrapFields(ErrAliasNotFound,
 		value("database", db),


### PR DESCRIPTION
Related to #51435

The delegator used the shared collection snapshot's schema barrier as its load freshness gate. A forwarded or reopened LoadSegments could advance that snapshot before the matching WAL schema event was consumed, making the delegator treat the real schema event as stale and skip broadcasting it to QueryNode workers. Workers then planned queries against a schema version they had never received, failing with "Cannot find field with field_id" until a later schema version arrived.

Gate segment load on the delegator's own WAL-driven schema view instead:

- Track a delegator-local schemaView that is advanced only by WAL UpdateSchema events. Load paths may read it but never advance it.
- Reject LoadSegments in the delegator with ErrCollectionSchemaVersionNotReady when the request schema version does not match the view. QueryCoord keeps the task pending and retries once the delegator catches up.
- Use the delegator schema snapshot (with SchemaBarrierTs zeroed) as the schema source when syncing collection index meta, so a load cannot push the shared collection schema ahead of the WAL stream.
- Gate distribution adds on schema version and gate UpdateSchema on the view version instead of the shared snapshot barrier.
- Seed each vchannel delegator with the schema carried by the watch request (WithInitialSchema) instead of the shared collection snapshot.

Supporting changes:

- Retry UpdateSchema in the delete node until it applies before TSafe advances, and panic on non-retryable failures to replay the WAL.
- Panic the filter node when a schema-change message cannot be appended, preserving the no-TSafe-advance / replay invariant.
- Add PreClose to the pipeline so schema retries can be interrupted during shutdown.
- Load and reopen sealed segments with the request schema, reopening already-loaded segments whose load schema version is stale.
- Keep collectionManager schema freshness keyed by schema.Version only; schemaBarrierTs remains metadata.
- Bump schema.Version for property-only alter collection callbacks so WAL consumers can gate on the version.
- Keep the delegator function-runtime sync introduced on master (#51818) while layering the WAL-driven schema gate on top.